### PR TITLE
perf(state): defer html2canvas import to first screenshot

### DIFF
--- a/app/packages/state/src/hooks/useScreenshot.ts
+++ b/app/packages/state/src/hooks/useScreenshot.ts
@@ -128,6 +128,9 @@ export const useScreenshot = (
             );
           }
         });
+      })
+      .catch((error) => {
+        console.error("Screenshot capture failed:", error);
       });
   }, [captureCallbacks, context, subscription]);
 

--- a/app/packages/state/src/hooks/useScreenshot.ts
+++ b/app/packages/state/src/hooks/useScreenshot.ts
@@ -1,5 +1,4 @@
 import { getFetchFunction, sendEvent } from "@fiftyone/utilities";
-import html2canvas from "html2canvas";
 import { useCallback, useContext } from "react";
 import { useRecoilValue } from "recoil";
 
@@ -98,7 +97,8 @@ export const useScreenshot = (
   const capture = useCallback(() => {
     const { width } = document.body.getBoundingClientRect();
     captureCallbacks()
-      .then(() => html2canvas(document.body))
+      .then(() => import("html2canvas"))
+      .then(({ default: html2canvas }) => html2canvas(document.body))
       .then((canvas) => {
         const imgData = canvas.toDataURL("image/jpeg", SCREENSHOT_QUALITY);
 


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

Defer the `html2canvas` import to first use. `useScreenshot` now `import('html2canvas')` inside the capture callback instead of at module scope, removing it from the eager bundle.

## 🧪 How is this patch tested? If it is not, please explain why.

- `yarn workspace @fiftyone/app build-bare` succeeds; html2canvas is emitted as its own lazy chunk.
- Lighthouse (desktop, median of 3): initial FCP/LCP unchanged (expected — html2canvas is only used on screenshot). ~45 KB gz removed from the eager bundle, loaded on first screenshot.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes.

N/A

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the screenshot capture to load the required canvas library dynamically at runtime.
  * Added error handling for failed screenshot captures, with a clear log message when capture fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2900
<!-- enterprise-sync-pr:end -->