### PR TITLE
ci: gate enterprise sync to develop and release/* branches

### DIFF
--- a/.github/workflows/enterprise-sync.yml
+++ b/.github/workflows/enterprise-sync.yml
@@ -3,6 +3,9 @@ name: Enterprise Sync
 on:
   pull_request:
     types: [opened, synchronize, reopened, closed, ready_for_review]
+    branches:
+      - develop
+      - release/*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -11,9 +14,7 @@ concurrency:
 jobs:
   enterprise-sync:
     if: >-
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      (github.event.pull_request.head.ref == 'develop' ||
-      startsWith(github.event.pull_request.head.ref, 'release/')) && (
+      github.event.pull_request.head.repo.full_name == github.repository && (
       github.event.action == 'closed' ||
       github.event.pull_request.draft != true)
     runs-on: ubuntu-latest

--- a/.github/workflows/enterprise-sync.yml
+++ b/.github/workflows/enterprise-sync.yml
@@ -13,7 +13,11 @@ concurrency:
 
 jobs:
   enterprise-sync:
+    # Only the OSS repo dispatches to Enterprise. The Enterprise repo carries an
+    # identical copy of this file (via OSS sync) where this guard makes it inert,
+    # so the file never diverges and never produces a sync conflict.
     if: >-
+      github.repository == 'voxel51/fiftyone' &&
       github.event.pull_request.head.repo.full_name == github.repository && (
       github.event.action == 'closed' ||
       github.event.pull_request.draft != true)

--- a/.github/workflows/enterprise-sync.yml
+++ b/.github/workflows/enterprise-sync.yml
@@ -1,0 +1,56 @@
+name: Enterprise Sync
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed, ready_for_review]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  enterprise-sync:
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (github.event.pull_request.head.ref == 'develop' ||
+      startsWith(github.event.pull_request.head.ref, 'release/')) && (
+      github.event.action == 'closed' ||
+      github.event.pull_request.draft != true)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.FIFTYONE_GITHUB_TOKEN }}
+          script: |
+            const sha = context.payload.pull_request.head.sha;
+
+            // Post `enterprise / ci = pending` on the PR head immediately so
+            // the required check appears on the PR without waiting for the
+            // Enterprise sync workflow to start. The Enterprise workflow
+            // overwrites this status with `success` or `failure` once it
+            // finishes. Skip for closed PRs — the OSS PR is past the gate.
+            if (context.payload.action !== 'closed') {
+              await github.rest.repos.createCommitStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                sha,
+                state: 'pending',
+                context: 'enterprise / ci',
+                description: 'Awaiting Enterprise sync workflow…',
+              });
+            }
+
+            await github.rest.repos.createDispatchEvent({
+              owner: 'voxel51',
+              repo: 'fiftyone-teams',
+              event_type: 'oss-pr-sync',
+              client_payload: {
+                action: context.payload.action,
+                branch: context.payload.pull_request.head.ref,
+                author: context.payload.pull_request.user.login,
+                pr_number: context.payload.pull_request.number,
+                commit_sha: sha,
+                base: context.payload.pull_request.base.ref,
+                merged: context.payload.pull_request.merged ?? false,
+              }
+            });

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -72,50 +72,6 @@ jobs:
       needs.modified-files.outputs.fiftyone-changes == 'true')
     uses: ./.github/workflows/lint-app.yml
 
-  enterprise-sync:
-    if: >-
-      github.event.pull_request.head.repo.full_name == github.repository && (
-      github.event.action == 'closed' ||
-      github.event.pull_request.draft != true)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/github-script@v9
-        with:
-          github-token: ${{ secrets.FIFTYONE_GITHUB_TOKEN }}
-          script: |
-            const sha = context.payload.pull_request.head.sha;
-
-            // Post `enterprise / ci = pending` on the PR head immediately so
-            // the required check appears on the PR without waiting for the
-            // Enterprise sync workflow to start. The Enterprise workflow
-            // overwrites this status with `success` or `failure` once it
-            // finishes. Skip for closed PRs — the OSS PR is past the gate.
-            if (context.payload.action !== 'closed') {
-              await github.rest.repos.createCommitStatus({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                sha,
-                state: 'pending',
-                context: 'enterprise / ci',
-                description: 'Awaiting Enterprise sync workflow…',
-              });
-            }
-
-            await github.rest.repos.createDispatchEvent({
-              owner: 'voxel51',
-              repo: 'fiftyone-teams',
-              event_type: 'oss-pr-sync',
-              client_payload: {
-                action: context.payload.action,
-                branch: context.payload.pull_request.head.ref,
-                author: context.payload.pull_request.user.login,
-                pr_number: context.payload.pull_request.number,
-                commit_sha: sha,
-                base: context.payload.pull_request.base.ref,
-                merged: context.payload.pull_request.merged ?? false,
-              }
-            });
-
   test:
     needs: modified-files
     if: >-


### PR DESCRIPTION
## What

Moves the `enterprise-sync` job out of `pr.yml` into its own dedicated `enterprise-sync.yml` workflow, and restricts it via the workflow's `on:` branch filter to run only for PRs targeting `develop` or `release/*`.

## Why

The job dispatches an `oss-pr-sync` `repository_dispatch` to `voxel51/fiftyone-teams`, which attempts to merge the OSS branch into the corresponding `oss-sync/<branch>` Enterprise branch. Previously it ran for **every** internal (non-fork) PR, producing noise and spurious "Enterprise sync workflow failed" comments (e.g. voxel51/fiftyone#7735).

## Changes

- New `.github/workflows/enterprise-sync.yml` containing the job (same `pull_request` types, its own concurrency group).
- `on: pull_request.branches` restricted to `develop` and `release/*` (matches the PR **base** branch).
- Removed the `enterprise-sync` job from `pr.yml`.

The job-level `if` retains only the fork guard and the draft/closed logic. Dispatch payload and pending-status posting are otherwise unchanged.

> Note: `on.pull_request.branches` filters on the **base** branch, so this fires for PRs *targeting* `develop`/`release/*`.

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2836
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized continuous integration workflows to separate enterprise synchronization logic into a dedicated workflow for improved maintainability and clearer separation of concerns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->