### PR TITLE
[HA] Fix ctrl+z behavior on windows

### DIFF
--- a/app/packages/looker-3d/src/hooks/use-camera-views.test.ts
+++ b/app/packages/looker-3d/src/hooks/use-camera-views.test.ts
@@ -1,0 +1,111 @@
+import { renderHook } from "@testing-library/react-hooks";
+import type { CameraControls } from "@react-three/drei";
+import type { RefObject } from "react";
+import type { PerspectiveCamera } from "three";
+import { Vector3 } from "three";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SET_ZOOM_TO_SELECTED_EVENT } from "../constants";
+import { useCameraViews } from "./use-camera-views";
+
+// The hook pulls in a wide surface of app state; stub it all out so the test
+// exercises only the keydown guard logic.
+vi.mock(
+  "@fiftyone/core/src/components/Modal/Sidebar/Annotate/useCanAnnotate",
+  () => ({
+    default: () => false,
+  }),
+);
+
+vi.mock("@fiftyone/state", () => ({
+  modalMode: { key: "modalMode" },
+}));
+
+vi.mock("jotai", () => ({
+  useAtomValue: () => "explore",
+}));
+
+vi.mock("recoil", () => ({
+  useRecoilValue: () => null,
+  useSetRecoilState: () => () => {},
+}));
+
+vi.mock("../annotation/store", () => ({
+  useWorkingLabel: () => null,
+}));
+
+vi.mock("../fo3d/context", () => ({
+  useFo3dContext: () => ({
+    sceneBoundingBox: null,
+    upVector: new Vector3(0, 1, 0),
+  }),
+}));
+
+vi.mock("../state", () => ({
+  annotationPlaneAtom: { key: "annotationPlaneAtom" },
+  cameraViewStatusAtom: { key: "cameraViewStatusAtom" },
+  isFo3dBackgroundOnAtom: { key: "isFo3dBackgroundOnAtom" },
+  selectedLabelForAnnotationAtom: { key: "selectedLabelForAnnotationAtom" },
+}));
+
+const makeRefs = () => ({
+  cameraRef: {
+    current: { position: new Vector3(1, 1, 1) },
+  } as unknown as RefObject<PerspectiveCamera>,
+  cameraControlsRef: {
+    current: { getTarget: vi.fn(), setLookAt: vi.fn() },
+  } as unknown as RefObject<CameraControls>,
+});
+
+const dispatchKeyZ = (
+  modifiers: { metaKey?: boolean; ctrlKey?: boolean } = {},
+) => {
+  document.dispatchEvent(
+    new KeyboardEvent("keydown", {
+      code: "KeyZ",
+      bubbles: true,
+      cancelable: true,
+      ...modifiers,
+    }),
+  );
+};
+
+describe("useCameraViews keydown guard", () => {
+  let zoomListener: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    zoomListener = vi.fn();
+    window.addEventListener(SET_ZOOM_TO_SELECTED_EVENT, zoomListener);
+  });
+
+  afterEach(() => {
+    window.removeEventListener(SET_ZOOM_TO_SELECTED_EVENT, zoomListener);
+    vi.clearAllMocks();
+  });
+
+  it("fires zoom-to-selected for bare Z (no modifiers)", () => {
+    const { cameraRef, cameraControlsRef } = makeRefs();
+    renderHook(() => useCameraViews({ cameraRef, cameraControlsRef }));
+
+    dispatchKeyZ();
+
+    expect(zoomListener).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT fire zoom for Ctrl+Z (so it can fall through to undo on Windows)", () => {
+    const { cameraRef, cameraControlsRef } = makeRefs();
+    renderHook(() => useCameraViews({ cameraRef, cameraControlsRef }));
+
+    dispatchKeyZ({ ctrlKey: true });
+
+    expect(zoomListener).not.toHaveBeenCalled();
+  });
+
+  it("does NOT fire zoom for Cmd/meta+Z (undo on Mac)", () => {
+    const { cameraRef, cameraControlsRef } = makeRefs();
+    renderHook(() => useCameraViews({ cameraRef, cameraControlsRef }));
+
+    dispatchKeyZ({ metaKey: true });
+
+    expect(zoomListener).not.toHaveBeenCalled();
+  });
+});

--- a/app/packages/looker-3d/src/hooks/use-camera-views.ts
+++ b/app/packages/looker-3d/src/hooks/use-camera-views.ts
@@ -255,7 +255,8 @@ export const useCameraViews = ({
         return;
       }
 
-      if (!event.metaKey && event.code === "KeyZ") {
+      // exclude ctrlKey so Windows Ctrl+Z falls through to undo
+      if (!event.metaKey && !event.ctrlKey && event.code === "KeyZ") {
         setCameraViewStatus({
           viewName: "Crop",
           timestamp: Date.now(),


### PR DESCRIPTION
## Summary
On Windows, `Ctrl+Z` during 3D annotation triggered the looker-3d "zoom to selected" instead of undo. Undo is bound to both `ctrl+z` and `meta+z`, but the bare-`Z` zoom shortcut in `use-camera-views.ts` guarded only `!event.metaKey`, so Windows `Ctrl+Z` matched it, fired zoom + `preventDefault()`, and undo never ran. Mac was unaffected (metaKey).

## Fix
Add `!event.ctrlKey` to the bare-`Z` zoom guard so `Ctrl+Z` falls through to the undo binding.

## Tests
New vitest unit test (`use-camera-views.test.ts`): bare `Z` fires zoom; `Ctrl+Z` and `Cmd/meta+Z` do not. Whole looker-3d package green (412 tests).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened the “Crop/Zoom to selection” keyboard shortcut so it triggers only on an unmodified **Z** keypress, and no longer activates with **Ctrl+Z** or **Cmd+Z**.
* **Tests**
  * Added automated coverage to confirm the action fires exactly once for plain **Z**, and remains blocked when modifier keys are pressed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->