### PR TITLE
Infinite scroll backend

### DIFF
--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -3544,6 +3544,8 @@ class GroupBy(ViewStage):
         self._create_index = create_index
         self._sort_stage = None
         self._order_by_key = order_by_key
+        # emit a per-group `_group_count`
+        self._include_count = False
 
     @property
     def outputs_dynamic_groups(self):
@@ -3604,6 +3606,11 @@ class GroupBy(ViewStage):
 
         return self._make_grouped_pipeline(sample_collection)
 
+    def _group_field_stage(self, sample_collection):
+        # shared `$addFields` so every read labels docs with `_group` identically
+        group_expr, _ = self._get_group_expr(sample_collection)
+        return {"$addFields": {"_group": group_expr}}
+
     def _make_flat_pipeline(self, sample_collection):
         group_expr, _ = self._get_group_expr(sample_collection)
         match_expr = self._get_mongo_match_expr()
@@ -3635,7 +3642,7 @@ class GroupBy(ViewStage):
             [
                 {"$unwind": "$docs"},
                 {"$replaceRoot": {"newRoot": "$docs"}},
-                {"$addFields": {"_group": group_expr}},
+                self._group_field_stage(sample_collection),
             ]
         )
 
@@ -3644,7 +3651,10 @@ class GroupBy(ViewStage):
     def _make_grouped_pipeline(self, sample_collection):
         if self._order_by_key is not None:
             order_by = sample_collection._handle_db_field(self._order_by)
-            return [{"$match": {order_by: self._order_by_key}}]
+            return [
+                {"$match": {order_by: self._order_by_key}},
+                self._group_field_stage(sample_collection),
+            ]
 
         group_expr, _ = self._get_group_expr(sample_collection)
         pipeline = []
@@ -3653,12 +3663,43 @@ class GroupBy(ViewStage):
         if self._sort_stage is not None:
             pipeline.extend(self._sort_stage.to_mongo(sample_collection))
 
-        pipeline.extend(
-            [
-                {"$group": {"_id": group_expr, "doc": {"$first": "$$ROOT"}}},
-                {"$replaceRoot": {"newRoot": "$doc"}},
-            ]
-        )
+        if self._include_count:
+            pipeline.extend(
+                [
+                    {
+                        "$group": {
+                            "_id": group_expr,
+                            "doc": {"$first": "$$ROOT"},
+                            "_group_count": {"$sum": 1},
+                        }
+                    },
+                    {
+                        "$replaceRoot": {
+                            "newRoot": {
+                                "$mergeObjects": [
+                                    "$doc",
+                                    {"_group_count": "$_group_count"},
+                                ]
+                            }
+                        }
+                    },
+                ]
+            )
+        else:
+            pipeline.extend(
+                [
+                    {
+                        "$group": {
+                            "_id": group_expr,
+                            "doc": {"$first": "$$ROOT"},
+                        }
+                    },
+                    {"$replaceRoot": {"newRoot": "$doc"}},
+                ]
+            )
+
+        # re-label `_group`; the `$group`/`$replaceRoot` above drops it
+        pipeline.append(self._group_field_stage(sample_collection))
 
         # add a sort stage so that we return a stable ordering of groups
         # sort by _id to preserve insertion order

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -3546,14 +3546,8 @@ class GroupBy(ViewStage):
         self._order_by_key = order_by_key
         # emit a per-group `_group_count`
         self._include_count = False
-        # emit `_group` (the dynamic-group value) on each doc. Off by default so
-        # plain SDK reads stay loadable; the app turns it on so it never has to
-        # re-derive the group value from the pipeline
+        # emit `_group` (the dynamic-group value) on each doc.
         self._include_group = False
-        # presort by the group key so the `$group` rides an index (IXSCAN)
-        # instead of scanning the collection. Off by default because it changes
-        # which document represents each group; the app turns it on
-        self._index_optimized = False
 
     @property
     def outputs_dynamic_groups(self):
@@ -3619,31 +3613,6 @@ class GroupBy(ViewStage):
         group_expr, _ = self._get_group_expr(sample_collection)
         return {"$addFields": {"_group": group_expr}}
 
-    def _index_presort(self, sample_collection):
-        # a `$sort` on the group key(s) lets the `$group` ride an index, but only
-        # when one exists; a presort without an index is a blocking sort (worse)
-        group_expr, _ = self._get_group_expr(sample_collection)
-        exprs = (
-            group_expr
-            if isinstance(group_expr, (list, tuple))
-            else [group_expr]
-        )
-        if not all(etau.is_str(e) and e.startswith("$") for e in exprs):
-            return None
-
-        fields = [e[1:] for e in exprs]
-        try:
-            index_info = sample_collection.get_index_information()
-        except Exception:
-            return None
-
-        for info in index_info.values():
-            keys = [k for k, _ in info.get("key", [])]
-            if keys[: len(fields)] == fields:
-                return {"$sort": {f: 1 for f in fields}}
-
-        return None
-
     def _make_flat_pipeline(self, sample_collection):
         group_expr, _ = self._get_group_expr(sample_collection)
         match_expr = self._get_mongo_match_expr()
@@ -3697,10 +3666,6 @@ class GroupBy(ViewStage):
         # sort so that first document in each group comes from a sorted list
         if self._sort_stage is not None:
             pipeline.extend(self._sort_stage.to_mongo(sample_collection))
-        elif self._index_optimized:
-            presort = self._index_presort(sample_collection)
-            if presort is not None:
-                pipeline.append(presort)
 
         if self._include_count:
             pipeline.extend(

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -3550,6 +3550,10 @@ class GroupBy(ViewStage):
         # plain SDK reads stay loadable; the app turns it on so it never has to
         # re-derive the group value from the pipeline
         self._include_group = False
+        # presort by the group key so the `$group` rides an index (IXSCAN)
+        # instead of scanning the collection. Off by default because it changes
+        # which document represents each group; the app turns it on
+        self._index_optimized = False
 
     @property
     def outputs_dynamic_groups(self):
@@ -3615,6 +3619,31 @@ class GroupBy(ViewStage):
         group_expr, _ = self._get_group_expr(sample_collection)
         return {"$addFields": {"_group": group_expr}}
 
+    def _index_presort(self, sample_collection):
+        # a `$sort` on the group key(s) lets the `$group` ride an index, but only
+        # when one exists; a presort without an index is a blocking sort (worse)
+        group_expr, _ = self._get_group_expr(sample_collection)
+        exprs = (
+            group_expr
+            if isinstance(group_expr, (list, tuple))
+            else [group_expr]
+        )
+        if not all(etau.is_str(e) and e.startswith("$") for e in exprs):
+            return None
+
+        fields = [e[1:] for e in exprs]
+        try:
+            index_info = sample_collection.get_index_information()
+        except Exception:
+            return None
+
+        for info in index_info.values():
+            keys = [k for k, _ in info.get("key", [])]
+            if keys[: len(fields)] == fields:
+                return {"$sort": {f: 1 for f in fields}}
+
+        return None
+
     def _make_flat_pipeline(self, sample_collection):
         group_expr, _ = self._get_group_expr(sample_collection)
         match_expr = self._get_mongo_match_expr()
@@ -3668,6 +3697,10 @@ class GroupBy(ViewStage):
         # sort so that first document in each group comes from a sorted list
         if self._sort_stage is not None:
             pipeline.extend(self._sort_stage.to_mongo(sample_collection))
+        elif self._index_optimized:
+            presort = self._index_presort(sample_collection)
+            if presort is not None:
+                pipeline.append(presort)
 
         if self._include_count:
             pipeline.extend(

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -3546,6 +3546,10 @@ class GroupBy(ViewStage):
         self._order_by_key = order_by_key
         # emit a per-group `_group_count`
         self._include_count = False
+        # emit `_group` (the dynamic-group value) on each doc. Off by default so
+        # plain SDK reads stay loadable; the app turns it on so it never has to
+        # re-derive the group value from the pipeline
+        self._include_group = False
 
     @property
     def outputs_dynamic_groups(self):
@@ -3642,19 +3646,21 @@ class GroupBy(ViewStage):
             [
                 {"$unwind": "$docs"},
                 {"$replaceRoot": {"newRoot": "$docs"}},
-                self._group_field_stage(sample_collection),
             ]
         )
+
+        if self._include_group:
+            pipeline.append(self._group_field_stage(sample_collection))
 
         return pipeline
 
     def _make_grouped_pipeline(self, sample_collection):
         if self._order_by_key is not None:
             order_by = sample_collection._handle_db_field(self._order_by)
-            return [
-                {"$match": {order_by: self._order_by_key}},
-                self._group_field_stage(sample_collection),
-            ]
+            pipeline = [{"$match": {order_by: self._order_by_key}}]
+            if self._include_group:
+                pipeline.append(self._group_field_stage(sample_collection))
+            return pipeline
 
         group_expr, _ = self._get_group_expr(sample_collection)
         pipeline = []
@@ -3699,7 +3705,8 @@ class GroupBy(ViewStage):
             )
 
         # re-label `_group`; the `$group`/`$replaceRoot` above drops it
-        pipeline.append(self._group_field_stage(sample_collection))
+        if self._include_group:
+            pipeline.append(self._group_field_stage(sample_collection))
 
         # add a sort stage so that we return a stable ordering of groups
         # sort by _id to preserve insertion order

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -908,6 +908,16 @@ class DatasetView(foc.SampleCollection):
 
         group_expr, is_id_field, root_view, sort = self._parse_dynamic_groups()
 
+        if isinstance(group_expr, (list, tuple)) and (
+            not isinstance(group_value, (list, tuple))
+            or len(group_value) != len(group_expr)
+        ):
+            # compound key: one value per field, else zip() builds a partial match
+            raise ValueError(
+                "Expected %d values for compound group key %s; found %r"
+                % (len(group_expr), group_expr, group_value)
+            )
+
         if isinstance(is_id_field, (list, tuple)):
             group_value = [
                 ObjectId(v) if i else v

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -920,6 +920,19 @@ class DatasetView(foc.SampleCollection):
 
         if etau.is_str(group_expr):
             pipeline.append({"$match": {group_expr[1:]: group_value}})
+        elif isinstance(group_expr, (list, tuple)) and all(
+            etau.is_str(e) and e.startswith("$") for e in group_expr
+        ):
+            # match each field directly (index-eligible); an `$expr` over a
+            # computed array cannot use an index
+            pipeline.append(
+                {
+                    "$match": {
+                        field_ref[1:]: value
+                        for field_ref, value in zip(group_expr, group_value)
+                    }
+                }
+            )
         else:
             pipeline.append(
                 {"$match": {"$expr": {"$eq": [group_expr, group_value]}}}

--- a/fiftyone/server/aggregations.py
+++ b/fiftyone/server/aggregations.py
@@ -319,7 +319,9 @@ def _resolve_path_aggregation(
 
     data = {"path": path}
     if use_estimate:
-        est = view._root_dataset._sample_collection.estimated_document_count()
+        # estimate the collection the view actually reads (`_dataset`); for
+        # generated views (patches/clips/frames) that differs from `_root_dataset`
+        est = view._dataset._sample_collection.estimated_document_count()
         data["count"] = est
         data["exists"] = est
     elif combined_root:

--- a/fiftyone/server/aggregations.py
+++ b/fiftyone/server/aggregations.py
@@ -150,13 +150,22 @@ async def aggregate_resolver(
     aggregations, deserializers = zip(
         *[
             _resolve_path_aggregation(
-                path, view, form.query_performance, form.hint, form.mixed
+                path, view, form.query_performance, form.hint, mixed=form.mixed
             )
             for path in form.paths
         ]
     )
     counts = [len(a) for a in aggregations]
     flattened = [item for sublist in aggregations for item in sublist]
+
+    # group-statistics mode on a grouped dataset: one `$group` pass over the
+    # mixed view yields both the sample total and the distinct-group total,
+    # instead of a second `Count` query over a single slice
+    grouped_root = (
+        form.mixed
+        and "" in form.paths
+        and view._root_dataset.media_type == fom.GROUP
+    )
 
     maxTimeMS = form.max_query_time * 1000 if form.max_query_time else None
     try:
@@ -165,6 +174,9 @@ async def aggregate_resolver(
             if flattened
             else []
         )
+        groups = samples = None
+        if grouped_root:
+            groups, samples = await _grouped_root_counts(view, maxTimeMS)
     except ExecutionTimeout:
         return [
             AggregationQueryTimeout(path=path, query_time=form.max_query_time)
@@ -177,11 +189,7 @@ async def aggregate_resolver(
         results.append(deserialize(result[offset : length + offset]))
         offset += length
 
-    if form.mixed and "" in form.paths:
-        # group-statistics mode: one `$group` pass over the mixed view yields
-        # both the sample total and the distinct-group total, instead of a
-        # second `Count` query over a single slice
-        groups, samples = await _grouped_root_counts(view, maxTimeMS)
+    if grouped_root:
         for result in results:
             if isinstance(result, RootAggregation):
                 result.slice = groups
@@ -192,7 +200,7 @@ async def aggregate_resolver(
     return results
 
 
-async def _grouped_root_counts(view, maxTimeMS=None):
+async def _grouped_root_counts(view, maxTimeMS=None) -> t.Tuple[int, int]:
     group_id = view._root_dataset.group_field + "._id"
     pipeline = view._pipeline() + [
         {"$group": {"_id": "$" + group_id, "_n": {"$sum": 1}}},
@@ -257,6 +265,7 @@ def _resolve_path_aggregation(
     view: foc.SampleCollection,
     query_performance: bool,
     hint: t.Optional[str] = None,
+    *,
     mixed: bool = False,
 ) -> AggregateResult:
     # root ("" path) total: the O(1) estimated document count ignores the

--- a/fiftyone/server/aggregations.py
+++ b/fiftyone/server/aggregations.py
@@ -233,13 +233,17 @@ def _resolve_path_aggregation(
     query_performance: bool,
     hint: t.Optional[str] = None,
 ) -> AggregateResult:
-    aggregations: t.List[foa.Aggregation] = [
-        foa.Count(
-            path if path and path != "" else None,
-            _optimize=query_performance,
-            _hint=hint if query_performance else None,
+    # root ("" path) total uses the estimated document count; a `Count` would
+    # force a full group-by pass on grouped views. only field paths get a count.
+    aggregations: t.List[foa.Aggregation] = []
+    if path:
+        aggregations.append(
+            foa.Count(
+                path,
+                _optimize=query_performance,
+                _hint=hint if query_performance else None,
+            )
         )
-    ]
     field = view.get_field(path)
 
     while isinstance(field, fof.ListField):
@@ -273,6 +277,10 @@ def _resolve_path_aggregation(
             aggregations.append(foa.CountValues(path, _first=LIST_LIMIT))
 
     data = {"path": path}
+    if not path:
+        est = view._root_dataset._sample_collection.estimated_document_count()
+        data["count"] = est
+        data["exists"] = est
 
     def from_results(results):
         for aggregation, result in zip(aggregations, results):

--- a/fiftyone/server/aggregations.py
+++ b/fiftyone/server/aggregations.py
@@ -17,6 +17,7 @@ import fiftyone.core.collections as foc
 import fiftyone.core.fields as fof
 import fiftyone.core.labels as fol
 import fiftyone.core.media as fom
+import fiftyone.core.odm as foo
 from fiftyone.core.utils import datetime_to_timestamp
 import fiftyone.core.view as fov
 
@@ -130,11 +131,6 @@ async def aggregate_resolver(
 
     view = await _load_view(form, form.slices)
 
-    slice_view = None
-
-    if form.mixed and "" in form.paths:
-        slice_view = await _load_view(form, [form.slice])
-
     if form.sample_ids:
         view = fov.make_optimized_select_view(view, form.sample_ids)
 
@@ -154,7 +150,7 @@ async def aggregate_resolver(
     aggregations, deserializers = zip(
         *[
             _resolve_path_aggregation(
-                path, view, form.query_performance, form.hint
+                path, view, form.query_performance, form.hint, form.mixed
             )
             for path in form.paths
         ]
@@ -164,7 +160,11 @@ async def aggregate_resolver(
 
     maxTimeMS = form.max_query_time * 1000 if form.max_query_time else None
     try:
-        result = await view._async_aggregate(flattened, maxTimeMS=maxTimeMS)
+        result = (
+            await view._async_aggregate(flattened, maxTimeMS=maxTimeMS)
+            if flattened
+            else []
+        )
     except ExecutionTimeout:
         return [
             AggregationQueryTimeout(path=path, query_time=form.max_query_time)
@@ -177,13 +177,38 @@ async def aggregate_resolver(
         results.append(deserialize(result[offset : length + offset]))
         offset += length
 
-    if slice_view:
+    if form.mixed and "" in form.paths:
+        # group-statistics mode: one `$group` pass over the mixed view yields
+        # both the sample total and the distinct-group total, instead of a
+        # second `Count` query over a single slice
+        groups, samples = await _grouped_root_counts(view, maxTimeMS)
         for result in results:
             if isinstance(result, RootAggregation):
-                result.slice = await slice_view._async_aggregate(foa.Count())
+                result.slice = groups
+                result.count = samples
+                result.exists = samples
                 break
 
     return results
+
+
+async def _grouped_root_counts(view, maxTimeMS=None):
+    group_id = view._root_dataset.group_field + "._id"
+    pipeline = view._pipeline() + [
+        {"$group": {"_id": "$" + group_id, "_n": {"$sum": 1}}},
+        {
+            "$group": {
+                "_id": None,
+                "groups": {"$sum": 1},
+                "samples": {"$sum": "$_n"},
+            }
+        },
+    ]
+    coll = foo.get_async_db_conn()[view._dataset._sample_collection_name]
+    rows = await foo.aggregate(coll, pipeline, maxTimeMS=maxTimeMS).to_list(1)
+    if not rows:
+        return 0, 0
+    return rows[0]["groups"], rows[0]["samples"]
 
 
 RESULT_MAPPING = {
@@ -232,14 +257,21 @@ def _resolve_path_aggregation(
     view: foc.SampleCollection,
     query_performance: bool,
     hint: t.Optional[str] = None,
+    mixed: bool = False,
 ) -> AggregateResult:
-    # root ("" path) total uses the estimated document count; a `Count` would
-    # force a full group-by pass on grouped views. only field paths get a count.
+    # root ("" path) total: the O(1) estimated document count ignores the
+    # pipeline, so only a bare, ungrouped view can use it. stages (filters,
+    # selection) or a single slice need a real `Count`; group-statistics mode
+    # is filled in by `aggregate_resolver` from one combined group pass.
+    grouped_root = not path and view._root_dataset.media_type == fom.GROUP
+    use_estimate = not path and not grouped_root and not view._stages
+    combined_root = grouped_root and mixed
+    exact_root = not path and not use_estimate and not combined_root
     aggregations: t.List[foa.Aggregation] = []
-    if path:
+    if path or exact_root:
         aggregations.append(
             foa.Count(
-                path,
+                path if path else None,
                 _optimize=query_performance,
                 _hint=hint if query_performance else None,
             )
@@ -277,10 +309,14 @@ def _resolve_path_aggregation(
             aggregations.append(foa.CountValues(path, _first=LIST_LIMIT))
 
     data = {"path": path}
-    if not path:
+    if use_estimate:
         est = view._root_dataset._sample_collection.estimated_document_count()
         data["count"] = est
         data["exists"] = est
+    elif combined_root:
+        # placeholder; aggregate_resolver overwrites with the combined counts
+        data["count"] = 0
+        data["exists"] = 0
 
     def from_results(results):
         for aggregation, result in zip(aggregations, results):

--- a/fiftyone/server/metadata.py
+++ b/fiftyone/server/metadata.py
@@ -120,8 +120,13 @@ async def get_metadata(
                 )
 
     if filepath not in metadata_cache and skip_dimensions:
-        # caller opted out of dimensions; use a placeholder aspect ratio
-        metadata_cache[filepath] = dict(aspect_ratio=1.0)
+        # caller opted out of dimensions; use a placeholder aspect ratio (plus a
+        # frame_rate placeholder for video, matching the fallback path)
+        metadata_cache[filepath] = (
+            dict(aspect_ratio=1.0, frame_rate=30)
+            if is_video
+            else dict(aspect_ratio=1.0)
+        )
 
     if filepath not in metadata_cache:
         try:

--- a/fiftyone/server/metadata.py
+++ b/fiftyone/server/metadata.py
@@ -60,6 +60,7 @@ async def get_metadata(
     url_cache: t.Dict[str, str],
     *,
     additional_media_fields: t.Optional[t.Tuple] = None,
+    skip_dimensions: bool = False,
 ):
     """Gets the metadata for the given local media file.
 
@@ -77,11 +78,11 @@ async def get_metadata(
     filepath = sample["filepath"]
     metadata = sample.get("metadata", None)
 
-    (
-        opm_field,
-        detections_fields,
-        additional_fields,
-    ) = additional_media_fields if additional_media_fields is not None else _get_additional_media_fields(collection)
+    (opm_field, detections_fields, additional_fields,) = (
+        additional_media_fields
+        if additional_media_fields is not None
+        else _get_additional_media_fields(collection)
+    )
 
     filepath_result, filepath_source, urls = _create_media_urls(
         collection,
@@ -117,6 +118,10 @@ async def get_metadata(
                 metadata_cache[filepath] = dict(
                     aspect_ratio=width / height,
                 )
+
+    if filepath not in metadata_cache and skip_dimensions:
+        # caller opted out of dimensions; use a placeholder aspect ratio
+        metadata_cache[filepath] = dict(aspect_ratio=1.0)
 
     if filepath not in metadata_cache:
         try:

--- a/fiftyone/server/query.py
+++ b/fiftyone/server/query.py
@@ -455,6 +455,7 @@ class Query(fosa.AggregateQuery):
         hint: t.Optional[str] = None,
         max_query_time: t.Optional[int] = None,
         dynamic_group: t.Optional[BSON] = None,
+        skip_metadata: t.Optional[bool] = False,
     ) -> t.Annotated[
         t.Union[Connection[SampleItem, str], QueryTimeout],
         gql.union("PaginateSamplesResponse"),
@@ -474,6 +475,7 @@ class Query(fosa.AggregateQuery):
                 hint=hint,
                 max_query_time=max_query_time,
                 dynamic_group=dynamic_group,
+                skip_metadata=skip_metadata,
             )
         except ExecutionTimeout:
             return QueryTimeout(query_time=max_query_time)

--- a/fiftyone/server/routes/__init__.py
+++ b/fiftyone/server/routes/__init__.py
@@ -26,6 +26,7 @@ from .ontology import OntologyAttributes, OntologyTaxonomy, Ontologies
 from .plugins import Plugins
 from .runtime_assets import RuntimeAssetRoutes
 from .sample import SampleRoutes
+from .samples import SamplesRoutes
 from .screenshot import Screenshot
 from .sort import Sort
 from .tag import Tag
@@ -46,6 +47,7 @@ routes = (
     + multimodal_routes
     + OperatorRoutes
     + RuntimeAssetRoutes
+    + SamplesRoutes
     + SampleRoutes
     + [
         ("/aggregate", Aggregate),

--- a/fiftyone/server/routes/frames.py
+++ b/fiftyone/server/routes/frames.py
@@ -47,7 +47,10 @@ def _heavy_frame_paths(schema, prefix=""):
             continue
 
         nested = field
-        while isinstance(nested, (fof.ListField, fof.DictField)):
+        while isinstance(
+            nested,
+            (fof.ListField, fof.DictField, fof.EmbeddedDocumentListField),
+        ):
             nested = nested.field
 
         if isinstance(nested, fof.EmbeddedDocumentField):

--- a/fiftyone/server/routes/frames.py
+++ b/fiftyone/server/routes/frames.py
@@ -6,18 +6,67 @@ FiftyOne Server /frames route
 |
 """
 
+import logging
+
+from bson import ObjectId
 from starlette.endpoints import HTTPEndpoint
 from starlette.responses import JSONResponse
 from starlette.requests import Request
 
 from fiftyone.core.expressions import ViewField as F
+import fiftyone.core.fields as fof
 import fiftyone.core.json as foj
+import fiftyone.core.media as fom
 import fiftyone.core.odm as foo
 from fiftyone.core.utils import run_sync_task
 import fiftyone.core.view as fov
 
 from fiftyone.server.decorators import route
 import fiftyone.server.view as fosv
+
+logger = logging.getLogger(__name__)
+
+
+_ALWAYS_FRAME = ("_id", "_sample_id", "frame_number", "filepath")
+
+
+def _heavy_frame_paths(schema, prefix=""):
+    # Collect paths to dicts, vectors, and per-label `logits` fields to exclude
+    # from the projection since they aren't exposed in the app anyways. Descends
+    # into label embedded docs to reach nested logits, but stops at any excluded
+    # field so the $project exclusions can't overlap.
+    paths = []
+    for name, field in schema.items():
+        path = f"{prefix}.{name}" if prefix else name
+
+        if (
+            isinstance(field, (fof.DictField, fof.VectorField))
+            or name == "logits"
+        ):
+            paths.append(path)
+            continue
+
+        nested = field
+        while isinstance(nested, (fof.ListField, fof.DictField)):
+            nested = nested.field
+
+        if isinstance(nested, fof.EmbeddedDocumentField):
+            paths.extend(_heavy_frame_paths(nested.get_field_schema(), path))
+
+    return paths
+
+
+def _frame_projection(fields, exclude, view):
+    """Mongo projection from the client's ``fields``/``exclude``, else heavy-field exclusion."""
+    if fields:
+        return {
+            **{p: True for p in fields},
+            **{p: True for p in _ALWAYS_FRAME},
+        }
+    if exclude:
+        return {p: False for p in exclude if p not in _ALWAYS_FRAME}
+    heavy = _heavy_frame_paths(view.get_frame_field_schema())
+    return {p: 0 for p in heavy} if heavy else None
 
 
 class Frames(HTTPEndpoint):
@@ -32,10 +81,19 @@ class Frames(HTTPEndpoint):
         sample_id = data.get("sampleId")
 
         view = await fosv.get_view(
-            dataset, stages=stages, extended_stages=extended, awaitable=True
+            dataset,
+            stages=stages,
+            extended_stages=extended,
+            awaitable=True,
         )
         end_frame = min(num_frames + start_frame, frame_count)
         support = None if stages else [start_frame, end_frame]
+
+        logger.info(
+            "[fetch] video-frames sample=%s range=%s",
+            sample_id,
+            [start_frame, end_frame],
+        )
 
         def run(view):
             view = fov.make_optimized_select_view(
@@ -55,10 +113,59 @@ class Frames(HTTPEndpoint):
 
         view = await run_sync_task(run, view)
 
-        frames = await foo.aggregate(
-            foo.get_async_db_conn()[view._dataset._sample_collection_name],
-            view._pipeline(frames_only=True, support=support),
-        ).to_list(end_frame - start_frame + 1)
+        projection = _frame_projection(
+            data.get("fields"), data.get("exclude"), view
+        )
+        _dataset = view._dataset
+        limit = end_frame - start_frame + 1
+
+        if (
+            support is not None
+            and sample_id is not None
+            and _dataset.media_type == fom.VIDEO
+            and not view._is_clips
+        ):
+            # Plain video, no view stages: query frames directly.
+            frame_coll = foo.get_async_db_conn()[
+                _dataset._frame_collection_name
+            ]
+            frames = (
+                await frame_coll.find(
+                    {
+                        "_sample_id": ObjectId(sample_id),
+                        "frame_number": {
+                            "$gte": support[0],
+                            "$lte": support[1],
+                        },
+                    },
+                    projection,
+                )
+                .sort("frame_number", 1)
+                .to_list(limit)
+            )
+        else:
+            pipeline = view._pipeline(frames_only=True, support=support)
+            if projection is not None:
+                # Exclude inside the `$lookup` so heavy fields aren't joined.
+                project = {"$project": projection}
+                lookup = next(
+                    (
+                        stage
+                        for stage in pipeline
+                        if "$lookup" in stage
+                        and stage["$lookup"].get("as") == "frames"
+                    ),
+                    None,
+                )
+                if lookup is not None:
+                    lookup["$lookup"]["pipeline"].append(project)
+                else:
+                    pipeline.append(project)
+
+            frames = await foo.aggregate(
+                foo.get_async_db_conn()[_dataset._sample_collection_name],
+                pipeline,
+            ).to_list(limit)
 
         return JSONResponse(
             {

--- a/fiftyone/server/routes/samples.py
+++ b/fiftyone/server/routes/samples.py
@@ -91,15 +91,6 @@ def _sample_filter(
     )
 
 
-async def _resolve_dataset_name(dataset_id: str) -> Optional[str]:
-    """Resolve a dataset id to its name, or ``None`` if it does not exist."""
-    db = foo.get_async_db_conn()
-    ds = await db["datasets"].find_one(
-        {"_id": ObjectId(dataset_id)}, {"name": 1}
-    )
-    return ds["name"] if ds is not None else None
-
-
 async def _build_item(
     view, doc, metadata_cache, url_cache, additional, skip_dimensions
 ):
@@ -134,12 +125,6 @@ class Samples(HTTPEndpoint):
     @decorators.route
     async def post(self, request: Request, data: dict) -> JSONResponse:
         dataset_id = request.path_params["dataset_id"]
-        dataset_name = await _resolve_dataset_name(dataset_id)
-        if dataset_name is None:
-            return JSONResponse(
-                {"error": "dataset not found"}, status_code=404
-            )
-
         ids = data.get("ids")
         after = data.get("after")
         count = int(data.get("count") or 0)
@@ -147,8 +132,13 @@ class Samples(HTTPEndpoint):
         dynamic_group = data.get("dynamicGroup")
 
         def _build():
+            dataset = foo.database.load_dataset(id=dataset_id)
+            if not dataset:
+                return JSONResponse(
+                    {"error": "dataset not found"}, status_code=404
+                )
             view = fosv.get_view(
-                dataset_name,
+                dataset,
                 stages=data.get("view") or [],
                 filters=data.get("filters"),
                 pagination_data=False,
@@ -211,11 +201,6 @@ class GridSamples(HTTPEndpoint):
     @decorators.route
     async def post(self, request: Request, data: dict) -> JSONResponse:
         dataset_id = request.path_params["dataset_id"]
-        dataset_name = await _resolve_dataset_name(dataset_id)
-        if dataset_name is None:
-            return JSONResponse(
-                {"error": "dataset not found"}, status_code=404
-            )
 
         after = int(data.get("after") or 0)
         sample_filter = _sample_filter(data.get("filter"))
@@ -223,8 +208,13 @@ class GridSamples(HTTPEndpoint):
         def _build():
             # pagination_data=False: only ids are needed; the final $project
             # strips back to _id anyway
+            dataset = foo.database.load_dataset(id=dataset_id)
+            if not dataset:
+                return JSONResponse(
+                    {"error": "dataset not found"}, status_code=404
+                )
             view = fosv.get_view(
-                dataset_name,
+                dataset,
                 stages=data.get("view") or [],
                 filters=data.get("filters"),
                 pagination_data=False,

--- a/fiftyone/server/routes/samples.py
+++ b/fiftyone/server/routes/samples.py
@@ -158,6 +158,9 @@ class Samples(HTTPEndpoint):
             return view
 
         view = await run_sync_task(_build)
+        if isinstance(view, JSONResponse):
+            # return early with 404 if the dataset doesn't exist
+            return view
         pipeline = await get_samples_pipeline(view, sample_filter)
 
         skip_dimensions = bool(data.get("skipMetadata"))
@@ -225,6 +228,9 @@ class GridSamples(HTTPEndpoint):
             return view.skip(after).limit(SPINE_PAGE + 1)
 
         view = await run_sync_task(_build)
+        if isinstance(view, JSONResponse):
+            # return early with 404 if the dataset doesn't exist
+            return view
         # GroupBy emits `_group_count` only when asked; turn it on so the spine
         # carries each group's length to the imavid timeline. `_index_optimized`
         # presorts the group key so the counting `$group` rides an index

--- a/fiftyone/server/routes/samples.py
+++ b/fiftyone/server/routes/samples.py
@@ -186,8 +186,13 @@ class Samples(HTTPEndpoint):
         view = await run_sync_task(_build)
         pipeline = await get_samples_pipeline(view, sample_filter)
 
-        # group-by/order-by db keys the client no longer knows to request
+        skip_dimensions = bool(data.get("skipMetadata"))
+
+        # group-by/order-by db keys the client no longer knows to request, plus
+        # `metadata` so the aspect ratio comes from stored dims, not a disk read
         extra = [db_field(view, p) for p in paths]
+        if not skip_dimensions:
+            extra = extra + ["metadata"]
         projection = _projection(
             data.get("fields"), data.get("exclude"), extra
         )
@@ -214,7 +219,6 @@ class Samples(HTTPEndpoint):
         )
 
         additional = fosm._get_additional_media_fields(view) if docs else None
-        skip_dimensions = bool(data.get("skipMetadata"))
         metadata_cache: Dict[str, Any] = {}
         url_cache: Dict[str, str] = {}
         samples = await asyncio.gather(

--- a/fiftyone/server/routes/samples.py
+++ b/fiftyone/server/routes/samples.py
@@ -32,10 +32,9 @@ from fiftyone.server import decorators
 from fiftyone.server.filters import GroupElementFilter, SampleFilter
 import fiftyone.server.metadata as fosm
 from fiftyone.server.samples import (
-    assemble_group,
-    assemble_group_counts,
     db_field,
     get_samples_pipeline,
+    group_field_stage,
     group_paths,
     strip_group_by,
 )
@@ -199,23 +198,15 @@ class Samples(HTTPEndpoint):
         if projection is not None:
             pipeline.append(projection)
 
+        # label `_group` from GroupBy's expression in Mongo so the frontend never
+        # decodes db keys; the by-id/offset `$match` above still drives the index
+        group_stage = group_field_stage(view, group_fields, order_by)
+        if group_stage is not None:
+            pipeline.append(group_stage)
+
         coll = foo.get_async_db_conn()[view._dataset._sample_collection_name]
         docs = await foo.aggregate(coll, pipeline, data.get("hint")).to_list(
             count or None
-        )
-
-        # rebuild `_group` server-side so the frontend never decodes db keys, and
-        # attach each group's frame count so the modal timeline opens at the right length
-        assemble_group(view, docs, group_fields)
-        await assemble_group_counts(
-            dataset_name,
-            degrouped,
-            data.get("filters"),
-            data.get("sortBy"),
-            data.get("desc"),
-            sample_filter,
-            docs,
-            group_fields,
         )
 
         additional = fosm._get_additional_media_fields(view) if docs else None

--- a/fiftyone/server/routes/samples.py
+++ b/fiftyone/server/routes/samples.py
@@ -26,23 +26,19 @@ import fiftyone.core.json as foj
 import fiftyone.core.media as fom
 import fiftyone.core.odm as foo
 import fiftyone.core.stages as fos
+import fiftyone.core.view as fov
 from fiftyone.core.utils import run_sync_task
 
 from fiftyone.server import decorators
 from fiftyone.server.filters import GroupElementFilter, SampleFilter
 import fiftyone.server.metadata as fosm
-from fiftyone.server.samples import (
-    db_field,
-    get_samples_pipeline,
-    group_field_stage,
-    group_paths,
-    strip_group_by,
-)
+from fiftyone.server.samples import get_samples_pipeline
 from fiftyone.server.utils.json.encoder import JSONResponse
 import fiftyone.server.view as fosv
 
 # identifiers the response always needs (media-type dispatch + signing + cache key)
-_ALWAYS = ("_id", "filepath", "_media_type")
+# plus `_group`/`_group_count`, which the GroupBy stage emits for grouped reads
+_ALWAYS = ("_id", "filepath", "_media_type", "_group", "_group_count")
 
 # max ids returned per spine fetch; larger views page by ``after``
 SPINE_PAGE = 5000
@@ -55,8 +51,8 @@ def _projection(
 ) -> Optional[Dict[str, Any]]:
     """A Mongo ``$project`` from the requested include/exclude field list.
 
-    ``extra`` paths (group-by/order-by db keys) are always included so the
-    server can rebuild ``_group`` even though the client didn't ask for them.
+    ``extra`` paths (e.g. ``metadata`` for aspect ratio) are always kept even
+    when the client didn't request them.
     """
     if fields:
         project = {path: True for path in fields}
@@ -150,23 +146,10 @@ class Samples(HTTPEndpoint):
         sample_filter = _sample_filter(data.get("filter"))
         dynamic_group = data.get("dynamicGroup")
 
-        # the poster read uses the de-grouped stages so its by-id/offset `$match`
-        # stays index-eligible; the single-group frame read keeps the GroupBy
-        # stage so `get_view` can select that group's frames
-        degrouped, group_fields, order_by = strip_group_by(
-            data.get("view") or []
-        )
-        stages = (
-            (data.get("view") or [])
-            if dynamic_group is not None
-            else degrouped
-        )
-        paths = group_paths(group_fields, order_by)
-
         def _build():
             view = fosv.get_view(
                 dataset_name,
-                stages=stages,
+                stages=data.get("view") or [],
                 filters=data.get("filters"),
                 pagination_data=False,
                 sort_by=data.get("sortBy"),
@@ -175,7 +158,9 @@ class Samples(HTTPEndpoint):
                 dynamic_group=dynamic_group,
             )
             if ids:
-                view = view.select(ids)
+                # core's optimized select drops any GroupBy `$group` for an
+                # index-eligible by-id `$match` and labels `_group` itself
+                view = fov.make_optimized_select_view(view, ids)
             elif after is not None:
                 view = view.skip(int(after))
             if count:
@@ -187,22 +172,13 @@ class Samples(HTTPEndpoint):
 
         skip_dimensions = bool(data.get("skipMetadata"))
 
-        # group-by/order-by db keys the client no longer knows to request, plus
-        # `metadata` so the aspect ratio comes from stored dims, not a disk read
-        extra = [db_field(view, p) for p in paths]
-        if not skip_dimensions:
-            extra = extra + ["metadata"]
+        # keep `metadata` so the aspect ratio comes from stored dims, not a disk read
+        extra = None if skip_dimensions else ["metadata"]
         projection = _projection(
             data.get("fields"), data.get("exclude"), extra
         )
         if projection is not None:
             pipeline.append(projection)
-
-        # label `_group` from GroupBy's expression in Mongo so the frontend never
-        # decodes db keys; the by-id/offset `$match` above still drives the index
-        group_stage = group_field_stage(view, group_fields, order_by)
-        if group_stage is not None:
-            pipeline.append(group_stage)
 
         coll = foo.get_async_db_conn()[view._dataset._sample_collection_name]
         docs = await foo.aggregate(coll, pipeline, data.get("hint")).to_list(

--- a/fiftyone/server/routes/samples.py
+++ b/fiftyone/server/routes/samples.py
@@ -1,0 +1,297 @@
+"""
+Samples routes for field-projected and id-only paginated reads.
+
+Two endpoints share one paginated pipeline builder (``get_view`` +
+``get_samples_pipeline``), differing only in projection and windowing:
+
+``POST /dataset/{id}/samples`` returns a per-id field slice + signed media urls,
+projected from the requested ``fields`` (inclusion) or ``exclude`` (exclusion).
+
+``POST /dataset/{id}/grid/samples`` returns an ordered window of ids only (final
+``$project`` keeps just ``_id``), windowed by ``after``.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import asyncio
+from typing import Any, Dict, List, Optional
+
+from bson import ObjectId
+from starlette.endpoints import HTTPEndpoint
+from starlette.requests import Request
+
+import fiftyone.core.json as foj
+import fiftyone.core.media as fom
+import fiftyone.core.odm as foo
+import fiftyone.core.stages as fos
+from fiftyone.core.utils import run_sync_task
+
+from fiftyone.server import decorators
+from fiftyone.server.filters import GroupElementFilter, SampleFilter
+import fiftyone.server.metadata as fosm
+from fiftyone.server.samples import (
+    assemble_group,
+    assemble_group_counts,
+    db_field,
+    get_samples_pipeline,
+    group_paths,
+    strip_group_by,
+)
+from fiftyone.server.utils.json.encoder import JSONResponse
+import fiftyone.server.view as fosv
+
+# identifiers the response always needs (media-type dispatch + signing + cache key)
+_ALWAYS = ("_id", "filepath", "_media_type")
+
+# max ids returned per spine fetch; larger views page by ``after``
+SPINE_PAGE = 5000
+
+
+def _projection(
+    fields: Optional[List[str]],
+    exclude: Optional[List[str]],
+    extra: Optional[List[str]] = None,
+) -> Optional[Dict[str, Any]]:
+    """A Mongo ``$project`` from the requested include/exclude field list.
+
+    ``extra`` paths (group-by/order-by db keys) are always included so the
+    server can rebuild ``_group`` even though the client didn't ask for them.
+    """
+    if fields:
+        project = {path: True for path in fields}
+        for path in _ALWAYS:
+            project[path] = True
+        for path in extra or []:
+            project[path] = True
+        return {"$project": project}
+    if exclude:
+        # exclusion never drops the identifiers the response is built from
+        keep = set(_ALWAYS) | set(extra or [])
+        return {
+            "$project": {path: False for path in exclude if path not in keep}
+        }
+    return None
+
+
+def _sample_filter(
+    filter_arg: Optional[Dict[str, Any]]
+) -> Optional[SampleFilter]:
+    """Build a ``SampleFilter`` (group slice) from the ``filter`` param."""
+    if not filter_arg:
+        return None
+    group = filter_arg.get("group")
+    return SampleFilter(
+        id=filter_arg.get("id"),
+        group=(
+            GroupElementFilter(
+                id=group.get("id"),
+                slice=group.get("slice"),
+                slices=group.get("slices"),
+            )
+            if group
+            else None
+        ),
+    )
+
+
+async def _resolve_dataset_name(dataset_id: str) -> Optional[str]:
+    """Resolve a dataset id to its name, or ``None`` if it does not exist."""
+    db = foo.get_async_db_conn()
+    ds = await db["datasets"].find_one(
+        {"_id": ObjectId(dataset_id)}, {"name": 1}
+    )
+    return ds["name"] if ds is not None else None
+
+
+async def _build_item(
+    view, doc, metadata_cache, url_cache, additional, skip_dimensions
+):
+    """Assemble one response item: signed urls + aspect ratio + the projected doc."""
+    media_type = fom.get_media_type(doc["filepath"])
+    metadata = await fosm.get_metadata(
+        view,
+        doc,
+        media_type,
+        metadata_cache,
+        url_cache,
+        additional_media_fields=additional,
+        skip_dimensions=skip_dimensions,
+    )
+
+    item = {
+        "id": str(doc["_id"]),
+        "urls": metadata.get("urls"),
+        "fields": foj.stringify(doc),
+    }
+
+    # aspect ratio is omitted when dimensions are skipped (no placeholder)
+    if not skip_dimensions:
+        item["aspectRatio"] = metadata.get("aspect_ratio")
+
+    return item
+
+
+class Samples(HTTPEndpoint):
+    """Field-projecting paginated samples reader."""
+
+    @decorators.route
+    async def post(self, request: Request, data: dict) -> JSONResponse:
+        dataset_id = request.path_params["dataset_id"]
+        dataset_name = await _resolve_dataset_name(dataset_id)
+        if dataset_name is None:
+            return JSONResponse(
+                {"error": "dataset not found"}, status_code=404
+            )
+
+        ids = data.get("ids")
+        after = data.get("after")
+        count = int(data.get("count") or 0)
+        sample_filter = _sample_filter(data.get("filter"))
+        dynamic_group = data.get("dynamicGroup")
+
+        # the poster read uses the de-grouped stages so its by-id/offset `$match`
+        # stays index-eligible; the single-group frame read keeps the GroupBy
+        # stage so `get_view` can select that group's frames
+        degrouped, group_fields, order_by = strip_group_by(
+            data.get("view") or []
+        )
+        stages = (
+            (data.get("view") or [])
+            if dynamic_group is not None
+            else degrouped
+        )
+        paths = group_paths(group_fields, order_by)
+
+        def _build():
+            view = fosv.get_view(
+                dataset_name,
+                stages=stages,
+                filters=data.get("filters"),
+                pagination_data=False,
+                sort_by=data.get("sortBy"),
+                desc=bool(data.get("desc")),
+                sample_filter=sample_filter,
+                dynamic_group=dynamic_group,
+            )
+            if ids:
+                view = view.select(ids)
+            elif after is not None:
+                view = view.skip(int(after))
+            if count:
+                view = view.limit(count)
+            return view
+
+        view = await run_sync_task(_build)
+        pipeline = await get_samples_pipeline(view, sample_filter)
+
+        # group-by/order-by db keys the client no longer knows to request
+        extra = [db_field(view, p) for p in paths]
+        projection = _projection(
+            data.get("fields"), data.get("exclude"), extra
+        )
+        if projection is not None:
+            pipeline.append(projection)
+
+        coll = foo.get_async_db_conn()[view._dataset._sample_collection_name]
+        docs = await foo.aggregate(coll, pipeline, data.get("hint")).to_list(
+            count or None
+        )
+
+        # rebuild `_group` server-side so the frontend never decodes db keys, and
+        # attach each group's frame count so the modal timeline opens at the right length
+        assemble_group(view, docs, group_fields)
+        await assemble_group_counts(
+            dataset_name,
+            degrouped,
+            data.get("filters"),
+            data.get("sortBy"),
+            data.get("desc"),
+            sample_filter,
+            docs,
+            group_fields,
+        )
+
+        additional = fosm._get_additional_media_fields(view) if docs else None
+        skip_dimensions = bool(data.get("skipMetadata"))
+        metadata_cache: Dict[str, Any] = {}
+        url_cache: Dict[str, str] = {}
+        samples = await asyncio.gather(
+            *[
+                _build_item(
+                    view,
+                    doc,
+                    metadata_cache,
+                    url_cache,
+                    additional,
+                    skip_dimensions,
+                )
+                for doc in docs
+            ]
+        )
+
+        return JSONResponse({"samples": samples})
+
+
+class GridSamples(HTTPEndpoint):
+    """Ordered id-only paginated reader."""
+
+    @decorators.route
+    async def post(self, request: Request, data: dict) -> JSONResponse:
+        dataset_id = request.path_params["dataset_id"]
+        dataset_name = await _resolve_dataset_name(dataset_id)
+        if dataset_name is None:
+            return JSONResponse(
+                {"error": "dataset not found"}, status_code=404
+            )
+
+        after = int(data.get("after") or 0)
+        sample_filter = _sample_filter(data.get("filter"))
+
+        def _build():
+            # pagination_data=False: only ids are needed; the final $project
+            # strips back to _id anyway
+            view = fosv.get_view(
+                dataset_name,
+                stages=data.get("view") or [],
+                filters=data.get("filters"),
+                pagination_data=False,
+                sort_by=data.get("sortBy"),
+                desc=bool(data.get("desc")),
+                sample_filter=sample_filter,
+            )
+            return view.skip(after).limit(SPINE_PAGE + 1)
+
+        view = await run_sync_task(_build)
+        # GroupBy emits `_group_count` only when asked; turn it on so the spine
+        # carries each group's length to the imavid timeline
+        for stage in getattr(view, "_stages", []):
+            if isinstance(stage, fos.GroupBy):
+                stage._include_count = True
+        pipeline = await get_samples_pipeline(view, sample_filter)
+        # keep `_group_count` alongside the id projection
+        pipeline.append({"$project": {"_id": 1, "_group_count": 1}})
+        coll = foo.get_async_db_conn()[view._dataset._sample_collection_name]
+        # same index hint paginate_samples uses, so $skip walks index entries
+        docs = await foo.aggregate(coll, pipeline, data.get("hint")).to_list(
+            SPINE_PAGE + 1
+        )
+
+        more = len(docs) > SPINE_PAGE
+        docs = docs[:SPINE_PAGE]
+        spine = [
+            {"id": str(d["_id"]), "groupCount": d["_group_count"]}
+            if "_group_count" in d
+            else {"id": str(d["_id"])}
+            for d in docs
+        ]
+        return JSONResponse(
+            {"spine": spine, "next": after + SPINE_PAGE if more else None}
+        )
+
+
+SamplesRoutes = [
+    ("/dataset/{dataset_id}/samples", Samples),
+    ("/dataset/{dataset_id}/grid/samples", GridSamples),
+]

--- a/fiftyone/server/routes/samples.py
+++ b/fiftyone/server/routes/samples.py
@@ -226,10 +226,12 @@ class GridSamples(HTTPEndpoint):
 
         view = await run_sync_task(_build)
         # GroupBy emits `_group_count` only when asked; turn it on so the spine
-        # carries each group's length to the imavid timeline
+        # carries each group's length to the imavid timeline. `_index_optimized`
+        # presorts the group key so the counting `$group` rides an index
         for stage in getattr(view, "_stages", []):
             if isinstance(stage, fos.GroupBy):
                 stage._include_count = True
+                stage._index_optimized = True
         pipeline = await get_samples_pipeline(view, sample_filter)
         # keep `_group_count` alongside the id projection
         pipeline.append({"$project": {"_id": 1, "_group_count": 1}})

--- a/fiftyone/server/routes/samples.py
+++ b/fiftyone/server/routes/samples.py
@@ -18,7 +18,6 @@ projected from the requested ``fields`` (inclusion) or ``exclude`` (exclusion).
 import asyncio
 from typing import Any, Dict, List, Optional
 
-from bson import ObjectId
 from starlette.endpoints import HTTPEndpoint
 from starlette.requests import Request
 
@@ -91,6 +90,37 @@ def _sample_filter(
     )
 
 
+async def _resolve_view(
+    dataset_id: str,
+    data: Dict[str, Any],
+    sample_filter: Optional[SampleFilter],
+    dynamic_group: Optional[Any] = None,
+) -> Optional[fov.DatasetView]:
+    """Load the dataset by id and build the base paginated view, in a sync task.
+
+    Returns the view, or ``None`` if the dataset doesn't exist.
+    """
+
+    def _run():
+        try:
+            dataset = foo.database.load_dataset(id=dataset_id)
+        except ValueError:
+            # unknown dataset id raises rather than returning None
+            return None
+        return fosv.get_view(
+            dataset,
+            stages=data.get("view") or [],
+            filters=data.get("filters"),
+            pagination_data=False,
+            sort_by=data.get("sortBy"),
+            desc=bool(data.get("desc")),
+            sample_filter=sample_filter,
+            dynamic_group=dynamic_group,
+        )
+
+    return await run_sync_task(_run)
+
+
 async def _build_item(
     view, doc, metadata_cache, url_cache, additional, skip_dimensions
 ):
@@ -129,38 +159,24 @@ class Samples(HTTPEndpoint):
         after = data.get("after")
         count = int(data.get("count") or 0)
         sample_filter = _sample_filter(data.get("filter"))
-        dynamic_group = data.get("dynamicGroup")
 
-        def _build():
-            dataset = foo.database.load_dataset(id=dataset_id)
-            if not dataset:
-                return JSONResponse(
-                    {"error": "dataset not found"}, status_code=404
-                )
-            view = fosv.get_view(
-                dataset,
-                stages=data.get("view") or [],
-                filters=data.get("filters"),
-                pagination_data=False,
-                sort_by=data.get("sortBy"),
-                desc=bool(data.get("desc")),
-                sample_filter=sample_filter,
-                dynamic_group=dynamic_group,
+        view = await _resolve_view(
+            dataset_id, data, sample_filter, data.get("dynamicGroup")
+        )
+        if view is None:
+            return JSONResponse(
+                {"error": "dataset not found"}, status_code=404
             )
-            if ids:
-                # core's optimized select drops any GroupBy `$group` for an
-                # index-eligible by-id `$match` and labels `_group` itself
-                view = fov.make_optimized_select_view(view, ids)
-            elif after is not None:
-                view = view.skip(int(after))
-            if count:
-                view = view.limit(count)
-            return view
 
-        view = await run_sync_task(_build)
-        if isinstance(view, JSONResponse):
-            # return early with 404 if the dataset doesn't exist
-            return view
+        if ids:
+            # core's optimized select drops any GroupBy `$group` for an
+            # index-eligible by-id `$match` and labels `_group` itself
+            view = fov.make_optimized_select_view(view, ids)
+        elif after is not None:
+            view = view.skip(int(after))
+        if count:
+            view = view.limit(count)
+
         pipeline = await get_samples_pipeline(view, sample_filter)
 
         skip_dimensions = bool(data.get("skipMetadata"))
@@ -204,41 +220,29 @@ class GridSamples(HTTPEndpoint):
     @decorators.route
     async def post(self, request: Request, data: dict) -> JSONResponse:
         dataset_id = request.path_params["dataset_id"]
-
         after = int(data.get("after") or 0)
         sample_filter = _sample_filter(data.get("filter"))
 
-        def _build():
-            # pagination_data=False: only ids are needed; the final $project
-            # strips back to _id anyway
-            dataset = foo.database.load_dataset(id=dataset_id)
-            if not dataset:
-                return JSONResponse(
-                    {"error": "dataset not found"}, status_code=404
-                )
-            view = fosv.get_view(
-                dataset,
-                stages=data.get("view") or [],
-                filters=data.get("filters"),
-                pagination_data=False,
-                sort_by=data.get("sortBy"),
-                desc=bool(data.get("desc")),
-                sample_filter=sample_filter,
+        # pagination_data=False: only ids are needed; the final $project below
+        # strips back to _id anyway
+        view = await _resolve_view(dataset_id, data, sample_filter)
+        if view is None:
+            return JSONResponse(
+                {"error": "dataset not found"}, status_code=404
             )
-            return view.skip(after).limit(SPINE_PAGE + 1)
 
-        view = await run_sync_task(_build)
-        if isinstance(view, JSONResponse):
-            # return early with 404 if the dataset doesn't exist
-            return view
+        view = view.skip(after).limit(SPINE_PAGE + 1)
+
         # GroupBy emits `_group_count` only when asked; turn it on so the spine
         # carries each group's length to the imavid timeline
         for stage in getattr(view, "_stages", []):
             if isinstance(stage, fos.GroupBy):
                 stage._include_count = True
+
         pipeline = await get_samples_pipeline(view, sample_filter)
         # keep `_group_count` alongside the id projection
         pipeline.append({"$project": {"_id": 1, "_group_count": 1}})
+
         coll = foo.get_async_db_conn()[view._dataset._sample_collection_name]
         # same index hint paginate_samples uses, so $skip walks index entries
         docs = await foo.aggregate(coll, pipeline, data.get("hint")).to_list(

--- a/fiftyone/server/routes/samples.py
+++ b/fiftyone/server/routes/samples.py
@@ -232,12 +232,10 @@ class GridSamples(HTTPEndpoint):
             # return early with 404 if the dataset doesn't exist
             return view
         # GroupBy emits `_group_count` only when asked; turn it on so the spine
-        # carries each group's length to the imavid timeline. `_index_optimized`
-        # presorts the group key so the counting `$group` rides an index
+        # carries each group's length to the imavid timeline
         for stage in getattr(view, "_stages", []):
             if isinstance(stage, fos.GroupBy):
                 stage._include_count = True
-                stage._index_optimized = True
         pipeline = await get_samples_pipeline(view, sample_filter)
         # keep `_group_count` alongside the id projection
         pipeline.append({"$project": {"_id": 1, "_group_count": 1}})

--- a/fiftyone/server/samples.py
+++ b/fiftyone/server/samples.py
@@ -125,13 +125,11 @@ async def paginate_samples(
     if int(after) > -1:
         view = view.skip(int(after) + 1)
 
-    # emit per-group counts only for the top-level paginated grouped read;
-    # `_index_optimized` presorts the group key so the count rides an index
+    # emit per-group counts only for the top-level paginated grouped read
     if dynamic_group is None and pagination_data:
         for stage in getattr(view, "_stages", []):
             if isinstance(stage, fos.GroupBy):
                 stage._include_count = True
-                stage._index_optimized = True
 
     pipeline = await get_samples_pipeline(view, sample_filter)
 

--- a/fiftyone/server/samples.py
+++ b/fiftyone/server/samples.py
@@ -74,76 +74,18 @@ def db_field(view, path):
     return (field.db_field or path) if field is not None else path
 
 
-def assemble_group(view, docs, group_fields):
-    """Set ``doc['_group']`` from the group-by field value(s): a scalar for a
-    single field, a list for multiple. Idempotent and a no-op for flat views."""
-    if not group_fields or not docs:
-        return
+def group_field_stage(view, group_fields, order_by=None):
+    """The GroupBy ``$addFields`` that labels each doc with its dynamic-group
+    value (``_group``), computed in Mongo from the group expression. Index
+    eligible (no ``$group``) so it rides on a by-id/offset read; ``None`` for
+    flat views. ``_group_count`` is emitted by the stage's ``_include_count``
+    plumbing on the grouped spine, never re-derived here."""
+    if not group_fields:
+        return None
 
-    is_list = isinstance(group_fields, (list, tuple))
-    fields = list(group_fields) if is_list else [group_fields]
-    db_fields = [db_field(view, f) for f in fields]
-
-    for doc in docs:
-        values = [doc.get(f) for f in db_fields]
-        doc["_group"] = values if is_list else values[0]
-
-
-async def assemble_group_counts(
-    dataset_name,
-    degrouped_stages,
-    filters,
-    sort_by,
-    desc,
-    sample_filter,
-    docs,
-    group_fields,
-):
-    """Set ``doc['_group_count']`` = the number of samples in each group within
-    the view, so the modal timeline opens at the right length. Skips docs that
-    already carry a count (grouped reads emit it) and the multi-field case.
-    """
-    if not group_fields or isinstance(group_fields, (list, tuple)) or not docs:
-        return
-
-    pending = [d for d in docs if d.get("_group_count") is None]
-    values = [d.get("_group") for d in pending if d.get("_group") is not None]
-    if not values:
-        return
-
-    # count the whole group: drop any single-sample `id` filter but keep the
-    # group slice, so the base view isn't narrowed to the one fetched sample
-    count_filter = (
-        SampleFilter(group=sample_filter.group)
-        if sample_filter is not None and sample_filter.group
-        else None
+    return fos.GroupBy(group_fields, order_by=order_by)._group_field_stage(
+        view
     )
-
-    def _build_base():
-        return fosv.get_view(
-            dataset_name,
-            stages=degrouped_stages,
-            filters=filters,
-            pagination_data=False,
-            sort_by=sort_by,
-            desc=bool(desc),
-            sample_filter=count_filter,
-        )
-
-    base = await run_sync_task(_build_base)
-    db = db_field(base, group_fields)
-    pipeline = await get_samples_pipeline(base, count_filter)
-    pipeline += [
-        {"$match": {db: {"$in": values}}},
-        {"$group": {"_id": f"${db}", "_n": {"$sum": 1}}},
-    ]
-    coll = foo.get_async_db_conn()[base._dataset._sample_collection_name]
-    counts = {
-        c["_id"]: c["_n"]
-        for c in await foo.aggregate(coll, pipeline).to_list(None)
-    }
-    for doc in pending:
-        doc["_group_count"] = counts.get(doc.get("_group"))
 
 
 @gql.type
@@ -251,6 +193,13 @@ async def paginate_samples(
 
     pipeline = await get_samples_pipeline(view, sample_filter)
 
+    # label `_group` from GroupBy's expression so the modal resolves every
+    # dynamic-group sample on any fetch path; no-op for flat views
+    _, group_fields, order_by = strip_group_by(stages)
+    group_stage = group_field_stage(view, group_fields, order_by)
+    if group_stage is not None:
+        pipeline.append(group_stage)
+
     samples = await foo.aggregate(
         coll,
         pipeline,
@@ -262,22 +211,6 @@ async def paginate_samples(
     if len(samples) > first:
         samples = samples[:first]
         more = True
-
-    # attach group identity + size to every dynamic-group sample so the modal
-    # resolves them on any fetch path; no-op for flat views
-    degrouped, group_fields, _ = strip_group_by(stages)
-    if group_fields and samples:
-        assemble_group(view, samples, group_fields)
-        await assemble_group_counts(
-            dataset,
-            degrouped,
-            filters,
-            sort_by,
-            desc,
-            sample_filter,
-            samples,
-            group_fields,
-        )
 
     metadata_cache = {}
     url_cache = {}

--- a/fiftyone/server/samples.py
+++ b/fiftyone/server/samples.py
@@ -125,11 +125,13 @@ async def paginate_samples(
     if int(after) > -1:
         view = view.skip(int(after) + 1)
 
-    # emit per-group counts only for the top-level paginated grouped read
+    # emit per-group counts only for the top-level paginated grouped read;
+    # `_index_optimized` presorts the group key so the count rides an index
     if dynamic_group is None and pagination_data:
         for stage in getattr(view, "_stages", []):
             if isinstance(stage, fos.GroupBy):
                 stage._include_count = True
+                stage._index_optimized = True
 
     pipeline = await get_samples_pipeline(view, sample_filter)
 

--- a/fiftyone/server/samples.py
+++ b/fiftyone/server/samples.py
@@ -28,66 +28,6 @@ from fiftyone.server.utils import from_dict
 import fiftyone.server.view as fosv
 
 
-# serialized class string for the dynamic-group stage the frontend sends in ``view``
-GROUP_BY_CLS = "fiftyone.core.stages.GroupBy"
-
-
-def strip_group_by(stages):
-    """Pull any ``GroupBy`` stage out of a serialized view.
-
-    Returns ``(kept_stages, field_or_expr, order_by)``. Removing the stage lets a
-    by-id read compile an index-eligible ``$match`` instead of re-grouping the
-    whole collection; the returned fields let the server rebuild ``_group``.
-    """
-    group_fields = None
-    order_by = None
-    kept = []
-    for stage in stages or []:
-        if stage.get("_cls") == GROUP_BY_CLS:
-            kwargs = dict(stage.get("kwargs") or [])
-            group_fields = kwargs.get("field_or_expr")
-            order_by = kwargs.get("order_by")
-            continue
-        kept.append(stage)
-    return kept, group_fields, order_by
-
-
-def group_paths(group_fields, order_by):
-    """Field paths a grouped read must project to rebuild ``_group``."""
-    paths = []
-    if isinstance(group_fields, (list, tuple)):
-        paths.extend(group_fields)
-    elif group_fields:
-        paths.append(group_fields)
-    if order_by:
-        paths.append(order_by)
-    return paths
-
-
-def db_field(view, path):
-    """Resolve a field path to its Mongo storage key (e.g. ``sample_id`` ->
-    ``_sample_id``). This db-key knowledge stays in the backend."""
-    try:
-        field = view.get_field(path)
-    except Exception:  # pragma: no cover - defensive: unknown path
-        return path
-    return (field.db_field or path) if field is not None else path
-
-
-def group_field_stage(view, group_fields, order_by=None):
-    """The GroupBy ``$addFields`` that labels each doc with its dynamic-group
-    value (``_group``), computed in Mongo from the group expression. Index
-    eligible (no ``$group``) so it rides on a by-id/offset read; ``None`` for
-    flat views. ``_group_count`` is emitted by the stage's ``_include_count``
-    plumbing on the grouped spine, never re-derived here."""
-    if not group_fields:
-        return None
-
-    return fos.GroupBy(group_fields, order_by=order_by)._group_field_stage(
-        view
-    )
-
-
 @gql.type
 class MediaURL:
     field: str
@@ -192,13 +132,6 @@ async def paginate_samples(
                 stage._include_count = True
 
     pipeline = await get_samples_pipeline(view, sample_filter)
-
-    # label `_group` from GroupBy's expression so the modal resolves every
-    # dynamic-group sample on any fetch path; no-op for flat views
-    _, group_fields, order_by = strip_group_by(stages)
-    group_stage = group_field_stage(view, group_fields, order_by)
-    if group_stage is not None:
-        pipeline.append(group_stage)
 
     samples = await foo.aggregate(
         coll,

--- a/fiftyone/server/samples.py
+++ b/fiftyone/server/samples.py
@@ -28,6 +28,124 @@ from fiftyone.server.utils import from_dict
 import fiftyone.server.view as fosv
 
 
+# serialized class string for the dynamic-group stage the frontend sends in ``view``
+GROUP_BY_CLS = "fiftyone.core.stages.GroupBy"
+
+
+def strip_group_by(stages):
+    """Pull any ``GroupBy`` stage out of a serialized view.
+
+    Returns ``(kept_stages, field_or_expr, order_by)``. Removing the stage lets a
+    by-id read compile an index-eligible ``$match`` instead of re-grouping the
+    whole collection; the returned fields let the server rebuild ``_group``.
+    """
+    group_fields = None
+    order_by = None
+    kept = []
+    for stage in stages or []:
+        if stage.get("_cls") == GROUP_BY_CLS:
+            kwargs = dict(stage.get("kwargs") or [])
+            group_fields = kwargs.get("field_or_expr")
+            order_by = kwargs.get("order_by")
+            continue
+        kept.append(stage)
+    return kept, group_fields, order_by
+
+
+def group_paths(group_fields, order_by):
+    """Field paths a grouped read must project to rebuild ``_group``."""
+    paths = []
+    if isinstance(group_fields, (list, tuple)):
+        paths.extend(group_fields)
+    elif group_fields:
+        paths.append(group_fields)
+    if order_by:
+        paths.append(order_by)
+    return paths
+
+
+def db_field(view, path):
+    """Resolve a field path to its Mongo storage key (e.g. ``sample_id`` ->
+    ``_sample_id``). This db-key knowledge stays in the backend."""
+    try:
+        field = view.get_field(path)
+    except Exception:  # pragma: no cover - defensive: unknown path
+        return path
+    return (field.db_field or path) if field is not None else path
+
+
+def assemble_group(view, docs, group_fields):
+    """Set ``doc['_group']`` from the group-by field value(s): a scalar for a
+    single field, a list for multiple. Idempotent and a no-op for flat views."""
+    if not group_fields or not docs:
+        return
+
+    is_list = isinstance(group_fields, (list, tuple))
+    fields = list(group_fields) if is_list else [group_fields]
+    db_fields = [db_field(view, f) for f in fields]
+
+    for doc in docs:
+        values = [doc.get(f) for f in db_fields]
+        doc["_group"] = values if is_list else values[0]
+
+
+async def assemble_group_counts(
+    dataset_name,
+    degrouped_stages,
+    filters,
+    sort_by,
+    desc,
+    sample_filter,
+    docs,
+    group_fields,
+):
+    """Set ``doc['_group_count']`` = the number of samples in each group within
+    the view, so the modal timeline opens at the right length. Skips docs that
+    already carry a count (grouped reads emit it) and the multi-field case.
+    """
+    if not group_fields or isinstance(group_fields, (list, tuple)) or not docs:
+        return
+
+    pending = [d for d in docs if d.get("_group_count") is None]
+    values = [d.get("_group") for d in pending if d.get("_group") is not None]
+    if not values:
+        return
+
+    # count the whole group: drop any single-sample `id` filter but keep the
+    # group slice, so the base view isn't narrowed to the one fetched sample
+    count_filter = (
+        SampleFilter(group=sample_filter.group)
+        if sample_filter is not None and sample_filter.group
+        else None
+    )
+
+    def _build_base():
+        return fosv.get_view(
+            dataset_name,
+            stages=degrouped_stages,
+            filters=filters,
+            pagination_data=False,
+            sort_by=sort_by,
+            desc=bool(desc),
+            sample_filter=count_filter,
+        )
+
+    base = await run_sync_task(_build_base)
+    db = db_field(base, group_fields)
+    pipeline = await get_samples_pipeline(base, count_filter)
+    pipeline += [
+        {"$match": {db: {"$in": values}}},
+        {"$group": {"_id": f"${db}", "_n": {"$sum": 1}}},
+    ]
+    coll = foo.get_async_db_conn()[base._dataset._sample_collection_name]
+    counts = {
+        c["_id"]: c["_n"]
+        for c in await foo.aggregate(coll, pipeline).to_list(None)
+    }
+    for doc in pending:
+        doc["_group_count"] = counts.get(doc.get("_group"))
+
+
 @gql.type
 class MediaURL:
     field: str
@@ -101,6 +219,7 @@ async def paginate_samples(
     hint: t.Optional[str] = None,
     dynamic_group: t.Optional[BSON] = None,
     max_query_time: t.Optional[int] = None,
+    skip_metadata: t.Optional[bool] = False,
 ) -> Connection[t.Union[ImageSample, VideoSample], str]:
     run = lambda: fosv.get_view(
         dataset,
@@ -118,13 +237,22 @@ async def paginate_samples(
     if after is None:
         after = "-1"
 
+    maxTimeMS = max_query_time * 1000 if max_query_time else None
+    coll = foo.get_async_db_conn()[view._dataset._sample_collection_name]
+
     if int(after) > -1:
         view = view.skip(int(after) + 1)
 
+    # emit per-group counts only for the top-level paginated grouped read
+    if dynamic_group is None and pagination_data:
+        for stage in getattr(view, "_stages", []):
+            if isinstance(stage, fos.GroupBy):
+                stage._include_count = True
+
     pipeline = await get_samples_pipeline(view, sample_filter)
-    maxTimeMS = max_query_time * 1000 if max_query_time else None
+
     samples = await foo.aggregate(
-        foo.get_async_db_conn()[view._dataset._sample_collection_name],
+        coll,
         pipeline,
         hint,
         maxTimeMS=maxTimeMS,
@@ -134,6 +262,22 @@ async def paginate_samples(
     if len(samples) > first:
         samples = samples[:first]
         more = True
+
+    # attach group identity + size to every dynamic-group sample so the modal
+    # resolves them on any fetch path; no-op for flat views
+    degrouped, group_fields, _ = strip_group_by(stages)
+    if group_fields and samples:
+        assemble_group(view, samples, group_fields)
+        await assemble_group_counts(
+            dataset,
+            degrouped,
+            filters,
+            sort_by,
+            desc,
+            sample_filter,
+            samples,
+            group_fields,
+        )
 
     metadata_cache = {}
     url_cache = {}
@@ -149,6 +293,7 @@ async def paginate_samples(
                 url_cache,
                 pagination_data,
                 additional_media_fields=additional_media_fields,
+                skip_dimensions=skip_metadata,
             )
             for sample in samples
         ]
@@ -182,6 +327,7 @@ async def _create_sample_item(
     pagination_data: bool,
     *,
     additional_media_fields: t.Optional[t.Tuple] = None,
+    skip_dimensions: bool = False,
 ) -> SampleItem:
     media_type = fom.get_media_type(sample["filepath"])
     cls = MEDIA_TYPES[media_type]
@@ -193,6 +339,7 @@ async def _create_sample_item(
         metadata_cache,
         url_cache,
         additional_media_fields=additional_media_fields,
+        skip_dimensions=skip_dimensions,
     )
 
     if cls == VideoSample:

--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -38,6 +38,15 @@ def _make_group_field_stage(view):
     return fosg.Mongo([group_by._group_field_stage(view)])
 
 
+def _include_group_fields(view):
+    # every server read of a grouped view emits `_group` from the stage, even the
+    # plain-pagination path that skips `get_extended_view`; no reader re-derives it
+    for stage in view._stages:
+        if isinstance(stage, fosg.GroupBy):
+            stage._include_group = True
+    return view
+
+
 @gql.input
 class ExtendedViewForm:
     filters: Optional[JSON] = None
@@ -166,7 +175,7 @@ def get_view(
                 desc=desc,
             )
 
-        return view
+        return _include_group_fields(view)
 
     if awaitable:
         return fou.run_sync_task(run, dataset, stages)
@@ -243,11 +252,6 @@ def get_extended_view(
 
     if sort_by:
         view = view.sort_by(sort_by, reverse=bool(desc), create_index=False)
-
-    # the GroupBy stage emits `_group` itself so the grid never re-derives it
-    for stage in view._stages:
-        if isinstance(stage, fosg.GroupBy):
-            stage._include_group = True
 
     if pagination_data:
         # omit all dict and vector field values for performance, not needed by grid

--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -140,7 +140,7 @@ def get_view(
             dataset = fod.load_dataset(dataset, reload=reload)
 
         if view_name is not None:
-            return dataset.load_saved_view(view_name)
+            return _include_group_fields(dataset.load_saved_view(view_name))
 
         if stages:
             view = fov.DatasetView._build(dataset, stages)

--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -244,9 +244,9 @@ def get_extended_view(
     if sort_by:
         view = view.sort_by(sort_by, reverse=bool(desc), create_index=False)
 
+    # the GroupBy stage emits `_group` itself so the grid never re-derives it
     for stage in view._stages:
         if isinstance(stage, fosg.GroupBy):
-            # the stage emits `_group` itself so the grid never re-derives it
             stage._include_group = True
 
     if pagination_data:

--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -35,9 +35,7 @@ def _make_group_field_stage(view):
     )
     if group_by is None:
         return None
-    return fosg.Mongo(
-        [{"$addFields": {"_group": group_by._get_group_expr(view)[0]}}]
-    )
+    return fosg.Mongo([group_by._group_field_stage(view)])
 
 
 @gql.input
@@ -248,9 +246,7 @@ def get_extended_view(
 
     for stage in view._stages:
         if isinstance(stage, fosg.GroupBy):
-            view = view.mongo(
-                [{"$addFields": {"_group": stage._get_group_expr(view)[0]}}]
-            )
+            view = view.mongo([stage._group_field_stage(view)])
 
     if pagination_data:
         # omit all dict and vector field values for performance, not needed by grid
@@ -331,15 +327,7 @@ def handle_group_filter(
                 # modal: inject _group so the relay store record carries the
                 # dynamic group value for the sample being viewed
                 view = view._add_view_stage(
-                    fosg.Mongo(
-                        [
-                            {
-                                "$addFields": {
-                                    "_group": stage._get_group_expr(view)[0]
-                                }
-                            }
-                        ]
-                    )
+                    fosg.Mongo([stage._group_field_stage(view)])
                 )
 
             if isinstance(
@@ -388,7 +376,7 @@ def _project_pagination_paths(
         if isinstance(field, (fof.DictField, fof.VectorField))
     ]
 
-    selected_fields = ["_group"]  # store dynamic group values
+    selected_fields = ["_group", "_group_count"]
     for path in schema:
         if any(path.startswith(exclude) for exclude in excluded):
             continue

--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -246,7 +246,8 @@ def get_extended_view(
 
     for stage in view._stages:
         if isinstance(stage, fosg.GroupBy):
-            view = view.mongo([stage._group_field_stage(view)])
+            # the stage emits `_group` itself so the grid never re-derives it
+            stage._include_group = True
 
     if pagination_data:
         # omit all dict and vector field values for performance, not needed by grid

--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -297,6 +297,11 @@ def handle_group_filter(
     stages = view._stages
     group_field = dataset.group_field
 
+    if group_field is None:
+        # a slice filter carried over from a previously-viewed grouped dataset;
+        # this dataset isn't grouped, so there's nothing to select
+        return view, None
+
     selected = False
     for stage in stages:
         if isinstance(stage, fosg.SelectGroupSlices) and stage.flat:

--- a/tests/unittests/server_samples_routes_tests.py
+++ b/tests/unittests/server_samples_routes_tests.py
@@ -105,31 +105,26 @@ class SamplesRouteTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual([s["id"] for s in body["samples"]], [str(s2.id)])
 
     @drop_async_dataset
-    async def test_grouped_read_labels_group_from_pipeline(self, dataset):
-        # GroupBy's `$addFields` labels each doc with its dynamic-group value in
-        # Mongo; the server never re-derives `_group` in Python
-        dataset.add_samples(
-            [
-                fo.Sample(filepath="a0.png", scene="a"),
-                fo.Sample(filepath="a1.png", scene="a"),
-                fo.Sample(filepath="b0.png", scene="b"),
-            ]
-        )
+    async def test_grouped_by_id_read_labels_group(self, dataset):
+        # a by-id read of a grouped view goes through core's optimized select:
+        # index-eligible `$match` (no `$group`), `_group` labeled by core
+        a = fo.Sample(filepath="a0.png", scene="a")
+        b = fo.Sample(filepath="b0.png", scene="b")
+        dataset.add_samples([a, b, fo.Sample(filepath="a1.png", scene="a")])
 
         view = dataset.group_by("scene")
         status, body = await _dispatch(
             Samples,
             str(dataset._doc.id),
-            {"view": view._serialize(), "skipMetadata": True},
+            {
+                "view": view._serialize(),
+                "ids": [str(a.id), str(b.id)],
+                "skipMetadata": True,
+            },
         )
         self.assertEqual(status, 200)
-        by_path = {
-            s["fields"]["filepath"].rsplit("/", 1)[-1]: s["fields"]["_group"]
-            for s in body["samples"]
-        }
-        self.assertEqual(by_path["a0.png"], "a")
-        self.assertEqual(by_path["a1.png"], "a")
-        self.assertEqual(by_path["b0.png"], "b")
+        groups = sorted(s["fields"]["_group"] for s in body["samples"])
+        self.assertEqual(groups, ["a", "b"])
 
     @drop_async_dataset
     async def test_unknown_dataset_returns_404(self, dataset):

--- a/tests/unittests/server_samples_routes_tests.py
+++ b/tests/unittests/server_samples_routes_tests.py
@@ -105,6 +105,33 @@ class SamplesRouteTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual([s["id"] for s in body["samples"]], [str(s2.id)])
 
     @drop_async_dataset
+    async def test_grouped_read_labels_group_from_pipeline(self, dataset):
+        # GroupBy's `$addFields` labels each doc with its dynamic-group value in
+        # Mongo; the server never re-derives `_group` in Python
+        dataset.add_samples(
+            [
+                fo.Sample(filepath="a0.png", scene="a"),
+                fo.Sample(filepath="a1.png", scene="a"),
+                fo.Sample(filepath="b0.png", scene="b"),
+            ]
+        )
+
+        view = dataset.group_by("scene")
+        status, body = await _dispatch(
+            Samples,
+            str(dataset._doc.id),
+            {"view": view._serialize(), "skipMetadata": True},
+        )
+        self.assertEqual(status, 200)
+        by_path = {
+            s["fields"]["filepath"].rsplit("/", 1)[-1]: s["fields"]["_group"]
+            for s in body["samples"]
+        }
+        self.assertEqual(by_path["a0.png"], "a")
+        self.assertEqual(by_path["a1.png"], "a")
+        self.assertEqual(by_path["b0.png"], "b")
+
+    @drop_async_dataset
     async def test_unknown_dataset_returns_404(self, dataset):
         status, _ = await _dispatch(Samples, str(ObjectId()), {})
         self.assertEqual(status, 404)

--- a/tests/unittests/server_samples_routes_tests.py
+++ b/tests/unittests/server_samples_routes_tests.py
@@ -1,0 +1,175 @@
+"""
+Tests for the REST samples routes (field-projected reads, id-only spine,
+grouped counts, skip-metadata) exercised through the public ASGI endpoints.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import json
+import unittest
+
+from bson import ObjectId
+
+import fiftyone as fo
+import fiftyone.core.labels as fol
+
+from fiftyone.server.routes.samples import GridSamples, Samples
+from fiftyone.server.samples import paginate_samples
+
+from decorators import drop_async_dataset
+
+
+async def _dispatch(endpoint_cls, dataset_id, body):
+    """Run a samples ASGI endpoint, returning ``(status, parsed_json)``."""
+    payload = json.dumps(body).encode()
+
+    async def receive():
+        return {"type": "http.request", "body": payload, "more_body": False}
+
+    sent = []
+
+    async def send(message):
+        sent.append(message)
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "headers": [],
+        "path_params": {"dataset_id": dataset_id},
+    }
+    await endpoint_cls(scope, receive, send)
+
+    (start,) = [m for m in sent if m["type"] == "http.response.start"]
+    data = b"".join(
+        m.get("body", b"") for m in sent if m["type"] == "http.response.body"
+    )
+    return start["status"], json.loads(data)
+
+
+class SamplesRouteTests(unittest.IsolatedAsyncioTestCase):
+    @drop_async_dataset
+    async def test_include_projects_requested_fields(self, dataset):
+        s1 = fo.Sample(
+            filepath="a.png",
+            uniqueness=0.5,
+            metadata=fo.ImageMetadata(width=20, height=10),
+            predictions=fol.Classification(label="cat", confidence=0.9),
+        )
+        s2 = fo.Sample(filepath="b.png", uniqueness=0.7)
+        dataset.add_samples([s1, s2])
+
+        status, body = await _dispatch(
+            Samples, str(dataset._doc.id), {"fields": ["uniqueness"]}
+        )
+        self.assertEqual(status, 200)
+        self.assertEqual(len(body["samples"]), 2)
+
+        item = next(s for s in body["samples"] if s["id"] == str(s1.id))
+        self.assertIn("urls", item)
+        # requested field kept, unrequested label field dropped
+        self.assertIn("uniqueness", item["fields"])
+        self.assertNotIn("predictions", item["fields"])
+        # aspect ratio computed from metadata dimensions (20 / 10)
+        self.assertAlmostEqual(item["aspectRatio"], 2.0)
+
+    @drop_async_dataset
+    async def test_skip_metadata_omits_aspect_ratio(self, dataset):
+        sample = fo.Sample(
+            filepath="a.png", metadata=fo.ImageMetadata(width=20, height=10)
+        )
+        dataset.add_sample(sample)
+
+        status, body = await _dispatch(
+            Samples, str(dataset._doc.id), {"skipMetadata": True}
+        )
+        self.assertEqual(status, 200)
+        item = body["samples"][0]
+        self.assertEqual(item["id"], str(sample.id))
+        self.assertIn("urls", item)
+        # the skip path must not ship a computed/placeholder aspect ratio
+        self.assertNotIn("aspectRatio", item)
+
+    @drop_async_dataset
+    async def test_select_by_ids(self, dataset):
+        s1 = fo.Sample(filepath="a.png")
+        s2 = fo.Sample(filepath="b.png")
+        dataset.add_samples([s1, s2])
+
+        status, body = await _dispatch(
+            Samples,
+            str(dataset._doc.id),
+            {"ids": [str(s2.id)], "skipMetadata": True},
+        )
+        self.assertEqual(status, 200)
+        self.assertEqual([s["id"] for s in body["samples"]], [str(s2.id)])
+
+    @drop_async_dataset
+    async def test_unknown_dataset_returns_404(self, dataset):
+        status, _ = await _dispatch(Samples, str(ObjectId()), {})
+        self.assertEqual(status, 404)
+
+
+class GridSamplesRouteTests(unittest.IsolatedAsyncioTestCase):
+    @drop_async_dataset
+    async def test_spine_returns_ordered_ids(self, dataset):
+        samples = [fo.Sample(filepath="%d.png" % i) for i in range(3)]
+        dataset.add_samples(samples)
+
+        status, body = await _dispatch(GridSamples, str(dataset._doc.id), {})
+        self.assertEqual(status, 200)
+        self.assertEqual(
+            [e["id"] for e in body["spine"]],
+            [str(s.id) for s in samples],
+        )
+        # small dataset fits in one page: no continuation token
+        self.assertIsNone(body["next"])
+
+    @drop_async_dataset
+    async def test_spine_after_skips(self, dataset):
+        samples = [fo.Sample(filepath="%d.png" % i) for i in range(3)]
+        dataset.add_samples(samples)
+
+        status, body = await _dispatch(
+            GridSamples, str(dataset._doc.id), {"after": 1}
+        )
+        self.assertEqual(status, 200)
+        self.assertEqual(
+            [e["id"] for e in body["spine"]],
+            [str(samples[1].id), str(samples[2].id)],
+        )
+
+    @drop_async_dataset
+    async def test_spine_carries_group_counts(self, dataset):
+        # group "a" has 3 samples, group "b" has 2
+        for i in range(3):
+            dataset.add_sample(fo.Sample(filepath="a%d.png" % i, scene="a"))
+        for i in range(2):
+            dataset.add_sample(fo.Sample(filepath="b%d.png" % i, scene="b"))
+
+        view = dataset.group_by("scene")
+        status, body = await _dispatch(
+            GridSamples, str(dataset._doc.id), {"view": view._serialize()}
+        )
+        self.assertEqual(status, 200)
+        # one spine entry per group, each carrying its full group size
+        self.assertEqual(
+            sorted(e["groupCount"] for e in body["spine"]), [2, 3]
+        )
+
+
+class PaginateSamplesSkipMetadataTests(unittest.IsolatedAsyncioTestCase):
+    @drop_async_dataset
+    async def test_skip_metadata_still_pages(self, dataset):
+        dataset.add_samples(
+            [fo.Sample(filepath="a.png"), fo.Sample(filepath="b.png")]
+        )
+
+        conn = await paginate_samples(
+            dataset.name, [], None, first=10, skip_metadata=True
+        )
+        self.assertEqual(len(conn.edges), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unittests/server_view_tests.py
+++ b/tests/unittests/server_view_tests.py
@@ -6,6 +6,7 @@ FiftyOne Server view tests.
 |
 """
 
+import json
 import math
 import unittest
 
@@ -1009,6 +1010,79 @@ class ServerViewTests(unittest.TestCase):
         self.assertGreater(len(samples), 0)
         for s in samples:
             self.assertEqual(s["_group"], "cat")
+
+    @drop_datasets
+    def test_grouped_pipeline_uses_index(self):
+        dataset = fod.Dataset("test")
+        samples = []
+        for s in range(20):
+            for f in range(3):
+                samples.append(
+                    fo.Sample(
+                        filepath="%d_%d.png" % (s, f),
+                        scene="s%d" % s,
+                        frame_number=f + 1,
+                    )
+                )
+        dataset.add_samples(samples)
+
+        # an ordered grouped read materializes a (scene, frame_number) index and
+        # walks it instead of scanning the collection
+        stages = [
+            fosg.GroupBy(
+                "scene", order_by="frame_number", create_index=True
+            )._serialize()
+        ]
+        view = fosv.get_view("test", stages=stages)
+        for stage in view._stages:
+            if isinstance(stage, fosg.GroupBy):
+                stage._include_count = True
+
+        explain = foo.get_db_conn().command(
+            "aggregate",
+            view._dataset._sample_collection_name,
+            pipeline=view._pipeline(),
+            explain=True,
+        )
+        plan = json.dumps(explain, default=str)
+        self.assertIn("IXSCAN", plan)
+        self.assertNotIn("COLLSCAN", plan)
+
+    @drop_datasets
+    def test_index_optimized_count_uses_index(self):
+        dataset = fod.Dataset("test")
+        samples = []
+        for s in range(20):
+            for f in range(3):
+                samples.append(
+                    fo.Sample(filepath="%d_%d.png" % (s, f), scene="s%d" % s)
+                )
+        dataset.add_samples(samples)
+        dataset.create_index("scene")
+
+        stages = [fosg.GroupBy("scene")._serialize()]
+
+        def _plan(index_optimized):
+            view = fosv.get_view("test", stages=stages)
+            for stage in view._stages:
+                if isinstance(stage, fosg.GroupBy):
+                    stage._include_count = True
+                    stage._index_optimized = index_optimized
+            explain = foo.get_db_conn().command(
+                "aggregate",
+                view._dataset._sample_collection_name,
+                pipeline=view._pipeline(),
+                explain=True,
+            )
+            return json.dumps(explain, default=str)
+
+        # gated off (SDK default): the counting `$group` scans the collection
+        self.assertIn("COLLSCAN", _plan(False))
+
+        # server opt-in: the presort rides the `scene` index instead
+        plan = _plan(True)
+        self.assertIn("IXSCAN", plan)
+        self.assertNotIn("COLLSCAN", plan)
 
     @drop_datasets
     def test_sort_by(self):

--- a/tests/unittests/server_view_tests.py
+++ b/tests/unittests/server_view_tests.py
@@ -11,6 +11,7 @@ import unittest
 
 import fiftyone as fo
 import fiftyone.core.dataset as fod
+import fiftyone.core.fields as fof
 import fiftyone.core.labels as fol
 import fiftyone.core.odm as foo
 import fiftyone.core.sample as fos
@@ -19,7 +20,7 @@ from fiftyone.server.query import Dataset
 from fiftyone.server.samples import paginate_samples
 import fiftyone.server.view as fosv
 
-from decorators import drop_datasets
+from decorators import drop_async_dataset, drop_datasets
 from utils.groups import make_disjoint_groups_dataset
 
 
@@ -1303,3 +1304,139 @@ class GetExtendedViewTests(unittest.TestCase):
         )
         self.assertEqual(len(view), 1)
         ds.delete()
+
+
+class SamplesProjectionTests(unittest.TestCase):
+    @drop_datasets
+    def test_include_keeps_only_requested(self):
+        from fiftyone.server.routes.samples import _projection
+
+        dataset = fod.Dataset("test_samples_incl")
+        dataset.add_sample(
+            fos.Sample(
+                filepath="a.png",
+                uniqueness=0.5,
+                predictions=fol.Classification(
+                    label="cat", confidence=0.9, logits=[0.1, 0.2]
+                ),
+            )
+        )
+        view = dataset.view()
+        pipeline = view._pipeline() + [
+            _projection(["predictions.label"], None)
+        ]
+        docs = list(
+            foo.aggregate(
+                foo.get_db_conn()[view._dataset._sample_collection_name],
+                pipeline,
+            )
+        )
+        doc = docs[0]
+        # identifiers always present
+        self.assertIn("_id", doc)
+        self.assertIn("filepath", doc)
+        # requested field present, non-requested fields absent
+        self.assertIn("label", doc["predictions"])
+        self.assertNotIn("uniqueness", doc)
+        self.assertNotIn("confidence", doc["predictions"])
+        self.assertNotIn("logits", doc["predictions"])
+
+    @drop_datasets
+    def test_exclude_drops_requested(self):
+        from fiftyone.server.routes.samples import _projection
+
+        dataset = fod.Dataset("test_samples_excl")
+        dataset.add_sample(
+            fos.Sample(
+                filepath="a.png",
+                uniqueness=0.5,
+                predictions=fol.Classification(
+                    label="cat", confidence=0.9, logits=[0.1, 0.2]
+                ),
+            )
+        )
+        view = dataset.view()
+        pipeline = view._pipeline() + [
+            _projection(None, ["predictions.logits", "filepath"])
+        ]
+        docs = list(
+            foo.aggregate(
+                foo.get_db_conn()[view._dataset._sample_collection_name],
+                pipeline,
+            )
+        )
+        doc = docs[0]
+        # everything kept except the excluded path
+        self.assertIn("uniqueness", doc)
+        self.assertIn("label", doc["predictions"])
+        self.assertIn("confidence", doc["predictions"])
+        self.assertNotIn("logits", doc["predictions"])
+        # identifiers are never excluded even if asked
+        self.assertIn("filepath", doc)
+
+
+class FramesRouteTests(unittest.IsolatedAsyncioTestCase):
+    @drop_async_dataset
+    async def test_response_excludes_heavy_fields(self, dataset):
+        import json
+
+        import numpy as np
+
+        from fiftyone.server.routes.frames import Frames
+
+        sample = fos.Sample(filepath="video.mp4")
+        sample.frames[1] = fo.Frame(
+            frame_str="keep",
+            embedding=np.random.rand(8),
+            info={"a": 1},
+            cls=fol.Classification(label="x", logits=[0.1, 0.2]),
+            detections=fol.Detections(
+                detections=[
+                    fol.Detection(label="d", bounding_box=[0, 0, 1, 1])
+                ]
+            ),
+        )
+        dataset.add_sample(sample)
+
+        body = json.dumps(
+            {
+                "frameNumber": 1,
+                "frameCount": 1,
+                "numFrames": 1,
+                "dataset": dataset.name,
+                "sampleId": str(sample.id),
+            }
+        ).encode()
+
+        async def receive():
+            return {"type": "http.request", "body": body, "more_body": False}
+
+        sent = []
+
+        async def send(message):
+            sent.append(message)
+
+        # dispatch the real ASGI endpoint (parses the body, runs the route)
+        await Frames(
+            {"type": "http", "method": "POST", "headers": []}, receive, send
+        )
+
+        (start,) = [m for m in sent if m["type"] == "http.response.start"]
+        self.assertEqual(start["status"], 200)
+        payload = b"".join(
+            m.get("body", b"")
+            for m in sent
+            if m["type"] == "http.response.body"
+        )
+        frames = json.loads(payload)["frames"]
+        self.assertEqual(len(frames), 1)
+        frame = frames[0]
+
+        # heavy fields (vectors, dicts, logits) must not ship in the response
+        self.assertNotIn("embedding", frame)
+        self.assertNotIn("info", frame)
+        self.assertNotIn("logits", frame.get("cls", {}))
+
+        # overlay fields the app renders are kept
+        self.assertIn("frame_str", frame)
+        self.assertIn("detections", frame)

--- a/tests/unittests/server_view_tests.py
+++ b/tests/unittests/server_view_tests.py
@@ -1049,42 +1049,6 @@ class ServerViewTests(unittest.TestCase):
         self.assertNotIn("COLLSCAN", plan)
 
     @drop_datasets
-    def test_index_optimized_count_uses_index(self):
-        dataset = fod.Dataset("test")
-        samples = []
-        for s in range(20):
-            for f in range(3):
-                samples.append(
-                    fo.Sample(filepath="%d_%d.png" % (s, f), scene="s%d" % s)
-                )
-        dataset.add_samples(samples)
-        dataset.create_index("scene")
-
-        stages = [fosg.GroupBy("scene")._serialize()]
-
-        def _plan(index_optimized):
-            view = fosv.get_view("test", stages=stages)
-            for stage in view._stages:
-                if isinstance(stage, fosg.GroupBy):
-                    stage._include_count = True
-                    stage._index_optimized = index_optimized
-            explain = foo.get_db_conn().command(
-                "aggregate",
-                view._dataset._sample_collection_name,
-                pipeline=view._pipeline(),
-                explain=True,
-            )
-            return json.dumps(explain, default=str)
-
-        # gated off (SDK default): the counting `$group` scans the collection
-        self.assertIn("COLLSCAN", _plan(False))
-
-        # server opt-in: the presort rides the `scene` index instead
-        plan = _plan(True)
-        self.assertIn("IXSCAN", plan)
-        self.assertNotIn("COLLSCAN", plan)
-
-    @drop_datasets
     def test_sort_by(self):
         dataset = fod.Dataset("test")
         dataset.add_sample(fo.Sample(filepath="image.png", value="value"))


### PR DESCRIPTION
<!--
Community contributors: target the `community` branch, not `develop`. PRs from
non-members are auto-retargeted to `community`. See CONTRIBUTING.md:
https://github.com/voxel51/fiftyone/blob/develop/CONTRIBUTING.md#community-pull-requests
-->

## 🔗 Related Issues

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->

## 📋 What changes are proposed in this pull request?

- add REST sample/frame endpoints, grouped counts, skip-metadata to support infinite scroll and improve grid/modal loading in the app


## 🧪 How is this patch tested? If it is not, please explain why.

<!--
Describe the tests you ran or wrote to verify your changes. Include:
- New or updated unit/integration tests
- Manual testing steps performed
- Why tests are not applicable (if skipped)
-->

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dataset-backed endpoints for reading samples (`/dataset/{dataset_id}/samples`) and grid spine samples (`/dataset/{dataset_id}/grid/samples`).
  * Grid responses can include per-group `groupCount` when grouping is enabled.
  * Frames endpoint now supports honoring requested `fields`/`exclude`.

* **Bug Fixes**
  * Improved dynamic grouping when group expressions are multiple field references.
  * Grouped pagination projection now consistently includes `_group` and `_group_count`.
  * Added `skipMetadata` / `skip_metadata` to omit expensive dimension metadata work; `skip_dimensions` is propagated to sample item creation.
  * Improved grouped pipeline handling to better materialize group values and enable index-backed execution.

* **Tests**
  * Added unit tests covering samples/grid endpoints, grouping/projection behavior, frames “heavy fields” omission, and index-backed grouped query plans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->