### PR TITLE
Fix/annotation tests

### DIFF
--- a/e2e-pw/src/oss/specs/MISSING-annotate-canvas-actions.spec.ts
+++ b/e2e-pw/src/oss/specs/MISSING-annotate-canvas-actions.spec.ts
@@ -214,8 +214,8 @@ test.describe.serial("canvas interactions and action state", () => {
     await modal.sidebar.annotate.assert.selectIsActive();
 
     // Classification tab renders at the top-left of the media bounds.
-    // Move to the top-left area and click.
-    await modal.sampleCanvas.move(0.05, 0.02);
+    // Move to the top-left area and click once the tab is hit-testable.
+    await modal.sampleCanvas.move(0.05, 0.02, "pointer");
     await modal.sampleCanvas.down();
     await modal.sampleCanvas.up();
 
@@ -236,7 +236,7 @@ test.describe.serial("canvas interactions and action state", () => {
     await modal.sidebar.annotate.assert.selectIsActive();
 
     // 2. Click the classification overlay → Classification active
-    await modal.sampleCanvas.move(0.05, 0.02);
+    await modal.sampleCanvas.move(0.05, 0.02, "pointer");
     await modal.sampleCanvas.down();
     await modal.sampleCanvas.up();
     await modal.sidebar.annotate.assert.classificationIsActive();
@@ -275,6 +275,12 @@ test.describe.serial("canvas interactions and action state", () => {
     await modal.sampleCanvas.down();
     await modal.sampleCanvas.move(0.9, 0.9);
     await modal.sampleCanvas.up();
+
+    // Wait for the new detection's edit form to open; quitting before the
+    // async establish flow commits would re-activate detection mode
+    await expect(
+      modal.sidebar.locator.getByText("Click labels to edit")
+    ).toBeHidden();
 
     await modal.sidebar.annotate.assert.detectionModeIsActive();
     await modal.sidebar.annotate.assert.selectIsActive(false);


### PR DESCRIPTION
## 🔗 Related Issues

Complaints of flaky tests

## 📋 What changes are proposed in this pull request?

- wait until the expected cursor is set
- wait until the edit form opens

## 🧪 How is this patch tested? If it is not, please explain why.

It ***is*** tests.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced canvas interaction end-to-end tests with improved targeting precision and state validation to ensure reliable behavior verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2874
<!-- enterprise-sync-pr:end -->