### PR TITLE
Perf: Annotation Sidebar Performance Improvement

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/LabelEntry.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/LabelEntry.tsx
@@ -3,8 +3,7 @@ import { useLighter } from "@fiftyone/lighter";
 import { isDetection3dOverlay, isPolyline3dOverlay } from "@fiftyone/looker-3d";
 import type { AnnotationLabel } from "@fiftyone/state";
 import { animated } from "@react-spring/web";
-import type { PrimitiveAtom } from "jotai";
-import { getDefaultStore, useAtomValue } from "jotai";
+import { type PrimitiveAtom, getDefaultStore, useAtomValue } from "jotai";
 import { useMemo } from "react";
 import styled from "styled-components";
 import { Column } from "./Components";
@@ -12,7 +11,7 @@ import { useAnnotationContext } from "./Edit/useAnnotationContext";
 import { ICONS } from "./Icons";
 import { fieldType } from "./state";
 import useColor from "./useColor";
-import { hoveringLabelIds } from "./useHover";
+import { useIsLabelHovering } from "./useHover";
 
 const Container = animated(styled.div`
   display: flex;
@@ -58,10 +57,9 @@ const LabelEntry = ({ atom }: { atom: PrimitiveAtom<AnnotationLabel> }) => {
   const type = useAtomValue(fieldType(label.path ?? ""));
   const { select, setSavedData } = useAnnotationContext();
   const Icon = ICONS[type] ?? (() => null);
-  const hoveringLabelIdsList = useAtomValue(hoveringLabelIds);
   const { scene } = useLighter();
 
-  const isHovering = hoveringLabelIdsList.includes(label.overlay.id);
+  const isHovering = useIsLabelHovering(label.overlay.id);
 
   const color = useColor(label.overlay);
 

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useHover.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useHover.ts
@@ -15,6 +15,13 @@ const isLabelHoveringFamily = atomFamily((id: string) =>
   atom((get) => get(hoveringLabelIds).includes(id))
 );
 
+// Evict atoms older than 10 minutes so the cache doesn't grow without bound across
+// long annotation sessions with many distinct label IDs. These atoms are purely
+// derived and hold no mutable state, so eviction and lazy recreation is transparent.
+isLabelHoveringFamily.setShouldRemove(
+  (createdAt) => Date.now() - createdAt > 10 * 60 * 1000
+);
+
 export const useIsLabelHovering = (id: string): boolean =>
   useAtomValue(isLabelHoveringFamily(id));
 

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useHover.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useHover.ts
@@ -4,10 +4,19 @@ import {
   useLighter,
   useLighterEventHandler,
 } from "@fiftyone/lighter";
-import { atom, getDefaultStore } from "jotai";
+import { atom, useAtomValue } from "jotai";
+import { atomFamily } from "jotai/utils";
+import { getDefaultStore } from "jotai";
 import { useCallback } from "react";
 
-export const hoveringLabelIds = atom<string[]>([]);
+const hoveringLabelIds = atom<string[]>([]);
+
+const isLabelHoveringFamily = atomFamily((id: string) =>
+  atom((get) => get(hoveringLabelIds).includes(id))
+);
+
+export const useIsLabelHovering = (id: string): boolean =>
+  useAtomValue(isLabelHoveringFamily(id));
 
 export default function useHover() {
   const { scene } = useLighter();

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useHover.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useHover.ts
@@ -4,9 +4,8 @@ import {
   useLighter,
   useLighterEventHandler,
 } from "@fiftyone/lighter";
-import { atom, useAtomValue } from "jotai";
+import { atom, useAtomValue, getDefaultStore } from "jotai";
 import { atomFamily } from "jotai/utils";
-import { getDefaultStore } from "jotai";
 import { useCallback } from "react";
 
 const hoveringLabelIds = atom<string[]>([]);


### PR DESCRIPTION

## 🔗 Related Issues

Fix that came from research done in https://voxel51.atlassian.net/browse/FOEPD-4003

## 📋 What changes are proposed in this pull request?

🐞 **Bug**: when any label is hovered in the sample modal canvas, the entire list of labels in the `AnnotateSidebar` rerenders. When only the individual label with style updates should be rerendering.
🔧 **Fix**: update `useHover` to utilize an atomFamily pattern instead of a single atom. This stops every `LabelEntry` component in the list from being notified on every hover update. 


## 🧪 How is this patch tested? If it is not, please explain why.

1. Open a sample in the modal and switch to Annotate Mode
2. Turn on React Profiler and enable the ability to visualize component rerenders on the page.
3. Mouse over various labels in the canvas and verify the entire list of labels in the sidebar doesnt rerender, only the labels you moused over should rerender.

**Before Fix**:

https://github.com/user-attachments/assets/9224b2cd-3a5e-4852-accb-9693ab946d66

**After Fix**

https://github.com/user-attachments/assets/8f9cd528-8ac2-49f8-ba4b-7bca9dbfb56e



## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved label hover-state handling in the annotation sidebar by switching from a shared list lookup to a per-label derived hover hook.
  * Kept hover tracking internal and introduced a simple `useIsLabelHovering` interface to power label-specific hover behavior.
  * Updated hover wiring so the highlighted state responds directly to each label’s overlay identifier for more consistent, responsive highlighting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3003
<!-- enterprise-sync-pr:end -->