### PR TITLE
Fix text-tower pooler_output unwrap for transformers 5.x

### DIFF
--- a/fiftyone/utils/transformers.py
+++ b/fiftyone/utils/transformers.py
@@ -557,6 +557,7 @@ class ZeroShotTransformerPromptMixin(PromptMixin):
     def _embed_prompts(self, prompts):
         # I don't think this is ever called with preprocess = False
         # but just in case
+        inputs = None
         if self.preprocess:
             inputs = self.transforms.processor(
                 text=prompts,
@@ -566,6 +567,16 @@ class ZeroShotTransformerPromptMixin(PromptMixin):
             text_features = self._model.base_model.get_text_features(
                 **inputs.to(self._device)
             )
+            # transformers 5.x returns a ``BaseModelOutputWithPooling``
+            # object instead of a plain tensor; pull the pooled embedding.
+            if not isinstance(text_features, torch.Tensor):
+                pooled = getattr(text_features, "pooler_output", None)
+                if pooled is None:
+                    raise ValueError(
+                        "get_text_features() returned a non-tensor output "
+                        "without a pooler_output attribute"
+                    )
+                text_features = pooled
         return text_features
 
 
@@ -1702,6 +1713,8 @@ def _get_image_size(img):
         width, height = img.size
     elif isinstance(img, np.ndarray):
         height, width = img.shape[:2]
+    else:
+        raise ValueError(f"Unsupported image type: {type(img)}")
 
     return height, width
 

--- a/fiftyone/utils/transformers.py
+++ b/fiftyone/utils/transformers.py
@@ -567,16 +567,26 @@ class ZeroShotTransformerPromptMixin(PromptMixin):
             text_features = self._model.base_model.get_text_features(
                 **inputs.to(self._device)
             )
-            # transformers 5.x returns a ``BaseModelOutputWithPooling``
-            # object instead of a plain tensor; pull the pooled embedding.
-            if not isinstance(text_features, torch.Tensor):
-                pooled = getattr(text_features, "pooler_output", None)
-                if pooled is None:
+            if isinstance(text_features, torch.Tensor):
+                # transformers < 5 returns the pooled embedding directly
+                pass
+            elif isinstance(
+                text_features,
+                transformers.modeling_outputs.BaseModelOutputWithPooling,
+            ):
+                # transformers 5.x returns a ``BaseModelOutputWithPooling``
+                # object instead of a plain tensor; pull the pooled embedding.
+                if text_features.pooler_output is None:
                     raise ValueError(
-                        "get_text_features() returned a non-tensor output "
-                        "without a pooler_output attribute"
+                        "get_text_features() returned a "
+                        "BaseModelOutputWithPooling without a pooler_output"
                     )
-                text_features = pooled
+                text_features = text_features.pooler_output
+            else:
+                raise ValueError(
+                    "get_text_features() returned an unsupported output "
+                    f"type: {type(text_features)}"
+                )
         return text_features
 
 

--- a/tests/unittests/utils/test_transformer_pooler.py
+++ b/tests/unittests/utils/test_transformer_pooler.py
@@ -44,8 +44,20 @@ def _make_mixin(get_text_features_return):
     return mixin
 
 
+def _pooling_output(pooler_output):
+    """Build a transformers ``BaseModelOutputWithPooling`` for tests.
+
+    The import is deferred so this module can still be collected when
+    ``transformers`` is not installed.
+    """
+    pytest.importorskip("transformers")
+    from transformers.modeling_outputs import BaseModelOutputWithPooling
+
+    return BaseModelOutputWithPooling(pooler_output=pooler_output)
+
+
 class TestEmbedPromptsPoolerUnwrap:
-    """Test that _embed_prompts handles both plain-tensor and pooler_output returns."""
+    """Test that _embed_prompts handles plain-tensor and pooler_output returns."""
 
     def test_plain_tensor_returned_unchanged(self):
         """When get_text_features returns a plain tensor, it should pass through."""
@@ -56,22 +68,29 @@ class TestEmbedPromptsPoolerUnwrap:
         assert result.shape == (2, 512)
 
     def test_pooler_output_object_is_unwrapped(self):
-        """transformers 5.x returns a namespace with pooler_output; must unwrap."""
+        """transformers 5.x returns a BaseModelOutputWithPooling; must unwrap."""
         pooler_tensor = torch.randn(2, 512)
-        model_output = types.SimpleNamespace(pooler_output=pooler_tensor)
+        model_output = _pooling_output(pooler_tensor)
         mixin = _make_mixin(model_output)
         result = mixin._embed_prompts(["cat", "dog"])
         assert isinstance(result, torch.Tensor)
         assert result.shape == (2, 512)
         assert torch.equal(result, pooler_tensor)
 
-    def test_non_tensor_without_pooler_output_raises(self):
-        """Non-tensor without pooler_output should raise a clear ValueError."""
+    def test_base_model_output_without_pooler_output_raises(self):
+        """A BaseModelOutputWithPooling whose pooler_output is None must raise."""
+        model_output = _pooling_output(None)
+        mixin = _make_mixin(model_output)
+        with pytest.raises(ValueError, match="pooler_output"):
+            mixin._embed_prompts(["cat"])
+
+    def test_unsupported_output_type_raises(self):
+        """An output that is neither a tensor nor a pooling output must raise."""
         bad_output = types.SimpleNamespace(
             last_hidden_state=torch.randn(2, 10, 512)
         )
         mixin = _make_mixin(bad_output)
-        with pytest.raises(ValueError, match="pooler_output"):
+        with pytest.raises(ValueError, match="unsupported"):
             mixin._embed_prompts(["cat"])
 
     def test_embed_prompts_returns_numpy_array(self):
@@ -83,9 +102,9 @@ class TestEmbedPromptsPoolerUnwrap:
         assert result.shape == (3, 256)
 
     def test_embed_prompts_pooler_output_returns_numpy_array(self):
-        """Public embed_prompts must unwrap pooler_output (the sort_by_similarity path)."""
+        """Public embed_prompts must unwrap pooler_output (sort_by_similarity path)."""
         pooler_tensor = torch.randn(3, 256)
-        model_output = types.SimpleNamespace(pooler_output=pooler_tensor)
+        model_output = _pooling_output(pooler_tensor)
         mixin = _make_mixin(model_output)
         result = mixin.embed_prompts(["a", "b", "c"])
         assert isinstance(result, np.ndarray)

--- a/tests/unittests/utils/test_transformer_pooler.py
+++ b/tests/unittests/utils/test_transformer_pooler.py
@@ -1,0 +1,92 @@
+"""
+Tests for ZeroShotTransformerPromptMixin._embed_prompts pooler_output unwrap.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import types
+from unittest import mock
+
+import numpy as np
+import pytest
+import torch
+
+from fiftyone.utils.transformers import ZeroShotTransformerPromptMixin
+
+
+def _make_mixin(get_text_features_return):
+    """Build a minimal ZeroShotTransformerPromptMixin instance with mocks."""
+    mixin = ZeroShotTransformerPromptMixin.__new__(
+        ZeroShotTransformerPromptMixin
+    )
+
+    base_model = mock.MagicMock()
+    base_model.get_text_features.return_value = get_text_features_return
+
+    model = mock.MagicMock()
+    model.base_model = base_model
+
+    mixin._model = model
+    mixin._device = "cpu"
+    mixin.preprocess = True
+
+    inputs_mock = mock.MagicMock()
+    inputs_mock.to.return_value = {}
+    processor_mock = mock.MagicMock(return_value=inputs_mock)
+    transforms_mock = mock.MagicMock()
+    transforms_mock.processor = processor_mock
+    transforms_mock.kwargs = {}
+    mixin.transforms = transforms_mock
+
+    return mixin
+
+
+class TestEmbedPromptsPoolerUnwrap:
+    """Test that _embed_prompts handles both plain-tensor and pooler_output returns."""
+
+    def test_plain_tensor_returned_unchanged(self):
+        """When get_text_features returns a plain tensor, it should pass through."""
+        tensor = torch.randn(2, 512)
+        mixin = _make_mixin(tensor)
+        result = mixin._embed_prompts(["cat", "dog"])
+        assert isinstance(result, torch.Tensor)
+        assert result.shape == (2, 512)
+
+    def test_pooler_output_object_is_unwrapped(self):
+        """transformers 5.x returns a namespace with pooler_output; must unwrap."""
+        pooler_tensor = torch.randn(2, 512)
+        model_output = types.SimpleNamespace(pooler_output=pooler_tensor)
+        mixin = _make_mixin(model_output)
+        result = mixin._embed_prompts(["cat", "dog"])
+        assert isinstance(result, torch.Tensor)
+        assert result.shape == (2, 512)
+        assert torch.equal(result, pooler_tensor)
+
+    def test_non_tensor_without_pooler_output_raises(self):
+        """Non-tensor without pooler_output should raise a clear ValueError."""
+        bad_output = types.SimpleNamespace(
+            last_hidden_state=torch.randn(2, 10, 512)
+        )
+        mixin = _make_mixin(bad_output)
+        with pytest.raises(ValueError, match="pooler_output"):
+            mixin._embed_prompts(["cat"])
+
+    def test_embed_prompts_returns_numpy_array(self):
+        """embed_prompts (public) should return a numpy array."""
+        tensor = torch.randn(3, 256)
+        mixin = _make_mixin(tensor)
+        result = mixin.embed_prompts(["a", "b", "c"])
+        assert isinstance(result, np.ndarray)
+        assert result.shape == (3, 256)
+
+    def test_embed_prompts_pooler_output_returns_numpy_array(self):
+        """Public embed_prompts must unwrap pooler_output (the sort_by_similarity path)."""
+        pooler_tensor = torch.randn(3, 256)
+        model_output = types.SimpleNamespace(pooler_output=pooler_tensor)
+        mixin = _make_mixin(model_output)
+        result = mixin.embed_prompts(["a", "b", "c"])
+        assert isinstance(result, np.ndarray)
+        assert result.shape == (3, 256)
+        assert np.allclose(result, pooler_tensor.numpy())

--- a/tests/unittests/utils/test_transformer_pooler.py
+++ b/tests/unittests/utils/test_transformer_pooler.py
@@ -13,11 +13,11 @@ import numpy as np
 import pytest
 import torch
 
-from fiftyone.utils.transformers import ZeroShotTransformerPromptMixin
-
 
 def _make_mixin(get_text_features_return):
     """Build a minimal ZeroShotTransformerPromptMixin instance with mocks."""
+    from fiftyone.utils.transformers import ZeroShotTransformerPromptMixin
+
     mixin = ZeroShotTransformerPromptMixin.__new__(
         ZeroShotTransformerPromptMixin
     )

--- a/tests/unittests/utils/test_transformer_pooler.py
+++ b/tests/unittests/utils/test_transformer_pooler.py
@@ -16,7 +16,10 @@ import torch
 
 def _make_mixin(get_text_features_return):
     """Build a minimal ZeroShotTransformerPromptMixin instance with mocks."""
-    from fiftyone.utils.transformers import ZeroShotTransformerPromptMixin
+    try:
+        from fiftyone.utils.transformers import ZeroShotTransformerPromptMixin
+    except Exception:
+        pytest.skip("transformers not installed")
 
     mixin = ZeroShotTransformerPromptMixin.__new__(
         ZeroShotTransformerPromptMixin

--- a/tests/unittests/utils/test_transformer_pooler.py
+++ b/tests/unittests/utils/test_transformer_pooler.py
@@ -16,10 +16,8 @@ import torch
 
 def _make_mixin(get_text_features_return):
     """Build a minimal ZeroShotTransformerPromptMixin instance with mocks."""
-    try:
-        from fiftyone.utils.transformers import ZeroShotTransformerPromptMixin
-    except Exception:
-        pytest.skip("transformers not installed")
+    pytest.importorskip("transformers")
+    from fiftyone.utils.transformers import ZeroShotTransformerPromptMixin
 
     mixin = ZeroShotTransformerPromptMixin.__new__(
         ZeroShotTransformerPromptMixin


### PR DESCRIPTION
## Problem

In transformers 5.x, `get_text_features()` returns a `BaseModelOutputWithPooling` object rather than a plain `torch.Tensor`. This caused `sort_by_similarity()` and `compute_similarity()` to crash for any SigLIP/CLIP zero-shot model when a text query was used.

The image-features path in `TransformerEmbeddingsMixin.embed_all` (lines 533–541) already handled this with a `pooler_output` fallback. The text-features path in `ZeroShotTransformerPromptMixin._embed_prompts` was missing the same guard.

## Changes

- **`fiftyone/utils/transformers.py`**: Apply the same `pooler_output` unwrap guard to `_embed_prompts` that already exists in `embed_all` for image features. If `get_text_features()` returns a non-tensor without a `pooler_output` attribute, a clear `ValueError` is raised. Also initialize `inputs` before its conditional block and add a type guard in `_get_image_size` to resolve pre-existing pylint unbound-variable warnings.

- **`tests/unittests/utils/test_transformer_pooler.py`**: New unit tests covering:
  - Plain-tensor passthrough (no unwrap needed)
  - `pooler_output` unwrap for transformers 5.x outputs
  - Error path for non-tensor without `pooler_output`
  - Public `embed_prompts` entry point (the path called by `sort_by_similarity`)

## Test plan

- [x] `python -m pytest tests/unittests/utils/test_transformer_pooler.py -v` — all 5 tests pass
- [ ] Verify `sort_by_similarity(..., model=<zoo CLIP/SigLIP>)` works end-to-end with transformers 5.x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved compatibility with newer Hugging Face Transformers outputs by unwrapping pooled text embeddings when returned as pooling-output objects
  * Added explicit validation that unsupported image input types raise a clear error
  * Ensured prompt embedding inputs are always initialized before any preprocessing step

* **Tests**
  * Added unit tests covering tensor vs pooling-output embedding behavior, NumPy output returns, and expected error cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2942
<!-- enterprise-sync-pr:end -->