### PR TITLE
fix(app): hoist redundant dynamic imports in DashboardView

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/DashboardView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/DashboardView.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect } from "react";
-import { useTheme } from "@fiftyone/components";
+import { ThemeProvider, useTheme } from "@fiftyone/components";
+import { createRoot } from "react-dom/client";
+import { RecoilRoot } from "recoil";
 import usePanelEvent from "@fiftyone/operators/src/usePanelEvent";
 import { usePanelId, usePanelState } from "@fiftyone/spaces";
 import useNotification from "@fiftyone/state/src/hooks/useNotification";
@@ -1304,9 +1306,6 @@ export default function DashboardView(props: ViewPropsType) {
       document.body.appendChild(exportContainer);
 
       // Create a React root and render the PNG export component
-      const { createRoot } = await import("react-dom/client");
-      const { RecoilRoot } = await import("recoil");
-      const { ThemeProvider } = await import("@fiftyone/components");
       const root = createRoot(exportContainer);
 
       // Render the PNG export component with necessary providers


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link.

## 📋 What changes are proposed in this pull request?

Hoists three redundant dynamic imports in `DashboardView.tsx`. The `onExportAsPNG` callback dynamically imported `recoil`, `react-dom/client`, and `@fiftyone/components`, all of which are statically imported throughout the app (`recoil` in 400+ files; `@fiftyone/components` already statically imported at the top of this same file). The dynamic imports yielded no code-splitting benefit and tripped Rollup's "dynamically imported but also statically imported" warning, forcing awkward chunking.

Fix: hoist them to static top-level imports. `html2canvas` stays dynamic since it is genuinely lazy-loaded only for PNG export.

## 🧪 How is this patch tested? If it is not, please explain why.

Import-style change with no runtime behavior change — the PNG export callback renders the same providers/component as before. Full bundle rebuild to confirm the Rollup warning is cleared is best verified in CI.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

N/A

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized dependency loading in dashboard export functionality through import reorganization.

---

**Note:** This release includes internal code improvements with no visible changes to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2897
<!-- enterprise-sync-pr:end -->