### PR TITLE
Separate scene context config and panel context config; improve labels interpolation

### DIFF
--- a/app/packages/multimodal/src/adapters/mcap/react/Mcap3dTile.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/Mcap3dTile.tsx
@@ -8,6 +8,7 @@ import {
   PointCloudPanel,
   type PointCloudPanelLayer,
 } from "../../../visualization/panels/point-cloud";
+import { checkboxNoSpaceToggleProps } from "./mcap-settings-keyboard";
 import settingsStyles from "./McapTile.settings.module.css";
 import styles from "./McapTile.module.css";
 import { McapTileEmptyState, McapTileStatusBadge } from "./McapTileStreamState";
@@ -25,6 +26,9 @@ const TILE_TYPE_LABEL = "3D";
 const Mcap3dTile: React.FC = () => {
   const pointClouds = useSceneSourcesByType(MCAP_SOURCE_TYPE.POINT_CLOUD);
   const setTileTitle = useSetTileTitle();
+  // Start with every source enabled. This tile only mounts after the scene
+  // inventory is ready (the renderer gates on it), so `pointClouds` is already
+  // populated and the lazy initializer captures the full set once.
   const [enabled, setEnabled] = useState<ReadonlySet<string>>(
     () => new Set(pointClouds.map((s) => s.id))
   );
@@ -106,14 +110,29 @@ const Mcap3dTile: React.FC = () => {
             <Text variant={TextVariant.Xs} color={TextColor.Secondary}>
               Sources
             </Text>
-            {pointClouds.map((s) => (
-              <Checkbox
-                key={s.id}
-                label={s.label}
-                checked={enabled.has(s.id)}
-                onChange={(checked) => toggleSource(s.id, checked)}
-              />
-            ))}
+            {pointClouds.length > 0 ? (
+              <>
+                <div className={settingsStyles.metaText}>
+                  {selectedTopics.length.toLocaleString()} of{" "}
+                  {pointClouds.length.toLocaleString()} selected
+                </div>
+                <div className={settingsStyles.optionStack}>
+                  {pointClouds.map((s) => (
+                    <Checkbox
+                      key={s.id}
+                      label={labelWithCount(s.label, s.recordCount)}
+                      checked={enabled.has(s.id)}
+                      onChange={(checked) => toggleSource(s.id, checked)}
+                      {...checkboxNoSpaceToggleProps}
+                    />
+                  ))}
+                </div>
+              </>
+            ) : (
+              <span className={settingsStyles.emptyText}>
+                No 3D sources available
+              </span>
+            )}
           </div>
         </div>
       </TileSettingsContent>
@@ -132,5 +151,9 @@ const Mcap3dTile: React.FC = () => {
     </>
   );
 };
+
+function labelWithCount(label: string, count: number | undefined): string {
+  return count ? `${label} (${count.toLocaleString()})` : label;
+}
 
 export default Mcap3dTile;

--- a/app/packages/multimodal/src/adapters/mcap/react/Mcap3dTile.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/Mcap3dTile.tsx
@@ -69,8 +69,7 @@ const Mcap3dTile: React.FC = () => {
   );
   const frames = useMcapTopicStreams<PointCloudVisualization>(selectedTopics);
 
-  // Keep the tile title in sync: a single selection reads as that source,
-  // anything else as the generic tile kind.
+  // This effect syncs the tile title with the current 3D source selection.
   useEffect(() => {
     const label =
       selectedTopics.length === 1

--- a/app/packages/multimodal/src/adapters/mcap/react/Mcap3dTile.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/Mcap3dTile.tsx
@@ -152,7 +152,7 @@ const Mcap3dTile: React.FC = () => {
 };
 
 function labelWithCount(label: string, count: number | undefined): string {
-  return count ? `${label} (${count.toLocaleString()})` : label;
+  return count !== undefined ? `${label} (${count.toLocaleString()})` : label;
 }
 
 export default Mcap3dTile;

--- a/app/packages/multimodal/src/adapters/mcap/react/McapImageAnnotationOverlay.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapImageAnnotationOverlay.tsx
@@ -33,6 +33,7 @@ const McapImageAnnotationOverlay: React.FC<McapImageAnnotationOverlayProps> = ({
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
   const topicKey = topics.join("\0");
 
+  // This effect clears the selected primitive when annotation topics change.
   useEffect(() => {
     setSelectedKey(null);
   }, [topicKey]);

--- a/app/packages/multimodal/src/adapters/mcap/react/McapImageAnnotationOverlay.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapImageAnnotationOverlay.tsx
@@ -5,39 +5,42 @@ import {
   ImageAnnotationsOverlay,
   type ImageAnnotationPickedPrimitive,
 } from "../../../visualization/panels/ImageAnnotationsOverlay";
-import { useInterpolatedImageAnnotations } from "./use-interpolated-image-annotations";
+import { useInterpolatedImageAnnotationSets } from "./use-interpolated-image-annotations";
 
 export interface McapImageAnnotationOverlayProps {
-  readonly topic: string;
   readonly imageWidth: number;
   readonly imageHeight: number;
   readonly fit?: "contain" | "cover";
   readonly interpolate?: boolean;
+  readonly topics: readonly string[];
 }
 
 /**
- * Subscribes to one MCAP image-annotations topic and overlays its decoded
- * primitives on top of the surrounding image panel. Mounting subscribes;
- * unmounting drops the subscription, so the image tile's settings toggle
- * is just a render gate.
+ * Subscribes to selected MCAP image-annotations topics and overlays their
+ * decoded primitives on top of the surrounding image panel.
  */
 const McapImageAnnotationOverlay: React.FC<McapImageAnnotationOverlayProps> = ({
-  topic,
   imageWidth,
   imageHeight,
   fit = "contain",
   interpolate = true,
+  topics,
 }) => {
-  const frame = useInterpolatedImageAnnotations(topic, { interpolate });
+  const annotationSets = useInterpolatedImageAnnotationSets(topics, {
+    interpolate,
+  });
   const setSelection = useSetTileSelection();
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const topicKey = topics.join("\0");
 
   useEffect(() => {
     setSelectedKey(null);
-  }, [topic]);
+  }, [topicKey]);
 
   const handleSelect = useCallback(
     (picked: ImageAnnotationPickedPrimitive) => {
+      const topic = annotationSets[picked.setIndex]?.topic;
+      if (!topic) return;
       setSelectedKey(picked.key);
       setSelection({
         kind: "image-annotation",
@@ -49,13 +52,13 @@ const McapImageAnnotationOverlay: React.FC<McapImageAnnotationOverlayProps> = ({
         data: picked.primitive.value,
       });
     },
-    [setSelection, topic]
+    [annotationSets, setSelection]
   );
 
-  if (!frame) return null;
+  if (annotationSets.length === 0) return null;
   return (
     <ImageAnnotationsOverlay
-      annotations={[frame]}
+      annotations={annotationSets.map((set) => set.frame)}
       imageWidth={imageWidth}
       imageHeight={imageHeight}
       fit={fit}

--- a/app/packages/multimodal/src/adapters/mcap/react/McapImageTile.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapImageTile.tsx
@@ -15,6 +15,8 @@ import { useSceneSourcesByType } from "../../../scene-inventory";
 import { MCAP_SOURCE_TYPE } from "../scene-sources";
 import { chooseAnnotationTopic } from "../topic-matching";
 import { ImagePanel } from "../../../visualization/panels/image";
+import { useMcapModalSettings } from "./mcap-modal-settings";
+import { checkboxNoSpaceToggleProps } from "./mcap-settings-keyboard";
 import McapImageAnnotationOverlay from "./McapImageAnnotationOverlay";
 import { rankImageSources } from "./playback-layout";
 import settingsStyles from "./McapTile.settings.module.css";
@@ -28,11 +30,12 @@ const McapImageTile: React.FC<McapTileProps> = ({ initialSourceId }) => {
     width: number;
     height: number;
   } | null>(null);
-  const [interpolateAnnotations, setInterpolateAnnotations] = useState(true);
   const images = useSceneSourcesByType(MCAP_SOURCE_TYPE.IMAGE);
   const annotationSources = useSceneSourcesByType(
     MCAP_SOURCE_TYPE.IMAGE_ANNOTATION
   );
+  const { imageLabelTopics, interpolate2dAnnotations, setImageLabelTopics } =
+    useMcapModalSettings();
   const setTileTitle = useSetTileTitle();
   // Open on the resolver-assigned source; tiles added by hand bind the
   // densest stream instead of whatever happens to be first in the file.
@@ -62,21 +65,43 @@ const McapImageTile: React.FC<McapTileProps> = ({ initialSourceId }) => {
   }, [topic]);
 
   const frame = useMcapTopicStream<EncodedImageVisualization>(topic);
-  // Pair the image with the annotation stream that actually exists in
-  // the scene — exact `<prefix>/annotations` sibling first, fuzzy token
-  // match otherwise — instead of guessing a topic by convention.
-  const annotationTopic = useMemo(
-    () =>
-      topic
-        ? chooseAnnotationTopic(
-            topic,
-            annotationSources.map((s) => s.id)
-          )
-        : null,
-    [topic, annotationSources]
+  const annotationTopics = useMemo(
+    () => annotationSources.map((s) => s.id),
+    [annotationSources]
+  );
+  const inferredAnnotationTopic = useMemo(
+    () => (topic ? chooseAnnotationTopic(topic, annotationTopics) : null),
+    [topic, annotationTopics]
+  );
+  const selectedLabelTopics = useMemo(() => {
+    if (!topic) return [];
+    if (Object.hasOwn(imageLabelTopics, topic)) {
+      const available = new Set(annotationTopics);
+      return imageLabelTopics[topic].filter((labelTopic) =>
+        available.has(labelTopic)
+      );
+    }
+    return inferredAnnotationTopic ? [inferredAnnotationTopic] : [];
+  }, [annotationTopics, imageLabelTopics, inferredAnnotationTopic, topic]);
+  const activeTopics = useMemo(
+    () => (topic ? [topic, ...selectedLabelTopics] : []),
+    [selectedLabelTopics, topic]
   );
   const currentLabel =
     images.find((s) => s.id === topic)?.label ?? "Select source";
+  const toggleLabelTopic = (labelTopic: string, checked: boolean) => {
+    if (!topic) return;
+    const next = new Set(selectedLabelTopics);
+    if (checked) {
+      next.add(labelTopic);
+    } else {
+      next.delete(labelTopic);
+    }
+    setImageLabelTopics(
+      topic,
+      annotationTopics.filter((availableTopic) => next.has(availableTopic))
+    );
+  };
 
   return (
     <>
@@ -102,16 +127,31 @@ const McapImageTile: React.FC<McapTileProps> = ({ initialSourceId }) => {
                 </MenuTextItem>
               ))}
             </Dropdown>
+            <div className={settingsStyles.metaText}>
+              {sourceDetails(images.find((s) => s.id === topic))}
+            </div>
           </div>
           <div className={settingsStyles.field}>
             <Text variant={TextVariant.Xs} color={TextColor.Secondary}>
-              Annotations
+              Labels
             </Text>
-            <Checkbox
-              label="Interpolate between annotations"
-              checked={interpolateAnnotations}
-              onChange={setInterpolateAnnotations}
-            />
+            {annotationSources.length > 0 ? (
+              <div className={settingsStyles.optionStack}>
+                {annotationSources.map((s) => (
+                  <Checkbox
+                    key={s.id}
+                    label={labelWithCount(s.label, s.recordCount)}
+                    checked={selectedLabelTopics.includes(s.id)}
+                    onChange={(checked) => toggleLabelTopic(s.id, checked)}
+                    {...checkboxNoSpaceToggleProps}
+                  />
+                ))}
+              </div>
+            ) : (
+              <span className={settingsStyles.emptyText}>
+                No label topics available
+              </span>
+            )}
           </div>
         </div>
       </TileSettingsContent>
@@ -128,15 +168,15 @@ const McapImageTile: React.FC<McapTileProps> = ({ initialSourceId }) => {
               )
             }
           />
-          {imageDims && annotationTopic ? (
+          {imageDims && selectedLabelTopics.length > 0 ? (
             <McapImageAnnotationOverlay
-              topic={annotationTopic}
               imageWidth={imageDims.width}
               imageHeight={imageDims.height}
-              interpolate={interpolateAnnotations}
+              interpolate={interpolate2dAnnotations}
+              topics={selectedLabelTopics}
             />
           ) : null}
-          <McapTileStatusBadge topics={topic ? [topic] : []} />
+          <McapTileStatusBadge topics={activeTopics} />
         </div>
       ) : (
         <McapTileEmptyState topics={topic ? [topic] : []} />
@@ -144,5 +184,15 @@ const McapImageTile: React.FC<McapTileProps> = ({ initialSourceId }) => {
     </>
   );
 };
+
+function labelWithCount(label: string, count: number | undefined): string {
+  return count ? `${label} (${count.toLocaleString()})` : label;
+}
+
+function sourceDetails(source: { recordCount?: number } | undefined): string {
+  return source?.recordCount
+    ? `${source.recordCount.toLocaleString()} messages`
+    : "Message count unavailable";
+}
 
 export default McapImageTile;

--- a/app/packages/multimodal/src/adapters/mcap/react/McapImageTile.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapImageTile.tsx
@@ -184,12 +184,13 @@ const McapImageTile: React.FC<McapTileProps> = ({ initialSourceId }) => {
 };
 
 function labelWithCount(label: string, count: number | undefined): string {
-  return count ? `${label} (${count.toLocaleString()})` : label;
+  return count !== undefined ? `${label} (${count.toLocaleString()})` : label;
 }
 
 function sourceDetails(source: { recordCount?: number } | undefined): string {
-  return source?.recordCount
-    ? `${source.recordCount.toLocaleString()} messages`
+  const count = source?.recordCount;
+  return count !== undefined
+    ? `${count.toLocaleString()} messages`
     : "Message count unavailable";
 }
 

--- a/app/packages/multimodal/src/adapters/mcap/react/McapImageTile.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapImageTile.tsx
@@ -43,8 +43,7 @@ const McapImageTile: React.FC<McapTileProps> = ({ initialSourceId }) => {
     () => initialSourceId ?? rankImageSources(images)[0]?.id ?? ""
   );
 
-  // If sources populated after the initial render (or the selected topic
-  // disappeared), bind to the best available source.
+  // This effect binds the pane to the best image source once sources resolve.
   useEffect(() => {
     if (topic && images.some((source) => source.id === topic)) return;
 
@@ -52,14 +51,13 @@ const McapImageTile: React.FC<McapTileProps> = ({ initialSourceId }) => {
     if (nextTopic !== topic) setTopic(nextTopic);
   }, [images, topic]);
 
-  // Keep the tile title in sync whenever the selected topic resolves.
+  // This effect syncs the tile title with the selected image source.
   useEffect(() => {
     const label = images.find((s) => s.id === topic)?.label;
     if (label) setTileTitle(label);
   }, [topic, images, setTileTitle]);
 
-  // Reset stale dims when the image source changes so the overlay cannot
-  // briefly use the previous source's dimensions before onImageLoaded fires.
+  // This effect resets image dimensions when the selected source changes.
   useEffect(() => {
     setImageDims(null);
   }, [topic]);

--- a/app/packages/multimodal/src/adapters/mcap/react/McapModalRenderer.module.css
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapModalRenderer.module.css
@@ -17,3 +17,8 @@
 .stateError {
   color: var(--color-content-text-destructive);
 }
+
+.captionText {
+  color: var(--color-content-text-muted);
+  font-size: 11px;
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/McapModalRenderer.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapModalRenderer.tsx
@@ -1,9 +1,13 @@
 import type { SampleRendererProps } from "@fiftyone/plugins";
+import { humanReadableBytes } from "@fiftyone/utilities";
 import { Size, Spinner } from "@voxel51/voodo";
 import clsx from "clsx";
-import React from "react";
+import React, { useMemo } from "react";
 import MultiModalPlayback from "../../../components/MultiModalPlayback/MultiModalPlayback";
+import { MCAP_SOURCE_TYPE } from "../scene-sources";
 import { McapDataStreamProvider } from "./mcap-data-stream-context";
+import { McapModalSettingsProvider } from "./mcap-modal-settings";
+import McapSettingsSidebar from "./McapSettingsSidebar";
 import { McapStreams } from "./McapStreams";
 import styles from "./McapModalRenderer.module.css";
 import {
@@ -34,8 +38,31 @@ import { useStableMcapSource } from "./use-stable-mcap-source";
 const McapModalRenderer: React.FC<SampleRendererProps> = ({ ctx }) => {
   const client = useMcapResourceClient({ worker: true });
   const source = useStableMcapSource(ctx);
-  const fileName = source?.sourceId.split("/").pop() ?? "recording.mcap";
-  const { status, error, sources } = useMcapSceneInventory({ client, source });
+  const fileName = fileNameFromPath(ctx.media.path) ?? "recording.mcap";
+  const { status, error, sources, topicCount } = useMcapSceneInventory({
+    client,
+    source,
+  });
+  const metadata = useMemo(
+    () => ({
+      sizeLabel: sourceSizeLabel(source?.sizeBytes),
+      ...sourceCounts(sources),
+      topicCount,
+    }),
+    [source?.sizeBytes, sources, topicCount]
+  );
+  const headerCaption = useMemo(
+    () => (
+      <McapHeaderCaption
+        imageCount={metadata.imageCount}
+        labelCount={metadata.labelCount}
+        pointCloudCount={metadata.pointCloudCount}
+        sizeLabel={metadata.sizeLabel}
+        topicCount={metadata.topicCount}
+      />
+    ),
+    [metadata]
+  );
   const {
     initialTiles,
     initialLayout,
@@ -66,24 +93,28 @@ const McapModalRenderer: React.FC<SampleRendererProps> = ({ ctx }) => {
   }
 
   return (
-    <McapDataStreamProvider>
-      <MultiModalPlayback
-        fileName={fileName}
-        sceneSources={sources}
-        initialTiles={initialTiles}
-        initialLayout={initialLayout}
-        tracks={tracks.length > 0 ? tracks : undefined}
-        onTagDelete={onTagDelete}
-        defaultLeftOpen={defaultLeftOpen}
-        defaultRightOpen={defaultRightOpen}
-        onLeftOpenChange={onLeftOpenChange}
-        onRightOpenChange={onRightOpenChange}
-        onTagCreate={onTagCreate}
-      >
-        <McapStreams ctx={ctx} client={client} />
-        <McapModalLayoutPersistence />
-      </MultiModalPlayback>
-    </McapDataStreamProvider>
+    <McapModalSettingsProvider>
+      <McapDataStreamProvider>
+        <MultiModalPlayback
+          fileName={fileName}
+          headerCaption={headerCaption}
+          sceneSources={sources}
+          initialTiles={initialTiles}
+          initialLayout={initialLayout}
+          tracks={tracks.length > 0 ? tracks : undefined}
+          onTagDelete={onTagDelete}
+          leftSidebar={<McapSettingsSidebar />}
+          defaultLeftOpen={defaultLeftOpen}
+          defaultRightOpen={defaultRightOpen}
+          onLeftOpenChange={onLeftOpenChange}
+          onRightOpenChange={onRightOpenChange}
+          onTagCreate={onTagCreate}
+        >
+          <McapStreams ctx={ctx} client={client} />
+          <McapModalLayoutPersistence />
+        </MultiModalPlayback>
+      </McapDataStreamProvider>
+    </McapModalSettingsProvider>
   );
 };
 
@@ -107,6 +138,66 @@ function McapModalState({
       ) : null}
     </div>
   );
+}
+
+function McapHeaderCaption({
+  imageCount,
+  labelCount,
+  pointCloudCount,
+  sizeLabel,
+  topicCount,
+}: {
+  readonly imageCount: number;
+  readonly labelCount: number;
+  readonly pointCloudCount: number;
+  readonly sizeLabel: string | null;
+  readonly topicCount: number;
+}) {
+  const parts = [
+    sizeLabel,
+    `${topicCount.toLocaleString()} ${plural(topicCount, "topic", "topics")}`,
+    `${(imageCount + pointCloudCount).toLocaleString()} ${plural(
+      imageCount + pointCloudCount,
+      "preview stream",
+      "preview streams"
+    )}`,
+    `${labelCount.toLocaleString()} ${plural(
+      labelCount,
+      "label topic",
+      "label topics"
+    )}`,
+  ].filter(Boolean);
+
+  return <span className={styles.captionText}>{parts.join(" / ")}</span>;
+}
+
+function sourceCounts(sources: readonly { type: string }[]) {
+  return {
+    imageCount: sources.filter((s) => s.type === MCAP_SOURCE_TYPE.IMAGE).length,
+    labelCount: sources.filter(
+      (s) => s.type === MCAP_SOURCE_TYPE.IMAGE_ANNOTATION
+    ).length,
+    pointCloudCount: sources.filter(
+      (s) => s.type === MCAP_SOURCE_TYPE.POINT_CLOUD
+    ).length,
+  };
+}
+
+function fileNameFromPath(path: unknown): string | null {
+  if (typeof path !== "string" || !path) return null;
+  return path.split(/[/\\]/).pop() || null;
+}
+
+function sourceSizeLabel(sizeBytes: string | undefined): string | null {
+  if (!sizeBytes || !/^\d+$/.test(sizeBytes)) return null;
+  const value = Number(sizeBytes);
+  if (!Number.isSafeInteger(value)) return null;
+  if (value === 0) return "0 B";
+  return humanReadableBytes(value) || null;
+}
+
+function plural(count: number, singular: string, pluralValue: string): string {
+  return count === 1 ? singular : pluralValue;
 }
 
 export default McapModalRenderer;

--- a/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.module.css
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.module.css
@@ -1,0 +1,55 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.contextTitle {
+  color: var(--color-brand-primary);
+  font-weight: 700;
+}
+
+.summaryGrid {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.metric {
+  background: var(--color-content-bg-card-2);
+  border: 1px solid var(--color-content-border-default);
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  padding: 8px;
+}
+
+.metricValue {
+  color: var(--color-content-text-primary);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.metricLabel {
+  color: var(--color-content-text-muted);
+  font-size: 10px;
+  line-height: 1.1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.controlStack {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.tsx
@@ -1,0 +1,102 @@
+import { SidebarPanel, useTiling } from "@fiftyone/tiling";
+import { Checkbox, Text, TextColor, TextVariant } from "@voxel51/voodo";
+import React, { useCallback, useMemo } from "react";
+import { useSceneInventory, type SceneSource } from "../../../scene-inventory";
+import { MCAP_SOURCE_TYPE } from "../scene-sources";
+import { useMcapModalSettings } from "./mcap-modal-settings";
+import { checkboxNoSpaceToggleProps } from "./mcap-settings-keyboard";
+import styles from "./McapSettingsSidebar.module.css";
+
+/**
+ * MCAP-specific left sidebar. When a pane is active, the pane body portals
+ * its settings into this shell; when no pane is active, the sidebar exposes
+ * scene-wide label settings.
+ */
+const McapSettingsSidebar: React.FC = () => {
+  const { focusedTileId, setSettingsSlotEl, tiles } = useTiling();
+  const focusedTile =
+    focusedTileId && tiles[focusedTileId] ? tiles[focusedTileId] : null;
+  const slotRef = useCallback(
+    (el: HTMLDivElement | null) => setSettingsSlotEl(el),
+    [setSettingsSlotEl]
+  );
+
+  const contextTitle = focusedTile ? focusedTile.title : "Scene context";
+
+  return (
+    <SidebarPanel
+      title={<span className={styles.contextTitle}>{contextTitle}</span>}
+    >
+      <div ref={slotRef} />
+      {!focusedTile ? <GlobalSceneSettings /> : null}
+    </SidebarPanel>
+  );
+};
+
+function GlobalSceneSettings() {
+  const sources = useSceneInventory();
+  const {
+    interpolate2dAnnotations,
+    interpolate3dAnnotations,
+    setInterpolate2dAnnotations,
+    setInterpolate3dAnnotations,
+  } = useMcapModalSettings();
+  const counts = useMemo(() => sceneCounts(sources), [sources]);
+
+  return (
+    <div className={styles.root}>
+      <div className={styles.summaryGrid}>
+        <SummaryMetric label="Images" value={counts.images} />
+        <SummaryMetric label="3D" value={counts.pointClouds} />
+        <SummaryMetric label="Labels" value={counts.labels} />
+      </div>
+
+      <section className={styles.section}>
+        <Text variant={TextVariant.Xs} color={TextColor.Secondary}>
+          Labels
+        </Text>
+        <div className={styles.controlStack}>
+          <Checkbox
+            label="Interpolate between 2D annotations"
+            checked={interpolate2dAnnotations}
+            onChange={setInterpolate2dAnnotations}
+            {...checkboxNoSpaceToggleProps}
+          />
+          <Checkbox
+            label="Interpolate between 3D annotations"
+            checked={interpolate3dAnnotations}
+            onChange={setInterpolate3dAnnotations}
+            {...checkboxNoSpaceToggleProps}
+          />
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function SummaryMetric({
+  label,
+  value,
+}: {
+  readonly label: string;
+  readonly value: number;
+}) {
+  return (
+    <div className={styles.metric}>
+      <span className={styles.metricValue}>{value.toLocaleString()}</span>
+      <span className={styles.metricLabel}>{label}</span>
+    </div>
+  );
+}
+
+function sceneCounts(sources: readonly SceneSource[]) {
+  return {
+    images: sources.filter((s) => s.type === MCAP_SOURCE_TYPE.IMAGE).length,
+    labels: sources.filter((s) => s.type === MCAP_SOURCE_TYPE.IMAGE_ANNOTATION)
+      .length,
+    pointClouds: sources.filter((s) => s.type === MCAP_SOURCE_TYPE.POINT_CLOUD)
+      .length,
+  };
+}
+
+export default McapSettingsSidebar;

--- a/app/packages/multimodal/src/adapters/mcap/react/McapTile.settings.module.css
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapTile.settings.module.css
@@ -1,17 +1,30 @@
 .root {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 16px;
 }
 
 .field {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 6px;
 }
 
 .row {
   display: flex;
   gap: 8px;
   align-items: center;
+}
+
+.optionStack {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.metaText,
+.emptyText {
+  color: var(--color-content-text-muted);
+  font-size: 11px;
+  line-height: 1.25;
 }

--- a/app/packages/multimodal/src/adapters/mcap/react/interpolate-image-annotations.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/interpolate-image-annotations.test.ts
@@ -492,6 +492,15 @@ describe("interpolateLineList", () => {
   });
 });
 
+describe("makeGroup", () => {
+  it("returns finite bounds and centroid for an empty segment group", () => {
+    const group = makeGroup([], "empty");
+    expect(group.bounds).toEqual({ minX: 0, minY: 0, maxX: 0, maxY: 0 });
+    expect(group.centroid).toEqual([0, 0]);
+    expect(group.vertices).toEqual([]);
+  });
+});
+
 describe("matchLineListGroups", () => {
   const A = makeGroup(boxSegments(0, 0, 10, 10), "car");
 

--- a/app/packages/multimodal/src/adapters/mcap/react/interpolate-image-annotations.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/interpolate-image-annotations.test.ts
@@ -1,0 +1,580 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  ImageAnnotationCircle,
+  ImageAnnotationPoints,
+  ImageAnnotationText,
+  ImageAnnotationsVisualization,
+} from "../../../decoders";
+import { VISUALIZATION_KIND } from "../../../visualization";
+import type { McapDecodedMessage } from "../types";
+import {
+  aabbIoU,
+  chamferDistance,
+  interpolateCircles,
+  interpolateImageAnnotations,
+  interpolateLineList,
+  interpolatePointsArray,
+  interpolateTexts,
+  interpolationFraction,
+  lowerBoundBigInt,
+  makeGroup,
+  matchLineListGroups,
+  vizOf,
+  type Point2,
+} from "./interpolate-image-annotations";
+
+// ---------------------------------------------------------------------------
+// Fixture builders (typed so array literals infer as the readonly tuples the
+// decoder types require, rather than number[]).
+// ---------------------------------------------------------------------------
+
+function circle(
+  position: readonly [number, number],
+  diameter: number
+): ImageAnnotationCircle {
+  return {
+    position,
+    diameter,
+    thickness: 1,
+    outlineColor: null,
+    fillColor: null,
+  };
+}
+
+function text(
+  t: string,
+  position: readonly [number, number]
+): ImageAnnotationText {
+  return {
+    position,
+    text: t,
+    fontSize: 12,
+    textColor: null,
+    backgroundColor: null,
+  };
+}
+
+function pointsPrim(
+  type: ImageAnnotationPoints["type"],
+  points: readonly (readonly [number, number])[]
+): ImageAnnotationPoints {
+  return {
+    type,
+    points,
+    thickness: 1,
+    outlineColor: null,
+    outlineColors: [],
+    fillColor: null,
+  };
+}
+
+function lineList(
+  points: readonly (readonly [number, number])[]
+): ImageAnnotationPoints {
+  return pointsPrim("line-list", points);
+}
+
+function viz(
+  parts: Partial<
+    Pick<ImageAnnotationsVisualization, "circles" | "points" | "texts">
+  > = {}
+): ImageAnnotationsVisualization {
+  return {
+    kind: VISUALIZATION_KIND.IMAGE_ANNOTATIONS,
+    circles: [],
+    points: [],
+    texts: [],
+    ...parts,
+  };
+}
+
+function seg(a: Point2, b: Point2): [Point2, Point2] {
+  return [a, b];
+}
+
+/** The four edge segments of an axis-aligned rectangle, counter-clockwise. */
+function boxSegments(
+  x: number,
+  y: number,
+  w: number,
+  h: number
+): [Point2, Point2][] {
+  const bl: Point2 = [x, y];
+  const br: Point2 = [x + w, y];
+  const tr: Point2 = [x + w, y + h];
+  const tl: Point2 = [x, y + h];
+  return [seg(bl, br), seg(br, tr), seg(tr, tl), seg(tl, bl)];
+}
+
+/** Flattened line-list point pairs for an axis-aligned rectangle. */
+function boxPoints(x: number, y: number, w: number, h: number): Point2[] {
+  return boxSegments(x, y, w, h).flatMap(([a, b]) => [a, b]);
+}
+
+const ns = (n: number) => BigInt(n);
+
+// ---------------------------------------------------------------------------
+
+describe("interpolationFraction", () => {
+  it("returns the linear fraction between prev and next", () => {
+    expect(
+      interpolationFraction({
+        previousTimelineTimeNs: ns(0),
+        nextTimelineTimeNs: ns(100),
+        playheadNs: ns(50),
+      })
+    ).toBe(0.5);
+    expect(
+      interpolationFraction({
+        previousTimelineTimeNs: ns(0),
+        nextTimelineTimeNs: ns(100),
+        playheadNs: ns(25),
+      })
+    ).toBe(0.25);
+  });
+
+  it("clamps to 1 when the playhead is past the next message", () => {
+    expect(
+      interpolationFraction({
+        previousTimelineTimeNs: ns(0),
+        nextTimelineTimeNs: ns(100),
+        playheadNs: ns(250),
+      })
+    ).toBe(1);
+  });
+
+  it("returns null when the span is non-positive (equal or out-of-order)", () => {
+    expect(
+      interpolationFraction({
+        previousTimelineTimeNs: ns(100),
+        nextTimelineTimeNs: ns(100),
+        playheadNs: ns(150),
+      })
+    ).toBeNull();
+    expect(
+      interpolationFraction({
+        previousTimelineTimeNs: ns(100),
+        nextTimelineTimeNs: ns(50),
+        playheadNs: ns(120),
+      })
+    ).toBeNull();
+  });
+
+  it("returns null when the playhead is at or before prev (elapsed <= 0)", () => {
+    expect(
+      interpolationFraction({
+        previousTimelineTimeNs: ns(100),
+        nextTimelineTimeNs: ns(200),
+        playheadNs: ns(100),
+      })
+    ).toBeNull();
+    expect(
+      interpolationFraction({
+        previousTimelineTimeNs: ns(100),
+        nextTimelineTimeNs: ns(200),
+        playheadNs: ns(50),
+      })
+    ).toBeNull();
+  });
+});
+
+describe("vizOf", () => {
+  const msgWith = (visualization: unknown): McapDecodedMessage =>
+    ({
+      decoded: { output: { visualization } },
+    } as unknown as McapDecodedMessage);
+
+  it("returns the visualization when it is an image-annotations kind", () => {
+    const v = viz({ circles: [circle([1, 2], 4)] });
+    expect(vizOf(msgWith(v))).toBe(v);
+  });
+
+  it("returns null when there is no visualization", () => {
+    expect(vizOf(msgWith(null))).toBeNull();
+    expect(vizOf(msgWith(undefined))).toBeNull();
+  });
+
+  it("returns null for a non-image-annotations visualization", () => {
+    expect(
+      vizOf(msgWith({ kind: VISUALIZATION_KIND.ENCODED_IMAGE }))
+    ).toBeNull();
+  });
+});
+
+describe("lowerBoundBigInt", () => {
+  const ticks = [ns(10), ns(20), ns(30), ns(40)];
+
+  it("returns the index of an exact match", () => {
+    expect(lowerBoundBigInt(ticks, ns(20))).toBe(1);
+    expect(lowerBoundBigInt(ticks, ns(10))).toBe(0);
+    expect(lowerBoundBigInt(ticks, ns(40))).toBe(3);
+  });
+
+  it("returns the insertion index for a value between ticks", () => {
+    expect(lowerBoundBigInt(ticks, ns(25))).toBe(2);
+  });
+
+  it("returns 0 before all and length after all", () => {
+    expect(lowerBoundBigInt(ticks, ns(5))).toBe(0);
+    expect(lowerBoundBigInt(ticks, ns(50))).toBe(4);
+  });
+
+  it("returns 0 for an empty array", () => {
+    expect(lowerBoundBigInt([], ns(5))).toBe(0);
+  });
+});
+
+describe("aabbIoU", () => {
+  it("is 1 for identical boxes", () => {
+    expect(
+      aabbIoU(
+        { minX: 0, minY: 0, maxX: 10, maxY: 10 },
+        { minX: 0, minY: 0, maxX: 10, maxY: 10 }
+      )
+    ).toBe(1);
+  });
+
+  it("is 0 for disjoint or edge-touching boxes", () => {
+    expect(
+      aabbIoU(
+        { minX: 0, minY: 0, maxX: 10, maxY: 10 },
+        { minX: 20, minY: 20, maxX: 30, maxY: 30 }
+      )
+    ).toBe(0);
+    // shares only the x=10 edge -> no positive-area intersection
+    expect(
+      aabbIoU(
+        { minX: 0, minY: 0, maxX: 10, maxY: 10 },
+        { minX: 10, minY: 0, maxX: 20, maxY: 10 }
+      )
+    ).toBe(0);
+  });
+
+  it("computes the intersection-over-union for partial overlap", () => {
+    // inter = 5x5 = 25, union = 100 + 100 - 25 = 175
+    expect(
+      aabbIoU(
+        { minX: 0, minY: 0, maxX: 10, maxY: 10 },
+        { minX: 5, minY: 5, maxX: 15, maxY: 15 }
+      )
+    ).toBeCloseTo(25 / 175, 6);
+  });
+
+  it("is 0 for a degenerate zero-area box", () => {
+    expect(
+      aabbIoU(
+        { minX: 0, minY: 0, maxX: 0, maxY: 0 },
+        { minX: 0, minY: 0, maxX: 0, maxY: 0 }
+      )
+    ).toBe(0);
+  });
+});
+
+describe("chamferDistance", () => {
+  it("is Infinity when either set is empty", () => {
+    expect(chamferDistance([], [[0, 0]])).toBe(Infinity);
+    expect(chamferDistance([[0, 0]], [])).toBe(Infinity);
+  });
+
+  it("is 0 for identical point sets", () => {
+    expect(
+      chamferDistance(
+        [
+          [0, 0],
+          [10, 0],
+        ],
+        [
+          [0, 0],
+          [10, 0],
+        ]
+      )
+    ).toBe(0);
+  });
+
+  it("is the symmetric mean nearest-neighbour distance", () => {
+    // single points 3-4-5 triangle apart -> distance 5 each way
+    expect(chamferDistance([[0, 0]], [[3, 4]])).toBeCloseTo(5, 6);
+  });
+});
+
+describe("interpolateCircles", () => {
+  it("returns prev unchanged when counts differ", () => {
+    const prev = [circle([0, 0], 10)];
+    expect(interpolateCircles(prev, [], 0.5)).toBe(prev);
+  });
+
+  it("lerps position and diameter at f, preserving other fields", () => {
+    const prev = [circle([0, 0], 10)];
+    const next = [circle([10, 20], 20)];
+    const out = interpolateCircles(prev, next, 0.5);
+    expect(out[0].position).toEqual([5, 10]);
+    expect(out[0].diameter).toBe(15);
+    expect(out[0].thickness).toBe(1);
+  });
+
+  it("equals prev at f=0 and next at f=1", () => {
+    const prev = [circle([0, 0], 10)];
+    const next = [circle([10, 20], 20)];
+    expect(interpolateCircles(prev, next, 0)[0].position).toEqual([0, 0]);
+    expect(interpolateCircles(prev, next, 0)[0].diameter).toBe(10);
+    expect(interpolateCircles(prev, next, 1)[0].position).toEqual([10, 20]);
+    expect(interpolateCircles(prev, next, 1)[0].diameter).toBe(20);
+  });
+});
+
+describe("interpolateTexts", () => {
+  it("lerps the position of a same-text match within distance", () => {
+    const out = interpolateTexts(
+      [text("car", [0, 0])],
+      [text("car", [10, 10])],
+      0.5
+    );
+    expect(out[0].position).toEqual([5, 5]);
+    expect(out[0].text).toBe("car");
+  });
+
+  it("keeps prev unchanged when the text content differs", () => {
+    const out = interpolateTexts(
+      [text("car", [0, 0])],
+      [text("truck", [0, 0])],
+      0.5
+    );
+    expect(out[0].position).toEqual([0, 0]);
+  });
+
+  it("keeps prev unchanged when the nearest same-text match is beyond MATCH_DISTANCE_PX", () => {
+    const out = interpolateTexts(
+      [text("car", [0, 0])],
+      [text("car", [300, 0])],
+      0.5
+    );
+    expect(out[0].position).toEqual([0, 0]);
+  });
+
+  it("matches greedily: a claimed next forces a later prev to a farther one", () => {
+    // Both prevs are nearest to next0=[5,0]; greedy gives next0 to the first
+    // prev, forcing the second to next1. A naive per-prev nearest match would
+    // (wrongly) send BOTH to next0 -> out[1] would be [5,0], not [200,0].
+    const prev = [text("car", [0, 0]), text("car", [6, 0])];
+    const next = [text("car", [5, 0]), text("car", [200, 0])];
+    const out = interpolateTexts(prev, next, 1);
+    expect(out[0].position).toEqual([5, 0]);
+    expect(out[1].position).toEqual([200, 0]);
+  });
+});
+
+describe("interpolatePointsArray", () => {
+  it("returns prev.points when the primitive counts differ", () => {
+    const prev = viz({ points: [pointsPrim("points", [[0, 0]])] });
+    const next = viz({
+      points: [pointsPrim("points", [[0, 0]]), pointsPrim("points", [[1, 1]])],
+    });
+    expect(interpolatePointsArray(prev, next, 0.5)).toBe(prev.points);
+  });
+
+  it("keeps a primitive as prev when its type changes between frames", () => {
+    const prev = viz({ points: [pointsPrim("points", [[0, 0]])] });
+    const next = viz({
+      points: [
+        lineList([
+          [0, 0],
+          [1, 1],
+        ]),
+      ],
+    });
+    expect(interpolatePointsArray(prev, next, 0.5)[0]).toBe(prev.points[0]);
+  });
+
+  it("index-lerps a non-line-list primitive of equal length", () => {
+    const prev = viz({
+      points: [
+        pointsPrim("points", [
+          [0, 0],
+          [10, 10],
+        ]),
+      ],
+    });
+    const next = viz({
+      points: [
+        pointsPrim("points", [
+          [10, 10],
+          [20, 20],
+        ]),
+      ],
+    });
+    const out = interpolatePointsArray(prev, next, 0.5)[0];
+    expect(out.points).toEqual([
+      [5, 5],
+      [15, 15],
+    ]);
+  });
+
+  it("keeps a non-line-list primitive as prev when point counts differ", () => {
+    const prev = viz({ points: [pointsPrim("points", [[0, 0]])] });
+    const next = viz({
+      points: [
+        pointsPrim("points", [
+          [0, 0],
+          [1, 1],
+        ]),
+      ],
+    });
+    expect(interpolatePointsArray(prev, next, 0.5)[0]).toBe(prev.points[0]);
+  });
+});
+
+describe("interpolateLineList", () => {
+  it("lerps endpoints of a matched, same-label box", () => {
+    const prev = lineList(boxPoints(0, 0, 10, 10));
+    const next = lineList(boxPoints(5, 0, 10, 10)); // overlaps prev (IoU ~0.33)
+    const out = interpolateLineList(
+      prev,
+      next,
+      [text("car", [5, 5])],
+      [text("car", [10, 5])],
+      0.5
+    );
+    expect(out.type).toBe("line-list");
+    expect(out.points).toHaveLength(8);
+    // first segment start: (0,0)->(5,0) at f=0.5 -> (2.5,0); end: (10,0)->(15,0) -> (12.5,0)
+    expect(out.points[0]).toEqual([2.5, 0]);
+    expect(out.points[1]).toEqual([12.5, 0]);
+  });
+
+  it("passes prev through unchanged when the groups do not match (different label)", () => {
+    const prevPts = boxPoints(0, 0, 10, 10);
+    const prev = lineList(prevPts);
+    const next = lineList(boxPoints(5, 0, 10, 10));
+    const out = interpolateLineList(
+      prev,
+      next,
+      [text("car", [5, 5])],
+      [text("truck", [10, 5])],
+      0.5
+    );
+    expect(out.points).toEqual(prevPts);
+  });
+
+  it("passes prev through when matched groups have differing segment counts", () => {
+    const prevPts = boxPoints(0, 0, 10, 10); // 4 segments
+    const prev = lineList(prevPts);
+    // A 3-segment triangle with the same label and identical bounding box: it
+    // matches (label + centroid + IoU) but can't be lerped segment-for-segment,
+    // so appendInterpolatedSegments must pass prev through unchanged.
+    const next = lineList([
+      [0, 0],
+      [10, 0],
+      [10, 0],
+      [5, 10],
+      [5, 10],
+      [0, 0],
+    ]);
+    const out = interpolateLineList(
+      prev,
+      next,
+      [text("car", [5, 5])],
+      [text("car", [5, 5])],
+      0.5
+    );
+    expect(out.points).toEqual(prevPts);
+  });
+
+  it("interpolates an unlabeled group from the fallback chunking", () => {
+    const prev = lineList(boxPoints(0, 0, 10, 10));
+    const next = lineList(boxPoints(5, 0, 10, 10));
+    // 4 segments with 3 texts -> 4 % 3 !== 0 -> grouping falls back to ONE
+    // unlabeled (label: null) group; null === null still matches and lerps.
+    const texts = [text("a", [0, 0]), text("b", [1, 1]), text("c", [2, 2])];
+    const out = interpolateLineList(prev, next, texts, texts, 0.5);
+    expect(out.points).toHaveLength(8);
+    expect(out.points[0]).toEqual([2.5, 0]);
+  });
+});
+
+describe("matchLineListGroups", () => {
+  const A = makeGroup(boxSegments(0, 0, 10, 10), "car");
+
+  it("matches a same-label group that is close and overlapping", () => {
+    const next = makeGroup(boxSegments(5, 0, 10, 10), "car");
+    const [pair] = matchLineListGroups([A], [next]);
+    expect(pair.next).toBe(next);
+  });
+
+  it("does not match when labels differ", () => {
+    const next = makeGroup(boxSegments(5, 0, 10, 10), "truck");
+    expect(matchLineListGroups([A], [next])[0].next).toBeNull();
+  });
+
+  it("does not match when centroids are beyond MATCH_DISTANCE_PX", () => {
+    const next = makeGroup(boxSegments(300, 0, 10, 10), "car");
+    expect(matchLineListGroups([A], [next])[0].next).toBeNull();
+  });
+
+  it("does not match when AABB IoU is below MIN_MATCH_IOU", () => {
+    // shifted by 9 -> overlap 1x10=10, union 190, IoU ~0.053 < 0.15
+    const next = makeGroup(boxSegments(9, 0, 10, 10), "car");
+    expect(matchLineListGroups([A], [next])[0].next).toBeNull();
+  });
+
+  it("is greedy: a claimed next cannot be reused by a later prev", () => {
+    const A2 = makeGroup(boxSegments(0, 0, 10, 10), "car");
+    const next = makeGroup(boxSegments(5, 0, 10, 10), "car");
+    const pairs = matchLineListGroups([A, A2], [next]);
+    expect(pairs[0].next).toBe(next);
+    expect(pairs[1].next).toBeNull();
+  });
+
+  it("assigns each prev group to its own matching next group", () => {
+    const p0 = makeGroup(boxSegments(0, 0, 10, 10), "car");
+    const p1 = makeGroup(boxSegments(100, 0, 10, 10), "car");
+    // next groups overlap each prev's location but are listed in reverse order.
+    const nFar = makeGroup(boxSegments(101, 0, 10, 10), "car"); // overlaps p1
+    const nNear = makeGroup(boxSegments(1, 0, 10, 10), "car"); // overlaps p0
+    const pairs = matchLineListGroups([p0, p1], [nFar, nNear]);
+    expect(pairs[0].next).toBe(nNear);
+    expect(pairs[1].next).toBe(nFar);
+  });
+
+  it("breaks ties by lowest Chamfer distance regardless of candidate order", () => {
+    const far = makeGroup(boxSegments(4, 0, 10, 10), "car"); // chamfer ~4
+    const near = makeGroup(boxSegments(2, 0, 10, 10), "car"); // chamfer ~2 (lowest)
+    const mid = makeGroup(boxSegments(3, 0, 10, 10), "car"); // chamfer ~3
+    // Lowest-chamfer candidate sits in the MIDDLE, so picking it rules out both
+    // first-wins and last-wins; only true minimization selects `near`.
+    const [pair] = matchLineListGroups([A], [far, near, mid]);
+    expect(pair.next).toBe(near);
+  });
+});
+
+describe("interpolateImageAnnotations", () => {
+  it("interpolates circles, texts, and line-list points together", () => {
+    const prev = viz({
+      circles: [circle([0, 0], 10)],
+      texts: [text("car", [0, 0])],
+      points: [lineList(boxPoints(0, 0, 10, 10))],
+    });
+    const next = viz({
+      circles: [circle([10, 10], 20)],
+      texts: [text("car", [10, 10])],
+      points: [lineList(boxPoints(5, 0, 10, 10))],
+    });
+
+    const out = interpolateImageAnnotations(prev, next, 0.5);
+
+    expect(out.kind).toBe(VISUALIZATION_KIND.IMAGE_ANNOTATIONS);
+    expect(out.circles[0].position).toEqual([5, 5]);
+    expect(out.circles[0].diameter).toBe(15);
+    expect(out.texts[0].position).toEqual([5, 5]);
+    expect(out.points[0].type).toBe("line-list");
+    expect(out.points[0].points).toHaveLength(8);
+    expect(out.points[0].points[0]).toEqual([2.5, 0]);
+  });
+
+  it("preserves the kind discriminant", () => {
+    const v = viz();
+    expect(interpolateImageAnnotations(v, v, 0.5).kind).toBe(
+      VISUALIZATION_KIND.IMAGE_ANNOTATIONS
+    );
+  });
+});

--- a/app/packages/multimodal/src/adapters/mcap/react/interpolate-image-annotations.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/interpolate-image-annotations.ts
@@ -346,6 +346,10 @@ interface Bounds {
 }
 
 function segmentsBounds(segments: readonly [Point2, Point2][]): Bounds {
+  if (segments.length === 0) {
+    return { minX: 0, minY: 0, maxX: 0, maxY: 0 };
+  }
+
   let minX = Infinity;
   let minY = Infinity;
   let maxX = -Infinity;

--- a/app/packages/multimodal/src/adapters/mcap/react/interpolate-image-annotations.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/interpolate-image-annotations.ts
@@ -1,0 +1,405 @@
+/**
+ * Pure geometry engine for interpolating decoded image annotations between two
+ * cached annotation messages at a sub-message playhead position. Intentionally
+ * free of React, cache, and timeline concerns so it can be unit-tested in
+ * isolation; the React/cache wiring lives in `use-interpolated-image-annotations`.
+ *
+ * Annotations arrive ~2 Hz against ~12 Hz camera images. To bridge that gap
+ * visually we lerp between the previous and next annotation message by fraction
+ * `(now - prev_t) / (next_t - prev_t)`.
+ *
+ * Foxglove doesn't carry stable instance IDs across messages, so we group
+ * LINE_LIST segments into per-object chunks, run a greedy label + geometry
+ * matching pass between prev/next groups, and only lerp matched pairs. Unmatched
+ * groups in prev stay put; unmatched groups in next don't appear until the next
+ * message becomes current.
+ */
+import type {
+  ImageAnnotationCircle,
+  ImageAnnotationPoints,
+  ImageAnnotationText,
+  ImageAnnotationsVisualization,
+} from "../../../decoders";
+import { groupLineSegmentsByLabel } from "../../../utils/line-segment-grouping";
+import type { McapDecodedMessage } from "../types";
+
+function interpolationFraction({
+  nextTimelineTimeNs,
+  playheadNs,
+  previousTimelineTimeNs,
+}: {
+  readonly nextTimelineTimeNs: bigint;
+  readonly playheadNs: bigint;
+  readonly previousTimelineTimeNs: bigint;
+}): number | null {
+  const span = nextTimelineTimeNs - previousTimelineTimeNs;
+  if (span <= 0n) return null;
+  const elapsed = playheadNs - previousTimelineTimeNs;
+  if (elapsed <= 0n) return null;
+  const f = Number(elapsed) / Number(span);
+  if (!Number.isFinite(f)) return null;
+  return Math.min(1, f);
+}
+
+function vizOf(msg: McapDecodedMessage): ImageAnnotationsVisualization | null {
+  const v = msg.decoded.output.visualization;
+  if (!v || v.kind !== "image-annotations") return null;
+  return v as ImageAnnotationsVisualization;
+}
+
+// ---------------------------------------------------------------------------
+// Interpolation
+// ---------------------------------------------------------------------------
+
+type Point2 = readonly [number, number];
+
+const MATCH_DISTANCE_PX = 200;
+const MIN_MATCH_IOU = 0.15;
+
+function interpolateImageAnnotations(
+  prev: ImageAnnotationsVisualization,
+  next: ImageAnnotationsVisualization,
+  f: number
+): ImageAnnotationsVisualization {
+  return {
+    kind: prev.kind,
+    circles: interpolateCircles(prev.circles, next.circles, f),
+    points: interpolatePointsArray(prev, next, f),
+    texts: interpolateTexts(prev.texts, next.texts, f),
+  };
+}
+
+function interpolateCircles(
+  prev: readonly ImageAnnotationCircle[],
+  next: readonly ImageAnnotationCircle[],
+  f: number
+): readonly ImageAnnotationCircle[] {
+  // Index matching is acceptable for circles — they're rare in this data
+  // and tend to stay in order; if counts differ we just keep prev.
+  if (prev.length !== next.length) return prev;
+  return prev.map((p, i) => {
+    const n = next[i];
+    return {
+      ...p,
+      position: lerpPoint(p.position, n.position, f),
+      diameter: lerp(p.diameter, n.diameter, f),
+    };
+  });
+}
+
+function interpolateTexts(
+  prev: readonly ImageAnnotationText[],
+  next: readonly ImageAnnotationText[],
+  f: number
+): readonly ImageAnnotationText[] {
+  // Match texts by `text` content + nearest position, greedy per content.
+  const out: ImageAnnotationText[] = [];
+  const usedNext = new Set<number>();
+  for (const p of prev) {
+    let bestIdx = -1;
+    let bestDist = Infinity;
+    for (let j = 0; j < next.length; j++) {
+      if (usedNext.has(j)) continue;
+      const n = next[j];
+      if (n.text !== p.text) continue;
+      const d = squaredDistance(p.position, n.position);
+      if (d < bestDist) {
+        bestDist = d;
+        bestIdx = j;
+      }
+    }
+    if (bestIdx === -1 || bestDist > MATCH_DISTANCE_PX * MATCH_DISTANCE_PX) {
+      out.push(p);
+      continue;
+    }
+    usedNext.add(bestIdx);
+    const n = next[bestIdx];
+    out.push({ ...p, position: lerpPoint(p.position, n.position, f) });
+  }
+  return out;
+}
+
+/**
+ * Interpolation for the points array. LINE_LIST primitives usually carry
+ * every cuboid in one big segment list; we split each into per-object
+ * groups using the same chunking helper as the overlay, match groups between
+ * prev and next, then lerp matched pairs. Non-line-list primitives fall back
+ * to index-based interpolation.
+ */
+function interpolatePointsArray(
+  prev: ImageAnnotationsVisualization,
+  next: ImageAnnotationsVisualization,
+  f: number
+): readonly ImageAnnotationPoints[] {
+  if (prev.points.length !== next.points.length) return prev.points;
+  return prev.points.map((pp, idx) => {
+    const np = next.points[idx];
+    if (pp.type !== np.type) return pp;
+    if (pp.type === "line-list") {
+      return interpolateLineList(pp, np, prev.texts, next.texts, f);
+    }
+    if (pp.points.length !== np.points.length) return pp;
+    return {
+      ...pp,
+      points: pp.points.map((pt, j) => lerpPoint(pt, np.points[j], f)),
+    };
+  });
+}
+
+function interpolateLineList(
+  prevPrim: ImageAnnotationPoints,
+  nextPrim: ImageAnnotationPoints,
+  prevTexts: readonly ImageAnnotationText[],
+  nextTexts: readonly ImageAnnotationText[],
+  f: number
+): ImageAnnotationPoints {
+  const prevGroups = groupLineList(prevPrim.points, prevTexts);
+  const nextGroups = groupLineList(nextPrim.points, nextTexts);
+  const matchedPairs = matchLineListGroups(prevGroups, nextGroups);
+
+  const out: Point2[] = [];
+  for (const { prev, next } of matchedPairs) {
+    appendInterpolatedSegments(out, prev, next, f);
+  }
+
+  return { ...prevPrim, points: out };
+}
+
+interface MatchedGroupPair {
+  readonly prev: Group;
+  readonly next: Group | null;
+}
+
+function matchLineListGroups(
+  prevGroups: readonly Group[],
+  nextGroups: readonly Group[]
+): readonly MatchedGroupPair[] {
+  // Per-prev candidate selection:
+  //   1. Same label class (hard).
+  //   2. Centroid within MATCH_DISTANCE_PX (coarse position filter).
+  //   3. AABB IoU above MIN_IOU (rejects gross size mismatches —
+  //      e.g. a parked truck near a passing sedan).
+  //   4. Among survivors, pick the lowest symmetric Chamfer distance
+  //      over the cuboid's unique vertices (shape similarity tiebreak).
+  // Greedy: first prev to claim a next wins.
+  const usedNext = new Set<number>();
+  return prevGroups.map((prev) => {
+    const nextIndex = bestNextGroupIndex(prev, nextGroups, usedNext);
+    if (nextIndex === -1) return { prev, next: null };
+    usedNext.add(nextIndex);
+    return { prev, next: nextGroups[nextIndex] };
+  });
+}
+
+function bestNextGroupIndex(
+  prev: Group,
+  nextGroups: readonly Group[],
+  usedNext: ReadonlySet<number>
+): number {
+  let bestIdx = -1;
+  let bestScore = Infinity;
+  const distSqThreshold = MATCH_DISTANCE_PX * MATCH_DISTANCE_PX;
+  for (let i = 0; i < nextGroups.length; i++) {
+    if (usedNext.has(i)) continue;
+    const next = nextGroups[i];
+    if (next.label !== prev.label) continue;
+    if (squaredDistance(prev.centroid, next.centroid) > distSqThreshold) {
+      continue;
+    }
+    if (aabbIoU(prev.bounds, next.bounds) < MIN_MATCH_IOU) continue;
+    const score = chamferDistance(prev.vertices, next.vertices);
+    if (score < bestScore) {
+      bestScore = score;
+      bestIdx = i;
+    }
+  }
+  return bestIdx;
+}
+
+function appendInterpolatedSegments(
+  out: Point2[],
+  prev: Group,
+  next: Group | null,
+  f: number
+): void {
+  if (!next || prev.segments.length !== next.segments.length) {
+    appendSegments(out, prev.segments);
+    return;
+  }
+  for (let i = 0; i < prev.segments.length; i++) {
+    const [pa, pb] = prev.segments[i];
+    const [na, nb] = next.segments[i];
+    out.push(lerpPoint(pa, na, f), lerpPoint(pb, nb, f));
+  }
+}
+
+function appendSegments(
+  out: Point2[],
+  segments: readonly [Point2, Point2][]
+): void {
+  for (const [a, b] of segments) {
+    out.push(a, b);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Line-list grouping (mirror of the overlay's render path)
+// ---------------------------------------------------------------------------
+
+interface Group {
+  readonly segments: readonly [Point2, Point2][];
+  readonly centroid: Point2;
+  readonly bounds: Bounds;
+  readonly vertices: readonly Point2[];
+  readonly label: string | null;
+}
+
+function groupLineList(
+  points: readonly Point2[],
+  texts: readonly ImageAnnotationText[]
+): readonly Group[] {
+  return groupLineSegmentsByLabel(points, texts).map(({ label, segments }) =>
+    makeGroup(segments, label)
+  );
+}
+
+function makeGroup(
+  segments: readonly [Point2, Point2][],
+  label: string | null
+): Group {
+  const bounds = segmentsBounds(segments);
+  const centroid: Point2 = [
+    (bounds.minX + bounds.maxX) / 2,
+    (bounds.minY + bounds.maxY) / 2,
+  ];
+  return {
+    segments,
+    centroid,
+    bounds,
+    vertices: uniqueVertices(segments),
+    label,
+  };
+}
+
+function uniqueVertices(
+  segments: readonly [Point2, Point2][]
+): readonly Point2[] {
+  const seen = new Set<string>();
+  const out: Point2[] = [];
+  for (const [a, b] of segments) {
+    for (const p of [a, b]) {
+      const k = `${Math.round(p[0] * 100)}|${Math.round(p[1] * 100)}`;
+      if (seen.has(k)) continue;
+      seen.add(k);
+      out.push(p);
+    }
+  }
+  return out;
+}
+
+function aabbIoU(a: Bounds, b: Bounds): number {
+  const x1 = Math.max(a.minX, b.minX);
+  const y1 = Math.max(a.minY, b.minY);
+  const x2 = Math.min(a.maxX, b.maxX);
+  const y2 = Math.min(a.maxY, b.maxY);
+  if (x2 <= x1 || y2 <= y1) return 0;
+  const inter = (x2 - x1) * (y2 - y1);
+  const areaA = Math.max(0, a.maxX - a.minX) * Math.max(0, a.maxY - a.minY);
+  const areaB = Math.max(0, b.maxX - b.minX) * Math.max(0, b.maxY - b.minY);
+  const union = areaA + areaB - inter;
+  return union > 0 ? inter / union : 0;
+}
+
+/**
+ * Symmetric Chamfer distance between two point sets — average nearest-
+ * neighbour distance from A→B plus from B→A, halved. Small values mean
+ * the two cuboid wireframes have similar vertex layouts (good match).
+ */
+function chamferDistance(a: readonly Point2[], b: readonly Point2[]): number {
+  if (a.length === 0 || b.length === 0) return Infinity;
+  let sumAB = 0;
+  for (const pa of a) {
+    let minD = Infinity;
+    for (const pb of b) {
+      const d = squaredDistance(pa, pb);
+      if (d < minD) minD = d;
+    }
+    sumAB += Math.sqrt(minD);
+  }
+  let sumBA = 0;
+  for (const pb of b) {
+    let minD = Infinity;
+    for (const pa of a) {
+      const d = squaredDistance(pa, pb);
+      if (d < minD) minD = d;
+    }
+    sumBA += Math.sqrt(minD);
+  }
+  return (sumAB / a.length + sumBA / b.length) / 2;
+}
+
+interface Bounds {
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+}
+
+function segmentsBounds(segments: readonly [Point2, Point2][]): Bounds {
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const [[x1, y1], [x2, y2]] of segments) {
+    if (x1 < minX) minX = x1;
+    if (x2 < minX) minX = x2;
+    if (x1 > maxX) maxX = x1;
+    if (x2 > maxX) maxX = x2;
+    if (y1 < minY) minY = y1;
+    if (y2 < minY) minY = y2;
+    if (y1 > maxY) maxY = y1;
+    if (y2 > maxY) maxY = y2;
+  }
+  return { minX, minY, maxX, maxY };
+}
+
+function squaredDistance(a: Point2, b: Point2): number {
+  const dx = a[0] - b[0];
+  const dy = a[1] - b[1];
+  return dx * dx + dy * dy;
+}
+
+function lerpPoint(a: Point2, b: Point2, f: number): Point2 {
+  return [a[0] + (b[0] - a[0]) * f, a[1] + (b[1] - a[1]) * f];
+}
+
+function lerp(a: number, b: number, f: number): number {
+  return a + (b - a) * f;
+}
+
+function lowerBoundBigInt(arr: readonly bigint[], target: bigint): number {
+  let lo = 0;
+  let hi = arr.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (arr[mid] < target) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo;
+}
+
+export {
+  aabbIoU,
+  chamferDistance,
+  interpolateCircles,
+  interpolateImageAnnotations,
+  interpolateLineList,
+  interpolatePointsArray,
+  interpolateTexts,
+  interpolationFraction,
+  lowerBoundBigInt,
+  makeGroup,
+  matchLineListGroups,
+  vizOf,
+};
+export type { Group, Point2 };

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-modal-settings.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-modal-settings.test.tsx
@@ -1,0 +1,86 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  McapModalSettingsProvider,
+  readMcapModalSettings,
+  useMcapModalSettings,
+  writeMcapModalSettings,
+} from "./mcap-modal-settings";
+
+describe("mcap-modal-settings", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => cleanup());
+
+  it("returns default interpolation settings when nothing is stored", () => {
+    expect(readMcapModalSettings()).toEqual({
+      version: 1,
+      imageLabelTopics: {},
+      interpolate2dAnnotations: true,
+      interpolate3dAnnotations: true,
+    });
+  });
+
+  it("round-trips global interpolation settings and image label topics", () => {
+    writeMcapModalSettings({
+      version: 1,
+      imageLabelTopics: {
+        "/camera/front": ["/labels/front", "/labels/all"],
+      },
+      interpolate2dAnnotations: false,
+      interpolate3dAnnotations: true,
+    });
+
+    expect(readMcapModalSettings()).toEqual({
+      version: 1,
+      imageLabelTopics: {
+        "/camera/front": ["/labels/front", "/labels/all"],
+      },
+      interpolate2dAnnotations: false,
+      interpolate3dAnnotations: true,
+    });
+  });
+
+  it("preserves explicit empty label selections", () => {
+    writeMcapModalSettings({
+      version: 1,
+      imageLabelTopics: {
+        "/camera/front": [],
+      },
+      interpolate2dAnnotations: true,
+      interpolate3dAnnotations: true,
+    });
+
+    const read = readMcapModalSettings();
+    expect(Object.hasOwn(read.imageLabelTopics, "/camera/front")).toBe(true);
+    expect(read.imageLabelTopics["/camera/front"]).toEqual([]);
+  });
+
+  it("updates settings through the provider hook", () => {
+    const { result } = renderHook(() => useMcapModalSettings(), {
+      wrapper: ({ children }: { children: React.ReactNode }) => (
+        <McapModalSettingsProvider>{children}</McapModalSettingsProvider>
+      ),
+    });
+
+    act(() => {
+      result.current.setInterpolate2dAnnotations(false);
+      result.current.setInterpolate3dAnnotations(false);
+      result.current.setImageLabelTopics("/camera/front", ["/labels"]);
+    });
+
+    expect(result.current.interpolate2dAnnotations).toBe(false);
+    expect(result.current.interpolate3dAnnotations).toBe(false);
+    expect(result.current.imageLabelTopics["/camera/front"]).toEqual([
+      "/labels",
+    ]);
+    expect(readMcapModalSettings()).toMatchObject({
+      imageLabelTopics: { "/camera/front": ["/labels"] },
+      interpolate2dAnnotations: false,
+      interpolate3dAnnotations: false,
+    });
+  });
+});

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-modal-settings.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-modal-settings.tsx
@@ -2,6 +2,7 @@ import React, {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useState,
 } from "react";
@@ -112,14 +113,14 @@ export const McapModalSettingsProvider: React.FC<{
         current: McapPersistedModalSettings
       ) => McapPersistedModalSettings
     ) => {
-      setSettings((current) => {
-        const next = resolver(current);
-        writeMcapModalSettings(next);
-        return next;
-      });
+      setSettings((current) => resolver(current));
     },
     []
   );
+
+  useEffect(() => {
+    writeMcapModalSettings(settings);
+  }, [settings]);
 
   const setInterpolate2dAnnotations = useCallback(
     (enabled: boolean) =>

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-modal-settings.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-modal-settings.tsx
@@ -1,0 +1,221 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
+
+interface McapPersistedModalSettings {
+  version: 1;
+  imageLabelTopics: Record<string, readonly string[]>;
+  interpolate2dAnnotations: boolean;
+  interpolate3dAnnotations: boolean;
+}
+
+interface McapModalSettingsContextValue {
+  readonly imageLabelTopics: Record<string, readonly string[]>;
+  readonly interpolate2dAnnotations: boolean;
+  readonly interpolate3dAnnotations: boolean;
+  readonly setImageLabelTopics: (
+    imageTopic: string,
+    labelTopics: readonly string[]
+  ) => void;
+  readonly setInterpolate2dAnnotations: (enabled: boolean) => void;
+  readonly setInterpolate3dAnnotations: (enabled: boolean) => void;
+}
+
+const STORAGE_KEY = "fiftyone.mcap.modal-settings";
+const VERSION = 1;
+
+const DEFAULT_SETTINGS: McapPersistedModalSettings = {
+  version: VERSION,
+  imageLabelTopics: {},
+  interpolate2dAnnotations: true,
+  interpolate3dAnnotations: true,
+};
+
+const McapModalSettingsContext =
+  createContext<McapModalSettingsContextValue | null>(null);
+
+/**
+ * Reads persisted MCAP modal settings from local storage.
+ */
+export function readMcapModalSettings(): McapPersistedModalSettings {
+  try {
+    const raw = globalThis.localStorage?.getItem(STORAGE_KEY);
+    if (!raw) return DEFAULT_SETTINGS;
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      (parsed as { version?: unknown }).version !== VERSION
+    ) {
+      return DEFAULT_SETTINGS;
+    }
+
+    const candidate = parsed as Partial<McapPersistedModalSettings>;
+    return {
+      version: VERSION,
+      imageLabelTopics: normalizeImageLabelTopicMap(candidate.imageLabelTopics),
+      interpolate2dAnnotations:
+        typeof candidate.interpolate2dAnnotations === "boolean"
+          ? candidate.interpolate2dAnnotations
+          : DEFAULT_SETTINGS.interpolate2dAnnotations,
+      interpolate3dAnnotations:
+        typeof candidate.interpolate3dAnnotations === "boolean"
+          ? candidate.interpolate3dAnnotations
+          : DEFAULT_SETTINGS.interpolate3dAnnotations,
+    };
+  } catch {
+    return DEFAULT_SETTINGS;
+  }
+}
+
+/**
+ * Writes the full persisted MCAP modal settings payload.
+ */
+export function writeMcapModalSettings(
+  settings: McapPersistedModalSettings
+): void {
+  try {
+    globalThis.localStorage?.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: VERSION,
+        imageLabelTopics: normalizeImageLabelTopicMap(
+          settings.imageLabelTopics
+        ),
+        interpolate2dAnnotations: settings.interpolate2dAnnotations,
+        interpolate3dAnnotations: settings.interpolate3dAnnotations,
+      })
+    );
+  } catch {
+    // Settings persistence is a convenience; storage failures should not
+    // interrupt playback.
+  }
+}
+
+/**
+ * Provides persisted MCAP modal settings to the sidebar and tile bodies.
+ */
+export const McapModalSettingsProvider: React.FC<{
+  children: React.ReactNode;
+}> = ({ children }) => {
+  const [settings, setSettings] = useState<McapPersistedModalSettings>(
+    readMcapModalSettings
+  );
+
+  const update = useCallback(
+    (
+      resolver: (
+        current: McapPersistedModalSettings
+      ) => McapPersistedModalSettings
+    ) => {
+      setSettings((current) => {
+        const next = resolver(current);
+        writeMcapModalSettings(next);
+        return next;
+      });
+    },
+    []
+  );
+
+  const setInterpolate2dAnnotations = useCallback(
+    (enabled: boolean) =>
+      update((current) => ({
+        ...current,
+        interpolate2dAnnotations: enabled,
+      })),
+    [update]
+  );
+  const setInterpolate3dAnnotations = useCallback(
+    (enabled: boolean) =>
+      update((current) => ({
+        ...current,
+        interpolate3dAnnotations: enabled,
+      })),
+    [update]
+  );
+  const setImageLabelTopics = useCallback(
+    (imageTopic: string, labelTopics: readonly string[]) => {
+      const normalizedImageTopic = imageTopic.trim();
+      if (!normalizedImageTopic) return;
+      const normalizedLabelTopics = normalizeTopicList(labelTopics);
+      update((current) => ({
+        ...current,
+        imageLabelTopics: {
+          ...current.imageLabelTopics,
+          [normalizedImageTopic]: normalizedLabelTopics,
+        },
+      }));
+    },
+    [update]
+  );
+
+  const value = useMemo<McapModalSettingsContextValue>(
+    () => ({
+      imageLabelTopics: settings.imageLabelTopics,
+      interpolate2dAnnotations: settings.interpolate2dAnnotations,
+      interpolate3dAnnotations: settings.interpolate3dAnnotations,
+      setImageLabelTopics,
+      setInterpolate2dAnnotations,
+      setInterpolate3dAnnotations,
+    }),
+    [
+      settings,
+      setImageLabelTopics,
+      setInterpolate2dAnnotations,
+      setInterpolate3dAnnotations,
+    ]
+  );
+
+  return (
+    <McapModalSettingsContext.Provider value={value}>
+      {children}
+    </McapModalSettingsContext.Provider>
+  );
+};
+
+/**
+ * Reads and updates MCAP modal settings.
+ */
+export function useMcapModalSettings(): McapModalSettingsContextValue {
+  const ctx = useContext(McapModalSettingsContext);
+  if (!ctx) {
+    throw new Error(
+      "useMcapModalSettings must be used inside <McapModalSettingsProvider>"
+    );
+  }
+  return ctx;
+}
+
+function normalizeImageLabelTopicMap(
+  value: unknown
+): Record<string, readonly string[]> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return {};
+  }
+
+  const result: Record<string, readonly string[]> = {};
+  for (const [imageTopic, labelTopics] of Object.entries(value)) {
+    const normalizedImageTopic = imageTopic.trim();
+    if (!normalizedImageTopic) continue;
+    result[normalizedImageTopic] = normalizeTopicList(labelTopics);
+  }
+  return result;
+}
+
+function normalizeTopicList(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return Array.from(
+    new Set(
+      value
+        .map((topic) => (typeof topic === "string" ? topic.trim() : ""))
+        .filter(Boolean)
+    )
+  );
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-settings-keyboard.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-settings-keyboard.test.tsx
@@ -1,0 +1,91 @@
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { Checkbox } from "@voxel51/voodo";
+import type React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  checkboxNoSpaceToggleProps,
+  preventSettingsCheckboxSpaceToggle,
+} from "./mcap-settings-keyboard";
+
+function keyboardEvent(
+  key: string,
+  code?: string
+): React.KeyboardEvent<HTMLElement> {
+  return {
+    code,
+    key,
+    preventDefault: vi.fn(),
+  } as unknown as React.KeyboardEvent<HTMLElement>;
+}
+
+describe("preventSettingsCheckboxSpaceToggle", () => {
+  it("prevents space key checkbox activation", () => {
+    const event = keyboardEvent(" ");
+    preventSettingsCheckboxSpaceToggle(event);
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles legacy and code-based space events", () => {
+    const legacyEvent = keyboardEvent("Spacebar");
+    const codeEvent = keyboardEvent("Unidentified", "Space");
+
+    preventSettingsCheckboxSpaceToggle(legacyEvent);
+    preventSettingsCheckboxSpaceToggle(codeEvent);
+
+    expect(legacyEvent.preventDefault).toHaveBeenCalledTimes(1);
+    expect(codeEvent.preventDefault).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves non-space keys alone", () => {
+    const event = keyboardEvent("Enter");
+    preventSettingsCheckboxSpaceToggle(event);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+});
+
+// Integration: the predicate above is only correct if cancelling the event on
+// a real voodo Checkbox actually suppresses its Space-toggle. These render a
+// live Checkbox and assert the end-to-end behavior.
+describe("checkboxNoSpaceToggleProps on a voodo Checkbox", () => {
+  afterEach(() => cleanup());
+
+  function renderCheckbox(extraProps: Record<string, unknown>) {
+    const onChange = vi.fn();
+    const { getByRole } = render(
+      <Checkbox
+        label="option"
+        checked={false}
+        onChange={onChange}
+        {...extraProps}
+      />
+    );
+    const checkbox = getByRole("checkbox");
+    checkbox.focus();
+    return { checkbox, onChange };
+  }
+
+  function pressSpace(el: HTMLElement) {
+    fireEvent.keyDown(el, { key: " ", code: "Space" });
+    fireEvent.keyUp(el, { key: " ", code: "Space" });
+  }
+
+  // Control: proves the test reproduces voodo's Space-to-toggle, so the guard
+  // assertion below can't pass for the wrong reason.
+  it("toggles on Space without the guard props", () => {
+    const { checkbox, onChange } = renderCheckbox({});
+    pressSpace(checkbox);
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it("does not toggle on Space with the guard props", () => {
+    const { checkbox, onChange } = renderCheckbox(checkboxNoSpaceToggleProps);
+    pressSpace(checkbox);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("still toggles on pointer click with the guard props", () => {
+    const { checkbox, onChange } = renderCheckbox(checkboxNoSpaceToggleProps);
+    fireEvent.click(checkbox);
+    expect(onChange).toHaveBeenCalled();
+  });
+});

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-settings-keyboard.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-settings-keyboard.test.tsx
@@ -1,21 +1,18 @@
 import { cleanup, fireEvent, render } from "@testing-library/react";
 import { Checkbox } from "@voxel51/voodo";
-import type React from "react";
+import { useState, type KeyboardEvent } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   checkboxNoSpaceToggleProps,
   preventSettingsCheckboxSpaceToggle,
 } from "./mcap-settings-keyboard";
 
-function keyboardEvent(
-  key: string,
-  code?: string
-): React.KeyboardEvent<HTMLElement> {
+function keyboardEvent(key: string, code?: string): KeyboardEvent<HTMLElement> {
   return {
     code,
     key,
     preventDefault: vi.fn(),
-  } as unknown as React.KeyboardEvent<HTMLElement>;
+  } as unknown as KeyboardEvent<HTMLElement>;
 }
 
 describe("preventSettingsCheckboxSpaceToggle", () => {
@@ -64,9 +61,37 @@ describe("checkboxNoSpaceToggleProps on a voodo Checkbox", () => {
     return { checkbox, onChange };
   }
 
+  function StatefulCheckbox({
+    extraProps,
+  }: {
+    readonly extraProps: Record<string, unknown>;
+  }) {
+    const [checked, setChecked] = useState(false);
+    return (
+      <Checkbox
+        label="option"
+        checked={checked}
+        onChange={setChecked}
+        {...extraProps}
+      />
+    );
+  }
+
+  function renderStatefulCheckbox(extraProps: Record<string, unknown>) {
+    const { getByRole } = render(<StatefulCheckbox extraProps={extraProps} />);
+    const checkbox = getByRole("checkbox");
+    checkbox.focus();
+    return { checkbox };
+  }
+
   function pressSpace(el: HTMLElement) {
     fireEvent.keyDown(el, { key: " ", code: "Space" });
     fireEvent.keyUp(el, { key: " ", code: "Space" });
+  }
+
+  function pressEnter(el: HTMLElement) {
+    fireEvent.keyDown(el, { key: "Enter", code: "Enter" });
+    fireEvent.keyUp(el, { key: "Enter", code: "Enter" });
   }
 
   // Control: proves the test reproduces voodo's Space-to-toggle, so the guard
@@ -87,5 +112,14 @@ describe("checkboxNoSpaceToggleProps on a voodo Checkbox", () => {
     const { checkbox, onChange } = renderCheckbox(checkboxNoSpaceToggleProps);
     fireEvent.click(checkbox);
     expect(onChange).toHaveBeenCalled();
+  });
+
+  it("still toggles on Enter with the guard props", () => {
+    const { checkbox } = renderStatefulCheckbox(checkboxNoSpaceToggleProps);
+    expect(checkbox.getAttribute("aria-checked")).toBe("false");
+
+    pressEnter(checkbox);
+
+    expect(checkbox.getAttribute("aria-checked")).toBe("true");
   });
 });

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-settings-keyboard.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-settings-keyboard.ts
@@ -6,14 +6,20 @@ function isSpaceKey(event: React.KeyboardEvent<HTMLElement>): boolean {
   );
 }
 
+function isEnterKey(event: React.KeyboardEvent<HTMLElement>): boolean {
+  return event.key === "Enter" || event.code === "Enter";
+}
+
 // The modal reserves bare Space for playback. voodo's Checkbox is a Headless UI
 // `role="checkbox"` whose Space-toggle fires on key *up*, so accidental focus in
 // the settings sidebar would otherwise flip a label/source setting when the user
 // means to play or pause. Cancelling the event suppresses that toggle: voodo
 // merges consumer handlers ahead of its own and short-circuits the chain once
 // `defaultPrevented` is set, so our preventDefault wins. We deliberately guard
-// keyDown as well — it cancels Space's default page-scroll and any
-// native-checkbox fallback — so don't drop it. Pointer/click toggles stay intact.
+// keyDown as well; it cancels Space's default page-scroll and any
+// native-checkbox fallback, so don't drop it. Enter gets an explicit click
+// fallback on keyUp so keyboard users can still toggle these guarded checkboxes.
+// Pointer/click toggles stay intact.
 export function preventSettingsCheckboxSpaceToggle(
   event: React.KeyboardEvent<HTMLElement>
 ) {
@@ -22,7 +28,18 @@ export function preventSettingsCheckboxSpaceToggle(
   }
 }
 
+function handleSettingsCheckboxKeyUp(event: React.KeyboardEvent<HTMLElement>) {
+  if (isSpaceKey(event)) {
+    event.preventDefault();
+    return;
+  }
+  if (isEnterKey(event)) {
+    event.preventDefault();
+    event.currentTarget.click();
+  }
+}
+
 export const checkboxNoSpaceToggleProps = {
   onKeyDown: preventSettingsCheckboxSpaceToggle,
-  onKeyUp: preventSettingsCheckboxSpaceToggle,
+  onKeyUp: handleSettingsCheckboxKeyUp,
 };

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-settings-keyboard.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-settings-keyboard.ts
@@ -1,0 +1,28 @@
+import type React from "react";
+
+function isSpaceKey(event: React.KeyboardEvent<HTMLElement>): boolean {
+  return (
+    event.key === " " || event.key === "Spacebar" || event.code === "Space"
+  );
+}
+
+// The modal reserves bare Space for playback. voodo's Checkbox is a Headless UI
+// `role="checkbox"` whose Space-toggle fires on key *up*, so accidental focus in
+// the settings sidebar would otherwise flip a label/source setting when the user
+// means to play or pause. Cancelling the event suppresses that toggle: voodo
+// merges consumer handlers ahead of its own and short-circuits the chain once
+// `defaultPrevented` is set, so our preventDefault wins. We deliberately guard
+// keyDown as well — it cancels Space's default page-scroll and any
+// native-checkbox fallback — so don't drop it. Pointer/click toggles stay intact.
+export function preventSettingsCheckboxSpaceToggle(
+  event: React.KeyboardEvent<HTMLElement>
+) {
+  if (isSpaceKey(event)) {
+    event.preventDefault();
+  }
+}
+
+export const checkboxNoSpaceToggleProps = {
+  onKeyDown: preventSettingsCheckboxSpaceToggle,
+  onKeyUp: preventSettingsCheckboxSpaceToggle,
+};

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-topic-cache.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-topic-cache.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+import type { McapDecodedMessage } from "../types";
+import { McapTopicCache } from "./mcap-topic-cache";
+
+const MESSAGE = {
+  decoded: { output: { visualization: null } },
+} as unknown as McapDecodedMessage;
+
+describe("McapTopicCache", () => {
+  it("publishes revision changes when cached tick contents change", () => {
+    const cache = new McapTopicCache();
+    const listener = vi.fn();
+    const unsubscribe = cache.subscribeToChanges(listener);
+
+    cache.set(1n, MESSAGE);
+    expect(cache.revision).toBe(1);
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    cache.set(1n, MESSAGE);
+    expect(cache.revision).toBe(1);
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    cache.set(1n, null);
+    expect(cache.revision).toBe(2);
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+    cache.set(2n, MESSAGE);
+    expect(cache.revision).toBe(3);
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it("bumps revision when a distinct message replaces the same tick", () => {
+    const cache = new McapTopicCache();
+    const listener = vi.fn();
+    cache.subscribeToChanges(listener);
+
+    cache.set(1n, MESSAGE);
+    expect(cache.revision).toBe(1);
+
+    // A new object with equivalent contents for the same tick is the path that
+    // drives re-renders during re-fetch — identity differs from the cached
+    // entry, so it must bump even though an entry already exists.
+    cache.set(1n, { ...MESSAGE });
+    expect(cache.revision).toBe(2);
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it("publishes when clear removes cached entries", () => {
+    const cache = new McapTopicCache();
+    const listener = vi.fn();
+    cache.subscribeToChanges(listener);
+
+    cache.clear();
+    expect(cache.revision).toBe(0);
+    expect(listener).not.toHaveBeenCalled();
+
+    cache.set(1n, MESSAGE);
+    cache.clear();
+
+    expect(cache.revision).toBe(2);
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears and publishes when the final active subscriber leaves", () => {
+    const cache = new McapTopicCache();
+    const listener = vi.fn();
+    cache.subscribeToChanges(listener);
+
+    const release = cache.subscribe();
+    cache.set(1n, MESSAGE);
+    release();
+
+    expect(cache.revision).toBe(2);
+    expect(cache.get(1n)).toBeUndefined();
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+});

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-topic-cache.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-topic-cache.test.ts
@@ -75,4 +75,21 @@ describe("McapTopicCache", () => {
     expect(cache.get(1n)).toBeUndefined();
     expect(listener).toHaveBeenCalledTimes(2);
   });
+
+  it("guards against a double release clearing the cache while another subscriber is active", () => {
+    const cache = new McapTopicCache();
+    const releaseA = cache.subscribe();
+    const releaseB = cache.subscribe();
+    expect(cache.isActive).toBe(true);
+
+    releaseA();
+    // StrictMode can fire the same cleanup twice; the second call must be a
+    // no-op rather than decrementing again (which would drop to 0 and clear
+    // while releaseB still holds the cache).
+    releaseA();
+    expect(cache.isActive).toBe(true);
+
+    releaseB();
+    expect(cache.isActive).toBe(false);
+  });
 });

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-topic-cache.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-topic-cache.ts
@@ -16,10 +16,17 @@ interface CacheEntry {
  * topic — distinct from "not yet fetched", which `has()` reports as false.
  * Tracks subscriber count so the data stream can skip fetching for topics
  * with no active tiles.
+ *
+ * The cache is also a tiny external store: interpolation hooks read lookahead
+ * messages directly from it, so they subscribe to `revision` changes via
+ * `subscribeToChanges()` instead of waiting for the playback stream value to
+ * change.
  */
 export class McapTopicCache {
   private readonly cache: LRUCache<string, CacheEntry>;
+  private readonly listeners = new Set<() => void>();
   private _subscriberCount = 0;
+  private _revision = 0;
 
   constructor(maxEntries = DEFAULT_MAX_ENTRIES) {
     this.cache = new LRUCache({ max: maxEntries });
@@ -27,6 +34,10 @@ export class McapTopicCache {
 
   get isActive(): boolean {
     return this._subscriberCount > 0;
+  }
+
+  get revision(): number {
+    return this._revision;
   }
 
   subscribe(): () => void {
@@ -43,7 +54,14 @@ export class McapTopicCache {
       // for a topic no tile is rendering is pure memory pressure, and a
       // future re-subscribe should start from a clean slate so it can't
       // flash stale data while the next fetch lands.
-      if (this._subscriberCount === 0) this.cache.clear();
+      if (this._subscriberCount === 0) this.clear();
+    };
+  }
+
+  subscribeToChanges(listener: () => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
     };
   }
 
@@ -56,7 +74,13 @@ export class McapTopicCache {
   }
 
   set(tick: bigint, msg: McapDecodedMessage | null): void {
-    this.cache.set(tick.toString(), { msg });
+    const key = tick.toString();
+    const hadEntry = this.cache.has(key);
+    // peek() reads the prior value without refreshing LRU recency, so re-setting
+    // an unchanged value doesn't promote the entry toward the front of the cache.
+    const previous = this.cache.peek(key)?.msg;
+    this.cache.set(key, { msg });
+    if (!hadEntry || previous !== msg) this.bumpRevision();
   }
 
   /** Drop every cached entry without touching subscriptions. Used when
@@ -64,6 +88,13 @@ export class McapTopicCache {
    *  previously-cached frames are now from a different recording and
    *  must not be reused. */
   clear(): void {
+    if (this.cache.size === 0) return;
     this.cache.clear();
+    this.bumpRevision();
+  }
+
+  private bumpRevision(): void {
+    this._revision++;
+    for (const listener of this.listeners) listener();
   }
 }

--- a/app/packages/multimodal/src/adapters/mcap/react/use-interpolated-image-annotations.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-interpolated-image-annotations.test.tsx
@@ -1,0 +1,639 @@
+import { act, cleanup, render } from "@testing-library/react";
+import { StrictMode, useEffect, type ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { ImageAnnotationsVisualization } from "../../../decoders";
+import { VISUALIZATION_KIND } from "../../../visualization";
+import type { McapDecodedMessage } from "../types";
+import {
+  McapDataStreamProvider,
+  useSetMcapDataStream,
+  type McapDataStream,
+} from "./mcap-data-stream-context";
+import type { McapTimelineIndex } from "./mcap-timeline-index";
+import { McapTopicCache } from "./mcap-topic-cache";
+import {
+  useInterpolatedImageAnnotations,
+  useInterpolatedImageAnnotationSets,
+} from "./use-interpolated-image-annotations";
+
+// These tests exercise the React/cache lifecycle wiring of the interpolation
+// hooks (subscription management + the useSyncExternalStore revision plumbing)
+// plus the hook's interpolation seam. The pure interpolation math is covered by
+// interpolate-image-annotations.test.
+//
+// usePlayhead is mocked so the tests are hermetic (no real PlaybackProvider RAF
+// engine / shared Jotai store that could leak across tests) and the playhead is
+// deterministic and controllable.
+const playhead = vi.hoisted(() => ({ seconds: 0 }));
+vi.mock("@fiftyone/playback", () => ({
+  usePlayhead: () => playhead.seconds,
+}));
+
+type AnnotationSets = ReturnType<typeof useInterpolatedImageAnnotationSets>;
+
+afterEach(() => {
+  cleanup();
+  playhead.seconds = 0;
+});
+
+// ---------------------------------------------------------------------------
+// Fakes — a real McapTopicCache behind a fake McapDataStream so cache.isActive
+// faithfully reports the hook's subscription state, and revision bumps drive
+// the external store for real. The stream also tracks the net active
+// subscription count so tests can assert exact counts (not just isActive).
+// ---------------------------------------------------------------------------
+
+function absBig(n: bigint): bigint {
+  return n < 0n ? -n : n;
+}
+
+function makeTimeline(ticks: readonly bigint[]): McapTimelineIndex {
+  const startTimeNs = ticks[0] ?? 0n;
+  const toNs = (sec: number) =>
+    startTimeNs + BigInt(Math.round((Number.isFinite(sec) ? sec : 0) * 1e9));
+  return {
+    ticks,
+    durationSec: 1,
+    startTimeNs,
+    secToNs: toNs,
+    nearestTick: (sec) => {
+      if (ticks.length === 0) return undefined;
+      const target = toNs(sec);
+      let best = ticks[0];
+      let bestDiff = absBig(target - best);
+      for (const t of ticks) {
+        const diff = absBig(target - t);
+        if (diff < bestDiff) {
+          bestDiff = diff;
+          best = t;
+        }
+      }
+      return best;
+    },
+  };
+}
+
+function makeStream(
+  caches: Map<string, McapTopicCache>,
+  timeline: McapTimelineIndex
+) {
+  let active = 0;
+  const subscribeToTopic = vi.fn((topic: string) => {
+    const cache = caches.get(topic);
+    const release = cache ? cache.subscribe() : () => undefined;
+    active += 1;
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      active -= 1;
+      release();
+    };
+  });
+  const stream: McapDataStream = {
+    subscribeToTopic,
+    getTopicCache: (topic) => caches.get(topic),
+    getTimelineIndex: () => timeline,
+  };
+  return { stream, subscribeToTopic, activeCount: () => active };
+}
+
+function emptyViz(): ImageAnnotationsVisualization {
+  return {
+    kind: VISUALIZATION_KIND.IMAGE_ANNOTATIONS,
+    circles: [],
+    points: [],
+    texts: [],
+  };
+}
+
+function circleViz(
+  position: readonly [number, number]
+): ImageAnnotationsVisualization {
+  return {
+    kind: VISUALIZATION_KIND.IMAGE_ANNOTATIONS,
+    circles: [
+      {
+        position,
+        diameter: 4,
+        thickness: 1,
+        outlineColor: null,
+        fillColor: null,
+      },
+    ],
+    points: [],
+    texts: [],
+  };
+}
+
+function message(
+  timelineTimeNs: bigint,
+  viz: ImageAnnotationsVisualization
+): McapDecodedMessage {
+  return {
+    timelineTimeNs,
+    decoded: { output: { visualization: viz } },
+  } as unknown as McapDecodedMessage;
+}
+
+function captureResult() {
+  let latest: AnnotationSets = [];
+  const onResult = vi.fn((sets: AnnotationSets) => {
+    latest = sets;
+  });
+  return { onResult, latest: () => latest };
+}
+
+function captureFrame() {
+  let latest: ImageAnnotationsVisualization | null = null;
+  const onResult = vi.fn((frame: ImageAnnotationsVisualization | null) => {
+    latest = frame;
+  });
+  return { onResult, latest: () => latest };
+}
+
+function Harness({
+  stream,
+  topics,
+  interpolate = true,
+  onResult,
+}: {
+  readonly stream: McapDataStream | null;
+  readonly topics: readonly string[];
+  readonly interpolate?: boolean;
+  readonly onResult: (sets: AnnotationSets) => void;
+}) {
+  const setStream = useSetMcapDataStream();
+  // Publish the test stream into context (the provider has no value prop).
+  useEffect(() => {
+    setStream(stream);
+  }, [setStream, stream]);
+
+  const sets = useInterpolatedImageAnnotationSets(topics, { interpolate });
+  // Surface the latest derived sets to the test.
+  useEffect(() => {
+    onResult(sets);
+  }, [onResult, sets]);
+  return null;
+}
+
+function SingleHarness({
+  stream,
+  topic,
+  onResult,
+}: {
+  readonly stream: McapDataStream | null;
+  readonly topic: string;
+  readonly onResult: (frame: ImageAnnotationsVisualization | null) => void;
+}) {
+  const setStream = useSetMcapDataStream();
+  useEffect(() => {
+    setStream(stream);
+  }, [setStream, stream]);
+
+  const frame = useInterpolatedImageAnnotations(topic);
+  useEffect(() => {
+    onResult(frame);
+  }, [onResult, frame]);
+  return null;
+}
+
+function TestProviders({ children }: { readonly children: ReactNode }) {
+  return <McapDataStreamProvider>{children}</McapDataStreamProvider>;
+}
+
+const TICKS = [0n, 1_000_000n, 2_000_000n] as const;
+
+// ---------------------------------------------------------------------------
+
+describe("useInterpolatedImageAnnotationSets — subscription lifecycle", () => {
+  it("subscribes once per topic on mount and marks caches active", () => {
+    const cacheA = new McapTopicCache();
+    const cacheB = new McapTopicCache();
+    const { stream, subscribeToTopic } = makeStream(
+      new Map([
+        ["/a", cacheA],
+        ["/b", cacheB],
+      ]),
+      makeTimeline(TICKS)
+    );
+    const { onResult } = captureResult();
+
+    render(
+      <Harness stream={stream} topics={["/a", "/b"]} onResult={onResult} />,
+      {
+        wrapper: TestProviders,
+      }
+    );
+
+    expect(subscribeToTopic).toHaveBeenCalledTimes(2);
+    expect(subscribeToTopic).toHaveBeenCalledWith("/a");
+    expect(subscribeToTopic).toHaveBeenCalledWith("/b");
+    expect(cacheA.isActive).toBe(true);
+    expect(cacheB.isActive).toBe(true);
+  });
+
+  it("unsubscribes every topic on unmount", () => {
+    const cacheA = new McapTopicCache();
+    const cacheB = new McapTopicCache();
+    const { stream } = makeStream(
+      new Map([
+        ["/a", cacheA],
+        ["/b", cacheB],
+      ]),
+      makeTimeline(TICKS)
+    );
+    const { onResult } = captureResult();
+
+    const { unmount } = render(
+      <Harness stream={stream} topics={["/a", "/b"]} onResult={onResult} />,
+      { wrapper: TestProviders }
+    );
+    expect(cacheA.isActive).toBe(true);
+
+    unmount();
+
+    expect(cacheA.isActive).toBe(false);
+    expect(cacheB.isActive).toBe(false);
+  });
+
+  it("subscribes when the data stream transitions from null to a real stream", () => {
+    const cacheA = new McapTopicCache();
+    const { stream, subscribeToTopic } = makeStream(
+      new Map([["/a", cacheA]]),
+      makeTimeline(TICKS)
+    );
+    const { onResult, latest } = captureResult();
+
+    const { rerender } = render(
+      <Harness stream={null} topics={["/a"]} onResult={onResult} />,
+      { wrapper: TestProviders }
+    );
+    expect(subscribeToTopic).not.toHaveBeenCalled();
+    expect(latest()).toEqual([]);
+
+    rerender(<Harness stream={stream} topics={["/a"]} onResult={onResult} />);
+
+    expect(subscribeToTopic).toHaveBeenCalledWith("/a");
+    expect(cacheA.isActive).toBe(true);
+  });
+
+  it("subscribes only the newly added topic when topics grow", () => {
+    const cacheA = new McapTopicCache();
+    const cacheB = new McapTopicCache();
+    const { stream, subscribeToTopic } = makeStream(
+      new Map([
+        ["/a", cacheA],
+        ["/b", cacheB],
+      ]),
+      makeTimeline(TICKS)
+    );
+    const { onResult } = captureResult();
+
+    const { rerender } = render(
+      <Harness stream={stream} topics={["/a"]} onResult={onResult} />,
+      { wrapper: TestProviders }
+    );
+    expect(subscribeToTopic).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <Harness stream={stream} topics={["/a", "/b"]} onResult={onResult} />
+    );
+
+    expect(subscribeToTopic).toHaveBeenCalledWith("/b");
+    // "/a" is not re-subscribed.
+    expect(
+      subscribeToTopic.mock.calls.filter(([t]) => t === "/a")
+    ).toHaveLength(1);
+    expect(cacheA.isActive).toBe(true);
+    expect(cacheB.isActive).toBe(true);
+  });
+
+  it("unsubscribes only the dropped topic when topics shrink", () => {
+    const cacheA = new McapTopicCache();
+    const cacheB = new McapTopicCache();
+    const { stream } = makeStream(
+      new Map([
+        ["/a", cacheA],
+        ["/b", cacheB],
+      ]),
+      makeTimeline(TICKS)
+    );
+    const { onResult } = captureResult();
+
+    const { rerender } = render(
+      <Harness stream={stream} topics={["/a", "/b"]} onResult={onResult} />,
+      { wrapper: TestProviders }
+    );
+
+    rerender(<Harness stream={stream} topics={["/a"]} onResult={onResult} />);
+
+    expect(cacheA.isActive).toBe(true);
+    expect(cacheB.isActive).toBe(false);
+  });
+
+  it("does not re-bind subscriptions when an equal-but-new topics array is passed", () => {
+    const cacheA = new McapTopicCache();
+    // Spying on subscribeToChanges detects external-store churn: if
+    // useStableTopics stopped returning a stable identity, the snapshot
+    // subscribe callback would change and useSyncExternalStore would re-bind.
+    const subscribeToChanges = vi.spyOn(cacheA, "subscribeToChanges");
+    const { stream, subscribeToTopic } = makeStream(
+      new Map([["/a", cacheA]]),
+      makeTimeline(TICKS)
+    );
+    const { onResult } = captureResult();
+
+    const { rerender } = render(
+      <Harness stream={stream} topics={["/a"]} onResult={onResult} />,
+      { wrapper: TestProviders }
+    );
+    const bindingsAfterMount = subscribeToChanges.mock.calls.length;
+
+    rerender(<Harness stream={stream} topics={["/a"]} onResult={onResult} />);
+
+    expect(subscribeToTopic).toHaveBeenCalledTimes(1);
+    expect(subscribeToChanges.mock.calls.length).toBe(bindingsAfterMount);
+  });
+
+  it("normalizes away empty topics before subscribing", () => {
+    const cacheA = new McapTopicCache();
+    const { stream, subscribeToTopic } = makeStream(
+      new Map([["/a", cacheA]]),
+      makeTimeline(TICKS)
+    );
+    const { onResult } = captureResult();
+
+    render(
+      <Harness stream={stream} topics={["/a", ""]} onResult={onResult} />,
+      {
+        wrapper: TestProviders,
+      }
+    );
+
+    expect(subscribeToTopic).toHaveBeenCalledTimes(1);
+    expect(subscribeToTopic).toHaveBeenCalledWith("/a");
+    expect(subscribeToTopic).not.toHaveBeenCalledWith("");
+  });
+
+  it("releases the old stream and resubscribes when the data stream is swapped", () => {
+    const timeline = makeTimeline(TICKS);
+    const streamACache = new McapTopicCache();
+    const streamBCache = new McapTopicCache();
+    const { stream: streamA, subscribeToTopic: subA } = makeStream(
+      new Map([["/a", streamACache]]),
+      timeline
+    );
+    const { stream: streamB, subscribeToTopic: subB } = makeStream(
+      new Map([["/a", streamBCache]]),
+      timeline
+    );
+    const { onResult } = captureResult();
+
+    const { rerender } = render(
+      <Harness stream={streamA} topics={["/a"]} onResult={onResult} />,
+      { wrapper: TestProviders }
+    );
+    expect(subA).toHaveBeenCalledTimes(1);
+    expect(streamACache.isActive).toBe(true);
+
+    rerender(<Harness stream={streamB} topics={["/a"]} onResult={onResult} />);
+
+    expect(streamACache.isActive).toBe(false);
+    expect(subB).toHaveBeenCalledWith("/a");
+    expect(streamBCache.isActive).toBe(true);
+  });
+
+  it("releases subscriptions and returns [] when the stream becomes null", () => {
+    const cacheA = new McapTopicCache();
+    const { stream } = makeStream(
+      new Map([["/a", cacheA]]),
+      makeTimeline(TICKS)
+    );
+    const { onResult, latest } = captureResult();
+
+    const { rerender } = render(
+      <Harness stream={stream} topics={["/a"]} onResult={onResult} />,
+      { wrapper: TestProviders }
+    );
+    expect(cacheA.isActive).toBe(true);
+
+    rerender(<Harness stream={null} topics={["/a"]} onResult={onResult} />);
+
+    expect(cacheA.isActive).toBe(false);
+    expect(latest()).toEqual([]);
+  });
+});
+
+describe("useInterpolatedImageAnnotationSets — external-store recompute", () => {
+  it("derives a frame when a cache revision bumps in", () => {
+    const cacheA = new McapTopicCache();
+    const { stream } = makeStream(
+      new Map([["/a", cacheA]]),
+      makeTimeline(TICKS)
+    );
+    const { onResult, latest } = captureResult();
+
+    render(<Harness stream={stream} topics={["/a"]} onResult={onResult} />, {
+      wrapper: TestProviders,
+    });
+    expect(latest()).toEqual([]);
+
+    act(() => {
+      cacheA.set(TICKS[0], message(TICKS[0], emptyViz()));
+    });
+
+    expect(latest()).toHaveLength(1);
+    expect(latest()[0].topic).toBe("/a");
+    expect(latest()[0].frame.kind).toBe(VISUALIZATION_KIND.IMAGE_ANNOTATIONS);
+  });
+
+  it("does not recompute when an unchanged message is re-set (no revision bump)", () => {
+    const cacheA = new McapTopicCache();
+    const { stream } = makeStream(
+      new Map([["/a", cacheA]]),
+      makeTimeline(TICKS)
+    );
+    const { onResult } = captureResult();
+
+    render(<Harness stream={stream} topics={["/a"]} onResult={onResult} />, {
+      wrapper: TestProviders,
+    });
+    const msg = message(TICKS[0], emptyViz());
+    act(() => {
+      cacheA.set(TICKS[0], msg);
+    });
+
+    const callsAfterFirstSet = onResult.mock.calls.length;
+    act(() => {
+      cacheA.set(TICKS[0], msg); // identical object -> no bump -> no re-render
+    });
+    expect(onResult.mock.calls.length).toBe(callsAfterFirstSet);
+  });
+
+  it("recomputes to empty when the cache is cleared", () => {
+    const cacheA = new McapTopicCache();
+    const { stream } = makeStream(
+      new Map([["/a", cacheA]]),
+      makeTimeline(TICKS)
+    );
+    const { onResult, latest } = captureResult();
+
+    render(<Harness stream={stream} topics={["/a"]} onResult={onResult} />, {
+      wrapper: TestProviders,
+    });
+    act(() => {
+      cacheA.set(TICKS[0], message(TICKS[0], emptyViz()));
+    });
+    expect(latest()).toHaveLength(1);
+
+    act(() => {
+      cacheA.clear();
+    });
+    expect(latest()).toEqual([]);
+  });
+
+  it("re-binds revision subscriptions to the newly watched topic", () => {
+    const cacheA = new McapTopicCache();
+    const cacheB = new McapTopicCache();
+    const { stream } = makeStream(
+      new Map([
+        ["/a", cacheA],
+        ["/b", cacheB],
+      ]),
+      makeTimeline(TICKS)
+    );
+    const { onResult, latest } = captureResult();
+
+    const { rerender } = render(
+      <Harness stream={stream} topics={["/a"]} onResult={onResult} />,
+      { wrapper: TestProviders }
+    );
+
+    rerender(<Harness stream={stream} topics={["/b"]} onResult={onResult} />);
+    expect(latest()).toEqual([]);
+
+    // A LIVE bump on /b after switching only reaches the hook if the snapshot
+    // subscription re-bound to /b's cache.
+    act(() => {
+      cacheB.set(TICKS[0], message(TICKS[0], emptyViz()));
+    });
+    expect(latest()).toHaveLength(1);
+    expect(latest()[0].topic).toBe("/b");
+
+    // A bump on /a (no longer watched) must NOT reach the hook — its binding
+    // was released.
+    const callsBeforeStaleBump = onResult.mock.calls.length;
+    act(() => {
+      cacheA.set(TICKS[0], message(TICKS[0], emptyViz()));
+    });
+    expect(onResult.mock.calls.length).toBe(callsBeforeStaleBump);
+  });
+});
+
+describe("useInterpolatedImageAnnotationSets — interpolation seam", () => {
+  it("interpolates between the surrounding cached messages at the playhead", () => {
+    const ticks = [0n, 1_000_000n, 2_000_000n];
+    // playhead 0.0005s -> 500_000ns -> fraction 0.25 between tick 0n and 2_000_000n
+    playhead.seconds = 0.0005;
+    const cacheA = new McapTopicCache();
+    const { stream } = makeStream(
+      new Map([["/a", cacheA]]),
+      makeTimeline(ticks)
+    );
+    const { onResult, latest } = captureResult();
+
+    render(<Harness stream={stream} topics={["/a"]} onResult={onResult} />, {
+      wrapper: TestProviders,
+    });
+    act(() => {
+      cacheA.set(0n, message(0n, circleViz([0, 0])));
+      cacheA.set(2_000_000n, message(2_000_000n, circleViz([100, 0])));
+    });
+
+    expect(latest()).toHaveLength(1);
+    // lerp([0,0] -> [100,0], 0.25) === [25, 0]
+    expect(latest()[0].frame.circles[0].position).toEqual([25, 0]);
+  });
+
+  it("returns the current frame without lerping when interpolate is false", () => {
+    const ticks = [0n, 1_000_000n, 2_000_000n];
+    playhead.seconds = 0.0005;
+    const cacheA = new McapTopicCache();
+    const { stream } = makeStream(
+      new Map([["/a", cacheA]]),
+      makeTimeline(ticks)
+    );
+    const { onResult, latest } = captureResult();
+
+    render(
+      <Harness
+        stream={stream}
+        topics={["/a"]}
+        interpolate={false}
+        onResult={onResult}
+      />,
+      { wrapper: TestProviders }
+    );
+    act(() => {
+      cacheA.set(0n, message(0n, circleViz([0, 0])));
+      cacheA.set(2_000_000n, message(2_000_000n, circleViz([100, 0])));
+    });
+
+    expect(latest()).toHaveLength(1);
+    // current frame at the playhead (nearest tick 0n), no lerp toward [100,0]
+    expect(latest()[0].frame.circles[0].position).toEqual([0, 0]);
+  });
+
+  it("single-topic wrapper returns the frame or null", () => {
+    const cacheA = new McapTopicCache();
+    const { stream } = makeStream(
+      new Map([["/a", cacheA]]),
+      makeTimeline(TICKS)
+    );
+    const { onResult, latest } = captureFrame();
+
+    render(<SingleHarness stream={stream} topic="/a" onResult={onResult} />, {
+      wrapper: TestProviders,
+    });
+    expect(latest()).toBeNull();
+
+    act(() => {
+      cacheA.set(TICKS[0], message(TICKS[0], emptyViz()));
+    });
+    expect(latest()?.kind).toBe(VISUALIZATION_KIND.IMAGE_ANNOTATIONS);
+  });
+});
+
+describe("useInterpolatedImageAnnotationSets — StrictMode", () => {
+  it("nets to a single subscription on mount and releases it on unmount", () => {
+    const cacheA = new McapTopicCache();
+    const { stream, activeCount } = makeStream(
+      new Map([["/a", cacheA]]),
+      makeTimeline(TICKS)
+    );
+    const { onResult, latest } = captureResult();
+
+    const { unmount } = render(
+      <StrictMode>
+        <Harness stream={stream} topics={["/a"]} onResult={onResult} />
+      </StrictMode>,
+      { wrapper: TestProviders }
+    );
+
+    // Double-invoked effects must net to EXACTLY one active subscription, not
+    // two (isActive alone would not distinguish a leak).
+    expect(activeCount()).toBe(1);
+    expect(cacheA.isActive).toBe(true);
+
+    act(() => {
+      cacheA.set(TICKS[0], message(TICKS[0], emptyViz()));
+    });
+    expect(latest()).toHaveLength(1);
+
+    unmount();
+    expect(activeCount()).toBe(0);
+    expect(cacheA.isActive).toBe(false);
+  });
+});

--- a/app/packages/multimodal/src/adapters/mcap/react/use-interpolated-image-annotations.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-interpolated-image-annotations.test.tsx
@@ -165,13 +165,13 @@ function Harness({
   readonly onResult: (sets: AnnotationSets) => void;
 }) {
   const setStream = useSetMcapDataStream();
-  // Publish the test stream into context (the provider has no value prop).
+  // This effect publishes the test stream into context.
   useEffect(() => {
     setStream(stream);
   }, [setStream, stream]);
 
   const sets = useInterpolatedImageAnnotationSets(topics, { interpolate });
-  // Surface the latest derived sets to the test.
+  // This effect surfaces the latest derived annotation sets to the test.
   useEffect(() => {
     onResult(sets);
   }, [onResult, sets]);
@@ -188,11 +188,13 @@ function SingleHarness({
   readonly onResult: (frame: ImageAnnotationsVisualization | null) => void;
 }) {
   const setStream = useSetMcapDataStream();
+  // This effect publishes the test stream into context.
   useEffect(() => {
     setStream(stream);
   }, [setStream, stream]);
 
   const frame = useInterpolatedImageAnnotations(topic);
+  // This effect surfaces the latest derived annotation frame to the test.
   useEffect(() => {
     onResult(frame);
   }, [onResult, frame]);

--- a/app/packages/multimodal/src/adapters/mcap/react/use-interpolated-image-annotations.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-interpolated-image-annotations.test.tsx
@@ -379,6 +379,34 @@ describe("useInterpolatedImageAnnotationSets — subscription lifecycle", () => 
     expect(subscribeToTopic).not.toHaveBeenCalledWith("");
   });
 
+  it("deduplicates topics before subscribing", () => {
+    const cacheA = new McapTopicCache();
+    const cacheB = new McapTopicCache();
+    const { stream, subscribeToTopic } = makeStream(
+      new Map([
+        ["/a", cacheA],
+        ["/b", cacheB],
+      ]),
+      makeTimeline(TICKS)
+    );
+    const { onResult } = captureResult();
+
+    render(
+      <Harness
+        stream={stream}
+        topics={["/a", "/b", "/a"]}
+        onResult={onResult}
+      />,
+      {
+        wrapper: TestProviders,
+      }
+    );
+
+    expect(subscribeToTopic).toHaveBeenCalledTimes(2);
+    expect(subscribeToTopic).toHaveBeenCalledWith("/a");
+    expect(subscribeToTopic).toHaveBeenCalledWith("/b");
+  });
+
   it("releases the old stream and resubscribes when the data stream is swapped", () => {
     const timeline = makeTimeline(TICKS);
     const streamACache = new McapTopicCache();

--- a/app/packages/multimodal/src/adapters/mcap/react/use-interpolated-image-annotations.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-interpolated-image-annotations.ts
@@ -1,5 +1,11 @@
 import { usePlayhead } from "@fiftyone/playback";
-import { useEffect, useMemo } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useSyncExternalStore,
+} from "react";
 
 import type {
   ImageAnnotationCircle,
@@ -9,7 +15,12 @@ import type {
 } from "../../../decoders";
 import { groupLineSegmentsByLabel } from "../../../utils/line-segment-grouping";
 import type { McapDecodedMessage } from "../types";
-import { useMcapDataStream } from "./mcap-data-stream-context";
+import {
+  useMcapDataStream,
+  type McapDataStream,
+} from "./mcap-data-stream-context";
+import type { McapTimelineIndex } from "./mcap-timeline-index";
+import type { McapTopicCache } from "./mcap-topic-cache";
 
 /**
  * Returns the annotation visualization for `topic` at the current playhead,
@@ -21,79 +32,305 @@ import { useMcapDataStream } from "./mcap-data-stream-context";
  * gap visually we lerp between the prev and next annotation message by
  * fraction `(now - prev_t) / (next_t - prev_t)`.
  *
- * Foxglove doesn't carry stable instance IDs across messages, so we run a
- * greedy nearest-centroid matching pass between prev and next groups
- * (connected-component clusters of the LINE_LIST segments, keyed by their
- * inferred label) and only lerp matched pairs. Unmatched groups in prev
- * stay put; unmatched groups in next don't appear until the next message
- * becomes current.
+ * Foxglove doesn't carry stable instance IDs across messages, so we group
+ * LINE_LIST segments into per-object chunks, run a greedy label + geometry
+ * matching pass between prev/next groups, and only lerp matched pairs.
+ * Unmatched groups in prev stay put; unmatched groups in next don't appear
+ * until the next message becomes current.
  */
 export interface UseInterpolatedImageAnnotationsOptions {
   /** When false, returns the current annotation as-is with no lerping. */
   readonly interpolate?: boolean;
 }
 
+const EMPTY_TOPICS: readonly string[] = [];
+// Forward-scan budget when searching for the next distinct annotation to lerp
+// toward. Coupled to the ~30 Hz timeline tick rate: 120 ticks ≈ 4s, which
+// comfortably spans the ~2 Hz annotation cadence. If the tick rate changes,
+// revisit this — set too low, sparse annotations silently stop interpolating.
+const MAX_NEXT_MESSAGE_SCAN_TICKS = 120;
+
 export function useInterpolatedImageAnnotations(
   topic: string,
   { interpolate = true }: UseInterpolatedImageAnnotationsOptions = {}
 ): ImageAnnotationsVisualization | null {
+  const topics = useMemo(() => (topic ? [topic] : EMPTY_TOPICS), [topic]);
+  const sets = useInterpolatedImageAnnotationSets(topics, { interpolate });
+  return sets[0]?.frame ?? null;
+}
+
+/**
+ * Returns decoded image-annotation visualizations for every selected
+ * annotation topic, in topic order, omitting topics with no frame at the
+ * current playhead.
+ */
+export function useInterpolatedImageAnnotationSets(
+  topics: readonly string[],
+  { interpolate = true }: UseInterpolatedImageAnnotationsOptions = {}
+): readonly {
+  readonly frame: ImageAnnotationsVisualization;
+  readonly topic: string;
+}[] {
+  const stableTopics = useStableTopics(topics);
   const dataStream = useMcapDataStream();
+  const subscriptionsRef = useRef<Map<string, () => void>>(new Map());
+  const streamRef = useRef<McapDataStream | null>(null);
+  const topicSet = useMemo(() => new Set(stableTopics), [stableTopics]);
 
   useEffect(() => {
-    if (!topic || !dataStream) return undefined;
-    return dataStream.subscribeToTopic(topic);
-  }, [topic, dataStream]);
+    const subscriptions = subscriptionsRef.current;
+
+    if (streamRef.current !== dataStream) {
+      for (const unsubscribe of subscriptions.values()) unsubscribe();
+      subscriptions.clear();
+      streamRef.current = dataStream;
+    }
+    if (!dataStream) return;
+
+    for (const [topic, unsubscribe] of subscriptions) {
+      if (!topicSet.has(topic)) {
+        unsubscribe();
+        subscriptions.delete(topic);
+      }
+    }
+    for (const topic of stableTopics) {
+      if (!subscriptions.has(topic)) {
+        subscriptions.set(topic, dataStream.subscribeToTopic(topic));
+      }
+    }
+  }, [dataStream, stableTopics, topicSet]);
+
+  useEffect(
+    () => () => {
+      for (const unsubscribe of subscriptionsRef.current.values()) {
+        unsubscribe();
+      }
+      subscriptionsRef.current.clear();
+    },
+    []
+  );
 
   // Re-render every RAF tick so the lerp tracks the playhead.
   const playhead = usePlayhead();
-
-  const cache = dataStream?.getTopicCache(topic);
   const timeline = dataStream?.getTimelineIndex() ?? null;
+  const cacheSnapshot = useTopicCacheSnapshot(dataStream, stableTopics);
 
-  return useMemo<ImageAnnotationsVisualization | null>(() => {
-    if (!cache || !timeline) return null;
+  return useMemo(
+    () =>
+      annotationSetsFromCaches({
+        cacheSnapshot,
+        dataStream,
+        interpolate,
+        playhead,
+        timeline,
+        topics: stableTopics,
+      }),
+    [cacheSnapshot, dataStream, interpolate, playhead, stableTopics, timeline]
+  );
+}
 
-    const currentTick = timeline.nearestTick(playhead);
-    if (currentTick === undefined) return null;
-    const currentMsg = cache.get(currentTick);
-    if (!currentMsg) return null;
-    const currentViz = vizOf(currentMsg);
-    if (!currentViz) return null;
-    if (!interpolate) return currentViz;
+interface AnnotationSetsFromCachesArgs {
+  /** Invalidation token from `useSyncExternalStore`; frame derivation reads caches below. */
+  readonly cacheSnapshot: string;
+  readonly dataStream: McapDataStream | null;
+  readonly interpolate: boolean;
+  readonly playhead: number;
+  readonly timeline: McapTimelineIndex | null;
+  readonly topics: readonly string[];
+}
 
-    // Find next distinct annotation (different timeline time). Cached
-    // ticks return the latest <= tick under LATEST sync, so consecutive
-    // ticks alias the same source message until the next one lands.
-    const ticks = timeline.ticks;
-    let lo = 0;
-    let hi = ticks.length - 1;
-    while (lo < hi) {
-      const mid = (lo + hi) >> 1;
-      if (ticks[mid] < currentTick) lo = mid + 1;
-      else hi = mid;
+function annotationSetsFromCaches({
+  dataStream,
+  interpolate,
+  playhead,
+  timeline,
+  topics,
+}: AnnotationSetsFromCachesArgs): readonly {
+  readonly frame: ImageAnnotationsVisualization;
+  readonly topic: string;
+}[] {
+  if (!dataStream || !timeline) return [];
+
+  const sets: {
+    frame: ImageAnnotationsVisualization;
+    topic: string;
+  }[] = [];
+  for (const topic of topics) {
+    const cache = dataStream.getTopicCache(topic);
+    const frame = cache
+      ? currentAnnotationFrame({
+          cache,
+          interpolate,
+          playhead,
+          timeline,
+        })
+      : null;
+    if (frame) {
+      sets.push({ frame, topic });
     }
-    let nextMsg: McapDecodedMessage | null = null;
-    for (let i = lo + 1; i < ticks.length; i++) {
-      const m = cache.get(ticks[i]);
-      if (m && m.timelineTimeNs !== currentMsg.timelineTimeNs) {
-        nextMsg = m;
-        break;
+  }
+  return sets;
+}
+
+function useStableTopics(topics: readonly string[]): readonly string[] {
+  // Memoize on the joined contents rather than array identity, so callers can
+  // pass a fresh array every render without churning the downstream memo and
+  // external-store subscriptions. A newline can't appear in a topic name, so
+  // equal lists always yield the same key. Keying here keeps it concurrent-safe,
+  // unlike caching it through a ref written during render.
+  const normalized = normalizeTopics(topics);
+  const key = normalized.join("\n");
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- key is the content digest of `normalized`
+  return useMemo(() => normalized, [key]);
+}
+
+function useTopicCacheSnapshot(
+  dataStream: McapDataStream | null,
+  topics: readonly string[]
+): string {
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      if (!dataStream || topics.length === 0) return () => undefined;
+      // Only caches that already exist are observed. This is safe because the
+      // data stream creates every topic cache before it publishes itself, so by
+      // the time `dataStream` is non-null the caches exist. If a topic's cache
+      // could appear *after* this subscription runs, its revision bumps would go
+      // unseen — bump a dependency here to re-subscribe in that case.
+      const unsubscribeFns: (() => void)[] = [];
+      for (const topic of topics) {
+        const cache = dataStream.getTopicCache(topic);
+        if (cache) {
+          unsubscribeFns.push(cache.subscribeToChanges(onStoreChange));
+        }
       }
+      return () => {
+        for (const unsubscribe of unsubscribeFns) unsubscribe();
+      };
+    },
+    [dataStream, topics]
+  );
+
+  const getSnapshot = useCallback(
+    () => topicCacheSnapshot(dataStream, topics),
+    [dataStream, topics]
+  );
+
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+function topicCacheSnapshot(
+  dataStream: McapDataStream | null,
+  topics: readonly string[]
+): string {
+  if (!dataStream || topics.length === 0) return "";
+  let snapshot = "";
+  for (const topic of topics) {
+    const revision = dataStream.getTopicCache(topic)?.revision ?? -1;
+    snapshot += `${topic}:${revision}|`;
+  }
+  return snapshot;
+}
+
+function normalizeTopics(topics: readonly string[]): readonly string[] {
+  if (topics.length === 0) return EMPTY_TOPICS;
+  let hasEmptyTopic = false;
+  for (const topic of topics) {
+    if (!topic) {
+      hasEmptyTopic = true;
+      break;
     }
-    if (!nextMsg) return currentViz;
-    const nextViz = vizOf(nextMsg);
-    if (!nextViz) return currentViz;
+  }
+  if (!hasEmptyTopic) return topics;
 
-    const span = nextMsg.timelineTimeNs - currentMsg.timelineTimeNs;
-    if (span <= 0n) return currentViz;
-    const playheadNs = timeline.secToNs(playhead);
-    const elapsed = playheadNs - currentMsg.timelineTimeNs;
-    let f = Number(elapsed) / Number(span);
-    if (!Number.isFinite(f) || f <= 0) return currentViz;
-    if (f >= 1) f = 1;
+  const normalized: string[] = [];
+  for (const topic of topics) {
+    if (topic) normalized.push(topic);
+  }
+  return normalized.length > 0 ? normalized : EMPTY_TOPICS;
+}
 
-    return interpolateImageAnnotations(currentViz, nextViz, f);
-  }, [cache, timeline, playhead, interpolate]);
+function currentAnnotationFrame({
+  cache,
+  interpolate,
+  playhead,
+  timeline,
+}: {
+  readonly cache: McapTopicCache;
+  readonly interpolate: boolean;
+  readonly playhead: number;
+  readonly timeline: McapTimelineIndex;
+}): ImageAnnotationsVisualization | null {
+  const currentTick = timeline.nearestTick(playhead);
+  if (currentTick === undefined) return null;
+  const currentMsg = cache.get(currentTick);
+  if (!currentMsg) return null;
+  const currentViz = vizOf(currentMsg);
+  if (!currentViz) return null;
+  if (!interpolate) return currentViz;
+
+  const nextMsg = nextDistinctAnnotationMessage({
+    cache,
+    currentTick,
+    currentTimelineTimeNs: currentMsg.timelineTimeNs,
+    timeline,
+  });
+  if (!nextMsg) return currentViz;
+  const nextViz = vizOf(nextMsg);
+  if (!nextViz) return currentViz;
+
+  const f = interpolationFraction({
+    nextTimelineTimeNs: nextMsg.timelineTimeNs,
+    playheadNs: timeline.secToNs(playhead),
+    previousTimelineTimeNs: currentMsg.timelineTimeNs,
+  });
+  if (f === null) return currentViz;
+
+  return interpolateImageAnnotations(currentViz, nextViz, f);
+}
+
+function nextDistinctAnnotationMessage({
+  cache,
+  currentTick,
+  currentTimelineTimeNs,
+  timeline,
+}: {
+  readonly cache: McapTopicCache;
+  readonly currentTick: bigint;
+  readonly currentTimelineTimeNs: bigint;
+  readonly timeline: McapTimelineIndex;
+}): McapDecodedMessage | null {
+  // Ticks are synchronized with LATEST semantics, so several cached ticks can
+  // point to the same source annotation. Walk forward only far enough to find
+  // the next cached source message; if lookahead is missing, staying on the
+  // current frame is cheaper and visually safer than scanning the full file.
+  const startIndex = lowerBoundBigInt(timeline.ticks, currentTick) + 1;
+  const endIndex = Math.min(
+    timeline.ticks.length,
+    startIndex + MAX_NEXT_MESSAGE_SCAN_TICKS
+  );
+  for (let i = startIndex; i < endIndex; i++) {
+    const msg = cache.get(timeline.ticks[i]);
+    if (msg && msg.timelineTimeNs !== currentTimelineTimeNs) return msg;
+  }
+  return null;
+}
+
+function interpolationFraction({
+  nextTimelineTimeNs,
+  playheadNs,
+  previousTimelineTimeNs,
+}: {
+  readonly nextTimelineTimeNs: bigint;
+  readonly playheadNs: bigint;
+  readonly previousTimelineTimeNs: bigint;
+}): number | null {
+  const span = nextTimelineTimeNs - previousTimelineTimeNs;
+  if (span <= 0n) return null;
+  const elapsed = playheadNs - previousTimelineTimeNs;
+  if (elapsed <= 0n) return null;
+  const f = Number(elapsed) / Number(span);
+  if (!Number.isFinite(f)) return null;
+  return Math.min(1, f);
 }
 
 function vizOf(msg: McapDecodedMessage): ImageAnnotationsVisualization | null {
@@ -175,11 +412,11 @@ function interpolateTexts(
 }
 
 /**
- * Interpolation for the points array. LINE_LIST primitives carry every
- * cuboid in one big segment list; we split each into per-object groups
- * via connected components, match groups between prev and next by label
- * + centroid proximity, then lerp matched pairs. Non-line-list primitives
- * fall back to index-based interpolation.
+ * Interpolation for the points array. LINE_LIST primitives usually carry
+ * every cuboid in one big segment list; we split each into per-object
+ * groups using the same chunking helper as the overlay, match groups between
+ * prev and next, then lerp matched pairs. Non-line-list primitives fall back
+ * to index-based interpolation.
  */
 function interpolatePointsArray(
   prev: ImageAnnotationsVisualization,
@@ -210,7 +447,25 @@ function interpolateLineList(
 ): ImageAnnotationPoints {
   const prevGroups = groupLineList(prevPrim.points, prevTexts);
   const nextGroups = groupLineList(nextPrim.points, nextTexts);
+  const matchedPairs = matchLineListGroups(prevGroups, nextGroups);
 
+  const out: Point2[] = [];
+  for (const { prev, next } of matchedPairs) {
+    appendInterpolatedSegments(out, prev, next, f);
+  }
+
+  return { ...prevPrim, points: out };
+}
+
+interface MatchedGroupPair {
+  readonly prev: Group;
+  readonly next: Group | null;
+}
+
+function matchLineListGroups(
+  prevGroups: readonly Group[],
+  nextGroups: readonly Group[]
+): readonly MatchedGroupPair[] {
   // Per-prev candidate selection:
   //   1. Same label class (hard).
   //   2. Centroid within MATCH_DISTANCE_PX (coarse position filter).
@@ -220,51 +475,67 @@ function interpolateLineList(
   //      over the cuboid's unique vertices (shape similarity tiebreak).
   // Greedy: first prev to claim a next wins.
   const usedNext = new Set<number>();
-  const matchedPairs: { prev: Group; next: Group | null }[] = prevGroups.map(
-    (pg) => {
-      let bestIdx = -1;
-      let bestScore = Infinity;
-      const distSqThreshold = MATCH_DISTANCE_PX * MATCH_DISTANCE_PX;
-      for (let j = 0; j < nextGroups.length; j++) {
-        if (usedNext.has(j)) continue;
-        const ng = nextGroups[j];
-        if (ng.label !== pg.label) continue;
-        if (squaredDistance(pg.centroid, ng.centroid) > distSqThreshold) {
-          continue;
-        }
-        if (aabbIoU(pg.bounds, ng.bounds) < MIN_MATCH_IOU) continue;
-        const score = chamferDistance(pg.vertices, ng.vertices);
-        if (score < bestScore) {
-          bestScore = score;
-          bestIdx = j;
-        }
-      }
-      if (bestIdx === -1) return { prev: pg, next: null };
-      usedNext.add(bestIdx);
-      return { prev: pg, next: nextGroups[bestIdx] };
-    }
-  );
+  return prevGroups.map((prev) => {
+    const nextIndex = bestNextGroupIndex(prev, nextGroups, usedNext);
+    if (nextIndex === -1) return { prev, next: null };
+    usedNext.add(nextIndex);
+    return { prev, next: nextGroups[nextIndex] };
+  });
+}
 
-  const out: Point2[] = [];
-  for (const { prev, next } of matchedPairs) {
-    if (!next || prev.segments.length !== next.segments.length) {
-      for (const [a, b] of prev.segments) {
-        out.push(a, b);
-      }
+function bestNextGroupIndex(
+  prev: Group,
+  nextGroups: readonly Group[],
+  usedNext: ReadonlySet<number>
+): number {
+  let bestIdx = -1;
+  let bestScore = Infinity;
+  const distSqThreshold = MATCH_DISTANCE_PX * MATCH_DISTANCE_PX;
+  for (let i = 0; i < nextGroups.length; i++) {
+    if (usedNext.has(i)) continue;
+    const next = nextGroups[i];
+    if (next.label !== prev.label) continue;
+    if (squaredDistance(prev.centroid, next.centroid) > distSqThreshold) {
       continue;
     }
-    for (let i = 0; i < prev.segments.length; i++) {
-      const [pa, pb] = prev.segments[i];
-      const [na, nb] = next.segments[i];
-      out.push(lerpPoint(pa, na, f), lerpPoint(pb, nb, f));
+    if (aabbIoU(prev.bounds, next.bounds) < MIN_MATCH_IOU) continue;
+    const score = chamferDistance(prev.vertices, next.vertices);
+    if (score < bestScore) {
+      bestScore = score;
+      bestIdx = i;
     }
   }
+  return bestIdx;
+}
 
-  return { ...prevPrim, points: out };
+function appendInterpolatedSegments(
+  out: Point2[],
+  prev: Group,
+  next: Group | null,
+  f: number
+): void {
+  if (!next || prev.segments.length !== next.segments.length) {
+    appendSegments(out, prev.segments);
+    return;
+  }
+  for (let i = 0; i < prev.segments.length; i++) {
+    const [pa, pb] = prev.segments[i];
+    const [na, nb] = next.segments[i];
+    out.push(lerpPoint(pa, na, f), lerpPoint(pb, nb, f));
+  }
+}
+
+function appendSegments(
+  out: Point2[],
+  segments: readonly [Point2, Point2][]
+): void {
+  for (const [a, b] of segments) {
+    out.push(a, b);
+  }
 }
 
 // ---------------------------------------------------------------------------
-// Connected-component grouping (mirror of the overlay's render path)
+// Line-list grouping (mirror of the overlay's render path)
 // ---------------------------------------------------------------------------
 
 interface Group {
@@ -396,4 +667,15 @@ function lerpPoint(a: Point2, b: Point2, f: number): Point2 {
 
 function lerp(a: number, b: number, f: number): number {
   return a + (b - a) * f;
+}
+
+function lowerBoundBigInt(arr: readonly bigint[], target: bigint): number {
+  let lo = 0;
+  let hi = arr.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (arr[mid] < target) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo;
 }

--- a/app/packages/multimodal/src/adapters/mcap/react/use-interpolated-image-annotations.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-interpolated-image-annotations.ts
@@ -68,6 +68,7 @@ export function useInterpolatedImageAnnotationSets(
   const streamRef = useRef<McapDataStream | null>(null);
   const topicSet = useMemo(() => new Set(stableTopics), [stableTopics]);
 
+  // This effect syncs topic subscriptions with the data stream and topic list.
   useEffect(() => {
     const subscriptions = subscriptionsRef.current;
 
@@ -91,6 +92,7 @@ export function useInterpolatedImageAnnotationSets(
     }
   }, [dataStream, stableTopics, topicSet]);
 
+  // This effect releases all topic subscriptions when the hook unmounts.
   useEffect(
     () => () => {
       for (const unsubscribe of subscriptionsRef.current.values()) {

--- a/app/packages/multimodal/src/adapters/mcap/react/use-interpolated-image-annotations.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-interpolated-image-annotations.ts
@@ -7,14 +7,14 @@ import {
   useSyncExternalStore,
 } from "react";
 
-import type {
-  ImageAnnotationCircle,
-  ImageAnnotationPoints,
-  ImageAnnotationText,
-  ImageAnnotationsVisualization,
-} from "../../../decoders";
-import { groupLineSegmentsByLabel } from "../../../utils/line-segment-grouping";
+import type { ImageAnnotationsVisualization } from "../../../decoders";
 import type { McapDecodedMessage } from "../types";
+import {
+  interpolateImageAnnotations,
+  interpolationFraction,
+  lowerBoundBigInt,
+  vizOf,
+} from "./interpolate-image-annotations";
 import {
   useMcapDataStream,
   type McapDataStream,
@@ -22,22 +22,7 @@ import {
 import type { McapTimelineIndex } from "./mcap-timeline-index";
 import type { McapTopicCache } from "./mcap-topic-cache";
 
-/**
- * Returns the annotation visualization for `topic` at the current playhead,
- * interpolated between the surrounding annotation messages when both are
- * cached. Falls back to the latest available message when the next one
- * isn't cached yet.
- *
- * Annotations arrive ~2 Hz against ~12 Hz camera images. To bridge that
- * gap visually we lerp between the prev and next annotation message by
- * fraction `(now - prev_t) / (next_t - prev_t)`.
- *
- * Foxglove doesn't carry stable instance IDs across messages, so we group
- * LINE_LIST segments into per-object chunks, run a greedy label + geometry
- * matching pass between prev/next groups, and only lerp matched pairs.
- * Unmatched groups in prev stay put; unmatched groups in next don't appear
- * until the next message becomes current.
- */
+/** Options for the interpolated image-annotation hooks. */
 export interface UseInterpolatedImageAnnotationsOptions {
   /** When false, returns the current annotation as-is with no lerping. */
   readonly interpolate?: boolean;
@@ -50,6 +35,12 @@ const EMPTY_TOPICS: readonly string[] = [];
 // revisit this — set too low, sparse annotations silently stop interpolating.
 const MAX_NEXT_MESSAGE_SCAN_TICKS = 120;
 
+/**
+ * Single-topic convenience wrapper over {@link useInterpolatedImageAnnotationSets}.
+ * Returns the interpolated image-annotation visualization for `topic` at the
+ * current playhead, or `null` when no frame is available. Pass
+ * `{ interpolate: false }` for the current frame at the playhead without lerping.
+ */
 export function useInterpolatedImageAnnotations(
   topic: string,
   { interpolate = true }: UseInterpolatedImageAnnotationsOptions = {}
@@ -172,6 +163,12 @@ function annotationSetsFromCaches({
   return sets;
 }
 
+/**
+ * Returns a referentially stable, empty-topic-free copy of `topics` that only
+ * changes identity when the topic *contents* change. Lets callers pass a fresh
+ * array each render without re-triggering the subscription effects or the
+ * `useSyncExternalStore` snapshot below.
+ */
 function useStableTopics(topics: readonly string[]): readonly string[] {
   // Memoize on the joined contents rather than array identity, so callers can
   // pass a fresh array every render without churning the downstream memo and
@@ -184,6 +181,12 @@ function useStableTopics(topics: readonly string[]): readonly string[] {
   return useMemo(() => normalized, [key]);
 }
 
+/**
+ * Subscribes to the per-topic cache revisions via `useSyncExternalStore` and
+ * returns a `"topic:revision|"` digest string. The digest changes whenever a
+ * watched cache bumps its revision (frames arrive, change, or are cleared),
+ * which is what drives the hook to re-derive annotation frames as data streams in.
+ */
 function useTopicCacheSnapshot(
   dataStream: McapDataStream | null,
   topics: readonly string[]
@@ -313,369 +316,4 @@ function nextDistinctAnnotationMessage({
     if (msg && msg.timelineTimeNs !== currentTimelineTimeNs) return msg;
   }
   return null;
-}
-
-function interpolationFraction({
-  nextTimelineTimeNs,
-  playheadNs,
-  previousTimelineTimeNs,
-}: {
-  readonly nextTimelineTimeNs: bigint;
-  readonly playheadNs: bigint;
-  readonly previousTimelineTimeNs: bigint;
-}): number | null {
-  const span = nextTimelineTimeNs - previousTimelineTimeNs;
-  if (span <= 0n) return null;
-  const elapsed = playheadNs - previousTimelineTimeNs;
-  if (elapsed <= 0n) return null;
-  const f = Number(elapsed) / Number(span);
-  if (!Number.isFinite(f)) return null;
-  return Math.min(1, f);
-}
-
-function vizOf(msg: McapDecodedMessage): ImageAnnotationsVisualization | null {
-  const v = msg.decoded.output.visualization;
-  if (!v || v.kind !== "image-annotations") return null;
-  return v as ImageAnnotationsVisualization;
-}
-
-// ---------------------------------------------------------------------------
-// Interpolation
-// ---------------------------------------------------------------------------
-
-type Point2 = readonly [number, number];
-
-const MATCH_DISTANCE_PX = 200;
-const MIN_MATCH_IOU = 0.15;
-
-function interpolateImageAnnotations(
-  prev: ImageAnnotationsVisualization,
-  next: ImageAnnotationsVisualization,
-  f: number
-): ImageAnnotationsVisualization {
-  return {
-    kind: prev.kind,
-    circles: interpolateCircles(prev.circles, next.circles, f),
-    points: interpolatePointsArray(prev, next, f),
-    texts: interpolateTexts(prev.texts, next.texts, f),
-  };
-}
-
-function interpolateCircles(
-  prev: readonly ImageAnnotationCircle[],
-  next: readonly ImageAnnotationCircle[],
-  f: number
-): readonly ImageAnnotationCircle[] {
-  // Index matching is acceptable for circles — they're rare in this data
-  // and tend to stay in order; if counts differ we just keep prev.
-  if (prev.length !== next.length) return prev;
-  return prev.map((p, i) => {
-    const n = next[i];
-    return {
-      ...p,
-      position: lerpPoint(p.position, n.position, f),
-      diameter: lerp(p.diameter, n.diameter, f),
-    };
-  });
-}
-
-function interpolateTexts(
-  prev: readonly ImageAnnotationText[],
-  next: readonly ImageAnnotationText[],
-  f: number
-): readonly ImageAnnotationText[] {
-  // Match texts by `text` content + nearest position, greedy per content.
-  const out: ImageAnnotationText[] = [];
-  const usedNext = new Set<number>();
-  for (const p of prev) {
-    let bestIdx = -1;
-    let bestDist = Infinity;
-    for (let j = 0; j < next.length; j++) {
-      if (usedNext.has(j)) continue;
-      const n = next[j];
-      if (n.text !== p.text) continue;
-      const d = squaredDistance(p.position, n.position);
-      if (d < bestDist) {
-        bestDist = d;
-        bestIdx = j;
-      }
-    }
-    if (bestIdx === -1 || bestDist > MATCH_DISTANCE_PX * MATCH_DISTANCE_PX) {
-      out.push(p);
-      continue;
-    }
-    usedNext.add(bestIdx);
-    const n = next[bestIdx];
-    out.push({ ...p, position: lerpPoint(p.position, n.position, f) });
-  }
-  return out;
-}
-
-/**
- * Interpolation for the points array. LINE_LIST primitives usually carry
- * every cuboid in one big segment list; we split each into per-object
- * groups using the same chunking helper as the overlay, match groups between
- * prev and next, then lerp matched pairs. Non-line-list primitives fall back
- * to index-based interpolation.
- */
-function interpolatePointsArray(
-  prev: ImageAnnotationsVisualization,
-  next: ImageAnnotationsVisualization,
-  f: number
-): readonly ImageAnnotationPoints[] {
-  if (prev.points.length !== next.points.length) return prev.points;
-  return prev.points.map((pp, idx) => {
-    const np = next.points[idx];
-    if (pp.type !== np.type) return pp;
-    if (pp.type === "line-list") {
-      return interpolateLineList(pp, np, prev.texts, next.texts, f);
-    }
-    if (pp.points.length !== np.points.length) return pp;
-    return {
-      ...pp,
-      points: pp.points.map((pt, j) => lerpPoint(pt, np.points[j], f)),
-    };
-  });
-}
-
-function interpolateLineList(
-  prevPrim: ImageAnnotationPoints,
-  nextPrim: ImageAnnotationPoints,
-  prevTexts: readonly ImageAnnotationText[],
-  nextTexts: readonly ImageAnnotationText[],
-  f: number
-): ImageAnnotationPoints {
-  const prevGroups = groupLineList(prevPrim.points, prevTexts);
-  const nextGroups = groupLineList(nextPrim.points, nextTexts);
-  const matchedPairs = matchLineListGroups(prevGroups, nextGroups);
-
-  const out: Point2[] = [];
-  for (const { prev, next } of matchedPairs) {
-    appendInterpolatedSegments(out, prev, next, f);
-  }
-
-  return { ...prevPrim, points: out };
-}
-
-interface MatchedGroupPair {
-  readonly prev: Group;
-  readonly next: Group | null;
-}
-
-function matchLineListGroups(
-  prevGroups: readonly Group[],
-  nextGroups: readonly Group[]
-): readonly MatchedGroupPair[] {
-  // Per-prev candidate selection:
-  //   1. Same label class (hard).
-  //   2. Centroid within MATCH_DISTANCE_PX (coarse position filter).
-  //   3. AABB IoU above MIN_IOU (rejects gross size mismatches —
-  //      e.g. a parked truck near a passing sedan).
-  //   4. Among survivors, pick the lowest symmetric Chamfer distance
-  //      over the cuboid's unique vertices (shape similarity tiebreak).
-  // Greedy: first prev to claim a next wins.
-  const usedNext = new Set<number>();
-  return prevGroups.map((prev) => {
-    const nextIndex = bestNextGroupIndex(prev, nextGroups, usedNext);
-    if (nextIndex === -1) return { prev, next: null };
-    usedNext.add(nextIndex);
-    return { prev, next: nextGroups[nextIndex] };
-  });
-}
-
-function bestNextGroupIndex(
-  prev: Group,
-  nextGroups: readonly Group[],
-  usedNext: ReadonlySet<number>
-): number {
-  let bestIdx = -1;
-  let bestScore = Infinity;
-  const distSqThreshold = MATCH_DISTANCE_PX * MATCH_DISTANCE_PX;
-  for (let i = 0; i < nextGroups.length; i++) {
-    if (usedNext.has(i)) continue;
-    const next = nextGroups[i];
-    if (next.label !== prev.label) continue;
-    if (squaredDistance(prev.centroid, next.centroid) > distSqThreshold) {
-      continue;
-    }
-    if (aabbIoU(prev.bounds, next.bounds) < MIN_MATCH_IOU) continue;
-    const score = chamferDistance(prev.vertices, next.vertices);
-    if (score < bestScore) {
-      bestScore = score;
-      bestIdx = i;
-    }
-  }
-  return bestIdx;
-}
-
-function appendInterpolatedSegments(
-  out: Point2[],
-  prev: Group,
-  next: Group | null,
-  f: number
-): void {
-  if (!next || prev.segments.length !== next.segments.length) {
-    appendSegments(out, prev.segments);
-    return;
-  }
-  for (let i = 0; i < prev.segments.length; i++) {
-    const [pa, pb] = prev.segments[i];
-    const [na, nb] = next.segments[i];
-    out.push(lerpPoint(pa, na, f), lerpPoint(pb, nb, f));
-  }
-}
-
-function appendSegments(
-  out: Point2[],
-  segments: readonly [Point2, Point2][]
-): void {
-  for (const [a, b] of segments) {
-    out.push(a, b);
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Line-list grouping (mirror of the overlay's render path)
-// ---------------------------------------------------------------------------
-
-interface Group {
-  readonly segments: readonly [Point2, Point2][];
-  readonly centroid: Point2;
-  readonly bounds: Bounds;
-  readonly vertices: readonly Point2[];
-  readonly label: string | null;
-}
-
-function groupLineList(
-  points: readonly Point2[],
-  texts: readonly ImageAnnotationText[]
-): readonly Group[] {
-  return groupLineSegmentsByLabel(points, texts).map(({ label, segments }) =>
-    makeGroup(segments, label)
-  );
-}
-
-function makeGroup(
-  segments: readonly [Point2, Point2][],
-  label: string | null
-): Group {
-  const bounds = segmentsBounds(segments);
-  const centroid: Point2 = [
-    (bounds.minX + bounds.maxX) / 2,
-    (bounds.minY + bounds.maxY) / 2,
-  ];
-  return {
-    segments,
-    centroid,
-    bounds,
-    vertices: uniqueVertices(segments),
-    label,
-  };
-}
-
-function uniqueVertices(
-  segments: readonly [Point2, Point2][]
-): readonly Point2[] {
-  const seen = new Set<string>();
-  const out: Point2[] = [];
-  for (const [a, b] of segments) {
-    for (const p of [a, b]) {
-      const k = `${Math.round(p[0] * 100)}|${Math.round(p[1] * 100)}`;
-      if (seen.has(k)) continue;
-      seen.add(k);
-      out.push(p);
-    }
-  }
-  return out;
-}
-
-function aabbIoU(a: Bounds, b: Bounds): number {
-  const x1 = Math.max(a.minX, b.minX);
-  const y1 = Math.max(a.minY, b.minY);
-  const x2 = Math.min(a.maxX, b.maxX);
-  const y2 = Math.min(a.maxY, b.maxY);
-  if (x2 <= x1 || y2 <= y1) return 0;
-  const inter = (x2 - x1) * (y2 - y1);
-  const areaA = Math.max(0, a.maxX - a.minX) * Math.max(0, a.maxY - a.minY);
-  const areaB = Math.max(0, b.maxX - b.minX) * Math.max(0, b.maxY - b.minY);
-  const union = areaA + areaB - inter;
-  return union > 0 ? inter / union : 0;
-}
-
-/**
- * Symmetric Chamfer distance between two point sets — average nearest-
- * neighbour distance from A→B plus from B→A, halved. Small values mean
- * the two cuboid wireframes have similar vertex layouts (good match).
- */
-function chamferDistance(a: readonly Point2[], b: readonly Point2[]): number {
-  if (a.length === 0 || b.length === 0) return Infinity;
-  let sumAB = 0;
-  for (const pa of a) {
-    let minD = Infinity;
-    for (const pb of b) {
-      const d = squaredDistance(pa, pb);
-      if (d < minD) minD = d;
-    }
-    sumAB += Math.sqrt(minD);
-  }
-  let sumBA = 0;
-  for (const pb of b) {
-    let minD = Infinity;
-    for (const pa of a) {
-      const d = squaredDistance(pa, pb);
-      if (d < minD) minD = d;
-    }
-    sumBA += Math.sqrt(minD);
-  }
-  return (sumAB / a.length + sumBA / b.length) / 2;
-}
-
-interface Bounds {
-  minX: number;
-  minY: number;
-  maxX: number;
-  maxY: number;
-}
-
-function segmentsBounds(segments: readonly [Point2, Point2][]): Bounds {
-  let minX = Infinity;
-  let minY = Infinity;
-  let maxX = -Infinity;
-  let maxY = -Infinity;
-  for (const [[x1, y1], [x2, y2]] of segments) {
-    if (x1 < minX) minX = x1;
-    if (x2 < minX) minX = x2;
-    if (x1 > maxX) maxX = x1;
-    if (x2 > maxX) maxX = x2;
-    if (y1 < minY) minY = y1;
-    if (y2 < minY) minY = y2;
-    if (y1 > maxY) maxY = y1;
-    if (y2 > maxY) maxY = y2;
-  }
-  return { minX, minY, maxX, maxY };
-}
-
-function squaredDistance(a: Point2, b: Point2): number {
-  const dx = a[0] - b[0];
-  const dy = a[1] - b[1];
-  return dx * dx + dy * dy;
-}
-
-function lerpPoint(a: Point2, b: Point2, f: number): Point2 {
-  return [a[0] + (b[0] - a[0]) * f, a[1] + (b[1] - a[1]) * f];
-}
-
-function lerp(a: number, b: number, f: number): number {
-  return a + (b - a) * f;
-}
-
-function lowerBoundBigInt(arr: readonly bigint[], target: bigint): number {
-  let lo = 0;
-  let hi = arr.length;
-  while (lo < hi) {
-    const mid = (lo + hi) >> 1;
-    if (arr[mid] < target) lo = mid + 1;
-    else hi = mid;
-  }
-  return lo;
 }

--- a/app/packages/multimodal/src/adapters/mcap/react/use-interpolated-image-annotations.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-interpolated-image-annotations.ts
@@ -238,19 +238,22 @@ function topicCacheSnapshot(
 
 function normalizeTopics(topics: readonly string[]): readonly string[] {
   if (topics.length === 0) return EMPTY_TOPICS;
-  let hasEmptyTopic = false;
+  const normalized: string[] = [];
+  const seen = new Set<string>();
+  let changed = false;
   for (const topic of topics) {
     if (!topic) {
-      hasEmptyTopic = true;
-      break;
+      changed = true;
+      continue;
     }
+    if (seen.has(topic)) {
+      changed = true;
+      continue;
+    }
+    seen.add(topic);
+    normalized.push(topic);
   }
-  if (!hasEmptyTopic) return topics;
-
-  const normalized: string[] = [];
-  for (const topic of topics) {
-    if (topic) normalized.push(topic);
-  }
+  if (!changed) return topics;
   return normalized.length > 0 ? normalized : EMPTY_TOPICS;
 }
 

--- a/app/packages/multimodal/src/adapters/mcap/react/use-mcap-scene-inventory.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-mcap-scene-inventory.ts
@@ -10,6 +10,7 @@ export interface McapSceneInventoryState {
   readonly error: string | null;
   readonly status: McapSceneInventoryStatus;
   readonly sources: readonly SceneSource[];
+  readonly topicCount: number;
 }
 
 /**
@@ -23,5 +24,8 @@ export function useMcapSceneInventory(
   const { status, error, topics } = useMcapTopics(options);
   const sources = useMemo(() => mcapSceneSources(topics), [topics]);
 
-  return useMemo(() => ({ error, sources, status }), [error, sources, status]);
+  return useMemo(
+    () => ({ error, sources, status, topicCount: topics.length }),
+    [error, sources, status, topics.length]
+  );
 }

--- a/app/packages/multimodal/src/components/MultiModalPlayback/MultiModalPlayback.module.css
+++ b/app/packages/multimodal/src/components/MultiModalPlayback/MultiModalPlayback.module.css
@@ -16,3 +16,9 @@
   flex: 1;
   min-width: 0;
 }
+
+.sidebarPane {
+  height: 100%;
+  min-height: 360px;
+  width: min(360px, 32vw);
+}

--- a/app/packages/multimodal/src/components/MultiModalPlayback/MultiModalPlayback.test.tsx
+++ b/app/packages/multimodal/src/components/MultiModalPlayback/MultiModalPlayback.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -12,14 +12,31 @@ vi.mock("@fiftyone/tiling", async () => {
   return {
     ...actual,
     MosaicGrid: ({
+      focusedTileId,
+      onFocusTile,
       tiles,
     }: {
+      focusedTileId?: string | null;
+      onFocusTile?: (id: string, reason: "select" | "action") => void;
       tiles: Record<string, { title: string; render: () => React.ReactNode }>;
     }) => (
       <div data-testid="mosaic-stub">
         {Object.entries(tiles).map(([id, t]) => (
           <div key={id} data-testid={`stub-${id}`}>
-            {t.title}
+            <span data-testid={`title-${id}`}>{t.title}</span>
+            <button
+              data-testid={`select-${id}`}
+              data-focused={focusedTileId === id ? "true" : "false"}
+              onClick={() => onFocusTile?.(id, "select")}
+            >
+              select
+            </button>
+            <button
+              data-testid={`action-${id}`}
+              onClick={() => onFocusTile?.(id, "action")}
+            >
+              action
+            </button>
           </div>
         ))}
       </div>
@@ -47,10 +64,10 @@ describe("MultiModalPlayback shell", () => {
         }}
       />
     );
-    expect(screen.getByTestId("stub-camera-1").textContent).toBe(
+    expect(screen.getByTestId("title-camera-1").textContent).toBe(
       "camera_front"
     );
-    expect(screen.getByTestId("stub-lidar-1").textContent).toBe("lidar_top");
+    expect(screen.getByTestId("title-lidar-1").textContent).toBe("lidar_top");
   });
 
   it("renders the default sidebars (settings + inspector empty states)", () => {
@@ -69,5 +86,58 @@ describe("MultiModalPlayback shell", () => {
       />
     );
     expect(screen.queryByTestId("drawer")).toBeNull();
+  });
+
+  it("lets header captions react to active pane selection and deselection", () => {
+    render(
+      <MultiModalPlayback
+        fileName="x"
+        headerCaption={({ focusedTileTitle }) => (
+          <span data-testid="caption-context">
+            {focusedTileTitle ?? "Scene context"}
+          </span>
+        )}
+        initialTiles={{
+          "camera-1": { title: "Camera", render: () => null },
+        }}
+      />
+    );
+
+    expect(screen.getByTestId("caption-context").textContent).toBe(
+      "Scene context"
+    );
+    fireEvent.click(screen.getByTestId("select-camera-1"));
+    expect(screen.getByTestId("caption-context").textContent).toBe("Camera");
+    expect(screen.getByTestId("select-camera-1").dataset.focused).toBe("true");
+
+    fireEvent.click(screen.getByTestId("select-camera-1"));
+    expect(screen.getByTestId("caption-context").textContent).toBe(
+      "Scene context"
+    );
+    expect(screen.getByTestId("select-camera-1").dataset.focused).toBe("false");
+  });
+
+  it("keeps pane actions focused instead of toggling the active pane off", () => {
+    render(
+      <MultiModalPlayback
+        fileName="x"
+        headerCaption={({ focusedTileTitle }) => (
+          <span data-testid="caption-context">
+            {focusedTileTitle ?? "Scene context"}
+          </span>
+        )}
+        initialTiles={{
+          "camera-1": { title: "Camera", render: () => null },
+        }}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId("action-camera-1"));
+    expect(screen.getByTestId("caption-context").textContent).toBe("Camera");
+    expect(screen.getByTestId("select-camera-1").dataset.focused).toBe("true");
+
+    fireEvent.click(screen.getByTestId("action-camera-1"));
+    expect(screen.getByTestId("caption-context").textContent).toBe("Camera");
+    expect(screen.getByTestId("select-camera-1").dataset.focused).toBe("true");
   });
 });

--- a/app/packages/multimodal/src/components/MultiModalPlayback/MultiModalPlayback.tsx
+++ b/app/packages/multimodal/src/components/MultiModalPlayback/MultiModalPlayback.tsx
@@ -5,11 +5,12 @@ import {
   TilingInspectorSidebar,
   TilingProvider,
   useTiling,
+  type TilingHeaderCaption,
   type TilingTile,
 } from "@fiftyone/tiling";
 import { Drawer } from "@voxel51/voodo";
 import clsx from "clsx";
-import React, { useState, type ReactNode } from "react";
+import React, { useCallback, useState, type ReactNode } from "react";
 import type { MosaicNode } from "react-mosaic-component";
 import {
   PlaybackProvider,
@@ -25,10 +26,13 @@ import {
 import styles from "./MultiModalPlayback.module.css";
 
 const EMPTY_SOURCES: readonly SceneSource[] = [];
+const SIDEBAR_SIZE_PX = 360;
 
 export interface MultiModalPlaybackProps {
   /** Filename rendered on the left of the top bar. */
   fileName: string;
+  /** Optional caption rendered below the filename in the top bar. */
+  headerCaption?: TilingHeaderCaption;
 
   /** Tracks broadcast through the embedded TrackProvider. */
   tracks?: Track[];
@@ -120,6 +124,7 @@ export interface MultiModalPlaybackProps {
  */
 const MultiModalPlayback: React.FC<MultiModalPlaybackProps> = ({
   fileName,
+  headerCaption,
   tracks,
   defaultPinnedTrackIds,
   initialTiles,
@@ -150,6 +155,7 @@ const MultiModalPlayback: React.FC<MultiModalPlaybackProps> = ({
             {children}
             <Layout
               fileName={fileName}
+              headerCaption={headerCaption}
               leftSidebar={leftSidebar}
               rightSidebar={rightSidebar}
               defaultLeftOpen={defaultLeftOpen}
@@ -169,6 +175,7 @@ const MultiModalPlayback: React.FC<MultiModalPlaybackProps> = ({
 
 interface LayoutProps {
   fileName: string;
+  headerCaption?: TilingHeaderCaption;
   leftSidebar: ReactNode;
   rightSidebar: ReactNode;
   defaultLeftOpen: boolean;
@@ -182,6 +189,7 @@ interface LayoutProps {
 
 function Layout({
   fileName,
+  headerCaption,
   leftSidebar,
   rightSidebar,
   defaultLeftOpen,
@@ -205,11 +213,20 @@ function Layout({
     setRightOpen(open);
     onRightOpenChange?.(open);
   };
+  // Re-selecting the focused tile clears focus (toggle off); "action" reasons
+  // (close/fullscreen) always focus without toggling.
+  const handleFocusTile = useCallback(
+    (id: string, reason: "select" | "action") => {
+      setFocusedTileId(reason === "select" && focusedTileId === id ? null : id);
+    },
+    [focusedTileId, setFocusedTileId]
+  );
 
   return (
     <div className={clsx(styles.root, className)}>
       <TilingHeader
         fileName={fileName}
+        headerCaption={headerCaption}
         leftSidebarOpen={leftOpen}
         rightSidebarOpen={rightOpen}
         onToggleLeftSidebar={() => updateLeftOpen(!leftOpen)}
@@ -220,11 +237,11 @@ function Layout({
         <Drawer
           side="left"
           mode="push"
-          maxSize={500}
+          maxSize={SIDEBAR_SIZE_PX}
           open={leftOpen}
           onOpenChange={updateLeftOpen}
         >
-          {leftSidebar}
+          <div className={styles.sidebarPane}>{leftSidebar}</div>
         </Drawer>
 
         <div className={styles.main}>
@@ -233,18 +250,18 @@ function Layout({
             value={layout}
             onChange={setLayout}
             focusedTileId={focusedTileId}
-            onFocusTile={setFocusedTileId}
+            onFocusTile={handleFocusTile}
           />
         </div>
 
         <Drawer
           side="right"
           mode="push"
-          maxSize={500}
+          maxSize={SIDEBAR_SIZE_PX}
           open={rightOpen}
           onOpenChange={updateRightOpen}
         >
-          {rightSidebar}
+          <div className={styles.sidebarPane}>{rightSidebar}</div>
         </Drawer>
       </div>
 

--- a/app/packages/tiling/src/index.ts
+++ b/app/packages/tiling/src/index.ts
@@ -46,7 +46,11 @@ export { default as Tile, TileHeader } from "./views/Tile/Tile";
 export type { TileProps, TileHeaderProps } from "./views/Tile/Tile";
 
 export { default as TilingHeader } from "./views/TilingHeader/TilingHeader";
-export type { TilingHeaderProps } from "./views/TilingHeader/TilingHeader";
+export type {
+  TilingHeaderCaption,
+  TilingHeaderCaptionContext,
+  TilingHeaderProps,
+} from "./views/TilingHeader/TilingHeader";
 
 export { default as SidebarPanel } from "./views/SidebarPanel/SidebarPanel";
 export type { SidebarPanelProps } from "./views/SidebarPanel/SidebarPanel";

--- a/app/packages/tiling/src/lib/TilingProvider.test.tsx
+++ b/app/packages/tiling/src/lib/TilingProvider.test.tsx
@@ -398,8 +398,7 @@ describe("TilingProvider", () => {
   describe("settings portal", () => {
     function Host({ initialFocus }: { initialFocus?: string }) {
       const tiling = useTiling();
-      // Bind the slot DOM element on mount so TileSettingsContent
-      // has somewhere to portal into.
+      // This effect primes the focused tile for settings portal tests.
       React.useEffect(() => {
         if (initialFocus) tiling.setFocusedTileId(initialFocus);
       }, [tiling, initialFocus]);

--- a/app/packages/tiling/src/lib/TilingProvider.test.tsx
+++ b/app/packages/tiling/src/lib/TilingProvider.test.tsx
@@ -1,6 +1,13 @@
-import { act, cleanup, render, renderHook } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  renderHook,
+  screen,
+} from "@testing-library/react";
 import React from "react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   TileIdScope,
   TileSettingsContent,
@@ -47,7 +54,10 @@ describe("TilingProvider", () => {
           <Wrapper initialTiles={initialTiles}>{children}</Wrapper>
         ),
       });
-      expect(Object.keys(result.current.tiles)).toEqual(["camera-1", "lidar-1"]);
+      expect(Object.keys(result.current.tiles)).toEqual([
+        "camera-1",
+        "lidar-1",
+      ]);
     });
 
     it("auto-lays out the initial tiles when no initialLayout is provided", () => {
@@ -73,7 +83,9 @@ describe("TilingProvider", () => {
         firstId = result.current.addTile(makeTile("a"), { idPrefix: "camera" });
       });
       act(() => {
-        secondId = result.current.addTile(makeTile("b"), { idPrefix: "camera" });
+        secondId = result.current.addTile(makeTile("b"), {
+          idPrefix: "camera",
+        });
       });
       expect(firstId).toBe("camera-1");
       expect(secondId).toBe("camera-2");
@@ -202,6 +214,26 @@ describe("TilingProvider", () => {
       });
       // Reference-equal — no re-render triggered.
       expect(result.current.tiles["cam-1"]).toBe(before);
+    });
+  });
+
+  describe("TileSettingsContent", () => {
+    it("does not bubble sidebar portal clicks back to the tile body", () => {
+      const onPanePointerDown = vi.fn();
+      render(
+        <TilingProvider
+          initialTiles={{
+            "tile-1": makeTile("tile"),
+          }}
+        >
+          <SettingsPortalHarness onPanePointerDown={onPanePointerDown} />
+        </TilingProvider>
+      );
+
+      fireEvent.click(screen.getByTestId("focus-tile"));
+      fireEvent.pointerDown(screen.getByTestId("settings-button"));
+
+      expect(onPanePointerDown).not.toHaveBeenCalled();
     });
   });
 
@@ -364,11 +396,7 @@ describe("TilingProvider", () => {
   });
 
   describe("settings portal", () => {
-    function Host({
-      initialFocus,
-    }: {
-      initialFocus?: string;
-    }) {
+    function Host({ initialFocus }: { initialFocus?: string }) {
       const tiling = useTiling();
       // Bind the slot DOM element on mount so TileSettingsContent
       // has somewhere to portal into.
@@ -419,9 +447,9 @@ describe("TilingProvider", () => {
       act(() => {
         utils.getByTestId("focus-cam").click();
       });
-      expect(utils.getByTestId("slot").contains(
-        utils.getByTestId("cam-settings")
-      )).toBe(true);
+      expect(
+        utils.getByTestId("slot").contains(utils.getByTestId("cam-settings"))
+      ).toBe(true);
       expect(utils.queryByTestId("lid-settings")).toBeNull();
     });
 
@@ -446,3 +474,30 @@ describe("TilingProvider", () => {
     });
   });
 });
+
+function SettingsPortalHarness({
+  onPanePointerDown,
+}: {
+  readonly onPanePointerDown: () => void;
+}) {
+  const { setFocusedTileId, setSettingsSlotEl } = useTiling();
+
+  return (
+    <>
+      <button
+        data-testid="focus-tile"
+        onClick={() => setFocusedTileId("tile-1")}
+      >
+        focus
+      </button>
+      <div data-testid="settings-slot" ref={setSettingsSlotEl} />
+      <TileIdScope tileId="tile-1">
+        <div data-testid="tile-body" onPointerDown={onPanePointerDown}>
+          <TileSettingsContent>
+            <button data-testid="settings-button">settings</button>
+          </TileSettingsContent>
+        </div>
+      </TileIdScope>
+    </>
+  );
+}

--- a/app/packages/tiling/src/lib/TilingProvider.tsx
+++ b/app/packages/tiling/src/lib/TilingProvider.tsx
@@ -16,11 +16,7 @@ import {
   collectTileIds,
 } from "../views/MosaicGrid/MosaicGrid";
 import { tileSelectionAtom } from "./atoms";
-import type {
-  AddTileOptions,
-  TilingContextValue,
-  TilingTile,
-} from "./types";
+import type { AddTileOptions, TilingContextValue, TilingTile } from "./types";
 
 export type { AddTileOptions, TilingContextValue, TilingTile } from "./types";
 
@@ -143,28 +139,25 @@ export const TilingProvider: React.FC<TilingProviderProps> = ({
     []
   );
 
-  const removeTile = useCallback(
-    (id: string) => {
-      setTiles((prev) => {
-        if (!(id in prev)) return prev;
-        const next = { ...prev };
-        delete next[id];
-        return next;
-      });
-      setLayoutState((prev) => {
-        if (prev === null) return null;
-        if (typeof prev === "string") return prev === id ? null : prev;
-        // Walk the tree, collapsing the parent split when one child is removed.
-        const stripped = stripTile(prev, id);
-        return stripped;
-      });
-      setFocusedTileId((current) => (current === id ? null : current));
-      // Release the per-tile atomFamily entry so the store doesn't
-      // grow unbounded across long sessions.
-      tileSelectionAtom.remove(id);
-    },
-    []
-  );
+  const removeTile = useCallback((id: string) => {
+    setTiles((prev) => {
+      if (!(id in prev)) return prev;
+      const next = { ...prev };
+      delete next[id];
+      return next;
+    });
+    setLayoutState((prev) => {
+      if (prev === null) return null;
+      if (typeof prev === "string") return prev === id ? null : prev;
+      // Walk the tree, collapsing the parent split when one child is removed.
+      const stripped = stripTile(prev, id);
+      return stripped;
+    });
+    setFocusedTileId((current) => (current === id ? null : current));
+    // Release the per-tile atomFamily entry so the store doesn't
+    // grow unbounded across long sessions.
+    tileSelectionAtom.remove(id);
+  }, []);
 
   const setTileTitle = useCallback((tileId: string, title: string) => {
     setTiles((prev) => {
@@ -272,5 +265,12 @@ export const TileSettingsContent: React.FC<{
   const tileId = useTileId();
   const { focusedTileId, settingsSlotEl } = useTiling();
   if (!tileId || tileId !== focusedTileId || !settingsSlotEl) return null;
-  return createPortal(children, settingsSlotEl);
+  return createPortal(
+    <div onPointerDown={stopPortalEvent}>{children}</div>,
+    settingsSlotEl
+  );
 };
+
+function stopPortalEvent(event: React.SyntheticEvent) {
+  event.stopPropagation();
+}

--- a/app/packages/tiling/src/lib/TilingProvider.tsx
+++ b/app/packages/tiling/src/lib/TilingProvider.tsx
@@ -61,6 +61,7 @@ export const TilingProvider: React.FC<TilingProviderProps> = ({
   // updater (state updaters must remain pure; nested setState calls
   // duplicate in Strict Mode).
   const focusedTileIdRef = useRef<string | null>(null);
+  // This effect mirrors focusedTileId into a ref for stable addTile calls.
   useEffect(() => {
     focusedTileIdRef.current = focusedTileId;
   }, [focusedTileId]);

--- a/app/packages/tiling/src/views/MosaicGrid/MosaicGrid.stories.tsx
+++ b/app/packages/tiling/src/views/MosaicGrid/MosaicGrid.stories.tsx
@@ -1,10 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { useCallback, useState } from "react";
 import type { MosaicNode } from "react-mosaic-component";
-import {
-  TilingProvider,
-  type TilingTile,
-} from "../../lib/TilingProvider";
+import { TilingProvider, type TilingTile } from "../../lib/TilingProvider";
 import MosaicGrid, {
   addTileToLayout,
   autoLayout,
@@ -97,7 +94,12 @@ function GridShell({
         <div style={{ padding: 8 }}>
           <button onClick={spawn}>Add tile</button>
           {focused && (
-            <span style={{ marginLeft: 12, color: "var(--color-content-text-muted)" }}>
+            <span
+              style={{
+                marginLeft: 12,
+                color: "var(--color-content-text-muted)",
+              }}
+            >
               focused: {focused}
             </span>
           )}

--- a/app/packages/tiling/src/views/MosaicGrid/MosaicGrid.tsx
+++ b/app/packages/tiling/src/views/MosaicGrid/MosaicGrid.tsx
@@ -115,6 +115,7 @@ const MosaicGrid: React.FC<MosaicGridProps> = ({
   // mutation happened (add/remove/reflow) and the snapshot is stale.
   const expandedLayoutRef = useRef<MosaicNode<string> | null>(null);
 
+  // This effect invalidates fullscreen restore state after external layout changes.
   useEffect(() => {
     if (
       expandedTileId !== null &&

--- a/app/packages/tiling/src/views/MosaicGrid/MosaicGrid.tsx
+++ b/app/packages/tiling/src/views/MosaicGrid/MosaicGrid.tsx
@@ -38,8 +38,8 @@ export interface MosaicGridProps {
    * (`addTileToLayout(layout, newId, focusedTileId)`).
    */
   focusedTileId?: string | null;
-  /** Called when the user clicks a tile's header or body. */
-  onFocusTile?: (id: string) => void;
+  /** Called when the user selects a tile or invokes one of its actions. */
+  onFocusTile?: (id: string, reason: "select" | "action") => void;
   className?: string;
 }
 
@@ -151,7 +151,8 @@ const MosaicGrid: React.FC<MosaicGridProps> = ({
     const tile = tiles[id];
     if (!tile) return <div />;
 
-    const focus = () => onFocusTile?.(id);
+    const focusForSelect = () => onFocusTile?.(id, "select");
+    const focusForAction = () => onFocusTile?.(id, "action");
     const isFocused = focusedTileId === id;
 
     // Focus is folded into the action callbacks rather than fired from a
@@ -159,7 +160,7 @@ const MosaicGrid: React.FC<MosaicGridProps> = ({
     // re-render between pointerdown and click that swallowed the click on
     // the toolbar's buttons (needed two taps to fullscreen).
     const handleClose = () => {
-      focus();
+      focusForAction();
       if (expandedTileId === id) {
         preExpandLayout.current = null;
         setExpandedTileId(null);
@@ -170,7 +171,7 @@ const MosaicGrid: React.FC<MosaicGridProps> = ({
       }
     };
     const handleFullscreen = () => {
-      focus();
+      focusForAction();
       handleExpand(id, path);
     };
 
@@ -180,7 +181,7 @@ const MosaicGrid: React.FC<MosaicGridProps> = ({
           path={path}
           tile={tile}
           isFocused={isFocused}
-          onFocus={focus}
+          onFocus={focusForSelect}
           onClose={handleClose}
           onFullscreen={handleFullscreen}
         />
@@ -214,10 +215,7 @@ export function autoLayout(ids: string[]): MosaicNode<string> | null {
   return build(ids, "row");
 }
 
-function build(
-  ids: string[],
-  direction: "row" | "column"
-): MosaicNode<string> {
+function build(ids: string[], direction: "row" | "column"): MosaicNode<string> {
   if (ids.length === 1) return ids[0];
   const mid = Math.ceil(ids.length / 2);
   const next: "row" | "column" = direction === "row" ? "column" : "row";

--- a/app/packages/tiling/src/views/SidebarPanel/SidebarPanel.tsx
+++ b/app/packages/tiling/src/views/SidebarPanel/SidebarPanel.tsx
@@ -4,7 +4,7 @@ import styles from "./SidebarPanel.module.css";
 
 export interface SidebarPanelProps {
   /** Section title shown at the top of the panel. */
-  title: string;
+  title: ReactNode;
   children: ReactNode;
 }
 

--- a/app/packages/tiling/src/views/TilingHeader/TilingHeader.module.css
+++ b/app/packages/tiling/src/views/TilingHeader/TilingHeader.module.css
@@ -11,8 +11,9 @@
 
 .fileName {
   display: flex;
-  align-items: center;
-  gap: 6px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
   min-width: 0;
   flex-shrink: 1;
   overflow: hidden;
@@ -22,6 +23,17 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.caption {
+  color: var(--color-content-text-muted);
+  font-size: 11px;
+  line-height: 1.2;
+  max-width: 100%;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .spacer {

--- a/app/packages/tiling/src/views/TilingHeader/TilingHeader.tsx
+++ b/app/packages/tiling/src/views/TilingHeader/TilingHeader.tsx
@@ -96,7 +96,9 @@ const TilingHeader: React.FC<TilingHeaderProps> = ({
         >
           {fileName}
         </Text>
-        {caption ? <div className={styles.caption}>{caption}</div> : null}
+        {caption !== null && caption !== undefined ? (
+          <div className={styles.caption}>{caption}</div>
+        ) : null}
       </div>
 
       <div className={styles.spacer} />

--- a/app/packages/tiling/src/views/TilingHeader/TilingHeader.tsx
+++ b/app/packages/tiling/src/views/TilingHeader/TilingHeader.tsx
@@ -12,14 +12,24 @@ import {
   Variant,
 } from "@voxel51/voodo";
 import clsx from "clsx";
-import React, { useMemo } from "react";
+import React, { useMemo, type ReactNode } from "react";
 import { useTileTypes } from "../../lib/use-tile-state";
 import { useTiling } from "../../lib/TilingProvider";
 import { SidebarLeftIcon, SidebarRightIcon } from "./tiling-header-icons";
 import styles from "./TilingHeader.module.css";
 
+export interface TilingHeaderCaptionContext {
+  readonly focusedTileId: string | null;
+  readonly focusedTileTitle: string | null;
+}
+
+export type TilingHeaderCaption =
+  | ReactNode
+  | ((context: TilingHeaderCaptionContext) => ReactNode);
+
 export interface TilingHeaderProps {
   fileName: string;
+  headerCaption?: TilingHeaderCaption;
   leftSidebarOpen?: boolean;
   rightSidebarOpen?: boolean;
   onToggleLeftSidebar?: () => void;
@@ -28,13 +38,20 @@ export interface TilingHeaderProps {
 
 const TilingHeader: React.FC<TilingHeaderProps> = ({
   fileName,
+  headerCaption,
   leftSidebarOpen,
   rightSidebarOpen,
   onToggleLeftSidebar,
   onToggleRightSidebar,
 }) => {
   const types = useTileTypes();
-  const { addTile, autoLayout } = useTiling();
+  const { addTile, autoLayout, focusedTileId, tiles } = useTiling();
+  const focusedTileTitle =
+    focusedTileId && tiles[focusedTileId] ? tiles[focusedTileId].title : null;
+  const caption =
+    typeof headerCaption === "function"
+      ? headerCaption({ focusedTileId, focusedTileTitle })
+      : headerCaption;
 
   const tileMenu = useMemo(() => {
     if (types.length === 0) return null;
@@ -79,6 +96,7 @@ const TilingHeader: React.FC<TilingHeaderProps> = ({
         >
           {fileName}
         </Text>
+        {caption ? <div className={styles.caption}>{caption}</div> : null}
       </div>
 
       <div className={styles.spacer} />


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

Builds on top of https://github.com/voxel51/fiftyone/pull/7765

Improve MCAP modal pane behavior for image labels and playback context:

- Add persisted MCAP modal settings for image label-topic selections and annotation interpolation controls.
- Let image panes render multiple selected image-annotation topics and keep tile/status context in sync.
- Extract and test image-annotation interpolation logic, including multi-topic cache subscriptions.
- Add focused-pane settings/sidebar behavior and tighten tiling focus/action handling.

## 🧪 How is this patch tested? If it is not, please explain why.

- Unit tests

Manual verification: open an MCAP modal with image and image-annotation topics, select multiple label topics from an image pane, scrub playback, and toggle interpolation from scene settings.

## Notes to Reviewer

Best reviewed commit-by-commit, or by these slices:

- MCAP modal settings/sidebar and image tile label-topic selection.
- Annotation interpolation cache/hook/pure geometry tests.
- Shared tiling focus, settings portal, and header-caption behavior.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

MCAP modal image panes can now overlay multiple image annotation topics, with smoother interpolation between annotation messages during playback.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added an MCAP-specific scene settings sidebar with interpolation toggles and live counts for images, labels, and 3D sources.
  * Enabled multi-topic image annotation overlays with per-topic playback interpolation.
  * Added persistent modal settings for annotation interpolation and label-topic selections.
* **UI Improvements**
  * Improved tile/header captions, including scene context and focused-tile summaries.
  * Updated annotation and 3D source selection controls with optional message-count labels and clearer empty states.
  * Enhanced checkbox keyboard behavior to prevent unintended Space toggling.
* **Tests**
  * Added coverage for interpolation logic and settings behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->