### PR TITLE
Preserve duplicate name conditional attributes

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/AnnotationSchema.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/AnnotationSchema.tsx
@@ -48,8 +48,11 @@ const useSchema = (readOnly: boolean) => {
     }, new Map<string, AttributeConfig>());
   }, [allAttributes, data]);
 
-  // Stable string key — only changes when the visible attribute set changes
-  const visibleKey = [...visibleAttributes.keys()].join("\0");
+  // Key on the winning entry's index, not its name: same-name variants must
+  // bust the schema memo when the active one swaps (Toyota model -> Honda).
+  const visibleKey = [...visibleAttributes.values()]
+    .map((attr) => allAttributes.indexOf(attr))
+    .join("\0");
 
   // Reruns only when the visible attribute set changes.
   return useMemo(() => {

--- a/fiftyone/core/annotation/hydrate_label_schemas.py
+++ b/fiftyone/core/annotation/hydrate_label_schemas.py
@@ -195,17 +195,46 @@ def inline_applied_ontology(label_schema: dict, ontology: Any) -> dict:
 def _merge(label_schema: dict, ontology: Any) -> dict:
     hydrated = copy.deepcopy(label_schema)
     existing = hydrated.get(foac.ATTRIBUTES, [])
-
-    # Preserve existing schema order; ontology-only attrs appended.
-    by_name: dict = {a.get(foac.NAME): a for a in existing}
-    ordered_names = [a.get(foac.NAME) for a in existing]
-
-    for attr_dict in attributes_with_source(ontology):
-        name = attr_dict.get(foac.NAME)
-        if name not in by_name:
-            ordered_names.append(name)
-        # ontology wins on collision
-        by_name[name] = attr_dict
-
-    hydrated[foac.ATTRIBUTES] = [by_name[n] for n in ordered_names]
+    onto_attrs = attributes_with_source(ontology)
+    hydrated[foac.ATTRIBUTES] = _merge_attributes(existing, onto_attrs)
     return hydrated
+
+
+def _merge_attributes(
+    existing: list[dict], onto_attrs: list[dict]
+) -> list[dict]:
+    """Merges ontology attributes into a schema's existing attributes.
+
+    The ontology owns every name it contributes: its attributes replace any
+    local attribute(s) of that name in place, anchored to the first local
+    occurrence. Local names the ontology doesn't touch pass through
+    unchanged; ontology-only names are appended in declaration order.
+
+    Conditional attributes share a name but differ by their ``when``
+    condition, so one name can map to several variants — all of which must
+    survive. Grouping (rather than keying) by name preserves every variant;
+    a name-keyed dict would collapse them to the last one.
+    """
+    # Group ontology attributes by name, preserving the declaration order of
+    # both the names and the variants within each name.
+    ontology_by_name: dict[str, list[dict]] = {}
+    for attr in onto_attrs:
+        ontology_by_name.setdefault(attr.get(foac.NAME), []).append(attr)
+
+    merged_attributes: list[dict] = []
+    ontology_names_placed: set[str] = set()
+    for attr in existing:
+        name = attr.get(foac.NAME)
+        if name in ontology_by_name:
+            if name not in ontology_names_placed:
+                merged_attributes.extend(ontology_by_name[name])
+                ontology_names_placed.add(name)
+        else:
+            merged_attributes.append(attr)
+
+    for name, variants in ontology_by_name.items():
+        if name not in ontology_names_placed:
+            merged_attributes.extend(variants)
+            ontology_names_placed.add(name)
+
+    return merged_attributes

--- a/tests/unittests/annotation/hydrate_label_schemas_tests.py
+++ b/tests/unittests/annotation/hydrate_label_schemas_tests.py
@@ -9,7 +9,7 @@ FiftyOne annotation unit tests.
 import unittest
 from unittest.mock import MagicMock, patch
 
-from fiftyone.core.annotation.attributes import AttributeSpec
+from fiftyone.core.annotation.attributes import AttributeSpec, WhenEquals
 from fiftyone.core.annotation.hydrate_label_schemas import (
     dehydrate_applied_ontology,
     hydrate_applied_ontology,
@@ -117,6 +117,95 @@ class HydrateLabelSchemasTests(unittest.TestCase):
         )
         self.assertNotIn("_source", local)
         self.assertEqual(ontology_attr["_source"], "my_ontology")
+
+    @drop_datasets
+    @drop_ontologies
+    def test_same_name_conditional_variants_all_preserved(self):
+        AnnotationOntology(
+            name="my_ontology",
+            attributes=[
+                AttributeSpec(
+                    name="make",
+                    type="str",
+                    component="dropdown",
+                    values=["Honda", "Toyota"],
+                ),
+                AttributeSpec(
+                    name="model",
+                    type="str",
+                    component="dropdown",
+                    values=["Civic", "Accord"],
+                    when=WhenEquals(field="make", value="Honda"),
+                ),
+                AttributeSpec(
+                    name="model",
+                    type="str",
+                    component="dropdown",
+                    values=["Camry", "Corolla"],
+                    when=WhenEquals(field="make", value="Toyota"),
+                ),
+            ],
+        ).save()
+
+        schema = {
+            "type": "detections",
+            "applied_ontology": "my_ontology",
+            "attributes": [],
+        }
+        result = hydrate_applied_ontology(schema)
+        names = [a["name"] for a in result["attributes"]]
+        # Both "model" variants survive rather than collapsing to the last.
+        self.assertEqual(names, ["make", "model", "model"])
+
+        models = [a for a in result["attributes"] if a["name"] == "model"]
+        self.assertEqual(
+            [m["values"] for m in models],
+            [["Civic", "Accord"], ["Camry", "Corolla"]],
+        )
+        self.assertEqual(
+            [m["when"]["value"] for m in models], ["Honda", "Toyota"]
+        )
+
+    @drop_datasets
+    @drop_ontologies
+    def test_ontology_variants_replace_local_attr_in_place(self):
+        AnnotationOntology(
+            name="my_ontology",
+            attributes=[
+                AttributeSpec(
+                    name="model",
+                    type="str",
+                    component="dropdown",
+                    values=["Civic"],
+                    when=WhenEquals(field="make", value="Honda"),
+                ),
+                AttributeSpec(
+                    name="model",
+                    type="str",
+                    component="dropdown",
+                    values=["Camry"],
+                    when=WhenEquals(field="make", value="Toyota"),
+                ),
+            ],
+        ).save()
+
+        schema = {
+            "type": "detections",
+            "applied_ontology": "my_ontology",
+            "attributes": [
+                {"name": "color", "type": "str", "component": "text"},
+                {"name": "model", "type": "str", "component": "text"},
+                {"name": "note", "type": "str", "component": "text"},
+            ],
+        }
+        result = hydrate_applied_ontology(schema)
+        names = [a["name"] for a in result["attributes"]]
+        # Local "model" is overridden by both ontology variants, anchored to
+        # the local "model" slot; the surrounding local attrs are untouched.
+        self.assertEqual(names, ["color", "model", "model", "note"])
+        models = [a for a in result["attributes"] if a["name"] == "model"]
+        self.assertEqual([m["component"] for m in models], ["dropdown"] * 2)
+        self.assertTrue(all(m["_source"] == "my_ontology" for m in models))
 
     @drop_datasets
     @drop_ontologies


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

This allows duplicate attributes to be specified in an annotation ontology.

## 🧪 How is this patch tested? If it is not, please explain why.

Tested locally, unit tests:

[Screencast from 2026-06-22 11-16-36.webm](https://github.com/user-attachments/assets/1ebdb65e-4333-4856-9283-93aa4d002888)

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fixes a bug where duplicate conditional attributes were overwritten. 

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed annotation schema generation to properly preserve multiple attribute variants with identical names but different conditional clauses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2959
<!-- enterprise-sync-pr:end -->