### PR TITLE
Fix siglip and medsiglip processor loading under transformers 5.x

### DIFF
--- a/fiftyone/utils/transformers.py
+++ b/fiftyone/utils/transformers.py
@@ -718,12 +718,9 @@ class FiftyOneTransformer(TransformerEmbeddingsMixin, fout.TorchImageModel):
             if proc_cls is None:
                 raise
 
-            try:
-                processor = proc_cls.from_pretrained(name, **ta)
-            except AttributeError:
-                # The processor declares no tokenizer_class, so from_pretrained
-                # re-enters the same tokenizer resolution; read the fast
-                # tokenizer from the repo directly.
+            if getattr(proc_cls, "tokenizer_class", None) is None:
+                # No tokenizer_class to auto-resolve; build the fast tokenizer
+                # directly.
                 processor = proc_cls(
                     image_processor=transformers.AutoImageProcessor.from_pretrained(
                         name, **ta
@@ -732,6 +729,8 @@ class FiftyOneTransformer(TransformerEmbeddingsMixin, fout.TorchImageModel):
                         name, **ta
                     ),
                 )
+            else:
+                processor = proc_cls.from_pretrained(name, **ta)
         return _HFTransformsHandler(
             processor, **(config.transformers_processor_kwargs)
         )

--- a/fiftyone/utils/transformers.py
+++ b/fiftyone/utils/transformers.py
@@ -701,7 +701,21 @@ class FiftyOneTransformer(TransformerEmbeddingsMixin, fout.TorchImageModel):
         )
 
     def _load_transforms(self, config):
-        processor = super()._load_transforms(config)
+        try:
+            processor = super()._load_transforms(config)
+        except AttributeError:
+            # build the processor from its components
+            from transformers.models.auto.processing_auto import PROCESSOR_MAPPING
+
+            ta = config.transforms_args or {}
+            name = ta.get("pretrained_model_name_or_path") or ta.get("name_or_path")
+            proc_cls = PROCESSOR_MAPPING[
+                type(transformers.AutoConfig.from_pretrained(name))
+            ]
+            processor = proc_cls(
+                image_processor=transformers.AutoImageProcessor.from_pretrained(name),
+                tokenizer=transformers.PreTrainedTokenizerFast.from_pretrained(name),
+            )
         return _HFTransformsHandler(
             processor, **(config.transformers_processor_kwargs)
         )

--- a/fiftyone/utils/transformers.py
+++ b/fiftyone/utils/transformers.py
@@ -704,18 +704,34 @@ class FiftyOneTransformer(TransformerEmbeddingsMixin, fout.TorchImageModel):
         try:
             processor = super()._load_transforms(config)
         except AttributeError:
-            # build the processor from its components
+            # AutoProcessor can't resolve the tokenizer for some models; resolve
+            # the processor class from the config and load it directly.
             from transformers.models.auto.processing_auto import PROCESSOR_MAPPING
 
-            ta = config.transforms_args or {}
-            name = ta.get("pretrained_model_name_or_path") or ta.get("name_or_path")
-            proc_cls = PROCESSOR_MAPPING[
-                type(transformers.AutoConfig.from_pretrained(name))
-            ]
-            processor = proc_cls(
-                image_processor=transformers.AutoImageProcessor.from_pretrained(name),
-                tokenizer=transformers.PreTrainedTokenizerFast.from_pretrained(name),
+            ta = dict(config.transforms_args or {})
+            name = ta.pop("pretrained_model_name_or_path", None)
+            name = name or ta.pop("name_or_path", None)
+
+            proc_cls = PROCESSOR_MAPPING.get(
+                type(transformers.AutoConfig.from_pretrained(name, **ta)), None
             )
+            if proc_cls is None:
+                raise
+
+            try:
+                processor = proc_cls.from_pretrained(name, **ta)
+            except AttributeError:
+                # The processor declares no tokenizer_class, so from_pretrained
+                # re-enters the same tokenizer resolution; read the fast
+                # tokenizer from the repo directly.
+                processor = proc_cls(
+                    image_processor=transformers.AutoImageProcessor.from_pretrained(
+                        name, **ta
+                    ),
+                    tokenizer=transformers.PreTrainedTokenizerFast.from_pretrained(
+                        name, **ta
+                    ),
+                )
         return _HFTransformsHandler(
             processor, **(config.transformers_processor_kwargs)
         )


### PR DESCRIPTION
## What changes are proposed in this pull request?

`siglip-base-patch16-224-torch` (`google/siglip2-base-patch16-224`) and `medsiglip-448-zero-torch` (`google/medsiglip-448`) fail to load under transformers 5.x. `AutoProcessor.from_pretrained` raises while resolving the tokenizer:

`AttributeError: 'NoneType' object has no attribute 'replace'`

The tokenizer auto-resolution maps these models' `model_type` to `None` in `transformers/models/auto/tokenization_auto.py`. The image processor and the processor class load correctly; only the tokenizer step fails.

`FiftyOneTransformer._load_transforms` now assembles the processor from its components when `AutoProcessor` raises: the tokenizer from `PreTrainedTokenizerFast` (which reads the repository's `tokenizer.json` directly and is independent of the `model_type` mapping), the image processor from `AutoImageProcessor`, and the processor class from the config. The standard `AutoProcessor` path is unchanged and the fallback runs only on failure.

## How is this patch tested? If it is not, please explain why.

Validated against the CV benchmark image (transformers 5.0.0), confirming the patched method is the one loaded.

- `siglip-base-patch16-224-torch` and `medsiglip-448-zero-torch`: `load_zoo_model`, `apply_model` zero-shot classification, and `compute_embeddings` all succeed (embeddings `(4, 768)` and `(4, 1152)`).
- Regression: `pubmed-clip-vit-base-patch32` and `zero-shot-classification-transformer-torch` (the same `_load_transforms` path, where `AutoProcessor` succeeds) plus `clip-vit-base32-torch` all load, classify, and embed unchanged.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for FiftyOne users.

Fixed `siglip-base-patch16-224-torch` and `medsiglip-448-zero-torch` so they load under transformers 5.x instead of failing with an `AttributeError` while building the processor.

### What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [x] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when loading Hugging Face transformer models by strengthening processor initialization. If the default processor-loading flow fails, the app now reconstructs the needed processor components from the model configuration, selecting the appropriate processor and tokenizer handling automatically. This increases compatibility across a wider range of model types and loading setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2971
<!-- enterprise-sync-pr:end -->