### PR TITLE
perf(app): panel Suspense boundary + deterministic lazy-vendor chunks

### DIFF
--- a/app/packages/app/vite.config.ts
+++ b/app/packages/app/vite.config.ts
@@ -93,6 +93,21 @@ async function loadConfig() {
           }
           warn(warning);
         },
+        output: {
+          // Give the heavy, lazily-loaded vendor libs their own deterministic
+          // chunks so rollup doesn't hoist them into the entry or glue them
+          // together (e.g. mapbox + plotly landing in one blob). Each only
+          // loads when its panel/view opens.
+          manualChunks(id) {
+            if (id.includes("node_modules")) {
+              if (/[\\/](mapbox-gl|@mapbox)[\\/]/.test(id)) return "mapbox-gl";
+              if (/[\\/]plotly\.js/.test(id) || /react-plotly\.js/.test(id))
+                return "plotly";
+              if (/[\\/]recharts[\\/]/.test(id)) return "recharts";
+              if (/[\\/]html2canvas[\\/]/.test(id)) return "html2canvas";
+            }
+          },
+        },
       },
     },
     server: {

--- a/app/packages/spaces/src/components/Panel.tsx
+++ b/app/packages/spaces/src/components/Panel.tsx
@@ -52,7 +52,9 @@ function Panel(props: PanelProps) {
       style={style}
     >
       <PanelContext.Provider value={{ node, scope }}>
-        <Component panelNode={node} dimensions={dimensions} />
+        <React.Suspense fallback={<PanelSkeleton />}>
+          <Component panelNode={node} dimensions={dimensions} />
+        </React.Suspense>
       </PanelContext.Provider>
     </StyledPanel>
   );


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

Two changes that unblock and stabilize lazy panel loading (prerequisite for the lazy-panel PRs that follow):

- Wrap the panel `<Component>` in a `React.Suspense` boundary with a skeleton fallback, so lazily-loaded panels (Embeddings, Map, Histograms) don't throw while their chunk loads.
- Add deterministic `manualChunks` for the heavy lazy vendor libs (`mapbox-gl`, `plotly`, `recharts`, `html2canvas`) so rollup stops hoisting them into the entry chunk or gluing them together. Each lib now loads only when its panel/view opens.

## 🧪 How is this patch tested? If it is not, please explain why.

- `yarn workspace @fiftyone/app build-bare` succeeds; the four vendor libs land in their own chunks.
- Lighthouse (desktop, median of 3): no standalone FCP change (12.6 s, same as `develop`) — this is infrastructure. `manualChunks` relocates the heavy libs into their own chunks; they only become lazy (and move first paint) in the dependent PRs. Without it, `lazy-plotly`/`lazy-map` glue mapbox + plotly into one chunk.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes.

N/A — infrastructure for the lazy-loading PRs.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [x] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved build output by strategically splitting large third-party libraries into separate bundles, reducing initial application load time and enabling more efficient caching.

* **Improvements**
  * Enhanced component loading experience with improved loading indicators when dynamically loading panels, resulting in better perceived performance and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2896
<!-- enterprise-sync-pr:end -->