### PR TITLE
fix(storage): allow get_file_size to accept open file handles

### DIFF
--- a/fiftyone/core/storage.py
+++ b/fiftyone/core/storage.py
@@ -1052,7 +1052,8 @@ def get_file_size(path):
     if hasattr(path, "read"):
         position = path.tell()
         try:
-            return path.seek(0, os.SEEK_END)
+            path.seek(0, os.SEEK_END)
+            return path.tell()
         finally:
             path.seek(position)
 

--- a/fiftyone/core/storage.py
+++ b/fiftyone/core/storage.py
@@ -8,6 +8,7 @@ File storage utilities.
 
 from datetime import datetime
 import enum
+import io
 import json
 import logging
 import multiprocessing.dummy
@@ -1050,6 +1051,11 @@ def get_file_size(path_or_file):
     """
     # If given a seekable file handle, use seek/tell to get the size.
     if hasattr(path_or_file, "seek") and hasattr(path_or_file, "tell"):
+        if isinstance(path_or_file, io.TextIOBase):
+            raise TypeError(
+                "get_file_size() requires a binary file handle; got a "
+                "text-mode file. Open the file in binary mode ('rb') instead."
+            )
         position = path_or_file.tell()
         try:
             path_or_file.seek(0, os.SEEK_END)

--- a/fiftyone/core/storage.py
+++ b/fiftyone/core/storage.py
@@ -1043,9 +1043,16 @@ def get_file_size(path):
     Returns the size of the file at the given path in bytes.
 
     Args:
-        path: the filepath
+        path: the filepath, or an open binary file handle
 
     Returns:
         the file size in bytes
     """
+    if hasattr(path, "read"):
+        position = path.tell()
+        try:
+            return path.seek(0, os.SEEK_END)
+        finally:
+            path.seek(position)
+
     return os.path.getsize(path)

--- a/fiftyone/core/storage.py
+++ b/fiftyone/core/storage.py
@@ -1038,23 +1038,23 @@ def _to_bytes(val, encoding="utf-8"):
     return b
 
 
-def get_file_size(path):
+def get_file_size(path_or_file):
     """
     Returns the size of the file at the given path in bytes.
 
     Args:
-        path: the filepath, or an open binary file handle
+        path_or_file: the filepath, or an open binary file handle
 
     Returns:
         the file size in bytes
     """
-    # If path is a file handle, use seek/tell to get the size.
-    if hasattr(path, "read"):
-        position = path.tell()
+    # If given a seekable file handle, use seek/tell to get the size.
+    if hasattr(path_or_file, "seek") and hasattr(path_or_file, "tell"):
+        position = path_or_file.tell()
         try:
-            path.seek(0, os.SEEK_END)
-            return path.tell()
+            path_or_file.seek(0, os.SEEK_END)
+            return path_or_file.tell()
         finally:
-            path.seek(position)
+            path_or_file.seek(position)
 
-    return os.path.getsize(path)
+    return os.path.getsize(path_or_file)

--- a/fiftyone/core/storage.py
+++ b/fiftyone/core/storage.py
@@ -1048,6 +1048,7 @@ def get_file_size(path):
     Returns:
         the file size in bytes
     """
+    # If path is a file handle, use seek/tell to get the size.
     if hasattr(path, "read"):
         position = path.tell()
         try:

--- a/tests/unittests/storage_tests.py
+++ b/tests/unittests/storage_tests.py
@@ -14,6 +14,7 @@ Usage:
 |
 """
 
+import io
 import os
 import shutil
 import tempfile
@@ -987,6 +988,130 @@ class TestTempDir:
                 assert os.path.isdir(tmpdir)
         finally:
             shutil.rmtree(basedir, ignore_errors=True)
+
+
+class TestGetFileSize:
+    """Test get_file_size() for path strings and binary file handles."""
+
+    def test_path_returns_correct_size(self, temp_dir):
+        content = b"hello world"
+        path = os.path.join(temp_dir, "sample.bin")
+        with open(path, "wb") as f:
+            f.write(content)
+
+        assert fos.get_file_size(path) == len(content)
+
+    def test_path_empty_file(self, temp_dir):
+        path = os.path.join(temp_dir, "empty.bin")
+        open(path, "wb").close()
+
+        assert fos.get_file_size(path) == 0
+
+    def test_binary_file_handle_returns_full_size(self, temp_dir):
+        content = b"abcdefghij"
+        path = os.path.join(temp_dir, "handle.bin")
+        with open(path, "wb") as f:
+            f.write(content)
+
+        with open(path, "rb") as f:
+            size = fos.get_file_size(f)
+
+        assert size == len(content)
+
+    def test_file_handle_agrees_with_path(self, temp_dir):
+        """Size from file handle must match size from path."""
+        content = b"\x00" * 512
+        path = os.path.join(temp_dir, "agree.bin")
+        with open(path, "wb") as f:
+            f.write(content)
+
+        with open(path, "rb") as f:
+            handle_size = fos.get_file_size(f)
+
+        assert handle_size == fos.get_file_size(path)
+
+    def test_file_handle_restores_position_at_start(self, temp_dir):
+        content = b"position test"
+        path = os.path.join(temp_dir, "pos.bin")
+        with open(path, "wb") as f:
+            f.write(content)
+
+        with open(path, "rb") as f:
+            assert f.tell() == 0
+            fos.get_file_size(f)
+            assert f.tell() == 0
+
+    def test_file_handle_restores_position_mid_file(self, temp_dir):
+        """If the caller has already read some bytes, the cursor must be
+        restored to that offset — not to 0 and not to EOF."""
+        content = b"abcdefghijklmnop"
+        path = os.path.join(temp_dir, "mid.bin")
+        with open(path, "wb") as f:
+            f.write(content)
+
+        with open(path, "rb") as f:
+            f.read(6)
+            assert f.tell() == 6
+            fos.get_file_size(f)
+            assert f.tell() == 6
+            assert f.read() == content[6:]
+
+    def test_file_handle_does_not_return_remaining_bytes(self, temp_dir):
+        """get_file_size must return the full file size, not EOF - current pos."""
+        content = b"x" * 100
+        path = os.path.join(temp_dir, "full.bin")
+        with open(path, "wb") as f:
+            f.write(content)
+
+        with open(path, "rb") as f:
+            f.seek(40)
+            size = fos.get_file_size(f)
+
+        assert size == 100
+
+    def test_bytesio_duck_typing(self):
+        """BytesIO has seek/tell but is not a real file; it should work via
+        the duck-typed file-handle path."""
+        data = b"in-memory content"
+        buf = io.BytesIO(data)
+
+        size = fos.get_file_size(buf)
+
+        assert size == len(data)
+
+    def test_bytesio_restores_position(self):
+        data = b"abcdefgh"
+        buf = io.BytesIO(data)
+        buf.seek(3)
+
+        fos.get_file_size(buf)
+
+        assert buf.tell() == 3
+
+    def test_text_mode_file_raises_type_error(self, temp_dir):
+        path = os.path.join(temp_dir, "text.txt")
+        with open(path, "w") as f:
+            f.write("some text")
+
+        with open(path, "r") as f:
+            with pytest.raises(TypeError, match="binary file handle"):
+                fos.get_file_size(f)
+
+    def test_stringio_raises_type_error(self):
+        """io.StringIO is an in-memory text stream; it must be rejected with
+        the same TypeError as an on-disk text-mode handle."""
+        buf = io.StringIO("hello")
+        with pytest.raises(TypeError, match="binary file handle"):
+            fos.get_file_size(buf)
+
+    def test_text_mode_error_message_is_helpful(self, temp_dir):
+        path = os.path.join(temp_dir, "text.txt")
+        with open(path, "w") as f:
+            f.write("data")
+
+        with open(path, "r") as f:
+            with pytest.raises(TypeError, match="'rb'"):
+                fos.get_file_size(f)
 
 
 class TestToBytes:


### PR DESCRIPTION
## Summary

`get_file_size` previously only accepted a filepath string. Callers that already hold an open file handle had to introduce their own seek-to-end helpers to avoid opening the file a second time.

When passed a file-like object (any object with a `read` attribute), `get_file_size` now seeks to the end to determine the size, then restores the cursor via `try/finally`. This is portable across any seekable stream, including those opened over remote/cloud paths.

## Test plan
- [ ] Existing unit tests pass
- [ ] Manual verification: call `get_file_size(f)` with an open file handle and confirm it returns the correct size and restores the cursor position

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file size handling so it now accepts either a filesystem path or an open binary file handle, while preserving the current read position to avoid interrupting ongoing reads.
  * Added validation to reject text-mode streams when an open handle is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2938
<!-- enterprise-sync-pr:end -->