### PR TITLE
Downgrade to protobuf 6.33.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -121,8 +121,9 @@ setup(
     entry_points={"console_scripts": ["fiftyone=fiftyone.core.cli:main"]},
     python_requires=">=3.10",
     extras_require={
-        "multimodal": [
+        "multimodal-mcap": [
             "protobuf==6.33.6",
         ],
+        "multimodal": ["fiftyone[multimodal-mcap]"],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ setup(
     python_requires=">=3.10",
     extras_require={
         "multimodal": [
-            "protobuf==7.35.0",
+            "protobuf==6.33.6",
         ],
     },
 )


### PR DESCRIPTION
## 🔗 Related Issues

[FO #7613](https://github.com/voxel51/fiftyone/pull/7613)

## 📋 What changes are proposed in this pull request?

This PR reverts [Dependabot's upgrade](https://github.com/voxel51/fiftyone/pull/7613/changes#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R73) of protobuf to 7.35.0, going back to the original 6.33.6. If there was a reason Dependabot upgraded and not just to keep us on the newest version, please speak up.

## 🧪 How is this patch tested? If it is not, please explain why.

TBD

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes
- [x] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the bundled dependency versions for the multimodal packaging to improve compatibility and consistency.
  * Refreshed the extras configuration by introducing a dedicated `multimodal-mcap` extra that pins the protobuf version, while making the `multimodal` extra act as a metapackage that pulls it in automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3078
<!-- enterprise-sync-pr:end -->