### PR TITLE
fix(e2e): stabilize annotate-canvas action-state tests

### DIFF
--- a/e2e-pw/src/oss/fixtures/loader.ts
+++ b/e2e-pw/src/oss/fixtures/loader.ts
@@ -87,10 +87,15 @@ export class OssLoader extends AbstractFiftyoneLoader {
 
       const handleCursorChange = (e: MouseEvent) => {
         const element = document.elementFromPoint(e.clientX, e.clientY);
+        // elementFromPoint may return null (e.g. pointer outside the
+        // viewport); a throw here would silently freeze the cursor flag
+        // at its previous value
+        if (!element) {
+          return;
+        }
         const cursor = window.getComputedStyle(element).cursor;
         if (cursor !== window.__FO_PLAYWRIGHT_CURRENT_CURSOR) {
-          window.__FO_PLAYWRIGHT_CURRENT_CURSOR =
-            window.getComputedStyle(element).cursor;
+          window.__FO_PLAYWRIGHT_CURRENT_CURSOR = cursor;
           document.dispatchEvent(new CustomEvent("cursor-change"));
         }
       };

--- a/e2e-pw/src/oss/poms/modal/sample-canvas/index.ts
+++ b/e2e-pw/src/oss/poms/modal/sample-canvas/index.ts
@@ -120,6 +120,14 @@ export class SampleCanvasPom {
     this.#mouseY = xy.y;
 
     if (cursor) {
+      // The cursor flag only updates on mouse events, so it can hold a stale
+      // value from a previous hover (e.g. a just-clicked sidebar button).
+      // Reset it so the gate below is only satisfied by a fresh hover-driven
+      // update at the target position — otherwise the click can fire before
+      // the canvas has rendered the element the test intends to hit.
+      await this.page.evaluate(() => {
+        window.__FO_PLAYWRIGHT_CURRENT_CURSOR = "";
+      });
       await expect(async () => {
         await this.page.mouse.move(xy.x, xy.y);
         await this.assert.hasCursor(cursor);

--- a/e2e-pw/src/oss/specs/MISSING-annotate-canvas-actions.spec.ts
+++ b/e2e-pw/src/oss/specs/MISSING-annotate-canvas-actions.spec.ts
@@ -83,6 +83,9 @@ test.describe.serial("canvas interactions and action state", () => {
     await modal.assert.isOpen();
     await modal.waitForSampleLoadDomAttribute();
     await modal.sidebar.switchMode("annotate");
+    // Lighter mounts hidden and reveals only after its first render;
+    // canvas overlays are not hit-testable until then
+    await modal.waitForLighterReady();
 
     // Activate detection mode
     await modal.sidebar.annotate.detectionMode("Detections");
@@ -104,6 +107,9 @@ test.describe.serial("canvas interactions and action state", () => {
     await modal.assert.isOpen();
     await modal.waitForSampleLoadDomAttribute();
     await modal.sidebar.switchMode("annotate");
+    // Lighter mounts hidden and reveals only after its first render;
+    // canvas overlays are not hit-testable until then
+    await modal.waitForLighterReady();
 
     // Activate detection mode
     await modal.sidebar.annotate.detectionMode("Detections");
@@ -126,6 +132,9 @@ test.describe.serial("canvas interactions and action state", () => {
     await modal.assert.isOpen();
     await modal.waitForSampleLoadDomAttribute();
     await modal.sidebar.switchMode("annotate");
+    // Lighter mounts hidden and reveals only after its first render;
+    // canvas overlays are not hit-testable until then
+    await modal.waitForLighterReady();
 
     // Activate detection mode
     await modal.sidebar.annotate.detectionMode("Detections");
@@ -152,6 +161,9 @@ test.describe.serial("canvas interactions and action state", () => {
     await modal.assert.isOpen();
     await modal.waitForSampleLoadDomAttribute();
     await modal.sidebar.switchMode("annotate");
+    // Lighter mounts hidden and reveals only after its first render;
+    // canvas overlays are not hit-testable until then
+    await modal.waitForLighterReady();
 
     // Click on the existing detection at (0.4-0.6, 0.4-0.6)
     await modal.sampleCanvas.move(0.5, 0.5, "pointer");
@@ -210,6 +222,9 @@ test.describe.serial("canvas interactions and action state", () => {
     await modal.assert.isOpen();
     await modal.waitForSampleLoadDomAttribute();
     await modal.sidebar.switchMode("annotate");
+    // Lighter mounts hidden and reveals only after its first render;
+    // canvas overlays are not hit-testable until then
+    await modal.waitForLighterReady();
 
     await modal.sidebar.annotate.assert.selectIsActive();
 
@@ -231,6 +246,9 @@ test.describe.serial("canvas interactions and action state", () => {
     await modal.assert.isOpen();
     await modal.waitForSampleLoadDomAttribute();
     await modal.sidebar.switchMode("annotate");
+    // Lighter mounts hidden and reveals only after its first render;
+    // canvas overlays are not hit-testable until then
+    await modal.waitForLighterReady();
 
     // 1. Start in Select mode
     await modal.sidebar.annotate.assert.selectIsActive();
@@ -268,6 +286,9 @@ test.describe.serial("canvas interactions and action state", () => {
     await modal.assert.isOpen();
     await modal.waitForSampleLoadDomAttribute();
     await modal.sidebar.switchMode("annotate");
+    // Lighter mounts hidden and reveals only after its first render;
+    // canvas overlays are not hit-testable until then
+    await modal.waitForLighterReady();
 
     // Activate detection mode and draw a detection
     await modal.sidebar.annotate.detectionMode("Detections");


### PR DESCRIPTION
## What changes are proposed in this pull request?

Ports e2e-pw robustness fixes for the annotate canvas action-state suite (`MISSING-annotate-canvas-actions.spec.ts`) that originated in fiftyone-teams [PR #2868](https://github.com/voxel51/fiftyone-teams/pull/2868). These belong in OSS since the affected files live under `e2e-pw/src/oss/` and are synced one-way OSS → teams.

The three changes work together to stop the canvas-interaction tests from racing the Lighter renderer:

- **`fixtures/loader.ts`** — guard `handleCursorChange` against a `null` `elementFromPoint` (e.g. pointer outside the viewport). Previously a `null` would throw inside the listener and silently freeze the page-global cursor flag at its previous value. Also reuse the already-computed `cursor` value instead of recomputing it.
- **`poms/modal/sample-canvas/index.ts`** — in `move()`, reset `__FO_PLAYWRIGHT_CURRENT_CURSOR` before the cursor-gated retry loop. The flag only updates on mouse events, so it can hold a stale value from a prior hover (e.g. a just-clicked sidebar button); resetting it ensures the gate is only satisfied by a fresh hover-driven update at the target position.
- **`specs/MISSING-annotate-canvas-actions.spec.ts`** — `await modal.waitForLighterReady()` after entering annotate mode in each canvas-interaction test. Lighter mounts hidden and its overlays are not hit-testable until its first render.

### Notes on the port

The teams PR also re-enabled a `test.skip("full cycle ...")`, but that test is already enabled on OSS `develop`, so no re-enable is needed here. The teams branch also lacks the two sidebar-only tests present on OSS; those don't touch the canvas, so `waitForLighterReady()` was intentionally **not** added to them.

## How is this patch tested?

Existing Playwright e2e suite (`e2e-pw`). These are test-stability changes to the annotate canvas action-state suite; no product code is affected.

## Release Notes

N/A — test infrastructure only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cursor tracking from becoming stuck during canvas interactions.
  * Resolved stale cursor state from persisting across mouse movements.
  * Improved canvas overlay readiness synchronization in modal views to prevent premature interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2937
<!-- enterprise-sync-pr:end -->