### PR TITLE
Video annotation documentation

### DIFF
--- a/docs/source/user_guide/annotation.rst
+++ b/docs/source/user_guide/annotation.rst
@@ -25,6 +25,7 @@ In-App annotation within FiftyOne supports datasets containing the following med
 * :ref:`media_type <dataset-media-type>`
 
   * ``image``
+  * ``video``
   * ``3D``
 
 * :ref:`Labels <basics-labels>`
@@ -35,6 +36,9 @@ In-App annotation within FiftyOne supports datasets containing the following med
   * ``2D Polylines and Polygons``
   * ``3D Polylines``
   * ``3D Cuboids``
+  * ``Events (Temporal Detections)``
+
+.. _annotate-tab:
 
 Annotation UI: Sample Visualizer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -43,6 +47,8 @@ All in-App annotation controls now live in the :ref:`expanded view for samples <
 
 .. image:: /_static/images/annotation/annotate_tab_grid.gif
    :alt: Annotate tab location
+
+.. _saving-and-reverting-changes:
 
 Saving and Reverting Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -453,8 +459,220 @@ The editing panel also enables editing the label, tags, confidence, index proper
 
 ----
 
-Working with 3D
----------------
+How to: Video Annotation
+------------------------
+
+.. |video-kf-icon| image:: https://cdn.voxel51.com/user_guide/annotation/video_toolbar_mark_keyframe_button.webp
+   :height: 1.6em
+   :alt: Mark Keyframe button
+.. |video-td-icon| image:: https://cdn.voxel51.com/user_guide/annotation/video_toolbar_new_td_button.webp
+   :height: 1.6em
+   :alt: New TD button
+.. |video-split-icon| image:: https://cdn.voxel51.com/user_guide/annotation/video_toolbar_split_button.webp
+   :height: 1.6em
+   :alt: Split button
+
+In-App video annotation lets you draw object tracks and timeline events on
+:ref:`video <dataset-media-type>` samples. The
+:ref:`Annotation Schema <annotation-schema-format>` and right-sidebar editing
+behavior on the :ref:`Annotate tab <annotate-tab>` are the same as for image
+annotation, and edits :ref:`auto-save <saving-and-reverting-changes>` through
+the database the same way. The video annotation surface adds a timeline
+below the canvas for scrubbing and to visualize tracks that maintain object
+identities and events across frames.
+
+.. raw:: html
+
+   <video autoplay controls muted loop playsinline width="100%"
+          style="max-width:720px"
+          aria-label="Drawing an object track on a video">
+     <source src="https://cdn.voxel51.com/user_guide/annotation/video_create_track.mp4"
+             type="video/mp4">
+   </video>
+
+Requirements
+~~~~~~~~~~~~
+
+Video annotation requires:
+
+* A ``video`` :ref:`type dataset <dataset-media-type>`
+* Images sampled from the video and stored on the frames (see
+  :ref:`frame views <frame-views>`)
+* Metadata computed on the samples
+
+.. code-block:: python
+
+    import fiftyone as fo
+
+    dataset = fo.load_dataset("my-video-dataset")
+    assert dataset.media_type == "video"
+    dataset.compute_metadata()
+    dataset.to_frames(sample_frames=True)
+
+Creating Object Tracks
+~~~~~~~~~~~~~~~~~~~~~~
+
+To create an object track, the
+:ref:`Annotation Schema <annotation-schema-format>` needs to contain a
+compatible field. Create a new field in the
+:ref:`Schema Manager <schema-manager>` that is prefixed with ``frames.``
+indicating that the field will have frame-level labels of the object — for
+example per-frame :ref:`Detections <object-detection>` for
+the bounding box of the object per frame.
+
+.. image:: https://cdn.voxel51.com/user_guide/annotation/video_schema_create_frame_field.webp
+   :alt: Create a frame-level Detections field in the schema editor
+
+To start a new object, click the bounding box icon in the annotate actions
+toolbar and draw a box on the current frame. The first box creates a new
+:class:`Instance <fiftyone.core.labels.Instance>` and marks a keyframe for
+the object at that frame. Scrub the playhead forward and adjust the box on a
+second frame to add the next keyframe. FiftyOne linearly interpolates the
+bounding box between adjacent keyframes at render time.
+:ref:`Polylines <polylines>` and mask labels are not
+interpolated, simply propagated forward.
+
+The start and end frames of an object track can be adjusted by dragging the
+handles on the ends of the track segment in the timeline. Track segments
+can also be dragged in their entirety to a new frame.
+
+Static and Dynamic Attributes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Tracks support two kinds of attributes, configured per-attribute in the
+:ref:`Annotation Schema <annotation-schema-format>`:
+
+* **Static attributes** apply to the whole track. Their value is the same on
+  every frame. Use these for properties that don't change across the track's
+  lifetime (e.g. a vehicle's ``make`` or ``color``).
+* **Dynamic attributes** are keyframed independently of geometry. Their
+  value is held step-wise from the previous attribute keyframe until the
+  next one. Use these for properties that change mid-track (e.g.
+  ``occluded``, ``turn_signal``). Each dynamic attribute has its own nested
+  track under the parent object track.
+
+.. image:: https://cdn.voxel51.com/user_guide/annotation/video_schema_dynamic_attribute_toggle.webp
+   :alt: Dynamic attribute toggle in the schema editor
+
+Static and dynamic attributes are both edited in the right sidebar. Static
+attribute changes propagate to all keyframes. Dynamic attribute changes
+apply to the current frame and propagate forward until the next keyframe.
+
+.. image:: https://cdn.voxel51.com/user_guide/annotation/video_dynamic_attribute_sublanes.webp
+   :alt: Dynamic attribute sub-lanes on the timeline
+
+
+.. _video-keyframes:
+
+Keyframes
+~~~~~~~~~
+
+A **keyframe** is a frame at which a track's value is explicitly set, as
+opposed to interpolated from neighboring frames. Each object track row in the
+timeline shows its keyframes as diamonds.
+
+.. image:: https://cdn.voxel51.com/user_guide/annotation/video_keyframes_on_track.webp
+   :alt: Keyframe diamonds on a selected object track
+
+There are two kinds of keyframes, tracked independently per track:
+
+* **Geometry keyframes** record an explicit bounding box, mask, or polyline
+  position. They are created automatically when you draw or resize an object,
+  or by pressing **K** at the playhead to commit the current geometry without
+  resizing. Between adjacent bounding box geometry keyframes, FiftyOne
+  linearly interpolates bounding boxes at render time. These keyframes are
+  indicated by diamonds.
+* **Attribute keyframes** record an explicit value for a dynamic attribute.
+  They are created automatically when you change the value of a dynamic
+  attribute from the right sidebar. Between adjacent attribute keyframes, the
+  previous value is held until the next keyframe. These keyframes
+  are indicated by different colored segments in the attribute tracks.
+
+The first frame of a track is always a keyframe. Press **K** with a track
+selected, or click the |video-kf-icon| toolbar button, to manually mark a
+geometry keyframe at the playhead without resizing the box. The same action
+also removes an existing keyframe at the playhead, which triggers a new
+interpolation/propagation between the adjacent keyframes.
+
+
+Temporal Events
+~~~~~~~~~~~~~~~
+
+Sample-level events (also known as
+:ref:`Temporal Detections <temporal-detection>`) are rendered as horizontal
+bars in the **Events** lane at the bottom of the video timeline. Each event
+has a label, a ``support=[start_frame, end_frame]``, and user-defined custom
+attributes.
+
+.. image:: https://cdn.voxel51.com/user_guide/annotation/video_events_lane.webp
+   :alt: Events lane in the timeline showing a TemporalDetection bar above
+         two object tracks
+
+To create an event, click the |video-td-icon| button in the timeline
+toolbar to create a new event at the current playhead position. Drag either
+edge of an event bar in the timeline to adjust ``support``. Select an event
+to edit its label and attributes in the right sidebar.
+
+.. raw:: html
+
+   <video autoplay controls muted loop playsinline width="100%"
+          style="max-width:720px"
+          aria-label="Creating a temporal event in the Events lane">
+     <source src="https://cdn.voxel51.com/user_guide/annotation/video_create_event.mp4"
+             type="video/mp4">
+   </video>
+
+Timeline Operations
+~~~~~~~~~~~~~~~~~~~
+
+**Drag-to-retime.** Click and drag an event or object track horizontally to
+move it to a new start and end time.
+
+.. raw:: html
+
+   <video autoplay controls muted loop playsinline width="100%"
+          style="max-width:720px"
+          aria-label="Dragging an event horizontally to retime it">
+     <source src="https://cdn.voxel51.com/user_guide/annotation/video_drag_retime.mp4"
+             type="video/mp4">
+   </video>
+
+**Split.** With the playhead on the desired frame and a track selected, click
+the |video-split-icon| button in the toolbar to split the track into
+two tracks at the playhead. Each side gets a fresh ``Instance`` and static
+attributes are copied to both. Dynamic attributes are split at the playhead,
+with the previous value propagated forward on the right side.
+
+.. raw:: html
+
+   <video autoplay controls muted loop playsinline width="100%"
+          style="max-width:720px"
+          aria-label="Splitting and merging tracks">
+     <source src="https://cdn.voxel51.com/user_guide/annotation/video_split_merge.mp4"
+             type="video/mp4">
+   </video>
+
+**Merge.** Right click an object track to merge it into another track of
+the same class label. The two tracks combine into a single ``Instance``
+with the union of their keyframes. On conflict, attribute values from the
+track being merged into take priority.
+
+**Delete a track** by right clicking the track row and choosing **Delete
+track**.
+
+**Loop a track** by right clicking the track and choosing
+**Shrink window to fit**. This loops playback over the track's duration,
+letting you focus on a specific object or event.
+
+.. image:: https://cdn.voxel51.com/user_guide/annotation/video_track_context_menu.webp
+   :alt: Track right-click context menu with Move/Shrink/Delete/Split/Merge
+         options
+
+
+----
+
+How to: 3D Label Annotation
+---------------------------
 
 3D Annotation Mode
 ~~~~~~~~~~~~~~~~~~

--- a/docs/source/user_guide/annotation.rst
+++ b/docs/source/user_guide/annotation.rst
@@ -580,7 +580,7 @@ There are two ways a track's value can vary over time:
   position. They are created automatically when you draw or resize an
   object, or by pressing **K** at the playhead to commit the current
   geometry without resizing. Between adjacent bounding box keyframes,
-  FiftyOne linearly interpolates the bounding box at render time. These
+  FiftyOne linearly interpolates the bounding box on edits. These
   keyframes are indicated by diamonds.
 * **Dynamic attribute changes** are propagated forward in time rather than
   interpolated. When you change a dynamic attribute's value from the right

--- a/docs/source/user_guide/annotation.rst
+++ b/docs/source/user_guide/annotation.rst
@@ -528,7 +528,7 @@ toolbar and draw a box on the current frame. The first box creates a new
 :class:`Instance <fiftyone.core.labels.Instance>` and marks a keyframe for
 the object at that frame. Scrub the playhead forward and adjust the box on a
 second frame to add the next keyframe. FiftyOne linearly interpolates the
-bounding box between adjacent keyframes at render time.
+bounding box between adjacent keyframes and updates the intermediate labels.
 :ref:`Polylines <polylines>` and mask labels are not
 interpolated, simply propagated forward.
 
@@ -545,18 +545,18 @@ Tracks support two kinds of attributes, configured per-attribute in the
 * **Static attributes** apply to the whole track. Their value is the same on
   every frame. Use these for properties that don't change across the track's
   lifetime (e.g. a vehicle's ``make`` or ``color``).
-* **Dynamic attributes** are keyframed independently of geometry. Their
-  value is held step-wise from the previous attribute keyframe until the
-  next one. Use these for properties that change mid-track (e.g.
-  ``occluded``, ``turn_signal``). Each dynamic attribute has its own nested
-  track under the parent object track.
+* **Dynamic attributes** can change value across a track. Use these for
+  properties that vary mid-track (e.g. ``occluded``, ``turn_signal``).
+  Each dynamic attribute has its own nested track under the parent object
+  track.
 
 .. image:: https://cdn.voxel51.com/user_guide/annotation/video_schema_dynamic_attribute_toggle.webp
    :alt: Dynamic attribute toggle in the schema editor
 
 Static and dynamic attributes are both edited in the right sidebar. Static
-attribute changes propagate to all keyframes. Dynamic attribute changes
-apply to the current frame and propagate forward until the next keyframe.
+attribute updates apply to every frame in the track. Dynamic attribute
+updates propagate forward from the playhead until the next attribute value
+change. Note that dynamic attributes do not have explicit keyframes.
 
 .. image:: https://cdn.voxel51.com/user_guide/annotation/video_dynamic_attribute_sublanes.webp
    :alt: Dynamic attribute sub-lanes on the timeline
@@ -574,19 +574,19 @@ timeline shows its keyframes as diamonds.
 .. image:: https://cdn.voxel51.com/user_guide/annotation/video_keyframes_on_track.webp
    :alt: Keyframe diamonds on a selected object track
 
-There are two kinds of keyframes, tracked independently per track:
+There are two ways a track's value can vary over time:
 
 * **Geometry keyframes** record an explicit bounding box, mask, or polyline
-  position. They are created automatically when you draw or resize an object,
-  or by pressing **K** at the playhead to commit the current geometry without
-  resizing. Between adjacent bounding box geometry keyframes, FiftyOne
-  linearly interpolates bounding boxes at render time. These keyframes are
-  indicated by diamonds.
-* **Attribute keyframes** record an explicit value for a dynamic attribute.
-  They are created automatically when you change the value of a dynamic
-  attribute from the right sidebar. Between adjacent attribute keyframes, the
-  previous value is held until the next keyframe. These keyframes
-  are indicated by different colored segments in the attribute tracks.
+  position. They are created automatically when you draw or resize an
+  object, or by pressing **K** at the playhead to commit the current
+  geometry without resizing. Between adjacent bounding box keyframes,
+  FiftyOne linearly interpolates the bounding box at render time. These
+  keyframes are indicated by diamonds.
+* **Dynamic attribute changes** are propagated forward in time rather than
+  interpolated. When you change a dynamic attribute's value from the right
+  sidebar, the new value is held forward until the next attribute change.
+  These changes are not explicit keyframes; they are indicated by
+  differently colored segments in the attribute sub-tracks.
 
 The first frame of a track is always a keyframe. Press **K** with a track
 selected, or click the |video-kf-icon| toolbar button, to manually mark a
@@ -637,11 +637,12 @@ move it to a new start and end time.
              type="video/mp4">
    </video>
 
-**Split.** With the playhead on the desired frame and a track selected, click
-the |video-split-icon| button in the toolbar to split the track into
-two tracks at the playhead. Each side gets a fresh ``Instance`` and static
-attributes are copied to both. Dynamic attributes are split at the playhead,
-with the previous value propagated forward on the right side.
+**Split.** With the playhead on the desired frame and a track selected,
+click the |video-split-icon| button in the toolbar to split the track into
+two tracks at the playhead. The segment before the playhead retains the
+original ``Instance``; the segment after the playhead is assigned a new
+``Instance``. Static attributes are copied to both tracks and dynamic
+attributes are split at the playhead.
 
 .. raw:: html
 


### PR DESCRIPTION
Adds an end-to-end How to: Video Annotation section to the In-App Annotation user guide, plus the supporting media/label-type updates so the page reflects the new video annotation feature shipping with this release.

What's new

A new section in docs/source/user_guide/annotation.rst, placed between the existing 2D and 3D label annotation sections, covering:

- Requirements — video media type + frame views + compute_metadata, with a code snippet
- Creating object tracks — frames.<field> schema convention, drawing the first box, keyframes, linear interpolation between bounding boxes, polyline/mask propagation, edge-handle resize, and legacy (label, index) → Instance migration
- Static and Dynamic Attributes — how each is keyframed and where they're edited
- Keyframes — geometry vs. attribute keyframes, the K shortcut, and how the diamond glyphs map to interpolation behavior
- Temporal Events — sample-level TemporalDetections rendered as horizontal bars on the Events lane; how to create, drag, and edit them
- Timeline Operations — Drag-to-retime, Cut, Merge (same-class, target-wins), Delete, and Loop ("Shrink window to fit") via the right-click context menu

Supporting changes on the same page

- Supported Media and Label Types list updated:
  - video added under media types
  - Events (Temporal Detections) added under label types
- 3D section heading renamed from "Working with 3D" to "How to: 3D Label Annotation" so the three "How to:" sections (2D / Video / 3D) read consistently
- Three new anchors so other docs can deep-link:
  - .. _annotate-tab:
  - .. _saving-and-reverting-changes:
  - .. _video-keyframes:

Assets

13 new files under docs/source/_static/images/annotation/

GIFs converted from screen recordings at fps=15, scaled to 720 wide, with palettegen + paletteuse — all within the existing GIF size range on this page (avg 2.7 MB, max ~10 MB).

The three toolbar icons render inline at line-height via |video-kf-icon| / |video-td-icon| / |video-split-icon| substitutions so prose like "click the |diamond| toolbar button" reads
naturally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the in-app annotation user guide with clearer supported media and label types, including **video** and **temporal (sample-level) events**.
  * Added a new **“How to: Video Annotation”** section with the full workflow: object tracks, keyframes, timeline editing, and temporal event creation/editing.
  * Updated/reorganized documentation anchors to improve navigation for the **Annotate** tab and **Saving and Reverting Changes**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3056
<!-- enterprise-sync-pr:end -->