### PR TITLE
ci: push back-merge branch as voxel51-bot

### DIFF
--- a/.github/workflows/develop-back-merge.yml
+++ b/.github/workflows/develop-back-merge.yml
@@ -18,6 +18,8 @@ jobs:
         with:
           ref: develop
           fetch-depth: 0
+          # Push as voxel51-bot, which can bypass the merge/* branch ruleset.
+          token: ${{ secrets.FIFTYONE_GITHUB_TOKEN }}
       - run: |
           git config user.name 'voxel51-bot'
           git config user.email 'bot@voxel51.com'


### PR DESCRIPTION
## What

The `Develop Back-Merge` workflow fails at the `git push` step (e.g. [this run](https://github.com/voxel51/fiftyone/actions/runs/27630618881/job/81704308949)):

```
remote: error: GH013: Repository rule violations found for refs/heads/merge/...
- Cannot create ref due to creations being restricted.
```

## Why

The checkout step uses the default `GITHUB_TOKEN` (`github-actions[bot]`), so the `git push` authenticates as that app — which is **not** on the `Protect Merge Branches` ruleset bypass list. (`git config user.name 'voxel51-bot'` only sets commit authorship, not push auth.)

## Fix

`voxel51-bot` is already a bypass actor, so pass its PAT (`FIFTYONE_GITHUB_TOKEN`) to `actions/checkout`. The push then authenticates as `voxel51-bot`, consistent with the `create-pull-request` step that already uses the same token.

Targeting `main` so the fix is in place for the `main` → `develop` back-merge — a push to `main` runs the workflow file as it exists on `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD automation by explicitly configuring the checkout token used during the develop back-merge workflow, enabling the workflow to perform required push operations while complying with the intended branch rules behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2903
<!-- enterprise-sync-pr:end -->