### PR TITLE
fix(app): MCAP scene previews crash in Vite production builds (wasm decompress require interop)

### DIFF
--- a/app/packages/app/vite.config.ts
+++ b/app/packages/app/vite.config.ts
@@ -86,6 +86,20 @@ async function loadConfig() {
       dedupe: ["react", "react-dom", "react/jsx-runtime"],
     },
     build: {
+      commonjsOptions: {
+        // The @foxglove wasm packages locate their .wasm binaries with
+        // `require("./<name>.wasm")`, which foxgloveWasmAsUrl() resolves
+        // to a Vite `?url` module (a single default export holding the
+        // asset URL string). Default CommonJS interop hands `require()`
+        // the frozen module namespace instead of that string, and the
+        // emscripten glue then crashes on `filename.startsWith(...)`.
+        // Returning the default export for exactly these ids gives the
+        // glue the URL string, matching the dev-mode esbuild shim.
+        requireReturnsDefault: (id: string) =>
+          /[\\/]@foxglove[\\/]wasm-(lz4|zstd|bz2)[\\/].*\.wasm\?url$/.test(id)
+            ? "auto"
+            : false,
+      },
       rollupOptions: {
         onwarn(warning, warn) {
           if (warning.code === "MODULE_LEVEL_DIRECTIVE") {


### PR DESCRIPTION
## Summary

In **Vite production builds** of the App, every MCAP sample tile (multimodal grid preview, gated behind `VFF_MULTIMODAL`) fails with **"Preview unavailable — `e.startsWith is not a function`"** and no scene preview ever renders. Dev mode (`yarn dev`) is unaffected, which is how this shipped unnoticed: the bug exists only in rollup production builds — i.e. the bundle served by `fo.launch_app` and packaged into the Python wheel's `fiftyone/server/static`.

## Root cause

`@mcap/support`'s decompress handlers (`@foxglove/wasm-zstd`/`wasm-lz4`/`wasm-bz2`) locate their binaries with CommonJS — the standard webpack asset pattern, where `require()` returns a URL string:

```js
// emscripten glue inside @foxglove/wasm-zstd
Module.locateFile = (input) => { const wasm_path = require("./wasm-zstd.wasm"); return wasm_path; };
...
function isFileURI(filename) { return filename.startsWith("file://"); }   // ← throws here
```

The existing `foxgloveWasmAsUrl()` plugin in `app/packages/app/vite.config.ts` resolves that `.wasm` import to a Vite `?url` module — an ES module with a single default export holding the asset URL string. The two Vite bundling paths then diverge:

- **Dev (esbuild / `foxgloveWasmOptimizeAsUrl`)** emits `module.exports = "<url>"` → `require()` returns the **string** → works.
- **Build (rollup-commonjs)** default interop hands `require()` the frozen **module namespace** instead. Verifiable in the emitted chunk:

  ```js
  be = "" + new URL("wasm-zstd-DFUPPyKO.wasm", import.meta.url).href,
  Ee = Object.freeze({ __proto__: null, default: be }),   // ← what require() returns
  ```

  `locateFile` returns that object, `wasmBinaryFile` becomes a non-string, and emscripten's `isDataURI`/`isFileURI` (`filename.startsWith(...)`) throw `TypeError: e.startsWith is not a function` inside the grid-preview worker. The worker transport surfaces only the message, so the tile shows "Preview unavailable".

`loadDecompressHandlers()` initializes all handlers up front (`Promise.all`), so **every** MCAP preview fails regardless of the file's actual chunk compression.

## Solution

One scoped option in `build.commonjsOptions`: `requireReturnsDefault` returns `"auto"` for exactly the `@foxglove/wasm-*` `.wasm?url` ids (and keeps rollup-commonjs's default `false` for everything else), so `require()` receives the URL string — identical semantics to the dev-mode esbuild shim and to webpack's asset handling. No dependency patching, no interop change for any other module.

## Testing

Reproduced on pristine `develop`:

1. `yarn build`, serve a multimodal (MCAP) dataset via `fo.launch_app` with `VFF_MULTIMODAL=1` → all grid tiles show "Preview unavailable — e.startsWith is not a function". Worker-side stack (captured via temporary instrumentation) points at emscripten `isFileURI` during `loadDecompressHandlers` init.
2. Emitted chunks contain the frozen `{default: <wasm url>}` namespace feeding `locateFile` for all three wasm packages.

With this fix:

- The same dataset renders real camera preview frames in the grid — verified headlessly via Playwright against nuScenes MCAP conversions: all tiles render frames, zero "Preview unavailable" tiles, zero console errors. (Verification is behavioral: the namespace helper may legitimately remain in chunks for other importers; `requireReturnsDefault` rewires the `require()` call site.)
- The `packages/multimodal` vitest suite (212 tests) passes before and after — unit tests drive the inline client in Node and structurally cannot catch this bundler-interop class of bug.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Chores**
- Improved Vite build configuration for WebAssembly modules. Enhanced module resolution and loading to ensure consistent behavior and interoperability between development and production environments, addressing compatibility requirements across different build and runtime contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2884
<!-- enterprise-sync-pr:end -->