### PR TITLE
allow live dev server for CORS

### DIFF
--- a/fiftyone/server/app.py
+++ b/fiftyone/server/app.py
@@ -132,6 +132,14 @@ _allowed_origins = [
     for o in (fo.config.allowed_origins or "").split(",")
     if o.strip()
 ]
+
+# allow live dev-server (`cd app/; yarn dev`)
+# gated on DEV_INSTALL so it never applies to pip-installed deployments.
+if foc.DEV_INSTALL:
+    for _origin in ("http://localhost:5173", "http://127.0.0.1:5173"):
+        if _origin not in _allowed_origins:
+            _allowed_origins.append(_origin)
+
 if _allowed_origins:
     _middleware.append(
         Middleware(


### PR DESCRIPTION
<!--
Community contributors: target the `community` branch, not `develop`. PRs from
non-members are auto-retargeted to `community`. See CONTRIBUTING.md:
https://github.com/voxel51/fiftyone/blob/develop/CONTRIBUTING.md#community-pull-requests
-->

## 🔗 Related Issues

The live devserver no longer loads as it is not allowed by our updated CORS policy.

## 📋 What changes are proposed in this pull request?

ThIs PR adds `localhost:5173` and `127.0.01:5173` to the allowed list for CORS.

## 🧪 How is this patch tested? If it is not, please explain why.

<!--
Describe the tests you ran or wrote to verify your changes. Include:
- New or updated unit/integration tests
- Manual testing steps performed
- Why tests are not applicable (if skipped)
-->

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced CORS configuration in development mode to automatically include local development server origins, improving cross-origin request handling for local development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2935
<!-- enterprise-sync-pr:end -->