### PR TITLE
Perf: Debounce Sidebar Filters

### DIFF
--- a/app/packages/core/src/components/Filters/StringFilter/useUseSearch.ts
+++ b/app/packages/core/src/components/Filters/StringFilter/useUseSearch.ts
@@ -1,6 +1,9 @@
+import { useDebounceCallback } from "@fiftyone/state";
 import { useEffect } from "react";
 import { useRecoilValue, useSetRecoilState } from "recoil";
 import { stringSearch, stringSearchResults } from "./state";
+
+const DEBOUNCE_DELAY = 200;
 
 export default function ({ modal, path }: { modal: boolean; path: string }) {
   return (search: string) => {
@@ -9,10 +12,11 @@ export default function ({ modal, path }: { modal: boolean; path: string }) {
     );
 
     const setSearch = useSetRecoilState(stringSearch({ modal, path }));
+    const debouncedSetSearch = useDebounceCallback(setSearch, DEBOUNCE_DELAY);
 
     useEffect(() => {
-      setSearch(search);
-    }, [search, setSearch]);
+      debouncedSetSearch(search);
+    }, [search, debouncedSetSearch]);
 
     return {
       values,


### PR DESCRIPTION

## 🔗 Related Issues

Fix that came from research done in https://voxel51.atlassian.net/browse/FOEPD-4003

## 📋 What changes are proposed in this pull request?

Adds a debounce to `useUseSearch` to stop a request from being fired on every keystroke

## 🧪 How is this patch tested? If it is not, please explain why.

1. Expand `ground_truth` label in the sidebar
2. Type some text into the 'filter by label' text input filter
3. Observe the network tab and verify a network request was not fired for every keystroke. This has been debounced by `200 ms`

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2949
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search responsiveness by implementing debouncing on search input updates, reducing lag during rapid typing and enhancing overall search performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->