### PR TITLE
[HA] Clear 3D label selection when entering annotate mode

### DIFF
--- a/app/packages/looker-3d/src/Looker3d.tsx
+++ b/app/packages/looker-3d/src/Looker3d.tsx
@@ -58,6 +58,9 @@ export const Looker3d = () => {
 
   const thisSampleId = useRecoilValue(fos.modalSampleId);
 
+  // test affordance: 3D selection has no DOM signal, so expose its count
+  const selectedLabelCount = useRecoilValue(fos.selectedLabels).length;
+
   useEffect(() => {
     return () => {
       setFo3dHasBackground(false);
@@ -195,7 +198,12 @@ export const Looker3d = () => {
   return (
     <Fo3dErrorBoundary key={looker3dSceneKey} boundaryName="fo3d">
       <Leva />
-      <Container onMouseOver={update} onMouseMove={update} data-cy="looker3d">
+      <Container
+        onMouseOver={update}
+        onMouseMove={update}
+        data-cy="looker3d"
+        data-cy-selected-label-count={selectedLabelCount}
+      >
         <MediaTypeFo3dComponent key={looker3dSceneKey} />
         <ActionBar
           onMouseEnter={() => {

--- a/app/packages/state/src/accessors/modal/index.ts
+++ b/app/packages/state/src/accessors/modal/index.ts
@@ -5,7 +5,12 @@ export * from "./use-active-modal-sample-value";
 import type { Schema } from "@fiftyone/utilities";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { useCallback, useMemo, useRef } from "react";
-import { useRecoilState, useRecoilValue, useRecoilValueLoadable } from "recoil";
+import {
+  useRecoilState,
+  useRecoilValue,
+  useRecoilValueLoadable,
+  useSetRecoilState,
+} from "recoil";
 import { ModalMode, modalMode } from "../../jotai";
 import { preferredGroupAnnotationSliceAtom } from "../../jotai/group-annotation";
 import type { ModalViewportState } from "../../jotai/modal";
@@ -20,6 +25,7 @@ import {
   fieldSchema,
   lookerOptions,
   modalSample,
+  selectedLabelMap,
   selectedMediaField,
 } from "../../recoil";
 import { GroupSampleNotFound } from "../../recoil/modal";
@@ -51,11 +57,14 @@ export interface ModalModeController {
  */
 export const useModalModeController = (): ModalModeController => {
   const setMode = useSetAtom(modalMode);
+  const clearSelectedLabels = useSetRecoilState(selectedLabelMap);
 
-  const activateAnnotateMode = useCallback(
-    () => setMode(ModalMode.ANNOTATE),
-    [setMode],
-  );
+  // Explore's 3D selection has no deselect affordance in Annotate, so clear it
+  // on entry; 2D entry uses the engine anchor, not this map.
+  const activateAnnotateMode = useCallback(() => {
+    clearSelectedLabels({});
+    setMode(ModalMode.ANNOTATE);
+  }, [clearSelectedLabels, setMode]);
   const activateExploreMode = useCallback(
     () => setMode(ModalMode.EXPLORE),
     [setMode],

--- a/e2e-pw/src/oss/specs/MISSING-annotate-3d-selection-clear.spec.ts
+++ b/e2e-pw/src/oss/specs/MISSING-annotate-3d-selection-clear.spec.ts
@@ -1,0 +1,116 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ *
+ * Entering Annotate clears the Explore 3D selection (Recoil `selectedLabelMap`),
+ * so a cuboid selected in Explore doesn't stay highlighted in Annotate. 3D
+ * selection has no DOM signal, so the looker3d container exposes the Explore
+ * selection count via `data-cy-selected-label-count`: select the seeded cuboid
+ * in Explore (count -> 1), switch to Annotate, assert it drops to 0.
+ */
+import { expect, test as base } from "src/oss/fixtures";
+import { ModalPom } from "src/oss/poms/modal";
+import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
+
+const datasetName = getUniqueDatasetNameWithPrefix(
+  "annotate-3d-selection-clear",
+);
+
+/** Fixed ObjectId addressing the first sample (so we can deep-link the modal). */
+const id = "000000000000000000000000";
+const plyPath = `/tmp/${datasetName}.ply`;
+const scenePath = `/tmp/${datasetName}.fo3d`;
+
+const test = base.extend<{ modal: ModalPom }>({
+  modal: async ({ page, eventUtils }, use) => {
+    await use(new ModalPom(page, eventUtils));
+  },
+});
+
+test.beforeAll(async ({ foWebServer, mediaFactory }) => {
+  await foWebServer.startWebServer();
+  mediaFactory.createPly({ outputPath: plyPath, shape: "cube" });
+  mediaFactory.createFo3d({ outputPath: scenePath, plyPath });
+});
+
+test.afterAll(async ({ foWebServer }) => {
+  await foWebServer.stopWebServer();
+});
+
+const looker3d = (modal: ModalPom) => modal.locator.getByTestId("looker3d");
+
+/** Number of Explore-selected labels, read off the looker3d test affordance. */
+const selectedCount = async (modal: ModalPom) => {
+  const raw = await looker3d(modal).getAttribute(
+    "data-cy-selected-label-count",
+  );
+  return Number(raw ?? "0");
+};
+
+test.describe
+  .serial("3d explore selection does not bleed into annotate", () => {
+  test.beforeEach(async ({ annotate3dSDK, fiftyoneLoader, modal, page }) => {
+    await annotate3dSDK.seed({
+      datasetName,
+      scenePaths: [scenePath],
+      classes: ["car", "truck", "pedestrian"],
+      cuboidSampleIndices: [0],
+    });
+
+    await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
+      searchParams: new URLSearchParams({ id }),
+    });
+    await modal.assert.isOpen();
+
+    // the modal opens in EXPLORE; wait for the 3D scene to be interactable
+    await modal.annotate3d.waitForSurface();
+  });
+
+  test("selecting a cuboid in explore then switching to annotate clears the selection", async ({
+    modal,
+    page,
+  }) => {
+    // look straight down the Z axis so the seeded cuboid (centered at the
+    // origin) sits under the canvas center, then click it to select in Explore
+    await modal.looker3dControls.setTopView();
+    await expect.poll(async () => selectedCount(modal)).toBe(0);
+
+    const box = await modal.annotate3d.canvas.boundingBox();
+    if (!box) {
+      throw new Error("3D canvas has no bounding box");
+    }
+    await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+
+    // the Explore selection landed: exactly one selected label
+    await expect.poll(async () => selectedCount(modal)).toBe(1);
+
+    // switching to Annotate must clear the Explore selection (no bleed)
+    await modal.sidebar.switchMode("annotate");
+    await modal.annotate3d.waitForSurface();
+    await expect.poll(async () => selectedCount(modal)).toBe(0);
+  });
+
+  test("annotate selection replaces rather than stacks", async ({
+    modal,
+    page,
+  }) => {
+    // seed an Explore selection first, then enter Annotate (which clears it)
+    await modal.looker3dControls.setTopView();
+    const box = await modal.annotate3d.canvas.boundingBox();
+    if (!box) {
+      throw new Error("3D canvas has no bounding box");
+    }
+    await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+    await expect.poll(async () => selectedCount(modal)).toBe(1);
+
+    await modal.sidebar.switchMode("annotate");
+    await modal.annotate3d.waitForSurface();
+    await expect.poll(async () => selectedCount(modal)).toBe(0);
+
+    // selecting an annotate label arms the engine anchor without re-populating
+    // the Explore selection map — so it stays at 0 (no stacking on top of a
+    // stale Explore highlight)
+    await modal.annotate3d.selectLabel("car");
+    await modal.sidebar.edit.assert.verifyFieldValue("label", "car");
+    await expect.poll(async () => selectedCount(modal)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
A 3D label selected in Explore stayed highlighted after switching to Annotate, with no way to clear it, and selecting another label stacked a second selection. Explore 3D selection lives in the Recoil `selectedLabelMap`, which nothing cleared on the Explore→Annotate transition, so the engine render model inherited `selected: true`.

## Fix
Clear `selectedLabelMap` in `activateAnnotateMode` — the single centralized Explore→Annotate transition point (covers 2D + 3D).

A stable `data-cy-selected-label-count` affordance is added to the looker3d container (3D selection had no DOM signal) so the behavior is e2e-testable.

## Tests
New e2e spec `MISSING-annotate-3d-selection-clear.spec.ts`: select a cuboid in Explore (count 1), switch to Annotate, assert count 0; plus a no-stacking assertion. Verified as a real guard via negative control (disabling the clear fails the post-switch assertion). Baselines green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Switching from Explore to Annotate now clears any existing 3D selection, preventing stale highlights from carrying over.
  * 3D selection behavior is more consistent when moving between selection modes, so selecting in Annotate no longer stacks on prior Explore selections.

* **Tests**
  * Added end-to-end coverage for 3D selection clearing and mode-switch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->