### PR TITLE
Fix: Stop onMouseUp Event Propagation from QuickEditEntry

### DIFF
--- a/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry/useTitleTemplate.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry/useTitleTemplate.tsx
@@ -88,9 +88,11 @@ const Title = ({
     <span key="path" data-cy={`sidebar-field-${path}`}>
       <span ref={hoverTarget} {...hoverHandlers}>
         {modal ? (
-          <QuickEditEntry enabled={hovering} path={path}>
-            {PATH_OVERRIDES[path] || path}
-          </QuickEditEntry>
+          <span onMouseUp={(e) => e.stopPropagation()}>
+            <QuickEditEntry enabled={hovering} path={path}>
+              {PATH_OVERRIDES[path] || path}
+            </QuickEditEntry>
+          </span>
         ) : (
           PATH_OVERRIDES[path] || path
         )}


### PR DESCRIPTION

## 🔗 Related Issues

N/A

## 📋 What changes are proposed in this pull request?

🐞 **Bug**: Clicking the `QuickEditEntry` button for a label in the Explore mode sidebar causes the event to propagate to the parent component and expand or collapse the container.
🔧 **Fix**: I wrapped the button in a span and stopped the event propagation to avoid this behavior

## 🧪 How is this patch tested? If it is not, please explain why.

Manual Testing
Before:

https://github.com/user-attachments/assets/7d625cb2-6f90-4c00-83ac-72022e219301

After:

https://github.com/user-attachments/assets/d01f0cc9-7809-4669-974e-d8bd1ed6878b


## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

- Stopped unexpected mouse event propagation from toggling the label container open state in the Explore mode sidebar

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interaction behavior in modal title editing so mouse-up events no longer bubble unexpectedly.
  * Reduced accidental closing or interference when using quick edit controls in modal views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3156
<!-- enterprise-sync-pr:end -->