### PR TITLE
Fix/3d edits

### DIFF
--- a/app/packages/annotation/src/hooks/useGetVersionToken.ts
+++ b/app/packages/annotation/src/hooks/useGetVersionToken.ts
@@ -1,4 +1,4 @@
-import { useModalSample } from "@fiftyone/state";
+import { useActiveModalSample } from "@fiftyone/state";
 import { useCallback } from "react";
 import type { Sample } from "@fiftyone/looker";
 import { getSampleVersionToken } from "../util";
@@ -20,5 +20,5 @@ export const useGetVersionTokenWith = ({
  * Hook which returns a version token getter for the current modal sample.
  */
 export const useGetVersionToken = (): (() => string | null) => {
-  return useGetVersionTokenWith({ sample: useModalSample()?.sample });
+  return useGetVersionTokenWith({ sample: useActiveModalSample() });
 };

--- a/app/packages/annotation/src/hooks/useLabelPersistence.test.ts
+++ b/app/packages/annotation/src/hooks/useLabelPersistence.test.ts
@@ -7,7 +7,7 @@ vi.mock("../util", () => ({
 
 vi.mock("@fiftyone/state", () => ({
   isGeneratedView: { key: "isGeneratedView" },
-  useModalSample: vi.fn(),
+  useActiveModalSample: vi.fn(),
 }));
 
 vi.mock("recoil", () => ({
@@ -19,7 +19,7 @@ vi.mock("./usePatchSample", () => ({
 }));
 
 import { handleLabelPersistence } from "../util";
-import { useModalSample, isGeneratedView } from "@fiftyone/state";
+import { useActiveModalSample, isGeneratedView } from "@fiftyone/state";
 import { useRecoilValue } from "recoil";
 import { usePatchSample } from "./usePatchSample";
 import { useUpsertLabel, useDeleteLabel } from "./useLabelPersistence";
@@ -43,7 +43,7 @@ describe("useUpsertLabel / useDeleteLabel", () => {
     mockApplyPatch = vi.fn().mockResolvedValue(true);
 
     vi.mocked(useRecoilValue).mockReturnValue(false);
-    vi.mocked(useModalSample).mockReturnValue({ sample: SAMPLE } as any);
+    vi.mocked(useActiveModalSample).mockReturnValue(SAMPLE as any);
     vi.mocked(usePatchSample).mockReturnValue(mockApplyPatch);
     vi.mocked(handleLabelPersistence).mockResolvedValue(true);
   });

--- a/app/packages/annotation/src/hooks/useLabelPersistence.ts
+++ b/app/packages/annotation/src/hooks/useLabelPersistence.ts
@@ -1,6 +1,6 @@
 import type { Field } from "@fiftyone/utilities";
 import { useCallback } from "react";
-import { isGeneratedView, useModalSample } from "@fiftyone/state";
+import { isGeneratedView, useActiveModalSample } from "@fiftyone/state";
 import { useRecoilValue } from "recoil";
 import { usePatchSample } from "./usePatchSample";
 import { handleLabelPersistence, type LabelPersistenceArgs } from "../util";
@@ -48,7 +48,7 @@ export const useUpsertLabel = (): ((
   const isGenerated = useRecoilValue(isGeneratedView);
 
   return useLabelPersistenceWith({
-    sample: useModalSample()?.sample,
+    sample: useActiveModalSample(),
     applyPatch: usePatchSample(),
     opType: "mutate",
     isGenerated,
@@ -66,7 +66,7 @@ export const useDeleteLabel = (): ((
   const isGenerated = useRecoilValue(isGeneratedView);
 
   return useLabelPersistenceWith({
-    sample: useModalSample()?.sample,
+    sample: useActiveModalSample(),
     applyPatch: usePatchSample(),
     opType: "delete",
     isGenerated,

--- a/app/packages/annotation/src/hooks/usePatchSample.ts
+++ b/app/packages/annotation/src/hooks/usePatchSample.ts
@@ -1,8 +1,8 @@
 import {
   generatedDatasetName as generatedDatasetNameAtom,
   isGeneratedView,
+  useActiveModalSample,
   useCurrentDatasetId,
-  useModalSample,
   useRefreshSample,
 } from "@fiftyone/state";
 import { useCallback } from "react";
@@ -80,7 +80,7 @@ export const usePatchSample = (): ((
   const generatedDatasetName = useRecoilValue(generatedDatasetNameAtom);
 
   return usePatchSampleWith({
-    sample: useModalSample()?.sample,
+    sample: useActiveModalSample(),
     datasetId: useCurrentDatasetId(),
     getVersionToken: useGetVersionToken(),
     refreshSample: useRefreshSample(),

--- a/app/packages/annotation/src/persistence/useGetLabelDelta.ts
+++ b/app/packages/annotation/src/persistence/useGetLabelDelta.ts
@@ -1,7 +1,7 @@
 import type { JSONDeltas } from "@fiftyone/core";
 import {
   isGeneratedView,
-  useModalSample,
+  useActiveModalSample,
   useModalSampleSchema,
 } from "@fiftyone/state";
 import type { Field } from "@fiftyone/utilities";
@@ -70,13 +70,13 @@ export const useGetLabelDelta = <T>(
   options: UseGetLabelDeltaOptions = {}
 ): ((labelSource: T, path: string) => JSONDeltas) => {
   const { opType = "mutate" } = options;
-  const modalSample = useModalSample();
+  const sample = useActiveModalSample();
   const modalSampleSchema = useModalSampleSchema();
   const isGenerated = useRecoilValue(isGeneratedView);
 
   return useCallback(
     (labelSource: T, path: string) => {
-      if (!modalSample?.sample) {
+      if (!sample) {
         return [];
       }
 
@@ -89,7 +89,7 @@ export const useGetLabelDelta = <T>(
 
         if (schema) {
           const labelDeltas = buildLabelDeltas(
-            modalSample.sample,
+            sample,
             labelProxy,
             schema,
             opType,
@@ -106,6 +106,6 @@ export const useGetLabelDelta = <T>(
 
       return [];
     },
-    [isGenerated, labelConstructor, modalSample, modalSampleSchema, opType]
+    [isGenerated, labelConstructor, sample, modalSampleSchema, opType]
   );
 };

--- a/app/packages/annotation/src/persistence/useSampleMutationManager.ts
+++ b/app/packages/annotation/src/persistence/useSampleMutationManager.ts
@@ -1,4 +1,4 @@
-import { useModalSample, useModalSampleSchema } from "@fiftyone/state";
+import { useActiveModalSample, useModalSampleSchema } from "@fiftyone/state";
 import { Primitive } from "@fiftyone/utilities";
 import { atom, useAtom } from "jotai";
 import { get, isEqual } from "lodash";
@@ -58,7 +58,7 @@ export interface SampleMutationManager {
  */
 export const useSampleMutationManager = (): SampleMutationManager => {
   const [stagedMutations, setStagedMutations] = useAtom(stagedMutationsAtom);
-  const modalSample = useModalSample();
+  const sample = useActiveModalSample();
   const modalSampleSchema = useModalSampleSchema();
   const firstRenderRef = useRef(true);
 
@@ -67,14 +67,14 @@ export const useSampleMutationManager = (): SampleMutationManager => {
       if (path in stagedMutations) {
         // return current value if mutated
         return stagedMutations[path].data as Primitive;
-      } else if (modalSample?.sample) {
+      } else if (sample) {
         // otherwise fall back to sample data
-        return get(modalSample.sample, path) as Primitive;
+        return get(sample, path) as Primitive;
       } else {
         return null;
       }
     },
-    [modalSample?.sample, stagedMutations]
+    [sample, stagedMutations]
   );
 
   const stageMutation = useCallback(
@@ -99,12 +99,10 @@ export const useSampleMutationManager = (): SampleMutationManager => {
       const data = mutation.data as Primitive;
       // primitives require custom comparator to handle types like dates
       if (isPrimitiveFieldType(getFieldSchema(modalSampleSchema, path))) {
-        if (
-          arePrimitivesEqual(get(modalSample?.sample, path) as Primitive, data)
-        ) {
+        if (arePrimitivesEqual(get(sample, path) as Primitive, data)) {
           keysToRemove.push(path);
         }
-      } else if (isEqual(get(modalSample?.sample, path), data)) {
+      } else if (isEqual(get(sample, path), data)) {
         keysToRemove.push(path);
       }
     });
@@ -117,12 +115,7 @@ export const useSampleMutationManager = (): SampleMutationManager => {
         return newData;
       });
     }
-  }, [
-    modalSample?.sample,
-    modalSampleSchema,
-    setStagedMutations,
-    stagedMutations,
-  ]);
+  }, [sample, modalSampleSchema, setStagedMutations, stagedMutations]);
 
   // clear state on sample change
   useEffect(() => {
@@ -135,10 +128,10 @@ export const useSampleMutationManager = (): SampleMutationManager => {
     }
 
     reset();
-  }, [modalSample?.sample?._id]);
+  }, [sample?._id]);
 
   // gc stale keys when sample data changes
-  useEffect(() => garbageCollect(), [modalSample?.sample]);
+  useEffect(() => garbageCollect(), [sample]);
 
   return useMemo(
     () => ({

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Actions.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Actions.tsx
@@ -16,7 +16,7 @@ import {
   useCurrent3dAnnotationMode,
   useSetCurrent3dAnnotationMode,
 } from "@fiftyone/looker-3d/src/state/accessors";
-import { is3DDataset, useIs3dPinned } from "@fiftyone/state";
+import { is3DDataset, useIs3dPinned, useIsGroupDataset } from "@fiftyone/state";
 import {
   DETECTION,
   DETECTIONS,
@@ -39,6 +39,7 @@ import { useDetectionMode } from "./Edit/useDetectionMode";
 import { usePolylineMode } from "./Edit/usePolylineMode";
 import { useSegmentationMode } from "./Edit/useSegmentationMode";
 import { useDeactivateAllModes } from "./useDeactivateAllModes";
+import { useGroupAnnotationSliceReady } from "./useGroupAnnotationSliceReady";
 
 const ActionsDiv = styled.div`
   align-items: center;
@@ -201,12 +202,8 @@ const Classification = () => {
 };
 
 const Detection = () => {
-  const {
-    activateDetectionMode,
-    detectionModeActive,
-    disabled,
-    tooltip,
-  } = useDetectionMode();
+  const { activateDetectionMode, detectionModeActive, disabled, tooltip } =
+    useDetectionMode();
   const deactivateAll = useDeactivateAll();
 
   return (
@@ -260,12 +257,8 @@ const Segmentation = () => {
 };
 
 const Polyline = () => {
-  const {
-    activatePolylineMode,
-    polylineModeActive,
-    disabled,
-    tooltip,
-  } = usePolylineMode();
+  const { activatePolylineMode, polylineModeActive, disabled, tooltip } =
+    usePolylineMode();
   const deactivateAll = useDeactivateAll();
 
   return (
@@ -456,6 +449,14 @@ const Actions = () => {
     !current3dAnnotationMode;
   const areThreeDActionsVisible = is3dDataset || is3dSamplePinned;
 
+  // For group datasets the 2D-vs-3D decision depends on the resolved annotation
+  // slice, which isn't known until the group's sample data loads. Withhold the
+  // slice-dependent tools until then so a 3D sample never flashes 2D tools.
+  // Non-group datasets resolve immediately and don't gate.
+  const isGroupDataset = useIsGroupDataset();
+  const [groupAnnotationSliceReady] = useGroupAnnotationSliceReady();
+  const toolsResolved = !isGroupDataset || groupAnnotationSliceReady;
+
   const deactivateAll = useDeactivateAllModes();
 
   return (
@@ -465,18 +466,19 @@ const Actions = () => {
           <ItemLeft style={{ columnGap: "0.1rem" }}>
             <Select active={noActiveActions} />
             <Classification />
-            {areThreeDActionsVisible ? (
-              <>
-                <ThreeDCuboids />
-                <ThreeDPolylines />
-              </>
-            ) : (
-              <>
-                <Detection />
-                <Segmentation />
-                <Polyline />
-              </>
-            )}
+            {toolsResolved &&
+              (areThreeDActionsVisible ? (
+                <>
+                  <ThreeDCuboids />
+                  <ThreeDPolylines />
+                </>
+              ) : (
+                <>
+                  <Detection />
+                  <Segmentation />
+                  <Polyline />
+                </>
+              ))}
           </ItemLeft>
           <ItemRight style={{ columnGap: "0.1rem" }}>
             <Undo />

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useApplyAnnotationSliceVisibility.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useApplyAnnotationSliceVisibility.ts
@@ -8,9 +8,7 @@ export function useApplyAnnotationSliceVisibility() {
   const actions = fos.useRenderConfig3dActions();
 
   return useCallback(
-    (sliceName: string) => {
-      actions.focusSlice(sliceName);
-    },
+    (sliceName: string) => actions.focusSlice(sliceName),
     [actions]
   );
 }

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useGroupAnnotationModeController.test.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useGroupAnnotationModeController.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { describe, expect, it } from "vitest";
+import { hasApplicableAnnotationSlice } from "./useGroupAnnotationModeController";
+import type { AnnotationSliceInfo } from "./useGroupAnnotationSlices";
+
+const slice = (over: Partial<AnnotationSliceInfo>): AnnotationSliceInfo => ({
+  name: "slice",
+  mediaType: "image",
+  isSupported: true,
+  is3D: false,
+  isMissing: false,
+  ...over,
+});
+
+describe("hasApplicableAnnotationSlice", () => {
+  it("is false while slices are loading", () => {
+    expect(hasApplicableAnnotationSlice("loading")).toBe(false);
+  });
+
+  it("is false for an empty slice list (group data not cached yet)", () => {
+    expect(hasApplicableAnnotationSlice([])).toBe(false);
+  });
+
+  it("is false when every slice is missing from the current group", () => {
+    // The first-open bug: currentGroupSliceNames is empty, so resolveSlices
+    // marks every slice as missing.
+    expect(
+      hasApplicableAnnotationSlice([
+        slice({ name: "left", isMissing: true }),
+        slice({
+          name: "pcd",
+          is3D: true,
+          mediaType: "point-cloud",
+          isMissing: true,
+        }),
+      ])
+    ).toBe(false);
+  });
+
+  it("is false when the only present slices are unsupported", () => {
+    expect(
+      hasApplicableAnnotationSlice([
+        slice({ name: "video", mediaType: "video", isSupported: false }),
+      ])
+    ).toBe(false);
+  });
+
+  it("is true once a supported, present slice is available", () => {
+    expect(
+      hasApplicableAnnotationSlice([
+        slice({ name: "left", isMissing: true }),
+        slice({
+          name: "pcd",
+          is3D: true,
+          mediaType: "point-cloud",
+          isMissing: false,
+        }),
+      ])
+    ).toBe(true);
+  });
+});

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useGroupAnnotationModeController.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useGroupAnnotationModeController.ts
@@ -12,13 +12,23 @@ import {
   useSetRecoilState,
 } from "recoil";
 import { useApplyAnnotationSliceVisibility } from "./useApplyAnnotationSliceVisibility";
+import type { AnnotationSliceInfo } from "./useGroupAnnotationSlices";
 import { useGroupAnnotationSlices } from "./useGroupAnnotationSlices";
+
+// Does the current group expose at least one slice we can annotate?
+export const hasApplicableAnnotationSlice = (
+  resolved: AnnotationSliceInfo[] | "loading"
+): boolean =>
+  resolved !== "loading" &&
+  resolved.some(({ isSupported, isMissing }) => isSupported && !isMissing);
 
 const useApplySlice = () => {
   const { request } = useGroupAnnotationSlices();
   const modalGroupSlice = useRecoilValue(fos.modalGroupSlice);
-  const [preferredSlice, setPreferredSlice] =
-    fos.usePreferredGroupAnnotationSlice();
+  const [
+    preferredSlice,
+    setPreferredSlice,
+  ] = fos.usePreferredGroupAnnotationSlice();
 
   const resolveSlice = useRecoilCallback(
     () => async () => {
@@ -87,21 +97,19 @@ export function useGroupAnnotationModeController() {
   );
 
   const applySlice = useApplySlice();
+
+  const appliedRef = useRef(false);
+  const { resolved } = useGroupAnnotationSlices();
+  const hasApplicableSlice = hasApplicableAnnotationSlice(resolved);
+
   const captureVisibility = useCallback((): GroupVisibilityConfigSnapshot => {
-    applySlice();
     return {
       main: mainVisible,
       carousel: carouselVisible,
       threeDViewer: threeDVisible,
       slice: modalGroupSliceValue,
     };
-  }, [
-    applySlice,
-    mainVisible,
-    carouselVisible,
-    threeDVisible,
-    modalGroupSliceValue,
-  ]);
+  }, [mainVisible, carouselVisible, threeDVisible, modalGroupSliceValue]);
 
   const restoreVisibility = useCallback(
     (snapshot: GroupVisibilityConfigSnapshot | null) => {
@@ -121,14 +129,28 @@ export function useGroupAnnotationModeController() {
     const prevMode = prevModeRef.current ?? ModalMode.EXPLORE;
 
     if (prevMode === ModalMode.EXPLORE && mode === ModalMode.ANNOTATE) {
-      // Entering Annotate mode: capture current visibility
+      // Entering Annotate mode: capture current visibility.
       visibilitySnapshotRef.current = captureVisibility();
+      appliedRef.current = false;
     } else if (prevMode === ModalMode.ANNOTATE && mode === ModalMode.EXPLORE) {
       // Returning to Explore mode: restore visibility
       restoreVisibility(visibilitySnapshotRef.current);
       visibilitySnapshotRef.current = null;
+      appliedRef.current = false;
     }
 
     prevModeRef.current = mode;
   }, [mode, captureVisibility, restoreVisibility]);
+
+  // Apply the annotation slice once the group's slices are available.
+  useEffect(() => {
+    if (
+      mode === ModalMode.ANNOTATE &&
+      !appliedRef.current &&
+      hasApplicableSlice
+    ) {
+      appliedRef.current = true;
+      applySlice();
+    }
+  }, [mode, hasApplicableSlice, applySlice]);
 }

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useGroupAnnotationModeController.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useGroupAnnotationModeController.ts
@@ -12,6 +12,7 @@ import {
   useSetRecoilState,
 } from "recoil";
 import { useApplyAnnotationSliceVisibility } from "./useApplyAnnotationSliceVisibility";
+import { useGroupAnnotationSliceReady } from "./useGroupAnnotationSliceReady";
 import type { AnnotationSliceInfo } from "./useGroupAnnotationSlices";
 import { useGroupAnnotationSlices } from "./useGroupAnnotationSlices";
 
@@ -25,10 +26,8 @@ export const hasApplicableAnnotationSlice = (
 const useApplySlice = () => {
   const { request } = useGroupAnnotationSlices();
   const modalGroupSlice = useRecoilValue(fos.modalGroupSlice);
-  const [
-    preferredSlice,
-    setPreferredSlice,
-  ] = fos.usePreferredGroupAnnotationSlice();
+  const [preferredSlice, setPreferredSlice] =
+    fos.usePreferredGroupAnnotationSlice();
 
   const resolveSlice = useRecoilCallback(
     () => async () => {
@@ -57,7 +56,11 @@ const useApplySlice = () => {
 
     setPreferredSlice(slice);
     setModalGroupSlice(slice);
-    applyVisibilityForSlice(slice);
+    // Await so the returned promise resolves only after focusSlice has settled
+    // is3dPinned, letting callers know the 2D/3D decision is final.
+    if (slice) {
+      await applyVisibilityForSlice(slice);
+    }
   }, [
     applyVisibilityForSlice,
     resolveSlice,
@@ -102,6 +105,8 @@ export function useGroupAnnotationModeController() {
   const { resolved } = useGroupAnnotationSlices();
   const hasApplicableSlice = hasApplicableAnnotationSlice(resolved);
 
+  const [, setGroupAnnotationSliceReady] = useGroupAnnotationSliceReady();
+
   const captureVisibility = useCallback((): GroupVisibilityConfigSnapshot => {
     return {
       main: mainVisible,
@@ -132,17 +137,26 @@ export function useGroupAnnotationModeController() {
       // Entering Annotate mode: capture current visibility.
       visibilitySnapshotRef.current = captureVisibility();
       appliedRef.current = false;
+      setGroupAnnotationSliceReady(false);
     } else if (prevMode === ModalMode.ANNOTATE && mode === ModalMode.EXPLORE) {
       // Returning to Explore mode: restore visibility
       restoreVisibility(visibilitySnapshotRef.current);
       visibilitySnapshotRef.current = null;
       appliedRef.current = false;
+      setGroupAnnotationSliceReady(false);
     }
 
     prevModeRef.current = mode;
-  }, [mode, captureVisibility, restoreVisibility]);
+  }, [
+    mode,
+    captureVisibility,
+    restoreVisibility,
+    setGroupAnnotationSliceReady,
+  ]);
 
-  // Apply the annotation slice once the group's slices are available.
+  // Apply the annotation slice once the group's slices are available. Mark it
+  // ready only after applySlice settles is3dPinned, so the Actions bar can
+  // withhold the 2D/3D tools until the decision is final (no wrong-tool flash).
   useEffect(() => {
     if (
       mode === ModalMode.ANNOTATE &&
@@ -150,7 +164,7 @@ export function useGroupAnnotationModeController() {
       hasApplicableSlice
     ) {
       appliedRef.current = true;
-      applySlice();
+      applySlice().then(() => setGroupAnnotationSliceReady(true));
     }
-  }, [mode, hasApplicableSlice, applySlice]);
+  }, [mode, hasApplicableSlice, applySlice, setGroupAnnotationSliceReady]);
 }

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useGroupAnnotationSliceReady.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useGroupAnnotationSliceReady.ts
@@ -1,0 +1,12 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { atom, useAtom } from "jotai";
+
+// whether the group annotation slice has been resolved and
+// applied so as to avoid a flash of the 2D annotation tools
+const groupAnnotationSliceReadyAtom = atom(false);
+
+export const useGroupAnnotationSliceReady = () =>
+  useAtom(groupAnnotationSliceReadyAtom);

--- a/app/packages/state/src/accessors/modal/index.ts
+++ b/app/packages/state/src/accessors/modal/index.ts
@@ -11,9 +11,11 @@ import { preferredGroupAnnotationSliceAtom } from "../../jotai/group-annotation"
 import type { ModalViewportState } from "../../jotai/modal";
 import { __unsafeModalViewportAtom } from "../../jotai/modal";
 import type { ModalSample } from "../../recoil";
+import type { Sample } from "@fiftyone/looker";
 import {
   State,
   activeFields,
+  activeModalSample,
   currentSampleId,
   fieldSchema,
   lookerOptions,
@@ -78,6 +80,27 @@ export const useModalMode = () => useAtomValue(modalMode);
  */
 export const useModalSample = (): ModalSample | undefined => {
   const loadable = useRecoilValueLoadable(modalSample);
+
+  if (loadable.state === "hasValue") {
+    return loadable.contents;
+  }
+
+  return undefined;
+};
+
+/**
+ * Get the sample currently being acted on in the modal.
+ *
+ * Unlike {@link useModalSample}, which always resolves the 2D `modalGroupSlice`
+ * sample, this is 3D-aware: when a 3D slice is pinned it returns that slice's
+ * sample. It mirrors the sample the sidebar and looker display, so annotation
+ * edits persist to the slice the user is actually editing (e.g. a cuboid edit
+ * targets the point-cloud sample, not the 2D image slice).
+ *
+ * Returns `undefined` if the modal is closed or the sample is still loading.
+ */
+export const useActiveModalSample = (): Sample | undefined => {
+  const loadable = useRecoilValueLoadable(activeModalSample);
 
   if (loadable.state === "hasValue") {
     return loadable.contents;
@@ -172,7 +195,7 @@ export const useModalMediaPath = (): string | null => {
   }
 
   return Array.isArray(sample.urls)
-    ? sample.urls.find((u) => u.field === mediaField)?.url ??
-        sample.urls[0]?.url
+    ? (sample.urls.find((u) => u.field === mediaField)?.url ??
+        sample.urls[0]?.url)
     : sample.urls[mediaField];
 };


### PR DESCRIPTION
<!--
Community contributors: target the `community` branch, not `develop`. PRs from
non-members are auto-retargeted to `community`. See CONTRIBUTING.md:
https://github.com/voxel51/fiftyone/blob/develop/CONTRIBUTING.md#community-pull-requests
-->

## 🔗 Related Issues

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->

## 📋 What changes are proposed in this pull request?

- ensure 3D tools for 3D groups
- don't display tools until we know which to display
- persist updates to the proper slice

## 🧪 How is this patch tested? If it is not, please explain why.

- load `quickstart-groups`
- select a sample
- ensure `left` is selected from the slices dropdown
- reload
- the 2D annotation tools are displayed
- select a detection, edits persist
- exit the current detection
- select `pcd` from the slices dropdown
- reload
- the 2D annotation tools are displayed (**incorrect**)
- select a detection, edits _appear_ to persist but do not (**incorrect**)

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Ensure that the proper 3D annotation tools are presented for grouped 3D datasets and that any edits persist to the appropriate slice.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved support for handling annotation tool visibility in group datasets.

* **Bug Fixes**
  * Fixed tool UI flashing before group annotation slices are properly resolved.

* **Tests**
  * Added comprehensive test coverage for annotation slice readiness validation.

* **Refactor**
  * Improved modal sample data access patterns across annotation hooks for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2983
<!-- enterprise-sync-pr:end -->