### PR TITLE
ci: reduce Actions spend (docs concurrency, matrix trim, e2e retention)

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -4,8 +4,6 @@ on:
     branches:
       - docs-*
       - github-actions-*
-      - rel-*
-      - release-*
       - release/*
     tags:
       - dev-docs-publish
@@ -22,10 +20,7 @@ on:
   pull_request:
     branches:
       - develop
-      - feat/*
       - main
-      - rel-*
-      - release-*
       - release/*
     paths:
       - .github/workflows/build-docs.yml
@@ -36,6 +31,10 @@ on:
       - "**.py"
       - "**.md"
       - "**.rst"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -273,4 +273,5 @@ jobs:
         with:
           name: playwright-report-mongodb-${{ matrix.mongodb-version }}-shard-${{ matrix.shard }}
           path: e2e-pw/playwright-report/
-          retention-days: 1
+          # 3 days so reports from Friday/weekend runs survive into Monday.
+          retention-days: 3

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -273,4 +273,4 @@ jobs:
         with:
           name: playwright-report-mongodb-${{ matrix.mongodb-version }}-shard-${{ matrix.shard }}
           path: e2e-pw/playwright-report/
-          retention-days: 30
+          retention-days: 1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -90,6 +90,13 @@ jobs:
       needs.modified-files.outputs.app-changes == 'true' ||
       needs.modified-files.outputs.fiftyone-changes == 'true')
     uses: ./.github/workflows/test.yml
+    with:
+      # Full Python coverage on PRs into long-lived release/main branches;
+      # boundary versions only (drop the 3.11 middle) on develop/feature PRs.
+      python-versions: >-
+        ${{ (github.base_ref == 'main' ||
+        startsWith(github.base_ref, 'release/'))
+        && '["3.10", "3.11", "3.12"]' || '["3.10", "3.12"]' }}
 
   test-windows:
     needs: modified-files
@@ -97,6 +104,11 @@ jobs:
       github.event.action != 'closed' &&
       needs.modified-files.outputs.fiftyone-changes == 'true'
     uses: ./.github/workflows/windows-test.yml
+    with:
+      python-versions: >-
+        ${{ (github.base_ref == 'main' ||
+        startsWith(github.base_ref, 'release/'))
+        && '["3.10", "3.11", "3.12"]' || '["3.10", "3.12"]' }}
 
   all-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -95,8 +95,6 @@ jobs:
       needs.modified-files.outputs.fiftyone-changes == 'true')
     uses: ./.github/workflows/test.yml
     with:
-      # Boundary versions only (drop the 3.11 middle) on develop/feature PRs;
-      # full Python coverage on every other base (release/main, etc.).
       python-versions: >-
         ${{ (github.base_ref == 'develop' ||
         startsWith(github.base_ref, 'feat/'))

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   modified-files:
     runs-on: ubuntu-latest
@@ -91,12 +94,12 @@ jobs:
       needs.modified-files.outputs.fiftyone-changes == 'true')
     uses: ./.github/workflows/test.yml
     with:
-      # Full Python coverage on PRs into long-lived release/main branches;
-      # boundary versions only (drop the 3.11 middle) on develop/feature PRs.
+      # Boundary versions only (drop the 3.11 middle) on develop/feature PRs;
+      # full Python coverage on every other base (release/main, etc.).
       python-versions: >-
-        ${{ (github.base_ref == 'main' ||
-        startsWith(github.base_ref, 'release/'))
-        && '["3.10", "3.11", "3.12"]' || '["3.10", "3.12"]' }}
+        ${{ (github.base_ref == 'develop' ||
+        startsWith(github.base_ref, 'feat/'))
+        && '["3.10", "3.12"]' || '["3.10", "3.11", "3.12"]' }}
 
   test-windows:
     needs: modified-files
@@ -106,9 +109,9 @@ jobs:
     uses: ./.github/workflows/windows-test.yml
     with:
       python-versions: >-
-        ${{ (github.base_ref == 'main' ||
-        startsWith(github.base_ref, 'release/'))
-        && '["3.10", "3.11", "3.12"]' || '["3.10", "3.12"]' }}
+        ${{ (github.base_ref == 'develop' ||
+        startsWith(github.base_ref, 'feat/'))
+        && '["3.10", "3.12"]' || '["3.10", "3.11", "3.12"]' }}
 
   all-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,6 +10,7 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   modified-files:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,12 @@
 name: Test
 
-on: workflow_call
+on:
+  workflow_call:
+    inputs:
+      python-versions:
+        description: JSON array of Python versions for the Python test matrix
+        type: string
+        default: '["3.10", "3.11", "3.12"]'
 
 jobs:
   test-app:
@@ -52,10 +58,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-        python:
-          - "3.10"
-          - "3.11"
-          - "3.12"
+        python: ${{ fromJSON(inputs.python-versions) }}
     defaults:
       run:
         shell: bash
@@ -114,7 +117,7 @@ jobs:
             --ignore tests/intensive/ \
             --ignore tests/no_wrapper
       - name: Upload
-        if: ${{ !startsWith(matrix.os, 'windows') && matrix.python == '3.11' }}
+        if: ${{ !startsWith(matrix.os, 'windows') && matrix.python == '3.12' }}
         uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -1,6 +1,12 @@
 name: Windows Tests
 
-on: workflow_call
+on:
+  workflow_call:
+    inputs:
+      python-versions:
+        description: JSON array of Python versions for the Windows test matrix
+        type: string
+        default: '["3.10", "3.11", "3.12"]'
 
 jobs:
   test-python:
@@ -15,10 +21,7 @@ jobs:
       matrix:
         os:
           - windows-latest
-        python:
-          - "3.10"
-          - "3.11"
-          - "3.12"
+        python: ${{ fromJSON(inputs.python-versions) }}
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
## What

Follow-ups to #7881 (which gated build/test/e2e/windows on long-lived base branches) targeting the remaining Actions spend it didn't cover.

### 1. `build-docs` — cancel superseded runs + skip intra-stack PRs
The docs build runs **~55 min on a single runner** and fires on every PR touching any `.py`/`.md`/`.rst` file. It had **no concurrency group**, so each push to a branch spawned a fresh full build while the previous one kept running.
- Adds a `concurrency` group with `cancel-in-progress`.
- Drops `feat/*` from the `pull_request` base branches, so PRs stacked on a feature branch don't build docs — they build when retargeted to a long-lived base (same philosophy as #7881).

### 2. Trim the Python test matrix on develop/feature PRs
`test.yml` and `windows-test.yml` gain a `python-versions` input (default = full `3.10/3.11/3.12`). `pr.yml` passes:
- **full** set for PRs into `main` / `release/*` / `rel-*` / `release-*`,
- **boundary** set (`3.10` + `3.12`, dropping the `3.11` middle) for PRs into `develop` or a feature branch.

Windows legs carry a **2× minute multiplier**, so that's where the savings concentrate. Full coverage is restored before anything ships via a release/main PR. Codecov upload moves from `3.11` → `3.12` so coverage still uploads on the reduced matrix.

### 3. `e2e` report retention 30 → 1 day
Every e2e shard uploads a Playwright report on every run; 30-day retention is storage spend with little value for transient PR runs.

## Trade-off
Develop/feature PRs lose the `3.11` Python leg until promotion to a release/main PR. Stacked PRs lose docs-build validation while stacked (restored on retarget).

## Not included (follow-up levers)
- Tightening `build-docs` path filters to drop the blanket `**.py` / `fiftyone/**` triggers (would skip docs builds on pure-code PRs, but risks missing autodoc breakage — wanted a separate discussion).
- Reducing e2e shard count (4 → 3).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated CI workflow triggers for documentation and pull requests, including branch allowlisting changes.
  * CI now selects Python test versions based on the pull request’s base branch.
* **Chores**
  * Parameterized Python test matrices for standard and Windows CI.
  * Adjusted code coverage uploads to run only for Python 3.12 on non-Windows.
  * Set workflow permissions to read-only and added concurrency to auto-cancel superseded documentation runs.
* **Bug Fixes**
  * Reduced end-to-end test report artifact retention to 3 days.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3074
<!-- enterprise-sync-pr:end -->