### PR TITLE
Persist source path during developer installs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -230,6 +230,25 @@ if [ "$SOURCE_ETA_INSTALL" = true ]; then
     cd -
 fi
 
-echo "NOTE: You probably want to run:"
-echo "  export PYTHONPATH=\$PYTHONPATH:$(pwd)"
+if [ "$DEV_INSTALL" = true ]; then
+    echo "Adding FiftyOne source checkout to Python path"
+
+    python - <<'PY'
+import sysconfig
+from pathlib import Path
+
+repo = Path.cwd().resolve()
+site_packages = Path(sysconfig.get_paths()["purelib"])
+pth = site_packages / "fiftyone_dev_source.pth"
+
+pth.write_text(str(repo) + "\n")
+
+print(f"  wrote {pth}")
+print(f"  source path: {repo}")
+PY
+else
+    echo "NOTE: You probably want to run:"
+    echo "  export PYTHONPATH=\$PYTHONPATH:$(pwd)"
+fi
+
 echo "***** INSTALLATION COMPLETE *****"


### PR DESCRIPTION
## 🔗 Related Issues

Addresses #5604

## 📋 What changes are proposed in this pull request?

This updates `install.sh -d` to persist the source checkout path via a `.pth` file in `site-packages`.

When running the CLI outside the repository after a developer install, Python can otherwise resolve an incomplete `fiftyone` namespace package from `site-packages`, which leaves public attributes such as `ViewField` and `config` unavailable.

After writing the `.pth` file, imports and the CLI resolve the local source checkout correctly outside the repository without requiring `PYTHONPATH` to be set in every shell.

## 🧪 How is this patch tested? If it is not, please explain why.

Tested manually with:

* `git diff --check`
* `bash -n install.sh`
* `bash install.sh -d`
* importing `fiftyone` outside the repository
* `fiftyone --version`

After running `bash install.sh -d`, importing `fiftyone` outside the repository resolves the local source checkout and exposes public attributes such as `ViewField` and `config`.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

* [x] No. You can skip the rest of this section.
* [ ] Yes. Give a description of this change to be included in the release
  notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

* [ ] App: FiftyOne application changes
* [x] Build: Build and test infrastructure changes
* [ ] Core: Core `fiftyone` Python library changes
* [ ] Documentation: FiftyOne documentation changes
* [ ] Other
