### PR TITLE
[HA] Anchor polyline label on points centroid

### DIFF
--- a/app/packages/lighter/src/overlay/PolylineOverlay.ts
+++ b/app/packages/lighter/src/overlay/PolylineOverlay.ts
@@ -7,8 +7,9 @@ import {
   LABEL_ARCHETYPE_PRIORITY,
   PREVIEW_LINE_OPACITY,
 } from "../constants";
+import { CONTAINS } from "../core/Scene2D";
 import type { Renderer2D } from "../renderer/Renderer2D";
-import type { DrawStyle, Point, RawLookerLabel } from "../types";
+import type { DrawStyle, Point, RawLookerLabel, Rect } from "../types";
 import {
   distance,
   distanceFromLineSegment,
@@ -19,6 +20,7 @@ import {
   type KeypointLabel,
   type KeypointRenderContext,
 } from "./KeypointOverlay";
+import { BaseOverlay } from "./BaseOverlay";
 
 export type PolylineLabel = RawLookerLabel & {
   label?: string;
@@ -113,6 +115,12 @@ export class PolylineOverlay extends KeypointOverlay {
    * the opposite endpoint of the active segment.
    */
   private previewAnchorPointId: string | null = null;
+
+  /**
+   * Absolute-space rect of the most recently drawn label text (background
+   * box), or `undefined` when no label is drawn.
+   */
+  private textBounds?: Rect;
 
   constructor(options: PolylineOptions) {
     const { flatPoints, connections, segmentBoundaries } =
@@ -869,6 +877,105 @@ export class PolylineOverlay extends KeypointOverlay {
         opacity: PREVIEW_LINE_OPACITY,
       },
       this.containerId,
+    );
+  }
+
+  /**
+   * Renders the label text at the centroid of the polyline's points.
+   * Anchoring on the centroid reads more clearly for polylines/polygons,
+   * where the bounding-box corner can sit far from any actual geometry.
+   */
+  protected override renderLabelText(
+    renderer: Renderer2D,
+    ctx: KeypointRenderContext
+  ): void {
+    // Reset first so a no-draw frame clears any stale hit region.
+    this.textBounds = undefined;
+
+    if (!this.label || !this.label.label?.length) {
+      return;
+    }
+
+    if (ctx.absPoints.length === 0) {
+      return;
+    }
+
+    if (!BaseOverlay.validBounds(this.bounds)) {
+      return;
+    }
+
+    const centroid = PolylineOverlay.computeCentroid(ctx.absPoints);
+
+    // `drawText` returns the absolute-space background rect; retain it for
+    // hover/selection hit-testing.
+    this.textBounds = renderer.drawText(
+      this.label.label,
+      centroid,
+      {
+        fontColor: "#ffffff",
+        backgroundColor: ctx.style.fillStyle || ctx.style.strokeStyle || "#000",
+        anchor: { vertical: "center", horizontal: "center" },
+      },
+      this.containerId
+    );
+  }
+
+  /**
+   * Extends the inherited point/edge/interior hit-testing so the label text
+   * box is also a hit target. A point landing on the label (but not on the
+   * geometry) reports `BORDER`.
+   */
+  override getContainmentLevel(point: Point): CONTAINS {
+    const base = super.getContainmentLevel(point);
+    if (base !== CONTAINS.NONE) {
+      return base;
+    }
+
+    if (
+      this.textBounds &&
+      PolylineOverlay.pointInRect(point, this.textBounds)
+    ) {
+      return CONTAINS.BORDER;
+    }
+
+    return CONTAINS.NONE;
+  }
+
+  /**
+   * Treats a cursor over the label text as a direct hit (distance 0), so the
+   * label wins overlay-ordering ties.
+   */
+  override getMouseDistance(point: Point): number {
+    const wp = this.renderer?.screenToWorld(point) ?? point;
+    if (this.textBounds && PolylineOverlay.pointInRect(wp, this.textBounds)) {
+      return 0;
+    }
+
+    return super.getMouseDistance(point);
+  }
+
+  /**
+   * Returns the centroid (mean position) of the given points. Callers are
+   * responsible for ensuring the array is non-empty.
+   */
+  private static computeCentroid(points: Point[]): Point {
+    let sumX = 0;
+    let sumY = 0;
+
+    for (const p of points) {
+      sumX += p.x;
+      sumY += p.y;
+    }
+
+    return {
+      x: sumX / points.length,
+      y: sumY / points.length,
+    };
+  }
+
+  private static pointInRect(p: Point, r: Rect): boolean {
+    return (
+      p.x >= r.x && p.y >= r.y && p.x <= r.x + r.width && p.y <= r.y + r.height
     );
   }
 


### PR DESCRIPTION
## 🔗 Related Issues

None

## 📋 What changes are proposed in this pull request?

Two small polyline annotation UX tweaks, both in `PolylineOverlay`.

- **Center the label on the points centroid** — the label text was anchored at the top-left of the points' bounding box (detection-style), which can sit far from any actual geometry for a polyline/polygon. It now renders at the centroid of the points for clearer association.
- **Make the label hoverable/selectable** — the label text box is now a hit target (mirroring `DetectionOverlay`), so you can hover/select the polyline by its label — useful when the centroid label sits away from the visible points.

## 🧪 How is this patch tested? If it is not, please explain why.

Verified locally in the app (open/closed polylines and filled polygons): the label centers on the shape and hovering/clicking the label selects the polyline.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed polyline label positioning and interaction detection — labels now render centered on polylines and accurately respond to clicks and hover actions. Improved hit-detection ensures labels work correctly when layered with other overlays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3338
<!-- enterprise-sync-pr:end -->