### PR TITLE
Update Label Studio brush converter import

### DIFF
--- a/fiftyone/utils/labelstudio.py
+++ b/fiftyone/utils/labelstudio.py
@@ -32,8 +32,8 @@ ls = fou.lazy_import(
     callback=lambda: fou.ensure_import("label_studio_sdk>=0.0.13"),
 )
 brush = fou.lazy_import(
-    "label_studio_converter.brush",
-    callback=lambda: fou.ensure_import("label_studio_converter.brush"),
+    "label_studio_sdk.converter.brush",
+    callback=lambda: fou.ensure_import("label_studio_sdk>=1.0.0"),
 )
 etree = fou.lazy_import(
     "lxml.etree",

--- a/fiftyone/utils/labelstudio.py
+++ b/fiftyone/utils/labelstudio.py
@@ -29,12 +29,9 @@ import fiftyone.utils.annotations as foua
 
 ls = fou.lazy_import(
     "label_studio_sdk",
-    callback=lambda: fou.ensure_import("label_studio_sdk>=0.0.13"),
-)
-brush = fou.lazy_import(
-    "label_studio_sdk.converter.brush",
     callback=lambda: fou.ensure_import("label_studio_sdk>=1.0.0"),
 )
+brush = fou.lazy_import("label_studio_sdk.converter.brush")
 etree = fou.lazy_import(
     "lxml.etree",
     callback=lambda: fou.ensure_import("lxml.etree"),


### PR DESCRIPTION
## Summary
- replace the archived `label_studio_converter.brush` lazy import with `label_studio_sdk.converter.brush`
- require `label-studio-sdk` 1.0.0+ when brush conversion is used, since the converter module is not present in the old 0.0.x SDK wheels

Closes #6282

## Testing
- `python3 -m py_compile fiftyone/utils/labelstudio.py`
- `git diff --check`
- inspected `label-studio-sdk` wheels: `label_studio_sdk/converter/brush.py` is present in 1.0.0+ and current 2.0.23, absent from 0.0.13/0.0.34

Note: the local FiftyOne `.venv` is missing project dependencies, so I could not run the full Label Studio integration tests in this workspace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Label Studio compatibility so brush-related functionality uses the newer SDK path and works with supported `label_studio_sdk` versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->