### PR TITLE
[FOEPD-3287] Support automatically selecting group slice in the target_view

### DIFF
--- a/fiftyone/operators/_types/types.py
+++ b/fiftyone/operators/_types/types.py
@@ -3061,6 +3061,7 @@ class ViewTargetProperty(Property):
         selected_samples_description=None,
         selected_labels_label="Selected labels",
         selected_labels_description=None,
+        require_flat=False,
         **kwargs,
     ):
         """Initializes instance
@@ -3111,7 +3112,20 @@ class ViewTargetProperty(Property):
             selected_labels_description (None): the description for the
                 "selected labels" target view. If ``None``, a default
                 description is generated
+            require_flat (False): whether the operation requires a flattened
+                (non-grouped) collection. When ``True``, grouped views that
+                cannot be automatically scoped to the active group slice
+                invalidate this property
         """
+        # surface unflattenable grouped views as a form validation error
+        # rather than an execution failure
+        invalid_error = None
+        if require_flat:
+            try:
+                # pylint: disable-next-line=protected-access
+                ctx._get_active_view(ctx.view, require_flat=True)
+            except ValueError as e:
+                invalid_error = str(e)
 
         # Determine which target views are available
         has_base_view = (
@@ -3171,6 +3185,10 @@ class ViewTargetProperty(Property):
             view=choice_view,
             **kwargs,
         )
+
+        if invalid_error is not None:
+            self.invalid = True
+            self.error_message = invalid_error
 
     @property
     def options(self):

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -20,6 +20,7 @@ import fiftyone as fo
 import fiftyone.core.dataset as fod
 import fiftyone.core.media as fom
 import fiftyone.core.odm as foo
+import fiftyone.core.stages as fosg
 import fiftyone.core.utils as fou
 import fiftyone.core.view as fov
 from fiftyone.core.session.constants import (
@@ -773,41 +774,84 @@ class ExecutionContext(contextlib.AbstractContextManager):
 
         return self._view
 
-    def target_view(self, param_name="view_target"):
+    def target_view(self, param_name="view_target", require_flat=False):
         """The target view for the operator being executed.
 
         Args:
             param_name ("view_target"): the name of the enum parameter defining
                 the target view choice
+            require_flat (False): whether the operation requires a flattened
+                (non-grouped) collection. When ``False``, grouped collections
+                are returned as-is. When ``True``, grouped collections are
+                flattened to the current active slice.
 
         Returns:
             a :class:`fiftyone.core.collections.SampleCollection`
         """
         target = self.params.get(param_name)
 
-        if target == constants.ViewTarget.CURRENT_VIEW:
-            return self.view
-        if target == constants.ViewTarget.DATASET:
-            return self.dataset
-        if target == constants.ViewTarget.BASE_VIEW:
-            return self.view._base_view  # pylint: disable=protected-access
-        if target == constants.ViewTarget.SELECTED_SAMPLES:
-            return self.view.select(self.selected)
-        if target == constants.ViewTarget.SELECTED_LABELS:
-            return self.view.select_labels(self.selected_labels)
-        if target == constants.ViewTarget.DATASET_VIEW:
-            return self.dataset.view()
-        if target == constants.ViewTarget.CUSTOM_VIEW_TARGET:
-            if (
+        match target:
+            case constants.ViewTarget.DATASET:
+                return self.dataset
+            case constants.ViewTarget.BASE_VIEW:
+                # pylint: disable-next-line=protected-access
+                return self.view._base_view
+            case constants.ViewTarget.CUSTOM_VIEW_TARGET if (
                 view_stages := self.params.get("custom_view_target")
             ) is not None:
                 # pylint: disable-next-line=protected-access
                 return fov.DatasetView._build(self.dataset, view_stages)
+            case constants.ViewTarget.DATASET_VIEW:
+                sample_collection = self.dataset.view()
+            case (
+                constants.ViewTarget.CURRENT_VIEW
+                | constants.ViewTarget.SELECTED_SAMPLES
+                | constants.ViewTarget.SELECTED_LABELS
+            ):
+                sample_collection = self.view
+            case _:
+                sample_collection = (
+                    self.view if self.has_custom_view else self.dataset
+                )
 
-        return self.view if self.has_custom_view else self.dataset
+        # scoping to the active slice compiles to a no-op pipeline, so the
+        # ordering relative to the selections below is immaterial
+        sample_collection = self._get_active_view(
+            sample_collection, require_flat=require_flat
+        )
+
+        if target == constants.ViewTarget.SELECTED_SAMPLES:
+            return sample_collection.select(self.selected)
+
+        if target == constants.ViewTarget.SELECTED_LABELS:
+            return sample_collection.select_labels(self.selected_labels)
+
+        return sample_collection
 
     # Alias for common word reversal
     view_target = target_view
+
+    def _get_active_view(self, sample_collection=None, require_flat=False):
+        # when a flat collection is required, grouped collections are scoped
+        # to the active group slice, unless the view already selects slices
+        if sample_collection is None:
+            sample_collection = self.dataset
+
+        if (
+            not require_flat
+            or self.group_slice is None
+            or sample_collection.media_type != fom.GROUP
+        ):
+            return sample_collection
+
+        stages = getattr(sample_collection, "_stages", None) or []
+        if any(isinstance(s, fosg.SelectGroupSlices) for s in stages):
+            raise ValueError(
+                "This operation requires a flattened view. Apply "
+                "select_group_slices(flat=True) to flatten the grouped view"
+            )
+
+        return sample_collection.select_group_slices(self.group_slice)
 
     @property
     def has_custom_view(self):
@@ -992,6 +1036,19 @@ class ExecutionContext(contextlib.AbstractContextManager):
     def group_slice(self):
         """The current group slice of the view (if any)."""
         return self.request_params.get("group_slice", None)
+
+    @property
+    def _active_media_type(self):
+        # the media type being processed, accounting for the active group
+        # slice of grouped datasets
+        dataset = self.dataset
+        if dataset is None:
+            return None
+
+        if dataset.media_type == fom.GROUP:
+            return dataset.group_media_types.get(dataset.group_slice)
+
+        return dataset.media_type
 
     @property
     def num_distributed_tasks(self):

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -961,6 +961,20 @@ class ExecutionContext(contextlib.AbstractContextManager):
         return self.request_params.get("active_fields", [])
 
     @property
+    def active_media_type(self):
+        """The media type being processed, accounting for the active group
+        slice of grouped datasets.
+        """
+        dataset = self.dataset
+        if dataset is None:
+            return None
+
+        if dataset.media_type == fom.GROUP:
+            return dataset.group_media_types.get(dataset.group_slice)
+
+        return dataset.media_type
+
+    @property
     def user_id(self):
         """The ID of the user executing the operation, if known."""
         return self.user.id if self.user else None
@@ -1036,19 +1050,6 @@ class ExecutionContext(contextlib.AbstractContextManager):
     def group_slice(self):
         """The current group slice of the view (if any)."""
         return self.request_params.get("group_slice", None)
-
-    @property
-    def _active_media_type(self):
-        # the media type being processed, accounting for the active group
-        # slice of grouped datasets
-        dataset = self.dataset
-        if dataset is None:
-            return None
-
-        if dataset.media_type == fom.GROUP:
-            return dataset.group_media_types.get(dataset.group_slice)
-
-        return dataset.media_type
 
     @property
     def num_distributed_tasks(self):

--- a/tests/unittests/operators/target_view_tests.py
+++ b/tests/unittests/operators/target_view_tests.py
@@ -6,6 +6,7 @@ FiftyOne operator type target_view tests.
 |
 """
 
+import os
 import unittest
 
 import fiftyone as fo
@@ -283,8 +284,8 @@ class TestGroupedDatasetTargetView(unittest.TestCase):
         self.assertEqual(target.media_type, "image")
         self.assertEqual(len(target), 2)
         self.assertSetEqual(
-            set(target.values("filepath")),
-            {"/path/to/left1.jpg", "/path/to/left2.jpg"},
+            {os.path.basename(f) for f in target.values("filepath")},
+            {"left1.jpg", "left2.jpg"},
         )
 
     def test_current_view_target_is_scoped_to_active_slice(self):

--- a/tests/unittests/operators/target_view_tests.py
+++ b/tests/unittests/operators/target_view_tests.py
@@ -8,8 +8,6 @@ FiftyOne operator type target_view tests.
 
 import unittest
 
-import bson
-
 import fiftyone as fo
 import fiftyone.operators as foo
 from fiftyone.operators import types
@@ -205,3 +203,144 @@ class TestResolveOperatorTargetViewInputs(unittest.TestCase):
             )
         finally:
             ds.delete()
+
+
+class TestGroupedDatasetTargetView(unittest.TestCase):
+    """Resolution of ``ctx.target_view()`` for grouped datasets."""
+
+    dataset = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.dataset = fo.Dataset()
+        cls.dataset.add_group_field("group", default="left")
+
+        group1 = fo.Group()
+        group2 = fo.Group()
+        cls.dataset.add_samples(
+            [
+                fo.Sample(
+                    filepath="/path/to/left1.jpg",
+                    group=group1.element("left"),
+                ),
+                fo.Sample(
+                    filepath="/path/to/lidar1.pcd",
+                    group=group1.element("lidar"),
+                ),
+                fo.Sample(
+                    filepath="/path/to/left2.jpg",
+                    group=group2.element("left"),
+                ),
+                fo.Sample(
+                    filepath="/path/to/lidar2.pcd",
+                    group=group2.element("lidar"),
+                ),
+            ]
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.dataset.delete()
+
+    def setUp(self):
+        # contexts with a group_slice reassign the singleton's active slice,
+        # so reset it for test independence
+        self.dataset.group_slice = "left"
+
+    def _ctx(self, **request_params):
+        return foo.ExecutionContext(
+            operator_uri="test_operator",
+            request_params=dict(
+                dataset_name=self.dataset.name,
+                dataset_id=self.dataset._doc.id,
+                **request_params,
+            ),
+        )
+
+    def test_no_group_slice_preserves_legacy_behavior(self):
+        ctx = self._ctx()
+        self.assertEqual(ctx.target_view(require_flat=True), self.dataset)
+        self.assertEqual(ctx._get_active_view(require_flat=True), self.dataset)
+
+    def test_default_is_not_scoped_without_require_flat(self):
+        ctx = self._ctx(group_slice="left")
+        self.assertEqual(ctx.target_view(), self.dataset)
+
+        stage = fo.SelectGroupSlices(["left", "lidar"], flat=False)
+        ctx = self._ctx(group_slice="left", view=[stage._serialize()])
+        self.assertEqual(ctx.target_view().media_type, "group")
+
+    def test_active_media_type_follows_active_slice(self):
+        self.assertEqual(
+            self._ctx(group_slice="left")._active_media_type, "image"
+        )
+        self.assertEqual(
+            self._ctx(group_slice="lidar")._active_media_type, "point-cloud"
+        )
+
+    def test_default_target_is_scoped_to_active_slice(self):
+        target = self._ctx(group_slice="left").target_view(require_flat=True)
+        self.assertEqual(target.media_type, "image")
+        self.assertEqual(len(target), 2)
+        self.assertSetEqual(
+            set(target.values("filepath")),
+            {"/path/to/left1.jpg", "/path/to/left2.jpg"},
+        )
+
+    def test_current_view_target_is_scoped_to_active_slice(self):
+        ctx = self._ctx(group_slice="lidar")
+        ctx.params["view_target"] = foo.constants.ViewTarget.CURRENT_VIEW
+
+        target = ctx.target_view(require_flat=True)
+        self.assertEqual(target.media_type, "point-cloud")
+        self.assertEqual(len(target), 2)
+
+    def test_dataset_target_is_not_scoped(self):
+        ctx = self._ctx(group_slice="left")
+        ctx.params["view_target"] = foo.constants.ViewTarget.DATASET
+
+        self.assertEqual(ctx.target_view(require_flat=True), self.dataset)
+
+    def test_applied_view_is_scoped_to_active_slice(self):
+        ctx = self._ctx(
+            group_slice="left",
+            view=[
+                {
+                    "_cls": "fiftyone.core.stages.Limit",
+                    "kwargs": [["limit", 1]],
+                }
+            ],
+        )
+
+        target = ctx.target_view(require_flat=True)
+        self.assertEqual(target.media_type, "image")
+        self.assertEqual(len(target), 1)
+
+    def test_flattened_view_is_used_as_is(self):
+        stage = fo.SelectGroupSlices("lidar")
+        ctx = self._ctx(group_slice="left", view=[stage._serialize()])
+
+        target = ctx.target_view(require_flat=True)
+        self.assertEqual(target.media_type, "point-cloud")
+        self.assertEqual(len(target), 2)
+
+    def test_non_flat_slice_selection_raises(self):
+        stage = fo.SelectGroupSlices(["left", "lidar"], flat=False)
+        ctx = self._ctx(group_slice="left", view=[stage._serialize()])
+
+        with self.assertRaises(ValueError):
+            ctx.target_view(require_flat=True)
+
+    def test_non_flat_slice_selection_invalidates_view_target_property(self):
+        stage = fo.SelectGroupSlices(["left", "lidar"], flat=False)
+        ctx = self._ctx(group_slice="left", view=[stage._serialize()])
+
+        inputs = types.Object()
+        prop = inputs.view_target(ctx, require_flat=True)
+        self.assertTrue(prop.invalid)
+        self.assertIn("flattened view", prop.error_message)
+
+        # without require_flat, the property remains valid
+        inputs = types.Object()
+        prop = inputs.view_target(ctx)
+        self.assertFalse(prop.invalid)

--- a/tests/unittests/operators/target_view_tests.py
+++ b/tests/unittests/operators/target_view_tests.py
@@ -272,10 +272,10 @@ class TestGroupedDatasetTargetView(unittest.TestCase):
 
     def test_active_media_type_follows_active_slice(self):
         self.assertEqual(
-            self._ctx(group_slice="left")._active_media_type, "image"
+            self._ctx(group_slice="left").active_media_type, "image"
         )
         self.assertEqual(
-            self._ctx(group_slice="lidar")._active_media_type, "point-cloud"
+            self._ctx(group_slice="lidar").active_media_type, "point-cloud"
         )
 
     def test_default_target_is_scoped_to_active_slice(self):
@@ -300,6 +300,36 @@ class TestGroupedDatasetTargetView(unittest.TestCase):
         ctx.params["view_target"] = foo.constants.ViewTarget.DATASET
 
         self.assertEqual(ctx.target_view(require_flat=True), self.dataset)
+
+    def test_base_view_target_is_not_scoped(self):
+        ctx = self._ctx(
+            group_slice="left",
+            view=[
+                {
+                    "_cls": "fiftyone.core.stages.Limit",
+                    "kwargs": [["limit", 1]],
+                }
+            ],
+        )
+        ctx.params["view_target"] = foo.constants.ViewTarget.BASE_VIEW
+
+        target = ctx.target_view(require_flat=True)
+        self.assertEqual(target.media_type, "group")
+        self.assertEqual(len(target), 2)
+
+    def test_custom_view_target_is_not_scoped(self):
+        ctx = self._ctx(group_slice="left")
+        ctx.params["view_target"] = foo.constants.ViewTarget.CUSTOM_VIEW_TARGET
+        ctx.params["custom_view_target"] = [
+            {
+                "_cls": "fiftyone.core.stages.Limit",
+                "kwargs": [["limit", 1]],
+            }
+        ]
+
+        target = ctx.target_view(require_flat=True)
+        self.assertEqual(target.media_type, "group")
+        self.assertEqual(len(target), 1)
 
     def test_applied_view_is_scoped_to_active_slice(self):
         ctx = self._ctx(


### PR DESCRIPTION
<!--
Community contributors: target the `community` branch, not `develop`. PRs from
non-members are auto-retargeted to `community`. See CONTRIBUTING.md:
https://github.com/voxel51/fiftyone/blob/develop/CONTRIBUTING.md#community-pull-requests
-->

## 🔗 Related Issues

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->

## 📋 What changes are proposed in this pull request?

- enable using builtin panels/operators on grouped datasets by automatically applying the active group slice

## 🧪 How is this patch tested? If it is not, please explain why.

- add tests
- run locally 

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [x] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `require_flat` support for operator view targeting, enabling accurate scoping for current view, selected samples, and selected labels on grouped datasets.
  * Introduced an effective `active_media_type` that follows the active slice.

* **Bug Fixes**
  * Improved target-view resolution for grouped datasets, including honoring flattened group-slice selections “as-is.”
  * When a flattened view is required but not possible, the view target is now marked invalid with a clear error message.

* **Tests**
  * Added unit coverage for grouped dataset target-view scoping and invalidation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3181
<!-- enterprise-sync-pr:end -->