### PR TITLE
ci(pr): skip heavy suite on intra-stack PRs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,7 +2,10 @@ name: Pull Request
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, closed, ready_for_review]
+    # `edited` catches base changes — notably GitHub auto-retargeting a stacked
+    # PR to develop when the PR below it merges — so the heavy suite runs before
+    # it can land (no `synchronize` fires on an auto-retarget).
+    types: [opened, synchronize, reopened, closed, ready_for_review, edited]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -15,6 +18,8 @@ jobs:
       app-changes: ${{ steps.filter.outputs.app }}
       e2e-changes: ${{ steps.filter.outputs.e2e-pw }}
       fiftyone-changes: ${{ steps.filter.outputs.fiftyone }}
+      run-ci: ${{ steps.gate.outputs.run-ci }}
+      heavy: ${{ steps.gate.outputs.heavy }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -44,10 +49,38 @@ jobs:
               - '.github/workflows/test.yml'
               - 'plugins/**'
 
+      - name: Gate CI by base branch
+        id: gate
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          ACTION: ${{ github.event.action }}
+          BASE_CHANGED: ${{ github.event.changes.base != null }}
+        shell: bash
+        run: |
+          # `edited` fires on title/body edits too; only (re)run when the base
+          # changed (e.g. a stacked PR auto-retargeted to develop after the one
+          # below merged).
+          run_ci=true
+          if [ "$ACTION" = "edited" ] && [ "$BASE_CHANGED" != "true" ]; then
+            run_ci=false
+          fi
+          # Heavy jobs (build/test/e2e/windows) only for PRs targeting a
+          # long-lived branch. Intra-stack PRs (base = another feature branch)
+          # skip them and are tested when promoted to develop/release.
+          heavy=false
+          if [ "$run_ci" = "true" ]; then
+            case "$BASE_REF" in
+              develop|main|release/*) heavy=true ;;
+            esac
+          fi
+          echo "run-ci=$run_ci" >> "$GITHUB_OUTPUT"
+          echo "heavy=$heavy" >> "$GITHUB_OUTPUT"
+
   build:
     needs: modified-files
     if: >-
-      github.event.action != 'closed' && (
+      github.event.action != 'closed' &&
+      needs.modified-files.outputs.heavy == 'true' && (
       needs.modified-files.outputs.app-changes == 'true' ||
       needs.modified-files.outputs.fiftyone-changes == 'true')
     uses: ./.github/workflows/build.yml
@@ -55,7 +88,8 @@ jobs:
   e2e:
     needs: modified-files
     if: >-
-      github.event.action != 'closed' && (
+      github.event.action != 'closed' &&
+      needs.modified-files.outputs.heavy == 'true' && (
       needs.modified-files.outputs.app-changes == 'true' ||
       needs.modified-files.outputs.e2e-changes == 'true' ||
       needs.modified-files.outputs.fiftyone-changes == 'true')
@@ -67,7 +101,8 @@ jobs:
   lint:
     needs: modified-files
     if: >-
-      github.event.action != 'closed' && (
+      github.event.action != 'closed' &&
+      needs.modified-files.outputs.run-ci == 'true' && (
       needs.modified-files.outputs.app-changes == 'true' ||
       needs.modified-files.outputs.fiftyone-changes == 'true')
     uses: ./.github/workflows/lint-app.yml
@@ -75,7 +110,8 @@ jobs:
   test:
     needs: modified-files
     if: >-
-      github.event.action != 'closed' && (
+      github.event.action != 'closed' &&
+      needs.modified-files.outputs.heavy == 'true' && (
       needs.modified-files.outputs.app-changes == 'true' ||
       needs.modified-files.outputs.fiftyone-changes == 'true')
     uses: ./.github/workflows/test.yml
@@ -84,6 +120,7 @@ jobs:
     needs: modified-files
     if: >-
       github.event.action != 'closed' &&
+      needs.modified-files.outputs.heavy == 'true' &&
       needs.modified-files.outputs.fiftyone-changes == 'true'
     uses: ./.github/workflows/windows-test.yml
 


### PR DESCRIPTION
## What

Gates the heavy CI jobs (`build`, `test`, `e2e`, `test-windows`) behind a **long-lived base branch** (`develop`, `release/*`, `main`). A PR stacked on another feature branch (base = a feature branch) skips the heavy suite and is tested when it's promoted to a long-lived base. `lint` still runs on every PR for signal.

Also adds `edited` to the `pull_request` triggers so a stacked PR that GitHub **auto-retargets to develop** (when the PR below it merges) runs the full suite before it can land — no `synchronize` fires on an auto-retarget. The gate ignores plain title/body edits and only re-runs when the base actually changed.

## Why

Actions minutes spiked ~7× and exhausted the org budget, blocking the 6/30 release. A large chained stack (~15 PRs) was the dominant driver: in a stack each restack/force-push fans out a `synchronize` to **every** PR above, so one restack = N full `pr.yml` runs (build + test + e2e + windows). Several branches in the stack each accumulated 35–51 full runs in 8 days.

This stops re-testing intermediate stacked states. Nothing merges to a long-lived branch untested — each layer runs the full suite at promotion.

## Trade-off

Stacked PRs lose per-push pass/fail on the heavy suite while stacked (lint still reports). The cumulative tip is fully tested the moment it's retargeted to a long-lived base.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI rerun behavior was refined for pull request edits, running when the base branch changes.
  * “Heavy” jobs now run only for pull requests targeting `develop`, `main`, or `release/*`.
  * Lint and test jobs use updated gating rules to reduce unnecessary workflow runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3034
<!-- enterprise-sync-pr:end -->