### PR TITLE
loosen panel area width constraints

### DIFF
--- a/app/packages/core/src/components/SamplesContainer.tsx
+++ b/app/packages/core/src/components/SamplesContainer.tsx
@@ -1,6 +1,7 @@
 import { OPERATOR_PROMPT_AREAS, OperatorPromptArea } from "@fiftyone/operators";
 import { PANEL_AREA, PanelArea } from "@fiftyone/spaces";
 import * as fos from "@fiftyone/state";
+import { constants } from "@fiftyone/utilities";
 import type { Controller } from "@react-spring/web";
 import React, { useCallback } from "react";
 import { useRecoilValue } from "recoil";
@@ -12,6 +13,8 @@ import { Filter } from "./Sidebar/Entries";
 import { createExploreIsDisabled } from "./Sidebar/InteractiveSidebar";
 import SidebarContainer from "./Sidebar/SidebarContainer";
 import ViewSelection from "./Sidebar/ViewSelection";
+
+const { IS_APP_MODE_FIFTYONE } = constants;
 
 const Container = styled.div`
   display: flex;
@@ -148,10 +151,12 @@ function SamplesContainer() {
       {!isModalOpen && (
         <OperatorPromptArea area={OPERATOR_PROMPT_AREAS.DRAWER_RIGHT} />
       )}
-      <PanelArea
-        id={PANEL_AREA.GRID_SIDEBAR_RIGHT}
-        resize={{ direction: "left" }}
-      />
+      {IS_APP_MODE_FIFTYONE && (
+        <PanelArea
+          id={PANEL_AREA.GRID_SIDEBAR_RIGHT}
+          resize={{ direction: "left" }}
+        />
+      )}
     </Container>
   );
 }

--- a/app/packages/spaces/src/PanelArea.tsx
+++ b/app/packages/spaces/src/PanelArea.tsx
@@ -3,9 +3,9 @@ import { usePanelAreaRenderer } from "./hooks";
 import { PanelAreaProps } from "./types";
 import { useState } from "react";
 
-const DEFAULT_WIDTH = 440;
-const DEFAULT_MIN_WIDTH = 300;
-const DEFAULT_MAX_WIDTH = 600;
+const DEFAULT_WIDTH = 450;
+const DEFAULT_MIN_WIDTH = "0%";
+const DEFAULT_MAX_WIDTH = "100%";
 
 export default function PanelArea(props: PanelAreaProps) {
   const { id, resize } = props;
@@ -20,9 +20,9 @@ export default function PanelArea(props: PanelAreaProps) {
   if (resize) {
     return (
       <Resizable
-        size={{ height: "100%", width: width }}
-        minWidth={minWidth || DEFAULT_MIN_WIDTH}
-        maxWidth={maxWidth || DEFAULT_MAX_WIDTH}
+        size={{ height: "100%", width }}
+        minWidth={minWidth ?? DEFAULT_MIN_WIDTH}
+        maxWidth={maxWidth ?? DEFAULT_MAX_WIDTH}
         direction={direction}
         onResizeStop={(_, __, ___, { width: delta }) => {
           setWidth((width) => width + delta);


### PR DESCRIPTION
No related issues to link

## 📋 What changes are proposed in this pull request?

increase max width to 1600 for GRID_SIDEBAR_RIGHT panel area

## 🧪 How is this patch tested? If it is not, please explain why.

Using an example panel

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

increase max width to 1600 for GRID_SIDEBAR_RIGHT panel area

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated the right sidebar panel to appear only when running in FiftyOne app mode.
  * Refined panel resizing defaults to use consistent CSS-based width limits.
  * Improved resize behavior so explicitly set min/max width values (including zero) are preserved, enhancing layout stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2965
<!-- enterprise-sync-pr:end -->