### PR TITLE
Add `media_type` kwargs to `Dataset.from_*` classmethods

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -347,8 +347,9 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         if not _virtual:
             self._update_last_loaded_at()
 
-        if doc.media_type:
-            self._configure_media_type(doc.media_type)
+        media_type = kwargs.get("media_type")
+        if media_type or doc.media_type:
+            self._configure_media_type(media_type or doc.media_type)
 
     def __eq__(self, other):
         return type(other) == type(self) and self.name == other.name
@@ -7883,6 +7884,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         tags=None,
         dynamic=False,
         progress=None,
+        media_type=None,
         **kwargs,
     ):
         """Creates a :class:`Dataset` from the contents of the given directory.
@@ -7974,6 +7976,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             progress (None): whether to render a progress bar (True/False), use
                 the default value ``fiftyone.config.show_progress_bars``
                 (None), or a progress callback function to invoke instead
+            media_type (None): the media type of the dataset. If provided, this
+                argument sets the media type of the dataset.
             **kwargs: optional keyword arguments to pass to the constructor of
                 the :class:`fiftyone.utils.data.importers.DatasetImporter` for
                 the specified ``dataset_type``
@@ -7981,7 +7985,12 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         Returns:
             a :class:`Dataset`
         """
-        dataset = cls(name, persistent=persistent, overwrite=overwrite)
+        dataset = cls(
+            name,
+            persistent=persistent,
+            overwrite=overwrite,
+            media_type=media_type,
+        )
         dataset.add_dir(
             dataset_dir=dataset_dir,
             dataset_type=dataset_type,
@@ -8010,6 +8019,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         dynamic=False,
         cleanup=True,
         progress=None,
+        media_type=None,
         **kwargs,
     ):
         """Creates a :class:`Dataset` from the contents of the given archive.
@@ -8098,6 +8108,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             progress (None): whether to render a progress bar (True/False), use
                 the default value ``fiftyone.config.show_progress_bars``
                 (None), or a progress callback function to invoke instead
+            media_type (None): the media type of the dataset. If provided, this
+                argument sets the media type of the dataset.
             **kwargs: optional keyword arguments to pass to the constructor of
                 the :class:`fiftyone.utils.data.importers.DatasetImporter` for
                 the specified ``dataset_type``
@@ -8105,7 +8117,12 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         Returns:
             a :class:`Dataset`
         """
-        dataset = cls(name, persistent=persistent, overwrite=overwrite)
+        dataset = cls(
+            name,
+            persistent=persistent,
+            overwrite=overwrite,
+            media_type=media_type,
+        )
         dataset.add_archive(
             archive_path,
             dataset_type=dataset_type,
@@ -8131,6 +8148,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         tags=None,
         dynamic=False,
         progress=None,
+        media_type=None,
     ):
         """Creates a :class:`Dataset` by importing the samples in the given
         :class:`fiftyone.utils.data.importers.DatasetImporter`.
@@ -8169,11 +8187,18 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             progress (None): whether to render a progress bar (True/False), use
                 the default value ``fiftyone.config.show_progress_bars``
                 (None), or a progress callback function to invoke instead
+            media_type (None): the media type of the dataset. If provided, this
+                argument sets the media type of the dataset.
 
         Returns:
             a :class:`Dataset`
         """
-        dataset = cls(name, persistent=persistent, overwrite=overwrite)
+        dataset = cls(
+            name,
+            persistent=persistent,
+            overwrite=overwrite,
+            media_type=media_type,
+        )
         dataset.add_importer(
             dataset_importer,
             label_field=label_field,
@@ -9939,6 +9964,17 @@ def _load_dataset(obj, name, virtual=False):
             ) from e
 
         raise e
+
+
+def _get_dataset_media_type(name, *, virtual=False) -> Optional[str]:
+    if not virtual:
+        fomi.migrate_dataset_if_necessary(name)
+
+    db = foo.get_db_conn()
+    res = db.datasets.find_one({"name": name}, {"media_type": 1})
+    if not res:
+        raise DatasetNotFoundError(name)
+    return res.get("media_type", None)
 
 
 def _do_load_dataset(obj, name):

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -9966,10 +9966,7 @@ def _load_dataset(obj, name, virtual=False):
         raise e
 
 
-def _get_dataset_media_type(name, *, virtual=False) -> Optional[str]:
-    if not virtual:
-        fomi.migrate_dataset_if_necessary(name)
-
+def _get_dataset_media_type(name) -> Optional[str]:
     db = foo.get_db_conn()
     res = db.datasets.find_one({"name": name}, {"media_type": 1})
     if not res:

--- a/fiftyone/core/singletons.py
+++ b/fiftyone/core/singletons.py
@@ -31,6 +31,17 @@ class DatasetSingleton(type):
         return cls
 
     def _make_instance(cls, name, _create, *args, **kwargs):
+        media_type = kwargs.get("media_type")
+        if media_type is None and (
+            not _create or kwargs.get("persistent") or kwargs.get("_head_name")
+        ):
+            try:
+                media_type = fo.core.dataset._get_dataset_media_type(name)
+            except fo.core.dataset.DatasetNotFoundError:
+                pass
+            else:
+                kwargs["media_type"] = media_type
+
         instance = cls.__new__(cls)
         instance.__init__(name=name, _create=_create, *args, **kwargs)
         return instance

--- a/fiftyone/utils/data/importers.py
+++ b/fiftyone/utils/data/importers.py
@@ -1929,10 +1929,11 @@ class FiftyOneDatasetImporter(BatchDatasetImporter):
                 last_loaded_at=doc.last_loaded_at,
                 sample_collection_name=doc.sample_collection_name,
                 frame_collection_name=doc.frame_collection_name,
-                media_type=doc.media_type,
             )
             if doc.description and not dataset_dict.get("description", None):
                 keep_fields["description"] = doc.description
+            if doc.media_type is not None:
+                keep_fields["media_type"] = doc.media_type
 
             if doc.tags:
                 tags = doc.tags.copy()

--- a/fiftyone/utils/data/importers.py
+++ b/fiftyone/utils/data/importers.py
@@ -1929,6 +1929,7 @@ class FiftyOneDatasetImporter(BatchDatasetImporter):
                 last_loaded_at=doc.last_loaded_at,
                 sample_collection_name=doc.sample_collection_name,
                 frame_collection_name=doc.frame_collection_name,
+                media_type=doc.media_type,
             )
             if doc.description and not dataset_dict.get("description", None):
                 keep_fields["description"] = doc.description

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -8384,11 +8384,11 @@ class DatasetFactoryTests(unittest.TestCase):
 
     @drop_datasets
     def test_from_videos(self):
-        filepaths = ["image.jpg"]
+        filepaths = ["video.mp4"]
         dataset = fo.Dataset.from_videos(filepaths)
 
         self.assertEqual(len(dataset), 1)
-        self.assertEqual(dataset.media_type, fom.IMAGE)
+        self.assertEqual(dataset.media_type, fom.VIDEO)
 
         with self.assertRaises(ValueError):
             fo.Dataset.from_videos(filepaths, name=dataset.name)

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -4997,6 +4997,40 @@ class DatasetTests(unittest.TestCase):
                     expected_extrinsics.quaternion[i],
                 )
 
+    @drop_datasets
+    def test_from_dir_with_image_media_type(self):
+        dataset = fo.Dataset()
+
+        with etau.TempDir() as tmp_dir:
+            dataset_dir = os.path.join(tmp_dir, "dataset")
+            dataset.export(dataset_dir, fo.types.FiftyOneDataset)
+            new_dataset = fo.Dataset.from_dir(
+                dataset_dir, fo.types.FiftyOneDataset, media_type=fom.IMAGE
+            )
+
+        assert new_dataset.media_type == fom.IMAGE
+        assert isinstance(new_dataset, fo.Dataset)
+
+    @drop_datasets
+    def test_from_dir_restores_media_type(self):
+        dataset = fo.Dataset(media_type=fom.IMAGE, _create=True)
+
+        with etau.TempDir() as tmp_dir:
+            dataset_dir = os.path.join(tmp_dir, "dataset")
+            dataset.export(dataset_dir, fo.types.FiftyOneDataset)
+            new_dataset = fo.Dataset.from_dir(
+                dataset_dir,
+                fo.types.FiftyOneDataset,
+                name=dataset.name,
+                persistent=True,
+                overwrite=True,
+            )
+
+        assert new_dataset.media_type == fom.IMAGE
+        assert isinstance(new_dataset, fo.Dataset)
+
+        new_dataset.delete()
+
 
 class DatasetExtrasTests(unittest.TestCase):
     @drop_datasets
@@ -8315,6 +8349,7 @@ class DatasetFactoryTests(unittest.TestCase):
         dataset = fo.Dataset.from_images(filepaths)
 
         self.assertEqual(len(dataset), 1)
+        self.assertEqual(dataset.media_type, fom.IMAGE)
 
         with self.assertRaises(ValueError):
             fo.Dataset.from_images(filepaths, name=dataset.name)
@@ -8353,6 +8388,7 @@ class DatasetFactoryTests(unittest.TestCase):
         dataset = fo.Dataset.from_videos(filepaths)
 
         self.assertEqual(len(dataset), 1)
+        self.assertEqual(dataset.media_type, fom.IMAGE)
 
         with self.assertRaises(ValueError):
             fo.Dataset.from_videos(filepaths, name=dataset.name)
@@ -8394,6 +8430,7 @@ class DatasetFactoryTests(unittest.TestCase):
         )
 
         self.assertEqual(dataset.values("ground_truth.label"), ["label"])
+        self.assertEqual(dataset.media_type, fom.IMAGE)
 
         with self.assertRaises(ValueError):
             fo.Dataset.from_labeled_images(
@@ -8422,6 +8459,7 @@ class DatasetFactoryTests(unittest.TestCase):
         )
 
         self.assertEqual(dataset.values("ground_truth.label"), ["label"])
+        self.assertEqual(dataset.media_type, fom.VIDEO)
 
         with self.assertRaises(ValueError):
             fo.Dataset.from_labeled_videos(


### PR DESCRIPTION
## 🔗 Related Issues

[FOEPD-3738](https://voxel51.atlassian.net/browse/FOEPD-3738)

## 📋 What changes are proposed in this pull request?

- Allows specifying the media type of the datasets returned by the classmethods `Dataset.from_dir`, `Dataset.from_archive`, and `Dataset.from_importer`
- Does not add `media_type` to `Dataset.from_*` classmethods that imply a media type (e.g. `Dataset.from_images`)
- Sets media type on new datasets to match datasets with existing Mongo doc

## 🧪 How is this patch tested? If it is not, please explain why.

- Adds tests for `Dataset.from_dir` (no existing tests of `from_archive` or `from_importer`; I can add tests if needed)
- Adds assertions to existing tests of `Dataset.from_images`, `Dataset.from_videos`, `Dataset.from_labeled_images`, and `Dataset.from_labeled_videos`

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

`Dataset.from_*` classmethods now support a `media_type` keyword argument to set the media type of the returned dataset.

### What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [x] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other

[FOEPD-3738]: https://voxel51.atlassian.net/browse/FOEPD-3738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional `media_type` parameter to dataset creation methods (from directory, archive, and importer), allowing you to explicitly set or override the dataset’s media type.

* **Bug Fixes**
  * `media_type` is now preserved correctly when exporting and reloading datasets via directory/asset workflows.
  * When creating a dataset from an existing dataset reference, the correct `media_type` is restored automatically when available.

* **Tests**
  * Added/updated unit tests to verify `media_type` propagation for `from_dir` reload scenarios and for image/video dataset factory methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3145
<!-- enterprise-sync-pr:end -->