### PR TITLE
[video annotation] Dedicated endpoints for temporal label presence

### DIFF
--- a/app/packages/annotation/src/engine/core/engine.ts
+++ b/app/packages/annotation/src/engine/core/engine.ts
@@ -241,6 +241,11 @@ export class AnnotationEngine {
     return this.stores.get(ref.sample)?.listLabels(ref.path, ref.frame) ?? [];
   }
 
+  /** Frame numbers edited this session for a sample (empty for non-frame stores). */
+  dirtyFrames(sample: string): number[] {
+    return this.stores.get(sample)?.dirtyFrames() ?? [];
+  }
+
   /** Current labels across all stores, for hydration. */
   enumerateLabels(kinds: readonly LabelType[]): LabelRef[] {
     const refs: LabelRef[] = [];

--- a/app/packages/annotation/src/engine/store/frameStore.ts
+++ b/app/packages/annotation/src/engine/store/frameStore.ts
@@ -136,6 +136,10 @@ export class FrameStore implements LabelStore {
     return refs;
   }
 
+  dirtyFrames(): number[] {
+    return [...this.working.keys()];
+  }
+
   // ---- mutation ----
 
   updateLabel(ref: LabelRef, partial: Partial<LabelData>): void {

--- a/app/packages/annotation/src/engine/store/sampleLabelStore.ts
+++ b/app/packages/annotation/src/engine/store/sampleLabelStore.ts
@@ -133,6 +133,10 @@ export class SampleLabelStore implements LabelStore {
     return refs;
   }
 
+  dirtyFrames(): number[] {
+    return [];
+  }
+
   // ---- mutation ----
 
   updateLabel(ref: LabelRef, partial: Partial<LabelData>): void {

--- a/app/packages/annotation/src/engine/store/types.ts
+++ b/app/packages/annotation/src/engine/store/types.ts
@@ -66,6 +66,11 @@ export interface LabelStore {
    *  per-store half of `engine.enumerateLabels` (hydration). */
   enumerateLabels(kinds: readonly LabelType[]): LabelRef[];
 
+  /** Frame numbers edited this session (the dirty overlay). Empty for stores
+   *  that are not frame-indexed. The timeline merges these over the server
+   *  index so in-session edits show without a whole-clip walk. */
+  dirtyFrames(): number[];
+
   // mutation (upsert by instanceId for list labels) — the store stamps
   // `_id = ref.instanceId`; callers never reconstruct arrays. `updateLabel`
   // merges (unset = explicit null write); `replaceLabel` writes the exact

--- a/app/packages/annotation/src/engine/store/videoLabelStore.test.ts
+++ b/app/packages/annotation/src/engine/store/videoLabelStore.test.ts
@@ -74,6 +74,10 @@ class FakeSampleStore implements LabelStore {
     return [tdRef("td-1")];
   }
 
+  dirtyFrames(): number[] {
+    return [];
+  }
+
   updateLabel(ref: LabelRef): void {
     this.calls.push(`updateLabel:${ref.path}`);
   }

--- a/app/packages/annotation/src/engine/store/videoLabelStore.ts
+++ b/app/packages/annotation/src/engine/store/videoLabelStore.ts
@@ -80,6 +80,10 @@ export class VideoLabelStore implements LabelStore {
     ];
   }
 
+  dirtyFrames(): number[] {
+    return this.frames.dirtyFrames();
+  }
+
   // ---- mutation ----
 
   updateLabel(ref: LabelRef, partial: Partial<LabelData>): void {

--- a/app/packages/core/src/client/framesClient.ts
+++ b/app/packages/core/src/client/framesClient.ts
@@ -30,6 +30,12 @@ export type GetFramesRequest = {
   slice?: string | null;
   /** Optional extended view stages. */
   extended?: unknown;
+  /**
+   * Optional frame-field projection. When set, the response carries only
+   * `frame_number` plus these fields — avoids shipping the whole frame
+   * document when a caller needs just a few fields (e.g. `["filepath"]`).
+   */
+  fields?: string[];
 };
 
 /**

--- a/app/packages/core/src/client/videoLabelsClient.ts
+++ b/app/packages/core/src/client/videoLabelsClient.ts
@@ -22,7 +22,13 @@ type VideoLabelsRequestBase = {
   extended?: unknown;
 };
 
-export type GetVideoLabelsIndexRequest = VideoLabelsRequestBase;
+export type GetVideoLabelsIndexRequest = VideoLabelsRequestBase & {
+  /**
+   * Declared-dynamic attribute names to value-segment per instance. Omitted →
+   * the index returns presence + keyframes only (no `attributeSegments`).
+   */
+  dynamicAttributes?: string[];
+};
 
 export type GetVideoLabelsWindowRequest = VideoLabelsRequestBase & {
   /** First frame of the window (1-indexed, inclusive). */
@@ -46,6 +52,13 @@ export type VideoLabelIndexInstance = {
   instance: { _cls: "Instance"; _id?: string } | null;
   segments: Array<[number, number]>;
   keyframes: number[];
+  /**
+   * Per declared-dynamic attribute, run-length-encoded `[startFrame, endFrame,
+   * value]` value runs across the instance's presence. Present only when the
+   * request named `dynamicAttributes`; a frame missing the attribute yields a
+   * `null`-valued run.
+   */
+  attributeSegments?: Record<string, Array<[number, number, unknown]>>;
 };
 
 export type GetVideoLabelsIndexResponse = {

--- a/app/packages/core/src/client/videoLabelsClient.ts
+++ b/app/packages/core/src/client/videoLabelsClient.ts
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import {
+  FetchFunctionConfig,
+  FetchFunctionResult,
+  getFetchFunctionExtended,
+} from "@fiftyone/utilities";
+
+/** Shared request fields — every video-labels read targets one video sample. */
+type VideoLabelsRequestBase = {
+  /** Sample id for the parent video document. */
+  sampleId: string;
+  /** Current dataset name. */
+  dataset: string;
+  /** Active view stages, sent opaquely like every dataset query. */
+  view: unknown[];
+  /** Per-frame label fields to read (frame-relative, e.g. `"detections"`). */
+  fields: string[];
+  /** Optional extended view stages. */
+  extended?: unknown;
+};
+
+export type GetVideoLabelsIndexRequest = VideoLabelsRequestBase;
+
+export type GetVideoLabelsWindowRequest = VideoLabelsRequestBase & {
+  /** First frame of the window (1-indexed, inclusive). */
+  startFrame: number;
+  /** Last frame of the window (1-indexed, inclusive). */
+  endFrame: number;
+};
+
+/**
+ * One tracked instance's presence distribution across the whole clip. Frame
+ * numbers only — no label payloads. `segments` are run-length-encoded
+ * `[startFrame, endFrame]` presence runs; `keyframes` is empty for data with
+ * no `keyframe` attribute.
+ */
+export type VideoLabelIndexInstance = {
+  /** Engine track id — `instance._id`, or the per-frame doc `_id` for legacy. */
+  instanceId: string;
+  classLabel: string | null;
+  /** The detection's persisted track `index`, when present. */
+  persistedIndex: number | null;
+  instance: { _cls: "Instance"; _id?: string } | null;
+  segments: Array<[number, number]>;
+  keyframes: number[];
+};
+
+export type GetVideoLabelsIndexResponse = {
+  [field: string]: { instances: VideoLabelIndexInstance[] };
+};
+
+export type GetVideoLabelsWindowResponse = {
+  /** Field-projected label payloads keyed by stringified frame number. */
+  frames: Record<string, Record<string, unknown>>;
+  /** Server-clamped `[startFrame, endFrame]` of the returned window. */
+  range: [number, number];
+};
+
+const doFetch = <A, R>(
+  config: FetchFunctionConfig<A>
+): Promise<FetchFunctionResult<R>> => {
+  return getFetchFunctionExtended()(config);
+};
+
+/**
+ * Fetch the timeline distribution index for a video sample — per-instance
+ * presence segments + keyframes, no label payloads. Cheap (projection-only
+ * server aggregation); call once on surface mount and on view change. Drives
+ * the timeline tracks; the playback stream fetches payloads separately via
+ * {@link getVideoLabelsWindow}.
+ */
+export const getVideoLabelsIndex = async (
+  request: GetVideoLabelsIndexRequest
+): Promise<GetVideoLabelsIndexResponse> => {
+  const { response } = await doFetch<
+    GetVideoLabelsIndexRequest,
+    GetVideoLabelsIndexResponse
+  >({
+    method: "POST",
+    path: "/video-labels/index",
+    body: request,
+    result: "json",
+    retries: 2,
+  });
+
+  return response;
+};
+
+/**
+ * Fetch full, field-projected label payloads for a bounded frame range — the
+ * playback stream's windowed read (the resident set). Returns a frame-keyed
+ * map; frames carry only the requested fields they actually have.
+ */
+export const getVideoLabelsWindow = async (
+  request: GetVideoLabelsWindowRequest
+): Promise<GetVideoLabelsWindowResponse> => {
+  const { response } = await doFetch<
+    GetVideoLabelsWindowRequest,
+    GetVideoLabelsWindowResponse
+  >({
+    method: "POST",
+    path: "/video-labels/window",
+    body: request,
+    result: "json",
+    retries: 2,
+  });
+
+  return response;
+};

--- a/app/packages/video-annotation/src/components/FrameLabels.tsx
+++ b/app/packages/video-annotation/src/components/FrameLabels.tsx
@@ -9,14 +9,8 @@ import {
   useLighter,
 } from "@fiftyone/lighter";
 import type { ModalSample } from "@fiftyone/state";
-import type { Stage } from "@fiftyone/utilities";
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import type { LabelData, Stage } from "@fiftyone/utilities";
+import React, { useCallback, useMemo, useRef } from "react";
 import {
   useActiveDetectionField,
   useColorScheme,
@@ -40,9 +34,11 @@ import {
   usePublishFrameLabelsStream,
 } from "../streams/frameLabelsStream";
 import {
-  buildPerInstanceTracks,
+  buildTracksFromIndex,
+  type FrameOverlay,
   type PerInstanceLabel,
 } from "../tracks/frameTracks";
+import { useVideoLabelsIndex } from "../hooks/useVideoLabelsIndex";
 import { LABELS_STREAM_ID } from "../utils/ids";
 import { getModalSampleFrameRate } from "../utils/modalSample";
 import { resolveTrackExtentEdit } from "../tracks/trackExtentEdit";
@@ -141,7 +137,6 @@ export const RegisterFrameLabels: React.FC<{
       sampleId={sampleId}
       dataset={dataset}
       view={view}
-      groupSlice={slice ?? null}
       frameCount={frameCount}
       frameRate={frameRate}
       frameField={frameField}
@@ -155,7 +150,6 @@ interface FrameLabelsRegistrationProps {
   sampleId: string;
   dataset: string;
   view: Stage[];
-  groupSlice: string | null;
   frameCount: number;
   frameRate: number;
   frameField: string;
@@ -174,7 +168,6 @@ const FrameLabelsRegistration: React.FC<FrameLabelsRegistrationProps> = ({
       sampleId: props.sampleId,
       dataset: props.dataset,
       view: props.view,
-      groupSlice: props.groupSlice,
       frameCount: props.frameCount,
       frameRate: props.frameRate,
       frameField: props.frameField,
@@ -193,10 +186,10 @@ const FrameLabelsRegistration: React.FC<FrameLabelsRegistrationProps> = ({
 };
 
 /**
- * Build the per-instance object tracks by warming every chunk so the engine
- * re-hydrates across the whole clip, then walking the engine. Returns `[]`
- * until warmup resolves; `resolved` flips true on the first resolved build
- * (including a legitimately empty clip) to gate the pin bootstrap.
+ * Build the per-instance object tracks from the server distribution index
+ * merged with the engine's edited-frame overlay — no whole-clip walk. Tracks
+ * rebuild on each engine commit (cheap: only the dirty frames are read).
+ * `resolved` flips true once the index settles, gating the pin bootstrap.
  */
 function useFrameDerivedTracks(resolveColor: ObjectTrackColorResolver): {
   tracks: Track[];
@@ -207,46 +200,54 @@ function useFrameDerivedTracks(resolveColor: ObjectTrackColorResolver): {
   const sampleId = useActiveSampleId();
   const path = stream ? `frames.${stream.labelsField}` : null;
 
-  const [tracks, setTracks] = useState<Track[]>([]);
-  const [resolved, setResolved] = useState(false);
+  const { index, loaded } = useVideoLabelsIndex(stream);
 
   // engine version is the rebuild signal.
   const engineVersion = useEngineSelector(engine, () => engine.getVersion());
 
-  useEffect(() => {
-    if (!stream || !sampleId || !path) {
-      setTracks([]);
-      setResolved(false);
-      return undefined;
+  const tracks = useMemo(() => {
+    if (!stream || !sampleId || !path || !loaded) {
+      return [];
     }
 
-    let cancelled = false;
-
-    void stream.warmupAll().then(() => {
-      if (cancelled) {
-        return;
-      }
-
-      setTracks(
-        buildPerInstanceTracks({
-          engine,
-          sample: sampleId,
-          path,
-          totalFrames: stream.totalFrames,
-          fps: stream.fps,
-          resolveColor,
-        })
-      );
-      setResolved(true);
+    return buildTracksFromIndex({
+      index,
+      overlay: readDirtyOverlay(engine, sampleId, path),
+      fps: stream.fps,
+      resolveColor,
     });
-
-    return () => {
-      cancelled = true;
-    };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- engineVersion is the invalidation signal
-  }, [engine, sampleId, path, stream, resolveColor, engineVersion]);
+  }, [
+    engine,
+    sampleId,
+    path,
+    stream,
+    resolveColor,
+    index,
+    loaded,
+    engineVersion,
+  ]);
 
-  return { tracks, resolved };
+  return { tracks, resolved: loaded };
+}
+
+/**
+ * The engine's edited frames + their live labels, keyed by frame number — the
+ * overlay that shadows the server index. Only dirty frames are read, so this
+ * is bounded by the edit count, never the clip length.
+ */
+function readDirtyOverlay(
+  engine: ReturnType<typeof useAnnotationEngine>,
+  sample: string,
+  path: string
+): FrameOverlay {
+  const overlay: FrameOverlay = new Map<number, LabelData[]>();
+
+  for (const frame of engine.dirtyFrames(sample)) {
+    overlay.set(frame, engine.listLabels({ sample, path, frame }));
+  }
+
+  return overlay;
 }
 
 /**

--- a/app/packages/video-annotation/src/hooks/useSyncAnnotationVideoStore.ts
+++ b/app/packages/video-annotation/src/hooks/useSyncAnnotationVideoStore.ts
@@ -51,6 +51,11 @@ export const useSyncAnnotationVideoStore = (): void => {
     const unsubscribe = stream.subscribeToEdits(seed);
     seed();
 
+    // Whole-clip seed for engine consumers that still walk every frame
+    // (propagation, interpolation, track ops). The timeline no longer needs
+    // it — it reads the server index. Retire once those ops fetch per-range.
+    void stream.warmupAll();
+
     return () => {
       unsubscribe();
       unregister();

--- a/app/packages/video-annotation/src/hooks/useVideoLabelsIndex.ts
+++ b/app/packages/video-annotation/src/hooks/useVideoLabelsIndex.ts
@@ -1,0 +1,61 @@
+import { useEffect, useState } from "react";
+import { getVideoLabelsIndex } from "../../../core/src/client/videoLabelsClient";
+import type { IndexInstance } from "../tracks/frameTracks";
+import type { VideoFrameLabelsStream } from "../streams/VideoFrameLabelsStream";
+
+interface VideoLabelsIndexState {
+  /** Per-instance presence baseline for the stream's label field. */
+  index: IndexInstance[];
+  /** True once the fetch settles (success or failure) — gates first paint. */
+  loaded: boolean;
+}
+
+const EMPTY: VideoLabelsIndexState = { index: [], loaded: false };
+
+/**
+ * Fetch the timeline distribution index for the active labels stream's field.
+ * One fetch per stream identity — the registrar re-mounts the stream (and so
+ * this hook) when the sample, dataset, or field changes. The result is the
+ * server baseline; live edits ride the engine overlay at merge time, so this
+ * never re-fetches on save.
+ */
+export function useVideoLabelsIndex(
+  stream: VideoFrameLabelsStream | null
+): VideoLabelsIndexState {
+  const [state, setState] = useState<VideoLabelsIndexState>(EMPTY);
+
+  useEffect(() => {
+    if (!stream) {
+      setState(EMPTY);
+      return undefined;
+    }
+
+    let cancelled = false;
+    setState(EMPTY);
+
+    const field = stream.labelsField;
+    const { sampleId, dataset, view } = stream.labelQuery();
+
+    void getVideoLabelsIndex({ sampleId, dataset, view, fields: [field] })
+      .then((response) => {
+        if (cancelled) {
+          return;
+        }
+
+        setState({ index: response[field]?.instances ?? [], loaded: true });
+      })
+      .catch(() => {
+        if (cancelled) {
+          return;
+        }
+
+        setState({ index: [], loaded: true });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [stream]);
+
+  return state;
+}

--- a/app/packages/video-annotation/src/streams/ImaVidImageStream.ts
+++ b/app/packages/video-annotation/src/streams/ImaVidImageStream.ts
@@ -333,6 +333,9 @@ export class ImaVidImageStream extends PlaybackStreamBase<ImaVidImageFrame> {
         dataset: this.dataset,
         view: this.view,
         slice: this.groupSlice ?? undefined,
+        // The image stream only needs each frame's media path; project to it
+        // so `/frames` doesn't ship every label field per frame.
+        fields: ["filepath"],
       },
     });
   }

--- a/app/packages/video-annotation/src/streams/VideoFrameLabelsStream.ts
+++ b/app/packages/video-annotation/src/streams/VideoFrameLabelsStream.ts
@@ -6,10 +6,8 @@ import {
   type Stage,
   type SyntheticBox,
 } from "@fiftyone/utilities";
-import {
-  getFrames,
-  type FrameDoc,
-} from "../../../core/src/client/framesClient";
+import { type FrameDoc } from "../../../core/src/client/framesClient";
+import { getVideoLabelsWindow } from "../../../core/src/client/videoLabelsClient";
 import {
   frameAt,
   PlaybackStreamBase,
@@ -25,28 +23,25 @@ export interface VideoFrameLabelsStreamOptions {
   id: string;
   /** Sample id for the parent video document. */
   sampleId: string;
-  /** Current dataset name (POST /frames requires it). */
+  /** Current dataset name (the window read requires it). */
   dataset: string;
   /** Active view stages — same shape sent on every dataset query. */
   view: Stage[];
-  /** Group slice name, when the dataset is grouped. */
-  groupSlice?: string | null;
   /** Total frame count of the clip (1-indexed up to this number). */
   frameCount: number;
   /** Frame rate in frames per second. */
   frameRate: number;
   /**
    * todo - multiple fields
-   * Field on the per-frame document that carries `Detections`. Strip the
-   * `frames.` prefix that lives in the parent video schema — the per-frame
-   * samples returned by `/frames` are already frame-relative.
+   * Field on the per-frame document that carries `Detections`, frame-relative
+   * (the `frames.` prefix from the parent video schema stripped).
    *
    * @default "detections"
    */
   frameField?: string;
   /**
-   * Number of frames to request in a single `/frames` chunk. Larger
-   * values mean fewer round trips but larger payloads.
+   * Number of frames to request in a single window chunk. Larger values mean
+   * fewer round trips but larger payloads.
    *
    * @default 60
    */
@@ -57,23 +52,22 @@ const DEFAULT_CHUNK_SIZE = 60;
 const DEFAULT_FRAME_FIELD = "detections";
 
 /**
- * Labels stream backed by the `POST /frames` endpoint.
+ * Labels stream backed by the `POST /video-labels/window` endpoint.
  *
- * Caches per-frame samples by 1-indexed frame number. `bufferState`
- * reports readiness for a given time; `prefetch` issues a chunk fetch
- * starting at the first missing frame in the requested range; `getValue`
+ * Caches field-projected per-frame label payloads by 1-indexed frame number.
+ * `bufferState` reports readiness for a given time; `prefetch` issues a window
+ * fetch starting at the first missing frame in the requested range; `getValue`
  * reads the cached frame for the read-only snapshot.
  *
- * Read-only: the stream loads `/frames` chunks and seeds the annotation
- * engine's frame store (via {@link cachedFrames} + {@link subscribeToEdits}).
- * All label mutation, dirty tracking, and persistence live in the engine; the
- * stream holds no edit state.
+ * Read-only: the stream loads window chunks and seeds the annotation engine's
+ * frame store (via {@link cachedFrames} + {@link subscribeToEdits}). All label
+ * mutation, dirty tracking, and persistence live in the engine; the stream
+ * holds no edit state.
  */
 export class VideoFrameLabelsStream extends PlaybackStreamBase<FrameLabelSnapshot> {
   private readonly sampleId: string;
   private readonly dataset: string;
   private readonly view: Stage[];
-  private readonly groupSlice: string | null;
   private readonly frameCount: number;
   private readonly frameRate: number;
   private readonly frameField: string;
@@ -84,7 +78,7 @@ export class VideoFrameLabelsStream extends PlaybackStreamBase<FrameLabelSnapsho
   private readonly fetchedRanges: Array<[number, number]> = [];
   // Notified whenever a chunk lands. The annotation engine's frame store
   // re-seeds from `cachedFrames()` on this signal (via `subscribeToEdits`);
-  // the stream itself holds no edit state — it is a read-only `/frames` seed
+  // the stream itself holds no edit state — it is a read-only window seed
   // and the engine owns all label mutations.
   private readonly editListeners = new Set<() => void>();
 
@@ -102,7 +96,6 @@ export class VideoFrameLabelsStream extends PlaybackStreamBase<FrameLabelSnapsho
     this.sampleId = opts.sampleId;
     this.dataset = opts.dataset;
     this.view = opts.view;
-    this.groupSlice = opts.groupSlice ?? null;
     this.frameCount = opts.frameCount;
     this.frameRate = opts.frameRate;
     this.frameField = opts.frameField ?? DEFAULT_FRAME_FIELD;
@@ -184,6 +177,14 @@ export class VideoFrameLabelsStream extends PlaybackStreamBase<FrameLabelSnapsho
   /** Per-frame field that carries the labels (e.g. `"detections"`). */
   get labelsField(): string {
     return this.frameField;
+  }
+
+  /**
+   * The dataset query this stream reads against — the params the
+   * `/video-labels/{index,window}` fetches share with the `/frames` seed.
+   */
+  labelQuery(): { sampleId: string; dataset: string; view: Stage[] } {
+    return { sampleId: this.sampleId, dataset: this.dataset, view: this.view };
   }
 
   bufferState(time: number): BufferReadiness {
@@ -319,33 +320,39 @@ export class VideoFrameLabelsStream extends PlaybackStreamBase<FrameLabelSnapsho
   }
 
   private async doFetch(startFrame: number, numFrames: number): Promise<void> {
+    const endFrame = Math.min(startFrame + numFrames - 1, this.frameCount);
+
     try {
-      const result = await getFrames({
-        frameNumber: startFrame,
-        numFrames,
-        frameCount: this.frameCount,
+      const result = await getVideoLabelsWindow({
         sampleId: this.sampleId,
         dataset: this.dataset,
         view: this.view,
-        slice: this.groupSlice ?? undefined,
+        fields: [this.frameField],
+        startFrame,
+        endFrame,
       });
 
-      for (const frame of result.frames) {
-        // The /frames response is the seed; the engine owns edits, so the
-        // stream never reconciles local state against the fetch.
-        this.cache.set(frame.frame_number, frame);
+      let landed = 0;
+      for (const [frameNumber, fields] of Object.entries(result.frames)) {
+        // Field-projected window payload → the cache's per-frame doc shape.
+        // The engine owns edits, so the stream never reconciles against it.
+        this.cache.set(Number(frameNumber), {
+          frame_number: Number(frameNumber),
+          ...fields,
+        });
+        landed++;
       }
 
       mergeRange(this.fetchedRanges, result.range);
 
-      if (result.frames.length > 0) {
+      if (landed > 0) {
         this.notifyEdits();
       }
     } catch (error) {
       // Surface but don't crash — the engine will keep asking; subsequent
       // prefetch calls will retry the missing frames.
       console.error(
-        `[VideoFrameLabelsStream] fetch failed for [${startFrame}, +${numFrames})`,
+        `[VideoFrameLabelsStream] fetch failed for [${startFrame}, ${endFrame}]`,
         error
       );
     }

--- a/app/packages/video-annotation/src/tracks/frameTracks.ts
+++ b/app/packages/video-annotation/src/tracks/frameTracks.ts
@@ -1,6 +1,7 @@
 import type { AnnotationEngine } from "@fiftyone/annotation";
 import type { Track, TrackEvent } from "@fiftyone/playback";
 import type { LabelData } from "@fiftyone/utilities";
+import { mergePresence, type Segment } from "./segments";
 
 /** The engine read surface this builder needs — one frame's labels at a time. */
 export type FrameLabelReader = Pick<AnnotationEngine, "listLabels">;
@@ -116,6 +117,61 @@ export function buildPerInstanceTracks({
   }
 
   const states = accumulatePresence(engine, sample, path, totalFrames, fps);
+  return statesToTracks(states, resolveColor);
+}
+
+/** One tracked instance's server-side presence distribution (no payloads). */
+export interface IndexInstance {
+  instanceId: string;
+  classLabel: string | null;
+  persistedIndex: number | null;
+  instance: { _cls: "Instance"; _id?: string } | null;
+  /** Run-length-encoded `[startFrame, endFrame]` presence runs. */
+  segments: Array<[number, number]>;
+  /** Frame numbers carrying a `keyframe` flag. */
+  keyframes: number[];
+}
+
+/** Live engine labels for the dirty (edited) frames, keyed by frame number. */
+export type FrameOverlay = Map<number, LabelData[]>;
+
+export interface BuildTracksFromIndexInput {
+  /** Server baseline distribution for the field, one entry per instance. */
+  index: IndexInstance[];
+  /** The engine's edited frames — these shadow the baseline frame-for-frame. */
+  overlay: FrameOverlay;
+  /** Frame rate, for the frame↔seconds mapping. */
+  fps: number;
+  resolveColor: (label: PerInstanceLabel) => string;
+}
+
+/**
+ * Build per-instance timeline tracks from the server index merged with the
+ * engine's edited-frame overlay. The index supplies the whole-clip presence
+ * baseline; the overlay supplies the authoritative presence at the (small)
+ * set of dirty frames, so in-session edits — new tracks, deletions, extended
+ * presence — reflect immediately without re-fetching the index or walking the
+ * whole clip. The merge stays in segment space (see {@link mergePresence}).
+ */
+export function buildTracksFromIndex({
+  index,
+  overlay,
+  fps,
+  resolveColor,
+}: BuildTracksFromIndexInput): Track[] {
+  if (!Number.isFinite(fps) || fps <= 0) {
+    return [];
+  }
+
+  const states = mergeIndexWithOverlay(index, overlay, fps);
+  return statesToTracks(states, resolveColor);
+}
+
+/** Shape the accumulated states into sorted, colored timeline tracks. */
+function statesToTracks(
+  states: Map<string, InstanceState>,
+  resolveColor: (label: PerInstanceLabel) => string
+): Track[] {
   assignDisplayOrdinals(states);
 
   const tracks: Track[] = [];
@@ -128,6 +184,128 @@ export function buildPerInstanceTracks({
   }
 
   return sortByClassThenOrdinal(tracks, states);
+}
+
+/**
+ * Reconcile the index baseline with the dirty-frame overlay into per-instance
+ * states. For each instance the merged presence is `baseline − dirtyFrames +
+ * (frames the overlay still has it)`; keyframes likewise prefer the overlay at
+ * dirty frames; class/index/instance prefer the live overlay label when the
+ * instance was touched this session, else the baseline.
+ */
+function mergeIndexWithOverlay(
+  index: IndexInstance[],
+  overlay: FrameOverlay,
+  fps: number
+): Map<string, InstanceState> {
+  const dirtySorted = [...overlay.keys()].sort((a, b) => a - b);
+  const dirtySet = new Set(dirtySorted);
+
+  const presentByInstance = new Map<string, number[]>();
+  const liveLabelByInstance = new Map<string, LabelData>();
+  const dirtyKeyframesByInstance = new Map<string, number[]>();
+
+  for (const frame of dirtySorted) {
+    for (const label of overlay.get(frame) ?? []) {
+      const id = addressIdOf(label);
+      pushTo(presentByInstance, id, frame);
+
+      if (!liveLabelByInstance.has(id)) {
+        liveLabelByInstance.set(id, label);
+      }
+
+      if (label.keyframe) {
+        pushTo(dirtyKeyframesByInstance, id, frame);
+      }
+    }
+  }
+
+  const baselineById = new Map(index.map((entry) => [entry.instanceId, entry]));
+  const ids = new Set<string>([
+    ...baselineById.keys(),
+    ...presentByInstance.keys(),
+  ]);
+
+  const states = new Map<string, InstanceState>();
+  for (const id of ids) {
+    const baseline = baselineById.get(id);
+    const baseSegments: Segment[] = baseline ? baseline.segments : [];
+    const present = presentByInstance.get(id) ?? [];
+
+    const segments = mergePresence(baseSegments, dirtySorted, present);
+    if (segments.length === 0) {
+      continue;
+    }
+
+    states.set(
+      id,
+      indexInstanceState({
+        baseline,
+        live: liveLabelByInstance.get(id),
+        segments,
+        baselineKeyframes: baseline?.keyframes ?? [],
+        dirtyKeyframes: dirtyKeyframesByInstance.get(id) ?? [],
+        dirtySet,
+        fps,
+      })
+    );
+  }
+
+  return states;
+}
+
+function pushTo(map: Map<string, number[]>, key: string, value: number): void {
+  const existing = map.get(key);
+  if (existing) {
+    existing.push(value);
+    return;
+  }
+
+  map.set(key, [value]);
+}
+
+/** Build one instance's state from its merged segments + class/keyframe sources. */
+function indexInstanceState({
+  baseline,
+  live,
+  segments,
+  baselineKeyframes,
+  dirtyKeyframes,
+  dirtySet,
+  fps,
+}: {
+  baseline: IndexInstance | undefined;
+  live: LabelData | undefined;
+  segments: Segment[];
+  baselineKeyframes: number[];
+  dirtyKeyframes: number[];
+  dirtySet: Set<number>;
+  fps: number;
+}): InstanceState {
+  const intervals = segments.map(([start, end]) => ({
+    start: (start - 1) / fps,
+    end: end / fps,
+  }));
+
+  const keyframeFrames = [
+    ...baselineKeyframes.filter((frame) => !dirtySet.has(frame)),
+    ...dirtyKeyframes,
+  ].sort((a, b) => a - b);
+
+  const keyframeTimes = keyframeFrames.map((frame) => (frame - 1) / fps);
+
+  return {
+    classLabel: live ? labelOf(live) : baseline?.classLabel || "unknown",
+    persistedIndex: live
+      ? indexOf(live)
+      : baseline?.persistedIndex ?? undefined,
+    instance: live ? instanceOf(live) : baseline?.instance ?? null,
+    displayIndex: 0,
+    inFrame: false,
+    currentStart: null,
+    intervals,
+    keyframeTimes,
+  };
 }
 
 /** Close a state's currently-open presence interval at `endSec`. */

--- a/app/packages/video-annotation/src/tracks/frameTracks.ts
+++ b/app/packages/video-annotation/src/tracks/frameTracks.ts
@@ -130,6 +130,13 @@ export interface IndexInstance {
   segments: Array<[number, number]>;
   /** Frame numbers carrying a `keyframe` flag. */
   keyframes: number[];
+  /**
+   * Per declared-dynamic attribute, RLE `[startFrame, endFrame, value]` value
+   * runs across the instance's presence. Present only when the index was
+   * fetched with `dynamicAttributes`; consumed by the dynamic-attribute
+   * sub-track read model (not the presence/keyframe timeline).
+   */
+  attributeSegments?: Record<string, Array<[number, number, unknown]>>;
 }
 
 /** Live engine labels for the dirty (edited) frames, keyed by frame number. */

--- a/app/packages/video-annotation/src/tracks/frameTracksIndex.test.ts
+++ b/app/packages/video-annotation/src/tracks/frameTracksIndex.test.ts
@@ -1,0 +1,139 @@
+import type { Track } from "@fiftyone/playback";
+import type { LabelData } from "@fiftyone/utilities";
+import { describe, expect, it } from "vitest";
+import {
+  buildTracksFromIndex,
+  type FrameOverlay,
+  type IndexInstance,
+} from "./frameTracks";
+
+const FPS = 30;
+
+function indexInstance(over: Partial<IndexInstance> = {}): IndexInstance {
+  return {
+    instanceId: "inst-a",
+    classLabel: "person",
+    persistedIndex: 1,
+    instance: { _cls: "Instance", _id: "inst-a" },
+    segments: [[1, 3]],
+    keyframes: [],
+    ...over,
+  };
+}
+
+function det(over: Partial<LabelData> = {}): LabelData {
+  return {
+    _id: "doc",
+    _cls: "Detection",
+    label: "person",
+    index: 1,
+    instance: { _cls: "Instance", _id: "inst-a" },
+    keyframe: false,
+    ...over,
+  } as LabelData;
+}
+
+function build(index: IndexInstance[], overlay: FrameOverlay = new Map()) {
+  return buildTracksFromIndex({
+    index,
+    overlay,
+    fps: FPS,
+    resolveColor: () => "#fff",
+  });
+}
+
+function presence(track: Track) {
+  return track.events.filter((e) => e.label === "in frame");
+}
+
+function keyframes(track: Track) {
+  return track.events.filter((e) => e.label === "Keyframe");
+}
+
+describe("buildTracksFromIndex", () => {
+  it("builds tracks from the baseline index with no overlay", () => {
+    const tracks = build([
+      indexInstance({
+        segments: [
+          [1, 3],
+          [5, 6],
+        ],
+        keyframes: [2],
+      }),
+    ]);
+
+    expect(tracks).toHaveLength(1);
+    expect(tracks[0].id).toBe("inst-a");
+
+    const bars = presence(tracks[0]);
+    expect(bars).toHaveLength(2);
+    expect(bars[0].startSec).toBeCloseTo(0);
+    expect(bars[0].endSec).toBeCloseTo(3 / FPS);
+    expect(bars[1].startSec).toBeCloseTo(4 / FPS);
+    expect(bars[1].endSec).toBeCloseTo(6 / FPS);
+
+    const kf = keyframes(tracks[0]);
+    expect(kf).toHaveLength(1);
+    expect(kf[0].startSec).toBeCloseTo(1 / FPS);
+  });
+
+  it("adds an instance present only in the overlay (newly drawn track)", () => {
+    const overlay: FrameOverlay = new Map([
+      [4, [det({ instance: { _cls: "Instance", _id: "inst-b" } })]],
+      [5, [det({ instance: { _cls: "Instance", _id: "inst-b" } })]],
+    ]);
+
+    const tracks = build([indexInstance()], overlay);
+    const ids = tracks.map((t) => t.id).sort();
+
+    expect(ids).toEqual(["inst-a", "inst-b"]);
+    const b = tracks.find((t) => t.id === "inst-b")!;
+    const bars = presence(b);
+    expect(bars).toHaveLength(1);
+    expect(bars[0].startSec).toBeCloseTo(3 / FPS);
+    expect(bars[0].endSec).toBeCloseTo(5 / FPS);
+  });
+
+  it("shrinks presence where the overlay deleted the label at a dirty frame", () => {
+    // Frame 2 is dirty and the overlay no longer has inst-a there.
+    const overlay: FrameOverlay = new Map([[2, []]]);
+
+    const tracks = build(
+      [indexInstance({ segments: [[1, 3]], keyframes: [2] })],
+      overlay
+    );
+
+    const bars = presence(tracks[0]);
+    expect(bars).toHaveLength(2);
+    expect(bars[0].endSec).toBeCloseTo(1 / FPS);
+    expect(bars[1].startSec).toBeCloseTo(2 / FPS);
+    // The baseline keyframe at the now-dirty, now-absent frame is gone.
+    expect(keyframes(tracks[0])).toHaveLength(0);
+  });
+
+  it("takes class and index from the live overlay label when present", () => {
+    const overlay: FrameOverlay = new Map([
+      [2, [det({ label: "car", index: 9, keyframe: true })]],
+    ]);
+
+    const tracks = build(
+      [indexInstance({ classLabel: "person", persistedIndex: 1 })],
+      overlay
+    );
+
+    // Row label combines the live class with its persisted index.
+    expect(tracks[0].label).toBe("car 9");
+    // The keyframe flag from the dirty overlay frame shows.
+    expect(keyframes(tracks[0])).toHaveLength(1);
+  });
+
+  it("drops an instance the overlay fully removed", () => {
+    const overlay: FrameOverlay = new Map([
+      [1, []],
+      [2, []],
+      [3, []],
+    ]);
+
+    expect(build([indexInstance({ segments: [[1, 3]] })], overlay)).toEqual([]);
+  });
+});

--- a/app/packages/video-annotation/src/tracks/segments.test.ts
+++ b/app/packages/video-annotation/src/tracks/segments.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import {
+  coalesce,
+  mergePresence,
+  removeFrames,
+  type Segment,
+} from "./segments";
+
+describe("removeFrames", () => {
+  it("returns a copy when nothing is removed", () => {
+    const segments: Segment[] = [[1, 5]];
+    expect(removeFrames(segments, [])).toEqual([[1, 5]]);
+  });
+
+  it("splits a run around an interior frame", () => {
+    expect(removeFrames([[1, 10]], [4])).toEqual([
+      [1, 3],
+      [5, 10],
+    ]);
+  });
+
+  it("trims at the edges", () => {
+    expect(removeFrames([[1, 10]], [1, 10])).toEqual([[2, 9]]);
+  });
+
+  it("ignores frames outside every run", () => {
+    expect(removeFrames([[3, 5]], [1, 2, 9])).toEqual([[3, 5]]);
+  });
+
+  it("removes a single-frame run entirely", () => {
+    expect(removeFrames([[4, 4]], [4])).toEqual([]);
+  });
+
+  it("handles multiple removals across multiple runs", () => {
+    expect(
+      removeFrames(
+        [
+          [1, 5],
+          [8, 12],
+        ],
+        [2, 4, 10]
+      )
+    ).toEqual([
+      [1, 1],
+      [3, 3],
+      [5, 5],
+      [8, 9],
+      [11, 12],
+    ]);
+  });
+});
+
+describe("coalesce", () => {
+  it("merges adjacent runs that touch by one frame", () => {
+    expect(
+      coalesce([
+        [1, 3],
+        [4, 6],
+      ])
+    ).toEqual([[1, 6]]);
+  });
+
+  it("merges overlapping runs", () => {
+    expect(
+      coalesce([
+        [1, 5],
+        [3, 8],
+      ])
+    ).toEqual([[1, 8]]);
+  });
+
+  it("keeps a genuine gap", () => {
+    expect(
+      coalesce([
+        [1, 3],
+        [5, 6],
+      ])
+    ).toEqual([
+      [1, 3],
+      [5, 6],
+    ]);
+  });
+
+  it("sorts before merging", () => {
+    expect(
+      coalesce([
+        [5, 6],
+        [1, 3],
+        [4, 4],
+      ])
+    ).toEqual([[1, 6]]);
+  });
+});
+
+describe("mergePresence", () => {
+  it("is the identity when no frames are dirty", () => {
+    expect(mergePresence([[1, 10]], [], [])).toEqual([[1, 10]]);
+  });
+
+  it("drops a dirty frame the overlay no longer has (deletion)", () => {
+    expect(mergePresence([[1, 10]], [5], [])).toEqual([
+      [1, 4],
+      [6, 10],
+    ]);
+  });
+
+  it("re-adds a dirty frame the overlay still has (untouched presence)", () => {
+    expect(mergePresence([[1, 10]], [5], [5])).toEqual([[1, 10]]);
+  });
+
+  it("extends presence onto a fresh dirty frame", () => {
+    expect(mergePresence([[1, 5]], [6], [6])).toEqual([[1, 6]]);
+  });
+
+  it("builds presence entirely from the overlay for a new track", () => {
+    expect(mergePresence([], [3, 4, 5], [3, 4, 5])).toEqual([[3, 5]]);
+  });
+});

--- a/app/packages/video-annotation/src/tracks/segments.ts
+++ b/app/packages/video-annotation/src/tracks/segments.ts
@@ -1,0 +1,87 @@
+/** An inclusive `[startFrame, endFrame]` presence run (1-indexed). */
+export type Segment = [number, number];
+
+/**
+ * Drop a sorted set of frame numbers from `segments`, splitting runs as needed.
+ *
+ * Bounded by the number of removed frames, never by run length — a removed
+ * frame inside `[s, e]` splits it without ever enumerating the run. Frames
+ * outside every segment are no-ops. `removeSorted` must be ascending.
+ */
+export function removeFrames(
+  segments: readonly Segment[],
+  removeSorted: readonly number[]
+): Segment[] {
+  if (removeSorted.length === 0) {
+    return segments.map(([s, e]) => [s, e]);
+  }
+
+  const out: Segment[] = [];
+  for (const [start, end] of segments) {
+    let cursor = start;
+
+    for (const frame of removeSorted) {
+      if (frame < start || frame > end) {
+        continue;
+      }
+
+      if (frame > cursor) {
+        out.push([cursor, frame - 1]);
+      }
+
+      cursor = frame + 1;
+    }
+
+    if (cursor <= end) {
+      out.push([cursor, end]);
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Merge overlapping or adjacent runs into maximal segments. Adjacent means
+ * touching by one frame (`[1,3]` + `[4,6]` → `[1,6]`), matching contiguous
+ * presence. Input need not be sorted.
+ */
+export function coalesce(segments: readonly Segment[]): Segment[] {
+  if (segments.length <= 1) {
+    return segments.map(([s, e]) => [s, e]);
+  }
+
+  const sorted = segments.map(([s, e]): Segment => [s, e]);
+  sorted.sort((a, b) => a[0] - b[0]);
+
+  const out: Segment[] = [sorted[0]];
+  for (let i = 1; i < sorted.length; i++) {
+    const last = out[out.length - 1];
+    const [start, end] = sorted[i];
+
+    if (start <= last[1] + 1) {
+      last[1] = Math.max(last[1], end);
+      continue;
+    }
+
+    out.push([start, end]);
+  }
+
+  return out;
+}
+
+/**
+ * Reconcile a baseline against a small dirty-frame edit set: drop every dirty
+ * frame from the baseline, then add back the frames the live overlay confirms
+ * present. The result is the merged presence in segment space — bounded by the
+ * dirty-frame count, with no whole-clip expansion.
+ */
+export function mergePresence(
+  baseline: readonly Segment[],
+  dirtySorted: readonly number[],
+  presentSorted: readonly number[]
+): Segment[] {
+  const kept = removeFrames(baseline, dirtySorted);
+  const added = presentSorted.map((frame): Segment => [frame, frame]);
+
+  return coalesce([...kept, ...added]);
+}

--- a/fiftyone/server/routes/__init__.py
+++ b/fiftyone/server/routes/__init__.py
@@ -31,6 +31,7 @@ from .sort import Sort
 from .tag import Tag
 from .tagging import Tagging
 from .values import Values
+from .video_labels import VideoLabelsIndex, VideoLabelsWindow
 
 multimodal_routes = []
 if is_feature_enabled("VFF_MULTIMODAL"):
@@ -66,5 +67,7 @@ routes = (
         ("/tagging", Tagging),
         ("/values", Values),
         ("/get-similar-labels-frames", GetSimilarLabelsFrameCollection),
+        ("/video-labels/index", VideoLabelsIndex),
+        ("/video-labels/window", VideoLabelsWindow),
     ]
 )

--- a/fiftyone/server/routes/frames.py
+++ b/fiftyone/server/routes/frames.py
@@ -30,6 +30,10 @@ class Frames(HTTPEndpoint):
         dataset = data.get("dataset")
         stages = data.get("view")
         sample_id = data.get("sampleId")
+        # Optional field projection: callers that need only a few frame fields
+        # (e.g. the ImaVid image stream wants just `filepath`) pass them here to
+        # avoid shipping the whole frame document.
+        fields = data.get("fields")
 
         view = await fosv.get_view(
             dataset, stages=stages, extended_stages=extended, awaitable=True
@@ -55,9 +59,19 @@ class Frames(HTTPEndpoint):
 
         view = await run_sync_task(run, view)
 
+        post_pipeline = None
+        if fields:
+            projection = {"frame_number": True}
+            for field in fields:
+                projection[field] = True
+
+            post_pipeline = [{"$project": projection}]
+
         frames = await foo.aggregate(
             foo.get_async_db_conn()[view._dataset._sample_collection_name],
-            view._pipeline(frames_only=True, support=support),
+            view._pipeline(
+                frames_only=True, support=support, post_pipeline=post_pipeline
+            ),
         ).to_list(end_frame - start_frame + 1)
 
         return JSONResponse(

--- a/fiftyone/server/routes/video_labels.py
+++ b/fiftyone/server/routes/video_labels.py
@@ -61,6 +61,42 @@ def run_length_encode(frames: t.Iterable[int]) -> t.List[t.List[int]]:
     return runs
 
 
+def run_length_encode_values(
+    pairs: t.Iterable[t.Tuple[int, t.Any]],
+) -> t.List[list]:
+    """Fold ``(frame, value)`` pairs into ``[start, end, value]`` value runs.
+
+    A run breaks on a value change OR a non-contiguous frame (a presence gap),
+    mirroring the dense per-frame attribute segmentation the client used before
+    the index existed. Later samples win on a duplicate frame; output is
+    frame-ordered. Like presence runs this is O(value-changes) on the wire, not
+    O(labels) — a dynamic attribute that never changes is a single run.
+    """
+    by_frame: t.Dict[int, t.Any] = {}
+    for frame, value in pairs:
+        by_frame[frame] = value
+
+    ordered = sorted(by_frame.items())
+    if not ordered:
+        return []
+
+    runs: t.List[list] = []
+    start, prev = ordered[0][0], ordered[0][0]
+    run_value = ordered[0][1]
+
+    for frame, value in ordered[1:]:
+        if frame == prev + 1 and value == run_value:
+            prev = frame
+            continue
+
+        runs.append([start, prev, run_value])
+        start = prev = frame
+        run_value = value
+
+    runs.append([start, prev, run_value])
+    return runs
+
+
 def resolve_label_list_field(dataset, field: str) -> t.Optional[str]:
     """The label-list subfield for a frame field, or ``None`` for a single label.
 
@@ -76,7 +112,9 @@ def resolve_label_list_field(dataset, field: str) -> t.Optional[str]:
 
 
 def index_post_pipeline(
-    field: str, list_field: t.Optional[str]
+    field: str,
+    list_field: t.Optional[str],
+    dynamic_attributes: t.Sequence[str] = (),
 ) -> t.List[dict]:
     """Mongo stages that group a frame field's labels into per-instance state.
 
@@ -86,8 +124,39 @@ def index_post_pipeline(
     fragment into single-frame entries — exactly as the client's frame walk
     does today. The run-length encoding itself happens in Python on the
     grouped output; see :func:`run_length_encode`.
+
+    When ``dynamic_attributes`` is non-empty the group also pushes each present
+    frame's value for those attributes (one ``{fn, <attr>: ...}`` sample per
+    frame), which :func:`build_instance_index` folds into per-attribute value
+    runs. The same unwind/group scan already visits every label, so collecting
+    the values is near-free; the cost the column adds is the pushed array, paid
+    only for the attributes the caller asks for.
     """
     labels_expr = "$%s.%s" % (field, list_field) if list_field else "$" + field
+
+    group: dict = {
+        "_id": {"$ifNull": ["$labels.instance._id", "$labels._id"]},
+        "frames": {"$addToSet": "$fn"},
+        "keyframes": {
+            "$addToSet": {
+                "$cond": [
+                    {"$eq": ["$labels.keyframe", True]},
+                    "$fn",
+                    None,
+                ]
+            }
+        },
+        "classLabel": {"$first": "$labels.label"},
+        "persistedIndex": {"$first": "$labels.index"},
+        "instance": {"$first": "$labels.instance"},
+    }
+
+    if dynamic_attributes:
+        sample = {"fn": "$fn"}
+        for attr in dynamic_attributes:
+            sample[attr] = "$labels.%s" % attr
+
+        group["attributeSamples"] = {"$push": sample}
 
     return [
         {
@@ -98,35 +167,29 @@ def index_post_pipeline(
             }
         },
         {"$unwind": "$labels"},
-        {
-            "$group": {
-                "_id": {"$ifNull": ["$labels.instance._id", "$labels._id"]},
-                "frames": {"$addToSet": "$fn"},
-                "keyframes": {
-                    "$addToSet": {
-                        "$cond": [
-                            {"$eq": ["$labels.keyframe", True]},
-                            "$fn",
-                            None,
-                        ]
-                    }
-                },
-                "classLabel": {"$first": "$labels.label"},
-                "persistedIndex": {"$first": "$labels.index"},
-                "instance": {"$first": "$labels.instance"},
-            }
-        },
+        {"$group": group},
     ]
 
 
-def build_instance_index(groups: t.Iterable[dict]) -> t.List[dict]:
+def build_instance_index(
+    groups: t.Iterable[dict],
+    dynamic_attributes: t.Sequence[str] = (),
+) -> t.List[dict]:
     """Turn grouped Mongo output into the per-instance index entries.
 
     One entry per instance: RLE presence ``segments``, the frames carrying a
     ``keyframe`` flag, and the class/index/instance metadata the client needs
     to label and color the row. Keyframes are empty for legacy data with no
     ``keyframe`` attribute — the client treats that as "no keyframes".
+
+    When ``dynamic_attributes`` is non-empty each entry also carries an
+    ``attributeSegments`` map: ``{attr: [[start, end, value], ...]}`` of value
+    runs across the instance's presence (a frame where the attribute is absent
+    contributes a ``null``-valued run, so "unset" reads as its own segment).
+    The key is omitted entirely when no dynamic attributes were requested, so
+    the response shape is unchanged for the presence-only path.
     """
+    dynamic_attributes = list(dynamic_attributes)
     instances: t.List[dict] = []
 
     for group in groups:
@@ -142,26 +205,44 @@ def build_instance_index(groups: t.Iterable[dict]) -> t.List[dict]:
             }
         )
 
-        instances.append(
-            {
-                "instanceId": str(group["_id"]),
-                "classLabel": group.get("classLabel"),
-                "persistedIndex": group.get("persistedIndex"),
-                "instance": group.get("instance"),
-                "segments": segments,
-                "keyframes": keyframes,
-            }
-        )
+        entry = {
+            "instanceId": str(group["_id"]),
+            "classLabel": group.get("classLabel"),
+            "persistedIndex": group.get("persistedIndex"),
+            "instance": group.get("instance"),
+            "segments": segments,
+            "keyframes": keyframes,
+        }
+
+        if dynamic_attributes:
+            samples = group.get("attributeSamples") or []
+            attribute_segments: t.Dict[str, t.List[list]] = {}
+            for attr in dynamic_attributes:
+                runs = run_length_encode_values(
+                    (sample["fn"], sample.get(attr)) for sample in samples
+                )
+                if runs:
+                    attribute_segments[attr] = runs
+
+            entry["attributeSegments"] = attribute_segments
+
+        instances.append(entry)
 
     return instances
 
 
-async def aggregate_index(view, fields: t.Iterable[str]) -> t.Dict[str, dict]:
+async def aggregate_index(
+    view,
+    fields: t.Iterable[str],
+    dynamic_attributes: t.Sequence[str] = (),
+) -> t.Dict[str, dict]:
     """Run the per-instance index aggregation for each requested field.
 
     ``view`` is expected to already select the single video sample. Returns
     ``{field: {"instances": [...]}}`` with frame numbers and ObjectIds still
-    raw — the route stringifies on the way out.
+    raw — the route stringifies on the way out. ``dynamic_attributes`` adds the
+    per-instance ``attributeSegments`` value runs (see
+    :func:`build_instance_index`).
     """
     collection = foo.get_async_db_conn()[view._dataset._sample_collection_name]
 
@@ -170,10 +251,14 @@ async def aggregate_index(view, fields: t.Iterable[str]) -> t.Dict[str, dict]:
         list_field = resolve_label_list_field(view._dataset, field)
         pipeline = view._pipeline(
             frames_only=True,
-            post_pipeline=index_post_pipeline(field, list_field),
+            post_pipeline=index_post_pipeline(
+                field, list_field, dynamic_attributes
+            ),
         )
         groups = await foo.aggregate(collection, pipeline).to_list(None)
-        result[field] = {"instances": build_instance_index(groups)}
+        result[field] = {
+            "instances": build_instance_index(groups, dynamic_attributes)
+        }
 
     return result
 
@@ -186,6 +271,7 @@ class VideoLabelsIndex(HTTPEndpoint):
         extended = data.get("extended", None)
         sample_id = data.get("sampleId")
         fields = data.get("fields") or []
+        dynamic_attributes = data.get("dynamicAttributes") or []
 
         view = await fosv.get_view(
             dataset, stages=stages, extended_stages=extended, awaitable=True
@@ -197,7 +283,7 @@ class VideoLabelsIndex(HTTPEndpoint):
             )
 
         view = await run_sync_task(select, view)
-        result = await aggregate_index(view, fields)
+        result = await aggregate_index(view, fields, dynamic_attributes)
 
         return JSONResponse(foj.stringify(result))
 

--- a/fiftyone/server/routes/video_labels.py
+++ b/fiftyone/server/routes/video_labels.py
@@ -1,0 +1,280 @@
+"""
+FiftyOne Server /video-labels routes
+
+Scalable label loading for the video annotation surface. Two endpoints,
+two responsibilities:
+
+- ``/video-labels/index`` returns the per-instance presence distribution
+  across the whole clip as run-length-encoded frame segments (plus keyframe
+  frames). It drives the timeline tracks without loading any label payloads,
+  so the surface no longer fetches every frame on mount.
+- ``/video-labels/window`` returns full, field-projected label payloads for a
+  bounded frame range. It is the playback stream's windowed read — the
+  resident set — and replaces the general-purpose ``/frames`` chunk seed.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import typing as t
+
+from starlette.endpoints import HTTPEndpoint
+from starlette.responses import JSONResponse
+from starlette.requests import Request
+
+from fiftyone.core.expressions import ViewField as F
+import fiftyone.core.fields as fof
+import fiftyone.core.json as foj
+import fiftyone.core.odm as foo
+from fiftyone.core.utils import run_sync_task
+import fiftyone.core.view as fov
+
+from fiftyone.server.decorators import route
+import fiftyone.server.view as fosv
+
+
+def run_length_encode(frames: t.Iterable[int]) -> t.List[t.List[int]]:
+    """Fold a set of frame numbers into contiguous ``[start, end]`` runs.
+
+    The frames need not be sorted or unique. Consecutive integers collapse
+    into one inclusive segment; a gap starts a new one. An instance present
+    for the whole clip becomes a single segment regardless of length — this
+    is what keeps the index O(segments) on the wire rather than O(labels).
+    """
+    ordered = sorted(set(frames))
+    if not ordered:
+        return []
+
+    runs: t.List[t.List[int]] = []
+    start = prev = ordered[0]
+
+    for frame in ordered[1:]:
+        if frame == prev + 1:
+            prev = frame
+            continue
+
+        runs.append([start, prev])
+        start = prev = frame
+
+    runs.append([start, prev])
+    return runs
+
+
+def resolve_label_list_field(dataset, field: str) -> t.Optional[str]:
+    """The label-list subfield for a frame field, or ``None`` for a single label.
+
+    A ``Detections`` field stores its labels under ``detections``, ``Polylines``
+    under ``polylines``, and so on; the index unwinds that list. A single-label
+    field (e.g. ``Detection``) has no list and is unwound directly.
+    """
+    field_obj = dataset.get_frame_field_schema().get(field)
+    if not isinstance(field_obj, fof.EmbeddedDocumentField):
+        return None
+
+    return getattr(field_obj.document_type, "_LABEL_LIST_FIELD", None)
+
+
+def index_post_pipeline(
+    field: str, list_field: t.Optional[str]
+) -> t.List[dict]:
+    """Mongo stages that group a frame field's labels into per-instance state.
+
+    Appended after ``frames_only`` makes per-frame documents the pipeline's
+    input. Groups by ``instance._id`` (the engine's track keystone), falling
+    back to the per-frame label ``_id`` so instance-less legacy detections
+    fragment into single-frame entries — exactly as the client's frame walk
+    does today. The run-length encoding itself happens in Python on the
+    grouped output; see :func:`run_length_encode`.
+    """
+    labels_expr = "$%s.%s" % (field, list_field) if list_field else "$" + field
+
+    return [
+        {
+            "$project": {
+                "_id": False,
+                "fn": "$frame_number",
+                "labels": {"$ifNull": [labels_expr, []]},
+            }
+        },
+        {"$unwind": "$labels"},
+        {
+            "$group": {
+                "_id": {"$ifNull": ["$labels.instance._id", "$labels._id"]},
+                "frames": {"$addToSet": "$fn"},
+                "keyframes": {
+                    "$addToSet": {
+                        "$cond": [
+                            {"$eq": ["$labels.keyframe", True]},
+                            "$fn",
+                            None,
+                        ]
+                    }
+                },
+                "classLabel": {"$first": "$labels.label"},
+                "persistedIndex": {"$first": "$labels.index"},
+                "instance": {"$first": "$labels.instance"},
+            }
+        },
+    ]
+
+
+def build_instance_index(groups: t.Iterable[dict]) -> t.List[dict]:
+    """Turn grouped Mongo output into the per-instance index entries.
+
+    One entry per instance: RLE presence ``segments``, the frames carrying a
+    ``keyframe`` flag, and the class/index/instance metadata the client needs
+    to label and color the row. Keyframes are empty for legacy data with no
+    ``keyframe`` attribute — the client treats that as "no keyframes".
+    """
+    instances: t.List[dict] = []
+
+    for group in groups:
+        segments = run_length_encode(group.get("frames") or [])
+        if not segments:
+            continue
+
+        keyframes = sorted(
+            {
+                frame
+                for frame in (group.get("keyframes") or [])
+                if frame is not None
+            }
+        )
+
+        instances.append(
+            {
+                "instanceId": str(group["_id"]),
+                "classLabel": group.get("classLabel"),
+                "persistedIndex": group.get("persistedIndex"),
+                "instance": group.get("instance"),
+                "segments": segments,
+                "keyframes": keyframes,
+            }
+        )
+
+    return instances
+
+
+async def aggregate_index(view, fields: t.Iterable[str]) -> t.Dict[str, dict]:
+    """Run the per-instance index aggregation for each requested field.
+
+    ``view`` is expected to already select the single video sample. Returns
+    ``{field: {"instances": [...]}}`` with frame numbers and ObjectIds still
+    raw — the route stringifies on the way out.
+    """
+    collection = foo.get_async_db_conn()[view._dataset._sample_collection_name]
+
+    result: t.Dict[str, dict] = {}
+    for field in fields:
+        list_field = resolve_label_list_field(view._dataset, field)
+        pipeline = view._pipeline(
+            frames_only=True,
+            post_pipeline=index_post_pipeline(field, list_field),
+        )
+        groups = await foo.aggregate(collection, pipeline).to_list(None)
+        result[field] = {"instances": build_instance_index(groups)}
+
+    return result
+
+
+class VideoLabelsIndex(HTTPEndpoint):
+    @route
+    async def post(self, request: Request, data: dict):
+        dataset = data.get("dataset")
+        stages = data.get("view")
+        extended = data.get("extended", None)
+        sample_id = data.get("sampleId")
+        fields = data.get("fields") or []
+
+        view = await fosv.get_view(
+            dataset, stages=stages, extended_stages=extended, awaitable=True
+        )
+
+        def select(view):
+            return fov.make_optimized_select_view(
+                view, sample_id, flatten=True
+            )
+
+        view = await run_sync_task(select, view)
+        result = await aggregate_index(view, fields)
+
+        return JSONResponse(foj.stringify(result))
+
+
+class VideoLabelsWindow(HTTPEndpoint):
+    @route
+    async def post(self, request: Request, data: dict):
+        start_frame = int(data.get("startFrame", 1))
+        end_frame = int(data.get("endFrame", start_frame))
+        dataset = data.get("dataset")
+        stages = data.get("view")
+        extended = data.get("extended", None)
+        sample_id = data.get("sampleId")
+        fields = data.get("fields") or []
+
+        view = await fosv.get_view(
+            dataset, stages=stages, extended_stages=extended, awaitable=True
+        )
+        support = None if stages else [start_frame, end_frame]
+
+        def run(view):
+            view = fov.make_optimized_select_view(
+                view, sample_id, flatten=True
+            )
+
+            if not support:
+                view = view.set_field(
+                    "frames",
+                    F("frames").filter(
+                        (F("frame_number") >= start_frame)
+                        & (F("frame_number") <= end_frame)
+                    ),
+                )
+
+            return view
+
+        view = await run_sync_task(run, view)
+        windowed = await aggregate_window(view, fields, support)
+
+        return JSONResponse(
+            {
+                "frames": foj.stringify(windowed),
+                "range": [start_frame, end_frame],
+            }
+        )
+
+
+async def aggregate_window(
+    view, fields: t.Iterable[str], support: t.Optional[t.List[int]]
+) -> t.Dict[str, dict]:
+    """Read field-projected label payloads for the windowed frames.
+
+    Returns ``{frame_number: {field: payload}}`` keyed by stringified frame
+    number, dropping fields a frame doesn't carry. ``view`` already selects the
+    sample and limits the frame range (via ``support`` or a ``$filter`` stage).
+    """
+    fields = list(fields)
+    project = {"frame_number": True}
+    for field in fields:
+        project[field] = True
+
+    frames = await foo.aggregate(
+        foo.get_async_db_conn()[view._dataset._sample_collection_name],
+        view._pipeline(
+            frames_only=True,
+            support=support,
+            post_pipeline=[{"$project": project}],
+        ),
+    ).to_list(None)
+
+    windowed: t.Dict[str, dict] = {}
+    for frame in frames:
+        frame_number = frame.get("frame_number")
+        windowed[str(frame_number)] = {
+            field: frame[field]
+            for field in fields
+            if frame.get(field) is not None
+        }
+
+    return windowed

--- a/tests/unittests/server_frames_tests.py
+++ b/tests/unittests/server_frames_tests.py
@@ -1,0 +1,71 @@
+"""
+FiftyOne Server /frames route tests.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import unittest
+
+import fiftyone as fo
+import fiftyone.core.odm as foo
+import fiftyone.core.view as fov
+
+from decorators import drop_async_dataset
+
+
+def _frames_projection(fields):
+    projection = {"frame_number": True}
+    for field in fields:
+        projection[field] = True
+
+    return [{"$project": projection}]
+
+
+class FramesProjectionTests(unittest.IsolatedAsyncioTestCase):
+    @drop_async_dataset
+    async def test_field_projection_drops_other_fields(self, dataset):
+        video = fo.Sample(filepath="video.mp4")
+        for frame_number in range(1, 4):
+            video[frame_number]["detections"] = fo.Detections(
+                detections=[fo.Detection(label="person")]
+            )
+            video[frame_number]["other"] = fo.Detections(
+                detections=[fo.Detection(label="thing")]
+            )
+        dataset.add_sample(video)
+
+        view = fov.make_optimized_select_view(
+            dataset.view(), video.id, flatten=True
+        )
+        collection = foo.get_async_db_conn()[
+            view._dataset._sample_collection_name
+        ]
+
+        # Projected read: only `frame_number` + the requested field.
+        projected = await foo.aggregate(
+            collection,
+            view._pipeline(
+                frames_only=True,
+                support=[1, 3],
+                post_pipeline=_frames_projection(["detections"]),
+            ),
+        ).to_list(None)
+
+        self.assertEqual(len(projected), 3)
+        self.assertIn("detections", projected[0])
+        self.assertNotIn("other", projected[0])
+
+        # Unprojected read still carries every frame field.
+        full = await foo.aggregate(
+            collection,
+            view._pipeline(frames_only=True, support=[1, 3]),
+        ).to_list(None)
+
+        self.assertIn("detections", full[0])
+        self.assertIn("other", full[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unittests/server_video_labels_tests.py
+++ b/tests/unittests/server_video_labels_tests.py
@@ -16,6 +16,7 @@ from fiftyone.server.routes.video_labels import (
     build_instance_index,
     resolve_label_list_field,
     run_length_encode,
+    run_length_encode_values,
 )
 
 from decorators import drop_async_dataset
@@ -42,7 +43,84 @@ class RunLengthEncodeTests(unittest.TestCase):
         )
 
 
+class RunLengthEncodeValuesTests(unittest.TestCase):
+    def test_empty(self):
+        self.assertEqual(run_length_encode_values([]), [])
+
+    def test_uniform_is_single_run(self):
+        self.assertEqual(
+            run_length_encode_values([(1, "off"), (2, "off"), (3, "off")]),
+            [[1, 3, "off"]],
+        )
+
+    def test_value_change_splits(self):
+        self.assertEqual(
+            run_length_encode_values(
+                [(1, "off"), (2, "off"), (3, "left"), (4, "left")]
+            ),
+            [[1, 2, "off"], [3, 4, "left"]],
+        )
+
+    def test_presence_gap_splits_equal_values(self):
+        self.assertEqual(
+            run_length_encode_values([(1, "off"), (2, "off"), (4, "off")]),
+            [[1, 2, "off"], [4, 4, "off"]],
+        )
+
+    def test_none_is_its_own_run(self):
+        self.assertEqual(
+            run_length_encode_values([(1, None), (2, "left"), (3, None)]),
+            [[1, 1, None], [2, 2, "left"], [3, 3, None]],
+        )
+
+    def test_unsorted_and_duplicate_frame_last_wins(self):
+        self.assertEqual(
+            run_length_encode_values([(2, "left"), (1, "off"), (2, "right")]),
+            [[1, 1, "off"], [2, 2, "right"]],
+        )
+
+
 class BuildInstanceIndexTests(unittest.TestCase):
+    def test_dynamic_attribute_segments(self):
+        groups = [
+            {
+                "_id": "abc",
+                "frames": [1, 2, 3, 4],
+                "keyframes": [],
+                "classLabel": "car",
+                "persistedIndex": 1,
+                "instance": {"_cls": "Instance", "_id": "abc"},
+                "attributeSamples": [
+                    {"fn": 1, "turn_signal": "off"},
+                    {"fn": 2, "turn_signal": "off"},
+                    {"fn": 3, "turn_signal": "left"},
+                    # frame 4 carries no turn_signal -> a null-valued run.
+                    {"fn": 4},
+                ],
+            }
+        ]
+
+        [entry] = build_instance_index(groups, ["turn_signal"])
+
+        self.assertEqual(
+            entry["attributeSegments"]["turn_signal"],
+            [[1, 2, "off"], [3, 3, "left"], [4, 4, None]],
+        )
+
+    def test_attribute_segments_omitted_without_dynamic_attributes(self):
+        groups = [
+            {
+                "_id": "abc",
+                "frames": [1, 2],
+                "keyframes": [],
+                "attributeSamples": [{"fn": 1, "turn_signal": "off"}],
+            }
+        ]
+
+        [entry] = build_instance_index(groups)
+
+        self.assertNotIn("attributeSegments", entry)
+
     def test_skips_empty_and_filters_none_keyframes(self):
         groups = [
             {
@@ -133,6 +211,44 @@ class VideoLabelsAggregationTests(unittest.IsolatedAsyncioTestCase):
         # The instance-less detection fragments into a single-frame entry.
         self.assertEqual(by_id[id_legacy]["segments"], [[1, 1]])
         self.assertEqual(by_id[id_legacy]["classLabel"], "car")
+
+    @drop_async_dataset
+    async def test_index_dynamic_attribute_segments(self, dataset):
+        inst = fo.Instance()
+
+        video = fo.Sample(filepath="video.mp4")
+        # turn_signal: off (1-2) -> left (3-4); the attribute is absent on
+        # frame 5, which must read back as a null-valued run.
+        signals = {1: "off", 2: "off", 3: "left", 4: "left"}
+        for frame_number in range(1, 6):
+            detection = fo.Detection(label="car", index=1, instance=inst)
+            if frame_number in signals:
+                detection["turn_signal"] = signals[frame_number]
+
+            video[frame_number]["detections"] = fo.Detections(
+                detections=[detection]
+            )
+        dataset.add_sample(video)
+
+        instance_id = str(video[1]["detections"].detections[0].instance._id)
+
+        view = fov.make_optimized_select_view(
+            dataset.view(), video.id, flatten=True
+        )
+        result = await aggregate_index(view, ["detections"], ["turn_signal"])
+
+        [entry] = result["detections"]["instances"]
+        self.assertEqual(entry["instanceId"], instance_id)
+        self.assertEqual(
+            entry["attributeSegments"]["turn_signal"],
+            [[1, 2, "off"], [3, 4, "left"], [5, 5, None]],
+        )
+
+        # Without dynamicAttributes the column is absent (unchanged shape).
+        plain = await aggregate_index(view, ["detections"])
+        self.assertNotIn(
+            "attributeSegments", plain["detections"]["instances"][0]
+        )
 
     @drop_async_dataset
     async def test_window_projects_fields_and_range(self, dataset):

--- a/tests/unittests/server_video_labels_tests.py
+++ b/tests/unittests/server_video_labels_tests.py
@@ -1,0 +1,175 @@
+"""
+FiftyOne Server /video-labels route tests.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import unittest
+
+import fiftyone as fo
+import fiftyone.core.view as fov
+from fiftyone.server.routes.video_labels import (
+    aggregate_index,
+    aggregate_window,
+    build_instance_index,
+    resolve_label_list_field,
+    run_length_encode,
+)
+
+from decorators import drop_async_dataset
+
+
+class RunLengthEncodeTests(unittest.TestCase):
+    def test_empty(self):
+        self.assertEqual(run_length_encode([]), [])
+
+    def test_single(self):
+        self.assertEqual(run_length_encode([7]), [[7, 7]])
+
+    def test_contiguous(self):
+        self.assertEqual(run_length_encode([1, 2, 3, 4]), [[1, 4]])
+
+    def test_gaps(self):
+        self.assertEqual(
+            run_length_encode([1, 2, 3, 5, 6, 9]), [[1, 3], [5, 6], [9, 9]]
+        )
+
+    def test_unsorted_and_duplicated(self):
+        self.assertEqual(
+            run_length_encode([6, 1, 2, 5, 2, 3]), [[1, 3], [5, 6]]
+        )
+
+
+class BuildInstanceIndexTests(unittest.TestCase):
+    def test_skips_empty_and_filters_none_keyframes(self):
+        groups = [
+            {
+                "_id": "abc",
+                "frames": [3, 1, 2],
+                "keyframes": [None, 2, None],
+                "classLabel": "person",
+                "persistedIndex": 1,
+                "instance": {"_cls": "Instance", "_id": "abc"},
+            },
+            # No frames -> dropped entirely.
+            {"_id": "empty", "frames": [], "keyframes": []},
+        ]
+
+        instances = build_instance_index(groups)
+
+        self.assertEqual(len(instances), 1)
+        entry = instances[0]
+        self.assertEqual(entry["instanceId"], "abc")
+        self.assertEqual(entry["segments"], [[1, 3]])
+        self.assertEqual(entry["keyframes"], [2])
+        self.assertEqual(entry["classLabel"], "person")
+        self.assertEqual(entry["persistedIndex"], 1)
+
+
+class VideoLabelsAggregationTests(unittest.IsolatedAsyncioTestCase):
+    @drop_async_dataset
+    async def test_index_segments_keyframes_and_legacy(self, dataset):
+        inst_a = fo.Instance()
+        inst_b = fo.Instance()
+
+        video = fo.Sample(filepath="video.mp4")
+        # A present 1-3 then 5-6 (gap at 4); keyframe at 2.
+        # B present 2-4. A legacy instance-less "car" sits on frame 1 only.
+        video[1]["detections"] = fo.Detections(
+            detections=[
+                fo.Detection(label="person", index=1, instance=inst_a),
+                fo.Detection(label="car"),
+            ]
+        )
+        video[2]["detections"] = fo.Detections(
+            detections=[
+                fo.Detection(
+                    label="person", index=1, instance=inst_a, keyframe=True
+                ),
+                fo.Detection(label="person", index=2, instance=inst_b),
+            ]
+        )
+        video[3]["detections"] = fo.Detections(
+            detections=[
+                fo.Detection(label="person", index=1, instance=inst_a),
+                fo.Detection(label="person", index=2, instance=inst_b),
+            ]
+        )
+        video[4]["detections"] = fo.Detections(
+            detections=[fo.Detection(label="person", index=2, instance=inst_b)]
+        )
+        video[5]["detections"] = fo.Detections(
+            detections=[fo.Detection(label="person", index=1, instance=inst_a)]
+        )
+        video[6]["detections"] = fo.Detections(
+            detections=[fo.Detection(label="person", index=1, instance=inst_a)]
+        )
+        dataset.add_sample(video)
+
+        id_a = str(video[1]["detections"].detections[0].instance._id)
+        id_b = str(video[2]["detections"].detections[1].instance._id)
+        id_legacy = str(video[1]["detections"].detections[1]._id)
+
+        view = fov.make_optimized_select_view(
+            dataset.view(), video.id, flatten=True
+        )
+        result = await aggregate_index(view, ["detections"])
+
+        instances = result["detections"]["instances"]
+        by_id = {entry["instanceId"]: entry for entry in instances}
+
+        self.assertEqual(set(by_id), {id_a, id_b, id_legacy})
+
+        self.assertEqual(by_id[id_a]["segments"], [[1, 3], [5, 6]])
+        self.assertEqual(by_id[id_a]["keyframes"], [2])
+        self.assertEqual(by_id[id_a]["classLabel"], "person")
+        self.assertEqual(by_id[id_a]["persistedIndex"], 1)
+
+        self.assertEqual(by_id[id_b]["segments"], [[2, 4]])
+        self.assertEqual(by_id[id_b]["keyframes"], [])
+
+        # The instance-less detection fragments into a single-frame entry.
+        self.assertEqual(by_id[id_legacy]["segments"], [[1, 1]])
+        self.assertEqual(by_id[id_legacy]["classLabel"], "car")
+
+    @drop_async_dataset
+    async def test_window_projects_fields_and_range(self, dataset):
+        video = fo.Sample(filepath="video.mp4")
+        for frame_number in range(1, 6):
+            video[frame_number]["detections"] = fo.Detections(
+                detections=[fo.Detection(label="person")]
+            )
+            video[frame_number]["other"] = fo.Detections(
+                detections=[fo.Detection(label="thing")]
+            )
+        dataset.add_sample(video)
+
+        view = fov.make_optimized_select_view(
+            dataset.view(), video.id, flatten=True
+        )
+        windowed = await aggregate_window(view, ["detections"], [2, 4])
+
+        # Only the requested range, only the requested field.
+        self.assertEqual(set(windowed), {"2", "3", "4"})
+        self.assertIn("detections", windowed["2"])
+        self.assertNotIn("other", windowed["2"])
+        self.assertEqual(len(windowed["3"]["detections"]["detections"]), 1)
+
+    @drop_async_dataset
+    async def test_resolve_label_list_field(self, dataset):
+        video = fo.Sample(filepath="video.mp4")
+        video[1]["detections"] = fo.Detections(
+            detections=[fo.Detection(label="person")]
+        )
+        dataset.add_sample(video)
+
+        self.assertEqual(
+            resolve_label_list_field(dataset, "detections"), "detections"
+        )
+        self.assertIsNone(resolve_label_list_field(dataset, "frame_number"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Scales video-annotation label loading from "fetch the whole clip on mount" toward windowed, projection-based reads. Today the timeline forces every frame's labels into memory on open (an O(clip) load + walk); this introduces label-distribution and windowed-payload endpoints so the surface loads only what it needs.

Three endpoint changes, all integrated end-to-end:

- **`POST /video-labels/index`** — per-instance presence distribution across the whole clip as run-length-encoded `[startFrame, endFrame]` segments (+ keyframes), **projection-only, no label payloads**. Drives the timeline tracks. Wire size is O(segments), not O(labels).
- **`POST /video-labels/window`** — field-projected label payloads for a bounded frame range. **Replaces `/frames` as the labels-stream seed** (leaner: only the requested label fields).
- **`/frames` + optional `fields` projection** — the ImaVid image stream now requests just `["filepath"]` instead of the whole frame document, eliminating an over-fetch on the media path.

## How it works

- **Timeline** = the server index **merged with the engine's edited-frame overlay**. The index is the server baseline (fetched once on mount); the engine's dirty frames shadow it frame-for-frame, so in-session edits (new tracks, deletions, extended presence) show immediately without re-fetching or walking the clip. The merge stays in segment space — bounded by the dirty-frame count, never the clip length.
- The engine gains a small `dirtyFrames()` read on the store contract (the overlay half of the merge).

## Testing

- Backend: 10 unit tests (index aggregation incl. multi-segment/gap tracks, keyframes, legacy instance-less fragmentation; window projection; `/frames` projection).
- App: video-annotation 149 + annotation-engine 248 unit tests; new segment-algebra + index-merge suites (20).
- e2e: full annotation set — **13/13 video** (timeline, draw/delete/edit, navigation, temporal, auto-extend, all three live endpoint paths) + **47/47 non-video** (no regression from the store-contract change).
- Benchmarked: a 10-min clip indexes in ~150 ms / ~280 KB; window reads are flat ~10 ms regardless of clip length.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scalable video label indexing and windowed loading to speed up timeline browsing.
  * Introduced frame-field projection to fetch only requested frame data.
  * Added tracking of in-session edited (“dirty”) frames to power correct overlays.
* **Bug Fixes / Improvements**
  * Improved track rebuilding by combining server-provided labels with in-session edits.
  * Updated frame/label loading to reduce payloads and improve responsiveness.
* **Tests**
  * Added unit and component tests covering the new label indexing/windowing and presence/overlay logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->