### PR TITLE
fix(app): break @fiftyone/core barrel circular dependency

### DIFF
--- a/app/packages/core/src/components/QueryPerformanceToast.tsx
+++ b/app/packages/core/src/components/QueryPerformanceToast.tsx
@@ -1,6 +1,6 @@
 import { useTrackEvent } from "@fiftyone/analytics";
 import { Toast, useTheme } from "@fiftyone/components";
-import { OPTIMIZING_QUERY_PERFORMANCE, SUMMARY_FIELDS } from "@fiftyone/core";
+import { OPTIMIZING_QUERY_PERFORMANCE, SUMMARY_FIELDS } from "../utils/links";
 import { getBrowserStorageEffectForKey } from "@fiftyone/state";
 import { Bolt } from "@mui/icons-material";
 import { Box, Button, Typography } from "@mui/material";

--- a/app/packages/core/src/components/Sidebar/Entries/QueryPerformanceIcon.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/QueryPerformanceIcon.tsx
@@ -1,5 +1,5 @@
 import { useTheme } from "@fiftyone/components";
-import { OPTIMIZING_QUERY_PERFORMANCE } from "@fiftyone/core";
+import { OPTIMIZING_QUERY_PERFORMANCE } from "../../../utils/links";
 import { getBrowserStorageEffectForKey } from "@fiftyone/state";
 import { Bolt } from "@mui/icons-material";
 import { Box, Button, Tooltip } from "@mui/material";

--- a/app/packages/core/src/components/Sidebar/ViewSelection/index.tsx
+++ b/app/packages/core/src/components/Sidebar/ViewSelection/index.tsx
@@ -1,6 +1,6 @@
 import { useTrackEvent } from "@fiftyone/analytics";
 import { Selection } from "@fiftyone/components";
-import { useRefetchableSavedViews } from "@fiftyone/core";
+import { default as useRefetchableSavedViews } from "../../../hooks/useRefetchableSavedViews";
 import * as fos from "@fiftyone/state";
 import React, { Suspense, useEffect, useMemo } from "react";
 import {


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link.

## 📋 What changes are proposed in this pull request?

Breaks a circular dependency inside the `@fiftyone/core` package. Three component files imported from the package root barrel (`@fiftyone/core`), which re-exports `./components`, forming a cycle (`components/index.ts → Dataset → SamplesContainer → Sidebar/... → @fiftyone/core → ./components`). Rollup flagged this as it forces the `components` barrel and `Dataset` into mutually-dependent chunks.

Fix: repoint those three imports at their source modules (`utils/links`, `hooks/useRefetchableSavedViews`). Import-path only — no behavior change.

## 🧪 How is this patch tested? If it is not, please explain why.

Build-time/import-path change with no runtime behavior change; existing unit tests cover the affected components. Full bundle rebuild to confirm the Rollup circular-dependency warning is cleared is best verified in CI.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

N/A

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated internal link and helper imports to use local modules instead of a shared core package.
  * Adjusted the saved-views hook import source to match local module exports.
  * No changes to UI behavior or user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2931
<!-- enterprise-sync-pr:end -->