### PR TITLE
[FVST-53] Upgrade `strawberry-graphql` to at least `0.315.7` to mitigate CVEs in fiftyone-app

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
         "sseclient-py>=1.7.2,<2",
         "sse-starlette>=0.10.3,<4",
         "starlette>=0.49.1,<1.1",
-        "strawberry-graphql>=0.312.3,<0.317.0",
+        "strawberry-graphql>=0.315.7,<0.317.0",
         "tabulate>=0.7,<0.11",
         "tqdm>=2,<5",
         "xmltodict>=1,<2",


### PR DESCRIPTION
## 🔗 Related Issues

- FVST-53
- CVE-2026-47706
- CVE-2026-45739
- CVE-2026-47707

## 📋 What changes are proposed in this pull request?

Upgrades `strawberry-graphql` to at least `0.315.7` to mitigate CVEs in fiftyone-app.

## 🧪 How is this patch tested? If it is not, please explain why.

1. Constrained `strawberry-graphql` to `==0.312.3` in `setup.py`, which is the lowest version allowed by the current constraint. (My system installed `0.316.0` by default, which is safe and didn't reproduce the CVEs.)
2. Built `fiftyone-app` image, confirmed CVE detected
3. Constrained `strawberry-graphql` to `>=0.315.7,<0.317.0` in `setup.py`
4. Re-installed repo
5. Built `fiftyone-app` image, confirmed CVE not detected

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes
- [x] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the minimum supported version of a key GraphQL dependency to a newer release, while keeping the existing upper version limit unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3184
<!-- enterprise-sync-pr:end -->