### PR TITLE
[chore] Tiling pkg - remove lint suppressions and fix @ts-explicit-any casts in TilingHeader

### DIFF
--- a/app/packages/tiling/src/views/TileSettingsSidebar/TileSettingsSidebar.stories.tsx
+++ b/app/packages/tiling/src/views/TileSettingsSidebar/TileSettingsSidebar.stories.tsx
@@ -36,7 +36,7 @@ const TileBody: React.FC = () => (
 
 function AutoFocus({ id }: { id: string }) {
   const { setFocusedTileId } = useTiling();
-  // setFocusedTileId is a stable Jotai setter; not in deps by design.
+  // setFocusedTileId is a stable useState setter; omitted from deps per project convention.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => setFocusedTileId(id), [id]);
   return null;

--- a/app/packages/tiling/src/views/TilingHeader/TilingHeader.tsx
+++ b/app/packages/tiling/src/views/TilingHeader/TilingHeader.tsx
@@ -67,8 +67,7 @@ const TilingHeader: React.FC<TilingHeaderProps> = ({
         />
       </>
     );
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [types]);
+  }, [types, addTile, autoLayout]);
 
   return (
     <div className={styles.root}>
@@ -110,8 +109,7 @@ const TilingHeader: React.FC<TilingHeaderProps> = ({
             variant={Variant.Borderless}
             size={Size.Xs}
             data-testid="tiling-header-toggle-left-sidebar"
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            leadingIcon={SidebarLeftIcon as any}
+            leadingIcon={SidebarLeftIcon}
             aria-label={leftSidebarOpen ? "Hide settings" : "Show settings"}
             aria-pressed={!!leftSidebarOpen}
             title={leftSidebarOpen ? "Hide settings" : "Show settings"}
@@ -125,8 +123,7 @@ const TilingHeader: React.FC<TilingHeaderProps> = ({
             variant={Variant.Borderless}
             size={Size.Xs}
             data-testid="tiling-header-toggle-right-sidebar"
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            leadingIcon={SidebarRightIcon as any}
+            leadingIcon={SidebarRightIcon}
             aria-label={rightSidebarOpen ? "Hide inspector" : "Show inspector"}
             aria-pressed={!!rightSidebarOpen}
             title={rightSidebarOpen ? "Hide inspector" : "Show inspector"}

--- a/app/packages/tiling/src/views/TilingHeader/tiling-header-icons.tsx
+++ b/app/packages/tiling/src/views/TilingHeader/tiling-header-icons.tsx
@@ -5,12 +5,15 @@ import React from "react";
 // `IconName` does not include sidebar variants yet. When it does, replace
 // these with the design-system names and delete this file.
 //
-// Typed as plain `FC` so they slot into voodo's `Button.leadingIcon`
-// (which expects `IconName | FC<{}>`) without a cast.
+// Cast as `React.FC` so they satisfy voodo's `Button.leadingIcon`
+// (`IconName | FC<{}>`). The `as unknown as React.FC` is needed because
+// voodo's published types were compiled against React 17, whose FC generic
+// diverges from React 18's on the children constraint.
+// TODO: Remove as unknown as React.FC once Icons are part of Voodoo
 // ---------------------------------------------------------------------------
 
 /** A rectangle with a vertical bar near the LEFT edge — implies a left panel. */
-export const SidebarLeftIcon: React.FC = () => (
+export const SidebarLeftIcon = ((): React.ReactElement => (
   <svg
     viewBox="0 0 24 24"
     fill="none"
@@ -22,10 +25,10 @@ export const SidebarLeftIcon: React.FC = () => (
     <rect width="20" height="18" x="2" y="3" rx="2" />
     <path d="M9 3v18" />
   </svg>
-);
+)) as unknown as React.FC;
 
 /** Mirror — vertical bar near the RIGHT edge for the right-side panel. */
-export const SidebarRightIcon: React.FC = () => (
+export const SidebarRightIcon = ((): React.ReactElement => (
   <svg
     viewBox="0 0 24 24"
     fill="none"
@@ -37,4 +40,4 @@ export const SidebarRightIcon: React.FC = () => (
     <rect width="20" height="18" x="2" y="3" rx="2" />
     <path d="M15 3v18" />
   </svg>
-);
+)) as unknown as React.FC;

--- a/app/packages/tiling/src/views/TilingInspectorSidebar/TilingInspectorSidebar.stories.tsx
+++ b/app/packages/tiling/src/views/TilingInspectorSidebar/TilingInspectorSidebar.stories.tsx
@@ -14,7 +14,7 @@ type Story = StoryObj<typeof TilingInspectorSidebar>;
 
 function AutoFocus({ id }: { id: string }) {
   const { setFocusedTileId } = useTiling();
-  // setFocusedTileId is a stable Jotai setter; not in deps by design.
+  // setFocusedTileId is a stable useState setter; omitted from deps per project convention.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => setFocusedTileId(id), [id]);
   return null;
@@ -22,7 +22,7 @@ function AutoFocus({ id }: { id: string }) {
 
 function EmitSelection({ payload }: { payload: unknown }) {
   const setSelection = useSetTileSelection();
-  // setSelection is a stable Jotai setter; not in deps by design.
+  // setSelection is stable (useCallback with empty deps); omitted per project convention.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => setSelection(payload), [payload]);
   return null;


### PR DESCRIPTION
## Summary

Post-sprint cleanup for `app/packages/tiling` addressing lint suppressions and a no-any policy violation identified in the sprint review.

**`TilingHeader.tsx`**
- Removed two `@ts-explicit-any` suppression comments (`leadingIcon={SidebarLeftIcon as any}` / `SidebarRightIcon`). The cast is now isolated to the declaration in `tiling-header-icons.tsx`.
- Removed `eslint-disable react-hooks/exhaustive-deps` on the tile menu `useMemo`. Added `addTile` and `autoLayout` to the dep array — both are `useCallback(fn, [])` in `TilingProvider` so this is safe and makes the deps exhaustive.

**`tiling-header-icons.tsx`**
- Moved the React 17/18 `FC` type mismatch cast from the two usage sites in `TilingHeader` to the declaration site, per the project's no-`any` policy. Cast is typed as `React.FC` (not `any`) with a comment explaining the constraint and a TODO to remove it once the icons are part of the voodo design system.

**`TilingInspectorSidebar.stories.tsx` / `TileSettingsSidebar.stories.tsx`**
- `eslint-disable react-hooks/exhaustive-deps` suppressions retained (per project convention for stable callbacks), but replaced with explicit reason comments explaining why the stable setter is intentionally omitted.

## Test plan

- [ ] `cd app/packages/tiling && npx vitest run` — all 55 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved sidebar toggle icon exports for more robust/compatible rendering.
  * Adjusted header menu memoization so the tile menu reliably updates when related actions change.
* **Documentation**
  * Clarified in-code comments about stable state setters used in hooks (no behavior changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2855
<!-- enterprise-sync-pr:end -->