### PR TITLE
Allow adding ontology when creating a field

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/ApplyOntologySection.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/ApplyOntologySection.tsx
@@ -1,87 +1,25 @@
-import {
-  Orientation,
-  Size,
-  Spacing,
-  Stack,
-  Text,
-  TextColor,
-  TextVariant,
-  Toggle,
-} from "@voxel51/voodo";
-import { useState } from "react";
-import { useConfirmDisconnectOntology } from "../../Confirmation/useConfirmDisconnectOntology";
-import OntologyPicker from "./OntologyPicker";
+import OntologySection from "./OntologySection";
 import { useAppliedOntology } from "./useLabelSchema";
-import { ONTOLOGY_TYPE, useOntologies } from "./useOntologies";
 
 interface ApplyOntologySectionProps {
   field: string;
 }
 
+/**
+ * Edit-flow ontology picker: wires the live schema state from
+ * {@link useAppliedOntology} into the shared {@link OntologySection}.
+ */
 const ApplyOntologySection = ({ field }: ApplyOntologySectionProps) => {
   const { appliedOntology, ontologyAttributes, applyOntology, clearOntology } =
     useAppliedOntology(field);
-  const { ontologies, isFetching, error } = useOntologies(
-    ONTOLOGY_TYPE.ontology
-  );
-  const [pickerArmed, setPickerArmed] = useState(false);
-
-  const expanded = !!appliedOntology || pickerArmed;
-
-  const { confirmDisconnect, DisconnectOntologyModal } =
-    useConfirmDisconnectOntology(() => {
-      clearOntology();
-      setPickerArmed(false);
-    }, ontologyAttributes);
-
-  const handleToggle = (): void => {
-    if (expanded) {
-      if (appliedOntology) {
-        confirmDisconnect();
-      } else {
-        setPickerArmed(false);
-      }
-    } else {
-      setPickerArmed(true);
-    }
-  };
-
-  const handlePick = (value: string): void => {
-    applyOntology(value);
-    setPickerArmed(false);
-  };
 
   return (
-    <Stack
-      orientation={Orientation.Column}
-      spacing={Spacing.Xs}
-      style={{ marginTop: "1rem", marginBottom: "1rem" }}
-    >
-      <Stack
-        orientation={Orientation.Row}
-        spacing={Spacing.Sm}
-        style={{ alignItems: "center", justifyContent: "space-between" }}
-      >
-        <Text variant={TextVariant.Lg}>Ontology</Text>
-        <Toggle size={Size.Md} checked={expanded} onChange={handleToggle} />
-      </Stack>
-      <Text variant={TextVariant.Lg} color={TextColor.Secondary}>
-        {appliedOntology
-          ? `Chosen ontology: ${appliedOntology}`
-          : "When enabled, your schema will use attributes defined in the ontology."}
-      </Text>
-
-      {expanded && !appliedOntology && (
-        <OntologyPicker
-          type={ONTOLOGY_TYPE.ontology}
-          ontologies={ontologies}
-          isFetching={isFetching}
-          error={error}
-          onPick={handlePick}
-        />
-      )}
-      {DisconnectOntologyModal}
-    </Stack>
+    <OntologySection
+      appliedOntology={appliedOntology}
+      ontologyAttributes={ontologyAttributes}
+      onPick={applyOntology}
+      onClear={clearOntology}
+    />
   );
 };
 

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/OntologySection.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/OntologySection.tsx
@@ -10,10 +10,10 @@ import {
 } from "@voxel51/voodo";
 import { useState } from "react";
 import { useConfirmDisconnectOntology } from "../../Confirmation/useConfirmDisconnectOntology";
-import OntologyPicker from "../EditFieldLabelSchema/OntologyPicker";
-import { ONTOLOGY_TYPE, useOntologies } from "../EditFieldLabelSchema/useOntologies";
+import OntologyPicker from "./OntologyPicker";
+import { ONTOLOGY_TYPE, useOntologies } from "./useOntologies";
 
-interface NewFieldOntologySectionProps {
+interface OntologySectionProps {
   appliedOntology?: string;
   // Names of the ontology-owned attributes, shown in the disconnect modal.
   ontologyAttributes: string[];
@@ -22,19 +22,19 @@ interface NewFieldOntologySectionProps {
 }
 
 /**
- * Ontology picker for the new-field flow.
+ * Presentational ontology picker shared by the create and edit flows.
  *
- * A props-driven sibling of {@link ApplyOntologySection}: it owns no schema
- * state (the create form keeps that in local React state), and instead reports
- * picks/clears up to the parent. The picker, ontology list, and disconnect
- * confirmation are all shared with the edit flow.
+ * Owns no schema state: it reports picks/clears up to the caller, which wires
+ * in whatever state source it uses (local React state for the create form,
+ * the schema atom via {@link useAppliedOntology} for the edit form). The
+ * picker, ontology list, and disconnect confirmation are shared.
  */
-const NewFieldOntologySection = ({
+const OntologySection = ({
   appliedOntology,
   ontologyAttributes,
   onPick,
   onClear,
-}: NewFieldOntologySectionProps) => {
+}: OntologySectionProps) => {
   const { ontologies, isFetching, error } = useOntologies(
     ONTOLOGY_TYPE.ontology
   );
@@ -99,4 +99,4 @@ const NewFieldOntologySection = ({
   );
 };
 
-export default NewFieldOntologySection;
+export default OntologySection;

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/useLabelSchema.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/useLabelSchema.ts
@@ -6,7 +6,6 @@ import {
   useNotification,
   useQueryPerformanceSampleLimit,
 } from "@fiftyone/state";
-import { getFetchFunction } from "@fiftyone/utilities";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { isEqual } from "lodash";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -27,35 +26,7 @@ import {
   useSchemaManagerEventBus,
 } from "../events";
 import { currentLabelSchema } from "../state";
-import { type AttributeConfig, reconcileComponent } from "../utils";
-
-const fetchAndMergeOntologyAttributes = async (
-  draft: FieldSchema,
-  name: string,
-  setCurrent: (schema: FieldSchema) => void
-): Promise<void> => {
-  const result = await getFetchFunction()(
-    "GET",
-    `/ontologies/${encodeURIComponent(name)}/attributes`
-  );
-
-  const attrs = (result as { attributes: AttributeConfig[] }).attributes;
-  if (!attrs?.length) return;
-
-  const existing = Array.isArray(draft.attributes) ? [...draft.attributes] : [];
-  const byName = new Map(existing.map((a) => [a.name, a]));
-  const orderedNames = existing.map((a) => a.name);
-
-  for (const attr of attrs) {
-    if (!byName.has(attr.name)) orderedNames.push(attr.name);
-    byName.set(attr.name, attr);
-  }
-
-  setCurrent({
-    ...draft,
-    attributes: orderedNames.map((n) => byName.get(n)),
-  });
-};
+import { fetchAndMergeOntologyAttributes, reconcileComponent } from "../utils";
 
 // =============================================================================
 // Internal Hooks
@@ -167,10 +138,12 @@ export const useAppliedOntology = (field: string) => {
     applyOntology: (name: string) => {
       const draft = { ...(schema as FieldSchema), applied_ontology: name };
       setCurrent(draft);
-      fetchAndMergeOntologyAttributes(draft, name, setCurrent).catch(() => {
-        // Preview failed. The name is already set, attributes will hydrate after save
-        console.error(`Failed to fetch ontology attributes for ${name}`);
-      });
+      fetchAndMergeOntologyAttributes(draft.attributes ?? [], name)
+        .then((attributes) => setCurrent({ ...draft, attributes }))
+        .catch(() => {
+          // Preview failed. The name is already set, attributes will hydrate after save
+          console.error(`Failed to fetch ontology attributes for ${name}`);
+        });
     },
     clearOntology: () => {
       const next: FieldSchema = { ...(schema as FieldSchema) };

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/NewFieldSchema/NewFieldOntologySection.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/NewFieldSchema/NewFieldOntologySection.tsx
@@ -1,0 +1,102 @@
+import {
+  Orientation,
+  Size,
+  Spacing,
+  Stack,
+  Text,
+  TextColor,
+  TextVariant,
+  Toggle,
+} from "@voxel51/voodo";
+import { useState } from "react";
+import { useConfirmDisconnectOntology } from "../../Confirmation/useConfirmDisconnectOntology";
+import OntologyPicker from "../EditFieldLabelSchema/OntologyPicker";
+import { ONTOLOGY_TYPE, useOntologies } from "../EditFieldLabelSchema/useOntologies";
+
+interface NewFieldOntologySectionProps {
+  appliedOntology?: string;
+  // Names of the ontology-owned attributes, shown in the disconnect modal.
+  ontologyAttributes: string[];
+  onPick: (name: string) => void;
+  onClear: () => void;
+}
+
+/**
+ * Ontology picker for the new-field flow.
+ *
+ * A props-driven sibling of {@link ApplyOntologySection}: it owns no schema
+ * state (the create form keeps that in local React state), and instead reports
+ * picks/clears up to the parent. The picker, ontology list, and disconnect
+ * confirmation are all shared with the edit flow.
+ */
+const NewFieldOntologySection = ({
+  appliedOntology,
+  ontologyAttributes,
+  onPick,
+  onClear,
+}: NewFieldOntologySectionProps) => {
+  const { ontologies, isFetching, error } = useOntologies(
+    ONTOLOGY_TYPE.ontology
+  );
+  const [pickerArmed, setPickerArmed] = useState(false);
+
+  const expanded = !!appliedOntology || pickerArmed;
+
+  const { confirmDisconnect, DisconnectOntologyModal } =
+    useConfirmDisconnectOntology(() => {
+      onClear();
+      setPickerArmed(false);
+    }, ontologyAttributes);
+
+  const handleToggle = (): void => {
+    if (expanded) {
+      if (appliedOntology) {
+        confirmDisconnect();
+      } else {
+        setPickerArmed(false);
+      }
+    } else {
+      setPickerArmed(true);
+    }
+  };
+
+  const handlePick = (value: string): void => {
+    onPick(value);
+    setPickerArmed(false);
+  };
+
+  return (
+    <Stack
+      orientation={Orientation.Column}
+      spacing={Spacing.Xs}
+      style={{ marginTop: "1rem", marginBottom: "1rem" }}
+    >
+      <Stack
+        orientation={Orientation.Row}
+        spacing={Spacing.Sm}
+        style={{ alignItems: "center", justifyContent: "space-between" }}
+      >
+        <Text variant={TextVariant.Lg}>Ontology</Text>
+        <Toggle size={Size.Md} checked={expanded} onChange={handleToggle} />
+      </Stack>
+      <Text variant={TextVariant.Lg} color={TextColor.Secondary}>
+        {appliedOntology
+          ? `Chosen ontology: ${appliedOntology}`
+          : "When enabled, your schema will use attributes defined in the ontology."}
+      </Text>
+
+      {expanded && !appliedOntology && (
+        <OntologyPicker
+          type={ONTOLOGY_TYPE.ontology}
+          ontologies={ontologies}
+          isFetching={isFetching}
+          error={error}
+          onPick={handlePick}
+        />
+      )}
+      {DisconnectOntologyModal}
+    </Stack>
+  );
+};
+
+export default NewFieldOntologySection;

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/NewFieldSchema/NewFieldSchema.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/NewFieldSchema/NewFieldSchema.tsx
@@ -46,7 +46,7 @@ import {
   getLabelTypeOptions,
   validateFieldName,
 } from "../utils";
-import NewFieldOntologySection from "./NewFieldOntologySection";
+import OntologySection from "../EditFieldLabelSchema/OntologySection";
 
 import {
   ATTRIBUTE_TYPE_OPTIONS,
@@ -404,7 +404,7 @@ const NewFieldSchema = () => {
           {/* Label field config: Ontology, Classes and Attributes */}
           {category === "label" && (
             <>
-              <NewFieldOntologySection
+              <OntologySection
                 appliedOntology={appliedOntology}
                 ontologyAttributes={ontologyAttributes}
                 onPick={handleApplyOntology}

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/NewFieldSchema/NewFieldSchema.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/NewFieldSchema/NewFieldSchema.tsx
@@ -41,7 +41,12 @@ import ClassesSection from "../EditFieldLabelSchema/GUIContent/ClassesSection";
 import PrimitiveFieldContent from "../EditFieldLabelSchema/GUIContent/PrimitiveFieldContent";
 import Footer from "../Footer";
 import { ListContainer } from "../styled";
-import { getLabelTypeOptions, validateFieldName } from "../utils";
+import {
+  fetchAndMergeOntologyAttributes,
+  getLabelTypeOptions,
+  validateFieldName,
+} from "../utils";
+import NewFieldOntologySection from "./NewFieldOntologySection";
 
 import {
   ATTRIBUTE_TYPE_OPTIONS,
@@ -73,6 +78,7 @@ const NewFieldSchema = () => {
     DEFAULT_DETECTION_ATTRIBUTES_2D
   );
   const [newAttributes, setNewAttributes] = useState<Set<string>>(new Set());
+  const [appliedOntology, setAppliedOntology] = useState<string>();
 
   const { createAndActivateField, listSchemas } = useSchemaManager();
   const setLabelSchemasData = useSetLabelSchemasData();
@@ -118,6 +124,9 @@ const NewFieldSchema = () => {
       setAttributes(getDefaultAttributesForType(newType, is3dMedia));
       setNewAttributes(new Set());
       setClasses([]);
+      // The reset above drops any ontology-sourced attributes, so clear the
+      // applied ontology too rather than strand its name without its attrs.
+      setAppliedOntology(undefined);
     },
     [is3dMedia]
   );
@@ -198,6 +207,32 @@ const NewFieldSchema = () => {
     []
   );
 
+  // Ontology handlers. Mirror the edit flow: applying an ontology merges its
+  // attributes (marked `_source`) into the list for live preview; clearing
+  // drops them. The `_source` markers are stripped server-side on create.
+  const ontologyAttributes = useMemo(
+    () => attributes.filter((a) => a._source).map((a) => a.name),
+    [attributes]
+  );
+
+  const handleApplyOntology = useCallback(
+    (name: string) => {
+      setAppliedOntology(name);
+      fetchAndMergeOntologyAttributes(attributes, name)
+        .then(setAttributes)
+        .catch(() => {
+          // Preview failed; the name is set and attributes hydrate on create.
+          console.error(`Failed to fetch ontology attributes for ${name}`);
+        });
+    },
+    [attributes]
+  );
+
+  const handleClearOntology = useCallback(() => {
+    setAppliedOntology(undefined);
+    setAttributes((prev) => prev.filter((a) => !a._source));
+  }, []);
+
   const handleCreate = useCallback(async () => {
     if (!canCreate) return;
 
@@ -214,6 +249,7 @@ const NewFieldSchema = () => {
         classes,
         attributes,
         new_attributes: newAttrsArr.length > 0 ? newAttrsArr : undefined,
+        applied_ontology: appliedOntology,
       };
     }
 
@@ -255,6 +291,7 @@ const NewFieldSchema = () => {
     }
   }, [
     addToExploreActiveFields,
+    appliedOntology,
     attributes,
     canCreate,
     category,
@@ -364,9 +401,15 @@ const NewFieldSchema = () => {
             />
           )}
 
-          {/* Label field config: Classes and Attributes */}
+          {/* Label field config: Ontology, Classes and Attributes */}
           {category === "label" && (
             <>
+              <NewFieldOntologySection
+                appliedOntology={appliedOntology}
+                ontologyAttributes={ontologyAttributes}
+                onPick={handleApplyOntology}
+                onClear={handleClearOntology}
+              />
               <ClassesSection
                 classes={classes}
                 attributeCount={attributes.length}

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/utils.test.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/utils.test.ts
@@ -1,10 +1,18 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  fetchAndMergeOntologyAttributes,
   formatAttributeCount,
   formatSchemaCount,
   getAttributeTypeLabel,
   getClassNameError,
+  type AttributeConfig,
 } from "./utils";
+
+const mockFetch = vi.fn();
+vi.mock("@fiftyone/utilities", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@fiftyone/utilities")>();
+  return { ...actual, getFetchFunction: () => mockFetch };
+});
 
 describe("getAttributeTypeLabel", () => {
   it("should return human-readable label for known components", () => {
@@ -107,5 +115,52 @@ describe("formatSchemaCount", () => {
     expect(formatSchemaCount(0)).toBe("0 schemas");
     expect(formatSchemaCount(2)).toBe("2 schemas");
     expect(formatSchemaCount(5)).toBe("5 schemas");
+  });
+});
+
+describe("fetchAndMergeOntologyAttributes", () => {
+  const attr = (name: string, extra: Partial<AttributeConfig> = {}) =>
+    ({ name, type: "str", ...extra } as AttributeConfig);
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it("appends new ontology attributes after existing ones", async () => {
+    mockFetch.mockResolvedValue({
+      attributes: [attr("size", { _source: "vehicles" })],
+    });
+
+    const merged = await fetchAndMergeOntologyAttributes(
+      [attr("color")],
+      "vehicles"
+    );
+
+    expect(merged.map((a) => a.name)).toEqual(["color", "size"]);
+    expect(merged.find((a) => a.name === "size")?._source).toBe("vehicles");
+  });
+
+  it("overrides same-named attributes in place, preserving order", async () => {
+    mockFetch.mockResolvedValue({
+      attributes: [attr("color", { _source: "vehicles", component: "radio" })],
+    });
+
+    const merged = await fetchAndMergeOntologyAttributes(
+      [attr("color"), attr("year")],
+      "vehicles"
+    );
+
+    expect(merged.map((a) => a.name)).toEqual(["color", "year"]);
+    expect(merged[0]._source).toBe("vehicles");
+    expect(merged[0].component).toBe("radio");
+  });
+
+  it("returns the existing list unchanged when the ontology has no attributes", async () => {
+    mockFetch.mockResolvedValue({ attributes: [] });
+
+    const existing = [attr("color")];
+    const merged = await fetchAndMergeOntologyAttributes(existing, "empty");
+
+    expect(merged).toBe(existing);
   });
 });

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/utils.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/utils.ts
@@ -2,7 +2,7 @@
  * Utility functions for SchemaManager
  */
 
-import { is3d } from "@fiftyone/utilities";
+import { getFetchFunction, is3d } from "@fiftyone/utilities";
 import type { ListItemProps as BaseListItemProps } from "@voxel51/voodo";
 import type { ReactNode } from "react";
 import {
@@ -88,6 +88,42 @@ export interface AttributeConfig {
 export interface ClassConfig {
   attributes?: AttributeConfig[];
 }
+
+// =============================================================================
+// Ontology attributes
+// =============================================================================
+
+/**
+ * Fetch an annotation ontology's attributes and merge them into an existing
+ * attribute list, returning the merged result.
+ *
+ * Existing order is preserved; ontology attributes (which carry the `_source`
+ * marker) override same-named entries in place, and any new ones are appended.
+ * Used to preview ontology attributes in the schema editor for both the create
+ * and edit flows.
+ */
+export const fetchAndMergeOntologyAttributes = async (
+  existing: AttributeConfig[],
+  name: string
+): Promise<AttributeConfig[]> => {
+  const result = await getFetchFunction()(
+    "GET",
+    `/ontologies/${encodeURIComponent(name)}/attributes`
+  );
+
+  const incoming = (result as { attributes: AttributeConfig[] }).attributes;
+  if (!incoming?.length) return existing;
+
+  const byName = new Map(existing.map((a) => [a.name, a]));
+  const orderedNames = existing.map((a) => a.name);
+
+  incoming.forEach((attr) => {
+    if (!byName.has(attr.name)) orderedNames.push(attr.name);
+    byName.set(attr.name, attr);
+  });
+
+  return orderedNames.map((n) => byName.get(n) as AttributeConfig);
+};
 
 // Schema configuration (for both label types and primitive fields)
 export interface SchemaConfigType {

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/utils.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/utils.ts
@@ -93,6 +93,11 @@ export interface ClassConfig {
 // Ontology attributes
 // =============================================================================
 
+// Response shape of `GET /ontologies/{name}/attributes`.
+export interface OntologyAttributesResponse {
+  attributes: AttributeConfig[];
+}
+
 /**
  * Fetch an annotation ontology's attributes and merge them into an existing
  * attribute list, returning the merged result.
@@ -106,18 +111,18 @@ export const fetchAndMergeOntologyAttributes = async (
   existing: AttributeConfig[],
   name: string
 ): Promise<AttributeConfig[]> => {
-  const result = await getFetchFunction()(
+  const result: OntologyAttributesResponse = await getFetchFunction()(
     "GET",
     `/ontologies/${encodeURIComponent(name)}/attributes`
   );
 
-  const incoming = (result as { attributes: AttributeConfig[] }).attributes;
-  if (!incoming?.length) return existing;
+  const incomingAttributes = result.attributes;
+  if (!incomingAttributes?.length) return existing;
 
   const byName = new Map(existing.map((a) => [a.name, a]));
   const orderedNames = existing.map((a) => a.name);
 
-  incoming.forEach((attr) => {
+  incomingAttributes.forEach((attr) => {
     if (!byName.has(attr.name)) orderedNames.push(attr.name);
     byName.set(attr.name, attr);
   });

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useSchemaManager.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useSchemaManager.ts
@@ -139,6 +139,7 @@ export type LabelSchemaConfig = {
   classes?: string[];
   attributes?: AttributeConfig[];
   new_attributes?: AttributeConfig[];
+  applied_ontology?: string;
 };
 
 export type CreateAndActivateFieldRequest = {

--- a/plugins/operators/annotation.py
+++ b/plugins/operators/annotation.py
@@ -293,6 +293,7 @@ class CreateAndActivateField(foo.Operator):
         # Get label schema config from frontend
         label_schema_config = ctx.params.get("label_schema_config", {})
         classes = label_schema_config.get("classes")
+        applied_ontology = label_schema_config.get("applied_ontology")
 
         # Determine component based on number of classes
         if classes and len(classes) > foac.CHECKBOXES_OR_RADIO_THRESHOLD:
@@ -303,13 +304,21 @@ class CreateAndActivateField(foo.Operator):
         else:
             component = foac.RADIO
 
-        # Build label schema
-        return {
+        # Build label schema. Setting `applied_ontology` here routes through the
+        # same `update_label_schema` dehydrate/validate/persist path the edit
+        # flow uses, so a field can be created with an ontology attached in a
+        # single step.
+        label_schema = {
             "type": field_type,
             "component": component,
             "attributes": label_schema_config.get("attributes", []),
-            **({"classes": classes} if classes else {}),
         }
+        if classes:
+            label_schema["classes"] = classes
+        if applied_ontology:
+            label_schema["applied_ontology"] = applied_ontology
+
+        return label_schema
 
     def _create_primitive_field(self, ctx, field_name, field_type, read_only):
         """Create a primitive field and return its schema."""

--- a/tests/unittests/annotation/dataset_label_schemas_tests.py
+++ b/tests/unittests/annotation/dataset_label_schemas_tests.py
@@ -14,6 +14,9 @@ import fiftyone as fo
 import fiftyone.core.labels as fol
 from fiftyone.core.annotation.attributes import AttributeSpec
 from fiftyone.core.ontology import AnnotationOntology, apply_ontology
+from fiftyone.operators.executor import ExecutionContext
+
+from plugins.operators.annotation import CreateAndActivateField
 
 from decorators import drop_datasets, drop_ontologies
 
@@ -512,3 +515,58 @@ def _make_applied_ontology_test_dataset(ontology_name: str = "my_ontology"):
     dataset.add_sample_field("str_field", fo.StringField)
 
     return dataset
+
+
+def _create_field_ctx(dataset, params):
+    return ExecutionContext(
+        operator_uri="@voxel51/operators/create_and_activate_field",
+        request_params={"dataset_name": dataset.name, "params": params},
+    )
+
+
+class CreateAndActivateFieldTests(unittest.TestCase):
+    """Unit tests for the `create_and_activate_field` operator."""
+
+    @drop_datasets
+    @drop_ontologies
+    def test_create_label_field_with_applied_ontology(self):
+        dataset = _make_applied_ontology_test_dataset()
+        ctx = _create_field_ctx(
+            dataset,
+            {
+                "field_name": "new_detections",
+                "field_category": "label",
+                "field_type": "detections",
+                "label_schema_config": {"applied_ontology": "my_ontology"},
+            },
+        )
+
+        result = CreateAndActivateField().execute(ctx)
+        self.assertNotIn("error", result)
+
+        dataset.reload()
+        self.assertEqual(
+            dataset.label_schemas["new_detections"]["applied_ontology"],
+            "my_ontology",
+        )
+
+    @drop_datasets
+    def test_create_label_field_without_applied_ontology(self):
+        dataset = fo.Dataset()
+        ctx = _create_field_ctx(
+            dataset,
+            {
+                "field_name": "new_detections",
+                "field_category": "label",
+                "field_type": "detections",
+                "label_schema_config": {},
+            },
+        )
+
+        result = CreateAndActivateField().execute(ctx)
+        self.assertNotIn("error", result)
+
+        dataset.reload()
+        self.assertNotIn(
+            "applied_ontology", dataset.label_schemas["new_detections"]
+        )


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

Previously, when you wanted to attach an ontology to a field, you had to first create the field and then edit it. This allows attaching the ontology while creating it. 

## 🧪 How is this patch tested? If it is not, please explain why.

Tested locally:

[Screencast from 2026-06-09 09-20-53.webm](https://github.com/user-attachments/assets/ab68bf7d-a559-4b28-8669-6e8b13a29c19)


## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
