### PR TITLE
Optimize default label schema

### DIFF
--- a/plugins/operators/annotation.py
+++ b/plugins/operators/annotation.py
@@ -122,17 +122,17 @@ class GetLabelSchemas(foo.Operator):
         supported_fields = foau.list_valid_annotation_fields(
             ctx.dataset, require_app_support=True, flatten=True
         )
+        default_label_schemas = (
+            ctx.dataset.generate_label_schemas(
+                fields=list(supported_fields), scan_samples=False
+            )
+            if supported_fields
+            else {}
+        )
+
         result = {}
 
         for field in fields:
-            supported = field in supported_fields
-
-            default_label_schema = None
-            if supported:
-                default_label_schema = ctx.dataset.generate_label_schemas(
-                    fields=field, scan_samples=False
-                )
-
             field_instance = ctx.dataset.get_field(field)
             read_only = field_instance.read_only
             _type = foau.get_type(field_instance)
@@ -140,10 +140,10 @@ class GetLabelSchemas(foo.Operator):
                 _type = field_instance.document_type.__name__.lower()
 
             result[field] = {
-                "default_label_schema": default_label_schema,
+                "default_label_schema": default_label_schemas.get(field),
                 "read_only": read_only,
                 "type": _type,
-                "unsupported": not supported,
+                "unsupported": field not in supported_fields,
             }
 
             if field in label_schemas:


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

Previously called generate_label_schemas once per field in a loop — each call re-ran list_valid_annotation_fields internally. The fix calls it once with all supported fields.

## 🧪 How is this patch tested? If it is not, please explain why.

tested locally

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal optimization to label schema generation for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2978
<!-- enterprise-sync-pr:end -->