### PR TITLE
Fix ZeroDivisionError in mask IoU for zero-area boxes

### DIFF
--- a/fiftyone/utils/iou.py
+++ b/fiftyone/utils/iou.py
@@ -550,6 +550,11 @@ def _dense_iou(gt, pred, gt_crowd=False):
     pred_bb = pred.bounding_box  # x,y,w,h of box
     pred_mask_h, pred_mask_w = pred_mask.shape
 
+    # a box with no positive width and height has no region in which to place
+    # its mask, so its IoU is 0 (and this avoids dividing by zero below)
+    if gt_bb[2] <= 0 or gt_bb[3] <= 0 or pred_bb[2] <= 0 or pred_bb[3] <= 0:
+        return 0.0
+
     gt_img_w = round(gt_mask_w / gt_bb[2])
     gt_img_h = round(gt_mask_h / gt_bb[3])
 

--- a/tests/unittests/evaluation_tests.py
+++ b/tests/unittests/evaluation_tests.py
@@ -2061,6 +2061,17 @@ class DetectionsTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             foui.compute_ious(preds, gts, keypoint_sigmas=[1])
 
+    def test_compute_ious_degenerate_mask_box(self):
+        # a detection whose box has zero width or height has no area to
+        # overlap, so its mask IoU is 0 rather than a ZeroDivisionError
+        mask = np.ones((10, 10), dtype=bool)
+        gts = [fo.Detection(label="x", bounding_box=[0, 0, 0, 0.5], mask=mask)]
+        preds = [fo.Detection(label="x", bounding_box=[0, 0, 0.5, 0.5], mask=mask)]
+
+        ious = foui.compute_ious(preds, gts, use_masks=True)
+
+        self.assertEqual(ious[0, 0], 0.0)
+
     @drop_datasets
     def test_evaluate_detections_open_images(self):
         dataset = self._make_detections_dataset()


### PR DESCRIPTION
### What changes are proposed in this pull request?

`fiftyone.utils.iou._dense_iou` sizes a full-image canvas for each mask from its bounding box — `gt_img_w = round(gt_mask_w / gt_bb[2])` — so a detection whose box has **zero width or height** divides by zero and raises `ZeroDivisionError` part way through `evaluate_detections(..., use_masks=True)` / `compute_ious(..., use_masks=True)`:

```python
import numpy as np
import fiftyone as fo
import fiftyone.utils.iou as foui

mask = np.ones((10, 10), dtype=bool)
gts = [fo.Detection(label="x", bounding_box=[0, 0, 0, 0.5], mask=mask)]   # zero-width box
preds = [fo.Detection(label="x", bounding_box=[0, 0, 0.5, 0.5], mask=mask)]
foui.compute_ious(preds, gts, use_masks=True)
# ZeroDivisionError: float division by zero
```

Degenerate (zero-area) boxes do occur in real model output, so a single one currently aborts an entire instance-segmentation evaluation. A box with no area cannot overlap anything, so this returns IoU `0` for it instead of crashing.

### How is this patch tested? If it is not, please explain why.

New unit test `DetectionsTests.test_compute_ious_degenerate_mask_box` in `tests/unittests/evaluation_tests.py`: `compute_ious(use_masks=True)` on a zero-width-box masked detection now returns `0.0` (previously raised `ZeroDivisionError`). Verified that normal, overlapping masked boxes still return the correct IoU.

### What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [x] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * IoU calculations now safely return `0.0` for degenerate bounding boxes with zero or negative width/height, avoiding errors during evaluation.
  * Improved handling of mask-based IoU comparisons so degenerate boxes no longer cause failures and instead produce a valid zero score.
* **Tests**
  * Added coverage for degenerate box scenarios to verify the expected IoU result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3055
<!-- enterprise-sync-pr:end -->