### PR TITLE
ci(enterprise-sync): skip back-merge PRs so the sync does not mirror them

### DIFF
--- a/.github/workflows/enterprise-sync.yml
+++ b/.github/workflows/enterprise-sync.yml
@@ -47,6 +47,27 @@ jobs:
             // Bases mirrored into Enterprise.
             const isSyncBase = (b) => b === 'develop' || b.startsWith('release/');
 
+            // Back-merge PRs (`merge/<ref> → develop`, opened by the
+            // develop-back-merge workflow as voxel51-bot) are *vertical*
+            // reconciliation, handled independently by each repo's own
+            // back-merge. Mirroring one would be a diagonal whole-branch merge
+            // that re-surfaces the entire OSS↔Enterprise divergence and
+            // duplicates the Enterprise repo's own back-merge. Skip the sync;
+            // mark the gate green so the OSS back-merge isn't blocked.
+            if (pr.head.ref.startsWith('merge/') && pr.user.login === 'voxel51-bot') {
+              if (action !== 'closed') {
+                await github.rest.repos.createCommitStatus({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  sha,
+                  state: 'success',
+                  context: 'enterprise / ci',
+                  description: 'No Enterprise sync — back-merge handled natively in Enterprise',
+                });
+              }
+              return;
+            }
+
             // Retarget away from a synced base: close the orphaned mirror.
             if (action === 'edited' && context.payload.changes.base) {
               const from = context.payload.changes.base.ref.from;


### PR DESCRIPTION
Targets `release/v1.18.0` to get the fix into the active release line now.

## Problem

The OSS→Enterprise sync forward-ports individual PRs at the **same level** (develop→develop, release→release) — small diffs, recent merge-base. A `develop-back-merge` PR (`merge/<ref> → develop`, opened by `voxel51-bot`) is the opposite shape: whole-branch content reconciling release into develop, handled independently by each repo's own back-merge.

When the sync picked one up it attempted a **diagonal, whole-branch, cross-repo merge** with an ancient merge-base, surfacing the *entire* OSS↔Enterprise divergence as conflicts on an `oss-sync/merge/*` branch — redundant with the Enterprise repo's own back-merge, which already does that release→develop hop correctly, and leaving the OSS back-merge PR's `enterprise / ci` check red.

## Fix

Skip the sync for back-merge PRs (head `merge/*` **and** author `voxel51-bot`) and post `enterprise / ci = success`, mirroring the existing retarget-away short-circuit. Because we `return` before the `repository_dispatch`, **no `oss-sync/merge/*` mirror is created**.

Mental model — two automations on two axes:
- **Horizontal = sync**, per-PR, same level, OSS→Enterprise.
- **Vertical = back-merge**, intra-repo, release→develop, run by each repo's own workflow.

Content should move along grid edges (one horizontal + one vertical hop), never diagonally.

## Scope / safety

Purely additive: only changes when the sync does **not** fire; normal feature/fix PRs are untouched. Validated the workflow YAML and the embedded github-script body parse. Single-file change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of certain bot-created pull request branches so they no longer trigger unnecessary Enterprise sync actions.
  * Updated status reporting to mark Enterprise CI as successful when sync is already managed automatically.
  * Prevented duplicate or redundant mirroring steps for these pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3036
<!-- enterprise-sync-pr:end -->