### PR TITLE
Clone execution store records (panel run history) on full dataset clone

### DIFF
--- a/fiftyone/__init__.py
+++ b/fiftyone/__init__.py
@@ -34,3 +34,12 @@ import fiftyone.core.logging as _fol
 
 
 _fol.init_logging()
+
+# Register the execution store extras cloner so that allowlisted panel run
+# history follows a full dataset clone (including SDK clones).
+try:
+    import fiftyone.operators.store.clone as _esclone  # noqa: F401
+except Exception:  # pragma: no cover - best-effort registration
+    logger.warning(
+        "Failed to register execution store clone hook", exc_info=True
+    )

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -10179,7 +10179,8 @@ def _clone_collection(
 
     # Clone extras (full datasets only)
     if view is None and (
-        dataset.has_saved_views
+        _extras_cloners
+        or dataset.has_saved_views
         or dataset.has_workspaces
         or dataset.has_annotation_runs
         or dataset.has_brain_runs
@@ -10560,9 +10561,38 @@ def _update_no_overwrite(d, dnew):
     d.update({k: v for k, v in dnew.items() if k not in d})
 
 
+# Hooks invoked when a full dataset is cloned, as
+# ``cloner(src_dataset, dst_dataset, now, id_map)``. This lets downstream code
+# register additional "extras" to clone (e.g. execution store records) without
+# this module needing to know about those concepts. See
+# :func:`register_extras_cloner`.
+_extras_cloners = []
+
+
+def register_extras_cloner(cloner):
+    """Registers a callable to be invoked during :func:`_clone_extras`.
+
+    Each registered cloner is called as ``cloner(src_dataset, dst_dataset,
+    now, id_map)`` whenever a full dataset (not a view) is cloned, where
+    ``id_map`` is a ``{str(old_id): str(new_id)}`` dict mapping the source
+    dataset doc id and every cloned run doc id to their newly-minted clone
+    counterparts. Failures in a cloner are logged but do not abort the clone.
+
+    Args:
+        cloner: a callable with signature
+            ``cloner(src_dataset, dst_dataset, now, id_map)``
+    """
+    if cloner not in _extras_cloners:
+        _extras_cloners.append(cloner)
+
+
 def _clone_extras(src_dataset, dst_dataset, now):
     src_doc = src_dataset._doc
     dst_doc = dst_dataset._doc
+
+    # Maps source ids (dataset doc + cloned run docs) to their new clone ids,
+    # so extras cloners can rewrite references that change on clone
+    id_map = {str(src_doc.id): str(dst_doc.id)}
 
     # Clone saved views
     for _view_doc in src_doc.get_saved_views():
@@ -10591,6 +10621,7 @@ def _clone_extras(src_dataset, dst_dataset, now):
         run_doc.timestamp = now
         run_doc.save(upsert=True)
 
+        id_map[str(_run_doc.id)] = str(run_doc.id)
         dst_doc.annotation_runs[anno_key] = run_doc
 
     # Clone brain method runs
@@ -10600,6 +10631,7 @@ def _clone_extras(src_dataset, dst_dataset, now):
         run_doc.timestamp = now
         run_doc.save(upsert=True)
 
+        id_map[str(_run_doc.id)] = str(run_doc.id)
         dst_doc.brain_methods[brain_key] = run_doc
 
     # Clone evaluation runs
@@ -10609,6 +10641,7 @@ def _clone_extras(src_dataset, dst_dataset, now):
         run_doc.timestamp = now
         run_doc.save(upsert=True)
 
+        id_map[str(_run_doc.id)] = str(run_doc.id)
         dst_doc.evaluations[eval_key] = run_doc
 
     # Clone other runs
@@ -10618,9 +10651,21 @@ def _clone_extras(src_dataset, dst_dataset, now):
         run_doc.timestamp = now
         run_doc.save(upsert=True)
 
+        id_map[str(_run_doc.id)] = str(run_doc.id)
         dst_doc.runs[run_key] = run_doc
 
     dst_doc.save()
+
+    # Run any registered extras cloners (e.g. execution store cloning).
+    # Best-effort: a failure here must not abort the clone, which has already
+    # copied the dataset and its samples.
+    for cloner in _extras_cloners:
+        try:
+            cloner(src_dataset, dst_dataset, now, id_map)
+        except Exception:
+            logger.warning(
+                "Failed to run extras cloner %r", cloner, exc_info=True
+            )
 
 
 def _clone_reference_doc(ref_doc):

--- a/fiftyone/operators/store/clone.py
+++ b/fiftyone/operators/store/clone.py
@@ -1,0 +1,170 @@
+"""
+Clone execution store records when a dataset is cloned.
+
+This module registers an "extras cloner" (see
+:func:`fiftyone.core.dataset.register_extras_cloner`) that copies an
+allowlisted set of execution store records from a source dataset to its
+clone, so the run history backing stateful panels follows a full dataset
+clone.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import logging
+
+from bson import ObjectId
+
+import fiftyone.core.odm as foo
+from fiftyone.core.dataset import register_extras_cloner
+
+logger = logging.getLogger(__name__)
+
+
+# Store names registered by downstream code (e.g. additional panels) to be
+# cloned alongside the built-in ones. See :func:`register_cloneable_store`.
+_registered_store_names = []
+
+
+def register_cloneable_store(store_name):
+    """Registers an execution store whose records should be copied when a full
+    dataset is cloned.
+
+    Lets code outside this module (e.g. additional panels) opt their store into
+    cloning without this module needing to import them. Registrations must be
+    in place before the clone runs.
+
+    Args:
+        store_name: the execution store name
+    """
+    if store_name and store_name not in _registered_store_names:
+        _registered_store_names.append(store_name)
+
+
+def _cloneable_store_names():
+    """Execution store names whose records are copied when a full dataset is
+    cloned: built-in panels (sourced from their own store-name constants) plus
+    anything registered via :func:`register_cloneable_store`.
+
+    This is intentionally an allowlist rather than "clone every store for the
+    dataset": stores may hold arbitrary plugin state, and some embed the source
+    dataset id (or version) inside their values or store name, so naively
+    copying them would produce stale or incorrect references on the clone.
+
+    Built-in panels are imported lazily here (at clone time, not at module
+    import) and skipped if unavailable, so a panel that isn't installed simply
+    isn't cloned.
+    """
+    names = list(_registered_store_names)
+
+    try:
+        from plugins.panels.similarity_search.constants import STORE_NAME
+
+        if STORE_NAME not in names:
+            names.append(STORE_NAME)
+    except Exception:
+        pass
+
+    try:
+        from plugins.utils.model_evaluation import STORE_NAME
+
+        if STORE_NAME not in names:
+            names.append(STORE_NAME)
+    except Exception:
+        pass
+
+    return names
+
+
+# Ids are 24-char ObjectId hex strings; strings longer than this can't be id
+# references, so skipping them keeps the value remap O(1) for large serialized
+# payloads (e.g. cached metrics) rather than hashing them on every lookup.
+_MAX_ID_LEN = 64
+
+
+def _remap_ids(value, id_map):
+    """Recursively rewrites any id in ``value`` that appears in ``id_map``.
+
+    Replaces both dict keys and scalar values (``str`` or ``ObjectId``). Only
+    substitutes ids the clone actually minted, so it needs no knowledge of a
+    store's schema; anything not in ``id_map`` passes through untouched.
+    """
+    if isinstance(value, dict):
+        return {
+            id_map.get(k, k): _remap_ids(v, id_map) for k, v in value.items()
+        }
+    if isinstance(value, list):
+        return [_remap_ids(v, id_map) for v in value]
+    if isinstance(value, str):
+        return id_map.get(value, value) if len(value) <= _MAX_ID_LEN else value
+    if isinstance(value, ObjectId):
+        mapped = id_map.get(str(value))
+        return ObjectId(mapped) if mapped else value
+    return value
+
+
+def clone_execution_stores(src_dataset, dst_dataset, now, id_map=None):
+    """Copies allowlisted execution store records to a cloned dataset.
+
+    Execution store records are keyed by ``(store_name, key, dataset_id)``.
+    Cloning copies each matching record under a fresh ``_id`` with
+    ``dataset_id`` rewritten to the destination dataset. Original timestamps
+    are preserved so the cloned panels reflect the original run history.
+
+    A clone re-creates run docs with new ids, so store data keyed by (or
+    referencing) a run doc id would otherwise be orphaned. ``id_map`` maps each
+    source id (the dataset doc + cloned run docs) to its new id; each record's
+    ``key`` and ``value`` are rewritten through it so references resolve on the
+    clone.
+
+    Args:
+        src_dataset: the source :class:`fiftyone.core.dataset.Dataset`
+        dst_dataset: the destination (clone)
+            :class:`fiftyone.core.dataset.Dataset`
+        now: the clone timestamp (unused; record timestamps are preserved)
+        id_map (None): a ``{str(old_id): str(new_id)}`` mapping of source ids to
+            their clone counterparts
+    """
+    from fiftyone.factory.repos.execution_store import MongoExecutionStoreRepo
+
+    src_id = src_dataset._doc.id
+    dst_id = dst_dataset._doc.id
+    if src_id is None or dst_id is None:
+        return
+
+    store_names = _cloneable_store_names()
+    if not store_names:
+        return
+
+    id_map = id_map or {}
+
+    coll = foo.get_db_conn()[MongoExecutionStoreRepo.COLLECTION_NAME]
+
+    docs = []
+    for doc in coll.find(
+        {
+            "dataset_id": src_id,
+            "store_name": {"$in": store_names},
+        }
+    ):
+        doc.pop("_id", None)
+        doc["dataset_id"] = dst_id
+        if id_map:
+            doc["key"] = id_map.get(doc.get("key"), doc.get("key"))
+            doc["value"] = _remap_ids(doc.get("value"), id_map)
+        docs.append(doc)
+
+    if docs:
+        coll.insert_many(docs)
+        logger.debug(
+            "Cloned %d execution store record(s) from dataset %s to %s",
+            len(docs),
+            src_id,
+            dst_id,
+        )
+
+
+# Runs on import. Keep the `import ...store.clone` in fiftyone/__init__.py —
+# without it nothing registers and clones silently stop copying these records.
+register_extras_cloner(clone_execution_stores)

--- a/fiftyone/operators/store/clone.py
+++ b/fiftyone/operators/store/clone.py
@@ -60,19 +60,25 @@ def _cloneable_store_names():
 
     try:
         from plugins.panels.similarity_search.constants import STORE_NAME
-
+    except ModuleNotFoundError as e:
+        # Panel not installed in this distribution; surface anything else
+        # (renamed constant, transitive import failure, etc.)
+        # pylint: disable=no-member
+        if not (e.name or "").startswith("plugins"):
+            raise
+    else:
         if STORE_NAME not in names:
             names.append(STORE_NAME)
-    except Exception:
-        pass
 
     try:
         from plugins.utils.model_evaluation import STORE_NAME
-
+    except ModuleNotFoundError as e:
+        # pylint: disable=no-member
+        if not (e.name or "").startswith("plugins"):
+            raise
+    else:
         if STORE_NAME not in names:
             names.append(STORE_NAME)
-    except Exception:
-        pass
 
     return names
 

--- a/tests/unittests/execution_store_unit_tests.py
+++ b/tests/unittests/execution_store_unit_tests.py
@@ -454,7 +454,7 @@ class TestCloneExecutionStores(unittest.TestCase):
         # the owning panels at runtime, but the copy/remap logic under test is
         # independent of which panels happen to be importable here.
         store_names = [
-            "auto_labeling_run_store",
+            "another_panel_store",
             "similarity_search_panel",
             "model_evaluation_panel_builtin",
         ]
@@ -494,7 +494,7 @@ class TestCloneExecutionStores(unittest.TestCase):
             {
                 "_id": ObjectId(),
                 "dataset_id": src_id,
-                "store_name": "auto_labeling_run_store",
+                "store_name": "another_panel_store",
                 "key": "al1",
                 "value": {"status": "done"},
             },
@@ -509,7 +509,7 @@ class TestCloneExecutionStores(unittest.TestCase):
             {
                 "_id": ObjectId(),
                 "dataset_id": src_id,
-                "store_name": "data_quality_panel",
+                "store_name": "unlisted_panel_store",
                 "key": "dq1",
                 "value": "no",
             },
@@ -530,7 +530,7 @@ class TestCloneExecutionStores(unittest.TestCase):
             names,
             {
                 "similarity_search_panel",
-                "auto_labeling_run_store",
+                "another_panel_store",
                 "model_evaluation_panel_builtin",
             },
         )
@@ -540,7 +540,7 @@ class TestCloneExecutionStores(unittest.TestCase):
         self.assertTrue(all(d["dataset_id"] == dst_id for d in inserted))
         self.assertTrue(all("_id" not in d for d in inserted))
         # excluded stores / other datasets never copied
-        self.assertNotIn("data_quality_panel", names)
+        self.assertNotIn("unlisted_panel_store", names)
         # original values preserved
         sim = next(
             d
@@ -609,8 +609,8 @@ class TestCloneExecutionStores(unittest.TestCase):
         self.assertTrue(all(d["dataset_id"] == dst_id for d in inserted))
 
     def test_remap_leaves_unmatched_ids_untouched(self):
-        # AL + Similarity Search reference only sample ids (preserved on clone)
-        # and panel uuids — none appear in the id_map, so they pass through.
+        # Records that reference only sample ids (preserved on clone) and panel
+        # uuids — none appear in the id_map, so they pass through unchanged.
         src_id = ObjectId()
         dst_id = ObjectId()
         id_map = {str(src_id): str(dst_id), str(ObjectId()): str(ObjectId())}
@@ -625,7 +625,7 @@ class TestCloneExecutionStores(unittest.TestCase):
             {
                 "_id": ObjectId(),
                 "dataset_id": src_id,
-                "store_name": "auto_labeling_run_store",
+                "store_name": "another_panel_store",
                 "key": "al-uuid",
                 "value": {"label_field": "predictions", "status": "done"},
             },
@@ -650,10 +650,14 @@ class TestCloneExecutionStores(unittest.TestCase):
         mock_coll.insert_many.assert_not_called()
 
     def test_registered_as_extras_cloner(self):
+        # Importing fiftyone must register the cloner (via fiftyone/__init__.py),
+        # so check the registry without importing the clone module directly,
+        # which would itself trigger the registration being asserted.
+        import fiftyone  # noqa: F401
         import fiftyone.core.dataset as fod
-        from fiftyone.operators.store.clone import clone_execution_stores
 
-        self.assertIn(clone_execution_stores, fod._extras_cloners)
+        registered = [getattr(c, "__name__", "") for c in fod._extras_cloners]
+        self.assertIn("clone_execution_stores", registered)
 
     def test_register_cloneable_store(self):
         from fiftyone.operators.store import clone as esc

--- a/tests/unittests/execution_store_unit_tests.py
+++ b/tests/unittests/execution_store_unit_tests.py
@@ -420,3 +420,250 @@ class ExecutionStoreServiceDatasetIdTests(unittest.TestCase):
             )
 
         self.assertIn("dataset_id must be an ObjectId", str(context.exception))
+
+
+class TestCloneExecutionStores(unittest.TestCase):
+    """Tests for cloning execution store records to a cloned dataset."""
+
+    def _clone(self, seed, src_id, dst_id, id_map=None):
+        """Runs ``clone_execution_stores`` against a mocked collection seeded
+        with ``seed`` and returns the list of inserted documents."""
+        from fiftyone.operators.store import clone as esc
+
+        inserted = []
+        mock_coll = MagicMock()
+
+        def _find(query):
+            ds = query["dataset_id"]
+            allow = set(query["store_name"]["$in"])
+            return [
+                dict(d)
+                for d in seed
+                if d["dataset_id"] == ds and d["store_name"] in allow
+            ]
+
+        mock_coll.find.side_effect = _find
+        mock_coll.insert_many.side_effect = lambda docs: inserted.extend(docs)
+
+        src = Mock()
+        src._doc.id = src_id
+        dst = Mock()
+        dst._doc.id = dst_id
+
+        # Decouple from plugin importability: the store names are sourced from
+        # the owning panels at runtime, but the copy/remap logic under test is
+        # independent of which panels happen to be importable here.
+        store_names = [
+            "auto_labeling_run_store",
+            "similarity_search_panel",
+            "model_evaluation_panel_builtin",
+        ]
+
+        with patch(
+            "fiftyone.operators.store.clone.foo.get_db_conn"
+        ) as mock_conn, patch(
+            "fiftyone.operators.store.clone._cloneable_store_names",
+            return_value=store_names,
+        ):
+            mock_conn.return_value = {
+                MongoExecutionStoreRepo.COLLECTION_NAME: mock_coll
+            }
+            esc.clone_execution_stores(src, dst, now=None, id_map=id_map)
+
+        return inserted, mock_coll
+
+    def test_clones_only_allowlisted_stores(self):
+        src_id = ObjectId()
+        other_id = ObjectId()
+        dst_id = ObjectId()
+        seed = [
+            {
+                "_id": ObjectId(),
+                "dataset_id": src_id,
+                "store_name": "similarity_search_panel",
+                "key": "run1",
+                "value": {"q": "dog"},
+            },
+            {
+                "_id": ObjectId(),
+                "dataset_id": src_id,
+                "store_name": "similarity_search_panel",
+                "key": "__store__",
+                "value": None,
+            },
+            {
+                "_id": ObjectId(),
+                "dataset_id": src_id,
+                "store_name": "auto_labeling_run_store",
+                "key": "al1",
+                "value": {"status": "done"},
+            },
+            {
+                "_id": ObjectId(),
+                "dataset_id": src_id,
+                "store_name": "model_evaluation_panel_builtin",
+                "key": "eval1",
+                "value": {"k": 1},
+            },
+            # Excluded: not on the allowlist
+            {
+                "_id": ObjectId(),
+                "dataset_id": src_id,
+                "store_name": "data_quality_panel",
+                "key": "dq1",
+                "value": "no",
+            },
+            # Excluded: belongs to a different dataset
+            {
+                "_id": ObjectId(),
+                "dataset_id": other_id,
+                "store_name": "similarity_search_panel",
+                "key": "other",
+                "value": "no",
+            },
+        ]
+
+        inserted, _ = self._clone(seed, src_id, dst_id)
+
+        names = {d["store_name"] for d in inserted}
+        self.assertEqual(
+            names,
+            {
+                "similarity_search_panel",
+                "auto_labeling_run_store",
+                "model_evaluation_panel_builtin",
+            },
+        )
+        # 3 allowlisted stores incl. the sim-search __store__ metadata record
+        self.assertEqual(len(inserted), 4)
+        # dataset_id rewritten to the clone; original _id dropped
+        self.assertTrue(all(d["dataset_id"] == dst_id for d in inserted))
+        self.assertTrue(all("_id" not in d for d in inserted))
+        # excluded stores / other datasets never copied
+        self.assertNotIn("data_quality_panel", names)
+        # original values preserved
+        sim = next(
+            d
+            for d in inserted
+            if d["store_name"] == "similarity_search_panel"
+            and d["key"] == "run1"
+        )
+        self.assertEqual(sim["value"], {"q": "dog"})
+
+    def test_remaps_model_evaluation_ids(self):
+        src_id = ObjectId()
+        dst_id = ObjectId()
+        old_eval_id = str(ObjectId())
+        new_eval_id = str(ObjectId())
+        id_map = {str(src_id): str(dst_id), old_eval_id: new_eval_id}
+        seed = [
+            # review status + note: eval id is a dict key inside the value
+            {
+                "_id": ObjectId(),
+                "dataset_id": src_id,
+                "store_name": "model_evaluation_panel_builtin",
+                "key": "statuses",
+                "value": {old_eval_id: "reviewed"},
+            },
+            {
+                "_id": ObjectId(),
+                "dataset_id": src_id,
+                "store_name": "model_evaluation_panel_builtin",
+                "key": "notes",
+                "value": {old_eval_id: "looks good"},
+            },
+            # pending_evaluations: keyed by the source dataset id
+            {
+                "_id": ObjectId(),
+                "dataset_id": src_id,
+                "store_name": "model_evaluation_panel_builtin",
+                "key": "pending_evaluations",
+                "value": {str(src_id): [{"eval_key": "eval"}]},
+            },
+            # cached metrics: eval id is the document key itself
+            {
+                "_id": ObjectId(),
+                "dataset_id": src_id,
+                "store_name": "model_evaluation_panel_builtin",
+                "key": old_eval_id,
+                "value": {"metrics": "..."},
+            },
+        ]
+
+        inserted, _ = self._clone(seed, src_id, dst_id, id_map=id_map)
+
+        by_key = {d["key"]: d for d in inserted}
+        # statuses/notes inner keys remapped to the new eval id
+        self.assertEqual(
+            by_key["statuses"]["value"], {new_eval_id: "reviewed"}
+        )
+        self.assertEqual(by_key["notes"]["value"], {new_eval_id: "looks good"})
+        # pending_evaluations dataset-id key remapped to the clone
+        self.assertEqual(
+            by_key["pending_evaluations"]["value"],
+            {str(dst_id): [{"eval_key": "eval"}]},
+        )
+        # cache document key itself remapped from old eval id to new
+        self.assertIn(new_eval_id, by_key)
+        self.assertNotIn(old_eval_id, by_key)
+        self.assertTrue(all(d["dataset_id"] == dst_id for d in inserted))
+
+    def test_remap_leaves_unmatched_ids_untouched(self):
+        # AL + Similarity Search reference only sample ids (preserved on clone)
+        # and panel uuids — none appear in the id_map, so they pass through.
+        src_id = ObjectId()
+        dst_id = ObjectId()
+        id_map = {str(src_id): str(dst_id), str(ObjectId()): str(ObjectId())}
+        seed = [
+            {
+                "_id": ObjectId(),
+                "dataset_id": src_id,
+                "store_name": "similarity_search_panel",
+                "key": "run:abc",
+                "value": {"brain_key": "sim", "result_ids": ["s1", "s2"]},
+            },
+            {
+                "_id": ObjectId(),
+                "dataset_id": src_id,
+                "store_name": "auto_labeling_run_store",
+                "key": "al-uuid",
+                "value": {"label_field": "predictions", "status": "done"},
+            },
+        ]
+
+        inserted, _ = self._clone(seed, src_id, dst_id, id_map=id_map)
+
+        by_key = {d["key"]: d for d in inserted}
+        self.assertEqual(
+            by_key["run:abc"]["value"],
+            {"brain_key": "sim", "result_ids": ["s1", "s2"]},
+        )
+        self.assertIn("al-uuid", by_key)
+        self.assertEqual(
+            by_key["al-uuid"]["value"],
+            {"label_field": "predictions", "status": "done"},
+        )
+
+    def test_no_records_no_insert(self):
+        inserted, mock_coll = self._clone([], ObjectId(), ObjectId())
+        self.assertEqual(inserted, [])
+        mock_coll.insert_many.assert_not_called()
+
+    def test_registered_as_extras_cloner(self):
+        import fiftyone.core.dataset as fod
+        from fiftyone.operators.store.clone import clone_execution_stores
+
+        self.assertIn(clone_execution_stores, fod._extras_cloners)
+
+    def test_register_cloneable_store(self):
+        from fiftyone.operators.store import clone as esc
+
+        name = "some_downstream_store"
+        try:
+            esc.register_cloneable_store(name)
+            self.assertIn(name, esc._cloneable_store_names())
+            # idempotent
+            esc.register_cloneable_store(name)
+            self.assertEqual(esc._cloneable_store_names().count(name), 1)
+        finally:
+            esc._registered_store_names.remove(name)

--- a/tests/unittests/execution_store_unit_tests.py
+++ b/tests/unittests/execution_store_unit_tests.py
@@ -428,6 +428,7 @@ class TestCloneExecutionStores(unittest.TestCase):
     def _clone(self, seed, src_id, dst_id, id_map=None):
         """Runs ``clone_execution_stores`` against a mocked collection seeded
         with ``seed`` and returns the list of inserted documents."""
+        # pylint: disable=no-name-in-module,import-error
         from fiftyone.operators.store import clone as esc
 
         inserted = []
@@ -650,16 +651,23 @@ class TestCloneExecutionStores(unittest.TestCase):
         mock_coll.insert_many.assert_not_called()
 
     def test_registered_as_extras_cloner(self):
-        # Importing fiftyone must register the cloner (via fiftyone/__init__.py),
-        # so check the registry without importing the clone module directly,
-        # which would itself trigger the registration being asserted.
-        import fiftyone  # noqa: F401
-        import fiftyone.core.dataset as fod
+        # `import fiftyone` alone must register the cloner (via
+        # fiftyone/__init__.py). Checked in a fresh interpreter so the result
+        # can't be satisfied by other tests importing the clone module
+        # directly (which would also trigger registration).
+        import subprocess
+        import sys
 
-        registered = [getattr(c, "__name__", "") for c in fod._extras_cloners]
-        self.assertIn("clone_execution_stores", registered)
+        code = (
+            "import fiftyone\n"
+            "import fiftyone.core.dataset as d\n"
+            "names = [getattr(c, '__name__', '') for c in d._extras_cloners]\n"
+            "assert 'clone_execution_stores' in names, names\n"
+        )
+        subprocess.run([sys.executable, "-c", code], check=True)
 
     def test_register_cloneable_store(self):
+        # pylint: disable=no-name-in-module,import-error
         from fiftyone.operators.store import clone as esc
 
         name = "some_downstream_store"


### PR DESCRIPTION
## 🔗 Related Issues

https://github.com/user-attachments/assets/715bc6ff-6faa-46e3-b9d5-15b1ad8b73ae




## 📋 What changes are proposed in this pull request?

Carries panel run history through a full dataset clone. Today `_clone_extras()`
copies saved views, workspaces, and annotation/brain/evaluation/other runs, but
**not** the execution-store records that stateful panels persist their run
history in. After a clone, the brain/eval runs exist on the new dataset but the
panels appear empty.

This adds a generic extras-cloner hook plus a cloner that copies an allowlisted
set of execution-store records to the clone:

- **`core/dataset.py`** — `register_extras_cloner()` + `_extras_cloners`,
  invoked best-effort at the end of `_clone_extras()` (a failure there never
  aborts the clone). `_clone_extras()` builds a `{str(old_id) -> str(new_id)}`
  map covering the dataset doc + every cloned run doc and passes it to each
  cloner. No panel/feature specifics live in this file.
- **`operators/store/clone.py`** (new) — `clone_execution_stores()` copies the
  allowlisted records under the new `dataset_id` (fresh `_id`, original
  timestamps preserved) and rewrites each record's `key` and `value` through
  the id map. A clone re-mints run-doc ids, so store data keyed by (or
  referencing) a run-doc id would otherwise be orphaned; `_remap_ids()` swaps
  only ids the clone actually minted, so it needs no knowledge of any store's
  schema, and a length guard keeps it O(1) for large serialized payloads.
  - The allowlist is sourced from each panel's own store-name constant
    (similarity search, model evaluation), plus a `register_cloneable_store()`
    hook so downstream packages can opt their own stores in without this module
    importing them.

Why an allowlist rather than cloning every store: stores can hold arbitrary
plugin state, and some embed the source dataset id (or version) inside their
values or store name, so copying them blindly would carry stale references onto
the clone.

Example: Model Evaluation keys its review statuses, notes, and metrics cache by
the evaluation id (the eval run-doc ObjectId), which changes on clone — the id
remap rewrites those so the review state survives.

## 🧪 How is this patch tested? If it is not, please explain why.

Adds `TestCloneExecutionStores` in
`tests/unittests/execution_store_unit_tests.py` covering:
- only allowlisted stores (and only the source dataset) are copied;
  `dataset_id` rewritten, original `_id` dropped, values preserved
- id remap rewrites nested dict keys (statuses/notes), the `pending_evaluations`
  dataset-id key, and a cache document whose key *is* the eval id
- records with no matching ids pass through untouched
- no records → no insert
- the cloner registers itself; `register_cloneable_store` is idempotent

Manual: run an evaluation, set a review status + note in the Model Evaluation
panel, clone the dataset, and confirm the status/note carry over to the clone.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Cloning an entire dataset now also carries over the run history of stateful
panels (Similarity Search, Model Evaluation).

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Dataset cloning now includes execution-store “extras” using a configurable allowlist, preserving related records in cloned datasets.
  * Added support for registering additional execution-store types to be copied during cloning.

* **Bug Fixes**
  * Cloned execution-store records now consistently rewrite destination dataset references and remap stored evaluation/ID references when mappings are available.
  * Best-effort extras cloning no longer interrupts the overall dataset clone if a specific extras step fails.

* **Tests**
  * Added unit tests for allowlisted cloning behavior, ID remapping (including nested values), and robustness when no records exist or mappings are missing.
  * Added a subprocess-based check that importing the package activates the extras cloner registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3017
<!-- enterprise-sync-pr:end -->