### PR TITLE
Trigger Enterprise sync when a PR's base changes to develop/release

### DIFF
--- a/.github/workflows/enterprise-sync.yml
+++ b/.github/workflows/enterprise-sync.yml
@@ -2,7 +2,10 @@ name: Enterprise Sync
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, closed, ready_for_review]
+    # `edited` covers base-branch changes — e.g. a stacked PR auto-retargeted
+    # to develop when its base PR merges. The head SHA doesn't change, so no
+    # `synchronize` fires; without `edited` the retargeted PR would never sync.
+    types: [opened, synchronize, reopened, closed, ready_for_review, edited]
     branches:
       - develop
       - release/*
@@ -16,9 +19,12 @@ jobs:
     # Only the OSS repo dispatches to Enterprise. The Enterprise repo carries an
     # identical copy of this file (via OSS sync) where this guard makes it inert,
     # so the file never diverges and never produces a sync conflict.
+    # On `edited`, only dispatch when the base branch changed (changes.base is
+    # only present then) — title/body edits don't need a re-sync.
     if: >-
       github.repository == 'voxel51/fiftyone' &&
-      github.event.pull_request.head.repo.full_name == github.repository && (
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (github.event.action != 'edited' || github.event.changes.base) && (
       github.event.action == 'closed' ||
       github.event.pull_request.draft != true)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Adds `edited` to the Enterprise Sync trigger types so that a PR whose **base branch changes** to `develop` or `release/*` gets an Enterprise CI run.

## Why

Stacked PRs are auto-retargeted by GitHub when their base PR merges. That fires a `pull_request` `edited` event with `changes.base` in the payload — the head SHA doesn't change, so no `synchronize` fires. Since `edited` wasn't in the trigger types, the retargeted PR never dispatched a sync and never got an `enterprise / ci` status on its head.

Concrete example: #7757 was stacked, got auto-retargeted to `develop` when its base merged, and its head SHA has no `enterprise / ci` status at all.

## How

- Add `edited` to `on.pull_request.types`. The existing `branches` filter evaluates against the **new** base, so this fires exactly when a PR is retargeted onto `develop`/`release/*`.
- Guard the job so `edited` only dispatches when the base actually changed (`github.event.changes.base` is only present for base changes) — title/body edits are ignored.

No downstream changes needed: `sync-enterprise-pr.yml` in fiftyone-teams treats any non-`closed` action as the sync path, and `sync-oss-branch` runs with `on-missing: create`, so the first sync for a freshly retargeted PR creates the Enterprise branch cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized GitHub Actions workflow to reduce unnecessary enterprise synchronization triggers when editing pull request details like titles or descriptions. Synchronization now runs only when the base branch is modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2871
<!-- enterprise-sync-pr:end -->