### PR TITLE
[video annotation] Add frames awareness to schema manager

### DIFF
--- a/app/packages/annotation/src/engine/identity/framePath.test.ts
+++ b/app/packages/annotation/src/engine/identity/framePath.test.ts
@@ -1,22 +1,13 @@
 import { describe, expect, it } from "vitest";
 
-import { toFrameEnginePath, toSchemaField } from "./framePath";
+import { toSchemaField } from "./framePath";
 
-describe("framePath seam", () => {
-  it("maps a relative field to the frame engine path", () => {
-    expect(toFrameEnginePath("detections")).toBe("frames.detections");
-  });
-
-  it("is idempotent — an already-prefixed path is unchanged", () => {
-    expect(toFrameEnginePath("frames.detections")).toBe("frames.detections");
-  });
-
-  it("strips the frame prefix to recover the schema field", () => {
+describe("framePath", () => {
+  it("strips the frame prefix to recover the in-frame-doc field", () => {
     expect(toSchemaField("frames.detections")).toBe("detections");
   });
 
-  it("leaves a sample-level path unchanged in both directions", () => {
+  it("leaves a sample-level path unchanged", () => {
     expect(toSchemaField("events")).toBe("events");
-    expect(toSchemaField(toFrameEnginePath("detections"))).toBe("detections");
   });
 });

--- a/app/packages/annotation/src/engine/identity/framePath.ts
+++ b/app/packages/annotation/src/engine/identity/framePath.ts
@@ -1,34 +1,18 @@
 /**
- * The per-frame label-field path convention — the single seam between the two
- * namespaces video annotation spans:
+ * The per-frame label-field path convention.
  *
- * - the ENGINE namespace addresses a video sample's per-frame label fields by
- *   their full dataset path, `frames.<field>` (a `FrameStore` is keyed this
- *   way; presence/interaction/persistence all speak it);
- * - the annotation-SCHEMA namespace (what `createNew`, the sidebar's active
- *   field set, the field selector operate on) names the same field by its
- *   relative `<field>`.
- *
- * Every core↔engine crossing for a video frame field must translate here
- * rather than re-deriving the prefix inline, so the convention has one home.
- * Sample-level fields (temporal detections, image labels) carry no prefix and
- * round-trip unchanged through both directions.
- *
- * This is the explicit form of a translation the video integration currently
- * does implicitly in several hooks; it is the thing to delete once the
- * annotation schema exposes real `frames.*` paths directly (see the
- * video-on-annotation-engine end-state plan).
+ * The annotation schema, the engine, the form, and the canvas all address a
+ * video sample's per-frame label field by its full dataset path,
+ * `frames.<field>` — one shared namespace. The only place that needs the
+ * relative `<field>` is the {@link FrameStore} when it addresses a field
+ * *inside* a per-frame document (a frame doc stores `detections`, not
+ * `frames.detections`); `toSchemaField` is that internal mapping. Sample-level
+ * fields carry no prefix and pass through unchanged.
  */
 
 export const FRAMES_PREFIX = "frames.";
 
-/** Relative field (`detections`) → engine path (`frames.detections`); idempotent. */
-export const toFrameEnginePath = (relativeField: string): string =>
-  relativeField.startsWith(FRAMES_PREFIX)
-    ? relativeField
-    : `${FRAMES_PREFIX}${relativeField}`;
-
-/** Engine path (`frames.detections`) → schema field (`detections`); identity for sample-level paths. */
+/** Frame engine path (`frames.detections`) → in-frame-doc field (`detections`); identity for sample-level paths. */
 export const toSchemaField = (enginePath: string): string =>
   enginePath.startsWith(FRAMES_PREFIX)
     ? enginePath.slice(FRAMES_PREFIX.length)

--- a/app/packages/annotation/src/engine/index.ts
+++ b/app/packages/annotation/src/engine/index.ts
@@ -8,11 +8,7 @@
 // identity
 export type { LabelRef, ScopedRef } from "./identity/ref";
 export { linkageKey, refKey, refsEqual, toLabelRef } from "./identity/ref";
-export {
-  FRAMES_PREFIX,
-  toFrameEnginePath,
-  toSchemaField,
-} from "./identity/framePath";
+export { FRAMES_PREFIX, toSchemaField } from "./identity/framePath";
 export type { EntityId, EntityIdentity } from "./identity/entityId";
 export {
   decodeEntityId,

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/AnnotationSchema.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/AnnotationSchema.tsx
@@ -1,7 +1,6 @@
 import {
   FRAMES_PREFIX,
   stripReservedLabelAttributes,
-  toFrameEnginePath,
   useActiveAnnotationSampleId,
   useAnnotationEngine,
 } from "@fiftyone/annotation";
@@ -231,17 +230,14 @@ const useHandleSchemaChange = (readOnly: boolean) => {
       if (isEqual(value, data)) return;
 
       // address the engine in its own namespace: the anchor ref carries the
-      // track `instanceId` and the present `frame` for a video frame label, and
-      // names the field by its full `frames.<field>` path. Use the LIVE field
-      // for the path name (a mid-edit field move tracks through `field`), but
-      // re-prefix it when the ref says this is a frame field. With no ref
-      // (externally-managed atoms) fall back to the field + doc id, already
-      // correct for the sample-level labels those carry.
+      // track `instanceId` and the present `frame` for a video frame label. The
+      // field is already the full path (`frames.<field>` for a frame field) — a
+      // mid-edit field move tracks through it — so name the ref by it directly.
       const editingRef = editingRefRef.current;
       const isFrameField = editingRef?.path?.startsWith(FRAMES_PREFIX) ?? false;
       const ref = {
         sample: sampleRef.current,
-        path: isFrameField ? toFrameEnginePath(field) : field,
+        path: field,
         instanceId:
           editingRef?.instanceId ??
           (data as { _id?: string })?._id ??

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useDetectionMode.test.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useDetectionMode.test.ts
@@ -145,21 +145,8 @@ describe("useDetectionMode", () => {
 
       expect(scene().exitInteractiveMode).toHaveBeenCalledOnce();
       expect(annotationContext().createNew).toHaveBeenCalledOnce();
-      // no pinned field → field/class resolve from last-used memory
-      expect(annotationContext().createNew).toHaveBeenCalledWith(
-        "Detection",
-        undefined
-      );
-    });
-
-    it("pins the destination field when one is given (video frame field)", () => {
-      const { result } = renderHook(() => useDetectionMode());
-
-      act(() => result.current.create("frames.detections"));
-
-      expect(annotationContext().createNew).toHaveBeenCalledWith("Detection", {
-        field: "frames.detections",
-      });
+      // field/class resolve from last-used memory → configured schema field
+      expect(annotationContext().createNew).toHaveBeenCalledWith("Detection");
     });
   });
 

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useDetectionMode.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useDetectionMode.ts
@@ -111,18 +111,14 @@ export const useDetectionMode = () => {
   }, [detectionModeActive, deactivateDetectionMode, activateDetectionMode]);
 
   /**
-   * Finalize the previous detection and create the next one. Field and
-   * label class are auto-resolved from {@link useAnnotationContext}'s
-   * last-used memory, unless `field` pins the destination field (the video
-   * surface stamps its frame field, which the schema doesn't expose).
+   * Finalize the previous detection and create the next one. Field and label
+   * class are auto-resolved from {@link useAnnotationContext}'s last-used
+   * memory, falling back to the configured schema's detection field.
    */
-  const create = useCallback(
-    (field?: string) => {
-      sceneRef.current?.exitInteractiveMode();
-      annotationContext.createNew(DETECTION, field ? { field } : undefined);
-    },
-    [annotationContext]
-  );
+  const create = useCallback(() => {
+    sceneRef.current?.exitInteractiveMode();
+    annotationContext.createNew(DETECTION);
+  }, [annotationContext]);
 
   return useMemo(
     () => ({

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useEntries.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useEntries.ts
@@ -2,7 +2,6 @@ import {
   useActiveAnnotationSampleId,
   useAnnotationEngine,
   useTemporal,
-  toSchemaField,
 } from "@fiftyone/annotation";
 import { EntryKind, type SidebarEntry } from "@fiftyone/state";
 import { LabelType } from "@fiftyone/utilities";
@@ -67,9 +66,9 @@ const useEntries = (): [SidebarEntry[], (entries: SidebarEntry[]) => void] => {
       > = {};
 
       for (const ref of t.getPresent()) {
-        // refs carry the ENGINE path (`frames.detections`); the active set is
-        // in the schema namespace (`detections`), so translate before matching.
-        if (ref.sample !== sampleId || !active.has(toSchemaField(ref.path))) {
+        // refs and the active set share the schema namespace — a frame field is
+        // `frames.<field>` on both sides, so match the ref path directly.
+        if (ref.sample !== sampleId || !active.has(ref.path)) {
           continue;
         }
 
@@ -89,13 +88,11 @@ const useEntries = (): [SidebarEntry[], (entries: SidebarEntry[]) => void] => {
         });
       }
 
-      // order by the active-field order of each present field, keyed by engine
-      // path so rows carry the path `LabelEntry` resolves the label at.
+      // order by the active-field order of each present field; rows carry the
+      // path `LabelEntry` resolves the label at.
       const result: LabelRow[] = [];
       const enginePaths = Object.keys(byField).sort(
-        (a, b) =>
-          activeFields.indexOf(toSchemaField(a)) -
-          activeFields.indexOf(toSchemaField(b))
+        (a, b) => activeFields.indexOf(a) - activeFields.indexOf(b)
       );
       for (const path of enginePaths) {
         const fieldRows = byField[path];

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useFormAnchor.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useFormAnchor.ts
@@ -1,6 +1,5 @@
 import {
   refKey,
-  toSchemaField,
   useAnnotationEngine,
   useInteraction,
   type LabelRef,
@@ -82,13 +81,13 @@ export const useFormAnchor = (): void => {
     atom: PrimitiveAtom<AnnotationLabel>;
   } | null>(null);
 
-  // build the editing-atom value from current engine truth. The form operates
-  // in the schema namespace, so the row's field is the relative `<field>`; the
-  // overlay is the live Lighter one when mounted (matched by id + field), else a
-  // stub over the engine label.
+  // build the editing-atom value from current engine truth. Form, overlay, and
+  // engine share one namespace — the ref's full path (`frames.<field>` for a
+  // frame field); the overlay is the live Lighter one when mounted (matched by
+  // id + field), else a stub over the engine label.
   const build = useCallback(
     (ref: LabelRef, data: AnnotationLabelData): AnnotationLabel => {
-      const field = toSchemaField(ref.path);
+      const field = ref.path;
       const mounted = scene?.getOverlay(data._id as string);
       const live = mounted && mounted.field === field ? mounted : undefined;
 

--- a/app/packages/video-annotation/src/components/FrameLabels.tsx
+++ b/app/packages/video-annotation/src/components/FrameLabels.tsx
@@ -25,6 +25,7 @@ import {
   useGroupSlice,
   useModalSampleId,
   useView,
+  useVisibleLabelSchemas,
 } from "../state/accessors";
 import { useTemporalOverlayVersion } from "../hooks/useTemporalOverlayVersion";
 import { useWarmupThenSeek } from "../hooks/useWarmupThenSeek";
@@ -205,7 +206,12 @@ function useFrameDerivedTracks(resolveColor: ObjectTrackColorResolver): {
   const stream = useFrameLabelsStream();
   const engine = useAnnotationEngine();
   const sampleId = useActiveSampleId();
+  const visible = useVisibleLabelSchemas();
   const path = stream ? `frames.${stream.labelsField}` : null;
+
+  // Gate the frame field's tracks on the sidebar's visible set — deactivating it
+  // in the schema manager hides its timeline rows, matching the canvas + sidebar.
+  const active = !!path && visible.has(path);
 
   const [tracks, setTracks] = useState<Track[]>([]);
   const [resolved, setResolved] = useState(false);
@@ -217,6 +223,13 @@ function useFrameDerivedTracks(resolveColor: ObjectTrackColorResolver): {
     if (!stream || !sampleId || !path) {
       setTracks([]);
       setResolved(false);
+      return undefined;
+    }
+
+    // Inactive field: no rows, but still resolved so TD-track pin bootstrap fires.
+    if (!active) {
+      setTracks([]);
+      setResolved(true);
       return undefined;
     }
 
@@ -244,7 +257,7 @@ function useFrameDerivedTracks(resolveColor: ObjectTrackColorResolver): {
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- engineVersion is the invalidation signal
-  }, [engine, sampleId, path, stream, resolveColor, engineVersion]);
+  }, [engine, sampleId, path, active, stream, resolveColor, engineVersion]);
 
   return { tracks, resolved };
 }
@@ -264,6 +277,7 @@ function useTemporalDetectionTracks(
     bumpOnSceneReady: true,
   });
   const frameRate = getModalSampleFrameRate(sample);
+  const visible = useVisibleLabelSchemas();
 
   return useMemo(() => {
     if (!scene) {
@@ -278,9 +292,12 @@ function useTemporalDetectionTracks(
       return [];
     }
 
+    // Only overlays whose field is visible — a deactivated TD field drops its
+    // timeline rows, matching the canvas + sidebar.
     const temporalOverlays = scene
       .getAllOverlays()
-      .filter((o): o is TemporalOverlay => o instanceof TemporalOverlay);
+      .filter((o): o is TemporalOverlay => o instanceof TemporalOverlay)
+      .filter((o) => visible.has(o.field));
 
     return buildTemporalDetectionTracks({
       sample: buildVirtualTemporalSample(temporalOverlays),
@@ -288,7 +305,7 @@ function useTemporalDetectionTracks(
       resolveColor,
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps -- tdVersion is the invalidation signal
-  }, [scene, frameRate, resolveColor, tdVersion]);
+  }, [scene, frameRate, resolveColor, tdVersion, visible]);
 }
 
 /** Build the row-color resolvers, kept in lock-step with the overlays. */

--- a/app/packages/video-annotation/src/hooks/useVideoAnnotationSyncBundle.ts
+++ b/app/packages/video-annotation/src/hooks/useVideoAnnotationSyncBundle.ts
@@ -4,6 +4,7 @@
 
 import { useLighterSetupWithPixi } from "@fiftyone/lighter";
 import type { RefObject } from "react";
+import { useExposeSceneOverlayFieldsForTest } from "../sync/useExposeSceneOverlayFieldsForTest";
 import { useSyncLighterAnnotation } from "../sync/useSyncLighterAnnotation";
 import { useSyncMediaTransform } from "../sync/useSyncMediaTransform";
 import { useTemporalOverlaySync } from "../sync/useTemporalOverlaySync";
@@ -31,4 +32,5 @@ export function useVideoAnnotationSyncBundle<T extends HTMLElement>({
   useTemporalOverlaySync(scene, canonicalMediaReady);
   useSyncLighterAnnotation(scene);
   useSyncMediaTransform(scene, mediaRef);
+  useExposeSceneOverlayFieldsForTest(scene);
 }

--- a/app/packages/video-annotation/src/hooks/useVideoLighterEngineBridge.ts
+++ b/app/packages/video-annotation/src/hooks/useVideoLighterEngineBridge.ts
@@ -9,7 +9,7 @@ import {
   useLighterEngineBridge,
 } from "@fiftyone/annotation";
 import { useCallback } from "react";
-import { useDatasetId } from "../state/accessors";
+import { useDatasetId, useVisibleLabelSchemas } from "../state/accessors";
 import { useCurrentFrameGetter } from "../state/useCurrentFrame";
 import { stashEstablishKey } from "../sync/establishKeyRelay";
 
@@ -32,6 +32,13 @@ export const useVideoLighterEngineBridge = (): void => {
   const sample = useActiveSampleId();
   const dataset = useDatasetId();
 
+  // The bridge's projection scope = the sidebar's visible set (annotation-active
+  // ∩ explore-active). Deactivating a frame field in the schema manager drops
+  // its path here, the bridge re-creates, and its overlays clear — the canvas
+  // now respects the active schema like the sidebar. Sample-level fields stay
+  // scoped too (a still-active temporal-detection field remains present).
+  const paths = useVisibleLabelSchemas();
+
   // referentially stable frame reader — a new identity would re-create the
   // bridge (clear + rehydrate); the playhead value is read live at call time
   const getFrame = useCurrentFrameGetter();
@@ -45,16 +52,17 @@ export const useVideoLighterEngineBridge = (): void => {
     [getFrame]
   );
 
-  // paths left unscoped: the composite store registers a single frame-detection
-  // field; sample-level temporal-detections carry no Lighter adapter, so the
-  // loop's kind filter drops them from hydration, but their select/hover events
-  // still route through the bridge (frame-less ref, instanceId == the TD `_id`).
-  // Stash each draw's gesture key by overlay id so the auto-extend can fold its
-  // filler into the draw's undo unit (one Ctrl-Z removes the whole drawn track).
+  // Sample-level temporal-detections carry no Lighter adapter, so the loop's
+  // kind filter drops them from hydration regardless of scope, but their
+  // select/hover events still route through the bridge (frame-less ref,
+  // instanceId == the TD `_id`). Stash each draw's gesture key by overlay id so
+  // the auto-extend can fold its filler into the draw's undo unit (one Ctrl-Z
+  // removes the whole drawn track).
   useLighterEngineBridge({
     engine,
     sample,
     dataset,
+    paths,
     frameOf,
     onEstablishCommit: stashEstablishKey,
   });

--- a/app/packages/video-annotation/src/state/accessors.ts
+++ b/app/packages/video-annotation/src/state/accessors.ts
@@ -3,7 +3,6 @@
  */
 
 import {
-  activeFields,
   colorScheme,
   colorSeed,
   datasetName,
@@ -19,8 +18,11 @@ import {
   type Stage,
   TEMPORAL_DETECTIONS_FIELD,
 } from "@fiftyone/utilities";
+import { useAtomValue } from "jotai";
+import { useMemo } from "react";
 import { useRecoilValue } from "recoil";
 import { useAnnotationContext } from "../../../core/src/components/Modal/Sidebar/Annotate/Edit/useAnnotationContext";
+import { visibleLabelSchemas } from "../../../core/src/components/Modal/Sidebar/Annotate/state";
 
 /**
  * Read accessors for the external recoil / jotai atoms the video surface
@@ -55,10 +57,6 @@ export const useModalSampleId = () => useRecoilValue(modalSampleId);
  */
 export const useView = (): Stage[] => (useRecoilValue(view) ?? []) as Stage[];
 
-/** Field paths active (collapsed) in the modal sidebar. */
-export const useActiveModalPaths = () =>
-  useRecoilValue(activeFields({ modal: true, expanded: false }));
-
 /** Schema paths of the dataset's temporal-detections fields. */
 export const useTemporalDetectionFieldPaths = () =>
   useRecoilValue(
@@ -80,3 +78,16 @@ export const useCurrentEditingOverlay = () =>
  */
 export const useActiveDetectionField = (): string | null =>
   useAnnotationContext().lastUsed.fieldFor(DETECTION);
+
+/**
+ * The label paths visible in the annotate sidebar — annotation-active ∩
+ * explore-active — in the engine namespace (frame fields as `frames.*`). The
+ * canvas overlays and timeline tracks gate rendering on this set so that
+ * deactivating a field in the schema manager (or hiding it in Explore) hides it
+ * everywhere, exactly like the sidebar. Returns a referentially-stable set so
+ * the bridge's `paths` scope only re-creates on a real visibility change.
+ */
+export const useVisibleLabelSchemas = (): ReadonlySet<string> => {
+  const visible = useAtomValue(visibleLabelSchemas);
+  return useMemo(() => new Set(visible), [visible]);
+};

--- a/app/packages/video-annotation/src/sync/useExposeSceneOverlayFieldsForTest.ts
+++ b/app/packages/video-annotation/src/sync/useExposeSceneOverlayFieldsForTest.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import type { useLighterSetupWithPixi } from "@fiftyone/lighter";
+import { useEffect } from "react";
+
+type Scene = ReturnType<typeof useLighterSetupWithPixi>["scene"];
+
+declare global {
+  interface Window {
+    /**
+     * E2E affordance: the distinct fields of the overlays currently mounted on
+     * the video annotation scene. Canvas overlays are PIXI (not DOM), so this
+     * is the only handle a Playwright spec has to assert that the canvas honors
+     * the active schema (deactivating a field hides its overlays). Read live;
+     * removed when the surface unmounts.
+     */
+    __FO_PLAYWRIGHT_SCENE_OVERLAY_FIELDS?: () => string[];
+  }
+}
+
+/**
+ * Publish the scene's live overlay fields on `window` for e2e assertions. A
+ * read-only probe — it never drives app behavior; the hook owns the global's
+ * lifecycle and clears it on scene change / unmount.
+ */
+export const useExposeSceneOverlayFieldsForTest = (scene: Scene): void => {
+  useEffect(() => {
+    if (!scene) {
+      return undefined;
+    }
+
+    window.__FO_PLAYWRIGHT_SCENE_OVERLAY_FIELDS = () =>
+      Array.from(new Set(scene.getAllOverlays().map((o) => o.field)));
+
+    return () => {
+      delete window.__FO_PLAYWRIGHT_SCENE_OVERLAY_FIELDS;
+    };
+  }, [scene]);
+};

--- a/app/packages/video-annotation/src/sync/useSyncLighterAnnotation.ts
+++ b/app/packages/video-annotation/src/sync/useSyncLighterAnnotation.ts
@@ -3,7 +3,6 @@
  */
 
 import {
-  toFrameEnginePath,
   useAnnotationEngine,
   useAnnotationEventHandler,
 } from "@fiftyone/annotation";
@@ -40,21 +39,17 @@ const useRegisterDrawHandler = ({
   registerHandler: RegisterLighterHandler;
 }): void => {
   const detectionMode = useDetectionMode();
-  const stream = useFrameLabelsStream();
 
   registerHandler(
     "lighter:overlay-create",
     useCallback(() => {
       if (detectionMode.detectionModeActive) {
-        // Pin the destination to the frame engine path. The schema only exposes
-        // the sample-level detection field, so the default resolution would
-        // stamp that path on the overlay and route the write to the sample
-        // store; the seam maps the relative field to `frames.<field>`.
-        detectionMode.create(
-          stream ? toFrameEnginePath(stream.labelsField) : undefined
-        );
+        // The schema exposes the frame field at its real `frames.<field>` path,
+        // so default field resolution stamps it and the write routes to the
+        // FrameStore — no pinned destination needed.
+        detectionMode.create();
       }
-    }, [detectionMode, stream])
+    }, [detectionMode])
   );
 };
 

--- a/app/packages/video-annotation/src/sync/useTemporalOverlaySync.ts
+++ b/app/packages/video-annotation/src/sync/useTemporalOverlaySync.ts
@@ -19,8 +19,8 @@ import { isTemporalDetectionsField } from "@fiftyone/utilities";
 import { type MutableRefObject, useEffect, useRef } from "react";
 import { frameAt, usePlayhead } from "@fiftyone/playback";
 import {
-  useActiveModalPaths,
   useTemporalDetectionFieldPaths,
+  useVisibleLabelSchemas,
 } from "../state/accessors";
 import type { FrameLabelReader } from "../tracks/frameTracks";
 import { getModalSampleFrameRate } from "../utils/modalSample";
@@ -219,7 +219,7 @@ const useOverlayDiff = (
   scene: Scene,
   canonicalMediaReady: boolean,
   temporalSample: Record<string, unknown>,
-  activePathsList: readonly string[],
+  activePaths: ReadonlySet<string>,
   overlaysRef: MutableRefObject<Map<string, TemporalOverlay>>,
   currentFrameRef: MutableRefObject<number | null>
 ): void => {
@@ -228,7 +228,6 @@ const useOverlayDiff = (
       return;
     }
 
-    const activePaths = new Set(activePathsList);
     syncTemporalOverlays({
       scene,
       sample: temporalSample,
@@ -242,7 +241,7 @@ const useOverlayDiff = (
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [scene, temporalSample, canonicalMediaReady, activePathsList]);
+  }, [scene, temporalSample, canonicalMediaReady, activePaths]);
 };
 
 /** Push the playhead frame into each tracked overlay on playhead changes. */
@@ -304,14 +303,18 @@ export function useTemporalOverlaySync(
   const overlaysRef = useRef<Map<string, TemporalOverlay>>(new Map());
 
   const temporalSample = useEngineTemporalSample();
-  const activePathsList = useActiveModalPaths();
+  // Gate on the sidebar's visible set (annotation-active ∩ explore-active) so a
+  // schema-manager deactivation evicts the TD overlay from the canvas too —
+  // matching the timeline + sidebar. (Was explore-active only, which the schema
+  // manager never touches.)
+  const activePaths = useVisibleLabelSchemas();
   const currentFrameRef = useCurrentFrameRef();
 
   useOverlayDiff(
     scene,
     canonicalMediaReady,
     temporalSample,
-    activePathsList,
+    activePaths,
     overlaysRef,
     currentFrameRef
   );

--- a/e2e-pw/src/oss/fixtures/video-annotate-sdk.ts
+++ b/e2e-pw/src/oss/fixtures/video-annotate-sdk.ts
@@ -25,13 +25,11 @@ export interface SeedVideoAnnotationOptions {
 }
 
 /**
- * Seeds a video-annotation dataset that mirrors the deployed demo
- * (`setup_video_annotation_demo.py`): a sample-level `detections` field that
- * SHADOWS `frames.detections` (the schema-manager hack the annotation logic
- * relies on), declared frame fields, an active `events` TemporalDetections
- * schema, materialized per-frame images for the ImaVid tile, and
- * empty-but-present `frames.detections` on every frame so the first draw's
- * JSON patch can append.
+ * Seeds a video-annotation dataset: declared frame fields with an active
+ * `frames.detections` annotation schema (keyed by its real frame path), an
+ * active sample-level `events` TemporalDetections schema, materialized per-frame
+ * images for the ImaVid tile, and empty-but-present `frames.detections` on every
+ * frame so the first draw's JSON patch can append.
  */
 export class VideoAnnotateSDK {
   loader: OssLoader;
@@ -65,6 +63,7 @@ EVENT_CLASSES = ${pyEventClasses}
 WITH_EVENTS = ${withEvents ? "True" : "False"}
 TRACKED = set(${pyTracked})
 DETECTIONS_FIELD = "detections"
+FRAME_DETECTIONS_PATH = "frames." + DETECTIONS_FIELD
 EVENTS_FIELD = "events"
 
 if fo.dataset_exists("${datasetName}"):
@@ -90,12 +89,7 @@ dataset.reload()
 # / dimensions).
 dataset.compute_metadata()
 
-# (2) sample-level Detections field that shadows frames.detections.
-dataset.add_sample_field(
-    DETECTIONS_FIELD, fo.EmbeddedDocumentField, embedded_doc_type=fo.Detections
-)
-
-# (3) frame fields the propagation pipeline writes. Declare the parent
+# (2) frame fields the propagation pipeline writes. Declare the parent
 # Detections container first, then the nested specs.
 dataset.add_frame_field(
     DETECTIONS_FIELD, fo.EmbeddedDocumentField, embedded_doc_type=fo.Detections
@@ -177,7 +171,7 @@ for sample in dataset.iter_samples(progress=False, autosave=True):
             if current is None or current.id != inst.id:
                 det.instance = inst
 
-# Active annotation schemas: detections (frame-forwarding shadow) + events.
+# Active annotation schemas: frames.detections + events.
 det_schema = {
     "type": "detections",
     "component": "dropdown",
@@ -190,8 +184,10 @@ det_schema = {
     ],
     "classes": CLASSES,
 }
-dataset.update_label_schema(DETECTIONS_FIELD, det_schema, allow_new_attrs=True)
-dataset.active_label_schemas = [DETECTIONS_FIELD]
+dataset.update_label_schema(
+    FRAME_DETECTIONS_PATH, det_schema, allow_new_attrs=True
+)
+dataset.active_label_schemas = [FRAME_DETECTIONS_PATH]
 
 events_schema = {
     "type": "temporaldetections",

--- a/e2e-pw/src/oss/poms/modal/video-annotate.ts
+++ b/e2e-pw/src/oss/poms/modal/video-annotate.ts
@@ -155,6 +155,23 @@ export class VideoAnnotatePom {
     // role="button" whose accessible name bubbles up "New TD".
     await this.page.locator('button[aria-label="New TD"]').click();
   }
+
+  /**
+   * The distinct fields of the overlays currently rendered on the canvas.
+   * Canvas overlays are PIXI (not DOM), so this reads the scene through the
+   * `__FO_PLAYWRIGHT_SCENE_OVERLAY_FIELDS` e2e affordance the surface exposes —
+   * the only handle a spec has on what the canvas is actually painting.
+   */
+  async canvasOverlayFields(): Promise<string[]> {
+    return this.page.evaluate(
+      () =>
+        (
+          window as unknown as {
+            __FO_PLAYWRIGHT_SCENE_OVERLAY_FIELDS?: () => string[];
+          }
+        ).__FO_PLAYWRIGHT_SCENE_OVERLAY_FIELDS?.() ?? []
+    );
+  }
 }
 
 class VideoAnnotateAsserter {
@@ -193,5 +210,12 @@ class VideoAnnotateAsserter {
     await expect
       .poll(async () => (await this.va.listedLabels()).length)
       .toBe(expected);
+  }
+
+  /** Assert whether the canvas currently renders any overlay for `field`. */
+  async canvasRendersField(field: string, rendered = true) {
+    await expect
+      .poll(async () => (await this.va.canvasOverlayFields()).includes(field))
+      .toBe(rendered);
   }
 }

--- a/e2e-pw/src/oss/poms/schema-manager/index.ts
+++ b/e2e-pw/src/oss/poms/schema-manager/index.ts
@@ -78,6 +78,34 @@ export class SchemaManagerPom {
   async moveFields() {
     await this.locator.getByTestId("move-fields").click();
   }
+
+  /**
+   * Deactivate an active field: check its row and move it to hidden. The field
+   * must currently be in the 'Active fields' section.
+   *
+   * @param field The field path, e.g. "frames.detections" or "events"
+   */
+  async deactivateField(field: string) {
+    const row = this.getFieldRow(field);
+    await row.clickCheckbox();
+    await row.assert.isChecked(true);
+    await this.moveFields();
+    await this.assert.isHiddenFieldRow(field);
+  }
+
+  /**
+   * Activate a hidden field: check its row and move it to active. The field
+   * must currently be in the 'Hidden fields' section.
+   *
+   * @param field The field path, e.g. "frames.detections" or "events"
+   */
+  async activateField(field: string) {
+    const row = this.getFieldRow(field);
+    await row.clickCheckbox();
+    await row.assert.isChecked(true);
+    await this.moveFields();
+    await this.assert.isActiveFieldRow(field);
+  }
 }
 
 /**

--- a/e2e-pw/src/oss/specs/MISSING-annotate-video-auto-extend.spec.ts
+++ b/e2e-pw/src/oss/specs/MISSING-annotate-video-auto-extend.spec.ts
@@ -137,11 +137,12 @@ test.describe.serial("video annotation fresh draw", () => {
 
     await drawBox(modal);
 
-    // finding A: the field reads the schema field `detections` immediately —
-    // not the raw engine path `frames.detections`, and with no deselect/reselect
+    // the form reads the schema field immediately (no deselect/reselect). The
+    // schema exposes the frame field at its real path, so that field is
+    // `frames.detections` — one namespace across schema, form, and engine.
     await expect
       .poll(() => modal.sidebar.edit.getCurrentField())
-      .toBe("detections");
+      .toBe("frames.detections");
 
     // committing a class keeps the form bound; the field stays `detections`
     const saved = page.waitForResponse(
@@ -160,7 +161,7 @@ test.describe.serial("video annotation fresh draw", () => {
     await expect(modal.sidebar.edit.backButton).toBeVisible();
     await expect
       .poll(() => modal.sidebar.edit.getCurrentField())
-      .toBe("detections");
+      .toBe("frames.detections");
   });
 
   test("undo removes a freshly-drawn box (engine undo on video)", async ({

--- a/e2e-pw/src/oss/specs/MISSING-annotate-video-last-used-class.spec.ts
+++ b/e2e-pw/src/oss/specs/MISSING-annotate-video-last-used-class.spec.ts
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ *
+ * Last-used class on the video surface: after setting a drawn frame detection's
+ * class, the NEXT drawn box defaults to that class — not the schema's first
+ * class. Exercises last-used resolution in the frame namespace (the field is
+ * `frames.detections`), the companion to the 2D last-used-class spec.
+ */
+import { expect, test as base } from "src/oss/fixtures";
+import { ModalPom } from "src/oss/poms/modal";
+import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
+import type { AbstractFiftyoneLoader } from "src/shared/abstract-loader";
+
+const datasetName = getUniqueDatasetNameWithPrefix("annotate-video-last-used");
+
+/** Fixed ObjectId addressing the first sample (so we can deep-link the modal). */
+const id = "000000000000000000000000";
+const clip = `/tmp/${datasetName}.webm`;
+
+const test = base.extend<{ modal: ModalPom }>({
+  modal: async ({ page, eventUtils }, use) => {
+    await use(new ModalPom(page, eventUtils));
+  },
+});
+
+test.beforeAll(async ({ foWebServer, mediaFactory, videoAnnotateSDK }) => {
+  await foWebServer.startWebServer();
+  await mediaFactory.createVideo({
+    outputPath: clip,
+    duration: 2,
+    width: 64,
+    height: 64,
+    frameRate: 10,
+    color: "#3050a0",
+  });
+  // classes: ["vehicle", "person", "road sign"] — "vehicle" is the schema
+  // default, so a draw that defaults to "person" proves last-used drove it.
+  await videoAnnotateSDK.seed({ datasetName, videoPaths: [clip] });
+});
+
+test.afterAll(async ({ foWebServer }) => {
+  await foWebServer.stopWebServer();
+});
+
+/** Open the modal in annotate mode on the deep-linked video sample. */
+const openAnnotate = async (
+  fiftyoneLoader: AbstractFiftyoneLoader,
+  modal: ModalPom,
+  page: import("src/oss/fixtures").Page
+) => {
+  await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
+    searchParams: new URLSearchParams({ id }),
+  });
+  await modal.assert.isOpen();
+  await modal.sidebar.switchMode("annotate");
+  await modal.videoAnnotate.waitForSurface();
+};
+
+/** Draw a detection box across the given relative corners (detection mode). */
+const drawBox = async (
+  modal: ModalPom,
+  from: [number, number],
+  to: [number, number]
+) => {
+  await modal.sidebar.annotate.detectionMode("Detections");
+  await modal.sampleCanvas.move(from[0], from[1]);
+  await modal.sampleCanvas.down();
+  await modal.sampleCanvas.move(to[0], to[1]);
+  await modal.sampleCanvas.up();
+};
+
+test.describe.serial("video annotation last-used class", () => {
+  test("a changed class becomes the default for the next drawn box", async ({
+    fiftyoneLoader,
+    modal,
+    page,
+  }) => {
+    await openAnnotate(fiftyoneLoader, modal, page);
+
+    // draw the first box and switch its class to the non-default "person"
+    await drawBox(modal, [0.55, 0.55], [0.78, 0.78]);
+    await modal.sidebar.edit.selectFieldChoice("label", "person");
+    await modal.sidebar.edit.assert.verifyFieldValue("label", "person");
+    await modal.sidebar.edit.exitToList();
+
+    // the next drawn box defaults to the last-used class ("person"), not the
+    // schema's first class ("vehicle")
+    await drawBox(modal, [0.1, 0.1], [0.3, 0.3]);
+    await expect
+      .poll(() => modal.sidebar.edit.getCurrentField())
+      .toBe("frames.detections");
+    await modal.sidebar.edit.assert.verifyFieldValue("label", "person");
+  });
+});

--- a/e2e-pw/src/oss/specs/MISSING-annotate-video-schema-activation.spec.ts
+++ b/e2e-pw/src/oss/specs/MISSING-annotate-video-schema-activation.spec.ts
@@ -1,0 +1,180 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ *
+ * Schema-manager activation gates EVERY annotate surface for a video dataset:
+ * deactivating a label field must hide it on the canvas overlays, the timeline
+ * tracks, AND the sidebar rows — not just one of them.
+ *
+ * This guards a fixed bug where only the sidebar consulted the active set: the
+ * canvas overlays (engine Lighter bridge) and timeline tracks rendered straight
+ * from presence, so a deactivated field stayed painted. The fix gates all three
+ * on the sidebar's visible set (annotation-active ∩ explore-active). Covered for
+ * both a per-frame field (`frames.detections`, via the engine bridge `paths`
+ * scope + the frame-derived tracks) and a sample-level TemporalDetections field
+ * (`events`, via the TD overlay sync + the TD track derivation).
+ *
+ * Seeded (per test, for isolation) with a tracked frame detection on sample 0
+ * (one `vehicle` instance on every frame) plus the demo `events` TDs
+ * (approach [1,6] / pass [7,13] / depart [14,20] over a 20-frame clip). At the
+ * initial frame both fields render everywhere.
+ */
+import { test as base } from "src/oss/fixtures";
+import { ModalPom } from "src/oss/poms/modal";
+import { SchemaManagerPom } from "src/oss/poms/schema-manager";
+import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
+import type { AbstractFiftyoneLoader } from "src/shared/abstract-loader";
+import type { Page } from "src/oss/fixtures";
+
+const datasetName = getUniqueDatasetNameWithPrefix(
+  "annotate-video-schema-active"
+);
+const id = "000000000000000000000000";
+const clip = `/tmp/${datasetName}.webm`;
+
+const FRAME_FIELD = "frames.detections";
+const TD_FIELD = "events";
+
+const test = base.extend<{
+  modal: ModalPom;
+  schemaManager: SchemaManagerPom;
+}>({
+  modal: async ({ page, eventUtils }, use) => {
+    await use(new ModalPom(page, eventUtils));
+  },
+  schemaManager: async ({ page, eventUtils }, use) => {
+    await use(new SchemaManagerPom(page, eventUtils));
+  },
+});
+
+test.beforeAll(async ({ foWebServer, mediaFactory }) => {
+  await foWebServer.startWebServer();
+  // 20-frame clip so the events thirds land on approach [1,6] / pass [7,13] /
+  // depart [14,20]; the playhead opens on frame 1 (approach in support).
+  await mediaFactory.createVideo({
+    outputPath: clip,
+    duration: 2,
+    width: 64,
+    height: 64,
+    frameRate: 10,
+    color: "#3050a0",
+  });
+});
+
+test.afterAll(async ({ foWebServer }) => {
+  await foWebServer.stopWebServer();
+});
+
+test.beforeEach(async ({ videoAnnotateSDK }) => {
+  // a tracked `vehicle` frame detection on every frame + the three demo TDs;
+  // both schemas active. Re-seeded per test so activation edits don't leak
+  // across the serial dataset.
+  await videoAnnotateSDK.seed({
+    datasetName,
+    videoPaths: [clip],
+    trackedSampleIndices: [0],
+  });
+});
+
+const openAnnotate = async (
+  fiftyoneLoader: AbstractFiftyoneLoader,
+  modal: ModalPom,
+  page: Page
+) => {
+  await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
+    searchParams: new URLSearchParams({ id }),
+  });
+  await modal.assert.isOpen();
+  await modal.sidebar.switchMode("annotate");
+  await modal.videoAnnotate.waitForSurface();
+};
+
+/** Both fields painted on every surface — the seeded starting point. */
+const assertBothFieldsRendered = async (modal: ModalPom) => {
+  const va = modal.videoAnnotate;
+  await va.assert.canvasRendersField(FRAME_FIELD, true);
+  await va.assert.canvasRendersField(TD_FIELD, true);
+  await va.assert.objectTrackCount(1);
+  await va.assert.temporalTrackCount(3);
+  await va.assert.labelListed("vehicle", true);
+  await va.assert.labelListed("approach", true);
+};
+
+test.describe.serial("video annotation schema activation gating", () => {
+  test("deactivating a frame field hides its canvas overlays, timeline tracks, and sidebar rows", async ({
+    fiftyoneLoader,
+    modal,
+    page,
+    schemaManager,
+  }) => {
+    await openAnnotate(fiftyoneLoader, modal, page);
+    const va = modal.videoAnnotate;
+
+    await assertBothFieldsRendered(modal);
+
+    await schemaManager.open();
+    await schemaManager.deactivateField(FRAME_FIELD);
+    await schemaManager.close();
+
+    // the frame field is gone everywhere; the TD field is untouched
+    await va.assert.canvasRendersField(FRAME_FIELD, false);
+    await va.assert.objectTrackCount(0);
+    await va.assert.labelListed("vehicle", false);
+
+    await va.assert.canvasRendersField(TD_FIELD, true);
+    await va.assert.temporalTrackCount(3);
+    await va.assert.labelListed("approach", true);
+  });
+
+  test("deactivating the temporal-detection field hides its canvas overlays + timeline tracks", async ({
+    fiftyoneLoader,
+    modal,
+    page,
+    schemaManager,
+  }) => {
+    await openAnnotate(fiftyoneLoader, modal, page);
+    const va = modal.videoAnnotate;
+
+    await assertBothFieldsRendered(modal);
+
+    await schemaManager.open();
+    await schemaManager.deactivateField(TD_FIELD);
+    await schemaManager.close();
+
+    // the TD field is gone everywhere; the frame field is untouched
+    await va.assert.canvasRendersField(TD_FIELD, false);
+    await va.assert.temporalTrackCount(0);
+    await va.assert.labelListed("approach", false);
+
+    await va.assert.canvasRendersField(FRAME_FIELD, true);
+    await va.assert.objectTrackCount(1);
+    await va.assert.labelListed("vehicle", true);
+  });
+
+  test("reactivating a deactivated frame field restores its overlays + tracks", async ({
+    fiftyoneLoader,
+    modal,
+    page,
+    schemaManager,
+  }) => {
+    await openAnnotate(fiftyoneLoader, modal, page);
+    const va = modal.videoAnnotate;
+
+    await assertBothFieldsRendered(modal);
+
+    // deactivate, confirm it's gone from the canvas, then reactivate
+    await schemaManager.open();
+    await schemaManager.deactivateField(FRAME_FIELD);
+    await schemaManager.close();
+    await va.assert.canvasRendersField(FRAME_FIELD, false);
+    await va.assert.objectTrackCount(0);
+
+    await schemaManager.open();
+    await schemaManager.activateField(FRAME_FIELD);
+    await schemaManager.close();
+
+    // the bridge re-creates and rehydrates: overlays, tracks, and rows return
+    await va.assert.canvasRendersField(FRAME_FIELD, true);
+    await va.assert.objectTrackCount(1);
+    await va.assert.labelListed("vehicle", true);
+  });
+});

--- a/fiftyone/core/annotation/generate_label_schemas.py
+++ b/fiftyone/core/annotation/generate_label_schemas.py
@@ -254,7 +254,10 @@ def generate_label_schemas(sample_collection, fields=None, scan_samples=True):
     original_fields = fields
     is_scalar = etau.is_str(fields)
     all_fields = foau.list_valid_annotation_fields(
-        sample_collection, require_app_support=True, flatten=True
+        sample_collection,
+        require_app_support=True,
+        flatten=True,
+        include_frames=True,
     )
     if is_scalar:
         fields = [fields]
@@ -441,8 +444,10 @@ def _preserve_applied_ontology(
 ) -> dict:
     # Carries a stored applied_ontology reference through regeneration.
     # Dangling references are not re-validated here; the next save handles it.
-    stored_label_schemas = sample_collection._dataset._doc.label_schemas or {}
-    stored_field_schema = stored_label_schemas.get(field_name) or {}
+    stored_field_schema = (
+        sample_collection._dataset._doc.get_stored_label_schema(field_name)
+        or {}
+    )
     applied_ontology = stored_field_schema.get(foac.APPLIED_ONTOLOGY)
     if applied_ontology is not None:
         label_schema[foac.APPLIED_ONTOLOGY] = applied_ontology

--- a/fiftyone/core/annotation/utils.py
+++ b/fiftyone/core/annotation/utils.py
@@ -68,7 +68,10 @@ def get_supported_app_annotation_fields(sample_collection):
 
 
 def list_valid_annotation_fields(
-    sample_collection, require_app_support=False, flatten=False
+    sample_collection,
+    require_app_support=False,
+    flatten=False,
+    include_frames=False,
 ):
     """Lists all valid annotation fields for a
     :class:`fiftyone.core.collections.SampleCollection`.
@@ -83,14 +86,35 @@ def list_valid_annotation_fields(
             by the App for annotation
         flatten (False): whether to flatten embedded documents with
             ``dot.notation``
+        include_frames (False): whether to also include valid per-frame label
+            fields, keyed by their ``frames.<field>`` path
 
     Returns:
         a sorted list of valid annotation field names
     """
-    fields = sample_collection.get_field_schema()
+    result = _valid_annotation_fields(
+        sample_collection,
+        sample_collection.get_field_schema(),
+        require_app_support,
+    )
 
+    if include_frames and sample_collection._has_frame_fields():
+        frame_fields = _valid_annotation_fields(
+            sample_collection,
+            sample_collection.get_frame_field_schema(),
+            require_app_support,
+        )
+        result |= {f"frames.{field_name}" for field_name in frame_fields}
+
+    if flatten:
+        result = flatten_fields(sample_collection, result, require_app_support)
+
+    return sorted(result)
+
+
+def _valid_annotation_fields(collection, schema, require_app_support):
     result = set()
-    for field_name, field in fields.items():
+    for field_name, field in schema.items():
 
         if _is_supported_primitive(field):
             result.add(field_name)
@@ -103,13 +127,10 @@ def list_valid_annotation_fields(
             result.add(field_name)
             continue
 
-        if _is_supported_label(sample_collection, field, require_app_support):
+        if _is_supported_label(collection, field, require_app_support):
             result.add(field_name)
 
-    if flatten:
-        result = flatten_fields(sample_collection, result, require_app_support)
-
-    return sorted(result)
+    return result
 
 
 def flatten_fields(collection, fields, require_app_support=False):

--- a/fiftyone/core/annotation/validate_label_schemas.py
+++ b/fiftyone/core/annotation/validate_label_schemas.py
@@ -62,9 +62,14 @@ def validate_label_schemas(
     elif fields is None:
         fields = sorted(label_schema.keys())
 
-    all_fields = sample_collection.get_field_schema(flat=True)
+    all_fields = dict(sample_collection.get_field_schema(flat=True))
+    if sample_collection._has_frame_fields():
+        frame_fields = sample_collection.get_frame_field_schema(flat=True)
+        for name, field in frame_fields.items():
+            all_fields[f"frames.{name}"] = field
+
     supported_fields = foau.list_valid_annotation_fields(
-        sample_collection, flatten=True
+        sample_collection, flatten=True, include_frames=True
     )
     exceptions = []
     for field_name in fields:

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -1743,8 +1743,9 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     def active_label_schemas(self, fields):
         fields = _as_str_list(fields)
 
+        label_schemas = self.label_schemas
         for field in fields:
-            if field not in self._doc.label_schemas:
+            if field not in label_schemas:
                 raise ValueError(
                     f"field '{field}' does not have a label schema"
                 )
@@ -1764,7 +1765,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         Returns:
             the dataset's label schemas ``dict``
         """
-        return copy.deepcopy(self._doc.label_schemas) or {}
+        return copy.deepcopy(self._doc.all_stored_label_schemas()) or {}
 
     def set_label_schemas(self, label_schemas):
         """Set the dataset's :ref:`label schemas <annotation-label-schema>`
@@ -1798,7 +1799,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             label_schemas = {}
 
         foa.validate_label_schemas(self, label_schemas)
-        self._doc.label_schemas = label_schemas
+        self._doc.set_all_stored_label_schemas(label_schemas)
         self._doc.active_label_schemas = [
             field
             for field in self.active_label_schemas
@@ -1845,9 +1846,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             allow_new_fields=allow_new_fields,
             fields=field,
         )
-        label_schemas = self.label_schemas
-        label_schemas[field] = copy.deepcopy(label_schema)
-        self._doc.label_schemas = label_schemas
+        self._doc.set_stored_label_schema(field, copy.deepcopy(label_schema))
         self.save()
 
     def delete_label_schemas(self, fields=None):
@@ -1893,9 +1892,10 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         fields = _as_str_list(fields)
 
+        label_schemas = self.label_schemas
         result = self.active_label_schemas
         for field in fields:
-            if field not in self._doc.label_schemas:
+            if field not in label_schemas:
                 raise ValueError(f"field '{field}' is not in the label schema")
 
             if field not in result:
@@ -1924,9 +1924,10 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         fields = _as_str_list(fields)
 
+        label_schemas = self.label_schemas
         result = self.active_label_schemas
         for field in fields:
-            if field not in self._doc.label_schemas:
+            if field not in label_schemas:
                 raise ValueError(
                     f"field '{field}' does not have a label schema"
                 )

--- a/fiftyone/core/odm/dataset.py
+++ b/fiftyone/core/odm/dataset.py
@@ -946,6 +946,58 @@ class DatasetDocument(Document):
     runs = DictField(ReferenceField(RunDocument))
     active_label_schemas = ListField(StringField())
     label_schemas = DictField()
+    frame_label_schemas = DictField()
+
+    # Frame label schemas are stored under their relative field name (dot-free,
+    # so they survive as Mongo dict keys) but addressed everywhere else by their
+    # full ``frames.<field>`` path. These helpers are the single place that
+    # routes a full path to the right store and presents a unified view.
+    _FRAMES_PREFIX = "frames."
+
+    def get_stored_label_schema(self, field):
+        """Returns the stored label schema for a field path, or ``None``."""
+        if field.startswith(self._FRAMES_PREFIX):
+            relative = field[len(self._FRAMES_PREFIX) :]
+            return (self.frame_label_schemas or {}).get(relative)
+
+        return (self.label_schemas or {}).get(field)
+
+    def set_stored_label_schema(self, field, label_schema):
+        """Stores the label schema for a field path in the right store."""
+        if field.startswith(self._FRAMES_PREFIX):
+            relative = field[len(self._FRAMES_PREFIX) :]
+            schemas = dict(self.frame_label_schemas or {})
+            schemas[relative] = label_schema
+            self.frame_label_schemas = schemas
+            return
+
+        schemas = dict(self.label_schemas or {})
+        schemas[field] = label_schema
+        self.label_schemas = schemas
+
+    def all_stored_label_schemas(self):
+        """Returns all stored label schemas keyed by full path, with frame
+        schemas re-keyed to their ``frames.<field>`` path."""
+        schemas = dict(self.label_schemas or {})
+        for relative, label_schema in (self.frame_label_schemas or {}).items():
+            schemas[self._FRAMES_PREFIX + relative] = label_schema
+
+        return schemas
+
+    def set_all_stored_label_schemas(self, label_schemas):
+        """Replaces all stored label schemas from a full-path-keyed dict,
+        splitting frame paths into the frame schema store."""
+        sample_schemas = {}
+        frame_schemas = {}
+        for field, label_schema in (label_schemas or {}).items():
+            if field.startswith(self._FRAMES_PREFIX):
+                frame_schemas[field[len(self._FRAMES_PREFIX) :]] = label_schema
+                continue
+
+            sample_schemas[field] = label_schema
+
+        self.label_schemas = sample_schemas
+        self.frame_label_schemas = frame_schemas
 
     def get_saved_views(self):
         saved_views = []

--- a/fiftyone/core/ontology.py
+++ b/fiftyone/core/ontology.py
@@ -565,11 +565,44 @@ def _find_label_schema_refs_by_ontology(
         # $filter can iterate it; we keep only the pairs whose
         # value's applied_ontology matches the target. ($$this is
         # the current pair, ``.v`` is its value — the schema dict.)
+        # Frame schemas live in a separate dict keyed by relative
+        # field, so we union them in, re-keyed to their ``frames.``
+        # path so the returned field names address the right store.
         {
             "$addFields": {
                 "_matching_fields": {
                     "$filter": {
-                        "input": {"$objectToArray": "$label_schemas"},
+                        "input": {
+                            "$concatArrays": [
+                                {
+                                    "$objectToArray": {
+                                        "$ifNull": ["$label_schemas", {}]
+                                    }
+                                },
+                                {
+                                    "$map": {
+                                        "input": {
+                                            "$objectToArray": {
+                                                "$ifNull": [
+                                                    "$frame_label_schemas",
+                                                    {},
+                                                ]
+                                            }
+                                        },
+                                        "as": "pair",
+                                        "in": {
+                                            "k": {
+                                                "$concat": [
+                                                    "frames.",
+                                                    "$$pair.k",
+                                                ]
+                                            },
+                                            "v": "$$pair.v",
+                                        },
+                                    }
+                                },
+                            ]
+                        },
                         "cond": {
                             "$eq": [
                                 "$$this.v.applied_ontology",
@@ -649,9 +682,9 @@ def delete_ontology(name: str, force: bool = False) -> None:
         # pylint: disable-next=no-member
         dataset_doc = DatasetDocument.objects.get(id=ref.dataset_id)
         for field_name in ref.field_names:
-            schema = dataset_doc.label_schemas.get(field_name, {})
-            dataset_doc.label_schemas[field_name] = inline_applied_ontology(
-                schema, ontology
+            schema = dataset_doc.get_stored_label_schema(field_name) or {}
+            dataset_doc.set_stored_label_schema(
+                field_name, inline_applied_ontology(schema, ontology)
             )
         dataset_doc.save()
 

--- a/plugins/operators/annotation.py
+++ b/plugins/operators/annotation.py
@@ -118,9 +118,14 @@ class GetLabelSchemas(foo.Operator):
 
     def execute(self, ctx):
         label_schemas = ctx.dataset.label_schemas
-        fields = foau.list_valid_annotation_fields(ctx.dataset, flatten=True)
+        fields = foau.list_valid_annotation_fields(
+            ctx.dataset, flatten=True, include_frames=True
+        )
         supported_fields = foau.list_valid_annotation_fields(
-            ctx.dataset, require_app_support=True, flatten=True
+            ctx.dataset,
+            require_app_support=True,
+            flatten=True,
+            include_frames=True,
         )
         result = {}
 
@@ -360,7 +365,10 @@ class ListValidAnnotationFields(foo.Operator):
         require_app_support = ctx.params.get("require_app_support", True)
 
         valid_fields = foau.list_valid_annotation_fields(
-            ctx.dataset, require_app_support=require_app_support, flatten=True
+            ctx.dataset,
+            require_app_support=require_app_support,
+            flatten=True,
+            include_frames=True,
         )
 
         return {"valid_fields": valid_fields}

--- a/tests/unittests/annotation/dataset_label_schemas_tests.py
+++ b/tests/unittests/annotation/dataset_label_schemas_tests.py
@@ -513,6 +513,132 @@ class DatasetAnnotationTests(unittest.TestCase):
         self.assertNotIn("_source", saved["attributes"][0])
 
 
+class FrameLabelSchemaTests(unittest.TestCase):
+    """Frame label fields are addressed by their ``frames.<field>`` path
+    everywhere, but persisted under their relative name in a separate store so
+    the dotted path never becomes a Mongo dict key."""
+
+    @drop_datasets
+    def test_frame_label_schema_roundtrip(self):
+        dataset = _make_video_dataset()
+        schema = dataset.generate_label_schemas(
+            "frames.detections", scan_samples=False
+        )
+
+        dataset.set_label_schemas({"frames.detections": schema})
+
+        self.assertEqual(list(dataset.label_schemas), ["frames.detections"])
+
+        # the dotted path must never reach the sample-level store; it lives in
+        # the frame store under its relative name
+        self.assertEqual(dataset._doc.label_schemas, {})
+        self.assertIn("detections", dataset._doc.frame_label_schemas)
+
+        dataset.reload()
+        self.assertEqual(list(dataset.label_schemas), ["frames.detections"])
+
+    @drop_datasets
+    def test_frame_and_sample_schemas_coexist(self):
+        dataset = _make_video_dataset()
+        dataset.add_sample_field("weather", fo.StringField)
+
+        frame_schema = dataset.generate_label_schemas(
+            "frames.detections", scan_samples=False
+        )
+        sample_schema = dataset.generate_label_schemas(
+            "weather", scan_samples=False
+        )
+
+        dataset.set_label_schemas(
+            {"frames.detections": frame_schema, "weather": sample_schema}
+        )
+
+        self.assertEqual(
+            set(dataset.label_schemas), {"frames.detections", "weather"}
+        )
+        self.assertEqual(list(dataset._doc.label_schemas), ["weather"])
+        self.assertEqual(
+            list(dataset._doc.frame_label_schemas), ["detections"]
+        )
+
+    @drop_datasets
+    def test_frame_label_schema_activation(self):
+        dataset = _make_video_dataset()
+        schema = dataset.generate_label_schemas(
+            "frames.detections", scan_samples=False
+        )
+        dataset.update_label_schema("frames.detections", schema)
+
+        dataset.activate_label_schemas("frames.detections")
+        self.assertEqual(dataset.active_label_schemas, ["frames.detections"])
+
+        dataset.deactivate_label_schemas("frames.detections")
+        self.assertEqual(dataset.active_label_schemas, [])
+
+        dataset.active_label_schemas = ["frames.detections"]
+        self.assertEqual(dataset.active_label_schemas, ["frames.detections"])
+
+        with self.assertRaises(ValueError):
+            dataset.active_label_schemas = ["frames.missing"]
+
+    @drop_datasets
+    def test_update_and_delete_frame_label_schema(self):
+        dataset = _make_video_dataset()
+        schema = dataset.generate_label_schemas(
+            "frames.detections", scan_samples=False
+        )
+
+        dataset.update_label_schema("frames.detections", schema)
+        self.assertIn("frames.detections", dataset.label_schemas)
+        self.assertIn("detections", dataset._doc.frame_label_schemas)
+
+        dataset.delete_label_schemas("frames.detections")
+        self.assertEqual(dataset.label_schemas, {})
+        self.assertEqual(dataset._doc.frame_label_schemas, {})
+
+    @drop_datasets
+    def test_clone_preserves_frame_label_schemas(self):
+        dataset = _make_video_dataset()
+        schema = dataset.generate_label_schemas(
+            "frames.detections", scan_samples=False
+        )
+        dataset.set_label_schemas({"frames.detections": schema})
+        dataset.activate_label_schemas("frames.detections")
+
+        clone = dataset.clone()
+        self.addCleanup(clone.delete)
+
+        self.assertEqual(list(clone.label_schemas), ["frames.detections"])
+        self.assertEqual(list(clone._doc.label_schemas), [])
+        self.assertIn("detections", clone._doc.frame_label_schemas)
+        self.assertEqual(clone.active_label_schemas, ["frames.detections"])
+
+    @drop_datasets
+    def test_list_valid_annotation_fields_includes_frames(self):
+        import fiftyone.core.annotation.utils as foau
+
+        dataset = _make_video_dataset()
+
+        without_frames = foau.list_valid_annotation_fields(
+            dataset, flatten=True
+        )
+        self.assertNotIn("frames.detections", without_frames)
+
+        with_frames = foau.list_valid_annotation_fields(
+            dataset, flatten=True, include_frames=True
+        )
+        self.assertIn("frames.detections", with_frames)
+
+
+def _make_video_dataset():
+    dataset = fo.Dataset()
+    dataset.media_type = "video"
+    dataset.add_frame_field(
+        "detections", fo.EmbeddedDocumentField, fo.Detections
+    )
+    return dataset
+
+
 def _make_applied_ontology_test_dataset(ontology_name: str = "my_ontology"):
     """Dataset with a `detections` label field and a `str_field`, with a real
     `AnnotationOntology` named ``ontology_name`` persisted to the `ontologies`


### PR DESCRIPTION
## Summary

Video annotation now operates on a dataset's real per-frame label fields at their
true `frames.*` paths, end to end.

- **Backend** — `get_label_schemas` returns per-frame label fields (with their classes/attributes) keyed by `frames.<field>` for video datasets. Frame schemas persist in a separate store keyed by the relative field name, so the dotted path never becomes a Mongo dict key, while the public API presents one unified `frames.*`-keyed view. Enumeration, generation, validation, and ontology paths are all frame-aware.
- **App** — the annotate sidebar, edit form, overlays, and the annotation engine all address frame fields by their full `frames.*` path. This removes an interim relative↔`frames.` translation that previously bridged the schema and engine namespaces; the only remaining relative-field mapping is internal to the frame store (addressing a field inside a per-frame document).
- **Default field / last-used** — field and class resolution follow the configured schema. Last-used is preserved; the stand-in sample-level default field is gone, so the experience is consistent with the configured schemas.

## Tests

- **Python** — frame label schema set/update/delete/activate, sample+frame coexistence, and clone round-trip; full annotation suite green.
- **App unit (vitest)** — 70 files / 757 tests green (updated detection-mode and frame-path tests).
- **e2e (Playwright)** — all annotate specs pass (image + video), including the video draw → commit → timeline → persist round-trip and the form-follows-playhead flow; added video last-used-class coverage. The form-field assertion now expects the real `frames.detections` path (intended namespace change).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Video annotation now supports frame-level label schemas end-to-end, including schema activation/deactivation and visibility-aware canvas, timeline, and sidebar updates.
  * Expanded label-field discovery/validation to include frame-scoped fields (for schema generation and supported-field lists).

* **Bug Fixes**
  * Corrected label path handling so frame detections use `frames.<field>` consistently across editing and creation flows.
  * Improved “last used” class behavior for frame detections.

* **Tests**
  * Added/updated unit and end-to-end coverage for frame label schemas, overlay rendering, and schema activation gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->