### PR TITLE
[FOEPD-3967] Skip flaky test "keeps sparse 3d modal navigation stable"

### DIFF
--- a/e2e-pw/src/oss/specs/MISSING-sparse-fo3d-groups.spec.ts
+++ b/e2e-pw/src/oss/specs/MISSING-sparse-fo3d-groups.spec.ts
@@ -129,7 +129,11 @@ test.describe.serial("sparse grouped fo3d", () => {
     await grid.selectSlice("z");
   });
 
-  test("keeps sparse 3d modal navigation stable", async ({ grid, modal }) => {
+  // TODO FOEPD-3967 re-enable this test once its flakiness is resolved
+  test.skip("keeps sparse 3d modal navigation stable", async ({
+    grid,
+    modal,
+  }) => {
     const assertSingleSliceState = async (
       index: number,
       expectedSlice: "x" | "y" | "z"


### PR DESCRIPTION
## 🔗 Related Issues

Got [this failure](https://github.com/voxel51/fiftyone-teams/actions/runs/27229706680/job/80406683929?pr=2766) on an unrelated PR, created [FOEPD-3967](https://voxel51.atlassian.net/browse/FOEPD-3967).

## 📋 What changes are proposed in this pull request?

Skip the test "keeps sparse 3d modal navigation stable" since it does not appear to be reliable.

## 🧪 How is this patch tested? If it is not, please explain why.

n/a

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes
- [x] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other

[FOEPD-3967]: https://voxel51.atlassian.net/browse/FOEPD-3967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Disabled test for sparse 3D modal navigation stability pending resolution of a known issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2848
<!-- enterprise-sync-pr:end -->