### PR TITLE
[video annotation] Object track split/merge

### DIFF
--- a/app/packages/annotation/src/engine/store/frameStore.test.ts
+++ b/app/packages/annotation/src/engine/store/frameStore.test.ts
@@ -173,6 +173,80 @@ describe("FrameStore through the engine: transactions + undo", () => {
   });
 });
 
+describe("FrameStore re-key via compose (the split/merge primitive)", () => {
+  const makeEngine = (data?: FramesData) => {
+    const engine = new AnnotationEngine();
+    const store = makeStore(data);
+    engine.registerStore(store);
+    return { engine, store };
+  };
+
+  // identity is engine-owned and `updateLabel` refuses to touch it, so split /
+  // merge re-key a frame by deleting the old instance + recreating its content
+  // under the new one — this strips the engine-owned fields like the hook does.
+  const content = (label: LabelData): Partial<LabelData> => {
+    const { _id, instance, ...rest } = label;
+    return rest;
+  };
+
+  it("delete(old) + create(new) re-keys a frame onto a fresh instance, one undo unit", () => {
+    const { engine, store } = makeEngine({
+      1: { [PATH]: [det("doc-1", "A", [0, 0, 3, 3], "car")] },
+    });
+
+    const before = store.getLabel(ref("A", 1))!;
+
+    engine.transaction(() => {
+      engine.deleteLabel(ref("A", 1));
+      engine.updateLabel(ref("B", 1), content(before));
+    });
+
+    // A is gone; B carries the content under a new instance + a fresh doc id
+    expect(store.getLabel(ref("A", 1))).toBeUndefined();
+
+    const reKeyed = store.getLabel(ref("B", 1))!;
+    expect((reKeyed.instance as { _id: string })._id).toBe("B");
+    expect(reKeyed.label).toBe("car");
+    expect(reKeyed.bounding_box).toEqual([0, 0, 3, 3]);
+    expect(reKeyed._id).not.toBe("doc-1"); // doc id re-minted (it links nothing)
+
+    // one transaction = one undo unit: drops B, restores A's content + instance
+    engine.undo();
+    expect(store.getLabel(ref("B", 1))).toBeUndefined();
+
+    const restored = store.getLabel(ref("A", 1))!;
+    expect((restored.instance as { _id: string })._id).toBe("A");
+    expect(restored.label).toBe("car");
+    expect(restored.bounding_box).toEqual([0, 0, 3, 3]);
+  });
+
+  it("re-keys only the tail, leaving earlier frames on the original instance", () => {
+    const { engine, store } = makeEngine({
+      1: { [PATH]: [det("doc-1", "A", [0, 0, 1, 1])] },
+      2: { [PATH]: [det("doc-2", "A", [0, 0, 2, 2])] },
+      3: { [PATH]: [det("doc-3", "A", [0, 0, 3, 3])] },
+    });
+
+    // split at frame 2: frames >= 2 move onto B, frame 1 stays on A
+    engine.transaction(() => {
+      for (const frame of [2, 3]) {
+        const current = store.getLabel(ref("A", frame))!;
+        engine.deleteLabel(ref("A", frame));
+        engine.updateLabel(ref("B", frame), content(current));
+      }
+    });
+
+    expect(store.getLabel(ref("A", 1))?.bounding_box).toEqual([0, 0, 1, 1]);
+    expect(store.getLabel(ref("A", 2))).toBeUndefined();
+    expect(store.getLabel(ref("B", 2))?.bounding_box).toEqual([0, 0, 2, 2]);
+    expect(store.getLabel(ref("B", 3))?.bounding_box).toEqual([0, 0, 3, 3]);
+
+    engine.undo();
+    expect(store.getLabel(ref("A", 2))?.bounding_box).toEqual([0, 0, 2, 2]);
+    expect(store.getLabel(ref("B", 2))).toBeUndefined();
+  });
+});
+
 describe("FrameStore persistence: id-aligned /frames/<n>/<field> deltas", () => {
   it("an in-place edit diffs at the baseline index", () => {
     const store = makeStore({

--- a/app/packages/annotation/src/events.ts
+++ b/app/packages/annotation/src/events.ts
@@ -121,6 +121,38 @@ export type AnnotationEventGroup = {
   };
 
   /**
+   * Notification event emitted when a track is split at a frame: frames at or
+   * after `atFrame` are re-keyed onto a fresh instance, the original keeps the
+   * earlier frames.
+   */
+  "annotation:trackSplit": {
+    /** Synthetic overlay id of the track that was split. */
+    trackId: string;
+    /** The original track's `instance._id` (keeps frames `< atFrame`). */
+    instanceId: string;
+    /** The minted `instance._id` carrying frames `>= atFrame`. */
+    newInstanceId: string;
+    /** 1-indexed split boundary; this frame lands on the new track. */
+    atFrame: number;
+  };
+
+  /**
+   * Notification event emitted when one track is merged into another: the
+   * source's frames are re-keyed onto the target's instance (target-wins on
+   * overlapping frames) and the source ceases to exist.
+   */
+  "annotation:trackMerged": {
+    /** Synthetic overlay id of the absorbed (source) track. */
+    sourceTrackId: string;
+    /** Synthetic overlay id of the surviving (target) track. */
+    targetTrackId: string;
+    /** The source track's `instance._id` (no longer present after merge). */
+    sourceInstanceId: string;
+    /** The target track's `instance._id` (now carries the merged frames). */
+    targetInstanceId: string;
+  };
+
+  /**
    * Notification event emitted when the active annotation agent transitions
    * between lifecycle states (e.g. `"initializing"` → `"inferring"`).
    */

--- a/app/packages/multimodal/src/components/MultiModalPlayback/MultiModalPlayback.tsx
+++ b/app/packages/multimodal/src/components/MultiModalPlayback/MultiModalPlayback.tsx
@@ -63,8 +63,8 @@ export interface MultiModalPlaybackProps {
   onTagCreate?: TemporalTagTimelineProps["onTagCreate"];
   /** Callback that deletes an existing temporal tag by its backend id. */
   onTagDelete?: NonNullable<
-    TemporalTagTimelineProps["eventDeleteConfig"]
-  >["onDelete"];
+    TemporalTagTimelineProps["eventMenuItems"]
+  >[number]["onSelect"];
 
   /**
    * Rendered inside the providers this component owns. Use it for
@@ -216,9 +216,15 @@ function Layout({
 
       <TemporalTagTimeline
         onTagCreate={onTagCreate}
-        eventDeleteConfig={
+        eventMenuItems={
           onTagDelete
-            ? { label: "Delete tag", onDelete: onTagDelete }
+            ? [
+                {
+                  label: "Delete tag",
+                  destructive: true,
+                  onSelect: onTagDelete,
+                },
+              ]
             : undefined
         }
       />

--- a/app/packages/playback/index.ts
+++ b/app/packages/playback/index.ts
@@ -14,6 +14,10 @@ export * from "./src/lib/tracks/TrackProvider";
 export * from "./src/views/Timeline/Timeline";
 export { default as TimelineWithTracks } from "./src/views/TimelineWithTracks/TimelineWithTracks";
 export type { TimelineWithTracksProps } from "./src/views/TimelineWithTracks/TimelineWithTracks";
+export type {
+  NormalizedEvent,
+  TrackEventMenuItem,
+} from "./src/views/TimelineTrack/TimelineTrack";
 export type { TemporalTagCreatePayload } from "./src/views/TemporalTag/TemporalTagContext";
 export { default as TemporalTagTimeline } from "./src/views/TemporalTag/TemporalTagTimeline";
 export type { TemporalTagTimelineProps } from "./src/views/TemporalTag/TemporalTagTimeline";

--- a/app/packages/playback/src/views/TimelineTrack/TimelineTrack.test.tsx
+++ b/app/packages/playback/src/views/TimelineTrack/TimelineTrack.test.tsx
@@ -284,10 +284,10 @@ describe("TimelineTrack", () => {
     });
   });
 
-  describe("eventDeleteConfig", () => {
+  describe("eventMenuItems", () => {
     const interval = { startSec: 4, endSec: 6 };
 
-    it("omits the delete item (and renders fine) when eventDeleteConfig is absent", () => {
+    it("adds no custom items (and renders fine) when eventMenuItems is absent", () => {
       const { container } = renderTrack({
         track: { start: 0, end: 10, events: [interval], labelWidth: 100 },
       });
@@ -299,14 +299,16 @@ describe("TimelineTrack", () => {
       expect(screen.queryByText("Delete track")).toBeNull();
     });
 
-    it("adds a destructive item with the supplied label that fires onDelete with the event", () => {
-      const onDelete = vi.fn();
+    it("fires an item's onSelect with the event the menu opened on", () => {
+      const onSelect = vi.fn();
       const { container } = renderTrack({
         track: {
           start: 0,
           end: 10,
           events: [interval],
-          eventDeleteConfig: { label: "Delete track", onDelete },
+          eventMenuItems: [
+            { label: "Delete track", destructive: true, onSelect },
+          ],
         },
       });
       const bar = container.querySelector(
@@ -314,27 +316,51 @@ describe("TimelineTrack", () => {
       ) as HTMLElement;
       fireEvent.contextMenu(bar);
       fireEvent.click(screen.getByText("Delete track"));
-      expect(onDelete).toHaveBeenCalledTimes(1);
-      expect(onDelete.mock.calls[0][0]).toMatchObject({
+      expect(onSelect).toHaveBeenCalledTimes(1);
+      expect(onSelect.mock.calls[0][0]).toMatchObject({
         startSec: 4,
         endSec: 6,
       });
     });
 
-    it("uses the supplied label verbatim (e.g. the temporal-tag 'Delete tag')", () => {
+    it("renders every supplied item in order (e.g. delete + split + merge)", () => {
       const { container } = renderTrack({
         track: {
           start: 0,
           end: 10,
           events: [interval],
-          eventDeleteConfig: { label: "Delete tag", onDelete: vi.fn() },
+          eventMenuItems: [
+            { label: "Delete track", destructive: true, onSelect: vi.fn() },
+            { label: "Split at playhead", onSelect: vi.fn() },
+            { label: "Merge into B", onSelect: vi.fn() },
+          ],
         },
       });
       const bar = container.querySelector(
         `.${styles.intervalBar}`
       ) as HTMLElement;
       fireEvent.contextMenu(bar);
-      expect(screen.getByText("Delete tag")).toBeTruthy();
+      expect(screen.getByText("Delete track")).toBeTruthy();
+      expect(screen.getByText("Split at playhead")).toBeTruthy();
+      expect(screen.getByText("Merge into B")).toBeTruthy();
+    });
+
+    it("does not fire onSelect for a disabled item", () => {
+      const onSelect = vi.fn();
+      const { container } = renderTrack({
+        track: {
+          start: 0,
+          end: 10,
+          events: [interval],
+          eventMenuItems: [{ label: "Merge into…", disabled: true, onSelect }],
+        },
+      });
+      const bar = container.querySelector(
+        `.${styles.intervalBar}`
+      ) as HTMLElement;
+      fireEvent.contextMenu(bar);
+      fireEvent.click(screen.getByText("Merge into…"));
+      expect(onSelect).not.toHaveBeenCalled();
     });
   });
 

--- a/app/packages/playback/src/views/TimelineTrack/TimelineTrack.tsx
+++ b/app/packages/playback/src/views/TimelineTrack/TimelineTrack.tsx
@@ -51,6 +51,18 @@ export interface NormalizedEvent {
   resizable?: boolean;
 }
 
+/** A custom action contributed to a track event's context menu. */
+export interface TrackEventMenuItem {
+  /** Menu text, e.g. "Delete track" or "Split at playhead". */
+  label: string;
+  /** Render in the destructive (red) style. */
+  destructive?: boolean;
+  /** Grey out and ignore clicks (e.g. "Merge into…" with no candidates). */
+  disabled?: boolean;
+  /** Receives the event the menu was opened on. */
+  onSelect: (event: NormalizedEvent) => void;
+}
+
 function normalizeEvent(e: TimelineTrackEvent): NormalizedEvent {
   return typeof e === "number" ? { startSec: e } : e;
 }
@@ -98,17 +110,13 @@ export interface TimelineTrackProps {
   /** Fired when an event marker / bar is clicked. Typically seeks. */
   onEventClick?: (event: NormalizedEvent) => void;
   /**
-   * Adds a destructive item to an event's context menu. `label` is the menu
-   * text (e.g. "Delete tag" or "Delete track") and `onDelete` receives the
-   * event the menu was opened on — the handler decides whether that means
-   * deleting the single event or the whole track. Hidden when not provided.
-   * Supply per-row via `decorateTrack` or uniformly via
-   * {@link TimelineWithTracksProps.eventDeleteConfig}.
+   * Custom items appended (below a separator) to an event's context menu.
+   * Each `onSelect` receives the event the menu was opened on — the handler
+   * decides whether that means the single event or the whole track. Supply
+   * per-row via `decorateTrack` or uniformly via
+   * {@link TimelineWithTracksProps.eventMenuItems}. Empty/omitted adds nothing.
    */
-  eventDeleteConfig?: {
-    label: string;
-    onDelete: (event: NormalizedEvent) => void;
-  };
+  eventMenuItems?: TrackEventMenuItem[];
   /** Override the label column text. Defaults to `id`. */
   label?: string;
   height?: number;
@@ -159,7 +167,7 @@ const TimelineTrack: React.FC<TimelineTrackProps> = ({
   end,
   events = [],
   onEventClick,
-  eventDeleteConfig,
+  eventMenuItems,
   label,
   height = 28,
   labelWidth = 0,
@@ -510,20 +518,27 @@ const TimelineTrack: React.FC<TimelineTrackProps> = ({
                 >
                   Shrink window to fit
                 </MenuTextItem>
-                {eventDeleteConfig && (
+                {eventMenuItems && eventMenuItems.length > 0 && (
                   <>
                     <MenuSeparator />
-                    <MenuTextItem
-                      destructive
-                      onClick={(ev) => {
-                        // Stop the click bubbling to the row's `onClick`
-                        // (`onTrackClick`).
-                        ev.stopPropagation();
-                        eventDeleteConfig.onDelete(event);
-                      }}
-                    >
-                      {eventDeleteConfig.label}
-                    </MenuTextItem>
+                    {eventMenuItems.map((item, i) => (
+                      <MenuTextItem
+                        key={i}
+                        destructive={item.destructive}
+                        disabled={item.disabled}
+                        onClick={(ev) => {
+                          // Stop the click bubbling to the row's `onClick`
+                          // (`onTrackClick`).
+                          ev.stopPropagation();
+
+                          if (!item.disabled) {
+                            item.onSelect(event);
+                          }
+                        }}
+                      >
+                        {item.label}
+                      </MenuTextItem>
+                    ))}
                   </>
                 )}
               </>

--- a/app/packages/playback/src/views/TimelineWithTracks/TimelineWithTracks.test.tsx
+++ b/app/packages/playback/src/views/TimelineWithTracks/TimelineWithTracks.test.tsx
@@ -84,11 +84,11 @@ describe("TimelineWithTracks", () => {
       expect(root.className).not.toContain(styles.noTracks);
     });
 
-    it("renders track labels for registered tracks", () => {
+    it("renders a pinned track exactly once", () => {
       renderTimeline({ tracks: [TRACK_A, TRACK_B], pinnedIds: ["track-a"] });
-      // A pinned track renders in both the collapsed header overlay and the
-      // drawer body, so its label appears more than once.
-      expect(screen.getAllByText("Track A").length).toBeGreaterThan(0);
+      // With the drawer closed (default) a pinned row lives only in the header
+      // overlay — not also in the body — so it mounts once under one track id.
+      expect(screen.getAllByText("Track A")).toHaveLength(1);
     });
 
     it("renders rows for both pinned and unpinned tracks", () => {

--- a/app/packages/playback/src/views/TimelineWithTracks/TimelineWithTracks.tsx
+++ b/app/packages/playback/src/views/TimelineWithTracks/TimelineWithTracks.tsx
@@ -16,8 +16,8 @@ import LoopOverlays from "../Loop/LoopOverlays";
 import PlayheadLine from "../Playhead/PlayheadLine";
 import TimelineHeader from "../TimelineHeader/TimelineHeader";
 import TimelineTrack, {
-  type NormalizedEvent,
   type TimelineTrackProps,
+  type TrackEventMenuItem,
 } from "../TimelineTrack/TimelineTrack";
 import styles from "./TimelineWithTracks.module.css";
 
@@ -38,14 +38,11 @@ export interface TimelineWithTracksProps {
   /** Overlay rendered on top of the ruler row in each TimelineHeader. */
   rulerOverlay?: React.ReactNode;
   /**
-   * Adds a destructive delete item to every track's event context menu. Per-row
-   * overrides can still be supplied via {@link decorateTrack}. See
-   * {@link TimelineTrackProps.eventDeleteConfig}.
+   * Custom context-menu items added to every track's events. Per-row overrides
+   * can still be supplied via {@link decorateTrack}. See
+   * {@link TimelineTrackProps.eventMenuItems}.
    */
-  eventDeleteConfig?: {
-    label: string;
-    onDelete: (event: NormalizedEvent) => void;
-  };
+  eventMenuItems?: TrackEventMenuItem[];
   /**
    * Optional content rendered inline between the playback control buttons and
    * the playhead time display. Forwarded to {@link TimelineHeader}'s
@@ -82,7 +79,7 @@ const TimelineWithTracks: React.FC<TimelineWithTracksProps> = ({
   maxSize = TIMELINE_DRAWER_MAX_SIZE,
   className,
   rulerOverlay,
-  eventDeleteConfig,
+  eventMenuItems,
   extraControls,
   extraActions,
   decorateTrack,
@@ -116,7 +113,7 @@ const TimelineWithTracks: React.FC<TimelineWithTracksProps> = ({
       pinned
       onPinClick={() => togglePin(track.id)}
       onEventClick={(e) => seek(e.startSec)}
-      eventDeleteConfig={eventDeleteConfig}
+      eventMenuItems={eventMenuItems}
       {...(decorateTrack ? decorateTrack(track, true) : null)}
     />
   );
@@ -158,7 +155,11 @@ const TimelineWithTracks: React.FC<TimelineWithTracksProps> = ({
             extraActions={extraActions}
           >
             <div className={styles.pinnedOverlayHost}>
-              {pinned.map(renderPinnedTrack)}
+              {/* Pinned rows live here only while the drawer is closed; when it
+                  opens they move into the body below. Rendering both
+                  unconditionally double-mounts every pinned row under the same
+                  track id, so selecting one hit both. */}
+              {!drawerOpen && pinned.map(renderPinnedTrack)}
               <LoopOverlays labelWidth={labelWidth} />
               <PlayheadLine labelWidth={labelWidth} />
             </div>
@@ -168,9 +169,10 @@ const TimelineWithTracks: React.FC<TimelineWithTracksProps> = ({
         <div className={styles.tracksOuter}>
           <div className={styles.tracksArea}>
             {/* When the drawer is open, pinned tracks move into the body
-                so they scroll together with the unpinned section below. */}
+                so they scroll together with the unpinned section below; the
+                header slot above stops rendering them so each row mounts once. */}
             <div className={styles.pinnedTracks}>
-              {pinned.map(renderPinnedTrack)}
+              {drawerOpen && pinned.map(renderPinnedTrack)}
             </div>
             <div>
               {unpinned.map((track) => {
@@ -188,7 +190,7 @@ const TimelineWithTracks: React.FC<TimelineWithTracksProps> = ({
                     pinned={false}
                     onPinClick={() => togglePin(track.id)}
                     onEventClick={(e) => seek(e.startSec)}
-                    eventDeleteConfig={eventDeleteConfig}
+                    eventMenuItems={eventMenuItems}
                     {...extra}
                     className={clsx(styles.unpinnedTrack, extra?.className)}
                   />

--- a/app/packages/video-annotation/src/components/FrameLabels.tsx
+++ b/app/packages/video-annotation/src/components/FrameLabels.tsx
@@ -32,6 +32,7 @@ import {
   TimelineWithTracks,
   TrackProvider,
   type Track,
+  type TrackEventMenuItem,
   useDuration,
   usePlaybackStream,
 } from "@fiftyone/playback";
@@ -48,6 +49,7 @@ import { getModalSampleFrameRate } from "../utils/modalSample";
 import { resolveTrackExtentEdit } from "../tracks/trackExtentEdit";
 import { useVideoTrackDecorator } from "../tracks/useVideoTrackDecorator";
 import { useScrollTrackToAnchor } from "../state/useVideoInteraction";
+import { useCurrentFrameGetter } from "../state/useCurrentFrame";
 import {
   useVideoSurfaceActions,
   type VideoSurfaceActions,
@@ -70,7 +72,8 @@ type BaseTrackDecoration = ReturnType<
 /** Decoration a track row contributes to {@link TimelineWithTracks}. */
 type TrackDecoration = BaseTrackDecoration & {
   snapStepSec?: number;
-  eventDeleteConfig?: { label: string; onDelete: () => void };
+  eventMenuItems?: TrackEventMenuItem[];
+  onContextMenu?: (e: React.MouseEvent<HTMLDivElement>) => void;
   onEventEdit?: (
     eventIndex: number,
     newStartSec: number,
@@ -323,16 +326,31 @@ function useTrackColorResolvers(path: string | null): {
   return { resolveObjectColor, resolveTemporalDetectionColor };
 }
 
-/** Build the row decorator that wires presence-bar edits + delete per kind. */
+/** Build the row decorator that wires presence-bar edits + menu per kind. */
 function useTrackDecorator(
-  sample: ModalSample | undefined
+  sample: ModalSample | undefined,
+  objectTracks: Track[]
 ): (track: Track) => TrackDecoration {
   const baseDecorate = useVideoTrackDecorator();
   const actions = useVideoSurfaceActions();
   const stream = useFrameLabelsStream();
+  const getCurrentFrame = useCurrentFrameGetter();
   const fps = getModalSampleFrameRate(sample);
   const snapStepSec =
     Number.isFinite(fps) && fps && fps > 0 ? 1 / fps : undefined;
+
+  // The split boundary, captured when the track's context menu OPENS — not read
+  // live in the menu item's handler, because clicking a menu item seeks the
+  // timeline to the track's start, racing the gesture (explicit payload over
+  // implicit context).
+  const splitFrameRef = useRef(1);
+
+  // id + label of every object track, the universe of merge targets; each row
+  // filters itself out below.
+  const mergeCandidates = useMemo(
+    () => objectTracks.map((t) => ({ id: t.id, label: t.label })),
+    [objectTracks]
+  );
 
   return useCallback(
     (track: Track): TrackDecoration => {
@@ -356,6 +374,9 @@ function useTrackDecorator(
           fps,
           totalFrames: stream.totalFrames,
           actions,
+          getCurrentFrame,
+          splitFrameRef,
+          mergeTargets: mergeCandidates.filter((c) => c.id !== track.id),
         });
       }
 
@@ -372,7 +393,15 @@ function useTrackDecorator(
         actions,
       });
     },
-    [baseDecorate, fps, snapStepSec, actions, stream]
+    [
+      baseDecorate,
+      fps,
+      snapStepSec,
+      actions,
+      stream,
+      getCurrentFrame,
+      mergeCandidates,
+    ]
   );
 }
 
@@ -413,7 +442,7 @@ export const FrameLabelsTracks: React.FC<{ sample?: ModalSample }> = ({
   const ready = frameTracksResolved;
 
   useScrollTrackToAnchor();
-  const decorateTrack = useTrackDecorator(sample);
+  const decorateTrack = useTrackDecorator(sample, frameTracks);
 
   return (
     <TrackProvider
@@ -437,6 +466,9 @@ function decorateObjectTrack({
   fps,
   totalFrames,
   actions,
+  getCurrentFrame,
+  splitFrameRef,
+  mergeTargets,
 }: {
   track: Track;
   base: BaseTrackDecoration;
@@ -444,13 +476,35 @@ function decorateObjectTrack({
   fps: number;
   totalFrames: number;
   actions: VideoSurfaceActions;
+  getCurrentFrame: () => number;
+  splitFrameRef: React.MutableRefObject<number>;
+  mergeTargets: { id: string; label: string }[];
 }): TrackDecoration {
+  const menuItems: TrackEventMenuItem[] = [
+    {
+      label: "Delete track",
+      destructive: true,
+      onSelect: () => actions.deleteTrack(track.id),
+    },
+    {
+      // splits at the frame captured when the menu opened (see onContextMenu)
+      label: "Split at playhead",
+      onSelect: () => actions.splitTrack(track.id, splitFrameRef.current),
+    },
+    ...mergeTargets.map((target) => ({
+      label: `Merge into ${target.label}`,
+      onSelect: () => actions.mergeTracks(track.id, target.id),
+    })),
+  ];
+
   return {
     ...base,
     snapStepSec,
-    eventDeleteConfig: {
-      label: "Delete track",
-      onDelete: () => actions.deleteTrack(track.id),
+    eventMenuItems: menuItems,
+    // snapshot the playhead frame as the menu opens, before the item click
+    // seeks the timeline to the track start
+    onContextMenu: () => {
+      splitFrameRef.current = getCurrentFrame();
     },
     onEventEdit: (eventIndex, newStartSec, newEndSec, mode) =>
       applyObjectTrackEdit({
@@ -483,11 +537,17 @@ function decorateTemporalDetectionTrack({
   return {
     ...base,
     snapStepSec,
-    eventDeleteConfig: {
-      label: "Delete track",
-      onDelete: () =>
-        actions.deleteTemporalDetection(tdEvent.fieldPath, tdEvent.detectionId),
-    },
+    eventMenuItems: [
+      {
+        label: "Delete track",
+        destructive: true,
+        onSelect: () =>
+          actions.deleteTemporalDetection(
+            tdEvent.fieldPath,
+            tdEvent.detectionId
+          ),
+      },
+    ],
     onEventEdit: (_eventIndex, newStartSec, newEndSec) =>
       applyTemporalDetectionEdit({
         tdEvent,

--- a/app/packages/video-annotation/src/hooks/useVideoAnnotationActions.tsx
+++ b/app/packages/video-annotation/src/hooks/useVideoAnnotationActions.tsx
@@ -54,6 +54,11 @@ export const useVideoAnnotationActions = (): ToolbarActionGroup[] => {
   const selectedIds = useMemo(() => Array.from(selected), [selected]);
   const hasSelection = selectedIds.length > 0;
 
+  // split needs one track + a playhead frame; merge needs exactly two
+  const canSplit =
+    selectedIds.length === 1 && Number.isFinite(fps) && !!fps && fps > 0;
+  const canMerge = selectedIds.length === 2;
+
   // Recomputed each playhead tick / selection change so the Propagate
   // affordance reflects the current frame's bracketing keyframes. When
   // disabled, `reason` becomes the tooltip — the "why can't I propagate?"
@@ -129,6 +134,40 @@ export const useVideoAnnotationActions = (): ToolbarActionGroup[] => {
               );
             },
           },
+          {
+            id: "split-track",
+            label: "Split",
+            icon: <Icon name={IconName.UnfoldMore} size={Size.Sm} />,
+            tooltip: canSplit
+              ? "Split the selected track at this frame"
+              : "Select one track to split it at the playhead",
+            isDisabled: !canSplit,
+            onClick: () => {
+              if (!canSplit || !fps) {
+                return;
+              }
+
+              actions.splitTrack(selectedIds[0], frameAt(playhead, fps));
+            },
+          },
+          {
+            id: "merge-tracks",
+            label: "Merge",
+            icon: <Icon name={IconName.Workspaces} size={Size.Sm} />,
+            // direction is ambiguous from a selection set, so fix a rule: the
+            // first-selected merges into the last-selected, which survives
+            tooltip: canMerge
+              ? "Merge the two selected tracks (keeps the later selection)"
+              : "Select two tracks to merge them",
+            isDisabled: !canMerge,
+            onClick: () => {
+              if (!canMerge) {
+                return;
+              }
+
+              actions.mergeTracks(selectedIds[0], selectedIds[1]);
+            },
+          },
         ],
       },
     ],
@@ -136,6 +175,8 @@ export const useVideoAnnotationActions = (): ToolbarActionGroup[] => {
       actions,
       propagate,
       canCreateTd,
+      canMerge,
+      canSplit,
       fps,
       hasSelection,
       playhead,

--- a/app/packages/video-annotation/src/hooks/useVideoSurfaceActions.test.ts
+++ b/app/packages/video-annotation/src/hooks/useVideoSurfaceActions.test.ts
@@ -20,6 +20,7 @@ let frameData: Record<number, Record<string, LabelData>>;
 const mockEngine = {
   getLabel: ({ instanceId, frame }: { instanceId: string; frame?: number }) =>
     frame != null ? frameData[frame]?.[instanceId] : undefined,
+  mintInstanceId: vi.fn(() => "NEW"),
 };
 
 const mockActions = {
@@ -178,6 +179,140 @@ describe("track ops", () => {
       { path: PATH, instanceId: "A", frame: 1 },
       { label: "car" }
     );
+  });
+});
+
+describe("track identity ops (split / merge)", () => {
+  it("splitTrack re-keys frames >= atFrame onto a fresh instance, one transaction", () => {
+    frameData = {
+      1: { A: det("d1", "A") },
+      2: { A: det("d2", "A") },
+      3: { A: det("d3", "A", { keyframe: true }) },
+      4: { A: det("d4", "A") },
+    };
+
+    render().current.splitTrack("instance-A", 3);
+
+    expect(mockActions.transaction).toHaveBeenCalledTimes(1);
+
+    // frames 3 and 4 (>= 3) are deleted off A...
+    expect(mockActions.deleteLabel).toHaveBeenCalledTimes(2);
+    expect(mockActions.deleteLabel).toHaveBeenCalledWith({
+      path: PATH,
+      instanceId: "A",
+      frame: 3,
+    });
+    expect(mockActions.deleteLabel).toHaveBeenCalledWith({
+      path: PATH,
+      instanceId: "A",
+      frame: 4,
+    });
+
+    // ...and re-laid under the minted instance, identity stripped, content kept
+    expect(mockActions.updateLabel).toHaveBeenCalledTimes(2);
+    expect(mockActions.updateLabel).toHaveBeenCalledWith(
+      { path: PATH, instanceId: "NEW", frame: 3 },
+      {
+        _cls: "Detection",
+        label: "x",
+        bounding_box: [0, 0, 1, 1],
+        keyframe: true,
+      }
+    );
+    expect(mockActions.updateLabel).toHaveBeenCalledWith(
+      { path: PATH, instanceId: "NEW", frame: 4 },
+      { _cls: "Detection", label: "x", bounding_box: [0, 0, 1, 1] }
+    );
+
+    // frames 1, 2 (< 3) are untouched
+    expect(mockActions.deleteLabel).not.toHaveBeenCalledWith(
+      expect.objectContaining({ frame: 1 })
+    );
+
+    expect(mockBus.dispatch).toHaveBeenCalledWith("annotation:trackSplit", {
+      trackId: "instance-A",
+      instanceId: "A",
+      newInstanceId: "NEW",
+      atFrame: 3,
+    });
+  });
+
+  it("splitTrack no-ops when no frame is at or after the boundary", () => {
+    frameData = { 1: { A: det("d1", "A") }, 2: { A: det("d2", "A") } };
+
+    render().current.splitTrack("instance-A", 5);
+
+    expect(mockActions.transaction).not.toHaveBeenCalled();
+    expect(mockEngine.mintInstanceId).not.toHaveBeenCalled();
+    expect(mockBus.dispatch).not.toHaveBeenCalled();
+  });
+
+  it("splitTrack skips a legacy track-<index> id", () => {
+    frameData = { 2: { A: det("d2", "A") } };
+
+    render().current.splitTrack("track-4", 1);
+
+    expect(mockActions.transaction).not.toHaveBeenCalled();
+    expect(mockEngine.mintInstanceId).not.toHaveBeenCalled();
+  });
+
+  it("mergeTracks re-keys source frames onto the target, target-wins on overlap", () => {
+    frameData = {
+      1: { A: det("d1a", "A") },
+      2: { A: det("d2a", "A"), B: det("d2b", "B") },
+      3: { B: det("d3b", "B") },
+    };
+
+    // merge B (source) into A (target)
+    render().current.mergeTracks("instance-B", "instance-A");
+
+    expect(mockActions.transaction).toHaveBeenCalledTimes(1);
+
+    // every source (B) frame is dropped
+    expect(mockActions.deleteLabel).toHaveBeenCalledTimes(2);
+    expect(mockActions.deleteLabel).toHaveBeenCalledWith({
+      path: PATH,
+      instanceId: "B",
+      frame: 2,
+    });
+    expect(mockActions.deleteLabel).toHaveBeenCalledWith({
+      path: PATH,
+      instanceId: "B",
+      frame: 3,
+    });
+
+    // frame 2 overlaps (A present) → target-wins, no re-stamp; only frame 3
+    // (A absent) is re-laid onto A
+    expect(mockActions.updateLabel).toHaveBeenCalledTimes(1);
+    expect(mockActions.updateLabel).toHaveBeenCalledWith(
+      { path: PATH, instanceId: "A", frame: 3 },
+      { _cls: "Detection", label: "x", bounding_box: [0, 0, 1, 1] }
+    );
+
+    expect(mockBus.dispatch).toHaveBeenCalledWith("annotation:trackMerged", {
+      sourceTrackId: "instance-B",
+      targetTrackId: "instance-A",
+      sourceInstanceId: "B",
+      targetInstanceId: "A",
+    });
+  });
+
+  it("mergeTracks no-ops on a self-merge", () => {
+    frameData = { 1: { A: det("d1", "A") } };
+
+    render().current.mergeTracks("instance-A", "instance-A");
+
+    expect(mockActions.transaction).not.toHaveBeenCalled();
+    expect(mockBus.dispatch).not.toHaveBeenCalled();
+  });
+
+  it("mergeTracks skips a legacy track-<index> on either side", () => {
+    frameData = { 1: { A: det("d1", "A") } };
+
+    render().current.mergeTracks("track-1", "instance-A");
+    render().current.mergeTracks("instance-A", "track-1");
+
+    expect(mockActions.transaction).not.toHaveBeenCalled();
   });
 });
 

--- a/app/packages/video-annotation/src/hooks/useVideoSurfaceActions.ts
+++ b/app/packages/video-annotation/src/hooks/useVideoSurfaceActions.ts
@@ -38,6 +38,19 @@ export interface VideoSurfaceActions {
     trackId: string,
     attributes: Record<string, unknown>
   ): void;
+  /**
+   * Split this track at `atFrame`: frames `>= atFrame` are re-keyed onto a
+   * fresh instance (a distinct object); the original keeps frames `< atFrame`.
+   * One undo unit. No-ops on a legacy/non-instance track or an empty tail.
+   */
+  splitTrack(trackId: string, atFrame: number): void;
+  /**
+   * Merge `sourceTrackId` into `targetTrackId`: the source's frames are
+   * re-keyed onto the target's instance, target-wins on overlapping frames
+   * (the source box is dropped there). One undo unit. No-ops on a
+   * legacy/non-instance track or a self-merge.
+   */
+  mergeTracks(sourceTrackId: string, targetTrackId: string): void;
   /** Create a sample-level TemporalDetection; returns its id (the new instanceId). */
   createTemporalDetection(
     fieldPath: string,
@@ -304,6 +317,115 @@ const makeTrackOps = (
   };
 };
 
+/** A frame's detection paired with its number, for stable-snapshot passes. */
+type FrameDetection = { frame: number; det: LabelData };
+
+/**
+ * Instance-level track identity rewrites (split / merge). Each re-keys frames
+ * by composing `deleteLabel` (old instance) + `updateLabel` (new instance,
+ * born under the target id) inside one transaction — one undo unit. The engine
+ * refuses identity edits via `updateLabel`, so re-keying is delete + recreate;
+ * the per-frame doc `_id` is re-minted (it links nothing — `instance._id` is
+ * the track key).
+ */
+const makeTrackIdentityOps = (
+  ctx: ReadyContext,
+  actions: SurfaceActions,
+  eventBus: AnnotationEventBus,
+  reader: FrameReader,
+  engine: AnnotationEngine
+) => {
+  const { path } = ctx;
+  const { read, content, trackFrames } = reader;
+
+  /** A track's frames with detections read up front, for a stable snapshot. */
+  const snapshot = (
+    instanceId: string,
+    keep: (frame: number) => boolean
+  ): FrameDetection[] =>
+    trackFrames(instanceId)
+      .filter(keep)
+      .map((frame) => ({ frame, det: read(instanceId, frame) }))
+      .filter((s): s is FrameDetection => !!s.det);
+
+  const splitTrack = (trackId: string, atFrame: number): void => {
+    const instanceId = instanceIdFromTrackId(trackId);
+
+    if (!instanceId) {
+      return;
+    }
+
+    const tail = snapshot(instanceId, (frame) => frame >= atFrame);
+
+    if (tail.length === 0) {
+      return;
+    }
+
+    const newInstanceId = engine.mintInstanceId();
+
+    actions.transaction(() => {
+      for (const { frame, det } of tail) {
+        actions.deleteLabel({ path, instanceId, frame });
+        actions.updateLabel(
+          { path, instanceId: newInstanceId, frame },
+          content(det)
+        );
+      }
+    });
+
+    eventBus.dispatch("annotation:trackSplit", {
+      trackId,
+      instanceId,
+      newInstanceId,
+      atFrame,
+    });
+  };
+
+  const mergeTracks = (sourceTrackId: string, targetTrackId: string): void => {
+    const sourceInstanceId = instanceIdFromTrackId(sourceTrackId);
+    const targetInstanceId = instanceIdFromTrackId(targetTrackId);
+
+    if (
+      !sourceInstanceId ||
+      !targetInstanceId ||
+      sourceInstanceId === targetInstanceId
+    ) {
+      return;
+    }
+
+    const occupied = new Set(trackFrames(targetInstanceId));
+    const sources = snapshot(sourceInstanceId, () => true);
+
+    if (sources.length === 0) {
+      return;
+    }
+
+    actions.transaction(() => {
+      for (const { frame, det } of sources) {
+        // target-wins: always drop the source box; only re-stamp onto the
+        // target where it has no box on this frame
+        actions.deleteLabel({ path, instanceId: sourceInstanceId, frame });
+
+        if (!occupied.has(frame)) {
+          actions.updateLabel(
+            { path, instanceId: targetInstanceId, frame },
+            content(det)
+          );
+        }
+      }
+    });
+
+    eventBus.dispatch("annotation:trackMerged", {
+      sourceTrackId,
+      targetTrackId,
+      sourceInstanceId,
+      targetInstanceId,
+    });
+  };
+
+  return { splitTrack, mergeTracks };
+};
+
 /** Sample-level TemporalDetection ops (no frame on the ref). */
 const makeTemporalDetectionOps = (actions: SurfaceActions) => {
   const createTemporalDetection = (
@@ -388,13 +510,22 @@ export const useVideoSurfaceActions = (): VideoSurfaceActions => {
         shiftTrack: () => {},
         deleteTrack: () => {},
         updateTrackAttributes: () => {},
+        splitTrack: () => {},
+        mergeTracks: () => {},
         ...temporal,
       };
     }
 
     const reader = makeFrameReader(engine, ctx);
     const track = makeTrackOps(ctx, actions, eventBus, reader);
+    const identity = makeTrackIdentityOps(
+      ctx,
+      actions,
+      eventBus,
+      reader,
+      engine
+    );
 
-    return { ...track, ...temporal };
+    return { ...track, ...identity, ...temporal };
   }, [engine, actions, sampleId, stream, eventBus]);
 };

--- a/e2e-pw/src/oss/fixtures/video-annotate-sdk.ts
+++ b/e2e-pw/src/oss/fixtures/video-annotate-sdk.ts
@@ -22,6 +22,12 @@ export interface SeedVideoAnnotationOptions {
    * existing track. Defaults to none (a clean slate, like `va-demo-bare`).
    */
   trackedSampleIndices?: number[];
+  /**
+   * Sample indices that should carry a SECOND tracked instance (`index=2`,
+   * class `classes[1]`, on every frame) alongside the first — so tests can
+   * exercise multi-track ops like merge. Additive; defaults to none.
+   */
+  secondTrackSampleIndices?: number[];
 }
 
 /**
@@ -48,12 +54,14 @@ export class VideoAnnotateSDK {
       eventClasses = ["approach", "pass", "depart"],
       withEvents = true,
       trackedSampleIndices = [],
+      secondTrackSampleIndices = [],
     } = options;
 
     const pyPaths = JSON.stringify(videoPaths);
     const pyClasses = JSON.stringify(classes);
     const pyEventClasses = JSON.stringify(eventClasses);
     const pyTracked = JSON.stringify(trackedSampleIndices);
+    const pySecondTracked = JSON.stringify(secondTrackSampleIndices);
 
     return this.loader.executePythonCode(`
 import fiftyone as fo
@@ -64,6 +72,7 @@ CLASSES = ${pyClasses}
 EVENT_CLASSES = ${pyEventClasses}
 WITH_EVENTS = ${withEvents ? "True" : "False"}
 TRACKED = set(${pyTracked})
+SECOND_TRACKED = set(${pySecondTracked})
 DETECTIONS_FIELD = "detections"
 EVENTS_FIELD = "events"
 
@@ -143,6 +152,24 @@ for idx, sample in enumerate(dataset.iter_samples(progress=False, autosave=True)
                 )
             ]
         )
+
+# A SECOND tracked instance (index=2, class CLASSES[1]) appended on every
+# frame of requested samples — for multi-track ops (merge).
+for idx, sample in enumerate(dataset.iter_samples(progress=False, autosave=True)):
+    if idx not in SECOND_TRACKED:
+        continue
+    for fn in range(1, total_frames(sample) + 1):
+        dets = sample.frames[fn]["detections"]
+        if dets is None:
+            dets = fo.Detections(detections=[])
+        dets.detections.append(
+            fo.Detection(
+                label=CLASSES[1],
+                bounding_box=[0.55, 0.55, 0.2, 0.2],
+                index=2,
+            )
+        )
+        sample.frames[fn]["detections"] = dets
 
 # (5) demo temporal events (approach / pass / depart thirds).
 if WITH_EVENTS:

--- a/e2e-pw/src/oss/poms/modal/video-annotate.ts
+++ b/e2e-pw/src/oss/poms/modal/video-annotate.ts
@@ -86,6 +86,65 @@ export class VideoAnnotatePom {
   }
 
   /**
+   * Right-click a track's interval bar and choose "Split at playhead" — re-keys
+   * the frames at/after the current playhead onto a fresh instance (a distinct
+   * object), splitting the track in two in one engine transaction.
+   */
+  async splitTrackViaContextMenu(trackId: string) {
+    await this.trackBar(trackId).click({ button: "right" });
+    await this.page
+      .getByRole("menuitem", { name: "Split at playhead" })
+      .click();
+  }
+
+  /**
+   * Seek the playhead by clicking the timeline ruler at `fraction` of its
+   * width — a real timeline seek that lands mid-clip (unlike clicking a track
+   * row, which jumps the playhead to that track's start frame).
+   */
+  async seekToRulerFraction(fraction: number) {
+    // the ruler uses `data-testid` (not the suite's `data-cy` testid attr), so
+    // address it explicitly; `.first()` covers the pinned + drawer layouts
+    const ruler = this.page.locator('[data-testid="timeline-ruler"]').first();
+    const box = await ruler.boundingBox();
+
+    if (!box) {
+      throw new Error("timeline ruler is not visible");
+    }
+
+    await ruler.click({
+      position: { x: box.width * fraction, y: box.height / 2 },
+    });
+  }
+
+  /** Click the toolbar "Split" button (enabled with exactly one track selected). */
+  async clickSplitToolbarButton() {
+    await this.page.locator('button[aria-label="Split"]').click();
+  }
+
+  /** Click the toolbar "Merge" button (enabled with exactly two tracks selected). */
+  async clickMergeToolbarButton() {
+    await this.page.locator('button[aria-label="Merge"]').click();
+  }
+
+  /**
+   * Right-click the source track's interval bar and choose "Merge into
+   * <targetLabel>" — re-keys the source's frames onto the target instance
+   * (target-wins on overlapping frames); the source track ceases to exist.
+   */
+  async mergeTrackViaContextMenu(sourceTrackId: string, targetLabel: string) {
+    await this.trackBar(sourceTrackId).click({ button: "right" });
+    await this.page
+      .getByRole("menuitem", { name: `Merge into ${targetLabel}` })
+      .click();
+  }
+
+  /** Undo the last annotation edit (the ModalAnnotate undo keybinding). */
+  async undo() {
+    await this.page.keyboard.press("ControlOrMeta+z");
+  }
+
+  /**
    * Advance the playhead one frame. Uses the Modal-context "." keybinding
    * (`KnownCommands.ModalStepForward`) rather than the icon button, which is
    * the robust path while the ImaVid buffer settles.

--- a/e2e-pw/src/oss/specs/MISSING-annotate-video-track-split-merge.spec.ts
+++ b/e2e-pw/src/oss/specs/MISSING-annotate-video-track-split-merge.spec.ts
@@ -1,0 +1,165 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ *
+ * Instance-level track actions on the video-annotation surface: SPLIT a track
+ * into two objects at the playhead (frames >= F re-keyed onto a fresh instance,
+ * the original keeps frames < F) and MERGE one track into another (the source's
+ * frames re-keyed onto the target's instance, target-wins on overlap; the
+ * source ceases to exist). Both are single engine transactions — one undo unit
+ * — and survive a true round-trip (fresh browser context) via autosave.
+ *
+ * Seeded with two distinct tracks on sample 0: a "vehicle" (index=1) and a
+ * "person" (index=2), each on every frame.
+ */
+import { Browser, expect, test as base } from "src/oss/fixtures";
+import { ModalPom } from "src/oss/poms/modal";
+import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
+import { EventUtils } from "src/shared/event-utils";
+import type { AbstractFiftyoneLoader } from "src/shared/abstract-loader";
+import type { Page } from "src/oss/fixtures";
+
+const datasetName = getUniqueDatasetNameWithPrefix(
+  "annotate-video-track-split-merge"
+);
+const id = "000000000000000000000000";
+const clip = `/tmp/${datasetName}.webm`;
+
+const test = base.extend<{ modal: ModalPom }>({
+  modal: async ({ page, eventUtils }, use) => {
+    await use(new ModalPom(page, eventUtils));
+  },
+});
+
+test.beforeAll(async ({ foWebServer, mediaFactory }) => {
+  await foWebServer.startWebServer();
+  await mediaFactory.createVideo({
+    outputPath: clip,
+    duration: 2,
+    width: 64,
+    height: 64,
+    frameRate: 10,
+    color: "#3050a0",
+  });
+});
+
+test.afterAll(async ({ foWebServer }) => {
+  await foWebServer.stopWebServer();
+});
+
+test.beforeEach(async ({ videoAnnotateSDK }) => {
+  // two tracks on sample 0: vehicle (index=1) + person (index=2), every frame.
+  await videoAnnotateSDK.seed({
+    datasetName,
+    videoPaths: [clip],
+    withEvents: false,
+    trackedSampleIndices: [0],
+    secondTrackSampleIndices: [0],
+  });
+});
+
+const openAnnotate = async (
+  fiftyoneLoader: AbstractFiftyoneLoader,
+  modal: ModalPom,
+  page: Page
+) => {
+  await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
+    searchParams: new URLSearchParams({ id }),
+  });
+  await modal.assert.isOpen();
+  await modal.sidebar.switchMode("annotate");
+  await modal.videoAnnotate.waitForSurface();
+};
+
+const savedResponse = (page: Page) =>
+  page.waitForResponse(
+    (r) =>
+      /\/sample\//.test(r.url()) &&
+      ["POST", "PATCH", "PUT"].includes(r.request().method())
+  );
+
+test.describe.serial("video annotation track split / merge", () => {
+  test("split at playhead (context menu) makes two tracks; undo restores one", async ({
+    fiftyoneLoader,
+    modal,
+    page,
+  }) => {
+    await openAnnotate(fiftyoneLoader, modal, page);
+    const va = modal.videoAnnotate;
+
+    // vehicle + person
+    await va.assert.objectTrackCount(2);
+    const vehicleId = await va.labelRowId("vehicle");
+
+    // seek mid-clip so the playhead sits between the track's first and last
+    // frame — both sides of the split are then non-empty
+    await va.clickTrack(vehicleId);
+    await va.seekToRulerFraction(0.5);
+    await va.splitTrackViaContextMenu(vehicleId);
+
+    // the vehicle track is now two; person is untouched (3 total)
+    await va.assert.objectTrackCount(3);
+
+    // one undo unit: back to vehicle + person
+    await va.undo();
+    await va.assert.objectTrackCount(2);
+    await va.assert.hasTrack(vehicleId);
+  });
+
+  test("split at playhead (toolbar) makes two tracks", async ({
+    fiftyoneLoader,
+    modal,
+    page,
+  }) => {
+    await openAnnotate(fiftyoneLoader, modal, page);
+    const va = modal.videoAnnotate;
+
+    await va.assert.objectTrackCount(2);
+    const vehicleId = await va.labelRowId("vehicle");
+
+    // select the track (Split enables with one selected), then seek mid-clip
+    // (the row click that selects also jumps the playhead to the track start)
+    await va.clickTrack(vehicleId);
+    await va.seekToRulerFraction(0.5);
+    await va.clickSplitToolbarButton();
+
+    await va.assert.objectTrackCount(3);
+  });
+
+  test("merge (context menu) folds the source into the target and persists", async ({
+    browser,
+    fiftyoneLoader,
+    modal,
+    page,
+  }) => {
+    await openAnnotate(fiftyoneLoader, modal, page);
+    const va = modal.videoAnnotate;
+
+    await va.assert.objectTrackCount(2);
+    await va.assert.labelListed("vehicle");
+    await va.assert.labelListed("person");
+    const personId = await va.labelRowId("person");
+
+    // merge person INTO vehicle; both span every frame, so target-wins drops
+    // every person frame — the person track disappears, vehicle survives
+    const saved = savedResponse(page);
+    await va.mergeTrackViaContextMenu(personId, "vehicle");
+    await va.assert.objectTrackCount(1);
+    await saved;
+
+    await va.assert.labelListed("person", false);
+    await va.assert.labelListed("vehicle");
+
+    // the merge survives a true round-trip
+    const context = await browser.newContext();
+    const freshPage = await context.newPage();
+    try {
+      const m2 = new ModalPom(freshPage, new EventUtils(freshPage));
+      await openAnnotate(fiftyoneLoader, m2, freshPage);
+      await m2.videoAnnotate.assert.objectTrackCount(1);
+      await m2.videoAnnotate.assert.labelListed("person", false);
+      await m2.videoAnnotate.assert.labelListed("vehicle");
+    } finally {
+      await context.close();
+    }
+  });
+});


### PR DESCRIPTION
## Object-track split / merge on the video annotation surface

Adds instance-level track operations to the engine-backed video annotation surface:

- **Split** a track at the playhead — frames `>= F` are re-keyed onto a fresh `instance._id` (a new object); the original keeps frames `< F`.
- **Merge** one track into another — the source's frames are re-keyed onto the target's instance, target-wins on overlapping frames; the source ceases to exist.

Both are single engine transactions (one undo unit)

### UX
- **Context menu** on a track's presence bar: Delete, "Split at playhead", and flat "Merge into &lt;track&gt;" entries (split frame captured at menu-open, so the menu-item click's seek can't race it).
- **Toolbar**: Split (one selected track) / Merge (two selected). The generic playback `eventDeleteConfig` is generalized into an `eventMenuItems[]` array, threaded through `TimelineTrack` / `TimelineWithTracks`, with the other consumer migrated in the same pass.

### Fixes a duplicate-row bug found in review
`TimelineWithTracks` rendered pinned tracks in **both** the drawer header slot and the drawer body with no drawer-state gate, so every pinned row mounted twice under the same track id — selecting/editing one row hit both. Now each pinned row renders once per drawer state (header when closed, body when open). Adds a regression-guard unit test.

### Tests
- Unit: split/merge hook ops, frame-store re-key + undo round-trips, generalized track menus, "pinned row renders exactly once".
- e2e (`MISSING-annotate-video-track-split-merge.spec.ts`): split via context menu (+ undo restores one track), split via toolbar, merge via context menu (+ persists across a fresh context).
- Verified locally: playback vitest green; video-annotate e2e suite green

### Deferred
Multi-track selection isn't available yet, so the **toolbar Merge** button (needs two selected tracks) isn't usable — context-menu merge works today. Multi-select is its own follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added split and merge track actions in video annotation, available from the toolbar and context menus.
  * Event menus now support multiple custom actions instead of a single delete option.
  * Playback timeline items can now show richer per-event actions.

* **Bug Fixes**
  * Improved pinned track rendering so labels no longer appear duplicated when the drawer is closed.
  * Updated undo behavior and track edits to keep changes reversible in a single step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->