### PR TITLE
PERF: Panel Loading State

### DIFF
--- a/app/packages/spaces/src/hooks.ts
+++ b/app/packages/spaces/src/hooks.ts
@@ -238,6 +238,9 @@ export function usePanelLoading(
         // Dedupe: returning the same reference skips the Recoil write and
         // avoids re-rendering every subscriber when the value is unchanged.
         if (panelsLoading.get(finalId) === loading) return panelsLoading;
+        // Also skip writing `false` for a key that doesn't exist yet — a
+        // missing entry already reads as false
+        if (!loading && !panelsLoading.has(finalId)) return panelsLoading;
         const updatedPanelsLoading = new Map(panelsLoading);
         updatedPanelsLoading.set(finalId, loading);
         return updatedPanelsLoading;

--- a/app/packages/spaces/src/hooks.ts
+++ b/app/packages/spaces/src/hooks.ts
@@ -28,6 +28,7 @@ import {
   currentPanelAreasRenderer,
   panelAreaRenderers,
   panelIdToScopeAtom,
+  panelLoadingSelector,
   panelStatePartialSelector,
   panelStateSelector,
   panelTitlesState,
@@ -223,18 +224,22 @@ export function usePanelLoading(
   id?: string
 ): [boolean, (loading: boolean, id?: string) => void] {
   const panelContext = useContext(PanelContext);
-  const [panelsLoadingState, setPanelsLoadingState] = useRecoilState(
-    panelsLoadingStateAtom
-  );
-
   const panelId = (id || panelContext?.node?.id) as string;
-  const panelLoading = Boolean(panelsLoadingState.get(panelId));
+
+  // Subscribe only to this panel's loading state so flips on other panels
+  // don't re-render this consumer.
+  const panelLoading = useRecoilValue(panelLoadingSelector(panelId));
+  const setPanelsLoadingState = useSetRecoilState(panelsLoadingStateAtom);
 
   const setPanelLoading = useCallback(
-    (loading: boolean, id?: string) => {
+    (loading: boolean, targetId?: string) => {
       setPanelsLoadingState((panelsLoading) => {
+        const finalId = targetId || panelId;
+        // Dedupe: returning the same reference skips the Recoil write and
+        // avoids re-rendering every subscriber when the value is unchanged.
+        if (panelsLoading.get(finalId) === loading) return panelsLoading;
         const updatedPanelsLoading = new Map(panelsLoading);
-        updatedPanelsLoading.set(id || panelId, loading);
+        updatedPanelsLoading.set(finalId, loading);
         return updatedPanelsLoading;
       });
     },

--- a/app/packages/spaces/src/state.ts
+++ b/app/packages/spaces/src/state.ts
@@ -48,6 +48,14 @@ export const panelsLoadingStateAtom = atom({
   default: new Map<string, boolean>(),
 });
 
+export const panelLoadingSelector = selectorFamily<boolean, string>({
+  key: "panelLoadingSelector",
+  get:
+    (panelId: string) =>
+    ({ get }) =>
+      Boolean(get(panelsLoadingStateAtom).get(panelId)),
+});
+
 export const panelsStateAtom = atom({
   key: "panelsState",
   default: new Map(),


### PR DESCRIPTION

## 🔗 Related Issues

No related issues to Link

## 📋 What changes are proposed in this pull request?

🐞 Issue: adding a new tab in a split panel results in **84** `CustomPanel` rerenders and **77** Grid context-cascade rerenders. The `panelsLoadingState` atom tracks an internal map that recoil sets as 'dirty' after every single redundant/duplicate map state update. This notifies all subscribers to rerender after every duplicate state change. 

🔧 Fix: add a dedupe guard in `usePanelLoading` such that it doesn't unnecessarily write state. Also, `usePanelLoading` subscribes to the entire map in the atom even though it only cares about **one** loading state. I added a `selectorFamily` to prevent panels from rerendering when _other_ panels' loading state changes. 

🎉 Result: Adding `Similarity Search` tab to a split panel used to result in **160** writes to the `panelsLoadingStateAtom` which resulted in **84** `CustomPanel` rerenders and **77** Grid context-cascade rerenders. After these changes, this action results in **7** writes to the atom and **~4 total rerenders of CustomPanel and Grid**, **95% reduction in waste**

## 🧪 How is this patch tested? If it is not, please explain why.

1. Create a split panel
2. Add `Similarity Search` tab to the new panel.
3. Observe total number of rerenders of the `CustomPanel` and `Grid` components. It should be roughly 4 down from 77-84

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2902
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized panel loading state tracking to reduce unnecessary component re-renders and improve application responsiveness when managing multiple panels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->