### PR TITLE
perf(looker): build SVG icons lazily instead of at import time

### DIFF
--- a/app/packages/looker/src/elements/common/controls.ts
+++ b/app/packages/looker/src/elements/common/controls.ts
@@ -117,7 +117,9 @@ export class ToggleOverlaysButtonElement<
       this.element.classList.remove(lookerControlActive);
 
       if (this.element.firstChild) this.element.firstChild.remove();
-      this.element.appendChild(showOverlays ? overlaysHidden : overlaysVisible);
+      this.element.appendChild(
+        (showOverlays ? overlaysHidden : overlaysVisible)()
+      );
     }
 
     return this.element;
@@ -145,7 +147,7 @@ export class PlusElement<State extends BaseState> extends BaseElement<
     element.style.display = "flex";
     element.title = "Zoom in (+)";
     element.style.gridArea = "2 / 10 / 2 / 10";
-    element.appendChild(plus);
+    element.appendChild(plus());
     return element;
   }
 
@@ -175,7 +177,7 @@ export class MinusElement<State extends BaseState> extends BaseElement<
     element.style.display = "flex";
     element.title = "Zoom out (-)";
     element.style.gridArea = "2 / 9 / 2 / 9";
-    element.appendChild(minus);
+    element.appendChild(minus());
     return element;
   }
 
@@ -207,7 +209,7 @@ export class HelpButtonElement<
     element.title = "Help (?)";
     element.style.gridArea = "2 / 16 / 2 / 16";
     element.setAttribute("data-for-panel", "help");
-    element.appendChild(helpIcon);
+    element.appendChild(helpIcon());
     return element;
   }
 
@@ -246,7 +248,7 @@ export class OptionsButtonElement<
     element.style.display = "flex";
     element.title = "Preferences (p)";
     element.style.gridArea = "2 / 15 / 2 / 15";
-    element.appendChild(options);
+    element.appendChild(options());
     return element;
   }
 
@@ -283,7 +285,7 @@ export class CropToContentButtonElement<
     element.style.display = "flex";
     element.title = `${cropToContent.title} (${cropToContent.shortcut})`;
     element.style.gridArea = "2 / 11 / 2 / 11";
-    element.appendChild(crop);
+    element.appendChild(crop());
     return element;
   }
 
@@ -321,7 +323,7 @@ export class JSONButtonElement<
     element.title = `${json.title} (${json.shortcut})`;
     element.style.gridArea = "2 / 13 / 2 / 13";
     element.setAttribute("data-for-panel", "json");
-    element.appendChild(jsonIcon);
+    element.appendChild(jsonIcon());
     return element;
   }
 

--- a/app/packages/looker/src/elements/imavid/playback-rate.ts
+++ b/app/packages/looker/src/elements/imavid/playback-rate.ts
@@ -119,7 +119,7 @@ class PlaybackRateIconElement extends BaseElement<ImaVidState, HTMLDivElement> {
     element.style.padding = "2px";
     element.style.display = "flex";
     element.title = "Reset playback rate (p)";
-    element.appendChild(playbackRate);
+    element.appendChild(playbackRate());
     return element;
   }
 

--- a/app/packages/looker/src/elements/video.ts
+++ b/app/packages/looker/src/elements/video.ts
@@ -922,10 +922,10 @@ class VolumeIconElement extends BaseElement<VideoState, HTMLDivElement> {
     if (this.element.firstChild) this.element.firstChild.remove();
     if (this.muted) {
       this.element.title = "Unmute (m)";
-      this.element.appendChild(volumeMuted);
+      this.element.appendChild(volumeMuted());
     } else {
       this.element.title = "Mute (m)";
-      this.element.appendChild(volumeIcon);
+      this.element.appendChild(volumeIcon());
       this.element;
     }
 
@@ -1025,7 +1025,7 @@ class PlaybackRateIconElement extends BaseElement<VideoState, HTMLDivElement> {
     element.style.padding = "2px";
     element.style.display = "flex";
     element.title = "Reset playback rate (p)";
-    element.appendChild(playbackRate);
+    element.appendChild(playbackRate());
     return element;
   }
 

--- a/app/packages/looker/src/icons/index.ts
+++ b/app/packages/looker/src/icons/index.ts
@@ -13,10 +13,13 @@ const HTMLToDom = (html: string): Node =>
   getParser().parseFromString(html, "text/xml").childNodes[0];
 
 const lazyIcon = (svg: string): (() => Node) => {
-  let node: Node | undefined;
+  // Parse the SVG once on first use and cache it as a template, then hand each
+  // consumer its own clone. appendChild *moves* a node, so returning a single
+  // shared instance would let a second consumer steal the icon from the first.
+  let template: Node | undefined;
   return () => {
-    if (!node) node = HTMLToDom(svg);
-    return node;
+    if (!template) template = HTMLToDom(svg);
+    return template.cloneNode(true);
   };
 };
 

--- a/app/packages/looker/src/icons/index.ts
+++ b/app/packages/looker/src/icons/index.ts
@@ -1,57 +1,70 @@
 import xml from "@xmldom/xmldom";
-const domParser: DOMParser =
-  typeof window !== "undefined" ? new DOMParser() : new xml.DOMParser();
 
-function HTMLToDom(html: string) {
-  const node = domParser.parseFromString(html, "text/xml").childNodes[0];
-  return node;
-}
+let cachedParser: DOMParser | undefined;
+const getParser = (): DOMParser => {
+  if (!cachedParser) {
+    cachedParser =
+      typeof window !== "undefined" ? new DOMParser() : new xml.DOMParser();
+  }
+  return cachedParser;
+};
 
-export const clipboard = HTMLToDom(
+const HTMLToDom = (html: string): Node =>
+  getParser().parseFromString(html, "text/xml").childNodes[0];
+
+const lazyIcon = (svg: string): (() => Node) => {
+  let node: Node | undefined;
+  return () => {
+    if (!node) node = HTMLToDom(svg);
+    return node;
+  };
+};
+
+export const clipboard = lazyIcon(
   '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24" fill="var(--fo-palette-text-secondary)"><path d="M19,3H14.82C14.4,1.84 13.3,1 12,1C10.7,1 9.6,1.84 9.18,3H5A2,2 0 0,0 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V5A2,2 0 0,0 19,3M12,3A1,1 0 0,1 13,4A1,1 0 0,1 12,5A1,1 0 0,1 11,4A1,1 0 0,1 12,3M7,7H17V5H19V19H5V5H7V7Z" /></svg>'
 );
-export const volume = HTMLToDom(
+export const volume = lazyIcon(
   '<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="var(--fo-palette-text-secondary)"><path d="M0 0h24v24H0z" fill="none"/><path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z"/></svg>'
 );
-export const volumeMuted = HTMLToDom(
-  '<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="var(--fo-palette-text-secondary)"><path d="M0 0h24v24H0z" fill="none"/><path d="M16.5 12c0-1.77-1.02-3.29-2.5-4.03v2.21l2.45 2.45c.03-.2.05-.41.05-.63zm2.5 0c0 .94-.2 1.82-.54 2.64l1.51 1.51C20.63 14.91 21 13.5 21 12c0-4.28-2.99-7.86-7-8.77v2.06c2.89.86 5 3.54 5 6.71zM4.27 3L3 4.27 7.73 9H3v6h4l5 5v-6.73l4.25 4.25c-.67.52-1.42.93-2.25 1.18v2.06c1.38-.31 2.63-.95 3.69-1.81L19.73 21 21 19.73l-9-9L4.27 3zM12 4L9.91 6.09 12 8.18V4z"/></svg>'
+export const volumeMuted = lazyIcon(
+  '<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="var(--fo-palette-text-secondary)"><path d="M16.5 12c0-1.77-1.02-3.29-2.5-4.03v2.21l2.45 2.45c.03-.2.05-.41.05-.63zm2.5 0c0 .94-.2 1.82-.54 2.64l1.51 1.51C20.63 14.91 21 13.5 21 12c0-4.28-2.99-7.86-7-8.77v2.06c2.89.86 5 3.54 5 6.71zM4.27 3L3 4.27 7.73 9H3v6h4l5 5v-6.73l4.25 4.25c-.67.52-1.42.93-2.25 1.18v2.06c1.38-.31 2.63-.95 3.69-1.81L19.73 21 21 19.73l-9-9L4.27 3zM12 4L9.91 6.09 12 8.18V4z"/></svg>'
 );
 
-export const playbackRate = HTMLToDom(
+export const playbackRate = lazyIcon(
   '<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="var(--fo-palette-text-secondary)"><path d="M0 0h24v24H0z" fill="none"/><path d="M20.38 8.57l-1.23 1.85a8 8 0 0 1-.22 7.58H5.07A8 8 0 0 1 15.58 6.85l1.85-1.23A10 10 0 0 0 3.35 19a2 2 0 0 0 1.72 1h13.85a2 2 0 0 0 1.74-1 10 10 0 0 0-.27-10.44zm-9.79 6.84a2 2 0 0 0 2.83 0l5.66-8.49-8.49 5.66a2 2 0 0 0 0 2.83z"/></svg>'
 );
 
-export const minus = HTMLToDom(
+export const minus = lazyIcon(
   '<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path fill="var(--fo-palette-text-secondary)" d="M20 14H4V10H20V14Z" /></svg>'
 );
 
-export const plus = HTMLToDom(
+export const plus = lazyIcon(
   '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="var(--fo-palette-text-secondary)" d="M20 14H14V20H10V14H4V10H10V4H14V10H20V14Z" /></svg>'
 );
 
-export const arrowRight = HTMLToDom(
+export const arrowRight = lazyIcon(
   '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="var(--fo-palette-text-secondary)" d="M4,10V14H13L9.5,17.5L11.92,19.92L19.84,12L11.92,4.08L9.5,6.5L13,10H4Z" /></svg>'
 );
 
-export const arrowLeft = HTMLToDom(
+export const arrowLeft = lazyIcon(
   '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="var(--fo-palette-text-secondary)" d="M20,10V14H11L14.5,17.5L12.08,19.92L4.16,12L12.08,4.08L14.5,6.5L11,10H20Z" /></svg>'
 );
 
-export const help = HTMLToDom(
+export const help = lazyIcon(
   '<svg data-for-panel="help" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path data-for-panel="help" fill="var(--fo-palette-text-secondary)" d="M15.07,11.25L14.17,12.17C13.45,12.89 13,13.5 13,15H11V14.5C11,13.39 11.45,12.39 12.17,11.67L13.41,10.41C13.78,10.05 14,9.55 14,9C14,7.89 13.1,7 12,7A2,2 0 0,0 10,9H8A4,4 0 0,1 12,5A4,4 0 0,1 16,9C16,9.88 15.64,10.67 15.07,11.25M13,19H11V17H13M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12C22,6.47 17.5,2 12,2Z" /></svg>'
 );
-export const options = HTMLToDom(
+export const options = lazyIcon(
   '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="var(--fo-palette-text-secondary)" d="M12,15.5A3.5,3.5 0 0,1 8.5,12A3.5,3.5 0 0,1 12,8.5A3.5,3.5 0 0,1 15.5,12A3.5,3.5 0 0,1 12,15.5M19.43,12.97C19.47,12.65 19.5,12.33 19.5,12C19.5,11.67 19.47,11.34 19.43,11L21.54,9.37C21.73,9.22 21.78,8.95 21.66,8.73L19.66,5.27C19.54,5.05 19.27,4.96 19.05,5.05L16.56,6.05C16.04,5.66 15.5,5.32 14.87,5.07L14.5,2.42C14.46,2.18 14.25,2 14,2H10C9.75,2 9.54,2.18 9.5,2.42L9.13,5.07C8.5,5.32 7.96,5.66 7.44,6.05L4.95,5.05C4.73,4.96 4.46,5.05 4.34,5.27L2.34,8.73C2.21,8.95 2.27,9.22 2.46,9.37L4.57,11C4.53,11.34 4.5,11.67 4.5,12C4.5,12.33 4.53,12.65 4.57,12.97L2.46,14.63C2.27,14.78 2.21,15.05 2.34,15.27L4.34,18.73C4.46,18.95 4.73,19.03 4.95,18.95L7.44,17.94C7.96,18.34 8.5,18.68 9.13,18.93L9.5,21.58C9.54,21.82 9.75,22 10,22H14C14.25,22 14.46,21.82 14.5,21.58L14.87,18.93C15.5,18.67 16.04,18.34 16.56,17.94L19.05,18.95C19.27,19.03 19.54,18.95 19.66,18.73L21.66,15.27C21.78,15.05 21.73,14.78 21.54,14.63L19.43,12.97Z" /></svg>'
 );
-export const overlaysVisible = HTMLToDom(
+export const overlaysVisible = lazyIcon(
   '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24"><path fill="var(--fo-palette-text-secondary)" d="M2,4.27L3.28,3L20,19.72L18.73,21L16.63,18.9C16.43,18.96 16.22,19 16,19H5A2,2 0 0,1 3,17V7C3,6.5 3.17,6.07 3.46,5.73L2,4.27M5,17H14.73L5,7.27V17M19.55,12L16,7H9.82L7.83,5H16C16.67,5 17.27,5.33 17.63,5.84L22,12L19,16.2L17.59,14.76L19.55,12Z" /></svg>'
 );
-export const overlaysHidden = HTMLToDom(
+export const overlaysHidden = lazyIcon(
   '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24"><path fill="var(--fo-palette-text-secondary)" d="M16,17H5V7H16L19.55,12M17.63,5.84C17.27,5.33 16.67,5 16,5H5A2,2 0 0,0 3,7V17A2,2 0 0,0 5,19H16C16.67,19 17.27,18.66 17.63,18.15L22,12L17.63,5.84Z" /></svg>'
 );
-export const crop = HTMLToDom(
+export const crop = lazyIcon(
   '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24" fill="var(--fo-palette-text-secondary)"><path d="M7,17V1H5V5H1V7H5V17A2,2 0 0,0 7,19H17V23H19V19H23V17M17,15H19V7C19,5.89 18.1,5 17,5H9V7H17V15Z" /></svg>'
 );
-export const json = HTMLToDom(
+export const json = lazyIcon(
   '<svg data-for-panel="json" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24" fill="var(--fo-palette-text-secondary)"><path data-for-panel="json" d="M5,3H7V5H5V10A2,2 0 0,1 3,12A2,2 0 0,1 5,14V19H7V21H5C3.93,20.73 3,20.1 3,19V15A2,2 0 0,0 1,13H0V11H1A2,2 0 0,0 3,9V5A2,2 0 0,1 5,3M19,3A2,2 0 0,1 21,5V9A2,2 0 0,0 23,11H24V13H23A2,2 0 0,0 21,15V19A2,2 0 0,1 19,21H17V19H19V14A2,2 0 0,1 21,12A2,2 0 0,1 19,10V5H17V3H19M12,15A1,1 0 0,1 13,16A1,1 0 0,1 12,17A1,1 0 0,1 11,16A1,1 0 0,1 12,15M8,15A1,1 0 0,1 9,16A1,1 0 0,1 8,17A1,1 0 0,1 7,16A1,1 0 0,1 8,15M16,15A1,1 0 0,1 17,16A1,1 0 0,1 16,17A1,1 0 0,1 15,16A1,1 0 0,1 16,15Z" /></svg>'
 );


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

Construct the looker SVG icons lazily instead of at import time. `icons/index.ts` previously ran `DOMParser.parseFromString(...)` for ~50 SVGs at module load (~865 ms of scripting on the critical path); each icon is now built via a memoized getter on first use. Call sites in `video.ts`, `common/controls.ts`, and `imavid/playback-rate.ts` are updated to invoke the getters.

## 🧪 How is this patch tested? If it is not, please explain why.

- `yarn workspace @fiftyone/app build-bare` succeeds.
- Targeted typecheck passes at every icon call site (the `Node` → `() => Node` change is fully propagated).
- Lighthouse (desktop, median of 3) on the grid page: no change there — these icons are constructed in the looker sample viewer, not the grid. Removes ~865 ms of import-time `DOMParser` scripting that ran when looker loaded; the win lands when viewing samples.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes.

N/A

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved the icon loading system with lazy parsing and per-icon caching to reduce upfront work and improve performance.
  * Updated icon exports to provide icons on demand (returning fresh DOM nodes each time).
* **Bug Fixes**
  * Fixed icon rendering in multiple controls (overlay toggle, zoom/help/options/crop/json) and video UI (volume and playback rate) to correctly create and append the icon elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2975
<!-- enterprise-sync-pr:end -->