### PR TITLE
Perf: Primitive Edit Workflow Fix

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Header.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Header.tsx
@@ -1,4 +1,4 @@
-import { useAtomValue } from "jotai";
+import { type PrimitiveAtom, useAtomValue, useSetAtom } from "jotai";
 import { useCallback, useRef, useState } from "react";
 import { Round } from "../Actions";
 
@@ -13,10 +13,14 @@ import { Row } from "./Components";
 
 import { labels } from "../useLabels";
 import * as fos from "@fiftyone/state";
-import { isGeneratedView } from "@fiftyone/state";
+import { isGeneratedView, ModalMode } from "@fiftyone/state";
 import { useRecoilValue } from "recoil";
 import { useSchemaManagerModal } from "../SchemaManager/hooks";
 import { useAnnotationContext } from "./useAnnotationContext";
+import {
+  useActivePrimitive,
+  usePrimitiveEditOriginMode,
+} from "./useActivePrimitive";
 
 import { KnownCommands, KnownContexts, useCommand } from "@fiftyone/commands";
 import useColor from "./useColor";
@@ -134,17 +138,24 @@ const Header = () => {
   const color = useColor(selected?.overlay ?? undefined);
 
   const { exitAnnotationMode } = useAnnotationController();
+  const [activePrimitive] = useActivePrimitive();
+  const [primitiveEditOriginMode, clearPrimitiveEditOriginMode] =
+    usePrimitiveEditOriginMode();
   const onExit = useExit();
   const { scene } = useLighter();
   const { deactivateDetectionMode } = useDetectionMode();
   const currentFieldIsReadOnly = selected?.isFieldReadOnly ?? false;
 
-  // In patches view with single label, clicking back should go to explore mode
+  // In patches view with single label, clicking back should go to explore mode.
+  // Also exit to explore when a primitive edit was initiated from explore mode.
   const isPatches = useRecoilValue(fos.isPatchesView);
   const labelCount = useAtomValue(labels).length;
-  const shouldExitToExplore = isPatches && labelCount === 1;
+  const shouldExitToExplore =
+    (isPatches && labelCount === 1) ||
+    (activePrimitive !== null && primitiveEditOriginMode === ModalMode.EXPLORE);
 
   const handleExit = useCallback(() => {
+    clearPrimitiveEditOriginMode(null);
     if (shouldExitToExplore) {
       exitAnnotationMode();
     }
@@ -152,6 +163,7 @@ const Header = () => {
     scene?.exitInteractiveMode();
     onExit();
   }, [
+    clearPrimitiveEditOriginMode,
     shouldExitToExplore,
     exitAnnotationMode,
     onExit,

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Header.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Header.tsx
@@ -1,4 +1,3 @@
-import { type PrimitiveAtom, useAtomValue, useSetAtom } from "jotai";
 import { useCallback, useRef, useState } from "react";
 import { Round } from "../Actions";
 
@@ -11,7 +10,7 @@ import { ItemLeft, ItemRight } from "../Components";
 import { ICONS } from "../Icons";
 import { Row } from "./Components";
 
-import { labels } from "../useLabels";
+import { useLabelsCount } from "../useLabels";
 import * as fos from "@fiftyone/state";
 import { isGeneratedView, ModalMode } from "@fiftyone/state";
 import { useRecoilValue } from "recoil";
@@ -149,7 +148,7 @@ const Header = () => {
   // In patches view with single label, clicking back should go to explore mode.
   // Also exit to explore when a primitive edit was initiated from explore mode.
   const isPatches = useRecoilValue(fos.isPatchesView);
-  const labelCount = useAtomValue(labels).length;
+  const labelCount = useLabelsCount();
   const shouldExitToExplore =
     (isPatches && labelCount === 1) ||
     (activePrimitive !== null && primitiveEditOriginMode === ModalMode.EXPLORE);
@@ -163,7 +162,6 @@ const Header = () => {
     scene?.exitInteractiveMode();
     onExit();
   }, [
-    clearPrimitiveEditOriginMode,
     shouldExitToExplore,
     exitAnnotationMode,
     onExit,

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useActivePrimitive.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useActivePrimitive.ts
@@ -1,9 +1,17 @@
 import { atom, useAtom } from "jotai";
 import { useMemo } from "react";
 import { useIsPrimitiveField } from "../SchemaManager/hooks";
+import { ModalMode } from "@fiftyone/state";
 
 // the path of the primitive that is currently being edited
 export const activePrimitiveAtom = atom<string | null>(null);
+
+// the mode from which the primitive edit was initiated
+export const primitiveEditOriginModeAtom = atom<ModalMode | null>(null);
+
+export const usePrimitiveEditOriginMode = () => {
+  return useAtom(primitiveEditOriginModeAtom);
+};
 
 export const useActivePrimitive = () => {
   return useAtom(activePrimitiveAtom);

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/QuickEditEntry.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/QuickEditEntry.tsx
@@ -1,9 +1,12 @@
 import { useAnnotationController } from "@fiftyone/annotation";
+import { ModalMode, useModalMode } from "@fiftyone/state";
 import { Stack } from "@mui/material";
 import { Button, Clickable, Icon, IconName, Size } from "@voxel51/voodo";
+import { type PrimitiveAtom, useSetAtom } from "jotai";
 import { FC, ReactNode } from "react";
 import useCanAnnotate from "./useCanAnnotate";
 import { useCanAnnotateField } from "./useCanAnnotateField";
+import { usePrimitiveEditOriginMode } from "./Edit/useActivePrimitive";
 
 type QuickEditActionType = "icon" | "button";
 
@@ -31,19 +34,21 @@ const QuickEditAction: FC<{
 }> = ({ labelId, onClick, path, type = "icon" }) => {
   const canAnnotateField = useCanAnnotateField(path);
   const { enterAnnotationMode } = useAnnotationController();
+  const currentMode = useModalMode();
+  const [, setPrimitiveEditOriginMode] = usePrimitiveEditOriginMode();
 
   if (!canAnnotateField) {
     return null;
   }
 
+  const handleClick = () => {
+    setPrimitiveEditOriginMode(currentMode as ModalMode);
+    enterAnnotationMode(path, labelId);
+    onClick?.();
+  };
+
   return type === "icon" ? (
-    <Clickable
-      data-cy="quick-edit"
-      onClick={() => {
-        enterAnnotationMode(path, labelId);
-        onClick?.();
-      }}
-    >
+    <Clickable data-cy="quick-edit" onClick={handleClick}>
       <EditIcon size={Size.Sm} />
     </Clickable>
   ) : (
@@ -51,10 +56,7 @@ const QuickEditAction: FC<{
       data-cy="quick-edit"
       leadingIcon={EditIcon}
       size={Size.Xs}
-      onClick={() => {
-        enterAnnotationMode(path, labelId);
-        onClick?.();
-      }}
+      onClick={handleClick}
     />
   );
 };

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useLabels.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useLabels.ts
@@ -313,6 +313,10 @@ const pathMap = selector<{ [key: string]: string }>({
   },
 });
 
+export const useLabelsCount = () => {
+  return useAtomValue(labels).length;
+};
+
 /**
  * Returns a callback that updates the {@link AnnotationLabelData} for a label
  * identified by its overlay ID.


### PR DESCRIPTION
## 🔗 Related Issues

Fix that came from research done in https://voxel51.atlassian.net/browse/FOEPD-4003

## 📋 What changes are proposed in this pull request?

🐞 **Bug**: When a user opens a sample modal dialog in Explore Mode, they can edit a primitive value. When they edit the primitive value and click the 'back' button, the modal is now in Annotate Mode (editing a primitive requires Annotate Mode context). Additionally the Annotate Mode interactive sidebar is not populated with label data when it should be (this is because entering Annotate Mode the normal way triggers additional data loading processes).

🔧 **Fix**: The fix is to track the origin when the user chooses to edit the primitive and return the user back to their original mode when they click the 'back' button when they finish their primitive edit.


## 🧪 How is this patch tested? If it is not, please explain why.
1. Open a sample modal in Explore Mode
2. Edit a primitive value
3. Click the 'back' button when you are done editing
4. Verify you are still in Explore Mode
5. Switch to Annotate Mode
6. Edit the primitive
7. Click the 'back' button when you are done editing
8. Verify you are still in Annotate Mode


## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

- Editing a primitive and then pressing the 'Back' button returns the user to the original Modal Mode (Explore vs Annotate) that the user was in when electing to edit the primitive.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Enhancements**
  * Improved annotation mode navigation: the “back”/exit flow now returns you to the correct screen based on how you entered editing (including quick-edit paths), and exits/cleans up modes more consistently.
* **Internal Improvements**
  * Updated sidebar state handling to use a dedicated labels count hook and added origin-mode tracking for primitive edits to ensure consistent navigation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->