### PR TITLE
Add H264 MCAP video rendering

### DIFF
--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove.test.ts
@@ -1,9 +1,17 @@
+import { parse as parseRosMessageDefinition } from "@foxglove/rosmsg";
+import { parseRos2idl } from "@foxglove/ros2idl-parser";
+import { MessageWriter as Ros2MessageWriter } from "@foxglove/rosmsg2-serialization";
+import { Root } from "protobufjs";
+import descriptor from "protobufjs/ext/descriptor";
 import { describe, expect, it } from "vitest";
+import type { Decoder } from "../../../decoders";
 import { VISUALIZATION_KIND } from "../../../visualization";
 import { createMcapDecoderRegistry } from ".";
 import {
   foxgloveCameraCalibrationDecoder,
   foxgloveCompressedImageDecoder,
+  foxgloveCompressedVideoCdrDecoders,
+  foxgloveCompressedVideoDecoder,
   foxgloveGridDecoder,
   foxgloveLaserScanDecoder,
   foxgloveLocationFixDecoder,
@@ -29,6 +37,12 @@ describe("Foxglove decoders", () => {
     expect(registry.find(foxgloveCompressedImageDecoder.payload)).toBe(
       foxgloveCompressedImageDecoder,
     );
+    expect(registry.find(foxgloveCompressedVideoDecoder.payload)).toBe(
+      foxgloveCompressedVideoDecoder,
+    );
+    for (const decoder of foxgloveCompressedVideoCdrDecoders) {
+      expect(registry.find(decoder.payload)).toBe(decoder);
+    }
     expect(registry.find(foxglovePointCloudDecoder.payload)).toBe(
       foxglovePointCloudDecoder,
     );
@@ -138,6 +152,22 @@ describe("Foxglove decoders", () => {
     expect(output.visualization.mimeType).toBe("image/jpeg");
   });
 
+  it("degrades compressed image video formats without throwing", () => {
+    const output = foxgloveCompressedImageDecoder.decode(
+      compressedImageMessage("h264"),
+      {
+        schemaData: COMPRESSED_IMAGE_FIXTURE.schemaData,
+      },
+    );
+
+    expect(output.visualization).toBeUndefined();
+    expect(output.attributes).toMatchObject({
+      byteLength: 9,
+      format: "h264",
+      unsupportedReason: "H.264 video rendering not yet supported",
+    });
+  });
+
   it("normalizes whitespace and unknown compressed image formats", () => {
     const jpeg = foxgloveCompressedImageDecoder.decode(
       compressedImageMessage(" JPG "),
@@ -160,6 +190,79 @@ describe("Foxglove decoders", () => {
     }
     expect(jpeg.visualization.mimeType).toBe("image/jpeg");
     expect(unknown.visualization.mimeType).toBeUndefined();
+  });
+
+  it("degrades protobuf compressed video messages to metadata-only", () => {
+    const output = foxgloveCompressedVideoDecoder.decode(
+      compressedVideoMessage("h264"),
+      {
+        schemaData: COMPRESSED_VIDEO_SCHEMA_DATA,
+        sourceTimestamps: {
+          captureTime: 10n,
+          receiveTime: 11n,
+        },
+        streamId: "/camera/video",
+        timeRangeStartKey: "captureTime",
+      },
+    );
+
+    expect(output.visualization).toBeUndefined();
+    expect(output.attributes).toMatchObject({
+      byteLength: 8,
+      format: "h264",
+      frameId: "CAM_VIDEO",
+      unsupportedReason: "H.264 video rendering not yet supported",
+    });
+    expect(output.timing?.timeRange?.startNs).toBe(10n);
+    expect(output.timing?.sourceTimestamps?.messageTime).toBe(123456000000000n);
+  });
+
+  it("degrades cdr compressed video messages to metadata-only", () => {
+    const output = decoderForSchemaEncoding(
+      foxgloveCompressedVideoCdrDecoders,
+      "ros2msg",
+    ).decode(
+      ros2Message(ROS2_COMPRESSED_VIDEO_SCHEMA, {
+        data: [0, 0, 0, 1, 0x67, 0x4d, 0x0c, 0x33],
+        format: "vp9",
+        frame_id: "CAM_VIDEO",
+        timestamp: { nanosec: 4, sec: 3 },
+      }),
+      { schemaData: schemaData(ROS2_COMPRESSED_VIDEO_SCHEMA) },
+    );
+
+    expect(output.visualization).toBeUndefined();
+    expect(output.attributes).toMatchObject({
+      byteLength: 8,
+      format: "vp9",
+      frameId: "CAM_VIDEO",
+      unsupportedReason: "VP9 video rendering not yet supported",
+    });
+    expect(output.timing?.sourceTimestamps?.messageTime).toBe(3_000_000_004n);
+  });
+
+  it("registers compressed video cdr payloads for both ROS 2 schema spellings", () => {
+    const output = decoderForSchemaEncoding(
+      foxgloveCompressedVideoCdrDecoders,
+      "ros2idl",
+    ).decode(
+      ros2IdlMessage(ROS2_IDL_COMPRESSED_VIDEO_SCHEMA, {
+        data: [1, 2, 3],
+        format: "av1",
+        frame_id: "CAM_IDL",
+        timestamp: { nsec: 6, sec: 5 },
+      }),
+      { schemaData: schemaData(ROS2_IDL_COMPRESSED_VIDEO_SCHEMA) },
+    );
+
+    expect(output.visualization).toBeUndefined();
+    expect(output.attributes).toMatchObject({
+      byteLength: 3,
+      format: "av1",
+      frameId: "CAM_IDL",
+      unsupportedReason: "AV1 video rendering not yet supported",
+    });
+    expect(output.timing?.sourceTimestamps?.messageTime).toBe(5_000_000_006n);
   });
 
   it("treats invalid optional bigint protobuf fields as absent", () => {
@@ -611,6 +714,15 @@ function compressedImageMessage(format: string): Uint8Array {
   );
 }
 
+function compressedVideoMessage(format: string): Uint8Array {
+  return concatProtobufFields(
+    protobufBytesField(1, concatProtobufFields(protobufVarintField(1, 123456))),
+    protobufBytesField(2, new TextEncoder().encode("CAM_VIDEO")),
+    protobufBytesField(3, Uint8Array.of(0, 0, 0, 1, 0x67, 0x4d, 0x0c, 0x33)),
+    protobufBytesField(4, new TextEncoder().encode(format)),
+  );
+}
+
 interface TestPointCloudField {
   readonly name: string;
   readonly offset: number;
@@ -904,4 +1016,120 @@ function concatProtobufFields(...fields: readonly Uint8Array[]): Uint8Array {
   }
 
   return result;
+}
+
+const COMPRESSED_VIDEO_ROOT = Root.fromJSON({
+  nested: {
+    foxglove: {
+      nested: {
+        CompressedVideo: {
+          fields: {
+            data: { id: 3, type: "bytes" },
+            format: { id: 4, type: "string" },
+            frameId: { id: 2, type: "string" },
+            timestamp: { id: 1, type: "google.protobuf.Timestamp" },
+          },
+        },
+      },
+    },
+    google: {
+      nested: {
+        protobuf: {
+          nested: {
+            Timestamp: {
+              fields: {
+                nanos: { id: 2, type: "int32" },
+                seconds: { id: 1, type: "int64" },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+});
+
+const COMPRESSED_VIDEO_SCHEMA_DATA = protobufDescriptorData(
+  COMPRESSED_VIDEO_ROOT,
+);
+
+const ROS2_COMPRESSED_VIDEO_SCHEMA = `builtin_interfaces/Time timestamp
+string frame_id
+uint8[] data
+string format
+================================================================================
+MSG: builtin_interfaces/Time
+int32 sec
+uint32 nanosec`;
+
+const ROS2_IDL_COMPRESSED_VIDEO_SCHEMA = `
+module foxglove_msgs {
+  module msg {
+    struct CompressedVideo {
+      builtin_interfaces::msg::Time timestamp;
+      string frame_id;
+      sequence<octet> data;
+      string format;
+    };
+  };
+};
+
+module builtin_interfaces {
+  module msg {
+    struct Time {
+      int32 sec;
+      uint32 nanosec;
+    };
+  };
+};
+`;
+
+function decoderForSchemaEncoding(
+  decoders: readonly Decoder[],
+  schemaEncoding: string,
+): Decoder {
+  const decoder = decoders.find(
+    (candidate) => candidate.payload.schemaEncoding === schemaEncoding,
+  );
+  if (!decoder) {
+    throw new Error(`Missing decoder for ${schemaEncoding}`);
+  }
+
+  return decoder;
+}
+
+function schemaData(schema: string): Uint8Array {
+  return new Uint8Array(new TextEncoder().encode(schema));
+}
+
+function ros2Message(
+  schema: string,
+  record: Record<string, unknown>,
+): Uint8Array {
+  const writer = new Ros2MessageWriter(
+    parseRosMessageDefinition(schema, { ros2: true }),
+  );
+  return writer.writeMessage(record);
+}
+
+function ros2IdlMessage(
+  schema: string,
+  record: Record<string, unknown>,
+): Uint8Array {
+  const writer = new Ros2MessageWriter(parseRos2idl(schema));
+  return writer.writeMessage(record);
+}
+
+function protobufDescriptorData(root: Root): Uint8Array {
+  return new Uint8Array(
+    descriptor.FileDescriptorSet.encode(
+      (
+        root as unknown as {
+          toDescriptor(
+            version: string,
+          ): Parameters<typeof descriptor.FileDescriptorSet.encode>[0];
+        }
+      ).toDescriptor("proto3"),
+    ).finish(),
+  );
 }

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove.test.ts
@@ -152,7 +152,7 @@ describe("Foxglove decoders", () => {
     expect(output.visualization.mimeType).toBe("image/jpeg");
   });
 
-  it("degrades compressed image video formats without throwing", () => {
+  it("keeps compressed image video formats metadata-only", () => {
     const output = foxgloveCompressedImageDecoder.decode(
       compressedImageMessage("h264"),
       {
@@ -164,7 +164,8 @@ describe("Foxglove decoders", () => {
     expect(output.attributes).toMatchObject({
       byteLength: 9,
       format: "h264",
-      unsupportedReason: "H.264 video rendering not yet supported",
+      unsupportedReason:
+        "Foxglove CompressedImage format 'h264' is unsupported",
     });
   });
 
@@ -192,7 +193,7 @@ describe("Foxglove decoders", () => {
     expect(unknown.visualization.mimeType).toBeUndefined();
   });
 
-  it("degrades protobuf compressed video messages to metadata-only", () => {
+  it("decodes protobuf compressed video messages into encoded video", () => {
     const output = foxgloveCompressedVideoDecoder.decode(
       compressedVideoMessage("h264"),
       {
@@ -206,15 +207,62 @@ describe("Foxglove decoders", () => {
       },
     );
 
-    expect(output.visualization).toBeUndefined();
+    expect(output.visualization?.kind).toBe(VISUALIZATION_KIND.ENCODED_VIDEO);
+    if (output.visualization?.kind !== VISUALIZATION_KIND.ENCODED_VIDEO) {
+      throw new Error("Expected encoded video visualization");
+    }
+    expect(output.visualization).toMatchObject({
+      codec: "h264",
+      coordinateFrameId: "CAM_VIDEO",
+      format: "h264",
+      keyframe: true,
+      timestampNs: 123456000000000n,
+    });
+    expect(output.visualization.h264).toMatchObject({
+      codecString: "avc1.4D001F",
+      hasFrame: true,
+    });
     expect(output.attributes).toMatchObject({
-      byteLength: 8,
+      byteLength: H264_KEYFRAME_BYTES.byteLength,
+      codec: "h264",
+      codecString: "avc1.4D001F",
       format: "h264",
       frameId: "CAM_VIDEO",
-      unsupportedReason: "H.264 video rendering not yet supported",
+      keyframe: true,
     });
     expect(output.timing?.timeRange?.startNs).toBe(10n);
     expect(output.timing?.sourceTimestamps?.messageTime).toBe(123456000000000n);
+  });
+
+  it("decodes cdr compressed video H.264 messages into encoded video", () => {
+    const output = decoderForSchemaEncoding(
+      foxgloveCompressedVideoCdrDecoders,
+      "ros2msg",
+    ).decode(
+      ros2Message(ROS2_COMPRESSED_VIDEO_SCHEMA, {
+        data: Array.from(H264_KEYFRAME_BYTES),
+        format: "h264",
+        frame_id: "CAM_VIDEO",
+        timestamp: { nanosec: 4, sec: 3 },
+      }),
+      { schemaData: schemaData(ROS2_COMPRESSED_VIDEO_SCHEMA) },
+    );
+
+    expect(output.visualization?.kind).toBe(VISUALIZATION_KIND.ENCODED_VIDEO);
+    if (output.visualization?.kind !== VISUALIZATION_KIND.ENCODED_VIDEO) {
+      throw new Error("Expected encoded video visualization");
+    }
+    expect(output.visualization).toMatchObject({
+      codec: "h264",
+      coordinateFrameId: "CAM_VIDEO",
+      keyframe: true,
+      timestampNs: 3_000_000_004n,
+    });
+    expect(output.attributes).toMatchObject({
+      codec: "h264",
+      frameId: "CAM_VIDEO",
+      keyframe: true,
+    });
   });
 
   it("degrades cdr compressed video messages to metadata-only", () => {
@@ -718,10 +766,31 @@ function compressedVideoMessage(format: string): Uint8Array {
   return concatProtobufFields(
     protobufBytesField(1, concatProtobufFields(protobufVarintField(1, 123456))),
     protobufBytesField(2, new TextEncoder().encode("CAM_VIDEO")),
-    protobufBytesField(3, Uint8Array.of(0, 0, 0, 1, 0x67, 0x4d, 0x0c, 0x33)),
+    protobufBytesField(3, H264_KEYFRAME_BYTES),
     protobufBytesField(4, new TextEncoder().encode(format)),
   );
 }
+
+const H264_KEYFRAME_BYTES = Uint8Array.of(
+  0,
+  0,
+  0,
+  1,
+  0x67,
+  0x4d,
+  0x00,
+  0x1f,
+  0,
+  0,
+  1,
+  0x68,
+  0xce,
+  0,
+  0,
+  1,
+  0x65,
+  0xb0,
+);
 
 interface TestPointCloudField {
   readonly name: string;

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove.test.ts
@@ -169,6 +169,42 @@ describe("Foxglove decoders", () => {
     });
   });
 
+  it("reports non-H.264 compressed image video formats with video reasons", () => {
+    const output = foxgloveCompressedImageDecoder.decode(
+      compressedImageMessage("vp9"),
+      {
+        schemaData: COMPRESSED_IMAGE_FIXTURE.schemaData,
+      },
+    );
+
+    expect(output.visualization).toBeUndefined();
+    expect(output.attributes).toMatchObject({
+      byteLength: 9,
+      format: "vp9",
+      unsupportedReason: "VP9 video rendering not yet supported",
+    });
+  });
+
+  it("keeps compressed images with missing formats previewable", () => {
+    const output = foxgloveCompressedImageDecoder.decode(
+      compressedImageMessage(),
+      {
+        schemaData: COMPRESSED_IMAGE_FIXTURE.schemaData,
+      },
+    );
+
+    expect(output.visualization?.kind).toBe(VISUALIZATION_KIND.ENCODED_IMAGE);
+    if (output.visualization?.kind !== VISUALIZATION_KIND.ENCODED_IMAGE) {
+      throw new Error("Expected encoded image visualization");
+    }
+    expect(output.visualization.mimeType).toBeUndefined();
+    expect(output.attributes).toMatchObject({
+      byteLength: 9,
+      format: "unknown",
+    });
+    expect(output.attributes?.unsupportedReason).toBeUndefined();
+  });
+
   it("normalizes whitespace and unknown compressed image formats", () => {
     const jpeg = foxgloveCompressedImageDecoder.decode(
       compressedImageMessage(" JPG "),
@@ -195,7 +231,7 @@ describe("Foxglove decoders", () => {
 
   it("decodes protobuf compressed video messages into encoded video", () => {
     const output = foxgloveCompressedVideoDecoder.decode(
-      compressedVideoMessage("h264"),
+      compressedVideoMessage("avc1.4D001F"),
       {
         schemaData: COMPRESSED_VIDEO_SCHEMA_DATA,
         sourceTimestamps: {
@@ -214,19 +250,19 @@ describe("Foxglove decoders", () => {
     expect(output.visualization).toMatchObject({
       codec: "h264",
       coordinateFrameId: "CAM_VIDEO",
-      format: "h264",
+      format: "avc1.4D001F",
       keyframe: true,
       timestampNs: 123456000000000n,
     });
     expect(output.visualization.h264).toMatchObject({
-      codecString: "avc1.4D001F",
+      codecString: "avc1.4d001f",
       hasFrame: true,
     });
     expect(output.attributes).toMatchObject({
       byteLength: H264_KEYFRAME_BYTES.byteLength,
       codec: "h264",
-      codecString: "avc1.4D001F",
-      format: "h264",
+      codecString: "avc1.4d001f",
+      format: "avc1.4D001F",
       frameId: "CAM_VIDEO",
       keyframe: true,
     });
@@ -289,6 +325,37 @@ describe("Foxglove decoders", () => {
     expect(output.timing?.sourceTimestamps?.messageTime).toBe(3_000_000_004n);
   });
 
+  it("reports missing compressed video formats without masking the reason", () => {
+    const protobuf = foxgloveCompressedVideoDecoder.decode(
+      compressedVideoMessage(),
+      {
+        schemaData: COMPRESSED_VIDEO_SCHEMA_DATA,
+      },
+    );
+    const cdr = decoderForSchemaEncoding(
+      foxgloveCompressedVideoCdrDecoders,
+      "ros2msg",
+    ).decode(
+      ros2Message(ROS2_COMPRESSED_VIDEO_SCHEMA, {
+        data: Array.from(H264_KEYFRAME_BYTES),
+        frame_id: "CAM_VIDEO",
+        timestamp: { nanosec: 4, sec: 3 },
+      }),
+      { schemaData: schemaData(ROS2_COMPRESSED_VIDEO_SCHEMA) },
+    );
+
+    expect(protobuf.visualization).toBeUndefined();
+    expect(protobuf.attributes).toMatchObject({
+      format: "unknown",
+      unsupportedReason: "Foxglove CompressedVideo format is missing",
+    });
+    expect(cdr.visualization).toBeUndefined();
+    expect(cdr.attributes).toMatchObject({
+      format: "unknown",
+      unsupportedReason: "Foxglove CompressedVideo format is missing",
+    });
+  });
+
   it("registers compressed video cdr payloads for both ROS 2 schema spellings", () => {
     const output = decoderForSchemaEncoding(
       foxgloveCompressedVideoCdrDecoders,
@@ -298,6 +365,7 @@ describe("Foxglove decoders", () => {
         data: [1, 2, 3],
         format: "av1",
         frame_id: "CAM_IDL",
+        // @foxglove/ros2idl-parser exposes builtin_interfaces/Time as nsec.
         timestamp: { nsec: 6, sec: 5 },
       }),
       { schemaData: schemaData(ROS2_IDL_COMPRESSED_VIDEO_SCHEMA) },
@@ -755,20 +823,26 @@ function text(data: Uint8Array): string {
   return new TextDecoder().decode(data);
 }
 
-function compressedImageMessage(format: string): Uint8Array {
-  return concatProtobufFields(
-    protobufBytesField(2, new TextEncoder().encode("fake-jpeg")),
-    protobufBytesField(3, new TextEncoder().encode(format)),
-  );
+function compressedImageMessage(format?: string): Uint8Array {
+  const fields = [protobufBytesField(2, new TextEncoder().encode("fake-jpeg"))];
+  if (format !== undefined) {
+    fields.push(protobufBytesField(3, new TextEncoder().encode(format)));
+  }
+
+  return concatProtobufFields(...fields);
 }
 
-function compressedVideoMessage(format: string): Uint8Array {
-  return concatProtobufFields(
+function compressedVideoMessage(format?: string): Uint8Array {
+  const fields = [
     protobufBytesField(1, concatProtobufFields(protobufVarintField(1, 123456))),
     protobufBytesField(2, new TextEncoder().encode("CAM_VIDEO")),
     protobufBytesField(3, H264_KEYFRAME_BYTES),
-    protobufBytesField(4, new TextEncoder().encode(format)),
-  );
+  ];
+  if (format !== undefined) {
+    fields.push(protobufBytesField(4, new TextEncoder().encode(format)));
+  }
+
+  return concatProtobufFields(...fields);
 }
 
 const H264_KEYFRAME_BYTES = Uint8Array.of(

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/compressed-image.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/compressed-image.ts
@@ -12,6 +12,7 @@ import {
   requiredBytes,
 } from "./protobuf/records";
 import { timingFromContext, timestampNs } from "./protobuf/timing";
+import { videoRenderingUnsupportedReason } from "../video-format";
 
 /**
  * Decoder for Foxglove compressed image protobuf messages.
@@ -35,9 +36,21 @@ export const foxgloveCompressedImageDecoder: Decoder = {
       byteLength: data.byteLength,
       format,
     };
+    const mimeType = mimeTypeFromFormat(format);
+    const unsupportedReason =
+      mimeType === null ? unsupportedImageReason(format) : undefined;
 
     if (frameId) {
       attributes.frameId = frameId;
+    }
+
+    if (unsupportedReason) {
+      attributes.unsupportedReason = unsupportedReason;
+      return {
+        attributes,
+        resourceHints: resourceHintsForArrayBufferViews(data),
+        timing: timingFromContext(context, messageTimestamp),
+      };
     }
 
     return {
@@ -47,18 +60,37 @@ export const foxgloveCompressedImageDecoder: Decoder = {
       visualization: {
         bytes: data,
         kind: VISUALIZATION_KIND.ENCODED_IMAGE,
-        mimeType: mimeTypeFromFormat(format),
+        mimeType: mimeType ?? undefined,
       },
     };
   },
 };
 
-function mimeTypeFromFormat(format: string): string | undefined {
+function mimeTypeFromFormat(format: string): string | null | undefined {
   const lowerFormat = format.trim().toLowerCase();
   if (!lowerFormat || lowerFormat === "unknown") {
     return undefined;
   }
 
-  const normalized = lowerFormat === "jpg" ? "jpeg" : lowerFormat;
-  return normalized.startsWith("image/") ? normalized : `image/${normalized}`;
+  const normalized = lowerFormat.startsWith("image/")
+    ? lowerFormat.slice("image/".length)
+    : lowerFormat;
+  const imageFormat = normalized === "jpg" ? "jpeg" : normalized;
+
+  switch (imageFormat) {
+    case "avif":
+    case "jpeg":
+    case "png":
+    case "webp":
+      return `image/${imageFormat}`;
+    default:
+      return null;
+  }
+}
+
+function unsupportedImageReason(format: string): string {
+  return (
+    videoRenderingUnsupportedReason(format) ??
+    `Foxglove CompressedImage format '${format}' is unsupported`
+  );
 }

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/compressed-image.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/compressed-image.ts
@@ -12,7 +12,10 @@ import {
   requiredBytes,
 } from "./protobuf/records";
 import { timingFromContext, timestampNs } from "./protobuf/timing";
-import { videoRenderingUnsupportedReason } from "../video-format";
+import {
+  videoCodecFromFormat,
+  videoRenderingUnsupportedReason,
+} from "../video-format";
 
 /**
  * Decoder for Foxglove compressed image protobuf messages.
@@ -89,6 +92,10 @@ function mimeTypeFromFormat(format: string): string | null | undefined {
 }
 
 function unsupportedImageReason(format: string): string {
+  if (videoCodecFromFormat(format) === "h264") {
+    return `Foxglove CompressedImage format '${format}' is unsupported`;
+  }
+
   return (
     videoRenderingUnsupportedReason(format) ??
     `Foxglove CompressedImage format '${format}' is unsupported`

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/compressed-image.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/compressed-image.ts
@@ -13,8 +13,9 @@ import {
 } from "./protobuf/records";
 import { timingFromContext, timestampNs } from "./protobuf/timing";
 import {
+  unsupportedSourceFormatReason,
+  unsupportedVideoFormatReason,
   videoCodecFromFormat,
-  videoRenderingUnsupportedReason,
 } from "../video-format";
 
 /**
@@ -92,12 +93,11 @@ function mimeTypeFromFormat(format: string): string | null | undefined {
 }
 
 function unsupportedImageReason(format: string): string {
+  // Keep Foxglove CompressedImage H.264 as image-only metadata; H.264 rendering
+  // is handled by video-specific message types with different expectations.
   if (videoCodecFromFormat(format) === "h264") {
-    return `Foxglove CompressedImage format '${format}' is unsupported`;
+    return unsupportedSourceFormatReason("Foxglove CompressedImage", format);
   }
 
-  return (
-    videoRenderingUnsupportedReason(format) ??
-    `Foxglove CompressedImage format '${format}' is unsupported`
-  );
+  return unsupportedVideoFormatReason("Foxglove CompressedImage", format);
 }

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/compressed-video.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/compressed-video.ts
@@ -21,8 +21,8 @@ import {
 } from "./protobuf/records";
 import { timingFromContext } from "./protobuf/timing";
 import {
+  unsupportedVideoFormatReason,
   videoCodecFromFormat,
-  videoRenderingUnsupportedReason,
 } from "../video-format";
 
 /**
@@ -41,7 +41,7 @@ export const foxgloveCompressedVideoDecoder: Decoder = {
     );
     return compressedVideoOutput({
       data: requiredBytes(message, "data"),
-      format: optionalString(message, "format") ?? "unknown",
+      format: optionalString(message, "format"),
       frameId: optionalString(message, "frameId", "frame_id"),
       messageTimestamp: rosTimestampNs(optionalRecord(message, "timestamp")),
       source: "Foxglove CompressedVideo",
@@ -58,7 +58,7 @@ export const foxgloveCompressedVideoCdrDecoders = rosDecodersForPayloads({
   map(message, context) {
     return compressedVideoOutput({
       data: bytesField(message, "data"),
-      format: optionalString(message, "format") ?? "unknown",
+      format: optionalString(message, "format"),
       frameId: optionalString(message, "frame_id", "frameId"),
       messageTimestamp: rosTimestampNs(recordField(message, "timestamp")),
       source: "Foxglove CompressedVideo",
@@ -77,53 +77,54 @@ function compressedVideoOutput({
   timingContext,
 }: {
   readonly data: Uint8Array;
-  readonly format: string;
+  readonly format?: string;
   readonly frameId?: string;
   readonly messageTimestamp?: bigint;
   readonly source: string;
   readonly timingContext: Parameters<typeof timingFromContext>[0];
 }): DecodedOutput {
+  const rawFormatForReason = format ?? "";
+  const displayFormat = format?.trim() ? format : "unknown";
   const attributes: Record<string, DecodedAttributeValue> = {
     byteLength: data.byteLength,
-    format,
+    format: displayFormat,
   };
-  const codec = videoCodecFromFormat(format);
+  const codec = videoCodecFromFormat(rawFormatForReason);
 
   if (frameId) {
     attributes.frameId = frameId;
   }
 
-  if (codec !== "h264") {
-    attributes.unsupportedReason = unsupportedCompressedVideoReason(
-      source,
-      format,
-    );
+  const metadataOnlyOutput = (reason: string): DecodedOutput => {
+    attributes.unsupportedReason = reason;
     return {
       attributes,
       resourceHints: resourceHintsForArrayBufferViews(data),
       timing: timingFromContext(timingContext, messageTimestamp),
     };
+  };
+
+  if (codec !== "h264") {
+    // Keep missing raw formats available to unsupportedSourceFormatReason while
+    // attributes use a display fallback.
+    return metadataOnlyOutput(
+      unsupportedVideoFormatReason(source, rawFormatForReason),
+    );
   }
 
   const h264 = analyzeH264AnnexBAccessUnit(data);
   if (!h264.hasStartCodes) {
-    attributes.unsupportedReason =
-      "H.264 video requires Annex-B NAL start codes";
-    return {
-      attributes,
-      resourceHints: resourceHintsForArrayBufferViews(data),
-      timing: timingFromContext(timingContext, messageTimestamp),
-    };
+    return metadataOnlyOutput("H.264 video requires Annex-B NAL start codes");
+  }
+
+  if (!h264.hasFrame) {
+    return metadataOnlyOutput("H.264 video requires frame NAL units");
   }
 
   if (h264.hasBFrames) {
-    attributes.unsupportedReason =
-      "H.264 video streams with B-frames are unsupported";
-    return {
-      attributes,
-      resourceHints: resourceHintsForArrayBufferViews(data),
-      timing: timingFromContext(timingContext, messageTimestamp),
-    };
+    return metadataOnlyOutput(
+      "H.264 video streams with B-frames are unsupported",
+    );
   }
 
   attributes.codec = "h264";
@@ -136,7 +137,7 @@ function compressedVideoOutput({
     bytes: data,
     codec: "h264",
     ...(frameId ? { coordinateFrameId: frameId } : {}),
-    format,
+    format: displayFormat,
     h264: {
       ...(h264.codecString ? { codecString: h264.codecString } : {}),
       hasFrame: h264.hasFrame,
@@ -156,13 +157,4 @@ function compressedVideoOutput({
     timing: timingFromContext(timingContext, messageTimestamp),
     visualization,
   };
-}
-
-function unsupportedCompressedVideoReason(source: string, format: string) {
-  return (
-    videoRenderingUnsupportedReason(format) ??
-    (format.trim()
-      ? `${source} format '${format}' is unsupported`
-      : `${source} format is missing`)
-  );
 }

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/compressed-video.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/compressed-video.ts
@@ -1,0 +1,106 @@
+import {
+  resourceHintsForArrayBufferViews,
+  type DecodedAttributeValue,
+  type DecodedOutput,
+  type Decoder,
+} from "../../../../decoders";
+import { bytesField, recordField, rosTimestampNs } from "../ros/common";
+import { rosDecodersForPayloads } from "../ros/factory";
+import { decodeProtobufMessage } from "./protobuf";
+import {
+  FOXGLOVE_COMPRESSED_VIDEO_CDR_PAYLOADS,
+  FOXGLOVE_COMPRESSED_VIDEO_PAYLOAD,
+} from "./payloads";
+import {
+  optionalRecord,
+  optionalString,
+  requiredBytes,
+} from "./protobuf/records";
+import { timingFromContext } from "./protobuf/timing";
+import { videoRenderingUnsupportedReason } from "../video-format";
+
+/**
+ * Decoder for Foxglove compressed video protobuf messages. Layer 1 makes
+ * these topics visible and inspectable, but does not emit renderable video
+ * visualizations until the WebCodecs playback layer exists.
+ */
+export const foxgloveCompressedVideoDecoder: Decoder = {
+  id: "foxglove.compressed-video",
+  payload: FOXGLOVE_COMPRESSED_VIDEO_PAYLOAD,
+  version: "1",
+
+  decode(bytes, context) {
+    const message = decodeProtobufMessage(
+      bytes,
+      FOXGLOVE_COMPRESSED_VIDEO_PAYLOAD,
+      context,
+    );
+    return compressedVideoOutput({
+      data: requiredBytes(message, "data"),
+      format: optionalString(message, "format") ?? "unknown",
+      frameId: optionalString(message, "frameId", "frame_id"),
+      messageTimestamp: rosTimestampNs(optionalRecord(message, "timestamp")),
+      source: "Foxglove CompressedVideo",
+      timingContext: context,
+    });
+  },
+};
+
+/**
+ * Decoders for Foxglove CompressedVideo messages carried over ROS 2 CDR.
+ */
+export const foxgloveCompressedVideoCdrDecoders = rosDecodersForPayloads({
+  id: "foxglove.compressed-video.cdr",
+  map(message, context) {
+    return compressedVideoOutput({
+      data: bytesField(message, "data"),
+      format: optionalString(message, "format") ?? "unknown",
+      frameId: optionalString(message, "frame_id", "frameId"),
+      messageTimestamp: rosTimestampNs(recordField(message, "timestamp")),
+      source: "Foxglove CompressedVideo",
+      timingContext: context,
+    });
+  },
+  payloads: FOXGLOVE_COMPRESSED_VIDEO_CDR_PAYLOADS,
+});
+
+function compressedVideoOutput({
+  data,
+  format,
+  frameId,
+  messageTimestamp,
+  source,
+  timingContext,
+}: {
+  readonly data: Uint8Array;
+  readonly format: string;
+  readonly frameId?: string;
+  readonly messageTimestamp?: bigint;
+  readonly source: string;
+  readonly timingContext: Parameters<typeof timingFromContext>[0];
+}): DecodedOutput {
+  const attributes: Record<string, DecodedAttributeValue> = {
+    byteLength: data.byteLength,
+    format,
+    unsupportedReason: unsupportedCompressedVideoReason(source, format),
+  };
+
+  if (frameId) {
+    attributes.frameId = frameId;
+  }
+
+  return {
+    attributes,
+    resourceHints: resourceHintsForArrayBufferViews(data),
+    timing: timingFromContext(timingContext, messageTimestamp),
+  };
+}
+
+function unsupportedCompressedVideoReason(source: string, format: string) {
+  return (
+    videoRenderingUnsupportedReason(format) ??
+    (format.trim()
+      ? `${source} format '${format}' is unsupported`
+      : `${source} format is missing`)
+  );
+}

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/compressed-video.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/compressed-video.ts
@@ -3,9 +3,12 @@ import {
   type DecodedAttributeValue,
   type DecodedOutput,
   type Decoder,
+  type EncodedVideoVisualization,
 } from "../../../../decoders";
+import { VISUALIZATION_KIND } from "../../../../visualization";
 import { bytesField, recordField, rosTimestampNs } from "../ros/common";
 import { rosDecodersForPayloads } from "../ros/factory";
+import { analyzeH264AnnexBAccessUnit } from "../../../../utils/h264-annexb";
 import { decodeProtobufMessage } from "./protobuf";
 import {
   FOXGLOVE_COMPRESSED_VIDEO_CDR_PAYLOADS,
@@ -17,12 +20,13 @@ import {
   requiredBytes,
 } from "./protobuf/records";
 import { timingFromContext } from "./protobuf/timing";
-import { videoRenderingUnsupportedReason } from "../video-format";
+import {
+  videoCodecFromFormat,
+  videoRenderingUnsupportedReason,
+} from "../video-format";
 
 /**
- * Decoder for Foxglove compressed video protobuf messages. Layer 1 makes
- * these topics visible and inspectable, but does not emit renderable video
- * visualizations until the WebCodecs playback layer exists.
+ * Decoder for Foxglove compressed video protobuf messages.
  */
 export const foxgloveCompressedVideoDecoder: Decoder = {
   id: "foxglove.compressed-video",
@@ -82,17 +86,75 @@ function compressedVideoOutput({
   const attributes: Record<string, DecodedAttributeValue> = {
     byteLength: data.byteLength,
     format,
-    unsupportedReason: unsupportedCompressedVideoReason(source, format),
   };
+  const codec = videoCodecFromFormat(format);
 
   if (frameId) {
     attributes.frameId = frameId;
   }
 
+  if (codec !== "h264") {
+    attributes.unsupportedReason = unsupportedCompressedVideoReason(
+      source,
+      format,
+    );
+    return {
+      attributes,
+      resourceHints: resourceHintsForArrayBufferViews(data),
+      timing: timingFromContext(timingContext, messageTimestamp),
+    };
+  }
+
+  const h264 = analyzeH264AnnexBAccessUnit(data);
+  if (!h264.hasStartCodes) {
+    attributes.unsupportedReason =
+      "H.264 video requires Annex-B NAL start codes";
+    return {
+      attributes,
+      resourceHints: resourceHintsForArrayBufferViews(data),
+      timing: timingFromContext(timingContext, messageTimestamp),
+    };
+  }
+
+  if (h264.hasBFrames) {
+    attributes.unsupportedReason =
+      "H.264 video streams with B-frames are unsupported";
+    return {
+      attributes,
+      resourceHints: resourceHintsForArrayBufferViews(data),
+      timing: timingFromContext(timingContext, messageTimestamp),
+    };
+  }
+
+  attributes.codec = "h264";
+  attributes.keyframe = h264.keyframe;
+  if (h264.codecString) {
+    attributes.codecString = h264.codecString;
+  }
+
+  const visualization = {
+    bytes: data,
+    codec: "h264",
+    ...(frameId ? { coordinateFrameId: frameId } : {}),
+    format,
+    h264: {
+      ...(h264.codecString ? { codecString: h264.codecString } : {}),
+      hasFrame: h264.hasFrame,
+      ...(h264.pps ? { pps: h264.pps } : {}),
+      ...(h264.sps ? { sps: h264.sps } : {}),
+    },
+    keyframe: h264.keyframe,
+    kind: VISUALIZATION_KIND.ENCODED_VIDEO,
+    ...(messageTimestamp !== undefined
+      ? { timestampNs: messageTimestamp }
+      : {}),
+  } satisfies EncodedVideoVisualization;
+
   return {
     attributes,
     resourceHints: resourceHintsForArrayBufferViews(data),
     timing: timingFromContext(timingContext, messageTimestamp),
+    visualization,
   };
 }
 

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/index.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/index.ts
@@ -1,6 +1,10 @@
 import type { Decoder } from "../../../../decoders";
 import { foxgloveCameraCalibrationDecoder } from "./camera-calibration";
 import { foxgloveCompressedImageDecoder } from "./compressed-image";
+import {
+  foxgloveCompressedVideoCdrDecoders,
+  foxgloveCompressedVideoDecoder,
+} from "./compressed-video";
 import { foxgloveGridDecoder } from "./grid";
 import { foxgloveImageAnnotationsDecoder } from "./image-annotations";
 import { foxgloveLaserScanDecoder } from "./laser-scan";
@@ -18,6 +22,14 @@ export { foxgloveCameraCalibrationDecoder } from "./camera-calibration";
  * Foxglove compressed image decoder export.
  */
 export { foxgloveCompressedImageDecoder } from "./compressed-image";
+
+/**
+ * Foxglove compressed video decoder export.
+ */
+export {
+  foxgloveCompressedVideoCdrDecoders,
+  foxgloveCompressedVideoDecoder,
+} from "./compressed-video";
 
 /**
  * Foxglove Grid decoder export.
@@ -55,11 +67,18 @@ export { foxglovePoseInFrameDecoder } from "./pose-in-frame";
 export { foxgloveSceneUpdateDecoder } from "./scene-update";
 
 /**
+ * Foxglove payload descriptor exports.
+ */
+export * from "./payloads";
+
+/**
  * Built-in Foxglove decoders for the MCAP adapter.
  */
 export const foxgloveDecoders: readonly Decoder[] = [
   foxgloveCameraCalibrationDecoder,
   foxgloveCompressedImageDecoder,
+  foxgloveCompressedVideoDecoder,
+  ...foxgloveCompressedVideoCdrDecoders,
   foxgloveGridDecoder,
   foxgloveImageAnnotationsDecoder,
   foxgloveLaserScanDecoder,

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/payloads.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/payloads.ts
@@ -1,0 +1,21 @@
+import type { PayloadDescriptor } from "../../../../decoders";
+
+export * from "./protobuf/payloads";
+
+/**
+ * Payload identities for foxglove_msgs/msg/CompressedVideo messages carried
+ * over ROS 2 CDR encodings.
+ */
+export const FOXGLOVE_COMPRESSED_VIDEO_CDR_PAYLOADS: readonly PayloadDescriptor[] =
+  [
+    {
+      encoding: "cdr",
+      schema: "foxglove_msgs/msg/CompressedVideo",
+      schemaEncoding: "ros2msg",
+    },
+    {
+      encoding: "cdr",
+      schema: "foxglove_msgs/msg/CompressedVideo",
+      schemaEncoding: "ros2idl",
+    },
+  ];

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/protobuf/payloads.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/protobuf/payloads.ts
@@ -13,6 +13,15 @@ export const FOXGLOVE_COMPRESSED_IMAGE_PAYLOAD: PayloadDescriptor = {
 };
 
 /**
+ * Payload identity for foxglove.CompressedVideo messages.
+ */
+export const FOXGLOVE_COMPRESSED_VIDEO_PAYLOAD: PayloadDescriptor = {
+  encoding: "protobuf",
+  schema: "foxglove.CompressedVideo",
+  schemaEncoding: "protobuf",
+};
+
+/**
  * Payload identity for foxglove.PointCloud messages.
  */
 export const FOXGLOVE_POINT_CLOUD_PAYLOAD: PayloadDescriptor = {

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros.test.ts
@@ -483,7 +483,7 @@ describe("ROS MCAP decoders", () => {
     ).decode(
       ros2Message(ROS2_COMPRESSED_IMAGE_SCHEMA, {
         data: Array.from(H264_KEYFRAME_BYTES),
-        format: "h264",
+        format: "bgr8; h264 compressed",
         header: {
           frame_id: "camera",
           stamp: { nanosec: 4, sec: 3 },
@@ -499,19 +499,19 @@ describe("ROS MCAP decoders", () => {
     expect(output.visualization).toMatchObject({
       codec: "h264",
       coordinateFrameId: "camera",
-      format: "h264",
+      format: "bgr8; h264 compressed",
       keyframe: true,
       timestampNs: 3_000_000_004n,
     });
     expect(output.visualization.h264).toMatchObject({
-      codecString: "avc1.4D001F",
+      codecString: "avc1.4d001f",
       hasFrame: true,
     });
     expect(output.attributes).toMatchObject({
       byteLength: H264_KEYFRAME_BYTES.byteLength,
       codec: "h264",
-      codecString: "avc1.4D001F",
-      format: "h264",
+      codecString: "avc1.4d001f",
+      format: "bgr8; h264 compressed",
       frameId: "camera",
       keyframe: true,
     });
@@ -540,6 +540,81 @@ describe("ROS MCAP decoders", () => {
       format: "h264",
       frameId: "camera",
       unsupportedReason: "H.264 video streams with B-frames are unsupported",
+    });
+  });
+
+  it("degrades ROS CompressedImage non-H.264 video formats", () => {
+    const output = decoderForSchemaEncoding(
+      rosCompressedImageDecoders,
+      "ros2msg",
+    ).decode(
+      ros2Message(ROS2_COMPRESSED_IMAGE_SCHEMA, {
+        data: [1, 2, 3],
+        format: "vp9",
+        header: {
+          frame_id: "camera",
+          stamp: { nanosec: 4, sec: 3 },
+        },
+      }),
+      { schemaData: schemaData(ROS2_COMPRESSED_IMAGE_SCHEMA) },
+    );
+
+    expect(output.visualization).toBeUndefined();
+    expect(output.attributes).toMatchObject({
+      byteLength: 3,
+      format: "vp9",
+      frameId: "camera",
+      unsupportedReason: "VP9 video rendering not yet supported",
+    });
+  });
+
+  it("degrades ROS CompressedImage H.264 without Annex-B start codes", () => {
+    const output = decoderForSchemaEncoding(
+      rosCompressedImageDecoders,
+      "ros2msg",
+    ).decode(
+      ros2Message(ROS2_COMPRESSED_IMAGE_SCHEMA, {
+        data: [0x65, 0xb0],
+        format: "h264",
+        header: {
+          frame_id: "camera",
+          stamp: { nanosec: 4, sec: 3 },
+        },
+      }),
+      { schemaData: schemaData(ROS2_COMPRESSED_IMAGE_SCHEMA) },
+    );
+
+    expect(output.visualization).toBeUndefined();
+    expect(output.attributes).toMatchObject({
+      byteLength: 2,
+      format: "h264",
+      frameId: "camera",
+      unsupportedReason: "H.264 video requires Annex-B NAL start codes",
+    });
+  });
+
+  it("degrades ROS CompressedImage H.264 parameter sets without frame NALs", () => {
+    const output = decoderForSchemaEncoding(
+      rosCompressedImageDecoders,
+      "ros2msg",
+    ).decode(
+      ros2Message(ROS2_COMPRESSED_IMAGE_SCHEMA, {
+        data: [0, 0, 0, 1, 0x67, 0x4d, 0x00, 0x1f, 0, 0, 1, 0x68, 0xce],
+        format: "h264",
+        header: {
+          frame_id: "camera",
+          stamp: { nanosec: 4, sec: 3 },
+        },
+      }),
+      { schemaData: schemaData(ROS2_COMPRESSED_IMAGE_SCHEMA) },
+    );
+
+    expect(output.visualization).toBeUndefined();
+    expect(output.attributes).toMatchObject({
+      byteLength: 13,
+      format: "h264",
+      frameId: "camera",
+      unsupportedReason: "H.264 video requires frame NAL units",
     });
   });
 

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros.test.ts
@@ -43,6 +43,26 @@ import {
 } from "./ros";
 
 const TEXT_ENCODER = new TextEncoder();
+const H264_KEYFRAME_BYTES = Uint8Array.of(
+  0,
+  0,
+  0,
+  1,
+  0x67,
+  0x4d,
+  0x00,
+  0x1f,
+  0,
+  0,
+  1,
+  0x68,
+  0xce,
+  0,
+  0,
+  1,
+  0x65,
+  0xb0,
+);
 
 const ROS2_HEADER_DEFINITIONS = `===
 MSG: std_msgs/Header
@@ -456,13 +476,55 @@ describe("ROS MCAP decoders", () => {
     expect(output.timing?.sourceTimestamps?.messageTime).toBe(3_000_000_004n);
   });
 
-  it("degrades ROS CompressedImage video formats without throwing", () => {
+  it("decodes ROS CompressedImage H.264 into encoded video", () => {
     const output = decoderForSchemaEncoding(
       rosCompressedImageDecoders,
       "ros2msg",
     ).decode(
       ros2Message(ROS2_COMPRESSED_IMAGE_SCHEMA, {
-        data: [0, 0, 0, 1, 0x67, 0x4d, 0x0c, 0x33],
+        data: Array.from(H264_KEYFRAME_BYTES),
+        format: "h264",
+        header: {
+          frame_id: "camera",
+          stamp: { nanosec: 4, sec: 3 },
+        },
+      }),
+      { schemaData: schemaData(ROS2_COMPRESSED_IMAGE_SCHEMA) },
+    );
+
+    expect(output.visualization?.kind).toBe(VISUALIZATION_KIND.ENCODED_VIDEO);
+    if (output.visualization?.kind !== VISUALIZATION_KIND.ENCODED_VIDEO) {
+      throw new Error("Expected encoded video visualization");
+    }
+    expect(output.visualization).toMatchObject({
+      codec: "h264",
+      coordinateFrameId: "camera",
+      format: "h264",
+      keyframe: true,
+      timestampNs: 3_000_000_004n,
+    });
+    expect(output.visualization.h264).toMatchObject({
+      codecString: "avc1.4D001F",
+      hasFrame: true,
+    });
+    expect(output.attributes).toMatchObject({
+      byteLength: H264_KEYFRAME_BYTES.byteLength,
+      codec: "h264",
+      codecString: "avc1.4D001F",
+      format: "h264",
+      frameId: "camera",
+      keyframe: true,
+    });
+    expect(output.timing?.sourceTimestamps?.messageTime).toBe(3_000_000_004n);
+  });
+
+  it("degrades ROS CompressedImage B-frame H.264 without throwing", () => {
+    const output = decoderForSchemaEncoding(
+      rosCompressedImageDecoders,
+      "ros2msg",
+    ).decode(
+      ros2Message(ROS2_COMPRESSED_IMAGE_SCHEMA, {
+        data: [0, 0, 1, 0x41, 0xa0],
         format: "h264",
         header: {
           frame_id: "camera",
@@ -474,12 +536,11 @@ describe("ROS MCAP decoders", () => {
 
     expect(output.visualization).toBeUndefined();
     expect(output.attributes).toMatchObject({
-      byteLength: 8,
+      byteLength: 5,
       format: "h264",
       frameId: "camera",
-      unsupportedReason: "H.264 video rendering not yet supported",
+      unsupportedReason: "H.264 video streams with B-frames are unsupported",
     });
-    expect(output.timing?.sourceTimestamps?.messageTime).toBe(3_000_000_004n);
   });
 
   it("decodes ros1 Image RGB/BGR rows with padding into raw RGBA", () => {

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros.test.ts
@@ -253,6 +253,11 @@ module builtin_interfaces {
   };
 };`;
 
+const ROS2_COMPRESSED_IMAGE_SCHEMA = `std_msgs/Header header
+string format
+uint8[] data
+${ROS2_HEADER_DEFINITIONS}`;
+
 const ROS1_IMAGE_SCHEMA = `std_msgs/Header header
 uint32 height
 uint32 width
@@ -447,6 +452,32 @@ describe("ROS MCAP decoders", () => {
       byteLength: 9,
       format: "jpeg",
       frameId: "camera",
+    });
+    expect(output.timing?.sourceTimestamps?.messageTime).toBe(3_000_000_004n);
+  });
+
+  it("degrades ROS CompressedImage video formats without throwing", () => {
+    const output = decoderForSchemaEncoding(
+      rosCompressedImageDecoders,
+      "ros2msg",
+    ).decode(
+      ros2Message(ROS2_COMPRESSED_IMAGE_SCHEMA, {
+        data: [0, 0, 0, 1, 0x67, 0x4d, 0x0c, 0x33],
+        format: "h264",
+        header: {
+          frame_id: "camera",
+          stamp: { nanosec: 4, sec: 3 },
+        },
+      }),
+      { schemaData: schemaData(ROS2_COMPRESSED_IMAGE_SCHEMA) },
+    );
+
+    expect(output.visualization).toBeUndefined();
+    expect(output.attributes).toMatchObject({
+      byteLength: 8,
+      format: "h264",
+      frameId: "camera",
+      unsupportedReason: "H.264 video rendering not yet supported",
     });
     expect(output.timing?.sourceTimestamps?.messageTime).toBe(3_000_000_004n);
   });

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/compressed-image.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/compressed-image.ts
@@ -1,18 +1,26 @@
 import {
   resourceHintsForArrayBufferViews,
   type DecodedAttributeValue,
+  type DecodedOutput,
+  type EncodedVideoVisualization,
 } from "../../../../decoders";
 import { VISUALIZATION_KIND } from "../../../../visualization";
 import {
   bytesField,
   rosHeader,
   rosHeaderAttributes,
+  rosHeaderFrameId,
+  rosHeaderTimestampNs,
   stringField,
   timingFromRosHeader,
 } from "./common";
 import { rosDecodersForPayloads } from "./factory";
 import { ROS_COMPRESSED_IMAGE_PAYLOADS } from "./payloads";
-import { videoRenderingUnsupportedReason } from "../video-format";
+import { analyzeH264AnnexBAccessUnit } from "../../../../utils/h264-annexb";
+import {
+  videoCodecFromFormat,
+  videoRenderingUnsupportedReason,
+} from "../video-format";
 
 /**
  * Decoders for ROS CompressedImage messages.
@@ -31,6 +39,18 @@ export const rosCompressedImageDecoders = rosDecodersForPayloads({
     const mimeType = mimeTypeFromRosCompressedImageFormat(format);
 
     if (!mimeType) {
+      const codec = videoCodecFromFormat(format);
+      if (codec === "h264") {
+        return h264CompressedImageOutput({
+          attributes,
+          data,
+          format,
+          frameId: rosHeaderFrameId(header),
+          timestampNs: rosHeaderTimestampNs(header),
+          timing: timingFromRosHeader(context, header),
+        });
+      }
+
       attributes.unsupportedReason = unsupportedCompressedImageReason(format);
       return {
         attributes,
@@ -52,6 +72,72 @@ export const rosCompressedImageDecoders = rosDecodersForPayloads({
   },
   payloads: ROS_COMPRESSED_IMAGE_PAYLOADS,
 });
+
+function h264CompressedImageOutput({
+  attributes,
+  data,
+  format,
+  frameId,
+  timestampNs,
+  timing,
+}: {
+  readonly attributes: Record<string, DecodedAttributeValue>;
+  readonly data: Uint8Array;
+  readonly format: string;
+  readonly frameId?: string;
+  readonly timestampNs?: bigint;
+  readonly timing: ReturnType<typeof timingFromRosHeader>;
+}): DecodedOutput {
+  const h264 = analyzeH264AnnexBAccessUnit(data);
+  if (!h264.hasStartCodes) {
+    attributes.unsupportedReason =
+      "H.264 video requires Annex-B NAL start codes";
+    return {
+      attributes,
+      resourceHints: resourceHintsForArrayBufferViews(data),
+      timing,
+    };
+  }
+
+  if (h264.hasBFrames) {
+    attributes.unsupportedReason =
+      "H.264 video streams with B-frames are unsupported";
+    return {
+      attributes,
+      resourceHints: resourceHintsForArrayBufferViews(data),
+      timing,
+    };
+  }
+
+  attributes.codec = "h264";
+  attributes.keyframe = h264.keyframe;
+  if (h264.codecString) {
+    attributes.codecString = h264.codecString;
+  }
+
+  const visualization = {
+    bytes: data,
+    codec: "h264",
+    ...(frameId ? { coordinateFrameId: frameId } : {}),
+    format,
+    h264: {
+      ...(h264.codecString ? { codecString: h264.codecString } : {}),
+      hasFrame: h264.hasFrame,
+      ...(h264.pps ? { pps: h264.pps } : {}),
+      ...(h264.sps ? { sps: h264.sps } : {}),
+    },
+    keyframe: h264.keyframe,
+    kind: VISUALIZATION_KIND.ENCODED_VIDEO,
+    ...(timestampNs !== undefined ? { timestampNs } : {}),
+  } satisfies EncodedVideoVisualization;
+
+  return {
+    attributes,
+    resourceHints: resourceHintsForArrayBufferViews(data),
+    timing,
+    visualization,
+  };
+}
 
 function mimeTypeFromRosCompressedImageFormat(
   format: string,

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/compressed-image.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/compressed-image.ts
@@ -31,6 +31,7 @@ export const rosCompressedImageDecoders = rosDecodersForPayloads({
     const header = rosHeader(message);
     const data = bytesField(message, "data");
     const format = stringField(message, "format", "unknown");
+    const timing = timingFromRosHeader(context, header);
     const attributes: Record<string, DecodedAttributeValue> = {
       ...rosHeaderAttributes(header),
       byteLength: data.byteLength,
@@ -47,22 +48,22 @@ export const rosCompressedImageDecoders = rosDecodersForPayloads({
           format,
           frameId: rosHeaderFrameId(header),
           timestampNs: rosHeaderTimestampNs(header),
-          timing: timingFromRosHeader(context, header),
+          timing,
         });
       }
 
-      attributes.unsupportedReason = unsupportedCompressedImageReason(format);
-      return {
+      return unsupportedCompressedImageOutput({
         attributes,
-        resourceHints: resourceHintsForArrayBufferViews(data),
-        timing: timingFromRosHeader(context, header),
-      };
+        data,
+        reason: unsupportedCompressedImageReason(format),
+        timing,
+      });
     }
 
     return {
       attributes,
       resourceHints: resourceHintsForArrayBufferViews(data),
-      timing: timingFromRosHeader(context, header),
+      timing,
       visualization: {
         bytes: data,
         kind: VISUALIZATION_KIND.ENCODED_IMAGE,
@@ -90,23 +91,30 @@ function h264CompressedImageOutput({
 }): DecodedOutput {
   const h264 = analyzeH264AnnexBAccessUnit(data);
   if (!h264.hasStartCodes) {
-    attributes.unsupportedReason =
-      "H.264 video requires Annex-B NAL start codes";
-    return {
+    return unsupportedCompressedImageOutput({
       attributes,
-      resourceHints: resourceHintsForArrayBufferViews(data),
+      data,
+      reason: "H.264 video requires Annex-B NAL start codes",
       timing,
-    };
+    });
+  }
+
+  if (!h264.hasFrame) {
+    return unsupportedCompressedImageOutput({
+      attributes,
+      data,
+      reason: "H.264 video requires frame NAL units",
+      timing,
+    });
   }
 
   if (h264.hasBFrames) {
-    attributes.unsupportedReason =
-      "H.264 video streams with B-frames are unsupported";
-    return {
+    return unsupportedCompressedImageOutput({
       attributes,
-      resourceHints: resourceHintsForArrayBufferViews(data),
+      data,
+      reason: "H.264 video streams with B-frames are unsupported",
       timing,
-    };
+    });
   }
 
   attributes.codec = "h264";
@@ -136,6 +144,25 @@ function h264CompressedImageOutput({
     resourceHints: resourceHintsForArrayBufferViews(data),
     timing,
     visualization,
+  };
+}
+
+function unsupportedCompressedImageOutput({
+  attributes,
+  data,
+  reason,
+  timing,
+}: {
+  readonly attributes: Record<string, DecodedAttributeValue>;
+  readonly data: Uint8Array;
+  readonly reason: string;
+  readonly timing: ReturnType<typeof timingFromRosHeader>;
+}): DecodedOutput {
+  attributes.unsupportedReason = reason;
+  return {
+    attributes,
+    resourceHints: resourceHintsForArrayBufferViews(data),
+    timing,
   };
 }
 

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/compressed-image.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/compressed-image.ts
@@ -12,6 +12,7 @@ import {
 } from "./common";
 import { rosDecodersForPayloads } from "./factory";
 import { ROS_COMPRESSED_IMAGE_PAYLOADS } from "./payloads";
+import { videoRenderingUnsupportedReason } from "../video-format";
 
 /**
  * Decoders for ROS CompressedImage messages.
@@ -27,6 +28,16 @@ export const rosCompressedImageDecoders = rosDecodersForPayloads({
       byteLength: data.byteLength,
       format,
     };
+    const mimeType = mimeTypeFromRosCompressedImageFormat(format);
+
+    if (!mimeType) {
+      attributes.unsupportedReason = unsupportedCompressedImageReason(format);
+      return {
+        attributes,
+        resourceHints: resourceHintsForArrayBufferViews(data),
+        timing: timingFromRosHeader(context, header),
+      };
+    }
 
     return {
       attributes,
@@ -35,7 +46,7 @@ export const rosCompressedImageDecoders = rosDecodersForPayloads({
       visualization: {
         bytes: data,
         kind: VISUALIZATION_KIND.ENCODED_IMAGE,
-        mimeType: mimeTypeFromRosCompressedImageFormat(format),
+        mimeType,
       },
     };
   },
@@ -65,4 +76,11 @@ function mimeTypeFromRosCompressedImageFormat(
   }
 
   return undefined;
+}
+
+function unsupportedCompressedImageReason(format: string): string {
+  return (
+    videoRenderingUnsupportedReason(format) ??
+    `ROS CompressedImage format '${format}' is unsupported`
+  );
 }

--- a/app/packages/multimodal/src/adapters/mcap/decoders/video-format.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/video-format.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  unsupportedSourceFormatReason,
+  unsupportedVideoFormatReason,
+  videoCodecFromFormat,
+  videoRenderingUnsupportedReason,
+} from "./video-format";
+
+describe("video format helpers", () => {
+  it("normalizes exact and prefixed codec identifiers", () => {
+    expect(videoCodecFromFormat("h264")).toBe("h264");
+    expect(videoCodecFromFormat("H.264")).toBe("h264");
+    expect(videoCodecFromFormat("avc")).toBe("h264");
+    expect(videoCodecFromFormat("avc1.4d001f")).toBe("h264");
+    expect(videoCodecFromFormat("avc3.64001f")).toBe("h264");
+    expect(videoCodecFromFormat("h265")).toBe("h265");
+    expect(videoCodecFromFormat("hevc")).toBe("h265");
+    expect(videoCodecFromFormat("hev1.1.6.l93.b0")).toBe("h265");
+    expect(videoCodecFromFormat("hvc1.1.6.l93.b0")).toBe("h265");
+    expect(videoCodecFromFormat("vp9")).toBe("vp9");
+    expect(videoCodecFromFormat("vp09.00.10.08")).toBe("vp9");
+    expect(videoCodecFromFormat("av1")).toBe("av1");
+    expect(videoCodecFromFormat("av01.0.05m.08")).toBe("av1");
+  });
+
+  it("finds codecs in source format strings", () => {
+    expect(videoCodecFromFormat("bgr8; h264 compressed")).toBe("h264");
+    expect(
+      videoCodecFromFormat('video/mp4; codecs="mp4a.40.2, avc1.4d001f"'),
+    ).toBe("h264");
+    expect(videoCodecFromFormat("image/jpeg")).toBeNull();
+    expect(videoCodecFromFormat("   ")).toBeNull();
+  });
+
+  it("formats unsupported codec and source-format reasons", () => {
+    expect(videoRenderingUnsupportedReason("vp09.00.10.08")).toBe(
+      "VP9 video rendering not yet supported",
+    );
+    expect(videoRenderingUnsupportedReason("image/jpeg")).toBeUndefined();
+    expect(unsupportedVideoFormatReason("Source", "av01.0.05m.08")).toBe(
+      "AV1 video rendering not yet supported",
+    );
+    expect(unsupportedVideoFormatReason("Source", "raw")).toBe(
+      "Source format 'raw' is unsupported",
+    );
+    expect(unsupportedSourceFormatReason("Source", " raw ")).toBe(
+      "Source format 'raw' is unsupported",
+    );
+    expect(unsupportedSourceFormatReason("Source", "   ")).toBe(
+      "Source format is missing",
+    );
+  });
+});

--- a/app/packages/multimodal/src/adapters/mcap/decoders/video-format.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/video-format.ts
@@ -13,13 +13,15 @@ type SupportedVideoFormat = keyof typeof VIDEO_FORMAT_LABELS;
 export function videoRenderingUnsupportedReason(
   format: string,
 ): string | undefined {
-  const videoFormat = normalizedVideoFormat(format);
+  const videoFormat = videoCodecFromFormat(format);
   return videoFormat
     ? `${VIDEO_FORMAT_LABELS[videoFormat]} video rendering not yet supported`
     : undefined;
 }
 
-function normalizedVideoFormat(format: string): SupportedVideoFormat | null {
+export function videoCodecFromFormat(
+  format: string,
+): SupportedVideoFormat | null {
   switch (format.trim().toLowerCase()) {
     case "av1":
       return "av1";

--- a/app/packages/multimodal/src/adapters/mcap/decoders/video-format.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/video-format.ts
@@ -1,0 +1,39 @@
+const VIDEO_FORMAT_LABELS = Object.freeze({
+  av1: "AV1",
+  h264: "H.264",
+  h265: "H.265",
+  vp9: "VP9",
+} as const);
+
+type SupportedVideoFormat = keyof typeof VIDEO_FORMAT_LABELS;
+
+/**
+ * Returns a legible Layer-1 reason for known video codecs.
+ */
+export function videoRenderingUnsupportedReason(
+  format: string,
+): string | undefined {
+  const videoFormat = normalizedVideoFormat(format);
+  return videoFormat
+    ? `${VIDEO_FORMAT_LABELS[videoFormat]} video rendering not yet supported`
+    : undefined;
+}
+
+function normalizedVideoFormat(format: string): SupportedVideoFormat | null {
+  switch (format.trim().toLowerCase()) {
+    case "av1":
+      return "av1";
+    case "h264":
+    case "h.264":
+    case "avc":
+      return "h264";
+    case "h265":
+    case "h.265":
+    case "hevc":
+      return "h265";
+    case "vp9":
+      return "vp9";
+    default:
+      return null;
+  }
+}

--- a/app/packages/multimodal/src/adapters/mcap/decoders/video-format.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/video-format.ts
@@ -1,11 +1,31 @@
-const VIDEO_FORMAT_LABELS = Object.freeze({
-  av1: "AV1",
-  h264: "H.264",
-  h265: "H.265",
-  vp9: "VP9",
+const VIDEO_FORMATS = Object.freeze({
+  av1: {
+    exact: ["av1"],
+    label: "AV1",
+    prefixes: ["av01"],
+  },
+  h264: {
+    exact: ["h264", "h.264", "avc"],
+    label: "H.264",
+    prefixes: ["avc"],
+  },
+  h265: {
+    exact: ["h265", "h.265", "hevc"],
+    label: "H.265",
+    prefixes: ["hev", "hvc"],
+  },
+  vp9: {
+    exact: ["vp9"],
+    label: "VP9",
+    prefixes: ["vp09"],
+  },
 } as const);
 
-type SupportedVideoFormat = keyof typeof VIDEO_FORMAT_LABELS;
+type SupportedVideoFormat = keyof typeof VIDEO_FORMATS;
+type VideoFormatDefinition = (typeof VIDEO_FORMATS)[keyof typeof VIDEO_FORMATS];
+const VIDEO_FORMAT_ENTRIES = Object.entries(VIDEO_FORMATS) as Array<
+  readonly [SupportedVideoFormat, VideoFormatDefinition]
+>;
 
 /**
  * Returns a legible unsupported-rendering reason for known video codecs.
@@ -15,8 +35,35 @@ export function videoRenderingUnsupportedReason(
 ): string | undefined {
   const videoFormat = videoCodecFromFormat(format);
   return videoFormat
-    ? `${VIDEO_FORMAT_LABELS[videoFormat]} video rendering not yet supported`
+    ? `${VIDEO_FORMATS[videoFormat].label} video rendering not yet supported`
     : undefined;
+}
+
+/**
+ * Returns a source-specific unsupported-format reason with a shared fallback
+ * for known-but-unrenderable video codecs.
+ */
+export function unsupportedVideoFormatReason(
+  source: string,
+  format: string,
+): string {
+  return (
+    videoRenderingUnsupportedReason(format) ??
+    unsupportedSourceFormatReason(source, format)
+  );
+}
+
+/**
+ * Returns the generic source-specific unsupported-format reason.
+ */
+export function unsupportedSourceFormatReason(
+  source: string,
+  format: string,
+): string {
+  const trimmed = format.trim();
+  return trimmed
+    ? `${source} format '${trimmed}' is unsupported`
+    : `${source} format is missing`;
 }
 
 /**
@@ -26,20 +73,24 @@ export function videoRenderingUnsupportedReason(
 export function videoCodecFromFormat(
   format: string,
 ): SupportedVideoFormat | null {
-  switch (format.trim().toLowerCase()) {
-    case "av1":
-      return "av1";
-    case "h264":
-    case "h.264":
-    case "avc":
-      return "h264";
-    case "h265":
-    case "h.265":
-    case "hevc":
-      return "h265";
-    case "vp9":
-      return "vp9";
-    default:
-      return null;
+  const normalized = format.trim().toLowerCase();
+  return (
+    normalized
+      .split(/[^a-z0-9.]+/)
+      .map(videoCodecFromToken)
+      .find((codec): codec is SupportedVideoFormat => codec !== null) ?? null
+  );
+}
+
+function videoCodecFromToken(token: string): SupportedVideoFormat | null {
+  for (const [codec, definition] of VIDEO_FORMAT_ENTRIES) {
+    if (definition.exact.some((exact) => exact === token)) {
+      return codec;
+    }
+    if (definition.prefixes.some((prefix) => token.startsWith(prefix))) {
+      return codec;
+    }
   }
+
+  return null;
 }

--- a/app/packages/multimodal/src/adapters/mcap/decoders/video-format.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/video-format.ts
@@ -8,7 +8,7 @@ const VIDEO_FORMAT_LABELS = Object.freeze({
 type SupportedVideoFormat = keyof typeof VIDEO_FORMAT_LABELS;
 
 /**
- * Returns a legible Layer-1 reason for known video codecs.
+ * Returns a legible unsupported-rendering reason for known video codecs.
  */
 export function videoRenderingUnsupportedReason(
   format: string,
@@ -19,6 +19,10 @@ export function videoRenderingUnsupportedReason(
     : undefined;
 }
 
+/**
+ * Normalizes source format strings into the video codecs the adapter can
+ * reason about.
+ */
 export function videoCodecFromFormat(
   format: string,
 ): SupportedVideoFormat | null {

--- a/app/packages/multimodal/src/adapters/mcap/grid-preview.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/grid-preview.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type {
   EncodedImageVisualization,
+  EncodedVideoVisualization,
   ImageAnnotationsVisualization,
   PointCloudVisualization,
 } from "../../decoders";
@@ -96,6 +97,35 @@ describe("MCAP grid preview", () => {
       throw new Error("Expected raw image preview");
     }
     expect(Array.from(image.rgba)).toEqual([255, 0, 0, 255]);
+  });
+
+  it("reads encoded video frames as image previews", async () => {
+    const readDecodedMessages = vi.fn(async function* (
+      request: Parameters<McapResourceClient["readDecodedMessages"]>[0],
+    ) {
+      yield createVideoMessage(request.topics?.[0] ?? "/camera/video", 12n);
+    });
+    const client = createClient({
+      readDecodedMessages,
+      readTopics: vi.fn(async () => [
+        createTopic(
+          "/camera/video",
+          "sensor_msgs/msg/CompressedImage",
+          "cdr",
+          "ros2msg",
+        ),
+      ]),
+    });
+
+    const result = await decodeGridPreview(
+      { client },
+      { source: createSource() },
+    );
+    const image = imageFrame(result.state.frame)?.image;
+
+    expect(result.state.status).toBe("ready");
+    expect(image?.kind).toBe(VISUALIZATION_KIND.ENCODED_VIDEO);
+    expect(result.nextStartTimeNs).toBe(13n);
   });
 
   it("pairs exact camera annotations with a nearby image frame", async () => {
@@ -600,6 +630,31 @@ function createRawImageMessage(
       sourceEncoding: "rgb8",
       width: 1,
     },
+  });
+}
+
+function createVideoMessage(
+  topic: string,
+  timelineTimeNs = 10n,
+): McapDecodedMessage {
+  const visualization: EncodedVideoVisualization = {
+    bytes: Uint8Array.of(0, 0, 1, 0x65),
+    codec: "h264",
+    format: "h264",
+    h264: {
+      codecString: "avc1.4D001F",
+      hasFrame: true,
+      pps: Uint8Array.of(0x68, 0xce),
+      sps: Uint8Array.of(0x67, 0x4d, 0x00, 0x1f),
+    },
+    keyframe: true,
+    kind: VISUALIZATION_KIND.ENCODED_VIDEO,
+    timestampNs: timelineTimeNs,
+  };
+
+  return createDecodedMessage(topic, "sensor_msgs/msg/CompressedImage", {
+    timelineTimeNs,
+    visualization,
   });
 }
 

--- a/app/packages/multimodal/src/adapters/mcap/grid-preview.ts
+++ b/app/packages/multimodal/src/adapters/mcap/grid-preview.ts
@@ -499,6 +499,7 @@ async function readImageFrameNear({
 function imageFrame(message: McapDecodedMessage): ImageVisualization | null {
   const visualization = message.decoded.output.visualization;
   return visualization?.kind === VISUALIZATION_KIND.ENCODED_IMAGE ||
+    visualization?.kind === VISUALIZATION_KIND.ENCODED_VIDEO ||
     visualization?.kind === VISUALIZATION_KIND.RAW_IMAGE
     ? visualization
     : null;

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-bandwidth-debug.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-bandwidth-debug.ts
@@ -161,6 +161,9 @@ function categoryForMessage(message: McapDecodedMessage): string {
   ) {
     return "image";
   }
+  if (kind === VISUALIZATION_KIND.ENCODED_VIDEO) {
+    return "video";
+  }
   if (kind === VISUALIZATION_KIND.IMAGE_ANNOTATIONS) {
     return "image-annotations";
   }

--- a/app/packages/multimodal/src/adapters/mcap/scene-sources.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/scene-sources.test.ts
@@ -11,6 +11,13 @@ describe("mcapSceneSources", () => {
     const sources = mcapSceneSources([
       createTopic("/CAM_FRONT/image_rect_compressed"),
       createTopic("/CAM_REAR/image", "sensor_msgs/msg/Image", "cdr", "ros2msg"),
+      createTopic("/CAM_VIDEO", "foxglove.CompressedVideo"),
+      createTopic(
+        "/CAM_VIDEO_CDR",
+        "foxglove_msgs/msg/CompressedVideo",
+        "cdr",
+        "ros2msg",
+      ),
       createTopic("/LIDAR_TOP", "foxglove.PointCloud"),
       createTopic("/scan", "foxglove.LaserScan"),
       createTopic("/CAM_FRONT/annotations", "foxglove.ImageAnnotations"),
@@ -35,6 +42,16 @@ describe("mcapSceneSources", () => {
         id: "/CAM_REAR/image",
         type: MCAP_SOURCE_TYPE.IMAGE,
         label: "CAM_REAR",
+      },
+      {
+        id: "/CAM_VIDEO",
+        type: MCAP_SOURCE_TYPE.IMAGE,
+        label: "CAM_VIDEO",
+      },
+      {
+        id: "/CAM_VIDEO_CDR",
+        type: MCAP_SOURCE_TYPE.IMAGE,
+        label: "CAM_VIDEO_CDR",
       },
       {
         id: "/LIDAR_TOP",

--- a/app/packages/multimodal/src/adapters/mcap/stream-topics.ts
+++ b/app/packages/multimodal/src/adapters/mcap/stream-topics.ts
@@ -4,6 +4,8 @@ import { JSON_POSE_PAYLOAD } from "./decoders/json/payloads";
 import {
   FOXGLOVE_CAMERA_CALIBRATION_PAYLOAD,
   FOXGLOVE_COMPRESSED_IMAGE_PAYLOAD,
+  FOXGLOVE_COMPRESSED_VIDEO_CDR_PAYLOADS,
+  FOXGLOVE_COMPRESSED_VIDEO_PAYLOAD,
   FOXGLOVE_GRID_PAYLOAD,
   FOXGLOVE_LASER_SCAN_PAYLOAD,
   FOXGLOVE_LOCATION_FIX_PAYLOAD,
@@ -11,7 +13,7 @@ import {
   FOXGLOVE_IMAGE_ANNOTATIONS_PAYLOAD,
   FOXGLOVE_POINT_CLOUD_PAYLOAD,
   FOXGLOVE_SCENE_UPDATE_PAYLOAD,
-} from "./decoders/foxglove/protobuf/payloads";
+} from "./decoders/foxglove/payloads";
 import {
   ROS_CAMERA_INFO_PAYLOADS,
   ROS_COMPRESSED_IMAGE_PAYLOADS,
@@ -85,6 +87,8 @@ export function topicName(topic: StreamInventory): string {
 export function isImageStream(topic: StreamInventory): boolean {
   return (
     hasPayload(topic, FOXGLOVE_COMPRESSED_IMAGE_PAYLOAD) ||
+    hasPayload(topic, FOXGLOVE_COMPRESSED_VIDEO_PAYLOAD) ||
+    hasAnyPayload(topic, FOXGLOVE_COMPRESSED_VIDEO_CDR_PAYLOADS) ||
     hasAnyPayload(topic, ROS_COMPRESSED_IMAGE_PAYLOADS) ||
     hasAnyPayload(topic, ROS_IMAGE_PAYLOADS)
   );

--- a/app/packages/multimodal/src/decoders/types.ts
+++ b/app/packages/multimodal/src/decoders/types.ts
@@ -24,26 +24,39 @@ export interface EncodedImageVisualization {
   readonly mimeType?: string;
 }
 
-/**
- * Encoded video access unit decoded from one message. The contract lets MCAP
- * topics be classified as image-family streams while decoders and renderers
- * stay source-format agnostic.
- */
-export interface EncodedVideoVisualization {
+interface BaseEncodedVideoVisualization {
   readonly kind: typeof VISUALIZATION_KIND.ENCODED_VIDEO;
   readonly bytes: Uint8Array;
-  readonly codec: "av1" | "h264" | "h265" | "vp9";
   readonly coordinateFrameId?: string;
   readonly format: string;
-  readonly h264?: {
+  readonly keyframe?: boolean;
+  readonly timestampNs?: bigint;
+}
+
+/**
+ * Encoded H.264 access unit decoded from one message.
+ */
+export interface EncodedH264VideoVisualization extends BaseEncodedVideoVisualization {
+  readonly codec: "h264";
+  readonly h264: {
     readonly codecString?: string;
     readonly hasFrame?: boolean;
     readonly pps?: Uint8Array;
     readonly sps?: Uint8Array;
   };
-  readonly keyframe?: boolean;
-  readonly timestampNs?: bigint;
 }
+
+/**
+ * Encoded video access unit decoded from one message. The contract lets MCAP
+ * topics be classified as image-family streams while keeping codec metadata
+ * aligned with the selected codec.
+ */
+export type EncodedVideoVisualization =
+  | EncodedH264VideoVisualization
+  | (BaseEncodedVideoVisualization & {
+      readonly codec: "av1" | "h265" | "vp9";
+      readonly h264?: never;
+    });
 
 /**
  * Raw image pixels normalized by a decoder into display-ready RGBA.

--- a/app/packages/multimodal/src/decoders/types.ts
+++ b/app/packages/multimodal/src/decoders/types.ts
@@ -25,6 +25,21 @@ export interface EncodedImageVisualization {
 }
 
 /**
+ * Encoded video access unit decoded from one message. Layer 1 defines the
+ * contract so MCAP topics can be classified as image-family streams; concrete
+ * decoders start emitting it once the WebCodecs playback layer is available.
+ */
+export interface EncodedVideoVisualization {
+  readonly kind: typeof VISUALIZATION_KIND.ENCODED_VIDEO;
+  readonly bytes: Uint8Array;
+  readonly codec: "av1" | "h264" | "h265" | "vp9";
+  readonly coordinateFrameId?: string;
+  readonly format: string;
+  readonly keyframe?: boolean;
+  readonly timestampNs?: bigint;
+}
+
+/**
  * Raw image pixels normalized by a decoder into display-ready RGBA.
  * `rgba` is row-major from the source image's top-left pixel.
  */

--- a/app/packages/multimodal/src/decoders/types.ts
+++ b/app/packages/multimodal/src/decoders/types.ts
@@ -25,9 +25,9 @@ export interface EncodedImageVisualization {
 }
 
 /**
- * Encoded video access unit decoded from one message. Layer 1 defines the
- * contract so MCAP topics can be classified as image-family streams; concrete
- * decoders start emitting it once the WebCodecs playback layer is available.
+ * Encoded video access unit decoded from one message. The contract lets MCAP
+ * topics be classified as image-family streams while decoders and renderers
+ * stay source-format agnostic.
  */
 export interface EncodedVideoVisualization {
   readonly kind: typeof VISUALIZATION_KIND.ENCODED_VIDEO;

--- a/app/packages/multimodal/src/decoders/types.ts
+++ b/app/packages/multimodal/src/decoders/types.ts
@@ -35,6 +35,12 @@ export interface EncodedVideoVisualization {
   readonly codec: "av1" | "h264" | "h265" | "vp9";
   readonly coordinateFrameId?: string;
   readonly format: string;
+  readonly h264?: {
+    readonly codecString?: string;
+    readonly hasFrame?: boolean;
+    readonly pps?: Uint8Array;
+    readonly sps?: Uint8Array;
+  };
   readonly keyframe?: boolean;
   readonly timestampNs?: bigint;
 }
@@ -60,6 +66,7 @@ export interface RawImageVisualization {
  * Image-like visualizations rendered by the multimodal image panel.
  */
 export type ImageVisualization =
+  | EncodedVideoVisualization
   | EncodedImageVisualization
   | RawImageVisualization;
 

--- a/app/packages/multimodal/src/index.ts
+++ b/app/packages/multimodal/src/index.ts
@@ -18,6 +18,7 @@ export type {
   DecodedVisualization,
   Decoder,
   EncodedImageVisualization,
+  EncodedVideoVisualization,
   ImageVisualization,
   PayloadDescriptor,
   PointCloudField,

--- a/app/packages/multimodal/src/index.ts
+++ b/app/packages/multimodal/src/index.ts
@@ -17,6 +17,7 @@ export type {
   DecodedTiming,
   DecodedVisualization,
   Decoder,
+  EncodedH264VideoVisualization,
   EncodedImageVisualization,
   EncodedVideoVisualization,
   ImageVisualization,

--- a/app/packages/multimodal/src/utils/h264-annexb.test.ts
+++ b/app/packages/multimodal/src/utils/h264-annexb.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  analyzeH264AnnexBAccessUnit,
+  h264AccessUnitWithParameterSets,
+} from "./h264-annexb";
+
+describe("H.264 Annex-B access unit inspection", () => {
+  it("extracts keyframe, codec string, and parameter sets", () => {
+    const info = analyzeH264AnnexBAccessUnit(
+      Uint8Array.of(
+        0,
+        0,
+        0,
+        1,
+        0x67,
+        0x4d,
+        0x00,
+        0x1f,
+        0,
+        0,
+        1,
+        0x68,
+        0xce,
+        0x06,
+        0,
+        0,
+        1,
+        0x65,
+        0xb0,
+      ),
+    );
+
+    expect(info).toMatchObject({
+      codecString: "avc1.4D001F",
+      hasBFrames: false,
+      hasFrame: true,
+      hasStartCodes: true,
+      keyframe: true,
+      nalUnitTypes: [7, 8, 5],
+    });
+    expect(Array.from(info.sps ?? [])).toEqual([0x67, 0x4d, 0x00, 0x1f]);
+    expect(Array.from(info.pps ?? [])).toEqual([0x68, 0xce, 0x06]);
+  });
+
+  it("detects B-slices without treating parse failures as fatal", () => {
+    const bFrame = analyzeH264AnnexBAccessUnit(
+      Uint8Array.of(0, 0, 1, 0x41, 0xa0),
+    );
+    const pFrame = analyzeH264AnnexBAccessUnit(
+      Uint8Array.of(0, 0, 1, 0x41, 0xc0),
+    );
+
+    expect(bFrame.hasBFrames).toBe(true);
+    expect(bFrame.hasFrame).toBe(true);
+    expect(pFrame.hasBFrames).toBe(false);
+  });
+
+  it("reports non-Annex-B bytes without throwing", () => {
+    const info = analyzeH264AnnexBAccessUnit(Uint8Array.of(0x65, 0xb0));
+
+    expect(info.hasStartCodes).toBe(false);
+    expect(info.keyframe).toBe(true);
+  });
+
+  it("prepends cached parameter sets to a later access unit", () => {
+    expect(
+      Array.from(
+        h264AccessUnitWithParameterSets({
+          bytes: Uint8Array.of(0, 0, 1, 0x65, 0xb0),
+          pps: Uint8Array.of(0x68, 0xce),
+          sps: Uint8Array.of(0x67, 0x4d, 0x00, 0x1f),
+        }),
+      ),
+    ).toEqual([
+      0, 0, 0, 1, 0x67, 0x4d, 0x00, 0x1f, 0, 0, 0, 1, 0x68, 0xce, 0, 0, 1, 0x65,
+      0xb0,
+    ]);
+  });
+});

--- a/app/packages/multimodal/src/utils/h264-annexb.test.ts
+++ b/app/packages/multimodal/src/utils/h264-annexb.test.ts
@@ -32,7 +32,7 @@ describe("H.264 Annex-B access unit inspection", () => {
     );
 
     expect(info).toMatchObject({
-      codecString: "avc1.4D001F",
+      codecString: "avc1.4d001f",
       hasBFrames: false,
       hasFrame: true,
       hasStartCodes: true,
@@ -47,13 +47,23 @@ describe("H.264 Annex-B access unit inspection", () => {
     const bFrame = analyzeH264AnnexBAccessUnit(
       Uint8Array.of(0, 0, 1, 0x41, 0xa0),
     );
+    const bFrameWithEmulationPrevention = analyzeH264AnnexBAccessUnit(
+      Uint8Array.of(0, 0, 1, 0x41, 0xa0, 0, 0, 0x03, 1),
+    );
     const pFrame = analyzeH264AnnexBAccessUnit(
       Uint8Array.of(0, 0, 1, 0x41, 0xc0),
+    );
+    const pFrameWithEmulationPrevention = analyzeH264AnnexBAccessUnit(
+      Uint8Array.of(0, 0, 1, 0x41, 0xc0, 0, 0, 0x03, 1),
     );
 
     expect(bFrame.hasBFrames).toBe(true);
     expect(bFrame.hasFrame).toBe(true);
+    expect(bFrameWithEmulationPrevention.hasBFrames).toBe(true);
+    expect(bFrameWithEmulationPrevention.hasFrame).toBe(true);
     expect(pFrame.hasBFrames).toBe(false);
+    expect(pFrameWithEmulationPrevention.hasBFrames).toBe(false);
+    expect(pFrameWithEmulationPrevention.hasFrame).toBe(true);
   });
 
   it("reports non-Annex-B bytes without throwing", () => {

--- a/app/packages/multimodal/src/utils/h264-annexb.ts
+++ b/app/packages/multimodal/src/utils/h264-annexb.ts
@@ -1,0 +1,268 @@
+export interface H264AnnexBAccessUnitInfo {
+  readonly codecString?: string;
+  readonly hasBFrames: boolean;
+  readonly hasFrame: boolean;
+  readonly hasStartCodes: boolean;
+  readonly keyframe: boolean;
+  readonly nalUnitTypes: readonly number[];
+  readonly pps?: Uint8Array;
+  readonly sps?: Uint8Array;
+}
+
+const H264_NAL_TYPE_CODED_SLICE_NON_IDR = 1;
+const H264_NAL_TYPE_CODED_SLICE_IDR = 5;
+const H264_NAL_TYPE_SPS = 7;
+const H264_NAL_TYPE_PPS = 8;
+
+/**
+ * Lightweight Annex-B H.264 access-unit inspection. This is deliberately not a
+ * full parser; it only extracts facts needed to decide whether WebCodecs can
+ * try the frame without allowing known-bad B-frame streams into playback.
+ */
+export function analyzeH264AnnexBAccessUnit(
+  bytes: Uint8Array,
+): H264AnnexBAccessUnitInfo {
+  const nalUnits = h264AnnexBNalUnits(bytes);
+  let codecString: string | undefined;
+  let hasBFrames = false;
+  let hasFrame = false;
+  let keyframe = false;
+  let pps: Uint8Array | undefined;
+  let sps: Uint8Array | undefined;
+  const nalUnitTypes: number[] = [];
+
+  for (const nal of nalUnits.units) {
+    if (nal.byteLength === 0) continue;
+    const nalType = nal[0] & 0x1f;
+    nalUnitTypes.push(nalType);
+
+    if (nalType === H264_NAL_TYPE_SPS) {
+      sps = copyBytes(nal);
+      codecString = codecStringFromSps(nal) ?? codecString;
+    } else if (nalType === H264_NAL_TYPE_PPS) {
+      pps = copyBytes(nal);
+    } else if (nalType === H264_NAL_TYPE_CODED_SLICE_IDR) {
+      hasFrame = true;
+      keyframe = true;
+      hasBFrames = isBFrameSlice(nal) || hasBFrames;
+    } else if (nalType === H264_NAL_TYPE_CODED_SLICE_NON_IDR) {
+      hasFrame = true;
+      hasBFrames = isBFrameSlice(nal) || hasBFrames;
+    }
+  }
+
+  return {
+    codecString,
+    hasBFrames,
+    hasFrame,
+    hasStartCodes: nalUnits.hasStartCodes,
+    keyframe,
+    nalUnitTypes,
+    pps,
+    sps,
+  };
+}
+
+export function h264AccessUnitWithParameterSets({
+  bytes,
+  pps,
+  sps,
+}: {
+  readonly bytes: Uint8Array;
+  readonly pps?: Uint8Array;
+  readonly sps?: Uint8Array;
+}): Uint8Array {
+  if (!sps && !pps) {
+    return bytes;
+  }
+
+  const chunks = [sps, pps, bytes].filter(
+    (chunk): chunk is Uint8Array => chunk !== undefined,
+  );
+  const startCodeLength = 4;
+  const totalLength = chunks.reduce(
+    (length, chunk) =>
+      length +
+      chunk.byteLength +
+      (hasLeadingStartCode(chunk) ? 0 : startCodeLength),
+    0,
+  );
+  const output = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    if (!hasLeadingStartCode(chunk)) {
+      output.set([0, 0, 0, 1], offset);
+      offset += startCodeLength;
+    }
+    output.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  return output;
+}
+
+function h264AnnexBNalUnits(bytes: Uint8Array): {
+  readonly hasStartCodes: boolean;
+  readonly units: readonly Uint8Array[];
+} {
+  const units: Uint8Array[] = [];
+  let current = findStartCode(bytes, 0);
+  if (!current) {
+    return {
+      hasStartCodes: false,
+      units: bytes.byteLength > 0 ? [bytes] : [],
+    };
+  }
+
+  while (current) {
+    const dataStart = current.index + current.length;
+    const next = findStartCode(bytes, dataStart);
+    const dataEnd = trimTrailingZeros(
+      bytes,
+      dataStart,
+      next?.index ?? bytes.byteLength,
+    );
+    if (dataEnd > dataStart) {
+      units.push(bytes.subarray(dataStart, dataEnd));
+    }
+    current = next;
+  }
+
+  return {
+    hasStartCodes: true,
+    units,
+  };
+}
+
+function findStartCode(
+  bytes: Uint8Array,
+  from: number,
+): { readonly index: number; readonly length: 3 | 4 } | null {
+  for (
+    let index = Math.max(0, from);
+    index + 3 <= bytes.byteLength;
+    index += 1
+  ) {
+    if (bytes[index] !== 0 || bytes[index + 1] !== 0) {
+      continue;
+    }
+    if (bytes[index + 2] === 1) {
+      return { index, length: 3 };
+    }
+    if (
+      index + 4 <= bytes.byteLength &&
+      bytes[index + 2] === 0 &&
+      bytes[index + 3] === 1
+    ) {
+      return { index, length: 4 };
+    }
+  }
+
+  return null;
+}
+
+function trimTrailingZeros(
+  bytes: Uint8Array,
+  start: number,
+  end: number,
+): number {
+  let trimmedEnd = end;
+  while (trimmedEnd > start && bytes[trimmedEnd - 1] === 0) {
+    trimmedEnd -= 1;
+  }
+  return trimmedEnd;
+}
+
+function codecStringFromSps(sps: Uint8Array): string | undefined {
+  if (sps.byteLength < 4) {
+    return undefined;
+  }
+
+  return `avc1.${hexByte(sps[1])}${hexByte(sps[2])}${hexByte(sps[3])}`;
+}
+
+function hexByte(value: number): string {
+  return value.toString(16).padStart(2, "0").toUpperCase();
+}
+
+function isBFrameSlice(nal: Uint8Array): boolean {
+  try {
+    const rbsp = removeEmulationPreventionBytes(nal.subarray(1));
+    const reader = new BitReader(rbsp);
+    reader.readUnsignedExpGolomb(); // first_mb_in_slice
+    const sliceType = reader.readUnsignedExpGolomb();
+    return sliceType % 5 === 1;
+  } catch {
+    return false;
+  }
+}
+
+function removeEmulationPreventionBytes(bytes: Uint8Array): Uint8Array {
+  const output: number[] = [];
+  let zeroCount = 0;
+
+  for (const byte of bytes) {
+    if (zeroCount >= 2 && byte === 0x03) {
+      zeroCount = 0;
+      continue;
+    }
+    output.push(byte);
+    zeroCount = byte === 0 ? zeroCount + 1 : 0;
+  }
+
+  return Uint8Array.from(output);
+}
+
+function hasLeadingStartCode(bytes: Uint8Array): boolean {
+  return (
+    (bytes.byteLength >= 3 &&
+      bytes[0] === 0 &&
+      bytes[1] === 0 &&
+      bytes[2] === 1) ||
+    (bytes.byteLength >= 4 &&
+      bytes[0] === 0 &&
+      bytes[1] === 0 &&
+      bytes[2] === 0 &&
+      bytes[3] === 1)
+  );
+}
+
+function copyBytes(bytes: Uint8Array): Uint8Array {
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  return copy;
+}
+
+class BitReader {
+  private bitOffset = 0;
+
+  constructor(private readonly bytes: Uint8Array) {}
+
+  readUnsignedExpGolomb(): number {
+    let leadingZeros = 0;
+    while (this.readBit() === 0) {
+      leadingZeros += 1;
+      if (leadingZeros > 31) {
+        throw new Error("Exp-Golomb code is too large");
+      }
+    }
+
+    let value = (1 << leadingZeros) - 1;
+    for (let index = 0; index < leadingZeros; index += 1) {
+      value += this.readBit() << (leadingZeros - index - 1);
+    }
+
+    return value;
+  }
+
+  private readBit(): number {
+    if (this.bitOffset >= this.bytes.byteLength * 8) {
+      throw new Error("Unexpected end of H.264 slice header");
+    }
+
+    const byte = this.bytes[this.bitOffset >> 3];
+    const bit = (byte >> (7 - (this.bitOffset & 7))) & 1;
+    this.bitOffset += 1;
+    return bit;
+  }
+}

--- a/app/packages/multimodal/src/utils/h264-annexb.ts
+++ b/app/packages/multimodal/src/utils/h264-annexb.ts
@@ -16,6 +16,7 @@ const H264_NAL_TYPE_CODED_SLICE_NON_IDR = 1;
 const H264_NAL_TYPE_CODED_SLICE_IDR = 5;
 const H264_NAL_TYPE_SPS = 7;
 const H264_NAL_TYPE_PPS = 8;
+const MAX_SLICE_HEADER_PREFIX_BYTES = 32;
 
 /**
  * Lightweight Annex-B H.264 access-unit inspection. This is deliberately not a
@@ -188,12 +189,16 @@ function codecStringFromSps(sps: Uint8Array): string | undefined {
 }
 
 function hexByte(value: number): string {
-  return value.toString(16).padStart(2, "0").toUpperCase();
+  return value.toString(16).padStart(2, "0");
 }
 
 function isBFrameSlice(nal: Uint8Array): boolean {
   try {
-    const rbsp = removeEmulationPreventionBytes(nal.subarray(1));
+    const headerPrefix = nal.subarray(
+      1,
+      Math.min(nal.byteLength, 1 + MAX_SLICE_HEADER_PREFIX_BYTES),
+    );
+    const rbsp = removeEmulationPreventionBytes(headerPrefix);
     const reader = new BitReader(rbsp);
     reader.readUnsignedExpGolomb(); // first_mb_in_slice
     const sliceType = reader.readUnsignedExpGolomb();
@@ -248,7 +253,7 @@ class BitReader {
     let leadingZeros = 0;
     while (this.readBit() === 0) {
       leadingZeros += 1;
-      if (leadingZeros > 31) {
+      if (leadingZeros >= 31) {
         throw new Error("Exp-Golomb code is too large");
       }
     }

--- a/app/packages/multimodal/src/utils/h264-annexb.ts
+++ b/app/packages/multimodal/src/utils/h264-annexb.ts
@@ -1,3 +1,6 @@
+/**
+ * Lightweight facts extracted from one Annex-B H.264 access unit.
+ */
 export interface H264AnnexBAccessUnitInfo {
   readonly codecString?: string;
   readonly hasBFrames: boolean;
@@ -63,6 +66,9 @@ export function analyzeH264AnnexBAccessUnit(
   };
 }
 
+/**
+ * Prepends remembered SPS/PPS parameter sets when a delta frame omits them.
+ */
 export function h264AccessUnitWithParameterSets({
   bytes,
   pps,

--- a/app/packages/multimodal/src/visualization/panels/bitmap-image-view.test.tsx
+++ b/app/packages/multimodal/src/visualization/panels/bitmap-image-view.test.tsx
@@ -1,7 +1,10 @@
 import { cleanup, render, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import type { RawImageVisualization } from "../../decoders";
+import type {
+  EncodedVideoVisualization,
+  RawImageVisualization,
+} from "../../decoders";
 import { VISUALIZATION_KIND } from "../visualization-registry";
 import { imageDisplayRect } from "./base-2d-scene";
 import {
@@ -10,9 +13,11 @@ import {
   BitmapImageView,
   bitmapDrawRect,
 } from "./bitmap-image-view";
+import { resetVideoTextureDecodersForTests } from "./video-texture";
 
 afterEach(() => {
   cleanup();
+  resetVideoTextureDecodersForTests();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
@@ -266,6 +271,33 @@ describe("BitmapImageView", () => {
   });
 });
 
+describe("BitmapImageFrameView", () => {
+  it("decodes encoded video frames and draws them into the grid canvas", async () => {
+    stubVideoDecoder();
+    stubElementSize(100, 50);
+    const context = sharedMockContext();
+    const drawImage = vi.spyOn(context, "drawImage");
+    const onImageLoaded = vi.fn();
+
+    render(
+      <BitmapImageFrameView
+        frame={videoFrame()}
+        onImageLoaded={onImageLoaded}
+      />,
+    );
+
+    await waitFor(() => expect(onImageLoaded).toHaveBeenCalledWith(640, 480));
+
+    expect(drawImage).toHaveBeenCalledTimes(2);
+    expect(drawImage.mock.calls[0]?.[0]).toMatchObject({
+      displayHeight: 480,
+      displayWidth: 640,
+    });
+    expect(drawImage.mock.calls[1]?.[0]).toBeInstanceOf(HTMLCanvasElement);
+    expect(drawImage.mock.calls[1]?.slice(1)).toEqual([0, -12.5, 100, 75]);
+  });
+});
+
 describe("BitmapCanvasHost", () => {
   it("draws a ready bitmap 1:1 when it matches the container size", () => {
     stubElementSize(100, 50);
@@ -341,6 +373,63 @@ function rawFrame(rgba: readonly number[]): RawImageVisualization {
     sourceEncoding: "rgb8",
     width: 2,
   };
+}
+
+function videoFrame(): EncodedVideoVisualization {
+  return {
+    bytes: Uint8Array.of(0, 0, 1, 0x65),
+    codec: "h264",
+    format: "h264",
+    h264: {
+      codecString: "avc1.4D001F",
+      hasFrame: true,
+      pps: Uint8Array.of(0x68, 0xce),
+      sps: Uint8Array.of(0x67, 0x4d, 0x00, 0x1f),
+    },
+    keyframe: true,
+    kind: VISUALIZATION_KIND.ENCODED_VIDEO,
+    timestampNs: 1000n,
+  };
+}
+
+function stubVideoDecoder() {
+  class FakeEncodedVideoChunk {
+    constructor(readonly init: unknown) {}
+  }
+
+  class FakeVideoDecoder {
+    static isConfigSupported = vi.fn(async () => ({ supported: true }));
+
+    constructor(
+      private readonly init: {
+        readonly output: (frame: unknown) => void;
+      },
+    ) {}
+
+    close(): void {
+      // no-op in the fake
+    }
+
+    configure(): void {
+      // no-op in the fake
+    }
+
+    decode(): void {
+      this.init.output({
+        close: vi.fn(),
+        displayHeight: 480,
+        displayWidth: 640,
+      });
+    }
+
+    reset(): void {
+      // no-op in the fake
+    }
+  }
+
+  vi.stubGlobal("EncodedVideoChunk", FakeEncodedVideoChunk);
+  vi.stubGlobal("VideoDecoder", FakeVideoDecoder);
+  vi.stubGlobal("isSecureContext", true);
 }
 
 /**

--- a/app/packages/multimodal/src/visualization/panels/bitmap-image-view.test.tsx
+++ b/app/packages/multimodal/src/visualization/panels/bitmap-image-view.test.tsx
@@ -296,6 +296,27 @@ describe("BitmapImageFrameView", () => {
     expect(drawImage.mock.calls[1]?.[0]).toBeInstanceOf(HTMLCanvasElement);
     expect(drawImage.mock.calls[1]?.slice(1)).toEqual([0, -12.5, 100, 75]);
   });
+
+  it("reports encoded video preview decode failures", async () => {
+    vi.stubGlobal("EncodedVideoChunk", undefined);
+    vi.stubGlobal("VideoDecoder", undefined);
+    const onError = vi.fn();
+    const onImageLoaded = vi.fn();
+
+    render(
+      <BitmapImageFrameView
+        frame={videoFrame()}
+        onError={onError}
+        onImageLoaded={onImageLoaded}
+      />,
+    );
+
+    await waitFor(() => expect(onError).toHaveBeenCalledTimes(1));
+    expect(onError.mock.calls[0]?.[0]).toEqual(
+      new Error("WebCodecs video decoding is unavailable"),
+    );
+    expect(onImageLoaded).not.toHaveBeenCalled();
+  });
 });
 
 describe("BitmapCanvasHost", () => {

--- a/app/packages/multimodal/src/visualization/panels/bitmap-image-view.tsx
+++ b/app/packages/multimodal/src/visualization/panels/bitmap-image-view.tsx
@@ -22,14 +22,17 @@
  * cancellation, or on unmount).
  */
 import type { CSSProperties } from "react";
-import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
+import { useCallback, useEffect, useId, useLayoutEffect, useRef } from "react";
 
 import type {
   EncodedVideoVisualization,
   ImageVisualization,
   RawImageVisualization,
 } from "../../decoders";
-import { createEncodedVideoCanvas } from "./video-texture";
+import {
+  createEncodedVideoCanvas,
+  releaseEncodedVideoSession,
+} from "./video-texture";
 
 const DEFAULT_MIME_TYPE = "image/jpeg";
 
@@ -369,13 +372,15 @@ function BitmapEncodedVideoView({
   onErrorRef.current = onError;
   const onImageLoadedRef = useRef(onImageLoaded);
   onImageLoadedRef.current = onImageLoaded;
+  const previewTextureKey = useId();
 
   useEffect(() => {
     let cancelled = false;
 
-    createEncodedVideoCanvas(frame, undefined)
+    createEncodedVideoCanvas(frame, previewTextureKey)
       .then((source) => {
         if (cancelled) {
+          closeDrawable(source);
           return;
         }
 
@@ -390,8 +395,9 @@ function BitmapEncodedVideoView({
 
     return () => {
       cancelled = true;
+      releaseEncodedVideoSession(frame, previewTextureKey);
     };
-  }, [commit, frame]);
+  }, [commit, frame, previewTextureKey]);
 
   return (
     <canvas

--- a/app/packages/multimodal/src/visualization/panels/bitmap-image-view.tsx
+++ b/app/packages/multimodal/src/visualization/panels/bitmap-image-view.tsx
@@ -6,7 +6,8 @@
  * Two entry points share one canvas lifecycle (`useBitmapCanvas`):
  *
  * - `BitmapImageView` decodes encoded image bytes with `createImageBitmap`
- *   and paints the result (image preview cells).
+ *   and paints the result (image preview cells). Encoded video frames use
+ *   WebCodecs for one-frame decode, then share the same canvas paint path.
  * - `BitmapCanvasHost` paints a ready `ImageBitmap` handed in as a prop
  *   (point-cloud preview cells at rest, fed by the shared snapshot
  *   renderer). The host OWNS every bitmap it is handed: it closes the
@@ -23,7 +24,12 @@
 import type { CSSProperties } from "react";
 import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
 
-import type { ImageVisualization, RawImageVisualization } from "../../decoders";
+import type {
+  EncodedVideoVisualization,
+  ImageVisualization,
+  RawImageVisualization,
+} from "../../decoders";
+import { createEncodedVideoCanvas } from "./video-texture";
 
 const DEFAULT_MIME_TYPE = "image/jpeg";
 
@@ -313,6 +319,19 @@ export function BitmapImageFrameView({
   onImageLoaded,
   style,
 }: BitmapImageFrameViewProps) {
+  if (frame.kind === "encoded-video") {
+    return (
+      <BitmapEncodedVideoView
+        className={className}
+        frame={frame}
+        fit={fit}
+        onError={onError}
+        onImageLoaded={onImageLoaded}
+        style={style}
+      />
+    );
+  }
+
   return frame.kind === "raw-image" ? (
     <BitmapRawImageView
       className={className}
@@ -331,6 +350,55 @@ export function BitmapImageFrameView({
       onError={onError}
       onImageLoaded={onImageLoaded}
       style={style}
+    />
+  );
+}
+
+function BitmapEncodedVideoView({
+  className,
+  frame,
+  fit = "cover",
+  onError,
+  onImageLoaded,
+  style,
+}: Omit<BitmapImageFrameViewProps, "frame"> & {
+  readonly frame: EncodedVideoVisualization;
+}) {
+  const { canvasRef, commit } = useBitmapCanvas(fit);
+  const onErrorRef = useRef(onError);
+  onErrorRef.current = onError;
+  const onImageLoadedRef = useRef(onImageLoaded);
+  onImageLoadedRef.current = onImageLoaded;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    createEncodedVideoCanvas(frame, undefined)
+      .then((source) => {
+        if (cancelled) {
+          return;
+        }
+
+        commit(source);
+        onImageLoadedRef.current?.(source.width, source.height);
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          onErrorRef.current?.(error);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [commit, frame]);
+
+  return (
+    <canvas
+      className={className}
+      ref={canvasRef}
+      role="img"
+      style={{ ...styles.canvas, ...style }}
     />
   );
 }

--- a/app/packages/multimodal/src/visualization/panels/image-texture.ts
+++ b/app/packages/multimodal/src/visualization/panels/image-texture.ts
@@ -11,16 +11,22 @@ import type {
   RawImageVisualization,
 } from "../../decoders";
 import type { ImageTextureHandle } from "./base-2d-scene";
+import { createEncodedVideoTexture } from "./video-texture";
 
 /**
  * Decodes an image visualization into a disposable texture handle.
  */
 export async function createImageTexture(
   frame: ImageVisualization,
+  textureKey?: string,
 ): Promise<ImageTextureHandle> {
-  return frame.kind === "raw-image"
-    ? createRawImageTexture(frame)
-    : createEncodedImageTexture(frame);
+  if (frame.kind === "raw-image") {
+    return createRawImageTexture(frame);
+  }
+  if (frame.kind === "encoded-video") {
+    return createEncodedVideoTexture(frame, textureKey);
+  }
+  return createEncodedImageTexture(frame);
 }
 
 /**

--- a/app/packages/multimodal/src/visualization/panels/image.test.tsx
+++ b/app/packages/multimodal/src/visualization/panels/image.test.tsx
@@ -10,6 +10,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type {
   EncodedImageVisualization,
+  EncodedVideoVisualization,
   RawImageVisualization,
 } from "../../decoders";
 import { VISUALIZATION_KIND } from "../visualization-registry";
@@ -18,6 +19,7 @@ import {
   imageTextureCacheStats,
   resetImageTextureCacheForTests,
 } from "./image-texture-cache";
+import { resetVideoTextureDecodersForTests } from "./video-texture";
 
 vi.mock("./base-2d-scene", () => ({
   Base2DScene: ({ children }: { readonly children?: ReactNode }) => (
@@ -34,10 +36,12 @@ vi.mock("./webgpu-canvas", () => ({
 
 beforeEach(() => {
   resetImageTextureCacheForTests();
+  resetVideoTextureDecodersForTests();
 });
 
 afterEach(() => {
   cleanup();
+  resetVideoTextureDecodersForTests();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
@@ -130,6 +134,12 @@ describe("ImagePanel", () => {
 
     expect(imageTextureCacheStats().decodeCount).toBe(1);
   });
+
+  it("surfaces video keyframe wait states from the shared image panel", async () => {
+    render(<ImagePanel frame={deltaVideoFrame()} />);
+
+    expect(await screen.findByText("Waiting for H.264 keyframe")).toBeTruthy();
+  });
 });
 
 function loadedFrame(): EncodedImageVisualization {
@@ -156,5 +166,17 @@ function rawFrame(): RawImageVisualization {
     rgba: new Uint8Array([255, 0, 0, 255, 0, 0, 255, 255]),
     sourceEncoding: "rgb8",
     width: 2,
+  };
+}
+
+function deltaVideoFrame(): EncodedVideoVisualization {
+  return {
+    bytes: Uint8Array.of(0, 0, 1, 0x41, 0xc0),
+    codec: "h264",
+    format: "h264",
+    h264: { hasFrame: true },
+    keyframe: false,
+    kind: VISUALIZATION_KIND.ENCODED_VIDEO,
+    timestampNs: 1000n,
   };
 }

--- a/app/packages/multimodal/src/visualization/panels/image.tsx
+++ b/app/packages/multimodal/src/visualization/panels/image.tsx
@@ -79,7 +79,11 @@ export function ImagePanel({
   viewTransform,
 }: ImagePanelProps) {
   const [canvasError, setCanvasError] = useState<string | null>(null);
-  const { handle: textureHandle, status } = useImageTextureLease({
+  const {
+    errorMessage,
+    handle: textureHandle,
+    status,
+  } = useImageTextureLease({
     disabledStatus: "error",
     enabled: hasImageData(frame),
     frame,
@@ -118,7 +122,9 @@ export function ImagePanel({
       {canvasError || status !== "loaded" ? (
         <div style={styles.status}>
           {canvasError ??
-            (status === "error" ? "Image unavailable" : "Loading image")}
+            (status === "error"
+              ? (errorMessage ?? "Image unavailable")
+              : "Loading image")}
         </div>
       ) : null}
       {!canvasError && status === "loaded" && onResetView ? (

--- a/app/packages/multimodal/src/visualization/panels/use-image-texture-lease.ts
+++ b/app/packages/multimodal/src/visualization/panels/use-image-texture-lease.ts
@@ -38,6 +38,7 @@ export function useImageTextureLease({
   onLoaded,
   textureKey,
 }: UseImageTextureLeaseOptions): {
+  readonly errorMessage: string | null;
   readonly handle: ImageTextureHandle | null;
   readonly status: ImageTextureLeaseStatus;
 } {
@@ -45,6 +46,7 @@ export function useImageTextureLease({
   const hasVisibleTextureRef = useRef(false);
   const onLoadedRef = useRef(onLoaded);
   onLoadedRef.current = onLoaded;
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [handle, setHandle] = useState<ImageTextureHandle | null>(null);
   const [status, setStatus] = useState<ImageTextureLeaseStatus>(() =>
     enabled && hasImageData(frame) ? "loading" : disabledStatus,
@@ -70,17 +72,19 @@ export function useImageTextureLease({
     if (!enabled || !hasImageData(frame)) {
       hasVisibleTextureRef.current = false;
       replaceHeldTexture(null, heldTextureRef, setHandle);
+      setErrorMessage(null);
       setStatus(disabledStatus);
       return undefined;
     }
 
     let cancelled = false;
     if (!hasVisibleTextureRef.current) {
+      setErrorMessage(null);
       setStatus("loading");
     }
 
     const lease = acquireImageTexture(textureKey, () =>
-      createImageTexture(frame),
+      createImageTexture(frame, textureKey),
     );
     lease.promise
       .then((decodedHandle) => {
@@ -95,10 +99,11 @@ export function useImageTextureLease({
           setHandle,
         );
         hasVisibleTextureRef.current = true;
+        setErrorMessage(null);
         setStatus("loaded");
         onLoadedRef.current?.(decodedHandle);
       })
-      .catch(() => {
+      .catch((error: unknown) => {
         lease.release();
         if (cancelled) {
           return;
@@ -106,6 +111,7 @@ export function useImageTextureLease({
 
         hasVisibleTextureRef.current = false;
         replaceHeldTexture(null, heldTextureRef, setHandle);
+        setErrorMessage(errorMessageFromUnknown(error));
         setStatus("error");
       });
 
@@ -117,7 +123,7 @@ export function useImageTextureLease({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [disabledStatus, enabled, identity, textureKey]);
 
-  return { handle, status };
+  return { errorMessage, handle, status };
 }
 
 export function hasImageData(
@@ -129,6 +135,9 @@ export function hasImageData(
   if (frame.kind === "encoded-image") {
     return frame.bytes.byteLength > 0;
   }
+  if (frame.kind === "encoded-video") {
+    return frame.bytes.byteLength > 0;
+  }
   return frame.rgba.byteLength > 0 && frame.width > 0 && frame.height > 0;
 }
 
@@ -138,7 +147,7 @@ export function imageIdentity(
   if (!frame) {
     return frame;
   }
-  return frame.kind === "encoded-image" ? frame.bytes : frame.rgba;
+  return frame.kind === "raw-image" ? frame.rgba : frame.bytes;
 }
 
 function replaceHeldTexture(
@@ -153,4 +162,14 @@ function replaceHeldTexture(
 
   heldRef.current = next;
   setHandle(next?.handle ?? null);
+}
+
+function errorMessageFromUnknown(error: unknown): string {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  if (typeof error === "string" && error) {
+    return error;
+  }
+  return "Image unavailable";
 }

--- a/app/packages/multimodal/src/visualization/panels/use-image-texture-lease.ts
+++ b/app/packages/multimodal/src/visualization/panels/use-image-texture-lease.ts
@@ -171,5 +171,20 @@ function errorMessageFromUnknown(error: unknown): string {
   if (typeof error === "string" && error) {
     return error;
   }
+  if (hasStringMessage(error)) {
+    return error.message;
+  }
   return "Image unavailable";
+}
+
+function hasStringMessage(
+  error: unknown,
+): error is { readonly message: string } {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "message" in error &&
+    typeof error.message === "string" &&
+    error.message.length > 0
+  );
 }

--- a/app/packages/multimodal/src/visualization/panels/video-texture.test.ts
+++ b/app/packages/multimodal/src/visualization/panels/video-texture.test.ts
@@ -1,0 +1,253 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { EncodedVideoVisualization } from "../../decoders";
+import { VISUALIZATION_KIND } from "../visualization-registry";
+import {
+  createEncodedVideoTexture,
+  resetVideoTextureDecodersForTests,
+} from "./video-texture";
+
+interface FakeChunk {
+  readonly data: BufferSource;
+  readonly timestamp: number;
+  readonly type: "key" | "delta";
+}
+
+interface FakeFrame {
+  readonly close: ReturnType<typeof vi.fn>;
+  readonly displayHeight: number;
+  readonly displayWidth: number;
+}
+
+const fakeDecoderInstances: FakeVideoDecoder[] = [];
+
+beforeEach(() => {
+  resetVideoTextureDecodersForTests();
+  fakeDecoderInstances.length = 0;
+  FakeVideoDecoder.isConfigSupported.mockClear();
+  vi.stubGlobal("EncodedVideoChunk", FakeEncodedVideoChunk);
+  vi.stubGlobal("VideoDecoder", FakeVideoDecoder);
+  vi.stubGlobal("isSecureContext", true);
+});
+
+afterEach(() => {
+  resetVideoTextureDecodersForTests();
+  vi.unstubAllGlobals();
+});
+
+describe("createEncodedVideoTexture", () => {
+  it("decodes H.264 keyframes into disposable Three textures", async () => {
+    const handle = await createEncodedVideoTexture(
+      h264Frame({ keyframe: true, timestampNs: 1000n }),
+      "rec\n/camera/video\n1000",
+    );
+
+    expect(handle.imageWidth).toBe(640);
+    expect(handle.imageHeight).toBe(480);
+    expect(fakeDecoderInstances).toHaveLength(1);
+    expect(FakeVideoDecoder.isConfigSupported).toHaveBeenCalledWith({
+      avc: { format: "annexb" },
+      codec: "avc1.4D001F",
+      hardwareAcceleration: "no-preference",
+      optimizeForLatency: true,
+    });
+    expect(fakeDecoderInstances[0].configuredCodec).toBe("avc1.4D001F");
+    expect(fakeDecoderInstances[0].decodeCalls[0]?.type).toBe("key");
+
+    const frame = fakeDecoderInstances[0].outputFrames[0];
+    handle.dispose();
+    expect(frame?.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("reuses per-topic decoder sessions and cached parameter sets", async () => {
+    const keyframe = await createEncodedVideoTexture(
+      h264Frame({ keyframe: true, timestampNs: 1000n }),
+      "rec\n/camera/video\n1000",
+    );
+    const delta = await createEncodedVideoTexture(
+      h264Frame({
+        bytes: Uint8Array.of(0, 0, 1, 0x41, 0xc0),
+        hasParameterSets: false,
+        keyframe: false,
+        timestampNs: 2000n,
+      }),
+      "rec\n/camera/video\n2000",
+    );
+
+    expect(fakeDecoderInstances).toHaveLength(1);
+    expect(fakeDecoderInstances[0].decodeCalls).toHaveLength(2);
+    expect(
+      Array.from(fakeDecoderInstances[0].decodeCalls[1]?.data as Uint8Array),
+    ).toEqual([
+      0, 0, 0, 1, 0x67, 0x4d, 0x00, 0x1f, 0, 0, 0, 1, 0x68, 0xce, 0, 0, 1, 0x41,
+      0xc0,
+    ]);
+
+    keyframe.dispose();
+    delta.dispose();
+  });
+
+  it("rejects delta frames until a keyframe has configured the session", async () => {
+    await expect(
+      createEncodedVideoTexture(
+        h264Frame({
+          bytes: Uint8Array.of(0, 0, 1, 0x41, 0xc0),
+          hasParameterSets: false,
+          keyframe: false,
+          timestampNs: 1000n,
+        }),
+        "rec\n/camera/video\n1000",
+      ),
+    ).rejects.toThrow("Waiting for H.264 keyframe");
+
+    expect(fakeDecoderInstances).toHaveLength(0);
+  });
+
+  it("resets decoder state on backwards timestamps", async () => {
+    const keyframe = await createEncodedVideoTexture(
+      h264Frame({ keyframe: true, timestampNs: 2000n }),
+      "rec\n/camera/video\n2000",
+    );
+
+    await expect(
+      createEncodedVideoTexture(
+        h264Frame({
+          bytes: Uint8Array.of(0, 0, 1, 0x41, 0xc0),
+          hasParameterSets: false,
+          keyframe: false,
+          timestampNs: 1000n,
+        }),
+        "rec\n/camera/video\n1000",
+      ),
+    ).rejects.toThrow("Waiting for H.264 keyframe");
+    expect(fakeDecoderInstances[0].resetCalls).toBe(1);
+
+    keyframe.dispose();
+  });
+
+  it("reconfigures on keyframes with a new H.264 codec string", async () => {
+    const first = await createEncodedVideoTexture(
+      h264Frame({ keyframe: true, timestampNs: 1000n }),
+      "rec\n/camera/video\n1000",
+    );
+    const second = await createEncodedVideoTexture(
+      h264Frame({
+        codecString: "avc1.64001F",
+        keyframe: true,
+        sps: Uint8Array.of(0x67, 0x64, 0x00, 0x1f),
+        timestampNs: 2000n,
+      }),
+      "rec\n/camera/video\n2000",
+    );
+
+    expect(fakeDecoderInstances).toHaveLength(2);
+    expect(fakeDecoderInstances[0].resetCalls).toBe(1);
+    expect(fakeDecoderInstances[1].configuredCodec).toBe("avc1.64001F");
+
+    first.dispose();
+    second.dispose();
+  });
+});
+
+function h264Frame({
+  bytes = Uint8Array.of(
+    0,
+    0,
+    0,
+    1,
+    0x67,
+    0x4d,
+    0x00,
+    0x1f,
+    0,
+    0,
+    1,
+    0x68,
+    0xce,
+    0,
+    0,
+    1,
+    0x65,
+    0xb0,
+  ),
+  codecString = "avc1.4D001F",
+  hasParameterSets = true,
+  keyframe,
+  sps = Uint8Array.of(0x67, 0x4d, 0x00, 0x1f),
+  timestampNs,
+}: {
+  readonly bytes?: Uint8Array;
+  readonly codecString?: string;
+  readonly hasParameterSets?: boolean;
+  readonly keyframe: boolean;
+  readonly sps?: Uint8Array;
+  readonly timestampNs: bigint;
+}): EncodedVideoVisualization {
+  return {
+    bytes,
+    codec: "h264",
+    coordinateFrameId: "camera",
+    format: "h264",
+    h264: {
+      ...(hasParameterSets ? { codecString } : {}),
+      hasFrame: true,
+      ...(hasParameterSets ? { pps: Uint8Array.of(0x68, 0xce), sps } : {}),
+    },
+    keyframe,
+    kind: VISUALIZATION_KIND.ENCODED_VIDEO,
+    timestampNs,
+  };
+}
+
+class FakeEncodedVideoChunk {
+  readonly data: BufferSource;
+  readonly timestamp: number;
+  readonly type: "key" | "delta";
+
+  constructor(init: FakeChunk) {
+    this.data = init.data;
+    this.timestamp = init.timestamp;
+    this.type = init.type;
+  }
+}
+
+class FakeVideoDecoder {
+  static isConfigSupported = vi.fn(async () => ({ supported: true }));
+
+  readonly decodeCalls: FakeChunk[] = [];
+  readonly outputFrames: FakeFrame[] = [];
+  configuredCodec: string | null = null;
+  resetCalls = 0;
+
+  constructor(
+    private readonly init: {
+      readonly error: (error: unknown) => void;
+      readonly output: (frame: FakeFrame) => void;
+    },
+  ) {
+    fakeDecoderInstances.push(this);
+  }
+
+  close(): void {
+    // no-op in the fake
+  }
+
+  configure(config: { readonly codec: string }): void {
+    this.configuredCodec = config.codec;
+  }
+
+  decode(chunk: FakeChunk): void {
+    this.decodeCalls.push(chunk);
+    const frame = {
+      close: vi.fn(),
+      displayHeight: 480,
+      displayWidth: 640,
+    };
+    this.outputFrames.push(frame);
+    this.init.output(frame);
+  }
+
+  reset(): void {
+    this.resetCalls += 1;
+  }
+}

--- a/app/packages/multimodal/src/visualization/panels/video-texture.test.ts
+++ b/app/packages/multimodal/src/visualization/panels/video-texture.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { EncodedVideoVisualization } from "../../decoders";
 import { VISUALIZATION_KIND } from "../visualization-registry";
 import {
+  createEncodedVideoCanvas,
   createEncodedVideoTexture,
   resetVideoTextureDecodersForTests,
 } from "./video-texture";
@@ -24,7 +25,8 @@ const fakeDecoderInstances: FakeVideoDecoder[] = [];
 beforeEach(() => {
   resetVideoTextureDecodersForTests();
   fakeDecoderInstances.length = 0;
-  FakeVideoDecoder.isConfigSupported.mockClear();
+  FakeVideoDecoder.decodeBehavior = "output";
+  FakeVideoDecoder.isConfigSupported = vi.fn(async () => ({ supported: true }));
   vi.stubGlobal("EncodedVideoChunk", FakeEncodedVideoChunk);
   vi.stubGlobal("VideoDecoder", FakeVideoDecoder);
   vi.stubGlobal("isSecureContext", true);
@@ -33,6 +35,8 @@ beforeEach(() => {
 afterEach(() => {
   resetVideoTextureDecodersForTests();
   vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  vi.useRealTimers();
 });
 
 describe("createEncodedVideoTexture", () => {
@@ -46,7 +50,6 @@ describe("createEncodedVideoTexture", () => {
     expect(handle.imageHeight).toBe(480);
     expect(fakeDecoderInstances).toHaveLength(1);
     expect(FakeVideoDecoder.isConfigSupported).toHaveBeenCalledWith({
-      avc: { format: "annexb" },
       codec: "avc1.4D001F",
       hardwareAcceleration: "no-preference",
       optimizeForLatency: true,
@@ -147,7 +150,92 @@ describe("createEncodedVideoTexture", () => {
     first.dispose();
     second.dispose();
   });
+
+  it("rejects pending textures when the decoder reports an error", async () => {
+    FakeVideoDecoder.decodeBehavior = "hold";
+
+    const texture = createEncodedVideoTexture(
+      h264Frame({ keyframe: true, timestampNs: 1000n }),
+      "rec\n/camera/video\n1000",
+    );
+    await vi.waitFor(() => {
+      expect(fakeDecoderInstances[0]?.decodeCalls).toHaveLength(1);
+    });
+
+    const expectation = expect(texture).rejects.toThrow("decoder failed");
+    fakeDecoderInstances[0].fail(new Error("decoder failed"));
+
+    await expectation;
+    expect(fakeDecoderInstances[0].resetCalls).toBe(1);
+    expect(fakeDecoderInstances[0].closeCalls).toBe(1);
+  });
+
+  it("rejects pending textures and resets the decoder on decode timeout", async () => {
+    vi.useFakeTimers();
+    FakeVideoDecoder.decodeBehavior = "hold";
+
+    const texture = createEncodedVideoTexture(
+      h264Frame({ keyframe: true, timestampNs: 1000n }),
+      "rec\n/camera/video\n1000",
+    );
+    await Promise.resolve();
+
+    const expectation = expect(texture).rejects.toThrow(
+      "Timed out waiting for H.264 frame decode",
+    );
+    await vi.advanceTimersByTimeAsync(3000);
+
+    await expectation;
+    expect(fakeDecoderInstances[0].resetCalls).toBe(1);
+    expect(fakeDecoderInstances[0].closeCalls).toBe(1);
+  });
 });
+
+describe("createEncodedVideoCanvas", () => {
+  it("decodes H.264 keyframes into canvases and closes decoded frames", async () => {
+    const context = stubVideoCanvasContext();
+    const drawImage = vi
+      .spyOn(context, "drawImage")
+      .mockImplementation(() => undefined);
+
+    const canvas = await createEncodedVideoCanvas(
+      h264Frame({ keyframe: true, timestampNs: 1000n }),
+      "rec\n/camera/video\n1000",
+    );
+
+    const frame = fakeDecoderInstances[0].outputFrames[0];
+    expect(canvas.width).toBe(640);
+    expect(canvas.height).toBe(480);
+    expect(drawImage).toHaveBeenCalledWith(frame, 0, 0, 640, 480);
+    expect(frame?.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("evicts least-recently-used decoder sessions from canvas previews", async () => {
+    stubVideoCanvasContext();
+
+    for (let index = 0; index < 7; index += 1) {
+      await createEncodedVideoCanvas(
+        h264Frame({ keyframe: true, timestampNs: BigInt(index + 1) }),
+        `rec\n/camera/${index}\n${index}`,
+      );
+    }
+
+    expect(fakeDecoderInstances).toHaveLength(7);
+    expect(fakeDecoderInstances[0].closeCalls).toBe(1);
+    expect(fakeDecoderInstances[1].closeCalls).toBe(0);
+  });
+});
+
+function stubVideoCanvasContext(): CanvasRenderingContext2D {
+  const context = document.createElement("canvas").getContext("2d");
+  if (!context) {
+    throw new Error("shared canvas 2d mock missing");
+  }
+  vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(
+    context as never,
+  );
+  return context;
+}
 
 function h264Frame({
   bytes = Uint8Array.of(
@@ -213,9 +301,11 @@ class FakeEncodedVideoChunk {
 
 class FakeVideoDecoder {
   static isConfigSupported = vi.fn(async () => ({ supported: true }));
+  static decodeBehavior: "hold" | "output" = "output";
 
   readonly decodeCalls: FakeChunk[] = [];
   readonly outputFrames: FakeFrame[] = [];
+  closeCalls = 0;
   configuredCodec: string | null = null;
   resetCalls = 0;
 
@@ -229,7 +319,7 @@ class FakeVideoDecoder {
   }
 
   close(): void {
-    // no-op in the fake
+    this.closeCalls += 1;
   }
 
   configure(config: { readonly codec: string }): void {
@@ -238,6 +328,10 @@ class FakeVideoDecoder {
 
   decode(chunk: FakeChunk): void {
     this.decodeCalls.push(chunk);
+    if (FakeVideoDecoder.decodeBehavior === "hold") {
+      return;
+    }
+
     const frame = {
       close: vi.fn(),
       displayHeight: 480,
@@ -249,5 +343,9 @@ class FakeVideoDecoder {
 
   reset(): void {
     this.resetCalls += 1;
+  }
+
+  fail(error: Error): void {
+    this.init.error(error);
   }
 }

--- a/app/packages/multimodal/src/visualization/panels/video-texture.ts
+++ b/app/packages/multimodal/src/visualization/panels/video-texture.ts
@@ -63,6 +63,9 @@ interface PendingVideoFrame {
 const sessions = new Map<string, H264VideoDecodeSession>();
 let syntheticTimestampUs = 0;
 
+/**
+ * Decodes an encoded video visualization into a disposable Three texture.
+ */
 export async function createEncodedVideoTexture(
   frame: EncodedVideoVisualization,
   textureKey: string | undefined,
@@ -75,6 +78,9 @@ export async function createEncodedVideoTexture(
   return session.decode(frame);
 }
 
+/**
+ * Decodes an encoded video visualization into a canvas for GPU-free previews.
+ */
 export async function createEncodedVideoCanvas(
   frame: EncodedVideoVisualization,
   textureKey: string | undefined,
@@ -92,6 +98,9 @@ export async function createEncodedVideoCanvas(
   }
 }
 
+/**
+ * Clears shared WebCodecs sessions and synthetic timestamps between tests.
+ */
 export function resetVideoTextureDecodersForTests(): void {
   for (const session of sessions.values()) {
     session.close();

--- a/app/packages/multimodal/src/visualization/panels/video-texture.ts
+++ b/app/packages/multimodal/src/visualization/panels/video-texture.ts
@@ -6,7 +6,7 @@ import type { ImageTextureHandle } from "./base-2d-scene";
 
 const VIDEO_DECODE_SESSION_CAP = 6;
 const VIDEO_DECODE_TIMEOUT_MS = 3000;
-const MICROSECONDS_PER_NANOSECOND = 1000n;
+const NANOSECONDS_PER_MICROSECOND = 1000n;
 
 type EncodedVideoChunkType = "key" | "delta";
 
@@ -29,9 +29,6 @@ interface VideoFrameLike {
 }
 
 interface VideoDecoderConfigLike {
-  readonly avc?: {
-    readonly format: "annexb";
-  };
   readonly codec: string;
   readonly hardwareAcceleration?: "no-preference" | "prefer-hardware";
   readonly optimizeForLatency?: boolean;
@@ -107,6 +104,20 @@ export function resetVideoTextureDecodersForTests(): void {
   }
   sessions.clear();
   syntheticTimestampUs = 0;
+}
+
+export function releaseEncodedVideoSession(
+  frame: EncodedVideoVisualization,
+  textureKey: string | undefined,
+): void {
+  const sessionKey = videoSessionKey(textureKey, frame);
+  const session = sessions.get(sessionKey);
+  if (!session) {
+    return;
+  }
+
+  session.close();
+  sessions.delete(sessionKey);
 }
 
 function videoDecodeSessionForKey(sessionKey: string): H264VideoDecodeSession {
@@ -216,8 +227,7 @@ class H264VideoDecodeSession {
     }
 
     const Decoder = videoDecoderConstructor();
-    const Chunk = encodedVideoChunkConstructor();
-    if (!Decoder || !Chunk) {
+    if (!Decoder) {
       throw new Error("WebCodecs video decoding is unavailable");
     }
     if (globalThis.isSecureContext === false) {
@@ -225,7 +235,6 @@ class H264VideoDecodeSession {
     }
 
     const config: VideoDecoderConfigLike = {
-      avc: { format: "annexb" },
       codec: codecString,
       hardwareAcceleration: "no-preference",
       optimizeForLatency: true,
@@ -233,6 +242,10 @@ class H264VideoDecodeSession {
     const supported = await Decoder.isConfigSupported?.(config);
     if (!supported?.supported) {
       throw new Error(`H.264 codec '${codecString}' is unsupported`);
+    }
+
+    if (this.decoder) {
+      return this.decoder;
     }
 
     this.codecString = codecString;
@@ -284,6 +297,7 @@ class H264VideoDecodeSession {
         resolve,
         timeout: setTimeout(() => {
           this.pending = this.pending.filter((entry) => entry !== pending);
+          this.resetDecoder();
           reject(new Error("Timed out waiting for H.264 frame decode"));
         }, VIDEO_DECODE_TIMEOUT_MS),
       };
@@ -394,7 +408,7 @@ function timestampMicros(timestampNs: bigint | undefined): number {
     return syntheticTimestampUs;
   }
 
-  return Number(timestampNs / MICROSECONDS_PER_NANOSECOND);
+  return Number(timestampNs / NANOSECONDS_PER_MICROSECOND);
 }
 
 function videoDecoderConstructor(): VideoDecoderConstructor | undefined {

--- a/app/packages/multimodal/src/visualization/panels/video-texture.ts
+++ b/app/packages/multimodal/src/visualization/panels/video-texture.ts
@@ -1,0 +1,413 @@
+import * as THREE from "three";
+
+import type { EncodedVideoVisualization } from "../../decoders";
+import { h264AccessUnitWithParameterSets } from "../../utils/h264-annexb";
+import type { ImageTextureHandle } from "./base-2d-scene";
+
+const VIDEO_DECODE_SESSION_CAP = 6;
+const VIDEO_DECODE_TIMEOUT_MS = 3000;
+const MICROSECONDS_PER_NANOSECOND = 1000n;
+
+type EncodedVideoChunkType = "key" | "delta";
+
+interface EncodedVideoChunkLike {
+  readonly data: BufferSource;
+  readonly timestamp: number;
+  readonly type: EncodedVideoChunkType;
+}
+
+interface EncodedVideoChunkConstructor {
+  new (init: EncodedVideoChunkLike): unknown;
+}
+
+interface VideoFrameLike {
+  readonly codedHeight?: number;
+  readonly codedWidth?: number;
+  readonly displayHeight?: number;
+  readonly displayWidth?: number;
+  close?: () => void;
+}
+
+interface VideoDecoderConfigLike {
+  readonly avc?: {
+    readonly format: "annexb";
+  };
+  readonly codec: string;
+  readonly hardwareAcceleration?: "no-preference" | "prefer-hardware";
+  readonly optimizeForLatency?: boolean;
+}
+
+interface VideoDecoderLike {
+  close(): void;
+  configure(config: VideoDecoderConfigLike): void;
+  decode(chunk: unknown): void;
+  reset(): void;
+}
+
+interface VideoDecoderConstructor {
+  new (init: {
+    error: (error: unknown) => void;
+    output: (frame: VideoFrameLike) => void;
+  }): VideoDecoderLike;
+  isConfigSupported?: (
+    config: VideoDecoderConfigLike,
+  ) => Promise<{ readonly supported?: boolean }>;
+}
+
+interface PendingVideoFrame {
+  readonly reject: (error: Error) => void;
+  readonly resolve: (frame: VideoFrameLike) => void;
+  readonly timeout: ReturnType<typeof setTimeout>;
+}
+
+const sessions = new Map<string, H264VideoDecodeSession>();
+let syntheticTimestampUs = 0;
+
+export async function createEncodedVideoTexture(
+  frame: EncodedVideoVisualization,
+  textureKey: string | undefined,
+): Promise<ImageTextureHandle> {
+  if (frame.codec !== "h264") {
+    throw new Error(`Video codec '${frame.codec}' is unsupported`);
+  }
+
+  const session = videoDecodeSessionForKey(videoSessionKey(textureKey, frame));
+  return session.decode(frame);
+}
+
+export async function createEncodedVideoCanvas(
+  frame: EncodedVideoVisualization,
+  textureKey: string | undefined,
+): Promise<HTMLCanvasElement> {
+  if (frame.codec !== "h264") {
+    throw new Error(`Video codec '${frame.codec}' is unsupported`);
+  }
+
+  const session = videoDecodeSessionForKey(videoSessionKey(textureKey, frame));
+  const output = await session.decodeVideoFrame(frame);
+  try {
+    return canvasFromVideoFrame(output);
+  } finally {
+    closeVideoFrame(output);
+  }
+}
+
+export function resetVideoTextureDecodersForTests(): void {
+  for (const session of sessions.values()) {
+    session.close();
+  }
+  sessions.clear();
+  syntheticTimestampUs = 0;
+}
+
+function videoDecodeSessionForKey(sessionKey: string): H264VideoDecodeSession {
+  const existing = sessions.get(sessionKey);
+  if (existing) {
+    sessions.delete(sessionKey);
+    sessions.set(sessionKey, existing);
+    return existing;
+  }
+
+  const session = new H264VideoDecodeSession();
+  sessions.set(sessionKey, session);
+  while (sessions.size > VIDEO_DECODE_SESSION_CAP) {
+    const oldestKey = sessions.keys().next().value as string;
+    sessions.get(oldestKey)?.close();
+    sessions.delete(oldestKey);
+  }
+
+  return session;
+}
+
+function videoSessionKey(
+  textureKey: string | undefined,
+  frame: EncodedVideoVisualization,
+): string {
+  if (!textureKey) {
+    return [
+      "keyless-video",
+      frame.coordinateFrameId ?? "",
+      frame.format,
+      frame.codec,
+    ].join("\n");
+  }
+
+  const firstSeparator = textureKey.indexOf("\n");
+  const secondSeparator =
+    firstSeparator >= 0 ? textureKey.indexOf("\n", firstSeparator + 1) : -1;
+  return secondSeparator >= 0
+    ? textureKey.slice(0, secondSeparator)
+    : textureKey;
+}
+
+class H264VideoDecodeSession {
+  private codecString: string | undefined;
+  private configuredCodecString: string | undefined;
+  private decoder: VideoDecoderLike | null = null;
+  private lastTimestampUs: number | undefined;
+  private pending: PendingVideoFrame[] = [];
+  private pps: Uint8Array | undefined;
+  private sps: Uint8Array | undefined;
+
+  async decode(frame: EncodedVideoVisualization): Promise<ImageTextureHandle> {
+    const output = await this.decodeVideoFrame(frame);
+    return textureFromVideoFrame(output);
+  }
+
+  async decodeVideoFrame(
+    frame: EncodedVideoVisualization,
+  ): Promise<VideoFrameLike> {
+    this.rememberParameterSets(frame);
+    const timestampUs = timestampMicros(frame.timestampNs);
+
+    if (
+      this.lastTimestampUs !== undefined &&
+      timestampUs <= this.lastTimestampUs
+    ) {
+      this.resetDecoder();
+    }
+    this.lastTimestampUs = timestampUs;
+
+    if (!frame.h264?.hasFrame) {
+      throw new Error("Waiting for H.264 frame");
+    }
+
+    const decoder = await this.ensureDecoder(frame);
+    return this.decodeFrame(decoder, frame, timestampUs);
+  }
+
+  close(): void {
+    this.rejectPending(new Error("Video decoder closed"));
+    this.decoder?.close();
+    this.decoder = null;
+  }
+
+  private async ensureDecoder(
+    frame: EncodedVideoVisualization,
+  ): Promise<VideoDecoderLike> {
+    if (!frame.keyframe && !this.decoder) {
+      throw new Error("Waiting for H.264 keyframe");
+    }
+
+    const codecString = frame.h264?.codecString ?? this.codecString;
+    if (!codecString) {
+      throw new Error("Waiting for H.264 keyframe with SPS/PPS");
+    }
+
+    if (
+      frame.keyframe &&
+      this.decoder &&
+      codecString !== this.configuredCodecString
+    ) {
+      this.resetDecoder();
+    }
+
+    if (this.decoder) {
+      return this.decoder;
+    }
+
+    const Decoder = videoDecoderConstructor();
+    const Chunk = encodedVideoChunkConstructor();
+    if (!Decoder || !Chunk) {
+      throw new Error("WebCodecs video decoding is unavailable");
+    }
+    if (globalThis.isSecureContext === false) {
+      throw new Error("WebCodecs video decoding requires HTTPS");
+    }
+
+    const config: VideoDecoderConfigLike = {
+      avc: { format: "annexb" },
+      codec: codecString,
+      hardwareAcceleration: "no-preference",
+      optimizeForLatency: true,
+    };
+    const supported = await Decoder.isConfigSupported?.(config);
+    if (!supported?.supported) {
+      throw new Error(`H.264 codec '${codecString}' is unsupported`);
+    }
+
+    this.codecString = codecString;
+    this.configuredCodecString = codecString;
+    this.decoder = new Decoder({
+      error: (error) => {
+        this.rejectPending(asError(error));
+        this.resetDecoder();
+      },
+      output: (videoFrame) => {
+        const pending = this.pending.shift();
+        if (!pending) {
+          closeVideoFrame(videoFrame);
+          return;
+        }
+
+        clearTimeout(pending.timeout);
+        pending.resolve(videoFrame);
+      },
+    });
+    this.decoder.configure(config);
+    return this.decoder;
+  }
+
+  private decodeFrame(
+    decoder: VideoDecoderLike,
+    frame: EncodedVideoVisualization,
+    timestampUs: number,
+  ): Promise<VideoFrameLike> {
+    const Chunk = encodedVideoChunkConstructor();
+    if (!Chunk) {
+      throw new Error("WebCodecs encoded video chunks are unavailable");
+    }
+
+    const data = h264AccessUnitWithParameterSets({
+      bytes: frame.bytes,
+      pps: frame.h264?.pps ? undefined : this.pps,
+      sps: frame.h264?.sps ? undefined : this.sps,
+    });
+    const chunk = new Chunk({
+      data,
+      timestamp: timestampUs,
+      type: frame.keyframe ? "key" : "delta",
+    });
+
+    return new Promise<VideoFrameLike>((resolve, reject) => {
+      const pending: PendingVideoFrame = {
+        reject,
+        resolve,
+        timeout: setTimeout(() => {
+          this.pending = this.pending.filter((entry) => entry !== pending);
+          reject(new Error("Timed out waiting for H.264 frame decode"));
+        }, VIDEO_DECODE_TIMEOUT_MS),
+      };
+      this.pending.push(pending);
+
+      try {
+        decoder.decode(chunk);
+      } catch (error) {
+        clearTimeout(pending.timeout);
+        this.pending = this.pending.filter((entry) => entry !== pending);
+        this.resetDecoder();
+        reject(asError(error));
+      }
+    });
+  }
+
+  private rememberParameterSets(frame: EncodedVideoVisualization): void {
+    if (frame.h264?.sps) {
+      this.sps = frame.h264.sps;
+    }
+    if (frame.h264?.pps) {
+      this.pps = frame.h264.pps;
+    }
+    if (frame.h264?.codecString) {
+      this.codecString = frame.h264.codecString;
+    }
+  }
+
+  private resetDecoder(): void {
+    this.rejectPending(new Error("Video decoder reset"));
+    try {
+      this.decoder?.reset();
+      this.decoder?.close();
+    } catch {
+      // Best effort cleanup; the next frame will build a fresh session.
+    }
+    this.decoder = null;
+    this.configuredCodecString = undefined;
+  }
+
+  private rejectPending(error: Error): void {
+    const pending = this.pending.splice(0);
+    for (const entry of pending) {
+      clearTimeout(entry.timeout);
+      entry.reject(error);
+    }
+  }
+}
+
+function textureFromVideoFrame(videoFrame: VideoFrameLike): ImageTextureHandle {
+  const { height, width } = videoFrameSize(videoFrame);
+  const texture = new THREE.Texture(videoFrame as TexImageSource);
+  texture.colorSpace = THREE.SRGBColorSpace;
+  texture.generateMipmaps = false;
+  texture.magFilter = THREE.LinearFilter;
+  texture.minFilter = THREE.LinearFilter;
+  texture.needsUpdate = true;
+
+  return {
+    aspectRatio: width / height,
+    dispose: () => {
+      texture.dispose();
+      closeVideoFrame(videoFrame);
+    },
+    imageHeight: height,
+    imageWidth: width,
+    texture,
+  };
+}
+
+function canvasFromVideoFrame(videoFrame: VideoFrameLike): HTMLCanvasElement {
+  const { height, width } = videoFrameSize(videoFrame);
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+
+  const context = canvas.getContext("2d");
+  if (!context) {
+    throw new Error("Unable to create video preview canvas context");
+  }
+
+  context.drawImage(
+    videoFrame as unknown as CanvasImageSource,
+    0,
+    0,
+    width,
+    height,
+  );
+  return canvas;
+}
+
+function videoFrameSize(videoFrame: VideoFrameLike): {
+  readonly height: number;
+  readonly width: number;
+} {
+  return {
+    height: Math.max(
+      1,
+      videoFrame.displayHeight ?? videoFrame.codedHeight ?? 1,
+    ),
+    width: Math.max(1, videoFrame.displayWidth ?? videoFrame.codedWidth ?? 1),
+  };
+}
+
+function timestampMicros(timestampNs: bigint | undefined): number {
+  if (timestampNs === undefined) {
+    syntheticTimestampUs += 1;
+    return syntheticTimestampUs;
+  }
+
+  return Number(timestampNs / MICROSECONDS_PER_NANOSECOND);
+}
+
+function videoDecoderConstructor(): VideoDecoderConstructor | undefined {
+  return (
+    globalThis as unknown as { readonly VideoDecoder?: VideoDecoderConstructor }
+  ).VideoDecoder;
+}
+
+function encodedVideoChunkConstructor():
+  | EncodedVideoChunkConstructor
+  | undefined {
+  return (
+    globalThis as unknown as {
+      readonly EncodedVideoChunk?: EncodedVideoChunkConstructor;
+    }
+  ).EncodedVideoChunk;
+}
+
+function closeVideoFrame(videoFrame: VideoFrameLike): void {
+  videoFrame.close?.();
+}
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}

--- a/app/packages/multimodal/src/visualization/visualization-registry.ts
+++ b/app/packages/multimodal/src/visualization/visualization-registry.ts
@@ -6,6 +6,7 @@
 export const VISUALIZATION_KIND = Object.freeze({
   CAMERA_CALIBRATION: "camera-calibration",
   ENCODED_IMAGE: "encoded-image",
+  ENCODED_VIDEO: "encoded-video",
   GRID: "grid",
   IMAGE_ANNOTATIONS: "image-annotations",
   LOCATION: "location",
@@ -46,6 +47,7 @@ export const VISUALIZATION_PANEL_REGISTRY: Readonly<
   // frustum in the 3D scene, so it maps to the 3D panel family.
   [VISUALIZATION_KIND.CAMERA_CALIBRATION]: PANEL_TYPE.THREE_D,
   [VISUALIZATION_KIND.ENCODED_IMAGE]: PANEL_TYPE.IMAGE,
+  [VISUALIZATION_KIND.ENCODED_VIDEO]: PANEL_TYPE.IMAGE,
   [VISUALIZATION_KIND.GRID]: PANEL_TYPE.THREE_D,
   [VISUALIZATION_KIND.IMAGE_ANNOTATIONS]: PANEL_TYPE.IMAGE,
   // No MAP panel exists yet; v1 surfaces locations as a 3D-tile HUD


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

Prev: #7961
Next: #7963 

This adds H.264 video rendering for MCAP topics that carry compressed video frames. The two supported inputs are Foxglove `CompressedVideo` messages and ROS `sensor_msgs/CompressedImage` messages whose `format` says they are H.264/AVC video rather than JPEG/PNG images.

The viewer treats video frames as another image-family visualization. Topic discovery can list them next to image topics, the image panel can render them, and grid previews can decode a frame without opening a WebGPU surface.

## Architecture notes

The decoders do the source-specific work. They inspect the compressed payload, normalize recognized H.264 metadata into `EncodedVideoVisualization`, and leave unsupported formats visible in raw-message inspection with an `unsupportedReason`.

`h264-annexb.ts` is intentionally small. It is not an H.264 parser. It only checks the facts the browser decode path needs: Annex-B start codes, SPS/PPS, codec string, keyframe-ness, and whether the access unit contains B-frames.

Rendering uses WebCodecs. The image panel sends one encoded H.264 access unit to a per-stream decode session, gets back a `VideoFrame`, and wraps that frame as either a Three texture or a 2D canvas preview. Sessions remember SPS/PPS across delta frames, reset on timestamp regression, and are capped so visible tiles cannot hold decoder resources forever.

## Supported here

- Foxglove `CompressedVideo` protobuf messages
- Foxglove `CompressedVideo` carried through ROS 2 CDR payloads
- ROS `sensor_msgs/CompressedImage` payloads marked as H.264 / AVC
- H.264 Annex-B access units with NAL start codes
- Streams with enough SPS/PPS data to configure WebCodecs, either on the current frame or from an earlier keyframe in the same stream
- Keyframe/delta frame stepping through the existing MCAP image panel
- Raw-message visibility for known-but-unrendered video formats

## Out of scope for this PR

- AV1, H.265/HEVC, VP9, and other non-H.264 codecs
- H.264 payloads without Annex-B start codes, including AVCC/length-prefixed samples
- B-frame streams, which need display/decode reordering and timestamp buffering
- MP4, fragmented MP4, Matroska, or other muxed video containers inside MCAP records
- Audio, multi-track media, transcoding, server-side decode, or WASM codec fallback
- Browsers where WebCodecs, secure-context decode, or the requested H.264 profile is unavailable

## Why this shape

MCAP playback already works as timestamped messages flowing into visualization contracts. For these ROS/Foxglove video topics, each message is already the useful unit: one compressed access unit. Treating that as an encoded image-family frame keeps seeking, raw inspection, topic selection, and previews in the same model as the rest of the multimodal viewer.

WebCodecs is the narrow browser-native API that can decode raw H.264 access units. Using it avoids an ffmpeg/WASM dependency, a server decode path, or an HTML video element that wants a containerized media stream.

The SPS/PPS session cache is there because real streams often put decoder configuration on keyframes and omit it from later frames. Keeping that state per stream lets frame stepping work without replaying the whole topic history.

B-frames and muxed containers change the problem. They need buffering, reordering, demuxing, and a clearer answer for how MCAP message time maps to display time. That should be a follow-up design, not hidden complexity in this first pass.

## 🧪 How is this patch tested? If it is not, please explain why.

- `yarn check` in `app/packages/multimodal`
- `yarn test packages/multimodal/src/adapters/mcap packages/multimodal/src/visualization/panels/image.test.tsx packages/multimodal/src/visualization/panels/bitmap-image-view.test.tsx packages/multimodal/src/visualization/panels/video-texture.test.ts packages/multimodal/src/utils/h264-annexb.test.ts` in `app` (95 files, 1013 tests)

## Notes to Reviewer

Review after #7961. GitHub should show only the compressed-video commits plus the small docstring cleanup commit.

Suggested order:

- Decoder contract and format handling: `decoders/types.ts`, `decoders/video-format.ts`, Foxglove/ROS compressed payload decoders
- H.264 access-unit inspection: `utils/h264-annexb.ts`
- Browser decode lifecycle: `visualization/panels/video-texture.ts`
- Image panel and preview integration: `bitmap-image-view.tsx`, `image.tsx`, and related tests

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

FiftyOne's multimodal MCAP viewer can detect and render H.264 compressed video streams from supported ROS and Foxglove MCAP topics.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3203
<!-- enterprise-sync-pr:end -->