### PR TITLE
fix ReferenceError: self is not defined

### DIFF
--- a/app/packages/plugins/src/registry.ts
+++ b/app/packages/plugins/src/registry.ts
@@ -12,7 +12,17 @@ declare global {
   }
 }
 
+// Holds the registry when evaluated outside a browser (Next.js SSR), where
+// `window` is undefined and the top-level registerComponent() calls would throw.
+let serverRegistry: PluginComponentRegistry | undefined;
+
 export function usingRegistry() {
+  if (typeof window === "undefined") {
+    if (!serverRegistry) {
+      serverRegistry = new PluginComponentRegistry();
+    }
+    return serverRegistry;
+  }
   if (!window.__fo_plugin_registry__) {
     window.__fo_plugin_registry__ = new PluginComponentRegistry();
   }


### PR DESCRIPTION
<!--
Community contributors: target the `community` branch, not `develop`. PRs from
non-members are auto-retargeted to `community`. See CONTRIBUTING.md:
https://github.com/voxel51/fiftyone/blob/develop/CONTRIBUTING.md#community-pull-requests
-->

## 🔗 Related Issues

Fix serverside error: 
```
    at eval (webpack-internal:///(pages-dir-node)/../../../app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Edit.tsx:16:75)
  14 |
  15 | export function usingRegistry() {
> 16 |   if (!window.__fo_plugin_registry__) {
     |   ^
  17 |     window.__fo_plugin_registry__ = new PluginComponentRegistry();
  18 |   }
  19 |   return window.__fo_plugin_registry__;
[ReferenceError: self is not defined]
 ⨯ unhandledRejection: [ReferenceError: self is not defined]
 ⨯ unhandledRejection:  [ReferenceError: self is not defined]
```

## 📋 What changes are proposed in this pull request?

- guard where window is not defined

## 🧪 How is this patch tested? If it is not, please explain why.

<!--
Describe the tests you ran or wrote to verify your changes. Include:
- New or updated unit/integration tests
- Manual testing steps performed
- Why tests are not applicable (if skipped)
-->

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugin registry system now supports server-side rendering environments alongside browser environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2951
<!-- enterprise-sync-pr:end -->