### PR TITLE
FOEPD-4007 Panel Opening Behavior

### DIFF
--- a/app/packages/spaces/src/SpaceTree.test.ts
+++ b/app/packages/spaces/src/SpaceTree.test.ts
@@ -173,6 +173,48 @@ describe("SpaceTree", () => {
     expect(nodeC.isActive()).toBe(true);
   });
 
+  it("clears sizes on the space container when joinNode collapses a split", () => {
+    const tree = new SpaceTree();
+    const panelA = new SpaceNode();
+    panelA.type = "panel_a";
+    const panelB = new SpaceNode();
+    panelB.type = "panel_b";
+    tree.addNodeAfter(tree.root, panelA);
+    tree.addNodeAfter(tree.root, panelB);
+    tree.splitLayout(tree.root, Layout.Horizontal);
+    tree.setNodeSizes(tree.root, [0.9, 0.1]);
+    expect(tree.root.sizes).toEqual([0.9, 0.1]);
+
+    // Simulate the tab-drag collapse path: the panel container for the
+    // right pane becomes empty and joinNode is called directly (no removeNode)
+    const rightPaneContainer = tree.root.children[1];
+    rightPaneContainer.remove();
+    tree.joinNode(tree.root);
+
+    expect(tree.root.sizes).toBeUndefined();
+    expect(tree.root.isSpaceContainer()).toBe(false);
+  });
+
+  it("clears sizes on the space container when a panel is closed via removeNode", () => {
+    const tree = new SpaceTree();
+    const panelA = new SpaceNode();
+    panelA.type = "panel_a";
+    const panelB = new SpaceNode();
+    panelB.type = "panel_b";
+    tree.addNodeAfter(tree.root, panelA);
+    tree.addNodeAfter(tree.root, panelB);
+    tree.splitLayout(tree.root, Layout.Horizontal);
+    tree.setNodeSizes(tree.root, [0.9, 0.1]);
+    expect(tree.root.sizes).toEqual([0.9, 0.1]);
+
+    // Close the panel in the right pane via the X button path
+    const rightPanel = tree.root.children[1].children[0];
+    tree.removeNode(rightPanel);
+
+    expect(tree.root.sizes).toBeUndefined();
+    expect(tree.root.isSpaceContainer()).toBe(false);
+  });
+
   it("splits a provided node in a panel container into separate space", () => {
     const tree = new SpaceTree();
     const nodeA = new SpaceNode();

--- a/app/packages/spaces/src/SpaceTree.ts
+++ b/app/packages/spaces/src/SpaceTree.ts
@@ -57,6 +57,7 @@ export default class SpaceTree {
       node.activeChild = node.firstChild().activeChild;
       node.layout = node.firstChild().layout;
       node.firstChild().remove();
+      node.sizes = undefined;
       this.updateTree(node);
     }
   }
@@ -66,7 +67,6 @@ export default class SpaceTree {
     let ancestorNode = parentNode;
     if (parentNode?.parent && parentNode?.children.length === 1) {
       ancestorNode = parentNode?.parent;
-      ancestorNode.sizes = undefined;
       parentNode?.remove();
       this.joinNode(ancestorNode);
     } else if (ancestorNode) {


### PR DESCRIPTION

## 🔗 Related Issues
https://voxel51.atlassian.net/browse/FOEPD-4007?search_id=97bd4ff8-4e75-4fd9-a928-e518814a6764

## 📋 What changes are proposed in this pull request?

🐞 **Bug**: opening or splitting a panel sometimes causes the panel to open with an unexpected split ratio.
🔧 **Fix**: When the last tab in a panel is dragged into another panel, both panels collapse into a single parent. The bug is caused by `sizes` values not being cleared when the panels are merged into a single one. Splitting the panel again causes the new panel to respect the stale values and not start at 50/50 as expected. The fix is to clear the stale `sizes` attribute when panels are merged.

This PR fixes the bug and adds two tests to avoid future regressions.

## 🧪 How is this patch tested? If it is not, please explain why.
1. Add a new panel and split the view.
2. Drag the divider and set the split ratio to something like 90%/10%. This will set and store the `sizes` array to `[90, 10]`
3. Drag the small tab into the large tab to merge the two panels into one.
4. Add another tab and split the panels again.
5. **Result** panels should open at 50%/50% as expected instead of 90%/10%

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

- Fix: resolved issue where new panels sometimes open at strange positions 

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test cases validating space container state transitions during panel collapse and closure scenarios.

* **Bug Fixes**
  * Enhanced space container cleanup and state consistency when collapsing containers and removing panels from the workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2899
<!-- enterprise-sync-pr:end -->