### PR TITLE
'erase' should not create new detections

### DIFF
--- a/app/packages/lighter/src/interaction/InteractionManager.ts
+++ b/app/packages/lighter/src/interaction/InteractionManager.ts
@@ -10,6 +10,7 @@ import { TypeGuards } from "../core/Scene2D";
 import type { LighterEventGroup } from "../events";
 import {
   SegmentationTool,
+  SegmentationToolMode,
   type SegmentationToolState,
 } from "@fiftyone/core/src/components/Modal/Sidebar/Annotate/Edit/useSegmentationMode";
 import { DetectionOverlay } from "../overlay/DetectionOverlay";
@@ -532,9 +533,18 @@ export class InteractionManager {
     const pending = this.pendingAction;
     this.pendingAction = undefined;
 
+    const hasSelection = this.selectionManager.getSelectionCount() > 0;
     const editingSegmentation =
+      segmentationModeBridge.isActive() && hasSelection;
+
+    // Erase with nothing selected is a no-op
+    if (
       segmentationModeBridge.isActive() &&
-      this.selectionManager.getSelectionCount() > 0;
+      !hasSelection &&
+      segmentationModeBridge.getToolMode() === SegmentationToolMode.Remove
+    ) {
+      return true;
+    }
 
     if (!editingSegmentation) {
       this.eventBus.dispatch("lighter:overlay-create", {


### PR DESCRIPTION
## 🔗 Related Issues

https://voxel51.atlassian.net/browse/FOEPD-3894?actionerId=5fa17675b5dd5a0071e9733d&sourceType=assign

## 📋 What changes are proposed in this pull request?

If a segmentation tool is set to 'erase'  and no detection is selected do not create a new detection, just no-op.

## 🧪 How is this patch tested? If it is not, please explain why.

manually

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Using a segmentation tool set to 'erase' with no detection selected will no longer create a new detection.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved segmentation mode efficiency by preventing unnecessary overlay operations when no selection exists, reducing redundant processing during remove operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2831
<!-- enterprise-sync-pr:end -->