### PR TITLE
Fix: no-op edited PR events cancel running CI and leave a false green

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,7 +9,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Only cancel an in-progress run when the new run will actually run CI.
+  # A PR title/body edit fires an `edited` event (no base change) that skips
+  # every heavy job; letting it cancel the running suite would leave the PR
+  # falsely green, since `all-tests` treats skipped jobs as a pass.
+  cancel-in-progress: ${{ github.event.action != 'edited' || github.event.changes.base != null }}
 
 jobs:
   modified-files:


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

Makes `concurrency.cancel-in-progress` in `pr.yml` conditional so a no-op `edited` event can't cancel an in-progress CI run.

How a PR goes green with zero tests run:

1. PR opens against `develop`; the heavy suite (`build`/`test`/`e2e`/`lint`) starts.
2. Mid-run the PR title/body is edited — by the author, CodeRabbit (writes its summary into the body), or the enterprise-sync bot (maintains a body section). Each fires a `pull_request: edited` event.
3. The gate treats `edited` with no base change as `run_ci=false`, so the new run skips every heavy job (intended — don't rerun CI for a title typo).
4. But `cancel-in-progress: true` makes that no-op run cancel the still-running real suite.
5. The no-op run's `all-tests` then reports success, because it counts `skipped` jobs as a pass.

Net: the real tests are killed mid-run and replaced by a green check — the PR looks tested when nothing ran.

The fix only changes that one case; pushes and base-retargets still cancel stale runs:

```yaml
cancel-in-progress: ${{ github.event.action != 'edited' || github.event.changes.base != null }}
```

`all-tests`' "skipped = pass" rule is intentionally left alone — it's correct for path-filtered skips (e.g. `test-python` on a TS-only PR). The bug is the cancellation, not the skip semantics.

> `fiftyone-teams/.github/workflows/pr.yml` has the identical block and needs the same fix (separate PR). The related sync-bot-merges-before-CI issue is tracked separately.

## 🧪 How is this patch tested? If it is not, please explain why.

No automated test — this is CI config and concurrency behavior isn't unit-testable. Verified by the expression's truth table:

| event | result |
|---|---|
| push (`synchronize`) | `true` → cancels stale runs (unchanged) |
| title/body edit (`edited`, no base change) | `false` → does **not** cancel the running suite |
| base retarget (`edited` + base changed) | `true` → cancels (correct; it runs heavy) |

Manual repro: open a PR, and while CI is running edit its description — on `develop` today that cancels the suite and shows green; with this change the suite keeps running.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for FiftyOne users.

N/A

### What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes
- [x] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved PR check handling so running CI is no longer always canceled when a new update arrives.
  * Edited-only PR updates now keep existing checks running unless the base branch changes, reducing unnecessary restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3085
<!-- enterprise-sync-pr:end -->