### PR TITLE
perf(core): drop moment for luxon in the file explorer

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/FileExplorerView/FileTable.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/FileExplorerView/FileTable.tsx
@@ -12,7 +12,7 @@ import {
 import { Button } from "@fiftyone/components";
 import FolderIcon from "@mui/icons-material/Folder";
 import InsertDriveFileIcon from "@mui/icons-material/InsertDriveFile";
-import moment from "moment";
+import { DateTime } from "luxon";
 import { scrollable } from "@fiftyone/components";
 import { humanReadableBytes } from "@fiftyone/utilities";
 
@@ -94,7 +94,10 @@ function FileTable({
                 </Box>
               </TableCell>
               <TableCell>
-                {file.date_modified && moment(file.date_modified).fromNow()}
+                {file.date_modified &&
+                  DateTime.fromJSDate(
+                    new Date(file.date_modified)
+                  ).toRelative()}
               </TableCell>
               <TableCell>{humanReadableBytes(file.size)}</TableCell>
             </TableRow>

--- a/app/packages/plugins/package.json
+++ b/app/packages/plugins/package.json
@@ -24,8 +24,5 @@
         "jest": "^29.7.0",
         "prettier": "2.2.1",
         "vite": "^7.3.2"
-    },
-    "dependencies": {
-        "moment": "^2.29.4"
     }
 }

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -3526,7 +3526,6 @@ __metadata:
     "@babel/preset-typescript": "npm:^7.17.12"
     "@fiftyone/utilities": "workspace:^"
     jest: "npm:^29.7.0"
-    moment: "npm:^2.29.4"
     prettier: "npm:2.2.1"
     vite: "npm:^7.3.2"
   languageName: unknown
@@ -17644,13 +17643,6 @@ __metadata:
     pkg-types: "npm:^1.3.1"
     ufo: "npm:^1.6.1"
   checksum: 10/4db690a421076d5fe88331679f702b77a4bfc9fe3f324bc6150270fb0b69ecd4b5e43570b8e4573dde341515b3eac4daa720a6ac9f2715c210b670852641ab1c
-  languageName: node
-  linkType: hard
-
-"moment@npm:^2.29.4":
-  version: 2.30.1
-  resolution: "moment@npm:2.30.1"
-  checksum: 10/ae42d876d4ec831ef66110bdc302c0657c664991e45cf2afffc4b0f6cd6d251dde11375c982a5c0564ccc0fa593fc564576ddceb8c8845e87c15f58aa6baca69
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

`FileTable` (file explorer) was the **only** user of `moment` — a single relative-time call. Migrated it to `luxon` (already a dependency) via `DateTime.fromJSDate(...).toRelative()`, and removed `moment` from `plugins/package.json` and the lockfile so it's no longer installed or bundled.

Removes a whole date library (~150 KB raw) from the eager graph — also one fewer dependency for Vite to pre-bundle on dev startup.

## 🧪 How is this patch tested? If it is not, please explain why.

- `yarn workspace @fiftyone/app build-bare` succeeds with `moment` fully uninstalled.
- Verified no `moment` internals remain in any chunk, and no remaining `moment` imports app-wide.
- Relative time still renders ("3 hours ago") via luxon's `toRelative()`.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes.

N/A

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [x] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the file modification date display logic in the file explorer component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2898
<!-- enterprise-sync-pr:end -->