### PR TITLE
chore: bump fiftyone-brain and voxel51-eta deps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,9 +96,9 @@ setup(
         "scikit-image<1",
         "scipy<2",
         # internal packages
-        "fiftyone-brain>=0.21.6,<0.22",
+        "fiftyone-brain>=0.22.0,<0.23",
         "fiftyone-db>=0.4,<2.0",
-        "voxel51-eta>=0.15.3,<0.16",
+        "voxel51-eta>=0.16.0,<0.17",
     ],
     include_package_data=True,
     classifiers=[


### PR DESCRIPTION
## Summary
Bumps the internal package pins in `setup.py` to pick up the new releases that drop Python 3.9 and add Python 3.12:

- `fiftyone-brain` `>=0.21.6,<0.22` → `>=0.22,<0.23`
- `voxel51-eta` `>=0.15.3,<0.16` → `>=0.16,<0.17`

## Notes
- Depends on the corresponding releases being published to PyPI:
  - fiftyone-brain v0.22.0 (PR voxel51/fiftyone-brain#290)
  - voxel51-eta v0.16.0 (PR voxel51/eta#706, merged; release pending)

## Test plan
- [x] pre-commit hooks (black/pylint/prettier) passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal package dependencies to newer compatible versions (brain and ETA packages), enabling access to recent improvements and fixes while keeping the database package constraint unchanged. No user-facing feature changes expected; this ensures better compatibility and stability for future updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2802
<!-- enterprise-sync-pr:end -->