### PR TITLE
Add Kapa customization ID to docs widget

### DIFF
--- a/docs/source/_static/js/custom.js
+++ b/docs/source/_static/js/custom.js
@@ -530,6 +530,7 @@ const initKapaAI = () => {
       "Your AI guide to all things FiftyOne and its community, powered by the complete [FiftyOne documentation](https://docs.voxel51.com/).\n\nNeed team collaboration, cloud storage, flexible deployment, and advanced workflows for production? [Get Enterprise](https://link.voxel51.com/docs-search-sales)",
     mcpEnabled: "true",
     mcpServerUrl: "https://voxel51.mcp.kapa.ai",
+    customizationId: "79381c29-919b-4c49-82eb-a90fd89b5501",
   });
 
   document.head.appendChild(script);


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link.

## 📋 What changes are proposed in this pull request?

This PR adds a Kapa customization configuration to the FiftyOne Docs AI widget via `data-customization-id`.

The customization aligns AI responses with the FiftyOne documentation style by encouraging capability-first, action-oriented answers and the use of code examples when helpful. It also adds guardrails to correctly distinguish open source and Enterprise features.

## 🧪 How is this patch tested? If it is not, please explain why.

Verified the customization configuration loads correctly in the Docs AI widget

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

* [x] No. You can skip the rest of this section.
* [ ] Yes. Give a description of this change to be included in the release notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

* [ ] App: FiftyOne application changes
* [ ] Build: Build and test infrastructure changes
* [ ] Core: Core `fiftyone` Python library changes
* [x] Documentation: FiftyOne documentation changes
* [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation widget configuration to enable enhanced customization settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->