### PR TITLE
Add GitHub Copilot MCP configuration to docs

### DIFF
--- a/docs/source/agents/using_agents.rst
+++ b/docs/source/agents/using_agents.rst
@@ -136,6 +136,25 @@ Step 2: Configure Your AI Tool
       Or use the one-click install:
       `Install FiftyOne MCP in VS Code <https://insiders.vscode.dev/redirect/mcp/install?name=fiftyone&config=%7B%22command%22%3A%22fiftyone-mcp%22%7D>`_
 
+   .. tab:: GitHub Copilot
+
+      Add to ``.vscode/mcp.json`` in your workspace (create if it doesn't
+      exist):
+
+      .. code-block:: json
+
+          {
+            "servers": {
+              "fiftyone": {
+                "type": "stdio",
+                "command": "fiftyone-mcp"
+              }
+            }
+          }
+
+      Enable **Agent mode** in Copilot Chat. MCP tools appear automatically
+      once the server is configured.
+
    .. tab:: Gemini CLI
 
       The Gemini CLI extension registers the MCP server automatically.


### PR DESCRIPTION
## 🔗 Related Issues
"No related issues to link"

## 📋 What changes are proposed in this pull request?

GitHub Copilot was already listed as a supported agent in the universal installer line, but had no configuration instructions anywhere, users landing on either the docs or the README had no path to connect the MCP server. Feedback suggested by @sherpan, thanks! 

## 🧪 How is this patch tested? If it is not, please explain why.

Built local and validate formats.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [X] Documentation: FiftyOne documentation changes
- [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the AI tool setup instructions with a new GitHub Copilot configuration tab.
  * Added steps for configuring the local MCP settings file so the server can be recognized.
  * Included guidance to enable Agent mode so available tools show up automatically after setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->