### PR TITLE
fix(app): vertically center object-editor parameter text

### DIFF
--- a/app/packages/core/src/components/ViewBar/ViewStage/ViewStageParameter.tsx
+++ b/app/packages/core/src/components/ViewBar/ViewStage/ViewStageParameter.tsx
@@ -60,6 +60,7 @@ const ObjectEditorContainer = animated(styled.div`
   margin-left: -1px;
   overflow: visible;
   display: flex;
+  align-items: center;
   border: 1px solid pink;
   border-style: solid;
   z-index: 800;


### PR DESCRIPTION
## 🔗 Related Issues

Follow-up to #7323, which centered the standard parameter inputs but left the object-editor boxes top-aligned.

## 📋 What changes are proposed in this pull request?

Vertically centers the text in the **object-editor parameter boxes** in the view bar — the dict/JSON-typed params, e.g. the `None` boxes on a `GroupBy` stage or `MapValues`' map. These sat top-aligned in their 36px row because `ObjectEditorContainer` is `display: flex` with no `align-items`, so they floated above the neighboring centered boxes.

One-line CSS fix — adds `align-items: center;` to `ObjectEditorContainer` in `ViewStageParameter.tsx`, matching the alignment #7323 already gave the standard inputs.

## 📸 Before / After

### Before

<img width="2158" height="426" alt="image" src="https://github.com/user-attachments/assets/de93e48c-efa9-4fc5-bc47-d1602ea1a41d" />


### After

<img width="2142" height="432" alt="image" src="https://github.com/user-attachments/assets/890bc5a0-6715-4782-926c-efd530ccb8ba" />

## 🧪 How is this patch tested? If it is not, please explain why.

Manual visual check in the App: the `None` boxes on a `GroupBy` stage now sit vertically centered in the view bar, matching the neighboring `False`/field boxes (see screenshots). No automated tests — single CSS property.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

N/A

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the alignment of the object editor container so its contents are vertically centered for a cleaner layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3016
<!-- enterprise-sync-pr:end -->