### PR TITLE
chore: Bump version from 1.18.0 to 1.19.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ Installs FiftyOne.
 import os
 from setuptools import setup, find_packages
 
-VERSION = "1.18.0"
+VERSION = "1.19.0"
 
 
 def get_version():


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

Bumps `develop` from `1.18.0` to `1.19.0` for the OSS `1.18.0` minor release. The release is cut on `release/v1.18.0`; this PR advances `develop` to the next dev minor.

## 🧪 How is this patch tested? If it is not, please explain why.

N/A — version string bump only.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.

### What areas of FiftyOne does this PR affect?

-   [x] Build: Build and test infrastructure changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version to **1.19.0**.
  * Version validation now accepts release version values starting with **1.19.0**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->