### PR TITLE
Optimize group and frame aggregations

### DIFF
--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -920,6 +920,19 @@ class DatasetView(foc.SampleCollection):
 
         if etau.is_str(group_expr):
             pipeline.append({"$match": {group_expr[1:]: group_value}})
+        elif isinstance(group_expr, (list, tuple)) and all(
+            etau.is_str(e) and e.startswith("$") for e in group_expr
+        ):
+            # match each field directly (index-eligible) rather than an `$expr` over
+            # a computed array, which cannot use an index.
+            pipeline.append(
+                {
+                    "$match": {
+                        field_ref[1:]: value
+                        for field_ref, value in zip(group_expr, group_value)
+                    }
+                }
+            )
         else:
             pipeline.append(
                 {"$match": {"$expr": {"$eq": [group_expr, group_value]}}}

--- a/fiftyone/server/aggregations.py
+++ b/fiftyone/server/aggregations.py
@@ -233,14 +233,18 @@ def _resolve_path_aggregation(
     query_performance: bool,
     hint: t.Optional[str] = None,
 ) -> AggregateResult:
-    # the root ("" path) total uses the estimated document count, not a `Count`
-    # (which forces a full group-by pass on grouped views); only field paths get a
-    # real indexed count.
+    # Get full collection counts from collection metadata (O(1)) instead of a
+    # full `$count` scan. Must skip groups because we need to apply the slice
+    # filter that isn't declared in the view.
+    estimate_root = (
+        not path and view._dataset.media_type != fom.GROUP and not view._stages
+    )
+
     aggregations: t.List[foa.Aggregation] = []
-    if path:
+    if path or not estimate_root:
         aggregations.append(
             foa.Count(
-                path,
+                path if path else None,
                 _optimize=query_performance,
                 _hint=hint if query_performance else None,
             )
@@ -278,8 +282,8 @@ def _resolve_path_aggregation(
             aggregations.append(foa.CountValues(path, _first=LIST_LIMIT))
 
     data = {"path": path}
-    if not path:
-        est = view._root_dataset._sample_collection.estimated_document_count()
+    if estimate_root:
+        est = view._dataset._sample_collection.estimated_document_count()
         data["count"] = est
         data["exists"] = est
 

--- a/fiftyone/server/aggregations.py
+++ b/fiftyone/server/aggregations.py
@@ -233,13 +233,18 @@ def _resolve_path_aggregation(
     query_performance: bool,
     hint: t.Optional[str] = None,
 ) -> AggregateResult:
-    aggregations: t.List[foa.Aggregation] = [
-        foa.Count(
-            path if path and path != "" else None,
-            _optimize=query_performance,
-            _hint=hint if query_performance else None,
+    # the root ("" path) total uses the estimated document count, not a `Count`
+    # (which forces a full group-by pass on grouped views); only field paths get a
+    # real indexed count.
+    aggregations: t.List[foa.Aggregation] = []
+    if path:
+        aggregations.append(
+            foa.Count(
+                path,
+                _optimize=query_performance,
+                _hint=hint if query_performance else None,
+            )
         )
-    ]
     field = view.get_field(path)
 
     while isinstance(field, fof.ListField):
@@ -273,6 +278,10 @@ def _resolve_path_aggregation(
             aggregations.append(foa.CountValues(path, _first=LIST_LIMIT))
 
     data = {"path": path}
+    if not path:
+        est = view._root_dataset._sample_collection.estimated_document_count()
+        data["count"] = est
+        data["exists"] = est
 
     def from_results(results):
         for aggregation, result in zip(aggregations, results):

--- a/fiftyone/server/routes/frames.py
+++ b/fiftyone/server/routes/frames.py
@@ -34,7 +34,7 @@ def _heavy_frame_paths(schema, prefix=""):
             isinstance(field, (fof.DictField, fof.VectorField))
             or name == "logits"
         ):
-            paths.append(f"frames.{path}")
+            paths.append(path)
             continue
 
         nested = field

--- a/fiftyone/server/routes/frames.py
+++ b/fiftyone/server/routes/frames.py
@@ -21,16 +21,30 @@ from fiftyone.server.decorators import route
 import fiftyone.server.view as fosv
 
 
-def _heavy_frame_paths(view):
-    # exclude large fields (dicts, vectors, logits) from the response
-    frame_schema = view.get_frame_field_schema(flat=True) or {}
-    return [
-        f"frames.{path}"
-        for path, field in frame_schema.items()
-        if isinstance(field, (fof.DictField, fof.VectorField))
-        or path == "logits"
-        or path.endswith(".logits")
-    ]
+def _heavy_frame_paths(schema, prefix=""):
+    # Collect paths to dicts, vectors, and per-label `logits` fields to exclude
+    # from the projection since they aren't exposed in the app anyways. Descends
+    # into label embedded docs to reach nested logits, but stops at any excluded
+    # field so the $project exclusions can't overlap.
+    paths = []
+    for name, field in schema.items():
+        path = f"{prefix}.{name}" if prefix else name
+
+        if (
+            isinstance(field, (fof.DictField, fof.VectorField))
+            or name == "logits"
+        ):
+            paths.append(f"frames.{path}")
+            continue
+
+        nested = field
+        while isinstance(nested, (fof.ListField, fof.DictField)):
+            nested = nested.field
+
+        if isinstance(nested, fof.EmbeddedDocumentField):
+            paths.extend(_heavy_frame_paths(nested.get_field_schema(), path))
+
+    return paths
 
 
 class Frames(HTTPEndpoint):
@@ -69,7 +83,7 @@ class Frames(HTTPEndpoint):
         view = await run_sync_task(run, view)
 
         pipeline = view._pipeline(frames_only=True, support=support)
-        heavy = _heavy_frame_paths(view)
+        heavy = _heavy_frame_paths(view.get_frame_field_schema())
         if heavy:
             pipeline.append({"$project": {path: 0 for path in heavy}})
 

--- a/fiftyone/server/routes/frames.py
+++ b/fiftyone/server/routes/frames.py
@@ -11,6 +11,7 @@ from starlette.responses import JSONResponse
 from starlette.requests import Request
 
 from fiftyone.core.expressions import ViewField as F
+import fiftyone.core.fields as fof
 import fiftyone.core.json as foj
 import fiftyone.core.odm as foo
 from fiftyone.core.utils import run_sync_task
@@ -18,6 +19,18 @@ import fiftyone.core.view as fov
 
 from fiftyone.server.decorators import route
 import fiftyone.server.view as fosv
+
+
+def _heavy_frame_paths(view):
+    # exclude large fields (dicts, vectors, logits) from the response
+    frame_schema = view.get_frame_field_schema(flat=True) or {}
+    return [
+        f"frames.{path}"
+        for path, field in frame_schema.items()
+        if isinstance(field, (fof.DictField, fof.VectorField))
+        or path == "logits"
+        or path.endswith(".logits")
+    ]
 
 
 class Frames(HTTPEndpoint):
@@ -55,9 +68,14 @@ class Frames(HTTPEndpoint):
 
         view = await run_sync_task(run, view)
 
+        pipeline = view._pipeline(frames_only=True, support=support)
+        heavy = _heavy_frame_paths(view)
+        if heavy:
+            pipeline.append({"$project": {path: 0 for path in heavy}})
+
         frames = await foo.aggregate(
             foo.get_async_db_conn()[view._dataset._sample_collection_name],
-            view._pipeline(frames_only=True, support=support),
+            pipeline,
         ).to_list(end_frame - start_frame + 1)
 
         return JSONResponse(


### PR DESCRIPTION

## 🔗 Related Issues

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->

## 📋 What changes are proposed in this pull request?

- view.py: match each group field directly instead of an `$expr` over a computed array, so `get_group` can use an index
- aggregations.py: use  `estimated_document_count()` for the root total instead of a full group-by Count
- routes/frames.py: exclude heavy frame fields (dicts/vectors/logits) from the frames response (previously already removed from the paginate_samples()/samples server queries)

## 🧪 How is this patch tested? If it is not, please explain why.

<!--
Describe the tests you ran or wrote to verify your changes. Include:
- New or updated unit/integration tests
- Manual testing steps performed
- Why tests are not applicable (if skipped)
-->

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dynamic group filtering so multi-field group expressions match each referenced field to its corresponding provided value.
  * Refined root aggregation resolution to conditionally apply count logic and prefill count/existence for more efficient results.
* **New Features**
  * Frame responses now automatically exclude heavy frame subfields to reduce payload size and improve retrieval speed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2981
<!-- enterprise-sync-pr:end -->