### PR TITLE
Add rtdetr v2 large to fiftyone model zoo

### DIFF
--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -9544,7 +9544,7 @@
             "source": "https://huggingface.co/PekingU/rtdetr_v2_r101vd",
             "author": "Wenyu Lv, et al.",
             "license": "Apache 2.0",
-            "size_bytes": 514000000,
+            "size_bytes": 307332000,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.transformers.FiftyOneTransformerForObjectDetection",
                 "config": {

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -9537,6 +9537,47 @@
             "date_added": "2025-07-03 12:00:00"
         },
         {
+            "base_name": "rtdetr-v2-l-coco-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "High-accuracy real-time object detector with ResNet-101 backbone, offering the best accuracy in the RT-DETRv2 family",
+            "source": "https://huggingface.co/PekingU/rtdetr_v2_r101vd",
+            "author": "Wenyu Lv, et al.",
+            "license": "Apache 2.0",
+            "size_bytes": 514000000,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.transformers.FiftyOneTransformerForObjectDetection",
+                "config": {
+                    "name_or_path": "PekingU/rtdetr_v2_r101vd",
+                    "transformers_processor_kwargs": {
+                        "return_tensors": "pt"
+                    }
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision", "transformers"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": [
+                "detection",
+                "coco",
+                "embeddings",
+                "torch",
+                "transformers",
+                "rtdetr",
+                "official"
+            ],
+            "training_data": [
+                { "name": "MS COCO 2017", "url": "https://cocodataset.org" }
+            ],
+            "date_added": "2026-06-25 12:00:00"
+        },
+        {
             "base_name": "dfine-nano-coco-torch",
             "base_filename": null,
             "version": null,


### PR DESCRIPTION
<!--
Community contributors: target the `community` branch, not `develop`. PRs from
non-members are auto-retargeted to `community`. See CONTRIBUTING.md:
https://github.com/voxel51/fiftyone/blob/develop/CONTRIBUTING.md#community-pull-requests
-->

## 🔗 Related Issues

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->
No related issues to link

## 📋 What changes are proposed in this pull request?

<!--
Provide a clear, concise description of what this PR does and why.
-->
Adds rtdetr v2 large to fiftyone model zoo manifest

## 🧪 How is this patch tested? If it is not, please explain why.

<!--
Describe the tests you ran or wrote to verify your changes. Include:
- New or updated unit/integration tests
- Manual testing steps performed
- Why tests are not applicable (if skipped)
-->

```
class TestRTDETR(unittest.TestCase):
    """All RT-DETR variants on COCO val."""

    @classmethod
    def setUpClass(cls):
        cls.dataset = _load_coco("zoo-rtdetr-test")

    def _run(self, model_name):
        model = foz.load_zoo_model(model_name)
        field = _label_field(model_name)
        self.dataset.apply_model(
            model,
            label_field=field,
            batch_size=1,
            num_workers=8,
            confidence_thresh=0.5,
        )
        _assert_populated(self, self.dataset, field)

    def test_rtdetr_v2_s(self):
        self._run("rtdetr-v2-s-coco-torch")

    def test_rtdetr_v2_m(self):
        self._run("rtdetr-v2-m-coco-torch")

    def test_rtdetr_v2_l(self):
        self._run("rtdetr-v2-l-coco-torch")
```

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [x] Other

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3029
<!-- enterprise-sync-pr:end -->