### PR TITLE
[FOEPD-3953] Avoid importing protobuf unless VFF_MULTIMODAL or using a multimodal feature

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -217,7 +217,7 @@ jobs:
 
       - name: Install fiftyone
         run: |
-          uv pip install --system . -r requirements/e2e.txt
+          uv pip install --system '.[multimodal]' -r requirements/e2e.txt
 
       - name: Configure
         id: test_config

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,7 +91,7 @@ jobs:
           uv pip install --system -r requirements/github.txt
       - name: Install fiftyone
         run: |
-          uv pip install --system . -r requirements/github.txt
+          uv pip install --system '.[multimodal]' -r requirements/github.txt
       - name: Configure
         id: test_config
         run: |

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -50,7 +50,7 @@ jobs:
           uv pip install --system -r requirements/github.txt
       - name: Install fiftyone
         run: |
-          uv pip install --system . -r requirements/github.txt
+          uv pip install --system '.[multimodal]' -r requirements/github.txt
       - name: Configure
         id: test_config
         run: |

--- a/fiftyone/server/routes/__init__.py
+++ b/fiftyone/server/routes/__init__.py
@@ -6,7 +6,8 @@ FiftyOne Server routes
 |
 """
 
-from fiftyone.multimodal.server import MultimodalRoutes
+from fiftyone.internal.features.registry import is_feature_enabled
+
 from fiftyone.operators.server import OperatorRoutes
 
 from .aggregate import Aggregate
@@ -31,12 +32,18 @@ from .tag import Tag
 from .tagging import Tagging
 from .values import Values
 
+multimodal_routes = []
+if is_feature_enabled("VFF_MULTIMODAL"):
+    from fiftyone.multimodal.server import MultimodalRoutes
+
+    multimodal_routes = MultimodalRoutes
+
 # Starlette routes should not be created here. Please leave as tuple definitions
 routes = (
     CameraRoutes
     + EmbeddingsRoutes
     + GroupsRoutes
-    + MultimodalRoutes
+    + multimodal_routes
     + OperatorRoutes
     + RuntimeAssetRoutes
     + SampleRoutes

--- a/fiftyone/utils/data/importers.py
+++ b/fiftyone/utils/data/importers.py
@@ -38,7 +38,6 @@ from fiftyone.core.sample import Sample
 import fiftyone.core.storage as fos
 import fiftyone.core.utils as fou
 import fiftyone.migrations as fomi
-import fiftyone.multimodal.tags._temporal_tags as fommtt
 import fiftyone.types as fot
 
 from .parsers import (
@@ -1824,6 +1823,8 @@ class FiftyOneDatasetImporter(BatchDatasetImporter):
         self._media_fields = None
 
     def setup(self):
+        import fiftyone.multimodal.tags._temporal_tags as fommtt
+
         self._data_dir = os.path.join(self.dataset_dir, "data")
         self._fields_dir = os.path.join(self.dataset_dir, "fields")
         self._anno_dir = os.path.join(self.dataset_dir, "annotations")
@@ -1855,6 +1856,8 @@ class FiftyOneDatasetImporter(BatchDatasetImporter):
                 self._has_frames = False
 
     def import_samples(self, dataset, tags=None, progress=None):
+        import fiftyone.multimodal.tags._temporal_tags as fommtt
+
         dataset_dict = foo.import_document(self._metadata_path)
 
         if len(dataset) > 0 and fomi.needs_migration(

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,6 @@ setup(
         "Pillow>=12.2",
         "plotly>=6.1.1,<7",
         "pprintpp>=0.1,<0.5",
-        "protobuf==7.35.0",
         "psutil>=5,<8",
         "pydash>=6,<9",
         "pymongo~=4.9.2",  # Keep small bounds on mongo-related libraries
@@ -121,4 +120,9 @@ setup(
     ],
     entry_points={"console_scripts": ["fiftyone=fiftyone.core.cli:main"]},
     python_requires=">=3.10",
+    extras_require={
+        "multimodal": [
+            "protobuf==7.35.0",
+        ],
+    },
 )

--- a/tests/isolated/protobuf_test.py
+++ b/tests/isolated/protobuf_test.py
@@ -7,6 +7,7 @@ version of protobuf is installed.
 |
 """
 
+import importlib.metadata
 import os
 import subprocess
 import sys
@@ -18,22 +19,45 @@ MODULES = [
 ]
 
 
-def test_incompatible_protobuf():
+def _pip_install(spec):
+    subprocess.check_call([sys.executable, "-m", "pip", "install", spec])
+
+
+def _pip_uninstall(package):
     subprocess.check_call(
-        [sys.executable, "-m", "pip", "install", "protobuf==4.25.9"]
+        [sys.executable, "-m", "pip", "uninstall", "-y", package]
     )
 
-    env = os.environ.copy()
-    env.pop("VFF_MULTIMODAL", None)
-    result = subprocess.run(
-        [sys.executable, "-c", f"import {', '.join(MODULES)}"],
-        capture_output=True,
-        check=False,
-        env=env,
-    )
-    if result.returncode != 0:
-        print(result.stdout.decode())
-        print(result.stderr.decode())
-        raise RuntimeError(
-            "Failed to import a fiftyone module with incompatible protobuf"
+
+def _current_version(package):
+    try:
+        return importlib.metadata.version(package)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def test_incompatible_protobuf():
+    original_version = _current_version("protobuf")
+
+    try:
+        _pip_install("protobuf==4.25.9")
+
+        env = os.environ.copy()
+        env.pop("VFF_MULTIMODAL", None)
+        result = subprocess.run(
+            [sys.executable, "-c", f"import {', '.join(MODULES)}"],
+            capture_output=True,
+            check=False,
+            env=env,
         )
+        if result.returncode != 0:
+            print(result.stdout.decode())
+            print(result.stderr.decode())
+            raise RuntimeError(
+                "Failed to import a fiftyone module with incompatible protobuf"
+            )
+    finally:
+        if original_version is None:
+            _pip_uninstall("protobuf")
+        else:
+            _pip_install(f"protobuf=={original_version}")

--- a/tests/isolated/protobuf_test.py
+++ b/tests/isolated/protobuf_test.py
@@ -7,6 +7,7 @@ version of protobuf is installed.
 |
 """
 
+import os
 import subprocess
 import sys
 
@@ -21,11 +22,14 @@ def test_incompatible_protobuf():
     subprocess.check_call(
         [sys.executable, "-m", "pip", "install", "protobuf==4.25.9"]
     )
+
+    env = os.environ.copy()
+    env.pop("VFF_MULTIMODAL", None)
     result = subprocess.run(
         [sys.executable, "-c", f"import {', '.join(MODULES)}"],
         capture_output=True,
         check=False,
-        env={},  # VFF_MULTIMODAL not set
+        env=env,
     )
     if result.returncode != 0:
         print(result.stdout.decode())

--- a/tests/isolated/protobuf_test.py
+++ b/tests/isolated/protobuf_test.py
@@ -1,0 +1,35 @@
+"""
+Test that certain fiftyone packages can be imported even when an incompatible
+version of protobuf is installed.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import subprocess
+import sys
+
+MODULES = [
+    "fiftyone.core.cli",
+    "fiftyone.server.routes",
+    "fiftyone.utils.data.importers",
+]
+
+
+def test_incompatible_protobuf():
+    subprocess.check_call(
+        [sys.executable, "-m", "pip", "install", "protobuf==4.25.9"]
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", f"import {', '.join(MODULES)}"],
+        capture_output=True,
+        check=False,
+        env={},  # VFF_MULTIMODAL not set
+    )
+    if result.returncode != 0:
+        print(result.stdout.decode())
+        print(result.stderr.decode())
+        raise RuntimeError(
+            "Failed to import a fiftyone module with incompatible protobuf"
+        )


### PR DESCRIPTION
## 🔗 Related Issues

[FOEPD-3953](https://voxel51.atlassian.net/browse/FOEPD-3953)

## 📋 What changes are proposed in this pull request?

- Lazily imported `fiftyone.multimodal.projection.compiler.model import SampleStatus` in `fiftyone/factory/repos/projection_repo.py`
- In `fiftyone/server/routes/__init__.py` only imported `fiftyone.multimodal.server` if `VFF_MULTIMODAL=1`

## 🧪 How is this patch tested? If it is not, please explain why.

1. Ran `pip install '.[multimodal]'`
2. Ran `pip install protobuf==4.25.9`
3. Ran `python -c 'import fiftyone.core.cli'`
4. With `VFF_MULTIMODAL` not set, ran `python -c 'import fiftyone as fo; fo.launch_app()'`

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes
- [x] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other

[FOEPD-3953]: https://voxel51.atlassian.net/browse/FOEPD-3953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Protobuf moved to an optional "multimodal" install to reduce default install size.

* **Changes**
  * Multimodal features and routes are now loaded only when the multimodal feature is enabled.
  * Internal multimodal imports deferred so related code is only brought in when used.

* **Tests**
  * CI workflows updated to install multimodal extras for relevant runs.
  * Added an isolated protobuf compatibility test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2877
<!-- enterprise-sync-pr:end -->