### PR TITLE
perf(embeddings): load react-plotly.js lazily (off the critical path)

### DIFF
--- a/app/packages/components/src/components/Plot/Plotly.tsx
+++ b/app/packages/components/src/components/Plot/Plotly.tsx
@@ -1,8 +1,10 @@
 import { Box, useTheme } from "@mui/material";
 import { merge } from "lodash";
-import React, { useMemo } from "react";
-import Plot, { PlotParams } from "react-plotly.js";
+import React, { lazy, Suspense, useMemo } from "react";
+import type { PlotParams } from "react-plotly.js";
 import PlotlyTooltip, { TooltipValue } from "./PlotlyTooltip";
+
+const Plot = lazy(() => import("react-plotly.js"));
 
 export default function EvaluationPlot(props: EvaluationPlotProps) {
   const { usePlotlyTooltip } = props;
@@ -112,13 +114,15 @@ function Plotly(props: EvaluationPlotProps) {
   }, []);
 
   return (
-    <Plot
-      config={configDefaults}
-      layout={mergedLayout}
-      style={{ height: "100%", width: "100%", zIndex: 1, ...style }}
-      data={data}
-      {...otherProps}
-    />
+    <Suspense fallback={null}>
+      <Plot
+        config={configDefaults}
+        layout={mergedLayout}
+        style={{ height: "100%", width: "100%", zIndex: 1, ...style }}
+        data={data}
+        {...otherProps}
+      />
+    </Suspense>
   );
 }
 

--- a/app/packages/core/src/plugins/SchemaIO/components/PlotlyView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/PlotlyView.tsx
@@ -3,8 +3,9 @@ import { usePanelEvent } from "@fiftyone/operators";
 import { usePanelId } from "@fiftyone/spaces";
 import { Box } from "@mui/material";
 import { merge, snakeCase } from "lodash";
-import React, { useEffect, useMemo } from "react";
-import Plot from "react-plotly.js";
+import React, { lazy, Suspense, useEffect, useMemo } from "react";
+
+const Plot = lazy(() => import("react-plotly.js"));
 import { HeaderView } from ".";
 import { getComponentProps } from "../utils";
 import { ViewPropsType } from "../utils/types";
@@ -220,15 +221,17 @@ export default function PlotlyView(props: ViewPropsType) {
       sx={{ height: "100%", width: "100%" }}
     >
       <HeaderView {...props} nested />
-      <Plot
-        revision={revision}
-        data={mergedData}
-        style={{ height: plotHeight, width: plotWidth, zIndex: 1 }}
-        config={mergedConfig}
-        layout={mergedLayout}
-        {...eventHandlers}
-        {...getComponentProps(props, "plotly")}
-      />
+      <Suspense fallback={null}>
+        <Plot
+          revision={revision}
+          data={mergedData}
+          style={{ height: plotHeight, width: plotWidth, zIndex: 1 }}
+          config={mergedConfig}
+          layout={mergedLayout}
+          {...eventHandlers}
+          {...getComponentProps(props, "plotly")}
+        />
+      </Suspense>
     </Box>
   );
 }

--- a/app/packages/embeddings/src/index.ts
+++ b/app/packages/embeddings/src/index.ts
@@ -4,9 +4,11 @@ import {
   registerComponent,
 } from "@fiftyone/plugins";
 import WorkspacesIcon from "@mui/icons-material/Workspaces";
-import Embeddings from "./Embeddings";
+import { lazy } from "react";
 import EmbeddingsTabIndicator from "./EmbeddingsTabIndicator";
 import { BUILT_IN_PANEL_PRIORITY_CONST } from "@fiftyone/utilities";
+
+const Embeddings = lazy(() => import("./Embeddings"));
 
 registerComponent({
   name: "Embeddings",


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

Load `react-plotly.js` (~1.5 MB gz) lazily instead of on the critical path. The Embeddings panel is registered via `React.lazy`, and the shared `Plot` component / SchemaIO `PlotlyView` render `<Plot>` under an internal `<Suspense>`. Plotly now loads on first plot/panel use rather than in the entry chunk.

Depends on #7754 (panel Suspense boundary + chunking).

## 🧪 How is this patch tested? If it is not, please explain why.

- `yarn workspace @fiftyone/app build-bare` succeeds; `react-plotly` is emitted as its own lazy chunk.
- Lighthouse (desktop, live `:5151`, median of 3), full stack (this PR + #7754) vs `develop`: **FCP 12.7 s → 8.5 s, LCP 15.0 s → 10.5 s, TBT 403 → 231 ms**, perf score 33 → 43.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No.
-   [x] Yes.

Faster initial load of the app: Plotly is no longer downloaded until an Embeddings/plot view is opened.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2915
<!-- enterprise-sync-pr:end -->