### PR TITLE
Add multimodal grid stream selector + 3d playback in grid

### DIFF
--- a/app/packages/core/src/components/Grid/GridCustomRendererItem.test.tsx
+++ b/app/packages/core/src/components/Grid/GridCustomRendererItem.test.tsx
@@ -89,6 +89,17 @@ describe("GridCustomRendererItem", () => {
     const wrapper = renderer?.parentElement as HTMLElement | null;
     expect(wrapper).toBeTruthy();
 
+    const hostClickSpy = vi.fn();
+    const hostContextMenuSpy = vi.fn();
+    host.addEventListener("click", hostClickSpy);
+    host.addEventListener("contextmenu", hostContextMenuSpy);
+
+    fireEvent.click(renderer as HTMLElement);
+    fireEvent.contextMenu(renderer as HTMLElement);
+
+    expect(hostClickSpy).not.toHaveBeenCalled();
+    expect(hostContextMenuSpy).not.toHaveBeenCalled();
+
     fireEvent.mouseEnter(wrapper as HTMLElement);
 
     await waitFor(() => {
@@ -96,12 +107,10 @@ describe("GridCustomRendererItem", () => {
       expect(getSelectControl(host)).toBeTruthy();
     });
 
-    const hostClickSpy = vi.fn();
-    host.addEventListener("click", hostClickSpy);
     const openButton = getOpenModalButton(host) as HTMLElement | null;
     expect(openButton).toBeTruthy();
     openButton?.click();
-    expect(hostClickSpy).toHaveBeenCalled();
+    expect(hostClickSpy).toHaveBeenCalledTimes(1);
 
     const selectSpy = vi.fn();
     looker.addEventListener("selectthumbnail", selectSpy);

--- a/app/packages/core/src/components/Grid/GridCustomRendererItem.tsx
+++ b/app/packages/core/src/components/Grid/GridCustomRendererItem.tsx
@@ -158,6 +158,12 @@ type GridCustomRendererWrapperProps = React.PropsWithChildren<{
   onSelect: React.MouseEventHandler<HTMLButtonElement>;
 }>;
 
+const stopGridActivationPropagation: React.MouseEventHandler<HTMLElement> = (
+  event
+) => {
+  event.stopPropagation();
+};
+
 const GridCustomRendererWrapper = ({
   children,
   selected,
@@ -173,6 +179,8 @@ const GridCustomRendererWrapper = ({
       onMouseEnter={() => setHovering(true)}
       onMouseMove={() => setHovering(true)}
       onMouseLeave={() => setHovering(false)}
+      onClick={stopGridActivationPropagation}
+      onContextMenu={stopGridActivationPropagation}
     >
       {children}
       {showSelectionControl && (

--- a/app/packages/core/src/components/Grid/Header/GridHeaderPluginSlot.test.tsx
+++ b/app/packages/core/src/components/Grid/Header/GridHeaderPluginSlot.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { ThemeProvider } from "styled-components";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import GridHeaderPluginSlot from "./GridHeaderPluginSlot";
+
+const { componentHasSlot, dataset, useActivePlugins, useCurrentDataset } =
+  vi.hoisted(() => ({
+    componentHasSlot: vi.fn(),
+    dataset: { mediaType: "multimodal", name: "dataset" },
+    useActivePlugins: vi.fn(),
+    useCurrentDataset: vi.fn(),
+  }));
+
+vi.mock("@fiftyone/plugins", () => ({
+  PLUGIN_COMPONENT_SLOT: {
+    GRID_HEADER_AFTER_RESOURCE_COUNT: "grid-header-after-resource-count",
+  },
+  PluginComponentType: { Component: 3 },
+  componentHasSlot: (...args: unknown[]) => componentHasSlot(...args),
+  useActivePlugins: (...args: unknown[]) => useActivePlugins(...args),
+}));
+
+vi.mock("@fiftyone/state", () => ({
+  useCurrentDataset: (...args: unknown[]) => useCurrentDataset(...args),
+}));
+
+const theme = {
+  primary: {
+    plainBorder: "#333",
+  },
+};
+
+const renderSlot = () =>
+  render(
+    <ThemeProvider theme={theme}>
+      <GridHeaderPluginSlot />
+    </ThemeProvider>
+  );
+
+describe("GridHeaderPluginSlot", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useCurrentDataset.mockReturnValue(dataset);
+    componentHasSlot.mockImplementation(
+      (component) =>
+        component.componentOptions?.slots?.includes(
+          "grid-header-after-resource-count"
+        ) === true
+    );
+  });
+
+  it("renders only components registered for the grid header slot", () => {
+    const SlotComponent = () => <div>slot component</div>;
+    const SlotlessComponent = () => <div>slotless component</div>;
+    useActivePlugins.mockReturnValue([
+      {
+        component: SlotlessComponent,
+        componentOptions: {},
+        name: "slotless",
+      },
+      {
+        component: SlotComponent,
+        componentOptions: {
+          slots: ["grid-header-after-resource-count"],
+        },
+        name: "slot",
+      },
+    ]);
+
+    renderSlot();
+
+    expect(screen.getByText("slot component")).toBeTruthy();
+    expect(screen.queryByText("slotless component")).toBeNull();
+    expect(useActivePlugins).toHaveBeenCalledWith(3, {
+      dataset,
+      slot: "grid-header-after-resource-count",
+      surface: "grid",
+    });
+  });
+});

--- a/app/packages/core/src/components/Grid/Header/GridHeaderPluginSlot.tsx
+++ b/app/packages/core/src/components/Grid/Header/GridHeaderPluginSlot.tsx
@@ -1,0 +1,44 @@
+import {
+  PLUGIN_COMPONENT_SLOT,
+  PluginComponentType,
+  componentHasSlot,
+  useActivePlugins,
+} from "@fiftyone/plugins";
+import * as fos from "@fiftyone/state";
+import React, { useMemo } from "react";
+import { RightDiv } from "./Containers";
+
+const SLOT = PLUGIN_COMPONENT_SLOT.GRID_HEADER_AFTER_RESOURCE_COUNT;
+
+/** Renders plugin components registered for the grid header count-adjacent slot. */
+const GridHeaderPluginSlot = () => {
+  const dataset = fos.useCurrentDataset();
+  const ctx = useMemo(
+    () => ({
+      dataset,
+      slot: SLOT,
+      surface: "grid",
+    }),
+    [dataset]
+  );
+  const components = useActivePlugins(
+    PluginComponentType.Component,
+    ctx
+  ).filter((registration) => componentHasSlot(registration, SLOT));
+
+  if (!components.length) {
+    return null;
+  }
+
+  return (
+    <>
+      {components.map(({ component: Component, name }) => (
+        <RightDiv key={name}>
+          <Component />
+        </RightDiv>
+      ))}
+    </>
+  );
+};
+
+export default GridHeaderPluginSlot;

--- a/app/packages/core/src/components/Grid/Header/GridHeaderPluginSlot.tsx
+++ b/app/packages/core/src/components/Grid/Header/GridHeaderPluginSlot.tsx
@@ -6,7 +6,7 @@ import {
 } from "@fiftyone/plugins";
 import * as fos from "@fiftyone/state";
 import React, { useMemo } from "react";
-import { RightDiv } from "./Containers";
+import { RightDiv as GridHeaderSlotContainer } from "./Containers";
 
 const SLOT = PLUGIN_COMPONENT_SLOT.GRID_HEADER_AFTER_RESOURCE_COUNT;
 
@@ -33,9 +33,9 @@ const GridHeaderPluginSlot = () => {
   return (
     <>
       {components.map(({ component: Component, name }) => (
-        <RightDiv key={name}>
+        <GridHeaderSlotContainer key={name}>
           <Component />
-        </RightDiv>
+        </GridHeaderSlotContainer>
       ))}
     </>
   );

--- a/app/packages/core/src/components/Grid/Header/Header.tsx
+++ b/app/packages/core/src/components/Grid/Header/Header.tsx
@@ -15,6 +15,7 @@ import {
   SamplesHeader,
   SliderContainer,
 } from "./Containers";
+import GridHeaderPluginSlot from "./GridHeaderPluginSlot";
 import GroupSlice from "./GroupSlice";
 import Sort from "./Sort";
 
@@ -96,6 +97,7 @@ const Header = () => {
         >
           <ResourceCount />
         </Suspense>
+        <GridHeaderPluginSlot />
         {shouldShowSliceSelector && (
           <RightDiv>
             <GroupSlice />

--- a/app/packages/multimodal/package.json
+++ b/app/packages/multimodal/package.json
@@ -64,7 +64,9 @@
     },
     "dependencies": {
         "@bufbuild/protobuf": "^2.11.0",
+        "@fiftyone/components": "*",
         "@fiftyone/plugins": "*",
+        "@fiftyone/state": "*",
         "@fiftyone/tiling": "*",
         "@fiftyone/utilities": "*",
         "@mcap/core": "^2.2.1",

--- a/app/packages/multimodal/package.json
+++ b/app/packages/multimodal/package.json
@@ -73,6 +73,7 @@
         "@mcap/support": "^1.1.0",
         "@react-three/drei": "9.105.4",
         "@react-three/fiber": "^8.18.0",
+        "@voxel51/voodo": "^0.0.34",
         "buffer": "^6.0.3",
         "lru-cache": "^11.0.1",
         "protobufjs": "^7.2.5",

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove.test.ts
@@ -176,7 +176,7 @@ describe("Foxglove decoders", () => {
     ).toEqual([10, 20]);
   });
 
-  it("ignores zero padding at the end of point cloud payloads", () => {
+  it("ignores only unaligned zero padding at the end of point cloud payloads", () => {
     const output = foxglovePointCloudDecoder.decode(
       pointCloudMessage(
         concatProtobufFields(
@@ -195,9 +195,9 @@ describe("Foxglove decoders", () => {
       throw new Error("Expected point cloud visualization");
     }
     expect(Array.from(output.visualization.positions)).toEqual([
-      1, 2, 3, 4, 5, 6,
+      1, 2, 3, 4, 5, 6, 0, 0, 0,
     ]);
-    expect(output.visualization.pointCount).toBe(2);
+    expect(output.visualization.pointCount).toBe(3);
   });
 
   it("rejects unaligned point cloud payloads with non-zero trailing data", () => {

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove.test.ts
@@ -134,6 +134,87 @@ describe("Foxglove decoders", () => {
     expect(output.timing?.timeRange?.startNs).toBe(10n);
     expect(output.timing?.sourceTimestamps?.messageTime).toBe(123456000001n);
   });
+
+  it("decodes point cloud colors and canonical scalar fields", () => {
+    const output = foxglovePointCloudDecoder.decode(
+      pointCloudMessage(radarPointBytes(), {
+        fields: [
+          { name: "x", offset: 0, type: 7 },
+          { name: "y", offset: 4, type: 7 },
+          { name: "z", offset: 8, type: 7 },
+          { name: "rcs", offset: 12, type: 7 },
+          { name: "r", offset: 16, type: 1 },
+          { name: "g", offset: 17, type: 1 },
+          { name: "b", offset: 18, type: 1 },
+        ],
+        pointStride: 19,
+      }),
+      {
+        schemaData: POINT_CLOUD_FIXTURE.schemaData,
+      }
+    );
+
+    expect(output.visualization?.kind).toBe(VISUALIZATION_KIND.POINT_CLOUD);
+    if (output.visualization?.kind !== VISUALIZATION_KIND.POINT_CLOUD) {
+      throw new Error("Expected point cloud visualization");
+    }
+
+    expect(Array.from(output.visualization.positions)).toEqual([
+      1, 2, 3, 4, 5, 6,
+    ]);
+    expectArrayCloseTo(Array.from(output.visualization.colors ?? []), [
+      1,
+      0,
+      0,
+      0,
+      128 / 255,
+      1,
+    ]);
+    expect(output.visualization.scalarFields?.[0]?.name).toBe("rcs");
+    expect(
+      Array.from(output.visualization.scalarFields?.[0]?.values ?? [])
+    ).toEqual([10, 20]);
+  });
+
+  it("ignores zero padding at the end of point cloud payloads", () => {
+    const output = foxglovePointCloudDecoder.decode(
+      pointCloudMessage(
+        concatProtobufFields(
+          float32Bytes([1, 2, 3, 4, 5, 6]),
+          new Uint8Array(12),
+          new Uint8Array(8)
+        )
+      ),
+      {
+        schemaData: POINT_CLOUD_FIXTURE.schemaData,
+      }
+    );
+
+    expect(output.visualization?.kind).toBe(VISUALIZATION_KIND.POINT_CLOUD);
+    if (output.visualization?.kind !== VISUALIZATION_KIND.POINT_CLOUD) {
+      throw new Error("Expected point cloud visualization");
+    }
+    expect(Array.from(output.visualization.positions)).toEqual([
+      1, 2, 3, 4, 5, 6,
+    ]);
+    expect(output.visualization.pointCount).toBe(2);
+  });
+
+  it("rejects unaligned point cloud payloads with non-zero trailing data", () => {
+    expect(() =>
+      foxglovePointCloudDecoder.decode(
+        pointCloudMessage(
+          concatProtobufFields(
+            float32Bytes([1, 2, 3, 4, 5, 6]),
+            Uint8Array.of(1)
+          )
+        ),
+        {
+          schemaData: POINT_CLOUD_FIXTURE.schemaData,
+        }
+      )
+    ).toThrow("Point cloud data length is not aligned to point stride");
+  });
 });
 
 function text(data: Uint8Array): string {
@@ -145,6 +226,119 @@ function compressedImageMessage(format: string): Uint8Array {
     protobufBytesField(2, new TextEncoder().encode("fake-jpeg")),
     protobufBytesField(3, new TextEncoder().encode(format))
   );
+}
+
+interface TestPointCloudField {
+  readonly name: string;
+  readonly offset: number;
+  readonly type: number;
+}
+
+function pointCloudMessage(
+  data: Uint8Array,
+  {
+    fields = [
+      { name: "x", offset: 0, type: 7 },
+      { name: "y", offset: 4, type: 7 },
+      { name: "z", offset: 8, type: 7 },
+    ],
+    pointStride = 12,
+  }: {
+    readonly fields?: readonly TestPointCloudField[];
+    readonly pointStride?: number;
+  } = {}
+): Uint8Array {
+  return concatProtobufFields(
+    protobufFixed32Field(4, pointStride),
+    ...fields.map((field) => packedPointCloudField(field)),
+    protobufBytesField(6, data)
+  );
+}
+
+function packedPointCloudField({
+  name,
+  offset,
+  type,
+}: TestPointCloudField): Uint8Array {
+  return protobufBytesField(
+    5,
+    concatProtobufFields(
+      protobufBytesField(1, new TextEncoder().encode(name)),
+      protobufFixed32Field(2, offset),
+      protobufVarintField(3, type)
+    )
+  );
+}
+
+function radarPointBytes(): Uint8Array {
+  const pointStride = 19;
+  const data = new Uint8Array(pointStride * 2);
+  const view = new DataView(data.buffer);
+
+  writeRadarPoint(view, 0, {
+    b: 0,
+    g: 0,
+    r: 255,
+    rcs: 10,
+    x: 1,
+    y: 2,
+    z: 3,
+  });
+  writeRadarPoint(view, pointStride, {
+    b: 255,
+    g: 128,
+    r: 0,
+    rcs: 20,
+    x: 4,
+    y: 5,
+    z: 6,
+  });
+
+  return data;
+}
+
+function writeRadarPoint(
+  view: DataView,
+  offset: number,
+  point: {
+    readonly b: number;
+    readonly g: number;
+    readonly r: number;
+    readonly rcs: number;
+    readonly x: number;
+    readonly y: number;
+    readonly z: number;
+  }
+) {
+  view.setFloat32(offset, point.x, true);
+  view.setFloat32(offset + 4, point.y, true);
+  view.setFloat32(offset + 8, point.z, true);
+  view.setFloat32(offset + 12, point.rcs, true);
+  view.setUint8(offset + 16, point.r);
+  view.setUint8(offset + 17, point.g);
+  view.setUint8(offset + 18, point.b);
+}
+
+function expectArrayCloseTo(
+  actual: readonly number[],
+  expected: readonly number[]
+) {
+  expect(actual).toHaveLength(expected.length);
+  actual.forEach((value, index) => {
+    expect(value).toBeCloseTo(expected[index]);
+  });
+}
+
+function protobufFixed32Field(fieldNumber: number, value: number): Uint8Array {
+  const bytes = new Uint8Array(5);
+  bytes[0] = (fieldNumber << 3) | 5;
+  new DataView(bytes.buffer).setUint32(1, value, true);
+
+  return bytes;
+}
+
+function protobufVarintField(fieldNumber: number, value: number): Uint8Array {
+  return concatProtobufFields(Uint8Array.of(fieldNumber << 3), varint(value));
 }
 
 function protobufBytesField(
@@ -168,6 +362,17 @@ function varint(value: number): Uint8Array {
   bytes.push(remaining);
 
   return Uint8Array.from(bytes);
+}
+
+function float32Bytes(values: readonly number[]): Uint8Array {
+  const data = new Uint8Array(values.length * 4);
+  const view = new DataView(data.buffer);
+
+  values.forEach((value, index) => {
+    view.setFloat32(index * 4, value, true);
+  });
+
+  return data;
 }
 
 function concatProtobufFields(...fields: readonly Uint8Array[]): Uint8Array {

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/point-cloud.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/point-cloud.ts
@@ -2,6 +2,7 @@ import type {
   DecodedAttributeValue,
   Decoder,
   PointCloudField,
+  PointCloudScalarField,
 } from "../../../../decoders";
 import { resourceHintsForArrayBufferViews } from "../../../../decoders";
 import { VISUALIZATION_KIND } from "../../../../visualization";
@@ -21,9 +22,24 @@ import { timingFromContext, timestampNs } from "./protobuf/timing";
 const FLOAT32_FIELD_TYPE = 7;
 const FLOAT32_BYTE_WIDTH = 4;
 const POINT_COMPONENT_COUNT = 3;
+const COLOR_COMPONENT_COUNT = 3;
 const X_COMPONENT_INDEX = 0;
 const Y_COMPONENT_INDEX = 1;
 const Z_COMPONENT_INDEX = 2;
+const UINT8_FIELD_TYPE = 1;
+const INT8_FIELD_TYPE = 2;
+const UINT16_FIELD_TYPE = 3;
+const INT16_FIELD_TYPE = 4;
+const UINT32_FIELD_TYPE = 5;
+const INT32_FIELD_TYPE = 6;
+const FLOAT64_FIELD_TYPE = 8;
+
+const CANONICAL_SCALAR_FIELDS = [
+  "intensity",
+  "reflectivity",
+  "reflectance",
+  "rcs",
+] as const;
 
 /**
  * Decoder for Foxglove point cloud protobuf messages.
@@ -42,12 +58,12 @@ export const foxglovePointCloudDecoder: Decoder = {
     const data = requiredBytes(message, "data");
     const pointStride = requiredNumber(message, "pointStride", "point_stride");
     const fields = packedFields(requiredArray(message, "fields"));
-    const positions = extractPositions(data, pointStride, fields);
+    const decodedPoints = extractPointCloudData(data, pointStride, fields);
     // Per-message Foxglove frame_id carried by this point cloud payload. This
     // is separate from the MCAP channel frame_id metadata fallback.
     const frameId = optionalString(message, "frameId", "frame_id");
     const messageTimestamp = timestampNs(optionalRecord(message, "timestamp"));
-    const pointCount = positions.length / POINT_COMPONENT_COUNT;
+    const pointCount = decodedPoints.positions.length / POINT_COMPONENT_COUNT;
     const packedFieldMetadata = fields.map((field) => ({
       name: field.name,
       offset: field.offset,
@@ -63,26 +79,42 @@ export const foxglovePointCloudDecoder: Decoder = {
       attributes.frameId = frameId;
     }
 
+    const transferableViews = [
+      decodedPoints.positions,
+      decodedPoints.colors,
+      ...decodedPoints.scalarFields.map((field) => field.values),
+    ].filter((view): view is Float32Array => view !== undefined);
+
     return {
       attributes,
-      resourceHints: resourceHintsForArrayBufferViews(positions),
+      resourceHints: resourceHintsForArrayBufferViews(...transferableViews),
       timing: timingFromContext(context, messageTimestamp),
       visualization: {
         ...(frameId ? { coordinateFrameId: frameId } : {}),
+        ...(decodedPoints.colors ? { colors: decodedPoints.colors } : {}),
+        ...(decodedPoints.scalarFields.length
+          ? { scalarFields: decodedPoints.scalarFields }
+          : {}),
         fields: packedFieldMetadata,
         kind: VISUALIZATION_KIND.POINT_CLOUD,
         pointCount,
-        positions,
+        positions: decodedPoints.positions,
       },
     };
   },
 };
 
-function extractPositions(
+interface DecodedPointCloudData {
+  readonly colors?: Float32Array;
+  readonly positions: Float32Array;
+  readonly scalarFields: readonly PointCloudScalarField[];
+}
+
+function extractPointCloudData(
   data: Uint8Array,
   pointStride: number,
   fields: readonly PointCloudField[]
-): Float32Array {
+): DecodedPointCloudData {
   if (pointStride <= 0) {
     throw new Error(`Invalid point stride ${pointStride}`);
   }
@@ -97,12 +129,16 @@ function extractPositions(
     }
   }
 
-  if (data.byteLength % pointStride !== 0) {
-    throw new Error("Point cloud data length is not aligned to point stride");
-  }
-
-  const pointCount = Math.floor(data.byteLength / pointStride);
+  const pointDataByteLength = alignedPointDataByteLength(data, pointStride);
+  const pointCount = Math.floor(pointDataByteLength / pointStride);
   const positions = new Float32Array(pointCount * POINT_COMPONENT_COUNT);
+  const colors = extractColorField(data, pointStride, pointCount, fields);
+  const scalarFields = extractScalarFields(
+    data,
+    pointStride,
+    pointCount,
+    fields
+  );
   const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
 
   for (let index = 0; index < pointCount; index++) {
@@ -122,7 +158,296 @@ function extractPositions(
     );
   }
 
-  return positions;
+  return { colors, positions, scalarFields };
+}
+
+function alignedPointDataByteLength(
+  data: Uint8Array,
+  pointStride: number
+): number {
+  const alignedByteLength =
+    Math.floor(data.byteLength / pointStride) * pointStride;
+
+  if (alignedByteLength === data.byteLength) {
+    return data.byteLength;
+  }
+
+  if (!isZeroRange(data, alignedByteLength, data.byteLength)) {
+    throw new Error("Point cloud data length is not aligned to point stride");
+  }
+
+  // Some exports pad fixed-size radar buffers with trailing zero bytes and
+  // zero-valued records. Treat only all-zero unaligned tails as padding.
+  return trimTrailingZeroPointRecords(data, alignedByteLength, pointStride);
+}
+
+function trimTrailingZeroPointRecords(
+  data: Uint8Array,
+  byteLength: number,
+  pointStride: number
+): number {
+  let trimmedByteLength = byteLength;
+
+  while (
+    trimmedByteLength >= pointStride &&
+    isZeroRange(data, trimmedByteLength - pointStride, trimmedByteLength)
+  ) {
+    trimmedByteLength -= pointStride;
+  }
+
+  return trimmedByteLength;
+}
+
+function isZeroRange(
+  data: Uint8Array,
+  startOffset: number,
+  endOffset: number
+): boolean {
+  for (let offset = startOffset; offset < endOffset; offset++) {
+    if (data[offset] !== 0) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function extractScalarFields(
+  data: Uint8Array,
+  pointStride: number,
+  pointCount: number,
+  fields: readonly PointCloudField[]
+): readonly PointCloudScalarField[] {
+  const scalarFields: PointCloudScalarField[] = [];
+  const usedFieldNames = new Set<string>();
+
+  for (const scalarName of CANONICAL_SCALAR_FIELDS) {
+    const field = fields.find(
+      (candidate) =>
+        !usedFieldNames.has(normalizedFieldName(candidate.name)) &&
+        normalizedFieldName(candidate.name) === scalarName &&
+        canReadNumericField(candidate, pointStride)
+    );
+
+    if (!field) {
+      continue;
+    }
+
+    usedFieldNames.add(normalizedFieldName(field.name));
+    scalarFields.push({
+      name: field.name,
+      values: extractNumericValues(data, pointStride, pointCount, field),
+    });
+  }
+
+  return scalarFields;
+}
+
+function extractColorField(
+  data: Uint8Array,
+  pointStride: number,
+  pointCount: number,
+  fields: readonly PointCloudField[]
+): Float32Array | undefined {
+  return (
+    extractSeparateColorChannels(data, pointStride, pointCount, fields) ??
+    extractPackedColorField(data, pointStride, pointCount, fields)
+  );
+}
+
+function extractSeparateColorChannels(
+  data: Uint8Array,
+  pointStride: number,
+  pointCount: number,
+  fields: readonly PointCloudField[]
+): Float32Array | undefined {
+  const red = findColorChannel(fields, pointStride, "r", "red");
+  const green = findColorChannel(fields, pointStride, "g", "green");
+  const blue = findColorChannel(fields, pointStride, "b", "blue");
+  if (!red || !green || !blue) {
+    return undefined;
+  }
+
+  const colors = new Float32Array(pointCount * COLOR_COMPONENT_COUNT);
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+
+  for (let index = 0; index < pointCount; index++) {
+    const baseOffset = index * pointStride;
+    const colorOffset = index * COLOR_COMPONENT_COUNT;
+    colors[colorOffset] = normalizeColorChannel(
+      readNumericField(view, baseOffset + red.offset, red.type),
+      red.type
+    );
+    colors[colorOffset + 1] = normalizeColorChannel(
+      readNumericField(view, baseOffset + green.offset, green.type),
+      green.type
+    );
+    colors[colorOffset + 2] = normalizeColorChannel(
+      readNumericField(view, baseOffset + blue.offset, blue.type),
+      blue.type
+    );
+  }
+
+  return colors;
+}
+
+function extractPackedColorField(
+  data: Uint8Array,
+  pointStride: number,
+  pointCount: number,
+  fields: readonly PointCloudField[]
+): Float32Array | undefined {
+  const field = fields.find(
+    (candidate) =>
+      ["color", "rgb", "rgba"].includes(normalizedFieldName(candidate.name)) &&
+      canReadNumericField(candidate, pointStride) &&
+      numericFieldByteWidth(candidate.type) === 4
+  );
+  if (!field) {
+    return undefined;
+  }
+
+  const colors = new Float32Array(pointCount * COLOR_COMPONENT_COUNT);
+
+  for (let index = 0; index < pointCount; index++) {
+    const byteOffset = index * pointStride + field.offset;
+    const colorOffset = index * COLOR_COMPONENT_COUNT;
+    // Packed PCL-style rgb/rgba values are commonly stored as little-endian
+    // 0xAARRGGBB bytes, even when the field type is FLOAT32.
+    colors[colorOffset] = data[byteOffset + 2] / 255;
+    colors[colorOffset + 1] = data[byteOffset + 1] / 255;
+    colors[colorOffset + 2] = data[byteOffset] / 255;
+  }
+
+  return colors;
+}
+
+function findColorChannel(
+  fields: readonly PointCloudField[],
+  pointStride: number,
+  ...names: readonly string[]
+): PointCloudField | undefined {
+  return fields.find(
+    (field) =>
+      names.includes(normalizedFieldName(field.name)) &&
+      canReadNumericField(field, pointStride)
+  );
+}
+
+function extractNumericValues(
+  data: Uint8Array,
+  pointStride: number,
+  pointCount: number,
+  field: PointCloudField
+): Float32Array {
+  const values = new Float32Array(pointCount);
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+
+  for (let index = 0; index < pointCount; index++) {
+    values[index] = readNumericField(
+      view,
+      index * pointStride + field.offset,
+      field.type
+    );
+  }
+
+  return values;
+}
+
+function canReadNumericField(
+  field: PointCloudField,
+  pointStride: number
+): boolean {
+  const byteWidth = numericFieldByteWidth(field.type);
+
+  return (
+    byteWidth > 0 &&
+    field.offset >= 0 &&
+    field.offset + byteWidth <= pointStride
+  );
+}
+
+function readNumericField(
+  view: DataView,
+  offset: number,
+  fieldType: number
+): number {
+  switch (fieldType) {
+    case UINT8_FIELD_TYPE:
+      return view.getUint8(offset);
+    case INT8_FIELD_TYPE:
+      return view.getInt8(offset);
+    case UINT16_FIELD_TYPE:
+      return view.getUint16(offset, true);
+    case INT16_FIELD_TYPE:
+      return view.getInt16(offset, true);
+    case UINT32_FIELD_TYPE:
+      return view.getUint32(offset, true);
+    case INT32_FIELD_TYPE:
+      return view.getInt32(offset, true);
+    case FLOAT32_FIELD_TYPE:
+      return view.getFloat32(offset, true);
+    case FLOAT64_FIELD_TYPE:
+      return view.getFloat64(offset, true);
+    default:
+      return Number.NaN;
+  }
+}
+
+function numericFieldByteWidth(fieldType: number): number {
+  switch (fieldType) {
+    case UINT8_FIELD_TYPE:
+    case INT8_FIELD_TYPE:
+      return 1;
+    case UINT16_FIELD_TYPE:
+    case INT16_FIELD_TYPE:
+      return 2;
+    case UINT32_FIELD_TYPE:
+    case INT32_FIELD_TYPE:
+    case FLOAT32_FIELD_TYPE:
+      return 4;
+    case FLOAT64_FIELD_TYPE:
+      return 8;
+    default:
+      return 0;
+  }
+}
+
+function normalizeColorChannel(value: number, fieldType: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+
+  if (fieldType === FLOAT32_FIELD_TYPE || fieldType === FLOAT64_FIELD_TYPE) {
+    return clamp01(value > 2 ? value / 255 : value);
+  }
+
+  return clamp01(value / integerFieldMaxValue(fieldType));
+}
+
+function integerFieldMaxValue(fieldType: number): number {
+  switch (fieldType) {
+    case UINT16_FIELD_TYPE:
+      return 65535;
+    case INT16_FIELD_TYPE:
+      return 32767;
+    case UINT32_FIELD_TYPE:
+      return 4294967295;
+    case INT32_FIELD_TYPE:
+      return 2147483647;
+    case INT8_FIELD_TYPE:
+      return 127;
+    default:
+      return 255;
+  }
+}
+
+function clamp01(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}
+
+function normalizedFieldName(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]/g, "");
 }
 
 function packedFields(values: readonly unknown[]): readonly PointCloudField[] {

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/point-cloud.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/point-cloud.ts
@@ -176,26 +176,9 @@ function alignedPointDataByteLength(
     throw new Error("Point cloud data length is not aligned to point stride");
   }
 
-  // Some exports pad fixed-size radar buffers with trailing zero bytes and
-  // zero-valued records. Treat only all-zero unaligned tails as padding.
-  return trimTrailingZeroPointRecords(data, alignedByteLength, pointStride);
-}
-
-function trimTrailingZeroPointRecords(
-  data: Uint8Array,
-  byteLength: number,
-  pointStride: number
-): number {
-  let trimmedByteLength = byteLength;
-
-  while (
-    trimmedByteLength >= pointStride &&
-    isZeroRange(data, trimmedByteLength - pointStride, trimmedByteLength)
-  ) {
-    trimmedByteLength -= pointStride;
-  }
-
-  return trimmedByteLength;
+  // Some exports pad fixed-size radar buffers with trailing zero bytes. Treat
+  // only the unaligned tail as padding so valid zero-valued points survive.
+  return alignedByteLength;
 }
 
 function isZeroRange(

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/point-cloud.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/point-cloud.ts
@@ -19,27 +19,46 @@ import {
 } from "./protobuf/records";
 import { timingFromContext, timestampNs } from "./protobuf/timing";
 
-const FLOAT32_FIELD_TYPE = 7;
-const FLOAT32_BYTE_WIDTH = 4;
-const POINT_COMPONENT_COUNT = 3;
-const COLOR_COMPONENT_COUNT = 3;
-const X_COMPONENT_INDEX = 0;
-const Y_COMPONENT_INDEX = 1;
-const Z_COMPONENT_INDEX = 2;
+// Foxglove PointCloud numeric Field.type ids, kept in protobuf enum order.
 const UINT8_FIELD_TYPE = 1;
 const INT8_FIELD_TYPE = 2;
 const UINT16_FIELD_TYPE = 3;
 const INT16_FIELD_TYPE = 4;
 const UINT32_FIELD_TYPE = 5;
 const INT32_FIELD_TYPE = 6;
+const FLOAT32_FIELD_TYPE = 7;
 const FLOAT64_FIELD_TYPE = 8;
 
-const CANONICAL_SCALAR_FIELDS = [
+const UINT8_MAX_VALUE = 255;
+const INT8_MAX_VALUE = 127;
+const UINT16_MAX_VALUE = 65_535;
+const INT16_MAX_VALUE = 32_767;
+const UINT32_MAX_VALUE = 4_294_967_295;
+const INT32_MAX_VALUE = 2_147_483_647;
+
+const FLOAT32_BYTE_WIDTH = 4;
+
+const POINT_COMPONENT_COUNT = 3;
+const COLOR_COMPONENT_COUNT = 3;
+
+const X_COMPONENT_INDEX = 0;
+const Y_COMPONENT_INDEX = 1;
+const Z_COMPONENT_INDEX = 2;
+
+const CANONICAL_SCALAR_FIELDS = Object.freeze([
   "intensity",
   "reflectivity",
   "reflectance",
   "rcs",
-] as const;
+] as const);
+const CANONICAL_SCALAR_FIELD_NAMES: ReadonlySet<string> = new Set(
+  CANONICAL_SCALAR_FIELDS
+);
+
+const RED_COLOR_CHANNEL_NAMES = Object.freeze(["r", "red"] as const);
+const GREEN_COLOR_CHANNEL_NAMES = Object.freeze(["g", "green"] as const);
+const BLUE_COLOR_CHANNEL_NAMES = Object.freeze(["b", "blue"] as const);
+const PACKED_COLOR_FIELD_NAMES = Object.freeze(["color", "rgb", "rgba"]);
 
 /**
  * Decoder for Foxglove point cloud protobuf messages.
@@ -202,21 +221,27 @@ function extractScalarFields(
   fields: readonly PointCloudField[]
 ): readonly PointCloudScalarField[] {
   const scalarFields: PointCloudScalarField[] = [];
-  const usedFieldNames = new Set<string>();
+  const scalarFieldByName = new Map<string, PointCloudField>();
+
+  for (const field of fields) {
+    const scalarName = normalizedFieldName(field.name);
+    if (
+      !CANONICAL_SCALAR_FIELD_NAMES.has(scalarName) ||
+      scalarFieldByName.has(scalarName) ||
+      !canReadNumericField(field, pointStride)
+    ) {
+      continue;
+    }
+
+    scalarFieldByName.set(scalarName, field);
+  }
 
   for (const scalarName of CANONICAL_SCALAR_FIELDS) {
-    const field = fields.find(
-      (candidate) =>
-        !usedFieldNames.has(normalizedFieldName(candidate.name)) &&
-        normalizedFieldName(candidate.name) === scalarName &&
-        canReadNumericField(candidate, pointStride)
-    );
-
+    const field = scalarFieldByName.get(scalarName);
     if (!field) {
       continue;
     }
 
-    usedFieldNames.add(normalizedFieldName(field.name));
     scalarFields.push({
       name: field.name,
       values: extractNumericValues(data, pointStride, pointCount, field),
@@ -244,9 +269,13 @@ function extractSeparateColorChannels(
   pointCount: number,
   fields: readonly PointCloudField[]
 ): Float32Array | undefined {
-  const red = findColorChannel(fields, pointStride, "r", "red");
-  const green = findColorChannel(fields, pointStride, "g", "green");
-  const blue = findColorChannel(fields, pointStride, "b", "blue");
+  const red = findColorChannel(fields, pointStride, RED_COLOR_CHANNEL_NAMES);
+  const green = findColorChannel(
+    fields,
+    pointStride,
+    GREEN_COLOR_CHANNEL_NAMES
+  );
+  const blue = findColorChannel(fields, pointStride, BLUE_COLOR_CHANNEL_NAMES);
   if (!red || !green || !blue) {
     return undefined;
   }
@@ -282,7 +311,7 @@ function extractPackedColorField(
 ): Float32Array | undefined {
   const field = fields.find(
     (candidate) =>
-      ["color", "rgb", "rgba"].includes(normalizedFieldName(candidate.name)) &&
+      PACKED_COLOR_FIELD_NAMES.includes(normalizedFieldName(candidate.name)) &&
       canReadNumericField(candidate, pointStride) &&
       numericFieldByteWidth(candidate.type) === 4
   );
@@ -297,9 +326,9 @@ function extractPackedColorField(
     const colorOffset = index * COLOR_COMPONENT_COUNT;
     // Packed PCL-style rgb/rgba values are commonly stored as little-endian
     // 0xAARRGGBB bytes, even when the field type is FLOAT32.
-    colors[colorOffset] = data[byteOffset + 2] / 255;
-    colors[colorOffset + 1] = data[byteOffset + 1] / 255;
-    colors[colorOffset + 2] = data[byteOffset] / 255;
+    colors[colorOffset] = data[byteOffset + 2] / UINT8_MAX_VALUE;
+    colors[colorOffset + 1] = data[byteOffset + 1] / UINT8_MAX_VALUE;
+    colors[colorOffset + 2] = data[byteOffset] / UINT8_MAX_VALUE;
   }
 
   return colors;
@@ -308,7 +337,7 @@ function extractPackedColorField(
 function findColorChannel(
   fields: readonly PointCloudField[],
   pointStride: number,
-  ...names: readonly string[]
+  names: readonly string[]
 ): PointCloudField | undefined {
   return fields.find(
     (field) =>
@@ -411,17 +440,17 @@ function normalizeColorChannel(value: number, fieldType: number): number {
 function integerFieldMaxValue(fieldType: number): number {
   switch (fieldType) {
     case UINT16_FIELD_TYPE:
-      return 65535;
+      return UINT16_MAX_VALUE;
     case INT16_FIELD_TYPE:
-      return 32767;
+      return INT16_MAX_VALUE;
     case UINT32_FIELD_TYPE:
-      return 4294967295;
+      return UINT32_MAX_VALUE;
     case INT32_FIELD_TYPE:
-      return 2147483647;
+      return INT32_MAX_VALUE;
     case INT8_FIELD_TYPE:
-      return 127;
+      return INT8_MAX_VALUE;
     default:
-      return 255;
+      return UINT8_MAX_VALUE;
   }
 }
 

--- a/app/packages/multimodal/src/adapters/mcap/entry.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/entry.tsx
@@ -1,6 +1,10 @@
-import { PluginComponentType, registerComponent } from "@fiftyone/plugins";
+import {
+  PLUGIN_COMPONENT_SLOT,
+  PluginComponentType,
+  registerComponent,
+} from "@fiftyone/plugins";
 import McapModalRenderer from "./react/McapModalRenderer";
-import { GridRenderer } from "./react";
+import { GridRenderer, McapGridStreamSelector } from "./react";
 
 registerComponent({
   name: "McapRenderer",
@@ -14,5 +18,16 @@ registerComponent({
       enabled: true,
       overrideComponent: GridRenderer,
     },
+  },
+});
+
+registerComponent({
+  name: "McapGridStreamSelector",
+  label: "MCAP grid stream selector",
+  component: McapGridStreamSelector,
+  type: PluginComponentType.Component,
+  activator: (ctx) => ctx.dataset?.mediaType === "multimodal",
+  componentOptions: {
+    slots: [PLUGIN_COMPONENT_SLOT.GRID_HEADER_AFTER_RESOURCE_COUNT],
   },
 });

--- a/app/packages/multimodal/src/adapters/mcap/grid-preview.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/grid-preview.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import type {
   EncodedImageVisualization,
   ImageAnnotationsVisualization,
+  PointCloudVisualization,
 } from "../../decoders";
 import type { ByteSourceDescriptor } from "../../query/bytes";
 import type { StreamInventory } from "../../schemas/v1";
@@ -12,6 +13,7 @@ import {
   chooseCameraSelection,
   decodeGridPreview,
   streamTopics,
+  type McapGridPreviewFrame,
 } from "./grid-preview";
 import type {
   McapDecodedMessage,
@@ -20,7 +22,7 @@ import type {
 } from "./types";
 
 describe("MCAP grid preview", () => {
-  it("returns an empty no-camera state and caches the missing selection", async () => {
+  it("returns an empty no-stream state and caches the missing selection", async () => {
     const client = createClient({
       readTopics: vi.fn(async () => []),
     });
@@ -31,15 +33,15 @@ describe("MCAP grid preview", () => {
 
     expect(first.state).toMatchObject({
       frame: null,
-      hasImageTopics: false,
-      imageTopic: null,
+      hasPreviewTopics: false,
+      streamTopic: null,
       status: "empty",
     });
     expect(second.state.status).toBe("empty");
     expect(client.readTopics).toHaveBeenCalledTimes(1);
   });
 
-  it("reads an image frame and reuses the cached camera selection", async () => {
+  it("reads an image frame and reuses the cached stream selection", async () => {
     const readDecodedMessages = vi.fn(async function* (
       request: Parameters<McapResourceClient["readDecodedMessages"]>[0]
     ) {
@@ -58,7 +60,7 @@ describe("MCAP grid preview", () => {
     });
 
     expect(first.state.status).toBe("ready");
-    expect(first.state.frame?.image.bytes[0]).toBe(1);
+    expect(imageFrame(first.state.frame)?.image.bytes[0]).toBe(1);
     expect(first.nextStartTimeNs).toBe(8n);
     expect(second.state.status).toBe("ready");
     expect(client.readTopics).toHaveBeenCalledTimes(1);
@@ -100,8 +102,10 @@ describe("MCAP grid preview", () => {
 
     expect(result.state.status).toBe("ready");
     expect(result.delayMs).toBe(MCAP_GRID_PREVIEW_ANNOTATION_FRAME_DELAY_MS);
-    expect(result.state.frame?.annotations?.texts[0]?.text).toBe("car");
-    expect(result.state.frame?.image.bytes[0]).toBe(1);
+    expect(imageFrame(result.state.frame)?.annotations?.texts[0]?.text).toBe(
+      "car"
+    );
+    expect(imageFrame(result.state.frame)?.image.bytes[0]).toBe(1);
     expect(readSynchronizedMessages).toHaveBeenCalledWith(
       expect.objectContaining({
         timeNs: 20n,
@@ -136,8 +140,8 @@ describe("MCAP grid preview", () => {
     );
 
     expect(result.state.status).toBe("ready");
-    expect(result.state.frame?.annotations).toBeNull();
-    expect(result.state.frame?.image.bytes[0]).toBe(4);
+    expect(imageFrame(result.state.frame)?.annotations).toBeNull();
+    expect(imageFrame(result.state.frame)?.image.bytes[0]).toBe(4);
     expect(result.nextStartTimeNs).toBe(31n);
     expect(
       readDecodedMessages.mock.calls.map(([request]) => request.topics)
@@ -147,7 +151,7 @@ describe("MCAP grid preview", () => {
     ]);
   });
 
-  it("returns empty with image topics when the selected camera has no frame", async () => {
+  it("returns empty with stream topics when the selected stream has no frame", async () => {
     const client = createClient({
       readDecodedMessages: vi.fn(async function* () {
         for (const item of [] as never[]) {
@@ -164,13 +168,13 @@ describe("MCAP grid preview", () => {
 
     expect(result.state).toMatchObject({
       frame: null,
-      hasImageTopics: true,
-      imageTopic: "/camera/front",
+      hasPreviewTopics: true,
+      streamTopic: "/camera/front",
       status: "empty",
     });
   });
 
-  it("uses an explicit selected image topic when it is available", async () => {
+  it("uses an explicit selected image stream when it is available", async () => {
     const readDecodedMessages = vi.fn(async function* (
       request: Parameters<McapResourceClient["readDecodedMessages"]>[0]
     ) {
@@ -187,23 +191,23 @@ describe("MCAP grid preview", () => {
     const result = await decodeGridPreview(
       { client },
       {
-        selectedImageTopic: "/camera/back",
+        selectedStreamTopic: "/camera/back",
         source: createSource(),
       }
     );
 
     expect(result.state).toMatchObject({
-      imageTopic: "/camera/back",
-      imageTopics: ["/camera/front", "/camera/back"],
+      streamTopic: "/camera/back",
+      streamTopics: ["/camera/front", "/camera/back"],
       status: "ready",
     });
-    expect(result.state.frame?.image.bytes[0]).toBe(8);
+    expect(imageFrame(result.state.frame)?.image.bytes[0]).toBe(8);
     expect(readDecodedMessages).toHaveBeenCalledWith(
       expect.objectContaining({ topics: ["/camera/back"] })
     );
   });
 
-  it("returns unavailable when an explicit selected image topic is missing", async () => {
+  it("returns unavailable when an explicit selected stream is missing", async () => {
     const readDecodedMessages = vi.fn(async function* () {
       for (const item of [] as never[]) {
         yield item;
@@ -217,7 +221,7 @@ describe("MCAP grid preview", () => {
     const result = await decodeGridPreview(
       { client },
       {
-        selectedImageTopic: "/camera/back",
+        selectedStreamTopic: "/camera/back",
         source: createSource(),
       }
     );
@@ -225,12 +229,83 @@ describe("MCAP grid preview", () => {
     expect(result.state).toEqual({
       error: null,
       frame: null,
-      hasImageTopics: true,
-      imageTopic: "/camera/back",
-      imageTopics: ["/camera/front"],
+      hasPreviewTopics: true,
+      streamTopic: "/camera/back",
+      streamTopics: ["/camera/front"],
       status: "unavailable",
     });
     expect(readDecodedMessages).not.toHaveBeenCalled();
+  });
+
+  it("uses a point-cloud stream when auto has no image stream", async () => {
+    const readDecodedMessages = vi.fn(async function* (
+      request: Parameters<McapResourceClient["readDecodedMessages"]>[0]
+    ) {
+      yield createPointCloudMessage(
+        request.topics?.[0] ?? "/lidar/points",
+        [1, 2, 3],
+        50n
+      );
+    });
+    const client = createClient({
+      readDecodedMessages,
+      readTopics: vi.fn(async () => [
+        createTopic("/lidar/points", "foxglove.PointCloud"),
+      ]),
+    });
+
+    const result = await decodeGridPreview(
+      { client },
+      { source: createSource() }
+    );
+
+    expect(result.state).toMatchObject({
+      streamTopic: "/lidar/points",
+      streamTopics: ["/lidar/points"],
+      status: "ready",
+    });
+    expect(pointCloudFrame(result.state.frame)?.pointCloud.positions[0]).toBe(
+      1
+    );
+    expect(readDecodedMessages).toHaveBeenCalledWith(
+      expect.objectContaining({ topics: ["/lidar/points"] })
+    );
+  });
+
+  it("uses an explicit selected point-cloud stream", async () => {
+    const readDecodedMessages = vi.fn(async function* (
+      request: Parameters<McapResourceClient["readDecodedMessages"]>[0]
+    ) {
+      yield createPointCloudMessage(
+        request.topics?.[0] ?? "/lidar/rear",
+        [4, 5, 6],
+        60n
+      );
+    });
+    const client = createClient({
+      readDecodedMessages,
+      readTopics: vi.fn(async () => [
+        createTopic("/camera/front"),
+        createTopic("/lidar/rear", "foxglove.PointCloud"),
+      ]),
+    });
+
+    const result = await decodeGridPreview(
+      { client },
+      {
+        selectedStreamTopic: "/lidar/rear",
+        source: createSource(),
+      }
+    );
+
+    expect(result.state).toMatchObject({
+      streamTopic: "/lidar/rear",
+      streamTopics: ["/camera/front", "/lidar/rear"],
+      status: "ready",
+    });
+    expect(pointCloudFrame(result.state.frame)?.pointCloud.positions[0]).toBe(
+      4
+    );
   });
 
   it("classifies image and annotation topics from schema metadata", () => {
@@ -238,11 +313,13 @@ describe("MCAP grid preview", () => {
       streamTopics([
         createTopic("/camera/front"),
         createTopic("/camera/front/annotations", "foxglove.ImageAnnotations"),
+        createTopic("/lidar/points", "foxglove.PointCloud"),
         createTopic("/tf", "foxglove.FrameTransform"),
       ])
     ).toEqual({
       annotations: ["/camera/front/annotations"],
       image: ["/camera/front"],
+      pointCloud: ["/lidar/points"],
     });
   });
 
@@ -253,11 +330,13 @@ describe("MCAP grid preview", () => {
         "/CAM_FRONT/image_rect_compressed",
         "/CAM_BACK/image_rect_compressed",
       ],
+      pointCloud: [],
     });
 
     expect(selection).toEqual({
       annotationTopic: "/CAM_FRONT/annotations",
-      imageTopic: "/CAM_FRONT/image_rect_compressed",
+      kind: "image",
+      streamTopic: "/CAM_FRONT/image_rect_compressed",
     });
   });
 
@@ -366,6 +445,36 @@ function createAnnotationMessage(
     visualization,
     timelineTimeNs,
   });
+}
+
+function createPointCloudMessage(
+  topic: string,
+  positions: readonly number[],
+  timelineTimeNs = 10n
+): McapDecodedMessage {
+  const visualization: PointCloudVisualization = {
+    fields: [],
+    kind: VISUALIZATION_KIND.POINT_CLOUD,
+    pointCount: Math.floor(positions.length / 3),
+    positions: new Float32Array(positions),
+  };
+
+  return createDecodedMessage(topic, "foxglove.PointCloud", {
+    visualization,
+    timelineTimeNs,
+  });
+}
+
+function imageFrame(
+  frame: McapGridPreviewFrame | null
+): Extract<McapGridPreviewFrame, { kind: "image" }> | null {
+  return frame?.kind === "image" ? frame : null;
+}
+
+function pointCloudFrame(
+  frame: McapGridPreviewFrame | null
+): Extract<McapGridPreviewFrame, { kind: "point-cloud" }> | null {
+  return frame?.kind === "point-cloud" ? frame : null;
 }
 
 function createDecodedMessage(

--- a/app/packages/multimodal/src/adapters/mcap/grid-preview.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/grid-preview.test.ts
@@ -170,6 +170,69 @@ describe("MCAP grid preview", () => {
     });
   });
 
+  it("uses an explicit selected image topic when it is available", async () => {
+    const readDecodedMessages = vi.fn(async function* (
+      request: Parameters<McapResourceClient["readDecodedMessages"]>[0]
+    ) {
+      yield createImageMessage(request.topics?.[0] ?? "/camera", [8, 9], 40n);
+    });
+    const client = createClient({
+      readDecodedMessages,
+      readTopics: vi.fn(async () => [
+        createTopic("/camera/front"),
+        createTopic("/camera/back"),
+      ]),
+    });
+
+    const result = await decodeGridPreview(
+      { client },
+      {
+        selectedImageTopic: "/camera/back",
+        source: createSource(),
+      }
+    );
+
+    expect(result.state).toMatchObject({
+      imageTopic: "/camera/back",
+      imageTopics: ["/camera/front", "/camera/back"],
+      status: "ready",
+    });
+    expect(result.state.frame?.image.bytes[0]).toBe(8);
+    expect(readDecodedMessages).toHaveBeenCalledWith(
+      expect.objectContaining({ topics: ["/camera/back"] })
+    );
+  });
+
+  it("returns unavailable when an explicit selected image topic is missing", async () => {
+    const readDecodedMessages = vi.fn(async function* () {
+      for (const item of [] as never[]) {
+        yield item;
+      }
+    });
+    const client = createClient({
+      readDecodedMessages,
+      readTopics: vi.fn(async () => [createTopic("/camera/front")]),
+    });
+
+    const result = await decodeGridPreview(
+      { client },
+      {
+        selectedImageTopic: "/camera/back",
+        source: createSource(),
+      }
+    );
+
+    expect(result.state).toEqual({
+      error: null,
+      frame: null,
+      hasImageTopics: true,
+      imageTopic: "/camera/back",
+      imageTopics: ["/camera/front"],
+      status: "unavailable",
+    });
+    expect(readDecodedMessages).not.toHaveBeenCalled();
+  });
+
   it("classifies image and annotation topics from schema metadata", () => {
     expect(
       streamTopics([

--- a/app/packages/multimodal/src/adapters/mcap/grid-preview.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/grid-preview.test.ts
@@ -9,12 +9,12 @@ import type { StreamInventory } from "../../schemas/v1";
 import { VISUALIZATION_KIND } from "../../visualization";
 import {
   MCAP_GRID_PREVIEW_ANNOTATION_FRAME_DELAY_MS,
-  chooseAnnotationTopic,
   chooseCameraSelection,
   decodeGridPreview,
-  streamTopics,
   type McapGridPreviewFrame,
 } from "./grid-preview";
+import { chooseAnnotationTopic } from "./topic-matching";
+import { streamTopics } from "./stream-topics";
 import type {
   McapDecodedMessage,
   McapResourceClient,
@@ -320,6 +320,27 @@ describe("MCAP grid preview", () => {
       annotations: ["/camera/front/annotations"],
       image: ["/camera/front"],
       pointCloud: ["/lidar/points"],
+      previewable: ["/camera/front", "/lidar/points"],
+    });
+  });
+
+  it("ignores point-cloud-like schemas without a supported decoder", () => {
+    expect(
+      streamTopics([
+        createTopic(
+          "/radar/points",
+          "sensor_msgs/msg/PointCloud2",
+          "cdr",
+          "ros2msg"
+        ),
+        createTopic("/radar/custom", "example.RadarPointCloud"),
+        createTopic("/tf", "foxglove.FrameTransform"),
+      ])
+    ).toEqual({
+      annotations: [],
+      image: [],
+      pointCloud: [],
+      previewable: [],
     });
   });
 
@@ -331,6 +352,10 @@ describe("MCAP grid preview", () => {
         "/CAM_BACK/image_rect_compressed",
       ],
       pointCloud: [],
+      previewable: [
+        "/CAM_FRONT/image_rect_compressed",
+        "/CAM_BACK/image_rect_compressed",
+      ],
     });
 
     expect(selection).toEqual({
@@ -387,7 +412,9 @@ function createSource(): ByteSourceDescriptor {
 
 function createTopic(
   topic: string,
-  schema = "foxglove.CompressedImage"
+  schema = "foxglove.CompressedImage",
+  encoding = "protobuf",
+  schemaEncoding = "protobuf"
 ): StreamInventory {
   return {
     $typeName: "fiftyone.multimodal.schemas.v1.StreamInventory",
@@ -398,9 +425,9 @@ function createTopic(
     },
     payload: {
       $typeName: "fiftyone.multimodal.schemas.v1.PayloadDescriptor",
-      encoding: "protobuf",
+      encoding,
       schema,
-      schemaEncoding: "protobuf",
+      schemaEncoding,
     },
     streamId: topic,
   };

--- a/app/packages/multimodal/src/adapters/mcap/grid-preview.ts
+++ b/app/packages/multimodal/src/adapters/mcap/grid-preview.ts
@@ -92,6 +92,7 @@ export type McapGridPreviewStatus =
   | "loading"
   | "ready"
   | "empty"
+  | "unavailable"
   | "error";
 
 /**
@@ -102,6 +103,7 @@ export interface McapGridPreviewSnapshot {
   readonly frame: McapGridPreviewFrame | null;
   readonly hasImageTopics: boolean;
   readonly imageTopic: string | null;
+  readonly imageTopics: readonly string[];
   readonly status: McapGridPreviewStatus;
 }
 
@@ -119,13 +121,15 @@ export interface McapGridPreviewResult {
  */
 export interface McapGridPreviewEntry {
   readonly client: McapResourceClient;
-  selection?: McapGridCameraSelection | null;
+  autoSelection?: McapGridCameraSelection | null;
+  topics?: McapGridTopics;
 }
 
 /**
  * High-level grid preview decode request handled inside the shared worker pool.
  */
 export interface McapGridPreviewDecodeRequest {
+  readonly selectedImageTopic?: string | null;
   readonly source: ByteSourceDescriptor;
   readonly startTimeNs?: bigint;
 }
@@ -135,14 +139,33 @@ export interface McapGridPreviewDecodeRequest {
  */
 export async function decodeGridPreview(
   entry: McapGridPreviewEntry,
-  { source, startTimeNs }: McapGridPreviewDecodeRequest
+  { selectedImageTopic, source, startTimeNs }: McapGridPreviewDecodeRequest
 ): Promise<McapGridPreviewResult> {
-  if (entry.selection === undefined) {
-    const topics = streamTopics(await entry.client.readTopics({ source }));
-    entry.selection = chooseCameraSelection(topics);
+  if (entry.topics === undefined) {
+    entry.topics = streamTopics(await entry.client.readTopics({ source }));
   }
 
-  const selection = entry.selection;
+  const topics = entry.topics;
+  const imageTopics = topics.image;
+  const selection = chooseRequestedCameraSelection(
+    entry,
+    topics,
+    selectedImageTopic
+  );
+
+  if (selectedImageTopic && !selection) {
+    return {
+      state: {
+        error: null,
+        frame: null,
+        hasImageTopics: imageTopics.length > 0,
+        imageTopic: selectedImageTopic,
+        imageTopics,
+        status: "unavailable",
+      },
+    };
+  }
+
   if (!selection) {
     return {
       state: {
@@ -150,6 +173,7 @@ export async function decodeGridPreview(
         frame: null,
         hasImageTopics: false,
         imageTopic: null,
+        imageTopics,
         status: "empty",
       },
     };
@@ -169,6 +193,7 @@ export async function decodeGridPreview(
         frame: null,
         hasImageTopics: true,
         imageTopic: selection.imageTopic,
+        imageTopics,
         status: "empty",
       },
     };
@@ -182,9 +207,36 @@ export async function decodeGridPreview(
       frame: result.frame,
       hasImageTopics: true,
       imageTopic: selection.imageTopic,
+      imageTopics,
       status: "ready",
     },
   };
+}
+
+function chooseRequestedCameraSelection(
+  entry: McapGridPreviewEntry,
+  topics: McapGridTopics,
+  selectedImageTopic: string | null | undefined
+): McapGridCameraSelection | null {
+  if (selectedImageTopic) {
+    if (!topics.image.includes(selectedImageTopic)) {
+      return null;
+    }
+
+    return {
+      annotationTopic: chooseAnnotationTopic(
+        selectedImageTopic,
+        topics.annotations
+      ),
+      imageTopic: selectedImageTopic,
+    };
+  }
+
+  if (entry.autoSelection === undefined) {
+    entry.autoSelection = chooseCameraSelection(topics);
+  }
+
+  return entry.autoSelection;
 }
 
 /**

--- a/app/packages/multimodal/src/adapters/mcap/grid-preview.ts
+++ b/app/packages/multimodal/src/adapters/mcap/grid-preview.ts
@@ -162,11 +162,7 @@ export async function decodeGridPreview(
 
   const topics = entry.topics;
   const previewTopics = topics.previewable;
-  const selection = chooseRequestedCameraSelection(
-    entry,
-    topics,
-    selectedStreamTopic
-  );
+  const selection = chooseSelection(entry, topics, selectedStreamTopic);
 
   if (selectedStreamTopic && !selection) {
     return {
@@ -228,7 +224,7 @@ export async function decodeGridPreview(
   };
 }
 
-function chooseRequestedCameraSelection(
+function chooseSelection(
   entry: McapGridPreviewEntry,
   topics: McapGridTopics,
   selectedStreamTopic: string | null | undefined

--- a/app/packages/multimodal/src/adapters/mcap/grid-preview.ts
+++ b/app/packages/multimodal/src/adapters/mcap/grid-preview.ts
@@ -4,18 +4,16 @@ import type {
   PointCloudVisualization,
 } from "../../decoders";
 import type { ByteSourceDescriptor } from "../../query/bytes";
-import { PlaybackSyncMode, type StreamInventory } from "../../schemas/v1";
+import { PlaybackSyncMode } from "../../schemas/v1";
 import { VISUALIZATION_KIND } from "../../visualization";
+import { chooseAnnotationTopic } from "./topic-matching";
+import { streamTopics, type McapPreviewTopics } from "./stream-topics";
 import type {
   McapDecodedMessage,
   McapResourceClient,
   McapStreamSyncPolicy,
 } from "./types";
 
-// Grid previews support schema-classified compressed images and point clouds.
-const COMPRESSED_IMAGE_PATTERN = /compressedimage/i;
-const IMAGE_ANNOTATIONS_PATTERN = /imageannotations/i;
-const POINT_CLOUD_PATTERN = /pointcloud|point_cloud/i;
 const IMAGE_SYNC_TOLERANCE_NS = 120_000_000n;
 const NEXT_FRAME_STEP_NS = 1n;
 
@@ -25,27 +23,8 @@ const IMAGE_SYNC_POLICY: McapStreamSyncPolicy = {
   toleranceBeforeNs: IMAGE_SYNC_TOLERANCE_NS,
 } as const;
 
-// Drop generic topic words before scoring image/annotation topic similarity so
-// camera-identifying tokens like "front" or "left" decide the best match.
-const IGNORED_TOPIC_TOKENS = new Set([
-  "annotation",
-  "annotations",
-  "cam",
-  "camera",
-  "compressed",
-  "image",
-  "rect",
-]);
-
-// Strip image-format suffix segments when deriving the camera topic prefix, so
-// "/camera/front/image_rect_compressed" pairs with "/camera/front/annotations".
-const IMAGE_TOPIC_SUFFIX_TOKENS = new Set([
-  "compressed",
-  "compressedimage",
-  "image",
-  "raw",
-  "rect",
-]);
+export { chooseAnnotationTopic } from "./topic-matching";
+export { streamTopics } from "./stream-topics";
 
 /**
  * Default playback speed for animated MCAP grid previews.
@@ -68,13 +47,9 @@ export const MCAP_GRID_PREVIEW_POINT_CLOUD_FRAME_DELAY_MS = 83;
 export const MCAP_GRID_PREVIEW_ANNOTATION_FRAME_DELAY_MS = 500;
 
 /**
- * Camera and annotation topic buckets used by grid preview selection.
+ * Supported stream topic buckets used by grid preview selection.
  */
-export interface McapGridTopics {
-  readonly annotations: readonly string[];
-  readonly image: readonly string[];
-  readonly pointCloud: readonly string[];
-}
+export type McapGridTopics = McapPreviewTopics;
 
 /**
  * Selected camera image topic plus its best matching annotation topic.
@@ -93,6 +68,9 @@ export interface McapGridPointCloudSelection {
   readonly streamTopic: string;
 }
 
+/**
+ * Selected stream descriptor for one MCAP grid preview.
+ */
 export type McapGridPreviewSelection =
   | McapGridCameraSelection
   | McapGridPointCloudSelection;
@@ -114,6 +92,9 @@ export interface McapGridPointCloudPreviewFrame {
   readonly pointCloud: PointCloudVisualization;
 }
 
+/**
+ * Render-ready preview frame shown by the MCAP grid renderer.
+ */
 export type McapGridPreviewFrame =
   | McapGridImagePreviewFrame
   | McapGridPointCloudPreviewFrame;
@@ -180,7 +161,7 @@ export async function decodeGridPreview(
   }
 
   const topics = entry.topics;
-  const previewTopics = previewableTopics(topics);
+  const previewTopics = topics.previewable;
   const selection = chooseRequestedCameraSelection(
     entry,
     topics,
@@ -535,140 +516,4 @@ function pointCloudFrame(
   return visualization?.kind === VISUALIZATION_KIND.POINT_CLOUD
     ? visualization
     : null;
-}
-
-/**
- * Splits stream inventory into image and annotation topics.
- */
-export function streamTopics(
-  topics: readonly StreamInventory[]
-): McapGridTopics {
-  const image: string[] = [];
-  const annotations: string[] = [];
-  const pointCloud: string[] = [];
-
-  for (const topic of topics) {
-    const name = topicName(topic);
-    if (!name) {
-      continue;
-    }
-
-    if (isCompressedImageStream(topic)) {
-      image.push(name);
-    } else if (isPointCloudStream(topic)) {
-      pointCloud.push(name);
-    } else if (isImageAnnotationsStream(topic)) {
-      annotations.push(name);
-    }
-  }
-
-  return { annotations, image, pointCloud };
-}
-
-function previewableTopics(topics: McapGridTopics): readonly string[] {
-  return [...topics.image, ...topics.pointCloud];
-}
-
-function topicName(topic: StreamInventory): string {
-  return topic.metadata["mcap.topic"] ?? topic.displayName ?? "";
-}
-
-function schemaIdentity(topic: StreamInventory): string {
-  return [topic.payload?.schema, topic.metadata["mcap.schema_name"]].join(" ");
-}
-
-function isCompressedImageStream(topic: StreamInventory): boolean {
-  return COMPRESSED_IMAGE_PATTERN.test(schemaIdentity(topic));
-}
-
-function isImageAnnotationsStream(topic: StreamInventory): boolean {
-  return IMAGE_ANNOTATIONS_PATTERN.test(schemaIdentity(topic));
-}
-
-function isPointCloudStream(topic: StreamInventory): boolean {
-  return POINT_CLOUD_PATTERN.test(schemaIdentity(topic));
-}
-
-/**
- * Chooses the annotation topic that best matches a selected camera topic.
- * Prefers the exact `<camera prefix>/annotations` sibling, then falls back
- * to the highest shared-token score.
- */
-export function chooseAnnotationTopic(
-  imageTopic: string,
-  annotationTopics: readonly string[]
-): string | null {
-  if (annotationTopics.length === 0) {
-    return null;
-  }
-
-  const cameraPrefix = topicPrefix(imageTopic);
-  const exactTopic = cameraPrefix ? `${cameraPrefix}/annotations` : "";
-  const exact = annotationTopics.find((topic) => topic === exactTopic);
-  if (exact) {
-    return exact;
-  }
-
-  let bestTopic: string | null = null;
-  let bestScore = 0;
-  const imageTokens = topicTokens(imageTopic);
-
-  for (const annotationTopic of annotationTopics) {
-    const annotationTokens = topicTokens(annotationTopic);
-    let score =
-      cameraPrefix && isTopicAtOrBelowPrefix(annotationTopic, cameraPrefix)
-        ? 10
-        : 0;
-    for (const token of imageTokens) {
-      if (annotationTokens.has(token)) {
-        score += 1;
-      }
-    }
-
-    if (score > bestScore) {
-      bestScore = score;
-      bestTopic = annotationTopic;
-    }
-  }
-
-  return bestTopic;
-}
-
-function topicPrefix(topic: string): string {
-  const normalized = topic.replace(/\/+$/, "");
-  const hasLeadingSlash = normalized.startsWith("/");
-  const parts = normalized.split("/").filter(Boolean);
-
-  while (parts.length > 0 && isImageTopicSuffix(parts[parts.length - 1])) {
-    parts.pop();
-  }
-
-  return parts.length > 0
-    ? `${hasLeadingSlash ? "/" : ""}${parts.join("/")}`
-    : "";
-}
-
-function isTopicAtOrBelowPrefix(topic: string, prefix: string): boolean {
-  return topic === prefix || topic.startsWith(`${prefix}/`);
-}
-
-function isImageTopicSuffix(segment: string): boolean {
-  const tokens = segment
-    .toLowerCase()
-    .split(/[^a-z0-9]+/)
-    .filter(Boolean);
-
-  return (
-    tokens.length > 0 &&
-    tokens.every((token) => IMAGE_TOPIC_SUFFIX_TOKENS.has(token))
-  );
-}
-
-function topicTokens(topic: string): Set<string> {
-  return new Set(
-    topic
-      .toLowerCase()
-      .split(/[^a-z0-9]+/)
-      .filter((token) => token && !IGNORED_TOPIC_TOKENS.has(token))
-  );
 }

--- a/app/packages/multimodal/src/adapters/mcap/grid-preview.ts
+++ b/app/packages/multimodal/src/adapters/mcap/grid-preview.ts
@@ -1,6 +1,7 @@
 import type {
   EncodedImageVisualization,
   ImageAnnotationsVisualization,
+  PointCloudVisualization,
 } from "../../decoders";
 import type { ByteSourceDescriptor } from "../../query/bytes";
 import { PlaybackSyncMode, type StreamInventory } from "../../schemas/v1";
@@ -11,9 +12,10 @@ import type {
   McapStreamSyncPolicy,
 } from "./types";
 
-// Note: we only support compressed image topics for preview now
+// Grid previews support schema-classified compressed images and point clouds.
 const COMPRESSED_IMAGE_PATTERN = /compressedimage/i;
 const IMAGE_ANNOTATIONS_PATTERN = /imageannotations/i;
+const POINT_CLOUD_PATTERN = /pointcloud|point_cloud/i;
 const IMAGE_SYNC_TOLERANCE_NS = 120_000_000n;
 const NEXT_FRAME_STEP_NS = 1n;
 
@@ -56,6 +58,11 @@ export const DEFAULT_MCAP_GRID_PREVIEW_PLAYBACK_RATE = 1.5;
 export const MCAP_GRID_PREVIEW_IMAGE_FRAME_DELAY_MS = 83;
 
 /**
+ * Default cadence for point-cloud MCAP grid preview playback.
+ */
+export const MCAP_GRID_PREVIEW_POINT_CLOUD_FRAME_DELAY_MS = 83;
+
+/**
  * Default cadence for annotated MCAP grid preview playback.
  */
 export const MCAP_GRID_PREVIEW_ANNOTATION_FRAME_DELAY_MS = 500;
@@ -66,6 +73,7 @@ export const MCAP_GRID_PREVIEW_ANNOTATION_FRAME_DELAY_MS = 500;
 export interface McapGridTopics {
   readonly annotations: readonly string[];
   readonly image: readonly string[];
+  readonly pointCloud: readonly string[];
 }
 
 /**
@@ -73,16 +81,42 @@ export interface McapGridTopics {
  */
 export interface McapGridCameraSelection {
   readonly annotationTopic: string | null;
-  readonly imageTopic: string;
+  readonly kind: "image";
+  readonly streamTopic: string;
 }
+
+/**
+ * Selected point-cloud topic.
+ */
+export interface McapGridPointCloudSelection {
+  readonly kind: "point-cloud";
+  readonly streamTopic: string;
+}
+
+export type McapGridPreviewSelection =
+  | McapGridCameraSelection
+  | McapGridPointCloudSelection;
 
 /**
  * Render-ready image preview frame, optionally paired with annotations.
  */
-export interface McapGridPreviewFrame {
+export interface McapGridImagePreviewFrame {
   readonly annotations: ImageAnnotationsVisualization | null;
   readonly image: EncodedImageVisualization;
+  readonly kind: "image";
 }
+
+/**
+ * Render-ready point-cloud preview frame.
+ */
+export interface McapGridPointCloudPreviewFrame {
+  readonly kind: "point-cloud";
+  readonly pointCloud: PointCloudVisualization;
+}
+
+export type McapGridPreviewFrame =
+  | McapGridImagePreviewFrame
+  | McapGridPointCloudPreviewFrame;
 
 /**
  * Status values used by the MCAP grid preview renderer.
@@ -96,14 +130,14 @@ export type McapGridPreviewStatus =
   | "error";
 
 /**
- * Render state for one lightweight MCAP camera preview in the grid.
+ * Render state for one lightweight MCAP stream preview in the grid.
  */
 export interface McapGridPreviewSnapshot {
   readonly error: string | null;
   readonly frame: McapGridPreviewFrame | null;
-  readonly hasImageTopics: boolean;
-  readonly imageTopic: string | null;
-  readonly imageTopics: readonly string[];
+  readonly hasPreviewTopics: boolean;
+  readonly streamTopic: string | null;
+  readonly streamTopics: readonly string[];
   readonly status: McapGridPreviewStatus;
 }
 
@@ -121,7 +155,7 @@ export interface McapGridPreviewResult {
  */
 export interface McapGridPreviewEntry {
   readonly client: McapResourceClient;
-  autoSelection?: McapGridCameraSelection | null;
+  autoSelection?: McapGridPreviewSelection | null;
   topics?: McapGridTopics;
 }
 
@@ -129,38 +163,38 @@ export interface McapGridPreviewEntry {
  * High-level grid preview decode request handled inside the shared worker pool.
  */
 export interface McapGridPreviewDecodeRequest {
-  readonly selectedImageTopic?: string | null;
+  readonly selectedStreamTopic?: string | null;
   readonly source: ByteSourceDescriptor;
   readonly startTimeNs?: bigint;
 }
 
 /**
- * Ensures a cached source camera selection and reads one render-ready preview.
+ * Ensures a cached source stream selection and reads one render-ready preview.
  */
 export async function decodeGridPreview(
   entry: McapGridPreviewEntry,
-  { selectedImageTopic, source, startTimeNs }: McapGridPreviewDecodeRequest
+  { selectedStreamTopic, source, startTimeNs }: McapGridPreviewDecodeRequest
 ): Promise<McapGridPreviewResult> {
   if (entry.topics === undefined) {
     entry.topics = streamTopics(await entry.client.readTopics({ source }));
   }
 
   const topics = entry.topics;
-  const imageTopics = topics.image;
+  const previewTopics = previewableTopics(topics);
   const selection = chooseRequestedCameraSelection(
     entry,
     topics,
-    selectedImageTopic
+    selectedStreamTopic
   );
 
-  if (selectedImageTopic && !selection) {
+  if (selectedStreamTopic && !selection) {
     return {
       state: {
         error: null,
         frame: null,
-        hasImageTopics: imageTopics.length > 0,
-        imageTopic: selectedImageTopic,
-        imageTopics,
+        hasPreviewTopics: previewTopics.length > 0,
+        streamTopic: selectedStreamTopic,
+        streamTopics: previewTopics,
         status: "unavailable",
       },
     };
@@ -171,9 +205,9 @@ export async function decodeGridPreview(
       state: {
         error: null,
         frame: null,
-        hasImageTopics: false,
-        imageTopic: null,
-        imageTopics,
+        hasPreviewTopics: false,
+        streamTopic: null,
+        streamTopics: previewTopics,
         status: "empty",
       },
     };
@@ -191,9 +225,9 @@ export async function decodeGridPreview(
       state: {
         error: null,
         frame: null,
-        hasImageTopics: true,
-        imageTopic: selection.imageTopic,
-        imageTopics,
+        hasPreviewTopics: true,
+        streamTopic: selection.streamTopic,
+        streamTopics: previewTopics,
         status: "empty",
       },
     };
@@ -205,9 +239,9 @@ export async function decodeGridPreview(
     state: {
       error: null,
       frame: result.frame,
-      hasImageTopics: true,
-      imageTopic: selection.imageTopic,
-      imageTopics,
+      hasPreviewTopics: true,
+      streamTopic: selection.streamTopic,
+      streamTopics: previewTopics,
       status: "ready",
     },
   };
@@ -216,27 +250,41 @@ export async function decodeGridPreview(
 function chooseRequestedCameraSelection(
   entry: McapGridPreviewEntry,
   topics: McapGridTopics,
-  selectedImageTopic: string | null | undefined
-): McapGridCameraSelection | null {
-  if (selectedImageTopic) {
-    if (!topics.image.includes(selectedImageTopic)) {
-      return null;
+  selectedStreamTopic: string | null | undefined
+): McapGridPreviewSelection | null {
+  if (selectedStreamTopic) {
+    if (topics.image.includes(selectedStreamTopic)) {
+      return {
+        annotationTopic: chooseAnnotationTopic(
+          selectedStreamTopic,
+          topics.annotations
+        ),
+        kind: "image",
+        streamTopic: selectedStreamTopic,
+      };
     }
 
-    return {
-      annotationTopic: chooseAnnotationTopic(
-        selectedImageTopic,
-        topics.annotations
-      ),
-      imageTopic: selectedImageTopic,
-    };
+    if (topics.pointCloud.includes(selectedStreamTopic)) {
+      return {
+        kind: "point-cloud",
+        streamTopic: selectedStreamTopic,
+      };
+    }
+
+    return null;
   }
 
   if (entry.autoSelection === undefined) {
-    entry.autoSelection = chooseCameraSelection(topics);
+    entry.autoSelection = chooseAutoSelection(topics);
   }
 
   return entry.autoSelection;
+}
+
+function chooseAutoSelection(
+  topics: McapGridTopics
+): McapGridPreviewSelection | null {
+  return chooseCameraSelection(topics) ?? choosePointCloudSelection(topics);
 }
 
 /**
@@ -253,13 +301,26 @@ export function chooseCameraSelection(
 
   return {
     annotationTopic: chooseAnnotationTopic(imageTopic, topics.annotations),
-    imageTopic,
+    kind: "image",
+    streamTopic: imageTopic,
   };
+}
+
+function choosePointCloudSelection(
+  topics: McapGridTopics
+): McapGridPointCloudSelection | null {
+  const pointCloudTopic = topics.pointCloud[0];
+  return pointCloudTopic
+    ? {
+        kind: "point-cloud",
+        streamTopic: pointCloudTopic,
+      }
+    : null;
 }
 
 interface ReadPreviewFrameRequest {
   readonly client: McapResourceClient;
-  readonly selection: McapGridCameraSelection;
+  readonly selection: McapGridPreviewSelection;
   readonly source: ByteSourceDescriptor;
   readonly startTimeNs?: bigint;
 }
@@ -276,6 +337,10 @@ interface McapGridPreviewReadResult {
 async function readNextPreviewFrame(
   request: ReadPreviewFrameRequest
 ): Promise<McapGridPreviewReadResult | null> {
+  if (request.selection.kind === "point-cloud") {
+    return readNextPointCloudPreviewFrame(request);
+  }
+
   if (request.selection.annotationTopic) {
     const annotatedFrame = await readNextAnnotatedPreviewFrame(request);
     if (annotatedFrame) {
@@ -292,11 +357,15 @@ async function readNextImagePreviewFrame({
   source,
   startTimeNs,
 }: ReadPreviewFrameRequest): Promise<McapGridPreviewReadResult | null> {
+  if (selection.kind !== "image") {
+    return null;
+  }
+
   const imageMessage = await readNextMessage({
     client,
     source,
     startTimeNs,
-    topic: selection.imageTopic,
+    topic: selection.streamTopic,
   });
   const image = imageMessage ? imageFrame(imageMessage) : null;
 
@@ -306,7 +375,7 @@ async function readNextImagePreviewFrame({
 
   return {
     delayMs: MCAP_GRID_PREVIEW_IMAGE_FRAME_DELAY_MS,
-    frame: { annotations: null, image },
+    frame: { annotations: null, image, kind: "image" },
     nextStartTimeNs: imageMessage.timelineTimeNs + NEXT_FRAME_STEP_NS,
   };
 }
@@ -317,6 +386,10 @@ async function readNextAnnotatedPreviewFrame({
   source,
   startTimeNs,
 }: ReadPreviewFrameRequest): Promise<McapGridPreviewReadResult | null> {
+  if (selection.kind !== "image") {
+    return null;
+  }
+
   if (!selection.annotationTopic) {
     return null;
   }
@@ -340,13 +413,13 @@ async function readNextAnnotatedPreviewFrame({
       client,
       source,
       timeNs: annotationMessage.timelineTimeNs,
-      topic: selection.imageTopic,
+      topic: selection.streamTopic,
     })) ??
     (await readNextMessage({
       client,
       source,
       startTimeNs: annotationMessage.timelineTimeNs,
-      topic: selection.imageTopic,
+      topic: selection.streamTopic,
     }).then((message) => (message ? imageFrame(message) : null)));
 
   if (!image) {
@@ -355,8 +428,39 @@ async function readNextAnnotatedPreviewFrame({
 
   return {
     delayMs: MCAP_GRID_PREVIEW_ANNOTATION_FRAME_DELAY_MS,
-    frame: { annotations, image },
+    frame: { annotations, image, kind: "image" },
     nextStartTimeNs: annotationMessage.timelineTimeNs + NEXT_FRAME_STEP_NS,
+  };
+}
+
+async function readNextPointCloudPreviewFrame({
+  client,
+  selection,
+  source,
+  startTimeNs,
+}: ReadPreviewFrameRequest): Promise<McapGridPreviewReadResult | null> {
+  if (selection.kind !== "point-cloud") {
+    return null;
+  }
+
+  const pointCloudMessage = await readNextMessage({
+    client,
+    source,
+    startTimeNs,
+    topic: selection.streamTopic,
+  });
+  const pointCloud = pointCloudMessage
+    ? pointCloudFrame(pointCloudMessage)
+    : null;
+
+  if (!pointCloudMessage || !pointCloud) {
+    return null;
+  }
+
+  return {
+    delayMs: MCAP_GRID_PREVIEW_POINT_CLOUD_FRAME_DELAY_MS,
+    frame: { kind: "point-cloud", pointCloud },
+    nextStartTimeNs: pointCloudMessage.timelineTimeNs + NEXT_FRAME_STEP_NS,
   };
 }
 
@@ -424,6 +528,15 @@ function annotationsFrame(
     : null;
 }
 
+function pointCloudFrame(
+  message: McapDecodedMessage
+): PointCloudVisualization | null {
+  const visualization = message.decoded.output.visualization;
+  return visualization?.kind === VISUALIZATION_KIND.POINT_CLOUD
+    ? visualization
+    : null;
+}
+
 /**
  * Splits stream inventory into image and annotation topics.
  */
@@ -432,6 +545,7 @@ export function streamTopics(
 ): McapGridTopics {
   const image: string[] = [];
   const annotations: string[] = [];
+  const pointCloud: string[] = [];
 
   for (const topic of topics) {
     const name = topicName(topic);
@@ -441,12 +555,18 @@ export function streamTopics(
 
     if (isCompressedImageStream(topic)) {
       image.push(name);
+    } else if (isPointCloudStream(topic)) {
+      pointCloud.push(name);
     } else if (isImageAnnotationsStream(topic)) {
       annotations.push(name);
     }
   }
 
-  return { annotations, image };
+  return { annotations, image, pointCloud };
+}
+
+function previewableTopics(topics: McapGridTopics): readonly string[] {
+  return [...topics.image, ...topics.pointCloud];
 }
 
 function topicName(topic: StreamInventory): string {
@@ -463,6 +583,10 @@ function isCompressedImageStream(topic: StreamInventory): boolean {
 
 function isImageAnnotationsStream(topic: StreamInventory): boolean {
   return IMAGE_ANNOTATIONS_PATTERN.test(schemaIdentity(topic));
+}
+
+function isPointCloudStream(topic: StreamInventory): boolean {
+  return POINT_CLOUD_PATTERN.test(schemaIdentity(topic));
 }
 
 /**

--- a/app/packages/multimodal/src/adapters/mcap/index.ts
+++ b/app/packages/multimodal/src/adapters/mcap/index.ts
@@ -13,6 +13,24 @@ export type {
 export { createMcapResourceClient } from "./resource-client";
 
 /**
+ * Shared MCAP stream classification and topic matching helpers.
+ */
+export {
+  chooseAnnotationTopic,
+  topicPrefix,
+  topicTokens,
+} from "./topic-matching";
+export {
+  hasPayload,
+  isCompressedImageStream,
+  isImageAnnotationsStream,
+  isPointCloudStream,
+  streamTopics,
+  topicName,
+} from "./stream-topics";
+export type { McapPreviewTopics } from "./stream-topics";
+
+/**
  * Default tolerance for synchronized MCAP playback windows.
  */
 export { DEFAULT_MCAP_SYNC_TOLERANCE_NS } from "./sync";

--- a/app/packages/multimodal/src/adapters/mcap/react/GridRenderer.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/GridRenderer.test.tsx
@@ -6,10 +6,11 @@ const previewHarness = vi.hoisted(() => ({
   preview: {
     error: null,
     frame: null,
-    hasImageTopics: false,
-    imageTopic: null,
+    hasPreviewTopics: false,
     pause: vi.fn(),
     play: vi.fn(),
+    streamTopic: null,
+    streamTopics: [],
     status: "idle",
   },
 }));
@@ -22,12 +23,26 @@ vi.mock("./use-mcap-grid-preview", () => ({
   useMcapGridPreview: vi.fn(() => previewHarness.preview),
 }));
 
+vi.mock("./mcap-grid-camera-state", () => ({
+  useMcapGridCameraPose: vi.fn(() => [null, vi.fn()]),
+}));
+
+vi.mock("./mcap-grid-stream-state", () => ({
+  MCAP_GRID_STREAM_AUTO: "__auto__",
+  useMcapGridSelectedStreamTopic: vi.fn(() => ["__auto__", vi.fn()]),
+  useRegisterMcapGridStreamTopics: vi.fn(() => vi.fn()),
+}));
+
 vi.mock("../../../visualization/panels/ImageAnnotationsOverlay", () => ({
   ImageAnnotationsOverlay: () => <div data-testid="annotations-overlay" />,
 }));
 
 vi.mock("../../../visualization/panels/image", () => ({
   ImagePanel: () => <div data-testid="image-panel" />,
+}));
+
+vi.mock("../../../visualization/panels/point-cloud", () => ({
+  PointCloudPanel: () => <div data-testid="point-cloud-panel" />,
 }));
 
 afterEach(() => {
@@ -37,11 +52,20 @@ afterEach(() => {
 describe("GridRenderer", () => {
   it("shows idle as an empty no-source state without loading animation", () => {
     previewHarness.preview.status = "idle";
-    previewHarness.preview.hasImageTopics = false;
+    previewHarness.preview.hasPreviewTopics = false;
 
-    render(<GridRenderer ctx={{} as never} />);
+    render(
+      <GridRenderer
+        ctx={
+          {
+            dataset: { name: "dataset" },
+            sample: { sample: { id: "1" } },
+          } as never
+        }
+      />
+    );
 
-    expect(screen.getByText("No camera streams")).toBeTruthy();
+    expect(screen.getByText("No preview streams")).toBeTruthy();
     expect(screen.queryByTestId("mcap-loading-ascii")).toBeNull();
   });
 });

--- a/app/packages/multimodal/src/adapters/mcap/react/GridRenderer.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/GridRenderer.tsx
@@ -1,10 +1,15 @@
 import type { SampleRendererProps } from "@fiftyone/plugins";
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { ImageAnnotationsOverlay } from "../../../visualization/panels/ImageAnnotationsOverlay";
 import { ImagePanel } from "../../../visualization/panels/image";
 import type { McapGridPreviewFrame } from "../grid-preview";
 import classes from "./GridRenderer.module.css";
 import { McapLoadingAscii } from "./McapLoadingAscii";
+import {
+  MCAP_GRID_STREAM_AUTO,
+  registerMcapGridImageTopics,
+  useMcapGridSelectedImageTopic,
+} from "./mcap-grid-stream-state";
 import {
   useMcapGridPreview,
   type McapGridPreviewStatus,
@@ -20,7 +25,24 @@ const GRID_ANNOTATION_STROKE_WIDTH = 1;
  */
 export function GridRenderer({ ctx }: SampleRendererProps) {
   const source = useStableMcapSource(ctx);
-  const preview = useMcapGridPreview({ source });
+  const sampleId = useMemo(() => {
+    const sample = ctx.sample.sample as { _id?: string; id?: string };
+    return sample._id ?? sample.id;
+  }, [ctx.sample.sample]);
+  const [selectedImageTopic] = useMcapGridSelectedImageTopic(ctx.dataset.name);
+  const preview = useMcapGridPreview({
+    selectedImageTopic:
+      selectedImageTopic === MCAP_GRID_STREAM_AUTO ? null : selectedImageTopic,
+    source,
+  });
+
+  useEffect(() => {
+    return registerMcapGridImageTopics({
+      datasetName: ctx.dataset.name,
+      sampleId,
+      topics: preview.imageTopics,
+    });
+  }, [ctx.dataset.name, preview.imageTopics, sampleId]);
 
   return (
     <div

--- a/app/packages/multimodal/src/adapters/mcap/react/GridRenderer.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/GridRenderer.tsx
@@ -2,13 +2,14 @@ import type { SampleRendererProps } from "@fiftyone/plugins";
 import { useEffect, useMemo, useState } from "react";
 import { ImageAnnotationsOverlay } from "../../../visualization/panels/ImageAnnotationsOverlay";
 import { ImagePanel } from "../../../visualization/panels/image";
+import { PointCloudPanel } from "../../../visualization/panels/point-cloud";
 import type { McapGridPreviewFrame } from "../grid-preview";
 import classes from "./GridRenderer.module.css";
 import { McapLoadingAscii } from "./McapLoadingAscii";
 import {
   MCAP_GRID_STREAM_AUTO,
-  registerMcapGridImageTopics,
-  useMcapGridSelectedImageTopic,
+  registerMcapGridStreamTopics,
+  useMcapGridSelectedStreamTopic,
 } from "./mcap-grid-stream-state";
 import {
   useMcapGridPreview,
@@ -29,20 +30,24 @@ export function GridRenderer({ ctx }: SampleRendererProps) {
     const sample = ctx.sample.sample as { _id?: string; id?: string };
     return sample._id ?? sample.id;
   }, [ctx.sample.sample]);
-  const [selectedImageTopic] = useMcapGridSelectedImageTopic(ctx.dataset.name);
+  const [selectedStreamTopic] = useMcapGridSelectedStreamTopic(
+    ctx.dataset.name
+  );
   const preview = useMcapGridPreview({
-    selectedImageTopic:
-      selectedImageTopic === MCAP_GRID_STREAM_AUTO ? null : selectedImageTopic,
+    selectedStreamTopic:
+      selectedStreamTopic === MCAP_GRID_STREAM_AUTO
+        ? null
+        : selectedStreamTopic,
     source,
   });
 
   useEffect(() => {
-    return registerMcapGridImageTopics({
+    return registerMcapGridStreamTopics({
       datasetName: ctx.dataset.name,
       sampleId,
-      topics: preview.imageTopics,
+      topics: preview.streamTopics,
     });
-  }, [ctx.dataset.name, preview.imageTopics, sampleId]);
+  }, [ctx.dataset.name, preview.streamTopics, sampleId]);
 
   return (
     <div
@@ -54,13 +59,13 @@ export function GridRenderer({ ctx }: SampleRendererProps) {
         <PreviewFrame
           // Image dimensions are per camera stream; remount to drop stale
           // dimensions when the source or selected topic changes.
-          key={`${source?.sourceId ?? ""}:${preview.imageTopic ?? ""}`}
+          key={`${source?.sourceId ?? ""}:${preview.streamTopic ?? ""}`}
           frame={preview.frame}
         />
       ) : (
         <PreviewStatus
           error={preview.error}
-          hasImageTopics={preview.hasImageTopics}
+          hasPreviewTopics={preview.hasPreviewTopics}
           status={preview.status}
         />
       )}
@@ -69,6 +74,33 @@ export function GridRenderer({ ctx }: SampleRendererProps) {
 }
 
 function PreviewFrame({ frame }: { readonly frame: McapGridPreviewFrame }) {
+  return frame.kind === "point-cloud" ? (
+    <PointCloudPreviewFrame frame={frame} />
+  ) : (
+    <ImagePreviewFrame frame={frame} />
+  );
+}
+
+function PointCloudPreviewFrame({
+  frame,
+}: {
+  readonly frame: Extract<McapGridPreviewFrame, { kind: "point-cloud" }>;
+}) {
+  return (
+    <PointCloudPanel
+      className={classes.imagePanel}
+      frame={frame.pointCloud}
+      showGizmo={false}
+      showHud={false}
+    />
+  );
+}
+
+function ImagePreviewFrame({
+  frame,
+}: {
+  readonly frame: Extract<McapGridPreviewFrame, { kind: "image" }>;
+}) {
   const [imageDims, setImageDims] = useState<{
     width: number;
     height: number;
@@ -105,15 +137,15 @@ function PreviewFrame({ frame }: { readonly frame: McapGridPreviewFrame }) {
 
 function PreviewStatus({
   error,
-  hasImageTopics,
+  hasPreviewTopics,
   status,
 }: {
   readonly error: string | null;
-  readonly hasImageTopics: boolean;
+  readonly hasPreviewTopics: boolean;
   readonly status: McapGridPreviewStatus;
 }) {
   const loading = status === "loading";
-  const message = previewStatusMessage(status, hasImageTopics);
+  const message = previewStatusMessage(status, hasPreviewTopics);
 
   return (
     <div className={classes.status}>

--- a/app/packages/multimodal/src/adapters/mcap/react/GridRenderer.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/GridRenderer.tsx
@@ -11,6 +11,7 @@ import {
   registerMcapGridStreamTopics,
   useMcapGridSelectedStreamTopic,
 } from "./mcap-grid-stream-state";
+import { useMcapGridCameraPose } from "./mcap-grid-camera-state";
 import {
   useMcapGridPreview,
   type McapGridPreviewStatus,
@@ -86,10 +87,14 @@ function PointCloudPreviewFrame({
 }: {
   readonly frame: Extract<McapGridPreviewFrame, { kind: "point-cloud" }>;
 }) {
+  const [cameraPose, setCameraPose] = useMcapGridCameraPose();
+
   return (
     <PointCloudPanel
+      cameraPose={cameraPose}
       className={classes.imagePanel}
       frame={frame.pointCloud}
+      onCameraPoseChange={setCameraPose}
       showGizmo={false}
       showHud={false}
     />

--- a/app/packages/multimodal/src/adapters/mcap/react/GridRenderer.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/GridRenderer.tsx
@@ -1,5 +1,5 @@
 import type { SampleRendererProps } from "@fiftyone/plugins";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { ImageAnnotationsOverlay } from "../../../visualization/panels/ImageAnnotationsOverlay";
 import { ImagePanel } from "../../../visualization/panels/image";
 import { PointCloudPanel } from "../../../visualization/panels/point-cloud";
@@ -8,7 +8,7 @@ import classes from "./GridRenderer.module.css";
 import { McapLoadingAscii } from "./McapLoadingAscii";
 import {
   MCAP_GRID_STREAM_AUTO,
-  registerMcapGridStreamTopics,
+  useRegisterMcapGridStreamTopics,
   useMcapGridSelectedStreamTopic,
 } from "./mcap-grid-stream-state";
 import { useMcapGridCameraPose } from "./mcap-grid-camera-state";
@@ -41,14 +41,16 @@ export function GridRenderer({ ctx }: SampleRendererProps) {
         : selectedStreamTopic,
     source,
   });
+  const registerStreamTopics = useRegisterMcapGridStreamTopics();
+  const stableStreamTopics = useStableGridStreamTopics(preview.streamTopics);
 
   useEffect(() => {
-    return registerMcapGridStreamTopics({
+    return registerStreamTopics({
       datasetName: ctx.dataset.name,
       sampleId,
-      topics: preview.streamTopics,
+      topics: stableStreamTopics.topics,
     });
-  }, [ctx.dataset.name, preview.streamTopics, sampleId]);
+  }, [ctx.dataset.name, registerStreamTopics, sampleId, stableStreamTopics]);
 
   return (
     <div
@@ -72,6 +74,28 @@ export function GridRenderer({ ctx }: SampleRendererProps) {
       )}
     </div>
   );
+}
+
+function useStableGridStreamTopics(topics: readonly string[]) {
+  const previous = useRef({
+    key: "",
+    topics: [] as readonly string[],
+  });
+
+  return useMemo(() => {
+    const normalizedTopics = Array.from(
+      new Set(
+        topics.map((topic) => topic.trim()).filter((topic) => topic.length > 0)
+      )
+    ).sort((a, b) => a.localeCompare(b));
+    const key = normalizedTopics.join("\0");
+
+    if (previous.current.key !== key) {
+      previous.current = { key, topics: normalizedTopics };
+    }
+
+    return previous.current;
+  }, [topics]);
 }
 
 function PreviewFrame({ frame }: { readonly frame: McapGridPreviewFrame }) {

--- a/app/packages/multimodal/src/adapters/mcap/react/GridRenderer.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/GridRenderer.tsx
@@ -189,7 +189,7 @@ function PreviewStatus({
 
 function previewStatusMessage(
   status: McapGridPreviewStatus,
-  hasImageTopics: boolean
+  hasPreviewTopics: boolean
 ): string | null {
   if (status === "loading") {
     return null;
@@ -199,5 +199,9 @@ function previewStatusMessage(
     return "Preview unavailable";
   }
 
-  return hasImageTopics ? "No preview frames" : "No camera streams";
+  if (status === "unavailable") {
+    return "No data available for this stream";
+  }
+
+  return hasPreviewTopics ? "No preview frames" : "No preview streams";
 }

--- a/app/packages/multimodal/src/adapters/mcap/react/GridRenderer.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/GridRenderer.tsx
@@ -50,7 +50,8 @@ export function GridRenderer({ ctx }: SampleRendererProps) {
       sampleId,
       topics: stableStreamTopics.topics,
     });
-  }, [ctx.dataset.name, registerStreamTopics, sampleId, stableStreamTopics]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- registerStreamTopics is stable
+  }, [ctx.dataset.name, sampleId, stableStreamTopics]);
 
   return (
     <div

--- a/app/packages/multimodal/src/adapters/mcap/react/McapGridStreamSelector.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapGridStreamSelector.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { McapGridStreamSelector } from "./McapGridStreamSelector";
 import {
   __resetMcapGridStreamStateForTests,
-  registerMcapGridImageTopics,
+  registerMcapGridStreamTopics,
 } from "./mcap-grid-stream-state";
 
 const { storedValues, useCurrentDataset } = vi.hoisted(() => ({
@@ -81,12 +81,12 @@ describe("McapGridStreamSelector", () => {
     __resetMcapGridStreamStateForTests();
   });
 
-  it("shows auto and mounted MCAP image topics", async () => {
+  it("shows auto and mounted MCAP stream topics", async () => {
     act(() => {
-      registerMcapGridImageTopics({
+      registerMcapGridStreamTopics({
         datasetName: "dataset",
         sampleId: "sample",
-        topics: ["/camera/front", "/camera/back"],
+        topics: ["/camera/front", "/camera/back", "/lidar/points"],
       });
     });
 
@@ -96,5 +96,6 @@ describe("McapGridStreamSelector", () => {
     expect(screen.getByText("Stream: Auto")).toBeTruthy();
     expect(screen.getByText("/camera/back")).toBeTruthy();
     expect(screen.getByText("/camera/front")).toBeTruthy();
+    expect(screen.getByText("/lidar/points")).toBeTruthy();
   });
 });

--- a/app/packages/multimodal/src/adapters/mcap/react/McapGridStreamSelector.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapGridStreamSelector.test.tsx
@@ -1,0 +1,100 @@
+import { act, render, screen } from "@testing-library/react";
+import type { ComponentType } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { McapGridStreamSelector } from "./McapGridStreamSelector";
+import {
+  __resetMcapGridStreamStateForTests,
+  registerMcapGridImageTopics,
+} from "./mcap-grid-stream-state";
+
+const { storedValues, useCurrentDataset } = vi.hoisted(() => ({
+  storedValues: new Map<string, string>(),
+  useCurrentDataset: vi.fn(),
+}));
+
+vi.mock("@fiftyone/state", async () => {
+  const React = await vi.importActual<typeof import("react")>("react");
+
+  return {
+    useBrowserStorage: <T,>(key: string, initialValue: T) => {
+      const [value, setValue] = React.useState<T>(() => {
+        const stored = storedValues.get(key);
+        return stored ? JSON.parse(stored) : initialValue;
+      });
+
+      return [
+        value,
+        (nextValue: T | ((value: T) => T)) => {
+          setValue((previousValue) => {
+            const resolvedValue =
+              nextValue instanceof Function
+                ? nextValue(previousValue)
+                : nextValue;
+            storedValues.set(key, JSON.stringify(resolvedValue));
+            return resolvedValue;
+          });
+        },
+      ] as const;
+    },
+    useCurrentDataset: (...args: unknown[]) => useCurrentDataset(...args),
+  };
+});
+
+vi.mock("@fiftyone/components", async () => {
+  class SelectorValidationError extends Error {}
+
+  return {
+    Selector: ({
+      component: Component,
+      useSearch,
+      value,
+    }: {
+      readonly component: ComponentType<{ value: string }>;
+      readonly useSearch: (search: string) => { values?: string[] };
+      readonly value: string;
+    }) => (
+      <div>
+        <div data-testid="selected-stream">{value}</div>
+        {useSearch("").values?.map((option) => (
+          <div key={option}>
+            <Component value={option} />
+          </div>
+        ))}
+      </div>
+    ),
+    SelectorValidationError,
+  };
+});
+
+describe("McapGridStreamSelector", () => {
+  beforeEach(() => {
+    storedValues.clear();
+    __resetMcapGridStreamStateForTests();
+    useCurrentDataset.mockReturnValue({
+      mediaType: "multimodal",
+      name: "dataset",
+    });
+  });
+
+  afterEach(() => {
+    storedValues.clear();
+    __resetMcapGridStreamStateForTests();
+  });
+
+  it("shows auto and mounted MCAP image topics", async () => {
+    act(() => {
+      registerMcapGridImageTopics({
+        datasetName: "dataset",
+        sampleId: "sample",
+        topics: ["/camera/front", "/camera/back"],
+      });
+    });
+
+    render(<McapGridStreamSelector />);
+
+    expect(screen.getByTestId("selected-stream").textContent).toBe("");
+    expect(screen.getByText("Stream: Auto")).toBeTruthy();
+    expect(screen.getByText("/camera/back")).toBeTruthy();
+    expect(screen.getByText("/camera/front")).toBeTruthy();
+  });
+});

--- a/app/packages/multimodal/src/adapters/mcap/react/McapGridStreamSelector.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapGridStreamSelector.test.tsx
@@ -1,10 +1,10 @@
-import { act, render, screen } from "@testing-library/react";
-import type { ComponentType } from "react";
+import { render, screen } from "@testing-library/react";
+import { useEffect, type ComponentType } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { McapGridStreamSelector } from "./McapGridStreamSelector";
 import {
   __resetMcapGridStreamStateForTests,
-  registerMcapGridStreamTopics,
+  useRegisterMcapGridStreamTopics,
 } from "./mcap-grid-stream-state";
 
 const { storedValues, useCurrentDataset } = vi.hoisted(() => ({
@@ -82,15 +82,7 @@ describe("McapGridStreamSelector", () => {
   });
 
   it("shows auto and mounted MCAP stream topics", async () => {
-    act(() => {
-      registerMcapGridStreamTopics({
-        datasetName: "dataset",
-        sampleId: "sample",
-        topics: ["/camera/front", "/camera/back", "/lidar/points"],
-      });
-    });
-
-    render(<McapGridStreamSelector />);
+    render(<RegisteredSelector />);
 
     expect(screen.getByTestId("selected-stream").textContent).toBe("");
     expect(screen.getByText("Stream: Auto")).toBeTruthy();
@@ -99,3 +91,19 @@ describe("McapGridStreamSelector", () => {
     expect(screen.getByText("/lidar/points")).toBeTruthy();
   });
 });
+
+function RegisteredSelector() {
+  const register = useRegisterMcapGridStreamTopics();
+
+  useEffect(
+    () =>
+      register({
+        datasetName: "dataset",
+        sampleId: "sample",
+        topics: ["/camera/front", "/camera/back", "/lidar/points"],
+      }),
+    [register]
+  );
+
+  return <McapGridStreamSelector />;
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/McapGridStreamSelector.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapGridStreamSelector.tsx
@@ -3,8 +3,8 @@ import * as fos from "@fiftyone/state";
 import { useCallback, useMemo } from "react";
 import {
   MCAP_GRID_STREAM_AUTO,
-  useMcapGridImageTopics,
-  useMcapGridSelectedImageTopic,
+  useMcapGridSelectedStreamTopic,
+  useMcapGridStreamTopics,
 } from "./mcap-grid-stream-state";
 
 const AUTO_PLACEHOLDER = "Stream: Auto";
@@ -14,14 +14,14 @@ const StreamOption = ({ value }: { className?: string; value: string }) => (
 );
 
 /**
- * Grid-header control for choosing the image topic used by MCAP previews.
+ * Grid-header control for choosing the stream topic used by MCAP previews.
  */
 export function McapGridStreamSelector() {
   const dataset = fos.useCurrentDataset();
   const datasetName = dataset?.name;
-  const topics = useMcapGridImageTopics(datasetName);
+  const topics = useMcapGridStreamTopics(datasetName);
   const [selectedTopic, setSelectedTopic] =
-    useMcapGridSelectedImageTopic(datasetName);
+    useMcapGridSelectedStreamTopic(datasetName);
 
   const options = useMemo(() => [MCAP_GRID_STREAM_AUTO, ...topics], [topics]);
   const useSearch = useCallback(

--- a/app/packages/multimodal/src/adapters/mcap/react/McapGridStreamSelector.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapGridStreamSelector.tsx
@@ -1,0 +1,64 @@
+import { Selector, SelectorValidationError } from "@fiftyone/components";
+import * as fos from "@fiftyone/state";
+import { useCallback, useMemo } from "react";
+import {
+  MCAP_GRID_STREAM_AUTO,
+  useMcapGridImageTopics,
+  useMcapGridSelectedImageTopic,
+} from "./mcap-grid-stream-state";
+
+const AUTO_PLACEHOLDER = "Stream: Auto";
+
+const StreamOption = ({ value }: { className?: string; value: string }) => (
+  <>{value === MCAP_GRID_STREAM_AUTO ? AUTO_PLACEHOLDER : value}</>
+);
+
+/**
+ * Grid-header control for choosing the image topic used by MCAP previews.
+ */
+export function McapGridStreamSelector() {
+  const dataset = fos.useCurrentDataset();
+  const datasetName = dataset?.name;
+  const topics = useMcapGridImageTopics(datasetName);
+  const [selectedTopic, setSelectedTopic] =
+    useMcapGridSelectedImageTopic(datasetName);
+
+  const options = useMemo(() => [MCAP_GRID_STREAM_AUTO, ...topics], [topics]);
+  const useSearch = useCallback(
+    (search: string) => {
+      const normalizedSearch = search.toLowerCase();
+      const values = options.filter((topic) =>
+        topic.toLowerCase().includes(normalizedSearch)
+      );
+
+      return { total: options.length, values };
+    },
+    [options]
+  );
+
+  return (
+    <Selector
+      component={StreamOption}
+      containerStyle={{
+        maxWidth: "16rem",
+        minWidth: "7.5rem",
+        position: "relative",
+      }}
+      cy="mcap-grid-stream"
+      inputStyle={{ height: 28 }}
+      onSelect={async (topic, value) => {
+        const nextTopic = value ?? topic;
+        if (!options.includes(nextTopic)) {
+          throw new SelectorValidationError();
+        }
+
+        setSelectedTopic(nextTopic);
+        return nextTopic === MCAP_GRID_STREAM_AUTO ? "" : nextTopic;
+      }}
+      overflow
+      placeholder={AUTO_PLACEHOLDER}
+      useSearch={useSearch}
+      value={selectedTopic === MCAP_GRID_STREAM_AUTO ? "" : selectedTopic}
+    />
+  );
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/index.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/index.ts
@@ -2,6 +2,7 @@
  * React renderers for MCAP-backed samples.
  */
 export { GridRenderer } from "./GridRenderer";
+export { McapGridStreamSelector } from "./McapGridStreamSelector";
 
 /**
  * React helper for MCAP renderer resource-client lifecycle.

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-grid-camera-state.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-grid-camera-state.test.tsx
@@ -1,0 +1,50 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  __resetMcapGridCameraPoseForTests,
+  useMcapGridCameraPose,
+} from "./mcap-grid-camera-state";
+
+afterEach(() => {
+  cleanup();
+  __resetMcapGridCameraPoseForTests();
+});
+
+describe("MCAP grid camera state", () => {
+  it("shares a camera pose across subscribers", () => {
+    render(
+      <>
+        <CameraHarness id="a" />
+        <CameraHarness id="b" />
+      </>
+    );
+
+    expect(screen.getByTestId("camera-a").textContent).toBe("empty");
+    expect(screen.getByTestId("camera-b").textContent).toBe("empty");
+
+    fireEvent.click(screen.getByTestId("camera-a"));
+
+    expect(screen.getByTestId("camera-a").textContent).toBe("1,2,3|4,5,6");
+    expect(screen.getByTestId("camera-b").textContent).toBe("1,2,3|4,5,6");
+  });
+});
+
+function CameraHarness({ id }: { readonly id: string }) {
+  const [pose, setPose] = useMcapGridCameraPose();
+
+  return (
+    <button
+      data-testid={`camera-${id}`}
+      onClick={() =>
+        setPose({
+          position: [1, 2, 3],
+          target: [4, 5, 6],
+        })
+      }
+      type="button"
+    >
+      {pose ? `${pose.position.join(",")}|${pose.target.join(",")}` : "empty"}
+    </button>
+  );
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-grid-camera-state.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-grid-camera-state.ts
@@ -1,0 +1,19 @@
+import { atom, getDefaultStore, useAtom } from "jotai";
+
+import type { PointCloudCameraPose } from "../../../visualization/panels/point-cloud";
+
+const mcapGridCameraPoseAtom = atom<PointCloudCameraPose | null>(null);
+
+/**
+ * Shared camera pose for 3D MCAP grid previews.
+ */
+export function useMcapGridCameraPose() {
+  return useAtom(mcapGridCameraPoseAtom);
+}
+
+/**
+ * Clears in-memory MCAP grid camera state for tests.
+ */
+export function __resetMcapGridCameraPoseForTests() {
+  getDefaultStore().set(mcapGridCameraPoseAtom, null);
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-grid-stream-state.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-grid-stream-state.test.tsx
@@ -1,0 +1,87 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  MCAP_GRID_STREAM_AUTO,
+  __resetMcapGridStreamStateForTests,
+  registerMcapGridImageTopics,
+  useMcapGridImageTopics,
+  useMcapGridSelectedImageTopic,
+} from "./mcap-grid-stream-state";
+
+describe("mcap-grid-stream-state", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    __resetMcapGridStreamStateForTests();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    __resetMcapGridStreamStateForTests();
+  });
+
+  it("aggregates image topics across mounted samples and removes them on cleanup", () => {
+    const { result } = renderHook(() => useMcapGridImageTopics("dataset"));
+
+    expect(result.current).toEqual([]);
+
+    let cleanupFront: () => void = () => undefined;
+    act(() => {
+      cleanupFront = registerMcapGridImageTopics({
+        datasetName: "dataset",
+        sampleId: "sample-front",
+        topics: ["/camera/front", "/camera/front"],
+      });
+    });
+    expect(result.current).toEqual(["/camera/front"]);
+
+    let cleanupBack: () => void = () => undefined;
+    act(() => {
+      cleanupBack = registerMcapGridImageTopics({
+        datasetName: "dataset",
+        sampleId: "sample-back",
+        topics: ["/camera/back", "/camera/front"],
+      });
+    });
+    expect(result.current).toEqual(["/camera/back", "/camera/front"]);
+
+    act(() => {
+      cleanupFront();
+    });
+    expect(result.current).toEqual(["/camera/back", "/camera/front"]);
+
+    act(() => {
+      cleanupBack();
+    });
+    expect(result.current).toEqual([]);
+  });
+
+  it("persists the selected image topic per dataset with auto as the default", async () => {
+    localStorage.setItem(
+      "mcap-grid-preview-image-topic:dataset",
+      JSON.stringify("/camera/front")
+    );
+
+    const { result } = renderHook(() =>
+      useMcapGridSelectedImageTopic("dataset")
+    );
+
+    await waitFor(() => {
+      expect(result.current[0]).toBe("/camera/front");
+    });
+
+    act(() => {
+      result.current[1]("/camera/back");
+    });
+
+    expect(result.current[0]).toBe("/camera/back");
+    expect(localStorage.getItem("mcap-grid-preview-image-topic:dataset")).toBe(
+      JSON.stringify("/camera/back")
+    );
+  });
+
+  it("uses auto when no dataset is available", () => {
+    const { result } = renderHook(() => useMcapGridSelectedImageTopic(null));
+
+    expect(result.current[0]).toBe(MCAP_GRID_STREAM_AUTO);
+  });
+});

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-grid-stream-state.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-grid-stream-state.test.tsx
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   MCAP_GRID_STREAM_AUTO,
   __resetMcapGridStreamStateForTests,
-  registerMcapGridStreamTopics,
+  useRegisterMcapGridStreamTopics,
   useMcapGridSelectedStreamTopic,
   useMcapGridStreamTopics,
 } from "./mcap-grid-stream-state";
@@ -20,29 +20,32 @@ describe("mcap-grid-stream-state", () => {
   });
 
   it("aggregates stream topics across mounted samples and removes them on cleanup", () => {
-    const { result } = renderHook(() => useMcapGridStreamTopics("dataset"));
+    const { result } = renderHook(() => ({
+      register: useRegisterMcapGridStreamTopics(),
+      topics: useMcapGridStreamTopics("dataset"),
+    }));
 
-    expect(result.current).toEqual([]);
+    expect(result.current.topics).toEqual([]);
 
     let cleanupFront: () => void = () => undefined;
     act(() => {
-      cleanupFront = registerMcapGridStreamTopics({
+      cleanupFront = result.current.register({
         datasetName: "dataset",
         sampleId: "sample-front",
         topics: ["/camera/front", "/camera/front"],
       });
     });
-    expect(result.current).toEqual(["/camera/front"]);
+    expect(result.current.topics).toEqual(["/camera/front"]);
 
     let cleanupBack: () => void = () => undefined;
     act(() => {
-      cleanupBack = registerMcapGridStreamTopics({
+      cleanupBack = result.current.register({
         datasetName: "dataset",
         sampleId: "sample-back",
         topics: ["/camera/back", "/lidar/points", "/camera/front"],
       });
     });
-    expect(result.current).toEqual([
+    expect(result.current.topics).toEqual([
       "/camera/back",
       "/camera/front",
       "/lidar/points",
@@ -51,7 +54,7 @@ describe("mcap-grid-stream-state", () => {
     act(() => {
       cleanupFront();
     });
-    expect(result.current).toEqual([
+    expect(result.current.topics).toEqual([
       "/camera/back",
       "/camera/front",
       "/lidar/points",
@@ -60,7 +63,7 @@ describe("mcap-grid-stream-state", () => {
     act(() => {
       cleanupBack();
     });
-    expect(result.current).toEqual([]);
+    expect(result.current.topics).toEqual([]);
   });
 
   it("persists the selected stream topic per dataset with auto as the default", async () => {

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-grid-stream-state.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-grid-stream-state.test.tsx
@@ -3,9 +3,9 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   MCAP_GRID_STREAM_AUTO,
   __resetMcapGridStreamStateForTests,
-  registerMcapGridImageTopics,
-  useMcapGridImageTopics,
-  useMcapGridSelectedImageTopic,
+  registerMcapGridStreamTopics,
+  useMcapGridSelectedStreamTopic,
+  useMcapGridStreamTopics,
 } from "./mcap-grid-stream-state";
 
 describe("mcap-grid-stream-state", () => {
@@ -19,14 +19,14 @@ describe("mcap-grid-stream-state", () => {
     __resetMcapGridStreamStateForTests();
   });
 
-  it("aggregates image topics across mounted samples and removes them on cleanup", () => {
-    const { result } = renderHook(() => useMcapGridImageTopics("dataset"));
+  it("aggregates stream topics across mounted samples and removes them on cleanup", () => {
+    const { result } = renderHook(() => useMcapGridStreamTopics("dataset"));
 
     expect(result.current).toEqual([]);
 
     let cleanupFront: () => void = () => undefined;
     act(() => {
-      cleanupFront = registerMcapGridImageTopics({
+      cleanupFront = registerMcapGridStreamTopics({
         datasetName: "dataset",
         sampleId: "sample-front",
         topics: ["/camera/front", "/camera/front"],
@@ -36,18 +36,26 @@ describe("mcap-grid-stream-state", () => {
 
     let cleanupBack: () => void = () => undefined;
     act(() => {
-      cleanupBack = registerMcapGridImageTopics({
+      cleanupBack = registerMcapGridStreamTopics({
         datasetName: "dataset",
         sampleId: "sample-back",
-        topics: ["/camera/back", "/camera/front"],
+        topics: ["/camera/back", "/lidar/points", "/camera/front"],
       });
     });
-    expect(result.current).toEqual(["/camera/back", "/camera/front"]);
+    expect(result.current).toEqual([
+      "/camera/back",
+      "/camera/front",
+      "/lidar/points",
+    ]);
 
     act(() => {
       cleanupFront();
     });
-    expect(result.current).toEqual(["/camera/back", "/camera/front"]);
+    expect(result.current).toEqual([
+      "/camera/back",
+      "/camera/front",
+      "/lidar/points",
+    ]);
 
     act(() => {
       cleanupBack();
@@ -55,14 +63,14 @@ describe("mcap-grid-stream-state", () => {
     expect(result.current).toEqual([]);
   });
 
-  it("persists the selected image topic per dataset with auto as the default", async () => {
+  it("persists the selected stream topic per dataset with auto as the default", async () => {
     localStorage.setItem(
       "mcap-grid-preview-image-topic:dataset",
       JSON.stringify("/camera/front")
     );
 
     const { result } = renderHook(() =>
-      useMcapGridSelectedImageTopic("dataset")
+      useMcapGridSelectedStreamTopic("dataset")
     );
 
     await waitFor(() => {
@@ -80,7 +88,7 @@ describe("mcap-grid-stream-state", () => {
   });
 
   it("uses auto when no dataset is available", () => {
-    const { result } = renderHook(() => useMcapGridSelectedImageTopic(null));
+    const { result } = renderHook(() => useMcapGridSelectedStreamTopic(null));
 
     expect(result.current[0]).toBe(MCAP_GRID_STREAM_AUTO);
   });

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-grid-stream-state.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-grid-stream-state.test.tsx
@@ -91,7 +91,9 @@ describe("mcap-grid-stream-state", () => {
   });
 
   it("uses auto when no dataset is available", () => {
-    const { result } = renderHook(() => useMcapGridSelectedStreamTopic(null));
+    const { result } = renderHook(() =>
+      useMcapGridSelectedStreamTopic(undefined)
+    );
 
     expect(result.current[0]).toBe(MCAP_GRID_STREAM_AUTO);
   });

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-grid-stream-state.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-grid-stream-state.ts
@@ -1,0 +1,229 @@
+import { useBrowserStorage } from "@fiftyone/state";
+import { useCallback, useEffect, useSyncExternalStore } from "react";
+
+/**
+ * Stored value that preserves the existing first-image-topic preview behavior.
+ */
+export const MCAP_GRID_STREAM_AUTO = "auto" as const;
+
+const EMPTY_TOPICS_SNAPSHOT = Object.freeze({
+  topics: [] as readonly string[],
+});
+
+type McapGridTopicsSnapshot = {
+  readonly topics: readonly string[];
+};
+
+type TopicRegistration = {
+  readonly datasetName: string | null | undefined;
+  readonly sampleId: string | null | undefined;
+  readonly topics: readonly string[];
+};
+
+const topicsByDataset = new Map<string, Map<string, readonly string[]>>();
+const topicsSnapshots = new Map<string, McapGridTopicsSnapshot>();
+const topicListeners = new Set<() => void>();
+
+const selectedTopicByDataset = new Map<string, string>();
+const selectedTopicListeners = new Set<() => void>();
+
+function storageKey(datasetName: string) {
+  return `mcap-grid-preview-image-topic:${datasetName}`;
+}
+
+function normalizeTopics(topics: readonly string[]) {
+  return Array.from(
+    new Set(
+      topics.map((topic) => topic.trim()).filter((topic) => topic.length > 0)
+    )
+  ).sort((a, b) => a.localeCompare(b));
+}
+
+function arraysEqual(a: readonly string[], b: readonly string[]) {
+  return a.length === b.length && a.every((value, index) => value === b[index]);
+}
+
+function buildTopicsSnapshot(datasetName: string): McapGridTopicsSnapshot {
+  const sampleTopics = topicsByDataset.get(datasetName);
+  const topics = sampleTopics
+    ? normalizeTopics(Array.from(sampleTopics.values()).flat())
+    : EMPTY_TOPICS_SNAPSHOT.topics;
+
+  return { topics };
+}
+
+function readTopicsSnapshot(
+  datasetName: string | null | undefined
+): McapGridTopicsSnapshot {
+  if (!datasetName) {
+    return EMPTY_TOPICS_SNAPSHOT;
+  }
+
+  let snapshot = topicsSnapshots.get(datasetName);
+  if (!snapshot) {
+    snapshot = buildTopicsSnapshot(datasetName);
+    topicsSnapshots.set(datasetName, snapshot);
+  }
+
+  return snapshot;
+}
+
+function updateTopicsSnapshot(datasetName: string) {
+  const previous = readTopicsSnapshot(datasetName);
+  const next = buildTopicsSnapshot(datasetName);
+
+  if (arraysEqual(previous.topics, next.topics)) {
+    return;
+  }
+
+  topicsSnapshots.set(datasetName, next);
+  topicListeners.forEach((listener) => listener());
+}
+
+function subscribeToTopics(listener: () => void) {
+  topicListeners.add(listener);
+  return () => {
+    topicListeners.delete(listener);
+  };
+}
+
+function normalizeSelectedTopic(topic: string | null | undefined) {
+  const normalized = topic?.trim();
+  return normalized ? normalized : MCAP_GRID_STREAM_AUTO;
+}
+
+function readSelectedTopic(datasetName: string | null | undefined) {
+  if (!datasetName) {
+    return MCAP_GRID_STREAM_AUTO;
+  }
+
+  return selectedTopicByDataset.get(datasetName) ?? MCAP_GRID_STREAM_AUTO;
+}
+
+function setSelectedTopic(datasetName: string, topic: string) {
+  const normalizedTopic = normalizeSelectedTopic(topic);
+  if (readSelectedTopic(datasetName) === normalizedTopic) {
+    return;
+  }
+
+  selectedTopicByDataset.set(datasetName, normalizedTopic);
+  selectedTopicListeners.forEach((listener) => listener());
+}
+
+function subscribeToSelectedTopic(listener: () => void) {
+  selectedTopicListeners.add(listener);
+  return () => {
+    selectedTopicListeners.delete(listener);
+  };
+}
+
+/**
+ * Registers image topics discovered by one mounted MCAP grid tile.
+ */
+export function registerMcapGridImageTopics({
+  datasetName,
+  sampleId,
+  topics,
+}: TopicRegistration) {
+  if (!datasetName || !sampleId) {
+    return () => undefined;
+  }
+
+  let sampleTopics = topicsByDataset.get(datasetName);
+  if (!sampleTopics) {
+    sampleTopics = new Map();
+    topicsByDataset.set(datasetName, sampleTopics);
+  }
+
+  sampleTopics.set(sampleId, normalizeTopics(topics));
+  updateTopicsSnapshot(datasetName);
+
+  return () => {
+    const currentSampleTopics = topicsByDataset.get(datasetName);
+    if (!currentSampleTopics) {
+      return;
+    }
+
+    currentSampleTopics.delete(sampleId);
+    if (!currentSampleTopics.size) {
+      topicsByDataset.delete(datasetName);
+    }
+
+    updateTopicsSnapshot(datasetName);
+  };
+}
+
+/**
+ * Subscribes to the aggregate image-topic set for mounted MCAP grid tiles.
+ */
+export function useMcapGridImageTopics(datasetName: string | null | undefined) {
+  const getSnapshot = useCallback(
+    () => readTopicsSnapshot(datasetName).topics,
+    [datasetName]
+  );
+
+  return useSyncExternalStore(
+    subscribeToTopics,
+    getSnapshot,
+    () => EMPTY_TOPICS_SNAPSHOT.topics
+  );
+}
+
+/**
+ * Reads and updates the per-dataset MCAP grid preview image-topic override.
+ */
+export function useMcapGridSelectedImageTopic(
+  datasetName: string | null | undefined
+) {
+  const key = datasetName
+    ? storageKey(datasetName)
+    : "mcap-grid-preview-image-topic";
+  const [storedTopic, setStoredTopic] = useBrowserStorage<string>(
+    key,
+    MCAP_GRID_STREAM_AUTO
+  );
+
+  useEffect(() => {
+    if (!datasetName) {
+      return;
+    }
+
+    setSelectedTopic(datasetName, storedTopic);
+  }, [datasetName, storedTopic]);
+
+  const getSnapshot = useCallback(
+    () => readSelectedTopic(datasetName),
+    [datasetName]
+  );
+  const selectedTopic = useSyncExternalStore(
+    subscribeToSelectedTopic,
+    getSnapshot,
+    () => MCAP_GRID_STREAM_AUTO
+  );
+
+  const setSelected = useCallback(
+    (topic: string) => {
+      if (!datasetName) {
+        return;
+      }
+
+      const normalizedTopic = normalizeSelectedTopic(topic);
+      setSelectedTopic(datasetName, normalizedTopic);
+      setStoredTopic(normalizedTopic);
+    },
+    [datasetName, setStoredTopic]
+  );
+
+  return [selectedTopic, setSelected] as const;
+}
+
+/**
+ * Clears in-memory MCAP grid stream state for tests.
+ */
+export function __resetMcapGridStreamStateForTests() {
+  topicsByDataset.clear();
+  topicsSnapshots.clear();
+  selectedTopicByDataset.clear();
+  topicListeners.forEach((listener) => listener());
+  selectedTopicListeners.forEach((listener) => listener());
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-grid-stream-state.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-grid-stream-state.ts
@@ -1,18 +1,16 @@
 import { useBrowserStorage } from "@fiftyone/state";
-import { useCallback, useEffect, useSyncExternalStore } from "react";
+import { atom, getDefaultStore, useAtomValue, useSetAtom } from "jotai";
+import { useCallback, useEffect, useMemo } from "react";
 
 /**
  * Stored value that preserves the existing first-image-topic preview behavior.
  */
 export const MCAP_GRID_STREAM_AUTO = "auto" as const;
 
-const EMPTY_STREAMS_SNAPSHOT = Object.freeze({
-  topics: [] as readonly string[],
-});
+const EMPTY_TOPICS: readonly string[] = Object.freeze([]);
 
-type McapGridStreamsSnapshot = {
-  readonly topics: readonly string[];
-};
+type StreamsByDataset = Map<string, Map<string, readonly string[]>>;
+type SelectedStreamByDataset = Map<string, string>;
 
 type StreamRegistration = {
   readonly datasetName: string | null | undefined;
@@ -20,12 +18,8 @@ type StreamRegistration = {
   readonly topics: readonly string[];
 };
 
-const streamsByDataset = new Map<string, Map<string, readonly string[]>>();
-const streamSnapshots = new Map<string, McapGridStreamsSnapshot>();
-const streamListeners = new Set<() => void>();
-
-const selectedStreamByDataset = new Map<string, string>();
-const selectedStreamListeners = new Set<() => void>();
+const streamsByDatasetAtom = atom<StreamsByDataset>(new Map());
+const selectedStreamByDatasetAtom = atom<SelectedStreamByDataset>(new Map());
 
 function storageKey(datasetName: string) {
   return `mcap-grid-preview-image-topic:${datasetName}`;
@@ -39,118 +33,94 @@ function normalizeStreams(topics: readonly string[]) {
   ).sort((a, b) => a.localeCompare(b));
 }
 
-function arraysEqual(a: readonly string[], b: readonly string[]) {
-  return a.length === b.length && a.every((value, index) => value === b[index]);
-}
-
-function buildStreamsSnapshot(datasetName: string): McapGridStreamsSnapshot {
-  const sampleTopics = streamsByDataset.get(datasetName);
-  const topics = sampleTopics
-    ? normalizeStreams(Array.from(sampleTopics.values()).flat())
-    : EMPTY_STREAMS_SNAPSHOT.topics;
-
-  return { topics };
-}
-
-function readStreamsSnapshot(
-  datasetName: string | null | undefined
-): McapGridStreamsSnapshot {
-  if (!datasetName) {
-    return EMPTY_STREAMS_SNAPSHOT;
-  }
-
-  let snapshot = streamSnapshots.get(datasetName);
-  if (!snapshot) {
-    snapshot = buildStreamsSnapshot(datasetName);
-    streamSnapshots.set(datasetName, snapshot);
-  }
-
-  return snapshot;
-}
-
-function updateStreamsSnapshot(datasetName: string) {
-  const previous = readStreamsSnapshot(datasetName);
-  const next = buildStreamsSnapshot(datasetName);
-
-  if (arraysEqual(previous.topics, next.topics)) {
-    return;
-  }
-
-  streamSnapshots.set(datasetName, next);
-  streamListeners.forEach((listener) => listener());
-}
-
-function subscribeToStreams(listener: () => void) {
-  streamListeners.add(listener);
-  return () => {
-    streamListeners.delete(listener);
-  };
-}
-
 function normalizeSelectedStream(topic: string | null | undefined) {
   const normalized = topic?.trim();
   return normalized ? normalized : MCAP_GRID_STREAM_AUTO;
 }
 
-function readSelectedStream(datasetName: string | null | undefined) {
-  if (!datasetName) {
-    return MCAP_GRID_STREAM_AUTO;
-  }
-
-  return selectedStreamByDataset.get(datasetName) ?? MCAP_GRID_STREAM_AUTO;
-}
-
-function setSelectedStream(datasetName: string, topic: string) {
+function updateSelectedStream(
+  current: SelectedStreamByDataset,
+  datasetName: string,
+  topic: string
+) {
   const normalizedTopic = normalizeSelectedStream(topic);
-  if (readSelectedStream(datasetName) === normalizedTopic) {
-    return;
+  if (current.get(datasetName) === normalizedTopic) {
+    return current;
   }
 
-  selectedStreamByDataset.set(datasetName, normalizedTopic);
-  selectedStreamListeners.forEach((listener) => listener());
-}
-
-function subscribeToSelectedStream(listener: () => void) {
-  selectedStreamListeners.add(listener);
-  return () => {
-    selectedStreamListeners.delete(listener);
-  };
+  const next = new Map(current);
+  next.set(datasetName, normalizedTopic);
+  return next;
 }
 
 /**
- * Registers previewable streams discovered by one mounted MCAP grid tile.
+ * Reads all mounted MCAP grid preview streams grouped by dataset and sample.
  */
-export function registerMcapGridStreamTopics({
-  datasetName,
-  sampleId,
-  topics,
-}: StreamRegistration) {
-  if (!datasetName || !sampleId) {
-    return () => undefined;
-  }
+export function useMcapStreams() {
+  return useAtomValue(streamsByDatasetAtom);
+}
 
-  let sampleTopics = streamsByDataset.get(datasetName);
-  if (!sampleTopics) {
-    sampleTopics = new Map();
-    streamsByDataset.set(datasetName, sampleTopics);
-  }
+/**
+ * Returns the aggregate preview-stream set for mounted MCAP grid tiles.
+ */
+export function useMcapStreamSnapshot(datasetName: string | null | undefined) {
+  const streamsByDataset = useMcapStreams();
 
-  sampleTopics.set(sampleId, normalizeStreams(topics));
-  updateStreamsSnapshot(datasetName);
-
-  return () => {
-    const currentSampleTopics = streamsByDataset.get(datasetName);
-    if (!currentSampleTopics) {
-      return;
+  return useMemo(() => {
+    if (!datasetName) {
+      return EMPTY_TOPICS;
     }
 
-    currentSampleTopics.delete(sampleId);
-    if (!currentSampleTopics.size) {
-      streamsByDataset.delete(datasetName);
-    }
+    const sampleTopics = streamsByDataset.get(datasetName);
+    return sampleTopics
+      ? normalizeStreams(Array.from(sampleTopics.values()).flat())
+      : EMPTY_TOPICS;
+  }, [datasetName, streamsByDataset]);
+}
 
-    updateStreamsSnapshot(datasetName);
-  };
+/**
+ * Returns a callback that registers streams discovered by one mounted grid tile.
+ */
+export function useRegisterMcapGridStreamTopics() {
+  const setStreamsByDataset = useSetAtom(streamsByDatasetAtom);
+
+  return useCallback(
+    ({ datasetName, sampleId, topics }: StreamRegistration) => {
+      if (!datasetName || !sampleId) {
+        return () => undefined;
+      }
+
+      const normalizedTopics = normalizeStreams(topics);
+      setStreamsByDataset((current) => {
+        const next = new Map(current);
+        const sampleTopics = new Map(next.get(datasetName));
+        sampleTopics.set(sampleId, normalizedTopics);
+        next.set(datasetName, sampleTopics);
+        return next;
+      });
+
+      return () => {
+        setStreamsByDataset((current) => {
+          const currentSampleTopics = current.get(datasetName);
+          if (!currentSampleTopics) {
+            return current;
+          }
+
+          const nextSampleTopics = new Map(currentSampleTopics);
+          nextSampleTopics.delete(sampleId);
+
+          const next = new Map(current);
+          if (nextSampleTopics.size) {
+            next.set(datasetName, nextSampleTopics);
+          } else {
+            next.delete(datasetName);
+          }
+          return next;
+        });
+      };
+    },
+    [setStreamsByDataset]
+  );
 }
 
 /**
@@ -159,24 +129,13 @@ export function registerMcapGridStreamTopics({
 export function useMcapGridStreamTopics(
   datasetName: string | null | undefined
 ) {
-  const getSnapshot = useCallback(
-    () => readStreamsSnapshot(datasetName).topics,
-    [datasetName]
-  );
-
-  return useSyncExternalStore(
-    subscribeToStreams,
-    getSnapshot,
-    () => EMPTY_STREAMS_SNAPSHOT.topics
-  );
+  return useMcapStreamSnapshot(datasetName);
 }
 
 /**
  * Reads and updates the per-dataset MCAP grid preview stream override.
  */
-export function useMcapGridSelectedStreamTopic(
-  datasetName: string | null | undefined
-) {
+export function useSelectedStream(datasetName: string | null | undefined) {
   const key = datasetName
     ? storageKey(datasetName)
     : "mcap-grid-preview-image-topic";
@@ -184,24 +143,22 @@ export function useMcapGridSelectedStreamTopic(
     key,
     MCAP_GRID_STREAM_AUTO
   );
+  const selectedStreamByDataset = useAtomValue(selectedStreamByDatasetAtom);
+  const setSelectedStreamByDataset = useSetAtom(selectedStreamByDatasetAtom);
 
   useEffect(() => {
     if (!datasetName) {
       return;
     }
 
-    setSelectedStream(datasetName, storedTopic);
-  }, [datasetName, storedTopic]);
+    setSelectedStreamByDataset((current) =>
+      updateSelectedStream(current, datasetName, storedTopic)
+    );
+  }, [datasetName, setSelectedStreamByDataset, storedTopic]);
 
-  const getSnapshot = useCallback(
-    () => readSelectedStream(datasetName),
-    [datasetName]
-  );
-  const selectedTopic = useSyncExternalStore(
-    subscribeToSelectedStream,
-    getSnapshot,
-    () => MCAP_GRID_STREAM_AUTO
-  );
+  const selectedTopic = datasetName
+    ? selectedStreamByDataset.get(datasetName) ?? MCAP_GRID_STREAM_AUTO
+    : MCAP_GRID_STREAM_AUTO;
 
   const setSelected = useCallback(
     (topic: string) => {
@@ -210,22 +167,31 @@ export function useMcapGridSelectedStreamTopic(
       }
 
       const normalizedTopic = normalizeSelectedStream(topic);
-      setSelectedStream(datasetName, normalizedTopic);
+      setSelectedStreamByDataset((current) =>
+        updateSelectedStream(current, datasetName, normalizedTopic)
+      );
       setStoredTopic(normalizedTopic);
     },
-    [datasetName, setStoredTopic]
+    [datasetName, setSelectedStreamByDataset, setStoredTopic]
   );
 
   return [selectedTopic, setSelected] as const;
 }
 
 /**
+ * Reads and updates the per-dataset MCAP grid preview stream override.
+ */
+export function useMcapGridSelectedStreamTopic(
+  datasetName: string | null | undefined
+) {
+  return useSelectedStream(datasetName);
+}
+
+/**
  * Clears in-memory MCAP grid stream state for tests.
  */
 export function __resetMcapGridStreamStateForTests() {
-  streamsByDataset.clear();
-  streamSnapshots.clear();
-  selectedStreamByDataset.clear();
-  streamListeners.forEach((listener) => listener());
-  selectedStreamListeners.forEach((listener) => listener());
+  const store = getDefaultStore();
+  store.set(streamsByDatasetAtom, new Map());
+  store.set(selectedStreamByDatasetAtom, new Map());
 }

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-grid-stream-state.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-grid-stream-state.ts
@@ -6,32 +6,32 @@ import { useCallback, useEffect, useSyncExternalStore } from "react";
  */
 export const MCAP_GRID_STREAM_AUTO = "auto" as const;
 
-const EMPTY_TOPICS_SNAPSHOT = Object.freeze({
+const EMPTY_STREAMS_SNAPSHOT = Object.freeze({
   topics: [] as readonly string[],
 });
 
-type McapGridTopicsSnapshot = {
+type McapGridStreamsSnapshot = {
   readonly topics: readonly string[];
 };
 
-type TopicRegistration = {
+type StreamRegistration = {
   readonly datasetName: string | null | undefined;
   readonly sampleId: string | null | undefined;
   readonly topics: readonly string[];
 };
 
-const topicsByDataset = new Map<string, Map<string, readonly string[]>>();
-const topicsSnapshots = new Map<string, McapGridTopicsSnapshot>();
-const topicListeners = new Set<() => void>();
+const streamsByDataset = new Map<string, Map<string, readonly string[]>>();
+const streamSnapshots = new Map<string, McapGridStreamsSnapshot>();
+const streamListeners = new Set<() => void>();
 
-const selectedTopicByDataset = new Map<string, string>();
-const selectedTopicListeners = new Set<() => void>();
+const selectedStreamByDataset = new Map<string, string>();
+const selectedStreamListeners = new Set<() => void>();
 
 function storageKey(datasetName: string) {
   return `mcap-grid-preview-image-topic:${datasetName}`;
 }
 
-function normalizeTopics(topics: readonly string[]) {
+function normalizeStreams(topics: readonly string[]) {
   return Array.from(
     new Set(
       topics.map((topic) => topic.trim()).filter((topic) => topic.length > 0)
@@ -43,136 +43,138 @@ function arraysEqual(a: readonly string[], b: readonly string[]) {
   return a.length === b.length && a.every((value, index) => value === b[index]);
 }
 
-function buildTopicsSnapshot(datasetName: string): McapGridTopicsSnapshot {
-  const sampleTopics = topicsByDataset.get(datasetName);
+function buildStreamsSnapshot(datasetName: string): McapGridStreamsSnapshot {
+  const sampleTopics = streamsByDataset.get(datasetName);
   const topics = sampleTopics
-    ? normalizeTopics(Array.from(sampleTopics.values()).flat())
-    : EMPTY_TOPICS_SNAPSHOT.topics;
+    ? normalizeStreams(Array.from(sampleTopics.values()).flat())
+    : EMPTY_STREAMS_SNAPSHOT.topics;
 
   return { topics };
 }
 
-function readTopicsSnapshot(
+function readStreamsSnapshot(
   datasetName: string | null | undefined
-): McapGridTopicsSnapshot {
+): McapGridStreamsSnapshot {
   if (!datasetName) {
-    return EMPTY_TOPICS_SNAPSHOT;
+    return EMPTY_STREAMS_SNAPSHOT;
   }
 
-  let snapshot = topicsSnapshots.get(datasetName);
+  let snapshot = streamSnapshots.get(datasetName);
   if (!snapshot) {
-    snapshot = buildTopicsSnapshot(datasetName);
-    topicsSnapshots.set(datasetName, snapshot);
+    snapshot = buildStreamsSnapshot(datasetName);
+    streamSnapshots.set(datasetName, snapshot);
   }
 
   return snapshot;
 }
 
-function updateTopicsSnapshot(datasetName: string) {
-  const previous = readTopicsSnapshot(datasetName);
-  const next = buildTopicsSnapshot(datasetName);
+function updateStreamsSnapshot(datasetName: string) {
+  const previous = readStreamsSnapshot(datasetName);
+  const next = buildStreamsSnapshot(datasetName);
 
   if (arraysEqual(previous.topics, next.topics)) {
     return;
   }
 
-  topicsSnapshots.set(datasetName, next);
-  topicListeners.forEach((listener) => listener());
+  streamSnapshots.set(datasetName, next);
+  streamListeners.forEach((listener) => listener());
 }
 
-function subscribeToTopics(listener: () => void) {
-  topicListeners.add(listener);
+function subscribeToStreams(listener: () => void) {
+  streamListeners.add(listener);
   return () => {
-    topicListeners.delete(listener);
+    streamListeners.delete(listener);
   };
 }
 
-function normalizeSelectedTopic(topic: string | null | undefined) {
+function normalizeSelectedStream(topic: string | null | undefined) {
   const normalized = topic?.trim();
   return normalized ? normalized : MCAP_GRID_STREAM_AUTO;
 }
 
-function readSelectedTopic(datasetName: string | null | undefined) {
+function readSelectedStream(datasetName: string | null | undefined) {
   if (!datasetName) {
     return MCAP_GRID_STREAM_AUTO;
   }
 
-  return selectedTopicByDataset.get(datasetName) ?? MCAP_GRID_STREAM_AUTO;
+  return selectedStreamByDataset.get(datasetName) ?? MCAP_GRID_STREAM_AUTO;
 }
 
-function setSelectedTopic(datasetName: string, topic: string) {
-  const normalizedTopic = normalizeSelectedTopic(topic);
-  if (readSelectedTopic(datasetName) === normalizedTopic) {
+function setSelectedStream(datasetName: string, topic: string) {
+  const normalizedTopic = normalizeSelectedStream(topic);
+  if (readSelectedStream(datasetName) === normalizedTopic) {
     return;
   }
 
-  selectedTopicByDataset.set(datasetName, normalizedTopic);
-  selectedTopicListeners.forEach((listener) => listener());
+  selectedStreamByDataset.set(datasetName, normalizedTopic);
+  selectedStreamListeners.forEach((listener) => listener());
 }
 
-function subscribeToSelectedTopic(listener: () => void) {
-  selectedTopicListeners.add(listener);
+function subscribeToSelectedStream(listener: () => void) {
+  selectedStreamListeners.add(listener);
   return () => {
-    selectedTopicListeners.delete(listener);
+    selectedStreamListeners.delete(listener);
   };
 }
 
 /**
- * Registers image topics discovered by one mounted MCAP grid tile.
+ * Registers previewable streams discovered by one mounted MCAP grid tile.
  */
-export function registerMcapGridImageTopics({
+export function registerMcapGridStreamTopics({
   datasetName,
   sampleId,
   topics,
-}: TopicRegistration) {
+}: StreamRegistration) {
   if (!datasetName || !sampleId) {
     return () => undefined;
   }
 
-  let sampleTopics = topicsByDataset.get(datasetName);
+  let sampleTopics = streamsByDataset.get(datasetName);
   if (!sampleTopics) {
     sampleTopics = new Map();
-    topicsByDataset.set(datasetName, sampleTopics);
+    streamsByDataset.set(datasetName, sampleTopics);
   }
 
-  sampleTopics.set(sampleId, normalizeTopics(topics));
-  updateTopicsSnapshot(datasetName);
+  sampleTopics.set(sampleId, normalizeStreams(topics));
+  updateStreamsSnapshot(datasetName);
 
   return () => {
-    const currentSampleTopics = topicsByDataset.get(datasetName);
+    const currentSampleTopics = streamsByDataset.get(datasetName);
     if (!currentSampleTopics) {
       return;
     }
 
     currentSampleTopics.delete(sampleId);
     if (!currentSampleTopics.size) {
-      topicsByDataset.delete(datasetName);
+      streamsByDataset.delete(datasetName);
     }
 
-    updateTopicsSnapshot(datasetName);
+    updateStreamsSnapshot(datasetName);
   };
 }
 
 /**
- * Subscribes to the aggregate image-topic set for mounted MCAP grid tiles.
+ * Subscribes to the aggregate preview-stream set for mounted MCAP grid tiles.
  */
-export function useMcapGridImageTopics(datasetName: string | null | undefined) {
+export function useMcapGridStreamTopics(
+  datasetName: string | null | undefined
+) {
   const getSnapshot = useCallback(
-    () => readTopicsSnapshot(datasetName).topics,
+    () => readStreamsSnapshot(datasetName).topics,
     [datasetName]
   );
 
   return useSyncExternalStore(
-    subscribeToTopics,
+    subscribeToStreams,
     getSnapshot,
-    () => EMPTY_TOPICS_SNAPSHOT.topics
+    () => EMPTY_STREAMS_SNAPSHOT.topics
   );
 }
 
 /**
- * Reads and updates the per-dataset MCAP grid preview image-topic override.
+ * Reads and updates the per-dataset MCAP grid preview stream override.
  */
-export function useMcapGridSelectedImageTopic(
+export function useMcapGridSelectedStreamTopic(
   datasetName: string | null | undefined
 ) {
   const key = datasetName
@@ -188,15 +190,15 @@ export function useMcapGridSelectedImageTopic(
       return;
     }
 
-    setSelectedTopic(datasetName, storedTopic);
+    setSelectedStream(datasetName, storedTopic);
   }, [datasetName, storedTopic]);
 
   const getSnapshot = useCallback(
-    () => readSelectedTopic(datasetName),
+    () => readSelectedStream(datasetName),
     [datasetName]
   );
   const selectedTopic = useSyncExternalStore(
-    subscribeToSelectedTopic,
+    subscribeToSelectedStream,
     getSnapshot,
     () => MCAP_GRID_STREAM_AUTO
   );
@@ -207,8 +209,8 @@ export function useMcapGridSelectedImageTopic(
         return;
       }
 
-      const normalizedTopic = normalizeSelectedTopic(topic);
-      setSelectedTopic(datasetName, normalizedTopic);
+      const normalizedTopic = normalizeSelectedStream(topic);
+      setSelectedStream(datasetName, normalizedTopic);
       setStoredTopic(normalizedTopic);
     },
     [datasetName, setStoredTopic]
@@ -221,9 +223,9 @@ export function useMcapGridSelectedImageTopic(
  * Clears in-memory MCAP grid stream state for tests.
  */
 export function __resetMcapGridStreamStateForTests() {
-  topicsByDataset.clear();
-  topicsSnapshots.clear();
-  selectedTopicByDataset.clear();
-  topicListeners.forEach((listener) => listener());
-  selectedTopicListeners.forEach((listener) => listener());
+  streamsByDataset.clear();
+  streamSnapshots.clear();
+  selectedStreamByDataset.clear();
+  streamListeners.forEach((listener) => listener());
+  selectedStreamListeners.forEach((listener) => listener());
 }

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-grid-stream-state.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-grid-stream-state.ts
@@ -152,7 +152,8 @@ export function useSelectedStream(datasetName?: string) {
     setSelectedStreamByDataset((current) =>
       updateSelectedStream(current, datasetName, storedTopic)
     );
-  }, [datasetName, setSelectedStreamByDataset, storedTopic]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- setter is stable
+  }, [datasetName, storedTopic]);
 
   const selectedTopic = datasetName
     ? selectedStreamByDataset.get(datasetName) ?? MCAP_GRID_STREAM_AUTO
@@ -170,7 +171,8 @@ export function useSelectedStream(datasetName?: string) {
       );
       setStoredTopic(normalizedTopic);
     },
-    [datasetName, setSelectedStreamByDataset, setStoredTopic]
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- setters are stable
+    [datasetName]
   );
 
   return [selectedTopic, setSelected] as const;

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-grid-stream-state.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-grid-stream-state.ts
@@ -13,8 +13,8 @@ type StreamsByDataset = Map<string, Map<string, readonly string[]>>;
 type SelectedStreamByDataset = Map<string, string>;
 
 type StreamRegistration = {
-  readonly datasetName: string | null | undefined;
-  readonly sampleId: string | null | undefined;
+  readonly datasetName?: string;
+  readonly sampleId?: string;
   readonly topics: readonly string[];
 };
 
@@ -63,7 +63,7 @@ export function useMcapStreams() {
 /**
  * Returns the aggregate preview-stream set for mounted MCAP grid tiles.
  */
-export function useMcapStreamSnapshot(datasetName: string | null | undefined) {
+export function useMcapStreamSnapshot(datasetName?: string) {
   const streamsByDataset = useMcapStreams();
 
   return useMemo(() => {
@@ -126,16 +126,14 @@ export function useRegisterMcapGridStreamTopics() {
 /**
  * Subscribes to the aggregate preview-stream set for mounted MCAP grid tiles.
  */
-export function useMcapGridStreamTopics(
-  datasetName: string | null | undefined
-) {
+export function useMcapGridStreamTopics(datasetName?: string) {
   return useMcapStreamSnapshot(datasetName);
 }
 
 /**
  * Reads and updates the per-dataset MCAP grid preview stream override.
  */
-export function useSelectedStream(datasetName: string | null | undefined) {
+export function useSelectedStream(datasetName?: string) {
   const key = datasetName
     ? storageKey(datasetName)
     : "mcap-grid-preview-image-topic";
@@ -181,9 +179,7 @@ export function useSelectedStream(datasetName: string | null | undefined) {
 /**
  * Reads and updates the per-dataset MCAP grid preview stream override.
  */
-export function useMcapGridSelectedStreamTopic(
-  datasetName: string | null | undefined
-) {
+export function useMcapGridSelectedStreamTopic(datasetName?: string) {
   return useSelectedStream(datasetName);
 }
 

--- a/app/packages/multimodal/src/adapters/mcap/react/use-mcap-grid-preview.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-mcap-grid-preview.test.tsx
@@ -4,7 +4,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { EncodedImageVisualization } from "../../../decoders";
 import type { ByteSourceDescriptor } from "../../../query/bytes";
 import { VISUALIZATION_KIND } from "../../../visualization";
-import type { McapGridPreviewResult } from "../grid-preview";
+import type {
+  McapGridPreviewFrame,
+  McapGridPreviewResult,
+} from "../grid-preview";
 import {
   useMcapGridPreview,
   type McapGridPreviewState,
@@ -128,7 +131,9 @@ describe("useMcapGridPreview", () => {
     await waitFor(() => {
       expect(latestState.current?.status).toBe("ready");
     });
-    expect(latestState.current?.frame?.image.bytes[0]).toBe(1);
+    expect(imageFrame(latestState.current?.frame ?? null)?.image.bytes[0]).toBe(
+      1
+    );
 
     act(() => {
       latestState.current?.play();
@@ -145,7 +150,9 @@ describe("useMcapGridPreview", () => {
     hover.resolve(readyResult({ bytes: [9, 8, 7], nextStartTimeNs: 20n }));
 
     await waitFor(() => {
-      expect(latestState.current?.frame?.image.bytes[0]).toBe(9);
+      expect(
+        imageFrame(latestState.current?.frame ?? null)?.image.bytes[0]
+      ).toBe(9);
     });
 
     act(() => {
@@ -154,19 +161,19 @@ describe("useMcapGridPreview", () => {
     expect(poolHarness.pool.release).not.toHaveBeenCalled();
   });
 
-  it("reloads and sends the selected image topic when it changes", async () => {
+  it("reloads and sends the selected stream topic when it changes", async () => {
     poolHarness.pool.request
       .mockResolvedValueOnce(
-        readyResult({ bytes: [1], imageTopic: "/camera/front" })
+        readyResult({ bytes: [1], streamTopic: "/camera/front" })
       )
       .mockResolvedValueOnce(
-        readyResult({ bytes: [2], imageTopic: "/camera/back" })
+        readyResult({ bytes: [2], streamTopic: "/camera/back" })
       );
 
     const { rerender } = render(
       <PreviewHarness
         id="selected"
-        selectedImageTopic="/camera/front"
+        selectedStreamTopic="/camera/front"
         source={sourceForId("selected")}
       />
     );
@@ -180,7 +187,7 @@ describe("useMcapGridPreview", () => {
     rerender(
       <PreviewHarness
         id="selected"
-        selectedImageTopic="/camera/back"
+        selectedStreamTopic="/camera/back"
         source={sourceForId("selected")}
       />
     );
@@ -189,7 +196,7 @@ describe("useMcapGridPreview", () => {
       expect(poolHarness.pool.request).toHaveBeenCalledTimes(2);
     });
     expect(poolHarness.pool.request.mock.calls[1]?.[0]).toMatchObject({
-      selectedImageTopic: "/camera/back",
+      selectedStreamTopic: "/camera/back",
       source: sourceForId("selected"),
     });
   });
@@ -198,15 +205,15 @@ describe("useMcapGridPreview", () => {
 function PreviewHarness({
   id,
   onState,
-  selectedImageTopic,
+  selectedStreamTopic,
   source,
 }: {
   readonly id: string;
   readonly onState?: (state: McapGridPreviewState) => void;
-  readonly selectedImageTopic?: string | null;
+  readonly selectedStreamTopic?: string | null;
   readonly source: ByteSourceDescriptor | null;
 }) {
-  const state = useMcapGridPreview({ selectedImageTopic, source });
+  const state = useMcapGridPreview({ selectedStreamTopic, source });
 
   useEffect(() => {
     onState?.(state);
@@ -218,7 +225,7 @@ function PreviewHarness({
 function formatState(state: McapGridPreviewState): string {
   return [
     state.status,
-    state.hasImageTopics ? "1" : "0",
+    state.hasPreviewTopics ? "1" : "0",
     state.frame ? "frame" : "no-frame",
     state.error ?? "",
   ].join(":");
@@ -226,11 +233,11 @@ function formatState(state: McapGridPreviewState): string {
 
 function readyResult({
   bytes,
-  imageTopic = "/camera/front",
+  streamTopic = "/camera/front",
   nextStartTimeNs = 5n,
 }: {
   readonly bytes: readonly number[];
-  readonly imageTopic?: string;
+  readonly streamTopic?: string;
   readonly nextStartTimeNs?: bigint;
 }): McapGridPreviewResult {
   return {
@@ -241,23 +248,24 @@ function readyResult({
       frame: {
         annotations: null,
         image: createImage(bytes),
+        kind: "image",
       },
-      hasImageTopics: true,
-      imageTopic,
-      imageTopics: [imageTopic],
+      hasPreviewTopics: true,
+      streamTopic,
+      streamTopics: [streamTopic],
       status: "ready",
     },
   };
 }
 
-function emptyResult(hasImageTopics: boolean): McapGridPreviewResult {
+function emptyResult(hasPreviewTopics: boolean): McapGridPreviewResult {
   return {
     state: {
       error: null,
       frame: null,
-      hasImageTopics,
-      imageTopic: hasImageTopics ? "/camera/front" : null,
-      imageTopics: hasImageTopics ? ["/camera/front"] : [],
+      hasPreviewTopics,
+      streamTopic: hasPreviewTopics ? "/camera/front" : null,
+      streamTopics: hasPreviewTopics ? ["/camera/front"] : [],
       status: "empty",
     },
   };
@@ -268,6 +276,12 @@ function createImage(bytes: readonly number[]): EncodedImageVisualization {
     bytes: new Uint8Array(bytes),
     kind: VISUALIZATION_KIND.ENCODED_IMAGE,
   };
+}
+
+function imageFrame(
+  frame: McapGridPreviewFrame | null
+): Extract<McapGridPreviewFrame, { kind: "image" }> | null {
+  return frame?.kind === "image" ? frame : null;
 }
 
 const SOURCES_BY_ID = new Map<string, ByteSourceDescriptor>();

--- a/app/packages/multimodal/src/adapters/mcap/react/use-mcap-grid-preview.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-mcap-grid-preview.test.tsx
@@ -153,18 +153,60 @@ describe("useMcapGridPreview", () => {
     });
     expect(poolHarness.pool.release).not.toHaveBeenCalled();
   });
+
+  it("reloads and sends the selected image topic when it changes", async () => {
+    poolHarness.pool.request
+      .mockResolvedValueOnce(
+        readyResult({ bytes: [1], imageTopic: "/camera/front" })
+      )
+      .mockResolvedValueOnce(
+        readyResult({ bytes: [2], imageTopic: "/camera/back" })
+      );
+
+    const { rerender } = render(
+      <PreviewHarness
+        id="selected"
+        selectedImageTopic="/camera/front"
+        source={sourceForId("selected")}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("preview-selected").textContent).toBe(
+        "ready:1:frame:"
+      );
+    });
+
+    rerender(
+      <PreviewHarness
+        id="selected"
+        selectedImageTopic="/camera/back"
+        source={sourceForId("selected")}
+      />
+    );
+
+    await waitFor(() => {
+      expect(poolHarness.pool.request).toHaveBeenCalledTimes(2);
+    });
+    expect(poolHarness.pool.request.mock.calls[1]?.[0]).toMatchObject({
+      selectedImageTopic: "/camera/back",
+      source: sourceForId("selected"),
+    });
+  });
 });
 
 function PreviewHarness({
   id,
   onState,
+  selectedImageTopic,
   source,
 }: {
   readonly id: string;
   readonly onState?: (state: McapGridPreviewState) => void;
+  readonly selectedImageTopic?: string | null;
   readonly source: ByteSourceDescriptor | null;
 }) {
-  const state = useMcapGridPreview({ source });
+  const state = useMcapGridPreview({ selectedImageTopic, source });
 
   useEffect(() => {
     onState?.(state);
@@ -184,10 +226,12 @@ function formatState(state: McapGridPreviewState): string {
 
 function readyResult({
   bytes,
-  nextStartTimeNs,
+  imageTopic = "/camera/front",
+  nextStartTimeNs = 5n,
 }: {
   readonly bytes: readonly number[];
-  readonly nextStartTimeNs: bigint;
+  readonly imageTopic?: string;
+  readonly nextStartTimeNs?: bigint;
 }): McapGridPreviewResult {
   return {
     delayMs: 83,
@@ -199,7 +243,8 @@ function readyResult({
         image: createImage(bytes),
       },
       hasImageTopics: true,
-      imageTopic: "/camera/front",
+      imageTopic,
+      imageTopics: [imageTopic],
       status: "ready",
     },
   };
@@ -212,6 +257,7 @@ function emptyResult(hasImageTopics: boolean): McapGridPreviewResult {
       frame: null,
       hasImageTopics,
       imageTopic: hasImageTopics ? "/camera/front" : null,
+      imageTopics: hasImageTopics ? ["/camera/front"] : [],
       status: "empty",
     },
   };

--- a/app/packages/multimodal/src/adapters/mcap/react/use-mcap-grid-preview.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-mcap-grid-preview.test.tsx
@@ -200,6 +200,53 @@ describe("useMcapGridPreview", () => {
       source: sourceForId("selected"),
     });
   });
+
+  it("does not play while a selected stream reload is still loading", async () => {
+    const latestState = { current: null as McapGridPreviewState | null };
+    const reload = deferred<McapGridPreviewResult>();
+    poolHarness.pool.request
+      .mockResolvedValueOnce(
+        readyResult({ bytes: [1], streamTopic: "/camera/front" })
+      )
+      .mockReturnValueOnce(reload.promise);
+
+    const { rerender } = render(
+      <PreviewHarness
+        id="reload-play"
+        onState={(state) => {
+          latestState.current = state;
+        }}
+        selectedStreamTopic="/camera/front"
+        source={sourceForId("reload-play")}
+      />
+    );
+
+    await waitFor(() => {
+      expect(latestState.current?.status).toBe("ready");
+    });
+
+    act(() => {
+      latestState.current?.play();
+      rerender(
+        <PreviewHarness
+          id="reload-play"
+          onState={(state) => {
+            latestState.current = state;
+          }}
+          selectedStreamTopic="/camera/back"
+          source={sourceForId("reload-play")}
+        />
+      );
+    });
+
+    await waitFor(() => {
+      expect(poolHarness.pool.request).toHaveBeenCalledTimes(2);
+    });
+    await act(async () => undefined);
+    expect(poolHarness.pool.request).toHaveBeenCalledTimes(2);
+
+    reload.resolve(readyResult({ bytes: [2], streamTopic: "/camera/back" }));
+  });
 });
 
 function PreviewHarness({

--- a/app/packages/multimodal/src/adapters/mcap/react/use-mcap-grid-preview.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-mcap-grid-preview.ts
@@ -21,6 +21,7 @@ export interface McapGridPreviewState extends McapGridPreviewSnapshot {
  * Options for rendering one lightweight MCAP camera preview in the grid.
  */
 export interface UseMcapGridPreviewOptions {
+  readonly selectedImageTopic?: string | null;
   readonly source: ByteSourceDescriptor | null;
 }
 
@@ -29,6 +30,7 @@ const IDLE_PREVIEW_STATE: McapGridPreviewSnapshot = {
   frame: null,
   hasImageTopics: false,
   imageTopic: null,
+  imageTopics: [],
   status: "idle",
 } as const;
 
@@ -38,6 +40,7 @@ const IDLE_PREVIEW_STATE: McapGridPreviewSnapshot = {
  * advance playback from the last rendered frame.
  */
 export function useMcapGridPreview({
+  selectedImageTopic,
   source,
 }: UseMcapGridPreviewOptions): McapGridPreviewState {
   const [state, setState] =
@@ -68,11 +71,15 @@ export function useMcapGridPreview({
       frame: null,
       hasImageTopics: false,
       imageTopic: null,
+      imageTopics: [],
       status: "loading",
     });
 
+    const request = selectedImageTopic
+      ? { selectedImageTopic, source }
+      : { source };
     pool
-      .request({ source }, { signal: controller.signal })
+      .request(request, { signal: controller.signal })
       .then((result) => {
         if (active) {
           nextStartTimeNsRef.current = result.nextStartTimeNs;
@@ -81,14 +88,17 @@ export function useMcapGridPreview({
       })
       .catch((caughtError) => {
         if (active && !controller.signal.aborted) {
-          setState({
-            error: mcapErrorMessage(caughtError),
-            frame: null,
-            hasImageTopics: false,
-            imageTopic: null,
-            status: "error",
-          });
+          return;
         }
+
+        setState({
+          error: mcapErrorMessage(caughtError),
+          frame: null,
+          hasImageTopics: false,
+          imageTopic: null,
+          imageTopics: [],
+          status: "error",
+        });
       });
 
     return () => {
@@ -96,7 +106,7 @@ export function useMcapGridPreview({
       controller.abort();
       pool.release();
     };
-  }, [source]);
+  }, [selectedImageTopic, source]);
 
   // This effect runs the hover playback loop: while playing, it keeps
   // requesting the next frame, wrapping back to the start when the
@@ -113,13 +123,19 @@ export function useMcapGridPreview({
     const run = async () => {
       try {
         while (active) {
-          const result = await pool.request(
-            {
-              source,
-              startTimeNs: nextStartTimeNsRef.current,
-            },
-            { signal: controller.signal }
-          );
+          const request = selectedImageTopic
+            ? {
+                selectedImageTopic,
+                source,
+                startTimeNs: nextStartTimeNsRef.current,
+              }
+            : {
+                source,
+                startTimeNs: nextStartTimeNsRef.current,
+              };
+          const result = await pool.request(request, {
+            signal: controller.signal,
+          });
 
           if (!active) {
             break;
@@ -152,7 +168,7 @@ export function useMcapGridPreview({
       active = false;
       controller.abort();
     };
-  }, [playing, source, state.status]);
+  }, [playing, selectedImageTopic, source, state.status]);
 
   return { ...state, pause, play };
 }

--- a/app/packages/multimodal/src/adapters/mcap/react/use-mcap-grid-preview.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-mcap-grid-preview.ts
@@ -46,6 +46,7 @@ export function useMcapGridPreview({
   const [state, setState] =
     useState<McapGridPreviewSnapshot>(IDLE_PREVIEW_STATE);
   const [playing, setPlaying] = useState(false);
+  const initialLoadInFlightRef = useRef(false);
   const nextStartTimeNsRef = useRef<bigint | undefined>(undefined);
   const pause = useCallback(() => setPlaying(false), []);
   const play = useCallback(() => setPlaying(true), []);
@@ -54,6 +55,7 @@ export function useMcapGridPreview({
   // holds a pool reference for the lifetime of the grid cell.
   useEffect(() => {
     if (!source) {
+      initialLoadInFlightRef.current = false;
       nextStartTimeNsRef.current = undefined;
       setPlaying(false);
       setState(IDLE_PREVIEW_STATE);
@@ -64,6 +66,7 @@ export function useMcapGridPreview({
     const controller = new AbortController();
     const pool = getMcapGridPreviewPool();
     pool.acquire();
+    initialLoadInFlightRef.current = true;
     nextStartTimeNsRef.current = undefined;
     setPlaying(false);
     setState({
@@ -99,10 +102,16 @@ export function useMcapGridPreview({
           streamTopics: [],
           status: "error",
         });
+      })
+      .finally(() => {
+        if (active) {
+          initialLoadInFlightRef.current = false;
+        }
       });
 
     return () => {
       active = false;
+      initialLoadInFlightRef.current = false;
       controller.abort();
       pool.release();
     };
@@ -112,8 +121,13 @@ export function useMcapGridPreview({
   // requesting the next frame, wrapping back to the start when the
   // source runs out of frames.
   useEffect(() => {
-    if (!playing || !source || state.status !== "ready") {
-      return undefined;
+    if (
+      !playing ||
+      !source ||
+      state.status !== "ready" ||
+      initialLoadInFlightRef.current
+    ) {
+      return;
     }
 
     let active = true;
@@ -123,6 +137,10 @@ export function useMcapGridPreview({
     const run = async () => {
       try {
         while (active) {
+          if (initialLoadInFlightRef.current) {
+            break;
+          }
+
           const request = selectedStreamTopic
             ? {
                 selectedStreamTopic,

--- a/app/packages/multimodal/src/adapters/mcap/react/use-mcap-grid-preview.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-mcap-grid-preview.ts
@@ -90,7 +90,7 @@ export function useMcapGridPreview({
         }
       })
       .catch((caughtError) => {
-        if (active && !controller.signal.aborted) {
+        if (!active || controller.signal.aborted) {
           return;
         }
 

--- a/app/packages/multimodal/src/adapters/mcap/react/use-mcap-grid-preview.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-mcap-grid-preview.ts
@@ -18,19 +18,19 @@ export interface McapGridPreviewState extends McapGridPreviewSnapshot {
 }
 
 /**
- * Options for rendering one lightweight MCAP camera preview in the grid.
+ * Options for rendering one lightweight MCAP stream preview in the grid.
  */
 export interface UseMcapGridPreviewOptions {
-  readonly selectedImageTopic?: string | null;
+  readonly selectedStreamTopic?: string | null;
   readonly source: ByteSourceDescriptor | null;
 }
 
 const IDLE_PREVIEW_STATE: McapGridPreviewSnapshot = {
   error: null,
   frame: null,
-  hasImageTopics: false,
-  imageTopic: null,
-  imageTopics: [],
+  hasPreviewTopics: false,
+  streamTopic: null,
+  streamTopics: [],
   status: "idle",
 } as const;
 
@@ -40,7 +40,7 @@ const IDLE_PREVIEW_STATE: McapGridPreviewSnapshot = {
  * advance playback from the last rendered frame.
  */
 export function useMcapGridPreview({
-  selectedImageTopic,
+  selectedStreamTopic,
   source,
 }: UseMcapGridPreviewOptions): McapGridPreviewState {
   const [state, setState] =
@@ -69,14 +69,14 @@ export function useMcapGridPreview({
     setState({
       error: null,
       frame: null,
-      hasImageTopics: false,
-      imageTopic: null,
-      imageTopics: [],
+      hasPreviewTopics: false,
+      streamTopic: null,
+      streamTopics: [],
       status: "loading",
     });
 
-    const request = selectedImageTopic
-      ? { selectedImageTopic, source }
+    const request = selectedStreamTopic
+      ? { selectedStreamTopic, source }
       : { source };
     pool
       .request(request, { signal: controller.signal })
@@ -94,9 +94,9 @@ export function useMcapGridPreview({
         setState({
           error: mcapErrorMessage(caughtError),
           frame: null,
-          hasImageTopics: false,
-          imageTopic: null,
-          imageTopics: [],
+          hasPreviewTopics: false,
+          streamTopic: null,
+          streamTopics: [],
           status: "error",
         });
       });
@@ -106,7 +106,7 @@ export function useMcapGridPreview({
       controller.abort();
       pool.release();
     };
-  }, [selectedImageTopic, source]);
+  }, [selectedStreamTopic, source]);
 
   // This effect runs the hover playback loop: while playing, it keeps
   // requesting the next frame, wrapping back to the start when the
@@ -123,9 +123,9 @@ export function useMcapGridPreview({
     const run = async () => {
       try {
         while (active) {
-          const request = selectedImageTopic
+          const request = selectedStreamTopic
             ? {
-                selectedImageTopic,
+                selectedStreamTopic,
                 source,
                 startTimeNs: nextStartTimeNsRef.current,
               }
@@ -168,7 +168,7 @@ export function useMcapGridPreview({
       active = false;
       controller.abort();
     };
-  }, [playing, selectedImageTopic, source, state.status]);
+  }, [playing, selectedStreamTopic, source, state.status]);
 
   return { ...state, pause, play };
 }

--- a/app/packages/multimodal/src/adapters/mcap/stream-topics.ts
+++ b/app/packages/multimodal/src/adapters/mcap/stream-topics.ts
@@ -57,21 +57,21 @@ export function topicName(topic: StreamInventory): string {
 }
 
 /**
- * Returns whether a stream inventory item is a supported compressed image.
+ * Returns whether a stream inventory item is a supported Foxglove compressed image.
  */
 export function isCompressedImageStream(topic: StreamInventory): boolean {
   return hasPayload(topic, FOXGLOVE_COMPRESSED_IMAGE_PAYLOAD);
 }
 
 /**
- * Returns whether a stream inventory item is a supported image annotation stream.
+ * Returns whether a stream inventory item is a supported Foxglove image annotation stream.
  */
 export function isImageAnnotationsStream(topic: StreamInventory): boolean {
   return hasPayload(topic, FOXGLOVE_IMAGE_ANNOTATIONS_PAYLOAD);
 }
 
 /**
- * Returns whether a stream inventory item is a supported point-cloud stream.
+ * Returns whether a stream inventory item is a supported Foxglove point-cloud stream.
  */
 export function isPointCloudStream(topic: StreamInventory): boolean {
   return hasPayload(topic, FOXGLOVE_POINT_CLOUD_PAYLOAD);

--- a/app/packages/multimodal/src/adapters/mcap/stream-topics.ts
+++ b/app/packages/multimodal/src/adapters/mcap/stream-topics.ts
@@ -1,0 +1,97 @@
+import type { PayloadDescriptor } from "../../decoders";
+import type { StreamInventory } from "../../schemas/v1";
+import {
+  FOXGLOVE_COMPRESSED_IMAGE_PAYLOAD,
+  FOXGLOVE_IMAGE_ANNOTATIONS_PAYLOAD,
+  FOXGLOVE_POINT_CLOUD_PAYLOAD,
+} from "./decoders/foxglove/protobuf/payloads";
+
+/**
+ * Supported MCAP topics that the adapter can preview or pair.
+ */
+export interface McapPreviewTopics {
+  readonly annotations: readonly string[];
+  readonly image: readonly string[];
+  readonly pointCloud: readonly string[];
+  readonly previewable: readonly string[];
+}
+
+/**
+ * Classifies stream inventory into supported preview and pairing topic buckets.
+ */
+export function streamTopics(
+  topics: readonly StreamInventory[]
+): McapPreviewTopics {
+  const image: string[] = [];
+  const annotations: string[] = [];
+  const pointCloud: string[] = [];
+
+  for (const topic of topics) {
+    const name = topicName(topic);
+    if (!name) {
+      continue;
+    }
+
+    if (isCompressedImageStream(topic)) {
+      image.push(name);
+    } else if (isPointCloudStream(topic)) {
+      pointCloud.push(name);
+    } else if (isImageAnnotationsStream(topic)) {
+      annotations.push(name);
+    }
+  }
+
+  return {
+    annotations,
+    image,
+    pointCloud,
+    previewable: [...image, ...pointCloud],
+  };
+}
+
+/**
+ * Returns the MCAP topic name stored on a stream inventory item.
+ */
+export function topicName(topic: StreamInventory): string {
+  return topic.metadata["mcap.topic"] ?? topic.displayName ?? "";
+}
+
+/**
+ * Returns whether a stream inventory item is a supported compressed image.
+ */
+export function isCompressedImageStream(topic: StreamInventory): boolean {
+  return hasPayload(topic, FOXGLOVE_COMPRESSED_IMAGE_PAYLOAD);
+}
+
+/**
+ * Returns whether a stream inventory item is a supported image annotation stream.
+ */
+export function isImageAnnotationsStream(topic: StreamInventory): boolean {
+  return hasPayload(topic, FOXGLOVE_IMAGE_ANNOTATIONS_PAYLOAD);
+}
+
+/**
+ * Returns whether a stream inventory item is a supported point-cloud stream.
+ */
+export function isPointCloudStream(topic: StreamInventory): boolean {
+  return hasPayload(topic, FOXGLOVE_POINT_CLOUD_PAYLOAD);
+}
+
+/**
+ * Returns whether a stream inventory item exactly matches a payload descriptor.
+ */
+export function hasPayload(
+  topic: StreamInventory,
+  payload: PayloadDescriptor
+): boolean {
+  const topicPayload = topic.payload;
+  if (!topicPayload) {
+    return false;
+  }
+
+  return (
+    topicPayload.encoding === payload.encoding &&
+    topicPayload.schema === payload.schema &&
+    topicPayload.schemaEncoding === payload.schemaEncoding
+  );
+}

--- a/app/packages/multimodal/src/adapters/mcap/topic-matching.ts
+++ b/app/packages/multimodal/src/adapters/mcap/topic-matching.ts
@@ -1,0 +1,111 @@
+// Drop generic topic words before scoring image/annotation topic similarity so
+// camera-identifying tokens like "front" or "left" decide the best match.
+const IGNORED_TOPIC_TOKENS = new Set([
+  "annotation",
+  "annotations",
+  "cam",
+  "camera",
+  "compressed",
+  "image",
+  "rect",
+]);
+
+// Strip image-format suffix segments when deriving the camera topic prefix, so
+// "/camera/front/image_rect_compressed" pairs with "/camera/front/annotations".
+const IMAGE_TOPIC_SUFFIX_TOKENS = new Set([
+  "compressed",
+  "compressedimage",
+  "image",
+  "raw",
+  "rect",
+]);
+
+/**
+ * Chooses the annotation topic that best matches a selected camera topic.
+ * Prefers the exact `<camera prefix>/annotations` sibling, then falls back
+ * to the highest shared-token score.
+ */
+export function chooseAnnotationTopic(
+  imageTopic: string,
+  annotationTopics: readonly string[]
+): string | null {
+  if (annotationTopics.length === 0) {
+    return null;
+  }
+
+  const cameraPrefix = topicPrefix(imageTopic);
+  const exactTopic = cameraPrefix ? `${cameraPrefix}/annotations` : "";
+  const exact = annotationTopics.find((topic) => topic === exactTopic);
+  if (exact) {
+    return exact;
+  }
+
+  let bestTopic: string | null = null;
+  let bestScore = 0;
+  const imageTokens = topicTokens(imageTopic);
+
+  for (const annotationTopic of annotationTopics) {
+    const annotationTokens = topicTokens(annotationTopic);
+    let score =
+      cameraPrefix && isTopicAtOrBelowPrefix(annotationTopic, cameraPrefix)
+        ? 10
+        : 0;
+    for (const token of imageTokens) {
+      if (annotationTokens.has(token)) {
+        score += 1;
+      }
+    }
+
+    if (score > bestScore) {
+      bestScore = score;
+      bestTopic = annotationTopic;
+    }
+  }
+
+  return bestTopic;
+}
+
+/**
+ * Returns the camera-like topic prefix after removing image suffix segments.
+ */
+export function topicPrefix(topic: string): string {
+  const normalized = topic.replace(/\/+$/, "");
+  const hasLeadingSlash = normalized.startsWith("/");
+  const parts = normalized.split("/").filter(Boolean);
+
+  while (parts.length > 0 && isImageTopicSuffix(parts[parts.length - 1])) {
+    parts.pop();
+  }
+
+  return parts.length > 0
+    ? `${hasLeadingSlash ? "/" : ""}${parts.join("/")}`
+    : "";
+}
+
+/**
+ * Returns normalized topic tokens used for fuzzy stream pairing.
+ */
+export function topicTokens(topic: string): Set<string> {
+  return new Set(
+    topic
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter((token) => token && !IGNORED_TOPIC_TOKENS.has(token))
+  );
+}
+
+function isTopicAtOrBelowPrefix(topic: string, prefix: string): boolean {
+  return topic === prefix || topic.startsWith(`${prefix}/`);
+}
+
+function isImageTopicSuffix(segment: string): boolean {
+  const tokens = segment
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+
+  return (
+    tokens.length > 0 &&
+    tokens.every((token) => IMAGE_TOPIC_SUFFIX_TOKENS.has(token))
+  );
+}

--- a/app/packages/multimodal/src/adapters/mcap/worker/grid-preview-pool.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/grid-preview-pool.test.ts
@@ -150,9 +150,9 @@ function createResult() {
     state: {
       error: null,
       frame: null,
-      hasImageTopics: false,
-      imageTopic: null,
-      imageTopics: [],
+      hasPreviewTopics: false,
+      streamTopic: null,
+      streamTopics: [],
       status: "empty" as const,
     },
   };

--- a/app/packages/multimodal/src/adapters/mcap/worker/grid-preview-pool.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/grid-preview-pool.test.ts
@@ -152,6 +152,7 @@ function createResult() {
       frame: null,
       hasImageTopics: false,
       imageTopic: null,
+      imageTopics: [],
       status: "empty" as const,
     },
   };

--- a/app/packages/multimodal/src/adapters/mcap/worker/grid-preview-transport.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/grid-preview-transport.test.ts
@@ -85,6 +85,7 @@ function createResult(status: "empty" | "ready") {
       frame: null,
       hasImageTopics: status === "ready",
       imageTopic: status === "ready" ? "/camera" : null,
+      imageTopics: status === "ready" ? ["/camera"] : [],
       status,
     },
   };

--- a/app/packages/multimodal/src/adapters/mcap/worker/grid-preview-transport.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/grid-preview-transport.test.ts
@@ -83,9 +83,9 @@ function createResult(status: "empty" | "ready") {
     state: {
       error: null,
       frame: null,
-      hasImageTopics: status === "ready",
-      imageTopic: status === "ready" ? "/camera" : null,
-      imageTopics: status === "ready" ? ["/camera"] : [],
+      hasPreviewTopics: status === "ready",
+      streamTopic: status === "ready" ? "/camera" : null,
+      streamTopics: status === "ready" ? ["/camera"] : [],
       status,
     },
   };

--- a/app/packages/multimodal/src/adapters/mcap/worker/grid-preview-worker.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/grid-preview-worker.ts
@@ -27,7 +27,7 @@ type McapGridPreviewWorkerScope = {
 const workerScope = self as unknown as McapGridPreviewWorkerScope;
 const scheduler = new McapPlaybackWorkerScheduler();
 // Each grid preview slot serves many sources (one per visible grid cell), so
-// keep a bounded per-source cache of readers and camera selections.
+// keep a bounded per-source cache of readers and stream selections.
 const entries = new LRUCache<string, McapGridPreviewEntry>({
   max: GRID_PREVIEW_SOURCE_CACHE_LIMIT,
   dispose: (entry) => {
@@ -111,6 +111,13 @@ function transferablesForResponse(
     return [];
   }
 
-  const buffer = response.result.state.frame?.image.bytes.buffer;
+  const frame = response.result.state.frame;
+  const buffer =
+    frame?.kind === "image"
+      ? frame.image.bytes.buffer
+      : frame?.kind === "point-cloud"
+      ? frame.pointCloud.positions.buffer
+      : null;
+
   return buffer instanceof ArrayBuffer ? [buffer] : [];
 }

--- a/app/packages/multimodal/src/adapters/mcap/worker/grid-preview-worker.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/grid-preview-worker.ts
@@ -112,12 +112,31 @@ function transferablesForResponse(
   }
 
   const frame = response.result.state.frame;
-  const buffer =
-    frame?.kind === "image"
-      ? frame.image.bytes.buffer
-      : frame?.kind === "point-cloud"
-      ? frame.pointCloud.positions.buffer
-      : null;
+  if (frame?.kind === "image") {
+    return transferableBuffers(frame.image.bytes);
+  }
 
-  return buffer instanceof ArrayBuffer ? [buffer] : [];
+  if (frame?.kind === "point-cloud") {
+    return transferableBuffers(
+      frame.pointCloud.positions,
+      frame.pointCloud.colors,
+      ...(frame.pointCloud.scalarFields?.map((field) => field.values) ?? [])
+    );
+  }
+
+  return [];
+}
+
+function transferableBuffers(
+  ...views: readonly (ArrayBufferView | undefined)[]
+): Transferable[] {
+  const buffers = new Set<ArrayBuffer>();
+
+  for (const view of views) {
+    if (view?.buffer instanceof ArrayBuffer) {
+      buffers.add(view.buffer);
+    }
+  }
+
+  return [...buffers];
 }

--- a/app/packages/multimodal/src/decoders/types.ts
+++ b/app/packages/multimodal/src/decoders/types.ts
@@ -34,6 +34,15 @@ export interface PointCloudField {
 }
 
 /**
+ * A decoded per-point scalar channel that can drive point-cloud colouring.
+ * Values must have length equal to the owning point cloud's pointCount.
+ */
+export interface PointCloudScalarField {
+  readonly name: string;
+  readonly values: Float32Array;
+}
+
+/**
  * Positions extracted from a point cloud into an interleaved x/y/z array.
  */
 export interface PointCloudVisualization {
@@ -41,10 +50,20 @@ export interface PointCloudVisualization {
    * Per-message source coordinate frame decoded from the point cloud payload.
    */
   readonly coordinateFrameId?: string;
+  /**
+   * Optional interleaved per-point RGB colours in 0-1 components.
+   * Length must equal 3 * pointCount.
+   */
+  readonly colors?: Float32Array;
   readonly kind: typeof VISUALIZATION_KIND.POINT_CLOUD;
   readonly fields: readonly PointCloudField[];
   readonly pointCount: number;
   readonly positions: Float32Array;
+  /**
+   * Optional canonical per-point sensor-return channels such as intensity/RCS.
+   * Each scalar field's values array must have length equal to pointCount.
+   */
+  readonly scalarFields?: readonly PointCloudScalarField[];
 }
 
 /**

--- a/app/packages/multimodal/src/visualization/panels/base-3d-scene.tsx
+++ b/app/packages/multimodal/src/visualization/panels/base-3d-scene.tsx
@@ -1,7 +1,13 @@
 /* eslint-disable react/no-unknown-property */
 import { GizmoHelper, GizmoViewport, OrbitControls } from "@react-three/drei";
 import { useThree } from "@react-three/fiber";
-import { useLayoutEffect, type ReactNode } from "react";
+import {
+  useCallback,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 
 import { VISUALIZATION_PANEL_BACKGROUND_COLOR } from "./style-tokens";
 
@@ -10,20 +16,54 @@ const AXIS_LABEL_COLOR = "#f8fafc";
 const DEFAULT_AMBIENT_LIGHT_INTENSITY = 0.8;
 const GIZMO_MARGIN_PIXELS: [number, number] = [72, 72];
 const GIZMO_RENDER_PRIORITY = 1;
+const CAMERA_POSE_EPSILON = 0.000001;
 const Z_UP_AXIS = { x: 0, y: 0, z: 1 } as const;
+
+type VectorTuple = readonly [number, number, number];
+
+type MutableVectorHandle = {
+  readonly x: number;
+  readonly y: number;
+  readonly z: number;
+  set: (x: number, y: number, z: number) => unknown;
+};
+
+type CameraHandle = {
+  readonly position: MutableVectorHandle;
+};
+
+type OrbitControlsHandle = {
+  readonly target: MutableVectorHandle;
+  update: () => void;
+};
+
+/**
+ * Controlled camera pose for shared 3D views.
+ */
+export interface ThreeCameraPose {
+  readonly position: VectorTuple;
+  readonly target: VectorTuple;
+}
 
 /**
  * Props for the shared 3D visualization scene shell.
  */
 export interface Base3DSceneProps {
+  readonly cameraPose?: ThreeCameraPose | null;
   readonly children?: ReactNode;
+  readonly onCameraPoseChange?: (pose: ThreeCameraPose) => void;
   readonly showGizmo?: boolean;
 }
 
 /**
  * Base 3D R3F scene with reusable navigation, axes, and Z-up coordinates.
  */
-export function Base3DScene({ children, showGizmo = true }: Base3DSceneProps) {
+export function Base3DScene({
+  cameraPose,
+  children,
+  onCameraPoseChange,
+  showGizmo = true,
+}: Base3DSceneProps) {
   useZUpSceneCoordinates();
 
   return (
@@ -34,7 +74,10 @@ export function Base3DScene({ children, showGizmo = true }: Base3DSceneProps) {
       />
       <ambientLight intensity={DEFAULT_AMBIENT_LIGHT_INTENSITY} />
       {children}
-      <OrbitControls enableDamping={false} makeDefault />
+      <ControlledOrbitControls
+        cameraPose={cameraPose}
+        onCameraPoseChange={onCameraPoseChange}
+      />
       {showGizmo ? (
         <GizmoHelper
           alignment="top-right"
@@ -48,6 +91,101 @@ export function Base3DScene({ children, showGizmo = true }: Base3DSceneProps) {
         </GizmoHelper>
       ) : null}
     </>
+  );
+}
+
+function ControlledOrbitControls({
+  cameraPose,
+  onCameraPoseChange,
+}: {
+  readonly cameraPose?: ThreeCameraPose | null;
+  readonly onCameraPoseChange?: (pose: ThreeCameraPose) => void;
+}) {
+  const applyingPoseRef = useRef(false);
+  const lastEmittedPoseRef = useRef<ThreeCameraPose | null>(null);
+  const [controls, setControls] = useState<OrbitControlsHandle | null>(null);
+  const camera = useThree((state) => state.camera);
+  const invalidate = useThree((state) => state.invalidate);
+  const setControlsRef = useCallback((nextControls: unknown) => {
+    setControls((nextControls as OrbitControlsHandle | null) ?? null);
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!cameraPose || !controls) {
+      return;
+    }
+
+    if (!cameraPoseEquals(cameraPoseFromScene(camera, controls), cameraPose)) {
+      applyingPoseRef.current = true;
+      setCameraPose(camera, controls, cameraPose);
+      controls.update();
+      invalidate();
+      applyingPoseRef.current = false;
+    }
+
+    lastEmittedPoseRef.current = cameraPose;
+  }, [camera, cameraPose, controls, invalidate]);
+
+  const handleChange = useCallback(() => {
+    if (applyingPoseRef.current || !controls) {
+      return;
+    }
+
+    const pose = cameraPoseFromScene(camera, controls);
+    if (cameraPoseEquals(lastEmittedPoseRef.current, pose)) {
+      return;
+    }
+
+    lastEmittedPoseRef.current = pose;
+    onCameraPoseChange?.(pose);
+  }, [camera, controls, onCameraPoseChange]);
+
+  return (
+    <OrbitControls
+      enableDamping={false}
+      makeDefault
+      onChange={handleChange}
+      ref={setControlsRef}
+    />
+  );
+}
+
+function setCameraPose(
+  camera: CameraHandle,
+  controls: OrbitControlsHandle,
+  pose: ThreeCameraPose
+) {
+  camera.position.set(...pose.position);
+  controls.target.set(...pose.target);
+}
+
+function cameraPoseFromScene(
+  camera: CameraHandle,
+  controls: OrbitControlsHandle
+): ThreeCameraPose {
+  return {
+    position: [camera.position.x, camera.position.y, camera.position.z],
+    target: [controls.target.x, controls.target.y, controls.target.z],
+  };
+}
+
+function cameraPoseEquals(
+  first: ThreeCameraPose | null | undefined,
+  second: ThreeCameraPose | null | undefined
+): boolean {
+  if (!first || !second) {
+    return first === second;
+  }
+
+  return (
+    vectorTupleEquals(first.position, second.position) &&
+    vectorTupleEquals(first.target, second.target)
+  );
+}
+
+function vectorTupleEquals(first: VectorTuple, second: VectorTuple): boolean {
+  return first.every(
+    (value, index) => Math.abs(value - second[index]) <= CAMERA_POSE_EPSILON
   );
 }
 

--- a/app/packages/multimodal/src/visualization/panels/base-3d-scene.tsx
+++ b/app/packages/multimodal/src/visualization/panels/base-3d-scene.tsx
@@ -17,12 +17,13 @@ const Z_UP_AXIS = { x: 0, y: 0, z: 1 } as const;
  */
 export interface Base3DSceneProps {
   readonly children?: ReactNode;
+  readonly showGizmo?: boolean;
 }
 
 /**
  * Base 3D R3F scene with reusable navigation, axes, and Z-up coordinates.
  */
-export function Base3DScene({ children }: Base3DSceneProps) {
+export function Base3DScene({ children, showGizmo = true }: Base3DSceneProps) {
   useZUpSceneCoordinates();
 
   return (
@@ -34,13 +35,18 @@ export function Base3DScene({ children }: Base3DSceneProps) {
       <ambientLight intensity={DEFAULT_AMBIENT_LIGHT_INTENSITY} />
       {children}
       <OrbitControls enableDamping={false} makeDefault />
-      <GizmoHelper
-        alignment="top-right"
-        margin={GIZMO_MARGIN_PIXELS}
-        renderPriority={GIZMO_RENDER_PRIORITY}
-      >
-        <GizmoViewport axisColors={AXIS_COLORS} labelColor={AXIS_LABEL_COLOR} />
-      </GizmoHelper>
+      {showGizmo ? (
+        <GizmoHelper
+          alignment="top-right"
+          margin={GIZMO_MARGIN_PIXELS}
+          renderPriority={GIZMO_RENDER_PRIORITY}
+        >
+          <GizmoViewport
+            axisColors={AXIS_COLORS}
+            labelColor={AXIS_LABEL_COLOR}
+          />
+        </GizmoHelper>
+      ) : null}
     </>
   );
 }

--- a/app/packages/multimodal/src/visualization/panels/point-cloud.test.tsx
+++ b/app/packages/multimodal/src/visualization/panels/point-cloud.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import * as THREE from "three";
@@ -11,8 +11,16 @@ vi.mock("@react-three/fiber", () => ({
 }));
 
 vi.mock("./base-3d-scene", () => ({
-  Base3DScene: ({ children }: { readonly children?: ReactNode }) => (
-    <>{children}</>
+  Base3DScene: ({
+    children,
+    showGizmo = true,
+  }: {
+    readonly children?: ReactNode;
+    readonly showGizmo?: boolean;
+  }) => (
+    <div data-testid="base-3d-scene" data-show-gizmo={String(showGizmo)}>
+      {children}
+    </div>
   ),
 }));
 
@@ -66,5 +74,25 @@ describe("PointCloudPanel", () => {
     const transformGroups = Array.from(container.querySelectorAll("group"));
     expect(transformGroups.at(-1)?.getAttribute("position")).toBe("10,0,0");
     expect(transformGroups.at(-1)?.getAttribute("quaternion")).toBe("0,0,0,1");
+  });
+
+  it("can hide the scene gizmo for compact previews", () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    render(
+      <PointCloudPanel
+        frame={{
+          fields: [],
+          kind: VISUALIZATION_KIND.POINT_CLOUD,
+          pointCount: 1,
+          positions: new Float32Array([1, 2, 3]),
+        }}
+        showGizmo={false}
+      />
+    );
+
+    expect(
+      screen.getByTestId("base-3d-scene").getAttribute("data-show-gizmo")
+    ).toBe("false");
   });
 });

--- a/app/packages/multimodal/src/visualization/panels/point-cloud.test.tsx
+++ b/app/packages/multimodal/src/visualization/panels/point-cloud.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import * as THREE from "three";
@@ -12,13 +12,37 @@ vi.mock("@react-three/fiber", () => ({
 
 vi.mock("./base-3d-scene", () => ({
   Base3DScene: ({
+    cameraPose,
     children,
+    onCameraPoseChange,
     showGizmo = true,
   }: {
+    readonly cameraPose?: {
+      readonly position: readonly [number, number, number];
+      readonly target: readonly [number, number, number];
+    } | null;
     readonly children?: ReactNode;
+    readonly onCameraPoseChange?: (pose: {
+      readonly position: readonly [number, number, number];
+      readonly target: readonly [number, number, number];
+    }) => void;
     readonly showGizmo?: boolean;
   }) => (
-    <div data-testid="base-3d-scene" data-show-gizmo={String(showGizmo)}>
+    <div
+      data-camera-pose={cameraPose ? JSON.stringify(cameraPose) : ""}
+      data-testid="base-3d-scene"
+      data-show-gizmo={String(showGizmo)}
+    >
+      <button
+        data-testid="camera-change"
+        onClick={() =>
+          onCameraPoseChange?.({
+            position: [7, 8, 9],
+            target: [1, 2, 3],
+          })
+        }
+        type="button"
+      />
       {children}
     </div>
   ),
@@ -95,4 +119,128 @@ describe("PointCloudPanel", () => {
       screen.getByTestId("base-3d-scene").getAttribute("data-show-gizmo")
     ).toBe("false");
   });
+
+  it("passes controlled camera pose through to the base scene", () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const onCameraPoseChange = vi.fn();
+    const cameraPose = {
+      position: [1, 2, 3],
+      target: [4, 5, 6],
+    } as const;
+
+    render(
+      <PointCloudPanel
+        cameraPose={cameraPose}
+        frame={{
+          fields: [],
+          kind: VISUALIZATION_KIND.POINT_CLOUD,
+          pointCount: 1,
+          positions: new Float32Array([1, 2, 3]),
+        }}
+        onCameraPoseChange={onCameraPoseChange}
+      />
+    );
+
+    expect(
+      screen.getByTestId("base-3d-scene").getAttribute("data-camera-pose")
+    ).toBe(JSON.stringify(cameraPose));
+
+    fireEvent.click(screen.getByTestId("camera-change"));
+
+    expect(onCameraPoseChange).toHaveBeenCalledWith({
+      position: [7, 8, 9],
+      target: [1, 2, 3],
+    });
+  });
+
+  it("defaults to explicit point colors before derived values", () => {
+    expectArrayCloseTo(
+      renderPointCloudColors({
+        colors: new Float32Array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6]),
+        positions: new Float32Array([0, 0, 0, 0, 0, 10]),
+        scalarFields: [{ name: "rcs", values: new Float32Array([10, 20]) }],
+      }),
+      [0.1, 0.2, 0.3, 0.4, 0.5, 0.6]
+    );
+  });
+
+  it("defaults to canonical sensor-return scalars before height", () => {
+    expectArrayCloseTo(
+      renderPointCloudColors({
+        positions: new Float32Array([0, 0, 100, 0, 0, 0]),
+        scalarFields: [{ name: "rcs", values: new Float32Array([10, 20]) }],
+      }),
+      [0.25, 0.55, 1, 1, 0.9, 0.52]
+    );
+  });
+
+  it("can force height coloring with colorBy", () => {
+    expectArrayCloseTo(
+      renderPointCloudColors({
+        colorBy: "height",
+        colors: new Float32Array([1, 0, 0, 1, 0, 0]),
+        positions: new Float32Array([0, 0, 0, 0, 0, 10]),
+      }),
+      [0.25, 0.55, 1, 1, 0.9, 0.52]
+    );
+  });
+
+  it("uses a neutral color when no source has useful variation", () => {
+    expectArrayCloseTo(
+      renderPointCloudColors({
+        positions: new Float32Array([0, 0, 3, 1, 1, 3]),
+      }),
+      [0.72, 0.76, 0.82, 0.72, 0.76, 0.82]
+    );
+  });
 });
+
+function renderPointCloudColors({
+  colorBy,
+  colors,
+  positions,
+  scalarFields,
+}: {
+  readonly colorBy?: "height";
+  readonly colors?: Float32Array;
+  readonly positions: Float32Array;
+  readonly scalarFields?: readonly {
+    readonly name: string;
+    readonly values: Float32Array;
+  }[];
+}) {
+  vi.spyOn(console, "error").mockImplementation(() => undefined);
+  const setAttribute = vi.spyOn(THREE.BufferGeometry.prototype, "setAttribute");
+
+  render(
+    <PointCloudPanel
+      colorBy={colorBy}
+      frame={{
+        ...(colors ? { colors } : {}),
+        ...(scalarFields ? { scalarFields } : {}),
+        fields: [],
+        kind: VISUALIZATION_KIND.POINT_CLOUD,
+        pointCount: Math.floor(positions.length / 3),
+        positions,
+      }}
+      showHud={false}
+    />
+  );
+
+  const colorCall = setAttribute.mock.calls.find(
+    ([attributeName]) => attributeName === "color"
+  );
+  const colorAttribute = colorCall?.[1] as THREE.BufferAttribute | undefined;
+
+  return Array.from(colorAttribute?.array ?? []);
+}
+
+function expectArrayCloseTo(
+  actual: readonly number[],
+  expected: readonly number[]
+) {
+  expect(actual).toHaveLength(expected.length);
+  actual.forEach((value, index) => {
+    expect(value).toBeCloseTo(expected[index]);
+  });
+}

--- a/app/packages/multimodal/src/visualization/panels/point-cloud.tsx
+++ b/app/packages/multimodal/src/visualization/panels/point-cloud.tsx
@@ -4,8 +4,11 @@ import type { CSSProperties } from "react";
 import { useEffect, useMemo, useState } from "react";
 import * as THREE from "three";
 
-import type { PointCloudVisualization } from "../../decoders";
-import { Base3DScene } from "./base-3d-scene";
+import type {
+  PointCloudScalarField,
+  PointCloudVisualization,
+} from "../../decoders";
+import { Base3DScene, type ThreeCameraPose } from "./base-3d-scene";
 import {
   VISUALIZATION_HUD_BACKGROUND_COLOR,
   VISUALIZATION_HUD_BORDER_COLOR,
@@ -34,6 +37,7 @@ const MIN_POINT_SAMPLE_COUNT = 1;
 const NORMALIZED_HEIGHT_MIN = 0;
 const NORMALIZED_HEIGHT_MAX = 1;
 const POINT_COMPONENT_COUNT = 3;
+const COLOR_COMPONENT_COUNT = 3;
 const X_COMPONENT_INDEX = 0;
 const Y_COMPONENT_INDEX = 1;
 const Z_COMPONENT_INDEX = 2;
@@ -55,6 +59,26 @@ const HUD_LINE_HEIGHT = 1;
 const HUD_OFFSET_PX = 8;
 const STATUS_FONT_SIZE_PX = 13;
 const STATUS_PADDING_PX = 16;
+const CANONICAL_SCALAR_COLOR_FIELDS = [
+  "intensity",
+  "reflectivity",
+  "reflectance",
+  "rcs",
+] as const;
+const NEUTRAL_POINT_COLOR = [0.72, 0.76, 0.82] as const;
+
+/**
+ * Supported point-cloud colouring modes.
+ */
+export type PointCloudColorBy =
+  | "auto"
+  | "height"
+  | "intensity"
+  | "rcs"
+  | "reflectance"
+  | "reflectivity"
+  | "rgb"
+  | "uniform";
 
 interface PointCloudRenderData {
   readonly bounds: THREE.Box3;
@@ -80,14 +104,22 @@ export interface PointCloudFrameTransform {
 }
 
 /**
+ * Camera pose shared by controlled point-cloud panels.
+ */
+export type PointCloudCameraPose = ThreeCameraPose;
+
+/**
  * Props for rendering one decoded point-cloud visualization frame.
  */
 export interface PointCloudPanelProps {
+  readonly cameraPose?: PointCloudCameraPose | null;
   readonly className?: string;
+  readonly colorBy?: PointCloudColorBy;
   readonly fit?: "initial" | "frame" | "never";
   readonly frame: PointCloudVisualization;
   readonly frameTransform?: PointCloudFrameTransform;
   readonly maxRenderedPoints?: number;
+  readonly onCameraPoseChange?: (pose: PointCloudCameraPose) => void;
   readonly pointSize?: number;
   readonly showGizmo?: boolean;
   readonly showHud?: boolean;
@@ -99,11 +131,14 @@ export interface PointCloudPanelProps {
  * Production point-cloud visualization panel backed by a stable Three.js canvas.
  */
 export function PointCloudPanel({
+  cameraPose,
   className,
+  colorBy,
   fit = "initial",
   frame,
   frameTransform,
   maxRenderedPoints = DEFAULT_MAX_RENDERED_POINTS,
+  onCameraPoseChange,
   pointSize = DEFAULT_POINT_SIZE,
   showGizmo = true,
   showHud = true,
@@ -115,20 +150,30 @@ export function PointCloudPanel({
   const scene = useMemo(
     () => (
       <PointCloudSceneContent
+        cameraPose={cameraPose}
+        colorBy={colorBy}
+        colors={frame.colors}
         fit={fit}
         maxRenderedPoints={maxRenderedPoints}
+        onCameraPoseChange={onCameraPoseChange}
         onFinitePointCount={setFinitePointCount}
         pointSize={pointSize}
         positions={frame.positions}
+        scalarFields={frame.scalarFields}
         showGizmo={showGizmo}
         transform={frameTransform}
       />
     ),
     [
+      cameraPose,
+      colorBy,
       fit,
+      frame.colors,
       frame.positions,
+      frame.scalarFields,
       frameTransform,
       maxRenderedPoints,
+      onCameraPoseChange,
       pointSize,
       showGizmo,
     ]
@@ -160,26 +205,41 @@ export function PointCloudPanel({
 }
 
 function PointCloudSceneContent({
+  cameraPose,
+  colorBy,
+  colors,
   fit: _fit,
   maxRenderedPoints,
+  onCameraPoseChange,
   onFinitePointCount,
   pointSize,
   positions,
+  scalarFields,
   showGizmo,
   transform,
 }: {
+  readonly cameraPose?: PointCloudCameraPose | null;
+  readonly colorBy?: PointCloudColorBy;
+  readonly colors?: Float32Array;
   readonly fit: "initial" | "frame" | "never";
   readonly maxRenderedPoints: number;
+  readonly onCameraPoseChange?: (pose: PointCloudCameraPose) => void;
   readonly onFinitePointCount: (count: number) => void;
   readonly pointSize: number;
   readonly positions: Float32Array;
+  readonly scalarFields?: readonly PointCloudScalarField[];
   readonly showGizmo: boolean;
   readonly transform: PointCloudFrameTransform | undefined;
 }) {
   const invalidate = useThree((state) => state.invalidate);
   const data = useMemo(
-    () => buildPointCloudRenderData(positions, maxRenderedPoints),
-    [maxRenderedPoints, positions]
+    () =>
+      buildPointCloudRenderData(positions, maxRenderedPoints, {
+        colorBy,
+        colors,
+        scalarFields,
+      }),
+    [colorBy, colors, maxRenderedPoints, positions, scalarFields]
   );
   const objectTransform = useMemo(
     () => pointCloudObjectTransform(transform),
@@ -195,7 +255,11 @@ function PointCloudSceneContent({
   }, [invalidate, objectTransform]);
 
   return (
-    <Base3DScene showGizmo={showGizmo}>
+    <Base3DScene
+      cameraPose={cameraPose}
+      onCameraPoseChange={onCameraPoseChange}
+      showGizmo={showGizmo}
+    >
       <group
         position={objectTransform.position}
         quaternion={objectTransform.quaternion}
@@ -252,7 +316,12 @@ function createPointCloudGeometry(data: PointCloudRenderData) {
 
 function buildPointCloudRenderData(
   sourcePositions: Float32Array,
-  maxRenderedPoints: number
+  maxRenderedPoints: number,
+  colorOptions: {
+    readonly colorBy?: PointCloudColorBy;
+    readonly colors?: Float32Array;
+    readonly scalarFields?: readonly PointCloudScalarField[];
+  }
 ): PointCloudRenderData {
   const sourcePointCount = Math.floor(
     sourcePositions.length / POINT_COMPONENT_COUNT
@@ -268,8 +337,14 @@ function buildPointCloudRenderData(
     Math.ceil(sourcePointCount / sampleEvery)
   );
   const positions = new Float32Array(maxSampleCount * POINT_COMPONENT_COUNT);
-  const colors = new Float32Array(maxSampleCount * POINT_COMPONENT_COUNT);
+  const colors = new Float32Array(maxSampleCount * COLOR_COMPONENT_COUNT);
   const heightBounds = computeSourceHeightBounds(sourcePositions);
+  const colorSource = resolvePointCloudColorSource({
+    ...colorOptions,
+    heightBounds,
+    sourcePointCount,
+    sourcePositions,
+  });
   const bounds = new THREE.Box3();
   // Bounds are updated per rendered point; reuse one vector to avoid a large
   // allocation burst on dense point clouds.
@@ -296,11 +371,7 @@ function buildPointCloudRenderData(
     positions[targetOffset + X_COMPONENT_INDEX] = x;
     positions[targetOffset + Y_COMPONENT_INDEX] = y;
     positions[targetOffset + Z_COMPONENT_INDEX] = z;
-    writeHeightColor(
-      colors,
-      targetOffset,
-      normalizeHeight(z, heightBounds.minHeight, heightBounds.maxHeight)
-    );
+    writePointColor(colors, targetOffset, colorSource, sourcePointIndex, z);
     tmpVec.set(
       positions[targetOffset + X_COMPONENT_INDEX],
       positions[targetOffset + Y_COMPONENT_INDEX],
@@ -330,6 +401,256 @@ function buildPointCloudRenderData(
     positions,
     renderedPointCount,
   };
+}
+
+type PointCloudColorSource =
+  | {
+      readonly kind: "height";
+      readonly maxValue: number;
+      readonly minValue: number;
+    }
+  | {
+      readonly colors: Float32Array;
+      readonly kind: "rgb";
+    }
+  | {
+      readonly kind: "scalar";
+      readonly maxValue: number;
+      readonly minValue: number;
+      readonly values: Float32Array;
+    }
+  | {
+      readonly kind: "uniform";
+    };
+
+function resolvePointCloudColorSource({
+  colorBy,
+  colors,
+  heightBounds,
+  scalarFields,
+  sourcePointCount,
+  sourcePositions,
+}: {
+  readonly colorBy?: PointCloudColorBy;
+  readonly colors?: Float32Array;
+  readonly heightBounds: ReturnType<typeof computeSourceHeightBounds>;
+  readonly scalarFields?: readonly PointCloudScalarField[];
+  readonly sourcePointCount: number;
+  readonly sourcePositions: Float32Array;
+}): PointCloudColorSource {
+  if (colorBy && colorBy !== "auto") {
+    return (
+      requestedColorSource({
+        colorBy,
+        colors,
+        heightBounds,
+        scalarFields,
+        sourcePointCount,
+        sourcePositions,
+      }) ?? { kind: "uniform" }
+    );
+  }
+
+  const rgbSource = rgbColorSource(colors, sourcePointCount);
+  if (rgbSource) {
+    return rgbSource;
+  }
+
+  for (const fieldName of CANONICAL_SCALAR_COLOR_FIELDS) {
+    const scalarSource = scalarColorSource(
+      sourcePositions,
+      sourcePointCount,
+      scalarFields,
+      fieldName
+    );
+    if (scalarSource) {
+      return scalarSource;
+    }
+  }
+
+  return heightColorSource(heightBounds) ?? { kind: "uniform" };
+}
+
+function requestedColorSource({
+  colorBy,
+  colors,
+  heightBounds,
+  scalarFields,
+  sourcePointCount,
+  sourcePositions,
+}: {
+  readonly colorBy: Exclude<PointCloudColorBy, "auto">;
+  readonly colors?: Float32Array;
+  readonly heightBounds: ReturnType<typeof computeSourceHeightBounds>;
+  readonly scalarFields?: readonly PointCloudScalarField[];
+  readonly sourcePointCount: number;
+  readonly sourcePositions: Float32Array;
+}): PointCloudColorSource | null {
+  if (colorBy === "uniform") {
+    return { kind: "uniform" };
+  }
+
+  if (colorBy === "height") {
+    return heightColorSource(heightBounds);
+  }
+
+  if (colorBy === "rgb") {
+    return rgbColorSource(colors, sourcePointCount);
+  }
+
+  return scalarColorSource(
+    sourcePositions,
+    sourcePointCount,
+    scalarFields,
+    colorBy
+  );
+}
+
+function rgbColorSource(
+  colors: Float32Array | undefined,
+  sourcePointCount: number
+): PointCloudColorSource | null {
+  return colors && colors.length >= sourcePointCount * COLOR_COMPONENT_COUNT
+    ? { colors, kind: "rgb" }
+    : null;
+}
+
+function scalarColorSource(
+  sourcePositions: Float32Array,
+  sourcePointCount: number,
+  scalarFields: readonly PointCloudScalarField[] | undefined,
+  fieldName: string
+): PointCloudColorSource | null {
+  const scalarField = scalarFields?.find(
+    (field) => normalizedFieldName(field.name) === fieldName
+  );
+  if (!scalarField || scalarField.values.length < sourcePointCount) {
+    return null;
+  }
+
+  const bounds = computeScalarBounds(sourcePositions, scalarField.values);
+  if (!hasUsefulRange(bounds)) {
+    return null;
+  }
+
+  return {
+    kind: "scalar",
+    maxValue: bounds.maxValue,
+    minValue: bounds.minValue,
+    values: scalarField.values,
+  };
+}
+
+function heightColorSource(
+  heightBounds: ReturnType<typeof computeSourceHeightBounds>
+): PointCloudColorSource | null {
+  return hasUsefulRange({
+    finitePointCount: heightBounds.finitePointCount,
+    maxValue: heightBounds.maxHeight,
+    minValue: heightBounds.minHeight,
+  })
+    ? {
+        kind: "height",
+        maxValue: heightBounds.maxHeight,
+        minValue: heightBounds.minHeight,
+      }
+    : null;
+}
+
+function writePointColor(
+  target: Float32Array,
+  targetOffset: number,
+  colorSource: PointCloudColorSource,
+  sourcePointIndex: number,
+  z: number
+) {
+  if (colorSource.kind === "rgb") {
+    const sourceOffset = sourcePointIndex * COLOR_COMPONENT_COUNT;
+    target[targetOffset] = clamp01(colorSource.colors[sourceOffset]);
+    target[targetOffset + 1] = clamp01(colorSource.colors[sourceOffset + 1]);
+    target[targetOffset + 2] = clamp01(colorSource.colors[sourceOffset + 2]);
+    return;
+  }
+
+  if (colorSource.kind === "height") {
+    writeHeightColor(
+      target,
+      targetOffset,
+      normalizeValue(z, colorSource.minValue, colorSource.maxValue)
+    );
+    return;
+  }
+
+  if (colorSource.kind === "scalar") {
+    const value = colorSource.values[sourcePointIndex];
+    if (Number.isFinite(value)) {
+      writeHeightColor(
+        target,
+        targetOffset,
+        normalizeValue(value, colorSource.minValue, colorSource.maxValue)
+      );
+      return;
+    }
+  }
+
+  writeNeutralColor(target, targetOffset);
+}
+
+function computeScalarBounds(
+  sourcePositions: Float32Array,
+  values: Float32Array
+) {
+  let finitePointCount = 0;
+  let minValue = Infinity;
+  let maxValue = -Infinity;
+  const pointCount = Math.min(
+    values.length,
+    Math.floor(sourcePositions.length / POINT_COMPONENT_COUNT)
+  );
+
+  for (let pointIndex = 0; pointIndex < pointCount; pointIndex++) {
+    const positionOffset = pointIndex * POINT_COMPONENT_COUNT;
+    const x = sourcePositions[positionOffset];
+    const y = sourcePositions[positionOffset + Y_COMPONENT_INDEX];
+    const z = sourcePositions[positionOffset + Z_COMPONENT_INDEX];
+    const value = values[pointIndex];
+
+    if (
+      !Number.isFinite(x) ||
+      !Number.isFinite(y) ||
+      !Number.isFinite(z) ||
+      !Number.isFinite(value)
+    ) {
+      continue;
+    }
+
+    finitePointCount++;
+    minValue = Math.min(minValue, value);
+    maxValue = Math.max(maxValue, value);
+  }
+
+  return {
+    finitePointCount,
+    maxValue: finitePointCount > 0 ? maxValue : 0,
+    minValue: finitePointCount > 0 ? minValue : 0,
+  };
+}
+
+function hasUsefulRange({
+  finitePointCount,
+  maxValue,
+  minValue,
+}: {
+  readonly finitePointCount: number;
+  readonly maxValue: number;
+  readonly minValue: number;
+}) {
+  return (
+    finitePointCount > 0 &&
+    Number.isFinite(minValue) &&
+    Number.isFinite(maxValue) &&
+    maxValue - minValue > HEIGHT_NORMALIZATION_EPSILON
+  );
 }
 
 function computeSourceHeightBounds(sourcePositions: Float32Array) {
@@ -413,10 +734,24 @@ function writeHeightColor(target: Float32Array, offset: number, value: number) {
     HEIGHT_COLOR_BLUE_BASE - warm * HEIGHT_COLOR_BLUE_WARM_RANGE;
 }
 
-function normalizeHeight(value: number, min: number, max: number) {
+function writeNeutralColor(target: Float32Array, offset: number) {
+  target[offset] = NEUTRAL_POINT_COLOR[0];
+  target[offset + 1] = NEUTRAL_POINT_COLOR[1];
+  target[offset + 2] = NEUTRAL_POINT_COLOR[2];
+}
+
+function normalizeValue(value: number, min: number, max: number) {
   const span = Math.max(max - min, HEIGHT_NORMALIZATION_EPSILON);
 
   return (value - min) / span;
+}
+
+function normalizedFieldName(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+function clamp01(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.min(1, value)) : 0;
 }
 
 function pointCountLabel(finitePointCount: number, declaredPointCount: number) {

--- a/app/packages/multimodal/src/visualization/panels/point-cloud.tsx
+++ b/app/packages/multimodal/src/visualization/panels/point-cloud.tsx
@@ -89,6 +89,7 @@ export interface PointCloudPanelProps {
   readonly frameTransform?: PointCloudFrameTransform;
   readonly maxRenderedPoints?: number;
   readonly pointSize?: number;
+  readonly showGizmo?: boolean;
   readonly showHud?: boolean;
   readonly style?: CSSProperties;
   readonly warning?: string | null;
@@ -104,6 +105,7 @@ export function PointCloudPanel({
   frameTransform,
   maxRenderedPoints = DEFAULT_MAX_RENDERED_POINTS,
   pointSize = DEFAULT_POINT_SIZE,
+  showGizmo = true,
   showHud = true,
   style,
   warning = null,
@@ -118,10 +120,18 @@ export function PointCloudPanel({
         onFinitePointCount={setFinitePointCount}
         pointSize={pointSize}
         positions={frame.positions}
+        showGizmo={showGizmo}
         transform={frameTransform}
       />
     ),
-    [fit, frame.positions, frameTransform, maxRenderedPoints, pointSize]
+    [
+      fit,
+      frame.positions,
+      frameTransform,
+      maxRenderedPoints,
+      pointSize,
+      showGizmo,
+    ]
   );
 
   return (
@@ -155,6 +165,7 @@ function PointCloudSceneContent({
   onFinitePointCount,
   pointSize,
   positions,
+  showGizmo,
   transform,
 }: {
   readonly fit: "initial" | "frame" | "never";
@@ -162,6 +173,7 @@ function PointCloudSceneContent({
   readonly onFinitePointCount: (count: number) => void;
   readonly pointSize: number;
   readonly positions: Float32Array;
+  readonly showGizmo: boolean;
   readonly transform: PointCloudFrameTransform | undefined;
 }) {
   const invalidate = useThree((state) => state.invalidate);
@@ -183,7 +195,7 @@ function PointCloudSceneContent({
   }, [invalidate, objectTransform]);
 
   return (
-    <Base3DScene>
+    <Base3DScene showGizmo={showGizmo}>
       <group
         position={objectTransform.position}
         quaternion={objectTransform.quaternion}

--- a/app/packages/plugins/src/registry.ts
+++ b/app/packages/plugins/src/registry.ts
@@ -164,6 +164,23 @@ export enum Categories {
 
 export type PluginActivator = (props: any) => boolean;
 
+/**
+ * Stable component slots exposed by core surfaces.
+ */
+export const PLUGIN_COMPONENT_SLOT = {
+  GRID_HEADER_AFTER_RESOURCE_COUNT: "grid-header-after-resource-count",
+} as const;
+
+export type PluginComponentSlot =
+  typeof PLUGIN_COMPONENT_SLOT[keyof typeof PLUGIN_COMPONENT_SLOT];
+
+export type ComponentOptions = {
+  /**
+   * Named UI insertion points where this component can be rendered.
+   */
+  slots?: readonly PluginComponentSlot[];
+};
+
 export type PanelOptions = {
   /**
    * Whether to allow multiple instances of the plugin.
@@ -285,6 +302,7 @@ export type ComponentRegistration<T extends {} = {}> =
     PluginComponentType.Component,
     PluginComponentProps<T>
   > & {
+    componentOptions?: ComponentOptions;
     panelOptions?: never;
     sampleRendererOptions?: never;
   };
@@ -337,6 +355,16 @@ export function getCategoryForPanel(
   panel: PanelRegistration | PlotRegistration
 ) {
   return panel.panelOptions?.category || "custom";
+}
+
+/**
+ * Returns whether a generic component is registered for a named UI slot.
+ */
+export function componentHasSlot(
+  registration: ComponentRegistration,
+  slot: PluginComponentSlot
+) {
+  return registration.componentOptions?.slots?.includes(slot) === true;
 }
 
 const DEFAULT_ACTIVATOR = () => true;

--- a/app/packages/plugins/src/useActivePlugins.test.tsx
+++ b/app/packages/plugins/src/useActivePlugins.test.tsx
@@ -1,25 +1,33 @@
 import { act, cleanup, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  PLUGIN_COMPONENT_SLOT,
   PluginActivator,
   PluginComponentType,
+  componentHasSlot,
   registerComponent,
   unregisterComponent,
   useActivePlugins,
   usePluginComponent,
 } from "./registry";
+import type { ComponentOptions } from "./registry";
 
 const NullComponent = () => null;
 
 const registered: string[] = [];
 
-const register = (name: string, activator?: PluginActivator) => {
+const register = (
+  name: string,
+  activator?: PluginActivator,
+  componentOptions?: ComponentOptions
+) => {
   registerComponent<PluginComponentType.Component>({
     name,
     label: name,
     component: NullComponent,
     type: PluginComponentType.Component,
     activator,
+    componentOptions,
   });
   registered.push(name);
 };
@@ -117,6 +125,27 @@ describe("useActivePlugins: runtime behavior", () => {
     expect(() =>
       renderHook(() => useActivePlugins(PluginComponentType.Component, {}))
     ).not.toThrow();
+  });
+
+  it("lets callers filter generic components by explicit slot metadata", () => {
+    register("slotless", () => true);
+    register("grid-header", () => true, {
+      slots: [PLUGIN_COMPONENT_SLOT.GRID_HEADER_AFTER_RESOURCE_COUNT],
+    });
+
+    const { result } = renderHook(() =>
+      useActivePlugins(PluginComponentType.Component, {})
+    );
+    const slotComponents = result.current.filter((component) =>
+      componentHasSlot(
+        component,
+        PLUGIN_COMPONENT_SLOT.GRID_HEADER_AFTER_RESOURCE_COUNT
+      )
+    );
+
+    expect(slotComponents.map((component) => component.name)).toEqual([
+      "grid-header",
+    ]);
   });
 });
 

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -3461,7 +3461,9 @@ __metadata:
   resolution: "@fiftyone/multimodal@workspace:packages/multimodal"
   dependencies:
     "@bufbuild/protobuf": "npm:^2.11.0"
+    "@fiftyone/components": "npm:*"
     "@fiftyone/plugins": "npm:*"
+    "@fiftyone/state": "npm:*"
     "@fiftyone/tiling": "npm:*"
     "@fiftyone/utilities": "npm:*"
     "@mcap/core": "npm:^2.2.1"

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -3471,6 +3471,7 @@ __metadata:
     "@react-three/drei": "npm:9.105.4"
     "@react-three/fiber": "npm:^8.18.0"
     "@types/three": "npm:^0.182.0"
+    "@voxel51/voodo": "npm:^0.0.34"
     buffer: "npm:^6.0.3"
     lru-cache: "npm:^11.0.1"
     protobufjs: "npm:^7.2.5"


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

Builds on top of https://github.com/voxel51/fiftyone/pull/7756

<img width="1726" height="958" alt="2026-06-10 19 46 06" src="https://github.com/user-attachments/assets/337fcfd3-6bc5-4c04-91cc-5f25a4d3f247" />

Three main features:
1. Allow `SampleRenderer` plugin types to render components in given slots. In this PR, we add one slot, which is to the right of sample count.
2. Then register a multimodal-owned MCAP stream selector there. The selector persists per dataset, defaults to Stream: Auto, aggregates mounted previewable streams, and lets MCAP grid tiles render either the automatic first preview stream or an explicitly selected image/point-cloud stream.
3. Point-cloud grid preview support with shared grid camera pose, schema-based MCAP stream classification, point-cloud color/scalar decoding.

We also now keep custom grid renderer clicks from opening the sample modal unless the explicit open button is clicked.

## 🧪 How is this patch tested? If it is not, please explain why.

Unit tests

## High Level Architecture

Core exposes a generic grid-header component slot, while multimodal owns the MCAP selector and stream aggregation state. Each mounted MCAP grid tile registers the previewable topics it discovers; the selector stores the chosen topic per dataset and the grid preview worker receives that topic as part of each preview request.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Multimodal MCAP datasets now expose a grid stream selector for choosing preview streams. MCAP grid previews can also display point-cloud streams with shared camera pose across grid items.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Point‑cloud previews in the MCAP grid with selectable streams, per‑point scalar fields, multiple coloring modes, and controlled camera‑pose/gizmo
  * Stream selector UI with per‑dataset persistent selection and aggregated stream discovery
  * Plugin header slot to render components adjacent to the resource count

* **Bug Fixes**
  * Prevented tile-level click/contextmenu events from bubbling to grid activation

* **Tests**
  * Expanded coverage for MCAP previews, stream/topic matching, decoding, visualization, stream state, and plugin slot behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2879
<!-- enterprise-sync-pr:end -->