### PR TITLE
[FOEPD-3956] Rename `drop_orphan_temporal_tags` utility method

### DIFF
--- a/fiftyone/core/odm/__init__.py
+++ b/fiftyone/core/odm/__init__.py
@@ -46,7 +46,7 @@ from .database import (
     drop_orphan_runs,
     drop_orphan_delegated_ops,
     drop_orphan_stores,
-    drop_orphan_temporal_tags,
+    drop_orphan_tags,
     list_collections,
     get_collection_stats,
     get_indexed_values,

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -1447,11 +1447,9 @@ def delete_dataset(name, dry_run=False):
             conn.drop_collection(frame_collection_name)
 
     _id = dataset_dict["_id"]
-    num_temporal_tags = fommtt.count_for_dataset_id(_id)
-    if num_temporal_tags > 0:
-        _logger.info(
-            "Deleting %d multimodal temporal tag(s)", num_temporal_tags
-        )
+    num_tags = fommtt.count_for_dataset_id(_id)
+    if num_tags > 0:
+        _logger.info("Deleting %d tag(s)", num_tags)
         if not dry_run:
             fommtt.delete_for_dataset_id(_id)
 

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -836,11 +836,11 @@ def drop_orphan_stores(dry_run=False):
             _delete_stores(conn, orphan_store_ids)
 
 
-def drop_orphan_temporal_tags(dry_run=False):
-    """Drops all orphan multimodal temporal tags from the database.
+def drop_orphan_tags(dry_run=False):
+    """Drops all orphan tags from the database.
 
-    Orphan temporal tags are those that are associated with a dataset that no
-    longer exists in the database.
+    Orphan tags are those that are associated with a dataset that no longer
+    exists in the database.
 
     Args:
         dry_run (False): whether to log the actions that would be taken but not
@@ -851,13 +851,12 @@ def drop_orphan_temporal_tags(dry_run=False):
 
     dataset_ids = set(conn.datasets.distinct("_id"))
     orphan_dataset_ids = fommtt.get_orphan_dataset_ids(dataset_ids)
-    num_temporal_tags = fommtt.count_for_dataset_ids(orphan_dataset_ids)
+    num_tags = fommtt.count_for_dataset_ids(orphan_dataset_ids)
 
-    if num_temporal_tags:
+    if num_tags:
         _logger.info(
-            "Deleting %d orphan multimodal temporal tag(s) for %d "
-            "dataset(s): %s",
-            num_temporal_tags,
+            "Deleting %d orphan tag(s) for %d dataset(s): %s",
+            num_tags,
             len(orphan_dataset_ids),
             orphan_dataset_ids,
         )

--- a/tests/unittests/multimodal/temporal_tags_tests.py
+++ b/tests/unittests/multimodal/temporal_tags_tests.py
@@ -1164,7 +1164,7 @@ class TemporalTagTests(unittest.TestCase):
 
     @drop_tags
     @drop_datasets
-    def test_drop_orphan_temporal_tags(self):
+    def test_drop_orphan_tags(self):
         orphan_dataset, orphan_sample_ids = _make_dataset(1)
         active_dataset, active_sample_ids = _make_dataset(1)
         orphan_sample_collection_name = orphan_dataset._sample_collection_name
@@ -1200,12 +1200,12 @@ class TemporalTagTests(unittest.TestCase):
         active_dataset_id = active_dataset._doc.id
         foo.get_db_conn().datasets.delete_one({"_id": orphan_dataset_id})
 
-        foo.drop_orphan_temporal_tags(dry_run=True)
+        foo.drop_orphan_tags(dry_run=True)
 
         self.assertEqual(_temporal_tag_count(orphan_dataset_id), 1)
         self.assertEqual(_temporal_tag_count(active_dataset_id), 1)
 
-        foo.drop_orphan_temporal_tags()
+        foo.drop_orphan_tags()
 
         self.assertEqual(_temporal_tag_count(orphan_dataset_id), 0)
         self.assertEqual(_temporal_tag_count(active_dataset_id), 1)


### PR DESCRIPTION
## 🔗 Related Issues

[FOEPD-3956](https://voxel51.atlassian.net/browse/FOEPD-3956)

## 📋 What changes are proposed in this pull request?

- Renames `drop_orphan_temporal_tags` to `drop_orphan_tags`, updates its docstring and internal var names
- Renames an internal var in `fiftyone/core/odm/database.py`'s `delete_dataset`

## 🧪 How is this patch tested? If it is not, please explain why.

Unit tests

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [x] Other

[FOEPD-3956]: https://voxel51.atlassian.net/browse/FOEPD-3956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed orphan tag cleanup functionality to provide a more generalized public API interface.
  * Updated logging messages for consistency across tag management operations.

* **Tests**
  * Updated unit tests to verify the renamed functionality works correctly and maintains expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2934
<!-- enterprise-sync-pr:end -->