### PR TITLE
ci: guard the package VERSION against out-of-band bumps

### DIFF
--- a/.github/workflows/version-guard.yml
+++ b/.github/workflows/version-guard.yml
@@ -1,0 +1,53 @@
+name: Version Guard
+
+# Fails a PR that changes the package VERSION outside the release flow. This is
+# the deterministic replacement for routing setup.py through a human reviewer:
+# the version number is owned by the release process, not ad-hoc PRs.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  version-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Guard VERSION
+        env:
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+          HEAD_REF: ${{ github.head_ref }}
+          BASE_REF: ${{ github.base_ref }}
+          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # The release flow legitimately bumps VERSION:
+          #   - release automation / back-merge PRs (voxel51-bot, merge/*)
+          #   - release stabilization (PRs targeting a release/v* branch)
+          #   - a deliberate manual bump tagged with the 'version-bump' label
+          if [ "$AUTHOR" = "voxel51-bot" ] \
+            || [[ "$HEAD_REF" == merge/* ]] \
+            || [[ "$BASE_REF" == release/v* ]] \
+            || echo "$LABELS" | grep -q '"version-bump"'; then
+            echo "Release-flow PR; VERSION changes are allowed."
+            exit 0
+          fi
+
+          changed=$(git diff "$BASE_SHA...$HEAD_SHA" -- setup.py package/db/setup.py \
+            | grep -E '^[+-]VERSION = ' || true)
+
+          if [ -n "$changed" ]; then
+            echo "::error::This PR changes the package VERSION outside the release flow:"
+            echo "$changed"
+            echo "The version number is owned by the release process. Bump it on a"
+            echo "release/v* branch, or add the 'version-bump' label if this is intentional."
+            exit 1
+          fi
+
+          echo "No out-of-band VERSION change. OK."


### PR DESCRIPTION
## What

Adds `.github/workflows/version-guard.yml` — a PR check that fails when the
`VERSION = ` line in `setup.py` or `package/db/setup.py` changes outside the
release flow.

## Why

We're moving the release/versioning concern off manual CODEOWNERS review (see
the Renovate PR #7819, which drops the Aloha Shirts versioning block). A human
reviewer reading a diff was never a reliable gate. The version number is owned
by the release process, so guard it deterministically instead.

This is the backstop that makes dropping the manual gate safe: the one thing
the human reviewer legitimately caught — an accidental/out-of-band version
bump on a normal PR — is now enforced by CI.

## Behavior

Fails a PR that touches `VERSION` in `setup.py` / `package/db/setup.py`,
**except** where bumping is legitimate:

- author `voxel51-bot` (release automation + back-merge PRs)
- head branch `merge/*` (back-merges carrying the release bump into develop)
- base branch `release/v*` (release stabilization)
- a deliberate manual bump tagged with the `version-bump` label

So only a normal feature/fix PR to `develop` that changes `VERSION` fails.

## Validation

- YAML parses
- detection grep matches a real bump (develop is at `1.19.0`) and ignores
  unrelated lines
- all four exemption branches resolve correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated checks to prevent accidental version changes in pull requests.
  * Version updates are now allowed only during approved release-related workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3050
<!-- enterprise-sync-pr:end -->