### PR TITLE
docs: add #7711 to v1.17.0 release notes

### DIFF
--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -31,6 +31,10 @@ App
 - Fixed value tearing in the dynamic-groups pagination bar during slice
   transitions
   `#7599 <https://github.com/voxel51/fiftyone/pull/7599>`_
+- Fixed a bug where mask and looker decode workers could run on the main
+  thread under non-Vite bundlers (e.g. webpack/Next.js), triggering a runaway
+  message loop that pegged CPU usage
+  `#7711 <https://github.com/voxel51/fiftyone/pull/7711>`_
 
 In-App Annotation
 

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -31,9 +31,7 @@ App
 - Fixed value tearing in the dynamic-groups pagination bar during slice
   transitions
   `#7599 <https://github.com/voxel51/fiftyone/pull/7599>`_
-- Fixed a bug where mask and looker decode workers could run on the main
-  thread under non-Vite bundlers (e.g. webpack/Next.js), triggering a runaway
-  message loop that pegged CPU usage
+- Improved performance of image and mask decoding in the App
   `#7711 <https://github.com/voxel51/fiftyone/pull/7711>`_
 
 In-App Annotation

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -31,7 +31,7 @@ App
 - Fixed value tearing in the dynamic-groups pagination bar during slice
   transitions
   `#7599 <https://github.com/voxel51/fiftyone/pull/7599>`_
-- Improved performance of image and mask decoding in the App
+- Improved performance of image and mask decoding
   `#7711 <https://github.com/voxel51/fiftyone/pull/7711>`_
 
 In-App Annotation


### PR DESCRIPTION
## Summary
Adds an App entry for `#7711` to the FiftyOne 1.17.0 release notes.

`#7711` fixed decode workers running on the main thread under non-Vite bundlers (webpack/Next.js), which caused a runaway postMessage loop. The original PR marked itself as non-user-facing, but the symptom (100% CPU in consuming apps) is worth surfacing in the notes.

## Test plan
- [x] `prettier` pre-commit hook passed; entry slots into the existing App bullet list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where mask and looker decode workers could run on the main thread under certain bundlers, which could trigger runaway message loops and sustained high CPU usage. This improves app stability and reduces unexpected CPU spikes during media decoding in affected build environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2798
<!-- enterprise-sync-pr:end -->