### PR TITLE
fix: sam parity tests use fout instead of pil

### DIFF
--- a/tests/intensive/sam_parity_tests.py
+++ b/tests/intensive/sam_parity_tests.py
@@ -48,9 +48,11 @@ def _create_test_dataset(num_samples=5, seed=51):
 
 
 def _get_image_as_numpy(filepath):
-    from PIL import Image
+    # Match :meth:`SegmentAnythingImageGetItem` / ``fout._load_image`` (OpenCV),
+    # not PIL, so decoded pixels match ``apply_model``.
+    import fiftyone.utils.torch as fout
 
-    return np.array(Image.open(filepath).convert("RGB"))
+    return fout._load_image(filepath, use_numpy=True, force_rgb=True)
 
 
 def _get_image_as_pil(filepath):
@@ -67,7 +69,8 @@ def _auto_masks_to_detections(masks_list):
         det = Detection.from_mask(
             mask=m["segmentation"],
             label=PLACEHOLDER_LABEL,
-            confidence=m.get("stability_score", m.get("predicted_iou", 1.0)),
+            score=m["predicted_iou"],
+            stability=m["stability_score"],
         )
         dets.append(det)
     return Detections(detections=dets)


### PR DESCRIPTION
PIL and OpenCV can produce subtly different pixel values for the same image. Since `apply_model` for the SAM tests uses the latter, the the parity test's "ground truth" input should ideally match the image decoding method.

Separately, making confidence field mapping explicit (score/stability) instead of a fallback chain, ensuring the test's label comparison is exact rather than fragile.

## 🔗 Related Issues

`pytest tests/intensive/sam_parity_tests.py` were failing locally on develop (on both mac as well as linux), possibly due to specific versions of numpy/fiftyone that allow for the above mentioned mismatch.

## 📋 What changes are proposed in this pull request?

- Made the sam parity tests' ground truth use `fout._load_image` to mimic `apply_model`
- Made score and stability values in the detection explicit

## 🧪 How is this patch tested? If it is not, please explain why.

Locally running the pytest.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other (Testing only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SAM mask quality metrics handling to properly preserve predicted IOU and stability scores during detection conversion, ensuring consistency with FiftyOne's standard image processing pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2910
<!-- enterprise-sync-pr:end -->