### PR TITLE
Validate longitude and latitude ranges on geo fields

### DIFF
--- a/fiftyone/core/fields.py
+++ b/fiftyone/core/fields.py
@@ -1251,9 +1251,18 @@ class _GeoField(Field):
     # The GeoJSON type of the field. Subclasses must implement this
     _TYPE = None
 
+    # The number of nested lists wrapping each ``[longitude, latitude]``
+    # coordinate pair. Subclasses must implement this
+    _NUM_COORD_DIMS = None
+
     def to_mongo(self, value):
         if isinstance(value, dict):
             return value
+
+        # Range-check coordinates on write rather than in ``validate()`` so
+        # that datasets containing out-of-range coordinates written by earlier
+        # versions can still be loaded
+        self._validate_coordinates(value, self._NUM_COORD_DIMS)
 
         return SON([("type", self._TYPE), ("coordinates", value)])
 
@@ -1262,6 +1271,43 @@ class _GeoField(Field):
             return value["coordinates"]
 
         return value
+
+    def validate(self, value):
+        if isinstance(value, dict):
+            self.error("Geo fields expect coordinate lists, but found dict")
+
+        super().validate(value)
+
+    def _validate_coordinates(self, value, num_dims):
+        if num_dims > 0:
+            if not isinstance(value, (list, tuple)):
+                # Defer malformed structure to ``validate()``, which raises a
+                # clearer GeoJSON error
+                return
+
+            for coordinates in value:
+                self._validate_coordinates(coordinates, num_dims - 1)
+
+            return
+
+        if not isinstance(value, (list, tuple)) or len(value) < 2:
+            return
+
+        longitude, latitude = value[0], value[1]
+        if not isinstance(longitude, numbers.Number) or not isinstance(
+            latitude, numbers.Number
+        ):
+            return
+
+        if not -180 <= longitude <= 180:
+            self.error(
+                f"Longitude {longitude} is not in the valid range [-180, 180]"
+            )
+
+        if not -90 <= latitude <= 90:
+            self.error(
+                f"Latitude {latitude} is not in the valid range [-90, 90]"
+            )
 
 
 class GeoPointField(_GeoField, mongoengine.fields.PointField):
@@ -1277,12 +1323,7 @@ class GeoPointField(_GeoField, mongoengine.fields.PointField):
     """
 
     _TYPE = "Point"
-
-    def validate(self, value):
-        if isinstance(value, dict):
-            self.error("Geo fields expect coordinate lists, but found dict")
-
-        super().validate(value)
+    _NUM_COORD_DIMS = 0
 
 
 class GeoLineStringField(_GeoField, mongoengine.fields.LineStringField):
@@ -1300,12 +1341,7 @@ class GeoLineStringField(_GeoField, mongoengine.fields.LineStringField):
     """
 
     _TYPE = "LineString"
-
-    def validate(self, value):
-        if isinstance(value, dict):
-            self.error("Geo fields expect coordinate lists, but found dict")
-
-        super().validate(value)
+    _NUM_COORD_DIMS = 1
 
 
 class GeoPolygonField(_GeoField, mongoengine.fields.PolygonField):
@@ -1330,12 +1366,7 @@ class GeoPolygonField(_GeoField, mongoengine.fields.PolygonField):
     """
 
     _TYPE = "Polygon"
-
-    def validate(self, value):
-        if isinstance(value, dict):
-            self.error("Geo fields expect coordinate lists, but found dict")
-
-        super().validate(value)
+    _NUM_COORD_DIMS = 2
 
 
 class GeoMultiPointField(_GeoField, mongoengine.fields.MultiPointField):
@@ -1353,12 +1384,7 @@ class GeoMultiPointField(_GeoField, mongoengine.fields.MultiPointField):
     """
 
     _TYPE = "MultiPoint"
-
-    def validate(self, value):
-        if isinstance(value, dict):
-            self.error("Geo fields expect coordinate lists, but found dict")
-
-        super().validate(value)
+    _NUM_COORD_DIMS = 1
 
 
 class GeoMultiLineStringField(
@@ -1382,12 +1408,7 @@ class GeoMultiLineStringField(
     """
 
     _TYPE = "MultiLineString"
-
-    def validate(self, value):
-        if isinstance(value, dict):
-            self.error("Geo fields expect coordinate lists, but found dict")
-
-        super().validate(value)
+    _NUM_COORD_DIMS = 2
 
 
 class GeoMultiPolygonField(_GeoField, mongoengine.fields.MultiPolygonField):
@@ -1417,12 +1438,7 @@ class GeoMultiPolygonField(_GeoField, mongoengine.fields.MultiPolygonField):
     """
 
     _TYPE = "MultiPolygon"
-
-    def validate(self, value):
-        if isinstance(value, dict):
-            self.error("Geo fields expect coordinate lists, but found dict")
-
-        super().validate(value)
+    _NUM_COORD_DIMS = 3
 
 
 class VectorField(mongoengine.fields.BinaryField, Field):

--- a/tests/unittests/label_tests.py
+++ b/tests/unittests/label_tests.py
@@ -10,11 +10,14 @@ import tempfile
 import unittest
 
 from bson import Binary, ObjectId
+from mongoengine.errors import ValidationError
 import numpy as np
 import numpy.testing as nptest
 
 import fiftyone as fo
+import fiftyone.core.fields as fof
 import fiftyone.core.labels as focl
+import fiftyone.core.odm as foo
 import fiftyone.utils.labels as foul
 from fiftyone.core.labels import _read_mask, _write_mask
 from fiftyone import ViewField as F
@@ -1008,6 +1011,171 @@ class ExportMaskTests(unittest.TestCase):
                         det.export_mask(
                             outpath, overwrite_path=case["overwrite_path"]
                         )
+
+
+class GeoLocationValidationTests(unittest.TestCase):
+    """Tests that out-of-range geographic coordinates are rejected when geo
+    data is written to a dataset, while datasets that already contain such
+    coordinates remain loadable (#2171).
+    """
+
+    # Field-level range validation on write (no database)
+
+    def test_geo_point_field_accepts_valid_coordinates(self):
+        field = fof.GeoPointField()
+        field.to_mongo([0, 0])
+        field.to_mongo([-180, -90])
+        field.to_mongo([180, 90])
+
+    def test_geo_point_field_rejects_out_of_range_longitude(self):
+        field = fof.GeoPointField()
+        with self.assertRaises(ValidationError):
+            field.to_mongo([181, 0])
+        with self.assertRaises(ValidationError):
+            field.to_mongo([-181, 0])
+
+    def test_geo_point_field_rejects_out_of_range_latitude(self):
+        field = fof.GeoPointField()
+        with self.assertRaises(ValidationError):
+            field.to_mongo([0, 91])
+        with self.assertRaises(ValidationError):
+            field.to_mongo([0, -91])
+
+    def test_geo_field_rejects_dict_input(self):
+        field = fof.GeoPointField()
+        with self.assertRaises(ValidationError):
+            field.validate({"type": "Point", "coordinates": [0, 0]})
+
+    def test_geo_line_string_field_validates_each_point(self):
+        field = fof.GeoLineStringField()
+        field.to_mongo([[0, 0], [10, 10]])
+        with self.assertRaises(ValidationError):
+            field.to_mongo([[0, 0], [200, 10]])
+        with self.assertRaises(ValidationError):
+            field.to_mongo([[0, 0], [10, 91]])
+
+    def test_geo_polygon_field_validates_nested_points(self):
+        field = fof.GeoPolygonField()
+        field.to_mongo([[[0, 0], [1, 1], [2, 0], [0, 0]]])
+        with self.assertRaises(ValidationError):
+            field.to_mongo([[[0, 0], [1, 1], [2, 95], [0, 0]]])
+        with self.assertRaises(ValidationError):
+            field.to_mongo([[[0, 0], [181, 1], [2, 0], [0, 0]]])
+
+    def test_geo_multi_point_field_validates_each_point(self):
+        field = fof.GeoMultiPointField()
+        field.to_mongo([[0, 0], [10, 10]])
+        with self.assertRaises(ValidationError):
+            field.to_mongo([[0, 0], [10, 200]])
+        with self.assertRaises(ValidationError):
+            field.to_mongo([[0, 0], [181, 10]])
+
+    def test_geo_multi_line_string_field_validates_nested_points(self):
+        field = fof.GeoMultiLineStringField()
+        field.to_mongo([[[0, 0], [1, 1]], [[2, 2], [3, 3]]])
+        with self.assertRaises(ValidationError):
+            field.to_mongo([[[0, 0], [1, 1]], [[2, 2], [181, 3]]])
+        with self.assertRaises(ValidationError):
+            field.to_mongo([[[0, 0], [1, 1]], [[2, 2], [3, 91]]])
+
+    def test_geo_multi_polygon_field_validates_deeply_nested_points(self):
+        field = fof.GeoMultiPolygonField()
+        field.to_mongo(
+            [
+                [[[0, 0], [1, 1], [2, 0], [0, 0]]],
+                [[[5, 5], [6, 6], [7, 5], [5, 5]]],
+            ]
+        )
+        with self.assertRaises(ValidationError):
+            field.to_mongo(
+                [
+                    [[[0, 0], [1, 1], [2, 0], [0, 0]]],
+                    [[[5, 5], [6, 6], [7, 95], [5, 5]]],
+                ]
+            )
+        with self.assertRaises(ValidationError):
+            field.to_mongo(
+                [
+                    [[[0, 0], [1, 1], [2, 0], [0, 0]]],
+                    [[[5, 5], [200, 6], [7, 5], [5, 5]]],
+                ]
+            )
+
+    # Out-of-range coordinates are rejected when written to a dataset (#2171)
+
+    @drop_datasets
+    def test_out_of_range_point_is_rejected_on_add(self):
+        dataset = fo.Dataset()
+        sample = fo.Sample(
+            filepath="image.jpg",
+            location=fo.GeoLocation(point=[200, 200]),
+        )
+        with self.assertRaises(ValidationError):
+            dataset.add_sample(sample)
+
+    @drop_datasets
+    def test_out_of_range_line_is_rejected_on_add(self):
+        dataset = fo.Dataset()
+        sample = fo.Sample(
+            filepath="image.jpg",
+            location=fo.GeoLocation(line=[[0, 0], [200, 10]]),
+        )
+        with self.assertRaises(ValidationError):
+            dataset.add_sample(sample)
+
+    @drop_datasets
+    def test_out_of_range_polygons_are_rejected_on_add(self):
+        dataset = fo.Dataset()
+        sample = fo.Sample(
+            filepath="image.jpg",
+            location=fo.GeoLocations(
+                polygons=[[[[0, 0], [1, 1], [2, 95], [0, 0]]]]
+            ),
+        )
+        with self.assertRaises(ValidationError):
+            dataset.add_sample(sample)
+
+    @drop_datasets
+    def test_valid_geolocation_is_added(self):
+        dataset = fo.Dataset()
+        sample = fo.Sample(
+            filepath="image.jpg",
+            location=fo.GeoLocation(point=[-73.9857, 40.7484]),
+        )
+        dataset.add_sample(sample)
+        self.assertEqual(len(dataset), 1)
+
+    @drop_datasets
+    def test_valid_geolocations_are_added(self):
+        dataset = fo.Dataset()
+        sample = fo.Sample(
+            filepath="image.jpg",
+            location=fo.GeoLocations(
+                points=[[-73.9857, 40.7484], [-87.6298, 41.8781]]
+            ),
+        )
+        dataset.add_sample(sample)
+        self.assertEqual(len(dataset), 1)
+
+    @drop_datasets
+    def test_existing_out_of_range_coordinates_remain_loadable(self):
+        dataset = fo.Dataset()
+        dataset.add_sample(
+            fo.Sample(
+                filepath="image.jpg",
+                location=fo.GeoLocation(point=[0, 0]),
+            )
+        )
+
+        # Simulate coordinates written by a version that did not range-check
+        conn = foo.get_db_conn()
+        conn[dataset._sample_collection_name].update_one(
+            {}, {"$set": {"location.point.coordinates": [200, 200]}}
+        )
+
+        dataset.reload()
+        sample = dataset.first()
+        self.assertEqual(sample.location.point, [200, 200])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 🔗 Related Issues

- Closes #2171

## 📋 What changes are proposed in this pull request?

Out-of-range longitude and latitude values in a `GeoLocation` field were accepted silently and only surfaced later as an App error: "Invalid LngLat latitude value: must be between -90 and 90".

The geo fields now range-check each `[longitude, latitude]` pair (longitude in `[-180, 180]`, latitude in `[-90, 90]`) when the value is serialized, so out-of-range coordinates raise a `ValidationError` when a sample is added to a dataset.

The check runs on write rather than in `validate()` so that datasets containing out-of-range coordinates written by earlier versions can still be loaded. The six `_GeoField` subclasses previously had identical `validate()` overrides; that logic is consolidated into the `_GeoField` base, which also carries a `_NUM_COORD_DIMS` nesting depth used to walk the coordinates.

## 🧪 How is this patch tested? If it is not, please explain why.

Added `GeoLocationValidationTests` in `tests/unittests/label_tests.py`:

- Field-level range checks for all six geo field types, including nested coordinates and boundary values (`-180/180`, `-90/90`).
- Out-of-range `GeoLocation` and `GeoLocations` raise when a sample is added to a dataset.
- A dataset with out-of-range coordinates written directly to the database (simulating older data) still loads.

Full `label_tests.py` passes, the import/export `GeoLocation` tests pass, and `black -l 79` and `pylint --errors-only` are clean.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Geo fields (`GeoLocation`, `GeoLocations`) now validate longitude and latitude ranges when written to a dataset, raising a `ValidationError` for out-of-range coordinates instead of failing later in the App. Existing datasets are unaffected.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
