### PR TITLE
Give Aloha Shirts ownership of package.json and yarn.lock files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,8 @@
 # Aloha Shirts care about versioning
 .github/                     @voxel51/aloha-shirts
 Dockerfile                   @voxel51/aloha-shirts
-setup.py                     @voxel51/aloha-shirts
+package.json                 @voxel51/aloha-shirts
 requirements.txt             @voxel51/aloha-shirts
 requirements/                @voxel51/aloha-shirts
+setup.py                     @voxel51/aloha-shirts
+yarn.lock                    @voxel51/aloha-shirts


### PR DESCRIPTION
## What

Adds two CODEOWNERS rules giving `@voxel51/aloha-shirts` ownership of all `package.json` and `yarn.lock` files:

```
package.json                 @voxel51/aloha-shirts
yarn.lock                    @voxel51/aloha-shirts
```

## Why

These are version/dependency manifests, which fall under the team that already owns versioning (`Dockerfile`, `setup.py`, `requirements*`)

## Notes

- Bare filenames (no leading slash, no wildcard) match at **any depth**, so these cover `app/package.json`, every `app/packages/*/package.json` (29 total), and `e2e-pw/package.json`, plus `app/yarn.lock` and `e2e-pw/yarn.lock`.
- CODEOWNERS is last-match-wins; placing these after `*` correctly overrides the default `@voxel51/developers` owner for these files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated code ownership to assign responsibility for package manifests, dependency lists, and packaging-related files to the aloha-shirts team.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2861
<!-- enterprise-sync-pr:end -->