### PR TITLE
Fix: PR required-check integrity — no ready_for_review re-runs; no-op runs mirror the last real all-tests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -162,7 +162,10 @@ jobs:
       # A run that skipped the suite (no-op body edit, `closed`, or a failed
       # gate) must not aggregate its skipped needs into a vacuous green that
       # becomes the latest `all-tests` for a SHA whose real suite failed.
-      NO_OP: ${{ needs.modified-files.result == 'success' && (needs.modified-files.outputs.run-ci != 'true' || github.event.action == 'closed') }}
+      NO_OP: >-
+        ${{ needs.modified-files.result == 'success' &&
+        (needs.modified-files.outputs.run-ci != 'true' ||
+        github.event.action == 'closed') }}
     steps:
       - name: Fail when the CI gate did not complete
         if: needs.modified-files.result != 'success'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -162,8 +162,11 @@ jobs:
       # A run that skipped the suite (no-op body edit, `closed`, or a failed
       # gate) must not aggregate its skipped needs into a vacuous green that
       # becomes the latest `all-tests` for a SHA whose real suite failed.
-      NO_OP: ${{ needs.modified-files.outputs.run-ci != 'true' || github.event.action == 'closed' }}
+      NO_OP: ${{ needs.modified-files.result == 'success' && (needs.modified-files.outputs.run-ci != 'true' || github.event.action == 'closed') }}
     steps:
+      - name: Fail when the CI gate did not complete
+        if: needs.modified-files.result != 'success'
+        run: exit 1
       - name: Mirror the last real all-tests result
         if: env.NO_OP == 'true'
         uses: actions/github-script@v9

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,6 +18,7 @@ concurrency:
 permissions:
   contents: read
   pull-requests: read
+  checks: read
 
 jobs:
   modified-files:
@@ -155,10 +156,39 @@ jobs:
 
   all-tests:
     runs-on: ubuntu-latest
-    needs: [build, lint, test, e2e]
+    needs: [modified-files, build, lint, test, e2e]
     if: always()
+    env:
+      # A run that skipped the suite (no-op body edit, `closed`, or a failed
+      # gate) must not aggregate its skipped needs into a vacuous green that
+      # becomes the latest `all-tests` for a SHA whose real suite failed.
+      NO_OP: ${{ needs.modified-files.outputs.run-ci != 'true' || github.event.action == 'closed' }}
     steps:
-      - run: sh -c ${{
+      - name: Mirror the last real all-tests result
+        if: env.NO_OP == 'true'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { data } = await github.rest.checks.listForRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.payload.pull_request.head.sha,
+              check_name: 'all-tests',
+              per_page: 100,
+            });
+            const prior = data.check_runs
+              .filter((c) => c.status === 'completed')
+              .sort((a, b) => new Date(b.started_at) - new Date(a.started_at))[0];
+            if (!prior) {
+              core.setFailed('No completed all-tests for this commit yet — deferring to the run testing it.');
+            } else if (prior.conclusion === 'success') {
+              core.info('Mirroring the previous all-tests result: success');
+            } else {
+              core.setFailed(`Mirroring the previous all-tests result: ${prior.conclusion}`);
+            }
+      - name: Aggregate suite results
+        if: env.NO_OP != 'true'
+        run: sh -c ${{
           (needs.build.result == 'success' || needs.build.result == 'skipped') &&
           (needs.lint.result == 'success' || needs.lint.result == 'skipped') &&
           (needs.test.result == 'success' || needs.test.result == 'skipped') &&

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,7 +5,7 @@ on:
     # `edited` catches base changes — notably GitHub auto-retargeting a stacked
     # PR to develop when the PR below it merges — so the heavy suite runs before
     # it can land (no `synchronize` fires on an auto-retarget).
-    types: [opened, synchronize, reopened, closed, ready_for_review, edited]
+    types: [opened, synchronize, reopened, closed, edited]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## 🔗 Related Issues

Follow-up to #7919, which fixed no-op `edited` events cancelling the running suite.

## 📋 What changes are proposed in this pull request?

Two required-check integrity fixes for `all-tests`, both observed live on #7819:

1. **Drop `ready_for_review` from the triggers.** Nothing in `pr.yml` is draft-gated — drafts already run the full suite — so flipping a PR out of draft re-ran everything on an unchanged head SHA, cancelling the in-flight suite and leaving a failed `all-tests` on the SHA (the cancelled run's aggregator runs under `if: always()`, sees `cancelled` needs, and fails) until the redundant re-run finished. `opened`/`synchronize` cover every code state.

2. **No-op runs mirror the last real `all-tests` result instead of aggregating to green.** A run whose gate decides `run_ci=false` (body/title edit — CodeRabbit edits every PR body — or `closed`, or a failed gate job) skips the whole suite, so its aggregator sees only skipped needs and posts a vacuously *successful* `all-tests` — the newest check run with that name on the SHA, which is what branch protection honors. A red PR could go green off a body edit. Skipping the aggregator instead would be just as bad: skipped required checks also satisfy protection. So a no-op run now looks up the most recent completed `all-tests` for the head SHA and reports that conclusion; if none exists yet (suite still in flight), it fails closed and the real run's result supersedes it.

`all-tests` still *fails* when its needs are cancelled: that's the safe sentinel for "this SHA has no passing suite right now" (a skipped or vacuous result would be mergeable), and with `ready_for_review` gone it only occurs on base-change retargets, where the re-run is genuinely needed.

## 🧪 How is this patch tested? If it is not, please explain why.

YAML validated; the mirror path exercises documented APIs (`checks.listForRef` with `check_name`). Failure modes it was built against were reproduced live on #7819: `ready_for_review` cancelled the in-flight suite and `all-tests` failed in 2s on an unchanged SHA; a 15:36 body-edit run then posted a vacuous green `all-tests` with `build`/`test`/`e2e`/`lint` all skipped.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes
- [x] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request check behavior so non-functional updates and closed/edited states no longer trigger misleading test aggregation.
  * Pull request status now more reliably reflects the latest completed test outcome for the same commit.
  * Added support for reading check status during automated validation, reducing false positives and inconsistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3148
<!-- enterprise-sync-pr:end -->