### PR TITLE
Parallelize plugin loading in the app

### DIFF
--- a/app/packages/plugins/src/index.ts
+++ b/app/packages/plugins/src/index.ts
@@ -58,24 +58,30 @@ class PluginDefinition {
 export async function loadPlugins() {
   const plugins = await fetchPluginsMetadata();
   const { pathPrefix } = getFetchParameters();
-  for (const plugin of plugins) {
-    usingRegistry().registerPluginDefinition(plugin);
-    if (plugin.hasJS) {
+
+  // Inject bundles in parallel so plugin readiness is gated by the slowest
+  // bundle, not the sum of all of them.
+  await Promise.all(
+    plugins.map((plugin) => {
+      usingRegistry().registerPluginDefinition(plugin);
+      if (!plugin.hasJS) {
+        return undefined;
+      }
       const name = plugin.name;
-      const scriptPath = plugin.jsBundleServerPath;
-      const cacheKey = plugin.jsBundleHash ? `?h=${plugin.jsBundleHash}` : "";
       if (usingRegistry().hasScript(name)) {
         console.debug(`Plugin "${name}": already loaded`);
-        continue;
+        return undefined;
       }
-      try {
-        await loadScript(name, pathPrefix + scriptPath + cacheKey);
-      } catch (e) {
+      const cacheKey = plugin.jsBundleHash ? `?h=${plugin.jsBundleHash}` : "";
+      return loadScript(
+        name,
+        pathPrefix + plugin.jsBundleServerPath + cacheKey
+      ).catch((e) => {
         console.error(`Plugin "${name}": failed to load!`);
         console.error(e);
-      }
-    }
-  }
+      });
+    })
+  );
 }
 async function loadScript(name, url) {
   console.debug(`Plugin "${name}": loading script...`);
@@ -180,7 +186,7 @@ export function getAbsolutePluginPath(name: string, path: string): string {
 
 export function usePluginSettings<T>(
   pluginName: string,
-  defaults?: Partial<T>,
+  defaults?: Partial<T>
 ): T {
   const datasetAppConfig = recoil.useRecoilValue(fos.datasetAppConfig);
   const appConfig = recoil.useRecoilValue(fos.config);
@@ -192,7 +198,7 @@ export function usePluginSettings<T>(
     return _.merge<T | {}, Partial<T>, Partial<T>>(
       { ...defaults },
       _.get(appConfigPlugins, pluginName, {}),
-      _.get(datasetPlugins, pluginName, {}),
+      _.get(datasetPlugins, pluginName, {})
     );
   }, [appConfig, pluginName, defaults, datasetAppConfig]);
 

--- a/app/packages/plugins/src/index.ts
+++ b/app/packages/plugins/src/index.ts
@@ -69,19 +69,23 @@ export async function loadPlugins() {
         return undefined;
       }
       const name = plugin.name;
-      if (registry.hasScript(name)) {
+      // Reuse the in-flight (or settled) load so overlapping loadPlugins()
+      // calls resolve only once the bundle has registered its components.
+      const existing = registry.getScript(name);
+      if (existing) {
         console.debug(`Plugin "${name}": already loaded`);
-        return undefined;
+        return existing;
       }
-      registry.registerScript(name);
       const cacheKey = plugin.jsBundleHash ? `?h=${plugin.jsBundleHash}` : "";
-      return loadScript(
+      const promise = loadScript(
         name,
         pathPrefix + plugin.jsBundleServerPath + cacheKey
       ).catch((e) => {
         console.error(`Plugin "${name}": failed to load!`);
         console.error(e);
       });
+      registry.registerScript(name, promise);
+      return promise;
     })
   );
 }
@@ -97,7 +101,6 @@ async function loadScript(name, url) {
       } else {
         reject(new Error(`Plugin "${name}": Failed to load script ${url}`));
       }
-      usingRegistry().registerScript(name);
     };
     const script = document.createElement("script");
     script.type = "application/javascript";

--- a/app/packages/plugins/src/index.ts
+++ b/app/packages/plugins/src/index.ts
@@ -63,15 +63,17 @@ export async function loadPlugins() {
   // bundle, not the sum of all of them.
   await Promise.all(
     plugins.map((plugin) => {
-      usingRegistry().registerPluginDefinition(plugin);
+      const registry = usingRegistry();
+      registry.registerPluginDefinition(plugin);
       if (!plugin.hasJS) {
         return undefined;
       }
       const name = plugin.name;
-      if (usingRegistry().hasScript(name)) {
+      if (registry.hasScript(name)) {
         console.debug(`Plugin "${name}": already loaded`);
         return undefined;
       }
+      registry.registerScript(name);
       const cacheKey = plugin.jsBundleHash ? `?h=${plugin.jsBundleHash}` : "";
       return loadScript(
         name,

--- a/app/packages/plugins/src/index.ts
+++ b/app/packages/plugins/src/index.ts
@@ -79,14 +79,14 @@ export async function loadPlugins() {
       const cacheKey = plugin.jsBundleHash ? `?h=${plugin.jsBundleHash}` : "";
       const promise = loadScript(
         name,
-        pathPrefix + plugin.jsBundleServerPath + cacheKey
+        pathPrefix + plugin.jsBundleServerPath + cacheKey,
       ).catch((e) => {
         console.error(`Plugin "${name}": failed to load!`);
         console.error(e);
       });
       registry.registerScript(name, promise);
       return promise;
-    })
+    }),
   );
 }
 async function loadScript(name, url) {
@@ -191,7 +191,7 @@ export function getAbsolutePluginPath(name: string, path: string): string {
 
 export function usePluginSettings<T>(
   pluginName: string,
-  defaults?: Partial<T>
+  defaults?: Partial<T>,
 ): T {
   const datasetAppConfig = recoil.useRecoilValue(fos.datasetAppConfig);
   const appConfig = recoil.useRecoilValue(fos.config);
@@ -203,7 +203,7 @@ export function usePluginSettings<T>(
     return _.merge<T | {}, Partial<T>, Partial<T>>(
       { ...defaults },
       _.get(appConfigPlugins, pluginName, {}),
-      _.get(datasetPlugins, pluginName, {})
+      _.get(datasetPlugins, pluginName, {}),
     );
   }, [appConfig, pluginName, defaults, datasetAppConfig]);
 

--- a/app/packages/plugins/src/registry.ts
+++ b/app/packages/plugins/src/registry.ts
@@ -24,7 +24,7 @@ export function usingRegistry() {
  * @param registration The plugin registration
  */
 export function registerComponent<TType extends PluginComponentType>(
-  registration: PluginComponentRegistrationByType[TType],
+  registration: PluginComponentRegistrationByType[TType]
 ) {
   if (!registration.activator) {
     registration.activator = () => true;
@@ -64,7 +64,7 @@ export function getComponent<T>(name: string) {
 }
 
 export function usePlugin<TType extends PluginComponentType>(
-  type: TType,
+  type: TType
 ): PluginComponentRegistrationByType[TType][] {
   return usingRegistry().getByType(type);
 }
@@ -72,7 +72,7 @@ export function usePlugin<TType extends PluginComponentType>(
 /** a utility for safely calling plugin defined activator functions */
 export function safePluginActivator(
   plugin: PluginComponentRegistration,
-  ctx: any,
+  ctx: any
 ): boolean {
   if (typeof plugin.activator === "function") {
     try {
@@ -107,7 +107,7 @@ const getRegistryVersion = () => usingRegistry().getVersion();
 
 export function useActivePlugins<TType extends PluginComponentType>(
   type: TType,
-  ctx: Record<string, unknown>,
+  ctx: Record<string, unknown>
 ) {
   // useSyncExternalStore reads the snapshot synchronously during render and
   // atomically subscribes, so a register/unregister event that fires between
@@ -119,7 +119,7 @@ export function useActivePlugins<TType extends PluginComponentType>(
       usingRegistry()
         .getByType(type)
         .filter((plugin) => safePluginActivator(plugin, ctx)),
-    [type, ctx, version],
+    [type, ctx, version]
   );
 }
 
@@ -240,7 +240,7 @@ type PluginComponentProps<T> = T & {
 
 type BasePluginComponentRegistration<
   TType extends PluginComponentType,
-  TComponentProps,
+  TComponentProps
 > = {
   /**
    * The name of the plugin
@@ -334,7 +334,7 @@ export function getCategoryLabel(category: CategoryID): string {
 }
 
 export function getCategoryForPanel(
-  panel: PanelRegistration | PlotRegistration,
+  panel: PanelRegistration | PlotRegistration
 ) {
   return panel.panelOptions?.category || "custom";
 }
@@ -354,14 +354,19 @@ const REQUIRED = ["name", "type", "component"];
 export class PluginComponentRegistry {
   private data = new Map<string, PluginComponentRegistration>();
   private pluginDefinitions = new Map<string, PluginDefinitionLike>();
-  private scripts = new Set<string>();
+  private scripts = new Map<string, Promise<void>>();
   private subscribers = new Set<RegistryEventHandler>();
   private version = 0;
   getVersion() {
     return this.version;
   }
-  registerScript(name: string) {
-    this.scripts.add(name);
+  // Track the in-flight load so overlapping loadPlugins() calls await the same
+  // promise instead of resolving early off a "started" flag.
+  registerScript(name: string, promise: Promise<void>) {
+    this.scripts.set(name, promise);
+  }
+  getScript(name: string) {
+    return this.scripts.get(name);
   }
   registerPluginDefinition(pluginDefinition: PluginDefinitionLike) {
     this.pluginDefinitions.set(pluginDefinition.name, pluginDefinition);
@@ -389,35 +394,35 @@ export class PluginComponentRegistry {
     for (const fieldName of REQUIRED) {
       assert(
         registration[fieldName],
-        `${fieldName} is required to register a Plugin Component`,
+        `${fieldName} is required to register a Plugin Component`
       );
     }
     warn(
       !this.data.has(name),
-      `${name} is already a registered Plugin Component`,
+      `${name} is already a registered Plugin Component`
     );
     warn(
       registration.type !== PluginComponentType.Plot,
-      `${name} is a Plot Plugin Component. This is deprecated. Please use "Panel" instead.`,
+      `${name} is a Plot Plugin Component. This is deprecated. Please use "Panel" instead.`
     );
 
     if (registration.type === PluginComponentType.SampleRenderer) {
       assert(
         registration.sampleRendererOptions,
-        `${name} declared SampleRenderer without sampleRendererOptions`,
+        `${name} declared SampleRenderer without sampleRendererOptions`
       );
 
       const { supports } = registration.sampleRendererOptions;
 
       assert(
         Boolean(supports),
-        `${name} declared SampleRenderer without sampleRendererOptions.supports`,
+        `${name} declared SampleRenderer without sampleRendererOptions.supports`
       );
 
       if (supports && typeof supports !== "function") {
         warn(
           hasMatchMediaMatchers(supports),
-          `${name} declared sampleRendererOptions.supports without any matchers`,
+          `${name} declared sampleRendererOptions.supports without any matchers`
         );
       }
     }

--- a/app/packages/plugins/src/registry.ts
+++ b/app/packages/plugins/src/registry.ts
@@ -24,7 +24,7 @@ export function usingRegistry() {
  * @param registration The plugin registration
  */
 export function registerComponent<TType extends PluginComponentType>(
-  registration: PluginComponentRegistrationByType[TType]
+  registration: PluginComponentRegistrationByType[TType],
 ) {
   if (!registration.activator) {
     registration.activator = () => true;
@@ -64,7 +64,7 @@ export function getComponent<T>(name: string) {
 }
 
 export function usePlugin<TType extends PluginComponentType>(
-  type: TType
+  type: TType,
 ): PluginComponentRegistrationByType[TType][] {
   return usingRegistry().getByType(type);
 }
@@ -72,7 +72,7 @@ export function usePlugin<TType extends PluginComponentType>(
 /** a utility for safely calling plugin defined activator functions */
 export function safePluginActivator(
   plugin: PluginComponentRegistration,
-  ctx: any
+  ctx: any,
 ): boolean {
   if (typeof plugin.activator === "function") {
     try {
@@ -107,7 +107,7 @@ const getRegistryVersion = () => usingRegistry().getVersion();
 
 export function useActivePlugins<TType extends PluginComponentType>(
   type: TType,
-  ctx: Record<string, unknown>
+  ctx: Record<string, unknown>,
 ) {
   // useSyncExternalStore reads the snapshot synchronously during render and
   // atomically subscribes, so a register/unregister event that fires between
@@ -119,7 +119,7 @@ export function useActivePlugins<TType extends PluginComponentType>(
       usingRegistry()
         .getByType(type)
         .filter((plugin) => safePluginActivator(plugin, ctx)),
-    [type, ctx, version]
+    [type, ctx, version],
   );
 }
 
@@ -240,7 +240,7 @@ type PluginComponentProps<T> = T & {
 
 type BasePluginComponentRegistration<
   TType extends PluginComponentType,
-  TComponentProps
+  TComponentProps,
 > = {
   /**
    * The name of the plugin
@@ -334,7 +334,7 @@ export function getCategoryLabel(category: CategoryID): string {
 }
 
 export function getCategoryForPanel(
-  panel: PanelRegistration | PlotRegistration
+  panel: PanelRegistration | PlotRegistration,
 ) {
   return panel.panelOptions?.category || "custom";
 }
@@ -394,35 +394,35 @@ export class PluginComponentRegistry {
     for (const fieldName of REQUIRED) {
       assert(
         registration[fieldName],
-        `${fieldName} is required to register a Plugin Component`
+        `${fieldName} is required to register a Plugin Component`,
       );
     }
     warn(
       !this.data.has(name),
-      `${name} is already a registered Plugin Component`
+      `${name} is already a registered Plugin Component`,
     );
     warn(
       registration.type !== PluginComponentType.Plot,
-      `${name} is a Plot Plugin Component. This is deprecated. Please use "Panel" instead.`
+      `${name} is a Plot Plugin Component. This is deprecated. Please use "Panel" instead.`,
     );
 
     if (registration.type === PluginComponentType.SampleRenderer) {
       assert(
         registration.sampleRendererOptions,
-        `${name} declared SampleRenderer without sampleRendererOptions`
+        `${name} declared SampleRenderer without sampleRendererOptions`,
       );
 
       const { supports } = registration.sampleRendererOptions;
 
       assert(
         Boolean(supports),
-        `${name} declared SampleRenderer without sampleRendererOptions.supports`
+        `${name} declared SampleRenderer without sampleRendererOptions.supports`,
       );
 
       if (supports && typeof supports !== "function") {
         warn(
           hasMatchMediaMatchers(supports),
-          `${name} declared sampleRendererOptions.supports without any matchers`
+          `${name} declared sampleRendererOptions.supports without any matchers`,
         );
       }
     }


### PR DESCRIPTION
<!--
Community contributors: target the `community` branch, not `develop`. PRs from
non-members are auto-retargeted to `community`. See CONTRIBUTING.md:
https://github.com/voxel51/fiftyone/blob/develop/CONTRIBUTING.md#community-pull-requests
-->

## 🔗 Related Issues

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->

## 📋 What changes are proposed in this pull request?

-parallelize plugin loading with promise.all

## 🧪 How is this patch tested? If it is not, please explain why.

<!--
Describe the tests you ran or wrote to verify your changes. Include:
- New or updated unit/integration tests
- Manual testing steps performed
- Why tests are not applicable (if skipped)
-->

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Plugin bundles now load in parallel to reduce startup time when multiple plugins are enabled.
  * Concurrent plugin load requests are de-duplicated and can share the same in-progress load.
* **Stability**
  * Errors during plugin bundle loading are handled per plugin and logged without blocking other plugin bundles from loading.
* **Reliability**
  * Improved script-load tracking ensures consistent behavior across repeated load attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3177
<!-- enterprise-sync-pr:end -->