### PR TITLE
[video annotation] Add support for instance masks and polylines

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Actions.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Actions.tsx
@@ -467,10 +467,11 @@ export const ThreeDCuboids = () => {
 const Actions = () => {
   // This checks if media type of the dataset resolved to 3d
   const is3dDataset = useRecoilValue(is3DDataset);
-  // Video annotation supports only box drawing today, so the surface shows a
-  // reduced label-type set (Select + Detection); the other label-type modes are
-  // hidden until segmentation/polyline land. Undo/redo are shown — the engine's
-  // value-based stack backs them on video too.
+  // Video annotation handles the per-frame spatial label types — boxes,
+  // instance masks (Segmentation mode paints onto a detection), and polylines —
+  // so the surface shows that reduced set (Select + Detection + Segmentation +
+  // Polyline). Classification stays image-only for now. Undo/redo are shown —
+  // the engine's value-based stack backs them on video too.
   const isVideo = useRecoilValue(isVideoDataset);
   // This checks if a 3d sample is pinned - is true when media type is `group` with a 3d slice pinned
   const is3dSamplePinned = useIs3dPinned();
@@ -498,7 +499,11 @@ const Actions = () => {
           <ItemLeft style={{ columnGap: "0.1rem" }}>
             <Select active={noActiveActions} />
             {isVideo ? (
-              <Detection />
+              <>
+                <Detection />
+                <Segmentation />
+                <Polyline />
+              </>
             ) : (
               <>
                 <Classification />

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/MaskPreview.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/MaskPreview.tsx
@@ -151,7 +151,7 @@ export default function MaskPreview() {
   const bg = isDark ? "#ffffff" : "#000000";
 
   return (
-    <Container>
+    <Container data-cy="annotate-mask-preview">
       <Label>Mask</Label>
       <CanvasContainer $bg={bg}>
         <StyledCanvas ref={canvasRef} />

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useFormAnchor.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useFormAnchor.ts
@@ -88,7 +88,13 @@ export const useFormAnchor = (): void => {
   const build = useCallback(
     (ref: LabelRef, data: AnnotationLabelData): AnnotationLabel => {
       const field = ref.path;
-      const mounted = scene?.getOverlay(data._id as string);
+      // the scene keys overlays by the track's `instance._id` (equal to the
+      // doc `_id` for an untracked 2D label, but distinct for a per-frame video
+      // track) — resolve the instance id so the live overlay (and its mask) is
+      // found, mirroring the sidebar list resolution in `useLabels`
+      const instanceId =
+        (data as { instance?: { _id?: string } }).instance?._id ?? data._id;
+      const mounted = scene?.getOverlay(instanceId as string);
       const live = mounted && mounted.field === field ? mounted : undefined;
 
       return {

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useLabels.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useLabels.ts
@@ -287,8 +287,15 @@ export default function useLabels() {
       for (const data of engine.listLabels({ sample: sampleId, path })) {
         engineIds.add(data._id);
 
+        // The scene keys overlays by the track's `instance._id` (the engine
+        // `instanceId`), which equals the doc `_id` for an untracked 2D label
+        // but differs for a per-frame video track — so resolve the instance id
+        // to find the live overlay (and its mask), falling back to `_id`.
+        const instanceId =
+          (data as { instance?: { _id?: string } }).instance?._id ?? data._id;
+
         const prev = previousById.get(data._id);
-        const mounted = scene?.getOverlay(data._id);
+        const mounted = scene?.getOverlay(instanceId);
         const live = mounted && mounted.field === path ? mounted : undefined;
 
         // keep stub identity across reconciles while the data is unchanged;

--- a/app/packages/lighter/src/overlay/DetectionOverlay.ts
+++ b/app/packages/lighter/src/overlay/DetectionOverlay.ts
@@ -174,9 +174,13 @@ export class DetectionOverlay
         this.mask = new MaskCanvas(label.mask);
       }
       this.markDirty();
-    } else if (label.mask === null) {
-      // null — explicit removal
-      // `undefined` can be cases when mask has not been saved yet - leave it alone
+    } else if (label.mask === null || !label.mask_path) {
+      // Drop a stale mask when the label carries neither inline `mask` data nor
+      // a `mask_path` to decode — an explicit removal (`null`), or reconciling
+      // this overlay onto a label with no mask at all (e.g. a video track's
+      // mask-less frame as the playhead advances past the mask's keyframe).
+      // A pending `mask_path` decode (mask `undefined`, `mask_path` set) is left
+      // alone so the in-flight decode still lands.
       const hadMask = !!this.mask;
       this.maskSource = undefined;
       this.mask?.destroy();

--- a/app/packages/utilities/src/videoLabels.ts
+++ b/app/packages/utilities/src/videoLabels.ts
@@ -72,12 +72,31 @@ export interface RawDetection {
   label?: string;
   bounding_box?: [number, number, number, number];
   instance?: { _cls: "Instance"; _id?: string } | null;
+  mask_path?: string;
+  mask?: unknown;
   keyframe?: boolean;
   propagation?: PropagationBlob | null;
 }
 
 export interface RawDetectionsField {
   detections?: RawDetection[];
+}
+
+export interface RawPolyline {
+  _id?: string;
+  id?: string;
+  index?: number;
+  label?: string;
+  points?: [number, number][][];
+  closed?: boolean;
+  filled?: boolean;
+  instance?: { _cls: "Instance"; _id?: string } | null;
+  keyframe?: boolean;
+  propagation?: PropagationBlob | null;
+}
+
+export interface RawPolylinesField {
+  polylines?: RawPolyline[];
 }
 
 /**

--- a/app/packages/video-annotation/src/components/FrameLabels.tsx
+++ b/app/packages/video-annotation/src/components/FrameLabels.tsx
@@ -22,6 +22,7 @@ import {
   useColorScheme,
   useColorSeed,
   useDatasetName,
+  useFrameLabelFields,
   useGroupSlice,
   useModalSampleId,
   useView,
@@ -81,7 +82,10 @@ type TrackDecoration = BaseTrackDecoration & {
 };
 
 /** Resolves the row color for a per-frame object track. */
-type ObjectTrackColorResolver = (label: PerInstanceLabel) => string;
+type ObjectTrackColorResolver = (
+  label: PerInstanceLabel,
+  path: string
+) => string;
 
 /** Resolves the row color for a temporal-detection track. */
 type TemporalDetectionColorResolver = (
@@ -207,11 +211,15 @@ function useFrameDerivedTracks(resolveColor: ObjectTrackColorResolver): {
   const engine = useAnnotationEngine();
   const sampleId = useActiveSampleId();
   const visible = useVisibleLabelSchemas();
-  const path = stream ? `frames.${stream.labelsField}` : null;
+  const labelTypes = useFrameLabelFields();
 
-  // Gate the frame field's tracks on the sidebar's visible set — deactivating it
-  // in the schema manager hides its timeline rows, matching the canvas + sidebar.
-  const active = !!path && visible.has(path);
+  // Gate each frame field's tracks on the sidebar's visible set — deactivating
+  // a field in the schema manager hides its timeline rows, matching the canvas
+  // + sidebar.
+  const paths = useMemo(
+    () => Object.keys(labelTypes).filter((p) => visible.has(p)),
+    [labelTypes, visible]
+  );
 
   const [tracks, setTracks] = useState<Track[]>([]);
   const [resolved, setResolved] = useState(false);
@@ -220,14 +228,17 @@ function useFrameDerivedTracks(resolveColor: ObjectTrackColorResolver): {
   const engineVersion = useEngineSelector(engine, () => engine.getVersion());
 
   useEffect(() => {
-    if (!stream || !sampleId || !path) {
+    // The stream's presence is the activation-independent "has a frame field"
+    // signal; without it there's nothing to bootstrap.
+    if (!stream || !sampleId) {
       setTracks([]);
       setResolved(false);
       return undefined;
     }
 
-    // Inactive field: no rows, but still resolved so TD-track pin bootstrap fires.
-    if (!active) {
+    // No visible frame field (none active, or all deactivated): no rows, but
+    // still resolved so the TD-track pin bootstrap fires.
+    if (paths.length === 0) {
       setTracks([]);
       setResolved(true);
       return undefined;
@@ -244,7 +255,7 @@ function useFrameDerivedTracks(resolveColor: ObjectTrackColorResolver): {
         buildPerInstanceTracks({
           engine,
           sample: sampleId,
-          path,
+          paths,
           totalFrames: stream.totalFrames,
           fps: stream.fps,
           resolveColor,
@@ -257,7 +268,7 @@ function useFrameDerivedTracks(resolveColor: ObjectTrackColorResolver): {
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- engineVersion is the invalidation signal
-  }, [engine, sampleId, path, active, stream, resolveColor, engineVersion]);
+  }, [engine, sampleId, paths, stream, resolveColor, engineVersion]);
 
   return { tracks, resolved };
 }
@@ -309,23 +320,23 @@ function useTemporalDetectionTracks(
 }
 
 /** Build the row-color resolvers, kept in lock-step with the overlays. */
-function useTrackColorResolvers(path: string | null): {
+function useTrackColorResolvers(): {
   resolveObjectColor: ObjectTrackColorResolver;
   resolveTemporalDetectionColor: TemporalDetectionColorResolver;
 } {
   const scheme = useColorScheme();
   const seed = useColorSeed();
-  const activeField = useActiveDetectionField() ?? DEFAULT_FRAME_FIELD;
 
-  // Color by the ENGINE path (`frames.detections`) to match the sidebar and
-  // canvas; the schema-namespace `activeField` keys a different scheme entry.
+  // Color by each row's own ENGINE path (`frames.detections`,
+  // `frames.polylines`, …) so the row matches its overlay's color and
+  // multi-field rows don't collapse onto one field's scheme entry.
   const resolveObjectColor = useCallback(
-    (label: PerInstanceLabel) =>
-      getLabelColorFromContext(path ?? activeField, label, {
+    (label: PerInstanceLabel, path: string) =>
+      getLabelColorFromContext(path, label, {
         colorScheme: scheme,
         seed,
       }),
-    [path, activeField, scheme, seed]
+    [scheme, seed]
   );
 
   const resolveTemporalDetectionColor = useCallback(
@@ -405,11 +416,8 @@ function useTrackDecorator(
 export const FrameLabelsTracks: React.FC<{ sample?: ModalSample }> = ({
   sample,
 }) => {
-  const stream = useFrameLabelsStream();
-  const path = stream ? `frames.${stream.labelsField}` : null;
-
   const { resolveObjectColor, resolveTemporalDetectionColor } =
-    useTrackColorResolvers(path);
+    useTrackColorResolvers();
 
   const { tracks: frameTracks, resolved: frameTracksResolved } =
     useFrameDerivedTracks(resolveObjectColor);

--- a/app/packages/video-annotation/src/hooks/useSyncAnnotationVideoStore.ts
+++ b/app/packages/video-annotation/src/hooks/useSyncAnnotationVideoStore.ts
@@ -6,10 +6,10 @@ import {
   useSampleInstanceGetter,
   VideoLabelStore,
 } from "@fiftyone/annotation";
-import { LabelType } from "@fiftyone/utilities";
 import { useEffect } from "react";
 import { useFrameLabelsStream } from "../streams/frameLabelsStream";
 import { parseFramesData } from "../streams/framesData";
+import { useFrameLabelFields } from "../state/accessors";
 
 /**
  * Own the video sample's engine store for the lifetime of the surface.
@@ -31,23 +31,25 @@ export const useSyncAnnotationVideoStore = (): void => {
   const sampleId = useActiveSampleId();
   const getSample = useSampleInstanceGetter();
   const stream = useFrameLabelsStream();
-  const field = stream?.labelsField;
+  const labelTypes = useFrameLabelFields();
 
   useEffect(() => {
-    if (!sampleId || !stream || !field) {
+    if (!sampleId || !stream) {
       return undefined;
     }
 
-    const path = `frames.${field}`;
-    const frames = new FrameStore(sampleId, {
-      labelTypes: { [path]: LabelType.Detections },
-    });
+    // Register whenever the surface has a sample + stream — NOT gated on the
+    // active frame fields. Deactivating every frame label field empties
+    // `labelTypes`, but the composite store still owns the sample-level
+    // (temporal-detection) labels; tearing it down then would sweep those
+    // overlays too. Visibility/activation gates rendering, never the store.
+    const frames = new FrameStore(sampleId, { labelTypes });
     const sampleLevel = new SampleLabelStore(sampleId, getSample(sampleId));
     const store = new VideoLabelStore(sampleId, frames, sampleLevel);
     const unregister = engine.registerStore(store);
 
     const seed = () =>
-      frames.setData(parseFramesData(stream.cachedFrames(), field));
+      frames.setData(parseFramesData(stream.cachedFrames(), labelTypes));
     const unsubscribe = stream.subscribeToEdits(seed);
     seed();
 
@@ -56,5 +58,5 @@ export const useSyncAnnotationVideoStore = (): void => {
       unregister();
       sampleLevel.dispose();
     };
-  }, [engine, sampleId, field, getSample, stream]);
+  }, [engine, sampleId, labelTypes, getSample, stream]);
 };

--- a/app/packages/video-annotation/src/state/accessors.ts
+++ b/app/packages/video-annotation/src/state/accessors.ts
@@ -12,16 +12,22 @@ import {
   useCurrentDatasetId,
   view,
 } from "@fiftyone/state";
+import { FRAMES_PREFIX } from "@fiftyone/annotation";
 import {
   DETECTION,
   EMBEDDED_DOCUMENT_FIELD,
+  LabelType,
+  POLYLINE,
   type Stage,
   TEMPORAL_DETECTIONS_FIELD,
 } from "@fiftyone/utilities";
 import { useAtomValue } from "jotai";
 import { useMemo } from "react";
 import { useRecoilValue } from "recoil";
-import { useAnnotationContext } from "../../../core/src/components/Modal/Sidebar/Annotate/Edit/useAnnotationContext";
+import {
+  useAnnotationContext,
+  useAnnotationFields,
+} from "../../../core/src/components/Modal/Sidebar/Annotate/Edit/useAnnotationContext";
 import { visibleLabelSchemas } from "../../../core/src/components/Modal/Sidebar/Annotate/state";
 
 /**
@@ -90,4 +96,37 @@ export const useActiveDetectionField = (): string | null =>
 export const useVisibleLabelSchemas = (): ReadonlySet<string> => {
   const visible = useAtomValue(visibleLabelSchemas);
   return useMemo(() => new Set(visible), [visible]);
+};
+
+/**
+ * Every schema-active per-frame label field, mapped to its list label type
+ * — the engine seed registers and renders exactly these (mirroring the 2D
+ * surface, which paints every active field of each supported type).
+ *
+ * Drawn from the annotation schema's active fields per type (read-only fields
+ * already filtered out by {@link useAnnotationFields}) and narrowed to the
+ * `frames.*` namespace, since the video surface only owns per-frame labels.
+ * Detection masks ride their parent detection field, so no separate entry.
+ */
+export const useFrameLabelFields = (): Record<string, LabelType> => {
+  const detectionFields = useAnnotationFields(DETECTION).fields;
+  const polylineFields = useAnnotationFields(POLYLINE).fields;
+
+  return useMemo(() => {
+    const fields: Record<string, LabelType> = {};
+
+    for (const field of detectionFields) {
+      if (field.startsWith(FRAMES_PREFIX)) {
+        fields[field] = LabelType.Detections;
+      }
+    }
+
+    for (const field of polylineFields) {
+      if (field.startsWith(FRAMES_PREFIX)) {
+        fields[field] = LabelType.Polylines;
+      }
+    }
+
+    return fields;
+  }, [detectionFields, polylineFields]);
 };

--- a/app/packages/video-annotation/src/state/useVideoInteraction.ts
+++ b/app/packages/video-annotation/src/state/useVideoInteraction.ts
@@ -9,7 +9,6 @@ import {
   useSurfaceActions,
 } from "@fiftyone/annotation";
 import { useCallback, useEffect, useRef } from "react";
-import { useFrameLabelsStream } from "../streams/frameLabelsStream";
 import { useCurrentFrame, useCurrentFrameGetter } from "./useCurrentFrame";
 
 const SURFACE = "video-timeline";
@@ -44,10 +43,14 @@ export interface VideoInteraction {
   selectedTrackIds: ReadonlySet<string>;
   /** Track ids (= engine instanceIds) currently hovered. */
   hoveredTrackIds: ReadonlySet<string>;
-  /** Replace the selection with this track's current-frame occurrence. */
-  selectTrack: (instanceId: string) => void;
-  /** Set hover on this track's current-frame occurrence. */
-  hoverTrack: (instanceId: string, on: boolean) => void;
+  /**
+   * Replace the selection with this track's current-frame occurrence on the
+   * given frame field path (tracks span multiple fields, so the path is
+   * explicit — not assumed to be the detections field).
+   */
+  selectTrack: (instanceId: string, path: string) => void;
+  /** Set hover on this track's current-frame occurrence on the given path. */
+  hoverTrack: (instanceId: string, path: string, on: boolean) => void;
   /**
    * Select / hover a label by its exact engine ref. Used for sample-level
    * labels (temporal detections: addressed by `instanceId`, no frame) whose
@@ -82,34 +85,23 @@ export const useHoveredTrackIds = (): ReadonlySet<string> => {
 export const useVideoInteraction = (): VideoInteraction => {
   const engine = useAnnotationEngine();
   const actions = useSurfaceActions(engine, SURFACE);
-  const stream = useFrameLabelsStream();
   const getFrame = useCurrentFrameGetter();
 
   const selectedTrackIds = useSelectedTrackIds();
   const hoveredTrackIds = useHoveredTrackIds();
 
-  const path = stream ? `frames.${stream.labelsField}` : null;
-
   const selectTrack = useCallback(
-    (instanceId: string) => {
-      if (!path) {
-        return;
-      }
-
+    (instanceId: string, path: string) => {
       actions.setActive([{ path, instanceId, frame: getFrame() }]);
     },
-    [actions, path, getFrame]
+    [actions, getFrame]
   );
 
   const hoverTrack = useCallback(
-    (instanceId: string, on: boolean) => {
-      if (!path) {
-        return;
-      }
-
+    (instanceId: string, path: string, on: boolean) => {
       actions.setHovered({ path, instanceId, frame: getFrame() }, on);
     },
-    [actions, path, getFrame]
+    [actions, getFrame]
   );
 
   const selectLabel = useCallback(

--- a/app/packages/video-annotation/src/streams/framesData.test.ts
+++ b/app/packages/video-annotation/src/streams/framesData.test.ts
@@ -1,12 +1,16 @@
 /**
  * The `/frames` → flat-FramesData adapter: frame keying, the `frames.<field>`
- * path, element pass-through, `_id` normalization, and empty/absent fields.
+ * path, multi-field projection, element pass-through, `_id` normalization, and
+ * empty/absent fields.
  */
 
+import { LabelType } from "@fiftyone/utilities";
 import { describe, expect, it } from "vitest";
 
 import type { FrameDocLike } from "./framesData";
 import { parseFramesData } from "./framesData";
+
+const DETECTIONS = { "frames.detections": LabelType.Detections };
 
 const doc = (frame_number: number, detections: unknown[]): FrameDocLike => ({
   frame_number,
@@ -20,7 +24,7 @@ describe("parseFramesData", () => {
         doc(1, [{ _id: "d1", instance: { _id: "A", _cls: "Instance" } }]),
         doc(2, [{ _id: "d2", instance: { _id: "A", _cls: "Instance" } }]),
       ],
-      "detections"
+      DETECTIONS
     );
 
     expect(Object.keys(data)).toEqual(["1", "2"]);
@@ -35,10 +39,15 @@ describe("parseFramesData", () => {
     const data = parseFramesData(
       [
         doc(1, [
-          { _id: "d1", label: "car", bounding_box: [0, 0, 1, 1], mask: "m" },
+          {
+            _id: "d1",
+            label: "car",
+            bounding_box: [0, 0, 1, 1],
+            mask_path: "/p/m.png",
+          },
         ]),
       ],
-      "detections"
+      DETECTIONS
     );
 
     const el = data[1]["frames.detections"][0];
@@ -47,12 +56,41 @@ describe("parseFramesData", () => {
       _cls: "Detection",
       label: "car",
       bounding_box: [0, 0, 1, 1],
-      mask: "m",
+      mask_path: "/p/m.png",
+    });
+  });
+
+  it("projects multiple label fields per frame with the right child + _cls", () => {
+    const data = parseFramesData(
+      [
+        {
+          frame_number: 1,
+          detections: { detections: [{ _id: "d1", label: "car" }] },
+          polylines: {
+            polylines: [{ _id: "p1", points: [[[0, 0]]], closed: true }],
+          },
+        },
+      ],
+      {
+        "frames.detections": LabelType.Detections,
+        "frames.polylines": LabelType.Polylines,
+      }
+    );
+
+    expect(data[1]["frames.detections"][0]).toMatchObject({
+      _id: "d1",
+      _cls: "Detection",
+    });
+    expect(data[1]["frames.polylines"][0]).toMatchObject({
+      _id: "p1",
+      _cls: "Polyline",
+      points: [[[0, 0]]],
+      closed: true,
     });
   });
 
   it("normalizes _id from a raw `id` when `_id` is absent", () => {
-    const data = parseFramesData([doc(1, [{ id: "legacy" }])], "detections");
+    const data = parseFramesData([doc(1, [{ id: "legacy" }])], DETECTIONS);
 
     expect(data[1]["frames.detections"][0]._id).toBe("legacy");
   });
@@ -60,17 +98,14 @@ describe("parseFramesData", () => {
   it("respects a non-default per-frame field name", () => {
     const data = parseFramesData(
       [{ frame_number: 5, boxes: { detections: [{ _id: "d1" }] } }],
-      "boxes"
+      { "frames.boxes": LabelType.Detections }
     );
 
     expect(data[5]["frames.boxes"]).toHaveLength(1);
   });
 
-  it("emits an empty list for a fetched frame with no detections", () => {
-    const data = parseFramesData(
-      [{ frame_number: 3 }, doc(4, [])],
-      "detections"
-    );
+  it("emits an empty list for every registered field on a label-less frame", () => {
+    const data = parseFramesData([{ frame_number: 3 }, doc(4, [])], DETECTIONS);
 
     expect(data[3]["frames.detections"]).toEqual([]);
     expect(data[4]["frames.detections"]).toEqual([]);

--- a/app/packages/video-annotation/src/streams/framesData.ts
+++ b/app/packages/video-annotation/src/streams/framesData.ts
@@ -1,8 +1,10 @@
-import type { FramesData } from "@fiftyone/annotation";
-import type {
-  LabelData,
-  RawDetection,
-  RawDetectionsField,
+import { type FramesData, toSchemaField } from "@fiftyone/annotation";
+import {
+  type LabelData,
+  LabelType,
+  LIST_LABEL_CHILD,
+  type RawDetection,
+  type RawPolyline,
 } from "@fiftyone/utilities";
 
 /** The minimal `/frames` document shape this adapter reads. */
@@ -11,41 +13,99 @@ export interface FrameDocLike {
   [key: string]: unknown;
 }
 
+/** A raw `/frames` list element (detection or polyline). */
+type RawElement = RawDetection | RawPolyline;
+
+/**
+ * Singular element `_cls` for each per-frame list label type. The store
+ * addresses elements by their track `instance._id` and persists each frame's
+ * list by document `_id`, so every element needs the right `_cls` stamped.
+ */
+const ELEMENT_CLS: Partial<Record<LabelType, string>> = {
+  [LabelType.Detections]: "Detection",
+  [LabelType.Polylines]: "Polyline",
+};
+
+/** Per-field projection plan derived from the registered label types. */
+interface FieldSpec {
+  /** Sample-schema path the store addresses by (e.g. `frames.detections`). */
+  path: string;
+  /** In-frame-doc field the `/frames` payload carries (e.g. `detections`). */
+  perFrameField: string;
+  /** Child key holding the element list (e.g. `detections`, `polylines`). */
+  listChild: string;
+  /** Singular `_cls` stamped on each element (e.g. `Detection`). */
+  cls: string;
+}
+
 /**
  * Map the nested `/frames` payload into the flat {@link FramesData} the
- * {@link FrameStore} seeds from.
+ * {@link FrameStore} seeds from, across every registered per-frame label
+ * field.
  *
- * Each `/frames` document carries a `Detections`-shaped field
- * (`{ detections: [...] }`) under the frame-relative field name
- * (`perFrameField`, e.g. `detections`). The store addresses by the
- * sample-schema path (`frames.detections`) and holds the element list directly,
- * so this flattens `{ frame_number, <field>: { detections } }` to
- * `{ [frame_number]: { "frames.<field>": elements } }`.
+ * Each `/frames` document carries one embedded-list field per label type
+ * under its frame-relative name (`detections: { detections: [...] }`,
+ * `polylines: { polylines: [...] }`, …). The store addresses by the
+ * sample-schema path (`frames.detections`) and holds the element list
+ * directly, so this flattens `{ frame_number, <field>: { <child>: [...] } }`
+ * to `{ [frame_number]: { "frames.<field>": elements } }` for each field in
+ * `labelTypes`.
  *
- * Elements are passed through whole (mask, attributes, confidence, … survive
- * the round trip); only `_id`/`_cls` are normalized so the store can address by
- * the track's `instance._id` and persist each frame's list by document `_id`.
+ * Every registered path is written for every frame (defaulting to an empty
+ * list) so a frame with no labels reads as honestly empty — the delta path
+ * relies on that to detect removals. Elements pass through whole (mask,
+ * `mask_path`, points, attributes, … survive the round trip); only `_id`/
+ * `_cls` are normalized.
+ *
+ * @param docs - Cached `/frames` documents to project.
+ * @param labelTypes - Registered per-frame label fields → their list type
+ *   (the same map the {@link FrameStore} is constructed with).
  */
 export const parseFramesData = (
   docs: Iterable<FrameDocLike>,
-  perFrameField: string
+  labelTypes: Record<string, LabelType>
 ): FramesData => {
-  const path = `frames.${perFrameField}`;
+  const specs = toFieldSpecs(labelTypes);
   const out: FramesData = {};
 
   for (const doc of docs) {
-    const field = doc[perFrameField] as RawDetectionsField | undefined;
-    const detections = field?.detections ?? [];
+    const frame: Record<string, LabelData[]> = {};
 
-    out[doc.frame_number] = { [path]: detections.map(toLabelData) };
+    for (const spec of specs) {
+      const field = doc[spec.perFrameField] as
+        | Record<string, RawElement[] | undefined>
+        | undefined;
+      const elements = field?.[spec.listChild] ?? [];
+      frame[spec.path] = elements.map((el) => toLabelData(el, spec.cls));
+    }
+
+    out[doc.frame_number] = frame;
   }
 
   return out;
 };
 
-/** A raw `/frames` detection as store {@link LabelData}: stable `_id`, `_cls`. */
-const toLabelData = (det: RawDetection): LabelData => ({
-  ...det,
-  _id: det._id ?? det.id ?? "",
-  _cls: "Detection",
+/** Resolve each registered list field into a concrete projection plan. */
+const toFieldSpecs = (labelTypes: Record<string, LabelType>): FieldSpec[] => {
+  const specs: FieldSpec[] = [];
+
+  for (const [path, type] of Object.entries(labelTypes)) {
+    const listChild = LIST_LABEL_CHILD[type];
+    const cls = ELEMENT_CLS[type];
+
+    if (!listChild || !cls) {
+      continue;
+    }
+
+    specs.push({ path, perFrameField: toSchemaField(path), listChild, cls });
+  }
+
+  return specs;
+};
+
+/** A raw `/frames` element as store {@link LabelData}: stable `_id`, `_cls`. */
+const toLabelData = (el: RawElement, cls: string): LabelData => ({
+  ...el,
+  _id: el._id ?? el.id ?? "",
+  _cls: cls,
 });

--- a/app/packages/video-annotation/src/sync/useSyncLighterAnnotation.ts
+++ b/app/packages/video-annotation/src/sync/useSyncLighterAnnotation.ts
@@ -15,6 +15,11 @@ import { LabelType } from "@fiftyone/utilities";
 import { useCallback } from "react";
 import { useAnnotationContext } from "../../../core/src/components/Modal/Sidebar/Annotate/Edit/useAnnotationContext";
 import { useDetectionMode } from "../../../core/src/components/Modal/Sidebar/Annotate/Edit/useDetectionMode";
+import {
+  usePolylineMode,
+  usePolylineModeInstaller,
+} from "../../../core/src/components/Modal/Sidebar/Annotate/Edit/usePolylineMode";
+import { useSegmentationMode } from "../../../core/src/components/Modal/Sidebar/Annotate/Edit/useSegmentationMode";
 import useExit from "../../../core/src/components/Modal/Sidebar/Annotate/Edit/useExit";
 import { useVideoSurfaceActions } from "../hooks/useVideoSurfaceActions";
 import { useFrameLabelsStream } from "../streams/frameLabelsStream";
@@ -25,31 +30,42 @@ import { takeEstablishKey } from "./establishKeyRelay";
 /** Registers a handler for a Lighter event on the bridged scene's channel. */
 type RegisterLighterHandler = ReturnType<typeof useLighterEventHandler>;
 
+/** The create modes the top hook resolves once and injects into sub-hooks. */
+type DetectionMode = ReturnType<typeof useDetectionMode>;
+type SegmentationMode = ReturnType<typeof useSegmentationMode>;
+type PolylineMode = ReturnType<typeof usePolylineMode>;
+
 /** Schema-driven TD check: a field whose label type is a temporal detection. */
 const isTemporalDetectionType = (type: LabelType): boolean =>
   type === LabelType.TemporalDetection || type === LabelType.TemporalDetections;
 
 /**
- * Draw: a Lighter overlay create while detection mode is active opens a new
- * detection draft on the engine frame path.
+ * Draw: a Lighter overlay create opens a new draft on the engine frame path —
+ * a masked detection while segmentation mode is active, else a plain detection
+ * while detection mode is active. (Polylines self-create through their own
+ * creation handler — see {@link usePolylineModeInstaller}.)
  */
 const useRegisterDrawHandler = ({
   registerHandler,
+  detectionMode,
+  segmentationMode,
 }: {
   registerHandler: RegisterLighterHandler;
+  detectionMode: DetectionMode;
+  segmentationMode: SegmentationMode;
 }): void => {
-  const detectionMode = useDetectionMode();
-
   registerHandler(
     "lighter:overlay-create",
     useCallback(() => {
-      if (detectionMode.detectionModeActive) {
-        // The schema exposes the frame field at its real `frames.<field>` path,
-        // so default field resolution stamps it and the write routes to the
-        // FrameStore — no pinned destination needed.
+      // The schema exposes the frame field at its real `frames.<field>` path,
+      // so default field resolution stamps it and the write routes to the
+      // FrameStore — no pinned destination needed.
+      if (segmentationMode.segmentationModeActive) {
+        segmentationMode.create();
+      } else if (detectionMode.detectionModeActive) {
         detectionMode.create();
       }
-    }, [detectionMode])
+    }, [detectionMode, segmentationMode])
   );
 };
 
@@ -177,16 +193,22 @@ const useRegisterEditorTeardownHandler = ({
 };
 
 /**
- * Mode quit: right-click (`lighter:detection-mode-quit`) and Esc
- * (`lighter:active-mode-quit-requested`) both deactivate detection mode.
+ * Mode quit: right-click and Esc deactivate whichever create mode is active.
+ * `lighter:detection-mode-quit` / `lighter:segmentation-mode-quit` target their
+ * own mode; the generic `lighter:active-mode-quit-requested` self-filters across
+ * detection, segmentation, and polyline.
  */
 const useRegisterModeQuitHandlers = ({
   registerHandler,
+  detectionMode,
+  segmentationMode,
+  polylineMode,
 }: {
   registerHandler: RegisterLighterHandler;
+  detectionMode: DetectionMode;
+  segmentationMode: SegmentationMode;
+  polylineMode: PolylineMode;
 }): void => {
-  const detectionMode = useDetectionMode();
-
   registerHandler(
     "lighter:detection-mode-quit",
     useCallback(() => {
@@ -195,12 +217,31 @@ const useRegisterModeQuitHandlers = ({
   );
 
   registerHandler(
+    "lighter:segmentation-mode-quit",
+    useCallback(() => {
+      if (segmentationMode.segmentationModeActive) {
+        segmentationMode.deactivateSegmentationMode();
+      }
+    }, [segmentationMode])
+  );
+
+  registerHandler(
     "lighter:active-mode-quit-requested",
     useCallback(() => {
       if (detectionMode.detectionModeActive) {
         detectionMode.deactivateDetectionMode();
+        return;
       }
-    }, [detectionMode])
+
+      if (segmentationMode.segmentationModeActive) {
+        segmentationMode.deactivateSegmentationMode();
+        return;
+      }
+
+      if (polylineMode.polylineModeActive) {
+        polylineMode.deactivatePolylineMode();
+      }
+    }, [detectionMode, segmentationMode, polylineMode])
   );
 };
 
@@ -208,9 +249,11 @@ const useRegisterModeQuitHandlers = ({
  * Track deleted: deleting a track leaves no useful edit/draw state to keep open,
  * so tear detection mode down.
  */
-const useRegisterTrackDeletedHandler = (): void => {
-  const detectionMode = useDetectionMode();
-
+const useRegisterTrackDeletedHandler = ({
+  detectionMode,
+}: {
+  detectionMode: DetectionMode;
+}): void => {
   useAnnotationEventHandler(
     "annotation:trackDeleted",
     useCallback(() => {
@@ -224,10 +267,13 @@ const useRegisterTrackDeletedHandler = (): void => {
  * surface. Binds the scene's event channel and delegates each concern to a
  * tightly-scoped handler hook.
  *
- * Event-handler-only: state changes flow through the public `useDetectionMode`
- * interface rather than direct atom access, so this stays decoupled from that
- * module's internals. Sidebar membership is engine-derived (`useEntries` reads
- * engine presence), so nothing here pushes or prunes sidebar rows.
+ * Event-handler-only: state changes flow through the public mode interfaces
+ * (`useDetectionMode` / `useSegmentationMode` / `usePolylineMode`) rather than
+ * direct atom access, so this stays decoupled from those modules' internals.
+ * The modes are resolved once here (the binding agent) and injected — segmentation
+ * in particular installs a scene handler (`usePenTool`), so it must mount once.
+ * Sidebar membership is engine-derived (`useEntries` reads engine presence), so
+ * nothing here pushes or prunes sidebar rows.
  *
  * Canvas selection (`lighter:overlay-select` / `deselect`) is owned by the
  * engine's Lighter `frame-locked` bridge (`SurfaceController.selectHandle`),
@@ -243,9 +289,23 @@ export const useSyncLighterAnnotation = (scene: Scene2D | null): void => {
     scene?.getEventChannel() ?? UNDEFINED_LIGHTER_SCENE_ID
   );
 
-  useRegisterDrawHandler({ registerHandler });
+  const detectionMode = useDetectionMode();
+  const segmentationMode = useSegmentationMode();
+  const polylineMode = usePolylineMode();
+
+  useRegisterDrawHandler({ registerHandler, detectionMode, segmentationMode });
   useRegisterDrawEstablishHandler({ registerHandler });
   useRegisterEditorTeardownHandler({ registerHandler });
-  useRegisterModeQuitHandlers({ registerHandler });
-  useRegisterTrackDeletedHandler();
+  useRegisterModeQuitHandlers({
+    registerHandler,
+    detectionMode,
+    segmentationMode,
+    polylineMode,
+  });
+  useRegisterTrackDeletedHandler({ detectionMode });
+
+  // Polylines self-create through an InteractiveCreationHandler the installer
+  // mounts on the scene (the image surface gets this via `useBridge`); without
+  // it polyline mode toggles but a canvas click draws nothing.
+  usePolylineModeInstaller();
 };

--- a/app/packages/video-annotation/src/tracks/frameTracks.test.ts
+++ b/app/packages/video-annotation/src/tracks/frameTracks.test.ts
@@ -10,10 +10,12 @@ const FPS = 30;
 const SAMPLE = "sample-1";
 const PATH = "frames.detections";
 
+type ColorResolver = (l: PerInstanceLabel, path: string) => string;
+
 /**
  * Minimal engine stub: `buildPerInstanceTracks` only calls
  * `listLabels({ sample, path, frame })`. `frames` maps a 1-indexed frame
- * number to the labels the engine projects for it.
+ * number to the labels the engine projects for it (path-agnostic).
  */
 function makeEngine(frames: Record<number, LabelData[]>): FrameLabelReader {
   return {
@@ -21,15 +23,27 @@ function makeEngine(frames: Record<number, LabelData[]>): FrameLabelReader {
   };
 }
 
+/**
+ * Path-aware engine stub for multi-field tests: `byPath` maps a field path to
+ * its per-frame labels.
+ */
+function makeMultiFieldEngine(
+  byPath: Record<string, Record<number, LabelData[]>>
+): FrameLabelReader {
+  return {
+    listLabels: ({ path, frame }) => (frame ? byPath[path]?.[frame] ?? [] : []),
+  };
+}
+
 function build(
   totalFrames: number,
   frames: Record<number, LabelData[]>,
-  resolveColor: (l: PerInstanceLabel) => string = () => "#fff"
+  resolveColor: ColorResolver = () => "#fff"
 ) {
   return buildPerInstanceTracks({
     engine: makeEngine(frames),
     sample: SAMPLE,
-    path: PATH,
+    paths: [PATH],
     totalFrames,
     fps: FPS,
     resolveColor,
@@ -50,17 +64,20 @@ describe("buildPerInstanceTracks", () => {
       keyframe: false,
     };
 
-    const resolveColor = vi.fn<(l: PerInstanceLabel) => string>(() => "#fff");
+    const resolveColor = vi.fn<ColorResolver>(() => "#fff");
     const tracks = build(2, { 1: [det], 2: [det] }, resolveColor);
 
     expect(tracks).toHaveLength(1);
     // Track id IS the engine instanceId (instance._id), no synthetic prefix.
     expect(tracks[0].id).toBe("abc123");
-    expect(resolveColor).toHaveBeenCalledWith({
-      label: "person",
-      index: 7,
-      instance: { _cls: "Instance", _id: "abc123" },
-    });
+    expect(resolveColor).toHaveBeenCalledWith(
+      {
+        label: "person",
+        index: 7,
+        instance: { _cls: "Instance", _id: "abc123" },
+      },
+      PATH
+    );
     // Display text still uses the persisted index as the ordinal.
     expect(tracks[0].label).toBe("person 7");
   });
@@ -74,15 +91,18 @@ describe("buildPerInstanceTracks", () => {
       keyframe: false,
     };
 
-    const resolveColor = vi.fn<(l: PerInstanceLabel) => string>(() => "#fff");
+    const resolveColor = vi.fn<ColorResolver>(() => "#fff");
     const tracks = build(1, { 1: [det] }, resolveColor);
 
     expect(tracks[0].id).toBe("doc-3");
-    expect(resolveColor).toHaveBeenCalledWith({
-      label: "vehicle",
-      index: 3,
-      instance: null,
-    });
+    expect(resolveColor).toHaveBeenCalledWith(
+      {
+        label: "vehicle",
+        index: 3,
+        instance: null,
+      },
+      PATH
+    );
   });
 
   it("assigns instance-only ordinals as the next free integer above the per-class max", () => {
@@ -104,6 +124,46 @@ describe("buildPerInstanceTracks", () => {
 
     // Sorted by ordinal: persisted 3, then the next free (4).
     expect(tracks.map((t) => t.label)).toEqual(["person 3", "person 4"]);
+  });
+
+  it("builds a track per instance across multiple fields, colored by each field's path", () => {
+    const POLY_PATH = "frames.polylines";
+    const box: LabelData = {
+      _id: "doc-box",
+      _cls: "Detection",
+      label: "vehicle",
+      index: 1,
+      instance: { _cls: "Instance", _id: "box-inst" },
+    };
+    const poly: LabelData = {
+      _id: "doc-poly",
+      _cls: "Polyline",
+      label: "lane",
+      index: 1,
+      instance: { _cls: "Instance", _id: "poly-inst" },
+    };
+
+    const resolveColor = vi.fn<ColorResolver>((_l, path) =>
+      path === POLY_PATH ? "#0f0" : "#00f"
+    );
+
+    const tracks = buildPerInstanceTracks({
+      engine: makeMultiFieldEngine({
+        [PATH]: { 1: [box] },
+        [POLY_PATH]: { 1: [poly] },
+      }),
+      sample: SAMPLE,
+      paths: [PATH, POLY_PATH],
+      totalFrames: 1,
+      fps: FPS,
+      resolveColor,
+    });
+
+    expect(tracks.map((t) => t.id).sort()).toEqual(["box-inst", "poly-inst"]);
+    const byId = Object.fromEntries(tracks.map((t) => [t.id, t]));
+    // Each row's color comes from its own field path.
+    expect(byId["box-inst"].color).toBe("#00f");
+    expect(byId["poly-inst"].color).toBe("#0f0");
   });
 
   it("emits one presence interval per contiguous run", () => {

--- a/app/packages/video-annotation/src/tracks/frameTracks.ts
+++ b/app/packages/video-annotation/src/tracks/frameTracks.ts
@@ -5,9 +5,31 @@ import type { LabelData } from "@fiftyone/utilities";
 /** The engine read surface this builder needs — one frame's labels at a time. */
 export type FrameLabelReader = Pick<AnnotationEngine, "listLabels">;
 
+/**
+ * Payload attached to each object track's {@link TrackEvent.data}. Carries the
+ * engine field path the row's instance lives on so a row click / hover can
+ * address the right `(path, instanceId)` ref — tracks span multiple frame
+ * fields (detections, polylines), so the path can't be assumed.
+ */
+export interface ObjectTrackEventData {
+  path: string;
+}
+
+/**
+ * The engine field path an object track's instance lives on, read off its
+ * event payload. `null` for a TD row (whose data is a
+ * {@link TemporalDetectionEventData}) or any row without the payload.
+ */
+export const objectTrackPathOf = (track: Track): string | null => {
+  const data = track.events[0]?.data as ObjectTrackEventData | undefined;
+  return typeof data?.path === "string" ? data.path : null;
+};
+
 interface InstanceState {
   /** Class label observed for this instance (e.g. "person"). */
   classLabel: string;
+  /** Engine field path the instance lives on (e.g. `frames.polylines`). */
+  path: string;
   /**
    * Persisted track index carried on the underlying detection, when
    * present. Undefined for freshly-drawn instances that haven't been
@@ -53,17 +75,27 @@ export interface PerInstanceLabel {
   instance?: { _cls: "Instance"; _id?: string } | null;
 }
 
+/** Resolve a row's color from its label and the field path it lives on. */
+export type PerInstanceColorResolver = (
+  label: PerInstanceLabel,
+  path: string
+) => string;
+
 export interface BuildPerInstanceTracksInput {
   engine: FrameLabelReader;
   /** Sample whose frame labels back the timeline. */
   sample: string;
-  /** Frame-agnostic detection field path (e.g. `frames.detections`). */
-  path: string;
+  /**
+   * Frame-agnostic label field paths to project (e.g. `frames.detections`,
+   * `frames.polylines`). Each instance keys by its `instance._id`, unique
+   * across fields, so the per-field walks merge into one set of tracks.
+   */
+  paths: string[];
   /** Total frames in the clip — the walk range `[1, totalFrames]`. */
   totalFrames: number;
   /** Frame rate, for the frame↔seconds mapping. */
   fps: number;
-  resolveColor: (label: PerInstanceLabel) => string;
+  resolveColor: PerInstanceColorResolver;
 }
 
 /** Track identity is `instance._id`; fall back to the doc `_id` (legacy). */
@@ -106,7 +138,7 @@ const instanceOf = (
 export function buildPerInstanceTracks({
   engine,
   sample,
-  path,
+  paths,
   totalFrames,
   fps,
   resolveColor,
@@ -115,7 +147,7 @@ export function buildPerInstanceTracks({
     return [];
   }
 
-  const states = accumulatePresence(engine, sample, path, totalFrames, fps);
+  const states = accumulatePresence(engine, sample, paths, totalFrames, fps);
   assignDisplayOrdinals(states);
 
   const tracks: Track[] = [];
@@ -141,9 +173,10 @@ function closeInterval(state: InstanceState, endSec: number): void {
   state.inFrame = false;
 }
 
-function newInstanceState(label: LabelData): InstanceState {
+function newInstanceState(label: LabelData, path: string): InstanceState {
   return {
     classLabel: labelOf(label),
+    path,
     persistedIndex: indexOf(label),
     instance: instanceOf(label),
     // Placeholder — overwritten by `assignDisplayOrdinals` once every
@@ -163,7 +196,7 @@ function newInstanceState(label: LabelData): InstanceState {
 function accumulatePresence(
   engine: FrameLabelReader,
   sample: string,
-  path: string,
+  paths: string[],
   totalFrames: number,
   fps: number
 ): Map<string, InstanceState> {
@@ -173,23 +206,25 @@ function accumulatePresence(
     const frameStartSec = (frame - 1) / fps;
     const present = new Set<string>();
 
-    for (const label of engine.listLabels({ sample, path, frame })) {
-      const id = addressIdOf(label);
-      present.add(id);
+    for (const path of paths) {
+      for (const label of engine.listLabels({ sample, path, frame })) {
+        const id = addressIdOf(label);
+        present.add(id);
 
-      let state = states.get(id);
-      if (!state) {
-        state = newInstanceState(label);
-        states.set(id, state);
-      }
+        let state = states.get(id);
+        if (!state) {
+          state = newInstanceState(label, path);
+          states.set(id, state);
+        }
 
-      if (!state.inFrame) {
-        state.currentStart = frameStartSec;
-        state.inFrame = true;
-      }
+        if (!state.inFrame) {
+          state.currentStart = frameStartSec;
+          state.inFrame = true;
+        }
 
-      if (label.keyframe) {
-        state.keyframeTimes.push(frameStartSec);
+        if (label.keyframe) {
+          state.keyframeTimes.push(frameStartSec);
+        }
       }
     }
 
@@ -245,8 +280,12 @@ function assignDisplayOrdinals(states: Map<string, InstanceState>): void {
 function toTrack(
   id: string,
   state: InstanceState,
-  resolveColor: (label: PerInstanceLabel) => string
+  resolveColor: PerInstanceColorResolver
 ): Track {
+  // Every event carries the field path so a row's click / hover resolves the
+  // correct `(path, instanceId)` ref regardless of which frame field it's on.
+  const data: ObjectTrackEventData = { path: state.path };
+
   const events: TrackEvent[] = [
     // `resizable: true` opts each presence bar into in-place edit — drag
     // handles to extend/trim the track, drag the body to shift it. Inert
@@ -257,6 +296,7 @@ function toTrack(
         endSec: end,
         label: "in frame",
         resizable: true,
+        data,
       })
     ),
     // Point events render as diamond markers on top of the presence bar
@@ -264,6 +304,7 @@ function toTrack(
     ...state.keyframeTimes.map((startSec) => ({
       startSec,
       label: "Keyframe",
+      data,
     })),
   ];
 
@@ -271,11 +312,14 @@ function toTrack(
     id,
     label: `${state.classLabel} ${state.displayIndex}`,
     description: `Tracked "${state.classLabel}" (track ${state.displayIndex})`,
-    color: resolveColor({
-      label: state.classLabel,
-      index: state.persistedIndex,
-      instance: state.instance,
-    }),
+    color: resolveColor(
+      {
+        label: state.classLabel,
+        index: state.persistedIndex,
+        instance: state.instance,
+      },
+      state.path
+    ),
     events,
   };
 }

--- a/app/packages/video-annotation/src/tracks/useVideoTrackDecorator.ts
+++ b/app/packages/video-annotation/src/tracks/useVideoTrackDecorator.ts
@@ -6,6 +6,7 @@ import type { Track } from "@fiftyone/playback";
 import clsx from "clsx";
 import { useCallback } from "react";
 import { useVideoInteraction } from "../state/useVideoInteraction";
+import { objectTrackPathOf } from "./frameTracks";
 import { temporalDetectionRefOf } from "./temporalDetectionTracks";
 import styles from "../components/VideoAnnotationSurface.module.css";
 
@@ -62,14 +63,18 @@ export const useVideoTrackDecorator = (): ((
         };
       }
 
+      // An object row addresses `(path, instanceId)` — the path is the field
+      // the track lives on (detections / polylines), carried on its events.
+      const path = objectTrackPathOf(track);
+
       return {
         className: clsx({
           [styles.linkHovered]: hoveredTrackIds.has(track.id),
           [styles.linkSelected]: selectedTrackIds.has(track.id),
         }),
-        onMouseEnter: () => hoverTrack(track.id, true),
-        onMouseLeave: () => hoverTrack(track.id, false),
-        onTrackClick: () => selectTrack(track.id),
+        onMouseEnter: () => path && hoverTrack(track.id, path, true),
+        onMouseLeave: () => path && hoverTrack(track.id, path, false),
+        onTrackClick: () => path && selectTrack(track.id, path),
       };
     },
     [

--- a/e2e-pw/src/oss/fixtures/video-annotate-sdk.ts
+++ b/e2e-pw/src/oss/fixtures/video-annotate-sdk.ts
@@ -22,6 +22,27 @@ export interface SeedVideoAnnotationOptions {
    * existing track. Defaults to none (a clean slate, like `va-demo-bare`).
    */
   trackedSampleIndices?: number[];
+  /**
+   * Subset of {@link trackedSampleIndices} whose tracked detection should also
+   * carry an instance mask (a full `np.ones` mask) on every frame, so tests can
+   * confirm detection masks render / decode on the video surface. Seeded via a
+   * real `fo.Detection` so the mask encoder ships the decodable form.
+   */
+  maskedSampleIndices?: number[];
+  /**
+   * Sample indices that should carry a pre-seeded polyline track (a single
+   * instance, `index=2`, class `classes[1]`, a closed triangle on every frame)
+   * plus a declared `frames.polylines` field and an active polylines schema.
+   * Defaults to none.
+   */
+  polylineSampleIndices?: number[];
+  /**
+   * Declare the `frames.polylines` field + activate its schema (and seed
+   * empty-but-present polylines on every frame) WITHOUT pre-seeding any track.
+   * Lets a clean-slate create test enter polyline mode and draw the first
+   * polyline. Implied true whenever {@link polylineSampleIndices} is non-empty.
+   */
+  withPolylineField?: boolean;
 }
 
 /**
@@ -46,15 +67,22 @@ export class VideoAnnotateSDK {
       eventClasses = ["approach", "pass", "depart"],
       withEvents = true,
       trackedSampleIndices = [],
+      maskedSampleIndices = [],
+      polylineSampleIndices = [],
+      withPolylineField = false,
     } = options;
 
     const pyPaths = JSON.stringify(videoPaths);
     const pyClasses = JSON.stringify(classes);
     const pyEventClasses = JSON.stringify(eventClasses);
     const pyTracked = JSON.stringify(trackedSampleIndices);
+    const pyMasked = JSON.stringify(maskedSampleIndices);
+    const pyPolyline = JSON.stringify(polylineSampleIndices);
+    const pyWithPolylineField = withPolylineField ? "True" : "False";
 
     return this.loader.executePythonCode(`
 import fiftyone as fo
+import numpy as np
 from bson import ObjectId
 
 VIDEO_PATHS = ${pyPaths}
@@ -62,8 +90,15 @@ CLASSES = ${pyClasses}
 EVENT_CLASSES = ${pyEventClasses}
 WITH_EVENTS = ${withEvents ? "True" : "False"}
 TRACKED = set(${pyTracked})
+MASKED = set(${pyMasked})
+POLYLINE_TRACKED = set(${pyPolyline})
+# Declare + activate the polylines field whenever a track is seeded OR a
+# clean-slate polyline-create test asked for the schema only.
+POLYLINE_SCHEMA = bool(POLYLINE_TRACKED) or ${pyWithPolylineField}
 DETECTIONS_FIELD = "detections"
 FRAME_DETECTIONS_PATH = "frames." + DETECTIONS_FIELD
+POLYLINES_FIELD = "polylines"
+FRAME_POLYLINES_PATH = "frames." + POLYLINES_FIELD
 EVENTS_FIELD = "events"
 
 if fo.dataset_exists("${datasetName}"):
@@ -97,6 +132,17 @@ dataset.add_frame_field(
 dataset.add_frame_field("detections.detections.keyframe", fo.BooleanField)
 dataset.add_frame_field("detections.detections.propagation", fo.DictField)
 
+# Per-frame Polylines container (declared when polyline tracks are seeded or a
+# clean-slate create test asked for the polylines schema).
+if POLYLINE_SCHEMA:
+    dataset.add_frame_field(
+        POLYLINES_FIELD,
+        fo.EmbeddedDocumentField,
+        embedded_doc_type=fo.Polylines,
+    )
+    dataset.add_frame_field("polylines.polylines.keyframe", fo.BooleanField)
+    dataset.add_frame_field("polylines.polylines.propagation", fo.DictField)
+
 # (4) sample-level TemporalDetections field.
 dataset.add_sample_field(
     EVENTS_FIELD, fo.EmbeddedDocumentField, embedded_doc_type=fo.TemporalDetections
@@ -123,10 +169,12 @@ for sample in dataset.iter_samples(progress=False, autosave=True):
         sample.frames[fn]["detections"] = fo.Detections(detections=[])
 
 # Pre-seed a tracked detection on requested samples (one instance, index=1,
-# class CLASSES[0], on every frame).
+# class CLASSES[0], on every frame). Samples in MASKED also carry a full
+# instance mask so detection-mask rendering can be exercised.
 for idx, sample in enumerate(dataset.iter_samples(progress=False, autosave=True)):
     if idx not in TRACKED:
         continue
+    mask = np.ones((20, 20), dtype=bool) if idx in MASKED else None
     for fn in range(1, total_frames(sample) + 1):
         sample.frames[fn]["detections"] = fo.Detections(
             detections=[
@@ -134,9 +182,34 @@ for idx, sample in enumerate(dataset.iter_samples(progress=False, autosave=True)
                     label=CLASSES[0],
                     bounding_box=[0.3, 0.3, 0.2, 0.2],
                     index=1,
+                    mask=mask,
                 )
             ]
         )
+
+# Pre-seed a polyline track on requested samples (one instance, index=2,
+# class CLASSES[1], a closed triangle on every frame). Every frame gets an
+# empty (present) Polylines first so the seed and any later append line up.
+if POLYLINE_SCHEMA:
+    for idx, sample in enumerate(
+        dataset.iter_samples(progress=False, autosave=True)
+    ):
+        for fn in range(1, total_frames(sample) + 1):
+            sample.frames[fn]["polylines"] = fo.Polylines(polylines=[])
+        if idx not in POLYLINE_TRACKED:
+            continue
+        for fn in range(1, total_frames(sample) + 1):
+            sample.frames[fn]["polylines"] = fo.Polylines(
+                polylines=[
+                    fo.Polyline(
+                        label=CLASSES[1],
+                        points=[[[0.2, 0.2], [0.5, 0.2], [0.35, 0.5]]],
+                        closed=True,
+                        filled=False,
+                        index=2,
+                    )
+                ]
+            )
 
 # (5) demo temporal events (approach / pass / depart thirds).
 if WITH_EVENTS:
@@ -152,24 +225,27 @@ if WITH_EVENTS:
             ]
         )
 
-# (6) stable cross-frame Instance per (label, index) track, per sample.
+# (6) stable cross-frame Instance per (label, index) track, per sample —
+# across both the detection and polyline lists.
 for sample in dataset.iter_samples(progress=False, autosave=True):
     by_track = {}
     for frame in sample.frames.values():
-        dets = frame.detections
-        if dets is None:
-            continue
-        for det in dets.detections:
-            if det.index is None:
+        elements = []
+        if frame.detections is not None:
+            elements.extend(frame.detections.detections)
+        if POLYLINE_TRACKED and frame.polylines is not None:
+            elements.extend(frame.polylines.polylines)
+        for label in elements:
+            if label.index is None:
                 continue
-            key = (det.label, det.index)
+            key = (type(label).__name__, label.label, label.index)
             inst = by_track.get(key)
             if inst is None:
                 inst = fo.Instance()
                 by_track[key] = inst
-            current = getattr(det, "instance", None)
+            current = getattr(label, "instance", None)
             if current is None or current.id != inst.id:
-                det.instance = inst
+                label.instance = inst
 
 # Active annotation schemas: frames.detections + events.
 det_schema = {
@@ -188,6 +264,24 @@ dataset.update_label_schema(
     FRAME_DETECTIONS_PATH, det_schema, allow_new_attrs=True
 )
 dataset.active_label_schemas = [FRAME_DETECTIONS_PATH]
+
+# Active polylines schema (whenever the polylines field is declared).
+if POLYLINE_SCHEMA:
+    poly_schema = {
+        "type": "polylines",
+        "component": "dropdown",
+        "attributes": [
+            {"name": "id", "type": "id", "component": "text", "read_only": True},
+            {"name": "index", "type": "int", "component": "text"},
+        ],
+        "classes": CLASSES,
+    }
+    dataset.update_label_schema(
+        FRAME_POLYLINES_PATH, poly_schema, allow_new_attrs=True
+    )
+    dataset.active_label_schemas = dataset.active_label_schemas + [
+        FRAME_POLYLINES_PATH
+    ]
 
 events_schema = {
     "type": "temporaldetections",

--- a/e2e-pw/src/oss/poms/modal/annotate-edit.ts
+++ b/e2e-pw/src/oss/poms/modal/annotate-edit.ts
@@ -213,6 +213,11 @@ export class ModalAnnotateEditPom {
     return this.page.getByRole("button", { name: "Brush" });
   }
 
+  /** Select the Brush tool from the segmentation toolbar (mask painting). */
+  async selectBrushTool() {
+    await this.segmentationBrushTool.click();
+  }
+
   /**
    * The segmentation Merge tool button (present while segmentation mode is
    * active; disabled until there are ≥2 masked detections in the field).
@@ -259,6 +264,25 @@ class ModalAnnotateEditAsserter {
   async verifyFieldValue(path: string, expectedValue: string) {
     const actualValue = await this.modalAnnotateEdit.getFieldValue(path);
     expect(actualValue).toBe(expectedValue);
+  }
+
+  /**
+   * Assert whether the sidebar renders the mask preview for the edited
+   * detection. The preview only mounts when the selected label resolves to a
+   * live `DetectionOverlay` with a mask, so its presence proves the row found
+   * the mask-bearing overlay (not a maskless stub).
+   *
+   * @param visible Whether the mask preview is expected to be shown
+   */
+  async hasMaskPreview(visible = true) {
+    const preview = this.modalAnnotateEdit.page.getByTestId(
+      "annotate-mask-preview"
+    );
+    if (visible) {
+      await expect(preview).toBeVisible();
+    } else {
+      await expect(preview).toBeHidden();
+    }
   }
 
   /**

--- a/e2e-pw/src/oss/poms/modal/annotate-sidebar.ts
+++ b/e2e-pw/src/oss/poms/modal/annotate-sidebar.ts
@@ -145,6 +145,16 @@ export class ModalAnnotateSidebarPom {
       await this.page.getByTestId("detection-mode").click();
     }
   }
+
+  /** Activate polyline-drawing mode (the Polyline action button). */
+  async polylineMode() {
+    await this.page.getByTestId("polyline-mode").click();
+  }
+
+  /** Activate segmentation (mask-paint) mode (the Segmentation action button). */
+  async segmentationMode() {
+    await this.page.getByTestId("segmentation-mode").click();
+  }
 }
 
 /**
@@ -273,9 +283,7 @@ class ModalAnnotateSidebarAsserter {
    * @param active Whether detection mode should be active (default true)
    */
   async detectionModeIsActive(active = true) {
-    const button = this.modalAnnotateSidebar.page.getByTestId(
-      "detection-mode"
-    );
+    const button = this.modalAnnotateSidebar.page.getByTestId("detection-mode");
     await expect(button).toHaveAttribute("data-cy-active", active.toString());
   }
 }

--- a/e2e-pw/src/oss/poms/modal/video-annotate.ts
+++ b/e2e-pw/src/oss/poms/modal/video-annotate.ts
@@ -147,6 +147,39 @@ export class VideoAnnotatePom {
   }
 
   /**
+   * Draw a polyline by clicking each vertex on the canvas (polyline mode must
+   * already be active). The first click seeds a new polyline via the creation
+   * handler; each subsequent click extends it from the nearest endpoint.
+   *
+   * @param vertices Container-relative [0, 1] points, one per vertex.
+   */
+  async drawPolyline(vertices: Array<[number, number]>) {
+    for (const [x, y] of vertices) {
+      await this.modal.sampleCanvas.click(x, y);
+    }
+  }
+
+  /**
+   * Paint a mask brush stroke on the canvas (segmentation mode + the Brush tool
+   * must already be active). With nothing selected the stroke's first move
+   * creates a fresh masked detection, then paints onto it.
+   *
+   * @param path Container-relative [0, 1] points; the first is the press point,
+   *   the rest are drag positions before release.
+   */
+  async paintMaskStroke(path: Array<[number, number]>) {
+    const [first, ...rest] = path;
+    await this.modal.sampleCanvas.move(first[0], first[1]);
+    await this.modal.sampleCanvas.down();
+
+    for (const [x, y] of rest) {
+      await this.modal.sampleCanvas.move(x, y);
+    }
+
+    await this.modal.sampleCanvas.up();
+  }
+
+  /**
    * Create a temporal detection at the current playhead via the "New TD"
    * toolbar action (a 1-second support window starting at the playhead frame).
    */

--- a/e2e-pw/src/oss/specs/MISSING-annotate-video-label-types-create.spec.ts
+++ b/e2e-pw/src/oss/specs/MISSING-annotate-video-label-types-create.spec.ts
@@ -1,0 +1,174 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ *
+ * Create round-trip for non-box label types on the video-annotation surface:
+ * drawing a polyline and painting an instance mask each add a track, open the
+ * edit form, commit through the engine on class assignment, and survive a true
+ * round-trip (fresh browser context).
+ *
+ * The video surface wires these the same way the image surface does, but
+ * through its own bridge: polylines self-create via the
+ * `usePolylineModeInstaller` creation handler; a brush stroke with nothing
+ * selected fires `lighter:overlay-create`, which opens a fresh masked detection
+ * (segmentation mode) on the engine frame path. Detection-box draw is covered
+ * separately (`MISSING-annotate-video-draw.spec.ts`).
+ */
+import { Browser, expect, test as base, type Page } from "src/oss/fixtures";
+import { ModalPom } from "src/oss/poms/modal";
+import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
+import { EventUtils } from "src/shared/event-utils";
+import type { AbstractFiftyoneLoader } from "src/shared/abstract-loader";
+
+const datasetName = getUniqueDatasetNameWithPrefix(
+  "annotate-video-label-types-create"
+);
+
+/** Fixed ObjectId addressing the first sample (so we can deep-link the modal). */
+const id = "000000000000000000000000";
+const clip = `/tmp/${datasetName}.webm`;
+
+const test = base.extend<{ modal: ModalPom }>({
+  modal: async ({ page, eventUtils }, use) => {
+    await use(new ModalPom(page, eventUtils));
+  },
+});
+
+test.beforeAll(async ({ foWebServer, mediaFactory, videoAnnotateSDK }) => {
+  await foWebServer.startWebServer();
+  await mediaFactory.createVideo({
+    outputPath: clip,
+    duration: 2,
+    width: 64,
+    height: 64,
+    frameRate: 10,
+    color: "#3050a0",
+  });
+  // clean slate (no pre-seeded tracks) but with the polylines field + schema
+  // active, so polyline create mode is enterable and the first draw can append.
+  await videoAnnotateSDK.seed({
+    datasetName,
+    videoPaths: [clip],
+    withPolylineField: true,
+  });
+});
+
+test.afterAll(async ({ foWebServer }) => {
+  await foWebServer.stopWebServer();
+});
+
+/** Open the modal in annotate mode on the deep-linked video sample. */
+const openAnnotate = async (
+  fiftyoneLoader: AbstractFiftyoneLoader,
+  modal: ModalPom,
+  page: Page
+) => {
+  await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
+    searchParams: new URLSearchParams({ id }),
+  });
+  await modal.assert.isOpen();
+  await modal.sidebar.switchMode("annotate");
+  await modal.videoAnnotate.waitForSurface();
+};
+
+/** Verify persisted state from a brand-new browser context (true round-trip). */
+const inFreshContext = async (
+  browser: Browser,
+  fiftyoneLoader: AbstractFiftyoneLoader,
+  verify: (modal: ModalPom) => Promise<void>
+) => {
+  const context = await browser.newContext();
+  const freshPage = await context.newPage();
+  try {
+    const freshModal = new ModalPom(freshPage, new EventUtils(freshPage));
+    await openAnnotate(fiftyoneLoader, freshModal, freshPage);
+    await verify(freshModal);
+  } finally {
+    await context.close();
+  }
+};
+
+/** A sample-mutating autosave (the engine commit that persists the draw). */
+const savedSample = (page: Page) =>
+  page.waitForResponse(
+    (r) =>
+      /\/sample\//.test(r.url()) &&
+      ["POST", "PATCH", "PUT"].includes(r.request().method())
+  );
+
+test.describe.serial("video non-box label create", () => {
+  test("drawing a polyline adds a track, assigns a class, and persists", async ({
+    browser,
+    fiftyoneLoader,
+    modal,
+    page,
+  }) => {
+    await openAnnotate(fiftyoneLoader, modal, page);
+
+    // capture the live count first — earlier tests persist, so siblings can't
+    // assume a clean slate.
+    const before = (await modal.videoAnnotate.objectTrackIds()).length;
+
+    await modal.sidebar.annotate.polylineMode();
+    await modal.videoAnnotate.drawPolyline([
+      [0.45, 0.45],
+      [0.6, 0.45],
+      [0.52, 0.6],
+    ]);
+
+    // the draw creates exactly one new object track on the timeline
+    await modal.videoAnnotate.assert.objectTrackCount(before + 1);
+
+    // the freshly-drawn polyline opens its edit form; assigning a class commits
+    const saved = savedSample(page);
+    await modal.sidebar.edit.selectFieldChoice("label", "person");
+    await modal.sidebar.edit.assert.verifyFieldValue("label", "person");
+    await saved;
+
+    // the polyline frame label survives a true round-trip — exactly one object
+    // track persists on the clean-slate timeline (the class is verified live
+    // above; a single-frame polyline isn't reliably playhead-listed on reload).
+    await inFreshContext(browser, fiftyoneLoader, async (freshModal) => {
+      await freshModal.videoAnnotate.assert.objectTrackCount(before + 1);
+    });
+  });
+
+  test("painting a mask adds a track, assigns a class, and persists", async ({
+    browser,
+    fiftyoneLoader,
+    modal,
+    page,
+  }) => {
+    await openAnnotate(fiftyoneLoader, modal, page);
+
+    const before = (await modal.videoAnnotate.objectTrackIds()).length;
+
+    await modal.sidebar.annotate.segmentationMode();
+    await modal.sidebar.edit.selectBrushTool();
+    await modal.videoAnnotate.paintMaskStroke([
+      [0.4, 0.4],
+      [0.48, 0.48],
+      [0.56, 0.56],
+    ]);
+
+    // the paint creates exactly one new masked-detection track
+    await modal.videoAnnotate.assert.objectTrackCount(before + 1);
+
+    // the new detection carries a mask, and assigning a class commits it
+    await modal.sidebar.edit.assert.hasMask(true);
+    // the sidebar mask preview renders — proving the open form resolved the
+    // live masked overlay by the track's instance id, not a maskless stub
+    await modal.sidebar.edit.assert.hasMaskPreview(true);
+    const saved = savedSample(page);
+    await modal.sidebar.edit.selectFieldChoice("label", "vehicle");
+    await modal.sidebar.edit.assert.verifyFieldValue("label", "vehicle");
+    await saved;
+
+    // the masked detection survives a true round-trip with its mask intact
+    await inFreshContext(browser, fiftyoneLoader, async (freshModal) => {
+      await freshModal.videoAnnotate.assert.objectTrackCount(before + 1);
+      await freshModal.videoAnnotate.selectLabel("vehicle");
+      await freshModal.sidebar.edit.assert.hasMask(true);
+      await freshModal.sidebar.edit.assert.hasMaskPreview(true);
+    });
+  });
+});

--- a/e2e-pw/src/oss/specs/MISSING-annotate-video-label-types.spec.ts
+++ b/e2e-pw/src/oss/specs/MISSING-annotate-video-label-types.spec.ts
@@ -1,0 +1,155 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ *
+ * Rendering of non-box label types on the video-annotation surface. A sample is
+ * seeded with TWO existing per-frame tracks — a detection carrying an instance
+ * mask, and a polyline — across two active `frames.*` label fields. Both must
+ * render: the multi-field frame seed registers every active per-frame label
+ * field (not just `frames.detections`) with its real `LabelType`, so the engine
+ * holds polylines + masks and the surface-agnostic engine→lighter bridge paints
+ * them and the sidebar lists them.
+ *
+ * Read signals (semantic, engine-derived):
+ *   - the sidebar lists a row per present label across ALL active frame fields
+ *     (`useEntries` walks `engine.getPresent()` filtered by active schema +
+ *     a known `getLabelType`) — a polyline only lists when its field is
+ *     registered + seeded, so listing it proves the multi-field seed.
+ *   - mask presence is read off the label menu (`Edit/Header.tsx`): "Remove
+ *     mask" for a masked detection, "Add mask" for a maskless one.
+ *
+ * Create/paint round-trips (drawing a polyline, painting a mask) live in
+ * `MISSING-annotate-video-label-types-create.spec.ts`.
+ */
+import { expect, test as base, type Page } from "src/oss/fixtures";
+import { ModalPom } from "src/oss/poms/modal";
+import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
+import type { AbstractFiftyoneLoader } from "src/shared/abstract-loader";
+
+const datasetName = getUniqueDatasetNameWithPrefix(
+  "annotate-video-label-types"
+);
+
+/** Fixed ObjectId addressing the first sample (so we can deep-link the modal). */
+const id = "000000000000000000000000";
+const clip = `/tmp/${datasetName}.webm`;
+
+const test = base.extend<{ modal: ModalPom }>({
+  modal: async ({ page, eventUtils }, use) => {
+    await use(new ModalPom(page, eventUtils));
+  },
+});
+
+test.beforeAll(async ({ foWebServer, mediaFactory, videoAnnotateSDK }) => {
+  await foWebServer.startWebServer();
+  await mediaFactory.createVideo({
+    outputPath: clip,
+    duration: 2,
+    width: 64,
+    height: 64,
+    frameRate: 10,
+    color: "#3050a0",
+  });
+  // sample 0: a masked detection track (vehicle) + a polyline track (person),
+  // each a single instance present on every frame.
+  await videoAnnotateSDK.seed({
+    datasetName,
+    videoPaths: [clip],
+    trackedSampleIndices: [0],
+    maskedSampleIndices: [0],
+    polylineSampleIndices: [0],
+  });
+});
+
+test.afterAll(async ({ foWebServer }) => {
+  await foWebServer.stopWebServer();
+});
+
+/** Open the modal in annotate mode on the deep-linked video sample. */
+const openAnnotate = async (
+  fiftyoneLoader: AbstractFiftyoneLoader,
+  modal: ModalPom,
+  page: Page
+) => {
+  await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
+    searchParams: new URLSearchParams({ id }),
+  });
+  await modal.assert.isOpen();
+  await modal.sidebar.switchMode("annotate");
+  await modal.videoAnnotate.waitForSurface();
+};
+
+test.describe.serial("video non-box label rendering", () => {
+  test.beforeEach(async ({ fiftyoneLoader, modal, page }) => {
+    await openAnnotate(fiftyoneLoader, modal, page);
+  });
+
+  test("existing detection and polyline labels both render in the sidebar", async ({
+    modal,
+  }) => {
+    // The polyline only lists if `frames.polylines` was registered + seeded
+    // into the engine alongside `frames.detections` — i.e. the multi-field seed.
+    await modal.videoAnnotate.assert.labelListed("vehicle");
+    await modal.videoAnnotate.assert.labelListed("person");
+  });
+
+  test("the polyline appears as its own timeline track", async ({ modal }) => {
+    // Two instances on two fields (detection index=1, polyline index=2) → two
+    // object tracks. Single-field track building would show only the detection.
+    await modal.videoAnnotate.assert.objectTrackCount(2);
+  });
+
+  test("an existing instance mask renders on the detection", async ({
+    modal,
+  }) => {
+    await modal.videoAnnotate.selectLabel("vehicle");
+    await modal.sidebar.edit.assert.hasMask(true);
+  });
+
+  test("an existing polyline is selectable and opens its editor", async ({
+    modal,
+  }) => {
+    await modal.videoAnnotate.selectLabel("person");
+    await modal.sidebar.edit.assert.verifyFieldValue("label", "person");
+  });
+
+  test("selecting a polyline from its timeline track drives the other surfaces", async ({
+    modal,
+  }) => {
+    // Read the polyline's instance id from the list first (selecting a label
+    // swaps the list for its editor), then start on a different label so the
+    // timeline click must change the selection.
+    const instanceId = await modal.videoAnnotate.labelRowId("person");
+    await modal.videoAnnotate.selectLabel("vehicle");
+    await modal.sidebar.edit.assert.verifyFieldValue("label", "vehicle");
+
+    // Clicking a timeline row writes engine interaction; the editor follows the
+    // anchor. The row must address the polyline's OWN field path (`frames.polylines`)
+    // — a row keyed to the detections field would select nothing, leaving the
+    // editor on "vehicle".
+    await modal.videoAnnotate.clickTrack(instanceId);
+    await modal.sidebar.edit.assert.verifyFieldValue("label", "person");
+  });
+
+  test("the annotate surface exposes mask + polyline create modes", async ({
+    page,
+  }) => {
+    // The video surface used to show only Detection; masks (Segmentation mode)
+    // and polylines are now ungated alongside it.
+    await expect(page.getByTestId("detection-mode")).toBeVisible();
+    await expect(page.getByTestId("segmentation-mode")).toBeVisible();
+    await expect(page.getByTestId("polyline-mode")).toBeVisible();
+  });
+
+  test("polyline create mode activates on the video surface", async ({
+    modal,
+    page,
+  }) => {
+    // The mode only enters (active flips true) when an active polyline field
+    // exists and the button isn't disabled — i.e. create is wired for video.
+    await modal.sidebar.annotate.polylineMode();
+    await expect(page.getByTestId("polyline-mode")).toHaveAttribute(
+      "data-cy-active",
+      "true"
+    );
+  });
+});

--- a/e2e-pw/src/oss/specs/MISSING-annotate-video-mask-playback.spec.ts
+++ b/e2e-pw/src/oss/specs/MISSING-annotate-video-mask-playback.spec.ts
@@ -1,0 +1,132 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ *
+ * A painted instance mask is a keyframe on the draw frame only; the box
+ * auto-extends forward as non-keyframe filler. As the playhead moves onto a
+ * filler frame, the track's overlay carries the box but NOT the mask — so the
+ * mask must visibly clear (guards the `DetectionOverlay.applyLabel` fix: a frame
+ * label whose `mask` is `undefined` — not just `null` — clears the stale mask).
+ *
+ * The sidebar mask preview is the render-level signal: it mounts only when the
+ * selected label's live overlay reports `hasMask()`, so its presence on the
+ * keyframe and absence on a filler frame proves the overlay paints/clears the
+ * mask with the playhead. Detection-box draw + auto-extend are covered in
+ * `MISSING-annotate-video-auto-extend.spec.ts`.
+ */
+import { expect, test as base, type Page } from "src/oss/fixtures";
+import { ModalPom } from "src/oss/poms/modal";
+import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
+import type { AbstractFiftyoneLoader } from "src/shared/abstract-loader";
+
+const datasetName = getUniqueDatasetNameWithPrefix(
+  "annotate-video-mask-playback"
+);
+const id = "000000000000000000000000";
+const clip = `/tmp/${datasetName}.webm`;
+
+const test = base.extend<{ modal: ModalPom }>({
+  modal: async ({ page, eventUtils }, use) => {
+    await use(new ModalPom(page, eventUtils));
+  },
+});
+
+test.beforeAll(async ({ foWebServer, mediaFactory, videoAnnotateSDK }) => {
+  await foWebServer.startWebServer();
+  // 40 frames @ 10fps — the 30-frame auto-extend stays clear of the clip end.
+  await mediaFactory.createVideo({
+    outputPath: clip,
+    duration: 4,
+    width: 64,
+    height: 64,
+    frameRate: 10,
+    color: "#3050a0",
+  });
+  // clean slate (no pre-seeded tracks) with the detections schema active, so
+  // segmentation mode is enterable and the first paint creates the only track.
+  await videoAnnotateSDK.seed({
+    datasetName,
+    videoPaths: [clip],
+    withEvents: false,
+  });
+});
+
+test.afterAll(async ({ foWebServer }) => {
+  await foWebServer.stopWebServer();
+});
+
+const openAnnotate = async (
+  fiftyoneLoader: AbstractFiftyoneLoader,
+  modal: ModalPom,
+  page: Page
+) => {
+  await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
+    searchParams: new URLSearchParams({ id }),
+  });
+  await modal.assert.isOpen();
+  await modal.sidebar.switchMode("annotate");
+  await modal.videoAnnotate.waitForSurface();
+};
+
+/** Drop focus so the "." / "," frame-step keybindings aren't typed into an input. */
+const blur = (page: Page) =>
+  page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur());
+
+const stepForward = async (modal: ModalPom, n: number) => {
+  for (let i = 0; i < n; i++) {
+    await modal.videoAnnotate.stepForward();
+  }
+};
+
+const stepBack = async (modal: ModalPom, n: number) => {
+  for (let i = 0; i < n; i++) {
+    await modal.videoAnnotate.stepBack();
+  }
+};
+
+test("a painted mask clears on auto-extended filler frames during playback", async ({
+  fiftyoneLoader,
+  modal,
+  page,
+}) => {
+  await openAnnotate(fiftyoneLoader, modal, page);
+  const va = modal.videoAnnotate;
+
+  await va.assert.objectTrackCount(0);
+
+  // paint a mask on frame 1 — segmentation mode opens a fresh masked detection
+  await modal.sidebar.annotate.segmentationMode();
+  await modal.sidebar.edit.selectBrushTool();
+  await va.paintMaskStroke([
+    [0.4, 0.4],
+    [0.48, 0.48],
+    [0.56, 0.56],
+  ]);
+  await va.assert.objectTrackCount(1);
+
+  // the keyframe carries the mask — the preview renders against the live overlay
+  await modal.sidebar.edit.assert.hasMask(true);
+  await modal.sidebar.edit.assert.hasMaskPreview(true);
+
+  // commit a class so the box auto-extends into engine presence; the form stays
+  // bound and follows the playhead
+  const saved = page.waitForResponse(
+    (r) =>
+      /\/sample\//.test(r.url()) &&
+      ["POST", "PATCH", "PUT"].includes(r.request().method())
+  );
+  await modal.sidebar.edit.selectFieldChoice("label", "vehicle");
+  await saved;
+  await blur(page);
+
+  // step onto a filler frame inside the auto-extended span: the box is present
+  // but the mask is not — the overlay must clear it (the form stays open)
+  await stepForward(modal, 10);
+  await expect(modal.sidebar.edit.backButton).toBeVisible();
+  await modal.sidebar.edit.assert.hasMask(false);
+  await modal.sidebar.edit.assert.hasMaskPreview(false);
+
+  // stepping back to the keyframe repaints the mask
+  await stepBack(modal, 10);
+  await modal.sidebar.edit.assert.hasMask(true);
+  await modal.sidebar.edit.assert.hasMaskPreview(true);
+});


### PR DESCRIPTION
Brings **polyline** and **instance-mask** annotation to the video annotation surface, which was previously Detection-box-only.

Stacked on #7850 (frame-aware schema manager) — review that first.

## What's included

- **Seed & render every per-frame label field.** `parseFramesData` now projects every registered `frames.*` label field (detections incl. masks, polylines) with the correct singular `_cls`/list-child per type; field discovery and `FrameStore` registration follow the active schema instead of a hardcoded detections path. The engine→lighter bridge already renders all kinds surface-agnostically, so rendering came for free once the seed was multi-field.
- **Multi-field timeline tracks.** Per-instance tracks accumulate presence across all label fields, colored per the row's own field path.
- **Create modes on video.** The create menu offers Detection, Segmentation (instance mask = detection + mask), and Polyline. Polyline self-creates via the interactive creation handler; a brush stroke with nothing selected opens a fresh masked detection. Mode-quit (Esc / right-click) wired for both.
- **Timeline selection by field path.** Selecting/hovering a non-detection row now carries the track's field path, so it addresses the right engine ref.

## Testing

- e2e: new `MISSING-annotate-video-label-types`, `-label-types-create`, and `-mask-playback` specs (render, create round-trip with mask_path encode/decode, and playback mask-clear). Full video annotate + 2D mask suites green (30 specs).
- Unit: video-annotation suite + annotate sidebar suite green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for video annotation with polylines and segmentation masks, alongside existing detection labeling.
  * Timeline tracks now reflect the correct annotation type and support multiple labeled fields per frame.

* **Bug Fixes**
  * Fixed mask previews so they clear and reappear correctly during playback and label updates.
  * Improved selection and editing so video annotations open the right label and mode across tracks and sidebar actions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->