### PR TITLE
ci: harden setup-ffmpeg action against apt-get hangs

### DIFF
--- a/.github/actions/setup-ffmpeg/action.yml
+++ b/.github/actions/setup-ffmpeg/action.yml
@@ -11,16 +11,43 @@ runs:
     - name: Install ffmpeg (Linux)
       if: runner.os == 'Linux'
       shell: bash
+      env:
+        DEBIAN_FRONTEND: noninteractive
       run: |
-        sudo apt-get update && \
-          sudo apt-get install -y ffmpeg
+        set -euxo pipefail
+
+        # GitHub-hosted runners run unattended-upgrades / apt-daily timers at
+        # boot, which hold the dpkg lock and can stall apt-get indefinitely.
+        # Stop them, then bound any remaining lock wait instead of blocking
+        # forever. </dev/null guards against debconf prompts that would
+        # otherwise hang waiting on stdin.
+        sudo systemctl stop apt-daily.service apt-daily-upgrade.service \
+          unattended-upgrades 2>/dev/null || true
+
+        apt_get() {
+          sudo timeout 300 apt-get -o DPkg::Lock::Timeout=120 "$@" </dev/null
+        }
+
+        for attempt in 1 2 3; do
+          if apt_get update && \
+             apt_get install -y --no-install-recommends ffmpeg; then
+            break
+          fi
+          if [ "$attempt" -eq 3 ]; then
+            echo "ffmpeg install failed after ${attempt} attempts" >&2
+            exit 1
+          fi
+          echo "apt-get attempt ${attempt} failed; retrying..." >&2
+          sleep "$((attempt * 15))"
+        done
+
         ffmpeg -version
 
     - name: Install ffmpeg (Windows)
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
-        choco install ffmpeg -y --no-progress
+        choco install ffmpeg -y --no-progress --execution-timeout=600
         # ensure the choco shim dir is on PATH for this and subsequent steps
         "C:\ProgramData\chocolatey\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         $env:PATH = "C:\ProgramData\chocolatey\bin;$env:PATH"


### PR DESCRIPTION
## What

Hardens the `setup-ffmpeg` composite action against the intermittent
`apt-get` hangs that have been stalling CI.

## Why

On GitHub-hosted Ubuntu runners the Linux ffmpeg install occasionally hangs
indefinitely on `sudo apt-get update && sudo apt-get install -y ffmpeg` — in
one recent e2e run a single shard sat in "Setup FFmpeg" for ~44 minutes
before the job was cancelled, while sibling shards installed fine. Because
the step has no upper bound, one stuck runner blocks the aggregate test gate
and holds up the merge.

There are three classic causes, all addressed here:

1. **dpkg lock contention.** Runners boot and immediately run
   `unattended-upgrades` / `apt-daily` timers, which hold the dpkg lock; our
   `apt-get install` then waits on it with no timeout. We now stop those
   timers up front and cap any remaining lock wait via
   `DPkg::Lock::Timeout=120`.
2. **Interactive debconf prompts.** A transitive dependency can trigger a
   prompt that blocks forever on stdin. We set
   `DEBIAN_FRONTEND=noninteractive` and redirect stdin from `/dev/null`.
3. **Unbounded network/lock waits.** Each `apt-get` call is wrapped in a
   `timeout 300` and retried up to 3 times for transient failures, so a hang
   fails fast and self-heals instead of stalling the whole job.

Composite-action steps can't use `timeout-minutes`, so the hard ceiling is
enforced with the `timeout` coreutil inside the step.

Also bounds the Windows `choco install` with `--execution-timeout=600` for
parity.

## Scope

CI-only change; no functional/runtime impact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced FFmpeg installation process on Linux with noninteractive Debian environment configuration, automated package manager lock cleanup, strict error handling, and automatic multi-attempt retry logic with exponential backoff between retries.
  * Extended execution timeout duration on Windows for Chocolatey-based FFmpeg installation to provide additional time for installation completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2941
<!-- enterprise-sync-pr:end -->