### PR TITLE
Make FO config dir customizable

### DIFF
--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -6,8 +6,34 @@ Configuring FiftyOne
 .. default-role:: code
 
 FiftyOne can be configured in various ways. This guide covers the various
-options that exist, how to view your current config, and how to customize your
-config as desired.
+options that exist, how to view your current configs, and how to customize
+your configs as desired.
+
+FiftyOne's configuration options are organized by feature:
+
++-------------------------------------------------+--------------------------------------+-------------------------------------------------------------------------------------------+
+| Environment variable                            | Default value                        | Description                                                                               |
++=================================================+======================================+===========================================================================================+
+| `FIFTYONE_CONFIG_DIR`                           | `~/.fiftyone`                        | The directory where all FiftyOne configuration information that must be persisted to      |
+|                                                 |                                      | disk is stored (unless overridden by per-feature config settings like those below)        |
++-------------------------------------------------+--------------------------------------+-------------------------------------------------------------------------------------------+
+| `FIFTYONE_CONFIG_PATH`                          | `~/.fiftyone/config.json`            | The path to a JSON file containing                                                        |
+|                                                 |                                      | :ref:`general settings <configuring-fiftyone-general>` you have permanently configured    |
++-------------------------------------------------+--------------------------------------+-------------------------------------------------------------------------------------------+
+| `FIFTYONE_APP_CONFIG_PATH`                      | `~/.fiftyone/app_config.json`        | The path to a JSON file containing any                                                    |
+|                                                 |                                      | :ref:`App settings <configuring-fiftyone-app>` you have permanently configured            |
++-------------------------------------------------+--------------------------------------+-------------------------------------------------------------------------------------------+
+| `FIFTYONE_ANNOTATION_CONFIG_PATH`               | `~/.fiftyone/annotation_config.json` | The path to a JSON file containing any                                                    |
+|                                                 |                                      | :ref:`annotation settings <annotation-config>` you have permanently configured            |
++-------------------------------------------------+--------------------------------------+-------------------------------------------------------------------------------------------+
+| `FIFTYONE_BRAIN_CONFIG_PATH`                    | `~/.fiftyone/brain_config.json`      | The path to a JSON file containing any                                                    |
+|                                                 |                                      | :ref:`brain settings <brain-config>` you have permanently configured                      |
++-------------------------------------------------+--------------------------------------+-------------------------------------------------------------------------------------------+
+| `FIFTYONE_EVALUATION_CONFIG_PATH`               | `~/.fiftyone/evaluation_config.json` | The path to a JSON file containing any                                                    |
+|                                                 |                                      | :ref:`evaluation settings <evaluation-config>` you have permanently configured            |
++-------------------------------------------------+--------------------------------------+-------------------------------------------------------------------------------------------+
+
+.. _configuring-fiftyone-general:
 
 Configuration options
 ---------------------

--- a/fiftyone/constants.py
+++ b/fiftyone/constants.py
@@ -17,7 +17,10 @@ from importlib.metadata import metadata
 CLIENT_TYPE = "fiftyone"
 
 FIFTYONE_DIR = os.path.dirname(os.path.abspath(__file__))
-FIFTYONE_CONFIG_DIR = os.path.join(os.path.expanduser("~"), ".fiftyone")
+FIFTYONE_CONFIG_DIR = os.environ.get(
+    "FIFTYONE_CONFIG_DIR",
+    os.path.join(os.path.expanduser("~"), ".fiftyone"),
+)
 FIFTYONE_CONFIG_PATH = os.path.join(FIFTYONE_CONFIG_DIR, "config.json")
 FIFTYONE_ANNOTATION_CONFIG_PATH = os.path.join(
     FIFTYONE_CONFIG_DIR, "annotation_config.json"

--- a/fiftyone/constants.py
+++ b/fiftyone/constants.py
@@ -17,25 +17,35 @@ from importlib.metadata import metadata
 CLIENT_TYPE = "fiftyone"
 
 FIFTYONE_DIR = os.path.dirname(os.path.abspath(__file__))
-FIFTYONE_CONFIG_DIR = os.environ.get(
-    "FIFTYONE_CONFIG_DIR",
-    os.path.join(os.path.expanduser("~"), ".fiftyone"),
+FIFTYONE_CONFIG_DIR = os.path.expanduser(
+    os.environ.get(
+        "FIFTYONE_CONFIG_DIR",
+        os.path.join("~", ".fiftyone"),
+    )
 )
-FIFTYONE_CONFIG_PATH = os.environ.get(
-    "FIFTYONE_CONFIG_PATH",
-    os.path.join(FIFTYONE_CONFIG_DIR, "config.json"),
+FIFTYONE_CONFIG_PATH = os.path.expanduser(
+    os.environ.get(
+        "FIFTYONE_CONFIG_PATH",
+        os.path.join(FIFTYONE_CONFIG_DIR, "config.json"),
+    )
 )
-FIFTYONE_ANNOTATION_CONFIG_PATH = os.environ.get(
-    "FIFTYONE_ANNOTATION_CONFIG_PATH",
-    os.path.join(FIFTYONE_CONFIG_DIR, "annotation_config.json"),
+FIFTYONE_ANNOTATION_CONFIG_PATH = os.path.expanduser(
+    os.environ.get(
+        "FIFTYONE_ANNOTATION_CONFIG_PATH",
+        os.path.join(FIFTYONE_CONFIG_DIR, "annotation_config.json"),
+    )
 )
-FIFTYONE_EVALUATION_CONFIG_PATH = os.environ.get(
-    "FIFTYONE_EVALUATION_CONFIG_PATH",
-    os.path.join(FIFTYONE_CONFIG_DIR, "evaluation_config.json"),
+FIFTYONE_EVALUATION_CONFIG_PATH = os.path.expanduser(
+    os.environ.get(
+        "FIFTYONE_EVALUATION_CONFIG_PATH",
+        os.path.join(FIFTYONE_CONFIG_DIR, "evaluation_config.json"),
+    )
 )
-FIFTYONE_APP_CONFIG_PATH = os.environ.get(
-    "FIFTYONE_APP_CONFIG_PATH",
-    os.path.join(FIFTYONE_CONFIG_DIR, "app_config.json"),
+FIFTYONE_APP_CONFIG_PATH = os.path.expanduser(
+    os.environ.get(
+        "FIFTYONE_APP_CONFIG_PATH",
+        os.path.join(FIFTYONE_CONFIG_DIR, "app_config.json"),
+    )
 )
 BASE_DIR = os.path.dirname(FIFTYONE_DIR)
 TEAMS_PATH = os.path.join(FIFTYONE_CONFIG_DIR, "var", "teams.json")

--- a/fiftyone/constants.py
+++ b/fiftyone/constants.py
@@ -21,14 +21,22 @@ FIFTYONE_CONFIG_DIR = os.environ.get(
     "FIFTYONE_CONFIG_DIR",
     os.path.join(os.path.expanduser("~"), ".fiftyone"),
 )
-FIFTYONE_CONFIG_PATH = os.path.join(FIFTYONE_CONFIG_DIR, "config.json")
-FIFTYONE_ANNOTATION_CONFIG_PATH = os.path.join(
-    FIFTYONE_CONFIG_DIR, "annotation_config.json"
+FIFTYONE_CONFIG_PATH = os.environ.get(
+    "FIFTYONE_CONFIG_PATH",
+    os.path.join(FIFTYONE_CONFIG_DIR, "config.json"),
 )
-FIFTYONE_EVALUATION_CONFIG_PATH = os.path.join(
-    FIFTYONE_CONFIG_DIR, "evaluation_config.json"
+FIFTYONE_ANNOTATION_CONFIG_PATH = os.environ.get(
+    "FIFTYONE_ANNOTATION_CONFIG_PATH",
+    os.path.join(FIFTYONE_CONFIG_DIR, "annotation_config.json"),
 )
-FIFTYONE_APP_CONFIG_PATH = os.path.join(FIFTYONE_CONFIG_DIR, "app_config.json")
+FIFTYONE_EVALUATION_CONFIG_PATH = os.environ.get(
+    "FIFTYONE_EVALUATION_CONFIG_PATH",
+    os.path.join(FIFTYONE_CONFIG_DIR, "evaluation_config.json"),
+)
+FIFTYONE_APP_CONFIG_PATH = os.environ.get(
+    "FIFTYONE_APP_CONFIG_PATH",
+    os.path.join(FIFTYONE_CONFIG_DIR, "app_config.json"),
+)
 BASE_DIR = os.path.dirname(FIFTYONE_DIR)
 TEAMS_PATH = os.path.join(FIFTYONE_CONFIG_DIR, "var", "teams.json")
 WELCOME_PATH = os.path.join(FIFTYONE_CONFIG_DIR, "var", "welcome.json")

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -856,6 +856,21 @@ class EvaluationConfig(EnvConfig):
         return d
 
 
+def locate_config_dir():
+    """Returns the path to FiftyOne's configuration directory.
+
+    The default location is ``~/.fiftyone``, but you can override this path by
+    setting the ``FIFTYONE_CONFIG_DIR`` environment variable.
+
+    Returns:
+        the path to FiftyOne's configuration directory
+    """
+    if "FIFTYONE_CONFIG_DIR" not in os.environ:
+        return os.path.join(os.path.expanduser("~"), ".fiftyone")
+
+    return os.environ["FIFTYONE_CONFIG_DIR"]
+
+
 def locate_config():
     """Returns the path to the :class:`FiftyOneConfig` on disk.
 

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -865,10 +865,7 @@ def locate_config_dir():
     Returns:
         the path to FiftyOne's configuration directory
     """
-    if "FIFTYONE_CONFIG_DIR" not in os.environ:
-        return os.path.join(os.path.expanduser("~"), ".fiftyone")
-
-    return os.environ["FIFTYONE_CONFIG_DIR"]
+    return foc.FIFTYONE_CONFIG_DIR
 
 
 def locate_config():
@@ -882,10 +879,7 @@ def locate_config():
     Returns:
         the path to the :class:`FiftyOneConfig` on disk
     """
-    if "FIFTYONE_CONFIG_PATH" not in os.environ:
-        return foc.FIFTYONE_CONFIG_PATH
-
-    return os.environ["FIFTYONE_CONFIG_PATH"]
+    return foc.FIFTYONE_CONFIG_PATH
 
 
 def locate_app_config():
@@ -900,10 +894,7 @@ def locate_app_config():
     Returns:
         the path to the :class:`AppConfig` on disk
     """
-    if "FIFTYONE_APP_CONFIG_PATH" not in os.environ:
-        return foc.FIFTYONE_APP_CONFIG_PATH
-
-    return os.environ["FIFTYONE_APP_CONFIG_PATH"]
+    return foc.FIFTYONE_APP_CONFIG_PATH
 
 
 def locate_annotation_config():
@@ -918,10 +909,7 @@ def locate_annotation_config():
     Returns:
         the path to the :class:`AnnotationConfig` on disk
     """
-    if "FIFTYONE_ANNOTATION_CONFIG_PATH" not in os.environ:
-        return foc.FIFTYONE_ANNOTATION_CONFIG_PATH
-
-    return os.environ["FIFTYONE_ANNOTATION_CONFIG_PATH"]
+    return foc.FIFTYONE_ANNOTATION_CONFIG_PATH
 
 
 class HTTPRetryConfig(object):
@@ -956,10 +944,7 @@ def locate_evaluation_config():
     Returns:
         the path to the :class:`EvaluationConfig` on disk
     """
-    if "FIFTYONE_EVALUATION_CONFIG_PATH" not in os.environ:
-        return foc.FIFTYONE_EVALUATION_CONFIG_PATH
-
-    return os.environ["FIFTYONE_EVALUATION_CONFIG_PATH"]
+    return foc.FIFTYONE_EVALUATION_CONFIG_PATH
 
 
 def load_config():

--- a/fiftyone/migrations/revisions/admin/v0_15_1.py
+++ b/fiftyone/migrations/revisions/admin/v0_15_1.py
@@ -40,13 +40,20 @@ def _get_database_name():
     return config.get("database_name", "fiftyone")
 
 
-def _load_config():
+def _get_config_path():
     if "FIFTYONE_CONFIG_PATH" in os.environ:
-        config_path = os.environ["FIFTYONE_CONFIG_PATH"]
+        return os.environ["FIFTYONE_CONFIG_PATH"]
+
+    if "FIFTYONE_CONFIG_DIR" in os.environ:
+        config_dir = os.environ["FIFTYONE_CONFIG_DIR"]
     else:
-        config_path = os.path.join(
-            os.path.expanduser("~"), ".fiftyone", "config.json"
-        )
+        config_dir = os.path.join(os.path.expanduser("~"), ".fiftyone")
+
+    return os.path.join(config_dir, "config.json")
+
+
+def _load_config():
+    config_path = _get_config_path()
 
     config = {}
 


### PR DESCRIPTION
Resolves https://github.com/voxel51/fiftyone/issues/7909

## Release notes

- Adds support for customizing the location where FiftyOne configuration info is stored (eg default mongo install, anonymous tracking info, welcome state, etc) via the new `FIFTYONE_CONFIG_DIR` environment variable

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3064
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for customizing where configuration files are stored via environment variables, including the main config and per-feature config locations.
  * Added a helper to locate the configuration directory and aligned config lookup across the app.
* **Documentation**
  * Expanded the “Configuring FiftyOne” user guide intro and added a table documenting configuration-related environment variables (including persistence paths).
  * Added an anchor to improve navigation within the guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->