### PR TITLE
Add taxonomy SDK methods and validation

### DIFF
--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -73,10 +73,14 @@ from .core.ontology import (
     Taxonomy,
     apply_ontology,
     delete_ontology,
+    delete_taxonomy,
     list_ontologies,
+    list_taxonomies,
     load_ontology,
+    load_taxonomy,
     ontology_exists,
     save_ontology,
+    taxonomy_exists,
 )
 from .core.fields import (
     flatten_schema,

--- a/fiftyone/core/ontology.py
+++ b/fiftyone/core/ontology.py
@@ -494,28 +494,36 @@ def load_ontology(name: str) -> Ontology:
     return _from_doc(doc)
 
 
+def _list_by_type(
+    glob_patt: Optional[str], ontology_type: str
+) -> list[str]:
+    """Returns a sorted list of names for ontologies of the given type,
+    optionally filtered by a glob pattern.
+    """
+    query: dict[str, Any] = {"type": ontology_type}
+    if glob_patt is not None:
+        query["name__regex"] = fnmatch.translate(glob_patt)
+
+    docs = OntologyDocument.objects(**query)  # pylint: disable=no-member
+    return sorted(docs.distinct("name"))
+
+
 def list_ontologies(glob_patt: Optional[str] = None) -> list[str]:
-    """Lists ontology names in the database.
+    """Lists annotation ontology names in the database.
+
+    Taxonomies are excluded; use :func:`list_taxonomies` for those.
 
     Args:
         glob_patt: an optional glob pattern to filter names
 
     Returns:
-        a sorted list of ontology names
+        a sorted list of annotation ontology names
     """
-    if glob_patt is not None:
-        regex = fnmatch.translate(glob_patt)
-        docs = OntologyDocument.objects(  # pylint: disable=no-member
-            name__regex=regex
-        )
-    else:
-        docs = OntologyDocument.objects()  # pylint: disable=no-member
-
-    return sorted(docs.distinct("name"))
+    return _list_by_type(glob_patt, OntologyType.ANNOTATION_ONTOLOGY.value)
 
 
 def ontology_exists(name: str) -> bool:
-    """Checks if an ontology with the given name exists.
+    """Checks if an ontology (of any type) with the given name exists.
 
     Args:
         name: the ontology name
@@ -524,6 +532,115 @@ def ontology_exists(name: str) -> bool:
         True/False
     """
     return _objects_by_slug(name).count() > 0
+
+
+# ---- Taxonomy-specific accessors ------------------------------------------
+#
+# Thin wrappers over the generic ontology functions above that constrain to
+# taxonomies, so callers can work with taxonomies without reasoning about
+# the shared ``ontologies`` collection or the annotation-ontology type.
+
+
+def load_taxonomy(name: str) -> "Taxonomy":
+    """Loads the latest version of a taxonomy by name.
+
+    Args:
+        name: the taxonomy name
+
+    Returns:
+        a :class:`Taxonomy`
+
+    Raises:
+        ValueError: if no taxonomy with the given name exists, or if the
+            name resolves to a non-taxonomy ontology
+    """
+    try:
+        ontology = load_ontology(name)
+    except ValueError:
+        raise ValueError(f"Taxonomy '{name}' not found") from None
+
+    if not ontology.is_taxonomy:
+        raise ValueError(f"'{name}' is not a taxonomy")
+
+    return ontology
+
+
+def list_taxonomies(glob_patt: Optional[str] = None) -> list[str]:
+    """Lists taxonomy names in the database.
+
+    Args:
+        glob_patt: an optional glob pattern to filter names
+
+    Returns:
+        a sorted list of taxonomy names
+    """
+    return _list_by_type(glob_patt, OntologyType.TAXONOMY.value)
+
+
+def taxonomy_exists(name: str) -> bool:
+    """Checks if a taxonomy with the given name exists.
+
+    Returns ``False`` if the name resolves to a non-taxonomy ontology.
+
+    Args:
+        name: the taxonomy name
+
+    Returns:
+        True/False
+    """
+    if not ontology_exists(name):
+        return False
+
+    return load_ontology(name).is_taxonomy
+
+
+def _find_ontologies_referencing_taxonomy(taxonomy_name: str) -> list[str]:
+    """Returns the names of annotation ontologies that bundle the named
+    taxonomy via their ``taxonomy`` reference.
+
+    Matches across all versions (a name is reported if any version
+    references the taxonomy); the lookup keys on the stored slug.
+    """
+    slug = fou.to_slug(taxonomy_name)
+    docs = OntologyDocument.objects(  # pylint: disable=no-member
+        type=OntologyType.ANNOTATION_ONTOLOGY.value,
+        root__taxonomy=slug,
+    )
+    return sorted(docs.distinct("name"))
+
+
+def delete_taxonomy(name: str, force: bool = False) -> None:
+    """Deletes a taxonomy and all its versions from the database.
+
+    If any annotation ontology bundles this taxonomy (via its
+    ``taxonomy`` reference), the default behavior is to raise rather than
+    leave those ontologies pointing at a deleted taxonomy. Pass
+    ``force=True`` to delete anyway.
+
+    Args:
+        name: the taxonomy name
+        force: if False (default), raise if any annotation ontology
+            references the taxonomy. If True, delete regardless
+
+    Raises:
+        ValueError: if the taxonomy does not exist (or is not a
+            taxonomy), or if it is referenced and ``force=False``
+    """
+    # Validates existence and type before touching anything; raises a
+    # taxonomy-flavored error if not found or not a taxonomy.
+    load_taxonomy(name)
+
+    referencing = _find_ontologies_referencing_taxonomy(name)
+    if referencing and not force:
+        raise ValueError(
+            f"Taxonomy '{name}' is referenced by {len(referencing)} "
+            f"annotation ontolog(y/ies): {referencing}. Pass force=True "
+            "to delete anyway."
+        )
+
+    # Reuse the generic delete; a taxonomy is never an ``applied_ontology``
+    # target, so there are no label-schema references to inline.
+    delete_ontology(name)
 
 
 class LabelSchemaOntologyRef(NamedTuple):

--- a/fiftyone/core/ontology.py
+++ b/fiftyone/core/ontology.py
@@ -502,7 +502,10 @@ def _list_by_type(
     """
     query: dict[str, Any] = {"type": ontology_type}
     if glob_patt is not None:
-        query["name__regex"] = fnmatch.translate(glob_patt)
+        # ``fnmatch.translate`` end-anchors with ``\Z`` but not the start;
+        # Mongo ``$regex`` matches anywhere, so anchor the start ourselves
+        # to avoid ``vehicle_*`` also matching e.g. ``myvehicle_classes``.
+        query["name__regex"] = "^" + fnmatch.translate(glob_patt)
 
     docs = OntologyDocument.objects(**query)  # pylint: disable=no-member
     return sorted(docs.distinct("name"))
@@ -598,15 +601,29 @@ def _find_ontologies_referencing_taxonomy(taxonomy_name: str) -> list[str]:
     """Returns the names of annotation ontologies that bundle the named
     taxonomy via their ``taxonomy`` reference.
 
-    Matches across all versions (a name is reported if any version
-    references the taxonomy); the lookup keys on the stored slug.
+    Only the latest version of each annotation-ontology lineage is
+    considered, matching how the accessors resolve ontologies: a lineage
+    whose newest version has dropped the taxonomy is not reported, even
+    if an older version still referenced it.
     """
     slug = fou.to_slug(taxonomy_name)
-    docs = OntologyDocument.objects(  # pylint: disable=no-member
-        type=OntologyType.ANNOTATION_ONTOLOGY.value,
-        root__taxonomy=slug,
-    )
-    return sorted(docs.distinct("name"))
+    pipeline = [
+        {"$match": {"type": OntologyType.ANNOTATION_ONTOLOGY.value}},
+        # Highest version first so $first picks the latest per slug.
+        {"$sort": {"slug": 1, "version": -1}},
+        {
+            "$group": {
+                "_id": "$slug",
+                "name": {"$first": "$name"},
+                "taxonomy": {"$first": "$root.taxonomy"},
+            }
+        },
+        # Keep only lineages whose latest version bundles this taxonomy.
+        {"$match": {"taxonomy": slug}},
+    ]
+    # pylint: disable-next=no-member
+    matches = OntologyDocument.objects.aggregate(pipeline)
+    return sorted(m["name"] for m in matches)
 
 
 def delete_taxonomy(name: str, force: bool = False) -> None:

--- a/fiftyone/core/ontology_validation.py
+++ b/fiftyone/core/ontology_validation.py
@@ -37,6 +37,7 @@ def validate_annotation_ontology(ontology: AnnotationOntology) -> None:
         *_validate_when_operators(ontology),
         *_validate_types(ontology),
         *_validate_components(ontology),
+        *_validate_taxonomy_components(ontology),
         *_validate_no_cycles(ontology),
         *_validate_then_keys(ontology),
         *_validate_taxonomy_ref(ontology),
@@ -122,6 +123,25 @@ def _validate_components(ontology: AnnotationOntology) -> list[str]:
             errors.append(
                 f"attribute {attr.name!r}: component {attr.component!r} "
                 f"not valid for type {attr.type!r}"
+            )
+    return errors
+
+
+def _validate_taxonomy_components(ontology: AnnotationOntology) -> list[str]:
+    """Reject attributes that pair a ``taxonomy`` reference with a
+    non-``dropdown`` component.
+
+    A taxonomy supplies the allowed values for a dropdown; the App only
+    renders taxonomy-backed attributes as dropdowns, so any other
+    component renders nothing. Mirrors the same rule enforced on
+    label-schema fields in ``validate_label_schemas``.
+    """
+    errors: list[str] = []
+    for attr in ontology.attributes:
+        if attr.taxonomy is not None and attr.component != _fac.DROPDOWN:
+            errors.append(
+                f"attribute {attr.name!r}: {_fac.TAXONOMY!r} requires a "
+                f"{_fac.DROPDOWN!r} component, got {attr.component!r}"
             )
     return errors
 

--- a/tests/unittests/ontology_class_tests.py
+++ b/tests/unittests/ontology_class_tests.py
@@ -1070,8 +1070,8 @@ class OntologySDKTests(unittest.TestCase):
         self.assertEqual(load_ontology("forwarded").description, "rev 2")
 
 
-class TaxonomySDKTests(unittest.TestCase):
-    """Integration tests for the taxonomy-specific accessors."""
+class TaxonomyAccessorTests(unittest.TestCase):
+    """Integration tests for the taxonomy-specific accessor functions."""
 
     def setUp(self):
         import fiftyone.core.odm as foo
@@ -1220,6 +1220,36 @@ class TaxonomySDKTests(unittest.TestCase):
 
         delete_taxonomy("vehicle_classes", force=True)
         self.assertFalse(taxonomy_exists("vehicle_classes"))
+
+    def test_delete_taxonomy_ignores_stale_reference_in_old_version(self):
+        from fiftyone.core.ontology import (
+            delete_taxonomy,
+            load_ontology,
+            taxonomy_exists,
+        )
+
+        taxonomy = self._make_taxonomy()
+        taxonomy.save()
+
+        # v1 bundles the taxonomy ...
+        AnnotationOntology(name="bundle", taxonomy=taxonomy).save()
+        # ... v2 drops it. Only the latest version should count.
+        ao = load_ontology("bundle")
+        ao.taxonomy = None
+        ao.save()
+
+        # not blocked by the stale v1 reference
+        delete_taxonomy("vehicle_classes")
+        self.assertFalse(taxonomy_exists("vehicle_classes"))
+
+    def test_list_taxonomies_glob_anchored_at_start(self):
+        from fiftyone.core.ontology import list_taxonomies
+
+        self._make_taxonomy("vehicle_classes").save()
+        self._make_taxonomy("myvehicle_classes").save()
+
+        # "vehicle_*" must not match a name that merely contains it
+        self.assertEqual(list_taxonomies("vehicle_*"), ["vehicle_classes"])
 
 
 class NodeTests(unittest.TestCase):

--- a/tests/unittests/ontology_class_tests.py
+++ b/tests/unittests/ontology_class_tests.py
@@ -1070,6 +1070,158 @@ class OntologySDKTests(unittest.TestCase):
         self.assertEqual(load_ontology("forwarded").description, "rev 2")
 
 
+class TaxonomySDKTests(unittest.TestCase):
+    """Integration tests for the taxonomy-specific accessors."""
+
+    def setUp(self):
+        import fiftyone.core.odm as foo
+
+        db = foo.get_db_conn()
+        db.drop_collection("ontologies")
+
+        from fiftyone.core.odm.ontology import OntologyDocument
+
+        OntologyDocument.ensure_indexes()
+
+    def tearDown(self):
+        import fiftyone.core.odm as foo
+
+        db = foo.get_db_conn()
+        db.drop_collection("ontologies")
+
+    def _make_taxonomy(self, name: str = "vehicle_classes") -> Taxonomy:
+        return Taxonomy(
+            name=name,
+            description="Vehicle class hierarchy",
+            root=Node(
+                name="vehicles",
+                can_select=False,
+                values=[Node(name="car"), Node(name="truck")],
+            ),
+        )
+
+    def _make_annotation_ontology(
+        self, name: str = "vehicle_ontology"
+    ) -> AnnotationOntology:
+        return AnnotationOntology(
+            name=name,
+            attributes=[
+                AttributeSpec(name="damaged", type="bool", component="checkbox"),
+            ],
+        )
+
+    def test_load_taxonomy(self):
+        from fiftyone.core.ontology import load_taxonomy
+
+        self._make_taxonomy().save()
+
+        loaded = load_taxonomy("vehicle_classes")
+        self.assertTrue(loaded.is_taxonomy)
+        self.assertEqual(loaded.root.name, "vehicles")
+
+    def test_load_taxonomy_nonexistent_raises(self):
+        from fiftyone.core.ontology import load_taxonomy
+
+        with self.assertRaises(ValueError):
+            load_taxonomy("nonexistent")
+
+    def test_load_taxonomy_on_annotation_ontology_raises(self):
+        from fiftyone.core.ontology import load_taxonomy
+
+        self._make_annotation_ontology("not_a_taxonomy").save()
+
+        with self.assertRaises(ValueError):
+            load_taxonomy("not_a_taxonomy")
+
+    def test_taxonomy_exists(self):
+        from fiftyone.core.ontology import taxonomy_exists
+
+        self.assertFalse(taxonomy_exists("vehicle_classes"))
+
+        self._make_taxonomy().save()
+        self.assertTrue(taxonomy_exists("vehicle_classes"))
+
+    def test_taxonomy_exists_false_for_annotation_ontology(self):
+        from fiftyone.core.ontology import taxonomy_exists
+
+        self._make_annotation_ontology("not_a_taxonomy").save()
+        self.assertFalse(taxonomy_exists("not_a_taxonomy"))
+
+    def test_list_taxonomies_excludes_annotation_ontologies(self):
+        from fiftyone.core.ontology import list_taxonomies
+
+        self._make_taxonomy("alpha_classes").save()
+        self._make_taxonomy("beta_classes").save()
+        self._make_annotation_ontology("an_ontology").save()
+
+        self.assertEqual(
+            list_taxonomies(), ["alpha_classes", "beta_classes"]
+        )
+
+    def test_list_taxonomies_glob(self):
+        from fiftyone.core.ontology import list_taxonomies
+
+        self._make_taxonomy("vehicle_classes").save()
+        self._make_taxonomy("animal_classes").save()
+
+        self.assertEqual(list_taxonomies("vehicle_*"), ["vehicle_classes"])
+
+    def test_list_ontologies_excludes_taxonomies(self):
+        from fiftyone.core.ontology import list_ontologies
+
+        self._make_taxonomy("vehicle_classes").save()
+        self._make_annotation_ontology("vehicle_ontology").save()
+
+        self.assertEqual(list_ontologies(), ["vehicle_ontology"])
+
+    def test_delete_taxonomy(self):
+        from fiftyone.core.ontology import delete_taxonomy, taxonomy_exists
+
+        self._make_taxonomy().save()
+
+        delete_taxonomy("vehicle_classes")
+        self.assertFalse(taxonomy_exists("vehicle_classes"))
+
+    def test_delete_taxonomy_nonexistent_raises(self):
+        from fiftyone.core.ontology import delete_taxonomy
+
+        with self.assertRaises(ValueError):
+            delete_taxonomy("nonexistent")
+
+    def test_delete_taxonomy_on_annotation_ontology_raises(self):
+        from fiftyone.core.ontology import delete_taxonomy, ontology_exists
+
+        self._make_annotation_ontology("not_a_taxonomy").save()
+
+        with self.assertRaises(ValueError):
+            delete_taxonomy("not_a_taxonomy")
+
+        # the annotation ontology is untouched
+        self.assertTrue(ontology_exists("not_a_taxonomy"))
+
+    def test_delete_referenced_taxonomy_without_force_raises(self):
+        from fiftyone.core.ontology import delete_taxonomy, taxonomy_exists
+
+        taxonomy = self._make_taxonomy()
+        taxonomy.save()
+        AnnotationOntology(name="bundle", taxonomy=taxonomy).save()
+
+        with self.assertRaises(ValueError):
+            delete_taxonomy("vehicle_classes")
+
+        self.assertTrue(taxonomy_exists("vehicle_classes"))
+
+    def test_delete_referenced_taxonomy_with_force_deletes(self):
+        from fiftyone.core.ontology import delete_taxonomy, taxonomy_exists
+
+        taxonomy = self._make_taxonomy()
+        taxonomy.save()
+        AnnotationOntology(name="bundle", taxonomy=taxonomy).save()
+
+        delete_taxonomy("vehicle_classes", force=True)
+        self.assertFalse(taxonomy_exists("vehicle_classes"))
+
+
 class NodeTests(unittest.TestCase):
     def test_create_leaf(self):
         n = Node(name="car")

--- a/tests/unittests/ontology_validation_tests.py
+++ b/tests/unittests/ontology_validation_tests.py
@@ -17,7 +17,10 @@ from fiftyone.core.annotation.attributes import (
     WhenOr,
 )
 from fiftyone.core.ontology import AnnotationOntology
-from fiftyone.core.ontology_validation import validate_annotation_ontology
+from fiftyone.core.ontology_validation import (
+    _validate_taxonomy_components,
+    validate_annotation_ontology,
+)
 
 
 class OperatorValidTests(unittest.TestCase):
@@ -114,6 +117,41 @@ class ComponentCompatibleTests(unittest.TestCase):
         )
         with self.assertRaises(ValueError):
             validate_annotation_ontology(ao)
+
+
+class TaxonomyComponentTests(unittest.TestCase):
+    def test_rejects_taxonomy_with_non_dropdown_component(self):
+        # the App only renders taxonomy-backed attributes as dropdowns
+        ao = AnnotationOntology(
+            name="test",
+            attributes=[
+                AttributeSpec(
+                    name="vehicle_type",
+                    type="str",
+                    component="radio",
+                    taxonomy="vehicle_classes",
+                ),
+            ],
+        )
+        with self.assertRaises(ValueError):
+            validate_annotation_ontology(ao)
+
+    def test_accepts_taxonomy_with_dropdown_component(self):
+        ao = AnnotationOntology(
+            name="test",
+            attributes=[
+                AttributeSpec(
+                    name="vehicle_type",
+                    type="str",
+                    component="dropdown",
+                    taxonomy="vehicle_classes",
+                ),
+            ],
+        )
+        # taxonomy-component rule passes; the taxonomy-ref resolver is what
+        # would flag the (unsaved) reference, validated separately
+        errors = _validate_taxonomy_components(ao)
+        self.assertEqual(errors, [])
 
 
 class NoCyclesTests(unittest.TestCase):

--- a/tests/unittests/ontology_validation_tests.py
+++ b/tests/unittests/ontology_validation_tests.py
@@ -133,8 +133,11 @@ class TaxonomyComponentTests(unittest.TestCase):
                 ),
             ],
         )
-        with self.assertRaises(ValueError):
-            validate_annotation_ontology(ao)
+        # Target the rule directly — going through
+        # validate_annotation_ontology would also raise on the unsaved
+        # taxonomy reference, so it wouldn't prove the dropdown rule fired.
+        errors = _validate_taxonomy_components(ao)
+        self.assertEqual(len(errors), 1)
 
     def test_accepts_taxonomy_with_dropdown_component(self):
         ao = AnnotationOntology(


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

- Add load_taxonomy, list_taxonomies, taxonomy_exists, delete_taxonomy 
- list_ontologies now excludes taxonomies
- delete_taxonomy guards against annotation ontologies that bundle it (force=True to override)
- Reject taxonomy-backed attributes with a non-dropdown component in validation

## 🧪 How is this patch tested? If it is not, please explain why.

Tested locally, added unit tests, and working on larger integration test. 

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added taxonomy-specific accessors and management actions, including loading, listing, checking existence, and deleting taxonomies.
  * Expanded public availability of taxonomy utilities.
* **Bug Fixes**
  * Split ontology listings so annotation ontologies and taxonomies are listed separately.
  * Added validation to ensure taxonomy-backed fields use the expected dropdown-style component.
  * Prevented accidental deletion of taxonomies that are still referenced, unless forced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2987
<!-- enterprise-sync-pr:end -->