### PR TITLE
Guard community workflows to OSS only

### DIFF
--- a/.github/workflows/community-prs.yml
+++ b/.github/workflows/community-prs.yml
@@ -17,6 +17,8 @@ permissions:
 
 jobs:
   triage:
+    # The `community` branch is OSS-only.
+    if: github.repository == 'voxel51/fiftyone'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v9

--- a/.github/workflows/sync-develop-to-community.yml
+++ b/.github/workflows/sync-develop-to-community.yml
@@ -20,6 +20,8 @@ permissions:
 
 jobs:
   sync:
+    # The `community` branch is OSS-only.
+    if: github.repository == 'voxel51/fiftyone'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## What

Adds the `if: github.repository == 'voxel51/fiftyone'` job guard to two workflows:
- `.github/workflows/community-prs.yml`
- `.github/workflows/sync-develop-to-community.yml`

## Why

Both act on the `community` branch, which is an OSS-only concept. They were missing the repo guard, so their copies (synced into `fiftyone-teams`) ran there too — and `sync-develop-to-community.yml` would create a `community` branch in fiftyone-teams on every push to `develop`.

This mirrors the convention already used by `enterprise-sync.yml`: the workflow lives identically in both repos, and the guard makes the Enterprise copy inert so the file never diverges and never produces a sync conflict.

After this lands, the fiftyone-teams copies go inert on the next OSS→Enterprise sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub workflow configurations to ensure proper execution in the upstream repository only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2919
<!-- enterprise-sync-pr:end -->