### PR TITLE
fix(server): avoid illegal union-of-unions when building GraphQL schema

### DIFF
--- a/fiftyone/server/aggregations.py
+++ b/fiftyone/server/aggregations.py
@@ -101,16 +101,18 @@ class StringAggregation(Aggregation):
     values: t.Optional[t.List[StringAggregationValue]] = None
 
 
-AggregateResult = t.Annotated[
-    t.Union[
-        BooleanAggregation,
-        DataAggregation,
-        IntAggregation,
-        FloatAggregation,
-        RootAggregation,
-        StringAggregation,
-    ],
-    gql.union("AggregateResult"),
+# Internal helper return type. Not exposed as a GraphQL field, so we
+# deliberately omit ``gql.union(...)`` — registering a Strawberry union
+# here causes the schema converter to dedupe the identical member set
+# inside ``AggregationResponse`` below, producing an illegal
+# union-of-unions at schema build time.
+AggregateResult = t.Union[
+    BooleanAggregation,
+    DataAggregation,
+    IntAggregation,
+    FloatAggregation,
+    RootAggregation,
+    StringAggregation,
 ]
 
 
@@ -118,7 +120,15 @@ async def aggregate_resolver(
     form: AggregationForm,
 ) -> t.List[
     t.Annotated[
-        t.Union[AggregateResult, AggregationQueryTimeout],
+        t.Union[
+            BooleanAggregation,
+            DataAggregation,
+            IntAggregation,
+            FloatAggregation,
+            RootAggregation,
+            StringAggregation,
+            AggregationQueryTimeout,
+        ],
         gql.union("AggregationResponse"),
     ]
 ]:


### PR DESCRIPTION
## What changes are proposed in this pull request?

`AggregateResult` in `fiftyone/server/aggregations.py` was registered as a Strawberry union via `gql.union("AggregateResult")`, but it is only ever used as an **internal resolver return annotation** — it is never exposed as a GraphQL field on its own.

Because `AggregationResponse` is itself a union built over the same members plus `AggregationQueryTimeout`, nesting `AggregateResult` inside it makes Strawberry's schema converter dedupe the identical member set into a **union-of-unions**, which is illegal in GraphQL and can fail at schema build time.

This PR:
- Demotes `AggregateResult` to a plain `t.Union[...]` (used purely as a Python return type), and
- Lists the concrete members inline in the `AggregationResponse` union.

There is **no schema or wire-format change** — `AggregationResponse` already exposed exactly these members; this only changes how the union is assembled internally.

## How is this patch tested?

Schema builds and existing aggregation server tests/resolvers exercise this path. The GraphQL schema (`schema.graphql`) is unchanged by this refactor.

## Release Notes

- [ ] Is this a user-facing change? No.

### What areas of FiftyOne does this PR affect?
- [x] Core `fiftyone` Python library / server

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could prevent aggregation responses from being built correctly.
  * Improved reliability of aggregation results, including timeout handling, so queries return more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/2998
<!-- enterprise-sync-pr:end -->