### PR TITLE
Use worker pool to decode image frame in MCAP grid renderer with playback-on-hover

### DIFF
--- a/app/packages/core/src/components/Grid/GridCustomRendererItem.test.tsx
+++ b/app/packages/core/src/components/Grid/GridCustomRendererItem.test.tsx
@@ -31,6 +31,9 @@ const BASE_CTX = {
 
 const BASE_SYMBOL = { description: "sample-id" } as const;
 
+const RGBA_BYTES_PER_PIXEL = 4;
+const MIN_GRID_RENDERER_SIZE_BYTES = 1;
+
 const TestBridge = ({ children }: React.PropsWithChildren) => <>{children}</>;
 
 const getOpenModalButton = (host: HTMLElement) =>
@@ -145,7 +148,9 @@ describe("GridCustomRendererItem", () => {
     const host = document.createElement("div");
     document.body.appendChild(host);
 
-    looker.attach(host, [320, 180], 14);
+    const tileWidthPx = 320;
+    const tileHeightPx = 180;
+    looker.attach(host, [tileWidthPx, tileHeightPx], 14);
 
     await waitFor(() => {
       expect(
@@ -163,7 +168,10 @@ describe("GridCustomRendererItem", () => {
 
     expect(Renderer.mock.calls.length).toBe(callsAfterFailure);
     expect(looker.getSampleOverlays()).toEqual([]);
-    expect(looker.getSizeBytesEstimate()).toBe(320 * 180 * 4 + 1);
+    expect(looker.getSizeBytesEstimate()).toBe(
+      tileWidthPx * tileHeightPx * RGBA_BYTES_PER_PIXEL +
+        MIN_GRID_RENDERER_SIZE_BYTES
+    );
 
     looker.destroy();
     host.remove();
@@ -171,12 +179,15 @@ describe("GridCustomRendererItem", () => {
 
   it("estimates size from raw sample shapes safely", () => {
     const Renderer = () => <div data-testid="renderer">raw sample</div>;
+    const tileWidthPx = 10;
+    const tileHeightPx = 20;
+    const sourceSizeBytes = 123;
     const rawSampleCtx = {
       ...BASE_CTX,
       sample: {
         id: "sample-id",
         filepath: "/tmp/file.pdf",
-        metadata: { size_bytes: 123 },
+        metadata: { size_bytes: sourceSizeBytes },
       },
     };
     const looker = new GridCustomRendererItem({
@@ -189,9 +200,13 @@ describe("GridCustomRendererItem", () => {
     const host = document.createElement("div");
     document.body.appendChild(host);
 
-    looker.attach(host, [10, 20], 12);
+    looker.attach(host, [tileWidthPx, tileHeightPx], 12);
 
-    expect(looker.getSizeBytesEstimate()).toBe(10 * 20 * 4 + 123 + 1);
+    expect(looker.getSizeBytesEstimate()).toBe(
+      tileWidthPx * tileHeightPx * RGBA_BYTES_PER_PIXEL +
+        sourceSizeBytes +
+        MIN_GRID_RENDERER_SIZE_BYTES
+    );
 
     looker.destroy();
     host.remove();

--- a/app/packages/core/src/components/Grid/GridCustomRendererItem.test.tsx
+++ b/app/packages/core/src/components/Grid/GridCustomRendererItem.test.tsx
@@ -169,6 +169,34 @@ describe("GridCustomRendererItem", () => {
     host.remove();
   });
 
+  it("estimates size from raw sample shapes safely", () => {
+    const Renderer = () => <div data-testid="renderer">raw sample</div>;
+    const rawSampleCtx = {
+      ...BASE_CTX,
+      sample: {
+        id: "sample-id",
+        filepath: "/tmp/file.pdf",
+        metadata: { size_bytes: 123 },
+      },
+    };
+    const looker = new GridCustomRendererItem({
+      pluginName: "pdf-renderer",
+      Renderer,
+      RecoilBridge: TestBridge,
+      ctx: rawSampleCtx as any,
+      symbol: BASE_SYMBOL,
+    });
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+
+    looker.attach(host, [10, 20], 12);
+
+    expect(looker.getSizeBytesEstimate()).toBe(10 * 20 * 4 + 123 + 1);
+
+    looker.destroy();
+    host.remove();
+  });
+
   it("avoids synchronously unmounting the plugin root", async () => {
     const Renderer = () => {
       throw new Error("render failed");

--- a/app/packages/core/src/components/Grid/GridCustomRendererItem.test.tsx
+++ b/app/packages/core/src/components/Grid/GridCustomRendererItem.test.tsx
@@ -163,7 +163,7 @@ describe("GridCustomRendererItem", () => {
 
     expect(Renderer.mock.calls.length).toBe(callsAfterFailure);
     expect(looker.getSampleOverlays()).toEqual([]);
-    expect(looker.getSizeBytesEstimate()).toBe(1);
+    expect(looker.getSizeBytesEstimate()).toBe(320 * 180 * 4 + 1);
 
     looker.destroy();
     host.remove();

--- a/app/packages/core/src/components/Grid/GridCustomRendererItem.tsx
+++ b/app/packages/core/src/components/Grid/GridCustomRendererItem.tsx
@@ -21,6 +21,13 @@ type GridCustomRendererItemConfig = {
 /** Dimensions as [width, height] in pixels. */
 type GridItemDimensions = [width: number, height: number];
 
+type GridSizeHintSample = {
+  filepath?: string;
+  metadata?: {
+    size_bytes?: unknown;
+  };
+};
+
 /** Error boundary for a sample renderer with fallback behavior. */
 class GridCustomRendererErrorBoundary extends React.Component<
   React.PropsWithChildren<{ onError: (error: Error) => void }>,
@@ -442,13 +449,21 @@ export class GridCustomRendererItem {
       return getPixelSizeBytes(rect.width, rect.height);
     })();
 
-    const sample = this.config.ctx.sample.sample;
+    const wrappedSample = this.config.ctx.sample as unknown as
+      | { sample?: GridSizeHintSample }
+      | null
+      | undefined;
+    const safeSample =
+      wrappedSample?.sample ??
+      (this.config.ctx.sample as unknown as GridSizeHintSample | undefined);
     const isSampleFile =
-      this.config.ctx.media.field === "filepath" ||
-      this.config.ctx.media.path === sample.filepath;
-    const sourceSizeBytes = isSampleFile
-      ? getFiniteSizeBytes(sample.metadata?.size_bytes)
-      : 0;
+      Boolean(safeSample) &&
+      (this.config.ctx.media.field === "filepath" ||
+        this.config.ctx.media.path === safeSample?.filepath);
+    const sourceSizeBytes =
+      isSampleFile && safeSample
+        ? getFiniteSizeBytes(safeSample.metadata?.size_bytes)
+        : 0;
     const sourceSizeHintBytes = getSourceSizeHintBytes(
       sourceSizeBytes,
       this.config.ctx.media.mediaType

--- a/app/packages/core/src/components/Grid/GridCustomRendererItem.tsx
+++ b/app/packages/core/src/components/Grid/GridCustomRendererItem.tsx
@@ -98,6 +98,47 @@ type GridItemOptions = {
   inSelectionMode?: boolean;
 };
 
+const BYTES_PER_PIXEL = 4;
+const MIN_GRID_RENDERER_SIZE_BYTES = 1;
+const MULTIMODAL_SOURCE_SIZE_FALLBACK_BYTES = 10 * 1024 * 1024;
+// Large custom-rendered media should influence autosizing, but one giant source
+// file should not force the grid straight to maximum zoom by itself.
+const SOURCE_SIZE_HINT_CAP_BYTES = 50 * 1024 * 1024;
+
+function getFiniteSizeBytes(value: unknown) {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return 0;
+  }
+
+  return Math.trunc(value);
+}
+
+function getPixelSizeBytes(width: number, height: number) {
+  if (!Number.isFinite(width) || !Number.isFinite(height)) {
+    return 0;
+  }
+
+  return Math.max(0, width * height * BYTES_PER_PIXEL);
+}
+
+function getSourceSizeHintBytes(
+  sourceSizeBytes: number,
+  mediaType: string | null
+) {
+  if (sourceSizeBytes > 0) {
+    return Math.min(sourceSizeBytes, SOURCE_SIZE_HINT_CAP_BYTES);
+  }
+
+  if (mediaType === "multimodal") {
+    // Multimodal files often decode expensive container data even when metadata
+    // has not populated size_bytes yet, so bias autosizing as though each item
+    // has a modest source-size hint.
+    return MULTIMODAL_SOURCE_SIZE_FALLBACK_BYTES;
+  }
+
+  return 0;
+}
+
 type GridCustomRendererWrapperProps = React.PropsWithChildren<{
   selected: boolean;
   onOpenModal: React.MouseEventHandler<HTMLButtonElement>;
@@ -167,6 +208,7 @@ export class GridCustomRendererItem {
   private destroyed = false;
   private selected = false;
   private inSelectionMode = false;
+  private dimensions: GridItemDimensions | null = null;
 
   constructor(private readonly config: GridCustomRendererItemConfig) {
     Object.assign(this.hostElement.style, HOST_ELEMENT_STYLES);
@@ -322,6 +364,7 @@ export class GridCustomRendererItem {
     }
 
     this.mountedElement = resolvedElement;
+    this.dimensions = dimensions ?? null;
 
     if (this.hostElement.parentElement !== resolvedElement) {
       // Replace all children of the target element with the host element.
@@ -388,6 +431,31 @@ export class GridCustomRendererItem {
   }
 
   getSizeBytesEstimate() {
-    return 1;
+    const renderedSizeBytes = (() => {
+      const dimensions = this.dimensions;
+      if (dimensions) {
+        const [width, height] = dimensions;
+        return getPixelSizeBytes(width, height);
+      }
+
+      const rect = this.hostElement.getBoundingClientRect();
+      return getPixelSizeBytes(rect.width, rect.height);
+    })();
+
+    const sample = this.config.ctx.sample.sample;
+    const isSampleFile =
+      this.config.ctx.media.field === "filepath" ||
+      this.config.ctx.media.path === sample.filepath;
+    const sourceSizeBytes = isSampleFile
+      ? getFiniteSizeBytes(sample.metadata?.size_bytes)
+      : 0;
+    const sourceSizeHintBytes = getSourceSizeHintBytes(
+      sourceSizeBytes,
+      this.config.ctx.media.mediaType
+    );
+
+    return Math.ceil(
+      MIN_GRID_RENDERER_SIZE_BYTES + renderedSizeBytes + sourceSizeHintBytes
+    );
   }
 }

--- a/app/packages/core/src/components/Grid/GridCustomRendererItem.tsx
+++ b/app/packages/core/src/components/Grid/GridCustomRendererItem.tsx
@@ -5,6 +5,7 @@ import {
 } from "@fiftyone/plugins";
 import type { ID } from "@fiftyone/spotlight";
 import * as fos from "@fiftyone/state";
+import { MEDIA_TYPE_MULTIMODAL } from "@fiftyone/utilities";
 import { Checkbox } from "@mui/material";
 import React from "react";
 import { createRoot, type Root } from "react-dom/client";
@@ -24,8 +25,13 @@ type GridItemDimensions = [width: number, height: number];
 type GridSizeHintSample = {
   filepath?: string;
   metadata?: {
-    size_bytes?: unknown;
-  };
+    size_bytes?: number | null;
+  } | null;
+};
+
+type GridSelectionSample = {
+  _id?: string;
+  id?: string;
 };
 
 /** Error boundary for a sample renderer with fallback behavior. */
@@ -112,15 +118,15 @@ const MULTIMODAL_SOURCE_SIZE_FALLBACK_BYTES = 10 * 1024 * 1024;
 // file should not force the grid straight to maximum zoom by itself.
 const SOURCE_SIZE_HINT_CAP_BYTES = 50 * 1024 * 1024;
 
-function getFiniteSizeBytes(value: unknown) {
-  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+function getFiniteSizeBytes(value: number | null | undefined): number {
+  if (value == null || !Number.isFinite(value) || value < 0) {
     return 0;
   }
 
   return Math.trunc(value);
 }
 
-function getPixelSizeBytes(width: number, height: number) {
+function getPixelSizeBytes(width: number, height: number): number {
   if (!Number.isFinite(width) || !Number.isFinite(height)) {
     return 0;
   }
@@ -131,12 +137,12 @@ function getPixelSizeBytes(width: number, height: number) {
 function getSourceSizeHintBytes(
   sourceSizeBytes: number,
   mediaType: string | null
-) {
+): number {
   if (sourceSizeBytes > 0) {
     return Math.min(sourceSizeBytes, SOURCE_SIZE_HINT_CAP_BYTES);
   }
 
-  if (mediaType === "multimodal") {
+  if (mediaType === MEDIA_TYPE_MULTIMODAL) {
     // Multimodal files often decode expensive container data even when metadata
     // has not populated size_bytes yet, so bias autosizing as though each item
     // has a modest source-size hint.
@@ -215,7 +221,7 @@ export class GridCustomRendererItem {
   private destroyed = false;
   private selected = false;
   private inSelectionMode = false;
-  private dimensions: GridItemDimensions | null = null;
+  private dimensions?: GridItemDimensions;
 
   constructor(private readonly config: GridCustomRendererItemConfig) {
     Object.assign(this.hostElement.style, HOST_ELEMENT_STYLES);
@@ -286,9 +292,9 @@ export class GridCustomRendererItem {
   }
 
   private getSelectionPayload(event: React.MouseEvent<HTMLButtonElement>) {
-    const sample = (this.config.ctx.sample as { sample?: fos.Sample })?.sample;
+    const sample = this.config.ctx.sample?.sample;
     const sampleId =
-      sample?.id ?? sample?._id ?? this.config.symbol.description;
+      sample?._id ?? sample?.["id"] ?? this.config.symbol.description;
 
     return buildThumbnailSelectionDetail({
       id: sampleId,
@@ -357,7 +363,7 @@ export class GridCustomRendererItem {
   attach(
     element: HTMLElement | string,
     dimensions?: GridItemDimensions,
-    fontSize?: number
+    _fontSize?: number
   ) {
     if (this.destroyed) {
       return;
@@ -371,7 +377,7 @@ export class GridCustomRendererItem {
     }
 
     this.mountedElement = resolvedElement;
-    this.dimensions = dimensions ?? null;
+    this.dimensions = dimensions;
 
     if (this.hostElement.parentElement !== resolvedElement) {
       // Replace all children of the target element with the host element.
@@ -437,7 +443,7 @@ export class GridCustomRendererItem {
     return [];
   }
 
-  getSizeBytesEstimate() {
+  getSizeBytesEstimate(): number {
     const renderedSizeBytes = (() => {
       const dimensions = this.dimensions;
       if (dimensions) {

--- a/app/packages/core/src/components/Modal/ModalLooker.tsx
+++ b/app/packages/core/src/components/Modal/ModalLooker.tsx
@@ -1,7 +1,7 @@
 import { useTheme } from "@fiftyone/components";
 import type { ImageLooker } from "@fiftyone/looker";
-import { isNativeMediaType } from "@fiftyone/looker/src/util";
 import * as fos from "@fiftyone/state";
+import { isNativeMediaType } from "@fiftyone/utilities";
 import { useAtomValue } from "jotai";
 import React from "react";
 import { useRecoilCallback, useRecoilValue } from "recoil";

--- a/app/packages/looker/src/util.ts
+++ b/app/packages/looker/src/util.ts
@@ -18,6 +18,10 @@ import {
 import {
   AppError,
   GraphQLError,
+  MEDIA_TYPE_3D,
+  MEDIA_TYPE_GROUP,
+  MEDIA_TYPE_IMAGE,
+  MEDIA_TYPE_VIDEO,
   NetworkError,
   ServerError,
   getFetchParameters,
@@ -603,21 +607,6 @@ function compareObjectArr(arr1: object[], arr2: object[]): boolean {
 
   return JSON.stringify(sortedArr1) === JSON.stringify(sortedArr2);
 }
-
-export const isNativeMediaType = (mediaType: string): boolean => {
-  return [
-    // undefined media_type is assumed to be an image
-    undefined,
-    "image",
-    "video",
-    "3d",
-    "three_d",
-    "pcd",
-    "point-cloud",
-    "point_cloud",
-    "group",
-  ].includes(mediaType);
-};
 
 // list of required attributes for arbitrary data to be "sample-like."
 const sampleTypeKeys = ["_id", "_media_type", "filepath"] as const;

--- a/app/packages/multimodal/src/adapters/mcap/grid-preview.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/grid-preview.test.ts
@@ -1,0 +1,358 @@
+import { describe, expect, it, vi } from "vitest";
+import type {
+  EncodedImageVisualization,
+  ImageAnnotationsVisualization,
+} from "../../decoders";
+import type { ByteSourceDescriptor } from "../../query/bytes";
+import type { StreamInventory } from "../../schemas/v1";
+import { VISUALIZATION_KIND } from "../../visualization";
+import {
+  MCAP_GRID_PREVIEW_ANNOTATION_FRAME_DELAY_MS,
+  chooseAnnotationTopic,
+  chooseCameraSelection,
+  decodeGridPreview,
+  streamTopics,
+} from "./grid-preview";
+import type {
+  McapDecodedMessage,
+  McapResourceClient,
+  McapSynchronizedMessageWindow,
+} from "./types";
+
+describe("MCAP grid preview", () => {
+  it("returns an empty no-camera state and caches the missing selection", async () => {
+    const client = createClient({
+      readTopics: vi.fn(async () => []),
+    });
+    const entry = { client };
+
+    const first = await decodeGridPreview(entry, { source: createSource() });
+    const second = await decodeGridPreview(entry, { source: createSource() });
+
+    expect(first.state).toMatchObject({
+      frame: null,
+      hasImageTopics: false,
+      imageTopic: null,
+      status: "empty",
+    });
+    expect(second.state.status).toBe("empty");
+    expect(client.readTopics).toHaveBeenCalledTimes(1);
+  });
+
+  it("reads an image frame and reuses the cached camera selection", async () => {
+    const readDecodedMessages = vi.fn(async function* (
+      request: Parameters<McapResourceClient["readDecodedMessages"]>[0]
+    ) {
+      yield createImageMessage(request.topics?.[0] ?? "/camera", [1, 2, 3], 7n);
+    });
+    const client = createClient({
+      readDecodedMessages,
+      readTopics: vi.fn(async () => [createTopic("/camera/front")]),
+    });
+    const entry = { client };
+
+    const first = await decodeGridPreview(entry, { source: createSource() });
+    const second = await decodeGridPreview(entry, {
+      source: createSource(),
+      startTimeNs: first.nextStartTimeNs,
+    });
+
+    expect(first.state.status).toBe("ready");
+    expect(first.state.frame?.image.bytes[0]).toBe(1);
+    expect(first.nextStartTimeNs).toBe(8n);
+    expect(second.state.status).toBe("ready");
+    expect(client.readTopics).toHaveBeenCalledTimes(1);
+    expect(readDecodedMessages.mock.calls[1]?.[0]).toMatchObject({
+      startTimeNs: 8n,
+      topics: ["/camera/front"],
+    });
+  });
+
+  it("pairs exact camera annotations with a nearby image frame", async () => {
+    const imageMessage = createImageMessage("/CAM_FRONT/image_rect_compressed");
+    const annotationMessage = createAnnotationMessage(
+      "/CAM_FRONT/annotations",
+      20n
+    );
+    const readDecodedMessages = vi.fn(async function* (
+      request: Parameters<McapResourceClient["readDecodedMessages"]>[0]
+    ) {
+      if (request.topics?.[0] === "/CAM_FRONT/annotations") {
+        yield annotationMessage;
+      }
+    });
+    const readSynchronizedMessages = vi.fn(async () =>
+      createWindow(20n, "/CAM_FRONT/image_rect_compressed", imageMessage)
+    );
+    const client = createClient({
+      readDecodedMessages,
+      readSynchronizedMessages,
+      readTopics: vi.fn(async () => [
+        createTopic("/CAM_FRONT/image_rect_compressed"),
+        createTopic("/CAM_FRONT/annotations", "foxglove.ImageAnnotations"),
+      ]),
+    });
+
+    const result = await decodeGridPreview(
+      { client },
+      { source: createSource() }
+    );
+
+    expect(result.state.status).toBe("ready");
+    expect(result.delayMs).toBe(MCAP_GRID_PREVIEW_ANNOTATION_FRAME_DELAY_MS);
+    expect(result.state.frame?.annotations?.texts[0]?.text).toBe("car");
+    expect(result.state.frame?.image.bytes[0]).toBe(1);
+    expect(readSynchronizedMessages).toHaveBeenCalledWith(
+      expect.objectContaining({
+        timeNs: 20n,
+        topics: ["/CAM_FRONT/image_rect_compressed"],
+      })
+    );
+  });
+
+  it("falls back to image-only frames when selected annotations are unavailable", async () => {
+    const readDecodedMessages = vi.fn(async function* (
+      request: Parameters<McapResourceClient["readDecodedMessages"]>[0]
+    ) {
+      if (request.topics?.[0] === "/CAM_FRONT/image_rect_compressed") {
+        yield createImageMessage(
+          "/CAM_FRONT/image_rect_compressed",
+          [4, 5, 6],
+          30n
+        );
+      }
+    });
+    const client = createClient({
+      readDecodedMessages,
+      readTopics: vi.fn(async () => [
+        createTopic("/CAM_FRONT/image_rect_compressed"),
+        createTopic("/CAM_FRONT/annotations", "foxglove.ImageAnnotations"),
+      ]),
+    });
+
+    const result = await decodeGridPreview(
+      { client },
+      { source: createSource() }
+    );
+
+    expect(result.state.status).toBe("ready");
+    expect(result.state.frame?.annotations).toBeNull();
+    expect(result.state.frame?.image.bytes[0]).toBe(4);
+    expect(result.nextStartTimeNs).toBe(31n);
+    expect(
+      readDecodedMessages.mock.calls.map(([request]) => request.topics)
+    ).toEqual([
+      ["/CAM_FRONT/annotations"],
+      ["/CAM_FRONT/image_rect_compressed"],
+    ]);
+  });
+
+  it("returns empty with image topics when the selected camera has no frame", async () => {
+    const client = createClient({
+      readDecodedMessages: vi.fn(async function* () {
+        for (const item of [] as never[]) {
+          yield item;
+        }
+      }),
+      readTopics: vi.fn(async () => [createTopic("/camera/front")]),
+    });
+
+    const result = await decodeGridPreview(
+      { client },
+      { source: createSource() }
+    );
+
+    expect(result.state).toMatchObject({
+      frame: null,
+      hasImageTopics: true,
+      imageTopic: "/camera/front",
+      status: "empty",
+    });
+  });
+
+  it("classifies image and annotation topics from schema metadata", () => {
+    expect(
+      streamTopics([
+        createTopic("/camera/front"),
+        createTopic("/camera/front/annotations", "foxglove.ImageAnnotations"),
+        createTopic("/tf", "foxglove.FrameTransform"),
+      ])
+    ).toEqual({
+      annotations: ["/camera/front/annotations"],
+      image: ["/camera/front"],
+    });
+  });
+
+  it("deterministically selects the first camera and its matching annotations", () => {
+    const selection = chooseCameraSelection({
+      annotations: ["/CAM_BACK/annotations", "/CAM_FRONT/annotations"],
+      image: [
+        "/CAM_FRONT/image_rect_compressed",
+        "/CAM_BACK/image_rect_compressed",
+      ],
+    });
+
+    expect(selection).toEqual({
+      annotationTopic: "/CAM_FRONT/annotations",
+      imageTopic: "/CAM_FRONT/image_rect_compressed",
+    });
+  });
+
+  it("prefers nested camera annotation siblings", () => {
+    expect(
+      chooseAnnotationTopic("/camera/front/image_rect_compressed", [
+        "/camera/annotations",
+        "/camera/front/annotations",
+      ])
+    ).toBe("/camera/front/annotations");
+  });
+
+  it("does not match camera prefixes across path segment boundaries", () => {
+    expect(
+      chooseAnnotationTopic("/cam/image_rect_compressed", [
+        "/cam_front/annotations",
+      ])
+    ).toBeNull();
+  });
+});
+
+function createClient(
+  overrides: Partial<McapResourceClient> = {}
+): McapResourceClient {
+  return {
+    dispose: vi.fn(),
+    readDecodedMessages: vi.fn(async function* () {
+      for (const item of [] as never[]) {
+        yield item;
+      }
+    }),
+    readFrameTransformBootstrap: vi.fn(),
+    readFrameTransformWindow: vi.fn(),
+    readSynchronizedMessageBatch: vi.fn(async () => []),
+    readSynchronizedMessages: vi.fn(),
+    readTimelineRange: vi.fn(),
+    readTopics: vi.fn(async () => []),
+    ...overrides,
+  };
+}
+
+function createSource(): ByteSourceDescriptor {
+  return {
+    sourceId: "sample-id",
+    url: "memory://sample.mcap",
+  };
+}
+
+function createTopic(
+  topic: string,
+  schema = "foxglove.CompressedImage"
+): StreamInventory {
+  return {
+    $typeName: "fiftyone.multimodal.schemas.v1.StreamInventory",
+    displayName: topic,
+    metadata: {
+      "mcap.schema_name": schema,
+      "mcap.topic": topic,
+    },
+    payload: {
+      $typeName: "fiftyone.multimodal.schemas.v1.PayloadDescriptor",
+      encoding: "protobuf",
+      schema,
+      schemaEncoding: "protobuf",
+    },
+    streamId: topic,
+  };
+}
+
+function createImageMessage(
+  topic: string,
+  bytes = [1, 2, 3],
+  timelineTimeNs = 10n
+): McapDecodedMessage {
+  const visualization: EncodedImageVisualization = {
+    bytes: new Uint8Array(bytes),
+    kind: VISUALIZATION_KIND.ENCODED_IMAGE,
+  };
+
+  return createDecodedMessage(topic, "foxglove.CompressedImage", {
+    visualization,
+    timelineTimeNs,
+  });
+}
+
+function createAnnotationMessage(
+  topic: string,
+  timelineTimeNs = 10n
+): McapDecodedMessage {
+  const visualization: ImageAnnotationsVisualization = {
+    circles: [],
+    kind: VISUALIZATION_KIND.IMAGE_ANNOTATIONS,
+    points: [],
+    texts: [
+      {
+        backgroundColor: null,
+        fontSize: 12,
+        position: [1, 2],
+        text: "car",
+        textColor: null,
+      },
+    ],
+  };
+
+  return createDecodedMessage(topic, "foxglove.ImageAnnotations", {
+    visualization,
+    timelineTimeNs,
+  });
+}
+
+function createDecodedMessage(
+  topic: string,
+  schema: string,
+  {
+    timelineTimeNs,
+    visualization,
+  }: {
+    readonly timelineTimeNs: bigint;
+    readonly visualization: McapDecodedMessage["decoded"]["output"]["visualization"];
+  }
+): McapDecodedMessage {
+  return {
+    activeTimeline: "log",
+    channelId: 1,
+    decoded: {
+      decoderId: "test-decoder",
+      decoderVersion: "1",
+      output: {
+        visualization,
+      },
+      payload: {
+        encoding: "protobuf",
+        schema,
+        schemaEncoding: "protobuf",
+      },
+    },
+    logTimeNs: timelineTimeNs,
+    publishTimeNs: timelineTimeNs,
+    sequence: 1,
+    timelineTimeNs,
+    topic,
+  };
+}
+
+function createWindow(
+  timeNs: bigint,
+  topic: string,
+  message: McapDecodedMessage
+): McapSynchronizedMessageWindow {
+  return {
+    activeTimeline: "log",
+    endTimeNs: timeNs,
+    messages: [message],
+    messagesByTopic: {
+      [topic]: [message],
+    },
+    startTimeNs: timeNs,
+    streamPolicies: {},
+    timeNs,
+  };
+}

--- a/app/packages/multimodal/src/adapters/mcap/grid-preview.ts
+++ b/app/packages/multimodal/src/adapters/mcap/grid-preview.ts
@@ -1,0 +1,507 @@
+import type {
+  EncodedImageVisualization,
+  ImageAnnotationsVisualization,
+} from "../../decoders";
+import type { ByteSourceDescriptor } from "../../query/bytes";
+import { PlaybackSyncMode, type StreamInventory } from "../../schemas/v1";
+import { VISUALIZATION_KIND } from "../../visualization";
+import type {
+  McapDecodedMessage,
+  McapResourceClient,
+  McapStreamSyncPolicy,
+} from "./types";
+
+// Note: we only support compressed image topics for preview now
+const COMPRESSED_IMAGE_PATTERN = /compressedimage/i;
+const IMAGE_ANNOTATIONS_PATTERN = /imageannotations/i;
+const IMAGE_SYNC_TOLERANCE_NS = 120_000_000n;
+const NEXT_FRAME_STEP_NS = 1n;
+
+const IMAGE_SYNC_POLICY: McapStreamSyncPolicy = {
+  mode: PlaybackSyncMode.NEAREST,
+  toleranceAfterNs: IMAGE_SYNC_TOLERANCE_NS,
+  toleranceBeforeNs: IMAGE_SYNC_TOLERANCE_NS,
+} as const;
+
+// Drop generic topic words before scoring image/annotation topic similarity so
+// camera-identifying tokens like "front" or "left" decide the best match.
+const IGNORED_TOPIC_TOKENS = new Set([
+  "annotation",
+  "annotations",
+  "cam",
+  "camera",
+  "compressed",
+  "image",
+  "rect",
+]);
+
+// Strip image-format suffix segments when deriving the camera topic prefix, so
+// "/camera/front/image_rect_compressed" pairs with "/camera/front/annotations".
+const IMAGE_TOPIC_SUFFIX_TOKENS = new Set([
+  "compressed",
+  "compressedimage",
+  "image",
+  "raw",
+  "rect",
+]);
+
+/**
+ * Default playback speed for animated MCAP grid previews.
+ */
+export const DEFAULT_MCAP_GRID_PREVIEW_PLAYBACK_RATE = 1.5;
+
+/**
+ * Default cadence for image-only MCAP grid preview playback.
+ */
+export const MCAP_GRID_PREVIEW_IMAGE_FRAME_DELAY_MS = 83;
+
+/**
+ * Default cadence for annotated MCAP grid preview playback.
+ */
+export const MCAP_GRID_PREVIEW_ANNOTATION_FRAME_DELAY_MS = 500;
+
+/**
+ * Camera and annotation topic buckets used by grid preview selection.
+ */
+export interface McapGridTopics {
+  readonly annotations: readonly string[];
+  readonly image: readonly string[];
+}
+
+/**
+ * Selected camera image topic plus its best matching annotation topic.
+ */
+export interface McapGridCameraSelection {
+  readonly annotationTopic: string | null;
+  readonly imageTopic: string;
+}
+
+/**
+ * Render-ready image preview frame, optionally paired with annotations.
+ */
+export interface McapGridPreviewFrame {
+  readonly annotations: ImageAnnotationsVisualization | null;
+  readonly image: EncodedImageVisualization;
+}
+
+/**
+ * Status values used by the MCAP grid preview renderer.
+ */
+export type McapGridPreviewStatus =
+  | "idle"
+  | "loading"
+  | "ready"
+  | "empty"
+  | "error";
+
+/**
+ * Render state for one lightweight MCAP camera preview in the grid.
+ */
+export interface McapGridPreviewSnapshot {
+  readonly error: string | null;
+  readonly frame: McapGridPreviewFrame | null;
+  readonly hasImageTopics: boolean;
+  readonly imageTopic: string | null;
+  readonly status: McapGridPreviewStatus;
+}
+
+/**
+ * Result returned by the grid preview worker for one high-level request.
+ */
+export interface McapGridPreviewResult {
+  readonly delayMs?: number;
+  readonly nextStartTimeNs?: bigint;
+  readonly state: McapGridPreviewSnapshot;
+}
+
+/**
+ * Worker-side cache entry for one MCAP source preview.
+ */
+export interface McapGridPreviewEntry {
+  readonly client: McapResourceClient;
+  selection?: McapGridCameraSelection | null;
+}
+
+/**
+ * High-level grid preview decode request handled inside the shared worker pool.
+ */
+export interface McapGridPreviewDecodeRequest {
+  readonly source: ByteSourceDescriptor;
+  readonly startTimeNs?: bigint;
+}
+
+/**
+ * Ensures a cached source camera selection and reads one render-ready preview.
+ */
+export async function decodeGridPreview(
+  entry: McapGridPreviewEntry,
+  { source, startTimeNs }: McapGridPreviewDecodeRequest
+): Promise<McapGridPreviewResult> {
+  if (entry.selection === undefined) {
+    const topics = streamTopics(await entry.client.readTopics({ source }));
+    entry.selection = chooseCameraSelection(topics);
+  }
+
+  const selection = entry.selection;
+  if (!selection) {
+    return {
+      state: {
+        error: null,
+        frame: null,
+        hasImageTopics: false,
+        imageTopic: null,
+        status: "empty",
+      },
+    };
+  }
+
+  const result = await readNextPreviewFrame({
+    client: entry.client,
+    selection,
+    source,
+    startTimeNs,
+  });
+
+  if (!result) {
+    return {
+      state: {
+        error: null,
+        frame: null,
+        hasImageTopics: true,
+        imageTopic: selection.imageTopic,
+        status: "empty",
+      },
+    };
+  }
+
+  return {
+    delayMs: result.delayMs,
+    nextStartTimeNs: result.nextStartTimeNs,
+    state: {
+      error: null,
+      frame: result.frame,
+      hasImageTopics: true,
+      imageTopic: selection.imageTopic,
+      status: "ready",
+    },
+  };
+}
+
+/**
+ * Picks the first camera stream and its best matching annotation topic.
+ * Deterministic so a sample keeps the same preview camera across renders.
+ */
+export function chooseCameraSelection(
+  topics: McapGridTopics
+): McapGridCameraSelection | null {
+  const imageTopic = topics.image[0];
+  if (!imageTopic) {
+    return null;
+  }
+
+  return {
+    annotationTopic: chooseAnnotationTopic(imageTopic, topics.annotations),
+    imageTopic,
+  };
+}
+
+interface ReadPreviewFrameRequest {
+  readonly client: McapResourceClient;
+  readonly selection: McapGridCameraSelection;
+  readonly source: ByteSourceDescriptor;
+  readonly startTimeNs?: bigint;
+}
+
+/**
+ * One decoded preview frame plus playback timing for the next tick.
+ */
+interface McapGridPreviewReadResult {
+  readonly delayMs: number;
+  readonly frame: McapGridPreviewFrame;
+  readonly nextStartTimeNs: bigint;
+}
+
+async function readNextPreviewFrame(
+  request: ReadPreviewFrameRequest
+): Promise<McapGridPreviewReadResult | null> {
+  if (request.selection.annotationTopic) {
+    const annotatedFrame = await readNextAnnotatedPreviewFrame(request);
+    if (annotatedFrame) {
+      return annotatedFrame;
+    }
+  }
+
+  return readNextImagePreviewFrame(request);
+}
+
+async function readNextImagePreviewFrame({
+  client,
+  selection,
+  source,
+  startTimeNs,
+}: ReadPreviewFrameRequest): Promise<McapGridPreviewReadResult | null> {
+  const imageMessage = await readNextMessage({
+    client,
+    source,
+    startTimeNs,
+    topic: selection.imageTopic,
+  });
+  const image = imageMessage ? imageFrame(imageMessage) : null;
+
+  if (!imageMessage || !image) {
+    return null;
+  }
+
+  return {
+    delayMs: MCAP_GRID_PREVIEW_IMAGE_FRAME_DELAY_MS,
+    frame: { annotations: null, image },
+    nextStartTimeNs: imageMessage.timelineTimeNs + NEXT_FRAME_STEP_NS,
+  };
+}
+
+async function readNextAnnotatedPreviewFrame({
+  client,
+  selection,
+  source,
+  startTimeNs,
+}: ReadPreviewFrameRequest): Promise<McapGridPreviewReadResult | null> {
+  if (!selection.annotationTopic) {
+    return null;
+  }
+
+  const annotationMessage = await readNextMessage({
+    client,
+    source,
+    startTimeNs,
+    topic: selection.annotationTopic,
+  });
+  const annotations = annotationMessage
+    ? annotationsFrame(annotationMessage)
+    : null;
+
+  if (!annotationMessage || !annotations) {
+    return null;
+  }
+
+  const image =
+    (await readImageFrameNear({
+      client,
+      source,
+      timeNs: annotationMessage.timelineTimeNs,
+      topic: selection.imageTopic,
+    })) ??
+    (await readNextMessage({
+      client,
+      source,
+      startTimeNs: annotationMessage.timelineTimeNs,
+      topic: selection.imageTopic,
+    }).then((message) => (message ? imageFrame(message) : null)));
+
+  if (!image) {
+    return null;
+  }
+
+  return {
+    delayMs: MCAP_GRID_PREVIEW_ANNOTATION_FRAME_DELAY_MS,
+    frame: { annotations, image },
+    nextStartTimeNs: annotationMessage.timelineTimeNs + NEXT_FRAME_STEP_NS,
+  };
+}
+
+async function readNextMessage({
+  client,
+  source,
+  startTimeNs,
+  topic,
+}: {
+  readonly client: McapResourceClient;
+  readonly source: ByteSourceDescriptor;
+  readonly startTimeNs?: bigint;
+  readonly topic: string;
+}): Promise<McapDecodedMessage | null> {
+  for await (const message of client.readDecodedMessages({
+    limit: 1,
+    source,
+    startTimeNs,
+    topics: [topic],
+  })) {
+    return message;
+  }
+
+  return null;
+}
+
+async function readImageFrameNear({
+  client,
+  source,
+  timeNs,
+  topic,
+}: {
+  readonly client: McapResourceClient;
+  readonly source: ByteSourceDescriptor;
+  readonly timeNs: bigint;
+  readonly topic: string;
+}): Promise<EncodedImageVisualization | null> {
+  const window = await client.readSynchronizedMessages({
+    source,
+    streamPolicies: {
+      [topic]: IMAGE_SYNC_POLICY,
+    },
+    timeNs,
+    topics: [topic],
+  });
+  const message = window.messagesByTopic[topic]?.[0];
+  return message ? imageFrame(message) : null;
+}
+
+function imageFrame(
+  message: McapDecodedMessage
+): EncodedImageVisualization | null {
+  const visualization = message.decoded.output.visualization;
+  return visualization?.kind === VISUALIZATION_KIND.ENCODED_IMAGE
+    ? visualization
+    : null;
+}
+
+function annotationsFrame(
+  message: McapDecodedMessage
+): ImageAnnotationsVisualization | null {
+  const visualization = message.decoded.output.visualization;
+  return visualization?.kind === VISUALIZATION_KIND.IMAGE_ANNOTATIONS
+    ? visualization
+    : null;
+}
+
+/**
+ * Splits stream inventory into image and annotation topics.
+ */
+export function streamTopics(
+  topics: readonly StreamInventory[]
+): McapGridTopics {
+  const image: string[] = [];
+  const annotations: string[] = [];
+
+  for (const topic of topics) {
+    const name = topicName(topic);
+    if (!name) {
+      continue;
+    }
+
+    if (isCompressedImageStream(topic)) {
+      image.push(name);
+    } else if (isImageAnnotationsStream(topic)) {
+      annotations.push(name);
+    }
+  }
+
+  return { annotations, image };
+}
+
+function topicName(topic: StreamInventory): string {
+  return topic.metadata["mcap.topic"] ?? topic.displayName ?? "";
+}
+
+function schemaIdentity(topic: StreamInventory): string {
+  return [topic.payload?.schema, topic.metadata["mcap.schema_name"]].join(" ");
+}
+
+function isCompressedImageStream(topic: StreamInventory): boolean {
+  if (COMPRESSED_IMAGE_PATTERN.test(schemaIdentity(topic))) {
+    return true;
+  }
+
+  const name = topicName(topic).toLowerCase();
+  return name.includes("compressed") && name.includes("image");
+}
+
+function isImageAnnotationsStream(topic: StreamInventory): boolean {
+  if (IMAGE_ANNOTATIONS_PATTERN.test(schemaIdentity(topic))) {
+    return true;
+  }
+
+  return topicName(topic).toLowerCase().includes("annotation");
+}
+
+/**
+ * Chooses the annotation topic that best matches a selected camera topic.
+ * Prefers the exact `<camera prefix>/annotations` sibling, then falls back
+ * to the highest shared-token score.
+ */
+export function chooseAnnotationTopic(
+  imageTopic: string,
+  annotationTopics: readonly string[]
+): string | null {
+  if (annotationTopics.length === 0) {
+    return null;
+  }
+
+  const cameraPrefix = topicPrefix(imageTopic);
+  const exactTopic = cameraPrefix ? `${cameraPrefix}/annotations` : "";
+  const exact = annotationTopics.find((topic) => topic === exactTopic);
+  if (exact) {
+    return exact;
+  }
+
+  let bestTopic: string | null = null;
+  let bestScore = 0;
+  const imageTokens = topicTokens(imageTopic);
+
+  for (const annotationTopic of annotationTopics) {
+    const annotationTokens = topicTokens(annotationTopic);
+    let score =
+      cameraPrefix && isTopicAtOrBelowPrefix(annotationTopic, cameraPrefix)
+        ? 10
+        : 0;
+    for (const token of imageTokens) {
+      if (annotationTokens.has(token)) {
+        score += 1;
+      }
+    }
+
+    if (score > bestScore) {
+      bestScore = score;
+      bestTopic = annotationTopic;
+    }
+  }
+
+  return bestTopic;
+}
+
+function topicPrefix(topic: string): string {
+  const normalized = topic.replace(/\/+$/, "");
+  const hasLeadingSlash = normalized.startsWith("/");
+  const parts = normalized.split("/").filter(Boolean);
+
+  while (parts.length > 0 && isImageTopicSuffix(parts[parts.length - 1])) {
+    parts.pop();
+  }
+
+  return parts.length > 0
+    ? `${hasLeadingSlash ? "/" : ""}${parts.join("/")}`
+    : "";
+}
+
+function isTopicAtOrBelowPrefix(topic: string, prefix: string): boolean {
+  return topic === prefix || topic.startsWith(`${prefix}/`);
+}
+
+function isImageTopicSuffix(segment: string): boolean {
+  const tokens = segment
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+
+  return (
+    tokens.length > 0 &&
+    tokens.every((token) => IMAGE_TOPIC_SUFFIX_TOKENS.has(token))
+  );
+}
+
+function topicTokens(topic: string): Set<string> {
+  return new Set(
+    topic
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter((token) => token && !IGNORED_TOPIC_TOKENS.has(token))
+  );
+}

--- a/app/packages/multimodal/src/adapters/mcap/grid-preview.ts
+++ b/app/packages/multimodal/src/adapters/mcap/grid-preview.ts
@@ -406,20 +406,11 @@ function schemaIdentity(topic: StreamInventory): string {
 }
 
 function isCompressedImageStream(topic: StreamInventory): boolean {
-  if (COMPRESSED_IMAGE_PATTERN.test(schemaIdentity(topic))) {
-    return true;
-  }
-
-  return false;
+  return COMPRESSED_IMAGE_PATTERN.test(schemaIdentity(topic));
 }
 
 function isImageAnnotationsStream(topic: StreamInventory): boolean {
-  const identity = schemaIdentity(topic);
-  if (IMAGE_ANNOTATIONS_PATTERN.test(identity)) {
-    return true;
-  }
-
-  return false;
+  return IMAGE_ANNOTATIONS_PATTERN.test(schemaIdentity(topic));
 }
 
 /**

--- a/app/packages/multimodal/src/adapters/mcap/grid-preview.ts
+++ b/app/packages/multimodal/src/adapters/mcap/grid-preview.ts
@@ -410,16 +410,16 @@ function isCompressedImageStream(topic: StreamInventory): boolean {
     return true;
   }
 
-  const name = topicName(topic).toLowerCase();
-  return name.includes("compressed") && name.includes("image");
+  return false;
 }
 
 function isImageAnnotationsStream(topic: StreamInventory): boolean {
-  if (IMAGE_ANNOTATIONS_PATTERN.test(schemaIdentity(topic))) {
+  const identity = schemaIdentity(topic);
+  if (IMAGE_ANNOTATIONS_PATTERN.test(identity)) {
     return true;
   }
 
-  return topicName(topic).toLowerCase().includes("annotation");
+  return false;
 }
 
 /**

--- a/app/packages/multimodal/src/adapters/mcap/react/GridRenderer.module.css
+++ b/app/packages/multimodal/src/adapters/mcap/react/GridRenderer.module.css
@@ -22,12 +22,6 @@
   position: absolute;
 }
 
-/* Grid cells are small; thin annotation strokes read better than the
-   modal-scale defaults. */
-.annotationLayer svg [stroke-width] {
-  stroke-width: 1px !important;
-}
-
 .status {
   font-size: 12px;
   font-weight: 600;

--- a/app/packages/multimodal/src/adapters/mcap/react/GridRenderer.module.css
+++ b/app/packages/multimodal/src/adapters/mcap/react/GridRenderer.module.css
@@ -1,0 +1,55 @@
+.root {
+  align-items: center;
+  background: #101114;
+  color: rgba(255, 255, 255, 0.78);
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  overflow: hidden;
+  position: relative;
+  width: 100%;
+}
+
+.imagePanel {
+  inset: 0;
+  position: absolute;
+}
+
+.annotationLayer {
+  inset: 0;
+  opacity: 0.5;
+  pointer-events: none;
+  position: absolute;
+}
+
+/* Grid cells are small; thin annotation strokes read better than the
+   modal-scale defaults. */
+.annotationLayer svg [stroke-width] {
+  stroke-width: 1px !important;
+}
+
+.status {
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.3;
+  padding: 12px;
+  text-align: center;
+}
+
+.statusTitle {
+  align-items: center;
+  display: inline-flex;
+  gap: 8px;
+  justify-content: center;
+}
+
+.error {
+  color: rgba(255, 120, 120, 0.78);
+  font-size: 11px;
+  font-weight: 500;
+  margin-top: 4px;
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/GridRenderer.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/GridRenderer.test.tsx
@@ -1,0 +1,47 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GridRenderer } from "./GridRenderer";
+
+const previewHarness = vi.hoisted(() => ({
+  preview: {
+    error: null,
+    frame: null,
+    hasImageTopics: false,
+    imageTopic: null,
+    pause: vi.fn(),
+    play: vi.fn(),
+    status: "idle",
+  },
+}));
+
+vi.mock("./use-stable-mcap-source", () => ({
+  useStableMcapSource: vi.fn(() => null),
+}));
+
+vi.mock("./use-mcap-grid-preview", () => ({
+  useMcapGridPreview: vi.fn(() => previewHarness.preview),
+}));
+
+vi.mock("../../../visualization/panels/ImageAnnotationsOverlay", () => ({
+  ImageAnnotationsOverlay: () => <div data-testid="annotations-overlay" />,
+}));
+
+vi.mock("../../../visualization/panels/image", () => ({
+  ImagePanel: () => <div data-testid="image-panel" />,
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("GridRenderer", () => {
+  it("shows idle as an empty no-source state without loading animation", () => {
+    previewHarness.preview.status = "idle";
+    previewHarness.preview.hasImageTopics = false;
+
+    render(<GridRenderer ctx={{} as never} />);
+
+    expect(screen.getByText("No camera streams")).toBeTruthy();
+    expect(screen.queryByTestId("mcap-loading-ascii")).toBeNull();
+  });
+});

--- a/app/packages/multimodal/src/adapters/mcap/react/GridRenderer.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/GridRenderer.tsx
@@ -88,7 +88,7 @@ function PreviewStatus({
   readonly hasImageTopics: boolean;
   readonly status: McapGridPreviewStatus;
 }) {
-  const loading = status === "idle" || status === "loading";
+  const loading = status === "loading";
   const message = loading
     ? null
     : status === "error"

--- a/app/packages/multimodal/src/adapters/mcap/react/GridRenderer.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/GridRenderer.tsx
@@ -1,31 +1,109 @@
-/**
- * THIS IS POC CODE FOR DEMO COUPLED WITH NUSCENES.
- * TODO(FOEPD-3830): REPLACE THIS DECODE/FETCH SLICE WITH PRODUCTION CODE.
- */
 import type { SampleRendererProps } from "@fiftyone/plugins";
-import { useMcapSampleTopics } from "./use-mcap-sample-topics";
+import { useState } from "react";
+import { ImageAnnotationsOverlay } from "../../../visualization/panels/ImageAnnotationsOverlay";
+import { ImagePanel } from "../../../visualization/panels/image";
+import type { McapGridPreviewFrame } from "../grid-preview";
+import classes from "./GridRenderer.module.css";
+import { McapLoadingAscii } from "./McapLoadingAscii";
+import {
+  useMcapGridPreview,
+  type McapGridPreviewStatus,
+} from "./use-mcap-grid-preview";
+import { useStableMcapSource } from "./use-stable-mcap-source";
+
+const IMAGE_FIT = "cover";
 
 /**
- * Grid proof renderer for MCAP-backed multimodal samples.
+ * Grid renderer for MCAP-backed multimodal samples. Shows one camera
+ * preview frame and plays the stream while hovered.
  */
 export function GridRenderer({ ctx }: SampleRendererProps) {
-  const topicState = useMcapSampleTopics(ctx);
-
-  if (topicState.status === "ready") {
-    return <div>{topicState.topics.length} topics</div>;
-  }
-
-  const message =
-    topicState.status === "idle"
-      ? "MCAP source missing"
-      : topicState.status === "error"
-      ? "Topics unavailable"
-      : "Loading topics";
+  const source = useStableMcapSource(ctx);
+  const preview = useMcapGridPreview({ source });
 
   return (
-    <div>
-      <div>{message}</div>
-      {topicState.status === "error" && <div>{topicState.error}</div>}
+    <div
+      className={classes.root}
+      onPointerEnter={preview.play}
+      onPointerLeave={preview.pause}
+    >
+      {preview.frame ? (
+        <PreviewFrame
+          // Image dimensions are per camera stream; remount to drop stale
+          // dimensions when the source or selected topic changes.
+          key={`${source?.sourceId ?? ""}:${preview.imageTopic ?? ""}`}
+          frame={preview.frame}
+        />
+      ) : (
+        <PreviewStatus
+          error={preview.error}
+          hasImageTopics={preview.hasImageTopics}
+          status={preview.status}
+        />
+      )}
+    </div>
+  );
+}
+
+function PreviewFrame({ frame }: { readonly frame: McapGridPreviewFrame }) {
+  const [imageDims, setImageDims] = useState<{
+    width: number;
+    height: number;
+  } | null>(null);
+
+  return (
+    <>
+      <ImagePanel
+        className={classes.imagePanel}
+        fit={IMAGE_FIT}
+        frame={frame.image}
+        onImageLoaded={(width, height) =>
+          setImageDims((prev) =>
+            prev?.width === width && prev?.height === height
+              ? prev
+              : { width, height }
+          )
+        }
+      />
+      {imageDims && frame.annotations ? (
+        <div className={classes.annotationLayer}>
+          <ImageAnnotationsOverlay
+            annotations={[frame.annotations]}
+            fit={IMAGE_FIT}
+            imageHeight={imageDims.height}
+            imageWidth={imageDims.width}
+          />
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+function PreviewStatus({
+  error,
+  hasImageTopics,
+  status,
+}: {
+  readonly error: string | null;
+  readonly hasImageTopics: boolean;
+  readonly status: McapGridPreviewStatus;
+}) {
+  const loading = status === "idle" || status === "loading";
+  const message = loading
+    ? null
+    : status === "error"
+    ? "Preview unavailable"
+    : hasImageTopics
+    ? "No preview frames"
+    : "No camera streams";
+
+  return (
+    <div className={classes.status}>
+      <div className={classes.statusTitle}>
+        {loading ? <McapLoadingAscii /> : null}
+        {message ? <span>{message}</span> : null}
+      </div>
+      {error ? <div className={classes.error}>{error}</div> : null}
     </div>
   );
 }

--- a/app/packages/multimodal/src/adapters/mcap/react/GridRenderer.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/GridRenderer.tsx
@@ -12,6 +12,7 @@ import {
 import { useStableMcapSource } from "./use-stable-mcap-source";
 
 const IMAGE_FIT = "cover";
+const GRID_ANNOTATION_STROKE_WIDTH = 1;
 
 /**
  * Grid renderer for MCAP-backed multimodal samples. Shows one camera
@@ -72,6 +73,7 @@ function PreviewFrame({ frame }: { readonly frame: McapGridPreviewFrame }) {
             fit={IMAGE_FIT}
             imageHeight={imageDims.height}
             imageWidth={imageDims.width}
+            strokeWidth={GRID_ANNOTATION_STROKE_WIDTH}
           />
         </div>
       ) : null}
@@ -89,13 +91,7 @@ function PreviewStatus({
   readonly status: McapGridPreviewStatus;
 }) {
   const loading = status === "loading";
-  const message = loading
-    ? null
-    : status === "error"
-    ? "Preview unavailable"
-    : hasImageTopics
-    ? "No preview frames"
-    : "No camera streams";
+  const message = previewStatusMessage(status, hasImageTopics);
 
   return (
     <div className={classes.status}>
@@ -106,4 +102,19 @@ function PreviewStatus({
       {error ? <div className={classes.error}>{error}</div> : null}
     </div>
   );
+}
+
+function previewStatusMessage(
+  status: McapGridPreviewStatus,
+  hasImageTopics: boolean
+): string | null {
+  if (status === "loading") {
+    return null;
+  }
+
+  if (status === "error") {
+    return "Preview unavailable";
+  }
+
+  return hasImageTopics ? "No preview frames" : "No camera streams";
 }

--- a/app/packages/multimodal/src/adapters/mcap/react/McapLoadingAscii.module.css
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapLoadingAscii.module.css
@@ -9,9 +9,9 @@
 }
 
 .fallingAsciiBoxInner {
-  animation: mcapAsciiFall 1.15s ease-in infinite;
+  animation: mcap-ascii-fall 1.15s ease-in infinite;
   display: block;
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-family: "SF Mono", Consolas, "Liberation Mono", monospace;
   font-size: 6px;
   font-weight: 800;
   line-height: 0.9;
@@ -20,7 +20,7 @@
   white-space: pre;
 }
 
-@keyframes mcapAsciiFall {
+@keyframes mcap-ascii-fall {
   0% {
     opacity: 0;
     transform: translateY(-14px);

--- a/app/packages/multimodal/src/adapters/mcap/react/McapLoadingAscii.module.css
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapLoadingAscii.module.css
@@ -1,0 +1,41 @@
+.fallingAsciiBox {
+  color: rgba(108, 214, 255, 0.9);
+  display: inline-block;
+  flex: 0 0 auto;
+  height: 22px;
+  overflow: hidden;
+  position: relative;
+  width: 28px;
+}
+
+.fallingAsciiBoxInner {
+  animation: mcapAsciiFall 1.15s ease-in infinite;
+  display: block;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 6px;
+  font-weight: 800;
+  line-height: 0.9;
+  text-align: left;
+  text-shadow: 0 0 8px rgba(108, 214, 255, 0.5);
+  white-space: pre;
+}
+
+@keyframes mcapAsciiFall {
+  0% {
+    opacity: 0;
+    transform: translateY(-14px);
+  }
+
+  24% {
+    opacity: 1;
+  }
+
+  74% {
+    opacity: 1;
+  }
+
+  100% {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/McapLoadingAscii.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapLoadingAscii.tsx
@@ -1,0 +1,16 @@
+import classes from "./McapLoadingAscii.module.css";
+
+/**
+ * Tiny falling-box ASCII animation shown while a grid preview loads.
+ */
+export function McapLoadingAscii() {
+  return (
+    <span
+      aria-hidden="true"
+      className={classes.fallingAsciiBox}
+      data-testid="mcap-loading-ascii"
+    >
+      <span className={classes.fallingAsciiBoxInner}>{"+--+\n|  |\n+--+"}</span>
+    </span>
+  );
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/index.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/index.ts
@@ -8,13 +8,6 @@ export { GridRenderer } from "./GridRenderer";
  */
 export { useMcapResourceClient } from "./use-mcap-resource-client";
 export type { UseMcapResourceClientOptions } from "./use-mcap-resource-client";
-export { useMcapSampleTopics } from "./use-mcap-sample-topics";
 export { useMcapFrameTransforms } from "./use-mcap-frame-transforms";
 export type { McapFrameTransformResolver } from "./use-mcap-frame-transforms";
-export { useMcapTopics } from "./use-mcap-topics";
-export type {
-  McapTopicsState,
-  McapTopicsStatus,
-  UseMcapTopicsOptions,
-} from "./use-mcap-topics";
 export { useStableMcapSource } from "./use-stable-mcap-source";

--- a/app/packages/multimodal/src/adapters/mcap/react/use-mcap-grid-preview.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-mcap-grid-preview.test.tsx
@@ -1,0 +1,259 @@
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { useEffect } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { EncodedImageVisualization } from "../../../decoders";
+import type { ByteSourceDescriptor } from "../../../query/bytes";
+import { VISUALIZATION_KIND } from "../../../visualization";
+import type { McapGridPreviewResult } from "../grid-preview";
+import {
+  useMcapGridPreview,
+  type McapGridPreviewState,
+} from "./use-mcap-grid-preview";
+
+const poolHarness = vi.hoisted(() => {
+  const pool = {
+    acquire: vi.fn(),
+    release: vi.fn(),
+    request: vi.fn(),
+  };
+
+  return {
+    getMcapGridPreviewPool: vi.fn(() => pool),
+    pool,
+  };
+});
+
+vi.mock("../worker", () => ({
+  getMcapGridPreviewPool: poolHarness.getMcapGridPreviewPool,
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useMcapGridPreview", () => {
+  beforeEach(() => {
+    poolHarness.getMcapGridPreviewPool.mockClear();
+    poolHarness.pool.acquire.mockClear();
+    poolHarness.pool.release.mockClear();
+    poolHarness.pool.request.mockReset();
+  });
+
+  it("loads an initial preview through the shared pool", async () => {
+    poolHarness.pool.request.mockResolvedValueOnce(
+      readyResult({ bytes: [1, 2, 3], nextStartTimeNs: 5n })
+    );
+
+    const { unmount } = render(
+      <PreviewHarness id="initial" source={sourceForId("initial")} />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("preview-initial").textContent).toBe(
+        "ready:1:frame:"
+      );
+    });
+
+    expect(poolHarness.pool.acquire).toHaveBeenCalledTimes(1);
+    expect(poolHarness.pool.request).toHaveBeenCalledWith(
+      { source: sourceForId("initial") },
+      { signal: expect.any(AbortSignal) }
+    );
+
+    const signal = poolHarness.pool.request.mock.calls[0]?.[1]
+      ?.signal as AbortSignal;
+    unmount();
+
+    expect(signal.aborted).toBe(true);
+    expect(poolHarness.pool.release).toHaveBeenCalledTimes(1);
+  });
+
+  it("aborts stale source loads and ignores late results", async () => {
+    const first = deferred<McapGridPreviewResult>();
+    poolHarness.pool.request
+      .mockReturnValueOnce(first.promise)
+      .mockResolvedValueOnce(emptyResult(false));
+
+    const { rerender } = render(
+      <PreviewHarness id="source" source={sourceForId("first")} />
+    );
+    const firstSignal = poolHarness.pool.request.mock.calls[0]?.[1]
+      ?.signal as AbortSignal;
+
+    rerender(<PreviewHarness id="source" source={sourceForId("second")} />);
+
+    expect(firstSignal.aborted).toBe(true);
+    first.resolve(readyResult({ bytes: [9], nextStartTimeNs: 9n }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("preview-source").textContent).toBe(
+        "empty:0:no-frame:"
+      );
+    });
+    expect(poolHarness.pool.acquire).toHaveBeenCalledTimes(2);
+    expect(poolHarness.pool.release).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces initial load failures", async () => {
+    poolHarness.pool.request.mockRejectedValueOnce(new Error("boom"));
+
+    render(<PreviewHarness id="error" source={sourceForId("error")} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("preview-error").textContent).toBe(
+        "error:0:no-frame:boom"
+      );
+    });
+  });
+
+  it("plays additional preview frames on hover", async () => {
+    const latestState = { current: null as McapGridPreviewState | null };
+    const hover = deferred<McapGridPreviewResult>();
+    poolHarness.pool.request
+      .mockResolvedValueOnce(
+        readyResult({ bytes: [1, 2, 3], nextStartTimeNs: 10n })
+      )
+      .mockReturnValueOnce(hover.promise);
+
+    render(
+      <PreviewHarness
+        id="hover"
+        onState={(state) => {
+          latestState.current = state;
+        }}
+        source={sourceForId("hover")}
+      />
+    );
+
+    await waitFor(() => {
+      expect(latestState.current?.status).toBe("ready");
+    });
+    expect(latestState.current?.frame?.image.bytes[0]).toBe(1);
+
+    act(() => {
+      latestState.current?.play();
+    });
+
+    await waitFor(() => {
+      expect(poolHarness.pool.request).toHaveBeenCalledTimes(2);
+    });
+    expect(poolHarness.pool.request.mock.calls[1]?.[0]).toMatchObject({
+      source: sourceForId("hover"),
+      startTimeNs: 10n,
+    });
+
+    hover.resolve(readyResult({ bytes: [9, 8, 7], nextStartTimeNs: 20n }));
+
+    await waitFor(() => {
+      expect(latestState.current?.frame?.image.bytes[0]).toBe(9);
+    });
+
+    act(() => {
+      latestState.current?.pause();
+    });
+    expect(poolHarness.pool.release).not.toHaveBeenCalled();
+  });
+});
+
+function PreviewHarness({
+  id,
+  onState,
+  source,
+}: {
+  readonly id: string;
+  readonly onState?: (state: McapGridPreviewState) => void;
+  readonly source: ByteSourceDescriptor | null;
+}) {
+  const state = useMcapGridPreview({ source });
+
+  useEffect(() => {
+    onState?.(state);
+  }, [onState, state]);
+
+  return <div data-testid={`preview-${id}`}>{formatState(state)}</div>;
+}
+
+function formatState(state: McapGridPreviewState): string {
+  return [
+    state.status,
+    state.hasImageTopics ? "1" : "0",
+    state.frame ? "frame" : "no-frame",
+    state.error ?? "",
+  ].join(":");
+}
+
+function readyResult({
+  bytes,
+  nextStartTimeNs,
+}: {
+  readonly bytes: readonly number[];
+  readonly nextStartTimeNs: bigint;
+}): McapGridPreviewResult {
+  return {
+    delayMs: 83,
+    nextStartTimeNs,
+    state: {
+      error: null,
+      frame: {
+        annotations: null,
+        image: createImage(bytes),
+      },
+      hasImageTopics: true,
+      imageTopic: "/camera/front",
+      status: "ready",
+    },
+  };
+}
+
+function emptyResult(hasImageTopics: boolean): McapGridPreviewResult {
+  return {
+    state: {
+      error: null,
+      frame: null,
+      hasImageTopics,
+      imageTopic: hasImageTopics ? "/camera/front" : null,
+      status: "empty",
+    },
+  };
+}
+
+function createImage(bytes: readonly number[]): EncodedImageVisualization {
+  return {
+    bytes: new Uint8Array(bytes),
+    kind: VISUALIZATION_KIND.ENCODED_IMAGE,
+  };
+}
+
+const SOURCES_BY_ID = new Map<string, ByteSourceDescriptor>();
+
+function sourceForId(id: string): ByteSourceDescriptor {
+  let source = SOURCES_BY_ID.get(id);
+  if (!source) {
+    source = {
+      sourceId: id,
+      url: `memory://${id}.mcap`,
+    };
+    SOURCES_BY_ID.set(id, source);
+  }
+
+  return source;
+}
+
+function deferred<T>() {
+  let resolveDeferred: ((value: T) => void) | undefined;
+  let rejectDeferred: ((reason?: unknown) => void) | undefined;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolveDeferred = resolvePromise;
+    rejectDeferred = rejectPromise;
+  });
+
+  return {
+    promise,
+    reject(reason?: unknown) {
+      rejectDeferred?.(reason);
+    },
+    resolve(value: T) {
+      resolveDeferred?.(value);
+    },
+  };
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/use-mcap-grid-preview.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-mcap-grid-preview.ts
@@ -1,0 +1,173 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { ByteSourceDescriptor } from "../../../query/bytes";
+import { mcapErrorMessage } from "../errors";
+import {
+  DEFAULT_MCAP_GRID_PREVIEW_PLAYBACK_RATE,
+  MCAP_GRID_PREVIEW_IMAGE_FRAME_DELAY_MS,
+  type McapGridPreviewSnapshot,
+  type McapGridPreviewStatus,
+} from "../grid-preview";
+import { getMcapGridPreviewPool } from "../worker";
+
+/**
+ * State returned by the MCAP grid preview hook.
+ */
+export interface McapGridPreviewState extends McapGridPreviewSnapshot {
+  pause(): void;
+  play(): void;
+}
+
+/**
+ * Options for rendering one lightweight MCAP camera preview in the grid.
+ */
+export interface UseMcapGridPreviewOptions {
+  readonly source: ByteSourceDescriptor | null;
+}
+
+const IDLE_PREVIEW_STATE: McapGridPreviewSnapshot = {
+  error: null,
+  frame: null,
+  hasImageTopics: false,
+  imageTopic: null,
+  status: "idle",
+} as const;
+
+/**
+ * Loads MCAP grid preview frames through the shared bounded worker pool.
+ * The first frame loads eagerly; `play`/`pause` (typically bound to hover)
+ * advance playback from the last rendered frame.
+ */
+export function useMcapGridPreview({
+  source,
+}: UseMcapGridPreviewOptions): McapGridPreviewState {
+  const [state, setState] =
+    useState<McapGridPreviewSnapshot>(IDLE_PREVIEW_STATE);
+  const [playing, setPlaying] = useState(false);
+  const nextStartTimeNsRef = useRef<bigint | undefined>(undefined);
+  const pause = useCallback(() => setPlaying(false), []);
+  const play = useCallback(() => setPlaying(true), []);
+
+  // This effect loads the initial preview frame for the current source and
+  // holds a pool reference for the lifetime of the grid cell.
+  useEffect(() => {
+    if (!source) {
+      nextStartTimeNsRef.current = undefined;
+      setPlaying(false);
+      setState(IDLE_PREVIEW_STATE);
+      return;
+    }
+
+    let active = true;
+    const controller = new AbortController();
+    const pool = getMcapGridPreviewPool();
+    pool.acquire();
+    nextStartTimeNsRef.current = undefined;
+    setPlaying(false);
+    setState({
+      error: null,
+      frame: null,
+      hasImageTopics: false,
+      imageTopic: null,
+      status: "loading",
+    });
+
+    pool
+      .request({ source }, { signal: controller.signal })
+      .then((result) => {
+        if (!active) {
+          return;
+        }
+
+        nextStartTimeNsRef.current = result.nextStartTimeNs;
+        setState(result.state);
+      })
+      .catch((caughtError) => {
+        if (!active || controller.signal.aborted) {
+          return;
+        }
+
+        setState({
+          error: mcapErrorMessage(caughtError),
+          frame: null,
+          hasImageTopics: false,
+          imageTopic: null,
+          status: "error",
+        });
+      });
+
+    return () => {
+      active = false;
+      controller.abort();
+      pool.release();
+    };
+  }, [source]);
+
+  // This effect runs the hover playback loop: while playing, it keeps
+  // requesting the next frame, wrapping back to the start when the
+  // source runs out of frames.
+  useEffect(() => {
+    if (!playing || !source || state.status !== "ready") {
+      return;
+    }
+
+    let active = true;
+    const controller = new AbortController();
+    const pool = getMcapGridPreviewPool();
+
+    const run = async () => {
+      try {
+        while (active) {
+          const result = await pool.request(
+            {
+              source,
+              startTimeNs: nextStartTimeNsRef.current,
+            },
+            { signal: controller.signal }
+          );
+
+          if (!active) {
+            break;
+          }
+
+          if (!result.state.frame) {
+            nextStartTimeNsRef.current = undefined;
+            await delayMs(playbackDelayMs(undefined));
+            continue;
+          }
+
+          nextStartTimeNsRef.current = result.nextStartTimeNs;
+          setState(result.state);
+          await delayMs(playbackDelayMs(result.delayMs));
+        }
+      } catch (caughtError) {
+        if (active && !controller.signal.aborted) {
+          setState((currentState) => ({
+            ...currentState,
+            error: mcapErrorMessage(caughtError),
+            status: currentState.frame ? "ready" : "error",
+          }));
+        }
+      }
+    };
+
+    void run();
+
+    return () => {
+      active = false;
+      controller.abort();
+    };
+  }, [playing, source, state.status]);
+
+  return { ...state, pause, play };
+}
+
+function playbackDelayMs(frameDelayMs: number | undefined): number {
+  const delay = frameDelayMs ?? MCAP_GRID_PREVIEW_IMAGE_FRAME_DELAY_MS;
+  return Math.max(0, delay / DEFAULT_MCAP_GRID_PREVIEW_PLAYBACK_RATE);
+}
+
+function delayMs(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+export type { McapGridPreviewStatus };

--- a/app/packages/multimodal/src/adapters/mcap/react/use-mcap-grid-preview.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-mcap-grid-preview.ts
@@ -54,7 +54,7 @@ export function useMcapGridPreview({
       nextStartTimeNsRef.current = undefined;
       setPlaying(false);
       setState(IDLE_PREVIEW_STATE);
-      return;
+      return undefined;
     }
 
     let active = true;
@@ -74,25 +74,21 @@ export function useMcapGridPreview({
     pool
       .request({ source }, { signal: controller.signal })
       .then((result) => {
-        if (!active) {
-          return;
+        if (active) {
+          nextStartTimeNsRef.current = result.nextStartTimeNs;
+          setState(result.state);
         }
-
-        nextStartTimeNsRef.current = result.nextStartTimeNs;
-        setState(result.state);
       })
       .catch((caughtError) => {
-        if (!active || controller.signal.aborted) {
-          return;
+        if (active && !controller.signal.aborted) {
+          setState({
+            error: mcapErrorMessage(caughtError),
+            frame: null,
+            hasImageTopics: false,
+            imageTopic: null,
+            status: "error",
+          });
         }
-
-        setState({
-          error: mcapErrorMessage(caughtError),
-          frame: null,
-          hasImageTopics: false,
-          imageTopic: null,
-          status: "error",
-        });
       });
 
     return () => {
@@ -107,7 +103,7 @@ export function useMcapGridPreview({
   // source runs out of frames.
   useEffect(() => {
     if (!playing || !source || state.status !== "ready") {
-      return;
+      return undefined;
     }
 
     let active = true;
@@ -131,7 +127,7 @@ export function useMcapGridPreview({
 
           if (!result.state.frame) {
             nextStartTimeNsRef.current = undefined;
-            await delayMs(playbackDelayMs(undefined));
+            await delayMs(playbackDelayMs());
             continue;
           }
 
@@ -161,9 +157,10 @@ export function useMcapGridPreview({
   return { ...state, pause, play };
 }
 
-function playbackDelayMs(frameDelayMs: number | undefined): number {
-  const delay = frameDelayMs ?? MCAP_GRID_PREVIEW_IMAGE_FRAME_DELAY_MS;
-  return Math.max(0, delay / DEFAULT_MCAP_GRID_PREVIEW_PLAYBACK_RATE);
+function playbackDelayMs(
+  frameDelayMs = MCAP_GRID_PREVIEW_IMAGE_FRAME_DELAY_MS
+): number {
+  return Math.max(0, frameDelayMs / DEFAULT_MCAP_GRID_PREVIEW_PLAYBACK_RATE);
 }
 
 function delayMs(milliseconds: number): Promise<void> {

--- a/app/packages/multimodal/src/adapters/mcap/worker/grid-preview-pool.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/grid-preview-pool.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  McapGridPreviewWorkerRequest,
+  McapGridPreviewWorkerResponse,
+  McapGridPreviewWorkerRpcRequest,
+} from "./grid-preview-worker-types";
+import {
+  getMcapGridPreviewPool,
+  resetMcapGridPreviewPoolForTests,
+} from "./grid-preview-pool";
+
+vi.mock("@fiftyone/utilities", () => ({
+  getFetchParameters: () => ({
+    headers: { Authorization: "token" },
+    origin: "http://localhost:5151",
+    pathPrefix: "/proxy",
+  }),
+  mergeHeaders: (...headers: readonly Record<string, string>[]) =>
+    Object.assign({}, ...headers),
+}));
+
+afterEach(() => {
+  resetMcapGridPreviewPoolForTests();
+});
+
+describe("MCAP grid preview worker pool", () => {
+  it("keeps requests for the same source on the same worker", async () => {
+    const { pool, workers } = createPoolHarness();
+    const source = createSource("source:1");
+
+    const first = pool.request({ source });
+    const second = pool.request({ source });
+
+    expect(workers).toHaveLength(1);
+    expect(workers[0].messages[0]).toEqual({
+      payload: {
+        headers: { Authorization: "token" },
+        origin: "http://localhost:5151",
+        pathPrefix: "/proxy",
+      },
+      type: "init",
+    });
+    expect(rpcMessages(workers[0])).toHaveLength(2);
+
+    respondToAll(workers);
+
+    await expect(first).resolves.toEqual(createResult());
+    await expect(second).resolves.toEqual(createResult());
+  });
+
+  it("does not create more workers than the configured pool size", async () => {
+    const { pool, workers } = createPoolHarness({ poolSize: 2 });
+    const requests = Array.from({ length: 8 }, (_, index) =>
+      pool.request({ source: createSource(`source:${index}`) })
+    );
+
+    expect(workers.length).toBeLessThanOrEqual(2);
+
+    respondToAll(workers);
+    await Promise.all(requests);
+  });
+
+  it("allows a single-worker pool on low-resource configurations", async () => {
+    const { pool, workers } = createPoolHarness({ poolSize: 1 });
+    const requests = Array.from({ length: 4 }, (_, index) =>
+      pool.request({ source: createSource(`source:${index}`) })
+    );
+
+    expect(workers).toHaveLength(1);
+
+    respondToAll(workers);
+    await Promise.all(requests);
+  });
+
+  it("terminates workers only after all grid users release the pool", async () => {
+    const { pool, workers } = createPoolHarness();
+    pool.acquire();
+    pool.acquire();
+
+    const request = pool.request({ source: createSource("source:1") });
+    respondToAll(workers);
+    await request;
+
+    pool.release();
+    expect(workers[0].terminate).not.toHaveBeenCalled();
+
+    pool.release();
+    expect(workers[0].messages.at(-1)).toEqual({ type: "dispose" });
+    expect(workers[0].terminate).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects pending work and respawns a slot after worker errors", async () => {
+    const { pool, workers } = createPoolHarness();
+    const first = pool.request({ source: createSource("source:1") });
+    const firstWorker = workers[0];
+
+    firstWorker.emitError("grid worker crashed");
+
+    await expect(first).rejects.toThrow("grid worker crashed");
+    expect(firstWorker.terminate).toHaveBeenCalledTimes(1);
+
+    const second = pool.request({ source: createSource("source:1") });
+    expect(workers[1]).not.toBe(firstWorker);
+    respondToAll([workers[1]]);
+
+    await expect(second).resolves.toEqual(createResult());
+  });
+
+  it("forwards abort cancellation to the selected worker", async () => {
+    const { pool, workers } = createPoolHarness();
+    const controller = new AbortController();
+    const request = pool.request(
+      { source: createSource("source:1") },
+      { signal: controller.signal }
+    );
+
+    controller.abort();
+
+    expect(workers[0].messages.at(-1)).toEqual({ id: 1, type: "cancel" });
+    await expect(request).rejects.toThrow("cancelled");
+  });
+});
+
+function createPoolHarness(options: { readonly poolSize?: number } = {}) {
+  const workers: MockGridPreviewWorker[] = [];
+  resetMcapGridPreviewPoolForTests({
+    poolSize: options.poolSize ?? 2,
+    workerFactory: () => {
+      const worker = new MockGridPreviewWorker();
+      workers.push(worker);
+      return worker as unknown as Worker;
+    },
+  });
+
+  return {
+    pool: getMcapGridPreviewPool(),
+    workers,
+  };
+}
+
+function createSource(sourceId: string) {
+  return {
+    sourceId,
+    url: `mcap-source://${encodeURIComponent(sourceId)}`,
+  };
+}
+
+function createResult() {
+  return {
+    state: {
+      error: null,
+      frame: null,
+      hasImageTopics: false,
+      imageTopic: null,
+      status: "empty" as const,
+    },
+  };
+}
+
+function rpcMessages(
+  worker: MockGridPreviewWorker
+): McapGridPreviewWorkerRpcRequest[] {
+  return worker.messages.filter(
+    (message): message is McapGridPreviewWorkerRpcRequest =>
+      message.type === "decodeGridPreview"
+  );
+}
+
+function respondToAll(workers: readonly MockGridPreviewWorker[]) {
+  for (const worker of workers) {
+    for (const message of rpcMessages(worker)) {
+      worker.respond({
+        id: message.id,
+        ok: true,
+        result: createResult(),
+      });
+    }
+  }
+}
+
+class MockGridPreviewWorker {
+  messages: McapGridPreviewWorkerRequest[] = [];
+  onerror: ((event: ErrorEvent) => void) | null = null;
+  onmessage:
+    | ((event: MessageEvent<McapGridPreviewWorkerResponse>) => void)
+    | null = null;
+  postMessage = vi.fn((message: McapGridPreviewWorkerRequest) => {
+    this.messages.push(message);
+  });
+  terminate = vi.fn();
+
+  emitError(message: string) {
+    this.onerror?.({ message } as ErrorEvent);
+  }
+
+  respond(response: McapGridPreviewWorkerResponse) {
+    this.onmessage?.({
+      data: response,
+    } as MessageEvent<McapGridPreviewWorkerResponse>);
+  }
+}

--- a/app/packages/multimodal/src/adapters/mcap/worker/grid-preview-pool.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/grid-preview-pool.ts
@@ -1,0 +1,236 @@
+import { byteSourceAccessKey } from "../../../query/bytes";
+import { mcapError, mcapErrorMessage } from "../errors";
+import { McapGridPreviewTransport } from "./grid-preview-transport";
+import type {
+  McapGridPreviewRequestPayload,
+  McapGridPreviewResult,
+  McapGridPreviewWorkerRequest,
+  McapGridPreviewWorkerResponse,
+} from "./grid-preview-worker-types";
+import { workerFetchParameters } from "./worker-resource-client";
+
+// Low-resource machines should not be forced to run multiple MCAP workers.
+const MIN_GRID_PREVIEW_WORKERS = 1;
+
+// Also bound the grid preview pool small. Each worker may build/cache MCAP readers,
+// and the regular App still needs main-thread and network/decoder headroom.
+const MAX_GRID_PREVIEW_WORKERS = 4;
+
+type McapGridPreviewWorkerSlot = {
+  readonly transport: McapGridPreviewTransport;
+  worker: Worker | undefined;
+};
+
+/**
+ * Options for one grid preview pool request.
+ */
+export interface McapGridPreviewPoolRequestOptions {
+  readonly signal?: AbortSignal;
+}
+
+/**
+ * Construction options for the shared MCAP grid preview worker pool.
+ */
+export interface CreateMcapGridPreviewPoolOptions {
+  readonly poolSize?: number;
+  readonly workerFactory?: () => Worker;
+}
+
+/**
+ * Shared bounded worker pool for MCAP grid previews. Grid cells acquire the
+ * pool while mounted; workers are terminated once the last user releases it.
+ */
+export class McapGridPreviewWorkerPool {
+  private readonly poolSize: number;
+  private refCount = 0;
+  private readonly slots: McapGridPreviewWorkerSlot[];
+
+  constructor(private readonly options: CreateMcapGridPreviewPoolOptions = {}) {
+    this.poolSize = normalizePoolSize(options.poolSize);
+    this.slots = Array.from({ length: this.poolSize }, () => ({
+      transport: new McapGridPreviewTransport(),
+      worker: undefined,
+    }));
+  }
+
+  acquire(): void {
+    this.refCount += 1;
+  }
+
+  release(): void {
+    if (this.refCount === 0) {
+      return;
+    }
+
+    this.refCount -= 1;
+    if (this.refCount === 0) {
+      this.resetSlots("MCAP grid preview pool released");
+    }
+  }
+
+  request(
+    payload: McapGridPreviewRequestPayload,
+    options: McapGridPreviewPoolRequestOptions = {}
+  ): Promise<McapGridPreviewResult> {
+    const sourceKey = byteSourceAccessKey(payload.source);
+    const slot = this.slotForSource(sourceKey);
+
+    return slot.transport.request(this.workerForSlot(slot), payload, options);
+  }
+
+  dispose(): void {
+    this.refCount = 0;
+    this.resetSlots("MCAP grid preview pool disposed");
+  }
+
+  private slotForSource(sourceKey: string): McapGridPreviewWorkerSlot {
+    // MCAP grid workers cache indexed readers by source, so keep source
+    // affinity. Stateless renderer pools can round-robin; this one should not.
+    return this.slots[hashSourceKey(sourceKey) % this.poolSize];
+  }
+
+  private workerForSlot(slot: McapGridPreviewWorkerSlot): Worker {
+    if (slot.worker) {
+      return slot.worker;
+    }
+
+    let worker: Worker | undefined;
+    try {
+      worker = this.createWorker();
+      slot.worker = worker;
+      worker.onmessage = (event: MessageEvent<McapGridPreviewWorkerResponse>) =>
+        slot.transport.handleResponse(event.data);
+      worker.onerror = (event) => {
+        this.resetSlot(slot, event.message || "MCAP grid preview worker error");
+      };
+
+      const initRequest: McapGridPreviewWorkerRequest = {
+        payload: workerFetchParameters(),
+        type: "init",
+      };
+      worker.postMessage(initRequest);
+    } catch (error) {
+      if (slot.worker === worker) {
+        this.resetSlot(
+          slot,
+          mcapErrorMessage(error, "MCAP grid preview worker startup failed")
+        );
+      } else {
+        disposeWorker(worker);
+      }
+      throw mcapError(error);
+    }
+
+    return worker;
+  }
+
+  private createWorker(): Worker {
+    if (this.options.workerFactory) {
+      return this.options.workerFactory();
+    }
+
+    return new Worker(new URL("./grid-preview-worker.ts", import.meta.url), {
+      type: "module",
+    });
+  }
+
+  private resetSlots(reason: string) {
+    for (const slot of this.slots) {
+      this.resetSlot(slot, reason);
+    }
+  }
+
+  private resetSlot(slot: McapGridPreviewWorkerSlot, reason: string) {
+    const worker = slot.worker;
+    slot.worker = undefined;
+
+    if (worker) {
+      worker.onmessage = null;
+      worker.onerror = null;
+      try {
+        const disposeRequest: McapGridPreviewWorkerRequest = {
+          type: "dispose",
+        };
+        worker.postMessage(disposeRequest);
+      } catch {
+        // The worker may already be gone.
+      }
+      worker.terminate();
+    }
+
+    slot.transport.rejectAll(reason);
+  }
+}
+
+let sharedPool: McapGridPreviewWorkerPool | null = null;
+let sharedPoolOptions: CreateMcapGridPreviewPoolOptions = {};
+
+/**
+ * Returns the singleton MCAP grid preview worker pool.
+ */
+export function getMcapGridPreviewPool(): McapGridPreviewWorkerPool {
+  if (!sharedPool) {
+    sharedPool = new McapGridPreviewWorkerPool(sharedPoolOptions);
+  }
+
+  return sharedPool;
+}
+
+/**
+ * Disposes and reconfigures the singleton grid preview pool for tests.
+ */
+export function resetMcapGridPreviewPoolForTests(
+  options: CreateMcapGridPreviewPoolOptions = {}
+): void {
+  sharedPool?.dispose();
+  sharedPool = null;
+  sharedPoolOptions = options;
+}
+
+/**
+ * Hashes a source key (FNV-1a) for deterministic worker affinity.
+ */
+export function hashSourceKey(sourceKey: string): number {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < sourceKey.length; index++) {
+    hash ^= sourceKey.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+
+  return hash >>> 0;
+}
+
+function normalizePoolSize(poolSize: number | undefined): number {
+  // Default to the browser's logical CPU count minus two, then clamp below.
+  // This reserves room for the main thread and other App work when the machine
+  // has enough cores. Small machines naturally collapse to a single worker.
+  const defaultPoolSize =
+    typeof navigator === "object" &&
+    Number.isFinite(navigator.hardwareConcurrency)
+      ? navigator.hardwareConcurrency - 2
+      : MIN_GRID_PREVIEW_WORKERS;
+
+  const requested = poolSize ?? defaultPoolSize;
+
+  if (!Number.isFinite(requested)) {
+    return MIN_GRID_PREVIEW_WORKERS;
+  }
+
+  // Clam to min, max
+  // - below 1: keep at least one decoder available
+  // - above 4: avoid overloading the browser with MCAP readers/decoders
+  return Math.max(
+    MIN_GRID_PREVIEW_WORKERS,
+    Math.min(MAX_GRID_PREVIEW_WORKERS, Math.trunc(requested))
+  );
+}
+
+function disposeWorker(worker: Worker | undefined) {
+  if (!worker) {
+    return;
+  }
+
+  worker.onmessage = null;
+  worker.onerror = null;
+  worker.terminate();
+}

--- a/app/packages/multimodal/src/adapters/mcap/worker/grid-preview-pool.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/grid-preview-pool.ts
@@ -14,11 +14,12 @@ const MIN_GRID_PREVIEW_WORKERS = 1;
 
 // Also bound the grid preview pool small. Each worker may build/cache MCAP readers,
 // and the regular App still needs main-thread and network/decoder headroom.
-const MAX_GRID_PREVIEW_WORKERS = 4;
+const MAX_GRID_PREVIEW_WORKERS = 5;
+const RESERVED_GRID_PREVIEW_WORKER_CORES = 2;
 
 type McapGridPreviewWorkerSlot = {
   readonly transport: McapGridPreviewTransport;
-  worker: Worker | undefined;
+  worker?: Worker;
 };
 
 /**
@@ -49,7 +50,6 @@ export class McapGridPreviewWorkerPool {
     this.poolSize = normalizePoolSize(options.poolSize);
     this.slots = Array.from({ length: this.poolSize }, () => ({
       transport: new McapGridPreviewTransport(),
-      worker: undefined,
     }));
   }
 
@@ -142,7 +142,7 @@ export class McapGridPreviewWorkerPool {
 
   private resetSlot(slot: McapGridPreviewWorkerSlot, reason: string) {
     const worker = slot.worker;
-    slot.worker = undefined;
+    delete slot.worker;
 
     if (worker) {
       worker.onmessage = null;
@@ -204,10 +204,11 @@ function normalizePoolSize(poolSize: number | undefined): number {
   // Default to the browser's logical CPU count minus two, then clamp below.
   // This reserves room for the main thread and other App work when the machine
   // has enough cores. Small machines naturally collapse to a single worker.
+  const hardwareConcurrency = globalThis.navigator?.hardwareConcurrency;
   const defaultPoolSize =
-    typeof navigator === "object" &&
-    Number.isFinite(navigator.hardwareConcurrency)
-      ? navigator.hardwareConcurrency - 2
+    typeof hardwareConcurrency === "number" &&
+    Number.isFinite(hardwareConcurrency)
+      ? hardwareConcurrency - RESERVED_GRID_PREVIEW_WORKER_CORES
       : MIN_GRID_PREVIEW_WORKERS;
 
   const requested = poolSize ?? defaultPoolSize;
@@ -216,13 +217,18 @@ function normalizePoolSize(poolSize: number | undefined): number {
     return MIN_GRID_PREVIEW_WORKERS;
   }
 
-  // Clam to min, max
+  // Clamp to min/max:
   // - below 1: keep at least one decoder available
   // - above 4: avoid overloading the browser with MCAP readers/decoders
-  return Math.max(
+  return clamp(
+    Math.trunc(requested),
     MIN_GRID_PREVIEW_WORKERS,
-    Math.min(MAX_GRID_PREVIEW_WORKERS, Math.trunc(requested))
+    MAX_GRID_PREVIEW_WORKERS
   );
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.max(minimum, Math.min(maximum, value));
 }
 
 function disposeWorker(worker: Worker | undefined) {

--- a/app/packages/multimodal/src/adapters/mcap/worker/grid-preview-transport.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/grid-preview-transport.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from "vitest";
+import { McapGridPreviewTransport } from "./grid-preview-transport";
+import type { McapGridPreviewWorkerRequest } from "./grid-preview-worker-types";
+
+describe("MCAP grid preview transport", () => {
+  it("sends flat unary preview requests and resolves responses", async () => {
+    const worker = createWorker();
+    const transport = new McapGridPreviewTransport();
+    const request = transport.request(worker, { source: createSource() });
+
+    expect(worker.messages[0]).toMatchObject({
+      id: 1,
+      payload: { source: createSource() },
+      type: "decodeGridPreview",
+    });
+    expect(worker.messages[0]).toHaveProperty("sourceKey");
+
+    transport.handleResponse({
+      id: 1,
+      ok: true,
+      result: createResult("empty"),
+    });
+
+    await expect(request).resolves.toEqual(createResult("empty"));
+  });
+
+  it("cancels pending requests when the abort signal fires", async () => {
+    const worker = createWorker();
+    const transport = new McapGridPreviewTransport();
+    const controller = new AbortController();
+    const request = transport.request(
+      worker,
+      { source: createSource() },
+      { signal: controller.signal }
+    );
+
+    controller.abort();
+
+    expect(worker.messages.at(-1)).toEqual({ id: 1, type: "cancel" });
+    await expect(request).rejects.toThrow("cancelled");
+
+    transport.handleResponse({
+      id: 1,
+      ok: true,
+      result: createResult("ready"),
+    });
+    await expect(flushPromises()).resolves.toBeUndefined();
+  });
+
+  it("rejects all pending work on worker reset", async () => {
+    const worker = createWorker();
+    const transport = new McapGridPreviewTransport();
+    const request = transport.request(worker, { source: createSource() });
+
+    transport.rejectAll("worker crashed");
+
+    await expect(request).rejects.toThrow("worker crashed");
+  });
+});
+
+function createWorker() {
+  const worker = {
+    messages: [] as McapGridPreviewWorkerRequest[],
+    postMessage: vi.fn((message: McapGridPreviewWorkerRequest) => {
+      worker.messages.push(message);
+    }),
+  };
+
+  return worker as unknown as Worker & {
+    readonly messages: McapGridPreviewWorkerRequest[];
+  };
+}
+
+function createSource() {
+  return {
+    sourceId: "source:1",
+    url: "mcap-source://sample",
+  };
+}
+
+function createResult(status: "empty" | "ready") {
+  return {
+    state: {
+      error: null,
+      frame: null,
+      hasImageTopics: status === "ready",
+      imageTopic: status === "ready" ? "/camera" : null,
+      status,
+    },
+  };
+}
+
+async function flushPromises() {
+  await Promise.resolve();
+  await Promise.resolve();
+}

--- a/app/packages/multimodal/src/adapters/mcap/worker/grid-preview-transport.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/grid-preview-transport.ts
@@ -1,0 +1,117 @@
+import { byteSourceAccessKey } from "../../../query/bytes";
+import { mcapError } from "../errors";
+import type {
+  McapGridPreviewRequestPayload,
+  McapGridPreviewResult,
+  McapGridPreviewWorkerResponse,
+  McapGridPreviewWorkerRpcRequest,
+} from "./grid-preview-worker-types";
+
+const CANCELLED_ERROR_MESSAGE = "MCAP grid preview request cancelled";
+
+type PendingRequest = {
+  readonly reject: (error: Error) => void;
+  readonly resolve: (result: McapGridPreviewResult) => void;
+  readonly worker: Worker;
+};
+
+/**
+ * Error used when a grid preview request is cancelled before completion.
+ */
+export class McapGridPreviewRequestCancelledError extends Error {
+  constructor() {
+    super(CANCELLED_ERROR_MESSAGE);
+    this.name = "McapGridPreviewRequestCancelledError";
+  }
+}
+
+/**
+ * Flat unary request/response transport for the MCAP grid preview worker.
+ */
+export class McapGridPreviewTransport {
+  private nextRequestId = 1;
+  private pending = new Map<number, PendingRequest>();
+
+  request(
+    worker: Worker,
+    payload: McapGridPreviewRequestPayload,
+    options: { readonly signal?: AbortSignal } = {}
+  ): Promise<McapGridPreviewResult> {
+    if (options.signal?.aborted) {
+      return Promise.reject(new McapGridPreviewRequestCancelledError());
+    }
+
+    const id = this.nextRequestId++;
+    const message: McapGridPreviewWorkerRpcRequest = {
+      id,
+      payload,
+      sourceKey: byteSourceAccessKey(payload.source),
+      type: "decodeGridPreview",
+    };
+
+    return new Promise((resolve, reject) => {
+      const abort = () => {
+        if (!this.pending.delete(id)) {
+          return;
+        }
+
+        try {
+          worker.postMessage({ id, type: "cancel" });
+        } catch {
+          // The worker may already be gone; the local promise is already done.
+        }
+        reject(new McapGridPreviewRequestCancelledError());
+      };
+
+      options.signal?.addEventListener("abort", abort, { once: true });
+      this.pending.set(id, {
+        reject: (error) => {
+          options.signal?.removeEventListener("abort", abort);
+          reject(error);
+        },
+        resolve: (result) => {
+          options.signal?.removeEventListener("abort", abort);
+          resolve(result);
+        },
+        worker,
+      });
+
+      try {
+        worker.postMessage(message);
+      } catch (error) {
+        options.signal?.removeEventListener("abort", abort);
+        this.pending.delete(id);
+        reject(mcapError(error));
+      }
+    });
+  }
+
+  handleResponse(response: McapGridPreviewWorkerResponse) {
+    const pending = this.pending.get(response.id);
+    if (!pending) {
+      return;
+    }
+
+    this.pending.delete(response.id);
+    if (response.ok) {
+      pending.resolve(response.result);
+    } else {
+      pending.reject(new Error(response.error));
+    }
+  }
+
+  rejectAll(reason: string) {
+    const error = new Error(reason);
+    for (const pending of this.pending.values()) {
+      pending.reject(error);
+    }
+    this.pending.clear();
+  }
+}
+
+/**
+ * Returns whether an error came from grid preview request cancellation.
+ */
+export function isMcapGridPreviewRequestCancelled(error: unknown): boolean {
+  return error instanceof McapGridPreviewRequestCancelledError;
+}

--- a/app/packages/multimodal/src/adapters/mcap/worker/grid-preview-worker-types.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/grid-preview-worker-types.ts
@@ -1,0 +1,63 @@
+import type {
+  McapGridPreviewDecodeRequest,
+  McapGridPreviewResult,
+} from "../grid-preview";
+import type { McapPlaybackWorkerFetchParameters } from "./playback-worker-types";
+
+/**
+ * Payload for one high-level MCAP grid preview decode request.
+ */
+export type McapGridPreviewRequestPayload = McapGridPreviewDecodeRequest;
+
+export type {
+  McapGridPreviewFrame,
+  McapGridPreviewResult,
+} from "../grid-preview";
+
+/**
+ * RPC request envelope for the shared MCAP grid preview worker.
+ */
+export type McapGridPreviewWorkerRpcRequest = {
+  readonly id: number;
+  readonly payload: McapGridPreviewRequestPayload;
+  readonly sourceKey: string;
+  readonly type: "decodeGridPreview";
+};
+
+/**
+ * Lifecycle and cancellation messages handled outside the scheduler queue.
+ */
+export type McapGridPreviewWorkerControlRequest =
+  | {
+      readonly payload: McapPlaybackWorkerFetchParameters;
+      readonly type: "init";
+    }
+  | {
+      readonly id: number;
+      readonly type: "cancel";
+    }
+  | {
+      readonly type: "dispose";
+    };
+
+/**
+ * Any message accepted by the MCAP grid preview worker.
+ */
+export type McapGridPreviewWorkerRequest =
+  | McapGridPreviewWorkerControlRequest
+  | McapGridPreviewWorkerRpcRequest;
+
+/**
+ * Response envelope posted by the MCAP grid preview worker.
+ */
+export type McapGridPreviewWorkerResponse =
+  | {
+      readonly id: number;
+      readonly ok: true;
+      readonly result: McapGridPreviewResult;
+    }
+  | {
+      readonly error: string;
+      readonly id: number;
+      readonly ok: false;
+    };

--- a/app/packages/multimodal/src/adapters/mcap/worker/grid-preview-worker.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/grid-preview-worker.ts
@@ -1,0 +1,116 @@
+import { setFetchFunction } from "@fiftyone/utilities";
+import { LRUCache } from "lru-cache";
+import { mcapErrorMessage } from "../errors";
+import { decodeGridPreview, type McapGridPreviewEntry } from "../grid-preview";
+import { McapPlaybackWorkerScheduler } from "./playback-worker-scheduler";
+import { MCAP_PLAYBACK_WORKER_PRIORITY } from "./playback-worker-types";
+import { createWorkerResourceClient } from "./worker-resource-client";
+import type {
+  McapGridPreviewWorkerRequest,
+  McapGridPreviewWorkerResponse,
+  McapGridPreviewWorkerRpcRequest,
+} from "./grid-preview-worker-types";
+
+const GRID_PREVIEW_SOURCE_CACHE_LIMIT = 24;
+
+type McapGridPreviewWorkerScope = {
+  close(): void;
+  onmessage:
+    | ((event: MessageEvent<McapGridPreviewWorkerRequest>) => void)
+    | null;
+  postMessage(
+    response: McapGridPreviewWorkerResponse,
+    transfer?: readonly Transferable[]
+  ): void;
+};
+
+const workerScope = self as unknown as McapGridPreviewWorkerScope;
+const scheduler = new McapPlaybackWorkerScheduler();
+// Each grid preview slot serves many sources (one per visible grid cell), so
+// keep a bounded per-source cache of readers and camera selections.
+const entries = new LRUCache<string, McapGridPreviewEntry>({
+  max: GRID_PREVIEW_SOURCE_CACHE_LIMIT,
+  dispose: (entry) => {
+    entry.client.dispose();
+  },
+});
+
+workerScope.onmessage = (event: MessageEvent<McapGridPreviewWorkerRequest>) => {
+  const message = event.data;
+
+  if (message.type === "init") {
+    setFetchFunction(
+      message.payload.origin,
+      message.payload.headers,
+      message.payload.pathPrefix
+    );
+    return;
+  }
+
+  if (message.type === "cancel") {
+    scheduler.cancel(message.id);
+    return;
+  }
+
+  if (message.type === "dispose") {
+    scheduler.dispose();
+    entries.clear();
+    workerScope.close();
+    return;
+  }
+
+  scheduler.enqueue({
+    id: message.id,
+    priority: MCAP_PLAYBACK_WORKER_PRIORITY.CURRENT_FRAME,
+    run: () => runAndRespond(message),
+    sourceKey: message.sourceKey,
+  });
+};
+
+async function runAndRespond(message: McapGridPreviewWorkerRpcRequest) {
+  try {
+    const result = await decodeGridPreview(
+      entryForSource(message.sourceKey),
+      message.payload
+    );
+
+    postResponse({
+      id: message.id,
+      ok: true,
+      result,
+    });
+  } catch (error) {
+    postResponse({
+      error: mcapErrorMessage(error),
+      id: message.id,
+      ok: false,
+    });
+  }
+}
+
+function entryForSource(sourceKey: string): McapGridPreviewEntry {
+  const cached = entries.get(sourceKey);
+  if (cached) {
+    return cached;
+  }
+
+  const entry = { client: createWorkerResourceClient() };
+  entries.set(sourceKey, entry);
+
+  return entry;
+}
+
+function postResponse(response: McapGridPreviewWorkerResponse) {
+  workerScope.postMessage(response, transferablesForResponse(response));
+}
+
+function transferablesForResponse(
+  response: McapGridPreviewWorkerResponse
+): Transferable[] {
+  if (!response.ok) {
+    return [];
+  }
+
+  const buffer = response.result.state.frame?.image.bytes.buffer;
+  return buffer instanceof ArrayBuffer ? [buffer] : [];
+}

--- a/app/packages/multimodal/src/adapters/mcap/worker/index.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/index.ts
@@ -7,3 +7,15 @@ export { createWorkerMcapResourceClient } from "./worker-client";
  * Options for creating a worker-backed MCAP resource client.
  */
 export type { CreateWorkerMcapResourceClientOptions } from "./worker-client";
+
+/**
+ * Shared bounded worker pool for MCAP grid previews.
+ */
+export {
+  getMcapGridPreviewPool,
+  resetMcapGridPreviewPoolForTests,
+} from "./grid-preview-pool";
+export type {
+  CreateMcapGridPreviewPoolOptions,
+  McapGridPreviewPoolRequestOptions,
+} from "./grid-preview-pool";

--- a/app/packages/multimodal/src/adapters/mcap/worker/playback-worker.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/playback-worker.ts
@@ -1,11 +1,5 @@
 import { setFetchFunction } from "@fiftyone/utilities";
-import { createMultimodalQueryClient } from "../../../query";
-import type { DecodedOutputCache } from "../../../query/decode";
-import { createDecodeClient } from "../../../query/decode";
 import { mcapErrorMessage } from "../errors";
-import { createMcapDecoderRegistry } from "../decoders";
-import { createInlineMcapResourceClient } from "../resources";
-import type { McapResourceClient } from "../types";
 import {
   isMcapPlaybackWorkerStreamRequest,
   runMcapPlaybackWorkerStreamRequest,
@@ -19,6 +13,7 @@ import type {
   McapPlaybackWorkerRpcRequest,
   McapPlaybackWorkerStreamType,
 } from "./playback-worker-types";
+import { createWorkerResourceClient } from "./worker-resource-client";
 
 type McapPlaybackWorkerScope = {
   close(): void;
@@ -31,18 +26,6 @@ type McapPlaybackWorkerScope = {
 
 const workerScope = self as unknown as McapPlaybackWorkerScope;
 const scheduler = new McapPlaybackWorkerScheduler();
-
-const transferSafeNoopDecodedOutputCache: DecodedOutputCache = {
-  clear() {
-    return Promise.resolve();
-  },
-  get() {
-    return Promise.resolve(undefined);
-  },
-  put() {
-    return Promise.resolve();
-  },
-};
 
 let activeSourceKey = "";
 let mcap = createWorkerResourceClient();
@@ -147,20 +130,4 @@ function transferablesForResponse(response: McapPlaybackWorkerResponse) {
   }
 
   return transferablesForMcapResult(response.result);
-}
-
-function createWorkerResourceClient(): McapResourceClient {
-  const query = createMultimodalQueryClient();
-
-  return createInlineMcapResourceClient({
-    byteClient: query.bytes,
-    decodeClient: createDecodeClient({
-      // Decoded visualization buffers are transferred to the UI thread.
-      // Reusing worker-cached decoded results would either return detached
-      // buffers or force extra clones, so playback-window reuse belongs on
-      // the main thread.
-      cache: transferSafeNoopDecodedOutputCache,
-      registry: createMcapDecoderRegistry(),
-    }),
-  });
 }

--- a/app/packages/multimodal/src/adapters/mcap/worker/worker-client.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/worker-client.ts
@@ -1,9 +1,8 @@
-import { getFetchParameters, mergeHeaders } from "@fiftyone/utilities";
 import { byteSourceAccessKey } from "../../../query/bytes";
 import { hydrateMcapFrameTransformSet } from "../frame-transforms";
 import { McapPlaybackWorkerTransport } from "./playback-worker-transport";
+import { workerFetchParameters } from "./worker-resource-client";
 import {
-  type McapPlaybackWorkerFetchParameters,
   type McapPlaybackWorkerRequest,
   type McapPlaybackWorkerRequestPayloadByType,
   type McapPlaybackWorkerResponse,
@@ -227,14 +226,4 @@ function disposeWorker(worker: Worker | undefined) {
   worker.onmessage = null;
   worker.onerror = null;
   worker.terminate();
-}
-
-function workerFetchParameters(): McapPlaybackWorkerFetchParameters {
-  const { headers, origin, pathPrefix } = getFetchParameters();
-
-  return {
-    headers: mergeHeaders(headers),
-    origin,
-    pathPrefix,
-  };
 }

--- a/app/packages/multimodal/src/adapters/mcap/worker/worker-resource-client.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/worker-resource-client.ts
@@ -1,0 +1,52 @@
+import { getFetchParameters, mergeHeaders } from "@fiftyone/utilities";
+import { createMultimodalQueryClient } from "../../../query";
+import type { DecodedOutputCache } from "../../../query/decode";
+import { createDecodeClient } from "../../../query/decode";
+import { createMcapDecoderRegistry } from "../decoders";
+import { createInlineMcapResourceClient } from "../resources";
+import type { McapResourceClient } from "../types";
+import type { McapPlaybackWorkerFetchParameters } from "./playback-worker-types";
+
+const transferSafeNoopDecodedOutputCache: DecodedOutputCache = {
+  clear() {
+    return Promise.resolve();
+  },
+  get() {
+    return Promise.resolve(undefined);
+  },
+  put() {
+    return Promise.resolve();
+  },
+};
+
+/**
+ * Creates an inline MCAP resource client for code running inside a worker.
+ */
+export function createWorkerResourceClient(): McapResourceClient {
+  const query = createMultimodalQueryClient();
+
+  return createInlineMcapResourceClient({
+    byteClient: query.bytes,
+    decodeClient: createDecodeClient({
+      // Decoded visualization buffers are transferred to the UI thread.
+      // Reusing worker-cached decoded results would either return detached
+      // buffers or force extra clones, so playback-window reuse belongs on
+      // the main thread.
+      cache: transferSafeNoopDecodedOutputCache,
+      registry: createMcapDecoderRegistry(),
+    }),
+  });
+}
+
+/**
+ * Copies the app fetch configuration into worker init messages.
+ */
+export function workerFetchParameters(): McapPlaybackWorkerFetchParameters {
+  const { headers, origin, pathPrefix } = getFetchParameters();
+
+  return {
+    headers: mergeHeaders(headers),
+    origin,
+    pathPrefix,
+  };
+}

--- a/app/packages/multimodal/src/load-status.ts
+++ b/app/packages/multimodal/src/load-status.ts
@@ -1,7 +1,7 @@
 /**
  * Shared load-state union used by React hooks throughout the multimodal
  * package. Each hook re-exports a domain-specific alias (e.g.
- * `McapTopicsStatus`, `TemporalTagsStatus`) so consumers keep stable,
+ * `McapFrameTransformsStatus`, `TemporalTagsStatus`) so consumers keep stable,
  * readable names while the underlying definition stays in one place.
  */
 export type LoadStatus = "idle" | "loading" | "ready" | "error";

--- a/app/packages/multimodal/src/visualization/panels/ImageAnnotationsOverlay.tsx
+++ b/app/packages/multimodal/src/visualization/panels/ImageAnnotationsOverlay.tsx
@@ -31,6 +31,7 @@ export interface ImageAnnotationsOverlayProps {
   readonly imageWidth: number;
   readonly imageHeight: number;
   readonly fit: "contain" | "cover";
+  readonly strokeWidth?: number;
   readonly selectedKey?: string | null;
   readonly onSelectPrimitive?: (picked: ImageAnnotationPickedPrimitive) => void;
 }
@@ -51,6 +52,7 @@ export function ImageAnnotationsOverlay({
   imageWidth,
   imageHeight,
   fit,
+  strokeWidth,
   selectedKey,
   onSelectPrimitive,
 }: ImageAnnotationsOverlayProps) {
@@ -62,7 +64,7 @@ export function ImageAnnotationsOverlay({
 
   useEffect(() => {
     const el = containerRef.current;
-    if (!el) return;
+    if (!el) return undefined;
     const observer = new ResizeObserver((entries) => {
       const entry = entries[0];
       if (!entry) return;
@@ -101,6 +103,7 @@ export function ImageAnnotationsOverlay({
               <SetPrimitives
                 set={set}
                 setIndex={i}
+                strokeWidth={strokeWidth}
                 selectedKey={selectedKey ?? null}
                 onSelectPrimitive={onSelectPrimitive}
               />
@@ -115,6 +118,7 @@ export function ImageAnnotationsOverlay({
 interface SetPrimitivesProps {
   readonly set: ImageAnnotationsVisualization;
   readonly setIndex: number;
+  readonly strokeWidth?: number;
   readonly selectedKey: string | null;
   readonly onSelectPrimitive?: (picked: ImageAnnotationPickedPrimitive) => void;
 }
@@ -122,6 +126,7 @@ interface SetPrimitivesProps {
 function SetPrimitives({
   set,
   setIndex,
+  strokeWidth,
   selectedKey,
   onSelectPrimitive,
 }: SetPrimitivesProps) {
@@ -135,6 +140,7 @@ function SetPrimitives({
             primitiveIndex={j}
             setIndex={setIndex}
             texts={set.texts}
+            strokeWidth={strokeWidth}
             selectedKey={selectedKey}
             onSelectPrimitive={onSelectPrimitive}
           />
@@ -145,6 +151,7 @@ function SetPrimitives({
             primitiveIndex={j}
             setIndex={setIndex}
             texts={set.texts}
+            strokeWidth={strokeWidth}
             selectedKey={selectedKey}
             onSelectPrimitive={onSelectPrimitive}
           />
@@ -157,6 +164,7 @@ function SetPrimitives({
           primitiveIndex={j}
           setIndex={setIndex}
           texts={set.texts}
+          strokeWidth={strokeWidth}
           selectedKey={selectedKey}
           onSelectPrimitive={onSelectPrimitive}
         />
@@ -180,6 +188,7 @@ interface CirclePrimitiveProps {
   readonly primitiveIndex: number;
   readonly setIndex: number;
   readonly texts: readonly ImageAnnotationText[];
+  readonly strokeWidth?: number;
   readonly selectedKey: string | null;
   readonly onSelectPrimitive?: (picked: ImageAnnotationPickedPrimitive) => void;
 }
@@ -189,6 +198,7 @@ function CirclePrimitive({
   primitiveIndex,
   setIndex,
   texts,
+  strokeWidth,
   selectedKey,
   onSelectPrimitive,
 }: CirclePrimitiveProps) {
@@ -221,7 +231,7 @@ function CirclePrimitive({
         cx={x}
         cy={y}
         r={radius}
-        strokeWidth={lineWidth(primitive.thickness)}
+        strokeWidth={lineWidth(primitive.thickness, strokeWidth)}
         vectorEffect="non-scaling-stroke"
         fill="none"
       />
@@ -234,6 +244,7 @@ interface PolylinePrimitiveProps {
   readonly primitiveIndex: number;
   readonly setIndex: number;
   readonly texts: readonly ImageAnnotationText[];
+  readonly strokeWidth?: number;
   readonly selectedKey: string | null;
   readonly onSelectPrimitive?: (picked: ImageAnnotationPickedPrimitive) => void;
 }
@@ -243,10 +254,11 @@ function PolylinePrimitive({
   primitiveIndex,
   setIndex,
   texts,
+  strokeWidth,
   selectedKey,
   onSelectPrimitive,
 }: PolylinePrimitiveProps) {
-  const thickness = lineWidth(primitive.thickness);
+  const thickness = lineWidth(primitive.thickness, strokeWidth);
   const centroid = pointsCentroid(primitive.points);
   const label = centroid ? nearestLabel(texts, centroid) : null;
   const color = colorForLabel(label);
@@ -328,6 +340,7 @@ interface LineListGroupsProps {
   readonly primitiveIndex: number;
   readonly setIndex: number;
   readonly texts: readonly ImageAnnotationText[];
+  readonly strokeWidth?: number;
   readonly selectedKey: string | null;
   readonly onSelectPrimitive?: (picked: ImageAnnotationPickedPrimitive) => void;
 }
@@ -337,10 +350,11 @@ function LineListGroups({
   primitiveIndex,
   setIndex,
   texts,
+  strokeWidth,
   selectedKey,
   onSelectPrimitive,
 }: LineListGroupsProps) {
-  const thickness = lineWidth(primitive.thickness);
+  const thickness = lineWidth(primitive.thickness, strokeWidth);
   const groups = groupLineListByLabel(primitive.points, texts);
 
   return (
@@ -619,7 +633,11 @@ function pickHandler(
   };
 }
 
-function lineWidth(thickness: number): number {
+function lineWidth(thickness: number, override?: number): number {
+  if (typeof override === "number" && Number.isFinite(override)) {
+    return Math.max(0, override);
+  }
+
   // Source thickness is conservative; bump it ~1.5x for readability while
   // keeping the look light.
   return Math.max(1.5, thickness * 1.5);
@@ -648,7 +666,6 @@ function displayRect(
     height,
   };
 }
-
 
 function rgbaToCss(color: RgbaColor | null | undefined): string | undefined {
   if (!color) return undefined;

--- a/app/packages/plugins/src/sample-renderer.ts
+++ b/app/packages/plugins/src/sample-renderer.ts
@@ -1,5 +1,5 @@
-import { isNativeMediaType } from "@fiftyone/looker/src/util";
 import * as fos from "@fiftyone/state";
+import { isNativeMediaType } from "@fiftyone/utilities";
 import type { Schema } from "@fiftyone/utilities";
 import mime from "mime";
 import type React from "react";

--- a/app/packages/state/src/hooks/useCreateLooker.ts
+++ b/app/packages/state/src/hooks/useCreateLooker.ts
@@ -13,13 +13,13 @@ import {
 import { ImaVidFramesController } from "@fiftyone/looker/src/lookers/imavid/controller";
 import { ImaVidFramesControllerStore } from "@fiftyone/looker/src/lookers/imavid/store";
 import type { BaseState, ImaVidConfig } from "@fiftyone/looker/src/state";
-import { isNativeMediaType } from "@fiftyone/looker/src/util";
 import {
   EMBEDDED_DOCUMENT_FIELD,
   LIST_FIELD,
   getMimeType,
   isDirect3dSamplePath,
   isFo3dSamplePath,
+  isNativeMediaType,
   isNullish,
 } from "@fiftyone/utilities";
 import { useEffect, useRef } from "react";
@@ -27,7 +27,7 @@ import { useErrorHandler } from "react-error-boundary";
 import { useRelayEnvironment } from "react-relay";
 import { useRecoilCallback, useRecoilValue } from "recoil";
 import { dynamicGroupsElementCount, selectedMediaField } from "../recoil";
-import { selectedSamples, sampleSelectionStyle } from "../recoil/atoms";
+import { sampleSelectionStyle, selectedSamples } from "../recoil/atoms";
 import * as dynamicGroupAtoms from "../recoil/dynamicGroups";
 import * as schemaAtoms from "../recoil/schema";
 import { datasetName, dynamicGroupsTargetFrameRate } from "../recoil/selectors";

--- a/app/packages/utilities/src/media.ts
+++ b/app/packages/utilities/src/media.ts
@@ -1,5 +1,23 @@
 import { PathType, determinePathType, getBasename } from "./paths";
 
+export const MEDIA_TYPE_IMAGE = "image";
+export const MEDIA_TYPE_VIDEO = "video";
+export const MEDIA_TYPE_POINT_CLOUD = "point-cloud";
+export const MEDIA_TYPE_3D = "3d";
+export const MEDIA_TYPE_GROUP = "group";
+export const MEDIA_TYPE_MULTIMODAL = "multimodal";
+
+export type NativeMediaType =
+  | typeof MEDIA_TYPE_3D
+  | typeof MEDIA_TYPE_GROUP
+  | typeof MEDIA_TYPE_IMAGE
+  | typeof MEDIA_TYPE_POINT_CLOUD
+  | typeof MEDIA_TYPE_VIDEO;
+
+export type RecognizedMediaType =
+  | NativeMediaType
+  | typeof MEDIA_TYPE_MULTIMODAL;
+
 /**
  * Returns true if annotation is supported for the provided media type.
  *
@@ -168,6 +186,22 @@ export const isPointCloud = (mediaType: string): boolean => {
  */
 export const is3d = (mediaType: string): boolean => {
   return isFo3d(mediaType) || isPointCloud(mediaType);
+};
+
+/**
+ * Returns true if the provided media type is handled by FiftyOne's built-in
+ * renderers.
+ */
+export const isNativeMediaType = (
+  mediaType: string | null | undefined
+): mediaType is NativeMediaType => {
+  return (
+    mediaType == null ||
+    mediaType === MEDIA_TYPE_IMAGE ||
+    mediaType === MEDIA_TYPE_VIDEO ||
+    mediaType === MEDIA_TYPE_GROUP ||
+    is3d(mediaType)
+  );
 };
 
 /**


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

<img width="1726" height="958" alt="2026-06-10 17 43 08" src="https://github.com/user-attachments/assets/4eb64637-0429-409f-bcf6-d181dab84380" />

<img width="1726" height="958" alt="2026-06-10 17 47 49" src="https://github.com/user-attachments/assets/e11b2b46-2e77-4781-8ce8-72f89284bbf8" />

This PR adds lightweight MCAP previews for multimodal samples in the grid.

Next: https://github.com/voxel51/fiftyone/pull/7757

It replaces the previous topic-count placeholder with a real camera preview renderer that:
- selects the first available compressed image stream deterministically
- pairs it with the best matching image annotations topic when available
- renders the first preview frame eagerly
- plays subsequent frames on hover
- shows loading, empty, and error states for unsupported or unavailable previews

The preview decoding runs through a bounded shared worker pool with source-affine worker assignment, request cancellation, source caching, and shared worker resource-client setup. This keeps grid preview work off the main thread while avoiding unbounded MCAP reader/decoder creation.

This PR also improves custom-renderer size estimates so multimodal samples contribute a reasonable source-size hint to grid autosizing without allowing one large source file to force maximum zoom.

## 🧪 How is this patch tested? If it is not, please explain why.

Unit tests and type checks

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

The FiftyOne App now shows lightweight camera previews for MCAP-backed multimodal samples in the grid, including hover playback and optional image annotation overlays when matching annotation streams are available.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2864
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCAP grid previews: hover-playback of camera frames with annotation overlays and deterministic topic selection.

* **UI Enhancements**
  * Improved preview status messaging and a tiny ASCII loading animation.
  * Preview frame overlays now respect image dimensions and optional annotation stroke width.
  * Prior topics UI replaced with concise preview/status view.

* **Performance**
  * Efficient background worker pool and lightweight preview hook for responsive frame decoding and playback.

* **Accuracy**
  * More accurate tile autosizing so grid tiles better match actual image bytes/dimensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->