### PR TITLE
Don't crash on startup when the UID file can't be written

### DIFF
--- a/fiftyone/core/uid.py
+++ b/fiftyone/core/uid.py
@@ -5,20 +5,27 @@ Utilities for usage analytics.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+import logging
 import os
 import uuid
 
 import fiftyone.constants as foc
 
 
+logger = logging.getLogger(__name__)
+
+
 def get_user_id():
     """Gets the UUID of the current user.
 
-    Returns:
-        a tuple of
+    The UUID is persisted in the FiftyOne config directory so that it is stable
+    across sessions. It is only used for anonymous usage analytics, so if the
+    config directory cannot be created or written to (e.g. a read-only
+    filesystem, or a container where ``~`` resolves to a directory we don't
+    own), a fresh ephemeral UUID is returned rather than raising an error.
 
-        -   UUID string
-        -   True/False whether the UUID was newly created
+    Returns:
+        a UUID string
     """
     uid_path = os.path.join(foc.FIFTYONE_CONFIG_DIR, "var", "uid")
 
@@ -30,8 +37,15 @@ def get_user_id():
             return None
 
     if not read():
-        os.makedirs(os.path.dirname(uid_path), exist_ok=True)
-        with open(uid_path, "w") as f:
-            f.write(str(uuid.uuid4()))
+        try:
+            os.makedirs(os.path.dirname(uid_path), exist_ok=True)
+            with open(uid_path, "w") as f:
+                f.write(str(uuid.uuid4()))
+        except OSError:
+            logger.debug(
+                "Failed to persist user ID to '%s'; using an ephemeral ID",
+                uid_path,
+            )
+            return str(uuid.uuid4())
 
     return read()

--- a/tests/unittests/uid_tests.py
+++ b/tests/unittests/uid_tests.py
@@ -1,0 +1,71 @@
+"""
+FiftyOne user ID utility unit tests.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import unittest
+import uuid
+from unittest.mock import patch, mock_open
+
+import fiftyone.core.uid as fou
+
+
+def _assert_is_uuid(test, value):
+    """Asserts that ``value`` is a valid UUID string."""
+    test.assertIsInstance(value, str)
+    # ``uuid.UUID`` raises ``ValueError`` if ``value`` is not a valid UUID
+    test.assertEqual(str(uuid.UUID(value)), value)
+
+
+class GetUserIdTests(unittest.TestCase):
+    """Tests for ``get_user_id``."""
+
+    @patch("os.makedirs")
+    def test_returns_persisted_uid_when_present(self, mock_makedirs):
+        """The happy path returns the persisted UID and never writes."""
+
+        existing = "12345678-1234-5678-1234-567812345678"
+
+        def fresh_handle(*args, **kwargs):
+            # Return a fresh handle each call so ``read()`` can be called
+            # multiple times without exhausting the iterator
+            return mock_open(read_data=existing + "\n")()
+
+        with patch("builtins.open", side_effect=fresh_handle):
+            uid = fou.get_user_id()
+
+        self.assertEqual(uid, existing)
+        mock_makedirs.assert_not_called()
+
+    @patch("os.makedirs", side_effect=PermissionError("read-only filesystem"))
+    @patch("builtins.open", side_effect=FileNotFoundError)
+    def test_makedirs_permission_error_returns_ephemeral_uuid(
+        self, _mock_open, mock_makedirs
+    ):
+        """A non-writable config dir must not crash; return a fresh UUID."""
+
+        uid = fou.get_user_id()
+
+        _assert_is_uuid(self, uid)
+        mock_makedirs.assert_called_once()
+
+    @patch("os.makedirs")
+    def test_write_oserror_returns_ephemeral_uuid(self, _mock_makedirs):
+        """A write failure (e.g. read-only FS) must not crash either."""
+
+        def open_side_effect(path, *args, **kwargs):
+            # First call is the read (no file yet); the write call fails
+            if "w" in args or kwargs.get("mode") == "w":
+                raise OSError("read-only file system")
+            raise FileNotFoundError
+
+        with patch("builtins.open", side_effect=open_side_effect):
+            uid = fou.get_user_id()
+
+        _assert_is_uuid(self, uid)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #6108

This targets the community branch, since I'm not a Voxel51 team member.

## What was happening

get_user_id() in fiftyone/core/uid.py persists an anonymous analytics UUID at FIFTYONE_CONFIG_DIR/var/uid. When the file doesn't exist yet it calls os.makedirs() unconditionally. If the config directory can't be created or written to, that raises PermissionError and crashes app startup. This shows up in arbitrary-UID containers (for example OpenShift), where HOME is often "/", so ~/.fiftyone resolves to /.fiftyone, which is owned by root and not writable.

## What I changed

The UID is only used for anonymous usage analytics, so it should never block startup. I wrapped the makedirs and write in try/except OSError and fall back to a fresh, non-persisted UUID when the config directory isn't writable. OSError covers PermissionError as well as read-only filesystems (EROFS) and other path errors. The happy path is unchanged.

I also fixed the docstring, which claimed the function returns a tuple. It has always returned a string, and the only caller (the uid GraphQL field in fiftyone/server/query.py) already treats it as a string.

## Tests

Added tests/unittests/uid_tests.py covering the existing-file happy path and two failure modes (makedirs raising PermissionError, and the write itself failing), asserting a valid UUID string is returned instead of an exception.

## Follow-up worth noting

While verifying this, I found that FIFTYONE_CONFIG_DIR is hardcoded from os.path.expanduser("~") in fiftyone/constants.py and the FIFTYONE_CONFIG_DIR environment variable is never read anywhere. That's why setting it to /tmp/fiftyone didn't help the reporter. Making the config dir configurable via env var is a broader change, so I left it out of this PR. This fix makes startup robust regardless of why the directory is unwritable.
