### PR TITLE
[FOEPD-4199] Add speed modifier in playback controls

### DIFF
--- a/app/packages/playback/src/lib/constants.ts
+++ b/app/packages/playback/src/lib/constants.ts
@@ -1,6 +1,16 @@
 export const DEFAULT_FRAME_NUMBER = 1;
 export const DEFAULT_LOOP = false;
 export const DEFAULT_SPEED = 1;
+/**
+ * Playback speed is a rate multiplier valid on `(0, MAX_SPEED]` — any positive
+ * value up to the ceiling. The ceiling is a UX guardrail, not the real limit:
+ * decode/buffer throughput is what actually caps sustained playback, and the
+ * engine's buffering already stalls when it can't keep up. There is no policy
+ * floor; `MIN_SPEED` is only the smallest value the 2-decimal display can show
+ * without rounding to 0.
+ */
+export const MAX_SPEED = 8;
+export const MIN_SPEED = 0.01;
 export const DEFAULT_TARGET_FRAME_RATE = 30;
 export const DEFAULT_USE_TIME_INDICATOR = false;
 export const GLOBAL_TIMELINE_ID = "fo-timeline-global";

--- a/app/packages/playback/src/lib/playback/PlaybackProvider.test.tsx
+++ b/app/packages/playback/src/lib/playback/PlaybackProvider.test.tsx
@@ -23,6 +23,7 @@ import {
 } from "./PlaybackProvider";
 import { bumpStreamRangesVersion, setBufferedRanges } from "./store-access";
 import type { PlaybackStream } from "./types";
+import { MAX_SPEED } from "../constants";
 
 interface RenderOpts {
   duration?: number;
@@ -765,6 +766,12 @@ describe("PlaybackProvider engine actions", () => {
       act(() => result.current.api.setSpeed(0));
       act(() => result.current.api.setSpeed(-1));
       expect(result.current.store.get(speedAtom)).toBe(before);
+    });
+
+    it("setSpeed clamps values above MAX_SPEED to the ceiling", () => {
+      const { result } = renderEngine({ duration: 10 });
+      act(() => result.current.api.setSpeed(MAX_SPEED + 100));
+      expect(result.current.store.get(speedAtom)).toBe(MAX_SPEED);
     });
   });
 

--- a/app/packages/playback/src/lib/playback/use-playback-engine.ts
+++ b/app/packages/playback/src/lib/playback/use-playback-engine.ts
@@ -17,7 +17,7 @@ import {
   viewEndAtom,
   viewStartAtom,
 } from "./atoms";
-import { SEEK_BAR_DEBOUNCE } from "../constants";
+import { MAX_SPEED, SEEK_BAR_DEBOUNCE } from "../constants";
 import { clamp, clampAndValidateBounds } from "./utils";
 import type {
   PlaybackClockSource,
@@ -684,7 +684,9 @@ export function usePlaybackEngine({
         // NaN / Infinity / non-positive values would corrupt `dt` in
         // the RAF tick and produce invalid playhead progression.
         if (!Number.isFinite(speed) || speed <= 0) return;
-        store.set(speedAtom, speed);
+        // Clamp (not reject) the upper bound so callers that pass an
+        // out-of-range value land at MAX_SPEED rather than silently no-op.
+        store.set(speedAtom, Math.min(speed, MAX_SPEED));
         // When a clock source is registered, the engine's `dt` arithmetic
         // isn't running — the source already paces the timeline. Speed in that
         // mode has to be applied at the source (e.g. `v.playbackRate` for a

--- a/app/packages/playback/src/utils/usePointerLockDrag.test.tsx
+++ b/app/packages/playback/src/utils/usePointerLockDrag.test.tsx
@@ -1,0 +1,147 @@
+import { act, renderHook } from "@testing-library/react";
+import type React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { usePointerLockDrag } from "./usePointerLockDrag";
+
+// A pointer-down event whose currentTarget can be pointer-locked.
+function pointerDownEvent() {
+  const el = document.createElement("div") as HTMLElement & {
+    requestPointerLock: () => void;
+  };
+  el.requestPointerLock = vi.fn();
+  return {
+    preventDefault: vi.fn(),
+    currentTarget: el,
+  } as unknown as React.PointerEvent<HTMLElement>;
+}
+
+// Dispatch a pointermove on window with a real movement delta (jsdom drops
+// movement* from fireEvent init, so define it on the event directly).
+function move(axis: "movementX" | "movementY", value: number) {
+  const ev = new MouseEvent("pointermove", { bubbles: true });
+  Object.defineProperty(ev, axis, { value, configurable: true });
+  act(() => {
+    window.dispatchEvent(ev);
+  });
+}
+
+function up() {
+  act(() => {
+    window.dispatchEvent(new MouseEvent("pointerup", { bubbles: true }));
+  });
+}
+
+describe("usePointerLockDrag", () => {
+  afterEach(() => {
+    document.exitPointerLock = undefined as never;
+  });
+
+  it("treats a press-release with no movement as a click", () => {
+    const onClick = vi.fn();
+    const onDelta = vi.fn();
+    const onDragStart = vi.fn();
+    const { result } = renderHook(() =>
+      usePointerLockDrag({ axis: "vertical", onDelta, onClick, onDragStart }),
+    );
+
+    act(() => result.current.handleProps.onPointerDown(pointerDownEvent()));
+    up();
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onDelta).not.toHaveBeenCalled();
+    expect(onDragStart).not.toHaveBeenCalled();
+  });
+
+  it("reports cumulative signed movement once past the threshold", () => {
+    const onDelta = vi.fn();
+    const onDragStart = vi.fn();
+    const onDragEnd = vi.fn();
+    const onClick = vi.fn();
+    const { result } = renderHook(() =>
+      usePointerLockDrag({
+        axis: "vertical",
+        onDelta,
+        onDragStart,
+        onDragEnd,
+        onClick,
+      }),
+    );
+
+    act(() => result.current.handleProps.onPointerDown(pointerDownEvent()));
+    move("movementY", -50);
+    move("movementY", -30);
+    up();
+
+    expect(onDragStart).toHaveBeenCalledTimes(1);
+    // Cumulative, not per-event: -50 then -80.
+    expect(onDelta.mock.calls.map((c) => c[0])).toEqual([-50, -80]);
+    expect(onDragEnd).toHaveBeenCalledTimes(1);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("does not report movement below the click threshold", () => {
+    const onDelta = vi.fn();
+    const onClick = vi.fn();
+    const { result } = renderHook(() =>
+      usePointerLockDrag({
+        axis: "vertical",
+        clickThreshold: 3,
+        onDelta,
+        onClick,
+      }),
+    );
+
+    act(() => result.current.handleProps.onPointerDown(pointerDownEvent()));
+    move("movementY", 2); // under threshold
+    up();
+
+    expect(onDelta).not.toHaveBeenCalled();
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("reads the horizontal axis when requested", () => {
+    const onDelta = vi.fn();
+    const { result } = renderHook(() =>
+      usePointerLockDrag({ axis: "horizontal", onDelta }),
+    );
+
+    act(() => result.current.handleProps.onPointerDown(pointerDownEvent()));
+    move("movementX", 40);
+    // A vertical move is ignored on the horizontal axis.
+    move("movementY", 100);
+    up();
+
+    expect(onDelta.mock.calls.map((c) => c[0])).toEqual([40, 40]);
+  });
+
+  it("requests and exits pointer lock around a real drag", () => {
+    const exitPointerLock = vi.fn();
+    document.exitPointerLock = exitPointerLock;
+    const { result } = renderHook(() =>
+      usePointerLockDrag({ axis: "vertical", onDelta: vi.fn() }),
+    );
+
+    const evt = pointerDownEvent();
+    act(() => result.current.handleProps.onPointerDown(evt));
+    move("movementY", -50);
+    expect(
+      (evt.currentTarget as unknown as { requestPointerLock: () => void })
+        .requestPointerLock,
+    ).toHaveBeenCalledTimes(1);
+    up();
+    expect(exitPointerLock).toHaveBeenCalledTimes(1);
+  });
+
+  it("tracks isDragging across the drag", () => {
+    const { result } = renderHook(() =>
+      usePointerLockDrag({ axis: "vertical", onDelta: vi.fn() }),
+    );
+
+    expect(result.current.isDragging).toBe(false);
+    act(() => result.current.handleProps.onPointerDown(pointerDownEvent()));
+    move("movementY", -50);
+    expect(result.current.isDragging).toBe(true);
+    up();
+    expect(result.current.isDragging).toBe(false);
+  });
+});

--- a/app/packages/playback/src/utils/usePointerLockDrag.ts
+++ b/app/packages/playback/src/utils/usePointerLockDrag.ts
@@ -81,6 +81,11 @@ export function usePointerLockDrag({
       // own the interaction until release.
       e.preventDefault();
 
+      // Tear down any in-flight drag before starting a new one, so a
+      // re-entrant pointerdown (multi-touch, programmatic dispatch) can't leak
+      // the previous interaction's window listeners.
+      teardownRef.current?.();
+
       const target = e.currentTarget;
       let accum = 0; // signed movement along `axis` since start
       let moved = 0; // total travel, for the click-vs-drag decision
@@ -98,12 +103,29 @@ export function usePointerLockDrag({
           // Engage Pointer Lock only once it's a real drag, so a plain click
           // never hides the cursor. Best-effort: unlocked movement deltas
           // still work until the cursor reaches a screen edge.
+          // Chromium returns a Promise here; older browsers return void. Mark
+          // as locked only once the request succeeds, and swallow a rejection
+          // (lock denied) so it doesn't surface as an unhandled rejection.
           try {
-            target.requestPointerLock?.();
+            // DOM lib types this as `void`, but Chromium returns a Promise.
+            const request = target.requestPointerLock?.() as unknown as
+              | Promise<void>
+              | undefined;
+            if (request?.then) {
+              request.then(
+                () => {
+                  locked = true;
+                },
+                () => {
+                  /* lock denied — keep dragging unlocked */
+                },
+              );
+            } else {
+              locked = true;
+            }
           } catch {
             /* Pointer Lock unavailable — keep dragging unlocked. */
           }
-          locked = true;
           cbRef.current.onDragStart?.();
         }
         cbRef.current.onDelta(accum);
@@ -112,6 +134,7 @@ export function usePointerLockDrag({
       const teardown = () => {
         window.removeEventListener("pointermove", onMove);
         window.removeEventListener("pointerup", onUp);
+        window.removeEventListener("pointercancel", onUp);
         if (locked) document.exitPointerLock?.();
         teardownRef.current = null;
       };
@@ -130,6 +153,7 @@ export function usePointerLockDrag({
       teardownRef.current = teardown;
       window.addEventListener("pointermove", onMove);
       window.addEventListener("pointerup", onUp);
+      window.addEventListener("pointercancel", onUp);
     },
     [axis, clickThreshold],
   );

--- a/app/packages/playback/src/utils/usePointerLockDrag.ts
+++ b/app/packages/playback/src/utils/usePointerLockDrag.ts
@@ -1,0 +1,138 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type React from "react";
+
+/** Axis whose movement is reported to {@link UsePointerLockDragOptions.onDelta}. */
+export type PointerLockDragAxis = "horizontal" | "vertical";
+
+export interface UsePointerLockDragOptions {
+  /** Axis whose movement is reported to `onDelta`. */
+  axis: PointerLockDragAxis;
+  /**
+   * Total travel (px) below which a press-and-release counts as a click rather
+   * than a drag — `onClick` fires and `onDelta` never does. Defaults to 3.
+   */
+  clickThreshold?: number;
+  /** Fired once when a drag begins (the first move past `clickThreshold`). */
+  onDragStart?: () => void;
+  /**
+   * Fired on every move once dragging, with the cumulative signed movement
+   * along `axis` since the drag began (positive = right / down). Because it is
+   * fed by Pointer Lock movement deltas, this value is unbounded — it keeps
+   * growing past the edge of the screen.
+   */
+  onDelta: (delta: number) => void;
+  /** Fired once when a press is released without ever crossing the threshold. */
+  onClick?: () => void;
+  /** Fired once when a real drag ends (pointer released after dragging). */
+  onDragEnd?: () => void;
+}
+
+export interface UsePointerLockDragReturn {
+  /** True between a drag actually starting and the pointer being released. */
+  isDragging: boolean;
+  /** Spread onto the element that should start a drag on pointer-down. */
+  handleProps: {
+    onPointerDown: (e: React.PointerEvent<HTMLElement>) => void;
+  };
+}
+
+/**
+ * Track a value-scrubbing drag driven by *relative* mouse motion.
+ *
+ * Unlike `useDragDelta` — which measures the pointer's absolute position
+ * (`clientX/clientY`) and therefore stops reporting once the cursor reaches a
+ * screen edge — this hook reads the Pointer Lock API's `movementX/movementY`
+ * deltas. It hides the cursor when a drag begins and accumulates raw motion, so
+ * the reported delta is unbounded: the drag never runs out of runway even when
+ * the element sits at the very bottom of the screen. It also distinguishes a
+ * click from a drag and owns the pointer-lock lifecycle.
+ *
+ * Use `useDragDelta` to drag something to a position on screen; use this to
+ * adjust a value by how far the mouse moves.
+ *
+ * The returned `onPointerDown` calls `preventDefault()` so the press doesn't
+ * focus / select the underlying element mid-drag; the caller decides on release
+ * (via `onClick`) whether to focus it. Window listeners and any held pointer
+ * lock are always torn down on release and on unmount.
+ */
+export function usePointerLockDrag({
+  axis,
+  clickThreshold = 3,
+  onDragStart,
+  onDelta,
+  onClick,
+  onDragEnd,
+}: UsePointerLockDragOptions): UsePointerLockDragReturn {
+  const [isDragging, setIsDragging] = useState(false);
+
+  // Route callbacks through a ref so `onPointerDown` stays referentially stable
+  // yet always invokes the latest closures.
+  const cbRef = useRef({ onDragStart, onDelta, onClick, onDragEnd });
+  cbRef.current = { onDragStart, onDelta, onClick, onDragEnd };
+
+  // Teardown for an in-flight drag, invoked on release and on unmount so an
+  // interrupted drag never leaks window listeners or a held pointer lock.
+  const teardownRef = useRef<(() => void) | null>(null);
+  useEffect(() => () => teardownRef.current?.(), []);
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent<HTMLElement>) => {
+      // Suppress the focus / text-selection a pointer-down would trigger; we
+      // own the interaction until release.
+      e.preventDefault();
+
+      const target = e.currentTarget;
+      let accum = 0; // signed movement along `axis` since start
+      let moved = 0; // total travel, for the click-vs-drag decision
+      let dragging = false;
+      let locked = false;
+
+      const onMove = (ev: PointerEvent) => {
+        const d = (axis === "vertical" ? ev.movementY : ev.movementX) || 0;
+        accum += d;
+        moved += Math.abs(d);
+        if (moved < clickThreshold) return;
+        if (!dragging) {
+          dragging = true;
+          setIsDragging(true);
+          // Engage Pointer Lock only once it's a real drag, so a plain click
+          // never hides the cursor. Best-effort: unlocked movement deltas
+          // still work until the cursor reaches a screen edge.
+          try {
+            target.requestPointerLock?.();
+          } catch {
+            /* Pointer Lock unavailable — keep dragging unlocked. */
+          }
+          locked = true;
+          cbRef.current.onDragStart?.();
+        }
+        cbRef.current.onDelta(accum);
+      };
+
+      const teardown = () => {
+        window.removeEventListener("pointermove", onMove);
+        window.removeEventListener("pointerup", onUp);
+        if (locked) document.exitPointerLock?.();
+        teardownRef.current = null;
+      };
+
+      const onUp = () => {
+        const wasDragging = dragging;
+        teardown();
+        if (wasDragging) {
+          setIsDragging(false);
+          cbRef.current.onDragEnd?.();
+        } else {
+          cbRef.current.onClick?.();
+        }
+      };
+
+      teardownRef.current = teardown;
+      window.addEventListener("pointermove", onMove);
+      window.addEventListener("pointerup", onUp);
+    },
+    [axis, clickThreshold],
+  );
+
+  return { isDragging, handleProps: { onPointerDown } };
+}

--- a/app/packages/playback/src/utils/usePointerLockDrag.ts
+++ b/app/packages/playback/src/utils/usePointerLockDrag.ts
@@ -106,12 +106,16 @@ export function usePointerLockDrag({
           // Chromium returns a Promise here; older browsers return void. Mark
           // as locked only once the request succeeds, and swallow a rejection
           // (lock denied) so it doesn't surface as an unhandled rejection.
+          // The DOM lib types requestPointerLock as returning `void`, but
+          // Chromium returns a Promise (older browsers return undefined).
+          const requestLock = target.requestPointerLock as
+            | (() => Promise<void> | undefined)
+            | undefined;
           try {
-            // DOM lib types this as `void`, but Chromium returns a Promise.
-            const request = target.requestPointerLock?.() as unknown as
-              | Promise<void>
-              | undefined;
-            if (request?.then) {
+            const request = requestLock?.call(target);
+            if (request) {
+              // Mark locked only once the lock resolves; swallow a rejection
+              // (denied) so it isn't an unhandled promise rejection.
               request.then(
                 () => {
                   locked = true;
@@ -121,6 +125,7 @@ export function usePointerLockDrag({
                 },
               );
             } else {
+              // Older browsers: synchronous / event-based, assume locked.
               locked = true;
             }
           } catch {

--- a/app/packages/playback/src/views/TimelineControls/SpeedControl.test.tsx
+++ b/app/packages/playback/src/views/TimelineControls/SpeedControl.test.tsx
@@ -1,7 +1,11 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
+import { MAX_SPEED } from "../../lib/constants";
 import { PlaybackProvider } from "../../lib/playback/PlaybackProvider";
-import SpeedControl, { SPEED_PRESETS } from "./SpeedControl";
+import SpeedControl from "./SpeedControl";
+
+// Kept in sync with the component; drag math is asserted in terms of it.
+const PX_PER_DOUBLING = 130;
 
 function renderSpeed(defaultSpeed?: number) {
   return render(
@@ -11,50 +15,148 @@ function renderSpeed(defaultSpeed?: number) {
       defaultSpeed={defaultSpeed}
     >
       <SpeedControl />
-    </PlaybackProvider>
+    </PlaybackProvider>,
   );
 }
 
-const trigger = () => screen.getByTestId("timeline-controls-speed");
+const field = () =>
+  screen.getByTestId("timeline-controls-speed") as HTMLInputElement;
+
+// Enter edit mode the way a user does: a pointer-down/up that doesn't move.
+// pointer-up is dispatched on window because that's where the drag listens.
+function clickToEdit() {
+  fireEvent.pointerDown(field());
+  fireEvent.pointerUp(window);
+}
+
+// Simulate a vertical scrub of `dy` pixels (negative = up = faster). jsdom
+// drops `movementY` from fireEvent init, so dispatch an event with it defined.
+function scrub(dy: number) {
+  fireEvent.pointerDown(field());
+  const move = new MouseEvent("pointermove", { bubbles: true });
+  Object.defineProperty(move, "movementY", { value: dy, configurable: true });
+  // Wrap the native dispatch so the setSpeed it triggers is flushed by React.
+  act(() => {
+    window.dispatchEvent(move);
+  });
+  fireEvent.pointerUp(window);
+}
 
 describe("SpeedControl", () => {
   afterEach(() => cleanup());
 
   it("shows 1× by default", () => {
     renderSpeed();
-    expect(trigger().textContent).toContain("1×");
+    expect(field().value).toBe("1×");
   });
 
   it("reflects a non-default initial speed", () => {
     renderSpeed(2);
-    expect(trigger().textContent).toContain("2×");
+    expect(field().value).toBe("2×");
   });
 
-  it("opens a menu with every preset speed", () => {
+  it("is read-only until clicked, then editable", () => {
     renderSpeed();
-    fireEvent.click(trigger());
-    for (const n of SPEED_PRESETS) {
-      expect(
-        screen.getByTestId(`timeline-controls-speed-option-${n}`)
-      ).toBeTruthy();
-    }
+    expect(field().readOnly).toBe(true);
+    clickToEdit();
+    expect(field().readOnly).toBe(false);
+    // Editing shows the bare number so the × doesn't get in the way.
+    expect(field().value).toBe("1");
   });
 
-  it("selecting a preset updates the active speed", () => {
+  it("commits a typed value on Enter", () => {
     renderSpeed();
-    fireEvent.click(trigger());
-    fireEvent.click(screen.getByTestId("timeline-controls-speed-option-2"));
-    expect(trigger().textContent).toContain("2×");
+    clickToEdit();
+    fireEvent.change(field(), { target: { value: "2.5" } });
+    fireEvent.keyDown(field(), { key: "Enter" });
+    expect(field().value).toBe("2.5×");
+    expect(field().readOnly).toBe(true);
   });
 
-  it("supports the fractional 0.25× preset", () => {
+  it("commits on blur", () => {
     renderSpeed();
-    fireEvent.click(trigger());
-    fireEvent.click(screen.getByTestId("timeline-controls-speed-option-0.25"));
-    expect(trigger().textContent).toContain("0.25×");
+    clickToEdit();
+    fireEvent.change(field(), { target: { value: "3" } });
+    fireEvent.blur(field());
+    expect(field().value).toBe("3×");
   });
 
-  it("offers exactly the documented presets", () => {
-    expect([...SPEED_PRESETS]).toEqual([0.25, 0.5, 1, 1.5, 2, 3]);
+  it("reverts to the committed value on Escape", () => {
+    renderSpeed(2);
+    clickToEdit();
+    fireEvent.change(field(), { target: { value: "5" } });
+    fireEvent.keyDown(field(), { key: "Escape" });
+    expect(field().value).toBe("2×");
+  });
+
+  it("parses a value with a trailing × or x", () => {
+    renderSpeed();
+    clickToEdit();
+    fireEvent.change(field(), { target: { value: "4x" } });
+    fireEvent.keyDown(field(), { key: "Enter" });
+    expect(field().value).toBe("4×");
+  });
+
+  it("reverts when the typed value is invalid", () => {
+    renderSpeed(2);
+    clickToEdit();
+    fireEvent.change(field(), { target: { value: "abc" } });
+    fireEvent.keyDown(field(), { key: "Enter" });
+    expect(field().value).toBe("2×");
+  });
+
+  it("clamps a value above MAX_SPEED down to the ceiling", () => {
+    renderSpeed();
+    clickToEdit();
+    fireEvent.change(field(), { target: { value: "50" } });
+    fireEvent.keyDown(field(), { key: "Enter" });
+    expect(field().value).toBe(`${MAX_SPEED}×`);
+  });
+
+  it("allows any small positive value (no 0.1 floor)", () => {
+    renderSpeed();
+    clickToEdit();
+    fireEvent.change(field(), { target: { value: "0.05" } });
+    fireEvent.keyDown(field(), { key: "Enter" });
+    expect(field().value).toBe("0.05×");
+  });
+
+  it("scrubbing up increases speed multiplicatively", () => {
+    renderSpeed(1);
+    // One doubling's worth of upward travel → 2×.
+    scrub(-PX_PER_DOUBLING);
+    expect(field().value).toBe("2×");
+  });
+
+  it("scrubbing down decreases speed and does not enter edit mode", () => {
+    renderSpeed(2);
+    // One doubling's worth of downward travel → 1×.
+    scrub(PX_PER_DOUBLING);
+    expect(field().value).toBe("1×");
+    expect(field().readOnly).toBe(true);
+  });
+
+  it("double-click resets to 1×", () => {
+    renderSpeed(3);
+    fireEvent.doubleClick(field());
+    expect(field().value).toBe("1×");
+  });
+
+  it("arrow keys nudge the committed speed", () => {
+    renderSpeed(1);
+    fireEvent.keyDown(field(), { key: "ArrowUp" });
+    // 1 × 1.1 = 1.1
+    expect(field().value).toBe("1.1×");
+    fireEvent.keyDown(field(), { key: "ArrowDown" });
+    // 1.1 × 1.1^-1 = 1 (rounded to 2dp)
+    expect(field().value).toBe("1×");
+  });
+
+  it("exposes spinbutton semantics for accessibility", () => {
+    renderSpeed(2);
+    const el = field();
+    expect(el.getAttribute("role")).toBe("spinbutton");
+    expect(el.getAttribute("aria-valuenow")).toBe("2");
+    expect(el.getAttribute("aria-valuemax")).toBe(String(MAX_SPEED));
   });
 });

--- a/app/packages/playback/src/views/TimelineControls/SpeedControl.test.tsx
+++ b/app/packages/playback/src/views/TimelineControls/SpeedControl.test.tsx
@@ -1,0 +1,60 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { PlaybackProvider } from "../../lib/playback/PlaybackProvider";
+import SpeedControl, { SPEED_PRESETS } from "./SpeedControl";
+
+function renderSpeed(defaultSpeed?: number) {
+  return render(
+    <PlaybackProvider
+      duration={10}
+      stepInterval={1 / 30}
+      defaultSpeed={defaultSpeed}
+    >
+      <SpeedControl />
+    </PlaybackProvider>
+  );
+}
+
+const trigger = () => screen.getByTestId("timeline-controls-speed");
+
+describe("SpeedControl", () => {
+  afterEach(() => cleanup());
+
+  it("shows 1× by default", () => {
+    renderSpeed();
+    expect(trigger().textContent).toContain("1×");
+  });
+
+  it("reflects a non-default initial speed", () => {
+    renderSpeed(2);
+    expect(trigger().textContent).toContain("2×");
+  });
+
+  it("opens a menu with every preset speed", () => {
+    renderSpeed();
+    fireEvent.click(trigger());
+    for (const n of SPEED_PRESETS) {
+      expect(
+        screen.getByTestId(`timeline-controls-speed-option-${n}`)
+      ).toBeTruthy();
+    }
+  });
+
+  it("selecting a preset updates the active speed", () => {
+    renderSpeed();
+    fireEvent.click(trigger());
+    fireEvent.click(screen.getByTestId("timeline-controls-speed-option-2"));
+    expect(trigger().textContent).toContain("2×");
+  });
+
+  it("supports the fractional 0.25× preset", () => {
+    renderSpeed();
+    fireEvent.click(trigger());
+    fireEvent.click(screen.getByTestId("timeline-controls-speed-option-0.25"));
+    expect(trigger().textContent).toContain("0.25×");
+  });
+
+  it("offers exactly the documented presets", () => {
+    expect([...SPEED_PRESETS]).toEqual([0.25, 0.5, 1, 1.5, 2, 3]);
+  });
+});

--- a/app/packages/playback/src/views/TimelineControls/SpeedControl.test.tsx
+++ b/app/packages/playback/src/views/TimelineControls/SpeedControl.test.tsx
@@ -1,4 +1,10 @@
-import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { MAX_SPEED } from "../../lib/constants";
 import { PlaybackProvider } from "../../lib/playback/PlaybackProvider";

--- a/app/packages/playback/src/views/TimelineControls/SpeedControl.tsx
+++ b/app/packages/playback/src/views/TimelineControls/SpeedControl.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useRef, useState } from "react";
 import { MAX_SPEED, MIN_SPEED } from "../../lib/constants";
 import { usePlayback } from "../../lib/playback/PlaybackProvider";
 import { useSpeed } from "../../lib/playback/use-playback-state";
+import { usePointerLockDrag } from "../../utils/usePointerLockDrag";
 import styles from "./TimelineControls.module.css";
 
 // A drag this small counts as a click (open for typing) rather than a scrub.
@@ -40,11 +41,10 @@ const parseSpeed = (raw: string): number | null => {
  * - click to type an exact value (Enter / blur commits, Escape reverts),
  * - double-click to reset to 1×.
  *
- * The scrub engages the Pointer Lock API once a real drag starts, so movement
- * deltas keep flowing even when the cursor would otherwise hit the bottom of
- * the screen — the controls sit near the modal's bottom edge, where a plain
- * pointer-capture drag runs out of runway. Falls back to unlocked movement
- * deltas where Pointer Lock is unavailable.
+ * The scrub uses {@link usePointerLockDrag}, so movement deltas keep flowing
+ * even when the cursor would otherwise hit the bottom of the screen — the
+ * controls sit near the modal's bottom edge, where a position-based drag runs
+ * out of runway.
  */
 const SpeedControl: React.FC = () => {
   const speed = useSpeed();
@@ -54,15 +54,11 @@ const SpeedControl: React.FC = () => {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState("");
 
-  // Latest speed, readable from the drag's native listeners without re-binding
-  // them each render.
+  // Latest speed, readable from the drag callbacks without re-binding them each
+  // render; also the speed captured when a scrub begins.
   const speedRef = useRef(speed);
   speedRef.current = speed;
-
-  // Teardown for an in-flight drag, invoked on pointer-up and on unmount so a
-  // drag interrupted by an unmount doesn't leak window listeners / a lock.
-  const endDragRef = useRef<(() => void) | null>(null);
-  useEffect(() => () => endDragRef.current?.(), []);
+  const dragStartSpeedRef = useRef(speed);
 
   // Focus + select-all once the input flips to editable, so typing overwrites.
   useEffect(() => {
@@ -91,56 +87,21 @@ const SpeedControl: React.FC = () => {
     setSpeed(next);
   };
 
-  const onScrubStart = (e: React.PointerEvent<HTMLInputElement>) => {
-    // While already editing, leave pointer handling to the text field so caret
-    // placement / selection work normally.
-    if (editing) return;
-    // Suppress the focus + caret a pointer-down on an input would trigger; we
-    // decide click-vs-scrub on pointer-up and focus manually if it was a click.
-    e.preventDefault();
-
-    const target = e.currentTarget;
-    const startSpeed = speedRef.current;
-    let accum = 0; // signed movement since start (negative = up = faster)
-    let moved = 0; // total travel, for the click-vs-scrub decision
-    let locked = false;
-
-    const onMove = (ev: PointerEvent) => {
-      const dy = ev.movementY || 0;
-      accum += dy;
-      moved += Math.abs(dy);
-      if (moved < CLICK_PX_THRESHOLD) return;
-      if (!locked) {
-        // Engage Pointer Lock only once we know it's a real drag, so a plain
-        // click never hides the cursor. Best-effort: unlocked deltas still work
-        // until the cursor reaches a screen edge.
-        try {
-          target.requestPointerLock?.();
-        } catch {
-          /* Pointer Lock unavailable — keep dragging unlocked. */
-        }
-        locked = true;
-      }
-      setSpeed(roundSpeed(startSpeed * 2 ** (-accum / PX_PER_DOUBLING)));
-    };
-
-    const end = () => {
-      window.removeEventListener("pointermove", onMove);
-      window.removeEventListener("pointerup", end);
-      if (locked) document.exitPointerLock?.();
-      endDragRef.current = null;
-    };
-
-    const onUp = () => {
-      end();
-      // A pointer-up that never moved far is a click → open for typing.
-      if (moved < CLICK_PX_THRESHOLD) beginEdit();
-    };
-
-    endDragRef.current = end;
-    window.addEventListener("pointermove", onMove);
-    window.addEventListener("pointerup", onUp, { once: true });
-  };
+  const scrub = usePointerLockDrag({
+    axis: "vertical",
+    clickThreshold: CLICK_PX_THRESHOLD,
+    onDragStart: () => {
+      dragStartSpeedRef.current = speedRef.current;
+    },
+    onDelta: (delta) => {
+      // delta is positive downward, so negate: dragging up speeds up.
+      setSpeed(
+        roundSpeed(dragStartSpeedRef.current * 2 ** (-delta / PX_PER_DOUBLING)),
+      );
+    },
+    // A press that never became a drag is a click → open for typing.
+    onClick: beginEdit,
+  });
 
   return (
     <input
@@ -157,7 +118,11 @@ const SpeedControl: React.FC = () => {
       readOnly={!editing}
       value={editing ? draft : fmtSpeed(speed)}
       onChange={(e) => setDraft(e.target.value)}
-      onPointerDown={onScrubStart}
+      onPointerDown={(e) => {
+        // While already editing, leave pointer handling to the text field so
+        // caret placement / selection work normally.
+        if (!editing) scrub.handleProps.onPointerDown(e);
+      }}
       onDoubleClick={() => {
         setEditing(false);
         setSpeed(1);

--- a/app/packages/playback/src/views/TimelineControls/SpeedControl.tsx
+++ b/app/packages/playback/src/views/TimelineControls/SpeedControl.tsx
@@ -1,0 +1,63 @@
+import {
+  Dropdown,
+  DropdownAnchor,
+  DropdownTrigger,
+  MenuCheckItem,
+  Size,
+} from "@voxel51/voodo";
+import React from "react";
+import { usePlayback } from "../../lib/playback/PlaybackProvider";
+import { useSpeed } from "../../lib/playback/use-playback-state";
+import styles from "./TimelineControls.module.css";
+
+/**
+ * Preset playback speeds surfaced as discrete choices in the UI. The engine's
+ * `setSpeed` accepts any finite positive number — these presets only gate what
+ * the picker offers, so a slider / free-form number input can replace this
+ * menu later without touching the engine or the `speedAtom` type.
+ */
+export const SPEED_PRESETS = [0.25, 0.5, 1, 1.5, 2, 3] as const;
+
+/** `1` -> "1×", `0.25` -> "0.25×". */
+const fmtSpeed = (n: number): string => `${n}×`;
+
+/**
+ * Playback-speed picker for the modern timeline controls. Reads the live
+ * `speedAtom` via `useSpeed()` (re-renders only on speed change, not per RAF
+ * tick) and writes through `usePlayback().setSpeed`. The trigger shows the
+ * active speed; the menu opens upward since the controls sit near the bottom
+ * of the modal.
+ */
+const SpeedControl: React.FC = () => {
+  const speed = useSpeed();
+  const { setSpeed } = usePlayback();
+
+  return (
+    <Dropdown
+      anchor={DropdownAnchor.Top}
+      className={styles.speed}
+      trigger={
+        <DropdownTrigger
+          size={Size.Xs}
+          data-testid="timeline-controls-speed"
+          aria-label={`Playback speed: ${fmtSpeed(speed)}`}
+        >
+          {fmtSpeed(speed)}
+        </DropdownTrigger>
+      }
+    >
+      {SPEED_PRESETS.map((n) => (
+        <MenuCheckItem
+          key={n}
+          checked={n === speed}
+          onClick={() => setSpeed(n)}
+          data-testid={`timeline-controls-speed-option-${n}`}
+        >
+          {fmtSpeed(n)}
+        </MenuCheckItem>
+      ))}
+    </Dropdown>
+  );
+};
+
+export default SpeedControl;

--- a/app/packages/playback/src/views/TimelineControls/SpeedControl.tsx
+++ b/app/packages/playback/src/views/TimelineControls/SpeedControl.tsx
@@ -1,62 +1,187 @@
-import {
-  Dropdown,
-  DropdownAnchor,
-  DropdownTrigger,
-  MenuCheckItem,
-  Size,
-} from "@voxel51/voodo";
-import React from "react";
+import clsx from "clsx";
+import React, { useEffect, useRef, useState } from "react";
+import { MAX_SPEED, MIN_SPEED } from "../../lib/constants";
 import { usePlayback } from "../../lib/playback/PlaybackProvider";
 import { useSpeed } from "../../lib/playback/use-playback-state";
 import styles from "./TimelineControls.module.css";
 
-/**
- * Preset playback speeds surfaced as discrete choices in the UI. The engine's
- * `setSpeed` accepts any finite positive number — these presets only gate what
- * the picker offers, so a slider / free-form number input can replace this
- * menu later without touching the engine or the `speedAtom` type.
- */
-export const SPEED_PRESETS = [0.25, 0.5, 1, 1.5, 2, 3] as const;
+// A drag this small counts as a click (open for typing) rather than a scrub.
+// Matches the timeline ruler's click/drag threshold so the two feel alike.
+const CLICK_PX_THRESHOLD = 3;
+// Pixels of vertical drag that double (up) or halve (down) the speed. Speed is
+// a ratio, so a multiplicative mapping feels consistent across the whole range
+// where a fixed px-per-unit step would be coarse near MIN and twitchy near MAX.
+const PX_PER_DOUBLING = 130;
+// Arrow-key / nudge factor.
+const NUDGE_FACTOR = 1.1;
 
 /** `1` -> "1×", `0.25` -> "0.25×". */
 const fmtSpeed = (n: number): string => `${n}×`;
 
+/** Round to 2dp and clamp into the valid `(0, MAX_SPEED]` range. */
+const roundSpeed = (n: number): number =>
+  Math.min(Math.max(Math.round(n * 100) / 100, MIN_SPEED), MAX_SPEED);
+
+/** Parse a user string like "2", "2x", "2×" into a speed, or null if invalid. */
+const parseSpeed = (raw: string): number | null => {
+  const cleaned = raw.replace(/[×x\s]/g, "");
+  if (cleaned === "") return null;
+  const n = Number(cleaned);
+  return Number.isFinite(n) && n > 0 ? n : null;
+};
+
 /**
- * Playback-speed picker for the modern timeline controls. Reads the live
- * `speedAtom` via `useSpeed()` (re-renders only on speed change, not per RAF
- * tick) and writes through `usePlayback().setSpeed`. The trigger shows the
- * active speed; the menu opens upward since the controls sit near the bottom
- * of the modal.
+ * Scrubbable playback-speed input for the modern timeline controls. Reads the
+ * live `speedAtom` via `useSpeed()` (re-renders only on speed change, not per
+ * RAF tick) and writes through `usePlayback().setSpeed`.
+ *
+ * Three ways to change the value, all on one field:
+ * - drag vertically to scrub (multiplicative; up = faster),
+ * - click to type an exact value (Enter / blur commits, Escape reverts),
+ * - double-click to reset to 1×.
+ *
+ * The scrub engages the Pointer Lock API once a real drag starts, so movement
+ * deltas keep flowing even when the cursor would otherwise hit the bottom of
+ * the screen — the controls sit near the modal's bottom edge, where a plain
+ * pointer-capture drag runs out of runway. Falls back to unlocked movement
+ * deltas where Pointer Lock is unavailable.
  */
 const SpeedControl: React.FC = () => {
   const speed = useSpeed();
   const { setSpeed } = usePlayback();
 
-  return (
-    <Dropdown
-      anchor={DropdownAnchor.Top}
-      className={styles.speed}
-      trigger={
-        <DropdownTrigger
-          size={Size.Xs}
-          data-testid="timeline-controls-speed"
-          aria-label={`Playback speed: ${fmtSpeed(speed)}`}
-        >
-          {fmtSpeed(speed)}
-        </DropdownTrigger>
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+
+  // Latest speed, readable from the drag's native listeners without re-binding
+  // them each render.
+  const speedRef = useRef(speed);
+  speedRef.current = speed;
+
+  // Teardown for an in-flight drag, invoked on pointer-up and on unmount so a
+  // drag interrupted by an unmount doesn't leak window listeners / a lock.
+  const endDragRef = useRef<(() => void) | null>(null);
+  useEffect(() => () => endDragRef.current?.(), []);
+
+  // Focus + select-all once the input flips to editable, so typing overwrites.
+  useEffect(() => {
+    if (editing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [editing]);
+
+  const beginEdit = () => {
+    setDraft(String(speedRef.current));
+    setEditing(true);
+  };
+
+  const commit = () => {
+    const parsed = parseSpeed(draft);
+    // Invalid / empty input reverts to the committed speed (display re-reads it).
+    if (parsed !== null) setSpeed(roundSpeed(parsed));
+    setEditing(false);
+  };
+
+  const nudge = (dir: 1 | -1) => {
+    const base = editing ? (parseSpeed(draft) ?? speed) : speed;
+    const next = roundSpeed(base * NUDGE_FACTOR ** dir);
+    if (editing) setDraft(String(next));
+    setSpeed(next);
+  };
+
+  const onScrubStart = (e: React.PointerEvent<HTMLInputElement>) => {
+    // While already editing, leave pointer handling to the text field so caret
+    // placement / selection work normally.
+    if (editing) return;
+    // Suppress the focus + caret a pointer-down on an input would trigger; we
+    // decide click-vs-scrub on pointer-up and focus manually if it was a click.
+    e.preventDefault();
+
+    const target = e.currentTarget;
+    const startSpeed = speedRef.current;
+    let accum = 0; // signed movement since start (negative = up = faster)
+    let moved = 0; // total travel, for the click-vs-scrub decision
+    let locked = false;
+
+    const onMove = (ev: PointerEvent) => {
+      const dy = ev.movementY || 0;
+      accum += dy;
+      moved += Math.abs(dy);
+      if (moved < CLICK_PX_THRESHOLD) return;
+      if (!locked) {
+        // Engage Pointer Lock only once we know it's a real drag, so a plain
+        // click never hides the cursor. Best-effort: unlocked deltas still work
+        // until the cursor reaches a screen edge.
+        try {
+          target.requestPointerLock?.();
+        } catch {
+          /* Pointer Lock unavailable — keep dragging unlocked. */
+        }
+        locked = true;
       }
-    >
-      {SPEED_PRESETS.map((n) => (
-        <MenuCheckItem
-          key={n}
-          checked={n === speed}
-          onClick={() => setSpeed(n)}
-          data-testid={`timeline-controls-speed-option-${n}`}
-        >
-          {fmtSpeed(n)}
-        </MenuCheckItem>
-      ))}
-    </Dropdown>
+      setSpeed(roundSpeed(startSpeed * 2 ** (-accum / PX_PER_DOUBLING)));
+    };
+
+    const end = () => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", end);
+      if (locked) document.exitPointerLock?.();
+      endDragRef.current = null;
+    };
+
+    const onUp = () => {
+      end();
+      // A pointer-up that never moved far is a click → open for typing.
+      if (moved < CLICK_PX_THRESHOLD) beginEdit();
+    };
+
+    endDragRef.current = end;
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp, { once: true });
+  };
+
+  return (
+    <input
+      ref={inputRef}
+      type="text"
+      inputMode="decimal"
+      role="spinbutton"
+      aria-label="Playback speed"
+      aria-valuenow={speed}
+      aria-valuemin={MIN_SPEED}
+      aria-valuemax={MAX_SPEED}
+      data-testid="timeline-controls-speed"
+      className={clsx(styles.speed, styles.speedInput)}
+      readOnly={!editing}
+      value={editing ? draft : fmtSpeed(speed)}
+      onChange={(e) => setDraft(e.target.value)}
+      onPointerDown={onScrubStart}
+      onDoubleClick={() => {
+        setEditing(false);
+        setSpeed(1);
+      }}
+      onKeyDown={(e) => {
+        if (e.key === "ArrowUp") {
+          e.preventDefault();
+          nudge(1);
+        } else if (e.key === "ArrowDown") {
+          e.preventDefault();
+          nudge(-1);
+        } else if (e.key === "Enter") {
+          e.preventDefault();
+          if (editing) commit();
+          else beginEdit();
+        } else if (e.key === "Escape" && editing) {
+          e.preventDefault();
+          setEditing(false);
+        }
+      }}
+      onBlur={() => {
+        if (editing) commit();
+      }}
+    />
   );
 };
 

--- a/app/packages/playback/src/views/TimelineControls/TimelineControls.module.css
+++ b/app/packages/playback/src/views/TimelineControls/TimelineControls.module.css
@@ -22,6 +22,32 @@
   margin-left: 2px;
 }
 
+/* Scrubbable speed field: ns-resize hints the vertical drag; a subtle border
+   appears on hover and turns into a focus ring while typing. Fixed width so
+   the row doesn't jitter as the value changes (0.1×…8×). */
+.speedInput {
+  width: 42px;
+  padding: 2px 4px;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--color-content-text-secondary);
+  font-size: 12px;
+  text-align: center;
+  cursor: ns-resize;
+}
+
+.speedInput:hover {
+  border-color: var(--color-content-border-default);
+}
+
+.speedInput:focus {
+  border-color: var(--color-brand-primary);
+  color: var(--color-content-text-primary);
+  cursor: text;
+  outline: none;
+}
+
 .divider {
   width: 1px;
   height: 12px;

--- a/app/packages/playback/src/views/TimelineControls/TimelineControls.module.css
+++ b/app/packages/playback/src/views/TimelineControls/TimelineControls.module.css
@@ -17,6 +17,11 @@
   cursor: pointer;
 }
 
+.speed {
+  flex-shrink: 0;
+  margin-left: 2px;
+}
+
 .divider {
   width: 1px;
   height: 12px;

--- a/app/packages/playback/src/views/TimelineControls/TimelineControls.module.css
+++ b/app/packages/playback/src/views/TimelineControls/TimelineControls.module.css
@@ -45,6 +45,10 @@
   border-color: var(--color-brand-primary);
   color: var(--color-content-text-primary);
   cursor: text;
+}
+
+/* Drop the ring only for pointer focus; keyboard focus keeps the native ring. */
+.speedInput:focus:not(:focus-visible) {
   outline: none;
 }
 

--- a/app/packages/playback/src/views/TimelineControls/TimelineControls.tsx
+++ b/app/packages/playback/src/views/TimelineControls/TimelineControls.tsx
@@ -20,6 +20,7 @@ import {
 } from "../../lib/playback/use-playback-state";
 import LoopBounds from "../Loop/LoopBounds";
 import PlayheadTime from "../Playhead/PlayheadTime";
+import SpeedControl from "./SpeedControl";
 import { PauseIcon, PlayIcon } from "./timeline-controls-icons";
 import styles from "./TimelineControls.module.css";
 
@@ -147,6 +148,7 @@ const TimelineControls: React.FC<TimelineControlsProps> = ({
         aria-label="Step forward"
         onClick={stepForward}
       />
+      <SpeedControl />
 
       {extraControls}
 


### PR DESCRIPTION
## 🔗 Related Issues

Jira: [FOEPD-4199](https://voxel51.atlassian.net/browse/FOEPD-4199) — Add speed modifier in playback controls

## 📋 What changes are proposed in this pull request?

Adds a playback-speed control to the modern timeline controls (`TimelineControls`) used by the multimodal timeline. The playback engine already exposed speed state (`speedAtom` / `setSpeed` / `useSpeed`); this wires up the UI and enforces the valid range.

**Scrubbable speed input (`SpeedControl`)** — a single compact field, chosen over a preset dropdown so any value in range is reachable and the control stays tiny in a crowded row. Three interactions:
- **Drag vertically to scrub** — multiplicative mapping (up = faster), so the feel is consistent across the whole range rather than coarse at low speeds and twitchy at high ones.
- **Click to type** an exact value — Enter/blur commits, Escape reverts, lenient parsing (`2`, `2x`, `2×`), invalid input reverts, out-of-range values clamp and reflect (typing `50` shows `8×`).
- **Double-click to reset** to `1×`, plus Arrow-key nudge and `role="spinbutton"` for accessibility.

Reads the live `speedAtom` via `useSpeed()` (re-renders only on speed change, **not** per RAF tick) and writes through `usePlayback().setSpeed`.

**Range** — speed is valid on `(0, 8]`: any positive value up to a ceiling of `8×`. The ceiling is a UX guardrail (real sustained-playback limits come from decode/buffer throughput, which already self-stalls); `setSpeed` now clamps the upper bound in the engine so every caller stays in range. There is no policy floor — the smallest displayable value is `0.01×` (2-decimal rounding).

**New `usePointerLockDrag` hook (`playback/src/utils/`)** — the scrub is driven by relative mouse motion via the Pointer Lock API (`movementX/Y`) rather than absolute pointer position. This keeps drag deltas flowing even when the cursor reaches a screen edge, which matters because the controls sit at the bottom of the modal where a position-based drag runs out of runway. Distinct from the existing `useDragDelta` (which measures `clientX/Y` and is bounded by the screen); the hook is reusable and has no playback-specific dependencies.

https://github.com/user-attachments/assets/f46a9b7f-7bc4-41ea-b570-a1df28f2e669


## 🧪 How is this patch tested? If it is not, please explain why.

- **`SpeedControl.test.tsx`** (15 cases): default/initial display, click-to-edit, commit on Enter and blur, Escape revert, lenient parse, invalid-input revert, clamp above `MAX_SPEED`, small-positive values below `0.1×`, scrub up/down, double-click reset, Arrow-key nudge, and spinbutton a11y attributes.
- **`usePointerLockDrag.test.tsx`** (6 cases): click vs. drag detection, cumulative signed delta, click threshold, axis selection, pointer-lock request/exit, and `isDragging` state.
- **Engine** (`PlaybackProvider.test.tsx`): added a case asserting `setSpeed` clamps values above `MAX_SPEED` to the ceiling; existing reject-invalid cases still pass.
- **Manual testing:** drag/type/reset in the modal; confirmed dragging past the bottom screen edge keeps decreasing speed via Pointer Lock.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

Playback controls for the multimodal timeline now include a speed control: drag it up/down to scrub playback speed, or click to type an exact value (0×–8×).

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other


[FOEPD-4199]: https://voxel51.atlassian.net/browse/FOEPD-4199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a playback speed control to the timeline with scrubbing drag, click-to-edit, arrow-key adjustments, and double-click reset.
  * Enforced a defined playback speed range and exposed speed bounds via ARIA for improved accessibility.
* **Bug Fixes**
  * Speed updates are now clamped to a maximum value and safely ignore invalid or empty inputs during edits.
* **Tests**
  * Added test coverage for pointer-lock drag behavior and the speed control’s interactions, clamping, and ARIA semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3212
<!-- enterprise-sync-pr:end -->