### PR TITLE
ci(pr): don't cancel in-flight CI on no-op PR edits

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,7 +9,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Don't cancel an in-flight run for a no-op `edited` event (title/body edit,
+  # e.g. a bot stamping the enterprise-sync link). Those edits don't change the
+  # base, the gate below skips their CI anyway, and cancelling would wipe out the
+  # real run's results. Still cancel on base-changing edits and code pushes.
+  cancel-in-progress: ${{ github.event.action != 'edited' || github.event.changes.base != null }}
 
 jobs:
   modified-files:


### PR DESCRIPTION
## What

Stops a no-op PR edit (title/body change) from wiping out an in-flight CI run.

## Why

The \`Pull Request\` workflow triggers on \`edited\` events to catch base changes (stacked-PR auto-retarget). But \`edited\` also fires on title/body edits — e.g. when the enterprise-sync bot stamps the \`enterprise-sync-pr\` link into the body shortly after a PR opens.

With unconditional \`cancel-in-progress: true\`, that bot edit:
1. **cancels** the real in-flight CI run (concurrency cancel), and
2. launches a **replacement** run that the gate intentionally skips (\`run_ci=false\` for non-base edits).

Net result: the PR ends up with cancelled jobs (shown as "fail") and a skipped \`e2e\`/\`build\`/\`test\`/\`lint\` — no completed checks, even though the code was fine. Seen on #7930.

## Change

Make \`cancel-in-progress\` conditional so it's \`false\` for \`edited\` events that don't change the base:

\`\`\`yaml
cancel-in-progress: \${{ github.event.action != 'edited' || github.event.changes.base != null }}
\`\`\`

- Title/body edits no longer cancel running CI (and the replacement run still harmlessly skips, queued behind the real one).
- Code pushes (\`synchronize\`) and base-changing edits (auto-retarget) still cancel in-progress runs as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved pull request check handling so harmless edit events no longer cancel in-progress runs.
  * Base-changing edits and new code pushes still restart checks as expected, helping keep CI results more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->