### PR TITLE
[FOEPD-3738] Persist dataset media type

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -9399,6 +9399,14 @@ def _create_dataset(
 ):
     slug = _validate_dataset_name(name)
 
+    if media_type is not None and (
+        not isinstance(media_type, str) or media_type not in fom.MEDIA_TYPES
+    ):
+        raise ValueError(
+            "Invalid media type '%s'. Must be one of %s"
+            % (media_type, sorted(fom.MEDIA_TYPES))
+        )
+
     _id = ObjectId()
     now = datetime.utcnow()
 

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -347,6 +347,9 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         if not _virtual:
             self._update_last_loaded_at()
 
+        if doc.media_type:
+            self._set_media_type(doc.media_type)
+
     def __eq__(self, other):
         return type(other) == type(self) and self.name == other.name
 

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -348,7 +348,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             self._update_last_loaded_at()
 
         if doc.media_type:
-            self._set_media_type(doc.media_type)
+            self._configure_media_type(doc.media_type)
 
     def __eq__(self, other):
         return type(other) == type(self) and self.name == other.name
@@ -475,15 +475,28 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         if self._contains_videos(any_slice=True):
             self._init_frames()
 
+        should_reload = self._configure_media_type(media_type)
+        self.save()
+        if should_reload:
+            self.reload()
+
+    def _configure_media_type(self, media_type):
+        """
+        Return:
+            True/False whether when a save is done a reload should also be done
+        """
+        self._doc.media_type = media_type
+
+        if self._contains_videos(any_slice=True):
+            self._init_frames()
+
         if media_type == fom.GROUP:
             # The `metadata` field of group datasets always stays as the
             # generic `Metadata` type because slices may have different types
-            self.save()
+            return False
         else:
             self._update_metadata_field(media_type)
-
-            self.save()
-            self.reload()
+            return True
 
     def _update_metadata_field(self, media_type):
         idx = None

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -18,7 +18,6 @@ import os
 import random
 import string
 from datetime import datetime
-from typing import Optional
 
 import cachetools
 import eta.core.serial as etas
@@ -9388,6 +9387,7 @@ def _create_dataset(
     obj,
     name,
     persistent=False,
+    media_type=None,
     _patches=False,
     _frames=False,
     _clips=False,
@@ -9427,7 +9427,7 @@ def _create_dataset(
         version=focn.VERSION,
         created_at=now,
         last_modified_at=now,
-        media_type=None,  # will be inferred when first sample is added
+        media_type=media_type,
         sample_collection_name=sample_collection_name,
         frame_collection_name=frame_collection_name,
         persistent=persistent,

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -18,6 +18,7 @@ import os
 import random
 import string
 from datetime import datetime
+from typing import Optional
 
 import cachetools
 import eta.core.serial as etas

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -4898,6 +4898,15 @@ class DatasetTests(unittest.TestCase):
                 dataset3.static_transforms, dataset.static_transforms
             )
 
+    @drop_datasets
+    def test_media_type(self):
+        dataset = fo.Dataset("test_media_type", media_type="custom_media_type")
+        assert dataset.media_type == "custom_media_type"
+
+        del fo.Dataset._instances["test_media_type"]
+        dataset2 = fo.load_dataset("test_media_type")
+        assert dataset2.media_type == "custom_media_type"
+
     def _assert_camera_intrinsics_equal(self, actual, expected):
         self.assertEqual(set(actual.keys()), set(expected.keys()))
 

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -4901,12 +4901,12 @@ class DatasetTests(unittest.TestCase):
 
     @drop_datasets
     def test_media_type(self):
-        dataset = fo.Dataset("test_media_type", media_type="custom_media_type")
-        assert dataset.media_type == "custom_media_type"
+        dataset = fo.Dataset("test_media_type", media_type=fom.IMAGE)
+        assert dataset.media_type == fom.IMAGE
 
         del fo.Dataset._instances["test_media_type"]
         dataset2 = fo.load_dataset("test_media_type")
-        assert dataset2.media_type == "custom_media_type"
+        assert dataset2.media_type == fom.IMAGE
 
     @drop_datasets
     def test_media_type_side_effects(self):
@@ -4922,6 +4922,11 @@ class DatasetTests(unittest.TestCase):
             metadata.embedded_doc_type
             == "fiftyone.core.metadata.ImageMetadata"
         )
+
+    @drop_datasets
+    def test_media_type_validated(self):
+        with self.assertRaises(ValueError):
+            fo.Dataset("test_media_type", media_type="not_a_valid_media_type")
 
     def _assert_camera_intrinsics_equal(self, actual, expected):
         self.assertEqual(set(actual.keys()), set(expected.keys()))

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -29,6 +29,7 @@ import fiftyone as fo
 import fiftyone.core.fields as fof
 import fiftyone.core.odm as foo
 import fiftyone.core.utils as fou
+import fiftyone.core.media as fom
 import fiftyone.utils.data as foud
 from fiftyone import ViewField as F
 from fiftyone.operators.store import ExecutionStoreService
@@ -4906,6 +4907,21 @@ class DatasetTests(unittest.TestCase):
         del fo.Dataset._instances["test_media_type"]
         dataset2 = fo.load_dataset("test_media_type")
         assert dataset2.media_type == "custom_media_type"
+
+    @drop_datasets
+    def test_media_type_side_effects(self):
+        dataset = fo.Dataset("test_media_type", media_type=fom.IMAGE)
+
+        metadata = next(
+            field
+            for field in dataset._doc.sample_fields
+            if field.name == "metadata"
+        )
+
+        assert (
+            metadata.embedded_doc_type
+            == "fiftyone.core.metadata.ImageMetadata"
+        )
 
     def _assert_camera_intrinsics_equal(self, actual, expected):
         self.assertEqual(set(actual.keys()), set(expected.keys()))


### PR DESCRIPTION
## 🔗 Related Issues

- [FOEPD-3738](https://voxel51.atlassian.net/browse/FOEPD-3738)
- [FOEPD-3937](https://voxel51.atlassian.net/browse/FOEPD-3937)

## 📋 What changes are proposed in this pull request?

Persist `media_type` passed to a new Dataset and set it on the dataset when it's loaded.

## 🧪 How is this patch tested? If it is not, please explain why.

Unit test

Can test persist a `media_type` to the DB with this script:
```python
import fiftyone as fo
ds = fo.Dataset('test', media_type='something')
ds.save()
```

Then query Mongo:
```bash
mongosh $DB_NAME --eval 'db.datasets.findOne({name: "test"}).media_type'
```

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

A dataset's `media_type` is now persisted to the DB.

### What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [x] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other

[FOEPD-3738]: https://voxel51.atlassian.net/browse/FOEPD-3738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOEPD-3937]: https://voxel51.atlassian.net/browse/FOEPD-3937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dataset media type is now recorded at creation and persists correctly after reloads.
  * Initializing a dataset with an explicit image media type properly configures sample metadata.
  * Passing an invalid media type now raises a clear validation error.

* **Tests**
  * Added unit tests verifying media-type persistence, metadata initialization, and validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2841
<!-- enterprise-sync-pr:end -->