### PR TITLE
Load extra CityPersons attributes on Cityscapes person detections

### DIFF
--- a/fiftyone/utils/cityscapes.py
+++ b/fiftyone/utils/cityscapes.py
@@ -39,6 +39,7 @@ def parse_cityscapes_dataset(
     fine_annos=None,
     coarse_annos=None,
     person_annos=None,
+    extra_attrs=True,
 ):
     """Parses the Cityscapes archive(s) in the specified directory and writes
     the requested splits in subdirectories of ``dataset_dir`` in
@@ -68,6 +69,13 @@ def parse_cityscapes_dataset(
             not (False), or only if the ZIP file exists (None)
         person_annos (None): whether to load the person detections (True), or
             not (False), or only if the ZIP file exists (None)
+        extra_attrs (True): whether to load extra attributes onto the person
+            detections. Only applies when ``person_annos`` are loaded.
+            Supported values are:
+
+            -   ``True``: load all extra attributes
+            -   ``False``: do not load any extra attributes
+            -   a name or list of names of specific attributes to load
 
     Raises:
         OSError: if any required source files are not present
@@ -111,6 +119,7 @@ def parse_cityscapes_dataset(
             fine_annos_dir,
             coarse_annos_dir,
             person_annos_dir,
+            extra_attrs=extra_attrs,
         )
 
 
@@ -218,6 +227,7 @@ def _export_split(
     fine_annos_dir,
     coarse_annos_dir,
     person_annos_dir,
+    extra_attrs=True,
 ):
     images_map = _parse_images(images_dir, split)
 
@@ -232,7 +242,9 @@ def _export_split(
         coarse_annos_map = {}
 
     if person_annos_dir:
-        person_annos_map = _parse_person_annos(person_annos_dir, split)
+        person_annos_map = _parse_person_annos(
+            person_annos_dir, split, extra_attrs=extra_attrs
+        )
     else:
         person_annos_map = {}
 
@@ -377,7 +389,7 @@ def _parse_polygon_annos(glob_patt, split, anno_type, suffix):
     return annos_map
 
 
-def _parse_person_annos(person_annos_dir, split):
+def _parse_person_annos(person_annos_dir, split, extra_attrs=True):
     paths_patt = os.path.join(person_annos_dir, split, "*", "*.json")
     anno_paths = etau.get_glob_matches(paths_patt)
     if not anno_paths:
@@ -390,7 +402,9 @@ def _parse_person_annos(person_annos_dir, split):
             uuid = os.path.splitext(os.path.basename(anno_path))[0][
                 : -len("_gtBboxCityPersons")
             ]
-            detections_map[uuid] = _parse_bbox_file(anno_path)
+            detections_map[uuid] = _parse_bbox_file(
+                anno_path, extra_attrs=extra_attrs
+            )
 
     return detections_map
 
@@ -413,7 +427,7 @@ def _parse_polygons_file(json_path):
     return fol.Polylines(polylines=polylines)
 
 
-def _parse_bbox_file(json_path):
+def _parse_bbox_file(json_path, extra_attrs=True):
     d = etas.load_json(json_path)
 
     width = d["imgWidth"]
@@ -424,7 +438,23 @@ def _parse_bbox_file(json_path):
         label = obj["label"]
         x, y, w, h = obj["bbox"]
         bounding_box = [x / width, y / height, w / width, h / height]
-        detection = fol.Detection(label=label, bounding_box=bounding_box)
+        attributes = _parse_bbox_attributes(obj, extra_attrs)
+        detection = fol.Detection(
+            label=label, bounding_box=bounding_box, **attributes
+        )
         detections.append(detection)
 
     return fol.Detections(detections=detections)
+
+
+def _parse_bbox_attributes(obj, extra_attrs):
+    if extra_attrs is True:
+        return {k: v for k, v in obj.items() if k not in ("label", "bbox")}
+
+    if not extra_attrs:
+        return {}
+
+    if etau.is_str(extra_attrs):
+        extra_attrs = [extra_attrs]
+
+    return {k: obj[k] for k in extra_attrs if k in obj}

--- a/fiftyone/zoo/datasets/base.py
+++ b/fiftyone/zoo/datasets/base.py
@@ -676,8 +676,15 @@ class CityscapesDataset(FiftyOneDataset):
             (False), or only if the ZIP file exists (None)
         coarse_annos (None): whether to load the coarse annotations (True), or
             not (False), or only if the ZIP file exists (None)
-        person_annos (None): whether to load the personn detections (True), or
+        person_annos (None): whether to load the person detections (True), or
             not (False), or only if the ZIP file exists (None)
+        extra_attrs (True): whether to load extra attributes onto the person
+            detections. Only applies when ``person_annos`` are loaded.
+            Supported values are:
+
+            -   ``True``: load all extra attributes
+            -   ``False``: do not load any extra attributes
+            -   a name or list of names of specific attributes to load
     """
 
     def __init__(
@@ -686,11 +693,13 @@ class CityscapesDataset(FiftyOneDataset):
         fine_annos=None,
         coarse_annos=None,
         person_annos=None,
+        extra_attrs=True,
     ):
         self.source_dir = source_dir
         self.fine_annos = fine_annos
         self.coarse_annos = coarse_annos
         self.person_annos = person_annos
+        self.extra_attrs = extra_attrs
 
     @property
     def name(self):
@@ -729,6 +738,7 @@ class CityscapesDataset(FiftyOneDataset):
                 fine_annos=self.fine_annos,
                 coarse_annos=self.coarse_annos,
                 person_annos=self.person_annos,
+                extra_attrs=self.extra_attrs,
             )
 
         logger.info("Parsing dataset metadata")

--- a/tests/unittests/cityscapes_tests.py
+++ b/tests/unittests/cityscapes_tests.py
@@ -1,0 +1,109 @@
+"""
+FiftyOne Cityscapes utils unit tests.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import json
+import os
+import tempfile
+import unittest
+
+import fiftyone.utils.cityscapes as fouc
+
+
+class CityscapesPersonAttributesTests(unittest.TestCase):
+    """Tests that extra CityPersons attributes are loaded onto the person
+    detections, controlled by the ``extra_attrs`` argument (#2196).
+    """
+
+    def setUp(self):
+        self._tmp_dir = tempfile.TemporaryDirectory()
+        objects = [
+            {
+                "label": "pedestrian",
+                "bbox": [10, 20, 30, 40],
+                "bboxVis": [12, 22, 20, 30],
+                "instanceId": 26000,
+            }
+        ]
+        self._json_path = os.path.join(self._tmp_dir.name, "bbox.json")
+        with open(self._json_path, "w") as f:
+            json.dump(
+                {"imgWidth": 100, "imgHeight": 200, "objects": objects}, f
+            )
+
+    def tearDown(self):
+        self._tmp_dir.cleanup()
+
+    def _parse(self, **kwargs):
+        return fouc._parse_bbox_file(self._json_path, **kwargs).detections[0]
+
+    def test_core_fields_are_always_parsed(self):
+        detection = self._parse(extra_attrs=False)
+        self.assertEqual(detection.label, "pedestrian")
+        self.assertEqual(detection.bounding_box, [0.1, 0.1, 0.3, 0.2])
+
+    def test_true_loads_all_extra_attributes(self):
+        detection = self._parse(extra_attrs=True)
+        self.assertEqual(detection["bboxVis"], [12, 22, 20, 30])
+        self.assertEqual(detection["instanceId"], 26000)
+
+    def test_false_loads_no_extra_attributes(self):
+        detection = self._parse(extra_attrs=False)
+        self.assertFalse(detection.has_field("bboxVis"))
+        self.assertFalse(detection.has_field("instanceId"))
+
+    def test_single_name_loads_one_attribute(self):
+        detection = self._parse(extra_attrs="bboxVis")
+        self.assertEqual(detection["bboxVis"], [12, 22, 20, 30])
+        self.assertFalse(detection.has_field("instanceId"))
+
+    def test_list_loads_specified_attributes(self):
+        detection = self._parse(extra_attrs=["instanceId"])
+        self.assertEqual(detection["instanceId"], 26000)
+        self.assertFalse(detection.has_field("bboxVis"))
+
+    def test_unknown_requested_attribute_is_skipped(self):
+        detection = self._parse(extra_attrs=["does_not_exist"])
+        self.assertFalse(detection.has_field("does_not_exist"))
+
+    def test_empty_objects_returns_empty_detections(self):
+        path = os.path.join(self._tmp_dir.name, "empty.json")
+        with open(path, "w") as f:
+            json.dump({"imgWidth": 100, "imgHeight": 200, "objects": []}, f)
+
+        detections = fouc._parse_bbox_file(path).detections
+        self.assertEqual(len(detections), 0)
+
+    def test_multiple_objects_are_all_parsed(self):
+        path = os.path.join(self._tmp_dir.name, "multi.json")
+        objects = [
+            {
+                "label": "pedestrian",
+                "bbox": [10, 20, 30, 40],
+                "bboxVis": [12, 22, 20, 30],
+                "instanceId": 26000,
+            },
+            {
+                "label": "rider",
+                "bbox": [50, 60, 10, 20],
+                "bboxVis": [51, 61, 8, 18],
+                "instanceId": 27000,
+            },
+        ]
+        with open(path, "w") as f:
+            json.dump(
+                {"imgWidth": 100, "imgHeight": 200, "objects": objects}, f
+            )
+
+        detections = fouc._parse_bbox_file(path).detections
+        self.assertEqual(len(detections), 2)
+        self.assertEqual(detections[0].label, "pedestrian")
+        self.assertEqual(detections[1].label, "rider")
+        self.assertEqual(detections[1]["instanceId"], 27000)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 🔗 Related Issues

Closes #2196

## 📋 What changes are proposed in this pull request?

The Cityscapes CityPersons parser only loaded the `label` and `bbox` for each person detection, dropping the other annotated fields (`bboxVis` and `instanceId`).

This adds an `extra_attrs` argument that controls whether those extra fields are attached to each `Detection`, mirroring the `extra_attrs` option on the COCO loader:

-   `True` (default): load all extra attributes
-   `False`: load none
-   a name or list of names: load only the specified attributes

The argument is threaded from `CityscapesDataset` through `parse_cityscapes_dataset` down to the bbox parser, which now copies the extra CityPersons object fields onto each `Detection`. It only applies when person annotations are loaded, and unknown requested attribute names are skipped rather than raising.

## 🧪 How is this patch tested? If it is not, please explain why.

Added `tests/unittests/cityscapes_tests.py`, which parses a synthetic CityPersons annotation and covers each `extra_attrs` mode:

-   core `label`/`bounding_box` fields are always parsed
-   `True` loads all extra attributes
-   `False` loads none
-   a single name loads only that attribute
-   a list loads only the named attributes
-   an unknown requested name is skipped
-   empty and multi-object annotation files

The new tests fail without this change. `black -l 79` and `pylint --errors-only` are clean on the changed files.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

The Cityscapes dataset now supports an `extra_attrs` argument that loads additional CityPersons attributes (`bboxVis`, `instanceId`) onto the person detections, matching the behavior of the COCO loader.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
