### PR TITLE
Add SAM3 video model to the zoo

### DIFF
--- a/fiftyone/utils/sam3.py
+++ b/fiftyone/utils/sam3.py
@@ -611,14 +611,14 @@ def _sam3_output_to_detections(
     frame_width,
     frame_height,
     label_map=None,
-    default_label="object",
+    default_label=None,
 ):
-    """Convert SAM 3 session API outputs to FiftyOne Detections.
+    """Convert SAM 3 video outputs to FiftyOne Detections.
 
     Args:
         out_binary_masks: (N, H, W) bool array of segmentation masks
         out_boxes_xywh: (N, 4) normalised [x, y, w, h] boxes
-        out_obj_ids: list/array of int object IDs
+        out_obj_ids: list of int object IDs
         out_probs: (N,) confidence scores
         frame_width: original frame width
         frame_height: original frame height
@@ -628,46 +628,45 @@ def _sam3_output_to_detections(
     Returns:
         list of :class:`fiftyone.core.labels.Detection`
     """
+    if len(out_obj_ids) == 0:
+        return []
+
+    boxes = np.asarray(out_boxes_xywh)
+    coords = np.round(
+        fosam._to_abs_boxes(boxes, frame_width, frame_height)
+    ).astype(int)
+    coords[:, [0, 2]] = np.clip(coords[:, [0, 2]], 0, frame_width)
+    coords[:, [1, 3]] = np.clip(coords[:, [1, 3]], 0, frame_height)
+
+    widths = coords[:, 2] - coords[:, 0]
+    heights = coords[:, 3] - coords[:, 1]
+    valid = (widths > 0) & (heights > 0)
+
     detections = []
     for i, obj_id in enumerate(out_obj_ids):
-        mask_full = out_binary_masks[i]  # (H, W)
-        bx, by, bw, bh = out_boxes_xywh[i]
-
-        # Convert normalised xywh to pixel coords
-        x1 = int(round(bx * frame_width))
-        y1 = int(round(by * frame_height))
-        x2 = int(round((bx + bw) * frame_width))
-        y2 = int(round((by + bh) * frame_height))
-        x1 = max(0, x1)
-        y1 = max(0, y1)
-        x2 = min(frame_width, x2)
-        y2 = min(frame_height, y2)
-
-        if x2 <= x1 or y2 <= y1:
+        if not valid[i]:
             continue
 
-        bounding_box = [
-            x1 / frame_width,
-            y1 / frame_height,
-            (x2 - x1) / frame_width,
-            (y2 - y1) / frame_height,
-        ]
-
-        cropped_mask = mask_full[y1:y2, x1:x2]
-
-        label = default_label
-        if label_map and obj_id in label_map:
-            label = label_map[obj_id]
+        x1, y1, x2, y2 = coords[i]
 
         detections.append(
             fol.Detection(
-                label=label,
-                bounding_box=bounding_box,
-                mask=cropped_mask,
+                label=(
+                    label_map.get(obj_id, default_label)
+                    if label_map
+                    else default_label
+                ),
+                bounding_box=[
+                    x1 / frame_width,
+                    y1 / frame_height,
+                    widths[i] / frame_width,
+                    heights[i] / frame_height,
+                ],
+                mask=out_binary_masks[i, y1:y2, x1:x2],
                 index=int(obj_id),
-                confidence=float(out_probs[i])
-                if out_probs is not None
-                else None,
+                confidence=(
+                    float(out_probs[i]) if out_probs is not None else None
+                ),
             )
         )
 
@@ -728,11 +727,11 @@ class SegmentAnything3VideoModel(fom.SamplesMixin, fom.Model):
 
         model = foz.load_zoo_model("segment-anything-3-video-torch")
 
-        # Segment and track all "person" instances across frames
+        # Segment and track "person" instances across frames
         dataset.apply_model(
             model,
             label_field="sam3_tracking",
-            classes="person",
+            classes=["person"],
         )
 
         session = fo.launch_app(dataset)
@@ -1209,8 +1208,8 @@ class SegmentAnything3VideoModel(fom.SamplesMixin, fom.Model):
 
                 points, labels = fosam._to_sam_points(
                     keypoint.points,
-                    width=self._curr_frame_width,
-                    height=self._curr_frame_height,
+                    width=1,
+                    height=1,
                     point_labels=fosam._get_sam_point_labels(keypoint),
                 )
 

--- a/fiftyone/utils/sam3.py
+++ b/fiftyone/utils/sam3.py
@@ -1012,7 +1012,7 @@ class SegmentAnything3VideoModel(fom.SamplesMixin, fom.Model):
 
         sample_detections = {
             i + 1: fol.Detections(detections=[])
-            for i in range(len(sample.frames))
+            for i in sorted(sample.frames.keys())
         }
 
         try:

--- a/fiftyone/utils/sam3.py
+++ b/fiftyone/utils/sam3.py
@@ -8,11 +8,17 @@ wrapper for the FiftyOne Model Zoo.
 """
 
 import logging
+import numpy as np
 import os
 import shutil
 from PIL import Image
 
 import fiftyone as fo
+import cv2
+import eta.core.utils as etau
+
+import fiftyone.core.labels as fol
+import fiftyone.core.models as fom
 import fiftyone.core.utils as fou
 import fiftyone.utils.torch as fout
 import fiftyone.utils.sam as fosam
@@ -65,8 +71,8 @@ class SegmentAnything3ImageModelConfig(
         points_mask_index (None): an optional mask index to use for each
             keypoint output
         get_item_cls (None): a string like
-            ``"fiftyone.utils.sam.SegmentAnythingImageGetItem"`` specifying the
-            :class:`GetItem` to use for SAM
+            ``"fiftyone.utils.sam.SegmentAnything3ImageGetItem"`` specifying the
+            :class:`GetItem` to use for SAM3
         get_item_args (None): a dictionary of arguments for
             ``get_item_cls(field_mapping=field_mapping, **kwargs)``
         tokenizer_source (None): the URL to download the SAM3 tokenizer BPE vocab
@@ -595,3 +601,742 @@ class SegmentAnything3ImageModel(fosam2.SegmentAnything2ImageModel):
         raise RuntimeError(
             "sam3.model.sam3_image.Sam3Image doesn't support auto segmentation. You may use one of the SAM/SAM2 zoo models for auto segmentation."
         )
+
+
+def _sam3_output_to_detections(
+    out_binary_masks,
+    out_boxes_xywh,
+    out_obj_ids,
+    out_probs,
+    frame_width,
+    frame_height,
+    label_map=None,
+    default_label="object",
+):
+    """Convert SAM 3 session API outputs to FiftyOne Detections.
+
+    Args:
+        out_binary_masks: (N, H, W) bool array of segmentation masks
+        out_boxes_xywh: (N, 4) normalised [x, y, w, h] boxes
+        out_obj_ids: list/array of int object IDs
+        out_probs: (N,) confidence scores
+        frame_width: original frame width
+        frame_height: original frame height
+        label_map: optional dict mapping obj_id -> label string
+        default_label: fallback label when ``label_map`` is ``None``
+
+    Returns:
+        list of :class:`fiftyone.core.labels.Detection`
+    """
+    detections = []
+    for i, obj_id in enumerate(out_obj_ids):
+        mask_full = out_binary_masks[i]  # (H, W)
+        bx, by, bw, bh = out_boxes_xywh[i]
+
+        # Convert normalised xywh to pixel coords
+        x1 = int(round(bx * frame_width))
+        y1 = int(round(by * frame_height))
+        x2 = int(round((bx + bw) * frame_width))
+        y2 = int(round((by + bh) * frame_height))
+        x1 = max(0, x1)
+        y1 = max(0, y1)
+        x2 = min(frame_width, x2)
+        y2 = min(frame_height, y2)
+
+        if x2 <= x1 or y2 <= y1:
+            continue
+
+        bounding_box = [
+            x1 / frame_width,
+            y1 / frame_height,
+            (x2 - x1) / frame_width,
+            (y2 - y1) / frame_height,
+        ]
+
+        cropped_mask = mask_full[y1:y2, x1:x2]
+
+        label = default_label
+        if label_map and obj_id in label_map:
+            label = label_map[obj_id]
+
+        detections.append(
+            fol.Detection(
+                label=label,
+                bounding_box=bounding_box,
+                mask=cropped_mask,
+                index=int(obj_id),
+                confidence=float(out_probs[i])
+                if out_probs is not None
+                else None,
+            )
+        )
+
+    return detections
+
+
+class SegmentAnything3VideoModelConfig(
+    fout.TorchImageModelConfig, fozm.HasZooModel
+):
+    """Configuration for running a :class:`SegmentAnything3VideoModel`.
+
+    See :class:`fiftyone.utils.torch.TorchImageModelConfig` for additional
+    arguments.
+
+    Args:
+        operation_mode ("concept"): concept or visual mode of operation for inference
+        propagation_direction ("forward"): direction to propagate in video;
+            supported values are ``"forward"``, ``"backward"``, and ``"both"``
+        prompt_frame_indices (None): 1-based frame indices for visual / exemplar prompts
+        text_frame_idx (1): 1-based frame index for text concept prompts
+    """
+
+    def __init__(self, cfg_dict):
+        """Initializes :class:`SegmentAnything3ImageModelConfig`
+
+        Args:
+            cfg_dict: a dictionary with config parameters
+        """
+        d = self.init(cfg_dict)
+        super().__init__(d)
+
+        self.operation_mode = self.parse_string(
+            d, "operation_mode", default="concept"
+        )
+        self.propagation_direction = self.parse_string(
+            d, "propagation_direction", default="forward"
+        )
+        self.prompt_frame_indices = self.parse_array(
+            d, "prompt_frame_indices", default=None
+        )
+        self.text_frame_idx = self.parse_array(d, "text_frame_idx", default=1)
+
+
+class SegmentAnything3VideoModel(fom.SamplesMixin, fom.Model):
+    """Wrapper for running `Segment Anything 3 <https://ai.meta.com/sam3>`_
+    inference on videos.
+
+    SAM3 Video performs Promptable Concept Segmentation (PCS) on videos -
+    given a text prompt, it finds, segments, and tracks ALL instances of the
+    concept across video frames.
+
+    Video prompt example::
+
+        import fiftyone as fo
+        import fiftyone.zoo as foz
+
+        dataset = foz.load_zoo_dataset("quickstart-video", max_samples=2)
+
+        model = foz.load_zoo_model("segment-anything-3-video-torch")
+
+        # Segment and track all "person" instances across frames
+        dataset.apply_model(
+            model,
+            label_field="sam3_tracking",
+            classes="person",
+        )
+
+        session = fo.launch_app(dataset)
+
+    Args:
+        config: a :class:`SegmentAnything3VideoModelConfig`
+    """
+
+    def __init__(self, config):
+        self._fields = {}
+        self.config = config
+        self.needs_fields = {}
+
+        device = config.device
+        if device is None:
+            device = "cuda" if torch.cuda.is_available() else "cpu"
+        self._device = torch.device(device)
+
+        if self._device.type != "cuda":
+            raise ValueError(
+                f"SAM3 device should be cuda. Found {self._device.type}"
+            )
+
+        self._operation_mode = self.config.operation_mode
+
+        self.ctx = _load_video_frames_monkey_patch_sam3()
+
+        self._download_model(config)
+        self.model = self._load_model(config)
+        self.visual_predictor = self.model.tracker
+        self.visual_predictor.backbone = self.model.detector.backbone
+        self.concept_predictor = self._load_concept_predictor()
+
+        self._curr_exemplar_prompts = None
+        self._curr_visual_prompts = None
+        self._curr_frame_width = None
+        self._curr_frame_height = None
+
+    @property
+    def media_type(self):
+        return "video"
+
+    def _download_model(self, config):
+        config.download_model_if_necessary()
+
+    def _load_model(self, config):
+        if config.model is not None:
+            model = config.model
+        else:
+            entrypoint_fcn = config.entrypoint_fcn
+
+            if etau.is_str(entrypoint_fcn):
+                entrypoint_fcn = etau.get_function(entrypoint_fcn)
+
+            kwargs = config.entrypoint_args or {}
+            with self.ctx:
+                model = entrypoint_fcn(**kwargs)
+
+        model = model.to(self._device)
+        if self.config.use_half_precision:
+            model = model.half()
+
+        model.eval()
+
+        return model
+
+    def _load_concept_predictor(self):
+        return sam3.model_builder.build_sam3_video_predictor(
+            gpus_to_use=[self._device.index if self._device.index else 0]
+        )
+
+    @property
+    def operation_mode(self):
+        """Whether to use the model in visual or concept segmentation mode"""
+        return self._operation_mode
+
+    @operation_mode.setter
+    def operation_mode(self, value):
+        if value not in ["visual", "concept"]:
+            raise ValueError(
+                f"Operation mode can be either visual or concept. {value} is not supported."
+            )
+        self._operation_mode = value
+
+    def _get_frame_prompt_field(self):
+        """Return the frame field name, or ``None`` when no
+        ``prompt_field`` was provided."""
+
+        prompt_field = None
+        if "prompt_field" in self.needs_fields:
+            prompt_field = self.needs_fields["prompt_field"]
+
+        if prompt_field is None:
+            return None
+
+        if not prompt_field.startswith("frames."):
+            raise ValueError(
+                "'prompt_field' should be a frame field for "
+                "segment anything 3 video model"
+            )
+
+        return prompt_field[len("frames.") :]
+
+    def _get_frame_indices(self):
+        """Return the frame indices from which to extract prompt fields for prompting.
+
+        When ``None``,``prompt_field`` in all the frames are used for visual prompting."""
+
+        prompt_frame_indices = self.config.prompt_frame_indices
+        if prompt_frame_indices is None:
+            logger.warning(
+                "No frame indices selected for prompting. Prompts in prompt_field across all the frames will be used."
+            )
+        return prompt_frame_indices
+
+    def _get_text_frame_idx(self):
+        """Return the 1-based frame index for text prompting."""
+        return self.config.text_frame_idx
+
+    def _parse_concept_frame_prompts(
+        self, sample, frame_field_name, frame_indices
+    ):
+        """Read per-frame exemplar prompts in concept mode.
+
+        Concept mode returns a dict of 0-based frame index to lists of
+        normalised prompt dicts::
+
+            {0: [{"box": [x1, y1, x2, y2], "_label": "dog"}], ...}
+            {0: [{"points": [[x1, y1], [x2, y2]], "labels": [1, 0], _label": "dog"}], ...}
+        """
+        _frame_indices = (
+            frame_indices
+            if frame_indices
+            else range(1, len(sample.frames) + 1)
+        )
+
+        if self.operation_mode == "concept":
+            prompts = {}
+            for frame_number in _frame_indices:
+                if frame_number > len(sample.frames):
+                    raise ValueError(
+                        f"Frame index {frame_number} not valid for {len(sample.frames)} sample frames."
+                    )
+
+                value = sample.frames[frame_number].get_field(frame_field_name)
+                frame_idx = int(frame_number - 1)
+                if isinstance(value, fol.Detections):
+                    frame_prompts = []
+                    for det in value.detections:
+                        rx, ry, rw, rh = det.bounding_box
+                        frame_prompts.append(
+                            {
+                                "box": [rx, ry, rx + rw, ry + rh],
+                                "_label": det.label,
+                            }
+                        )
+                    if frame_prompts:
+                        prompts[frame_idx] = frame_prompts
+
+                elif isinstance(value, fol.Keypoints):
+                    frame_prompts = []
+                    for kp in value.keypoints:
+                        points_norm, labels = fosam._to_sam_points(
+                            kp.points,
+                            width=1,
+                            height=1,
+                            point_labels=fosam._get_sam_point_labels(kp),
+                        )
+                        frame_prompts.append(
+                            {
+                                "points": points_norm.tolist(),
+                                "labels": labels.tolist(),
+                                "_label": kp.label,
+                            }
+                        )
+                    if frame_prompts:
+                        prompts[frame_idx] = frame_prompts
+
+                else:
+                    raise ValueError(
+                        f"Unsupported prompt type {type(value)} on frame "
+                        f"{frame_number}. Use Detections or Keypoints. "
+                    )
+
+            return prompts
+
+    def _parse_visual_frame_prompts(
+        self, sample, frame_field_name, frame_indices
+    ):
+        """Read per-frame prompts for visual mode.
+
+        Returns a flat list of raw FiftyOne labels, one per frame:
+
+            [Detections(...), [], [], ...]
+        """
+        _frame_indices = (
+            frame_indices
+            if frame_indices
+            else range(1, len(sample.frames) + 1)
+        )
+        prompts = []
+        for f_idx, frame in sample.frames.items():
+            value = frame.get_field(frame_field_name)
+            prompts.append(
+                value if value is not None and f_idx in _frame_indices else []
+            )
+        return prompts
+
+    def _get_visual_prompt_type(self, sample, field_name):
+        for _, frame in sample.frames.items():
+            value = frame.get_field(field_name)
+            if value is None:
+                continue
+            if isinstance(value, fol.Detections):
+                return "boxes"
+            if isinstance(value, fol.Keypoints):
+                return "points"
+            raise ValueError(
+                f"Unsupported prompt type {type(value)} for visual mode"
+            )
+        raise ValueError(f"Frame field '{field_name}' is empty")
+
+    def predict(self, video_reader, sample):
+        (
+            self._curr_frame_width,
+            self._curr_frame_height,
+        ) = video_reader.frame_size
+
+        frame_field_name = self._get_frame_prompt_field()
+        if frame_field_name is not None:
+            frame_indices = self._get_frame_indices()
+            if self.operation_mode == "concept":
+                self._curr_exemplar_prompts = (
+                    self._parse_concept_frame_prompts(
+                        sample, frame_field_name, frame_indices
+                    )
+                )
+            else:
+                self._curr_visual_prompts = self._parse_visual_frame_prompts(
+                    sample, frame_field_name, frame_indices
+                )
+        else:
+            self._curr_exemplar_prompts = {}
+            self._curr_visual_prompts = []
+
+        if self.operation_mode == "concept":
+            outputs = self._forward_pass_concept(video_reader, sample)
+        else:
+            outputs = self._forward_pass_visual(video_reader, sample)
+
+        return outputs
+
+    def _forward_pass_concept(self, video_reader, sample):
+        """Run video segmentation via the SAM 3 session API."""
+        video_path = sample.filepath
+
+        response = self.concept_predictor.handle_request(
+            request=dict(
+                type="start_session",
+                resource_path=video_path,
+            )
+        )
+        session_id = response["session_id"]
+
+        try:
+            label_map = {}
+
+            if self.config.classes:
+                text_frame = self._get_text_frame_idx()
+                for text_prompt in self.config.classes:
+                    prompt_response = self.concept_predictor.handle_request(
+                        request=dict(
+                            type="add_prompt",
+                            session_id=session_id,
+                            frame_index=text_frame,
+                            text=text_prompt,
+                        )
+                    )
+                    outputs = prompt_response.get("outputs", prompt_response)
+                    for oid in outputs.get("out_obj_ids", []):
+                        label_map[oid] = text_prompt
+
+            for frame_idx, prompt_list in self._curr_exemplar_prompts.items():
+                for prompt_dict in prompt_list:
+                    label = prompt_dict.get("_label", "object")
+
+                    request = dict(
+                        type="add_prompt",
+                        session_id=session_id,
+                        frame_index=frame_idx,
+                    )
+                    request.update(
+                        {k: v for k, v in prompt_dict.items() if k != "_label"}
+                    )
+
+                    prompt_response = self.concept_predictor.handle_request(
+                        request=request
+                    )
+
+                    outputs = prompt_response.get("outputs", prompt_response)
+                    for oid in outputs.get("out_obj_ids", []):
+                        label_map[oid] = label
+
+            # Handle label assignment for detections.
+            unique_labels = list(dict.fromkeys(label_map.values()))
+            if len(unique_labels) == 1:
+                propagation_default_label = unique_labels[0]
+            else:
+                propagation_default_label = None
+                if len(unique_labels) > 1:
+                    logger.warning(
+                        "SAM3 video: new object instances discovered during "
+                        "propagation could not be assigned a label because "
+                        "multiple text prompts were used (%s). Those instances "
+                        "will not be labeled. To avoid this, run each "
+                        "prompt in a separate apply_model call.",
+                        unique_labels,
+                    )
+
+            sample_detections = {
+                i + 1: fol.Detections(detections=[])
+                for i in range(len(sample.frames))
+            }
+
+            for frame_result in self.concept_predictor.handle_stream_request(
+                request=dict(
+                    type="propagate_in_video",
+                    session_id=session_id,
+                    propagation_direction=self.config.propagation_direction,
+                )
+            ):
+                out_frame_idx = frame_result.get("frame_index", 0)
+                outputs = frame_result.get("outputs", frame_result)
+
+                out_obj_ids = outputs.get("out_obj_ids", [])
+                out_probs = outputs.get("out_probs")
+                out_boxes = outputs.get("out_boxes_xywh")
+                out_masks = outputs.get("out_binary_masks")
+
+                if out_masks is None or len(out_obj_ids) == 0:
+                    sample_detections[int(out_frame_idx) + 1] = fol.Detections(
+                        detections=[]
+                    )
+                    continue
+
+                if isinstance(out_masks, torch.Tensor):
+                    out_masks = out_masks.cpu().numpy()
+                if isinstance(out_probs, torch.Tensor):
+                    out_probs = out_probs.cpu().numpy()
+                if isinstance(out_boxes, torch.Tensor):
+                    out_boxes = out_boxes.cpu().numpy()
+
+                detections = _sam3_output_to_detections(
+                    out_binary_masks=out_masks,
+                    out_boxes_xywh=out_boxes,
+                    out_obj_ids=out_obj_ids,
+                    out_probs=out_probs,
+                    frame_width=self._curr_frame_width,
+                    frame_height=self._curr_frame_height,
+                    label_map=label_map,
+                    default_label=propagation_default_label,
+                )
+
+                sample_detections[int(out_frame_idx) + 1] = fol.Detections(
+                    detections=detections
+                )
+
+        finally:
+            self.concept_predictor.handle_request(
+                request=dict(
+                    type="close_session",
+                    session_id=session_id,
+                )
+            )
+
+        return sample_detections
+
+    def _forward_pass_visual(self, video_reader, sample):
+        field_name = self._get_frame_prompt_field()
+        if field_name is None:
+            raise ValueError(
+                "Visual mode requires a prompt_field with "
+                "Detections or Keypoints"
+            )
+
+        prompt_type = self._get_visual_prompt_type(sample, field_name)
+
+        if prompt_type == "boxes":
+            return self._forward_pass_visual_boxes(video_reader, sample)
+        else:
+            return self._forward_pass_visual_points(video_reader, sample)
+
+    def _forward_pass_visual_boxes(self, video_reader, sample):
+        video_path = (sample, video_reader)
+
+        with self.ctx:
+            inference_state = self.visual_predictor.init_state(
+                video_path=video_path
+            )
+
+        classes_obj_id_map = {}
+        idx_obj_id_map = {}
+        current_obj_idx = 0
+
+        for frame_idx, frame_detections in enumerate(
+            self._curr_visual_prompts
+        ):
+            if (
+                not frame_detections
+                or not isinstance(frame_detections, fol.Detections)
+                or len(frame_detections.detections) == 0
+            ):
+                continue
+
+            for detection in frame_detections.detections:
+                if detection.index is not None:
+                    if detection.index in idx_obj_id_map:
+                        ann_obj_id = idx_obj_id_map[detection.index]
+                    else:
+                        ann_obj_id = current_obj_idx
+                        idx_obj_id_map[detection.index] = ann_obj_id
+                        current_obj_idx += 1
+                else:
+                    ann_obj_id = current_obj_idx
+                    current_obj_idx += 1
+
+                classes_obj_id_map[ann_obj_id] = detection.label
+
+                rx, ry, rw, rh = detection.bounding_box
+                box = np.array([rx, ry, rx + rw, ry + rh], dtype=np.float32)
+
+                _, _, _, _ = self.visual_predictor.add_new_points_or_box(
+                    inference_state=inference_state,
+                    frame_idx=frame_idx,
+                    obj_id=ann_obj_id,
+                    box=box,
+                )
+
+        return self._propagate_visual(inference_state, classes_obj_id_map)
+
+    def _forward_pass_visual_points(self, video_reader, sample):
+        video_path = (sample, video_reader)
+
+        with self.ctx:
+            inference_state = self.visual_predictor.init_state(
+                video_path=video_path
+            )
+
+        classes_obj_id_map = {}
+        idx_obj_id_map = {}
+        current_obj_idx = 0
+
+        for frame_idx, frame_keypoints in enumerate(self._curr_visual_prompts):
+            if (
+                not frame_keypoints
+                or not isinstance(frame_keypoints, fol.Keypoints)
+                or len(frame_keypoints.keypoints) == 0
+            ):
+                continue
+
+            for keypoint in frame_keypoints.keypoints:
+                if keypoint.index is not None:
+                    if keypoint.index in idx_obj_id_map:
+                        ann_obj_id = idx_obj_id_map[keypoint.index]
+                    else:
+                        ann_obj_id = current_obj_idx
+                        idx_obj_id_map[keypoint.index] = ann_obj_id
+                        current_obj_idx += 1
+                else:
+                    ann_obj_id = current_obj_idx
+                    current_obj_idx += 1
+
+                classes_obj_id_map[ann_obj_id] = keypoint.label
+
+                points, labels = fosam._to_sam_points(
+                    keypoint.points,
+                    width=self._curr_frame_width,
+                    height=self._curr_frame_height,
+                    point_labels=fosam._get_sam_point_labels(keypoint),
+                )
+
+                _, _, _, _ = self.visual_predictor.add_new_points_or_box(
+                    inference_state=inference_state,
+                    frame_idx=frame_idx,
+                    obj_id=ann_obj_id,
+                    points=points,
+                    labels=labels,
+                )
+
+        return self._propagate_visual(inference_state, classes_obj_id_map)
+
+    def _propagate_visual(self, inference_state, classes_obj_id_map):
+        """Shared propagation for visual mode."""
+        sample_detections = {}
+
+        for (
+            out_frame_idx,
+            out_obj_ids,
+            _low_res_masks,
+            out_mask_logits,
+            _obj_scores,
+        ) in self.visual_predictor.propagate_in_video(
+            inference_state,
+            start_frame_idx=None,
+            max_frame_num_to_track=None,
+            reverse=False,
+            propagate_preflight=True,
+        ):
+            detections = []
+
+            for i, out_obj_id in enumerate(out_obj_ids):
+                mask = np.squeeze(
+                    (out_mask_logits[i] > 0.0).cpu().numpy(), axis=0
+                )
+
+                box = fosam._mask_to_box(mask)
+                if box is None:
+                    continue
+
+                label = classes_obj_id_map.get(out_obj_id, "object")
+                x1, y1, x2, y2 = box
+
+                bounding_box = [
+                    x1 / self._curr_frame_width,
+                    y1 / self._curr_frame_height,
+                    (x2 - x1) / self._curr_frame_width,
+                    (y2 - y1) / self._curr_frame_height,
+                ]
+
+                mask = mask[
+                    int(round(y1)) : int(round(y2)),
+                    int(round(x1)) : int(round(x2)),
+                ]
+
+                detections.append(
+                    fol.Detection(
+                        label=label,
+                        bounding_box=bounding_box,
+                        mask=mask,
+                        index=out_obj_id,
+                    )
+                )
+
+            sample_detections[int(out_frame_idx) + 1] = fol.Detections(
+                detections=detections
+            )
+
+        return sample_detections
+
+
+def load_fiftyone_video_frames_sam3(
+    video_path,
+    image_size,
+    offload_video_to_cpu,
+    img_mean=(0.5, 0.5, 0.5),
+    img_std=(0.5, 0.5, 0.5),
+    async_loading_frames=False,
+    compute_device=torch.device("cuda"),
+):
+    """Load video frames from a FiftyOne video reader for SAM 3.
+
+    SAM 3 uses different normalisation constants from SAM 2:
+    mean/std = 0.5 instead of ImageNet values.
+    """
+    sample, video_reader = video_path
+
+    img_mean = torch.tensor(img_mean, dtype=torch.float32)[:, None, None]
+    img_std = torch.tensor(img_std, dtype=torch.float32)[:, None, None]
+
+    num_frames = len(sample.frames)
+
+    images = torch.zeros(
+        num_frames, 3, image_size, image_size, dtype=torch.float32
+    )
+
+    for frame_number in range(num_frames):
+        current_frame = video_reader.read()
+        resized_frame = (
+            cv2.resize(current_frame, (image_size, image_size)) / 255.0
+        )
+        img = torch.from_numpy(resized_frame).permute(2, 0, 1)
+        images[frame_number] = img
+
+        video_width, video_height = (
+            current_frame.shape[1],
+            current_frame.shape[0],
+        )
+
+    if not offload_video_to_cpu:
+        images = images.to(compute_device)
+        img_mean = img_mean.to(compute_device)
+        img_std = img_std.to(compute_device)
+
+    images -= img_mean
+    images /= img_std
+
+    return images, video_height, video_width
+
+
+def _load_video_frames_monkey_patch_sam3():
+    import sam3.model.sam3_tracking_predictor as _m
+
+    return fou.MonkeyPatchFunction(
+        _m,
+        load_fiftyone_video_frames_sam3,
+        fcn_name="load_video_frames",
+    )

--- a/fiftyone/utils/sam3.py
+++ b/fiftyone/utils/sam3.py
@@ -683,7 +683,7 @@ class SegmentAnything3VideoModelConfig(
 
     Args:
         operation_mode ("concept"): concept or visual mode of operation for inference
-        propagation_direction ("forward"): direction to propagate in video;
+        propagation_direction ("both"): direction to propagate in video;
             supported values are ``"forward"``, ``"backward"``, and ``"both"``
         prompt_frame_indices (None): 1-based frame indices for visual / exemplar prompts
         text_frame_idx (1): 1-based frame index for text concept prompts
@@ -702,7 +702,7 @@ class SegmentAnything3VideoModelConfig(
             d, "operation_mode", default="concept"
         )
         self.propagation_direction = self.parse_string(
-            d, "propagation_direction", default="forward"
+            d, "propagation_direction", default="both"
         )
         self.prompt_frame_indices = self.parse_array(
             d, "prompt_frame_indices", default=None
@@ -996,9 +996,14 @@ class SegmentAnything3VideoModel(fom.SamplesMixin, fom.Model):
         )
         session_id = response["session_id"]
 
-        try:
-            label_map = {}
+        sample_detections = {
+            i + 1: fol.Detections(detections=[])
+            for i in range(len(sample.frames))
+        }
 
+        try:
+            # Each add_prompt call resets model state, so we run a separate
+            # propagation pass per prompt and accumulate results across passes.
             if self.config.classes:
                 text_frame = self._get_text_frame_idx()
                 for text_prompt in self.config.classes:
@@ -1006,18 +1011,22 @@ class SegmentAnything3VideoModel(fom.SamplesMixin, fom.Model):
                         request=dict(
                             type="add_prompt",
                             session_id=session_id,
-                            frame_index=text_frame,
+                            frame_index=text_frame - 1,
                             text=text_prompt,
                         )
                     )
                     outputs = prompt_response.get("outputs", prompt_response)
-                    for oid in outputs.get("out_obj_ids", []):
-                        label_map[oid] = text_prompt
+                    label_map = {
+                        oid: text_prompt
+                        for oid in outputs.get("out_obj_ids", [])
+                    }
+                    self._accumulate_concept_propagation(
+                        session_id, label_map, text_prompt, sample_detections
+                    )
 
             for frame_idx, prompt_list in self._curr_exemplar_prompts.items():
                 for prompt_dict in prompt_list:
                     label = prompt_dict.get("_label", "object")
-
                     request = dict(
                         type="add_prompt",
                         session_id=session_id,
@@ -1026,78 +1035,16 @@ class SegmentAnything3VideoModel(fom.SamplesMixin, fom.Model):
                     request.update(
                         {k: v for k, v in prompt_dict.items() if k != "_label"}
                     )
-
                     prompt_response = self.concept_predictor.handle_request(
                         request=request
                     )
-
                     outputs = prompt_response.get("outputs", prompt_response)
-                    for oid in outputs.get("out_obj_ids", []):
-                        label_map[oid] = label
-
-            # Handle label assignment for detections.
-            unique_labels = list(dict.fromkeys(label_map.values()))
-            if len(unique_labels) == 1:
-                propagation_default_label = unique_labels[0]
-            else:
-                propagation_default_label = None
-                if len(unique_labels) > 1:
-                    logger.warning(
-                        "SAM3 video: new object instances discovered during "
-                        "propagation could not be assigned a label because "
-                        "multiple text prompts were used (%s). Those instances "
-                        "will not be labeled. To avoid this, run each "
-                        "prompt in a separate apply_model call.",
-                        unique_labels,
+                    label_map = {
+                        oid: label for oid in outputs.get("out_obj_ids", [])
+                    }
+                    self._accumulate_concept_propagation(
+                        session_id, label_map, label, sample_detections
                     )
-
-            sample_detections = {
-                i + 1: fol.Detections(detections=[])
-                for i in range(len(sample.frames))
-            }
-
-            for frame_result in self.concept_predictor.handle_stream_request(
-                request=dict(
-                    type="propagate_in_video",
-                    session_id=session_id,
-                    propagation_direction=self.config.propagation_direction,
-                )
-            ):
-                out_frame_idx = frame_result.get("frame_index", 0)
-                outputs = frame_result.get("outputs", frame_result)
-
-                out_obj_ids = outputs.get("out_obj_ids", [])
-                out_probs = outputs.get("out_probs")
-                out_boxes = outputs.get("out_boxes_xywh")
-                out_masks = outputs.get("out_binary_masks")
-
-                if out_masks is None or len(out_obj_ids) == 0:
-                    sample_detections[int(out_frame_idx) + 1] = fol.Detections(
-                        detections=[]
-                    )
-                    continue
-
-                if isinstance(out_masks, torch.Tensor):
-                    out_masks = out_masks.cpu().numpy()
-                if isinstance(out_probs, torch.Tensor):
-                    out_probs = out_probs.cpu().numpy()
-                if isinstance(out_boxes, torch.Tensor):
-                    out_boxes = out_boxes.cpu().numpy()
-
-                detections = _sam3_output_to_detections(
-                    out_binary_masks=out_masks,
-                    out_boxes_xywh=out_boxes,
-                    out_obj_ids=out_obj_ids,
-                    out_probs=out_probs,
-                    frame_width=self._curr_frame_width,
-                    frame_height=self._curr_frame_height,
-                    label_map=label_map,
-                    default_label=propagation_default_label,
-                )
-
-                sample_detections[int(out_frame_idx) + 1] = fol.Detections(
-                    detections=detections
-                )
 
         finally:
             self.concept_predictor.handle_request(
@@ -1108,6 +1055,56 @@ class SegmentAnything3VideoModel(fom.SamplesMixin, fom.Model):
             )
 
         return sample_detections
+
+    def _accumulate_concept_propagation(
+        self, session_id, label_map, default_label, sample_detections
+    ):
+        """Propagate the current session state and merge detections into
+        ``sample_detections``, using ``default_label`` for any object whose
+        ID is not in ``label_map`` (e.g. newly discovered instances)."""
+        for frame_result in self.concept_predictor.handle_stream_request(
+            request=dict(
+                type="propagate_in_video",
+                session_id=session_id,
+                propagation_direction=self.config.propagation_direction,
+            )
+        ):
+            out_frame_idx = frame_result.get("frame_index", 0)
+            outputs = frame_result.get("outputs", frame_result)
+
+            out_obj_ids = outputs.get("out_obj_ids", [])
+            out_probs = outputs.get("out_probs")
+            out_boxes = outputs.get("out_boxes_xywh")
+            out_masks = outputs.get("out_binary_masks")
+
+            if out_masks is None or len(out_obj_ids) == 0:
+                continue
+
+            if isinstance(out_masks, torch.Tensor):
+                out_masks = out_masks.cpu().numpy()
+            if isinstance(out_probs, torch.Tensor):
+                out_probs = out_probs.cpu().numpy()
+            if isinstance(out_boxes, torch.Tensor):
+                out_boxes = out_boxes.cpu().numpy()
+
+            new_dets = _sam3_output_to_detections(
+                out_binary_masks=out_masks,
+                out_boxes_xywh=out_boxes,
+                out_obj_ids=out_obj_ids,
+                out_probs=out_probs,
+                frame_width=self._curr_frame_width,
+                frame_height=self._curr_frame_height,
+                label_map=label_map,
+                default_label=default_label,
+            )
+
+            frame_num = int(out_frame_idx) + 1
+            existing = sample_detections.get(
+                frame_num, fol.Detections(detections=[])
+            )
+            sample_detections[frame_num] = fol.Detections(
+                detections=existing.detections + new_dets
+            )
 
     def _forward_pass_visual(self, video_reader, sample):
         field_name = self._get_frame_prompt_field()

--- a/fiftyone/utils/sam3.py
+++ b/fiftyone/utils/sam3.py
@@ -701,9 +701,20 @@ class SegmentAnything3VideoModelConfig(
         self.operation_mode = self.parse_string(
             d, "operation_mode", default="concept"
         )
+        if self.operation_mode not in {"concept", "visual"}:
+            raise ValueError("operation_mode must be 'concept' or 'visual'")
+
         self.propagation_direction = self.parse_string(
             d, "propagation_direction", default="both"
         )
+        if self.propagation_direction not in {
+            "forward",
+            "backward",
+            "both",
+        }:
+            raise ValueError(
+                "propagation_direction must be 'forward', 'backward', or 'both'"
+            )
         self.prompt_frame_indices = self.parse_array(
             d, "prompt_frame_indices", default=None
         )
@@ -876,6 +887,8 @@ class SegmentAnything3VideoModel(fom.SamplesMixin, fom.Model):
                 )
 
             value = sample.frames[frame_number].get_field(frame_field_name)
+            if value is None:
+                continue
             frame_idx = int(frame_number - 1)
             if isinstance(value, fol.Detections):
                 frame_prompts = []
@@ -1025,7 +1038,7 @@ class SegmentAnything3VideoModel(fom.SamplesMixin, fom.Model):
 
             for frame_idx, prompt_list in self._curr_exemplar_prompts.items():
                 for prompt_dict in prompt_list:
-                    label = prompt_dict.get("_label", "object")
+                    label = prompt_dict.get("_label", None)
                     request = dict(
                         type="add_prompt",
                         session_id=session_id,
@@ -1221,6 +1234,41 @@ class SegmentAnything3VideoModel(fom.SamplesMixin, fom.Model):
 
     def _propagate_visual(self, inference_state, classes_obj_id_map):
         """Shared propagation for visual mode."""
+        direction = self.config.propagation_direction
+
+        if direction == "forward":
+            return self._run_visual_propagation(
+                inference_state,
+                classes_obj_id_map,
+                reverse=False,
+                propagate_preflight=True,
+            )
+        elif direction == "backward":
+            return self._run_visual_propagation(
+                inference_state,
+                classes_obj_id_map,
+                reverse=True,
+                propagate_preflight=True,
+            )
+        else:
+            forward = self._run_visual_propagation(
+                inference_state,
+                classes_obj_id_map,
+                reverse=False,
+                propagate_preflight=True,
+            )
+            backward = self._run_visual_propagation(
+                inference_state,
+                classes_obj_id_map,
+                reverse=True,
+                propagate_preflight=False,
+            )
+            return self._merge_propagation_results(forward, backward)
+
+    def _run_visual_propagation(
+        self, inference_state, classes_obj_id_map, reverse, propagate_preflight
+    ):
+        """Run a single-direction propagation pass and return frame detections."""
         sample_detections = {}
 
         for (
@@ -1233,8 +1281,8 @@ class SegmentAnything3VideoModel(fom.SamplesMixin, fom.Model):
             inference_state,
             start_frame_idx=None,
             max_frame_num_to_track=None,
-            reverse=False,
-            propagate_preflight=True,
+            reverse=reverse,
+            propagate_preflight=propagate_preflight,
         ):
             detections = []
 
@@ -1247,7 +1295,7 @@ class SegmentAnything3VideoModel(fom.SamplesMixin, fom.Model):
                 if box is None:
                     continue
 
-                label = classes_obj_id_map.get(out_obj_id, "object")
+                label = classes_obj_id_map.get(out_obj_id, None)
                 x1, y1, x2, y2 = box
 
                 bounding_box = [
@@ -1276,6 +1324,18 @@ class SegmentAnything3VideoModel(fom.SamplesMixin, fom.Model):
             )
 
         return sample_detections
+
+    def _merge_propagation_results(self, forward, backward):
+        """Merge forward and backward propagation results.
+
+        Forward-pass detections take precedence; backward fills frames that
+        are absent or empty in the forward pass.
+        """
+        merged = dict(forward)
+        for frame_num, dets in backward.items():
+            if frame_num not in merged or not merged[frame_num].detections:
+                merged[frame_num] = dets
+        return merged
 
 
 def load_fiftyone_video_frames_sam3(

--- a/fiftyone/utils/sam3.py
+++ b/fiftyone/utils/sam3.py
@@ -13,7 +13,6 @@ import os
 import shutil
 from PIL import Image
 
-import fiftyone as fo
 import cv2
 import eta.core.utils as etau
 
@@ -326,7 +325,6 @@ class SegmentAnything3ImageModel(fosam2.SegmentAnything2ImageModel):
             # Sam3Image.inst_interactive_predictor is only needed for "visual" operation mode.
             # Always set to True for easy switching of operation modes in a loaded zoo model.
             config.entrypoint_args["enable_inst_interactivity"] = True
-
         if (
             "bpe_path" not in config.entrypoint_args
             and config.tokenizer_source
@@ -358,14 +356,15 @@ class SegmentAnything3ImageModel(fosam2.SegmentAnything2ImageModel):
         return model
 
     def _download_model(self, config):
-        # Download sam3 to fo.config.model_zoo_dir from HF hub.
-        from huggingface_hub import hf_hub_download
+        if "checkpoint_path" not in config.entrypoint_args:
+            # Download sam3 to fo.config.model_zoo_dir from HF hub.
+            from huggingface_hub import hf_hub_download
 
-        hf_hub_download(
-            repo_id="facebook/sam3",
-            filename=os.path.basename(config.model_path),
-            local_dir=os.path.dirname(config.model_path),
-        )
+            config.entrypoint_args["checkpoint_path"] = hf_hub_download(
+                repo_id="facebook/sam3",
+                filename=os.path.basename(config.model_path),
+                local_dir=os.path.dirname(config.model_path),
+            )
 
         bpe_path = config.entrypoint_args["bpe_path"]
         if not os.path.isfile(bpe_path):
@@ -685,8 +684,14 @@ class SegmentAnything3VideoModelConfig(
         operation_mode ("concept"): concept or visual mode of operation for inference
         propagation_direction ("both"): direction to propagate in video;
             supported values are ``"forward"``, ``"backward"``, and ``"both"``
+        propagation_precedence: detection that takes precendence when merging results for bidirection propagation;
+            supported values are ``"forward"`` and ``"backward"``
         prompt_frame_indices (None): 1-based frame indices for visual / exemplar prompts
         text_frame_idx (1): 1-based frame index for text concept prompts
+        tokenizer_source (None): the URL to download the SAM3 tokenizer BPE vocab
+        concept_predictor_fcn (None): a function or string like
+            ``"sam3.model_builder.build_sam3_video_model"`` specifying the entrypoint
+            function that loads the concept predictor
     """
 
     def __init__(self, cfg_dict):
@@ -697,6 +702,13 @@ class SegmentAnything3VideoModelConfig(
         """
         d = self.init(cfg_dict)
         super().__init__(d)
+
+        self.tokenizer_source = self.parse_string(
+            d, "tokenizer_source", default=None
+        )
+        self.concept_predictor_fcn = self.parse_raw(
+            d, "concept_predictor_fcn", default=None
+        )
 
         self.operation_mode = self.parse_string(
             d, "operation_mode", default="concept"
@@ -714,6 +726,17 @@ class SegmentAnything3VideoModelConfig(
         }:
             raise ValueError(
                 "propagation_direction must be 'forward', 'backward', or 'both'"
+            )
+        # .
+        self.propagation_precedence = self.parse_string(
+            d, "propagation_precedence", default="forward"
+        )
+        if self.propagation_precedence not in {
+            "forward",
+            "backward",
+        }:
+            raise ValueError(
+                "propagation_precedence must be 'forward' or 'backward'"
             )
         self.prompt_frame_indices = self.parse_array(
             d, "prompt_frame_indices", default=None
@@ -768,6 +791,17 @@ class SegmentAnything3VideoModel(fom.SamplesMixin, fom.Model):
 
         self._operation_mode = self.config.operation_mode
 
+        if config.entrypoint_args is None:
+            config.entrypoint_args = {}
+        if (
+            "bpe_path" not in config.entrypoint_args
+            and config.tokenizer_source
+        ):
+            config.entrypoint_args["bpe_path"] = os.path.join(
+                os.path.dirname(config.model_path),
+                os.path.basename(config.tokenizer_source),
+            )
+
         self.ctx = _load_video_frames_monkey_patch_sam3()
 
         self._download_model(config)
@@ -786,7 +820,40 @@ class SegmentAnything3VideoModel(fom.SamplesMixin, fom.Model):
         return "video"
 
     def _download_model(self, config):
-        config.download_model_if_necessary()
+        if config.entrypoint_args is None:
+            config.entrypoint_args = {}
+        if "checkpoint_path" not in config.entrypoint_args:
+            from huggingface_hub import hf_hub_download
+
+            repo_id = "facebook/sam3"
+            # The HF repo uses "sam3.pt"; local base_filename is "sam3_video.pt"
+            # to avoid collisions with the image model in the zoo manifest.
+            zoo_dir = os.path.dirname(config.model_path)
+            model_filename = "sam3.pt"
+            _ = hf_hub_download(repo_id=repo_id, filename="config.json")
+            hf_zoo_path = hf_hub_download(
+                repo_id=repo_id,
+                filename=model_filename,
+                local_dir=zoo_dir,
+            )
+            if not os.path.isfile(config.model_path):
+                shutil.copy2(hf_zoo_path, config.model_path)
+            config.entrypoint_args["checkpoint_path"] = config.model_path
+
+        if "bpe_path" in config.entrypoint_args:
+            bpe_path = config.entrypoint_args["bpe_path"]
+            if not os.path.isfile(bpe_path):
+                if not config.tokenizer_source:
+                    raise ValueError(
+                        "Missing BPE vocabulary tokenizer. Either provide "
+                        "'tokenizer_source' in the model config for downloading "
+                        "or set 'bpe_path' in the model config 'entrypoint_args' "
+                        "to a pre-downloaded file."
+                    )
+                _download_sam3_bpe_vocab_file(
+                    tokenizer_source=config.tokenizer_source,
+                    bpe_path=bpe_path,
+                )
 
     def _load_model(self, config):
         if config.model is not None:
@@ -797,7 +864,7 @@ class SegmentAnything3VideoModel(fom.SamplesMixin, fom.Model):
             if etau.is_str(entrypoint_fcn):
                 entrypoint_fcn = etau.get_function(entrypoint_fcn)
 
-            kwargs = config.entrypoint_args or {}
+            kwargs = dict(config.entrypoint_args or {})
             with self.ctx:
                 model = entrypoint_fcn(**kwargs)
 
@@ -810,8 +877,14 @@ class SegmentAnything3VideoModel(fom.SamplesMixin, fom.Model):
         return model
 
     def _load_concept_predictor(self):
-        return sam3.model_builder.build_sam3_video_predictor(
-            gpus_to_use=[self._device.index if self._device.index else 0]
+        concept_predictor_fcn = self.config.concept_predictor_fcn
+        if etau.is_str(concept_predictor_fcn):
+            concept_predictor_fcn = etau.get_function(concept_predictor_fcn)
+
+        kwargs = dict(self.config.entrypoint_args or {})
+        return concept_predictor_fcn(
+            gpus_to_use=[self._device.index if self._device.index else 0],
+            **kwargs,
         )
 
     @property
@@ -1263,7 +1336,9 @@ class SegmentAnything3VideoModel(fom.SamplesMixin, fom.Model):
                 reverse=True,
                 propagate_preflight=False,
             )
-            return self._merge_propagation_results(forward, backward)
+            if self.config.propagation_precedence == "forward":
+                return self._merge_propagation_results(forward, backward)
+            return self._merge_propagation_results(backward, forward)
 
     def _run_visual_propagation(
         self, inference_state, classes_obj_id_map, reverse, propagate_preflight
@@ -1325,27 +1400,33 @@ class SegmentAnything3VideoModel(fom.SamplesMixin, fom.Model):
 
         return sample_detections
 
-    def _merge_propagation_results(self, forward, backward):
+    def _merge_propagation_results(
+        self, primary_direction, secondary_direction
+    ):
         """Merge forward and backward propagation results per Detection.index.
 
         Detections are merged by their ``index`` field so that objects tracked
         only in the backward pass are not discarded on frames where the forward
         pass produced detections for different objects.
         """
-        all_frame_nums = set(forward) | set(backward)
+        all_frame_nums = set(primary_direction) | set(secondary_direction)
         merged = {}
         for frame_num in all_frame_nums:
-            fwd_dets = forward.get(frame_num, fol.Detections(detections=[]))
-            bwd_dets = backward.get(frame_num, fol.Detections(detections=[]))
+            prim_dets = primary_direction.get(
+                frame_num, fol.Detections(detections=[])
+            )
+            sec_dets = secondary_direction.get(
+                frame_num, fol.Detections(detections=[])
+            )
 
             seen_indices = set()
             combined = []
-            for det in fwd_dets.detections:
+            for det in prim_dets.detections:
                 combined.append(det)
                 if det.index is not None:
                     seen_indices.add(det.index)
 
-            for det in bwd_dets.detections:
+            for det in sec_dets.detections:
                 if det.index is None or det.index not in seen_indices:
                     combined.append(det)
 

--- a/fiftyone/utils/sam3.py
+++ b/fiftyone/utils/sam3.py
@@ -690,7 +690,7 @@ class SegmentAnything3VideoModelConfig(
     """
 
     def __init__(self, cfg_dict):
-        """Initializes :class:`SegmentAnything3ImageModelConfig`
+        """Initializes :class:`SegmentAnything3VideoModelConfig`
 
         Args:
             cfg_dict: a dictionary with config parameters
@@ -707,7 +707,7 @@ class SegmentAnything3VideoModelConfig(
         self.prompt_frame_indices = self.parse_array(
             d, "prompt_frame_indices", default=None
         )
-        self.text_frame_idx = self.parse_array(d, "text_frame_idx", default=1)
+        self.text_frame_idx = self.parse_int(d, "text_frame_idx", default=1)
 
 
 class SegmentAnything3VideoModel(fom.SamplesMixin, fom.Model):
@@ -868,55 +868,54 @@ class SegmentAnything3VideoModel(fom.SamplesMixin, fom.Model):
             else range(1, len(sample.frames) + 1)
         )
 
-        if self.operation_mode == "concept":
-            prompts = {}
-            for frame_number in _frame_indices:
-                if frame_number > len(sample.frames):
-                    raise ValueError(
-                        f"Frame index {frame_number} not valid for {len(sample.frames)} sample frames."
+        prompts = {}
+        for frame_number in _frame_indices:
+            if frame_number > len(sample.frames):
+                raise ValueError(
+                    f"Frame index {frame_number} not valid for {len(sample.frames)} sample frames."
+                )
+
+            value = sample.frames[frame_number].get_field(frame_field_name)
+            frame_idx = int(frame_number - 1)
+            if isinstance(value, fol.Detections):
+                frame_prompts = []
+                for det in value.detections:
+                    rx, ry, rw, rh = det.bounding_box
+                    frame_prompts.append(
+                        {
+                            "box": [rx, ry, rx + rw, ry + rh],
+                            "_label": det.label,
+                        }
                     )
+                if frame_prompts:
+                    prompts[frame_idx] = frame_prompts
 
-                value = sample.frames[frame_number].get_field(frame_field_name)
-                frame_idx = int(frame_number - 1)
-                if isinstance(value, fol.Detections):
-                    frame_prompts = []
-                    for det in value.detections:
-                        rx, ry, rw, rh = det.bounding_box
-                        frame_prompts.append(
-                            {
-                                "box": [rx, ry, rx + rw, ry + rh],
-                                "_label": det.label,
-                            }
-                        )
-                    if frame_prompts:
-                        prompts[frame_idx] = frame_prompts
-
-                elif isinstance(value, fol.Keypoints):
-                    frame_prompts = []
-                    for kp in value.keypoints:
-                        points_norm, labels = fosam._to_sam_points(
-                            kp.points,
-                            width=1,
-                            height=1,
-                            point_labels=fosam._get_sam_point_labels(kp),
-                        )
-                        frame_prompts.append(
-                            {
-                                "points": points_norm.tolist(),
-                                "labels": labels.tolist(),
-                                "_label": kp.label,
-                            }
-                        )
-                    if frame_prompts:
-                        prompts[frame_idx] = frame_prompts
-
-                else:
-                    raise ValueError(
-                        f"Unsupported prompt type {type(value)} on frame "
-                        f"{frame_number}. Use Detections or Keypoints. "
+            elif isinstance(value, fol.Keypoints):
+                frame_prompts = []
+                for kp in value.keypoints:
+                    points_norm, labels = fosam._to_sam_points(
+                        kp.points,
+                        width=1,
+                        height=1,
+                        point_labels=fosam._get_sam_point_labels(kp),
                     )
+                    frame_prompts.append(
+                        {
+                            "points": points_norm.tolist(),
+                            "labels": labels.tolist(),
+                            "_label": kp.label,
+                        }
+                    )
+                if frame_prompts:
+                    prompts[frame_idx] = frame_prompts
 
-            return prompts
+            else:
+                raise ValueError(
+                    f"Unsupported prompt type {type(value)} on frame "
+                    f"{frame_number}. Use Detections or Keypoints. "
+                )
+
+        return prompts
 
     def _parse_visual_frame_prompts(
         self, sample, frame_field_name, frame_indices
@@ -1304,18 +1303,21 @@ def load_fiftyone_video_frames_sam3(
         num_frames, 3, image_size, image_size, dtype=torch.float32
     )
 
+    video_width, video_height = None, None
     for frame_number in range(num_frames):
         current_frame = video_reader.read()
+        if current_frame is None:
+            raise RuntimeError(
+                f"Video reader returned None at frame {frame_number}, "
+                f"expected {num_frames} frames"
+            )
+        if video_width is None:
+            video_height, video_width = current_frame.shape[:2]
         resized_frame = (
             cv2.resize(current_frame, (image_size, image_size)) / 255.0
         )
         img = torch.from_numpy(resized_frame).permute(2, 0, 1)
         images[frame_number] = img
-
-        video_width, video_height = (
-            current_frame.shape[1],
-            current_frame.shape[0],
-        )
 
     if not offload_video_to_cpu:
         images = images.to(compute_device)

--- a/fiftyone/utils/sam3.py
+++ b/fiftyone/utils/sam3.py
@@ -777,7 +777,7 @@ class SegmentAnything3VideoModel(fom.SamplesMixin, fom.Model):
         self.concept_predictor = self._load_concept_predictor()
 
         self._curr_exemplar_prompts = None
-        self._curr_visual_prompts = None
+        self._curr_visual_prompts = {}
         self._curr_frame_width = None
         self._curr_frame_height = None
 
@@ -874,16 +874,14 @@ class SegmentAnything3VideoModel(fom.SamplesMixin, fom.Model):
             {0: [{"points": [[x1, y1], [x2, y2]], "labels": [1, 0], _label": "dog"}], ...}
         """
         _frame_indices = (
-            frame_indices
-            if frame_indices
-            else range(1, len(sample.frames) + 1)
+            frame_indices if frame_indices else sorted(sample.frames.keys())
         )
 
         prompts = {}
         for frame_number in _frame_indices:
-            if frame_number > len(sample.frames):
+            if frame_number not in sample.frames:
                 raise ValueError(
-                    f"Frame index {frame_number} not valid for {len(sample.frames)} sample frames."
+                    f"Frame index {frame_number} not valid for sample with frame keys {sorted(sample.frames.keys())}."
                 )
 
             value = sample.frames[frame_number].get_field(frame_field_name)
@@ -935,21 +933,19 @@ class SegmentAnything3VideoModel(fom.SamplesMixin, fom.Model):
     ):
         """Read per-frame prompts for visual mode.
 
-        Returns a flat list of raw FiftyOne labels, one per frame:
-
-            [Detections(...), [], [], ...]
+        Returns a dict mapping 0-based SAM3 frame index to raw FiftyOne labels.
+        Frame number N (1-based FiftyOne) maps to SAM3 frame index N-1.
         """
         _frame_indices = (
-            frame_indices
-            if frame_indices
-            else range(1, len(sample.frames) + 1)
+            set(frame_indices) if frame_indices else set(sample.frames.keys())
         )
-        prompts = []
-        for f_idx, frame in sample.frames.items():
+        prompts = {}
+        for frame_number, frame in sample.frames.items():
+            if frame_number not in _frame_indices:
+                continue
             value = frame.get_field(frame_field_name)
-            prompts.append(
-                value if value is not None and f_idx in _frame_indices else []
-            )
+            if value is not None:
+                prompts[frame_number - 1] = value
         return prompts
 
     def _get_visual_prompt_type(self, sample, field_name):
@@ -987,7 +983,7 @@ class SegmentAnything3VideoModel(fom.SamplesMixin, fom.Model):
                 )
         else:
             self._curr_exemplar_prompts = {}
-            self._curr_visual_prompts = []
+            self._curr_visual_prompts = {}
 
         if self.operation_mode == "concept":
             outputs = self._forward_pass_concept(video_reader, sample)
@@ -998,6 +994,12 @@ class SegmentAnything3VideoModel(fom.SamplesMixin, fom.Model):
 
     def _forward_pass_concept(self, video_reader, sample):
         """Run video segmentation via the SAM 3 session API."""
+        if not self.config.classes and not self._curr_exemplar_prompts:
+            raise ValueError(
+                "Concept mode requires at least one text prompt (via 'classes') "
+                "or one exemplar prompt (via 'prompt_field')."
+            )
+
         video_path = sample.filepath
 
         response = self.concept_predictor.handle_request(
@@ -1145,9 +1147,7 @@ class SegmentAnything3VideoModel(fom.SamplesMixin, fom.Model):
         idx_obj_id_map = {}
         current_obj_idx = 0
 
-        for frame_idx, frame_detections in enumerate(
-            self._curr_visual_prompts
-        ):
+        for frame_idx, frame_detections in self._curr_visual_prompts.items():
             if (
                 not frame_detections
                 or not isinstance(frame_detections, fol.Detections)
@@ -1193,7 +1193,7 @@ class SegmentAnything3VideoModel(fom.SamplesMixin, fom.Model):
         idx_obj_id_map = {}
         current_obj_idx = 0
 
-        for frame_idx, frame_keypoints in enumerate(self._curr_visual_prompts):
+        for frame_idx, frame_keypoints in self._curr_visual_prompts.items():
             if (
                 not frame_keypoints
                 or not isinstance(frame_keypoints, fol.Keypoints)
@@ -1326,15 +1326,30 @@ class SegmentAnything3VideoModel(fom.SamplesMixin, fom.Model):
         return sample_detections
 
     def _merge_propagation_results(self, forward, backward):
-        """Merge forward and backward propagation results.
+        """Merge forward and backward propagation results per Detection.index.
 
-        Forward-pass detections take precedence; backward fills frames that
-        are absent or empty in the forward pass.
+        Detections are merged by their ``index`` field so that objects tracked
+        only in the backward pass are not discarded on frames where the forward
+        pass produced detections for different objects.
         """
-        merged = dict(forward)
-        for frame_num, dets in backward.items():
-            if frame_num not in merged or not merged[frame_num].detections:
-                merged[frame_num] = dets
+        all_frame_nums = set(forward) | set(backward)
+        merged = {}
+        for frame_num in all_frame_nums:
+            fwd_dets = forward.get(frame_num, fol.Detections(detections=[]))
+            bwd_dets = backward.get(frame_num, fol.Detections(detections=[]))
+
+            seen_indices = set()
+            combined = []
+            for det in fwd_dets.detections:
+                combined.append(det)
+                if det.index is not None:
+                    seen_indices.add(det.index)
+
+            for det in bwd_dets.detections:
+                if det.index is None or det.index not in seen_indices:
+                    combined.append(det)
+
+            merged[frame_num] = fol.Detections(detections=combined)
         return merged
 
 
@@ -1357,7 +1372,12 @@ def load_fiftyone_video_frames_sam3(
     img_mean = torch.tensor(img_mean, dtype=torch.float32)[:, None, None]
     img_std = torch.tensor(img_std, dtype=torch.float32)[:, None, None]
 
-    num_frames = len(sample.frames)
+    num_frames = (
+        sample.metadata.total_frame_count
+        if sample.metadata is not None
+        and sample.metadata.total_frame_count is not None
+        else len(sample.frames)
+    )
 
     images = torch.zeros(
         num_frames, 3, image_size, image_size, dtype=torch.float32

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -667,7 +667,6 @@
                 "type": "fiftyone.utils.sam3.SegmentAnything3ImageModel",
                 "config": {
                     "entrypoint_fcn": "sam3.model_builder.build_sam3_image_model",
-                    "entrypoint_args": {},
                     "tokenizer_source": "https://raw.githubusercontent.com/openai/CLIP/main/clip/bpe_simple_vocab_16e6.txt.gz"
                 }
             },
@@ -681,11 +680,9 @@
                 }
             },
             "tags": [
-                "segmentation",
-                "instance-segmentation",
+                "segment-anything",
+                "torch",
                 "zero-shot",
-                "open-vocabulary",
-                "text-prompted",
                 "transformer",
                 "official"
             ],
@@ -718,7 +715,8 @@
                 "type": "fiftyone.utils.sam3.SegmentAnything3VideoModel",
                 "config": {
                     "entrypoint_fcn": "sam3.model_builder.build_sam3_video_model",
-                    "entrypoint_args": {}
+                    "tokenizer_source": "https://raw.githubusercontent.com/openai/CLIP/main/clip/bpe_simple_vocab_16e6.txt.gz",
+                    "concept_predictor_fcn": "sam3.model_builder.build_sam3_video_predictor"
                 }
             },
             "requirements": {
@@ -731,13 +729,10 @@
                 }
             },
             "tags": [
-                "segmentation",
-                "instance-segmentation",
-                "video",
-                "tracking",
+                "segment-anything",
+                "torch",
                 "zero-shot",
-                "open-vocabulary",
-                "text-prompted",
+                "video",
                 "transformer",
                 "official"
             ],

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -702,6 +702,58 @@
             "date_added": "2026-01-30"
         },
         {
+            "base_name": "segment-anything-3-video-torch",
+            "base_filename": "sam3_video.pt",
+            "version": null,
+            "description": "Open-vocabulary video segmentation that finds, segments, and tracks all objects matching a text concept across video frames",
+            "source": "https://github.com/facebookresearch/sam3",
+            "author": "Nicolas Carion, Laura Gustafson, Yuan-Ting Hu, et al.",
+            "license": "SAM License",
+            "size_bytes": 3704365056,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {}
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.sam3.SegmentAnything3VideoModel",
+                "config": {
+                    "entrypoint_fcn": "sam3.model_builder.build_sam3_video_model",
+                    "entrypoint_args": {}
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision", "sam3"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": [
+                "segmentation",
+                "instance-segmentation",
+                "video",
+                "tracking",
+                "zero-shot",
+                "open-vocabulary",
+                "text-prompted",
+                "transformer",
+                "official"
+            ],
+            "training_data": [
+                {
+                    "name": "SA-1B",
+                    "url": "https://ai.meta.com/datasets/segment-anything/"
+                },
+                {
+                    "name": "SA-Co",
+                    "url": "https://github.com/facebookresearch/sam3"
+                }
+            ],
+            "date_added": "2026-01-30"
+        },
+        {
             "base_name": "med-sam-2-video-torch",
             "base_filename": "med-sam-2_pretrain.pth",
             "version": null,
@@ -7461,7 +7513,14 @@
                     "support": true
                 }
             },
-            "tags": ["instances", "torch", "yolo", "zero-shot", "prompt-free", "official"],
+            "tags": [
+                "instances",
+                "torch",
+                "yolo",
+                "zero-shot",
+                "prompt-free",
+                "official"
+            ],
             "training_data": [
                 {
                     "name": "Objects365v1",
@@ -7519,7 +7578,14 @@
                     "support": true
                 }
             },
-            "tags": ["instances", "torch", "yolo", "zero-shot", "prompt-free", "official"],
+            "tags": [
+                "instances",
+                "torch",
+                "yolo",
+                "zero-shot",
+                "prompt-free",
+                "official"
+            ],
             "training_data": [
                 {
                     "name": "Objects365v1",
@@ -7577,7 +7643,14 @@
                     "support": true
                 }
             },
-            "tags": ["instances", "torch", "yolo", "zero-shot", "prompt-free", "official"],
+            "tags": [
+                "instances",
+                "torch",
+                "yolo",
+                "zero-shot",
+                "prompt-free",
+                "official"
+            ],
             "training_data": [
                 {
                     "name": "Objects365v1",
@@ -7635,7 +7708,14 @@
                     "support": true
                 }
             },
-            "tags": ["instances", "torch", "yolo", "zero-shot", "prompt-free", "official"],
+            "tags": [
+                "instances",
+                "torch",
+                "yolo",
+                "zero-shot",
+                "prompt-free",
+                "official"
+            ],
             "training_data": [
                 {
                     "name": "Objects365v1",
@@ -7693,7 +7773,14 @@
                     "support": true
                 }
             },
-            "tags": ["instances", "torch", "yolo", "zero-shot", "prompt-free", "official"],
+            "tags": [
+                "instances",
+                "torch",
+                "yolo",
+                "zero-shot",
+                "prompt-free",
+                "official"
+            ],
             "training_data": [
                 {
                     "name": "Objects365v1",

--- a/tests/intensive/model_zoo_tests.py
+++ b/tests/intensive/model_zoo_tests.py
@@ -347,6 +347,11 @@ def _apply_video_models(
 
     if _SAM_PROMPT_FIELD in kwargs:
         if prompt_type == "keypoints":
+            if not kwargs[_SAM_PROMPT_FIELD].startswith("frames."):
+                raise ValueError(
+                    f"Prompt field must start with 'frames.' for video models, "
+                    f"got: {kwargs[_SAM_PROMPT_FIELD]}"
+                )
             frame_field = kwargs[_SAM_PROMPT_FIELD][len("frames.") :]
             kp_field = frame_field + "_points"
             for sample in dataset:

--- a/tests/intensive/model_zoo_tests.py
+++ b/tests/intensive/model_zoo_tests.py
@@ -117,6 +117,84 @@ def test_sam2_video():
     )
 
 
+def test_sam3_image_concept():
+    models = ["segment-anything-3-image-torch"]
+    _apply_models(
+        models,
+        max_samples=3,
+        model_kwargs=dict(classes=["person"], operation_mode="concept"),
+    )
+
+
+def test_sam3_image_concept_multi_prompt():
+    models = ["segment-anything-3-image-torch"]
+    _apply_models(
+        models,
+        max_samples=3,
+        model_kwargs=dict(classes=["person", "car"], operation_mode="concept"),
+    )
+
+
+def test_sam3_image_visual_boxes():
+    models = ["segment-anything-3-image-torch"]
+    _apply_models(
+        models,
+        max_samples=3,
+        model_kwargs=dict(operation_mode="visual"),
+        apply_kwargs={_SAM_PROMPT_FIELD: "ground_truth"},
+    )
+
+
+def test_sam3_image_visual_points():
+    models = ["segment-anything-3-image-torch"]
+    _apply_models(
+        models,
+        max_samples=3,
+        model_kwargs=dict(operation_mode="visual"),
+        apply_kwargs={_SAM_PROMPT_FIELD: "ground_truth"},
+        prompt_type="keypoints",
+    )
+
+
+def test_sam3_video_concept():
+    _apply_video_models(
+        ["segment-anything-3-video-torch"],
+        max_samples=2,
+        max_frames=5,
+        model_kwargs=dict(classes=["person"], operation_mode="concept"),
+    )
+
+
+def test_sam3_video_concept_multi_prompt():
+    _apply_video_models(
+        ["segment-anything-3-video-torch"],
+        max_samples=2,
+        max_frames=5,
+        model_kwargs=dict(classes=["person", "car"], operation_mode="concept"),
+    )
+
+
+def test_sam3_video_visual_boxes():
+    _apply_video_models(
+        ["segment-anything-3-video-torch"],
+        max_samples=2,
+        max_frames=5,
+        model_kwargs=dict(operation_mode="visual"),
+        apply_kwargs={_SAM_PROMPT_FIELD: "frames.detections"},
+    )
+
+
+def test_sam3_video_visual_points():
+    _apply_video_models(
+        ["segment-anything-3-video-torch"],
+        max_samples=2,
+        max_frames=5,
+        model_kwargs=dict(operation_mode="visual", prompt_frame_indices=[1]),
+        apply_kwargs={_SAM_PROMPT_FIELD: "frames.detections"},
+        prompt_type="keypoints",
+    )
+
+
 def test_keypoint_models():
     models = _get_models_with_tag("keypoints")
     _apply_person_keypoint_models(models)
@@ -247,6 +325,7 @@ def _apply_video_models(
     pass_confidence_thresh=False,
     max_samples=10,
     max_frames=10,
+    prompt_type=None,
     model_kwargs=None,
     apply_kwargs=None,
 ):
@@ -266,9 +345,21 @@ def _apply_video_models(
     dataset.match_frames(F("frame_number") <= max_frames).keep_frames()
 
     if _SAM_PROMPT_FIELD in kwargs:
-        dataset.match_frames(F("frame_number") > 1).set_field(
-            kwargs[_SAM_PROMPT_FIELD], None
-        ).save()
+        if prompt_type == "keypoints":
+            frame_field = kwargs[_SAM_PROMPT_FIELD][len("frames.") :]
+            kp_field = frame_field + "_points"
+            for sample in dataset:
+                first_frame = sample.frames.get(1)
+                if first_frame is not None and first_frame[frame_field]:
+                    first_frame[kp_field] = _detections_to_keypoints(
+                        first_frame[frame_field].detections
+                    )
+                    sample.save()
+            kwargs[_SAM_PROMPT_FIELD] = f"frames.{kp_field}"
+        else:
+            dataset.match_frames(F("frame_number") > 1).set_field(
+                kwargs[_SAM_PROMPT_FIELD], None
+            ).save()
 
     for idx, model_name in enumerate(model_names, 1):
         print(

--- a/tests/intensive/model_zoo_tests.py
+++ b/tests/intensive/model_zoo_tests.py
@@ -19,6 +19,7 @@ from fiftyone import ViewField as F
 
 
 _SAM_PROMPT_FIELD = "prompt_field"
+_APP_PORT = 5151
 
 
 def test_all_models():
@@ -161,7 +162,7 @@ def test_sam3_video_concept():
         ["segment-anything-3-video-torch"],
         max_samples=2,
         max_frames=5,
-        model_kwargs=dict(classes=["person"], operation_mode="concept"),
+        model_kwargs=dict(classes=["car"], operation_mode="concept"),
     )
 
 
@@ -314,7 +315,7 @@ def _apply_models(
             model, label_field=label_field, batch_size=batch_size, **kwargs
         )
 
-    session = fo.launch_app(dataset)
+    session = fo.launch_app(dataset, port=_APP_PORT)
     session.wait()
 
 
@@ -349,7 +350,9 @@ def _apply_video_models(
             frame_field = kwargs[_SAM_PROMPT_FIELD][len("frames.") :]
             kp_field = frame_field + "_points"
             for sample in dataset:
-                first_frame = sample.frames.get(1)
+                first_frame = None
+                if 1 in sample.frames:
+                    first_frame = sample.frames[1]
                 if first_frame is not None and first_frame[frame_field]:
                     first_frame[kp_field] = _detections_to_keypoints(
                         first_frame[frame_field].detections
@@ -380,7 +383,7 @@ def _apply_video_models(
                 assert last_frame[label_field] is not None
                 assert len(last_frame[label_field].detections) > 0
 
-    session = fo.launch_app(dataset)
+    session = fo.launch_app(dataset, port=_APP_PORT)
     session.wait()
 
 
@@ -497,7 +500,7 @@ def _apply_person_keypoint_models(model_names):
         label_field = model_name.lower().replace("-", "_").replace(".", "_")
         person_samples.apply_model(model, label_field=label_field)
 
-    session = fo.launch_app(view=person_samples)
+    session = fo.launch_app(view=person_samples, port=_APP_PORT)
     session.wait()
 
 

--- a/tests/intensive/sam_parity_tests.py
+++ b/tests/intensive/sam_parity_tests.py
@@ -1431,7 +1431,12 @@ class TestSAM3ConceptParity(unittest.TestCase):
         from sam3.model.sam3_image_processor import Sam3Processor
 
         bpe_path = cls.fo_model.config.entrypoint_args.get("bpe_path")
-        cls.sam3_model = build_sam3_image_model(bpe_path=bpe_path)
+        checkpoint_path = cls.fo_model.config.entrypoint_args.get(
+            "checkpoint_path"
+        )
+        cls.sam3_model = build_sam3_image_model(
+            bpe_path=bpe_path, checkpoint_path=checkpoint_path
+        )
         cls.processor = Sam3Processor(cls.sam3_model)
 
         cls.device = "cuda" if torch.cuda.is_available() else "cpu"
@@ -1547,9 +1552,13 @@ class TestSAM3VisualParity(unittest.TestCase):
         from sam3.model_builder import build_sam3_image_model
 
         bpe_path = cls.fo_model.config.entrypoint_args.get("bpe_path")
+        checkpoint_path = cls.fo_model.config.entrypoint_args.get(
+            "checkpoint_path"
+        )
         sam3_model = build_sam3_image_model(
             enable_inst_interactivity=True,
             bpe_path=bpe_path,
+            checkpoint_path=checkpoint_path,
         )
         tracker_model = sam3_model.inst_interactive_predictor.model
         if getattr(tracker_model, "backbone", None) is None:
@@ -1817,8 +1826,14 @@ class TestSAM3VideoConceptParity(unittest.TestCase):
             if cls.fo_model._device.index is not None
             else 0
         )
+        checkpoint_path = cls.fo_model.config.entrypoint_args.get(
+            "checkpoint_path"
+        )
+        bpe_path = cls.fo_model.config.entrypoint_args.get("bpe_path")
         cls.direct_predictor = build_sam3_video_predictor(
-            gpus_to_use=[device_idx]
+            gpus_to_use=[device_idx],
+            checkpoint_path=checkpoint_path,
+            bpe_path=bpe_path,
         )
         cls.dataset = _create_video_dataset(num_samples=2, seed=31)
 
@@ -1977,7 +1992,13 @@ class TestSAM3VideoVisualParity(unittest.TestCase):
             prompt_frame_indices=[1],
         )
 
-        sam3_model = build_sam3_video_model()
+        checkpoint_path = cls.fo_model.config.entrypoint_args.get(
+            "checkpoint_path"
+        )
+        bpe_path = cls.fo_model.config.entrypoint_args.get("bpe_path")
+        sam3_model = build_sam3_video_model(
+            checkpoint_path=checkpoint_path, bpe_path=bpe_path
+        )
         cls.direct_predictor = sam3_model.tracker
         cls.direct_predictor.backbone = sam3_model.detector.backbone
 

--- a/tests/intensive/sam_parity_tests.py
+++ b/tests/intensive/sam_parity_tests.py
@@ -185,7 +185,7 @@ def _assert_video_parity(test_case, dataset, pred_field, gt_field, eval_key):
         eval_key=eval_key,
         iou=MASK_IOU,
         use_masks=True,
-        classwise=False,
+        classwise=True,
     )
     metrics = results.metrics()
     for metric_name in ("accuracy", "precision", "recall", "fscore"):
@@ -1984,6 +1984,11 @@ class TestSAM3VideoVisualParity(unittest.TestCase):
         cls.ctx = fosam3._load_video_frames_monkey_patch_sam3()
         cls.dataset = _create_video_dataset(num_samples=2, seed=21)
 
+        # Shared frame anchors for directional tests.
+        # Use per-sample minimums so prompt_frame_indices is valid for all samples.
+        cls.last_frame_1based = min(len(s.frames) for s in cls.dataset)
+        cls.mid_frame_1based = max(1, cls.last_frame_1based // 2)
+
     @classmethod
     def tearDownClass(cls):
         del cls.fo_model
@@ -2188,6 +2193,202 @@ class TestSAM3VideoVisualParity(unittest.TestCase):
             fo_field,
             direct_field,
             eval_key="eval_sam3v_vis_box",
+        )
+
+    def _run_direct_visual_boxes_for_direction(
+        self, sample, propagation_direction, prompt_frame_0based
+    ):
+        """Run visual_predictor directly with box prompts from ``prompt_frame_0based``
+        using the specified propagation direction, mirroring FO's _propagate_visual."""
+        w = sample.metadata.frame_width
+        h = sample.metadata.frame_height
+
+        with etav.FFmpegVideoReader(sample.filepath) as video_reader:
+            with self.ctx:
+                inference_state = self.direct_predictor.init_state(
+                    video_path=(sample, video_reader)
+                )
+
+        classes_obj_id_map = {}
+        current_obj_idx = 0
+
+        frame_dets = sample.frames[prompt_frame_0based + 1].get_field(
+            "detections"
+        )
+        if frame_dets is not None:
+            for detection in frame_dets.detections:
+                ann_obj_id = current_obj_idx
+                current_obj_idx += 1
+                classes_obj_id_map[ann_obj_id] = detection.label
+                rx, ry, rw, rh = detection.bounding_box
+                box = np.array([rx, ry, rx + rw, ry + rh], dtype=np.float32)
+                self.direct_predictor.add_new_points_or_box(
+                    inference_state=inference_state,
+                    frame_idx=prompt_frame_0based,
+                    obj_id=ann_obj_id,
+                    box=box,
+                )
+
+        def _collect(reverse, preflight):
+            result = {}
+            for (
+                out_frame_idx,
+                out_obj_ids,
+                _low_res_masks,
+                out_mask_logits,
+                _obj_scores,
+            ) in self.direct_predictor.propagate_in_video(
+                inference_state,
+                start_frame_idx=None,
+                max_frame_num_to_track=None,
+                reverse=reverse,
+                propagate_preflight=preflight,
+            ):
+                detections = []
+                for i, out_obj_id in enumerate(out_obj_ids):
+                    mask = np.squeeze(
+                        (out_mask_logits[i] > 0.0).cpu().numpy(), axis=0
+                    )
+                    b = fosam._mask_to_box(mask)
+                    if b is None:
+                        continue
+                    label = classes_obj_id_map.get(out_obj_id, "object")
+                    x1, y1, x2, y2 = b
+                    bounding_box = [
+                        x1 / w,
+                        y1 / h,
+                        (x2 - x1) / w,
+                        (y2 - y1) / h,
+                    ]
+                    cropped_mask = mask[
+                        int(round(y1)) : int(round(y2)),
+                        int(round(x1)) : int(round(x2)),
+                    ]
+                    detections.append(
+                        Detection(
+                            label=label,
+                            bounding_box=bounding_box,
+                            mask=cropped_mask,
+                            index=out_obj_id,
+                        )
+                    )
+                result[int(out_frame_idx) + 1] = Detections(
+                    detections=detections
+                )
+            return result
+
+        if propagation_direction == "forward":
+            return _collect(reverse=False, preflight=True)
+        elif propagation_direction == "backward":
+            return _collect(reverse=True, preflight=True)
+        else:  # "both"
+            forward = _collect(reverse=False, preflight=True)
+            backward = _collect(reverse=True, preflight=False)
+            merged = dict(forward)
+            for frame_num, dets in backward.items():
+                if frame_num not in merged or not merged[frame_num].detections:
+                    merged[frame_num] = dets
+            return merged
+
+    def test_visual_box_explicit_forward_parity(self):
+        """direction='forward' from frame 1 matches direct reverse=False propagation."""
+        fo_model_fwd = foz.load_zoo_model(
+            SAM3_VIDEO_MODEL_NAME,
+            operation_mode="visual",
+            prompt_frame_indices=[1],
+            propagation_direction="forward",
+        )
+        fo_field = "sam3v_vis_box_fwd_fo"
+        direct_field = "sam3v_vis_box_fwd_direct"
+
+        self.dataset.apply_model(
+            fo_model_fwd,
+            label_field=fo_field,
+            prompt_field="frames.detections",
+        )
+
+        for sample in self.dataset.iter_samples(progress=False, autosave=True):
+            direct_result = self._run_direct_visual_boxes_for_direction(
+                sample, "forward", prompt_frame_0based=0
+            )
+            for frame_number, dets in direct_result.items():
+                if frame_number in sample.frames:
+                    sample.frames[frame_number][direct_field] = dets
+
+        _assert_video_parity(
+            self,
+            self.dataset,
+            fo_field,
+            direct_field,
+            eval_key="eval_sam3v_vis_fwd",
+        )
+
+    def test_visual_box_backward_parity(self):
+        """direction='backward' from the last frame matches direct reverse=True."""
+        fo_model_bwd = foz.load_zoo_model(
+            SAM3_VIDEO_MODEL_NAME,
+            operation_mode="visual",
+            prompt_frame_indices=[self.last_frame_1based],
+            propagation_direction="backward",
+        )
+        fo_field = "sam3v_vis_box_bwd_fo"
+        direct_field = "sam3v_vis_box_bwd_direct"
+
+        self.dataset.apply_model(
+            fo_model_bwd,
+            label_field=fo_field,
+            prompt_field="frames.detections",
+        )
+
+        for sample in self.dataset.iter_samples(progress=False, autosave=True):
+            direct_result = self._run_direct_visual_boxes_for_direction(
+                sample,
+                "backward",
+                prompt_frame_0based=self.last_frame_1based - 1,
+            )
+            for frame_number, dets in direct_result.items():
+                if frame_number in sample.frames:
+                    sample.frames[frame_number][direct_field] = dets
+
+        _assert_video_parity(
+            self,
+            self.dataset,
+            fo_field,
+            direct_field,
+            eval_key="eval_sam3v_vis_bwd",
+        )
+
+    def test_visual_box_both_parity(self):
+        """direction='both' from a mid-video frame matches direct forward+backward merge."""
+        fo_model_both = foz.load_zoo_model(
+            SAM3_VIDEO_MODEL_NAME,
+            operation_mode="visual",
+            prompt_frame_indices=[self.mid_frame_1based],
+            propagation_direction="both",
+        )
+        fo_field = "sam3v_vis_box_both_fo"
+        direct_field = "sam3v_vis_box_both_direct"
+
+        self.dataset.apply_model(
+            fo_model_both,
+            label_field=fo_field,
+            prompt_field="frames.detections",
+        )
+
+        for sample in self.dataset.iter_samples(progress=False, autosave=True):
+            direct_result = self._run_direct_visual_boxes_for_direction(
+                sample, "both", prompt_frame_0based=self.mid_frame_1based - 1
+            )
+            for frame_number, dets in direct_result.items():
+                if frame_number in sample.frames:
+                    sample.frames[frame_number][direct_field] = dets
+
+        _assert_video_parity(
+            self,
+            self.dataset,
+            fo_field,
+            direct_field,
+            eval_key="eval_sam3v_vis_both",
         )
 
     def test_visual_keypoint_parity(self):

--- a/tests/intensive/sam_parity_tests.py
+++ b/tests/intensive/sam_parity_tests.py
@@ -12,15 +12,21 @@ Usage:
     pytest sam_parity_tests.py -v --timeout=500
 """
 
+import gc
+
 import cv2
 import numpy as np
 import torch
 import unittest
 
+import eta.core.video as etav
+
 import fiftyone as fo
 import fiftyone.zoo as foz
 from fiftyone.core.labels import Detection, Detections, Keypoint, Keypoints
 from fiftyone import ViewField as F
+import fiftyone.utils.sam as fosam
+import fiftyone.utils.sam3 as fosam3
 
 MASK_IOU = 0.95  # change for more/less aggressive mask parity testing
 MASK_THRESH = 0.5
@@ -28,7 +34,8 @@ PLACEHOLDER_LABEL = "mask"
 MIN_METRIC = 1.0
 
 # Default text prompts for concept-mode tests
-TEXT_PROMPTS = ["person"]
+TEXT_PROMPTS = ["car"]
+SAM3_VIDEO_MODEL_NAME = "segment-anything-3-video-torch"
 
 
 def _create_test_dataset(num_samples=5, seed=51):
@@ -40,6 +47,20 @@ def _create_test_dataset(num_samples=5, seed=51):
         max_samples=num_samples,
         shuffle=True,
         seed=seed,
+        dataset_name=name,
+    )
+    dataset.persistent = True
+    dataset.compute_metadata()
+    return dataset
+
+
+def _create_video_dataset(num_samples=2, seed=51):
+    name = f"sam3-video-test-{seed}"
+    if name in fo.list_datasets():
+        fo.delete_dataset(name)
+    dataset = foz.load_zoo_dataset(
+        "quickstart-video",
+        max_samples=num_samples,
         dataset_name=name,
     )
     dataset.persistent = True
@@ -151,6 +172,25 @@ def _assert_parity(
         MIN_METRIC,
         f"[{eval_key}] Fscore {metrics['fscore']:.4f} < {MIN_METRIC}",
     )
+
+
+def _assert_video_parity(test_case, dataset, pred_field, gt_field, eval_key):
+    """Run frame-level evaluate_detections and assert near-perfect agreement."""
+    results = dataset.evaluate_detections(
+        f"frames.{pred_field}",
+        gt_field=f"frames.{gt_field}",
+        eval_key=eval_key,
+        iou=MASK_IOU,
+        use_masks=True,
+        classwise=False,
+    )
+    metrics = results.metrics()
+    for metric_name in ("accuracy", "precision", "recall", "fscore"):
+        test_case.assertGreaterEqual(
+            metrics[metric_name],
+            MIN_METRIC,
+            f"[{eval_key}] {metric_name} {metrics[metric_name]:.4f} < {MIN_METRIC}",
+        )
 
 
 class TestSAMParity(unittest.TestCase):
@@ -1697,6 +1737,445 @@ class TestSAM3VisualParity(unittest.TestCase):
             fo_field,
             direct_field,
             eval_key="eval_sam3_combo",
+        )
+
+
+class TestSAM3VideoConceptParity(unittest.TestCase):
+    """Compare FiftyOne SAM3 video concept-mode output against direct
+    concept_predictor (handle_request) inference."""
+
+    @classmethod
+    def setUpClass(cls):
+        from sam3.model_builder import build_sam3_video_predictor
+
+        cls.fo_model = foz.load_zoo_model(
+            SAM3_VIDEO_MODEL_NAME,
+            classes=TEXT_PROMPTS,
+            operation_mode="concept",
+        )
+
+        device_idx = (
+            cls.fo_model._device.index
+            if cls.fo_model._device.index is not None
+            else 0
+        )
+        cls.direct_predictor = build_sam3_video_predictor(
+            gpus_to_use=[device_idx]
+        )
+        cls.dataset = _create_video_dataset(num_samples=2, seed=31)
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.fo_model
+        del cls.direct_predictor
+        gc.collect()
+        torch.cuda.empty_cache()
+
+    def tearDown(self):
+        gc.collect()
+        torch.cuda.empty_cache()
+
+    def _run_direct_concept(self, sample, text_prompts, text_frame_idx=0):
+        """Run concept_predictor directly and return {frame_number: Detections}.
+
+        Mirrors FO's per-prompt propagation: each add_prompt resets model
+        state, so we run one propagation pass per prompt and accumulate."""
+        video_path = sample.filepath
+        w = sample.metadata.frame_width
+        h = sample.metadata.frame_height
+
+        response = self.direct_predictor.handle_request(
+            request=dict(type="start_session", resource_path=video_path)
+        )
+        session_id = response["session_id"]
+
+        result = {
+            i + 1: Detections(detections=[]) for i in range(len(sample.frames))
+        }
+
+        try:
+            for text_prompt in text_prompts:
+                prompt_response = self.direct_predictor.handle_request(
+                    request=dict(
+                        type="add_prompt",
+                        session_id=session_id,
+                        frame_index=text_frame_idx,
+                        text=text_prompt,
+                    )
+                )
+                outputs = prompt_response.get("outputs", prompt_response)
+                label_map = {
+                    oid: text_prompt for oid in outputs.get("out_obj_ids", [])
+                }
+
+                for (
+                    frame_result
+                ) in self.direct_predictor.handle_stream_request(
+                    request=dict(
+                        type="propagate_in_video",
+                        session_id=session_id,
+                        propagation_direction="forward",
+                    )
+                ):
+                    out_frame_idx = frame_result.get("frame_index", 0)
+                    out = frame_result.get("outputs", frame_result)
+
+                    out_obj_ids = out.get("out_obj_ids", [])
+                    out_probs = out.get("out_probs")
+                    out_boxes = out.get("out_boxes_xywh")
+                    out_masks = out.get("out_binary_masks")
+
+                    if out_masks is None or len(out_obj_ids) == 0:
+                        continue
+
+                    if isinstance(out_masks, torch.Tensor):
+                        out_masks = out_masks.cpu().numpy()
+                    if isinstance(out_probs, torch.Tensor):
+                        out_probs = out_probs.cpu().numpy()
+                    if isinstance(out_boxes, torch.Tensor):
+                        out_boxes = out_boxes.cpu().numpy()
+
+                    new_dets = fosam3._sam3_output_to_detections(
+                        out_binary_masks=out_masks,
+                        out_boxes_xywh=out_boxes,
+                        out_obj_ids=out_obj_ids,
+                        out_probs=out_probs,
+                        frame_width=w,
+                        frame_height=h,
+                        label_map=label_map,
+                        default_label=text_prompt,
+                    )
+                    frame_num = int(out_frame_idx) + 1
+                    existing = result.get(frame_num, Detections(detections=[]))
+                    result[frame_num] = Detections(
+                        detections=existing.detections + new_dets
+                    )
+
+        finally:
+            self.direct_predictor.handle_request(
+                request=dict(type="close_session", session_id=session_id)
+            )
+
+        return result
+
+    def test_concept_single_prompt_parity(self):
+        """FO apply_model concept output matches direct concept predictor (single text prompt)."""
+        fo_field = "sam3v_concept_fo"
+        direct_field = "sam3v_concept_direct"
+
+        self.dataset.apply_model(self.fo_model, label_field=fo_field)
+
+        for sample in self.dataset.iter_samples(progress=False, autosave=True):
+            direct_result = self._run_direct_concept(sample, TEXT_PROMPTS)
+            for frame_number, dets in direct_result.items():
+                sample.frames[frame_number][direct_field] = dets
+
+        _assert_video_parity(
+            self,
+            self.dataset,
+            fo_field,
+            direct_field,
+            eval_key="eval_sam3v_concept",
+        )
+
+    def test_concept_multi_prompt_parity(self):
+        """Multiple text prompts: FO output matches direct concept predictor."""
+        multi_prompts = ["person", "car"]
+        fo_model_multi = foz.load_zoo_model(
+            SAM3_VIDEO_MODEL_NAME,
+            classes=multi_prompts,
+            operation_mode="concept",
+        )
+
+        fo_field = "sam3v_concept_multi_fo"
+        direct_field = "sam3v_concept_multi_direct"
+
+        self.dataset.apply_model(fo_model_multi, label_field=fo_field)
+
+        for sample in self.dataset.iter_samples(progress=False, autosave=True):
+            direct_result = self._run_direct_concept(sample, multi_prompts)
+            for frame_number, dets in direct_result.items():
+                sample.frames[frame_number][direct_field] = dets
+
+        _assert_video_parity(
+            self,
+            self.dataset,
+            fo_field,
+            direct_field,
+            eval_key="eval_sam3v_concept_multi",
+        )
+
+
+class TestSAM3VideoVisualParity(unittest.TestCase):
+    """Compare FiftyOne SAM3 video visual-mode output against direct
+    visual_predictor (tracker) inference."""
+
+    @classmethod
+    def setUpClass(cls):
+        from sam3.model_builder import build_sam3_video_model
+
+        cls.fo_model = foz.load_zoo_model(
+            SAM3_VIDEO_MODEL_NAME,
+            operation_mode="visual",
+            prompt_frame_indices=[1],
+        )
+
+        sam3_model = build_sam3_video_model()
+        cls.direct_predictor = sam3_model.tracker
+        cls.direct_predictor.backbone = sam3_model.detector.backbone
+
+        cls.ctx = fosam3._load_video_frames_monkey_patch_sam3()
+        cls.dataset = _create_video_dataset(num_samples=2, seed=21)
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.fo_model
+        del cls.direct_predictor
+        gc.collect()
+        torch.cuda.empty_cache()
+
+    def tearDown(self):
+        gc.collect()
+        torch.cuda.empty_cache()
+
+    def _run_direct_visual_boxes(self, sample):
+        """Run visual_predictor directly with box prompts from frames.detections."""
+        w = sample.metadata.frame_width
+        h = sample.metadata.frame_height
+
+        with etav.FFmpegVideoReader(sample.filepath) as video_reader:
+            with self.ctx:
+                inference_state = self.direct_predictor.init_state(
+                    video_path=(sample, video_reader)
+                )
+
+        classes_obj_id_map = {}
+        current_obj_idx = 0
+
+        first_frame = next(iter(sample.frames.values()))
+        dets = first_frame.get_field("detections")
+        if dets is not None:
+            for detection in dets.detections:
+                ann_obj_id = current_obj_idx
+                current_obj_idx += 1
+                classes_obj_id_map[ann_obj_id] = detection.label
+
+                rx, ry, rw, rh = detection.bounding_box
+                box = np.array([rx, ry, rx + rw, ry + rh], dtype=np.float32)
+
+                self.direct_predictor.add_new_points_or_box(
+                    inference_state=inference_state,
+                    frame_idx=0,
+                    obj_id=ann_obj_id,
+                    box=box,
+                )
+
+        result = {}
+
+        for (
+            out_frame_idx,
+            out_obj_ids,
+            _low_res_masks,
+            out_mask_logits,
+            _obj_scores,
+        ) in self.direct_predictor.propagate_in_video(
+            inference_state,
+            start_frame_idx=None,
+            max_frame_num_to_track=None,
+            reverse=False,
+            propagate_preflight=True,
+        ):
+            detections = []
+            for i, out_obj_id in enumerate(out_obj_ids):
+                mask = np.squeeze(
+                    (out_mask_logits[i] > 0.0).cpu().numpy(), axis=0
+                )
+                box = fosam._mask_to_box(mask)
+                if box is None:
+                    continue
+
+                label = classes_obj_id_map.get(out_obj_id, "object")
+                x1, y1, x2, y2 = box
+                bounding_box = [
+                    x1 / w,
+                    y1 / h,
+                    (x2 - x1) / w,
+                    (y2 - y1) / h,
+                ]
+                cropped_mask = mask[
+                    int(round(y1)) : int(round(y2)),
+                    int(round(x1)) : int(round(x2)),
+                ]
+                detections.append(
+                    Detection(
+                        label=label,
+                        bounding_box=bounding_box,
+                        mask=cropped_mask,
+                        index=out_obj_id,
+                    )
+                )
+
+            result[int(out_frame_idx) + 1] = Detections(detections=detections)
+
+        return result
+
+    def _run_direct_visual_points(self, sample, kp_field):
+        """Run visual_predictor directly with point prompts from a Keypoints frame field."""
+        w = sample.metadata.frame_width
+        h = sample.metadata.frame_height
+
+        with etav.FFmpegVideoReader(sample.filepath) as video_reader:
+            with self.ctx:
+                inference_state = self.direct_predictor.init_state(
+                    video_path=(sample, video_reader)
+                )
+
+        classes_obj_id_map = {}
+        current_obj_idx = 0
+
+        for frame_idx, (_, frame) in enumerate(sample.frames.items()):
+            kps = frame.get_field(kp_field)
+            if kps is None or not kps.keypoints:
+                continue
+
+            for keypoint in kps.keypoints:
+                ann_obj_id = current_obj_idx
+                current_obj_idx += 1
+                classes_obj_id_map[ann_obj_id] = keypoint.label
+
+                points, labels = fosam._to_sam_points(
+                    keypoint.points,
+                    width=1,
+                    height=1,
+                    point_labels=fosam._get_sam_point_labels(keypoint),
+                )
+
+                self.direct_predictor.add_new_points_or_box(
+                    inference_state=inference_state,
+                    frame_idx=frame_idx,
+                    obj_id=ann_obj_id,
+                    points=points,
+                    labels=labels,
+                )
+
+        result = {}
+
+        for (
+            out_frame_idx,
+            out_obj_ids,
+            _low_res_masks,
+            out_mask_logits,
+            _obj_scores,
+        ) in self.direct_predictor.propagate_in_video(
+            inference_state,
+            start_frame_idx=None,
+            max_frame_num_to_track=None,
+            reverse=False,
+            propagate_preflight=True,
+        ):
+            detections = []
+            for i, out_obj_id in enumerate(out_obj_ids):
+                mask = np.squeeze(
+                    (out_mask_logits[i] > 0.0).cpu().numpy(), axis=0
+                )
+                box = fosam._mask_to_box(mask)
+                if box is None:
+                    continue
+
+                label = classes_obj_id_map.get(out_obj_id, "object")
+                x1, y1, x2, y2 = box
+                bounding_box = [
+                    x1 / w,
+                    y1 / h,
+                    (x2 - x1) / w,
+                    (y2 - y1) / h,
+                ]
+                cropped_mask = mask[
+                    int(round(y1)) : int(round(y2)),
+                    int(round(x1)) : int(round(x2)),
+                ]
+                detections.append(
+                    Detection(
+                        label=label,
+                        bounding_box=bounding_box,
+                        mask=cropped_mask,
+                        index=out_obj_id,
+                    )
+                )
+
+            result[int(out_frame_idx) + 1] = Detections(detections=detections)
+
+        del inference_state
+        return result
+
+    def test_visual_box_parity(self):
+        """FO apply_model visual-box output matches direct visual predictor."""
+        fo_field = "sam3v_vis_box_fo"
+        direct_field = "sam3v_vis_box_direct"
+
+        self.dataset.apply_model(
+            self.fo_model,
+            label_field=fo_field,
+            prompt_field="frames.detections",
+        )
+
+        for sample in self.dataset.iter_samples(progress=False, autosave=True):
+            direct_result = self._run_direct_visual_boxes(sample)
+            for frame_number, dets in direct_result.items():
+                if frame_number in sample.frames:
+                    sample.frames[frame_number][direct_field] = dets
+
+        _assert_video_parity(
+            self,
+            self.dataset,
+            fo_field,
+            direct_field,
+            eval_key="eval_sam3v_vis_box",
+        )
+
+    def test_visual_keypoint_parity(self):
+        """FO apply_model visual-keypoint output matches direct visual predictor."""
+        kp_field = "sam3v_vis_kps"
+        fo_field = "sam3v_vis_kp_fo"
+        direct_field = "sam3v_vis_kp_direct"
+
+        for sample in self.dataset.iter_samples(progress=False, autosave=True):
+            first_frame = next(iter(sample.frames.values()))
+            dets = first_frame.get_field("detections")
+            if dets is not None and dets.detections:
+                first_frame[kp_field] = Keypoints(
+                    keypoints=[
+                        Keypoint(
+                            label=d.label,
+                            points=[
+                                (
+                                    d.bounding_box[0] + d.bounding_box[2] / 2,
+                                    d.bounding_box[1] + d.bounding_box[3] / 2,
+                                )
+                            ],
+                        )
+                        for d in dets.detections
+                    ]
+                )
+
+        self.dataset.apply_model(
+            self.fo_model,
+            label_field=fo_field,
+            prompt_field=f"frames.{kp_field}",
+        )
+
+        for sample in self.dataset.iter_samples(progress=False, autosave=True):
+            direct_result = self._run_direct_visual_points(sample, kp_field)
+            for frame_number, dets in direct_result.items():
+                if frame_number in sample.frames:
+                    sample.frames[frame_number][direct_field] = dets
+
+        _assert_video_parity(
+            self,
+            self.dataset,
+            fo_field,
+            direct_field,
+            eval_key="eval_sam3v_vis_kp",
         )
 
 

--- a/tests/intensive/sam_parity_tests.py
+++ b/tests/intensive/sam_parity_tests.py
@@ -1797,6 +1797,7 @@ class TestSAM3VisualParity(unittest.TestCase):
         )
 
 
+@unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
 class TestSAM3VideoConceptParity(unittest.TestCase):
     """Compare FiftyOne SAM3 video concept-mode output against direct
     concept_predictor (handle_request) inference."""
@@ -1846,9 +1847,7 @@ class TestSAM3VideoConceptParity(unittest.TestCase):
         )
         session_id = response["session_id"]
 
-        result = {
-            i + 1: Detections(detections=[]) for i in range(len(sample.frames))
-        }
+        result = {fn: Detections(detections=[]) for fn in sample.frames.keys()}
 
         try:
             for text_prompt in text_prompts:
@@ -1963,6 +1962,7 @@ class TestSAM3VideoConceptParity(unittest.TestCase):
         )
 
 
+@unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
 class TestSAM3VideoVisualParity(unittest.TestCase):
     """Compare FiftyOne SAM3 video visual-mode output against direct
     visual_predictor (tracker) inference."""
@@ -1986,7 +1986,7 @@ class TestSAM3VideoVisualParity(unittest.TestCase):
 
         # Shared frame anchors for directional tests.
         # Use per-sample minimums so prompt_frame_indices is valid for all samples.
-        cls.last_frame_1based = min(len(s.frames) for s in cls.dataset)
+        cls.last_frame_1based = min(max(s.frames.keys()) for s in cls.dataset)
         cls.mid_frame_1based = max(1, cls.last_frame_1based // 2)
 
     @classmethod

--- a/tests/intensive/sam_parity_tests.py
+++ b/tests/intensive/sam_parity_tests.py
@@ -33,8 +33,9 @@ MASK_THRESH = 0.5
 PLACEHOLDER_LABEL = "mask"
 MIN_METRIC = 1.0
 
-# Default text prompts for concept-mode tests
-TEXT_PROMPTS = ["car"]
+TEXT_PROMPTS = ["person"]
+VID_TEXT_PROMPTS = ["car"]
+
 SAM3_VIDEO_MODEL_NAME = "segment-anything-3-video-torch"
 
 
@@ -61,6 +62,8 @@ def _create_video_dataset(num_samples=2, seed=51):
     dataset = foz.load_zoo_dataset(
         "quickstart-video",
         max_samples=num_samples,
+        shuffle=True,
+        seed=seed,
         dataset_name=name,
     )
     dataset.persistent = True
@@ -218,6 +221,14 @@ class TestSAMParity(unittest.TestCase):
         cls.dataset = _create_test_dataset(num_samples=4, seed=12)
         cls.output_processor = fo.utils.sam.SAMSegmenterOutputProcessor()
 
+    @classmethod
+    def tearDownClass(cls):
+        del cls.fo_model
+        del cls.predictor
+        del cls.auto_gen
+        gc.collect()
+        torch.cuda.empty_cache()
+
     def test_automatic_segmentation_parity(self):
         fo_field = "sam_auto_fo"
         direct_field = "sam_auto_direct"
@@ -230,7 +241,8 @@ class TestSAMParity(unittest.TestCase):
 
         for sample in self.dataset.iter_samples(progress=False, autosave=True):
             image = _get_image_as_numpy(sample.filepath)
-            masks = self.auto_gen.generate(image)
+            with torch.amp.autocast("cuda", enabled=False):
+                masks = self.auto_gen.generate(image)
             sample[direct_field] = _auto_masks_to_detections(masks)
 
         _assert_parity(
@@ -263,16 +275,17 @@ class TestSAMParity(unittest.TestCase):
             dims_hw = (h, w)
             box_prompts = []
             labels = []
-            for gt_det in gt.detections:
-                box_abs = _box_to_sam_abs(gt_det.bounding_box, w, h)
-                _masks, _scores, _ = self.predictor.predict(
-                    box=box_abs,
-                    multimask_output=False,
-                )
-                masks.append(_masks[None, ...])
-                scores.append(_scores[None, ...])
-                box_prompts.append(box_abs)
-                labels.append(gt_det.label)
+            with torch.amp.autocast("cuda", enabled=False):
+                for gt_det in gt.detections:
+                    box_abs = _box_to_sam_abs(gt_det.bounding_box, w, h)
+                    _masks, _scores, _ = self.predictor.predict(
+                        box=box_abs,
+                        multimask_output=False,
+                    )
+                    masks.append(_masks[None, ...])
+                    scores.append(_scores[None, ...])
+                    box_prompts.append(box_abs)
+                    labels.append(gt_det.label)
 
             outputs = {
                 "masks": torch.as_tensor(np.concatenate(masks, axis=0)),
@@ -329,23 +342,24 @@ class TestSAMParity(unittest.TestCase):
             scores = []
             dims_hw = (h, w)
             labels = []
-            for kp in kps_label.keypoints:
-                pts = np.array(kp.points)
-                valid = (pts[:, 0] > 0) & (pts[:, 1] > 0)
-                if not valid.any():
-                    continue
+            with torch.amp.autocast("cuda", enabled=False):
+                for kp in kps_label.keypoints:
+                    pts = np.array(kp.points)
+                    valid = (pts[:, 0] > 0) & (pts[:, 1] > 0)
+                    if not valid.any():
+                        continue
 
-                pts_abs = pts[valid] * np.array([w, h])
-                pts_labels = np.ones(len(pts_abs), dtype=np.int32)
+                    pts_abs = pts[valid] * np.array([w, h])
+                    pts_labels = np.ones(len(pts_abs), dtype=np.int32)
 
-                _masks, _scores, _ = self.predictor.predict(
-                    point_coords=pts_abs,
-                    point_labels=pts_labels,
-                    multimask_output=True,
-                )
-                masks.append(_masks[None, ...])
-                scores.append(_scores[None, ...])
-                labels.append(PLACEHOLDER_LABEL)
+                    _masks, _scores, _ = self.predictor.predict(
+                        point_coords=pts_abs,
+                        point_labels=pts_labels,
+                        multimask_output=True,
+                    )
+                    masks.append(_masks[None, ...])
+                    scores.append(_scores[None, ...])
+                    labels.append(PLACEHOLDER_LABEL)
 
             if not masks:
                 sample[direct_field] = Detections()
@@ -398,6 +412,14 @@ class TestSAM2Parity(unittest.TestCase):
         cls.device = device
         cls.dataset = _create_test_dataset(num_samples=4, seed=21)
         cls.output_processor = fo.utils.sam.SAMSegmenterOutputProcessor()
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.fo_model
+        del cls.predictor
+        del cls.auto_gen
+        gc.collect()
+        torch.cuda.empty_cache()
 
     def test_automatic_segmentation_parity(self):
         fo_field = "sam2_auto_fo"
@@ -736,6 +758,14 @@ class TestSAMInteractiveParity(unittest.TestCase):
         cls.dataset = _create_test_dataset(num_samples=2, seed=7)
         cls.output_processor = fo.utils.sam.SAMSegmenterOutputProcessor()
 
+    @classmethod
+    def tearDownClass(cls):
+        del cls.fo_model
+        del cls.predictor
+        del cls.auto_gen
+        gc.collect()
+        torch.cuda.empty_cache()
+
     def test_interactive_auto_parity(self):
         interactive_field = "sam_inter_auto"
         direct_field = "sam_direct_auto"
@@ -748,7 +778,8 @@ class TestSAMInteractiveParity(unittest.TestCase):
 
             # Direct SAM auto
             image = _get_image_as_numpy(sample.filepath)
-            masks = self.auto_gen.generate(image)
+            with torch.amp.autocast("cuda", enabled=False):
+                masks = self.auto_gen.generate(image)
             sample[direct_field] = _auto_masks_to_detections(masks)
 
         self.dataset.set_field(
@@ -793,16 +824,17 @@ class TestSAMInteractiveParity(unittest.TestCase):
             scores = []
             box_prompts = []
             labels = []
-            for gt_det in gt.detections:
-                box_abs = _box_to_sam_abs(gt_det.bounding_box, w, h)
-                _masks, _scores, _ = self.predictor.predict(
-                    box=box_abs,
-                    multimask_output=False,
-                )
-                masks.append(_masks[None, ...])
-                scores.append(_scores[None, ...])
-                box_prompts.append(box_abs)
-                labels.append(gt_det.label)
+            with torch.amp.autocast("cuda", enabled=False):
+                for gt_det in gt.detections:
+                    box_abs = _box_to_sam_abs(gt_det.bounding_box, w, h)
+                    _masks, _scores, _ = self.predictor.predict(
+                        box=box_abs,
+                        multimask_output=False,
+                    )
+                    masks.append(_masks[None, ...])
+                    scores.append(_scores[None, ...])
+                    box_prompts.append(box_abs)
+                    labels.append(gt_det.label)
 
             outputs = {
                 "masks": torch.as_tensor(np.concatenate(masks, axis=0)),
@@ -866,23 +898,24 @@ class TestSAMInteractiveParity(unittest.TestCase):
             masks = []
             scores = []
             labels = []
-            for kp in kps_label.keypoints:
-                pts = np.array(kp.points)
-                valid = (pts[:, 0] > 0) & (pts[:, 1] > 0)
-                if not valid.any():
-                    continue
+            with torch.amp.autocast("cuda", enabled=False):
+                for kp in kps_label.keypoints:
+                    pts = np.array(kp.points)
+                    valid = (pts[:, 0] > 0) & (pts[:, 1] > 0)
+                    if not valid.any():
+                        continue
 
-                pts_abs = pts[valid] * np.array([w, h])
-                pts_labels = np.ones(len(pts_abs), dtype=np.int32)
+                    pts_abs = pts[valid] * np.array([w, h])
+                    pts_labels = np.ones(len(pts_abs), dtype=np.int32)
 
-                _masks, _scores, _ = self.predictor.predict(
-                    point_coords=pts_abs,
-                    point_labels=pts_labels,
-                    multimask_output=True,
-                )
-                masks.append(_masks[None, ...])
-                scores.append(_scores[None, ...])
-                labels.append(PLACEHOLDER_LABEL)
+                    _masks, _scores, _ = self.predictor.predict(
+                        point_coords=pts_abs,
+                        point_labels=pts_labels,
+                        multimask_output=True,
+                    )
+                    masks.append(_masks[None, ...])
+                    scores.append(_scores[None, ...])
+                    labels.append(PLACEHOLDER_LABEL)
 
             outputs = {
                 "masks": torch.as_tensor(np.concatenate(masks, axis=0)),
@@ -970,28 +1003,29 @@ class TestSAMInteractiveParity(unittest.TestCase):
             scores = []
             box_prompts = []
             labels = []
-            for i, gt_det in enumerate(gt.detections):
-                box_abs = _box_to_sam_abs(gt_det.bounding_box, w, h)
+            with torch.amp.autocast("cuda", enabled=False):
+                for i, gt_det in enumerate(gt.detections):
+                    box_abs = _box_to_sam_abs(gt_det.bounding_box, w, h)
 
-                point_coords = None
-                point_labels_arr = None
-                if combo_kps is not None and i < len(combo_kps.keypoints):
-                    pts = combo_kps.keypoints[i].points
-                    if pts:
-                        px, py = pts[0]
-                        point_coords = np.array([[px * w, py * h]])
-                        point_labels_arr = np.array([1])
+                    point_coords = None
+                    point_labels_arr = None
+                    if combo_kps is not None and i < len(combo_kps.keypoints):
+                        pts = combo_kps.keypoints[i].points
+                        if pts:
+                            px, py = pts[0]
+                            point_coords = np.array([[px * w, py * h]])
+                            point_labels_arr = np.array([1])
 
-                _masks, _scores, _ = self.predictor.predict(
-                    point_coords=point_coords,
-                    point_labels=point_labels_arr,
-                    box=box_abs,
-                    multimask_output=False,
-                )
-                masks.append(_masks[None, ...])
-                scores.append(_scores[None, ...])
-                box_prompts.append(box_abs)
-                labels.append(gt_det.label)
+                    _masks, _scores, _ = self.predictor.predict(
+                        point_coords=point_coords,
+                        point_labels=point_labels_arr,
+                        box=box_abs,
+                        multimask_output=False,
+                    )
+                    masks.append(_masks[None, ...])
+                    scores.append(_scores[None, ...])
+                    box_prompts.append(box_abs)
+                    labels.append(gt_det.label)
 
             outputs = {
                 "masks": torch.as_tensor(np.concatenate(masks, axis=0)),
@@ -1040,6 +1074,14 @@ class TestSAM2InteractiveParity(unittest.TestCase):
         cls.device = device
         cls.dataset = _create_test_dataset(num_samples=2, seed=7)
         cls.output_processor = fo.utils.sam.SAMSegmenterOutputProcessor()
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.fo_model
+        del cls.predictor
+        del cls.auto_gen
+        gc.collect()
+        torch.cuda.empty_cache()
 
     def test_interactive_auto_parity(self):
         interactive_field = "sam2_inter_auto"
@@ -1395,6 +1437,14 @@ class TestSAM3ConceptParity(unittest.TestCase):
         cls.device = "cuda" if torch.cuda.is_available() else "cpu"
         cls.dataset = _create_test_dataset(num_samples=4, seed=31)
 
+    @classmethod
+    def tearDownClass(cls):
+        del cls.fo_model
+        del cls.sam3_model
+        del cls.processor
+        gc.collect()
+        torch.cuda.empty_cache()
+
     def test_concept_text_prompt_parity(self):
         fo_field = "sam3_concept_fo"
         direct_field = "sam3_concept_direct"
@@ -1509,6 +1559,13 @@ class TestSAM3VisualParity(unittest.TestCase):
         cls.device = "cuda" if torch.cuda.is_available() else "cpu"
         cls.dataset = _create_test_dataset(num_samples=4, seed=21)
         cls.output_processor = fo.utils.sam.SAMSegmenterOutputProcessor()
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.fo_model
+        del cls.predictor
+        gc.collect()
+        torch.cuda.empty_cache()
 
     def test_box_prompt_parity(self):
         """Box prompts: FiftyOne apply_model vs. direct predictor."""
@@ -1750,7 +1807,7 @@ class TestSAM3VideoConceptParity(unittest.TestCase):
 
         cls.fo_model = foz.load_zoo_model(
             SAM3_VIDEO_MODEL_NAME,
-            classes=TEXT_PROMPTS,
+            classes=VID_TEXT_PROMPTS,
             operation_mode="concept",
         )
 
@@ -1866,7 +1923,7 @@ class TestSAM3VideoConceptParity(unittest.TestCase):
         self.dataset.apply_model(self.fo_model, label_field=fo_field)
 
         for sample in self.dataset.iter_samples(progress=False, autosave=True):
-            direct_result = self._run_direct_concept(sample, TEXT_PROMPTS)
+            direct_result = self._run_direct_concept(sample, VID_TEXT_PROMPTS)
             for frame_number, dets in direct_result.items():
                 sample.frames[frame_number][direct_field] = dets
 

--- a/tests/intensive/sam_video_model_tests.py
+++ b/tests/intensive/sam_video_model_tests.py
@@ -172,21 +172,24 @@ class TestSAM3VideoVisualApplyModel(unittest.TestCase):
         for sample in self.dataset.iter_samples(progress=False, autosave=True):
             first_frame = next(iter(sample.frames.values()))
             dets = first_frame.get_field("detections")
-            if dets is not None and dets.detections:
-                first_frame[kp_field] = Keypoints(
-                    keypoints=[
-                        Keypoint(
-                            label=d.label,
-                            points=[
-                                (
-                                    d.bounding_box[0] + d.bounding_box[2] / 2,
-                                    d.bounding_box[1] + d.bounding_box[3] / 2,
-                                )
-                            ],
-                        )
-                        for d in dets.detections
-                    ]
-                )
+            self.assertTrue(
+                dets is not None and bool(dets.detections),
+                f"Missing first-frame detections required for keypoint prompts on sample {sample.id}",
+            )
+            first_frame[kp_field] = Keypoints(
+                keypoints=[
+                    Keypoint(
+                        label=d.label,
+                        points=[
+                            (
+                                d.bounding_box[0] + d.bounding_box[2] / 2,
+                                d.bounding_box[1] + d.bounding_box[3] / 2,
+                            )
+                        ],
+                    )
+                    for d in dets.detections
+                ]
+            )
 
         field = "sam3v_visual_kp"
         self.dataset.apply_model(

--- a/tests/intensive/sam_video_model_tests.py
+++ b/tests/intensive/sam_video_model_tests.py
@@ -1,0 +1,205 @@
+"""
+Tests for the SAM3 video model (SegmentAnything3VideoModel).
+
+Covers:
+  - apply_model tests for concept mode (text prompts)
+  - apply_model tests for visual mode (box and keypoint prompts)
+  - Parity tests: FiftyOne apply_model vs. direct SAM3 video predictor inference
+
+Usage:
+    pytest sam_video_model_tests.py -v --timeout=600
+"""
+
+import gc
+
+import torch
+import unittest
+
+import fiftyone as fo
+import fiftyone.zoo as foz
+from fiftyone.core.labels import Detections, Keypoint, Keypoints
+
+SAM3_VIDEO_MODEL_NAME = "segment-anything-3-video-torch"
+TEXT_PROMPTS = ["car"]
+MASK_IOU = 0.95
+MIN_METRIC = 1.0
+
+
+def _create_video_dataset(num_samples=2, seed=51):
+    name = f"sam3-video-test-{seed}"
+    if name in fo.list_datasets():
+        fo.delete_dataset(name)
+    dataset = foz.load_zoo_dataset(
+        "quickstart-video",
+        max_samples=num_samples,
+        dataset_name=name,
+    )
+    dataset.persistent = True
+    dataset.compute_metadata()
+    return dataset
+
+
+def _assert_video_field_populated(test_case, dataset, frame_field):
+    """Assert every frame has a non-None Detections object in frame_field."""
+    for sample in dataset.iter_samples(progress=False):
+        for frame_number, frame in sample.frames.items():
+            value = frame.get_field(frame_field)
+            test_case.assertIsNotNone(
+                value,
+                f"Frame {frame_number} of sample {sample.id} "
+                f"is missing field '{frame_field}'",
+            )
+            test_case.assertIsInstance(value, Detections)
+
+
+class TestSAM3VideoConceptApplyModel(unittest.TestCase):
+    """Verify apply_model works for SAM3 video model in concept mode."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = foz.load_zoo_model(
+            SAM3_VIDEO_MODEL_NAME,
+            classes=TEXT_PROMPTS,
+            operation_mode="concept",
+        )
+        cls.dataset = _create_video_dataset(num_samples=2, seed=42)
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.model
+        gc.collect()
+        torch.cuda.empty_cache()
+
+    def tearDown(self):
+        gc.collect()
+        torch.cuda.empty_cache()
+
+    def test_concept_single_text_prompt(self):
+        """Concept mode with a single text prompt produces Detections on every frame."""
+        field = "sam3v_concept_single"
+        self.dataset.apply_model(self.model, label_field=field)
+        _assert_video_field_populated(self, self.dataset, field)
+
+    def test_concept_multi_text_prompt(self):
+        """Multiple text prompts produce per-frame Detections."""
+        model = foz.load_zoo_model(
+            SAM3_VIDEO_MODEL_NAME,
+            classes=["person", "car"],
+            operation_mode="concept",
+        )
+        field = "sam3v_concept_multi"
+        self.dataset.apply_model(model, label_field=field)
+        _assert_video_field_populated(self, self.dataset, field)
+
+    def test_output_has_masks(self):
+        """All concept-mode detections should have instance masks."""
+        field = "sam3v_concept_masks"
+        self.dataset.apply_model(self.model, label_field=field)
+
+        for sample in self.dataset.iter_samples(progress=False):
+            for frame_number, frame in sample.frames.items():
+                dets = frame.get_field(field)
+                if dets is None:
+                    continue
+                for det in dets.detections:
+                    self.assertIsNotNone(
+                        det.mask,
+                        f"Detection missing mask on frame {frame_number} "
+                        f"of sample {sample.id}",
+                    )
+
+    def test_concept_propagation_forward(self):
+        """Forward propagation fills every frame (not just the first)."""
+        model = foz.load_zoo_model(
+            SAM3_VIDEO_MODEL_NAME,
+            classes=TEXT_PROMPTS,
+            operation_mode="concept",
+            propagation_direction="forward",
+        )
+        field = "sam3v_concept_fwd"
+        self.dataset.apply_model(model, label_field=field)
+
+        for sample in self.dataset.iter_samples(progress=False):
+            n_frames = len(sample.frames)
+            frames_with_detections = sum(
+                1
+                for frame in sample.frames.values()
+                if frame.get_field(field) is not None
+            )
+            self.assertEqual(
+                frames_with_detections,
+                n_frames,
+                f"Expected {n_frames} frames with '{field}', "
+                f"got {frames_with_detections} on sample {sample.id}",
+            )
+
+
+class TestSAM3VideoVisualApplyModel(unittest.TestCase):
+    """Verify apply_model works for SAM3 video model in visual mode."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = foz.load_zoo_model(
+            SAM3_VIDEO_MODEL_NAME,
+            operation_mode="visual",
+            prompt_frame_indices=[1],
+        )
+        cls.dataset = _create_video_dataset(num_samples=2, seed=77)
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.model
+        gc.collect()
+        torch.cuda.empty_cache()
+
+    def tearDown(self):
+        gc.collect()
+        torch.cuda.empty_cache()
+
+    def test_visual_box_prompt_first_frame_only(self):
+        """Visual mode prompting only from frame 1 still propagates to all frames."""
+        field = "sam3v_visual_box_f1"
+        self.dataset.apply_model(
+            self.model,
+            label_field=field,
+            prompt_field="frames.detections",
+        )
+        _assert_video_field_populated(self, self.dataset, field)
+
+    def test_visual_keypoint_prompt_first_frame_only(self):
+        """Visual mode with Keypoints as prompts produces per-frame segmentations."""
+        kp_field = "sam3v_visual_kps"
+        for sample in self.dataset.iter_samples(progress=False, autosave=True):
+            first_frame = next(iter(sample.frames.values()))
+            dets = first_frame.get_field("detections")
+            if dets is not None and dets.detections:
+                first_frame[kp_field] = Keypoints(
+                    keypoints=[
+                        Keypoint(
+                            label=d.label,
+                            points=[
+                                (
+                                    d.bounding_box[0] + d.bounding_box[2] / 2,
+                                    d.bounding_box[1] + d.bounding_box[3] / 2,
+                                )
+                            ],
+                        )
+                        for d in dets.detections
+                    ]
+                )
+
+        field = "sam3v_visual_kp"
+        self.dataset.apply_model(
+            self.model,
+            label_field=field,
+            prompt_field=f"frames.{kp_field}",
+        )
+        _assert_video_field_populated(self, self.dataset, field)
+
+        self.dataset.delete_frame_field(field)
+        if kp_field in self.dataset.get_frame_field_schema():
+            self.dataset.delete_frame_field(kp_field)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/intensive/sam_video_model_tests.py
+++ b/tests/intensive/sam_video_model_tests.py
@@ -172,7 +172,7 @@ class TestSAM3VideoVisualApplyModel(unittest.TestCase):
         """Visual mode with Keypoints as prompts produces per-frame segmentations."""
         kp_field = "sam3v_visual_kps"
         for sample in self.dataset.iter_samples(progress=False, autosave=True):
-            first_frame = next(iter(sample.frames.values()))
+            first_frame = sample.frames[1]
             dets = first_frame.get_field("detections")
             self.assertTrue(
                 dets is not None and bool(dets.detections),

--- a/tests/intensive/sam_video_model_tests.py
+++ b/tests/intensive/sam_video_model_tests.py
@@ -95,12 +95,14 @@ class TestSAM3VideoConceptApplyModel(unittest.TestCase):
         """All concept-mode detections should have instance masks."""
         field = "sam3v_concept_masks"
         self.dataset.apply_model(self.model, label_field=field)
-
         for sample in self.dataset.iter_samples(progress=False):
             for frame_number, frame in sample.frames.items():
                 dets = frame.get_field(field)
-                if dets is None:
-                    continue
+                self.assertIsNotNone(
+                    dets,
+                    f"No detections on frame {frame_number} "
+                    f"of sample {sample.id}",
+                )
                 for det in dets.detections:
                     self.assertIsNotNone(
                         det.mask,


### PR DESCRIPTION
## 🔗 Related Issues

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->
No related issues to link

## 📋 What changes are proposed in this pull request?

<!--
Provide a clear, concise description of what this PR does and why.
-->

This PR adds SAM3 video model the model zoo. The integration supports concept prompting as well as visual prompting.

## 🧪 How is this patch tested? If it is not, please explain why.

<!--
Describe the tests you ran or wrote to verify your changes. Include:
- New or updated unit/integration tests
- Manual testing steps performed
- Why tests are not applicable (if skipped)
-->

``` 
$ pytest tests/intensive/sam_image_model_tests.py --timeout=500 -v
$ pytest tests/intensive/sam_parity_tests.py --timeout=500 -v
$ pytest tests/intensive/sam_video_model_tests.py --timeout=500 -v
```

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

SAM3 video model with concept and visual prompting added to the zoo.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SAM3 video support with concept (text) and visual (box/keypoint) prompting, configurable propagation settings, prompt-frame selection, per-frame mask+box outputs, and prompt→label mapping.
  * Enhanced SAM3 video processing with FiftyOne-based frame loading and normalization.

* **Tests**
  * Added intensive SAM3 video concept/visual integration tests ensuring detections are populated across frames (including mask presence in concept mode).
  * Expanded SAM parity coverage for SAM3 video (forward/backward/both propagation and keypoint prompting) and strengthened GPU/resource cleanup for deterministic runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2863
<!-- enterprise-sync-pr:end -->