### PR TITLE
increase e2e ci shard fanout

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -129,7 +129,7 @@ jobs:
     needs: prepare-e2e
     timeout-minutes: 90
     runs-on: ubuntu-latest # the standard runner's 14GB free disk space is not sufficient.  We create more free space with the `jlumbroso/free-disk-space` action as a step (below).
-    name: Test e2e (Mongo ${{ matrix.mongodb-version }}, shard ${{ matrix.shard }}/4)
+    name: Test e2e (Mongo ${{ matrix.mongodb-version }}, shard ${{ matrix.shard }}/6)
     env:
       FIFTYONE_DO_NOT_TRACK: true
       FIFTYONE_APP_DEFAULT_QUERY_PERFORMANCE: false
@@ -147,7 +147,7 @@ jobs:
       matrix:
         mongodb-version:
           - "latest"
-        shard: [1, 2, 3, 4]
+        shard: [1, 2, 3, 4, 5, 6]
     services:
       # Run MongoDB as a service container rather than via a Docker-based
       # action. Container actions are built from `docker:latest` at job start
@@ -279,7 +279,7 @@ jobs:
         wait: setup-ffmpeg
 
       - name: Run Playwright tests
-        run: yarn e2e --shard=${{ matrix.shard }}/4
+        run: yarn e2e --shard=${{ matrix.shard }}/6
         working-directory: e2e-pw
 
       - name: Lint Playwright tests


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

We have had a dramatic increase in number of e2e specs recently. This PR is to account for that. 
Increase the GitHub Actions e2e test matrix from 4 to 6 shards and pass the matching Playwright shard count. Update the e2e job name so shard labels reflect the new total.

## 🧪 How is this patch tested? If it is not, please explain why.

- `git diff --check origin/develop...HEAD`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/e2e.yml"); puts "yaml ok"'`
- `coderabbit review --agent -t committed --base origin/develop` returned 0 findings

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

N/A

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [x] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end test coverage by increasing test sharding from 4 to 6, helping tests run more efficiently and reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3097
<!-- enterprise-sync-pr:end -->