### PR TITLE
Fix: useUnselectVisible Reads from the Wrong Atom

### DIFF
--- a/app/packages/core/src/components/Actions/Selected/hooks.test.ts
+++ b/app/packages/core/src/components/Actions/Selected/hooks.test.ts
@@ -1,0 +1,265 @@
+// @vitest-environment jsdom
+
+/**
+ * Tests for useUnselectVisible.
+ *
+ * Regression: Before the fix, the hook read from fos.selectedLabels (an array)
+ * instead of fos.selectedLabelMap (a {labelId: labelData} object). This caused
+ * Object.entries() to iterate the numeric array indices, writing keys like "0",
+ * "1", "2" into selectedLabelMap instead of the real labelIds — permanently
+ * corrupting selection state so that the "Manage Selected" badge showed the
+ * wrong count after deselecting visible labels.
+ */
+
+import { act, renderHook } from "@testing-library/react";
+import React from "react";
+import {
+  DefaultValue,
+  RecoilRoot,
+  useRecoilValue,
+  type MutableSnapshot,
+} from "recoil";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Atom/selector stubs ────────────────────────────────────────────────────
+// vi.hoisted ensures these refs exist as a mutable container before any
+// vi.mock factory or import runs. The async factory populates them.
+const stubs = vi.hoisted(() => ({
+  selectedLabels: null as any,
+  selectedLabelMap: null as any,
+}));
+
+vi.mock("@fiftyone/state", async () => {
+  const { atom, selector, DefaultValue: DV } = await import("recoil");
+
+  stubs.selectedLabels = atom<any[]>({
+    key: "_test/Selected/selectedLabels",
+    default: [],
+  });
+
+  stubs.selectedLabelMap = selector<Record<string, any>>({
+    key: "_test/Selected/selectedLabelMap",
+    get: ({ get }) =>
+      (get(stubs.selectedLabels) as any[]).reduce(
+        (acc: Record<string, any>, { labelId, ...label }: any) => ({
+          [labelId]: label,
+          ...acc,
+        }),
+        {} as Record<string, any>
+      ),
+    set: ({ set }, newValue) => {
+      if (newValue instanceof DV) {
+        set(stubs.selectedLabels, []);
+        return;
+      }
+      set(
+        stubs.selectedLabels,
+        Object.entries(newValue as Record<string, any>).map(
+          ([labelId, label]) => ({ ...label, labelId })
+        )
+      );
+    },
+  });
+
+  return {
+    selectedLabels: stubs.selectedLabels,
+    selectedLabelMap: stubs.selectedLabelMap,
+  };
+});
+
+// ── Lighter scene mock ─────────────────────────────────────────────────────
+const refs = vi.hoisted(() => ({
+  scene: { clearSelection: vi.fn() } as {
+    clearSelection: ReturnType<typeof vi.fn>;
+  } | null,
+}));
+
+vi.mock("@fiftyone/lighter", () => ({
+  useLighter: () => ({ scene: refs.scene }),
+}));
+
+import { useUnselectVisible } from "./hooks";
+
+type LabelEntry = { sampleId: string; field: string; frameNumber?: number };
+type LabelMap = Record<string, LabelEntry>;
+
+//Creates a RecoilRoot wrapper pre-seeded with `initialMap`.
+function makeWrapper(initialMap: LabelMap) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(
+      RecoilRoot,
+      {
+        initializeState: ({ set }: MutableSnapshot) => {
+          set(stubs.selectedLabelMap, initialMap);
+        },
+      },
+      children
+    );
+  };
+}
+
+describe("useUnselectVisible", () => {
+  beforeEach(() => {
+    refs.scene = { clearSelection: vi.fn() };
+  });
+
+  it("removes visible label IDs from selectedLabelMap", async () => {
+    const initial: LabelMap = {
+      "label-a": { sampleId: "s1", field: "detections" },
+      "label-b": { sampleId: "s1", field: "detections" },
+      "label-c": { sampleId: "s2", field: "detections" },
+    };
+
+    const { result } = renderHook(
+      () => ({
+        callback: useUnselectVisible(
+          undefined,
+          new Set(["label-a", "label-b"])
+        ),
+        map: useRecoilValue(stubs.selectedLabelMap),
+      }),
+      { wrapper: makeWrapper(initial) }
+    );
+
+    await act(async () => {
+      await result.current.callback();
+    });
+
+    expect(result.current.map).toEqual({
+      "label-c": { sampleId: "s2", field: "detections" },
+    });
+  });
+
+  it("leaves selectedLabelMap unchanged when no visible IDs match", async () => {
+    const initial: LabelMap = {
+      "label-a": { sampleId: "s1", field: "detections" },
+    };
+
+    const { result } = renderHook(
+      () => ({
+        callback: useUnselectVisible(undefined, new Set(["label-x"])),
+        map: useRecoilValue(stubs.selectedLabelMap),
+      }),
+      { wrapper: makeWrapper(initial) }
+    );
+
+    await act(async () => {
+      await result.current.callback();
+    });
+
+    expect(result.current.map).toEqual({
+      "label-a": { sampleId: "s1", field: "detections" },
+    });
+  });
+
+  it("produces an empty map when all labels are in the visible set", async () => {
+    const initial: LabelMap = {
+      "label-a": { sampleId: "s1", field: "detections" },
+      "label-b": { sampleId: "s2", field: "detections" },
+    };
+
+    const { result } = renderHook(
+      () => ({
+        callback: useUnselectVisible(
+          undefined,
+          new Set(["label-a", "label-b"])
+        ),
+        map: useRecoilValue(stubs.selectedLabelMap),
+      }),
+      { wrapper: makeWrapper(initial) }
+    );
+
+    await act(async () => {
+      await result.current.callback();
+    });
+
+    expect(result.current.map).toEqual({});
+  });
+
+  it("calls scene.clearSelection when a lighter scene is present", async () => {
+    const { result } = renderHook(
+      () => useUnselectVisible(undefined, new Set(["label-a"])),
+      {
+        wrapper: makeWrapper({
+          "label-a": { sampleId: "s1", field: "detections" },
+        }),
+      }
+    );
+
+    await act(async () => {
+      await result.current();
+    });
+
+    expect(refs.scene!.clearSelection).toHaveBeenCalledOnce();
+    expect(refs.scene!.clearSelection).toHaveBeenCalledWith({
+      ignoreSideEffects: true,
+    });
+  });
+
+  it("does not call scene.clearSelection when scene is null", async () => {
+    refs.scene = null;
+    const clearSelection = vi.fn();
+
+    const { result } = renderHook(
+      () => useUnselectVisible(undefined, new Set(["label-a"])),
+      {
+        wrapper: makeWrapper({
+          "label-a": { sampleId: "s1", field: "detections" },
+        }),
+      }
+    );
+
+    await act(async () => {
+      await result.current();
+    });
+
+    expect(clearSelection).not.toHaveBeenCalled();
+  });
+
+  it("works correctly with an empty initial selection", async () => {
+    const { result } = renderHook(
+      () => ({
+        callback: useUnselectVisible(undefined, new Set(["label-x"])),
+        map: useRecoilValue(stubs.selectedLabelMap),
+      }),
+      { wrapper: makeWrapper({}) }
+    );
+
+    await act(async () => {
+      await result.current.callback();
+    });
+
+    expect(result.current.map).toEqual({});
+  });
+
+  it("retains only labelId-keyed entries after filtering (regression: array-index corruption)", async () => {
+    const initial: LabelMap = {
+      "label-a": { sampleId: "s1", field: "detections" },
+      "label-b": { sampleId: "s2", field: "detections" },
+    };
+
+    const { result } = renderHook(
+      () => ({
+        callback: useUnselectVisible(undefined, new Set(["label-a"])),
+        map: useRecoilValue(stubs.selectedLabelMap),
+      }),
+      { wrapper: makeWrapper(initial) }
+    );
+
+    await act(async () => {
+      await result.current.callback();
+    });
+
+    const keys = Object.keys(result.current.map);
+
+    // No numeric index keys must survive — a buggy read from the array would
+    // produce "0" and "1" instead of the real labelIds. This tests against a previous regression.
+    expect(keys).not.toContain("0");
+    expect(keys).not.toContain("1");
+
+    // The surviving label must be keyed by its actual labelId.
+    expect(result.current.map).toEqual({
+      "label-b": { sampleId: "s2", field: "detections" },
+    });
+  });
+});

--- a/app/packages/core/src/components/Actions/Selected/hooks.test.ts
+++ b/app/packages/core/src/components/Actions/Selected/hooks.test.ts
@@ -2,13 +2,6 @@
 
 /**
  * Tests for useUnselectVisible.
- *
- * Regression: Before the fix, the hook read from fos.selectedLabels (an array)
- * instead of fos.selectedLabelMap (a {labelId: labelData} object). This caused
- * Object.entries() to iterate the numeric array indices, writing keys like "0",
- * "1", "2" into selectedLabelMap instead of the real labelIds — permanently
- * corrupting selection state so that the "Manage Selected" badge showed the
- * wrong count after deselecting visible labels.
  */
 
 import { act, renderHook } from "@testing-library/react";
@@ -96,6 +89,7 @@ function makeWrapper(initialMap: LabelMap) {
 
 describe("useUnselectVisible", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     refs.scene = { clearSelection: vi.fn() };
   });
 

--- a/app/packages/core/src/components/Actions/Selected/hooks.test.ts
+++ b/app/packages/core/src/components/Actions/Selected/hooks.test.ts
@@ -21,9 +21,6 @@ import {
 } from "recoil";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-// ── Atom/selector stubs ────────────────────────────────────────────────────
-// vi.hoisted ensures these refs exist as a mutable container before any
-// vi.mock factory or import runs. The async factory populates them.
 const stubs = vi.hoisted(() => ({
   selectedLabels: null as any,
   selectedLabelMap: null as any,
@@ -67,7 +64,6 @@ vi.mock("@fiftyone/state", async () => {
   };
 });
 
-// ── Lighter scene mock ─────────────────────────────────────────────────────
 const refs = vi.hoisted(() => ({
   scene: { clearSelection: vi.fn() } as {
     clearSelection: ReturnType<typeof vi.fn>;

--- a/app/packages/core/src/components/Actions/Selected/hooks.ts
+++ b/app/packages/core/src/components/Actions/Selected/hooks.ts
@@ -124,7 +124,7 @@ export const useUnselectVisible = (
       scene.clearSelection({ ignoreSideEffects: true });
     }
 
-    const selected = await snapshot.getPromise(fos.selectedLabels);
+    const selected = await snapshot.getPromise(fos.selectedLabelMap);
     const result = visibleIdsAtom
       ? await snapshot.getPromise(visibleIdsAtom)
       : visibleIds;


### PR DESCRIPTION

## 🔗 Related IssuesFix that came from research done in https://voxel51.atlassian.net/browse/FOEPD-4003

## 📋 What changes are proposed in this pull request?

🐞 Bug: Selecting labels in the modal and then clicking 'Unselect Visible' _does_ unselect the labels, however, because it reads from the `selectedLabels` atom (which is an array) instead of the `selectedLabelsMap` selector, it permanently adds badly formatted data into the `selectedLabelsMap`

🔧 Fix: simply updating the `useUnselectVisible` hook to read from the correct atom fixes this bug

## 🧪 How is this patch tested? If it is not, please explain why.

1. Open a sample modal
2. Select multiple labels
3. Click the 'Manage Selected' button and select 'Unselect Visible' option
4. Verify the labels are unselected.
5. Verify the count in the 'Manage Selected' button resets to 0 and isn't permanently incremented.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fix: Manage Selected button now accurately displays the selected count in the button

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed visible-label unselection to keep selection state consistent by correctly filtering and updating the stored label mapping based on the visible set.
* **Tests**
  * Added a full test suite for the unselect-visible hook, covering key scenarios, regression protection for label ID keying, and expected side-effect behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2950
<!-- enterprise-sync-pr:end -->