### PR TITLE
fix(annotation): avoid no-cors CORS collision in browser-inference image fetch

### DIFF
--- a/app/packages/annotation/src/providers/worker.ts
+++ b/app/packages/annotation/src/providers/worker.ts
@@ -150,7 +150,11 @@ let decoderSession: ort.InferenceSession | null = null;
 async function loadImageData(url: string): Promise<ImageData> {
   let response: Response;
   try {
-    response = await fetch(url);
+    // Bypass the HTTP cache so this cors fetch never reuses a cached no-cors
+    // display load of the same URL. A no-cors <img> load sends no Origin, so a
+    // cross-origin host returns it without an Access-Control-Allow-Origin
+    // header (and no Vary); reusing that entry here would fail the CORS check.
+    response = await fetch(url, { cache: "reload" });
   } catch (e) {
     throw new Error(`Image fetch failed (check CORS headers): ${e}`);
   }


### PR DESCRIPTION
## What

The browser-inference worker (`annotation/src/providers/worker.ts`) fetches sample media to decode it into `ImageData` for in-browser segmentation. This is a **cors** request — reading cross-origin pixels requires it. But the same media URL is also loaded for display by a no-cors `<img>` in the lighter rendering layer (`ImageOverlay.ts`).

When media is served from a cross-origin host, the two loads collide in the browser's HTTP cache:

1. The no-cors `<img>` display load sends **no `Origin` header**, so the host returns the image with **no `Access-Control-Allow-Origin`** header (and no `Vary`). The browser caches that header-less response.
2. The worker's cors `fetch()` of the **same URL** reuses that cached entry and runs the CORS check against it → fails with `MissingAllowOriginHeader`, even when the bucket's CORS config is correct.

## Fix

Issue the worker's fetch with `{ cache: "reload" }` so it bypasses the shared HTTP-cache entry and always gets a fresh cors response (which carries `Access-Control-Allow-Origin` + `Vary: Origin`). The fresh response is cached with `Vary: Origin`, so it no longer cross-contaminates the no-cors display load.

In-browser inference on cross-origin media inherently requires CORS to be enabled on the host (reading cross-origin pixels is gated by the browser); this change does not alter that, it only fixes the case where CORS *is* configured correctly but the fetch still failed due to the cached no-cors response.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image loading for cross-origin content by bypassing cached responses, helping prevent missing CORS headers and related loading issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3090
<!-- enterprise-sync-pr:end -->