### PR TITLE
Video annotation surface on the annotation engine

### DIFF
--- a/app/packages/app/package.json
+++ b/app/packages/app/package.json
@@ -22,6 +22,7 @@
         "@fiftyone/relay": "*",
         "@fiftyone/state": "*",
         "@fiftyone/utilities": "*",
+        "@fiftyone/video-annotation": "workspace:*",
         "@material-ui/core": "4.12.4",
         "@use-gesture/react": "10.1.1",
         "classnames": "^2.2.6",

--- a/app/packages/core/package.json
+++ b/app/packages/core/package.json
@@ -81,6 +81,7 @@
     },
     "peerDependencies": {
         "@fiftyone/annotation": "*",
+        "@fiftyone/video-annotation": "*",
         "@mui/icons-material": "*",
         "@mui/material": "*",
         "@react-spring/web": "*",

--- a/app/packages/core/src/components/Modal/ModalLooker.tsx
+++ b/app/packages/core/src/components/Modal/ModalLooker.tsx
@@ -2,6 +2,7 @@ import { useTheme } from "@fiftyone/components";
 import type { ImageLooker } from "@fiftyone/looker";
 import * as fos from "@fiftyone/state";
 import { isNativeMediaType } from "@fiftyone/utilities";
+import { VideoAnnotationSurface } from "@fiftyone/video-annotation";
 import { useAtomValue } from "jotai";
 import React from "react";
 import { useRecoilCallback, useRecoilValue } from "recoil";
@@ -97,7 +98,11 @@ const ModalLookerContent = React.memo(
     }
 
     if (video) {
-      return <VideoLookerReact sample={sample} showControls={!isAnnotate} />;
+      return isAnnotate ? (
+        <VideoAnnotationSurface sample={sample} />
+      ) : (
+        <VideoLookerReact sample={sample} showControls />
+      );
     }
 
     if (isNative) {

--- a/app/packages/video-annotation/README.md
+++ b/app/packages/video-annotation/README.md
@@ -1,0 +1,310 @@
+# @fiftyone/video-annotation
+
+Annotate video one frame at a time — draw a box, mark a keyframe, let SAM2 fill
+the gaps in between.
+
+The package is a thin, video-specific **surface** over the shared annotation
+engine. It owns gestures, the media tiles, the streams, and the timeline; the
+[`@fiftyone/annotation`](../annotation) **engine** owns label state — identity,
+transactions, undo, selection, presence, and persistence. Three ideas make the
+surface work; understand them and the rest is detail.
+
+## The three ideas
+
+**1. The renderer never sees the video.** [`@fiftyone/lighter`](../lighter) is
+an overlay engine for _still images_. So we don't show it the video at all. We
+hand it a single non-drawing overlay —
+[`ExternalCanonicalMedia`](src/media/ExternalCanonicalMedia.ts) — whose only
+job is to answer _"where on screen is the frame, and how big?"_ The actual
+pixels come from a real `<video>` element (or a `<canvas>` we paint per-frame
+bitmaps onto) sitting _behind_ Lighter's overlay layer. A sync hook locks that
+element's pan/zoom transform to Lighter's viewport, so boxes and frame move as
+one. The browser draws the picture; Lighter draws the boxes; the image renderer
+never has to know about video. The annotation toolset — selection, drag, color,
+the sidebar — works the same as it does for images.
+
+**2. Everything is a function of the playhead — through the engine.** There is
+no imperative "now load frame 47." A [playback engine](../playback) owns a
+clock; a single seam
+([`useSyncAnnotationFrameClock`](src/hooks/useSyncAnnotationFrameClock.ts))
+feeds the playhead's frame to the annotation engine, which holds every label.
+The engine's **`FrameTemporalView`** recomputes which labels are _present_ at
+that frame; its **Lighter bridge** mounts/unmounts the frame's overlays on the
+canvas, and the sidebar derives its rows from the same presence (temporal
+detections are gated by their `support` range). Move the playhead, the present
+set recomputes, everything downstream follows. The `/frames` stream is no
+longer a per-tick snapshot source — it is a read-only **seed**: it loads chunks
+and hydrates the engine's frame store, and the engine is the source of truth
+thereafter.
+
+**3. Tracks are ephemeral; frames are the truth.** On disk there are no
+"tracks" — just detections living on individual frames, tagged with an id. A
+track is something we _reconstruct_: walk the engine's labels, group them by
+`instanceId` across the clip, infer presence intervals, and draw a timeline row
+(the row id _is_ the instanceId). Keyframes mark the frames a human actually
+touched; **propagation** (linear interpolation or SAM2 tracking) fills
+everything between them. Edit a box and you've edited _one frame's_ detection —
+which is exactly what the engine persists.
+
+## Two video backends, one set of machinery
+
+The same overlay + timeline stack runs on two completely different media
+sources, chosen by a `?tile=` URL switch:
+
+|        | `?tile=video` (native)                              | `?tile=imavid` _(default)_                                                                           |
+| ------ | --------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| Pixels | a single `<video>` element                          | one materialized image **per frame** (`to_frames(sample_frames=True)`), decoded off-main in a worker |
+| Clock  | the element's `requestVideoFrameCallback` mediaTime | the image stream's frame index                                                                       |
+| Why    | cheap, streams from one URL                         | **frame-exact** — no codec seek fuzz, the right pixels for the right frame                           |
+
+There's also a third, `?labels=synthetic`, that fabricates oscillating actors
+with zero real labels — a way to exercise the whole render path in tests
+without a dataset behind it.
+
+## How a frame becomes pixels-and-boxes
+
+The read-half is entirely engine-driven: the playhead advances the engine's
+clock, the temporal view recomputes presence, and the engine reconciles the
+canvas and sidebar.
+
+```mermaid
+sequenceDiagram
+    participant PB as Playback engine
+    participant CK as frame clock<br/>(useSyncAnnotationFrameClock)
+    participant EN as AnnotationEngine
+    participant TV as FrameTemporalView
+    participant BR as engine Lighter bridge
+    participant SB as Annotation sidebar
+
+    PB->>CK: settle on frame N
+    CK->>EN: advance the engine clock to N
+    EN->>TV: recompute the present set at N
+    TV-->>BR: enter/exit → mount/unmount DetectionOverlays
+    TV-->>SB: presence-derived rows + support-gated TDs
+    Note over BR: media element pan/scaled to the viewport<br/>(useSyncMediaTransform)
+```
+
+Two video-owned reconcilers ride alongside the engine bridge:
+temporal-detection chips are sourced from the engine and synced onto the canvas
+([`useTemporalOverlaySync`](src/sync/useTemporalOverlaySync.ts)), and the media
+element tracks the viewport
+([`useSyncMediaTransform`](src/sync/useSyncMediaTransform.ts)).
+[`useVideoAnnotationSyncBundle`](src/hooks/useVideoAnnotationSyncBundle.ts)
+mounts those plus the draw-mode event bridge; each tile mounts it once.
+
+## How an edit becomes saved
+
+The loop above runs _downstream_. Editing writes _through the engine_: a
+gesture or timeline op becomes an engine **transaction**, the engine mutates
+the registered store's working set, and a central autosave drains every dirty
+sample via `engine.getJsonPatch()`.
+
+```mermaid
+sequenceDiagram
+    participant U as You<br/>(canvas · timeline · keys · sidebar)
+    participant SA as useVideoSurfaceActions
+    participant EN as AnnotationEngine
+    participant ST as VideoLabelStore<br/>(FrameStore + SampleLabelStore)
+    participant AS as annotation autosave
+
+    U->>SA: markKeyframe / extendTrack / editTemporalDetection / …
+    SA->>EN: engine.transaction(create/update/deleteLabel @ ref)
+    EN->>ST: per-frame write (ref carries frame);<br/>TDs → SampleLabelStore (no frame)
+    Note over EN: identity · undo · selection are engine-owned
+    AS->>EN: engine.getJsonPatch() per dirty sample
+    EN-->>AS: JSON-Patch ops at /frames/<n>/<field>
+```
+
+Canvas draws and drags don't go through `useVideoSurfaceActions` — the engine
+Lighter bridge commits those gestures straight to the engine. The sidebar edit
+panels write the engine directly too. In every case `annotation` aggregates the
+persistence without importing this package. See
+[the broader picture](#fitting-into-the-annotation-ecosystem).
+
+## The layers
+
+Server-backed **streams** _seed_ the engine; the engine projects state onto the
+canvas and feeds the **track** builders, which feed the **components**.
+
+```mermaid
+flowchart TB
+    subgraph streams["streams/ — read-only seed"]
+        VFLS[VideoFrameLabelsStream<br/>/frames chunks]
+        IVS[ImaVidImageStream<br/>per-frame bitmaps]
+        SLS[SyntheticLabelStream<br/>fabricated actors]
+    end
+    subgraph engine["@fiftyone/annotation — owns label state"]
+        VLS[VideoLabelStore<br/>FrameStore + SampleLabelStore]
+        TV[FrameTemporalView<br/>present set per frame]
+        BR[engine Lighter bridge]
+    end
+    subgraph tracks["tracks/ — reconstruct the timeline from the engine"]
+        FT[buildPerInstanceTracks]
+        TDT[buildTemporalDetectionTracks]
+        TEE[resolveTrackExtentEdit<br/>trim · shift · extend]
+    end
+    subgraph comp["components/ — the UI"]
+        TILE[VideoLighterTile /<br/>ImaVidLighterTile]
+        SCENE[useLighterTileScene]
+        TL[TimelineWithTracks]
+    end
+
+    VFLS -. setData seed .-> VLS
+    VLS --> TV --> BR
+    VLS --> FT & TDT
+    FT & TDT --> TL
+    TEE -. drag spans .-> TL
+    TILE --> SCENE
+    BR --> TILE
+```
+
+A handful of supporting modules round it out:
+[`useVideoSurfaceActions`](src/hooks/useVideoSurfaceActions.ts) (timeline /
+keyframe / TD edits as engine transactions),
+[`state/useVideoInteraction.ts`](src/state/useVideoInteraction.ts) (timeline
+select/hover through engine interaction, and the playhead-follows-anchor hook),
+[`propagation/`](src/propagation) (can a SAM2/linear run start, and where —
+then write the result through the engine),
+[`overlayAdapters/`](src/overlayAdapters) (raw label ↔ Lighter overlay props),
+and [`state/accessors.ts`](src/state/accessors.ts) (the _one_ place foreign
+recoil/jotai atoms are read). Persistence is no longer a video concern — the
+engine aggregates every registered store's `getJsonPatch()`.
+
+## How it's wired together
+
+`VideoAnnotationSurface` reads its two URL switches once, then nests registrars
+so each provider sees the one below it. The handler registrars sit _inside_
+`PlaybackProvider` specifically so they can read the current time — and in a
+fixed order: the frame clock and the engine store must exist before the engine
+Lighter bridge reconciles against them (otherwise the bridge binds to the
+degenerate pool view over an unseeded store).
+
+```mermaid
+flowchart TB
+    PP[PlaybackProvider snapToFrameOnSettle]
+    HR[handler registration<br/>frame clock → engine store → engine bridge →<br/>keybindings → autoInterpolate → follow-anchor]
+    RIV[RegisterImaVidImage<br/>publishes the image stream]
+    RFL[RegisterFrameLabels<br/>publishes the labels stream · gates on duration]
+    LAYOUT[layout: topbar · media tile · timeline]
+
+    PP --> HR
+    PP --> RIV --> RFL --> LAYOUT
+```
+
+> Two subtleties worth knowing before you touch this: the image stream _is_ the
+> timeline's duration source, so `RegisterImaVidImage` has to mount
+> **outside** > `RegisterFrameLabels` (which swaps its wrapper when duration
+> flips ready and would otherwise remount everything nested in it). And there's
+> deliberately no `TilingProvider` — it spins up an isolated jotai store that
+> would shadow the modal-scoped atoms the sidebar writes to.
+
+## Fitting into the annotation ecosystem
+
+This package depends on `@fiftyone/annotation`, but `annotation` does not
+depend back — the package graph is acyclic. The surface _registers_ a store, a
+Lighter bridge, and propagation agents with the engine; the engine then drives
+the read-half and pulls those registrations. Every edge points one way.
+
+```mermaid
+flowchart LR
+    VA["video-annotation"]
+    ANN["annotation (engine)"]
+    PB["playback"]
+    LI["lighter"]
+    ST["state / core"]
+
+    VA -->|registers a composite store · Lighter bridge| ANN
+    VA -->|engine transactions · interaction · presence| ANN
+    VA -->|registers propagation agents| ANN
+    VA -->|streams · timeline · frameAt| PB
+    VA -->|overlays · scene| LI
+    VA -->|reads atoms via accessors| ST
+
+    ANN -. drives the read-half: present set → bridge + sidebar .-> VA
+    ANN -. pulls registered agents · aggregates getJsonPatch .-> VA
+```
+
+The dotted edges are the inversion: once the surface registers its store and
+bridge, `annotation` owns the read-half (presence → canvas + sidebar), pulls
+registered propagation agents by id, and aggregates persistence across every
+registered store — all without knowing who registered them. There is no longer
+a command-bus or a per-package delta supplier; both were retired when the
+engine took ownership of writes and persistence.
+
+| Seam                | What crosses it                                                                                         | Mechanism                                                                      |
+| ------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| **Engine store**    | composite `VideoLabelStore` (`FrameStore` + `SampleLabelStore`), seeded from `/frames`                  | `engine.registerStore` (`useSyncAnnotationVideoStore`)                         |
+| **Frame clock**     | the playhead's current frame                                                                            | `useSyncAnnotationFrameClock` drives the engine clock                          |
+| **Canvas**          | `DetectionOverlay` add·update·remove + gesture commits                                                  | engine Lighter bridge (`useVideoLighterEngineBridge`)                          |
+| **Selection/hover** | active / hovered `instanceId`s                                                                          | engine interaction (`useVideoInteraction`; sidebar + canvas read the same)     |
+| **Sidebar**         | present frame labels + in-support temporal detections                                                   | engine temporal presence (`FrameTemporalView` → sidebar `useEntries`)          |
+| **Edits**           | `MarkKeyframe`, `Extend/Trim/Shift/Delete/UpdateTrackAttributes`, `Create/Edit/DeleteTemporalDetection` | engine transactions (`useVideoSurfaceActions`)                                 |
+| **Autosave**        | per-sample JSON-Patch deltas                                                                            | central `engine.getJsonPatch()` — no video-specific supplier                   |
+| **Propagation**     | SAM2 / linear inference results                                                                         | `annotation`'s agent registry, looked up by id; results written via the engine |
+| **Playback**        | `Track[]`, playhead time, stream registration                                                           | streams extend `PlaybackStreamBase`; tracks feed `TimelineWithTracks`          |
+| **Lighter**         | scene lifecycle                                                                                         | scene owned by `useLighterTileScene`                                           |
+| **State**           | color/dataset/view/slice/sampleId/paths (read-only)                                                     | every read goes through `state/accessors.ts`                                   |
+
+---
+
+## Reference
+
+### Public API (`index.ts`)
+
+| Symbol                                                                          | Purpose                                             |
+| ------------------------------------------------------------------------------- | --------------------------------------------------- |
+| `VideoAnnotationSurface`                                                        | Composition root — the component consumers mount.   |
+| `VideoFrameLabelsStream`, `ImaVidImageStream`, `SyntheticLabelStream`           | Playback streams (`PlaybackStreamBase` subclasses). |
+| `useFrameLabelsStream`, `useImaVidImageStream` / `usePublishImaVidImageStream`  | Published-stream-handle hooks.                      |
+| `buildTemporalDetectionTracks`, `resolveTrackExtentEdit`                        | Track builders / drag resolution.                   |
+| `useTemporalOverlaySync`, `syncTemporalOverlays`                                | Engine-sourced temporal-detection ↔ overlay sync.   |
+| `useRegisterVideoAnnotationKeybindings`, `useAutoInterpolate`                   | Behavior registrars.                                |
+| `PropagationStatusItem`, `useVideoAnnotationStatus`, `resolvePropagationTarget` | Propagation / status UI.                            |
+
+### Directory map
+
+```
+src/
+├── components/      # React UI: surface, tiles, timeline, top bar, toolbar, status
+├── streams/         # PlaybackStreamBase data sources (read-only seed) + handles + worker
+├── sync/            # the reconcilers left after the engine took the canvas/sidebar
+├── tracks/          # engine-sourced timeline-row builders + drag/extent + identity
+├── hooks/           # scene/clock/bridge orchestration + engine-write surface actions
+├── state/           # foreign-atom accessors + frame/interaction seams + status slot
+├── media/           # ExternalCanonicalMedia (non-drawing canonical overlay)
+├── propagation/     # propagation target resolution + result application (engine-write)
+├── overlayAdapters/ # raw label ↔ Lighter overlay-prop adapters
+└── utils/           # stream/tile id constants + modal-sample accessors
+```
+
+| Directory          | Key modules                                                                                                                                                                                                                                                                                                                                                                           | Role                                                                                   |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `components/`      | `VideoAnnotationSurface`, `VideoLighterTile`, `ImaVidLighterTile`, `FrameLabels`, `SyntheticLabels`, `RegisterImaVidImage`, `VideoAnnotationTopBar`, `VideoAnnotationToolbar`, `PropagationStatusItem`                                                                                                                                                                                | Composition root, media tiles, timeline, chrome.                                       |
+| `streams/`         | `VideoFrameLabelsStream`, `ImaVidImageStream`, `SyntheticLabelStream`, `frameLabelsStream`, `imaVidImageStreamHandle`, `createStreamHandle`, `framesData`, `fetchedRanges`, `framesWorker`                                                                                                                                                                                            | Server-backed streams that seed the engine + the published-handle factory + decode.    |
+| `sync/`            | `useTemporalOverlaySync`, `useSyncLighterAnnotation`, `useSyncMediaTransform`                                                                                                                                                                                                                                                                                                         | Engine-sourced TD chips, the draw-mode / mode-quit event bridge, media transform.      |
+| `tracks/`          | `frameTracks`, `temporalDetectionTracks`, `syntheticTracks`, `trackExtentEdit`, `trackIdentity`, `useVideoTrackDecorator`, `autoExtend`                                                                                                                                                                                                                                               | Build `Track[]` rows from the engine; trim/shift/extend; row ↔ engine identity.        |
+| `hooks/`           | `useLighterTileScene`, `useVideoLighterEngineBridge`, `useSyncAnnotationVideoStore`, `useSyncAnnotationFrameClock`, `useFrameClock`, `useVideoSurfaceActions`, `useVideoAnnotationActions`, `useVideoPropagate`, `useVideoAnnotationSyncBundle`, `useWarmupThenSeek`, `useTemporalOverlayVersion`, `useAutoInterpolate`, `useRegisterVideoAnnotationKeybindings`, `useVfcClockSource` | Scene lifecycle, engine store/bridge/clock registration, engine-write surface actions. |
+| `state/`           | `accessors`, `useCurrentFrame`, `useVideoInteraction`, `videoAnnotationStatus`                                                                                                                                                                                                                                                                                                        | Foreign atoms; the frame source + engine-interaction seam; the top-bar status slot.    |
+| `media/`           | `ExternalCanonicalMedia`                                                                                                                                                                                                                                                                                                                                                              | Intrinsic + letterbox bounds for media Lighter doesn't paint.                          |
+| `propagation/`     | `propagationTarget`, `useApplyPropagationResult`                                                                                                                                                                                                                                                                                                                                      | Resolve a propagation run; write SAM2/linear results through the engine.               |
+| `overlayAdapters/` | `detection`, `index`, `types`                                                                                                                                                                                                                                                                                                                                                         | Typed label ↔ overlay-prop registry (`detection` wired); `VideoDetectionLabel` type.   |
+| `utils/`           | `ids`, `modalSample`                                                                                                                                                                                                                                                                                                                                                                  | Stream/tile id constants; `getModalSampleFrameRate`.                                   |
+
+### Development
+
+```bash
+# tests (root vitest)
+cd app && ./node_modules/.bin/vitest run --no-coverage packages/video-annotation
+
+# lint (eslint v9, package-local)
+cd app/packages/video-annotation && node_modules/.bin/eslint src index.ts
+
+# package type-check — pulls the whole import graph, so filter to va files
+cd app && node_modules/.bin/tsc --noEmit -p packages/video-annotation/tsconfig.json \
+  2>&1 | grep "packages/video-annotation"
+```
+
+State is managed with **jotai**; foreign atoms are read only through
+`state/accessors.ts`, and module atoms stay private behind read/write hooks
+rather than being exported. Every label read and write goes through the
+annotation engine — never a stream cache or a store directly.

--- a/app/packages/video-annotation/eslint.config.mjs
+++ b/app/packages/video-annotation/eslint.config.mjs
@@ -1,0 +1,30 @@
+import { fixupConfigRules } from "@eslint/compat";
+import hooksPlugin from "eslint-plugin-react-hooks";
+import pluginReactConfig from "eslint-plugin-react/configs/recommended.js";
+import pluginReactJSXRuntime from "eslint-plugin-react/configs/jsx-runtime.js";
+import globals from "globals";
+import tseslint from "typescript-eslint";
+
+export default [
+  { ignores: ["dist/**", "node_modules/**", "**/*.config.*"] },
+  { languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } } },
+  { languageOptions: { globals: globals.browser } },
+  ...tseslint.configs.recommended,
+  ...fixupConfigRules(pluginReactConfig),
+  // Automatic JSX runtime (tsconfig `jsx: "react-jsx"`) — disables
+  // react-in-jsx-scope / jsx-uses-react, which are false positives here.
+  ...fixupConfigRules(pluginReactJSXRuntime),
+  {
+    files: ["**/*.{ts,tsx}"],
+    settings: { react: { version: "detect" } },
+    plugins: { "react-hooks": hooksPlugin },
+    rules: {
+      ...hooksPlugin.configs.recommended.rules,
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
+      "react/display-name": "off",
+    },
+  },
+];

--- a/app/packages/video-annotation/index.ts
+++ b/app/packages/video-annotation/index.ts
@@ -1,0 +1,52 @@
+export { VideoAnnotationSurface } from "./src/components/VideoAnnotationSurface";
+export { SyntheticLabelStream } from "./src/streams/SyntheticLabelStream";
+export type {
+  FrameLabelSnapshot,
+  PropagationBlob,
+  PropagationMethod,
+  SyntheticBox,
+} from "./src/streams/SyntheticLabelStream";
+export {
+  IMAVID_STREAM_ID,
+  LABELS_STREAM_ID,
+  MAIN_TILE_ID,
+  VIDEO_STREAM_ID,
+} from "./src/utils/ids";
+export { ImaVidImageStream } from "./src/streams/ImaVidImageStream";
+export type { ImaVidImageFrame } from "./src/streams/ImaVidImageStream";
+export { useFrameLabelsStream } from "./src/streams/frameLabelsStream";
+export {
+  useImaVidImageStream,
+  usePublishImaVidImageStream,
+} from "./src/streams/imaVidImageStreamHandle";
+export { PropagationStatusItem } from "./src/components/PropagationStatusItem";
+export { useVideoAnnotationStatus } from "./src/state/videoAnnotationStatus";
+export type { VideoAnnotationStatusContent } from "./src/state/videoAnnotationStatus";
+export { resolvePropagationTarget } from "./src/propagation/propagationTarget";
+export type { PropagationTarget } from "./src/propagation/propagationTarget";
+export { resolveTrackExtentEdit } from "./src/tracks/trackExtentEdit";
+export type {
+  ResolveTrackExtentEditInput,
+  TrackDragMode,
+  TrackExtentEdit,
+} from "./src/tracks/trackExtentEdit";
+export { VideoFrameLabelsStream } from "./src/streams/VideoFrameLabelsStream";
+export type {
+  LocalDetection,
+  RawDetection,
+  RawDetectionsField,
+} from "./src/streams/VideoFrameLabelsStream";
+export { buildTemporalDetectionTracks } from "./src/tracks/temporalDetectionTracks";
+export type {
+  RawTemporalDetection,
+  RawTemporalDetectionsField,
+  TemporalDetectionLabelLike,
+  TemporalDetectionEventData,
+  BuildTemporalDetectionTracksInput,
+} from "./src/tracks/temporalDetectionTracks";
+export {
+  syncTemporalOverlays,
+  useTemporalOverlaySync,
+} from "./src/sync/useTemporalOverlaySync";
+export { useAutoInterpolate } from "./src/hooks/useAutoInterpolate";
+export { useRegisterVideoAnnotationKeybindings } from "./src/hooks/useRegisterVideoAnnotationKeybindings";

--- a/app/packages/video-annotation/package.json
+++ b/app/packages/video-annotation/package.json
@@ -1,0 +1,34 @@
+{
+    "name": "@fiftyone/video-annotation",
+    "main": "./index.ts",
+    "packageManager": "yarn@4.9.1",
+    "scripts": {
+        "lint": "eslint src index.ts",
+        "lint:fix": "eslint src index.ts --fix",
+        "typecheck": "tsc --noEmit -p tsconfig.json"
+    },
+    "dependencies": {
+        "@fiftyone/annotation": "workspace:*",
+        "@fiftyone/command-bus": "workspace:*",
+        "@fiftyone/commands": "workspace:*",
+        "@fiftyone/components": "workspace:*",
+        "@fiftyone/lighter": "workspace:*",
+        "@fiftyone/playback": "workspace:*",
+        "@fiftyone/state": "workspace:*",
+        "@fiftyone/tiling": "workspace:*",
+        "@fiftyone/utilities": "workspace:*",
+        "@voxel51/voodo": "^0.0.30",
+        "clsx": "^2.1.0",
+        "jotai": "^2.9.3",
+        "lru-cache": "^11.0.1"
+    },
+    "devDependencies": {
+        "@eslint/compat": "^1.1.1",
+        "eslint": "9.7.0",
+        "eslint-plugin-react": "^7.35.0",
+        "eslint-plugin-react-hooks": "rc",
+        "globals": "^15.8.0",
+        "typescript-eslint": "^7.17.0",
+        "vite": "^7.3.2"
+    }
+}

--- a/app/packages/video-annotation/src/components/FrameLabels.tsx
+++ b/app/packages/video-annotation/src/components/FrameLabels.tsx
@@ -1,0 +1,614 @@
+import {
+  useActiveSampleId,
+  useAnnotationEngine,
+  useEngineSelector,
+} from "@fiftyone/annotation";
+import {
+  getLabelColorFromContext,
+  TemporalOverlay,
+  useLighter,
+} from "@fiftyone/lighter";
+import type { ModalSample } from "@fiftyone/state";
+import type { Stage } from "@fiftyone/utilities";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import {
+  useActiveDetectionField,
+  useColorScheme,
+  useColorSeed,
+  useDatasetName,
+  useGroupSlice,
+  useModalSampleId,
+  useView,
+} from "../state/accessors";
+import { useTemporalOverlayVersion } from "../hooks/useTemporalOverlayVersion";
+import { useWarmupThenSeek } from "../hooks/useWarmupThenSeek";
+import {
+  TimelineWithTracks,
+  TrackProvider,
+  type Track,
+  useDuration,
+  usePlaybackStream,
+} from "@fiftyone/playback";
+import {
+  useFrameLabelsStream,
+  usePublishFrameLabelsStream,
+} from "../streams/frameLabelsStream";
+import {
+  buildPerInstanceTracks,
+  type PerInstanceLabel,
+} from "../tracks/frameTracks";
+import { LABELS_STREAM_ID } from "../utils/ids";
+import { getModalSampleFrameRate } from "../utils/modalSample";
+import { resolveTrackExtentEdit } from "../tracks/trackExtentEdit";
+import { useVideoTrackDecorator } from "../tracks/useVideoTrackDecorator";
+import { useScrollTrackToAnchor } from "../state/useVideoInteraction";
+import {
+  useVideoSurfaceActions,
+  type VideoSurfaceActions,
+} from "../hooks/useVideoSurfaceActions";
+import {
+  buildTemporalDetectionTracks,
+  type TemporalDetectionEventData,
+  type TemporalDetectionLabelLike,
+} from "../tracks/temporalDetectionTracks";
+import { VideoFrameLabelsStream } from "../streams/VideoFrameLabelsStream";
+import { VideoAnnotationToolbar } from "./VideoAnnotationToolbar";
+
+const DEFAULT_FRAME_FIELD = "frames.detections";
+
+/** Base linked-overlay decoration the interaction layer attaches per row. */
+type BaseTrackDecoration = ReturnType<
+  ReturnType<typeof useVideoTrackDecorator>
+>;
+
+/** Decoration a track row contributes to {@link TimelineWithTracks}. */
+type TrackDecoration = BaseTrackDecoration & {
+  snapStepSec?: number;
+  eventDeleteConfig?: { label: string; onDelete: () => void };
+  onEventEdit?: (
+    eventIndex: number,
+    newStartSec: number,
+    newEndSec: number,
+    mode: "resize-start" | "resize-end" | "move"
+  ) => void;
+};
+
+/** Resolves the row color for a per-frame object track. */
+type ObjectTrackColorResolver = (label: PerInstanceLabel) => string;
+
+/** Resolves the row color for a temporal-detection track. */
+type TemporalDetectionColorResolver = (
+  path: string,
+  label: TemporalDetectionLabelLike
+) => string;
+
+/** Strip the `frames.` prefix so the value matches what `/frames` returns. */
+const toPerFrameField = (field: string): string =>
+  field.startsWith("frames.") ? field.slice("frames.".length) : field;
+
+/**
+ * Reads the params needed to construct a real `/frames`-backed labels
+ * stream, waits until duration is known (so we can derive `frameCount`),
+ * then mounts the registrar with an identity key so a fresh stream cleanly
+ * replaces the old one through usePlaybackStream's lifecycle. The active
+ * stream is published via {@link usePublishFrameLabelsStream} for consumers
+ * outside the registrar's subtree.
+ */
+export const RegisterFrameLabels: React.FC<{
+  sample: ModalSample;
+  children: React.ReactNode;
+}> = ({ sample, children }) => {
+  const duration = useDuration();
+  const dataset = useDatasetName();
+  const view = useView();
+  const slice = useGroupSlice();
+  const sampleId = useModalSampleId();
+  // Source of truth for which per-frame list this stream reads + patches.
+  // Default while the schema resolves avoids a tear-down/re-mount churn.
+  const activeField = useActiveDetectionField() ?? DEFAULT_FRAME_FIELD;
+
+  const frameRate = getModalSampleFrameRate(sample);
+  const ready =
+    duration > 0 &&
+    !!sampleId &&
+    !!dataset &&
+    frameRate !== undefined &&
+    Number.isFinite(frameRate);
+
+  if (!ready) {
+    // Params incomplete; consumers read `null` until the registrar mounts.
+    return <>{children}</>;
+  }
+
+  const frameCount = Math.max(1, Math.round(duration * frameRate));
+  const frameField = toPerFrameField(activeField);
+
+  // Stream-identity key: changing any input re-mounts the registrar so
+  // usePlaybackStream's cleanup unregisters the old stream.
+  const key = `${sampleId}|${dataset}|${
+    slice ?? ""
+  }|${frameRate}|${frameCount}|${frameField}`;
+
+  return (
+    <FrameLabelsRegistration
+      key={key}
+      sampleId={sampleId}
+      dataset={dataset}
+      view={view}
+      groupSlice={slice ?? null}
+      frameCount={frameCount}
+      frameRate={frameRate}
+      frameField={frameField}
+    >
+      {children}
+    </FrameLabelsRegistration>
+  );
+};
+
+interface FrameLabelsRegistrationProps {
+  sampleId: string;
+  dataset: string;
+  view: Stage[];
+  groupSlice: string | null;
+  frameCount: number;
+  frameRate: number;
+  frameField: string;
+  children: React.ReactNode;
+}
+
+const FrameLabelsRegistration: React.FC<FrameLabelsRegistrationProps> = ({
+  children,
+  ...props
+}) => {
+  // Construct once per mount; the parent re-mounts on identity changes.
+  const streamRef = useRef<VideoFrameLabelsStream | null>(null);
+  if (streamRef.current === null) {
+    streamRef.current = new VideoFrameLabelsStream({
+      id: LABELS_STREAM_ID,
+      sampleId: props.sampleId,
+      dataset: props.dataset,
+      view: props.view,
+      groupSlice: props.groupSlice,
+      frameCount: props.frameCount,
+      frameRate: props.frameRate,
+      frameField: props.frameField,
+    });
+  }
+
+  usePlaybackStream(streamRef.current);
+
+  // Publish so consumers above the surface reach it via useFrameLabelsStream.
+  usePublishFrameLabelsStream(streamRef.current);
+
+  // Prefetch + seek t=0 so overlays paint on first load, not on first play.
+  useWarmupThenSeek(streamRef.current);
+
+  return <>{children}</>;
+};
+
+/**
+ * Build the per-instance object tracks by warming every chunk so the engine
+ * re-hydrates across the whole clip, then walking the engine. Returns `[]`
+ * until warmup resolves; `resolved` flips true on the first resolved build
+ * (including a legitimately empty clip) to gate the pin bootstrap.
+ */
+function useFrameDerivedTracks(resolveColor: ObjectTrackColorResolver): {
+  tracks: Track[];
+  resolved: boolean;
+} {
+  const stream = useFrameLabelsStream();
+  const engine = useAnnotationEngine();
+  const sampleId = useActiveSampleId();
+  const path = stream ? `frames.${stream.labelsField}` : null;
+
+  const [tracks, setTracks] = useState<Track[]>([]);
+  const [resolved, setResolved] = useState(false);
+
+  // engine version is the rebuild signal.
+  const engineVersion = useEngineSelector(engine, () => engine.getVersion());
+
+  useEffect(() => {
+    if (!stream || !sampleId || !path) {
+      setTracks([]);
+      setResolved(false);
+      return undefined;
+    }
+
+    let cancelled = false;
+
+    void stream.warmupAll().then(() => {
+      if (cancelled) {
+        return;
+      }
+
+      setTracks(
+        buildPerInstanceTracks({
+          engine,
+          sample: sampleId,
+          path,
+          totalFrames: stream.totalFrames,
+          fps: stream.fps,
+          resolveColor,
+        })
+      );
+      setResolved(true);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- engineVersion is the invalidation signal
+  }, [engine, sampleId, path, stream, resolveColor, engineVersion]);
+
+  return { tracks, resolved };
+}
+
+/**
+ * Derive TD tracks from the scene's live `TemporalOverlay` set rather than
+ * the sample, which lags an autosave behind local edits. `useTemporalOverlaySync`
+ * primes the overlays from the sample on first load.
+ */
+function useTemporalDetectionTracks(
+  sample: ModalSample | undefined,
+  resolveColor: TemporalDetectionColorResolver
+): Track[] {
+  const { scene } = useLighter();
+  const tdVersion = useTemporalOverlayVersion(scene, {
+    listenLabelEdit: true,
+    bumpOnSceneReady: true,
+  });
+  const frameRate = getModalSampleFrameRate(sample);
+
+  return useMemo(() => {
+    if (!scene) {
+      return [];
+    }
+
+    if (
+      frameRate === undefined ||
+      !Number.isFinite(frameRate) ||
+      frameRate <= 0
+    ) {
+      return [];
+    }
+
+    const temporalOverlays = scene
+      .getAllOverlays()
+      .filter((o): o is TemporalOverlay => o instanceof TemporalOverlay);
+
+    return buildTemporalDetectionTracks({
+      sample: buildVirtualTemporalSample(temporalOverlays),
+      fps: frameRate,
+      resolveColor,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- tdVersion is the invalidation signal
+  }, [scene, frameRate, resolveColor, tdVersion]);
+}
+
+/** Build the row-color resolvers, kept in lock-step with the overlays. */
+function useTrackColorResolvers(path: string | null): {
+  resolveObjectColor: ObjectTrackColorResolver;
+  resolveTemporalDetectionColor: TemporalDetectionColorResolver;
+} {
+  const scheme = useColorScheme();
+  const seed = useColorSeed();
+  const activeField = useActiveDetectionField() ?? DEFAULT_FRAME_FIELD;
+
+  // Color by the ENGINE path (`frames.detections`) to match the sidebar and
+  // canvas; the schema-namespace `activeField` keys a different scheme entry.
+  const resolveObjectColor = useCallback(
+    (label: PerInstanceLabel) =>
+      getLabelColorFromContext(path ?? activeField, label, {
+        colorScheme: scheme,
+        seed,
+      }),
+    [path, activeField, scheme, seed]
+  );
+
+  const resolveTemporalDetectionColor = useCallback(
+    (tdPath: string, label: TemporalDetectionLabelLike) =>
+      getLabelColorFromContext(tdPath, label, {
+        colorScheme: scheme,
+        seed,
+      }),
+    [scheme, seed]
+  );
+
+  return { resolveObjectColor, resolveTemporalDetectionColor };
+}
+
+/** Build the row decorator that wires presence-bar edits + delete per kind. */
+function useTrackDecorator(
+  sample: ModalSample | undefined
+): (track: Track) => TrackDecoration {
+  const baseDecorate = useVideoTrackDecorator();
+  const actions = useVideoSurfaceActions();
+  const stream = useFrameLabelsStream();
+  const fps = getModalSampleFrameRate(sample);
+  const snapStepSec =
+    Number.isFinite(fps) && fps && fps > 0 ? 1 / fps : undefined;
+
+  return useCallback(
+    (track: Track): TrackDecoration => {
+      const base = baseDecorate(track);
+      if (!fps) {
+        return base;
+      }
+
+      // A TD row is identified by its structured event payload; anything else
+      // is an engine-addressed object track (row id == instanceId).
+      const tdEvent = track.events[0]?.data as
+        | TemporalDetectionEventData
+        | undefined;
+      const isObjectTrack = tdEvent?.detectionId === undefined;
+
+      if (isObjectTrack && stream) {
+        return decorateObjectTrack({
+          track,
+          base,
+          snapStepSec,
+          fps,
+          totalFrames: stream.totalFrames,
+          actions,
+        });
+      }
+
+      // Object track with no stream yet: can't wire frame edits — base only.
+      if (isObjectTrack) {
+        return base;
+      }
+
+      return decorateTemporalDetectionTrack({
+        tdEvent: tdEvent as TemporalDetectionEventData,
+        base,
+        snapStepSec,
+        fps,
+        actions,
+      });
+    },
+    [baseDecorate, fps, snapStepSec, actions, stream]
+  );
+}
+
+/**
+ * Labels track timeline — one row per tracked instance (grouped by `index`)
+ * plus one row per `TemporalDetection` (rendered as a `support`-spanning
+ * interval). Untracked labels still paint as overlays but get no rows.
+ *
+ * One-shot re-key on the empty→ready transition so `initialPinnedIds` (read
+ * only at mount) bootstraps from the real frame-track list; later recolors
+ * update through the live `tracks` prop and preserve the user's pin state.
+ */
+export const FrameLabelsTracks: React.FC<{ sample?: ModalSample }> = ({
+  sample,
+}) => {
+  const stream = useFrameLabelsStream();
+  const path = stream ? `frames.${stream.labelsField}` : null;
+
+  const { resolveObjectColor, resolveTemporalDetectionColor } =
+    useTrackColorResolvers(path);
+
+  const { tracks: frameTracks, resolved: frameTracksResolved } =
+    useFrameDerivedTracks(resolveObjectColor);
+  const temporalDetectionTracks = useTemporalDetectionTracks(
+    sample,
+    resolveTemporalDetectionColor
+  );
+
+  const tracks = useMemo(
+    () => [...frameTracks, ...temporalDetectionTracks],
+    [frameTracks, temporalDetectionTracks]
+  );
+  const pinned = useMemo(() => tracks.map((t) => t.id), [tracks]);
+
+  // Bootstrap on frame-tracks-resolved, not `tracks.length`: TD tracks resolve
+  // synchronously and would otherwise trip the empty→ready flip before frame
+  // tracks land, leaving frame tracks unpinned.
+  const ready = frameTracksResolved;
+
+  useScrollTrackToAnchor();
+  const decorateTrack = useTrackDecorator(sample);
+
+  return (
+    <TrackProvider
+      key={ready ? "ready" : "init"}
+      tracks={tracks}
+      initialPinnedIds={pinned}
+    >
+      <TimelineWithTracks
+        decorateTrack={decorateTrack}
+        extraControls={<VideoAnnotationToolbar />}
+      />
+    </TrackProvider>
+  );
+};
+
+/** Decorate an object track: snap, delete, and presence-bar drag edits. */
+function decorateObjectTrack({
+  track,
+  base,
+  snapStepSec,
+  fps,
+  totalFrames,
+  actions,
+}: {
+  track: Track;
+  base: BaseTrackDecoration;
+  snapStepSec: number | undefined;
+  fps: number;
+  totalFrames: number;
+  actions: VideoSurfaceActions;
+}): TrackDecoration {
+  return {
+    ...base,
+    snapStepSec,
+    eventDeleteConfig: {
+      label: "Delete track",
+      onDelete: () => actions.deleteTrack(track.id),
+    },
+    onEventEdit: (eventIndex, newStartSec, newEndSec, mode) =>
+      applyObjectTrackEdit({
+        track,
+        eventIndex,
+        newStartSec,
+        newEndSec,
+        mode,
+        fps,
+        totalFrames,
+        actions,
+      }),
+  };
+}
+
+/** Decorate a TD track: snap, delete, and interval drag edits. */
+function decorateTemporalDetectionTrack({
+  tdEvent,
+  base,
+  snapStepSec,
+  fps,
+  actions,
+}: {
+  tdEvent: TemporalDetectionEventData;
+  base: BaseTrackDecoration;
+  snapStepSec: number | undefined;
+  fps: number;
+  actions: VideoSurfaceActions;
+}): TrackDecoration {
+  return {
+    ...base,
+    snapStepSec,
+    eventDeleteConfig: {
+      label: "Delete track",
+      onDelete: () =>
+        actions.deleteTemporalDetection(tdEvent.fieldPath, tdEvent.detectionId),
+    },
+    onEventEdit: (_eventIndex, newStartSec, newEndSec) =>
+      applyTemporalDetectionEdit({
+        tdEvent,
+        newStartSec,
+        newEndSec,
+        fps,
+        actions,
+      }),
+  };
+}
+
+/**
+ * Project scene `TemporalOverlay`s into a sample-shaped dict so
+ * {@link buildTemporalDetectionTracks} consumes live overlay state the same
+ * way it consumes a server sample.
+ */
+function buildVirtualTemporalSample(
+  overlays: TemporalOverlay[]
+): Record<string, unknown> {
+  const byField = new Map<string, unknown[]>();
+  for (const overlay of overlays) {
+    const detections = byField.get(overlay.field) ?? [];
+    detections.push(overlay.label);
+    byField.set(overlay.field, detections);
+  }
+
+  const virtualSample: Record<string, unknown> = {};
+  for (const [field, detections] of byField) {
+    virtualSample[field] = { _cls: "TemporalDetections", detections };
+  }
+
+  return virtualSample;
+}
+
+/**
+ * Apply an object-track presence-bar drag: resolve it to an extend / trim /
+ * shift edit and dispatch the matching command. No-op for a degenerate drag.
+ */
+function applyObjectTrackEdit({
+  track,
+  eventIndex,
+  newStartSec,
+  newEndSec,
+  mode,
+  fps,
+  totalFrames,
+  actions,
+}: {
+  track: Track;
+  eventIndex: number;
+  newStartSec: number;
+  newEndSec: number;
+  mode: "resize-start" | "resize-end" | "move";
+  fps: number;
+  totalFrames: number;
+  actions: VideoSurfaceActions;
+}): void {
+  const dragged = track.events[eventIndex];
+  if (!dragged || dragged.endSec === undefined) {
+    return;
+  }
+
+  // Other presence bars of this track — used to clamp a move against neighbors.
+  const neighborSegments = track.events
+    .filter((e, i) => i !== eventIndex && e.endSec !== undefined)
+    .map(
+      (e) =>
+        [
+          Math.round(e.startSec * fps) + 1,
+          Math.round((e.endSec as number) * fps),
+        ] as const
+    );
+
+  const edit = resolveTrackExtentEdit({
+    mode,
+    origStartSec: dragged.startSec,
+    origEndSec: dragged.endSec,
+    newStartSec,
+    newEndSec,
+    fps,
+    totalFrames,
+    neighborSegments,
+  });
+
+  switch (edit.op) {
+    case "extend":
+      actions.extendTrack(track.id, edit.sourceFrame, edit.targetFrames);
+      break;
+    case "trim":
+      actions.trimTrack(track.id, edit.frames);
+      break;
+    case "shift":
+      actions.shiftTrack(track.id, edit.frames, edit.delta);
+      break;
+    default:
+      break;
+  }
+}
+
+/**
+ * Apply a TD interval drag: convert the dragged seconds back to a 1-indexed
+ * inclusive frame `support` and dispatch the edit. Inverts the build's
+ * mapping: `startSec = (firstFrame - 1) / fps`, `endSec = lastFrame / fps`.
+ */
+function applyTemporalDetectionEdit({
+  tdEvent,
+  newStartSec,
+  newEndSec,
+  fps,
+  actions,
+}: {
+  tdEvent: TemporalDetectionEventData;
+  newStartSec: number;
+  newEndSec: number;
+  fps: number;
+  actions: VideoSurfaceActions;
+}): void {
+  const firstFrame = Math.max(1, Math.round(newStartSec * fps) + 1);
+  const lastFrame = Math.max(firstFrame, Math.round(newEndSec * fps));
+
+  actions.editTemporalDetection(tdEvent.fieldPath, tdEvent.detectionId, {
+    support: [firstFrame, lastFrame],
+  });
+}

--- a/app/packages/video-annotation/src/components/ImaVidLighterTile.module.css
+++ b/app/packages/video-annotation/src/components/ImaVidLighterTile.module.css
@@ -1,0 +1,30 @@
+.body {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  background: black;
+  overflow: hidden;
+}
+
+.frame {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  z-index: 0;
+  user-select: none;
+  pointer-events: none;
+  /* Mirrors the Lighter viewport transform (see useSyncMediaTransform): the
+     origin must be the container's top-left so `translate(pan) scale()` lines
+     up with the overlays' pan + scale·world mapping. */
+  transform-origin: 0 0;
+  will-change: transform;
+}
+
+.lighterHost {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  display: flex;
+}

--- a/app/packages/video-annotation/src/components/ImaVidLighterTile.tsx
+++ b/app/packages/video-annotation/src/components/ImaVidLighterTile.tsx
@@ -1,0 +1,107 @@
+import React, { useEffect, useRef, useState } from "react";
+import { useStream } from "@fiftyone/playback";
+import { useLighterTileScene } from "../hooks/useLighterTileScene";
+import { useVideoAnnotationSyncBundle } from "../hooks/useVideoAnnotationSyncBundle";
+import { IMAVID_STREAM_ID } from "../utils/ids";
+import type { ImaVidImageFrame } from "../streams/ImaVidImageStream";
+import styles from "./ImaVidLighterTile.module.css";
+
+interface ImageDimensions {
+  w: number;
+  h: number;
+}
+
+/**
+ * Paint each decoded frame's bitmap into `canvasRef`, sizing the drawing
+ * buffer to the bitmap's intrinsic dimensions (CSS keeps the element fitting
+ * the host via `object-fit: contain`). Returns the current intrinsic
+ * dimensions, which the caller feeds to the scene as canonical-media size.
+ *
+ * Smoothing is disabled around the draw so pixel-exact frames don't blur.
+ */
+function usePaintFrameToCanvas(
+  frame: ImaVidImageFrame | undefined,
+  canvasRef: React.RefObject<HTMLCanvasElement | null>
+): ImageDimensions | null {
+  const [dims, setDims] = useState<ImageDimensions | null>(null);
+
+  useEffect(() => {
+    if (!frame) {
+      return;
+    }
+
+    const canvasEl = canvasRef.current;
+    if (!canvasEl) {
+      return;
+    }
+
+    const w = frame.bitmap.width;
+    const h = frame.bitmap.height;
+    if (canvasEl.width !== w) {
+      canvasEl.width = w;
+    }
+
+    if (canvasEl.height !== h) {
+      canvasEl.height = h;
+    }
+
+    const ctx = canvasEl.getContext("2d");
+    if (!ctx) {
+      return;
+    }
+
+    const priorImageSmoothing = ctx.imageSmoothingEnabled;
+    ctx.imageSmoothingEnabled = false;
+    ctx.drawImage(frame.bitmap, 0, 0);
+    ctx.imageSmoothingEnabled = priorImageSmoothing;
+
+    if (dims === null || dims.w !== w || dims.h !== h) {
+      setDims({ w, h });
+    }
+  }, [frame, dims, canvasRef]);
+
+  return dims;
+}
+
+/**
+ * ImaVid tile — draws each frame's `ImageBitmap` (decoded off-main in
+ * `framesWorker`) into a `<canvas>` and overlays Lighter on top.
+ *
+ * Drawn via 2D `drawImage`, not a `bitmaprenderer` context, because the LRU
+ * may serve the same bitmap again (a revisited frame) and
+ * `transferFromImageBitmap` would consume it.
+ */
+export const ImaVidLighterTile: React.FC = () => {
+  const sourceId = IMAVID_STREAM_ID;
+
+  const lighterHostRef = useRef<HTMLDivElement | null>(null);
+  const frameCanvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  // Latest decoded frame; the image stream dedupes on frameNumber so this
+  // only changes when the frame actually changes.
+  const frame = useStream<ImaVidImageFrame>(sourceId);
+
+  const imageDims = usePaintFrameToCanvas(frame, frameCanvasRef);
+
+  // Scene lifecycle: once-per-mount scene; `dims` from the decoded bitmap.
+  const { scene, canonicalMediaReady } = useLighterTileScene({
+    hostRef: lighterHostRef,
+    dims: imageDims,
+    sceneIdPrefix: "imavid-anno",
+  });
+
+  // Overlay / sidebar sync. `frameCanvasRef` keeps the frame canvas
+  // zoomed/panned with the Lighter viewport so scroll-zoom scales the picture.
+  useVideoAnnotationSyncBundle({
+    scene,
+    canonicalMediaReady,
+    mediaRef: frameCanvasRef,
+  });
+
+  return (
+    <div className={styles.body}>
+      <canvas ref={frameCanvasRef} className={styles.frame} />
+      <div ref={lighterHostRef} className={styles.lighterHost} />
+    </div>
+  );
+};

--- a/app/packages/video-annotation/src/components/PropagationStatusItem.tsx
+++ b/app/packages/video-annotation/src/components/PropagationStatusItem.tsx
@@ -1,0 +1,56 @@
+import {
+  Align,
+  Button,
+  Orientation,
+  Size,
+  Spacing,
+  Spinner,
+  Stack,
+  Text,
+  TextColor,
+  TextVariant,
+  Variant,
+} from "@voxel51/voodo";
+import React from "react";
+
+/**
+ * Right-hand top-bar status content for an in-flight propagation run. Drive
+ * it through {@link useVideoAnnotationStatus}'s `setContent`: re-set on each
+ * progress tick and clear (`null`) on completion. The `done`/`total` count
+ * is shown only when both are provided — omit them for indeterminate phases
+ * (e.g. one-time model download). `onStop`, when provided, renders a Stop
+ * button — propagation polls the same flag via `shouldAbort`.
+ *
+ * @example
+ * setContent(<PropagationStatusItem label="Loading SAM2…" onStop={stop} />);
+ * setContent(<PropagationStatusItem label="SAM2 tracking" done={n} total={t} onStop={stop} />);
+ */
+export const PropagationStatusItem: React.FC<{
+  label: string;
+  done?: number;
+  total?: number;
+  onStop?: () => void;
+}> = ({ label, done, total, onStop }) => {
+  const text =
+    typeof done === "number" && typeof total === "number"
+      ? `${label} ${done}/${total}`
+      : label;
+
+  return (
+    <Stack
+      orientation={Orientation.Row}
+      align={Align.Center}
+      spacing={Spacing.Sm}
+    >
+      <Spinner size={Size.Sm} />
+      <Text variant={TextVariant.Sm} color={TextColor.Secondary}>
+        {text}
+      </Text>
+      {onStop && (
+        <Button variant={Variant.Secondary} size={Size.Sm} onClick={onStop}>
+          Stop
+        </Button>
+      )}
+    </Stack>
+  );
+};

--- a/app/packages/video-annotation/src/components/RegisterImaVidImage.test.ts
+++ b/app/packages/video-annotation/src/components/RegisterImaVidImage.test.ts
@@ -1,0 +1,28 @@
+import type { ModalSample } from "@fiftyone/state";
+import { describe, expect, it } from "vitest";
+import { resolveFrameCount } from "./RegisterImaVidImage";
+
+const sampleWith = (metadata: Record<string, unknown>): ModalSample =>
+  ({ sample: { metadata } } as unknown as ModalSample);
+
+describe("resolveFrameCount", () => {
+  it("prefers total_frame_count, rounded", () => {
+    expect(
+      resolveFrameCount(sampleWith({ total_frame_count: 119.6 }), 30)
+    ).toBe(120);
+  });
+
+  it("falls back to duration * frameRate when total_frame_count is absent", () => {
+    expect(resolveFrameCount(sampleWith({ duration: 4 }), 30)).toBe(120);
+  });
+
+  it("ignores a non-positive total_frame_count and uses duration", () => {
+    expect(
+      resolveFrameCount(sampleWith({ total_frame_count: 0, duration: 2 }), 30)
+    ).toBe(60);
+  });
+
+  it("throws when neither total_frame_count nor duration is present", () => {
+    expect(() => resolveFrameCount(sampleWith({}), 30)).toThrow();
+  });
+});

--- a/app/packages/video-annotation/src/components/RegisterImaVidImage.tsx
+++ b/app/packages/video-annotation/src/components/RegisterImaVidImage.tsx
@@ -1,0 +1,164 @@
+import type { ModalSample } from "@fiftyone/state";
+import type { Stage } from "@fiftyone/utilities";
+import React, { useEffect, useRef } from "react";
+import { usePlaybackStream } from "@fiftyone/playback";
+import { useWarmupThenSeek } from "../hooks/useWarmupThenSeek";
+import {
+  useDatasetName,
+  useGroupSlice,
+  useModalSampleId,
+  useView,
+} from "../state/accessors";
+import { IMAVID_STREAM_ID } from "../utils/ids";
+import { getModalSampleFrameRate } from "../utils/modalSample";
+import { ImaVidImageStream } from "../streams/ImaVidImageStream";
+import { usePublishImaVidImageStream } from "../streams/imaVidImageStreamHandle";
+
+/**
+ * Construct and register `ImaVidImageStream` as soon as the sample's
+ * params resolve. The image stream contributes `duration = frameCount/fps`
+ * back to the engine, which is what unblocks `RegisterFrameLabels`
+ * downstream — in the native-video tile the `<video>` element plays
+ * this role via `useVideoStream`.
+ *
+ * fps comes from `sample.frameRate` (GraphQL-hoisted from
+ * `VideoMetadata.frame_rate`); frameCount comes from
+ * `sample.sample.metadata.total_frame_count` and falls back to
+ * `metadata.duration * frameRate`. Both fps and frameCount throw if
+ * absent — the plan explicitly forbids silent defaults because the
+ * failure mode (misaligned frames or a stuck timeline) is hard to
+ * debug after the fact.
+ *
+ * Re-keys on any identity change so a fresh stream replaces the old
+ * one via `usePlaybackStream`'s standard cleanup.
+ */
+export const RegisterImaVidImage: React.FC<{
+  sample: ModalSample;
+  children: React.ReactNode;
+}> = ({ sample, children }) => {
+  const dataset = useDatasetName();
+  const view = useView();
+  const slice = useGroupSlice();
+  const sampleId = useModalSampleId();
+
+  const frameRate = getModalSampleFrameRate(sample);
+  if (frameRate === undefined) {
+    throw new Error(
+      "ImaVid playback requires VideoMetadata.frame_rate to be set on the sample"
+    );
+  }
+  if (!Number.isFinite(frameRate) || frameRate <= 0) {
+    throw new Error(
+      `ImaVid playback requires a positive, finite fps (got ${frameRate})`
+    );
+  }
+
+  const frameCount = resolveFrameCount(sample, frameRate);
+
+  const ready = !!sampleId && !!dataset;
+  if (!ready) {
+    return <>{children}</>;
+  }
+
+  const key = `${sampleId}|${dataset}|${
+    slice ?? ""
+  }|${frameRate}|${frameCount}`;
+
+  return (
+    <ImaVidImageRegistration
+      key={key}
+      sampleId={sampleId}
+      dataset={dataset}
+      view={view}
+      groupSlice={slice ?? null}
+      frameCount={frameCount}
+      frameRate={frameRate}
+    >
+      {children}
+    </ImaVidImageRegistration>
+  );
+};
+
+/**
+ * Read total frame count from sample.metadata. The `Sample` TS type
+ * only declares `width / height / mime_type`, but VideoMetadata
+ * persists `total_frame_count` and `duration` at runtime — we
+ * loose-cast through.
+ */
+export function resolveFrameCount(
+  sample: ModalSample,
+  frameRate: number
+): number {
+  const metadata = (sample.sample as { metadata?: Record<string, unknown> })
+    ?.metadata;
+
+  const total = metadata?.total_frame_count;
+  if (typeof total === "number" && Number.isFinite(total) && total > 0) {
+    return Math.round(total);
+  }
+
+  const duration = metadata?.duration;
+  if (
+    typeof duration === "number" &&
+    Number.isFinite(duration) &&
+    duration > 0
+  ) {
+    return Math.max(1, Math.round(duration * frameRate));
+  }
+
+  throw new Error(
+    "ImaVid playback requires VideoMetadata.total_frame_count (or .duration) on the sample"
+  );
+}
+
+interface ImaVidImageRegistrationProps {
+  sampleId: string;
+  dataset: string;
+  view: Stage[];
+  groupSlice: string | null;
+  frameCount: number;
+  frameRate: number;
+  children: React.ReactNode;
+}
+
+const ImaVidImageRegistration: React.FC<ImaVidImageRegistrationProps> = ({
+  children,
+  ...props
+}) => {
+  const streamRef = useRef<ImaVidImageStream | null>(null);
+  if (streamRef.current === null) {
+    streamRef.current = new ImaVidImageStream({
+      id: IMAVID_STREAM_ID,
+      sampleId: props.sampleId,
+      dataset: props.dataset,
+      view: props.view,
+      groupSlice: props.groupSlice,
+      frameCount: props.frameCount,
+      frameRate: props.frameRate,
+    });
+  }
+
+  // Tear down the worker on unmount. The effect is declared BEFORE
+  // `usePlaybackStream` so React runs its cleanup AFTER the playback
+  // registration's cleanup (LIFO order): the engine unregisters the
+  // stream first, then we terminate the worker.
+  useEffect(() => {
+    const stream = streamRef.current;
+
+    return () => {
+      stream?.destroy();
+    };
+  }, []);
+
+  usePlaybackStream(streamRef.current);
+
+  // Publish the stream instance so off-tile consumers
+  // can pull arbitrary frame bitmaps by index via warmup/getValue.
+  usePublishImaVidImageStream(streamRef.current);
+
+  // Pre-warm the first chunk and seek to t=0 so the first paint isn't
+  // a blank tile waiting on the network + decode.
+  useWarmupThenSeek(streamRef.current);
+
+  return <>{children}</>;
+};

--- a/app/packages/video-annotation/src/components/SyntheticLabels.tsx
+++ b/app/packages/video-annotation/src/components/SyntheticLabels.tsx
@@ -1,0 +1,108 @@
+import { getLabelColorFromContext } from "@fiftyone/lighter";
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
+import { useColorScheme, useColorSeed } from "../state/accessors";
+import {
+  TimelineWithTracks,
+  TrackProvider,
+  useDuration,
+  usePlayback,
+  usePlaybackStream,
+} from "@fiftyone/playback";
+import { LABELS_STREAM_ID } from "../utils/ids";
+import {
+  DEFAULT_ACTOR_SPECS,
+  resolveActor,
+  SyntheticLabelStream,
+} from "../streams/SyntheticLabelStream";
+import {
+  buildSyntheticTracks,
+  type SyntheticActorLabel,
+} from "../tracks/syntheticTracks";
+
+// todo - hardcoded for demo
+export const SYNTHETIC_FIELD = "synthetic_detections";
+export const SYNTHETIC_FPS = 30;
+
+/**
+ * Synthetic labels stream — exercises the rendering path without real labels.
+ * Constructs the stream once, pushes actors in once duration is known, and
+ * nudges `seek(0)`.
+ */
+export const RegisterSyntheticLabels: React.FC = () => {
+  const duration = useDuration();
+  const { seek } = usePlayback();
+
+  const streamRef = useRef<SyntheticLabelStream | null>(null);
+  if (streamRef.current === null) {
+    streamRef.current = new SyntheticLabelStream(LABELS_STREAM_ID, {
+      fps: SYNTHETIC_FPS,
+    });
+  }
+
+  const stream = streamRef.current;
+  usePlaybackStream(stream);
+
+  useEffect(() => {
+    if (duration <= 0) {
+      return;
+    }
+
+    const actors = DEFAULT_ACTOR_SPECS.map((spec) =>
+      resolveActor(spec, duration)
+    );
+    stream.setActors(actors);
+    seek(0);
+  }, [stream, duration, seek]);
+
+  return null;
+};
+
+/**
+ * Synthetic track timeline — one row per actor, colored against the same
+ * color scheme the overlays use. Recolors live through the reactive `tracks`
+ * prop, with a one-shot empty→ready key flip so `initialPinnedIds` bootstraps
+ * when the real track list lands.
+ */
+export const SyntheticTrackTimeline: React.FC = () => {
+  const duration = useDuration();
+  const scheme = useColorScheme();
+  const seed = useColorSeed();
+
+  const resolveColor = useCallback(
+    (label: SyntheticActorLabel) =>
+      getLabelColorFromContext(SYNTHETIC_FIELD, label, {
+        colorScheme: scheme,
+        seed,
+      }),
+    [scheme, seed]
+  );
+
+  const actors = useMemo(
+    () =>
+      duration > 0
+        ? DEFAULT_ACTOR_SPECS.map((spec) => resolveActor(spec, duration))
+        : [],
+    [duration]
+  );
+
+  const tracks = useMemo(
+    () => buildSyntheticTracks(actors, duration, resolveColor),
+    [actors, duration, resolveColor]
+  );
+
+  const pinned = useMemo(() => tracks.map((t) => t.id), [tracks]);
+  const ready = tracks.length > 0;
+  // Synthetic actors carry no engine identity, so rows have no interaction
+  // linkage — render them undecorated.
+  const decorateTrack = useCallback(() => ({}), []);
+
+  return (
+    <TrackProvider
+      key={ready ? "ready" : "init"}
+      tracks={tracks}
+      initialPinnedIds={pinned}
+    >
+      <TimelineWithTracks decorateTrack={decorateTrack} />
+    </TrackProvider>
+  );
+};

--- a/app/packages/video-annotation/src/components/VideoAnnotationSurface.module.css
+++ b/app/packages/video-annotation/src/components/VideoAnnotationSurface.module.css
@@ -1,0 +1,45 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+}
+
+.media {
+  flex: 1 1 auto;
+  min-height: 0;
+  position: relative;
+}
+
+.timeline {
+  flex: 0 0 auto;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  background: var(--bg-panel, #1a1a1a);
+}
+
+.empty {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+/* Linked-state classes applied to a timeline track row whose matching
+   overlay is currently hovered / selected. Self-hover (the user's cursor
+   over the row itself) is handled by the row's normal :hover styles —
+   these only need to cover the external (overlay-side) trigger. */
+.linkHovered {
+  background: var(--color-background-level-1, rgba(255, 255, 255, 0.06));
+}
+
+.linkSelected {
+  box-shadow: inset 4px 0 0 var(--color-brand-primary, #fb923c);
+}
+
+/* When both are set, the box-shadow accent stays on top of the bg. */
+.linkSelected.linkHovered {
+  background: var(--color-background-level-1, rgba(255, 255, 255, 0.06));
+}

--- a/app/packages/video-annotation/src/components/VideoAnnotationSurface.tsx
+++ b/app/packages/video-annotation/src/components/VideoAnnotationSurface.tsx
@@ -1,0 +1,184 @@
+import { getSampleSrc } from "@fiftyone/state";
+import type { ModalSample } from "@fiftyone/state";
+import React, { useMemo, useState } from "react";
+import { useAutoInterpolate } from "../hooks/useAutoInterpolate";
+import { useRegisterVideoAnnotationKeybindings } from "../hooks/useRegisterVideoAnnotationKeybindings";
+import { useSyncAnnotationFrameClock } from "../hooks/useSyncAnnotationFrameClock";
+import { useSyncAnnotationVideoStore } from "../hooks/useSyncAnnotationVideoStore";
+import { useVideoLighterEngineBridge } from "../hooks/useVideoLighterEngineBridge";
+import { useFollowAnchorFrame } from "../state/useVideoInteraction";
+import { PlaybackProvider } from "@fiftyone/playback";
+import { FrameLabelsTracks, RegisterFrameLabels } from "./FrameLabels";
+import { ImaVidLighterTile } from "./ImaVidLighterTile";
+import { RegisterImaVidImage } from "./RegisterImaVidImage";
+import {
+  RegisterSyntheticLabels,
+  SyntheticTrackTimeline,
+} from "./SyntheticLabels";
+import { VideoAnnotationTopBar } from "./VideoAnnotationTopBar";
+import { VideoLighterTile } from "./VideoLighterTile";
+import styles from "./VideoAnnotationSurface.module.css";
+
+/**
+ * Switch between the synthetic stream (for testing the rendering path
+ * without real labels) and the real `/frames`-backed stream.
+ *
+ * - default: real
+ * - `?labels=synthetic`: synthetic
+ *
+ * Read once at mount; flipping requires reopening the modal.
+ */
+type LabelsMode = "real" | "synthetic";
+
+/**
+ * Switch between the ImaVid (image-per-frame) tile and the native
+ * `<video>` tile.
+ *
+ * - default: imavid (the demo's locked-in target — `to_frames(sample_frames=True)` data)
+ * - `?tile=video`: native video tile (kept around for the existing path)
+ *
+ * Read once at mount; flipping requires reopening the modal.
+ */
+type TileMode = "imavid" | "video";
+
+function useLabelsMode(): LabelsMode {
+  const [mode] = useState<LabelsMode>(() => {
+    if (typeof window === "undefined") {
+      return "real";
+    }
+
+    const param = new URLSearchParams(window.location.search).get("labels");
+    return param === "synthetic" ? "synthetic" : "real";
+  });
+
+  return mode;
+}
+
+function useTileMode(): TileMode {
+  const [mode] = useState<TileMode>(() => {
+    if (typeof window === "undefined") {
+      return "imavid";
+    }
+
+    const param = new URLSearchParams(window.location.search).get("tile");
+    return param === "video" ? "video" : "imavid";
+  });
+
+  return mode;
+}
+
+export interface VideoAnnotationSurfaceProps {
+  sample: ModalSample;
+}
+
+/**
+ * Composition root for the video annotation surface. Wires
+ * PlaybackProvider + TrackProvider + TilingProvider, registers a labels
+ * stream (real `/frames` by default; synthetic when `?labels=synthetic`),
+ * and renders media (top) + timeline (bottom).
+ *
+ * Tile mode (`?tile=imavid|video`) picks between an ImaVid tile (default,
+ * one materialized image per frame via `to_frames(sample_frames=True)`)
+ * and the native `<video>` tile.
+ *
+ * Lives inside the modal's media region — the existing right-side
+ * annotation sidebar continues to render outside this component.
+ */
+export const VideoAnnotationSurface: React.FC<VideoAnnotationSurfaceProps> = ({
+  sample,
+}) => {
+  const labelsMode = useLabelsMode();
+  const tileMode = useTileMode();
+
+  // The native-video tile binds to a single top-level URL. The ImaVid
+  // tile resolves a per-frame URL through the image stream, so it does
+  // not need (and ignores) this value.
+  const videoSrc = useMemo(() => {
+    if (tileMode !== "video") {
+      return null;
+    }
+
+    const url = sample.urls?.[0]?.url;
+    return url ? getSampleSrc(url) : null;
+  }, [sample, tileMode]);
+
+  const media =
+    tileMode === "imavid" ? (
+      <ImaVidLighterTile />
+    ) : videoSrc ? (
+      <VideoLighterTile videoSrc={videoSrc} />
+    ) : (
+      <div className={styles.empty}>No media URL on this sample.</div>
+    );
+
+  const layout = (
+    <div className={styles.root}>
+      <VideoAnnotationTopBar sample={sample} />
+      <div className={styles.media}>{media}</div>
+      <div className={styles.timeline}>
+        {labelsMode === "synthetic" ? (
+          <SyntheticTrackTimeline />
+        ) : (
+          <FrameLabelsTracks sample={sample} />
+        )}
+      </div>
+    </div>
+  );
+
+  // Both registrars run against the same PlaybackProvider. In the ImaVid
+  // path the image stream is the timeline's duration source (analogous to
+  // `<video>` in the native tile), so it has to mount OUTSIDE the labels
+  // registrar — `RegisterFrameLabels` gates on `useDuration() > 0` and
+  // swaps its wrapper component when it flips ready, which would otherwise
+  // remount whatever's nested inside it.
+  const labels =
+    labelsMode === "synthetic" ? (
+      <>
+        <RegisterSyntheticLabels />
+        {layout}
+      </>
+    ) : (
+      <RegisterFrameLabels sample={sample}>{layout}</RegisterFrameLabels>
+    );
+
+  const registered =
+    tileMode === "imavid" ? (
+      <RegisterImaVidImage sample={sample}>{labels}</RegisterImaVidImage>
+    ) : (
+      labels
+    );
+
+  // No TilingProvider: it mounts an isolated jotai store, which would
+  // shadow modal-scoped atoms the sidebar writes to (lighterSceneAtom,
+  // detection-mode, label list). Reintroducing multi-tile here requires
+  // first pinning those atoms to the modal-default store explicitly.
+  return (
+    // Annotation wants the playhead to rest on a real frame after a pause or
+    // scrub-drag, so the labels snapshot and any keyframe op align to a frame.
+    // Scrubbing stays continuous — only the settle position snaps.
+    <PlaybackProvider snapToFrameOnSettle>
+      <VideoAnnotationHandlerRegistration />
+      {registered}
+    </PlaybackProvider>
+  );
+};
+
+/**
+ * Mounts video-specific command + keybinding registrars inside the
+ * surface's `<PlaybackProvider>` so they can read `useCurrentTime`.
+ * The handlers no-op when there's no active selection or frame-labels
+ * stream, so it's safe to render unconditionally.
+ */
+const VideoAnnotationHandlerRegistration: React.FC = () => {
+  useSyncAnnotationFrameClock();
+  useSyncAnnotationVideoStore();
+  // after the clock + store: the bridge reconciles against the FrameTemporalView
+  // and a seeded frame store, not the degenerate pool view
+  useVideoLighterEngineBridge();
+  useRegisterVideoAnnotationKeybindings();
+  useAutoInterpolate();
+  // editing a frame label: keep the anchor (and the form) on the playhead's
+  // occurrence of the same track as the playhead moves
+  useFollowAnchorFrame();
+  return null;
+};

--- a/app/packages/video-annotation/src/components/VideoAnnotationToolbar.module.css
+++ b/app/packages/video-annotation/src/components/VideoAnnotationToolbar.module.css
@@ -1,0 +1,12 @@
+/* Inline cluster sitting in the controls row, between the playback
+   buttons and the playhead time display. */
+.root {
+  margin: 0 6px;
+}
+
+/* Tooltip anchors to this wrapper so the tip still shows while the inner
+   button is disabled (a disabled <button> swallows its own pointer
+   events). */
+.slot {
+  display: inline-flex;
+}

--- a/app/packages/video-annotation/src/components/VideoAnnotationToolbar.tsx
+++ b/app/packages/video-annotation/src/components/VideoAnnotationToolbar.tsx
@@ -1,0 +1,115 @@
+import type { ToolbarActionItem } from "@fiftyone/components";
+import {
+  Align,
+  Button,
+  Orientation,
+  Size,
+  Spacing,
+  Stack,
+  Text,
+  TextColor,
+  TextVariant,
+  Tooltip,
+  Variant,
+} from "@voxel51/voodo";
+import React from "react";
+import { useVideoAnnotationActions } from "../hooks/useVideoAnnotationActions";
+import styles from "./VideoAnnotationToolbar.module.css";
+
+/**
+ * Renders a single {@link ToolbarActionItem} as a tooltip-wrapped icon button.
+ * Mirrors `ActionToolbar`'s per-action handling: `customComponent` is an escape
+ * hatch, the action's `icon` node is the button content, and the tooltip shows
+ * the shortcut alongside the hint.
+ */
+const Action: React.FC<{ action: ToolbarActionItem }> = ({ action }) => {
+  if (action.customComponent) {
+    return <>{action.customComponent}</>;
+  }
+
+  const button = (
+    <Button
+      borderless
+      variant={Variant.Secondary}
+      size={Size.Xs}
+      disabled={action.isDisabled}
+      aria-label={action.label}
+      onClick={action.onClick}
+    >
+      {action.icon}
+    </Button>
+  );
+
+  if (!action.tooltip && !action.shortcut) {
+    // A disabled <button> swallows pointer events, so even the no-tooltip
+    // case wraps in the span for consistent layout.
+    return <span className={styles.slot}>{button}</span>;
+  }
+
+  return (
+    <Tooltip
+      portal
+      content={
+        <Stack
+          orientation={Orientation.Row}
+          spacing={Spacing.Sm}
+          align={Align.Center}
+        >
+          {action.shortcut && (
+            <Text variant={TextVariant.Sm} color={TextColor.Secondary}>
+              ({action.shortcut})
+            </Text>
+          )}
+          <Text variant={TextVariant.Sm}>{action.tooltip ?? action.label}</Text>
+        </Stack>
+      }
+    >
+      {/* Tooltip anchors to the span, not the (possibly disabled) button. */}
+      <span className={styles.slot}>{button}</span>
+    </Tooltip>
+  );
+};
+
+/**
+ * Action bar between the playback controls and the timestamp.
+ *
+ * Thin, data-driven renderer: all behavior lives in
+ * {@link useVideoAnnotationActions}, which returns `ToolbarActionGroup`s in the
+ * same shape `ActionToolbar` consumes elsewhere. This component only lays the
+ * groups out inline in the controls row — the shared `ActionToolbar` renders a
+ * floating, draggable palette, which is wrong for this slot. Add functionality
+ * by editing the hook, not this file.
+ */
+export const VideoAnnotationToolbar: React.FC = () => {
+  const groups = useVideoAnnotationActions();
+
+  return (
+    <Stack
+      orientation={Orientation.Row}
+      align={Align.Center}
+      spacing={Spacing.Sm}
+      className={styles.root}
+    >
+      {groups
+        .filter(
+          (group) =>
+            !group.isHidden &&
+            group.actions.some((action) => action.isVisible !== false)
+        )
+        .map((group) => (
+          <Stack
+            key={group.id}
+            orientation={Orientation.Row}
+            align={Align.Center}
+            spacing={Spacing.Xs}
+          >
+            {group.actions
+              .filter((action) => action.isVisible !== false)
+              .map((action) => (
+                <Action key={action.id} action={action} />
+              ))}
+          </Stack>
+        ))}
+    </Stack>
+  );
+};

--- a/app/packages/video-annotation/src/components/VideoAnnotationTopBar.module.css
+++ b/app/packages/video-annotation/src/components/VideoAnnotationTopBar.module.css
@@ -1,0 +1,29 @@
+.root {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  height: 36px;
+  padding: 0 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  background: var(--bg-panel, #1a1a1a);
+  user-select: none;
+  white-space: nowrap;
+}
+
+/* Thin vertical rule between media facts. */
+.sep {
+  width: 1px;
+  height: 12px;
+  background: rgba(255, 255, 255, 0.18);
+}
+
+/* Right-hand status slot; min-width 0 so its content can truncate rather
+   than push the bar wider than the surface. */
+.status {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  overflow: hidden;
+}

--- a/app/packages/video-annotation/src/components/VideoAnnotationTopBar.tsx
+++ b/app/packages/video-annotation/src/components/VideoAnnotationTopBar.tsx
@@ -1,0 +1,130 @@
+import type { ModalSample } from "@fiftyone/state";
+import {
+  Align,
+  Orientation,
+  Spacing,
+  Stack,
+  Text,
+  TextColor,
+  TextVariant,
+} from "@voxel51/voodo";
+import React, { useMemo } from "react";
+import styles from "./VideoAnnotationTopBar.module.css";
+import { useVideoAnnotationStatusContent } from "../state/videoAnnotationStatus";
+import { getModalSampleFrameRate } from "../utils/modalSample";
+
+/**
+ * Media facts shown at the top-left of the bar. Resolution and codec are
+ * optional — they're absent on samples whose `VideoMetadata` wasn't fully
+ * populated, so the bar simply omits them rather than rendering blanks.
+ */
+interface MediaInfo {
+  filename: string;
+  resolution: string | null;
+  fps: string | null;
+  codec: string | null;
+}
+
+type VideoMetadataLike = {
+  frame_width?: unknown;
+  frame_height?: unknown;
+  encoding_str?: unknown;
+};
+
+const basename = (filepath: string): string => {
+  const cleaned = filepath.replace(/[\\/]+$/, "");
+  const idx = Math.max(cleaned.lastIndexOf("/"), cleaned.lastIndexOf("\\"));
+
+  return idx >= 0 ? cleaned.slice(idx + 1) : cleaned;
+};
+
+const finitePositive = (value: unknown): number | null =>
+  typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : null;
+
+/** Format fps trimming trailing zeros: 30 → "30 fps", 29.97 → "29.97 fps". */
+const formatFps = (fps: number): string => `${Number(fps.toFixed(2))} fps`;
+
+const useMediaInfo = (sample: ModalSample): MediaInfo => {
+  return useMemo(() => {
+    const metadata = (
+      sample.sample as { metadata?: VideoMetadataLike } | undefined
+    )?.metadata;
+
+    const width = finitePositive(metadata?.frame_width);
+    const height = finitePositive(metadata?.frame_height);
+    const fps = finitePositive(getModalSampleFrameRate(sample));
+    const codec =
+      typeof metadata?.encoding_str === "string" && metadata.encoding_str
+        ? metadata.encoding_str
+        : null;
+
+    return {
+      filename: basename(sample.sample.filepath),
+      resolution: width && height ? `${width}×${height}` : null,
+      fps: fps ? formatFps(fps) : null,
+      codec,
+    };
+  }, [sample]);
+};
+
+const MetaItem: React.FC<{ children: React.ReactNode; muted?: boolean }> = ({
+  children,
+  muted,
+}) => (
+  <Text
+    variant={TextVariant.Sm}
+    color={muted ? TextColor.Secondary : TextColor.Primary}
+  >
+    {children}
+  </Text>
+);
+
+/**
+ * Top bar for the video annotation surface. Left side shows the open sample's
+ * media facts (filename, resolution, fps, codec when available); the right
+ * side is a programmatically-controllable status slot driven by
+ * {@link useVideoAnnotationStatus} — e.g. propagation progress.
+ *
+ * Mounted as the first row of the surface layout (above the media region).
+ */
+export const VideoAnnotationTopBar: React.FC<{ sample: ModalSample }> = ({
+  sample,
+}) => {
+  const info = useMediaInfo(sample);
+  const status = useVideoAnnotationStatusContent();
+
+  return (
+    <div className={styles.root} data-cy="video-annotation-top-bar">
+      <Stack
+        orientation={Orientation.Row}
+        align={Align.Center}
+        spacing={Spacing.Sm}
+      >
+        <MetaItem>{info.filename}</MetaItem>
+        {info.resolution && (
+          <>
+            <span className={styles.sep} aria-hidden />
+            <MetaItem muted>{info.resolution}</MetaItem>
+          </>
+        )}
+        {info.fps && (
+          <>
+            <span className={styles.sep} aria-hidden />
+            <MetaItem muted>{info.fps}</MetaItem>
+          </>
+        )}
+        {info.codec && (
+          <>
+            <span className={styles.sep} aria-hidden />
+            <MetaItem muted>{info.codec}</MetaItem>
+          </>
+        )}
+      </Stack>
+      <div className={styles.status} data-cy="video-annotation-status-slot">
+        {status}
+      </div>
+    </div>
+  );
+};

--- a/app/packages/video-annotation/src/components/VideoLighterTile.module.css
+++ b/app/packages/video-annotation/src/components/VideoLighterTile.module.css
@@ -1,0 +1,28 @@
+.body {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  background: black;
+  overflow: hidden;
+}
+
+.video {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  z-index: 0;
+  /* Mirrors the Lighter viewport transform (see useSyncMediaTransform): the
+     origin must be the container's top-left so `translate(pan) scale()` lines
+     up with the overlays' pan + scale·world mapping. */
+  transform-origin: 0 0;
+  will-change: transform;
+}
+
+.lighterHost {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  display: flex;
+}

--- a/app/packages/video-annotation/src/components/VideoLighterTile.tsx
+++ b/app/packages/video-annotation/src/components/VideoLighterTile.tsx
@@ -1,0 +1,83 @@
+import React, { useRef, useState } from "react";
+import { usePlayback, useVideoStream, useVideoSync } from "@fiftyone/playback";
+import { useLighterTileScene } from "../hooks/useLighterTileScene";
+import { useVfcClockSource } from "../hooks/useVfcClockSource";
+import { useVideoAnnotationSyncBundle } from "../hooks/useVideoAnnotationSyncBundle";
+import { VIDEO_STREAM_ID } from "../utils/ids";
+import styles from "./VideoLighterTile.module.css";
+
+export interface VideoLighterTileProps {
+  /** Resolved media URL for the video. */
+  videoSrc: string;
+}
+
+/**
+ * <video> bound to the playback engine, Lighter overlaid on top,
+ * Overlays diffed in from the labels stream each commit.
+ */
+export const VideoLighterTile: React.FC<VideoLighterTileProps> = ({
+  videoSrc,
+}) => {
+  const sourceId = VIDEO_STREAM_ID;
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const lighterHostRef = useRef<HTMLDivElement | null>(null);
+  const [videoDims, setVideoDims] = useState<{ w: number; h: number } | null>(
+    null
+  );
+
+  // Bind <video> -> playback engine. The video-annotation tile uses
+  // video-anchored playback: `useVfcClockSource` registers the
+  // element's vfc-presented mediaTime as the engine's clock source,
+  // so the engine commits exactly where the picture is. We pass
+  // `blocking: false` to `useVideoStream` because the clock source
+  // already owns presentation time — gating the engine again on the
+  // stream's bufferState would produce spurious stalls.
+  useVideoStream(sourceId, videoRef, { blocking: false });
+  useVideoSync(videoRef);
+  useVfcClockSource(videoRef);
+  const { seek } = usePlayback();
+
+  // Scene lifecycle (singleton canvas, pixi setup, color scheme, canonical
+  // media, viewport fit). A fresh scene per `videoSrc` so a new source video
+  // gets its own scene; `dims` from the <video>'s intrinsic resolution.
+  const { scene, canonicalMediaReady } = useLighterTileScene({
+    hostRef: lighterHostRef,
+    dims: videoDims,
+    sceneIdPrefix: "video-anno",
+    sceneIdDeps: [videoSrc],
+  });
+
+  // Overlay / sidebar sync. `videoRef` keeps the <video> zoomed/panned with
+  // the Lighter viewport so scroll-zoom scales the picture, not just overlays.
+  useVideoAnnotationSyncBundle({
+    scene,
+    canonicalMediaReady,
+    mediaRef: videoRef,
+  });
+
+  return (
+    <div className={styles.body}>
+      <video
+        ref={videoRef}
+        className={styles.video}
+        src={videoSrc}
+        preload="auto"
+        playsInline
+        muted
+        onLoadedMetadata={(e) => {
+          const v = e.currentTarget;
+          setVideoDims({ w: v.videoWidth, h: v.videoHeight });
+        }}
+        onLoadedData={() => {
+          // Force the engine to commit once now that the video stream is
+          // ready. The engine's RAF loop is dormant while paused — without
+          // a seek the label stream never gets `onCommit` called
+          // and `useStream` stays at null, so no overlays paint on first
+          // load.
+          seek(0);
+        }}
+      />
+      <div ref={lighterHostRef} className={styles.lighterHost} />
+    </div>
+  );
+};

--- a/app/packages/video-annotation/src/hooks/useAutoInterpolate.ts
+++ b/app/packages/video-annotation/src/hooks/useAutoInterpolate.ts
@@ -1,0 +1,109 @@
+import {
+  useActiveSampleId,
+  useAnnotationEngine,
+  useAnnotationEventHandler,
+} from "@fiftyone/annotation";
+import { useCallback } from "react";
+import { useFrameLabelsStream } from "../streams/frameLabelsStream";
+import { useVideoPropagate } from "./useVideoPropagate";
+
+/** Inclusive `[fromFrame, toFrame]` segment to re-propagate. */
+export type FrameRange = [number, number];
+
+/**
+ * Given the current set of keyframe frames on a track and the frame where a
+ * keyframe just changed, return the `(from, to)` pairs whose in-between frames
+ * need re-propagation.
+ *
+ * - `kind: "set"` — `frame` is now a keyframe. Re-propagate both sides:
+ *   (prev-keyframe, frame) and (frame, next-keyframe). Each side is skipped if
+ *   no bracketing keyframe exists on that side.
+ * - `kind: "removed"` — `frame` is no longer a keyframe. Re-propagate the wider
+ *   span (prev-keyframe, next-keyframe). Skipped entirely if either bracketing
+ *   keyframe is missing.
+ */
+export function resolveSegmentsToRepropagate(
+  keyframeFrames: number[],
+  changedFrame: number,
+  kind: "set" | "removed"
+): FrameRange[] {
+  const sorted = [...keyframeFrames].sort((a, b) => a - b);
+  const prev = sorted.filter((f) => f < changedFrame).at(-1) ?? null;
+  const next = sorted.find((f) => f > changedFrame) ?? null;
+
+  const segments: FrameRange[] = [];
+
+  if (kind === "set") {
+    if (prev !== null) {
+      segments.push([prev, changedFrame]);
+    }
+
+    if (next !== null) {
+      segments.push([changedFrame, next]);
+    }
+  } else if (prev !== null && next !== null) {
+    segments.push([prev, next]);
+  }
+
+  return segments;
+}
+
+/**
+ * Subscribe to `annotation:keyframeChanged` and re-propagate (linear) each
+ * in-between segment that needs re-lerping against the new keyframe layout.
+ *
+ * Keyframe frames are read from the engine, so the layout reflects the edit
+ * that just fired the event. Mount once inside the surface; a no-op until a
+ * stream is published
+ * (it supplies the field path / frame count) and an instance is identified.
+ */
+export const useAutoInterpolate = (): void => {
+  const engine = useAnnotationEngine();
+  const sampleId = useActiveSampleId();
+  const stream = useFrameLabelsStream();
+  const propagate = useVideoPropagate();
+
+  useAnnotationEventHandler(
+    "annotation:keyframeChanged",
+    useCallback(
+      (payload) => {
+        if (!stream) {
+          return;
+        }
+
+        const { instanceId, frame, kind } = payload;
+
+        if (!instanceId) {
+          return;
+        }
+
+        const path = `frames.${stream.labelsField}`;
+        const keyframeFrames: number[] = [];
+
+        for (let f = 1; f <= stream.totalFrames; f++) {
+          const det = engine.getLabel({
+            sample: sampleId,
+            path,
+            instanceId,
+            frame: f,
+          });
+
+          if (det?.keyframe) {
+            keyframeFrames.push(f);
+          }
+        }
+
+        const segments = resolveSegmentsToRepropagate(
+          keyframeFrames,
+          frame,
+          kind
+        );
+
+        segments.forEach(([from, to]) => {
+          void propagate(instanceId, from, to, "linear");
+        });
+      },
+      [engine, sampleId, stream, propagate]
+    )
+  );
+};

--- a/app/packages/video-annotation/src/hooks/useFrameClock.test.ts
+++ b/app/packages/video-annotation/src/hooks/useFrameClock.test.ts
@@ -1,0 +1,50 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+// Drive the clock through the frame-source seam. `useFrameClock` only pulls
+// `Clock` from @fiftyone/annotation as a type (erased), so no engine runtime is
+// loaded here; the playback engine is represented by the seam's frame value.
+const { source } = vi.hoisted(() => ({ source: { frame: 7 } }));
+
+vi.mock("../state/useCurrentFrame", () => ({
+  useCurrentFrame: () => source.frame,
+}));
+
+import { useFrameClock } from "./useFrameClock";
+
+describe("useFrameClock", () => {
+  it("reads the current frame as the engine clock time", () => {
+    const { result, rerender } = renderHook(() => useFrameClock());
+
+    expect(result.current.getTime()).toBe(7);
+
+    source.frame = 9;
+    rerender();
+    expect(result.current.getTime()).toBe(9);
+  });
+
+  it("forwards frame changes to subscribers and stops on teardown", () => {
+    const { result, rerender } = renderHook(() => useFrameClock());
+    const listener = vi.fn();
+
+    const teardown = result.current.subscribe(listener);
+
+    source.frame = 42;
+    rerender();
+    expect(listener).toHaveBeenCalledWith(42);
+
+    teardown();
+    source.frame = 43;
+    rerender();
+    expect(listener).not.toHaveBeenCalledWith(43);
+  });
+
+  it("returns a stable clock across renders (attaches once)", () => {
+    const { result, rerender } = renderHook(() => useFrameClock());
+    const first = result.current;
+
+    source.frame = 5;
+    rerender();
+    expect(result.current).toBe(first);
+  });
+});

--- a/app/packages/video-annotation/src/hooks/useFrameClock.ts
+++ b/app/packages/video-annotation/src/hooks/useFrameClock.ts
@@ -1,0 +1,40 @@
+import type { Clock } from "@fiftyone/annotation";
+import { useEffect, useMemo, useRef } from "react";
+import { useCurrentFrame } from "../state/useCurrentFrame";
+
+/**
+ * Adapts the surface's playback position to the annotation engine's
+ * {@link Clock}. The frame comes from {@link useCurrentFrame} (the
+ * `PlaybackProvider` engine's playhead), so `getTime` already yields a frame
+ * number and the engine's `frameAtTime` is identity.
+ *
+ * The returned clock is referentially STABLE: `getTime` reads the latest frame
+ * through a ref and `subscribe` registers listeners notified by an effect when
+ * the frame changes. A stable clock means the `FrameTemporalView` attaches once
+ * (no re-attach churn that would reset its present-set each render).
+ */
+export const useFrameClock = (): Clock => {
+  const frame = useCurrentFrame();
+
+  const frameRef = useRef(frame);
+  frameRef.current = frame;
+
+  const listeners = useRef(new Set<(time: number) => void>()).current;
+
+  useEffect(() => {
+    for (const listener of listeners) {
+      listener(frame);
+    }
+  }, [frame, listeners]);
+
+  return useMemo<Clock>(
+    () => ({
+      getTime: () => frameRef.current,
+      subscribe: (listener) => {
+        listeners.add(listener);
+        return () => listeners.delete(listener);
+      },
+    }),
+    [listeners]
+  );
+};

--- a/app/packages/video-annotation/src/hooks/useLighterTileScene.ts
+++ b/app/packages/video-annotation/src/hooks/useLighterTileScene.ts
@@ -1,0 +1,200 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import {
+  UNDEFINED_LIGHTER_SCENE_ID,
+  useLighterEventHandler,
+  useLighterSetupWithPixi,
+} from "@fiftyone/lighter";
+import { useModalLookerOptions } from "@fiftyone/state";
+import {
+  type DependencyList,
+  type RefObject,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { singletonCanvas } from "../../../core/src/components/Modal/Lighter/SharedCanvas";
+import { ExternalCanonicalMedia } from "../media/ExternalCanonicalMedia";
+import { useColorScheme, useColorSeed } from "../state/accessors";
+
+/** Intrinsic media resolution the canonical-media overlay is sized to. */
+interface Dimensions {
+  w: number;
+  h: number;
+}
+
+type LighterScene = ReturnType<typeof useLighterSetupWithPixi>["scene"];
+
+/**
+ * Attach the SINGLETON Lighter canvas into `hostRef`. One
+ * SharedPixiApplication per page binds to the first canvas it sees; a fresh
+ * canvas would leave Pixi rendering to the old (image-modal) one.
+ */
+function useAttachedSingletonCanvas(
+  hostRef: RefObject<HTMLDivElement | null>
+): HTMLCanvasElement | null {
+  const [canvas, setCanvas] = useState<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) {
+      return undefined;
+    }
+
+    setCanvas(singletonCanvas.getCanvas(host));
+
+    return () => {
+      singletonCanvas.detach();
+    };
+  }, [hostRef]);
+
+  return canvas;
+}
+
+/** Keep the scene's color mapping in sync with the FiftyOne color scheme. */
+function useSceneColorScheme(scene: LighterScene, sceneId: string): void {
+  const scheme = useColorScheme();
+  const seed = useColorSeed();
+
+  useEffect(() => {
+    if (!scene || scene.getSceneId() !== sceneId) {
+      return;
+    }
+
+    scene.updateColorMappingContext({ colorScheme: scheme, seed });
+  }, [scene, sceneId, scheme, seed]);
+}
+
+/**
+ * Install a no-pixel canonical-media overlay sized to `dims`. Lighter draws
+ * overlays relative to it. Returns whether the current scene's media is
+ * installed — overlays added before it exists have no coordinate context.
+ */
+function useCanonicalMediaInstall(
+  scene: LighterScene,
+  sceneId: string,
+  dims: Dimensions | null
+): boolean {
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    setReady(false);
+  }, [sceneId]);
+
+  useEffect(() => {
+    if (!scene || !dims) {
+      return;
+    }
+
+    if (scene.getSceneId() !== sceneId) {
+      return;
+    }
+
+    const media = new ExternalCanonicalMedia({
+      width: dims.w,
+      height: dims.h,
+    });
+
+    scene.addOverlay(media);
+    scene.setCanonicalMedia(media);
+    setReady(true);
+  }, [scene, sceneId, dims]);
+
+  return ready;
+}
+
+/**
+ * Reset the viewport to the resting IDENTITY frame once the renderer and the
+ * canonical media's real bounds are both ready. Identity (not `fitToContent`,
+ * which frames the labels' bbox) keeps the letterboxed media aligned with
+ * world coordinates. Bounds arrive via ResizeObserver after layout, so we gate
+ * on the `bounds-changed` event rather than renderer-ready alone (which races
+ * a zero-size scene).
+ */
+function useViewportReset(scene: LighterScene, sceneId: string): void {
+  const [rendererReady, setRendererReady] = useState(false);
+  const [mediaBoundsReady, setMediaBoundsReady] = useState(false);
+  const useEventHandler = useLighterEventHandler(
+    scene?.getEventChannel() ?? UNDEFINED_LIGHTER_SCENE_ID
+  );
+
+  useEffect(() => {
+    setMediaBoundsReady(false);
+  }, [sceneId]);
+
+  useEventHandler(
+    "lighter:renderer-ready",
+    useCallback(() => setRendererReady(true), []),
+    { once: true }
+  );
+
+  useEventHandler(
+    "lighter:canonical-media-bounds-changed",
+    useCallback(() => setMediaBoundsReady(true), [])
+  );
+
+  useEffect(() => {
+    if (!scene || !rendererReady || !mediaBoundsReady) {
+      return;
+    }
+
+    if (scene.getSceneId() !== sceneId) {
+      return;
+    }
+
+    scene.resetZoomPan();
+  }, [scene, sceneId, rendererReady, mediaBoundsReady]);
+}
+
+/**
+ * Owns the Lighter scene lifecycle shared by both video-annotation tiles:
+ * attaches the singleton canvas, sets up the pixi scene under a fresh scene
+ * id, syncs the color scheme, installs a canonical-media overlay sized to
+ * `dims`, and resets the viewport once renderer + media are ready.
+ *
+ * `dims` is injected so the hook stays agnostic to how the tile discovered
+ * them. `sceneIdDeps` recompute the scene id (the video tile re-mints per
+ * source; pass nothing for a once-per-mount scene).
+ *
+ * Returns the scene plus whether its canonical media is installed; feed
+ * `canonicalMediaReady` into {@link useVideoAnnotationSyncBundle}.
+ */
+export function useLighterTileScene({
+  hostRef,
+  dims,
+  sceneIdPrefix,
+  sceneIdDeps = [],
+}: {
+  hostRef: RefObject<HTMLDivElement | null>;
+  dims: Dimensions | null;
+  sceneIdPrefix: string;
+  sceneIdDeps?: DependencyList;
+}): {
+  scene: LighterScene;
+  canonicalMediaReady: boolean;
+} {
+  const canvas = useAttachedSingletonCanvas(hostRef);
+
+  // Modal options so activePaths / showOverlays / alpha match the sidebar.
+  const options = useModalLookerOptions();
+
+  // Fresh scene id whenever `sceneIdDeps` change, so a new source gets its
+  // own scene.
+  const sceneId = useMemo(
+    () => `${sceneIdPrefix}-${Math.random().toString(36).slice(2, 9)}`,
+    // caller-supplied dep list; exhaustive-deps can't statically verify it.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    sceneIdDeps
+  );
+
+  const { scene } = useLighterSetupWithPixi(canvas, options, sceneId);
+
+  useSceneColorScheme(scene, sceneId);
+  const canonicalMediaReady = useCanonicalMediaInstall(scene, sceneId, dims);
+  useViewportReset(scene, sceneId);
+
+  return { scene, canonicalMediaReady };
+}

--- a/app/packages/video-annotation/src/hooks/useRegisterVideoAnnotationKeybindings.ts
+++ b/app/packages/video-annotation/src/hooks/useRegisterVideoAnnotationKeybindings.ts
@@ -1,0 +1,52 @@
+import { KnownContexts, useKeyBindings } from "@fiftyone/commands";
+import { useLighter } from "@fiftyone/lighter";
+import { useRef } from "react";
+import { usePlayhead } from "@fiftyone/playback";
+import { useVideoSurfaceActions } from "./useVideoSurfaceActions";
+
+/**
+ * Registers video-only keybindings into the modal-annotate context.
+ * Must mount inside the video annotation surface's `<PlaybackProvider>`
+ * because it reads `usePlayhead` to capture the user-visible time at
+ * key-press. Composes with {@link useRegisterAnnotationKeybindings};
+ * both can target the same context.
+ */
+export const useRegisterVideoAnnotationKeybindings = () => {
+  const actions = useVideoSurfaceActions();
+  const { scene } = useLighter();
+
+  // Read the visual playhead, not `useCurrentTime` — currentTime lags
+  // playhead while streams buffer, so dispatching at "the moment the
+  // user pressed K" needs the visual position. Held in a ref so the
+  // keybinding handler is rebuilt only when `scene` or `actions` change.
+  const playhead = usePlayhead();
+  const playheadRef = useRef(playhead);
+  playheadRef.current = playhead;
+
+  useKeyBindings(
+    KnownContexts.ModalAnnotate,
+    [
+      {
+        commandId: "annotation-mark-keyframe",
+        sequence: "k",
+        handler: () => {
+          if (!scene) {
+            return;
+          }
+
+          const ids = scene.getSelectedOverlayIds();
+
+          if (ids.length === 0) {
+            return;
+          }
+
+          actions.markKeyframe(playheadRef.current, ids);
+        },
+        label: "Mark keyframe",
+        description:
+          "Toggle the keyframe attribute on the selected detection at the current frame.",
+      },
+    ],
+    [scene, actions]
+  );
+};

--- a/app/packages/video-annotation/src/hooks/useSyncAnnotationFrameClock.ts
+++ b/app/packages/video-annotation/src/hooks/useSyncAnnotationFrameClock.ts
@@ -1,0 +1,25 @@
+import { FrameTemporalView, useAnnotationEngine } from "@fiftyone/annotation";
+import { useEffect } from "react";
+import { useFrameClock } from "./useFrameClock";
+
+/**
+ * Install a frame-temporal view on the shared annotation engine for the lifetime
+ * of the video surface, driven by the playback clock. Mirrors the engine's store
+ * lifecycle ({@link useSyncAnnotationEngine}): attach on mount, detach (restore
+ * the pool view) on unmount. The clock yields frame numbers directly, so the
+ * engine's time→frame map is identity.
+ *
+ * Must be mounted inside a `PlaybackProvider` (see {@link useFrameClock}).
+ */
+export const useSyncAnnotationFrameClock = (): void => {
+  const engine = useAnnotationEngine();
+  const clock = useFrameClock();
+
+  useEffect(
+    () =>
+      engine.attachTemporal(
+        (e) => new FrameTemporalView(e, clock, (time) => time)
+      ),
+    [engine, clock]
+  );
+};

--- a/app/packages/video-annotation/src/hooks/useSyncAnnotationVideoStore.ts
+++ b/app/packages/video-annotation/src/hooks/useSyncAnnotationVideoStore.ts
@@ -1,0 +1,60 @@
+import {
+  FrameStore,
+  SampleLabelStore,
+  useActiveSampleId,
+  useAnnotationEngine,
+  useSampleInstanceGetter,
+  VideoLabelStore,
+} from "@fiftyone/annotation";
+import { LabelType } from "@fiftyone/utilities";
+import { useEffect } from "react";
+import { useFrameLabelsStream } from "../streams/frameLabelsStream";
+import { parseFramesData } from "../streams/framesData";
+
+/**
+ * Own the video sample's engine store for the lifetime of the surface.
+ *
+ * The engine federates one {@link LabelStore} per sample, so a video sample
+ * registers a composite {@link VideoLabelStore} — a {@link FrameStore} for the
+ * per-frame detections plus a {@link SampleLabelStore} (over the shared
+ * `Sample`) for sample-level labels. The annotation root's
+ * `useSyncAnnotationEngine` skips the video sample precisely so this hook can
+ * own it.
+ *
+ * The frame backing is seeded from the active `/frames` stream and re-seeded as
+ * chunks land or local edits mutate the cache (via `subscribeToEdits`).
+ *
+ * Must be mounted under the modal scope where the labels stream is published.
+ */
+export const useSyncAnnotationVideoStore = (): void => {
+  const engine = useAnnotationEngine();
+  const sampleId = useActiveSampleId();
+  const getSample = useSampleInstanceGetter();
+  const stream = useFrameLabelsStream();
+  const field = stream?.labelsField;
+
+  useEffect(() => {
+    if (!sampleId || !stream || !field) {
+      return undefined;
+    }
+
+    const path = `frames.${field}`;
+    const frames = new FrameStore(sampleId, {
+      labelTypes: { [path]: LabelType.Detections },
+    });
+    const sampleLevel = new SampleLabelStore(sampleId, getSample(sampleId));
+    const store = new VideoLabelStore(sampleId, frames, sampleLevel);
+    const unregister = engine.registerStore(store);
+
+    const seed = () =>
+      frames.setData(parseFramesData(stream.cachedFrames(), field));
+    const unsubscribe = stream.subscribeToEdits(seed);
+    seed();
+
+    return () => {
+      unsubscribe();
+      unregister();
+      sampleLevel.dispose();
+    };
+  }, [engine, sampleId, field, getSample, stream]);
+};

--- a/app/packages/video-annotation/src/hooks/useTemporalOverlayVersion.test.ts
+++ b/app/packages/video-annotation/src/hooks/useTemporalOverlayVersion.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Capture the callbacks the hook registers so tests can fire them directly.
+// `useLighterEventHandler(channel)` returns a per-channel registrar; we store
+// the latest callback per event name. `TemporalOverlay` must be a real class
+// for the hook's `instanceof` guard.
+const { lighterHandlers, annotationHandlers } = vi.hoisted(() => ({
+  lighterHandlers: new Map<string, (payload: unknown) => void>(),
+  annotationHandlers: new Map<string, (payload: unknown) => void>(),
+}));
+
+vi.mock("@fiftyone/lighter", () => {
+  class TemporalOverlay {}
+  return {
+    TemporalOverlay,
+    UNDEFINED_LIGHTER_SCENE_ID: "__undefined__",
+    useLighterEventHandler:
+      () => (event: string, cb: (payload: unknown) => void) => {
+        lighterHandlers.set(event, cb);
+      },
+  };
+});
+
+vi.mock("@fiftyone/annotation", () => ({
+  useAnnotationEventHandler: (
+    event: string,
+    cb: (payload: unknown) => void
+  ) => {
+    annotationHandlers.set(event, cb);
+  },
+}));
+
+import { TemporalOverlay } from "@fiftyone/lighter";
+import { useTemporalOverlayVersion } from "./useTemporalOverlayVersion";
+
+const fireLighter = (event: string, payload: unknown) =>
+  act(() => lighterHandlers.get(event)!(payload));
+const fireAnnotation = (event: string, payload: unknown) =>
+  act(() => annotationHandlers.get(event)!(payload));
+
+// A stable scene reference per test — the hook keys the `bumpOnSceneReady`
+// effect on `scene` identity, so a fresh object per render would loop.
+const makeScene = () => ({ getEventChannel: () => "channel-1" } as never);
+let scene: ReturnType<typeof makeScene>;
+
+beforeEach(() => {
+  lighterHandlers.clear();
+  annotationHandlers.clear();
+  scene = makeScene();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useTemporalOverlayVersion", () => {
+  it("starts at 0", () => {
+    const { result } = renderHook(() => useTemporalOverlayVersion(scene));
+    expect(result.current).toBe(0);
+  });
+
+  describe("overlay-added", () => {
+    it("bumps when a TemporalOverlay is added to the scene", () => {
+      const { result } = renderHook(() => useTemporalOverlayVersion(scene));
+
+      fireLighter("lighter:overlay-added", {
+        overlay: new TemporalOverlay({} as never),
+      });
+
+      expect(result.current).toBe(1);
+    });
+
+    it("ignores non-temporal overlays", () => {
+      const { result } = renderHook(() => useTemporalOverlayVersion(scene));
+
+      fireLighter("lighter:overlay-added", { overlay: { id: "det-1" } });
+
+      expect(result.current).toBe(0);
+    });
+  });
+
+  describe("overlay-removed", () => {
+    it("bumps on any overlay removal (the removed id no longer reveals the type)", () => {
+      const { result } = renderHook(() => useTemporalOverlayVersion(scene));
+
+      fireLighter("lighter:overlay-removed", { id: "any-overlay" });
+
+      expect(result.current).toBe(1);
+    });
+
+    it("bumps even when the removal payload has no id", () => {
+      const { result } = renderHook(() => useTemporalOverlayVersion(scene));
+
+      fireLighter("lighter:overlay-removed", { id: undefined });
+
+      expect(result.current).toBe(1);
+    });
+  });
+
+  describe("annotation:labelEdit (listenLabelEdit)", () => {
+    it("does not bump on a TD label edit when the flag is off (default)", () => {
+      const { result } = renderHook(() => useTemporalOverlayVersion(scene));
+
+      fireAnnotation("annotation:labelEdit", {
+        label: { _cls: "TemporalDetection" },
+      });
+
+      expect(result.current).toBe(0);
+    });
+
+    it("bumps on a TD label edit when the flag is on", () => {
+      const { result } = renderHook(() =>
+        useTemporalOverlayVersion(scene, { listenLabelEdit: true })
+      );
+
+      fireAnnotation("annotation:labelEdit", {
+        label: { _cls: "TemporalDetection" },
+      });
+
+      expect(result.current).toBe(1);
+    });
+
+    it("ignores edits to non-TD labels even when the flag is on", () => {
+      const { result } = renderHook(() =>
+        useTemporalOverlayVersion(scene, { listenLabelEdit: true })
+      );
+
+      fireAnnotation("annotation:labelEdit", { label: { _cls: "Detection" } });
+      fireAnnotation("annotation:labelEdit", { label: null });
+
+      expect(result.current).toBe(0);
+    });
+  });
+
+  describe("bumpOnSceneReady", () => {
+    it("emits a one-shot bump once the scene is available", () => {
+      const { result } = renderHook(() =>
+        useTemporalOverlayVersion(scene, { bumpOnSceneReady: true })
+      );
+
+      expect(result.current).toBe(1);
+    });
+
+    it("does not bump on mount when the scene is null", () => {
+      const { result } = renderHook(() =>
+        useTemporalOverlayVersion(null, { bumpOnSceneReady: true })
+      );
+
+      expect(result.current).toBe(0);
+    });
+
+    it("does not bump on mount when the flag is off", () => {
+      const { result } = renderHook(() => useTemporalOverlayVersion(scene));
+
+      expect(result.current).toBe(0);
+    });
+  });
+});

--- a/app/packages/video-annotation/src/hooks/useTemporalOverlayVersion.ts
+++ b/app/packages/video-annotation/src/hooks/useTemporalOverlayVersion.ts
@@ -1,0 +1,117 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { useAnnotationEventHandler } from "@fiftyone/annotation";
+import {
+  type Scene2D,
+  TemporalOverlay,
+  UNDEFINED_LIGHTER_SCENE_ID,
+  useLighterEventHandler,
+} from "@fiftyone/lighter";
+import type { LabelData } from "@fiftyone/utilities";
+import { useCallback, useEffect, useState } from "react";
+
+interface TemporalOverlayVersionOptions {
+  /**
+   * Bump on `annotation:labelEdit` for a `TemporalDetection` label.
+   * Default `false`.
+   */
+  listenLabelEdit?: boolean;
+  /**
+   * Emit a one-shot bump once `scene` becomes available, so TDs that
+   * `useTemporalOverlaySync` added before this hook's handlers registered are
+   * still picked up. Default `false`.
+   */
+  bumpOnSceneReady?: boolean;
+}
+
+type Bump = () => void;
+
+/** Bump on a `TemporalOverlay` add or any overlay removal in the scene. */
+const useSceneOverlayBumps = (scene: Scene2D | null, bump: Bump): void => {
+  const useLighterEvent = useLighterEventHandler(
+    scene?.getEventChannel() ?? UNDEFINED_LIGHTER_SCENE_ID
+  );
+
+  useLighterEvent(
+    "lighter:overlay-added",
+    useCallback(
+      (payload) => {
+        if (payload.overlay instanceof TemporalOverlay) {
+          bump();
+        }
+      },
+      [bump]
+    )
+  );
+
+  // The removed payload carries only an id, so we can't tell a TD from a
+  // detection by type — bump on ANY removal. Re-deriving the small TD set on an
+  // unrelated detection delete is cheap, and never missing a TD removal keeps
+  // the timeline rows in step.
+  useLighterEvent(
+    "lighter:overlay-removed",
+    useCallback(() => bump(), [bump])
+  );
+};
+
+/** Opt-in: bump on a `TemporalDetection` label edit. Handler is a no-op when off. */
+const useLabelEditBump = (enabled: boolean, bump: Bump): void => {
+  useAnnotationEventHandler(
+    "annotation:labelEdit",
+    useCallback(
+      (payload) => {
+        if (!enabled) {
+          return;
+        }
+
+        const cls = (payload.label as Partial<LabelData> | null)?._cls;
+        if (cls === "TemporalDetection") {
+          bump();
+        }
+      },
+      [bump, enabled]
+    )
+  );
+};
+
+/** Opt-in: emit a one-shot bump once `scene` becomes available. */
+const useSceneReadyBump = (
+  enabled: boolean,
+  scene: Scene2D | null,
+  bump: Bump
+): void => {
+  useEffect(() => {
+    if (enabled && scene) {
+      bump();
+    }
+  }, [enabled, scene, bump]);
+};
+
+/**
+ * A counter that bumps whenever the scene's `TemporalDetection` set could have
+ * changed — a `TemporalOverlay` added to, or a `td-` overlay removed from, the
+ * scene. Lets consumers re-derive scene-only TD state that a sample- or
+ * sidebar-derived signature can't observe.
+ *
+ * Two opt-in extras via {@link TemporalOverlayVersionOptions} cover the
+ * TD-track rebuild's needs; their handlers are always registered (no
+ * conditional hooks) and no-op when the flag is off.
+ */
+export function useTemporalOverlayVersion(
+  scene: Scene2D | null,
+  {
+    listenLabelEdit = false,
+    bumpOnSceneReady = false,
+  }: TemporalOverlayVersionOptions = {}
+): number {
+  const [version, setVersion] = useState(0);
+  const bump = useCallback(() => setVersion((v) => v + 1), []);
+
+  useSceneOverlayBumps(scene, bump);
+  useLabelEditBump(listenLabelEdit, bump);
+  useSceneReadyBump(bumpOnSceneReady, scene, bump);
+
+  return version;
+}

--- a/app/packages/video-annotation/src/hooks/useVfcClockSource.ts
+++ b/app/packages/video-annotation/src/hooks/useVfcClockSource.ts
@@ -1,0 +1,20 @@
+import { useEffect, type RefObject } from "react";
+import { usePlayback, usePresentedMediaTime } from "@fiftyone/playback";
+
+/**
+ * Register a `<video>` element's vfc-reported presentation time as the
+ * playback engine's clock source. The clock reads `null` before the first
+ * vfc tick lands, for which the engine falls back to its dt advance.
+ */
+export function useVfcClockSource(
+  videoRef: RefObject<HTMLVideoElement | null>
+): void {
+  const { setClockSource } = usePlayback();
+  const presentedMediaTimeRef = usePresentedMediaTime(videoRef);
+
+  useEffect(() => {
+    return setClockSource({
+      read: () => presentedMediaTimeRef.current,
+    });
+  }, [presentedMediaTimeRef, setClockSource]);
+}

--- a/app/packages/video-annotation/src/hooks/useVideoAnnotationActions.tsx
+++ b/app/packages/video-annotation/src/hooks/useVideoAnnotationActions.tsx
@@ -1,0 +1,148 @@
+import type { ToolbarActionGroup } from "@fiftyone/components";
+import { useModalSample } from "@fiftyone/state";
+import { Icon, IconName, Size } from "@voxel51/voodo";
+import { useMemo } from "react";
+import { frameAt, usePlayhead } from "@fiftyone/playback";
+import { getModalSampleFrameRate } from "../utils/modalSample";
+import { useTemporalDetectionFieldPaths } from "../state/accessors";
+import { useFrameLabelsStream } from "../streams/frameLabelsStream";
+import {
+  resolvePropagationTarget,
+  type PropagationTarget,
+} from "../propagation/propagationTarget";
+import { useSelectedTrackIds } from "../state/useVideoInteraction";
+import { useVideoPropagate } from "./useVideoPropagate";
+import { useVideoSurfaceActions } from "./useVideoSurfaceActions";
+
+/**
+ * Builds the data-driven config for the video annotation toolbar, mirroring
+ * the `ToolbarActionGroup` pattern used by `ActionToolbar` (segmentation, 3D).
+ *
+ * This hook is the single extension point for toolbar functionality: to add a
+ * button, append a {@link ToolbarActionItem} to a group's `actions` (or add a
+ * new group). Each item owns its own enablement, tooltip, and dispatch, so the
+ * renderer stays dumb and the toolbar doesn't grow into a monolith as features
+ * land. Reactive to the visual playhead and the intentional-selection atom, so
+ * enabled state and tooltips track the user scrubbing / selecting in real time.
+ *
+ * Mount inside the surface's `<PlaybackProvider>` + command bus (it is, via
+ * `FrameLabelsTracks`).
+ */
+export const useVideoAnnotationActions = (): ToolbarActionGroup[] => {
+  const actions = useVideoSurfaceActions();
+  const propagate = useVideoPropagate();
+  const stream = useFrameLabelsStream();
+  const playhead = usePlayhead();
+  const selected = useSelectedTrackIds();
+  const modalSample = useModalSample();
+
+  // Resolve from the dataset schema
+  const tdFieldPaths = useTemporalDetectionFieldPaths();
+
+  const tdFieldPath = useMemo(
+    // Sample-level only — temporal detections are video-level; the create
+    // command targets a top-level field path.
+    () => tdFieldPaths.find((p) => !p.startsWith("frames.")) ?? null,
+    [tdFieldPaths]
+  );
+  const fps = getModalSampleFrameRate(modalSample);
+  const canCreateTd =
+    !!tdFieldPath && Number.isFinite(fps) && fps !== undefined && fps > 0;
+
+  // Selection is keyed on the engine instanceId — the same id the propagation
+  // target resolver matches against the per-frame detections.
+  const selectedIds = useMemo(() => Array.from(selected), [selected]);
+  const hasSelection = selectedIds.length > 0;
+
+  // Recomputed each playhead tick / selection change so the Propagate
+  // affordance reflects the current frame's bracketing keyframes. When
+  // disabled, `reason` becomes the tooltip — the "why can't I propagate?"
+  // diagnostic.
+  const target = useMemo<PropagationTarget>(() => {
+    if (!stream) {
+      return { ok: false, reason: "No active video stream." };
+    }
+    return resolvePropagationTarget(stream, selectedIds, playhead);
+  }, [stream, selectedIds, playhead]);
+
+  // When propagation can't run, `reason` is the disabled-tooltip diagnostic.
+  const propagateTooltip =
+    target.ok === false
+      ? target.reason
+      : `Track frames ${target.fromFrame}–${target.toFrame} with SAM2`;
+
+  return useMemo<ToolbarActionGroup[]>(
+    () => [
+      {
+        id: "video-annotation-edit",
+        label: "Edit",
+        actions: [
+          {
+            id: "mark-keyframe",
+            label: "Mark Keyframe",
+            icon: <Icon name={IconName.VAL} size={Size.Sm} />,
+            shortcut: "K",
+            tooltip: hasSelection
+              ? "Toggle keyframe at this frame"
+              : "Select a label to mark a keyframe",
+            isDisabled: !hasSelection,
+            onClick: () => {
+              if (!hasSelection) return;
+              actions.markKeyframe(playhead, selectedIds);
+            },
+          },
+          {
+            id: "create-temporal-detection",
+            label: "New TD",
+            icon: <Icon name={IconName.Add} size={Size.Sm} />,
+            tooltip: canCreateTd
+              ? `Create a TemporalDetection on \`${tdFieldPath}\``
+              : "No TemporalDetections field on this dataset",
+            isDisabled: !canCreateTd,
+            onClick: () => {
+              if (!canCreateTd || !tdFieldPath || !fps) return;
+              // Default: 1-second window starting at the playhead frame.
+              const startFrame = frameAt(playhead, fps);
+              const endFrame = startFrame + Math.round(fps);
+              actions.createTemporalDetection(tdFieldPath, [
+                startFrame,
+                endFrame,
+              ]);
+            },
+          },
+          {
+            id: "propagate-sam2",
+            label: "Track (SAM2)",
+            icon: <Icon name={IconName.AI} size={Size.Sm} />,
+            tooltip: propagateTooltip,
+            isDisabled: !target.ok,
+            onClick: () => {
+              if (!target.ok) {
+                return;
+              }
+
+              void propagate(
+                target.instanceId,
+                target.fromFrame,
+                target.toFrame,
+                "sam2"
+              );
+            },
+          },
+        ],
+      },
+    ],
+    [
+      actions,
+      propagate,
+      canCreateTd,
+      fps,
+      hasSelection,
+      playhead,
+      propagateTooltip,
+      selectedIds,
+      target,
+      tdFieldPath,
+    ]
+  );
+};

--- a/app/packages/video-annotation/src/hooks/useVideoAnnotationSyncBundle.ts
+++ b/app/packages/video-annotation/src/hooks/useVideoAnnotationSyncBundle.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { useLighterSetupWithPixi } from "@fiftyone/lighter";
+import type { RefObject } from "react";
+import { useSyncLighterAnnotation } from "../sync/useSyncLighterAnnotation";
+import { useSyncMediaTransform } from "../sync/useSyncMediaTransform";
+import { useTemporalOverlaySync } from "../sync/useTemporalOverlaySync";
+
+type TileScene = ReturnType<typeof useLighterSetupWithPixi>["scene"];
+
+/**
+ * The overlay / sync hooks both lighter tiles wire up, in their order-sensitive
+ * order: TD overlay sync, the draw-mode / mode-quit event bridges, and media
+ * transform tracking.
+ *
+ * `mediaRef` is the element the media transform tracks so scroll-zoom scales
+ * the picture, not just the overlays — the `<video>` for the native tile, the
+ * frame `<canvas>` for imavid.
+ */
+export function useVideoAnnotationSyncBundle<T extends HTMLElement>({
+  scene,
+  canonicalMediaReady,
+  mediaRef,
+}: {
+  scene: TileScene;
+  canonicalMediaReady: boolean;
+  mediaRef: RefObject<T | null>;
+}): void {
+  useTemporalOverlaySync(scene, canonicalMediaReady);
+  useSyncLighterAnnotation(scene);
+  useSyncMediaTransform(scene, mediaRef);
+}

--- a/app/packages/video-annotation/src/hooks/useVideoLighterEngineBridge.ts
+++ b/app/packages/video-annotation/src/hooks/useVideoLighterEngineBridge.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import {
+  FRAMES_PREFIX,
+  useActiveSampleId,
+  useAnnotationEngine,
+  useLighterEngineBridge,
+} from "@fiftyone/annotation";
+import { useCallback } from "react";
+import { useDatasetId } from "../state/accessors";
+import { useCurrentFrameGetter } from "../state/useCurrentFrame";
+import { stashEstablishKey } from "../sync/establishKeyRelay";
+
+/**
+ * Mount the video canvas on the annotation engine. The tile's Lighter scene
+ * registers the engine's frame-locked Lighter bridge — the same contract the
+ * image surface uses — so overlay hydration, reconcile, gesture commits, and
+ * select/hover all route through the engine. The only video-specific input is
+ * `frameOf`: the playhead's current frame, stamped onto every ref so writes and
+ * selection address `(instanceId, frame)` (the `FrameStore` is frame-keyed; the
+ * scene holds one overlay per track, keyed by `instanceId`).
+ *
+ * Mount inside the surface's `PlaybackProvider` (for `useTimeline`) and AFTER
+ * the store registration + frame-clock attach, so the bridge reconciles against
+ * a seeded frame store and the `FrameTemporalView` rather than the degenerate
+ * pool view.
+ */
+export const useVideoLighterEngineBridge = (): void => {
+  const engine = useAnnotationEngine();
+  const sample = useActiveSampleId();
+  const dataset = useDatasetId();
+
+  // referentially stable frame reader — a new identity would re-create the
+  // bridge (clear + rehydrate); the playhead value is read live at call time
+  const getFrame = useCurrentFrameGetter();
+
+  // Stamp the playhead frame only onto frame-scoped paths (`frames.*`). A
+  // sample-level temporal detection sharing this scene must stay frame-less so
+  // its engine ref matches the sidebar / timeline; stamping a frame would make
+  // each surface address a different occurrence and break cross-surface select.
+  const frameOf = useCallback(
+    (path: string) => (path.startsWith(FRAMES_PREFIX) ? getFrame() : undefined),
+    [getFrame]
+  );
+
+  // paths left unscoped: the composite store registers a single frame-detection
+  // field; sample-level temporal-detections carry no Lighter adapter, so the
+  // loop's kind filter drops them from hydration, but their select/hover events
+  // still route through the bridge (frame-less ref, instanceId == the TD `_id`).
+  // Stash each draw's gesture key by overlay id so the auto-extend can fold its
+  // filler into the draw's undo unit (one Ctrl-Z removes the whole drawn track).
+  useLighterEngineBridge({
+    engine,
+    sample,
+    dataset,
+    frameOf,
+    onEstablishCommit: stashEstablishKey,
+  });
+};

--- a/app/packages/video-annotation/src/hooks/useVideoPropagate.ts
+++ b/app/packages/video-annotation/src/hooks/useVideoPropagate.ts
@@ -1,0 +1,295 @@
+import {
+  AgentTaskType,
+  type AnnotationAgent,
+  type PropagationContext,
+  type PropagationInferenceResult,
+  type SAM2PropagationBrowserAgent,
+  useActiveSampleId,
+  useAgentRegistry,
+  useAnnotationEngine,
+  useSampleDescriptor,
+} from "@fiftyone/annotation";
+import type {
+  LabelData,
+  PropagationBlob,
+  SyntheticBox,
+} from "@fiftyone/utilities";
+import { createElement, useCallback } from "react";
+import { PropagationStatusItem } from "../components/PropagationStatusItem";
+import {
+  useApplyPropagatedDetection,
+  useApplyPropagationResult,
+} from "../propagation/useApplyPropagationResult";
+import { useVideoAnnotationStatus } from "../state/videoAnnotationStatus";
+import { useFrameLabelsStream } from "../streams/frameLabelsStream";
+import { useImaVidImageStream } from "../streams/imaVidImageStreamHandle";
+
+export type PropagationMethod = "sam2" | "linear";
+
+/** The engine's stored detection as the `SyntheticBox` the agents consume. */
+const toSyntheticBox = (label: LabelData): SyntheticBox => ({
+  id: label._id,
+  _id: label._id,
+  label: (label.label as string) ?? "",
+  bounding_box: label.bounding_box as [number, number, number, number],
+  index: label.index as number | undefined,
+  instance: label.instance as SyntheticBox["instance"],
+  keyframe: (label.keyframe as boolean) ?? false,
+  propagation: (label.propagation as PropagationBlob | null) ?? null,
+});
+
+/**
+ * The streaming SAM2 agent is registered under the broad `AnnotationAgent`
+ * type but driven through its dedicated `propagate()` (which carries the frame
+ * source). Narrow by that method rather than casting blind.
+ */
+const isSam2Agent = (
+  agent: AnnotationAgent<PropagationInferenceResult>
+): agent is SAM2PropagationBrowserAgent =>
+  typeof (agent as Partial<SAM2PropagationBrowserAgent>).propagate ===
+  "function";
+
+/** Resolves a registered agent by id, or `null` when absent. */
+const useResolveAgent = () => {
+  const registry = useAgentRegistry();
+
+  return useCallback(
+    async (
+      id: string
+    ): Promise<AnnotationAgent<PropagationInferenceResult> | null> => {
+      const agents = await registry.listAgents();
+      const descriptor = agents.find((a) => a.id === id);
+
+      return descriptor
+        ? (descriptor.agent as AnnotationAgent<PropagationInferenceResult>)
+        : null;
+    },
+    [registry]
+  );
+};
+
+/** A track's box at a frame, read through the engine. */
+type FrameReader = (frame: number) => LabelData | undefined;
+
+interface PropagateArgs {
+  instanceId: string;
+  fromFrame: number;
+  toFrame: number;
+  /** Frames-field path of the active stream. */
+  path: string;
+  /** Reads the track's box at a frame through the engine. */
+  at: FrameReader;
+  /** The seed keyframe (already verified present + keyframe). */
+  leftKeyframe: LabelData;
+  /** The end keyframe, if any. */
+  rightKeyframe: LabelData | undefined;
+}
+
+/**
+ * SAM2 tracking runs asynchronously over the decoded ImaVid frames and streams
+ * a detection per frame as inference lands. Per-frame writes can't share one
+ * synchronous transaction, so they coalesce under a single minted gesture id
+ * (one undo unit per propagation). No-ops without an image stream.
+ */
+const useSam2Propagate = () => {
+  const engine = useAnnotationEngine();
+  const imageStream = useImaVidImageStream();
+  const resolveAgent = useResolveAgent();
+  const sampleDescriptor = useSampleDescriptor();
+  const applyPropagatedDetection = useApplyPropagatedDetection();
+  const { setContent: setStatusContent } = useVideoAnnotationStatus();
+
+  return useCallback(
+    async (args: PropagateArgs): Promise<boolean> => {
+      const { instanceId, fromFrame, toFrame, leftKeyframe, rightKeyframe } =
+        args;
+
+      if (!imageStream) {
+        return false;
+      }
+
+      const agent = await resolveAgent("propagate-sam2");
+
+      if (!agent || !isSam2Agent(agent)) {
+        return false;
+      }
+
+      const undoKey = engine.mintGestureId();
+
+      let aborted = false;
+      const onStop = () => {
+        aborted = true;
+      };
+
+      // Drive the phase off `onProgress` (monotonic, fires once per-frame
+      // inference starts) rather than the agent lifecycle, which churns
+      // inferring→encoding→idle every frame and would flicker the label.
+      // Until the first progress tick we're in the one-time model download /
+      // encode, shown as an indeterminate "Loading SAM2…".
+      let tracking = false;
+      const render = (done?: number, runTotal?: number) =>
+        setStatusContent(
+          createElement(PropagationStatusItem, {
+            label: tracking ? "SAM2 tracking" : "Loading SAM2…",
+            done,
+            total: runTotal,
+            onStop,
+          })
+        );
+      render();
+
+      // Map a 1-based frame number to its decoded bitmap, fetching + decoding
+      // on demand if the LRU doesn't already hold it.
+      const getFrameBitmap = async (
+        frameNumber: number
+      ): Promise<ImageBitmap> => {
+        const time = (frameNumber - 1) / imageStream.fps;
+        await imageStream.warmup(time);
+        const frame = imageStream.getValue(time);
+
+        if (!frame) {
+          throw new Error(`ImaVid frame ${frameNumber} unavailable`);
+        }
+
+        return frame.bitmap;
+      };
+
+      try {
+        await agent.propagate({
+          instanceId,
+          seedKeyframe: toSyntheticBox(leftKeyframe),
+          endKeyframe: rightKeyframe
+            ? toSyntheticBox(rightKeyframe)
+            : undefined,
+          fromFrame,
+          toFrame,
+          videoKey: sampleDescriptor.sampleId,
+          getFrameBitmap,
+          onDetection: (frameNumber, detection) =>
+            applyPropagatedDetection(frameNumber, detection, { undoKey }),
+          onProgress: (done, runTotal) => {
+            tracking = true;
+            render(done, runTotal);
+          },
+          shouldAbort: () => aborted,
+        });
+        return true;
+      } catch (err) {
+        console.error("[va] SAM2 propagation failed", err);
+        return false;
+      } finally {
+        setStatusContent(null);
+      }
+    },
+    [
+      engine,
+      imageStream,
+      resolveAgent,
+      sampleDescriptor,
+      applyPropagatedDetection,
+      setStatusContent,
+    ]
+  );
+};
+
+/**
+ * Linear interpolation lerps the bracketing keyframe pair in one synchronous
+ * inference call. No-ops without an end keyframe to lerp toward.
+ */
+const useLinearPropagate = () => {
+  const resolveAgent = useResolveAgent();
+  const sampleDescriptor = useSampleDescriptor();
+  const applyPropagation = useApplyPropagationResult();
+
+  return useCallback(
+    async (args: PropagateArgs): Promise<boolean> => {
+      const { instanceId, fromFrame, toFrame, leftKeyframe, rightKeyframe } =
+        args;
+
+      if (!rightKeyframe) {
+        return false;
+      }
+
+      const agent = await resolveAgent("propagate-linear");
+
+      if (!agent) {
+        return false;
+      }
+
+      const context: PropagationContext = {
+        sampleDescriptor,
+        taskType: AgentTaskType.PROPAGATE,
+        instanceId,
+        fromFrame,
+        toFrame,
+        parentKeyframes: [
+          toSyntheticBox(leftKeyframe),
+          toSyntheticBox(rightKeyframe),
+        ],
+      };
+
+      const result = await agent.infer(context);
+      applyPropagation(result);
+      return true;
+    },
+    [resolveAgent, sampleDescriptor, applyPropagation]
+  );
+};
+
+/**
+ * Run object-track propagation between two keyframes of one instance,
+ * dispatching to the SAM2 or linear pipeline by `method`. The seed / end
+ * keyframes are read with `engine.getLabel` (the track's box at a frame) and
+ * results apply through the engine writers.
+ *
+ * Returns `true` when work was applied. No-ops (returns `false`) without a
+ * stream, on a degenerate range, or when the seed frame isn't a keyframe.
+ */
+export const useVideoPropagate = () => {
+  const engine = useAnnotationEngine();
+  const sampleId = useActiveSampleId();
+  const stream = useFrameLabelsStream();
+  const sam2Propagate = useSam2Propagate();
+  const linearPropagate = useLinearPropagate();
+
+  return useCallback(
+    async (
+      instanceId: string,
+      fromFrame: number,
+      toFrame: number,
+      method: PropagationMethod
+    ): Promise<boolean> => {
+      if (!stream || fromFrame >= toFrame) {
+        return false;
+      }
+
+      const path = `frames.${stream.labelsField}`;
+      const at: FrameReader = (frame) =>
+        engine.getLabel({ sample: sampleId, path, instanceId, frame });
+
+      const leftKeyframe = at(fromFrame);
+
+      if (!leftKeyframe?.keyframe) {
+        return false;
+      }
+
+      const rightKeyframe = at(toFrame);
+      const args: PropagateArgs = {
+        instanceId,
+        fromFrame,
+        toFrame,
+        path,
+        at,
+        leftKeyframe,
+        rightKeyframe,
+      };
+
+      if (method === "sam2") {
+        return sam2Propagate(args);
+      }
+
+      return linearPropagate(args);
+    },
+    [engine, sampleId, stream, sam2Propagate, linearPropagate]
+  );
+};

--- a/app/packages/video-annotation/src/hooks/useVideoSurfaceActions.test.ts
+++ b/app/packages/video-annotation/src/hooks/useVideoSurfaceActions.test.ts
@@ -1,0 +1,218 @@
+/**
+ * The engine-native video actions: track-id → instanceId mapping, per-frame ref
+ * stamping, one-transaction-per-op grouping, keyframe/track notification events,
+ * and TD ops routed sample-level (no frame). Engine correctness lives in the
+ * store/engine tests; here we assert the hook emits the right ops.
+ */
+
+import { renderHook } from "@testing-library/react";
+import type { LabelData } from "@fiftyone/utilities";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useVideoSurfaceActions } from "./useVideoSurfaceActions";
+
+const SAMPLE = "v";
+const PATH = "frames.detections";
+
+// per-frame engine truth the hook reads through `engine.getLabel`
+let frameData: Record<number, Record<string, LabelData>>;
+
+const mockEngine = {
+  getLabel: ({ instanceId, frame }: { instanceId: string; frame?: number }) =>
+    frame != null ? frameData[frame]?.[instanceId] : undefined,
+};
+
+const mockActions = {
+  transaction: vi.fn((fn: () => unknown) => fn()),
+  updateLabel: vi.fn(),
+  deleteLabel: vi.fn(),
+  createLabel: vi.fn(() => ({
+    sample: SAMPLE,
+    path: "events",
+    instanceId: "new-td",
+  })),
+};
+
+const mockBus = { dispatch: vi.fn() };
+const mockStream = { fps: 10, totalFrames: 5, labelsField: "detections" };
+
+vi.mock("@fiftyone/annotation", () => ({
+  useAnnotationEngine: () => mockEngine,
+  useSurfaceActions: () => mockActions,
+  useActiveSampleId: () => SAMPLE,
+  useAnnotationEventBus: () => mockBus,
+}));
+
+vi.mock("@fiftyone/playback", () => ({ frameAt: (time: number) => time }));
+
+vi.mock("../streams/frameLabelsStream", () => ({
+  useFrameLabelsStream: () => mockStream,
+}));
+
+const det = (
+  id: string,
+  instanceId: string,
+  over: Partial<LabelData> = {}
+): LabelData => ({
+  _id: id,
+  _cls: "Detection",
+  instance: { _id: instanceId, _cls: "Instance" },
+  label: "x",
+  bounding_box: [0, 0, 1, 1],
+  ...over,
+});
+
+const render = () => renderHook(() => useVideoSurfaceActions()).result;
+
+beforeEach(() => {
+  frameData = {};
+  vi.clearAllMocks();
+});
+
+describe("track ops", () => {
+  it("markKeyframe toggles keyframe on the addressed frame and notifies", () => {
+    frameData = {
+      2: { A: det("d2", "A", { keyframe: false, propagation: { foo: 1 } }) },
+    };
+
+    render().current.markKeyframe(2, ["instance-A"]);
+
+    expect(mockActions.transaction).toHaveBeenCalledTimes(1);
+    expect(mockActions.updateLabel).toHaveBeenCalledWith(
+      { path: PATH, instanceId: "A", frame: 2 },
+      { keyframe: true, propagation: null }
+    );
+    expect(mockBus.dispatch).toHaveBeenCalledWith(
+      "annotation:keyframeChanged",
+      {
+        trackId: "instance-A",
+        instanceId: "A",
+        frame: 2,
+        kind: "set",
+      }
+    );
+  });
+
+  it("markKeyframe skips a legacy track-<index> id (no engine identity)", () => {
+    frameData = { 2: { A: det("d2", "A") } };
+
+    render().current.markKeyframe(2, ["track-4"]);
+
+    expect(mockActions.updateLabel).not.toHaveBeenCalled();
+    expect(mockBus.dispatch).not.toHaveBeenCalled();
+  });
+
+  it("extendTrack fills target frames with the source content as non-keyframes", () => {
+    frameData = {
+      1: { A: det("d1", "A", { keyframe: true, confidence: 0.9 }) },
+    };
+
+    render().current.extendTrack("instance-A", 1, [2, 3, 99]);
+
+    // 99 is out of range [1,5] and dropped; identity fields stripped from content
+    expect(mockActions.updateLabel).toHaveBeenCalledTimes(2);
+    expect(mockActions.updateLabel).toHaveBeenCalledWith(
+      { path: PATH, instanceId: "A", frame: 2 },
+      {
+        _cls: "Detection",
+        label: "x",
+        bounding_box: [0, 0, 1, 1],
+        confidence: 0.9,
+        keyframe: false,
+      }
+    );
+  });
+
+  it("trimTrack deletes only frames where the track is present", () => {
+    frameData = { 2: { A: det("d2", "A") } };
+
+    render().current.trimTrack("instance-A", [2, 3]);
+
+    expect(mockActions.deleteLabel).toHaveBeenCalledTimes(1);
+    expect(mockActions.deleteLabel).toHaveBeenCalledWith({
+      path: PATH,
+      instanceId: "A",
+      frame: 2,
+    });
+  });
+
+  it("shiftTrack deletes originals then re-lays content at frame+delta", () => {
+    frameData = { 2: { A: det("d2", "A", { keyframe: true }) } };
+
+    render().current.shiftTrack("instance-A", [2], 1);
+
+    expect(mockActions.deleteLabel).toHaveBeenCalledWith({
+      path: PATH,
+      instanceId: "A",
+      frame: 2,
+    });
+    expect(mockActions.updateLabel).toHaveBeenCalledWith(
+      { path: PATH, instanceId: "A", frame: 3 },
+      {
+        _cls: "Detection",
+        label: "x",
+        bounding_box: [0, 0, 1, 1],
+        keyframe: true,
+      }
+    );
+  });
+
+  it("deleteTrack removes every frame it appears on and notifies", () => {
+    frameData = { 1: { A: det("d1", "A") }, 4: { A: det("d4", "A") } };
+
+    render().current.deleteTrack("instance-A");
+
+    expect(mockActions.deleteLabel).toHaveBeenCalledTimes(2);
+    expect(mockBus.dispatch).toHaveBeenCalledWith("annotation:trackDeleted", {
+      trackId: "instance-A",
+    });
+  });
+
+  it("updateTrackAttributes merges onto every frame", () => {
+    frameData = { 1: { A: det("d1", "A") }, 3: { A: det("d3", "A") } };
+
+    render().current.updateTrackAttributes("instance-A", { label: "car" });
+
+    expect(mockActions.updateLabel).toHaveBeenCalledTimes(2);
+    expect(mockActions.updateLabel).toHaveBeenCalledWith(
+      { path: PATH, instanceId: "A", frame: 1 },
+      { label: "car" }
+    );
+  });
+});
+
+describe("temporal-detection ops", () => {
+  it("createTemporalDetection mints a sample-level TD and returns its id", () => {
+    const id = render().current.createTemporalDetection(
+      "events",
+      [3, 12],
+      "speaking"
+    );
+
+    expect(id).toBe("new-td");
+    expect(mockActions.createLabel).toHaveBeenCalledWith("events", {
+      _cls: "TemporalDetection",
+      support: [3, 12],
+      tags: [],
+      label: "speaking",
+    });
+  });
+
+  it("editTemporalDetection updates by id with no frame", () => {
+    render().current.editTemporalDetection("events", "t1", { support: [5, 9] });
+
+    expect(mockActions.updateLabel).toHaveBeenCalledWith(
+      { path: "events", instanceId: "t1" },
+      { support: [5, 9] }
+    );
+  });
+
+  it("deleteTemporalDetection deletes by id with no frame", () => {
+    render().current.deleteTemporalDetection("events", "t1");
+
+    expect(mockActions.deleteLabel).toHaveBeenCalledWith({
+      path: "events",
+      instanceId: "t1",
+    });
+  });
+});

--- a/app/packages/video-annotation/src/hooks/useVideoSurfaceActions.ts
+++ b/app/packages/video-annotation/src/hooks/useVideoSurfaceActions.ts
@@ -1,0 +1,400 @@
+import {
+  useAnnotationEngine,
+  useAnnotationEventBus,
+  useActiveSampleId,
+  useSurfaceActions,
+} from "@fiftyone/annotation";
+import type { LabelRef } from "@fiftyone/annotation";
+import type { LabelData } from "@fiftyone/utilities";
+import { frameAt } from "@fiftyone/playback";
+import { useMemo } from "react";
+import { instanceIdFromTrackId } from "../tracks/trackIdentity";
+import { useFrameLabelsStream } from "../streams/frameLabelsStream";
+
+const SURFACE = "video";
+
+export interface VideoSurfaceActions {
+  /** Toggle `keyframe` on each selected track at `time`'s frame, in one undo unit. */
+  markKeyframe(time: number, trackIds: readonly string[]): void;
+  /**
+   * Fill `targetFrames` with the source frame's box (non-keyframe). Pass
+   * `undoKey` to coalesce the fill into a prior commit's undo unit (the
+   * auto-extend folds into the draw that triggered it).
+   */
+  extendTrack(
+    trackId: string,
+    sourceFrame: number,
+    targetFrames: number[],
+    undoKey?: string
+  ): void;
+  /** Delete this track's box on each of `frames`. */
+  trimTrack(trackId: string, frames: number[]): void;
+  /** Move this track's boxes on `frames` by `delta`, keyframe/propagation intact. */
+  shiftTrack(trackId: string, frames: number[], delta: number): void;
+  /** Delete this track's box on every frame it appears. */
+  deleteTrack(trackId: string): void;
+  /** Merge track-level attributes onto every frame this track appears. */
+  updateTrackAttributes(
+    trackId: string,
+    attributes: Record<string, unknown>
+  ): void;
+  /** Create a sample-level TemporalDetection; returns its id (the new instanceId). */
+  createTemporalDetection(
+    fieldPath: string,
+    support: [number, number],
+    label?: string
+  ): string;
+  /** Edit a sample-level TemporalDetection (e.g. `support`). */
+  editTemporalDetection(
+    fieldPath: string,
+    detectionId: string,
+    update: Partial<LabelData>
+  ): void;
+  /** Delete a sample-level TemporalDetection. */
+  deleteTemporalDetection(fieldPath: string, detectionId: string): void;
+}
+
+type SurfaceActions = ReturnType<typeof useSurfaceActions>;
+type AnnotationEngine = ReturnType<typeof useAnnotationEngine>;
+type AnnotationEventBus = ReturnType<typeof useAnnotationEventBus>;
+
+/** Narrowed, non-null inputs every per-frame op needs to run. */
+interface ReadyContext {
+  sample: string;
+  path: string;
+  fps: number;
+  totalFrames: number;
+}
+
+/** Engine-backed reads scoped to the active sample + frames field. */
+interface FrameReader {
+  /** This track's detection on a frame, read through the engine. */
+  read(instanceId: string, frame: number): LabelData | undefined;
+  /** A detection's content minus engine-owned identity (re-stamped on write). */
+  content(label: LabelData): Partial<LabelData>;
+  /** Every frame [1, total] this track appears on. */
+  trackFrames(instanceId: string): number[];
+}
+
+const makeFrameReader = (
+  engine: AnnotationEngine,
+  ctx: ReadyContext
+): FrameReader => {
+  const read = (instanceId: string, frame: number): LabelData | undefined =>
+    engine.getLabel({
+      sample: ctx.sample,
+      path: ctx.path,
+      instanceId,
+      frame,
+    });
+
+  const content = (label: LabelData): Partial<LabelData> => {
+    const { _id, instance, ...rest } = label;
+    return rest;
+  };
+
+  const trackFrames = (instanceId: string): number[] => {
+    const frames: number[] = [];
+
+    for (let frame = 1; frame <= ctx.totalFrames; frame++) {
+      if (read(instanceId, frame)) {
+        frames.push(frame);
+      }
+    }
+
+    return frames;
+  };
+
+  return { read, content, trackFrames };
+};
+
+/** Per-frame track ops (keyframes, fills, trims, shifts, deletes, attributes). */
+const makeTrackOps = (
+  ctx: ReadyContext,
+  actions: SurfaceActions,
+  eventBus: AnnotationEventBus,
+  reader: FrameReader
+) => {
+  const { path, fps, totalFrames } = ctx;
+  const { read, content, trackFrames } = reader;
+
+  const markKeyframe = (time: number, trackIds: readonly string[]): void => {
+    if (trackIds.length === 0) {
+      return;
+    }
+
+    const frame = frameAt(time, fps, totalFrames);
+    const changed: { trackId: string; instanceId: string; set: boolean }[] = [];
+
+    actions.transaction(() => {
+      for (const trackId of trackIds) {
+        const instanceId = instanceIdFromTrackId(trackId);
+
+        if (!instanceId) {
+          continue;
+        }
+
+        const det = read(instanceId, frame);
+
+        if (!det) {
+          continue;
+        }
+
+        const set = !det.keyframe;
+        const update: Partial<LabelData> = { keyframe: set };
+
+        // promotion clears interpolation provenance — only when present, so
+        // an unchanged baseline doesn't accrue a no-op `propagation: null` op
+        if (set && det.propagation) {
+          update.propagation = null;
+        }
+
+        actions.updateLabel({ path, instanceId, frame }, update);
+        changed.push({ trackId, instanceId, set });
+      }
+    });
+
+    for (const { trackId, instanceId, set } of changed) {
+      eventBus.dispatch("annotation:keyframeChanged", {
+        trackId,
+        instanceId,
+        frame,
+        kind: set ? "set" : "removed",
+      });
+    }
+  };
+
+  const extendTrack = (
+    trackId: string,
+    sourceFrame: number,
+    targetFrames: number[],
+    undoKey?: string
+  ): void => {
+    const instanceId = instanceIdFromTrackId(trackId);
+
+    if (!instanceId || targetFrames.length === 0) {
+      return;
+    }
+
+    const source = read(instanceId, sourceFrame);
+
+    if (!source) {
+      return;
+    }
+
+    // non-keyframe filler — a later propagate overwrites these in place
+    const filler = { ...content(source), keyframe: false };
+
+    actions.transaction(
+      () => {
+        for (const frame of targetFrames) {
+          if (frame >= 1 && frame <= totalFrames) {
+            actions.updateLabel({ path, instanceId, frame }, filler);
+          }
+        }
+      },
+      undoKey ? { undoKey } : undefined
+    );
+  };
+
+  const trimTrack = (trackId: string, frames: number[]): void => {
+    const instanceId = instanceIdFromTrackId(trackId);
+
+    if (!instanceId || frames.length === 0) {
+      return;
+    }
+
+    actions.transaction(() => {
+      for (const frame of frames) {
+        if (read(instanceId, frame)) {
+          actions.deleteLabel({ path, instanceId, frame });
+        }
+      }
+    });
+  };
+
+  const shiftTrack = (
+    trackId: string,
+    frames: number[],
+    delta: number
+  ): void => {
+    const instanceId = instanceIdFromTrackId(trackId);
+
+    if (!instanceId || delta === 0 || frames.length === 0) {
+      return;
+    }
+
+    // read the whole segment up front so the delete/write passes operate on
+    // a stable snapshot
+    const sources = frames
+      .map((frame) => ({ frame, det: read(instanceId, frame) }))
+      .filter((s): s is { frame: number; det: LabelData } => !!s.det);
+
+    if (sources.length === 0) {
+      return;
+    }
+
+    actions.transaction(() => {
+      for (const { frame } of sources) {
+        actions.deleteLabel({ path, instanceId, frame });
+      }
+
+      for (const { frame, det } of sources) {
+        const target = frame + delta;
+
+        if (target >= 1 && target <= totalFrames) {
+          actions.updateLabel(
+            { path, instanceId, frame: target },
+            content(det)
+          );
+        }
+      }
+    });
+  };
+
+  const deleteTrack = (trackId: string): void => {
+    const instanceId = instanceIdFromTrackId(trackId);
+
+    if (!instanceId) {
+      return;
+    }
+
+    const frames = trackFrames(instanceId);
+
+    if (frames.length === 0) {
+      return;
+    }
+
+    actions.transaction(() => {
+      for (const frame of frames) {
+        actions.deleteLabel({ path, instanceId, frame });
+      }
+    });
+
+    // let selection/editing consumers drop state bound to this track
+    eventBus.dispatch("annotation:trackDeleted", { trackId });
+  };
+
+  const updateTrackAttributes = (
+    trackId: string,
+    attributes: Record<string, unknown>
+  ): void => {
+    const instanceId = instanceIdFromTrackId(trackId);
+
+    if (!instanceId || Object.keys(attributes).length === 0) {
+      return;
+    }
+
+    const frames = trackFrames(instanceId);
+
+    actions.transaction(() => {
+      for (const frame of frames) {
+        actions.updateLabel({ path, instanceId, frame }, attributes);
+      }
+    });
+  };
+
+  return {
+    markKeyframe,
+    extendTrack,
+    trimTrack,
+    shiftTrack,
+    deleteTrack,
+    updateTrackAttributes,
+  };
+};
+
+/** Sample-level TemporalDetection ops (no frame on the ref). */
+const makeTemporalDetectionOps = (actions: SurfaceActions) => {
+  const createTemporalDetection = (
+    fieldPath: string,
+    support: [number, number],
+    label?: string
+  ): string => {
+    const ref: LabelRef = actions.createLabel(fieldPath, {
+      _cls: "TemporalDetection",
+      support,
+      // mirror the server-materialized default so a tag edit has a real
+      // array and the next refetch diff doesn't see an absent key
+      tags: [],
+      ...(label !== undefined ? { label } : {}),
+    });
+
+    return ref.instanceId;
+  };
+
+  const editTemporalDetection = (
+    fieldPath: string,
+    detectionId: string,
+    update: Partial<LabelData>
+  ): void => {
+    actions.updateLabel({ path: fieldPath, instanceId: detectionId }, update);
+  };
+
+  const deleteTemporalDetection = (
+    fieldPath: string,
+    detectionId: string
+  ): void => {
+    actions.deleteLabel({ path: fieldPath, instanceId: detectionId });
+  };
+
+  return {
+    createTemporalDetection,
+    editTemporalDetection,
+    deleteTemporalDetection,
+  };
+};
+
+/**
+ * Engine-native video annotation writes. Every op is an
+ * {@link AnnotationEngine} transaction over the registered composite store:
+ * per-frame detections route to the `FrameStore` (ref carries `frame`),
+ * sample-level temporal-detections route to the `SampleLabelStore` (no
+ * `frame`). The engine owns identity, undo, and persistence; this layer maps
+ * the timeline's synthetic track ids to engine `instanceId`s and reads current
+ * geometry through the engine, not the stream.
+ *
+ * Per-frame ops no-op until a labels stream is published (it supplies fps /
+ * frame-count / field) and a sample is active. Mount under the surface's modal
+ * scope.
+ */
+export const useVideoSurfaceActions = (): VideoSurfaceActions => {
+  const engine = useAnnotationEngine();
+  const actions = useSurfaceActions(engine, SURFACE);
+  const sampleId = useActiveSampleId();
+  const stream = useFrameLabelsStream();
+  const eventBus = useAnnotationEventBus();
+
+  return useMemo<VideoSurfaceActions>(() => {
+    const ctx: ReadyContext | null =
+      sampleId && stream && stream.fps
+        ? {
+            sample: sampleId,
+            path: `frames.${stream.labelsField}`,
+            fps: stream.fps,
+            totalFrames: stream.totalFrames ?? 0,
+          }
+        : null;
+
+    const temporal = makeTemporalDetectionOps(actions);
+
+    if (!ctx) {
+      // TD ops are sample-level and stream-independent; per-frame track ops
+      // no-op until the stream + sample are ready.
+      return {
+        markKeyframe: () => {},
+        extendTrack: () => {},
+        trimTrack: () => {},
+        shiftTrack: () => {},
+        deleteTrack: () => {},
+        updateTrackAttributes: () => {},
+        ...temporal,
+      };
+    }
+
+    const reader = makeFrameReader(engine, ctx);
+    const track = makeTrackOps(ctx, actions, eventBus, reader);
+
+    return { ...track, ...temporal };
+  }, [engine, actions, sampleId, stream, eventBus]);
+};

--- a/app/packages/video-annotation/src/hooks/useWarmupThenSeek.ts
+++ b/app/packages/video-annotation/src/hooks/useWarmupThenSeek.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { useEffect } from "react";
+import { usePlayback } from "@fiftyone/playback";
+
+/** A stream that can prefetch the chunk containing a given stream time. */
+interface Warmupable {
+  warmup(time: number): Promise<void>;
+}
+
+/**
+ * Warm up the chunk containing `time`, then `seek` to it once the warmup
+ * resolves. The engine's `seek` only commits when every blocking stream is
+ * already ready, so without the warmup the seek queues silently and the first
+ * paint stays blank until the user presses play; with it, content paints as
+ * soon as the first chunk lands.
+ *
+ * Pass the stream from a construct-once ref (stable identity) so the effect
+ * runs once per registration.
+ */
+export function useWarmupThenSeek(stream: Warmupable | null, time = 0): void {
+  const { seek } = usePlayback();
+
+  useEffect(() => {
+    if (!stream) {
+      return undefined;
+    }
+
+    let cancelled = false;
+    void stream.warmup(time).then(() => {
+      if (!cancelled) {
+        seek(time);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [stream, seek, time]);
+}

--- a/app/packages/video-annotation/src/media/ExternalCanonicalMedia.test.ts
+++ b/app/packages/video-annotation/src/media/ExternalCanonicalMedia.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { letterboxRect } from "./ExternalCanonicalMedia";
+
+describe("letterboxRect", () => {
+  it("fills exactly when aspect ratios match", () => {
+    expect(letterboxRect({ width: 1920, height: 1080 }, 1280, 720)).toEqual({
+      x: 0,
+      y: 0,
+      width: 1280,
+      height: 720,
+    });
+  });
+
+  it("pillarboxes media wider than the container", () => {
+    expect(letterboxRect({ width: 200, height: 100 }, 100, 100)).toEqual({
+      x: 0,
+      y: 25,
+      width: 100,
+      height: 50,
+    });
+  });
+
+  it("letterboxes media taller than the container", () => {
+    expect(letterboxRect({ width: 100, height: 200 }, 100, 100)).toEqual({
+      x: 25,
+      y: 0,
+      width: 50,
+      height: 100,
+    });
+  });
+});

--- a/app/packages/video-annotation/src/media/ExternalCanonicalMedia.ts
+++ b/app/packages/video-annotation/src/media/ExternalCanonicalMedia.ts
@@ -1,0 +1,159 @@
+import type {
+  CanonicalMedia,
+  Dimensions,
+  Rect,
+  Renderer2D,
+} from "@fiftyone/lighter";
+// Deep import (not the `@fiftyone/lighter` barrel): `ExternalCanonicalMedia`
+// extends `BaseOverlay`, and pulling the base class through the barrel triggers
+// a circular-init failure (the class is `undefined` at `extends` time).
+import { BaseOverlay } from "@fiftyone/lighter/src/overlay/BaseOverlay";
+
+/**
+ * Letterbox `original` to fit a `containerW`×`containerH` box while keeping
+ * aspect ratio, centering on the constrained axis.
+ */
+export function letterboxRect(
+  original: Dimensions,
+  containerW: number,
+  containerH: number
+): Rect {
+  const origAspect = original.width / original.height;
+  const targetAspect = containerW / containerH;
+
+  let width: number;
+  let height: number;
+  let x = 0;
+  let y = 0;
+
+  if (origAspect > targetAspect) {
+    width = containerW;
+    height = containerW / origAspect;
+    y = (containerH - height) / 2;
+  } else {
+    height = containerH;
+    width = containerH * origAspect;
+    x = (containerW - width) / 2;
+  }
+
+  return { x, y, width, height };
+}
+
+function makeExternalCanonicalId(): string {
+  const suffix = Math.random().toString(36).slice(2, 7);
+
+  return `external-canonical-${Date.now()}-${suffix}`;
+}
+
+/**
+ * Minimal CanonicalMedia for tiles whose visible pixels come from a
+ * non-Lighter element layered behind the canvas — a `<video>` for the
+ * native-video tile, an `<img>` for the ImaVid (image-per-frame) tile.
+ * Provides coordinate-space bounds (intrinsic media dimensions +
+ * container-fitted rendered bounds) so Lighter overlays position
+ * correctly, but draws no pixels of its own.
+ *
+ * Not `ImageOverlay`: it sizes from the loaded image's natural dimensions
+ * (collapsing the coordinate space to a placeholder) and paints a sprite every
+ * frame; we want intrinsic-resolution bounds and no pixels of our own.
+ */
+export class ExternalCanonicalMedia
+  extends BaseOverlay
+  implements CanonicalMedia
+{
+  private originalDimensions: Dimensions;
+  private currentBounds: Rect = { x: 0, y: 0, width: 0, height: 0 };
+  private resizeObserver?: ResizeObserver;
+  private detach?: () => void;
+
+  constructor(opts: { width: number; height: number }) {
+    super(makeExternalCanonicalId(), "", null as never);
+
+    this.originalDimensions = { width: opts.width, height: opts.height };
+  }
+
+  override getOverlayType(): string {
+    return "ExternalCanonicalMedia";
+  }
+
+  override setRenderer(renderer: Renderer2D): void {
+    super.setRenderer(renderer);
+
+    const canvas = renderer.getCanvas();
+    const parent = canvas?.parentElement;
+    if (!parent) {
+      return;
+    }
+
+    this.updateBoundsFromContainer(parent.clientWidth, parent.clientHeight);
+
+    this.resizeObserver?.disconnect();
+    this.resizeObserver = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) {
+        return;
+      }
+
+      const { width, height } = entry.contentRect;
+      this.updateBoundsFromContainer(width, height);
+    });
+    this.resizeObserver.observe(parent);
+
+    this.detach = () => {
+      this.resizeObserver?.disconnect();
+      this.resizeObserver = undefined;
+    };
+  }
+
+  protected renderImpl(): void {
+    // No-op: the element drawn behind the Lighter canvas is the
+    // visible media. We exist only to anchor the coordinate system.
+  }
+
+  getOriginalDimensions(): Dimensions {
+    return this.originalDimensions;
+  }
+
+  getRenderedBounds(): Rect {
+    return this.currentBounds;
+  }
+
+  getAspectRatio(): number {
+    const { width, height } = this.originalDimensions;
+    return height > 0 ? width / height : 1;
+  }
+
+  updateBounds(): void {
+    if (!this.renderer) {
+      return;
+    }
+
+    const parent = this.renderer.getCanvas()?.parentElement;
+    if (!parent) {
+      return;
+    }
+
+    this.updateBoundsFromContainer(parent.clientWidth, parent.clientHeight);
+  }
+
+  private updateBoundsFromContainer(width: number, height: number): void {
+    if (width <= 0 || height <= 0) {
+      return;
+    }
+
+    this.currentBounds = letterboxRect(this.originalDimensions, width, height);
+    this.markDirty();
+
+    // Tell Scene2D to update its coordinate-system transform. Without this
+    // event the coord system stays at the default identity and overlays
+    // collapse to (0,0) — relativeToAbsolute([0..1]) returns ~0.
+    this.eventBus.dispatch("lighter:canonical-media-bounds-changed", {
+      bounds: this.currentBounds,
+    });
+  }
+
+  /** Caller cleanup (also runs on Scene2D.removeOverlay -> overlay.destroy). */
+  override destroy(): void {
+    this.detach?.();
+  }
+}

--- a/app/packages/video-annotation/src/overlayAdapters/detection.ts
+++ b/app/packages/video-annotation/src/overlayAdapters/detection.ts
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { DetectionOverlay } from "@fiftyone/lighter";
+import type { SyntheticBox } from "../streams/SyntheticLabelStream";
+import type { OverlayAdapter, VideoDetectionLabel } from "./types";
+
+/**
+ * {@link OverlayAdapter} for FiftyOne `Detection` labels (axis-aligned
+ * bounding boxes). Maps the per-frame `detections` array onto Lighter
+ * `DetectionOverlay`s.
+ */
+export const detectionAdapter: OverlayAdapter<"detection"> = {
+  factoryKey: "detection",
+  snapshotKey: "detections",
+
+  extract(data, ctx) {
+    return {
+      id: data.id,
+      props: {
+        id: data.id,
+        label: toDetectionLabel(data),
+        relativeBounds: toRect(data.bounding_box),
+        field: ctx.field,
+        draggable: ctx.editable,
+        resizeable: ctx.editable,
+      },
+    };
+  },
+
+  update(overlay, data) {
+    if (!(overlay instanceof DetectionOverlay)) {
+      return;
+    }
+
+    overlay.updateLabel(toDetectionLabel(data));
+  },
+};
+
+/**
+ * Project a normalized bounding box (`[x, y, w, h]` tuple) onto the
+ * `Rect` shape Lighter's `DetectionOverlay.relativeBounds` expects.
+ *
+ * @param bbox - Normalized `[x, y, width, height]` in `[0, 1]`.
+ */
+function toRect(bbox: SyntheticBox["bounding_box"]): {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+} {
+  return { x: bbox[0], y: bbox[1], width: bbox[2], height: bbox[3] };
+}
+
+/**
+ * Project a {@link SyntheticBox} onto a {@link VideoDetectionLabel} for the
+ * overlay's `label` field. `index` and `instance` are preserved
+ * verbatim — `COLOR_BY.INSTANCE` hashes on them, and without them
+ * every detection of the same class collapses to a single color in
+ * instance-color mode.
+ */
+export function toDetectionLabel(box: SyntheticBox): VideoDetectionLabel {
+  return {
+    _id: box._id,
+    label: box.label,
+    bounding_box: box.bounding_box,
+    index: box.index,
+    instance: box.instance,
+  };
+}

--- a/app/packages/video-annotation/src/overlayAdapters/index.ts
+++ b/app/packages/video-annotation/src/overlayAdapters/index.ts
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { detectionAdapter } from "./detection";
+import type {
+  LabelKind,
+  OverlayAdapter,
+  OverlayAdapterRegistry,
+} from "./types";
+
+export type {
+  AdapterContext,
+  ExtractedOverlay,
+  LabelDataMap,
+  LabelKind,
+  OverlayAdapter,
+  OverlayAdapterRegistry,
+} from "./types";
+
+/**
+ * Build a stub adapter for a {@link LabelKind} that hasn't been wired
+ * yet. Stub entries surface the missing kind at the call site (rather
+ * than silently dropping its labels) and document at registry-read
+ * time which kinds the surface knows about but hasn't implemented.
+ *
+ * Replace the stub with a real adapter file when implementing the kind.
+ *
+ * @param kind - The unimplemented label kind, used in error messages.
+ */
+const notImplemented = <K extends LabelKind>(kind: K): OverlayAdapter<K> =>
+  ({
+    factoryKey: kind,
+    // No snapshot field is named for the kind, so the diff loop reads
+    // `undefined` and skips the adapter (the consumer keys off `snapshotKey`).
+    snapshotKey: kind as never,
+    extract() {
+      throw new Error(`Overlay adapter for "${kind}" is not implemented`);
+    },
+    update() {
+      throw new Error(`Overlay adapter for "${kind}" is not implemented`);
+    },
+  } as OverlayAdapter<K>);
+
+/**
+ * Registry mapping each {@link LabelKind} to its {@link OverlayAdapter}.
+ * Real entries forward to dedicated adapter files; unimplemented kinds
+ * use {@link notImplemented} so adding a new kind is a single-line swap
+ * here plus a new adapter file.
+ */
+export const overlayAdapters: OverlayAdapterRegistry = {
+  detection: detectionAdapter,
+  polyline: notImplemented("polyline"),
+  keypoint: notImplemented("keypoint"),
+  segmentation: notImplemented("segmentation"),
+  heatmap: notImplemented("heatmap"),
+  mask: notImplemented("mask"),
+};

--- a/app/packages/video-annotation/src/overlayAdapters/types.ts
+++ b/app/packages/video-annotation/src/overlayAdapters/types.ts
@@ -1,0 +1,135 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import type { BaseOverlay, DetectionLabel } from "@fiftyone/lighter";
+import type {
+  FrameLabelSnapshot,
+  SyntheticBox,
+} from "../streams/SyntheticLabelStream";
+
+/**
+ * A lighter {@link DetectionLabel} sourced from a raw `/frames` detection
+ * document, which carries the persisted Mongo `_id`.
+ *
+ * Lighter's own `DetectionLabel` models a looker-*serialized* label, exposing
+ * the string `id` it inherits from `BaseLabel` — not the raw `_id`. But the
+ * video surface feeds raw frame docs straight into the overlays, and the
+ * per-frame label cache upserts against that `_id` (see
+ * `VideoFrameLabelsStream`), so the field has to ride along on the overlay's
+ * label. `_id` is absent only for a freshly-drawn box that hasn't been
+ * persisted to the backend yet.
+ */
+export type VideoDetectionLabel = NonNullable<DetectionLabel> & {
+  _id?: string;
+};
+
+/**
+ * Kinds of FiftyOne labels the video surface knows how to render.
+ *
+ * Adding a new kind requires three changes:
+ *   1. Add the kind to this union.
+ *   2. Add the kind's data shape to {@link LabelDataMap}.
+ *   3. Replace the kind's stub in the adapter registry with a real
+ *      {@link OverlayAdapter} implementation.
+ */
+export type LabelKind =
+  | "detection"
+  | "polyline"
+  | "keypoint"
+  | "segmentation"
+  | "heatmap"
+  | "mask";
+
+/**
+ * Maps each {@link LabelKind} to its in-snapshot data type. Unimplemented
+ * kinds map to `never` so the registry's typed signatures still compile;
+ * replace with the real wire shape when wiring the kind up.
+ */
+export type LabelDataMap = {
+  detection: SyntheticBox;
+  polyline: never;
+  keypoint: never;
+  segmentation: never;
+  heatmap: never;
+  mask: never;
+};
+
+/**
+ * Per-frame context threaded into {@link OverlayAdapter.extract}.
+ */
+export interface AdapterContext {
+  /** Schema field the labels are read from (e.g. `predictions.detections`). */
+  field: string;
+  /**
+   * Whether the user is currently allowed to drag/resize overlays.
+   * Wired from playback paused-state by {@link useFrameOverlaySync}.
+   */
+  editable: boolean;
+}
+
+/**
+ * Result of {@link OverlayAdapter.extract}: the data needed to call
+ * `overlayFactory.create(factoryKey, props)`.
+ */
+export interface ExtractedOverlay {
+  /** Stable identity for the overlay across frames. */
+  id: string;
+  /** Props forwarded as the second argument to `overlayFactory.create`. */
+  props: Record<string, unknown>;
+}
+
+/**
+ * Translates one kind of FiftyOne label into the Lighter overlay
+ * lifecycle calls needed to render it. Used by {@link useFrameOverlaySync}
+ * to dispatch per-kind without hardcoding any specific overlay type.
+ *
+ * @example
+ * ```ts
+ * const detectionAdapter: OverlayAdapter<"detection"> = {
+ *   factoryKey: "detection",
+ *   snapshotKey: "detections",
+ *   extract: (data, ctx) => ({ id: data.id, props: { ... } }),
+ *   update: (overlay, data) => { ... },
+ * };
+ * ```
+ */
+export interface OverlayAdapter<K extends LabelKind = LabelKind> {
+  /** Overlay-factory key passed to `overlayFactory.create(key, props)`. */
+  factoryKey: string;
+  /**
+   * Field on {@link FrameLabelSnapshot} this adapter's labels live under.
+   * The diff loop reads `snapshot[snapshotKey]` to enumerate inputs.
+   */
+  snapshotKey: keyof FrameLabelSnapshot;
+  /**
+   * Project a raw label into the args needed to create an overlay.
+   *
+   * @param data - One label entry pulled from `snapshot[snapshotKey]`.
+   * @param ctx - Per-diff context (field, editable, etc.).
+   * @returns Overlay-construction args, or `null` to skip this label
+   *   (e.g. malformed input, missing required fields).
+   */
+  extract(data: LabelDataMap[K], ctx: AdapterContext): ExtractedOverlay | null;
+  /**
+   * Apply a snapshot update to an existing overlay in place. Called
+   * when the diff loop finds an overlay with a matching id already in
+   * the scene. Implementations should mutate the overlay's reactive
+   * state directly (e.g. `overlay.relativeBounds = ...`).
+   *
+   * @param overlay - The existing scene overlay (caller-narrowed to a
+   *   `BaseOverlay`; implementations narrow further via `instanceof`).
+   * @param data - The latest label data from the snapshot.
+   */
+  update(overlay: BaseOverlay, data: LabelDataMap[K]): void;
+}
+
+/**
+ * Type-safe registry binding each {@link LabelKind} to its adapter.
+ * `Object.values(...)` over this still erases to `OverlayAdapter<LabelKind>`
+ * (the iteration site uses a narrow `as never` cast accordingly), but
+ * per-key access (`overlayAdapters.detection`) stays precisely typed.
+ */
+export type OverlayAdapterRegistry = {
+  [K in LabelKind]: OverlayAdapter<K>;
+};

--- a/app/packages/video-annotation/src/propagation/propagationTarget.test.ts
+++ b/app/packages/video-annotation/src/propagation/propagationTarget.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+import type {
+  FrameLabelSnapshot,
+  SyntheticBox,
+} from "../streams/SyntheticLabelStream";
+import type { VideoFrameLabelsStream } from "../streams/VideoFrameLabelsStream";
+import { resolvePropagationTarget } from "./propagationTarget";
+
+const FPS = 30;
+const INSTANCE = "inst-1"; // engine instanceId = the track's instance._id
+const OVERLAY = "obj"; // per-frame doc id (det.id)
+
+// Frame N's start time is (N-1)/fps; mirror the stream's frame→time mapping.
+const timeOfFrame = (frame: number): number => (frame - 1) / FPS;
+
+/** Minimal tracked-detection snapshot row the resolver reads. */
+const det = (
+  keyframe: boolean
+): Pick<SyntheticBox, "id" | "keyframe" | "instance"> => ({
+  id: OVERLAY,
+  keyframe,
+  instance: { _cls: "Instance", _id: INSTANCE },
+});
+
+/**
+ * Stub stream over a map of frame number → the tracked object's keyframe
+ * state on that frame (absent = the object isn't present). Only the surface
+ * the resolver touches (`getValue` / `fps` / `totalFrames`) is implemented.
+ */
+const fakeStream = (
+  totalFrames: number,
+  keyframeByFrame: Record<number, boolean>
+): VideoFrameLabelsStream =>
+  ({
+    fps: FPS,
+    totalFrames,
+    getValue(time: number): FrameLabelSnapshot | null {
+      const frame = Math.floor(time * FPS + 1e-6) + 1;
+      const present = frame in keyframeByFrame;
+      return {
+        frameNumber: frame,
+        detections: present
+          ? ([det(keyframeByFrame[frame])] as SyntheticBox[])
+          : [],
+      };
+    },
+  } as unknown as VideoFrameLabelsStream);
+
+describe("resolvePropagationTarget", () => {
+  it("brackets between two keyframes around the playhead", () => {
+    const stream = fakeStream(100, { 10: true, 20: false, 40: true });
+    const target = resolvePropagationTarget(
+      stream,
+      [INSTANCE],
+      timeOfFrame(20)
+    );
+    expect(target).toEqual({
+      ok: true,
+      instanceId: INSTANCE,
+      fromFrame: 10,
+      toFrame: 40,
+    });
+  });
+
+  it("fills forward to the end of the extended track (no downstream keyframe)", () => {
+    // Seed keyframe at 10, drag-extended with non-keyframe filler through 45.
+    const frames: Record<number, boolean> = { 10: true };
+    for (let f = 11; f <= 45; f++) frames[f] = false;
+    const stream = fakeStream(100, frames);
+    const target = resolvePropagationTarget(
+      stream,
+      [INSTANCE],
+      timeOfFrame(20)
+    );
+    expect(target).toEqual({
+      ok: true,
+      instanceId: INSTANCE,
+      fromFrame: 10,
+      toFrame: 45, // the track's extent, not the clip end (100)
+    });
+  });
+
+  it("caps at the next keyframe (bracket) once one exists", () => {
+    // Same object, but now a later keyframe is present — prefer the bracket.
+    // The tracked object is present (non-kf) at the playhead frame too.
+    const stream = fakeStream(100, { 10: true, 30: false, 70: true });
+    const target = resolvePropagationTarget(
+      stream,
+      [INSTANCE],
+      timeOfFrame(30)
+    );
+    expect(target).toMatchObject({
+      ok: true,
+      fromFrame: 10,
+      toFrame: 70,
+    });
+  });
+
+  it("won't fill an un-extended single-frame track", () => {
+    // Just a seed keyframe, nothing ahead — extend the track first.
+    const stream = fakeStream(100, { 10: true });
+    const target = resolvePropagationTarget(
+      stream,
+      [INSTANCE],
+      timeOfFrame(10)
+    );
+    expect(target).toEqual({
+      ok: false,
+      reason: "Extend the track past this frame to fill it with SAM2.",
+    });
+  });
+
+  it("needs a keyframe at or before the playhead", () => {
+    // Only a keyframe after the playhead; the object is present (non-kf) now.
+    const stream = fakeStream(100, { 10: false, 40: true });
+    const target = resolvePropagationTarget(
+      stream,
+      [INSTANCE],
+      timeOfFrame(10)
+    );
+    expect(target).toEqual({
+      ok: false,
+      reason: "Need a keyframe at or before this frame.",
+    });
+  });
+
+  it("reports when the object has no keyframes yet", () => {
+    const stream = fakeStream(100, { 10: false });
+    const target = resolvePropagationTarget(
+      stream,
+      [INSTANCE],
+      timeOfFrame(10)
+    );
+    expect(target).toEqual({
+      ok: false,
+      reason: "Mark a keyframe to seed propagation",
+    });
+  });
+
+  it("matches an instance-less detection by its doc id, then asks for a tracked box", () => {
+    // engine addresses an instance-less detection by its doc id (`?? d.id`), so
+    // it IS found — but propagation needs a real instance to track across frames
+    const stream = {
+      fps: FPS,
+      totalFrames: 100,
+      getValue: (time: number): FrameLabelSnapshot | null => {
+        const frame = Math.floor(time * FPS + 1e-6) + 1;
+        return {
+          frameNumber: frame,
+          detections:
+            frame === 10
+              ? ([{ id: OVERLAY, keyframe: true }] as SyntheticBox[])
+              : [],
+        };
+      },
+    } as unknown as VideoFrameLabelsStream;
+
+    const target = resolvePropagationTarget(stream, [OVERLAY], timeOfFrame(10));
+    expect(target).toEqual({
+      ok: false,
+      reason:
+        "Selected object has no instance id — draw it as a tracked box first.",
+    });
+  });
+
+  it("requires a selection", () => {
+    const stream = fakeStream(100, { 10: true });
+    expect(resolvePropagationTarget(stream, [], timeOfFrame(10))).toEqual({
+      ok: false,
+      reason: "Select a tracked object to propagate.",
+    });
+  });
+});

--- a/app/packages/video-annotation/src/propagation/propagationTarget.ts
+++ b/app/packages/video-annotation/src/propagation/propagationTarget.ts
@@ -1,0 +1,186 @@
+import { frameAt } from "@fiftyone/playback";
+import type { VideoFrameLabelsStream } from "../streams/VideoFrameLabelsStream";
+
+/**
+ * Resolved input for a propagation run, or the reason one can't run yet.
+ *
+ * The `reason` strings are user-facing — they surface in the toolbar's
+ * Propagate tooltip when the button is disabled, so they double as the
+ * "why didn't this trigger?" diagnostic.
+ */
+export type PropagationTarget =
+  | {
+      ok: true;
+      /** `Instance._id` shared by the selected detection's keyframes. */
+      instanceId: string;
+      /** Frame of the seed keyframe at or before the playhead. */
+      fromFrame: number;
+      /**
+       * Last frame of the run. The first keyframe strictly after the playhead
+       * (a *bracket* run), or — when there's no downstream keyframe — the end
+       * of the track's contiguous presence run containing the playhead (a
+       * *forward* run, filling the extended track). The command handler tells
+       * the two apart by whether a keyframe sits at this frame, so no extra
+       * flag is needed here.
+       */
+      toFrame: number;
+    }
+  | { ok: false; reason: string };
+
+/**
+ * Given the active stream, the currently-selected track ids (engine
+ * instanceIds), and the visual playhead time, work out whether a SAM2
+ * tracking run can start and,
+ * if so, over which frame span.
+ *
+ * Two shapes of run:
+ *   - **Bracket** — the playhead sits between two keyframes of the selected
+ *     object; tracks the seed (left) keyframe up to the next (right) one.
+ *   - **Forward** — there's a seed keyframe at/before the playhead but none
+ *     after it; tracks forward to the end of the track's presence run (the
+ *     extended-but-unfilled frames), matching the timeline bar. The user can
+ *     halt early via the Stop control. SAM2's natural strength. Drawing then
+ *     extending a track and triggering this fills the extension.
+ *
+ * Pure (no React, no atoms) so it's trivially unit-testable and callable
+ * from a render pass. Used by the timeline toolbar's "Track (SAM2)" action.
+ */
+export function resolvePropagationTarget(
+  stream: VideoFrameLabelsStream,
+  selectedIds: readonly string[],
+  time: number
+): PropagationTarget {
+  if (selectedIds.length === 0) {
+    return { ok: false, reason: "Select a tracked object to propagate." };
+  }
+
+  const snapshot = stream.getValue(time);
+  if (!snapshot) {
+    return { ok: false, reason: "No labels loaded at the current frame yet." };
+  }
+
+  // selectedIds are engine instanceIds (`instance._id`, or the doc `_id` for
+  // instance-less detections) — match the snapshot the same way the engine
+  // addresses a label.
+  const selected = snapshot.detections.find((d) =>
+    selectedIds.includes(d.instance?._id ?? d.id)
+  );
+  if (!selected) {
+    return {
+      ok: false,
+      reason: "Selected object isn't present at this frame.",
+    };
+  }
+
+  const instanceId = selected.instance?._id;
+  if (!instanceId) {
+    return {
+      ok: false,
+      reason:
+        "Selected object has no instance id — draw it as a tracked box first.",
+    };
+  }
+
+  const currentFrame = frameAt(time, stream.fps, stream.totalFrames);
+
+  const { leftFrame, rightFrame } = findBracketingKeyframes(
+    stream,
+    instanceId,
+    currentFrame
+  );
+
+  if (leftFrame === null && rightFrame === null) {
+    return {
+      ok: false,
+      reason: "Mark a keyframe to seed propagation",
+    };
+  }
+
+  if (leftFrame === null) {
+    return { ok: false, reason: "Need a keyframe at or before this frame." };
+  }
+
+  // Bracketed run: a keyframe exists on both sides of the playhead.
+  if (rightFrame !== null) {
+    return { ok: true, instanceId, fromFrame: leftFrame, toFrame: rightFrame };
+  }
+
+  // Forward run: only the seed keyframe exists. Fill forward to the end of
+  // the track's contiguous presence run containing the playhead.
+  const endFrame = forwardPresenceEnd(stream, instanceId, currentFrame);
+
+  if (endFrame <= leftFrame) {
+    return {
+      ok: false,
+      reason: "Extend the track past this frame to fill it with SAM2.",
+    };
+  }
+
+  return { ok: true, instanceId, fromFrame: leftFrame, toFrame: endFrame };
+}
+
+/**
+ * Walk the cached frames for the keyframes bracketing the playhead: the most
+ * recent keyframe at or before it (`leftFrame`), and the first keyframe strictly
+ * after (`rightFrame`). `leftFrame` keeps updating until the loop hits a frame
+ * past the playhead, at which point `rightFrame` is locked in.
+ */
+function findBracketingKeyframes(
+  stream: VideoFrameLabelsStream,
+  instanceId: string,
+  currentFrame: number
+): { leftFrame: number | null; rightFrame: number | null } {
+  let leftFrame: number | null = null;
+  let rightFrame: number | null = null;
+
+  for (let f = 1; f <= stream.totalFrames; f++) {
+    const snap = stream.getValue((f - 1) / stream.fps);
+    if (!snap) {
+      continue;
+    }
+
+    const det = snap.detections.find(
+      (d) => d.keyframe && d.instance?._id === instanceId
+    );
+    if (!det) {
+      continue;
+    }
+
+    if (f <= currentFrame) {
+      leftFrame = f;
+    }
+
+    if (f > currentFrame && rightFrame === null) {
+      rightFrame = f;
+      break;
+    }
+  }
+
+  return { leftFrame, rightFrame };
+}
+
+/**
+ * Last frame of the track's contiguous presence run containing the playhead.
+ * Walks forward from `currentFrame` until the instance is no longer present.
+ */
+function forwardPresenceEnd(
+  stream: VideoFrameLabelsStream,
+  instanceId: string,
+  currentFrame: number
+): number {
+  let endFrame = currentFrame;
+
+  for (let f = currentFrame + 1; f <= stream.totalFrames; f++) {
+    const present = stream
+      .getValue((f - 1) / stream.fps)
+      ?.detections.some((d) => d.instance?._id === instanceId);
+
+    if (!present) {
+      break;
+    }
+
+    endFrame = f;
+  }
+
+  return endFrame;
+}

--- a/app/packages/video-annotation/src/propagation/useApplyPropagationResult.test.ts
+++ b/app/packages/video-annotation/src/propagation/useApplyPropagationResult.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockActions = {
+  transaction: vi.fn((fn: () => unknown) => fn()),
+  updateLabel: vi.fn(),
+};
+
+const h = vi.hoisted(() => ({ stream: null as unknown }));
+
+vi.mock("@fiftyone/annotation", () => ({
+  useAnnotationEngine: () => ({}),
+  useSurfaceActions: () => mockActions,
+}));
+
+vi.mock("../streams/frameLabelsStream", () => ({
+  useFrameLabelsStream: () => h.stream,
+}));
+
+import {
+  useApplyPropagatedDetection,
+  useApplyPropagationResult,
+} from "./useApplyPropagationResult";
+
+const PATH = "frames.detections";
+
+beforeEach(() => {
+  h.stream = { labelsField: "detections" };
+  vi.clearAllMocks();
+});
+
+describe("useApplyPropagatedDetection", () => {
+  it("writes the detection at its frame, addressed by instance._id, identity stripped", () => {
+    const { result } = renderHook(() => useApplyPropagatedDetection());
+
+    result.current(3, {
+      _id: "minted",
+      instance: { _id: "inst-1" },
+      bounding_box: [0, 0, 1, 1],
+    } as never);
+
+    expect(mockActions.updateLabel).toHaveBeenCalledWith(
+      { path: PATH, instanceId: "inst-1", frame: 3 },
+      { bounding_box: [0, 0, 1, 1] }
+    );
+  });
+
+  it("coalesces a streaming run under a shared undoKey", () => {
+    const { result } = renderHook(() => useApplyPropagatedDetection());
+
+    result.current(
+      4,
+      {
+        _id: "m",
+        instance: { _id: "inst-1" },
+        bounding_box: [0, 0, 1, 1],
+      } as never,
+      { undoKey: "propagate:1" }
+    );
+
+    expect(mockActions.transaction).toHaveBeenCalledWith(expect.any(Function), {
+      undoKey: "propagate:1",
+    });
+  });
+
+  it("falls back to the doc _id when the detection has no instance", () => {
+    const { result } = renderHook(() => useApplyPropagatedDetection());
+
+    result.current(2, { _id: "doc-2", bounding_box: [0, 0, 1, 1] } as never);
+
+    expect(mockActions.updateLabel).toHaveBeenCalledWith(
+      { path: PATH, instanceId: "doc-2", frame: 2 },
+      { bounding_box: [0, 0, 1, 1] }
+    );
+  });
+
+  it("is a no-op when no stream is mounted", () => {
+    h.stream = null;
+    const { result } = renderHook(() => useApplyPropagatedDetection());
+
+    expect(() =>
+      result.current(1, { instance: { _id: "x" } } as never)
+    ).not.toThrow();
+    expect(mockActions.updateLabel).not.toHaveBeenCalled();
+  });
+});
+
+describe("useApplyPropagationResult", () => {
+  it("writes each per-frame detection from a sync result in one transaction", () => {
+    const { result } = renderHook(() => useApplyPropagationResult());
+
+    result.current({
+      type: "sync",
+      response: {
+        perFrame: [
+          { frameNumber: 2, detection: { _id: "a", instance: { _id: "i" } } },
+          { frameNumber: 3, detection: { _id: "b", instance: { _id: "i" } } },
+        ],
+      },
+    } as never);
+
+    // the outer batch transaction plus each writer's nested transaction
+    expect(mockActions.updateLabel).toHaveBeenCalledTimes(2);
+    expect(mockActions.updateLabel).toHaveBeenCalledWith(
+      { path: PATH, instanceId: "i", frame: 2 },
+      {}
+    );
+  });
+
+  it("ignores a non-sync (streaming) result", () => {
+    const { result } = renderHook(() => useApplyPropagationResult());
+
+    result.current({ type: "async" } as never);
+
+    expect(mockActions.updateLabel).not.toHaveBeenCalled();
+  });
+});

--- a/app/packages/video-annotation/src/propagation/useApplyPropagationResult.ts
+++ b/app/packages/video-annotation/src/propagation/useApplyPropagationResult.ts
@@ -1,0 +1,104 @@
+import {
+  type InferenceResult,
+  type PropagatedDetection,
+  type PropagationInferenceResult,
+  useAnnotationEngine,
+  useSurfaceActions,
+} from "@fiftyone/annotation";
+import { useCallback } from "react";
+
+import { useFrameLabelsStream } from "../streams/frameLabelsStream";
+
+/**
+ * Method which applies a {@link PropagationInferenceResult} to the engine. Each
+ * per-frame entry is written via `engine.updateLabel`, which the autosave
+ * pipeline picks up through `engine.getJsonPatch`.
+ */
+export type PropagationResultHandler = (
+  result: InferenceResult<PropagationInferenceResult>
+) => void;
+
+/**
+ * Writes a single propagated detection into a 1-based frame. `undoKey`
+ * coalesces a streaming run's per-frame writes (which can't share one
+ * synchronous transaction) into a single undo unit.
+ */
+export type PropagatedDetectionWriter = (
+  frameNumber: number,
+  detection: PropagatedDetection,
+  opts?: { undoKey?: string }
+) => void;
+
+const SURFACE = "video";
+
+/**
+ * Hook which returns a single-frame writer bound to the active session. Used by
+ * the batch {@link useApplyPropagationResult} (sync agents returning every
+ * frame at once) and by streaming agents (SAM2) that emit a frame at a time as
+ * inference lands.
+ *
+ * The engine addresses a track by its `instance._id`, so a per-frame write
+ * upserts that track's box at the frame — no fresh-id dedup dance: an existing
+ * box for the instance is overwritten in place, a gap gets a freshly-minted
+ * frame doc. Identity fields (`_id`/`instance`) are the store's, so they're
+ * stripped from the written content and re-stamped from the ref.
+ */
+export const useApplyPropagatedDetection = (): PropagatedDetectionWriter => {
+  const engine = useAnnotationEngine();
+  const actions = useSurfaceActions(engine, SURFACE);
+  const stream = useFrameLabelsStream();
+
+  return useCallback(
+    (frameNumber, detection, opts) => {
+      if (!stream) {
+        return;
+      }
+
+      const instanceId = detection.instance?._id ?? detection._id;
+
+      if (!instanceId) {
+        return;
+      }
+
+      const path = `frames.${stream.labelsField}`;
+      const { _id, instance, ...content } = detection;
+
+      actions.transaction(
+        () =>
+          actions.updateLabel(
+            { path, instanceId, frame: frameNumber },
+            content
+          ),
+        opts?.undoKey ? { undoKey: opts.undoKey } : undefined
+      );
+    },
+    [actions, stream]
+  );
+};
+
+/**
+ * Hook which returns a {@link PropagationResultHandler} bound to the current
+ * session. A sync agent returns every frame at once, so the whole batch lands
+ * in one engine transaction (one undo unit).
+ */
+export const useApplyPropagationResult = (): PropagationResultHandler => {
+  const engine = useAnnotationEngine();
+  const actions = useSurfaceActions(engine, SURFACE);
+  const applyDetection = useApplyPropagatedDetection();
+
+  return useCallback(
+    (result: InferenceResult<PropagationInferenceResult>) => {
+      if (result.type !== "sync") {
+        return;
+      }
+
+      // One transaction so the per-frame writers nest into a single undo unit.
+      actions.transaction(() => {
+        result.response.perFrame.forEach(({ frameNumber, detection }) =>
+          applyDetection(frameNumber, detection)
+        );
+      });
+    },
+    [actions, applyDetection]
+  );
+};

--- a/app/packages/video-annotation/src/state/accessors.ts
+++ b/app/packages/video-annotation/src/state/accessors.ts
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import {
+  activeFields,
+  colorScheme,
+  colorSeed,
+  datasetName,
+  fieldPaths,
+  groupSlice,
+  modalSampleId,
+  useCurrentDatasetId,
+  view,
+} from "@fiftyone/state";
+import {
+  DETECTION,
+  EMBEDDED_DOCUMENT_FIELD,
+  type Stage,
+  TEMPORAL_DETECTIONS_FIELD,
+} from "@fiftyone/utilities";
+import { useRecoilValue } from "recoil";
+import { useAnnotationContext } from "../../../core/src/components/Modal/Sidebar/Annotate/Edit/useAnnotationContext";
+
+/**
+ * Read accessors for the external recoil / jotai atoms the video surface
+ * consumes. The rest of the package depends on these hooks rather than on
+ * recoil / jotai or the foreign atoms' module paths, so there's a single
+ * seam to update if an upstream atom moves or changes shape — and the
+ * surrounding code reads as plain hooks, not state-library plumbing.
+ */
+
+/** Active color scheme (`@fiftyone/state`). */
+export const useColorScheme = () => useRecoilValue(colorScheme);
+
+/** Color seed used for instance / field color hashing. */
+export const useColorSeed = () => useRecoilValue(colorSeed);
+
+/** Current dataset name. */
+export const useDatasetName = () => useRecoilValue(datasetName);
+
+/** Current dataset id — the `EntityId` namespace for engine signal keys. */
+export const useDatasetId = (): string => useCurrentDatasetId() ?? "";
+
+/** Active group slice, or `null` when the dataset isn't grouped. */
+export const useGroupSlice = () => useRecoilValue(groupSlice);
+
+/** Id of the sample open in the modal. */
+export const useModalSampleId = () => useRecoilValue(modalSampleId);
+
+/**
+ * Active view stages, narrowed to the `utilities` `Stage` shape the streams
+ * expect. `fos.view` is typed as `State.Stage[]`; the two are structurally
+ * compatible. Empty array when no view is applied.
+ */
+export const useView = (): Stage[] => (useRecoilValue(view) ?? []) as Stage[];
+
+/** Field paths active (collapsed) in the modal sidebar. */
+export const useActiveModalPaths = () =>
+  useRecoilValue(activeFields({ modal: true, expanded: false }));
+
+/** Schema paths of the dataset's temporal-detections fields. */
+export const useTemporalDetectionFieldPaths = () =>
+  useRecoilValue(
+    fieldPaths({
+      ftype: EMBEDDED_DOCUMENT_FIELD,
+      embeddedDocType: TEMPORAL_DETECTIONS_FIELD,
+    })
+  );
+
+/** The overlay currently being edited in the sidebar (`@fiftyone/core`). */
+export const useCurrentEditingOverlay = () =>
+  useAnnotationContext().selected?.overlay ?? null;
+
+/**
+ * The detection field new frame overlays paint into and the `/frames` stream
+ * reads from: the last-used detection field, falling back to the schema
+ * default. Replaces core's deleted `useActiveDetectionField` — `fieldFor`
+ * encapsulates the remembered → default resolution.
+ */
+export const useActiveDetectionField = (): string | null =>
+  useAnnotationContext().lastUsed.fieldFor(DETECTION);

--- a/app/packages/video-annotation/src/state/useCurrentFrame.ts
+++ b/app/packages/video-annotation/src/state/useCurrentFrame.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { frameAt, usePlayhead } from "@fiftyone/playback";
+import { useModalSample } from "@fiftyone/state";
+import { useCallback, useRef } from "react";
+import { getModalSampleFrameRate } from "../utils/modalSample";
+
+/**
+ * The single source of "current frame" for the engine integration on the video
+ * surface.
+ *
+ * The surface drives playback through `PlaybackProvider` / `usePlaybackEngine`
+ * (visible position = `usePlayhead()` seconds), NOT the legacy `useTimeline`
+ * timeline-state machinery (which is never created here, so its frame number
+ * stays frozen). Everything that needs the live frame — the engine clock,
+ * the canvas bridge's `frameOf`, timeline select/hover frame-stamping — must
+ * read it from here, converting the playhead seconds to a 1-indexed frame via
+ * the shared `frameAt`.
+ */
+export const useCurrentFrame = (): number => {
+  const playhead = usePlayhead();
+  const fps = getModalSampleFrameRate(useModalSample());
+
+  return fps && Number.isFinite(fps) ? frameAt(playhead, fps) : -1;
+};
+
+/**
+ * A referentially-stable getter for the live frame — for the engine `Clock` and
+ * gesture callbacks that must read the current frame imperatively without
+ * re-subscribing on every tick.
+ */
+export const useCurrentFrameGetter = (): (() => number) => {
+  const frame = useCurrentFrame();
+  const ref = useRef(frame);
+  ref.current = frame;
+
+  return useCallback(() => ref.current, []);
+};

--- a/app/packages/video-annotation/src/state/useVideoInteraction.ts
+++ b/app/packages/video-annotation/src/state/useVideoInteraction.ts
@@ -1,0 +1,203 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import {
+  type ScopedRef,
+  useAnnotationEngine,
+  useInteraction,
+  useSurfaceActions,
+} from "@fiftyone/annotation";
+import { useCallback, useEffect, useRef } from "react";
+import { useFrameLabelsStream } from "../streams/frameLabelsStream";
+import { useCurrentFrame, useCurrentFrameGetter } from "./useCurrentFrame";
+
+const SURFACE = "video-timeline";
+
+/** Membership equality so a selector only re-renders on an id set change. */
+const sameIds = (a: ReadonlySet<string>, b: ReadonlySet<string>): boolean => {
+  if (a.size !== b.size) {
+    return false;
+  }
+
+  for (const id of a) {
+    if (!b.has(id)) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+/**
+ * The timeline's seam onto engine interaction. A timeline row is a whole
+ * track, so it links on the engine's `instanceId` (the linkage key spanning a
+ * track's per-frame occurrences) — a track lights up when ANY of its
+ * occurrences is active / hovered. Writes address the occurrence at the current
+ * playhead frame, since interaction state is keyed on the full ref.
+ *
+ * The video canvas Lighter bridge reads the same engine interaction state, so
+ * select / hover from a row reflects on the canvas with no extra wiring.
+ */
+export interface VideoInteraction {
+  /** Track ids (= engine instanceIds) currently selected. */
+  selectedTrackIds: ReadonlySet<string>;
+  /** Track ids (= engine instanceIds) currently hovered. */
+  hoveredTrackIds: ReadonlySet<string>;
+  /** Replace the selection with this track's current-frame occurrence. */
+  selectTrack: (instanceId: string) => void;
+  /** Set hover on this track's current-frame occurrence. */
+  hoverTrack: (instanceId: string, on: boolean) => void;
+  /**
+   * Select / hover a label by its exact engine ref. Used for sample-level
+   * labels (temporal detections: addressed by `instanceId`, no frame) whose
+   * path differs from the frame-detection field, so they can't go through the
+   * `instanceId`-only track seam above.
+   */
+  selectLabel: (ref: ScopedRef) => void;
+  hoverLabel: (ref: ScopedRef, on: boolean) => void;
+}
+
+/** Read selected track ids (engine instanceIds) from interaction state. */
+export const useSelectedTrackIds = (): ReadonlySet<string> => {
+  const engine = useAnnotationEngine();
+  return useInteraction(
+    engine,
+    (i) => new Set(i.getActive().map((ref) => ref.instanceId)),
+    sameIds
+  );
+};
+
+/** Read hovered track ids (engine instanceIds) from interaction state. */
+export const useHoveredTrackIds = (): ReadonlySet<string> => {
+  const engine = useAnnotationEngine();
+  return useInteraction(
+    engine,
+    (i) => new Set(i.getHovered().map((ref) => ref.instanceId)),
+    sameIds
+  );
+};
+
+/** The full select / hover seam for timeline rows. */
+export const useVideoInteraction = (): VideoInteraction => {
+  const engine = useAnnotationEngine();
+  const actions = useSurfaceActions(engine, SURFACE);
+  const stream = useFrameLabelsStream();
+  const getFrame = useCurrentFrameGetter();
+
+  const selectedTrackIds = useSelectedTrackIds();
+  const hoveredTrackIds = useHoveredTrackIds();
+
+  const path = stream ? `frames.${stream.labelsField}` : null;
+
+  const selectTrack = useCallback(
+    (instanceId: string) => {
+      if (!path) {
+        return;
+      }
+
+      actions.setActive([{ path, instanceId, frame: getFrame() }]);
+    },
+    [actions, path, getFrame]
+  );
+
+  const hoverTrack = useCallback(
+    (instanceId: string, on: boolean) => {
+      if (!path) {
+        return;
+      }
+
+      actions.setHovered({ path, instanceId, frame: getFrame() }, on);
+    },
+    [actions, path, getFrame]
+  );
+
+  const selectLabel = useCallback(
+    (ref: ScopedRef) => actions.setActive([ref]),
+    [actions]
+  );
+
+  const hoverLabel = useCallback(
+    (ref: ScopedRef, on: boolean) => actions.setHovered(ref, on),
+    [actions]
+  );
+
+  return {
+    selectedTrackIds,
+    hoveredTrackIds,
+    selectTrack,
+    hoverTrack,
+    selectLabel,
+    hoverLabel,
+  };
+};
+
+/**
+ * Keep the editing anchor on the playhead. While a video frame label is the
+ * anchor (the form follows it), advancing the playhead re-stamps the anchor to
+ * the SAME track (`instanceId`) at the new frame, so the form and canvas
+ * selection track the instance across frames. Only re-stamps when that track
+ * has an occurrence on the new frame — a gap leaves the anchor on its current
+ * occurrence rather than blanking the form. Sample-level anchors (no `frame`,
+ * e.g. a temporal detection) are left alone.
+ */
+export const useFollowAnchorFrame = (): void => {
+  const engine = useAnnotationEngine();
+  const frame = useCurrentFrame();
+
+  useEffect(() => {
+    const anchor = engine.interaction.getAnchor();
+
+    if (!anchor || anchor.frame == null || anchor.frame === frame) {
+      return;
+    }
+
+    const next = { ...anchor, frame };
+
+    // track absent on this frame — keep editing the current occurrence
+    if (!engine.getLabel(next)) {
+      return;
+    }
+
+    engine.interaction.setActive([next]);
+  }, [engine, frame]);
+};
+
+/**
+ * Bring the anchored (lead) track's row into view when selection moves — the
+ * engine-native replacement for the scene-event scroll. Relies on
+ * `data-track-id={id}` rendered by `TimelineTrack` (row id == instanceId for
+ * object tracks). `scrollIntoView` with `block: "nearest"` no-ops when the row
+ * is already visible, so pinned / on-screen rows generate no scroll.
+ */
+export const useScrollTrackToAnchor = (): void => {
+  const engine = useAnnotationEngine();
+  const anchorId = useInteraction(
+    engine,
+    (i) => i.getAnchor()?.instanceId ?? null
+  );
+  const previous = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!anchorId || anchorId === previous.current) {
+      previous.current = anchorId;
+      return;
+    }
+
+    previous.current = anchorId;
+
+    // Defer to the next frame so any layout shift from the selection settles
+    // before scrolling.
+    requestAnimationFrame(() => {
+      const row = document.querySelector(
+        `[data-track-id="${CSS.escape(anchorId)}"]`
+      );
+
+      row?.scrollIntoView({
+        behavior: "smooth",
+        block: "nearest",
+        inline: "nearest",
+      });
+    });
+  }, [anchorId]);
+};

--- a/app/packages/video-annotation/src/state/videoAnnotationStatus.ts
+++ b/app/packages/video-annotation/src/state/videoAnnotationStatus.ts
@@ -1,0 +1,38 @@
+import { atom, type PrimitiveAtom, useAtomValue, useSetAtom } from "jotai";
+import type { ReactElement } from "react";
+import { useMemo } from "react";
+
+export type VideoAnnotationStatusContent = ReactElement | null;
+
+/**
+ * Module-private content for the top bar's right-hand status slot. A plain
+ * module-level atom (not a TilingProvider/Context-scoped store) so writers
+ * mounted anywhere in the surface and the bar's reader resolve to the same
+ * modal-default jotai store — see the "No TilingProvider" note in
+ * {@link VideoAnnotationSurface}.
+ */
+const statusContentAtom = atom<VideoAnnotationStatusContent>(
+  null
+) as PrimitiveAtom<VideoAnnotationStatusContent>;
+
+/**
+ * Programmatic control over the top bar's status slot. Call
+ * `setContent(<PropagationProgress />)` to show something (e.g. propagation
+ * progress), `setContent(null)` to clear it. Last-writer-wins; rely on
+ * conditional mounting / effect cleanup so at most one writer is live.
+ *
+ * @example
+ * const { setContent } = useVideoAnnotationStatus();
+ * useEffect(() => {
+ *   setContent(<StatusItem icon={<Spinner />} label={`${pct}%`} />);
+ *   return () => setContent(null);
+ * }, [pct, setContent]);
+ */
+export const useVideoAnnotationStatus = () => {
+  const setContent = useSetAtom(statusContentAtom);
+  return useMemo(() => ({ setContent }), [setContent]);
+};
+
+/** Reads the current status-slot content. Internal to the top bar. */
+export const useVideoAnnotationStatusContent = () =>
+  useAtomValue(statusContentAtom);

--- a/app/packages/video-annotation/src/streams/ImaVidImageStream.ts
+++ b/app/packages/video-annotation/src/streams/ImaVidImageStream.ts
@@ -1,0 +1,455 @@
+import { getFetchParameters, type Stage } from "@fiftyone/utilities";
+import { LRUCache } from "lru-cache";
+import {
+  frameAt,
+  PlaybackStreamBase,
+  type BufferReadiness,
+  type PlaybackStore,
+} from "@fiftyone/playback";
+import { mergeRange, toSecondRanges } from "./fetchedRanges";
+import type {
+  ChunkDoneMessage,
+  ChunkFailedMessage,
+  FrameReadyMessage,
+  OutboundMessage,
+} from "./framesWorker";
+
+/**
+ * What the stream publishes per tick. Consumers (the ImaVid tile) draw
+ * `bitmap` into a canvas; `sampleId` and `frameNumber` are exposed for
+ * commands / persistence that need to know which frame this is. `src`
+ * is kept for debugging / dev-tools inspection — production rendering
+ * does not use it.
+ */
+export interface ImaVidImageFrame {
+  bitmap: ImageBitmap;
+  src: string;
+  sampleId: string;
+  frameNumber: number;
+}
+
+/**
+ * What we keep in the LRU. Decoded `ImageBitmap`s are sized by pixel
+ * bytes; on eviction we call `.close()` to free the underlying GPU /
+ * native memory immediately rather than waiting on GC.
+ */
+interface CachedFrame extends ImaVidImageFrame {
+  sizeBytes: number;
+}
+
+export interface ImaVidImageStreamOptions {
+  id: string;
+  /** Sample id for the parent video document. */
+  sampleId: string;
+  /** Current dataset name (POST /frames requires it). */
+  dataset: string;
+  /** Active view stages — same shape sent on every dataset query. */
+  view: Stage[];
+  /** Group slice name, when the dataset is grouped. */
+  groupSlice?: string | null;
+  /** Total frame count of the clip (1-indexed up to this number). */
+  frameCount: number;
+  /** Frame rate in frames per second. */
+  frameRate: number;
+  /**
+   * Number of frames to request in a single `/frames` chunk. Larger
+   * values mean fewer round trips but larger payloads.
+   *
+   * @default 60
+   */
+  chunkSize?: number;
+  /**
+   * Cap on cached pixel bytes. Defaults to 1 GB which matches looker's
+   * ImaVid path. The LRU evicts the oldest frames first once this is
+   * exceeded.
+   *
+   * @default 1e9
+   */
+  maxBytes?: number;
+}
+
+const DEFAULT_CHUNK_SIZE = 60;
+const DEFAULT_MAX_BYTES = 1e9;
+
+/**
+ * Image stream backed by `POST /frames` for ImaVid-style playback
+ * (i.e. `to_frames(sample_frames=True)` data, one materialized image
+ * per frame).
+ *
+ * Both the JSON fetch and the per-image fetch+decode run inside a
+ * `framesWorker` so the main thread never has to parse a `/frames`
+ * response or decode an image. The worker transfers `ImageBitmap`s
+ * back zero-copy; the tile renders them via `<canvas>` + `drawImage`.
+ *
+ * `bufferState` reports `ready` only after a frame's bitmap has landed
+ * in the cache — so the engine never tries to render a half-decoded
+ * frame.
+ */
+export class ImaVidImageStream extends PlaybackStreamBase<ImaVidImageFrame> {
+  private readonly sampleId: string;
+  private readonly dataset: string;
+  private readonly view: Stage[];
+  private readonly groupSlice: string | null;
+  private readonly frameCount: number;
+  private readonly frameRate: number;
+  private readonly chunkSize: number;
+
+  private readonly cache: LRUCache<number, CachedFrame>;
+  private readonly inflight = new Map<number, InflightEntry>();
+  /** reqId → frame numbers that request asked for. */
+  private readonly requestFrames = new Map<number, number[]>();
+  private readonly fetchedRanges: Array<[number, number]> = [];
+
+  private readonly worker: Worker;
+  private nextReqId = 1;
+  private destroyed = false;
+
+  constructor(opts: ImaVidImageStreamOptions) {
+    super(opts.id, {
+      blocking: true,
+      duration: opts.frameCount / opts.frameRate,
+      nativeStepSeconds: 1 / opts.frameRate,
+      lookupPolicy: {
+        type: "nearestPrevious",
+        thresholdSeconds: 1 / opts.frameRate,
+      },
+    });
+
+    this.sampleId = opts.sampleId;
+    this.dataset = opts.dataset;
+    this.view = opts.view;
+    this.groupSlice = opts.groupSlice ?? null;
+    this.frameCount = opts.frameCount;
+    this.frameRate = opts.frameRate;
+    this.chunkSize = opts.chunkSize ?? DEFAULT_CHUNK_SIZE;
+
+    this.cache = new LRUCache<number, CachedFrame>({
+      maxSize: opts.maxBytes ?? DEFAULT_MAX_BYTES,
+      sizeCalculation: (entry) => entry.sizeBytes,
+      dispose: (entry) => {
+        // Free the underlying decoded pixels immediately. Without
+        // .close(), the bitmap sits in GPU / native memory until GC
+        // runs, which can push us well past the byte cap before
+        // memory is actually reclaimed.
+        entry.bitmap.close();
+      },
+    });
+
+    this.worker = new Worker(new URL("./framesWorker.ts", import.meta.url), {
+      type: "module",
+    });
+    this.worker.addEventListener("message", this.handleWorkerMessage);
+
+    // Hand the worker the same fetch context the main thread uses.
+    // Normalize HeadersInit → Record<string, string> so it's structured-
+    // cloneable (Headers objects and arrays both serialize fine, but
+    // the worker side is simpler if it can spread headers verbatim).
+    const params = getFetchParameters();
+    this.worker.postMessage({
+      type: "init",
+      origin: params.origin,
+      pathPrefix: params.pathPrefix,
+      headers: normalizeHeaders(params.headers),
+    });
+  }
+
+  /**
+   * Resolve once the frame containing `time` has been fetched and
+   * decoded. Use in tandem with `seek(time)` on mount so the first
+   * paint isn't a blank tile waiting for the network.
+   */
+  async warmup(time = 0): Promise<void> {
+    const frame = this.timeToFrame(time);
+    if (this.cache.has(frame)) {
+      return;
+    }
+
+    const existing = this.inflight.get(frame);
+    if (existing) {
+      await existing.promise;
+      return;
+    }
+
+    this.requestChunkStartingAt(frame);
+    const entry = this.inflight.get(frame);
+    if (entry) {
+      await entry.promise;
+    }
+  }
+
+  /** Terminate the worker. Call when the stream is being replaced. */
+  destroy(): void {
+    if (this.destroyed) {
+      return;
+    }
+
+    this.destroyed = true;
+
+    this.worker.removeEventListener("message", this.handleWorkerMessage);
+    this.worker.terminate();
+
+    // Settle anyone awaiting a frame that will never arrive.
+    for (const entry of this.inflight.values()) {
+      entry.resolve();
+    }
+    this.inflight.clear();
+    this.requestFrames.clear();
+    this.cache.clear();
+  }
+
+  /** Total frames in the clip. */
+  get totalFrames(): number {
+    return this.frameCount;
+  }
+
+  /** Frame rate in fps. */
+  get fps(): number {
+    return this.frameRate;
+  }
+
+  bufferState(time: number): BufferReadiness {
+    const frame = this.timeToFrame(time);
+
+    if (this.cache.has(frame)) {
+      return "ready";
+    }
+
+    if (this.inflight.has(frame)) {
+      return "loading";
+    }
+
+    return "missing";
+  }
+
+  prefetch(range: [number, number]): void {
+    const [startSec, endSec] = range;
+    const startFrame = this.timeToFrame(startSec);
+    const endFrame = this.timeToFrame(endSec);
+
+    // First missing frame wins — the engine re-calls prefetch as the
+    // playhead advances, so we don't need to fan out here.
+    for (let f = startFrame; f <= endFrame; f++) {
+      if (this.cache.has(f) || this.inflight.has(f)) {
+        continue;
+      }
+
+      this.requestChunkStartingAt(f);
+      return;
+    }
+  }
+
+  getValue(time: number): ImaVidImageFrame | null {
+    const frame = this.timeToFrame(time);
+    const entry = this.cache.get(frame);
+    if (!entry) {
+      return null;
+    }
+
+    return {
+      bitmap: entry.bitmap,
+      src: entry.src,
+      sampleId: entry.sampleId,
+      frameNumber: entry.frameNumber,
+    };
+  }
+
+  /**
+   * Custom `onCommit`: dedupe by `frameNumber`. The engine ticks several
+   * times per frame; without dedupe each tick republishes an identical
+   * value and kicks every `useStream` consumer into a re-render.
+   */
+  override onCommit(time: number, store: PlaybackStore): void {
+    const next = this.getValue(time);
+    const prev = this.readPublished(store);
+
+    if (prev && next && prev.frameNumber === next.frameNumber) {
+      return;
+    }
+
+    if (prev === null && next === null) {
+      return;
+    }
+
+    // We're advancing to a new committed frame; proactively pull the next
+    // chunk into flight so it lands before the playhead reaches it. The engine
+    // only gives us a 1-frame warning, so we want to get ahead of that.
+    if (next) {
+      this.prefetch([time, time + this.lookaheadSeconds]);
+    }
+
+    this.publish(store, next);
+  }
+
+  bufferedRanges(): Array<[number, number]> {
+    return toSecondRanges(this.fetchedRanges, this.frameRate);
+  }
+
+  private timeToFrame(time: number): number {
+    return frameAt(time, this.frameRate, this.frameCount);
+  }
+
+  private requestChunkStartingAt(startFrame: number): void {
+    if (this.destroyed) {
+      return;
+    }
+
+    const numFrames = Math.min(
+      this.chunkSize,
+      this.frameCount - startFrame + 1
+    );
+    if (numFrames <= 0) {
+      return;
+    }
+
+    const reqId = this.nextReqId++;
+    const frames: number[] = [];
+    for (let f = startFrame; f < startFrame + numFrames; f++) {
+      // Skip frames the cache already has or another request is fetching;
+      // the worker doesn't dedupe so we have to.
+      if (this.cache.has(f) || this.inflight.has(f)) {
+        continue;
+      }
+
+      const entry = createInflightEntry();
+
+      this.inflight.set(f, entry);
+      frames.push(f);
+    }
+
+    if (frames.length === 0) {
+      return;
+    }
+
+    this.requestFrames.set(reqId, frames);
+
+    this.worker.postMessage({
+      type: "fetchChunk",
+      reqId,
+      request: {
+        frameNumber: startFrame,
+        numFrames,
+        frameCount: this.frameCount,
+        sampleId: this.sampleId,
+        dataset: this.dataset,
+        view: this.view,
+        slice: this.groupSlice ?? undefined,
+      },
+    });
+  }
+
+  private handleWorkerMessage = (
+    event: MessageEvent<OutboundMessage>
+  ): void => {
+    const msg = event.data;
+    switch (msg.type) {
+      case "frameReady":
+        this.onFrameReady(msg);
+        break;
+      case "chunkDone":
+        this.onChunkDone(msg);
+        break;
+      case "chunkFailed":
+        this.onChunkFailed(msg);
+        break;
+    }
+  };
+
+  private onFrameReady(msg: FrameReadyMessage): void {
+    // If the stream was destroyed between request and reply, the bitmap
+    // would leak — close it explicitly.
+    if (this.destroyed) {
+      msg.bitmap.close();
+      return;
+    }
+
+    const sizeBytes = Math.max(1, msg.width * msg.height * 4);
+    this.cache.set(msg.frameNumber, {
+      bitmap: msg.bitmap,
+      src: msg.src,
+      sampleId: this.sampleId,
+      frameNumber: msg.frameNumber,
+      sizeBytes,
+    });
+
+    const entry = this.inflight.get(msg.frameNumber);
+    if (entry) {
+      entry.resolve();
+      this.inflight.delete(msg.frameNumber);
+    }
+  }
+
+  private onChunkDone(msg: ChunkDoneMessage): void {
+    mergeRange(this.fetchedRanges, msg.range);
+    this.resolveOutstandingFrames(msg.reqId);
+  }
+
+  private onChunkFailed(msg: ChunkFailedMessage): void {
+    console.error(
+      `[ImaVidImageStream] worker chunk ${msg.reqId} failed: ${msg.error}`
+    );
+    this.resolveOutstandingFrames(msg.reqId);
+  }
+
+  /**
+   * Settle any in-flight frames from this request that never received
+   * a `frameReady` (e.g. missing filepath, decode error, top-level
+   * fetch failure). They drop from `loading` → `missing` so the engine
+   * re-prefetches on the next tick. Anyone awaiting `warmup` unblocks
+   * (the cache miss is observable via `bufferState`).
+   */
+  private resolveOutstandingFrames(reqId: number): void {
+    const frames = this.requestFrames.get(reqId);
+    if (!frames) {
+      return;
+    }
+
+    this.requestFrames.delete(reqId);
+
+    for (const f of frames) {
+      const entry = this.inflight.get(f);
+      if (!entry) {
+        continue;
+      }
+
+      entry.resolve();
+      this.inflight.delete(f);
+    }
+  }
+}
+
+interface InflightEntry {
+  promise: Promise<void>;
+  resolve: () => void;
+}
+
+function createInflightEntry(): InflightEntry {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+
+  return { promise, resolve };
+}
+
+function normalizeHeaders(
+  headers: HeadersInit | undefined
+): Record<string, string> {
+  if (!headers) {
+    return {};
+  }
+
+  if (headers instanceof Headers) {
+    const out: Record<string, string> = {};
+    headers.forEach((value, key) => {
+      out[key] = value;
+    });
+
+    return out;
+  }
+
+  if (Array.isArray(headers)) {
+    return Object.fromEntries(headers);
+  }
+
+  return { ...(headers as Record<string, string>) };
+}

--- a/app/packages/video-annotation/src/streams/SyntheticLabelStream.test.ts
+++ b/app/packages/video-annotation/src/streams/SyntheticLabelStream.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import {
+  getPresenceIntervals,
+  isPresent,
+  resolveActor,
+  type SyntheticActor,
+  type SyntheticActorSpec,
+} from "./SyntheticLabelStream";
+
+function makeActor(overrides: Partial<SyntheticActor> = {}): SyntheticActor {
+  return {
+    id: "a",
+    label: "person",
+    width: 0.1,
+    height: 0.1,
+    xPeriodSec: 10,
+    yPeriodSec: 10,
+    xPhase: 0,
+    yPhase: 0,
+    presenceCycleSec: 10,
+    presenceDuty: 0.5,
+    presencePhase: 0,
+    ...overrides,
+  };
+}
+
+describe("resolveActor", () => {
+  it("projects per-clip cycle counts onto absolute periods", () => {
+    const spec: SyntheticActorSpec = {
+      id: "a",
+      label: "person",
+      width: 0.1,
+      height: 0.1,
+      xCyclesPerClip: 1,
+      yCyclesPerClip: 0.5,
+      xPhase: 0,
+      yPhase: 0,
+      presenceCyclesPerClip: 2,
+      presenceDuty: 0.5,
+      presencePhase: 0,
+    };
+
+    const actor = resolveActor(spec, 10);
+    expect(actor.xPeriodSec).toBe(10);
+    expect(actor.yPeriodSec).toBe(20);
+    expect(actor.presenceCycleSec).toBe(5);
+  });
+
+  it("guards a zero-length clip against divide-by-zero", () => {
+    const actor = resolveActor(
+      {
+        id: "a",
+        label: "person",
+        width: 0.1,
+        height: 0.1,
+        xCyclesPerClip: 1,
+        yCyclesPerClip: 1,
+        xPhase: 0,
+        yPhase: 0,
+        presenceCyclesPerClip: 1,
+        presenceDuty: 0.5,
+        presencePhase: 0,
+      },
+      0
+    );
+    expect(Number.isFinite(actor.xPeriodSec)).toBe(true);
+  });
+});
+
+describe("isPresent", () => {
+  it("is in frame for the duty fraction of each cycle", () => {
+    const actor = makeActor({ presenceCycleSec: 10, presenceDuty: 0.5 });
+    expect(isPresent(0, actor)).toBe(true);
+    expect(isPresent(4, actor)).toBe(true);
+    expect(isPresent(6, actor)).toBe(false);
+    // Next cycle wraps back to present.
+    expect(isPresent(10, actor)).toBe(true);
+  });
+});
+
+describe("getPresenceIntervals", () => {
+  it("returns empty for a non-positive duration", () => {
+    expect(getPresenceIntervals(makeActor(), 0)).toEqual([]);
+  });
+
+  it("clips intervals to [0, duration]", () => {
+    const actor = makeActor({ presenceCycleSec: 10, presenceDuty: 0.5 });
+    expect(getPresenceIntervals(actor, 10)).toEqual([
+      { startSec: 0, endSec: 5 },
+    ]);
+  });
+
+  it("captures phased intervals across multiple cycles", () => {
+    const actor = makeActor({
+      presenceCycleSec: 10,
+      presenceDuty: 0.5,
+      presencePhase: 0.5,
+    });
+    expect(getPresenceIntervals(actor, 20)).toEqual([
+      { startSec: 5, endSec: 10 },
+      { startSec: 15, endSec: 20 },
+    ]);
+  });
+});

--- a/app/packages/video-annotation/src/streams/SyntheticLabelStream.ts
+++ b/app/packages/video-annotation/src/streams/SyntheticLabelStream.ts
@@ -1,0 +1,268 @@
+import type { FrameLabelSnapshot, SyntheticBox } from "@fiftyone/utilities";
+import { PlaybackStreamBase } from "@fiftyone/playback";
+
+// Re-exported from `@fiftyone/utilities` for the package barrel.
+export type {
+  FrameLabelSnapshot,
+  PropagationBlob,
+  PropagationMethod,
+  SyntheticBox,
+} from "@fiftyone/utilities";
+
+export interface SyntheticActor {
+  id: string;
+  label: string;
+  width: number;
+  height: number;
+  /** Cycle length in seconds for x and y trajectories. */
+  xPeriodSec: number;
+  yPeriodSec: number;
+  xPhase: number;
+  yPhase: number;
+  /**
+   * Presence schedule: the actor is in frame for `presenceDuty` fraction
+   * of each `presenceCycleSec`-long cycle, starting at `presencePhase`
+   * (0–1) of the way through that cycle at t=0. Same shape as the
+   * trajectory oscillators so the math composes the same way.
+   */
+  presenceCycleSec: number;
+  presenceDuty: number;
+  presencePhase: number;
+}
+
+/**
+ * Clip-relative actor spec — cycle counts are expressed per-clip so the
+ * motion / presence rhythms scale to whatever video length is loaded.
+ * Resolve to concrete time-domain {@link SyntheticActor}s via
+ * {@link resolveActor} once the clip duration is known.
+ */
+export interface SyntheticActorSpec {
+  id: string;
+  label: string;
+  width: number;
+  height: number;
+  /** Number of x/y trajectory oscillations across the full clip. */
+  xCyclesPerClip: number;
+  yCyclesPerClip: number;
+  xPhase: number;
+  yPhase: number;
+  /** Number of presence (enter/exit) cycles across the full clip. */
+  presenceCyclesPerClip: number;
+  presenceDuty: number;
+  presencePhase: number;
+}
+
+export interface PresenceInterval {
+  startSec: number;
+  endSec: number;
+}
+
+/**
+ * Project a clip-relative {@link SyntheticActorSpec} onto an absolute-time
+ * {@link SyntheticActor} for the given clip duration.
+ */
+export function resolveActor(
+  spec: SyntheticActorSpec,
+  duration: number
+): SyntheticActor {
+  const safeDuration = duration > 0 ? duration : 1;
+  return {
+    id: spec.id,
+    label: spec.label,
+    width: spec.width,
+    height: spec.height,
+    xPeriodSec: safeDuration / Math.max(spec.xCyclesPerClip, 1e-3),
+    yPeriodSec: safeDuration / Math.max(spec.yCyclesPerClip, 1e-3),
+    xPhase: spec.xPhase,
+    yPhase: spec.yPhase,
+    presenceCycleSec: safeDuration / Math.max(spec.presenceCyclesPerClip, 1e-3),
+    presenceDuty: spec.presenceDuty,
+    presencePhase: spec.presencePhase,
+  };
+}
+
+export const DEFAULT_ACTOR_SPECS: SyntheticActorSpec[] = [
+  {
+    id: "actor-a",
+    label: "person",
+    width: 0.18,
+    height: 0.32,
+    // Two slow sweeps across the clip horizontally, ~1.3 vertically.
+    xCyclesPerClip: 1,
+    yCyclesPerClip: 0.5,
+    xPhase: 0,
+    yPhase: 0.25,
+    // In ~60% of the time, two enter/exit cycles.
+    presenceCyclesPerClip: 2,
+    presenceDuty: 0.6,
+    presencePhase: 0,
+  },
+  {
+    id: "actor-b",
+    label: "car",
+    width: 0.22,
+    height: 0.14,
+    // Faster horizontal motion (cars move).
+    xCyclesPerClip: 1.2,
+    yCyclesPerClip: 1,
+    xPhase: 0.5,
+    yPhase: 0.6,
+    // Starts in-frame briefly, then a longer middle appearance.
+    presenceCyclesPerClip: 1.5,
+    presenceDuty: 0.5,
+    presencePhase: 0.4,
+  },
+  {
+    id: "actor-c",
+    label: "dog",
+    width: 0.12,
+    height: 0.12,
+    xCyclesPerClip: 0.8,
+    yCyclesPerClip: 1.3,
+    xPhase: 0.8,
+    yPhase: 0.1,
+    // Starts out-of-frame, several short visits.
+    presenceCyclesPerClip: 2.5,
+    presenceDuty: 0.4,
+    presencePhase: 0.6,
+  },
+];
+
+const TWO_PI = Math.PI * 2;
+
+function oscillate(t: number, periodSec: number, phase: number): number {
+  // sine in [-1, 1] -> [0, 1]
+  return 0.5 + 0.5 * Math.sin(TWO_PI * (t / periodSec + phase));
+}
+
+/** Position in the current presence cycle, normalized to [0, 1). */
+function presenceOffset(time: number, actor: SyntheticActor): number {
+  const raw = time / actor.presenceCycleSec + actor.presencePhase;
+  return raw - Math.floor(raw);
+}
+
+/** True when the actor's presence cycle says it's in frame at `time`. */
+export function isPresent(time: number, actor: SyntheticActor): boolean {
+  return presenceOffset(time, actor) < actor.presenceDuty;
+}
+
+/**
+ * Enumerate the presence intervals (start, end pairs) for an actor over
+ * `[0, duration]`. Intervals are clipped to the duration; the actor may
+ * be in mid-interval at t=0 or at t=duration.
+ */
+export function getPresenceIntervals(
+  actor: SyntheticActor,
+  duration: number
+): PresenceInterval[] {
+  if (!(duration > 0)) {
+    return [];
+  }
+
+  const {
+    presenceCycleSec: cycle,
+    presenceDuty: duty,
+    presencePhase: phase,
+  } = actor;
+  const intervalLen = cycle * duty;
+  const out: PresenceInterval[] = [];
+
+  // Cycle n starts at t = cycle * (n - phase). Walk forward until we pass
+  // duration, including n=-1 so a cycle straddling t=0 is captured.
+  for (let n = -1; ; n++) {
+    const cycleStart = cycle * (n - phase);
+    if (cycleStart >= duration) {
+      break;
+    }
+
+    const intervalEnd = cycleStart + intervalLen;
+    const start = Math.max(0, cycleStart);
+    const end = Math.min(duration, intervalEnd);
+
+    if (end > start) {
+      out.push({ startSec: start, endSec: end });
+    }
+  }
+
+  return out;
+}
+
+function snapshotAtTime(
+  time: number,
+  fps: number,
+  actors: SyntheticActor[]
+): FrameLabelSnapshot {
+  const frameNumber = Math.max(0, Math.floor(time * fps));
+  const detections: SyntheticBox[] = [];
+  for (const actor of actors) {
+    if (!isPresent(time, actor)) {
+      continue;
+    }
+
+    // Position the bbox top-left so the whole box stays inside [0, 1].
+    const maxX = 1 - actor.width;
+    const maxY = 1 - actor.height;
+    const x = oscillate(time, actor.xPeriodSec, actor.xPhase) * maxX;
+    const y = oscillate(time, actor.yPeriodSec, actor.yPhase) * maxY;
+    detections.push({
+      id: actor.id,
+      label: actor.label,
+      bounding_box: [x, y, actor.width, actor.height],
+      // Per-actor stable instance so COLOR_BY.INSTANCE produces distinct
+      // colors per synthetic actor (the index path doesn't apply here
+      // — synthetic actors have no numeric index by design).
+      instance: { _cls: "Instance", _id: actor.id },
+      keyframe: true,
+      propagation: null,
+    });
+  }
+  return { frameNumber, detections };
+}
+
+/**
+ * Demo / test stream that emits a deterministic moving set of bboxes as a
+ * function of time. Synchronous — no fetch, never stalls the clock. Useful
+ * for exercising the playback → overlay diff path without real label data.
+ */
+export class SyntheticLabelStream extends PlaybackStreamBase<FrameLabelSnapshot> {
+  private readonly fps: number;
+  private actors: SyntheticActor[];
+
+  constructor(
+    id: string,
+    opts: { fps: number; duration?: number; actors?: SyntheticActor[] }
+  ) {
+    super(id, {
+      blocking: false,
+      duration: opts.duration,
+      nativeStepSeconds: 1 / opts.fps,
+      lookupPolicy: {
+        type: "nearestPrevious",
+        thresholdSeconds: 1 / opts.fps,
+      },
+    });
+    this.fps = opts.fps;
+    this.actors = opts.actors ?? [];
+  }
+
+  /**
+   * Replace the actor set. Callers typically resolve clip-relative specs
+   * to absolute actors once the video duration is known and call this.
+   * The next commit (seek or RAF tick) will reflect the new actors.
+   */
+  setActors(actors: SyntheticActor[]): void {
+    this.actors = actors;
+  }
+
+  bufferState(): "ready" {
+    return "ready";
+  }
+
+  prefetch(): void {
+    // no-op — generation is synchronous
+  }
+
+  getValue(time: number): FrameLabelSnapshot {
+    return snapshotAtTime(time, this.fps, this.actors);
+  }
+}

--- a/app/packages/video-annotation/src/streams/VideoFrameLabelsStream.test.ts
+++ b/app/packages/video-annotation/src/streams/VideoFrameLabelsStream.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveSyntheticId,
+  VideoFrameLabelsStream,
+} from "./VideoFrameLabelsStream";
+
+function buildStream(): VideoFrameLabelsStream {
+  return new VideoFrameLabelsStream({
+    id: "test",
+    sampleId: "s",
+    dataset: "d",
+    view: [],
+    frameCount: 100,
+    frameRate: 30,
+  });
+}
+
+// Frame numbers are 1-indexed: frame N's start time is (N-1)/fps.
+const timeOfFrame = (frame: number, fps: number): number => (frame - 1) / fps;
+
+describe("VideoFrameLabelsStream fetched-empty", () => {
+  it("bufferState returns 'ready' for frames in a fetched range with no cached doc", () => {
+    const stream = buildStream();
+    // @ts-expect-error — test-only: populate the private fetched-ranges list
+    stream.fetchedRanges.push([1, 60]);
+    expect(stream.bufferState(timeOfFrame(10, 30))).toBe("ready");
+  });
+
+  it("getValue returns an empty snapshot for frames in a fetched range with no cached doc", () => {
+    const stream = buildStream();
+    // @ts-expect-error - poke the private fetchedRanges to set up the test
+    stream.fetchedRanges.push([1, 60]);
+    expect(stream.getValue(timeOfFrame(10, 30))).toEqual({
+      frameNumber: 10,
+      detections: [],
+    });
+  });
+});
+
+describe("VideoFrameLabelsStream extractDetections", () => {
+  it("defaults missing keyframe to false and propagation to null", () => {
+    const stream = buildStream();
+    // @ts-expect-error — test-only: populate the private cache
+    stream.cache.set(10, {
+      frame_number: 10,
+      detections: {
+        detections: [
+          { _id: "a", label: "car", bounding_box: [0, 0, 0.1, 0.1] },
+        ],
+      },
+    });
+
+    const value = stream.getValue(timeOfFrame(10, 30));
+    expect(value?.detections[0].keyframe).toBe(false);
+    expect(value?.detections[0].propagation).toBeNull();
+  });
+});
+
+describe("resolveSyntheticId", () => {
+  it("prefers instance._id over index and _id", () => {
+    expect(
+      resolveSyntheticId({
+        instance: { _cls: "Instance", _id: "i1" },
+        index: 3,
+        _id: "d1",
+      })
+    ).toBe("instance-i1");
+  });
+
+  it("falls back to track-${index} when there is no instance id", () => {
+    expect(resolveSyntheticId({ index: 3, _id: "d1" })).toBe("track-3");
+  });
+
+  it("treats index 0 as a valid track id", () => {
+    expect(resolveSyntheticId({ index: 0, _id: "d1" })).toBe("track-0");
+  });
+
+  it("falls back to _id (then id) for untracked detections", () => {
+    expect(resolveSyntheticId({ _id: "d1" })).toBe("d1");
+    expect(resolveSyntheticId({ id: "d2" })).toBe("d2");
+  });
+
+  it("returns null when no usable identifier is present", () => {
+    expect(resolveSyntheticId({ label: "car" })).toBeNull();
+  });
+});

--- a/app/packages/video-annotation/src/streams/VideoFrameLabelsStream.ts
+++ b/app/packages/video-annotation/src/streams/VideoFrameLabelsStream.ts
@@ -1,0 +1,419 @@
+import {
+  type FrameLabelSnapshot,
+  type LocalDetection,
+  type RawDetection,
+  type RawDetectionsField,
+  type Stage,
+  type SyntheticBox,
+} from "@fiftyone/utilities";
+import {
+  getFrames,
+  type FrameDoc,
+} from "../../../core/src/client/framesClient";
+import {
+  frameAt,
+  PlaybackStreamBase,
+  type BufferReadiness,
+  type PlaybackStore,
+} from "@fiftyone/playback";
+import { isInFetchedRange, mergeRange, toSecondRanges } from "./fetchedRanges";
+
+// Re-exported from `@fiftyone/utilities` for the package barrel.
+export type { LocalDetection, RawDetection, RawDetectionsField };
+
+export interface VideoFrameLabelsStreamOptions {
+  id: string;
+  /** Sample id for the parent video document. */
+  sampleId: string;
+  /** Current dataset name (POST /frames requires it). */
+  dataset: string;
+  /** Active view stages — same shape sent on every dataset query. */
+  view: Stage[];
+  /** Group slice name, when the dataset is grouped. */
+  groupSlice?: string | null;
+  /** Total frame count of the clip (1-indexed up to this number). */
+  frameCount: number;
+  /** Frame rate in frames per second. */
+  frameRate: number;
+  /**
+   * todo - multiple fields
+   * Field on the per-frame document that carries `Detections`. Strip the
+   * `frames.` prefix that lives in the parent video schema — the per-frame
+   * samples returned by `/frames` are already frame-relative.
+   *
+   * @default "detections"
+   */
+  frameField?: string;
+  /**
+   * Number of frames to request in a single `/frames` chunk. Larger
+   * values mean fewer round trips but larger payloads.
+   *
+   * @default 60
+   */
+  chunkSize?: number;
+}
+
+const DEFAULT_CHUNK_SIZE = 60;
+const DEFAULT_FRAME_FIELD = "detections";
+
+/**
+ * Labels stream backed by the `POST /frames` endpoint.
+ *
+ * Caches per-frame samples by 1-indexed frame number. `bufferState`
+ * reports readiness for a given time; `prefetch` issues a chunk fetch
+ * starting at the first missing frame in the requested range; `getValue`
+ * reads the cached frame for the read-only snapshot.
+ *
+ * Read-only: the stream loads `/frames` chunks and seeds the annotation
+ * engine's frame store (via {@link cachedFrames} + {@link subscribeToEdits}).
+ * All label mutation, dirty tracking, and persistence live in the engine; the
+ * stream holds no edit state.
+ */
+export class VideoFrameLabelsStream extends PlaybackStreamBase<FrameLabelSnapshot> {
+  private readonly sampleId: string;
+  private readonly dataset: string;
+  private readonly view: Stage[];
+  private readonly groupSlice: string | null;
+  private readonly frameCount: number;
+  private readonly frameRate: number;
+  private readonly frameField: string;
+  private readonly chunkSize: number;
+
+  private readonly cache = new Map<number, FrameDoc>();
+  private readonly inflight = new Map<number, Promise<void>>();
+  private readonly fetchedRanges: Array<[number, number]> = [];
+  // Notified whenever a chunk lands. The annotation engine's frame store
+  // re-seeds from `cachedFrames()` on this signal (via `subscribeToEdits`);
+  // the stream itself holds no edit state — it is a read-only `/frames` seed
+  // and the engine owns all label mutations.
+  private readonly editListeners = new Set<() => void>();
+
+  constructor(opts: VideoFrameLabelsStreamOptions) {
+    super(opts.id, {
+      blocking: true,
+      duration: opts.frameCount / opts.frameRate,
+      nativeStepSeconds: 1 / opts.frameRate,
+      lookupPolicy: {
+        type: "nearestPrevious",
+        thresholdSeconds: 1 / opts.frameRate,
+      },
+    });
+
+    this.sampleId = opts.sampleId;
+    this.dataset = opts.dataset;
+    this.view = opts.view;
+    this.groupSlice = opts.groupSlice ?? null;
+    this.frameCount = opts.frameCount;
+    this.frameRate = opts.frameRate;
+    this.frameField = opts.frameField ?? DEFAULT_FRAME_FIELD;
+    this.chunkSize = opts.chunkSize ?? DEFAULT_CHUNK_SIZE;
+  }
+
+  /**
+   * Resolve once the frame containing `time` is cached. Coalesces against
+   * any in-flight chunk covering that frame; otherwise kicks one off.
+   *
+   * Intended for "show overlays before the user plays" — call this after
+   * registering the stream, then `seek(time)` once it resolves so the
+   * engine commits with the frame in hand.
+   */
+  async warmup(time = 0): Promise<void> {
+    const frame = this.timeToFrame(time);
+    if (this.cache.has(frame)) {
+      return;
+    }
+
+    const inflight = this.inflight.get(frame);
+    if (inflight) {
+      await inflight;
+      return;
+    }
+
+    await this.fetchChunk(frame);
+  }
+
+  /**
+   * Resolve once every frame in [1, frameCount] is cached. Coalesces
+   * against any in-flight chunks; otherwise walks the range in chunk-
+   * sized strides and dispatches fetches in parallel. Expensive over long
+   * clips; used for one-shot full-clip analyses (e.g. timeline tracks).
+   */
+  async warmupAll(): Promise<void> {
+    const promises: Promise<void>[] = [];
+    let f = 1;
+
+    while (f <= this.frameCount) {
+      if (this.cache.has(f)) {
+        f++;
+        continue;
+      }
+
+      const inflight = this.inflight.get(f);
+      if (inflight) {
+        promises.push(inflight);
+        f += this.chunkSize;
+        continue;
+      }
+
+      promises.push(this.fetchChunk(f));
+      f += this.chunkSize;
+    }
+
+    await Promise.all(promises);
+  }
+
+  /** Total frames in the clip — useful for callers iterating the cache. */
+  get totalFrames(): number {
+    return this.frameCount;
+  }
+
+  /**
+   * Every cached frame document, for seeding an external store (the annotation
+   * engine's frame store). Pairs with {@link subscribeToEdits} so the seed
+   * re-runs as chunks land.
+   */
+  cachedFrames(): FrameDoc[] {
+    return [...this.cache.values()];
+  }
+
+  /** Frame rate the stream was constructed with, in fps. */
+  get fps(): number {
+    return this.frameRate;
+  }
+
+  /** Per-frame field that carries the labels (e.g. `"detections"`). */
+  get labelsField(): string {
+    return this.frameField;
+  }
+
+  bufferState(time: number): BufferReadiness {
+    const frame = this.timeToFrame(time);
+
+    if (this.cache.has(frame)) {
+      return "ready";
+    }
+
+    if (this.isInflight(frame)) {
+      return "loading";
+    }
+
+    if (isInFetchedRange(this.fetchedRanges, frame)) {
+      return "ready";
+    }
+
+    return "missing";
+  }
+
+  prefetch(range: [number, number]): void {
+    const [startSec, endSec] = range;
+    const startFrame = this.timeToFrame(startSec);
+    const endFrame = this.timeToFrame(endSec);
+
+    // Find the first missing frame in the range and issue one chunk
+    // starting there. The engine calls prefetch again as the playhead
+    // advances — we don't need to fan out multiple requests here.
+    for (let f = startFrame; f <= endFrame; f++) {
+      if (this.cache.has(f) || this.isInflight(f)) {
+        continue;
+      }
+
+      void this.fetchChunk(f);
+
+      return;
+    }
+  }
+
+  getValue(time: number): FrameLabelSnapshot | null {
+    const frame = this.timeToFrame(time);
+    const sample = this.cache.get(frame);
+    if (!sample) {
+      // Chunk fetched, this frame had no labels — return an empty
+      // snapshot so consumers can tell "no labels here" from "not fetched".
+      if (isInFetchedRange(this.fetchedRanges, frame)) {
+        return { frameNumber: frame, detections: [] };
+      }
+      return null;
+    }
+
+    return {
+      frameNumber: frame,
+      // todo - adapter pattern for other label types
+      detections: extractDetections(sample, this.frameField),
+    };
+  }
+
+  /**
+   * Custom `onCommit`: dedupe by `frameNumber` so we only publish when the
+   * frame changes or transitions to/from `null` (cache miss → hit). Avoids
+   * re-publishing identical content on every intra-frame tick.
+   */
+  override onCommit(time: number, store: PlaybackStore): void {
+    const next = this.getValue(time);
+    const prev = this.readPublished(store);
+
+    if (prev && next && prev.frameNumber === next.frameNumber) {
+      return;
+    }
+
+    if (prev === null && next === null) {
+      return;
+    }
+
+    this.publish(store, next);
+  }
+
+  /**
+   * Subscribe to cache-mutation events (chunks landing). Returns an
+   * unsubscribe function. Used to re-seed an external store (the engine's
+   * frame store) whenever the `/frames` cache changes.
+   */
+  subscribeToEdits(listener: () => void): () => void {
+    this.editListeners.add(listener);
+    return () => {
+      this.editListeners.delete(listener);
+    };
+  }
+
+  private notifyEdits(): void {
+    for (const listener of this.editListeners) {
+      listener();
+    }
+  }
+
+  bufferedRanges(): Array<[number, number]> {
+    return toSecondRanges(this.fetchedRanges, this.frameRate);
+  }
+
+  /** Map a stream time to the 1-indexed frame number. */
+  timeToFrame(time: number): number {
+    return frameAt(time, this.frameRate, this.frameCount);
+  }
+
+  private isInflight(frame: number): boolean {
+    return this.inflight.has(frame);
+  }
+
+  private async fetchChunk(startFrame: number): Promise<void> {
+    const numFrames = Math.min(
+      this.chunkSize,
+      this.frameCount - startFrame + 1
+    );
+
+    if (numFrames <= 0) {
+      return;
+    }
+
+    const promise = this.doFetch(startFrame, numFrames).finally(() => {
+      for (let f = startFrame; f < startFrame + numFrames; f++) {
+        if (this.inflight.get(f) === promise) {
+          this.inflight.delete(f);
+        }
+      }
+    });
+
+    for (let f = startFrame; f < startFrame + numFrames; f++) {
+      this.inflight.set(f, promise);
+    }
+
+    return promise;
+  }
+
+  private async doFetch(startFrame: number, numFrames: number): Promise<void> {
+    try {
+      const result = await getFrames({
+        frameNumber: startFrame,
+        numFrames,
+        frameCount: this.frameCount,
+        sampleId: this.sampleId,
+        dataset: this.dataset,
+        view: this.view,
+        slice: this.groupSlice ?? undefined,
+      });
+
+      for (const frame of result.frames) {
+        // The /frames response is the seed; the engine owns edits, so the
+        // stream never reconciles local state against the fetch.
+        this.cache.set(frame.frame_number, frame);
+      }
+
+      mergeRange(this.fetchedRanges, result.range);
+
+      if (result.frames.length > 0) {
+        this.notifyEdits();
+      }
+    } catch (error) {
+      // Surface but don't crash — the engine will keep asking; subsequent
+      // prefetch calls will retry the missing frames.
+      console.error(
+        `[VideoFrameLabelsStream] fetch failed for [${startFrame}, +${numFrames})`,
+        error
+      );
+    }
+  }
+}
+
+/**
+ * Pull detections off a per-frame sample and convert them into the
+ * `SyntheticBox` shape the existing overlay-diff path consumes.
+ *
+ * Prefers FiftyOne's track `index` for stable cross-frame identity; falls
+ * back to `_id` so un-tracked detections still render (with the caveat
+ * that they will churn add/remove on every frame).
+ */
+function extractDetections(
+  sample: FrameDoc,
+  frameField: string
+): SyntheticBox[] {
+  const raw = sample[frameField] as RawDetectionsField | undefined;
+  const detections = raw?.detections;
+  if (!Array.isArray(detections)) {
+    return [];
+  }
+
+  const out: SyntheticBox[] = [];
+  for (const det of detections) {
+    if (!det.bounding_box || det.bounding_box.length !== 4) {
+      continue;
+    }
+
+    const id = resolveSyntheticId(det);
+    if (!id) {
+      continue;
+    }
+
+    out.push({
+      id,
+      _id: det._id ?? det.id ?? undefined,
+      label: det.label ?? "",
+      bounding_box: det.bounding_box,
+      index: det.index,
+      instance: det.instance ?? undefined,
+      keyframe: det.keyframe ?? false,
+      propagation: det.propagation ?? null,
+    });
+  }
+
+  return out;
+}
+
+/**
+ * Derive a detection's cross-frame overlay id for the read-only snapshot.
+ * Prefers `instance._id` so tracked instances keep one identity across frames;
+ * falls back to `track-${index}` for legacy data carrying only a numeric index,
+ * then to the per-frame `_id` for untracked, un-instanced detections. `null`
+ * when the detection carries no usable identifier.
+ *
+ * Note: this is the snapshot's synthetic scheme; the engine addresses tracks by
+ * the raw `instance._id` (see `trackIdentity`).
+ */
+export function resolveSyntheticId(det: RawDetection): string | null {
+  if (det.instance?._id) {
+    return `instance-${det.instance._id}`;
+  }
+
+  if (det.index !== undefined) {
+    return `track-${det.index}`;
+  }
+
+  return det._id ?? det.id ?? null;
+}

--- a/app/packages/video-annotation/src/streams/createStreamHandle.ts
+++ b/app/packages/video-annotation/src/streams/createStreamHandle.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { atom, type PrimitiveAtom, useAtomValue, useSetAtom } from "jotai";
+import { useEffect } from "react";
+
+/**
+ * A published "active stream" handle: a module-private jotai atom paired with
+ * a reader hook and a publisher hook. The video surface registers a single
+ * live instance of each stream (frame labels, imavid images) so external code
+ * can read the active one, while only the stream's registrar can publish it.
+ *
+ * The atom is **closure-private** — it can't be imported even by accident,
+ * Call once at module scope and re-export the returned hooks under
+ * stream-specific names.
+ *
+ * @example
+ * const { useStream, usePublishStream } =
+ *   createStreamHandle<VideoFrameLabelsStream>();
+ * export const useFrameLabelsStream = useStream;
+ * export const usePublishFrameLabelsStream = usePublishStream;
+ */
+export function createStreamHandle<T>(): {
+  /** Reads the active stream, or `null` when none is published. */
+  useStream: () => T | null;
+  /**
+   * Publishes `stream` for the lifetime of the calling component, clearing
+   * it on unmount. Intended for the stream's registrar; nothing else should
+   * publish.
+   */
+  usePublishStream: (stream: T | null) => void;
+} {
+  // jotai `atom<T>(null)` with strictNullChecks off infers a read-only `Atom`
+  // (null satisfies the first `read`-fn overload), so cast to the writable
+  // primitive it actually is.
+  const streamAtom = atom<T | null>(null) as PrimitiveAtom<T | null>;
+
+  const useStream = (): T | null => useAtomValue(streamAtom);
+
+  const usePublishStream = (stream: T | null): void => {
+    const setStream = useSetAtom(streamAtom);
+
+    useEffect(() => {
+      setStream(stream);
+
+      return () => setStream(null);
+    }, [setStream, stream]);
+  };
+
+  return { useStream, usePublishStream };
+}

--- a/app/packages/video-annotation/src/streams/fetchedRanges.test.ts
+++ b/app/packages/video-annotation/src/streams/fetchedRanges.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  type FrameRange,
+  isInFetchedRange,
+  mergeRange,
+  toSecondRanges,
+} from "./fetchedRanges";
+
+describe("mergeRange", () => {
+  it("adds the first range to an empty list", () => {
+    const ranges: FrameRange[] = [];
+    mergeRange(ranges, [5, 10]);
+    expect(ranges).toEqual([[5, 10]]);
+  });
+
+  it("keeps non-adjacent ranges separate", () => {
+    const ranges: FrameRange[] = [[1, 5]];
+    mergeRange(ranges, [10, 15]);
+    expect(ranges).toEqual([
+      [1, 5],
+      [10, 15],
+    ]);
+  });
+
+  it("coalesces an adjacent range (gap of exactly one frame)", () => {
+    const ranges: FrameRange[] = [[1, 5]];
+    // 6 === 5 + 1, so the chunks touch and should merge.
+    mergeRange(ranges, [6, 10]);
+    expect(ranges).toEqual([[1, 10]]);
+  });
+
+  it("merges overlapping ranges", () => {
+    const ranges: FrameRange[] = [[1, 8]];
+    mergeRange(ranges, [5, 12]);
+    expect(ranges).toEqual([[1, 12]]);
+  });
+
+  it("sorts then merges an out-of-order insert", () => {
+    const ranges: FrameRange[] = [[20, 25]];
+    mergeRange(ranges, [1, 5]);
+    mergeRange(ranges, [6, 19]);
+    expect(ranges).toEqual([[1, 25]]);
+  });
+
+  it("absorbs a fully-contained range without shrinking the span", () => {
+    const ranges: FrameRange[] = [[1, 20]];
+    mergeRange(ranges, [5, 10]);
+    expect(ranges).toEqual([[1, 20]]);
+  });
+});
+
+describe("isInFetchedRange", () => {
+  const ranges: FrameRange[] = [
+    [1, 5],
+    [10, 15],
+  ];
+
+  it("returns true for a frame inside a range", () => {
+    expect(isInFetchedRange(ranges, 12)).toBe(true);
+  });
+
+  it("is inclusive of both endpoints", () => {
+    expect(isInFetchedRange(ranges, 1)).toBe(true);
+    expect(isInFetchedRange(ranges, 5)).toBe(true);
+    expect(isInFetchedRange(ranges, 10)).toBe(true);
+    expect(isInFetchedRange(ranges, 15)).toBe(true);
+  });
+
+  it("returns false for a frame in a gap or outside all ranges", () => {
+    expect(isInFetchedRange(ranges, 7)).toBe(false);
+    expect(isInFetchedRange(ranges, 20)).toBe(false);
+  });
+
+  it("returns false against an empty list", () => {
+    expect(isInFetchedRange([], 1)).toBe(false);
+  });
+});
+
+describe("toSecondRanges", () => {
+  it("shifts the start back one frame and divides by the frame rate", () => {
+    // At 10 fps, frames 1..10 cover [0, 1] seconds.
+    expect(toSecondRanges([[1, 10]], 10)).toEqual([[0, 1]]);
+  });
+
+  it("converts each range independently", () => {
+    expect(
+      toSecondRanges(
+        [
+          [1, 5],
+          [11, 20],
+        ],
+        10
+      )
+    ).toEqual([
+      [0, 0.5],
+      [1, 2],
+    ]);
+  });
+
+  it("returns an empty list for no ranges", () => {
+    expect(toSecondRanges([], 30)).toEqual([]);
+  });
+});

--- a/app/packages/video-annotation/src/streams/fetchedRanges.ts
+++ b/app/packages/video-annotation/src/streams/fetchedRanges.ts
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+/**
+ * A `[start, end]` span of 1-indexed frame numbers, both ends inclusive.
+ * Streams track which frames they've fetched as a sorted, disjoint list of
+ * these.
+ */
+export type FrameRange = [number, number];
+
+/**
+ * Merge a newly-fetched `[start, end]` range into a sorted, disjoint list of
+ * contiguous ranges, in place. Ranges that touch or overlap (`cur.start <=
+ * prev.end + 1`) collapse, so adjacent chunks coalesce into one span.
+ */
+export function mergeRange(ranges: Array<FrameRange>, add: FrameRange): void {
+  ranges.push(add);
+  ranges.sort((a, b) => a[0] - b[0]);
+
+  for (let i = ranges.length - 1; i > 0; i--) {
+    const prev = ranges[i - 1];
+    const cur = ranges[i];
+
+    if (cur[0] <= prev[1] + 1) {
+      prev[1] = Math.max(prev[1], cur[1]);
+      ranges.splice(i, 1);
+    }
+  }
+}
+
+/** Whether `frame` falls within any fetched range (both ends inclusive). */
+export function isInFetchedRange(
+  ranges: ReadonlyArray<FrameRange>,
+  frame: number
+): boolean {
+  for (const [start, end] of ranges) {
+    if (frame >= start && frame <= end) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Project 1-indexed frame ranges onto stream-time second ranges — the form
+ * the timeline's buffered-bar consumes. The start shifts back one frame so a
+ * fetched frame covers the interval leading up to its timestamp.
+ */
+export function toSecondRanges(
+  ranges: ReadonlyArray<FrameRange>,
+  frameRate: number
+): Array<FrameRange> {
+  return ranges.map(
+    ([start, end]) => [(start - 1) / frameRate, end / frameRate] as FrameRange
+  );
+}

--- a/app/packages/video-annotation/src/streams/frameLabelsStream.ts
+++ b/app/packages/video-annotation/src/streams/frameLabelsStream.ts
@@ -1,0 +1,23 @@
+import { createStreamHandle } from "./createStreamHandle";
+import type { VideoFrameLabelsStream } from "./VideoFrameLabelsStream";
+
+const { useStream, usePublishStream } =
+  createStreamHandle<VideoFrameLabelsStream>();
+
+/**
+ * Active frame-labels stream; publication goes through
+ * {@link usePublishFrameLabelsStream} so external code can't write arbitrary
+ * values.
+ *
+ * `null` while the stream's params (sampleId, duration, etc.) aren't all
+ * available yet — consumers should treat that as "no data available; render
+ * placeholder."
+ */
+export const useFrameLabelsStream = useStream;
+
+/**
+ * Publishes `stream` as the active frame-labels stream for the lifetime of
+ * the calling component, clearing on unmount. Intended for the labels
+ * registrar; nothing else should be publishing.
+ */
+export const usePublishFrameLabelsStream = usePublishStream;

--- a/app/packages/video-annotation/src/streams/framesData.test.ts
+++ b/app/packages/video-annotation/src/streams/framesData.test.ts
@@ -1,0 +1,78 @@
+/**
+ * The `/frames` → flat-FramesData adapter: frame keying, the `frames.<field>`
+ * path, element pass-through, `_id` normalization, and empty/absent fields.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { FrameDocLike } from "./framesData";
+import { parseFramesData } from "./framesData";
+
+const doc = (frame_number: number, detections: unknown[]): FrameDocLike => ({
+  frame_number,
+  detections: { detections },
+});
+
+describe("parseFramesData", () => {
+  it("flattens to { [frame]: { 'frames.<field>': elements } }", () => {
+    const data = parseFramesData(
+      [
+        doc(1, [{ _id: "d1", instance: { _id: "A", _cls: "Instance" } }]),
+        doc(2, [{ _id: "d2", instance: { _id: "A", _cls: "Instance" } }]),
+      ],
+      "detections"
+    );
+
+    expect(Object.keys(data)).toEqual(["1", "2"]);
+    expect(data[1]["frames.detections"]).toHaveLength(1);
+    expect(data[1]["frames.detections"][0].instance).toEqual({
+      _id: "A",
+      _cls: "Instance",
+    });
+  });
+
+  it("passes element fields through whole and stamps _cls", () => {
+    const data = parseFramesData(
+      [
+        doc(1, [
+          { _id: "d1", label: "car", bounding_box: [0, 0, 1, 1], mask: "m" },
+        ]),
+      ],
+      "detections"
+    );
+
+    const el = data[1]["frames.detections"][0];
+    expect(el).toMatchObject({
+      _id: "d1",
+      _cls: "Detection",
+      label: "car",
+      bounding_box: [0, 0, 1, 1],
+      mask: "m",
+    });
+  });
+
+  it("normalizes _id from a raw `id` when `_id` is absent", () => {
+    const data = parseFramesData([doc(1, [{ id: "legacy" }])], "detections");
+
+    expect(data[1]["frames.detections"][0]._id).toBe("legacy");
+  });
+
+  it("respects a non-default per-frame field name", () => {
+    const data = parseFramesData(
+      [{ frame_number: 5, boxes: { detections: [{ _id: "d1" }] } }],
+      "boxes"
+    );
+
+    expect(data[5]["frames.boxes"]).toHaveLength(1);
+  });
+
+  it("emits an empty list for a fetched frame with no detections", () => {
+    const data = parseFramesData(
+      [{ frame_number: 3 }, doc(4, [])],
+      "detections"
+    );
+
+    expect(data[3]["frames.detections"]).toEqual([]);
+    expect(data[4]["frames.detections"]).toEqual([]);
+  });
+});

--- a/app/packages/video-annotation/src/streams/framesData.ts
+++ b/app/packages/video-annotation/src/streams/framesData.ts
@@ -1,0 +1,51 @@
+import type { FramesData } from "@fiftyone/annotation";
+import type {
+  LabelData,
+  RawDetection,
+  RawDetectionsField,
+} from "@fiftyone/utilities";
+
+/** The minimal `/frames` document shape this adapter reads. */
+export interface FrameDocLike {
+  frame_number: number;
+  [key: string]: unknown;
+}
+
+/**
+ * Map the nested `/frames` payload into the flat {@link FramesData} the
+ * {@link FrameStore} seeds from.
+ *
+ * Each `/frames` document carries a `Detections`-shaped field
+ * (`{ detections: [...] }`) under the frame-relative field name
+ * (`perFrameField`, e.g. `detections`). The store addresses by the
+ * sample-schema path (`frames.detections`) and holds the element list directly,
+ * so this flattens `{ frame_number, <field>: { detections } }` to
+ * `{ [frame_number]: { "frames.<field>": elements } }`.
+ *
+ * Elements are passed through whole (mask, attributes, confidence, … survive
+ * the round trip); only `_id`/`_cls` are normalized so the store can address by
+ * the track's `instance._id` and persist each frame's list by document `_id`.
+ */
+export const parseFramesData = (
+  docs: Iterable<FrameDocLike>,
+  perFrameField: string
+): FramesData => {
+  const path = `frames.${perFrameField}`;
+  const out: FramesData = {};
+
+  for (const doc of docs) {
+    const field = doc[perFrameField] as RawDetectionsField | undefined;
+    const detections = field?.detections ?? [];
+
+    out[doc.frame_number] = { [path]: detections.map(toLabelData) };
+  }
+
+  return out;
+};
+
+/** A raw `/frames` detection as store {@link LabelData}: stable `_id`, `_cls`. */
+const toLabelData = (det: RawDetection): LabelData => ({
+  ...det,
+  _id: det._id ?? det.id ?? "",
+  _cls: "Detection",
+});

--- a/app/packages/video-annotation/src/streams/framesWorker.ts
+++ b/app/packages/video-annotation/src/streams/framesWorker.ts
@@ -1,0 +1,214 @@
+/**
+ * Worker that owns `POST /frames` + per-image fetch + `createImageBitmap`
+ * decode for `ImaVidImageStream`. Moves both the JSON parse and the
+ * pixel decode off the main thread; ImageBitmaps are transferred back
+ * (zero-copy) so the main thread can `drawImage` them onto a canvas
+ * without a re-decode.
+ *
+ * Auth handling: on `init` we install `@fiftyone/utilities`'s fetch
+ * singleton inside the worker scope with the same `(origin, headers,
+ * pathPrefix)` the main thread uses. `/frames` requests then flow
+ * through `getFrames` exactly as they do on the main thread. Token
+ * refresh would require an `updateHeaders` message (looker's worker
+ * has the same gap; deferred until needed).
+ *
+ * Wire protocol (all messages have a `type`):
+ *
+ *   main → worker:
+ *     { type: "init", origin, pathPrefix, headers }      // once at start
+ *     { type: "fetchChunk", reqId, request }             // per chunk
+ *
+ *   worker → main:
+ *     { type: "frameReady", reqId, frameNumber, src, bitmap, width, height }
+ *     { type: "chunkDone", reqId, range }                // all frames in chunk processed
+ *     { type: "chunkFailed", reqId, error }              // top-level fetch / parse failure
+ */
+
+/// <reference lib="webworker" />
+
+import { setFetchFunction } from "@fiftyone/utilities";
+import {
+  getFrames,
+  type GetFramesRequest,
+} from "../../../core/src/client/framesClient";
+
+interface InitMessage {
+  type: "init";
+  origin: string;
+  pathPrefix: string;
+  headers: Record<string, string>;
+}
+
+interface FetchChunkMessage {
+  type: "fetchChunk";
+  reqId: number;
+  request: GetFramesRequest;
+}
+
+type InboundMessage = InitMessage | FetchChunkMessage;
+
+export interface FrameReadyMessage {
+  type: "frameReady";
+  reqId: number;
+  frameNumber: number;
+  src: string;
+  bitmap: ImageBitmap;
+  width: number;
+  height: number;
+}
+
+export interface ChunkDoneMessage {
+  type: "chunkDone";
+  reqId: number;
+  range: [number, number];
+}
+
+export interface ChunkFailedMessage {
+  type: "chunkFailed";
+  reqId: number;
+  error: string;
+}
+
+export type OutboundMessage =
+  | FrameReadyMessage
+  | ChunkDoneMessage
+  | ChunkFailedMessage;
+
+let initialized = false;
+let origin = "";
+let pathPrefix = "";
+
+self.addEventListener("message", (event: MessageEvent<InboundMessage>) => {
+  const msg = event.data;
+
+  switch (msg.type) {
+    case "init":
+      // Install the fetch singleton inside the worker's module scope.
+      // Subsequent `getFrames` calls in this worker pick up the configured
+      // origin / headers / pathPrefix.
+      origin = msg.origin;
+      pathPrefix = msg.pathPrefix;
+      setFetchFunction(msg.origin, msg.headers ?? {}, msg.pathPrefix);
+      initialized = true;
+      break;
+
+    case "fetchChunk":
+      if (!initialized) {
+        postFailed(msg.reqId, "framesWorker received fetchChunk before init");
+        return;
+      }
+      void handleFetchChunk(msg);
+      break;
+  }
+});
+
+async function handleFetchChunk(msg: FetchChunkMessage): Promise<void> {
+  let frames: Awaited<ReturnType<typeof getFrames>>;
+  try {
+    frames = await getFrames(msg.request);
+  } catch (error) {
+    postFailed(msg.reqId, errorMessage(error));
+    return;
+  }
+
+  // Kick off every frame's fetch+decode in parallel; post each one as
+  // soon as it's ready so the main-thread cache fills incrementally.
+  await Promise.all(
+    frames.frames.map((frame) => decodeAndDispatch(msg.reqId, frame))
+  );
+
+  postOutbound({
+    type: "chunkDone",
+    reqId: msg.reqId,
+    range: frames.range,
+  });
+}
+
+async function decodeAndDispatch(
+  reqId: number,
+  frame: { frame_number: number; filepath?: string }
+): Promise<void> {
+  if (!frame.filepath || typeof frame.filepath !== "string") {
+    return;
+  }
+
+  const src = resolveMediaSrc(frame.filepath);
+
+  let bitmap: ImageBitmap;
+  try {
+    // Match `<img src>` semantics for the media GET: no custom
+    // headers, default credentials
+    const r = await fetch(src, { mode: "cors" });
+
+    if (!r.ok) {
+      throw new Error(`image fetch failed: ${r.status}`);
+    }
+
+    const blob = await r.blob();
+    bitmap = await createImageBitmap(blob);
+  } catch (error) {
+    // Skip — main-thread treats this frame as missing and the engine
+    // re-requests on the next prefetch tick.
+    console.error(
+      `[framesWorker] decode failed for frame ${frame.frame_number}`,
+      error
+    );
+
+    return;
+  }
+
+  postOutbound(
+    {
+      type: "frameReady",
+      reqId,
+      frameNumber: frame.frame_number,
+      src,
+      bitmap,
+      width: bitmap.width,
+      height: bitmap.height,
+    },
+    [bitmap]
+  );
+}
+
+/**
+ * Mirror of `@fiftyone/state`'s `getSampleSrc`: passthrough for absolute
+ * URLs / data: / blob: schemes; otherwise wrap as `/media?filepath=...`
+ * using the worker-resolved origin + pathPrefix (set on `init`).
+ */
+function resolveMediaSrc(filepath: string): string {
+  if (/^\w+:\/\//.test(filepath) || /^(data|blob):/.test(filepath)) {
+    return filepath;
+  }
+
+  return `${joinUrl(
+    origin,
+    pathPrefix,
+    "/media"
+  )}?filepath=${encodeURIComponent(filepath)}`;
+}
+
+function joinUrl(origin: string, pathPrefix: string, suffix: string): string {
+  return `${origin}${pathPrefix}${suffix}`.replace(/([^:]\/)\/+/g, "$1");
+}
+
+function postOutbound(msg: OutboundMessage, transfer?: Transferable[]): void {
+  // self.postMessage's typing varies by lib; the cast is to the worker
+  // DedicatedWorkerGlobalScope signature.
+  (self as unknown as DedicatedWorkerGlobalScope).postMessage(
+    msg,
+    transfer ?? []
+  );
+}
+
+function postFailed(reqId: number, error: string): void {
+  postOutbound({ type: "chunkFailed", reqId, error });
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+}

--- a/app/packages/video-annotation/src/streams/imaVidImageStreamHandle.ts
+++ b/app/packages/video-annotation/src/streams/imaVidImageStreamHandle.ts
@@ -1,0 +1,24 @@
+import { createStreamHandle } from "./createStreamHandle";
+import type { ImaVidImageStream } from "./ImaVidImageStream";
+
+const { useStream, usePublishStream } = createStreamHandle<ImaVidImageStream>();
+
+/**
+ * Active ImaVid image stream (decoded per-frame bitmaps). Published so
+ * consumers outside the tile — e.g. SAM2 video propagation, which needs to
+ * pull arbitrary frame bitmaps by index — can reach the stream instance to
+ * call `warmup` / `getValue`.
+ *
+ * Mirrors {@link useFrameLabelsStream}: publication goes through
+ * {@link usePublishImaVidImageStream} so external code can't write arbitrary
+ * values; `null` until the imavid registrar mounts (e.g. the native-video
+ * surface, which has no image stream).
+ */
+export const useImaVidImageStream = useStream;
+
+/**
+ * Publishes `stream` as the active ImaVid image stream for the lifetime of
+ * the calling component, clearing on unmount. Intended for the imavid image
+ * registrar; nothing else should be publishing.
+ */
+export const usePublishImaVidImageStream = usePublishStream;

--- a/app/packages/video-annotation/src/sync/establishKeyRelay.ts
+++ b/app/packages/video-annotation/src/sync/establishKeyRelay.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+/**
+ * A consume-once relay for the undo key a freshly-drawn overlay committed
+ * under. The engine Lighter bridge stashes the key by overlay id when it commits
+ * a draw (`onEstablishCommit`); the video auto-extend takes it back — also by
+ * overlay id — to fold its filler write into the draw's single undo unit. Keying
+ * by the globally-unique overlay id keeps the handoff explicit and
+ * order-independent: the take runs in a microtask, after the synchronous stash.
+ */
+const keys = new Map<string, string>();
+
+/** Stash the gesture key a draw committed under, keyed by its overlay id. */
+export const stashEstablishKey = (overlayId: string, undoKey: string): void => {
+  keys.set(overlayId, undoKey);
+};
+
+/** Take (and clear) a draw's stashed gesture key; `undefined` if none. */
+export const takeEstablishKey = (overlayId: string): string | undefined => {
+  const key = keys.get(overlayId);
+  keys.delete(overlayId);
+  return key;
+};

--- a/app/packages/video-annotation/src/sync/useSyncLighterAnnotation.ts
+++ b/app/packages/video-annotation/src/sync/useSyncLighterAnnotation.ts
@@ -1,0 +1,256 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import {
+  toFrameEnginePath,
+  useAnnotationEngine,
+  useAnnotationEventHandler,
+} from "@fiftyone/annotation";
+import {
+  type Scene2D,
+  UNDEFINED_LIGHTER_SCENE_ID,
+  useLighterEventHandler,
+} from "@fiftyone/lighter";
+import { LabelType } from "@fiftyone/utilities";
+import { useCallback } from "react";
+import { useAnnotationContext } from "../../../core/src/components/Modal/Sidebar/Annotate/Edit/useAnnotationContext";
+import { useDetectionMode } from "../../../core/src/components/Modal/Sidebar/Annotate/Edit/useDetectionMode";
+import useExit from "../../../core/src/components/Modal/Sidebar/Annotate/Edit/useExit";
+import { useVideoSurfaceActions } from "../hooks/useVideoSurfaceActions";
+import { useFrameLabelsStream } from "../streams/frameLabelsStream";
+import { autoExtendTargetFrames } from "../tracks/autoExtend";
+import { useCurrentEditingOverlay } from "../state/accessors";
+import { takeEstablishKey } from "./establishKeyRelay";
+
+/** Registers a handler for a Lighter event on the bridged scene's channel. */
+type RegisterLighterHandler = ReturnType<typeof useLighterEventHandler>;
+
+/** Schema-driven TD check: a field whose label type is a temporal detection. */
+const isTemporalDetectionType = (type: LabelType): boolean =>
+  type === LabelType.TemporalDetection || type === LabelType.TemporalDetections;
+
+/**
+ * Draw: a Lighter overlay create while detection mode is active opens a new
+ * detection draft on the engine frame path.
+ */
+const useRegisterDrawHandler = ({
+  registerHandler,
+}: {
+  registerHandler: RegisterLighterHandler;
+}): void => {
+  const detectionMode = useDetectionMode();
+  const stream = useFrameLabelsStream();
+
+  registerHandler(
+    "lighter:overlay-create",
+    useCallback(() => {
+      if (detectionMode.detectionModeActive) {
+        // Pin the destination to the frame engine path. The schema only exposes
+        // the sample-level detection field, so the default resolution would
+        // stamp that path on the overlay and route the write to the sample
+        // store; the seam maps the relative field to `frames.<field>`.
+        detectionMode.create(
+          stream ? toFrameEnginePath(stream.labelsField) : undefined
+        );
+      }
+    }, [detectionMode, stream])
+  );
+};
+
+/**
+ * Draw establish: the engine bridge commits + selects the draw synchronously, so
+ * a microtask later the engine owns the label and the interaction anchor IS the
+ * new track's ref. Two things happen here, both keyed off that anchor:
+ *
+ *  1. Hand the form off from the surface-owned draft to the engine anchor. The
+ *     draft pins the ENGINE path (`frames.<field>`) so the write routes to the
+ *     FrameStore and carries no engine ref, so the form shows the raw path and
+ *     neither playhead-follow nor live re-sync engage. Dropping the draft
+ *     (`clear`) lets `useFormAnchor` adopt the anchor — schema field + ref — so
+ *     the form reads `<field>` and tracks the playhead, as a deselect→reselect
+ *     does manually.
+ *  2. Auto-extend a freshly-drawn box forward as a short track. `establish` fires
+ *     only for a new draw (a new track), so this is new-tracks-only by
+ *     construction; copy its box onto the next frames as non-keyframe filler
+ *     (`extendTrack` semantics), matching a manual drag-to-extend. Leaves a
+ *     single keyframe, so a later propagate/auto-lerp fills these in place.
+ */
+const useRegisterDrawEstablishHandler = ({
+  registerHandler,
+}: {
+  registerHandler: RegisterLighterHandler;
+}): void => {
+  const { clear } = useAnnotationContext();
+  const stream = useFrameLabelsStream();
+  const engine = useAnnotationEngine();
+  const surfaceActions = useVideoSurfaceActions();
+
+  registerHandler(
+    "lighter:overlay-establish",
+    useCallback(
+      (payload) => {
+        if (!stream) {
+          return;
+        }
+
+        queueMicrotask(() => {
+          // The bridge stashed this draw's gesture key by overlay id during its
+          // synchronous establish commit; take it (consume-once) so the
+          // auto-extend folds into the draw's undo unit. Microtask order
+          // guarantees the stash ran first, and it's keyed by identity.
+          const drawUndoKey = takeEstablishKey(payload.overlayId);
+          const anchor = engine.interaction.getAnchor();
+
+          if (!anchor || anchor.frame == null) {
+            return;
+          }
+
+          const source = engine.getLabel(anchor);
+
+          if (!source) {
+            return;
+          }
+
+          clear();
+
+          // boxes only — a fresh draw of another label kind isn't a track
+          if (!Array.isArray(source.bounding_box)) {
+            return;
+          }
+
+          const targetFrames = autoExtendTargetFrames(
+            anchor.frame,
+            stream.totalFrames
+          );
+
+          if (targetFrames.length === 0) {
+            return;
+          }
+
+          // fold the filler into the draw's undo unit (key taken above)
+          surfaceActions.extendTrack(
+            anchor.instanceId,
+            anchor.frame,
+            targetFrames,
+            drawUndoKey
+          );
+        });
+      },
+      [clear, engine, surfaceActions, stream]
+    )
+  );
+};
+
+/**
+ * Editor teardown: a TemporalDetection deleted from the timeline context menu
+ * removes its overlay directly; if it was open in the editor, tear the
+ * now-dangling edit panel down.
+ */
+const useRegisterEditorTeardownHandler = ({
+  registerHandler,
+}: {
+  registerHandler: RegisterLighterHandler;
+}): void => {
+  const exit = useExit();
+  const engine = useAnnotationEngine();
+  const editingOverlay = useCurrentEditingOverlay();
+
+  registerHandler(
+    "lighter:overlay-removed",
+    useCallback(
+      (payload) => {
+        // Identify the TD by the editing overlay's FIELD TYPE (the schema)
+        // rather than an id shape: a fresh-draw detection swap (which also
+        // removes an overlay mid-edit then re-selects its replacement) is a
+        // Detection field, so it's left untouched.
+        if (
+          editingOverlay &&
+          editingOverlay.id === payload.id &&
+          isTemporalDetectionType(engine.getLabelType(editingOverlay.field))
+        ) {
+          // `overlay-removed` fires synchronously inside the engine's delete
+          // dispatch; `exit()` writes `engine.interaction.setActive([])`, so
+          // defer it outside the dispatch — a subscriber must never write back
+          // to the engine.
+          queueMicrotask(() => exit());
+        }
+      },
+      [engine, exit, editingOverlay]
+    )
+  );
+};
+
+/**
+ * Mode quit: right-click (`lighter:detection-mode-quit`) and Esc
+ * (`lighter:active-mode-quit-requested`) both deactivate detection mode.
+ */
+const useRegisterModeQuitHandlers = ({
+  registerHandler,
+}: {
+  registerHandler: RegisterLighterHandler;
+}): void => {
+  const detectionMode = useDetectionMode();
+
+  registerHandler(
+    "lighter:detection-mode-quit",
+    useCallback(() => {
+      detectionMode.deactivateDetectionMode();
+    }, [detectionMode])
+  );
+
+  registerHandler(
+    "lighter:active-mode-quit-requested",
+    useCallback(() => {
+      if (detectionMode.detectionModeActive) {
+        detectionMode.deactivateDetectionMode();
+      }
+    }, [detectionMode])
+  );
+};
+
+/**
+ * Track deleted: deleting a track leaves no useful edit/draw state to keep open,
+ * so tear detection mode down.
+ */
+const useRegisterTrackDeletedHandler = (): void => {
+  const detectionMode = useDetectionMode();
+
+  useAnnotationEventHandler(
+    "annotation:trackDeleted",
+    useCallback(() => {
+      detectionMode.deactivateDetectionMode();
+    }, [detectionMode])
+  );
+};
+
+/**
+ * Bridges Lighter overlay events into the annotation systems for the video
+ * surface. Binds the scene's event channel and delegates each concern to a
+ * tightly-scoped handler hook.
+ *
+ * Event-handler-only: state changes flow through the public `useDetectionMode`
+ * interface rather than direct atom access, so this stays decoupled from that
+ * module's internals. Sidebar membership is engine-derived (`useEntries` reads
+ * engine presence), so nothing here pushes or prunes sidebar rows.
+ *
+ * Canvas selection (`lighter:overlay-select` / `deselect`) is owned by the
+ * engine's Lighter `frame-locked` bridge (`SurfaceController.selectHandle`),
+ * which maps an overlay handle to its `LabelRef` and drives `engine.interaction`
+ * — so there is deliberately no select/deselect handler here.
+ *
+ * @param scene - The scene to bridge, or `null` while it's still being set up.
+ *   When `null`, handlers attach to an inert sentinel channel and re-bind once
+ *   the real scene becomes available.
+ */
+export const useSyncLighterAnnotation = (scene: Scene2D | null): void => {
+  const registerHandler = useLighterEventHandler(
+    scene?.getEventChannel() ?? UNDEFINED_LIGHTER_SCENE_ID
+  );
+
+  useRegisterDrawHandler({ registerHandler });
+  useRegisterDrawEstablishHandler({ registerHandler });
+  useRegisterEditorTeardownHandler({ registerHandler });
+  useRegisterModeQuitHandlers({ registerHandler });
+  useRegisterTrackDeletedHandler();
+};

--- a/app/packages/video-annotation/src/sync/useSyncMediaTransform.ts
+++ b/app/packages/video-annotation/src/sync/useSyncMediaTransform.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import {
+  type Scene2D,
+  UNDEFINED_LIGHTER_SCENE_ID,
+  useLighterEventHandler,
+} from "@fiftyone/lighter";
+import type { RefObject } from "react";
+import { useCallback } from "react";
+
+/**
+ * Locks the canonical-media element (the `<video>` / frame `<canvas>` layered
+ * behind the Lighter canvas) to the scene's zoom/pan, so scroll-zoom scales
+ * the picture together with the overlays instead of just the boxes.
+ *
+ * Lighter draws overlays through the pixi-viewport transform; the external
+ * media element is a plain DOM node that never receives it. The viewport maps
+ * a world point `w` to screen as `pan + scale·w`, and at rest (scale 1, pan 0)
+ * the media element's local coordinates already equal world coordinates — both
+ * are container CSS pixels, and `object-fit: contain` letterboxes into the same
+ * rect the coordinate system uses. So mirroring the viewport onto the element
+ * is exactly `translate(panX, panY) scale(scale)` about a top-left origin (set
+ * in CSS). Applied imperatively rather than via state so a wheel/drag stream
+ * doesn't rerender the tile per frame.
+ */
+export const useSyncMediaTransform = <T extends HTMLElement>(
+  scene: Scene2D | null,
+  mediaRef: RefObject<T | null>
+): void => {
+  const useEventHandler = useLighterEventHandler(
+    scene?.getEventChannel() ?? UNDEFINED_LIGHTER_SCENE_ID
+  );
+
+  const apply = useCallback(
+    (panX: number, panY: number, scale: number) => {
+      const el = mediaRef.current;
+      if (!el) {
+        return;
+      }
+
+      el.style.transform = `translate(${panX}px, ${panY}px) scale(${scale})`;
+    },
+    [mediaRef]
+  );
+
+  useEventHandler(
+    "lighter:viewport-moved",
+    useCallback((p) => apply(p.x, p.y, p.scale), [apply])
+  );
+
+  // Seed the resting transform once the renderer is ready — the pixi
+  // viewport is initialized by then, so reading its state is safe (reading
+  // it on mere `scene` presence races viewport init and throws). The
+  // post-`fitToContent` framing then arrives as a `viewport-moved`. Fires
+  // per scene, so remounts re-seed.
+  useEventHandler(
+    "lighter:renderer-ready",
+    useCallback(() => {
+      if (!scene) {
+        return;
+      }
+
+      const { panX, panY, scale } = scene.getViewportState();
+      apply(panX, panY, scale);
+    }, [scene, apply])
+  );
+};

--- a/app/packages/video-annotation/src/sync/useTemporalOverlaySync.test.ts
+++ b/app/packages/video-annotation/src/sync/useTemporalOverlaySync.test.ts
@@ -1,0 +1,406 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import type {
+  TemporalLabel,
+  TemporalOptions,
+  TemporalOverlay,
+} from "@fiftyone/lighter";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { syncTemporalOverlays } from "./useTemporalOverlaySync";
+
+/**
+ * Lightweight stand-in for TemporalOverlay. We only need to verify
+ * that `label` is re-assigned on update + record construction args,
+ * so this skips the real Lighter machinery entirely.
+ */
+class FakeOverlay {
+  label: TemporalLabel;
+  constructor(public opts: TemporalOptions) {
+    this.label = opts.label;
+  }
+}
+
+const makeScene = () => {
+  const added: FakeOverlay[] = [];
+  const removed: string[] = [];
+  const byId = new Map<string, FakeOverlay>();
+  return {
+    added,
+    removed,
+    byId,
+    // Signature matches SceneLike (TemporalOverlay); the fakes flowing
+    // through are FakeOverlays, cast back to read their construction opts.
+    addOverlay: vi.fn((o: TemporalOverlay) => {
+      const fake = o as unknown as FakeOverlay;
+      added.push(fake);
+      byId.set(fake.opts.id, fake);
+    }),
+    removeOverlay: vi.fn((id: string) => {
+      removed.push(id);
+      byId.delete(id);
+    }),
+    getOverlay: vi.fn((id: string) => byId.get(id)),
+  };
+};
+
+const td = (
+  id: string,
+  support: [number, number],
+  extra: Record<string, unknown> = {}
+) => ({
+  _cls: "TemporalDetection",
+  _id: id,
+  label: "x",
+  support,
+  ...extra,
+});
+
+const field = (...detections: ReturnType<typeof td>[]) => ({
+  _cls: "TemporalDetections",
+  detections,
+});
+
+const createFake = (opts: TemporalOptions): FakeOverlay =>
+  new FakeOverlay(opts);
+
+const ALL_ACTIVE = new Set(["events", "highlights"]);
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("syncTemporalOverlays", () => {
+  describe("add / update / remove", () => {
+    it("adds an overlay for each TD on the active sample", () => {
+      const scene = makeScene();
+      const overlays = new Map();
+
+      syncTemporalOverlays({
+        scene,
+        sample: { events: field(td("a", [1, 10]), td("b", [20, 30])) },
+        activePaths: ALL_ACTIVE,
+        overlays,
+        create: createFake as never,
+      });
+
+      expect(scene.added).toHaveLength(2);
+      expect(overlays.size).toBe(2);
+      expect(overlays.get("a")).toBeDefined();
+      expect(overlays.get("b")).toBeDefined();
+    });
+
+    it("adopts an overlay already present on the scene under the same id (avoids double-add collision)", () => {
+      const scene = makeScene();
+      const overlays = new Map();
+
+      // Pre-seed the scene with an overlay at our expected id — as if
+      // useCreateAnnotationLabel created it first.
+      const pre = new FakeOverlay({
+        id: "a",
+        field: "events",
+        label: {
+          _cls: "TemporalDetection",
+          _id: "a",
+          support: [1, 10],
+          label: "running",
+        } as TemporalLabel,
+      });
+      scene.byId.set("a", pre);
+
+      syncTemporalOverlays({
+        scene,
+        sample: { events: field(td("a", [1, 10], { label: "running" })) },
+        activePaths: ALL_ACTIVE,
+        overlays,
+        create: createFake as never,
+      });
+
+      // No new overlay added — adopted the pre-existing one.
+      expect(scene.addOverlay).not.toHaveBeenCalled();
+      // But we tracked it locally and refreshed its label.
+      expect(overlays.get("a")).toBe(pre);
+    });
+
+    it("does not re-add an overlay that already exists", () => {
+      const scene = makeScene();
+      const overlays = new Map();
+
+      const sample = { events: field(td("a", [1, 10])) };
+
+      syncTemporalOverlays({
+        scene,
+        sample,
+        activePaths: ALL_ACTIVE,
+        overlays,
+        create: createFake as never,
+      });
+      scene.addOverlay.mockClear();
+
+      syncTemporalOverlays({
+        scene,
+        sample,
+        activePaths: ALL_ACTIVE,
+        overlays,
+        create: createFake as never,
+      });
+
+      expect(scene.addOverlay).not.toHaveBeenCalled();
+    });
+
+    it("refreshes an adopted overlay's label from the authoritative source", () => {
+      const scene = makeScene();
+      const overlays = new Map();
+
+      syncTemporalOverlays({
+        scene,
+        sample: { events: field(td("a", [1, 10])) },
+        activePaths: ALL_ACTIVE,
+        overlays,
+        create: createFake as never,
+      });
+      const overlay = overlays.get("a") as FakeOverlay;
+
+      // The engine is authoritative: a subsequent sync carrying an edited
+      // support / label refreshes the same overlay in place.
+      syncTemporalOverlays({
+        scene,
+        sample: { events: field(td("a", [5, 25], { label: "renamed" })) },
+        activePaths: ALL_ACTIVE,
+        overlays,
+        create: createFake as never,
+      });
+
+      expect(overlays.get("a")).toBe(overlay);
+      expect(overlay.label.support).toEqual([5, 25]);
+      expect(overlay.label.label).toBe("renamed");
+    });
+
+    it("removes overlays whose TDs are no longer on the sample", () => {
+      const scene = makeScene();
+      const overlays = new Map();
+
+      syncTemporalOverlays({
+        scene,
+        sample: { events: field(td("a", [1, 10]), td("b", [20, 30])) },
+        activePaths: ALL_ACTIVE,
+        overlays,
+        create: createFake as never,
+      });
+      scene.removeOverlay.mockClear();
+
+      syncTemporalOverlays({
+        scene,
+        sample: { events: field(td("a", [1, 10])) },
+        activePaths: ALL_ACTIVE,
+        overlays,
+        create: createFake as never,
+      });
+
+      expect(scene.removeOverlay).toHaveBeenCalledWith("b");
+      expect(overlays.has("b")).toBe(false);
+      expect(overlays.has("a")).toBe(true);
+    });
+
+    it("removes every overlay when the sample becomes null", () => {
+      const scene = makeScene();
+      const overlays = new Map();
+
+      syncTemporalOverlays({
+        scene,
+        sample: { events: field(td("a", [1, 10]), td("b", [20, 30])) },
+        activePaths: ALL_ACTIVE,
+        overlays,
+        create: createFake as never,
+      });
+      scene.removeOverlay.mockClear();
+
+      syncTemporalOverlays({
+        scene,
+        sample: null,
+        activePaths: ALL_ACTIVE,
+        overlays,
+        create: createFake as never,
+      });
+
+      expect(scene.removeOverlay).toHaveBeenCalledTimes(2);
+      expect(overlays.size).toBe(0);
+    });
+  });
+
+  describe("active field filter", () => {
+    it("skips overlays for TD fields not in activePaths", () => {
+      const scene = makeScene();
+      const overlays = new Map();
+
+      syncTemporalOverlays({
+        scene,
+        sample: {
+          events: field(td("a", [1, 10])),
+          highlights: field(td("b", [20, 30])),
+        },
+        activePaths: new Set(["events"]),
+        overlays,
+        create: createFake as never,
+      });
+
+      expect(overlays.has("a")).toBe(true);
+      expect(overlays.has("b")).toBe(false);
+    });
+
+    it("removes existing overlays whose field becomes inactive", () => {
+      const scene = makeScene();
+      const overlays = new Map();
+
+      syncTemporalOverlays({
+        scene,
+        sample: { events: field(td("a", [1, 10])) },
+        activePaths: new Set(["events"]),
+        overlays,
+        create: createFake as never,
+      });
+      scene.removeOverlay.mockClear();
+
+      syncTemporalOverlays({
+        scene,
+        sample: { events: field(td("a", [1, 10])) },
+        activePaths: new Set(),
+        overlays,
+        create: createFake as never,
+      });
+
+      expect(scene.removeOverlay).toHaveBeenCalledWith("a");
+      expect(overlays.has("a")).toBe(false);
+    });
+  });
+
+  describe("filtering invalid entries", () => {
+    it("skips TDs missing both _id and id", () => {
+      const scene = makeScene();
+      const overlays = new Map();
+
+      const td = {
+        _cls: "TemporalDetection",
+        label: "x",
+        support: [1, 10] as [number, number],
+      };
+
+      syncTemporalOverlays({
+        scene,
+        sample: {
+          events: { _cls: "TemporalDetections", detections: [td] },
+        },
+        activePaths: ALL_ACTIVE,
+        overlays,
+        create: createFake as never,
+      });
+
+      expect(overlays.size).toBe(0);
+    });
+
+    it("skips TDs with malformed support", () => {
+      const scene = makeScene();
+      const overlays = new Map();
+
+      syncTemporalOverlays({
+        scene,
+        sample: {
+          events: {
+            _cls: "TemporalDetections",
+            detections: [
+              { _cls: "TemporalDetection", _id: "a" }, // no support
+              {
+                _cls: "TemporalDetection",
+                _id: "b",
+                support: [NaN, 10],
+              },
+              {
+                _cls: "TemporalDetection",
+                _id: "c",
+                support: [20, 10], // inverted
+              },
+              {
+                _cls: "TemporalDetection",
+                _id: "d",
+                support: [1] as unknown as [number, number], // wrong length
+              },
+            ],
+          },
+        },
+        activePaths: ALL_ACTIVE,
+        overlays,
+        create: createFake as never,
+      });
+
+      expect(overlays.size).toBe(0);
+    });
+
+    it("ignores fields whose `_cls` isn't TemporalDetections", () => {
+      const scene = makeScene();
+      const overlays = new Map();
+
+      syncTemporalOverlays({
+        scene,
+        sample: {
+          detections: { _cls: "Detections", detections: [] },
+          metadata: { frame_rate: 30 },
+          some_string: "hi",
+        },
+        activePaths: new Set(["detections", "metadata", "some_string"]),
+        overlays,
+        create: createFake as never,
+      });
+
+      expect(overlays.size).toBe(0);
+    });
+  });
+
+  describe("multiple fields", () => {
+    it("creates overlays across multiple active TD fields", () => {
+      const scene = makeScene();
+      const overlays = new Map();
+
+      syncTemporalOverlays({
+        scene,
+        sample: {
+          events: field(td("a", [1, 10])),
+          highlights: field(td("b", [20, 30])),
+        },
+        activePaths: ALL_ACTIVE,
+        overlays,
+        create: createFake as never,
+      });
+
+      expect(overlays.has("a")).toBe(true);
+      expect(overlays.has("b")).toBe(true);
+    });
+
+    it("keys overlays by the TD `_id` (the engine instanceId, globally unique)", () => {
+      const scene = makeScene();
+      const overlays = new Map();
+
+      // TD `_id`s are globally unique across fields, so the overlay id is the
+      // bare `_id` (== the engine instanceId the bridge addresses); two TDs in
+      // different fields have distinct ids and distinct overlays.
+      syncTemporalOverlays({
+        scene,
+        sample: {
+          events: field(td("a", [1, 10])),
+          highlights: field(td("b", [20, 30])),
+        },
+        activePaths: ALL_ACTIVE,
+        overlays,
+        create: createFake as never,
+      });
+
+      expect(overlays.size).toBe(2);
+      expect(overlays.has("a")).toBe(true);
+      expect(overlays.has("b")).toBe(true);
+    });
+  });
+});

--- a/app/packages/video-annotation/src/sync/useTemporalOverlaySync.ts
+++ b/app/packages/video-annotation/src/sync/useTemporalOverlaySync.ts
@@ -1,0 +1,322 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import {
+  useActiveSampleId,
+  useAnnotationEngine,
+  useEngineSelector,
+} from "@fiftyone/annotation";
+import {
+  overlayFactory,
+  TemporalOverlay,
+  type TemporalLabel,
+  type TemporalOptions,
+  useLighterSetupWithPixi,
+} from "@fiftyone/lighter";
+import { useModalSample } from "@fiftyone/state";
+import { isTemporalDetectionsField } from "@fiftyone/utilities";
+import { type MutableRefObject, useEffect, useRef } from "react";
+import { frameAt, usePlayhead } from "@fiftyone/playback";
+import {
+  useActiveModalPaths,
+  useTemporalDetectionFieldPaths,
+} from "../state/accessors";
+import type { FrameLabelReader } from "../tracks/frameTracks";
+import { getModalSampleFrameRate } from "../utils/modalSample";
+
+/**
+ * Minimal scene surface the diff needs — typed against the lighter
+ * scene's actual signatures but kept narrow so tests can mock with a
+ * plain object.
+ */
+interface SceneLike {
+  addOverlay(overlay: TemporalOverlay): void;
+  removeOverlay(id: string): void;
+  /** Used to adopt an overlay another code path created at the same id. */
+  getOverlay(id: string): unknown;
+}
+
+export interface SyncTemporalOverlaysInput {
+  scene: SceneLike;
+  /**
+   * TD set shaped like a sample dict (`{ [field]: { _cls:
+   * "TemporalDetections", detections } }`). Built from the engine (the
+   * authoritative TD source) so it carries local creates / edits; the diff
+   * adds, refreshes, and evicts overlays to match it.
+   */
+  sample: Record<string, unknown> | null | undefined;
+  activePaths: ReadonlySet<string>;
+  /** Map<overlayId, overlay> — mutated in place to track surviving overlays. */
+  overlays: Map<string, TemporalOverlay>;
+  /** Factory hook so tests can inject a fake. */
+  create?: (opts: TemporalOptions) => TemporalOverlay;
+}
+
+/**
+ * Diff the sample's `TemporalDetections` fields against an existing
+ * overlay map. Adds new TDs, updates changed ones in place (preserving
+ * Lighter selection state), removes TDs no longer present.
+ *
+ * Pure-ish: mutates `overlays` and calls `scene.addOverlay` /
+ * `removeOverlay`. Returns nothing.
+ */
+export function syncTemporalOverlays({
+  scene,
+  sample,
+  activePaths,
+  overlays,
+  create = (opts) =>
+    overlayFactory.create<TemporalOptions, TemporalOverlay>("temporal", opts),
+}: SyncTemporalOverlaysInput): void {
+  if (!sample) {
+    for (const id of Array.from(overlays.keys())) {
+      scene.removeOverlay(id);
+      overlays.delete(id);
+    }
+
+    return;
+  }
+
+  const next = new Set<string>();
+
+  for (const [fieldPath, value] of Object.entries(sample)) {
+    if (!isTemporalDetectionsField(value)) {
+      continue;
+    }
+
+    if (!activePaths.has(fieldPath)) {
+      continue;
+    }
+
+    const detections = value.detections ?? [];
+    for (const td of detections) {
+      const detId = td._id ?? td.id;
+      if (!detId) {
+        continue;
+      }
+
+      const support = td.support;
+      if (
+        !Array.isArray(support) ||
+        support.length !== 2 ||
+        !Number.isFinite(support[0]) ||
+        !Number.isFinite(support[1]) ||
+        support[1] < support[0]
+      ) {
+        continue;
+      }
+
+      // The overlay id IS the TD's `_id` (the engine `instanceId`), so the
+      // engine Lighter bridge builds the canonical sample-level ref for its
+      // select / hover events. (The field is frame-less; frameOf omits it.)
+      const id = String(detId);
+      next.add(id);
+      const label = td as unknown as TemporalLabel;
+
+      // Adopt an existing overlay at the same id so concurrent paths don't
+      // double-add.
+      const adopted =
+        overlays.get(id) ??
+        (scene.getOverlay(id) as TemporalOverlay | undefined);
+
+      if (adopted) {
+        // Refresh the overlay's label from the engine so an engine-side support
+        // / label edit shows on the canvas chip without an autosave round-trip.
+        adopted.label = label;
+        overlays.set(id, adopted);
+      } else {
+        const created = create({ id, field: fieldPath, label });
+        scene.addOverlay(created);
+        overlays.set(id, created);
+      }
+    }
+  }
+
+  for (const id of Array.from(overlays.keys())) {
+    if (!next.has(id)) {
+      scene.removeOverlay(id);
+      overlays.delete(id);
+    }
+  }
+}
+
+/**
+ * Build the engine's sample-level temporal detections, shaped like a sample
+ * dict so {@link syncTemporalOverlays} can consume them. Reads the engine — the
+ * authoritative TD source — so local creates / edits are reflected immediately.
+ */
+const buildEngineTemporalSample = (
+  engine: FrameLabelReader,
+  sample: string,
+  tdPaths: readonly string[]
+): Record<string, unknown> => {
+  const out: Record<string, unknown> = {};
+
+  for (const path of tdPaths) {
+    // TDs are sample-level; never the per-frame `frames.` fields.
+    if (path.startsWith("frames.")) {
+      continue;
+    }
+
+    const detections = engine.listLabels({ sample, path });
+    if (detections.length) {
+      out[path] = { _cls: "TemporalDetections", detections };
+    }
+  }
+
+  return out;
+};
+
+/** Deep equality so the sync effect only re-runs when the TDs actually change. */
+const sameTemporalSample = (
+  a: Record<string, unknown>,
+  b: Record<string, unknown>
+): boolean => JSON.stringify(a) === JSON.stringify(b);
+
+type Scene = ReturnType<typeof useLighterSetupWithPixi>["scene"];
+
+/** Engine-authoritative TD set as a sample dict, stable across unrelated bumps. */
+const useEngineTemporalSample = (): Record<string, unknown> => {
+  const engine = useAnnotationEngine();
+  const sampleId = useActiveSampleId();
+  const tdPaths = useTemporalDetectionFieldPaths();
+
+  return useEngineSelector(
+    engine,
+    (e) => (sampleId ? buildEngineTemporalSample(e, sampleId, tdPaths) : {}),
+    sameTemporalSample
+  );
+};
+
+/**
+ * Current playhead frame, held in a ref. fps comes from the sample metadata;
+ * the ref lets the diff effect seed overlays without re-running per tick.
+ */
+const useCurrentFrameRef = (): MutableRefObject<number | null> => {
+  const modalSample = useModalSample();
+  const playheadSec = usePlayhead();
+  const frameRate = getModalSampleFrameRate(modalSample);
+
+  const currentFrame =
+    frameRate && Number.isFinite(frameRate) && frameRate > 0
+      ? frameAt(playheadSec, frameRate)
+      : null;
+
+  const currentFrameRef = useRef(currentFrame);
+  currentFrameRef.current = currentFrame;
+
+  return currentFrameRef;
+};
+
+/**
+ * Run the diff whenever the engine's TD set, active paths, or scene readiness
+ * changes, then seed the time gate on freshly-added overlays so a TD in range
+ * at the initial frame renders on first load (the playhead-push effect only
+ * fires on *subsequent* changes).
+ */
+const useOverlayDiff = (
+  scene: Scene,
+  canonicalMediaReady: boolean,
+  temporalSample: Record<string, unknown>,
+  activePathsList: readonly string[],
+  overlaysRef: MutableRefObject<Map<string, TemporalOverlay>>,
+  currentFrameRef: MutableRefObject<number | null>
+): void => {
+  useEffect(() => {
+    if (!scene || !canonicalMediaReady) {
+      return;
+    }
+
+    const activePaths = new Set(activePathsList);
+    syncTemporalOverlays({
+      scene,
+      sample: temporalSample,
+      activePaths,
+      overlays: overlaysRef.current,
+    });
+
+    if (currentFrameRef.current !== null) {
+      for (const overlay of overlaysRef.current.values()) {
+        overlay.setCurrentFrame(currentFrameRef.current);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scene, temporalSample, canonicalMediaReady, activePathsList]);
+};
+
+/** Push the playhead frame into each tracked overlay on playhead changes. */
+const usePlayheadPush = (
+  currentFrame: number | null,
+  overlaysRef: MutableRefObject<Map<string, TemporalOverlay>>
+): void => {
+  useEffect(() => {
+    if (currentFrame === null) {
+      return;
+    }
+
+    for (const overlay of overlaysRef.current.values()) {
+      overlay.setCurrentFrame(currentFrame);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentFrame]);
+};
+
+/**
+ * Remove every tracked overlay on scene change / unmount. Owns the scene
+ * reference, not the overlays, because Lighter's `destroy()` runs through
+ * `removeOverlay`. Reads the live tracked set at teardown.
+ */
+const useOverlayCleanup = (
+  scene: Scene,
+  overlaysRef: MutableRefObject<Map<string, TemporalOverlay>>
+): void => {
+  useEffect(() => {
+    return () => {
+      if (!scene) {
+        return;
+      }
+
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      for (const id of overlaysRef.current.keys()) {
+        scene.removeOverlay(id);
+      }
+
+      overlaysRef.current.clear();
+    };
+  }, [scene]);
+};
+
+/**
+ * Keep the Lighter scene's `TemporalOverlay` set in sync with the engine's
+ * `TemporalDetections`, and push the playhead frame into each overlay so the
+ * time gate updates live.
+ *
+ * The TD set is sourced from the engine (authoritative), so creates / edits /
+ * deletes show on the canvas without an autosave round-trip. Pass `scene` +
+ * `canonicalMediaReady` from the host tile; the hook owns the diff lifecycle
+ * and cleans up every tracked overlay on scene change / unmount.
+ */
+export function useTemporalOverlaySync(
+  scene: Scene,
+  canonicalMediaReady: boolean
+): void {
+  const overlaysRef = useRef<Map<string, TemporalOverlay>>(new Map());
+
+  const temporalSample = useEngineTemporalSample();
+  const activePathsList = useActiveModalPaths();
+  const currentFrameRef = useCurrentFrameRef();
+
+  useOverlayDiff(
+    scene,
+    canonicalMediaReady,
+    temporalSample,
+    activePathsList,
+    overlaysRef,
+    currentFrameRef
+  );
+
+  usePlayheadPush(currentFrameRef.current, overlaysRef);
+
+  useOverlayCleanup(scene, overlaysRef);
+}

--- a/app/packages/video-annotation/src/tracks/autoExtend.test.ts
+++ b/app/packages/video-annotation/src/tracks/autoExtend.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { AUTO_EXTEND_FRAMES, autoExtendTargetFrames } from "./autoExtend";
+
+describe("autoExtendTargetFrames", () => {
+  it("fills the next AUTO_EXTEND_FRAMES frames after the draw", () => {
+    const frames = autoExtendTargetFrames(10, 1000);
+    expect(frames[0]).toBe(11);
+    expect(frames).toHaveLength(AUTO_EXTEND_FRAMES);
+    expect(frames[frames.length - 1]).toBe(10 + AUTO_EXTEND_FRAMES);
+  });
+
+  it("clamps to the inclusive clip length", () => {
+    // drawn at frame 95 of a 100-frame clip → only 96..100
+    expect(autoExtendTargetFrames(95, 100)).toEqual([96, 97, 98, 99, 100]);
+  });
+
+  it("is empty when drawn on the last frame", () => {
+    expect(autoExtendTargetFrames(100, 100)).toEqual([]);
+  });
+});

--- a/app/packages/video-annotation/src/tracks/autoExtend.ts
+++ b/app/packages/video-annotation/src/tracks/autoExtend.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+/**
+ * Frames a freshly-drawn box auto-extends forward as non-keyframe filler, so a
+ * single drawn box immediately becomes a short track (matching a manual
+ * drag-to-extend). Clamped at the clip end.
+ */
+export const AUTO_EXTEND_FRAMES = 30;
+
+/**
+ * The frames a fresh draw at `startFrame` should fill forward — `startFrame + 1`
+ * through `startFrame + AUTO_EXTEND_FRAMES`, clamped to the inclusive clip
+ * length `totalFrames`. Empty when the draw is already at (or past) the end.
+ * Pure so the clamp/range is unit-testable; the hook applies it via the engine.
+ */
+export const autoExtendTargetFrames = (
+  startFrame: number,
+  totalFrames: number
+): number[] => {
+  const end = Math.min(startFrame + AUTO_EXTEND_FRAMES, totalFrames);
+  const frames: number[] = [];
+
+  for (let frame = startFrame + 1; frame <= end; frame++) {
+    frames.push(frame);
+  }
+
+  return frames;
+};

--- a/app/packages/video-annotation/src/tracks/frameTracks.test.ts
+++ b/app/packages/video-annotation/src/tracks/frameTracks.test.ts
@@ -1,0 +1,123 @@
+import type { LabelData } from "@fiftyone/utilities";
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildPerInstanceTracks,
+  type FrameLabelReader,
+  type PerInstanceLabel,
+} from "./frameTracks";
+
+const FPS = 30;
+const SAMPLE = "sample-1";
+const PATH = "frames.detections";
+
+/**
+ * Minimal engine stub: `buildPerInstanceTracks` only calls
+ * `listLabels({ sample, path, frame })`. `frames` maps a 1-indexed frame
+ * number to the labels the engine projects for it.
+ */
+function makeEngine(frames: Record<number, LabelData[]>): FrameLabelReader {
+  return {
+    listLabels: ({ frame }) => (frame ? frames[frame] ?? [] : []),
+  };
+}
+
+function build(
+  totalFrames: number,
+  frames: Record<number, LabelData[]>,
+  resolveColor: (l: PerInstanceLabel) => string = () => "#fff"
+) {
+  return buildPerInstanceTracks({
+    engine: makeEngine(frames),
+    sample: SAMPLE,
+    path: PATH,
+    totalFrames,
+    fps: FPS,
+    resolveColor,
+  });
+}
+
+describe("buildPerInstanceTracks", () => {
+  it("resolves row color from the real detection index + instance, not the display ordinal", () => {
+    // An instance-keyed box whose persisted index (7) differs from the
+    // display ordinal it would be assigned. The color hash must use 7 +
+    // the instance so it matches the bbox overlay under color-by-instance.
+    const det: LabelData = {
+      _id: "doc-1",
+      _cls: "Detection",
+      label: "person",
+      index: 7,
+      instance: { _cls: "Instance", _id: "abc123" },
+      keyframe: false,
+    };
+
+    const resolveColor = vi.fn<(l: PerInstanceLabel) => string>(() => "#fff");
+    const tracks = build(2, { 1: [det], 2: [det] }, resolveColor);
+
+    expect(tracks).toHaveLength(1);
+    // Track id IS the engine instanceId (instance._id), no synthetic prefix.
+    expect(tracks[0].id).toBe("abc123");
+    expect(resolveColor).toHaveBeenCalledWith({
+      label: "person",
+      index: 7,
+      instance: { _cls: "Instance", _id: "abc123" },
+    });
+    // Display text still uses the persisted index as the ordinal.
+    expect(tracks[0].label).toBe("person 7");
+  });
+
+  it("addresses legacy instance-less detections by their doc _id", () => {
+    const det: LabelData = {
+      _id: "doc-3",
+      _cls: "Detection",
+      label: "vehicle",
+      index: 3,
+      keyframe: false,
+    };
+
+    const resolveColor = vi.fn<(l: PerInstanceLabel) => string>(() => "#fff");
+    const tracks = build(1, { 1: [det] }, resolveColor);
+
+    expect(tracks[0].id).toBe("doc-3");
+    expect(resolveColor).toHaveBeenCalledWith({
+      label: "vehicle",
+      index: 3,
+      instance: null,
+    });
+  });
+
+  it("assigns instance-only ordinals as the next free integer above the per-class max", () => {
+    const tracked: LabelData = {
+      _id: "doc-a",
+      _cls: "Detection",
+      label: "person",
+      index: 3,
+      instance: { _cls: "Instance", _id: "tracked" },
+    };
+    const drawn: LabelData = {
+      _id: "doc-b",
+      _cls: "Detection",
+      label: "person",
+      instance: { _cls: "Instance", _id: "fresh" },
+    };
+
+    const tracks = build(1, { 1: [tracked, drawn] });
+
+    // Sorted by ordinal: persisted 3, then the next free (4).
+    expect(tracks.map((t) => t.label)).toEqual(["person 3", "person 4"]);
+  });
+
+  it("emits one presence interval per contiguous run", () => {
+    const det: LabelData = {
+      _id: "doc-1",
+      _cls: "Detection",
+      label: "person",
+      index: 1,
+      instance: { _cls: "Instance", _id: "runner" },
+    };
+    // Present 1-2, absent 3, present 4-5.
+    const tracks = build(5, { 1: [det], 2: [det], 4: [det], 5: [det] });
+
+    const intervals = tracks[0].events.filter((e) => e.endSec !== undefined);
+    expect(intervals).toHaveLength(2);
+  });
+});

--- a/app/packages/video-annotation/src/tracks/frameTracks.ts
+++ b/app/packages/video-annotation/src/tracks/frameTracks.ts
@@ -1,0 +1,301 @@
+import type { AnnotationEngine } from "@fiftyone/annotation";
+import type { Track, TrackEvent } from "@fiftyone/playback";
+import type { LabelData } from "@fiftyone/utilities";
+
+/** The engine read surface this builder needs — one frame's labels at a time. */
+export type FrameLabelReader = Pick<AnnotationEngine, "listLabels">;
+
+interface InstanceState {
+  /** Class label observed for this instance (e.g. "person"). */
+  classLabel: string;
+  /**
+   * Persisted track index carried on the underlying detection, when
+   * present. Undefined for freshly-drawn instances that haven't been
+   * numbered.
+   */
+  persistedIndex?: number;
+  /**
+   * Display ordinal used for the row label text. Equals
+   * `persistedIndex` when set; otherwise assigned at build time as the
+   * next free integer above the per-class max so the demo UI always
+   * has a readable "person 3" / "person 4" label.
+   */
+  displayIndex: number;
+  /**
+   * The underlying detection's `Instance` reference, when present. Carried
+   * so the row color hashes on the same `instance._id` the overlay does
+   * under color-by-instance.
+   */
+  instance?: { _cls: "Instance"; _id?: string } | null;
+  /** Whether the instance was present in the most recent frame. */
+  inFrame: boolean;
+  /** Start time (sec) of the currently-open interval, if any. */
+  currentStart: number | null;
+  /** Closed presence intervals. */
+  intervals: Array<{ start: number; end: number }>;
+  /** Frame start times (sec) where this instance has `keyframe: true`. */
+  keyframeTimes: number[];
+}
+
+/**
+ * Minimal label-shape passed to {@link BuildPerInstanceTracksInput.resolveColor}.
+ * Mirrors the fields `getLabelColorFromContext` reads, so the color resolves
+ * the same way it would for the matching overlay.
+ *
+ * `index` and `instance` must be the *underlying detection's* values (not a
+ * synthetic display ordinal), because color-by-instance hashes on
+ * `${label}-${index}-${instance._id}` — passing the display ordinal or
+ * dropping the instance would desync the row color from the bbox overlay.
+ */
+export interface PerInstanceLabel {
+  label: string;
+  index?: number;
+  instance?: { _cls: "Instance"; _id?: string } | null;
+}
+
+export interface BuildPerInstanceTracksInput {
+  engine: FrameLabelReader;
+  /** Sample whose frame labels back the timeline. */
+  sample: string;
+  /** Frame-agnostic detection field path (e.g. `frames.detections`). */
+  path: string;
+  /** Total frames in the clip — the walk range `[1, totalFrames]`. */
+  totalFrames: number;
+  /** Frame rate, for the frame↔seconds mapping. */
+  fps: number;
+  resolveColor: (label: PerInstanceLabel) => string;
+}
+
+/** Track identity is `instance._id`; fall back to the doc `_id` (legacy). */
+const addressIdOf = (label: LabelData): string => {
+  const instance = label.instance as { _id?: string } | undefined;
+  return instance?._id ?? label._id;
+};
+
+const labelOf = (label: LabelData): string =>
+  (label.label as string | undefined) || "unknown";
+
+const indexOf = (label: LabelData): number | undefined =>
+  label.index as number | undefined;
+
+const instanceOf = (
+  label: LabelData
+): { _cls: "Instance"; _id?: string } | null =>
+  (label.instance as { _cls: "Instance"; _id?: string } | null) ?? null;
+
+/**
+ * Walk every frame in `[1, totalFrames]`, group the engine's per-frame labels
+ * by their engine `instanceId` (`instance._id`, or the doc `_id` for legacy
+ * instance-less detections), and emit one {@link Track} per tracked instance
+ * whose events are the contiguous presence intervals.
+ *
+ * The track id IS the engine `instanceId`, so the timeline links to engine
+ * interaction with no synthetic-id mapping. Legacy instance-less detections
+ * carry a distinct doc `_id` per frame and so fragment into single-frame rows
+ * until edited into a real instance.
+ *
+ * Row labels combine the class with a per-class display ordinal (e.g.
+ * "person 5"). For detections that already carry a persisted `index`, that
+ * number is used; otherwise the ordinal is the next free integer above the
+ * per-class max. Row color is resolved from the class so each row matches the
+ * colour of its bbox overlay.
+ *
+ * Requires the engine to project the whole clip; trigger a full warmup of the
+ * `/frames` seed first so every frame is loaded.
+ */
+export function buildPerInstanceTracks({
+  engine,
+  sample,
+  path,
+  totalFrames,
+  fps,
+  resolveColor,
+}: BuildPerInstanceTracksInput): Track[] {
+  if (totalFrames < 1 || !Number.isFinite(fps) || fps <= 0) {
+    return [];
+  }
+
+  const states = accumulatePresence(engine, sample, path, totalFrames, fps);
+  assignDisplayOrdinals(states);
+
+  const tracks: Track[] = [];
+  for (const [id, state] of states) {
+    if (state.intervals.length === 0) {
+      continue;
+    }
+
+    tracks.push(toTrack(id, state, resolveColor));
+  }
+
+  return sortByClassThenOrdinal(tracks, states);
+}
+
+/** Close a state's currently-open presence interval at `endSec`. */
+function closeInterval(state: InstanceState, endSec: number): void {
+  if (state.currentStart === null) {
+    return;
+  }
+
+  state.intervals.push({ start: state.currentStart, end: endSec });
+  state.currentStart = null;
+  state.inFrame = false;
+}
+
+function newInstanceState(label: LabelData): InstanceState {
+  return {
+    classLabel: labelOf(label),
+    persistedIndex: indexOf(label),
+    instance: instanceOf(label),
+    // Placeholder — overwritten by `assignDisplayOrdinals` once every
+    // state is known and per-class ordinals can be computed.
+    displayIndex: 0,
+    inFrame: false,
+    currentStart: null,
+    intervals: [],
+    keyframeTimes: [],
+  };
+}
+
+/**
+ * Walk every frame and group the engine's labels into per-instance presence
+ * intervals + keyframe times. Intervals still open at clip end are closed.
+ */
+function accumulatePresence(
+  engine: FrameLabelReader,
+  sample: string,
+  path: string,
+  totalFrames: number,
+  fps: number
+): Map<string, InstanceState> {
+  const states = new Map<string, InstanceState>();
+
+  for (let frame = 1; frame <= totalFrames; frame++) {
+    const frameStartSec = (frame - 1) / fps;
+    const present = new Set<string>();
+
+    for (const label of engine.listLabels({ sample, path, frame })) {
+      const id = addressIdOf(label);
+      present.add(id);
+
+      let state = states.get(id);
+      if (!state) {
+        state = newInstanceState(label);
+        states.set(id, state);
+      }
+
+      if (!state.inFrame) {
+        state.currentStart = frameStartSec;
+        state.inFrame = true;
+      }
+
+      if (label.keyframe) {
+        state.keyframeTimes.push(frameStartSec);
+      }
+    }
+
+    // Close any instance that was present last frame but not now.
+    for (const [id, state] of states) {
+      if (!present.has(id) && state.inFrame) {
+        closeInterval(state, frameStartSec);
+      }
+    }
+  }
+
+  const clipEndSec = totalFrames / fps;
+  for (const state of states.values()) {
+    closeInterval(state, clipEndSec);
+  }
+
+  return states;
+}
+
+/**
+ * Set each state's `displayIndex`. Persisted indexes are honored as-is so
+ * existing tracked data keeps its familiar numbers; instance-only boxes
+ * (typically freshly-drawn) get the next free integer above the per-class
+ * max. Mutates the states in place.
+ */
+function assignDisplayOrdinals(states: Map<string, InstanceState>): void {
+  const classCounters = new Map<string, number>();
+
+  for (const state of states.values()) {
+    if (state.persistedIndex === undefined) {
+      continue;
+    }
+
+    const cur = classCounters.get(state.classLabel) ?? 0;
+    if (state.persistedIndex > cur) {
+      classCounters.set(state.classLabel, state.persistedIndex);
+    }
+  }
+
+  for (const state of states.values()) {
+    if (state.persistedIndex !== undefined) {
+      state.displayIndex = state.persistedIndex;
+      continue;
+    }
+
+    const next = (classCounters.get(state.classLabel) ?? 0) + 1;
+    state.displayIndex = next;
+    classCounters.set(state.classLabel, next);
+  }
+}
+
+/** Build the timeline {@link Track} for one accumulated instance state. */
+function toTrack(
+  id: string,
+  state: InstanceState,
+  resolveColor: (label: PerInstanceLabel) => string
+): Track {
+  const events: TrackEvent[] = [
+    // `resizable: true` opts each presence bar into in-place edit — drag
+    // handles to extend/trim the track, drag the body to shift it. Inert
+    // without an `onEventEdit`, so non-object timelines are unaffected.
+    ...state.intervals.map(
+      ({ start, end }): TrackEvent & { resizable: true } => ({
+        startSec: start,
+        endSec: end,
+        label: "in frame",
+        resizable: true,
+      })
+    ),
+    // Point events render as diamond markers on top of the presence bar
+    // via `TimelineTrack`'s no-`endSec` branch.
+    ...state.keyframeTimes.map((startSec) => ({
+      startSec,
+      label: "Keyframe",
+    })),
+  ];
+
+  return {
+    id,
+    label: `${state.classLabel} ${state.displayIndex}`,
+    description: `Tracked "${state.classLabel}" (track ${state.displayIndex})`,
+    color: resolveColor({
+      label: state.classLabel,
+      index: state.persistedIndex,
+      instance: state.instance,
+    }),
+    events,
+  };
+}
+
+/**
+ * Order tracks by class then display ordinal — keeps instances of the same
+ * class adjacent and the row order reproducible across runs.
+ */
+function sortByClassThenOrdinal(
+  tracks: Track[],
+  states: Map<string, InstanceState>
+): Track[] {
+  return tracks.sort((a, b) => {
+    const sa = states.get(a.id)!;
+    const sb = states.get(b.id)!;
+
+    if (sa.classLabel !== sb.classLabel) {
+      return sa.classLabel.localeCompare(sb.classLabel);
+    }
+
+    return sa.displayIndex - sb.displayIndex;
+  });
+}

--- a/app/packages/video-annotation/src/tracks/syntheticTracks.ts
+++ b/app/packages/video-annotation/src/tracks/syntheticTracks.ts
@@ -1,0 +1,121 @@
+import type { Track, TrackEvent } from "@fiftyone/playback";
+import {
+  getPresenceIntervals,
+  type PresenceInterval,
+  type SyntheticActor,
+} from "../streams/SyntheticLabelStream";
+
+/**
+ * Minimal label-shape passed to {@link buildSyntheticTracks}' resolver.
+ * Mirrors the fields the overlay's color resolution reads, so a row's
+ * color matches its bboxes — including under `COLOR_BY.INSTANCE`, which
+ * hashes on `${label}-${instance._id}` when no numeric index is present
+ * (the case for synthetic actors).
+ */
+export interface SyntheticActorLabel {
+  label: string;
+  instance: { _cls: "Instance"; _id: string };
+}
+
+const MAX_HIGHLIGHTS = 3;
+
+function isInsideAny(t: number, intervals: PresenceInterval[]): boolean {
+  for (const { startSec, endSec } of intervals) {
+    if (t >= startSec && t <= endSec) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Times in [0, duration] at which the oscillator
+ *   f(t) = 0.5 + 0.5 * sin(2π * (t / periodSec + phase))
+ * hits its maximum (= 1). Each maximum corresponds to the actor being at
+ * the rightmost (or topmost) edge of its trajectory.
+ */
+function maximaTimes(
+  periodSec: number,
+  phase: number,
+  duration: number,
+  limit: number
+): number[] {
+  // sin is maximal when its argument is π/2 + 2πn → t/period + phase = 0.25 + n
+  const out: number[] = [];
+  // Start n at the first integer for which t >= 0.
+  const firstN = Math.ceil(phase - 0.25);
+  for (let n = firstN; out.length < limit; n++) {
+    const t = periodSec * (0.25 - phase + n);
+    if (t < 0) {
+      continue;
+    }
+
+    if (t > duration) {
+      break;
+    }
+
+    out.push(t);
+  }
+
+  return out;
+}
+
+/**
+ * Build per-actor timeline tracks from the synthetic stream's actor model.
+ *
+ * Each actor becomes one row: a full-duration interval (the actor is
+ * "in frame" the whole clip) plus a handful of point events marking
+ * deterministic moments along its trajectory (when the actor reaches
+ * the right edge of the frame).
+ *
+ * Colors are resolved through the caller-supplied function so the rows
+ * match whatever scheme the overlays use.
+ */
+export function buildSyntheticTracks(
+  actors: SyntheticActor[],
+  duration: number,
+  resolveColor: (label: SyntheticActorLabel) => string
+): Track[] {
+  if (!(duration > 0)) {
+    return [];
+  }
+
+  return actors.map((actor) => {
+    const intervals = getPresenceIntervals(actor, duration);
+
+    const presenceEvents: TrackEvent[] = intervals.map(
+      ({ startSec, endSec }) => ({
+        startSec,
+        endSec,
+        label: "in frame",
+      })
+    );
+
+    // Only highlight x-maxima that fall inside a presence interval — a
+    // "right edge" marker during a gap would be misleading.
+    const highlights: TrackEvent[] = maximaTimes(
+      actor.xPeriodSec,
+      actor.xPhase,
+      duration,
+      MAX_HIGHLIGHTS * 2
+    )
+      .filter((t) => isInsideAny(t, intervals))
+      .slice(0, MAX_HIGHLIGHTS)
+      .map((t) => ({
+        startSec: t,
+        label: `${actor.label} → right edge`,
+      }));
+
+    return {
+      id: actor.id,
+      label: actor.label,
+      description: `Synthetic actor "${actor.label}"`,
+      color: resolveColor({
+        label: actor.label,
+        instance: { _cls: "Instance", _id: actor.id },
+      }),
+      events: [...presenceEvents, ...highlights],
+    };
+  });
+}

--- a/app/packages/video-annotation/src/tracks/temporalDetectionTracks.test.ts
+++ b/app/packages/video-annotation/src/tracks/temporalDetectionTracks.test.ts
@@ -1,0 +1,314 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildTemporalDetectionTracks,
+  type RawTemporalDetectionsField,
+} from "./temporalDetectionTracks";
+
+const DEFAULT_FPS = 30;
+
+function makeTd(
+  id: string,
+  support: [number, number],
+  label = "running",
+  extras: Record<string, unknown> = {}
+) {
+  return {
+    _cls: "TemporalDetection" as const,
+    _id: id,
+    label,
+    support,
+    confidence: 0.9,
+    ...extras,
+  };
+}
+
+function makeField(
+  ...detections: ReturnType<typeof makeTd>[]
+): RawTemporalDetectionsField {
+  return { _cls: "TemporalDetections", detections };
+}
+
+const passthroughColor = (path: string) => `color-${path}`;
+
+describe("buildTemporalDetectionTracks", () => {
+  describe("happy path", () => {
+    it("emits one track per TD with an interval event spanning support", () => {
+      const tracks = buildTemporalDetectionTracks({
+        sample: {
+          events: makeField(makeTd("a", [1, 30], "running")),
+        },
+        fps: DEFAULT_FPS,
+        resolveColor: passthroughColor,
+      });
+
+      expect(tracks).toHaveLength(1);
+      const t = tracks[0];
+      expect(t.id).toBe("td-events-a");
+      expect(t.color).toBe("color-events");
+      expect(t.events).toHaveLength(1);
+
+      const ev = t.events[0];
+      expect(ev.startSec).toBeCloseTo(0); // (1-1)/30
+      expect(ev.endSec).toBeCloseTo(30 / 30); // 30/30 = 1s
+      expect(ev.label).toBe("running");
+    });
+
+    it("converts 1-indexed inclusive frame support to seconds correctly", () => {
+      // support = [16, 45] on a 30fps clip:
+      //   startSec = (16 - 1) / 30 = 0.5
+      //   endSec   = 45 / 30 = 1.5
+      const tracks = buildTemporalDetectionTracks({
+        sample: { events: makeField(makeTd("a", [16, 45])) },
+        fps: 30,
+        resolveColor: passthroughColor,
+      });
+      const ev = tracks[0].events[0];
+      expect(ev.startSec).toBeCloseTo(0.5);
+      expect(ev.endSec).toBeCloseTo(1.5);
+    });
+
+    it("marks emitted interval events as resizable for in-place edit", () => {
+      const tracks = buildTemporalDetectionTracks({
+        sample: { events: makeField(makeTd("a", [1, 10])) },
+        fps: DEFAULT_FPS,
+        resolveColor: passthroughColor,
+      });
+      const event = tracks[0].events[0] as { resizable?: boolean };
+      expect(event.resizable).toBe(true);
+    });
+
+    it("attaches a TemporalDetectionEventData payload to each event", () => {
+      const td = makeTd("abc", [10, 20], "walking");
+      const tracks = buildTemporalDetectionTracks({
+        sample: { events: makeField(td) },
+        fps: DEFAULT_FPS,
+        resolveColor: passthroughColor,
+      });
+      const data = tracks[0].events[0].data as {
+        fieldPath: string;
+        detectionId: string;
+        detectionIndex: number;
+        support: [number, number];
+        raw: typeof td;
+      };
+
+      expect(data.fieldPath).toBe("events");
+      expect(data.detectionId).toBe("abc");
+      expect(data.detectionIndex).toBe(0);
+      expect(data.support).toEqual([10, 20]);
+      expect(data.raw).toBe(td);
+    });
+
+    it("returns a row label combining the TD label and field path", () => {
+      const tracks = buildTemporalDetectionTracks({
+        sample: { events: makeField(makeTd("a", [1, 10], "running")) },
+        fps: DEFAULT_FPS,
+        resolveColor: passthroughColor,
+      });
+      expect(tracks[0].label).toBe("running (events)");
+    });
+
+    it("falls back to a truncated id label when the TD has no label string", () => {
+      const tracks = buildTemporalDetectionTracks({
+        sample: { events: makeField(makeTd("0123456789abcdef", [1, 10], "")) },
+        fps: DEFAULT_FPS,
+        resolveColor: passthroughColor,
+      });
+      expect(tracks[0].label).toBe("events 89abcdef");
+    });
+
+    it("falls back to `id` when `_id` is missing", () => {
+      const td = {
+        _cls: "TemporalDetection" as const,
+        id: "x1",
+        label: "j",
+        support: [1, 5] as [number, number],
+      };
+      const tracks = buildTemporalDetectionTracks({
+        sample: {
+          events: { _cls: "TemporalDetections" as const, detections: [td] },
+        },
+        fps: DEFAULT_FPS,
+        resolveColor: passthroughColor,
+      });
+      expect(tracks).toHaveLength(1);
+      expect(tracks[0].id).toBe("td-events-x1");
+    });
+  });
+
+  describe("color resolution", () => {
+    it("calls resolveColor with the field path and a label-like dict", () => {
+      const resolveColor = vi.fn(() => "#abc");
+      buildTemporalDetectionTracks({
+        sample: { events: makeField(makeTd("a", [1, 5], "running")) },
+        fps: DEFAULT_FPS,
+        resolveColor,
+      });
+
+      expect(resolveColor).toHaveBeenCalledTimes(1);
+      expect(resolveColor).toHaveBeenCalledWith("events", {
+        _cls: "TemporalDetection",
+        label: "running",
+        id: "a",
+      });
+    });
+  });
+
+  describe("multiple fields and detections", () => {
+    it("emits tracks for every TemporalDetections field on the sample", () => {
+      const tracks = buildTemporalDetectionTracks({
+        sample: {
+          events: makeField(makeTd("a", [1, 10])),
+          highlights: makeField(makeTd("b", [5, 15])),
+        },
+        fps: DEFAULT_FPS,
+        resolveColor: passthroughColor,
+      });
+      expect(tracks).toHaveLength(2);
+      const ids = tracks.map((t) => t.id);
+      expect(ids).toContain("td-events-a");
+      expect(ids).toContain("td-highlights-b");
+    });
+
+    it("orders TDs within a field by support start, with id as tie-break", () => {
+      const tracks = buildTemporalDetectionTracks({
+        sample: {
+          events: makeField(
+            makeTd("z", [10, 20]),
+            makeTd("a", [1, 5]),
+            makeTd("m", [10, 30])
+          ),
+        },
+        fps: DEFAULT_FPS,
+        resolveColor: passthroughColor,
+      });
+      expect(tracks.map((t) => t.id)).toEqual([
+        "td-events-a",
+        "td-events-m",
+        "td-events-z",
+      ]);
+    });
+  });
+
+  describe("filtering invalid entries", () => {
+    it("skips TDs with missing support", () => {
+      const td = { _cls: "TemporalDetection" as const, _id: "a", label: "x" };
+      const tracks = buildTemporalDetectionTracks({
+        sample: {
+          events: { _cls: "TemporalDetections" as const, detections: [td] },
+        },
+        fps: DEFAULT_FPS,
+        resolveColor: passthroughColor,
+      });
+      expect(tracks).toEqual([]);
+    });
+
+    it("skips TDs with malformed support (wrong length, NaN, inverted)", () => {
+      const tracks = buildTemporalDetectionTracks({
+        sample: {
+          events: makeField(
+            {
+              ...makeTd("a", [1, 5]),
+              support: [1] as unknown as [number, number],
+            },
+            { ...makeTd("b", [1, 5]), support: [NaN, 10] },
+            { ...makeTd("c", [1, 5]), support: [20, 10] }
+          ),
+        },
+        fps: DEFAULT_FPS,
+        resolveColor: passthroughColor,
+      });
+      expect(tracks).toEqual([]);
+    });
+
+    it("skips TDs missing both _id and id", () => {
+      const td = {
+        _cls: "TemporalDetection" as const,
+        label: "x",
+        support: [1, 5] as [number, number],
+      };
+      const tracks = buildTemporalDetectionTracks({
+        sample: {
+          events: { _cls: "TemporalDetections" as const, detections: [td] },
+        },
+        fps: DEFAULT_FPS,
+        resolveColor: passthroughColor,
+      });
+      expect(tracks).toEqual([]);
+    });
+
+    it("ignores fields that aren't TemporalDetections", () => {
+      const tracks = buildTemporalDetectionTracks({
+        sample: {
+          detections: { _cls: "Detections", detections: [] },
+          metadata: { frame_rate: 30 },
+          some_string: "hello",
+          some_array: [1, 2, 3],
+          some_null: null,
+        },
+        fps: DEFAULT_FPS,
+        resolveColor: passthroughColor,
+      });
+      expect(tracks).toEqual([]);
+    });
+
+    it("tolerates a TemporalDetections field with an empty detections list", () => {
+      const tracks = buildTemporalDetectionTracks({
+        sample: { events: makeField() },
+        fps: DEFAULT_FPS,
+        resolveColor: passthroughColor,
+      });
+      expect(tracks).toEqual([]);
+    });
+
+    it("tolerates a TemporalDetections field with missing detections array", () => {
+      const tracks = buildTemporalDetectionTracks({
+        sample: {
+          events: { _cls: "TemporalDetections" as const },
+        },
+        fps: DEFAULT_FPS,
+        resolveColor: passthroughColor,
+      });
+      // Not a valid TemporalDetections field per our type-guard (detections
+      // is required); should be ignored.
+      expect(tracks).toEqual([]);
+    });
+  });
+
+  describe("guards", () => {
+    it("returns [] for an empty sample", () => {
+      expect(
+        buildTemporalDetectionTracks({
+          sample: {},
+          fps: DEFAULT_FPS,
+          resolveColor: passthroughColor,
+        })
+      ).toEqual([]);
+    });
+
+    it("returns [] when fps is not finite or non-positive", () => {
+      const sample = { events: makeField(makeTd("a", [1, 5])) };
+      expect(
+        buildTemporalDetectionTracks({
+          sample,
+          fps: 0,
+          resolveColor: passthroughColor,
+        })
+      ).toEqual([]);
+      expect(
+        buildTemporalDetectionTracks({
+          sample,
+          fps: -10,
+          resolveColor: passthroughColor,
+        })
+      ).toEqual([]);
+      expect(
+        buildTemporalDetectionTracks({
+          sample,
+          fps: Number.NaN,
+          resolveColor: passthroughColor,
+        })
+      ).toEqual([]);
+    });
+  });
+});

--- a/app/packages/video-annotation/src/tracks/temporalDetectionTracks.ts
+++ b/app/packages/video-annotation/src/tracks/temporalDetectionTracks.ts
@@ -1,0 +1,197 @@
+import {
+  isTemporalDetectionsField,
+  isValidSupport,
+  type RawTemporalDetection,
+  type RawTemporalDetectionsField,
+} from "@fiftyone/utilities";
+import type { Track, TrackEvent } from "@fiftyone/playback";
+
+// Raw TD shapes + predicates live in `@fiftyone/utilities`; re-exported from
+// the package barrel.
+export type { RawTemporalDetection, RawTemporalDetectionsField };
+
+/**
+ * Minimal label shape passed to {@link BuildTemporalDetectionTracksInput.resolveColor}.
+ * Mirrors the fields `getLabelColorFromContext` reads.
+ */
+export interface TemporalDetectionLabelLike {
+  _cls: "TemporalDetection";
+  label: string;
+  /**
+   * The TD `_id`, exposed as `id` because that's the key FiftyOne's
+   * value-mode color resolution falls back to when there's no class label.
+   */
+  id?: string;
+}
+
+export interface BuildTemporalDetectionTracksInput {
+  /**
+   * Top-level sample dict from `ModalSample.sample`. The function walks
+   * the dict's top-level keys looking for `TemporalDetections` fields —
+   * nested locations (e.g. under `predictions.events`) are not searched.
+   */
+  sample: Record<string, unknown>;
+  /** Frame rate in frames per second. Used to convert support → seconds. */
+  fps: number;
+  /**
+   * Resolve the row color for a TD. Receives the field path (e.g.
+   * `"events"`) and a label-like dict so the result matches whatever the
+   * Lighter overlay would have produced for the same label.
+   */
+  resolveColor: (path: string, label: TemporalDetectionLabelLike) => string;
+}
+
+/**
+ * Payload attached to each emitted {@link TrackEvent.data}.
+ *
+ * Carries enough information that a downstream consumer (e.g. a drag-
+ * handle handler, a sidebar click router) can identify the TD without
+ * re-walking the sample dict.
+ */
+export interface TemporalDetectionEventData {
+  /** Field path on the sample (e.g. `"events"`). */
+  fieldPath: string;
+  /** The TD's `_id` (or `id` fallback). */
+  detectionId: string;
+  /** Index of this TD inside its parent `detections` array. */
+  detectionIndex: number;
+  /** 1-indexed inclusive frame support `[first, last]`. */
+  support: [number, number];
+  /** Snapshot of the raw TD for inspectors / drag-source readback. */
+  raw: RawTemporalDetection;
+}
+
+/**
+ * The sample-level engine ref `{ path, instanceId }` for a timeline track that
+ * represents a TemporalDetection, or `null` for an object track. Reads the
+ * track's structured event payload (set by {@link buildTemporalDetectionTracks})
+ * — never the row-id shape, so the TD vs object-track distinction stays driven
+ * by the data, not a string prefix. Frame-less: a TD is sample-level.
+ */
+export const temporalDetectionRefOf = (
+  track: Track
+): { path: string; instanceId: string } | null => {
+  const data = track.events[0]?.data as TemporalDetectionEventData | undefined;
+
+  if (!data || typeof data.detectionId !== "string") {
+    return null;
+  }
+
+  return { path: data.fieldPath, instanceId: data.detectionId };
+};
+
+/**
+ * Walk the top-level sample dict, find every `TemporalDetections` field,
+ * and emit one {@link Track} per `TemporalDetection` whose single event
+ * is an interval spanning `support`.
+ *
+ * Rows are returned grouped by field path, then ordered within each
+ * group by `support[0]` (earlier first), with `_id` as a stable
+ * tie-breaker. This makes the timeline read top-to-bottom roughly in
+ * the order events occur.
+ *
+ * TDs missing a valid `support` (not a 2-tuple, NaN, or `last < first`)
+ * are skipped. TDs with no `_id`/`id` are also skipped — we'd have no
+ * stable handle for selection, edits, or persistence.
+ *
+ * Returns `[]` when the sample is empty, fps is invalid, or no TD
+ * fields are present.
+ */
+export function buildTemporalDetectionTracks({
+  sample,
+  fps,
+  resolveColor,
+}: BuildTemporalDetectionTracksInput): Track[] {
+  if (!sample || !Number.isFinite(fps) || fps <= 0) {
+    return [];
+  }
+
+  const tracks: Track[] = [];
+
+  for (const [fieldPath, value] of Object.entries(sample)) {
+    if (!isTemporalDetectionsField(value)) {
+      continue;
+    }
+
+    const detections = value.detections ?? [];
+    const groupTracks: Array<{ track: Track; firstFrame: number }> = [];
+
+    for (let i = 0; i < detections.length; i++) {
+      const td = detections[i];
+
+      if (!isValidSupport(td.support)) {
+        continue;
+      }
+
+      const support = td.support;
+      const detectionId = td._id ?? td.id;
+      if (!detectionId) {
+        continue;
+      }
+
+      const label = td.label ?? "";
+      const startSec = (support[0] - 1) / fps;
+      const endSec = support[1] / fps;
+
+      const eventData: TemporalDetectionEventData = {
+        fieldPath,
+        detectionId,
+        detectionIndex: i,
+        support: [support[0], support[1]],
+        raw: td,
+      };
+
+      // `resizable: true` opts the interval into in-place edit via the
+      // TimelineTrack's drag handles. The drag-end callback is wired up
+      // in {@link FrameLabelsTracks}.
+      const event: TrackEvent & { resizable: true } = {
+        startSec,
+        endSec,
+        label: label || "temporal detection",
+        data: eventData,
+        resizable: true,
+      };
+
+      const color = resolveColor(fieldPath, {
+        _cls: "TemporalDetection",
+        label,
+        id: detectionId,
+      });
+
+      const rowLabel = label
+        ? `${label} (${fieldPath})`
+        : `${fieldPath} ${truncateId(detectionId)}`;
+
+      groupTracks.push({
+        track: {
+          id: `td-${fieldPath}-${detectionId}`,
+          label: rowLabel,
+          description: `Temporal detection "${
+            label || "unnamed"
+          }" on \`${fieldPath}\` (frames ${support[0]}–${support[1]})`,
+          color,
+          events: [event],
+        },
+        firstFrame: support[0],
+      });
+    }
+
+    groupTracks.sort((a, b) => {
+      if (a.firstFrame !== b.firstFrame) {
+        return a.firstFrame - b.firstFrame;
+      }
+
+      return a.track.id.localeCompare(b.track.id);
+    });
+
+    for (const entry of groupTracks) {
+      tracks.push(entry.track);
+    }
+  }
+
+  return tracks;
+}
+
+function truncateId(id: string): string {
+  return id.length > 8 ? id.slice(-8) : id;
+}

--- a/app/packages/video-annotation/src/tracks/trackExtentEdit.test.ts
+++ b/app/packages/video-annotation/src/tracks/trackExtentEdit.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveTrackExtentEdit,
+  type ResolveTrackExtentEditInput,
+} from "./trackExtentEdit";
+
+const FPS = 30;
+
+// A segment covering frames [11, 31] inclusive:
+//   startSec = (11 - 1) / 30, endSec = 31 / 30.
+const SEG_FIRST = 11;
+const SEG_LAST = 31;
+const origStartSec = (SEG_FIRST - 1) / FPS;
+const origEndSec = SEG_LAST / FPS;
+
+const base = (
+  over: Partial<ResolveTrackExtentEditInput>
+): ResolveTrackExtentEditInput => ({
+  mode: "resize-end",
+  origStartSec,
+  origEndSec,
+  newStartSec: origStartSec,
+  newEndSec: origEndSec,
+  fps: FPS,
+  totalFrames: 120,
+  ...over,
+});
+
+// Convert a frame to the end-second its bar edge would sit at.
+const endSecOf = (frame: number) => frame / FPS;
+// Convert a frame to the start-second its bar edge would sit at.
+const startSecOf = (frame: number) => (frame - 1) / FPS;
+
+describe("resolveTrackExtentEdit", () => {
+  it("returns none for degenerate fps", () => {
+    expect(resolveTrackExtentEdit(base({ fps: 0 })).op).toBe("none");
+  });
+
+  it("returns none when the drag snaps back to the original extent", () => {
+    expect(resolveTrackExtentEdit(base({ mode: "resize-end" })).op).toBe(
+      "none"
+    );
+    expect(resolveTrackExtentEdit(base({ mode: "resize-start" })).op).toBe(
+      "none"
+    );
+    expect(resolveTrackExtentEdit(base({ mode: "move" })).op).toBe("none");
+  });
+
+  describe("resize-end", () => {
+    it("extends forward, copying the last frame onto the grown frames", () => {
+      const edit = resolveTrackExtentEdit(
+        base({ mode: "resize-end", newEndSec: endSecOf(45) })
+      );
+      expect(edit).toEqual({
+        op: "extend",
+        sourceFrame: SEG_LAST,
+        targetFrames: [32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45],
+      });
+    });
+
+    it("clamps growth to totalFrames", () => {
+      const edit = resolveTrackExtentEdit(
+        base({ mode: "resize-end", newEndSec: endSecOf(200), totalFrames: 40 })
+      );
+      expect(edit).toEqual({
+        op: "extend",
+        sourceFrame: SEG_LAST,
+        targetFrames: [32, 33, 34, 35, 36, 37, 38, 39, 40],
+      });
+    });
+
+    it("trims from the end when dragged inward", () => {
+      const edit = resolveTrackExtentEdit(
+        base({ mode: "resize-end", newEndSec: endSecOf(28) })
+      );
+      expect(edit).toEqual({ op: "trim", frames: [29, 30, 31] });
+    });
+  });
+
+  describe("resize-start", () => {
+    it("extends backward, copying the first frame onto the grown frames", () => {
+      const edit = resolveTrackExtentEdit(
+        base({ mode: "resize-start", newStartSec: startSecOf(8) })
+      );
+      expect(edit).toEqual({
+        op: "extend",
+        sourceFrame: SEG_FIRST,
+        targetFrames: [8, 9, 10],
+      });
+    });
+
+    it("clamps backward growth to frame 1", () => {
+      const edit = resolveTrackExtentEdit(
+        base({ mode: "resize-start", newStartSec: startSecOf(-5) })
+      );
+      expect(edit).toEqual({
+        op: "extend",
+        sourceFrame: SEG_FIRST,
+        targetFrames: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      });
+    });
+
+    it("trims from the start when dragged inward", () => {
+      const edit = resolveTrackExtentEdit(
+        base({ mode: "resize-start", newStartSec: startSecOf(14) })
+      );
+      expect(edit).toEqual({ op: "trim", frames: [11, 12, 13] });
+    });
+  });
+
+  describe("move", () => {
+    it("shifts the whole segment by the dragged delta", () => {
+      const edit = resolveTrackExtentEdit(
+        base({ mode: "move", newStartSec: startSecOf(SEG_FIRST + 1) })
+      );
+      expect(edit).toEqual({
+        op: "shift",
+        frames: Array.from({ length: 21 }, (_, i) => SEG_FIRST + i),
+        delta: 1,
+      });
+    });
+
+    it("clamps a backward shift to the clip start", () => {
+      const edit = resolveTrackExtentEdit(
+        base({ mode: "move", newStartSec: startSecOf(1) })
+      );
+      // first is 11, so the most it can move left is -10.
+      expect(edit).toMatchObject({ op: "shift", delta: -10 });
+    });
+
+    it("clamps a forward shift so it can't overrun a right neighbour", () => {
+      const edit = resolveTrackExtentEdit(
+        base({
+          mode: "move",
+          newStartSec: startSecOf(SEG_FIRST + 20),
+          // Neighbour occupies [40, 50]; segment end is 31, so the bar
+          // can move forward at most to end at 39 → delta +8.
+          neighborSegments: [[40, 50]],
+        })
+      );
+      expect(edit).toMatchObject({ op: "shift", delta: 8 });
+    });
+  });
+});

--- a/app/packages/video-annotation/src/tracks/trackExtentEdit.ts
+++ b/app/packages/video-annotation/src/tracks/trackExtentEdit.ts
@@ -1,0 +1,168 @@
+/**
+ * Pure translation from a timeline interval drag on an object
+ * track into the per-frame edit it implies. Kept free of React / stream
+ * dependencies so it can be unit-tested directly; the command handlers in
+ * `@fiftyone/annotation` carry out the resulting frame writes.
+ *
+ * Frame ↔ seconds mapping mirrors the one `buildPerInstanceTracks` uses in
+ * the forward direction (`startSec = (firstFrame - 1) / fps`,
+ * `endSec = lastFrame / fps`), inverted here.
+ */
+
+/** Drag mode reported by `TimelineTrack`'s `onEventEdit`. */
+export type TrackDragMode = "resize-start" | "resize-end" | "move";
+
+/**
+ * Resolved per-frame edit for a track drag.
+ * - `extend` — copy `sourceFrame`'s box onto each of `targetFrames` (the
+ *   grown frames) as non-keyframe filler.
+ * - `trim` — delete the track's detection on each of `frames` (the frames
+ *   the drag pulled the edge past).
+ * - `shift` — move the track's detection on each of `frames` by `delta`
+ *   frames (rigid shift of the dragged segment).
+ * - `none` — the drag resolved to no frame-level change.
+ */
+export type TrackExtentEdit =
+  | { op: "extend"; sourceFrame: number; targetFrames: number[] }
+  | { op: "trim"; frames: number[] }
+  | { op: "shift"; frames: number[]; delta: number }
+  | { op: "none" };
+
+export interface ResolveTrackExtentEditInput {
+  mode: TrackDragMode;
+  /** Dragged segment's original bounds in seconds (the event's start/end). */
+  origStartSec: number;
+  origEndSec: number;
+  /** Post-drag bounds in seconds (already snapped to frames by the track). */
+  newStartSec: number;
+  newEndSec: number;
+  fps: number;
+  /** 1-indexed inclusive clip length. Grown/shifted frames clamp to this. */
+  totalFrames: number;
+  /**
+   * Other presence segments of the same track (the in-frame intervals
+   * other than the dragged one), as `[firstFrame, lastFrame]` pairs. A
+   * `move` is clamped so it can't overrun a neighbouring segment.
+   */
+  neighborSegments?: ReadonlyArray<readonly [number, number]>;
+}
+
+const firstFrameOf = (sec: number, fps: number): number =>
+  Math.round(sec * fps) + 1;
+
+const lastFrameOf = (sec: number, fps: number): number => Math.round(sec * fps);
+
+const inclusiveRange = (from: number, to: number): number[] => {
+  const out: number[] = [];
+  for (let f = from; f <= to; f++) {
+    out.push(f);
+  }
+
+  return out;
+};
+
+/**
+ * Clamp a `move` delta so the shifted block `[first, last]` stays within
+ * `[1, totalFrames]` and never overlaps a neighbouring segment of the same
+ * track.
+ */
+const clampShift = (
+  delta: number,
+  first: number,
+  last: number,
+  totalFrames: number,
+  neighbors: ReadonlyArray<readonly [number, number]>
+): number => {
+  let lo = 1 - first; // first + delta >= 1
+  let hi = totalFrames - last; // last + delta <= totalFrames
+
+  for (const [nFirst, nLast] of neighbors) {
+    if (nLast < first) {
+      // Neighbour sits to the left: keep first + delta strictly past it.
+      lo = Math.max(lo, nLast + 1 - first);
+    } else if (nFirst > last) {
+      // Neighbour sits to the right: keep last + delta strictly before it.
+      hi = Math.min(hi, nFirst - 1 - last);
+    }
+  }
+
+  return Math.max(lo, Math.min(hi, delta));
+};
+
+/**
+ * Translate an interval drag into the per-frame edit it implies. Returns
+ * `{ op: "none" }` for degenerate input (bad fps, zero-width segment) and
+ * for drags that snapped back to the original extent.
+ */
+export function resolveTrackExtentEdit(
+  input: ResolveTrackExtentEditInput
+): TrackExtentEdit {
+  const { mode, fps, totalFrames } = input;
+  if (!Number.isFinite(fps) || fps <= 0) {
+    return { op: "none" };
+  }
+
+  const origFirst = firstFrameOf(input.origStartSec, fps);
+  const origLast = lastFrameOf(input.origEndSec, fps);
+
+  if (origLast < origFirst) {
+    return { op: "none" };
+  }
+
+  if (mode === "resize-end") {
+    const newLast = Math.min(
+      Math.max(lastFrameOf(input.newEndSec, fps), origFirst),
+      totalFrames
+    );
+
+    if (newLast > origLast) {
+      return {
+        op: "extend",
+        sourceFrame: origLast,
+        targetFrames: inclusiveRange(origLast + 1, newLast),
+      };
+    }
+
+    if (newLast < origLast) {
+      return { op: "trim", frames: inclusiveRange(newLast + 1, origLast) };
+    }
+
+    return { op: "none" };
+  }
+
+  if (mode === "resize-start") {
+    const newFirst = Math.max(
+      Math.min(firstFrameOf(input.newStartSec, fps), origLast),
+      1
+    );
+
+    if (newFirst < origFirst) {
+      return {
+        op: "extend",
+        sourceFrame: origFirst,
+        targetFrames: inclusiveRange(newFirst, origFirst - 1),
+      };
+    }
+
+    if (newFirst > origFirst) {
+      return { op: "trim", frames: inclusiveRange(origFirst, newFirst - 1) };
+    }
+
+    return { op: "none" };
+  }
+
+  // move
+  const delta = clampShift(
+    firstFrameOf(input.newStartSec, fps) - origFirst,
+    origFirst,
+    origLast,
+    totalFrames,
+    input.neighborSegments ?? []
+  );
+
+  if (delta === 0) {
+    return { op: "none" };
+  }
+
+  return { op: "shift", frames: inclusiveRange(origFirst, origLast), delta };
+}

--- a/app/packages/video-annotation/src/tracks/trackIdentity.test.ts
+++ b/app/packages/video-annotation/src/tracks/trackIdentity.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { instanceIdFromTrackId } from "./trackIdentity";
+
+describe("instanceIdFromTrackId", () => {
+  it("strips the instance- prefix to the engine instanceId", () => {
+    expect(instanceIdFromTrackId("instance-abc123")).toBe("abc123");
+  });
+
+  it("returns a bare document id unchanged (untracked detection)", () => {
+    expect(instanceIdFromTrackId("65f0a1b2c3d4e5f6a7b8c9d0")).toBe(
+      "65f0a1b2c3d4e5f6a7b8c9d0"
+    );
+  });
+
+  it("returns null for a legacy index-only track (no engine identity)", () => {
+    expect(instanceIdFromTrackId("track-4")).toBeNull();
+  });
+});

--- a/app/packages/video-annotation/src/tracks/trackIdentity.ts
+++ b/app/packages/video-annotation/src/tracks/trackIdentity.ts
@@ -1,0 +1,29 @@
+/**
+ * Map a timeline track id back to the engine's `LabelRef.instanceId`.
+ *
+ * Track ids are the synthetic ids `resolveSyntheticId` mints for overlays /
+ * timeline rows; the engine addresses a track by its `instance._id` (the
+ * `FrameStore` resolves `instance?._id ?? _id`). The two reconcile per id form:
+ *
+ * - `instance-<id>` — a tracked instance; `<id>` IS the engine instanceId.
+ * - a bare document `_id` — an untracked detection; the engine addresses it by
+ *   that same `_id`, so the track id is already the instanceId.
+ * - `track-<index>` — a legacy index-only track with no `instance._id`. Its
+ *   per-frame docs carry different `_id`s, so there is no single engine
+ *   instanceId for the track — returns `null`.
+ */
+
+const INSTANCE_PREFIX = "instance-";
+const LEGACY_INDEX_PREFIX = "track-";
+
+export const instanceIdFromTrackId = (trackId: string): string | null => {
+  if (trackId.startsWith(INSTANCE_PREFIX)) {
+    return trackId.slice(INSTANCE_PREFIX.length);
+  }
+
+  if (trackId.startsWith(LEGACY_INDEX_PREFIX)) {
+    return null;
+  }
+
+  return trackId;
+};

--- a/app/packages/video-annotation/src/tracks/useVideoTrackDecorator.ts
+++ b/app/packages/video-annotation/src/tracks/useVideoTrackDecorator.ts
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import type { Track } from "@fiftyone/playback";
+import clsx from "clsx";
+import { useCallback } from "react";
+import { useVideoInteraction } from "../state/useVideoInteraction";
+import { temporalDetectionRefOf } from "./temporalDetectionTracks";
+import styles from "../components/VideoAnnotationSurface.module.css";
+
+type TrackDecoration = Partial<{
+  className: string;
+  onMouseEnter: () => void;
+  onMouseLeave: () => void;
+  onTrackClick: () => void;
+}>;
+
+/**
+ * Decorate timeline rows from engine interaction so a row lights up
+ * (`linkHovered` / `linkSelected`) when its label is hovered / selected on any
+ * surface, and the row's own hover / click writes that interaction back through
+ * the engine — which the canvas Lighter bridge applies to the overlay. The
+ * row's visual hover is plain CSS `:hover`; only the cross-component direction
+ * needs the engine.
+ *
+ * Two row kinds, both engine-addressed:
+ *  - an OBJECT track's row id IS its `instanceId` (a frame-detection track), so
+ *    it links on `track.id` at the current playhead frame;
+ *  - a TEMPORAL-DETECTION row is sample-level — identified by its structured
+ *    event payload (not the row-id shape) — so it links on the TD's `_id`
+ *    (`instanceId`) at its own field path, frame-less.
+ *
+ * Both read the same engine interaction sets (keyed by `instanceId`), so the TD
+ * `_id` matches the canvas overlay and sidebar row.
+ */
+export const useVideoTrackDecorator = (): ((
+  track: Track
+) => TrackDecoration) => {
+  const {
+    selectedTrackIds,
+    hoveredTrackIds,
+    selectTrack,
+    hoverTrack,
+    selectLabel,
+    hoverLabel,
+  } = useVideoInteraction();
+
+  return useCallback(
+    (track: Track) => {
+      const tdRef = temporalDetectionRefOf(track);
+
+      if (tdRef) {
+        return {
+          className: clsx({
+            [styles.linkHovered]: hoveredTrackIds.has(tdRef.instanceId),
+            [styles.linkSelected]: selectedTrackIds.has(tdRef.instanceId),
+          }),
+          onMouseEnter: () => hoverLabel(tdRef, true),
+          onMouseLeave: () => hoverLabel(tdRef, false),
+          onTrackClick: () => selectLabel(tdRef),
+        };
+      }
+
+      return {
+        className: clsx({
+          [styles.linkHovered]: hoveredTrackIds.has(track.id),
+          [styles.linkSelected]: selectedTrackIds.has(track.id),
+        }),
+        onMouseEnter: () => hoverTrack(track.id, true),
+        onMouseLeave: () => hoverTrack(track.id, false),
+        onTrackClick: () => selectTrack(track.id),
+      };
+    },
+    [
+      hoveredTrackIds,
+      selectedTrackIds,
+      hoverTrack,
+      selectTrack,
+      hoverLabel,
+      selectLabel,
+    ]
+  );
+};

--- a/app/packages/video-annotation/src/utils/ids.ts
+++ b/app/packages/video-annotation/src/utils/ids.ts
@@ -1,0 +1,4 @@
+export const VIDEO_STREAM_ID = "video";
+export const IMAVID_STREAM_ID = "imavid-image";
+export const LABELS_STREAM_ID = "frame-labels";
+export const MAIN_TILE_ID = "main";

--- a/app/packages/video-annotation/src/utils/modalSample.ts
+++ b/app/packages/video-annotation/src/utils/modalSample.ts
@@ -1,0 +1,12 @@
+import type { ModalSample } from "@fiftyone/state";
+
+/**
+ * Frame rate of the modal sample, or `undefined`. `frameRate` exists only on
+ * the video variant of the sample response; `ModalSample`'s `Omit`-over-union
+ * shape erases it, so read it through this narrowing accessor rather than off
+ * the union directly.
+ */
+export const getModalSampleFrameRate = (
+  sample: ModalSample | null | undefined
+): number | undefined =>
+  (sample as { frameRate?: number } | null | undefined)?.frameRate;

--- a/app/packages/video-annotation/tsconfig.json
+++ b/app/packages/video-annotation/tsconfig.json
@@ -1,0 +1,4 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "include": ["./src", "./index.ts"]
+}

--- a/app/packages/video-annotation/vite.config.ts
+++ b/app/packages/video-annotation/vite.config.ts
@@ -1,0 +1,12 @@
+import { UserConfig } from "vite";
+
+export default <UserConfig>{
+  rollupOptions: {
+    external: ["react", "react-dom"],
+  },
+  resolve: {
+    alias: {
+      "@fiftyone/video-annotation": "@fiftyone/video-annotation/index.ts",
+    },
+  },
+};

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2996,7 +2996,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@fiftyone/annotation@workspace:packages/annotation":
+"@fiftyone/annotation@workspace:*, @fiftyone/annotation@workspace:packages/annotation":
   version: 0.0.0-use.local
   resolution: "@fiftyone/annotation@workspace:packages/annotation"
   dependencies:
@@ -3036,6 +3036,7 @@ __metadata:
     "@fiftyone/relay": "npm:*"
     "@fiftyone/state": "npm:*"
     "@fiftyone/utilities": "npm:*"
+    "@fiftyone/video-annotation": "workspace:*"
     "@material-ui/core": "npm:4.12.4"
     "@types/lodash": "npm:^4.14.182"
     "@types/mime": "npm:^2.0.3"
@@ -3077,7 +3078,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@fiftyone/command-bus@workspace:packages/command-bus":
+"@fiftyone/command-bus@workspace:*, @fiftyone/command-bus@workspace:packages/command-bus":
   version: 0.0.0-use.local
   resolution: "@fiftyone/command-bus@workspace:packages/command-bus"
   dependencies:
@@ -3095,7 +3096,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@fiftyone/commands@workspace:^, @fiftyone/commands@workspace:packages/commands":
+"@fiftyone/commands@workspace:*, @fiftyone/commands@workspace:^, @fiftyone/commands@workspace:packages/commands":
   version: 0.0.0-use.local
   resolution: "@fiftyone/commands@workspace:packages/commands"
   dependencies:
@@ -3113,7 +3114,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@fiftyone/components@npm:*, @fiftyone/components@workspace:packages/components":
+"@fiftyone/components@npm:*, @fiftyone/components@workspace:*, @fiftyone/components@workspace:packages/components":
   version: 0.0.0-use.local
   resolution: "@fiftyone/components@workspace:packages/components"
   dependencies:
@@ -3232,6 +3233,7 @@ __metadata:
     xstate: "npm:^4.14.0"
   peerDependencies:
     "@fiftyone/annotation": "*"
+    "@fiftyone/video-annotation": "*"
     "@mui/icons-material": "*"
     "@mui/material": "*"
     "@react-spring/web": "*"
@@ -3353,7 +3355,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@fiftyone/lighter@workspace:packages/lighter":
+"@fiftyone/lighter@workspace:*, @fiftyone/lighter@workspace:packages/lighter":
   version: 0.0.0-use.local
   resolution: "@fiftyone/lighter@workspace:packages/lighter"
   dependencies:
@@ -3498,7 +3500,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@fiftyone/playback@workspace:packages/playback":
+"@fiftyone/playback@workspace:*, @fiftyone/playback@workspace:packages/playback":
   version: 0.0.0-use.local
   resolution: "@fiftyone/playback@workspace:packages/playback"
   dependencies:
@@ -3596,7 +3598,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@fiftyone/state@npm:*, @fiftyone/state@workspace:packages/state":
+"@fiftyone/state@npm:*, @fiftyone/state@workspace:*, @fiftyone/state@workspace:packages/state":
   version: 0.0.0-use.local
   resolution: "@fiftyone/state@workspace:packages/state"
   dependencies:
@@ -3620,7 +3622,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@fiftyone/tiling@npm:*, @fiftyone/tiling@workspace:packages/tiling":
+"@fiftyone/tiling@npm:*, @fiftyone/tiling@workspace:*, @fiftyone/tiling@workspace:packages/tiling":
   version: 0.0.0-use.local
   resolution: "@fiftyone/tiling@workspace:packages/tiling"
   dependencies:
@@ -3634,7 +3636,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@fiftyone/utilities@npm:*, @fiftyone/utilities@workspace:^, @fiftyone/utilities@workspace:packages/utilities":
+"@fiftyone/utilities@npm:*, @fiftyone/utilities@workspace:*, @fiftyone/utilities@workspace:^, @fiftyone/utilities@workspace:packages/utilities":
   version: 0.0.0-use.local
   resolution: "@fiftyone/utilities@workspace:packages/utilities"
   dependencies:
@@ -3651,6 +3653,33 @@ __metadata:
     vite: "npm:^7.3.2"
   peerDependencies:
     react: "*"
+  languageName: unknown
+  linkType: soft
+
+"@fiftyone/video-annotation@workspace:*, @fiftyone/video-annotation@workspace:packages/video-annotation":
+  version: 0.0.0-use.local
+  resolution: "@fiftyone/video-annotation@workspace:packages/video-annotation"
+  dependencies:
+    "@eslint/compat": "npm:^1.1.1"
+    "@fiftyone/annotation": "workspace:*"
+    "@fiftyone/command-bus": "workspace:*"
+    "@fiftyone/commands": "workspace:*"
+    "@fiftyone/components": "workspace:*"
+    "@fiftyone/lighter": "workspace:*"
+    "@fiftyone/playback": "workspace:*"
+    "@fiftyone/state": "workspace:*"
+    "@fiftyone/tiling": "workspace:*"
+    "@fiftyone/utilities": "workspace:*"
+    "@voxel51/voodo": "npm:^0.0.30"
+    clsx: "npm:^2.1.0"
+    eslint: "npm:9.7.0"
+    eslint-plugin-react: "npm:^7.35.0"
+    eslint-plugin-react-hooks: "npm:rc"
+    globals: "npm:^15.8.0"
+    jotai: "npm:^2.9.3"
+    lru-cache: "npm:^11.0.1"
+    typescript-eslint: "npm:^7.17.0"
+    vite: "npm:^7.3.2"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## What

Adds the **`@fiftyone/video-annotation`** package — the video annotation modal surface, built directly on the annotation engine — and mounts it in the modal. Labels, identity, selection, undo, and persistence all flow through the engine introduced in PR 1; there is no parallel state model.

Stacked PR **2 of 3** (base: `feat/anno-engine-frame-store`):
1. `feat/anno-engine-frame-store` — frame engine + foundation
2. **`feat/anno-engine-video-surface`** ← this PR — the package + modal mount
3. `test/anno-engine-video-e2e` — Playwright coverage

## Changes

- **New package `@fiftyone/video-annotation`**
  - **streams / media** — an imavid frame stream (worker fetch + decode) feeding a read-only frames seed, plus the media canonical / letterbox math.
  - **tracks / components** — engine-sourced timeline tracks (one row per instance, keyed by `instance._id`), temporal-detection rows, and the surface components (top bar, frame labels, toolbar).
  - **engine integration** — hooks/sync that register the video sample's composite store, drive the frame clock and presence from the playhead, route draw/edit/delete/propagation through engine transactions, and bridge canvas + timeline selection/hover to engine interaction. Includes SAM2 forward-tracking propagation.
- **`core`** — mounts `VideoAnnotationSurface` in `ModalLooker` for video samples; declares the workspace dependency.

## Notes

- Per-frame detections, temporal detections (support-gated), keyframes, auto-extend (a fresh box fills ~30 frames as one undo unit), and track-wide attribute edits are all supported. Segmentation/polyline for video are not yet wired (box-only today).
- Depends on PR 1's engine — review/merge in order.
- The `ModalLooker` mount touches shared modal code; otherwise the change is contained to the new package.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive video annotation package with frame-level label tracking
  * Introduced temporal detection support with keyframe marking and linear interpolation
  * Added track editing capabilities (extend, trim, shift, delete tracks)
  * Integrated SAM2 propagation for semi-automatic frame filling
  * Enabled synthetic label mode for testing
  * Support for both native video and per-frame image formats

* **Documentation**
  * Added detailed package README with architecture and usage guide

* **Tests**
  * Added comprehensive test coverage for core annotation features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->