### PR TITLE
feat(annotation): live preview of label edits via the label-patch signal

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -70,7 +70,7 @@
         "react-plotly.js": "^2.6.0"
     },
     "resolutions": {
-        "@voxel51/voodo": "^0.0.35",
+        "@voxel51/voodo": "^0.0.36",
         "brace-expansion": "^5.0.6",
         "three-stdlib": "^2.36.1",
         "@types/react": "18.2.0",

--- a/app/packages/annotation/src/engine/index.ts
+++ b/app/packages/annotation/src/engine/index.ts
@@ -115,3 +115,10 @@ export {
   type Geometry3d,
   type GeometrySignal,
 } from "./signals/geometry";
+
+// generalized cross-surface label-patch preview signal
+export {
+  LABEL_PATCH_SIGNAL,
+  type LabelPatchSignal,
+  publishLabelPreview,
+} from "./signals/labelPatch";

--- a/app/packages/annotation/src/engine/signals/labelPatch.ts
+++ b/app/packages/annotation/src/engine/signals/labelPatch.ts
@@ -1,0 +1,45 @@
+/**
+ * The generalized cross-surface LABEL-PATCH signal: a render-only preview of a
+ * label edit, carrying the SAME `Partial<LabelData>` shape that
+ * `engine.updateLabel` commits. Any surface publishes the fields it is
+ * previewing mid-edit (a slider, a text input, a gesture); observers merge
+ * `{ ...committed, ...patch }` and render only — the shared dispatch guard
+ * forbids writing engine state back during the notification.
+ *
+ * Preview is the render-only twin of the commit: anything you can commit you
+ * can preview, with no per-field code. Keyed by {@link EntityId}.
+ */
+
+import type { LabelData } from "@fiftyone/utilities";
+
+import type { AnnotationEngine } from "../core/engine";
+import { encodeEntityId } from "../identity/entityId";
+import type { LabelRef } from "../identity/ref";
+
+/** Signal-pipe topic for live label-field previews. */
+export const LABEL_PATCH_SIGNAL = "label-patch";
+
+/**
+ * A sparse patch of the label fields being previewed — the same shape
+ * `engine.updateLabel` accepts. Absolute values (the publisher resolves any
+ * deltas), so observers merge it over their committed copy without base state.
+ */
+export type LabelPatchSignal = Partial<LabelData>;
+
+/**
+ * Imperative live preview: publish a render-only label patch on the engine
+ * signal pipe (no commit). Surface-agnostic — the 2D and 3D bridges both mirror
+ * it onto their overlay. Usable outside React; pass the engine instance.
+ */
+export const publishLabelPreview = (
+  engine: AnnotationEngine,
+  dataset: string,
+  ref: LabelRef,
+  patch: LabelPatchSignal
+): void => {
+  engine.publishSignal<LabelPatchSignal>(
+    LABEL_PATCH_SIGNAL,
+    encodeEntityId(dataset, ref),
+    patch
+  );
+};

--- a/app/packages/annotation/src/engine/surfaces/lighter/useLighterEngineBridge.test.tsx
+++ b/app/packages/annotation/src/engine/surfaces/lighter/useLighterEngineBridge.test.tsx
@@ -44,6 +44,7 @@ vi.mock("./lighterBridge", () => ({
   createLighterBridge: () => ({ clear: vi.fn() }),
 }));
 vi.mock("./adapters", () => ({ lighterAdapters: {} }));
+vi.mock("./useLighterPreviewSync", () => ({ useLighterPreviewSync: vi.fn() }));
 const mockCommit = vi.fn();
 const mockSelectHandle = vi.fn();
 const mockSetExternalUndoAuthority = vi.fn();

--- a/app/packages/annotation/src/engine/surfaces/lighter/useLighterEngineBridge.ts
+++ b/app/packages/annotation/src/engine/surfaces/lighter/useLighterEngineBridge.ts
@@ -28,6 +28,7 @@ import { lighterAdapters } from "./adapters";
 import type { LighterInteractionPolicy } from "./interactionPolicy";
 import type { LighterBridgeDeps } from "./lighterBridge";
 import { createLighterBridge } from "./lighterBridge";
+import { useLighterPreviewSync } from "./useLighterPreviewSync";
 
 export interface UseLighterEngineBridgeArgs {
   engine: AnnotationEngine;
@@ -294,6 +295,8 @@ export const useLighterEngineBridge = ({
 
   on("lighter:overlay-drag-move", publishGeometry);
   on("lighter:overlay-resize-move", publishGeometry);
+
+  useLighterPreviewSync(engine, sample, scene as Scene2D | null);
 
   // interaction write-half
   on(

--- a/app/packages/annotation/src/engine/surfaces/lighter/useLighterEngineBridge.ts
+++ b/app/packages/annotation/src/engine/surfaces/lighter/useLighterEngineBridge.ts
@@ -296,7 +296,12 @@ export const useLighterEngineBridge = ({
   on("lighter:overlay-drag-move", publishGeometry);
   on("lighter:overlay-resize-move", publishGeometry);
 
-  useLighterPreviewSync(engine, sample, scene as Scene2D | null);
+  useLighterPreviewSync(
+    engine,
+    dataset,
+    sample,
+    enabled ? (scene as Scene2D | null) : null
+  );
 
   // interaction write-half
   on(

--- a/app/packages/annotation/src/engine/surfaces/lighter/useLighterPreviewSync.test.tsx
+++ b/app/packages/annotation/src/engine/surfaces/lighter/useLighterPreviewSync.test.tsx
@@ -1,0 +1,73 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { encodeEntityId } from "../../identity/entityId";
+import { LABEL_PATCH_SIGNAL } from "../../signals/labelPatch";
+import { makeEngine, ref } from "../../testing/fixtures";
+import { useLighterPreviewSync } from "./useLighterPreviewSync";
+
+const overlay = (label: Record<string, unknown>) => ({
+  label,
+  applyLabel: vi.fn(),
+});
+
+const scene = (overlays: Record<string, ReturnType<typeof overlay>>) =>
+  ({ getOverlay: (id: string) => overlays[id] } as never);
+
+const publish = (
+  engine: ReturnType<typeof makeEngine>["engine"],
+  instanceId: string,
+  patch: Record<string, unknown>,
+  sample = "sample-1"
+) =>
+  engine.publishSignal(
+    LABEL_PATCH_SIGNAL,
+    encodeEntityId("ds", ref("ground_truth", instanceId, sample)),
+    patch
+  );
+
+describe("useLighterPreviewSync", () => {
+  it("merges a published patch onto the matching overlay (render-only)", () => {
+    const { engine } = makeEngine();
+    const d1 = overlay({ _id: "d1", label: "car", confidence: 0.2 });
+    renderHook(() => useLighterPreviewSync(engine, "sample-1", scene({ d1 })));
+
+    publish(engine, "d1", { confidence: 0.9 });
+
+    expect(d1.applyLabel).toHaveBeenCalledWith({
+      _id: "d1",
+      label: "car",
+      confidence: 0.9,
+    });
+  });
+
+  it("ignores a patch for a different sample", () => {
+    const { engine } = makeEngine();
+    const d1 = overlay({ _id: "d1" });
+    renderHook(() => useLighterPreviewSync(engine, "sample-1", scene({ d1 })));
+
+    publish(engine, "d1", { confidence: 0.9 }, "other-sample");
+
+    expect(d1.applyLabel).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when the scene has no matching overlay", () => {
+    const { engine } = makeEngine();
+    renderHook(() => useLighterPreviewSync(engine, "sample-1", scene({})));
+
+    expect(() => publish(engine, "absent", { confidence: 0.9 })).not.toThrow();
+  });
+
+  it("stops applying after unmount", () => {
+    const { engine } = makeEngine();
+    const d1 = overlay({ _id: "d1" });
+    const { unmount } = renderHook(() =>
+      useLighterPreviewSync(engine, "sample-1", scene({ d1 }))
+    );
+
+    unmount();
+    publish(engine, "d1", { confidence: 0.9 });
+
+    expect(d1.applyLabel).not.toHaveBeenCalled();
+  });
+});

--- a/app/packages/annotation/src/engine/surfaces/lighter/useLighterPreviewSync.test.tsx
+++ b/app/packages/annotation/src/engine/surfaces/lighter/useLighterPreviewSync.test.tsx
@@ -18,11 +18,12 @@ const publish = (
   engine: ReturnType<typeof makeEngine>["engine"],
   instanceId: string,
   patch: Record<string, unknown>,
-  sample = "sample-1"
+  sample = "sample-1",
+  dataset = "ds"
 ) =>
   engine.publishSignal(
     LABEL_PATCH_SIGNAL,
-    encodeEntityId("ds", ref("ground_truth", instanceId, sample)),
+    encodeEntityId(dataset, ref("ground_truth", instanceId, sample)),
     patch
   );
 
@@ -30,7 +31,9 @@ describe("useLighterPreviewSync", () => {
   it("merges a published patch onto the matching overlay (render-only)", () => {
     const { engine } = makeEngine();
     const d1 = overlay({ _id: "d1", label: "car", confidence: 0.2 });
-    renderHook(() => useLighterPreviewSync(engine, "sample-1", scene({ d1 })));
+    renderHook(() =>
+      useLighterPreviewSync(engine, "ds", "sample-1", scene({ d1 }))
+    );
 
     publish(engine, "d1", { confidence: 0.9 });
 
@@ -44,16 +47,32 @@ describe("useLighterPreviewSync", () => {
   it("ignores a patch for a different sample", () => {
     const { engine } = makeEngine();
     const d1 = overlay({ _id: "d1" });
-    renderHook(() => useLighterPreviewSync(engine, "sample-1", scene({ d1 })));
+    renderHook(() =>
+      useLighterPreviewSync(engine, "ds", "sample-1", scene({ d1 }))
+    );
 
     publish(engine, "d1", { confidence: 0.9 }, "other-sample");
 
     expect(d1.applyLabel).not.toHaveBeenCalled();
   });
 
+  it("ignores a patch from a different dataset", () => {
+    const { engine } = makeEngine();
+    const d1 = overlay({ _id: "d1" });
+    renderHook(() =>
+      useLighterPreviewSync(engine, "ds", "sample-1", scene({ d1 }))
+    );
+
+    publish(engine, "d1", { confidence: 0.9 }, "sample-1", "other-dataset");
+
+    expect(d1.applyLabel).not.toHaveBeenCalled();
+  });
+
   it("no-ops when the scene has no matching overlay", () => {
     const { engine } = makeEngine();
-    renderHook(() => useLighterPreviewSync(engine, "sample-1", scene({})));
+    renderHook(() =>
+      useLighterPreviewSync(engine, "ds", "sample-1", scene({}))
+    );
 
     expect(() => publish(engine, "absent", { confidence: 0.9 })).not.toThrow();
   });
@@ -62,7 +81,7 @@ describe("useLighterPreviewSync", () => {
     const { engine } = makeEngine();
     const d1 = overlay({ _id: "d1" });
     const { unmount } = renderHook(() =>
-      useLighterPreviewSync(engine, "sample-1", scene({ d1 }))
+      useLighterPreviewSync(engine, "ds", "sample-1", scene({ d1 }))
     );
 
     unmount();

--- a/app/packages/annotation/src/engine/surfaces/lighter/useLighterPreviewSync.ts
+++ b/app/packages/annotation/src/engine/surfaces/lighter/useLighterPreviewSync.ts
@@ -1,0 +1,52 @@
+import type { Scene2D } from "@fiftyone/lighter";
+import { useEffect } from "react";
+
+import type { AnnotationEngine } from "../../core/engine";
+import { decodeEntityId } from "../../identity/entityId";
+import {
+  LABEL_PATCH_SIGNAL,
+  type LabelPatchSignal,
+} from "../../signals/labelPatch";
+
+/**
+ * Mirror live label-patch previews onto this scene's overlays, render-only. A
+ * surface (e.g. the sidebar form) publishes a patch during a continuous gesture;
+ * we apply it to the matching overlay without committing — `applyLabel` touches
+ * only overlay render state, so the dispatch guard holds. The committed value
+ * re-baselines via the normal reproject.
+ */
+export const useLighterPreviewSync = (
+  engine: AnnotationEngine,
+  sample: string,
+  scene: Scene2D | null
+): void => {
+  useEffect(() => {
+    return engine.subscribeSignal<LabelPatchSignal>(
+      LABEL_PATCH_SIGNAL,
+      "*",
+      (patch, key) => {
+        let identity: ReturnType<typeof decodeEntityId>;
+        try {
+          identity = decodeEntityId(key);
+        } catch {
+          return;
+        }
+
+        if (identity.ref.sample !== sample) {
+          return;
+        }
+
+        const overlay = scene?.getOverlay(identity.ref.instanceId);
+
+        if (!overlay) {
+          return;
+        }
+
+        overlay.applyLabel({
+          ...(overlay.label as Record<string, unknown>),
+          ...patch,
+        } as Parameters<typeof overlay.applyLabel>[0]);
+      }
+    );
+  }, [engine, sample, scene]);
+};

--- a/app/packages/annotation/src/engine/surfaces/lighter/useLighterPreviewSync.ts
+++ b/app/packages/annotation/src/engine/surfaces/lighter/useLighterPreviewSync.ts
@@ -17,6 +17,7 @@ import {
  */
 export const useLighterPreviewSync = (
   engine: AnnotationEngine,
+  dataset: string,
   sample: string,
   scene: Scene2D | null
 ): void => {
@@ -32,7 +33,9 @@ export const useLighterPreviewSync = (
           return;
         }
 
-        if (identity.ref.sample !== sample) {
+        // scope to this surface's entity namespace — instanceIds can overlap
+        // across datasets/samples
+        if (identity.dataset !== dataset || identity.ref.sample !== sample) {
           return;
         }
 
@@ -48,5 +51,5 @@ export const useLighterPreviewSync = (
         } as Parameters<typeof overlay.applyLabel>[0]);
       }
     );
-  }, [engine, sample, scene]);
+  }, [engine, dataset, sample, scene]);
 };

--- a/app/packages/annotation/src/state/index.ts
+++ b/app/packages/annotation/src/state/index.ts
@@ -2,6 +2,7 @@ export * from "./build3dLabel";
 export * from "./useAnnotationContextManager";
 export * from "./useEngine";
 export * from "./useGroupAnnotationSample";
+export * from "./useLabelPreview";
 export * from "./useLooker3dSurfaceController";
 export * from "./useSample";
 export * from "./useSync3dModalSample";

--- a/app/packages/annotation/src/state/useLabelPreview.ts
+++ b/app/packages/annotation/src/state/useLabelPreview.ts
@@ -1,0 +1,23 @@
+import { useCallback } from "react";
+
+import {
+  type LabelPatchSignal,
+  type LabelRef,
+  publishLabelPreview,
+} from "../engine";
+import { useAnnotationEngine } from "./useEngine";
+
+/**
+ * Declarative live preview: a stable callback bound to the session engine that
+ * publishes a render-only label patch (no commit). Surfaces call it during a
+ * continuous gesture (e.g. a slider drag) to preview an edit before committing.
+ */
+export const usePublishLabelPreview = () => {
+  const engine = useAnnotationEngine();
+
+  return useCallback(
+    (dataset: string, ref: LabelRef, patch: LabelPatchSignal) =>
+      publishLabelPreview(engine, dataset, ref, patch),
+    [engine]
+  );
+};

--- a/app/packages/components/src/components/SmartForm/RJSF/index.tsx
+++ b/app/packages/components/src/components/SmartForm/RJSF/index.tsx
@@ -107,6 +107,7 @@ export default function RJSF(props: SmartFormProps) {
     <Form
       key={revision}
       ref={formRef}
+      formContext={formProps?.formContext}
       schema={schema as RJSFSchema}
       uiSchema={uiSchema}
       validator={validator}

--- a/app/packages/components/src/components/SmartForm/RJSF/widgets/SliderWidget.tsx
+++ b/app/packages/components/src/components/SmartForm/RJSF/widgets/SliderWidget.tsx
@@ -10,7 +10,24 @@ import { BaseSlider, FormField } from "@voxel51/voodo";
 import React from "react";
 
 export default function Slider(props: WidgetProps) {
-  const { value, onChange, schema, uiSchema, label, rawErrors } = props;
+  const {
+    value,
+    onChange,
+    schema,
+    uiSchema,
+    label,
+    rawErrors,
+    registry,
+    name,
+  } = props;
+
+  // @rjsf v5 delivers formContext to widgets via `registry.formContext`;
+  // `props.formContext` is not populated.
+  const formContext = (props.formContext ?? registry?.formContext) as
+    | { onLivePreview?: (name: string, value: unknown) => void }
+    | undefined;
+
+  const onLivePreview = formContext?.onLivePreview;
 
   // Extract min/max from schema
   const min = schema.minimum ?? 0;
@@ -31,6 +48,10 @@ export default function Slider(props: WidgetProps) {
   const maxLabel = uiSchema?.["ui:options"]?.maxLabel;
 
   const handleChange = (newValue: number | number[]) => {
+    onLivePreview?.(name, newValue);
+  };
+
+  const handleChangeCommitted = (newValue: number | number[]) => {
     onChange(newValue);
   };
 
@@ -40,7 +61,9 @@ export default function Slider(props: WidgetProps) {
       max={max}
       step={step}
       value={value}
+      debounceDelay={0}
       onChange={handleChange}
+      onChangeCommitted={handleChangeCommitted}
       multi={isMulti}
       bare={bare}
       labeled={labeled}

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/AnnotationSchema.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/AnnotationSchema.tsx
@@ -29,6 +29,7 @@ import {
 } from "./trackFanOut";
 import { useAnnotationContext } from "./useAnnotationContext";
 import { current } from "./useAnnotationContext/selectors";
+import { useLivePreview } from "./useLivePreview";
 
 const useSchema = (readOnly: boolean) => {
   const { selected } = useAnnotationContext();
@@ -326,6 +327,7 @@ const AnnotationSchema = ({ readOnly = false }: AnnotationSchemaProps) => {
   const overlay = selected?.overlay;
   const field = selected?.field ?? null;
   const onChange = useHandleSchemaChange(readOnly);
+  const onLivePreview = useLivePreview(readOnly);
 
   if (!field) throw new Error("no field");
   if (!overlay) throw new Error("no overlay");
@@ -345,7 +347,10 @@ const AnnotationSchema = ({ readOnly = false }: AnnotationSchemaProps) => {
       <SchemaIOComponent
         key={overlay.id}
         smartForm={true}
-        smartFormProps={{ liveValidate: "onChange" }}
+        smartFormProps={{
+          liveValidate: "onChange",
+          formContext: { onLivePreview },
+        }}
         schema={schema}
         data={displayData}
         onChange={onChange}

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useLivePreview.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useLivePreview.ts
@@ -8,6 +8,13 @@ import { useCallback, useRef } from "react";
 
 import { useAnnotationContext } from "./useAnnotationContext";
 
+/**
+ * Sidebar binding for live label preview. Returns a `(name, value)` callback
+ * that publishes a render-only patch for the selected label — observing surfaces
+ * (e.g. the canvas overlay) preview the in-progress edit without a commit. The
+ * actual write still happens separately, on gesture release. Reads the selection
+ * through refs so the callback identity stays stable across edits.
+ */
 export const useLivePreview = (readOnly: boolean) => {
   const { selected } = useAnnotationContext();
   const overlay = selected?.overlay;

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useLivePreview.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useLivePreview.ts
@@ -1,56 +1,29 @@
-import {
-  useActiveAnnotationSampleId,
-  usePublishLabelPreview,
-} from "@fiftyone/annotation";
+import { usePublishLabelPreview } from "@fiftyone/annotation";
 import { useCurrentDatasetId } from "@fiftyone/state";
 import type { LabelData } from "@fiftyone/utilities";
-import { useCallback, useRef } from "react";
+import { useCallback } from "react";
 
 import { useAnnotationContext } from "./useAnnotationContext";
 
 /**
  * Sidebar binding for live label preview. Returns a `(name, value)` callback
- * that publishes a render-only patch for the selected label — observing surfaces
- * (e.g. the canvas overlay) preview the in-progress edit without a commit. The
- * actual write still happens separately, on gesture release. Reads the selection
- * through refs so the callback identity stays stable across edits.
+ * that publishes a render-only patch for the selected label — addressed by the
+ * engine anchor (`selected.ref`, which carries `instanceId` and `frame`) — so
+ * observing surfaces like the canvas overlay preview the in-progress edit
+ * without a commit. The actual write still happens separately, on release.
  */
 export const useLivePreview = (readOnly: boolean) => {
   const { selected } = useAnnotationContext();
-  const overlay = selected?.overlay;
-  const field = selected?.field ?? null;
-  const data = selected?.data;
-  const sample = useActiveAnnotationSampleId();
+  const ref = selected?.ref ?? null;
   const dataset = useCurrentDatasetId() ?? "";
   const publishPreview = usePublishLabelPreview();
 
-  const overlayRef = useRef(overlay);
-  const fieldRef = useRef(field);
-  const dataRef = useRef(data);
-  const sampleRef = useRef(sample);
-  const datasetRef = useRef(dataset);
-  overlayRef.current = overlay;
-  fieldRef.current = field;
-  dataRef.current = data;
-  sampleRef.current = sample;
-  datasetRef.current = dataset;
-
   return useCallback(
     (name: string, value: unknown) => {
-      const overlay = overlayRef.current;
-      const field = fieldRef.current;
+      if (readOnly || !ref) return;
 
-      if (readOnly || !field || !overlay) return;
-
-      const instanceId =
-        (dataRef.current as { _id?: string })?._id ?? overlay.id;
-
-      publishPreview(
-        datasetRef.current,
-        { sample: sampleRef.current, path: field, instanceId },
-        { [name]: value } as Partial<LabelData>
-      );
+      publishPreview(dataset, ref, { [name]: value } as Partial<LabelData>);
     },
-    [publishPreview, readOnly]
+    [publishPreview, readOnly, ref, dataset]
   );
 };

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useLivePreview.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useLivePreview.ts
@@ -1,0 +1,49 @@
+import {
+  useActiveAnnotationSampleId,
+  usePublishLabelPreview,
+} from "@fiftyone/annotation";
+import { useCurrentDatasetId } from "@fiftyone/state";
+import type { LabelData } from "@fiftyone/utilities";
+import { useCallback, useRef } from "react";
+
+import { useAnnotationContext } from "./useAnnotationContext";
+
+export const useLivePreview = (readOnly: boolean) => {
+  const { selected } = useAnnotationContext();
+  const overlay = selected?.overlay;
+  const field = selected?.field ?? null;
+  const data = selected?.data;
+  const sample = useActiveAnnotationSampleId();
+  const dataset = useCurrentDatasetId() ?? "";
+  const publishPreview = usePublishLabelPreview();
+
+  const overlayRef = useRef(overlay);
+  const fieldRef = useRef(field);
+  const dataRef = useRef(data);
+  const sampleRef = useRef(sample);
+  const datasetRef = useRef(dataset);
+  overlayRef.current = overlay;
+  fieldRef.current = field;
+  dataRef.current = data;
+  sampleRef.current = sample;
+  datasetRef.current = dataset;
+
+  return useCallback(
+    (name: string, value: unknown) => {
+      const overlay = overlayRef.current;
+      const field = fieldRef.current;
+
+      if (readOnly || !field || !overlay) return;
+
+      const instanceId =
+        (dataRef.current as { _id?: string })?._id ?? overlay.id;
+
+      publishPreview(
+        datasetRef.current,
+        { sample: sampleRef.current, path: field, instanceId },
+        { [name]: value } as Partial<LabelData>
+      );
+    },
+    [publishPreview, readOnly]
+  );
+};

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -8685,9 +8685,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@voxel51/voodo@npm:^0.0.35":
-  version: 0.0.35
-  resolution: "@voxel51/voodo@npm:0.0.35"
+"@voxel51/voodo@npm:^0.0.36":
+  version: 0.0.36
+  resolution: "@voxel51/voodo@npm:0.0.36"
   dependencies:
     "@dnd-kit/core": "npm:^6.3.1"
     "@dnd-kit/sortable": "npm:^10.0.0"
@@ -8704,7 +8704,7 @@ __metadata:
     react: ^18.0.0
     react-dom: ^18.0.0
     react-is: ^18.0.0
-  checksum: 10/a2cc59ae1a6f2842b494363c1c918349b165cb65dbc3a2c6c6c1cb8ff6cd74336d76ebd0df455c8bbc8a8b32100461e5ea2ecd7bcc89b8684bfe66315522b09e
+  checksum: 10/742c289f7c7714d3bfeca3d3d34de5c4c373fc1dd98b89ae070411736a6564dee309493fa79ee0e24ce7f46d89b6e0ec3cb5f004ab89d377a829ec8a40e5f382
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

Adds a render-only **live preview** path: a continuous edit (e.g. dragging the confidence slider) updates the on-canvas overlay live, while the single commit still happens on release. Surface-agnostic — same mechanism for 2D and 3D.


https://github.com/user-attachments/assets/a2bff8aa-3849-4a68-88a4-eb46a81a81c7



## How

**Engine (`@fiftyone/annotation`)**
- `signals/labelPatch.ts` — `LABEL_PATCH_SIGNAL` + `LabelPatchSignal` (a render-only preview carrying the same `Partial<LabelData>` shape `engine.updateLabel` commits), plus the **imperative** `publishLabelPreview(engine, dataset, ref, patch)`.
- `state/useLabelPreview.ts` — the **declarative** `usePublishLabelPreview()` bound to the session engine.
- `surfaces/lighter/useLighterPreviewSync.ts` — the Lighter bridge subscribes and applies the patch to the matching overlay **render-only** (`applyLabel`, no engine write, dispatch-guard safe), keyed by `EntityId`.

**Form layer**
- RJSF `<Form>` forwards the standard `formContext`; `SliderWidget` reads `onLivePreview` from `registry.formContext` (rjsf v5), publishes on each drag tick (`debounceDelay={0}`), and commits once on release via `onChangeCommitted`.
- Sidebar `Edit/useLivePreview.ts` binds the current selection to `usePublishLabelPreview`; `AnnotationSchema` provides it through `formContext`.

**Flow:** drag → `onChange` → `onLivePreview` → signal → overlay `applyLabel` (live, no commit); release → `onChangeCommitted` → engine commit (one undo unit).

## Tests

- `useLighterPreviewSync.test.tsx` — unit coverage (merge onto matching overlay, sample mismatch ignored, missing-overlay no-op, unsubscribe on unmount).
- Bridge test isolates the new hook via `vi.mock`.

## Dependency

The slider **commit-on-release** relies on `onChangeCommitted`, added in design-system (voodo) voxel51/design-system#155. The live-preview half works with the current voodo; bump the voodo dependency once #155 releases to get commit-on-release.

> Ported from the `feat/annotation-engine` working branch onto `feat/anno-engine-integration` (3-way); the engine/bridge/schema files diverged, so worth a careful review + CI pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added render-only label preview signaling with a publish/sync flow for live overlay updates during annotation editing.
  * Introduced new hooks to publish live preview changes and synchronize them to Lighter overlays.
  * Wired live-preview support into SmartForm so widgets can trigger previews separately from committed edits.

* **Bug Fixes**
  * Preview updates are scoped to the active dataset/sample, safely ignored when overlays are missing, and stop applying after unmount.

* **Tests**
  * Added coverage for preview synchronization behavior and improved test isolation via updated mocking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->