### PR TITLE
ci: don't cancel enterprise-sync on PR close

### DIFF
--- a/.github/workflows/enterprise-sync.yml
+++ b/.github/workflows/enterprise-sync.yml
@@ -9,7 +9,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Don't cancel the `closed` run: merging a PR auto-deletes its head branch,
+  # which tears down refs/pull/<n>/merge and cancels the in-flight run before it
+  # can dispatch the "OSS merged" signal to fiftyone-teams. Only cancel the
+  # superseded in-PR runs (opened/synchronize/etc.).
+  cancel-in-progress: ${{ github.event.action != 'closed' }}
 
 jobs:
   enterprise-sync:


### PR DESCRIPTION
## What

Exclude the `closed` action from `cancel-in-progress` in `enterprise-sync.yml`:

```yaml
cancel-in-progress: ${{ github.event.action != 'closed' }}
```

## Why

Merging a PR auto-deletes its head branch, which tears down `refs/pull/<n>/merge` and cancels the in-flight `closed`-event run **before** it reaches `createDispatchEvent` — so the "OSS merged" signal is never dispatched to `fiftyone-teams`, and the enterprise sync PR's `oss / merged` gate stays pending forever.

This is a race: OSS#7778 and OSS#7787 merged within the same minute; #7787's dispatch fired, #7778's run was cancelled 13s in with **zero steps executed** and its enterprise sync PR (#2897) never auto-merged.

Excluding `closed` from cancellation lets the merge handler always run to completion. In-PR runs (opened/synchronize/reopened/edited) still cancel their superseded predecessors as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved workflow reliability to ensure deployment signals complete successfully during pull request close operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2970
<!-- enterprise-sync-pr:end -->