### PR TITLE
[FOEPD-3956] Provide external interface to internal tags module

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -54,7 +54,7 @@ fot = fou.lazy_import("fiftyone.core.stages")
 foud = fou.lazy_import("fiftyone.utils.data")
 food = fou.lazy_import("fiftyone.operators.delegated")
 foos = fou.lazy_import("fiftyone.operators.store")
-fommtt = fou.lazy_import("fiftyone.multimodal.tags._temporal_tags")
+fota = fou.lazy_import("fiftyone.core.tags")
 
 
 _SUMMARY_FIELD_KEY = "_summary_field"
@@ -6029,9 +6029,9 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         foo.bulk_write(ops, self._sample_collection)
 
         if sample_ids is None:
-            fommtt.delete_for_dataset_id(self._doc.id)
+            fota.delete_for_dataset_id(self._doc.id)
         else:
-            fommtt.delete_for_sample_ids(self._doc.id, sample_ids)
+            fota.delete_for_sample_ids(self._doc.id, sample_ids)
 
         self._update_last_deletion_at(now)
 
@@ -10047,7 +10047,7 @@ def _delete_dataset_extras(dataset):
     svc = foos.ExecutionStoreService(dataset_id=dataset_id)
     svc.cleanup()
 
-    fommtt.delete_for_dataset_id(dataset_id)
+    fota.delete_for_dataset_id(dataset_id)
 
 
 def _clone_collection(
@@ -10173,7 +10173,7 @@ def _clone_collection(
 
     clone_dataset = load_dataset(name)
 
-    fommtt.clone_tags(
+    fota.clone_tags(
         dataset, clone_dataset, sample_collection=sample_collection, now=now
     )
 

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -45,7 +45,7 @@ fob = fou.lazy_import("fiftyone.core.brain")
 fod = fou.lazy_import("fiftyone.core.dataset")
 foe = fou.lazy_import("fiftyone.core.evaluation")
 fors = fou.lazy_import("fiftyone.core.runs")
-fommtt = fou.lazy_import("fiftyone.multimodal.tags._temporal_tags")
+fota = fou.lazy_import("fiftyone.core.tags")
 
 
 logger = logging.getLogger(__name__)
@@ -850,8 +850,8 @@ def drop_orphan_tags(dry_run=False):
     _logger = _get_logger(dry_run=dry_run)
 
     dataset_ids = set(conn.datasets.distinct("_id"))
-    orphan_dataset_ids = fommtt.get_orphan_dataset_ids(dataset_ids)
-    num_tags = fommtt.count_for_dataset_ids(orphan_dataset_ids)
+    orphan_dataset_ids = fota.get_orphan_dataset_ids(dataset_ids)
+    num_tags = fota.count_for_dataset_ids(orphan_dataset_ids)
 
     if num_tags:
         _logger.info(
@@ -861,7 +861,7 @@ def drop_orphan_tags(dry_run=False):
             orphan_dataset_ids,
         )
         if not dry_run:
-            fommtt.delete_for_dataset_ids(orphan_dataset_ids)
+            fota.delete_for_dataset_ids(orphan_dataset_ids)
 
 
 def stream_collection(collection_name):
@@ -1447,11 +1447,11 @@ def delete_dataset(name, dry_run=False):
             conn.drop_collection(frame_collection_name)
 
     _id = dataset_dict["_id"]
-    num_tags = fommtt.count_for_dataset_id(_id)
+    num_tags = fota.count_for_dataset_id(_id)
     if num_tags > 0:
         _logger.info("Deleting %d tag(s)", num_tags)
         if not dry_run:
-            fommtt.delete_for_dataset_id(_id)
+            fota.delete_for_dataset_id(_id)
 
     view_ids = _get_saved_view_ids(dataset_dict)
 

--- a/fiftyone/core/tags.py
+++ b/fiftyone/core/tags.py
@@ -1,0 +1,33 @@
+"""
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+from fiftyone.multimodal.tags._temporal_tags import (
+    clone_tags,
+    count_for_dataset_id,
+    count_for_dataset_ids,
+    delete_for_dataset_id,
+    delete_for_dataset_ids,
+    delete_for_sample_ids,
+    export_tags,
+    get_orphan_dataset_ids,
+    import_tags,
+    TAGS_EXPORT_FILENAME,
+    TemporalTagNotFoundError,
+)
+
+__all__ = [
+    "clone_tags",
+    "count_for_dataset_id",
+    "count_for_dataset_ids",
+    "delete_for_dataset_id",
+    "delete_for_dataset_ids",
+    "delete_for_sample_ids",
+    "export_tags",
+    "get_orphan_dataset_ids",
+    "import_tags",
+    "TAGS_EXPORT_FILENAME",
+    "TemporalTagNotFoundError",
+]

--- a/fiftyone/multimodal/server/routes.py
+++ b/fiftyone/multimodal/server/routes.py
@@ -12,7 +12,7 @@ from starlette.requests import Request
 from starlette.responses import Response
 
 import fiftyone.multimodal.tags as fomt
-from fiftyone.multimodal.tags._temporal_tags import TemporalTagNotFoundError
+from fiftyone.core.tags import TemporalTagNotFoundError
 from fiftyone.multimodal.query import (
     resolve_playback_plan,
     resolve_scene_inventory,

--- a/fiftyone/multimodal/server/routes.py
+++ b/fiftyone/multimodal/server/routes.py
@@ -12,7 +12,7 @@ from starlette.requests import Request
 from starlette.responses import Response
 
 import fiftyone.multimodal.tags as fomt
-from fiftyone.core.tags import TemporalTagNotFoundError
+from fiftyone.multimodal.tags._temporal_tags import TemporalTagNotFoundError
 from fiftyone.multimodal.query import (
     resolve_playback_plan,
     resolve_scene_inventory,

--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -45,7 +45,7 @@ from .parsers import (
     ImageSampleParser,
 )
 
-fommtt = fou.lazy_import("fiftyone.multimodal.tags._temporal_tags")
+fota = fou.lazy_import("fiftyone.core.tags")
 
 logger = logging.getLogger(__name__)
 
@@ -2188,7 +2188,7 @@ class FiftyOneDatasetExporter(BatchDatasetExporter):
         self._runs_dir = os.path.join(self.export_dir, "runs")
         self._metadata_path = os.path.join(self.export_dir, "metadata.json")
         self._tags_path = os.path.join(
-            self.export_dir, fommtt.TAGS_EXPORT_FILENAME
+            self.export_dir, fota.TAGS_EXPORT_FILENAME
         )
 
         if self.use_dirs:
@@ -2349,7 +2349,7 @@ class FiftyOneDatasetExporter(BatchDatasetExporter):
 
         foo.export_document(dataset_dict, self._metadata_path)
 
-        fommtt.export_tags(
+        fota.export_tags(
             _sample_collection, self._tags_path, progress=progress
         )
 

--- a/fiftyone/utils/data/importers.py
+++ b/fiftyone/utils/data/importers.py
@@ -48,7 +48,7 @@ from .parsers import (
     FiftyOneVideoLabelsSampleParser,
 )
 
-fommtt = fou.lazy_import("fiftyone.multimodal.tags._temporal_tags")
+fota = fou.lazy_import("fiftyone.core.tags")
 
 logger = logging.getLogger(__name__)
 
@@ -1833,7 +1833,7 @@ class FiftyOneDatasetImporter(BatchDatasetImporter):
         self._runs_dir = os.path.join(self.dataset_dir, "runs")
         self._metadata_path = os.path.join(self.dataset_dir, "metadata.json")
         self._tags_path = os.path.join(
-            self.dataset_dir, fommtt.TAGS_EXPORT_FILENAME
+            self.dataset_dir, fota.TAGS_EXPORT_FILENAME
         )
 
         if os.path.isdir(self._fields_dir):
@@ -1880,7 +1880,7 @@ class FiftyOneDatasetImporter(BatchDatasetImporter):
                 dataset, dataset_dict, tags=tags, progress=progress
             )
 
-        fommtt.import_tags(
+        fota.import_tags(
             dataset,
             self._tags_path,
             sample_ids=sample_ids if self.max_samples is not None else None,


### PR DESCRIPTION
## 🔗 Related Issues

[FOEPD-3956](https://voxel51.atlassian.net/browse/FOEPD-3956)

## 📋 What changes are proposed in this pull request?

Creates a new `fiftyone.core.tags` module and proxies imports from `fiftyone.multimodal.tags._temporal_tags`, rather than having other modules depend directly on the multimodal internal module.

## 🧪 How is this patch tested? If it is not, please explain why.

Unit tests

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [x] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other

[FOEPD-3956]: https://voxel51.atlassian.net/browse/FOEPD-3956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2964
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized internal tag management by establishing a unified public API in the core module, improving code organization and maintainability across dataset operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->