### PR TITLE
Taxonomy/fe-integration-classes

### DIFF
--- a/app/packages/components/src/components/SmartForm/RJSF/widgets/useTaxonomyTree.ts
+++ b/app/packages/components/src/components/SmartForm/RJSF/widgets/useTaxonomyTree.ts
@@ -33,6 +33,7 @@ export const useTaxonomyTree = (
     }
 
     let cancelled = false;
+    setTree(null);
     setIsFetching(true);
     setError(null);
 
@@ -42,7 +43,10 @@ export const useTaxonomyTree = (
         if (!cancelled) setTree((result as TaxonomyResponse).taxonomy.root);
       })
       .catch((e: unknown) => {
-        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+        if (!cancelled) {
+          setTree(null);
+          setError(e instanceof Error ? e.message : String(e));
+        }
       })
       .finally(() => {
         if (!cancelled) setIsFetching(false);

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/AnnotationSchema.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/AnnotationSchema.tsx
@@ -53,11 +53,13 @@ const useSchema = (readOnly: boolean) => {
 
   // Reruns only when the visible attribute set changes.
   return useMemo(() => {
+    const taxonomy = config?.applied_taxonomy;
     const properties: Record<string, SchemaType | undefined> = {
       label: generatePrimitiveSchema("label", {
         type: "str",
-        component: config?.component || "dropdown",
-        values: config?.classes || [],
+        component: taxonomy ? "dropdown" : config?.component || "dropdown",
+        values: taxonomy ? [] : config?.classes || [],
+        taxonomy,
         readOnly: effectiveReadOnly,
       }),
     };

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/ApplyOntologySection.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/ApplyOntologySection.tsx
@@ -19,8 +19,13 @@ interface ApplyOntologySectionProps {
 }
 
 const ApplyOntologySection = ({ field }: ApplyOntologySectionProps) => {
-  const { appliedOntology, ontologyAttributes, applyOntology, clearOntology } =
-    useAppliedOntology(field);
+  const {
+    appliedOntology,
+    appliedTaxonomy,
+    ontologyAttributes,
+    applyOntology,
+    clearOntology,
+  } = useAppliedOntology(field);
   const { ontologies, isFetching, error } = useOntologies(
     ONTOLOGY_TYPE.ontology
   );
@@ -70,6 +75,11 @@ const ApplyOntologySection = ({ field }: ApplyOntologySectionProps) => {
           ? `Chosen ontology: ${appliedOntology}`
           : "When enabled, your schema will use attributes defined in the ontology."}
       </Text>
+      {appliedTaxonomy && (
+        <Text variant={TextVariant.Lg} color={TextColor.Secondary}>
+          Taxonomy: {appliedTaxonomy}
+        </Text>
+      )}
 
       {expanded && !appliedOntology && (
         <OntologyPicker

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/ApplyOntologySection.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/ApplyOntologySection.tsx
@@ -52,7 +52,8 @@ const ApplyOntologySection = ({ field }: ApplyOntologySectionProps) => {
   };
 
   const handlePick = (value: string): void => {
-    applyOntology(value);
+    const taxonomy = ontologies?.find((o) => o.name === value)?.taxonomy;
+    applyOntology(value, taxonomy);
     setPickerArmed(false);
   };
 

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/index.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/index.tsx
@@ -16,6 +16,7 @@ import { PRIMITIVE_FIELD_TYPES } from "../../constants";
 import { useFieldType } from "../../hooks";
 import { EditSectionHeader, EmptyStateBox, Section } from "../../styled";
 import type { AttributeConfig, SchemaConfigType } from "../../utils";
+import { useAppliedOntology } from "../useLabelSchema";
 import AttributesSection from "./AttributesSection";
 import ClassesSection from "./ClassesSection";
 import PrimitiveFieldContent from "./PrimitiveFieldContent";
@@ -44,6 +45,7 @@ const GUIContent = ({
 }: GUIContentProps) => {
   const fType = useFieldType(field);
   const isPrimitive = fType ? PRIMITIVE_FIELD_TYPES.has(fType) : false;
+  const { appliedTaxonomy } = useAppliedOntology(field);
 
   const classes = useMemo(() => config?.classes || [], [config?.classes]);
   const attributes = useMemo(
@@ -180,14 +182,16 @@ const GUIContent = ({
 
   return (
     <>
-      <ClassesSection
-        classes={classes}
-        attributeCount={attributes.length}
-        onAddClass={handleAddClass}
-        onEditClass={handleEditClass}
-        onDeleteClass={handleDeleteClass}
-        onOrderChange={handleClassOrderChange}
-      />
+      {!appliedTaxonomy && (
+        <ClassesSection
+          classes={classes}
+          attributeCount={attributes.length}
+          onAddClass={handleAddClass}
+          onEditClass={handleEditClass}
+          onDeleteClass={handleDeleteClass}
+          onOrderChange={handleClassOrderChange}
+        />
+      )}
       <AttributesSection
         attributes={attributes}
         onAddAttribute={handleAddAttribute}

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/useLabelSchema.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/useLabelSchema.ts
@@ -30,9 +30,8 @@ import { currentLabelSchema } from "../state";
 import { type AttributeConfig, reconcileComponent } from "../utils";
 
 const fetchAndMergeOntologyAttributes = async (
-  draft: FieldSchema,
   name: string,
-  setCurrent: (schema: FieldSchema) => void
+  setCurrent: (updater: (live: unknown) => unknown) => void
 ): Promise<void> => {
   const result = await getFetchFunction()(
     "GET",
@@ -42,18 +41,27 @@ const fetchAndMergeOntologyAttributes = async (
   const attrs = (result as { attributes: AttributeConfig[] }).attributes;
   if (!attrs?.length) return;
 
-  const existing = Array.isArray(draft.attributes) ? [...draft.attributes] : [];
-  const byName = new Map(existing.map((a) => [a.name, a]));
-  const orderedNames = existing.map((a) => a.name);
+  setCurrent((live) => {
+    const liveSchema = live as FieldSchema | undefined;
+    // If the ontology was cleared or switched while the fetch was in flight,
+    // discard the result rather than restoring stale data.
+    if (liveSchema?.applied_ontology !== name) return live;
 
-  for (const attr of attrs) {
-    if (!byName.has(attr.name)) orderedNames.push(attr.name);
-    byName.set(attr.name, attr);
-  }
+    const existing = Array.isArray(liveSchema.attributes)
+      ? [...liveSchema.attributes]
+      : [];
+    const byName = new Map(existing.map((a) => [a.name, a]));
+    const orderedNames = existing.map((a) => a.name);
 
-  setCurrent({
-    ...draft,
-    attributes: orderedNames.map((n) => byName.get(n)),
+    for (const attr of attrs) {
+      if (!byName.has(attr.name)) orderedNames.push(attr.name);
+      byName.set(attr.name, attr);
+    }
+
+    return {
+      ...liveSchema,
+      attributes: orderedNames.map((n) => byName.get(n)),
+    };
   });
 };
 
@@ -172,7 +180,7 @@ export const useAppliedOntology = (field: string) => {
         applied_taxonomy: taxonomy,
       };
       setCurrent(draft);
-      fetchAndMergeOntologyAttributes(draft, name, setCurrent).catch(() => {
+      fetchAndMergeOntologyAttributes(name, setCurrent).catch(() => {
         console.error(`Failed to fetch ontology attributes for ${name}`);
       });
     },

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/useLabelSchema.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/useLabelSchema.ts
@@ -165,11 +165,14 @@ export const useAppliedOntology = (field: string) => {
     appliedOntology: schema?.applied_ontology,
     appliedTaxonomy: schema?.applied_taxonomy,
     ontologyAttributes,
-    applyOntology: (name: string) => {
-      const draft = { ...(schema as FieldSchema), applied_ontology: name };
+    applyOntology: (name: string, taxonomy?: string) => {
+      const draft: FieldSchema = {
+        ...(schema as FieldSchema),
+        applied_ontology: name,
+        applied_taxonomy: taxonomy,
+      };
       setCurrent(draft);
       fetchAndMergeOntologyAttributes(draft, name, setCurrent).catch(() => {
-        // Preview failed. The name is already set, attributes will hydrate after save
         console.error(`Failed to fetch ontology attributes for ${name}`);
       });
     },

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/useLabelSchema.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/useLabelSchema.ts
@@ -176,6 +176,7 @@ export const useAppliedOntology = (field: string) => {
     clearOntology: () => {
       const next: FieldSchema = { ...(schema as FieldSchema) };
       delete next.applied_ontology;
+      delete next.applied_taxonomy;
       // Drop ontology-owned attributes (carry the `_source` marker). The
       // backend's dehydrate only strips them while `applied_ontology` is
       // still set, so we'd leave orphaned `when` clauses for the validator

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/useLabelSchema.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/useLabelSchema.ts
@@ -163,6 +163,7 @@ export const useAppliedOntology = (field: string) => {
 
   return {
     appliedOntology: schema?.applied_ontology,
+    appliedTaxonomy: schema?.applied_taxonomy,
     ontologyAttributes,
     applyOntology: (name: string) => {
       const draft = { ...(schema as FieldSchema), applied_ontology: name };

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/useOntologies.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/useOntologies.ts
@@ -13,6 +13,7 @@ export interface OntologySummary {
   type: OntologyType;
   version: number;
   last_modified_at: string;
+  taxonomy?: string;
 }
 
 interface OntologiesResponse {

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useSchemaManager.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useSchemaManager.ts
@@ -47,6 +47,7 @@ export type FieldSchema = {
   default?: unknown;
   attributes?: AttributeConfig[];
   applied_ontology?: string;
+  applied_taxonomy?: string;
 };
 
 /**

--- a/fiftyone/server/routes/ontology.py
+++ b/fiftyone/server/routes/ontology.py
@@ -131,6 +131,7 @@ async def _list_ontology_summaries(
                 "type": {"$first": "$type"},
                 "version": {"$first": "$version"},
                 "last_modified_at": {"$first": "$last_modified_at"},
+                "taxonomy": {"$first": "$root.taxonomy"},
             }
         },
         {"$sort": {"last_modified_at": -1}},
@@ -216,9 +217,7 @@ async def _load_taxonomy_response(
         return None, error
 
     root_dict = doc.get("root") or {}
-    subtree, error = _select_subtree(
-        root_dict, doc["name"], node_name, depth
-    )
+    subtree, error = _select_subtree(root_dict, doc["name"], node_name, depth)
     if error is not None:
         return None, error
 

--- a/fiftyone/server/routes/ontology.py
+++ b/fiftyone/server/routes/ontology.py
@@ -131,7 +131,9 @@ async def _list_ontology_summaries(
                 "type": {"$first": "$type"},
                 "version": {"$first": "$version"},
                 "last_modified_at": {"$first": "$last_modified_at"},
-                "taxonomy": {"$first": "$root.taxonomy"},
+                "taxonomy": {
+                    "$first": {"$ifNull": ["$root.taxonomy", "$$REMOVE"]}
+                },
             }
         },
         {"$sort": {"last_modified_at": -1}},

--- a/tests/unittests/annotation/validate_label_schemas_tests.py
+++ b/tests/unittests/annotation/validate_label_schemas_tests.py
@@ -1214,6 +1214,23 @@ class TaxonomySettingValidationTests(unittest.TestCase):
                 fields="str_list_field",
             )
 
+    @drop_datasets
+    def test_str_list_dropdown_taxonomy_non_string_rejected(self):
+        dataset = fo.Dataset()
+        dataset.add_sample_field(
+            "str_list_field", fo.ListField, subfield=fo.StringField
+        )
+        with self.assertRaises(ExceptionGroup):
+            validate_label_schemas(
+                dataset,
+                {
+                    "type": "list<str>",
+                    "component": "dropdown",
+                    "taxonomy": 123,
+                },
+                fields="str_list_field",
+            )
+
     # -- attribute-level (nested under a label field) --
 
     @drop_datasets


### PR DESCRIPTION

## 📋 What changes are proposed in this pull request?
This PR extends annotation such that when an `ontology` is applied to a label schema, and that ontology has a taxonomy defined within it, the `label` field in the annotation smart form utilizes the taxonomy instead of any manually defined class definitions on the schema

## 🧪 How is this patch tested? If it is not, please explain why.

https://github.com/user-attachments/assets/4d34aade-30fb-44f2-9040-46fe985f5c07

Steps to Reproduce:
1. Create an ontology and a taxonomy. The ontology should reference the new taxonomy internally. Use this script if necessary: [create_ontology_with_taxonomy.py](https://github.com/user-attachments/files/28815624/create_ontology_with_taxonomy.py)
2. Open a sample and apply the ontology to the schema. You will see the 'classes' section disappear and a Taxonomy label showing the applied taxonomy's name
3. Create a new detection for the field in annotation mode
4. Notice the `label` appears to be a dropdown, this is actually a `TreeView` navigation component that will allow you to select a value from within a taxonomy tree as the label.
5. If you select `motorcycle` you will see conditional attributes from the ontology render in the annotation sidebar.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Users can define a Taxonomy that can be used to provide selection values to the label field when annotating a sample.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added taxonomy support to annotation field schema management, allowing users to apply taxonomies when selecting ontologies for label fields.
  * Ontology selection now includes and preserves taxonomy information.

* **Bug Fixes**
  * Improved data consistency by resetting tree state during initialization and error conditions.

* **Tests**
  * Added comprehensive taxonomy validation test suite covering dropdown components, list types, and nested attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2869
<!-- enterprise-sync-pr:end -->