### PR TITLE
perf(server): gzip static app assets (uncompressed today)

### DIFF
--- a/fiftyone/server/app.py
+++ b/fiftyone/server/app.py
@@ -24,6 +24,7 @@ from starlette.middleware.base import (
     RequestResponseEndpoint,
 )
 from starlette.middleware.cors import CORSMiddleware
+from starlette.middleware.gzip import GZipMiddleware
 from starlette.requests import Request
 from starlette.responses import FileResponse, RedirectResponse, Response
 from starlette.routing import Mount, Route
@@ -207,20 +208,33 @@ app = Starlette(
         ),
         Mount(
             "/plugins",
-            app=Static(
-                directory=fo.config.plugins_dir,
-                html=True,
-                check_dir=False,
-                follow_symlink=True,
+            # gzip the static app/plugin assets (JS/CSS/HTML/wasm). Scoped to
+            # these mounts rather than app-wide so media (/media, range
+            # requests) and GraphQL responses are left untouched.
+            app=GZipMiddleware(
+                Static(
+                    directory=fo.config.plugins_dir,
+                    html=True,
+                    check_dir=False,
+                    follow_symlink=True,
+                ),
+                minimum_size=860,
+                compresslevel=6,
             ),
             name="plugins",
         ),
         Mount(
             "/",
-            app=Static(
-                directory=os.path.join(os.path.dirname(__file__), "static"),
-                html=True,
-                follow_symlink=True,
+            app=GZipMiddleware(
+                Static(
+                    directory=os.path.join(
+                        os.path.dirname(__file__), "static"
+                    ),
+                    html=True,
+                    follow_symlink=True,
+                ),
+                minimum_size=860,
+                compresslevel=6,
             ),
             name="static",
         ),


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

The server served the built app bundle **uncompressed**, so any deployment hitting the fiftyone server directly (OSS, notebooks, self-hosted) downloads the full raw JS/CSS on first paint (~15 MB today). There's no compressing proxy in the repo.

Wrap the `/plugins` and `/` static mounts in Starlette's `GZipMiddleware`. Scoped to those mounts (not app-wide) on purpose, so `/media` (and its range requests) and `/graphql` responses are left untouched — gzipping already-compressed media is wasteful and conflicts with range serving.

On the wire the entry chunk drops to ~30% of its size, which is the single biggest first-paint lever for direct-served deployments (Lighthouse simulates first paint largely as bytes ÷ bandwidth).

Follow-up worth considering for high-traffic servers: ship **pre-compressed** brotli/gzip assets at build time and serve them, avoiding per-request compression CPU.

## 🧪 How is this patch tested? If it is not, please explain why.

Verified with Starlette `TestClient` against the real built static dir (Starlette 0.52):
- Entry chunk **15.5 MB raw → 4.4 MB on the wire**, `content-encoding: gzip`.
- Request without `Accept-Encoding` → served uncompressed.
- A sibling `/media`-style route → **not** compressed (confirms the scoping; range/media serving is unaffected).

The change is a pure ASGI wrap of the existing `Static` app, so SPA routing/`get_response` behavior is unchanged.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No.
-   [x] Yes.

The App now serves its static assets gzip-compressed, significantly reducing initial load time for deployments served directly by the FiftyOne server.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
