### PR TITLE
perf(core): lazy-load the histograms panel (recharts off the entry chunk)

### DIFF
--- a/app/packages/core/src/plugins/HistogramsPanel.tsx
+++ b/app/packages/core/src/plugins/HistogramsPanel.tsx
@@ -1,0 +1,82 @@
+import { Loading, Selector } from "@fiftyone/components";
+import { OperatorPlacements, types } from "@fiftyone/operators";
+import { usePanelStatePartial, usePanelTitle } from "@fiftyone/spaces";
+import { distributionPaths } from "@fiftyone/state";
+import { useEffect } from "react";
+import { useRecoilValue } from "recoil";
+import styled from "styled-components";
+import Histogram from "../components/Histogram";
+
+const HistogramsContainer = styled.div`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+  max-height: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+`;
+
+const ControlsContainer = styled.div`
+  display: flex;
+  gap: 1rem;
+  margin: 1rem;
+`;
+
+function usePlotPath() {
+  const paths = useRecoilValue(distributionPaths);
+  const [path, setPath] = usePanelStatePartial("path", paths[0]);
+
+  useEffect(() => {
+    if (!paths.includes(path)) {
+      setPath(paths[0]);
+    }
+  }, [path, paths, setPath]);
+
+  return { path, setPath, paths };
+}
+
+const PlotSelector = () => {
+  const { path, setPath, paths } = usePlotPath();
+
+  return (
+    <Selector
+      component={({ value }) => <>{value}</>}
+      containerStyle={{ position: "relative" }}
+      onSelect={setPath}
+      overflow={true}
+      resultsPlacement="bottom-start"
+      placeholder={"Select field"}
+      useSearch={(search) => {
+        const values = paths.filter((name) => name.includes(search));
+        return { values, total: paths.length };
+      }}
+      value={path || ""}
+      cy={"histograms"}
+    />
+  );
+};
+
+export default function Plots() {
+  const [_, setTitle] = usePanelTitle();
+  const { path } = usePlotPath();
+
+  useEffect(() => {
+    setTitle(path);
+  }, [path]);
+
+  return (
+    <HistogramsContainer data-cy="histograms-container">
+      <ControlsContainer>
+        <PlotSelector />
+        <OperatorPlacements place={types.Places.HISTOGRAM_ACTIONS} />
+      </ControlsContainer>
+      {path ? (
+        <Histogram key={path} path={path} />
+      ) : (
+        <Loading>Select a field</Loading>
+      )}
+    </HistogramsContainer>
+  );
+}

--- a/app/packages/core/src/plugins/histograms.tsx
+++ b/app/packages/core/src/plugins/histograms.tsx
@@ -1,92 +1,13 @@
-import { Loading, Selector } from "@fiftyone/components";
-import { OperatorPlacements, types } from "@fiftyone/operators";
 import {
   Categories,
   PluginComponentType,
   registerComponent,
 } from "@fiftyone/plugins";
-import { usePanelStatePartial, usePanelTitle } from "@fiftyone/spaces";
-import { distributionPaths } from "@fiftyone/state";
 import { BUILT_IN_PANEL_PRIORITY_CONST } from "@fiftyone/utilities";
 import { BarChart } from "@mui/icons-material";
-import { useEffect } from "react";
-import { useRecoilValue } from "recoil";
-import styled from "styled-components";
-import Histogram from "../components/Histogram";
+import { lazy } from "react";
 
-const HistogramsContainer = styled.div`
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  width: 100%;
-  max-height: 100%;
-  overflow-x: auto;
-  overflow-y: hidden;
-`;
-
-const ControlsContainer = styled.div`
-  display: flex;
-  gap: 1rem;
-  margin: 1rem;
-`;
-
-function usePlotPath() {
-  const paths = useRecoilValue(distributionPaths);
-  const [path, setPath] = usePanelStatePartial("path", paths[0]);
-
-  useEffect(() => {
-    if (!paths.includes(path)) {
-      setPath(paths[0]);
-    }
-  }, [path, paths, setPath]);
-
-  return { path, setPath, paths };
-}
-
-const PlotSelector = () => {
-  const { path, setPath, paths } = usePlotPath();
-
-  return (
-    <Selector
-      component={({ value }) => <>{value}</>}
-      containerStyle={{ position: "relative" }}
-      onSelect={setPath}
-      overflow={true}
-      resultsPlacement="bottom-start"
-      placeholder={"Select field"}
-      useSearch={(search) => {
-        const values = paths.filter((name) => name.includes(search));
-        return { values, total: paths.length };
-      }}
-      value={path || ""}
-      cy={"histograms"}
-    />
-  );
-};
-
-function Plots() {
-  const [_, setTitle] = usePanelTitle();
-  const { path } = usePlotPath();
-
-  useEffect(() => {
-    setTitle(path);
-  }, [path]);
-
-  return (
-    <HistogramsContainer data-cy="histograms-container">
-      <ControlsContainer>
-        <PlotSelector />
-        <OperatorPlacements place={types.Places.HISTOGRAM_ACTIONS} />
-      </ControlsContainer>
-      {path ? (
-        <Histogram key={path} path={path} />
-      ) : (
-        <Loading>Select a field</Loading>
-      )}
-    </HistogramsContainer>
-  );
-}
+const Plots = lazy(() => import("./HistogramsPanel"));
 
 registerComponent({
   name: "Histograms",


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

Split the recharts-backed Histograms panel into a lazily-loaded chunk. The `Plots` component is extracted to `HistogramsPanel.tsx`; `histograms.tsx` is now just registration + `React.lazy`, moving recharts off the entry chunk.

Depends on #7754 (panel Suspense boundary + chunking).

## 🧪 How is this patch tested? If it is not, please explain why.

- `yarn workspace @fiftyone/app build-bare` succeeds; recharts is emitted as its own lazy chunk.
- Lighthouse (desktop, median of 3): initial grid FCP/LCP unchanged vs `develop` (expected — recharts is only needed once the Histograms panel opens). recharts (~90 KB gz) now loads on panel open.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes.

N/A

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2914
<!-- enterprise-sync-pr:end -->