### PR TITLE
Add Mask2Former to the model zoo

### DIFF
--- a/fiftyone/utils/transformers.py
+++ b/fiftyone/utils/transformers.py
@@ -39,6 +39,9 @@ DEFAULT_DEPTH_ESTIMATION_PATH = "Intel/dpt-hybrid-midas"
 DEFAULT_ZERO_SHOT_CLASSIFICATION_PATH = "openai/clip-vit-large-patch14"
 DEFAULT_ZERO_SHOT_DETECTION_PATH = "google/owlvit-base-patch32"
 DEFAULT_POSE_ESTIMATION_PATH = "usyd-community/vitpose-base-simple"
+DEFAULT_UNIVERSAL_SEGMENTATION_PATH = (
+    "facebook/mask2former-swin-tiny-coco-instance"
+)
 
 
 def convert_transformers_model(model, task=None, **kwargs):
@@ -727,7 +730,9 @@ class FiftyOneTransformer(TransformerEmbeddingsMixin, fout.TorchImageModel):
         except AttributeError:
             # AutoProcessor can't resolve the tokenizer for some models; resolve
             # the processor class from the config and load it directly.
-            from transformers.models.auto.processing_auto import PROCESSOR_MAPPING
+            from transformers.models.auto.processing_auto import (
+                PROCESSOR_MAPPING,
+            )
 
             ta = dict(config.transforms_args or {})
             name = ta.pop("pretrained_model_name_or_path", None)
@@ -1137,6 +1142,71 @@ class FiftyOneTransformerForSemanticSegmentation(FiftyOneTransformer):
         # or passing the entire model to the output processor
         self._output_processor.processor = self.transforms.processor
         # ew
+        self.transforms.return_image_sizes = True
+
+
+class FiftyOneTransformerForUniversalSegmentationConfig(
+    FiftyOneTransformerConfig
+):
+    """Configuration for a
+    :class:`FiftyOneTransformerForUniversalSegmentation`.
+
+    Args:
+        model (None): a ``transformers`` model
+        name_or_path (None): the name or path to a checkpoint file to load
+        task ("instance"): segmentation task — ``"semantic"``, ``"instance"``,
+            or ``"panoptic"``
+        output_processor_args (None): optional dict of kwargs forwarded to the
+            output processor constructor, e.g.
+            ``{"mask_threshold": 0.3, "overlap_mask_area_threshold": 0.6}``
+    """
+
+    def __init__(self, d):
+        if (
+            d.get("name_or_path", None) is None
+            and d.get("model", None) is None
+        ):
+            d["name_or_path"] = DEFAULT_UNIVERSAL_SEGMENTATION_PATH
+        super().__init__(d)
+        self.task = self.parse_string(d, "task", default="instance")
+
+
+class FiftyOneTransformerForUniversalSegmentation(FiftyOneTransformer):
+    """FiftyOne wrapper around a ``transformers`` universal segmentation model.
+
+    Supports Mask2Former and similar architectures that handle semantic,
+    instance, and panoptic segmentation through a unified model.  The
+    ``task`` config parameter selects the post-processing path:
+
+    * ``"semantic"``  → :class:`fiftyone.core.labels.Segmentation`
+    * ``"instance"``  → :class:`fiftyone.core.labels.Detections` (with masks)
+    * ``"panoptic"``  → :class:`fiftyone.core.labels.Detections` (with masks)
+
+    Args:
+        config: a
+            :class:`FiftyOneTransformerForUniversalSegmentationConfig`
+    """
+
+    def __init__(self, config):
+        if config.entrypoint_fcn is None:
+            config.entrypoint_fcn = "transformers.AutoModelForUniversalSegmentation.from_pretrained"
+
+        if config.output_processor_cls is None:
+            if config.task == "semantic":
+                config.output_processor_cls = "fiftyone.utils.transformers.TransformersUniversalSemanticSegmentatorOutputProcessor"
+                if config.output_processor_args is None:
+                    config.output_processor_args = {}
+                config.output_processor_args.setdefault(
+                    "no_background_cls", True
+                )
+            else:
+                config.output_processor_cls = "fiftyone.utils.transformers.TransformersUniversalSegmentatorOutputProcessor"
+                if config.output_processor_args is None:
+                    config.output_processor_args = {}
+                config.output_processor_args["task"] = config.task
+
+        super().__init__(config)
+        self._output_processor.processor = self.transforms.processor
         self.transforms.return_image_sizes = True
 
 
@@ -1643,6 +1713,145 @@ class TransformersSemanticSegmentatorOutputProcessor(
         )
 
 
+class TransformersUniversalSemanticSegmentatorOutputProcessor(
+    fout.SemanticSegmenterOutputProcessor
+):
+    """Output processor for universal segmentation models in semantic mode.
+
+    Calls ``post_process_semantic_segmentation`` and returns
+    :class:`fiftyone.core.labels.Segmentation` labels (one per image).
+    """
+
+    def __init__(self, classes=None, no_background_cls=False, **kwargs):
+        super().__init__(classes=classes, no_background_cls=no_background_cls)
+        self._processor = None
+
+    @property
+    def processor(self):
+        return self._processor
+
+    @processor.setter
+    def processor(self, value):
+        self._processor = value
+
+    def __call__(
+        self,
+        output,
+        image_sizes,
+        confidence_thresh=None,
+        classes=None,
+        **kwargs,
+    ):
+        if hasattr(image_sizes, "tolist"):
+            target_sizes = [tuple(sz) for sz in image_sizes.tolist()]
+        else:
+            target_sizes = [tuple(int(x) for x in sz) for sz in image_sizes]
+        seg_maps = self._processor.post_process_semantic_segmentation(
+            output, target_sizes=target_sizes
+        )
+        results = []
+        for m in seg_maps:
+            mask = m.cpu().numpy().astype(np.int16)
+            if self.no_background_cls:
+                mask += 1
+            results.append(fol.Segmentation(mask=mask))
+        return results
+
+
+class TransformersUniversalSegmentatorOutputProcessor(
+    fout.InstanceSegmenterOutputProcessor
+):
+    """Output processor for universal segmentation models in instance/panoptic mode.
+
+    Args:
+        task ("instance"): ``"instance"`` calls
+            ``post_process_instance_segmentation``; ``"panoptic"`` calls
+            ``post_process_panoptic_segmentation``
+        mask_threshold (0.5): mask binarisation threshold
+        overlap_mask_area_threshold (0.8): overlap threshold for mask merging
+    """
+
+    def __init__(
+        self,
+        classes=None,
+        task="instance",
+        mask_threshold=0.5,
+        overlap_mask_area_threshold=0.8,
+        **kwargs,
+    ):
+        self.classes = classes
+        self.task = task
+        self.mask_thresh = mask_threshold
+        self.overlap_mask_area_threshold = overlap_mask_area_threshold
+        self._processor = None
+
+    @property
+    def processor(self):
+        return self._processor
+
+    @processor.setter
+    def processor(self, value):
+        self._processor = value
+
+    def __call__(
+        self,
+        output,
+        image_sizes,
+        confidence_thresh=None,
+        classes=None,
+        **kwargs,
+    ):
+        threshold = confidence_thresh if confidence_thresh is not None else 0.5
+        post_process = (
+            self._processor.post_process_panoptic_segmentation
+            if self.task == "panoptic"
+            else self._processor.post_process_instance_segmentation
+        )
+        if hasattr(image_sizes, "tolist"):
+            target_sizes = [tuple(sz) for sz in image_sizes.tolist()]
+        else:
+            target_sizes = [tuple(int(x) for x in sz) for sz in image_sizes]
+        processed = post_process(
+            output,
+            threshold=threshold,
+            mask_threshold=self.mask_thresh,
+            overlap_mask_area_threshold=self.overlap_mask_area_threshold,
+            target_sizes=target_sizes,
+        )
+        results = []
+        for item in processed:
+            segmentation = item.get("segmentation")
+            segments_info = item.get("segments_info", [])
+            detections = []
+            if segmentation is not None:
+                seg_np = segmentation.cpu().numpy()
+                for seg in segments_info:
+                    score = seg.get("score", 1.0)
+                    if (
+                        confidence_thresh is not None
+                        and score < confidence_thresh
+                    ):
+                        continue
+                    idx = int(seg["label_id"])
+                    label = (
+                        self.classes[idx]
+                        if self.classes is not None and idx < len(self.classes)
+                        else str(idx)
+                    )
+                    if classes is not None and label not in classes:
+                        continue
+                    binary_mask = seg_np == seg["id"]
+                    if not binary_mask.any():
+                        continue
+                    detections.append(
+                        fol.Detection.from_mask(
+                            binary_mask, label=label, confidence=score
+                        )
+                    )
+            results.append(fol.Detections(detections=detections))
+        return results
+
+
 class TransformersDepthEstimatorOutputProcessor(fout.OutputProcessor):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -1775,6 +1984,7 @@ MODEL_TYPE_TO_CONFIG_CLASS = {
     "image-classification": FiftyOneTransformerForImageClassificationConfig,
     "object-detection": FiftyOneTransformerForObjectDetectionConfig,
     "semantic-segmentation": FiftyOneTransformerForSemanticSegmentationConfig,
+    "universal-segmentation": FiftyOneTransformerForUniversalSegmentationConfig,
     "depth-estimation": FiftyOneTransformerForDepthEstimationConfig,
     "zero-shot-image-classification": FiftyOneZeroShotTransformerForImageClassificationConfig,
     "zero-shot-object-detection": FiftyOneZeroShotTransformerForObjectDetectionConfig,
@@ -1787,6 +1997,7 @@ MODEL_TYPE_TO_MODEL_CLASS = {
     "image-classification": FiftyOneTransformerForImageClassification,
     "object-detection": FiftyOneTransformerForObjectDetection,
     "semantic-segmentation": FiftyOneTransformerForSemanticSegmentation,
+    "universal-segmentation": FiftyOneTransformerForUniversalSegmentation,
     "depth-estimation": FiftyOneTransformerForDepthEstimation,
     "zero-shot-image-classification": FiftyOneZeroShotTransformerForImageClassification,
     "zero-shot-object-detection": FiftyOneZeroShotTransformerForObjectDetection,

--- a/fiftyone/utils/transformers.py
+++ b/fiftyone/utils/transformers.py
@@ -1822,22 +1822,25 @@ class TransformersUniversalSegmentatorOutputProcessor(
         **kwargs,
     ):
         threshold = confidence_thresh if confidence_thresh is not None else 0.0
-        post_process = (
-            self._processor.post_process_panoptic_segmentation
-            if self.task == "panoptic"
-            else self._processor.post_process_instance_segmentation
-        )
         if hasattr(image_sizes, "tolist"):
             target_sizes = [tuple(sz) for sz in image_sizes.tolist()]
         else:
             target_sizes = [tuple(int(x) for x in sz) for sz in image_sizes]
-        processed = post_process(
-            output,
+        post_process_kwargs = dict(
             threshold=threshold,
             mask_threshold=self.mask_thresh,
             overlap_mask_area_threshold=self.overlap_mask_area_threshold,
             target_sizes=target_sizes,
         )
+        if self.task == "panoptic":
+            processed = self._processor.post_process_panoptic_segmentation(
+                output, **post_process_kwargs
+            )
+        else:
+            # for instance segmentation, preserve overlapping instances with return_binary_maps set to True.
+            processed = self._processor.post_process_instance_segmentation(
+                output, **post_process_kwargs, return_binary_maps=True
+            )
         results = []
         for item in processed:
             segmentation = item.get("segmentation")
@@ -1845,7 +1848,7 @@ class TransformersUniversalSegmentatorOutputProcessor(
             detections = []
             if segmentation is not None:
                 seg_np = segmentation.cpu().numpy()
-                for seg in segments_info:
+                for i, seg in enumerate(segments_info):
                     score = seg.get("score", 1.0)
                     if (
                         confidence_thresh is not None
@@ -1860,7 +1863,10 @@ class TransformersUniversalSegmentatorOutputProcessor(
                     )
                     if classes is not None and label not in classes:
                         continue
-                    binary_mask = seg_np == seg["id"]
+                    if self.task == "panoptic":
+                        binary_mask = seg_np == seg["id"]
+                    else:
+                        binary_mask = seg_np[i] > 0
                     if not binary_mask.any():
                         continue
                     detections.append(

--- a/fiftyone/utils/transformers.py
+++ b/fiftyone/utils/transformers.py
@@ -107,11 +107,15 @@ def get_model_type(model, task=None):
         "semantic-segmentation",
         "depth-estimation",
         "pose-estimation",
+        "universal-segmentation",
     )
     if task is not None and task not in supported_tasks:
         raise ValueError(
             f"Unknown task: {task}. Valid tasks are {supported_tasks}"
         )
+
+    if task == "universal-segmentation":
+        return "universal-segmentation"
 
     zs = _is_zero_shot_model(model)
 
@@ -1169,6 +1173,11 @@ class FiftyOneTransformerForUniversalSegmentationConfig(
             d["name_or_path"] = DEFAULT_UNIVERSAL_SEGMENTATION_PATH
         super().__init__(d)
         self.task = self.parse_string(d, "task", default="instance")
+        valid_tasks = {"semantic", "instance", "panoptic"}
+        if self.task not in valid_tasks:
+            raise ValueError(
+                f"Invalid task '{self.task}'. Must be one of {sorted(valid_tasks)}"
+            )
 
 
 class FiftyOneTransformerForUniversalSegmentation(FiftyOneTransformer):
@@ -1746,14 +1755,25 @@ class TransformersUniversalSemanticSegmentatorOutputProcessor(
             target_sizes = [tuple(sz) for sz in image_sizes.tolist()]
         else:
             target_sizes = [tuple(int(x) for x in sz) for sz in image_sizes]
+        # confidence_thresh is not applicable to semantic segmentation because
+        # post_process_semantic_segmentation returns a per-pixel argmax with no
+        # associated per-pixel confidence score.
         seg_maps = self._processor.post_process_semantic_segmentation(
             output, target_sizes=target_sizes
         )
+        effective_classes = classes if classes is not None else self.classes
         results = []
         for m in seg_maps:
             mask = m.cpu().numpy().astype(np.int16)
             if self.no_background_cls:
                 mask += 1
+            if effective_classes is not None and self.classes is not None:
+                allowed_indices = {
+                    i + (1 if self.no_background_cls else 0)
+                    for i, c in enumerate(self.classes)
+                    if c in effective_classes
+                }
+                mask = np.where(np.isin(mask, list(allowed_indices)), mask, 0)
             results.append(fol.Segmentation(mask=mask))
         return results
 
@@ -1801,7 +1821,7 @@ class TransformersUniversalSegmentatorOutputProcessor(
         classes=None,
         **kwargs,
     ):
-        threshold = confidence_thresh if confidence_thresh is not None else 0.5
+        threshold = confidence_thresh if confidence_thresh is not None else 0.0
         post_process = (
             self._processor.post_process_panoptic_segmentation
             if self.task == "panoptic"

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -4249,7 +4249,7 @@
             "source": "https://huggingface.co/facebook/mask2former-swin-tiny-coco-instance",
             "author": "Bowen Cheng, et al.",
             "license": "MIT",
-            "size_bytes": 178000000,
+            "size_bytes": 190840832,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.transformers.FiftyOneTransformerForUniversalSegmentation",
                 "config": {
@@ -4276,7 +4276,7 @@
             "source": "https://huggingface.co/facebook/mask2former-swin-small-coco-instance",
             "author": "Bowen Cheng, et al.",
             "license": "MIT",
-            "size_bytes": 270000000,
+            "size_bytes": 275775488,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.transformers.FiftyOneTransformerForUniversalSegmentation",
                 "config": {
@@ -4303,7 +4303,7 @@
             "source": "https://huggingface.co/facebook/mask2former-swin-base-coco-instance",
             "author": "Bowen Cheng, et al.",
             "license": "MIT",
-            "size_bytes": 350000000,
+            "size_bytes": 432013312,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.transformers.FiftyOneTransformerForUniversalSegmentation",
                 "config": {
@@ -4330,7 +4330,7 @@
             "source": "https://huggingface.co/facebook/mask2former-swin-large-coco-instance",
             "author": "Bowen Cheng, et al.",
             "license": "MIT",
-            "size_bytes": 875000000,
+            "size_bytes": 867172352,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.transformers.FiftyOneTransformerForUniversalSegmentation",
                 "config": {
@@ -4357,7 +4357,7 @@
             "source": "https://huggingface.co/facebook/mask2former-swin-tiny-coco-panoptic",
             "author": "Bowen Cheng, et al.",
             "license": "MIT",
-            "size_bytes": 178000000,
+            "size_bytes": 190840832,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.transformers.FiftyOneTransformerForUniversalSegmentation",
                 "config": {
@@ -4384,7 +4384,7 @@
             "source": "https://huggingface.co/facebook/mask2former-swin-small-coco-panoptic",
             "author": "Bowen Cheng, et al.",
             "license": "MIT",
-            "size_bytes": 270000000,
+            "size_bytes": 275775488,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.transformers.FiftyOneTransformerForUniversalSegmentation",
                 "config": {
@@ -4411,7 +4411,7 @@
             "source": "https://huggingface.co/facebook/mask2former-swin-base-coco-panoptic",
             "author": "Bowen Cheng, et al.",
             "license": "MIT",
-            "size_bytes": 350000000,
+            "size_bytes": 432013312,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.transformers.FiftyOneTransformerForUniversalSegmentation",
                 "config": {
@@ -4438,7 +4438,7 @@
             "source": "https://huggingface.co/facebook/mask2former-swin-large-coco-panoptic",
             "author": "Bowen Cheng, et al.",
             "license": "MIT",
-            "size_bytes": 875000000,
+            "size_bytes": 1825361101,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.transformers.FiftyOneTransformerForUniversalSegmentation",
                 "config": {
@@ -4465,7 +4465,7 @@
             "source": "https://huggingface.co/facebook/mask2former-swin-tiny-ade-semantic",
             "author": "Bowen Cheng, et al.",
             "license": "MIT",
-            "size_bytes": 178000000,
+            "size_bytes": 380633088,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.transformers.FiftyOneTransformerForUniversalSegmentation",
                 "config": {
@@ -4495,7 +4495,7 @@
             "source": "https://huggingface.co/facebook/mask2former-swin-small-ade-semantic",
             "author": "Bowen Cheng, et al.",
             "license": "MIT",
-            "size_bytes": 270000000,
+            "size_bytes": 275775488,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.transformers.FiftyOneTransformerForUniversalSegmentation",
                 "config": {
@@ -4525,7 +4525,7 @@
             "source": "https://huggingface.co/facebook/mask2former-swin-base-ade-semantic",
             "author": "Bowen Cheng, et al.",
             "license": "MIT",
-            "size_bytes": 350000000,
+            "size_bytes": 432013312,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.transformers.FiftyOneTransformerForUniversalSegmentation",
                 "config": {
@@ -4555,7 +4555,7 @@
             "source": "https://huggingface.co/facebook/mask2former-swin-large-ade-semantic",
             "author": "Bowen Cheng, et al.",
             "license": "MIT",
-            "size_bytes": 875000000,
+            "size_bytes": 867172352,
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.transformers.FiftyOneTransformerForUniversalSegmentation",
                 "config": {

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -3488,6 +3488,39 @@
             "date_added": "2024-01-17 14:25:51"
         },
         {
+            "base_name": "universal-segmentation-transformer-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "Hugging Face Transformers model for universal segmentation (instance, panoptic, or semantic)",
+            "source": "https://huggingface.co/docs/transformers/en/model_doc/mask2former",
+            "author": "Bowen Cheng, et al.",
+            "license": "MIT",
+            "size_bytes": null,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.transformers.FiftyOneTransformerForUniversalSegmentation",
+                "config": {}
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision", "transformers"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": [
+                "instances",
+                "panoptic",
+                "segmentation",
+                "torch",
+                "transformers",
+                "official"
+            ],
+            "training_data": [],
+            "date_added": "2025-06-29 00:00:00"
+        },
+        {
             "base_name": "depth-estimation-transformer-torch",
             "base_filename": null,
             "version": null,
@@ -4207,6 +4240,342 @@
                 { "name": "Cap4M", "url": "https://arxiv.org/abs/2112.03857" }
             ],
             "date_added": "2026-06-26 00:00:00"
+        },
+        {
+            "base_name": "mask2former-swin-tiny-coco-instance-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "Mask2Former with Swin-T backbone for instance segmentation on COCO, returning per-instance binary masks",
+            "source": "https://huggingface.co/facebook/mask2former-swin-tiny-coco-instance",
+            "author": "Bowen Cheng, et al.",
+            "license": "MIT",
+            "size_bytes": 178000000,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.transformers.FiftyOneTransformerForUniversalSegmentation",
+                "config": {
+                    "name_or_path": "facebook/mask2former-swin-tiny-coco-instance",
+                    "task": "instance"
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision", "transformers"],
+                "cpu": { "support": true },
+                "gpu": { "support": true }
+            },
+            "tags": ["instances", "torch", "transformers", "official"],
+            "training_data": [
+                { "name": "MS COCO 2017", "url": "https://cocodataset.org" }
+            ],
+            "date_added": "2026-06-29 00:00:00"
+        },
+        {
+            "base_name": "mask2former-swin-small-coco-instance-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "Mask2Former with Swin-S backbone for instance segmentation on COCO, returning per-instance binary masks",
+            "source": "https://huggingface.co/facebook/mask2former-swin-small-coco-instance",
+            "author": "Bowen Cheng, et al.",
+            "license": "MIT",
+            "size_bytes": 270000000,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.transformers.FiftyOneTransformerForUniversalSegmentation",
+                "config": {
+                    "name_or_path": "facebook/mask2former-swin-small-coco-instance",
+                    "task": "instance"
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision", "transformers"],
+                "cpu": { "support": true },
+                "gpu": { "support": true }
+            },
+            "tags": ["instances", "torch", "transformers", "official"],
+            "training_data": [
+                { "name": "MS COCO 2017", "url": "https://cocodataset.org" }
+            ],
+            "date_added": "2026-06-29 00:00:00"
+        },
+        {
+            "base_name": "mask2former-swin-base-coco-instance-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "Mask2Former with Swin-B backbone for instance segmentation on COCO, returning per-instance binary masks",
+            "source": "https://huggingface.co/facebook/mask2former-swin-base-coco-instance",
+            "author": "Bowen Cheng, et al.",
+            "license": "MIT",
+            "size_bytes": 350000000,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.transformers.FiftyOneTransformerForUniversalSegmentation",
+                "config": {
+                    "name_or_path": "facebook/mask2former-swin-base-coco-instance",
+                    "task": "instance"
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision", "transformers"],
+                "cpu": { "support": true },
+                "gpu": { "support": true }
+            },
+            "tags": ["instances", "torch", "transformers", "official"],
+            "training_data": [
+                { "name": "MS COCO 2017", "url": "https://cocodataset.org" }
+            ],
+            "date_added": "2026-06-29 00:00:00"
+        },
+        {
+            "base_name": "mask2former-swin-large-coco-instance-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "Mask2Former with Swin-L backbone for instance segmentation on COCO, returning per-instance binary masks",
+            "source": "https://huggingface.co/facebook/mask2former-swin-large-coco-instance",
+            "author": "Bowen Cheng, et al.",
+            "license": "MIT",
+            "size_bytes": 875000000,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.transformers.FiftyOneTransformerForUniversalSegmentation",
+                "config": {
+                    "name_or_path": "facebook/mask2former-swin-large-coco-instance",
+                    "task": "instance"
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision", "transformers"],
+                "cpu": { "support": true },
+                "gpu": { "support": true }
+            },
+            "tags": ["instances", "torch", "transformers", "official"],
+            "training_data": [
+                { "name": "MS COCO 2017", "url": "https://cocodataset.org" }
+            ],
+            "date_added": "2026-06-29 00:00:00"
+        },
+        {
+            "base_name": "mask2former-swin-tiny-coco-panoptic-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "Mask2Former with Swin-T backbone for panoptic segmentation on COCO, unifying things and stuff into a single segmentation",
+            "source": "https://huggingface.co/facebook/mask2former-swin-tiny-coco-panoptic",
+            "author": "Bowen Cheng, et al.",
+            "license": "MIT",
+            "size_bytes": 178000000,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.transformers.FiftyOneTransformerForUniversalSegmentation",
+                "config": {
+                    "name_or_path": "facebook/mask2former-swin-tiny-coco-panoptic",
+                    "task": "panoptic"
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision", "transformers"],
+                "cpu": { "support": true },
+                "gpu": { "support": true }
+            },
+            "tags": ["panoptic", "torch", "transformers", "official"],
+            "training_data": [
+                { "name": "MS COCO 2017", "url": "https://cocodataset.org" }
+            ],
+            "date_added": "2026-06-29 00:00:00"
+        },
+        {
+            "base_name": "mask2former-swin-small-coco-panoptic-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "Mask2Former with Swin-S backbone for panoptic segmentation on COCO, unifying things and stuff into a single segmentation",
+            "source": "https://huggingface.co/facebook/mask2former-swin-small-coco-panoptic",
+            "author": "Bowen Cheng, et al.",
+            "license": "MIT",
+            "size_bytes": 270000000,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.transformers.FiftyOneTransformerForUniversalSegmentation",
+                "config": {
+                    "name_or_path": "facebook/mask2former-swin-small-coco-panoptic",
+                    "task": "panoptic"
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision", "transformers"],
+                "cpu": { "support": true },
+                "gpu": { "support": true }
+            },
+            "tags": ["panoptic", "torch", "transformers", "official"],
+            "training_data": [
+                { "name": "MS COCO 2017", "url": "https://cocodataset.org" }
+            ],
+            "date_added": "2026-06-29 00:00:00"
+        },
+        {
+            "base_name": "mask2former-swin-base-coco-panoptic-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "Mask2Former with Swin-B backbone for panoptic segmentation on COCO, unifying things and stuff into a single segmentation",
+            "source": "https://huggingface.co/facebook/mask2former-swin-base-coco-panoptic",
+            "author": "Bowen Cheng, et al.",
+            "license": "MIT",
+            "size_bytes": 350000000,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.transformers.FiftyOneTransformerForUniversalSegmentation",
+                "config": {
+                    "name_or_path": "facebook/mask2former-swin-base-coco-panoptic",
+                    "task": "panoptic"
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision", "transformers"],
+                "cpu": { "support": true },
+                "gpu": { "support": true }
+            },
+            "tags": ["panoptic", "torch", "transformers", "official"],
+            "training_data": [
+                { "name": "MS COCO 2017", "url": "https://cocodataset.org" }
+            ],
+            "date_added": "2026-06-29 00:00:00"
+        },
+        {
+            "base_name": "mask2former-swin-large-coco-panoptic-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "Mask2Former with Swin-L backbone for panoptic segmentation on COCO, unifying things and stuff into a single segmentation",
+            "source": "https://huggingface.co/facebook/mask2former-swin-large-coco-panoptic",
+            "author": "Bowen Cheng, et al.",
+            "license": "MIT",
+            "size_bytes": 875000000,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.transformers.FiftyOneTransformerForUniversalSegmentation",
+                "config": {
+                    "name_or_path": "facebook/mask2former-swin-large-coco-panoptic",
+                    "task": "panoptic"
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision", "transformers"],
+                "cpu": { "support": true },
+                "gpu": { "support": true }
+            },
+            "tags": ["panoptic", "torch", "transformers", "official"],
+            "training_data": [
+                { "name": "MS COCO 2017", "url": "https://cocodataset.org" }
+            ],
+            "date_added": "2026-06-29 00:00:00"
+        },
+        {
+            "base_name": "mask2former-swin-tiny-ade-semantic-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "Mask2Former with Swin-T backbone for semantic segmentation on ADE20K (150 classes)",
+            "source": "https://huggingface.co/facebook/mask2former-swin-tiny-ade-semantic",
+            "author": "Bowen Cheng, et al.",
+            "license": "MIT",
+            "size_bytes": 178000000,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.transformers.FiftyOneTransformerForUniversalSegmentation",
+                "config": {
+                    "name_or_path": "facebook/mask2former-swin-tiny-ade-semantic",
+                    "task": "semantic"
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision", "transformers"],
+                "cpu": { "support": true },
+                "gpu": { "support": true }
+            },
+            "tags": ["segmentation", "torch", "transformers", "official"],
+            "training_data": [
+                {
+                    "name": "ADE20K",
+                    "url": "https://groups.csail.mit.edu/vision/datasets/ADE20K/"
+                }
+            ],
+            "date_added": "2026-06-29 00:00:00"
+        },
+        {
+            "base_name": "mask2former-swin-small-ade-semantic-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "Mask2Former with Swin-S backbone for semantic segmentation on ADE20K (150 classes)",
+            "source": "https://huggingface.co/facebook/mask2former-swin-small-ade-semantic",
+            "author": "Bowen Cheng, et al.",
+            "license": "MIT",
+            "size_bytes": 270000000,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.transformers.FiftyOneTransformerForUniversalSegmentation",
+                "config": {
+                    "name_or_path": "facebook/mask2former-swin-small-ade-semantic",
+                    "task": "semantic"
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision", "transformers"],
+                "cpu": { "support": true },
+                "gpu": { "support": true }
+            },
+            "tags": ["segmentation", "torch", "transformers", "official"],
+            "training_data": [
+                {
+                    "name": "ADE20K",
+                    "url": "https://groups.csail.mit.edu/vision/datasets/ADE20K/"
+                }
+            ],
+            "date_added": "2026-06-29 00:00:00"
+        },
+        {
+            "base_name": "mask2former-swin-base-ade-semantic-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "Mask2Former with Swin-B backbone for semantic segmentation on ADE20K (150 classes)",
+            "source": "https://huggingface.co/facebook/mask2former-swin-base-ade-semantic",
+            "author": "Bowen Cheng, et al.",
+            "license": "MIT",
+            "size_bytes": 350000000,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.transformers.FiftyOneTransformerForUniversalSegmentation",
+                "config": {
+                    "name_or_path": "facebook/mask2former-swin-base-ade-semantic",
+                    "task": "semantic"
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision", "transformers"],
+                "cpu": { "support": true },
+                "gpu": { "support": true }
+            },
+            "tags": ["segmentation", "torch", "transformers", "official"],
+            "training_data": [
+                {
+                    "name": "ADE20K",
+                    "url": "https://groups.csail.mit.edu/vision/datasets/ADE20K/"
+                }
+            ],
+            "date_added": "2026-06-29 00:00:00"
+        },
+        {
+            "base_name": "mask2former-swin-large-ade-semantic-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "Mask2Former with Swin-L backbone for semantic segmentation on ADE20K (150 classes)",
+            "source": "https://huggingface.co/facebook/mask2former-swin-large-ade-semantic",
+            "author": "Bowen Cheng, et al.",
+            "license": "MIT",
+            "size_bytes": 875000000,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.transformers.FiftyOneTransformerForUniversalSegmentation",
+                "config": {
+                    "name_or_path": "facebook/mask2former-swin-large-ade-semantic",
+                    "task": "semantic"
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision", "transformers"],
+                "cpu": { "support": true },
+                "gpu": { "support": true }
+            },
+            "tags": ["segmentation", "torch", "transformers", "official"],
+            "training_data": [
+                {
+                    "name": "ADE20K",
+                    "url": "https://groups.csail.mit.edu/vision/datasets/ADE20K/"
+                }
+            ],
+            "date_added": "2026-06-29 00:00:00"
         },
         {
             "base_name": "clip-vit-base32-torch",


### PR DESCRIPTION
<!--
Community contributors: target the `community` branch, not `develop`. PRs from
non-members are auto-retargeted to `community`. See CONTRIBUTING.md:
https://github.com/voxel51/fiftyone/blob/develop/CONTRIBUTING.md#community-pull-requests
-->

## 🔗 Related Issues

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->
No related issues to link

## 📋 What changes are proposed in this pull request?

<!--
Provide a clear, concise description of what this PR does and why.
-->
This PR adds [Mask2Former](https://huggingface.co/docs/transformers/v5.12.0/en/model_doc/mask2former) model and related wrappers to fiftyone `transformers` integration

## 🧪 How is this patch tested? If it is not, please explain why.

<!--
Describe the tests you ran or wrote to verify your changes. Include:
- New or updated unit/integration tests
- Manual testing steps performed
- Why tests are not applicable (if skipped)
-->

- [x] Run parity tests comparing direct HF inference and fiftyone integration outputs
- [x] Run all models via `apply_model` in fiftyone

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [x] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Hugging Face universal segmentation models with semantic, instance, and panoptic output handling.
  * Automatically converts model outputs into FiftyOne segmentation masks and detection objects, including confidence thresholding and optional class-name filtering.
  * Introduced a default universal segmentation checkpoint path when no model is specified.
* **Other Changes**
  * Updated model/task selection so `universal-segmentation` is recognized and correctly configured, including task-specific processing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3087
<!-- enterprise-sync-pr:end -->