### PR TITLE
perf(components): use syntax-highlighter Light build in CodeBlock

### DIFF
--- a/app/packages/components/src/components/CodeBlock/index.tsx
+++ b/app/packages/components/src/components/CodeBlock/index.tsx
@@ -1,14 +1,32 @@
 import { CopyButton } from "@fiftyone/components";
 import { Box, useColorScheme } from "@mui/material";
 import React from "react";
-import SyntaxHighlighter from "react-syntax-highlighter";
-import {
-  a11yDark,
-  a11yLight,
-} from "react-syntax-highlighter/dist/esm/styles/hljs";
+// Use the `Light` build and register only the languages we render. The default
+// `react-syntax-highlighter` export bundles all ~190 hljs languages (~1.4MB) onto
+// the eager critical path; this keeps it to the handful we actually use.
+import { Light as SyntaxHighlighter } from "react-syntax-highlighter";
+import bash from "react-syntax-highlighter/dist/esm/languages/hljs/bash";
+import javascript from "react-syntax-highlighter/dist/esm/languages/hljs/javascript";
+import json from "react-syntax-highlighter/dist/esm/languages/hljs/json";
+import python from "react-syntax-highlighter/dist/esm/languages/hljs/python";
+import typescript from "react-syntax-highlighter/dist/esm/languages/hljs/typescript";
+import yaml from "react-syntax-highlighter/dist/esm/languages/hljs/yaml";
+import a11yDark from "react-syntax-highlighter/dist/esm/styles/hljs/a11y-dark";
+import a11yLight from "react-syntax-highlighter/dist/esm/styles/hljs/a11y-light";
 import { scrollable } from "../../scrollable.module.css";
 
-export default function CodeBlock({ text, ...props }: CodeBlockProps) {
+SyntaxHighlighter.registerLanguage("bash", bash);
+SyntaxHighlighter.registerLanguage("javascript", javascript);
+SyntaxHighlighter.registerLanguage("json", json);
+SyntaxHighlighter.registerLanguage("python", python);
+SyntaxHighlighter.registerLanguage("typescript", typescript);
+SyntaxHighlighter.registerLanguage("yaml", yaml);
+
+export default function CodeBlock({
+  text,
+  language,
+  ...props
+}: CodeBlockProps) {
   const { mode } = useColorScheme();
 
   return (
@@ -42,7 +60,7 @@ export default function CodeBlock({ text, ...props }: CodeBlockProps) {
       <SyntaxHighlighter
         showLineNumbers
         className={scrollable}
-        language="Python"
+        language={(language ?? "python").toLowerCase()}
         customStyle={{ margin: 0, lineHeight: 1.75 }}
         style={mode === "dark" ? a11yDark : a11yLight}
         {...props}


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

`CodeBlock` imported the default `react-syntax-highlighter` export, which bundles **all ~190 hljs languages (~1.4 MB raw)** onto the eager critical path. Switched to the `Light` build and registered only the languages we actually render (bash, javascript, json, python, typescript, yaml) — the same pattern `Markdown` already uses. The default language is lowercased so existing callers (e.g. `"Python"`) keep highlighting.

This trims the eager bundle in prod **and** the dev module graph (190 fewer modules Vite has to transform/serve), so it helps every developer's startup/reload too.

## 🧪 How is this patch tested? If it is not, please explain why.

- `yarn workspace @fiftyone/app build-bare` succeeds.
- Verified the full hljs language set is gone from the entry chunk (obscure langs like `x86asm`/`pgsql` no longer present) while the registered languages remain.
- Entry chunk: **4219 → 3947 KB gz (−272 KB)**.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes.

N/A

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2916
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CodeBlock component now supports specifying programming languages (bash, javascript, json, python, typescript, yaml) via a `language` prop.

* **Performance**
  * Optimized syntax highlighter to use a lightweight build with only essential language support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->