### PR TITLE
Upgrade relevant import types to support data and labels that are co-located in the same directory 

### DIFF
--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -784,7 +784,7 @@ class CVATVideoDatasetImporter(
 
     def setup(self):
         video_paths_map = self._load_data_map(
-            self.data_path, ignore_exts=True, recursive=True
+            self.data_path, ignore_exts=True, skip_exts=".xml", recursive=True
         )
 
         if self.labels_path is not None and os.path.isdir(self.labels_path):

--- a/fiftyone/utils/data/importers.py
+++ b/fiftyone/utils/data/importers.py
@@ -826,7 +826,9 @@ class ImportPathsMixin(object):
         return labels_path
 
     @staticmethod
-    def _load_data_map(data_path, ignore_exts=False, recursive=False):
+    def _load_data_map(
+        data_path, ignore_exts=False, skip_exts=None, recursive=False
+    ):
         """Helper function that parses either a data directory or a data
         manifest file into a UUID -> filepath map.
         """
@@ -835,8 +837,20 @@ class ImportPathsMixin(object):
         else:
             to_uuid = lambda p: fos.normpath(p)
 
+        if skip_exts is not None:
+            if etau.is_container(skip_exts):
+                skip_exts = tuple(skip_exts)
+
+            match = lambda v: not v.endswith(skip_exts)
+        else:
+            match = lambda v: True
+
         if isinstance(data_path, dict):
-            return {to_uuid(k): fos.normpath(v) for k, v in data_path.items()}
+            return {
+                to_uuid(k): fos.normpath(v)
+                for k, v in data_path.items()
+                if match(v)
+            }
 
         if not data_path:
             return {}
@@ -849,9 +863,11 @@ class ImportPathsMixin(object):
 
             data_map = etas.read_json(data_path)
             data_root = os.path.dirname(data_path)
+
             return {
                 to_uuid(k): fos.normpath(os.path.join(data_root, v))
                 for k, v in data_map.items()
+                if match(v)
             }
 
         if not os.path.isdir(data_path):
@@ -860,6 +876,7 @@ class ImportPathsMixin(object):
         return {
             to_uuid(p): fos.normpath(os.path.join(data_path, p))
             for p in etau.list_files(data_path, recursive=recursive)
+            if match(p)
         }
 
 

--- a/fiftyone/utils/kitti.py
+++ b/fiftyone/utils/kitti.py
@@ -173,7 +173,7 @@ class KITTIDetectionDatasetImporter(
 
     def setup(self):
         image_paths_map = self._load_data_map(
-            self.data_path, ignore_exts=True, recursive=True
+            self.data_path, ignore_exts=True, skip_exts=".txt", recursive=True
         )
 
         if self.labels_path is not None and os.path.isdir(self.labels_path):

--- a/fiftyone/utils/openlabel.py
+++ b/fiftyone/utils/openlabel.py
@@ -211,7 +211,7 @@ class OpenLABELImageDatasetImporter(
 
     def setup(self):
         image_paths_map = self._load_data_map(
-            self.data_path, ignore_exts=True, recursive=True
+            self.data_path, ignore_exts=True, skip_exts=".json", recursive=True
         )
 
         file_ids = []
@@ -428,7 +428,7 @@ class OpenLABELVideoDatasetImporter(
 
     def setup(self):
         video_paths_map = self._load_data_map(
-            self.data_path, ignore_exts=True, recursive=True
+            self.data_path, ignore_exts=True, skip_exts=".json", recursive=True
         )
 
         file_ids = []

--- a/fiftyone/utils/voc.py
+++ b/fiftyone/utils/voc.py
@@ -183,7 +183,7 @@ class VOCDetectionDatasetImporter(
 
     def setup(self):
         image_paths_map = self._load_data_map(
-            self.data_path, ignore_exts=True, recursive=True
+            self.data_path, ignore_exts=True, skip_exts=".xml", recursive=True
         )
 
         if self.labels_path is not None and os.path.isdir(self.labels_path):


### PR DESCRIPTION
Resolves https://github.com/voxel51/fiftyone/issues/1781.
Supersedes https://github.com/voxel51/fiftyone/pull/7904.

## Release Notes

- Upgrades the [VOC](https://docs.voxel51.com/user_guide/import_datasets.html#voc), [KITTI](https://docs.voxel51.com/user_guide/import_datasets.html#kitti), [CVAT Video](https://docs.voxel51.com/user_guide/import_datasets.html#cvat-video), [OpenLABEL Image](https://docs.voxel51.com/user_guide/import_datasets.html#openlabel-image), and [OpenLABEL Video](https://docs.voxel51.com/user_guide/import_datasets.html#openlabel-video) formats to support data and labels that are colocated in the same directory, ie `data_path == labels_path` 

## Tested by

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")

dataset.export(
    dataset_type=fo.types.VOCDetectionDataset,
    data_path="/tmp/test",
    labels_path="/tmp/test",
    label_field="ground_truth",
)

dataset2 = fo.Dataset.from_dir(
    dataset_type=fo.types.VOCDetectionDataset,
    data_path="/tmp/voc",
    labels_path="/tmp/voc",
    label_field="ground_truth",
)

assert dataset.count("ground_truth.detections") == dataset2.count("ground_truth.detections")
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dataset import handling so annotation/label files are no longer mistaken for media files.
  * Prevented `.xml`, `.txt`, and `.json` files from being picked up during media path scanning in supported import workflows.
  * Made file mapping more reliable across folders, manifests, and recursive scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->