### PR TITLE
fix: avoid utcfromtimestamp in core utils

### DIFF
--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -3182,13 +3182,13 @@ def timestamp_to_datetime(ts):
     Returns:
         a `datetime.datetime`
     """
-    dt = datetime.utcfromtimestamp(ts / 1000.0)
+    dt = datetime.fromtimestamp(ts / 1000.0, tz=pytz.utc)
 
     if fo.config.timezone is None:
-        return dt
+        return dt.replace(tzinfo=None)
 
     timezone = pytz.timezone(fo.config.timezone)
-    return dt.replace(tzinfo=pytz.utc).astimezone(timezone)
+    return dt.astimezone(timezone)
 
 
 def timedelta_to_ms(td):


### PR DESCRIPTION
Problem: timestamp_to_datetime() uses datetime.utcfromtimestamp(), which is deprecated and returns a naive UTC datetime.

Before / after: before, the function built a naive UTC datetime with utcfromtimestamp() and then attached UTC when a configured timezone was requested. After, it uses datetime.fromtimestamp(..., tz=pytz.utc), keeps the existing naive UTC return when no timezone is configured, and converts directly from the aware UTC value when a timezone is configured.

Verification:
- python -m py_compile fiftyone\core\utils.py