### PR TITLE
Add export for sub-components in failover

### DIFF
--- a/app/packages/core/src/components/DatasetGridRendererFailover.tsx
+++ b/app/packages/core/src/components/DatasetGridRendererFailover.tsx
@@ -11,7 +11,7 @@ import { useRecoilValue } from "recoil";
  * Forces dataset pages onto a fresh FiftyOne subscription after a renderer
  * crash so the rest of the session uses a clean backend-synced state channel.
  */
-const DatasetGridRendererFailoverReload = () => {
+export const DatasetGridRendererFailoverReload = () => {
   const currentSubscription = useRecoilValue(fos.stateSubscription);
   const { forcedSubscription, hasAnyFailures } =
     fos.useGridCustomRendererFailover();
@@ -37,7 +37,7 @@ const DatasetGridRendererFailoverReload = () => {
 };
 
 /** Banner shown when the session has been switched to the built-in grid renderer. */
-const DatasetGridRendererFailoverBanner = () => {
+export const DatasetGridRendererFailoverBanner = () => {
   const currentDatasetName = useRecoilValue(fos.datasetName);
   const gridRendererFailover =
     fos.useGridCustomRendererFailover(currentDatasetName);


### PR DESCRIPTION
Export sub-components, too (means something in enterprise)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Made internal failover UI components available for broader usage within the application architecture, enabling better code reusability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->