### PR TITLE
E2E coverage for the video annotation surface

### DIFF
--- a/e2e-pw/src/oss/fixtures/index.ts
+++ b/e2e-pw/src/oss/fixtures/index.ts
@@ -7,6 +7,7 @@ import { AggregationWatcher } from "./aggregation-watcher";
 import { AnnotateSDK } from "./annotate-sdk";
 import { FoWebServer } from "./fo-server";
 import { OssLoader } from "./loader";
+import { VideoAnnotateSDK } from "./video-annotate-sdk";
 
 // note: this difference between "with" and "without" is only for type safety
 
@@ -18,6 +19,7 @@ export type CustomFixturesWithoutPage = {
   mediaFactory: typeof MediaFactory;
   foWebServer: FoWebServer;
   annotateSDK: AnnotateSDK;
+  videoAnnotateSDK: VideoAnnotateSDK;
 };
 
 // these fixtures have access to the {page} fixture
@@ -70,6 +72,12 @@ const customFixtures = base.extend<object, CustomFixturesWithoutPage>({
   annotateSDK: [
     async ({}, use) => {
       await use(new AnnotateSDK());
+    },
+    { scope: "worker" },
+  ],
+  videoAnnotateSDK: [
+    async ({}, use) => {
+      await use(new VideoAnnotateSDK());
     },
     { scope: "worker" },
   ],

--- a/e2e-pw/src/oss/fixtures/video-annotate-sdk.ts
+++ b/e2e-pw/src/oss/fixtures/video-annotate-sdk.ts
@@ -1,0 +1,216 @@
+import { OssLoader } from "./loader";
+
+export interface SeedVideoAnnotationOptions {
+  /** Dataset name. */
+  datasetName: string;
+  /**
+   * Absolute paths of the video media, one per sample. Sample `i` is created
+   * with the fixed `_id` `ObjectId(f"{i:024x}")` so it can be deep-linked via
+   * the `id` search param (sample 0 => "000000000000000000000000").
+   */
+  videoPaths: string[];
+  /** Detection classes offered by the `detections` annotation schema. */
+  classes?: string[];
+  /** Temporal-detection classes offered by the `events` schema. */
+  eventClasses?: string[];
+  /** Seed the demo `events` TemporalDetections (approach/pass/depart). */
+  withEvents?: boolean;
+  /**
+   * Sample indices that should carry a pre-seeded tracked frame detection
+   * (a single instance, `index=1`, class `classes[0]`, on every frame) so
+   * tests can exercise select/edit/track-fan-out/follow-anchor on an
+   * existing track. Defaults to none (a clean slate, like `va-demo-bare`).
+   */
+  trackedSampleIndices?: number[];
+}
+
+/**
+ * Seeds a video-annotation dataset that mirrors the deployed demo
+ * (`setup_video_annotation_demo.py`): a sample-level `detections` field that
+ * SHADOWS `frames.detections` (the schema-manager hack the annotation logic
+ * relies on), declared frame fields, an active `events` TemporalDetections
+ * schema, materialized per-frame images for the ImaVid tile, and
+ * empty-but-present `frames.detections` on every frame so the first draw's
+ * JSON patch can append.
+ */
+export class VideoAnnotateSDK {
+  loader: OssLoader;
+
+  constructor() {
+    this.loader = new OssLoader();
+  }
+
+  seed(options: SeedVideoAnnotationOptions) {
+    const {
+      datasetName,
+      videoPaths,
+      classes = ["vehicle", "person", "road sign"],
+      eventClasses = ["approach", "pass", "depart"],
+      withEvents = true,
+      trackedSampleIndices = [],
+    } = options;
+
+    const pyPaths = JSON.stringify(videoPaths);
+    const pyClasses = JSON.stringify(classes);
+    const pyEventClasses = JSON.stringify(eventClasses);
+    const pyTracked = JSON.stringify(trackedSampleIndices);
+
+    return this.loader.executePythonCode(`
+import fiftyone as fo
+from bson import ObjectId
+
+VIDEO_PATHS = ${pyPaths}
+CLASSES = ${pyClasses}
+EVENT_CLASSES = ${pyEventClasses}
+WITH_EVENTS = ${withEvents ? "True" : "False"}
+TRACKED = set(${pyTracked})
+DETECTIONS_FIELD = "detections"
+EVENTS_FIELD = "events"
+
+if fo.dataset_exists("${datasetName}"):
+    fo.delete_dataset("${datasetName}")
+
+dataset = fo.Dataset("${datasetName}")
+dataset.persistent = True
+dataset.media_type = "video"
+
+# Fixed sample ids -> deep-linkable: sample i == ObjectId(f"{i:024x}").
+# add_samples() regenerates ids, so force them via a raw insert of the
+# sample docs (mirrors the image dataset factory's _make_dict trick).
+samples = [
+    fo.Sample(_id=ObjectId(f"{i:024x}"), filepath=p)
+    for i, p in enumerate(VIDEO_PATHS)
+]
+dataset._sample_collection.insert_many(
+    [dataset._make_dict(s, include_id=True) for s in samples]
+)
+dataset.reload()
+
+# The surface requires populated VideoMetadata (frame_rate / total_frame_count
+# / dimensions).
+dataset.compute_metadata()
+
+# (2) sample-level Detections field that shadows frames.detections.
+dataset.add_sample_field(
+    DETECTIONS_FIELD, fo.EmbeddedDocumentField, embedded_doc_type=fo.Detections
+)
+
+# (3) frame fields the propagation pipeline writes. Declare the parent
+# Detections container first, then the nested specs.
+dataset.add_frame_field(
+    DETECTIONS_FIELD, fo.EmbeddedDocumentField, embedded_doc_type=fo.Detections
+)
+dataset.add_frame_field("detections.detections.keyframe", fo.BooleanField)
+dataset.add_frame_field("detections.detections.propagation", fo.DictField)
+
+# (4) sample-level TemporalDetections field.
+dataset.add_sample_field(
+    EVENTS_FIELD, fo.EmbeddedDocumentField, embedded_doc_type=fo.TemporalDetections
+)
+
+
+def total_frames(sample):
+    n = (
+        getattr(sample.metadata, "total_frame_count", None)
+        if sample.metadata
+        else None
+    )
+    if not n:
+        n = max(sample.frames.keys()) if sample.frames else 0
+    return int(n)
+
+
+# Materialize per-frame images (ImaVid serves frames from these).
+dataset.to_frames(sample_frames=True)
+
+# Every frame gets an empty (present) Detections so the first draw can append.
+for sample in dataset.iter_samples(progress=False, autosave=True):
+    for fn in range(1, total_frames(sample) + 1):
+        sample.frames[fn]["detections"] = fo.Detections(detections=[])
+
+# Pre-seed a tracked detection on requested samples (one instance, index=1,
+# class CLASSES[0], on every frame).
+for idx, sample in enumerate(dataset.iter_samples(progress=False, autosave=True)):
+    if idx not in TRACKED:
+        continue
+    for fn in range(1, total_frames(sample) + 1):
+        sample.frames[fn]["detections"] = fo.Detections(
+            detections=[
+                fo.Detection(
+                    label=CLASSES[0],
+                    bounding_box=[0.3, 0.3, 0.2, 0.2],
+                    index=1,
+                )
+            ]
+        )
+
+# (5) demo temporal events (approach / pass / depart thirds).
+if WITH_EVENTS:
+    for sample in dataset.iter_samples(progress=False, autosave=True):
+        n = total_frames(sample)
+        a = max(1, n // 3)
+        b = max(a + 1, (2 * n) // 3)
+        sample[EVENTS_FIELD] = fo.TemporalDetections(
+            detections=[
+                fo.TemporalDetection(label=EVENT_CLASSES[0], support=[1, a]),
+                fo.TemporalDetection(label=EVENT_CLASSES[1], support=[a + 1, b]),
+                fo.TemporalDetection(label=EVENT_CLASSES[2], support=[b + 1, n]),
+            ]
+        )
+
+# (6) stable cross-frame Instance per (label, index) track, per sample.
+for sample in dataset.iter_samples(progress=False, autosave=True):
+    by_track = {}
+    for frame in sample.frames.values():
+        dets = frame.detections
+        if dets is None:
+            continue
+        for det in dets.detections:
+            if det.index is None:
+                continue
+            key = (det.label, det.index)
+            inst = by_track.get(key)
+            if inst is None:
+                inst = fo.Instance()
+                by_track[key] = inst
+            current = getattr(det, "instance", None)
+            if current is None or current.id != inst.id:
+                det.instance = inst
+
+# Active annotation schemas: detections (frame-forwarding shadow) + events.
+det_schema = {
+    "type": "detections",
+    "component": "dropdown",
+    "attributes": [
+        {"name": "id", "type": "id", "component": "text", "read_only": True},
+        {"name": "tags", "type": "list<str>", "component": "text"},
+        {"name": "confidence", "type": "float", "component": "text"},
+        {"name": "index", "type": "int", "component": "text"},
+        {"name": "mask_path", "type": "str", "component": "text"},
+    ],
+    "classes": CLASSES,
+}
+dataset.update_label_schema(DETECTIONS_FIELD, det_schema, allow_new_attrs=True)
+dataset.active_label_schemas = [DETECTIONS_FIELD]
+
+events_schema = {
+    "type": "temporaldetections",
+    "component": "dropdown",
+    "attributes": [
+        {"name": "id", "type": "id", "component": "text", "read_only": True},
+    ],
+    "classes": EVENT_CLASSES,
+}
+dataset.update_label_schema(EVENTS_FIELD, events_schema, allow_new_attrs=True)
+dataset.active_label_schemas = dataset.active_label_schemas + [EVENTS_FIELD]
+
+dataset.save()
+print(
+    "VIDEO_ANNOTATE_SEED_DONE",
+    dataset.name,
+    "samples=", len(dataset),
+    "frames0=", total_frames(dataset.first()),
+)
+`);
+  }
+}

--- a/e2e-pw/src/oss/poms/modal/annotate-edit.ts
+++ b/e2e-pw/src/oss/poms/modal/annotate-edit.ts
@@ -68,6 +68,15 @@ export class ModalAnnotateEditPom {
   }
 
   /**
+   * Delete the currently-edited label via the label menu. The MUI menu renders
+   * in a document-level portal, so target the item off `page`.
+   */
+  async deleteLabel() {
+    await this.openLabelMenu();
+    await this.page.getByTestId("label-menu-delete").click();
+  }
+
+  /**
    * Click the undo button
    */
   async undo() {

--- a/e2e-pw/src/oss/poms/modal/index.ts
+++ b/e2e-pw/src/oss/poms/modal/index.ts
@@ -9,6 +9,7 @@ import { ModalImaAsVideoControlsPom } from "./imavid-controls";
 import { Looker3DControlsPom } from "./looker-3d-controls";
 import { ModalSidebarPom } from "./modal-sidebar";
 import { SampleCanvasPom } from "./sample-canvas";
+import { VideoAnnotatePom } from "./video-annotate";
 import { ModalVideoControlsPom } from "./video-controls";
 
 const SAMPLE_LOAD_TIMEOUT = Duration.Seconds(20);
@@ -30,6 +31,7 @@ export class ModalPom {
   readonly tagger: ModalTaggerPom;
   readonly url: UrlPom;
   readonly video: ModalVideoControlsPom;
+  readonly videoAnnotate: VideoAnnotatePom;
 
   constructor(
     private readonly page: Page,
@@ -51,6 +53,7 @@ export class ModalPom {
     this.tagger = new ModalTaggerPom(page, this);
     this.url = new UrlPom(page, eventUtils);
     this.video = new ModalVideoControlsPom(page, this);
+    this.videoAnnotate = new VideoAnnotatePom(page, this);
   }
 
   get modalSamplePluginTitle() {

--- a/e2e-pw/src/oss/poms/modal/video-annotate.ts
+++ b/e2e-pw/src/oss/poms/modal/video-annotate.ts
@@ -1,0 +1,197 @@
+import { expect, Locator, Page } from "src/oss/fixtures";
+import { ModalPom } from ".";
+
+/**
+ * The video-annotation surface: the ImaVid media tile, the timeline of
+ * per-instance frame-label tracks + temporal-detection (TD) interval rows, and
+ * the playback controls (from `@fiftyone/playback`). Composes with the shared
+ * modal POMs (`modal.sidebar.annotate` / `modal.sidebar.edit` /
+ * `modal.sampleCanvas`) — only the video-specific timeline/playback affordances
+ * live here.
+ *
+ * Timeline tracks expose `data-track-id`: an object track's id is the engine
+ * `instanceId`; a TD track's id is `td-<field>-<detectionId>`.
+ */
+export class VideoAnnotatePom {
+  readonly page: Page;
+  readonly modal: ModalPom;
+  readonly assert: VideoAnnotateAsserter;
+  readonly topBar: Locator;
+  readonly statusSlot: Locator;
+
+  constructor(page: Page, modal: ModalPom) {
+    this.page = page;
+    this.modal = modal;
+    this.assert = new VideoAnnotateAsserter(this);
+    this.topBar = page.getByTestId("video-annotation-top-bar");
+    this.statusSlot = page.getByTestId("video-annotation-status-slot");
+  }
+
+  /** Wait until the video-annotation surface (top bar) has mounted. */
+  async waitForSurface() {
+    await expect(this.topBar).toBeVisible();
+  }
+
+  /** All distinct timeline track ids (object instanceIds + `td-…` rows). */
+  async trackIds(): Promise<string[]> {
+    const ids = await this.page
+      .locator("[data-track-id]")
+      .evaluateAll((els) =>
+        els.map((e) => e.getAttribute("data-track-id") ?? "")
+      );
+    return Array.from(new Set(ids.filter(Boolean)));
+  }
+
+  /** Timeline track ids for object (frame-label) tracks — the engine instanceIds. */
+  async objectTrackIds(): Promise<string[]> {
+    return (await this.trackIds()).filter((id) => !id.startsWith("td-"));
+  }
+
+  /** Timeline track ids for temporal-detection rows (`td-<field>-<id>`). */
+  async temporalTrackIds(): Promise<string[]> {
+    return (await this.trackIds()).filter((id) => id.startsWith("td-"));
+  }
+
+  /** A timeline track row by its id (object instanceId or `td-…`). */
+  track(trackId: string): Locator {
+    return this.page.locator(`[data-track-id="${trackId}"]`).first();
+  }
+
+  /** Click a timeline track row (selects it via engine interaction). */
+  async clickTrack(trackId: string) {
+    await this.track(trackId).click();
+  }
+
+  /**
+   * The track's presence interval bar (the right-click target for its context
+   * menu). The bar carries `data-event-index`; its resize handles also do, so
+   * exclude `data-resize-handle` to land on the bar itself.
+   */
+  trackBar(trackId: string): Locator {
+    return this.page
+      .locator(
+        `[data-track-id="${trackId}"] [data-event-index]:not([data-resize-handle])`
+      )
+      .first();
+  }
+
+  /**
+   * Right-click a track's interval bar and choose "Delete track" from the
+   * timeline context menu — removes the whole track (every frame's label),
+   * unlike the per-frame sidebar/keyboard delete.
+   */
+  async deleteTrackViaContextMenu(trackId: string) {
+    await this.trackBar(trackId).click({ button: "right" });
+    await this.page.getByRole("menuitem", { name: "Delete track" }).click();
+  }
+
+  /**
+   * Advance the playhead one frame. Uses the Modal-context "." keybinding
+   * (`KnownCommands.ModalStepForward`) rather than the icon button, which is
+   * the robust path while the ImaVid buffer settles.
+   */
+  async stepForward() {
+    await this.page.keyboard.press(".");
+  }
+
+  /** Move the playhead back one frame (the "," Modal-context keybinding). */
+  async stepBack() {
+    await this.page.keyboard.press(",");
+  }
+
+  /** Toggle playback (play/pause) via the timeline control. */
+  async togglePlay() {
+    await this.page.getByTestId("timeline-controls-play-pause").click();
+  }
+
+  /**
+   * The annotate-sidebar label rows currently listed (engine-presence derived:
+   * the current frame's labels + in-support temporal detections). Each row is a
+   * `[data-cy^=annotate-label-]` with `data-cy-label` / `data-cy-frame`.
+   */
+  get labelRows(): Locator {
+    return this.page
+      .getByTestId("modal")
+      .getByTestId("sidebar")
+      .locator("[data-cy^='annotate-label-']");
+  }
+
+  /** A listed label row by its class text (e.g. "approach", "vehicle"). */
+  labelRow(labelText: string): Locator {
+    return this.page
+      .getByTestId("modal")
+      .getByTestId("sidebar")
+      .locator(`[data-cy^='annotate-label-'][data-cy-label='${labelText}']`);
+  }
+
+  /** The class texts of every label row currently listed in the sidebar. */
+  async listedLabels(): Promise<string[]> {
+    return this.labelRows.evaluateAll((els) =>
+      els.map((e) => e.getAttribute("data-cy-label") ?? "")
+    );
+  }
+
+  /** Select a listed label row by its class text (opens its editor). */
+  async selectLabel(labelText: string) {
+    await this.labelRow(labelText).first().click();
+  }
+
+  /**
+   * The engine instanceId of a listed label row (read off its
+   * `data-cy=annotate-label-<id>`). For a temporal detection this is the bare
+   * `_id` — the same id the timeline encodes as `td-<field>-<id>`.
+   */
+  async labelRowId(labelText: string): Promise<string> {
+    const cy = await this.labelRow(labelText).first().getAttribute("data-cy");
+    return (cy ?? "").replace(/^annotate-label-/, "");
+  }
+
+  /**
+   * Create a temporal detection at the current playhead via the "New TD"
+   * toolbar action (a 1-second support window starting at the playhead frame).
+   */
+  async createTemporalDetection() {
+    // target the actual button — the timeline-controls wrapper is also a
+    // role="button" whose accessible name bubbles up "New TD".
+    await this.page.locator('button[aria-label="New TD"]').click();
+  }
+}
+
+class VideoAnnotateAsserter {
+  constructor(private readonly va: VideoAnnotatePom) {}
+
+  /** Assert the number of object (frame-label) tracks on the timeline. */
+  async objectTrackCount(expected: number) {
+    await expect
+      .poll(async () => (await this.va.objectTrackIds()).length)
+      .toBe(expected);
+  }
+
+  /** Assert the number of temporal-detection rows on the timeline. */
+  async temporalTrackCount(expected: number) {
+    await expect
+      .poll(async () => (await this.va.temporalTrackIds()).length)
+      .toBe(expected);
+  }
+
+  /** Assert a track with the given id is present on the timeline. */
+  async hasTrack(trackId: string, present = true) {
+    await expect
+      .poll(async () => (await this.va.trackIds()).includes(trackId))
+      .toBe(present);
+  }
+
+  /** Assert a label (by class text) is / isn't listed in the annotate sidebar. */
+  async labelListed(labelText: string, listed = true) {
+    await expect
+      .poll(async () => (await this.va.listedLabels()).includes(labelText))
+      .toBe(listed);
+  }
+
+  /** Assert the number of label rows currently listed in the annotate sidebar. */
+  async listedLabelCount(expected: number) {
+    await expect
+      .poll(async () => (await this.va.listedLabels()).length)
+      .toBe(expected);
+  }
+}

--- a/e2e-pw/src/oss/specs/MISSING-annotate-video-auto-extend.spec.ts
+++ b/e2e-pw/src/oss/specs/MISSING-annotate-video-auto-extend.spec.ts
@@ -1,0 +1,189 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ *
+ * Drawing a fresh per-frame detection box on the video-annotation surface:
+ *
+ *  - auto-extend (guards `9dbd95a6b2`): a freshly-drawn box becomes a short
+ *    track, copied forward ~30 frames as non-keyframe filler (clamped at the
+ *    clip end). Bracketed semantically via engine presence — a frame inside the
+ *    extent lists the label, a frame past it does not.
+ *  - fresh-draw form-sync (guards finding A / fcc91e013a / 94c366c562): the
+ *    moment the draw is released to the engine the edit form's field reads the
+ *    schema field `detections` (NOT the raw engine path `frames.detections`),
+ *    and the form keeps following the playhead with no deselect/reselect.
+ *
+ * Clean slate, re-seeded per test (no pre-existing tracks) so the draw is the
+ * only object track. The clip is 40 frames so the 30-frame extent isn't clamped.
+ */
+import { expect, test as base } from "src/oss/fixtures";
+import { ModalPom } from "src/oss/poms/modal";
+import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
+import type { AbstractFiftyoneLoader } from "src/shared/abstract-loader";
+import type { Page } from "src/oss/fixtures";
+
+const datasetName = getUniqueDatasetNameWithPrefix(
+  "annotate-video-auto-extend"
+);
+const id = "000000000000000000000000";
+const clip = `/tmp/${datasetName}.webm`;
+
+const test = base.extend<{ modal: ModalPom }>({
+  modal: async ({ page, eventUtils }, use) => {
+    await use(new ModalPom(page, eventUtils));
+  },
+});
+
+test.beforeAll(async ({ foWebServer, mediaFactory }) => {
+  await foWebServer.startWebServer();
+  // 40 frames @ 10fps — the 30-frame auto-extend stays clear of the clip end.
+  await mediaFactory.createVideo({
+    outputPath: clip,
+    duration: 4,
+    width: 64,
+    height: 64,
+    frameRate: 10,
+    color: "#3050a0",
+  });
+});
+
+test.afterAll(async ({ foWebServer }) => {
+  await foWebServer.stopWebServer();
+});
+
+test.beforeEach(async ({ videoAnnotateSDK }) => {
+  await videoAnnotateSDK.seed({
+    datasetName,
+    videoPaths: [clip],
+    withEvents: false,
+  });
+});
+
+const openAnnotate = async (
+  fiftyoneLoader: AbstractFiftyoneLoader,
+  modal: ModalPom,
+  page: Page
+) => {
+  await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
+    searchParams: new URLSearchParams({ id }),
+  });
+  await modal.assert.isOpen();
+  await modal.sidebar.switchMode("annotate");
+  await modal.videoAnnotate.waitForSurface();
+};
+
+/** Draw a detection box across the given relative corners (annotate mode). */
+const drawBox = async (modal: ModalPom) => {
+  await modal.sidebar.annotate.detectionMode("Detections");
+  await modal.sampleCanvas.move(0.55, 0.55, "crosshair");
+  await modal.sampleCanvas.down();
+  await modal.sampleCanvas.move(0.78, 0.78);
+  await modal.sampleCanvas.up();
+};
+
+const stepForward = async (modal: ModalPom, n: number) => {
+  for (let i = 0; i < n; i++) {
+    await modal.videoAnnotate.stepForward();
+  }
+};
+
+/** Drop focus so the "." / "," frame-step keybindings aren't typed into an input. */
+const blur = (page: Page) =>
+  page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur());
+
+test.describe.serial("video annotation fresh draw", () => {
+  test("a freshly-drawn box auto-extends ~30 frames forward as filler", async ({
+    fiftyoneLoader,
+    modal,
+    page,
+  }) => {
+    await openAnnotate(fiftyoneLoader, modal, page);
+    const va = modal.videoAnnotate;
+
+    await va.assert.objectTrackCount(0);
+    await drawBox(modal);
+    await va.assert.objectTrackCount(1);
+
+    // commit the fresh draw (a class) so it — and the auto-extended filler —
+    // enter engine presence; an uncommitted draft isn't listed in the sidebar
+    const saved = page.waitForResponse(
+      (r) =>
+        /\/sample\//.test(r.url()) &&
+        ["POST", "PATCH", "PUT"].includes(r.request().method())
+    );
+    await modal.sidebar.edit.selectFieldChoice("label", "vehicle");
+    await saved;
+    await modal.sidebar.edit.exitToList();
+    await blur(page);
+
+    // frame 1 has exactly the drawn box
+    await va.assert.listedLabelCount(1);
+
+    // frame 28 is inside the auto-extended span [1, 31] — the filler is present
+    await stepForward(modal, 27);
+    await va.assert.listedLabelCount(1);
+
+    // frame 35 is past the span — no filler there
+    await stepForward(modal, 7);
+    await va.assert.listedLabelCount(0);
+  });
+
+  test("the fresh-draw form reads the schema field and follows the playhead", async ({
+    fiftyoneLoader,
+    modal,
+    page,
+  }) => {
+    await openAnnotate(fiftyoneLoader, modal, page);
+    const va = modal.videoAnnotate;
+
+    await drawBox(modal);
+
+    // finding A: the field reads the schema field `detections` immediately —
+    // not the raw engine path `frames.detections`, and with no deselect/reselect
+    await expect
+      .poll(() => modal.sidebar.edit.getCurrentField())
+      .toBe("detections");
+
+    // committing a class keeps the form bound; the field stays `detections`
+    const saved = page.waitForResponse(
+      (r) =>
+        /\/sample\//.test(r.url()) &&
+        ["POST", "PATCH", "PUT"].includes(r.request().method())
+    );
+    await modal.sidebar.edit.selectFieldChoice("label", "vehicle");
+    await modal.sidebar.edit.assert.verifyFieldValue("label", "vehicle");
+    await saved;
+
+    // the form follows the playhead without a manual reselect: still open, still
+    // bound to the schema field on the next frame
+    await blur(page);
+    await va.stepForward();
+    await expect(modal.sidebar.edit.backButton).toBeVisible();
+    await expect
+      .poll(() => modal.sidebar.edit.getCurrentField())
+      .toBe("detections");
+  });
+
+  test("undo removes a freshly-drawn box (engine undo on video)", async ({
+    fiftyoneLoader,
+    modal,
+    page,
+  }) => {
+    await openAnnotate(fiftyoneLoader, modal, page);
+    const va = modal.videoAnnotate;
+
+    await va.assert.objectTrackCount(0);
+    await drawBox(modal);
+    await va.assert.objectTrackCount(1);
+
+    // undo/redo are enabled on the video surface (engine value-based stack). The
+    // auto-extend filler coalesces into the draw's undo unit, so a SINGLE undo
+    // removes the whole freshly-drawn track (box + filler).
+    await modal.sidebar.edit.assert.undoIsEnabled();
+    await modal.sidebar.edit.undo();
+    await va.assert.objectTrackCount(0);
+
+    // redo re-creates the whole track in one step
+    await modal.sidebar.edit.redo();
+    await va.assert.objectTrackCount(1);
+  });
+});

--- a/e2e-pw/src/oss/specs/MISSING-annotate-video-draw.spec.ts
+++ b/e2e-pw/src/oss/specs/MISSING-annotate-video-draw.spec.ts
@@ -1,0 +1,114 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ *
+ * Per-frame detection drawing on the video-annotation surface: drawing a box in
+ * detection mode adds a track to the timeline, the freshly-drawn box opens its
+ * edit form, assigning a class commits it through the engine, and the frame
+ * label survives a true round-trip (fresh browser context). Foundational
+ * coverage for video on the annotation engine.
+ */
+import { Browser, expect, test as base } from "src/oss/fixtures";
+import { ModalPom } from "src/oss/poms/modal";
+import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
+import { EventUtils } from "src/shared/event-utils";
+import type { AbstractFiftyoneLoader } from "src/shared/abstract-loader";
+
+const datasetName = getUniqueDatasetNameWithPrefix("annotate-video-draw");
+
+/** Fixed ObjectId addressing the first sample (so we can deep-link the modal). */
+const id = "000000000000000000000000";
+const clip = `/tmp/${datasetName}.webm`;
+
+const test = base.extend<{ modal: ModalPom }>({
+  modal: async ({ page, eventUtils }, use) => {
+    await use(new ModalPom(page, eventUtils));
+  },
+});
+
+test.beforeAll(async ({ foWebServer, mediaFactory, videoAnnotateSDK }) => {
+  await foWebServer.startWebServer();
+  await mediaFactory.createVideo({
+    outputPath: clip,
+    duration: 2,
+    width: 64,
+    height: 64,
+    frameRate: 10,
+    color: "#3050a0",
+  });
+  // clean slate (no pre-seeded tracks): drawing is the only object track.
+  await videoAnnotateSDK.seed({ datasetName, videoPaths: [clip] });
+});
+
+test.afterAll(async ({ foWebServer }) => {
+  await foWebServer.stopWebServer();
+});
+
+/** Open the modal in annotate mode on the deep-linked video sample. */
+const openAnnotate = async (
+  fiftyoneLoader: AbstractFiftyoneLoader,
+  modal: ModalPom,
+  page: import("src/oss/fixtures").Page
+) => {
+  await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
+    searchParams: new URLSearchParams({ id }),
+  });
+  await modal.assert.isOpen();
+  await modal.sidebar.switchMode("annotate");
+  await modal.videoAnnotate.waitForSurface();
+};
+
+/** Verify persisted state from a brand-new browser context (true round-trip). */
+const inFreshContext = async (
+  browser: Browser,
+  fiftyoneLoader: AbstractFiftyoneLoader,
+  verify: (modal: ModalPom) => Promise<void>
+) => {
+  const context = await browser.newContext();
+  const freshPage = await context.newPage();
+  try {
+    const freshModal = new ModalPom(freshPage, new EventUtils(freshPage));
+    await openAnnotate(fiftyoneLoader, freshModal, freshPage);
+    await verify(freshModal);
+  } finally {
+    await context.close();
+  }
+};
+
+test.describe.serial("video per-frame detection drawing", () => {
+  test("drawing a box adds a timeline track, opens its editor, and persists", async ({
+    browser,
+    fiftyoneLoader,
+    modal,
+    page,
+  }) => {
+    await openAnnotate(fiftyoneLoader, modal, page);
+
+    // clean slate: no object tracks yet
+    await modal.videoAnnotate.assert.objectTrackCount(0);
+
+    // draw a box in detection mode
+    await modal.sidebar.annotate.detectionMode("Detections");
+    await modal.sampleCanvas.move(0.55, 0.55);
+    await modal.sampleCanvas.down();
+    await modal.sampleCanvas.move(0.78, 0.78);
+    await modal.sampleCanvas.up();
+
+    // the draw creates exactly one object track on the timeline
+    await modal.videoAnnotate.assert.objectTrackCount(1);
+
+    // the freshly-drawn box opens its edit form; assigning a class commits it
+    const saved = page.waitForResponse(
+      (r) =>
+        /\/sample\//.test(r.url()) &&
+        ["POST", "PATCH", "PUT"].includes(r.request().method())
+    );
+    await modal.sidebar.edit.selectFieldChoice("label", "vehicle");
+    await modal.sidebar.edit.assert.verifyFieldValue("label", "vehicle");
+    await saved;
+
+    // the frame label survives a true round-trip
+    await inFreshContext(browser, fiftyoneLoader, async (freshModal) => {
+      await freshModal.videoAnnotate.assert.objectTrackCount(1);
+    });
+  });
+});

--- a/e2e-pw/src/oss/specs/MISSING-annotate-video-navigation.spec.ts
+++ b/e2e-pw/src/oss/specs/MISSING-annotate-video-navigation.spec.ts
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ *
+ * Paging between video samples on the annotation surface. Regression guard for
+ * the next/prev "a store for sample X is already registered" crash: on a sample
+ * switch the 3D-scene store registration raced the video surface's own store
+ * while the modal id was settling. Paging forward then back must re-home the
+ * engine store cleanly — the surface re-renders each sample's own track and no
+ * duplicate-store error is thrown.
+ *
+ * The modal is opened from the GRID (not a deep link) so it carries the sample
+ * sequence — a deep-linked single sample has no next/previous sibling.
+ */
+import { expect, test as base } from "src/oss/fixtures";
+import { GridPom } from "src/oss/poms/grid";
+import { ModalPom } from "src/oss/poms/modal";
+import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
+
+const datasetName = getUniqueDatasetNameWithPrefix("annotate-video-nav");
+const clip0 = `/tmp/${datasetName}-0.webm`;
+const clip1 = `/tmp/${datasetName}-1.webm`;
+
+const test = base.extend<{ grid: GridPom; modal: ModalPom }>({
+  grid: async ({ page, eventUtils }, use) => use(new GridPom(page, eventUtils)),
+  modal: async ({ page, eventUtils }, use) =>
+    use(new ModalPom(page, eventUtils)),
+});
+
+test.beforeAll(async ({ foWebServer, mediaFactory, videoAnnotateSDK }) => {
+  await foWebServer.startWebServer();
+  await mediaFactory.createVideo({
+    outputPath: clip0,
+    duration: 2,
+    width: 64,
+    height: 64,
+    frameRate: 10,
+    color: "#3050a0",
+  });
+  await mediaFactory.createVideo({
+    outputPath: clip1,
+    duration: 2,
+    width: 64,
+    height: 64,
+    frameRate: 10,
+    color: "#a05030",
+  });
+  // both samples carry their own tracked instance, so the object track id
+  // differs between samples — a reliable "the surface switched" signal.
+  await videoAnnotateSDK.seed({
+    datasetName,
+    videoPaths: [clip0, clip1],
+    trackedSampleIndices: [0, 1],
+  });
+});
+
+test.afterAll(async ({ foWebServer }) => {
+  await foWebServer.stopWebServer();
+});
+
+test.describe.serial("video annotation sample navigation", () => {
+  test("paging next then prev re-homes the store without a duplicate-store crash", async ({
+    fiftyoneLoader,
+    grid,
+    modal,
+    page,
+  }) => {
+    const storeErrors: string[] = [];
+    page.on("pageerror", (e) => {
+      if (/store|registered/i.test(e.message)) storeErrors.push(e.message);
+    });
+
+    // open the modal from the grid so it carries the sample sequence
+    await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
+      withGrid: true,
+    });
+    await grid.openFirstSample();
+    await modal.assert.isOpen();
+    await modal.sidebar.switchMode("annotate");
+    await modal.videoAnnotate.waitForSurface();
+
+    const va = modal.videoAnnotate;
+    await va.assert.objectTrackCount(1);
+    const [firstTrack] = await va.objectTrackIds();
+
+    // page forward to the next video sample (ArrowRight = ModalNextSample)
+    await page.keyboard.press("ArrowRight");
+    await expect
+      .poll(async () => {
+        const ids = await va.objectTrackIds();
+        return ids.length === 1 && ids[0] !== firstTrack;
+      })
+      .toBe(true);
+    await va.waitForSurface();
+    const [secondTrack] = await va.objectTrackIds();
+
+    // page back to the first sample
+    await page.keyboard.press("ArrowLeft");
+    await expect
+      .poll(async () => {
+        const ids = await va.objectTrackIds();
+        return ids.length === 1 && ids[0] === firstTrack;
+      })
+      .toBe(true);
+    await va.waitForSurface();
+
+    expect(secondTrack).not.toBe(firstTrack);
+    // no "a store for sample X is already registered" (or similar) was thrown
+    expect(storeErrors).toEqual([]);
+  });
+});

--- a/e2e-pw/src/oss/specs/MISSING-annotate-video-temporal-crud.spec.ts
+++ b/e2e-pw/src/oss/specs/MISSING-annotate-video-temporal-crud.spec.ts
@@ -1,0 +1,194 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ *
+ * Temporal-detection (TD) create / edit / delete on the video-annotation
+ * surface, all engine-routed:
+ *
+ *  - create + edit: the "New TD" toolbar action mints a sample-level TD at the
+ *    playhead; selecting it opens the editor and a class assigns through the
+ *    engine and persists.
+ *  - mid-list delete id-preservation (guards step-4 `idAlignedListDelta`):
+ *    deleting the MIDDLE of three TDs must not renumber/rewrite the siblings.
+ *    The sample-level list diff is id-aligned, so the surviving two keep their
+ *    exact `_id`s and labels across a true round-trip (fresh browser context).
+ *    The regression this guards rewrote a sibling's `_id` on a mid-list delete.
+ *
+ * Seeded with the three demo events (approach [1,6] / pass [7,13] /
+ * depart [14,20] over a 20-frame clip), re-seeded per test for isolation.
+ */
+import { Browser, expect, test as base } from "src/oss/fixtures";
+import { ModalPom } from "src/oss/poms/modal";
+import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
+import { EventUtils } from "src/shared/event-utils";
+import type { AbstractFiftyoneLoader } from "src/shared/abstract-loader";
+import type { Page } from "src/oss/fixtures";
+
+const datasetName = getUniqueDatasetNameWithPrefix("annotate-video-td-crud");
+const id = "000000000000000000000000";
+const clip = `/tmp/${datasetName}.webm`;
+
+const test = base.extend<{ modal: ModalPom }>({
+  modal: async ({ page, eventUtils }, use) => {
+    await use(new ModalPom(page, eventUtils));
+  },
+});
+
+/**
+ * Engine-purity guard: deleting a TD must not write back to the engine from a
+ * `lighter:overlay-removed` subscriber (the DispatchGuard throws "setActive was
+ * called from within a subscriber"). Collect such violations to assert none.
+ */
+const collectEngineErrors = (page: Page): string[] => {
+  const out: string[] = [];
+  const keep = (t: string) => {
+    if (/within a subscriber|setActive|DispatchGuard/.test(t)) out.push(t);
+  };
+  page.on("pageerror", (e) => keep(e.message));
+  page.on("console", (m) => {
+    if (m.type() === "error") keep(m.text());
+  });
+  return out;
+};
+
+test.beforeAll(async ({ foWebServer, mediaFactory }) => {
+  await foWebServer.startWebServer();
+  await mediaFactory.createVideo({
+    outputPath: clip,
+    duration: 2,
+    width: 64,
+    height: 64,
+    frameRate: 10,
+    color: "#3050a0",
+  });
+});
+
+test.afterAll(async ({ foWebServer }) => {
+  await foWebServer.stopWebServer();
+});
+
+test.beforeEach(async ({ videoAnnotateSDK }) => {
+  // three TDs: approach [1,6], pass [7,13], depart [14,20].
+  await videoAnnotateSDK.seed({ datasetName, videoPaths: [clip] });
+});
+
+const openAnnotate = async (
+  fiftyoneLoader: AbstractFiftyoneLoader,
+  modal: ModalPom,
+  page: Page
+) => {
+  await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
+    searchParams: new URLSearchParams({ id }),
+  });
+  await modal.assert.isOpen();
+  await modal.sidebar.switchMode("annotate");
+  await modal.videoAnnotate.waitForSurface();
+};
+
+const savedResponse = (page: Page) =>
+  page.waitForResponse(
+    (r) =>
+      /\/sample\//.test(r.url()) &&
+      ["POST", "PATCH", "PUT", "DELETE"].includes(r.request().method())
+  );
+
+const stepForward = async (modal: ModalPom, n: number) => {
+  for (let i = 0; i < n; i++) {
+    await modal.videoAnnotate.stepForward();
+  }
+};
+
+test.describe.serial("video annotation temporal detection CRUD", () => {
+  test("New TD creates a temporal detection, a class edit persists", async ({
+    browser,
+    fiftyoneLoader,
+    modal,
+    page,
+  }) => {
+    await openAnnotate(fiftyoneLoader, modal, page);
+    const va = modal.videoAnnotate;
+
+    await va.assert.temporalTrackCount(3);
+    const before = new Set(await va.temporalTrackIds());
+
+    // mint a TD at the playhead (frame 1 -> support [1, 11])
+    await va.createTemporalDetection();
+    await va.assert.temporalTrackCount(4);
+
+    // find the new TD row and open its editor from the timeline
+    const newTrack = (await va.temporalTrackIds()).find((t) => !before.has(t));
+    expect(newTrack).toBeTruthy();
+
+    const saved = savedResponse(page);
+    await va.clickTrack(newTrack as string);
+    await expect(modal.sidebar.edit.backButton).toBeVisible();
+    await modal.sidebar.edit.selectFieldChoice("label", "depart");
+    await modal.sidebar.edit.assert.verifyFieldValue("label", "depart");
+    await saved;
+
+    // the create + class survive a true round-trip
+    const context = await browser.newContext();
+    const freshPage = await context.newPage();
+    try {
+      const m2 = new ModalPom(freshPage, new EventUtils(freshPage));
+      await openAnnotate(fiftyoneLoader, m2, freshPage);
+      await m2.videoAnnotate.assert.temporalTrackCount(4);
+    } finally {
+      await context.close();
+    }
+  });
+
+  test("deleting the middle TD preserves the siblings' ids and labels", async ({
+    browser,
+    fiftyoneLoader,
+    modal,
+    page,
+  }) => {
+    const engineErrors = collectEngineErrors(page);
+    await openAnnotate(fiftyoneLoader, modal, page);
+    const va = modal.videoAnnotate;
+
+    await va.assert.temporalTrackCount(3);
+    const beforeIds = await va.temporalTrackIds();
+
+    // step into the "pass" third [7,13] and target the middle TD
+    await stepForward(modal, 7);
+    await va.assert.labelListed("pass");
+    const deletedId = await va.labelRowId("pass");
+    const expectedIds = beforeIds.filter((t) => !t.endsWith(deletedId)).sort();
+    expect(expectedIds).toHaveLength(2);
+
+    // delete it through the editor (engine delete -> id-aligned list diff)
+    const saved = savedResponse(page);
+    await va.selectLabel("pass");
+    await expect(modal.sidebar.edit.backButton).toBeVisible();
+    await modal.sidebar.edit.deleteLabel();
+    await saved;
+
+    await va.assert.temporalTrackCount(2);
+    expect((await va.temporalTrackIds()).sort()).toEqual(expectedIds);
+
+    // deleting the open-in-editor TD must not write to the engine from the
+    // `overlay-removed` subscriber (engine-purity DispatchGuard)
+    expect(engineErrors).toEqual([]);
+
+    // the round-trip is the real guard: the surviving two keep IDENTICAL ids
+    // (a mid-list delete must not rewrite a sibling's _id) and their labels.
+    const context = await browser.newContext();
+    const freshPage = await context.newPage();
+    try {
+      const m2 = new ModalPom(freshPage, new EventUtils(freshPage));
+      const va2 = m2.videoAnnotate;
+      await openAnnotate(fiftyoneLoader, m2, freshPage);
+      await va2.assert.temporalTrackCount(2);
+      expect((await va2.temporalTrackIds()).sort()).toEqual(expectedIds);
+
+      // labels intact: approach at frame 1, depart in its third; no "pass"
+      await va2.assert.labelListed("approach");
+      await stepForward(m2, 13);
+      await va2.assert.labelListed("depart");
+      await va2.assert.labelListed("pass", false);
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/e2e-pw/src/oss/specs/MISSING-annotate-video-temporal.spec.ts
+++ b/e2e-pw/src/oss/specs/MISSING-annotate-video-temporal.spec.ts
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ *
+ * Temporal-detection (TD) membership on the video-annotation surface: the
+ * annotate sidebar lists a sample-level TD only while the playhead is inside
+ * that TD's `support` span (support-gated engine presence), and re-derives as
+ * the playhead moves. The three seeded events (approach / pass / depart) split
+ * the clip into thirds, so each is listed only within its own third.
+ */
+import { test as base } from "src/oss/fixtures";
+import { ModalPom } from "src/oss/poms/modal";
+import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
+import type { AbstractFiftyoneLoader } from "src/shared/abstract-loader";
+
+const datasetName = getUniqueDatasetNameWithPrefix("annotate-video-temporal");
+const id = "000000000000000000000000";
+const clip = `/tmp/${datasetName}.webm`;
+
+const test = base.extend<{ modal: ModalPom }>({
+  modal: async ({ page, eventUtils }, use) => {
+    await use(new ModalPom(page, eventUtils));
+  },
+});
+
+test.beforeAll(async ({ foWebServer, mediaFactory, videoAnnotateSDK }) => {
+  await foWebServer.startWebServer();
+  await mediaFactory.createVideo({
+    outputPath: clip,
+    duration: 2,
+    width: 64,
+    height: 64,
+    frameRate: 10,
+    color: "#3050a0",
+  });
+  // 20 frames @ 10fps; events split into thirds:
+  // approach [1,6], pass [7,13], depart [14,20].
+  await videoAnnotateSDK.seed({ datasetName, videoPaths: [clip] });
+});
+
+test.afterAll(async ({ foWebServer }) => {
+  await foWebServer.stopWebServer();
+});
+
+const openAnnotate = async (
+  fiftyoneLoader: AbstractFiftyoneLoader,
+  modal: ModalPom,
+  page: import("src/oss/fixtures").Page
+) => {
+  await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
+    searchParams: new URLSearchParams({ id }),
+  });
+  await modal.assert.isOpen();
+  await modal.sidebar.switchMode("annotate");
+  await modal.videoAnnotate.waitForSurface();
+};
+
+test.describe.serial("video temporal-detection membership", () => {
+  test("the sidebar lists a temporal detection only inside its support", async ({
+    fiftyoneLoader,
+    modal,
+    page,
+  }) => {
+    await openAnnotate(fiftyoneLoader, modal, page);
+
+    const va = modal.videoAnnotate;
+
+    // three TD interval rows on the timeline regardless of the playhead
+    await va.assert.temporalTrackCount(3);
+
+    const stepForward = async (n: number) => {
+      for (let i = 0; i < n; i++) {
+        await va.stepForward();
+      }
+    };
+
+    // initial frame is inside "approach" [1,6]
+    await va.assert.labelListed("approach");
+    await va.assert.labelListed("pass", false);
+    await va.assert.labelListed("depart", false);
+
+    // step into the "pass" third [7,13]
+    await stepForward(8);
+    await va.assert.labelListed("pass");
+    await va.assert.labelListed("approach", false);
+    await va.assert.labelListed("depart", false);
+
+    // step into the "depart" third [14,20]
+    await stepForward(8);
+    await va.assert.labelListed("depart");
+    await va.assert.labelListed("pass", false);
+    await va.assert.labelListed("approach", false);
+  });
+});

--- a/e2e-pw/src/oss/specs/MISSING-annotate-video-track-delete.spec.ts
+++ b/e2e-pw/src/oss/specs/MISSING-annotate-video-track-delete.spec.ts
@@ -1,0 +1,115 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ *
+ * Whole-track delete on the video-annotation surface. The sidebar / keyboard
+ * delete is PER-FRAME (it removes only the current frame's instance — the track
+ * persists on other frames). Deleting an entire track is the timeline track's
+ * right-click context menu → "Delete track", which removes the instance's label
+ * on every frame in one engine transaction. The removal survives a true
+ * round-trip (fresh browser context) via autosave.
+ */
+import { Browser, expect, test as base } from "src/oss/fixtures";
+import { ModalPom } from "src/oss/poms/modal";
+import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
+import { EventUtils } from "src/shared/event-utils";
+import type { AbstractFiftyoneLoader } from "src/shared/abstract-loader";
+import type { Page } from "src/oss/fixtures";
+
+const datasetName = getUniqueDatasetNameWithPrefix(
+  "annotate-video-track-delete"
+);
+const id = "000000000000000000000000";
+const clip = `/tmp/${datasetName}.webm`;
+
+const test = base.extend<{ modal: ModalPom }>({
+  modal: async ({ page, eventUtils }, use) => {
+    await use(new ModalPom(page, eventUtils));
+  },
+});
+
+test.beforeAll(async ({ foWebServer, mediaFactory }) => {
+  await foWebServer.startWebServer();
+  await mediaFactory.createVideo({
+    outputPath: clip,
+    duration: 2,
+    width: 64,
+    height: 64,
+    frameRate: 10,
+    color: "#3050a0",
+  });
+});
+
+test.afterAll(async ({ foWebServer }) => {
+  await foWebServer.stopWebServer();
+});
+
+test.beforeEach(async ({ videoAnnotateSDK }) => {
+  // one tracked vehicle (index=1) on every frame; no TDs to keep the timeline
+  // to a single object track.
+  await videoAnnotateSDK.seed({
+    datasetName,
+    videoPaths: [clip],
+    withEvents: false,
+    trackedSampleIndices: [0],
+  });
+});
+
+const openAnnotate = async (
+  fiftyoneLoader: AbstractFiftyoneLoader,
+  modal: ModalPom,
+  page: Page
+) => {
+  await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
+    searchParams: new URLSearchParams({ id }),
+  });
+  await modal.assert.isOpen();
+  await modal.sidebar.switchMode("annotate");
+  await modal.videoAnnotate.waitForSurface();
+};
+
+const stepForward = async (modal: ModalPom, n: number) => {
+  for (let i = 0; i < n; i++) await modal.videoAnnotate.stepForward();
+};
+
+test.describe.serial("video annotation whole-track delete", () => {
+  test("right-click Delete track removes the instance from every frame and persists", async ({
+    browser,
+    fiftyoneLoader,
+    modal,
+    page,
+  }) => {
+    await openAnnotate(fiftyoneLoader, modal, page);
+    const va = modal.videoAnnotate;
+
+    await va.assert.objectTrackCount(1);
+    await va.assert.labelListed("vehicle");
+    const [trackId] = await va.objectTrackIds();
+
+    // delete the whole track via the timeline context menu; autosave persists it
+    const saved = page.waitForResponse(
+      (r) =>
+        /\/sample\//.test(r.url()) &&
+        ["POST", "PATCH", "PUT"].includes(r.request().method())
+    );
+    await va.deleteTrackViaContextMenu(trackId);
+    await va.assert.objectTrackCount(0);
+    await saved;
+
+    // gone from frame 1 and from a later frame (the WHOLE track, not one frame)
+    await va.assert.labelListed("vehicle", false);
+    await stepForward(modal, 9);
+    await va.assert.labelListed("vehicle", false);
+
+    // the whole-track delete survives a true round-trip
+    const context = await browser.newContext();
+    const freshPage = await context.newPage();
+    try {
+      const m2 = new ModalPom(freshPage, new EventUtils(freshPage));
+      await openAnnotate(fiftyoneLoader, m2, freshPage);
+      await m2.videoAnnotate.assert.objectTrackCount(0);
+      await m2.videoAnnotate.assert.labelListed("vehicle", false);
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/e2e-pw/src/oss/specs/MISSING-annotate-video-track-edit.spec.ts
+++ b/e2e-pw/src/oss/specs/MISSING-annotate-video-track-edit.spec.ts
@@ -1,0 +1,224 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ *
+ * Editing an existing per-frame detection track on the video-annotation surface,
+ * all through the annotation engine:
+ *
+ *  - track-wide fan-out (guards `trackFanOut` / 26cdd69308): a class edit on one
+ *    frame fans across every frame of the instance, while geometry
+ *    (`bounding_box`) stays per-frame.
+ *  - anchor-follows-playhead (guards `d50221164d`): with a track selected, the
+ *    edit form re-reads that track's data at each new frame as the playhead
+ *    moves — it does NOT freeze on the selection frame's values or deselect.
+ *  - selection sync: the canvas, the timeline row, and the sidebar row all drive
+ *    the one shared engine selection, so selecting on any surface opens the
+ *    editor on the same track.
+ *
+ * The dataset is re-seeded per test (one tracked instance, class `vehicle`,
+ * `bounding_box=[0.3,0.3,0.2,0.2]` on every frame) so a persisting edit in one
+ * test can't leak into the next.
+ */
+import { expect, test as base } from "src/oss/fixtures";
+import { ModalPom } from "src/oss/poms/modal";
+import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
+import type { AbstractFiftyoneLoader } from "src/shared/abstract-loader";
+import type { Page } from "src/oss/fixtures";
+
+const datasetName = getUniqueDatasetNameWithPrefix("annotate-video-track-edit");
+const id = "000000000000000000000000";
+const clip = `/tmp/${datasetName}.webm`;
+
+const test = base.extend<{ modal: ModalPom }>({
+  modal: async ({ page, eventUtils }, use) => {
+    await use(new ModalPom(page, eventUtils));
+  },
+});
+
+test.beforeAll(async ({ foWebServer, mediaFactory }) => {
+  await foWebServer.startWebServer();
+  // 20 frames @ 10fps — long enough to step several frames off the start.
+  await mediaFactory.createVideo({
+    outputPath: clip,
+    duration: 2,
+    width: 64,
+    height: 64,
+    frameRate: 10,
+    color: "#3050a0",
+  });
+});
+
+test.afterAll(async ({ foWebServer }) => {
+  await foWebServer.stopWebServer();
+});
+
+const openAnnotate = async (
+  fiftyoneLoader: AbstractFiftyoneLoader,
+  modal: ModalPom,
+  page: Page
+) => {
+  await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
+    searchParams: new URLSearchParams({ id }),
+  });
+  await modal.assert.isOpen();
+  await modal.sidebar.switchMode("annotate");
+  await modal.videoAnnotate.waitForSurface();
+};
+
+/** Read a numeric edit-form field value (the sidebar shows relative [0,1]). */
+const fieldNum = async (modal: ModalPom, path: string) =>
+  Number(await modal.sidebar.edit.getFieldValue(path));
+
+/** Drop focus so the "." / "," frame-step keybindings aren't typed into an input. */
+const blur = (page: Page) =>
+  page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur());
+
+/** Await the autosave round-trip for the edited sample. */
+const savedResponse = (page: Page) =>
+  page.waitForResponse(
+    (r) =>
+      /\/sample\//.test(r.url()) &&
+      ["POST", "PATCH", "PUT"].includes(r.request().method())
+  );
+
+// re-seed per test: one tracked instance (vehicle, index=1) on every frame.
+test.beforeEach(async ({ videoAnnotateSDK }) => {
+  await videoAnnotateSDK.seed({
+    datasetName,
+    videoPaths: [clip],
+    withEvents: false,
+    trackedSampleIndices: [0],
+  });
+});
+
+test.describe.serial("video annotation track editing", () => {
+  test("a class edit fans across the track while geometry stays per-frame", async ({
+    fiftyoneLoader,
+    modal,
+    page,
+  }) => {
+    await openAnnotate(fiftyoneLoader, modal, page);
+    const va = modal.videoAnnotate;
+
+    // the seeded track is the only object track; it shows as "vehicle" on frame 1
+    await va.assert.objectTrackCount(1);
+    await va.assert.labelListed("vehicle");
+    await va.selectLabel("vehicle");
+
+    // per-frame geometry edit on frame 1 (bounding_box is NOT fanned out)
+    await modal.sidebar.edit.setFieldValue("position.x", "0.5");
+    await expect.poll(() => fieldNum(modal, "position.x")).toBeCloseTo(0.5, 4);
+
+    // track-level class edit — fans across every frame of the instance
+    const saved = savedResponse(page);
+    await modal.sidebar.edit.selectFieldChoice("label", "person");
+    await modal.sidebar.edit.assert.verifyFieldValue("label", "person");
+    await saved;
+
+    // step well off the edited frame and re-select the (now "person") track
+    await modal.sidebar.edit.exitToList();
+    for (let i = 0; i < 5; i++) {
+      await va.stepForward();
+    }
+
+    // the class fanned out: frame 6 lists "person", not "vehicle"
+    await va.assert.labelListed("person");
+    await va.assert.labelListed("vehicle", false);
+
+    // but geometry did NOT fan out: frame 6 keeps the seeded x (0.3), not 0.5
+    await va.selectLabel("person");
+    await expect.poll(() => fieldNum(modal, "position.x")).toBeCloseTo(0.3, 4);
+  });
+
+  test("the edit form follows the selected track across frames", async ({
+    fiftyoneLoader,
+    modal,
+    page,
+  }) => {
+    await openAnnotate(fiftyoneLoader, modal, page);
+    const va = modal.videoAnnotate;
+
+    await va.selectLabel("vehicle");
+
+    // make frame 1 geometrically distinct from the rest of the track
+    await modal.sidebar.edit.setFieldValue("position.x", "0.5");
+    await expect.poll(() => fieldNum(modal, "position.x")).toBeCloseTo(0.5, 4);
+
+    // step forward: the form follows the anchor to frame 2's detection, so it
+    // shows that frame's x (still the seeded 0.3) — NOT frame 1's edited 0.5,
+    // and NOT a closed/blank form. Blur first so "." steps the frame instead of
+    // typing into the focused number input.
+    await blur(page);
+    await va.stepForward();
+    await expect(modal.sidebar.edit.backButton).toBeVisible();
+    await expect.poll(() => fieldNum(modal, "position.x")).toBeCloseTo(0.3, 4);
+
+    // step back: the form re-reads frame 1, where the edit lives
+    await blur(page);
+    await va.stepBack();
+    await expect.poll(() => fieldNum(modal, "position.x")).toBeCloseTo(0.5, 4);
+  });
+
+  test("geometry edits undo and redo through the engine stack", async ({
+    fiftyoneLoader,
+    modal,
+    page,
+  }) => {
+    // undo/redo are enabled on the video surface (engine value-based stack)
+    await openAnnotate(fiftyoneLoader, modal, page);
+
+    await modal.videoAnnotate.selectLabel("vehicle");
+    const before = await fieldNum(modal, "position.x");
+    await modal.sidebar.edit.assert.undoIsEnabled(false);
+
+    // commit a geometry edit; undo becomes enabled
+    await modal.sidebar.edit.setFieldValue("position.x", "0.1");
+    await expect.poll(() => fieldNum(modal, "position.x")).toBeCloseTo(0.1, 4);
+    await modal.sidebar.edit.assert.undoIsEnabled();
+
+    // undo reverts to the committed baseline; redo re-applies
+    await modal.sidebar.edit.undo();
+    await expect
+      .poll(() => fieldNum(modal, "position.x"))
+      .toBeCloseTo(before, 4);
+
+    await modal.sidebar.edit.redo();
+    await expect.poll(() => fieldNum(modal, "position.x")).toBeCloseTo(0.1, 4);
+
+    // restore baseline for any sibling
+    await modal.sidebar.edit.undo();
+    await expect
+      .poll(() => fieldNum(modal, "position.x"))
+      .toBeCloseTo(before, 4);
+  });
+
+  test("selecting on the canvas, timeline, and sidebar all open the same editor", async ({
+    fiftyoneLoader,
+    modal,
+    page,
+  }) => {
+    await openAnnotate(fiftyoneLoader, modal, page);
+    const va = modal.videoAnnotate;
+
+    await va.assert.objectTrackCount(1);
+    const [trackId] = await va.objectTrackIds();
+
+    // sidebar row -> editor
+    await va.selectLabel("vehicle");
+    await expect(modal.sidebar.edit.backButton).toBeVisible();
+    await modal.sidebar.edit.assert.verifyFieldValue("label", "vehicle");
+    await modal.sidebar.edit.exitToList();
+
+    // timeline row -> editor (same shared engine selection)
+    await va.clickTrack(trackId);
+    await expect(modal.sidebar.edit.backButton).toBeVisible();
+    await modal.sidebar.edit.assert.verifyFieldValue("label", "vehicle");
+    await modal.sidebar.edit.exitToList();
+
+    // canvas overlay -> editor (the seeded box centers near 0.4,0.4 in relative
+    // container coords; hover until the overlay's "pointer" cursor registers)
+    await modal.sampleCanvas.move(0.4, 0.4, "pointer");
+    await modal.sampleCanvas.click(0.4, 0.4);
+    await expect(modal.sidebar.edit.backButton).toBeVisible();
+    await modal.sidebar.edit.assert.verifyFieldValue("label", "vehicle");
+  });
+});


### PR DESCRIPTION
## What

Playwright end-to-end coverage for the engine video-annotation surface, plus the offline seeding fixture and page objects it needs.

Stacked PR **3 of 3** (base: `feat/anno-engine-video-surface`):
1. `feat/anno-engine-frame-store` — frame engine + foundation
2. `feat/anno-engine-video-surface` — the package + modal mount
3. **`test/anno-engine-video-e2e`** ← this PR — Playwright coverage

## Changes

- **Fixture** — `VideoAnnotateSDK.seed()`: a deterministic, fully **offline** video dataset (mediaFactory webm, no zoo download) with forced-stable sample ids, per-frame `Detections`, and a temporal-detection schema.
- **Page objects** — `VideoAnnotatePom` (timeline track ids, frame stepping, label rows) wired in as `modal.videoAnnotate`, plus a `deleteLabel()` affordance on the annotate-edit POM.
- **Specs** — draw → track → class → fresh-context persist; temporal-detection support gating; sample next/prev (no duplicate-store crash); temporal-detection create/edit/delete; track delete via the timeline context menu; track-wide attribute editing; freshly-drawn box auto-extend.

## Notes

- Harness facts (frame stepping is keyboard `.` / `,`; sample nav requires opening from the grid; timeline rows carry `data-track-id`) are documented inline in the POM.
- Depends on PRs 1 and 2.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end test coverage for video annotation features, including detection drawing, temporal event management, track editing and deletion, sample navigation, undo/redo functionality, and auto-extend behavior.
  * Introduced test fixtures and page object models to support video annotation testing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->