### PR TITLE
fix(components): render Markdown safely without a ThemeProvider

### DIFF
--- a/app/packages/components/src/components/Markdown/index.tsx
+++ b/app/packages/components/src/components/Markdown/index.tsx
@@ -31,8 +31,9 @@ SyntaxHighlighter.registerLanguage("typescript", ts);
 SyntaxHighlighter.registerLanguage("python", python);
 
 const InlineCode = styled.span`
-  background: ${({ theme }) => theme.background.level1};
-  color: ${({ theme }) => theme.voxel[500]};
+  background: ${({ theme }) =>
+    theme?.background?.level1 ?? "hsl(200, 0%, 20%)"};
+  color: ${({ theme }) => theme?.voxel?.[500] ?? "#FF6D04"};
   border-radius: 3px;
   padding: 0.2em 0.4em;
   font-size: 85%;
@@ -40,7 +41,8 @@ const InlineCode = styled.span`
 `;
 
 const CodeContainer = styled(Box)`
-  border: 1px solid ${({ theme }) => theme.background.level1};
+  border: 1px solid
+    ${({ theme }) => theme?.background?.level1 ?? "hsl(200, 0%, 20%)"};
   pre {
     margin: 0;
     padding: 1rem !important;
@@ -53,8 +55,10 @@ const CodeHeader = styled.div`
   justify-content: space-between;
   align-items: center;
   padding: 0rem 1rem;
-  border-bottom: 1px solid ${({ theme }) => theme.background.level1};
-  background: ${({ theme }) => theme.background.level2};
+  border-bottom: 1px solid
+    ${({ theme }) => theme?.background?.level1 ?? "hsl(200, 0%, 20%)"};
+  background: ${({ theme }) =>
+    theme?.background?.level2 ?? "hsl(200, 0%, 10%)"};
 `;
 
 const defaultSx: SxProps = { color: "inherit", mb: 1 };


### PR DESCRIPTION
## What changes are proposed in this pull request?

The `Markdown` component's styled-components read theme tokens directly — `theme.background.level1`, `theme.background.level2`, and `theme.voxel[500]`. When `Markdown` is rendered outside a `ThemeProvider` (for example in a standalone operator/modal host, or a story/preview), `theme` is `undefined` and the component throws.

This adds optional chaining with literal fallbacks that match the default dark theme, so the component degrades gracefully instead of crashing:

```ts
background: ${({ theme }) => theme?.background?.level1 ?? "hsl(200, 0%, 20%)"};
color: ${({ theme }) => theme?.voxel?.[500] ?? "#FF6D04"};
```

When a `ThemeProvider` is present (the normal case), behavior is unchanged.

## How is this patch tested?

Manually verified Markdown renders both with and without a surrounding `ThemeProvider`. No behavior change in the themed path.

## Release Notes

- [ ] Is this a user-facing change? No (robustness fix).

### What areas of FiftyOne does this PR affect?
- [x] App: FiftyOne application changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved theme styling fallbacks for markdown code blocks and headers, making them display more reliably when theme values are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3000
<!-- enterprise-sync-pr:end -->