### PR TITLE
fix(video-annotation): window label fetching for long videos

### DIFF
--- a/app/packages/video-annotation/src/components/FrameLabels.tsx
+++ b/app/packages/video-annotation/src/components/FrameLabels.tsx
@@ -5,7 +5,7 @@ import {
 } from "@fiftyone/annotation";
 import { getLabelColorFromContext } from "@fiftyone/lighter";
 import type { ModalSample } from "@fiftyone/state";
-import type { LabelData, Stage } from "@fiftyone/utilities";
+import type { Stage } from "@fiftyone/utilities";
 import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import {
   useActiveDetectionField,
@@ -20,6 +20,7 @@ import {
   useVisibleLabelSchemas,
 } from "../state/accessors";
 import { useEngineTemporalSample } from "../sync/useTemporalOverlaySync";
+import { useDriveLabelsStream } from "../hooks/useDriveLabelsStream";
 import { useWarmupThenSeek } from "../hooks/useWarmupThenSeek";
 import {
   TimelineWithTracks,
@@ -38,7 +39,7 @@ import {
   objectTrackClassOf,
   objectTrackPathOf,
   parseSubTrackId,
-  type FrameOverlay,
+  readEngineOverlay,
   type PerInstanceLabel,
 } from "../tracks/frameTracks";
 import { useVideoLabelsIndex } from "../hooks/useVideoLabelsIndex";
@@ -227,6 +228,11 @@ const FrameLabelsRegistration: React.FC<FrameLabelsRegistrationProps> = ({
 
   usePlaybackStream(streamRef.current);
 
+  // Subscribe the labels stream so the playback engine actually drives it (its
+  // `prefetch` per playhead move, gated on label readiness for image sync) —
+  // registration alone leaves it dormant.
+  useDriveLabelsStream();
+
   // Publish so consumers above the surface reach it via useFrameLabelsStream.
   usePublishFrameLabelsStream(streamRef.current);
 
@@ -325,30 +331,6 @@ function useFrameDerivedTracks(
   ]);
 
   return { tracks, resolved: loaded };
-}
-
-/**
- * The engine's materialized frames + their live labels, keyed by frame number —
- * the overlay that shadows the server index. Reads every loaded frame, not just
- * the dirty set: a successful autosave folds edits into the seed and clears the
- * dirty set, so a dirty-only overlay would revert the timeline to the stale
- * index after each save. The engine is authoritative for every frame it holds,
- * so overlaying all of them keeps the timeline correct post-save and composes
- * index (unloaded) ⊕ engine (loaded window) once the seed is windowed. Bounded
- * by the loaded window, which today is the whole clip (see `warmupAll`).
- */
-function readEngineOverlay(
-  engine: ReturnType<typeof useAnnotationEngine>,
-  sample: string,
-  path: string,
-): FrameOverlay {
-  const overlay: FrameOverlay = new Map<number, LabelData[]>();
-
-  for (const frame of engine.loadedFrames(sample)) {
-    overlay.set(frame, engine.listLabels({ sample, path, frame }));
-  }
-
-  return overlay;
 }
 
 /**

--- a/app/packages/video-annotation/src/hooks/useAutoInterpolate.test.ts
+++ b/app/packages/video-annotation/src/hooks/useAutoInterpolate.test.ts
@@ -1,10 +1,16 @@
 /**
  * Copyright 2017-2026, Voxel51, Inc.
  *
- * Tests for the synchronous, field-aware `useAutoInterpolate` handler: the
- * bracketing re-lerp (delegated to `useVideoPropagate`, carrying the changed
- * field path + the edit's undo key) and the Case C tail step-hold (geometry
- * held forward over the trailing filler when the LAST keyframe is edited).
+ * Tests for the field-aware `useAutoInterpolate` handler: the bracketing
+ * re-lerp (delegated to `useVideoPropagate`, carrying the changed field path +
+ * the edit's undo key) and the Case C tail step-hold (geometry held forward
+ * over the trailing filler when the LAST keyframe is edited).
+ *
+ * The keyframe/presence layout is derived from the server index ⊕ the engine's
+ * edited-frame overlay (no whole-clip walk); here the index is empty and the
+ * overlay (every loaded frame's labels) supplies the whole track — exercising a
+ * freshly-loaded track. Box geometry is read via `engine.getLabel` after the
+ * affected range is fetched.
  */
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -14,13 +20,19 @@ const {
   propagate,
   updateLabel,
   transaction,
+  fetchRange,
   getLabelImpl,
 } = vi.hoisted(() => ({
-  annotationHandlers: new Map<string, (payload: unknown) => void>(),
+  annotationHandlers: new Map<
+    string,
+    (payload: unknown) => void | Promise<void>
+  >(),
   propagate: vi.fn(),
   updateLabel: vi.fn(),
   transaction: vi.fn((fn: () => void) => fn()),
-  // Mutable so individual tests swap in their own label table.
+  fetchRange: vi.fn(async () => {}),
+  // Mutable so individual tests swap in their own label table. Drives both the
+  // overlay (presence + keyframe layout) and the geometry reads.
   getLabelImpl: {
     current: ({ frame }: { frame: number }) =>
       frame === 1 || frame === 3 ? { keyframe: true } : null,
@@ -31,28 +43,52 @@ const {
   },
 }));
 
+const { streamRef } = vi.hoisted(() => ({
+  streamRef: {
+    current: {
+      labelsField: "detections",
+      totalFrames: 3,
+      fetchRange,
+    } as unknown,
+  },
+}));
+
+// The overlay reads every loaded frame; `totalFrames` bounds the loaded set.
+const loadedCount = (): number =>
+  (streamRef.current as { totalFrames?: number } | null)?.totalFrames ?? 0;
+
 vi.mock("@fiftyone/annotation", () => ({
   useAnnotationEventHandler: (
     event: string,
-    cb: (payload: unknown) => void,
+    cb: (payload: unknown) => void | Promise<void>,
   ) => {
     annotationHandlers.set(event, cb);
   },
   useAnnotationEngine: () => ({
     getLabel: (args: { frame: number }) => getLabelImpl.current(args),
+    loadedFrames: () => Array.from({ length: loadedCount() }, (_, i) => i + 1),
+    // The overlay tags each label with the instance id so the layout merge
+    // attributes it to "i1"; absent frames contribute no label.
+    listLabels: ({ frame }: { frame: number }) => {
+      const label = getLabelImpl.current({ frame });
+      return label ? [{ ...label, _id: "i1" }] : [];
+    },
   }),
   useActiveSampleId: () => "sample-1",
   useSurfaceActions: () => ({ transaction, updateLabel }),
 }));
 
-const { streamRef } = vi.hoisted(() => ({
-  streamRef: {
-    current: { labelsField: "detections", totalFrames: 3 } as unknown,
-  },
-}));
-
 vi.mock("../streams/frameLabelsStream", () => ({
   useFrameLabelsStream: () => streamRef.current,
+}));
+
+// Empty server index → the layout comes entirely from the engine overlay.
+vi.mock("./useVideoLabelsIndex", () => ({
+  useVideoLabelsIndex: () => ({ indexByPath: {}, loaded: true }),
+}));
+
+vi.mock("../state/accessors", () => ({
+  useFrameLabelFields: () => ({ "frames.detections": "Detections" }),
 }));
 
 vi.mock("./useVideoPropagate", () => ({
@@ -62,14 +98,17 @@ vi.mock("./useVideoPropagate", () => ({
 import { useAutoInterpolate } from "./useAutoInterpolate";
 
 const fireKeyframeChanged = (payload: unknown) =>
-  act(() => annotationHandlers.get("annotation:keyframeChanged")!(payload));
+  act(async () => {
+    await annotationHandlers.get("annotation:keyframeChanged")!(payload);
+  });
 
 beforeEach(() => {
   annotationHandlers.clear();
   propagate.mockReset();
   updateLabel.mockReset();
   transaction.mockClear();
-  streamRef.current = { labelsField: "detections", totalFrames: 3 };
+  fetchRange.mockClear();
+  streamRef.current = { labelsField: "detections", totalFrames: 3, fetchRange };
   getLabelImpl.current = ({ frame }: { frame: number }) =>
     frame === 1 || frame === 3 ? { keyframe: true } : null;
 });
@@ -79,10 +118,10 @@ afterEach(() => {
 });
 
 describe("useAutoInterpolate (re-lerp)", () => {
-  it("re-lerps both bracketing segments on a middle keyframe edit, threading the field path and undo key", () => {
+  it("re-lerps both bracketing segments on a middle keyframe edit, threading the field path and undo key", async () => {
     renderHook(() => useAutoInterpolate());
 
-    fireKeyframeChanged({
+    await fireKeyframeChanged({
       trackId: "t1",
       instanceId: "i1",
       frame: 2,
@@ -114,10 +153,10 @@ describe("useAutoInterpolate (re-lerp)", () => {
     expect(updateLabel).not.toHaveBeenCalled();
   });
 
-  it("falls back to the primary field path when the payload omits one", () => {
+  it("falls back to the primary field path when the payload omits one", async () => {
     renderHook(() => useAutoInterpolate());
 
-    fireKeyframeChanged({
+    await fireKeyframeChanged({
       trackId: "t1",
       instanceId: "i1",
       frame: 2,
@@ -135,11 +174,11 @@ describe("useAutoInterpolate (re-lerp)", () => {
     );
   });
 
-  it("is a no-op without a stream", () => {
+  it("is a no-op without a stream", async () => {
     streamRef.current = null;
     renderHook(() => useAutoInterpolate());
 
-    fireKeyframeChanged({
+    await fireKeyframeChanged({
       trackId: "t1",
       instanceId: "i1",
       frame: 2,
@@ -152,10 +191,14 @@ describe("useAutoInterpolate (re-lerp)", () => {
 });
 
 describe("useAutoInterpolate (Case C — tail step-hold)", () => {
-  it("step-holds non-keyframe filler after the edited last keyframe, coalesced under the edit's undo key", () => {
+  it("step-holds non-keyframe filler after the edited last keyframe, coalesced under the edit's undo key", async () => {
     // 5 frames: keyframes at 1 and 3 (3 is the last keyframe); 4 and 5 are
     // non-keyframe filler with stale geometry.
-    streamRef.current = { labelsField: "detections", totalFrames: 5 };
+    streamRef.current = {
+      labelsField: "detections",
+      totalFrames: 5,
+      fetchRange,
+    };
     getLabelImpl.current = ({ frame }: { frame: number }) => {
       if (frame === 1) return { keyframe: true, bounding_box: [0, 0, 1, 1] };
       if (frame === 3)
@@ -169,7 +212,7 @@ describe("useAutoInterpolate (Case C — tail step-hold)", () => {
 
     renderHook(() => useAutoInterpolate());
 
-    fireKeyframeChanged({
+    await fireKeyframeChanged({
       trackId: "t1",
       instanceId: "i1",
       frame: 3,
@@ -177,6 +220,9 @@ describe("useAutoInterpolate (Case C — tail step-hold)", () => {
       path: "frames.detections",
       undoKey: "g1",
     });
+
+    // The affected span (segment + tail) is fetched before reading geometry.
+    expect(fetchRange).toHaveBeenCalledWith(1, 5);
 
     // Backward bracketing interp (1→3) runs; forward is a no-op (no next KF).
     expect(propagate).toHaveBeenCalledTimes(1);
@@ -206,8 +252,12 @@ describe("useAutoInterpolate (Case C — tail step-hold)", () => {
     });
   });
 
-  it("step-holds all subsequent frames on a single-keyframe track", () => {
-    streamRef.current = { labelsField: "detections", totalFrames: 3 };
+  it("step-holds all subsequent frames on a single-keyframe track", async () => {
+    streamRef.current = {
+      labelsField: "detections",
+      totalFrames: 3,
+      fetchRange,
+    };
     getLabelImpl.current = ({ frame }: { frame: number }) => {
       if (frame === 1)
         return { keyframe: true, bounding_box: [0, 0, 0.5, 0.5] };
@@ -220,7 +270,7 @@ describe("useAutoInterpolate (Case C — tail step-hold)", () => {
 
     renderHook(() => useAutoInterpolate());
 
-    fireKeyframeChanged({
+    await fireKeyframeChanged({
       trackId: "t1",
       instanceId: "i1",
       frame: 1,
@@ -238,9 +288,13 @@ describe("useAutoInterpolate (Case C — tail step-hold)", () => {
     );
   });
 
-  it("does not step-hold a non-detection anchor (no bounding_box)", () => {
+  it("does not step-hold a non-detection anchor (no bounding_box)", async () => {
     // A polyline-style track: keyframe present but no bbox to hold forward.
-    streamRef.current = { labelsField: "polylines", totalFrames: 3 };
+    streamRef.current = {
+      labelsField: "polylines",
+      totalFrames: 3,
+      fetchRange,
+    };
     getLabelImpl.current = ({ frame }: { frame: number }) => {
       if (frame === 1) return { keyframe: true, points: [[0, 0]] } as never;
       if (frame === 2) return { keyframe: false, points: [[1, 1]] } as never;
@@ -249,7 +303,7 @@ describe("useAutoInterpolate (Case C — tail step-hold)", () => {
 
     renderHook(() => useAutoInterpolate());
 
-    fireKeyframeChanged({
+    await fireKeyframeChanged({
       trackId: "t1",
       instanceId: "i1",
       frame: 1,
@@ -260,8 +314,12 @@ describe("useAutoInterpolate (Case C — tail step-hold)", () => {
     expect(updateLabel).not.toHaveBeenCalled();
   });
 
-  it("does not step-hold on a keyframe removal", () => {
-    streamRef.current = { labelsField: "detections", totalFrames: 3 };
+  it("does not step-hold on a keyframe removal", async () => {
+    streamRef.current = {
+      labelsField: "detections",
+      totalFrames: 3,
+      fetchRange,
+    };
     getLabelImpl.current = ({ frame }: { frame: number }) => {
       if (frame === 1) return { keyframe: true, bounding_box: [0, 0, 1, 1] };
       if (frame === 2)
@@ -271,7 +329,7 @@ describe("useAutoInterpolate (Case C — tail step-hold)", () => {
 
     renderHook(() => useAutoInterpolate());
 
-    fireKeyframeChanged({
+    await fireKeyframeChanged({
       trackId: "t1",
       instanceId: "i1",
       frame: 1,

--- a/app/packages/video-annotation/src/hooks/useAutoInterpolate.ts
+++ b/app/packages/video-annotation/src/hooks/useAutoInterpolate.ts
@@ -4,8 +4,14 @@ import {
   useAnnotationEventHandler,
   useSurfaceActions,
 } from "@fiftyone/annotation";
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { useFrameLabelsStream } from "../streams/frameLabelsStream";
+import { useVideoLabelsIndex } from "./useVideoLabelsIndex";
+import { useFrameLabelFields } from "../state/accessors";
+import {
+  readEngineOverlay,
+  resolveInstanceFrameLayout,
+} from "../tracks/frameTracks";
 import { useVideoPropagate } from "./useVideoPropagate";
 
 const SURFACE = "video";
@@ -55,10 +61,13 @@ export function resolveSegmentsToRepropagate(
  * Subscribe to `annotation:keyframeChanged` and re-propagate (linear) each
  * in-between segment that needs re-lerping against the new keyframe layout.
  *
- * Keyframe frames are read from the engine, so the layout reflects the edit
- * that just fired the event. Mount once inside the surface; a no-op until a
- * stream is published
- * (it supplies the field path / frame count) and an instance is identified.
+ * The keyframe/presence layout is read from the server index (`keyframes` is a
+ * first-class field there) merged with the engine's edited-frame overlay, so
+ * the layout reflects the edit that just fired the event WITHOUT walking the
+ * clip. Only the affected span's box geometry is then fetched on demand — the
+ * index carries no payloads. Mount once inside the surface; a no-op until a
+ * stream is published (it supplies the field path) and an instance is
+ * identified.
  */
 export const useAutoInterpolate = (): void => {
   const engine = useAnnotationEngine();
@@ -67,10 +76,16 @@ export const useAutoInterpolate = (): void => {
   const propagate = useVideoPropagate();
   const actions = useSurfaceActions(engine, SURFACE);
 
+  // The presence/keyframe baseline for every active frame field. `keyframes`
+  // rides the index for free, so no dynamic-attribute projection is needed.
+  const frameFields = useFrameLabelFields();
+  const fields = useMemo(() => Object.keys(frameFields), [frameFields]);
+  const { indexByPath } = useVideoLabelsIndex(stream, fields);
+
   useAnnotationEventHandler(
     "annotation:keyframeChanged",
     useCallback(
-      (payload) => {
+      async (payload) => {
         if (!stream) {
           return;
         }
@@ -84,35 +99,46 @@ export const useAutoInterpolate = (): void => {
         // re-lerp on the field the change happened on (a non-primary track,
         // e.g. a polyline, re-lerps in place); fall back to the primary field
         const path = payload.path ?? `frames.${stream.labelsField}`;
-        const keyframeFrames: number[] = [];
-        // Every frame the instance is present on (keyframe or filler). The tail
-        // step-hold below walks the trailing filler.
-        const presentFrames: number[] = [];
 
-        for (let f = 1; f <= stream.totalFrames; f++) {
-          const det = engine.getLabel({
-            sample: sampleId,
-            path,
-            instanceId,
-            frame: f,
-          });
-
-          if (!det) {
-            continue;
-          }
-
-          presentFrames.push(f);
-
-          if (det.keyframe) {
-            keyframeFrames.push(f);
-          }
-        }
+        // Keyframe + presence frames from the index baseline ⊕ the engine's
+        // edited-frame overlay — the payload-free layout, no whole-clip walk.
+        const { keyframeFrames, presentFrames } = resolveInstanceFrameLayout(
+          indexByPath[path] ?? [],
+          readEngineOverlay(engine, sampleId, path),
+          instanceId,
+        );
 
         const segments = resolveSegmentsToRepropagate(
           keyframeFrames,
           frame,
           kind,
         );
+
+        // The tail step-hold (Case C below) walks the trailing filler when the
+        // LAST keyframe is edited — empty otherwise. Computed up front so the
+        // on-demand fetch covers it.
+        const hasNextKeyframe = keyframeFrames.some((kf) => kf > frame);
+        const tailFrames =
+          kind === "set" && !hasNextKeyframe
+            ? presentFrames.filter((f) => f > frame)
+            : [];
+
+        // Fetch only the affected span's box geometry: the segment endpoints the
+        // re-lerp reads, the in-between filler it overwrites, and the tail filler
+        // the step-hold rewrites. The index gave us the layout for free — the
+        // boxes are the one thing it doesn't carry.
+        let lo = frame;
+        let hi = frame;
+        for (const [from, to] of segments) {
+          lo = Math.min(lo, from);
+          hi = Math.max(hi, to);
+        }
+
+        if (tailFrames.length > 0) {
+          hi = Math.max(hi, tailFrames[tailFrames.length - 1]);
+        }
+
+        await stream.fetchRange(lo, hi);
 
         // Re-lerp under the triggering edit's gesture key (when present) so
         // each segment coalesces into that edit's single undo unit, on the
@@ -130,51 +156,46 @@ export const useAutoInterpolate = (): void => {
         // Step-hold the edited keyframe's box forward over that filler,
         // coalesced into the edit's undo unit. Detections only — a keyframe is a
         // bbox concern (mirrors the guard in `useKeyframePromotionOnEdit`).
-        if (kind === "set") {
-          const anchor = engine.getLabel({
-            sample: sampleId,
-            path,
-            instanceId,
-            frame,
-          });
-          const hasNextKeyframe = keyframeFrames.some((kf) => kf > frame);
+        if (tailFrames.length === 0) {
+          return;
+        }
 
-          if (
-            anchor &&
-            Array.isArray(anchor.bounding_box) &&
-            !hasNextKeyframe
-          ) {
-            const tailFrames = presentFrames.filter((f) => f > frame);
+        const anchor = engine.getLabel({
+          sample: sampleId,
+          path,
+          instanceId,
+          frame,
+        });
 
-            if (tailFrames.length > 0) {
-              actions.transaction(
-                () => {
-                  for (const tailFrame of tailFrames) {
-                    const existing = engine.getLabel({
-                      sample: sampleId,
-                      path,
-                      instanceId,
-                      frame: tailFrame,
-                    });
+        if (!anchor || !Array.isArray(anchor.bounding_box)) {
+          return;
+        }
 
-                    // Only overwrite filler — never a real keyframe in the tail.
-                    if (!existing || existing.keyframe === true) {
-                      continue;
-                    }
+        actions.transaction(
+          () => {
+            for (const tailFrame of tailFrames) {
+              const existing = engine.getLabel({
+                sample: sampleId,
+                path,
+                instanceId,
+                frame: tailFrame,
+              });
 
-                    actions.updateLabel(
-                      { path, instanceId, frame: tailFrame },
-                      { bounding_box: anchor.bounding_box, keyframe: false },
-                    );
-                  }
-                },
-                undoKey ? { undoKey } : undefined,
+              // Only overwrite filler — never a real keyframe in the tail.
+              if (!existing || existing.keyframe === true) {
+                continue;
+              }
+
+              actions.updateLabel(
+                { path, instanceId, frame: tailFrame },
+                { bounding_box: anchor.bounding_box, keyframe: false },
               );
             }
-          }
-        }
+          },
+          undoKey ? { undoKey } : undefined,
+        );
       },
-      [engine, sampleId, stream, propagate, actions],
+      [engine, sampleId, stream, propagate, actions, indexByPath],
     ),
   );
 };

--- a/app/packages/video-annotation/src/hooks/useDriveLabelsStream.test.ts
+++ b/app/packages/video-annotation/src/hooks/useDriveLabelsStream.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ *
+ * The labels stream must be SUBSCRIBED into the playback engine, not merely
+ * registered — only a subscriber makes the engine drive a stream's `prefetch`.
+ * Registration without subscription was the regression where labels stopped
+ * fetching past the first window.
+ */
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { subscribeStream, unsubscribe } = vi.hoisted(() => {
+  const unsubscribe = vi.fn();
+  return { subscribeStream: vi.fn(() => unsubscribe), unsubscribe };
+});
+
+vi.mock("@fiftyone/playback", () => ({
+  usePlayback: () => ({ subscribeStream }),
+}));
+
+import { LABELS_STREAM_ID } from "../utils/ids";
+import { useDriveLabelsStream } from "./useDriveLabelsStream";
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useDriveLabelsStream", () => {
+  it("subscribes the labels stream on mount so the engine drives its prefetch", () => {
+    renderHook(() => useDriveLabelsStream());
+
+    expect(subscribeStream).toHaveBeenCalledTimes(1);
+    expect(subscribeStream).toHaveBeenCalledWith(LABELS_STREAM_ID);
+  });
+
+  it("unsubscribes on unmount", () => {
+    const { unmount } = renderHook(() => useDriveLabelsStream());
+
+    expect(unsubscribe).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/packages/video-annotation/src/hooks/useDriveLabelsStream.ts
+++ b/app/packages/video-annotation/src/hooks/useDriveLabelsStream.ts
@@ -1,0 +1,23 @@
+import { usePlayback } from "@fiftyone/playback";
+import { useEffect } from "react";
+import { LABELS_STREAM_ID } from "../utils/ids";
+
+/**
+ * Subscribe the frame-labels stream into the playback engine's barrier loop.
+ *
+ * Registration (`usePlaybackStream`) alone leaves a stream dormant — the engine
+ * only drives streams that have at least one subscriber. Subscribing here makes
+ * the (blocking) labels stream active, so the engine calls its `prefetch` for
+ * the lookahead window as the playhead moves (play / scrub / seek) and gates
+ * the commit on label readiness — keeping labels frame-synced with the image
+ * stream.
+ *
+ * Subscribes via the `subscribeStream` action rather than `useStream` because
+ * we don't consume the published snapshot (the engine seeds the FrameStore as
+ * chunks land, via `subscribeToEdits`) and don't want a per-frame re-render of
+ * the surface.
+ */
+export const useDriveLabelsStream = (): void => {
+  const { subscribeStream } = usePlayback();
+  useEffect(() => subscribeStream(LABELS_STREAM_ID), [subscribeStream]);
+};

--- a/app/packages/video-annotation/src/hooks/useSyncAnnotationVideoStore.ts
+++ b/app/packages/video-annotation/src/hooks/useSyncAnnotationVideoStore.ts
@@ -82,10 +82,10 @@ export const useSyncAnnotationVideoStore = (): void => {
     }
     carry.current = null;
 
-    // Whole-clip seed for engine consumers that still walk every frame
-    // (propagation, interpolation, track ops). The timeline no longer needs
-    // it — it reads the server index. Retire once those ops fetch per-range.
-    void stream.warmupAll();
+    // No whole-clip warmup. The timeline reads the server index; the canvas
+    // reads the playback-driven prefetch window; and re-interpolation fetches
+    // only its affected range on demand (see `useAutoInterpolate`). Seeding
+    // every frame here was the long-video first-load stall.
 
     return () => {
       // Carry unsaved edits to the next FrameStore (this same hook stays

--- a/app/packages/video-annotation/src/streams/VideoFrameLabelsStream.test.ts
+++ b/app/packages/video-annotation/src/streams/VideoFrameLabelsStream.test.ts
@@ -123,6 +123,21 @@ describe("VideoFrameLabelsStream fetchRange", () => {
     expect(startsSince(n)).toEqual([11]);
   });
 
+  it("does not skip frames past an unaligned in-flight chunk", async () => {
+    const n = windowMock.mock.calls.length;
+    const stream = chunked(10, 100);
+
+    // Start an unaligned chunk covering frames 6..15, then ask for 1..20.
+    // The reused 6..15 promise only covers through 15, so the range walk must
+    // still fetch the 16..20 tail rather than striding past it.
+    // @ts-expect-error — test-only: drive the private chunk fetch
+    void stream.fetchChunk(6);
+    await stream.fetchRange(1, 20);
+
+    // Chunks: the pre-existing 6..15, plus 1..10 and 16..20 from the range.
+    expect(startsSince(n)).toEqual([1, 6, 16]);
+  });
+
   it("is a no-op when the range is empty after clamping", async () => {
     const n = windowMock.mock.calls.length;
     await chunked(10).fetchRange(50, 40);

--- a/app/packages/video-annotation/src/streams/VideoFrameLabelsStream.test.ts
+++ b/app/packages/video-annotation/src/streams/VideoFrameLabelsStream.test.ts
@@ -1,8 +1,20 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   resolveSyntheticId,
   VideoFrameLabelsStream,
 } from "./VideoFrameLabelsStream";
+import { getVideoLabelsWindow } from "../../../core/src/client/videoLabelsClient";
+
+vi.mock("../../../core/src/client/videoLabelsClient", () => ({
+  getVideoLabelsWindow: vi.fn(
+    async (req: { startFrame: number; endFrame: number }) => ({
+      frames: {},
+      range: [req.startFrame, req.endFrame],
+    }),
+  ),
+}));
+
+const windowMock = vi.mocked(getVideoLabelsWindow);
 
 function buildStream(): VideoFrameLabelsStream {
   return new VideoFrameLabelsStream({
@@ -53,6 +65,81 @@ describe("VideoFrameLabelsStream extractDetections", () => {
     const value = stream.getValue(timeOfFrame(10, 30));
     expect(value?.detections[0].keyframe).toBe(false);
     expect(value?.detections[0].propagation).toBeNull();
+  });
+});
+
+describe("VideoFrameLabelsStream fetchRange", () => {
+  const chunked = (chunkSize: number, frameCount = 100) =>
+    new VideoFrameLabelsStream({
+      id: "test",
+      sampleId: "s",
+      dataset: "d",
+      view: [],
+      frameCount,
+      frameRate: 30,
+      chunkSize,
+    });
+
+  // Chunk start frames of the calls made since `from`. Asserting on call-count
+  // deltas keeps tests independent without `mockClear` between them — clearing
+  // this async module mock spuriously re-invokes its implementation under
+  // vitest.
+  const startsSince = (from: number) =>
+    windowMock.mock.calls
+      .slice(from)
+      .map((c) => c[0].startFrame)
+      .sort((a, b) => a - b);
+
+  it("fetches one chunk per chunk-sized stride across the range", async () => {
+    const n = windowMock.mock.calls.length;
+    await chunked(10).fetchRange(1, 25);
+    // first-missing frames at 1, 11, 21 → three chunk fetches
+    expect(startsSince(n)).toEqual([1, 11, 21]);
+  });
+
+  it("clamps the start to frame 1", async () => {
+    const n = windowMock.mock.calls.length;
+    await chunked(10).fetchRange(-5, 5);
+    expect(startsSince(n)).toEqual([1]);
+    expect(windowMock.mock.calls[n][0].endFrame).toBe(10);
+  });
+
+  it("clamps the end to the clip's frame count", async () => {
+    const n = windowMock.mock.calls.length;
+    await chunked(10, 100).fetchRange(95, 200);
+    expect(startsSince(n)).toEqual([95]);
+    expect(windowMock.mock.calls[n][0].endFrame).toBe(100);
+  });
+
+  it("skips frames already cached", async () => {
+    const n = windowMock.mock.calls.length;
+    const stream = chunked(10);
+    for (let f = 1; f <= 10; f++) {
+      // @ts-expect-error — test-only: pretend frames 1..10 are cached
+      stream.cache.set(f, { frame_number: f });
+    }
+
+    await stream.fetchRange(1, 20);
+    expect(startsSince(n)).toEqual([11]);
+  });
+
+  it("is a no-op when the range is empty after clamping", async () => {
+    const n = windowMock.mock.calls.length;
+    await chunked(10).fetchRange(50, 40);
+    expect(windowMock.mock.calls.length).toBe(n);
+  });
+
+  it("populates the cache from the fetched window", async () => {
+    windowMock.mockResolvedValueOnce({
+      frames: { 3: { detections: { detections: [] } } },
+      range: [1, 10],
+    } as never);
+
+    const stream = chunked(10);
+    await stream.fetchRange(1, 5);
+
+    // Frame 3 landed in the cache → ready at its time.
+    expect(stream.bufferState((3 - 1) / 30)).toBe("ready");
   });
 });
 

--- a/app/packages/video-annotation/src/streams/VideoFrameLabelsStream.ts
+++ b/app/packages/video-annotation/src/streams/VideoFrameLabelsStream.ts
@@ -140,16 +140,22 @@ export class VideoFrameLabelsStream extends PlaybackStreamBase<FrameLabelSnapsho
   }
 
   /**
-   * Resolve once every frame in [1, frameCount] is cached. Coalesces
-   * against any in-flight chunks; otherwise walks the range in chunk-
-   * sized strides and dispatches fetches in parallel. Expensive over long
-   * clips; used for one-shot full-clip analyses (e.g. timeline tracks).
+   * Resolve once every frame in `[startFrame, endFrame]` (inclusive, clamped to
+   * the clip) is cached. Coalesces against in-flight chunks; otherwise walks the
+   * range in chunk-sized strides and dispatches the missing chunks in parallel.
+   *
+   * The bounded fetch an op uses when it needs a known span loaded — e.g.
+   * re-interpolation reading its segment's keyframe endpoints and step-holding
+   * the tail filler — without warming the whole clip.
    */
-  async warmupAll(): Promise<void> {
-    const promises: Promise<void>[] = [];
-    let f = 1;
+  async fetchRange(startFrame: number, endFrame: number): Promise<void> {
+    const start = Math.max(1, startFrame);
+    const end = Math.min(this.frameCount, endFrame);
 
-    while (f <= this.frameCount) {
+    const promises: Promise<void>[] = [];
+    let f = start;
+
+    while (f <= end) {
       if (this.cache.has(f)) {
         f++;
         continue;
@@ -167,6 +173,15 @@ export class VideoFrameLabelsStream extends PlaybackStreamBase<FrameLabelSnapsho
     }
 
     await Promise.all(promises);
+  }
+
+  /**
+   * Resolve once every frame in [1, frameCount] is cached. Expensive over long
+   * clips — prefer {@link fetchRange} for a bounded need. Retained for one-shot
+   * whole-clip analyses.
+   */
+  async warmupAll(): Promise<void> {
+    return this.fetchRange(1, this.frameCount);
   }
 
   /** Total frames in the clip — useful for callers iterating the cache. */

--- a/app/packages/video-annotation/src/streams/VideoFrameLabelsStream.ts
+++ b/app/packages/video-annotation/src/streams/VideoFrameLabelsStream.ts
@@ -152,7 +152,7 @@ export class VideoFrameLabelsStream extends PlaybackStreamBase<FrameLabelSnapsho
     const start = Math.max(1, startFrame);
     const end = Math.min(this.frameCount, endFrame);
 
-    const promises: Promise<void>[] = [];
+    const promises = new Set<Promise<void>>();
     let f = start;
 
     while (f <= end) {
@@ -161,14 +161,20 @@ export class VideoFrameLabelsStream extends PlaybackStreamBase<FrameLabelSnapsho
         continue;
       }
 
+      // Reuse an in-flight chunk, but only skip the frames it actually covers:
+      // chunks can begin at arbitrary frames (prefetch, an overlapping
+      // fetchRange), so striding a full chunkSize past an unaligned promise
+      // would jump over frames it never loaded and resolve with a gap.
       const inflight = this.inflight.get(f);
       if (inflight) {
-        promises.push(inflight);
-        f += this.chunkSize;
+        promises.add(inflight);
+        do {
+          f++;
+        } while (f <= end && this.inflight.get(f) === inflight);
         continue;
       }
 
-      promises.push(this.fetchChunk(f));
+      promises.add(this.fetchChunk(f));
       f += this.chunkSize;
     }
 

--- a/app/packages/video-annotation/src/tracks/frameTracks.test.ts
+++ b/app/packages/video-annotation/src/tracks/frameTracks.test.ts
@@ -3,9 +3,14 @@ import { describe, expect, it, vi } from "vitest";
 import {
   buildPerInstanceTracks,
   parseSubTrackId,
+  readEngineOverlay,
+  resolveInstanceFrameLayout,
   segmentAttribute,
   subTrackId,
   type FrameLabelReader,
+  type FrameOverlay,
+  type FrameOverlayReader,
+  type IndexInstance,
   type PerInstanceLabel,
 } from "./frameTracks";
 
@@ -325,5 +330,99 @@ describe("buildPerInstanceTracks dynamic-attribute sub-tracks", () => {
 
     expect(tracks).toHaveLength(1);
     expect(parseSubTrackId(tracks[0].id)).toBeNull();
+  });
+});
+
+describe("readEngineOverlay", () => {
+  it("maps every loaded frame to its labels", () => {
+    const engine: FrameOverlayReader = {
+      loadedFrames: () => [1, 3],
+      listLabels: ({ frame }) =>
+        frame === 1
+          ? ([{ _id: "i1" }] as LabelData[])
+          : frame === 3
+            ? ([{ _id: "i1", keyframe: true }] as LabelData[])
+            : [],
+    };
+
+    const overlay = readEngineOverlay(engine, SAMPLE, PATH);
+
+    expect([...overlay.keys()]).toEqual([1, 3]);
+    expect(overlay.get(3)).toEqual([{ _id: "i1", keyframe: true }]);
+  });
+});
+
+describe("resolveInstanceFrameLayout", () => {
+  const index: IndexInstance[] = [
+    {
+      instanceId: "i1",
+      classLabel: "car",
+      persistedIndex: 1,
+      instance: null,
+      segments: [[1, 5]],
+      keyframes: [1, 5],
+    },
+  ];
+
+  it("reads presence + keyframes straight from the index when nothing is edited", () => {
+    const { presentFrames, keyframeFrames } = resolveInstanceFrameLayout(
+      index,
+      new Map(),
+      "i1",
+    );
+
+    expect(presentFrames).toEqual([1, 2, 3, 4, 5]);
+    expect(keyframeFrames).toEqual([1, 5]);
+  });
+
+  it("adds an overlay keyframe that isn't in the index baseline", () => {
+    const overlay: FrameOverlay = new Map([
+      [3, [{ _id: "i1", keyframe: true }] as LabelData[]],
+    ]);
+
+    const { keyframeFrames } = resolveInstanceFrameLayout(index, overlay, "i1");
+
+    expect(keyframeFrames).toEqual([1, 3, 5]);
+  });
+
+  it("drops a baseline keyframe the overlay no longer flags", () => {
+    const overlay: FrameOverlay = new Map([
+      [5, [{ _id: "i1", keyframe: false }] as LabelData[]],
+    ]);
+
+    const { keyframeFrames } = resolveInstanceFrameLayout(index, overlay, "i1");
+
+    expect(keyframeFrames).toEqual([1]);
+  });
+
+  it("derives a freshly-drawn instance (absent from the index) from the overlay alone", () => {
+    const overlay: FrameOverlay = new Map([
+      [1, [{ _id: "i2", keyframe: true }] as LabelData[]],
+      [2, [{ _id: "i2", keyframe: false }] as LabelData[]],
+    ]);
+
+    const { presentFrames, keyframeFrames } = resolveInstanceFrameLayout(
+      [],
+      overlay,
+      "i2",
+    );
+
+    expect(presentFrames).toEqual([1, 2]);
+    expect(keyframeFrames).toEqual([1]);
+  });
+
+  it("ignores overlay frames belonging to other instances", () => {
+    const overlay: FrameOverlay = new Map([
+      [8, [{ _id: "other", keyframe: true }] as LabelData[]],
+    ]);
+
+    const { presentFrames, keyframeFrames } = resolveInstanceFrameLayout(
+      index,
+      overlay,
+      "i1",
+    );
+
+    expect(presentFrames).toEqual([1, 2, 3, 4, 5]);
+    expect(keyframeFrames).toEqual([1, 5]);
   });
 });

--- a/app/packages/video-annotation/src/tracks/frameTracks.ts
+++ b/app/packages/video-annotation/src/tracks/frameTracks.ts
@@ -265,6 +265,101 @@ export function buildTracksFromIndex({
   return statesToTracks(states, resolveColor, dynamicAttributes);
 }
 
+/** The engine read surface the overlay reader needs. */
+export type FrameOverlayReader = Pick<
+  AnnotationEngine,
+  "listLabels" | "loadedFrames"
+>;
+
+/**
+ * The engine's materialized frames + their live labels, keyed by frame number —
+ * the overlay that shadows the server index. Reads every loaded frame, not just
+ * the dirty set: a successful autosave folds edits into the seed and clears the
+ * dirty set, so a dirty-only overlay would revert to the stale index after each
+ * save. The engine is authoritative for every frame it holds, so overlaying all
+ * of them keeps the merge correct post-save. Bounded by the loaded window (the
+ * cache is windowed + never evicts, so it covers every frame touched this
+ * session — including every keyframe the user created — atop the index baseline).
+ */
+export function readEngineOverlay(
+  engine: FrameOverlayReader,
+  sample: string,
+  path: string,
+): FrameOverlay {
+  const overlay: FrameOverlay = new Map<number, LabelData[]>();
+
+  for (const frame of engine.loadedFrames(sample)) {
+    overlay.set(frame, engine.listLabels({ sample, path, frame }));
+  }
+
+  return overlay;
+}
+
+/** One instance's whole-clip keyframe + presence frames (1-indexed, ascending). */
+export interface InstanceFrameLayout {
+  /** Every frame the instance is present on. */
+  presentFrames: number[];
+  /** Frames carrying `keyframe: true`. */
+  keyframeFrames: number[];
+}
+
+/**
+ * The instance's keyframe + presence frames from the server index baseline
+ * merged with the engine's dirty-frame overlay — the payload-free layout
+ * re-interpolation needs WITHOUT walking the clip. Keyframes come straight off
+ * the index's `keyframes` (the server already flags them), shadowed by the
+ * overlay at edited frames; presence is the same index ⊕ overlay merge the
+ * timeline uses. Box geometry is NOT here (the index carries none) — fetch the
+ * affected range for that.
+ */
+export function resolveInstanceFrameLayout(
+  index: IndexInstance[],
+  overlay: FrameOverlay,
+  instanceId: string,
+): InstanceFrameLayout {
+  const baseline = index.find((entry) => entry.instanceId === instanceId);
+
+  const dirtySorted = [...overlay.keys()].sort((a, b) => a - b);
+  const dirtySet = new Set(dirtySorted);
+
+  const presentInOverlay: number[] = [];
+  const dirtyKeyframes: number[] = [];
+  for (const frame of dirtySorted) {
+    for (const label of overlay.get(frame) ?? []) {
+      if (addressIdOf(label) !== instanceId) {
+        continue;
+      }
+
+      presentInOverlay.push(frame);
+      if (label.keyframe) {
+        dirtyKeyframes.push(frame);
+      }
+
+      break;
+    }
+  }
+
+  const segments = mergePresence(
+    baseline?.segments ?? [],
+    dirtySorted,
+    presentInOverlay,
+  );
+
+  const presentFrames: number[] = [];
+  for (const [start, end] of segments) {
+    for (let f = start; f <= end; f++) {
+      presentFrames.push(f);
+    }
+  }
+
+  const keyframeFrames = [
+    ...(baseline?.keyframes ?? []).filter((frame) => !dirtySet.has(frame)),
+    ...dirtyKeyframes,
+  ].sort((a, b) => a - b);
+
+  return { presentFrames, keyframeFrames };
+}
+
 /** Shape the accumulated states into sorted, colored timeline tracks. */
 function statesToTracks(
   states: Map<string, InstanceState>,


### PR DESCRIPTION
## Problem

Opening a video on the annotation surface fetched **every** frame's labels up front. On mount the labels stream ran a whole-clip warmup that issued one `POST /video-labels/window` request per 60-frame chunk — ~900 requests for a 30-min / 30fps clip (54k frames) — stalling first load badly on long videos.

## Fix

Make label fetching windowed, driven by playback, the same way the image (`/frames`) stream already works.

**1. Fetch interpolation ranges on demand (no whole-clip warmup).**
- Removed the on-mount `warmupAll()` in `useSyncAnnotationVideoStore`.
- The only consumer that needed the whole clip was auto-reinterpolation, which walked `1..frameCount` to find a track's keyframes/present-frames. It now derives that layout from the server distribution index (which already returns per-instance `segments` + `keyframes`) merged with the engine's edited-frame overlay — no walk — via the new `resolveInstanceFrameLayout` (reusing the timeline's `mergePresence`).
- Box geometry (which the index doesn't carry) is loaded for just the affected segment via a new bounded `VideoFrameLabelsStream.fetchRange(start, end)`.

**2. Drive the labels stream from playback.**
- The labels stream was *registered* with the playback engine but never *subscribed*, so the engine's barrier loop skipped it and never called its `prefetch` — the warmup had been masking this. Added `useDriveLabelsStream` to subscribe it, so as the playhead moves (play / scrub / seek) the engine prefetches the next window and, because the stream is blocking, gates the commit on label readiness — keeping labels frame-synced with the image stream.

Net effect: first load no longer bursts `/video-labels/window`; windows are fetched incrementally as needed, in lockstep with `/frames`.

## Testing

- `video-annotation` unit suite: **228 passing** (+14 new) — `fetchRange` windowing/clamping, `resolveInstanceFrameLayout` + `readEngineOverlay` (index ⊕ overlay), the reworked `useAutoInterpolate`, and `useDriveLabelsStream` subscribe/unsubscribe.
- Type-clean on all changed files.
- Manually verified on synthetic 10-min and 30-min clips: instant first load, `/video-labels/window` fires progressively on play/scrub/seek, and re-interpolation still updates in-between + trailing-filler frames.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a bounded, range-based prefetch API for frame label data, clamping requests to the visible clip span.
  * Introduced playback-driven label streaming so frame labels are loaded on demand and stay in sync while scrubbing.

* **Bug Fixes**
  * Improved auto-interpolation after keyframe edits, including more reliable “tail step-hold” updates.
  * Reduced long-video first-load stalls by removing whole-clip label warmup.

* **Tests**
  * Expanded coverage for label streaming, range prefetching, and auto-interpolation ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->