### PR TITLE
fix: avoid utcnow in execution store models

### DIFF
--- a/fiftyone/operators/store/models.py
+++ b/fiftyone/operators/store/models.py
@@ -6,7 +6,7 @@ Execution store models.
 |
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from dataclasses import dataclass, field, asdict
 from typing import Optional, Any
 from enum import Enum
@@ -28,6 +28,10 @@ class KeyPolicy(str, Enum):
     EVICT = "evict"
 
 
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
 @dataclass
 class KeyDocument:
     """Model representing a key in the store."""
@@ -37,7 +41,7 @@ class KeyDocument:
     value: Any
     _id: Optional[Any] = None
     dataset_id: Optional[ObjectId] = None
-    created_at: datetime = field(default_factory=datetime.utcnow)
+    created_at: datetime = field(default_factory=_utcnow)
     updated_at: Optional[datetime] = None
     expires_at: Optional[datetime] = None
     policy: KeyPolicy = KeyPolicy.PERSIST
@@ -48,7 +52,7 @@ class KeyDocument:
         if ttl is None:
             return None
 
-        return datetime.utcnow() + timedelta(seconds=ttl)
+        return _utcnow() + timedelta(seconds=ttl)
 
     @classmethod
     def from_dict(cls, doc: dict[str, Any]) -> "KeyDocument":

--- a/tests/unittests/execution_store_unit_tests.py
+++ b/tests/unittests/execution_store_unit_tests.py
@@ -6,7 +6,7 @@ FiftyOne execution store related unit tests.
 |
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 import time
 import unittest
 from unittest.mock import patch, MagicMock, ANY, Mock
@@ -34,7 +34,7 @@ def assert_delta_seconds_approx(time_delta, seconds, epsilon=EPSILON):
 class TestKeyDocument(unittest.TestCase):
     def test_get_expiration(self):
         ttl = 1
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
         expiration = KeyDocument.get_expiration(ttl)
         time_delta = expiration - now
         assert_delta_seconds_approx(time_delta, ttl)


### PR DESCRIPTION
Problem: the execution store key model used datetime.utcnow() for created_at defaults and TTL expiration timestamps. datetime.utcnow() is deprecated and returns naive UTC values.

Before / after: before, the execution store generated naive UTC timestamps directly with datetime.utcnow(). After, it uses datetime.now(timezone.utc).replace(tzinfo=None), preserving the existing naive UTC shape used by the store while avoiding the deprecated helper.

Verification:
- python -m py_compile fiftyone\operators\store\models.py tests\unittests\execution_store_unit_tests.py
- python -m pytest tests\unittests\execution_store_unit_tests.py::TestKeyDocument -q currently cannot collect in my local environment because bson is not installed: ModuleNotFoundError: No module named bson