### PR TITLE
fix(voc): ignore non-image files when importing from a single directory

### DIFF
--- a/fiftyone/utils/data/importers.py
+++ b/fiftyone/utils/data/importers.py
@@ -826,9 +826,17 @@ class ImportPathsMixin(object):
         return labels_path
 
     @staticmethod
-    def _load_data_map(data_path, ignore_exts=False, recursive=False):
+    def _load_data_map(
+        data_path, ignore_exts=False, recursive=False, image_only=False
+    ):
         """Helper function that parses either a data directory or a data
         manifest file into a UUID -> filepath map.
+
+        When ``image_only`` is True, only image files are included. This is
+        useful when ``data_path`` may contain non-image files such as labels
+        that live alongside the images (e.g. VOC ``.xml`` files). Filtering is
+        applied before UUIDs are computed so that, when ``ignore_exts`` is also
+        True, a non-image file does not clobber an image with the same basename.
         """
         if ignore_exts:
             to_uuid = lambda p: fos.normpath(os.path.splitext(p)[0])
@@ -836,7 +844,13 @@ class ImportPathsMixin(object):
             to_uuid = lambda p: fos.normpath(p)
 
         if isinstance(data_path, dict):
-            return {to_uuid(k): fos.normpath(v) for k, v in data_path.items()}
+            items = data_path.items()
+            if image_only:
+                items = [
+                    (k, v) for k, v in items if etai.is_image_mime_type(v)
+                ]
+
+            return {to_uuid(k): fos.normpath(v) for k, v in items}
 
         if not data_path:
             return {}
@@ -849,17 +863,27 @@ class ImportPathsMixin(object):
 
             data_map = etas.read_json(data_path)
             data_root = os.path.dirname(data_path)
+            items = data_map.items()
+            if image_only:
+                items = [
+                    (k, v) for k, v in items if etai.is_image_mime_type(v)
+                ]
+
             return {
                 to_uuid(k): fos.normpath(os.path.join(data_root, v))
-                for k, v in data_map.items()
+                for k, v in items
             }
 
         if not os.path.isdir(data_path):
             raise ValueError("Data directory '%s' does not exist" % data_path)
 
+        filepaths = etau.list_files(data_path, recursive=recursive)
+        if image_only:
+            filepaths = [p for p in filepaths if etai.is_image_mime_type(p)]
+
         return {
             to_uuid(p): fos.normpath(os.path.join(data_path, p))
-            for p in etau.list_files(data_path, recursive=recursive)
+            for p in filepaths
         }
 
 

--- a/fiftyone/utils/voc.py
+++ b/fiftyone/utils/voc.py
@@ -182,8 +182,12 @@ class VOCDetectionDatasetImporter(
         return fol.Detections
 
     def setup(self):
+        # Only treat image files as media so that VOC labels (`.xml`) are not
+        # mistaken for images when ``data_path`` and ``labels_path`` are the
+        # same directory
+        # https://github.com/voxel51/fiftyone/issues/1781
         image_paths_map = self._load_data_map(
-            self.data_path, ignore_exts=True, recursive=True
+            self.data_path, ignore_exts=True, recursive=True, image_only=True
         )
 
         if self.labels_path is not None and os.path.isdir(self.labels_path):

--- a/tests/unittests/import_export_tests.py
+++ b/tests/unittests/import_export_tests.py
@@ -1746,6 +1746,50 @@ class ImageDetectionDatasetTests(ImageDatasetTests):
         self.assertEqual(len(relpath.split(os.path.sep)), 3)
 
     @drop_datasets
+    def test_voc_detection_dataset_single_dir(self):
+        # https://github.com/voxel51/fiftyone/issues/1781
+        #
+        # When images and VOC labels (`.xml`) live in the same directory, the
+        # importer must not mistake the label files for images
+        dataset = self._make_dataset()
+
+        # ``include_paths=False`` ensures the importer must locate images via
+        # the data directory (the label files do not embed the image path), so
+        # a label file masquerading as an image is not silently recovered
+        for include_paths in (True, False):
+            single_dir = self._new_dir()
+
+            dataset.export(
+                dataset_type=fo.types.VOCDetectionDataset,
+                data_path=single_dir,
+                labels_path=single_dir,
+                include_paths=include_paths,
+            )
+
+            dataset2 = fo.Dataset.from_dir(
+                dataset_type=fo.types.VOCDetectionDataset,
+                data_path=single_dir,
+                labels_path=single_dir,
+                label_field="predictions",
+                include_all_data=True,
+            )
+
+            # No imported sample's media should be a `.xml` labels file
+            for filepath in dataset2.values("filepath"):
+                self.assertFalse(
+                    filepath.endswith(".xml"),
+                    "Imported media should not be a VOC labels file: %s"
+                    % filepath,
+                )
+
+            # The images (not the label files) are imported as samples
+            self.assertEqual(len(dataset), len(dataset2))
+            self.assertEqual(
+                dataset.count("predictions.detections"),
+                dataset2.count("predictions.detections"),
+            )
+
+    @drop_datasets
     def test_kitti_detection_dataset(self):
         dataset = self._make_dataset()
 


### PR DESCRIPTION
## 🔗 Related Issues

Fixes #1781

## 📋 What changes are proposed in this pull request?

`VOCDetectionDatasetImporter` listed **every** file under `data_path` as media. When images and
their VOC `.xml` labels live in the same directory (e.g. `data_path == labels_path`), the label files
were folded into the image map. Because UUIDs are computed with extensions stripped
(`ignore_exts=True`), an entry like `foo.xml` could clobber `foo.jpg` on the shared UUID `foo`, so the
importer either raised `MediaTypeError: Sample media type 'image' does not match dataset media type
'unknown'` (trying to load the `.xml` as media) or `ValueError: No image found for sample` when the
label file did not embed the image path.

This adds an opt-in `image_only` flag to `ImportPathsMixin._load_data_map()` that filters to image
files **before** UUIDs are computed (so a non-image file can't clobber an image with the same
basename), and has the VOC importer pass `image_only=True`. The flag defaults to `False`, so all other
importers are unaffected.

## 🧪 How is this patch tested? If it is not, please explain why.

Added a regression test `test_voc_detection_dataset_single_dir` in
`tests/unittests/import_export_tests.py` that exports a VOC dataset with images and labels into one
shared directory and re-imports it, asserting no sample's media is a `.xml` file and the image count /
detection count are preserved. It covers both `include_paths=True` and `include_paths=False` (the
latter being the case the embedded-path fallback can't mask). Verified failing on `develop` before the
fix and passing after; the image-importer test classes
(`ImageDetectionDatasetTests`/`ImageClassificationDatasetTests`/`UnlabeledImageDatasetTests`/
`ImageSegmentationDatasetTests`/`OpenLABELImageDatasetTests`) pass. `black -l 79` and
`pylint --errors-only` clean.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] Yes. Give a description of this change to be included in the release notes for FiftyOne users.

Fixed importing VOC detection datasets when images and their `.xml` labels are stored in the same
directory.

### What areas of FiftyOne does this PR affect?

-   [x] Core: Core `fiftyone` Python library changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dataset importing so only image files are loaded when building file mappings, preventing non-image files from being treated as media.
  * Fixed VOC dataset imports when image and label files are stored in the same directory, avoiding `.xml` files being included as imported media.

* **Tests**
  * Added coverage for importing a VOC detection dataset from a single directory to verify media counts and annotations remain correct.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->