### PR TITLE
ci: split community↔develop sync and route conflicts to #community Slack

### DIFF
--- a/.github/workflows/community-prs.yml
+++ b/.github/workflows/community-prs.yml
@@ -71,7 +71,7 @@ jobs:
 
             if (from) {
               body.push(
-                `Community pull requests target the \`community\` branch, so I've changed this PR's base from \`${from}\` to \`community\`. Your changes are unaffected — a maintainer integrates \`community\` into \`develop\` automatically.`,
+                `Community pull requests target the \`community\` branch, so I've changed this PR's base from \`${from}\` to \`community\`. Your changes are unaffected — a maintainer integrates \`community\` into \`develop\`.`,
                 '',
               );
             }

--- a/.github/workflows/community-to-develop.yml
+++ b/.github/workflows/community-to-develop.yml
@@ -71,7 +71,7 @@ jobs:
             "$included")"
 
           number="$(gh pr list --repo "$REPO" --head community --base develop \
-            --state open --json number --jq '.[0].number')"
+            --state open --json number --jq '.[0].number // empty')"
           if [ -n "$number" ]; then
             gh pr edit "$number" --repo "$REPO" --body "$body"
             action="updated"
@@ -80,7 +80,7 @@ jobs:
               --title 'AUTOMATED MERGE `community` to `develop`' \
               --body "$body"
             number="$(gh pr list --repo "$REPO" --head community --base develop \
-              --state open --json number --jq '.[0].number')"
+              --state open --json number --jq '.[0].number // empty')"
             action="opened"
           fi
 

--- a/.github/workflows/community-to-develop.yml
+++ b/.github/workflows/community-to-develop.yml
@@ -7,6 +7,11 @@ name: Community to develop PR
 # direction).
 
 on:
+  # pull_request_target (not pull_request) is required to access the
+  # FIFTYONE_GITHUB_TOKEN secret needed to open a PR that triggers downstream CI.
+  # This is safe despite the usual warnings: the job only runs on merged PRs
+  # (closed + merged == true guard), checkout uses the base `ref: community`
+  # rather than the PR head, and no repo code is executed — only git/gh commands.
   pull_request_target:
     types: [closed]
     branches: [community]
@@ -34,6 +39,7 @@ jobs:
           fetch-depth: 0
           # Use the bot PAT so the PR triggers CI (GITHUB_TOKEN-authored PRs don't).
           token: ${{ secrets.FIFTYONE_GITHUB_TOKEN }}
+          persist-credentials: false
 
       - name: Open or update community → develop PR and notify #community
         env:

--- a/.github/workflows/community-to-develop.yml
+++ b/.github/workflows/community-to-develop.yml
@@ -47,6 +47,13 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_COMMUNITY_WEBHOOK_URL }}
           REPO: ${{ github.repository }}
         run: |
+          # Fail fast: this job exists to notify #community, so a missing webhook
+          # is a misconfiguration to surface, not something to silently skip.
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "::error::SLACK_COMMUNITY_WEBHOOK_URL not set; cannot notify #community."
+            exit 1
+          fi
+
           git fetch --no-tags origin develop community
 
           if git diff --quiet origin/develop...origin/community; then
@@ -54,14 +61,24 @@ jobs:
             exit 0
           fi
 
+          # The contributions landing in this PR — what `community` is ahead of
+          # `develop` by — so the body shows (and refreshes) what's integrated.
+          included="$(git log --format='- %s' origin/develop..origin/community)"
+          body="$(printf '%s\n' \
+            'Automated integration of community contributions into `develop`, opened because `community` is ahead of `develop`. This PR tracks the `community` branch and updates as more contributions land.' \
+            '' \
+            '### Included from `community`' \
+            "$included")"
+
           number="$(gh pr list --repo "$REPO" --head community --base develop \
             --state open --json number --jq '.[0].number')"
           if [ -n "$number" ]; then
+            gh pr edit "$number" --repo "$REPO" --body "$body"
             action="updated"
           else
             gh pr create --repo "$REPO" --head community --base develop \
               --title 'AUTOMATED MERGE `community` to `develop`' \
-              --body 'Automated integration of community contributions into `develop`, opened because `community` is ahead of `develop`. This PR tracks the `community` branch and updates as more contributions land.'
+              --body "$body"
             number="$(gh pr list --repo "$REPO" --head community --base develop \
               --state open --json number --jq '.[0].number')"
             action="opened"
@@ -82,10 +99,23 @@ jobs:
           fi
           git merge --abort 2>/dev/null || true
 
-          if [ -z "$SLACK_WEBHOOK_URL" ]; then
-            echo "::warning::SLACK_COMMUNITY_WEBHOOK_URL not set; skipping Slack notification."
-            exit 0
-          fi
+          # Record the outcome in the run's step summary so it's visible from the
+          # Actions UI without going to Slack.
+          {
+            if [ -n "$conflicts" ]; then
+              echo "### 🚨 community → develop PR $action — merge conflict"
+              echo
+              echo "[#$number]($url) conflicts with \`develop\` and needs manual resolution."
+              echo
+              echo "Conflicting files:"
+              echo
+              printf '%s\n' "$conflicts" | sed 's/^/- `/; s/$/`/'
+            else
+              echo "### community → develop PR $action — ✅ no conflicts"
+              echo
+              echo "[#$number]($url)"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
           if [ -n "$conflicts" ]; then
             files="$(printf '%s\n' "$conflicts" | sed 's/^/• /')"

--- a/.github/workflows/community-to-develop.yml
+++ b/.github/workflows/community-to-develop.yml
@@ -41,7 +41,7 @@ jobs:
           token: ${{ secrets.FIFTYONE_GITHUB_TOKEN }}
           persist-credentials: false
 
-      - name: Open or update community → develop PR and notify #community
+      - name: "Open or update community → develop PR and notify #community"
         env:
           GH_TOKEN: ${{ secrets.FIFTYONE_GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_COMMUNITY_WEBHOOK_URL }}

--- a/.github/workflows/community-to-develop.yml
+++ b/.github/workflows/community-to-develop.yml
@@ -1,0 +1,103 @@
+name: Community to develop PR
+
+# When a pull request is merged into the `community` branch, open (or update) a
+# direct `community` → `develop` pull request and post to the #community Slack
+# channel. The PR head is the `community` branch itself — there is no intermediate
+# merge branch. Pairs with sync-develop-to-community.yml (the develop → community
+# direction).
+
+on:
+  pull_request_target:
+    types: [closed]
+    branches: [community]
+  workflow_dispatch:
+
+concurrency:
+  group: community-to-develop
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  pr:
+    # The `community` branch is OSS-only; only act on merged PRs (or manual runs).
+    if: >-
+      github.repository == 'voxel51/fiftyone' &&
+      (github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: community
+          fetch-depth: 0
+          # Use the bot PAT so the PR triggers CI (GITHUB_TOKEN-authored PRs don't).
+          token: ${{ secrets.FIFTYONE_GITHUB_TOKEN }}
+
+      - name: Open or update community → develop PR and notify #community
+        env:
+          GH_TOKEN: ${{ secrets.FIFTYONE_GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_COMMUNITY_WEBHOOK_URL }}
+          REPO: ${{ github.repository }}
+        run: |
+          git fetch --no-tags origin develop community
+
+          if git diff --quiet origin/develop...origin/community; then
+            echo "No changes to integrate from community into develop."
+            exit 0
+          fi
+
+          number="$(gh pr list --repo "$REPO" --head community --base develop \
+            --state open --json number --jq '.[0].number')"
+          if [ -n "$number" ]; then
+            action="updated"
+          else
+            gh pr create --repo "$REPO" --head community --base develop \
+              --title 'AUTOMATED MERGE `community` to `develop`' \
+              --body 'Automated integration of community contributions into `develop`, opened because `community` is ahead of `develop`. This PR tracks the `community` branch and updates as more contributions land.'
+            number="$(gh pr list --repo "$REPO" --head community --base develop \
+              --state open --json number --jq '.[0].number')"
+            action="opened"
+          fi
+
+          url="$(gh pr view "$number" --repo "$REPO" --json url --jq .url)"
+
+          # Detect conflicts deterministically with a local trial merge, rather
+          # than GitHub's asynchronously-computed `mergeable` field. The
+          # conflicting file set is identical in either merge direction, and this
+          # catches conflicts introduced by the community side (which the
+          # develop → community sync never sees, since it only runs on develop pushes).
+          git config user.name 'voxel51-bot'
+          git config user.email 'bot@voxel51.com'
+          conflicts=""
+          if ! git merge --no-commit --no-ff origin/develop >/dev/null 2>&1; then
+            conflicts="$(git diff --name-only --diff-filter=U)"
+          fi
+          git merge --abort 2>/dev/null || true
+
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "::warning::SLACK_COMMUNITY_WEBHOOK_URL not set; skipping Slack notification."
+            exit 0
+          fi
+
+          if [ -n "$conflicts" ]; then
+            files="$(printf '%s\n' "$conflicts" | sed 's/^/• /')"
+            text="$(printf '%s\n' \
+              ":rotating_light: community → develop PR $action — merge conflict" \
+              "" \
+              "<$url|#$number> conflicts with \`develop\` and needs manual resolution." \
+              "" \
+              "Conflicting files:" \
+              "$files")"
+          else
+            text="$(printf '%s\n' \
+              ":twisted_rightwards_arrows: community → develop PR $action" \
+              "" \
+              "<$url|#$number> — ✅ no conflicts" \
+              "" \
+              "Integrates community contributions into \`develop\`.")"
+          fi
+
+          jq -nc --arg text "$text" '{text: $text}' \
+            | curl -sS -X POST -H 'Content-type: application/json' --data @- "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/develop-back-merge.yml
+++ b/.github/workflows/develop-back-merge.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - main
       - release/v[0-9]+.[0-9]+.[0-9]+
-      # Batches non-member contributions accumulated on `community` into
-      # `develop` via a standing "AUTOMATED MERGE community to develop" PR.
-      - community
   workflow_dispatch:
     inputs:
       ref_name:

--- a/.github/workflows/sync-develop-to-community.yml
+++ b/.github/workflows/sync-develop-to-community.yml
@@ -1,14 +1,16 @@
 name: Sync develop to community
 
 # Keeps the long-lived `community` branch current with `develop` by merging
-# `develop` into `community` on every push to `develop`. When the merge
-# conflicts, it posts a summary to the #community Slack channel and fails so a
-# maintainer can resolve it on the `community` branch.
+# `develop` into `community` once a day, rather than on every push to
+# `develop`. When the merge conflicts, it posts a summary to the #community
+# Slack channel and fails so a maintainer can resolve it on the `community`
+# branch.
 
 on:
-  push:
-    branches:
-      - develop
+  schedule:
+    # 09:00 America/New_York. GitHub cron runs in UTC and ignores DST, so this
+    # fires at 09:00 during EDT (summer) and 08:00 during EST (winter).
+    - cron: "0 13 * * *"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/sync-develop-to-community.yml
+++ b/.github/workflows/sync-develop-to-community.yml
@@ -75,7 +75,7 @@ jobs:
           echo "::error::Merging develop into community conflicted — resolve on the community branch."
           exit 1
 
-      - name: Notify #community of conflict
+      - name: "Notify #community of conflict"
         if: failure() && steps.merge.outputs.conflicts != ''
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_COMMUNITY_WEBHOOK_URL }}

--- a/.github/workflows/sync-develop-to-community.yml
+++ b/.github/workflows/sync-develop-to-community.yml
@@ -1,9 +1,9 @@
 name: Sync develop to community
 
-# Keeps the long-lived `community` branch current with `develop`.
-#
-# The reverse direction — `community` → `develop` — is the standing
-# `AUTOMATED MERGE community to develop` PR maintained by develop-back-merge.yml.
+# Keeps the long-lived `community` branch current with `develop` by merging
+# `develop` into `community` on every push to `develop`. When the merge
+# conflicts, it posts a summary to the #community Slack channel and fails so a
+# maintainer can resolve it on the `community` branch.
 
 on:
   push:
@@ -31,6 +31,7 @@ jobs:
           token: ${{ secrets.FIFTYONE_GITHUB_TOKEN }}
 
       - name: Merge develop into community
+        id: merge
         run: |
           git config user.name 'voxel51-bot'
           git config user.email 'bot@voxel51.com'
@@ -49,17 +50,55 @@ jobs:
             exit 0
           fi
 
-          if ! git merge origin/develop --no-edit; then
-            {
-              echo "### ⚠️ develop → community conflict"
-              echo
-              echo "Merging \`develop\` into \`community\` conflicted in:"
-              echo
-              git diff --name-only --diff-filter=U | sed 's/^/- `/; s/$/`/'
-            } >> "$GITHUB_STEP_SUMMARY"
-            git merge --abort
-            echo "::error::Merging develop into community conflicted — resolve on the community branch."
-            exit 1
+          if git merge origin/develop --no-edit; then
+            git push origin community
+            exit 0
           fi
 
-          git push origin community
+          conflicts="$(git diff --name-only --diff-filter=U)"
+          git merge --abort
+
+          {
+            echo "### ⚠️ develop → community conflict"
+            echo
+            echo "Merging \`develop\` into \`community\` conflicted in:"
+            echo
+            printf '%s\n' "$conflicts" | sed 's/^/- `/; s/$/`/'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          {
+            echo "conflicts<<EOF"
+            printf '%s\n' "$conflicts"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "::error::Merging develop into community conflicted — resolve on the community branch."
+          exit 1
+
+      - name: Notify #community of conflict
+        if: failure() && steps.merge.outputs.conflicts != ''
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_COMMUNITY_WEBHOOK_URL }}
+          CONFLICTS: ${{ steps.merge.outputs.conflicts }}
+          SHA: ${{ github.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "::warning::SLACK_COMMUNITY_WEBHOOK_URL not set; skipping Slack notification."
+            exit 0
+          fi
+
+          files="$(printf '%s\n' "$CONFLICTS" | sed 's/^/• /')"
+          text="$(printf '%s\n' \
+            ":warning: develop → community sync conflicted" \
+            "" \
+            "Merging \`develop\` into \`community\` failed — resolve on the \`community\` branch." \
+            "" \
+            "Commit: <$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/commit/$SHA|${SHA:0:9}>" \
+            "Conflicting files:" \
+            "$files" \
+            "" \
+            "<$RUN_URL|View workflow run>")"
+
+          jq -nc --arg text "$text" '{text: $text}' \
+            | curl -sS -X POST -H 'Content-type: application/json' --data @- "$SLACK_WEBHOOK_URL"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,9 +55,10 @@ If you are **not** a Voxel51 team member, open your pull request against the
 **`community`** branch rather than `develop`. If you open one against `develop`
 or a release branch, it is automatically retargeted to `community` for you.
 
-Your changes are unaffected by the retarget. A maintainer integrates the
-`community` branch into `develop` via an automated pull request, so your
-contribution still lands in `develop` — it just goes through `community` first.
+Your changes are unaffected by the retarget. Whenever `community` is ahead of
+`develop`, a `community` → `develop` pull request is opened automatically for a
+maintainer to review and merge, so your contribution still lands in `develop` —
+it just goes through `community` first.
 
 Once your pull request has been merged, your changes will be automatically
 included in the next FiftyOne release!


### PR DESCRIPTION
## What

Reworks the community contribution automation so the two directions are independent, and routes merge conflicts to the **#community** Slack channel.

| File | Change |
|------|--------|
| `develop-back-merge.yml` | Drop the `community` trigger — it now back-merges **main** and **release/v\*** into `develop` only. The `merge/community` branch is retired (already deleted on the remote). |
| `sync-develop-to-community.yml` | On a `develop → community` merge conflict, post a summary (conflicting files + run link) to #community, then fail for manual resolution. |
| `community-to-develop.yml` **(new)** | When a PR is merged into `community`, open or update a direct `community → develop` PR (PR head is the `community` branch — no intermediate merge branch) and notify #community. |
| `community-prs.yml`, `CONTRIBUTING.md` | Wording updates for the new flow. |

## Conflict coverage

A 3-way merge conflict is symmetric, but the *triggers* aren't, so each direction detects conflicts itself with a **local trial merge** (not GitHub's async `mergeable`):

- **develop advances** → `sync-develop-to-community` runs → conflict pinged to #community.
- **a community PR merges** → `community-to-develop` runs → trial merge → conflict pinged to #community.

Either way the conflicting files land in #community.

## Required setup

Add a repo secret **`SLACK_COMMUNITY_WEBHOOK_URL`** (a Slack incoming webhook bound to #community). The notify steps no-op with a warning if it's unset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated community synchronization to run on a daily schedule, with deterministic merge-conflict detection, improved conflict reporting in workflow summaries, and optional Slack notifications when configured.
  * Added automation to create or update a direct community → develop pull request, including rich PR body details.
  * Removed the automated back-merge from community into develop to avoid redundant syncing.
  * Updated the welcome message text for retargeted community pull requests.
* **Documentation**
  * Refreshed contributing guidance to clarify the impact of retargeting and how community changes are brought into develop.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2961
<!-- enterprise-sync-pr:end -->