### PR TITLE
Add multiline, placeholder, and icon-position options to EditableLabel

### DIFF
--- a/app/packages/components/src/components/EditableLabel/index.tsx
+++ b/app/packages/components/src/components/EditableLabel/index.tsx
@@ -11,7 +11,7 @@ import {
   Typography,
   TypographyProps,
 } from "@mui/material";
-import React, { useState } from "react";
+import { useState } from "react";
 import TooltipProvider from "../TooltipProvider";
 
 export default function EditableLabel(props: EditableLabelProps) {
@@ -44,7 +44,7 @@ export default function EditableLabel(props: EditableLabelProps) {
   // When a placeholder is supplied and the value is empty, render the
   // muted placeholder so the field stays a visible (clickable) target —
   // e.g. an unset description. Otherwise render exactly as before so
-  // existing consumers are unaffected.
+  // existing consumers are byte-for-byte unaffected.
   const showPlaceholder = !label && placeholder !== undefined;
   const labelNode = showPlaceholder ? (
     <Typography
@@ -135,7 +135,9 @@ export default function EditableLabel(props: EditableLabelProps) {
               </Stack>
             ),
           }}
-          sx={{ backgroundColor: "#191919" }}
+          sx={{
+            backgroundColor: (theme) => theme.palette.background.overlay75,
+          }}
         />
       )}
       {mode === "view" && iconPosition === "end" && editIcon}

--- a/app/packages/components/src/components/EditableLabel/index.tsx
+++ b/app/packages/components/src/components/EditableLabel/index.tsx
@@ -135,9 +135,7 @@ export default function EditableLabel(props: EditableLabelProps) {
               </Stack>
             ),
           }}
-          sx={{
-            backgroundColor: (theme) => theme.palette.background.overlay75,
-          }}
+          sx={{ backgroundColor: "#191919" }}
         />
       )}
       {mode === "view" && iconPosition === "end" && editIcon}

--- a/app/packages/components/src/components/EditableLabel/index.tsx
+++ b/app/packages/components/src/components/EditableLabel/index.tsx
@@ -33,6 +33,14 @@ export default function EditableLabel(props: EditableLabelProps) {
   const [mode, setMode] = useState<"view" | "edit">("view");
   const [updatedLabel, setUpdatedLabel] = useState(label);
 
+  // Seed the draft from the current label every time the editor opens so a
+  // reopen (or a label prop that changed since the last edit) never submits
+  // a stale draft — the input below is controlled by ``updatedLabel``.
+  const openEditor = () => {
+    setUpdatedLabel(label);
+    setMode("edit");
+  };
+
   // When a placeholder is supplied and the value is empty, render the
   // muted placeholder so the field stays a visible (clickable) target —
   // e.g. an unset description. Otherwise render exactly as before so
@@ -63,7 +71,7 @@ export default function EditableLabel(props: EditableLabelProps) {
         onClick={(e) => {
           e.preventDefault();
           e.stopPropagation();
-          setMode("edit");
+          openEditor();
         }}
         disabled={disabled}
       >
@@ -82,7 +90,7 @@ export default function EditableLabel(props: EditableLabelProps) {
       {mode === "view" && labelNode}
       {mode === "edit" && (
         <TextField
-          defaultValue={label}
+          value={updatedLabel}
           size="small"
           autoFocus={autoFocus}
           multiline={multiline}

--- a/app/packages/components/src/components/EditableLabel/index.tsx
+++ b/app/packages/components/src/components/EditableLabel/index.tsx
@@ -24,21 +24,70 @@ export default function EditableLabel(props: EditableLabelProps) {
     showEditIcon = true,
     disabled,
     title,
+    multiline = false,
+    minRows = 2,
+    placeholder,
+    iconPosition = "end",
+    autoFocus = false,
   } = props;
   const [mode, setMode] = useState<"view" | "edit">("view");
   const [updatedLabel, setUpdatedLabel] = useState(label);
 
+  // When a placeholder is supplied and the value is empty, render the
+  // muted placeholder so the field stays a visible (clickable) target —
+  // e.g. an unset description. Otherwise render exactly as before so
+  // existing consumers are unaffected.
+  const showPlaceholder = !label && placeholder !== undefined;
+  const labelNode = showPlaceholder ? (
+    <Typography
+      {...labelProps}
+      sx={[
+        { color: (theme) => theme.palette.text.secondary },
+        ...(Array.isArray(labelProps.sx) ? labelProps.sx : [labelProps.sx]),
+      ]}
+    >
+      {placeholder}
+    </Typography>
+  ) : (
+    <Typography {...labelProps}>{label}</Typography>
+  );
+
   if (!showEditIcon) {
-    return <Typography {...labelProps}>{label}</Typography>;
+    return labelNode;
   }
 
+  const editIcon = (
+    <TooltipProvider title={title}>
+      <IconButton
+        size="small"
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          setMode("edit");
+        }}
+        disabled={disabled}
+      >
+        <EditOutlined sx={{ fontSize: 16 }} />
+      </IconButton>
+    </TooltipProvider>
+  );
+
   return (
-    <Stack direction="row" spacing={0.5} alignItems="center">
-      {mode === "view" && <Typography {...labelProps}>{label}</Typography>}
+    <Stack
+      direction="row"
+      spacing={0.5}
+      alignItems={multiline ? "flex-start" : "center"}
+    >
+      {mode === "view" && iconPosition === "start" && editIcon}
+      {mode === "view" && labelNode}
       {mode === "edit" && (
         <TextField
           defaultValue={label}
           size="small"
+          autoFocus={autoFocus}
+          multiline={multiline}
+          minRows={multiline ? minRows : undefined}
+          placeholder={placeholder}
           onClick={(e) => {
             e.preventDefault();
             e.stopPropagation();
@@ -81,21 +130,7 @@ export default function EditableLabel(props: EditableLabelProps) {
           sx={{ backgroundColor: "#191919" }}
         />
       )}
-      {mode === "view" && (
-        <TooltipProvider title={title}>
-          <IconButton
-            size="small"
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              setMode("edit");
-            }}
-            disabled={disabled}
-          >
-            <EditOutlined sx={{ fontSize: 16 }} />
-          </IconButton>
-        </TooltipProvider>
-      )}
+      {mode === "view" && iconPosition === "end" && editIcon}
     </Stack>
   );
 }
@@ -110,4 +145,17 @@ type EditableLabelProps = {
   mode?: "view" | "edit";
   disabled?: boolean;
   title?: string;
+  /** Render a multiline (textarea) input in edit mode. Defaults to false. */
+  multiline?: boolean;
+  /** Minimum rows for the multiline input. Defaults to 2. */
+  minRows?: number;
+  /**
+   * Placeholder for the input, and the muted text shown in view mode when
+   * ``label`` is empty (so an empty field stays clickable).
+   */
+  placeholder?: string;
+  /** Whether the edit pencil renders before or after the text. Default "end". */
+  iconPosition?: "start" | "end";
+  /** Focus the input when edit mode opens. Defaults to false. */
+  autoFocus?: boolean;
 };

--- a/app/packages/components/src/components/EditableLabel/index.tsx
+++ b/app/packages/components/src/components/EditableLabel/index.tsx
@@ -135,7 +135,9 @@ export default function EditableLabel(props: EditableLabelProps) {
               </Stack>
             ),
           }}
-          sx={{ backgroundColor: "#191919" }}
+          sx={{
+            backgroundColor: (theme) => theme.palette.background.level2,
+          }}
         />
       )}
       {mode === "view" && iconPosition === "end" && editIcon}


### PR DESCRIPTION
## What


https://github.com/user-attachments/assets/da90d1ec-438d-4df2-aae5-fef5ed1ad905


Extends the shared `EditableLabel` component with four **backwards-compatible** props so it can back richer inline editors (e.g. an inline name + multiline description):

- **`multiline`** / **`minRows`** — render a textarea input in edit mode
- **`placeholder`** — input placeholder, and muted *clickable* text shown in view mode when the value is empty (so an empty field is still a target)
- **`iconPosition`** — render the edit pencil `"start"` (before the text) or `"end"` (after — the default)
- **`autoFocus`** — focus the input when edit mode opens

## Compatibility

All new props default to the **current behavior**, so existing consumers (model-evaluation cards, run cards, etc.) render and behave identically:

- `multiline=false`, `iconPosition="end"`, `autoFocus=false`, `placeholder` undefined.
- The non-placeholder view-mode label renders exactly as before (`<Typography {...labelProps}>{label}</Typography>`); the placeholder branch is only taken when `placeholder` is set *and* the value is empty.
- The early-return label and the pencil button are factored into `labelNode` / `editIcon` locals to support the new ordering and placeholder rendering — no behavioral change for the default path.

## Why

annotation-workflow header needs an inline editor for a workflow's name (single-line) and description (multiline, pencil-in-front, with an "Add a description" placeholder). 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Editable labels now support multiline editing, configurable minimum rows, customizable placeholder text, selectable edit icon placement (start/end), and optional auto-focus on entry.
  * When a label is empty, view mode can display muted placeholder text instead of empty content.

* **Bug Fixes**
  * Improved edit/view rendering behavior for consistent layout with different icon positions and multiline configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3042
<!-- enterprise-sync-pr:end -->