### PR TITLE
Remove all unused imports

### DIFF
--- a/app/packages/annotation/src/util/labelPersistence.test.ts
+++ b/app/packages/annotation/src/util/labelPersistence.test.ts
@@ -1,11 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import {
-  handleLabelPersistence,
-  type LabelPersistenceArgs,
-} from "./labelPersistence";
+import { handleLabelPersistence } from "./labelPersistence";
 import type { Sample } from "@fiftyone/looker";
 import type { Field } from "@fiftyone/utilities";
-import type { AnnotationLabel } from "@fiftyone/state";
 import type { LabelProxy } from "../deltas";
 import type { JSONDeltas } from "@fiftyone/core/src/client";
 import type { OpType } from "../types";

--- a/app/packages/app/src/Renderer.tsx
+++ b/app/packages/app/src/Renderer.tsx
@@ -72,7 +72,7 @@ const Renderer = () => {
         set(entry, result);
         setReady(true);
       },
-    [router],
+    [router]
   );
 
   const init = useCallback(
@@ -81,7 +81,7 @@ const Renderer = () => {
       await setExpansion();
       apply(result);
     },
-    [apply, setExpansion, setModalState],
+    [apply, setExpansion, setModalState]
   );
 
   useEffect(() => {
@@ -95,7 +95,7 @@ const Renderer = () => {
   useEffect(() => {
     return router.subscribe(
       () => undefined,
-      () => setPending(true),
+      () => setPending(true)
     );
   }, [router, setPending]);
 

--- a/app/packages/app/src/Renderer.tsx
+++ b/app/packages/app/src/Renderer.tsx
@@ -72,7 +72,7 @@ const Renderer = () => {
         set(entry, result);
         setReady(true);
       },
-    [router]
+    [router],
   );
 
   const init = useCallback(
@@ -81,7 +81,7 @@ const Renderer = () => {
       await setExpansion();
       apply(result);
     },
-    [apply, setExpansion, setModalState]
+    [apply, setExpansion, setModalState],
   );
 
   useEffect(() => {
@@ -95,7 +95,7 @@ const Renderer = () => {
   useEffect(() => {
     return router.subscribe(
       () => undefined,
-      () => setPending(true)
+      () => setPending(true),
     );
   }, [router, setPending]);
 

--- a/app/packages/core/src/components/Actions/BrowseOperations/index.tsx
+++ b/app/packages/core/src/components/Actions/BrowseOperations/index.tsx
@@ -1,7 +1,6 @@
 import { PillButton } from "@fiftyone/components";
 import { useOperatorBrowser } from "@fiftyone/operators";
 import { List } from "@mui/icons-material";
-import React from "react";
 import type { ActionProps } from "../types";
 import { ActionDiv, getStringAndNumberProps } from "../utils";
 

--- a/app/packages/core/src/components/Actions/ColorScheme/index.tsx
+++ b/app/packages/core/src/components/Actions/ColorScheme/index.tsx
@@ -1,7 +1,7 @@
 import { useTrackEvent } from "@fiftyone/analytics";
 import { PillButton } from "@fiftyone/components";
 import { ColorLens } from "@mui/icons-material";
-import React, { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRecoilState } from "recoil";
 import { activeColorEntry } from "../../ColorModal/state";
 import { ACTIVE_FIELD } from "../../ColorModal/utils";

--- a/app/packages/core/src/components/Actions/Loading.tsx
+++ b/app/packages/core/src/components/Actions/Loading.tsx
@@ -1,6 +1,5 @@
 import { LoadingDots, useTheme } from "@fiftyone/components";
 import type { CSSProperties } from "react";
-import React from "react";
 
 const Loading = ({ style }: { style?: CSSProperties }) => {
   const theme = useTheme();

--- a/app/packages/core/src/components/Actions/Options/index.tsx
+++ b/app/packages/core/src/components/Actions/Options/index.tsx
@@ -1,7 +1,7 @@
 import { PillButton } from "@fiftyone/components";
 import { useOutsideClick } from "@fiftyone/state";
 import { Settings } from "@mui/icons-material";
-import React, { useRef, useState } from "react";
+import { useRef, useState } from "react";
 import type { ActionProps } from "../types";
 import { ActionDiv, getStringAndNumberProps } from "../utils";
 import Options from "./Options";

--- a/app/packages/core/src/components/Actions/Selected/Grid.tsx
+++ b/app/packages/core/src/components/Actions/Selected/Grid.tsx
@@ -1,6 +1,6 @@
 import * as fos from "@fiftyone/state";
 import type { MutableRefObject } from "react";
-import React, { useCallback } from "react";
+import { useCallback } from "react";
 import { useRecoilValue } from "recoil";
 import { ActionOption } from "../Common";
 import Popout from "../Popout";

--- a/app/packages/core/src/components/Actions/Selected/Modal.tsx
+++ b/app/packages/core/src/components/Actions/Selected/Modal.tsx
@@ -2,7 +2,7 @@ import type { Lookers } from "@fiftyone/looker";
 import { VideoLooker } from "@fiftyone/looker";
 import * as fos from "@fiftyone/state";
 import type { MutableRefObject } from "react";
-import React, { useCallback, useLayoutEffect } from "react";
+import { useCallback, useLayoutEffect } from "react";
 import { useRecoilValue } from "recoil";
 import type { ActionOptionProps } from "../Common";
 import { ActionOption } from "../Common";

--- a/app/packages/core/src/components/Actions/Selected/index.tsx
+++ b/app/packages/core/src/components/Actions/Selected/index.tsx
@@ -2,7 +2,7 @@ import { PillButton } from "@fiftyone/components";
 import * as fos from "@fiftyone/state";
 import { Check } from "@mui/icons-material";
 import type { MutableRefObject } from "react";
-import React, { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRecoilValue } from "recoil";
 import Loading from "../Loading";
 import type { ActionProps } from "../types";

--- a/app/packages/core/src/components/Actions/Similarity/GroupButton.tsx
+++ b/app/packages/core/src/components/Actions/Similarity/GroupButton.tsx
@@ -4,7 +4,6 @@ import SearchIcon from "@mui/icons-material/Search";
 import SettingsIcon from "@mui/icons-material/Settings";
 import CircularProgress from "@mui/material/CircularProgress";
 import type { CSSProperties } from "react";
-import React from "react";
 import styled from "styled-components";
 
 type GroupButtonProps = {

--- a/app/packages/core/src/components/Actions/Similarity/Helper.tsx
+++ b/app/packages/core/src/components/Actions/Similarity/Helper.tsx
@@ -1,7 +1,7 @@
 import { PopoutSectionTitle } from "@fiftyone/components";
 import { executeOperator } from "@fiftyone/operators";
 import SettingsIcon from "@mui/icons-material/Settings";
-import React, { useCallback } from "react";
+import { useCallback } from "react";
 import styled from "styled-components";
 import { PANEL_NAME } from "./constants";
 

--- a/app/packages/core/src/components/Actions/Similarity/MaxKWarning.tsx
+++ b/app/packages/core/src/components/Actions/Similarity/MaxKWarning.tsx
@@ -1,6 +1,5 @@
 import { useTheme } from "@fiftyone/components";
 import ClearOutlinedIcon from "@mui/icons-material/ClearOutlined";
-import React from "react";
 
 type Props = {
   onClose: () => void;

--- a/app/packages/core/src/components/Actions/Similarity/index.tsx
+++ b/app/packages/core/src/components/Actions/Similarity/index.tsx
@@ -2,7 +2,7 @@ import { PillButton } from "@fiftyone/components";
 import { executeOperator } from "@fiftyone/operators";
 import { useOutsideClick, useSimilarityType } from "@fiftyone/state";
 import { Search, Wallpaper } from "@mui/icons-material";
-import React, { useCallback, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { useRecoilValue } from "recoil";
 import Loading from "../Loading";
 import type { ActionProps } from "../types";

--- a/app/packages/core/src/components/Actions/Tag/index.tsx
+++ b/app/packages/core/src/components/Actions/Tag/index.tsx
@@ -3,7 +3,7 @@ import type { Lookers } from "@fiftyone/looker";
 import * as fos from "@fiftyone/state";
 import { LocalOffer } from "@mui/icons-material";
 import type { MutableRefObject } from "react";
-import React, { useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { useRecoilValue } from "recoil";
 import Loading from "../Loading";
 import type { ActionProps } from "../types";

--- a/app/packages/core/src/components/ActivityToast.tsx
+++ b/app/packages/core/src/components/ActivityToast.tsx
@@ -1,6 +1,5 @@
 import { useActivityToast } from "@fiftyone/state";
 import { Icon, ActivityToast as VoodoActivityToast } from "@voxel51/voodo";
-import React from "react";
 
 /**
  * Wrapper for VOODO's ActivityToast which manages toast state.

--- a/app/packages/core/src/components/ColorModal/GlobalSetting.tsx
+++ b/app/packages/core/src/components/ColorModal/GlobalSetting.tsx
@@ -1,7 +1,6 @@
 import * as fos from "@fiftyone/state";
 import { SettingsBackupRestore } from "@mui/icons-material";
 import { Divider, Slider, Typography } from "@mui/material";
-import { default as React } from "react";
 import { useRecoilState } from "recoil";
 import Checkbox from "../Common/Checkbox";
 import RadioGroup from "../Common/RadioGroup";

--- a/app/packages/core/src/components/ColorModal/colorPalette/FieldsMaskTarget.tsx
+++ b/app/packages/core/src/components/ColorModal/colorPalette/FieldsMaskTarget.tsx
@@ -1,8 +1,7 @@
 import { isRgbMaskTargets } from "@fiftyone/looker/src/overlays/util";
 import { MaskColorInput } from "@fiftyone/relay";
 import * as fos from "@fiftyone/state";
-import { cloneDeep } from "lodash";
-import React, { useCallback, useEffect, useMemo } from "react";
+import React, { useCallback, useEffect } from "react";
 import { useRecoilState, useRecoilValue } from "recoil";
 import Checkbox from "../../Common/Checkbox";
 import { fieldColorSetting } from "../FieldSetting";

--- a/app/packages/core/src/components/Common/Checkbox.tsx
+++ b/app/packages/core/src/components/Common/Checkbox.tsx
@@ -1,7 +1,7 @@
 import { LoadingDots, useTheme } from "@fiftyone/components";
 import { Checkbox as MaterialCheckbox } from "@mui/material";
 import { animated } from "@react-spring/web";
-import React, { useMemo } from "react";
+import { useMemo } from "react";
 import { RecoilValueReadOnly, constSelector } from "recoil";
 import styled from "styled-components";
 import { prettify } from "../../utils/generic";

--- a/app/packages/core/src/components/Common/CountSubcount.tsx
+++ b/app/packages/core/src/components/Common/CountSubcount.tsx
@@ -1,6 +1,6 @@
 import { LoadingDots } from "@fiftyone/components";
 import { AggregationQueryTimeout } from "@fiftyone/state";
-import React, { Suspense } from "react";
+import { Suspense } from "react";
 import type { RecoilValue } from "recoil";
 import { constSelector, useRecoilValue, useRecoilValueLoadable } from "recoil";
 import TimedOut from "../Common/TimedOut";

--- a/app/packages/core/src/components/Common/Results.tsx
+++ b/app/packages/core/src/components/Common/Results.tsx
@@ -1,5 +1,5 @@
 import { animated } from "@react-spring/web";
-import React, { useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 import styled from "styled-components";
 
 import { useHighlightHover } from "../Actions/utils";

--- a/app/packages/core/src/components/Common/TimedOut.tsx
+++ b/app/packages/core/src/components/Common/TimedOut.tsx
@@ -1,6 +1,5 @@
 import { Tooltip } from "@fiftyone/components";
 import { QuestionMark } from "@mui/icons-material";
-import React from "react";
 import { useTheme } from "styled-components";
 
 const TimedOut = ({ queryTime }: { queryTime: number }) => {

--- a/app/packages/core/src/components/Common/utils.tsx
+++ b/app/packages/core/src/components/Common/utils.tsx
@@ -6,7 +6,6 @@ import {
   INT_FIELD,
 } from "@fiftyone/utilities";
 import numeral from "numeral";
-import React from "react";
 
 import { getDateTimeRangeFormattersWithPrecision } from "../../utils/generic";
 

--- a/app/packages/core/src/components/EmptySamples.tsx
+++ b/app/packages/core/src/components/EmptySamples.tsx
@@ -2,7 +2,7 @@ import { Button, useTheme } from "@fiftyone/components";
 import * as fos from "@fiftyone/state";
 import ClearAll from "@mui/icons-material/ClearAll";
 import { Typography } from "@mui/material";
-import React, { useMemo } from "react";
+import { useMemo } from "react";
 import { useRecoilValue } from "recoil";
 import styled from "styled-components";
 import ErrorImg from "../images/error.svg";

--- a/app/packages/core/src/components/EventTracker.tsx
+++ b/app/packages/core/src/components/EventTracker.tsx
@@ -14,7 +14,7 @@ const useTrackViewChanges = () => {
       const view = snapshot.getLoadable(fos.view)?.contents;
       const extendedStages = snapshot.getLoadable(fos.extendedStages)?.contents;
       const count = snapshot.getLoadable(
-        fos.count({ path: "", extended: false, modal: false })
+        fos.count({ path: "", extended: false, modal: false }),
       )?.contents;
       const filters = snapshot.getLoadable(fos.filters)?.contents;
 
@@ -35,7 +35,7 @@ const useTrackViewChanges = () => {
         setChanges((prevChanges) => ({ ...prevChanges, ...newChanges }));
       }
     },
-    [changes]
+    [changes],
   );
 
   useRecoilTransactionObserver_UNSTABLE(handleStateChange);

--- a/app/packages/core/src/components/EventTracker.tsx
+++ b/app/packages/core/src/components/EventTracker.tsx
@@ -1,6 +1,6 @@
 import { useRecoilTransactionObserver_UNSTABLE, useRecoilValue } from "recoil";
-import React, { useEffect, useState, useCallback } from "react";
-import { viewAtom, extendedStagesAtom, countAtom } from "./atoms"; // Replace with actual atom imports
+import { useEffect, useState, useCallback } from "react";
+// Replace with actual atom imports
 import * as fos from "@fiftyone/state";
 import { analyticsInfo, useTrackEvent } from "@fiftyone/analytics";
 

--- a/app/packages/core/src/components/EventTracker.tsx
+++ b/app/packages/core/src/components/EventTracker.tsx
@@ -1,6 +1,5 @@
 import { useRecoilTransactionObserver_UNSTABLE, useRecoilValue } from "recoil";
 import { useEffect, useState, useCallback } from "react";
-// Replace with actual atom imports
 import * as fos from "@fiftyone/state";
 import { analyticsInfo, useTrackEvent } from "@fiftyone/analytics";
 
@@ -15,7 +14,7 @@ const useTrackViewChanges = () => {
       const view = snapshot.getLoadable(fos.view)?.contents;
       const extendedStages = snapshot.getLoadable(fos.extendedStages)?.contents;
       const count = snapshot.getLoadable(
-        fos.count({ path: "", extended: false, modal: false }),
+        fos.count({ path: "", extended: false, modal: false })
       )?.contents;
       const filters = snapshot.getLoadable(fos.filters)?.contents;
 
@@ -36,7 +35,7 @@ const useTrackViewChanges = () => {
         setChanges((prevChanges) => ({ ...prevChanges, ...newChanges }));
       }
     },
-    [changes],
+    [changes]
   );
 
   useRecoilTransactionObserver_UNSTABLE(handleStateChange);

--- a/app/packages/core/src/components/Filters/FilterOption/Selected.tsx
+++ b/app/packages/core/src/components/Filters/FilterOption/Selected.tsx
@@ -1,5 +1,4 @@
 import { isSidebarFilterMode } from "@fiftyone/state";
-import React from "react";
 import { useRecoilValue } from "recoil";
 import { getIcon } from "./FilterItem";
 import { Option, OptionKey } from "./useOptions";

--- a/app/packages/core/src/components/Filters/NumericFieldFilter/Boxes.tsx
+++ b/app/packages/core/src/components/Filters/NumericFieldFilter/Boxes.tsx
@@ -1,6 +1,5 @@
 import { Selector, useTheme } from "@fiftyone/components";
 import { maxAtom, minAtom, pathColor } from "@fiftyone/state";
-import React from "react";
 import type { RecoilState } from "recoil";
 import { useRecoilState, useRecoilValue } from "recoil";
 import styled from "styled-components";

--- a/app/packages/core/src/components/Filters/NumericFieldFilter/FilterOption.tsx
+++ b/app/packages/core/src/components/Filters/NumericFieldFilter/FilterOption.tsx
@@ -1,5 +1,4 @@
 import * as fos from "@fiftyone/state";
-import React from "react";
 import { useRecoilValue } from "recoil";
 import Option from "../FilterOption";
 import * as state from "./state";

--- a/app/packages/core/src/components/Filters/NumericFieldFilter/Input.tsx
+++ b/app/packages/core/src/components/Filters/NumericFieldFilter/Input.tsx
@@ -13,7 +13,7 @@ import {
   styles,
 } from "@fiftyone/utilities";
 import type { CSSProperties } from "react";
-import React, { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useRecoilValue } from "recoil";
 
 export type InputType =

--- a/app/packages/core/src/components/Filters/NumericFieldFilter/Inputs.tsx
+++ b/app/packages/core/src/components/Filters/NumericFieldFilter/Inputs.tsx
@@ -1,5 +1,4 @@
 import * as fos from "@fiftyone/state";
-import React from "react";
 import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 import styled from "styled-components";
 import type { InputType } from "./Input";

--- a/app/packages/core/src/components/Filters/NumericFieldFilter/Nonfinites.tsx
+++ b/app/packages/core/src/components/Filters/NumericFieldFilter/Nonfinites.tsx
@@ -1,6 +1,5 @@
 import * as fos from "@fiftyone/state";
 import { FLOAT_FIELD } from "@fiftyone/utilities";
-import React from "react";
 import type { RecoilValueReadOnly, SetterOrUpdater } from "recoil";
 import { useRecoilState, useRecoilValue } from "recoil";
 import Checkbox from "../../Common/Checkbox";

--- a/app/packages/core/src/components/Filters/NumericFieldFilter/NumericFieldFilter.tsx
+++ b/app/packages/core/src/components/Filters/NumericFieldFilter/NumericFieldFilter.tsx
@@ -1,5 +1,5 @@
 import * as fos from "@fiftyone/state";
-import React, { Suspense } from "react";
+import { Suspense } from "react";
 import styled from "styled-components";
 import FieldLabelAndInfo from "../../FieldLabelAndInfo";
 import useQueryPerformanceIcon from "../use-query-performance-icon";

--- a/app/packages/core/src/components/Filters/NumericFieldFilter/RangeSlider.tsx
+++ b/app/packages/core/src/components/Filters/NumericFieldFilter/RangeSlider.tsx
@@ -1,6 +1,6 @@
 import * as fos from "@fiftyone/state";
 import { formatPrimitive } from "@fiftyone/utilities";
-import React, { useRef } from "react";
+import { useRef } from "react";
 import { useRecoilValue } from "recoil";
 import styled from "styled-components";
 import CommonRangeSlider from "../../Common/RangeSlider";

--- a/app/packages/core/src/components/Filters/NumericFieldFilter/Reset.tsx
+++ b/app/packages/core/src/components/Filters/NumericFieldFilter/Reset.tsx
@@ -1,5 +1,4 @@
 import * as fos from "@fiftyone/state";
-import React from "react";
 import { useRecoilCallback, useRecoilValue } from "recoil";
 import { Button } from "../../utils";
 

--- a/app/packages/core/src/components/Filters/StringFilter/Checkboxes.tsx
+++ b/app/packages/core/src/components/Filters/StringFilter/Checkboxes.tsx
@@ -1,6 +1,5 @@
 import { LoadingDots } from "@fiftyone/components";
 import * as fos from "@fiftyone/state";
-import React from "react";
 import type { RecoilState } from "recoil";
 import {
   selectorFamily,

--- a/app/packages/core/src/components/Filters/StringFilter/Reset.tsx
+++ b/app/packages/core/src/components/Filters/StringFilter/Reset.tsx
@@ -1,6 +1,5 @@
 import * as fos from "@fiftyone/state";
 import { isSidebarFilterMode } from "@fiftyone/state";
-import React from "react";
 import { useRecoilCallback } from "recoil";
 import { Button } from "../../utils";
 

--- a/app/packages/core/src/components/Filters/StringFilter/Result.tsx
+++ b/app/packages/core/src/components/Filters/StringFilter/Result.tsx
@@ -1,6 +1,5 @@
 import { useTheme } from "@fiftyone/components";
 import * as fos from "@fiftyone/state";
-import React from "react";
 import { useRecoilValue } from "recoil";
 
 export type Result = { value: string | null; count: number | null };

--- a/app/packages/core/src/components/Filters/use-incomplete-results.tsx
+++ b/app/packages/core/src/components/Filters/use-incomplete-results.tsx
@@ -6,7 +6,6 @@ import {
   queryPerformanceMaxSearch,
 } from "@fiftyone/state";
 import { Launch } from "@mui/icons-material";
-import React from "react";
 import { useRecoilValue } from "recoil";
 import { QUERY_PERFORMANCE_RESULTS } from "../../utils/links";
 

--- a/app/packages/core/src/components/Filters/use-query-performance-icon.tsx
+++ b/app/packages/core/src/components/Filters/use-query-performance-icon.tsx
@@ -1,5 +1,4 @@
 import * as fos from "@fiftyone/state";
-import React from "react";
 import { useRecoilValue } from "recoil";
 import { LightningBolt } from "../Sidebar/Entries/FilterablePathEntry/Icon";
 

--- a/app/packages/core/src/components/Grid/Actions/Patches/index.tsx
+++ b/app/packages/core/src/components/Grid/Actions/Patches/index.tsx
@@ -1,7 +1,7 @@
 import { PillButton } from "@fiftyone/components";
 import * as fos from "@fiftyone/state";
 import { FlipToBack } from "@mui/icons-material";
-import React, { useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { useRecoilValue } from "recoil";
 import Loading from "../../../Actions/Loading";
 import type { ActionProps } from "../../../Actions/types";

--- a/app/packages/core/src/components/Grid/Actions/SaveFilters/index.tsx
+++ b/app/packages/core/src/components/Grid/Actions/SaveFilters/index.tsx
@@ -2,7 +2,6 @@ import { PillButton } from "@fiftyone/components";
 import { subscribe } from "@fiftyone/relay";
 import * as fos from "@fiftyone/state";
 import { Bookmark } from "@mui/icons-material";
-import React from "react";
 import { selector, useRecoilCallback, useRecoilValue } from "recoil";
 import Loading from "../../../Actions/Loading";
 import type { ActionProps } from "../../../Actions/types";

--- a/app/packages/core/src/components/Grid/Actions/index.tsx
+++ b/app/packages/core/src/components/Grid/Actions/index.tsx
@@ -7,7 +7,7 @@ import {
 } from "@fiftyone/operators";
 import { useItemsWithOrderPersistence } from "@fiftyone/utilities";
 import { Box } from "@mui/material";
-import React, { useMemo } from "react";
+import { useMemo } from "react";
 import BrowseOperationsAction from "../../Actions/BrowseOperations";
 import ColorSchemeAction from "../../Actions/ColorScheme";
 import OptionsAction from "../../Actions/Options";

--- a/app/packages/core/src/components/Grid/GridTagBubbles.tsx
+++ b/app/packages/core/src/components/Grid/GridTagBubbles.tsx
@@ -1,7 +1,7 @@
 import { computeTagData } from "@fiftyone/looker/src/elements/common/computeTagData";
 import * as fos from "@fiftyone/state";
 import { prettify } from "@fiftyone/utilities";
-import React, { useMemo } from "react";
+import { useMemo } from "react";
 import styles from "./GridTagBubbles.module.css";
 
 const DEFAULT_FONT_SIZE = 14;

--- a/app/packages/core/src/components/Grid/Header/GroupSlice.tsx
+++ b/app/packages/core/src/components/Grid/Header/GroupSlice.tsx
@@ -1,6 +1,6 @@
 import { Selector } from "@fiftyone/components";
 import { groupSlice, groupSlices, useSetGroupSlice } from "@fiftyone/state";
-import React, { useCallback } from "react";
+import { useCallback } from "react";
 import { useRecoilValue } from "recoil";
 
 const Slice = ({ value }: { className?: string; value: string }) => {

--- a/app/packages/core/src/components/Grid/Header/Header.tsx
+++ b/app/packages/core/src/components/Grid/Header/Header.tsx
@@ -2,7 +2,7 @@ import { LoadingDots, useTheme } from "@fiftyone/components";
 import * as fos from "@fiftyone/state";
 import { isGroup as isGroupAtom } from "@fiftyone/state";
 import { Apps, ImageAspectRatio } from "@mui/icons-material";
-import React, { Suspense, useMemo } from "react";
+import { Suspense, useMemo } from "react";
 import { constSelector, useRecoilValue, useResetRecoilState } from "recoil";
 import { Slider } from "../../Common/RangeSlider";
 import ResourceCount from "../../ResourceCount";

--- a/app/packages/core/src/components/Grid/Header/Sort.tsx
+++ b/app/packages/core/src/components/Grid/Header/Sort.tsx
@@ -6,7 +6,6 @@ import {
   similarityParameters,
 } from "@fiftyone/state";
 import { ArrowDownward, ArrowUpward } from "@mui/icons-material";
-import React from "react";
 import { useRecoilState, useRecoilValue } from "recoil";
 import { ActionOption } from "../../Actions/Common";
 import { SORT_BY_INDEXED_FIELDS } from "../../../utils/links";

--- a/app/packages/core/src/components/Modal/Actions/GroupVisibility/GroupVisibility.tsx
+++ b/app/packages/core/src/components/Modal/Actions/GroupVisibility/GroupVisibility.tsx
@@ -1,7 +1,7 @@
 import { PopoutSectionTitle } from "@fiftyone/components";
 import * as fos from "@fiftyone/state";
 import type { MutableRefObject, ReactNode } from "react";
-import React, { useMemo } from "react";
+import { useMemo } from "react";
 import { useRecoilState, useRecoilValue } from "recoil";
 import Popout from "../../../Actions/Popout";
 import Checkbox from "../../../Common/Checkbox";

--- a/app/packages/core/src/components/Modal/Actions/HiddenLabels/index.tsx
+++ b/app/packages/core/src/components/Modal/Actions/HiddenLabels/index.tsx
@@ -1,7 +1,6 @@
 import { PillButton } from "@fiftyone/components";
 import { hiddenLabels } from "@fiftyone/state";
 import { VisibilityOff } from "@mui/icons-material";
-import React from "react";
 import { useRecoilState } from "recoil";
 
 const HiddenLabels = ({ modal }: { modal?: boolean }) => {

--- a/app/packages/core/src/components/Modal/Actions/ToggleFullscreen/index.tsx
+++ b/app/packages/core/src/components/Modal/Actions/ToggleFullscreen/index.tsx
@@ -1,7 +1,6 @@
 import { PillButton } from "@fiftyone/components";
 import { fullscreen } from "@fiftyone/state";
 import { Fullscreen, FullscreenExit } from "@mui/icons-material";
-import React from "react";
 import { useRecoilState } from "recoil";
 
 const ToggleFullscreen = () => {

--- a/app/packages/core/src/components/Modal/Actions/index.tsx
+++ b/app/packages/core/src/components/Modal/Actions/index.tsx
@@ -1,7 +1,7 @@
 import { OperatorPlacements, types } from "@fiftyone/operators";
 import * as fos from "@fiftyone/state";
 import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
-import React, { useMemo } from "react";
+import { useMemo } from "react";
 import Draggable from "react-draggable";
 import { useRecoilValue } from "recoil";
 import styled from "styled-components";

--- a/app/packages/core/src/components/Modal/Bars.tsx
+++ b/app/packages/core/src/components/Modal/Bars.tsx
@@ -1,5 +1,4 @@
 import { Bar, useTheme } from "@fiftyone/components";
-import { VideoLooker } from "@fiftyone/looker";
 import * as fos from "@fiftyone/state";
 import { Checkbox } from "@mui/material";
 import React, { MutableRefObject, useMemo, useRef } from "react";

--- a/app/packages/core/src/components/Modal/Group/DynamicGroup/NestedGroup/index.tsx
+++ b/app/packages/core/src/components/Modal/Group/DynamicGroup/NestedGroup/index.tsx
@@ -1,5 +1,5 @@
 import * as fos from "@fiftyone/state";
-import React, { Suspense } from "react";
+import { Suspense } from "react";
 import { useRecoilValue } from "recoil";
 import { GroupSuspense } from "../../GroupSuspense";
 import { GroupView } from "../../GroupView";

--- a/app/packages/core/src/components/Modal/Group/DynamicGroup/NonNestedGroup/index.tsx
+++ b/app/packages/core/src/components/Modal/Group/DynamicGroup/NonNestedGroup/index.tsx
@@ -1,5 +1,5 @@
 import * as fos from "@fiftyone/state";
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { useRecoilState, useRecoilValue } from "recoil";
 import styled from "styled-components";
 import { Sample2D } from "../../../Sample2D";

--- a/app/packages/core/src/components/Modal/Group/GroupImageVideoSample.tsx
+++ b/app/packages/core/src/components/Modal/Group/GroupImageVideoSample.tsx
@@ -1,5 +1,4 @@
 import * as fos from "@fiftyone/state";
-import React from "react";
 import { useRecoilValue } from "recoil";
 import { ModalLooker } from "../ModalLooker";
 import { GroupSampleWrapper } from "./GroupSampleWrapper";

--- a/app/packages/core/src/components/Modal/Pin.tsx
+++ b/app/packages/core/src/components/Modal/Pin.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 export default () => {
   return (
     <div

--- a/app/packages/core/src/components/Modal/SelectSampleCheckbox.tsx
+++ b/app/packages/core/src/components/Modal/SelectSampleCheckbox.tsx
@@ -13,7 +13,6 @@ import {
   selectionIconThumbsup,
   selectionIconX,
 } from "@fiftyone/looker";
-import React from "react";
 import { useRecoilValue } from "recoil";
 
 interface SelectSampleCheckboxProps {

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Confirmation/useConfirmDelete.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Confirmation/useConfirmDelete.tsx
@@ -2,7 +2,7 @@ import { MuiButton } from "@fiftyone/components";
 import { Typography } from "@mui/material";
 import { atom, useAtom, useAtomValue, useSetAtom } from "jotai";
 import { atomWithStorage } from "jotai/utils";
-import React, { useCallback } from "react";
+import { useCallback } from "react";
 import styled from "styled-components";
 import { CheckboxView } from "../../../../../plugins/SchemaIO/components";
 import { useAnnotationContext } from "../Edit/useAnnotationContext";

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/AddSchema.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/AddSchema.tsx
@@ -7,7 +7,6 @@ import {
 } from "@mui/icons-material";
 import { Alert, Typography } from "@mui/material";
 import { useSetAtom } from "jotai";
-import React from "react";
 import styled from "styled-components";
 import { activeSchemaTab } from "../state";
 import useCanManageSchema from "../useCanManageSchema";

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Id.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Id.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { SchemaIOComponent } from "../../../../../plugins/SchemaIO";
 import { useAnnotationContext } from "./useAnnotationContext";
 

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/LoadingEntry.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/LoadingEntry.tsx
@@ -1,6 +1,5 @@
 import { LoadingDots, useTheme } from "@fiftyone/components";
 import { animated } from "@react-spring/web";
-import React from "react";
 import styled from "styled-components";
 
 const Container = animated(styled.div`

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/RequiredFieldPrompt.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/RequiredFieldPrompt.tsx
@@ -1,6 +1,6 @@
 import { useNotification } from "@fiftyone/state";
 import { Button, Text, TextColor, TextVariant, Variant } from "@voxel51/voodo";
-import React, { useCallback, useState } from "react";
+import { useCallback, useState } from "react";
 import useCanManageSchema from "./useCanManageSchema";
 import {
   InitializationStatus,

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/AddClassCard.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/EditFieldLabelSchema/GUIContent/AddClassCard.tsx
@@ -3,11 +3,9 @@
  */
 
 import {
-  Checkbox,
   Input,
   Orientation,
   RichList,
-  Size,
   Spacing,
   Stack,
   Text,

--- a/app/packages/core/src/components/QueryPerformanceToast.tsx
+++ b/app/packages/core/src/components/QueryPerformanceToast.tsx
@@ -4,7 +4,7 @@ import { OPTIMIZING_QUERY_PERFORMANCE, SUMMARY_FIELDS } from "../utils/links";
 import { getBrowserStorageEffectForKey } from "@fiftyone/state";
 import { Bolt } from "@mui/icons-material";
 import { Box, Button, Typography } from "@mui/material";
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { atom, useRecoilState } from "recoil";
 

--- a/app/packages/core/src/components/ResourceCount.tsx
+++ b/app/packages/core/src/components/ResourceCount.tsx
@@ -3,7 +3,6 @@ import {
   isGroup as isGroupAtom,
   parentMediaTypeSelector,
 } from "@fiftyone/state";
-import React from "react";
 import { useRecoilValue, useRecoilValueLoadable } from "recoil";
 import styled from "styled-components";
 import TimedOut from "./Common/TimedOut";

--- a/app/packages/core/src/components/Schema/SchemaSearch.tsx
+++ b/app/packages/core/src/components/Schema/SchemaSearch.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { Box, Typography } from "@mui/material";
 import { Tooltip, useTheme } from "@fiftyone/components";
 import { SchemaSelection } from "./SchemaSelection";

--- a/app/packages/core/src/components/Schema/SchemaSearchHelp.tsx
+++ b/app/packages/core/src/components/Schema/SchemaSearchHelp.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Box, Typography } from "@mui/material";
 
 import { CodeBlock, useTheme } from "@fiftyone/components";

--- a/app/packages/core/src/components/Schema/SchemaSelectControls.tsx
+++ b/app/packages/core/src/components/Schema/SchemaSelectControls.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import { useMemo } from "react";
 import { Box, FormControlLabel, FormGroup, Switch } from "@mui/material";
 
 import { useSchemaSettings, useSearchSchemaFields } from "@fiftyone/state";

--- a/app/packages/core/src/components/Schema/SchemaSelection.tsx
+++ b/app/packages/core/src/components/Schema/SchemaSelection.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { Box } from "@mui/material";
 
 import { useSchemaSettings, useSearchSchemaFields } from "@fiftyone/state";

--- a/app/packages/core/src/components/Schema/SchemaSelectionRow.tsx
+++ b/app/packages/core/src/components/Schema/SchemaSelectionRow.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import { useCallback } from "react";
 import { Box, Typography } from "@mui/material";
 
 import Checkbox from "@mui/material/Checkbox";

--- a/app/packages/core/src/components/Schema/SchemaSettings.tsx
+++ b/app/packages/core/src/components/Schema/SchemaSettings.tsx
@@ -3,7 +3,7 @@ import * as fos from "@fiftyone/state";
 import { useOutsideClick } from "@fiftyone/state";
 import CloseIcon from "@mui/icons-material/Close";
 import { Box, Typography } from "@mui/material";
-import React, { Fragment, useCallback, useRef } from "react";
+import { Fragment, useCallback, useRef } from "react";
 import { useResetRecoilState } from "recoil";
 import styled from "styled-components";
 import { TabOption } from "../utils";

--- a/app/packages/core/src/components/Sidebar/Entries/EntryCounts.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/EntryCounts.tsx
@@ -1,5 +1,5 @@
 import * as fos from "@fiftyone/state";
-import React, { useCallback } from "react";
+import { useCallback } from "react";
 import { selectorFamily, useRecoilValue } from "recoil";
 import { SuspenseEntryCounts } from "../../Common/CountSubcount";
 

--- a/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry/Arrow.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry/Arrow.tsx
@@ -1,7 +1,6 @@
 import { Tooltip } from "@fiftyone/components";
 import KeyboardArrowDown from "@mui/icons-material/KeyboardArrowDown";
 import KeyboardArrowUp from "@mui/icons-material/KeyboardArrowUp";
-import React from "react";
 import type { RecoilState } from "recoil";
 import { useRecoilState } from "recoil";
 import { useTheme } from "styled-components";

--- a/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry/DisabledReason.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry/DisabledReason.tsx
@@ -1,6 +1,5 @@
 import { ExternalLink, useTheme } from "@fiftyone/components";
 import Launch from "@mui/icons-material/Launch";
-import React from "react";
 
 export default ({ href, text }: { href: string; text: string }) => {
   const theme = useTheme();

--- a/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry/FilterablePathEntries.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry/FilterablePathEntries.tsx
@@ -1,5 +1,4 @@
 import { pathColor } from "@fiftyone/state";
-import React from "react";
 import { useRecoilValue } from "recoil";
 import FilterItem from "./FilterItem";
 import useFilterData from "./useFilterData";

--- a/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry/Loading.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry/Loading.tsx
@@ -1,5 +1,5 @@
 import { LoadingDots } from "@fiftyone/components";
-import React, { useLayoutEffect, useState } from "react";
+import { useLayoutEffect, useState } from "react";
 import Container from "./Container";
 
 export default function () {

--- a/app/packages/core/src/components/Sidebar/Entries/QueryPerformanceIcon.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/QueryPerformanceIcon.tsx
@@ -3,7 +3,6 @@ import { OPTIMIZING_QUERY_PERFORMANCE } from "../../../utils/links";
 import { getBrowserStorageEffectForKey } from "@fiftyone/state";
 import { Bolt } from "@mui/icons-material";
 import { Box, Button, Tooltip } from "@mui/material";
-import React from "react";
 import { atom, useRecoilState } from "recoil";
 import styled from "styled-components";
 

--- a/app/packages/core/src/components/Sidebar/SidebarContainer.tsx
+++ b/app/packages/core/src/components/Sidebar/SidebarContainer.tsx
@@ -2,7 +2,6 @@ import { Resizable } from "@fiftyone/components";
 import * as fos from "@fiftyone/state";
 import { useTheme as useMUITheme } from "@mui/material";
 import type { ReactNode } from "react";
-import React from "react";
 import { useRecoilState, useResetRecoilState } from "recoil";
 
 const SidebarContainer = ({

--- a/app/packages/core/src/components/Sidebar/ViewSelection/index.tsx
+++ b/app/packages/core/src/components/Sidebar/ViewSelection/index.tsx
@@ -2,7 +2,7 @@ import { useTrackEvent } from "@fiftyone/analytics";
 import { Selection } from "@fiftyone/components";
 import { default as useRefetchableSavedViews } from "../../../hooks/useRefetchableSavedViews";
 import * as fos from "@fiftyone/state";
-import React, { Suspense, useEffect, useMemo } from "react";
+import { Suspense, useEffect, useMemo } from "react";
 import {
   atom,
   useRecoilState,

--- a/app/packages/core/src/components/Snackbar.tsx
+++ b/app/packages/core/src/components/Snackbar.tsx
@@ -3,7 +3,6 @@ import * as fos from "@fiftyone/state";
 import { Launch } from "@mui/icons-material";
 import { Button } from "@mui/material";
 import { SnackbarProvider } from "notistack";
-import React from "react";
 import { useRecoilState } from "recoil";
 
 const SNACK_VISIBLE_DURATION = 5000;

--- a/app/packages/core/src/components/Starter/index.tsx
+++ b/app/packages/core/src/components/Starter/index.tsx
@@ -15,7 +15,7 @@ import {
   Stack,
   Typography,
 } from "@mui/material";
-import React, { useCallback, useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { useRecoilValue } from "recoil";
 import { CONTENT_BY_MODE } from "./content";
 

--- a/app/packages/core/src/plugins/SchemaIO/components/AlertView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/AlertView.tsx
@@ -1,6 +1,5 @@
 import { Markdown } from "@fiftyone/components";
 import { Alert, AlertTitle, Typography } from "@mui/material";
-import React from "react";
 import { getComponentProps } from "../utils";
 
 export default function AlertView(props) {

--- a/app/packages/core/src/plugins/SchemaIO/components/ArrowNavView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/ArrowNavView.tsx
@@ -5,7 +5,6 @@ import {
 } from "@fiftyone/components";
 import { usePanelEvent } from "@fiftyone/operators";
 import { usePanelId } from "@fiftyone/spaces";
-import React from "react";
 import { ViewPropsType } from "../utils/types";
 
 export default function ArrowNavView(props: ViewPropsType) {

--- a/app/packages/core/src/plugins/SchemaIO/components/Button.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/Button.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { ButtonProps, Button as MUIButton } from "@mui/material";
 
 export default function Button(props: ButtonProps) {

--- a/app/packages/core/src/plugins/SchemaIO/components/ChoiceMenuItemBody.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/ChoiceMenuItemBody.tsx
@@ -1,5 +1,4 @@
 import { Box, ListItemText, Typography } from "@mui/material";
-import React from "react";
 import { getComponentProps } from "../utils";
 
 export default function ChoiceMenuItemBody(props: ChoiceMenuItemBodyPropsType) {

--- a/app/packages/core/src/plugins/SchemaIO/components/DashboardPNGExport.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/DashboardPNGExport.tsx
@@ -1,9 +1,9 @@
-import React, { useEffect, useRef } from "react";
+import { useRef } from "react";
 import { Box, Typography } from "@mui/material";
 import { useTheme } from "@fiftyone/components";
 import DynamicIO from "./DynamicIO";
-import { ObjectSchemaType, ViewPropsType } from "../utils/types";
-import { getPath, getProps } from "../utils";
+import { ObjectSchemaType } from "../utils/types";
+import { getPath } from "../utils";
 
 interface DashboardPNGExportProps {
   schema: ObjectSchemaType;

--- a/app/packages/core/src/plugins/SchemaIO/components/DashboardView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/DashboardView.tsx
@@ -14,7 +14,6 @@ import {
   Alert,
   Box,
   BoxProps,
-  Button,
   Checkbox,
   Fab,
   FormControl,

--- a/app/packages/core/src/plugins/SchemaIO/components/EmptyState.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/EmptyState.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Box, Typography } from "@mui/material";
 
 export default function EmptyState(props) {

--- a/app/packages/core/src/plugins/SchemaIO/components/ErrorView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/ErrorView.tsx
@@ -1,5 +1,5 @@
 import { Box, Stack, Typography } from "@mui/material";
-import React, { useState } from "react";
+import { useState } from "react";
 import PopoutButton from "./PopoutButton";
 import { Error } from "@mui/icons-material";
 import { getComponentProps } from "../utils";

--- a/app/packages/core/src/plugins/SchemaIO/components/FieldView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/FieldView.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import TextFieldView from "./TextFieldView";
 
 export default function FieldView(props) {

--- a/app/packages/core/src/plugins/SchemaIO/components/FileDrop.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/FileDrop.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Box, Chip, Typography } from "@mui/material";
 import { useEffect, useRef, useState } from "react";
 import { FileDrop as ReactFileDrop } from "react-file-drop";

--- a/app/packages/core/src/plugins/SchemaIO/components/FileExplorerView/ExplorerActions.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/FileExplorerView/ExplorerActions.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import {
   IconButton,
   TextField,

--- a/app/packages/core/src/plugins/SchemaIO/components/FileExplorerView/FileExplorer.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/FileExplorerView/FileExplorer.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Button } from "@fiftyone/components";
 import ExplorerActions from "./ExplorerActions";
 import FileTable from "./FileTable";

--- a/app/packages/core/src/plugins/SchemaIO/components/FileExplorerView/FileExplorerView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/FileExplorerView/FileExplorerView.tsx
@@ -1,6 +1,5 @@
 import Folder from "@mui/icons-material/Folder";
 import { TextField } from "@mui/material";
-import React from "react";
 import FieldWrapper from "../FieldWrapper";
 import FileExplorer from "./FileExplorer";
 

--- a/app/packages/core/src/plugins/SchemaIO/components/FileExplorerView/FileTable.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/FileExplorerView/FileTable.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import {
   Table,
   TableBody,

--- a/app/packages/core/src/plugins/SchemaIO/components/FileExplorerView/VolumeSelector.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/FileExplorerView/VolumeSelector.tsx
@@ -6,7 +6,6 @@ import {
   Stack,
   Tooltip,
 } from "@mui/material";
-import React from "react";
 import * as icons from "./icons/index";
 import FolderIcon from "@mui/icons-material/Folder";
 import { useAvailableFileSystems } from "./state";

--- a/app/packages/core/src/plugins/SchemaIO/components/FileView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/FileView.tsx
@@ -1,5 +1,5 @@
 import { Alert, Box, Typography } from "@mui/material";
-import React, { useState } from "react";
+import { useState } from "react";
 import FileDrop from "./FileDrop";
 import HeaderView from "./HeaderView";
 import { getComponentProps } from "../utils";

--- a/app/packages/core/src/plugins/SchemaIO/components/HeaderView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/HeaderView.tsx
@@ -1,5 +1,4 @@
 import { Box } from "@mui/material";
-import React from "react";
 import Header from "./Header";
 import { getErrorsForView } from "../utils";
 

--- a/app/packages/core/src/plugins/SchemaIO/components/InferredView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/InferredView.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { generateSchema } from "../utils";
 import DynamicIO from "./DynamicIO";
 

--- a/app/packages/core/src/plugins/SchemaIO/components/JSONView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/JSONView.tsx
@@ -1,7 +1,6 @@
 import { JSONViewer } from "@fiftyone/components";
 import { styles } from "@fiftyone/utilities";
 import { Stack } from "@mui/material";
-import React from "react";
 import styled from "styled-components";
 import { HeaderView } from ".";
 import { getComponentProps } from "../utils";

--- a/app/packages/core/src/plugins/SchemaIO/components/KeyValueView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/KeyValueView.tsx
@@ -7,7 +7,6 @@ import {
   TableContainer,
   TableRow,
 } from "@mui/material";
-import React from "react";
 import { HeaderView } from ".";
 import { getComponentProps } from "../utils";
 import { isPlainObject } from "lodash";

--- a/app/packages/core/src/plugins/SchemaIO/components/LabelValueView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/LabelValueView.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Box, Stack, Typography } from "@mui/material";
 import { getComponentProps } from "../utils";
 

--- a/app/packages/core/src/plugins/SchemaIO/components/LazyFieldView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/LazyFieldView.tsx
@@ -1,7 +1,7 @@
 import { Replay, Save } from "@mui/icons-material";
 import { Box, IconButton, Stack } from "@mui/material";
 import { merge } from "lodash";
-import React, { useCallback, useState } from "react";
+import { useCallback, useState } from "react";
 import FieldView from "./FieldView";
 
 export default function LazyFieldView(props) {

--- a/app/packages/core/src/plugins/SchemaIO/components/LinkView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/LinkView.tsx
@@ -1,5 +1,4 @@
 import { Box, Link } from "@mui/material";
-import React from "react";
 import { getComponentProps } from "../utils";
 
 export default function LinkView(props) {

--- a/app/packages/core/src/plugins/SchemaIO/components/LoaderView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/LoaderView.tsx
@@ -4,7 +4,7 @@
 
 import { Alert, Box, CircularProgress, Typography } from "@mui/material";
 import { get } from "lodash";
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { getComponentProps } from "../utils";
 import DynamicIO from "./DynamicIO";
 import {

--- a/app/packages/core/src/plugins/SchemaIO/components/LoadingView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/LoadingView.tsx
@@ -1,7 +1,6 @@
 import LoadingDots from "@fiftyone/components/src/components/Loading/LoadingDots";
 import LoadingSpinner from "@fiftyone/components/src/components/Loading/LoadingSpinner";
 import { Box } from "@mui/material";
-import React from "react";
 import { getComponentProps } from "../utils";
 
 export default function LoadingView(props) {

--- a/app/packages/core/src/plugins/SchemaIO/components/MapView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/MapView.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import ListView from "./ListView";
 import { getComponentProps } from "../utils";
 

--- a/app/packages/core/src/plugins/SchemaIO/components/MarkdownView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/MarkdownView.tsx
@@ -1,6 +1,5 @@
 import { Markdown } from "@fiftyone/components";
 import { Box } from "@mui/material";
-import React from "react";
 import { HeaderView } from ".";
 import { getComponentProps } from "../utils";
 import { ViewPropsType } from "../utils/types";

--- a/app/packages/core/src/plugins/SchemaIO/components/ModalView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/ModalView.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import ModalBase from "@fiftyone/components/src/components/ModalBase/ModalBase";
 
 export default function ModalView(props) {

--- a/app/packages/core/src/plugins/SchemaIO/components/ObjectView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/ObjectView.tsx
@@ -1,5 +1,4 @@
 import { Box, Grid } from "@mui/material";
-import React from "react";
 import { HeaderView } from ".";
 import { getComponentProps, getPath } from "../utils";
 import DynamicIO from "./DynamicIO";

--- a/app/packages/core/src/plugins/SchemaIO/components/OneOfView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/OneOfView.tsx
@@ -1,6 +1,6 @@
 import { HelpTooltip } from "@fiftyone/components";
 import { Box, Tab, Tabs } from "@mui/material";
-import React, { useState } from "react";
+import { useState } from "react";
 import { HeaderView } from ".";
 import { getComponentProps } from "../utils";
 import DynamicIO from "./DynamicIO";

--- a/app/packages/core/src/plugins/SchemaIO/components/PopoutButton.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/PopoutButton.tsx
@@ -1,7 +1,7 @@
 import { IconButton, Popout } from "@fiftyone/components";
 import { useOutsideClick } from "@fiftyone/state";
 import { Box } from "@mui/material";
-import React, { useRef, useState } from "react";
+import { useRef, useState } from "react";
 
 // todo: convert to a view
 export default function PopoutButton(props: PopoutButtonProps) {

--- a/app/packages/core/src/plugins/SchemaIO/components/PrimitiveView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/PrimitiveView.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import LabelValueView from "./LabelValueView";
 import CheckboxView from "./CheckboxView";
 import FieldView from "./FieldView";

--- a/app/packages/core/src/plugins/SchemaIO/components/ProgressView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/ProgressView.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import {
   Box,
   CircularProgress,

--- a/app/packages/core/src/plugins/SchemaIO/components/RadioView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/RadioView.tsx
@@ -5,7 +5,7 @@ import {
   RadioGroup as MUIRadioGroup,
   Radio,
 } from "@mui/material";
-import React, { useMemo } from "react";
+import { useMemo } from "react";
 import { ButtonView, HeaderView } from ".";
 import { autoFocus, getComponentProps } from "../utils";
 import { useKey } from "../hooks";

--- a/app/packages/core/src/plugins/SchemaIO/components/RoundedTabs.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/RoundedTabs.tsx
@@ -1,6 +1,5 @@
 import { HelpTooltip } from "@fiftyone/components";
 import { Box, Stack, Typography } from "@mui/material";
-import React from "react";
 
 type RoundedTabsProps = {
   tabs: Array<{ id: string; label: string }>;

--- a/app/packages/core/src/plugins/SchemaIO/components/SliderView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/SliderView.tsx
@@ -1,5 +1,5 @@
 import { Box, Grid, Slider, TextField, Typography } from "@mui/material";
-import { isNumber, isEqual } from "lodash";
+import { isNumber } from "lodash";
 import React, { useEffect, useRef, useState } from "react";
 import { useKey } from "../hooks";
 import { autoFocus, getComponentProps } from "../utils";

--- a/app/packages/core/src/plugins/SchemaIO/components/StatusButtonView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/StatusButtonView.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { StatusButton } from "@fiftyone/components";
 import { usePanelEvent } from "@fiftyone/operators";
 import { usePanelId } from "@fiftyone/spaces";

--- a/app/packages/core/src/plugins/SchemaIO/components/SwitchView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/SwitchView.tsx
@@ -1,5 +1,4 @@
 import { FormControlLabel, Switch } from "@mui/material";
-import React from "react";
 import { HeaderView } from ".";
 import { autoFocus, getComponentProps } from "../utils";
 import { useKey } from "../hooks";

--- a/app/packages/core/src/plugins/SchemaIO/components/TableView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/TableView.tsx
@@ -14,7 +14,7 @@ import {
   useTheme,
 } from "@mui/material";
 import { isPlainObject } from "lodash";
-import React, { useCallback } from "react";
+import { useCallback } from "react";
 import { HeaderView } from ".";
 import { getComponentProps } from "../utils";
 import { ViewPropsType } from "../utils/types";

--- a/app/packages/core/src/plugins/SchemaIO/components/TabsView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/TabsView.tsx
@@ -1,6 +1,6 @@
 import { HelpTooltip } from "@fiftyone/components";
 import { Box, Tab, Tabs } from "@mui/material";
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useKey } from "../hooks";
 import { getComponentProps } from "../utils";
 import HeaderView from "./HeaderView";

--- a/app/packages/core/src/plugins/SchemaIO/components/TagsView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/TagsView.tsx
@@ -1,5 +1,4 @@
 import { Box, Chip } from "@mui/material";
-import React from "react";
 import HeaderView from "./HeaderView";
 import { getComponentProps } from "../utils";
 

--- a/app/packages/core/src/plugins/SchemaIO/components/TextView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/TextView.tsx
@@ -1,5 +1,4 @@
 import { Box, Typography } from "@mui/material";
-import React from "react";
 import { getComponentProps } from "../utils";
 import { NumberSchemaType, ViewPropsType } from "../utils/types";
 

--- a/app/packages/core/src/plugins/SchemaIO/components/TimelineView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/TimelineView.tsx
@@ -1,5 +1,5 @@
-import React, { useMemo } from "react";
-import { Timeline, useCreateTimeline, useTimeline } from "@fiftyone/playback";
+import { useMemo } from "react";
+import { Timeline, useCreateTimeline } from "@fiftyone/playback";
 import { ViewPropsType } from "../utils/types";
 
 const DEFAULT_CONFIG = { loop: false };

--- a/app/packages/core/src/plugins/SchemaIO/components/TupleView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/TupleView.tsx
@@ -1,5 +1,4 @@
 import { Box, Grid } from "@mui/material";
-import React from "react";
 import { HeaderView } from ".";
 import { getComponentProps, getPath } from "../utils";
 import DynamicIO from "./DynamicIO";

--- a/app/packages/core/src/plugins/SchemaIO/components/UnsupportedView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/UnsupportedView.tsx
@@ -1,6 +1,6 @@
 import { CodeBlock } from "@fiftyone/components";
 import { Box } from "@mui/material";
-import React, { useState } from "react";
+import { useState } from "react";
 import Button from "./Button";
 import HeaderView from "./HeaderView";
 

--- a/app/packages/core/src/url/useSchemaManagerUrl.test.ts
+++ b/app/packages/core/src/url/useSchemaManagerUrl.test.ts
@@ -21,7 +21,6 @@ import {
   SCHEMA_MANAGER_QUERY_VALUE,
   useSchemaManagerUrl,
 } from "./useSchemaManagerUrl";
-import { URL_CHANGED_EVENT } from "./useUrlSearchSubscription";
 
 const setSearch = (qs: string) => {
   // jsdom lets us pushState; we go through it so subscribers fire.

--- a/app/packages/looker-3d/src/fo3d/point-cloud/use-pcd-material.tsx
+++ b/app/packages/looker-3d/src/fo3d/point-cloud/use-pcd-material.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useMemo } from "react";
 import type { BufferGeometry, Quaternion } from "three";
 import {
   DEFAULT_BOUNDING_BOX,

--- a/app/packages/looker/src/elements/frame.ts
+++ b/app/packages/looker/src/elements/frame.ts
@@ -2,8 +2,8 @@
  * Copyright 2017-2026, Voxel51, Inc.
  */
 
-import { FrameState, StateUpdate } from "../state";
-import { BaseElement, Events } from "./base";
+import { FrameState } from "../state";
+import { BaseElement } from "./base";
 import {
   acquirePlayer,
   acquireThumbnailer,

--- a/app/packages/operators/src/CustomPanel.tsx
+++ b/app/packages/operators/src/CustomPanel.tsx
@@ -1,4 +1,4 @@
-import { CenteredStack, CodeBlock, scrollable } from "@fiftyone/components";
+import { CenteredStack, scrollable } from "@fiftyone/components";
 import { clearUseKeyStores } from "@fiftyone/core/src/plugins/SchemaIO/hooks";
 import {
   PanelSkeleton,

--- a/app/packages/operators/src/useCustomPanelHooks.ts
+++ b/app/packages/operators/src/useCustomPanelHooks.ts
@@ -1,5 +1,5 @@
 import { debounce, merge, mergeWith } from "lodash";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 
 import { usePanelState, useSetCustomPanelState } from "@fiftyone/spaces";
 import { DimensionsType, useUnboundState } from "@fiftyone/state";
@@ -7,7 +7,6 @@ import {
   PANEL_STATE_CHANGE_DEBOUNCE,
   PANEL_STATE_PATH_CHANGE_DEBOUNCE,
 } from "./constants";
-import { executeOperator } from "./operators";
 import { useCurrentSample, useGlobalExecutionContext } from "./state";
 import usePanelEvent from "./usePanelEvent";
 import { memoizedDebounce } from "./utils";

--- a/app/packages/playback/src/views/TimelineWithTracks/TimelineWithTracks.test.tsx
+++ b/app/packages/playback/src/views/TimelineWithTracks/TimelineWithTracks.test.tsx
@@ -1,11 +1,8 @@
 import {
-  act,
   cleanup,
-  fireEvent,
   render,
   screen,
 } from "@testing-library/react";
-import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PlaybackProvider } from "../../lib/playback/PlaybackProvider";
 import { TrackProvider, type Track } from "../../lib/tracks/TrackProvider";

--- a/app/packages/playback/src/views/TimelineWithTracks/TimelineWithTracks.test.tsx
+++ b/app/packages/playback/src/views/TimelineWithTracks/TimelineWithTracks.test.tsx
@@ -1,8 +1,4 @@
-import {
-  cleanup,
-  render,
-  screen,
-} from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PlaybackProvider } from "../../lib/playback/PlaybackProvider";
 import { TrackProvider, type Track } from "../../lib/tracks/TrackProvider";

--- a/app/packages/similarity-search/src/components/Home/BulkActionBar.tsx
+++ b/app/packages/similarity-search/src/components/Home/BulkActionBar.tsx
@@ -12,7 +12,7 @@ import {
   Spacing,
   Variant,
 } from "@voxel51/voodo";
-import React, { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { pluralizeSearches } from "../../utils";
 import { BulkActionBarContainer } from "../styled";
 

--- a/app/packages/similarity-search/src/components/Home/ExpandedThumbnails.tsx
+++ b/app/packages/similarity-search/src/components/Home/ExpandedThumbnails.tsx
@@ -6,7 +6,6 @@ import {
   Orientation,
   Spacing,
 } from "@voxel51/voodo";
-import React from "react";
 import { SimilarityRun } from "../../types";
 import SampleThumbnails from "./SampleThumbnails";
 import { ExpandedSection } from "../styled";

--- a/app/packages/similarity-search/src/components/Home/FilterBar.tsx
+++ b/app/packages/similarity-search/src/components/Home/FilterBar.tsx
@@ -13,7 +13,7 @@ import {
   Spacing,
   Variant,
 } from "@voxel51/voodo";
-import React, { useState } from "react";
+import { useState } from "react";
 import { RunFilterState, DateFilterPreset } from "../../types";
 import { DATE_PRESET_OPTIONS, OWNER_ALL, OWNER_MINE } from "../../constants";
 import { FilterBarSearchCol, FilterBarDateCol } from "../styled";

--- a/app/packages/similarity-search/src/components/Home/SampleThumbnails.tsx
+++ b/app/packages/similarity-search/src/components/Home/SampleThumbnails.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { getSampleSrc } from "@fiftyone/state";
 import { ImageList, Orientation } from "@voxel51/voodo";
 import { THUMB_SIZE, THUMB_GAP, THUMB_SINGLE_ROW_MAX } from "../../constants";

--- a/app/packages/similarity-search/src/components/Home/StatusBadge.tsx
+++ b/app/packages/similarity-search/src/components/Home/StatusBadge.tsx
@@ -1,5 +1,4 @@
 import { Pill, Size, TextColor } from "@voxel51/voodo";
-import React from "react";
 import { RunStatus } from "../../types";
 import { STATUS_COLORS, STATUS_LABELS } from "../../constants";
 

--- a/app/packages/similarity-search/src/components/NewSearch/NewSearch.tsx
+++ b/app/packages/similarity-search/src/components/NewSearch/NewSearch.tsx
@@ -22,7 +22,7 @@ import {
   Variant,
 } from "@voxel51/voodo";
 import { FileUploadOutlined } from "../../mui";
-import React, { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { OperatorExecutionButton } from "@fiftyone/operators";
 import {
   BrainKeyConfig,

--- a/app/packages/similarity-search/src/components/SimilaritySearchCTA.tsx
+++ b/app/packages/similarity-search/src/components/SimilaritySearchCTA.tsx
@@ -1,6 +1,5 @@
 import { PanelCTA, PanelCTAProps } from "@fiftyone/components";
 import { Button, Size, Variant } from "@voxel51/voodo";
-import React from "react";
 import useComputeSimilarity from "../hooks/useComputeSimilarity";
 
 function Actions() {

--- a/app/packages/similarity-search/src/components/SimilaritySearchView.tsx
+++ b/app/packages/similarity-search/src/components/SimilaritySearchView.tsx
@@ -1,6 +1,6 @@
 import { usePanelContext } from "@fiftyone/spaces";
 import { Spinner } from "@voxel51/voodo";
-import React, { Suspense } from "react";
+import { Suspense } from "react";
 import { SimilaritySearchViewProps } from "../types";
 import { useSimilarityPanel } from "../hooks/useSimilarityPanel";
 import RunList from "./Home/RunList";

--- a/app/packages/similarity-search/src/components/styled.tsx
+++ b/app/packages/similarity-search/src/components/styled.tsx
@@ -9,7 +9,7 @@
  * containers. Keep styled() wrappers only for components that need
  * non-flex CSS (borders, backgrounds, positioning, fixed dimensions).
  */
-import React, { CSSProperties, HTMLAttributes, forwardRef } from "react";
+import { CSSProperties, HTMLAttributes, forwardRef } from "react";
 
 // ─── Helpers ────────────────────────────────────────────────────────
 

--- a/app/packages/similarity-search/src/hooks/useNewSearchForm.ts
+++ b/app/packages/similarity-search/src/hooks/useNewSearchForm.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { BrainKeyConfig, CloneConfig, QueryType, SearchScope } from "../types";
-import { SCOPE_VIEW, SCOPE_DATASET } from "../constants";
+import { SCOPE_DATASET } from "../constants";
 import { UploadedImage } from "../utils";
 import { useSearchSelection } from "./useSearchSelection";
 import { useSearchSubmission } from "./useSearchSubmission";

--- a/app/packages/state/src/hooks/useNotification.tsx
+++ b/app/packages/state/src/hooks/useNotification.tsx
@@ -1,7 +1,6 @@
 import Close from "@mui/icons-material/Close";
 import { Button, ButtonProps, IconButton, Stack } from "@mui/material";
 import { closeSnackbar, enqueueSnackbar, OptionsObject } from "notistack";
-import React from "react";
 
 const SNACKBAR_AUTO_HIDE_DURATION = 3000;
 

--- a/app/packages/state/src/recoil/skeletonFilter.ts
+++ b/app/packages/state/src/recoil/skeletonFilter.ts
@@ -1,5 +1,4 @@
 import { Point } from "@fiftyone/looker";
-import { initial } from "lodash";
 import { selectorFamily } from "recoil";
 import { filters, modalFilters } from "./filters";
 import { BooleanFilter } from "./pathFilters/boolean";

--- a/app/types/css-modules.d.ts
+++ b/app/types/css-modules.d.ts
@@ -1,4 +1,1 @@
-declare module "*.module.css" {
-  const classes: Record<string, string>;
-  export default classes;
-}
+declare module "*.module.css";


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link.

## 📋 What changes are proposed in this pull request?

Mechanical TypeScript/lint hygiene for the App — **no runtime or behavior changes.** Three automated sweeps:

- **React import codemod** — removed dead `import React` statements (the app uses the automatic JSX runtime, `jsx: "react-jsx"`), via `react-codemod update-react-imports`.
- **Unused imports & variables** — removed via `eslint-plugin-unused-imports --fix`.
- **CSS-module declaration** — simplified `app/types/css-modules.d.ts` to the shorthand `declare module "*.module.css";`, resolving the CSS-module import-form errors.

**185 files changed (+89 / −224)** — exclusively removals plus the one declaration change.

Effect on `tsc` (`yarn typecheck` / `tsconfig.check.json`): **1,652 → 1,360 errors (−292)**:
- `TS6133` (unused locals/imports): −189
- `TS2614` (CSS-module import form): −101
- `TS6192` / `TS2307`: −2

> ⚠️ Note for reviewers: the `*.module.css` shorthand types CSS-module imports loosely (effectively `any`), so per-class name-checking is no longer enforced by `tsc`. This matches how these imports are consumed today, but it's a suppression rather than a precise fix — a follow-up could restore typed access via per-file `.d.ts` codegen.

## 🧪 How is this patch tested? If it is not, please explain why.

No new tests. The change is purely mechanical — dead-import/unused-variable removal and a single ambient declaration — with no runtime behavior change. Verified by running `yarn typecheck` before and after: the error count only decreased and no error code increased (the diff is exclusively removals). Existing unit/e2e tests and CI cover the unchanged runtime behavior.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Cleaned up imports across many components, aligning them with the modern JSX runtime and named hook imports.
  * Removed a number of unused React, utility, and library imports.

* **Chores**
  * Simplified TypeScript CSS module declarations.
  * Removed a few unused references in supporting hooks and state modules.

* **Tests**
  * Updated test imports to match the new import style without changing test behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3076
<!-- enterprise-sync-pr:end -->