### PR TITLE
Support custom OKS sigmas for keypoint evaluation

### DIFF
--- a/docs/source/user_guide/evaluation.rst
+++ b/docs/source/user_guide/evaluation.rst
@@ -916,8 +916,9 @@ calculated:
 -   For keypoint tasks,
     `object keypoint similarity <https://cocodataset.org/#keypoints-eval>`_
     is computed for each pair of objects, using the extent of the ground truth
-    keypoints as a proxy for the area of the object's bounding box, and
-    assuming uniform falloff (:math:`\kappa`)
+    keypoints as a proxy for the area of the object's bounding box. By default,
+    uniform falloff (:math:`\kappa`) is assumed, but you can provide
+    `keypoint_sigmas` to customize the per-keypoint OKS falloff
 -   For temporal detections, IoU is computed between the 1D support of two
     temporal segments
 

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -4321,6 +4321,8 @@ class SampleCollection(object):
 
         When evaluating keypoints, "IoUs" are computed via
         `object keypoint similarity <https://cocodataset.org/#keypoints-eval>`_.
+        You can pass ``keypoint_sigmas`` to customize the per-keypoint OKS
+        falloff.
 
         For temporal segment detection, this method uses ActivityNet-style
         evaluation by default.

--- a/fiftyone/utils/eval/coco.py
+++ b/fiftyone/utils/eval/coco.py
@@ -52,6 +52,8 @@ class COCOEvaluationConfig(DetectionEvaluationConfig):
         tolerance (None): a tolerance, in pixels, when generating approximate
             polylines for instance masks. Typical values are 1-3 pixels. By
             default, IoUs are computed directly on the dense pixel masks
+        keypoint_sigmas (None): an optional list of per-keypoint OKS sigmas to
+            use when evaluating :class:`fiftyone.core.labels.Keypoints`
         compute_mAP (False): whether to perform the necessary computations so
             that mAP, mAR, and PR curves can be generated
         iou_threshs (None): a list of IoU thresholds to use when computing mAP
@@ -82,6 +84,7 @@ class COCOEvaluationConfig(DetectionEvaluationConfig):
         use_masks=False,
         use_boxes=False,
         tolerance=None,
+        keypoint_sigmas=None,
         compute_mAP=False,
         iou_threshs=None,
         max_preds=None,
@@ -108,6 +111,7 @@ class COCOEvaluationConfig(DetectionEvaluationConfig):
         self.use_masks = use_masks
         self.use_boxes = use_boxes
         self.tolerance = tolerance
+        self.keypoint_sigmas = keypoint_sigmas
         self.compute_mAP = compute_mAP
         self.iou_threshs = iou_threshs
         self.max_preds = max_preds
@@ -542,6 +546,9 @@ def _coco_evaluation_setup(
 
     if config.use_boxes:
         iou_kwargs.update(use_boxes=True)
+
+    if config.keypoint_sigmas is not None:
+        iou_kwargs.update(keypoint_sigmas=config.keypoint_sigmas)
 
     # Organize ground truth and predictions by category
 

--- a/fiftyone/utils/eval/detection.py
+++ b/fiftyone/utils/eval/detection.py
@@ -5,6 +5,7 @@ Detection evaluation.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from copy import deepcopy
 import inspect
 import itertools
@@ -65,6 +66,8 @@ def evaluate_detections(
 
     When evaluating keypoints, "IoUs" are computed via
     `object keypoint similarity <https://cocodataset.org/#keypoints-eval>`_.
+    You can pass ``keypoint_sigmas`` to COCO-style evaluation to customize the
+    per-keypoint OKS falloff.
 
     For temporal segment detection, this method uses ActivityNet-style
     evaluation by default.

--- a/fiftyone/utils/eval/detection.py
+++ b/fiftyone/utils/eval/detection.py
@@ -66,8 +66,7 @@ def evaluate_detections(
 
     When evaluating keypoints, "IoUs" are computed via
     `object keypoint similarity <https://cocodataset.org/#keypoints-eval>`_.
-    You can pass ``keypoint_sigmas`` to COCO-style evaluation to customize the
-    per-keypoint OKS falloff.
+    You can pass ``keypoint_sigmas`` to customize the per-keypoint OKS falloff.
 
     For temporal segment detection, this method uses ActivityNet-style
     evaluation by default.

--- a/fiftyone/utils/eval/openimages.py
+++ b/fiftyone/utils/eval/openimages.py
@@ -46,6 +46,8 @@ class OpenImagesEvaluationConfig(DetectionEvaluationConfig):
         tolerance (None): a tolerance, in pixels, when generating approximate
             polylines for instance masks. Typical values are 1-3 pixels. By
             default, IoUs are computed directly on the dense pixel masks
+        keypoint_sigmas (None): an optional list of per-keypoint OKS sigmas to
+            use when evaluating :class:`fiftyone.core.labels.Keypoints`
         max_preds (None): the maximum number of predicted objects to evaluate
             when computing mAP and PR curves
         error_level (1): the error level to use when manipulating instance
@@ -84,6 +86,7 @@ class OpenImagesEvaluationConfig(DetectionEvaluationConfig):
         use_masks=False,
         use_boxes=False,
         tolerance=None,
+        keypoint_sigmas=None,
         max_preds=None,
         error_level=1,
         hierarchy=None,
@@ -107,6 +110,7 @@ class OpenImagesEvaluationConfig(DetectionEvaluationConfig):
         self.use_masks = use_masks
         self.use_boxes = use_boxes
         self.tolerance = tolerance
+        self.keypoint_sigmas = keypoint_sigmas
         self.max_preds = max_preds
         self.error_level = error_level
         self.hierarchy = hierarchy
@@ -529,6 +533,9 @@ def _open_images_evaluation_setup(
 
     if config.use_boxes:
         iou_kwargs.update(use_boxes=True)
+
+    if config.keypoint_sigmas is not None:
+        iou_kwargs.update(keypoint_sigmas=config.keypoint_sigmas)
 
     # Organize ground truth and predictions by category
 

--- a/fiftyone/utils/iou.py
+++ b/fiftyone/utils/iou.py
@@ -5,6 +5,7 @@ Intersection over union (IoU) utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import contextlib
 import itertools
 import logging
@@ -35,6 +36,7 @@ def compute_ious(
     use_masks=False,
     use_boxes=False,
     tolerance=None,
+    keypoint_sigmas=None,
     sparse=False,
     error_level=1,
 ):
@@ -75,6 +77,8 @@ def compute_ious(
         tolerance (None): a tolerance, in pixels, when generating approximate
             polylines for instance masks. Typical values are 1-3 pixels. By
             default, IoUs are computed directly on the dense pixel masks
+        keypoint_sigmas (None): an optional list of per-keypoint OKS sigmas to
+            use when comparing :class:`fiftyone.core.labels.Keypoint` instances
         sparse (False): whether to return a sparse dict of non-zero IoUs rather
             than a full matrix
         error_level (1): the error level to use when manipulating instance
@@ -133,6 +137,7 @@ def compute_ious(
             preds,
             gts,
             classwise=classwise,
+            keypoint_sigmas=keypoint_sigmas,
             sparse=sparse,
         )
 
@@ -967,7 +972,9 @@ def _compute_segment_ious(preds, gts, sparse=False):
     return ious
 
 
-def _compute_keypoint_similarities(preds, gts, classwise=False, sparse=False):
+def _compute_keypoint_similarities(
+    preds, gts, classwise=False, keypoint_sigmas=None, sparse=False
+):
     is_symmetric = preds is gts
 
     if sparse:
@@ -985,7 +992,9 @@ def _compute_keypoint_similarities(preds, gts, classwise=False, sparse=False):
 
             gtp = gt.points
             predp = pred.points
-            sim = _compute_object_keypoint_similarity(gtp, predp)
+            sim = _compute_object_keypoint_similarity(
+                gtp, predp, keypoint_sigmas=keypoint_sigmas
+            )
             if sim <= 0:
                 continue
 
@@ -1001,9 +1010,26 @@ def _compute_keypoint_similarities(preds, gts, classwise=False, sparse=False):
     return sims
 
 
-def _compute_object_keypoint_similarity(gtp, predp):
+def _compute_object_keypoint_similarity(gtp, predp, keypoint_sigmas=None):
     gtp = np.asarray(gtp, dtype=float)
     predp = np.asarray(predp, dtype=float)
+
+    if keypoint_sigmas is not None:
+        keypoint_sigmas = np.asarray(keypoint_sigmas, dtype=float)
+        if keypoint_sigmas.ndim != 1:
+            raise ValueError("`keypoint_sigmas` must be a 1D array")
+
+        if len(keypoint_sigmas) != len(gtp):
+            raise ValueError(
+                "Expected `keypoint_sigmas` to have length %d, found %d"
+                % (len(gtp), len(keypoint_sigmas))
+            )
+
+        if not np.all(np.isfinite(keypoint_sigmas)):
+            raise ValueError("`keypoint_sigmas` must contain finite values")
+
+        if np.any(keypoint_sigmas <= 0):
+            raise ValueError("`keypoint_sigmas` must contain positive values")
 
     # Use extent of GT points as proxy for box area
     scale = np.sqrt(np.prod(np.nanmax(gtp, axis=0) - np.nanmin(gtp, axis=0)))
@@ -1012,7 +1038,8 @@ def _compute_object_keypoint_similarity(gtp, predp):
     # If GT points are None/nan/inf: skip
     # If pred points are None/nan/inf: use max distance
     dists = []
-    for g, p in zip(gtp, predp):
+    sigmas = []
+    for idx, (g, p) in enumerate(zip(gtp, predp)):
         if not np.isfinite(g).all():
             continue
 
@@ -1023,6 +1050,8 @@ def _compute_object_keypoint_similarity(gtp, predp):
             d = 1
 
         dists.append(d)
+        if keypoint_sigmas is not None:
+            sigmas.append(keypoint_sigmas[idx])
 
     dists = np.array(dists)
     n = len(dists)
@@ -1030,9 +1059,14 @@ def _compute_object_keypoint_similarity(gtp, predp):
     if n == 0:
         return 0.0
 
-    # object keypoint similarity with kappa == 1
+    if keypoint_sigmas is None:
+        sigmas = 1.0
+    else:
+        sigmas = np.array(sigmas)
+
+    # object keypoint similarity with default kappa == 1
     # https://cocodataset.org/#keypoints-eval
-    return np.sum(np.exp(-(dists**2) / (2 * (scale**2)))) / n
+    return np.sum(np.exp(-(dists**2) / (2 * ((scale * sigmas) ** 2)))) / n
 
 
 def _float_to_pixel(gt_bb, img_w, img_h):

--- a/fiftyone/utils/iou.py
+++ b/fiftyone/utils/iou.py
@@ -50,6 +50,7 @@ def compute_ious(
 
     For keypoints, "IoUs" are computed via
     `object keypoint similarity <https://cocodataset.org/#keypoints-eval>`_.
+    You can pass ``keypoint_sigmas`` to customize the per-keypoint OKS falloff.
 
     Args:
         preds: a list of predicted
@@ -1015,21 +1016,11 @@ def _compute_object_keypoint_similarity(gtp, predp, keypoint_sigmas=None):
     predp = np.asarray(predp, dtype=float)
 
     if keypoint_sigmas is not None:
-        keypoint_sigmas = np.asarray(keypoint_sigmas, dtype=float)
-        if keypoint_sigmas.ndim != 1:
-            raise ValueError("`keypoint_sigmas` must be a 1D array")
-
-        if len(keypoint_sigmas) != len(gtp):
+        if len(gtp) != len(keypoint_sigmas):
             raise ValueError(
-                "Expected `keypoint_sigmas` to have length %d, found %d"
-                % (len(gtp), len(keypoint_sigmas))
+                "The number of object keypoints (%d) must match the number of "
+                "`keypoint_sigmas` (%d)" % (len(gtp), len(keypoint_sigmas))
             )
-
-        if not np.all(np.isfinite(keypoint_sigmas)):
-            raise ValueError("`keypoint_sigmas` must contain finite values")
-
-        if np.any(keypoint_sigmas <= 0):
-            raise ValueError("`keypoint_sigmas` must contain positive values")
 
     # Use extent of GT points as proxy for box area
     scale = np.sqrt(np.prod(np.nanmax(gtp, axis=0) - np.nanmin(gtp, axis=0)))
@@ -1060,11 +1051,11 @@ def _compute_object_keypoint_similarity(gtp, predp, keypoint_sigmas=None):
         return 0.0
 
     if keypoint_sigmas is None:
-        sigmas = 1.0
+        sigmas = 1.0  # default: kappa=1
     else:
         sigmas = np.array(sigmas)
 
-    # object keypoint similarity with default kappa == 1
+    # Object keypoint similarity
     # https://cocodataset.org/#keypoints-eval
     return np.sum(np.exp(-(dists**2) / (2 * ((scale * sigmas) ** 2)))) / n
 

--- a/tests/unittests/evaluation_tests.py
+++ b/tests/unittests/evaluation_tests.py
@@ -5,6 +5,7 @@ FiftyOne evaluation-related unit tests.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import os
 import random
 import string
@@ -1535,6 +1536,34 @@ class DetectionsTests(unittest.TestCase):
 
         return dataset
 
+    def _make_keypoints_dataset(self):
+        dataset = fo.Dataset()
+
+        sample = fo.Sample(
+            filepath="image.jpg",
+            ground_truth=fo.Keypoints(
+                keypoints=[
+                    fo.Keypoint(
+                        label="pose",
+                        points=[(0, 0), (1, 1)],
+                    )
+                ]
+            ),
+            predictions=fo.Keypoints(
+                keypoints=[
+                    fo.Keypoint(
+                        label="pose",
+                        points=[(0, 0), (0.7, 1)],
+                        confidence=[0.9, 0.9],
+                    )
+                ]
+            ),
+        )
+
+        dataset.add_sample(sample)
+
+        return dataset
+
     def _evaluate_coco(self, dataset, kwargs):
         _, gt_eval_field = dataset._get_label_field_path(
             "ground_truth", "eval"
@@ -1976,6 +2005,61 @@ class DetectionsTests(unittest.TestCase):
         kwargs = {}
 
         self._evaluate_coco(dataset, kwargs)
+
+    @drop_datasets
+    def test_evaluate_keypoints_with_custom_sigmas(self):
+        dataset = self._make_keypoints_dataset()
+
+        results = dataset.evaluate_detections(
+            "predictions",
+            gt_field="ground_truth",
+            eval_key="default",
+            method="coco",
+            iou=0.9,
+        )
+
+        self.assertEqual(results.metrics()["support"], 1)
+        self.assertListEqual(dataset.values("default_tp"), [1])
+        self.assertListEqual(dataset.values("default_fp"), [0])
+        self.assertListEqual(dataset.values("default_fn"), [0])
+
+        results = dataset.evaluate_detections(
+            "predictions",
+            gt_field="ground_truth",
+            eval_key="strict",
+            method="coco",
+            iou=0.9,
+            keypoint_sigmas=[1, 0.05],
+            compute_mAP=True,
+        )
+
+        self.assertEqual(results.config.keypoint_sigmas, [1, 0.05])
+        self.assertListEqual(dataset.values("strict_tp"), [0])
+        self.assertListEqual(dataset.values("strict_fp"), [1])
+        self.assertListEqual(dataset.values("strict_fn"), [1])
+
+    def test_compute_ious_with_custom_keypoint_sigmas(self):
+        gts = [
+            fo.Keypoint(
+                label="pose",
+                points=[(0, 0), (1, 1)],
+            )
+        ]
+        preds = [
+            fo.Keypoint(
+                label="pose",
+                points=[(0, 0), (0.7, 1)],
+            )
+        ]
+
+        default = foui.compute_ious(preds, gts)[0, 0]
+        strict = foui.compute_ious(preds, gts, keypoint_sigmas=[1, 0.05])[0, 0]
+
+        self.assertGreater(default, 0.9)
+        self.assertLess(strict, 0.9)
+
+        with self.assertRaises(ValueError):
+            foui.compute_ious(preds, gts, keypoint_sigmas=[1])
 
     @drop_datasets
     def test_evaluate_detections_open_images(self):


### PR DESCRIPTION
## What changed

Adds configurable per-keypoint OKS sigmas for COCO-style keypoint evaluation.

This lets users evaluate pose, face landmark, pet skeleton, and other non-COCO keypoint schemas with a task-specific falloff instead of the current fixed kappa=1 behavior.

Closes #5299.

## Why

The existing OKS implementation treats every keypoint with the same tolerance. That can make custom keypoint models look much better than they are when some landmarks should be scored more strictly.

This PR wires `keypoint_sigmas` through:

- `compute_ious()` for `Keypoint` labels
- COCO evaluation config
- Open Images evaluation config
- normal matching and `compute_mAP` IoU sweeps

## Tests

- Added unit coverage for raw OKS scoring with custom sigmas
- Added evaluation coverage showing a prediction that passes default OKS but fails under stricter per-keypoint sigmas
- `python3 -m compileall -q fiftyone/utils/iou.py fiftyone/utils/eval/coco.py fiftyone/utils/eval/detection.py tests/unittests/evaluation_tests.py`
- `python3 -m black --check fiftyone/utils/iou.py fiftyone/utils/eval/coco.py fiftyone/utils/eval/detection.py tests/unittests/evaluation_tests.py`
- `git diff --check`

I could not run the focused pytest locally because this machine is missing the repo dependency `eta` during test collection.
