### PR TITLE
Support JSON-schema ROS MCAP streams

### DIFF
--- a/app/packages/multimodal/src/adapters/mcap/decoders/json/factory.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/json/factory.ts
@@ -1,0 +1,59 @@
+import type {
+  DecodeContext,
+  DecodedOutput,
+  Decoder,
+  PayloadDescriptor,
+} from "../../../../decoders";
+import { timingFromContext } from "../foxglove/protobuf/timing";
+import { decodeJsonRecord } from "./decode";
+
+type JsonMapper = (
+  record: Record<string, unknown>,
+  context: DecodeContext,
+) => DecodedOutput;
+
+/**
+ * Builds one JSON decoder per supported payload descriptor for a message family.
+ */
+export function jsonDecodersForPayloads({
+  id,
+  map,
+  payloads,
+}: {
+  readonly id: string;
+  readonly map: JsonMapper;
+  readonly payloads: readonly PayloadDescriptor[];
+}): readonly Decoder[] {
+  return payloads.map((payload) => ({
+    id: `${id}.${decoderIdSuffix(payload)}`,
+    payload,
+    version: "1",
+    decode(bytes, context) {
+      try {
+        return map(decodeJsonRecord(bytes), context);
+      } catch (error) {
+        console.warn(`[${id}] JSON decode failed`, error);
+        return degradedJsonOutput(context, error);
+      }
+    },
+  }));
+}
+
+function decoderIdSuffix(payload: PayloadDescriptor): string {
+  return [payload.schema, payload.schemaEncoding]
+    .filter((value): value is string => Boolean(value))
+    .join(".")
+    .replace(/[^a-zA-Z0-9_.-]+/g, "-");
+}
+
+function degradedJsonOutput(
+  context: DecodeContext,
+  error: unknown,
+): DecodedOutput {
+  return {
+    attributes: {
+      decodeError: error instanceof Error ? error.message : String(error),
+    },
+    timing: timingFromContext(context, undefined),
+  };
+}

--- a/app/packages/multimodal/src/adapters/mcap/decoders/json/index.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/json/index.ts
@@ -1,10 +1,16 @@
 import type { Decoder } from "../../../../decoders";
 import { jsonPoseDecoder } from "./pose";
+import { jsonRosDecoders } from "./ros";
 
 /**
  * JSON Pose decoder export.
  */
 export { jsonPoseDecoder } from "./pose";
+
+/**
+ * JSON-schema ROS decoder exports.
+ */
+export * from "./ros";
 
 /**
  * JSON payload descriptor exports.
@@ -14,4 +20,7 @@ export * from "./payloads";
 /**
  * Built-in JSON decoders for the MCAP adapter.
  */
-export const jsonDecoders: readonly Decoder[] = [jsonPoseDecoder];
+export const jsonDecoders: readonly Decoder[] = [
+  jsonPoseDecoder,
+  ...jsonRosDecoders,
+];

--- a/app/packages/multimodal/src/adapters/mcap/decoders/json/payloads.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/json/payloads.ts
@@ -14,3 +14,93 @@ export const JSON_POSE_PAYLOAD: PayloadDescriptor = {
   schema: "Pose",
   schemaEncoding: "jsonschema",
 };
+
+function jsonRosPayloads(
+  ros1Schema: string,
+  ros2Schema: string,
+): readonly PayloadDescriptor[] {
+  return [
+    {
+      encoding: "json",
+      schema: ros1Schema,
+      schemaEncoding: "jsonschema",
+    },
+    {
+      encoding: "json",
+      schema: ros2Schema,
+      schemaEncoding: "jsonschema",
+    },
+  ];
+}
+
+/**
+ * Payload descriptors for JSON-schema ROS PointCloud2 messages.
+ */
+export const JSON_ROS_POINT_CLOUD2_PAYLOADS = jsonRosPayloads(
+  "sensor_msgs/PointCloud2",
+  "sensor_msgs/msg/PointCloud2",
+);
+
+/**
+ * Payload descriptors for JSON-schema ROS CompressedImage messages.
+ */
+export const JSON_ROS_COMPRESSED_IMAGE_PAYLOADS = jsonRosPayloads(
+  "sensor_msgs/CompressedImage",
+  "sensor_msgs/msg/CompressedImage",
+);
+
+/**
+ * Payload descriptors for JSON-schema ROS Image messages.
+ */
+export const JSON_ROS_IMAGE_PAYLOADS = jsonRosPayloads(
+  "sensor_msgs/Image",
+  "sensor_msgs/msg/Image",
+);
+
+/**
+ * Payload descriptors for JSON-schema ROS CameraInfo messages.
+ */
+export const JSON_ROS_CAMERA_INFO_PAYLOADS = jsonRosPayloads(
+  "sensor_msgs/CameraInfo",
+  "sensor_msgs/msg/CameraInfo",
+);
+
+/**
+ * Payload descriptors for JSON-schema ROS LaserScan messages.
+ */
+export const JSON_ROS_LASER_SCAN_PAYLOADS = jsonRosPayloads(
+  "sensor_msgs/LaserScan",
+  "sensor_msgs/msg/LaserScan",
+);
+
+/**
+ * Payload descriptors for JSON-schema ROS PoseStamped messages.
+ */
+export const JSON_ROS_POSE_STAMPED_PAYLOADS = jsonRosPayloads(
+  "geometry_msgs/PoseStamped",
+  "geometry_msgs/msg/PoseStamped",
+);
+
+/**
+ * Payload descriptors for JSON-schema ROS Odometry messages.
+ */
+export const JSON_ROS_ODOMETRY_PAYLOADS = jsonRosPayloads(
+  "nav_msgs/Odometry",
+  "nav_msgs/msg/Odometry",
+);
+
+/**
+ * Payload descriptors for JSON-schema ROS NavSatFix messages.
+ */
+export const JSON_ROS_NAV_SAT_FIX_PAYLOADS = jsonRosPayloads(
+  "sensor_msgs/NavSatFix",
+  "sensor_msgs/msg/NavSatFix",
+);
+
+/**
+ * Payload descriptors for JSON-schema ROS OccupancyGrid messages.
+ */
+export const JSON_ROS_OCCUPANCY_GRID_PAYLOADS = jsonRosPayloads(
+  "nav_msgs/OccupancyGrid",
+  "nav_msgs/msg/OccupancyGrid",
+);

--- a/app/packages/multimodal/src/adapters/mcap/decoders/json/ros.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/json/ros.test.ts
@@ -1,0 +1,550 @@
+import { describe, expect, it, vi } from "vitest";
+import type {
+  DecodedOutput,
+  Decoder,
+  PayloadDescriptor,
+} from "../../../../decoders";
+import type { StreamInventory } from "../../../../schemas/v1";
+import { VISUALIZATION_KIND } from "../../../../visualization";
+import { createMcapDecoderRegistry } from "..";
+import {
+  isCameraCalibrationStream,
+  isCompressedImageStream,
+  isGridStream,
+  isImageStream,
+  isLocationFixStream,
+  isPointCloudStream,
+  isPoseStream,
+  streamTopics,
+} from "../../stream-topics";
+import {
+  JSON_ROS_CAMERA_INFO_PAYLOADS,
+  JSON_ROS_COMPRESSED_IMAGE_PAYLOADS,
+  JSON_ROS_IMAGE_PAYLOADS,
+  JSON_ROS_LASER_SCAN_PAYLOADS,
+  JSON_ROS_NAV_SAT_FIX_PAYLOADS,
+  JSON_ROS_OCCUPANCY_GRID_PAYLOADS,
+  JSON_ROS_ODOMETRY_PAYLOADS,
+  JSON_ROS_POINT_CLOUD2_PAYLOADS,
+  JSON_ROS_POSE_STAMPED_PAYLOADS,
+} from "./payloads";
+import {
+  jsonRosCameraInfoDecoders,
+  jsonRosCompressedImageDecoders,
+  jsonRosImageDecoders,
+  jsonRosLaserScanDecoders,
+  jsonRosNavSatFixDecoders,
+  jsonRosOccupancyGridDecoders,
+  jsonRosOdometryDecoders,
+  jsonRosPointCloud2Decoders,
+  jsonRosPoseStampedDecoders,
+} from "./ros";
+
+const TEXT_ENCODER = new TextEncoder();
+const TEXT_DECODER = new TextDecoder();
+const H264_KEYFRAME_BYTES = Uint8Array.of(
+  0,
+  0,
+  0,
+  1,
+  0x67,
+  0x4d,
+  0x00,
+  0x1f,
+  0,
+  0,
+  1,
+  0x68,
+  0xce,
+  0,
+  0,
+  1,
+  0x65,
+  0xb0,
+);
+
+describe("JSON-schema ROS MCAP decoders", () => {
+  it("registers every JSON-schema ROS payload with the MCAP decoder registry", () => {
+    const registry = createMcapDecoderRegistry();
+    const payloads = [
+      ...JSON_ROS_CAMERA_INFO_PAYLOADS,
+      ...JSON_ROS_COMPRESSED_IMAGE_PAYLOADS,
+      ...JSON_ROS_IMAGE_PAYLOADS,
+      ...JSON_ROS_LASER_SCAN_PAYLOADS,
+      ...JSON_ROS_NAV_SAT_FIX_PAYLOADS,
+      ...JSON_ROS_OCCUPANCY_GRID_PAYLOADS,
+      ...JSON_ROS_ODOMETRY_PAYLOADS,
+      ...JSON_ROS_POINT_CLOUD2_PAYLOADS,
+      ...JSON_ROS_POSE_STAMPED_PAYLOADS,
+    ];
+
+    for (const payload of payloads) {
+      expect(registry.find(payload), JSON.stringify(payload)).toBeDefined();
+    }
+  });
+
+  it("decodes JSON CompressedImage JPEG records into encoded images", () => {
+    const output = decoderForSchema(
+      jsonRosCompressedImageDecoders,
+      "sensor_msgs/CompressedImage",
+    ).decode(
+      jsonMessage({
+        data: Array.from(TEXT_ENCODER.encode("fake-jpeg")),
+        format: "jpeg",
+        header: headerRecord("camera", 3, 4),
+      }),
+      {},
+    );
+
+    expect(output.visualization?.kind).toBe(VISUALIZATION_KIND.ENCODED_IMAGE);
+    if (output.visualization?.kind !== VISUALIZATION_KIND.ENCODED_IMAGE) {
+      throw new Error("Expected encoded image visualization");
+    }
+    expect(TEXT_DECODER.decode(output.visualization.bytes)).toBe("fake-jpeg");
+    expect(output.visualization.mimeType).toBe("image/jpeg");
+    expect(output.attributes).toMatchObject({
+      byteLength: 9,
+      format: "jpeg",
+      frameId: "camera",
+    });
+    expect(output.timing?.sourceTimestamps?.messageTime).toBe(3_000_000_004n);
+  });
+
+  it("decodes JSON CompressedImage H.264 records into encoded videos", () => {
+    const output = decoderForSchema(
+      jsonRosCompressedImageDecoders,
+      "sensor_msgs/msg/CompressedImage",
+    ).decode(
+      jsonMessage({
+        data: Array.from(H264_KEYFRAME_BYTES),
+        format: "h264",
+        header: headerRecord("camera", 3, 4),
+      }),
+      {},
+    );
+
+    expect(output.visualization?.kind).toBe(VISUALIZATION_KIND.ENCODED_VIDEO);
+    if (output.visualization?.kind !== VISUALIZATION_KIND.ENCODED_VIDEO) {
+      throw new Error("Expected encoded video visualization");
+    }
+    expect(output.visualization).toMatchObject({
+      codec: "h264",
+      coordinateFrameId: "camera",
+      format: "h264",
+      keyframe: true,
+      timestampNs: 3_000_000_004n,
+    });
+    expect(output.attributes).toMatchObject({
+      byteLength: H264_KEYFRAME_BYTES.byteLength,
+      codec: "h264",
+      codecString: "avc1.4d001f",
+      format: "h264",
+      frameId: "camera",
+      keyframe: true,
+    });
+  });
+
+  it("decodes JSON Image RGB records into raw RGBA", () => {
+    const output = decoderForSchema(
+      jsonRosImageDecoders,
+      "sensor_msgs/Image",
+    ).decode(
+      jsonMessage({
+        data: [1, 2, 3, 4, 5, 6],
+        encoding: "rgb8",
+        header: headerRecord("camera", 1, 2),
+        height: 1,
+        is_bigendian: false,
+        step: 6,
+        width: 2,
+      }),
+      {},
+    );
+
+    expect(rawRgba(output)).toEqual([1, 2, 3, 255, 4, 5, 6, 255]);
+    expect(output.visualization).toMatchObject({
+      coordinateFrameId: "camera",
+      height: 1,
+      sourceEncoding: "rgb8",
+      timestampNs: 1_000_000_002n,
+      width: 2,
+    });
+  });
+
+  it("decodes JSON NavSatFix records into location visualizations", () => {
+    const output = decoderForSchema(
+      jsonRosNavSatFixDecoders,
+      "sensor_msgs/NavSatFix",
+    ).decode(
+      jsonMessage({
+        altitude: 12.5,
+        latitude: 37.77,
+        longitude: -122.42,
+      }),
+      {},
+    );
+
+    expect(output.visualization?.kind).toBe(VISUALIZATION_KIND.LOCATION);
+    if (output.visualization?.kind !== VISUALIZATION_KIND.LOCATION) {
+      throw new Error("Expected location visualization");
+    }
+    expect(output.visualization).toMatchObject({
+      altitude: 12.5,
+      latitude: 37.77,
+      longitude: -122.42,
+    });
+    expect(output.attributes).toMatchObject({
+      latitude: 37.77,
+      longitude: -122.42,
+    });
+  });
+
+  it("decodes JSON CameraInfo records into calibration visualizations", () => {
+    const K = [100, 0, 50, 0, 101, 51, 0, 0, 1];
+    const output = decoderForSchema(
+      jsonRosCameraInfoDecoders,
+      "sensor_msgs/msg/CameraInfo",
+    ).decode(
+      jsonMessage({
+        D: [0.1, -0.2, 0, 0, 0],
+        K,
+        P: [100, 0, 50, 0, 0, 101, 51, 0, 0, 0, 1, 0],
+        R: [1, 0, 0, 0, 1, 0, 0, 0, 1],
+        distortion_model: "plumb_bob",
+        header: headerRecord("camera_optical", 5, 6),
+        height: 480,
+        width: 640,
+      }),
+      {},
+    );
+
+    expect(output.visualization?.kind).toBe(
+      VISUALIZATION_KIND.CAMERA_CALIBRATION,
+    );
+    if (output.visualization?.kind !== VISUALIZATION_KIND.CAMERA_CALIBRATION) {
+      throw new Error("Expected camera calibration visualization");
+    }
+    expect(output.visualization).toMatchObject({
+      coordinateFrameId: "camera_optical",
+      D: [0.1, -0.2, 0, 0, 0],
+      distortionModel: "plumb_bob",
+      height: 480,
+      K,
+      timestampNs: 5_000_000_006n,
+      width: 640,
+    });
+  });
+
+  it("decodes JSON PointCloud2 and LaserScan records into point clouds", () => {
+    const cloud = decoderForSchema(
+      jsonRosPointCloud2Decoders,
+      "sensor_msgs/msg/PointCloud2",
+    ).decode(
+      jsonMessage({
+        data: pointCloud2Data([
+          [1, 2, 3],
+          [4, 5, 6],
+        ]),
+        fields: [pointField("x", 0), pointField("y", 4), pointField("z", 8)],
+        header: headerRecord("lidar", 7, 8),
+        height: 1,
+        is_bigendian: false,
+        is_dense: true,
+        point_step: 12,
+        row_step: 24,
+        width: 2,
+      }),
+      {},
+    );
+    const scan = decoderForSchema(
+      jsonRosLaserScanDecoders,
+      "sensor_msgs/LaserScan",
+    ).decode(
+      jsonMessage({
+        angle_increment: Math.PI / 2,
+        angle_max: Math.PI,
+        angle_min: 0,
+        header: headerRecord("scan", 9, 10),
+        intensities: [5, 6, 7, 8],
+        range_max: 100,
+        range_min: 0,
+        ranges: [1, 101, 1, -0.5],
+      }),
+      {},
+    );
+
+    expect(cloud.visualization?.kind).toBe(VISUALIZATION_KIND.POINT_CLOUD);
+    expect(scan.visualization?.kind).toBe(VISUALIZATION_KIND.POINT_CLOUD);
+    if (
+      cloud.visualization?.kind !== VISUALIZATION_KIND.POINT_CLOUD ||
+      scan.visualization?.kind !== VISUALIZATION_KIND.POINT_CLOUD
+    ) {
+      throw new Error("Expected point cloud visualizations");
+    }
+    expect(Array.from(cloud.visualization.positions)).toEqual([
+      1, 2, 3, 4, 5, 6,
+    ]);
+    expect(cloud.visualization.coordinateFrameId).toBe("lidar");
+    expect(scan.visualization.coordinateFrameId).toBe("scan");
+    expect(scan.visualization.pointCount).toBe(2);
+    expect(
+      Array.from(scan.visualization.scalarFields?.[0]?.values ?? []),
+    ).toEqual([5, 7]);
+  });
+
+  it("decodes JSON OccupancyGrid records into grid visualizations", () => {
+    const output = decoderForSchema(
+      jsonRosOccupancyGridDecoders,
+      "nav_msgs/OccupancyGrid",
+    ).decode(
+      jsonMessage({
+        data: [-1, 0, 50, 100],
+        header: headerRecord("map", 15, 16),
+        info: {
+          height: 2,
+          map_load_time: { nsec: 18, sec: 17 },
+          origin: poseRecord([1, 2, 0], [0, 0, 0, 1]),
+          resolution: 0.5,
+          width: 2,
+        },
+      }),
+      {},
+    );
+
+    expect(output.visualization?.kind).toBe(VISUALIZATION_KIND.GRID);
+    if (output.visualization?.kind !== VISUALIZATION_KIND.GRID) {
+      throw new Error("Expected grid visualization");
+    }
+    expect(output.visualization).toMatchObject({
+      cellSize: [0.5, 0.5],
+      columnCount: 2,
+      coordinateFrameId: "map",
+      rowCount: 2,
+      timestampNs: 15_000_000_016n,
+    });
+    expect(Array.from(output.visualization.rgba)).toEqual([
+      0, 0, 0, 0, 255, 255, 255, 255, 127, 127, 127, 255, 0, 0, 0, 255,
+    ]);
+  });
+
+  it("decodes JSON PoseStamped and Odometry records into pose visualizations", () => {
+    const poseStamped = decoderForSchema(
+      jsonRosPoseStampedDecoders,
+      "geometry_msgs/PoseStamped",
+    ).decode(
+      jsonMessage({
+        header: headerRecord("map", 9, 10),
+        pose: poseRecord([1, 2, 3], [0, 0, 0, 1]),
+      }),
+      {},
+    );
+    const odometry = decoderForSchema(
+      jsonRosOdometryDecoders,
+      "nav_msgs/msg/Odometry",
+    ).decode(
+      jsonMessage({
+        child_frame_id: "base_link",
+        header: headerRecord("odom", 11, 12),
+        pose: {
+          pose: poseRecord([4, 5, 6], [0, 0, 0, 1]),
+        },
+        twist: {
+          twist: {
+            angular: vectorRecord([0.1, 0.2, 0.3]),
+            linear: vectorRecord([7, 8, 9]),
+          },
+        },
+      }),
+      {},
+    );
+
+    expect(poseStamped.visualization?.kind).toBe(VISUALIZATION_KIND.POSE);
+    expect(odometry.visualization?.kind).toBe(VISUALIZATION_KIND.POSE);
+    if (
+      poseStamped.visualization?.kind !== VISUALIZATION_KIND.POSE ||
+      odometry.visualization?.kind !== VISUALIZATION_KIND.POSE
+    ) {
+      throw new Error("Expected pose visualizations");
+    }
+    expect(poseStamped.visualization).toMatchObject({
+      coordinateFrameId: "map",
+      position: [1, 2, 3],
+      timestampNs: 9_000_000_010n,
+    });
+    expect(odometry.visualization).toMatchObject({
+      angularVelocity: [0.1, 0.2, 0.3],
+      coordinateFrameId: "odom",
+      position: [4, 5, 6],
+      timestampNs: 11_000_000_012n,
+      velocity: [7, 8, 9],
+    });
+    expect(odometry.attributes).toMatchObject({ childFrameId: "base_link" });
+  });
+
+  it("degrades invalid JSON and malformed JSON records without throwing", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const decoder = decoderForSchema(
+      jsonRosCompressedImageDecoders,
+      "sensor_msgs/CompressedImage",
+    );
+    const badJson = decoder.decode(TEXT_ENCODER.encode("{nope"), {});
+    const missingFields = decoderForSchema(
+      jsonRosNavSatFixDecoders,
+      "sensor_msgs/NavSatFix",
+    ).decode(jsonMessage({}), {});
+    const malformedBytes = decoder.decode(
+      jsonMessage({ data: "not-a-byte-array", format: "jpeg" }),
+      {},
+    );
+
+    for (const output of [badJson, missingFields, malformedBytes]) {
+      expect(output.visualization).toBeUndefined();
+      expect(output.attributes?.decodeError).toBeTruthy();
+    }
+    expect(warn).toHaveBeenCalledTimes(3);
+    warn.mockRestore();
+  });
+
+  it("classifies JSON-schema ROS streams with the same buckets as ROS-wire streams", () => {
+    const compressed = createTopic(
+      "/camera/compressed",
+      JSON_ROS_COMPRESSED_IMAGE_PAYLOADS[0],
+    );
+    const rawImage = createTopic("/camera/image", JSON_ROS_IMAGE_PAYLOADS[1]);
+    const cloud = createTopic("/points", JSON_ROS_POINT_CLOUD2_PAYLOADS[0]);
+    const scan = createTopic("/scan", JSON_ROS_LASER_SCAN_PAYLOADS[1]);
+
+    expect(isCompressedImageStream(compressed)).toBe(true);
+    expect(isCompressedImageStream(rawImage)).toBe(false);
+    expect(isImageStream(compressed)).toBe(true);
+    expect(isImageStream(rawImage)).toBe(true);
+    expect(isPointCloudStream(cloud)).toBe(true);
+    expect(isPointCloudStream(scan)).toBe(true);
+    expect(
+      isCameraCalibrationStream(
+        createTopic("/camera/info", JSON_ROS_CAMERA_INFO_PAYLOADS[0]),
+      ),
+    ).toBe(true);
+    expect(
+      isPoseStream(createTopic("/pose", JSON_ROS_POSE_STAMPED_PAYLOADS[1])),
+    ).toBe(true);
+    expect(
+      isPoseStream(createTopic("/odom", JSON_ROS_ODOMETRY_PAYLOADS[0])),
+    ).toBe(true);
+    expect(
+      isLocationFixStream(
+        createTopic("/gps", JSON_ROS_NAV_SAT_FIX_PAYLOADS[0]),
+      ),
+    ).toBe(true);
+    expect(
+      isGridStream(createTopic("/map", JSON_ROS_OCCUPANCY_GRID_PAYLOADS[1])),
+    ).toBe(true);
+    expect(streamTopics([compressed, rawImage, cloud, scan])).toMatchObject({
+      image: ["/camera/compressed", "/camera/image"],
+      pointCloud: ["/points", "/scan"],
+      previewable: ["/camera/compressed", "/camera/image", "/points", "/scan"],
+    });
+  });
+});
+
+function decoderForSchema(
+  decoders: readonly Decoder[],
+  schema: string,
+): Decoder {
+  const decoder = decoders.find(
+    (candidate) => candidate.payload.schema === schema,
+  );
+  if (!decoder) {
+    throw new Error(`Missing decoder for ${schema}`);
+  }
+
+  return decoder;
+}
+
+function jsonMessage(record: Record<string, unknown>): Uint8Array {
+  return TEXT_ENCODER.encode(JSON.stringify(record));
+}
+
+function rawRgba(output: DecodedOutput): readonly number[] {
+  expect(output.visualization?.kind).toBe(VISUALIZATION_KIND.RAW_IMAGE);
+  if (output.visualization?.kind !== VISUALIZATION_KIND.RAW_IMAGE) {
+    throw new Error("Expected raw image visualization");
+  }
+
+  return Array.from(output.visualization.rgba);
+}
+
+function headerRecord(frameId: string, sec: number, nanosec: number) {
+  return {
+    frame_id: frameId,
+    stamp: { nanosec, sec },
+  };
+}
+
+function pointField(name: string, offset: number, datatype = 7) {
+  return {
+    count: 1,
+    datatype,
+    name,
+    offset,
+  };
+}
+
+function pointCloud2Data(
+  points: readonly (readonly [number, number, number])[],
+): readonly number[] {
+  const data = new Uint8Array(points.length * 12);
+  const view = new DataView(data.buffer);
+  points.forEach(([x, y, z], index) => {
+    const offset = index * 12;
+    view.setFloat32(offset, x, true);
+    view.setFloat32(offset + 4, y, true);
+    view.setFloat32(offset + 8, z, true);
+  });
+
+  return Array.from(data);
+}
+
+function poseRecord(
+  position: readonly [number, number, number],
+  quaternion: readonly [number, number, number, number],
+) {
+  return {
+    orientation: {
+      w: quaternion[3],
+      x: quaternion[0],
+      y: quaternion[1],
+      z: quaternion[2],
+    },
+    position: vectorRecord(position),
+  };
+}
+
+function vectorRecord(vector: readonly [number, number, number]) {
+  return {
+    x: vector[0],
+    y: vector[1],
+    z: vector[2],
+  };
+}
+
+function createTopic(
+  topic: string,
+  payload: PayloadDescriptor,
+): StreamInventory {
+  return {
+    $typeName: "fiftyone.multimodal.schemas.v1.StreamInventory",
+    displayName: topic,
+    metadata: {
+      "mcap.schema_name": payload.schema ?? "",
+      "mcap.topic": topic,
+    },
+    payload: {
+      $typeName: "fiftyone.multimodal.schemas.v1.PayloadDescriptor",
+      encoding: payload.encoding,
+      schema: payload.schema,
+      schemaEncoding: payload.schemaEncoding,
+    },
+    streamId: topic,
+  };
+}

--- a/app/packages/multimodal/src/adapters/mcap/decoders/json/ros.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/json/ros.ts
@@ -1,0 +1,120 @@
+import type { Decoder } from "../../../../decoders";
+import { decodeRosCameraInfoRecord } from "../ros/camera-info";
+import { decodeRosCompressedImageRecord } from "../ros/compressed-image";
+import { decodeRosImageRecord } from "../ros/image";
+import { decodeRosLaserScanRecord } from "../ros/laser-scan";
+import { decodeRosNavSatFixRecord } from "../ros/nav-sat-fix";
+import { decodeRosOccupancyGridRecord } from "../ros/occupancy-grid";
+import { decodeRosPointCloud2Record } from "../ros/point-cloud2";
+import {
+  decodeRosOdometryRecord,
+  decodeRosPoseStampedRecord,
+} from "../ros/pose";
+import { jsonDecodersForPayloads } from "./factory";
+import {
+  JSON_ROS_CAMERA_INFO_PAYLOADS,
+  JSON_ROS_COMPRESSED_IMAGE_PAYLOADS,
+  JSON_ROS_IMAGE_PAYLOADS,
+  JSON_ROS_LASER_SCAN_PAYLOADS,
+  JSON_ROS_NAV_SAT_FIX_PAYLOADS,
+  JSON_ROS_OCCUPANCY_GRID_PAYLOADS,
+  JSON_ROS_ODOMETRY_PAYLOADS,
+  JSON_ROS_POINT_CLOUD2_PAYLOADS,
+  JSON_ROS_POSE_STAMPED_PAYLOADS,
+} from "./payloads";
+
+/**
+ * JSON-schema decoders for ROS CompressedImage records.
+ */
+export const jsonRosCompressedImageDecoders = jsonDecodersForPayloads({
+  id: "json.ros.compressed-image",
+  map: decodeRosCompressedImageRecord,
+  payloads: JSON_ROS_COMPRESSED_IMAGE_PAYLOADS,
+});
+
+/**
+ * JSON-schema decoders for ROS Image records.
+ */
+export const jsonRosImageDecoders = jsonDecodersForPayloads({
+  id: "json.ros.image",
+  map: decodeRosImageRecord,
+  payloads: JSON_ROS_IMAGE_PAYLOADS,
+});
+
+/**
+ * JSON-schema decoders for ROS PointCloud2 records.
+ */
+export const jsonRosPointCloud2Decoders = jsonDecodersForPayloads({
+  id: "json.ros.point-cloud2",
+  map: decodeRosPointCloud2Record,
+  payloads: JSON_ROS_POINT_CLOUD2_PAYLOADS,
+});
+
+/**
+ * JSON-schema decoders for ROS LaserScan records.
+ */
+export const jsonRosLaserScanDecoders = jsonDecodersForPayloads({
+  id: "json.ros.laser-scan",
+  map: decodeRosLaserScanRecord,
+  payloads: JSON_ROS_LASER_SCAN_PAYLOADS,
+});
+
+/**
+ * JSON-schema decoders for ROS CameraInfo records.
+ */
+export const jsonRosCameraInfoDecoders = jsonDecodersForPayloads({
+  id: "json.ros.camera-info",
+  map: decodeRosCameraInfoRecord,
+  payloads: JSON_ROS_CAMERA_INFO_PAYLOADS,
+});
+
+/**
+ * JSON-schema decoders for ROS NavSatFix records.
+ */
+export const jsonRosNavSatFixDecoders = jsonDecodersForPayloads({
+  id: "json.ros.nav-sat-fix",
+  map: decodeRosNavSatFixRecord,
+  payloads: JSON_ROS_NAV_SAT_FIX_PAYLOADS,
+});
+
+/**
+ * JSON-schema decoders for ROS OccupancyGrid records.
+ */
+export const jsonRosOccupancyGridDecoders = jsonDecodersForPayloads({
+  id: "json.ros.occupancy-grid",
+  map: decodeRosOccupancyGridRecord,
+  payloads: JSON_ROS_OCCUPANCY_GRID_PAYLOADS,
+});
+
+/**
+ * JSON-schema decoders for ROS PoseStamped records.
+ */
+export const jsonRosPoseStampedDecoders = jsonDecodersForPayloads({
+  id: "json.ros.pose-stamped",
+  map: decodeRosPoseStampedRecord,
+  payloads: JSON_ROS_POSE_STAMPED_PAYLOADS,
+});
+
+/**
+ * JSON-schema decoders for ROS Odometry records.
+ */
+export const jsonRosOdometryDecoders = jsonDecodersForPayloads({
+  id: "json.ros.odometry",
+  map: decodeRosOdometryRecord,
+  payloads: JSON_ROS_ODOMETRY_PAYLOADS,
+});
+
+/**
+ * Built-in JSON-schema decoders for supported ROS message families.
+ */
+export const jsonRosDecoders: readonly Decoder[] = [
+  ...jsonRosCompressedImageDecoders,
+  ...jsonRosImageDecoders,
+  ...jsonRosPointCloud2Decoders,
+  ...jsonRosLaserScanDecoders,
+  ...jsonRosCameraInfoDecoders,
+  ...jsonRosNavSatFixDecoders,
+  ...jsonRosOccupancyGridDecoders,
+  ...jsonRosPoseStampedDecoders,
+  ...jsonRosOdometryDecoders,
+];

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/camera-info.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/camera-info.ts
@@ -1,6 +1,8 @@
 import type {
   CameraCalibrationVisualization,
+  DecodeContext,
   DecodedAttributeValue,
+  DecodedOutput,
 } from "../../../../decoders";
 import { VISUALIZATION_KIND } from "../../../../visualization";
 import {
@@ -25,67 +27,75 @@ const PROJECTION_MATRIX_LENGTH = 12;
  */
 export const rosCameraInfoDecoders = rosDecodersForPayloads({
   id: "ros.camera-info",
-  map(message, context) {
-    const header = rosHeader(message);
-    const frameId = rosHeaderFrameId(header);
-    const messageTimestamp = rosHeaderTimestampNs(header);
-    const width = numberField(message, "width");
-    const height = numberField(message, "height");
-    if (!Number.isInteger(width) || width <= 0) {
-      throw new Error(`Invalid camera info width ${width}`);
-    }
-    if (!Number.isInteger(height) || height <= 0) {
-      throw new Error(`Invalid camera info height ${height}`);
-    }
-
-    const K = finiteNumberArrayField(message, "K", "k");
-    if (K.length !== INTRINSIC_MATRIX_LENGTH) {
-      throw new Error(
-        `Camera info K must have ${INTRINSIC_MATRIX_LENGTH} values, got ${K.length}`,
-      );
-    }
-
-    const R = matrixOrUndefined(message, "R", "r", RECTIFICATION_MATRIX_LENGTH);
-    const P = matrixOrUndefined(message, "P", "p", PROJECTION_MATRIX_LENGTH);
-    const D = finiteNumberArrayField(message, "D", "d");
-    const distortionModel = stringField(
-      message,
-      "distortion_model",
-      stringField(message, "distortionModel"),
-    );
-
-    const attributes: Record<string, DecodedAttributeValue> = {
-      ...rosHeaderAttributes(header),
-      height,
-      width,
-    };
-    if (distortionModel) {
-      attributes.distortionModel = distortionModel;
-    }
-
-    const visualization: CameraCalibrationVisualization = {
-      ...(frameId ? { coordinateFrameId: frameId } : {}),
-      ...(D.length > 0 ? { D } : {}),
-      ...(distortionModel ? { distortionModel } : {}),
-      height,
-      K,
-      kind: VISUALIZATION_KIND.CAMERA_CALIBRATION,
-      ...(P ? { P } : {}),
-      ...(R ? { R } : {}),
-      ...(messageTimestamp !== undefined
-        ? { timestampNs: messageTimestamp }
-        : {}),
-      width,
-    };
-
-    return {
-      attributes,
-      timing: timingFromRosHeader(context, header),
-      visualization,
-    };
-  },
+  map: decodeRosCameraInfoRecord,
   payloads: ROS_CAMERA_INFO_PAYLOADS,
 });
+
+/**
+ * Normalizes a decoded ROS CameraInfo record into a camera calibration output.
+ */
+export function decodeRosCameraInfoRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+): DecodedOutput {
+  const header = rosHeader(message);
+  const frameId = rosHeaderFrameId(header);
+  const messageTimestamp = rosHeaderTimestampNs(header);
+  const width = numberField(message, "width");
+  const height = numberField(message, "height");
+  if (!Number.isInteger(width) || width <= 0) {
+    throw new Error(`Invalid camera info width ${width}`);
+  }
+  if (!Number.isInteger(height) || height <= 0) {
+    throw new Error(`Invalid camera info height ${height}`);
+  }
+
+  const K = finiteNumberArrayField(message, "K", "k");
+  if (K.length !== INTRINSIC_MATRIX_LENGTH) {
+    throw new Error(
+      `Camera info K must have ${INTRINSIC_MATRIX_LENGTH} values, got ${K.length}`,
+    );
+  }
+
+  const R = matrixOrUndefined(message, "R", "r", RECTIFICATION_MATRIX_LENGTH);
+  const P = matrixOrUndefined(message, "P", "p", PROJECTION_MATRIX_LENGTH);
+  const D = finiteNumberArrayField(message, "D", "d");
+  const distortionModel = stringField(
+    message,
+    "distortion_model",
+    stringField(message, "distortionModel"),
+  );
+
+  const attributes: Record<string, DecodedAttributeValue> = {
+    ...rosHeaderAttributes(header),
+    height,
+    width,
+  };
+  if (distortionModel) {
+    attributes.distortionModel = distortionModel;
+  }
+
+  const visualization: CameraCalibrationVisualization = {
+    ...(frameId ? { coordinateFrameId: frameId } : {}),
+    ...(D.length > 0 ? { D } : {}),
+    ...(distortionModel ? { distortionModel } : {}),
+    height,
+    K,
+    kind: VISUALIZATION_KIND.CAMERA_CALIBRATION,
+    ...(P ? { P } : {}),
+    ...(R ? { R } : {}),
+    ...(messageTimestamp !== undefined
+      ? { timestampNs: messageTimestamp }
+      : {}),
+    width,
+  };
+
+  return {
+    attributes,
+    timing: timingFromRosHeader(context, header),
+    visualization,
+  };
+}
 
 function matrixOrUndefined(
   record: Record<string, unknown>,

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/compressed-image.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/compressed-image.ts
@@ -1,5 +1,6 @@
 import {
   resourceHintsForArrayBufferViews,
+  type DecodeContext,
   type DecodedAttributeValue,
   type DecodedOutput,
   type EncodedVideoVisualization,
@@ -27,52 +28,60 @@ import {
  */
 export const rosCompressedImageDecoders = rosDecodersForPayloads({
   id: "ros.compressed-image",
-  map(message, context) {
-    const header = rosHeader(message);
-    const data = bytesField(message, "data");
-    const format = stringField(message, "format", "unknown");
-    const timing = timingFromRosHeader(context, header);
-    const attributes: Record<string, DecodedAttributeValue> = {
-      ...rosHeaderAttributes(header),
-      byteLength: data.byteLength,
-      format,
-    };
-    const mimeType = mimeTypeFromRosCompressedImageFormat(format);
+  map: decodeRosCompressedImageRecord,
+  payloads: ROS_COMPRESSED_IMAGE_PAYLOADS,
+});
 
-    if (!mimeType) {
-      const codec = videoCodecFromFormat(format);
-      if (codec === "h264") {
-        return h264CompressedImageOutput({
-          attributes,
-          data,
-          format,
-          frameId: rosHeaderFrameId(header),
-          timestampNs: rosHeaderTimestampNs(header),
-          timing,
-        });
-      }
+/**
+ * Normalizes a decoded ROS CompressedImage record into image/video output.
+ */
+export function decodeRosCompressedImageRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+): DecodedOutput {
+  const header = rosHeader(message);
+  const data = bytesField(message, "data");
+  const format = stringField(message, "format", "unknown");
+  const timing = timingFromRosHeader(context, header);
+  const attributes: Record<string, DecodedAttributeValue> = {
+    ...rosHeaderAttributes(header),
+    byteLength: data.byteLength,
+    format,
+  };
+  const mimeType = mimeTypeFromRosCompressedImageFormat(format);
 
-      return unsupportedCompressedImageOutput({
+  if (!mimeType) {
+    const codec = videoCodecFromFormat(format);
+    if (codec === "h264") {
+      return h264CompressedImageOutput({
         attributes,
         data,
-        reason: unsupportedCompressedImageReason(format),
+        format,
+        frameId: rosHeaderFrameId(header),
+        timestampNs: rosHeaderTimestampNs(header),
         timing,
       });
     }
 
-    return {
+    return unsupportedCompressedImageOutput({
       attributes,
-      resourceHints: resourceHintsForArrayBufferViews(data),
+      data,
+      reason: unsupportedCompressedImageReason(format),
       timing,
-      visualization: {
-        bytes: data,
-        kind: VISUALIZATION_KIND.ENCODED_IMAGE,
-        mimeType,
-      },
-    };
-  },
-  payloads: ROS_COMPRESSED_IMAGE_PAYLOADS,
-});
+    });
+  }
+
+  return {
+    attributes,
+    resourceHints: resourceHintsForArrayBufferViews(data),
+    timing,
+    visualization: {
+      bytes: data,
+      kind: VISUALIZATION_KIND.ENCODED_IMAGE,
+      mimeType,
+    },
+  };
+}
 
 function h264CompressedImageOutput({
   attributes,

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/image.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/image.ts
@@ -1,4 +1,8 @@
-import type { DecodedAttributeValue } from "../../../../decoders";
+import type {
+  DecodeContext,
+  DecodedAttributeValue,
+  DecodedOutput,
+} from "../../../../decoders";
 import { resourceHintsForArrayBufferViews } from "../../../../decoders";
 import { VISUALIZATION_KIND } from "../../../../visualization";
 import {
@@ -41,68 +45,76 @@ interface DecodeImageResult {
  */
 export const rosImageDecoders = rosDecodersForPayloads({
   id: "ros.image",
-  map(message, context) {
-    const header = rosHeader(message);
-    const frameId = rosHeaderFrameId(header);
-    const messageTimestamp = rosHeaderTimestampNs(header);
-    const width = integerField(message, "width");
-    const height = integerField(message, "height");
-    const step = integerField(message, "step");
-    const encoding = stringField(message, "encoding", "unknown");
-    const data = bytesField(message, "data");
-    const bigEndian = booleanLikeField(message, "is_bigendian");
-    const baseAttributes: Record<string, DecodedAttributeValue> = {
-      ...rosHeaderAttributes(header),
-      bigEndian,
-      byteLength: data.byteLength,
-      encoding,
-      height,
-      step,
-      width,
-    };
-    const timing = timingFromRosHeader(context, header);
-    const result = decodeImageRgba({
-      bigEndian,
-      data,
-      encoding,
-      height,
-      step,
-      width,
-    });
-    const attributes = {
-      ...baseAttributes,
-      ...result.attributes,
-      ...(result.unsupportedReason
-        ? { unsupportedReason: result.unsupportedReason }
-        : {}),
-    };
-
-    if (!result.rgba) {
-      return {
-        attributes,
-        timing,
-      };
-    }
-
-    return {
-      attributes,
-      resourceHints: resourceHintsForArrayBufferViews(result.rgba),
-      timing,
-      visualization: {
-        ...(frameId ? { coordinateFrameId: frameId } : {}),
-        height,
-        kind: VISUALIZATION_KIND.RAW_IMAGE,
-        rgba: result.rgba,
-        sourceEncoding: encoding,
-        ...(messageTimestamp !== undefined
-          ? { timestampNs: messageTimestamp }
-          : {}),
-        width,
-      },
-    };
-  },
+  map: decodeRosImageRecord,
   payloads: ROS_IMAGE_PAYLOADS,
 });
+
+/**
+ * Normalizes a decoded ROS Image record into raw image output.
+ */
+export function decodeRosImageRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+): DecodedOutput {
+  const header = rosHeader(message);
+  const frameId = rosHeaderFrameId(header);
+  const messageTimestamp = rosHeaderTimestampNs(header);
+  const width = integerField(message, "width");
+  const height = integerField(message, "height");
+  const step = integerField(message, "step");
+  const encoding = stringField(message, "encoding", "unknown");
+  const data = bytesField(message, "data");
+  const bigEndian = booleanLikeField(message, "is_bigendian");
+  const baseAttributes: Record<string, DecodedAttributeValue> = {
+    ...rosHeaderAttributes(header),
+    bigEndian,
+    byteLength: data.byteLength,
+    encoding,
+    height,
+    step,
+    width,
+  };
+  const timing = timingFromRosHeader(context, header);
+  const result = decodeImageRgba({
+    bigEndian,
+    data,
+    encoding,
+    height,
+    step,
+    width,
+  });
+  const attributes = {
+    ...baseAttributes,
+    ...result.attributes,
+    ...(result.unsupportedReason
+      ? { unsupportedReason: result.unsupportedReason }
+      : {}),
+  };
+
+  if (!result.rgba) {
+    return {
+      attributes,
+      timing,
+    };
+  }
+
+  return {
+    attributes,
+    resourceHints: resourceHintsForArrayBufferViews(result.rgba),
+    timing,
+    visualization: {
+      ...(frameId ? { coordinateFrameId: frameId } : {}),
+      height,
+      kind: VISUALIZATION_KIND.RAW_IMAGE,
+      rgba: result.rgba,
+      sourceEncoding: encoding,
+      ...(messageTimestamp !== undefined
+        ? { timestampNs: messageTimestamp }
+        : {}),
+      width,
+    },
+  };
+}
 
 function decodeImageRgba({
   bigEndian,

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/laser-scan.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/laser-scan.ts
@@ -1,6 +1,8 @@
 import {
   resourceHintsForArrayBufferViews,
+  type DecodeContext,
   type DecodedAttributeValue,
+  type DecodedOutput,
 } from "../../../../decoders";
 import { VISUALIZATION_KIND } from "../../../../visualization";
 import { scanToPoints } from "../foxglove/laser-scan";
@@ -32,75 +34,80 @@ const IDENTITY_POSE: ProtobufPose3D = {
  */
 export const rosLaserScanDecoders = rosDecodersForPayloads({
   id: "ros.laser-scan",
-  map(message, context) {
-    const header = rosHeader(message);
-    const frameId = rosHeaderFrameId(header);
-    const startAngle = numberField(message, "angle_min");
-    const angleMax = numberField(message, "angle_max", undefined, startAngle);
-    const angleIncrement = numberField(message, "angle_increment");
-    const rawRanges = numberArrayField(message, "ranges");
-    const intensities = numberArrayField(message, "intensities");
-    const rangeMin = numberField(message, "range_min", undefined, Number.NaN);
-    const rangeMax = numberField(message, "range_max", undefined, Number.NaN);
-    const ranges = boundedRanges(rawRanges, rangeMin, rangeMax);
-    const endAngle =
-      Number.isFinite(angleIncrement) &&
-      angleIncrement !== 0 &&
-      ranges.length > 1
-        ? startAngle + angleIncrement * (ranges.length - 1)
-        : angleMax;
-    const decoded = scanToPoints({
-      endAngle,
-      intensities:
-        intensities.length === ranges.length ? intensities : undefined,
-      pose: IDENTITY_POSE,
-      ranges,
-      startAngle,
-    });
-    const pointCount = decoded.positions.length / POINT_COMPONENT_COUNT;
-
-    const attributes: Record<string, DecodedAttributeValue> = {
-      ...rosHeaderAttributes(header),
-      angleIncrement,
-      angleMax,
-      pointCount,
-      rangeCount: rawRanges.length,
-      startAngle,
-    };
-    if (Number.isFinite(rangeMin)) {
-      attributes.rangeMin = rangeMin;
-    }
-    if (Number.isFinite(rangeMax)) {
-      attributes.rangeMax = rangeMax;
-    }
-
-    const transferableViews = [
-      decoded.positions,
-      ...(decoded.intensities ? [decoded.intensities] : []),
-    ];
-
-    return {
-      attributes,
-      resourceHints: resourceHintsForArrayBufferViews(...transferableViews),
-      timing: timingFromRosHeader(context, header),
-      visualization: {
-        ...(frameId ? { coordinateFrameId: frameId } : {}),
-        fields: [],
-        kind: VISUALIZATION_KIND.POINT_CLOUD,
-        pointCount,
-        positions: decoded.positions,
-        ...(decoded.intensities
-          ? {
-              scalarFields: [
-                { name: INTENSITY_FIELD_NAME, values: decoded.intensities },
-              ],
-            }
-          : {}),
-      },
-    };
-  },
+  map: decodeRosLaserScanRecord,
   payloads: ROS_LASER_SCAN_PAYLOADS,
 });
+
+/**
+ * Normalizes a decoded ROS LaserScan record into point-cloud output.
+ */
+export function decodeRosLaserScanRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+): DecodedOutput {
+  const header = rosHeader(message);
+  const frameId = rosHeaderFrameId(header);
+  const startAngle = numberField(message, "angle_min");
+  const angleMax = numberField(message, "angle_max", undefined, startAngle);
+  const angleIncrement = numberField(message, "angle_increment");
+  const rawRanges = numberArrayField(message, "ranges");
+  const intensities = numberArrayField(message, "intensities");
+  const rangeMin = numberField(message, "range_min", undefined, Number.NaN);
+  const rangeMax = numberField(message, "range_max", undefined, Number.NaN);
+  const ranges = boundedRanges(rawRanges, rangeMin, rangeMax);
+  const endAngle =
+    Number.isFinite(angleIncrement) && angleIncrement !== 0 && ranges.length > 1
+      ? startAngle + angleIncrement * (ranges.length - 1)
+      : angleMax;
+  const decoded = scanToPoints({
+    endAngle,
+    intensities: intensities.length === ranges.length ? intensities : undefined,
+    pose: IDENTITY_POSE,
+    ranges,
+    startAngle,
+  });
+  const pointCount = decoded.positions.length / POINT_COMPONENT_COUNT;
+
+  const attributes: Record<string, DecodedAttributeValue> = {
+    ...rosHeaderAttributes(header),
+    angleIncrement,
+    angleMax,
+    pointCount,
+    rangeCount: rawRanges.length,
+    startAngle,
+  };
+  if (Number.isFinite(rangeMin)) {
+    attributes.rangeMin = rangeMin;
+  }
+  if (Number.isFinite(rangeMax)) {
+    attributes.rangeMax = rangeMax;
+  }
+
+  const transferableViews = [
+    decoded.positions,
+    ...(decoded.intensities ? [decoded.intensities] : []),
+  ];
+
+  return {
+    attributes,
+    resourceHints: resourceHintsForArrayBufferViews(...transferableViews),
+    timing: timingFromRosHeader(context, header),
+    visualization: {
+      ...(frameId ? { coordinateFrameId: frameId } : {}),
+      fields: [],
+      kind: VISUALIZATION_KIND.POINT_CLOUD,
+      pointCount,
+      positions: decoded.positions,
+      ...(decoded.intensities
+        ? {
+            scalarFields: [
+              { name: INTENSITY_FIELD_NAME, values: decoded.intensities },
+            ],
+          }
+        : {}),
+    },
+  };
+}
 
 function boundedRanges(
   ranges: readonly number[],

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/nav-sat-fix.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/nav-sat-fix.ts
@@ -1,5 +1,7 @@
 import type {
+  DecodeContext,
   DecodedAttributeValue,
+  DecodedOutput,
   LocationVisualization,
 } from "../../../../decoders";
 import { VISUALIZATION_KIND } from "../../../../visualization";
@@ -24,64 +26,72 @@ const COVARIANCE_TYPE_UNKNOWN = 0;
  */
 export const rosNavSatFixDecoders = rosDecodersForPayloads({
   id: "ros.nav-sat-fix",
-  map(message, context) {
-    const header = rosHeader(message);
-    const frameId = rosHeaderFrameId(header);
-    const messageTimestamp = rosHeaderTimestampNs(header);
-    const latitude = numberField(message, "latitude", undefined, Number.NaN);
-    const longitude = numberField(message, "longitude", undefined, Number.NaN);
-    if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
-      throw new Error("NavSatFix has no finite latitude/longitude");
-    }
-
-    const altitude = numberField(message, "altitude", undefined, Number.NaN);
-    const attributes: Record<string, DecodedAttributeValue> = {
-      ...rosHeaderAttributes(header),
-      latitude,
-      longitude,
-    };
-    const covarianceType = numberField(
-      message,
-      "position_covariance_type",
-      undefined,
-      Number.NaN,
-    );
-    if (Number.isFinite(covarianceType)) {
-      attributes.positionCovarianceType = covarianceType;
-    }
-    const positionCovariance =
-      Number.isFinite(covarianceType) &&
-      covarianceType !== COVARIANCE_TYPE_UNKNOWN
-        ? covariance(message)
-        : undefined;
-
-    const status = statusAttributes(recordField(message, "status"));
-    if (status) {
-      attributes.status = status;
-    }
-
-    // Match the Foxglove LocationFix heuristic: many drivers emit altitude 0
-    // when altitude is unknown, even though true sea-level fixes are valid.
-    const visualization: LocationVisualization = {
-      ...(Number.isFinite(altitude) && altitude !== 0 ? { altitude } : {}),
-      ...(frameId ? { coordinateFrameId: frameId } : {}),
-      kind: VISUALIZATION_KIND.LOCATION,
-      latitude,
-      longitude,
-      ...(positionCovariance ? { positionCovariance } : {}),
-      ...(messageTimestamp !== undefined
-        ? { timestampNs: messageTimestamp }
-        : {}),
-    };
-
-    return {
-      attributes,
-      timing: timingFromRosHeader(context, header),
-      visualization,
-    };
-  },
+  map: decodeRosNavSatFixRecord,
   payloads: ROS_NAV_SAT_FIX_PAYLOADS,
 });
+
+/**
+ * Normalizes a decoded ROS NavSatFix record into location output.
+ */
+export function decodeRosNavSatFixRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+): DecodedOutput {
+  const header = rosHeader(message);
+  const frameId = rosHeaderFrameId(header);
+  const messageTimestamp = rosHeaderTimestampNs(header);
+  const latitude = numberField(message, "latitude", undefined, Number.NaN);
+  const longitude = numberField(message, "longitude", undefined, Number.NaN);
+  if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
+    throw new Error("NavSatFix has no finite latitude/longitude");
+  }
+
+  const altitude = numberField(message, "altitude", undefined, Number.NaN);
+  const attributes: Record<string, DecodedAttributeValue> = {
+    ...rosHeaderAttributes(header),
+    latitude,
+    longitude,
+  };
+  const covarianceType = numberField(
+    message,
+    "position_covariance_type",
+    undefined,
+    Number.NaN,
+  );
+  if (Number.isFinite(covarianceType)) {
+    attributes.positionCovarianceType = covarianceType;
+  }
+  const positionCovariance =
+    Number.isFinite(covarianceType) &&
+    covarianceType !== COVARIANCE_TYPE_UNKNOWN
+      ? covariance(message)
+      : undefined;
+
+  const status = statusAttributes(recordField(message, "status"));
+  if (status) {
+    attributes.status = status;
+  }
+
+  // Match the Foxglove LocationFix heuristic: many drivers emit altitude 0
+  // when altitude is unknown, even though true sea-level fixes are valid.
+  const visualization: LocationVisualization = {
+    ...(Number.isFinite(altitude) && altitude !== 0 ? { altitude } : {}),
+    ...(frameId ? { coordinateFrameId: frameId } : {}),
+    kind: VISUALIZATION_KIND.LOCATION,
+    latitude,
+    longitude,
+    ...(positionCovariance ? { positionCovariance } : {}),
+    ...(messageTimestamp !== undefined
+      ? { timestampNs: messageTimestamp }
+      : {}),
+  };
+
+  return {
+    attributes,
+    timing: timingFromRosHeader(context, header),
+    visualization,
+  };
+}
 
 function covariance(
   record: Record<string, unknown>,

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/occupancy-grid.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/occupancy-grid.ts
@@ -1,5 +1,7 @@
 import type {
+  DecodeContext,
   DecodedAttributeValue,
+  DecodedOutput,
   GridVisualization,
 } from "../../../../decoders";
 import { resourceHintsForArrayBufferViews } from "../../../../decoders";
@@ -29,63 +31,71 @@ const UINT8_MAX = 255;
  */
 export const rosOccupancyGridDecoders = rosDecodersForPayloads({
   id: "ros.occupancy-grid",
-  map(message, context) {
-    const header = rosHeader(message);
-    const frameId = rosHeaderFrameId(header);
-    const messageTimestamp = rosHeaderTimestampNs(header);
-    const info = recordField(message, "info");
-    if (!info) {
-      throw new Error("OccupancyGrid is missing map metadata");
-    }
-
-    const width = integerField(info, "width");
-    const height = integerField(info, "height");
-    const resolution = numberField(info, "resolution", undefined, Number.NaN);
-    validateMapInfo({ height, resolution, width });
-
-    const data = int8ArrayField(message, "data");
-    const cellCount = width * height;
-    if (data.length < cellCount) {
-      throw new Error(
-        `OccupancyGrid has ${data.length} cells, expected at least ${cellCount}`,
-      );
-    }
-
-    const rgba = occupancyRgba(data, cellCount);
-    const mapLoadTimeNs = rosTimestampNs(recordField(info, "map_load_time"));
-    const attributes: Record<string, DecodedAttributeValue> = {
-      ...rosHeaderAttributes(header),
-      cellCount,
-      height,
-      resolution,
-      width,
-    };
-    if (mapLoadTimeNs !== undefined) {
-      attributes.mapLoadTimeNs = mapLoadTimeNs;
-    }
-
-    const visualization: GridVisualization = {
-      ...(frameId ? { coordinateFrameId: frameId } : {}),
-      cellSize: [resolution, resolution],
-      columnCount: width,
-      kind: VISUALIZATION_KIND.GRID,
-      pose: decodePose(recordField(info, "origin")),
-      rgba,
-      rowCount: height,
-      ...(messageTimestamp !== undefined
-        ? { timestampNs: messageTimestamp }
-        : {}),
-    };
-
-    return {
-      attributes,
-      resourceHints: resourceHintsForArrayBufferViews(rgba),
-      timing: timingFromRosHeader(context, header),
-      visualization,
-    };
-  },
+  map: decodeRosOccupancyGridRecord,
   payloads: ROS_OCCUPANCY_GRID_PAYLOADS,
 });
+
+/**
+ * Normalizes a decoded ROS OccupancyGrid record into grid output.
+ */
+export function decodeRosOccupancyGridRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+): DecodedOutput {
+  const header = rosHeader(message);
+  const frameId = rosHeaderFrameId(header);
+  const messageTimestamp = rosHeaderTimestampNs(header);
+  const info = recordField(message, "info");
+  if (!info) {
+    throw new Error("OccupancyGrid is missing map metadata");
+  }
+
+  const width = integerField(info, "width");
+  const height = integerField(info, "height");
+  const resolution = numberField(info, "resolution", undefined, Number.NaN);
+  validateMapInfo({ height, resolution, width });
+
+  const data = int8ArrayField(message, "data");
+  const cellCount = width * height;
+  if (data.length < cellCount) {
+    throw new Error(
+      `OccupancyGrid has ${data.length} cells, expected at least ${cellCount}`,
+    );
+  }
+
+  const rgba = occupancyRgba(data, cellCount);
+  const mapLoadTimeNs = rosTimestampNs(recordField(info, "map_load_time"));
+  const attributes: Record<string, DecodedAttributeValue> = {
+    ...rosHeaderAttributes(header),
+    cellCount,
+    height,
+    resolution,
+    width,
+  };
+  if (mapLoadTimeNs !== undefined) {
+    attributes.mapLoadTimeNs = mapLoadTimeNs;
+  }
+
+  const visualization: GridVisualization = {
+    ...(frameId ? { coordinateFrameId: frameId } : {}),
+    cellSize: [resolution, resolution],
+    columnCount: width,
+    kind: VISUALIZATION_KIND.GRID,
+    pose: decodePose(recordField(info, "origin")),
+    rgba,
+    rowCount: height,
+    ...(messageTimestamp !== undefined
+      ? { timestampNs: messageTimestamp }
+      : {}),
+  };
+
+  return {
+    attributes,
+    resourceHints: resourceHintsForArrayBufferViews(rgba),
+    timing: timingFromRosHeader(context, header),
+    visualization,
+  };
+}
 
 function validateMapInfo({
   height,

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/point-cloud2.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/point-cloud2.ts
@@ -1,5 +1,7 @@
 import type {
+  DecodeContext,
   DecodedAttributeValue,
+  DecodedOutput,
   PointCloudField,
 } from "../../../../decoders";
 import { resourceHintsForArrayBufferViews } from "../../../../decoders";
@@ -61,94 +63,102 @@ const ROS_TO_FOXGLOVE_FIELD_TYPE = new Map<number, number>([
  */
 export const rosPointCloud2Decoders = rosDecodersForPayloads({
   id: "ros.point-cloud2",
-  map(message, context) {
-    const header = rosHeader(message);
-    const frameId = rosHeaderFrameId(header);
-    const height = integerField(message, "height");
-    const width = integerField(message, "width");
-    const pointStep = integerField(message, "point_step");
-    const rowStep = integerField(message, "row_step");
-    validateLayout({ height, pointStep, rowStep, width });
-    const originalFields = pointFields(arrayField(message, "fields"));
-    const originalFieldMetadata = originalFields.map(
-      (field): Record<string, DecodedAttributeValue> => ({
-        count: field.count,
-        datatype: field.datatype,
-        name: field.name,
-        offset: field.offset,
-      }),
-    );
-    const attributes: Record<string, DecodedAttributeValue> = {
-      ...rosHeaderAttributes(header),
-      fields: originalFieldMetadata,
-      height,
-      pointStep,
-      rowStep,
-      width,
-    };
-    const isDense = optionalBoolean(message, "is_dense");
-    if (isDense !== undefined) {
-      attributes.isDense = isDense;
-    }
-
-    if (optionalBoolean(message, "is_bigendian") === true) {
-      return {
-        attributes: {
-          ...attributes,
-          bigEndian: true,
-          declaredPointCount: height * width,
-          unsupportedReason: "ROS PointCloud2 big-endian data is unsupported",
-        },
-        timing: timingFromRosHeader(context, header),
-      };
-    }
-
-    const data = flattenPointCloudRows({
-      data: bytesField(message, "data"),
-      height,
-      pointStep,
-      rowStep,
-      width,
-    });
-    const fields = originalFields
-      .map(mapRosPointField)
-      .filter((field): field is PointCloudField => field !== undefined);
-    const decodedPoints = filterFinitePoints(
-      extractPointCloudData(data, pointStep, fields),
-    );
-    const pointCount = decodedPoints.positions.length / POINT_COMPONENT_COUNT;
-    attributes.pointCount = pointCount;
-    const packedFieldMetadata = fields.map((field) => ({
-      name: field.name,
-      offset: field.offset,
-      type: field.type,
-    }));
-
-    const transferableViews = [
-      decodedPoints.positions,
-      decodedPoints.colors,
-      ...decodedPoints.scalarFields.map((field) => field.values),
-    ].filter((view): view is Float32Array => view !== undefined);
-
-    return {
-      attributes,
-      resourceHints: resourceHintsForArrayBufferViews(...transferableViews),
-      timing: timingFromRosHeader(context, header),
-      visualization: {
-        ...(frameId ? { coordinateFrameId: frameId } : {}),
-        ...(decodedPoints.colors ? { colors: decodedPoints.colors } : {}),
-        ...(decodedPoints.scalarFields.length
-          ? { scalarFields: decodedPoints.scalarFields }
-          : {}),
-        fields: packedFieldMetadata,
-        kind: VISUALIZATION_KIND.POINT_CLOUD,
-        pointCount,
-        positions: decodedPoints.positions,
-      },
-    };
-  },
+  map: decodeRosPointCloud2Record,
   payloads: ROS_POINT_CLOUD2_PAYLOADS,
 });
+
+/**
+ * Normalizes a decoded ROS PointCloud2 record into point-cloud output.
+ */
+export function decodeRosPointCloud2Record(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+): DecodedOutput {
+  const header = rosHeader(message);
+  const frameId = rosHeaderFrameId(header);
+  const height = integerField(message, "height");
+  const width = integerField(message, "width");
+  const pointStep = integerField(message, "point_step");
+  const rowStep = integerField(message, "row_step");
+  validateLayout({ height, pointStep, rowStep, width });
+  const originalFields = pointFields(arrayField(message, "fields"));
+  const originalFieldMetadata = originalFields.map(
+    (field): Record<string, DecodedAttributeValue> => ({
+      count: field.count,
+      datatype: field.datatype,
+      name: field.name,
+      offset: field.offset,
+    }),
+  );
+  const attributes: Record<string, DecodedAttributeValue> = {
+    ...rosHeaderAttributes(header),
+    fields: originalFieldMetadata,
+    height,
+    pointStep,
+    rowStep,
+    width,
+  };
+  const isDense = optionalBoolean(message, "is_dense");
+  if (isDense !== undefined) {
+    attributes.isDense = isDense;
+  }
+
+  if (optionalBoolean(message, "is_bigendian") === true) {
+    return {
+      attributes: {
+        ...attributes,
+        bigEndian: true,
+        declaredPointCount: height * width,
+        unsupportedReason: "ROS PointCloud2 big-endian data is unsupported",
+      },
+      timing: timingFromRosHeader(context, header),
+    };
+  }
+
+  const data = flattenPointCloudRows({
+    data: bytesField(message, "data"),
+    height,
+    pointStep,
+    rowStep,
+    width,
+  });
+  const fields = originalFields
+    .map(mapRosPointField)
+    .filter((field): field is PointCloudField => field !== undefined);
+  const decodedPoints = filterFinitePoints(
+    extractPointCloudData(data, pointStep, fields),
+  );
+  const pointCount = decodedPoints.positions.length / POINT_COMPONENT_COUNT;
+  attributes.pointCount = pointCount;
+  const packedFieldMetadata = fields.map((field) => ({
+    name: field.name,
+    offset: field.offset,
+    type: field.type,
+  }));
+
+  const transferableViews = [
+    decodedPoints.positions,
+    decodedPoints.colors,
+    ...decodedPoints.scalarFields.map((field) => field.values),
+  ].filter((view): view is Float32Array => view !== undefined);
+
+  return {
+    attributes,
+    resourceHints: resourceHintsForArrayBufferViews(...transferableViews),
+    timing: timingFromRosHeader(context, header),
+    visualization: {
+      ...(frameId ? { coordinateFrameId: frameId } : {}),
+      ...(decodedPoints.colors ? { colors: decodedPoints.colors } : {}),
+      ...(decodedPoints.scalarFields.length
+        ? { scalarFields: decodedPoints.scalarFields }
+        : {}),
+      fields: packedFieldMetadata,
+      kind: VISUALIZATION_KIND.POINT_CLOUD,
+      pointCount,
+      positions: decodedPoints.positions,
+    },
+  };
+}
 
 interface RosPointField {
   readonly count: number;

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/pose.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/pose.ts
@@ -1,6 +1,7 @@
 import type {
   DecodeContext,
   DecodedAttributeValue,
+  DecodedOutput,
   PoseVisualization,
 } from "../../../../decoders";
 import { VISUALIZATION_KIND } from "../../../../visualization";
@@ -26,17 +27,7 @@ import { ROS_ODOMETRY_PAYLOADS, ROS_POSE_STAMPED_PAYLOADS } from "./payloads";
  */
 export const rosPoseStampedDecoders = rosDecodersForPayloads({
   id: "ros.pose-stamped",
-  map(message, context) {
-    const header = rosHeader(message);
-    const pose = recordField(message, "pose");
-
-    return poseOutput({
-      attributes: rosHeaderAttributes(header),
-      context,
-      header,
-      pose,
-    });
-  },
+  map: decodeRosPoseStampedRecord,
   payloads: ROS_POSE_STAMPED_PAYLOADS,
 });
 
@@ -45,30 +36,56 @@ export const rosPoseStampedDecoders = rosDecodersForPayloads({
  */
 export const rosOdometryDecoders = rosDecodersForPayloads({
   id: "ros.odometry",
-  map(message, context) {
-    const header = rosHeader(message);
-    const poseWithCovariance = recordField(message, "pose");
-    const twistWithCovariance = recordField(message, "twist");
-    const twist = recordField(twistWithCovariance, "twist");
-    const childFrameId = stringField(message, "child_frame_id");
-    const attributes: Record<string, DecodedAttributeValue> = {
-      ...rosHeaderAttributes(header),
-    };
-    if (childFrameId) {
-      attributes.childFrameId = childFrameId;
-    }
-
-    return poseOutput({
-      angularVelocity: vectorOrUndefined(recordField(twist, "angular")),
-      attributes,
-      context,
-      header,
-      pose: recordField(poseWithCovariance, "pose"),
-      velocity: vectorOrUndefined(recordField(twist, "linear")),
-    });
-  },
+  map: decodeRosOdometryRecord,
   payloads: ROS_ODOMETRY_PAYLOADS,
 });
+
+/**
+ * Normalizes a decoded ROS PoseStamped record into pose output.
+ */
+export function decodeRosPoseStampedRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+): DecodedOutput {
+  const header = rosHeader(message);
+  const pose = recordField(message, "pose");
+
+  return poseOutput({
+    attributes: rosHeaderAttributes(header),
+    context,
+    header,
+    pose,
+  });
+}
+
+/**
+ * Normalizes a decoded ROS Odometry record into pose output.
+ */
+export function decodeRosOdometryRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+): DecodedOutput {
+  const header = rosHeader(message);
+  const poseWithCovariance = recordField(message, "pose");
+  const twistWithCovariance = recordField(message, "twist");
+  const twist = recordField(twistWithCovariance, "twist");
+  const childFrameId = stringField(message, "child_frame_id");
+  const attributes: Record<string, DecodedAttributeValue> = {
+    ...rosHeaderAttributes(header),
+  };
+  if (childFrameId) {
+    attributes.childFrameId = childFrameId;
+  }
+
+  return poseOutput({
+    angularVelocity: vectorOrUndefined(recordField(twist, "angular")),
+    attributes,
+    context,
+    header,
+    pose: recordField(poseWithCovariance, "pose"),
+    velocity: vectorOrUndefined(recordField(twist, "linear")),
+  });
+}
 
 function poseOutput({
   angularVelocity,
@@ -84,7 +101,7 @@ function poseOutput({
   readonly header: Record<string, unknown> | undefined;
   readonly pose: Record<string, unknown> | undefined;
   readonly velocity?: ProtobufVector3;
-}) {
+}): DecodedOutput {
   const frameId = rosHeaderFrameId(header);
   const messageTimestamp = rosHeaderTimestampNs(header);
   const position = decodeVector3(recordField(pose, "position"));

--- a/app/packages/multimodal/src/adapters/mcap/scene-sources.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/scene-sources.test.ts
@@ -118,6 +118,69 @@ describe("mcapSceneSources", () => {
     ]);
   });
 
+  it("classifies JSON-schema ROS topics from Test1-style MCAPs", () => {
+    const sources = mcapSceneSources([
+      createTopic(
+        "IMG1_ltm_pyr_L1",
+        "sensor_msgs/CompressedImage",
+        "json",
+        "jsonschema",
+      ),
+      createTopic(
+        "IMG1_ltm_pyr_L1_left",
+        "sensor_msgs/CompressedImage",
+        "json",
+        "jsonschema",
+      ),
+      createTopic(
+        "IMG1_ltm_pyr_L1_right",
+        "sensor_msgs/CompressedImage",
+        "json",
+        "jsonschema",
+      ),
+      createTopic(
+        "IMG1_ltm_pyr_L1_wide",
+        "sensor_msgs/CompressedImage",
+        "json",
+        "jsonschema",
+      ),
+      createTopic(
+        "GNSS_Position",
+        "sensor_msgs/NavSatFix",
+        "json",
+        "jsonschema",
+      ),
+    ]);
+
+    expect(sources).toEqual([
+      {
+        id: "IMG1_ltm_pyr_L1",
+        type: MCAP_SOURCE_TYPE.IMAGE,
+        label: "IMG1_ltm_pyr_L1",
+      },
+      {
+        id: "IMG1_ltm_pyr_L1_left",
+        type: MCAP_SOURCE_TYPE.IMAGE,
+        label: "IMG1_ltm_pyr_L1_left",
+      },
+      {
+        id: "IMG1_ltm_pyr_L1_right",
+        type: MCAP_SOURCE_TYPE.IMAGE,
+        label: "IMG1_ltm_pyr_L1_right",
+      },
+      {
+        id: "IMG1_ltm_pyr_L1_wide",
+        type: MCAP_SOURCE_TYPE.IMAGE,
+        label: "IMG1_ltm_pyr_L1_wide",
+      },
+      {
+        id: "GNSS_Position",
+        type: MCAP_SOURCE_TYPE.LOCATION,
+        label: "GNSS_Position",
+      },
+    ]);
+  });
+
   it("falls back to the full topic when short labels collide", () => {
     const sources = mcapSceneSources([
       createTopic("/camera/front/image_raw"),

--- a/app/packages/multimodal/src/adapters/mcap/stream-topics.ts
+++ b/app/packages/multimodal/src/adapters/mcap/stream-topics.ts
@@ -1,6 +1,17 @@
 import type { PayloadDescriptor } from "../../decoders";
 import type { StreamInventory } from "../../schemas/v1";
-import { JSON_POSE_PAYLOAD } from "./decoders/json/payloads";
+import {
+  JSON_POSE_PAYLOAD,
+  JSON_ROS_CAMERA_INFO_PAYLOADS,
+  JSON_ROS_COMPRESSED_IMAGE_PAYLOADS,
+  JSON_ROS_IMAGE_PAYLOADS,
+  JSON_ROS_LASER_SCAN_PAYLOADS,
+  JSON_ROS_NAV_SAT_FIX_PAYLOADS,
+  JSON_ROS_OCCUPANCY_GRID_PAYLOADS,
+  JSON_ROS_ODOMETRY_PAYLOADS,
+  JSON_ROS_POINT_CLOUD2_PAYLOADS,
+  JSON_ROS_POSE_STAMPED_PAYLOADS,
+} from "./decoders/json/payloads";
 import {
   FOXGLOVE_CAMERA_CALIBRATION_PAYLOAD,
   FOXGLOVE_COMPRESSED_IMAGE_PAYLOAD,
@@ -89,6 +100,8 @@ export function isImageStream(topic: StreamInventory): boolean {
     hasPayload(topic, FOXGLOVE_COMPRESSED_IMAGE_PAYLOAD) ||
     hasPayload(topic, FOXGLOVE_COMPRESSED_VIDEO_PAYLOAD) ||
     hasAnyPayload(topic, FOXGLOVE_COMPRESSED_VIDEO_CDR_PAYLOADS) ||
+    hasAnyPayload(topic, JSON_ROS_COMPRESSED_IMAGE_PAYLOADS) ||
+    hasAnyPayload(topic, JSON_ROS_IMAGE_PAYLOADS) ||
     hasAnyPayload(topic, ROS_COMPRESSED_IMAGE_PAYLOADS) ||
     hasAnyPayload(topic, ROS_IMAGE_PAYLOADS)
   );
@@ -100,6 +113,7 @@ export function isImageStream(topic: StreamInventory): boolean {
 export function isCompressedImageStream(topic: StreamInventory): boolean {
   return (
     hasPayload(topic, FOXGLOVE_COMPRESSED_IMAGE_PAYLOAD) ||
+    hasAnyPayload(topic, JSON_ROS_COMPRESSED_IMAGE_PAYLOADS) ||
     hasAnyPayload(topic, ROS_COMPRESSED_IMAGE_PAYLOADS)
   );
 }
@@ -119,6 +133,8 @@ export function isPointCloudStream(topic: StreamInventory): boolean {
   return (
     hasPayload(topic, FOXGLOVE_POINT_CLOUD_PAYLOAD) ||
     hasPayload(topic, FOXGLOVE_LASER_SCAN_PAYLOAD) ||
+    hasAnyPayload(topic, JSON_ROS_POINT_CLOUD2_PAYLOADS) ||
+    hasAnyPayload(topic, JSON_ROS_LASER_SCAN_PAYLOADS) ||
     hasAnyPayload(topic, ROS_POINT_CLOUD2_PAYLOADS) ||
     hasAnyPayload(topic, ROS_LASER_SCAN_PAYLOADS)
   );
@@ -137,6 +153,7 @@ export function isSceneUpdateStream(topic: StreamInventory): boolean {
 export function isGridStream(topic: StreamInventory): boolean {
   return (
     hasPayload(topic, FOXGLOVE_GRID_PAYLOAD) ||
+    hasAnyPayload(topic, JSON_ROS_OCCUPANCY_GRID_PAYLOADS) ||
     hasAnyPayload(topic, ROS_OCCUPANCY_GRID_PAYLOADS)
   );
 }
@@ -148,6 +165,7 @@ export function isGridStream(topic: StreamInventory): boolean {
 export function isCameraCalibrationStream(topic: StreamInventory): boolean {
   return (
     hasPayload(topic, FOXGLOVE_CAMERA_CALIBRATION_PAYLOAD) ||
+    hasAnyPayload(topic, JSON_ROS_CAMERA_INFO_PAYLOADS) ||
     hasAnyPayload(topic, ROS_CAMERA_INFO_PAYLOADS)
   );
 }
@@ -160,6 +178,8 @@ export function isPoseStream(topic: StreamInventory): boolean {
   return (
     hasPayload(topic, FOXGLOVE_POSE_IN_FRAME_PAYLOAD) ||
     hasPayload(topic, JSON_POSE_PAYLOAD) ||
+    hasAnyPayload(topic, JSON_ROS_POSE_STAMPED_PAYLOADS) ||
+    hasAnyPayload(topic, JSON_ROS_ODOMETRY_PAYLOADS) ||
     hasAnyPayload(topic, ROS_POSE_STAMPED_PAYLOADS) ||
     hasAnyPayload(topic, ROS_ODOMETRY_PAYLOADS)
   );
@@ -172,6 +192,7 @@ export function isPoseStream(topic: StreamInventory): boolean {
 export function isLocationFixStream(topic: StreamInventory): boolean {
   return (
     hasPayload(topic, FOXGLOVE_LOCATION_FIX_PAYLOAD) ||
+    hasAnyPayload(topic, JSON_ROS_NAV_SAT_FIX_PAYLOADS) ||
     hasAnyPayload(topic, ROS_NAV_SAT_FIX_PAYLOADS)
   );
 }


### PR DESCRIPTION
## What changed

Next: https://github.com/voxel51/fiftyone/pull/7964
Prev: https://github.com/voxel51/fiftyone/pull/7962

- Added JSON-schema payload descriptors for the ROS message families already supported by the MCAP stack, with both ROS 1-style and ROS 2-style schema names.
- Added JSON decoders that parse UTF-8 JSON records and reuse the same ROS record-to-visualization mappers as ROS-wire decoding.
- Classified JSON-schema ROS topics into the existing image, point cloud, map/grid, calibration, pose, and location source buckets.
- Kept decoder failures local to the message: invalid JSON or malformed record shapes return `decodeError` attributes instead of rejecting the playback window.

## Notes

This is stacked on `sash/mm-mcap-video-support` so JSON `sensor_msgs/CompressedImage` gets both the existing JPEG/PNG encoded-image path and the H.264 encoded-video path.

## Testing

- Unit testing
- Verified with json schema mcaps

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3205
<!-- enterprise-sync-pr:end -->