### PR TITLE
[FOEPD-3760] multimodal: gate QP off when dataset has non-Mongo fields

### DIFF
--- a/app/packages/state/src/recoil/queryPerformance.ts
+++ b/app/packages/state/src/recoil/queryPerformance.ts
@@ -5,6 +5,7 @@ import {
   OBJECT_ID_FIELD,
   STRING_FIELD,
   VALID_PRIMITIVE_TYPES,
+  hasNonMongoFields,
 } from "@fiftyone/utilities";
 import {
   DefaultValue,
@@ -22,6 +23,7 @@ import { filters } from "./filters";
 import { groupMediaTypes, groupSlice } from "./groups";
 import { isLabelPath } from "./labels";
 import { RelayEnvironmentKey } from "./relay";
+import { mediaType } from "./atoms";
 import * as schemaAtoms from "./schema";
 import { datasetId, datasetName } from "./selectors";
 import { State } from "./types";
@@ -473,7 +475,18 @@ export const defaultQueryPerformanceConfig = selector({
 
 export const queryPerformance = selector<boolean>({
   key: "queryPerformance",
-  get: ({ get }) => get(queryPerformanceSetting) && get(isQueryPerformantView),
+  get: ({ get }) => {
+    // Lightning is a Mongo-side fast path; datasets with fields
+    // outside the Mongo sample collection can't be fully served by
+    // it. Force QP off so the standard aggregations path runs. The
+    // default ``hasNonMongoFields`` impl returns false (no such
+    // datasets exist in OSS); Enterprise overrides it for multimodal
+    // datasets.
+    if (hasNonMongoFields(get(mediaType))) {
+      return false;
+    }
+    return get(queryPerformanceSetting) && get(isQueryPerformantView);
+  },
   set: ({ set }, value) => set(queryPerformanceSetting, value),
 });
 

--- a/app/packages/utilities/src/media.ts
+++ b/app/packages/utilities/src/media.ts
@@ -205,6 +205,33 @@ export const isNativeMediaType = (
 };
 
 /**
+ * Returns true if the provided media type is multimodal.
+ *
+ * @param mediaType media type
+ */
+export const isMultimodal = (mediaType: string | null | undefined): boolean => {
+  return mediaType === MEDIA_TYPE_MULTIMODAL;
+};
+
+/**
+ * Returns true if the dataset has fields outside the Mongo sample
+ * collection — i.e. fields the standard ``lightning`` resolver can't
+ * see. Always false in OSS; overridden in Enterprise where multimodal
+ * datasets carry parquet-backed fields alongside their Mongo doc.
+ *
+ * Callers use this to disable Query Performance for affected
+ * datasets so the sidebar falls back to the standard aggregations
+ * path.
+ *
+ * @param mediaType media type
+ */
+export const hasNonMongoFields = (
+  _mediaType: string | null | undefined
+): boolean => {
+  return false;
+};
+
+/**
  * Returns true if the provided set contains any media types which are
  * associated with FO3D.
  *


### PR DESCRIPTION
## 🔗 Related Issues

[FOEPD-3760](https://voxel51.atlassian.net/browse/FOEPD-3760)

Frontend half of the Enterprise multimodal grid backend; the consumer
that flips the predicate to ``true`` lives in
[voxel51/fiftyone-teams#2904](https://github.com/voxel51/fiftyone-teams/pull/2904).

## 📋 What changes are proposed in this pull request?

Two small additions to ``@fiftyone/utilities/media`` plus a one-line
wire-up in ``state/recoil/queryPerformance``:

* ``isMultimodal(mediaType)`` — predicate over the existing
  ``MEDIA_TYPE_MULTIMODAL`` constant.
* ``hasNonMongoFields(mediaType)`` — does this dataset carry fields
  outside the Mongo sample collection (i.e. fields the ``lightning``
  resolver can't see). **Default impl returns ``false``** because no
  such backends exist in OSS today. Enterprise overrides this for
  multimodal datasets (parquet-backed fields living alongside the
  Mongo episode doc).
* ``queryPerformance`` selector: short-circuit to ``false`` when
  ``hasNonMongoFields`` is true, so the sidebar falls back from the
  Mongo-indexed lightning fast path to the standard aggregations
  path.

In OSS the predicate is always ``false``, so the new branch is
dormant — no behavior change for OSS users. The branch only fires
once an Enterprise build overrides the helper body.

## 🧪 How is this patch tested? If it is not, please explain why.

Two helpers + one short-circuit. Verified manually:

- Frontend builds clean (``yarn lint`` + ``yarn build``)
- ``isMultimodal`` resolves through ``@fiftyone/utilities`` and types
  check
- Default ``hasNonMongoFields`` returns ``false`` for every media
  type, so ``queryPerformance`` continues to honor
  ``queryPerformanceSetting && isQueryPerformantView`` unchanged in
  OSS

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes.

Dormant in OSS; only meaningful once Enterprise overrides the
helper body. Not user-visible on its own.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core \`\`fiftyone\`\` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FOEPD-3760]: https://voxel51.atlassian.net/browse/FOEPD-3760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Query performance settings now automatically and more reliably reflect the dataset’s media type and whether special (non-standard) fields are present, helping ensure optimal performance.
* **Improvements**
  * Added improved media-type detection to accurately identify multimodal datasets, improving consistency in how media capabilities are handled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2944
<!-- enterprise-sync-pr:end -->