### PR TITLE
docs: add 1.17.0 release note for GHSA-q78p-hj9h-5466

### DIFF
--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -57,6 +57,9 @@ Security
   CVE-2026-27904), ``protobufjs`` (>=7.6, CVE-2026-41242), and
   ``brace-expansion`` (>=5.0.6, CVE-2026-33750)
   `#7694 <https://github.com/voxel51/fiftyone/pull/7694>`_
+- Made the App server's CORS policy configurable via ``allowed_origins`` and
+  changed the default to same-origin
+  `GHSA-q78p-hj9h-5466 <https://github.com/advisories/GHSA-q78p-hj9h-5466>`_
 
 General
 

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -5,7 +5,7 @@ FiftyOne Release Notes
 
 FiftyOne Enterprise 2.20.0
 --------------------------
-*Released June 3, 2026*
+*Released June 4, 2026*
 
 Includes all updates from :ref:`FiftyOne 1.17.0 <release-notes-v1.17.0>`. No
 additional Enterprise-specific changes in this release.
@@ -15,7 +15,7 @@ additional Enterprise-specific changes in this release.
 
 FiftyOne 1.17.0
 ---------------
-*Released June 3, 2026*
+*Released June 4, 2026*
 
 App
 


### PR DESCRIPTION
Adds a release note to the FiftyOne 1.17.0 Security section for the configurable-CORS fix (GHSA-q78p-hj9h-5466), which shipped via the security advisory merge to `release/v1.17.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release dates for FiftyOne Enterprise 2.20.0 and FiftyOne 1.17.0 to June 4, 2026.

* **Security**
  * App server CORS policy is now configurable via the `allowed_origins` parameter, with same-origin set as the new default for cross-origin requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2809
<!-- enterprise-sync-pr:end -->