### PR TITLE
[chore] Tiling pkg - improve test coverage

### DIFF
--- a/app/packages/tiling/src/lib/TilingProvider.test.tsx
+++ b/app/packages/tiling/src/lib/TilingProvider.test.tsx
@@ -152,6 +152,59 @@ describe("TilingProvider", () => {
     });
   });
 
+  describe("initialLayout prop", () => {
+    it("uses the provided initialLayout instead of auto-laying out", () => {
+      const initialTiles = {
+        "a-1": makeTile("a"),
+        "b-1": makeTile("b"),
+      };
+      const explicitLayout = "a-1";
+      const { result } = renderHook(() => useTiling(), {
+        wrapper: ({ children }) => (
+          <TilingProvider
+            initialTiles={initialTiles}
+            initialLayout={explicitLayout}
+          >
+            {children}
+          </TilingProvider>
+        ),
+      });
+      expect(result.current.layout).toBe("a-1");
+    });
+  });
+
+  describe("setTileTitle", () => {
+    it("updates the title of a registered tile", () => {
+      const { result } = renderHook(() => useTiling(), {
+        wrapper: ({ children }) => (
+          <Wrapper initialTiles={{ "cam-1": makeTile("Camera") }}>
+            {children}
+          </Wrapper>
+        ),
+      });
+      act(() => {
+        result.current.setTileTitle("cam-1", "Front Camera");
+      });
+      expect(result.current.tiles["cam-1"].title).toBe("Front Camera");
+    });
+
+    it("is a no-op when the title is unchanged", () => {
+      const { result } = renderHook(() => useTiling(), {
+        wrapper: ({ children }) => (
+          <Wrapper initialTiles={{ "cam-1": makeTile("Camera") }}>
+            {children}
+          </Wrapper>
+        ),
+      });
+      const before = result.current.tiles["cam-1"];
+      act(() => {
+        result.current.setTileTitle("cam-1", "Camera");
+      });
+      // Reference-equal — no re-render triggered.
+      expect(result.current.tiles["cam-1"]).toBe(before);
+    });
+  });
+
   describe("removeTile", () => {
     it("drops the tile from the tiles map and the layout", () => {
       const { result } = renderHook(() => useTiling(), {
@@ -198,6 +251,43 @@ describe("TilingProvider", () => {
         result.current.removeTile("a-1");
       });
       expect(result.current.focusedTileId).toBe("b-1");
+    });
+
+    it("collapses the split when removing the second of two tiles", () => {
+      // Removing "b-1" from {row, "a-1", "b-1"} should collapse to just "a-1".
+      const initialTiles = { "a-1": makeTile("a"), "b-1": makeTile("b") };
+      const { result } = renderHook(() => useTiling(), {
+        wrapper: ({ children }) => (
+          <Wrapper initialTiles={initialTiles}>{children}</Wrapper>
+        ),
+      });
+      act(() => {
+        result.current.removeTile("b-1");
+      });
+      expect(result.current.layout).toBe("a-1");
+      expect(result.current.tiles["b-1"]).toBeUndefined();
+    });
+
+    it("preserves the sibling subtree when removing a leaf from a deeper split", () => {
+      // 3-tile layout: {row, "a-1", {col, "b-1", "c-1"}}
+      // Removing "c-1" → {row, "a-1", "b-1"} — both children survive so the
+      // root split node is reconstructed (not collapsed).
+      const initialTiles = {
+        "a-1": makeTile("a"),
+        "b-1": makeTile("b"),
+        "c-1": makeTile("c"),
+      };
+      const { result } = renderHook(() => useTiling(), {
+        wrapper: ({ children }) => (
+          <Wrapper initialTiles={initialTiles}>{children}</Wrapper>
+        ),
+      });
+      act(() => {
+        result.current.removeTile("c-1");
+      });
+      expect(result.current.tiles["c-1"]).toBeUndefined();
+      expect(result.current.tiles["a-1"]).toBeDefined();
+      expect(result.current.tiles["b-1"]).toBeDefined();
     });
 
     it("is a no-op when removing an unknown id", () => {
@@ -259,6 +349,17 @@ describe("TilingProvider", () => {
       });
       expect(result.current.tiles).toEqual(initialTiles);
       expect(result.current.layout).not.toBeNull();
+    });
+  });
+
+  describe("useTiling guard", () => {
+    it("throws when called outside a TilingProvider", () => {
+      const consoleError = console.error;
+      console.error = () => {};
+      expect(() => renderHook(() => useTiling())).toThrow(
+        "useTiling must be used inside <TilingProvider>"
+      );
+      console.error = consoleError;
     });
   });
 

--- a/app/packages/tiling/src/lib/use-tile-state.test.tsx
+++ b/app/packages/tiling/src/lib/use-tile-state.test.tsx
@@ -8,8 +8,11 @@ import type { RegisteredTile } from "./types";
 import { useTileRegistry } from "./use-tile-registry";
 import {
   useSetTileSelection,
+  useSetTileTitle,
   useTileSelection,
   useTileSelectionFor,
+  useTileTitle,
+  useTileTitleFor,
   useTileTypes,
 } from "./use-tile-state";
 
@@ -107,6 +110,107 @@ describe("useTileSelection / useTileSelectionFor / useSetTileSelection", () => {
       wrapper: makePlainWrap(),
     });
     expect(result.current).toBeNull();
+  });
+});
+
+describe("useTileTitle / useTileTitleFor / useSetTileTitle", () => {
+  afterEach(() => cleanup());
+
+  it("useTileTitle returns null when outside a TileIdScope", () => {
+    const { result } = renderHook(
+      () => ({ title: useTileTitle() }),
+      { wrapper: makePlainWrap() }
+    );
+    expect(result.current.title).toBeNull();
+  });
+
+  it("useTileTitle returns the tile's current title when scoped", () => {
+    const store = createStore();
+    const { result } = renderHook(
+      () => ({ title: useTileTitle() }),
+      {
+        wrapper: ({ children }) => (
+          <JotaiProvider store={store}>
+            <TilingProvider initialTiles={{ "cam-1": { title: "Camera", render: () => null } }}>
+              <TileIdScope tileId="cam-1">{children}</TileIdScope>
+            </TilingProvider>
+          </JotaiProvider>
+        ),
+      }
+    );
+    expect(result.current.title).toBe("Camera");
+  });
+
+  it("useTileTitleFor returns null for a null tileId", () => {
+    const { result } = renderHook(
+      () => ({ title: useTileTitleFor(null) }),
+      { wrapper: makePlainWrap() }
+    );
+    expect(result.current.title).toBeNull();
+  });
+
+  it("useTileTitleFor returns the title for an explicit tileId", () => {
+    const store = createStore();
+    const { result } = renderHook(
+      () => ({ title: useTileTitleFor("cam-1") }),
+      {
+        wrapper: ({ children }) => (
+          <JotaiProvider store={store}>
+            <TilingProvider initialTiles={{ "cam-1": { title: "Camera", render: () => null } }}>
+              {children}
+            </TilingProvider>
+          </JotaiProvider>
+        ),
+      }
+    );
+    expect(result.current.title).toBe("Camera");
+  });
+
+  it("useSetTileTitle updates the tile's title", () => {
+    const store = createStore();
+    const { result } = renderHook(
+      () => ({
+        setTitle: useSetTileTitle(),
+        title: useTileTitleFor("cam-1"),
+      }),
+      {
+        wrapper: ({ children }) => (
+          <JotaiProvider store={store}>
+            <TilingProvider initialTiles={{ "cam-1": { title: "Camera", render: () => null } }}>
+              <TileIdScope tileId="cam-1">{children}</TileIdScope>
+            </TilingProvider>
+          </JotaiProvider>
+        ),
+      }
+    );
+    expect(result.current.title).toBe("Camera");
+    act(() => {
+      result.current.setTitle("Front Camera");
+    });
+    expect(result.current.title).toBe("Front Camera");
+  });
+
+  it("useSetTileTitle is a no-op when called outside a TileIdScope", () => {
+    const store = createStore();
+    const { result } = renderHook(
+      () => ({
+        setTitle: useSetTileTitle(),
+        title: useTileTitleFor("cam-1"),
+      }),
+      {
+        wrapper: ({ children }) => (
+          <JotaiProvider store={store}>
+            <TilingProvider initialTiles={{ "cam-1": { title: "Camera", render: () => null } }}>
+              {children}
+            </TilingProvider>
+          </JotaiProvider>
+        ),
+      }
+    );
+    act(() => {
+      result.current.setTitle("Should Not Change");
+    });
+    expect(result.current.title).toBe("Camera");
   });
 });
 

--- a/app/packages/tiling/src/views/MosaicGrid/MosaicGrid.test.tsx
+++ b/app/packages/tiling/src/views/MosaicGrid/MosaicGrid.test.tsx
@@ -71,6 +71,12 @@ describe("MosaicGrid pure helpers", () => {
       const next = addTileToLayout(layout, "d", "ghost");
       expect(collectTileIds(next).sort()).toEqual(["a", "b", "c", "d"]);
     });
+
+    it("throws when the new id already exists in the layout", () => {
+      expect(() => addTileToLayout("a", "a")).toThrow(
+        'Tile id "a" already exists in layout'
+      );
+    });
   });
 });
 

--- a/app/packages/tiling/src/views/TilingHeader/TilingHeader.test.tsx
+++ b/app/packages/tiling/src/views/TilingHeader/TilingHeader.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { IconName } from "@voxel51/voodo";
 import React, { useEffect } from "react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { TilingProvider, useTiling } from "../../lib/TilingProvider";
 import type { RegisteredTile } from "../../lib/types";
@@ -31,7 +31,19 @@ const RegisterTiles: React.FC<{ entries: RegisteredTile[] }> = ({
 };
 
 describe("TilingHeader", () => {
-  afterEach(() => cleanup());
+  beforeEach(() => {
+    // voodo's Dropdown (headlessui Menu) uses ResizeObserver internally.
+    global.ResizeObserver = vi.fn().mockImplementation(() => ({
+      observe: vi.fn(),
+      unobserve: vi.fn(),
+      disconnect: vi.fn(),
+    }));
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
 
   it("renders the filename and no add-tile menu when nothing is registered", () => {
     render(

--- a/app/packages/tiling/src/views/TilingHeader/TilingHeader.test.tsx
+++ b/app/packages/tiling/src/views/TilingHeader/TilingHeader.test.tsx
@@ -3,10 +3,16 @@ import { IconName } from "@voxel51/voodo";
 import React, { useEffect } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { TilingProvider } from "../../lib/TilingProvider";
+import { TilingProvider, useTiling } from "../../lib/TilingProvider";
 import type { RegisteredTile } from "../../lib/types";
 import { useTileRegistry } from "../../lib/use-tile-registry";
 import TilingHeader from "./TilingHeader";
+
+// Reads the current tile count so tests can assert addTile was called.
+const TileCount: React.FC = () => {
+  const { tiles } = useTiling();
+  return <span data-testid="tile-count">{Object.keys(tiles).length}</span>;
+};
 
 const CameraTile: React.FC = () => <div data-testid="camera-body" />;
 const LidarTile: React.FC = () => <div data-testid="lidar-body" />;
@@ -98,5 +104,31 @@ describe("TilingHeader", () => {
       </TilingProvider>
     );
     expect(screen.getByTestId("tiling-header-add-tile")).toBeTruthy();
+  });
+
+  it("clicking a menu item calls addTile with the registered tile type", () => {
+    render(
+      <TilingProvider>
+        <RegisterTiles
+          entries={[
+            {
+              type: "camera",
+              typeLabel: "Camera",
+              icon: IconName.GridView,
+              Tile: CameraTile,
+            },
+          ]}
+        />
+        <TilingHeader fileName="x" />
+        <TileCount />
+      </TilingProvider>
+    );
+    expect(screen.getByTestId("tile-count").textContent).toBe("0");
+
+    // Open the dropdown and click the Camera menu item.
+    fireEvent.click(screen.getByTestId("tiling-header-add-tile"));
+    fireEvent.click(screen.getByText("Camera"));
+
+    expect(screen.getByTestId("tile-count").textContent).toBe("1");
   });
 });

--- a/app/packages/tiling/src/views/TilingInspectorSidebar/TilingInspectorSidebar.test.tsx
+++ b/app/packages/tiling/src/views/TilingInspectorSidebar/TilingInspectorSidebar.test.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -84,6 +84,42 @@ describe("TilingInspectorSidebar", () => {
     // by tag instead so the pretty-printed indentation is preserved.
     const pre = screen.getByText(
       (_text, node) => node?.tagName === "PRE" && node.textContent === json
+    );
+    expect(pre).toBeTruthy();
+  });
+
+  it("renders the Annotate tab content when the Annotate tab is clicked", () => {
+    render(
+      <TilingProvider>
+        <TilingInspectorSidebar />
+      </TilingProvider>
+    );
+    fireEvent.click(screen.getByRole("tab", { name: "Annotate" }));
+    expect(screen.getByText("Annotation workflows are coming soon.")).toBeTruthy();
+  });
+
+  it("falls back to String() when the selection cannot be JSON-serialised", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    render(
+      <TilingProvider
+        initialTiles={{ "graph-1": { title: "g", render: () => null } }}
+      >
+        <TileIdScope tileId="graph-1">
+          <Selector payload={circular} />
+        </TileIdScope>
+        <FocusButton id="graph-1" />
+        <TilingInspectorSidebar />
+      </TilingProvider>
+    );
+    act(() => {
+      screen.getByTestId("focus-graph-1").click();
+      screen.getByTestId("emit-selection").click();
+    });
+    // JSON.stringify throws on circular refs → formatSelection returns String(value).
+    const pre = screen.getByText(
+      (_text, node) => node?.tagName === "PRE" && node.textContent === "[object Object]"
     );
     expect(pre).toBeTruthy();
   });


### PR DESCRIPTION
## Summary

Fills coverage gaps across `app/packages/tiling` identified in the post-sprint review. 16 new tests across 5 existing test files.

**Coverage before → after** (excluding stories):

| File | Before | After |
|------|--------|-------|
| `TilingProvider.tsx` | 93% | 100% |
| `use-tile-state.ts` | 71% | 100% |
| `TilingHeader.tsx` | 92% | 100% |
| `TilingInspectorSidebar.tsx` | 94% | 100% |
| **Overall** | **83%** | **88%** |

**What was added:**

- **`TilingProvider.test.tsx`** — explicit `initialLayout` prop; `setTileTitle` (update + no-op when unchanged); `removeTile` collapsing a split when the second of two tiles is removed; `removeTile` on a 3-tile layout where the sibling subtree survives; `useTiling()` error throw outside provider.
- **`use-tile-state.test.tsx`** — `useTileTitle` (scoped and unscoped); `useTileTitleFor` (explicit id and null id); `useSetTileTitle` (updates title, no-op outside scope).
- **`MosaicGrid.test.tsx`** — `addTileToLayout` throws when the new id already exists in the layout.
- **`TilingHeader.test.tsx`** — clicking a dropdown menu item calls `addTile` and adds the tile to the provider.
- **`TilingInspectorSidebar.test.tsx`** — Annotate tab renders its content; `formatSelection` falls back to `String()` for non-JSON-serialisable values (circular reference).

**Still at 0%**: `src/index.ts` (barrel export, not meaningful to test). `MosaicGrid.tsx` component code (61%) — the `TileWindow` component and drag/expand/close handlers depend on `react-mosaic-component`'s DnD backend which doesn't function in jsdom; left for integration tests.

## Test plan

- [ ] `cd app/packages/tiling && npx vitest run` — all 71 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for tile layout provider with validation of layout behavior, tile title updates, and tile removal scenarios.
  * Added tests for tile state and title management hooks.
  * Introduced test for duplicate tile ID detection in layout operations.
  * Enhanced header tests with tile addition workflow validation.
  * Improved sidebar tests for tab navigation and JSON serialization edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2858
<!-- enterprise-sync-pr:end -->