### PR TITLE
perf(lighter): decode masks off the main thread (worker + transfer)

### DIFF
--- a/app/packages/lighter/src/utils/maskDecodeWorker.ts
+++ b/app/packages/lighter/src/utils/maskDecodeWorker.ts
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ *
+ * Web worker that decodes + rasterizes a mask into a white+alpha `ImageBitmap`
+ * off the main thread, then transfers the bitmap (zero-copy) back. Moves the
+ * base64/numpy decode, the per-pixel rasterize, and the `ImageBitmap` creation
+ * off the UI thread so dense samples don't allocate/loop on it.
+ *
+ * Pairs with `maskDecoding.ts` (the dispatcher + main-thread fallback).
+ */
+
+import type { OverlayMask } from "@fiftyone/looker/src/numpy";
+
+import { decodeMaskToRaster } from "./maskRaster";
+
+export interface MaskDecodeRequest {
+  uuid: string;
+  maskData: string | OverlayMask;
+}
+
+interface MaskDecodeSuccess {
+  uuid: string;
+  ok: true;
+  bitmap: ImageBitmap;
+  rawPixels: Uint8Array;
+  width: number;
+  height: number;
+}
+
+interface MaskDecodeFailure {
+  uuid: string;
+  ok: false;
+  error: string;
+}
+
+export type MaskDecodeResponse = MaskDecodeSuccess | MaskDecodeFailure;
+
+/** True only when this module is running as a dedicated worker. */
+const isWorkerScope = (): boolean => {
+  const scope = globalThis as { WorkerGlobalScope?: new () => unknown };
+  return (
+    typeof scope.WorkerGlobalScope !== "undefined" &&
+    self instanceof scope.WorkerGlobalScope
+  );
+};
+
+const handleMessage = async (event: MessageEvent<MaskDecodeRequest>) => {
+  const { uuid, maskData } = event.data;
+  const post = (self as DedicatedWorkerGlobalScope).postMessage.bind(self);
+
+  try {
+    const { rgba, width, height, rawPixels } = decodeMaskToRaster(maskData);
+    const bitmap = await createImageBitmap(
+      new ImageData(new Uint8ClampedArray(rgba), width, height)
+    );
+
+    const payload: MaskDecodeSuccess = {
+      uuid,
+      ok: true,
+      bitmap,
+      rawPixels,
+      width,
+      height,
+    };
+
+    // Transfer the decoded bitmap + the single-channel buffer zero-copy.
+    post(payload, [bitmap, rawPixels.buffer]);
+  } catch (err) {
+    const payload: MaskDecodeFailure = {
+      uuid,
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+    post(payload);
+  }
+};
+
+if (isWorkerScope()) {
+  self.onmessage = handleMessage;
+}

--- a/app/packages/lighter/src/utils/maskDecoding.test.ts
+++ b/app/packages/lighter/src/utils/maskDecoding.test.ts
@@ -29,6 +29,9 @@ describe("decodeMask", () => {
   beforeEach(() => {
     lastImageData = undefined;
 
+    // Force the deterministic main-thread fallback (no real Worker in jsdom).
+    vi.stubGlobal("Worker", undefined);
+
     vi.stubGlobal(
       "ImageData",
       class {

--- a/app/packages/lighter/src/utils/maskDecoding.ts
+++ b/app/packages/lighter/src/utils/maskDecoding.ts
@@ -1,12 +1,21 @@
 /**
  * Copyright 2017-2026, Voxel51, Inc.
+ *
+ * Mask decode dispatcher. Produces a color-INDEPENDENT white+alpha
+ * `ImageBitmap` (for GPU tinting) plus single-channel hit-test pixels. The
+ * decode + rasterize + `ImageBitmap` creation run in `maskDecodeWorker`
+ * off the main thread when Workers are available, with a main-thread fallback
+ * (SSR, tests, CSP-blocked workers, or a worker crash).
+ *
+ * The bitmap encodes only the mask SHAPE — opaque white where present,
+ * transparent elsewhere — so the display color is applied at draw time via the
+ * renderer's per-sprite tint and a color change never re-decodes.
  */
 
-import {
-  ARRAY_TYPES,
-  deserialize,
-  type OverlayMask,
-} from "@fiftyone/looker/src/numpy";
+import type { OverlayMask } from "@fiftyone/looker/src/numpy";
+
+import { decodeMaskToRaster } from "./maskRaster";
+import type { MaskDecodeResponse } from "./maskDecodeWorker";
 
 export interface DecodedMask {
   bitmap: ImageBitmap;
@@ -14,89 +23,126 @@ export interface DecodedMask {
   rawPixels: { src: Uint8Array; width: number; height: number };
 }
 
+// ---- worker plumbing ----
+
+let worker: Worker | undefined;
+let nextId = 1;
+const pending = new Map<
+  string,
+  { resolve: (mask: DecodedMask) => void; reject: (err: Error) => void }
+>();
+
+const supportsWorkers = (): boolean =>
+  typeof Worker !== "undefined" && typeof window !== "undefined";
+
+const ensureWorker = (): Worker | undefined => {
+  if (worker) {
+    return worker;
+  }
+  if (!supportsWorkers()) {
+    return undefined;
+  }
+
+  try {
+    worker = new Worker(new URL("./maskDecodeWorker.ts", import.meta.url), {
+      type: "module",
+    });
+  } catch (err) {
+    // `new Worker` can throw synchronously (e.g. CSP `worker-src`). Fall back
+    // to the main thread instead of failing the decode.
+    console.error("[decodeMask] worker unavailable; main-thread decode:", err);
+    worker = undefined;
+    return undefined;
+  }
+
+  worker.addEventListener(
+    "message",
+    (event: MessageEvent<MaskDecodeResponse>) => {
+      // Destructure once so the discriminated union narrows on `data.ok`.
+      const data = event.data;
+      const job = pending.get(data.uuid);
+      if (!job) {
+        return;
+      }
+      pending.delete(data.uuid);
+
+      if (data.ok) {
+        job.resolve({
+          bitmap: data.bitmap,
+          rawPixels: {
+            src: data.rawPixels,
+            width: data.width,
+            height: data.height,
+          },
+        });
+      } else {
+        // `in`-narrow (the union discriminant doesn't narrow under this
+        // package's tsconfig — cf. maskPathDecoding).
+        job.reject(
+          new Error("error" in data ? data.error : "mask rasterize failed")
+        );
+      }
+    }
+  );
+
+  worker.addEventListener("error", (event) => {
+    // Worker died: fail everyone in flight (callers fall back) and drop the
+    // instance so the next decode respawns.
+    console.error("[decodeMask] worker crashed; respawning:", event);
+    for (const job of pending.values()) {
+      job.reject(new Error("mask rasterize worker crashed"));
+    }
+    pending.clear();
+    worker?.terminate();
+    worker = undefined;
+  });
+
+  return worker;
+};
+
+const decodeViaWorker = (
+  w: Worker,
+  maskData: string | OverlayMask
+): Promise<DecodedMask> =>
+  new Promise((resolve, reject) => {
+    const uuid = String(nextId++);
+    pending.set(uuid, { resolve, reject });
+    w.postMessage({ uuid, maskData });
+  });
+
+const decodeOnMainThread = async (
+  maskData: string | OverlayMask
+): Promise<DecodedMask> => {
+  const { rgba, width, height, rawPixels } = decodeMaskToRaster(maskData);
+  const bitmap = await createImageBitmap(
+    new ImageData(new Uint8ClampedArray(rgba), width, height)
+  );
+  return { bitmap, rawPixels: { src: rawPixels, width, height } };
+};
+
 /**
- * Decodes a mask source into a color-INDEPENDENT white+alpha ImageBitmap
- * ready for GPU tinting, alongside the raw single-channel pixel data for
- * hit-testing.
+ * Decode + rasterize a mask source. Runs off the main thread via
+ * `maskDecodeWorker` when possible; falls back to the main thread when
+ * Workers are unavailable or the worker fails.
  *
- * The bitmap encodes only the mask SHAPE — opaque white where the mask is
- * present, transparent elsewhere. The display color is applied at draw time
- * via the renderer's per-sprite tint (`white × tint = tint`), so a color or
- * colorscheme change never re-decodes or re-rasterizes; it just re-tints.
- *
- * Accepts either a base64-encoded numpy string (inline `mask` field) or a
- * pre-decoded {@link OverlayMask} (e.g. produced from a `mask_path` fetch).
- * The string path runs the full base64 → inflate → numpy parse pipeline; the
- * `OverlayMask` path skips straight to rasterizing.
- *
- * @param maskData - Base64-encoded compressed numpy string, or a decoded
- *   {@link OverlayMask}.
+ * @param maskData - Base64-encoded compressed numpy string (inline `mask`), or
+ *   a pre-decoded {@link OverlayMask} (`mask_path`).
  */
 export async function decodeMask(
   maskData: string | OverlayMask
 ): Promise<DecodedMask> {
-  const overlayMask =
-    typeof maskData === "string" ? deserialize(maskData) : maskData;
-  const rgbaBuffer = rasterizeMaskAlpha(overlayMask);
-  const [height, width] = overlayMask.shape;
-  const imageData = new ImageData(
-    new Uint8ClampedArray(rgbaBuffer),
-    width,
-    height
-  );
-  const bitmap = await createImageBitmap(imageData);
-
-  const ArrayType = ARRAY_TYPES[overlayMask.arrayType];
-  if (!ArrayType) {
-    throw new Error(`Unsupported mask array type: ${overlayMask.arrayType}`);
+  const w = ensureWorker();
+  if (!w) {
+    return decodeOnMainThread(maskData);
   }
 
-  const typed = new ArrayType(overlayMask.buffer);
-  const src = new Uint8Array(typed.length);
-  for (let i = 0; i < typed.length; i++) {
-    src[i] = typed[i] ? 1 : 0;
-  }
-
-  return { bitmap, rawPixels: { src, width, height } };
-}
-
-/**
- * Rasterizes a single-channel mask into a color-INDEPENDENT RGBA buffer:
- * non-zero mask values become opaque white, zero values stay transparent.
- * The display color is applied later via GPU tint, so this never bakes a
- * color in and never needs to re-run on a color change.
- */
-function rasterizeMaskAlpha(mask: OverlayMask): ArrayBuffer {
-  if (mask.channels !== 1) {
-    throw new Error(`Expected single-channel mask, got ${mask.channels}`);
-  }
-
-  const [height, width] = mask.shape;
-  const rgbaBuffer = new ArrayBuffer(width * height * 4);
-  const overlay = new Uint32Array(rgbaBuffer);
-
-  // Opaque white (RGBA 255,255,255,255 → 0xFFFFFFFF in any byte order).
-  const WHITE = 0xffffffff;
-  const ArrayType = ARRAY_TYPES[mask.arrayType];
-
-  if (!ArrayType) {
-    throw new Error(`Unsupported mask array type: ${mask.arrayType}`);
-  }
-
-  const targets = new ArrayType(mask.buffer);
-  const expectedPixels = width * height;
-
-  if (targets.length !== expectedPixels) {
-    throw new Error(
-      `Mask payload length mismatch: expected ${expectedPixels}, got ${targets.length}`
+  try {
+    return await decodeViaWorker(w, maskData);
+  } catch (err) {
+    console.error(
+      "[decodeMask] worker decode failed; main-thread fallback:",
+      err
     );
+    return decodeOnMainThread(maskData);
   }
-
-  for (let i = 0; i < expectedPixels; i++) {
-    if (targets[i]) {
-      overlay[i] = WHITE;
-    }
-  }
-
-  return rgbaBuffer;
 }

--- a/app/packages/lighter/src/utils/maskRaster.test.ts
+++ b/app/packages/lighter/src/utils/maskRaster.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { describe, expect, it } from "vitest";
+import { deserialize } from "@fiftyone/looker/src/numpy";
+import { decodeMaskToRaster } from "./maskRaster";
+
+// Real mask from a FiftyOne detection (base64 zlib numpy uint8). Shared with
+// maskDecoding.test.ts / maskEncoding.test.ts.
+const SAMPLE_MASK =
+  "eJyb7BfqGxDJyFDGUK2eklqcXKRupaBek2SorqOgnpZfVFKUmBefX5SSChJ3S8wpTgWKF2ckFqQC+RoWhjoKRqaaOgq1CmQCLkZGBuyAEQJwSmDKMmIAnBJQKZIkGIeLBCOdJIaNRwZOgnHkSjAOE4mBDMRBmW2pWCRTTwJnRUE9CdJrKepJ4KwkGZABTglkSQwJqBw2cbAclAYAWfUiKw==";
+
+describe("decodeMaskToRaster", () => {
+  it("paints non-zero source pixels opaque white, leaves the rest transparent", () => {
+    const overlayMask = deserialize(SAMPLE_MASK);
+    const src = new Uint8Array(overlayMask.buffer);
+
+    const { rgba, width, height, rawPixels } = decodeMaskToRaster(SAMPLE_MASK);
+    expect(width).toBe(overlayMask.shape[1]);
+    expect(height).toBe(overlayMask.shape[0]);
+    expect(rgba.byteLength).toBe(width * height * 4);
+
+    const px = new Uint8Array(rgba);
+    let painted = 0;
+    let transparent = 0;
+    for (let i = 0; i < src.length; i++) {
+      if (src[i] > 0) {
+        // color-independent: opaque white (color applied later via GPU tint)
+        expect(px[i * 4]).toBe(255);
+        expect(px[i * 4 + 1]).toBe(255);
+        expect(px[i * 4 + 2]).toBe(255);
+        expect(px[i * 4 + 3]).toBe(255);
+        expect(rawPixels[i]).toBe(1);
+        painted++;
+      } else {
+        expect(px[i * 4 + 3]).toBe(0);
+        expect(rawPixels[i]).toBe(0);
+        transparent++;
+      }
+    }
+
+    expect(painted).toBeGreaterThan(0);
+    expect(transparent).toBeGreaterThan(0);
+  });
+
+  it("rejects a multi-channel mask", () => {
+    const overlayMask = deserialize(SAMPLE_MASK);
+    expect(() => decodeMaskToRaster({ ...overlayMask, channels: 3 })).toThrow(
+      /single-channel/
+    );
+  });
+});

--- a/app/packages/lighter/src/utils/maskRaster.ts
+++ b/app/packages/lighter/src/utils/maskRaster.ts
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ *
+ * Pure mask decode + rasterization — no DOM, runs identically on the main
+ * thread (fallback) and inside `maskDecodeWorker`. Produces a color-INDEPENDENT
+ * white+alpha RGBA buffer (the display color is applied later via GPU tint)
+ * plus the single-channel pixel data used for hit-testing.
+ */
+
+import {
+  ARRAY_TYPES,
+  deserialize,
+  type OverlayMask,
+} from "@fiftyone/looker/src/numpy";
+
+export interface RasterizedMask {
+  /** White+alpha RGBA, row-major, `width * height * 4` bytes. */
+  rgba: ArrayBuffer;
+  width: number;
+  height: number;
+  /** Single-channel mask (non-zero source → 1) for hit-testing. */
+  rawPixels: Uint8Array;
+}
+
+/**
+ * Decode (if base64) + rasterize a mask source. This is the heavy work — the
+ * base64 → inflate → numpy parse pipeline and the two per-pixel passes — and
+ * is exactly what the worker offloads from the main thread.
+ *
+ * @param maskData - Base64-encoded compressed numpy string, or a decoded
+ *   {@link OverlayMask}.
+ */
+export const decodeMaskToRaster = (
+  maskData: string | OverlayMask
+): RasterizedMask => {
+  const mask = typeof maskData === "string" ? deserialize(maskData) : maskData;
+
+  if (mask.channels !== 1) {
+    throw new Error(`Expected single-channel mask, got ${mask.channels}`);
+  }
+
+  const ArrayType = ARRAY_TYPES[mask.arrayType];
+  if (!ArrayType) {
+    throw new Error(`Unsupported mask array type: ${mask.arrayType}`);
+  }
+
+  const [height, width] = mask.shape;
+  const expectedPixels = width * height;
+  const targets = new ArrayType(mask.buffer);
+
+  if (targets.length !== expectedPixels) {
+    throw new Error(
+      `Mask payload length mismatch: expected ${expectedPixels}, got ${targets.length}`
+    );
+  }
+
+  // White+alpha RGBA (0xFFFFFFFF where present), color-independent.
+  const rgba = new ArrayBuffer(expectedPixels * 4);
+  const overlay = new Uint32Array(rgba);
+  const rawPixels = new Uint8Array(expectedPixels);
+
+  for (let i = 0; i < expectedPixels; i++) {
+    if (targets[i]) {
+      overlay[i] = 0xffffffff;
+      rawPixels[i] = 1;
+    }
+  }
+
+  return { rgba, width, height, rawPixels };
+};


### PR DESCRIPTION
Stacks on #7859 (GPU tint) — review/merge that first; this PR's diff is only the worker (base = `perf/mask-gpu-tint`).

## What

Even after the tint change, `decodeMask` still allocated + looped over mask pixel
data on the **main thread**: the base64/numpy decode, the white+alpha RGBA pass,
the single-channel hit-test pass, and `ImageBitmap` creation.

## Change

Move all of it into a dedicated worker that transfers the `ImageBitmap` +
single-channel buffer back **zero-copy**. The main thread no longer allocates or
loops over mask pixels.

- `maskRaster.ts` — pure `decodeMaskToRaster()` → `{ rgba, width, height, rawPixels }`,
  shared by the worker and the main-thread fallback.
- `maskDecodeWorker.ts` — runs it in a worker, `createImageBitmap` in-worker,
  transfers `[bitmap, rawPixels.buffer]`.
- `maskDecoding.ts` — `decodeMask` dispatches to the worker (uuid-keyed), with a
  main-thread fallback when Workers are unavailable (SSR / tests / CSP) or crash.

`decodeMask`'s signature/return are unchanged, so callers (`MaskCanvas`) are
unaffected.

Transfer rather than `SharedArrayBuffer`: the payload is a one-shot
produce→consume, the `ImageBitmap` can't be shared anyway, and SAB would force
cross-origin isolation (COOP/COEP) the app doesn't require.

Follow-up: thread an abort signal into the worker to cancel a superseded
in-flight decode.

## Tests

New `maskRaster` test (white+alpha + single-channel); `maskDecoding` exercises
the main-thread fallback; lighter suite green.
