### PR TITLE
[FOEPD-4052] Modal look-ahead prefetch for next/previous navigation (Phase 1: images)

### DIFF
--- a/app/packages/core/src/components/Modal/ModalNavigation.tsx
+++ b/app/packages/core/src/components/Modal/ModalNavigation.tsx
@@ -10,6 +10,7 @@ import styled from "styled-components";
 import useExit from "./Sidebar/Annotate/Edit/useExit";
 import useSave from "./Sidebar/Annotate/Edit/useSave";
 import { createDebouncedNavigator } from "./debouncedNavigator";
+import useModalPrefetch from "./useModalPrefetch";
 import {
   KnownCommands,
   KnownContexts,
@@ -75,6 +76,9 @@ const ModalNavigation = ({ closePanels }: { closePanels: () => void }) => {
 
   const setModal = fos.useSetExpandedSample();
   const modal = useRecoilValue(fos.modalSelector);
+
+  // Warm adjacent samples (GraphQL + media) so next/previous is instant.
+  useModalPrefetch();
 
   const modalRef = useRef(modal);
 

--- a/app/packages/core/src/components/Modal/useModalPrefetch.test.ts
+++ b/app/packages/core/src/components/Modal/useModalPrefetch.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+// Keep the import light and assert selection logic, not URL formatting or Relay
+// wiring. The pure functions only touch `mainSample` (a generated tagged node,
+// used elsewhere in the module) and two @fiftyone/state url helpers.
+vi.mock("@fiftyone/relay", () => ({ mainSample: {} }));
+vi.mock("@fiftyone/state", () => ({
+  getNormalizedUrls: (
+    urls:
+      | readonly { readonly field: string; readonly url: string }[]
+      | Record<string, string>
+      | null,
+  ): Record<string, string> =>
+    Array.isArray(urls)
+      ? Object.fromEntries(urls.map(({ field, url }) => [field, url]))
+      : ((urls ?? {}) as Record<string, string>),
+  getSampleSrc: (path: string) => `SRC:${path}`,
+}));
+
+import type { mainSampleQuery } from "@fiftyone/relay";
+import {
+  DEFAULT_WINDOW,
+  keyFor,
+  reconcileWindow,
+  resolveModalMediaSrc,
+  resolveWindow,
+} from "./useModalPrefetch";
+
+type Response = mainSampleQuery["response"];
+// Test fixtures don't construct the full generated union; cast the shape we need.
+const response = (sample: unknown): Response =>
+  ({ sample }) as unknown as Response;
+
+describe("resolveWindow", () => {
+  it("returns the default window with no hints", () => {
+    expect(resolveWindow()).toEqual(DEFAULT_WINDOW);
+    expect(resolveWindow({})).toEqual(DEFAULT_WINDOW);
+  });
+
+  it("returns the default window on fast/normal connections", () => {
+    expect(resolveWindow({ effectiveType: "4g" })).toEqual(DEFAULT_WINDOW);
+    expect(resolveWindow({ effectiveType: "3g" })).toEqual(DEFAULT_WINDOW);
+    expect(resolveWindow({ saveData: false })).toEqual(DEFAULT_WINDOW);
+  });
+
+  it("disables prefetch under Save-Data", () => {
+    expect(resolveWindow({ saveData: true })).toEqual({
+      lookahead: 0,
+      lookbehind: 0,
+    });
+  });
+
+  it("disables prefetch on slow (2g) connections", () => {
+    expect(resolveWindow({ effectiveType: "2g" })).toEqual({
+      lookahead: 0,
+      lookbehind: 0,
+    });
+    expect(resolveWindow({ effectiveType: "slow-2g" })).toEqual({
+      lookahead: 0,
+      lookbehind: 0,
+    });
+  });
+});
+
+describe("reconcileWindow", () => {
+  const gen = "g";
+
+  it("warms every neighbor on a fresh open, evicts nothing", () => {
+    const { toWarm, toEvict, keep } = reconcileWindow({
+      currentId: "c",
+      generation: gen,
+      neighborIds: ["a", "b"],
+      existingKeys: [],
+    });
+
+    expect(toWarm).toEqual([
+      { id: "a", key: keyFor(gen, "a") },
+      { id: "b", key: keyFor(gen, "b") },
+    ]);
+    expect(toEvict).toEqual([]);
+    expect(keep).toEqual(
+      new Set([keyFor(gen, "c"), keyFor(gen, "a"), keyFor(gen, "b")]),
+    );
+  });
+
+  it("never warms the current sample", () => {
+    const { toWarm } = reconcileWindow({
+      currentId: "c",
+      generation: gen,
+      neighborIds: ["c", "a"],
+      existingKeys: [],
+    });
+    expect(toWarm).toEqual([{ id: "a", key: keyFor(gen, "a") }]);
+  });
+
+  it("skips already-warmed neighbors and dedupes repeated offsets", () => {
+    const { toWarm } = reconcileWindow({
+      currentId: "c",
+      generation: gen,
+      neighborIds: ["a", "a", "b"],
+      existingKeys: [keyFor(gen, "b")],
+    });
+    // "a" appears once (dedupe); "b" is skipped (already warmed).
+    expect(toWarm).toEqual([{ id: "a", key: keyFor(gen, "a") }]);
+  });
+
+  it("keeps current + window and evicts entries that left the window", () => {
+    // Moved onto "a" (a former lookahead neighbor); "z" is now out of window.
+    const { toWarm, toEvict } = reconcileWindow({
+      currentId: "a",
+      generation: gen,
+      neighborIds: ["b", "x"],
+      existingKeys: [keyFor(gen, "a"), keyFor(gen, "b"), keyFor(gen, "z")],
+    });
+    expect(toWarm).toEqual([{ id: "x", key: keyFor(gen, "x") }]);
+    expect(toEvict).toEqual([keyFor(gen, "z")]);
+  });
+
+  it("evicts all prior-generation entries when the generation changes", () => {
+    const { toWarm, toEvict } = reconcileWindow({
+      currentId: "c",
+      generation: "g2",
+      neighborIds: ["a"],
+      existingKeys: [keyFor("g1", "c"), keyFor("g1", "a")],
+    });
+    expect(toWarm).toEqual([{ id: "a", key: keyFor("g2", "a") }]);
+    expect(toEvict).toEqual([keyFor("g1", "c"), keyFor("g1", "a")]);
+  });
+});
+
+describe("resolveModalMediaSrc", () => {
+  const urls = [
+    { field: "filepath", url: "/full.jpg" },
+    { field: "thumbnail", url: "/thumb.jpg" },
+  ];
+
+  it("resolves the requested media field for an image sample", () => {
+    expect(
+      resolveModalMediaSrc(
+        response({ __typename: "ImageSample", urls }),
+        "thumbnail",
+      ),
+    ).toBe("SRC:/thumb.jpg");
+  });
+
+  it("falls back to filepath when the media field is absent", () => {
+    expect(
+      resolveModalMediaSrc(
+        response({ __typename: "ImageSample", urls }),
+        "missing",
+      ),
+    ).toBe("SRC:/full.jpg");
+  });
+
+  it("returns null when an image sample has no usable url", () => {
+    expect(
+      resolveModalMediaSrc(
+        response({ __typename: "ImageSample", urls: [] }),
+        "x",
+      ),
+    ).toBeNull();
+    expect(
+      resolveModalMediaSrc(
+        response({ __typename: "ImageSample", urls: null }),
+        "x",
+      ),
+    ).toBeNull();
+  });
+
+  it("no-ops (returns null) for non-image media — the Phase 1 gate", () => {
+    for (const __typename of [
+      "VideoSample",
+      "ThreeDSample",
+      "PointCloudSample",
+      "UnknownSample",
+      "%other",
+    ]) {
+      expect(
+        resolveModalMediaSrc(response({ __typename, urls }), "thumbnail"),
+      ).toBeNull();
+    }
+  });
+
+  it("returns null for a missing sample", () => {
+    expect(resolveModalMediaSrc(response(null), "thumbnail")).toBeNull();
+  });
+});

--- a/app/packages/core/src/components/Modal/useModalPrefetch.test.ts
+++ b/app/packages/core/src/components/Modal/useModalPrefetch.test.ts
@@ -23,11 +23,9 @@ vi.mock("@fiftyone/state", () => ({
 
 import type { mainSampleQuery } from "@fiftyone/relay";
 import {
-  DEFAULT_WINDOW,
   keyFor,
   reconcileWindow,
   resolveModalMediaSrc,
-  resolveWindow,
 } from "./useModalPrefetch";
 
 type Response = mainSampleQuery["response"];
@@ -35,42 +33,11 @@ type Response = mainSampleQuery["response"];
 const response = (sample: unknown): Response =>
   ({ sample }) as unknown as Response;
 
-describe("resolveWindow", () => {
-  it("returns the default window with no hints", () => {
-    expect(resolveWindow()).toEqual(DEFAULT_WINDOW);
-    expect(resolveWindow({})).toEqual(DEFAULT_WINDOW);
-  });
-
-  it("returns the default window on fast/normal connections", () => {
-    expect(resolveWindow({ effectiveType: "4g" })).toEqual(DEFAULT_WINDOW);
-    expect(resolveWindow({ effectiveType: "3g" })).toEqual(DEFAULT_WINDOW);
-    expect(resolveWindow({ saveData: false })).toEqual(DEFAULT_WINDOW);
-  });
-
-  it("disables prefetch under Save-Data", () => {
-    expect(resolveWindow({ saveData: true })).toEqual({
-      lookahead: 0,
-      lookbehind: 0,
-    });
-  });
-
-  it("disables prefetch on slow (2g) connections", () => {
-    expect(resolveWindow({ effectiveType: "2g" })).toEqual({
-      lookahead: 0,
-      lookbehind: 0,
-    });
-    expect(resolveWindow({ effectiveType: "slow-2g" })).toEqual({
-      lookahead: 0,
-      lookbehind: 0,
-    });
-  });
-});
-
 describe("reconcileWindow", () => {
   const gen = "g";
 
   it("warms every neighbor on a fresh open, evicts nothing", () => {
-    const { toWarm, toEvict, keep } = reconcileWindow({
+    const { toWarm, toEvict } = reconcileWindow({
       currentId: "c",
       generation: gen,
       neighborIds: ["a", "b"],
@@ -82,9 +49,6 @@ describe("reconcileWindow", () => {
       { id: "b", key: keyFor(gen, "b") },
     ]);
     expect(toEvict).toEqual([]);
-    expect(keep).toEqual(
-      new Set([keyFor(gen, "c"), keyFor(gen, "a"), keyFor(gen, "b")]),
-    );
   });
 
   it("never warms the current sample", () => {

--- a/app/packages/core/src/components/Modal/useModalPrefetch.ts
+++ b/app/packages/core/src/components/Modal/useModalPrefetch.ts
@@ -1,0 +1,364 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+/**
+ * Look-ahead prefetch for modal next/previous navigation
+ * (FOEPD-4052, Phase 1: image datasets).
+ *
+ * On each modal sample change, warms a small window of neighbors (N+m forward,
+ * N-n back) so arrowing to them is instant, on two layers:
+ *
+ *   1. GraphQL (ALL media types) — fire each neighbor's `mainSample` query and
+ *      RETAIN it. The modal env uses `gcReleaseBufferSize: 0`, so query data is
+ *      GC'd the moment nothing is subscribed; retain pins it. On navigation
+ *      `modalSample` re-resolves with the neighbor's variables and, because
+ *      recoil-relay queries with `store-or-network`, reads straight from the
+ *      store — no network round-trip. Because the GraphQL is the slow part, this
+ *      is a win for image AND video / 3D / multimodal neighbors alike.
+ *   2. Media (images only, Phase 1) — off the response, resolve the modal media
+ *      URL and warm it with a `new Image()` that stays referenced until the
+ *      entry is evicted, keeping the decoded bitmap in memory. When the Looker
+ *      mounts and sets the same `src` (looker/.../elements/image.ts), the
+ *      browser serves it from memory (or the HTTP cache) → fast first paint.
+ *      Non-image samples no-op the media step (see `resolveModalMediaSrc`);
+ *      their media needs different machinery in later phases (Three's
+ *      LoadingManager for 3D, etc.).
+ *
+ * Neighbors come from `navigation.peek(offset)`, which reads the spotlight
+ * cursor WITHOUT moving it — the mutating `next`/`previous` would corrupt
+ * navigation (see useExpandSample.ts). Grouped / dynamic-group navigation uses a
+ * different mechanism and does not set `peek`, so the hook safely no-ops there
+ * (Phase 2).
+ *
+ * The pure decision logic (`resolveWindow`, `reconcileWindow`,
+ * `resolveModalMediaSrc`) is exported and unit-tested; the hook itself is thin
+ * orchestration over Relay + Recoil.
+ *
+ * Validate: Network panel — arrowing onto a warmed neighbor should issue NO
+ * `/graphql` request and (for images) the media should paint immediately.
+ */
+import { mainSample, type mainSampleQuery } from "@fiftyone/relay";
+import * as fos from "@fiftyone/state";
+import { useEffect, useRef } from "react";
+import { fetchQuery, useRelayEnvironment } from "react-relay";
+import { useRecoilCallback, useRecoilValue } from "recoil";
+import {
+  createOperationDescriptor,
+  getRequest,
+  type IEnvironment,
+} from "relay-runtime";
+
+/** How many samples to warm ahead of / behind the current one. */
+export type PrefetchWindow = { lookahead: number; lookbehind: number };
+
+/**
+ * Network Information API hints used to scale the window down on metered / slow
+ * connections. Passed in as a plain arg (not read from `navigator` here) so the
+ * function stays pure and testable.
+ */
+export type ConnectionHints = { saveData?: boolean; effectiveType?: string };
+
+// Forward navigation is more common than backward (ticket: N + m ahead, N - n
+// behind). Fixed default; a user preference could promote this later.
+export const DEFAULT_WINDOW: PrefetchWindow = { lookahead: 2, lookbehind: 1 };
+
+const SLOW_EFFECTIVE_TYPES = new Set(["slow-2g", "2g"]);
+
+/**
+ * Resolve the prefetch window from connection hints. Honors Save-Data and slow
+ * connections by disabling prefetch (don't burn a metered link warming samples
+ * the user may never reach); otherwise returns the default window.
+ */
+export function resolveWindow(hints?: ConnectionHints): PrefetchWindow {
+  const slow =
+    Boolean(hints?.saveData) ||
+    (hints?.effectiveType !== undefined &&
+      SLOW_EFFECTIVE_TYPES.has(hints.effectiveType));
+
+  return slow ? { lookahead: 0, lookbehind: 0 } : DEFAULT_WINDOW;
+}
+
+/** A neighbor to warm: its sample id and its generation-scoped cache key. */
+export type WarmTarget = { id: string; key: string };
+
+export type Reconciliation = {
+  /** Fresh neighbors (not already warmed) to warm now. */
+  toWarm: WarmTarget[];
+  /** Existing keys outside the current window/generation to release. */
+  toEvict: string[];
+  /** All keys that should remain warm (current + window). */
+  keep: Set<string>;
+};
+
+/**
+ * Warmed entries are keyed `${generation}::${sampleId}`. The generation bundles
+ * (dataset, view, mediaField, group slice); when any changes, prior-generation
+ * keys fall out of `keep` and are evicted — the same sample id then needs
+ * different query variables.
+ */
+export const keyFor = (generation: string, id: string): string =>
+  `${generation}::${id}`;
+
+/**
+ * Pure window reconciliation: given the current sample, the freshly-peeked
+ * neighbor ids, and the keys already warmed, decide what to warm and evict. The
+ * current sample is always kept (it was a neighbor a moment ago) but never
+ * warmed (its data is already live). Neighbors already warmed, duplicates, and
+ * the current id are excluded from `toWarm`.
+ */
+export function reconcileWindow({
+  currentId,
+  generation,
+  neighborIds,
+  existingKeys,
+}: {
+  currentId: string;
+  generation: string;
+  neighborIds: string[];
+  existingKeys: Iterable<string>;
+}): Reconciliation {
+  const existing = new Set(existingKeys);
+  const keep = new Set<string>([keyFor(generation, currentId)]);
+  const toWarm: WarmTarget[] = [];
+  const queued = new Set<string>();
+
+  for (const id of neighborIds) {
+    const key = keyFor(generation, id);
+    keep.add(key);
+    if (id === currentId || existing.has(key) || queued.has(key)) {
+      continue;
+    }
+    queued.add(key);
+    toWarm.push({ id, key });
+  }
+
+  const toEvict: string[] = [];
+  for (const key of existing) {
+    if (!keep.has(key)) {
+      toEvict.push(key);
+    }
+  }
+
+  return { toWarm, toEvict, keep };
+}
+
+/**
+ * Resolve the browser media URL to warm for a prefetched sample, or `null` if
+ * there's nothing to warm.
+ *
+ * Phase 1 gate: only `ImageSample` media is warmed. Video / 3D / point-cloud /
+ * unknown samples return `null` — their media needs different machinery
+ * (Three's LoadingManager for 3D, `<video>` preload for video) that lands in
+ * later phases. Only this media step is image-gated; the caller still warms the
+ * GraphQL/JSON for every media type.
+ */
+export function resolveModalMediaSrc(
+  response: mainSampleQuery["response"],
+  mediaField: string,
+): string | null {
+  const sample = response?.sample;
+  if (
+    !sample ||
+    sample.__typename !== "ImageSample" ||
+    !("urls" in sample) ||
+    !sample.urls
+  ) {
+    return null;
+  }
+
+  const normalized = fos.getNormalizedUrls(sample.urls);
+  const path = normalized[mediaField] ?? normalized.filepath;
+  return path ? fos.getSampleSrc(path) : null;
+}
+
+/**
+ * Warm a media URL by decoding it into an `<img>`. The returned element must
+ * stay referenced (see `WarmEntry`) — dropping it would let the browser free
+ * the decoded bitmap before navigation reaches it.
+ */
+const warmImage = (src: string): HTMLImageElement => {
+  const image = new Image();
+  image.decoding = "async";
+  image.src = src;
+  return image;
+};
+
+/** Read Network Information API hints, if the browser exposes them. */
+const getConnectionHints = (): ConnectionHints | undefined => {
+  if (typeof navigator === "undefined") {
+    return undefined;
+  }
+  // `connection` is non-standard (Chromium only); guard + narrow.
+  const connection = (
+    navigator as Navigator & {
+      connection?: { saveData?: boolean; effectiveType?: string };
+    }
+  ).connection;
+
+  return connection
+    ? { saveData: connection.saveData, effectiveType: connection.effectiveType }
+    : undefined;
+};
+
+type WarmEntry = {
+  /** Dispose the retain, cancel the in-flight fetch, free the warmed image. */
+  release: () => void;
+};
+
+export default function useModalPrefetch() {
+  const environment = useRelayEnvironment();
+  const current = useRecoilValue(fos.modalSelector);
+
+  // Inputs that change a sample's query variables. When any of these change,
+  // previously warmed entries belong to a stale generation and are flushed
+  // (the same id then needs different variables / a different media URL).
+  const datasetName = useRecoilValue(fos.datasetName);
+  const view = useRecoilValue(fos.view);
+  const mediaField = useRecoilValue(fos.selectedMediaField(true));
+  const slice = useRecoilValue(fos.groupSlice);
+
+  // `${generation}::${sampleId}` -> teardown
+  const warmed = useRef(new Map<string, WarmEntry>());
+
+  const warm = useRecoilCallback(
+    ({ snapshot }) =>
+      (env: IEnvironment, key: string, selector: fos.ModalSelector) => {
+        const id = selector.id;
+        if (!id || warmed.current.has(key)) {
+          return;
+        }
+
+        const groupSlice = snapshot.getLoadable(fos.groupSlice).getValue();
+        const variables = fos.buildModalSampleVariables({
+          dataset: snapshot.getLoadable(fos.datasetName).getValue(),
+          view: snapshot.getLoadable(fos.view).getValue(),
+          id,
+          slice: groupSlice || null,
+          sliceSelect: snapshot.getLoadable(fos.modalGroupSlice).getValue(),
+          groupId: groupSlice ? (selector.groupId ?? null) : null,
+        });
+        const field = snapshot
+          .getLoadable(fos.selectedMediaField(true))
+          .getValue();
+
+        // Pin against gcReleaseBufferSize: 0 so the data survives until nav.
+        const operation = createOperationDescriptor(
+          getRequest(mainSample),
+          variables,
+        );
+        const retained = env.retain(operation);
+
+        // Referenced until this entry is evicted so the decoded bitmap stays
+        // in memory for the navigation it was warmed for.
+        let warmedImage: HTMLImageElement | undefined;
+
+        const subscription = fetchQuery<mainSampleQuery>(
+          env,
+          mainSample,
+          variables,
+          { fetchPolicy: "store-or-network" },
+        ).subscribe({
+          next: (data) => {
+            // GraphQL is warmed for every media type; media only for images.
+            const src = resolveModalMediaSrc(data, field);
+            if (src) {
+              warmedImage = warmImage(src);
+            }
+          },
+          error: (error) =>
+            console.warn(`Failed to prefetch sample ${id}`, error),
+        });
+
+        warmed.current.set(key, {
+          release: () => {
+            subscription.unsubscribe();
+            retained.dispose();
+            if (warmedImage) {
+              // Drop the src so the browser can free the decoded bitmap.
+              warmedImage.src = "";
+              warmedImage = undefined;
+            }
+          },
+        });
+      },
+    [],
+  );
+
+  // Re-warm the window whenever the current sample (or a variable input)
+  // changes.
+  useEffect(() => {
+    if (!current?.id) {
+      return;
+    }
+    const currentId = current.id;
+
+    const navigation = fos.modalNavigation.get();
+    const peek = navigation?.peek;
+    if (!peek) {
+      return;
+    }
+
+    const { lookahead, lookbehind } = resolveWindow(getConnectionHints());
+    if (lookahead === 0 && lookbehind === 0) {
+      return;
+    }
+
+    // One generation per (dataset, view, mediaField, slice); prior-generation
+    // entries fall out of `keep` in reconcileWindow and are evicted below.
+    const generation = JSON.stringify([datasetName, view, mediaField, slice]);
+
+    const offsets: number[] = [];
+    for (let i = 1; i <= lookahead; i++) offsets.push(i);
+    for (let i = 1; i <= lookbehind; i++) offsets.push(-i);
+
+    let cancelled = false;
+
+    Promise.all(offsets.map((offset) => peek(offset).catch(() => null)))
+      .then((selectors) => {
+        if (cancelled) {
+          return;
+        }
+
+        const byId = new Map<string, fos.ModalSelector>();
+        for (const selector of selectors) {
+          if (selector?.id) {
+            byId.set(selector.id, selector);
+          }
+        }
+
+        const { toWarm, toEvict } = reconcileWindow({
+          currentId,
+          generation,
+          neighborIds: [...byId.keys()],
+          existingKeys: warmed.current.keys(),
+        });
+
+        for (const { id, key } of toWarm) {
+          const selector = byId.get(id);
+          if (selector) {
+            warm(environment, key, selector);
+          }
+        }
+
+        for (const key of toEvict) {
+          warmed.current.get(key)?.release();
+          warmed.current.delete(key);
+        }
+      })
+      .catch((error) => console.warn("Failed to prefetch neighbors", error));
+
+    return () => {
+      cancelled = true;
+    };
+  }, [current, datasetName, view, mediaField, slice, environment, warm]);
+
+  // Release everything on unmount.
+  useEffect(() => {
+    const map = warmed.current;
+    return () => {
+      for (const entry of map.values()) entry.release();
+      map.clear();
+    };
+  }, []);
+}

--- a/app/packages/core/src/components/Modal/useModalPrefetch.ts
+++ b/app/packages/core/src/components/Modal/useModalPrefetch.ts
@@ -6,37 +6,20 @@
  * Look-ahead prefetch for modal next/previous navigation
  * (FOEPD-4052, Phase 1: image datasets).
  *
- * On each modal sample change, warms a small window of neighbors (N+m forward,
- * N-n back) so arrowing to them is instant, on two layers:
+ * On each modal sample change, warms neighboring samples so arrowing to them
+ * is instant:
  *
- *   1. GraphQL (ALL media types) — fire each neighbor's `mainSample` query and
- *      RETAIN it. The modal env uses `gcReleaseBufferSize: 0`, so query data is
- *      GC'd the moment nothing is subscribed; retain pins it. On navigation
- *      `modalSample` re-resolves with the neighbor's variables and, because
- *      recoil-relay queries with `store-or-network`, reads straight from the
- *      store — no network round-trip. Because the GraphQL is the slow part, this
- *      is a win for image AND video / 3D / multimodal neighbors alike.
- *   2. Media (images only, Phase 1) — off the response, resolve the modal media
- *      URL and warm it with a `new Image()` that stays referenced until the
- *      entry is evicted, keeping the decoded bitmap in memory. When the Looker
- *      mounts and sets the same `src` (looker/.../elements/image.ts), the
- *      browser serves it from memory (or the HTTP cache) → fast first paint.
- *      Non-image samples no-op the media step (see `resolveModalMediaSrc`);
- *      their media needs different machinery in later phases (Three's
- *      LoadingManager for 3D, etc.).
+ *   1. GraphQL (all media types) — fetch and RETAIN each neighbor's
+ *      `mainSample` query. The modal env uses `gcReleaseBufferSize: 0`, so the
+ *      retain is what lets `modalSample` resolve from the Relay store on
+ *      navigation instead of the network.
+ *   2. Media (images only in this phase) — decode the media URL into a
+ *      retained `new Image()` so the bitmap is in memory when the looker
+ *      mounts the same src. Other media types no-op (`resolveModalMediaSrc`).
  *
  * Neighbors come from `navigation.peek(offset)`, which reads the spotlight
- * cursor WITHOUT moving it — the mutating `next`/`previous` would corrupt
- * navigation (see useExpandSample.ts). Grouped / dynamic-group navigation uses a
- * different mechanism and does not set `peek`, so the hook safely no-ops there
- * (Phase 2).
- *
- * The pure decision logic (`resolveWindow`, `reconcileWindow`,
- * `resolveModalMediaSrc`) is exported and unit-tested; the hook itself is thin
- * orchestration over Relay + Recoil.
- *
- * Validate: Network panel — arrowing onto a warmed neighbor should issue NO
- * `/graphql` request and (for images) the media should paint immediately.
+ * cursor without moving it. Grouped / dynamic-group navigation does not
+ * provide `peek`, so the hook no-ops there (Phase 2).
  */
 import { mainSample, type mainSampleQuery } from "@fiftyone/relay";
 import * as fos from "@fiftyone/state";
@@ -49,35 +32,17 @@ import {
   type IEnvironment,
 } from "relay-runtime";
 
-/** How many samples to warm ahead of / behind the current one. */
-export type PrefetchWindow = { lookahead: number; lookbehind: number };
+// Forward navigation is more common than backward.
+const LOOKAHEAD = 2;
+const LOOKBEHIND = 1;
 
-/**
- * Network Information API hints used to scale the window down on metered / slow
- * connections. Passed in as a plain arg (not read from `navigator` here) so the
- * function stays pure and testable.
- */
-export type ConnectionHints = { saveData?: boolean; effectiveType?: string };
-
-// Forward navigation is more common than backward (ticket: N + m ahead, N - n
-// behind). Fixed default; a user preference could promote this later.
-export const DEFAULT_WINDOW: PrefetchWindow = { lookahead: 2, lookbehind: 1 };
-
-const SLOW_EFFECTIVE_TYPES = new Set(["slow-2g", "2g"]);
-
-/**
- * Resolve the prefetch window from connection hints. Honors Save-Data and slow
- * connections by disabling prefetch (don't burn a metered link warming samples
- * the user may never reach); otherwise returns the default window.
- */
-export function resolveWindow(hints?: ConnectionHints): PrefetchWindow {
-  const slow =
-    Boolean(hints?.saveData) ||
-    (hints?.effectiveType !== undefined &&
-      SLOW_EFFECTIVE_TYPES.has(hints.effectiveType));
-
-  return slow ? { lookahead: 0, lookbehind: 0 } : DEFAULT_WINDOW;
-}
+// Save-Data is an explicit user preference; speculative downloads are exactly
+// the traffic it exists to stop. `connection` is non-standard (Chromium only).
+const prefersReducedData = (): boolean =>
+  Boolean(
+    (navigator as Navigator & { connection?: { saveData?: boolean } })
+      .connection?.saveData,
+  );
 
 /** A neighbor to warm: its sample id and its generation-scoped cache key. */
 export type WarmTarget = { id: string; key: string };
@@ -87,25 +52,19 @@ export type Reconciliation = {
   toWarm: WarmTarget[];
   /** Existing keys outside the current window/generation to release. */
   toEvict: string[];
-  /** All keys that should remain warm (current + window). */
-  keep: Set<string>;
 };
 
 /**
- * Warmed entries are keyed `${generation}::${sampleId}`. The generation bundles
- * (dataset, view, mediaField, group slice); when any changes, prior-generation
- * keys fall out of `keep` and are evicted — the same sample id then needs
- * different query variables.
+ * Warm keys are `${generation}::${sampleId}`; the generation bundles the
+ * query-variable inputs, so changing any of them evicts prior entries.
  */
 export const keyFor = (generation: string, id: string): string =>
   `${generation}::${id}`;
 
 /**
- * Pure window reconciliation: given the current sample, the freshly-peeked
- * neighbor ids, and the keys already warmed, decide what to warm and evict. The
- * current sample is always kept (it was a neighbor a moment ago) but never
- * warmed (its data is already live). Neighbors already warmed, duplicates, and
- * the current id are excluded from `toWarm`.
+ * Decide what to warm and evict given the current sample, the peeked neighbor
+ * ids, and the already-warmed keys. The current sample is kept but never
+ * warmed (its data is already live).
  */
 export function reconcileWindow({
   currentId,
@@ -140,18 +99,13 @@ export function reconcileWindow({
     }
   }
 
-  return { toWarm, toEvict, keep };
+  return { toWarm, toEvict };
 }
 
 /**
- * Resolve the browser media URL to warm for a prefetched sample, or `null` if
- * there's nothing to warm.
- *
- * Phase 1 gate: only `ImageSample` media is warmed. Video / 3D / point-cloud /
- * unknown samples return `null` — their media needs different machinery
- * (Three's LoadingManager for 3D, `<video>` preload for video) that lands in
- * later phases. Only this media step is image-gated; the caller still warms the
- * GraphQL/JSON for every media type.
+ * Resolve the media URL to warm, or `null`. Phase 1 gate: only `ImageSample`
+ * media is warmed — video/3D need different machinery (later phases). The
+ * caller still warms every media type's GraphQL.
  */
 export function resolveModalMediaSrc(
   response: mainSampleQuery["response"],
@@ -182,23 +136,6 @@ const warmImage = (src: string): HTMLImageElement => {
   image.decoding = "async";
   image.src = src;
   return image;
-};
-
-/** Read Network Information API hints, if the browser exposes them. */
-const getConnectionHints = (): ConnectionHints | undefined => {
-  if (typeof navigator === "undefined") {
-    return undefined;
-  }
-  // `connection` is non-standard (Chromium only); guard + narrow.
-  const connection = (
-    navigator as Navigator & {
-      connection?: { saveData?: boolean; effectiveType?: string };
-    }
-  ).connection;
-
-  return connection
-    ? { saveData: connection.saveData, effectiveType: connection.effectiveType }
-    : undefined;
 };
 
 type WarmEntry = {
@@ -234,10 +171,8 @@ export default function useModalPrefetch() {
           .getLoadable(fos.modalGroupSlice)
           .getValue();
 
-        // Mirror modalSample's variables guard: without a resolved slice
-        // selection the query variables would be invalid (`slices: [null]`).
-        // Unreachable while grouped navigation lacks `peek`; kept in lockstep
-        // for when it gains it.
+        // Mirror modalSample's variables guard (unreachable until grouped
+        // navigation gains `peek`).
         const hasSlices = snapshot.getLoadable(fos.hasGroupSlices).getValue();
         if (hasSlices && (!groupSlice || !sliceSelect)) {
           return;
@@ -301,10 +236,8 @@ export default function useModalPrefetch() {
   // Re-warm the window whenever the current sample (or a variable input)
   // changes.
   useEffect(() => {
-    // In the states below there is nothing to prefetch (modal closed,
-    // navigation without peek support, prefetch disabled by connection
-    // hints) — release anything already warmed rather than just bailing, so
-    // retained queries and decoded bitmaps don't outlive their usefulness.
+    // Nothing to prefetch in the early-return states below — also release
+    // anything already warmed so retains/bitmaps don't outlive the modal.
     const flush = () => {
       for (const entry of warmed.current.values()) {
         entry.release();
@@ -325,8 +258,7 @@ export default function useModalPrefetch() {
       return;
     }
 
-    const { lookahead, lookbehind } = resolveWindow(getConnectionHints());
-    if (lookahead === 0 && lookbehind === 0) {
+    if (prefersReducedData()) {
       flush();
       return;
     }
@@ -336,8 +268,8 @@ export default function useModalPrefetch() {
     const generation = JSON.stringify([datasetName, view, mediaField, slice]);
 
     const offsets: number[] = [];
-    for (let i = 1; i <= lookahead; i++) offsets.push(i);
-    for (let i = 1; i <= lookbehind; i++) offsets.push(-i);
+    for (let i = 1; i <= LOOKAHEAD; i++) offsets.push(i);
+    for (let i = 1; i <= LOOKBEHIND; i++) offsets.push(-i);
 
     let cancelled = false;
 

--- a/app/packages/core/src/components/Modal/useModalPrefetch.ts
+++ b/app/packages/core/src/components/Modal/useModalPrefetch.ts
@@ -278,6 +278,9 @@ export default function useModalPrefetch() {
       // reads are not guaranteed safe to interleave.
       const selectors: (fos.ModalSelector | null)[] = [];
       for (const offset of offsets) {
+        if (cancelled) {
+          return;
+        }
         selectors.push(await peek(offset).catch(() => null));
       }
 

--- a/app/packages/core/src/components/Modal/useModalPrefetch.ts
+++ b/app/packages/core/src/components/Modal/useModalPrefetch.ts
@@ -230,12 +230,25 @@ export default function useModalPrefetch() {
         }
 
         const groupSlice = snapshot.getLoadable(fos.groupSlice).getValue();
+        const sliceSelect = snapshot
+          .getLoadable(fos.modalGroupSlice)
+          .getValue();
+
+        // Mirror modalSample's variables guard: without a resolved slice
+        // selection the query variables would be invalid (`slices: [null]`).
+        // Unreachable while grouped navigation lacks `peek`; kept in lockstep
+        // for when it gains it.
+        const hasSlices = snapshot.getLoadable(fos.hasGroupSlices).getValue();
+        if (hasSlices && (!groupSlice || !sliceSelect)) {
+          return;
+        }
+
         const variables = fos.buildModalSampleVariables({
           dataset: snapshot.getLoadable(fos.datasetName).getValue(),
           view: snapshot.getLoadable(fos.view).getValue(),
           id,
           slice: groupSlice || null,
-          sliceSelect: snapshot.getLoadable(fos.modalGroupSlice).getValue(),
+          sliceSelect,
           groupId: groupSlice ? (selector.groupId ?? null) : null,
         });
         const field = snapshot
@@ -288,7 +301,19 @@ export default function useModalPrefetch() {
   // Re-warm the window whenever the current sample (or a variable input)
   // changes.
   useEffect(() => {
+    // In the states below there is nothing to prefetch (modal closed,
+    // navigation without peek support, prefetch disabled by connection
+    // hints) — release anything already warmed rather than just bailing, so
+    // retained queries and decoded bitmaps don't outlive their usefulness.
+    const flush = () => {
+      for (const entry of warmed.current.values()) {
+        entry.release();
+      }
+      warmed.current.clear();
+    };
+
     if (!current?.id) {
+      flush();
       return;
     }
     const currentId = current.id;
@@ -296,11 +321,13 @@ export default function useModalPrefetch() {
     const navigation = fos.modalNavigation.get();
     const peek = navigation?.peek;
     if (!peek) {
+      flush();
       return;
     }
 
     const { lookahead, lookbehind } = resolveWindow(getConnectionHints());
     if (lookahead === 0 && lookbehind === 0) {
+      flush();
       return;
     }
 
@@ -314,39 +341,44 @@ export default function useModalPrefetch() {
 
     let cancelled = false;
 
-    Promise.all(offsets.map((offset) => peek(offset).catch(() => null)))
-      .then((selectors) => {
-        if (cancelled) {
-          return;
-        }
+    (async () => {
+      // Peek sequentially — the peeks share the spotlight cursor, and soft
+      // reads are not guaranteed safe to interleave.
+      const selectors: (fos.ModalSelector | null)[] = [];
+      for (const offset of offsets) {
+        selectors.push(await peek(offset).catch(() => null));
+      }
 
-        const byId = new Map<string, fos.ModalSelector>();
-        for (const selector of selectors) {
-          if (selector?.id) {
-            byId.set(selector.id, selector);
-          }
-        }
+      if (cancelled) {
+        return;
+      }
 
-        const { toWarm, toEvict } = reconcileWindow({
-          currentId,
-          generation,
-          neighborIds: [...byId.keys()],
-          existingKeys: warmed.current.keys(),
-        });
-
-        for (const { id, key } of toWarm) {
-          const selector = byId.get(id);
-          if (selector) {
-            warm(environment, key, selector);
-          }
+      const byId = new Map<string, fos.ModalSelector>();
+      for (const selector of selectors) {
+        if (selector?.id) {
+          byId.set(selector.id, selector);
         }
+      }
 
-        for (const key of toEvict) {
-          warmed.current.get(key)?.release();
-          warmed.current.delete(key);
+      const { toWarm, toEvict } = reconcileWindow({
+        currentId,
+        generation,
+        neighborIds: [...byId.keys()],
+        existingKeys: warmed.current.keys(),
+      });
+
+      for (const { id, key } of toWarm) {
+        const selector = byId.get(id);
+        if (selector) {
+          warm(environment, key, selector);
         }
-      })
-      .catch((error) => console.warn("Failed to prefetch neighbors", error));
+      }
+
+      for (const key of toEvict) {
+        warmed.current.get(key)?.release();
+        warmed.current.delete(key);
+      }
+    })().catch((error) => console.warn("Failed to prefetch neighbors", error));
 
     return () => {
       cancelled = true;

--- a/app/packages/state/src/hooks/useExpandSample.ts
+++ b/app/packages/state/src/hooks/useExpandSample.ts
@@ -83,12 +83,29 @@ export default (store: WeakMap<ID, { index: number; sample: Sample }>) => {
           };
         };
 
+        // Read-ahead: resolve the sample at `offset` WITHOUT moving the cursor
+        // (the `true` flag is the soft/peek mode in spotlight's Iter.next).
+        // Used to prefetch neighbors; returns null when out of range or not yet
+        // paged into the store (iter throws in that case).
+        const peek = async (offset: number) => {
+          const peekId = await cursor.next(offset, true);
+          if (!peekId) {
+            return null;
+          }
+          try {
+            return await iter(Promise.resolve(peekId));
+          } catch {
+            return null;
+          }
+        };
+
         const hasNext = Boolean(await cursor.next(1, true));
         const hasPrevious = Boolean(await cursor.next(-1, true));
 
         setModalState({
           next,
           previous,
+          peek,
         })
           .then(() => iter(Promise.resolve(item.id)))
           .then((data) => setExpandedSample({ ...data, hasNext, hasPrevious }));

--- a/app/packages/state/src/recoil/modal.test.ts
+++ b/app/packages/state/src/recoil/modal.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { describe, expect, it } from "vitest";
+import { buildModalSampleVariables } from "./modal";
+
+describe("buildModalSampleVariables", () => {
+  it("builds non-group variables with a null group and threads dataset/view/id", () => {
+    expect(
+      buildModalSampleVariables({
+        dataset: "ds",
+        view: [],
+        id: "sample-1",
+        slice: null,
+        sliceSelect: null,
+        groupId: null,
+      }),
+    ).toEqual({
+      dataset: "ds",
+      view: [],
+      filter: { id: "sample-1", group: null },
+    });
+  });
+
+  it("treats an empty-string slice as non-group (group is null)", () => {
+    const vars = buildModalSampleVariables({
+      dataset: "ds",
+      view: [],
+      id: "sample-1",
+      slice: "",
+      sliceSelect: null,
+      groupId: null,
+    });
+    expect(vars.filter.group).toBeNull();
+  });
+
+  it("builds group variables from slice, sliceSelect, and groupId", () => {
+    expect(
+      buildModalSampleVariables({
+        dataset: "ds",
+        view: [],
+        id: "sample-2",
+        slice: "left",
+        sliceSelect: "right",
+        groupId: "group-1",
+      }),
+    ).toEqual({
+      dataset: "ds",
+      view: [],
+      filter: {
+        id: "sample-2",
+        group: { slice: "left", slices: ["right"], id: "group-1" },
+      },
+    });
+  });
+});

--- a/app/packages/state/src/recoil/modal.ts
+++ b/app/packages/state/src/recoil/modal.ts
@@ -109,6 +109,14 @@ export const isModalActive = selector<boolean>({
 export type ModalNavigation = {
   next: (offset?: number) => Promise<ModalSelector>;
   previous: (offset?: number) => Promise<ModalSelector>;
+  /**
+   * Resolve the sample at `offset` relative to the current position WITHOUT
+   * moving the cursor — a read-ahead used to prefetch neighboring samples.
+   * Resolves to `null` when the offset is out of range or the sample has not
+   * been paged into the store yet. Optional: the modal can be opened without
+   * navigation (see {@link useSetModalState}), in which case it is absent.
+   */
+  peek?: (offset: number) => Promise<ModalSelector | null>;
 };
 
 export const modalNavigation = (() => {
@@ -148,6 +156,36 @@ export const nullableModalSampleId = selector<string>({
   },
 });
 
+/**
+ * Builds the variables for the {@link mainSample} query for a single sample.
+ *
+ * Shared by {@link modalSample} and the modal prefetch hook so a prefetched
+ * neighbor lands under the exact same Relay store key the selector reads on
+ * navigation — if these diverged, `store-or-network` would silently miss and
+ * the prefetch would buy nothing.
+ */
+export const buildModalSampleVariables = (params: {
+  dataset: VariablesOf<mainSampleQuery>["dataset"];
+  view: VariablesOf<mainSampleQuery>["view"];
+  id: string;
+  slice: string | null;
+  sliceSelect: string | null;
+  groupId: string | null;
+}): VariablesOf<mainSampleQuery> => ({
+  dataset: params.dataset,
+  view: params.view,
+  filter: {
+    id: params.id,
+    group: params.slice
+      ? {
+          slice: params.slice,
+          slices: [params.sliceSelect],
+          id: params.groupId,
+        }
+      : null,
+  },
+});
+
 export const modalSample = graphQLSelector<
   VariablesOf<mainSampleQuery>,
   ModalSample
@@ -182,16 +220,14 @@ export const modalSample = graphQLSelector<
       return null;
     }
 
-    return {
+    return buildModalSampleVariables({
       dataset: get(datasetName),
       view: get(view),
-      filter: {
-        id: current.id,
-        group: slice
-          ? { slice, slices: [sliceSelect], id: get(groupId) }
-          : null,
-      },
-    };
+      id: current.id,
+      slice: slice || null,
+      sliceSelect,
+      groupId: slice ? get(groupId) : null,
+    });
   },
 });
 


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link (internal ticket: FOEPD-4052).

## 📋 What changes are proposed in this pull request?

Arrowing to the next/previous sample in the modal currently pays a full
round-trip on every navigation: a `mainSample` GraphQL query, then the media
download, then first paint. This PR warms a small window of neighboring
samples (2 ahead, 1 behind) whenever the modal sample changes, so navigating
to a neighbor is instant.

The prefetch works on two layers:

- **GraphQL (all media types):** each neighbor's `mainSample` query is fired
  and retained in the Relay store. The modal environment runs with
  `gcReleaseBufferSize: 0`, so unretained data is collected immediately —
  the retain is what makes the store hit possible. On navigation,
  `modalSample` resolves from the store with no network round-trip.
- **Media (images only, this phase):** the neighbor's media URL is warmed
  with a `new Image()` that stays referenced until the entry is evicted,
  keeping the decoded bitmap in memory for the looker to reuse. Video, 3D,
  and point-cloud samples skip this step (their media needs different
  machinery — later phases); they still get the GraphQL warm.

Design notes for reviewers:

- **Non-mutating peek.** Neighbors are resolved via a new
  `navigation.peek(offset)` that reads the spotlight cursor without moving it
  (the existing `next`/`previous` mutate it). Grouped/dynamic-group
  navigation doesn't provide `peek`, so the hook no-ops there. The modal
  opened without navigation also no-ops (`peek` is optional on
  `ModalNavigation`).
- **Shared query variables.** `buildModalSampleVariables` is extracted into
  `@fiftyone/state` and used by both the `modalSample` selector and the
  prefetch, so a warmed neighbor lands under the exact Relay store key the
  selector reads — if these diverged, the prefetch would silently buy
  nothing. The `modalSample` refactor is behavior-identical.
- **Bounded memory.** At most window+1 entries are ever retained; entries are
  released (query disposed, in-flight fetch cancelled, image reference
  dropped) when they leave the window, when the dataset / view / media field
  / group slice changes, when the modal closes, or on unmount.
- **Save-Data aware.** The Save-Data preference disables the prefetch
  entirely — speculative downloads are exactly the traffic it exists to stop.
- **Server cost, stated explicitly:** each modal navigation can issue up to 3
  additional `mainSample` queries. The window is small, already-warmed
  neighbors are skipped, and `store-or-network` dedupes — but this is a
  deliberate throughput-for-latency trade and worth a reviewer's eyes.
- The hook follows the Modal subsystem's existing Recoil patterns
  (the subsystem predates the Jotai migration guidance in
  CODING_STANDARDS.md).

## 🧪 How is this patch tested? If it is not, please explain why.

- **13 new unit tests** (run via `yarn test` from `app/`):
  - `useModalPrefetch.test.ts` (10) — the exported pure decision logic:
    window reconciliation (warm/evict, dedupe, generation change) and the
    media-URL gate incl. video/3D/point-cloud → `null` cases.
  - `modal.test.ts` (3) — `buildModalSampleVariables` for non-group,
    empty-slice, and group cases.
- **Manual verification** on an image dataset (quickstart) with a throttled
  connection: arrowing onto a warmed neighbor issues no `/graphql` request
  and paints immediately. Verified no-op behavior for grouped datasets
  (no `peek`) and video samples (media step gated, GraphQL still warmed).
- The Relay/Recoil orchestration (retain/dispose lifecycle, the `Image` side
  effect) is intentionally not unit-tested — mocking cost outweighs signal —
  and is covered by the manual verification above.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

Next/previous navigation in the sample modal is now significantly faster:
neighboring samples are prefetched in the background, so arrowing through
samples no longer waits on a network round-trip.

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Modal navigation now preloads nearby samples in the background, improving the speed of next/previous transitions.
  * Added a “peek” capability to read neighboring items without moving the current cursor.
* **Bug Fixes**
  * Improved modal data handling for grouped and non-grouped samples to ensure consistent query variables and media resolution.
  * When reduced-data mode is enabled or navigation context isn’t available, prefetching is automatically disabled to avoid unnecessary loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3149
<!-- enterprise-sync-pr:end -->