### PR TITLE
perf(map): load the mapbox-gl Map panel lazily

### DIFF
--- a/app/packages/map/src/index.ts
+++ b/app/packages/map/src/index.ts
@@ -1,10 +1,10 @@
 import { registerComponent, PluginComponentType } from "@fiftyone/plugins";
 import { BUILT_IN_PANEL_PRIORITY_CONST, Schema } from "@fiftyone/utilities";
-import Map from "./Map";
 import MapIcon from "@mui/icons-material/Map";
+import { lazy } from "react";
 import MapTabIndicator from "./MapTabIndicator";
 
-export { default as Map } from "./Map";
+const Map = lazy(() => import("./Map"));
 
 registerComponent({
   name: "Map",


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

Load the mapbox-gl-backed Map panel via `React.lazy`, so mapbox-gl loads when the Map panel opens rather than in the entry chunk. Drops the unused `Map` re-export.

Depends on #7754 (panel Suspense boundary + chunking — the `manualChunks` change is what lets mapbox-gl split into its own chunk here).

## 🧪 How is this patch tested? If it is not, please explain why.

- `yarn workspace @fiftyone/app build-bare` succeeds; mapbox-gl is emitted as its own lazy chunk (no longer hoisted into the entry).
- Lighthouse (desktop, median of 3): initial grid FCP/LCP unchanged vs `develop` (expected — mapbox is only needed when the Map panel opens). mapbox-gl (~300 KB gz) now loads on panel open, in its own chunk.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes.

N/A

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2913
<!-- enterprise-sync-pr:end -->