### PR TITLE
[bug] Fix bug with new Temporal Tags response schema

### DIFF
--- a/app/packages/multimodal/src/temporal-tags/client.test.ts
+++ b/app/packages/multimodal/src/temporal-tags/client.test.ts
@@ -55,7 +55,7 @@ describe("createTemporalTagsClient", () => {
   });
 
   it("serializes repeated filter query params", async () => {
-    const fetchFunction = createFetch({ temporal_tags: [] });
+    const fetchFunction = createFetch({ tags: [] });
     const client = createTemporalTagsClient({
       fetchFunction: fetchFunction as never,
     });
@@ -86,7 +86,7 @@ describe("createTemporalTagsClient", () => {
 
   it("converts create bodies and response tags between app and route shapes", async () => {
     const fetchFunction = createFetch({
-      temporal_tags: [createTemporalTagDto()],
+      tags: [createTemporalTagDto()],
     });
     const client = createTemporalTagsClient({
       fetchFunction: fetchFunction as never,
@@ -131,7 +131,7 @@ describe("createTemporalTagsClient", () => {
 
   it("converts update bodies without route-owned identity fields", async () => {
     const fetchFunction = createFetch({
-      temporal_tag: createTemporalTagDto({ end: 15, tag: "moved" }),
+      tag: createTemporalTagDto({ end: 15, tag: "moved" }),
     });
     const client = createTemporalTagsClient({
       fetchFunction: fetchFunction as never,
@@ -157,6 +157,49 @@ describe("createTemporalTagsClient", () => {
       "sample_id",
     );
     expect(tag.tag).toBe("moved");
+  });
+
+  it("reads list responses from the `tags` field", async () => {
+    const fetchFunction = createFetch({ tags: [createTemporalTagDto()] });
+    const client = createTemporalTagsClient({
+      fetchFunction: fetchFunction as never,
+    });
+
+    await expect(
+      client.listSampleTemporalTags({
+        datasetId: "dataset-id",
+        sampleId: "sample-id",
+      }),
+    ).resolves.toHaveLength(1);
+    await expect(
+      client.listDatasetTemporalTags({ datasetId: "dataset-id" }),
+    ).resolves.toHaveLength(1);
+    await expect(
+      client.createSampleTemporalTags({
+        datasetId: "dataset-id",
+        sampleId: "sample-id",
+        temporalTags: [createTemporalTagInput()],
+      }),
+    ).resolves.toHaveLength(1);
+  });
+
+  it("reads single-tag responses from the `tag` field", async () => {
+    const fetchFunction = createFetch({
+      tag: createTemporalTagDto({ tag: "moved" }),
+    });
+    const client = createTemporalTagsClient({
+      fetchFunction: fetchFunction as never,
+    });
+
+    const tag = await client.updateSampleTemporalTag({
+      datasetId: "dataset-id",
+      sampleId: "sample-id",
+      temporalTagId: "temporal-tag-id",
+      update: { tag: "moved" },
+    });
+
+    expect(tag.tag).toBe("moved");
+    expect(tag.id).toBe("temporal-tag-id");
   });
 
   it("supports deleting explicit temporal tag ids", async () => {
@@ -228,10 +271,10 @@ function responseForRoute(config: FetchConfig) {
   }
 
   if (config.method === "PATCH") {
-    return { temporal_tag: createTemporalTagDto() };
+    return { tag: createTemporalTagDto() };
   }
 
-  return { temporal_tags: [createTemporalTagDto()] };
+  return { tags: [createTemporalTagDto()] };
 }
 
 function routeKey(config: FetchConfig) {

--- a/app/packages/multimodal/src/temporal-tags/client.ts
+++ b/app/packages/multimodal/src/temporal-tags/client.ts
@@ -31,11 +31,11 @@ type TemporalTagDto = {
 };
 
 type TemporalTagsResponseDto = {
-  readonly temporal_tags: readonly TemporalTagDto[];
+  readonly tags: readonly TemporalTagDto[];
 };
 
 type TemporalTagResponseDto = {
-  readonly temporal_tag: TemporalTagDto;
+  readonly tag: TemporalTagDto;
 };
 
 type TemporalTagCountsResponseDto = {
@@ -80,7 +80,7 @@ export function createTemporalTagsClient(
         )}/sample/${encodeURIComponent(sampleId)}/tags`,
       });
 
-      return response.response.temporal_tags.map(temporalTagFromDto);
+      return response.response.tags.map(temporalTagFromDto);
     },
 
     async clearSampleTemporalTags({
@@ -151,7 +151,7 @@ export function createTemporalTagsClient(
         ),
       });
 
-      return response.response.temporal_tags.map(temporalTagFromDto);
+      return response.response.tags.map(temporalTagFromDto);
     },
 
     async listSampleTemporalTags({
@@ -169,7 +169,7 @@ export function createTemporalTagsClient(
         ),
       });
 
-      return response.response.temporal_tags.map(temporalTagFromDto);
+      return response.response.tags.map(temporalTagFromDto);
     },
 
     async updateSampleTemporalTag({
@@ -191,7 +191,7 @@ export function createTemporalTagsClient(
         )}`,
       });
 
-      return temporalTagFromDto(response.response.temporal_tag);
+      return temporalTagFromDto(response.response.tag);
     },
   };
 }


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link.

## 📋 What changes are proposed in this pull request?

The temporal tags backend routes were updated to return tags under generic
`tags` / `tag` response keys instead of the previous `temporal_tags` /
`temporal_tag` keys. The App client (`temporal-tags/client.ts`) was still
reading the old field names, so every read path silently broke:

- `listSampleTemporalTags`, `listDatasetTemporalTags`, and
  `createSampleTemporalTags` threw `Cannot read properties of undefined
  (reading 'map')` because `response.response.temporal_tags` no longer existed.
- `updateSampleTemporalTag` threw when mapping `response.response.temporal_tag`.

This PR points the client's response DTO types and read paths at the new
`tags` / `tag` fields. The request body key for `createSampleTemporalTags`
(`temporal_tags`) is unchanged, since only the response schema changed.

## 🧪 How is this patch tested? If it is not, please explain why.

Updated `temporal-tags/client.test.ts`:

- Migrated all response mocks (and the `responseForRoute` helper) to the new
  `tags` / `tag` schema. Without the client fix these mocks reproduce the
  runtime failures above.
- Added two regression tests that pin the parsing contract:
  - reads list/create responses from the `tags` field
  - reads single-tag (update) responses from the `tag` field

All 8 tests in the suite pass (`vitest run packages/multimodal/src/temporal-tags/client.test.ts`).

I also can now create tags without error.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

Fixed temporal tags failing to load and update in the App after the tags
route response schema changed.

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated temporal tag handling to match the latest API response field names, improving tag loading and updates across samples and datasets.
  * Adjusted client request/response conversions and test coverage to reflect the new `tags` (list) and `tag` (single) shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3176
<!-- enterprise-sync-pr:end -->