### PR TITLE
[HA] Misc bug fixes

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/constants.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/SchemaManager/constants.ts
@@ -61,11 +61,11 @@ export const LABEL_TYPE_OPTIONS_3D = [
   { id: "classification", data: { label: "Classification" } },
 ];
 
-// Label type options for video datasets
+// Label type options for video datasets. Spatial labels (detections/polylines)
+// are frame-level only on video, and this flow creates sample-level fields —
+// so it offers just the sample-level label types valid for a video clip.
 export const LABEL_TYPE_OPTIONS_VIDEO = [
-  { id: "detections", data: { label: "Detections" } },
   { id: "classification", data: { label: "Classification" } },
-  { id: "polylines", data: { label: "Polylines" } },
   { id: "temporaldetections", data: { label: "Temporal Detections" } },
 ];
 

--- a/app/packages/video-annotation/src/components/AnnotatePrerequisiteNotice.test.tsx
+++ b/app/packages/video-annotation/src/components/AnnotatePrerequisiteNotice.test.tsx
@@ -1,0 +1,41 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  AnnotatePrerequisiteChecking,
+  AnnotatePrerequisiteNotice,
+} from "./AnnotatePrerequisiteNotice";
+
+describe("AnnotatePrerequisiteNotice", () => {
+  it("renders the metadata prompt", () => {
+    const { container, getByText } = render(
+      <AnnotatePrerequisiteNotice blocker="metadata" />
+    );
+
+    expect(
+      container.querySelector('[data-cy="video-annotate-prerequisite-notice"]')
+    ).toBeTruthy();
+    getByText("Computed metadata required");
+    getByText(/compute_metadata/);
+  });
+
+  it("renders the frames prompt", () => {
+    const { getByText } = render(
+      <AnnotatePrerequisiteNotice blocker="frames" />
+    );
+
+    getByText("Frames not sampled");
+    getByText(/to_frames/);
+  });
+});
+
+describe("AnnotatePrerequisiteChecking", () => {
+  it("renders a checking placeholder", () => {
+    const { container } = render(<AnnotatePrerequisiteChecking />);
+
+    expect(
+      container.querySelector(
+        '[data-cy="video-annotate-prerequisite-checking"]'
+      )
+    ).toBeTruthy();
+  });
+});

--- a/app/packages/video-annotation/src/components/AnnotatePrerequisiteNotice.test.tsx
+++ b/app/packages/video-annotation/src/components/AnnotatePrerequisiteNotice.test.tsx
@@ -15,7 +15,8 @@ describe("AnnotatePrerequisiteNotice", () => {
       container.querySelector('[data-cy="video-annotate-prerequisite-notice"]')
     ).toBeTruthy();
     getByText("Computed metadata required");
-    getByText(/compute_metadata/);
+    getByText(/frame count is unknown/);
+    getByText("Compute metadata");
   });
 
   it("renders the frames prompt", () => {

--- a/app/packages/video-annotation/src/components/AnnotatePrerequisiteNotice.test.tsx
+++ b/app/packages/video-annotation/src/components/AnnotatePrerequisiteNotice.test.tsx
@@ -8,11 +8,11 @@ import {
 describe("AnnotatePrerequisiteNotice", () => {
   it("renders the metadata prompt", () => {
     const { container, getByText } = render(
-      <AnnotatePrerequisiteNotice blocker="metadata" />
+      <AnnotatePrerequisiteNotice blocker="metadata" />,
     );
 
     expect(
-      container.querySelector('[data-cy="video-annotate-prerequisite-notice"]')
+      container.querySelector('[data-cy="video-annotate-prerequisite-notice"]'),
     ).toBeTruthy();
     getByText("Computed metadata required");
     getByText(/frame count is unknown/);
@@ -21,7 +21,7 @@ describe("AnnotatePrerequisiteNotice", () => {
 
   it("renders the frames prompt", () => {
     const { getByText } = render(
-      <AnnotatePrerequisiteNotice blocker="frames" />
+      <AnnotatePrerequisiteNotice blocker="frames" />,
     );
 
     getByText("Frames not sampled");
@@ -35,8 +35,8 @@ describe("AnnotatePrerequisiteChecking", () => {
 
     expect(
       container.querySelector(
-        '[data-cy="video-annotate-prerequisite-checking"]'
-      )
+        '[data-cy="video-annotate-prerequisite-checking"]',
+      ),
     ).toBeTruthy();
   });
 });

--- a/app/packages/video-annotation/src/components/AnnotatePrerequisiteNotice.tsx
+++ b/app/packages/video-annotation/src/components/AnnotatePrerequisiteNotice.tsx
@@ -1,0 +1,46 @@
+import { EmptyState, IconName } from "@voxel51/voodo";
+import React from "react";
+import type { AnnotateBlocker } from "../hooks/useAnnotatePrerequisites";
+
+const COPY: Record<
+  AnnotateBlocker,
+  { icon: IconName; title: string; description: string }
+> = {
+  metadata: {
+    icon: IconName.Warning,
+    title: "Computed metadata required",
+    description:
+      "This video's frame count is unknown. Run dataset.compute_metadata() " +
+      "to annotate it, or switch to Explore to view the sample.",
+  },
+};
+
+/**
+ * Media-region takeover shown when the video annotation surface can't mount
+ * its playback stream because a prerequisite is missing. Replaces the old
+ * hard throw in `RegisterImaVidImage`, which crashed the whole modal.
+ */
+export const AnnotatePrerequisiteNotice: React.FC<{
+  blocker: AnnotateBlocker;
+}> = ({ blocker }) => {
+  const copy = COPY[blocker];
+
+  return (
+    <div
+      data-cy="video-annotate-prerequisite-notice"
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <EmptyState
+        icon={copy.icon}
+        title={copy.title}
+        description={copy.description}
+      />
+    </div>
+  );
+};

--- a/app/packages/video-annotation/src/components/AnnotatePrerequisiteNotice.tsx
+++ b/app/packages/video-annotation/src/components/AnnotatePrerequisiteNotice.tsx
@@ -1,4 +1,4 @@
-import { EmptyState, IconName } from "@voxel51/voodo";
+import { EmptyState, IconName, Size, Spinner } from "@voxel51/voodo";
 import React from "react";
 import type { AnnotateBlocker } from "../hooks/useAnnotatePrerequisites";
 
@@ -13,12 +13,28 @@ const COPY: Record<
       "This video's frame count is unknown. Run dataset.compute_metadata() " +
       "to annotate it, or switch to Explore to view the sample.",
   },
+  frames: {
+    icon: IconName.ImageSearch,
+    title: "Frames not sampled",
+    description:
+      "This video's frames haven't been sampled to images, which annotation " +
+      "requires. Run dataset.to_frames(sample_frames=True) to annotate it.",
+  },
+};
+
+const center: React.CSSProperties = {
+  width: "100%",
+  height: "100%",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
 };
 
 /**
  * Media-region takeover shown when the video annotation surface can't mount
  * its playback stream because a prerequisite is missing. Replaces the old
- * hard throw in `RegisterImaVidImage`, which crashed the whole modal.
+ * hard throw in `RegisterImaVidImage` (which crashed the whole modal) and the
+ * silent blank when frames aren't sampled.
  */
 export const AnnotatePrerequisiteNotice: React.FC<{
   blocker: AnnotateBlocker;
@@ -26,16 +42,7 @@ export const AnnotatePrerequisiteNotice: React.FC<{
   const copy = COPY[blocker];
 
   return (
-    <div
-      data-cy="video-annotate-prerequisite-notice"
-      style={{
-        width: "100%",
-        height: "100%",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-      }}
-    >
+    <div data-cy="video-annotate-prerequisite-notice" style={center}>
       <EmptyState
         icon={copy.icon}
         title={copy.title}
@@ -44,3 +51,10 @@ export const AnnotatePrerequisiteNotice: React.FC<{
     </div>
   );
 };
+
+/** Shown while a prerequisite (e.g. the sampled-frames probe) is resolving. */
+export const AnnotatePrerequisiteChecking: React.FC = () => (
+  <div data-cy="video-annotate-prerequisite-checking" style={center}>
+    <Spinner size={Size.Lg} />
+  </div>
+);

--- a/app/packages/video-annotation/src/components/AnnotatePrerequisiteNotice.tsx
+++ b/app/packages/video-annotation/src/components/AnnotatePrerequisiteNotice.tsx
@@ -1,24 +1,66 @@
-import { EmptyState, IconName, Size, Spinner } from "@voxel51/voodo";
+import {
+  Align,
+  Icon,
+  IconColor,
+  IconName,
+  Orientation,
+  Size,
+  Spacing,
+  Spinner,
+  Stack,
+  Text,
+  TextColor,
+  TextVariant,
+} from "@voxel51/voodo";
 import React from "react";
 import type { AnnotateBlocker } from "../hooks/useAnnotatePrerequisites";
 
+/** Inline docs link rendered within a notice description. */
+const DocsLink: React.FC<{ href: string; children: React.ReactNode }> = ({
+  href,
+  children,
+}) => (
+  <a
+    href={href}
+    target="_blank"
+    rel="noopener noreferrer"
+    style={{ color: "var(--color-brand-accent)" }}
+  >
+    {children}
+  </a>
+);
+
 const COPY: Record<
   AnnotateBlocker,
-  { icon: IconName; title: string; description: string }
+  { icon: IconName; title: string; description: React.ReactNode }
 > = {
   metadata: {
     icon: IconName.Warning,
     title: "Computed metadata required",
-    description:
-      "This video's frame count is unknown. Run dataset.compute_metadata() " +
-      "to annotate it, or switch to Explore to view the sample.",
+    description: (
+      <>
+        This video's frame count is unknown.{" "}
+        <DocsLink href="https://docs.voxel51.com/enterprise/getting_started.html#compute-metadata">
+          Compute metadata
+        </DocsLink>{" "}
+        to annotate it or switch to Explore to view the sample.
+      </>
+    ),
   },
   frames: {
     icon: IconName.ImageSearch,
     title: "Frames not sampled",
-    description:
-      "This video's frames haven't been sampled to images, which annotation " +
-      "requires. Run dataset.to_frames(sample_frames=True) to annotate it.",
+    description: (
+      <>
+        This video's frames haven't been sampled to images, which annotation
+        requires.{" "}
+        <DocsLink href="https://docs.voxel51.com/user_guide/using_views.html#frame-views">
+          Run dataset.to_frames(sample_frames=True) or populate filepaths to
+          existing frame images
+        </DocsLink>{" "}
+        to annotate it.
+      </>
+    ),
   },
 };
 
@@ -43,11 +85,16 @@ export const AnnotatePrerequisiteNotice: React.FC<{
 
   return (
     <div data-cy="video-annotate-prerequisite-notice" style={center}>
-      <EmptyState
-        icon={copy.icon}
-        title={copy.title}
-        description={copy.description}
-      />
+      <Stack
+        orientation={Orientation.Column}
+        align={Align.Center}
+        spacing={Spacing.Md}
+        style={{ maxWidth: 520, padding: 40, textAlign: "center" }}
+      >
+        <Icon name={copy.icon} size={Size.Xl} color={IconColor.Warning} />
+        <Text variant={TextVariant.Xl}>{copy.title}</Text>
+        <Text color={TextColor.Muted}>{copy.description}</Text>
+      </Stack>
     </div>
   );
 };

--- a/app/packages/video-annotation/src/components/ImaVidLighterTile.tsx
+++ b/app/packages/video-annotation/src/components/ImaVidLighterTile.tsx
@@ -26,12 +26,17 @@ function usePaintFrameToCanvas(
   const [dims, setDims] = useState<ImageDimensions | null>(null);
 
   useEffect(() => {
-    if (!frame) {
+    const canvasEl = canvasRef.current;
+    if (!canvasEl) {
       return;
     }
 
-    const canvasEl = canvasRef.current;
-    if (!canvasEl) {
+    // No frame: initial load, or a frame the stream gave up on (unresolvable
+    // filepath / decode error) that the engine played through. Clear so the
+    // black `.body` shows instead of the previous frame lingering on-canvas.
+    if (!frame) {
+      const ctx = canvasEl.getContext("2d");
+      ctx?.clearRect(0, 0, canvasEl.width, canvasEl.height);
       return;
     }
 

--- a/app/packages/video-annotation/src/components/RegisterImaVidImage.tsx
+++ b/app/packages/video-annotation/src/components/RegisterImaVidImage.tsx
@@ -1,4 +1,3 @@
-import type { ModalSample } from "@fiftyone/state";
 import type { Stage } from "@fiftyone/utilities";
 import React, { useEffect, useRef } from "react";
 import { usePlaybackStream } from "@fiftyone/playback";
@@ -10,7 +9,6 @@ import {
   useView,
 } from "../state/accessors";
 import { IMAVID_STREAM_ID } from "../utils/ids";
-import { getModalSampleFrameRate } from "../utils/modalSample";
 import { ImaVidImageStream } from "../streams/ImaVidImageStream";
 import { usePublishImaVidImageStream } from "../streams/imaVidImageStreamHandle";
 
@@ -21,39 +19,23 @@ import { usePublishImaVidImageStream } from "../streams/imaVidImageStreamHandle"
  * downstream — in the native-video tile the `<video>` element plays
  * this role via `useVideoStream`.
  *
- * fps comes from `sample.frameRate` (GraphQL-hoisted from
- * `VideoMetadata.frame_rate`); frameCount comes from
- * `sample.sample.metadata.total_frame_count` and falls back to
- * `metadata.duration * frameRate`. Both fps and frameCount throw if
- * absent — the plan explicitly forbids silent defaults because the
- * failure mode (misaligned frames or a stuck timeline) is hard to
- * debug after the fact.
+ * `frameCount` and `frameRate` are resolved + validated upstream by
+ * `useAnnotatePrerequisites` (which gates this component behind a
+ * "compute metadata" prompt when they're absent), so they arrive as
+ * positive finite numbers — no resolution or throwing here.
  *
  * Re-keys on any identity change so a fresh stream replaces the old
  * one via `usePlaybackStream`'s standard cleanup.
  */
 export const RegisterImaVidImage: React.FC<{
-  sample: ModalSample;
+  frameCount: number;
+  frameRate: number;
   children: React.ReactNode;
-}> = ({ sample, children }) => {
+}> = ({ frameCount, frameRate, children }) => {
   const dataset = useDatasetName();
   const view = useView();
   const slice = useGroupSlice();
   const sampleId = useModalSampleId();
-
-  const frameRate = getModalSampleFrameRate(sample);
-  if (frameRate === undefined) {
-    throw new Error(
-      "ImaVid playback requires VideoMetadata.frame_rate to be set on the sample",
-    );
-  }
-  if (!Number.isFinite(frameRate) || frameRate <= 0) {
-    throw new Error(
-      `ImaVid playback requires a positive, finite fps (got ${frameRate})`,
-    );
-  }
-
-  const frameCount = resolveFrameCount(sample, frameRate);
 
   const ready = !!sampleId && !!dataset;
   if (!ready) {
@@ -78,38 +60,6 @@ export const RegisterImaVidImage: React.FC<{
     </ImaVidImageRegistration>
   );
 };
-
-/**
- * Read total frame count from sample.metadata. The `Sample` TS type
- * only declares `width / height / mime_type`, but VideoMetadata
- * persists `total_frame_count` and `duration` at runtime — we
- * loose-cast through.
- */
-export function resolveFrameCount(
-  sample: ModalSample,
-  frameRate: number,
-): number {
-  const metadata = (sample.sample as { metadata?: Record<string, unknown> })
-    ?.metadata;
-
-  const total = metadata?.total_frame_count;
-  if (typeof total === "number" && Number.isFinite(total) && total > 0) {
-    return Math.round(total);
-  }
-
-  const duration = metadata?.duration;
-  if (
-    typeof duration === "number" &&
-    Number.isFinite(duration) &&
-    duration > 0
-  ) {
-    return Math.max(1, Math.round(duration * frameRate));
-  }
-
-  throw new Error(
-    "ImaVid playback requires VideoMetadata.total_frame_count (or .duration) on the sample",
-  );
-}
 
 interface ImaVidImageRegistrationProps {
   sampleId: string;

--- a/app/packages/video-annotation/src/components/VideoAnnotationSurface.tsx
+++ b/app/packages/video-annotation/src/components/VideoAnnotationSurface.tsx
@@ -9,7 +9,10 @@ import { useVideoLighterEngineBridge } from "../hooks/useVideoLighterEngineBridg
 import { useFollowAnchorFrame } from "../state/useVideoInteraction";
 import { useAnnotatePrerequisites } from "../hooks/useAnnotatePrerequisites";
 import { PlaybackProvider } from "@fiftyone/playback";
-import { AnnotatePrerequisiteNotice } from "./AnnotatePrerequisiteNotice";
+import {
+  AnnotatePrerequisiteChecking,
+  AnnotatePrerequisiteNotice,
+} from "./AnnotatePrerequisiteNotice";
 import { FrameLabelsTracks, RegisterFrameLabels } from "./FrameLabels";
 import { ImaVidLighterTile } from "./ImaVidLighterTile";
 import { RegisterImaVidImage } from "./RegisterImaVidImage";
@@ -93,16 +96,20 @@ export const VideoAnnotationSurface: React.FC<VideoAnnotationSurfaceProps> = ({
   const tileMode = useTileMode();
   const prerequisites = useAnnotatePrerequisites(sample);
 
-  // Annotation needs a frame count (and fps) to drive the timeline; when the
-  // sample's VideoMetadata wasn't computed we can't resolve one. Show a prompt
-  // instead of mounting the playback stream — which used to throw and take the
-  // whole modal down (explore included).
-  if (!prerequisites.ok) {
+  // Annotation needs computed metadata (frame count + fps) and sampled frame
+  // images. When a prerequisite is missing, show an actionable prompt instead
+  // of mounting the playback stream — which used to throw and take the whole
+  // modal down (metadata), or render a silent blank (frames).
+  if (prerequisites.status !== "ready") {
     return (
       <div className={styles.root}>
         <VideoAnnotationTopBar sample={sample} />
         <div className={styles.media}>
-          <AnnotatePrerequisiteNotice blocker={prerequisites.blocker} />
+          {prerequisites.status === "blocked" ? (
+            <AnnotatePrerequisiteNotice blocker={prerequisites.blocker} />
+          ) : (
+            <AnnotatePrerequisiteChecking />
+          )}
         </div>
       </div>
     );

--- a/app/packages/video-annotation/src/components/VideoAnnotationSurface.tsx
+++ b/app/packages/video-annotation/src/components/VideoAnnotationSurface.tsx
@@ -7,7 +7,9 @@ import { useSyncAnnotationFrameClock } from "../hooks/useSyncAnnotationFrameCloc
 import { useSyncAnnotationVideoStore } from "../hooks/useSyncAnnotationVideoStore";
 import { useVideoLighterEngineBridge } from "../hooks/useVideoLighterEngineBridge";
 import { useFollowAnchorFrame } from "../state/useVideoInteraction";
+import { useAnnotatePrerequisites } from "../hooks/useAnnotatePrerequisites";
 import { PlaybackProvider } from "@fiftyone/playback";
+import { AnnotatePrerequisiteNotice } from "./AnnotatePrerequisiteNotice";
 import { FrameLabelsTracks, RegisterFrameLabels } from "./FrameLabels";
 import { ImaVidLighterTile } from "./ImaVidLighterTile";
 import { RegisterImaVidImage } from "./RegisterImaVidImage";
@@ -89,6 +91,22 @@ export const VideoAnnotationSurface: React.FC<VideoAnnotationSurfaceProps> = ({
 }) => {
   const labelsMode = useLabelsMode();
   const tileMode = useTileMode();
+  const prerequisites = useAnnotatePrerequisites(sample);
+
+  // Annotation needs a frame count (and fps) to drive the timeline; when the
+  // sample's VideoMetadata wasn't computed we can't resolve one. Show a prompt
+  // instead of mounting the playback stream — which used to throw and take the
+  // whole modal down (explore included).
+  if (!prerequisites.ok) {
+    return (
+      <div className={styles.root}>
+        <VideoAnnotationTopBar sample={sample} />
+        <div className={styles.media}>
+          <AnnotatePrerequisiteNotice blocker={prerequisites.blocker} />
+        </div>
+      </div>
+    );
+  }
 
   // The native-video tile binds to a single top-level URL. The ImaVid
   // tile resolves a per-frame URL through the image stream, so it does
@@ -143,7 +161,12 @@ export const VideoAnnotationSurface: React.FC<VideoAnnotationSurfaceProps> = ({
 
   const registered =
     tileMode === "imavid" ? (
-      <RegisterImaVidImage sample={sample}>{labels}</RegisterImaVidImage>
+      <RegisterImaVidImage
+        frameCount={prerequisites.frameCount}
+        frameRate={prerequisites.frameRate}
+      >
+        {labels}
+      </RegisterImaVidImage>
     ) : (
       labels
     );

--- a/app/packages/video-annotation/src/components/VideoAnnotationSurface.tsx
+++ b/app/packages/video-annotation/src/components/VideoAnnotationSurface.tsx
@@ -96,6 +96,19 @@ export const VideoAnnotationSurface: React.FC<VideoAnnotationSurfaceProps> = ({
   const tileMode = useTileMode();
   const prerequisites = useAnnotatePrerequisites(sample);
 
+  // The native-video tile binds to a single top-level URL. The ImaVid
+  // tile resolves a per-frame URL through the image stream, so it does
+  // not need (and ignores) this value. Computed before the prerequisite
+  // gate so hook order stays stable across the checking → ready transition.
+  const videoSrc = useMemo(() => {
+    if (tileMode !== "video") {
+      return null;
+    }
+
+    const url = sample.urls?.[0]?.url;
+    return url ? getSampleSrc(url) : null;
+  }, [sample, tileMode]);
+
   // Annotation needs computed metadata (frame count + fps) and sampled frame
   // images. When a prerequisite is missing, show an actionable prompt instead
   // of mounting the playback stream — which used to throw and take the whole
@@ -114,18 +127,6 @@ export const VideoAnnotationSurface: React.FC<VideoAnnotationSurfaceProps> = ({
       </div>
     );
   }
-
-  // The native-video tile binds to a single top-level URL. The ImaVid
-  // tile resolves a per-frame URL through the image stream, so it does
-  // not need (and ignores) this value.
-  const videoSrc = useMemo(() => {
-    if (tileMode !== "video") {
-      return null;
-    }
-
-    const url = sample.urls?.[0]?.url;
-    return url ? getSampleSrc(url) : null;
-  }, [sample, tileMode]);
 
   const media =
     tileMode === "imavid" ? (

--- a/app/packages/video-annotation/src/hooks/useAnnotatePrerequisites.test.ts
+++ b/app/packages/video-annotation/src/hooks/useAnnotatePrerequisites.test.ts
@@ -12,9 +12,9 @@ vi.mock("./useSampledFramesProbe", () => ({
 
 const sampleWith = (
   frameRate: unknown,
-  metadata: Record<string, unknown>
+  metadata: Record<string, unknown>,
 ): ModalSample =>
-  ({ frameRate, sample: { metadata } } as unknown as ModalSample);
+  ({ frameRate, sample: { metadata } }) as unknown as ModalSample;
 
 beforeEach(() => {
   probeState = "sampled";
@@ -24,7 +24,7 @@ describe("useAnnotatePrerequisites", () => {
   it("is ready when metadata is present and frames are sampled", () => {
     probeState = "sampled";
     const { result } = renderHook(() =>
-      useAnnotatePrerequisites(sampleWith(30, { total_frame_count: 90 }))
+      useAnnotatePrerequisites(sampleWith(30, { total_frame_count: 90 })),
     );
 
     expect(result.current).toEqual({
@@ -37,7 +37,7 @@ describe("useAnnotatePrerequisites", () => {
   it("reports checking while the frames probe is in flight", () => {
     probeState = "checking";
     const { result } = renderHook(() =>
-      useAnnotatePrerequisites(sampleWith(30, { total_frame_count: 90 }))
+      useAnnotatePrerequisites(sampleWith(30, { total_frame_count: 90 })),
     );
 
     expect(result.current).toEqual({
@@ -50,7 +50,7 @@ describe("useAnnotatePrerequisites", () => {
   it("blocks on frames when the video isn't sampled", () => {
     probeState = "unsampled";
     const { result } = renderHook(() =>
-      useAnnotatePrerequisites(sampleWith(30, { total_frame_count: 90 }))
+      useAnnotatePrerequisites(sampleWith(30, { total_frame_count: 90 })),
     );
 
     expect(result.current).toEqual({
@@ -63,7 +63,9 @@ describe("useAnnotatePrerequisites", () => {
 
   it("blocks on metadata when frameRate is missing", () => {
     const { result } = renderHook(() =>
-      useAnnotatePrerequisites(sampleWith(undefined, { total_frame_count: 90 }))
+      useAnnotatePrerequisites(
+        sampleWith(undefined, { total_frame_count: 90 }),
+      ),
     );
 
     expect(result.current).toEqual({ status: "blocked", blocker: "metadata" });
@@ -71,7 +73,7 @@ describe("useAnnotatePrerequisites", () => {
 
   it("blocks on metadata when frame count is unresolvable", () => {
     const { result } = renderHook(() =>
-      useAnnotatePrerequisites(sampleWith(30, {}))
+      useAnnotatePrerequisites(sampleWith(30, {})),
     );
 
     expect(result.current).toEqual({ status: "blocked", blocker: "metadata" });

--- a/app/packages/video-annotation/src/hooks/useAnnotatePrerequisites.test.ts
+++ b/app/packages/video-annotation/src/hooks/useAnnotatePrerequisites.test.ts
@@ -1,7 +1,14 @@
 import type { ModalSample } from "@fiftyone/state";
 import { renderHook } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useAnnotatePrerequisites } from "./useAnnotatePrerequisites";
+import type { SampledFramesState } from "./useSampledFramesProbe";
+
+let probeState: SampledFramesState = "sampled";
+
+vi.mock("./useSampledFramesProbe", () => ({
+  useSampledFramesProbe: () => probeState,
+}));
 
 const sampleWith = (
   frameRate: unknown,
@@ -9,14 +16,46 @@ const sampleWith = (
 ): ModalSample =>
   ({ frameRate, sample: { metadata } } as unknown as ModalSample);
 
+beforeEach(() => {
+  probeState = "sampled";
+});
+
 describe("useAnnotatePrerequisites", () => {
-  it("resolves frameRate + frameCount when metadata is present", () => {
+  it("is ready when metadata is present and frames are sampled", () => {
+    probeState = "sampled";
     const { result } = renderHook(() =>
       useAnnotatePrerequisites(sampleWith(30, { total_frame_count: 90 }))
     );
 
     expect(result.current).toEqual({
-      ok: true,
+      status: "ready",
+      frameRate: 30,
+      frameCount: 90,
+    });
+  });
+
+  it("reports checking while the frames probe is in flight", () => {
+    probeState = "checking";
+    const { result } = renderHook(() =>
+      useAnnotatePrerequisites(sampleWith(30, { total_frame_count: 90 }))
+    );
+
+    expect(result.current).toEqual({
+      status: "checking",
+      frameRate: 30,
+      frameCount: 90,
+    });
+  });
+
+  it("blocks on frames when the video isn't sampled", () => {
+    probeState = "unsampled";
+    const { result } = renderHook(() =>
+      useAnnotatePrerequisites(sampleWith(30, { total_frame_count: 90 }))
+    );
+
+    expect(result.current).toEqual({
+      status: "blocked",
+      blocker: "frames",
       frameRate: 30,
       frameCount: 90,
     });
@@ -27,7 +66,7 @@ describe("useAnnotatePrerequisites", () => {
       useAnnotatePrerequisites(sampleWith(undefined, { total_frame_count: 90 }))
     );
 
-    expect(result.current).toEqual({ ok: false, blocker: "metadata" });
+    expect(result.current).toEqual({ status: "blocked", blocker: "metadata" });
   });
 
   it("blocks on metadata when frame count is unresolvable", () => {
@@ -35,6 +74,6 @@ describe("useAnnotatePrerequisites", () => {
       useAnnotatePrerequisites(sampleWith(30, {}))
     );
 
-    expect(result.current).toEqual({ ok: false, blocker: "metadata" });
+    expect(result.current).toEqual({ status: "blocked", blocker: "metadata" });
   });
 });

--- a/app/packages/video-annotation/src/hooks/useAnnotatePrerequisites.test.ts
+++ b/app/packages/video-annotation/src/hooks/useAnnotatePrerequisites.test.ts
@@ -1,0 +1,40 @@
+import type { ModalSample } from "@fiftyone/state";
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useAnnotatePrerequisites } from "./useAnnotatePrerequisites";
+
+const sampleWith = (
+  frameRate: unknown,
+  metadata: Record<string, unknown>
+): ModalSample =>
+  ({ frameRate, sample: { metadata } } as unknown as ModalSample);
+
+describe("useAnnotatePrerequisites", () => {
+  it("resolves frameRate + frameCount when metadata is present", () => {
+    const { result } = renderHook(() =>
+      useAnnotatePrerequisites(sampleWith(30, { total_frame_count: 90 }))
+    );
+
+    expect(result.current).toEqual({
+      ok: true,
+      frameRate: 30,
+      frameCount: 90,
+    });
+  });
+
+  it("blocks on metadata when frameRate is missing", () => {
+    const { result } = renderHook(() =>
+      useAnnotatePrerequisites(sampleWith(undefined, { total_frame_count: 90 }))
+    );
+
+    expect(result.current).toEqual({ ok: false, blocker: "metadata" });
+  });
+
+  it("blocks on metadata when frame count is unresolvable", () => {
+    const { result } = renderHook(() =>
+      useAnnotatePrerequisites(sampleWith(30, {}))
+    );
+
+    expect(result.current).toEqual({ ok: false, blocker: "metadata" });
+  });
+});

--- a/app/packages/video-annotation/src/hooks/useAnnotatePrerequisites.ts
+++ b/app/packages/video-annotation/src/hooks/useAnnotatePrerequisites.ts
@@ -1,0 +1,48 @@
+import type { ModalSample } from "@fiftyone/state";
+import { useMemo } from "react";
+import { resolveFrameCount } from "../utils/frameCount";
+import { getModalSampleFrameRate } from "../utils/modalSample";
+
+/** Why the annotate surface can't mount its playback stream yet. */
+export type AnnotateBlocker = "metadata";
+
+/**
+ * Flat (not discriminated-union) shape: this codebase compiles with
+ * `strict: false`, so `if (!x.ok)` doesn't narrow a union — keep every field
+ * accessible and lean on `ok` at runtime. `blocker` is set iff `ok` is false;
+ * `frameRate`/`frameCount` are valid iff `ok` is true.
+ */
+export interface AnnotatePrerequisites {
+  ok: boolean;
+  blocker?: AnnotateBlocker;
+  frameRate?: number;
+  frameCount?: number;
+}
+
+/**
+ * Resolve the inputs the ImaVid playback stream needs: a positive fps and a
+ * frame count (from `total_frame_count`, else `duration * fps`). When the
+ * sample's `VideoMetadata` wasn't computed, both are absent — report a
+ * `metadata` blocker so the surface shows a prompt instead of throwing and
+ * taking down the whole modal.
+ */
+export const useAnnotatePrerequisites = (
+  sample: ModalSample
+): AnnotatePrerequisites =>
+  useMemo(() => {
+    const frameRate = getModalSampleFrameRate(sample);
+    if (
+      frameRate === undefined ||
+      !Number.isFinite(frameRate) ||
+      frameRate <= 0
+    ) {
+      return { ok: false, blocker: "metadata" };
+    }
+
+    const frameCount = resolveFrameCount(sample, frameRate);
+    if (frameCount === null) {
+      return { ok: false, blocker: "metadata" };
+    }
+
+    return { ok: true, frameRate, frameCount };
+  }, [sample]);

--- a/app/packages/video-annotation/src/hooks/useAnnotatePrerequisites.ts
+++ b/app/packages/video-annotation/src/hooks/useAnnotatePrerequisites.ts
@@ -41,14 +41,14 @@ export interface AnnotatePrerequisites {
  * resolved, since it needs the frame count.
  */
 export const useAnnotatePrerequisites = (
-  sample: ModalSample
+  sample: ModalSample,
 ): AnnotatePrerequisites => {
   const frameRate = getModalSampleFrameRate(sample);
   const hasFrameRate =
     frameRate !== undefined && Number.isFinite(frameRate) && frameRate > 0;
 
   const frameCount = hasFrameRate
-    ? resolveFrameCount(sample, frameRate as number) ?? undefined
+    ? (resolveFrameCount(sample, frameRate as number) ?? undefined)
     : undefined;
 
   const metadataOk = hasFrameRate && frameCount !== undefined;

--- a/app/packages/video-annotation/src/hooks/useAnnotatePrerequisites.ts
+++ b/app/packages/video-annotation/src/hooks/useAnnotatePrerequisites.ts
@@ -1,48 +1,73 @@
 import type { ModalSample } from "@fiftyone/state";
-import { useMemo } from "react";
 import { resolveFrameCount } from "../utils/frameCount";
 import { getModalSampleFrameRate } from "../utils/modalSample";
+import { useSampledFramesProbe } from "./useSampledFramesProbe";
 
-/** Why the annotate surface can't mount its playback stream yet. */
-export type AnnotateBlocker = "metadata";
+/** Why the annotate surface can't mount its playback stream. */
+export type AnnotateBlocker = "metadata" | "frames";
+
+/**
+ * `checking` — still resolving a prerequisite (a `/frames` probe is in
+ * flight); `ready` — the playback stream can mount; `blocked` — a `blocker`
+ * needs user action first.
+ */
+export type AnnotateStatus = "checking" | "ready" | "blocked";
 
 /**
  * Flat (not discriminated-union) shape: this codebase compiles with
- * `strict: false`, so `if (!x.ok)` doesn't narrow a union — keep every field
- * accessible and lean on `ok` at runtime. `blocker` is set iff `ok` is false;
- * `frameRate`/`frameCount` are valid iff `ok` is true.
+ * `strict: false`, so `if (status === ...)` can't narrow a union — keep every
+ * field accessible and switch on `status` at runtime. `blocker` is set iff
+ * `status` is "blocked"; `frameRate`/`frameCount` are valid once metadata
+ * resolves (i.e. for every status except a "metadata" block).
  */
 export interface AnnotatePrerequisites {
-  ok: boolean;
+  status: AnnotateStatus;
   blocker?: AnnotateBlocker;
   frameRate?: number;
   frameCount?: number;
 }
 
 /**
- * Resolve the inputs the ImaVid playback stream needs: a positive fps and a
- * frame count (from `total_frame_count`, else `duration * fps`). When the
- * sample's `VideoMetadata` wasn't computed, both are absent — report a
- * `metadata` blocker so the surface shows a prompt instead of throwing and
- * taking down the whole modal.
+ * Resolve everything the ImaVid playback stream needs before it mounts:
+ *
+ * 1. a positive fps + a frame count (from `total_frame_count`, else
+ *    `duration * fps`) — absent when `VideoMetadata` wasn't computed →
+ *    `metadata` block;
+ * 2. materialized per-frame images — absent when the video wasn't
+ *    `to_frames(sample_frames=True)`'d → `frames` block.
+ *
+ * Reporting a block (instead of mounting + throwing/blank) lets the surface
+ * show an actionable prompt. The frames probe only runs once metadata is
+ * resolved, since it needs the frame count.
  */
 export const useAnnotatePrerequisites = (
   sample: ModalSample
-): AnnotatePrerequisites =>
-  useMemo(() => {
-    const frameRate = getModalSampleFrameRate(sample);
-    if (
-      frameRate === undefined ||
-      !Number.isFinite(frameRate) ||
-      frameRate <= 0
-    ) {
-      return { ok: false, blocker: "metadata" };
-    }
+): AnnotatePrerequisites => {
+  const frameRate = getModalSampleFrameRate(sample);
+  const hasFrameRate =
+    frameRate !== undefined && Number.isFinite(frameRate) && frameRate > 0;
 
-    const frameCount = resolveFrameCount(sample, frameRate);
-    if (frameCount === null) {
-      return { ok: false, blocker: "metadata" };
-    }
+  const frameCount = hasFrameRate
+    ? resolveFrameCount(sample, frameRate as number) ?? undefined
+    : undefined;
 
-    return { ok: true, frameRate, frameCount };
-  }, [sample]);
+  const metadataOk = hasFrameRate && frameCount !== undefined;
+
+  // Hooks can't be conditional — the probe always runs but no-ops (stays
+  // "checking") until metadata resolves and enables it.
+  const framesState = useSampledFramesProbe(frameCount, metadataOk);
+
+  if (!metadataOk) {
+    return { status: "blocked", blocker: "metadata" };
+  }
+
+  if (framesState === "checking") {
+    return { status: "checking", frameRate, frameCount };
+  }
+
+  if (framesState === "unsampled") {
+    return { status: "blocked", blocker: "frames", frameRate, frameCount };
+  }
+
+  return { status: "ready", frameRate, frameCount };
+};

--- a/app/packages/video-annotation/src/hooks/useSampledFramesProbe.test.ts
+++ b/app/packages/video-annotation/src/hooks/useSampledFramesProbe.test.ts
@@ -34,13 +34,13 @@ describe("responseHasSampledFrames", () => {
     expect(
       responseHasSampledFrames({
         frames: [{ frame_number: 1, filepath: "/a.jpg" }],
-      })
+      }),
     ).toBe(true);
     expect(responseHasSampledFrames({ frames: [{ frame_number: 1 }] })).toBe(
-      false
+      false,
     );
     expect(
-      responseHasSampledFrames({ frames: [{ frame_number: 1, filepath: "" }] })
+      responseHasSampledFrames({ frames: [{ frame_number: 1, filepath: "" }] }),
     ).toBe(false);
     expect(responseHasSampledFrames({ frames: [] })).toBe(false);
     expect(responseHasSampledFrames({})).toBe(false);
@@ -71,7 +71,7 @@ describe("useSampledFramesProbe", () => {
         frameNumber: 1,
         numFrames: 1,
         fields: ["filepath"],
-      })
+      }),
     );
   });
 

--- a/app/packages/video-annotation/src/hooks/useSampledFramesProbe.test.ts
+++ b/app/packages/video-annotation/src/hooks/useSampledFramesProbe.test.ts
@@ -1,0 +1,95 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  responseHasSampledFrames,
+  useSampledFramesProbe,
+} from "./useSampledFramesProbe";
+
+const { fetchFn } = vi.hoisted(() => ({ fetchFn: vi.fn() }));
+
+vi.mock("@fiftyone/utilities", () => ({
+  getFetchFunction: () => fetchFn,
+}));
+
+vi.mock("../state/accessors", () => ({
+  useDatasetName: () => "d1",
+  useView: () => [],
+  useGroupSlice: () => null,
+  useModalSampleId: () => "s1",
+}));
+
+/** Flush the probe's fetch-resolve → setState microtask chain inside act. */
+const flush = () =>
+  act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
+beforeEach(() => {
+  fetchFn.mockReset();
+});
+
+describe("responseHasSampledFrames", () => {
+  it("is true only when frame 1 carries a non-empty filepath", () => {
+    expect(
+      responseHasSampledFrames({
+        frames: [{ frame_number: 1, filepath: "/a.jpg" }],
+      })
+    ).toBe(true);
+    expect(responseHasSampledFrames({ frames: [{ frame_number: 1 }] })).toBe(
+      false
+    );
+    expect(
+      responseHasSampledFrames({ frames: [{ frame_number: 1, filepath: "" }] })
+    ).toBe(false);
+    expect(responseHasSampledFrames({ frames: [] })).toBe(false);
+    expect(responseHasSampledFrames({})).toBe(false);
+  });
+});
+
+describe("useSampledFramesProbe", () => {
+  it("stays checking and issues no request while disabled", () => {
+    const { result } = renderHook(() => useSampledFramesProbe(90, false));
+
+    expect(result.current).toBe("checking");
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("reports sampled when frame 1 has a filepath", async () => {
+    fetchFn.mockResolvedValue({
+      frames: [{ frame_number: 1, filepath: "/a/1.jpg" }],
+    });
+
+    const { result } = renderHook(() => useSampledFramesProbe(90, true));
+    await flush();
+
+    expect(result.current).toBe("sampled");
+    expect(fetchFn).toHaveBeenCalledWith(
+      "POST",
+      "/frames",
+      expect.objectContaining({
+        frameNumber: 1,
+        numFrames: 1,
+        fields: ["filepath"],
+      })
+    );
+  });
+
+  it("reports unsampled when frame 1 has no filepath", async () => {
+    fetchFn.mockResolvedValue({ frames: [{ frame_number: 1 }] });
+
+    const { result } = renderHook(() => useSampledFramesProbe(90, true));
+    await flush();
+
+    expect(result.current).toBe("unsampled");
+  });
+
+  it("treats a probe error as inconclusive so it doesn't wrongly block", async () => {
+    fetchFn.mockRejectedValue(new Error("boom"));
+
+    const { result } = renderHook(() => useSampledFramesProbe(90, true));
+    await flush();
+
+    expect(result.current).toBe("sampled");
+  });
+});

--- a/app/packages/video-annotation/src/hooks/useSampledFramesProbe.ts
+++ b/app/packages/video-annotation/src/hooks/useSampledFramesProbe.ts
@@ -1,0 +1,97 @@
+import { getFetchFunction } from "@fiftyone/utilities";
+import { useEffect, useState } from "react";
+import {
+  useDatasetName,
+  useGroupSlice,
+  useModalSampleId,
+  useView,
+} from "../state/accessors";
+
+export type SampledFramesState = "checking" | "sampled" | "unsampled";
+
+export interface FramesProbeResponse {
+  frames?: Array<{ frame_number: number; filepath?: string }>;
+}
+
+/** A `/frames` probe response counts as "sampled" iff frame 1 has a filepath. */
+export const responseHasSampledFrames = (
+  response: FramesProbeResponse
+): boolean => {
+  const filepath = response?.frames?.[0]?.filepath;
+  return typeof filepath === "string" && filepath.length > 0;
+};
+
+/**
+ * Probe whether the open video's frames are materialized on disk. The ImaVid
+ * annotate path renders one image per frame, so a video that hasn't been
+ * `to_frames(sample_frames=True)`'d has no per-frame `filepath` and renders
+ * blank. We POST a single-frame `/frames` request for frame 1 and treat a
+ * non-empty `filepath` as "sampled".
+ *
+ * `enabled` gates the probe on upstream metadata being resolved (we need a
+ * frame count first); while disabled or in-flight it reports "checking". A
+ * probe error is treated as inconclusive — we report "sampled" so a transient
+ * failure doesn't wrongly block annotation; the stream's own failed-frame
+ * handling covers genuinely missing media.
+ */
+export const useSampledFramesProbe = (
+  frameCount: number | undefined,
+  enabled: boolean
+): SampledFramesState => {
+  const dataset = useDatasetName();
+  const view = useView();
+  const slice = useGroupSlice();
+  const sampleId = useModalSampleId();
+
+  const [state, setState] = useState<SampledFramesState>("checking");
+
+  // `view` is a fresh array each render when no view is applied, so key the
+  // effect off its serialized value — depending on the array identity would
+  // re-run the probe (and re-fetch) on every render.
+  const viewKey = JSON.stringify(view);
+
+  useEffect(() => {
+    if (!enabled || !sampleId || !dataset || !frameCount) {
+      setState("checking");
+      return undefined;
+    }
+
+    let cancelled = false;
+    setState("checking");
+
+    const probe = async () => {
+      try {
+        const response = (await getFetchFunction()("POST", "/frames", {
+          sampleId,
+          dataset,
+          view,
+          frameNumber: 1,
+          numFrames: 1,
+          frameCount,
+          slice: slice ?? undefined,
+          fields: ["filepath"],
+        })) as FramesProbeResponse;
+
+        if (cancelled) {
+          return;
+        }
+
+        setState(responseHasSampledFrames(response) ? "sampled" : "unsampled");
+      } catch {
+        if (!cancelled) {
+          setState("sampled");
+        }
+      }
+    };
+
+    probe();
+
+    return () => {
+      cancelled = true;
+    };
+    // `view` is intentionally tracked via `viewKey` (stable by value).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, sampleId, dataset, slice, frameCount, viewKey]);
+
+  return state;
+};

--- a/app/packages/video-annotation/src/hooks/useSampledFramesProbe.ts
+++ b/app/packages/video-annotation/src/hooks/useSampledFramesProbe.ts
@@ -15,7 +15,7 @@ export interface FramesProbeResponse {
 
 /** A `/frames` probe response counts as "sampled" iff frame 1 has a filepath. */
 export const responseHasSampledFrames = (
-  response: FramesProbeResponse
+  response: FramesProbeResponse,
 ): boolean => {
   const filepath = response?.frames?.[0]?.filepath;
   return typeof filepath === "string" && filepath.length > 0;
@@ -36,7 +36,7 @@ export const responseHasSampledFrames = (
  */
 export const useSampledFramesProbe = (
   frameCount: number | undefined,
-  enabled: boolean
+  enabled: boolean,
 ): SampledFramesState => {
   const dataset = useDatasetName();
   const view = useView();

--- a/app/packages/video-annotation/src/streams/ImaVidImageStream.test.ts
+++ b/app/packages/video-annotation/src/streams/ImaVidImageStream.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ImaVidImageStream } from "./ImaVidImageStream";
+
+interface WorkerMessage {
+  type: string;
+  reqId?: number;
+  request?: { frameNumber: number; numFrames: number };
+}
+
+/** Minimal Worker stub: records outbound messages, replays inbound ones. */
+class FakeWorker {
+  static instances: FakeWorker[] = [];
+  listeners: Array<(e: { data: unknown }) => void> = [];
+  posted: WorkerMessage[] = [];
+
+  constructor() {
+    FakeWorker.instances.push(this);
+  }
+
+  addEventListener(_type: string, cb: (e: { data: unknown }) => void) {
+    this.listeners.push(cb);
+  }
+
+  removeEventListener(_type: string, cb: (e: { data: unknown }) => void) {
+    this.listeners = this.listeners.filter((l) => l !== cb);
+  }
+
+  postMessage(msg: WorkerMessage) {
+    this.posted.push(msg);
+  }
+
+  terminate() {}
+
+  emit(data: unknown) {
+    for (const l of this.listeners) {
+      l({ data });
+    }
+  }
+}
+
+const fetchChunks = (w: FakeWorker) =>
+  w.posted.filter((m) => m.type === "fetchChunk");
+
+const makeStream = () =>
+  new ImaVidImageStream({
+    id: "test",
+    sampleId: "s1",
+    dataset: "d1",
+    view: [],
+    frameCount: 120,
+    frameRate: 30,
+    chunkSize: 4,
+  });
+
+beforeEach(() => {
+  FakeWorker.instances = [];
+  vi.stubGlobal("Worker", FakeWorker as unknown as typeof Worker);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("ImaVidImageStream failed-frame handling", () => {
+  it("treats frames that settle without a bitmap as terminally ready and never re-requests them", () => {
+    const stream = makeStream();
+    const worker = FakeWorker.instances[0];
+
+    // Engine nudges a missing frame → one chunk goes out.
+    stream.prefetch([0, 0]);
+    const requests = fetchChunks(worker);
+    expect(requests).toHaveLength(1);
+
+    const { reqId, request } = requests[0];
+
+    // Chunk completes but no frame produced a bitmap (e.g. unresolvable
+    // filepath) → every requested frame failed.
+    worker.emit({
+      type: "chunkDone",
+      reqId,
+      range: [
+        request!.frameNumber,
+        request!.frameNumber + request!.numFrames - 1,
+      ],
+    });
+
+    // The frame reports ready (empty) so the buffer barrier plays through it...
+    expect(stream.bufferState(0)).toBe("ready");
+
+    // ...and re-prefetching the same range issues no further fetch.
+    stream.prefetch([0, 0]);
+    expect(fetchChunks(worker)).toHaveLength(1);
+
+    stream.destroy();
+  });
+});

--- a/app/packages/video-annotation/src/streams/ImaVidImageStream.ts
+++ b/app/packages/video-annotation/src/streams/ImaVidImageStream.ts
@@ -98,6 +98,13 @@ export class ImaVidImageStream extends PlaybackStreamBase<ImaVidImageFrame> {
   private readonly inflight = new Map<number, InflightEntry>();
   /** reqId → frame numbers that request asked for. */
   private readonly requestFrames = new Map<number, number[]>();
+  /**
+   * Frames that settled without a bitmap — unresolvable `filepath`, decode
+   * error, or a failed `/frames` chunk. Terminal: we never re-request them, so
+   * a bad frame can't drive an infinite `/frames` loop. Cleared only on
+   * `destroy` (a re-sampled clip arrives as a fresh, re-keyed stream).
+   */
+  private readonly failed = new Set<number>();
   private readonly fetchedRanges: Array<[number, number]> = [];
 
   private readonly worker: Worker;
@@ -160,7 +167,7 @@ export class ImaVidImageStream extends PlaybackStreamBase<ImaVidImageFrame> {
    */
   async warmup(time = 0): Promise<void> {
     const frame = this.timeToFrame(time);
-    if (this.cache.has(frame)) {
+    if (this.cache.has(frame) || this.failed.has(frame)) {
       return;
     }
 
@@ -194,6 +201,7 @@ export class ImaVidImageStream extends PlaybackStreamBase<ImaVidImageFrame> {
     }
     this.inflight.clear();
     this.requestFrames.clear();
+    this.failed.clear();
     this.cache.clear();
   }
 
@@ -214,6 +222,13 @@ export class ImaVidImageStream extends PlaybackStreamBase<ImaVidImageFrame> {
       return "ready";
     }
 
+    // A terminally-failed frame is reported "ready" (it just has no bitmap):
+    // the engine's buffer barrier plays through to a blank frame instead of
+    // stalling on it forever and re-issuing prefetch every tick.
+    if (this.failed.has(frame)) {
+      return "ready";
+    }
+
     if (this.inflight.has(frame)) {
       return "loading";
     }
@@ -229,7 +244,7 @@ export class ImaVidImageStream extends PlaybackStreamBase<ImaVidImageFrame> {
     // First missing frame wins — the engine re-calls prefetch as the
     // playhead advances, so we don't need to fan out here.
     for (let f = startFrame; f <= endFrame; f++) {
-      if (this.cache.has(f) || this.inflight.has(f)) {
+      if (this.cache.has(f) || this.inflight.has(f) || this.failed.has(f)) {
         continue;
       }
 
@@ -304,9 +319,9 @@ export class ImaVidImageStream extends PlaybackStreamBase<ImaVidImageFrame> {
     const reqId = this.nextReqId++;
     const frames: number[] = [];
     for (let f = startFrame; f < startFrame + numFrames; f++) {
-      // Skip frames the cache already has or another request is fetching;
-      // the worker doesn't dedupe so we have to.
-      if (this.cache.has(f) || this.inflight.has(f)) {
+      // Skip frames the cache already has, another request is fetching, or
+      // that already failed terminally; the worker doesn't dedupe so we have to.
+      if (this.cache.has(f) || this.inflight.has(f) || this.failed.has(f)) {
         continue;
       }
 
@@ -394,11 +409,11 @@ export class ImaVidImageStream extends PlaybackStreamBase<ImaVidImageFrame> {
   }
 
   /**
-   * Settle any in-flight frames from this request that never received
-   * a `frameReady` (e.g. missing filepath, decode error, top-level
-   * fetch failure). They drop from `loading` → `missing` so the engine
-   * re-prefetches on the next tick. Anyone awaiting `warmup` unblocks
-   * (the cache miss is observable via `bufferState`).
+   * Settle any in-flight frames from this request that never received a
+   * `frameReady` (missing/unresolvable filepath, decode error, or a failed
+   * chunk). They're marked terminally `failed` so we never re-request them —
+   * otherwise the engine, seeing them perpetually un-ready, would re-prefetch
+   * every tick and hammer `/frames` forever. Anyone awaiting `warmup` unblocks.
    */
   private resolveOutstandingFrames(reqId: number): void {
     const frames = this.requestFrames.get(reqId);
@@ -414,6 +429,7 @@ export class ImaVidImageStream extends PlaybackStreamBase<ImaVidImageFrame> {
         continue;
       }
 
+      this.failed.add(f);
       entry.resolve();
       this.inflight.delete(f);
     }

--- a/app/packages/video-annotation/src/utils/frameCount.test.ts
+++ b/app/packages/video-annotation/src/utils/frameCount.test.ts
@@ -1,6 +1,6 @@
 import type { ModalSample } from "@fiftyone/state";
 import { describe, expect, it } from "vitest";
-import { resolveFrameCount } from "./RegisterImaVidImage";
+import { resolveFrameCount } from "./frameCount";
 
 const sampleWith = (metadata: Record<string, unknown>): ModalSample =>
   ({ sample: { metadata } }) as unknown as ModalSample;
@@ -22,7 +22,7 @@ describe("resolveFrameCount", () => {
     ).toBe(60);
   });
 
-  it("throws when neither total_frame_count nor duration is present", () => {
-    expect(() => resolveFrameCount(sampleWith({}), 30)).toThrow();
+  it("returns null when neither total_frame_count nor duration is present", () => {
+    expect(resolveFrameCount(sampleWith({}), 30)).toBeNull();
   });
 });

--- a/app/packages/video-annotation/src/utils/frameCount.ts
+++ b/app/packages/video-annotation/src/utils/frameCount.ts
@@ -1,0 +1,34 @@
+import type { ModalSample } from "@fiftyone/state";
+
+/**
+ * Total frame count from `sample.metadata`, or `null` when it can't be
+ * resolved. The `Sample` TS type only declares `width / height / mime_type`,
+ * but VideoMetadata persists `total_frame_count` and `duration` at runtime —
+ * we loose-cast through.
+ *
+ * Returns `null` (never throws) when neither is usable: the caller shows a
+ * "compute metadata" prompt instead of crashing the modal.
+ */
+export function resolveFrameCount(
+  sample: ModalSample,
+  frameRate: number
+): number | null {
+  const metadata = (sample.sample as { metadata?: Record<string, unknown> })
+    ?.metadata;
+
+  const total = metadata?.total_frame_count;
+  if (typeof total === "number" && Number.isFinite(total) && total > 0) {
+    return Math.round(total);
+  }
+
+  const duration = metadata?.duration;
+  if (
+    typeof duration === "number" &&
+    Number.isFinite(duration) &&
+    duration > 0
+  ) {
+    return Math.max(1, Math.round(duration * frameRate));
+  }
+
+  return null;
+}

--- a/app/packages/video-annotation/src/utils/frameCount.ts
+++ b/app/packages/video-annotation/src/utils/frameCount.ts
@@ -11,7 +11,7 @@ import type { ModalSample } from "@fiftyone/state";
  */
 export function resolveFrameCount(
   sample: ModalSample,
-  frameRate: number
+  frameRate: number,
 ): number | null {
   const metadata = (sample.sample as { metadata?: Record<string, unknown> })
     ?.metadata;

--- a/fiftyone/core/annotation/constants.py
+++ b/fiftyone/core/annotation/constants.py
@@ -217,6 +217,16 @@ SUPPORTED_LABEL_TYPES_BY_MEDIA_TYPE = {
         fol.TemporalDetections,
     },
 }
+# Spatial label types that are only meaningful per-frame on video (a video
+# sample is the whole clip, so spatial detections/polylines belong to its
+# frames). Excluded from sample-level annotation fields for video; still
+# allowed at the frame level.
+SPATIAL_LABEL_TYPES = (
+    fol.Detection,
+    fol.Detections,
+    fol.Polyline,
+    fol.Polylines,
+)
 SUPPORTED_LISTS_OF_PRIMITIVES = (
     fof.FloatField,
     fof.IntField,

--- a/fiftyone/core/annotation/constants.py
+++ b/fiftyone/core/annotation/constants.py
@@ -217,6 +217,18 @@ SUPPORTED_LABEL_TYPES_BY_MEDIA_TYPE = {
         fol.TemporalDetections,
     },
 }
+# Label types that support tracks (an ``instance`` linking the same object
+# across frames). Used to backfill legacy ``index``-based tracks into
+# ``instance``. Mirrors the types accepted by
+# :func:`fiftyone.utils.labels.index_to_instance`.
+TRACK_LABEL_TYPES = (
+    fol.Detection,
+    fol.Detections,
+    fol.Polyline,
+    fol.Polylines,
+    fol.Keypoint,
+    fol.Keypoints,
+)
 # Spatial label types that are only meaningful per-frame on video (a video
 # sample is the whole clip, so spatial detections/polylines belong to its
 # frames). Excluded from sample-level annotation fields for video; still

--- a/fiftyone/core/annotation/utils.py
+++ b/fiftyone/core/annotation/utils.py
@@ -118,7 +118,7 @@ def list_valid_annotation_fields(
     return sorted(result)
 
 
-def backfill_instances_from_index(sample_collection, fields):
+def backfill_instances_from_index(sample_collection, fields=None):
     """Populates the ``instance`` attribute from a legacy ``index`` attribute
     for any of the given track label fields that have ``index`` values but no
     ``instance`` values yet.
@@ -131,12 +131,15 @@ def backfill_instances_from_index(sample_collection, fields):
     Args:
         sample_collection: a
             :class:`fiftyone.core.collections.SampleCollection`
-        fields: a field name or iterable of field names to process
+        fields (None): a field name or iterable of field names to process. By
+            default, all valid annotation fields are processed, matching the
+            all-fields scan in :func:`generate_label_schemas`
     """
-    if not fields:
-        return
-
-    if isinstance(fields, str):
+    if fields is None:
+        fields = list_valid_annotation_fields(
+            sample_collection, include_frames=True
+        )
+    elif isinstance(fields, str):
         fields = [fields]
 
     for field in fields:

--- a/fiftyone/core/annotation/utils.py
+++ b/fiftyone/core/annotation/utils.py
@@ -118,6 +118,61 @@ def list_valid_annotation_fields(
     return sorted(result)
 
 
+def backfill_instances_from_index(sample_collection, fields):
+    """Populates the ``instance`` attribute from a legacy ``index`` attribute
+    for any of the given track label fields that have ``index`` values but no
+    ``instance`` values yet.
+
+    Lets datasets whose tracks are defined by ``index`` (rather than
+    ``instance``) be recognized as tracks during a scan. Fields that already
+    have any ``instance`` values are left untouched, so existing tracks are
+    never clobbered and the operation is idempotent.
+
+    Args:
+        sample_collection: a
+            :class:`fiftyone.core.collections.SampleCollection`
+        fields: a field name or iterable of field names to process
+    """
+    if not fields:
+        return
+
+    if isinstance(fields, str):
+        fields = [fields]
+
+    for field in fields:
+        _maybe_backfill_field_instances(sample_collection, field)
+
+
+def _maybe_backfill_field_instances(sample_collection, field):
+    # imported lazily — `fiftyone.utils.labels` pulls in heavy deps we don't
+    # want at annotation-module import time
+    import fiftyone.utils.labels as foul
+
+    label_field = sample_collection.get_field(field)
+    if not isinstance(label_field, fof.EmbeddedDocumentField):
+        return
+
+    if not issubclass(label_field.document_type, foac.TRACK_LABEL_TYPES):
+        return
+
+    root, _ = sample_collection._get_label_field_root(field)
+    instance_path = f"{root}.instance"
+    index_path = f"{root}.index"
+
+    # `instance` is a dynamic attribute (absent from the declared schema), so
+    # count the data directly rather than checking the schema
+
+    # don't clobber a field that already has tracks
+    if sample_collection.count(instance_path) > 0:
+        return
+
+    # nothing to backfill from
+    if sample_collection.count(index_path) == 0:
+        return
+
+    foul.index_to_instance(sample_collection, field)
+
+
 def _valid_annotation_fields(
     collection, schema, require_app_support, exclude_spatial_labels=False
 ):

--- a/fiftyone/core/annotation/utils.py
+++ b/fiftyone/core/annotation/utils.py
@@ -92,10 +92,16 @@ def list_valid_annotation_fields(
     Returns:
         a sorted list of valid annotation field names
     """
+    # On video, spatial labels belong to frames — a sample-level
+    # detections/polylines field isn't annotatable, so drop it from the
+    # sample-level scan (frame-level spatial labels are added below).
+    exclude_sample_spatial = sample_collection.media_type == fom.VIDEO
+
     result = _valid_annotation_fields(
         sample_collection,
         sample_collection.get_field_schema(),
         require_app_support,
+        exclude_spatial_labels=exclude_sample_spatial,
     )
 
     if include_frames and sample_collection._has_frame_fields():
@@ -112,7 +118,9 @@ def list_valid_annotation_fields(
     return sorted(result)
 
 
-def _valid_annotation_fields(collection, schema, require_app_support):
+def _valid_annotation_fields(
+    collection, schema, require_app_support, exclude_spatial_labels=False
+):
     result = set()
     for field_name, field in schema.items():
 
@@ -125,6 +133,11 @@ def _valid_annotation_fields(collection, schema, require_app_support):
 
         if field.document_type in foac.SUPPORTED_DOC_TYPES:
             result.add(field_name)
+            continue
+
+        if exclude_spatial_labels and issubclass(
+            field.document_type, foac.SPATIAL_LABEL_TYPES
+        ):
             continue
 
         if _is_supported_label(collection, field, require_app_support):

--- a/plugins/operators/annotation.py
+++ b/plugins/operators/annotation.py
@@ -95,13 +95,22 @@ class GenerateLabelSchemas(foo.Operator):
     def execute(self, ctx):
         field = ctx.params.get("field", None)
         limit = ctx.params.get("limit", None)
+        scan_samples = ctx.params.get("scan_samples", True)
+
+        # Backfill legacy `index`-based tracks into `instance` so they're
+        # recognized as tracks. Runs on the full dataset (not the scan's
+        # limited view) and only fills fields that have indexes but no
+        # instances yet, so existing tracks are never clobbered.
+        if scan_samples:
+            foau.backfill_instances_from_index(ctx.dataset, field)
+
         if limit:
             view = ctx.dataset.limit(limit)
         else:
             view = ctx.dataset
         return {
             "label_schema": view.generate_label_schemas(
-                fields=field, scan_samples=ctx.params.get("scan_samples", True)
+                fields=field, scan_samples=scan_samples
             )
         }
 

--- a/tests/unittests/annotation/dataset_label_schemas_tests.py
+++ b/tests/unittests/annotation/dataset_label_schemas_tests.py
@@ -630,6 +630,26 @@ class FrameLabelSchemaTests(unittest.TestCase):
         self.assertIn("frames.detections", with_frames)
 
     @drop_datasets
+    def test_sample_level_spatial_labels_excluded_for_video(self):
+        import fiftyone.core.annotation.utils as foau
+
+        dataset = _make_video_dataset()
+        dataset.add_sample_field(
+            "ground_truth", fo.EmbeddedDocumentField, fo.Detections
+        )
+        dataset.add_sample_field("weather", fo.StringField)
+
+        valid = foau.list_valid_annotation_fields(
+            dataset, flatten=True, include_frames=True
+        )
+
+        # sample-level spatial labels belong on frames, not the clip
+        self.assertNotIn("ground_truth", valid)
+        # frame-level spatial labels and sample-level primitives are still valid
+        self.assertIn("frames.detections", valid)
+        self.assertIn("weather", valid)
+
+    @drop_datasets
     def test_frame_attribute_dynamic_flag(self):
         dataset = _make_video_dataset()
         dataset.add_frame_field(

--- a/tests/unittests/annotation/dataset_label_schemas_tests.py
+++ b/tests/unittests/annotation/dataset_label_schemas_tests.py
@@ -695,6 +695,31 @@ class FrameLabelSchemaTests(unittest.TestCase):
         self.assertNotEqual(car_f2.instance.id, ped_f2.instance.id)
 
     @drop_datasets
+    def test_backfill_all_fields_when_field_omitted(self):
+        import fiftyone.core.annotation.utils as foau
+
+        dataset = _make_video_dataset()
+        sample = fo.Sample(filepath="/tmp/video.mp4")
+        sample.frames[1] = fo.Frame(
+            detections=fo.Detections(
+                detections=[
+                    fo.Detection(
+                        label="car", index=1, bounding_box=[0, 0, 0.1, 0.1]
+                    )
+                ]
+            )
+        )
+        dataset.add_sample(sample)
+
+        # the all-fields path (no explicit field) mirrors the all-fields scan
+        foau.backfill_instances_from_index(dataset)
+
+        sample.reload()
+        self.assertIsNotNone(
+            sample.frames[1].detections.detections[0].instance
+        )
+
+    @drop_datasets
     def test_backfill_skips_fields_with_existing_instances(self):
         import fiftyone.core.annotation.utils as foau
 

--- a/tests/unittests/annotation/dataset_label_schemas_tests.py
+++ b/tests/unittests/annotation/dataset_label_schemas_tests.py
@@ -650,6 +650,80 @@ class FrameLabelSchemaTests(unittest.TestCase):
         self.assertIn("weather", valid)
 
     @drop_datasets
+    def test_backfill_instances_from_index(self):
+        import fiftyone.core.annotation.utils as foau
+
+        dataset = _make_video_dataset()
+        sample = fo.Sample(filepath="/tmp/video.mp4")
+        sample.frames[1] = fo.Frame(
+            detections=fo.Detections(
+                detections=[
+                    fo.Detection(
+                        label="car", index=1, bounding_box=[0, 0, 0.1, 0.1]
+                    )
+                ]
+            )
+        )
+        sample.frames[2] = fo.Frame(
+            detections=fo.Detections(
+                detections=[
+                    fo.Detection(
+                        label="car", index=1, bounding_box=[0, 0, 0.1, 0.1]
+                    ),
+                    fo.Detection(
+                        label="ped", index=2, bounding_box=[0.5, 0.5, 0.1, 0.1]
+                    ),
+                ]
+            )
+        )
+        dataset.add_sample(sample)
+
+        foau.backfill_instances_from_index(dataset, "frames.detections")
+
+        sample.reload()
+        car_f1 = sample.frames[1].detections.detections[0]
+        f2 = sample.frames[2].detections.detections
+        car_f2 = next(d for d in f2 if d.index == 1)
+        ped_f2 = next(d for d in f2 if d.index == 2)
+
+        # every indexed label gets an instance
+        self.assertIsNotNone(car_f1.instance)
+        self.assertIsNotNone(ped_f2.instance)
+        # the same index within a sample is one track
+        self.assertEqual(car_f1.instance.id, car_f2.instance.id)
+        # distinct indices are distinct tracks
+        self.assertNotEqual(car_f2.instance.id, ped_f2.instance.id)
+
+    @drop_datasets
+    def test_backfill_skips_fields_with_existing_instances(self):
+        import fiftyone.core.annotation.utils as foau
+
+        dataset = _make_video_dataset()
+        existing = fol.Instance()
+        sample = fo.Sample(filepath="/tmp/video.mp4")
+        sample.frames[1] = fo.Frame(
+            detections=fo.Detections(
+                detections=[
+                    fo.Detection(
+                        label="car",
+                        index=1,
+                        instance=existing,
+                        bounding_box=[0, 0, 0.1, 0.1],
+                    )
+                ]
+            )
+        )
+        dataset.add_sample(sample)
+        original_id = sample.frames[1].detections.detections[0].instance.id
+
+        foau.backfill_instances_from_index(dataset, "frames.detections")
+
+        sample.reload()
+        self.assertEqual(
+            sample.frames[1].detections.detections[0].instance.id, original_id
+        )
+
+    @drop_datasets
     def test_frame_attribute_dynamic_flag(self):
         dataset = _make_video_dataset()
         dataset.add_frame_field(


### PR DESCRIPTION
- FOEPD-4103: video modal crashed when `VideoMetadata` wasn't computed; now shows a prompt instead
- FOEPD-4104: video annotate surface rendered blank when frames weren't sampled; now shows a prompt
- ImaVid stream re-requested frames that failed to load, looping `/frames` indefinitely; failed frames are now terminal (black frame, no refetch)
- FOEPD-4105: sample-level spatial label fields were offered for video annotation; restricted to frame-level detections/polylines
- FOEPD-4106: index-based tracks weren't recognized; `scan` now backfills `instance` from a legacy `index` attribute


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Video annotation now presents clear prerequisite states (loading, actionable notices, and checking) when frame metadata or sampled frames aren’t ready.
  * Video label setup improves support for track-based labels, including automatic migration from legacy indexing to instance-based tracking.
  * Video-specific label options are now more focused and omit unsupported types.
* **Bug Fixes**
  * Prevents stale frames from remaining visible when no frame is available.
  * Stops endless re-tries for frames that can’t be rendered, treating terminal failures as complete.
  * Excludes unsupported spatial label fields from sample-level video annotation options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->