### PR TITLE
[chore] Playback pkg - add tests / spruce up old tests

### DIFF
--- a/app/packages/playback/src/lib/playback/playback-store-context.test.tsx
+++ b/app/packages/playback/src/lib/playback/playback-store-context.test.tsx
@@ -1,0 +1,47 @@
+import { cleanup, renderHook } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import { PlaybackProvider } from "./PlaybackProvider";
+import {
+  PlaybackStoreContext,
+  usePlaybackStore,
+} from "./playback-store-context";
+
+describe("usePlaybackStore", () => {
+  afterEach(() => cleanup());
+
+  it("throws when called outside a PlaybackProvider", () => {
+    // Suppress the expected React error boundary noise in test output.
+    const consoleError = console.error;
+    console.error = () => {};
+
+    expect(() => renderHook(() => usePlaybackStore())).toThrow(
+      "usePlaybackStore must be used inside a <PlaybackProvider>"
+    );
+
+    console.error = consoleError;
+  });
+
+  it("returns the store when called inside a PlaybackProvider", () => {
+    const { result } = renderHook(() => usePlaybackStore(), {
+      wrapper: ({ children }) => (
+        <PlaybackProvider duration={5} stepInterval={1 / 30}>
+          {children}
+        </PlaybackProvider>
+      ),
+    });
+
+    expect(result.current).toBeDefined();
+    // A Jotai store has get/set/sub methods
+    expect(typeof result.current.get).toBe("function");
+    expect(typeof result.current.set).toBe("function");
+    expect(typeof result.current.sub).toBe("function");
+  });
+
+  it("returns null from context when the context is unset (raw context read)", () => {
+    const { result } = renderHook(() =>
+      React.useContext(PlaybackStoreContext)
+    );
+    expect(result.current).toBeNull();
+  });
+});

--- a/app/packages/playback/src/lib/playback/use-video-stream.test.tsx
+++ b/app/packages/playback/src/lib/playback/use-video-stream.test.tsx
@@ -1,0 +1,171 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { useAtomValue } from "jotai";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { durationAtom } from "./atoms";
+import { PlaybackProvider, usePlaybackStore } from "./PlaybackProvider";
+import { useVideoStream } from "./use-video-stream";
+
+interface FakeVideo {
+  duration: number;
+  buffered: TimeRanges;
+  addEventListener: ReturnType<typeof vi.fn>;
+  removeEventListener: ReturnType<typeof vi.fn>;
+  _fire(event: string): void;
+}
+
+function makeTimeRanges(ranges: Array<[number, number]>): TimeRanges {
+  return {
+    length: ranges.length,
+    start: (i: number) => ranges[i][0],
+    end: (i: number) => ranges[i][1],
+  } as TimeRanges;
+}
+
+function makeVideo(initialDuration = NaN): FakeVideo {
+  const listeners = new Map<string, EventListener[]>();
+  return {
+    duration: initialDuration,
+    buffered: makeTimeRanges([]),
+    addEventListener: vi.fn((event: string, fn: EventListener) => {
+      if (!listeners.has(event)) listeners.set(event, []);
+      listeners.get(event)!.push(fn);
+    }),
+    removeEventListener: vi.fn((event: string, fn: EventListener) => {
+      const arr = listeners.get(event) ?? [];
+      listeners.set(event, arr.filter((f) => f !== fn));
+    }),
+    _fire(event: string) {
+      for (const fn of listeners.get(event) ?? []) fn(new Event(event));
+    },
+  };
+}
+
+function renderStream(
+  video: FakeVideo | null,
+  opts: { blocking?: boolean } = {}
+) {
+  const videoRef = {
+    current: video,
+  } as React.RefObject<HTMLVideoElement | null>;
+
+  return renderHook(
+    () => {
+      const store = usePlaybackStore();
+      useVideoStream("video-1", videoRef, opts);
+      return { store, duration: useAtomValue(durationAtom, { store }) };
+    },
+    {
+      wrapper: ({ children }) => (
+        <PlaybackProvider duration={0} stepInterval={1 / 30}>
+          {children}
+        </PlaybackProvider>
+      ),
+    }
+  );
+}
+
+describe("useVideoStream", () => {
+  afterEach(() => cleanup());
+
+  it("does not register a stream when the ref is null", () => {
+    const { result } = renderStream(null);
+    expect(result.current.duration).toBe(0);
+  });
+
+  it("does not register a stream when initial duration is NaN", () => {
+    const { result } = renderStream(makeVideo(NaN));
+    expect(result.current.duration).toBe(0);
+  });
+
+  it("registers the stream immediately when the video already has a finite duration", () => {
+    const { result } = renderStream(makeVideo(10));
+    expect(result.current.duration).toBe(10);
+  });
+
+  it("registers the stream after loadedmetadata fires with a finite duration", () => {
+    const video = makeVideo(NaN);
+    const { result } = renderStream(video);
+    expect(result.current.duration).toBe(0);
+
+    act(() => {
+      video.duration = 20;
+      video._fire("loadedmetadata");
+    });
+
+    expect(result.current.duration).toBe(20);
+  });
+
+  it("updates the stream duration when durationchange fires", () => {
+    const video = makeVideo(10);
+    const { result } = renderStream(video);
+    expect(result.current.duration).toBe(10);
+
+    act(() => {
+      video.duration = 30;
+      video._fire("durationchange");
+    });
+
+    expect(result.current.duration).toBe(30);
+  });
+
+  it("ignores an Infinity duration from loadedmetadata", () => {
+    const video = makeVideo(NaN);
+    const { result } = renderStream(video);
+
+    act(() => {
+      video.duration = Infinity;
+      video._fire("loadedmetadata");
+    });
+
+    expect(result.current.duration).toBe(0);
+  });
+
+  it("ignores a negative duration from durationchange", () => {
+    const video = makeVideo(NaN);
+    const { result } = renderStream(video);
+
+    act(() => {
+      video.duration = -5;
+      video._fire("durationchange");
+    });
+
+    expect(result.current.duration).toBe(0);
+  });
+
+  it("subscribes to loadedmetadata and durationchange on the video element", () => {
+    const video = makeVideo(NaN);
+    renderStream(video);
+    expect(video.addEventListener).toHaveBeenCalledWith(
+      "loadedmetadata",
+      expect.any(Function)
+    );
+    expect(video.addEventListener).toHaveBeenCalledWith(
+      "durationchange",
+      expect.any(Function)
+    );
+  });
+
+  it("removes both event listeners when unmounted", () => {
+    const video = makeVideo(10);
+    const { unmount } = renderStream(video);
+
+    act(() => unmount());
+
+    expect(video.removeEventListener).toHaveBeenCalledWith(
+      "loadedmetadata",
+      expect.any(Function)
+    );
+    expect(video.removeEventListener).toHaveBeenCalledWith(
+      "durationchange",
+      expect.any(Function)
+    );
+  });
+
+  it("passes blocking:false to the registered stream", () => {
+    // A non-blocking stream still contributes its duration to the engine.
+    const video = makeVideo(5);
+    const { result } = renderStream(video, { blocking: false });
+    expect(result.current.duration).toBe(5);
+  });
+});

--- a/app/packages/playback/src/lib/playback/use-video-sync.test.tsx
+++ b/app/packages/playback/src/lib/playback/use-video-sync.test.tsx
@@ -1,0 +1,200 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { useAtomValue } from "jotai";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  currentTimeAtom,
+  isPlayingAtom,
+  playheadAtom,
+} from "./atoms";
+import { PlaybackProvider, usePlaybackStore } from "./PlaybackProvider";
+import { useVideoSync } from "./use-video-sync";
+
+interface FakeVideo {
+  currentTime: number;
+  play: ReturnType<typeof vi.fn>;
+  pause: ReturnType<typeof vi.fn>;
+  addEventListener: ReturnType<typeof vi.fn>;
+  removeEventListener: ReturnType<typeof vi.fn>;
+  _fire(event: string): void;
+}
+
+function makeVideo(initialTime = 0): FakeVideo {
+  const listeners = new Map<string, EventListener[]>();
+  const video: FakeVideo = {
+    currentTime: initialTime,
+    play: vi.fn().mockResolvedValue(undefined),
+    pause: vi.fn(),
+    addEventListener: vi.fn((event: string, fn: EventListener) => {
+      if (!listeners.has(event)) listeners.set(event, []);
+      listeners.get(event)!.push(fn);
+    }),
+    removeEventListener: vi.fn((event: string, fn: EventListener) => {
+      const arr = listeners.get(event) ?? [];
+      listeners.set(event, arr.filter((f) => f !== fn));
+    }),
+    _fire(event: string) {
+      for (const fn of listeners.get(event) ?? []) fn(new Event(event));
+    },
+  };
+  return video;
+}
+
+function renderSync(video: FakeVideo | null, duration = 10) {
+  const videoRef = {
+    current: video,
+  } as React.RefObject<HTMLVideoElement | null>;
+
+  return renderHook(
+    () => {
+      const store = usePlaybackStore();
+      useVideoSync(videoRef);
+      return {
+        store,
+        isPlaying: useAtomValue(isPlayingAtom, { store }),
+        playhead: useAtomValue(playheadAtom, { store }),
+        currentTime: useAtomValue(currentTimeAtom, { store }),
+      };
+    },
+    {
+      wrapper: ({ children }) => (
+        <PlaybackProvider duration={duration} stepInterval={1 / 30}>
+          {children}
+        </PlaybackProvider>
+      ),
+    }
+  );
+}
+
+describe("useVideoSync", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe("play / pause driving", () => {
+    it("calls video.play() when isPlayingAtom becomes true", async () => {
+      const video = makeVideo();
+      const { result } = renderSync(video);
+      // The effect runs on mount with isPlaying=false, calling pause() once.
+      // Clear those initial calls before testing the state transition.
+      video.play.mockClear();
+      video.pause.mockClear();
+
+      await act(async () => {
+        result.current.store.set(isPlayingAtom, true);
+      });
+
+      expect(video.play).toHaveBeenCalledTimes(1);
+      expect(video.pause).not.toHaveBeenCalled();
+    });
+
+    it("calls video.pause() when isPlayingAtom becomes false after playing", async () => {
+      const video = makeVideo();
+      const { result } = renderSync(video);
+
+      await act(async () => {
+        result.current.store.set(isPlayingAtom, true);
+      });
+      // Clear after play so we isolate the pause call.
+      video.pause.mockClear();
+
+      await act(async () => {
+        result.current.store.set(isPlayingAtom, false);
+      });
+
+      expect(video.pause).toHaveBeenCalledTimes(1);
+    });
+
+    it("does nothing when the video ref is null", async () => {
+      // Should not throw — the effect guard exits early on null.
+      const { result } = renderSync(null);
+      await act(async () => {
+        result.current.store.set(isPlayingAtom, true);
+      });
+      // No error thrown; nothing to assert beyond that.
+    });
+  });
+
+  describe("playhead → video seek", () => {
+    it("seeks the video when playhead diverges beyond the tolerance (0.15s)", () => {
+      const video = makeVideo(0);
+      const { result } = renderSync(video);
+
+      act(() => {
+        result.current.store.set(playheadAtom, 5);
+      });
+
+      // video.currentTime should be updated to 5 (delta = 5 > 0.15)
+      expect(video.currentTime).toBe(5);
+    });
+
+    it("does not seek when the delta is within the tolerance", () => {
+      const video = makeVideo(0);
+      const { result } = renderSync(video);
+
+      act(() => {
+        // 0.1 < SEEK_TOLERANCE_S (0.15) → no seek
+        result.current.store.set(playheadAtom, 0.1);
+      });
+
+      expect(video.currentTime).toBe(0);
+    });
+
+    it("does not seek when the ref is null", () => {
+      const { result } = renderSync(null);
+      // Should not throw
+      act(() => {
+        result.current.store.set(playheadAtom, 5);
+      });
+    });
+  });
+
+  describe("video → atoms sync", () => {
+    it("updates playhead and currentTime atoms when timeupdate fires", () => {
+      const video = makeVideo(0);
+      const { result } = renderSync(video);
+
+      act(() => {
+        video.currentTime = 3.5;
+        video._fire("timeupdate");
+      });
+
+      expect(result.current.playhead).toBe(3.5);
+      expect(result.current.currentTime).toBe(3.5);
+    });
+
+    it("sets isPlayingAtom to false when the ended event fires", () => {
+      const video = makeVideo(0);
+      const { result } = renderSync(video);
+
+      act(() => {
+        result.current.store.set(isPlayingAtom, true);
+      });
+      act(() => {
+        video._fire("ended");
+      });
+
+      expect(result.current.isPlaying).toBe(false);
+      expect(video.pause).toHaveBeenCalled();
+    });
+  });
+
+  describe("cleanup", () => {
+    it("removes timeupdate and ended listeners when unmounted", () => {
+      const video = makeVideo();
+      const { unmount } = renderSync(video);
+
+      act(() => unmount());
+
+      expect(video.removeEventListener).toHaveBeenCalledWith(
+        "timeupdate",
+        expect.any(Function)
+      );
+      expect(video.removeEventListener).toHaveBeenCalledWith(
+        "ended",
+        expect.any(Function)
+      );
+    });
+  });
+});

--- a/app/packages/playback/src/views/SimplePlaybackBar/SimplePlaybackBar.test.tsx
+++ b/app/packages/playback/src/views/SimplePlaybackBar/SimplePlaybackBar.test.tsx
@@ -144,4 +144,116 @@ describe("SimplePlaybackBar", () => {
     // Readout stays at the zero baseline; no NaN, no throw.
     expect(screen.getByText("0:00.00 / 0:00.00")).toBeTruthy();
   });
+
+  describe("keyboard scrubbing", () => {
+    // Seek to 50% (5s) first so there is room to go both forward and backward.
+    function renderAtMidpoint() {
+      const result = renderBar(10);
+      const track = result.container.querySelector<HTMLDivElement>(
+        `.${styles.track}`
+      )!;
+      pointerDown(track, 50); // 50px of 100px → 5s
+      expect(screen.getByText("0:05.00 / 0:10.00")).toBeTruthy();
+      return { ...result, track };
+    }
+
+    // For nudge tests (±1%), we assert on `aria-valuenow` rather than the
+    // formatted text. `5 + 0.1` in IEEE 754 is 5.0999…, so
+    // Math.floor(5.0999… * 100) = 509 and formatTime renders "0:05.09",
+    // not "0:05.10". Asserting the underlying number sidesteps that.
+    it("ArrowRight nudges forward by 1% of duration", () => {
+      const { track } = renderAtMidpoint();
+      fireEvent.keyDown(track, { key: "ArrowRight" });
+      expect(parseFloat(track.getAttribute("aria-valuenow") ?? "0")).toBeCloseTo(
+        5.1,
+        5
+      );
+    });
+
+    it("ArrowUp nudges forward by 1% (same as ArrowRight)", () => {
+      const { track } = renderAtMidpoint();
+      fireEvent.keyDown(track, { key: "ArrowUp" });
+      expect(parseFloat(track.getAttribute("aria-valuenow") ?? "0")).toBeCloseTo(
+        5.1,
+        5
+      );
+    });
+
+    it("ArrowLeft nudges backward by 1% of duration", () => {
+      const { track } = renderAtMidpoint();
+      fireEvent.keyDown(track, { key: "ArrowLeft" });
+      expect(parseFloat(track.getAttribute("aria-valuenow") ?? "0")).toBeCloseTo(
+        4.9,
+        5
+      );
+    });
+
+    it("ArrowDown nudges backward by 1% (same as ArrowLeft)", () => {
+      const { track } = renderAtMidpoint();
+      fireEvent.keyDown(track, { key: "ArrowDown" });
+      expect(parseFloat(track.getAttribute("aria-valuenow") ?? "0")).toBeCloseTo(
+        4.9,
+        5
+      );
+    });
+
+    it("PageUp jumps forward by 10% of duration", () => {
+      const { track } = renderAtMidpoint();
+      fireEvent.keyDown(track, { key: "PageUp" });
+      expect(screen.getByText("0:06.00 / 0:10.00")).toBeTruthy();
+    });
+
+    it("PageDown jumps backward by 10% of duration", () => {
+      const { track } = renderAtMidpoint();
+      fireEvent.keyDown(track, { key: "PageDown" });
+      expect(screen.getByText("0:04.00 / 0:10.00")).toBeTruthy();
+    });
+
+    it("Home jumps to the start", () => {
+      const { track } = renderAtMidpoint();
+      fireEvent.keyDown(track, { key: "Home" });
+      expect(screen.getByText("0:00.00 / 0:10.00")).toBeTruthy();
+    });
+
+    it("End jumps to the end", () => {
+      const { track } = renderAtMidpoint();
+      fireEvent.keyDown(track, { key: "End" });
+      expect(screen.getByText("0:10.00 / 0:10.00")).toBeTruthy();
+    });
+
+    it("ArrowRight clamps at duration", () => {
+      const result = renderBar(10);
+      const track = result.container.querySelector<HTMLDivElement>(
+        `.${styles.track}`
+      )!;
+      pointerDown(track, 100); // seek to 10s (end)
+      fireEvent.keyDown(track, { key: "ArrowRight" });
+      expect(screen.getByText("0:10.00 / 0:10.00")).toBeTruthy();
+    });
+
+    it("ArrowLeft clamps at 0", () => {
+      const result = renderBar(10);
+      const track = result.container.querySelector<HTMLDivElement>(
+        `.${styles.track}`
+      )!;
+      // Playhead is at 0 by default
+      fireEvent.keyDown(track, { key: "ArrowLeft" });
+      expect(screen.getByText("0:00.00 / 0:10.00")).toBeTruthy();
+    });
+
+    it("ignores unknown keys without moving the playhead", () => {
+      const { track } = renderAtMidpoint();
+      fireEvent.keyDown(track, { key: "Tab" });
+      expect(screen.getByText("0:05.00 / 0:10.00")).toBeTruthy();
+    });
+
+    it("does not seek when duration is 0", () => {
+      const result = renderBar(0);
+      const track = result.container.querySelector<HTMLDivElement>(
+        `.${styles.track}`
+      )!;
+      fireEvent.keyDown(track, { key: "ArrowRight" });
+      expect(screen.getByText("0:00.00 / 0:00.00")).toBeTruthy();
+    });
+  });
 });

--- a/app/packages/playback/src/views/TimelineRuler/TimelineRuler.test.tsx
+++ b/app/packages/playback/src/views/TimelineRuler/TimelineRuler.test.tsx
@@ -363,4 +363,5 @@ describe("TimelineRuler", () => {
       expect(vs).toBeCloseTo(6, 2);
     });
   });
+
 });

--- a/app/packages/playback/src/views/TimelineWithTracks/TimelineWithTracks.test.tsx
+++ b/app/packages/playback/src/views/TimelineWithTracks/TimelineWithTracks.test.tsx
@@ -1,0 +1,114 @@
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PlaybackProvider } from "../../lib/playback/PlaybackProvider";
+import {
+  TrackProvider,
+  type Track,
+} from "../../lib/tracks/TrackProvider";
+import TimelineWithTracks from "./TimelineWithTracks";
+import styles from "./TimelineWithTracks.module.css";
+
+const TRACK_A: Track = {
+  id: "track-a",
+  label: "Track A",
+  color: "#4a9eff",
+  events: [{ startSec: 1, endSec: 3 }],
+};
+const TRACK_B: Track = {
+  id: "track-b",
+  label: "Track B",
+  color: "#ff6b6b",
+  events: [],
+};
+
+interface RenderOpts {
+  tracks?: Track[];
+  pinnedIds?: string[];
+  duration?: number;
+  labelWidth?: number;
+}
+
+function renderTimeline(opts: RenderOpts = {}) {
+  const {
+    tracks = [],
+    pinnedIds = [],
+    duration = 10,
+    labelWidth,
+  } = opts;
+
+  return render(
+    <PlaybackProvider duration={duration} stepInterval={1 / 30}>
+      <TrackProvider initialTracks={tracks} initialPinnedIds={pinnedIds}>
+        <TimelineWithTracks labelWidth={labelWidth} />
+      </TrackProvider>
+    </PlaybackProvider>
+  );
+}
+
+describe("TimelineWithTracks", () => {
+  beforeEach(() => {
+    // useElementSize relies on ResizeObserver which jsdom doesn't support.
+    // Provide a no-op stub so the hook mounts without errors.
+    global.ResizeObserver = vi.fn().mockImplementation(() => ({
+      observe: vi.fn(),
+      unobserve: vi.fn(),
+      disconnect: vi.fn(),
+    }));
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe("empty state (no tracks)", () => {
+    it("renders the root container with the noTracks modifier", () => {
+      const { container } = renderTimeline({ tracks: [] });
+      const root = container.firstElementChild as HTMLElement;
+      expect(root.className).toContain(styles.noTracks);
+    });
+
+    it("does not render the tracks area when there are no tracks", () => {
+      const { container } = renderTimeline({ tracks: [] });
+      // noTracks branch skips the Drawer entirely — no tracksOuter section
+      expect(container.querySelector(`.${styles.tracksOuter}`)).toBeNull();
+    });
+  });
+
+  describe("with tracks", () => {
+    it("renders the root container without the noTracks class", () => {
+      const { container } = renderTimeline({
+        tracks: [TRACK_A],
+        pinnedIds: ["track-a"],
+      });
+      const root = container.firstElementChild as HTMLElement;
+      expect(root.className).not.toContain(styles.noTracks);
+    });
+
+    it("renders track labels for registered tracks", () => {
+      renderTimeline({ tracks: [TRACK_A, TRACK_B], pinnedIds: ["track-a"] });
+      expect(screen.getByText("Track A")).toBeTruthy();
+    });
+
+    it("renders all tracks in the drawer body when open", () => {
+      renderTimeline({
+        tracks: [TRACK_A, TRACK_B],
+        pinnedIds: ["track-a"],
+      });
+      // Both labels should be visible in the default open state
+      expect(screen.getByText("Track A")).toBeTruthy();
+      expect(screen.getByText("Track B")).toBeTruthy();
+    });
+  });
+
+  describe("label width", () => {
+    it("uses 0 label width when there are no tracks", () => {
+      // When there are no tracks, labelWidth collapses to 0 so the ruler
+      // spans full width. We verify no label column elements are present.
+      const { container } = renderTimeline({ tracks: [] });
+      // No track label elements in the empty state
+      expect(container.querySelectorAll("[class*=label]")).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

**Bug fixes** from the post-sprint review (`app/packages/playback`):

- **`LoopOverlays.tsx`** — Removed a local `LOOP_EDGE_EPSILON = 0.001` that diverged from the canonical `0.02` in `timeline-controls-utils`. Loop overlay masks and loop bound labels were using different thresholds, causing them to hide at different positions. Updated the corresponding test to match.
- **`use-playback-engine.ts`** — Replaced a hardcoded `50ms` seek debounce with `SEEK_BAR_DEBOUNCE` from `constants.ts` (value: `10ms`). The two values were silently diverged.
- **`state.ts`** — Added `_currentBufferingRange.remove(timelineName)` to the LRU cache dispose callback. The atom family was being leaked on every timeline eviction — all other atom families were cleaned up but this one was missed.
- **`context.tsx`** — Deleted `GlobalTimelineContext` / `GlobalTimelineProvider` / `useGlobalTimelineContext`. The file was never imported anywhere in the codebase.

**Test coverage** for `app/packages/playback` (excluding legacy `lib/timeline`):

| File | Before | After |
|------|--------|-------|
| `use-video-sync.ts` | 0% | 100% |
| `playback-store-context.ts` | 64% | 100% |
| `SimplePlaybackBar.tsx` | 68% | 100% |
| `TimelineWithTracks.tsx` | 56% | 95% |
| `use-video-stream.ts` | 0% | 72% |
| `TimelineTrack.tsx` | 85% | 99% |
| **Overall** | **61%** | **69%** |

New test files: `use-video-stream.test.tsx`, `use-video-sync.test.tsx`, `TimelineWithTracks.test.tsx`, `playback-store-context.test.tsx`. Expanded: `SimplePlaybackBar.test.tsx` (keyboard scrubbing), `LoopOverlays.test.tsx` (epsilon update).

**Still at 0%**: `Timeline.tsx`, `PlaybackElements.tsx`, `TimelineExamples.tsx` — these import from the legacy `lib/timeline` tree which pulls in `@fiftyone/state` and relay-runtime at module load time, making them untestable without significant mocking. Left for a follow-up.

## Test plan

- [x] `cd app/packages/playback && npx vitest run` — all 251 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites for playback functionality, including video stream handling, synchronization, and playback state management.
  * Added keyboard control tests for playback scrubbing (nudge forward/backward by 1%, jump by 10%, seek to start/end).
  * Added UI component tests for timeline and track rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2857
<!-- enterprise-sync-pr:end -->