### PR TITLE
feat(qwen3-vl): add embed_frames for in-memory frame clips

### DIFF
--- a/fiftyone/utils/qwen3_vl.py
+++ b/fiftyone/utils/qwen3_vl.py
@@ -468,6 +468,53 @@ class Qwen3VLModel(fout.TorchImageModel, fom.EmbeddingsMixin, fom.PromptMixin):
         """
         return self._predict_all(args)
 
+    def embed_frames(self, frames, fps=None):
+        """Generates a single embedding for an ordered list of in-memory
+        frames.
+
+        The frames are treated as one clip and embedded together via
+        Qwen3-VL's native video input, yielding a single vector that
+        captures their full temporal context. This is the in-memory
+        counterpart to passing an ``eta.core.video.FFmpegVideoReader`` to
+        :meth:`embed`, for callers that already hold decoded frames.
+
+        The frames are subsampled toward ``config.video_fps`` (treating
+        ``fps`` as the source rate) and capped at
+        ``config.max_video_frames``, matching how :meth:`embed` handles a
+        video file.
+
+        Args:
+            frames: an ordered iterable of in-memory frames (PIL images,
+                numpy arrays, or torch tensors)
+            fps (None): the rate the frames were sampled at, used to decide
+                how aggressively to subsample. If ``None`` (or zero), the
+                frames are used as-is and ``config.video_fps`` is reported
+                to the model as the playback rate
+
+        Returns:
+            a 1D numpy array embedding
+        """
+        frames = list(frames)
+        if not frames:
+            raise ValueError("Cannot embed an empty list of frames")
+
+        sample_fps = self.config.video_fps
+
+        if fps and sample_fps > 0:
+            step = max(1, round(fps / sample_fps))
+        else:
+            step = 1
+
+        sampled = []
+        for i in range(0, len(frames), step):
+            sampled.append(self._prepare_image(frames[i]))
+            if len(sampled) >= self.config.max_video_frames:
+                break
+
+        effective_fps = fps / step if fps else sample_fps
+
+        return self._embed_frame_list(sampled, effective_fps)
+
     def embed_prompt(self, prompt):
         """Generates an embedding for the given text prompt.
 
@@ -569,6 +616,19 @@ class Qwen3VLModel(fout.TorchImageModel, fom.EmbeddingsMixin, fom.PromptMixin):
 
         effective_fps = raw_fps / step if raw_fps > 0 else sample_fps
 
+        return self._embed_frame_list(frames, effective_fps)
+
+    def _embed_frame_list(self, frames, fps):
+        """Embeds an ordered list of prepared frames as one native Qwen3-VL
+        video message and returns a 1D numpy array embedding.
+
+        Args:
+            frames: a list of prepared frames (e.g. PIL images), in order
+            fps: the playback frame rate to report to the model
+
+        Returns:
+            a 1D numpy array embedding
+        """
         messages = [
             {
                 "role": "user",
@@ -576,7 +636,7 @@ class Qwen3VLModel(fout.TorchImageModel, fom.EmbeddingsMixin, fom.PromptMixin):
                     {
                         "type": "video",
                         "video": frames,
-                        "fps": effective_fps,
+                        "fps": fps,
                     },
                 ],
             }

--- a/fiftyone/utils/qwen3_vl.py
+++ b/fiftyone/utils/qwen3_vl.py
@@ -487,9 +487,9 @@ class Qwen3VLModel(fout.TorchImageModel, fom.EmbeddingsMixin, fom.PromptMixin):
             frames: an ordered iterable of in-memory frames (PIL images,
                 numpy arrays, or torch tensors)
             fps (None): the rate the frames were sampled at, used to decide
-                how aggressively to subsample. If ``None`` (or zero), the
-                frames are used as-is and ``config.video_fps`` is reported
-                to the model as the playback rate
+                how aggressively to subsample. If ``None`` or non-positive,
+                the frames are used as-is and ``config.video_fps`` is
+                reported to the model as the playback rate
 
         Returns:
             a 1D numpy array embedding
@@ -500,7 +500,9 @@ class Qwen3VLModel(fout.TorchImageModel, fom.EmbeddingsMixin, fom.PromptMixin):
 
         sample_fps = self.config.video_fps
 
-        if fps and sample_fps > 0:
+        has_fps = fps is not None and fps > 0
+
+        if has_fps and sample_fps > 0:
             step = max(1, round(fps / sample_fps))
         else:
             step = 1
@@ -511,7 +513,7 @@ class Qwen3VLModel(fout.TorchImageModel, fom.EmbeddingsMixin, fom.PromptMixin):
             if len(sampled) >= self.config.max_video_frames:
                 break
 
-        effective_fps = fps / step if fps else sample_fps
+        effective_fps = fps / step if has_fps else sample_fps
 
         return self._embed_frame_list(sampled, effective_fps)
 

--- a/tests/unittests/utils/test_qwen3_vl.py
+++ b/tests/unittests/utils/test_qwen3_vl.py
@@ -783,6 +783,47 @@ class TestQwen3VLEmbedFrames:
         assert len(captured["frames"]) == 5
         assert captured["fps"] == 2.0
 
+    def test_embed_frames_fps_zero(self):
+        model = self._make_model()
+        model.config.video_fps = 2.0
+
+        captured = {}
+
+        def _capture(messages):
+            content = messages[0]["content"][0]
+            captured["frames"] = content["video"]
+            captured["fps"] = content["fps"]
+            return (None, ["<video>"])
+
+        with mock.patch.object(qwen3_vl, "qwen_vl_utils") as mock_qvu:
+            mock_qvu.process_vision_info.side_effect = _capture
+            model.embed_frames(self._frames(5), fps=0)
+
+        # fps == 0 is treated as unknown: no subsampling, target fps reported
+        assert len(captured["frames"]) == 5
+        assert captured["fps"] == 2.0
+
+    def test_embed_frames_fps_negative(self):
+        model = self._make_model()
+        model.config.video_fps = 2.0
+
+        captured = {}
+
+        def _capture(messages):
+            content = messages[0]["content"][0]
+            captured["frames"] = content["video"]
+            captured["fps"] = content["fps"]
+            return (None, ["<video>"])
+
+        with mock.patch.object(qwen3_vl, "qwen_vl_utils") as mock_qvu:
+            mock_qvu.process_vision_info.side_effect = _capture
+            model.embed_frames(self._frames(5), fps=-4.0)
+
+        # negative fps is treated as unknown (like the video-file path): no
+        # subsampling and a sane, non-negative fps reported to the model
+        assert len(captured["frames"]) == 5
+        assert captured["fps"] == 2.0
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unittests/utils/test_qwen3_vl.py
+++ b/tests/unittests/utils/test_qwen3_vl.py
@@ -15,6 +15,7 @@ from unittest import mock
 import fiftyone as fo
 import fiftyone.core.labels as fol
 import fiftyone.core.models as fom
+import fiftyone.utils.qwen3_vl as qwen3_vl
 from fiftyone.utils.qwen3_vl import (
     Qwen3VLModel,
     Qwen3VLModelConfig,
@@ -668,6 +669,119 @@ class TestPromptMixinMocked:
         model = self._make_model_with_mock_processor()
         with pytest.raises(ValueError, match="at least one"):
             model.embed_prompts([])
+
+
+class TestQwen3VLEmbedFrames:
+    """Test embed_frames: embedding a list of in-memory frames as one clip."""
+
+    def _make_model(self):
+        """Build a Qwen3VLModel with mocked _model and _processor."""
+        model = Qwen3VLModel.__new__(Qwen3VLModel)
+        model._output_processor = None
+        model._mode = None
+        model.config = Qwen3VLModelConfig(
+            {
+                "name_or_path": "Qwen/Qwen3-VL-Embedding-2B",
+                "embedding_dim": None,
+                "normalize_embeddings": True,
+            }
+        )
+
+        fake_hidden = torch.randn(1, 10, 2048)
+        mock_outputs = mock.MagicMock()
+        mock_outputs.hidden_states = [fake_hidden]
+
+        mock_model = mock.MagicMock()
+        mock_model.return_value = mock_outputs
+        mock_model.device = torch.device("cpu")
+        model._model = mock_model
+
+        mock_processor = mock.MagicMock()
+        mock_processor.apply_chat_template.return_value = "<chat-text>"
+        mock_processor.return_value = {
+            "input_ids": torch.randint(0, 1000, (1, 10)),
+            "attention_mask": torch.ones(1, 10, dtype=torch.long),
+        }
+        model._processor = mock_processor
+
+        return model
+
+    @staticmethod
+    def _frames(n):
+        return [
+            np.random.randint(0, 255, (8, 8, 3), dtype=np.uint8)
+            for _ in range(n)
+        ]
+
+    def test_embed_frames_returns_1d_array(self):
+        model = self._make_model()
+        with mock.patch.object(qwen3_vl, "qwen_vl_utils") as mock_qvu:
+            mock_qvu.process_vision_info.return_value = (None, ["<video>"])
+            result = model.embed_frames(self._frames(4), fps=4.0)
+
+        assert isinstance(result, np.ndarray)
+        assert result.ndim == 1
+
+    def test_embed_frames_empty_raises(self):
+        model = self._make_model()
+        with pytest.raises(ValueError, match="empty"):
+            model.embed_frames([])
+
+    def test_embed_frames_subsamples_to_video_fps(self):
+        model = self._make_model()
+        model.config.video_fps = 2.0
+
+        captured = {}
+
+        def _capture(messages):
+            content = messages[0]["content"][0]
+            captured["frames"] = content["video"]
+            captured["fps"] = content["fps"]
+            return (None, ["<video>"])
+
+        with mock.patch.object(qwen3_vl, "qwen_vl_utils") as mock_qvu:
+            mock_qvu.process_vision_info.side_effect = _capture
+            model.embed_frames(self._frames(8), fps=8.0)
+
+        # 8 fps down to 2 fps -> keep every 4th frame -> 2 frames
+        assert len(captured["frames"]) == 2
+        assert captured["fps"] == 2.0
+
+    def test_embed_frames_caps_at_max_video_frames(self):
+        model = self._make_model()
+        model.config.max_video_frames = 3
+
+        captured = {}
+
+        def _capture(messages):
+            captured["frames"] = messages[0]["content"][0]["video"]
+            return (None, ["<video>"])
+
+        with mock.patch.object(qwen3_vl, "qwen_vl_utils") as mock_qvu:
+            mock_qvu.process_vision_info.side_effect = _capture
+            model.embed_frames(self._frames(10), fps=None)
+
+        assert len(captured["frames"]) == 3
+
+    def test_embed_frames_fps_none_keeps_all_frames(self):
+        model = self._make_model()
+        model.config.video_fps = 2.0
+
+        captured = {}
+
+        def _capture(messages):
+            content = messages[0]["content"][0]
+            captured["frames"] = content["video"]
+            captured["fps"] = content["fps"]
+            return (None, ["<video>"])
+
+        with mock.patch.object(qwen3_vl, "qwen_vl_utils") as mock_qvu:
+            mock_qvu.process_vision_info.side_effect = _capture
+            model.embed_frames(self._frames(5), fps=None)
+
+        # fps unknown -> no subsampling; all frames used, target fps reported
+        assert len(captured["frames"]) == 5
+        assert captured["fps"] == 2.0
 
 
 if __name__ == "__main__":

--- a/tests/unittests/utils/test_qwen3_vl.py
+++ b/tests/unittests/utils/test_qwen3_vl.py
@@ -715,7 +715,9 @@ class TestQwen3VLEmbedFrames:
 
     def test_embed_frames_returns_1d_array(self):
         model = self._make_model()
-        with mock.patch.object(qwen3_vl, "qwen_vl_utils") as mock_qvu:
+        with mock.patch.object(
+            qwen3_vl, "qwen_vl_utils", mock.MagicMock()
+        ) as mock_qvu:
             mock_qvu.process_vision_info.return_value = (None, ["<video>"])
             result = model.embed_frames(self._frames(4), fps=4.0)
 
@@ -739,7 +741,9 @@ class TestQwen3VLEmbedFrames:
             captured["fps"] = content["fps"]
             return (None, ["<video>"])
 
-        with mock.patch.object(qwen3_vl, "qwen_vl_utils") as mock_qvu:
+        with mock.patch.object(
+            qwen3_vl, "qwen_vl_utils", mock.MagicMock()
+        ) as mock_qvu:
             mock_qvu.process_vision_info.side_effect = _capture
             model.embed_frames(self._frames(8), fps=8.0)
 
@@ -757,7 +761,9 @@ class TestQwen3VLEmbedFrames:
             captured["frames"] = messages[0]["content"][0]["video"]
             return (None, ["<video>"])
 
-        with mock.patch.object(qwen3_vl, "qwen_vl_utils") as mock_qvu:
+        with mock.patch.object(
+            qwen3_vl, "qwen_vl_utils", mock.MagicMock()
+        ) as mock_qvu:
             mock_qvu.process_vision_info.side_effect = _capture
             model.embed_frames(self._frames(10), fps=None)
 
@@ -775,7 +781,9 @@ class TestQwen3VLEmbedFrames:
             captured["fps"] = content["fps"]
             return (None, ["<video>"])
 
-        with mock.patch.object(qwen3_vl, "qwen_vl_utils") as mock_qvu:
+        with mock.patch.object(
+            qwen3_vl, "qwen_vl_utils", mock.MagicMock()
+        ) as mock_qvu:
             mock_qvu.process_vision_info.side_effect = _capture
             model.embed_frames(self._frames(5), fps=None)
 
@@ -795,7 +803,9 @@ class TestQwen3VLEmbedFrames:
             captured["fps"] = content["fps"]
             return (None, ["<video>"])
 
-        with mock.patch.object(qwen3_vl, "qwen_vl_utils") as mock_qvu:
+        with mock.patch.object(
+            qwen3_vl, "qwen_vl_utils", mock.MagicMock()
+        ) as mock_qvu:
             mock_qvu.process_vision_info.side_effect = _capture
             model.embed_frames(self._frames(5), fps=0)
 
@@ -815,7 +825,9 @@ class TestQwen3VLEmbedFrames:
             captured["fps"] = content["fps"]
             return (None, ["<video>"])
 
-        with mock.patch.object(qwen3_vl, "qwen_vl_utils") as mock_qvu:
+        with mock.patch.object(
+            qwen3_vl, "qwen_vl_utils", mock.MagicMock()
+        ) as mock_qvu:
             mock_qvu.process_vision_info.side_effect = _capture
             model.embed_frames(self._frames(5), fps=-4.0)
 


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link.

## 📋 What changes are proposed in this pull request?

Adds a public `Qwen3VLModel.embed_frames(frames, fps=None)` method for embedding an ordered list of **in-memory** frames as a single native Qwen3-VL video clip.

Today, the only way to get a clip-level Qwen3-VL embedding is to pass an `eta.core.video.FFmpegVideoReader` (i.e. a video file on disk) to `embed()`, which samples frames from the reader and embeds them as one clip. Callers that already hold decoded frames in memory have no entry point short of re-encoding the frames to a temporary video file.

`embed_frames`:

- Treats the frames as one clip and embeds them together via Qwen3-VL's native video input, returning a single embedding vector.
- Subsamples toward `config.video_fps` (treating `fps` as the source rate, or skipping subsampling when `fps` is `None`/unknown) and caps at `config.max_video_frames` — exactly mirroring how `embed()` handles a video file.

To avoid duplicating logic, the shared message-building + inference tail of `_embed_video` is refactored into a private `_embed_frame_list(frames, fps)` helper used by both the file-based and in-memory paths. `_embed_video`'s behavior is otherwise unchanged.

## 🧪 How is this patch tested? If it is not, please explain why.

New `TestQwen3VLEmbedFrames` unit tests in `tests/unittests/utils/test_qwen3_vl.py` (mocked model/processor — no model download) cover:

- 1D output shape for a list of frames
- empty input raises `ValueError`
- fps-based subsampling (e.g. 8 fps → `video_fps=2` keeps every 4th frame)
- capping at `config.max_video_frames`
- `fps=None` passthrough (no subsampling; `config.video_fps` reported to the model)

Full `tests/unittests/utils/test_qwen3_vl.py` suite passes (57 tests).

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release notes for FiftyOne users.

Added `Qwen3VLModel.embed_frames(frames, fps=None)` to embed an in-memory list of frames as a single Qwen3-VL video clip, complementing the existing file-based video embedding path.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `embed_frames` to enable embedding ordered in-memory frame sequences as native video clips, with automatic handling for empty inputs, optional framerate-based subsampling, and maximum frame-count limits.
* **Bug Fixes**
  * Improved correctness of reported FPS in the generated video embedding request by ensuring the embedding path consistently uses the intended FPS value.
* **Tests**
  * Added unit tests covering `embed_frames` behavior for empty input, subsampling, `max_video_frames` capping, and `fps` being `None`, zero, or negative.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2980
<!-- enterprise-sync-pr:end -->