### PR TITLE
test(e2e): assert the duplicate-name error is visible, not just defined

### DIFF
--- a/e2e-pw/src/oss/poms/saved-views.ts
+++ b/e2e-pw/src/oss/poms/saved-views.ts
@@ -323,7 +323,7 @@ class SavedViewAsserter {
 
   async verifySaveViewFails() {
     await expect(this.svp.saveButton()).toBeDisabled();
-    expect(this.svp.nameError()).toBeDefined();
+    await expect(this.svp.nameError()).toBeVisible();
     await this.svp.clickCloseModal();
   }
 


### PR DESCRIPTION
## What

`verifySaveViewFails` (the SavedViews asserter) checks the "name already exists" error with `expect(this.svp.nameError()).toBeDefined()`. `nameError()` returns `this.dialogLocator.getByText("Name already exists")`, a Playwright `Locator`, which is always a defined object. So this assertion passes whether or not the error actually renders, and it is the method's only check of that error.

## Why

`verifySaveViewFails` exists to prove the duplicate-name validation shows its error. With the always-true `toBeDefined()`, a broken validation (no error shown) would still pass. The sibling `await expect(this.svp.saveButton()).toBeDisabled()` is a real check, but the error-message verification was dead.

This switches it to the web-first `await expect(...).toBeVisible()`, which auto-waits for and verifies the error element the method name promises. One-line change, no new imports or selectors.

## Tests

I could not run the e2e-pw suite locally (it needs a built FiftyOne app and browsers), so I am disclosing that rather than claiming a green run. The change is a single assertion swap and `git diff --check` is clean.

---

Found while reviewing the test suite with [`e2e-skills/e2e-reviewer`](https://github.com/voidmatcha/e2e-skills#skill-2-e2e-reviewer--quality-review).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation feedback when saving a view by ensuring the name-field error is actually shown to the user.
  * Kept the existing flow intact after the check, including closing the dialog as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->