### PR TITLE
Run CI steps in parallel

### DIFF
--- a/.github/workflows/build-db.yml
+++ b/.github/workflows/build-db.yml
@@ -86,14 +86,18 @@ jobs:
       - name: Clone fiftyone
         uses: actions/checkout@v6
       - name: Download fiftyone-db
+        id: download-fiftyone-db
         uses: actions/download-artifact@v8
         with:
           name: dist-sdist
           path: downloads
+        background: true
       - name: Set up Python 3.10
         uses: actions/setup-python@v6
         with:
           python-version: "3.10"
+      - name: Wait for fiftyone-db
+        wait: download-fiftyone-db
       - name: Install fiftyone-db
         run: |
           pip install downloads/fiftyone_db-*.tar.gz

--- a/.github/workflows/build-docker-internal.yml
+++ b/.github/workflows/build-docker-internal.yml
@@ -27,10 +27,12 @@ jobs:
       - name: Clone fiftyone
         uses: actions/checkout@v6
       - name: Download dist
+        id: download-dist
         uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
+        background: true
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v3
         with:
@@ -52,6 +54,8 @@ jobs:
           echo "today=$(date +%Y%m%d)" >> "$GITHUB_ENV"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+      - name: Wait for dist
+        wait: download-dist
       - name: Build and push internal image
         uses: docker/build-push-action@v7
         with:

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -115,6 +115,7 @@ jobs:
           python -Im build
           pip install ./dist/*.whl
       - name: Install
+        id: install-docs-dependencies
         run: |
           echo "Installing system dependencies"
           sudo apt-get install pandoc
@@ -124,6 +125,7 @@ jobs:
           pip install fiftyone-brain fiftyone-db
           echo "Installing fiftyone"
           pip install .
+        background: true
 
       - name: Setup node 22
         uses: actions/setup-node@v6
@@ -146,6 +148,8 @@ jobs:
       - name: Install app
         if: steps.node-cache.outputs.cache-hit != 'true'
         run: cd app && yarn install
+      - name: Wait for docs dependencies
+        wait: install-docs-dependencies
       - name: Build docs
         run: |
           ./docs/generate_docs.bash -t fiftyone-teams
@@ -165,16 +169,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download docs
+        id: download-docs
         uses: actions/download-artifact@v8
         with:
           name: docs
           path: docs-download/
+        background: true
       - name: Authorize gcloud
         uses: google-github-actions/auth@v3
         with:
           credentials_json: "${{ secrets.DOCS_GCP_CREDENTIALS }}"
       - name: Set up gcloud
         uses: google-github-actions/setup-gcloud@v3
+      - name: Wait for docs
+        wait: download-docs
       - name: publish
         run: gsutil -m rsync -dR -x '^SBOMs/.*' docs-download gs://docs.voxel51.com
 
@@ -186,15 +194,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download docs
+        id: download-docs
         uses: actions/download-artifact@v8
         with:
           name: docs
           path: docs-download/
+        background: true
       - name: Authorize gcloud
         uses: google-github-actions/auth@v3
         with:
           credentials_json: "${{ secrets.DOCS_GCP_CREDENTIALS }}"
       - name: Set up gcloud
         uses: google-github-actions/setup-gcloud@v3
+      - name: Wait for docs
+        wait: download-docs
       - name: publish
         run: gsutil -m rsync -dR -x '^robots.txt' docs-download gs://docs.dev.voxel51.com

--- a/.github/workflows/build-graphql.yml
+++ b/.github/workflows/build-graphql.yml
@@ -45,9 +45,11 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/db-v')
     steps:
       - name: Download wheels
+        id: download-wheels
         uses: actions/download-artifact@v8
         with:
           path: downloads
+        background: true
       - name: Install dependencies
         run: |
           pip install twine
@@ -57,6 +59,8 @@ jobs:
         run: |
           echo "TWINE_PASSWORD=${{ secrets.FIFTYONE_PYPI_TOKEN }}" >> $GITHUB_ENV
           echo "TWINE_REPOSITORY=pypi" >> $GITHUB_ENV
+      - name: Wait for wheels
+        wait: download-wheels
       - name: Upload to pypi
         env:
           TWINE_USERNAME: __token__

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,7 @@ jobs:
         with:
           path: fiftyone/server/static
           key: app-static-${{ runner.os }}-${{ steps.app-tree-hash.outputs.hash }}
+        background: true
 
       - name: Cache Node Modules
         id: node-cache
@@ -63,6 +64,10 @@ jobs:
             app/node_modules
             app/.yarn/cache
           key: node-modules-${{ hashFiles('app/yarn.lock') }}
+        background: true
+
+      - name: Wait for caches
+        wait: [app-static-cache, node-cache]
       - name: Install app
         if: steps.app-static-cache.outputs.cache-hit != 'true' && steps.node-cache.outputs.cache-hit != 'true'
         run: cd app && yarn install

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -53,8 +53,9 @@ jobs:
         with:
           path: fiftyone/server/static
           key: app-static-${{ runner.os }}-${{ steps.app-tree-hash.outputs.hash }}
+        background: true
 
-      - name: Cache Node Modules
+      - name: Cache app Node Modules
         id: app-node-cache
         uses: actions/cache@v5
         with:
@@ -62,25 +63,7 @@ jobs:
             app/node_modules
             app/.yarn/cache
           key: node-modules-${{ hashFiles('app/yarn.lock') }}
-
-      - name: Install app
-        if: steps.app-static-cache.outputs.cache-hit != 'true' && steps.app-node-cache.outputs.cache-hit != 'true'
-        run: yarn install
-        working-directory: app
-
-      - name: Build app
-        if: steps.app-static-cache.outputs.cache-hit != 'true'
-        run: make app
-
-      - name: Bundle built app static assets
-        run: tar -czf e2e-app-static.tgz fiftyone/server/static
-
-      - name: Upload built app static assets
-        uses: actions/upload-artifact@v7
-        with:
-          name: e2e-app-static
-          path: e2e-app-static.tgz
-          retention-days: 1
+        background: true
 
       - name: Cache E2E Node Modules
         id: e2e-node-cache
@@ -89,6 +72,21 @@ jobs:
           path: |
             e2e-pw/node_modules
           key: node-modules-${{ hashFiles('e2e-pw/yarn.lock') }}
+        background: true
+
+      - name: Wait for dependency caches
+        wait: [app-static-cache, app-node-cache, e2e-node-cache]
+
+      - name: Install app
+        if: steps.app-static-cache.outputs.cache-hit != 'true' && steps.app-node-cache.outputs.cache-hit != 'true'
+        run: yarn install
+        working-directory: app
+
+      - name: Build app
+        id: build-app
+        if: steps.app-static-cache.outputs.cache-hit != 'true'
+        run: make app
+        background: true
 
       - name: Install E2E dependencies if not cached
         run: yarn install
@@ -112,6 +110,20 @@ jobs:
         run: yarn playwright install chromium
         if: steps.playwright-browser-cache.outputs.cache-hit != 'true'
         working-directory: e2e-pw
+
+      - name: Wait for app build
+        if: steps.app-static-cache.outputs.cache-hit != 'true'
+        wait: build-app
+
+      - name: Bundle built app static assets
+        run: tar -czf e2e-app-static.tgz fiftyone/server/static
+
+      - name: Upload built app static assets
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-app-static
+          path: e2e-app-static.tgz
+          retention-days: 1
 
   test-e2e:
     needs: prepare-e2e
@@ -211,22 +223,17 @@ jobs:
         uses: jlumbroso/free-disk-space@v1.3.1
         with:
           large-packages: false # e2e test failed when `true`
-      - name: Install requirements
+      - name: Install Python dependencies
+        id: install-python-dependencies
         run: |
           uv pip install --system -r requirements/e2e.txt
-
-      - name: Install fiftyone
-        run: |
           uv pip install --system '.[multimodal]' -r requirements/e2e.txt
-
-      - name: Configure
-        id: test_config
-        run: |
-          python tests/utils/setup_config.py
-          python tests/utils/github_actions_flags.py
+        background: true
 
       - name: Setup FFmpeg
+        id: setup-ffmpeg
         uses: ./.github/actions/setup-ffmpeg
+        background: true
 
       - name: Cache E2E Node Modules
         id: e2e-node-cache
@@ -258,6 +265,18 @@ jobs:
         run: yarn playwright install chromium
         if: steps.playwright-browser-cache.outputs.cache-hit != 'true'
         working-directory: e2e-pw
+
+      - name: Wait for Python dependencies
+        wait: install-python-dependencies
+
+      - name: Configure
+        id: test_config
+        run: |
+          python tests/utils/setup_config.py
+          python tests/utils/github_actions_flags.py
+
+      - name: Wait for FFmpeg
+        wait: setup-ffmpeg
 
       - name: Run Playwright tests
         run: yarn e2e --shard=${{ matrix.shard }}/4

--- a/.github/workflows/lint-app.yml
+++ b/.github/workflows/lint-app.yml
@@ -39,18 +39,19 @@ jobs:
         if: steps.node-cache.outputs.cache-hit != 'true'
         run: cd app && yarn install
 
-      - name: Lint ESLint packages
-        run: |
-          cd app
-          ESLINT_PACKAGES=$(grep -v '^#' ./eslint-packages.txt | xargs)
-          yarn eslint $ESLINT_PACKAGES
+      - parallel:
+          - name: Lint ESLint packages
+            run: |
+              cd app
+              ESLINT_PACKAGES=$(grep -v '^#' ./eslint-packages.txt | xargs)
+              yarn eslint $ESLINT_PACKAGES
 
-      - name: Check formatting
-        run: |
-          cd app
-          yarn format:check
+          - name: Check formatting
+            run: |
+              cd app
+              yarn format:check
 
-      - name: Check multimodal package
-        run: |
-          cd app
-          yarn check
+          - name: Check multimodal package
+            run: |
+              cd app
+              yarn check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,6 +85,10 @@ jobs:
         uses: jlumbroso/free-disk-space@v1.3.1
         with:
           large-packages: false # e2e test failed when `true`
+      - name: Setup FFmpeg
+        id: setup-ffmpeg
+        uses: ./.github/actions/setup-ffmpeg
+        background: true
       - name: Install requirements
         run: |
           uv pip install --system -U wheel setuptools
@@ -98,8 +102,8 @@ jobs:
           python tests/utils/setup_config.py
           python tests/utils/github_actions_flags.py
 
-      - name: Setup FFmpeg
-        uses: ./.github/actions/setup-ffmpeg
+      - name: Wait for FFmpeg
+        wait: setup-ffmpeg
 
       # Important: use pytest_wrapper.py instead of pytest directly to ensure
       # that services shut down cleanly and do not conflict with steps later in

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -44,6 +44,10 @@ jobs:
             requirements/common.txt
             requirements/github.txt
             requirements/test.txt
+      - name: Setup FFmpeg
+        id: setup-ffmpeg
+        uses: ./.github/actions/setup-ffmpeg
+        background: true
       - name: Install requirements
         run: |
           uv pip install --system -U wheel setuptools
@@ -57,8 +61,8 @@ jobs:
           python tests/utils/setup_config.py
           python tests/utils/github_actions_flags.py
 
-      - name: Setup FFmpeg
-        uses: ./.github/actions/setup-ffmpeg
+      - name: Wait for FFmpeg
+        wait: setup-ffmpeg
 
       # Important: use pytest_wrapper.py instead of pytest directly to ensure
       # that services shut down cleanly and do not conflict with steps later in


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

Use GitHub Actions step-level parallelism for independent CI setup, build, lint, artifact, and publish preparation steps. This follows the documented `parallel`, `background`, and `wait` syntax from GitHub Actions.

The only `parallel:` group is the self-contained app lint/check block, where no individual step outputs are consumed. Places that need individual outputs, such as cache-hit checks, use explicit `background: true` steps plus `wait` before the first consumer.

## 🧪 How is this patch tested? If it is not, please explain why.

- `ruby -ryaml -e "ARGV.each { |p| YAML.load_file(p); puts \"#{p}: ok\" }" .github/workflows/*.yml`
- `git diff --check origin/develop...HEAD`
- Full CI was forced once on this PR and verified the regular build/lint/test/e2e/windows jobs could run for the branch before the temporary forcing workflow was removed.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

N/A

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [x] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3083
<!-- enterprise-sync-pr:end -->