### PR TITLE
Bump @voxel51/voodo to v0.0.35

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -70,7 +70,7 @@
         "react-plotly.js": "^2.6.0"
     },
     "resolutions": {
-        "@voxel51/voodo": "^0.0.34",
+        "@voxel51/voodo": "^0.0.35",
         "brace-expansion": "^5.0.6",
         "three-stdlib": "^2.36.1",
         "@types/react": "18.2.0",

--- a/app/packages/components/package.json
+++ b/app/packages/components/package.json
@@ -53,7 +53,7 @@
         "@mui/material": "^5.9.0",
         "@react-spring/web": "^9.7.3",
         "@textea/json-viewer": "^3.4.1",
-        "@voxel51/voodo": "^0.0.34",
+        "@voxel51/voodo": "^0.0.35",
         "classnames": "^2.3.1",
         "framer-motion": "^6.2.7",
         "material-icons": "^1.13.12",

--- a/app/packages/core/package.json
+++ b/app/packages/core/package.json
@@ -23,7 +23,7 @@
         "@mui/material": "^5.9.0",
         "@react-spring/web": "^9.4.3",
         "@use-gesture/react": "^10.3.0",
-        "@voxel51/voodo": "^0.0.34",
+        "@voxel51/voodo": "^0.0.35",
         "@xstate/react": "1.3.3",
         "classnames": "^2.2.6",
         "color": "^4.2.3",

--- a/app/packages/multimodal/package.json
+++ b/app/packages/multimodal/package.json
@@ -73,7 +73,7 @@
         "@mcap/support": "^1.1.0",
         "@react-three/drei": "9.105.4",
         "@react-three/fiber": "^8.18.0",
-        "@voxel51/voodo": "^0.0.34",
+        "@voxel51/voodo": "^0.0.35",
         "buffer": "^6.0.3",
         "lru-cache": "^11.0.1",
         "protobufjs": "^7.2.5",

--- a/app/packages/playback/package.json
+++ b/app/packages/playback/package.json
@@ -15,7 +15,7 @@
     "dependencies": {
         "@fiftyone/commands": "workspace:^",
         "@fiftyone/tiling": "*",
-        "@voxel51/voodo": "^0.0.34",
+        "@voxel51/voodo": "^0.0.35",
         "jotai": "^2.9.3",
         "jotai-optics": "^0.4.0",
         "vite-plugin-svgr": "^4.2.0"

--- a/app/packages/similarity-search/package.json
+++ b/app/packages/similarity-search/package.json
@@ -17,7 +17,7 @@
         "@fiftyone/plugins": "*",
         "@fiftyone/spaces": "*",
         "@fiftyone/state": "*",
-        "@voxel51/voodo": "^0.0.34"
+        "@voxel51/voodo": "^0.0.35"
     },
     "devDependencies": {
         "vite": "^7.3.2",

--- a/app/packages/state/package.json
+++ b/app/packages/state/package.json
@@ -35,7 +35,7 @@
         "@fiftyone/relay": "*",
         "@fiftyone/utilities": "*",
         "@microsoft/fetch-event-source": "^2.0.1",
-        "@voxel51/voodo": "^0.0.34",
+        "@voxel51/voodo": "^0.0.35",
         "html2canvas": "1.0.0-rc.7",
         "lodash": "^4.18.1"
     }

--- a/app/packages/tiling/package.json
+++ b/app/packages/tiling/package.json
@@ -5,7 +5,7 @@
     "types": "./src/index.ts",
     "packageManager": "yarn@4.9.1",
     "dependencies": {
-        "@voxel51/voodo": "^0.0.34",
+        "@voxel51/voodo": "^0.0.35",
         "clsx": "^2.1.1",
         "jotai": "^2.9.3",
         "react-mosaic-component": "^6.1.1"

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -3132,7 +3132,7 @@ __metadata:
     "@textea/json-viewer": "npm:^3.4.1"
     "@types/react-input-autosize": "npm:^2.2.1"
     "@types/react-syntax-highlighter": "npm:^15.5.6"
-    "@voxel51/voodo": "npm:^0.0.34"
+    "@voxel51/voodo": "npm:^0.0.35"
     classnames: "npm:^2.3.1"
     framer-motion: "npm:^6.2.7"
     material-icons: "npm:^1.13.12"
@@ -3185,7 +3185,7 @@ __metadata:
     "@types/styled-components": "npm:^5.1.23"
     "@use-gesture/react": "npm:^10.3.0"
     "@vitejs/plugin-react-refresh": "npm:^1.3.3"
-    "@voxel51/voodo": "npm:^0.0.34"
+    "@voxel51/voodo": "npm:^0.0.35"
     "@xstate/react": "npm:1.3.3"
     classnames: "npm:^2.2.6"
     color: "npm:^4.2.3"
@@ -3471,7 +3471,7 @@ __metadata:
     "@react-three/drei": "npm:9.105.4"
     "@react-three/fiber": "npm:^8.18.0"
     "@types/three": "npm:^0.182.0"
-    "@voxel51/voodo": "npm:^0.0.34"
+    "@voxel51/voodo": "npm:^0.0.35"
     buffer: "npm:^6.0.3"
     lru-cache: "npm:^11.0.1"
     protobufjs: "npm:^7.2.5"
@@ -3503,7 +3503,7 @@ __metadata:
     "@eslint/compat": "npm:^1.1.1"
     "@fiftyone/commands": "workspace:^"
     "@fiftyone/tiling": "npm:*"
-    "@voxel51/voodo": "npm:^0.0.34"
+    "@voxel51/voodo": "npm:^0.0.35"
     eslint: "npm:9.7.0"
     eslint-plugin-react: "npm:^7.35.0"
     eslint-plugin-react-hooks: "npm:rc"
@@ -3555,7 +3555,7 @@ __metadata:
     "@fiftyone/plugins": "npm:*"
     "@fiftyone/spaces": "npm:*"
     "@fiftyone/state": "npm:*"
-    "@voxel51/voodo": "npm:^0.0.34"
+    "@voxel51/voodo": "npm:^0.0.35"
     vite: "npm:^7.3.2"
     vite-plugin-externals: "npm:^0.5.0"
   peerDependencies:
@@ -3603,7 +3603,7 @@ __metadata:
     "@fiftyone/utilities": "npm:*"
     "@microsoft/fetch-event-source": "npm:^2.0.1"
     "@testing-library/react-hooks": "npm:latest"
-    "@voxel51/voodo": "npm:^0.0.34"
+    "@voxel51/voodo": "npm:^0.0.35"
     babel-plugin-relay: "npm:^14.1.0"
     html2canvas: "npm:1.0.0-rc.7"
     lodash: "npm:^4.18.1"
@@ -3622,7 +3622,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fiftyone/tiling@workspace:packages/tiling"
   dependencies:
-    "@voxel51/voodo": "npm:^0.0.34"
+    "@voxel51/voodo": "npm:^0.0.35"
     clsx: "npm:^2.1.1"
     jotai: "npm:^2.9.3"
     react-mosaic-component: "npm:^6.1.1"
@@ -8916,9 +8916,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@voxel51/voodo@npm:^0.0.34":
-  version: 0.0.34
-  resolution: "@voxel51/voodo@npm:0.0.34"
+"@voxel51/voodo@npm:^0.0.35":
+  version: 0.0.35
+  resolution: "@voxel51/voodo@npm:0.0.35"
   dependencies:
     "@dnd-kit/core": "npm:^6.3.1"
     "@dnd-kit/sortable": "npm:^10.0.0"
@@ -8935,7 +8935,7 @@ __metadata:
     react: ^18.0.0
     react-dom: ^18.0.0
     react-is: ^18.0.0
-  checksum: 10/e7ca0e9d792182805891d8e4bf8e89356112f4cd78811613108634e803494e9695457eb5d48194518a75a1e41fded08ecd730c7eed3f16e23017ccf3529502fe
+  checksum: 10/a2cc59ae1a6f2842b494363c1c918349b165cb65dbc3a2c6c6c1cb8ff6cd74336d76ebd0df455c8bbc8a8b32100461e5ea2ecd7bcc89b8684bfe66315522b09e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bumps `@voxel51/voodo` from `^0.0.34` to `^0.0.35` across all app workspaces and updates `yarn.lock` accordingly.

Workspaces updated:
- `app`
- `@fiftyone/core`
- `@fiftyone/components`
- `@fiftyone/multimodal`
- `@fiftyone/playback`
- `@fiftyone/similarity-search`
- `@fiftyone/state`
- `@fiftyone/tiling`

Verified with `yarn install` (lockfile resolves to `0.0.35`) and a successful `yarn build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2982
<!-- enterprise-sync-pr:end -->