### PR TITLE
feat(spaces): open new panels split by default

### DIFF
--- a/app/packages/spaces/src/components/AddPanelItem.tsx
+++ b/app/packages/spaces/src/components/AddPanelItem.tsx
@@ -32,7 +32,12 @@ export default function AddPanelItem({
         const newNode = new SpaceNode();
         newNode.type = name;
         spaces.addNodeAfter(node, newNode);
-        if (e.altKey) {
+        if (e.altKey && e.shiftKey) {
+          // Shift+Alt opens the panel full-screen: it was already added as a
+          // tab above, so we intentionally skip splitting the layout. This
+          // preserves full-screen open, which split-by-default would otherwise
+          // remove entirely.
+        } else if (e.altKey) {
           spaces.splitLayout(node, Layout.Horizontal);
         } else if (e.shiftKey) {
           spaces.splitLayout(node, Layout.Vertical);

--- a/app/packages/spaces/src/components/AddPanelItem.tsx
+++ b/app/packages/spaces/src/components/AddPanelItem.tsx
@@ -36,6 +36,10 @@ export default function AddPanelItem({
           spaces.splitLayout(node, Layout.Horizontal);
         } else if (e.shiftKey) {
           spaces.splitLayout(node, Layout.Vertical);
+        } else if (!node.parent?.isSpaceContainer()) {
+          // by default, open the panel side-by-side with the current view;
+          // if the layout is already split, just add it as a tab
+          spaces.splitLayout(node, Layout.Horizontal);
         }
         if (onClick) onClick();
       }}

--- a/e2e-pw/src/oss/poms/panels/grid-panel.ts
+++ b/e2e-pw/src/oss/poms/panels/grid-panel.ts
@@ -46,7 +46,10 @@ export class GridPanelPom {
 
   async open(panelName: GridPanelName) {
     await this.newPanelBtn.click();
-    await this.getPanelOption(panelName).click();
+    // Open full-screen (Shift+Alt) so the panel fills the view as it did
+    // before split-by-default. Keeps layout-sensitive assertions stable and
+    // independent of the default split behavior.
+    await this.getPanelOption(panelName).click({ modifiers: ["Alt", "Shift"] });
   }
 
   async close() {


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link.

## 📋 What changes are proposed in this pull request?

Panels opened from the "+" dropdown now open **side-by-side with the current view by default**, instead of as a new tab.

The default split only fires when the layout **isn't already split** — so normal clicks never produce runaway splits. Already-split layouts add the panel as a tab. Alt/Shift still force a split regardless, which keeps them useful for intentional deeper splitting.

Because split-by-default takes over the no-modifier gesture, it would otherwise **remove the ability to open a panel full-screen entirely**. To preserve that, **Shift+Alt now opens a panel full-screen** (full-width, as a tab) — the behavior the no-modifier click used to have.

| Action | Not yet split | Already split |
|---|---|---|
| **No modifier** | Horizontal split | Added as a tab |
| **Alt** | Horizontal split | Splits further |
| **Shift** | Vertical split | Splits further |
| **Shift+Alt** | Full-screen (as a tab) | Added as a tab |

In `AddPanelItem.tsx`: the default `else if (!node.parent?.isSpaceContainer())` branch calls `spaces.splitLayout(node, Layout.Horizontal)`, and a new `if (e.altKey && e.shiftKey)` branch (checked first) skips splitting to open full-screen. The existing Alt/Shift branches are unchanged.

## 🧪 How is this patch tested? If it is not, please explain why.

Manual verification in the App:

1. No modifier, layout not split → panel opens side-by-side.
2. Layout already split → panel added as a tab (no further split).
3. Alt → horizontal split; Shift → vertical split (unchanged).
4. Shift+Alt → panel opens full-screen.

E2E: `GridPanelPom.open()` now opens panels full-screen (Shift+Alt) so layout-sensitive specs stay stable under the new default. This keeps the `histograms`, `embeddings`, and `display-options` specs passing without re-baselining screenshots or rewriting interaction coordinates.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Panels opened from the panel menu now open side-by-side with the current view by default (previously opened as a new tab). Hold Alt or Shift to force a horizontal or vertical split, or Shift+Alt to open the panel full-screen; already-split layouts add the panel as a tab.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [x] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new default behavior when inserting a panel item: if no modifier keys are held and the target is not already in a split container, it now opens side-by-side automatically.
  
* **Bug Fixes**
  * Improved click handling for panel insertion so the layout changes more predictably based on the current container state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3012
<!-- enterprise-sync-pr:end -->
