### PR TITLE
Inspect and plot other mcap topics

### DIFF
--- a/app/packages/multimodal/package.json
+++ b/app/packages/multimodal/package.json
@@ -84,6 +84,7 @@
         "date-fns": "^4.1.0",
         "jotai": "^2.9.3",
         "lru-cache": "^11.0.1",
+        "maplibre-gl": "^4.7.1",
         "meshoptimizer": "^0.22.0",
         "protobufjs": "^7.6.4",
         "three": "patch:three@npm%3A0.185.1#~/.yarn/patches/three-npm-0.185.1-e07195d8b4.patch",

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove.test.ts
@@ -956,9 +956,12 @@ describe("Foxglove decoders", () => {
     expect(protobuf.timing?.sourceTimestamps?.messageTime).toBe(8_000_000_009n);
     expect(cdr.attributes?.logRows).toEqual([
       expect.objectContaining({
+        file: "controller.cpp",
         level: "warn",
         levelNumber: 3,
+        line: 10,
         message: "tracking degraded",
+        name: "controller",
         timestampNs: 5_000_000_004n,
       }),
     ]);

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove.test.ts
@@ -14,6 +14,7 @@ import {
   isImageAnnotationsStream,
   isImageStream,
   isLocationFixStream,
+  isLogStream,
   isPointCloudStream,
   isPoseStream,
   isSceneUpdateStream,
@@ -27,6 +28,7 @@ import {
   FOXGLOVE_IMAGE_ANNOTATIONS_CDR_PAYLOADS,
   FOXGLOVE_LASER_SCAN_CDR_PAYLOADS,
   FOXGLOVE_LOCATION_FIX_CDR_PAYLOADS,
+  FOXGLOVE_LOG_CDR_PAYLOADS,
   FOXGLOVE_POINT_CLOUD_CDR_PAYLOADS,
   FOXGLOVE_POSE_IN_FRAME_CDR_PAYLOADS,
   FOXGLOVE_SCENE_UPDATE_CDR_PAYLOADS,
@@ -44,6 +46,8 @@ import {
   foxgloveLaserScanDecoder,
   foxgloveLocationFixCdrDecoders,
   foxgloveLocationFixDecoder,
+  foxgloveLogCdrDecoders,
+  foxgloveLogDecoder,
   foxglovePointCloudCdrDecoders,
   foxglovePointCloudDecoder,
   foxglovePoseInFrameCdrDecoders,
@@ -119,6 +123,10 @@ describe("Foxglove decoders", () => {
       foxgloveLocationFixDecoder,
     );
     for (const decoder of foxgloveLocationFixCdrDecoders) {
+      expect(registry.find(decoder.payload)).toBe(decoder);
+    }
+    expect(registry.find(foxgloveLogDecoder.payload)).toBe(foxgloveLogDecoder);
+    for (const decoder of foxgloveLogCdrDecoders) {
       expect(registry.find(decoder.payload)).toBe(decoder);
     }
     for (const decoder of foxgloveImageAnnotationsCdrDecoders) {
@@ -905,6 +913,57 @@ describe("Foxglove decoders", () => {
     expect(output.timing?.sourceTimestamps?.messageTime).toBe(4_000_000_005n);
   });
 
+  it("decodes Foxglove Log protobuf and CDR payloads into console rows", () => {
+    const Log = LOG_ROOT.lookupType("foxglove.Log");
+    const protobuf = foxgloveLogDecoder.decode(
+      Log.encode(
+        Log.create({
+          file: "planner.cpp",
+          level: 4,
+          line: 42,
+          message: "planner failed",
+          name: "planner",
+          timestamp: { nanos: 9, seconds: 8 },
+        }),
+      ).finish(),
+      { schemaData: LOG_SCHEMA_DATA },
+    );
+    const cdr = decoderForSchemaEncoding(
+      foxgloveLogCdrDecoders,
+      "ros2msg",
+    ).decode(
+      ros2Message(ROS2_LOG_SCHEMA, {
+        file: "controller.cpp",
+        level: 3,
+        line: 10,
+        message: "tracking degraded",
+        name: "controller",
+        timestamp: { nanosec: 4, sec: 5 },
+      }),
+      { schemaData: schemaData(ROS2_LOG_SCHEMA) },
+    );
+
+    expect(protobuf.attributes?.logRows).toEqual([
+      expect.objectContaining({
+        file: "planner.cpp",
+        level: "error",
+        line: 42,
+        message: "planner failed",
+        name: "planner",
+        timestampNs: 8_000_000_009n,
+      }),
+    ]);
+    expect(protobuf.timing?.sourceTimestamps?.messageTime).toBe(8_000_000_009n);
+    expect(cdr.attributes?.logRows).toEqual([
+      expect.objectContaining({
+        level: "warn",
+        levelNumber: 3,
+        message: "tracking degraded",
+        timestampNs: 5_000_000_004n,
+      }),
+    ]);
+  });
+
   it("decodes protobuf scalar grid payloads into translucent masks", () => {
     const output = foxgloveGridDecoder.decode(
       gridWireMessage({
@@ -963,6 +1022,7 @@ describe("Foxglove decoders", () => {
       "/scene",
       FOXGLOVE_SCENE_UPDATE_CDR_PAYLOADS[0],
     );
+    const log = createTopic("/logs", FOXGLOVE_LOG_CDR_PAYLOADS[0]);
 
     expect(isCompressedImageStream(compressedImage)).toBe(true);
     expect(isImageStream(compressedImage)).toBe(true);
@@ -991,6 +1051,7 @@ describe("Foxglove decoders", () => {
         createTopic("/gps", FOXGLOVE_LOCATION_FIX_CDR_PAYLOADS[0]),
       ),
     ).toBe(true);
+    expect(isLogStream(log)).toBe(true);
     expect(
       streamTopics([
         compressedImage,
@@ -998,12 +1059,14 @@ describe("Foxglove decoders", () => {
         laserScan,
         annotations,
         sceneUpdate,
+        log,
       ]),
     ).toMatchObject({
       annotations: ["/camera/annotations"],
       image: ["/camera/compressed"],
+      logs: ["/logs"],
       pointCloud: ["/points", "/scan"],
-      previewable: ["/camera/compressed", "/points", "/scan"],
+      previewable: ["/camera/compressed", "/points", "/scan", "/logs"],
       sceneUpdates: ["/scene"],
     });
   });
@@ -1443,6 +1506,52 @@ bool frame_locked
 MSG: builtin_interfaces/Time
 int32 sec
 uint32 nanosec`;
+
+const ROS2_LOG_SCHEMA = `builtin_interfaces/Time timestamp
+uint8 level
+string message
+string name
+string file
+uint32 line
+================================================================================
+MSG: builtin_interfaces/Time
+int32 sec
+uint32 nanosec`;
+
+const LOG_ROOT = Root.fromJSON({
+  nested: {
+    foxglove: {
+      nested: {
+        Log: {
+          fields: {
+            file: { id: 5, type: "string" },
+            level: { id: 2, type: "uint32" },
+            line: { id: 6, type: "uint32" },
+            message: { id: 3, type: "string" },
+            name: { id: 4, type: "string" },
+            timestamp: { id: 1, type: "google.protobuf.Timestamp" },
+          },
+        },
+      },
+    },
+    google: {
+      nested: {
+        protobuf: {
+          nested: {
+            Timestamp: {
+              fields: {
+                nanos: { id: 2, type: "int32" },
+                seconds: { id: 1, type: "int64" },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+});
+
+const LOG_SCHEMA_DATA = protobufDescriptorData(LOG_ROOT);
 
 function decoderForSchemaEncoding(
   decoders: readonly Decoder[],

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove.test.ts
@@ -4,19 +4,51 @@ import { MessageWriter as Ros2MessageWriter } from "@foxglove/rosmsg2-serializat
 import { Root } from "protobufjs";
 import descriptor from "protobufjs/ext/descriptor";
 import { describe, expect, it } from "vitest";
-import type { Decoder } from "../../../decoders";
+import type { Decoder, PayloadDescriptor } from "../../../decoders";
+import type { StreamInventory } from "../../../schemas/v1";
 import { VISUALIZATION_KIND } from "../../../visualization";
+import {
+  isCameraCalibrationStream,
+  isCompressedImageStream,
+  isGridStream,
+  isImageAnnotationsStream,
+  isImageStream,
+  isLocationFixStream,
+  isPointCloudStream,
+  isPoseStream,
+  isSceneUpdateStream,
+  streamTopics,
+} from "../stream-topics";
 import { createMcapDecoderRegistry } from ".";
 import {
+  FOXGLOVE_CAMERA_CALIBRATION_CDR_PAYLOADS,
+  FOXGLOVE_COMPRESSED_IMAGE_CDR_PAYLOADS,
+  FOXGLOVE_GRID_CDR_PAYLOADS,
+  FOXGLOVE_IMAGE_ANNOTATIONS_CDR_PAYLOADS,
+  FOXGLOVE_LASER_SCAN_CDR_PAYLOADS,
+  FOXGLOVE_LOCATION_FIX_CDR_PAYLOADS,
+  FOXGLOVE_POINT_CLOUD_CDR_PAYLOADS,
+  FOXGLOVE_POSE_IN_FRAME_CDR_PAYLOADS,
+  FOXGLOVE_SCENE_UPDATE_CDR_PAYLOADS,
+  foxgloveCameraCalibrationCdrDecoders,
   foxgloveCameraCalibrationDecoder,
+  foxgloveCompressedImageCdrDecoders,
   foxgloveCompressedImageDecoder,
   foxgloveCompressedVideoCdrDecoders,
   foxgloveCompressedVideoDecoder,
+  foxgloveGridCdrDecoders,
   foxgloveGridDecoder,
+  foxgloveImageAnnotationsCdrDecoders,
+  foxgloveImageAnnotationsDecoder,
+  foxgloveLaserScanCdrDecoders,
   foxgloveLaserScanDecoder,
+  foxgloveLocationFixCdrDecoders,
   foxgloveLocationFixDecoder,
+  foxglovePointCloudCdrDecoders,
   foxglovePointCloudDecoder,
+  foxglovePoseInFrameCdrDecoders,
   foxglovePoseInFrameDecoder,
+  foxgloveSceneUpdateCdrDecoders,
   foxgloveSceneUpdateDecoder,
 } from "./foxglove";
 import { jsonPoseDecoder } from "./json";
@@ -37,6 +69,9 @@ describe("Foxglove decoders", () => {
     expect(registry.find(foxgloveCompressedImageDecoder.payload)).toBe(
       foxgloveCompressedImageDecoder,
     );
+    for (const decoder of foxgloveCompressedImageCdrDecoders) {
+      expect(registry.find(decoder.payload)).toBe(decoder);
+    }
     expect(registry.find(foxgloveCompressedVideoDecoder.payload)).toBe(
       foxgloveCompressedVideoDecoder,
     );
@@ -46,24 +81,51 @@ describe("Foxglove decoders", () => {
     expect(registry.find(foxglovePointCloudDecoder.payload)).toBe(
       foxglovePointCloudDecoder,
     );
+    for (const decoder of foxglovePointCloudCdrDecoders) {
+      expect(registry.find(decoder.payload)).toBe(decoder);
+    }
     expect(registry.find(foxgloveLaserScanDecoder.payload)).toBe(
       foxgloveLaserScanDecoder,
     );
+    for (const decoder of foxgloveLaserScanCdrDecoders) {
+      expect(registry.find(decoder.payload)).toBe(decoder);
+    }
     expect(registry.find(foxgloveSceneUpdateDecoder.payload)).toBe(
       foxgloveSceneUpdateDecoder,
     );
+    for (const decoder of foxgloveSceneUpdateCdrDecoders) {
+      expect(registry.find(decoder.payload)).toBe(decoder);
+    }
     expect(registry.find(foxgloveGridDecoder.payload)).toBe(
       foxgloveGridDecoder,
     );
+    for (const decoder of foxgloveGridCdrDecoders) {
+      expect(registry.find(decoder.payload)).toBe(decoder);
+    }
     expect(registry.find(foxgloveCameraCalibrationDecoder.payload)).toBe(
       foxgloveCameraCalibrationDecoder,
     );
+    for (const decoder of foxgloveCameraCalibrationCdrDecoders) {
+      expect(registry.find(decoder.payload)).toBe(decoder);
+    }
     expect(registry.find(foxglovePoseInFrameDecoder.payload)).toBe(
       foxglovePoseInFrameDecoder,
     );
+    for (const decoder of foxglovePoseInFrameCdrDecoders) {
+      expect(registry.find(decoder.payload)).toBe(decoder);
+    }
     expect(registry.find(jsonPoseDecoder.payload)).toBe(jsonPoseDecoder);
     expect(registry.find(foxgloveLocationFixDecoder.payload)).toBe(
       foxgloveLocationFixDecoder,
+    );
+    for (const decoder of foxgloveLocationFixCdrDecoders) {
+      expect(registry.find(decoder.payload)).toBe(decoder);
+    }
+    for (const decoder of foxgloveImageAnnotationsCdrDecoders) {
+      expect(registry.find(decoder.payload)).toBe(decoder);
+    }
+    expect(registry.find(foxgloveImageAnnotationsDecoder.payload)).toBe(
+      foxgloveImageAnnotationsDecoder,
     );
   });
 
@@ -135,6 +197,34 @@ describe("Foxglove decoders", () => {
     });
     expect(output.timing?.timeRange?.startNs).toBe(10n);
     expect(output.timing?.sourceTimestamps?.messageTime).toBe(123456000000n);
+  });
+
+  it("decodes cdr compressed image messages with Foxglove ROS2 schemas", () => {
+    const output = decoderForSchemaEncoding(
+      foxgloveCompressedImageCdrDecoders,
+      "ros2msg",
+    ).decode(
+      ros2Message(ROS2_COMPRESSED_IMAGE_SCHEMA, {
+        data: Array.from(new TextEncoder().encode("fake-png")),
+        format: "png",
+        frame_id: "CAM_CDR",
+        timestamp: { nanosec: 4, sec: 3 },
+      }),
+      { schemaData: schemaData(ROS2_COMPRESSED_IMAGE_SCHEMA) },
+    );
+
+    expect(output.visualization?.kind).toBe(VISUALIZATION_KIND.ENCODED_IMAGE);
+    if (output.visualization?.kind !== VISUALIZATION_KIND.ENCODED_IMAGE) {
+      throw new Error("Expected encoded image visualization");
+    }
+    expect(text(output.visualization.bytes)).toBe("fake-png");
+    expect(output.visualization.mimeType).toBe("image/png");
+    expect(output.attributes).toMatchObject({
+      byteLength: 8,
+      format: "png",
+      frameId: "CAM_CDR",
+    });
+    expect(output.timing?.sourceTimestamps?.messageTime).toBe(3_000_000_004n);
   });
 
   it("normalizes uppercase compressed image MIME formats", () => {
@@ -778,6 +868,43 @@ describe("Foxglove decoders", () => {
     expect(output.timing?.timeRange?.startNs).toBe(10n);
   });
 
+  it("decodes cdr scene update messages with Foxglove ROS2 schemas", () => {
+    const output = decoderForSchemaEncoding(
+      foxgloveSceneUpdateCdrDecoders,
+      "ros2msg",
+    ).decode(
+      ros2Message(ROS2_SCENE_UPDATE_SCHEMA, {
+        deletions: [],
+        entities: [
+          {
+            frame_id: "map",
+            frame_locked: true,
+            id: "debug/ego",
+            timestamp: { nanosec: 5, sec: 4 },
+          },
+        ],
+      }),
+      { schemaData: schemaData(ROS2_SCENE_UPDATE_SCHEMA) },
+    );
+
+    expect(output.visualization?.kind).toBe(VISUALIZATION_KIND.SCENE_UPDATE);
+    if (output.visualization?.kind !== VISUALIZATION_KIND.SCENE_UPDATE) {
+      throw new Error("Expected scene update visualization");
+    }
+    expect(output.visualization.entities).toHaveLength(1);
+    expect(output.visualization.entities[0]).toMatchObject({
+      frameId: "map",
+      frameLocked: true,
+      id: "debug/ego",
+      timestampNs: 4_000_000_005n,
+    });
+    expect(output.attributes).toMatchObject({
+      deletionCount: 0,
+      entityCount: 1,
+    });
+    expect(output.timing?.sourceTimestamps?.messageTime).toBe(4_000_000_005n);
+  });
+
   it("decodes protobuf scalar grid payloads into translucent masks", () => {
     const output = foxgloveGridDecoder.decode(
       gridWireMessage({
@@ -816,6 +943,69 @@ describe("Foxglove decoders", () => {
         },
       ),
     ).toThrow("Point cloud data length is not aligned to point stride");
+  });
+
+  it("classifies Foxglove ROS2 CDR streams with the same payload descriptors the registry uses", () => {
+    const compressedImage = createTopic(
+      "/camera/compressed",
+      FOXGLOVE_COMPRESSED_IMAGE_CDR_PAYLOADS[1],
+    );
+    const pointCloud = createTopic(
+      "/points",
+      FOXGLOVE_POINT_CLOUD_CDR_PAYLOADS[0],
+    );
+    const laserScan = createTopic("/scan", FOXGLOVE_LASER_SCAN_CDR_PAYLOADS[0]);
+    const annotations = createTopic(
+      "/camera/annotations",
+      FOXGLOVE_IMAGE_ANNOTATIONS_CDR_PAYLOADS[1],
+    );
+    const sceneUpdate = createTopic(
+      "/scene",
+      FOXGLOVE_SCENE_UPDATE_CDR_PAYLOADS[0],
+    );
+
+    expect(isCompressedImageStream(compressedImage)).toBe(true);
+    expect(isImageStream(compressedImage)).toBe(true);
+    expect(isPointCloudStream(pointCloud)).toBe(true);
+    expect(isPointCloudStream(laserScan)).toBe(true);
+    expect(isImageAnnotationsStream(annotations)).toBe(true);
+    expect(isSceneUpdateStream(sceneUpdate)).toBe(true);
+    expect(
+      isGridStream(createTopic("/grid", FOXGLOVE_GRID_CDR_PAYLOADS[0])),
+    ).toBe(true);
+    expect(
+      isCameraCalibrationStream(
+        createTopic(
+          "/camera/info",
+          FOXGLOVE_CAMERA_CALIBRATION_CDR_PAYLOADS[0],
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      isPoseStream(
+        createTopic("/pose", FOXGLOVE_POSE_IN_FRAME_CDR_PAYLOADS[1]),
+      ),
+    ).toBe(true);
+    expect(
+      isLocationFixStream(
+        createTopic("/gps", FOXGLOVE_LOCATION_FIX_CDR_PAYLOADS[0]),
+      ),
+    ).toBe(true);
+    expect(
+      streamTopics([
+        compressedImage,
+        pointCloud,
+        laserScan,
+        annotations,
+        sceneUpdate,
+      ]),
+    ).toMatchObject({
+      annotations: ["/camera/annotations"],
+      image: ["/camera/compressed"],
+      pointCloud: ["/points", "/scan"],
+      previewable: ["/camera/compressed", "/points", "/scan"],
+      sceneUpdates: ["/scene"],
+    });
   });
 });
 
@@ -1196,6 +1386,15 @@ const COMPRESSED_VIDEO_SCHEMA_DATA = protobufDescriptorData(
   COMPRESSED_VIDEO_ROOT,
 );
 
+const ROS2_COMPRESSED_IMAGE_SCHEMA = `builtin_interfaces/Time timestamp
+string frame_id
+uint8[] data
+string format
+================================================================================
+MSG: builtin_interfaces/Time
+int32 sec
+uint32 nanosec`;
+
 const ROS2_COMPRESSED_VIDEO_SCHEMA = `builtin_interfaces/Time timestamp
 string frame_id
 uint8[] data
@@ -1226,6 +1425,24 @@ module builtin_interfaces {
   };
 };
 `;
+
+const ROS2_SCENE_UPDATE_SCHEMA = `foxglove_msgs/SceneEntityDeletion[] deletions
+foxglove_msgs/SceneEntity[] entities
+================================================================================
+MSG: foxglove_msgs/SceneEntityDeletion
+builtin_interfaces/Time timestamp
+string id
+uint8 type
+================================================================================
+MSG: foxglove_msgs/SceneEntity
+builtin_interfaces/Time timestamp
+string frame_id
+string id
+bool frame_locked
+================================================================================
+MSG: builtin_interfaces/Time
+int32 sec
+uint32 nanosec`;
 
 function decoderForSchemaEncoding(
   decoders: readonly Decoder[],
@@ -1275,4 +1492,25 @@ function protobufDescriptorData(root: Root): Uint8Array {
       ).toDescriptor("proto3"),
     ).finish(),
   );
+}
+
+function createTopic(
+  topic: string,
+  payload: PayloadDescriptor,
+): StreamInventory {
+  return {
+    $typeName: "fiftyone.multimodal.schemas.v1.StreamInventory",
+    displayName: topic,
+    metadata: {
+      "mcap.schema_name": payload.schema ?? "",
+      "mcap.topic": topic,
+    },
+    payload: {
+      $typeName: "fiftyone.multimodal.schemas.v1.PayloadDescriptor",
+      encoding: payload.encoding,
+      schema: payload.schema,
+      schemaEncoding: payload.schemaEncoding,
+    },
+    streamId: topic,
+  };
 }

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/camera-calibration.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/camera-calibration.ts
@@ -1,11 +1,17 @@
 import type {
   CameraCalibrationVisualization,
+  DecodeContext,
   DecodedAttributeValue,
+  DecodedOutput,
   Decoder,
 } from "../../../../decoders";
 import { VISUALIZATION_KIND } from "../../../../visualization";
+import { rosDecodersForPayloads } from "../ros/factory";
 import { decodeProtobufMessage } from "./protobuf";
-import { FOXGLOVE_CAMERA_CALIBRATION_PAYLOAD } from "./protobuf/payloads";
+import {
+  FOXGLOVE_CAMERA_CALIBRATION_CDR_PAYLOADS,
+  FOXGLOVE_CAMERA_CALIBRATION_PAYLOAD,
+} from "./payloads";
 import {
   optionalRecord,
   optionalString,
@@ -34,66 +40,82 @@ export const foxgloveCameraCalibrationDecoder: Decoder = {
       FOXGLOVE_CAMERA_CALIBRATION_PAYLOAD,
       context,
     );
-    const width = requiredNumber(message, "width");
-    const height = requiredNumber(message, "height");
-    const frameId = optionalString(message, "frameId", "frame_id");
-    const distortionModel = optionalString(
-      message,
-      "distortionModel",
-      "distortion_model",
-    );
-    const messageTimestamp = timestampNs(optionalRecord(message, "timestamp"));
-
-    if (!Number.isInteger(width) || width <= 0) {
-      throw new Error(`Invalid camera calibration width ${width}`);
-    }
-    if (!Number.isInteger(height) || height <= 0) {
-      throw new Error(`Invalid camera calibration height ${height}`);
-    }
-
-    const K = numberArray(message, "K");
-    if (K.length !== INTRINSIC_MATRIX_LENGTH) {
-      throw new Error(
-        `Camera calibration K must have ${INTRINSIC_MATRIX_LENGTH} values, got ${K.length}`,
-      );
-    }
-    const R = matrixOrUndefined(message, "R", RECTIFICATION_MATRIX_LENGTH);
-    const P = matrixOrUndefined(message, "P", PROJECTION_MATRIX_LENGTH);
-    const D = numberArray(message, "D");
-
-    const attributes: Record<string, DecodedAttributeValue> = {
-      height,
-      width,
-    };
-    if (frameId) {
-      attributes.frameId = frameId;
-    }
-    if (distortionModel) {
-      attributes.distortionModel = distortionModel;
-    }
-
-    const visualization: CameraCalibrationVisualization = {
-      ...(frameId ? { coordinateFrameId: frameId } : {}),
-      ...(D.length > 0 ? { D } : {}),
-      ...(distortionModel ? { distortionModel } : {}),
-      height,
-      K,
-      kind: VISUALIZATION_KIND.CAMERA_CALIBRATION,
-      ...(P ? { P } : {}),
-      ...(R ? { R } : {}),
-      ...(messageTimestamp !== undefined
-        ? { timestampNs: messageTimestamp }
-        : {}),
-      width,
-    };
-
-    return {
-      attributes,
-      timing: timingFromContext(context, messageTimestamp),
-      visualization,
-    };
+    return decodeFoxgloveCameraCalibrationRecord(message, context);
   },
 };
+
+/**
+ * Decoders for Foxglove CameraCalibration messages carried over ROS 2 CDR.
+ */
+export const foxgloveCameraCalibrationCdrDecoders = rosDecodersForPayloads({
+  id: "foxglove.camera-calibration.cdr",
+  map: decodeFoxgloveCameraCalibrationRecord,
+  payloads: FOXGLOVE_CAMERA_CALIBRATION_CDR_PAYLOADS,
+});
+
+export function decodeFoxgloveCameraCalibrationRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+): DecodedOutput {
+  const width = requiredNumber(message, "width");
+  const height = requiredNumber(message, "height");
+  const frameId = optionalString(message, "frameId", "frame_id");
+  const distortionModel = optionalString(
+    message,
+    "distortionModel",
+    "distortion_model",
+  );
+  const messageTimestamp = timestampNs(optionalRecord(message, "timestamp"));
+
+  if (!Number.isInteger(width) || width <= 0) {
+    throw new Error(`Invalid camera calibration width ${width}`);
+  }
+  if (!Number.isInteger(height) || height <= 0) {
+    throw new Error(`Invalid camera calibration height ${height}`);
+  }
+
+  const K = numberArray(message, "K");
+  if (K.length !== INTRINSIC_MATRIX_LENGTH) {
+    throw new Error(
+      `Camera calibration K must have ${INTRINSIC_MATRIX_LENGTH} values, got ${K.length}`,
+    );
+  }
+  const R = matrixOrUndefined(message, "R", RECTIFICATION_MATRIX_LENGTH);
+  const P = matrixOrUndefined(message, "P", PROJECTION_MATRIX_LENGTH);
+  const D = numberArray(message, "D");
+
+  const attributes: Record<string, DecodedAttributeValue> = {
+    height,
+    width,
+  };
+  if (frameId) {
+    attributes.frameId = frameId;
+  }
+  if (distortionModel) {
+    attributes.distortionModel = distortionModel;
+  }
+
+  const visualization: CameraCalibrationVisualization = {
+    ...(frameId ? { coordinateFrameId: frameId } : {}),
+    ...(D.length > 0 ? { D } : {}),
+    ...(distortionModel ? { distortionModel } : {}),
+    height,
+    K,
+    kind: VISUALIZATION_KIND.CAMERA_CALIBRATION,
+    ...(P ? { P } : {}),
+    ...(R ? { R } : {}),
+    ...(messageTimestamp !== undefined
+      ? { timestampNs: messageTimestamp }
+      : {}),
+    width,
+  };
+
+  return {
+    attributes,
+    timing: timingFromContext(context, messageTimestamp),
+    visualization,
+  };
+}
 
 function matrixOrUndefined(
   record: Record<string, unknown>,

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/compressed-image.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/compressed-image.ts
@@ -1,11 +1,17 @@
 import {
   resourceHintsForArrayBufferViews,
+  type DecodeContext,
   type DecodedAttributeValue,
+  type DecodedOutput,
   type Decoder,
 } from "../../../../decoders";
 import { VISUALIZATION_KIND } from "../../../../visualization";
+import { rosDecodersForPayloads } from "../ros/factory";
 import { decodeProtobufMessage } from "./protobuf";
-import { FOXGLOVE_COMPRESSED_IMAGE_PAYLOAD } from "./protobuf/payloads";
+import {
+  FOXGLOVE_COMPRESSED_IMAGE_CDR_PAYLOADS,
+  FOXGLOVE_COMPRESSED_IMAGE_PAYLOAD,
+} from "./payloads";
 import {
   optionalRecord,
   optionalString,
@@ -32,43 +38,59 @@ export const foxgloveCompressedImageDecoder: Decoder = {
       FOXGLOVE_COMPRESSED_IMAGE_PAYLOAD,
       context,
     );
-    const data = requiredBytes(message, "data");
-    const format = optionalString(message, "format") ?? "unknown";
-    const frameId = optionalString(message, "frameId", "frame_id");
-    const messageTimestamp = timestampNs(optionalRecord(message, "timestamp"));
-    const attributes: Record<string, DecodedAttributeValue> = {
-      byteLength: data.byteLength,
-      format,
-    };
-    const mimeType = mimeTypeFromFormat(format);
-    const unsupportedReason =
-      mimeType === null ? unsupportedImageReason(format) : undefined;
+    return decodeFoxgloveCompressedImageRecord(message, context);
+  },
+};
 
-    if (frameId) {
-      attributes.frameId = frameId;
-    }
+/**
+ * Decoders for Foxglove CompressedImage messages carried over ROS 2 CDR.
+ */
+export const foxgloveCompressedImageCdrDecoders = rosDecodersForPayloads({
+  id: "foxglove.compressed-image.cdr",
+  map: decodeFoxgloveCompressedImageRecord,
+  payloads: FOXGLOVE_COMPRESSED_IMAGE_CDR_PAYLOADS,
+});
 
-    if (unsupportedReason) {
-      attributes.unsupportedReason = unsupportedReason;
-      return {
-        attributes,
-        resourceHints: resourceHintsForArrayBufferViews(data),
-        timing: timingFromContext(context, messageTimestamp),
-      };
-    }
+export function decodeFoxgloveCompressedImageRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+): DecodedOutput {
+  const data = requiredBytes(message, "data");
+  const format = optionalString(message, "format") ?? "unknown";
+  const frameId = optionalString(message, "frameId", "frame_id");
+  const messageTimestamp = timestampNs(optionalRecord(message, "timestamp"));
+  const attributes: Record<string, DecodedAttributeValue> = {
+    byteLength: data.byteLength,
+    format,
+  };
+  const mimeType = mimeTypeFromFormat(format);
+  const unsupportedReason =
+    mimeType === null ? unsupportedImageReason(format) : undefined;
 
+  if (frameId) {
+    attributes.frameId = frameId;
+  }
+
+  if (unsupportedReason) {
+    attributes.unsupportedReason = unsupportedReason;
     return {
       attributes,
       resourceHints: resourceHintsForArrayBufferViews(data),
       timing: timingFromContext(context, messageTimestamp),
-      visualization: {
-        bytes: data,
-        kind: VISUALIZATION_KIND.ENCODED_IMAGE,
-        mimeType: mimeType ?? undefined,
-      },
     };
-  },
-};
+  }
+
+  return {
+    attributes,
+    resourceHints: resourceHintsForArrayBufferViews(data),
+    timing: timingFromContext(context, messageTimestamp),
+    visualization: {
+      bytes: data,
+      kind: VISUALIZATION_KIND.ENCODED_IMAGE,
+      mimeType: mimeType ?? undefined,
+    },
+  };
+}
 
 function mimeTypeFromFormat(format: string): string | null | undefined {
   const lowerFormat = format.trim().toLowerCase();

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/grid.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/grid.ts
@@ -1,14 +1,17 @@
 import type {
+  DecodeContext,
   DecodedAttributeValue,
+  DecodedOutput,
   Decoder,
   GridField,
   GridVisualization,
 } from "../../../../decoders";
 import { resourceHintsForArrayBufferViews } from "../../../../decoders";
 import { VISUALIZATION_KIND } from "../../../../visualization";
+import { rosDecodersForPayloads } from "../ros/factory";
 import { decodeProtobufMessage } from "./protobuf";
 import { decodePose } from "./protobuf/geometry";
-import { FOXGLOVE_GRID_PAYLOAD } from "./protobuf/payloads";
+import { FOXGLOVE_GRID_CDR_PAYLOADS, FOXGLOVE_GRID_PAYLOAD } from "./payloads";
 import {
   asRecord,
   numberField,
@@ -56,68 +59,84 @@ export const foxgloveGridDecoder: Decoder = {
       FOXGLOVE_GRID_PAYLOAD,
       context,
     );
-    const data = requiredBytes(message, "data");
-    const cellSize = decodeCellSize(
-      optionalRecord(message, "cellSize", "cell_size"),
-    );
-    const cellStride = requiredNumber(message, "cellStride", "cell_stride");
-    const columnCount = requiredNumber(message, "columnCount", "column_count");
-    const rowStride = requiredNumber(message, "rowStride", "row_stride");
-    const fields = gridFields(requiredArray(message, "fields"));
-    const frameId = optionalString(message, "frameId", "frame_id");
-    const messageTimestamp = timestampNs(optionalRecord(message, "timestamp"));
-    const pose = decodePose(optionalRecord(message, "pose"));
-
-    validateGridLayout({ cellStride, columnCount, rowStride });
-    const rowCount = deriveRowCount(data, rowStride);
-    const { colorMode, rgba } = extractGridRgba({
-      cellStride,
-      columnCount,
-      data,
-      fields,
-      rowCount,
-      rowStride,
-    });
-
-    const fieldMetadata = fields.map((field) => ({
-      name: field.name,
-      offset: field.offset,
-      type: field.type,
-    }));
-    const attributes: Record<string, DecodedAttributeValue> = {
-      cellSize: [cellSize[0], cellSize[1]],
-      cellStride,
-      colorMode,
-      columnCount,
-      fields: fieldMetadata,
-      rowCount,
-      rowStride,
-    };
-    if (frameId) {
-      attributes.frameId = frameId;
-    }
-
-    const visualization: GridVisualization = {
-      ...(frameId ? { coordinateFrameId: frameId } : {}),
-      cellSize,
-      columnCount,
-      kind: VISUALIZATION_KIND.GRID,
-      pose,
-      rgba,
-      rowCount,
-      ...(messageTimestamp !== undefined
-        ? { timestampNs: messageTimestamp }
-        : {}),
-    };
-
-    return {
-      attributes,
-      resourceHints: resourceHintsForArrayBufferViews(rgba),
-      timing: timingFromContext(context, messageTimestamp),
-      visualization,
-    };
+    return decodeFoxgloveGridRecord(message, context);
   },
 };
+
+/**
+ * Decoders for Foxglove Grid messages carried over ROS 2 CDR.
+ */
+export const foxgloveGridCdrDecoders = rosDecodersForPayloads({
+  id: "foxglove.grid.cdr",
+  map: decodeFoxgloveGridRecord,
+  payloads: FOXGLOVE_GRID_CDR_PAYLOADS,
+});
+
+export function decodeFoxgloveGridRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+): DecodedOutput {
+  const data = requiredBytes(message, "data");
+  const cellSize = decodeCellSize(
+    optionalRecord(message, "cellSize", "cell_size"),
+  );
+  const cellStride = requiredNumber(message, "cellStride", "cell_stride");
+  const columnCount = requiredNumber(message, "columnCount", "column_count");
+  const rowStride = requiredNumber(message, "rowStride", "row_stride");
+  const fields = gridFields(requiredArray(message, "fields"));
+  const frameId = optionalString(message, "frameId", "frame_id");
+  const messageTimestamp = timestampNs(optionalRecord(message, "timestamp"));
+  const pose = decodePose(optionalRecord(message, "pose"));
+
+  validateGridLayout({ cellStride, columnCount, rowStride });
+  const rowCount = deriveRowCount(data, rowStride);
+  const { colorMode, rgba } = extractGridRgba({
+    cellStride,
+    columnCount,
+    data,
+    fields,
+    rowCount,
+    rowStride,
+  });
+
+  const fieldMetadata = fields.map((field) => ({
+    name: field.name,
+    offset: field.offset,
+    type: field.type,
+  }));
+  const attributes: Record<string, DecodedAttributeValue> = {
+    cellSize: [cellSize[0], cellSize[1]],
+    cellStride,
+    colorMode,
+    columnCount,
+    fields: fieldMetadata,
+    rowCount,
+    rowStride,
+  };
+  if (frameId) {
+    attributes.frameId = frameId;
+  }
+
+  const visualization: GridVisualization = {
+    ...(frameId ? { coordinateFrameId: frameId } : {}),
+    cellSize,
+    columnCount,
+    kind: VISUALIZATION_KIND.GRID,
+    pose,
+    rgba,
+    rowCount,
+    ...(messageTimestamp !== undefined
+      ? { timestampNs: messageTimestamp }
+      : {}),
+  };
+
+  return {
+    attributes,
+    resourceHints: resourceHintsForArrayBufferViews(rgba),
+    timing: timingFromContext(context, messageTimestamp),
+    visualization,
+  };
+}
 
 function validateGridLayout({
   cellStride,

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/image-annotations.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/image-annotations.ts
@@ -1,5 +1,7 @@
 import {
+  type DecodeContext,
   type DecodedAttributeValue,
+  type DecodedOutput,
   type Decoder,
   type ImageAnnotationCircle,
   type ImageAnnotationPoints,
@@ -9,8 +11,12 @@ import {
   type RgbaColor,
 } from "../../../../decoders";
 import { VISUALIZATION_KIND } from "../../../../visualization";
+import { rosDecodersForPayloads } from "../ros/factory";
 import { decodeProtobufMessage } from "./protobuf";
-import { FOXGLOVE_IMAGE_ANNOTATIONS_PAYLOAD } from "./protobuf/payloads";
+import {
+  FOXGLOVE_IMAGE_ANNOTATIONS_CDR_PAYLOADS,
+  FOXGLOVE_IMAGE_ANNOTATIONS_PAYLOAD,
+} from "./payloads";
 import { asRecord, numberField, optionalRecord } from "./protobuf/records";
 import { timingFromContext, timestampNs } from "./protobuf/timing";
 
@@ -45,42 +51,58 @@ export const foxgloveImageAnnotationsDecoder: Decoder = {
       FOXGLOVE_IMAGE_ANNOTATIONS_PAYLOAD,
       context,
     );
-
-    const rawCircles = optionalArray(message, "circles");
-    const rawPoints = optionalArray(message, "points");
-    const rawTexts = optionalArray(message, "texts");
-
-    const circles = rawCircles.map(decodeCircle);
-    const points = rawPoints.map(decodePoints);
-    const texts = rawTexts.map(decodeText);
-
-    // Per Foxglove schema: top-level timestamp overrides individual annotation timestamps.
-    const topLevelTs = optionalRecord(message, "timestamp");
-    const messageTimestamp = topLevelTs
-      ? timestampNs(topLevelTs)
-      : firstAnnotationTimestamp(rawCircles, rawPoints, rawTexts);
-
-    const visualization: ImageAnnotationsVisualization = {
-      kind: VISUALIZATION_KIND.IMAGE_ANNOTATIONS,
-      circles,
-      points,
-      texts,
-    };
-
-    const attributes: Record<string, DecodedAttributeValue> = {
-      circleCount: circles.length,
-      pointGroupCount: points.length,
-      textCount: texts.length,
-    };
-
-    return {
-      attributes,
-      resourceHints: { sizeBytes: bytes.byteLength },
-      timing: timingFromContext(context, messageTimestamp),
-      visualization,
-    };
+    return decodeFoxgloveImageAnnotationsRecord(message, context, bytes);
   },
 };
+
+/**
+ * Decoders for Foxglove ImageAnnotations messages carried over ROS 2 CDR.
+ */
+export const foxgloveImageAnnotationsCdrDecoders = rosDecodersForPayloads({
+  id: "foxglove.image-annotations.cdr",
+  map: decodeFoxgloveImageAnnotationsRecord,
+  payloads: FOXGLOVE_IMAGE_ANNOTATIONS_CDR_PAYLOADS,
+});
+
+export function decodeFoxgloveImageAnnotationsRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+  bytes?: Uint8Array,
+): DecodedOutput {
+  const rawCircles = optionalArray(message, "circles");
+  const rawPoints = optionalArray(message, "points");
+  const rawTexts = optionalArray(message, "texts");
+
+  const circles = rawCircles.map(decodeCircle);
+  const points = rawPoints.map(decodePoints);
+  const texts = rawTexts.map(decodeText);
+
+  // Per Foxglove schema: top-level timestamp overrides individual annotation timestamps.
+  const topLevelTs = optionalRecord(message, "timestamp");
+  const messageTimestamp = topLevelTs
+    ? timestampNs(topLevelTs)
+    : firstAnnotationTimestamp(rawCircles, rawPoints, rawTexts);
+
+  const visualization: ImageAnnotationsVisualization = {
+    kind: VISUALIZATION_KIND.IMAGE_ANNOTATIONS,
+    circles,
+    points,
+    texts,
+  };
+
+  const attributes: Record<string, DecodedAttributeValue> = {
+    circleCount: circles.length,
+    pointGroupCount: points.length,
+    textCount: texts.length,
+  };
+
+  return {
+    attributes,
+    resourceHints: { sizeBytes: bytes?.byteLength ?? 0 },
+    timing: timingFromContext(context, messageTimestamp),
+    visualization,
+  };
+}
 
 function decodeCircle(value: unknown): ImageAnnotationCircle {
   const record = asRecord(value);

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/index.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/index.ts
@@ -1,27 +1,57 @@
 import type { Decoder } from "../../../../decoders";
-import { foxgloveCameraCalibrationDecoder } from "./camera-calibration";
-import { foxgloveCompressedImageDecoder } from "./compressed-image";
+import {
+  foxgloveCameraCalibrationCdrDecoders,
+  foxgloveCameraCalibrationDecoder,
+} from "./camera-calibration";
+import {
+  foxgloveCompressedImageCdrDecoders,
+  foxgloveCompressedImageDecoder,
+} from "./compressed-image";
 import {
   foxgloveCompressedVideoCdrDecoders,
   foxgloveCompressedVideoDecoder,
 } from "./compressed-video";
-import { foxgloveGridDecoder } from "./grid";
-import { foxgloveImageAnnotationsDecoder } from "./image-annotations";
-import { foxgloveLaserScanDecoder } from "./laser-scan";
-import { foxgloveLocationFixDecoder } from "./location-fix";
-import { foxglovePointCloudDecoder } from "./point-cloud";
-import { foxglovePoseInFrameDecoder } from "./pose-in-frame";
-import { foxgloveSceneUpdateDecoder } from "./scene-update";
+import { foxgloveGridCdrDecoders, foxgloveGridDecoder } from "./grid";
+import {
+  foxgloveImageAnnotationsCdrDecoders,
+  foxgloveImageAnnotationsDecoder,
+} from "./image-annotations";
+import {
+  foxgloveLaserScanCdrDecoders,
+  foxgloveLaserScanDecoder,
+} from "./laser-scan";
+import {
+  foxgloveLocationFixCdrDecoders,
+  foxgloveLocationFixDecoder,
+} from "./location-fix";
+import {
+  foxglovePointCloudCdrDecoders,
+  foxglovePointCloudDecoder,
+} from "./point-cloud";
+import {
+  foxglovePoseInFrameCdrDecoders,
+  foxglovePoseInFrameDecoder,
+} from "./pose-in-frame";
+import {
+  foxgloveSceneUpdateCdrDecoders,
+  foxgloveSceneUpdateDecoder,
+} from "./scene-update";
 
 /**
  * Foxglove camera calibration decoder export.
  */
-export { foxgloveCameraCalibrationDecoder } from "./camera-calibration";
+export {
+  foxgloveCameraCalibrationCdrDecoders,
+  foxgloveCameraCalibrationDecoder,
+} from "./camera-calibration";
 
 /**
  * Foxglove compressed image decoder export.
  */
-export { foxgloveCompressedImageDecoder } from "./compressed-image";
+export {
+  foxgloveCompressedImageCdrDecoders,
+  foxgloveCompressedImageDecoder,
+} from "./compressed-image";
 
 /**
  * Foxglove compressed video decoder export.
@@ -34,37 +64,55 @@ export {
 /**
  * Foxglove Grid decoder export.
  */
-export { foxgloveGridDecoder } from "./grid";
+export { foxgloveGridCdrDecoders, foxgloveGridDecoder } from "./grid";
 
 /**
  * Foxglove image annotations decoder export.
  */
-export { foxgloveImageAnnotationsDecoder } from "./image-annotations";
+export {
+  foxgloveImageAnnotationsCdrDecoders,
+  foxgloveImageAnnotationsDecoder,
+} from "./image-annotations";
 
 /**
  * Foxglove LaserScan decoder export.
  */
-export { foxgloveLaserScanDecoder } from "./laser-scan";
+export {
+  foxgloveLaserScanCdrDecoders,
+  foxgloveLaserScanDecoder,
+} from "./laser-scan";
 
 /**
  * Foxglove point cloud decoder export.
  */
-export { foxglovePointCloudDecoder } from "./point-cloud";
+export {
+  foxglovePointCloudCdrDecoders,
+  foxglovePointCloudDecoder,
+} from "./point-cloud";
 
 /**
  * Foxglove LocationFix decoder export.
  */
-export { foxgloveLocationFixDecoder } from "./location-fix";
+export {
+  foxgloveLocationFixCdrDecoders,
+  foxgloveLocationFixDecoder,
+} from "./location-fix";
 
 /**
  * Foxglove PoseInFrame decoder export.
  */
-export { foxglovePoseInFrameDecoder } from "./pose-in-frame";
+export {
+  foxglovePoseInFrameCdrDecoders,
+  foxglovePoseInFrameDecoder,
+} from "./pose-in-frame";
 
 /**
  * Foxglove SceneUpdate decoder export.
  */
-export { foxgloveSceneUpdateDecoder } from "./scene-update";
+export {
+  foxgloveSceneUpdateCdrDecoders,
+  foxgloveSceneUpdateDecoder,
+} from "./scene-update";
 
 /**
  * Foxglove payload descriptor exports.
@@ -76,14 +124,23 @@ export * from "./payloads";
  */
 export const foxgloveDecoders: readonly Decoder[] = [
   foxgloveCameraCalibrationDecoder,
+  ...foxgloveCameraCalibrationCdrDecoders,
   foxgloveCompressedImageDecoder,
+  ...foxgloveCompressedImageCdrDecoders,
   foxgloveCompressedVideoDecoder,
   ...foxgloveCompressedVideoCdrDecoders,
   foxgloveGridDecoder,
+  ...foxgloveGridCdrDecoders,
   foxgloveImageAnnotationsDecoder,
+  ...foxgloveImageAnnotationsCdrDecoders,
   foxgloveLaserScanDecoder,
+  ...foxgloveLaserScanCdrDecoders,
   foxgloveLocationFixDecoder,
+  ...foxgloveLocationFixCdrDecoders,
   foxglovePointCloudDecoder,
+  ...foxglovePointCloudCdrDecoders,
   foxglovePoseInFrameDecoder,
+  ...foxglovePoseInFrameCdrDecoders,
   foxgloveSceneUpdateDecoder,
+  ...foxgloveSceneUpdateCdrDecoders,
 ];

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/index.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/index.ts
@@ -24,6 +24,7 @@ import {
   foxgloveLocationFixCdrDecoders,
   foxgloveLocationFixDecoder,
 } from "./location-fix";
+import { foxgloveLogCdrDecoders, foxgloveLogDecoder } from "./log";
 import {
   foxglovePointCloudCdrDecoders,
   foxglovePointCloudDecoder,
@@ -99,6 +100,11 @@ export {
 } from "./location-fix";
 
 /**
+ * Foxglove Log decoder export.
+ */
+export { foxgloveLogCdrDecoders, foxgloveLogDecoder } from "./log";
+
+/**
  * Foxglove PoseInFrame decoder export.
  */
 export {
@@ -137,6 +143,8 @@ export const foxgloveDecoders: readonly Decoder[] = [
   ...foxgloveLaserScanCdrDecoders,
   foxgloveLocationFixDecoder,
   ...foxgloveLocationFixCdrDecoders,
+  foxgloveLogDecoder,
+  ...foxgloveLogCdrDecoders,
   foxglovePointCloudDecoder,
   ...foxglovePointCloudCdrDecoders,
   foxglovePoseInFrameDecoder,

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/laser-scan.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/laser-scan.ts
@@ -1,13 +1,22 @@
-import type { DecodedAttributeValue, Decoder } from "../../../../decoders";
+import type {
+  DecodeContext,
+  DecodedAttributeValue,
+  DecodedOutput,
+  Decoder,
+} from "../../../../decoders";
 import { resourceHintsForArrayBufferViews } from "../../../../decoders";
 import { VISUALIZATION_KIND } from "../../../../visualization";
+import { rosDecodersForPayloads } from "../ros/factory";
 import { decodeProtobufMessage } from "./protobuf";
 import {
   decodePose,
   normalizedQuaternion,
   type ProtobufPose3D,
 } from "./protobuf/geometry";
-import { FOXGLOVE_LASER_SCAN_PAYLOAD } from "./protobuf/payloads";
+import {
+  FOXGLOVE_LASER_SCAN_CDR_PAYLOADS,
+  FOXGLOVE_LASER_SCAN_PAYLOAD,
+} from "./payloads";
 import {
   numberField,
   optionalRecord,
@@ -42,62 +51,77 @@ export const foxgloveLaserScanDecoder: Decoder = {
       FOXGLOVE_LASER_SCAN_PAYLOAD,
       context,
     );
-    const frameId = optionalString(message, "frameId", "frame_id");
-    const messageTimestamp = timestampNs(optionalRecord(message, "timestamp"));
-    const startAngle = numberField(message, "startAngle", "start_angle");
-    const endAngle = numberField(message, "endAngle", "end_angle");
-    const ranges = numberArrayField(message, "ranges");
-    const intensities = numberArrayField(message, "intensities");
-    const pose = decodePose(optionalRecord(message, "pose"));
-    const decoded = scanToPoints({
-      endAngle,
-      // Intensities are per-range by schema; a mismatched array is
-      // untrustworthy, so it is dropped rather than misaligned.
-      intensities:
-        intensities.length === ranges.length ? intensities : undefined,
-      pose,
-      ranges,
-      startAngle,
-    });
-    const pointCount =
-      decoded.positions.length / LASER_SCAN_POINT_COMPONENT_COUNT;
-
-    const attributes: Record<string, DecodedAttributeValue> = {
-      endAngle,
-      pointCount,
-      rangeCount: ranges.length,
-      startAngle,
-    };
-    if (frameId) {
-      attributes.frameId = frameId;
-    }
-
-    const transferableViews = [
-      decoded.positions,
-      ...(decoded.intensities ? [decoded.intensities] : []),
-    ];
-
-    return {
-      attributes,
-      resourceHints: resourceHintsForArrayBufferViews(...transferableViews),
-      timing: timingFromContext(context, messageTimestamp),
-      visualization: {
-        ...(frameId ? { coordinateFrameId: frameId } : {}),
-        fields: [],
-        kind: VISUALIZATION_KIND.POINT_CLOUD,
-        pointCount,
-        positions: decoded.positions,
-        ...(decoded.intensities
-          ? {
-              scalarFields: [
-                { name: INTENSITY_FIELD_NAME, values: decoded.intensities },
-              ],
-            }
-          : {}),
-      },
-    };
+    return decodeFoxgloveLaserScanRecord(message, context);
   },
 };
+
+/**
+ * Decoders for Foxglove LaserScan messages carried over ROS 2 CDR.
+ */
+export const foxgloveLaserScanCdrDecoders = rosDecodersForPayloads({
+  id: "foxglove.laser-scan.cdr",
+  map: decodeFoxgloveLaserScanRecord,
+  payloads: FOXGLOVE_LASER_SCAN_CDR_PAYLOADS,
+});
+
+export function decodeFoxgloveLaserScanRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+): DecodedOutput {
+  const frameId = optionalString(message, "frameId", "frame_id");
+  const messageTimestamp = timestampNs(optionalRecord(message, "timestamp"));
+  const startAngle = numberField(message, "startAngle", "start_angle");
+  const endAngle = numberField(message, "endAngle", "end_angle");
+  const ranges = numberArrayField(message, "ranges");
+  const intensities = numberArrayField(message, "intensities");
+  const pose = decodePose(optionalRecord(message, "pose"));
+  const decoded = scanToPoints({
+    endAngle,
+    // Intensities are per-range by schema; a mismatched array is
+    // untrustworthy, so it is dropped rather than misaligned.
+    intensities: intensities.length === ranges.length ? intensities : undefined,
+    pose,
+    ranges,
+    startAngle,
+  });
+  const pointCount =
+    decoded.positions.length / LASER_SCAN_POINT_COMPONENT_COUNT;
+
+  const attributes: Record<string, DecodedAttributeValue> = {
+    endAngle,
+    pointCount,
+    rangeCount: ranges.length,
+    startAngle,
+  };
+  if (frameId) {
+    attributes.frameId = frameId;
+  }
+
+  const transferableViews = [
+    decoded.positions,
+    ...(decoded.intensities ? [decoded.intensities] : []),
+  ];
+
+  return {
+    attributes,
+    resourceHints: resourceHintsForArrayBufferViews(...transferableViews),
+    timing: timingFromContext(context, messageTimestamp),
+    visualization: {
+      ...(frameId ? { coordinateFrameId: frameId } : {}),
+      fields: [],
+      kind: VISUALIZATION_KIND.POINT_CLOUD,
+      pointCount,
+      positions: decoded.positions,
+      ...(decoded.intensities
+        ? {
+            scalarFields: [
+              { name: INTENSITY_FIELD_NAME, values: decoded.intensities },
+            ],
+          }
+        : {}),
+    },
+  };
+}
 
 /**
  * Cartesian points produced from a polar laser scan.

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/location-fix.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/location-fix.ts
@@ -1,11 +1,17 @@
 import type {
+  DecodeContext,
   DecodedAttributeValue,
+  DecodedOutput,
   Decoder,
   LocationVisualization,
 } from "../../../../decoders";
 import { VISUALIZATION_KIND } from "../../../../visualization";
+import { rosDecodersForPayloads } from "../ros/factory";
 import { decodeProtobufMessage } from "./protobuf";
-import { FOXGLOVE_LOCATION_FIX_PAYLOAD } from "./protobuf/payloads";
+import {
+  FOXGLOVE_LOCATION_FIX_CDR_PAYLOADS,
+  FOXGLOVE_LOCATION_FIX_PAYLOAD,
+} from "./payloads";
 import {
   numberField,
   optionalRecord,
@@ -30,46 +36,62 @@ export const foxgloveLocationFixDecoder: Decoder = {
       FOXGLOVE_LOCATION_FIX_PAYLOAD,
       context,
     );
-    const latitude = numberField(message, "latitude");
-    const longitude = numberField(message, "longitude");
-    if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
-      throw new Error("Location fix has no finite latitude/longitude");
-    }
-
-    const altitude = numberField(message, "altitude");
-    const frameId = optionalString(message, "frameId", "frame_id");
-    const messageTimestamp = timestampNs(optionalRecord(message, "timestamp"));
-    const positionCovariance = covariance(
-      message["positionCovariance"] ?? message["position_covariance"],
-    );
-
-    const attributes: Record<string, DecodedAttributeValue> = {
-      latitude,
-      longitude,
-    };
-    if (frameId) {
-      attributes.frameId = frameId;
-    }
-
-    const visualization: LocationVisualization = {
-      ...(altitude !== 0 ? { altitude } : {}),
-      ...(frameId ? { coordinateFrameId: frameId } : {}),
-      kind: VISUALIZATION_KIND.LOCATION,
-      latitude,
-      longitude,
-      ...(positionCovariance ? { positionCovariance } : {}),
-      ...(messageTimestamp !== undefined
-        ? { timestampNs: messageTimestamp }
-        : {}),
-    };
-
-    return {
-      attributes,
-      timing: timingFromContext(context, messageTimestamp),
-      visualization,
-    };
+    return decodeFoxgloveLocationFixRecord(message, context);
   },
 };
+
+/**
+ * Decoders for Foxglove LocationFix messages carried over ROS 2 CDR.
+ */
+export const foxgloveLocationFixCdrDecoders = rosDecodersForPayloads({
+  id: "foxglove.location-fix.cdr",
+  map: decodeFoxgloveLocationFixRecord,
+  payloads: FOXGLOVE_LOCATION_FIX_CDR_PAYLOADS,
+});
+
+export function decodeFoxgloveLocationFixRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+): DecodedOutput {
+  const latitude = numberField(message, "latitude");
+  const longitude = numberField(message, "longitude");
+  if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
+    throw new Error("Location fix has no finite latitude/longitude");
+  }
+
+  const altitude = numberField(message, "altitude");
+  const frameId = optionalString(message, "frameId", "frame_id");
+  const messageTimestamp = timestampNs(optionalRecord(message, "timestamp"));
+  const positionCovariance = covariance(
+    message["positionCovariance"] ?? message["position_covariance"],
+  );
+
+  const attributes: Record<string, DecodedAttributeValue> = {
+    latitude,
+    longitude,
+  };
+  if (frameId) {
+    attributes.frameId = frameId;
+  }
+
+  const visualization: LocationVisualization = {
+    ...(altitude !== 0 ? { altitude } : {}),
+    ...(frameId ? { coordinateFrameId: frameId } : {}),
+    kind: VISUALIZATION_KIND.LOCATION,
+    latitude,
+    longitude,
+    ...(positionCovariance ? { positionCovariance } : {}),
+    ...(messageTimestamp !== undefined
+      ? { timestampNs: messageTimestamp }
+      : {}),
+  };
+
+  return {
+    attributes,
+    timing: timingFromContext(context, messageTimestamp),
+    visualization,
+  };
+}
 
 function covariance(value: unknown): readonly number[] | undefined {
   if (!Array.isArray(value) || value.length !== COVARIANCE_LENGTH) {

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/location-fix.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/location-fix.ts
@@ -53,8 +53,8 @@ export function decodeFoxgloveLocationFixRecord(
   message: Record<string, unknown>,
   context: DecodeContext,
 ): DecodedOutput {
-  const latitude = numberField(message, "latitude");
-  const longitude = numberField(message, "longitude");
+  const latitude = numberField(message, "latitude", undefined, Number.NaN);
+  const longitude = numberField(message, "longitude", undefined, Number.NaN);
   if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
     throw new Error("Location fix has no finite latitude/longitude");
   }

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/location-fix.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/location-fix.ts
@@ -59,7 +59,11 @@ export function decodeFoxgloveLocationFixRecord(
     throw new Error("Location fix has no finite latitude/longitude");
   }
 
-  const altitude = numberField(message, "altitude");
+  const hasAltitude =
+    message.altitude !== undefined && message.altitude !== null;
+  const altitude = hasAltitude
+    ? numberField(message, "altitude", undefined, Number.NaN)
+    : undefined;
   const frameId = optionalString(message, "frameId", "frame_id");
   const messageTimestamp = timestampNs(optionalRecord(message, "timestamp"));
   const positionCovariance = covariance(
@@ -75,7 +79,9 @@ export function decodeFoxgloveLocationFixRecord(
   }
 
   const visualization: LocationVisualization = {
-    ...(altitude !== 0 ? { altitude } : {}),
+    ...(altitude !== undefined && Number.isFinite(altitude)
+      ? { altitude }
+      : {}),
     ...(frameId ? { coordinateFrameId: frameId } : {}),
     kind: VISUALIZATION_KIND.LOCATION,
     latitude,

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/log.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/log.ts
@@ -69,9 +69,10 @@ export function decodeFoxgloveLogRecord(
 function logOutputAttributes(
   row: McapDecodedLogRow,
 ): Record<string, DecodedAttributeValue> {
+  const rows = logRowsAttribute([row]);
   return {
-    ...logRowsAttribute([row])[0],
-    [MCAP_LOG_ATTRIBUTE_ROWS]: logRowsAttribute([row]),
+    ...rows[0],
+    [MCAP_LOG_ATTRIBUTE_ROWS]: rows,
   };
 }
 

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/log.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/log.ts
@@ -1,0 +1,101 @@
+import type {
+  DecodeContext,
+  DecodedAttributeValue,
+  DecodedOutput,
+  Decoder,
+} from "../../../../decoders";
+import {
+  MCAP_LOG_ATTRIBUTE_ROWS,
+  MCAP_LOG_LEVEL,
+  type McapDecodedLogRow,
+  logRowsAttribute,
+} from "../../log-records";
+import { rosDecodersForPayloads } from "../ros/factory";
+import { decodeProtobufMessage } from "./protobuf";
+import {
+  numberField,
+  optionalRecord,
+  optionalString,
+} from "./protobuf/records";
+import { timingFromContext, timestampNs } from "./protobuf/timing";
+import { FOXGLOVE_LOG_CDR_PAYLOADS, FOXGLOVE_LOG_PAYLOAD } from "./payloads";
+
+/**
+ * Decoder for Foxglove Log protobuf messages.
+ */
+export const foxgloveLogDecoder: Decoder = {
+  id: "foxglove.log",
+  payload: FOXGLOVE_LOG_PAYLOAD,
+  version: "1",
+
+  decode(bytes, context) {
+    const message = decodeProtobufMessage(bytes, FOXGLOVE_LOG_PAYLOAD, context);
+    return decodeFoxgloveLogRecord(message, context);
+  },
+};
+
+/**
+ * Decoders for Foxglove Log messages carried over ROS 2 CDR.
+ */
+export const foxgloveLogCdrDecoders = rosDecodersForPayloads({
+  id: "foxglove.log.cdr",
+  map: decodeFoxgloveLogRecord,
+  payloads: FOXGLOVE_LOG_CDR_PAYLOADS,
+});
+
+export function decodeFoxgloveLogRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+): DecodedOutput {
+  const messageTimestamp = timestampNs(optionalRecord(message, "timestamp"));
+  const levelNumber = numberField(message, "level");
+  const row: McapDecodedLogRow = {
+    file: optionalString(message, "file"),
+    kind: "log",
+    level: foxgloveLogLevel(levelNumber),
+    levelNumber,
+    line: positiveNumberField(message, "line"),
+    message: optionalString(message, "message") ?? "",
+    name: optionalString(message, "name"),
+    timestampNs: messageTimestamp,
+  };
+
+  return {
+    attributes: logOutputAttributes(row),
+    timing: timingFromContext(context, messageTimestamp),
+  };
+}
+
+function logOutputAttributes(
+  row: McapDecodedLogRow,
+): Record<string, DecodedAttributeValue> {
+  return {
+    ...logRowsAttribute([row])[0],
+    [MCAP_LOG_ATTRIBUTE_ROWS]: logRowsAttribute([row]),
+  };
+}
+
+function foxgloveLogLevel(level: number) {
+  switch (level) {
+    case 1:
+      return MCAP_LOG_LEVEL.DEBUG;
+    case 2:
+      return MCAP_LOG_LEVEL.INFO;
+    case 3:
+      return MCAP_LOG_LEVEL.WARN;
+    case 4:
+      return MCAP_LOG_LEVEL.ERROR;
+    case 5:
+      return MCAP_LOG_LEVEL.FATAL;
+    default:
+      return MCAP_LOG_LEVEL.UNKNOWN;
+  }
+}
+
+function positiveNumberField(
+  record: Record<string, unknown>,
+  field: string,
+): number | undefined {
+  const value = numberField(record, field, undefined, Number.NaN);
+  return Number.isFinite(value) && value > 0 ? value : undefined;
+}

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/payloads.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/payloads.ts
@@ -2,20 +2,97 @@ import type { PayloadDescriptor } from "../../../../decoders";
 
 export * from "./protobuf/payloads";
 
+function foxgloveCdrPayloads(schema: string): readonly PayloadDescriptor[] {
+  return [
+    {
+      encoding: "cdr",
+      schema: `foxglove_msgs/msg/${schema}`,
+      schemaEncoding: "ros2msg",
+    },
+    {
+      encoding: "cdr",
+      schema: `foxglove_msgs/msg/${schema}`,
+      schemaEncoding: "ros2idl",
+    },
+  ];
+}
+
+/**
+ * Payload identities for foxglove_msgs/msg/CameraCalibration messages carried
+ * over ROS 2 CDR encodings.
+ */
+export const FOXGLOVE_CAMERA_CALIBRATION_CDR_PAYLOADS =
+  foxgloveCdrPayloads("CameraCalibration");
+
+/**
+ * Payload identities for foxglove_msgs/msg/CompressedImage messages carried
+ * over ROS 2 CDR encodings.
+ */
+export const FOXGLOVE_COMPRESSED_IMAGE_CDR_PAYLOADS =
+  foxgloveCdrPayloads("CompressedImage");
+
 /**
  * Payload identities for foxglove_msgs/msg/CompressedVideo messages carried
  * over ROS 2 CDR encodings.
  */
 export const FOXGLOVE_COMPRESSED_VIDEO_CDR_PAYLOADS: readonly PayloadDescriptor[] =
-  [
-    {
-      encoding: "cdr",
-      schema: "foxglove_msgs/msg/CompressedVideo",
-      schemaEncoding: "ros2msg",
-    },
-    {
-      encoding: "cdr",
-      schema: "foxglove_msgs/msg/CompressedVideo",
-      schemaEncoding: "ros2idl",
-    },
-  ];
+  foxgloveCdrPayloads("CompressedVideo");
+
+/**
+ * Payload identities for foxglove_msgs/msg/Grid messages carried over ROS 2
+ * CDR encodings.
+ */
+export const FOXGLOVE_GRID_CDR_PAYLOADS = foxgloveCdrPayloads("Grid");
+
+/**
+ * Payload identities for foxglove_msgs/msg/ImageAnnotations messages carried
+ * over ROS 2 CDR encodings.
+ */
+export const FOXGLOVE_IMAGE_ANNOTATIONS_CDR_PAYLOADS =
+  foxgloveCdrPayloads("ImageAnnotations");
+
+/**
+ * Payload identities for foxglove_msgs/msg/LaserScan messages carried over
+ * ROS 2 CDR encodings.
+ */
+export const FOXGLOVE_LASER_SCAN_CDR_PAYLOADS =
+  foxgloveCdrPayloads("LaserScan");
+
+/**
+ * Payload identities for foxglove_msgs/msg/LocationFix messages carried over
+ * ROS 2 CDR encodings.
+ */
+export const FOXGLOVE_LOCATION_FIX_CDR_PAYLOADS =
+  foxgloveCdrPayloads("LocationFix");
+
+/**
+ * Payload identities for foxglove_msgs/msg/PointCloud messages carried over
+ * ROS 2 CDR encodings.
+ */
+export const FOXGLOVE_POINT_CLOUD_CDR_PAYLOADS =
+  foxgloveCdrPayloads("PointCloud");
+
+/**
+ * Payload identities for foxglove_msgs/msg/PoseInFrame messages carried over
+ * ROS 2 CDR encodings.
+ */
+export const FOXGLOVE_POSE_IN_FRAME_CDR_PAYLOADS =
+  foxgloveCdrPayloads("PoseInFrame");
+
+/**
+ * Payload identities for foxglove_msgs/msg/SceneUpdate messages carried over
+ * ROS 2 CDR encodings.
+ */
+export const FOXGLOVE_SCENE_UPDATE_CDR_PAYLOADS =
+  foxgloveCdrPayloads("SceneUpdate");
+
+/**
+ * Payload identities for foxglove_msgs/msg/FrameTransform(s) messages carried
+ * over ROS 2 CDR encodings. Frame transforms are discovered by the transform
+ * reader rather than the visual decoder registry, but stream classification
+ * and tests need the same canonical spellings.
+ */
+export const FOXGLOVE_FRAME_TRANSFORM_CDR_PAYLOADS =
+  foxgloveCdrPayloads("FrameTransform");
+export const FOXGLOVE_FRAME_TRANSFORMS_CDR_PAYLOADS =
+  foxgloveCdrPayloads("FrameTransforms");

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/payloads.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/payloads.ts
@@ -35,7 +35,7 @@ export const FOXGLOVE_COMPRESSED_IMAGE_CDR_PAYLOADS =
  * Payload identities for foxglove_msgs/msg/CompressedVideo messages carried
  * over ROS 2 CDR encodings.
  */
-export const FOXGLOVE_COMPRESSED_VIDEO_CDR_PAYLOADS: readonly PayloadDescriptor[] =
+export const FOXGLOVE_COMPRESSED_VIDEO_CDR_PAYLOADS =
   foxgloveCdrPayloads("CompressedVideo");
 
 /**

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/payloads.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/payloads.ts
@@ -66,6 +66,12 @@ export const FOXGLOVE_LOCATION_FIX_CDR_PAYLOADS =
   foxgloveCdrPayloads("LocationFix");
 
 /**
+ * Payload identities for foxglove_msgs/msg/Log messages carried over ROS 2
+ * CDR encodings.
+ */
+export const FOXGLOVE_LOG_CDR_PAYLOADS = foxgloveCdrPayloads("Log");
+
+/**
  * Payload identities for foxglove_msgs/msg/PointCloud messages carried over
  * ROS 2 CDR encodings.
  */

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/point-cloud.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/point-cloud.ts
@@ -1,18 +1,24 @@
 import type {
+  DecodeContext,
   DecodedAttributeValue,
+  DecodedOutput,
   Decoder,
   PointCloudField,
   PointCloudScalarField,
 } from "../../../../decoders";
 import { resourceHintsForArrayBufferViews } from "../../../../decoders";
 import { VISUALIZATION_KIND } from "../../../../visualization";
+import { rosDecodersForPayloads } from "../ros/factory";
 import { decodeProtobufMessage } from "./protobuf";
 import {
   decodePose,
   normalizedQuaternion,
   type ProtobufPose3D,
 } from "./protobuf/geometry";
-import { FOXGLOVE_POINT_CLOUD_PAYLOAD } from "./protobuf/payloads";
+import {
+  FOXGLOVE_POINT_CLOUD_CDR_PAYLOADS,
+  FOXGLOVE_POINT_CLOUD_PAYLOAD,
+} from "./payloads";
 import {
   asRecord,
   optionalRecord,
@@ -95,58 +101,74 @@ export const foxglovePointCloudDecoder: Decoder = {
       FOXGLOVE_POINT_CLOUD_PAYLOAD,
       context,
     );
-    const data = requiredBytes(message, "data");
-    const pointStride = requiredNumber(message, "pointStride", "point_stride");
-    const fields = packedFields(requiredArray(message, "fields"));
-    const decodedPoints = extractPointCloudData(data, pointStride, fields);
-    applyPose(
-      decodedPoints.positions,
-      decodePose(optionalRecord(message, "pose")),
-    );
-    // Per-message Foxglove frame_id carried by this point cloud payload. This
-    // is separate from the MCAP channel frame_id metadata fallback.
-    const frameId = optionalString(message, "frameId", "frame_id");
-    const messageTimestamp = timestampNs(optionalRecord(message, "timestamp"));
-    const pointCount = decodedPoints.positions.length / POINT_COMPONENT_COUNT;
-    const packedFieldMetadata = fields.map((field) => ({
-      name: field.name,
-      offset: field.offset,
-      type: field.type,
-    }));
-    const attributes: Record<string, DecodedAttributeValue> = {
-      fields: packedFieldMetadata,
-      pointCount,
-      pointStride,
-    };
-
-    if (frameId) {
-      attributes.frameId = frameId;
-    }
-
-    const transferableViews = [
-      decodedPoints.positions,
-      decodedPoints.colors,
-      ...decodedPoints.scalarFields.map((field) => field.values),
-    ].filter((view): view is Float32Array => view !== undefined);
-
-    return {
-      attributes,
-      resourceHints: resourceHintsForArrayBufferViews(...transferableViews),
-      timing: timingFromContext(context, messageTimestamp),
-      visualization: {
-        ...(frameId ? { coordinateFrameId: frameId } : {}),
-        ...(decodedPoints.colors ? { colors: decodedPoints.colors } : {}),
-        ...(decodedPoints.scalarFields.length
-          ? { scalarFields: decodedPoints.scalarFields }
-          : {}),
-        fields: packedFieldMetadata,
-        kind: VISUALIZATION_KIND.POINT_CLOUD,
-        pointCount,
-        positions: decodedPoints.positions,
-      },
-    };
+    return decodeFoxglovePointCloudRecord(message, context);
   },
 };
+
+/**
+ * Decoders for Foxglove PointCloud messages carried over ROS 2 CDR.
+ */
+export const foxglovePointCloudCdrDecoders = rosDecodersForPayloads({
+  id: "foxglove.point-cloud.cdr",
+  map: decodeFoxglovePointCloudRecord,
+  payloads: FOXGLOVE_POINT_CLOUD_CDR_PAYLOADS,
+});
+
+export function decodeFoxglovePointCloudRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+): DecodedOutput {
+  const data = requiredBytes(message, "data");
+  const pointStride = requiredNumber(message, "pointStride", "point_stride");
+  const fields = packedFields(requiredArray(message, "fields"));
+  const decodedPoints = extractPointCloudData(data, pointStride, fields);
+  applyPose(
+    decodedPoints.positions,
+    decodePose(optionalRecord(message, "pose")),
+  );
+  // Per-message Foxglove frame_id carried by this point cloud payload. This
+  // is separate from the MCAP channel frame_id metadata fallback.
+  const frameId = optionalString(message, "frameId", "frame_id");
+  const messageTimestamp = timestampNs(optionalRecord(message, "timestamp"));
+  const pointCount = decodedPoints.positions.length / POINT_COMPONENT_COUNT;
+  const packedFieldMetadata = fields.map((field) => ({
+    name: field.name,
+    offset: field.offset,
+    type: field.type,
+  }));
+  const attributes: Record<string, DecodedAttributeValue> = {
+    fields: packedFieldMetadata,
+    pointCount,
+    pointStride,
+  };
+
+  if (frameId) {
+    attributes.frameId = frameId;
+  }
+
+  const transferableViews = [
+    decodedPoints.positions,
+    decodedPoints.colors,
+    ...decodedPoints.scalarFields.map((field) => field.values),
+  ].filter((view): view is Float32Array => view !== undefined);
+
+  return {
+    attributes,
+    resourceHints: resourceHintsForArrayBufferViews(...transferableViews),
+    timing: timingFromContext(context, messageTimestamp),
+    visualization: {
+      ...(frameId ? { coordinateFrameId: frameId } : {}),
+      ...(decodedPoints.colors ? { colors: decodedPoints.colors } : {}),
+      ...(decodedPoints.scalarFields.length
+        ? { scalarFields: decodedPoints.scalarFields }
+        : {}),
+      fields: packedFieldMetadata,
+      kind: VISUALIZATION_KIND.POINT_CLOUD,
+      pointCount,
+      positions: decodedPoints.positions,
+    },
+  };
+}
 
 /**
  * Normalized point cloud buffers shared by Foxglove and ROS decoders.

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/pose-in-frame.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/pose-in-frame.ts
@@ -1,12 +1,18 @@
 import type {
+  DecodeContext,
   DecodedAttributeValue,
+  DecodedOutput,
   Decoder,
   PoseVisualization,
 } from "../../../../decoders";
 import { VISUALIZATION_KIND } from "../../../../visualization";
+import { rosDecodersForPayloads } from "../ros/factory";
 import { decodeProtobufMessage } from "./protobuf";
 import { decodeQuaternion, decodeVector3 } from "./protobuf/geometry";
-import { FOXGLOVE_POSE_IN_FRAME_PAYLOAD } from "./protobuf/payloads";
+import {
+  FOXGLOVE_POSE_IN_FRAME_CDR_PAYLOADS,
+  FOXGLOVE_POSE_IN_FRAME_PAYLOAD,
+} from "./payloads";
 import { optionalRecord, optionalString } from "./protobuf/records";
 import { timingFromContext, timestampNs } from "./protobuf/timing";
 
@@ -26,35 +32,51 @@ export const foxglovePoseInFrameDecoder: Decoder = {
       FOXGLOVE_POSE_IN_FRAME_PAYLOAD,
       context,
     );
-    const frameId = optionalString(message, "frameId", "frame_id");
-    const messageTimestamp = timestampNs(optionalRecord(message, "timestamp"));
-    const pose = optionalRecord(message, "pose");
-    const position = decodeVector3(pose && optionalRecord(pose, "position"));
-    const quaternion = decodeQuaternion(
-      pose && optionalRecord(pose, "orientation"),
-    );
-
-    const attributes: Record<string, DecodedAttributeValue> = {
-      position: [position[0], position[1], position[2]],
-    };
-    if (frameId) {
-      attributes.frameId = frameId;
-    }
-
-    const visualization: PoseVisualization = {
-      ...(frameId ? { coordinateFrameId: frameId } : {}),
-      kind: VISUALIZATION_KIND.POSE,
-      position,
-      quaternion,
-      ...(messageTimestamp !== undefined
-        ? { timestampNs: messageTimestamp }
-        : {}),
-    };
-
-    return {
-      attributes,
-      timing: timingFromContext(context, messageTimestamp),
-      visualization,
-    };
+    return decodeFoxglovePoseInFrameRecord(message, context);
   },
 };
+
+/**
+ * Decoders for Foxglove PoseInFrame messages carried over ROS 2 CDR.
+ */
+export const foxglovePoseInFrameCdrDecoders = rosDecodersForPayloads({
+  id: "foxglove.pose-in-frame.cdr",
+  map: decodeFoxglovePoseInFrameRecord,
+  payloads: FOXGLOVE_POSE_IN_FRAME_CDR_PAYLOADS,
+});
+
+export function decodeFoxglovePoseInFrameRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+): DecodedOutput {
+  const frameId = optionalString(message, "frameId", "frame_id");
+  const messageTimestamp = timestampNs(optionalRecord(message, "timestamp"));
+  const pose = optionalRecord(message, "pose");
+  const position = decodeVector3(pose && optionalRecord(pose, "position"));
+  const quaternion = decodeQuaternion(
+    pose && optionalRecord(pose, "orientation"),
+  );
+
+  const attributes: Record<string, DecodedAttributeValue> = {
+    position: [position[0], position[1], position[2]],
+  };
+  if (frameId) {
+    attributes.frameId = frameId;
+  }
+
+  const visualization: PoseVisualization = {
+    ...(frameId ? { coordinateFrameId: frameId } : {}),
+    kind: VISUALIZATION_KIND.POSE,
+    position,
+    quaternion,
+    ...(messageTimestamp !== undefined
+      ? { timestampNs: messageTimestamp }
+      : {}),
+  };
+
+  return {
+    attributes,
+    timing: timingFromContext(context, messageTimestamp),
+    visualization,
+  };
+}

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/protobuf/payloads.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/protobuf/payloads.ts
@@ -101,3 +101,18 @@ export const FOXGLOVE_LOG_PAYLOAD: PayloadDescriptor = {
   schema: "foxglove.Log",
   schemaEncoding: "protobuf",
 };
+
+/**
+ * Payload identities for Foxglove frame transform protobuf messages.
+ */
+export const FOXGLOVE_FRAME_TRANSFORM_PAYLOAD: PayloadDescriptor = {
+  encoding: "protobuf",
+  schema: "foxglove.FrameTransform",
+  schemaEncoding: "protobuf",
+};
+
+export const FOXGLOVE_FRAME_TRANSFORMS_PAYLOAD: PayloadDescriptor = {
+  encoding: "protobuf",
+  schema: "foxglove.FrameTransforms",
+  schemaEncoding: "protobuf",
+};

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/protobuf/payloads.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/protobuf/payloads.ts
@@ -92,3 +92,12 @@ export const FOXGLOVE_LOCATION_FIX_PAYLOAD: PayloadDescriptor = {
   schema: "foxglove.LocationFix",
   schemaEncoding: "protobuf",
 };
+
+/**
+ * Payload identity for foxglove.Log messages.
+ */
+export const FOXGLOVE_LOG_PAYLOAD: PayloadDescriptor = {
+  encoding: "protobuf",
+  schema: "foxglove.Log",
+  schemaEncoding: "protobuf",
+};

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/protobuf/timing.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/protobuf/timing.ts
@@ -49,15 +49,22 @@ export function timingFromContext(
 }
 
 /**
- * Convert a protobuf Timestamp-like record into nanoseconds.
+ * Convert a protobuf Timestamp or ROS 2 Time-like record into nanoseconds.
  */
 export function timestampNs(timestamp: Record<string, unknown> | undefined) {
   if (!timestamp) {
     return undefined;
   }
 
-  const seconds = optionalBigInt(timestamp, "seconds") ?? 0n;
-  const nanos = optionalBigInt(timestamp, "nanos") ?? 0n;
+  const seconds =
+    optionalBigInt(timestamp, "seconds") ??
+    optionalBigInt(timestamp, "sec") ??
+    0n;
+  const nanos =
+    optionalBigInt(timestamp, "nanos") ??
+    optionalBigInt(timestamp, "nanosec") ??
+    optionalBigInt(timestamp, "nsec") ??
+    0n;
 
   return seconds * NANOSECONDS_PER_SECOND + nanos;
 }

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/scene-update.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/scene-update.ts
@@ -1,5 +1,7 @@
 import {
+  type DecodeContext,
   type DecodedAttributeValue,
+  type DecodedOutput,
   type Decoder,
   type RgbaColor,
   resourceHintsForArrayBufferViews,
@@ -19,9 +21,13 @@ import {
   type SceneUpdateVisualization,
 } from "../../../../decoders";
 import { VISUALIZATION_KIND } from "../../../../visualization";
+import { rosDecodersForPayloads } from "../ros/factory";
 import { decodeProtobufMessage } from "./protobuf";
 import { decodePose, decodeVector3 } from "./protobuf/geometry";
-import { FOXGLOVE_SCENE_UPDATE_PAYLOAD } from "./protobuf/payloads";
+import {
+  FOXGLOVE_SCENE_UPDATE_CDR_PAYLOADS,
+  FOXGLOVE_SCENE_UPDATE_PAYLOAD,
+} from "./payloads";
 import { asRecord, numberField, optionalRecord } from "./protobuf/records";
 import { timingFromContext, timestampNs } from "./protobuf/timing";
 
@@ -62,44 +68,60 @@ export const foxgloveSceneUpdateDecoder: Decoder = {
       FOXGLOVE_SCENE_UPDATE_PAYLOAD,
       context,
     );
-
-    const rawDeletions = optionalArray(message, "deletions");
-    const rawEntities = optionalArray(message, "entities");
-    const deletions = rawDeletions.map(decodeDeletion);
-    const entities = rawEntities.map(decodeEntity);
-    const primitiveCounts = primitiveCountsForEntities(entities);
-    const modelDataHints = resourceHintsForArrayBufferViews(
-      ...modelDataViewsForEntities(entities),
-    );
-
-    const visualization: SceneUpdateVisualization = {
-      kind: VISUALIZATION_KIND.SCENE_UPDATE,
-      deletions,
-      entities,
-    };
-    const attributes: Record<string, DecodedAttributeValue> = {
-      deletionCount: deletions.length,
-      entityCount: entities.length,
-      ...primitiveCounts,
-      unsupportedPrimitiveCount: 0,
-    };
-
-    return {
-      attributes,
-      resourceHints: {
-        sizeBytes: bytes.byteLength + (modelDataHints.sizeBytes ?? 0),
-        ...(modelDataHints.transferables?.length
-          ? { transferables: modelDataHints.transferables }
-          : {}),
-      },
-      timing: timingFromContext(
-        context,
-        firstSceneUpdateTimestamp(entities, deletions),
-      ),
-      visualization,
-    };
+    return decodeFoxgloveSceneUpdateRecord(message, context, bytes);
   },
 };
+
+/**
+ * Decoders for Foxglove SceneUpdate messages carried over ROS 2 CDR.
+ */
+export const foxgloveSceneUpdateCdrDecoders = rosDecodersForPayloads({
+  id: "foxglove.scene-update.cdr",
+  map: decodeFoxgloveSceneUpdateRecord,
+  payloads: FOXGLOVE_SCENE_UPDATE_CDR_PAYLOADS,
+});
+
+export function decodeFoxgloveSceneUpdateRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+  bytes?: Uint8Array,
+): DecodedOutput {
+  const rawDeletions = optionalArray(message, "deletions");
+  const rawEntities = optionalArray(message, "entities");
+  const deletions = rawDeletions.map(decodeDeletion);
+  const entities = rawEntities.map(decodeEntity);
+  const primitiveCounts = primitiveCountsForEntities(entities);
+  const modelDataHints = resourceHintsForArrayBufferViews(
+    ...modelDataViewsForEntities(entities),
+  );
+
+  const visualization: SceneUpdateVisualization = {
+    kind: VISUALIZATION_KIND.SCENE_UPDATE,
+    deletions,
+    entities,
+  };
+  const attributes: Record<string, DecodedAttributeValue> = {
+    deletionCount: deletions.length,
+    entityCount: entities.length,
+    ...primitiveCounts,
+    unsupportedPrimitiveCount: 0,
+  };
+
+  return {
+    attributes,
+    resourceHints: {
+      sizeBytes: (bytes?.byteLength ?? 0) + (modelDataHints.sizeBytes ?? 0),
+      ...(modelDataHints.transferables?.length
+        ? { transferables: modelDataHints.transferables }
+        : {}),
+    },
+    timing: timingFromContext(
+      context,
+      firstSceneUpdateTimestamp(entities, deletions),
+    ),
+    visualization,
+  };
+}
 
 function decodeEntity(value: unknown): SceneEntityVisualization {
   const record = asRecord(value);

--- a/app/packages/multimodal/src/adapters/mcap/decoders/json/payloads.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/json/payloads.ts
@@ -114,6 +114,36 @@ export const JSON_ROS_NAV_SAT_FIX_PAYLOADS = jsonRosPayloads(
 );
 
 /**
+ * Payload descriptors for JSON-schema ROS rosgraph Log messages.
+ */
+export const JSON_ROS_ROSGRAPH_LOG_PAYLOADS: readonly PayloadDescriptor[] = [
+  {
+    encoding: "json",
+    schema: "rosgraph_msgs/Log",
+    schemaEncoding: "jsonschema",
+  },
+];
+
+/**
+ * Payload descriptors for JSON-schema ROS 2 rcl_interfaces Log messages.
+ */
+export const JSON_ROS_RCL_LOG_PAYLOADS: readonly PayloadDescriptor[] = [
+  {
+    encoding: "json",
+    schema: "rcl_interfaces/msg/Log",
+    schemaEncoding: "jsonschema",
+  },
+];
+
+/**
+ * Payload descriptors for JSON-schema ROS DiagnosticArray messages.
+ */
+export const JSON_ROS_DIAGNOSTIC_ARRAY_PAYLOADS = jsonRosPayloads(
+  "diagnostic_msgs/DiagnosticArray",
+  "diagnostic_msgs/msg/DiagnosticArray",
+);
+
+/**
  * Payload descriptors for JSON-schema ROS OccupancyGrid messages.
  */
 export const JSON_ROS_OCCUPANCY_GRID_PAYLOADS = jsonRosPayloads(

--- a/app/packages/multimodal/src/adapters/mcap/decoders/json/payloads.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/json/payloads.ts
@@ -104,3 +104,19 @@ export const JSON_ROS_OCCUPANCY_GRID_PAYLOADS = jsonRosPayloads(
   "nav_msgs/OccupancyGrid",
   "nav_msgs/msg/OccupancyGrid",
 );
+
+/**
+ * Payload descriptors for JSON-schema ROS visualization Marker messages.
+ */
+export const JSON_ROS_MARKER_PAYLOADS = jsonRosPayloads(
+  "visualization_msgs/Marker",
+  "visualization_msgs/msg/Marker",
+);
+
+/**
+ * Payload descriptors for JSON-schema ROS visualization MarkerArray messages.
+ */
+export const JSON_ROS_MARKER_ARRAY_PAYLOADS = jsonRosPayloads(
+  "visualization_msgs/MarkerArray",
+  "visualization_msgs/msg/MarkerArray",
+);

--- a/app/packages/multimodal/src/adapters/mcap/decoders/json/payloads.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/json/payloads.ts
@@ -136,3 +136,19 @@ export const JSON_ROS_MARKER_ARRAY_PAYLOADS = jsonRosPayloads(
   "visualization_msgs/MarkerArray",
   "visualization_msgs/msg/MarkerArray",
 );
+
+/**
+ * Payload descriptors for JSON-schema ROS vision Detection2DArray messages.
+ */
+export const JSON_ROS_DETECTION_2D_ARRAY_PAYLOADS = jsonRosPayloads(
+  "vision_msgs/Detection2DArray",
+  "vision_msgs/msg/Detection2DArray",
+);
+
+/**
+ * Payload descriptors for JSON-schema ROS vision Detection3DArray messages.
+ */
+export const JSON_ROS_DETECTION_3D_ARRAY_PAYLOADS = jsonRosPayloads(
+  "vision_msgs/Detection3DArray",
+  "vision_msgs/msg/Detection3DArray",
+);

--- a/app/packages/multimodal/src/adapters/mcap/decoders/json/payloads.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/json/payloads.ts
@@ -82,11 +82,27 @@ export const JSON_ROS_POSE_STAMPED_PAYLOADS = jsonRosPayloads(
 );
 
 /**
+ * Payload descriptors for JSON-schema ROS PoseArray messages.
+ */
+export const JSON_ROS_POSE_ARRAY_PAYLOADS = jsonRosPayloads(
+  "geometry_msgs/PoseArray",
+  "geometry_msgs/msg/PoseArray",
+);
+
+/**
  * Payload descriptors for JSON-schema ROS Odometry messages.
  */
 export const JSON_ROS_ODOMETRY_PAYLOADS = jsonRosPayloads(
   "nav_msgs/Odometry",
   "nav_msgs/msg/Odometry",
+);
+
+/**
+ * Payload descriptors for JSON-schema ROS Path messages.
+ */
+export const JSON_ROS_PATH_PAYLOADS = jsonRosPayloads(
+  "nav_msgs/Path",
+  "nav_msgs/msg/Path",
 );
 
 /**

--- a/app/packages/multimodal/src/adapters/mcap/decoders/json/ros.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/json/ros.test.ts
@@ -14,6 +14,7 @@ import {
   isImageAnnotationsStream,
   isImageStream,
   isLocationFixStream,
+  isLogStream,
   isPointCloudStream,
   isPoseStream,
   isSceneUpdateStream,
@@ -24,6 +25,7 @@ import {
   JSON_ROS_COMPRESSED_IMAGE_PAYLOADS,
   JSON_ROS_DETECTION_2D_ARRAY_PAYLOADS,
   JSON_ROS_DETECTION_3D_ARRAY_PAYLOADS,
+  JSON_ROS_DIAGNOSTIC_ARRAY_PAYLOADS,
   JSON_ROS_IMAGE_PAYLOADS,
   JSON_ROS_LASER_SCAN_PAYLOADS,
   JSON_ROS_NAV_SAT_FIX_PAYLOADS,
@@ -33,10 +35,13 @@ import {
   JSON_ROS_POINT_CLOUD2_PAYLOADS,
   JSON_ROS_POSE_ARRAY_PAYLOADS,
   JSON_ROS_POSE_STAMPED_PAYLOADS,
+  JSON_ROS_RCL_LOG_PAYLOADS,
+  JSON_ROS_ROSGRAPH_LOG_PAYLOADS,
 } from "./payloads";
 import {
   jsonRosCameraInfoDecoders,
   jsonRosCompressedImageDecoders,
+  jsonRosDiagnosticArrayDecoders,
   jsonRosDetection2DArrayDecoders,
   jsonRosDetection3DArrayDecoders,
   jsonRosImageDecoders,
@@ -48,6 +53,8 @@ import {
   jsonRosPointCloud2Decoders,
   jsonRosPoseArrayDecoders,
   jsonRosPoseStampedDecoders,
+  jsonRosRclLogDecoders,
+  jsonRosRosgraphLogDecoders,
 } from "./ros";
 
 const TEXT_ENCODER = new TextEncoder();
@@ -81,6 +88,7 @@ describe("JSON-schema ROS MCAP decoders", () => {
       ...JSON_ROS_COMPRESSED_IMAGE_PAYLOADS,
       ...JSON_ROS_DETECTION_2D_ARRAY_PAYLOADS,
       ...JSON_ROS_DETECTION_3D_ARRAY_PAYLOADS,
+      ...JSON_ROS_DIAGNOSTIC_ARRAY_PAYLOADS,
       ...JSON_ROS_IMAGE_PAYLOADS,
       ...JSON_ROS_LASER_SCAN_PAYLOADS,
       ...JSON_ROS_NAV_SAT_FIX_PAYLOADS,
@@ -90,6 +98,8 @@ describe("JSON-schema ROS MCAP decoders", () => {
       ...JSON_ROS_POINT_CLOUD2_PAYLOADS,
       ...JSON_ROS_POSE_ARRAY_PAYLOADS,
       ...JSON_ROS_POSE_STAMPED_PAYLOADS,
+      ...JSON_ROS_RCL_LOG_PAYLOADS,
+      ...JSON_ROS_ROSGRAPH_LOG_PAYLOADS,
     ];
 
     for (const payload of payloads) {
@@ -211,6 +221,85 @@ describe("JSON-schema ROS MCAP decoders", () => {
       latitude: 37.77,
       longitude: -122.42,
     });
+  });
+
+  it("decodes JSON ROS logs and diagnostics into console rows", () => {
+    const rosgraph = decoderForSchema(
+      jsonRosRosgraphLogDecoders,
+      "rosgraph_msgs/Log",
+    ).decode(
+      jsonMessage({
+        file: "planner.cpp",
+        function: "tick",
+        header: headerRecord("rosout", 7, 8),
+        level: 8,
+        line: 42,
+        msg: "planner failed",
+        name: "planner",
+        topics: ["/plan"],
+      }),
+      {},
+    );
+    const rcl = decoderForSchema(
+      jsonRosRclLogDecoders,
+      "rcl_interfaces/msg/Log",
+    ).decode(
+      jsonMessage({
+        file: "controller.cpp",
+        function: "update",
+        level: 30,
+        line: 10,
+        msg: "tracking degraded",
+        name: "controller",
+        stamp: { nanosec: 4, sec: 5 },
+      }),
+      {},
+    );
+    const diagnostics = decoderForSchema(
+      jsonRosDiagnosticArrayDecoders,
+      "diagnostic_msgs/msg/DiagnosticArray",
+    ).decode(
+      jsonMessage({
+        header: headerRecord("base", 6, 9),
+        status: [
+          {
+            hardware_id: "lidar-top",
+            level: 2,
+            message: "packet drops",
+            name: "driver",
+            values: [{ key: "drop_rate", value: "0.2" }],
+          },
+        ],
+      }),
+      {},
+    );
+
+    expect(rosgraph.attributes?.logRows).toEqual([
+      expect.objectContaining({
+        level: "error",
+        message: "planner failed",
+        timestampNs: 7_000_000_008n,
+      }),
+    ]);
+    expect(rcl.attributes?.logRows).toEqual([
+      expect.objectContaining({
+        level: "warn",
+        levelNumber: 30,
+        message: "tracking degraded",
+        timestampNs: 5_000_000_004n,
+      }),
+    ]);
+    expect(diagnostics.attributes?.logRows).toEqual([
+      expect.objectContaining({
+        details: [{ key: "drop_rate", value: "0.2" }],
+        hardwareId: "lidar-top",
+        kind: "diagnostic",
+        level: "error",
+        message: "packet drops",
+        name: "driver",
+        status: "ERROR",
+      }),
+    ]);
   });
 
   it("decodes JSON CameraInfo records into calibration visualizations", () => {
@@ -577,6 +666,11 @@ describe("JSON-schema ROS MCAP decoders", () => {
       "/detections3d",
       JSON_ROS_DETECTION_3D_ARRAY_PAYLOADS[0],
     );
+    const logs = createTopic("/rosout", JSON_ROS_RCL_LOG_PAYLOADS[0]);
+    const diagnostics = createTopic(
+      "/diagnostics",
+      JSON_ROS_DIAGNOSTIC_ARRAY_PAYLOADS[1],
+    );
 
     expect(isCompressedImageStream(compressed)).toBe(true);
     expect(isCompressedImageStream(rawImage)).toBe(false);
@@ -607,6 +701,8 @@ describe("JSON-schema ROS MCAP decoders", () => {
     expect(isSceneUpdateStream(poseArray)).toBe(true);
     expect(isImageAnnotationsStream(detections2d)).toBe(true);
     expect(isSceneUpdateStream(detections3d)).toBe(true);
+    expect(isLogStream(logs)).toBe(true);
+    expect(isLogStream(diagnostics)).toBe(true);
     expect(
       streamTopics([
         compressed,
@@ -617,12 +713,22 @@ describe("JSON-schema ROS MCAP decoders", () => {
         poseArray,
         detections2d,
         detections3d,
+        logs,
+        diagnostics,
       ]),
     ).toMatchObject({
       annotations: ["/detections2d"],
       image: ["/camera/compressed", "/camera/image"],
+      logs: ["/rosout", "/diagnostics"],
       pointCloud: ["/points", "/scan"],
-      previewable: ["/camera/compressed", "/camera/image", "/points", "/scan"],
+      previewable: [
+        "/camera/compressed",
+        "/camera/image",
+        "/points",
+        "/scan",
+        "/rosout",
+        "/diagnostics",
+      ],
       sceneUpdates: ["/planned_path", "/pose_hypotheses", "/detections3d"],
     });
   });

--- a/app/packages/multimodal/src/adapters/mcap/decoders/json/ros.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/json/ros.test.ts
@@ -15,6 +15,7 @@ import {
   isLocationFixStream,
   isPointCloudStream,
   isPoseStream,
+  isSceneUpdateStream,
   streamTopics,
 } from "../../stream-topics";
 import {
@@ -25,7 +26,9 @@ import {
   JSON_ROS_NAV_SAT_FIX_PAYLOADS,
   JSON_ROS_OCCUPANCY_GRID_PAYLOADS,
   JSON_ROS_ODOMETRY_PAYLOADS,
+  JSON_ROS_PATH_PAYLOADS,
   JSON_ROS_POINT_CLOUD2_PAYLOADS,
+  JSON_ROS_POSE_ARRAY_PAYLOADS,
   JSON_ROS_POSE_STAMPED_PAYLOADS,
 } from "./payloads";
 import {
@@ -36,7 +39,9 @@ import {
   jsonRosNavSatFixDecoders,
   jsonRosOccupancyGridDecoders,
   jsonRosOdometryDecoders,
+  jsonRosPathDecoders,
   jsonRosPointCloud2Decoders,
+  jsonRosPoseArrayDecoders,
   jsonRosPoseStampedDecoders,
 } from "./ros";
 
@@ -74,7 +79,9 @@ describe("JSON-schema ROS MCAP decoders", () => {
       ...JSON_ROS_NAV_SAT_FIX_PAYLOADS,
       ...JSON_ROS_OCCUPANCY_GRID_PAYLOADS,
       ...JSON_ROS_ODOMETRY_PAYLOADS,
+      ...JSON_ROS_PATH_PAYLOADS,
       ...JSON_ROS_POINT_CLOUD2_PAYLOADS,
+      ...JSON_ROS_POSE_ARRAY_PAYLOADS,
       ...JSON_ROS_POSE_STAMPED_PAYLOADS,
     ];
 
@@ -381,6 +388,68 @@ describe("JSON-schema ROS MCAP decoders", () => {
     expect(odometry.attributes).toMatchObject({ childFrameId: "base_link" });
   });
 
+  it("decodes JSON Path and PoseArray records into scene-update overlays", () => {
+    const path = decoderForSchema(
+      jsonRosPathDecoders,
+      "nav_msgs/msg/Path",
+    ).decode(
+      jsonMessage({
+        header: headerRecord("map", 13, 14),
+        poses: [
+          {
+            header: headerRecord("map", 1, 1),
+            pose: poseRecord([1, 2, 0], [0, 0, 0, 1]),
+          },
+          {
+            header: headerRecord("map", 1, 2),
+            pose: poseRecord([3, 4, 0], [0, 0, 0, 1]),
+          },
+        ],
+      }),
+      { streamId: "/planned_path" },
+    );
+    const poseArray = decoderForSchema(
+      jsonRosPoseArrayDecoders,
+      "geometry_msgs/PoseArray",
+    ).decode(
+      jsonMessage({
+        header: headerRecord("map", 15, 16),
+        poses: [
+          poseRecord([5, 6, 0], [0, 0, 0, 1]),
+          poseRecord([7, 8, 0], [0, 0, 1, 0]),
+        ],
+      }),
+      { streamId: "/pose_hypotheses" },
+    );
+
+    expect(path.visualization?.kind).toBe(VISUALIZATION_KIND.SCENE_UPDATE);
+    expect(poseArray.visualization?.kind).toBe(VISUALIZATION_KIND.SCENE_UPDATE);
+    if (
+      path.visualization?.kind !== VISUALIZATION_KIND.SCENE_UPDATE ||
+      poseArray.visualization?.kind !== VISUALIZATION_KIND.SCENE_UPDATE
+    ) {
+      throw new Error("Expected scene update visualizations");
+    }
+    expect(path.visualization.entities[0]?.lines[0]?.points).toEqual([
+      [1, 2, 0],
+      [3, 4, 0],
+    ]);
+    expect(path.visualization.entities[0]).toMatchObject({
+      frameId: "map",
+      id: "/planned_path:path",
+      timestampNs: 13_000_000_014n,
+    });
+    expect(poseArray.visualization.entities[0]).toMatchObject({
+      arrowCount: 2,
+      frameId: "map",
+      id: "/pose_hypotheses:pose-array",
+      timestampNs: 15_000_000_016n,
+    });
+    expect(
+      poseArray.visualization.entities[0]?.arrows[0]?.pose.position,
+    ).toEqual([5, 6, 0]);
+  });
+
   it("degrades invalid JSON and malformed JSON records without throwing", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const decoder = decoderForSchema(
@@ -413,6 +482,11 @@ describe("JSON-schema ROS MCAP decoders", () => {
     const rawImage = createTopic("/camera/image", JSON_ROS_IMAGE_PAYLOADS[1]);
     const cloud = createTopic("/points", JSON_ROS_POINT_CLOUD2_PAYLOADS[0]);
     const scan = createTopic("/scan", JSON_ROS_LASER_SCAN_PAYLOADS[1]);
+    const path = createTopic("/planned_path", JSON_ROS_PATH_PAYLOADS[1]);
+    const poseArray = createTopic(
+      "/pose_hypotheses",
+      JSON_ROS_POSE_ARRAY_PAYLOADS[0],
+    );
 
     expect(isCompressedImageStream(compressed)).toBe(true);
     expect(isCompressedImageStream(rawImage)).toBe(false);
@@ -439,10 +513,15 @@ describe("JSON-schema ROS MCAP decoders", () => {
     expect(
       isGridStream(createTopic("/map", JSON_ROS_OCCUPANCY_GRID_PAYLOADS[1])),
     ).toBe(true);
-    expect(streamTopics([compressed, rawImage, cloud, scan])).toMatchObject({
+    expect(isSceneUpdateStream(path)).toBe(true);
+    expect(isSceneUpdateStream(poseArray)).toBe(true);
+    expect(
+      streamTopics([compressed, rawImage, cloud, scan, path, poseArray]),
+    ).toMatchObject({
       image: ["/camera/compressed", "/camera/image"],
       pointCloud: ["/points", "/scan"],
       previewable: ["/camera/compressed", "/camera/image", "/points", "/scan"],
+      sceneUpdates: ["/planned_path", "/pose_hypotheses"],
     });
   });
 });

--- a/app/packages/multimodal/src/adapters/mcap/decoders/json/ros.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/json/ros.test.ts
@@ -20,6 +20,7 @@ import {
   isSceneUpdateStream,
   streamTopics,
 } from "../../stream-topics";
+import { detection2DRecord, detection3DRecord } from "../ros.test-fixtures";
 import {
   JSON_ROS_CAMERA_INFO_PAYLOADS,
   JSON_ROS_COMPRESSED_IMAGE_PAYLOADS,
@@ -812,61 +813,6 @@ function vectorRecord(vector: readonly [number, number, number]) {
     x: vector[0],
     y: vector[1],
     z: vector[2],
-  };
-}
-
-function detection2DRecord({
-  classId,
-  id,
-  score,
-  x,
-  y,
-}: {
-  readonly classId: string;
-  readonly id: string;
-  readonly score: number;
-  readonly x: number;
-  readonly y: number;
-}) {
-  return {
-    bbox: {
-      center: {
-        position: { x, y },
-        theta: 0,
-      },
-      size_x: 20,
-      size_y: 20,
-    },
-    id,
-    results: [detectionResult(classId, score)],
-  };
-}
-
-function detection3DRecord({
-  classId,
-  id,
-  score,
-}: {
-  readonly classId: string;
-  readonly id: string;
-  readonly score: number;
-}) {
-  return {
-    bbox: {
-      center: poseRecord([1, 2, 3], [0, 0, 0, 1]),
-      size: vectorRecord([2, 1, 1.5]),
-    },
-    id,
-    results: [detectionResult(classId, score)],
-  };
-}
-
-function detectionResult(classId: string, score: number) {
-  return {
-    hypothesis: {
-      class_id: classId,
-      score,
-    },
   };
 }
 

--- a/app/packages/multimodal/src/adapters/mcap/decoders/json/ros.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/json/ros.test.ts
@@ -11,6 +11,7 @@ import {
   isCameraCalibrationStream,
   isCompressedImageStream,
   isGridStream,
+  isImageAnnotationsStream,
   isImageStream,
   isLocationFixStream,
   isPointCloudStream,
@@ -21,6 +22,8 @@ import {
 import {
   JSON_ROS_CAMERA_INFO_PAYLOADS,
   JSON_ROS_COMPRESSED_IMAGE_PAYLOADS,
+  JSON_ROS_DETECTION_2D_ARRAY_PAYLOADS,
+  JSON_ROS_DETECTION_3D_ARRAY_PAYLOADS,
   JSON_ROS_IMAGE_PAYLOADS,
   JSON_ROS_LASER_SCAN_PAYLOADS,
   JSON_ROS_NAV_SAT_FIX_PAYLOADS,
@@ -34,6 +37,8 @@ import {
 import {
   jsonRosCameraInfoDecoders,
   jsonRosCompressedImageDecoders,
+  jsonRosDetection2DArrayDecoders,
+  jsonRosDetection3DArrayDecoders,
   jsonRosImageDecoders,
   jsonRosLaserScanDecoders,
   jsonRosNavSatFixDecoders,
@@ -74,6 +79,8 @@ describe("JSON-schema ROS MCAP decoders", () => {
     const payloads = [
       ...JSON_ROS_CAMERA_INFO_PAYLOADS,
       ...JSON_ROS_COMPRESSED_IMAGE_PAYLOADS,
+      ...JSON_ROS_DETECTION_2D_ARRAY_PAYLOADS,
+      ...JSON_ROS_DETECTION_3D_ARRAY_PAYLOADS,
       ...JSON_ROS_IMAGE_PAYLOADS,
       ...JSON_ROS_LASER_SCAN_PAYLOADS,
       ...JSON_ROS_NAV_SAT_FIX_PAYLOADS,
@@ -450,6 +457,81 @@ describe("JSON-schema ROS MCAP decoders", () => {
     ).toEqual([5, 6, 0]);
   });
 
+  it("decodes JSON vision detections into transient viewer overlays", () => {
+    const detections2d = decoderForSchema(
+      jsonRosDetection2DArrayDecoders,
+      "vision_msgs/msg/Detection2DArray",
+    ).decode(
+      jsonMessage({
+        detections: [
+          detection2DRecord({
+            classId: "car",
+            id: "track-1",
+            score: 0.93,
+            x: 50,
+            y: 40,
+          }),
+        ],
+        header: headerRecord("camera", 17, 18),
+      }),
+      {},
+    );
+    const detections3d = decoderForSchema(
+      jsonRosDetection3DArrayDecoders,
+      "vision_msgs/Detection3DArray",
+    ).decode(
+      jsonMessage({
+        detections: [
+          detection3DRecord({
+            classId: "pedestrian",
+            id: "track-9",
+            score: 0.81,
+          }),
+        ],
+        header: headerRecord("map", 19, 20),
+      }),
+      { streamId: "/detections3d" },
+    );
+
+    expect(detections2d.visualization?.kind).toBe(
+      VISUALIZATION_KIND.IMAGE_ANNOTATIONS,
+    );
+    expect(detections3d.visualization?.kind).toBe(
+      VISUALIZATION_KIND.SCENE_UPDATE,
+    );
+    if (
+      detections2d.visualization?.kind !==
+        VISUALIZATION_KIND.IMAGE_ANNOTATIONS ||
+      detections3d.visualization?.kind !== VISUALIZATION_KIND.SCENE_UPDATE
+    ) {
+      throw new Error("Expected detection visualizations");
+    }
+    expect(detections2d.visualization.points[0]?.points).toEqual([
+      [40, 30],
+      [60, 30],
+      [60, 50],
+      [40, 50],
+    ]);
+    expect(detections2d.visualization.texts[0]).toMatchObject({
+      position: [40, 16],
+      text: "car 0.93",
+    });
+    expect(detections3d.visualization.deletions).toEqual([
+      { id: "", timestampNs: 19_000_000_020n, type: "all" },
+    ]);
+    expect(detections3d.visualization.entities[0]).toMatchObject({
+      cubeCount: 1,
+      frameId: "map",
+      id: "/detections3d:detection3d:track-9",
+      metadata: {
+        classId: "pedestrian",
+        id: "track-9",
+        score: "0.8100",
+        source: "vision_msgs",
+      },
+    });
+  });
+
   it("degrades invalid JSON and malformed JSON records without throwing", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const decoder = decoderForSchema(
@@ -487,6 +569,14 @@ describe("JSON-schema ROS MCAP decoders", () => {
       "/pose_hypotheses",
       JSON_ROS_POSE_ARRAY_PAYLOADS[0],
     );
+    const detections2d = createTopic(
+      "/detections2d",
+      JSON_ROS_DETECTION_2D_ARRAY_PAYLOADS[1],
+    );
+    const detections3d = createTopic(
+      "/detections3d",
+      JSON_ROS_DETECTION_3D_ARRAY_PAYLOADS[0],
+    );
 
     expect(isCompressedImageStream(compressed)).toBe(true);
     expect(isCompressedImageStream(rawImage)).toBe(false);
@@ -515,13 +605,25 @@ describe("JSON-schema ROS MCAP decoders", () => {
     ).toBe(true);
     expect(isSceneUpdateStream(path)).toBe(true);
     expect(isSceneUpdateStream(poseArray)).toBe(true);
+    expect(isImageAnnotationsStream(detections2d)).toBe(true);
+    expect(isSceneUpdateStream(detections3d)).toBe(true);
     expect(
-      streamTopics([compressed, rawImage, cloud, scan, path, poseArray]),
+      streamTopics([
+        compressed,
+        rawImage,
+        cloud,
+        scan,
+        path,
+        poseArray,
+        detections2d,
+        detections3d,
+      ]),
     ).toMatchObject({
+      annotations: ["/detections2d"],
       image: ["/camera/compressed", "/camera/image"],
       pointCloud: ["/points", "/scan"],
       previewable: ["/camera/compressed", "/camera/image", "/points", "/scan"],
-      sceneUpdates: ["/planned_path", "/pose_hypotheses"],
+      sceneUpdates: ["/planned_path", "/pose_hypotheses", "/detections3d"],
     });
   });
 });
@@ -604,6 +706,61 @@ function vectorRecord(vector: readonly [number, number, number]) {
     x: vector[0],
     y: vector[1],
     z: vector[2],
+  };
+}
+
+function detection2DRecord({
+  classId,
+  id,
+  score,
+  x,
+  y,
+}: {
+  readonly classId: string;
+  readonly id: string;
+  readonly score: number;
+  readonly x: number;
+  readonly y: number;
+}) {
+  return {
+    bbox: {
+      center: {
+        position: { x, y },
+        theta: 0,
+      },
+      size_x: 20,
+      size_y: 20,
+    },
+    id,
+    results: [detectionResult(classId, score)],
+  };
+}
+
+function detection3DRecord({
+  classId,
+  id,
+  score,
+}: {
+  readonly classId: string;
+  readonly id: string;
+  readonly score: number;
+}) {
+  return {
+    bbox: {
+      center: poseRecord([1, 2, 3], [0, 0, 0, 1]),
+      size: vectorRecord([2, 1, 1.5]),
+    },
+    id,
+    results: [detectionResult(classId, score)],
+  };
+}
+
+function detectionResult(classId: string, score: number) {
+  return {
+    hypothesis: {
+      class_id: classId,
+      score,
+    },
   };
 }
 

--- a/app/packages/multimodal/src/adapters/mcap/decoders/json/ros.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/json/ros.test.ts
@@ -20,7 +20,12 @@ import {
   isSceneUpdateStream,
   streamTopics,
 } from "../../stream-topics";
-import { detection2DRecord, detection3DRecord } from "../ros.test-fixtures";
+import {
+  detection2DRecord,
+  detection3DRecord,
+  poseRecord,
+  vectorRecord,
+} from "../ros.test-fixtures";
 import {
   JSON_ROS_CAMERA_INFO_PAYLOADS,
   JSON_ROS_COMPRESSED_IMAGE_PAYLOADS,
@@ -791,29 +796,6 @@ function pointCloud2Data(
   });
 
   return Array.from(data);
-}
-
-function poseRecord(
-  position: readonly [number, number, number],
-  quaternion: readonly [number, number, number, number],
-) {
-  return {
-    orientation: {
-      w: quaternion[3],
-      x: quaternion[0],
-      y: quaternion[1],
-      z: quaternion[2],
-    },
-    position: vectorRecord(position),
-  };
-}
-
-function vectorRecord(vector: readonly [number, number, number]) {
-  return {
-    x: vector[0],
-    y: vector[1],
-    z: vector[2],
-  };
 }
 
 function createTopic(

--- a/app/packages/multimodal/src/adapters/mcap/decoders/json/ros.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/json/ros.ts
@@ -3,6 +3,10 @@ import { decodeRosCameraInfoRecord } from "../ros/camera-info";
 import { decodeRosCompressedImageRecord } from "../ros/compressed-image";
 import { decodeRosImageRecord } from "../ros/image";
 import { decodeRosLaserScanRecord } from "../ros/laser-scan";
+import {
+  decodeRosMarkerArrayRecord,
+  decodeRosMarkerRecord,
+} from "../ros/marker";
 import { decodeRosNavSatFixRecord } from "../ros/nav-sat-fix";
 import { decodeRosOccupancyGridRecord } from "../ros/occupancy-grid";
 import { decodeRosPointCloud2Record } from "../ros/point-cloud2";
@@ -16,6 +20,8 @@ import {
   JSON_ROS_COMPRESSED_IMAGE_PAYLOADS,
   JSON_ROS_IMAGE_PAYLOADS,
   JSON_ROS_LASER_SCAN_PAYLOADS,
+  JSON_ROS_MARKER_ARRAY_PAYLOADS,
+  JSON_ROS_MARKER_PAYLOADS,
   JSON_ROS_NAV_SAT_FIX_PAYLOADS,
   JSON_ROS_OCCUPANCY_GRID_PAYLOADS,
   JSON_ROS_ODOMETRY_PAYLOADS,
@@ -57,6 +63,24 @@ export const jsonRosLaserScanDecoders = jsonDecodersForPayloads({
   id: "json.ros.laser-scan",
   map: decodeRosLaserScanRecord,
   payloads: JSON_ROS_LASER_SCAN_PAYLOADS,
+});
+
+/**
+ * JSON-schema decoders for ROS Marker records.
+ */
+export const jsonRosMarkerDecoders = jsonDecodersForPayloads({
+  id: "json.ros.marker",
+  map: decodeRosMarkerRecord,
+  payloads: JSON_ROS_MARKER_PAYLOADS,
+});
+
+/**
+ * JSON-schema decoders for ROS MarkerArray records.
+ */
+export const jsonRosMarkerArrayDecoders = jsonDecodersForPayloads({
+  id: "json.ros.marker-array",
+  map: decodeRosMarkerArrayRecord,
+  payloads: JSON_ROS_MARKER_ARRAY_PAYLOADS,
 });
 
 /**
@@ -112,6 +136,8 @@ export const jsonRosDecoders: readonly Decoder[] = [
   ...jsonRosImageDecoders,
   ...jsonRosPointCloud2Decoders,
   ...jsonRosLaserScanDecoders,
+  ...jsonRosMarkerDecoders,
+  ...jsonRosMarkerArrayDecoders,
   ...jsonRosCameraInfoDecoders,
   ...jsonRosNavSatFixDecoders,
   ...jsonRosOccupancyGridDecoders,

--- a/app/packages/multimodal/src/adapters/mcap/decoders/json/ros.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/json/ros.ts
@@ -9,6 +9,7 @@ import {
 } from "../ros/marker";
 import { decodeRosNavSatFixRecord } from "../ros/nav-sat-fix";
 import { decodeRosOccupancyGridRecord } from "../ros/occupancy-grid";
+import { decodeRosPathRecord, decodeRosPoseArrayRecord } from "../ros/path";
 import { decodeRosPointCloud2Record } from "../ros/point-cloud2";
 import {
   decodeRosOdometryRecord,
@@ -25,7 +26,9 @@ import {
   JSON_ROS_NAV_SAT_FIX_PAYLOADS,
   JSON_ROS_OCCUPANCY_GRID_PAYLOADS,
   JSON_ROS_ODOMETRY_PAYLOADS,
+  JSON_ROS_PATH_PAYLOADS,
   JSON_ROS_POINT_CLOUD2_PAYLOADS,
+  JSON_ROS_POSE_ARRAY_PAYLOADS,
   JSON_ROS_POSE_STAMPED_PAYLOADS,
 } from "./payloads";
 
@@ -129,6 +132,24 @@ export const jsonRosOdometryDecoders = jsonDecodersForPayloads({
 });
 
 /**
+ * JSON-schema decoders for ROS Path records.
+ */
+export const jsonRosPathDecoders = jsonDecodersForPayloads({
+  id: "json.ros.path",
+  map: decodeRosPathRecord,
+  payloads: JSON_ROS_PATH_PAYLOADS,
+});
+
+/**
+ * JSON-schema decoders for ROS PoseArray records.
+ */
+export const jsonRosPoseArrayDecoders = jsonDecodersForPayloads({
+  id: "json.ros.pose-array",
+  map: decodeRosPoseArrayRecord,
+  payloads: JSON_ROS_POSE_ARRAY_PAYLOADS,
+});
+
+/**
  * Built-in JSON-schema decoders for supported ROS message families.
  */
 export const jsonRosDecoders: readonly Decoder[] = [
@@ -143,4 +164,6 @@ export const jsonRosDecoders: readonly Decoder[] = [
   ...jsonRosOccupancyGridDecoders,
   ...jsonRosPoseStampedDecoders,
   ...jsonRosOdometryDecoders,
+  ...jsonRosPathDecoders,
+  ...jsonRosPoseArrayDecoders,
 ];

--- a/app/packages/multimodal/src/adapters/mcap/decoders/json/ros.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/json/ros.ts
@@ -15,10 +15,16 @@ import {
   decodeRosOdometryRecord,
   decodeRosPoseStampedRecord,
 } from "../ros/pose";
+import {
+  decodeRosDetection2DArrayRecord,
+  decodeRosDetection3DArrayRecord,
+} from "../ros/vision";
 import { jsonDecodersForPayloads } from "./factory";
 import {
   JSON_ROS_CAMERA_INFO_PAYLOADS,
   JSON_ROS_COMPRESSED_IMAGE_PAYLOADS,
+  JSON_ROS_DETECTION_2D_ARRAY_PAYLOADS,
+  JSON_ROS_DETECTION_3D_ARRAY_PAYLOADS,
   JSON_ROS_IMAGE_PAYLOADS,
   JSON_ROS_LASER_SCAN_PAYLOADS,
   JSON_ROS_MARKER_ARRAY_PAYLOADS,
@@ -150,6 +156,24 @@ export const jsonRosPoseArrayDecoders = jsonDecodersForPayloads({
 });
 
 /**
+ * JSON-schema decoders for ROS Detection2DArray records.
+ */
+export const jsonRosDetection2DArrayDecoders = jsonDecodersForPayloads({
+  id: "json.ros.detection-2d-array",
+  map: decodeRosDetection2DArrayRecord,
+  payloads: JSON_ROS_DETECTION_2D_ARRAY_PAYLOADS,
+});
+
+/**
+ * JSON-schema decoders for ROS Detection3DArray records.
+ */
+export const jsonRosDetection3DArrayDecoders = jsonDecodersForPayloads({
+  id: "json.ros.detection-3d-array",
+  map: decodeRosDetection3DArrayRecord,
+  payloads: JSON_ROS_DETECTION_3D_ARRAY_PAYLOADS,
+});
+
+/**
  * Built-in JSON-schema decoders for supported ROS message families.
  */
 export const jsonRosDecoders: readonly Decoder[] = [
@@ -166,4 +190,6 @@ export const jsonRosDecoders: readonly Decoder[] = [
   ...jsonRosOdometryDecoders,
   ...jsonRosPathDecoders,
   ...jsonRosPoseArrayDecoders,
+  ...jsonRosDetection2DArrayDecoders,
+  ...jsonRosDetection3DArrayDecoders,
 ];

--- a/app/packages/multimodal/src/adapters/mcap/decoders/json/ros.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/json/ros.ts
@@ -4,6 +4,11 @@ import { decodeRosCompressedImageRecord } from "../ros/compressed-image";
 import { decodeRosImageRecord } from "../ros/image";
 import { decodeRosLaserScanRecord } from "../ros/laser-scan";
 import {
+  decodeDiagnosticArrayRecord,
+  decodeRclLogRecord,
+  decodeRosgraphLogRecord,
+} from "../ros/log";
+import {
   decodeRosMarkerArrayRecord,
   decodeRosMarkerRecord,
 } from "../ros/marker";
@@ -25,6 +30,7 @@ import {
   JSON_ROS_COMPRESSED_IMAGE_PAYLOADS,
   JSON_ROS_DETECTION_2D_ARRAY_PAYLOADS,
   JSON_ROS_DETECTION_3D_ARRAY_PAYLOADS,
+  JSON_ROS_DIAGNOSTIC_ARRAY_PAYLOADS,
   JSON_ROS_IMAGE_PAYLOADS,
   JSON_ROS_LASER_SCAN_PAYLOADS,
   JSON_ROS_MARKER_ARRAY_PAYLOADS,
@@ -36,6 +42,8 @@ import {
   JSON_ROS_POINT_CLOUD2_PAYLOADS,
   JSON_ROS_POSE_ARRAY_PAYLOADS,
   JSON_ROS_POSE_STAMPED_PAYLOADS,
+  JSON_ROS_RCL_LOG_PAYLOADS,
+  JSON_ROS_ROSGRAPH_LOG_PAYLOADS,
 } from "./payloads";
 
 /**
@@ -72,6 +80,33 @@ export const jsonRosLaserScanDecoders = jsonDecodersForPayloads({
   id: "json.ros.laser-scan",
   map: decodeRosLaserScanRecord,
   payloads: JSON_ROS_LASER_SCAN_PAYLOADS,
+});
+
+/**
+ * JSON-schema decoders for ROS rosgraph Log records.
+ */
+export const jsonRosRosgraphLogDecoders = jsonDecodersForPayloads({
+  id: "json.ros.rosgraph-log",
+  map: decodeRosgraphLogRecord,
+  payloads: JSON_ROS_ROSGRAPH_LOG_PAYLOADS,
+});
+
+/**
+ * JSON-schema decoders for ROS 2 rcl_interfaces Log records.
+ */
+export const jsonRosRclLogDecoders = jsonDecodersForPayloads({
+  id: "json.ros.rcl-log",
+  map: decodeRclLogRecord,
+  payloads: JSON_ROS_RCL_LOG_PAYLOADS,
+});
+
+/**
+ * JSON-schema decoders for ROS DiagnosticArray records.
+ */
+export const jsonRosDiagnosticArrayDecoders = jsonDecodersForPayloads({
+  id: "json.ros.diagnostic-array",
+  map: decodeDiagnosticArrayRecord,
+  payloads: JSON_ROS_DIAGNOSTIC_ARRAY_PAYLOADS,
 });
 
 /**
@@ -181,6 +216,9 @@ export const jsonRosDecoders: readonly Decoder[] = [
   ...jsonRosImageDecoders,
   ...jsonRosPointCloud2Decoders,
   ...jsonRosLaserScanDecoders,
+  ...jsonRosRosgraphLogDecoders,
+  ...jsonRosRclLogDecoders,
+  ...jsonRosDiagnosticArrayDecoders,
   ...jsonRosMarkerDecoders,
   ...jsonRosMarkerArrayDecoders,
   ...jsonRosCameraInfoDecoders,

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros.test-fixtures.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros.test-fixtures.ts
@@ -1,0 +1,77 @@
+export function detection2DRecord({
+  classId,
+  id,
+  score,
+  x,
+  y,
+}: {
+  readonly classId: string;
+  readonly id: string;
+  readonly score: number;
+  readonly x: number;
+  readonly y: number;
+}) {
+  return {
+    bbox: {
+      center: {
+        position: { x, y },
+        theta: 0,
+      },
+      size_x: 20,
+      size_y: 20,
+    },
+    id,
+    results: [detectionResult(classId, score)],
+  };
+}
+
+export function detection3DRecord({
+  classId,
+  id,
+  score,
+}: {
+  readonly classId: string;
+  readonly id: string;
+  readonly score: number;
+}) {
+  return {
+    bbox: {
+      center: poseRecord([1, 2, 3], [0, 0, 0, 1]),
+      size: vectorRecord([2, 1, 1.5]),
+    },
+    id,
+    results: [detectionResult(classId, score)],
+  };
+}
+
+export function detectionResult(classId: string, score: number) {
+  return {
+    hypothesis: {
+      class_id: classId,
+      score,
+    },
+  };
+}
+
+function poseRecord(
+  position: readonly [number, number, number],
+  quaternion: readonly [number, number, number, number],
+) {
+  return {
+    orientation: {
+      w: quaternion[3],
+      x: quaternion[0],
+      y: quaternion[1],
+      z: quaternion[2],
+    },
+    position: vectorRecord(position),
+  };
+}
+
+function vectorRecord(vector: readonly [number, number, number]) {
+  return {
+    x: vector[0],
+    y: vector[1],
+    z: vector[2],
+  };
+}

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros.test-fixtures.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros.test-fixtures.ts
@@ -53,7 +53,7 @@ export function detectionResult(classId: string, score: number) {
   };
 }
 
-function poseRecord(
+export function poseRecord(
   position: readonly [number, number, number],
   quaternion: readonly [number, number, number, number],
 ) {
@@ -68,7 +68,7 @@ function poseRecord(
   };
 }
 
-function vectorRecord(vector: readonly [number, number, number]) {
+export function vectorRecord(vector: readonly [number, number, number]) {
   return {
     x: vector[0],
     y: vector[1],

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros.test.ts
@@ -60,7 +60,12 @@ import {
   rosRclLogDecoders,
   rosRosgraphLogDecoders,
 } from "./ros";
-import { detection2DRecord, detection3DRecord } from "./ros.test-fixtures";
+import {
+  detection2DRecord,
+  detection3DRecord,
+  poseRecord,
+  vectorRecord,
+} from "./ros.test-fixtures";
 
 const TEXT_ENCODER = new TextEncoder();
 const H264_KEYFRAME_BYTES = Uint8Array.of(
@@ -2004,29 +2009,6 @@ function float32Bytes(
     view.setFloat32(index * 4, value, littleEndian);
   });
   return Array.from(data);
-}
-
-function poseRecord(
-  position: readonly [number, number, number],
-  quaternion: readonly [number, number, number, number],
-) {
-  return {
-    orientation: {
-      w: quaternion[3],
-      x: quaternion[0],
-      y: quaternion[1],
-      z: quaternion[2],
-    },
-    position: vectorRecord(position),
-  };
-}
-
-function vectorRecord(vector: readonly [number, number, number]) {
-  return {
-    x: vector[0],
-    y: vector[1],
-    z: vector[2],
-  };
 }
 
 function markerRecord({

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros.test.ts
@@ -17,6 +17,7 @@ import {
   isImageAnnotationsStream,
   isImageStream,
   isLocationFixStream,
+  isLogStream,
   isPointCloudStream,
   isPoseStream,
   isSceneUpdateStream,
@@ -28,6 +29,7 @@ import {
   ROS_COMPRESSED_IMAGE_PAYLOADS,
   ROS_DETECTION_2D_ARRAY_PAYLOADS,
   ROS_DETECTION_3D_ARRAY_PAYLOADS,
+  ROS_DIAGNOSTIC_ARRAY_PAYLOADS,
   ROS_IMAGE_PAYLOADS,
   ROS_LASER_SCAN_PAYLOADS,
   ROS_MARKER_ARRAY_PAYLOADS,
@@ -38,8 +40,11 @@ import {
   ROS_POINT_CLOUD2_PAYLOADS,
   ROS_POSE_ARRAY_PAYLOADS,
   ROS_POSE_STAMPED_PAYLOADS,
+  ROS_RCL_LOG_PAYLOADS,
+  ROS_ROSGRAPH_LOG_PAYLOADS,
   rosCameraInfoDecoders,
   rosCompressedImageDecoders,
+  rosDiagnosticArrayDecoders,
   rosDetection2DArrayDecoders,
   rosDetection3DArrayDecoders,
   rosImageDecoders,
@@ -52,6 +57,8 @@ import {
   rosPointCloud2Decoders,
   rosPoseArrayDecoders,
   rosPoseStampedDecoders,
+  rosRclLogDecoders,
+  rosRosgraphLogDecoders,
 } from "./ros";
 
 const TEXT_ENCODER = new TextEncoder();
@@ -275,6 +282,48 @@ float64 x
 float64 y
 float64 z
 float64 w`;
+
+const ROS1_LOG_SCHEMA = `std_msgs/Header header
+byte level
+string name
+string msg
+string file
+string function
+uint32 line
+string[] topics
+===
+MSG: std_msgs/Header
+uint32 seq
+time stamp
+string frame_id`;
+
+const ROS2_RCL_LOG_SCHEMA = `builtin_interfaces/Time stamp
+uint8 level
+string name
+string msg
+string file
+string function
+uint32 line
+${ROS2_HEADER_DEFINITIONS}`;
+
+const ROS2_DIAGNOSTIC_ARRAY_SCHEMA = `std_msgs/Header header
+diagnostic_msgs/DiagnosticStatus[] status
+${ROS2_HEADER_DEFINITIONS}
+===
+MSG: diagnostic_msgs/DiagnosticStatus
+byte OK=0
+byte WARN=1
+byte ERROR=2
+byte STALE=3
+byte level
+string name
+string message
+string hardware_id
+diagnostic_msgs/KeyValue[] values
+===
+MSG: diagnostic_msgs/KeyValue
+string key
+string value`;
 
 const ROS2_ODOMETRY_SCHEMA = `std_msgs/Header header
 string child_frame_id
@@ -507,6 +556,7 @@ describe("ROS MCAP decoders", () => {
       ...ROS_COMPRESSED_IMAGE_PAYLOADS,
       ...ROS_DETECTION_2D_ARRAY_PAYLOADS,
       ...ROS_DETECTION_3D_ARRAY_PAYLOADS,
+      ...ROS_DIAGNOSTIC_ARRAY_PAYLOADS,
       ...ROS_IMAGE_PAYLOADS,
       ...ROS_LASER_SCAN_PAYLOADS,
       ...ROS_NAV_SAT_FIX_PAYLOADS,
@@ -516,6 +566,8 @@ describe("ROS MCAP decoders", () => {
       ...ROS_POINT_CLOUD2_PAYLOADS,
       ...ROS_POSE_ARRAY_PAYLOADS,
       ...ROS_POSE_STAMPED_PAYLOADS,
+      ...ROS_RCL_LOG_PAYLOADS,
+      ...ROS_ROSGRAPH_LOG_PAYLOADS,
     ];
 
     for (const payload of payloads) {
@@ -615,6 +667,93 @@ describe("ROS MCAP decoders", () => {
       frameId: "lidar",
       unsupportedReason: "ROS PointCloud2 big-endian data is unsupported",
     });
+  });
+
+  it("decodes ROS log and diagnostics records into console rows", () => {
+    const rosgraph = decoderForSchemaEncoding(
+      rosRosgraphLogDecoders,
+      "ros1msg",
+    ).decode(
+      ros1Message(ROS1_LOG_SCHEMA, {
+        file: "planner.cpp",
+        function: "tick",
+        header: ros1Header({ frameId: "rosout", nsec: 8, sec: 7, seq: 3 }),
+        level: 8,
+        line: 42,
+        msg: "planner failed",
+        name: "planner",
+        topics: ["/plan"],
+      }),
+      { schemaData: schemaData(ROS1_LOG_SCHEMA) },
+    );
+    const rcl = decoderForSchemaEncoding(rosRclLogDecoders, "ros2msg").decode(
+      ros2Message(ROS2_RCL_LOG_SCHEMA, {
+        file: "controller.cpp",
+        function: "update",
+        level: 30,
+        line: 10,
+        msg: "tracking degraded",
+        name: "controller",
+        stamp: { nanosec: 4, sec: 5 },
+      }),
+      { schemaData: schemaData(ROS2_RCL_LOG_SCHEMA) },
+    );
+    const diagnostics = decoderForSchemaEncoding(
+      rosDiagnosticArrayDecoders,
+      "ros2msg",
+    ).decode(
+      ros2Message(ROS2_DIAGNOSTIC_ARRAY_SCHEMA, {
+        header: ros2Header({ frameId: "base", nanosec: 9, sec: 6 }),
+        status: [
+          {
+            hardware_id: "lidar-top",
+            level: 2,
+            message: "packet drops",
+            name: "driver",
+            values: [{ key: "drop_rate", value: "0.2" }],
+          },
+        ],
+      }),
+      { schemaData: schemaData(ROS2_DIAGNOSTIC_ARRAY_SCHEMA) },
+    );
+
+    expect(rosgraph.attributes?.logRows).toEqual([
+      expect.objectContaining({
+        file: "planner.cpp",
+        functionName: "tick",
+        level: "error",
+        line: 42,
+        message: "planner failed",
+        name: "planner",
+        timestampNs: 7_000_000_008n,
+        topics: ["/plan"],
+      }),
+    ]);
+    expect(rosgraph.timing?.sourceTimestamps?.messageTime).toBe(7_000_000_008n);
+    expect(rcl.attributes?.logRows).toEqual([
+      expect.objectContaining({
+        level: "warn",
+        levelNumber: 30,
+        message: "tracking degraded",
+        timestampNs: 5_000_000_004n,
+      }),
+    ]);
+    expect(diagnostics.attributes).toMatchObject({
+      diagnosticCount: 1,
+      errorCount: 1,
+    });
+    expect(diagnostics.attributes?.logRows).toEqual([
+      expect.objectContaining({
+        details: [{ key: "drop_rate", value: "0.2" }],
+        hardwareId: "lidar-top",
+        kind: "diagnostic",
+        level: "error",
+        message: "packet drops",
+        name: "driver",
+        status: "ERROR",
+        timestampNs: 6_000_000_009n,
+      }),
+    ]);
   });
 
   it("decodes ros2 idl CompressedImage into an encoded image visualization", () => {
@@ -1519,6 +1658,11 @@ describe("ROS MCAP decoders", () => {
       "/detections3d",
       ROS_DETECTION_3D_ARRAY_PAYLOADS[1],
     );
+    const logs = createTopic("/rosout", ROS_RCL_LOG_PAYLOADS[0]);
+    const diagnostics = createTopic(
+      "/diagnostics",
+      ROS_DIAGNOSTIC_ARRAY_PAYLOADS[1],
+    );
 
     expect(isCompressedImageStream(compressed)).toBe(true);
     expect(isCompressedImageStream(rawImage)).toBe(false);
@@ -1548,6 +1692,8 @@ describe("ROS MCAP decoders", () => {
     expect(isSceneUpdateStream(poseArray)).toBe(true);
     expect(isImageAnnotationsStream(detections2d)).toBe(true);
     expect(isSceneUpdateStream(detections3d)).toBe(true);
+    expect(isLogStream(logs)).toBe(true);
+    expect(isLogStream(diagnostics)).toBe(true);
     expect(
       streamTopics([
         compressed,
@@ -1559,12 +1705,22 @@ describe("ROS MCAP decoders", () => {
         poseArray,
         detections2d,
         detections3d,
+        logs,
+        diagnostics,
       ]),
     ).toMatchObject({
       annotations: ["/detections2d"],
       image: ["/camera/compressed", "/camera/image"],
+      logs: ["/rosout", "/diagnostics"],
       pointCloud: ["/points", "/scan"],
-      previewable: ["/camera/compressed", "/camera/image", "/points", "/scan"],
+      previewable: [
+        "/camera/compressed",
+        "/camera/image",
+        "/points",
+        "/scan",
+        "/rosout",
+        "/diagnostics",
+      ],
       sceneUpdates: [
         "/markers",
         "/planned_path",

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros.test.ts
@@ -14,6 +14,7 @@ import {
   isCameraCalibrationStream,
   isCompressedImageStream,
   isGridStream,
+  isImageAnnotationsStream,
   isImageStream,
   isLocationFixStream,
   isPointCloudStream,
@@ -25,6 +26,8 @@ import { createMcapDecoderRegistry } from ".";
 import {
   ROS_CAMERA_INFO_PAYLOADS,
   ROS_COMPRESSED_IMAGE_PAYLOADS,
+  ROS_DETECTION_2D_ARRAY_PAYLOADS,
+  ROS_DETECTION_3D_ARRAY_PAYLOADS,
   ROS_IMAGE_PAYLOADS,
   ROS_LASER_SCAN_PAYLOADS,
   ROS_MARKER_ARRAY_PAYLOADS,
@@ -37,6 +40,8 @@ import {
   ROS_POSE_STAMPED_PAYLOADS,
   rosCameraInfoDecoders,
   rosCompressedImageDecoders,
+  rosDetection2DArrayDecoders,
+  rosDetection3DArrayDecoders,
   rosImageDecoders,
   rosLaserScanDecoders,
   rosMarkerArrayDecoders,
@@ -192,6 +197,75 @@ geometry_msgs/Point position
 geometry_msgs/Quaternion orientation
 ===
 MSG: geometry_msgs/Point
+float64 x
+float64 y
+float64 z
+===
+MSG: geometry_msgs/Quaternion
+float64 x
+float64 y
+float64 z
+float64 w`;
+
+const ROS2_DETECTION_2D_ARRAY_SCHEMA = `std_msgs/Header header
+vision_msgs/Detection2D[] detections
+${ROS2_HEADER_DEFINITIONS}
+===
+MSG: vision_msgs/Detection2D
+vision_msgs/ObjectHypothesisWithPose[] results
+vision_msgs/BoundingBox2D bbox
+string id
+===
+MSG: vision_msgs/ObjectHypothesisWithPose
+vision_msgs/ObjectHypothesis hypothesis
+===
+MSG: vision_msgs/ObjectHypothesis
+string class_id
+float64 score
+===
+MSG: vision_msgs/BoundingBox2D
+vision_msgs/Pose2D center
+float64 size_x
+float64 size_y
+===
+MSG: vision_msgs/Pose2D
+vision_msgs/Point2D position
+float64 theta
+===
+MSG: vision_msgs/Point2D
+float64 x
+float64 y`;
+
+const ROS2_DETECTION_3D_ARRAY_SCHEMA = `std_msgs/Header header
+vision_msgs/Detection3D[] detections
+${ROS2_HEADER_DEFINITIONS}
+===
+MSG: vision_msgs/Detection3D
+vision_msgs/ObjectHypothesisWithPose[] results
+vision_msgs/BoundingBox3D bbox
+string id
+===
+MSG: vision_msgs/ObjectHypothesisWithPose
+vision_msgs/ObjectHypothesis hypothesis
+===
+MSG: vision_msgs/ObjectHypothesis
+string class_id
+float64 score
+===
+MSG: vision_msgs/BoundingBox3D
+geometry_msgs/Pose center
+geometry_msgs/Vector3 size
+===
+MSG: geometry_msgs/Pose
+geometry_msgs/Point position
+geometry_msgs/Quaternion orientation
+===
+MSG: geometry_msgs/Point
+float64 x
+float64 y
+float64 z
+===
+MSG: geometry_msgs/Vector3
 float64 x
 float64 y
 float64 z
@@ -431,6 +505,8 @@ describe("ROS MCAP decoders", () => {
     const payloads = [
       ...ROS_CAMERA_INFO_PAYLOADS,
       ...ROS_COMPRESSED_IMAGE_PAYLOADS,
+      ...ROS_DETECTION_2D_ARRAY_PAYLOADS,
+      ...ROS_DETECTION_3D_ARRAY_PAYLOADS,
       ...ROS_IMAGE_PAYLOADS,
       ...ROS_LASER_SCAN_PAYLOADS,
       ...ROS_NAV_SAT_FIX_PAYLOADS,
@@ -1106,6 +1182,99 @@ describe("ROS MCAP decoders", () => {
     });
   });
 
+  it("decodes ros2 vision detections into transient viewer overlays", () => {
+    const detections2d = decoderForSchemaEncoding(
+      rosDetection2DArrayDecoders,
+      "ros2msg",
+    ).decode(
+      ros2Message(ROS2_DETECTION_2D_ARRAY_SCHEMA, {
+        detections: [
+          detection2DRecord({
+            classId: "car",
+            id: "track-1",
+            score: 0.93,
+            x: 50,
+            y: 40,
+          }),
+        ],
+        header: ros2Header({ frameId: "camera", nanosec: 18, sec: 17 }),
+      }),
+      { schemaData: schemaData(ROS2_DETECTION_2D_ARRAY_SCHEMA) },
+    );
+    const detections3d = decoderForSchemaEncoding(
+      rosDetection3DArrayDecoders,
+      "ros2msg",
+    ).decode(
+      ros2Message(ROS2_DETECTION_3D_ARRAY_SCHEMA, {
+        detections: [
+          detection3DRecord({
+            classId: "pedestrian",
+            id: "track-9",
+            score: 0.81,
+          }),
+        ],
+        header: ros2Header({ frameId: "map", nanosec: 20, sec: 19 }),
+      }),
+      {
+        schemaData: schemaData(ROS2_DETECTION_3D_ARRAY_SCHEMA),
+        streamId: "/detections3d",
+      },
+    );
+
+    expect(detections2d.visualization?.kind).toBe(
+      VISUALIZATION_KIND.IMAGE_ANNOTATIONS,
+    );
+    expect(detections3d.visualization?.kind).toBe(
+      VISUALIZATION_KIND.SCENE_UPDATE,
+    );
+    if (
+      detections2d.visualization?.kind !==
+        VISUALIZATION_KIND.IMAGE_ANNOTATIONS ||
+      detections3d.visualization?.kind !== VISUALIZATION_KIND.SCENE_UPDATE
+    ) {
+      throw new Error("Expected detection visualizations");
+    }
+    expect(detections2d.visualization.points[0]).toMatchObject({
+      points: [
+        [40, 30],
+        [60, 30],
+        [60, 50],
+        [40, 50],
+      ],
+      type: "line-loop",
+    });
+    expect(detections2d.visualization.texts[0]).toMatchObject({
+      position: [40, 16],
+      text: "car 0.93",
+    });
+    expect(detections2d.attributes).toMatchObject({
+      boxCount: 1,
+      classIds: ["car"],
+      detectionCount: 1,
+      frameId: "camera",
+      textCount: 1,
+    });
+    expect(detections3d.visualization.deletions).toEqual([
+      { id: "", timestampNs: 19_000_000_020n, type: "all" },
+    ]);
+    expect(detections3d.visualization.entities[0]).toMatchObject({
+      cubeCount: 1,
+      frameId: "map",
+      id: "/detections3d:detection3d:track-9",
+      metadata: {
+        classId: "pedestrian",
+        id: "track-9",
+        score: "0.8100",
+        source: "vision_msgs",
+      },
+      textCount: 1,
+      timestampNs: 19_000_000_020n,
+    });
+    expect(detections3d.visualization.entities[0]?.cubes[0]?.size).toEqual([
+      2, 1, 1.5,
+    ]);
+  });
+
   it("decodes ros2 MarkerArray into scene-update entities and deletions", () => {
     const output = decoderForSchemaEncoding(
       rosMarkerArrayDecoders,
@@ -1342,6 +1511,14 @@ describe("ROS MCAP decoders", () => {
       "/pose_hypotheses",
       ROS_POSE_ARRAY_PAYLOADS[1],
     );
+    const detections2d = createTopic(
+      "/detections2d",
+      ROS_DETECTION_2D_ARRAY_PAYLOADS[1],
+    );
+    const detections3d = createTopic(
+      "/detections3d",
+      ROS_DETECTION_3D_ARRAY_PAYLOADS[1],
+    );
 
     expect(isCompressedImageStream(compressed)).toBe(true);
     expect(isCompressedImageStream(rawImage)).toBe(false);
@@ -1369,6 +1546,8 @@ describe("ROS MCAP decoders", () => {
     expect(isSceneUpdateStream(markers)).toBe(true);
     expect(isSceneUpdateStream(path)).toBe(true);
     expect(isSceneUpdateStream(poseArray)).toBe(true);
+    expect(isImageAnnotationsStream(detections2d)).toBe(true);
+    expect(isSceneUpdateStream(detections3d)).toBe(true);
     expect(
       streamTopics([
         compressed,
@@ -1378,12 +1557,20 @@ describe("ROS MCAP decoders", () => {
         markers,
         path,
         poseArray,
+        detections2d,
+        detections3d,
       ]),
     ).toMatchObject({
+      annotations: ["/detections2d"],
       image: ["/camera/compressed", "/camera/image"],
       pointCloud: ["/points", "/scan"],
       previewable: ["/camera/compressed", "/camera/image", "/points", "/scan"],
-      sceneUpdates: ["/markers", "/planned_path", "/pose_hypotheses"],
+      sceneUpdates: [
+        "/markers",
+        "/planned_path",
+        "/pose_hypotheses",
+        "/detections3d",
+      ],
     });
   });
 });
@@ -1640,6 +1827,61 @@ function vectorRecord(vector: readonly [number, number, number]) {
     x: vector[0],
     y: vector[1],
     z: vector[2],
+  };
+}
+
+function detection2DRecord({
+  classId,
+  id,
+  score,
+  x,
+  y,
+}: {
+  readonly classId: string;
+  readonly id: string;
+  readonly score: number;
+  readonly x: number;
+  readonly y: number;
+}) {
+  return {
+    bbox: {
+      center: {
+        position: { x, y },
+        theta: 0,
+      },
+      size_x: 20,
+      size_y: 20,
+    },
+    id,
+    results: [detectionResult(classId, score)],
+  };
+}
+
+function detection3DRecord({
+  classId,
+  id,
+  score,
+}: {
+  readonly classId: string;
+  readonly id: string;
+  readonly score: number;
+}) {
+  return {
+    bbox: {
+      center: poseRecord([1, 2, 3], [0, 0, 0, 1]),
+      size: vectorRecord([2, 1, 1.5]),
+    },
+    id,
+    results: [detectionResult(classId, score)],
+  };
+}
+
+function detectionResult(classId: string, score: number) {
+  return {
+    hypothesis: {
+      class_id: classId,
+      score,
+    },
   };
 }
 

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros.test.ts
@@ -1593,6 +1593,8 @@ describe("ROS MCAP decoders", () => {
     expect(output.visualization).toMatchObject({
       altitude: 12.5,
       coordinateFrameId: "gps",
+      fixService: 1,
+      fixStatus: 0,
       latitude: 37.77,
       longitude: -122.42,
       positionCovariance: [1, 0, 0, 0, 2, 0, 0, 0, 3],

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros.test.ts
@@ -31,7 +31,9 @@ import {
   ROS_NAV_SAT_FIX_PAYLOADS,
   ROS_OCCUPANCY_GRID_PAYLOADS,
   ROS_ODOMETRY_PAYLOADS,
+  ROS_PATH_PAYLOADS,
   ROS_POINT_CLOUD2_PAYLOADS,
+  ROS_POSE_ARRAY_PAYLOADS,
   ROS_POSE_STAMPED_PAYLOADS,
   rosCameraInfoDecoders,
   rosCompressedImageDecoders,
@@ -41,7 +43,9 @@ import {
   rosNavSatFixDecoders,
   rosOccupancyGridDecoders,
   rosOdometryDecoders,
+  rosPathDecoders,
   rosPointCloud2Decoders,
+  rosPoseArrayDecoders,
   rosPoseStampedDecoders,
 } from "./ros";
 
@@ -139,6 +143,48 @@ ${ROS2_HEADER_DEFINITIONS}`;
 
 const ROS2_POSE_STAMPED_SCHEMA = `std_msgs/Header header
 geometry_msgs/Pose pose
+${ROS2_HEADER_DEFINITIONS}
+===
+MSG: geometry_msgs/Pose
+geometry_msgs/Point position
+geometry_msgs/Quaternion orientation
+===
+MSG: geometry_msgs/Point
+float64 x
+float64 y
+float64 z
+===
+MSG: geometry_msgs/Quaternion
+float64 x
+float64 y
+float64 z
+float64 w`;
+
+const ROS2_PATH_SCHEMA = `std_msgs/Header header
+geometry_msgs/PoseStamped[] poses
+${ROS2_HEADER_DEFINITIONS}
+===
+MSG: geometry_msgs/PoseStamped
+std_msgs/Header header
+geometry_msgs/Pose pose
+===
+MSG: geometry_msgs/Pose
+geometry_msgs/Point position
+geometry_msgs/Quaternion orientation
+===
+MSG: geometry_msgs/Point
+float64 x
+float64 y
+float64 z
+===
+MSG: geometry_msgs/Quaternion
+float64 x
+float64 y
+float64 z
+float64 w`;
+
+const ROS2_POSE_ARRAY_SCHEMA = `std_msgs/Header header
+geometry_msgs/Pose[] poses
 ${ROS2_HEADER_DEFINITIONS}
 ===
 MSG: geometry_msgs/Pose
@@ -390,7 +436,9 @@ describe("ROS MCAP decoders", () => {
       ...ROS_NAV_SAT_FIX_PAYLOADS,
       ...ROS_OCCUPANCY_GRID_PAYLOADS,
       ...ROS_ODOMETRY_PAYLOADS,
+      ...ROS_PATH_PAYLOADS,
       ...ROS_POINT_CLOUD2_PAYLOADS,
+      ...ROS_POSE_ARRAY_PAYLOADS,
       ...ROS_POSE_STAMPED_PAYLOADS,
     ];
 
@@ -985,6 +1033,79 @@ describe("ROS MCAP decoders", () => {
     expect(odometry.attributes).toMatchObject({ childFrameId: "base_link" });
   });
 
+  it("decodes ros2 Path and PoseArray into scene-update overlays", () => {
+    const path = decoderForSchemaEncoding(rosPathDecoders, "ros2msg").decode(
+      ros2Message(ROS2_PATH_SCHEMA, {
+        header: ros2Header({ frameId: "map", nanosec: 14, sec: 13 }),
+        poses: [
+          {
+            header: ros2Header({ frameId: "map", nanosec: 1, sec: 1 }),
+            pose: poseRecord([1, 2, 0], [0, 0, 0, 1]),
+          },
+          {
+            header: ros2Header({ frameId: "map", nanosec: 2, sec: 1 }),
+            pose: poseRecord([3, 4, 0], [0, 0, 0, 1]),
+          },
+        ],
+      }),
+      { schemaData: schemaData(ROS2_PATH_SCHEMA), streamId: "/planned_path" },
+    );
+    const poseArray = decoderForSchemaEncoding(
+      rosPoseArrayDecoders,
+      "ros2msg",
+    ).decode(
+      ros2Message(ROS2_POSE_ARRAY_SCHEMA, {
+        header: ros2Header({ frameId: "map", nanosec: 16, sec: 15 }),
+        poses: [
+          poseRecord([5, 6, 0], [0, 0, 0, 1]),
+          poseRecord([7, 8, 0], [0, 0, 1, 0]),
+        ],
+      }),
+      {
+        schemaData: schemaData(ROS2_POSE_ARRAY_SCHEMA),
+        streamId: "/pose_hypotheses",
+      },
+    );
+
+    expect(path.visualization?.kind).toBe(VISUALIZATION_KIND.SCENE_UPDATE);
+    expect(poseArray.visualization?.kind).toBe(VISUALIZATION_KIND.SCENE_UPDATE);
+    if (
+      path.visualization?.kind !== VISUALIZATION_KIND.SCENE_UPDATE ||
+      poseArray.visualization?.kind !== VISUALIZATION_KIND.SCENE_UPDATE
+    ) {
+      throw new Error("Expected scene update visualizations");
+    }
+    expect(path.visualization.entities[0]).toMatchObject({
+      frameId: "map",
+      id: "/planned_path:path",
+      lineCount: 1,
+      timestampNs: 13_000_000_014n,
+    });
+    expect(path.visualization.entities[0]?.lines[0]?.points).toEqual([
+      [1, 2, 0],
+      [3, 4, 0],
+    ]);
+    expect(path.attributes).toMatchObject({
+      frameId: "map",
+      pointCount: 2,
+      poseCount: 2,
+    });
+    expect(poseArray.visualization.entities[0]).toMatchObject({
+      arrowCount: 2,
+      frameId: "map",
+      id: "/pose_hypotheses:pose-array",
+      timestampNs: 15_000_000_016n,
+    });
+    expect(
+      poseArray.visualization.entities[0]?.arrows[0]?.pose.position,
+    ).toEqual([5, 6, 0]);
+    expect(poseArray.attributes).toMatchObject({
+      frameId: "map",
+      poseCount: 2,
+      renderedPoseCount: 2,
+    });
+  });
+
   it("decodes ros2 MarkerArray into scene-update entities and deletions", () => {
     const output = decoderForSchemaEncoding(
       rosMarkerArrayDecoders,
@@ -1216,6 +1337,11 @@ describe("ROS MCAP decoders", () => {
       schemaEncoding: "ros2msg",
     });
     const markers = createTopic("/markers", ROS_MARKER_ARRAY_PAYLOADS[1]);
+    const path = createTopic("/planned_path", ROS_PATH_PAYLOADS[1]);
+    const poseArray = createTopic(
+      "/pose_hypotheses",
+      ROS_POSE_ARRAY_PAYLOADS[1],
+    );
 
     expect(isCompressedImageStream(compressed)).toBe(true);
     expect(isCompressedImageStream(rawImage)).toBe(false);
@@ -1241,13 +1367,23 @@ describe("ROS MCAP decoders", () => {
       isGridStream(createTopic("/map", ROS_OCCUPANCY_GRID_PAYLOADS[0])),
     ).toBe(true);
     expect(isSceneUpdateStream(markers)).toBe(true);
+    expect(isSceneUpdateStream(path)).toBe(true);
+    expect(isSceneUpdateStream(poseArray)).toBe(true);
     expect(
-      streamTopics([compressed, rawImage, cloud, scan, markers]),
+      streamTopics([
+        compressed,
+        rawImage,
+        cloud,
+        scan,
+        markers,
+        path,
+        poseArray,
+      ]),
     ).toMatchObject({
       image: ["/camera/compressed", "/camera/image"],
       pointCloud: ["/points", "/scan"],
       previewable: ["/camera/compressed", "/camera/image", "/points", "/scan"],
-      sceneUpdates: ["/markers"],
+      sceneUpdates: ["/markers", "/planned_path", "/pose_hypotheses"],
     });
   });
 });

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros.test.ts
@@ -60,6 +60,7 @@ import {
   rosRclLogDecoders,
   rosRosgraphLogDecoders,
 } from "./ros";
+import { detection2DRecord, detection3DRecord } from "./ros.test-fixtures";
 
 const TEXT_ENCODER = new TextEncoder();
 const H264_KEYFRAME_BYTES = Uint8Array.of(
@@ -1521,6 +1522,48 @@ describe("ROS MCAP decoders", () => {
     ]);
   });
 
+  it("marks oversized ros2 marker point lists as unsupported", () => {
+    const points = Array.from({ length: 513 }, (_, index) =>
+      vectorRecord([index, 0, 0]),
+    );
+    const output = decoderForSchemaEncoding(
+      rosMarkerArrayDecoders,
+      "ros2msg",
+    ).decode(
+      ros2Message(ROS2_MARKER_ARRAY_SCHEMA, {
+        markers: [
+          markerRecord({
+            id: 10,
+            ns: "too-many-cubes",
+            points,
+            type: 6,
+          }),
+          markerRecord({
+            id: 11,
+            ns: "too-many-spheres",
+            points,
+            type: 7,
+          }),
+        ],
+      }),
+      {
+        schemaData: schemaData(ROS2_MARKER_ARRAY_SCHEMA),
+        streamId: "/markers",
+      },
+    );
+
+    expect(output.visualization?.kind).toBe(VISUALIZATION_KIND.SCENE_UPDATE);
+    if (output.visualization?.kind !== VISUALIZATION_KIND.SCENE_UPDATE) {
+      throw new Error("Expected scene update visualization");
+    }
+    expect(output.visualization.entities).toEqual([]);
+    expect(output.attributes).toMatchObject({
+      entityCount: 0,
+      unsupportedMarkerCount: 2,
+      unsupportedMarkerTypes: ["CUBE_LIST(513)", "SPHERE_LIST(513)"],
+    });
+  });
+
   it("decodes ros1 NavSatFix into a location visualization", () => {
     const output = decoderForSchemaEncoding(
       rosNavSatFixDecoders,
@@ -1983,61 +2026,6 @@ function vectorRecord(vector: readonly [number, number, number]) {
     x: vector[0],
     y: vector[1],
     z: vector[2],
-  };
-}
-
-function detection2DRecord({
-  classId,
-  id,
-  score,
-  x,
-  y,
-}: {
-  readonly classId: string;
-  readonly id: string;
-  readonly score: number;
-  readonly x: number;
-  readonly y: number;
-}) {
-  return {
-    bbox: {
-      center: {
-        position: { x, y },
-        theta: 0,
-      },
-      size_x: 20,
-      size_y: 20,
-    },
-    id,
-    results: [detectionResult(classId, score)],
-  };
-}
-
-function detection3DRecord({
-  classId,
-  id,
-  score,
-}: {
-  readonly classId: string;
-  readonly id: string;
-  readonly score: number;
-}) {
-  return {
-    bbox: {
-      center: poseRecord([1, 2, 3], [0, 0, 0, 1]),
-      size: vectorRecord([2, 1, 1.5]),
-    },
-    id,
-    results: [detectionResult(classId, score)],
-  };
-}
-
-function detectionResult(classId: string, score: number) {
-  return {
-    hypothesis: {
-      class_id: classId,
-      score,
-    },
   };
 }
 

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros.test.ts
@@ -18,6 +18,7 @@ import {
   isLocationFixStream,
   isPointCloudStream,
   isPoseStream,
+  isSceneUpdateStream,
   streamTopics,
 } from "../stream-topics";
 import { createMcapDecoderRegistry } from ".";
@@ -26,6 +27,7 @@ import {
   ROS_COMPRESSED_IMAGE_PAYLOADS,
   ROS_IMAGE_PAYLOADS,
   ROS_LASER_SCAN_PAYLOADS,
+  ROS_MARKER_ARRAY_PAYLOADS,
   ROS_NAV_SAT_FIX_PAYLOADS,
   ROS_OCCUPANCY_GRID_PAYLOADS,
   ROS_ODOMETRY_PAYLOADS,
@@ -35,6 +37,7 @@ import {
   rosCompressedImageDecoders,
   rosImageDecoders,
   rosLaserScanDecoders,
+  rosMarkerArrayDecoders,
   rosNavSatFixDecoders,
   rosOccupancyGridDecoders,
   rosOdometryDecoders,
@@ -190,6 +193,52 @@ float64 x
 float64 y
 float64 z
 float64 w`;
+
+const ROS2_MARKER_ARRAY_SCHEMA = `visualization_msgs/Marker[] markers
+===
+MSG: visualization_msgs/Marker
+std_msgs/Header header
+string ns
+int32 id
+int32 type
+int32 action
+geometry_msgs/Pose pose
+geometry_msgs/Vector3 scale
+std_msgs/ColorRGBA color
+builtin_interfaces/Duration lifetime
+bool frame_locked
+geometry_msgs/Point[] points
+std_msgs/ColorRGBA[] colors
+string text
+string mesh_resource
+bool mesh_use_embedded_materials
+${ROS2_HEADER_DEFINITIONS}
+===
+MSG: geometry_msgs/Pose
+geometry_msgs/Point position
+geometry_msgs/Quaternion orientation
+===
+MSG: geometry_msgs/Point
+float64 x
+float64 y
+float64 z
+===
+MSG: geometry_msgs/Vector3
+float64 x
+float64 y
+float64 z
+===
+MSG: geometry_msgs/Quaternion
+float64 x
+float64 y
+float64 z
+float64 w
+===
+MSG: std_msgs/ColorRGBA
+float32 r
+float32 g
+float32 b
+float32 a`;
 
 const ROS1_NAV_SAT_FIX_SCHEMA = `std_msgs/Header header
 sensor_msgs/NavSatStatus status
@@ -936,6 +985,113 @@ describe("ROS MCAP decoders", () => {
     expect(odometry.attributes).toMatchObject({ childFrameId: "base_link" });
   });
 
+  it("decodes ros2 MarkerArray into scene-update entities and deletions", () => {
+    const output = decoderForSchemaEncoding(
+      rosMarkerArrayDecoders,
+      "ros2msg",
+    ).decode(
+      ros2Message(ROS2_MARKER_ARRAY_SCHEMA, {
+        markers: [
+          markerRecord({
+            color: colorRecord([1, 0, 0, 0.5]),
+            frameLocked: true,
+            id: 7,
+            lifetime: { nanosec: 4, sec: 3 },
+            ns: "boxes",
+            pose: poseRecord([1, 2, 3], [0, 0, 0, 1]),
+            scale: vectorRecord([4, 5, 6]),
+            type: 1,
+          }),
+          markerRecord({
+            color: colorRecord([0, 1, 0, 1]),
+            id: 2,
+            ns: "plan",
+            points: [
+              vectorRecord([0, 0, 0]),
+              vectorRecord([1, 0, 0]),
+              vectorRecord([1, 1, 0]),
+            ],
+            scale: vectorRecord([2, 1, 1]),
+            type: 4,
+          }),
+          markerRecord({
+            color: colorRecord([0, 0, 1, 1]),
+            id: 3,
+            ns: "labels",
+            pose: poseRecord([0, 0, 2], [0, 0, 0, 1]),
+            scale: vectorRecord([1, 1, 1.5]),
+            text: "car",
+            type: 9,
+          }),
+          markerRecord({ action: 2, id: 8, ns: "boxes", type: 1 }),
+          markerRecord({ action: 3, id: 0, ns: "ignored", type: 1 }),
+        ],
+      }),
+      {
+        schemaData: schemaData(ROS2_MARKER_ARRAY_SCHEMA),
+        streamId: "/markers",
+      },
+    );
+
+    expect(output.visualization?.kind).toBe(VISUALIZATION_KIND.SCENE_UPDATE);
+    if (output.visualization?.kind !== VISUALIZATION_KIND.SCENE_UPDATE) {
+      throw new Error("Expected scene update visualization");
+    }
+
+    expect(output.attributes).toMatchObject({
+      deletionCount: 2,
+      entityCount: 3,
+      markerCount: 5,
+      transparentMarkerCount: 0,
+      unsupportedMarkerCount: 0,
+    });
+    expect(output.visualization.entities[0]).toMatchObject({
+      cubeCount: 1,
+      frameId: "map",
+      frameLocked: true,
+      id: "/markers:boxes:7",
+      lifetimeNs: 3_000_000_004n,
+      metadata: {
+        id: "7",
+        namespace: "boxes",
+        source: "visualization_msgs/Marker",
+        type: "CUBE",
+      },
+      timestampNs: 21_000_000_022n,
+    });
+    expect(output.visualization.entities[0]?.cubes[0]).toMatchObject({
+      color: [1, 0, 0, 0.5],
+      pose: { position: [1, 2, 3], quaternion: [0, 0, 0, 1] },
+      size: [4, 5, 6],
+    });
+    expect(output.visualization.entities[1]?.lines[0]).toMatchObject({
+      points: [
+        [0, 0, 0],
+        [1, 0, 0],
+        [1, 1, 0],
+      ],
+      thickness: 2,
+      type: "line-strip",
+    });
+    expect(output.visualization.entities[2]?.texts[0]).toMatchObject({
+      billboard: true,
+      fontSize: 1.5,
+      text: "car",
+    });
+    expect(output.visualization.deletions).toEqual([
+      {
+        id: "/markers:boxes:8",
+        timestampNs: 21_000_000_022n,
+        type: "matching-id",
+      },
+      {
+        id: "",
+        timestampNs: 21_000_000_022n,
+        type: "all",
+      },
+    ]);
+  });
+
   it("decodes ros1 NavSatFix into a location visualization", () => {
     const output = decoderForSchemaEncoding(
       rosNavSatFixDecoders,
@@ -1059,6 +1215,7 @@ describe("ROS MCAP decoders", () => {
       schema: "sensor_msgs/msg/LaserScan",
       schemaEncoding: "ros2msg",
     });
+    const markers = createTopic("/markers", ROS_MARKER_ARRAY_PAYLOADS[1]);
 
     expect(isCompressedImageStream(compressed)).toBe(true);
     expect(isCompressedImageStream(rawImage)).toBe(false);
@@ -1083,10 +1240,14 @@ describe("ROS MCAP decoders", () => {
     expect(
       isGridStream(createTopic("/map", ROS_OCCUPANCY_GRID_PAYLOADS[0])),
     ).toBe(true);
-    expect(streamTopics([compressed, rawImage, cloud, scan])).toMatchObject({
+    expect(isSceneUpdateStream(markers)).toBe(true);
+    expect(
+      streamTopics([compressed, rawImage, cloud, scan, markers]),
+    ).toMatchObject({
       image: ["/camera/compressed", "/camera/image"],
       pointCloud: ["/points", "/scan"],
       previewable: ["/camera/compressed", "/camera/image", "/points", "/scan"],
+      sceneUpdates: ["/markers"],
     });
   });
 });
@@ -1343,6 +1504,65 @@ function vectorRecord(vector: readonly [number, number, number]) {
     x: vector[0],
     y: vector[1],
     z: vector[2],
+  };
+}
+
+function markerRecord({
+  action = 0,
+  color = colorRecord([1, 1, 1, 1]),
+  colors = [],
+  frameLocked = false,
+  id,
+  lifetime = { nanosec: 0, sec: 0 },
+  meshResource = "",
+  meshUseEmbeddedMaterials = false,
+  ns,
+  points = [],
+  pose = poseRecord([0, 0, 0], [0, 0, 0, 1]),
+  scale = vectorRecord([1, 1, 1]),
+  text = "",
+  type,
+}: {
+  readonly action?: number;
+  readonly color?: ReturnType<typeof colorRecord>;
+  readonly colors?: readonly ReturnType<typeof colorRecord>[];
+  readonly frameLocked?: boolean;
+  readonly id: number;
+  readonly lifetime?: { readonly nanosec: number; readonly sec: number };
+  readonly meshResource?: string;
+  readonly meshUseEmbeddedMaterials?: boolean;
+  readonly ns: string;
+  readonly points?: readonly ReturnType<typeof vectorRecord>[];
+  readonly pose?: ReturnType<typeof poseRecord>;
+  readonly scale?: ReturnType<typeof vectorRecord>;
+  readonly text?: string;
+  readonly type: number;
+}) {
+  return {
+    action,
+    color,
+    colors,
+    frame_locked: frameLocked,
+    header: ros2Header({ frameId: "map", nanosec: 22, sec: 21 }),
+    id,
+    lifetime,
+    mesh_resource: meshResource,
+    mesh_use_embedded_materials: meshUseEmbeddedMaterials,
+    ns,
+    points,
+    pose,
+    scale,
+    text,
+    type,
+  };
+}
+
+function colorRecord(color: readonly [number, number, number, number]) {
+  return {
+    a: color[3],
+    b: color[2],
+    g: color[1],
+    r: color[0],
   };
 }
 

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/common.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/common.ts
@@ -2,6 +2,15 @@ import type {
   DecodeContext,
   DecodedAttributeValue,
   PayloadDescriptor,
+  SceneArrowPrimitive,
+  SceneCubePrimitive,
+  SceneCylinderPrimitive,
+  SceneEntityVisualization,
+  SceneLinePrimitive,
+  SceneModelPrimitive,
+  SceneSpherePrimitive,
+  SceneTextPrimitive,
+  SceneTrianglePrimitive,
 } from "../../../../decoders";
 import { optionalBigInt, optionalString } from "../foxglove/protobuf/records";
 import { timingFromContext } from "../foxglove/protobuf/timing";
@@ -87,6 +96,26 @@ export function arrayField(
   }
 
   return value;
+}
+
+/**
+ * Reads an array field as records, replacing malformed entries with empty
+ * records so message-level degradation stays local to the entry.
+ */
+export function arrayRecords(
+  record: Record<string, unknown>,
+  field: string,
+): readonly Record<string, unknown>[] {
+  return arrayField(record, field).map((value) =>
+    isRecord(value) ? value : {},
+  );
+}
+
+/**
+ * Type guard for plain record-shaped values.
+ */
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
 /**
@@ -308,6 +337,66 @@ export function stringField(
 ): string {
   const value = record[field];
   return typeof value === "string" ? value : fallback;
+}
+
+/**
+ * Builds a SceneEntityVisualization with the shared default primitive fields.
+ */
+export function sceneEntityVisualization({
+  arrows = [],
+  cubes = [],
+  cylinders = [],
+  frameId,
+  frameLocked = false,
+  id,
+  lifetimeNs,
+  lines = [],
+  metadata = {},
+  models = [],
+  spheres = [],
+  texts = [],
+  timestampNs,
+  triangles = [],
+}: {
+  readonly arrows?: readonly SceneArrowPrimitive[];
+  readonly cubes?: readonly SceneCubePrimitive[];
+  readonly cylinders?: readonly SceneCylinderPrimitive[];
+  readonly frameId?: string | undefined;
+  readonly frameLocked?: boolean;
+  readonly id: string;
+  readonly lifetimeNs?: bigint | undefined;
+  readonly lines?: readonly SceneLinePrimitive[];
+  readonly metadata?: Readonly<Record<string, string>>;
+  readonly models?: readonly SceneModelPrimitive[];
+  readonly spheres?: readonly SceneSpherePrimitive[];
+  readonly texts?: readonly SceneTextPrimitive[];
+  readonly timestampNs?: bigint | undefined;
+  readonly triangles?: readonly SceneTrianglePrimitive[];
+}): SceneEntityVisualization {
+  return {
+    arrowCount: arrows.length,
+    arrows,
+    cubeCount: cubes.length,
+    cubes,
+    cylinderCount: cylinders.length,
+    cylinders,
+    ...(frameId ? { frameId } : {}),
+    frameLocked,
+    id,
+    lineCount: lines.length,
+    lines,
+    ...(lifetimeNs !== undefined ? { lifetimeNs } : {}),
+    metadata,
+    modelCount: models.length,
+    models,
+    sphereCount: spheres.length,
+    spheres,
+    textCount: texts.length,
+    texts,
+    ...(timestampNs !== undefined ? { timestampNs } : {}),
+    triangleCount: triangles.length,
+    triangles,
+  };
 }
 
 function firstBigInt(

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/factory.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/factory.ts
@@ -9,6 +9,7 @@ import { decodeRosMessage } from "./common";
 type RosMapper = (
   record: Record<string, unknown>,
   context: DecodeContext,
+  bytes: Uint8Array,
 ) => DecodedOutput;
 
 /**
@@ -28,7 +29,7 @@ export function rosDecodersForPayloads({
     payload,
     version: "1",
     decode(bytes, context) {
-      return map(decodeRosMessage(bytes, payload, context), context);
+      return map(decodeRosMessage(bytes, payload, context), context, bytes);
     },
   }));
 }

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/index.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/index.ts
@@ -7,6 +7,7 @@ import { rosMarkerArrayDecoders, rosMarkerDecoders } from "./marker";
 import { rosNavSatFixDecoders } from "./nav-sat-fix";
 import { rosOccupancyGridDecoders } from "./occupancy-grid";
 import { rosOdometryDecoders, rosPoseStampedDecoders } from "./pose";
+import { rosPathDecoders, rosPoseArrayDecoders } from "./path";
 import { rosPointCloud2Decoders } from "./point-cloud2";
 
 export { rosCameraInfoDecoders } from "./camera-info";
@@ -17,6 +18,7 @@ export { rosMarkerArrayDecoders, rosMarkerDecoders } from "./marker";
 export { rosNavSatFixDecoders } from "./nav-sat-fix";
 export { rosOccupancyGridDecoders } from "./occupancy-grid";
 export { rosOdometryDecoders, rosPoseStampedDecoders } from "./pose";
+export { rosPathDecoders, rosPoseArrayDecoders } from "./path";
 export { rosPointCloud2Decoders } from "./point-cloud2";
 export * from "./payloads";
 
@@ -33,6 +35,8 @@ export const rosDecoders: readonly Decoder[] = [
   ...rosNavSatFixDecoders,
   ...rosOccupancyGridDecoders,
   ...rosOdometryDecoders,
+  ...rosPathDecoders,
+  ...rosPoseArrayDecoders,
   ...rosPoseStampedDecoders,
   ...rosPointCloud2Decoders,
 ];

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/index.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/index.ts
@@ -3,6 +3,7 @@ import { rosCameraInfoDecoders } from "./camera-info";
 import { rosCompressedImageDecoders } from "./compressed-image";
 import { rosImageDecoders } from "./image";
 import { rosLaserScanDecoders } from "./laser-scan";
+import { rosMarkerArrayDecoders, rosMarkerDecoders } from "./marker";
 import { rosNavSatFixDecoders } from "./nav-sat-fix";
 import { rosOccupancyGridDecoders } from "./occupancy-grid";
 import { rosOdometryDecoders, rosPoseStampedDecoders } from "./pose";
@@ -12,6 +13,7 @@ export { rosCameraInfoDecoders } from "./camera-info";
 export { rosCompressedImageDecoders } from "./compressed-image";
 export { rosImageDecoders } from "./image";
 export { rosLaserScanDecoders } from "./laser-scan";
+export { rosMarkerArrayDecoders, rosMarkerDecoders } from "./marker";
 export { rosNavSatFixDecoders } from "./nav-sat-fix";
 export { rosOccupancyGridDecoders } from "./occupancy-grid";
 export { rosOdometryDecoders, rosPoseStampedDecoders } from "./pose";
@@ -26,6 +28,8 @@ export const rosDecoders: readonly Decoder[] = [
   ...rosCompressedImageDecoders,
   ...rosImageDecoders,
   ...rosLaserScanDecoders,
+  ...rosMarkerDecoders,
+  ...rosMarkerArrayDecoders,
   ...rosNavSatFixDecoders,
   ...rosOccupancyGridDecoders,
   ...rosOdometryDecoders,

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/index.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/index.ts
@@ -3,6 +3,11 @@ import { rosCameraInfoDecoders } from "./camera-info";
 import { rosCompressedImageDecoders } from "./compressed-image";
 import { rosImageDecoders } from "./image";
 import { rosLaserScanDecoders } from "./laser-scan";
+import {
+  rosDiagnosticArrayDecoders,
+  rosRclLogDecoders,
+  rosRosgraphLogDecoders,
+} from "./log";
 import { rosMarkerArrayDecoders, rosMarkerDecoders } from "./marker";
 import { rosNavSatFixDecoders } from "./nav-sat-fix";
 import { rosOccupancyGridDecoders } from "./occupancy-grid";
@@ -18,6 +23,11 @@ export { rosCameraInfoDecoders } from "./camera-info";
 export { rosCompressedImageDecoders } from "./compressed-image";
 export { rosImageDecoders } from "./image";
 export { rosLaserScanDecoders } from "./laser-scan";
+export {
+  rosDiagnosticArrayDecoders,
+  rosRclLogDecoders,
+  rosRosgraphLogDecoders,
+} from "./log";
 export { rosMarkerArrayDecoders, rosMarkerDecoders } from "./marker";
 export { rosNavSatFixDecoders } from "./nav-sat-fix";
 export { rosOccupancyGridDecoders } from "./occupancy-grid";
@@ -38,6 +48,9 @@ export const rosDecoders: readonly Decoder[] = [
   ...rosCompressedImageDecoders,
   ...rosImageDecoders,
   ...rosLaserScanDecoders,
+  ...rosRosgraphLogDecoders,
+  ...rosRclLogDecoders,
+  ...rosDiagnosticArrayDecoders,
   ...rosMarkerDecoders,
   ...rosMarkerArrayDecoders,
   ...rosNavSatFixDecoders,

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/index.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/index.ts
@@ -9,6 +9,10 @@ import { rosOccupancyGridDecoders } from "./occupancy-grid";
 import { rosOdometryDecoders, rosPoseStampedDecoders } from "./pose";
 import { rosPathDecoders, rosPoseArrayDecoders } from "./path";
 import { rosPointCloud2Decoders } from "./point-cloud2";
+import {
+  rosDetection2DArrayDecoders,
+  rosDetection3DArrayDecoders,
+} from "./vision";
 
 export { rosCameraInfoDecoders } from "./camera-info";
 export { rosCompressedImageDecoders } from "./compressed-image";
@@ -20,6 +24,10 @@ export { rosOccupancyGridDecoders } from "./occupancy-grid";
 export { rosOdometryDecoders, rosPoseStampedDecoders } from "./pose";
 export { rosPathDecoders, rosPoseArrayDecoders } from "./path";
 export { rosPointCloud2Decoders } from "./point-cloud2";
+export {
+  rosDetection2DArrayDecoders,
+  rosDetection3DArrayDecoders,
+} from "./vision";
 export * from "./payloads";
 
 /**
@@ -39,4 +47,6 @@ export const rosDecoders: readonly Decoder[] = [
   ...rosPoseArrayDecoders,
   ...rosPoseStampedDecoders,
   ...rosPointCloud2Decoders,
+  ...rosDetection2DArrayDecoders,
+  ...rosDetection3DArrayDecoders,
 ];

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/log.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/log.ts
@@ -135,10 +135,11 @@ function logOutputAttributes(
   row: McapDecodedLogRow,
   base: Record<string, DecodedAttributeValue> = {},
 ): Record<string, DecodedAttributeValue> {
+  const rows = logRowsAttribute([row]);
   return {
     ...base,
-    ...logRowsAttribute([row])[0],
-    [MCAP_LOG_ATTRIBUTE_ROWS]: logRowsAttribute([row]),
+    ...rows[0],
+    [MCAP_LOG_ATTRIBUTE_ROWS]: rows,
   };
 }
 
@@ -146,7 +147,7 @@ function diagnosticStatusRow(
   status: Record<string, unknown>,
   timestampNs: bigint | undefined,
 ): McapDecodedLogRow {
-  const levelNumber = numberField(status, "level", undefined, 0);
+  const levelNumber = numberValue(status.level);
   const statusName = diagnosticStatusName(levelNumber);
   const name = optionalString(status, "name");
   const message = optionalString(status, "message") ?? statusName;
@@ -157,11 +158,11 @@ function diagnosticStatusRow(
     hardwareId,
     kind: "diagnostic",
     level: diagnosticLogLevel(levelNumber),
-    levelNumber,
     message,
     name,
     status: statusName,
     timestampNs,
+    ...(levelNumber !== undefined ? { levelNumber } : {}),
   };
 }
 
@@ -223,14 +224,14 @@ function rclLogLevel(level: number) {
   return MCAP_LOG_LEVEL.UNKNOWN;
 }
 
-function diagnosticLogLevel(level: number) {
+function diagnosticLogLevel(level: number | undefined) {
   if (level === 2) return MCAP_LOG_LEVEL.ERROR;
   if (level === 1 || level === 3) return MCAP_LOG_LEVEL.WARN;
   if (level === 0) return MCAP_LOG_LEVEL.INFO;
   return MCAP_LOG_LEVEL.UNKNOWN;
 }
 
-function diagnosticStatusName(level: number): string {
+function diagnosticStatusName(level: number | undefined): string {
   switch (level) {
     case 0:
       return "OK";

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/log.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/log.ts
@@ -1,0 +1,293 @@
+import type {
+  DecodeContext,
+  DecodedAttributeValue,
+  DecodedOutput,
+} from "../../../../decoders";
+import {
+  MCAP_LOG_ATTRIBUTE_ROWS,
+  MCAP_LOG_LEVEL,
+  type McapDecodedLogRow,
+  logRowsAttribute,
+} from "../../log-records";
+import { optionalString } from "../foxglove/protobuf/records";
+import { timingFromContext } from "../foxglove/protobuf/timing";
+import {
+  arrayField,
+  numberField,
+  recordField,
+  rosHeader,
+  rosHeaderAttributes,
+  rosHeaderTimestampNs,
+  rosTimestampNs,
+  timingFromRosHeader,
+} from "./common";
+import { rosDecodersForPayloads } from "./factory";
+import {
+  ROS_DIAGNOSTIC_ARRAY_PAYLOADS,
+  ROS_RCL_LOG_PAYLOADS,
+  ROS_ROSGRAPH_LOG_PAYLOADS,
+} from "./payloads";
+
+/**
+ * Decoders for ROS1 rosgraph_msgs/Log messages.
+ */
+export const rosRosgraphLogDecoders = rosDecodersForPayloads({
+  id: "ros.rosgraph-log",
+  map: decodeRosgraphLogRecord,
+  payloads: ROS_ROSGRAPH_LOG_PAYLOADS,
+});
+
+/**
+ * Decoders for ROS2 rcl_interfaces/msg/Log messages.
+ */
+export const rosRclLogDecoders = rosDecodersForPayloads({
+  id: "ros.rcl-log",
+  map: decodeRclLogRecord,
+  payloads: ROS_RCL_LOG_PAYLOADS,
+});
+
+/**
+ * Decoders for ROS diagnostic_msgs/(msg/)DiagnosticArray messages.
+ */
+export const rosDiagnosticArrayDecoders = rosDecodersForPayloads({
+  id: "ros.diagnostic-array",
+  map: decodeDiagnosticArrayRecord,
+  payloads: ROS_DIAGNOSTIC_ARRAY_PAYLOADS,
+});
+
+export function decodeRosgraphLogRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+): DecodedOutput {
+  const header = rosHeader(message);
+  const timestampNs = rosHeaderTimestampNs(header);
+  const levelNumber = numberField(message, "level", undefined, 0);
+  const row: McapDecodedLogRow = {
+    file: optionalString(message, "file"),
+    functionName: optionalString(message, "function"),
+    kind: "log",
+    level: rosgraphLogLevel(levelNumber),
+    levelNumber,
+    line: positiveNumberField(message, "line"),
+    message: optionalString(message, "msg") ?? "",
+    name: optionalString(message, "name"),
+    timestampNs,
+    topics: stringArrayField(message, "topics"),
+  };
+
+  return {
+    attributes: logOutputAttributes(row, rosHeaderAttributes(header)),
+    timing: timingFromRosHeader(context, header),
+  };
+}
+
+export function decodeRclLogRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+): DecodedOutput {
+  const timestampNs = rosTimestampNs(recordField(message, "stamp"));
+  const levelNumber = numberField(message, "level", undefined, 0);
+  const row: McapDecodedLogRow = {
+    file: optionalString(message, "file"),
+    functionName: optionalString(message, "function"),
+    kind: "log",
+    level: rclLogLevel(levelNumber),
+    levelNumber,
+    line: positiveNumberField(message, "line"),
+    message: optionalString(message, "msg") ?? "",
+    name: optionalString(message, "name"),
+    timestampNs,
+  };
+
+  return {
+    attributes: logOutputAttributes(row),
+    timing: timingFromContext(context, timestampNs),
+  };
+}
+
+export function decodeDiagnosticArrayRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+): DecodedOutput {
+  const header = rosHeader(message);
+  const timestampNs = rosHeaderTimestampNs(header);
+  const rows = arrayField(message, "status")
+    .map(asRecord)
+    .filter(isRecord)
+    .map((status) => diagnosticStatusRow(status, timestampNs));
+  const counts = diagnosticCounts(rows);
+
+  return {
+    attributes: {
+      ...rosHeaderAttributes(header),
+      [MCAP_LOG_ATTRIBUTE_ROWS]: logRowsAttribute(rows),
+      diagnosticCount: rows.length,
+      errorCount: counts.error,
+      okCount: counts.ok,
+      staleCount: counts.stale,
+      warnCount: counts.warn,
+    },
+    timing: timingFromRosHeader(context, header),
+  };
+}
+
+function logOutputAttributes(
+  row: McapDecodedLogRow,
+  base: Record<string, DecodedAttributeValue> = {},
+): Record<string, DecodedAttributeValue> {
+  return {
+    ...base,
+    ...logRowsAttribute([row])[0],
+    [MCAP_LOG_ATTRIBUTE_ROWS]: logRowsAttribute([row]),
+  };
+}
+
+function diagnosticStatusRow(
+  status: Record<string, unknown>,
+  timestampNs: bigint | undefined,
+): McapDecodedLogRow {
+  const levelNumber = numberField(status, "level", undefined, 0);
+  const statusName = diagnosticStatusName(levelNumber);
+  const name = optionalString(status, "name");
+  const message = optionalString(status, "message") ?? statusName;
+  const hardwareId = optionalString(status, "hardware_id", "hardwareId");
+
+  return {
+    details: diagnosticDetails(status),
+    hardwareId,
+    kind: "diagnostic",
+    level: diagnosticLogLevel(levelNumber),
+    levelNumber,
+    message,
+    name,
+    status: statusName,
+    timestampNs,
+  };
+}
+
+function diagnosticDetails(
+  status: Record<string, unknown>,
+): readonly { readonly key: string; readonly value: string }[] {
+  return arrayField(status, "values")
+    .map(asRecord)
+    .filter(isRecord)
+    .map((value) => ({
+      key: optionalString(value, "key") ?? "",
+      value: stringValue(value["value"]) ?? "",
+    }))
+    .filter((value) => value.key || value.value);
+}
+
+function diagnosticCounts(rows: readonly McapDecodedLogRow[]) {
+  const counts = {
+    error: 0,
+    ok: 0,
+    stale: 0,
+    warn: 0,
+  };
+  for (const row of rows) {
+    switch (row.status) {
+      case "ERROR":
+        counts.error += 1;
+        break;
+      case "STALE":
+        counts.stale += 1;
+        break;
+      case "WARN":
+        counts.warn += 1;
+        break;
+      case "OK":
+        counts.ok += 1;
+        break;
+    }
+  }
+
+  return counts;
+}
+
+function rosgraphLogLevel(level: number) {
+  if ((level & 16) !== 0) return MCAP_LOG_LEVEL.FATAL;
+  if ((level & 8) !== 0) return MCAP_LOG_LEVEL.ERROR;
+  if ((level & 4) !== 0) return MCAP_LOG_LEVEL.WARN;
+  if ((level & 2) !== 0) return MCAP_LOG_LEVEL.INFO;
+  if ((level & 1) !== 0) return MCAP_LOG_LEVEL.DEBUG;
+  return MCAP_LOG_LEVEL.UNKNOWN;
+}
+
+function rclLogLevel(level: number) {
+  if (level >= 50) return MCAP_LOG_LEVEL.FATAL;
+  if (level >= 40) return MCAP_LOG_LEVEL.ERROR;
+  if (level >= 30) return MCAP_LOG_LEVEL.WARN;
+  if (level >= 20) return MCAP_LOG_LEVEL.INFO;
+  if (level >= 10) return MCAP_LOG_LEVEL.DEBUG;
+  return MCAP_LOG_LEVEL.UNKNOWN;
+}
+
+function diagnosticLogLevel(level: number) {
+  if (level === 2) return MCAP_LOG_LEVEL.ERROR;
+  if (level === 1 || level === 3) return MCAP_LOG_LEVEL.WARN;
+  if (level === 0) return MCAP_LOG_LEVEL.INFO;
+  return MCAP_LOG_LEVEL.UNKNOWN;
+}
+
+function diagnosticStatusName(level: number): string {
+  switch (level) {
+    case 0:
+      return "OK";
+    case 1:
+      return "WARN";
+    case 2:
+      return "ERROR";
+    case 3:
+      return "STALE";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+function positiveNumberField(
+  record: Record<string, unknown>,
+  field: string,
+): number | undefined {
+  const value = numberValue(record[field]);
+  return value !== undefined && value > 0 ? value : undefined;
+}
+
+function stringArrayField(
+  record: Record<string, unknown>,
+  field: string,
+): readonly string[] | undefined {
+  const values = arrayField(record, field).filter(
+    (value): value is string => typeof value === "string" && value.length > 0,
+  );
+  return values.length > 0 ? values : undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function isRecord(
+  value: Record<string, unknown> | null,
+): value is Record<string, unknown> {
+  return value !== null;
+}
+
+function stringValue(value: unknown): string | undefined {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+  return undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "bigint") return Number(value);
+  return undefined;
+}

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/marker.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/marker.ts
@@ -441,14 +441,15 @@ function markerArrows({
     totalLength,
     positiveOr(scale[2], totalLength * DEFAULT_ARROW_HEAD_FRACTION),
   );
+  const headDiameter = positiveOr(scale[1], 0.2);
 
   return [
     {
       color,
-      headDiameter: positiveOr(scale[1], 0.2),
+      headDiameter,
       headLength,
       pose,
-      shaftDiameter: positiveOr(scale[1], 0.1),
+      shaftDiameter: headDiameter * 0.5,
       shaftLength: Math.max(0, totalLength - headLength),
     },
   ];

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/marker.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/marker.ts
@@ -1,0 +1,722 @@
+import { Quaternion, Vector3 } from "three";
+
+import type {
+  DecodeContext,
+  DecodedAttributeValue,
+  DecodedOutput,
+  RgbaColor,
+  SceneArrowPrimitive,
+  SceneCubePrimitive,
+  SceneCylinderPrimitive,
+  SceneEntityDeletionKind,
+  SceneEntityDeletionVisualization,
+  SceneEntityVisualization,
+  SceneLinePrimitive,
+  SceneLinePrimitiveKind,
+  SceneModelPrimitive,
+  ScenePoint3D,
+  ScenePose3D,
+  SceneSpherePrimitive,
+  SceneTextPrimitive,
+  SceneTrianglePrimitive,
+} from "../../../../decoders";
+import { VISUALIZATION_KIND } from "../../../../visualization";
+import {
+  decodePose,
+  decodeQuaternion,
+  decodeVector3,
+  IDENTITY_QUATERNION,
+  ZERO_VECTOR3,
+} from "../foxglove/protobuf/geometry";
+import {
+  arrayField,
+  numberField,
+  recordField,
+  rosHeader,
+  rosHeaderFrameId,
+  rosHeaderTimestampNs,
+  rosTimestampNs,
+  stringField,
+  timingFromRosHeader,
+} from "./common";
+import { rosDecodersForPayloads } from "./factory";
+import { ROS_MARKER_ARRAY_PAYLOADS, ROS_MARKER_PAYLOADS } from "./payloads";
+
+const MARKER_TYPE = {
+  ARROW: 0,
+  CUBE: 1,
+  SPHERE: 2,
+  CYLINDER: 3,
+  LINE_STRIP: 4,
+  LINE_LIST: 5,
+  CUBE_LIST: 6,
+  SPHERE_LIST: 7,
+  POINTS: 8,
+  TEXT_VIEW_FACING: 9,
+  MESH_RESOURCE: 10,
+  TRIANGLE_LIST: 11,
+} as const;
+
+const MARKER_ACTION = {
+  ADD: 0,
+  DELETE: 2,
+  DELETEALL: 3,
+} as const;
+
+const MARKER_TYPE_BY_NAME: Readonly<Record<string, number>> = {
+  ARROW: MARKER_TYPE.ARROW,
+  CUBE: MARKER_TYPE.CUBE,
+  CUBE_LIST: MARKER_TYPE.CUBE_LIST,
+  CYLINDER: MARKER_TYPE.CYLINDER,
+  LINE_LIST: MARKER_TYPE.LINE_LIST,
+  LINE_STRIP: MARKER_TYPE.LINE_STRIP,
+  MESH_RESOURCE: MARKER_TYPE.MESH_RESOURCE,
+  POINTS: MARKER_TYPE.POINTS,
+  SPHERE: MARKER_TYPE.SPHERE,
+  SPHERE_LIST: MARKER_TYPE.SPHERE_LIST,
+  TEXT_VIEW_FACING: MARKER_TYPE.TEXT_VIEW_FACING,
+  TRIANGLE_LIST: MARKER_TYPE.TRIANGLE_LIST,
+};
+
+const MARKER_ACTION_BY_NAME: Readonly<Record<string, number>> = {
+  ADD: MARKER_ACTION.ADD,
+  DELETE: MARKER_ACTION.DELETE,
+  DELETEALL: MARKER_ACTION.DELETEALL,
+  MODIFY: MARKER_ACTION.ADD,
+};
+
+const DEFAULT_LINE_THICKNESS = 1;
+const DEFAULT_POINT_SIZE = 0.1;
+const DEFAULT_ARROW_HEAD_FRACTION = 0.2;
+const MAX_POINT_MARKER_SPHERES = 512;
+
+interface MarkerDecodeStats {
+  readonly transparentMarkers: number;
+  readonly unsupportedTypes: readonly string[];
+}
+
+interface MarkerEntityResult {
+  readonly entity?: SceneEntityVisualization;
+  readonly unsupportedType?: string;
+}
+
+/**
+ * Decoders for ROS visualization Marker messages.
+ */
+export const rosMarkerDecoders = rosDecodersForPayloads({
+  id: "ros.marker",
+  map: decodeRosMarkerRecord,
+  payloads: ROS_MARKER_PAYLOADS,
+});
+
+/**
+ * Decoders for ROS visualization MarkerArray messages.
+ */
+export const rosMarkerArrayDecoders = rosDecodersForPayloads({
+  id: "ros.marker-array",
+  map: decodeRosMarkerArrayRecord,
+  payloads: ROS_MARKER_ARRAY_PAYLOADS,
+});
+
+/**
+ * Normalizes one ROS Marker into a SceneUpdate delta.
+ */
+export function decodeRosMarkerRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+): DecodedOutput {
+  return markerOutput([message], context);
+}
+
+/**
+ * Normalizes one ROS MarkerArray into a SceneUpdate delta.
+ */
+export function decodeRosMarkerArrayRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+): DecodedOutput {
+  return markerOutput(
+    arrayField(message, "markers").map((marker) =>
+      recordField({ marker }, "marker"),
+    ),
+    context,
+  );
+}
+
+function markerOutput(
+  markers: readonly (Record<string, unknown> | undefined)[],
+  context: DecodeContext,
+): DecodedOutput {
+  const entities: SceneEntityVisualization[] = [];
+  const deletions: SceneEntityDeletionVisualization[] = [];
+  const unsupportedTypes: string[] = [];
+  let transparentMarkers = 0;
+
+  for (const marker of markers) {
+    if (!marker) {
+      continue;
+    }
+
+    const action = markerAction(marker["action"]);
+    if (action === MARKER_ACTION.DELETE || action === MARKER_ACTION.DELETEALL) {
+      deletions.push(deletionForMarker(marker, context, action));
+      continue;
+    }
+
+    if (markerAlpha(marker) <= 0) {
+      transparentMarkers += 1;
+    }
+
+    const result = entityForMarker(marker, context);
+    if (result.entity) {
+      entities.push(result.entity);
+    }
+    if (result.unsupportedType) {
+      unsupportedTypes.push(result.unsupportedType);
+    }
+  }
+
+  const stats: MarkerDecodeStats = {
+    transparentMarkers,
+    unsupportedTypes,
+  };
+
+  return {
+    attributes: markerAttributes(markers.length, entities, deletions, stats),
+    timing: markerTiming(context, markers),
+    visualization: {
+      deletions,
+      entities,
+      kind: VISUALIZATION_KIND.SCENE_UPDATE,
+    },
+  };
+}
+
+function deletionForMarker(
+  marker: Record<string, unknown>,
+  context: DecodeContext,
+  action: number,
+): SceneEntityDeletionVisualization {
+  const timestampNs = markerTimestampNs(marker);
+  const type: SceneEntityDeletionKind =
+    action === MARKER_ACTION.DELETEALL ? "all" : "matching-id";
+
+  return {
+    id: type === "all" ? "" : markerEntityId(marker, context),
+    ...(timestampNs !== undefined ? { timestampNs } : {}),
+    type,
+  };
+}
+
+function entityForMarker(
+  marker: Record<string, unknown>,
+  context: DecodeContext,
+): MarkerEntityResult {
+  const markerType = markerTypeValue(marker["type"]);
+  const color = markerColor(marker);
+  const colors = markerColors(marker);
+  const pose = markerPose(marker);
+  const points = markerPoints(marker);
+  const scale = markerScale(marker);
+  const metadata = markerMetadata(marker, markerType);
+
+  const base = {
+    arrows: [] as SceneArrowPrimitive[],
+    cubes: [] as SceneCubePrimitive[],
+    cylinders: [] as SceneCylinderPrimitive[],
+    lines: [] as SceneLinePrimitive[],
+    models: [] as SceneModelPrimitive[],
+    spheres: [] as SceneSpherePrimitive[],
+    texts: [] as SceneTextPrimitive[],
+    triangles: [] as SceneTrianglePrimitive[],
+  };
+  let unsupportedType: string | undefined;
+
+  switch (markerType) {
+    case MARKER_TYPE.ARROW:
+      base.arrows.push(...markerArrows({ color, points, pose, scale }));
+      break;
+    case MARKER_TYPE.CUBE:
+      base.cubes.push({ color, pose, size: scale });
+      break;
+    case MARKER_TYPE.SPHERE:
+      base.spheres.push({ color, pose, size: scale });
+      break;
+    case MARKER_TYPE.CYLINDER:
+      base.cylinders.push({
+        bottomScale: 1,
+        color,
+        pose,
+        size: scale,
+        topScale: 1,
+      });
+      break;
+    case MARKER_TYPE.LINE_STRIP:
+      base.lines.push(
+        markerLine({
+          color,
+          colors,
+          points,
+          pose,
+          scale,
+          type: "line-strip",
+        }),
+      );
+      break;
+    case MARKER_TYPE.LINE_LIST:
+      base.lines.push(
+        markerLine({
+          color,
+          colors,
+          points,
+          pose,
+          scale,
+          type: "line-list",
+        }),
+      );
+      break;
+    case MARKER_TYPE.CUBE_LIST:
+      base.cubes.push(
+        ...points.map((point, index) => ({
+          color: colors[index] ?? color,
+          pose: composeMarkerPointPose(pose, point),
+          size: scale,
+        })),
+      );
+      break;
+    case MARKER_TYPE.SPHERE_LIST:
+      base.spheres.push(
+        ...points.map((point, index) => ({
+          color: colors[index] ?? color,
+          pose: composeMarkerPointPose(pose, point),
+          size: scale,
+        })),
+      );
+      break;
+    case MARKER_TYPE.POINTS:
+      if (points.length <= MAX_POINT_MARKER_SPHERES) {
+        base.spheres.push(
+          ...points.map((point, index) => ({
+            color: colors[index] ?? color,
+            pose: composeMarkerPointPose(pose, point),
+            size: markerPointSize(scale),
+          })),
+        );
+      } else {
+        unsupportedType = `POINTS(${points.length})`;
+      }
+      break;
+    case MARKER_TYPE.TEXT_VIEW_FACING:
+      base.texts.push({
+        billboard: true,
+        color,
+        fontSize: positiveOr(scale[2], 1),
+        pose,
+        scaleInvariant: false,
+        text: stringField(marker, "text"),
+      });
+      break;
+    case MARKER_TYPE.MESH_RESOURCE: {
+      const model = markerModel(marker, color, pose, scale);
+      if (model) {
+        base.models.push(model);
+      } else {
+        unsupportedType = "MESH_RESOURCE";
+      }
+      break;
+    }
+    case MARKER_TYPE.TRIANGLE_LIST:
+      base.triangles.push({
+        color,
+        colors,
+        indices: [],
+        points,
+        pose,
+      });
+      break;
+    default:
+      unsupportedType = `type:${String(marker["type"])}`;
+      break;
+  }
+
+  const primitiveCount =
+    base.arrows.length +
+    base.cubes.length +
+    base.cylinders.length +
+    base.lines.length +
+    base.models.length +
+    base.spheres.length +
+    base.texts.length +
+    base.triangles.length;
+  if (primitiveCount === 0) {
+    return { ...(unsupportedType ? { unsupportedType } : {}) };
+  }
+
+  const header = rosHeader(marker);
+  const frameId = rosHeaderFrameId(header);
+  const lifetimeNs = rosTimestampNs(recordField(marker, "lifetime"));
+  const timestampNs = markerTimestampNs(marker);
+
+  const entity: SceneEntityVisualization = {
+    arrowCount: base.arrows.length,
+    arrows: base.arrows,
+    cubeCount: base.cubes.length,
+    cubes: base.cubes,
+    cylinderCount: base.cylinders.length,
+    cylinders: base.cylinders,
+    ...(frameId ? { frameId } : {}),
+    frameLocked: booleanField(marker, "frame_locked", "frameLocked"),
+    id: markerEntityId(marker, context),
+    lineCount: base.lines.length,
+    lines: base.lines,
+    ...(lifetimeNs !== undefined ? { lifetimeNs } : {}),
+    metadata,
+    modelCount: base.models.length,
+    models: base.models,
+    sphereCount: base.spheres.length,
+    spheres: base.spheres,
+    textCount: base.texts.length,
+    texts: base.texts,
+    ...(timestampNs !== undefined ? { timestampNs } : {}),
+    triangleCount: base.triangles.length,
+    triangles: base.triangles,
+  };
+
+  return {
+    entity,
+    ...(unsupportedType ? { unsupportedType } : {}),
+  };
+}
+
+function markerArrows({
+  color,
+  points,
+  pose,
+  scale,
+}: {
+  readonly color: RgbaColor | null;
+  readonly points: readonly ScenePoint3D[];
+  readonly pose: ScenePose3D;
+  readonly scale: ScenePoint3D;
+}): readonly SceneArrowPrimitive[] {
+  if (points.length >= 2) {
+    const start = transformPointByPose(pose, points[0]);
+    const end = transformPointByPose(pose, points[1]);
+    const delta = new Vector3(
+      end[0] - start[0],
+      end[1] - start[1],
+      end[2] - start[2],
+    );
+    const length = delta.length();
+    if (!Number.isFinite(length) || length <= 0) {
+      return [];
+    }
+    const headLength = positiveOr(
+      scale[2],
+      length * DEFAULT_ARROW_HEAD_FRACTION,
+    );
+    const shaftLength = Math.max(0, length - headLength);
+    const quaternion = new Quaternion().setFromUnitVectors(
+      new Vector3(1, 0, 0),
+      delta.normalize(),
+    );
+
+    return [
+      {
+        color,
+        headDiameter: positiveOr(scale[1], positiveOr(scale[0], 0.1) * 2),
+        headLength,
+        pose: {
+          position: start,
+          quaternion: [quaternion.x, quaternion.y, quaternion.z, quaternion.w],
+        },
+        shaftDiameter: positiveOr(scale[0], 0.05),
+        shaftLength,
+      },
+    ];
+  }
+
+  const totalLength = positiveOr(scale[0], 1);
+  const headLength = Math.min(
+    totalLength,
+    positiveOr(scale[2], totalLength * DEFAULT_ARROW_HEAD_FRACTION),
+  );
+
+  return [
+    {
+      color,
+      headDiameter: positiveOr(scale[1], 0.2),
+      headLength,
+      pose,
+      shaftDiameter: positiveOr(scale[1], 0.1),
+      shaftLength: Math.max(0, totalLength - headLength),
+    },
+  ];
+}
+
+function markerLine({
+  color,
+  colors,
+  points,
+  pose,
+  scale,
+  type,
+}: {
+  readonly color: RgbaColor | null;
+  readonly colors: readonly RgbaColor[];
+  readonly points: readonly ScenePoint3D[];
+  readonly pose: ScenePose3D;
+  readonly scale: ScenePoint3D;
+  readonly type: SceneLinePrimitiveKind;
+}): SceneLinePrimitive {
+  return {
+    color,
+    colors,
+    indices: [],
+    points,
+    pose,
+    scaleInvariant: false,
+    thickness: positiveOr(scale[0], DEFAULT_LINE_THICKNESS),
+    type,
+  };
+}
+
+function markerModel(
+  marker: Record<string, unknown>,
+  color: RgbaColor | null,
+  pose: ScenePose3D,
+  scale: ScenePoint3D,
+): SceneModelPrimitive | null {
+  const url = stringField(marker, "mesh_resource", "");
+  if (!url.startsWith("data:")) {
+    return null;
+  }
+
+  return {
+    color,
+    mediaType: mediaTypeFromDataUri(url),
+    overrideColor: !booleanField(marker, "mesh_use_embedded_materials"),
+    pose,
+    scale,
+    url,
+  };
+}
+
+function markerAttributes(
+  markerCount: number,
+  entities: readonly SceneEntityVisualization[],
+  deletions: readonly SceneEntityDeletionVisualization[],
+  { transparentMarkers, unsupportedTypes }: MarkerDecodeStats,
+): Record<string, DecodedAttributeValue> {
+  const attributes: Record<string, DecodedAttributeValue> = {
+    deletionCount: deletions.length,
+    entityCount: entities.length,
+    markerCount,
+    transparentMarkerCount: transparentMarkers,
+    unsupportedMarkerCount: unsupportedTypes.length,
+  };
+  if (unsupportedTypes.length > 0) {
+    attributes.unsupportedMarkerTypes = [...new Set(unsupportedTypes)].sort();
+  }
+
+  return attributes;
+}
+
+function markerMetadata(
+  marker: Record<string, unknown>,
+  markerType: number,
+): Readonly<Record<string, string>> {
+  const metadata: Record<string, string> = {
+    id: String(integerField(marker, "id", 0)),
+    namespace: stringField(marker, "ns"),
+    source: "visualization_msgs/Marker",
+    type: markerTypeName(markerType),
+  };
+  const meshResource = stringField(marker, "mesh_resource");
+  if (meshResource) {
+    metadata.meshResource = meshResource;
+    if (!meshResource.startsWith("data:")) {
+      metadata.unsupportedReason =
+        "Only inline data: mesh resources are supported";
+    }
+  }
+
+  return metadata;
+}
+
+function markerTiming(
+  context: DecodeContext,
+  markers: readonly (Record<string, unknown> | undefined)[],
+) {
+  const firstHeader = markers.find((marker) => marker && rosHeader(marker));
+  return timingFromRosHeader(
+    context,
+    firstHeader ? rosHeader(firstHeader) : undefined,
+  );
+}
+
+function markerTimestampNs(
+  marker: Record<string, unknown>,
+): bigint | undefined {
+  return rosHeaderTimestampNs(rosHeader(marker));
+}
+
+function markerEntityId(
+  marker: Record<string, unknown>,
+  context: DecodeContext,
+): string {
+  const topic = context.streamId ?? "marker";
+  return `${topic}:${stringField(marker, "ns")}:${integerField(marker, "id", 0)}`;
+}
+
+function markerPose(marker: Record<string, unknown>): ScenePose3D {
+  const pose = decodePose(recordField(marker, "pose"));
+  return {
+    position: pose.position,
+    quaternion: pose.quaternion,
+  };
+}
+
+function markerScale(marker: Record<string, unknown>): ScenePoint3D {
+  const scale = decodeVector3(recordField(marker, "scale"), [1, 1, 1]);
+  return [
+    positiveOr(scale[0], 1),
+    positiveOr(scale[1], 1),
+    positiveOr(scale[2], 1),
+  ];
+}
+
+function markerPointSize(scale: ScenePoint3D): ScenePoint3D {
+  return [
+    positiveOr(scale[0], DEFAULT_POINT_SIZE),
+    positiveOr(scale[1], DEFAULT_POINT_SIZE),
+    positiveOr(scale[1], DEFAULT_POINT_SIZE),
+  ];
+}
+
+function markerPoints(
+  marker: Record<string, unknown>,
+): readonly ScenePoint3D[] {
+  return arrayField(marker, "points").map((point) =>
+    decodeVector3(recordField({ point }, "point"), ZERO_VECTOR3),
+  );
+}
+
+function markerColor(marker: Record<string, unknown>): RgbaColor | null {
+  return colorFromRecord(recordField(marker, "color"));
+}
+
+function markerColors(marker: Record<string, unknown>): readonly RgbaColor[] {
+  return arrayField(marker, "colors").map((color) =>
+    colorFromRecord(recordField({ color }, "color")),
+  );
+}
+
+function markerAlpha(marker: Record<string, unknown>): number {
+  return markerColor(marker)?.[3] ?? 0;
+}
+
+function colorFromRecord(
+  record: Record<string, unknown> | undefined,
+): RgbaColor {
+  return [
+    numberField(record, "r", undefined, 0),
+    numberField(record, "g", undefined, 0),
+    numberField(record, "b", undefined, 0),
+    numberField(record, "a", undefined, 0),
+  ];
+}
+
+function composeMarkerPointPose(
+  markerPoseValue: ScenePose3D,
+  point: ScenePoint3D,
+): ScenePose3D {
+  return {
+    position: transformPointByPose(markerPoseValue, point),
+    quaternion: markerPoseValue.quaternion,
+  };
+}
+
+function transformPointByPose(
+  pose: ScenePose3D,
+  point: ScenePoint3D,
+): ScenePoint3D {
+  const q = decodeQuaternion(
+    {
+      w: pose.quaternion[3],
+      x: pose.quaternion[0],
+      y: pose.quaternion[1],
+      z: pose.quaternion[2],
+    },
+    IDENTITY_QUATERNION,
+  );
+  const quaternion = new Quaternion(q[0], q[1], q[2], q[3]);
+  if (quaternion.lengthSq() === 0) {
+    quaternion.identity();
+  } else {
+    quaternion.normalize();
+  }
+  const transformed = new Vector3(...point)
+    .applyQuaternion(quaternion)
+    .add(new Vector3(...pose.position));
+
+  return [transformed.x, transformed.y, transformed.z];
+}
+
+function mediaTypeFromDataUri(uri: string): string {
+  const match = /^data:([^;,]+)/.exec(uri);
+  return match?.[1] || "model/gltf-binary";
+}
+
+function markerTypeValue(value: unknown): number {
+  if (typeof value === "number") return value;
+  if (typeof value === "bigint") return Number(value);
+  if (typeof value === "string") {
+    const numeric = Number(value);
+    if (Number.isFinite(numeric)) return numeric;
+    return MARKER_TYPE_BY_NAME[value] ?? -1;
+  }
+  return -1;
+}
+
+function markerAction(value: unknown): number {
+  if (typeof value === "number") return value;
+  if (typeof value === "bigint") return Number(value);
+  if (typeof value === "string") {
+    const numeric = Number(value);
+    if (Number.isFinite(numeric)) return numeric;
+    return MARKER_ACTION_BY_NAME[value] ?? MARKER_ACTION.ADD;
+  }
+  return MARKER_ACTION.ADD;
+}
+
+function markerTypeName(type: number): string {
+  return (
+    Object.entries(MARKER_TYPE_BY_NAME).find(
+      ([, value]) => value === type,
+    )?.[0] ?? String(type)
+  );
+}
+
+function booleanField(
+  record: Record<string, unknown>,
+  field: string,
+  fallbackField?: string,
+): boolean {
+  const value =
+    record[field] ?? (fallbackField ? record[fallbackField] : undefined);
+  return typeof value === "boolean" ? value : Boolean(value);
+}
+
+function integerField(
+  record: Record<string, unknown>,
+  field: string,
+  defaultValue: number,
+): number {
+  const value = numberField(record, field, undefined, defaultValue);
+  return Number.isFinite(value) ? Math.trunc(value) : defaultValue;
+}
+
+function positiveOr(value: number, fallback: number): number {
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/marker.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/marker.ts
@@ -36,6 +36,7 @@ import {
   rosHeaderFrameId,
   rosHeaderTimestampNs,
   rosTimestampNs,
+  sceneEntityVisualization,
   stringField,
   timingFromRosHeader,
 } from "./common";
@@ -276,22 +277,30 @@ function entityForMarker(
       );
       break;
     case MARKER_TYPE.CUBE_LIST:
-      base.cubes.push(
-        ...points.map((point, index) => ({
-          color: colors[index] ?? color,
-          pose: composeMarkerPointPose(pose, point),
-          size: scale,
-        })),
-      );
+      if (points.length <= MAX_POINT_MARKER_SPHERES) {
+        base.cubes.push(
+          ...points.map((point, index) => ({
+            color: colors[index] ?? color,
+            pose: composeMarkerPointPose(pose, point),
+            size: scale,
+          })),
+        );
+      } else {
+        unsupportedType = `CUBE_LIST(${points.length})`;
+      }
       break;
     case MARKER_TYPE.SPHERE_LIST:
-      base.spheres.push(
-        ...points.map((point, index) => ({
-          color: colors[index] ?? color,
-          pose: composeMarkerPointPose(pose, point),
-          size: scale,
-        })),
-      );
+      if (points.length <= MAX_POINT_MARKER_SPHERES) {
+        base.spheres.push(
+          ...points.map((point, index) => ({
+            color: colors[index] ?? color,
+            pose: composeMarkerPointPose(pose, point),
+            size: scale,
+          })),
+        );
+      } else {
+        unsupportedType = `SPHERE_LIST(${points.length})`;
+      }
       break;
     case MARKER_TYPE.POINTS:
       if (points.length <= MAX_POINT_MARKER_SPHERES) {
@@ -357,30 +366,22 @@ function entityForMarker(
   const lifetimeNs = rosTimestampNs(recordField(marker, "lifetime"));
   const timestampNs = markerTimestampNs(marker);
 
-  const entity: SceneEntityVisualization = {
-    arrowCount: base.arrows.length,
+  const entity = sceneEntityVisualization({
     arrows: base.arrows,
-    cubeCount: base.cubes.length,
     cubes: base.cubes,
-    cylinderCount: base.cylinders.length,
     cylinders: base.cylinders,
-    ...(frameId ? { frameId } : {}),
     frameLocked: booleanField(marker, "frame_locked", "frameLocked"),
+    frameId,
     id: markerEntityId(marker, context),
-    lineCount: base.lines.length,
-    lines: base.lines,
-    ...(lifetimeNs !== undefined ? { lifetimeNs } : {}),
+    lifetimeNs,
     metadata,
-    modelCount: base.models.length,
+    lines: base.lines,
     models: base.models,
-    sphereCount: base.spheres.length,
     spheres: base.spheres,
-    textCount: base.texts.length,
     texts: base.texts,
-    ...(timestampNs !== undefined ? { timestampNs } : {}),
-    triangleCount: base.triangles.length,
+    timestampNs,
     triangles: base.triangles,
-  };
+  });
 
   return {
     entity,

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/nav-sat-fix.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/nav-sat-fix.ts
@@ -67,9 +67,9 @@ export function decodeRosNavSatFixRecord(
       ? covariance(message)
       : undefined;
 
-  const status = statusAttributes(recordField(message, "status"));
-  if (status) {
-    attributes.status = status;
+  const navSatStatus = navSatStatusValues(recordField(message, "status"));
+  if (navSatStatus.attributes) {
+    attributes.status = navSatStatus.attributes;
   }
 
   // Match the Foxglove LocationFix heuristic: many drivers emit altitude 0
@@ -78,6 +78,12 @@ export function decodeRosNavSatFixRecord(
     ...(Number.isFinite(altitude) && altitude !== 0 ? { altitude } : {}),
     ...(frameId ? { coordinateFrameId: frameId } : {}),
     kind: VISUALIZATION_KIND.LOCATION,
+    ...(navSatStatus.fixService !== undefined
+      ? { fixService: navSatStatus.fixService }
+      : {}),
+    ...(navSatStatus.fixStatus !== undefined
+      ? { fixStatus: navSatStatus.fixStatus }
+      : {}),
     latitude,
     longitude,
     ...(positionCovariance ? { positionCovariance } : {}),
@@ -100,22 +106,31 @@ function covariance(
   return values.length === COVARIANCE_LENGTH ? values : undefined;
 }
 
-function statusAttributes(
-  status: Record<string, unknown> | undefined,
-): DecodedAttributeValue | undefined {
+function navSatStatusValues(status: Record<string, unknown> | undefined): {
+  readonly attributes?: DecodedAttributeValue;
+  readonly fixService?: number;
+  readonly fixStatus?: number;
+} {
   if (!status) {
-    return undefined;
+    return {};
   }
 
-  const result: Record<string, DecodedAttributeValue> = {};
   const statusValue = numberField(status, "status", undefined, Number.NaN);
   const service = numberField(status, "service", undefined, Number.NaN);
-  if (Number.isFinite(statusValue)) {
-    result.status = statusValue;
+  const fixStatus = Number.isFinite(statusValue) ? statusValue : undefined;
+  const fixService = Number.isFinite(service) ? service : undefined;
+
+  const result: Record<string, DecodedAttributeValue> = {};
+  if (fixStatus !== undefined) {
+    result.status = fixStatus;
   }
-  if (Number.isFinite(service)) {
-    result.service = service;
+  if (fixService !== undefined) {
+    result.service = fixService;
   }
 
-  return Object.keys(result).length > 0 ? result : undefined;
+  return {
+    attributes: Object.keys(result).length > 0 ? result : undefined,
+    fixService,
+    fixStatus,
+  };
 }

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/path.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/path.ts
@@ -110,15 +110,16 @@ export function decodeRosPoseArrayRecord(
   const header = rosHeader(message);
   const frameId = rosHeaderFrameId(header);
   const timestampNs = rosHeaderTimestampNs(header);
-  const poses = poseArrayPoses(message);
-  const renderedPoses = poses.slice(0, MAX_POSE_ARRAY_ARROWS);
+  const poseRecords = arrayRecords(message, "poses");
+  const renderedPoseRecords = poseRecords.slice(0, MAX_POSE_ARRAY_ARROWS);
+  const renderedPoses = poseArrayPoses(renderedPoseRecords);
   const attributes: Record<string, DecodedAttributeValue> = {
     ...rosHeaderAttributes(header),
-    poseCount: poses.length,
+    poseCount: poseRecords.length,
     renderedPoseCount: renderedPoses.length,
   };
-  if (poses.length > renderedPoses.length) {
-    attributes.truncatedPoseCount = poses.length - renderedPoses.length;
+  if (poseRecords.length > renderedPoses.length) {
+    attributes.truncatedPoseCount = poseRecords.length - renderedPoses.length;
   }
   const entities =
     renderedPoses.length > 0
@@ -128,7 +129,7 @@ export function decodeRosPoseArrayRecord(
             frameId,
             id: `${context.streamId ?? "pose-array"}:pose-array`,
             metadata: {
-              poseCount: String(poses.length),
+              poseCount: String(poseRecords.length),
               renderedPoseCount: String(renderedPoses.length),
               source: "geometry_msgs/PoseArray",
             },
@@ -158,9 +159,9 @@ function pathPoints(message: Record<string, unknown>): readonly ScenePoint3D[] {
 }
 
 function poseArrayPoses(
-  message: Record<string, unknown>,
+  poses: readonly Record<string, unknown>[],
 ): readonly ScenePose3D[] {
-  return arrayRecords(message, "poses").map((pose) => {
+  return poses.map((pose) => {
     const decoded = decodePose(pose);
     return {
       position: decoded.position,
@@ -237,9 +238,13 @@ function arrayRecords(
   record: Record<string, unknown>,
   field: string,
 ): readonly Record<string, unknown>[] {
-  return arrayField(record, field).map(
-    (value) => recordField({ value }, "value") ?? {},
+  return arrayField(record, field).map((value) =>
+    isRecord(value) ? value : {},
   );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
 function identityPose(): ScenePose3D {

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/path.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/path.ts
@@ -4,7 +4,6 @@ import type {
   DecodedOutput,
   RgbaColor,
   SceneArrowPrimitive,
-  SceneEntityVisualization,
   SceneLinePrimitive,
   ScenePoint3D,
   ScenePose3D,
@@ -17,12 +16,13 @@ import {
   ZERO_VECTOR3,
 } from "../foxglove/protobuf/geometry";
 import {
-  arrayField,
+  arrayRecords,
   recordField,
   rosHeader,
   rosHeaderAttributes,
   rosHeaderFrameId,
   rosHeaderTimestampNs,
+  sceneEntityVisualization,
   timingFromRosHeader,
 } from "./common";
 import { rosDecodersForPayloads } from "./factory";
@@ -75,7 +75,7 @@ export function decodeRosPathRecord(
   const entities =
     points.length > 0
       ? [
-          sceneEntity({
+          sceneEntityVisualization({
             frameId,
             id: `${context.streamId ?? "path"}:path`,
             lines: [pathLine(points)],
@@ -125,7 +125,7 @@ export function decodeRosPoseArrayRecord(
   const entities =
     renderedPoses.length > 0
       ? [
-          sceneEntity({
+          sceneEntityVisualization({
             arrows: renderedPoses.map(poseArrow),
             frameId,
             id: `${context.streamId ?? "pose-array"}:pose-array`,
@@ -195,59 +195,6 @@ function poseArrow(pose: ScenePose3D): SceneArrowPrimitive {
     shaftDiameter: POSE_ARROW_SHAFT_DIAMETER,
     shaftLength: POSE_ARROW_SHAFT_LENGTH,
   };
-}
-
-function sceneEntity({
-  arrows = [],
-  frameId,
-  id,
-  lines = [],
-  metadata,
-  timestampNs,
-}: {
-  readonly arrows?: readonly SceneArrowPrimitive[];
-  readonly frameId: string | undefined;
-  readonly id: string;
-  readonly lines?: readonly SceneLinePrimitive[];
-  readonly metadata: Readonly<Record<string, string>>;
-  readonly timestampNs: bigint | undefined;
-}): SceneEntityVisualization {
-  return {
-    arrowCount: arrows.length,
-    arrows,
-    cubeCount: 0,
-    cubes: [],
-    cylinderCount: 0,
-    cylinders: [],
-    ...(frameId ? { frameId } : {}),
-    frameLocked: false,
-    id,
-    lineCount: lines.length,
-    lines,
-    metadata,
-    modelCount: 0,
-    models: [],
-    sphereCount: 0,
-    spheres: [],
-    textCount: 0,
-    texts: [],
-    ...(timestampNs !== undefined ? { timestampNs } : {}),
-    triangleCount: 0,
-    triangles: [],
-  };
-}
-
-function arrayRecords(
-  record: Record<string, unknown>,
-  field: string,
-): readonly Record<string, unknown>[] {
-  return arrayField(record, field).map((value) =>
-    isRecord(value) ? value : {},
-  );
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
 function identityPose(): ScenePose3D {

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/path.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/path.ts
@@ -1,0 +1,250 @@
+import type {
+  DecodeContext,
+  DecodedAttributeValue,
+  DecodedOutput,
+  RgbaColor,
+  SceneArrowPrimitive,
+  SceneEntityVisualization,
+  SceneLinePrimitive,
+  ScenePoint3D,
+  ScenePose3D,
+} from "../../../../decoders";
+import { VISUALIZATION_KIND } from "../../../../visualization";
+import {
+  decodePose,
+  decodeVector3,
+  IDENTITY_QUATERNION,
+  ZERO_VECTOR3,
+} from "../foxglove/protobuf/geometry";
+import {
+  arrayField,
+  recordField,
+  rosHeader,
+  rosHeaderAttributes,
+  rosHeaderFrameId,
+  rosHeaderTimestampNs,
+  timingFromRosHeader,
+} from "./common";
+import { rosDecodersForPayloads } from "./factory";
+import { ROS_PATH_PAYLOADS, ROS_POSE_ARRAY_PAYLOADS } from "./payloads";
+
+const PATH_COLOR: RgbaColor = [0.2, 0.72, 1, 1];
+const PATH_THICKNESS = 2;
+const POSE_ARRAY_COLOR: RgbaColor = [1, 0.62, 0.18, 1];
+const POSE_ARROW_SHAFT_LENGTH = 0.35;
+const POSE_ARROW_SHAFT_DIAMETER = 0.04;
+const POSE_ARROW_HEAD_LENGTH = 0.12;
+const POSE_ARROW_HEAD_DIAMETER = 0.12;
+const MAX_POSE_ARRAY_ARROWS = 1_024;
+
+/**
+ * Decoders for ROS Path messages.
+ */
+export const rosPathDecoders = rosDecodersForPayloads({
+  id: "ros.path",
+  map: decodeRosPathRecord,
+  payloads: ROS_PATH_PAYLOADS,
+});
+
+/**
+ * Decoders for ROS PoseArray messages.
+ */
+export const rosPoseArrayDecoders = rosDecodersForPayloads({
+  id: "ros.pose-array",
+  map: decodeRosPoseArrayRecord,
+  payloads: ROS_POSE_ARRAY_PAYLOADS,
+});
+
+/**
+ * Normalizes a ROS nav_msgs/Path record into a SceneUpdate line-strip overlay.
+ */
+export function decodeRosPathRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+): DecodedOutput {
+  const header = rosHeader(message);
+  const frameId = rosHeaderFrameId(header);
+  const timestampNs = rosHeaderTimestampNs(header);
+  const points = pathPoints(message);
+  const attributes: Record<string, DecodedAttributeValue> = {
+    ...rosHeaderAttributes(header),
+    pointCount: points.length,
+    poseCount: points.length,
+  };
+  const entities =
+    points.length > 0
+      ? [
+          sceneEntity({
+            frameId,
+            id: `${context.streamId ?? "path"}:path`,
+            lines: [pathLine(points)],
+            metadata: {
+              poseCount: String(points.length),
+              source: "nav_msgs/Path",
+            },
+            timestampNs,
+          }),
+        ]
+      : [];
+
+  return {
+    attributes,
+    timing: timingFromRosHeader(context, header),
+    visualization: {
+      deletions: [],
+      entities,
+      kind: VISUALIZATION_KIND.SCENE_UPDATE,
+    },
+  };
+}
+
+/**
+ * Normalizes a ROS geometry_msgs/PoseArray record into a SceneUpdate overlay.
+ * Each pose renders as one orientation arrow to keep large hypothesis clouds
+ * fast enough for interactive playback.
+ */
+export function decodeRosPoseArrayRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+): DecodedOutput {
+  const header = rosHeader(message);
+  const frameId = rosHeaderFrameId(header);
+  const timestampNs = rosHeaderTimestampNs(header);
+  const poses = poseArrayPoses(message);
+  const renderedPoses = poses.slice(0, MAX_POSE_ARRAY_ARROWS);
+  const attributes: Record<string, DecodedAttributeValue> = {
+    ...rosHeaderAttributes(header),
+    poseCount: poses.length,
+    renderedPoseCount: renderedPoses.length,
+  };
+  if (poses.length > renderedPoses.length) {
+    attributes.truncatedPoseCount = poses.length - renderedPoses.length;
+  }
+  const entities =
+    renderedPoses.length > 0
+      ? [
+          sceneEntity({
+            arrows: renderedPoses.map(poseArrow),
+            frameId,
+            id: `${context.streamId ?? "pose-array"}:pose-array`,
+            metadata: {
+              poseCount: String(poses.length),
+              renderedPoseCount: String(renderedPoses.length),
+              source: "geometry_msgs/PoseArray",
+            },
+            timestampNs,
+          }),
+        ]
+      : [];
+
+  return {
+    attributes,
+    timing: timingFromRosHeader(context, header),
+    visualization: {
+      deletions: [],
+      entities,
+      kind: VISUALIZATION_KIND.SCENE_UPDATE,
+    },
+  };
+}
+
+function pathPoints(message: Record<string, unknown>): readonly ScenePoint3D[] {
+  return arrayRecords(message, "poses").map((poseStamped) =>
+    decodeVector3(
+      recordField(recordField(poseStamped, "pose"), "position"),
+      ZERO_VECTOR3,
+    ),
+  );
+}
+
+function poseArrayPoses(
+  message: Record<string, unknown>,
+): readonly ScenePose3D[] {
+  return arrayRecords(message, "poses").map((pose) => {
+    const decoded = decodePose(pose);
+    return {
+      position: decoded.position,
+      quaternion: decoded.quaternion,
+    };
+  });
+}
+
+function pathLine(points: readonly ScenePoint3D[]): SceneLinePrimitive {
+  return {
+    color: PATH_COLOR,
+    colors: [],
+    indices: [],
+    points,
+    pose: identityPose(),
+    scaleInvariant: false,
+    thickness: PATH_THICKNESS,
+    type: "line-strip",
+  };
+}
+
+function poseArrow(pose: ScenePose3D): SceneArrowPrimitive {
+  return {
+    color: POSE_ARRAY_COLOR,
+    headDiameter: POSE_ARROW_HEAD_DIAMETER,
+    headLength: POSE_ARROW_HEAD_LENGTH,
+    pose,
+    shaftDiameter: POSE_ARROW_SHAFT_DIAMETER,
+    shaftLength: POSE_ARROW_SHAFT_LENGTH,
+  };
+}
+
+function sceneEntity({
+  arrows = [],
+  frameId,
+  id,
+  lines = [],
+  metadata,
+  timestampNs,
+}: {
+  readonly arrows?: readonly SceneArrowPrimitive[];
+  readonly frameId: string | undefined;
+  readonly id: string;
+  readonly lines?: readonly SceneLinePrimitive[];
+  readonly metadata: Readonly<Record<string, string>>;
+  readonly timestampNs: bigint | undefined;
+}): SceneEntityVisualization {
+  return {
+    arrowCount: arrows.length,
+    arrows,
+    cubeCount: 0,
+    cubes: [],
+    cylinderCount: 0,
+    cylinders: [],
+    ...(frameId ? { frameId } : {}),
+    frameLocked: false,
+    id,
+    lineCount: lines.length,
+    lines,
+    metadata,
+    modelCount: 0,
+    models: [],
+    sphereCount: 0,
+    spheres: [],
+    textCount: 0,
+    texts: [],
+    ...(timestampNs !== undefined ? { timestampNs } : {}),
+    triangleCount: 0,
+    triangles: [],
+  };
+}
+
+function arrayRecords(
+  record: Record<string, unknown>,
+  field: string,
+): readonly Record<string, unknown>[] {
+  return arrayField(record, field).map(
+    (value) => recordField({ value }, "value") ?? {},
+  );
+}
+
+function identityPose(): ScenePose3D {
+  return {
+    position: ZERO_VECTOR3,
+    quaternion: IDENTITY_QUATERNION,
+  };
+}

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/path.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/path.ts
@@ -30,6 +30,7 @@ import { ROS_PATH_PAYLOADS, ROS_POSE_ARRAY_PAYLOADS } from "./payloads";
 
 const PATH_COLOR: RgbaColor = [0.2, 0.72, 1, 1];
 const PATH_THICKNESS = 2;
+const MAX_PATH_POINTS = 4_096;
 const POSE_ARRAY_COLOR: RgbaColor = [1, 0.62, 0.18, 1];
 const POSE_ARROW_SHAFT_LENGTH = 0.35;
 const POSE_ARROW_SHAFT_DIAMETER = 0.04;
@@ -150,12 +151,14 @@ export function decodeRosPoseArrayRecord(
 }
 
 function pathPoints(message: Record<string, unknown>): readonly ScenePoint3D[] {
-  return arrayRecords(message, "poses").map((poseStamped) =>
-    decodeVector3(
-      recordField(recordField(poseStamped, "pose"), "position"),
-      ZERO_VECTOR3,
-    ),
-  );
+  return arrayRecords(message, "poses")
+    .slice(0, MAX_PATH_POINTS)
+    .map((poseStamped) =>
+      decodeVector3(
+        recordField(recordField(poseStamped, "pose"), "position"),
+        ZERO_VECTOR3,
+      ),
+    );
 }
 
 function poseArrayPoses(

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/payloads.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/payloads.ts
@@ -177,3 +177,16 @@ export const ROS_DETECTION_3D_ARRAY_PAYLOADS = rosPayloads(
   "vision_msgs/Detection3DArray",
   "vision_msgs/msg/Detection3DArray",
 );
+
+/**
+ * Payload descriptors for ROS TF transform messages.
+ */
+export const ROS_TF_MESSAGE_PAYLOADS = rosPayloads(
+  "tf2_msgs/TFMessage",
+  "tf2_msgs/msg/TFMessage",
+);
+
+export const ROS_TRANSFORM_STAMPED_PAYLOADS = rosPayloads(
+  "geometry_msgs/TransformStamped",
+  "geometry_msgs/msg/TransformStamped",
+);

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/payloads.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/payloads.ts
@@ -104,6 +104,41 @@ export const ROS_NAV_SAT_FIX_PAYLOADS = rosPayloads(
 );
 
 /**
+ * Payload descriptors for ROS rosgraph Log messages.
+ */
+export const ROS_ROSGRAPH_LOG_PAYLOADS: readonly PayloadDescriptor[] = [
+  {
+    encoding: "ros1",
+    schema: "rosgraph_msgs/Log",
+    schemaEncoding: "ros1msg",
+  },
+];
+
+/**
+ * Payload descriptors for ROS 2 rcl_interfaces Log messages.
+ */
+export const ROS_RCL_LOG_PAYLOADS: readonly PayloadDescriptor[] = [
+  {
+    encoding: "cdr",
+    schema: "rcl_interfaces/msg/Log",
+    schemaEncoding: "ros2msg",
+  },
+  {
+    encoding: "cdr",
+    schema: "rcl_interfaces/msg/Log",
+    schemaEncoding: "ros2idl",
+  },
+];
+
+/**
+ * Payload descriptors for ROS DiagnosticArray messages.
+ */
+export const ROS_DIAGNOSTIC_ARRAY_PAYLOADS = rosPayloads(
+  "diagnostic_msgs/DiagnosticArray",
+  "diagnostic_msgs/msg/DiagnosticArray",
+);
+
+/**
  * Payload descriptors for ROS OccupancyGrid messages.
  */
 export const ROS_OCCUPANCY_GRID_PAYLOADS = rosPayloads(

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/payloads.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/payloads.ts
@@ -72,11 +72,27 @@ export const ROS_POSE_STAMPED_PAYLOADS = rosPayloads(
 );
 
 /**
+ * Payload descriptors for ROS PoseArray messages.
+ */
+export const ROS_POSE_ARRAY_PAYLOADS = rosPayloads(
+  "geometry_msgs/PoseArray",
+  "geometry_msgs/msg/PoseArray",
+);
+
+/**
  * Payload descriptors for ROS Odometry messages.
  */
 export const ROS_ODOMETRY_PAYLOADS = rosPayloads(
   "nav_msgs/Odometry",
   "nav_msgs/msg/Odometry",
+);
+
+/**
+ * Payload descriptors for ROS Path messages.
+ */
+export const ROS_PATH_PAYLOADS = rosPayloads(
+  "nav_msgs/Path",
+  "nav_msgs/msg/Path",
 );
 
 /**

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/payloads.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/payloads.ts
@@ -126,3 +126,19 @@ export const ROS_MARKER_ARRAY_PAYLOADS = rosPayloads(
   "visualization_msgs/MarkerArray",
   "visualization_msgs/msg/MarkerArray",
 );
+
+/**
+ * Payload descriptors for ROS vision Detection2DArray messages.
+ */
+export const ROS_DETECTION_2D_ARRAY_PAYLOADS = rosPayloads(
+  "vision_msgs/Detection2DArray",
+  "vision_msgs/msg/Detection2DArray",
+);
+
+/**
+ * Payload descriptors for ROS vision Detection3DArray messages.
+ */
+export const ROS_DETECTION_3D_ARRAY_PAYLOADS = rosPayloads(
+  "vision_msgs/Detection3DArray",
+  "vision_msgs/msg/Detection3DArray",
+);

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/payloads.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/payloads.ts
@@ -94,3 +94,19 @@ export const ROS_OCCUPANCY_GRID_PAYLOADS = rosPayloads(
   "nav_msgs/OccupancyGrid",
   "nav_msgs/msg/OccupancyGrid",
 );
+
+/**
+ * Payload descriptors for ROS visualization Marker messages.
+ */
+export const ROS_MARKER_PAYLOADS = rosPayloads(
+  "visualization_msgs/Marker",
+  "visualization_msgs/msg/Marker",
+);
+
+/**
+ * Payload descriptors for ROS visualization MarkerArray messages.
+ */
+export const ROS_MARKER_ARRAY_PAYLOADS = rosPayloads(
+  "visualization_msgs/MarkerArray",
+  "visualization_msgs/msg/MarkerArray",
+);

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/vision.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/vision.ts
@@ -76,14 +76,13 @@ export function decodeRosDetection2DArrayRecord(
 ): DecodedOutput {
   const header = rosHeader(message);
   const detections = detectionRecords(message);
+  const labels = detections.map(detectionLabel);
   const detectionBoxes = detections.map(detection2DBox);
   const boxes = detectionBoxes.filter(isPresent);
-  const labels = detections
-    .map((detection, index) =>
-      detection2DText(detection, detectionBoxes[index]),
-    )
+  const textLabels = labels
+    .map((label, index) => detection2DText(label, detectionBoxes[index]))
     .filter(isPresent);
-  const classIds = uniqueClassIds(detections);
+  const classIds = uniqueClassIds(labels);
 
   return {
     attributes: detectionAttributes({
@@ -91,14 +90,14 @@ export function decodeRosDetection2DArrayRecord(
       classIds,
       detectionCount: detections.length,
       header,
-      textCount: labels.length,
+      textCount: textLabels.length,
     }),
     timing: timingFromRosHeader(context, header),
     visualization: {
       circles: [],
       kind: VISUALIZATION_KIND.IMAGE_ANNOTATIONS,
       points: boxes,
-      texts: labels,
+      texts: textLabels,
     },
   };
 }
@@ -115,6 +114,7 @@ export function decodeRosDetection3DArrayRecord(
   const frameId = rosHeaderFrameId(header);
   const timestampNs = rosHeaderTimestampNs(header);
   const detections = detectionRecords(message);
+  const labels = detections.map(detectionLabel);
   const entities = detections
     .map((detection, index) =>
       detection3DEntity({
@@ -122,11 +122,12 @@ export function decodeRosDetection3DArrayRecord(
         detection,
         frameId,
         index,
+        label: labels[index] ?? null,
         timestampNs,
       }),
     )
     .filter(isPresent);
-  const classIds = uniqueClassIds(detections);
+  const classIds = uniqueClassIds(labels);
   const deletions: readonly SceneEntityDeletionVisualization[] =
     timestampNs !== undefined
       ? [{ id: "", timestampNs, type: "all" }]
@@ -178,10 +179,9 @@ function detection2DBox(
 }
 
 function detection2DText(
-  detection: Record<string, unknown>,
+  label: DetectionLabel | null | undefined,
   box: ImageAnnotationPoints | null | undefined,
 ): ImageAnnotationText | null {
-  const label = detectionLabel(detection);
   if (!label || !box || box.points.length === 0) {
     return null;
   }
@@ -202,12 +202,14 @@ function detection3DEntity({
   detection,
   frameId,
   index,
+  label,
   timestampNs,
 }: {
   readonly context: DecodeContext;
   readonly detection: Record<string, unknown>;
   readonly frameId: string | undefined;
   readonly index: number;
+  readonly label: DetectionLabel | null;
   readonly timestampNs: bigint | undefined;
 }): SceneEntityVisualization | null {
   const bbox = recordField(detection, "bbox");
@@ -220,7 +222,6 @@ function detection3DEntity({
     pose: decodePose(recordField(bbox, "center")),
     size,
   };
-  const label = detectionLabel(detection);
   const texts = label ? [detection3DText(cube.pose, size, label.text)] : [];
   const id = detectionId(detection) ?? String(index);
 
@@ -338,12 +339,12 @@ function detectionMetadata(
 }
 
 function uniqueClassIds(
-  detections: readonly Record<string, unknown>[],
+  labels: readonly (DetectionLabel | null)[],
 ): readonly string[] {
   return [
     ...new Set(
-      detections
-        .map((detection) => detectionLabel(detection)?.classId)
+      labels
+        .map((label) => label?.classId)
         .filter((classId): classId is string => Boolean(classId)),
     ),
   ].sort();
@@ -442,9 +443,13 @@ function arrayRecords(
   record: Record<string, unknown>,
   field: string,
 ): readonly Record<string, unknown>[] {
-  return arrayField(record, field).map(
-    (value) => recordField({ value }, "value") ?? {},
+  return arrayField(record, field).map((value) =>
+    isRecord(value) ? value : {},
   );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
 function stringFromValue(value: unknown): string | undefined {

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/vision.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/vision.ts
@@ -18,13 +18,14 @@ import {
   IDENTITY_QUATERNION,
 } from "../foxglove/protobuf/geometry";
 import {
-  arrayField,
+  arrayRecords,
   numberField,
   recordField,
   rosHeader,
   rosHeaderAttributes,
   rosHeaderFrameId,
   rosHeaderTimestampNs,
+  sceneEntityVisualization,
   timingFromRosHeader,
 } from "./common";
 import { rosDecodersForPayloads } from "./factory";
@@ -227,7 +228,7 @@ function detection3DEntity({
     detectionId(detection) ??
     detectionFallbackId({ context, index, timestampNs });
 
-  return sceneEntity({
+  return sceneEntityVisualization({
     cubes: [cube],
     frameId,
     id: `${context.streamId ?? "detections3d"}:detection3d:${id}`,
@@ -417,59 +418,6 @@ function rotatedBoxCorners({
     center[0] + x * cos - y * sin,
     center[1] + x * sin + y * cos,
   ]);
-}
-
-function sceneEntity({
-  cubes,
-  frameId,
-  id,
-  metadata,
-  texts,
-  timestampNs,
-}: {
-  readonly cubes: readonly SceneCubePrimitive[];
-  readonly frameId: string | undefined;
-  readonly id: string;
-  readonly metadata: Readonly<Record<string, string>>;
-  readonly texts: readonly SceneTextPrimitive[];
-  readonly timestampNs: bigint | undefined;
-}): SceneEntityVisualization {
-  return {
-    arrowCount: 0,
-    arrows: [],
-    cubeCount: cubes.length,
-    cubes,
-    cylinderCount: 0,
-    cylinders: [],
-    ...(frameId ? { frameId } : {}),
-    frameLocked: false,
-    id,
-    lineCount: 0,
-    lines: [],
-    metadata,
-    modelCount: 0,
-    models: [],
-    sphereCount: 0,
-    spheres: [],
-    textCount: texts.length,
-    texts,
-    ...(timestampNs !== undefined ? { timestampNs } : {}),
-    triangleCount: 0,
-    triangles: [],
-  };
-}
-
-function arrayRecords(
-  record: Record<string, unknown>,
-  field: string,
-): readonly Record<string, unknown>[] {
-  return arrayField(record, field).map((value) =>
-    isRecord(value) ? value : {},
-  );
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
 function stringFromValue(value: unknown): string | undefined {

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/vision.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/vision.ts
@@ -223,7 +223,9 @@ function detection3DEntity({
     size,
   };
   const texts = label ? [detection3DText(cube.pose, size, label.text)] : [];
-  const id = detectionId(detection) ?? String(index);
+  const id =
+    detectionId(detection) ??
+    detectionFallbackId({ context, index, timestampNs });
 
   return sceneEntity({
     cubes: [cube],
@@ -315,6 +317,24 @@ function detectionId(detection: Record<string, unknown>): string | undefined {
     stringFromValue(detection["tracking_id"]) ??
     stringFromValue(detection["trackingId"])
   );
+}
+
+function detectionFallbackId({
+  context,
+  index,
+  timestampNs,
+}: {
+  readonly context: DecodeContext;
+  readonly index: number;
+  readonly timestampNs: bigint | undefined;
+}): string {
+  const messageSalt =
+    timestampNs?.toString() ??
+    context.sourceTimestamps?.messageTime?.toString() ??
+    context.timeRangeStartNs?.toString() ??
+    context.streamId ??
+    "message";
+  return `${messageSalt}:${index}`;
 }
 
 function detectionMetadata(

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/vision.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/vision.ts
@@ -1,0 +1,467 @@
+import type {
+  DecodeContext,
+  DecodedAttributeValue,
+  DecodedOutput,
+  ImageAnnotationPoints,
+  ImageAnnotationText,
+  RgbaColor,
+  SceneCubePrimitive,
+  SceneEntityDeletionVisualization,
+  SceneEntityVisualization,
+  ScenePose3D,
+  SceneTextPrimitive,
+} from "../../../../decoders";
+import { VISUALIZATION_KIND } from "../../../../visualization";
+import {
+  decodePose,
+  decodeVector3,
+  IDENTITY_QUATERNION,
+} from "../foxglove/protobuf/geometry";
+import {
+  arrayField,
+  numberField,
+  recordField,
+  rosHeader,
+  rosHeaderAttributes,
+  rosHeaderFrameId,
+  rosHeaderTimestampNs,
+  timingFromRosHeader,
+} from "./common";
+import { rosDecodersForPayloads } from "./factory";
+import {
+  ROS_DETECTION_2D_ARRAY_PAYLOADS,
+  ROS_DETECTION_3D_ARRAY_PAYLOADS,
+} from "./payloads";
+
+const BOX_2D_COLOR: RgbaColor = [0.16, 0.9, 0.42, 1];
+const BOX_2D_FILL: RgbaColor = [0.16, 0.9, 0.42, 0.08];
+const BOX_2D_LABEL_BACKGROUND: RgbaColor = [0, 0, 0, 0.72];
+const BOX_2D_THICKNESS = 2;
+const BOX_2D_FONT_SIZE = 14;
+
+const BOX_3D_COLOR: RgbaColor = [0.16, 0.9, 0.42, 0.35];
+const BOX_3D_LABEL_COLOR: RgbaColor = [0.9, 1, 0.92, 1];
+const BOX_3D_LABEL_FONT_SIZE = 16;
+
+interface DetectionLabel {
+  readonly classId: string;
+  readonly score?: number;
+  readonly text: string;
+}
+
+/**
+ * Decoders for ROS vision Detection2DArray messages.
+ */
+export const rosDetection2DArrayDecoders = rosDecodersForPayloads({
+  id: "ros.detection-2d-array",
+  map: decodeRosDetection2DArrayRecord,
+  payloads: ROS_DETECTION_2D_ARRAY_PAYLOADS,
+});
+
+/**
+ * Decoders for ROS vision Detection3DArray messages.
+ */
+export const rosDetection3DArrayDecoders = rosDecodersForPayloads({
+  id: "ros.detection-3d-array",
+  map: decodeRosDetection3DArrayRecord,
+  payloads: ROS_DETECTION_3D_ARRAY_PAYLOADS,
+});
+
+/**
+ * Normalizes a ROS vision_msgs/Detection2DArray record into image overlays.
+ */
+export function decodeRosDetection2DArrayRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+): DecodedOutput {
+  const header = rosHeader(message);
+  const detections = detectionRecords(message);
+  const detectionBoxes = detections.map(detection2DBox);
+  const boxes = detectionBoxes.filter(isPresent);
+  const labels = detections
+    .map((detection, index) =>
+      detection2DText(detection, detectionBoxes[index]),
+    )
+    .filter(isPresent);
+  const classIds = uniqueClassIds(detections);
+
+  return {
+    attributes: detectionAttributes({
+      boxCount: boxes.length,
+      classIds,
+      detectionCount: detections.length,
+      header,
+      textCount: labels.length,
+    }),
+    timing: timingFromRosHeader(context, header),
+    visualization: {
+      circles: [],
+      kind: VISUALIZATION_KIND.IMAGE_ANNOTATIONS,
+      points: boxes,
+      texts: labels,
+    },
+  };
+}
+
+/**
+ * Normalizes a ROS vision_msgs/Detection3DArray record into transient 3D
+ * scene overlays.
+ */
+export function decodeRosDetection3DArrayRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+): DecodedOutput {
+  const header = rosHeader(message);
+  const frameId = rosHeaderFrameId(header);
+  const timestampNs = rosHeaderTimestampNs(header);
+  const detections = detectionRecords(message);
+  const entities = detections
+    .map((detection, index) =>
+      detection3DEntity({
+        context,
+        detection,
+        frameId,
+        index,
+        timestampNs,
+      }),
+    )
+    .filter(isPresent);
+  const classIds = uniqueClassIds(detections);
+  const deletions: readonly SceneEntityDeletionVisualization[] =
+    timestampNs !== undefined
+      ? [{ id: "", timestampNs, type: "all" }]
+      : [{ id: "", type: "all" }];
+
+  return {
+    attributes: detectionAttributes({
+      boxCount: entities.length,
+      classIds,
+      detectionCount: detections.length,
+      header,
+      textCount: sum(entities, (entity) => entity.textCount),
+    }),
+    timing: timingFromRosHeader(context, header),
+    visualization: {
+      deletions,
+      entities,
+      kind: VISUALIZATION_KIND.SCENE_UPDATE,
+    },
+  };
+}
+
+function detection2DBox(
+  detection: Record<string, unknown>,
+): ImageAnnotationPoints | null {
+  const bbox = recordField(detection, "bbox");
+  if (!bbox) {
+    return null;
+  }
+  const width = numberField(bbox, "size_x", "sizeX", Number.NaN);
+  const height = numberField(bbox, "size_y", "sizeY", Number.NaN);
+  if (!Number.isFinite(width) || !Number.isFinite(height)) {
+    return null;
+  }
+
+  return {
+    fillColor: BOX_2D_FILL,
+    outlineColor: BOX_2D_COLOR,
+    outlineColors: [],
+    points: rotatedBoxCorners({
+      center: detection2DCenter(bbox),
+      height,
+      theta: detection2DTheta(bbox),
+      width,
+    }),
+    thickness: BOX_2D_THICKNESS,
+    type: "line-loop",
+  };
+}
+
+function detection2DText(
+  detection: Record<string, unknown>,
+  box: ImageAnnotationPoints | null | undefined,
+): ImageAnnotationText | null {
+  const label = detectionLabel(detection);
+  if (!label || !box || box.points.length === 0) {
+    return null;
+  }
+  const x = Math.min(...box.points.map((point) => point[0]));
+  const y = Math.min(...box.points.map((point) => point[1]));
+
+  return {
+    backgroundColor: BOX_2D_LABEL_BACKGROUND,
+    fontSize: BOX_2D_FONT_SIZE,
+    position: [x, Math.max(0, y - BOX_2D_FONT_SIZE)],
+    text: label.text,
+    textColor: BOX_2D_COLOR,
+  };
+}
+
+function detection3DEntity({
+  context,
+  detection,
+  frameId,
+  index,
+  timestampNs,
+}: {
+  readonly context: DecodeContext;
+  readonly detection: Record<string, unknown>;
+  readonly frameId: string | undefined;
+  readonly index: number;
+  readonly timestampNs: bigint | undefined;
+}): SceneEntityVisualization | null {
+  const bbox = recordField(detection, "bbox");
+  if (!bbox) {
+    return null;
+  }
+  const size = decodeVector3(recordField(bbox, "size"));
+  const cube: SceneCubePrimitive = {
+    color: BOX_3D_COLOR,
+    pose: decodePose(recordField(bbox, "center")),
+    size,
+  };
+  const label = detectionLabel(detection);
+  const texts = label ? [detection3DText(cube.pose, size, label.text)] : [];
+  const id = detectionId(detection) ?? String(index);
+
+  return sceneEntity({
+    cubes: [cube],
+    frameId,
+    id: `${context.streamId ?? "detections3d"}:detection3d:${id}`,
+    metadata: detectionMetadata(detection, label),
+    texts,
+    timestampNs,
+  });
+}
+
+function detection3DText(
+  pose: ScenePose3D,
+  size: readonly [number, number, number],
+  text: string,
+): SceneTextPrimitive {
+  return {
+    billboard: true,
+    color: BOX_3D_LABEL_COLOR,
+    fontSize: BOX_3D_LABEL_FONT_SIZE,
+    pose: {
+      position: [
+        pose.position[0],
+        pose.position[1],
+        pose.position[2] + Math.max(0, size[2]) / 2,
+      ],
+      quaternion: IDENTITY_QUATERNION,
+    },
+    scaleInvariant: true,
+    text,
+  };
+}
+
+function detectionAttributes({
+  boxCount,
+  classIds,
+  detectionCount,
+  header,
+  textCount,
+}: {
+  readonly boxCount: number;
+  readonly classIds: readonly string[];
+  readonly detectionCount: number;
+  readonly header: Record<string, unknown> | undefined;
+  readonly textCount: number;
+}): Record<string, DecodedAttributeValue> {
+  return {
+    ...rosHeaderAttributes(header),
+    boxCount,
+    classIds,
+    detectionCount,
+    textCount,
+  };
+}
+
+function detectionRecords(
+  message: Record<string, unknown>,
+): readonly Record<string, unknown>[] {
+  return arrayRecords(message, "detections");
+}
+
+function detectionLabel(
+  detection: Record<string, unknown>,
+): DetectionLabel | null {
+  const result = arrayRecords(detection, "results")[0];
+  if (!result) {
+    return null;
+  }
+  const hypothesis = recordField(result, "hypothesis") ?? result;
+  const classId =
+    stringFromValue(hypothesis["class_id"]) ??
+    stringFromValue(hypothesis["classId"]) ??
+    stringFromValue(hypothesis["id"]);
+  const score = numberField(hypothesis, "score", undefined, Number.NaN);
+  if (!classId) {
+    return null;
+  }
+
+  return {
+    classId,
+    ...(Number.isFinite(score) ? { score } : {}),
+    text: Number.isFinite(score) ? `${classId} ${score.toFixed(2)}` : classId,
+  };
+}
+
+function detectionId(detection: Record<string, unknown>): string | undefined {
+  return (
+    stringFromValue(detection["id"]) ??
+    stringFromValue(detection["tracking_id"]) ??
+    stringFromValue(detection["trackingId"])
+  );
+}
+
+function detectionMetadata(
+  detection: Record<string, unknown>,
+  label: DetectionLabel | null,
+): Readonly<Record<string, string>> {
+  const metadata: Record<string, string> = {
+    source: "vision_msgs",
+  };
+  const id = detectionId(detection);
+  if (id) {
+    metadata.id = id;
+  }
+  if (label) {
+    metadata.classId = label.classId;
+    if (label.score !== undefined) {
+      metadata.score = label.score.toFixed(4);
+    }
+  }
+
+  return metadata;
+}
+
+function uniqueClassIds(
+  detections: readonly Record<string, unknown>[],
+): readonly string[] {
+  return [
+    ...new Set(
+      detections
+        .map((detection) => detectionLabel(detection)?.classId)
+        .filter((classId): classId is string => Boolean(classId)),
+    ),
+  ].sort();
+}
+
+function detection2DCenter(
+  bbox: Record<string, unknown>,
+): readonly [number, number] {
+  const center = recordField(bbox, "center");
+  const position = recordField(center, "position");
+  if (position) {
+    return [
+      numberField(position, "x", undefined, 0),
+      numberField(position, "y", undefined, 0),
+    ];
+  }
+
+  return [
+    numberField(center, "x", undefined, 0),
+    numberField(center, "y", undefined, 0),
+  ];
+}
+
+function detection2DTheta(bbox: Record<string, unknown>): number {
+  return numberField(recordField(bbox, "center"), "theta", undefined, 0);
+}
+
+function rotatedBoxCorners({
+  center,
+  height,
+  theta,
+  width,
+}: {
+  readonly center: readonly [number, number];
+  readonly height: number;
+  readonly theta: number;
+  readonly width: number;
+}): readonly (readonly [number, number])[] {
+  const halfWidth = width / 2;
+  const halfHeight = height / 2;
+  const cos = Math.cos(theta);
+  const sin = Math.sin(theta);
+
+  return [
+    [-halfWidth, -halfHeight],
+    [halfWidth, -halfHeight],
+    [halfWidth, halfHeight],
+    [-halfWidth, halfHeight],
+  ].map(([x, y]) => [
+    center[0] + x * cos - y * sin,
+    center[1] + x * sin + y * cos,
+  ]);
+}
+
+function sceneEntity({
+  cubes,
+  frameId,
+  id,
+  metadata,
+  texts,
+  timestampNs,
+}: {
+  readonly cubes: readonly SceneCubePrimitive[];
+  readonly frameId: string | undefined;
+  readonly id: string;
+  readonly metadata: Readonly<Record<string, string>>;
+  readonly texts: readonly SceneTextPrimitive[];
+  readonly timestampNs: bigint | undefined;
+}): SceneEntityVisualization {
+  return {
+    arrowCount: 0,
+    arrows: [],
+    cubeCount: cubes.length,
+    cubes,
+    cylinderCount: 0,
+    cylinders: [],
+    ...(frameId ? { frameId } : {}),
+    frameLocked: false,
+    id,
+    lineCount: 0,
+    lines: [],
+    metadata,
+    modelCount: 0,
+    models: [],
+    sphereCount: 0,
+    spheres: [],
+    textCount: texts.length,
+    texts,
+    ...(timestampNs !== undefined ? { timestampNs } : {}),
+    triangleCount: 0,
+    triangles: [],
+  };
+}
+
+function arrayRecords(
+  record: Record<string, unknown>,
+  field: string,
+): readonly Record<string, unknown>[] {
+  return arrayField(record, field).map(
+    (value) => recordField({ value }, "value") ?? {},
+  );
+}
+
+function stringFromValue(value: unknown): string | undefined {
+  if (typeof value === "string" && value) {
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "bigint") {
+    return String(value);
+  }
+
+  return undefined;
+}
+
+function isPresent<T>(value: T | null | undefined): value is T {
+  return value !== null && value !== undefined;
+}
+
+function sum<T>(values: readonly T[], select: (value: T) => number): number {
+  return values.reduce((total, value) => total + select(value), 0);
+}

--- a/app/packages/multimodal/src/adapters/mcap/grid-preview.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/grid-preview.test.ts
@@ -474,6 +474,7 @@ describe("MCAP grid preview", () => {
     ).toEqual({
       annotations: ["/camera/front/annotations"],
       image: ["/camera/front"],
+      logs: [],
       pointCloud: ["/lidar/points"],
       previewable: ["/camera/front", "/lidar/points"],
       sceneUpdates: ["/markers"],
@@ -495,6 +496,7 @@ describe("MCAP grid preview", () => {
     ).toEqual({
       annotations: [],
       image: [],
+      logs: [],
       pointCloud: [],
       previewable: [],
       sceneUpdates: [],
@@ -508,6 +510,7 @@ describe("MCAP grid preview", () => {
         "/CAM_FRONT/image_rect_compressed",
         "/CAM_BACK/image_rect_compressed",
       ],
+      logs: [],
       pointCloud: [],
       previewable: [
         "/CAM_FRONT/image_rect_compressed",

--- a/app/packages/multimodal/src/adapters/mcap/log-records.ts
+++ b/app/packages/multimodal/src/adapters/mcap/log-records.ts
@@ -1,0 +1,91 @@
+import type { DecodedAttributeValue } from "../../decoders";
+
+export const MCAP_LOG_ATTRIBUTE_ROWS = "logRows";
+
+export const MCAP_LOG_LEVEL = {
+  DEBUG: "debug",
+  ERROR: "error",
+  FATAL: "fatal",
+  INFO: "info",
+  UNKNOWN: "unknown",
+  WARN: "warn",
+} as const;
+
+export type McapLogLevel = (typeof MCAP_LOG_LEVEL)[keyof typeof MCAP_LOG_LEVEL];
+
+export const MCAP_LOG_LEVELS: readonly McapLogLevel[] = [
+  MCAP_LOG_LEVEL.DEBUG,
+  MCAP_LOG_LEVEL.INFO,
+  MCAP_LOG_LEVEL.WARN,
+  MCAP_LOG_LEVEL.ERROR,
+  MCAP_LOG_LEVEL.FATAL,
+  MCAP_LOG_LEVEL.UNKNOWN,
+];
+
+export interface McapLogDetail {
+  readonly key: string;
+  readonly value: string;
+}
+
+export interface McapDecodedLogRow {
+  readonly details?: readonly McapLogDetail[];
+  readonly file?: string;
+  readonly functionName?: string;
+  readonly hardwareId?: string;
+  readonly kind?: "diagnostic" | "log";
+  readonly level: McapLogLevel;
+  readonly levelNumber?: number;
+  readonly line?: number;
+  readonly message: string;
+  readonly name?: string;
+  readonly status?: string;
+  readonly timestampNs?: bigint;
+  readonly topics?: readonly string[];
+}
+
+export function logRowsAttribute(
+  rows: readonly McapDecodedLogRow[],
+): readonly Record<string, DecodedAttributeValue>[] {
+  return rows.map(logRowAttribute);
+}
+
+export function logRowAttribute(
+  row: McapDecodedLogRow,
+): Record<string, DecodedAttributeValue> {
+  const attributes: Record<string, DecodedAttributeValue> = {
+    level: row.level,
+    message: row.message,
+  };
+  assignOptional(attributes, "details", row.details?.map(logDetailAttribute));
+  assignOptional(attributes, "file", row.file);
+  assignOptional(attributes, "functionName", row.functionName);
+  assignOptional(attributes, "hardwareId", row.hardwareId);
+  assignOptional(attributes, "kind", row.kind);
+  assignOptional(attributes, "levelNumber", row.levelNumber);
+  assignOptional(attributes, "line", row.line);
+  assignOptional(attributes, "name", row.name);
+  assignOptional(attributes, "status", row.status);
+  assignOptional(attributes, "timestampNs", row.timestampNs);
+  assignOptional(attributes, "topics", row.topics);
+
+  return attributes;
+}
+
+function logDetailAttribute(
+  detail: McapLogDetail,
+): Record<string, DecodedAttributeValue> {
+  return {
+    key: detail.key,
+    value: detail.value,
+  };
+}
+
+function assignOptional(
+  target: Record<string, DecodedAttributeValue>,
+  key: string,
+  value: DecodedAttributeValue | undefined,
+) {
+  if (value !== undefined) {
+    target[key] = value;
+  }
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/McapAddTileMenu.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapAddTileMenu.test.tsx
@@ -9,6 +9,7 @@ import McapAddTileMenu from "./McapAddTileMenu";
 // bodies.
 vi.mock("./McapImageTile", () => ({ default: () => null }));
 vi.mock("./Mcap3dTile", () => ({ default: () => null }));
+vi.mock("./McapLogConsoleTile", () => ({ default: () => null }));
 vi.mock("./McapPlotTile", () => ({ default: () => null }));
 vi.mock("./McapRawMessageTile", () => ({ default: () => null }));
 
@@ -64,6 +65,7 @@ describe("McapAddTileMenu", () => {
 
     expect(screen.getByText("Image")).toBeTruthy();
     expect(screen.getByText("3D")).toBeTruthy();
+    expect(screen.getByText("Logs")).toBeTruthy();
     expect(screen.getByText("Plot")).toBeTruthy();
     expect(screen.getByText("Message")).toBeTruthy();
     expect(screen.queryByText("Image streams")).toBeNull();
@@ -93,6 +95,21 @@ describe("McapAddTileMenu", () => {
     expect(rawIds).toEqual(["raw-1", "raw-2"]);
     for (const id of rawIds) {
       expect(titles[id]).toBe("Message");
+    }
+  });
+
+  it("spawns additive log tiles", () => {
+    renderMenu();
+    openMenu();
+    fireEvent.click(screen.getByText("Logs"));
+    openMenu();
+    fireEvent.click(screen.getByText("Logs"));
+
+    const { titles } = probeState();
+    const logIds = Object.keys(titles).filter((id) => id.startsWith("log-"));
+    expect(logIds).toEqual(["log-1", "log-2"]);
+    for (const id of logIds) {
+      expect(titles[id]).toBe("Logs");
     }
   });
 });

--- a/app/packages/multimodal/src/adapters/mcap/react/McapAddTileMenu.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapAddTileMenu.test.tsx
@@ -10,6 +10,7 @@ import McapAddTileMenu from "./McapAddTileMenu";
 vi.mock("./McapImageTile", () => ({ default: () => null }));
 vi.mock("./Mcap3dTile", () => ({ default: () => null }));
 vi.mock("./McapLogConsoleTile", () => ({ default: () => null }));
+vi.mock("./McapMapTile", () => ({ default: () => null }));
 vi.mock("./McapPlotTile", () => ({ default: () => null }));
 vi.mock("./McapRawMessageTile", () => ({ default: () => null }));
 
@@ -65,6 +66,7 @@ describe("McapAddTileMenu", () => {
 
     expect(screen.getByText("Image")).toBeTruthy();
     expect(screen.getByText("3D")).toBeTruthy();
+    expect(screen.getByText("Map")).toBeTruthy();
     expect(screen.getByText("Logs")).toBeTruthy();
     expect(screen.getByText("Plot")).toBeTruthy();
     expect(screen.getByText("Message")).toBeTruthy();

--- a/app/packages/multimodal/src/adapters/mcap/react/McapAddTileMenu.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapAddTileMenu.tsx
@@ -7,6 +7,7 @@ import { getMcapTileDefinition } from "./use-mcap-tiles";
 const MCAP_ADD_TILE_TYPES: readonly McapTileType[] = [
   MCAP_TILE_TYPE.IMAGE,
   MCAP_TILE_TYPE.THREE_D,
+  MCAP_TILE_TYPE.LOG,
   MCAP_TILE_TYPE.PLOT,
   MCAP_TILE_TYPE.RAW,
 ];

--- a/app/packages/multimodal/src/adapters/mcap/react/McapAddTileMenu.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapAddTileMenu.tsx
@@ -7,6 +7,7 @@ import { getMcapTileDefinition } from "./use-mcap-tiles";
 const MCAP_ADD_TILE_TYPES: readonly McapTileType[] = [
   MCAP_TILE_TYPE.IMAGE,
   MCAP_TILE_TYPE.THREE_D,
+  MCAP_TILE_TYPE.MAP,
   MCAP_TILE_TYPE.LOG,
   MCAP_TILE_TYPE.PLOT,
   MCAP_TILE_TYPE.RAW,

--- a/app/packages/multimodal/src/adapters/mcap/react/McapLogConsoleTile.module.css
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapLogConsoleTile.module.css
@@ -1,0 +1,140 @@
+.body {
+  background: var(--plot-surface, #050b12);
+  color: var(--color-content-text-primary);
+  display: flex;
+  flex-direction: column;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  height: 100%;
+  min-width: 0;
+  overflow: hidden;
+  width: 100%;
+}
+
+.toolbar {
+  align-items: center;
+  border-bottom: 1px solid var(--color-content-border-default, #383835);
+  color: var(--color-content-text-secondary);
+  display: flex;
+  flex: none;
+  flex-wrap: wrap;
+  font-size: 11px;
+  gap: 8px 12px;
+  min-height: 34px;
+  padding: 6px 10px;
+}
+
+.controlGroup {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  min-width: 0;
+}
+
+.meta {
+  color: var(--color-content-text-secondary);
+  margin-left: auto;
+  white-space: nowrap;
+}
+
+.scroll {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+}
+
+.row {
+  align-items: baseline;
+  background: transparent;
+  border: 0;
+  border-bottom: 1px solid
+    color-mix(
+      in srgb,
+      var(--color-content-border-default, #383835) 45%,
+      transparent
+    );
+  color: inherit;
+  cursor: pointer;
+  display: grid;
+  font: inherit;
+  grid-template-columns: 74px 54px minmax(120px, 0.28fr) minmax(0, 1fr);
+  gap: 10px;
+  line-height: 1.45;
+  min-height: 30px;
+  padding: 5px 10px;
+  text-align: left;
+  width: 100%;
+}
+
+.row:hover,
+.row:focus-visible {
+  background: color-mix(
+    in srgb,
+    var(--color-content-text-secondary) 8%,
+    transparent
+  );
+  outline: none;
+}
+
+.time,
+.source,
+.message,
+.level {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.time {
+  color: var(--color-content-text-secondary);
+}
+
+.source {
+  color: var(--color-content-text-secondary);
+}
+
+.message {
+  color: var(--color-content-text-primary);
+}
+
+.level {
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.debug {
+  color: #7eb6ff;
+}
+
+.info {
+  color: #86d88f;
+}
+
+.warn {
+  color: #f1c75b;
+}
+
+.error {
+  color: #ff837a;
+}
+
+.fatal {
+  color: #ff5ea8;
+}
+
+.unknown {
+  color: var(--color-content-text-secondary);
+}
+
+.empty {
+  align-items: center;
+  color: var(--color-content-text-secondary);
+  display: flex;
+  flex: 1;
+  font-size: 12px;
+  justify-content: center;
+  min-height: 0;
+  padding: 16px;
+  text-align: center;
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/McapLogConsoleTile.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapLogConsoleTile.tsx
@@ -43,9 +43,8 @@ interface LogRowsState {
 
 interface LogRowsCacheWindow {
   readonly client: unknown;
-  readonly endTimeNs: bigint;
+  readonly ranges: readonly LogReadRange[];
   readonly sourceKey: string;
-  readonly startTimeNs: bigint;
   readonly topicsKey: string;
 }
 
@@ -146,33 +145,37 @@ const McapLogConsoleTile: React.FC<McapTileProps> = () => {
       setState(INITIAL_ROWS);
       return undefined;
     }
-    if (selectedLevels.length === 0) {
-      setState((current) =>
-        current.status === "loading"
-          ? { ...current, error: undefined, status: "ready" }
-          : current,
-      );
-      return undefined;
-    }
 
     let cancelled = false;
-    const startTimeNs = logWindowStartNs(centerTimeNs);
-    const endTimeNs = centerTimeNs + LOG_WINDOW_AFTER_NS;
+    const activeWindow = logWindowForCenter(centerTimeNs);
     const cachedWindow = fetchedWindowRef.current;
     const reusableWindow =
       cachedWindow?.client === client &&
       cachedWindow.sourceKey === sourceKey &&
       cachedWindow.topicsKey === selectedTopicsKey
-        ? cachedWindow
+        ? clipLogCacheWindow(cachedWindow, activeWindow)
         : null;
-    const ranges = missingLogReadRanges(reusableWindow, startTimeNs, endTimeNs);
+    fetchedWindowRef.current = reusableWindow;
+
+    if (selectedLevels.length === 0) {
+      setState((current) => ({
+        ...current,
+        error: undefined,
+        rawRows: pruneLogRows(current.rawRows, activeWindow),
+        status: "ready",
+      }));
+      return undefined;
+    }
+
+    const ranges = missingLogReadRanges(reusableWindow, activeWindow);
 
     if (ranges.length === 0) {
-      setState((current) =>
-        current.status === "ready"
+      setState((current) => {
+        const rawRows = pruneLogRows(current.rawRows, activeWindow);
+        return current.status === "ready" && rawRows === current.rawRows
           ? current
-          : { ...current, error: undefined, status: "ready" },
-      );
+          : { ...current, error: undefined, rawRows, status: "ready" };
+      });
       return undefined;
     }
 
@@ -183,14 +186,20 @@ const McapLogConsoleTile: React.FC<McapTileProps> = () => {
       setState((current) => ({
         ...current,
         error: undefined,
+        rawRows: pruneLogRows(current.rawRows, activeWindow),
         status: "loading",
       }));
     }
 
     void (async () => {
       try {
+        const coveredRanges: LogReadRange[] = reusableWindow
+          ? [...reusableWindow.ranges]
+          : [];
         const fetchedRows: McapLogConsoleRow[] = [];
         for (const range of ranges) {
+          let messageCount = 0;
+          let lastMessageTimeNs: bigint | undefined;
           for await (const message of client.readDecodedMessages(
             {
               endTimeNs: range.endTimeNs,
@@ -204,11 +213,16 @@ const McapLogConsoleTile: React.FC<McapTileProps> = () => {
             if (cancelled) {
               break;
             }
+            messageCount += 1;
+            lastMessageTimeNs = message.timelineTimeNs;
             fetchedRows.push(...logConsoleRowsFromDecodedMessage(message));
           }
           if (cancelled) {
             break;
           }
+          coveredRanges.push(
+            coveredLogReadRange(range, messageCount, lastMessageTimeNs),
+          );
         }
 
         if (cancelled) {
@@ -217,22 +231,21 @@ const McapLogConsoleTile: React.FC<McapTileProps> = () => {
 
         fetchedWindowRef.current = {
           client,
-          endTimeNs: maxBigInt(reusableWindow?.endTimeNs, endTimeNs),
+          ranges: mergeLogReadRanges(coveredRanges, activeWindow),
           sourceKey,
-          startTimeNs: minBigInt(reusableWindow?.startTimeNs, startTimeNs),
           topicsKey: selectedTopicsKey,
         };
         setState((current) => ({
-          rawRows: reusableWindow
-            ? mergeLogRows(current.rawRows, fetchedRows)
-            : fetchedRows,
+          rawRows: mergeLogRows(current.rawRows, fetchedRows, activeWindow),
           status: "ready",
         }));
       } catch (error) {
         if (!cancelled) {
           setState((current) => ({
             error: error instanceof Error ? error.message : String(error),
-            rawRows: reusableWindow ? current.rawRows : [],
+            rawRows: reusableWindow
+              ? pruneLogRows(current.rawRows, activeWindow)
+              : [],
             status: "error",
           }));
         }
@@ -377,64 +390,140 @@ function logWindowStartNs(centerTimeNs: bigint): bigint {
     : 0n;
 }
 
+function logWindowForCenter(centerTimeNs: bigint): LogReadRange {
+  return {
+    endTimeNs: centerTimeNs + LOG_WINDOW_AFTER_NS,
+    startTimeNs: logWindowStartNs(centerTimeNs),
+  };
+}
+
+function clipLogCacheWindow(
+  cachedWindow: LogRowsCacheWindow,
+  activeWindow: LogReadRange,
+): LogRowsCacheWindow | null {
+  const ranges = mergeLogReadRanges(cachedWindow.ranges, activeWindow);
+  return ranges.length > 0 ? { ...cachedWindow, ranges } : null;
+}
+
 function missingLogReadRanges(
   cachedWindow: LogRowsCacheWindow | null,
-  startTimeNs: bigint,
-  endTimeNs: bigint,
+  activeWindow: LogReadRange,
 ): readonly LogReadRange[] {
   if (!cachedWindow) {
-    return [{ endTimeNs, startTimeNs }];
+    return [activeWindow];
   }
 
   const ranges: LogReadRange[] = [];
-  if (startTimeNs < cachedWindow.startTimeNs) {
-    ranges.push({ endTimeNs: cachedWindow.startTimeNs, startTimeNs });
+  let cursor = activeWindow.startTimeNs;
+  for (const covered of cachedWindow.ranges) {
+    if (covered.startTimeNs > cursor) {
+      ranges.push({ endTimeNs: covered.startTimeNs, startTimeNs: cursor });
+    }
+    if (covered.endTimeNs > cursor) {
+      cursor = covered.endTimeNs;
+    }
+    if (cursor >= activeWindow.endTimeNs) {
+      break;
+    }
   }
-  if (endTimeNs > cachedWindow.endTimeNs) {
-    ranges.push({ endTimeNs, startTimeNs: cachedWindow.endTimeNs });
+  if (cursor < activeWindow.endTimeNs) {
+    ranges.push({ endTimeNs: activeWindow.endTimeNs, startTimeNs: cursor });
   }
 
   return ranges;
 }
 
+function coveredLogReadRange(
+  range: LogReadRange,
+  messageCount: number,
+  lastMessageTimeNs: bigint | undefined,
+): LogReadRange {
+  if (messageCount >= LOG_READ_LIMIT && lastMessageTimeNs !== undefined) {
+    return {
+      endTimeNs: minBigInt(lastMessageTimeNs, range.endTimeNs),
+      startTimeNs: range.startTimeNs,
+    };
+  }
+
+  return range;
+}
+
+function mergeLogReadRanges(
+  ranges: readonly LogReadRange[],
+  activeWindow: LogReadRange,
+): readonly LogReadRange[] {
+  const clippedRanges: LogReadRange[] = [];
+  for (const range of ranges) {
+    const startTimeNs = maxBigInt(range.startTimeNs, activeWindow.startTimeNs);
+    const endTimeNs = minBigInt(range.endTimeNs, activeWindow.endTimeNs);
+    if (startTimeNs <= endTimeNs) {
+      clippedRanges.push({ endTimeNs, startTimeNs });
+    }
+  }
+  clippedRanges.sort((left, right) =>
+    compareBigInt(left.startTimeNs, right.startTimeNs),
+  );
+
+  const merged: LogReadRange[] = [];
+  for (const range of clippedRanges) {
+    const previous = merged[merged.length - 1];
+    if (!previous || range.startTimeNs > previous.endTimeNs) {
+      merged.push(range);
+      continue;
+    }
+    if (range.endTimeNs > previous.endTimeNs) {
+      merged[merged.length - 1] = {
+        ...previous,
+        endTimeNs: range.endTimeNs,
+      };
+    }
+  }
+
+  return merged;
+}
+
 function mergeLogRows(
   current: readonly McapLogConsoleRow[],
   incoming: readonly McapLogConsoleRow[],
+  activeWindow: LogReadRange,
 ): readonly McapLogConsoleRow[] {
+  const retainedRows = pruneLogRows(current, activeWindow);
   if (incoming.length === 0) {
-    return current;
+    return retainedRows;
   }
 
-  const rowsById = new Map(current.map((row) => [row.id, row]));
+  const rowsById = new Map(retainedRows.map((row) => [row.id, row]));
   for (const row of incoming) {
-    rowsById.set(row.id, row);
+    if (logRowInWindow(row, activeWindow)) {
+      rowsById.set(row.id, row);
+    }
   }
   return Array.from(rowsById.values());
 }
 
-function minBigInt(
-  left: bigint | undefined,
-  right: bigint | undefined,
-): bigint {
-  if (left === undefined) {
-    return right ?? 0n;
-  }
-  if (right === undefined) {
-    return left;
-  }
+function pruneLogRows(
+  rows: readonly McapLogConsoleRow[],
+  activeWindow: LogReadRange,
+): readonly McapLogConsoleRow[] {
+  const retainedRows = rows.filter((row) => logRowInWindow(row, activeWindow));
+  return retainedRows.length === rows.length ? rows : retainedRows;
+}
+
+function logRowInWindow(
+  row: McapLogConsoleRow,
+  activeWindow: LogReadRange,
+): boolean {
+  return (
+    row.timeNs >= activeWindow.startTimeNs &&
+    row.timeNs <= activeWindow.endTimeNs
+  );
+}
+
+function minBigInt(left: bigint, right: bigint): bigint {
   return left < right ? left : right;
 }
 
-function maxBigInt(
-  left: bigint | undefined,
-  right: bigint | undefined,
-): bigint {
-  if (left === undefined) {
-    return right ?? 0n;
-  }
-  if (right === undefined) {
-    return left;
-  }
+function maxBigInt(left: bigint, right: bigint): bigint {
   return left > right ? left : right;
 }
 

--- a/app/packages/multimodal/src/adapters/mcap/react/McapLogConsoleTile.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapLogConsoleTile.tsx
@@ -1,0 +1,305 @@
+import {
+  getPlayhead,
+  subscribePlayhead,
+  usePlayback,
+  usePlaybackStore,
+} from "@fiftyone/playback";
+import { useSetTileTitle } from "@fiftyone/tiling";
+import { Checkbox } from "@voxel51/voodo";
+import clsx from "clsx";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { useSceneSourcesByType } from "../../../scene-inventory";
+import { MCAP_LOG_LEVELS, type McapLogLevel } from "../log-records";
+import { MCAP_SOURCE_TYPE } from "../scene-sources";
+import { useMcapDataStream } from "./mcap-data-stream-context";
+import {
+  logConsoleRowsFromDecodedMessage,
+  type McapLogConsoleRow,
+} from "./mcap-log-console-rows";
+import { useMcapLogConsoleContext } from "./mcap-log-console-context";
+import { checkboxNoSpaceToggleProps } from "./mcap-settings-keyboard";
+import styles from "./McapLogConsoleTile.module.css";
+import tileStyles from "./McapTile.module.css";
+import type { McapTileProps } from "./mcap-tile-types";
+
+const PLAYHEAD_REFRESH_MS = 500;
+const LOG_WINDOW_BEFORE_NS = 30_000_000_000n;
+const LOG_WINDOW_AFTER_NS = 2_000_000_000n;
+const LOG_WINDOW_LABEL = "32s";
+const LOG_READ_LIMIT = 600;
+
+interface LogRowsState {
+  readonly error?: string;
+  readonly rows: readonly McapLogConsoleRow[];
+  readonly status: "idle" | "loading" | "ready" | "error";
+}
+
+const INITIAL_ROWS: LogRowsState = { rows: [], status: "idle" };
+
+const McapLogConsoleTile: React.FC<McapTileProps> = () => {
+  const logSources = useSceneSourcesByType(MCAP_SOURCE_TYPE.LOG);
+  const { client, source } = useMcapLogConsoleContext();
+  const dataStream = useMcapDataStream();
+  const timelineIndex = dataStream?.getTimelineIndex() ?? null;
+  const store = usePlaybackStore();
+  const { seek } = usePlayback();
+  const setTileTitle = useSetTileTitle();
+  const [followPlayhead, setFollowPlayhead] = useState(true);
+  const [centerTimeNs, setCenterTimeNs] = useState<bigint | undefined>();
+  const [selectedTopics, setSelectedTopics] = useState<readonly string[]>([]);
+  const [selectedLevels, setSelectedLevels] =
+    useState<readonly McapLogLevel[]>(MCAP_LOG_LEVELS);
+  const [state, setState] = useState<LogRowsState>(INITIAL_ROWS);
+
+  useEffect(() => {
+    setTileTitle("Logs", { source: "auto" });
+  }, [setTileTitle]);
+
+  useEffect(() => {
+    const ids = logSources.map((entry) => entry.id);
+    setSelectedTopics((current) => {
+      const valid = current.filter((topic) => ids.includes(topic));
+      return valid.length > 0 ? valid : ids;
+    });
+  }, [logSources]);
+
+  useEffect(() => {
+    if (!followPlayhead || !timelineIndex) {
+      return undefined;
+    }
+
+    let lastPublishMs = 0;
+    const publish = () => {
+      const now = Date.now();
+      if (now - lastPublishMs < PLAYHEAD_REFRESH_MS) {
+        return;
+      }
+      lastPublishMs = now;
+      setCenterTimeNs(timelineIndex.nearestTick(getPlayhead(store)));
+    };
+
+    publish();
+    return subscribePlayhead(store, publish);
+  }, [followPlayhead, store, timelineIndex]);
+
+  useEffect(() => {
+    if (centerTimeNs === undefined && timelineIndex) {
+      setCenterTimeNs(timelineIndex.startTimeNs);
+    }
+  }, [centerTimeNs, timelineIndex]);
+
+  const selectedLevelSet = useMemo(
+    () => new Set(selectedLevels),
+    [selectedLevels],
+  );
+
+  useEffect(() => {
+    if (!source || centerTimeNs === undefined || selectedTopics.length === 0) {
+      setState(INITIAL_ROWS);
+      return undefined;
+    }
+
+    let cancelled = false;
+    setState((current) => ({ ...current, status: "loading" }));
+
+    const startTimeNs =
+      centerTimeNs > LOG_WINDOW_BEFORE_NS
+        ? centerTimeNs - LOG_WINDOW_BEFORE_NS
+        : 0n;
+    const endTimeNs = centerTimeNs + LOG_WINDOW_AFTER_NS;
+
+    void (async () => {
+      try {
+        const rows: McapLogConsoleRow[] = [];
+        for await (const message of client.readDecodedMessages(
+          {
+            endTimeNs,
+            limit: LOG_READ_LIMIT,
+            source,
+            startTimeNs,
+            topics: selectedTopics,
+          },
+          { priority: "current" },
+        )) {
+          rows.push(...logConsoleRowsFromDecodedMessage(message));
+        }
+
+        if (cancelled) {
+          return;
+        }
+
+        setState({
+          rows: rows
+            .filter((row) => selectedLevelSet.has(row.level))
+            .sort((left, right) => compareBigInt(left.timeNs, right.timeNs)),
+          status: "ready",
+        });
+      } catch (error) {
+        if (!cancelled) {
+          setState({
+            error: error instanceof Error ? error.message : String(error),
+            rows: [],
+            status: "error",
+          });
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [centerTimeNs, client, selectedLevelSet, selectedTopics, source]);
+
+  const handleRowClick = useCallback(
+    (row: McapLogConsoleRow) => {
+      if (!timelineIndex) {
+        return;
+      }
+      setCenterTimeNs(row.timeNs);
+      seek(timelineIndex.nsToSec(row.timeNs));
+    },
+    [seek, timelineIndex],
+  );
+
+  const toggleTopic = useCallback((topic: string, checked: boolean) => {
+    setSelectedTopics((current) =>
+      checked
+        ? [...new Set([...current, topic])]
+        : current.filter((entry) => entry !== topic),
+    );
+  }, []);
+
+  const toggleLevel = useCallback((level: McapLogLevel, checked: boolean) => {
+    setSelectedLevels((current) =>
+      checked
+        ? [...new Set([...current, level])]
+        : current.filter((entry) => entry !== level),
+    );
+  }, []);
+
+  const windowStartNs =
+    centerTimeNs !== undefined && centerTimeNs > LOG_WINDOW_BEFORE_NS
+      ? centerTimeNs - LOG_WINDOW_BEFORE_NS
+      : 0n;
+  const timeOriginNs = timelineIndex?.startTimeNs;
+
+  if (logSources.length === 0) {
+    return (
+      <div className={styles.body} data-testid="mcap-log-console-tile">
+        <div className={styles.empty}>No log streams in this recording</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.body} data-testid="mcap-log-console-tile">
+      <div className={styles.toolbar}>
+        <div className={styles.controlGroup}>
+          <Checkbox
+            checked={followPlayhead}
+            label="Follow"
+            onChange={setFollowPlayhead}
+            {...checkboxNoSpaceToggleProps}
+          />
+        </div>
+        <div className={styles.controlGroup}>
+          {MCAP_LOG_LEVELS.map((level) => (
+            <Checkbox
+              key={level}
+              checked={selectedLevels.includes(level)}
+              label={level}
+              onChange={(checked) => toggleLevel(level, checked)}
+              {...checkboxNoSpaceToggleProps}
+            />
+          ))}
+        </div>
+        {logSources.length > 1 ? (
+          <div className={styles.controlGroup}>
+            {logSources.map((logSource) => (
+              <Checkbox
+                key={logSource.id}
+                checked={selectedTopics.includes(logSource.id)}
+                label={logSource.label}
+                onChange={(checked) => toggleTopic(logSource.id, checked)}
+                {...checkboxNoSpaceToggleProps}
+              />
+            ))}
+          </div>
+        ) : null}
+        <span className={styles.meta}>
+          {state.status === "loading" ? "loading" : state.rows.length} ·{" "}
+          {LOG_WINDOW_LABEL}
+        </span>
+      </div>
+      {state.status === "error" ? (
+        <div className={tileStyles.loading}>
+          <span className={tileStyles.emptyTextError}>
+            Could not read logs{state.error ? `: ${state.error}` : ""}
+          </span>
+        </div>
+      ) : state.rows.length === 0 ? (
+        <div className={styles.empty}>
+          {selectedTopics.length === 0 || selectedLevels.length === 0
+            ? "No filters selected"
+            : "No log rows in this time window"}
+        </div>
+      ) : (
+        <div className={styles.scroll}>
+          {state.rows.map((row) => (
+            <button
+              key={row.id}
+              className={styles.row}
+              onClick={() => handleRowClick(row)}
+              title={rowTitle(row)}
+              type="button"
+            >
+              <span className={styles.time}>
+                {timeOriginNs !== undefined
+                  ? formatRelativeTime(row.timeNs, timeOriginNs)
+                  : formatWindowOffset(row.timeNs, windowStartNs)}
+              </span>
+              <span className={clsx(styles.level, styles[row.level])}>
+                {row.status ?? row.level}
+              </span>
+              <span className={styles.source}>
+                {row.groupLabel ?? row.topic}
+              </span>
+              <span className={styles.message}>{row.message}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+function compareBigInt(left: bigint, right: bigint): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function formatRelativeTime(timeNs: bigint, originNs: bigint): string {
+  const deltaNs = timeNs - originNs;
+  const sign = deltaNs < 0n ? "-" : "";
+  const absoluteNs = deltaNs < 0n ? -deltaNs : deltaNs;
+  const seconds = absoluteNs / 1_000_000_000n;
+  const millis = (absoluteNs % 1_000_000_000n) / 1_000_000n;
+  return `${sign}${seconds.toString()}.${millis.toString().padStart(3, "0")}s`;
+}
+
+function formatWindowOffset(timeNs: bigint, windowStartNs: bigint): string {
+  return `+${formatRelativeTime(timeNs, windowStartNs)}`;
+}
+
+function rowTitle(row: McapLogConsoleRow): string {
+  const location =
+    row.file && row.line ? `${row.file}:${row.line}` : (row.file ?? null);
+  const details =
+    row.details.length > 0
+      ? row.details.map((entry) => `${entry.key}=${entry.value}`).join(", ")
+      : null;
+  return [row.topic, row.groupLabel, location, row.functionName, details]
+    .filter(Boolean)
+    .join(" · ");
+}
+
+export default McapLogConsoleTile;

--- a/app/packages/multimodal/src/adapters/mcap/react/McapLogConsoleTile.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapLogConsoleTile.tsx
@@ -7,7 +7,14 @@ import {
 import { useSetTileTitle } from "@fiftyone/tiling";
 import { Checkbox } from "@voxel51/voodo";
 import clsx from "clsx";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { byteSourceAccessKey } from "../../../query/bytes";
 import { useSceneSourcesByType } from "../../../scene-inventory/SceneInventoryProvider";
 import { MCAP_LOG_LEVELS, type McapLogLevel } from "../log-records";
 import { MCAP_SOURCE_TYPE } from "../scene-sources";
@@ -34,6 +41,19 @@ interface LogRowsState {
   readonly status: "idle" | "loading" | "ready" | "error";
 }
 
+interface LogRowsCacheWindow {
+  readonly client: unknown;
+  readonly endTimeNs: bigint;
+  readonly sourceKey: string;
+  readonly startTimeNs: bigint;
+  readonly topicsKey: string;
+}
+
+interface LogReadRange {
+  readonly endTimeNs: bigint;
+  readonly startTimeNs: bigint;
+}
+
 const INITIAL_ROWS: LogRowsState = { rawRows: [], status: "idle" };
 
 const McapLogConsoleTile: React.FC<McapTileProps> = () => {
@@ -50,6 +70,7 @@ const McapLogConsoleTile: React.FC<McapTileProps> = () => {
   const [selectedLevels, setSelectedLevels] =
     useState<readonly McapLogLevel[]>(MCAP_LOG_LEVELS);
   const [state, setState] = useState<LogRowsState>(INITIAL_ROWS);
+  const fetchedWindowRef = useRef<LogRowsCacheWindow | null>(null);
 
   useEffect(() => {
     setTileTitle("Logs", { source: "auto" });
@@ -92,68 +113,128 @@ const McapLogConsoleTile: React.FC<McapTileProps> = () => {
     () => new Set(selectedLevels),
     [selectedLevels],
   );
+  const selectedTopicsKey = useMemo(
+    () => [...selectedTopics].sort().join("\0"),
+    [selectedTopics],
+  );
+  const sourceKey = source ? byteSourceAccessKey(source) : null;
+  const windowStartNs =
+    centerTimeNs !== undefined ? logWindowStartNs(centerTimeNs) : 0n;
+  const windowEndNs =
+    centerTimeNs !== undefined ? centerTimeNs + LOG_WINDOW_AFTER_NS : undefined;
   const rows = useMemo(
     () =>
       state.rawRows
-        .filter((row) => selectedLevelSet.has(row.level))
+        .filter(
+          (row) =>
+            selectedLevelSet.has(row.level) &&
+            (windowEndNs === undefined ||
+              (row.timeNs >= windowStartNs && row.timeNs <= windowEndNs)),
+        )
         .sort((left, right) => compareBigInt(left.timeNs, right.timeNs)),
-    [selectedLevelSet, state.rawRows],
+    [selectedLevelSet, state.rawRows, windowEndNs, windowStartNs],
   );
 
   useEffect(() => {
     if (
       !source ||
+      !sourceKey ||
       centerTimeNs === undefined ||
-      selectedTopics.length === 0 ||
-      selectedLevels.length === 0
+      selectedTopics.length === 0
     ) {
+      fetchedWindowRef.current = null;
       setState(INITIAL_ROWS);
+      return undefined;
+    }
+    if (selectedLevels.length === 0) {
+      setState((current) =>
+        current.status === "loading"
+          ? { ...current, error: undefined, status: "ready" }
+          : current,
+      );
       return undefined;
     }
 
     let cancelled = false;
-    setState((current) => ({ ...current, status: "loading" }));
-
-    const startTimeNs =
-      centerTimeNs > LOG_WINDOW_BEFORE_NS
-        ? centerTimeNs - LOG_WINDOW_BEFORE_NS
-        : 0n;
+    const startTimeNs = logWindowStartNs(centerTimeNs);
     const endTimeNs = centerTimeNs + LOG_WINDOW_AFTER_NS;
+    const cachedWindow = fetchedWindowRef.current;
+    const reusableWindow =
+      cachedWindow?.client === client &&
+      cachedWindow.sourceKey === sourceKey &&
+      cachedWindow.topicsKey === selectedTopicsKey
+        ? cachedWindow
+        : null;
+    const ranges = missingLogReadRanges(reusableWindow, startTimeNs, endTimeNs);
+
+    if (ranges.length === 0) {
+      setState((current) =>
+        current.status === "ready"
+          ? current
+          : { ...current, error: undefined, status: "ready" },
+      );
+      return undefined;
+    }
+
+    if (!reusableWindow) {
+      fetchedWindowRef.current = null;
+      setState({ rawRows: [], status: "loading" });
+    } else {
+      setState((current) => ({
+        ...current,
+        error: undefined,
+        status: "loading",
+      }));
+    }
 
     void (async () => {
       try {
         const fetchedRows: McapLogConsoleRow[] = [];
-        for await (const message of client.readDecodedMessages(
-          {
-            endTimeNs,
-            limit: LOG_READ_LIMIT,
-            source,
-            startTimeNs,
-            topics: selectedTopics,
-          },
-          { priority: "current" },
-        )) {
+        for (const range of ranges) {
+          for await (const message of client.readDecodedMessages(
+            {
+              endTimeNs: range.endTimeNs,
+              limit: LOG_READ_LIMIT,
+              source,
+              startTimeNs: range.startTimeNs,
+              topics: selectedTopics,
+            },
+            { priority: "current" },
+          )) {
+            if (cancelled) {
+              break;
+            }
+            fetchedRows.push(...logConsoleRowsFromDecodedMessage(message));
+          }
           if (cancelled) {
             break;
           }
-          fetchedRows.push(...logConsoleRowsFromDecodedMessage(message));
         }
 
         if (cancelled) {
           return;
         }
 
-        setState({
-          rawRows: fetchedRows,
+        fetchedWindowRef.current = {
+          client,
+          endTimeNs: maxBigInt(reusableWindow?.endTimeNs, endTimeNs),
+          sourceKey,
+          startTimeNs: minBigInt(reusableWindow?.startTimeNs, startTimeNs),
+          topicsKey: selectedTopicsKey,
+        };
+        setState((current) => ({
+          rawRows: reusableWindow
+            ? mergeLogRows(current.rawRows, fetchedRows)
+            : fetchedRows,
           status: "ready",
-        });
+        }));
       } catch (error) {
         if (!cancelled) {
-          setState({
+          setState((current) => ({
             error: error instanceof Error ? error.message : String(error),
-            rawRows: [],
+            rawRows: reusableWindow ? current.rawRows : [],
             status: "error",
-          });
+          }));
         }
       }
     })();
@@ -161,7 +242,15 @@ const McapLogConsoleTile: React.FC<McapTileProps> = () => {
     return () => {
       cancelled = true;
     };
-  }, [centerTimeNs, client, selectedLevels.length, selectedTopics, source]);
+  }, [
+    centerTimeNs,
+    client,
+    selectedLevels.length,
+    selectedTopics,
+    selectedTopicsKey,
+    source,
+    sourceKey,
+  ]);
 
   const handleRowClick = useCallback(
     (row: McapLogConsoleRow) => {
@@ -190,10 +279,6 @@ const McapLogConsoleTile: React.FC<McapTileProps> = () => {
     );
   }, []);
 
-  const windowStartNs =
-    centerTimeNs !== undefined && centerTimeNs > LOG_WINDOW_BEFORE_NS
-      ? centerTimeNs - LOG_WINDOW_BEFORE_NS
-      : 0n;
   const timeOriginNs = timelineIndex?.startTimeNs;
 
   if (logSources.length === 0) {
@@ -285,6 +370,73 @@ const McapLogConsoleTile: React.FC<McapTileProps> = () => {
     </div>
   );
 };
+
+function logWindowStartNs(centerTimeNs: bigint): bigint {
+  return centerTimeNs > LOG_WINDOW_BEFORE_NS
+    ? centerTimeNs - LOG_WINDOW_BEFORE_NS
+    : 0n;
+}
+
+function missingLogReadRanges(
+  cachedWindow: LogRowsCacheWindow | null,
+  startTimeNs: bigint,
+  endTimeNs: bigint,
+): readonly LogReadRange[] {
+  if (!cachedWindow) {
+    return [{ endTimeNs, startTimeNs }];
+  }
+
+  const ranges: LogReadRange[] = [];
+  if (startTimeNs < cachedWindow.startTimeNs) {
+    ranges.push({ endTimeNs: cachedWindow.startTimeNs, startTimeNs });
+  }
+  if (endTimeNs > cachedWindow.endTimeNs) {
+    ranges.push({ endTimeNs, startTimeNs: cachedWindow.endTimeNs });
+  }
+
+  return ranges;
+}
+
+function mergeLogRows(
+  current: readonly McapLogConsoleRow[],
+  incoming: readonly McapLogConsoleRow[],
+): readonly McapLogConsoleRow[] {
+  if (incoming.length === 0) {
+    return current;
+  }
+
+  const rowsById = new Map(current.map((row) => [row.id, row]));
+  for (const row of incoming) {
+    rowsById.set(row.id, row);
+  }
+  return Array.from(rowsById.values());
+}
+
+function minBigInt(
+  left: bigint | undefined,
+  right: bigint | undefined,
+): bigint {
+  if (left === undefined) {
+    return right ?? 0n;
+  }
+  if (right === undefined) {
+    return left;
+  }
+  return left < right ? left : right;
+}
+
+function maxBigInt(
+  left: bigint | undefined,
+  right: bigint | undefined,
+): bigint {
+  if (left === undefined) {
+    return right ?? 0n;
+  }
+  if (right === undefined) {
+    return left;
+  }
+  return left > right ? left : right;
+}
 
 function compareBigInt(left: bigint, right: bigint): number {
   return left < right ? -1 : left > right ? 1 : 0;

--- a/app/packages/multimodal/src/adapters/mcap/react/McapLogConsoleTile.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapLogConsoleTile.tsx
@@ -101,7 +101,12 @@ const McapLogConsoleTile: React.FC<McapTileProps> = () => {
   );
 
   useEffect(() => {
-    if (!source || centerTimeNs === undefined || selectedTopics.length === 0) {
+    if (
+      !source ||
+      centerTimeNs === undefined ||
+      selectedTopics.length === 0 ||
+      selectedLevels.length === 0
+    ) {
       setState(INITIAL_ROWS);
       return undefined;
     }
@@ -156,7 +161,7 @@ const McapLogConsoleTile: React.FC<McapTileProps> = () => {
     return () => {
       cancelled = true;
     };
-  }, [centerTimeNs, client, selectedTopics, source]);
+  }, [centerTimeNs, client, selectedLevels.length, selectedTopics, source]);
 
   const handleRowClick = useCallback(
     (row: McapLogConsoleRow) => {
@@ -300,7 +305,9 @@ function formatWindowOffset(timeNs: bigint, windowStartNs: bigint): string {
 
 function rowTitle(row: McapLogConsoleRow): string {
   const location =
-    row.file && row.line ? `${row.file}:${row.line}` : (row.file ?? null);
+    row.file && row.line !== undefined
+      ? `${row.file}:${row.line}`
+      : (row.file ?? null);
   const details =
     row.details.length > 0
       ? row.details.map((entry) => `${entry.key}=${entry.value}`).join(", ")

--- a/app/packages/multimodal/src/adapters/mcap/react/McapLogConsoleTile.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapLogConsoleTile.tsx
@@ -8,7 +8,7 @@ import { useSetTileTitle } from "@fiftyone/tiling";
 import { Checkbox } from "@voxel51/voodo";
 import clsx from "clsx";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { useSceneSourcesByType } from "../../../scene-inventory";
+import { useSceneSourcesByType } from "../../../scene-inventory/SceneInventoryProvider";
 import { MCAP_LOG_LEVELS, type McapLogLevel } from "../log-records";
 import { MCAP_SOURCE_TYPE } from "../scene-sources";
 import { useMcapDataStream } from "./mcap-data-stream-context";
@@ -30,11 +30,11 @@ const LOG_READ_LIMIT = 600;
 
 interface LogRowsState {
   readonly error?: string;
-  readonly rows: readonly McapLogConsoleRow[];
+  readonly rawRows: readonly McapLogConsoleRow[];
   readonly status: "idle" | "loading" | "ready" | "error";
 }
 
-const INITIAL_ROWS: LogRowsState = { rows: [], status: "idle" };
+const INITIAL_ROWS: LogRowsState = { rawRows: [], status: "idle" };
 
 const McapLogConsoleTile: React.FC<McapTileProps> = () => {
   const logSources = useSceneSourcesByType(MCAP_SOURCE_TYPE.LOG);
@@ -92,6 +92,13 @@ const McapLogConsoleTile: React.FC<McapTileProps> = () => {
     () => new Set(selectedLevels),
     [selectedLevels],
   );
+  const rows = useMemo(
+    () =>
+      state.rawRows
+        .filter((row) => selectedLevelSet.has(row.level))
+        .sort((left, right) => compareBigInt(left.timeNs, right.timeNs)),
+    [selectedLevelSet, state.rawRows],
+  );
 
   useEffect(() => {
     if (!source || centerTimeNs === undefined || selectedTopics.length === 0) {
@@ -110,7 +117,7 @@ const McapLogConsoleTile: React.FC<McapTileProps> = () => {
 
     void (async () => {
       try {
-        const rows: McapLogConsoleRow[] = [];
+        const fetchedRows: McapLogConsoleRow[] = [];
         for await (const message of client.readDecodedMessages(
           {
             endTimeNs,
@@ -121,7 +128,10 @@ const McapLogConsoleTile: React.FC<McapTileProps> = () => {
           },
           { priority: "current" },
         )) {
-          rows.push(...logConsoleRowsFromDecodedMessage(message));
+          if (cancelled) {
+            break;
+          }
+          fetchedRows.push(...logConsoleRowsFromDecodedMessage(message));
         }
 
         if (cancelled) {
@@ -129,16 +139,14 @@ const McapLogConsoleTile: React.FC<McapTileProps> = () => {
         }
 
         setState({
-          rows: rows
-            .filter((row) => selectedLevelSet.has(row.level))
-            .sort((left, right) => compareBigInt(left.timeNs, right.timeNs)),
+          rawRows: fetchedRows,
           status: "ready",
         });
       } catch (error) {
         if (!cancelled) {
           setState({
             error: error instanceof Error ? error.message : String(error),
-            rows: [],
+            rawRows: [],
             status: "error",
           });
         }
@@ -148,7 +156,7 @@ const McapLogConsoleTile: React.FC<McapTileProps> = () => {
     return () => {
       cancelled = true;
     };
-  }, [centerTimeNs, client, selectedLevelSet, selectedTopics, source]);
+  }, [centerTimeNs, client, selectedTopics, source]);
 
   const handleRowClick = useCallback(
     (row: McapLogConsoleRow) => {
@@ -227,7 +235,7 @@ const McapLogConsoleTile: React.FC<McapTileProps> = () => {
           </div>
         ) : null}
         <span className={styles.meta}>
-          {state.status === "loading" ? "loading" : state.rows.length} ·{" "}
+          {state.status === "loading" ? "loading" : rows.length} ·{" "}
           {LOG_WINDOW_LABEL}
         </span>
       </div>
@@ -237,7 +245,7 @@ const McapLogConsoleTile: React.FC<McapTileProps> = () => {
             Could not read logs{state.error ? `: ${state.error}` : ""}
           </span>
         </div>
-      ) : state.rows.length === 0 ? (
+      ) : rows.length === 0 ? (
         <div className={styles.empty}>
           {selectedTopics.length === 0 || selectedLevels.length === 0
             ? "No filters selected"
@@ -245,7 +253,7 @@ const McapLogConsoleTile: React.FC<McapTileProps> = () => {
         </div>
       ) : (
         <div className={styles.scroll}>
-          {state.rows.map((row) => (
+          {rows.map((row) => (
             <button
               key={row.id}
               className={styles.row}

--- a/app/packages/multimodal/src/adapters/mcap/react/McapMapTile.module.css
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapMapTile.module.css
@@ -1,0 +1,228 @@
+/*
+ * Overlay chrome is keyed to the map imagery (and the fixed-dark no-tile
+ * canvas), not the app theme, so the glass palette is intentionally
+ * literal — but defined once here. The accent is the one theme-sourced
+ * color: Voxel51 primary, matching the ego puck and comet trail drawn in
+ * GL (which resolve the same variable at runtime).
+ */
+.body {
+  --map-surface: #06101a;
+  --map-accent: var(--fo-palette-primary-plainColor, #ff6d04);
+  --map-chrome-bg: rgb(4 12 22 / 76%);
+  --map-chrome-border: rgb(148 163 184 / 28%);
+  --map-chrome-border-subtle: rgb(148 163 184 / 22%);
+  --map-chrome-shadow: 0 8px 20px rgb(0 0 0 / 24%);
+  --map-measure: #22d3ee;
+  --map-text: #e2e8f0;
+  --map-text-muted: #94a3b8;
+
+  background: var(--map-surface);
+  color: var(--map-text);
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+  position: relative;
+  width: 100%;
+}
+
+.map {
+  height: 100%;
+  width: 100%;
+}
+
+.map :global(.maplibregl-ctrl-group) {
+  backdrop-filter: blur(10px);
+  background: var(--map-chrome-bg);
+  border: 1px solid var(--map-chrome-border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.map :global(.maplibregl-ctrl-group:not(:empty)) {
+  box-shadow: var(--map-chrome-shadow);
+}
+
+.map :global(.maplibregl-ctrl-group button) {
+  height: 28px;
+  width: 28px;
+}
+
+.map :global(.maplibregl-ctrl-group button + button) {
+  border-top: 1px solid var(--map-chrome-border-subtle);
+}
+
+.map :global(.maplibregl-ctrl-group button:not(:disabled):hover) {
+  background-color: rgb(56 189 248 / 16%);
+}
+
+.map :global(.maplibregl-ctrl-group button .maplibregl-ctrl-icon) {
+  filter: invert(96%) sepia(7%) saturate(489%) hue-rotate(177deg)
+    brightness(96%) contrast(88%);
+}
+
+.fallback {
+  height: 100%;
+  inset: 0;
+  position: absolute;
+  width: 100%;
+}
+
+.fallback svg {
+  display: block;
+  height: 100%;
+  width: 100%;
+}
+
+.overlay {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  left: 10px;
+  max-width: calc(100% - 20px);
+  pointer-events: none;
+  position: absolute;
+  top: 10px;
+  z-index: 2;
+}
+
+.statusBadge,
+.controlButton {
+  backdrop-filter: blur(10px);
+  background: var(--map-chrome-bg);
+  border: 1px solid var(--map-chrome-border);
+  border-radius: 6px;
+  box-shadow: var(--map-chrome-shadow);
+  color: var(--map-text);
+  font-size: 11px;
+  line-height: 1.2;
+  min-height: 28px;
+  padding: 6px 8px;
+}
+
+.statusBadge {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.controlButton {
+  cursor: pointer;
+  pointer-events: auto;
+}
+
+.controlButton:hover {
+  border-color: var(--map-accent);
+}
+
+.toolOverlay {
+  align-items: flex-end;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  pointer-events: none;
+  position: absolute;
+  right: 10px;
+  top: 78px;
+  z-index: 2;
+}
+
+.iconControlButton,
+.iconControlButtonActive,
+.measureReadout {
+  backdrop-filter: blur(10px);
+  background: var(--map-chrome-bg);
+  border: 1px solid var(--map-chrome-border);
+  border-radius: 6px;
+  box-shadow: var(--map-chrome-shadow);
+  color: var(--map-text);
+}
+
+.iconControlButton,
+.iconControlButtonActive {
+  align-items: center;
+  cursor: pointer;
+  display: inline-flex;
+  height: 28px;
+  justify-content: center;
+  padding: 0;
+  pointer-events: auto;
+  width: 28px;
+}
+
+.iconControlButtonActive {
+  border-color: var(--map-measure);
+  color: var(--map-measure);
+}
+
+.iconControlButton:hover,
+.iconControlButtonActive:hover {
+  border-color: var(--map-accent);
+}
+
+.measureReadout {
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.2;
+  max-width: min(220px, calc(100vw - 40px));
+  padding: 6px 8px;
+  pointer-events: none;
+  text-align: right;
+}
+
+.legend {
+  bottom: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  left: 10px;
+  max-width: min(360px, calc(100% - 20px));
+  pointer-events: none;
+  position: absolute;
+  z-index: 2;
+}
+
+.legendRow {
+  align-items: center;
+  backdrop-filter: blur(10px);
+  background: var(--map-chrome-bg);
+  border: 1px solid var(--map-chrome-border-subtle);
+  border-radius: 6px;
+  display: grid;
+  gap: 6px;
+  grid-template-columns: 10px minmax(0, 1fr) auto;
+  min-height: 24px;
+  padding: 4px 7px;
+}
+
+.legendSwatch {
+  border-radius: 50%;
+  height: 8px;
+  width: 8px;
+}
+
+.legendLabel,
+.legendMeta {
+  font-size: 11px;
+  line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.legendMeta {
+  color: var(--map-text-muted);
+}
+
+.emptyState {
+  align-items: center;
+  color: var(--map-text-muted);
+  display: flex;
+  font-size: 12px;
+  inset: 0;
+  justify-content: center;
+  line-height: 1.35;
+  padding: 16px;
+  position: absolute;
+  text-align: center;
+  z-index: 1;
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/McapMapTile.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapMapTile.tsx
@@ -1,0 +1,1496 @@
+import {
+  getHoverTime,
+  getPlayhead,
+  setHoverTime,
+  subscribeHoverTime,
+  subscribePlayhead,
+  useIsPlaying,
+  usePlayback,
+  usePlaybackStore,
+} from "@fiftyone/playback";
+import { useSetTileTitle } from "@fiftyone/tiling";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import MeasureRulerIcon from "../../../components/MeasureRulerIcon";
+import { useSceneInventory } from "../../../scene-inventory";
+import { MCAP_SOURCE_TYPE } from "../scene-sources";
+import { useMcapLocationTracksContext } from "./mcap-location-tracks-context";
+import {
+  combineLocationBounds,
+  interpolateLocationAtTime,
+  locationBounds,
+  locationTrailCoordinates,
+  type InterpolatedLocation,
+  type LocationBounds,
+  type McapLocationTrackSegment,
+  type McapLocationTrackState,
+} from "./mcap-location-track";
+import {
+  ensurePuckImages,
+  hexColorWithAlpha,
+  puckImageId,
+  PUCK_VARIANT,
+} from "./mcap-map-puck";
+import {
+  formatMapMeasurementDistance,
+  mapMeasurementDistance,
+  nextMapMeasurementState,
+  type MapMeasurementPoint,
+  type MapMeasurementState,
+} from "./mcap-map-measurement";
+import {
+  MCAP_MAP_BASE_LAYER,
+  OPENFREEMAP_LIBERTY_STYLE_URL,
+  type McapMapBaseLayer,
+  useMcapMapTileSettings,
+  useSetMcapMapTileSettings,
+} from "./mcap-map-tile-state";
+import { useMcapDataStream } from "./mcap-data-stream-context";
+import type { McapTileProps } from "./mcap-tile-types";
+import { degreesToRadians } from "./wgs84";
+import McapMapTileSettings from "./McapMapTileSettings";
+import styles from "./McapMapTile.module.css";
+
+const ROUTE_PAST_SOURCE_ID = "mcap-location-route-past";
+const ROUTE_FUTURE_SOURCE_ID = "mcap-location-route-future";
+const HIT_SOURCE_ID = "mcap-location-hit-points";
+const CURRENT_SOURCE_ID = "mcap-location-current";
+const HOVER_SOURCE_ID = "mcap-location-hover";
+const MEASURE_LINE_SOURCE_ID = "mcap-location-measure-line";
+const MEASURE_PREVIEW_SOURCE_ID = "mcap-location-measure-preview";
+const MEASURE_POINTS_SOURCE_ID = "mcap-location-measure-points";
+
+const ROUTE_PAST_LAYER_ID = "mcap-location-route-past";
+const ROUTE_PAST_CASING_LAYER_ID = "mcap-location-route-past-casing";
+const ROUTE_FUTURE_LAYER_ID = "mcap-location-route-future";
+const ROUTE_FUTURE_CASING_LAYER_ID = "mcap-location-route-future-casing";
+const HIT_LAYER_ID = "mcap-location-hit-points";
+const ACCURACY_LAYER_ID = "mcap-location-accuracy";
+const PULSE_LAYER_ID = "mcap-location-pulse";
+const PUCK_LAYER_ID = "mcap-location-puck";
+const HOVER_LAYER_ID = "mcap-location-hover";
+const MEASURE_LINE_LAYER_ID = "mcap-location-measure-line";
+const MEASURE_PREVIEW_LAYER_ID = "mcap-location-measure-preview";
+const MEASURE_POINTS_LAYER_ID = "mcap-location-measure-points";
+
+// Comet-trail sources/layers are per track (line-gradient cannot read
+// feature properties); the color is baked into the id so a palette change
+// recreates the layer.
+const COMET_ID_PREFIX = "mcap-location-comet:";
+const COMET_TRAIL_NS = 15_000_000_000n;
+
+const PULSE_PERIOD_MS = 1_600;
+// Recenter zooms to the recent trail when one exists; otherwise this
+// street-scale zoom around the marker.
+const RECENTER_MARKER_ZOOM = 16;
+// While the recenter animation runs, the follow easeTo must stand down or
+// it freezes the zoom mid-flight (easeTo without zoom keeps current zoom).
+const RECENTER_GUARD_MS = 600;
+const FUTURE_ROUTE_COLOR = "#8b98a9";
+// Dark casing under every route line so the colored strokes hold contrast
+// on light basemaps as well as the dark no-tile canvas.
+const ROUTE_CASING_COLOR = "#0b1220";
+const MEASURE_COLOR = "#22d3ee";
+// Tail alpha of the comet gradient; > 0 keeps the fade gentle rather than
+// a hard laser taper.
+const COMET_TAIL_ALPHA = 0.35;
+
+// Web-mercator ground resolution at zoom 0 on the equator (512px world):
+// 40075016.686m / 512. The accuracy ring stores its radius as
+// pixels-at-zoom-0 so a base-2 zoom interpolation renders a true metric
+// circle at every zoom.
+const METERS_PER_PIXEL_ZOOM_0 = 40075016.686 / 512;
+const MAX_STYLE_ZOOM = 22;
+
+// Type-only imports are erased at compile time, so they do not defeat the
+// dynamic import that keeps maplibre-gl out of the main bundle.
+type MapLibreModule = typeof import("maplibre-gl");
+type MapLibreMap = import("maplibre-gl").Map;
+type MapLibreStyle = import("maplibre-gl").StyleSpecification;
+
+interface MapLayerFeatureEvent {
+  readonly features?: readonly {
+    readonly properties?: Record<string, unknown>;
+  }[];
+}
+
+interface MapPointerEvent {
+  readonly lngLat?: {
+    readonly lat: number;
+    readonly lng: number;
+  };
+}
+
+interface GeoJsonFeature {
+  readonly type: "Feature";
+  readonly geometry: {
+    readonly type: "LineString" | "Point";
+    readonly coordinates: readonly unknown[];
+  };
+  readonly properties: Record<string, string | number | boolean | undefined>;
+}
+
+interface GeoJsonFeatureCollection {
+  readonly type: "FeatureCollection";
+  readonly features: readonly GeoJsonFeature[];
+}
+
+let mapLibreImport: Promise<MapLibreModule> | null = null;
+let mapLibreCssImport: Promise<void> | null = null;
+
+const EMPTY_FEATURE_COLLECTION: GeoJsonFeatureCollection = {
+  type: "FeatureCollection",
+  features: [],
+};
+
+const NO_TILE_STYLE: MapLibreStyle = {
+  version: 8,
+  sources: {},
+  layers: [
+    {
+      id: "mcap-location-background",
+      type: "background",
+      paint: { "background-color": "#06101a" },
+    },
+  ],
+};
+
+const McapMapTile: React.FC<McapTileProps> = () => {
+  const setTileTitle = useSetTileTitle();
+  const sources = useSceneInventory();
+  const tracksByTopic = useMcapLocationTracksContext();
+  const settings = useMcapMapTileSettings();
+  const setSettings = useSetMcapMapTileSettings();
+  const dataStream = useMcapDataStream();
+  const timeline = dataStream?.getTimelineIndex() ?? null;
+  const store = usePlaybackStore();
+  const { seek } = usePlayback();
+  const isPlaying = useIsPlaying();
+  const [playheadSec, setPlayheadSec] = useState(() => getPlayhead(store));
+  const [hoverSec, setHoverSec] = useState<number | null>(() =>
+    getHoverTime(store),
+  );
+  const [recenterNonce, setRecenterNonce] = useState(0);
+  const [measureArmed, setMeasureArmed] = useState(false);
+  const [measurement, setMeasurement] = useState<MapMeasurementState | null>(
+    null,
+  );
+
+  const locationSources = useMemo(
+    () => sources.filter((source) => source.type === MCAP_SOURCE_TYPE.LOCATION),
+    [sources],
+  );
+  const allTopics = useMemo(
+    () => locationSources.map((source) => source.id),
+    [locationSources],
+  );
+  const enabledTopics = useMemo(
+    () => new Set(settings.enabledTopics ?? allTopics),
+    [allTopics, settings.enabledTopics],
+  );
+  const visibleTopics = useMemo(
+    () => allTopics.filter((topic) => enabledTopics.has(topic)),
+    [allTopics, enabledTopics],
+  );
+  const tracks = useMemo(
+    () =>
+      visibleTopics
+        .map((topic) => tracksByTopic.get(topic))
+        .filter((track): track is McapLocationTrackState => Boolean(track)),
+    [tracksByTopic, visibleTopics],
+  );
+  const readyTracks = useMemo(
+    () =>
+      tracks.filter(
+        (track) => track.status === "ready" && track.segments.length > 0,
+      ),
+    [tracks],
+  );
+
+  useEffect(() => {
+    setTileTitle(mapTileTitle(readyTracks, locationSources.length), {
+      source: "auto",
+    });
+  }, [locationSources.length, readyTracks, setTileTitle]);
+
+  useEffect(() => {
+    const unsubscribePlayhead = subscribePlayhead(store, () => {
+      setPlayheadSec(getPlayhead(store));
+    });
+    const unsubscribeHover = subscribeHoverTime(store, () => {
+      setHoverSec(getHoverTime(store));
+    });
+    setPlayheadSec(getPlayhead(store));
+    setHoverSec(getHoverTime(store));
+    return () => {
+      unsubscribePlayhead();
+      unsubscribeHover();
+      setHoverTime(store, null);
+    };
+  }, [store]);
+
+  const playheadNs = useMemo(
+    () => (timeline ? timeline.secToNs(playheadSec) : null),
+    [playheadSec, timeline],
+  );
+  const hoverNs = useMemo(
+    () => (timeline && hoverSec !== null ? timeline.secToNs(hoverSec) : null),
+    [hoverSec, timeline],
+  );
+  const bounds = useMemo(
+    () =>
+      combineLocationBounds(
+        readyTracks.map((track) => locationBounds(track.segments)),
+      ),
+    [readyTracks],
+  );
+  const currentLocations = useMemo(
+    () => trackMarkersAt(readyTracks, playheadNs),
+    [playheadNs, readyTracks],
+  );
+  const hoverLocations = useMemo(
+    () => trackMarkersAt(readyTracks, hoverNs),
+    [hoverNs, readyTracks],
+  );
+
+  const onSeekTimeNs = useCallback(
+    (timeNs: bigint) => {
+      if (!timeline) return;
+      seek(timeline.nsToSec(timeNs));
+    },
+    [seek, timeline],
+  );
+  const onHoverTimeNs = useCallback(
+    (timeNs: bigint | null) => {
+      setHoverTime(
+        store,
+        timeNs !== null && timeline ? timeline.nsToSec(timeNs) : null,
+      );
+    },
+    [store, timeline],
+  );
+  const onMeasurePick = useCallback((point: MapMeasurementPoint) => {
+    setMeasurement((current) => nextMapMeasurementState(current, point));
+  }, []);
+  const onMeasureToggle = useCallback(() => {
+    setMeasureArmed((armed) => {
+      if (armed) setMeasurement(null);
+      return !armed;
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!measureArmed) return undefined;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      if (measurement) {
+        setMeasurement(null);
+      } else {
+        setMeasureArmed(false);
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [measureArmed, measurement]);
+
+  const measuredDistance = mapMeasurementDistance(measurement);
+  const measureReadout = !measureArmed
+    ? null
+    : measuredDistance !== null
+      ? formatMapMeasurementDistance(measuredDistance)
+      : measurement
+        ? "Pick the second map point"
+        : "Pick two map points";
+
+  const loadingCount = tracks.filter(
+    (track) => track.status === "loading",
+  ).length;
+  const errorCount = tracks.filter((track) => track.status === "error").length;
+  const truncated = tracks.some((track) => track.truncated);
+  const statusText = mapStatusText({
+    enabledTopicCount: visibleTopics.length,
+    errorCount,
+    loadingCount,
+    locationTopicCount: locationSources.length,
+    readyTrackCount: readyTracks.length,
+    truncated,
+  });
+
+  return (
+    <>
+      <McapMapTileSettings />
+      <div className={styles.body} data-testid="mcap-map-tile">
+        <McapMapLibreSurface
+          bounds={bounds}
+          currentLocations={currentLocations}
+          followEgo={settings.followEgo}
+          hoverLocations={hoverLocations}
+          measureArmed={measureArmed}
+          measurement={measurement}
+          onHoverTimeNs={onHoverTimeNs}
+          onMeasurePick={onMeasurePick}
+          onSeekTimeNs={onSeekTimeNs}
+          onUserMove={() => setSettings({ followEgo: false })}
+          playheadNs={playheadNs}
+          pulseActive={isPlaying}
+          recenterNonce={recenterNonce}
+          baseLayer={settings.baseLayer}
+          tracks={readyTracks}
+        />
+        <div className={styles.overlay}>
+          {statusText ? (
+            <span className={styles.statusBadge}>{statusText}</span>
+          ) : null}
+          {!settings.followEgo && readyTracks.length > 0 ? (
+            <button
+              className={styles.controlButton}
+              onClick={() => {
+                setSettings({ followEgo: true });
+                setRecenterNonce((value) => value + 1);
+              }}
+              type="button"
+            >
+              Recenter
+            </button>
+          ) : null}
+        </div>
+        {readyTracks.length > 0 ? (
+          <div className={styles.toolOverlay}>
+            <button
+              aria-label="Measure distance"
+              aria-pressed={measureArmed}
+              className={
+                measureArmed
+                  ? styles.iconControlButtonActive
+                  : styles.iconControlButton
+              }
+              onClick={onMeasureToggle}
+              title="Measure distance on the map (Esc clears)"
+              type="button"
+            >
+              <MeasureRulerIcon />
+            </button>
+            {measureReadout ? (
+              <div className={styles.measureReadout}>{measureReadout}</div>
+            ) : null}
+          </div>
+        ) : null}
+        {readyTracks.length > 0 ? <MapLegend tracks={readyTracks} /> : null}
+        {emptyText({
+          enabledTopicCount: visibleTopics.length,
+          locationTopicCount: locationSources.length,
+          loadingCount,
+          readyTrackCount: readyTracks.length,
+        })}
+      </div>
+    </>
+  );
+};
+
+function McapMapLibreSurface({
+  baseLayer,
+  bounds,
+  currentLocations,
+  followEgo,
+  hoverLocations,
+  measureArmed,
+  measurement,
+  onHoverTimeNs,
+  onMeasurePick,
+  onSeekTimeNs,
+  onUserMove,
+  playheadNs,
+  pulseActive,
+  recenterNonce,
+  tracks,
+}: {
+  readonly baseLayer: McapMapBaseLayer;
+  readonly bounds: LocationBounds | null;
+  readonly currentLocations: readonly MapLocationMarker[];
+  readonly followEgo: boolean;
+  readonly hoverLocations: readonly MapLocationMarker[];
+  readonly measureArmed: boolean;
+  readonly measurement: MapMeasurementState | null;
+  readonly onHoverTimeNs: (timeNs: bigint | null) => void;
+  readonly onMeasurePick: (point: MapMeasurementPoint) => void;
+  readonly onSeekTimeNs: (timeNs: bigint) => void;
+  readonly onUserMove: () => void;
+  readonly playheadNs: bigint | null;
+  readonly pulseActive: boolean;
+  readonly recenterNonce: number;
+  readonly tracks: readonly McapLocationTrackState[];
+}) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const mapRef = useRef<MapLibreMap | null>(null);
+  const loadedRef = useRef(false);
+  const fitKeyRef = useRef<string | null>(null);
+  const recenterGuardUntilRef = useRef(0);
+  const [failed, setFailed] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const [measurementHover, setMeasurementHover] =
+    useState<MapMeasurementPoint | null>(null);
+  const onSeekTimeNsRef = useRef(onSeekTimeNs);
+  const onHoverTimeNsRef = useRef(onHoverTimeNs);
+  const onMeasurePickRef = useRef(onMeasurePick);
+  const onUserMoveRef = useRef(onUserMove);
+  const measureArmedRef = useRef(measureArmed);
+  const measurementRef = useRef(measurement);
+  onSeekTimeNsRef.current = onSeekTimeNs;
+  onHoverTimeNsRef.current = onHoverTimeNs;
+  onMeasurePickRef.current = onMeasurePick;
+  onUserMoveRef.current = onUserMove;
+  measureArmedRef.current = measureArmed;
+  measurementRef.current = measurement;
+
+  useEffect(() => {
+    if (!containerRef.current || mapRef.current || failed) {
+      return undefined;
+    }
+    setLoaded(false);
+    loadedRef.current = false;
+    fitKeyRef.current = null;
+    let cancelled = false;
+    let resizeObserver: ResizeObserver | null = null;
+
+    void loadMapLibre()
+      .then((maplibregl) => {
+        if (cancelled || !containerRef.current) return;
+        const map = new maplibregl.Map({
+          attributionControl: false,
+          center: [0, 0],
+          container: containerRef.current,
+          interactive: true,
+          pitchWithRotate: false,
+          style: mapStyleForBaseLayer(baseLayer),
+          zoom: 1,
+        });
+        mapRef.current = map;
+        map.addControl(
+          new maplibregl.NavigationControl({
+            showCompass: false,
+            showZoom: true,
+          }),
+          "top-right",
+        );
+
+        map.on("load", () => {
+          loadedRef.current = true;
+          addMcapMapSourcesAndLayers(map);
+          setLoaded(true);
+        });
+        map.on("error", () => {
+          if (!loadedRef.current) {
+            setFailed(true);
+          }
+        });
+        const handleUserMove = (event: { originalEvent?: unknown }) => {
+          if (event.originalEvent) {
+            onUserMoveRef.current();
+          }
+        };
+        map.on("dragstart", handleUserMove);
+        map.on("zoomstart", handleUserMove);
+        map.on("rotatestart", handleUserMove);
+        map.on("pitchstart", handleUserMove);
+        map.on("click", HIT_LAYER_ID, (event) => {
+          if (measureArmedRef.current) return;
+          const timeNs = timeNsFromMapEvent(event);
+          if (timeNs !== null) {
+            onSeekTimeNsRef.current(timeNs);
+          }
+        });
+        map.on("mousemove", HIT_LAYER_ID, (event) => {
+          if (measureArmedRef.current) return;
+          map.getCanvas().style.cursor = "pointer";
+          onHoverTimeNsRef.current(timeNsFromMapEvent(event));
+        });
+        map.on("mouseleave", HIT_LAYER_ID, () => {
+          if (measureArmedRef.current) return;
+          map.getCanvas().style.cursor = "";
+          onHoverTimeNsRef.current(null);
+        });
+        map.on("click", (event) => {
+          if (!measureArmedRef.current) return;
+          const point = measurementPointFromMapEvent(event);
+          if (point) onMeasurePickRef.current(point);
+        });
+        map.on("mousemove", (event) => {
+          if (!measureArmedRef.current) return;
+          const current = measurementRef.current;
+          if (!current || current.b) {
+            setMeasurementHover(null);
+            return;
+          }
+          setMeasurementHover(measurementPointFromMapEvent(event));
+        });
+        // "mouseleave" only exists as a layer-scoped event; the map-level
+        // pointer-exit event is "mouseout".
+        map.on("mouseout", () => {
+          setMeasurementHover(null);
+        });
+        map.getCanvas().addEventListener("webglcontextlost", () => {
+          setFailed(true);
+        });
+
+        if (typeof ResizeObserver !== "undefined") {
+          resizeObserver = new ResizeObserver(() => map.resize());
+          resizeObserver.observe(containerRef.current);
+        }
+      })
+      .catch(() => setFailed(true));
+
+    return () => {
+      cancelled = true;
+      resizeObserver?.disconnect();
+      const map = mapRef.current;
+      if (map) {
+        map.remove();
+        mapRef.current = null;
+      }
+      loadedRef.current = false;
+    };
+  }, [baseLayer, failed]);
+
+  useEffect(() => {
+    setFailed(false);
+  }, [baseLayer]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+    map.getCanvas().style.cursor = measureArmed ? "crosshair" : "";
+    if (!measureArmed) {
+      setMeasurementHover(null);
+    }
+  }, [measureArmed, loaded]);
+
+  const sourceData = useMemo(
+    () => ({
+      comets: cometTrails(tracks, playheadNs),
+      current: currentPuckFeatures(currentLocations),
+      future: routeFeatures(tracks, playheadNs, "future"),
+      hit: hitPointFeatures(tracks),
+      hover: markerFeatures(hoverLocations),
+      measureLine: measurementLineFeature(measurement),
+      measurePoints: measurementPointFeatures(measurement),
+      measurePreview: measurementPreviewFeature(measurement, measurementHover),
+      past: routeFeatures(tracks, playheadNs, "past"),
+      trackColors: tracks.map((track) => track.color),
+    }),
+    [
+      currentLocations,
+      hoverLocations,
+      measurement,
+      measurementHover,
+      playheadNs,
+      tracks,
+    ],
+  );
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !loadedRef.current) {
+      return;
+    }
+    ensurePuckImages(map, sourceData.trackColors);
+    syncCometLayers(map, sourceData.comets);
+    setGeoJsonSourceData(map, ROUTE_PAST_SOURCE_ID, sourceData.past);
+    setGeoJsonSourceData(map, ROUTE_FUTURE_SOURCE_ID, sourceData.future);
+    setGeoJsonSourceData(map, HIT_SOURCE_ID, sourceData.hit);
+    setGeoJsonSourceData(map, CURRENT_SOURCE_ID, sourceData.current);
+    setGeoJsonSourceData(map, HOVER_SOURCE_ID, sourceData.hover);
+    setGeoJsonSourceData(map, MEASURE_LINE_SOURCE_ID, sourceData.measureLine);
+    setGeoJsonSourceData(
+      map,
+      MEASURE_PREVIEW_SOURCE_ID,
+      sourceData.measurePreview,
+    );
+    setGeoJsonSourceData(
+      map,
+      MEASURE_POINTS_SOURCE_ID,
+      sourceData.measurePoints,
+    );
+  }, [sourceData, loaded]);
+
+  // Sonar pulse under the puck while playing: the marker doubles as the
+  // playback-state indicator. rAF-driven paint updates on one tiny layer.
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !loadedRef.current || !map.getLayer(PULSE_LAYER_ID)) {
+      return undefined;
+    }
+    if (!pulseActive) {
+      map.setPaintProperty(PULSE_LAYER_ID, "circle-opacity", 0);
+      return undefined;
+    }
+    let frame = 0;
+    const tick = (now: number) => {
+      const phase = (now % PULSE_PERIOD_MS) / PULSE_PERIOD_MS;
+      map.setPaintProperty(PULSE_LAYER_ID, "circle-radius", 10 + phase * 16);
+      map.setPaintProperty(PULSE_LAYER_ID, "circle-opacity", 0.4 * (1 - phase));
+      frame = requestAnimationFrame(tick);
+    };
+    frame = requestAnimationFrame(tick);
+    return () => {
+      cancelAnimationFrame(frame);
+      // Skip the reset when this cleanup races a map teardown.
+      if (mapRef.current === map && map.getLayer(PULSE_LAYER_ID)) {
+        map.setPaintProperty(PULSE_LAYER_ID, "circle-opacity", 0);
+      }
+    };
+  }, [pulseActive, loaded]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !loadedRef.current || !bounds) {
+      return;
+    }
+    const fitKey = `${bounds.west}:${bounds.south}:${bounds.east}:${bounds.north}`;
+    if (fitKeyRef.current === fitKey) {
+      return;
+    }
+    fitKeyRef.current = fitKey;
+    map.fitBounds(
+      [
+        [bounds.west, bounds.south],
+        [bounds.east, bounds.north],
+      ],
+      { duration: 240, maxZoom: 17, padding: 42 },
+    );
+  }, [bounds, loaded]);
+
+  // Recenter: re-frame around "now" — fit the recent trail when one
+  // exists (adaptive zoom: a fast vehicle gets a wider view), else ease to
+  // the marker at street zoom, else fall back to the whole track.
+  useEffect(() => {
+    const map = mapRef.current;
+    if (recenterNonce === 0 || !map || !loadedRef.current) {
+      return;
+    }
+    recenterGuardUntilRef.current = performance.now() + RECENTER_GUARD_MS;
+    const trailBounds = coordinateBounds(
+      sourceData.comets.flatMap((trail) => trail.coordinates),
+    );
+    const marker = currentLocations[0]?.location;
+    if (trailBounds) {
+      map.fitBounds(
+        [
+          [trailBounds.west, trailBounds.south],
+          [trailBounds.east, trailBounds.north],
+        ],
+        { duration: 400, maxZoom: 17, padding: 80 },
+      );
+    } else if (marker) {
+      map.easeTo({
+        center: [marker.longitude, marker.latitude],
+        duration: 400,
+        zoom: RECENTER_MARKER_ZOOM,
+      });
+    } else if (bounds) {
+      map.fitBounds(
+        [
+          [bounds.west, bounds.south],
+          [bounds.east, bounds.north],
+        ],
+        { duration: 400, maxZoom: 17, padding: 42 },
+      );
+    }
+    // Latest-closure effect: only the nonce (and load state) may trigger
+    // it — depending on trail/marker would re-run the camera move every
+    // playhead tick — but React runs the freshest closure, so the values
+    // read here are current.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [recenterNonce, loaded]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    const current = currentLocations[0]?.location;
+    if (!map || !loadedRef.current || !followEgo || !current) {
+      return;
+    }
+    if (performance.now() < recenterGuardUntilRef.current) {
+      return;
+    }
+    map.easeTo({
+      center: [current.longitude, current.latitude],
+      duration: 120,
+      essential: false,
+    });
+  }, [currentLocations, followEgo, loaded]);
+
+  return (
+    <>
+      <div className={styles.map} ref={containerRef} />
+      {failed || !loaded ? (
+        <div className={styles.fallback}>
+          <StaticLocationMap tracks={tracks} />
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+interface MapLocationMarker {
+  readonly color: string;
+  readonly label: string;
+  readonly location: InterpolatedLocation;
+  readonly topic: string;
+}
+
+function trackMarkersAt(
+  tracks: readonly McapLocationTrackState[],
+  timeNs: bigint | null,
+): readonly MapLocationMarker[] {
+  if (timeNs === null) return [];
+  const markers: MapLocationMarker[] = [];
+  for (const track of tracks) {
+    const location = interpolateLocationAtTime(track.segments, timeNs);
+    if (location) {
+      markers.push({
+        color: track.color,
+        label: track.label,
+        location,
+        topic: track.topic,
+      });
+    }
+  }
+  return markers;
+}
+
+function MapLegend({
+  tracks,
+}: {
+  readonly tracks: readonly McapLocationTrackState[];
+}) {
+  return (
+    <div className={styles.legend}>
+      {tracks.map((track) => (
+        <div className={styles.legendRow} key={track.topic} title={track.topic}>
+          <span
+            className={styles.legendSwatch}
+            style={{ backgroundColor: track.color }}
+          />
+          <span className={styles.legendLabel}>{track.label}</span>
+          <span className={styles.legendMeta}>
+            {track.pointCount.toLocaleString()}
+            {track.truncated ? " sampled" : ""}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function StaticLocationMap({
+  tracks,
+}: {
+  readonly tracks: readonly McapLocationTrackState[];
+}) {
+  const bounds = combineLocationBounds(
+    tracks.map((track) => locationBounds(track.segments)),
+  );
+  const project = useCallback(
+    (longitude: number, latitude: number): [number, number] => {
+      if (!bounds) return [50, 50];
+      const width = Math.max(bounds.east - bounds.west, 0.000001);
+      const height = Math.max(bounds.north - bounds.south, 0.000001);
+      const x = ((longitude - bounds.west) / width) * 92 + 4;
+      const y = 96 - ((latitude - bounds.south) / height) * 92;
+      return [x, y];
+    },
+    [bounds],
+  );
+
+  return (
+    <svg aria-hidden="true" preserveAspectRatio="none" viewBox="0 0 100 100">
+      <rect fill="#06101a" height="100" width="100" />
+      {Array.from({ length: 6 }, (_, index) => (
+        <React.Fragment key={index}>
+          <line
+            stroke="rgba(148, 163, 184, 0.14)"
+            strokeWidth="0.15"
+            x1={index * 20}
+            x2={index * 20}
+            y1="0"
+            y2="100"
+          />
+          <line
+            stroke="rgba(148, 163, 184, 0.14)"
+            strokeWidth="0.15"
+            x1="0"
+            x2="100"
+            y1={index * 20}
+            y2={index * 20}
+          />
+        </React.Fragment>
+      ))}
+      {tracks.flatMap((track) =>
+        track.segments.map((segment, segmentIndex) => {
+          const points = segment.points
+            .map((point) => project(point.longitude, point.latitude))
+            .map(([x, y]) => `${x},${y}`)
+            .join(" ");
+          return (
+            <polyline
+              fill="none"
+              key={`${track.topic}:${segmentIndex}`}
+              points={points}
+              stroke={track.color}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="0.7"
+            />
+          );
+        }),
+      )}
+    </svg>
+  );
+}
+
+function addMcapMapSourcesAndLayers(map: MapLibreMap) {
+  addGeoJsonSource(map, ROUTE_PAST_SOURCE_ID);
+  addGeoJsonSource(map, ROUTE_FUTURE_SOURCE_ID);
+  addGeoJsonSource(map, HIT_SOURCE_ID);
+  addGeoJsonSource(map, CURRENT_SOURCE_ID);
+  addGeoJsonSource(map, HOVER_SOURCE_ID);
+  addGeoJsonSource(map, MEASURE_LINE_SOURCE_ID);
+  addGeoJsonSource(map, MEASURE_PREVIEW_SOURCE_ID);
+  addGeoJsonSource(map, MEASURE_POINTS_SOURCE_ID);
+
+  map.addLayer({
+    id: ROUTE_FUTURE_CASING_LAYER_ID,
+    type: "line",
+    source: ROUTE_FUTURE_SOURCE_ID,
+    layout: { "line-cap": "round", "line-join": "round" },
+    paint: {
+      "line-color": ROUTE_CASING_COLOR,
+      "line-opacity": 0.55,
+      "line-width": 4.5,
+    },
+  });
+  // Future route is deliberately colorless: track identity lives in the
+  // traveled route, comet trail, puck, and legend.
+  map.addLayer({
+    id: ROUTE_FUTURE_LAYER_ID,
+    type: "line",
+    source: ROUTE_FUTURE_SOURCE_ID,
+    layout: { "line-cap": "round", "line-join": "round" },
+    paint: {
+      "line-color": FUTURE_ROUTE_COLOR,
+      "line-opacity": 0.3,
+      "line-width": 2.5,
+    },
+  });
+  map.addLayer({
+    id: ROUTE_PAST_CASING_LAYER_ID,
+    type: "line",
+    source: ROUTE_PAST_SOURCE_ID,
+    layout: { "line-cap": "round", "line-join": "round" },
+    paint: {
+      "line-color": ROUTE_CASING_COLOR,
+      "line-opacity": 0.85,
+      "line-width": 4.5,
+    },
+  });
+  // Dim history base; the per-track comet-trail layers (inserted above
+  // this, below the pulse) add the bright gradient head behind the puck.
+  map.addLayer({
+    id: ROUTE_PAST_LAYER_ID,
+    type: "line",
+    source: ROUTE_PAST_SOURCE_ID,
+    layout: { "line-cap": "round", "line-join": "round" },
+    paint: {
+      "line-color": ["get", "color"],
+      "line-opacity": 0.5,
+      "line-width": 2.5,
+    },
+  });
+  // Accuracy ring: the receiver's own 2σ horizontal-error estimate as a
+  // metric circle under the puck. Present only when the fix carried a
+  // non-degenerate covariance — no estimate, no ring.
+  map.addLayer({
+    id: ACCURACY_LAYER_ID,
+    type: "circle",
+    source: CURRENT_SOURCE_ID,
+    filter: ["has", "accuracyPx0"],
+    paint: {
+      "circle-color": ["get", "color"],
+      "circle-opacity": 0.12,
+      "circle-pitch-alignment": "map",
+      "circle-radius": [
+        "interpolate",
+        ["exponential", 2],
+        ["zoom"],
+        0,
+        ["get", "accuracyPx0"],
+        MAX_STYLE_ZOOM,
+        ["*", ["get", "accuracyPx0"], 2 ** MAX_STYLE_ZOOM],
+      ],
+      "circle-stroke-color": ["get", "color"],
+      "circle-stroke-opacity": 0.4,
+      "circle-stroke-width": 1,
+    },
+  });
+  map.addLayer({
+    id: PULSE_LAYER_ID,
+    type: "circle",
+    source: CURRENT_SOURCE_ID,
+    paint: {
+      "circle-color": ["get", "color"],
+      "circle-opacity": 0,
+      "circle-radius": 10,
+    },
+  });
+  map.addLayer({
+    id: HOVER_LAYER_ID,
+    type: "circle",
+    source: HOVER_SOURCE_ID,
+    paint: {
+      "circle-color": "#f8fafc",
+      "circle-radius": 5,
+      "circle-stroke-color": ["get", "color"],
+      "circle-stroke-width": 2,
+    },
+  });
+  map.addLayer({
+    id: MEASURE_PREVIEW_LAYER_ID,
+    type: "line",
+    source: MEASURE_PREVIEW_SOURCE_ID,
+    paint: {
+      "line-color": MEASURE_COLOR,
+      "line-dasharray": [1.2, 1.2],
+      "line-opacity": 0.9,
+      "line-width": 2,
+    },
+  });
+  map.addLayer({
+    id: MEASURE_LINE_LAYER_ID,
+    type: "line",
+    source: MEASURE_LINE_SOURCE_ID,
+    paint: {
+      "line-color": MEASURE_COLOR,
+      "line-opacity": 0.95,
+      "line-width": 2.5,
+    },
+  });
+  map.addLayer({
+    id: MEASURE_POINTS_LAYER_ID,
+    type: "circle",
+    source: MEASURE_POINTS_SOURCE_ID,
+    paint: {
+      "circle-color": MEASURE_COLOR,
+      "circle-radius": 4.5,
+      "circle-stroke-color": "#06101a",
+      "circle-stroke-width": 1.5,
+    },
+  });
+  map.addLayer({
+    id: HIT_LAYER_ID,
+    type: "circle",
+    source: HIT_SOURCE_ID,
+    paint: {
+      "circle-opacity": 0,
+      "circle-radius": 8,
+    },
+  });
+  map.addLayer({
+    id: PUCK_LAYER_ID,
+    type: "symbol",
+    source: CURRENT_SOURCE_ID,
+    layout: {
+      "icon-allow-overlap": true,
+      "icon-ignore-placement": true,
+      "icon-image": ["get", "icon"],
+      "icon-rotate": ["get", "bearing"],
+      "icon-rotation-alignment": "map",
+    },
+  });
+}
+
+interface CometTrail {
+  readonly color: string;
+  readonly coordinates: readonly [number, number][];
+  readonly key: string;
+}
+
+function coordinateBounds(
+  coordinates: readonly [number, number][],
+): LocationBounds | null {
+  if (coordinates.length === 0) {
+    return null;
+  }
+  let west = Number.POSITIVE_INFINITY;
+  let east = Number.NEGATIVE_INFINITY;
+  let south = Number.POSITIVE_INFINITY;
+  let north = Number.NEGATIVE_INFINITY;
+  for (const [longitude, latitude] of coordinates) {
+    west = Math.min(west, longitude);
+    east = Math.max(east, longitude);
+    south = Math.min(south, latitude);
+    north = Math.max(north, latitude);
+  }
+  return { east, north, south, west };
+}
+
+function cometTrails(
+  tracks: readonly McapLocationTrackState[],
+  playheadNs: bigint | null,
+): readonly CometTrail[] {
+  if (playheadNs === null) {
+    return [];
+  }
+  const trails: CometTrail[] = [];
+  for (const track of tracks) {
+    const coordinates = locationTrailCoordinates(
+      track.segments,
+      playheadNs,
+      COMET_TRAIL_NS,
+    );
+    if (coordinates.length >= 2) {
+      trails.push({
+        color: track.color,
+        coordinates,
+        key: `${COMET_ID_PREFIX}${track.color}:${track.topic}`,
+      });
+    }
+  }
+  return trails;
+}
+
+/**
+ * Reconciles one gradient line source+layer per comet trail. Layers are
+ * per track because `line-gradient` cannot read feature properties; the
+ * gradient runs transparent → track color toward the puck.
+ */
+function syncCometLayers(
+  map: MapLibreMap,
+  trails: readonly CometTrail[],
+): void {
+  const wanted = new Map(trails.map((trail) => [trail.key, trail]));
+  for (const layer of map.getStyle()?.layers ?? []) {
+    if (layer.id.startsWith(COMET_ID_PREFIX) && !wanted.has(layer.id)) {
+      map.removeLayer(layer.id);
+      map.removeSource(layer.id);
+    }
+  }
+  for (const [id, trail] of wanted) {
+    if (!map.getSource(id)) {
+      map.addSource(id, {
+        type: "geojson",
+        data: EMPTY_FEATURE_COLLECTION,
+        lineMetrics: true,
+      } as never);
+      map.addLayer(
+        {
+          id,
+          type: "line",
+          source: id,
+          layout: { "line-cap": "round", "line-join": "round" },
+          paint: {
+            "line-gradient": [
+              "interpolate",
+              ["linear"],
+              ["line-progress"],
+              0,
+              hexColorWithAlpha(trail.color, COMET_TAIL_ALPHA),
+              1,
+              trail.color,
+            ],
+            // Same width as the base route so the trail reads as part of
+            // the line rather than a bulge riding on top of it.
+            "line-width": 2.5,
+          },
+        },
+        PULSE_LAYER_ID,
+      );
+    }
+    setGeoJsonSourceData(map, id, {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          geometry: { type: "LineString", coordinates: trail.coordinates },
+          properties: {},
+        },
+      ],
+    });
+  }
+}
+
+function addGeoJsonSource(map: MapLibreMap, sourceId: string) {
+  map.addSource(sourceId, {
+    type: "geojson",
+    data: EMPTY_FEATURE_COLLECTION,
+  } as never);
+}
+
+function setGeoJsonSourceData(
+  map: MapLibreMap,
+  sourceId: string,
+  data: GeoJsonFeatureCollection,
+) {
+  const source = map.getSource(sourceId) as
+    | { setData: (data: GeoJsonFeatureCollection) => void }
+    | undefined;
+  source?.setData(data);
+}
+
+function routeFeatures(
+  tracks: readonly McapLocationTrackState[],
+  playheadNs: bigint | null,
+  side: "past" | "future",
+): GeoJsonFeatureCollection {
+  const features: GeoJsonFeature[] = [];
+  for (const track of tracks) {
+    for (const segment of track.segments) {
+      const coordinates = routeCoordinatesForSegment(segment, playheadNs, side);
+      if (coordinates.length < 2) continue;
+      features.push({
+        type: "Feature",
+        geometry: { type: "LineString", coordinates },
+        properties: {
+          color: track.color,
+          topic: track.topic,
+        },
+      });
+    }
+  }
+  return { type: "FeatureCollection", features };
+}
+
+function routeCoordinatesForSegment(
+  segment: McapLocationTrackSegment,
+  playheadNs: bigint | null,
+  side: "past" | "future",
+): readonly [number, number][] {
+  if (playheadNs === null) {
+    return side === "future"
+      ? segment.points.map((point) => [point.longitude, point.latitude])
+      : [];
+  }
+
+  const points =
+    side === "past"
+      ? segment.points.filter((point) => point.timeNs <= playheadNs)
+      : segment.points.filter((point) => point.timeNs >= playheadNs);
+  const interpolated = interpolateLocationAtTime([segment], playheadNs);
+  if (interpolated) {
+    if (side === "past") {
+      points.push({
+        latitude: interpolated.latitude,
+        longitude: interpolated.longitude,
+        timeNs: interpolated.timeNs,
+      });
+    } else {
+      points.unshift({
+        latitude: interpolated.latitude,
+        longitude: interpolated.longitude,
+        timeNs: interpolated.timeNs,
+      });
+    }
+  }
+
+  return points.map((point) => [point.longitude, point.latitude]);
+}
+
+function hitPointFeatures(
+  tracks: readonly McapLocationTrackState[],
+): GeoJsonFeatureCollection {
+  const features: GeoJsonFeature[] = [];
+  for (const track of tracks) {
+    for (const segment of track.segments) {
+      for (const point of segment.points) {
+        features.push({
+          type: "Feature",
+          geometry: {
+            type: "Point",
+            coordinates: [point.longitude, point.latitude],
+          },
+          properties: {
+            color: track.color,
+            timeNs: point.timeNs.toString(),
+            topic: track.topic,
+          },
+        });
+      }
+    }
+  }
+  return { type: "FeatureCollection", features };
+}
+
+function markerFeatures(
+  markers: readonly MapLocationMarker[],
+): GeoJsonFeatureCollection {
+  return {
+    type: "FeatureCollection",
+    features: markers.map((marker) => ({
+      type: "Feature",
+      geometry: {
+        type: "Point",
+        coordinates: [marker.location.longitude, marker.location.latitude],
+      },
+      properties: {
+        color: marker.color,
+        label: marker.label,
+        topic: marker.topic,
+      },
+    })),
+  };
+}
+
+/**
+ * Current-position features carrying the sprite id and bearing for the
+ * puck symbol layer. Stationary markers (no derivable bearing) fall back
+ * to the unrotated dome variant.
+ */
+function currentPuckFeatures(
+  markers: readonly MapLocationMarker[],
+): GeoJsonFeatureCollection {
+  return {
+    type: "FeatureCollection",
+    features: markers.map((marker) => {
+      const bearing = marker.location.bearingDeg;
+      return {
+        type: "Feature",
+        geometry: {
+          type: "Point",
+          coordinates: [marker.location.longitude, marker.location.latitude],
+        },
+        properties: {
+          ...(marker.location.accuracyM !== undefined
+            ? {
+                accuracyPx0: accuracyPixelsAtZoom0(
+                  marker.location.accuracyM,
+                  marker.location.latitude,
+                ),
+              }
+            : {}),
+          bearing: bearing ?? 0,
+          color: marker.color,
+          icon: puckImageId(
+            bearing === undefined ? PUCK_VARIANT.DOT : PUCK_VARIANT.NAV,
+            marker.color,
+          ),
+          label: marker.label,
+          topic: marker.topic,
+        },
+      };
+    }),
+  };
+}
+
+/**
+ * A ground distance in meters as its pixel size at zoom 0, adjusted for
+ * the mercator scale factor at the marker's latitude.
+ */
+function accuracyPixelsAtZoom0(meters: number, latitude: number): number {
+  const groundResolution =
+    METERS_PER_PIXEL_ZOOM_0 * Math.cos(degreesToRadians(latitude));
+  return meters / Math.max(groundResolution, 1e-6);
+}
+
+function measurementLineFeature(
+  measurement: MapMeasurementState | null,
+): GeoJsonFeatureCollection {
+  if (!measurement?.b) {
+    return EMPTY_FEATURE_COLLECTION;
+  }
+  return {
+    type: "FeatureCollection",
+    features: [
+      {
+        type: "Feature",
+        geometry: {
+          type: "LineString",
+          coordinates: [
+            [measurement.a.longitude, measurement.a.latitude],
+            [measurement.b.longitude, measurement.b.latitude],
+          ],
+        },
+        properties: {},
+      },
+    ],
+  };
+}
+
+function measurementPreviewFeature(
+  measurement: MapMeasurementState | null,
+  hover: MapMeasurementPoint | null,
+): GeoJsonFeatureCollection {
+  if (!measurement || measurement.b || !hover) {
+    return EMPTY_FEATURE_COLLECTION;
+  }
+  return {
+    type: "FeatureCollection",
+    features: [
+      {
+        type: "Feature",
+        geometry: {
+          type: "LineString",
+          coordinates: [
+            [measurement.a.longitude, measurement.a.latitude],
+            [hover.longitude, hover.latitude],
+          ],
+        },
+        properties: {},
+      },
+    ],
+  };
+}
+
+function measurementPointFeatures(
+  measurement: MapMeasurementState | null,
+): GeoJsonFeatureCollection {
+  if (!measurement) {
+    return EMPTY_FEATURE_COLLECTION;
+  }
+  const points = [measurement.a, measurement.b].filter(
+    (point): point is MapMeasurementPoint => point !== null,
+  );
+  return {
+    type: "FeatureCollection",
+    features: points.map((point) => ({
+      type: "Feature",
+      geometry: {
+        type: "Point",
+        coordinates: [point.longitude, point.latitude],
+      },
+      properties: {},
+    })),
+  };
+}
+
+function timeNsFromMapEvent(event: MapLayerFeatureEvent): bigint | null {
+  const value = event.features?.[0]?.properties?.timeNs;
+  if (typeof value !== "string" || value.length === 0) {
+    return null;
+  }
+  try {
+    return BigInt(value);
+  } catch {
+    return null;
+  }
+}
+
+function measurementPointFromMapEvent(
+  event: MapPointerEvent,
+): MapMeasurementPoint | null {
+  const lngLat = event.lngLat;
+  if (!lngLat || !Number.isFinite(lngLat.lng) || !Number.isFinite(lngLat.lat)) {
+    return null;
+  }
+  return { latitude: lngLat.lat, longitude: lngLat.lng };
+}
+
+function mapTileTitle(
+  readyTracks: readonly McapLocationTrackState[],
+  locationTopicCount: number,
+): string {
+  if (readyTracks.length === 1) {
+    return readyTracks[0].label;
+  }
+  if (locationTopicCount > 1) {
+    return `Map (${locationTopicCount})`;
+  }
+  return "Map";
+}
+
+function mapStatusText({
+  enabledTopicCount,
+  errorCount,
+  loadingCount,
+  locationTopicCount,
+  readyTrackCount,
+  truncated,
+}: {
+  readonly enabledTopicCount: number;
+  readonly errorCount: number;
+  readonly loadingCount: number;
+  readonly locationTopicCount: number;
+  readonly readyTrackCount: number;
+  readonly truncated: boolean;
+}): string | null {
+  if (locationTopicCount === 0 || enabledTopicCount === 0) {
+    return null;
+  }
+  const notes = [
+    loadingCount > 0 ? `loading ${loadingCount}` : null,
+    errorCount > 0 ? `${errorCount} failed` : null,
+    readyTrackCount > 0 && truncated ? "downsampled" : null,
+  ].filter(Boolean);
+  return notes.length > 0 ? notes.join(" · ") : null;
+}
+
+function emptyText({
+  enabledTopicCount,
+  loadingCount,
+  locationTopicCount,
+  readyTrackCount,
+}: {
+  readonly enabledTopicCount: number;
+  readonly loadingCount: number;
+  readonly locationTopicCount: number;
+  readonly readyTrackCount: number;
+}): React.ReactElement | null {
+  let text: string | null = null;
+  if (locationTopicCount === 0) {
+    text = "No GPS topics in this recording";
+  } else if (enabledTopicCount === 0) {
+    text = "All GPS topics are hidden";
+  } else if (readyTrackCount === 0 && loadingCount === 0) {
+    text = "No valid GPS fixes to render";
+  }
+  return text ? <div className={styles.emptyState}>{text}</div> : null;
+}
+
+function mapStyleForBaseLayer(
+  baseLayer: McapMapBaseLayer,
+): MapLibreStyle | string {
+  return baseLayer === MCAP_MAP_BASE_LAYER.NONE
+    ? NO_TILE_STYLE
+    : OPENFREEMAP_LIBERTY_STYLE_URL;
+}
+
+function loadMapLibre(): Promise<MapLibreModule> {
+  if (!mapLibreImport) {
+    mapLibreImport = Promise.all([
+      import("maplibre-gl"),
+      loadMapLibreStylesheet(),
+    ]).then(([maplibregl]) => maplibregl);
+  }
+  return mapLibreImport;
+}
+
+function loadMapLibreStylesheet(): Promise<void> {
+  if (!mapLibreCssImport) {
+    mapLibreCssImport = import("maplibre-gl/dist/maplibre-gl.css?url").then(
+      ({ default: href }) => {
+        ensureMapLibreStylesheet(href);
+      },
+    );
+  }
+  return mapLibreCssImport;
+}
+
+function ensureMapLibreStylesheet(href: string) {
+  if (typeof document === "undefined") {
+    return;
+  }
+  const linkId = "fiftyone-maplibre-gl-css";
+  if (document.getElementById(linkId)) {
+    return;
+  }
+  const link = document.createElement("link");
+  link.href = href;
+  link.id = linkId;
+  link.rel = "stylesheet";
+  document.head.appendChild(link);
+}
+
+export default McapMapTile;

--- a/app/packages/multimodal/src/adapters/mcap/react/McapMapTile.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapMapTile.tsx
@@ -457,6 +457,9 @@ function McapMapLibreSurface({
     fitKeyRef.current = null;
     let cancelled = false;
     let resizeObserver: ResizeObserver | null = null;
+    let webglCanvas: HTMLCanvasElement | null = null;
+    let handleWebglContextLost: ((event: Event) => void) | null = null;
+    let handleWebglContextRestored: (() => void) | null = null;
 
     void loadMapLibre()
       .then((maplibregl) => {
@@ -534,9 +537,25 @@ function McapMapLibreSurface({
         map.on("mouseout", () => {
           setMeasurementHover(null);
         });
-        map.getCanvas().addEventListener("webglcontextlost", () => {
-          setFailed(true);
-        });
+        webglCanvas = map.getCanvas();
+        handleWebglContextLost = (event: Event) => {
+          event.preventDefault();
+          setLoaded(false);
+        };
+        handleWebglContextRestored = () => {
+          setFailed(false);
+          setLoaded(loadedRef.current);
+          map.resize();
+          map.triggerRepaint();
+        };
+        webglCanvas.addEventListener(
+          "webglcontextlost",
+          handleWebglContextLost,
+        );
+        webglCanvas.addEventListener(
+          "webglcontextrestored",
+          handleWebglContextRestored,
+        );
 
         if (typeof ResizeObserver !== "undefined") {
           resizeObserver = new ResizeObserver(() => map.resize());
@@ -548,6 +567,18 @@ function McapMapLibreSurface({
     return () => {
       cancelled = true;
       resizeObserver?.disconnect();
+      if (webglCanvas && handleWebglContextLost) {
+        webglCanvas.removeEventListener(
+          "webglcontextlost",
+          handleWebglContextLost,
+        );
+      }
+      if (webglCanvas && handleWebglContextRestored) {
+        webglCanvas.removeEventListener(
+          "webglcontextrestored",
+          handleWebglContextRestored,
+        );
+      }
       const map = mapRef.current;
       if (map) {
         map.remove();

--- a/app/packages/multimodal/src/adapters/mcap/react/McapMapTileSettings.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapMapTileSettings.tsx
@@ -1,0 +1,89 @@
+import { TileSettingsContent } from "@fiftyone/tiling";
+import { Checkbox, RadioGroup, Size } from "@voxel51/voodo";
+import React, { useMemo } from "react";
+import { useSceneInventory } from "../../../scene-inventory";
+import { MCAP_SOURCE_TYPE } from "../scene-sources";
+import {
+  MCAP_MAP_BASE_LAYER,
+  type McapMapBaseLayer,
+  useMcapMapTileSettings,
+  useSetMcapMapTileSettings,
+  useToggleMcapMapTileTopic,
+} from "./mcap-map-tile-state";
+import { checkboxNoSpaceToggleProps } from "./mcap-settings-keyboard";
+import plotStyles from "./McapPlotTile.module.css";
+import settingsStyles from "./McapTile.settings.module.css";
+
+const BASE_LAYER_OPTIONS = [
+  {
+    value: MCAP_MAP_BASE_LAYER.DEFAULT,
+    label: "Default basemap (OpenFreeMap)",
+  },
+  { value: MCAP_MAP_BASE_LAYER.NONE, label: "No basemap" },
+];
+
+const McapMapTileSettings: React.FC = () => {
+  const sources = useSceneInventory();
+  const locationSources = useMemo(
+    () => sources.filter((source) => source.type === MCAP_SOURCE_TYPE.LOCATION),
+    [sources],
+  );
+  const topics = useMemo(
+    () => locationSources.map((source) => source.id),
+    [locationSources],
+  );
+  const settings = useMcapMapTileSettings();
+  const setSettings = useSetMcapMapTileSettings();
+  const toggleTopic = useToggleMcapMapTileTopic();
+  const enabledTopics = new Set(settings.enabledTopics ?? topics);
+  const baseLayer = settings.baseLayer ?? MCAP_MAP_BASE_LAYER.DEFAULT;
+
+  return (
+    <TileSettingsContent>
+      <div className={settingsStyles.root}>
+        <div className={settingsStyles.optionStack}>
+          <RadioGroup
+            name="mcap-map-base-layer"
+            onChange={(value) =>
+              setSettings({ baseLayer: value as McapMapBaseLayer })
+            }
+            options={BASE_LAYER_OPTIONS}
+            size={Size.Md}
+            value={baseLayer}
+          />
+          <div className={plotStyles.fieldRow}>
+            <Checkbox
+              checked={settings.followEgo}
+              label="Follow playhead"
+              onChange={(checked) => setSettings({ followEgo: checked })}
+              {...checkboxNoSpaceToggleProps}
+            />
+          </div>
+        </div>
+        {locationSources.length === 0 ? (
+          <span className={settingsStyles.emptyText}>
+            No GPS topics in this recording
+          </span>
+        ) : (
+          <div className={settingsStyles.optionStack}>
+            {locationSources.map((source) => (
+              <div className={plotStyles.fieldRow} key={source.id}>
+                <Checkbox
+                  checked={enabledTopics.has(source.id)}
+                  label={source.label}
+                  onChange={(checked) =>
+                    toggleTopic(source.id, checked, topics)
+                  }
+                  {...checkboxNoSpaceToggleProps}
+                />
+                <span className={settingsStyles.metaText}>{source.id}</span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </TileSettingsContent>
+  );
+};
+
+export default McapMapTileSettings;

--- a/app/packages/multimodal/src/adapters/mcap/react/McapRawMessageTile.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapRawMessageTile.tsx
@@ -1,9 +1,11 @@
 import { humanReadableBytes } from "@fiftyone/utilities";
 import { useSetTileTitle } from "@fiftyone/tiling";
-import React, { useCallback, useEffect } from "react";
+import React, { useCallback, useEffect, useMemo } from "react";
 import { rawNodeToJson } from "../resources/raw-record-prune";
 import type { McapRawMessageRecordResult } from "../types";
+import { useAddMcapFieldToPlot } from "./use-add-mcap-field-to-plot";
 import { useMcapDataStream } from "./mcap-data-stream-context";
+import { useMcapNumericSeriesContext } from "./mcap-numeric-series-context";
 import { useMcapRawMessageContext } from "./mcap-raw-message-context";
 import { useMcapRawTileTopic } from "./mcap-raw-tile-state";
 import type { McapTileProps } from "./mcap-tile-types";
@@ -26,6 +28,8 @@ const McapRawMessageTile: React.FC<McapTileProps> = () => {
   const topic = useMcapRawTileTopic();
   const setTileTitle = useSetTileTitle();
   const { recordsByTopic, subscribeRecord } = useMcapRawMessageContext();
+  const { ensureEnumeration, enumeration } = useMcapNumericSeriesContext();
+  const addFieldToPlot = useAddMcapFieldToPlot();
 
   // This effect declares interest in the selected topic while the tile
   // shows it; the bridge follows the playhead for interested topics.
@@ -36,12 +40,41 @@ const McapRawMessageTile: React.FC<McapTileProps> = () => {
     return subscribeRecord(topic);
   }, [subscribeRecord, topic]);
 
+  // The raw tree only shows "plot" on fields confirmed by the numeric
+  // catalog. While the catalog is idle/loading/error, no affordance is shown.
+  useEffect(() => {
+    if (topic) {
+      ensureEnumeration();
+    }
+  }, [ensureEnumeration, topic]);
+
   useEffect(() => {
     setTileTitle(topic ?? "Message", { source: "auto" });
   }, [setTileTitle, topic]);
 
   const state = topic ? recordsByTopic.get(topic) : undefined;
   const result = state?.result;
+  const plottableFieldPaths = useMemo(() => {
+    if (!topic || enumeration.status !== "ready") {
+      return undefined;
+    }
+    const topicFields = enumeration.topics.find(
+      (entry) => entry.topic === topic && entry.availability === "ready",
+    );
+    if (!topicFields || topicFields.fields.length === 0) {
+      return undefined;
+    }
+    return new Set(topicFields.fields.map((field) => field.path));
+  }, [enumeration, topic]);
+
+  const handleAddFieldToPlot = useCallback(
+    (fieldPath: string) => {
+      if (topic) {
+        addFieldToPlot(topic, fieldPath);
+      }
+    },
+    [addFieldToPlot, topic],
+  );
 
   return (
     <>
@@ -70,7 +103,11 @@ const McapRawMessageTile: React.FC<McapTileProps> = () => {
         ) : (
           <>
             <MetaRow result={result} topic={topic} />
-            <RecordBody result={result} />
+            <RecordBody
+              onAddNumericFieldToPlot={handleAddFieldToPlot}
+              plottableFieldPaths={plottableFieldPaths}
+              result={result}
+            />
           </>
         )}
       </div>
@@ -152,14 +189,22 @@ function MetaRow({
 }
 
 function RecordBody({
+  onAddNumericFieldToPlot,
+  plottableFieldPaths,
   result,
 }: {
+  readonly onAddNumericFieldToPlot: (path: string) => void;
+  readonly plottableFieldPaths?: ReadonlySet<string>;
   readonly result: McapRawMessageRecordResult;
 }) {
   if (result.status === "ok" && result.root) {
     return (
       <div className={rawStyles.scroll}>
-        <McapRawMessageTree root={result.root} />
+        <McapRawMessageTree
+          onAddNumericFieldToPlot={onAddNumericFieldToPlot}
+          plottableFieldPaths={plottableFieldPaths}
+          root={result.root}
+        />
       </div>
     );
   }

--- a/app/packages/multimodal/src/adapters/mcap/react/McapRawMessageTree.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapRawMessageTree.test.tsx
@@ -19,6 +19,10 @@ afterEach(() => {
 const ROOT: McapRawObjectNode = {
   entries: [
     ["speed", { kind: "scalar", value: "3.5", valueType: "number" }],
+    [
+      "sequence",
+      { kind: "scalar", value: "9007199254740993", valueType: "bigint" },
+    ],
     ["label", { kind: "scalar", value: "ego", valueType: "string" }],
     ["enabled", { kind: "scalar", value: "true", valueType: "boolean" }],
     ["unlisted", { kind: "scalar", value: "9", valueType: "number" }],
@@ -113,23 +117,35 @@ describe("McapRawMessageTree", () => {
     expect(screen.getByTestId("mcap-raw-copy-data").textContent).toBe("copied");
   });
 
-  it("shows add-to-plot actions only for plottable scalar number leaves", () => {
+  it("shows add-to-plot actions only for plottable scalar numeric leaves", () => {
     render(
       <McapRawMessageTree
         onAddNumericFieldToPlot={addToPlot}
         plottableFieldPaths={
-          new Set(["speed", "enabled", "pose.position.x", "data.0"])
+          new Set(["speed", "sequence", "enabled", "pose.position.x", "data.0"])
         }
         root={ROOT}
       />,
     );
 
     expect(screen.getByTestId("mcap-raw-plot-speed")).toBeTruthy();
+    expect(screen.getByTestId("mcap-raw-plot-sequence")).toBeTruthy();
     expect(screen.getByTestId("mcap-raw-plot-pose.position.x")).toBeTruthy();
     expect(screen.queryByTestId("mcap-raw-plot-label")).toBeNull();
     expect(screen.queryByTestId("mcap-raw-plot-enabled")).toBeNull();
     expect(screen.queryByTestId("mcap-raw-plot-unlisted")).toBeNull();
     expect(screen.queryByTestId("mcap-raw-plot-data.0")).toBeNull();
+  });
+
+  it("hides add-to-plot actions when no handler is available", () => {
+    render(
+      <McapRawMessageTree
+        plottableFieldPaths={new Set(["speed"])}
+        root={ROOT}
+      />,
+    );
+
+    expect(screen.queryByTestId("mcap-raw-plot-speed")).toBeNull();
   });
 
   it("emits the dotted field path when a plottable row is added", () => {

--- a/app/packages/multimodal/src/adapters/mcap/react/McapRawMessageTree.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapRawMessageTree.test.tsx
@@ -4,9 +4,11 @@ import type { McapRawObjectNode } from "../types";
 import McapRawMessageTree from "./McapRawMessageTree";
 
 const writeText = vi.fn(async (_text: string) => undefined);
+const addToPlot = vi.fn();
 
 beforeEach(() => {
   writeText.mockClear();
+  addToPlot.mockClear();
   Object.assign(navigator, { clipboard: { writeText } });
 });
 
@@ -18,6 +20,8 @@ const ROOT: McapRawObjectNode = {
   entries: [
     ["speed", { kind: "scalar", value: "3.5", valueType: "number" }],
     ["label", { kind: "scalar", value: "ego", valueType: "string" }],
+    ["enabled", { kind: "scalar", value: "true", valueType: "boolean" }],
+    ["unlisted", { kind: "scalar", value: "9", valueType: "number" }],
     [
       "pose",
       {
@@ -107,5 +111,42 @@ describe("McapRawMessageTree", () => {
       "… 499 more items",
     ]);
     expect(screen.getByTestId("mcap-raw-copy-data").textContent).toBe("copied");
+  });
+
+  it("shows add-to-plot actions only for plottable scalar number leaves", () => {
+    render(
+      <McapRawMessageTree
+        onAddNumericFieldToPlot={addToPlot}
+        plottableFieldPaths={
+          new Set(["speed", "enabled", "pose.position.x", "data.0"])
+        }
+        root={ROOT}
+      />,
+    );
+
+    expect(screen.getByTestId("mcap-raw-plot-speed")).toBeTruthy();
+    expect(screen.getByTestId("mcap-raw-plot-pose.position.x")).toBeTruthy();
+    expect(screen.queryByTestId("mcap-raw-plot-label")).toBeNull();
+    expect(screen.queryByTestId("mcap-raw-plot-enabled")).toBeNull();
+    expect(screen.queryByTestId("mcap-raw-plot-unlisted")).toBeNull();
+    expect(screen.queryByTestId("mcap-raw-plot-data.0")).toBeNull();
+  });
+
+  it("emits the dotted field path when a plottable row is added", () => {
+    render(
+      <McapRawMessageTree
+        onAddNumericFieldToPlot={addToPlot}
+        plottableFieldPaths={new Set(["pose.position.x"])}
+        root={ROOT}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("mcap-raw-plot-pose.position.x"));
+
+    expect(addToPlot).toHaveBeenCalledTimes(1);
+    expect(addToPlot).toHaveBeenCalledWith("pose.position.x");
+    expect(
+      screen.getByTestId("mcap-raw-plot-pose.position.x").textContent,
+    ).toBe("plotted");
   });
 });

--- a/app/packages/multimodal/src/adapters/mcap/react/McapRawMessageTree.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapRawMessageTree.tsx
@@ -51,11 +51,17 @@ const McapRawMessageTree: React.FC<McapRawMessageTreeProps> = ({
 
   const addToPlot = useCallback(
     (path: string) => {
-      onAddNumericFieldToPlot?.(path);
+      if (!onAddNumericFieldToPlot) {
+        return;
+      }
+      onAddNumericFieldToPlot(path);
       showPlottedPath(path);
     },
     [onAddNumericFieldToPlot, showPlottedPath],
   );
+  const effectivePlottableFieldPaths = onAddNumericFieldToPlot
+    ? plottableFieldPaths
+    : undefined;
 
   return (
     <div className={styles.tree} data-testid="mcap-raw-tree">
@@ -70,7 +76,7 @@ const McapRawMessageTree: React.FC<McapRawMessageTreeProps> = ({
           label={key}
           node={node}
           path={key}
-          plottableFieldPaths={plottableFieldPaths}
+          plottableFieldPaths={effectivePlottableFieldPaths}
           plottedPath={plottedPath}
           toggle={toggle}
           withinArray={false}
@@ -122,6 +128,8 @@ function TreeRow({
   const indent = { paddingLeft: `${depth * 14}px` };
   const canAddToPlot =
     !withinArray && isPlottableScalar(node) && plottableFieldPaths?.has(path);
+  const addToPlotLabel =
+    plottedPath === path ? `${path} plotted` : `Add ${path} to plot`;
 
   return (
     <>
@@ -148,7 +156,7 @@ function TreeRow({
         </div>
         {canAddToPlot ? (
           <button
-            aria-label={`Add ${path} to plot`}
+            aria-label={addToPlotLabel}
             className={styles.copyButton}
             data-testid={`mcap-raw-plot-${path}`}
             onClick={() => addToPlot(path)}

--- a/app/packages/multimodal/src/adapters/mcap/react/McapRawMessageTree.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapRawMessageTree.tsx
@@ -7,6 +7,12 @@ import { useCopyFeedback } from "./use-copy-feedback";
 /** Levels expanded by default; deeper nodes open on demand. */
 const AUTO_EXPAND_DEPTH = 2;
 
+export interface McapRawMessageTreeProps {
+  readonly onAddNumericFieldToPlot?: (path: string) => void;
+  readonly plottableFieldPaths?: ReadonlySet<string>;
+  readonly root: McapRawObjectNode;
+}
+
 /**
  * Collapsible tree over one pruned message record. Children render only
  * while their parent is expanded, so even a budget-maxed tree stays a
@@ -14,13 +20,16 @@ const AUTO_EXPAND_DEPTH = 2;
  * lives across record refreshes — watching one value during playback
  * must not re-fold the tree every message.
  */
-const McapRawMessageTree: React.FC<{
-  readonly root: McapRawObjectNode;
-}> = ({ root }) => {
+const McapRawMessageTree: React.FC<McapRawMessageTreeProps> = ({
+  onAddNumericFieldToPlot,
+  plottableFieldPaths,
+  root,
+}) => {
   const [expandedOverrides, setExpandedOverrides] = useState<
     ReadonlyMap<string, boolean>
   >(new Map());
   const [copiedPath, showCopiedPath] = useCopyFeedback<string | null>(null);
+  const [plottedPath, showPlottedPath] = useCopyFeedback<string | null>(null);
 
   const toggle = useCallback((path: string, expanded: boolean) => {
     setExpandedOverrides((previous) => {
@@ -40,10 +49,19 @@ const McapRawMessageTree: React.FC<{
     [showCopiedPath],
   );
 
+  const addToPlot = useCallback(
+    (path: string) => {
+      onAddNumericFieldToPlot?.(path);
+      showPlottedPath(path);
+    },
+    [onAddNumericFieldToPlot, showPlottedPath],
+  );
+
   return (
     <div className={styles.tree} data-testid="mcap-raw-tree">
       {root.entries.map(([key, node]) => (
         <TreeRow
+          addToPlot={addToPlot}
           copiedPath={copiedPath}
           copy={copy}
           depth={0}
@@ -52,7 +70,10 @@ const McapRawMessageTree: React.FC<{
           label={key}
           node={node}
           path={key}
+          plottableFieldPaths={plottableFieldPaths}
+          plottedPath={plottedPath}
           toggle={toggle}
+          withinArray={false}
         />
       ))}
       {root.droppedEntries ? (
@@ -67,6 +88,7 @@ const McapRawMessageTree: React.FC<{
 };
 
 interface TreeRowProps {
+  readonly addToPlot: (path: string) => void;
   readonly copiedPath: string | null;
   readonly copy: (path: string, node: McapRawValueNode) => void;
   readonly depth: number;
@@ -74,10 +96,14 @@ interface TreeRowProps {
   readonly label: string;
   readonly node: McapRawValueNode;
   readonly path: string;
+  readonly plottableFieldPaths?: ReadonlySet<string>;
+  readonly plottedPath: string | null;
   readonly toggle: (path: string, expanded: boolean) => void;
+  readonly withinArray: boolean;
 }
 
 function TreeRow({
+  addToPlot,
   copiedPath,
   copy,
   depth,
@@ -85,12 +111,17 @@ function TreeRow({
   label,
   node,
   path,
+  plottableFieldPaths,
+  plottedPath,
   toggle,
+  withinArray,
 }: TreeRowProps) {
   const expandable = isExpandable(node);
   const expanded =
     expandedOverrides.get(path) ?? (expandable && depth < AUTO_EXPAND_DEPTH);
   const indent = { paddingLeft: `${depth * 14}px` };
+  const canAddToPlot =
+    !withinArray && isPlottableScalar(node) && plottableFieldPaths?.has(path);
 
   return (
     <>
@@ -115,6 +146,18 @@ function TreeRow({
             {expanded && expandable ? "" : nodePreview(node)}
           </span>
         </div>
+        {canAddToPlot ? (
+          <button
+            aria-label={`Add ${path} to plot`}
+            className={styles.copyButton}
+            data-testid={`mcap-raw-plot-${path}`}
+            onClick={() => addToPlot(path)}
+            title="Add field to plot"
+            type="button"
+          >
+            {plottedPath === path ? "plotted" : "plot"}
+          </button>
+        ) : null}
         <button
           aria-label={`Copy ${label}`}
           className={styles.copyButton}
@@ -129,6 +172,7 @@ function TreeRow({
       {expanded && node.kind === "object"
         ? node.entries.map(([childKey, child]) => (
             <TreeRow
+              addToPlot={addToPlot}
               copiedPath={copiedPath}
               copy={copy}
               depth={depth + 1}
@@ -137,7 +181,10 @@ function TreeRow({
               label={childKey}
               node={child}
               path={`${path}.${childKey}`}
+              plottableFieldPaths={plottableFieldPaths}
+              plottedPath={plottedPath}
               toggle={toggle}
+              withinArray={withinArray}
             />
           ))
         : null}
@@ -157,6 +204,7 @@ function TreeRow({
       {expanded && node.kind === "array"
         ? node.items.map((item, index) => (
             <TreeRow
+              addToPlot={addToPlot}
               copiedPath={copiedPath}
               copy={copy}
               depth={depth + 1}
@@ -165,7 +213,10 @@ function TreeRow({
               label={String(index)}
               node={item}
               path={`${path}.${index}`}
+              plottableFieldPaths={plottableFieldPaths}
+              plottedPath={plottedPath}
               toggle={toggle}
+              withinArray={true}
             />
           ))
         : null}
@@ -193,6 +244,13 @@ function isExpandable(node: McapRawValueNode): boolean {
   return (
     (node.kind === "object" && node.entries.length > 0) ||
     (node.kind === "array" && node.items.length > 0)
+  );
+}
+
+function isPlottableScalar(node: McapRawValueNode): boolean {
+  return (
+    node.kind === "scalar" &&
+    (node.valueType === "number" || node.valueType === "bigint")
   );
 }
 

--- a/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.module.css
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.module.css
@@ -130,6 +130,26 @@
   line-height: 1.2;
 }
 
+.topicInspectButton {
+  align-self: flex-start;
+  background: transparent;
+  border: 0;
+  color: var(--color-content-text-muted);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 10px;
+  line-height: 1.2;
+  padding: 0;
+  text-decoration-line: underline;
+  text-decoration-style: dotted;
+  text-underline-offset: 3px;
+}
+
+.topicInspectButton:focus-visible {
+  outline: 1px solid var(--color-border);
+  outline-offset: 2px;
+}
+
 .topicEmpty {
   color: var(--color-content-text-muted);
   font-size: 11px;

--- a/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.module.css
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.module.css
@@ -102,6 +102,11 @@
   gap: 8px;
 }
 
+.topicSearchInput {
+  min-width: 0;
+  width: 100%;
+}
+
 .topicRow {
   border-left: 1px solid var(--color-border);
   display: flex;
@@ -123,6 +128,12 @@
   color: var(--color-content-text-muted);
   font-size: 10px;
   line-height: 1.2;
+}
+
+.topicEmpty {
+  color: var(--color-content-text-muted);
+  font-size: 11px;
+  line-height: 1.25;
 }
 
 .resetButton {

--- a/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.module.css
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.module.css
@@ -102,6 +102,12 @@
   gap: 8px;
 }
 
+.topicGroups {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
 .topicSearchInput {
   min-width: 0;
   width: 100%;
@@ -116,26 +122,59 @@
   padding-left: 8px;
 }
 
-.topicMeta {
-  color: var(--color-content-text-muted);
+.topicRowHeader {
+  align-items: baseline;
+  display: flex;
+  gap: 8px;
+  min-width: 0;
+}
+
+.topicName {
+  color: var(--color-content-text);
+  flex: 1 1 auto;
   font-size: 11px;
   line-height: 1.25;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.topicMetaLine {
+  align-items: baseline;
+  display: flex;
+  gap: 8px;
+  justify-content: space-between;
+  min-width: 0;
+}
+
+.topicActions {
+  align-items: baseline;
+  display: flex;
+  flex: 0 0 auto;
+  gap: 8px;
+}
+
+.topicMeta {
+  color: var(--color-content-text-muted);
+  flex: 1 1 auto;
+  font-size: 11px;
+  line-height: 1.25;
+  min-width: 0;
   overflow-wrap: anywhere;
 }
 
 .topicStatus {
-  align-self: flex-start;
+  flex: 0 0 auto;
   color: var(--color-content-text-muted);
   font-size: 10px;
   line-height: 1.2;
 }
 
-.topicInspectButton {
-  align-self: flex-start;
+.topicActionButton {
   background: transparent;
   border: 0;
   color: var(--color-content-text-muted);
   cursor: pointer;
+  flex: 0 0 auto;
   font-family: inherit;
   font-size: 10px;
   line-height: 1.2;
@@ -145,7 +184,7 @@
   text-underline-offset: 3px;
 }
 
-.topicInspectButton:focus-visible {
+.topicActionButton:focus-visible {
   outline: 1px solid var(--color-border);
   outline-offset: 2px;
 }

--- a/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.test.tsx
@@ -209,7 +209,7 @@ describe("McapSettingsSidebar", () => {
     expect(screen.queryByText("/lidar/top")).toBeNull();
     expect(screen.getByText("/imu")).toBeTruthy();
     expect(screen.getByText("sensor_msgs/Imu · ros1 · 8 msgs")).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Inspect" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Inspect /imu" })).toBeTruthy();
     expect(screen.getByText("Schema unavailable")).toBeTruthy();
     expect(screen.getByText("Encoding unsupported")).toBeTruthy();
   });
@@ -227,7 +227,7 @@ describe("McapSettingsSidebar", () => {
     });
 
     fireEvent.click(screen.getByRole("button", { name: /Other topics/ }));
-    fireEvent.click(screen.getByRole("button", { name: "Inspect" }));
+    fireEvent.click(screen.getByRole("button", { name: "Inspect /imu" }));
 
     const focusedTileId = probeState.current?.focusedTileId;
     expect(focusedTileId?.startsWith("raw-")).toBe(true);
@@ -289,7 +289,7 @@ describe("McapSettingsSidebar", () => {
       "Search other topics",
     ) as HTMLInputElement;
     expect(search).toBeTruthy();
-    expect(screen.queryByText("/camera/front")).toBeNull();
+    expect(screen.getByText("/alpha")).toBeTruthy();
 
     fireEvent.change(search, { target: { value: "navsat" } });
 

--- a/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.test.tsx
@@ -129,6 +129,7 @@ describe("McapSettingsSidebar", () => {
     renderSidebar();
 
     expect(screen.getByRole("tab", { name: "Scene" })).toBeTruthy();
+    expect(screen.getByRole("tab", { name: "Topics" })).toBeTruthy();
     expect(screen.queryByRole("tab", { name: "Camera" })).toBeNull();
     expect(screen.queryByRole("heading", { name: "Settings" })).toBeNull();
     expect(screen.getByText("Advanced timing")).toBeTruthy();
@@ -173,7 +174,7 @@ describe("McapSettingsSidebar", () => {
     expect(screen.getByText("Reset to defaults")).toBeTruthy();
   });
 
-  it("lists non-renderable topics in scene settings", () => {
+  it("lists all topics by category in the topics tab", () => {
     renderSidebar({
       topics: [
         topic("/lidar/top", {
@@ -187,6 +188,12 @@ describe("McapSettingsSidebar", () => {
           decodeStatus: "decodable",
           encoding: "ros1",
           schema: "sensor_msgs/Imu",
+        }),
+        topic("/tf_static", {
+          count: "2",
+          decodeStatus: "decodable",
+          encoding: "ros1",
+          schema: "tf2_msgs/TFMessage",
         }),
         topic("/broken", {
           count: "3",
@@ -203,18 +210,41 @@ describe("McapSettingsSidebar", () => {
       ],
     });
 
-    fireEvent.click(screen.getByRole("button", { name: /Other topics/ }));
+    expect(screen.queryByRole("button", { name: /Other topics/ })).toBeNull();
 
-    expect(screen.queryByLabelText("Search other topics")).toBeNull();
-    expect(screen.queryByText("/lidar/top")).toBeNull();
+    fireEvent.click(screen.getByRole("tab", { name: "Topics" }));
+
+    expect(screen.queryByLabelText("Search topics")).toBeNull();
+    expect(screen.getByRole("button", { name: /Sensors/ })).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: /Transforms & Poses/ }),
+    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Telemetry/ })).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: /Custom \/ Unknown/ }),
+    ).toBeTruthy();
+    expect(screen.getByText("/lidar/top")).toBeTruthy();
     expect(screen.getByText("/imu")).toBeTruthy();
-    expect(screen.getByText("sensor_msgs/Imu · ros1 · 8 msgs")).toBeTruthy();
+    expect(screen.getByText("8 msgs · Plot · Raw")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Inspect /imu" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "3D /lidar/top" })).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Inspect /tf_static" }),
+    ).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Open 3D/ })).toBeNull();
+    expect(screen.queryByRole("button", { name: /^Open / })).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Inspect /broken" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Inspect /binary" }),
+    ).toBeTruthy();
+    expect(screen.queryByText("Inspectable")).toBeNull();
     expect(screen.getByText("Schema unavailable")).toBeTruthy();
     expect(screen.getByText("Encoding unsupported")).toBeTruthy();
   });
 
-  it("opens decodable other topics in a Message panel", () => {
+  it("opens decodable topics in a Message panel without leaving Topics", () => {
     const { probeState } = renderSidebar({
       topics: [
         topic("/imu", {
@@ -226,16 +256,19 @@ describe("McapSettingsSidebar", () => {
       ],
     });
 
-    fireEvent.click(screen.getByRole("button", { name: /Other topics/ }));
+    fireEvent.click(screen.getByRole("tab", { name: "Topics" }));
     fireEvent.click(screen.getByRole("button", { name: "Inspect /imu" }));
 
     const focusedTileId = probeState.current?.focusedTileId;
     expect(focusedTileId?.startsWith("raw-")).toBe(true);
     expect(probeState.current?.titles[focusedTileId ?? ""]).toBe("/imu");
     expect(probeState.current?.topicsByTile[focusedTileId ?? ""]).toBe("/imu");
+    expect(
+      screen.getByRole("tab", { name: "Topics" }).getAttribute("aria-selected"),
+    ).toBe("true");
   });
 
-  it("searches long other topic lists", () => {
+  it("searches long topic lists", () => {
     renderSidebar({
       topics: [
         topic("/alpha", {
@@ -283,13 +316,17 @@ describe("McapSettingsSidebar", () => {
       ],
     });
 
-    fireEvent.click(screen.getByRole("button", { name: /Other topics/ }));
+    fireEvent.click(screen.getByRole("tab", { name: "Topics" }));
 
-    const search = screen.getByLabelText(
-      "Search other topics",
-    ) as HTMLInputElement;
+    const search = screen.getByLabelText("Search topics") as HTMLInputElement;
     expect(search).toBeTruthy();
-    expect(screen.getByText("/alpha")).toBeTruthy();
+    expect(screen.getByText("/camera/front")).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Image /camera/front" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Inspect /camera/front" }),
+    ).toBeTruthy();
 
     fireEvent.change(search, { target: { value: "navsat" } });
 
@@ -299,7 +336,7 @@ describe("McapSettingsSidebar", () => {
 
     fireEvent.change(search, { target: { value: "nothing" } });
 
-    expect(screen.getByText('No other topics match "nothing"')).toBeTruthy();
+    expect(screen.getByText('No topics match "nothing"')).toBeTruthy();
   });
 
   it("switches to the panel tab when a panel tab first appears", () => {

--- a/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.test.tsx
@@ -6,6 +6,7 @@ import {
   useTiling,
   type TilingTile,
 } from "@fiftyone/tiling";
+import { useAtomValue } from "jotai";
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
@@ -14,6 +15,7 @@ import {
 } from "../../../scene-inventory";
 import type { StreamInventory } from "../../../schemas/v1";
 import { MCAP_SOURCE_TYPE } from "../scene-sources";
+import { mcapRawTileTopicAtom } from "./mcap-raw-tile-state";
 import { __resetMcapModalSettingsForTests } from "./mcap-modal-settings";
 import McapSettingsSidebar from "./McapSettingsSidebar";
 
@@ -69,14 +71,37 @@ const FocusButton: React.FC<{ id: string; testId: string }> = ({
   );
 };
 
+interface TilingProbeState {
+  readonly focusedTileId: string | null;
+  readonly titles: Readonly<Record<string, string>>;
+  readonly topicsByTile: Readonly<Record<string, string>>;
+}
+
+const TilingStateProbe: React.FC<{
+  readonly stateRef: { current: TilingProbeState | null };
+}> = ({ stateRef }) => {
+  const { focusedTileId, tiles } = useTiling();
+  const topicsByTile = useAtomValue(mcapRawTileTopicAtom);
+  stateRef.current = {
+    focusedTileId,
+    titles: Object.fromEntries(
+      Object.entries(tiles).map(([id, tile]) => [id, tile.title]),
+    ),
+    topicsByTile,
+  };
+  return null;
+};
+
 function renderSidebar({
   topics = [],
 }: {
   readonly topics?: readonly StreamInventory[];
 } = {}) {
-  return render(
+  const probeState: { current: TilingProbeState | null } = { current: null };
+  const result = render(
     <SceneInventoryProvider sources={SOURCES}>
       <TilingProvider initialTiles={INITIAL_TILES}>
+        <TilingStateProbe stateRef={probeState} />
         <TileIdScope tileId={CAMERA_TILE_ID}>
           <TileBody label="camera" />
         </TileIdScope>
@@ -89,6 +114,7 @@ function renderSidebar({
       </TilingProvider>
     </SceneInventoryProvider>,
   );
+  return { ...result, probeState };
 }
 
 describe("McapSettingsSidebar", () => {
@@ -183,9 +209,30 @@ describe("McapSettingsSidebar", () => {
     expect(screen.queryByText("/lidar/top")).toBeNull();
     expect(screen.getByText("/imu")).toBeTruthy();
     expect(screen.getByText("sensor_msgs/Imu · ros1 · 8 msgs")).toBeTruthy();
-    expect(screen.getByText("Inspectable in Message")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Inspect" })).toBeTruthy();
     expect(screen.getByText("Schema unavailable")).toBeTruthy();
     expect(screen.getByText("Encoding unsupported")).toBeTruthy();
+  });
+
+  it("opens decodable other topics in a Message panel", () => {
+    const { probeState } = renderSidebar({
+      topics: [
+        topic("/imu", {
+          count: "8",
+          decodeStatus: "decodable",
+          encoding: "ros1",
+          schema: "sensor_msgs/Imu",
+        }),
+      ],
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Other topics/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Inspect" }));
+
+    const focusedTileId = probeState.current?.focusedTileId;
+    expect(focusedTileId?.startsWith("raw-")).toBe(true);
+    expect(probeState.current?.titles[focusedTileId ?? ""]).toBe("/imu");
+    expect(probeState.current?.topicsByTile[focusedTileId ?? ""]).toBe("/imu");
   });
 
   it("searches long other topic lists", () => {

--- a/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.test.tsx
@@ -179,12 +179,80 @@ describe("McapSettingsSidebar", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /Other topics/ }));
 
+    expect(screen.queryByLabelText("Search other topics")).toBeNull();
     expect(screen.queryByText("/lidar/top")).toBeNull();
     expect(screen.getByText("/imu")).toBeTruthy();
     expect(screen.getByText("sensor_msgs/Imu · ros1 · 8 msgs")).toBeTruthy();
     expect(screen.getByText("Inspectable in Message")).toBeTruthy();
     expect(screen.getByText("Schema unavailable")).toBeTruthy();
     expect(screen.getByText("Encoding unsupported")).toBeTruthy();
+  });
+
+  it("searches long other topic lists", () => {
+    renderSidebar({
+      topics: [
+        topic("/alpha", {
+          count: "1",
+          decodeStatus: "decodable",
+          encoding: "ros1",
+          schema: "example_msgs/Alpha",
+        }),
+        topic("/beta", {
+          count: "2",
+          decodeStatus: "decodable",
+          encoding: "ros1",
+          schema: "example_msgs/Beta",
+        }),
+        topic("/camera/front", {
+          count: "3",
+          decodeStatus: "decodable",
+          encoding: "ros1",
+          schema: "sensor_msgs/Image",
+        }),
+        topic("/diagnostics", {
+          count: "4",
+          decodeStatus: "decodable",
+          encoding: "ros1",
+          schema: "diagnostic_msgs/DiagnosticArray",
+        }),
+        topic("/gps", {
+          count: "5",
+          decodeStatus: "decodable",
+          encoding: "ros1",
+          schema: "sensor_msgs/NavSatFix",
+        }),
+        topic("/imu", {
+          count: "6",
+          decodeStatus: "decodable",
+          encoding: "ros1",
+          schema: "sensor_msgs/Imu",
+        }),
+        topic("/tf_static", {
+          count: "7",
+          decodeStatus: "decodable",
+          encoding: "ros1",
+          schema: "tf2_msgs/TFMessage",
+        }),
+      ],
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Other topics/ }));
+
+    const search = screen.getByLabelText(
+      "Search other topics",
+    ) as HTMLInputElement;
+    expect(search).toBeTruthy();
+    expect(screen.queryByText("/camera/front")).toBeNull();
+
+    fireEvent.change(search, { target: { value: "navsat" } });
+
+    expect(screen.getByText("/gps")).toBeTruthy();
+    expect(screen.queryByText("/alpha")).toBeNull();
+    expect(screen.queryByText("/imu")).toBeNull();
+
+    fireEvent.change(search, { target: { value: "nothing" } });
+
+    expect(screen.getByText('No other topics match "nothing"')).toBeTruthy();
   });
 
   it("switches to the panel tab when a panel tab first appears", () => {

--- a/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.tsx
@@ -1,7 +1,5 @@
 import { useTiling } from "@fiftyone/tiling";
 import {
-  Input,
-  InputType,
   Size,
   Text,
   TextColor,
@@ -16,9 +14,7 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { useSceneInventory } from "../../../scene-inventory/SceneInventoryProvider";
 import type { StreamInventory } from "../../../schemas/v1";
-import { topicName } from "../stream-topics";
 import {
   type McapPlaybackFidelityMode,
   type McapTemporalPolicySettings,
@@ -27,11 +23,9 @@ import {
 } from "./mcap-modal-settings";
 import McapSidebarGroup from "./McapSidebarGroup";
 import styles from "./McapSettingsSidebar.module.css";
-import { useOpenMcapRawMessageTile } from "./use-open-mcap-raw-message-tile";
+import McapTopicsSettings from "./McapTopicsSettings";
 
-type ActiveSettingsTab = "scene" | "panel";
-
-const OTHER_TOPICS_SEARCH_THRESHOLD = 5;
+type ActiveSettingsTab = "panel" | "scene" | "topics";
 
 /**
  * MCAP-specific left sidebar. Panel settings stay on an explicit tab while
@@ -48,19 +42,27 @@ const McapSettingsSidebar: React.FC<{
   const hasPanelTab = focusedTileTitle !== null;
   const [activeTab, setActiveTab] = useState<ActiveSettingsTab>("scene");
   const hadPanelTabRef = useRef(false);
+  const suppressNextPanelAutoSwitchRef = useRef(false);
   const slotRef = useCallback(
     (el: HTMLDivElement | null) => setSettingsSlotEl(el),
     [setSettingsSlotEl],
   );
+  const suppressNextPanelAutoSwitch = useCallback(() => {
+    suppressNextPanelAutoSwitchRef.current = true;
+  }, []);
 
   useLayoutEffect(() => {
     if (hasPanelTab && !hadPanelTabRef.current) {
-      setActiveTab("panel");
-    } else if (!hasPanelTab) {
+      if (suppressNextPanelAutoSwitchRef.current) {
+        suppressNextPanelAutoSwitchRef.current = false;
+      } else {
+        setActiveTab("panel");
+      }
+    } else if (!hasPanelTab && activeTab === "panel") {
       setActiveTab("scene");
     }
     hadPanelTabRef.current = hasPanelTab;
-  }, [hasPanelTab]);
+  }, [activeTab, hasPanelTab]);
 
   const tabs = useMemo<Descriptor<ToggleSwitchTab>[]>(() => {
     const nextTabs: Descriptor<ToggleSwitchTab>[] = [
@@ -68,7 +70,19 @@ const McapSettingsSidebar: React.FC<{
         id: "scene",
         data: {
           label: "Scene",
-          content: <GlobalSceneSettings topics={topics} />,
+          content: <GlobalSceneSettings />,
+        },
+      },
+      {
+        id: "topics",
+        data: {
+          label: "Topics",
+          content: (
+            <McapTopicsSettings
+              onTopicActionStart={suppressNextPanelAutoSwitch}
+              topics={topics}
+            />
+          ),
         },
       },
     ];
@@ -84,13 +98,18 @@ const McapSettingsSidebar: React.FC<{
     }
 
     return nextTabs;
-  }, [focusedTileTitle, slotRef, topics]);
-  const defaultIndex = activeTab === "panel" && hasPanelTab ? 1 : 0;
+  }, [focusedTileTitle, slotRef, suppressNextPanelAutoSwitch, topics]);
+  const defaultIndex = Math.max(
+    0,
+    tabs.findIndex((tab) => tab.id === activeTab),
+  );
   const handleTabChange = useCallback(
     (index: number) => {
-      setActiveTab(index === 1 && hasPanelTab ? "panel" : "scene");
+      setActiveTab(
+        (tabs[index]?.id as ActiveSettingsTab | undefined) ?? "scene",
+      );
     },
-    [hasPanelTab],
+    [tabs],
   );
 
   return (
@@ -119,176 +138,13 @@ function PanelSettingsContent({
   );
 }
 
-function GlobalSceneSettings({
-  topics,
-}: {
-  readonly topics: readonly StreamInventory[];
-}) {
+function GlobalSceneSettings() {
   return (
     <div className={`${styles.root} ${styles.tabContent}`}>
-      <OtherTopicsSettings topics={topics} />
       <PlaybackFidelitySettings />
       <TimeResolutionSettings />
     </div>
   );
-}
-
-interface OtherTopicRow {
-  readonly canInspect: boolean;
-  readonly countLabel: string;
-  readonly encoding: string;
-  readonly schemaName: string;
-  readonly statusLabel: string;
-  readonly topic: string;
-}
-
-function OtherTopicsSettings({
-  topics,
-}: {
-  readonly topics: readonly StreamInventory[];
-}) {
-  const sceneSources = useSceneInventory();
-  const openRawMessageTile = useOpenMcapRawMessageTile();
-  const [search, setSearch] = useState("");
-  const rows = useMemo(
-    () =>
-      otherTopicRows(
-        topics,
-        sceneSources.map((source) => source.id),
-      ),
-    [sceneSources, topics],
-  );
-  const showSearch = rows.length > OTHER_TOPICS_SEARCH_THRESHOLD;
-  const filteredRows = useMemo(
-    () => (showSearch ? filterOtherTopicRows(rows, search) : rows),
-    [rows, search, showSearch],
-  );
-
-  if (rows.length === 0) {
-    return null;
-  }
-
-  return (
-    <McapSidebarGroup
-      defaultExpanded={false}
-      summary={`${rows.length} not rendered`}
-      title="Other topics"
-    >
-      {showSearch ? (
-        <Input
-          aria-label="Search other topics"
-          className={styles.topicSearchInput}
-          onChange={(event) => setSearch(event.target.value)}
-          placeholder="Search topics"
-          size={Size.Sm}
-          type={InputType.Search}
-          value={search}
-        />
-      ) : null}
-      <div className={styles.topicList}>
-        {filteredRows.map((row) => (
-          <div className={styles.topicRow} key={row.topic}>
-            <Text variant={TextVariant.Xs} color={TextColor.Primary}>
-              {row.topic}
-            </Text>
-            <span className={styles.topicMeta}>
-              {row.schemaName} · {row.encoding} · {row.countLabel}
-            </span>
-            {row.canInspect ? (
-              <button
-                aria-label={`Inspect ${row.topic}`}
-                className={styles.topicInspectButton}
-                onClick={() => openRawMessageTile(row.topic)}
-                type="button"
-              >
-                {row.statusLabel}
-              </button>
-            ) : (
-              <span className={styles.topicStatus}>{row.statusLabel}</span>
-            )}
-          </div>
-        ))}
-        {filteredRows.length === 0 ? (
-          <span className={styles.topicEmpty}>
-            No other topics match &quot;{search}&quot;
-          </span>
-        ) : null}
-      </div>
-    </McapSidebarGroup>
-  );
-}
-
-function filterOtherTopicRows(
-  rows: readonly OtherTopicRow[],
-  search: string,
-): readonly OtherTopicRow[] {
-  const needle = search.trim().toLowerCase();
-  if (!needle) {
-    return rows;
-  }
-
-  return rows.filter((row) =>
-    [row.topic, row.schemaName, row.encoding, row.statusLabel].some((value) =>
-      value.toLowerCase().includes(needle),
-    ),
-  );
-}
-
-function otherTopicRows(
-  topics: readonly StreamInventory[],
-  renderedTopicIds: readonly string[],
-): readonly OtherTopicRow[] {
-  const rendered = new Set(renderedTopicIds);
-  return topics
-    .map((topic) => {
-      const name = topicName(topic);
-      if (!name || rendered.has(name)) {
-        return null;
-      }
-      const decodeStatus = genericDecodeStatus(
-        topic.metadata["mcap.generic_decode_status"],
-      );
-      return {
-        canInspect: decodeStatus.canInspect,
-        countLabel: messageCountLabel(topic.recordCount),
-        encoding:
-          topic.metadata["mcap.message_encoding"] ??
-          topic.payload?.encoding ??
-          "unknown",
-        schemaName:
-          topic.metadata["mcap.schema_name"] ??
-          topic.payload?.schema ??
-          "no schema",
-        statusLabel: decodeStatus.label,
-        topic: name,
-      };
-    })
-    .filter((row): row is OtherTopicRow => row !== null)
-    .sort((left, right) => left.topic.localeCompare(right.topic));
-}
-
-function genericDecodeStatus(status: string | undefined): {
-  readonly canInspect: boolean;
-  readonly label: string;
-} {
-  switch (status) {
-    case "decodable":
-      return { canInspect: true, label: "Inspect" };
-    case "schema-unavailable":
-      return { canInspect: false, label: "Schema unavailable" };
-    case "unsupported-encoding":
-      return { canInspect: false, label: "Encoding unsupported" };
-    default:
-      return { canInspect: false, label: "Raw status unknown" };
-  }
-}
-
-function messageCountLabel(recordCount: string | undefined): string {
-  const count = recordCount === undefined ? Number.NaN : Number(recordCount);
-  if (!Number.isFinite(count) || count < 0) {
-    return "unknown msgs";
-  }
-  return `${count.toLocaleString()} ${count === 1 ? "msg" : "msgs"}`;
 }
 
 const FIDELITY_OPTIONS: readonly {

--- a/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.tsx
@@ -1,5 +1,7 @@
 import { useTiling } from "@fiftyone/tiling";
 import {
+  Input,
+  InputType,
   Size,
   Text,
   TextColor,
@@ -27,6 +29,8 @@ import McapSidebarGroup from "./McapSidebarGroup";
 import styles from "./McapSettingsSidebar.module.css";
 
 type ActiveSettingsTab = "scene" | "panel";
+
+const OTHER_TOPICS_SEARCH_THRESHOLD = 5;
 
 /**
  * MCAP-specific left sidebar. Panel settings stay on an explicit tab while
@@ -142,6 +146,7 @@ function OtherTopicsSettings({
   readonly topics: readonly StreamInventory[];
 }) {
   const sceneSources = useSceneInventory();
+  const [search, setSearch] = useState("");
   const rows = useMemo(
     () =>
       otherTopicRows(
@@ -149,6 +154,11 @@ function OtherTopicsSettings({
         sceneSources.map((source) => source.id),
       ),
     [sceneSources, topics],
+  );
+  const showSearch = rows.length > OTHER_TOPICS_SEARCH_THRESHOLD;
+  const filteredRows = useMemo(
+    () => (showSearch ? filterOtherTopicRows(rows, search) : rows),
+    [rows, search, showSearch],
   );
 
   if (rows.length === 0) {
@@ -161,8 +171,19 @@ function OtherTopicsSettings({
       summary={`${rows.length} not rendered`}
       title="Other topics"
     >
+      {showSearch ? (
+        <Input
+          aria-label="Search other topics"
+          className={styles.topicSearchInput}
+          onChange={(event) => setSearch(event.target.value)}
+          placeholder="Search topics"
+          size={Size.Sm}
+          type={InputType.Search}
+          value={search}
+        />
+      ) : null}
       <div className={styles.topicList}>
-        {rows.map((row) => (
+        {filteredRows.map((row) => (
           <div className={styles.topicRow} key={row.topic}>
             <Text variant={TextVariant.Xs} color={TextColor.Primary}>
               {row.topic}
@@ -173,8 +194,29 @@ function OtherTopicsSettings({
             <span className={styles.topicStatus}>{row.statusLabel}</span>
           </div>
         ))}
+        {filteredRows.length === 0 ? (
+          <span className={styles.topicEmpty}>
+            No other topics match &quot;{search}&quot;
+          </span>
+        ) : null}
       </div>
     </McapSidebarGroup>
+  );
+}
+
+function filterOtherTopicRows(
+  rows: readonly OtherTopicRow[],
+  search: string,
+): readonly OtherTopicRow[] {
+  const needle = search.trim().toLowerCase();
+  if (!needle) {
+    return rows;
+  }
+
+  return rows.filter((row) =>
+    [row.topic, row.schemaName, row.encoding, row.statusLabel].some((value) =>
+      value.toLowerCase().includes(needle),
+    ),
   );
 }
 

--- a/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.tsx
@@ -52,15 +52,15 @@ const McapSettingsSidebar: React.FC<{
   }, []);
 
   useLayoutEffect(() => {
+    const suppressPanelAutoSwitch = suppressNextPanelAutoSwitchRef.current;
     if (hasPanelTab && !hadPanelTabRef.current) {
-      if (suppressNextPanelAutoSwitchRef.current) {
-        suppressNextPanelAutoSwitchRef.current = false;
-      } else {
+      if (!suppressPanelAutoSwitch) {
         setActiveTab("panel");
       }
     } else if (!hasPanelTab && activeTab === "panel") {
       setActiveTab("scene");
     }
+    suppressNextPanelAutoSwitchRef.current = false;
     hadPanelTabRef.current = hasPanelTab;
   }, [activeTab, hasPanelTab]);
 

--- a/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.tsx
@@ -27,6 +27,7 @@ import {
 } from "./mcap-modal-settings";
 import McapSidebarGroup from "./McapSidebarGroup";
 import styles from "./McapSettingsSidebar.module.css";
+import { useOpenMcapRawMessageTile } from "./use-open-mcap-raw-message-tile";
 
 type ActiveSettingsTab = "scene" | "panel";
 
@@ -133,6 +134,7 @@ function GlobalSceneSettings({
 }
 
 interface OtherTopicRow {
+  readonly canInspect: boolean;
   readonly countLabel: string;
   readonly encoding: string;
   readonly schemaName: string;
@@ -146,6 +148,7 @@ function OtherTopicsSettings({
   readonly topics: readonly StreamInventory[];
 }) {
   const sceneSources = useSceneInventory();
+  const openRawMessageTile = useOpenMcapRawMessageTile();
   const [search, setSearch] = useState("");
   const rows = useMemo(
     () =>
@@ -191,7 +194,17 @@ function OtherTopicsSettings({
             <span className={styles.topicMeta}>
               {row.schemaName} · {row.encoding} · {row.countLabel}
             </span>
-            <span className={styles.topicStatus}>{row.statusLabel}</span>
+            {row.canInspect ? (
+              <button
+                className={styles.topicInspectButton}
+                onClick={() => openRawMessageTile(row.topic)}
+                type="button"
+              >
+                {row.statusLabel}
+              </button>
+            ) : (
+              <span className={styles.topicStatus}>{row.statusLabel}</span>
+            )}
           </div>
         ))}
         {filteredRows.length === 0 ? (
@@ -231,7 +244,11 @@ function otherTopicRows(
       if (!name || rendered.has(name)) {
         return null;
       }
+      const decodeStatus = genericDecodeStatus(
+        topic.metadata["mcap.generic_decode_status"],
+      );
       return {
+        canInspect: decodeStatus.canInspect,
         countLabel: messageCountLabel(topic.recordCount),
         encoding:
           topic.metadata["mcap.message_encoding"] ??
@@ -241,9 +258,7 @@ function otherTopicRows(
           topic.metadata["mcap.schema_name"] ??
           topic.payload?.schema ??
           "no schema",
-        statusLabel: genericDecodeStatusLabel(
-          topic.metadata["mcap.generic_decode_status"],
-        ),
+        statusLabel: decodeStatus.label,
         topic: name,
       };
     })
@@ -251,16 +266,19 @@ function otherTopicRows(
     .sort((left, right) => left.topic.localeCompare(right.topic));
 }
 
-function genericDecodeStatusLabel(status: string | undefined): string {
+function genericDecodeStatus(status: string | undefined): {
+  readonly canInspect: boolean;
+  readonly label: string;
+} {
   switch (status) {
     case "decodable":
-      return "Inspectable in Message";
+      return { canInspect: true, label: "Inspect" };
     case "schema-unavailable":
-      return "Schema unavailable";
+      return { canInspect: false, label: "Schema unavailable" };
     case "unsupported-encoding":
-      return "Encoding unsupported";
+      return { canInspect: false, label: "Encoding unsupported" };
     default:
-      return "Raw status unknown";
+      return { canInspect: false, label: "Raw status unknown" };
   }
 }
 

--- a/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.tsx
@@ -99,9 +99,15 @@ const McapSettingsSidebar: React.FC<{
 
     return nextTabs;
   }, [focusedTileTitle, slotRef, suppressNextPanelAutoSwitch, topics]);
+  const selectedTab =
+    hasPanelTab &&
+    !hadPanelTabRef.current &&
+    !suppressNextPanelAutoSwitchRef.current
+      ? "panel"
+      : activeTab;
   const defaultIndex = Math.max(
     0,
-    tabs.findIndex((tab) => tab.id === activeTab),
+    tabs.findIndex((tab) => tab.id === selectedTab),
   );
   const handleTabChange = useCallback(
     (index: number) => {
@@ -115,7 +121,7 @@ const McapSettingsSidebar: React.FC<{
   return (
     <div className={styles.sidebarRoot}>
       <ToggleSwitch
-        key={`${hasPanelTab ? "with-panel" : "scene-only"}-${defaultIndex}`}
+        key={hasPanelTab ? "with-panel" : "scene-only"}
         defaultIndex={defaultIndex}
         fullWidth
         onChange={handleTabChange}

--- a/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.tsx
@@ -196,6 +196,7 @@ function OtherTopicsSettings({
             </span>
             {row.canInspect ? (
               <button
+                aria-label={`Inspect ${row.topic}`}
                 className={styles.topicInspectButton}
                 onClick={() => openRawMessageTile(row.topic)}
                 type="button"

--- a/app/packages/multimodal/src/adapters/mcap/react/McapSourcePlayback.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapSourcePlayback.test.tsx
@@ -81,6 +81,11 @@ describe("McapSourcePlayback", () => {
         "No previewable streams in this recording (3 topics found)",
       ),
     ).toBeTruthy();
+    expect(playbackHarness.useMcapModalLayout).toHaveBeenCalledWith(
+      expect.objectContaining({
+        datasetId: "mcap-source:local-file:unsupported.mcap:12:1",
+      }),
+    );
     expect(document.querySelector('[data-testid="playback-shell"]')).toBeNull();
   });
 });

--- a/app/packages/multimodal/src/adapters/mcap/react/McapSourcePlayback.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapSourcePlayback.tsx
@@ -109,6 +109,8 @@ export const McapSourcePlayback: React.FC<McapSourcePlaybackProps> = ({
     client,
     source,
   });
+  const effectiveLayoutScopeKey =
+    layoutScopeKey ?? (source ? `mcap-source:${source.sourceId}` : undefined);
   const metadata = useMemo(
     () => ({
       sizeLabel: sourceSizeLabel(source?.sizeBytes),
@@ -136,7 +138,7 @@ export const McapSourcePlayback: React.FC<McapSourcePlaybackProps> = ({
     sceneUpAxis,
     onSceneUpAxisChange,
   } = useMcapModalLayout({
-    datasetId: layoutScopeKey,
+    datasetId: effectiveLayoutScopeKey,
     readProfile: source?.readProfile,
     sources,
   });
@@ -223,7 +225,9 @@ export const McapSourcePlayback: React.FC<McapSourcePlaybackProps> = ({
                     <McapPausedByteBanking client={client} source={source} />
                     <McapSelectionHotkeys />
                     {children}
-                    <McapModalLayoutPersistence datasetId={layoutScopeKey} />
+                    <McapModalLayoutPersistence
+                      datasetId={effectiveLayoutScopeKey}
+                    />
                   </MultiModalPlayback>
                 </Mcap3dViewSettingsProvider>
               </McapDataStreamProvider>

--- a/app/packages/multimodal/src/adapters/mcap/react/McapSourcePlayback.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapSourcePlayback.tsx
@@ -20,6 +20,7 @@ import { Mcap3dViewSettingsProvider } from "./mcap-3d-view-settings-context";
 import { McapDataStreamProvider } from "./mcap-data-stream-context";
 import { McapFrameTransformsProvider } from "./mcap-frame-transforms-context";
 import { McapLogConsoleProvider } from "./mcap-log-console-context";
+import { McapLocationTracksProvider } from "./mcap-location-tracks-context";
 import { McapNumericSeriesProvider } from "./mcap-numeric-series-context";
 import { McapPoseTrajectoriesProvider } from "./mcap-pose-trajectories-context";
 import { McapRawMessageProvider } from "./mcap-raw-message-context";
@@ -187,61 +188,65 @@ export const McapSourcePlayback: React.FC<McapSourcePlaybackProps> = ({
     <React.Fragment key={byteSourceAccessKey(source)}>
       <McapFrameTransformsProvider>
         <McapPoseTrajectoriesProvider>
-          <McapSceneUpdateHistoryProvider>
-            <McapNumericSeriesProvider>
-              <McapRawMessageProvider>
-                <McapLogConsoleProvider client={client} source={source}>
-                  <McapDataStreamProvider>
-                    <Mcap3dViewSettingsProvider
-                      sceneUpAxis={sceneUpAxis}
-                      setSceneUpAxis={onSceneUpAxisChange}
-                    >
-                      <MultiModalPlayback
-                        fileName={fileName}
-                        headerCaption={headerCaption}
-                        headerActions={
-                          <McapHeaderActions actions={headerActions} />
-                        }
-                        addTileMenu={<McapAddTileMenu />}
-                        timelineExtraActions={<McapTimestampReadout />}
-                        sceneSources={sources}
-                        deselectFocusedTileOnRepeatSelect={false}
-                        initialTiles={initialTiles}
-                        initialManualTileTitles={initialManualTileTitles}
-                        autoLayoutStrategy={buildMcapAutoLayout}
-                        initialLayout={initialLayout}
-                        initialExpandedTileId={initialExpandedTileId}
-                        tracks={
-                          tracks && tracks.length > 0 ? [...tracks] : undefined
-                        }
-                        onTagDelete={onTagDelete}
-                        leftSidebar={<McapSettingsSidebar topics={topics} />}
-                        rightSidebar={<McapInspectorSidebar />}
-                        defaultRightOpen={false}
-                        defaultLeftOpen={defaultLeftOpen}
-                        onLeftOpenChange={onLeftOpenChange}
-                        leftSidebarWidth={defaultLeftSidebarWidth}
-                        onLeftSidebarWidthChange={onLeftSidebarWidthChange}
-                        onTagCreate={onTagCreate}
+          <McapLocationTracksProvider>
+            <McapSceneUpdateHistoryProvider>
+              <McapNumericSeriesProvider>
+                <McapRawMessageProvider>
+                  <McapLogConsoleProvider client={client} source={source}>
+                    <McapDataStreamProvider>
+                      <Mcap3dViewSettingsProvider
+                        sceneUpAxis={sceneUpAxis}
+                        setSceneUpAxis={onSceneUpAxisChange}
                       >
-                        <McapStreams client={client} source={source} />
-                        <McapNetworkHealthTracker client={client} />
-                        <McapPausedByteBanking
-                          client={client}
-                          source={source}
-                        />
-                        <McapSelectionHotkeys />
-                        {children}
-                        <McapModalLayoutPersistence
-                          datasetId={effectiveLayoutScopeKey}
-                        />
-                      </MultiModalPlayback>
-                    </Mcap3dViewSettingsProvider>
-                  </McapDataStreamProvider>
-                </McapLogConsoleProvider>
-              </McapRawMessageProvider>
-            </McapNumericSeriesProvider>
-          </McapSceneUpdateHistoryProvider>
+                        <MultiModalPlayback
+                          fileName={fileName}
+                          headerCaption={headerCaption}
+                          headerActions={
+                            <McapHeaderActions actions={headerActions} />
+                          }
+                          addTileMenu={<McapAddTileMenu />}
+                          timelineExtraActions={<McapTimestampReadout />}
+                          sceneSources={sources}
+                          deselectFocusedTileOnRepeatSelect={false}
+                          initialTiles={initialTiles}
+                          initialManualTileTitles={initialManualTileTitles}
+                          autoLayoutStrategy={buildMcapAutoLayout}
+                          initialLayout={initialLayout}
+                          initialExpandedTileId={initialExpandedTileId}
+                          tracks={
+                            tracks && tracks.length > 0
+                              ? [...tracks]
+                              : undefined
+                          }
+                          onTagDelete={onTagDelete}
+                          leftSidebar={<McapSettingsSidebar topics={topics} />}
+                          rightSidebar={<McapInspectorSidebar />}
+                          defaultRightOpen={false}
+                          defaultLeftOpen={defaultLeftOpen}
+                          onLeftOpenChange={onLeftOpenChange}
+                          leftSidebarWidth={defaultLeftSidebarWidth}
+                          onLeftSidebarWidthChange={onLeftSidebarWidthChange}
+                          onTagCreate={onTagCreate}
+                        >
+                          <McapStreams client={client} source={source} />
+                          <McapNetworkHealthTracker client={client} />
+                          <McapPausedByteBanking
+                            client={client}
+                            source={source}
+                          />
+                          <McapSelectionHotkeys />
+                          {children}
+                          <McapModalLayoutPersistence
+                            datasetId={effectiveLayoutScopeKey}
+                          />
+                        </MultiModalPlayback>
+                      </Mcap3dViewSettingsProvider>
+                    </McapDataStreamProvider>
+                  </McapLogConsoleProvider>
+                </McapRawMessageProvider>
+              </McapNumericSeriesProvider>
+            </McapSceneUpdateHistoryProvider>
+          </McapLocationTracksProvider>
         </McapPoseTrajectoriesProvider>
       </McapFrameTransformsProvider>
     </React.Fragment>

--- a/app/packages/multimodal/src/adapters/mcap/react/McapSourcePlayback.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapSourcePlayback.tsx
@@ -22,6 +22,7 @@ import { McapFrameTransformsProvider } from "./mcap-frame-transforms-context";
 import { McapNumericSeriesProvider } from "./mcap-numeric-series-context";
 import { McapPoseTrajectoriesProvider } from "./mcap-pose-trajectories-context";
 import { McapRawMessageProvider } from "./mcap-raw-message-context";
+import { McapSceneUpdateHistoryProvider } from "./mcap-scene-update-history-context";
 import { McapSelectionHotkeys } from "./mcap-selected-object";
 import McapAddTileMenu from "./McapAddTileMenu";
 import McapInspectorSidebar from "./McapInspectorSidebar";
@@ -185,54 +186,56 @@ export const McapSourcePlayback: React.FC<McapSourcePlaybackProps> = ({
     <React.Fragment key={byteSourceAccessKey(source)}>
       <McapFrameTransformsProvider>
         <McapPoseTrajectoriesProvider>
-          <McapNumericSeriesProvider>
-            <McapRawMessageProvider>
-              <McapDataStreamProvider>
-                <Mcap3dViewSettingsProvider
-                  sceneUpAxis={sceneUpAxis}
-                  setSceneUpAxis={onSceneUpAxisChange}
-                >
-                  <MultiModalPlayback
-                    fileName={fileName}
-                    headerCaption={headerCaption}
-                    headerActions={
-                      <McapHeaderActions actions={headerActions} />
-                    }
-                    addTileMenu={<McapAddTileMenu />}
-                    timelineExtraActions={<McapTimestampReadout />}
-                    sceneSources={sources}
-                    deselectFocusedTileOnRepeatSelect={false}
-                    initialTiles={initialTiles}
-                    initialManualTileTitles={initialManualTileTitles}
-                    autoLayoutStrategy={buildMcapAutoLayout}
-                    initialLayout={initialLayout}
-                    initialExpandedTileId={initialExpandedTileId}
-                    tracks={
-                      tracks && tracks.length > 0 ? [...tracks] : undefined
-                    }
-                    onTagDelete={onTagDelete}
-                    leftSidebar={<McapSettingsSidebar topics={topics} />}
-                    rightSidebar={<McapInspectorSidebar />}
-                    defaultRightOpen={false}
-                    defaultLeftOpen={defaultLeftOpen}
-                    onLeftOpenChange={onLeftOpenChange}
-                    leftSidebarWidth={defaultLeftSidebarWidth}
-                    onLeftSidebarWidthChange={onLeftSidebarWidthChange}
-                    onTagCreate={onTagCreate}
+          <McapSceneUpdateHistoryProvider>
+            <McapNumericSeriesProvider>
+              <McapRawMessageProvider>
+                <McapDataStreamProvider>
+                  <Mcap3dViewSettingsProvider
+                    sceneUpAxis={sceneUpAxis}
+                    setSceneUpAxis={onSceneUpAxisChange}
                   >
-                    <McapStreams client={client} source={source} />
-                    <McapNetworkHealthTracker client={client} />
-                    <McapPausedByteBanking client={client} source={source} />
-                    <McapSelectionHotkeys />
-                    {children}
-                    <McapModalLayoutPersistence
-                      datasetId={effectiveLayoutScopeKey}
-                    />
-                  </MultiModalPlayback>
-                </Mcap3dViewSettingsProvider>
-              </McapDataStreamProvider>
-            </McapRawMessageProvider>
-          </McapNumericSeriesProvider>
+                    <MultiModalPlayback
+                      fileName={fileName}
+                      headerCaption={headerCaption}
+                      headerActions={
+                        <McapHeaderActions actions={headerActions} />
+                      }
+                      addTileMenu={<McapAddTileMenu />}
+                      timelineExtraActions={<McapTimestampReadout />}
+                      sceneSources={sources}
+                      deselectFocusedTileOnRepeatSelect={false}
+                      initialTiles={initialTiles}
+                      initialManualTileTitles={initialManualTileTitles}
+                      autoLayoutStrategy={buildMcapAutoLayout}
+                      initialLayout={initialLayout}
+                      initialExpandedTileId={initialExpandedTileId}
+                      tracks={
+                        tracks && tracks.length > 0 ? [...tracks] : undefined
+                      }
+                      onTagDelete={onTagDelete}
+                      leftSidebar={<McapSettingsSidebar topics={topics} />}
+                      rightSidebar={<McapInspectorSidebar />}
+                      defaultRightOpen={false}
+                      defaultLeftOpen={defaultLeftOpen}
+                      onLeftOpenChange={onLeftOpenChange}
+                      leftSidebarWidth={defaultLeftSidebarWidth}
+                      onLeftSidebarWidthChange={onLeftSidebarWidthChange}
+                      onTagCreate={onTagCreate}
+                    >
+                      <McapStreams client={client} source={source} />
+                      <McapNetworkHealthTracker client={client} />
+                      <McapPausedByteBanking client={client} source={source} />
+                      <McapSelectionHotkeys />
+                      {children}
+                      <McapModalLayoutPersistence
+                        datasetId={effectiveLayoutScopeKey}
+                      />
+                    </MultiModalPlayback>
+                  </Mcap3dViewSettingsProvider>
+                </McapDataStreamProvider>
+              </McapRawMessageProvider>
+            </McapNumericSeriesProvider>
+          </McapSceneUpdateHistoryProvider>
         </McapPoseTrajectoriesProvider>
       </McapFrameTransformsProvider>
     </React.Fragment>

--- a/app/packages/multimodal/src/adapters/mcap/react/McapSourcePlayback.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapSourcePlayback.tsx
@@ -19,6 +19,7 @@ import { clearMcap3dViewState } from "./mcap-3d-view-state";
 import { Mcap3dViewSettingsProvider } from "./mcap-3d-view-settings-context";
 import { McapDataStreamProvider } from "./mcap-data-stream-context";
 import { McapFrameTransformsProvider } from "./mcap-frame-transforms-context";
+import { McapLogConsoleProvider } from "./mcap-log-console-context";
 import { McapNumericSeriesProvider } from "./mcap-numeric-series-context";
 import { McapPoseTrajectoriesProvider } from "./mcap-pose-trajectories-context";
 import { McapRawMessageProvider } from "./mcap-raw-message-context";
@@ -189,50 +190,55 @@ export const McapSourcePlayback: React.FC<McapSourcePlaybackProps> = ({
           <McapSceneUpdateHistoryProvider>
             <McapNumericSeriesProvider>
               <McapRawMessageProvider>
-                <McapDataStreamProvider>
-                  <Mcap3dViewSettingsProvider
-                    sceneUpAxis={sceneUpAxis}
-                    setSceneUpAxis={onSceneUpAxisChange}
-                  >
-                    <MultiModalPlayback
-                      fileName={fileName}
-                      headerCaption={headerCaption}
-                      headerActions={
-                        <McapHeaderActions actions={headerActions} />
-                      }
-                      addTileMenu={<McapAddTileMenu />}
-                      timelineExtraActions={<McapTimestampReadout />}
-                      sceneSources={sources}
-                      deselectFocusedTileOnRepeatSelect={false}
-                      initialTiles={initialTiles}
-                      initialManualTileTitles={initialManualTileTitles}
-                      autoLayoutStrategy={buildMcapAutoLayout}
-                      initialLayout={initialLayout}
-                      initialExpandedTileId={initialExpandedTileId}
-                      tracks={
-                        tracks && tracks.length > 0 ? [...tracks] : undefined
-                      }
-                      onTagDelete={onTagDelete}
-                      leftSidebar={<McapSettingsSidebar topics={topics} />}
-                      rightSidebar={<McapInspectorSidebar />}
-                      defaultRightOpen={false}
-                      defaultLeftOpen={defaultLeftOpen}
-                      onLeftOpenChange={onLeftOpenChange}
-                      leftSidebarWidth={defaultLeftSidebarWidth}
-                      onLeftSidebarWidthChange={onLeftSidebarWidthChange}
-                      onTagCreate={onTagCreate}
+                <McapLogConsoleProvider client={client} source={source}>
+                  <McapDataStreamProvider>
+                    <Mcap3dViewSettingsProvider
+                      sceneUpAxis={sceneUpAxis}
+                      setSceneUpAxis={onSceneUpAxisChange}
                     >
-                      <McapStreams client={client} source={source} />
-                      <McapNetworkHealthTracker client={client} />
-                      <McapPausedByteBanking client={client} source={source} />
-                      <McapSelectionHotkeys />
-                      {children}
-                      <McapModalLayoutPersistence
-                        datasetId={effectiveLayoutScopeKey}
-                      />
-                    </MultiModalPlayback>
-                  </Mcap3dViewSettingsProvider>
-                </McapDataStreamProvider>
+                      <MultiModalPlayback
+                        fileName={fileName}
+                        headerCaption={headerCaption}
+                        headerActions={
+                          <McapHeaderActions actions={headerActions} />
+                        }
+                        addTileMenu={<McapAddTileMenu />}
+                        timelineExtraActions={<McapTimestampReadout />}
+                        sceneSources={sources}
+                        deselectFocusedTileOnRepeatSelect={false}
+                        initialTiles={initialTiles}
+                        initialManualTileTitles={initialManualTileTitles}
+                        autoLayoutStrategy={buildMcapAutoLayout}
+                        initialLayout={initialLayout}
+                        initialExpandedTileId={initialExpandedTileId}
+                        tracks={
+                          tracks && tracks.length > 0 ? [...tracks] : undefined
+                        }
+                        onTagDelete={onTagDelete}
+                        leftSidebar={<McapSettingsSidebar topics={topics} />}
+                        rightSidebar={<McapInspectorSidebar />}
+                        defaultRightOpen={false}
+                        defaultLeftOpen={defaultLeftOpen}
+                        onLeftOpenChange={onLeftOpenChange}
+                        leftSidebarWidth={defaultLeftSidebarWidth}
+                        onLeftSidebarWidthChange={onLeftSidebarWidthChange}
+                        onTagCreate={onTagCreate}
+                      >
+                        <McapStreams client={client} source={source} />
+                        <McapNetworkHealthTracker client={client} />
+                        <McapPausedByteBanking
+                          client={client}
+                          source={source}
+                        />
+                        <McapSelectionHotkeys />
+                        {children}
+                        <McapModalLayoutPersistence
+                          datasetId={effectiveLayoutScopeKey}
+                        />
+                      </MultiModalPlayback>
+                    </Mcap3dViewSettingsProvider>
+                  </McapDataStreamProvider>
+                </McapLogConsoleProvider>
               </McapRawMessageProvider>
             </McapNumericSeriesProvider>
           </McapSceneUpdateHistoryProvider>

--- a/app/packages/multimodal/src/adapters/mcap/react/McapStreams.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapStreams.tsx
@@ -10,6 +10,7 @@ import {
 import { McapNumericSeriesBridge } from "./mcap-numeric-series-context";
 import { McapPoseTrajectoriesStartupGate } from "./mcap-pose-trajectories-context";
 import { McapRawMessageBridge } from "./mcap-raw-message-context";
+import { McapSceneUpdateHistoryBridge } from "./mcap-scene-update-history-context";
 import { useMcapDataStream } from "./mcap-data-stream-context";
 import { markMcapLatencyEvent } from "../mcap-latency-debug";
 import {
@@ -102,6 +103,13 @@ export function McapStreams({ client, source }: McapStreamsProps) {
       sources.filter((s) => s.type === MCAP_SOURCE_TYPE.POSE).map((s) => s.id),
     [sources],
   );
+  const sceneAnnotationTopics = useMemo(
+    () =>
+      sources
+        .filter((s) => s.type === MCAP_SOURCE_TYPE.SCENE_ANNOTATION)
+        .map((s) => s.id),
+    [sources],
+  );
 
   useRegisterMcapDataStream({
     blockingTopics,
@@ -126,6 +134,11 @@ export function McapStreams({ client, source }: McapStreamsProps) {
       <McapPoseTrajectoriesStartupGate
         client={client}
         poseTopics={poseTopics}
+        source={source}
+      />
+      <McapSceneUpdateHistoryBridge
+        client={client}
+        sceneAnnotationTopics={sceneAnnotationTopics}
         source={source}
       />
       <McapNumericSeriesBridge client={client} source={source} />

--- a/app/packages/multimodal/src/adapters/mcap/react/McapStreams.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapStreams.tsx
@@ -7,6 +7,7 @@ import {
   idleMcapFrameTransformsState,
   useSetMcapFrameTransformsContext,
 } from "./mcap-frame-transforms-context";
+import { McapLocationTracksBridge } from "./mcap-location-tracks-context";
 import { McapNumericSeriesBridge } from "./mcap-numeric-series-context";
 import { McapPoseTrajectoriesStartupGate } from "./mcap-pose-trajectories-context";
 import { McapRawMessageBridge } from "./mcap-raw-message-context";
@@ -104,6 +105,10 @@ export function McapStreams({ client, source }: McapStreamsProps) {
       sources.filter((s) => s.type === MCAP_SOURCE_TYPE.POSE).map((s) => s.id),
     [sources],
   );
+  const locationSources = useMemo(
+    () => sources.filter((s) => s.type === MCAP_SOURCE_TYPE.LOCATION),
+    [sources],
+  );
   const sceneAnnotationTopics = useMemo(
     () =>
       sources
@@ -135,6 +140,11 @@ export function McapStreams({ client, source }: McapStreamsProps) {
       <McapPoseTrajectoriesStartupGate
         client={client}
         poseTopics={poseTopics}
+        source={source}
+      />
+      <McapLocationTracksBridge
+        client={client}
+        locationSources={locationSources}
         source={source}
       />
       <McapSceneUpdateHistoryBridge

--- a/app/packages/multimodal/src/adapters/mcap/react/McapStreams.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapStreams.tsx
@@ -77,7 +77,8 @@ export function McapStreams({ client, source }: McapStreamsProps) {
             s.type !== MCAP_SOURCE_TYPE.MAP_LAYER &&
             s.type !== MCAP_SOURCE_TYPE.CAMERA_CALIBRATION &&
             s.type !== MCAP_SOURCE_TYPE.POSE &&
-            s.type !== MCAP_SOURCE_TYPE.LOCATION,
+            s.type !== MCAP_SOURCE_TYPE.LOCATION &&
+            s.type !== MCAP_SOURCE_TYPE.LOG,
         )
         .map((s) => s.id),
     [sources],

--- a/app/packages/multimodal/src/adapters/mcap/react/McapTopicsSettings.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapTopicsSettings.tsx
@@ -1,6 +1,6 @@
 import { useTiling } from "@fiftyone/tiling";
 import { Input, InputType, Size } from "@voxel51/voodo";
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useMemo, useRef, useState } from "react";
 import { useSceneInventory } from "../../../scene-inventory/SceneInventoryProvider";
 import type { StreamInventory } from "../../../schemas/v1";
 import { MCAP_SOURCE_TYPE } from "../scene-sources";
@@ -43,14 +43,25 @@ const McapTopicsSettings: React.FC<{
     () => (showSearch ? filterMcapTopicInventoryRows(rows, search) : rows),
     [rows, search, showSearch],
   );
-  const groups = useMemo(
-    () =>
-      MCAP_TOPIC_CATEGORY_ORDER.map((category) => ({
-        category,
-        rows: filteredRows.filter((row) => row.category === category),
-      })).filter((group) => group.rows.length > 0),
-    [filteredRows],
-  );
+  const groups = useMemo(() => {
+    const rowsByCategory = new Map<
+      McapTopicInventoryRow["category"],
+      McapTopicInventoryRow[]
+    >();
+    for (const row of filteredRows) {
+      const categoryRows = rowsByCategory.get(row.category);
+      if (categoryRows) {
+        categoryRows.push(row);
+      } else {
+        rowsByCategory.set(row.category, [row]);
+      }
+    }
+
+    return MCAP_TOPIC_CATEGORY_ORDER.map((category) => ({
+      category,
+      rows: rowsByCategory.get(category) ?? [],
+    })).filter((group) => group.rows.length > 0);
+  }, [filteredRows]);
   const actionHandlers = useMemo(
     () => ({
       open3dTile,
@@ -230,10 +241,13 @@ function visibleTopicStatusLabel(row: McapTopicInventoryRow): string | null {
 
 function useOpenMcapPanelTile(type: McapTileType): () => void {
   const { addTile, setFocusedTileId, tiles } = useTiling();
+  const tilesRef = useRef(tiles);
+  tilesRef.current = tiles;
 
   return useCallback(() => {
-    const existingTileId = Object.keys(tiles).find(
-      (tileId) => tiles[tileId]?.type === type,
+    const currentTiles = tilesRef.current;
+    const existingTileId = Object.keys(currentTiles).find(
+      (tileId) => currentTiles[tileId]?.type === type,
     );
     if (existingTileId) {
       setFocusedTileId(existingTileId);
@@ -245,15 +259,14 @@ function useOpenMcapPanelTile(type: McapTileType): () => void {
       return;
     }
     const Tile = definition.Tile;
-    addTile(
-      {
-        render: () => <Tile />,
-        title: definition.typeLabel,
-        type,
-      },
-      { idPrefix: type },
-    );
-  }, [addTile, setFocusedTileId, tiles, type]);
+    const tile = {
+      render: () => <Tile />,
+      title: definition.typeLabel,
+      type,
+    };
+    const tileId = addTile(tile, { idPrefix: type });
+    tilesRef.current = { ...currentTiles, [tileId]: tile };
+  }, [addTile, setFocusedTileId, type]);
 }
 
 function topicDetails(row: McapTopicInventoryRow): string {

--- a/app/packages/multimodal/src/adapters/mcap/react/McapTopicsSettings.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapTopicsSettings.tsx
@@ -1,7 +1,7 @@
 import { useTiling } from "@fiftyone/tiling";
 import { Input, InputType, Size } from "@voxel51/voodo";
 import React, { useCallback, useMemo, useState } from "react";
-import { useSceneInventory } from "../../../scene-inventory";
+import { useSceneInventory } from "../../../scene-inventory/SceneInventoryProvider";
 import type { StreamInventory } from "../../../schemas/v1";
 import { MCAP_SOURCE_TYPE } from "../scene-sources";
 import {

--- a/app/packages/multimodal/src/adapters/mcap/react/McapTopicsSettings.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapTopicsSettings.tsx
@@ -1,0 +1,272 @@
+import { useTiling } from "@fiftyone/tiling";
+import { Input, InputType, Size } from "@voxel51/voodo";
+import React, { useCallback, useMemo, useState } from "react";
+import { useSceneInventory } from "../../../scene-inventory";
+import type { StreamInventory } from "../../../schemas/v1";
+import { MCAP_SOURCE_TYPE } from "../scene-sources";
+import {
+  MCAP_TOPIC_CAPABILITY,
+  MCAP_TOPIC_CAPABILITY_LABEL,
+  MCAP_TOPIC_CATEGORY,
+  MCAP_TOPIC_CATEGORY_LABEL,
+  MCAP_TOPIC_CATEGORY_ORDER,
+  MCAP_TOPIC_SUPPORT_LABEL,
+  buildMcapTopicInventoryRows,
+  filterMcapTopicInventoryRows,
+  type McapTopicInventoryRow,
+} from "../topic-inventory";
+import McapSidebarGroup from "./McapSidebarGroup";
+import styles from "./McapSettingsSidebar.module.css";
+import { MCAP_TILE_TYPE, type McapTileType } from "./mcap-tile-types";
+import { getMcapTileDefinition } from "./use-mcap-tiles";
+import { useOpenMcapImageTile } from "./use-open-mcap-image-tile";
+import { useOpenMcapRawMessageTile } from "./use-open-mcap-raw-message-tile";
+
+const TOPICS_SEARCH_THRESHOLD = 5;
+
+const McapTopicsSettings: React.FC<{
+  readonly onTopicActionStart?: () => void;
+  readonly topics: readonly StreamInventory[];
+}> = ({ onTopicActionStart, topics }) => {
+  const sceneSources = useSceneInventory();
+  const openImageTile = useOpenMcapImageTile();
+  const openRawMessageTile = useOpenMcapRawMessageTile();
+  const open3dTile = useOpenMcapPanelTile(MCAP_TILE_TYPE.THREE_D);
+  const openLogTile = useOpenMcapPanelTile(MCAP_TILE_TYPE.LOG);
+  const [search, setSearch] = useState("");
+  const rows = useMemo(
+    () => buildMcapTopicInventoryRows({ sceneSources, topics }),
+    [sceneSources, topics],
+  );
+  const showSearch = rows.length > TOPICS_SEARCH_THRESHOLD;
+  const filteredRows = useMemo(
+    () => (showSearch ? filterMcapTopicInventoryRows(rows, search) : rows),
+    [rows, search, showSearch],
+  );
+  const groups = useMemo(
+    () =>
+      MCAP_TOPIC_CATEGORY_ORDER.map((category) => ({
+        category,
+        rows: filteredRows.filter((row) => row.category === category),
+      })).filter((group) => group.rows.length > 0),
+    [filteredRows],
+  );
+  const actionHandlers = useMemo(
+    () => ({
+      open3dTile,
+      openImageTile,
+      openLogTile,
+      openRawMessageTile,
+    }),
+    [open3dTile, openImageTile, openLogTile, openRawMessageTile],
+  );
+
+  return (
+    <div className={`${styles.root} ${styles.tabContent}`}>
+      {rows.length === 0 ? (
+        <span className={styles.topicEmpty}>No topics found</span>
+      ) : (
+        <>
+          {showSearch ? (
+            <Input
+              aria-label="Search topics"
+              className={styles.topicSearchInput}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Search topics"
+              size={Size.Sm}
+              type={InputType.Search}
+              value={search}
+            />
+          ) : null}
+          <div className={styles.topicGroups}>
+            {groups.map((group) => (
+              <McapSidebarGroup
+                key={group.category}
+                summary={topicCountLabel(group.rows.length)}
+                title={MCAP_TOPIC_CATEGORY_LABEL[group.category]}
+              >
+                <div className={styles.topicList}>
+                  {group.rows.map((row) => (
+                    <TopicRow
+                      actionHandlers={actionHandlers}
+                      key={row.topic}
+                      onTopicActionStart={onTopicActionStart}
+                      row={row}
+                    />
+                  ))}
+                </div>
+              </McapSidebarGroup>
+            ))}
+            {filteredRows.length === 0 ? (
+              <span className={styles.topicEmpty}>
+                No topics match &quot;{search}&quot;
+              </span>
+            ) : null}
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+function TopicRow({
+  actionHandlers,
+  onTopicActionStart,
+  row,
+}: {
+  readonly actionHandlers: TopicActionHandlers;
+  readonly onTopicActionStart?: () => void;
+  readonly row: McapTopicInventoryRow;
+}) {
+  const actions = topicActionsForRow(row, actionHandlers);
+  const statusLabel = visibleTopicStatusLabel(row);
+  const capabilitySummary = row.capabilities
+    .map((capability) => MCAP_TOPIC_CAPABILITY_LABEL[capability])
+    .join(" · ");
+
+  return (
+    <div className={styles.topicRow} title={topicDetails(row)}>
+      <div className={styles.topicRowHeader}>
+        <span className={styles.topicName}>{row.topic}</span>
+        {statusLabel ? (
+          <span className={styles.topicStatus}>{statusLabel}</span>
+        ) : null}
+      </div>
+      <div className={styles.topicMetaLine}>
+        <span className={styles.topicMeta}>
+          {row.countLabel}
+          {capabilitySummary ? ` · ${capabilitySummary}` : ""}
+        </span>
+        <div className={styles.topicActions}>
+          {actions.map((action) => (
+            <button
+              aria-label={action.ariaLabel}
+              className={styles.topicActionButton}
+              key={action.id}
+              onClick={() => {
+                onTopicActionStart?.();
+                action.onClick();
+              }}
+              type="button"
+            >
+              {action.label}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface TopicActionHandlers {
+  readonly open3dTile: () => void;
+  readonly openImageTile: (sourceId: string) => void;
+  readonly openLogTile: () => void;
+  readonly openRawMessageTile: (topic: string) => void;
+}
+
+interface TopicAction {
+  readonly ariaLabel: string;
+  readonly id: string;
+  readonly label: string;
+  readonly onClick: () => void;
+}
+
+function topicActionsForRow(
+  row: McapTopicInventoryRow,
+  handlers: TopicActionHandlers,
+): readonly TopicAction[] {
+  const actions: TopicAction[] = [];
+
+  if (row.sourceType === MCAP_SOURCE_TYPE.IMAGE) {
+    actions.push({
+      ariaLabel: `Image ${row.topic}`,
+      id: "image",
+      label: "Image",
+      onClick: () => handlers.openImageTile(row.topic),
+    });
+  }
+
+  if (
+    row.category !== MCAP_TOPIC_CATEGORY.TRANSFORMS_POSES &&
+    row.capabilities.includes(MCAP_TOPIC_CAPABILITY.THREE_D)
+  ) {
+    actions.push({
+      ariaLabel: `3D ${row.topic}`,
+      id: "3d",
+      label: "3D",
+      onClick: handlers.open3dTile,
+    });
+  }
+
+  if (row.capabilities.includes(MCAP_TOPIC_CAPABILITY.LOGS)) {
+    actions.push({
+      ariaLabel: `Logs ${row.topic}`,
+      id: "logs",
+      label: "Logs",
+      onClick: handlers.openLogTile,
+    });
+  }
+
+  actions.push({
+    ariaLabel: `Inspect ${row.topic}`,
+    id: "inspect",
+    label: "Inspect",
+    onClick: () => handlers.openRawMessageTile(row.topic),
+  });
+
+  return actions;
+}
+
+function visibleTopicStatusLabel(row: McapTopicInventoryRow): string | null {
+  if (
+    row.supportStatus === "renderable" ||
+    row.supportStatus === "inspectable"
+  ) {
+    return null;
+  }
+  return MCAP_TOPIC_SUPPORT_LABEL[row.supportStatus];
+}
+
+function useOpenMcapPanelTile(type: McapTileType): () => void {
+  const { addTile, setFocusedTileId, tiles } = useTiling();
+
+  return useCallback(() => {
+    const existingTileId = Object.keys(tiles).find(
+      (tileId) => tiles[tileId]?.type === type,
+    );
+    if (existingTileId) {
+      setFocusedTileId(existingTileId);
+      return;
+    }
+
+    const definition = getMcapTileDefinition(type);
+    if (!definition) {
+      return;
+    }
+    const Tile = definition.Tile;
+    addTile(
+      {
+        render: () => <Tile />,
+        title: definition.typeLabel,
+        type,
+      },
+      { idPrefix: type },
+    );
+  }, [addTile, setFocusedTileId, tiles, type]);
+}
+
+function topicDetails(row: McapTopicInventoryRow): string {
+  return [
+    row.schemaName,
+    row.encoding,
+    MCAP_TOPIC_CATEGORY_LABEL[row.category],
+    MCAP_TOPIC_SUPPORT_LABEL[row.supportStatus],
+  ].join(" · ");
+}
+
+function topicCountLabel(count: number): string {
+  return `${count.toLocaleString()} ${count === 1 ? "topic" : "topics"}`;
+}
+
+export default McapTopicsSettings;

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-layout-persistence.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-layout-persistence.test.ts
@@ -93,8 +93,10 @@ describe("mcap-layout-persistence", () => {
       STORAGE_KEY,
       JSON.stringify({
         version: 1,
-        leftSidebarOpen: true,
-        layout: { direction: "diagonal", first: "a", second: "b" },
+        fallback: {
+          leftSidebarOpen: true,
+          layout: { direction: "diagonal", first: "a", second: "b" },
+        },
       }),
     );
     const read = readMcapModalLayout();
@@ -106,7 +108,7 @@ describe("mcap-layout-persistence", () => {
     localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
-        version: 2,
+        version: 1,
         fallback: { expandedTileId: "", leftSidebarOpen: true },
       }),
     );
@@ -123,59 +125,19 @@ describe("mcap-layout-persistence", () => {
       expect(readMcapModalLayout("dataset-b")?.layout).toBe("3d-1");
     });
 
-    it("falls back to the latest write anywhere for a never-seen dataset", () => {
+    it("does not restore another dataset's arrangement for a never-seen dataset", () => {
       writeMcapModalLayout({ layout: "image-1" }, "dataset-a");
       writeMcapModalLayout({ layout: "3d-1" }, "dataset-b");
-      expect(readMcapModalLayout("dataset-never-seen")?.layout).toBe("3d-1");
-      expect(readMcapModalLayout()?.layout).toBe("3d-1");
+      expect(readMcapModalLayout("dataset-never-seen")).toBeNull();
+      expect(readMcapModalLayout()).toBeNull();
     });
 
-    it("resolves each field independently between entry and fallback", () => {
+    it("does not fill missing fields from another dataset", () => {
       writeMcapModalLayout({ leftSidebarOpen: false }, "dataset-a");
       writeMcapModalLayout({ layout: "image-1" }, "dataset-b");
       const read = readMcapModalLayout("dataset-a");
-      // Own entry wins where present…
       expect(read?.leftSidebarOpen).toBe(false);
-      // …and the fallback fills the fields it doesn't have.
-      expect(read?.layout).toBe("image-1");
-    });
-  });
-
-  describe("v1 migration", () => {
-    it("reads a v1 payload as the fallback layer", () => {
-      localStorage.setItem(
-        STORAGE_KEY,
-        JSON.stringify({
-          version: 1,
-          leftSidebarOpen: false,
-          layout: "image-1",
-        }),
-      );
-      const read = readMcapModalLayout("dataset-never-seen");
-      expect(read?.leftSidebarOpen).toBe(false);
-      expect(read?.layout).toBe("image-1");
-    });
-
-    it("migrates v1 fields into the v2 fallback on the first write", () => {
-      localStorage.setItem(
-        STORAGE_KEY,
-        JSON.stringify({
-          version: 1,
-          leftSidebarOpen: false,
-          layout: "image-1",
-        }),
-      );
-      writeMcapModalLayout({ sidebarWidthPx: 400 }, "dataset-a");
-      const raw = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "null");
-      expect(raw.version).toBe(2);
-      expect(raw.fallback).toMatchObject({
-        leftSidebarOpen: false,
-        layout: "image-1",
-        sidebarWidthPx: 400,
-      });
-      expect(readMcapModalLayout("dataset-a")?.sidebarWidthPx).toBe(400);
-      // The pre-migration fields survived for other datasets too.
-      expect(readMcapModalLayout("dataset-b")?.layout).toBe("image-1");
+      expect(read?.layout).toBeUndefined();
     });
   });
 
@@ -188,13 +150,13 @@ describe("mcap-layout-persistence", () => {
     it("drops non-numeric or non-positive widths but keeps valid fields", () => {
       localStorage.setItem(
         STORAGE_KEY,
-        JSON.stringify({ version: 2, fallback: { sidebarWidthPx: "wide" } }),
+        JSON.stringify({ version: 1, fallback: { sidebarWidthPx: "wide" } }),
       );
       expect(readMcapModalLayout()?.sidebarWidthPx).toBeUndefined();
       localStorage.setItem(
         STORAGE_KEY,
         JSON.stringify({
-          version: 2,
+          version: 1,
           fallback: { sidebarWidthPx: -5, leftSidebarOpen: true },
         }),
       );
@@ -226,8 +188,8 @@ describe("mcap-layout-persistence", () => {
       expect(keys).not.toContain("dataset-1");
       expect(keys).toContain("dataset-0");
       expect(keys).toContain("dataset-20");
-      // The evicted dataset resolves from the fallback from now on.
-      expect(readMcapModalLayout("dataset-1")?.layout).toBe("image-20");
+      // The evicted dataset starts from defaults from now on.
+      expect(readMcapModalLayout("dataset-1")).toBeNull();
     });
   });
 
@@ -306,16 +268,12 @@ describe("mcap-layout-persistence", () => {
       });
     });
 
-    it("never leaks plot series through the browser-wide fallback", () => {
+    it("never leaks plot config to another dataset", () => {
       writeMcapModalLayout(
         { layout: "plot-1", plotSeries: { "plot-1": SERIES } },
         "ds-a",
       );
-      // Another dataset inherits the layout via the fallback but not
-      // the dataset-scoped series.
-      const other = readMcapModalLayout("ds-b");
-      expect(other?.layout).toBe("plot-1");
-      expect(other?.plotSeries).toBeUndefined();
+      expect(readMcapModalLayout("ds-b")).toBeNull();
     });
 
     it("sanitizes malformed plot series rows individually", () => {
@@ -355,15 +313,13 @@ describe("mcap-layout-persistence", () => {
       });
     });
 
-    it("never leaks raw topics through the browser-wide fallback", () => {
+    it("never leaks raw topic config to another dataset", () => {
       writeMcapModalLayout(
         { layout: "raw-1", rawTopics: { "raw-1": "/imu" } },
         "ds-a",
       );
 
-      const other = readMcapModalLayout("ds-b");
-      expect(other?.layout).toBe("raw-1");
-      expect(other?.rawTopics).toBeUndefined();
+      expect(readMcapModalLayout("ds-b")).toBeNull();
     });
 
     it("drops rows with non-raw tile ids or invalid topics", () => {
@@ -403,15 +359,13 @@ describe("mcap-layout-persistence", () => {
       });
     });
 
-    it("never leaks tile titles through the browser-wide fallback", () => {
+    it("never leaks tile titles to another dataset", () => {
       writeMcapModalLayout(
         { layout: "image-1", tileTitles: { "image-1": "Front Camera" } },
         "ds-a",
       );
 
-      const other = readMcapModalLayout("ds-b");
-      expect(other?.layout).toBe("image-1");
-      expect(other?.tileTitles).toBeUndefined();
+      expect(readMcapModalLayout("ds-b")).toBeNull();
     });
 
     it("drops rows with invalid tile ids or titles", () => {
@@ -445,19 +399,17 @@ describe("mcap-layout-persistence", () => {
       expect(readMcapModalLayout("ds-a")?.sceneUpAxis).toBe("y");
     });
 
-    it("never leaks scene up-axis through the browser-wide fallback", () => {
+    it("never leaks scene up-axis to another dataset", () => {
       writeMcapModalLayout({ layout: "3d-1", sceneUpAxis: "x" }, "ds-a");
 
-      const other = readMcapModalLayout("ds-b");
-      expect(other?.layout).toBe("3d-1");
-      expect(other?.sceneUpAxis).toBeUndefined();
+      expect(readMcapModalLayout("ds-b")).toBeNull();
     });
 
     it("drops invalid scene up-axis values but keeps valid fields", () => {
       localStorage.setItem(
         STORAGE_KEY,
         JSON.stringify({
-          version: 2,
+          version: 1,
           byDataset: {
             "ds-a": {
               leftSidebarOpen: true,

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-layout-persistence.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-layout-persistence.test.ts
@@ -88,6 +88,44 @@ describe("mcap-layout-persistence", () => {
     expect(readMcapModalLayout()).toBeNull();
   });
 
+  it("migrates pre-versioned fallback layouts", () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        layout: "image-1",
+        leftSidebarOpen: true,
+        rawTopics: { "raw-1": "/imu" },
+        sceneUpAxis: "y",
+        tileTitles: { "image-1": "Front Camera" },
+      }),
+    );
+
+    expect(readMcapModalLayout()).toEqual({
+      layout: "image-1",
+      leftSidebarOpen: true,
+    });
+  });
+
+  it("strips dataset-scoped fields from fallback reads", () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        fallback: {
+          leftSidebarOpen: true,
+          plotSeries: {
+            "plot-1": [{ color: "#3987e5", fieldPath: "x", topic: "/odom" }],
+          },
+          rawTopics: { "raw-1": "/imu" },
+          sceneUpAxis: "z",
+          tileTitles: { "image-1": "Front Camera" },
+        },
+      }),
+    );
+
+    expect(readMcapModalLayout()).toEqual({ leftSidebarOpen: true });
+  });
+
   it("drops structurally invalid layouts but keeps valid fields", () => {
     localStorage.setItem(
       STORAGE_KEY,
@@ -269,11 +307,14 @@ describe("mcap-layout-persistence", () => {
     });
 
     it("never leaks plot config to another dataset", () => {
+      writeMcapModalLayout({ leftSidebarOpen: true }, "ds-b");
       writeMcapModalLayout(
         { layout: "plot-1", plotSeries: { "plot-1": SERIES } },
         "ds-a",
       );
-      expect(readMcapModalLayout("ds-b")).toBeNull();
+
+      expect(readMcapModalLayout("ds-b")).toEqual({ leftSidebarOpen: true });
+      expect(readMcapModalLayout("ds-b")?.plotSeries).toBeUndefined();
     });
 
     it("sanitizes malformed plot series rows individually", () => {
@@ -314,12 +355,14 @@ describe("mcap-layout-persistence", () => {
     });
 
     it("never leaks raw topic config to another dataset", () => {
+      writeMcapModalLayout({ leftSidebarOpen: true }, "ds-b");
       writeMcapModalLayout(
         { layout: "raw-1", rawTopics: { "raw-1": "/imu" } },
         "ds-a",
       );
 
-      expect(readMcapModalLayout("ds-b")).toBeNull();
+      expect(readMcapModalLayout("ds-b")).toEqual({ leftSidebarOpen: true });
+      expect(readMcapModalLayout("ds-b")?.rawTopics).toBeUndefined();
     });
 
     it("drops rows with non-raw tile ids or invalid topics", () => {
@@ -360,12 +403,14 @@ describe("mcap-layout-persistence", () => {
     });
 
     it("never leaks tile titles to another dataset", () => {
+      writeMcapModalLayout({ leftSidebarOpen: true }, "ds-b");
       writeMcapModalLayout(
         { layout: "image-1", tileTitles: { "image-1": "Front Camera" } },
         "ds-a",
       );
 
-      expect(readMcapModalLayout("ds-b")).toBeNull();
+      expect(readMcapModalLayout("ds-b")).toEqual({ leftSidebarOpen: true });
+      expect(readMcapModalLayout("ds-b")?.tileTitles).toBeUndefined();
     });
 
     it("drops rows with invalid tile ids or titles", () => {
@@ -400,9 +445,11 @@ describe("mcap-layout-persistence", () => {
     });
 
     it("never leaks scene up-axis to another dataset", () => {
+      writeMcapModalLayout({ leftSidebarOpen: true }, "ds-b");
       writeMcapModalLayout({ layout: "3d-1", sceneUpAxis: "x" }, "ds-a");
 
-      expect(readMcapModalLayout("ds-b")).toBeNull();
+      expect(readMcapModalLayout("ds-b")).toEqual({ leftSidebarOpen: true });
+      expect(readMcapModalLayout("ds-b")?.sceneUpAxis).toBeUndefined();
     });
 
     it("drops invalid scene up-axis values but keeps valid fields", () => {

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-layout-persistence.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-layout-persistence.test.ts
@@ -3,6 +3,7 @@ import {
   isValidMosaicLayout,
   mcapTileTypeFromId,
   readMcapModalLayout,
+  sanitizeMapSettings,
   sanitizePlotSeries,
   sanitizeRawTopics,
   sanitizeTileTitles,
@@ -94,6 +95,7 @@ describe("mcap-layout-persistence", () => {
       JSON.stringify({
         layout: "image-1",
         leftSidebarOpen: true,
+        mapSettings: { "map-1": { enabledTopics: ["/gps"], followEgo: true } },
         rawTopics: { "raw-1": "/imu" },
         sceneUpAxis: "y",
         tileTitles: { "image-1": "Front Camera" },
@@ -115,6 +117,9 @@ describe("mcap-layout-persistence", () => {
           leftSidebarOpen: true,
           plotSeries: {
             "plot-1": [{ color: "#3987e5", fieldPath: "x", topic: "/odom" }],
+          },
+          mapSettings: {
+            "map-1": { enabledTopics: ["/gps"], followEgo: false },
           },
           rawTopics: { "raw-1": "/imu" },
           sceneUpAxis: "z",
@@ -388,6 +393,78 @@ describe("mcap-layout-persistence", () => {
       expect(sanitizeRawTopics([])).toBeUndefined();
       expect(sanitizeRawTopics("x")).toBeUndefined();
       expect(sanitizeRawTopics({})).toBeUndefined();
+    });
+  });
+
+  describe("mapSettings", () => {
+    const SETTINGS = {
+      "map-1": {
+        baseLayer: "none" as const,
+        enabledTopics: ["/gps/front", "/gps/rear"],
+        followEgo: false,
+      },
+    };
+
+    it("round-trips per-dataset map tile settings", () => {
+      writeMcapModalLayout({ mapSettings: SETTINGS }, "ds-a");
+      expect(readMcapModalLayout("ds-a")?.mapSettings).toEqual(SETTINGS);
+    });
+
+    it("never leaks map settings to another dataset", () => {
+      writeMcapModalLayout({ leftSidebarOpen: true }, "ds-b");
+      writeMcapModalLayout({ layout: "map-1", mapSettings: SETTINGS }, "ds-a");
+
+      expect(readMcapModalLayout("ds-b")).toEqual({ leftSidebarOpen: true });
+      expect(readMcapModalLayout("ds-b")?.mapSettings).toBeUndefined();
+    });
+
+    it("sanitizes malformed map settings rows individually", () => {
+      writeMcapModalLayout(
+        {
+          mapSettings: {
+            "map-1": {
+              baseLayer: "none",
+              enabledTopics: ["/gps", "", "/gps", 5],
+              followEgo: false,
+              styleUrl: "https://tiles.example.test/style.json",
+            },
+            "image-1": {
+              enabledTopics: ["/camera"],
+              followEgo: true,
+            },
+            "map-2": {
+              baseLayer: "surprise",
+              enabledTopics: [],
+              followEgo: "yes",
+            },
+            "no-suffix": {
+              enabledTopics: ["/gps"],
+              followEgo: true,
+            },
+          } as never,
+        },
+        "ds-a",
+      );
+
+      expect(readMcapModalLayout("ds-a")?.mapSettings).toEqual({
+        "map-1": {
+          baseLayer: "none",
+          enabledTopics: ["/gps"],
+          followEgo: false,
+        },
+        "map-2": {
+          baseLayer: "default",
+          enabledTopics: [],
+          followEgo: true,
+        },
+      });
+    });
+
+    it("sanitizeMapSettings rejects non-object payloads", () => {
+      expect(sanitizeMapSettings(null)).toBeUndefined();
+      expect(sanitizeMapSettings([])).toBeUndefined();
+      expect(sanitizeMapSettings("x")).toBeUndefined();
+      expect(sanitizeMapSettings({})).toBeUndefined();
     });
   });
 

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-layout-persistence.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-layout-persistence.ts
@@ -3,6 +3,11 @@ import {
   normalizeMcap3dSceneUpAxis,
   type Mcap3dSceneUpAxis,
 } from "./mcap-3d-scene-up";
+import {
+  DEFAULT_MCAP_MAP_TILE_SETTINGS,
+  normalizeMcapMapBaseLayer,
+  type McapMapTileSettings,
+} from "./mcap-map-tile-state";
 import { MCAP_TILE_TYPE } from "./mcap-tile-types";
 
 /**
@@ -37,6 +42,11 @@ export interface McapPersistedModalLayout {
    */
   plotSeries?: Record<string, readonly McapPersistedPlotSeries[]>;
   /**
+   * Map tile topic visibility and follow/basemap preferences. Dataset-scoped:
+   * topic names belong to one recording family.
+   */
+  mapSettings?: Record<string, McapPersistedMapSettings>;
+  /**
    * Inspected topic per raw-message tile id. Topics belong to one
    * dataset's recordings, so this field is dataset-scoped only — like
    * `plotSeries`, never merged into the browser-wide fallback.
@@ -67,12 +77,17 @@ export interface McapPersistedPlotSeries {
   readonly topic: string;
 }
 
+export type McapPersistedMapSettings = McapMapTileSettings;
+
 // Bound the persisted plot config so a corrupt or adversarial payload
 // cannot balloon the localStorage entry parsed on every modal mount.
 const MAX_PLOT_TILES = 32;
 const MAX_PLOT_SERIES_PER_TILE = 64;
 const MAX_RAW_TILES = 32;
 const MAX_RAW_TOPIC_LENGTH = 512;
+const MAX_MAP_TILES = 16;
+const MAX_MAP_TOPICS_PER_TILE = 64;
+const MAX_MAP_TOPIC_LENGTH = 512;
 const MAX_TILE_TITLES = 64;
 const MAX_TILE_TITLE_LENGTH = 160;
 const HEX_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
@@ -92,6 +107,7 @@ interface PersistedStore {
 const STORAGE_KEY = "fiftyone.mcap.modal-layout";
 const STORAGE_VERSION = 1;
 const FALLBACK_OMITTED_FIELDS = [
+  "mapSettings",
   "plotSeries",
   "rawTopics",
   "sceneUpAxis",
@@ -134,6 +150,7 @@ function sanitizeEntry(raw: unknown): McapPersistedModalLayout | undefined {
     layout: isValidMosaicLayout(candidate.layout)
       ? candidate.layout
       : undefined,
+    mapSettings: sanitizeMapSettings(candidate.mapSettings),
     plotSeries: sanitizePlotSeries(candidate.plotSeries),
     rawTopics: sanitizeRawTopics(candidate.rawTopics),
     sceneUpAxis: normalizeMcap3dSceneUpAxis(candidate.sceneUpAxis),
@@ -232,6 +249,74 @@ export function sanitizeRawTopics(
   }
 
   return Object.keys(result).length > 0 ? result : undefined;
+}
+
+/**
+ * Structural validation of per-map tile settings. Topic arrays are allowed
+ * to be empty (the user may hide every GPS topic), topic strings are bounded,
+ * and only map tile ids are restored.
+ */
+export function sanitizeMapSettings(
+  raw: unknown,
+): Record<string, McapPersistedMapSettings> | undefined {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    return undefined;
+  }
+
+  const result: Record<string, McapPersistedMapSettings> = {};
+  let tileCount = 0;
+  for (const [tileId, settings] of Object.entries(raw)) {
+    if (
+      tileCount >= MAX_MAP_TILES ||
+      mcapTileTypeFromId(tileId) !== MCAP_TILE_TYPE.MAP ||
+      typeof settings !== "object" ||
+      settings === null ||
+      Array.isArray(settings)
+    ) {
+      continue;
+    }
+
+    const record = settings as Record<string, unknown>;
+    const baseLayer =
+      normalizeMcapMapBaseLayer(record.baseLayer) ??
+      DEFAULT_MCAP_MAP_TILE_SETTINGS.baseLayer;
+    const enabledTopics = sanitizeMapTopicList(record.enabledTopics);
+    const followEgo =
+      typeof record.followEgo === "boolean"
+        ? record.followEgo
+        : DEFAULT_MCAP_MAP_TILE_SETTINGS.followEgo;
+
+    result[tileId] = {
+      baseLayer,
+      followEgo,
+      ...(enabledTopics !== undefined ? { enabledTopics } : {}),
+    };
+    tileCount += 1;
+  }
+
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+function sanitizeMapTopicList(raw: unknown): readonly string[] | undefined {
+  if (!Array.isArray(raw)) {
+    return undefined;
+  }
+  const topics: string[] = [];
+  const seen = new Set<string>();
+  for (const value of raw) {
+    if (topics.length >= MAX_MAP_TOPICS_PER_TILE) break;
+    if (
+      typeof value !== "string" ||
+      value.length === 0 ||
+      value.length > MAX_MAP_TOPIC_LENGTH ||
+      seen.has(value)
+    ) {
+      continue;
+    }
+    seen.add(value);
+    topics.push(value);
+  }
+  return topics;
 }
 
 /**

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-layout-persistence.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-layout-persistence.ts
@@ -9,25 +9,20 @@ import { MCAP_TILE_TYPE } from "./mcap-tile-types";
  * Persistence for the MCAP modal's chrome: sidebar visibility, sidebar
  * width, the mosaic tile arrangement, and the currently expanded tile.
  *
- * One localStorage key holding per-dataset entries plus a browser-wide
- * fallback. Samples in a dataset are typically different recordings with
- * the same topic structure, so the arrangement a user settles on should
- * follow them from sample to sample — and datasets with different topic
- * shapes should each keep their own. Every write also updates the
- * fallback, which tracks the latest arrangement anywhere, so a
- * never-seen dataset opens with the same continuity the old
- * browser-wide key provided. Legacy v1 payloads (one browser-wide
- * entry) are read as that fallback layer, so upgrading loses nothing;
- * the first v2 write migrates them into `fallback` for good.
+ * One localStorage key holding scoped entries plus a browser-wide fallback
+ * for callers that do not provide a scope. Samples in a dataset are
+ * typically different recordings with the same topic structure, so the
+ * sample renderer scopes by dataset; the standalone MCAP explorer scopes by
+ * source. A scoped read intentionally restores only that exact scope, so a
+ * new dataset or new explorer MCAP starts from the built-in defaults.
  *
  * Restore is best-effort: anything unreadable or structurally invalid
  * falls back to the built-in defaults (see `use-mcap-modal-layout`).
  */
 
 /**
- * Per-scope persisted fields. Every field is optional — callers fall
- * back per-field, and a dataset entry falls back to the shared
- * `fallback` entry per-field on read.
+ * Per-scope persisted fields. Every field is optional — callers fall back to
+ * built-in defaults per-field.
  */
 export interface McapPersistedModalLayout {
   /** Tile id rendered expanded over the saved layout, when any. */
@@ -88,16 +83,15 @@ interface PersistedDatasetEntry extends McapPersistedModalLayout {
 }
 
 interface PersistedStore {
-  version: typeof VERSION;
-  /** Latest arrangement written anywhere — the never-seen-dataset layer. */
+  version: typeof STORAGE_VERSION;
+  /** Browser-wide layer used only by unscoped callers. */
   fallback?: McapPersistedModalLayout;
   byDataset?: Record<string, PersistedDatasetEntry>;
 }
 
 const STORAGE_KEY = "fiftyone.mcap.modal-layout";
-const VERSION = 2;
-const LEGACY_VERSION = 1;
-const DATASET_SCOPED_LAYOUT_FIELDS = [
+const STORAGE_VERSION = 1;
+const FALLBACK_OMITTED_FIELDS = [
   "plotSeries",
   "rawTopics",
   "sceneUpAxis",
@@ -108,7 +102,7 @@ const DATASET_SCOPED_LAYOUT_FIELDS = [
 // payload unboundedly — localStorage is quota'd and the whole key is
 // parsed on every modal mount. 20 comfortably covers a user's active
 // datasets; least-recently-updated entries beyond that are evicted and
-// simply fall back to the shared entry on their next open.
+// simply use defaults on their next open.
 const MAX_DATASET_ENTRIES = 20;
 
 /** True when the value is a structurally valid mosaic tree of tile ids. */
@@ -269,11 +263,7 @@ export function sanitizeTileTitles(
   return Object.keys(result).length > 0 ? result : undefined;
 }
 
-/**
- * Parse and sanitize whatever is in storage into the v2 store shape.
- * v1 payloads are read as the fallback layer (their single entry was
- * browser-wide, which is exactly what `fallback` means now).
- */
+/** Parse and sanitize whatever is in storage into the current store shape. */
 function readStore(): {
   fallback?: McapPersistedModalLayout;
   byDataset: Record<string, PersistedDatasetEntry>;
@@ -284,10 +274,7 @@ function readStore(): {
     const parsed: unknown = JSON.parse(raw);
     if (typeof parsed !== "object" || parsed === null) return null;
     const version = (parsed as { version?: unknown }).version;
-    if (version === LEGACY_VERSION) {
-      return { fallback: sanitizeEntry(parsed), byDataset: {} };
-    }
-    if (version !== VERSION) return null;
+    if (version !== STORAGE_VERSION) return null;
     const store = parsed as { fallback?: unknown; byDataset?: unknown };
     const byDataset: Record<string, PersistedDatasetEntry> = {};
     if (typeof store.byDataset === "object" && store.byDataset !== null) {
@@ -320,34 +307,21 @@ function readStore(): {
 
 /**
  * Read the persisted modal layout for `datasetKey`, or `null` when
- * nothing valid is stored. Each field resolves from the dataset's entry
- * first and the browser-wide fallback second; individual fields remain
- * optional — callers fall back per-field.
+ * nothing valid is stored. Scoped reads restore only the exact entry; a
+ * missing entry means the caller should use built-in defaults. Unscoped reads
+ * use the browser-wide fallback.
  */
 export function readMcapModalLayout(
   datasetKey?: string,
 ): McapPersistedModalLayout | null {
   const store = readStore();
   if (!store) return null;
-  const entry = datasetKey ? store.byDataset[datasetKey] : undefined;
-  const fallback = store.fallback;
-  if (!entry && !fallback) return null;
-  return {
-    expandedTileId: entry?.expandedTileId ?? fallback?.expandedTileId,
-    leftSidebarOpen: entry?.leftSidebarOpen ?? fallback?.leftSidebarOpen,
-    layout: entry?.layout ?? fallback?.layout,
-    // Dataset-scoped on purpose: series reference this dataset's topics,
-    // so another dataset's plots must never leak in via the fallback.
-    plotSeries: entry?.plotSeries,
-    // Dataset-scoped for the same reason as plotSeries.
-    rawTopics: entry?.rawTopics,
-    // Dataset-scoped for the same reason as plotSeries/rawTopics.
-    tileTitles: entry?.tileTitles,
-    // Dataset-scoped on purpose: world-up conventions are recording-family
-    // semantics, not reusable browser chrome.
-    sceneUpAxis: entry?.sceneUpAxis,
-    sidebarWidthPx: entry?.sidebarWidthPx ?? fallback?.sidebarWidthPx,
-  };
+  if (datasetKey) {
+    const entry = store.byDataset[datasetKey];
+    return entry ? layoutFromDatasetEntry(entry) : null;
+  }
+
+  return store.fallback ?? null;
 }
 
 /**
@@ -355,10 +329,8 @@ export function readMcapModalLayout(
  * toggles, the width observer, and the layout observer write
  * independently.
  *
- * Writes update both the dataset's entry and the browser-wide fallback:
- * the fallback tracks the latest arrangement anywhere, so a dataset the
- * user has never opened before starts from their most recent
- * arrangement instead of the built-in defaults.
+ * Scoped writes update only the scoped entry. Unscoped writes update the
+ * browser-wide fallback.
  */
 export function writeMcapModalLayout(
   patch: Partial<McapPersistedModalLayout>,
@@ -369,6 +341,7 @@ export function writeMcapModalLayout(
     if (!storage) return;
     const store = readStore();
     const byDataset = { ...store?.byDataset };
+    let fallback = store?.fallback;
     if (datasetKey) {
       byDataset[datasetKey] = {
         ...byDataset[datasetKey],
@@ -376,15 +349,14 @@ export function writeMcapModalLayout(
         updatedAtMs: Date.now(),
       };
       evictLeastRecentlyUpdated(byDataset);
+    } else {
+      fallback = stripDatasetScopedLayoutFields({
+        ...fallback,
+        ...patch,
+      });
     }
-    // The fallback layer tracks the latest arrangement anywhere, but
-    // dataset-scoped semantics must not leak between unrelated topic sets.
-    const fallback = stripDatasetScopedLayoutFields({
-      ...store?.fallback,
-      ...patch,
-    });
     const next: PersistedStore = {
-      version: VERSION,
+      version: STORAGE_VERSION,
       fallback,
       byDataset,
     };
@@ -395,11 +367,26 @@ export function writeMcapModalLayout(
   }
 }
 
+function layoutFromDatasetEntry(
+  entry: PersistedDatasetEntry,
+): McapPersistedModalLayout {
+  return {
+    expandedTileId: entry.expandedTileId,
+    leftSidebarOpen: entry.leftSidebarOpen,
+    layout: entry.layout,
+    plotSeries: entry.plotSeries,
+    rawTopics: entry.rawTopics,
+    sceneUpAxis: entry.sceneUpAxis,
+    sidebarWidthPx: entry.sidebarWidthPx,
+    tileTitles: entry.tileTitles,
+  };
+}
+
 function stripDatasetScopedLayoutFields(
   layout: Partial<McapPersistedModalLayout>,
 ): McapPersistedModalLayout {
   const fallback = { ...layout };
-  for (const field of DATASET_SCOPED_LAYOUT_FIELDS) {
+  for (const field of FALLBACK_OMITTED_FIELDS) {
     delete fallback[field];
   }
   return fallback;

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-layout-persistence.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-layout-persistence.ts
@@ -274,7 +274,15 @@ function readStore(): {
     const parsed: unknown = JSON.parse(raw);
     if (typeof parsed !== "object" || parsed === null) return null;
     const version = (parsed as { version?: unknown }).version;
-    if (version !== STORAGE_VERSION) return null;
+    if (version !== STORAGE_VERSION) {
+      if (version === undefined) {
+        const legacyFallback = sanitizedFallbackLayout(parsed);
+        return legacyFallback
+          ? { fallback: legacyFallback, byDataset: {} }
+          : null;
+      }
+      return null;
+    }
     const store = parsed as { fallback?: unknown; byDataset?: unknown };
     const byDataset: Record<string, PersistedDatasetEntry> = {};
     if (typeof store.byDataset === "object" && store.byDataset !== null) {
@@ -291,11 +299,12 @@ function readStore(): {
         };
       }
     }
+    const fallback =
+      store.fallback === undefined
+        ? undefined
+        : sanitizedFallbackLayout(store.fallback);
     return {
-      fallback:
-        store.fallback === undefined
-          ? undefined
-          : sanitizeEntry(store.fallback),
+      fallback,
       byDataset,
     };
   } catch {
@@ -370,16 +379,8 @@ export function writeMcapModalLayout(
 function layoutFromDatasetEntry(
   entry: PersistedDatasetEntry,
 ): McapPersistedModalLayout {
-  return {
-    expandedTileId: entry.expandedTileId,
-    leftSidebarOpen: entry.leftSidebarOpen,
-    layout: entry.layout,
-    plotSeries: entry.plotSeries,
-    rawTopics: entry.rawTopics,
-    sceneUpAxis: entry.sceneUpAxis,
-    sidebarWidthPx: entry.sidebarWidthPx,
-    tileTitles: entry.tileTitles,
-  };
+  const { updatedAtMs: _updatedAtMs, ...layout } = entry;
+  return layout;
 }
 
 function stripDatasetScopedLayoutFields(
@@ -390,6 +391,19 @@ function stripDatasetScopedLayoutFields(
     delete fallback[field];
   }
   return fallback;
+}
+
+function sanitizedFallbackLayout(
+  raw: unknown,
+): McapPersistedModalLayout | undefined {
+  const entry = sanitizeEntry(raw);
+  if (!entry) {
+    return undefined;
+  }
+  const fallback = stripDatasetScopedLayoutFields(entry);
+  return Object.values(fallback).some((value) => value !== undefined)
+    ? fallback
+    : undefined;
 }
 
 /** Drop the least-recently-updated entries beyond the table cap. */

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-location-track.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-location-track.test.ts
@@ -66,6 +66,27 @@ describe("decimateLocationTrackSegments", () => {
     expect(result.segments[0].points[0]).toBe(segments[0].points[0]);
     expect(result.segments[0].points[10]).toBe(segments[0].points[100]);
   });
+
+  it("keeps the returned segments under the requested render cap", () => {
+    const segments = Array.from({ length: 20 }, (_, segmentIndex) => ({
+      points: [point(segmentIndex * 2), point(segmentIndex * 2 + 1)],
+    }));
+
+    const result = decimateLocationTrackSegments(segments, 10);
+
+    expect(result.truncated).toBe(true);
+    expect(result.pointCount).toBe(40);
+    expect(
+      result.segments.reduce(
+        (count, segment) => count + segment.points.length,
+        0,
+      ),
+    ).toBeLessThanOrEqual(10);
+    expect(result.segments[0].points[0]).toBe(segments[0].points[0]);
+    expect(result.segments[result.segments.length - 1].points.at(-1)).toBe(
+      segments[segments.length - 1].points[1],
+    );
+  });
 });
 
 describe("interpolateLocationAtTime", () => {

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-location-track.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-location-track.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vitest";
+import {
+  decimateLocationTrackSegments,
+  horizontalAccuracyM,
+  interpolateLocationAtTime,
+  isValidLocationPoint,
+  locationTrailCoordinates,
+  segmentLocationTrack,
+  type McapLocationTrackPoint,
+} from "./mcap-location-track";
+import { bearingDegrees } from "./wgs84";
+
+function point(
+  index: number,
+  overrides: Partial<McapLocationTrackPoint> = {},
+): McapLocationTrackPoint {
+  return {
+    latitude: 37 + index * 0.001,
+    longitude: -122 - index * 0.001,
+    timeNs: BigInt(index) * 1_000_000_000n,
+    ...overrides,
+  };
+}
+
+describe("isValidLocationPoint", () => {
+  it("rejects impossible coordinates and explicit no-fix statuses", () => {
+    expect(isValidLocationPoint(point(0))).toBe(true);
+    expect(isValidLocationPoint(point(0, { latitude: 100 }))).toBe(false);
+    expect(isValidLocationPoint(point(0, { longitude: Number.NaN }))).toBe(
+      false,
+    );
+    expect(isValidLocationPoint(point(0, { fixStatus: -1 }))).toBe(false);
+  });
+});
+
+describe("segmentLocationTrack", () => {
+  it("breaks the route at invalid fixes without interpolating over them", () => {
+    const segments = segmentLocationTrack([
+      point(0),
+      point(1),
+      point(2, { fixStatus: -1 }),
+      point(3),
+      point(4),
+    ]);
+
+    expect(
+      segments.map((segment) => segment.points.map((p) => p.timeNs)),
+    ).toEqual([
+      [0n, 1_000_000_000n],
+      [3_000_000_000n, 4_000_000_000n],
+    ]);
+    expect(interpolateLocationAtTime(segments, 2_000_000_000n)).toBeNull();
+  });
+});
+
+describe("decimateLocationTrackSegments", () => {
+  it("uses a global stride and keeps segment endpoints", () => {
+    const segments = segmentLocationTrack(
+      Array.from({ length: 101 }, (_, index) => point(index)),
+    );
+    const result = decimateLocationTrackSegments(segments, 11);
+
+    expect(result.truncated).toBe(true);
+    expect(result.pointCount).toBe(101);
+    expect(result.segments[0].points).toHaveLength(11);
+    expect(result.segments[0].points[0]).toBe(segments[0].points[0]);
+    expect(result.segments[0].points[10]).toBe(segments[0].points[100]);
+  });
+});
+
+describe("interpolateLocationAtTime", () => {
+  it("interpolates coordinates within a valid GPS segment", () => {
+    const segments = segmentLocationTrack([
+      point(0, {
+        accuracyM: 4,
+        altitude: 10,
+        latitude: 37,
+        longitude: -122,
+      }),
+      point(10, {
+        accuracyM: 8,
+        altitude: 20,
+        latitude: 38,
+        longitude: -123,
+      }),
+    ]);
+
+    const location = interpolateLocationAtTime(segments, 5_000_000_000n);
+
+    expect(location?.latitude).toBeCloseTo(37.5);
+    expect(location?.longitude).toBeCloseTo(-122.5);
+    expect(location?.altitude).toBeCloseTo(15);
+    expect(location?.accuracyM).toBeCloseTo(6);
+    expect(location?.bearingDeg).toBeDefined();
+  });
+});
+
+describe("horizontalAccuracyM", () => {
+  it("is twice the worst-axis standard deviation", () => {
+    // Diagonal: worst axis is north (variance 9 → σ 3).
+    expect(horizontalAccuracyM([4, 0, 0, 0, 9, 0, 0, 0, 1])).toBeCloseTo(6);
+    // Correlated: eigenvalue (4+4)/2 + √(0+3²) = 7.
+    expect(horizontalAccuracyM([4, 3, 0, 3, 4, 0, 0, 0, 1])).toBeCloseTo(
+      2 * Math.sqrt(7),
+    );
+  });
+
+  it("treats degenerate matrices as no estimate", () => {
+    expect(horizontalAccuracyM(undefined)).toBeUndefined();
+    expect(horizontalAccuracyM([1, 2, 3])).toBeUndefined();
+    expect(horizontalAccuracyM([0, 0, 0, 0, 0, 0, 0, 0, 0])).toBeUndefined();
+    expect(horizontalAccuracyM([-1, 0, 0, 0, 4, 0, 0, 0, 1])).toBeUndefined();
+    expect(
+      horizontalAccuracyM([Number.NaN, 0, 0, 0, 4, 0, 0, 0, 1]),
+    ).toBeUndefined();
+  });
+});
+
+describe("locationTrailCoordinates", () => {
+  it("clips the trail to the window and interpolates both endpoints", () => {
+    const segments = segmentLocationTrack(
+      Array.from({ length: 11 }, (_, index) => point(index)),
+    );
+
+    const coords = locationTrailCoordinates(
+      segments,
+      5_250_000_000n,
+      2_500_000_000n,
+    );
+
+    expect(coords).toHaveLength(5);
+    expect(coords[0][1]).toBeCloseTo(37.00275);
+    expect(coords[coords.length - 1][1]).toBeCloseTo(37.00525);
+  });
+
+  it("vanishes in no-fix gaps and freezes past the end of the track", () => {
+    const segments = segmentLocationTrack([
+      point(0),
+      point(1),
+      point(2, { fixStatus: -1 }),
+      point(3),
+      point(4),
+    ]);
+
+    expect(
+      locationTrailCoordinates(segments, 2_000_000_000n, 5_000_000_000n),
+    ).toEqual([]);
+
+    const frozen = locationTrailCoordinates(
+      segments,
+      60_000_000_000n,
+      1_500_000_000n,
+    );
+    expect(frozen.length).toBeGreaterThanOrEqual(2);
+    expect(frozen[frozen.length - 1][1]).toBeCloseTo(37.004);
+  });
+});
+
+describe("bearingDegrees", () => {
+  it("returns geographic bearing clockwise from north", () => {
+    expect(
+      bearingDegrees(
+        { latitude: 0, longitude: 0 },
+        { latitude: 1, longitude: 0 },
+      ),
+    ).toBeCloseTo(0);
+    expect(
+      bearingDegrees(
+        { latitude: 0, longitude: 0 },
+        { latitude: 0, longitude: 1 },
+      ),
+    ).toBeCloseTo(90);
+  });
+});

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-location-track.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-location-track.ts
@@ -160,12 +160,11 @@ export function decimateLocationTrackSegments(
     return { pointCount, segments, truncated: false };
   }
 
-  const stride = Math.max(1, Math.ceil(pointCount / maxPoints));
-  const decimated = segments
-    .map((segment) => ({
-      points: decimateSegmentByStride(segment.points, stride),
-    }))
-    .filter((segment) => segment.points.length > 0);
+  const decimated = decimateSegmentsByGlobalIndex(
+    segments,
+    pointCount,
+    maxPoints,
+  );
 
   return { pointCount, segments: decimated, truncated: true };
 }
@@ -363,15 +362,38 @@ function lastLocationPoint(
   return null;
 }
 
-function decimateSegmentByStride(
-  points: readonly McapLocationTrackPoint[],
-  stride: number,
-): readonly McapLocationTrackPoint[] {
-  if (points.length <= 2 || stride <= 1) return points;
-  const decimated: McapLocationTrackPoint[] = [];
-  for (let index = 0; index < points.length; index += 1) {
-    if (index % stride === 0 || index === points.length - 1) {
-      decimated.push(points[index]);
+function decimateSegmentsByGlobalIndex(
+  segments: readonly McapLocationTrackSegment[],
+  pointCount: number,
+  maxPoints: number,
+): readonly McapLocationTrackSegment[] {
+  if (maxPoints <= 0) {
+    return [];
+  }
+
+  const wantedIndices = new Set<number>();
+  if (maxPoints === 1) {
+    wantedIndices.add(0);
+  } else {
+    for (let sampleIndex = 0; sampleIndex < maxPoints; sampleIndex += 1) {
+      wantedIndices.add(
+        Math.round((sampleIndex * (pointCount - 1)) / (maxPoints - 1)),
+      );
+    }
+  }
+
+  let globalIndex = 0;
+  const decimated: McapLocationTrackSegment[] = [];
+  for (const segment of segments) {
+    const points: McapLocationTrackPoint[] = [];
+    for (const point of segment.points) {
+      if (wantedIndices.has(globalIndex)) {
+        points.push(point);
+      }
+      globalIndex += 1;
+    }
+    if (points.length > 0) {
+      decimated.push({ points });
     }
   }
   return decimated;

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-location-track.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-location-track.ts
@@ -1,0 +1,398 @@
+import type { LocationVisualization } from "../../../decoders";
+import { voxel51PrimaryColor } from "./mcap-map-puck";
+import { bearingDegrees } from "./wgs84";
+
+// Brand orange leads so the (near-universal) single-GPS case reads as
+// "the ego"; the rest are visually distant from it and from each other.
+const SECONDARY_TRACK_COLORS = [
+  "#3b82f6",
+  "#84cc16",
+  "#f472b6",
+  "#a78bfa",
+  "#22c55e",
+] as const;
+
+export function locationTrackColor(index: number): string {
+  const colors = [voxel51PrimaryColor(), ...SECONDARY_TRACK_COLORS];
+  return colors[index % colors.length];
+}
+
+export const MAX_LOCATION_TRACK_RENDER_POINTS = 10_000;
+
+const NO_FIX_STATUS = -1;
+
+export interface McapLocationTrackPoint {
+  /** 95% (2σ) horizontal accuracy in meters, when the fix carried one. */
+  readonly accuracyM?: number;
+  readonly altitude?: number;
+  readonly fixService?: number;
+  readonly fixStatus?: number;
+  readonly latitude: number;
+  readonly longitude: number;
+  readonly timeNs: bigint;
+}
+
+export interface McapLocationTrackSegment {
+  readonly points: readonly McapLocationTrackPoint[];
+}
+
+export interface McapLocationTrackState {
+  readonly color: string;
+  readonly label: string;
+  readonly pointCount: number;
+  readonly segments: readonly McapLocationTrackSegment[];
+  readonly status: "loading" | "ready" | "error";
+  readonly topic: string;
+  readonly truncated?: boolean;
+}
+
+export type McapLocationTracks = ReadonlyMap<string, McapLocationTrackState>;
+
+export interface InterpolatedLocation {
+  readonly accuracyM?: number;
+  readonly altitude?: number;
+  readonly bearingDeg?: number;
+  readonly latitude: number;
+  readonly longitude: number;
+  readonly timeNs: bigint;
+}
+
+export interface LocationBounds {
+  readonly east: number;
+  readonly north: number;
+  readonly south: number;
+  readonly west: number;
+}
+
+export function locationPointFromVisualization(
+  visualization: LocationVisualization,
+  timelineTimeNs: bigint,
+): McapLocationTrackPoint {
+  return {
+    accuracyM: horizontalAccuracyM(visualization.positionCovariance),
+    altitude: finiteOrUndefined(visualization.altitude),
+    fixService: finiteOrUndefined(visualization.fixService),
+    fixStatus: finiteOrUndefined(visualization.fixStatus),
+    latitude: visualization.latitude,
+    longitude: visualization.longitude,
+    timeNs: timelineTimeNs,
+  };
+}
+
+/**
+ * 95% (2σ) horizontal accuracy in meters from a row-major 3×3 ENU
+ * position covariance: twice the square root of the worst-axis eigenvalue
+ * of the East/North block, so a tilted error ellipse is never
+ * understated. Degenerate matrices (all-zero, negative, non-finite) yield
+ * `undefined` — receivers that report no real estimate report zeros, and
+ * drawing "perfect accuracy" from junk would be a lie.
+ */
+export function horizontalAccuracyM(
+  covariance: readonly number[] | undefined,
+): number | undefined {
+  if (!covariance || covariance.length !== 9) {
+    return undefined;
+  }
+  const varEast = covariance[0];
+  const varNorth = covariance[4];
+  const covEastNorth = covariance[1];
+  if (
+    !Number.isFinite(varEast) ||
+    !Number.isFinite(varNorth) ||
+    !Number.isFinite(covEastNorth) ||
+    varEast < 0 ||
+    varNorth < 0
+  ) {
+    return undefined;
+  }
+  const mean = (varEast + varNorth) / 2;
+  const spread = Math.sqrt(((varEast - varNorth) / 2) ** 2 + covEastNorth ** 2);
+  const maxVariance = mean + spread;
+  return maxVariance > 0 ? 2 * Math.sqrt(maxVariance) : undefined;
+}
+
+export function isValidLocationPoint(point: McapLocationTrackPoint): boolean {
+  return (
+    Number.isFinite(point.latitude) &&
+    Number.isFinite(point.longitude) &&
+    point.latitude >= -90 &&
+    point.latitude <= 90 &&
+    point.longitude >= -180 &&
+    point.longitude <= 180 &&
+    point.fixStatus !== NO_FIX_STATUS
+  );
+}
+
+export function segmentLocationTrack(
+  points: readonly McapLocationTrackPoint[],
+): readonly McapLocationTrackSegment[] {
+  const segments: McapLocationTrackSegment[] = [];
+  let current: McapLocationTrackPoint[] = [];
+
+  for (const point of points) {
+    if (!isValidLocationPoint(point)) {
+      if (current.length > 0) {
+        segments.push({ points: current });
+        current = [];
+      }
+      continue;
+    }
+    current.push(point);
+  }
+
+  if (current.length > 0) {
+    segments.push({ points: current });
+  }
+
+  return segments;
+}
+
+export function decimateLocationTrackSegments(
+  segments: readonly McapLocationTrackSegment[],
+  maxPoints = MAX_LOCATION_TRACK_RENDER_POINTS,
+): {
+  readonly pointCount: number;
+  readonly segments: readonly McapLocationTrackSegment[];
+  readonly truncated: boolean;
+} {
+  const pointCount = countLocationTrackPoints(segments);
+  if (pointCount <= maxPoints) {
+    return { pointCount, segments, truncated: false };
+  }
+
+  const stride = Math.max(1, Math.ceil(pointCount / maxPoints));
+  const decimated = segments
+    .map((segment) => ({
+      points: decimateSegmentByStride(segment.points, stride),
+    }))
+    .filter((segment) => segment.points.length > 0);
+
+  return { pointCount, segments: decimated, truncated: true };
+}
+
+export function countLocationTrackPoints(
+  segments: readonly McapLocationTrackSegment[],
+): number {
+  return segments.reduce((count, segment) => count + segment.points.length, 0);
+}
+
+export function interpolateLocationAtTime(
+  segments: readonly McapLocationTrackSegment[],
+  timeNs: bigint,
+): InterpolatedLocation | null {
+  const first = firstLocationPoint(segments);
+  const last = lastLocationPoint(segments);
+  if (!first || !last) return null;
+  if (timeNs <= first.timeNs) return locationFromPoint(first);
+  if (timeNs >= last.timeNs) return locationFromPoint(last);
+
+  for (const segment of segments) {
+    const points = segment.points;
+    if (points.length === 0) continue;
+    const segmentStart = points[0];
+    const segmentEnd = points[points.length - 1];
+    if (timeNs < segmentStart.timeNs || timeNs > segmentEnd.timeNs) {
+      continue;
+    }
+
+    for (let index = 0; index < points.length - 1; index += 1) {
+      const left = points[index];
+      const right = points[index + 1];
+      if (timeNs < left.timeNs || timeNs > right.timeNs) {
+        continue;
+      }
+      return interpolateBetweenPoints(left, right, timeNs);
+    }
+
+    return locationFromPoint(segmentEnd);
+  }
+
+  // A timestamp between valid segments is a no-fix gap; do not draw a
+  // marker there because that would visually bridge invalid GPS.
+  return null;
+}
+
+/**
+ * Coordinates of the "comet trail": the route inside
+ * `[timeNs - windowNs, timeNs]`, clipped to the segment containing the
+ * playhead so the trail never bridges a no-fix gap. Endpoints are
+ * time-interpolated so the trail head sits exactly under the marker.
+ */
+export function locationTrailCoordinates(
+  segments: readonly McapLocationTrackSegment[],
+  timeNs: bigint,
+  windowNs: bigint,
+): readonly [number, number][] {
+  const first = firstLocationPoint(segments);
+  const last = lastLocationPoint(segments);
+  if (!first || !last || timeNs < first.timeNs) {
+    return [];
+  }
+  // Past the end of the track the marker holds at the final fix, so the
+  // trail freezes behind it rather than vanishing.
+  const headNs = timeNs > last.timeNs ? last.timeNs : timeNs;
+
+  for (const segment of segments) {
+    const points = segment.points;
+    if (points.length === 0) continue;
+    const startNs = points[0].timeNs;
+    const endNs = points[points.length - 1].timeNs;
+    if (headNs < startNs || headNs > endNs) {
+      continue;
+    }
+
+    const tailNs = headNs - windowNs > startNs ? headNs - windowNs : startNs;
+    const coordinates: [number, number][] = [];
+    const tail = interpolateLocationAtTime([segment], tailNs);
+    if (tail) {
+      coordinates.push([tail.longitude, tail.latitude]);
+    }
+    for (const point of points) {
+      if (point.timeNs > tailNs && point.timeNs < headNs) {
+        coordinates.push([point.longitude, point.latitude]);
+      }
+    }
+    const head = interpolateLocationAtTime([segment], headNs);
+    if (head) {
+      coordinates.push([head.longitude, head.latitude]);
+    }
+    return coordinates.length >= 2 ? coordinates : [];
+  }
+
+  // The playhead sits in a no-fix gap: no marker, no trail.
+  return [];
+}
+
+export function locationBounds(
+  segments: readonly McapLocationTrackSegment[],
+): LocationBounds | null {
+  let west = Number.POSITIVE_INFINITY;
+  let east = Number.NEGATIVE_INFINITY;
+  let south = Number.POSITIVE_INFINITY;
+  let north = Number.NEGATIVE_INFINITY;
+
+  for (const segment of segments) {
+    for (const point of segment.points) {
+      west = Math.min(west, point.longitude);
+      east = Math.max(east, point.longitude);
+      south = Math.min(south, point.latitude);
+      north = Math.max(north, point.latitude);
+    }
+  }
+
+  if (
+    west === Number.POSITIVE_INFINITY ||
+    east === Number.NEGATIVE_INFINITY ||
+    south === Number.POSITIVE_INFINITY ||
+    north === Number.NEGATIVE_INFINITY
+  ) {
+    return null;
+  }
+
+  return { east, north, south, west };
+}
+
+export function combineLocationBounds(
+  bounds: readonly (LocationBounds | null)[],
+): LocationBounds | null {
+  let combined: LocationBounds | null = null;
+  for (const bound of bounds) {
+    if (!bound) continue;
+    combined = combined
+      ? {
+          east: Math.max(combined.east, bound.east),
+          north: Math.max(combined.north, bound.north),
+          south: Math.min(combined.south, bound.south),
+          west: Math.min(combined.west, bound.west),
+        }
+      : bound;
+  }
+  return combined;
+}
+
+function interpolateBetweenPoints(
+  left: McapLocationTrackPoint,
+  right: McapLocationTrackPoint,
+  timeNs: bigint,
+): InterpolatedLocation {
+  const span = Number(right.timeNs - left.timeNs);
+  if (span <= 0) {
+    return locationFromPoint(right, bearingDegrees(left, right));
+  }
+  const fraction = Number(timeNs - left.timeNs) / span;
+  return {
+    accuracyM: interpolateOptional(left.accuracyM, right.accuracyM, fraction),
+    altitude: interpolateOptional(left.altitude, right.altitude, fraction),
+    bearingDeg: bearingDegrees(left, right),
+    latitude: interpolateNumber(left.latitude, right.latitude, fraction),
+    longitude: interpolateNumber(left.longitude, right.longitude, fraction),
+    timeNs,
+  };
+}
+
+function locationFromPoint(
+  point: McapLocationTrackPoint,
+  bearingDeg?: number,
+): InterpolatedLocation {
+  return {
+    accuracyM: point.accuracyM,
+    altitude: point.altitude,
+    bearingDeg,
+    latitude: point.latitude,
+    longitude: point.longitude,
+    timeNs: point.timeNs,
+  };
+}
+
+function firstLocationPoint(
+  segments: readonly McapLocationTrackSegment[],
+): McapLocationTrackPoint | null {
+  for (const segment of segments) {
+    if (segment.points.length > 0) return segment.points[0];
+  }
+  return null;
+}
+
+function lastLocationPoint(
+  segments: readonly McapLocationTrackSegment[],
+): McapLocationTrackPoint | null {
+  for (let index = segments.length - 1; index >= 0; index -= 1) {
+    const points = segments[index].points;
+    if (points.length > 0) return points[points.length - 1];
+  }
+  return null;
+}
+
+function decimateSegmentByStride(
+  points: readonly McapLocationTrackPoint[],
+  stride: number,
+): readonly McapLocationTrackPoint[] {
+  if (points.length <= 2 || stride <= 1) return points;
+  const decimated: McapLocationTrackPoint[] = [];
+  for (let index = 0; index < points.length; index += 1) {
+    if (index % stride === 0 || index === points.length - 1) {
+      decimated.push(points[index]);
+    }
+  }
+  return decimated;
+}
+
+function finiteOrUndefined(value: number | undefined): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function interpolateNumber(left: number, right: number, fraction: number) {
+  return left + (right - left) * fraction;
+}
+
+function interpolateOptional(
+  left: number | undefined,
+  right: number | undefined,
+  fraction: number,
+): number | undefined {
+  return left === undefined || right === undefined
+    ? undefined
+    : interpolateNumber(left, right, fraction);
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-location-tracks-context.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-location-tracks-context.test.tsx
@@ -1,0 +1,166 @@
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ByteSourceDescriptor } from "../../../query/bytes";
+import type { SceneSource } from "../../../scene-inventory";
+import { VISUALIZATION_KIND } from "../../../visualization";
+import type { McapDecodedMessage, McapResourceClient } from "../types";
+import {
+  McapLocationTracksBridge,
+  McapLocationTracksProvider,
+  useMcapLocationTracksContext,
+} from "./mcap-location-tracks-context";
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("McapLocationTracksBridge", () => {
+  it("delays full-track reads, uses the bulk lane, and publishes no-fix gaps", async () => {
+    vi.useFakeTimers();
+    const source = createSource("drive");
+    const locationSources = [locationSource("/gps")];
+    const client = createClient(async function* () {
+      yield locationMessage(1_000_000_000n, 37, -122, 0);
+      yield locationMessage(2_000_000_000n, 37.001, -122.001, -1);
+      yield locationMessage(3_000_000_000n, 37.002, -122.002, 0);
+    });
+
+    render(
+      <Harness
+        client={client}
+        locationSources={locationSources}
+        source={source}
+      />,
+    );
+
+    await advanceTimers(1_499);
+    expect(client.readDecodedMessages).not.toHaveBeenCalled();
+
+    await advanceTimers(1);
+    expect(client.readDecodedMessages).toHaveBeenCalledWith(
+      {
+        activeTimeline: "log",
+        limit: 25_000,
+        source,
+        topics: ["/gps"],
+      },
+      { priority: "bulk" },
+    );
+    expect(screen.getByTestId("location-tracks").textContent).toBe(
+      "/gps:ready:2:2",
+    );
+  });
+});
+
+function Harness({
+  client,
+  locationSources,
+  source,
+}: {
+  readonly client: McapResourceClient;
+  readonly locationSources: readonly SceneSource[];
+  readonly source: ByteSourceDescriptor;
+}) {
+  return (
+    <McapLocationTracksProvider>
+      <McapLocationTracksBridge
+        client={client}
+        locationSources={locationSources}
+        source={source}
+      />
+      <LocationTracksProbe />
+    </McapLocationTracksProvider>
+  );
+}
+
+function LocationTracksProbe() {
+  const tracks = useMcapLocationTracksContext();
+  return (
+    <div data-testid="location-tracks">
+      {[...tracks.entries()]
+        .map(
+          ([topic, state]) =>
+            `${topic}:${state.status}:${state.pointCount}:${state.segments.length}`,
+        )
+        .join("|")}
+    </div>
+  );
+}
+
+function createClient(
+  messages: () => AsyncGenerator<
+    McapDecodedMessage,
+    void,
+    void
+  > = emptyMessages,
+): McapResourceClient {
+  return {
+    dispose: vi.fn(),
+    enumerateNumericFields: vi.fn(async () => []),
+    readDecodedMessages: vi.fn(messages),
+    readFrameTransformBootstrap: vi.fn(async () => ({ samples: [] })),
+    readFrameTransformWindow: vi.fn(async () => ({ samples: [] })),
+    readNumericSeries: vi.fn(async () => ({
+      baseTimeNs: 0n,
+      fields: [],
+      messageCount: 0,
+      topic: "",
+      truncated: false,
+    })),
+    readRawMessageRecord: vi.fn(),
+    readSynchronizedMessageBatch: vi.fn(async () => []),
+    readSynchronizedMessages: vi.fn(),
+    readTimelineRange: vi.fn(),
+    readTopicTimeBounds: vi.fn(async () => []),
+    readTopics: vi.fn(async () => []),
+  };
+}
+
+async function* emptyMessages(): AsyncGenerator<
+  McapDecodedMessage,
+  void,
+  void
+> {
+  for (const message of [] as McapDecodedMessage[]) {
+    yield message;
+  }
+}
+
+function locationMessage(
+  timelineTimeNs: bigint,
+  latitude: number,
+  longitude: number,
+  fixStatus: number,
+): McapDecodedMessage {
+  return {
+    decoded: {
+      output: {
+        visualization: {
+          fixStatus,
+          kind: VISUALIZATION_KIND.LOCATION,
+          latitude,
+          longitude,
+        },
+      },
+    },
+    timelineTimeNs,
+  } as unknown as McapDecodedMessage;
+}
+
+function locationSource(id: string): SceneSource {
+  return { id, label: id.replace(/^\//, ""), type: "location" };
+}
+
+function createSource(sourceId: string): ByteSourceDescriptor {
+  return {
+    sourceId,
+    url: `memory://${sourceId}.mcap`,
+  };
+}
+
+async function advanceTimers(ms: number) {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-location-tracks-context.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-location-tracks-context.test.tsx
@@ -1,4 +1,7 @@
+import { isPlayingAtom } from "@fiftyone/playback/src/lib/playback/atoms";
+import { PlaybackStoreContext } from "@fiftyone/playback/src/lib/playback/playback-store-context";
 import { act, cleanup, render, screen } from "@testing-library/react";
+import { createStore } from "jotai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ByteSourceDescriptor } from "../../../query/bytes";
 import type { SceneSource } from "../../../scene-inventory";
@@ -9,6 +12,7 @@ import {
   McapLocationTracksProvider,
   useMcapLocationTracksContext,
 } from "./mcap-location-tracks-context";
+import { setMcapNetworkHealth } from "./mcap-network-health";
 
 afterEach(() => {
   cleanup();
@@ -48,7 +52,95 @@ describe("McapLocationTracksBridge", () => {
       { priority: "bulk" },
     );
     expect(screen.getByTestId("location-tracks").textContent).toBe(
-      "/gps:ready:2:2",
+      "/gps:ready:2:2:full",
+    );
+  });
+
+  it("marks topics as error when the bulk read rejects", async () => {
+    vi.useFakeTimers();
+    const source = createSource("drive");
+    const locationSources = [locationSource("/gps")];
+    const client = createClient(async function* () {
+      throw new Error("boom");
+      yield locationMessage(0n, 0, 0, 0);
+    });
+
+    render(
+      <Harness
+        client={client}
+        locationSources={locationSources}
+        source={source}
+      />,
+    );
+
+    await advanceTimers(1_500);
+
+    expect(screen.getByTestId("location-tracks").textContent).toBe(
+      "/gps:error:0:0:full",
+    );
+  });
+
+  it("retries deferred track reads after playback pressure stands down", async () => {
+    vi.useFakeTimers();
+    const source = createSource("drive");
+    const store = createStore();
+    store.set(isPlayingAtom, true);
+    setMcapNetworkHealth(store, {
+      busyFraction: 1,
+      busyThroughputBytesPerSec: 1,
+      limited: true,
+      throughputBytesPerSec: 1,
+      throughputPlannable: true,
+      updatedAtMs: 0,
+    });
+    const client = createClient(async function* () {
+      yield locationMessage(1_000_000_000n, 37, -122, 0);
+    });
+
+    render(
+      <Harness
+        client={client}
+        locationSources={[locationSource("/gps")]}
+        source={source}
+        store={store}
+      />,
+    );
+
+    await advanceTimers(1_500);
+    expect(client.readDecodedMessages).not.toHaveBeenCalled();
+
+    store.set(isPlayingAtom, false);
+    await advanceTimers(1_999);
+    expect(client.readDecodedMessages).not.toHaveBeenCalled();
+
+    await advanceTimers(1);
+    expect(client.readDecodedMessages).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("location-tracks").textContent).toBe(
+      "/gps:ready:1:1:full",
+    );
+  });
+
+  it("marks the track truncated when the read limit is reached before usable fixes", async () => {
+    vi.useFakeTimers();
+    const source = createSource("drive");
+    const client = createClient(async function* () {
+      for (let index = 0; index < 25_000; index += 1) {
+        yield nonLocationMessage(BigInt(index));
+      }
+    });
+
+    render(
+      <Harness
+        client={client}
+        locationSources={[locationSource("/gps")]}
+        source={source}
+      />,
+    );
+
+    await advanceTimers(1_500);
+
+    expect(screen.getByTestId("location-tracks").textContent).toBe(
+      "/gps:ready:0:0:truncated",
     );
   });
 });
@@ -57,12 +149,14 @@ function Harness({
   client,
   locationSources,
   source,
+  store,
 }: {
   readonly client: McapResourceClient;
   readonly locationSources: readonly SceneSource[];
   readonly source: ByteSourceDescriptor;
+  readonly store?: ReturnType<typeof createStore>;
 }) {
-  return (
+  const body = (
     <McapLocationTracksProvider>
       <McapLocationTracksBridge
         client={client}
@@ -71,6 +165,13 @@ function Harness({
       />
       <LocationTracksProbe />
     </McapLocationTracksProvider>
+  );
+  return store ? (
+    <PlaybackStoreContext.Provider value={store}>
+      {body}
+    </PlaybackStoreContext.Provider>
+  ) : (
+    body
   );
 }
 
@@ -81,7 +182,9 @@ function LocationTracksProbe() {
       {[...tracks.entries()]
         .map(
           ([topic, state]) =>
-            `${topic}:${state.status}:${state.pointCount}:${state.segments.length}`,
+            `${topic}:${state.status}:${state.pointCount}:${state.segments.length}:${
+              state.truncated ? "truncated" : "full"
+            }`,
         )
         .join("|")}
     </div>
@@ -142,6 +245,17 @@ function locationMessage(
           latitude,
           longitude,
         },
+      },
+    },
+    timelineTimeNs,
+  } as unknown as McapDecodedMessage;
+}
+
+function nonLocationMessage(timelineTimeNs: bigint): McapDecodedMessage {
+  return {
+    decoded: {
+      output: {
+        visualization: { kind: VISUALIZATION_KIND.POSE },
       },
     },
     timelineTimeNs,

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-location-tracks-context.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-location-tracks-context.tsx
@@ -159,6 +159,7 @@ export function McapLocationTracksBridge({
 
         void (async () => {
           const points: McapLocationTrackPoint[] = [];
+          let messageCount = 0;
           try {
             for await (const message of client.readDecodedMessages(
               {
@@ -172,6 +173,7 @@ export function McapLocationTracksBridge({
               if (cancelled) {
                 return;
               }
+              messageCount += 1;
               if (shouldStandDown()) {
                 fetchedTopicsRef.current.delete(topic);
                 scheduleRetry(LOCATION_TRACK_DEFERRED_RETRY_MS);
@@ -192,7 +194,9 @@ export function McapLocationTracksBridge({
             const result = decimateLocationTrackSegments(
               segmentLocationTrack(points),
             );
-            if (result.truncated) {
+            const truncated =
+              result.truncated || messageCount >= LOCATION_TRACK_READ_LIMIT;
+            if (truncated) {
               markMcapLatencyEvent("location track downsampled", {
                 points: result.pointCount,
                 topic,
@@ -203,7 +207,7 @@ export function McapLocationTracksBridge({
               pointCount: result.pointCount,
               segments: result.segments,
               status: "ready",
-              ...(result.truncated ? { truncated: true } : {}),
+              ...(truncated ? { truncated: true } : {}),
             });
           } catch {
             commit(topic, { ...baseState, status: "error" });

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-location-tracks-context.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-location-tracks-context.tsx
@@ -1,0 +1,244 @@
+// Deep imports on purpose: the playback package root barrel pulls view
+// components whose relay fragments cannot evaluate under vitest, and this
+// bridge mirrors the pose-trajectory bulk fetch path.
+import { PlaybackStoreContext } from "@fiftyone/playback/src/lib/playback/playback-store-context";
+import { getIsPlaying } from "@fiftyone/playback/src/lib/playback/store-access";
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import type { ByteSourceDescriptor } from "../../../query/bytes";
+import { byteSourceAccessKey } from "../../../query/bytes";
+import type { SceneSource } from "../../../scene-inventory";
+import { VISUALIZATION_KIND } from "../../../visualization";
+import { markMcapLatencyEvent } from "../mcap-latency-debug";
+import { MCAP_ACTIVE_TIMELINE, type McapResourceClient } from "../types";
+import {
+  getMcapNetworkHealth,
+  shouldDeferMcapIdleWorkForStore,
+} from "./mcap-network-health";
+import {
+  decimateLocationTrackSegments,
+  locationPointFromVisualization,
+  locationTrackColor,
+  segmentLocationTrack,
+  type McapLocationTrackPoint,
+  type McapLocationTracks,
+  type McapLocationTrackState,
+} from "./mcap-location-track";
+
+const LOCATION_TRACK_READ_LIMIT = 25_000;
+const LOCATION_TRACK_START_DELAY_MS = 1_500;
+const LOCATION_TRACK_DEFERRED_RETRY_MS = 2_000;
+
+const EMPTY_LOCATION_TRACKS: McapLocationTracks = new Map();
+
+interface McapLocationTracksContextValue {
+  readonly setTracks: (state: McapLocationTracks) => void;
+  readonly tracks: McapLocationTracks;
+}
+
+const McapLocationTracksContext =
+  createContext<McapLocationTracksContextValue | null>(null);
+
+/**
+ * Shares full-file geographic tracks with map tiles. The provider lives
+ * outside playback; the bridge inside playback performs one bulk read per
+ * source file and publishes normalized route segments here.
+ */
+export const McapLocationTracksProvider: React.FC<{
+  children: React.ReactNode;
+}> = ({ children }) => {
+  const [tracks, setTracks] = useState<McapLocationTracks>(
+    EMPTY_LOCATION_TRACKS,
+  );
+  const value = useMemo(() => ({ setTracks, tracks }), [tracks]);
+
+  return (
+    <McapLocationTracksContext.Provider value={value}>
+      {children}
+    </McapLocationTracksContext.Provider>
+  );
+};
+
+export function useMcapLocationTracksContext(): McapLocationTracks {
+  return useContextValue().tracks;
+}
+
+/**
+ * Bridge that fetches every location topic's full track once per source.
+ * The track is tiny compared to camera/point-cloud data, and seeing the
+ * whole route is the map tile's core value, so this intentionally uses the
+ * same capped bulk-lane pattern as pose trajectories.
+ */
+export function McapLocationTracksBridge({
+  client,
+  locationSources,
+  source,
+}: {
+  readonly client: McapResourceClient;
+  readonly locationSources: readonly SceneSource[];
+  readonly source: ByteSourceDescriptor | null;
+}) {
+  const { setTracks } = useContextValue();
+  const sourceKey = source ? byteSourceAccessKey(source) : null;
+  const fetchedTopicsRef = useRef(new Set<string>());
+  const tracksRef = useRef(new Map<string, McapLocationTrackState>());
+  const playbackStore = useContext(PlaybackStoreContext);
+
+  useEffect(() => {
+    fetchedTopicsRef.current = new Set();
+    tracksRef.current = new Map();
+    setTracks(EMPTY_LOCATION_TRACKS);
+
+    if (!sourceKey || !source || locationSources.length === 0) {
+      return undefined;
+    }
+
+    let cancelled = false;
+    let retryTimeout: ReturnType<typeof setTimeout> | null = null;
+    const commit = (topic: string, state: McapLocationTrackState) => {
+      if (cancelled) {
+        return;
+      }
+      tracksRef.current.set(topic, state);
+      setTracks(new Map(tracksRef.current));
+    };
+
+    const shouldStandDown = (): boolean => {
+      if (!playbackStore) {
+        return false;
+      }
+      if (
+        getIsPlaying(playbackStore) &&
+        getMcapNetworkHealth(playbackStore).limited
+      ) {
+        return true;
+      }
+      return shouldDeferMcapIdleWorkForStore(playbackStore, null);
+    };
+
+    const scheduleRetry = (delayMs: number) => {
+      if (cancelled || retryTimeout !== null) {
+        return;
+      }
+      retryTimeout = setTimeout(() => {
+        retryTimeout = null;
+        start();
+      }, delayMs);
+    };
+
+    const start = () => {
+      if (cancelled) {
+        return;
+      }
+      if (shouldStandDown()) {
+        scheduleRetry(LOCATION_TRACK_DEFERRED_RETRY_MS);
+        return;
+      }
+
+      locationSources.forEach((locationSource, index) => {
+        const topic = locationSource.id;
+        if (fetchedTopicsRef.current.has(topic)) {
+          return;
+        }
+        fetchedTopicsRef.current.add(topic);
+        const color = locationTrackColor(index);
+        const baseState = {
+          color,
+          label: locationSource.label,
+          pointCount: 0,
+          segments: [],
+          topic,
+        } satisfies Omit<McapLocationTrackState, "status">;
+        commit(topic, { ...baseState, status: "loading" });
+
+        void (async () => {
+          const points: McapLocationTrackPoint[] = [];
+          try {
+            for await (const message of client.readDecodedMessages(
+              {
+                activeTimeline: MCAP_ACTIVE_TIMELINE.LOG,
+                limit: LOCATION_TRACK_READ_LIMIT,
+                source,
+                topics: [topic],
+              },
+              { priority: "bulk" },
+            )) {
+              if (cancelled) {
+                return;
+              }
+              if (shouldStandDown()) {
+                fetchedTopicsRef.current.delete(topic);
+                scheduleRetry(LOCATION_TRACK_DEFERRED_RETRY_MS);
+                return;
+              }
+              const visualization = message.decoded.output.visualization;
+              if (visualization?.kind !== VISUALIZATION_KIND.LOCATION) {
+                continue;
+              }
+              points.push(
+                locationPointFromVisualization(
+                  visualization,
+                  message.timelineTimeNs,
+                ),
+              );
+            }
+
+            const result = decimateLocationTrackSegments(
+              segmentLocationTrack(points),
+            );
+            if (result.truncated) {
+              markMcapLatencyEvent("location track downsampled", {
+                points: result.pointCount,
+                topic,
+              });
+            }
+            commit(topic, {
+              ...baseState,
+              pointCount: result.pointCount,
+              segments: result.segments,
+              status: "ready",
+              ...(result.truncated ? { truncated: true } : {}),
+            });
+          } catch {
+            commit(topic, { ...baseState, status: "error" });
+          }
+        })();
+      });
+    };
+
+    scheduleRetry(LOCATION_TRACK_START_DELAY_MS);
+
+    return () => {
+      cancelled = true;
+      if (retryTimeout !== null) {
+        clearTimeout(retryTimeout);
+      }
+    };
+  }, [client, locationSources, playbackStore, setTracks, source, sourceKey]);
+
+  useEffect(
+    () => () => {
+      setTracks(EMPTY_LOCATION_TRACKS);
+    },
+    [setTracks],
+  );
+
+  return null;
+}
+
+function useContextValue(): McapLocationTracksContextValue {
+  const value = useContext(McapLocationTracksContext);
+  if (!value) {
+    throw new Error(
+      "MCAP location tracks must be used inside <McapLocationTracksProvider>",
+    );
+  }
+
+  return value;
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-log-console-context.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-log-console-context.tsx
@@ -1,0 +1,35 @@
+import React, { createContext, useContext, useMemo } from "react";
+import type { ByteSourceDescriptor } from "../../../query/bytes";
+import type { McapResourceClient } from "../types";
+
+export interface McapLogConsoleContextValue {
+  readonly client: McapResourceClient;
+  readonly source: ByteSourceDescriptor | null;
+}
+
+const McapLogConsoleContext = createContext<McapLogConsoleContextValue | null>(
+  null,
+);
+
+export const McapLogConsoleProvider: React.FC<{
+  readonly children: React.ReactNode;
+  readonly client: McapResourceClient;
+  readonly source: ByteSourceDescriptor | null;
+}> = ({ children, client, source }) => {
+  const value = useMemo(() => ({ client, source }), [client, source]);
+  return (
+    <McapLogConsoleContext.Provider value={value}>
+      {children}
+    </McapLogConsoleContext.Provider>
+  );
+};
+
+export function useMcapLogConsoleContext(): McapLogConsoleContextValue {
+  const value = useContext(McapLogConsoleContext);
+  if (!value) {
+    throw new Error(
+      "useMcapLogConsoleContext must be used inside <McapLogConsoleProvider>",
+    );
+  }
+  return value;
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-log-console-rows.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-log-console-rows.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import type { McapDecodedMessage } from "../types";
+import { logConsoleRowsFromDecodedMessage } from "./mcap-log-console-rows";
+
+describe("logConsoleRowsFromDecodedMessage", () => {
+  it("expands decoder logRows into console rows with diagnostic grouping", () => {
+    const rows = logConsoleRowsFromDecodedMessage(
+      decodedMessage({
+        attributes: {
+          logRows: [
+            {
+              details: [{ key: "drop_rate", value: "0.2" }],
+              hardwareId: "lidar-top",
+              kind: "diagnostic",
+              level: "error",
+              message: "packet drops",
+              name: "driver",
+              status: "ERROR",
+              timestampNs: 7_000_000_009n,
+            },
+          ],
+        },
+        topic: "/diagnostics",
+      }),
+    );
+
+    expect(rows).toEqual([
+      expect.objectContaining({
+        details: [{ key: "drop_rate", value: "0.2" }],
+        groupLabel: "lidar-top / driver",
+        kind: "diagnostic",
+        level: "error",
+        message: "packet drops",
+        status: "ERROR",
+        timeNs: 7_000_000_009n,
+        topic: "/diagnostics",
+      }),
+    ]);
+  });
+
+  it("falls back to top-level message attributes and timeline time", () => {
+    const rows = logConsoleRowsFromDecodedMessage(
+      decodedMessage({
+        attributes: {
+          level: "warn",
+          message: "tracking degraded",
+          name: "controller",
+        },
+        timelineTimeNs: 5_000_000_004n,
+        topic: "/rosout",
+      }),
+    );
+
+    expect(rows).toEqual([
+      expect.objectContaining({
+        groupLabel: "controller",
+        level: "warn",
+        message: "tracking degraded",
+        timeNs: 5_000_000_004n,
+        topic: "/rosout",
+      }),
+    ]);
+  });
+});
+
+function decodedMessage({
+  attributes,
+  timelineTimeNs = 1n,
+  topic,
+}: {
+  readonly attributes: NonNullable<
+    McapDecodedMessage["decoded"]["output"]["attributes"]
+  >;
+  readonly timelineTimeNs?: bigint;
+  readonly topic: string;
+}): McapDecodedMessage {
+  return {
+    activeTimeline: "log",
+    channelId: 1,
+    decoded: {
+      decoderId: "test",
+      decoderVersion: "1",
+      output: { attributes },
+      payload: {
+        encoding: "json",
+        schema: "test",
+        schemaEncoding: "jsonschema",
+      },
+    },
+    encodedPayloadBytes: 1,
+    logTimeNs: timelineTimeNs,
+    publishTimeNs: timelineTimeNs,
+    sequence: 3,
+    timelineTimeNs,
+    topic,
+  };
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-log-console-rows.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-log-console-rows.test.ts
@@ -61,6 +61,17 @@ describe("logConsoleRowsFromDecodedMessage", () => {
       }),
     ]);
   });
+
+  it("returns no rows when logRows is empty and no fallback message exists", () => {
+    const rows = logConsoleRowsFromDecodedMessage(
+      decodedMessage({
+        attributes: {},
+        topic: "/empty",
+      }),
+    );
+
+    expect(rows).toEqual([]);
+  });
 });
 
 function decodedMessage({

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-log-console-rows.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-log-console-rows.ts
@@ -1,0 +1,158 @@
+import type { DecodedAttributeValue } from "../../../decoders";
+import {
+  MCAP_LOG_ATTRIBUTE_ROWS,
+  MCAP_LOG_LEVEL,
+  MCAP_LOG_LEVELS,
+  type McapLogLevel,
+} from "../log-records";
+import type { McapDecodedMessage } from "../types";
+
+export interface McapLogConsoleRow {
+  readonly details: readonly { readonly key: string; readonly value: string }[];
+  readonly file?: string;
+  readonly functionName?: string;
+  readonly groupLabel?: string;
+  readonly hardwareId?: string;
+  readonly id: string;
+  readonly kind: "diagnostic" | "log";
+  readonly level: McapLogLevel;
+  readonly levelNumber?: number;
+  readonly line?: number;
+  readonly message: string;
+  readonly name?: string;
+  readonly status?: string;
+  readonly timeNs: bigint;
+  readonly topic: string;
+}
+
+const LOG_LEVEL_SET = new Set(MCAP_LOG_LEVELS);
+
+export function logConsoleRowsFromDecodedMessage(
+  message: McapDecodedMessage,
+): readonly McapLogConsoleRow[] {
+  const attributes = message.decoded.output.attributes ?? {};
+  const rows = arrayValue(attributes[MCAP_LOG_ATTRIBUTE_ROWS])
+    .map(recordValue)
+    .filter(isRecord);
+
+  if (rows.length === 0) {
+    const fallbackMessage = stringValue(attributes.message);
+    if (!fallbackMessage) {
+      return [];
+    }
+    return [
+      buildRow({
+        index: 0,
+        message,
+        record: attributes,
+      }),
+    ];
+  }
+
+  return rows.map((record, index) =>
+    buildRow({
+      index,
+      message,
+      record,
+    }),
+  );
+}
+
+function buildRow({
+  index,
+  message,
+  record,
+}: {
+  readonly index: number;
+  readonly message: McapDecodedMessage;
+  readonly record: Record<string, DecodedAttributeValue>;
+}): McapLogConsoleRow {
+  const hardwareId = stringValue(record.hardwareId);
+  const name = stringValue(record.name);
+
+  return {
+    details: arrayValue(record.details)
+      .map(recordValue)
+      .filter(isRecord)
+      .map((detail) => ({
+        key: stringValue(detail.key) ?? "",
+        value: stringValue(detail.value) ?? "",
+      }))
+      .filter((detail) => detail.key || detail.value),
+    file: stringValue(record.file),
+    functionName: stringValue(record.functionName),
+    groupLabel: logGroupLabel(hardwareId, name),
+    hardwareId,
+    id: `${message.topic}:${message.timelineTimeNs.toString()}:${message.sequence}:${index}`,
+    kind: stringValue(record.kind) === "diagnostic" ? "diagnostic" : "log",
+    level: logLevelValue(record.level),
+    levelNumber: numberValue(record.levelNumber),
+    line: numberValue(record.line),
+    message: stringValue(record.message) ?? "",
+    name,
+    status: stringValue(record.status),
+    timeNs: bigintValue(record.timestampNs) ?? message.timelineTimeNs,
+    topic: message.topic,
+  };
+}
+
+function logGroupLabel(
+  hardwareId: string | undefined,
+  name: string | undefined,
+): string | undefined {
+  if (hardwareId && name) return `${hardwareId} / ${name}`;
+  return hardwareId ?? name;
+}
+
+function logLevelValue(value: DecodedAttributeValue | undefined): McapLogLevel {
+  return typeof value === "string" && LOG_LEVEL_SET.has(value as McapLogLevel)
+    ? (value as McapLogLevel)
+    : MCAP_LOG_LEVEL.UNKNOWN;
+}
+
+function arrayValue(
+  value: DecodedAttributeValue | undefined,
+): readonly DecodedAttributeValue[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function recordValue(
+  value: DecodedAttributeValue,
+): Record<string, DecodedAttributeValue> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, DecodedAttributeValue>)
+    : null;
+}
+
+function isRecord(
+  value: Record<string, DecodedAttributeValue> | null,
+): value is Record<string, DecodedAttributeValue> {
+  return value !== null;
+}
+
+function stringValue(value: DecodedAttributeValue | undefined) {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function numberValue(value: DecodedAttributeValue | undefined) {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : typeof value === "bigint"
+      ? Number(value)
+      : undefined;
+}
+
+function bigintValue(value: DecodedAttributeValue | undefined) {
+  if (typeof value === "bigint") return value;
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return BigInt(Math.round(value));
+  }
+  if (typeof value === "string" && value) {
+    try {
+      return BigInt(value);
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-map-measurement.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-map-measurement.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatMapMeasurementDistance,
+  mapMeasurementDistance,
+  nextMapMeasurementState,
+} from "./mcap-map-measurement";
+import { haversineDistanceMeters } from "./wgs84";
+
+describe("mcap map measurement", () => {
+  it("advances a two-click measurement and restarts after completion", () => {
+    const first = nextMapMeasurementState(null, {
+      latitude: 37,
+      longitude: -122,
+    });
+    expect(first).toEqual({
+      a: { latitude: 37, longitude: -122 },
+      b: null,
+    });
+
+    const complete = nextMapMeasurementState(first, {
+      latitude: 38,
+      longitude: -123,
+    });
+    expect(complete).toEqual({
+      a: { latitude: 37, longitude: -122 },
+      b: { latitude: 38, longitude: -123 },
+    });
+
+    const restarted = nextMapMeasurementState(complete, {
+      latitude: 39,
+      longitude: -124,
+    });
+    expect(restarted).toEqual({
+      a: { latitude: 39, longitude: -124 },
+      b: null,
+    });
+  });
+
+  it("measures complete WGS84 pairs with great-circle distance", () => {
+    expect(mapMeasurementDistance(null)).toBeNull();
+    expect(
+      mapMeasurementDistance({ a: { latitude: 0, longitude: 0 }, b: null }),
+    ).toBeNull();
+
+    expect(
+      haversineDistanceMeters(
+        { latitude: 0, longitude: 0 },
+        { latitude: 0, longitude: 1 },
+      ),
+    ).toBeCloseTo(111_195, -1);
+  });
+
+  it("formats map-scale distances", () => {
+    expect(formatMapMeasurementDistance(12.345)).toBe("12.35 m");
+    expect(formatMapMeasurementDistance(123.45)).toBe("123.5 m");
+    expect(formatMapMeasurementDistance(1_234.5)).toBe("1.23 km");
+    expect(formatMapMeasurementDistance(123_456)).toBe("123.5 km");
+  });
+});

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-map-measurement.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-map-measurement.ts
@@ -1,0 +1,48 @@
+/**
+ * Pure state + math for the map tile's two-click WGS84 ruler.
+ */
+
+import { haversineDistanceMeters, type GeoPoint } from "./wgs84";
+
+export type MapMeasurementPoint = GeoPoint;
+
+export interface MapMeasurementState {
+  readonly a: MapMeasurementPoint;
+  /** `null` while waiting for the second pick. */
+  readonly b: MapMeasurementPoint | null;
+}
+
+/**
+ * Advance the two-click state machine: first pick anchors, second pick
+ * completes, a third starts a fresh measurement.
+ */
+export function nextMapMeasurementState(
+  current: MapMeasurementState | null,
+  pick: MapMeasurementPoint,
+): MapMeasurementState {
+  if (!current || current.b !== null) {
+    return { a: pick, b: null };
+  }
+  return { a: current.a, b: pick };
+}
+
+/** Great-circle distance of a complete WGS84 measurement, else `null`. */
+export function mapMeasurementDistance(
+  measurement: MapMeasurementState | null,
+): number | null {
+  if (!measurement?.b) return null;
+  return haversineDistanceMeters(measurement.a, measurement.b);
+}
+
+export function formatMapMeasurementDistance(meters: number): string {
+  if (meters < 100) {
+    return `${meters.toFixed(2)} m`;
+  }
+  if (meters < 1_000) {
+    return `${meters.toFixed(1)} m`;
+  }
+  if (meters < 100_000) {
+    return `${(meters / 1_000).toFixed(2)} km`;
+  }
+  return `${(meters / 1_000).toFixed(1)} km`;
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-map-puck.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-map-puck.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   ensurePuckImages,
   hexColorWithAlpha,
@@ -6,6 +6,10 @@ import {
   PUCK_VARIANT,
   voxel51PrimaryColor,
 } from "./mcap-map-puck";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("mcap map puck", () => {
   it("produces stable per-variant, per-color sprite ids", () => {
@@ -32,6 +36,7 @@ describe("mcap map puck", () => {
   });
 
   it("degrades to a no-op without throwing when 2D canvas is unavailable", () => {
+    mockCanvasContext(null);
     const added: string[] = [];
     ensurePuckImages(
       {
@@ -40,11 +45,29 @@ describe("mcap map puck", () => {
         },
         hasImage: () => false,
       },
-      // Duplicate colors must not register twice even when drawing works.
       ["#ff6d04", "#ff6d04"],
     );
-    expect(new Set(added).size).toBe(added.length);
-    expect(added.length === 0 || added.length === 2).toBe(true);
+    expect(added).toEqual([]);
+  });
+
+  it("registers each variant once for duplicate track colors", () => {
+    mockCanvasContext(fakeCanvasContext());
+    const added: string[] = [];
+
+    ensurePuckImages(
+      {
+        addImage: (id) => {
+          added.push(id);
+        },
+        hasImage: () => false,
+      },
+      ["#ff6d04", "#ff6d04"],
+    );
+
+    expect(added).toEqual([
+      puckImageId(PUCK_VARIANT.DOT, "#ff6d04"),
+      puckImageId(PUCK_VARIANT.NAV, "#ff6d04"),
+    ]);
   });
 
   it("falls back to brand orange when the theme variable is absent", () => {
@@ -58,3 +81,42 @@ describe("mcap map puck", () => {
     );
   });
 });
+
+function mockCanvasContext(context: CanvasRenderingContext2D | null) {
+  const createElement = document.createElement.bind(document);
+  vi.spyOn(document, "createElement").mockImplementation((tagName, options) => {
+    if (tagName === "canvas") {
+      return {
+        getContext: () => context,
+        height: 0,
+        width: 0,
+      } as unknown as HTMLCanvasElement;
+    }
+    return createElement(tagName, options);
+  });
+}
+
+function fakeCanvasContext(): CanvasRenderingContext2D {
+  const gradient = { addColorStop: vi.fn() };
+  return {
+    arc: vi.fn(),
+    beginPath: vi.fn(),
+    closePath: vi.fn(),
+    createRadialGradient: vi.fn(() => gradient),
+    ellipse: vi.fn(),
+    fill: vi.fn(),
+    getImageData: vi.fn(
+      () =>
+        ({
+          data: new Uint8ClampedArray(),
+          height: 1,
+          width: 1,
+        }) as ImageData,
+    ),
+    lineJoin: "round",
+    lineWidth: 0,
+    moveTo: vi.fn(),
+    quadraticCurveTo: vi.fn(),
+    stroke: vi.fn(),
+  } as unknown as CanvasRenderingContext2D;
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-map-puck.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-map-puck.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  ensurePuckImages,
+  hexColorWithAlpha,
+  puckImageId,
+  PUCK_VARIANT,
+  voxel51PrimaryColor,
+} from "./mcap-map-puck";
+
+describe("mcap map puck", () => {
+  it("produces stable per-variant, per-color sprite ids", () => {
+    expect(puckImageId(PUCK_VARIANT.NAV, "#ff6d04")).toBe(
+      "mcap-puck-nav-#ff6d04",
+    );
+    expect(puckImageId(PUCK_VARIANT.DOT, "#3b82f6")).toBe(
+      "mcap-puck-dot-#3b82f6",
+    );
+  });
+
+  it("skips registration for ids the map already has", () => {
+    const added: string[] = [];
+    ensurePuckImages(
+      {
+        addImage: (id) => {
+          added.push(id);
+        },
+        hasImage: () => true,
+      },
+      ["#ff6d04", "#3b82f6"],
+    );
+    expect(added).toEqual([]);
+  });
+
+  it("degrades to a no-op without throwing when 2D canvas is unavailable", () => {
+    const added: string[] = [];
+    ensurePuckImages(
+      {
+        addImage: (id) => {
+          added.push(id);
+        },
+        hasImage: () => false,
+      },
+      // Duplicate colors must not register twice even when drawing works.
+      ["#ff6d04", "#ff6d04"],
+    );
+    expect(new Set(added).size).toBe(added.length);
+    expect(added.length === 0 || added.length === 2).toBe(true);
+  });
+
+  it("falls back to brand orange when the theme variable is absent", () => {
+    expect(voxel51PrimaryColor()).toBe("#ff6d04");
+  });
+
+  it("applies alpha to hex colors and passes through unparseable ones", () => {
+    expect(hexColorWithAlpha("#ff6d04", 0)).toBe("rgba(255, 109, 4, 0)");
+    expect(hexColorWithAlpha("hsl(25, 100%, 51%)", 0.5)).toBe(
+      "hsl(25, 100%, 51%)",
+    );
+  });
+});

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-map-puck.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-map-puck.ts
@@ -1,0 +1,269 @@
+/**
+ * Canvas-rendered position "pucks" for the map tile. MapLibre circle
+ * layers cannot render gradients, so the dimensional look — dome shading,
+ * specular highlight, white rim, baked drop shadow — is pre-drawn once per
+ * track color and registered as a symbol icon, the technique behind
+ * Google/Uber-style navigation markers. The nav variant is a teardrop
+ * drawn pointing north; `icon-rotate` supplies the bearing.
+ */
+
+export const PUCK_VARIANT = {
+  /** Plain dome, used when no heading is derivable. */
+  DOT: "dot",
+  /** North-pointing teardrop, rotated to the GPS segment bearing. */
+  NAV: "nav",
+} as const;
+
+export type PuckVariant = (typeof PUCK_VARIANT)[keyof typeof PUCK_VARIANT];
+
+/** CSS size of the rendered sprite; drawn at 2x for retina. */
+const PUCK_SIZE_PX = 40;
+const PUCK_PIXEL_RATIO = 2;
+const PUCK_RADIUS_PX = 9;
+
+const VOXEL51_PRIMARY_FALLBACK = "#ff6d04";
+const VOXEL51_PRIMARY_CSS_VAR = "--fo-palette-primary-plainColor";
+
+let cachedPrimaryColor: string | null = null;
+
+/**
+ * The app's primary (Voxel51 orange) resolved from the theme's CSS
+ * variable, with a literal fallback for standalone/test environments.
+ * MapLibre paint values cannot reference CSS variables, so this is
+ * resolved once and handed over as a concrete color.
+ */
+export function voxel51PrimaryColor(): string {
+  if (cachedPrimaryColor) {
+    return cachedPrimaryColor;
+  }
+  if (typeof document === "undefined") {
+    return VOXEL51_PRIMARY_FALLBACK;
+  }
+  const value = getComputedStyle(document.documentElement)
+    .getPropertyValue(VOXEL51_PRIMARY_CSS_VAR)
+    .trim();
+  // The theme emits hsl() strings; the sprite/gradient math needs hex, so
+  // normalize through canvas (which serializes opaque colors as #rrggbb).
+  cachedPrimaryColor =
+    value.length > 0
+      ? (normalizeCssColorToHex(value) ?? VOXEL51_PRIMARY_FALLBACK)
+      : VOXEL51_PRIMARY_FALLBACK;
+  return cachedPrimaryColor;
+}
+
+function normalizeCssColorToHex(color: string): string | null {
+  if (/^#[0-9a-f]{6}$/i.test(color)) {
+    return color;
+  }
+  const ctx = document.createElement("canvas").getContext("2d");
+  if (!ctx) {
+    return null;
+  }
+  ctx.fillStyle = color;
+  const normalized = ctx.fillStyle;
+  return /^#[0-9a-f]{6}$/i.test(normalized) ? normalized : null;
+}
+
+export function puckImageId(variant: PuckVariant, color: string): string {
+  return `mcap-puck-${variant}-${color}`;
+}
+
+/** The subset of the MapLibre map surface the sprite registry needs. */
+export interface PuckImageHost {
+  hasImage(id: string): boolean;
+  addImage(
+    id: string,
+    image: ImageData,
+    options?: { pixelRatio?: number },
+  ): void;
+}
+
+/**
+ * Registers both puck variants for each track color, skipping ids the map
+ * already has. A no-op where 2D canvas is unavailable (e.g. jsdom) — the
+ * symbol layer simply renders nothing rather than erroring.
+ */
+export function ensurePuckImages(
+  map: PuckImageHost,
+  colors: readonly string[],
+): void {
+  for (const color of new Set(colors)) {
+    for (const variant of Object.values(PUCK_VARIANT)) {
+      const id = puckImageId(variant, color);
+      if (map.hasImage(id)) {
+        continue;
+      }
+      const image = drawPuckImage(variant, color);
+      if (image) {
+        map.addImage(id, image, { pixelRatio: PUCK_PIXEL_RATIO });
+      }
+    }
+  }
+}
+
+export function drawPuckImage(
+  variant: PuckVariant,
+  color: string,
+): ImageData | null {
+  // Partial canvas implementations (jsdom, test stubs) surface as thrown
+  // TypeErrors mid-draw; a puck that cannot draw degrades to no icon.
+  try {
+    return drawPuckImageUnsafe(variant, color);
+  } catch {
+    return null;
+  }
+}
+
+function drawPuckImageUnsafe(
+  variant: PuckVariant,
+  color: string,
+): ImageData | null {
+  if (typeof document === "undefined") {
+    return null;
+  }
+  const size = PUCK_SIZE_PX * PUCK_PIXEL_RATIO;
+  const canvas = document.createElement("canvas");
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) {
+    return null;
+  }
+
+  const center = size / 2;
+  const radius = PUCK_RADIUS_PX * PUCK_PIXEL_RATIO;
+
+  // Baked drop shadow: a soft dark ellipse slightly below the dome.
+  const shadow = ctx.createRadialGradient(
+    center,
+    center + radius * 0.5,
+    radius * 0.2,
+    center,
+    center + radius * 0.5,
+    radius * 1.5,
+  );
+  shadow.addColorStop(0, "rgba(2, 8, 16, 0.4)");
+  shadow.addColorStop(1, "rgba(2, 8, 16, 0)");
+  ctx.fillStyle = shadow;
+  ctx.beginPath();
+  ctx.ellipse(
+    center,
+    center + radius * 0.5,
+    radius * 1.5,
+    radius * 1.1,
+    0,
+    0,
+    Math.PI * 2,
+  );
+  ctx.fill();
+
+  tracePuckPath(ctx, variant, center, radius);
+
+  // White rim first (stroked under the fill so half its width shows),
+  // then the gradient dome.
+  ctx.strokeStyle = "#ffffff";
+  ctx.lineWidth = 3 * PUCK_PIXEL_RATIO;
+  ctx.lineJoin = "round";
+  ctx.stroke();
+
+  const dome = ctx.createRadialGradient(
+    center - radius * 0.45,
+    center - radius * 0.55,
+    radius * 0.15,
+    center,
+    center,
+    radius * 2.1,
+  );
+  dome.addColorStop(0, mixHexColor(color, "#ffffff", 0.45));
+  dome.addColorStop(0.45, color);
+  dome.addColorStop(1, mixHexColor(color, "#000000", 0.35));
+  ctx.fillStyle = dome;
+  ctx.fill();
+
+  // Specular highlight off toward the light source.
+  const specular = ctx.createRadialGradient(
+    center - radius * 0.4,
+    center - radius * 0.5,
+    0,
+    center - radius * 0.4,
+    center - radius * 0.5,
+    radius * 0.8,
+  );
+  specular.addColorStop(0, "rgba(255, 255, 255, 0.55)");
+  specular.addColorStop(1, "rgba(255, 255, 255, 0)");
+  ctx.fillStyle = specular;
+  ctx.beginPath();
+  ctx.arc(
+    center - radius * 0.3,
+    center - radius * 0.4,
+    radius * 0.7,
+    0,
+    Math.PI * 2,
+  );
+  ctx.fill();
+
+  return ctx.getImageData(0, 0, size, size);
+}
+
+function tracePuckPath(
+  ctx: CanvasRenderingContext2D,
+  variant: PuckVariant,
+  center: number,
+  radius: number,
+) {
+  ctx.beginPath();
+  if (variant === PUCK_VARIANT.DOT) {
+    ctx.arc(center, center, radius, 0, Math.PI * 2);
+    return;
+  }
+  // Teardrop pointing north (up): nose tip, left shoulder, around the
+  // bottom of the circle, right shoulder back to the tip.
+  const tipY = center - radius * 2;
+  ctx.moveTo(center, tipY);
+  ctx.quadraticCurveTo(
+    center - radius * 0.95,
+    center - radius * 0.75,
+    center - radius,
+    center,
+  );
+  ctx.arc(center, center, radius, Math.PI, 0, true);
+  ctx.quadraticCurveTo(
+    center + radius * 0.95,
+    center - radius * 0.75,
+    center,
+    tipY,
+  );
+  ctx.closePath();
+}
+
+/** `color` with `alpha` applied, for gradient endpoints. */
+export function hexColorWithAlpha(color: string, alpha: number): string {
+  const rgb = parseHexColor(color);
+  if (!rgb) {
+    return color;
+  }
+  return `rgba(${rgb[0]}, ${rgb[1]}, ${rgb[2]}, ${alpha})`;
+}
+
+function mixHexColor(color: string, target: string, amount: number): string {
+  const from = parseHexColor(color);
+  const to = parseHexColor(target);
+  if (!from || !to) {
+    return color;
+  }
+  const mixed = from.map((channel, index) =>
+    Math.round(channel + (to[index] - channel) * amount),
+  );
+  return `rgb(${mixed[0]}, ${mixed[1]}, ${mixed[2]})`;
+}
+
+function parseHexColor(
+  color: string,
+): readonly [number, number, number] | null {
+  const match = /^#([0-9a-f]{6})$/i.exec(color.trim());
+  if (!match) {
+    return null;
+  }
+  const value = Number.parseInt(match[1], 16);
+  return [(value >> 16) & 0xff, (value >> 8) & 0xff, value & 0xff];
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-map-tile-state.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-map-tile-state.ts
@@ -1,0 +1,123 @@
+import { useTileId } from "@fiftyone/tiling";
+import { atom, useAtomValue, useStore } from "jotai";
+import { useCallback, useMemo } from "react";
+
+export const MCAP_MAP_BASE_LAYER = {
+  DEFAULT: "default",
+  NONE: "none",
+} as const;
+
+export type McapMapBaseLayer =
+  (typeof MCAP_MAP_BASE_LAYER)[keyof typeof MCAP_MAP_BASE_LAYER];
+
+export const OPENFREEMAP_LIBERTY_STYLE_URL =
+  "https://tiles.openfreemap.org/styles/liberty";
+
+export interface McapMapTileSettings {
+  /**
+   * Basemap selection for the geographic view. The default is an OSS
+   * OpenFreeMap style; `none` is the explicit offline/no-tile mode.
+   */
+  readonly baseLayer: McapMapBaseLayer;
+  /**
+   * `undefined` means "all location topics currently present". Once the
+   * user edits topic visibility, this becomes the explicit visible list.
+   */
+  readonly enabledTopics?: readonly string[];
+  /** Follow the playhead marker until the user manually pans/zooms. */
+  readonly followEgo: boolean;
+}
+
+export type McapMapTileSettingsByTile = Readonly<
+  Record<string, McapMapTileSettings>
+>;
+
+export const DEFAULT_MCAP_MAP_TILE_SETTINGS: McapMapTileSettings = {
+  baseLayer: MCAP_MAP_BASE_LAYER.DEFAULT,
+  followEgo: true,
+};
+
+export const mcapMapTileSettingsAtom = atom<McapMapTileSettingsByTile>({});
+
+export function useMcapMapTileSettings(): McapMapTileSettings {
+  const tileId = useTileId();
+  const byTile = useAtomValue(mcapMapTileSettingsAtom);
+  return useMemo(
+    () =>
+      tileId
+        ? { ...DEFAULT_MCAP_MAP_TILE_SETTINGS, ...byTile[tileId] }
+        : DEFAULT_MCAP_MAP_TILE_SETTINGS,
+    [byTile, tileId],
+  );
+}
+
+export function useSetMcapMapTileSettings(): (
+  patch: Partial<McapMapTileSettings>,
+) => void {
+  const tileId = useTileId();
+  const store = useStore();
+  return useCallback(
+    (patch) => {
+      if (!tileId) return;
+      store.set(mcapMapTileSettingsAtom, (previous) => {
+        const current = {
+          ...DEFAULT_MCAP_MAP_TILE_SETTINGS,
+          ...previous[tileId],
+        };
+        const next = { ...current, ...patch };
+        if (
+          next.baseLayer === current.baseLayer &&
+          next.enabledTopics === current.enabledTopics &&
+          next.followEgo === current.followEgo
+        ) {
+          return previous;
+        }
+        return { ...previous, [tileId]: next };
+      });
+    },
+    [store, tileId],
+  );
+}
+
+export function useToggleMcapMapTileTopic(): (
+  topic: string,
+  enabled: boolean,
+  allTopics: readonly string[],
+) => void {
+  const tileId = useTileId();
+  const store = useStore();
+  return useCallback(
+    (topic, enabled, allTopics) => {
+      if (!tileId) return;
+      store.set(mcapMapTileSettingsAtom, (previous) => {
+        const current = {
+          ...DEFAULT_MCAP_MAP_TILE_SETTINGS,
+          ...previous[tileId],
+        };
+        const enabledTopics = new Set(current.enabledTopics ?? allTopics);
+        if (enabled) {
+          enabledTopics.add(topic);
+        } else {
+          enabledTopics.delete(topic);
+        }
+        const nextTopics = allTopics.filter((candidate) =>
+          enabledTopics.has(candidate),
+        );
+        const next: McapMapTileSettings = {
+          ...current,
+          enabledTopics: nextTopics,
+        };
+        return { ...previous, [tileId]: next };
+      });
+    },
+    [store, tileId],
+  );
+}
+
+export function normalizeMcapMapBaseLayer(
+  raw: unknown,
+): McapMapBaseLayer | undefined {
+  return raw === MCAP_MAP_BASE_LAYER.DEFAULT || raw === MCAP_MAP_BASE_LAYER.NONE
+    ? raw
+    : undefined;
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-plot-tile-state.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-plot-tile-state.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   MCAP_PLOT_SERIES_PALETTE,
+  addMcapPlotSeriesToTile,
   nextPlotSeriesColor,
 } from "./mcap-plot-tile-state";
 
@@ -45,6 +46,61 @@ describe("nextPlotSeriesColor", () => {
       MCAP_PLOT_SERIES_PALETTE[
         current.length % MCAP_PLOT_SERIES_PALETTE.length
       ],
+    );
+  });
+});
+
+describe("addMcapPlotSeriesToTile", () => {
+  it("adds a new series to an empty tile", () => {
+    expect(addMcapPlotSeriesToTile({}, "plot-1", "/odom", "speed")).toEqual({
+      "plot-1": [
+        {
+          color: MCAP_PLOT_SERIES_PALETTE[0],
+          fieldPath: "speed",
+          topic: "/odom",
+        },
+      ],
+    });
+  });
+
+  it("keeps existing series and assigns the next available color", () => {
+    const previous = {
+      "plot-1": [
+        {
+          color: MCAP_PLOT_SERIES_PALETTE[2],
+          fieldPath: "speed",
+          topic: "/odom",
+        },
+      ],
+    };
+
+    expect(
+      addMcapPlotSeriesToTile(previous, "plot-1", "/odom", "accel"),
+    ).toEqual({
+      "plot-1": [
+        previous["plot-1"][0],
+        {
+          color: MCAP_PLOT_SERIES_PALETTE[0],
+          fieldPath: "accel",
+          topic: "/odom",
+        },
+      ],
+    });
+  });
+
+  it("does not duplicate an existing topic and field path", () => {
+    const previous = {
+      "plot-1": [
+        {
+          color: MCAP_PLOT_SERIES_PALETTE[0],
+          fieldPath: "speed",
+          topic: "/odom",
+        },
+      ],
+    };
+
+    expect(addMcapPlotSeriesToTile(previous, "plot-1", "/odom", "speed")).toBe(
+      previous,
     );
   });
 });

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-plot-tile-state.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-plot-tile-state.ts
@@ -39,6 +39,32 @@ export const mcapPlotTileSeriesAtom = atom<
   Readonly<Record<string, readonly McapPlotSeriesConfig[]>>
 >({});
 
+/**
+ * Adds one topic+field series to a specific plot tile. Existing series
+ * are left untouched so repeated "add to plot" actions are idempotent.
+ */
+export function addMcapPlotSeriesToTile(
+  previous: Readonly<Record<string, readonly McapPlotSeriesConfig[]>>,
+  tileId: string,
+  topic: string,
+  fieldPath: string,
+): Readonly<Record<string, readonly McapPlotSeriesConfig[]>> {
+  const current = previous[tileId] ?? [];
+  const exists = current.some(
+    (series) => series.topic === topic && series.fieldPath === fieldPath,
+  );
+  if (exists) {
+    return previous;
+  }
+  return {
+    ...previous,
+    [tileId]: [
+      ...current,
+      { color: nextPlotSeriesColor(current), fieldPath, topic },
+    ],
+  };
+}
+
 /** Subscribe to the surrounding plot tile's enabled series. */
 export function useMcapPlotTileSeries(): readonly McapPlotSeriesConfig[] {
   const tileId = useTileId();
@@ -76,10 +102,7 @@ export function useToggleMcapPlotSeries(): (
           return previous;
         }
         const next = enabled
-          ? [
-              ...current,
-              { color: nextPlotSeriesColor(current), fieldPath, topic },
-            ]
+          ? addMcapPlotSeriesToTile(previous, tileId, topic, fieldPath)[tileId]
           : current.filter(
               (series) =>
                 series.topic !== topic || series.fieldPath !== fieldPath,

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-plot-tile-state.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-plot-tile-state.ts
@@ -101,13 +101,16 @@ export function useToggleMcapPlotSeries(): (
         if (enabled === exists) {
           return previous;
         }
-        const next = enabled
-          ? addMcapPlotSeriesToTile(previous, tileId, topic, fieldPath)[tileId]
-          : current.filter(
-              (series) =>
-                series.topic !== topic || series.fieldPath !== fieldPath,
-            );
-        return { ...previous, [tileId]: next };
+        if (enabled) {
+          return addMcapPlotSeriesToTile(previous, tileId, topic, fieldPath);
+        }
+        return {
+          ...previous,
+          [tileId]: current.filter(
+            (series) =>
+              series.topic !== topic || series.fieldPath !== fieldPath,
+          ),
+        };
       });
     },
     [store, tileId],

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-raw-tile-state.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-raw-tile-state.ts
@@ -8,7 +8,9 @@ import { useCallback } from "react";
  * modal and vanishes with it; layout persistence snapshots it per
  * dataset.
  */
-export const mcapRawTileTopicAtom = atom<Readonly<Record<string, string>>>({});
+export type McapRawTileTopics = Readonly<Record<string, string>>;
+
+export const mcapRawTileTopicAtom = atom<McapRawTileTopics>({});
 
 /** Subscribe to the surrounding raw-message tile's inspected topic. */
 export function useMcapRawTileTopic(): string | null {

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-scene-update-history-context.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-scene-update-history-context.tsx
@@ -25,7 +25,7 @@ const SCENE_UPDATE_HISTORY_DEFERRED_RETRY_MS = 2_000;
 
 export interface McapSceneUpdateHistoryTopic {
   readonly deltas: readonly McapSceneUpdateDelta[];
-  readonly status: "error" | "loading" | "ready";
+  readonly status: "error" | "loading" | "ready" | "truncated";
   readonly truncated?: boolean;
 }
 
@@ -173,12 +173,11 @@ export function McapSceneUpdateHistoryBridge({
               });
             }
 
+            const truncated = messageCount >= SCENE_UPDATE_HISTORY_READ_LIMIT;
             commit(topic, {
               deltas,
-              status: "ready",
-              ...(messageCount >= SCENE_UPDATE_HISTORY_READ_LIMIT
-                ? { truncated: true }
-                : {}),
+              status: truncated ? "truncated" : "ready",
+              ...(truncated ? { truncated: true } : {}),
             });
           } catch {
             commit(topic, { deltas: [], status: "error" });

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-scene-update-history-context.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-scene-update-history-context.tsx
@@ -1,0 +1,223 @@
+import { PlaybackStoreContext } from "@fiftyone/playback/src/lib/playback/playback-store-context";
+import { getIsPlaying } from "@fiftyone/playback/src/lib/playback/store-access";
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import type { ByteSourceDescriptor } from "../../../query/bytes";
+import { byteSourceAccessKey } from "../../../query/bytes";
+import { VISUALIZATION_KIND } from "../../../visualization";
+import { MCAP_ACTIVE_TIMELINE, type McapResourceClient } from "../types";
+import {
+  getMcapNetworkHealth,
+  shouldDeferMcapIdleWorkForStore,
+} from "./mcap-network-health";
+import type { McapSceneUpdateDelta } from "./mcap-scene-update-state";
+
+const SCENE_UPDATE_HISTORY_READ_LIMIT = 50_000;
+const SCENE_UPDATE_HISTORY_START_DELAY_MS = 1_500;
+const SCENE_UPDATE_HISTORY_DEFERRED_RETRY_MS = 2_000;
+
+export interface McapSceneUpdateHistoryTopic {
+  readonly deltas: readonly McapSceneUpdateDelta[];
+  readonly status: "error" | "loading" | "ready";
+  readonly truncated?: boolean;
+}
+
+export type McapSceneUpdateHistory = ReadonlyMap<
+  string,
+  McapSceneUpdateHistoryTopic
+>;
+
+const EMPTY_HISTORY: McapSceneUpdateHistory = new Map();
+
+interface McapSceneUpdateHistoryContextValue {
+  readonly history: McapSceneUpdateHistory;
+  readonly setHistory: (state: McapSceneUpdateHistory) => void;
+}
+
+const McapSceneUpdateHistoryContext =
+  createContext<McapSceneUpdateHistoryContextValue | null>(null);
+
+/**
+ * Shares full-topic scene-update histories with 3D tiles. These histories are
+ * needed for correctness on stateful streams such as ROS MarkerArray: the
+ * latest delta at a seek target is not enough to reconstruct older persistent
+ * marker ids.
+ */
+export const McapSceneUpdateHistoryProvider: React.FC<{
+  children: React.ReactNode;
+}> = ({ children }) => {
+  const [history, setHistory] = useState<McapSceneUpdateHistory>(EMPTY_HISTORY);
+  const value = useMemo(() => ({ history, setHistory }), [history]);
+
+  return (
+    <McapSceneUpdateHistoryContext.Provider value={value}>
+      {children}
+    </McapSceneUpdateHistoryContext.Provider>
+  );
+};
+
+export function useMcapSceneUpdateHistoryContext(): McapSceneUpdateHistory {
+  return useContext(McapSceneUpdateHistoryContext)?.history ?? EMPTY_HISTORY;
+}
+
+export function McapSceneUpdateHistoryBridge({
+  client,
+  sceneAnnotationTopics,
+  source,
+}: {
+  readonly client: McapResourceClient;
+  readonly sceneAnnotationTopics: readonly string[];
+  readonly source: ByteSourceDescriptor | null;
+}) {
+  const { setHistory } = useContextValue();
+  const sourceKey = source ? byteSourceAccessKey(source) : null;
+  const fetchedTopicsRef = useRef(new Set<string>());
+  const historyRef = useRef(new Map<string, McapSceneUpdateHistoryTopic>());
+  const playbackStore = useContext(PlaybackStoreContext);
+
+  useEffect(() => {
+    fetchedTopicsRef.current = new Set();
+    historyRef.current = new Map();
+    setHistory(EMPTY_HISTORY);
+
+    if (!sourceKey || !source || sceneAnnotationTopics.length === 0) {
+      return undefined;
+    }
+
+    let cancelled = false;
+    let retryTimeout: ReturnType<typeof setTimeout> | null = null;
+    const activeTopics = new Set(sceneAnnotationTopics);
+    const commit = (topic: string, state: McapSceneUpdateHistoryTopic) => {
+      if (cancelled) {
+        return;
+      }
+      historyRef.current.set(topic, state);
+      setHistory(new Map(historyRef.current));
+    };
+
+    const shouldStandDown = (): boolean => {
+      if (!playbackStore) {
+        return false;
+      }
+      if (
+        getIsPlaying(playbackStore) &&
+        getMcapNetworkHealth(playbackStore).limited
+      ) {
+        return true;
+      }
+      return shouldDeferMcapIdleWorkForStore(playbackStore, null);
+    };
+
+    const scheduleRetry = (delayMs: number) => {
+      if (cancelled || retryTimeout !== null) {
+        return;
+      }
+      retryTimeout = setTimeout(() => {
+        retryTimeout = null;
+        start();
+      }, delayMs);
+    };
+
+    const start = () => {
+      if (cancelled) {
+        return;
+      }
+      if (shouldStandDown()) {
+        scheduleRetry(SCENE_UPDATE_HISTORY_DEFERRED_RETRY_MS);
+        return;
+      }
+
+      for (const topic of sceneAnnotationTopics) {
+        if (!activeTopics.has(topic) || fetchedTopicsRef.current.has(topic)) {
+          continue;
+        }
+        fetchedTopicsRef.current.add(topic);
+        commit(topic, { deltas: [], status: "loading" });
+
+        void (async () => {
+          const deltas: McapSceneUpdateDelta[] = [];
+          try {
+            for await (const message of client.readDecodedMessages(
+              {
+                activeTimeline: MCAP_ACTIVE_TIMELINE.LOG,
+                limit: SCENE_UPDATE_HISTORY_READ_LIMIT,
+                source,
+                topics: [topic],
+              },
+              { priority: "bulk" },
+            )) {
+              if (cancelled) {
+                return;
+              }
+              if (shouldStandDown()) {
+                fetchedTopicsRef.current.delete(topic);
+                scheduleRetry(SCENE_UPDATE_HISTORY_DEFERRED_RETRY_MS);
+                return;
+              }
+              const visualization = message.decoded.output.visualization;
+              if (visualization?.kind !== VISUALIZATION_KIND.SCENE_UPDATE) {
+                continue;
+              }
+              deltas.push({
+                timeNs: message.timelineTimeNs,
+                update: visualization,
+              });
+            }
+
+            commit(topic, {
+              deltas,
+              status: "ready",
+              ...(deltas.length >= SCENE_UPDATE_HISTORY_READ_LIMIT
+                ? { truncated: true }
+                : {}),
+            });
+          } catch {
+            commit(topic, { deltas: [], status: "error" });
+          }
+        })();
+      }
+    };
+
+    scheduleRetry(SCENE_UPDATE_HISTORY_START_DELAY_MS);
+
+    return () => {
+      cancelled = true;
+      if (retryTimeout !== null) {
+        clearTimeout(retryTimeout);
+      }
+    };
+  }, [
+    client,
+    playbackStore,
+    sceneAnnotationTopics,
+    setHistory,
+    source,
+    sourceKey,
+  ]);
+
+  useEffect(
+    () => () => {
+      setHistory(EMPTY_HISTORY);
+    },
+    [setHistory],
+  );
+
+  return null;
+}
+
+function useContextValue(): McapSceneUpdateHistoryContextValue {
+  const value = useContext(McapSceneUpdateHistoryContext);
+  if (!value) {
+    throw new Error(
+      "MCAP scene update history must be used inside <McapSceneUpdateHistoryProvider>",
+    );
+  }
+  return value;
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-scene-update-history-context.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-scene-update-history-context.tsx
@@ -143,6 +143,7 @@ export function McapSceneUpdateHistoryBridge({
 
         void (async () => {
           const deltas: McapSceneUpdateDelta[] = [];
+          let messageCount = 0;
           try {
             for await (const message of client.readDecodedMessages(
               {
@@ -161,6 +162,7 @@ export function McapSceneUpdateHistoryBridge({
                 scheduleRetry(SCENE_UPDATE_HISTORY_DEFERRED_RETRY_MS);
                 return;
               }
+              messageCount += 1;
               const visualization = message.decoded.output.visualization;
               if (visualization?.kind !== VISUALIZATION_KIND.SCENE_UPDATE) {
                 continue;
@@ -174,7 +176,7 @@ export function McapSceneUpdateHistoryBridge({
             commit(topic, {
               deltas,
               status: "ready",
-              ...(deltas.length >= SCENE_UPDATE_HISTORY_READ_LIMIT
+              ...(messageCount >= SCENE_UPDATE_HISTORY_READ_LIMIT
                 ? { truncated: true }
                 : {}),
             });

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-scene-update-state.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-scene-update-state.test.ts
@@ -21,6 +21,19 @@ describe("sceneUpdateSnapshotAt", () => {
     expect(snapshot.entities[0]?.metadata.label).toBe("new");
   });
 
+  it("sorts deltas before folding", () => {
+    const snapshot = sceneUpdateSnapshotAt(
+      [
+        updateDelta(20n, [entity("box", { label: "new" })]),
+        updateDelta(10n, [entity("box", { label: "old" })]),
+      ],
+      20n,
+    );
+
+    expect(snapshot.entities).toHaveLength(1);
+    expect(snapshot.entities[0]?.metadata.label).toBe("new");
+  });
+
   it("applies matching and all-entity deletions before upserts", () => {
     const snapshot = sceneUpdateSnapshotAt(
       [

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-scene-update-state.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-scene-update-state.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  SceneEntityVisualization,
+  SceneUpdateVisualization,
+} from "../../../decoders";
+import { VISUALIZATION_KIND } from "../../../visualization";
+import { sceneUpdateSnapshotAt } from "./mcap-scene-update-state";
+
+describe("sceneUpdateSnapshotAt", () => {
+  it("upserts scene entities by id", () => {
+    const snapshot = sceneUpdateSnapshotAt(
+      [
+        updateDelta(10n, [entity("box", { label: "old" })]),
+        updateDelta(20n, [entity("box", { label: "new" })]),
+      ],
+      20n,
+    );
+
+    expect(snapshot.entities).toHaveLength(1);
+    expect(snapshot.entities[0]?.metadata.label).toBe("new");
+  });
+
+  it("applies matching and all-entity deletions before upserts", () => {
+    const snapshot = sceneUpdateSnapshotAt(
+      [
+        updateDelta(10n, [entity("old"), entity("kept")]),
+        {
+          timeNs: 20n,
+          update: {
+            deletions: [
+              { id: "old", type: "matching-id" },
+              { id: "", type: "all" },
+            ],
+            entities: [entity("replacement")],
+            kind: VISUALIZATION_KIND.SCENE_UPDATE,
+          },
+        },
+      ],
+      20n,
+    );
+
+    expect(snapshot.entities.map((e) => e.id)).toEqual(["replacement"]);
+  });
+
+  it("expires entity lifetimes relative to entity timestamps", () => {
+    const beforeExpiry = sceneUpdateSnapshotAt(
+      [updateDelta(10n, [entity("short", {}, 10n, 5n)])],
+      14n,
+    );
+    const afterExpiry = sceneUpdateSnapshotAt(
+      [updateDelta(10n, [entity("short", {}, 10n, 5n)])],
+      15n,
+    );
+
+    expect(beforeExpiry.entities.map((e) => e.id)).toEqual(["short"]);
+    expect(afterExpiry.entities).toEqual([]);
+  });
+});
+
+function updateDelta(
+  timeNs: bigint,
+  entities: readonly SceneEntityVisualization[],
+) {
+  return {
+    timeNs,
+    update: {
+      deletions: [],
+      entities,
+      kind: VISUALIZATION_KIND.SCENE_UPDATE,
+    } satisfies SceneUpdateVisualization,
+  };
+}
+
+function entity(
+  id: string,
+  metadata: Readonly<Record<string, string>> = {},
+  timestampNs?: bigint,
+  lifetimeNs?: bigint,
+): SceneEntityVisualization {
+  return {
+    arrowCount: 0,
+    arrows: [],
+    cubeCount: 0,
+    cubes: [],
+    cylinderCount: 0,
+    cylinders: [],
+    frameLocked: false,
+    id,
+    lineCount: 0,
+    lines: [],
+    ...(lifetimeNs !== undefined ? { lifetimeNs } : {}),
+    metadata,
+    modelCount: 0,
+    models: [],
+    sphereCount: 0,
+    spheres: [],
+    textCount: 0,
+    texts: [],
+    ...(timestampNs !== undefined ? { timestampNs } : {}),
+    triangleCount: 0,
+    triangles: [],
+  };
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-scene-update-state.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-scene-update-state.test.ts
@@ -43,6 +43,25 @@ describe("sceneUpdateSnapshotAt", () => {
     expect(snapshot.entities.map((e) => e.id)).toEqual(["replacement"]);
   });
 
+  it("skips deletions whose own timestamp is after the playhead", () => {
+    const snapshot = sceneUpdateSnapshotAt(
+      [
+        updateDelta(10n, [entity("kept")]),
+        {
+          timeNs: 20n,
+          update: {
+            deletions: [{ id: "kept", timestampNs: 30n, type: "matching-id" }],
+            entities: [],
+            kind: VISUALIZATION_KIND.SCENE_UPDATE,
+          },
+        },
+      ],
+      20n,
+    );
+
+    expect(snapshot.entities.map((e) => e.id)).toEqual(["kept"]);
+  });
+
   it("expires entity lifetimes relative to entity timestamps", () => {
     const beforeExpiry = sceneUpdateSnapshotAt(
       [updateDelta(10n, [entity("short", {}, 10n, 5n)])],

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-scene-update-state.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-scene-update-state.ts
@@ -14,6 +14,11 @@ interface SceneEntityRecord {
   readonly updatedAtNs: bigint;
 }
 
+const SORTED_DELTAS_CACHE = new WeakMap<
+  readonly McapSceneUpdateDelta[],
+  readonly McapSceneUpdateDelta[]
+>();
+
 /**
  * Folds scene-update deltas into a render snapshot at one playhead time.
  *
@@ -36,7 +41,7 @@ export function sceneUpdateSnapshotAt(
 ): SceneUpdateVisualization {
   const state = new Map<string, SceneEntityRecord>();
 
-  for (const delta of [...deltas].sort(compareSceneUpdateDeltas)) {
+  for (const delta of sortedSceneUpdateDeltas(deltas)) {
     if (delta.timeNs > timeNs) {
       break;
     }
@@ -49,6 +54,35 @@ export function sceneUpdateSnapshotAt(
     entities: [...state.values()].map((record) => record.entity),
     kind: VISUALIZATION_KIND.SCENE_UPDATE,
   };
+}
+
+function sortedSceneUpdateDeltas(
+  deltas: readonly McapSceneUpdateDelta[],
+): readonly McapSceneUpdateDelta[] {
+  const cached = SORTED_DELTAS_CACHE.get(deltas);
+  if (cached) {
+    return cached;
+  }
+
+  const sorted = isSortedByTime(deltas)
+    ? deltas
+    : [...deltas].sort(compareSceneUpdateDeltas);
+  SORTED_DELTAS_CACHE.set(deltas, sorted);
+  return sorted;
+}
+
+function isSortedByTime(deltas: readonly McapSceneUpdateDelta[]): boolean {
+  for (let index = 1; index < deltas.length; index++) {
+    const previous = deltas[index - 1];
+    const current = deltas[index];
+    if (!previous || !current) {
+      continue;
+    }
+    if (previous.timeNs > current.timeNs) {
+      return false;
+    }
+  }
+  return true;
 }
 
 function applySceneUpdateDelta(

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-scene-update-state.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-scene-update-state.ts
@@ -1,0 +1,118 @@
+import { VISUALIZATION_KIND } from "../../../visualization";
+import type {
+  SceneEntityVisualization,
+  SceneUpdateVisualization,
+} from "../../../decoders";
+
+export interface McapSceneUpdateDelta {
+  readonly timeNs: bigint;
+  readonly update: SceneUpdateVisualization;
+}
+
+interface SceneEntityRecord {
+  readonly entity: SceneEntityVisualization;
+  readonly expiresAtNs?: bigint;
+  readonly updatedAtNs: bigint;
+}
+
+/**
+ * Folds scene-update deltas into a render snapshot at one playhead time.
+ *
+ * SceneUpdate and ROS MarkerArray are state-update streams: ADD/MODIFY
+ * upserts by id, DELETE removes by id, DELETEALL clears the topic, and
+ * lifetimes expire relative to the message/entity timestamp. The renderer
+ * wants a full entity snapshot, so this fold is intentionally pure and
+ * deterministic; callers can cache or rebuild around it depending on the
+ * playback path.
+ *
+ * Within one SceneUpdate message, deletions are applied before entity upserts.
+ * The wire shape stores them in separate arrays, so true interleaving order is
+ * unavailable. This ordering supports the common "clear all, then publish a
+ * full replacement snapshot" pattern while remaining stable for Foxglove and
+ * ROS marker streams.
+ */
+export function sceneUpdateSnapshotAt(
+  deltas: readonly McapSceneUpdateDelta[],
+  timeNs: bigint,
+): SceneUpdateVisualization {
+  const state = new Map<string, SceneEntityRecord>();
+
+  for (const delta of [...deltas].sort(compareSceneUpdateDeltas)) {
+    if (delta.timeNs > timeNs) {
+      break;
+    }
+
+    expireEntities(state, timeNs);
+    applySceneUpdateDelta(state, delta, timeNs);
+  }
+  expireEntities(state, timeNs);
+
+  return {
+    deletions: [],
+    entities: [...state.values()].map((record) => record.entity),
+    kind: VISUALIZATION_KIND.SCENE_UPDATE,
+  };
+}
+
+function applySceneUpdateDelta(
+  state: Map<string, SceneEntityRecord>,
+  { timeNs, update }: McapSceneUpdateDelta,
+  targetTimeNs: bigint,
+): void {
+  for (const deletion of update.deletions) {
+    const deletionTimeNs = deletion.timestampNs ?? timeNs;
+    if (deletionTimeNs > targetTimeNs) {
+      continue;
+    }
+    if (deletion.type === "all") {
+      state.clear();
+    } else {
+      state.delete(deletion.id);
+    }
+  }
+
+  for (const entity of update.entities) {
+    const updatedAtNs = entity.timestampNs ?? timeNs;
+    if (updatedAtNs > targetTimeNs) {
+      continue;
+    }
+    const expiresAtNs =
+      entity.lifetimeNs !== undefined && entity.lifetimeNs > 0n
+        ? updatedAtNs + entity.lifetimeNs
+        : undefined;
+    if (expiresAtNs !== undefined && expiresAtNs <= targetTimeNs) {
+      state.delete(entity.id);
+      continue;
+    }
+
+    state.set(entity.id, {
+      entity,
+      ...(expiresAtNs !== undefined ? { expiresAtNs } : {}),
+      updatedAtNs,
+    });
+  }
+}
+
+function expireEntities(
+  state: Map<string, SceneEntityRecord>,
+  targetTimeNs: bigint,
+): void {
+  for (const [id, record] of state) {
+    if (
+      record.expiresAtNs !== undefined &&
+      record.expiresAtNs <= targetTimeNs
+    ) {
+      state.delete(id);
+    }
+  }
+}
+
+function compareSceneUpdateDeltas(
+  left: McapSceneUpdateDelta,
+  right: McapSceneUpdateDelta,
+): number {
+  if (left.timeNs === right.timeNs) {
+    return 0;
+  }
+  return left.timeNs < right.timeNs ? -1 : 1;
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-scene-update-state.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-scene-update-state.ts
@@ -11,7 +11,6 @@ export interface McapSceneUpdateDelta {
 
 interface SceneEntityRecord {
   readonly entity: SceneEntityVisualization;
-  readonly expiresAtNs?: bigint;
   readonly updatedAtNs: bigint;
 }
 
@@ -42,10 +41,8 @@ export function sceneUpdateSnapshotAt(
       break;
     }
 
-    expireEntities(state, timeNs);
     applySceneUpdateDelta(state, delta, timeNs);
   }
-  expireEntities(state, timeNs);
 
   return {
     deletions: [],
@@ -87,23 +84,8 @@ function applySceneUpdateDelta(
 
     state.set(entity.id, {
       entity,
-      ...(expiresAtNs !== undefined ? { expiresAtNs } : {}),
       updatedAtNs,
     });
-  }
-}
-
-function expireEntities(
-  state: Map<string, SceneEntityRecord>,
-  targetTimeNs: bigint,
-): void {
-  for (const [id, record] of state) {
-    if (
-      record.expiresAtNs !== undefined &&
-      record.expiresAtNs <= targetTimeNs
-    ) {
-      state.delete(id);
-    }
   }
 }
 

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-settings-keyboard.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-settings-keyboard.test.tsx
@@ -23,14 +23,14 @@ describe("preventSettingsCheckboxSpaceToggle", () => {
     expect(event.preventDefault).toHaveBeenCalledTimes(1);
   });
 
-  it("handles legacy and code-based space events", () => {
-    const legacyEvent = keyboardEvent("Spacebar");
+  it("handles key and code-based space events", () => {
+    const keyEvent = keyboardEvent("Spacebar");
     const codeEvent = keyboardEvent("Unidentified", "Space");
 
-    preventSettingsCheckboxSpaceToggle(legacyEvent);
+    preventSettingsCheckboxSpaceToggle(keyEvent);
     preventSettingsCheckboxSpaceToggle(codeEvent);
 
-    expect(legacyEvent.preventDefault).toHaveBeenCalledTimes(1);
+    expect(keyEvent.preventDefault).toHaveBeenCalledTimes(1);
     expect(codeEvent.preventDefault).toHaveBeenCalledTimes(1);
   });
 

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-tile-types.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-tile-types.ts
@@ -10,6 +10,7 @@
  */
 export const MCAP_TILE_TYPE = {
   IMAGE: "image",
+  LOG: "log",
   PLOT: "plot",
   RAW: "raw",
   THREE_D: "3d",

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-tile-types.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-tile-types.ts
@@ -11,6 +11,7 @@
 export const MCAP_TILE_TYPE = {
   IMAGE: "image",
   LOG: "log",
+  MAP: "map",
   PLOT: "plot",
   RAW: "raw",
   THREE_D: "3d",

--- a/app/packages/multimodal/src/adapters/mcap/react/playback-layout.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/playback-layout.test.ts
@@ -28,6 +28,15 @@ function imageSource(id: string, recordCount?: number): SceneSource {
   };
 }
 
+function logSource(id: string, recordCount?: number): SceneSource {
+  return {
+    id,
+    label: id.replace(/^\//, ""),
+    type: "log",
+    ...(recordCount !== undefined ? { recordCount } : {}),
+  };
+}
+
 const POINT_CLOUD: SceneSource = {
   id: "/points",
   label: "points",
@@ -259,6 +268,23 @@ describe("resolvePlaybackLayout", () => {
     expect(layout).toBe("3d-1");
   });
 
+  it("opens a log tile for logs-only scenes", () => {
+    const { tiles, layout } = resolvePlaybackLayout({
+      capabilities: STRONG_LOCAL,
+      readProfile: "local",
+      sources: [logSource("/diagnostics", 12)],
+    });
+
+    expect(tiles).toEqual([
+      {
+        id: "log-1",
+        tileType: "log",
+        title: "Logs",
+      },
+    ]);
+    expect(layout).toBe("log-1");
+  });
+
   it("returns no tiles for scenes without renderable sources", () => {
     const { tiles, layout } = resolvePlaybackLayout({
       capabilities: STRONG_LOCAL,
@@ -339,6 +365,15 @@ describe("buildMcapAutoLayout", () => {
         splitPercentage: 50,
       },
       splitPercentage: 100 / 3,
+    });
+  });
+
+  it("stacks log tiles vertically", () => {
+    expect(buildMcapAutoLayout(["log-1", "log-2"])).toEqual({
+      direction: "column",
+      first: "log-1",
+      second: "log-2",
+      splitPercentage: 50,
     });
   });
 

--- a/app/packages/multimodal/src/adapters/mcap/react/playback-layout.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/playback-layout.test.ts
@@ -37,6 +37,15 @@ function logSource(id: string, recordCount?: number): SceneSource {
   };
 }
 
+function locationSource(id: string, recordCount?: number): SceneSource {
+  return {
+    id,
+    label: id.replace(/^\//, ""),
+    type: "location",
+    ...(recordCount !== undefined ? { recordCount } : {}),
+  };
+}
+
 const POINT_CLOUD: SceneSource = {
   id: "/points",
   label: "points",
@@ -268,6 +277,39 @@ describe("resolvePlaybackLayout", () => {
     expect(layout).toBe("3d-1");
   });
 
+  it("opens a map tile for location-only scenes", () => {
+    const { tiles, layout } = resolvePlaybackLayout({
+      capabilities: STRONG_LOCAL,
+      readProfile: "local",
+      sources: [locationSource("/gps/fix", 1_000)],
+    });
+
+    expect(tiles).toEqual([
+      {
+        id: "map-1",
+        tileType: "map",
+        title: "Map",
+      },
+    ]);
+    expect(layout).toBe("map-1");
+  });
+
+  it("places location maps beside the 3d view", () => {
+    const { tiles, layout } = resolvePlaybackLayout({
+      capabilities: STRONG_LOCAL,
+      readProfile: "local",
+      sources: [POINT_CLOUD, locationSource("/gps/fix", 1_000)],
+    });
+
+    expect(tiles.map((tile) => tile.id)).toEqual(["3d-1", "map-1"]);
+    expect(layout).toEqual({
+      direction: "row",
+      first: "3d-1",
+      second: "map-1",
+      splitPercentage: 70,
+    });
+  });
+
   it("opens a log tile for logs-only scenes", () => {
     const { tiles, layout } = resolvePlaybackLayout({
       capabilities: STRONG_LOCAL,
@@ -340,6 +382,20 @@ describe("buildMcapAutoLayout", () => {
     });
   });
 
+  it("places map tiles beside 3d tiles in the top visual region", () => {
+    expect(buildMcapAutoLayout(["image-1", "3d-1", "map-1"])).toEqual({
+      direction: "column",
+      first: {
+        direction: "row",
+        first: "3d-1",
+        second: "map-1",
+        splitPercentage: 70,
+      },
+      second: "image-1",
+      splitPercentage: THREE_D_TOP_SPLIT_PERCENTAGE,
+    });
+  });
+
   it("keeps image tiles co-located in a visual bank", () => {
     expect(buildMcapAutoLayout(["image-1", "image-2", "image-3"])).toEqual({
       direction: "row",
@@ -351,6 +407,15 @@ describe("buildMcapAutoLayout", () => {
       },
       second: "image-3",
       splitPercentage: 50,
+    });
+  });
+
+  it("co-locates maps with images when no 3d tile is present", () => {
+    expect(buildMcapAutoLayout(["image-1", "map-1"])).toEqual({
+      direction: "row",
+      first: "image-1",
+      second: "map-1",
+      splitPercentage: 65,
     });
   });
 

--- a/app/packages/multimodal/src/adapters/mcap/react/playback-layout.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/playback-layout.ts
@@ -38,6 +38,7 @@ const CONTEXT_SHELF_IMAGE_SPLIT_PERCENTAGE = 65;
 
 // Mosaic leaf id of the single default 3D tile.
 const THREE_D_TILE_ID = `${MCAP_TILE_TYPE.THREE_D}-1`;
+const LOG_TILE_ID = `${MCAP_TILE_TYPE.LOG}-1`;
 
 /**
  * Device/runtime signals the layout resolver weighs. Collected once per
@@ -203,6 +204,9 @@ export function resolvePlaybackLayout({
       source.type === MCAP_SOURCE_TYPE.MAP_LAYER ||
       source.type === MCAP_SOURCE_TYPE.POSE,
   );
+  const hasLogs = sources.some(
+    (source) => source.type === MCAP_SOURCE_TYPE.LOG,
+  );
 
   const imageTileCount =
     rankedImages.length === 0
@@ -225,6 +229,13 @@ export function resolvePlaybackLayout({
       id: THREE_D_TILE_ID,
       tileType: MCAP_TILE_TYPE.THREE_D,
       title: "3D",
+    });
+  }
+  if (hasLogs) {
+    tiles.push({
+      id: LOG_TILE_ID,
+      tileType: MCAP_TILE_TYPE.LOG,
+      title: "Logs",
     });
   }
 
@@ -316,6 +327,7 @@ export function buildMcapAutoLayout(
   const images: string[] = [];
   const threeD: string[] = [];
   const plots: string[] = [];
+  const logs: string[] = [];
   const messages: string[] = [];
   const unknown: string[] = [];
 
@@ -330,6 +342,9 @@ export function buildMcapAutoLayout(
       case MCAP_TILE_TYPE.PLOT:
         plots.push(tileId);
         break;
+      case MCAP_TILE_TYPE.LOG:
+        logs.push(tileId);
+        break;
       case MCAP_TILE_TYPE.RAW:
         messages.push(tileId);
         break;
@@ -341,8 +356,8 @@ export function buildMcapAutoLayout(
 
   const threeDRegion = autoLayout(threeD);
   const supportingRegion = threeDRegion
-    ? buildContextShelf(images, plots, messages, unknown)
-    : buildNon3dLayout(images, plots, messages, unknown);
+    ? buildContextShelf(images, plots, logs, messages, unknown)
+    : buildNon3dLayout(images, plots, logs, messages, unknown);
 
   if (threeDRegion) {
     if (!supportingRegion) {
@@ -363,11 +378,12 @@ export function buildMcapAutoLayout(
 function buildNon3dLayout(
   images: readonly string[],
   plots: readonly string[],
+  logs: readonly string[],
   messages: readonly string[],
   unknown: readonly string[],
 ): MosaicNode<string> | null {
   const imageBank = autoLayout([...images]);
-  const diagnostics = buildDiagnosticsStack(plots, unknown);
+  const diagnostics = buildDiagnosticsStack(plots, logs, unknown);
   const left = stackNodes([imageBank, diagnostics], {
     direction: "column",
     splitPercentage: VISUAL_WITH_PLOTS_SPLIT_PERCENTAGE,
@@ -392,11 +408,12 @@ function buildNon3dLayout(
 function buildContextShelf(
   images: readonly string[],
   plots: readonly string[],
+  logs: readonly string[],
   messages: readonly string[],
   unknown: readonly string[],
 ): MosaicNode<string> | null {
   const imageBank = autoLayout([...images]);
-  const diagnostics = buildDiagnosticsStack(plots, unknown);
+  const diagnostics = buildDiagnosticsStack(plots, logs, unknown);
   const left = stackNodes([imageBank, diagnostics], {
     direction: "row",
     splitPercentage: CONTEXT_SHELF_IMAGE_SPLIT_PERCENTAGE,
@@ -426,10 +443,12 @@ function buildLayoutTree(
 
 function buildDiagnosticsStack(
   plots: readonly string[],
+  logs: readonly string[],
   unknown: readonly string[],
 ): MosaicNode<string> | null {
   return stackNodes([
     stackTiles(plots, "column"),
+    stackTiles(logs, "column"),
     stackTiles(unknown, "column"),
   ]);
 }

--- a/app/packages/multimodal/src/adapters/mcap/react/playback-layout.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/playback-layout.ts
@@ -32,12 +32,14 @@ const DEFAULT_VIEWPORT_WIDTH_PX = 1280;
 const DEFAULT_VIEWPORT_HEIGHT_PX = 800;
 
 const THREE_D_TOP_SPLIT_PERCENTAGE = 100 * (2 / 3);
+const THREE_D_WITH_MAP_SPLIT_PERCENTAGE = 70;
 const MESSAGE_RAIL_SPLIT_PERCENTAGE = 75;
 const VISUAL_WITH_PLOTS_SPLIT_PERCENTAGE = 70;
 const CONTEXT_SHELF_IMAGE_SPLIT_PERCENTAGE = 65;
 
 // Mosaic leaf id of the single default 3D tile.
 const THREE_D_TILE_ID = `${MCAP_TILE_TYPE.THREE_D}-1`;
+const MAP_TILE_ID = `${MCAP_TILE_TYPE.MAP}-1`;
 const LOG_TILE_ID = `${MCAP_TILE_TYPE.LOG}-1`;
 
 /**
@@ -207,6 +209,9 @@ export function resolvePlaybackLayout({
   const hasLogs = sources.some(
     (source) => source.type === MCAP_SOURCE_TYPE.LOG,
   );
+  const hasMap = sources.some(
+    (source) => source.type === MCAP_SOURCE_TYPE.LOCATION,
+  );
 
   const imageTileCount =
     rankedImages.length === 0
@@ -229,6 +234,13 @@ export function resolvePlaybackLayout({
       id: THREE_D_TILE_ID,
       tileType: MCAP_TILE_TYPE.THREE_D,
       title: "3D",
+    });
+  }
+  if (hasMap) {
+    tiles.push({
+      id: MAP_TILE_ID,
+      tileType: MCAP_TILE_TYPE.MAP,
+      title: "Map",
     });
   }
   if (hasLogs) {
@@ -316,7 +328,7 @@ function remoteNetworkBudget(downlinkMbps: number | null): number {
  * Customer-oriented MCAP arrangement:
  *
  * - images stay co-located as a camera bank
- * - 3D tiles span a full-width top region when present
+ * - 3D and map tiles share the top visual region when both are present
  * - plots stack as time-series diagnostics
  * - raw/message tiles stack as a right inspection rail
  * - unknown tile ids fall into diagnostics after known groups
@@ -326,6 +338,7 @@ export function buildMcapAutoLayout(
 ): MosaicNode<string> | null {
   const images: string[] = [];
   const threeD: string[] = [];
+  const maps: string[] = [];
   const plots: string[] = [];
   const logs: string[] = [];
   const messages: string[] = [];
@@ -338,6 +351,9 @@ export function buildMcapAutoLayout(
         break;
       case MCAP_TILE_TYPE.THREE_D:
         threeD.push(tileId);
+        break;
+      case MCAP_TILE_TYPE.MAP:
+        maps.push(tileId);
         break;
       case MCAP_TILE_TYPE.PLOT:
         plots.push(tileId);
@@ -354,19 +370,20 @@ export function buildMcapAutoLayout(
     }
   }
 
-  const threeDRegion = autoLayout(threeD);
-  const supportingRegion = threeDRegion
+  const topVisualRegion =
+    threeD.length > 0 ? buildTopVisualRegion(threeD, maps) : null;
+  const supportingRegion = topVisualRegion
     ? buildContextShelf(images, plots, logs, messages, unknown)
-    : buildNon3dLayout(images, plots, logs, messages, unknown);
+    : buildNon3dLayout(images, maps, plots, logs, messages, unknown);
 
-  if (threeDRegion) {
+  if (topVisualRegion) {
     if (!supportingRegion) {
-      return threeDRegion;
+      return topVisualRegion;
     }
 
     return {
       direction: "column",
-      first: threeDRegion,
+      first: topVisualRegion,
       second: supportingRegion,
       splitPercentage: THREE_D_TOP_SPLIT_PERCENTAGE,
     };
@@ -377,14 +394,20 @@ export function buildMcapAutoLayout(
 
 function buildNon3dLayout(
   images: readonly string[],
+  maps: readonly string[],
   plots: readonly string[],
   logs: readonly string[],
   messages: readonly string[],
   unknown: readonly string[],
 ): MosaicNode<string> | null {
   const imageBank = autoLayout([...images]);
+  const mapBank = autoLayout([...maps]);
+  const visualBank = stackNodes([imageBank, mapBank], {
+    direction: "row",
+    splitPercentage: CONTEXT_SHELF_IMAGE_SPLIT_PERCENTAGE,
+  });
   const diagnostics = buildDiagnosticsStack(plots, logs, unknown);
-  const left = stackNodes([imageBank, diagnostics], {
+  const left = stackNodes([visualBank, diagnostics], {
     direction: "column",
     splitPercentage: VISUAL_WITH_PLOTS_SPLIT_PERCENTAGE,
   });
@@ -403,6 +426,16 @@ function buildNon3dLayout(
     second: messageRail,
     splitPercentage: MESSAGE_RAIL_SPLIT_PERCENTAGE,
   };
+}
+
+function buildTopVisualRegion(
+  threeD: readonly string[],
+  maps: readonly string[],
+): MosaicNode<string> | null {
+  return stackNodes([autoLayout([...threeD]), autoLayout([...maps])], {
+    direction: "row",
+    splitPercentage: THREE_D_WITH_MAP_SPLIT_PERCENTAGE,
+  });
 }
 
 function buildContextShelf(

--- a/app/packages/multimodal/src/adapters/mcap/react/use-add-mcap-field-to-plot.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-add-mcap-field-to-plot.test.tsx
@@ -1,0 +1,145 @@
+import { TilingProvider, useTiling, type TilingTile } from "@fiftyone/tiling";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { useAtomValue } from "jotai";
+import React from "react";
+import type { MosaicNode } from "react-mosaic-component";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mcapPlotTileSeriesAtom } from "./mcap-plot-tile-state";
+import { MCAP_TILE_TYPE } from "./mcap-tile-types";
+import { useAddMcapFieldToPlot } from "./use-add-mcap-field-to-plot";
+
+vi.mock("./McapPlotTile", () => ({ default: () => null }));
+
+const Probe: React.FC = () => {
+  const addFieldToPlot = useAddMcapFieldToPlot();
+  const { focusedTileId, tiles } = useTiling();
+  const series = useAtomValue(mcapPlotTileSeriesAtom);
+
+  return (
+    <>
+      <button
+        onClick={() => addFieldToPlot("/odom", "twist.linear.x")}
+        type="button"
+      >
+        add x
+      </button>
+      <span data-testid="probe">
+        {JSON.stringify({
+          focusedTileId,
+          series,
+          types: Object.fromEntries(
+            Object.entries(tiles).map(([id, tile]) => [id, tile.type]),
+          ),
+        })}
+      </span>
+    </>
+  );
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useAddMcapFieldToPlot", () => {
+  it("adds to the first existing plot tile in layout order and focuses it", () => {
+    renderProbe({
+      initialLayout: {
+        direction: "row",
+        first: "raw-1",
+        second: {
+          direction: "column",
+          first: "plot-2",
+          second: "plot-1",
+        },
+      },
+      initialTiles: {
+        "plot-1": tile(MCAP_TILE_TYPE.PLOT),
+        "plot-2": tile(MCAP_TILE_TYPE.PLOT),
+        "raw-1": tile(MCAP_TILE_TYPE.RAW),
+      },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "add x" }));
+
+    expect(probeState()).toMatchObject({
+      focusedTileId: "plot-2",
+      series: {
+        "plot-2": [
+          {
+            fieldPath: "twist.linear.x",
+            topic: "/odom",
+          },
+        ],
+      },
+    });
+  });
+
+  it("does not duplicate a field already plotted on the target tile", () => {
+    renderProbe({
+      initialLayout: "plot-1",
+      initialTiles: {
+        "plot-1": tile(MCAP_TILE_TYPE.PLOT),
+      },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "add x" }));
+    fireEvent.click(screen.getByRole("button", { name: "add x" }));
+
+    expect(probeState().series["plot-1"]).toHaveLength(1);
+  });
+
+  it("creates and focuses a plot tile when none exists", () => {
+    renderProbe();
+
+    fireEvent.click(screen.getByRole("button", { name: "add x" }));
+
+    expect(probeState()).toMatchObject({
+      focusedTileId: "plot-1",
+      series: {
+        "plot-1": [
+          {
+            fieldPath: "twist.linear.x",
+            topic: "/odom",
+          },
+        ],
+      },
+      types: {
+        "plot-1": MCAP_TILE_TYPE.PLOT,
+      },
+    });
+  });
+});
+
+function renderProbe({
+  initialLayout,
+  initialTiles,
+}: {
+  readonly initialLayout?: MosaicNode<string> | null;
+  readonly initialTiles?: Record<string, TilingTile>;
+} = {}) {
+  return render(
+    <TilingProvider initialLayout={initialLayout} initialTiles={initialTiles}>
+      <Probe />
+    </TilingProvider>,
+  );
+}
+
+function probeState(): {
+  readonly focusedTileId: string | null;
+  readonly series: Record<
+    string,
+    readonly { readonly fieldPath: string; readonly topic: string }[]
+  >;
+  readonly types: Record<string, string>;
+} {
+  const probe = screen.getByTestId("probe");
+  return JSON.parse(probe.textContent ?? "{}");
+}
+
+function tile(type: string): TilingTile {
+  return {
+    render: () => null,
+    title: type,
+    type,
+  };
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/use-add-mcap-field-to-plot.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-add-mcap-field-to-plot.test.tsx
@@ -23,6 +23,15 @@ const Probe: React.FC = () => {
       >
         add x
       </button>
+      <button
+        onClick={() => {
+          addFieldToPlot("/odom", "twist.linear.x");
+          addFieldToPlot("/odom", "twist.linear.x");
+        }}
+        type="button"
+      >
+        add x twice
+      </button>
       <span data-testid="probe">
         {JSON.stringify({
           focusedTileId,
@@ -92,6 +101,27 @@ describe("useAddMcapFieldToPlot", () => {
     renderProbe();
 
     fireEvent.click(screen.getByRole("button", { name: "add x" }));
+
+    expect(probeState()).toMatchObject({
+      focusedTileId: "plot-1",
+      series: {
+        "plot-1": [
+          {
+            fieldPath: "twist.linear.x",
+            topic: "/odom",
+          },
+        ],
+      },
+      types: {
+        "plot-1": MCAP_TILE_TYPE.PLOT,
+      },
+    });
+  });
+
+  it("reuses a freshly created plot tile across same-tick calls", () => {
+    renderProbe();
+
+    fireEvent.click(screen.getByRole("button", { name: "add x twice" }));
 
     expect(probeState()).toMatchObject({
       focusedTileId: "plot-1",

--- a/app/packages/multimodal/src/adapters/mcap/react/use-add-mcap-field-to-plot.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-add-mcap-field-to-plot.tsx
@@ -1,0 +1,56 @@
+import { collectTileIds, useTiling } from "@fiftyone/tiling";
+import { useStore } from "jotai";
+import { useCallback } from "react";
+import type { MosaicNode } from "react-mosaic-component";
+import McapPlotTile from "./McapPlotTile";
+import {
+  addMcapPlotSeriesToTile,
+  mcapPlotTileSeriesAtom,
+} from "./mcap-plot-tile-state";
+import { MCAP_TILE_TYPE } from "./mcap-tile-types";
+
+/**
+ * Adds a raw-message numeric field to the first existing plot tile, or
+ * creates a plot tile when none exists. The created/target tile is focused.
+ */
+export function useAddMcapFieldToPlot(): (
+  topic: string,
+  fieldPath: string,
+) => void {
+  const { addTile, layout, setFocusedTileId, tiles } = useTiling();
+  const store = useStore();
+
+  return useCallback(
+    (topic, fieldPath) => {
+      let tileId = firstPlotTileId(layout, tiles);
+      if (!tileId) {
+        tileId = addTile(
+          {
+            render: () => <McapPlotTile />,
+            title: "Plot",
+            type: MCAP_TILE_TYPE.PLOT,
+          },
+          { idPrefix: MCAP_TILE_TYPE.PLOT },
+        );
+      }
+      const targetTileId = tileId;
+      setFocusedTileId(targetTileId);
+      store.set(mcapPlotTileSeriesAtom, (previous) =>
+        addMcapPlotSeriesToTile(previous, targetTileId, topic, fieldPath),
+      );
+    },
+    [addTile, layout, setFocusedTileId, store, tiles],
+  );
+}
+
+function firstPlotTileId(
+  layout: MosaicNode<string> | null,
+  tiles: Readonly<Record<string, { readonly type?: string }>>,
+): string | null {
+  for (const tileId of collectTileIds(layout)) {
+    if (tiles[tileId]?.type === MCAP_TILE_TYPE.PLOT) {
+      return tileId;
+    }
+  }
+  return null;
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/use-add-mcap-field-to-plot.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-add-mcap-field-to-plot.tsx
@@ -1,6 +1,11 @@
-import { collectTileIds, useTiling } from "@fiftyone/tiling";
-import { useStore } from "jotai";
-import { useCallback } from "react";
+import {
+  addTileToLayout,
+  collectTileIds,
+  useTiling,
+  type TilingTile,
+} from "@fiftyone/tiling";
+import { useSetAtom } from "jotai";
+import { useCallback, useRef } from "react";
 import type { MosaicNode } from "react-mosaic-component";
 import McapPlotTile from "./McapPlotTile";
 import {
@@ -17,35 +22,48 @@ export function useAddMcapFieldToPlot(): (
   topic: string,
   fieldPath: string,
 ) => void {
-  const { addTile, layout, setFocusedTileId, tiles } = useTiling();
-  const store = useStore();
+  const { addTile, focusedTileId, layout, setFocusedTileId, tiles } =
+    useTiling();
+  const setPlotTileSeries = useSetAtom(mcapPlotTileSeriesAtom);
+  const stateRef = useRef({ focusedTileId, layout, tiles });
+  stateRef.current = { focusedTileId, layout, tiles };
 
   return useCallback(
     (topic, fieldPath) => {
-      let tileId = firstPlotTileId(layout, tiles);
+      const current = stateRef.current;
+      let tileId = firstPlotTileId(current.layout, current.tiles);
       if (!tileId) {
-        tileId = addTile(
-          {
-            render: () => <McapPlotTile />,
-            title: "Plot",
-            type: MCAP_TILE_TYPE.PLOT,
-          },
-          { idPrefix: MCAP_TILE_TYPE.PLOT },
-        );
+        const tile: TilingTile = {
+          render: () => <McapPlotTile />,
+          title: "Plot",
+          type: MCAP_TILE_TYPE.PLOT,
+        };
+        tileId = addTile(tile, { idPrefix: MCAP_TILE_TYPE.PLOT });
+        stateRef.current = {
+          layout: addTileToLayout(
+            current.layout,
+            tileId,
+            current.focusedTileId,
+          ),
+          tiles: { ...current.tiles, [tileId]: tile },
+          focusedTileId: tileId,
+        };
       }
       const targetTileId = tileId;
       setFocusedTileId(targetTileId);
-      store.set(mcapPlotTileSeriesAtom, (previous) =>
+      setPlotTileSeries((previous) =>
         addMcapPlotSeriesToTile(previous, targetTileId, topic, fieldPath),
       );
     },
-    [addTile, layout, setFocusedTileId, store, tiles],
+    // setPlotTileSeries is a stable useSetAtom setter; omitted from deps.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [addTile, setFocusedTileId],
   );
 }
 
 function firstPlotTileId(
   layout: MosaicNode<string> | null,
-  tiles: Readonly<Record<string, { readonly type?: string }>>,
+  tiles: Readonly<Record<string, TilingTile>>,
 ): string | null {
   for (const tileId of collectTileIds(layout)) {
     if (tiles[tileId]?.type === MCAP_TILE_TYPE.PLOT) {

--- a/app/packages/multimodal/src/adapters/mcap/react/use-interpolated-scene-updates.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-interpolated-scene-updates.ts
@@ -48,8 +48,8 @@ export function useInterpolatedSceneUpdateFrames({
   // lerp even while the playhead is paused mid-gap.
   const cacheSnapshot = useTopicCacheSnapshot(dataStream, topics);
 
-  return useMemo(() => {
-    const resolvedFrames = frames.map((playbackFrame, index) => {
+  const resolvedFrames = useMemo(() => {
+    return frames.map((playbackFrame, index) => {
       const topic = topics[index];
       if (!playbackFrame || !topic) {
         return playbackFrame;
@@ -72,7 +72,10 @@ export function useInterpolatedSceneUpdateFrames({
         frame: sceneUpdateSnapshotAt(deltas, playbackFrame.requestedTimeNs),
       };
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- cacheSnapshot is the caches' change digest
+  }, [cacheSnapshot, dataStream, frames, history, topics]);
 
+  return useMemo(() => {
     if (!interpolate || !dataStream || !timeline) {
       return resolvedFrames;
     }
@@ -143,15 +146,13 @@ export function useInterpolatedSceneUpdateFrames({
       };
     });
 
-    return changed ? interpolated : frames;
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- cacheSnapshot is the caches' change digest
+    return changed ? interpolated : resolvedFrames;
   }, [
-    cacheSnapshot,
     dataStream,
-    frames,
     history,
     interpolate,
     playhead,
+    resolvedFrames,
     timeline,
     topics,
   ]);

--- a/app/packages/multimodal/src/adapters/mcap/react/use-interpolated-scene-updates.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-interpolated-scene-updates.ts
@@ -55,12 +55,13 @@ export function useInterpolatedSceneUpdateFrames({
         return playbackFrame;
       }
       const cache = dataStream?.getTopicCache(topic) ?? null;
+      const historyTopic = history.get(topic);
       const deltas = sceneUpdateDeltasForTopic({
         cache,
         fallbackFrame: playbackFrame.frame,
         fallbackTimeNs: playbackFrame.contentTimeNs,
-        historyDeltas: history.get(topic)?.deltas,
-        historyReady: history.get(topic)?.status === "ready",
+        historyDeltas: historyTopic?.deltas,
+        historyReady: historyTopic?.status === "ready",
         targetTimeNs: playbackFrame.requestedTimeNs,
       });
       if (deltas.length === 0) {
@@ -110,12 +111,13 @@ export function useInterpolatedSceneUpdateFrames({
       if (!nextViz) {
         return playbackFrame;
       }
+      const historyTopic = history.get(topic);
       const nextDeltas = sceneUpdateDeltasForTopic({
         cache,
         fallbackFrame: nextViz,
         fallbackTimeNs: nextMsg.timelineTimeNs,
-        historyDeltas: history.get(topic)?.deltas,
-        historyReady: history.get(topic)?.status === "ready",
+        historyDeltas: historyTopic?.deltas,
+        historyReady: historyTopic?.status === "ready",
         targetTimeNs: nextMsg.timelineTimeNs,
       });
       const nextFrame =

--- a/app/packages/multimodal/src/adapters/mcap/react/use-interpolated-scene-updates.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-interpolated-scene-updates.ts
@@ -6,6 +6,12 @@ import type { McapDecodedMessage } from "../types";
 import { interpolationFraction } from "./interpolate-image-annotations";
 import { interpolateSceneUpdate } from "./interpolate-scene-entities";
 import { useMcapDataStream } from "./mcap-data-stream-context";
+import { useMcapSceneUpdateHistoryContext } from "./mcap-scene-update-history-context";
+import {
+  sceneUpdateSnapshotAt,
+  type McapSceneUpdateDelta,
+} from "./mcap-scene-update-state";
+import type { McapTopicCache } from "./mcap-topic-cache";
 import {
   nextDistinctCachedMessage,
   useTopicCacheSnapshot,
@@ -34,29 +40,51 @@ export function useInterpolatedSceneUpdateFrames({
   readonly topics: readonly string[];
 }): readonly (McapTopicPlaybackFrame<SceneUpdateVisualization> | null)[] {
   const dataStream = useMcapDataStream();
+  const history = useMcapSceneUpdateHistoryContext();
   // Re-render every RAF tick so the lerp tracks the playhead.
   const playhead = usePlayhead();
   const timeline = dataStream?.getTimelineIndex() ?? null;
-  // Late-arriving lookahead messages must re-derive the lerp even while the
-  // playhead is paused mid-gap.
-  const cacheSnapshot = useTopicCacheSnapshot(
-    interpolate ? dataStream : null,
-    topics,
-  );
+  // Late-arriving lookahead messages must re-derive the lifecycle snapshot and
+  // lerp even while the playhead is paused mid-gap.
+  const cacheSnapshot = useTopicCacheSnapshot(dataStream, topics);
 
   return useMemo(() => {
+    const resolvedFrames = frames.map((playbackFrame, index) => {
+      const topic = topics[index];
+      if (!playbackFrame || !topic) {
+        return playbackFrame;
+      }
+      const cache = dataStream?.getTopicCache(topic) ?? null;
+      const deltas = sceneUpdateDeltasForTopic({
+        cache,
+        fallbackFrame: playbackFrame.frame,
+        fallbackTimeNs: playbackFrame.contentTimeNs,
+        historyDeltas: history.get(topic)?.deltas,
+        historyReady: history.get(topic)?.status === "ready",
+        targetTimeNs: playbackFrame.requestedTimeNs,
+      });
+      if (deltas.length === 0) {
+        return playbackFrame;
+      }
+
+      return {
+        ...playbackFrame,
+        frame: sceneUpdateSnapshotAt(deltas, playbackFrame.requestedTimeNs),
+      };
+    });
+
     if (!interpolate || !dataStream || !timeline) {
-      return frames;
+      return resolvedFrames;
     }
 
     const currentTick = timeline.nearestTick(playhead);
     if (currentTick === undefined) {
-      return frames;
+      return resolvedFrames;
     }
     const playheadNs = timeline.secToNs(playhead);
 
     let changed = false;
-    const interpolated = frames.map((playbackFrame, index) => {
+    const interpolated = resolvedFrames.map((playbackFrame, index) => {
       const topic = topics[index];
       if (!playbackFrame || !topic) {
         return playbackFrame;
@@ -79,6 +107,18 @@ export function useInterpolatedSceneUpdateFrames({
       if (!nextViz) {
         return playbackFrame;
       }
+      const nextDeltas = sceneUpdateDeltasForTopic({
+        cache,
+        fallbackFrame: nextViz,
+        fallbackTimeNs: nextMsg.timelineTimeNs,
+        historyDeltas: history.get(topic)?.deltas,
+        historyReady: history.get(topic)?.status === "ready",
+        targetTimeNs: nextMsg.timelineTimeNs,
+      });
+      const nextFrame =
+        nextDeltas.length > 0
+          ? sceneUpdateSnapshotAt(nextDeltas, nextMsg.timelineTimeNs)
+          : nextViz;
 
       const f = interpolationFraction({
         nextTimelineTimeNs: nextMsg.timelineTimeNs,
@@ -96,7 +136,7 @@ export function useInterpolatedSceneUpdateFrames({
         contentTimeNs: playheadNs,
         frame: interpolateSceneUpdate(
           playbackFrame.frame,
-          nextViz,
+          nextFrame,
           f,
           playheadNs,
         ),
@@ -109,11 +149,68 @@ export function useInterpolatedSceneUpdateFrames({
     cacheSnapshot,
     dataStream,
     frames,
+    history,
     interpolate,
     playhead,
     timeline,
     topics,
   ]);
+}
+
+function sceneUpdateDeltasForTopic({
+  cache,
+  fallbackFrame,
+  fallbackTimeNs,
+  historyDeltas,
+  historyReady,
+  targetTimeNs,
+}: {
+  readonly cache: McapTopicCache | null;
+  readonly fallbackFrame: SceneUpdateVisualization;
+  readonly fallbackTimeNs: bigint;
+  readonly historyDeltas: readonly McapSceneUpdateDelta[] | undefined;
+  readonly historyReady: boolean;
+  readonly targetTimeNs: bigint;
+}): readonly McapSceneUpdateDelta[] {
+  if (historyReady && historyDeltas) {
+    return historyDeltas;
+  }
+
+  const cachedDeltas = cachedSceneUpdateDeltas(cache, targetTimeNs);
+  if (cachedDeltas.length > 0) {
+    return cachedDeltas;
+  }
+
+  return [{ timeNs: fallbackTimeNs, update: fallbackFrame }];
+}
+
+function cachedSceneUpdateDeltas(
+  cache: McapTopicCache | null,
+  targetTimeNs: bigint,
+): readonly McapSceneUpdateDelta[] {
+  if (!cache) {
+    return [];
+  }
+
+  const deltas: McapSceneUpdateDelta[] = [];
+  const seenMessages = new Set<string>();
+  for (const tick of cache.cachedTicks()) {
+    const msg = cache.get(tick);
+    if (!msg || msg.timelineTimeNs > targetTimeNs) {
+      continue;
+    }
+    const update = sceneUpdateOf(msg);
+    if (!update) {
+      continue;
+    }
+    const key = `${msg.channelId}:${msg.sequence}:${msg.timelineTimeNs}`;
+    if (seenMessages.has(key)) {
+      continue;
+    }
+    seenMessages.add(key);
+    deltas.push({ timeNs: msg.timelineTimeNs, update });
+  }
+  return deltas;
 }
 
 function sceneUpdateOf(

--- a/app/packages/multimodal/src/adapters/mcap/react/use-mcap-modal-layout.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-mcap-modal-layout.test.tsx
@@ -358,6 +358,29 @@ describe("useMcapModalLayout", () => {
     });
   });
 
+  it("uses resolver defaults for a never-seen dataset", () => {
+    writeMcapModalLayout(
+      {
+        layout: {
+          direction: "row",
+          first: "image-1",
+          second: "3d-1",
+          splitPercentage: 20,
+        },
+      },
+      "dataset-a",
+    );
+
+    const { result } = renderLayoutHook(SCENE_SOURCES, "dataset-b");
+
+    expect(result.current.initialLayout).toMatchObject({
+      direction: "column",
+      first: "3d-1",
+      second: "image-1",
+    });
+    expect(result.current.defaultLeftOpen).toBe(true);
+  });
+
   it("restores the persisted sidebar width", () => {
     writeMcapModalLayout({ sidebarWidthPx: 480 }, "dataset-a");
     const { result } = renderLayoutHook(SCENE_SOURCES, "dataset-a");

--- a/app/packages/multimodal/src/adapters/mcap/react/use-mcap-modal-layout.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-mcap-modal-layout.test.tsx
@@ -22,6 +22,7 @@ vi.mock("./McapImageTile", () => ({
   ),
 }));
 vi.mock("./Mcap3dTile", () => ({ default: () => null }));
+vi.mock("./McapMapTile", () => ({ default: () => null }));
 
 const SCENE_SOURCES: readonly SceneSource[] = [
   { id: "/cam/image_rect_compressed", type: "image", label: "cam" },

--- a/app/packages/multimodal/src/adapters/mcap/react/use-mcap-modal-layout.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-mcap-modal-layout.tsx
@@ -21,6 +21,11 @@ import {
   type McapPersistedModalLayout,
 } from "./mcap-layout-persistence";
 import {
+  DEFAULT_MCAP_MAP_TILE_SETTINGS,
+  mcapMapTileSettingsAtom,
+  type McapMapTileSettings,
+} from "./mcap-map-tile-state";
+import {
   mcapPlotTileSeriesAtom,
   type McapPlotSeriesConfig,
 } from "./mcap-plot-tile-state";
@@ -379,6 +384,38 @@ export function McapModalLayoutPersistence({
     store,
   });
 
+  const seededMapKeyRef = useRef<string | null>(null);
+  useEffect(() => {
+    const persisted = readMcapModalLayout(datasetIdRef.current)?.mapSettings;
+    if (persisted) {
+      store.set(mcapMapTileSettingsAtom, (previous) => {
+        const next = { ...previous };
+        for (const [tileId, settings] of Object.entries(persisted)) {
+          if (!(tileId in tilesRef.current) || next[tileId]) continue;
+          next[tileId] = settings;
+        }
+        return next;
+      });
+    }
+    seededMapKeyRef.current = JSON.stringify(
+      store.get(mcapMapTileSettingsAtom),
+    );
+  }, [store]);
+
+  const mapSettingsPatch = useCallback(
+    (value: Readonly<Record<string, McapMapTileSettings>>) => ({
+      mapSettings: compactMapSettings(value),
+    }),
+    [],
+  );
+  useDebouncedMcapLayoutAtomMirror({
+    atom: mcapMapTileSettingsAtom,
+    datasetIdRef,
+    patchForValue: mapSettingsPatch,
+    seededKeyRef: seededMapKeyRef,
+    store,
+  });
+
   // Write only after the layout actually changes from what this mount
   // started with. Restores can be PRUNED views of the saved arrangement
   // (e.g. an image-only sample drops the 3D leaf); persisting one without
@@ -495,6 +532,31 @@ function compactPlotSeries(
     }
   }
   return compact;
+}
+
+function compactMapSettings(
+  value: Readonly<Record<string, McapMapTileSettings>>,
+): Record<string, McapMapTileSettings> | undefined {
+  const compact: Record<string, McapMapTileSettings> = {};
+  for (const [tileId, settings] of Object.entries(value)) {
+    const baseLayer =
+      settings.baseLayer ?? DEFAULT_MCAP_MAP_TILE_SETTINGS.baseLayer;
+    const isDefault =
+      baseLayer === DEFAULT_MCAP_MAP_TILE_SETTINGS.baseLayer &&
+      settings.followEgo === DEFAULT_MCAP_MAP_TILE_SETTINGS.followEgo &&
+      settings.enabledTopics === undefined;
+    if (isDefault) {
+      continue;
+    }
+    compact[tileId] = {
+      baseLayer,
+      followEgo: settings.followEgo,
+      ...(settings.enabledTopics !== undefined
+        ? { enabledTopics: settings.enabledTopics }
+        : {}),
+    };
+  }
+  return Object.keys(compact).length > 0 ? compact : undefined;
 }
 
 /**

--- a/app/packages/multimodal/src/adapters/mcap/react/use-mcap-modal-layout.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-mcap-modal-layout.tsx
@@ -56,8 +56,9 @@ export interface UseMcapModalLayoutOptions {
   sources: readonly SceneSource[];
   /**
    * Persistence scope — `ctx.dataset.datasetId` (stable across dataset
-   * renames, unlike the name). Absent, reads/writes hit only the
-   * browser-wide fallback entry.
+   * renames, unlike the name) for the sample renderer, or an MCAP source key
+   * for the explorer. Absent, reads/writes hit only the browser-wide fallback
+   * entry.
    */
   datasetId?: string;
   /** Source locality hint; tightens the default tile budget when remote. */

--- a/app/packages/multimodal/src/adapters/mcap/react/use-mcap-modal-layout.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-mcap-modal-layout.tsx
@@ -1,5 +1,5 @@
 import { collectTileIds, useTiling, type TilingTile } from "@fiftyone/tiling";
-import { useStore, type Atom } from "jotai";
+import { useStore, type Atom, type PrimitiveAtom } from "jotai";
 import React, {
   useCallback,
   useEffect,
@@ -321,42 +321,24 @@ export function McapModalLayoutPersistence({
   const tilesRef = useRef(tiles);
   tilesRef.current = tiles;
 
-  // This effect seeds the plot-series atom once per mount from the
-  // persisted dataset entry — persistence is an external system.
-  useEffect(() => {
-    const persisted = readMcapModalLayout(datasetIdRef.current)?.plotSeries;
-    if (persisted) {
-      store.set(mcapPlotTileSeriesAtom, (previous) => {
-        const next = { ...previous };
-        for (const [tileId, series] of Object.entries(persisted)) {
-          if (!(tileId in tilesRef.current) || next[tileId]) continue;
-          next[tileId] = series;
-        }
-        return next;
-      });
-    }
-    seededPlotKeyRef.current = JSON.stringify(
-      store.get(mcapPlotTileSeriesAtom),
-    );
-  }, [store]);
+  useSeedPersistedTileAtom({
+    atom: mcapPlotTileSeriesAtom,
+    datasetIdRef,
+    field: "plotSeries",
+    seededKeyRef: seededPlotKeyRef,
+    store,
+    tilesRef,
+  });
 
-  // This effect seeds the raw-tile topic atom once per mount from the
-  // persisted dataset entry — same contract as the plot series above.
   const seededRawKeyRef = useRef<string | null>(null);
-  useEffect(() => {
-    const persisted = readMcapModalLayout(datasetIdRef.current)?.rawTopics;
-    if (persisted) {
-      store.set(mcapRawTileTopicAtom, (previous) => {
-        const next = { ...previous };
-        for (const [tileId, topic] of Object.entries(persisted)) {
-          if (!(tileId in tilesRef.current) || next[tileId]) continue;
-          next[tileId] = topic;
-        }
-        return next;
-      });
-    }
-    seededRawKeyRef.current = JSON.stringify(store.get(mcapRawTileTopicAtom));
-  }, [store]);
+  useSeedPersistedTileAtom({
+    atom: mcapRawTileTopicAtom,
+    datasetIdRef,
+    field: "rawTopics",
+    seededKeyRef: seededRawKeyRef,
+    store,
+    tilesRef,
+  });
 
   const plotSeriesPatch = useCallback(
     (value: Readonly<Record<string, readonly McapPlotSeriesConfig[]>>) => ({
@@ -385,22 +367,14 @@ export function McapModalLayoutPersistence({
   });
 
   const seededMapKeyRef = useRef<string | null>(null);
-  useEffect(() => {
-    const persisted = readMcapModalLayout(datasetIdRef.current)?.mapSettings;
-    if (persisted) {
-      store.set(mcapMapTileSettingsAtom, (previous) => {
-        const next = { ...previous };
-        for (const [tileId, settings] of Object.entries(persisted)) {
-          if (!(tileId in tilesRef.current) || next[tileId]) continue;
-          next[tileId] = settings;
-        }
-        return next;
-      });
-    }
-    seededMapKeyRef.current = JSON.stringify(
-      store.get(mcapMapTileSettingsAtom),
-    );
-  }, [store]);
+  useSeedPersistedTileAtom({
+    atom: mcapMapTileSettingsAtom,
+    datasetIdRef,
+    field: "mapSettings",
+    seededKeyRef: seededMapKeyRef,
+    store,
+    tilesRef,
+  });
 
   const mapSettingsPatch = useCallback(
     (value: Readonly<Record<string, McapMapTileSettings>>) => ({
@@ -557,6 +531,49 @@ function compactMapSettings(
     };
   }
   return Object.keys(compact).length > 0 ? compact : undefined;
+}
+
+type PersistedTileAtomField = "mapSettings" | "plotSeries" | "rawTopics";
+
+/**
+ * Seeds tile-scoped atoms from the dataset entry once per modal mount.
+ * Persistence is external state, so the effect intentionally owns the
+ * read/seed boundary while callers provide the field-specific atom.
+ */
+function useSeedPersistedTileAtom<TileValue>({
+  atom,
+  datasetIdRef,
+  field,
+  seededKeyRef,
+  store,
+  tilesRef,
+}: {
+  readonly atom: PrimitiveAtom<Readonly<Record<string, TileValue>>>;
+  readonly datasetIdRef: React.MutableRefObject<string | undefined>;
+  readonly field: PersistedTileAtomField;
+  readonly seededKeyRef: React.MutableRefObject<string | null>;
+  readonly store: ReturnType<typeof useStore>;
+  readonly tilesRef: React.MutableRefObject<Record<string, TilingTile>>;
+}) {
+  useEffect(() => {
+    const persisted = readMcapModalLayout(datasetIdRef.current)?.[field] as
+      | Readonly<Record<string, TileValue>>
+      | undefined;
+    if (persisted) {
+      store.set(atom, (previous) => {
+        const next = { ...previous };
+        for (const [tileId, value] of Object.entries(persisted) as [
+          string,
+          TileValue,
+        ][]) {
+          if (!(tileId in tilesRef.current) || next[tileId]) continue;
+          next[tileId] = value;
+        }
+        return next;
+      });
+    }
+    seededKeyRef.current = JSON.stringify(store.get(atom));
+  }, [atom, datasetIdRef, field, seededKeyRef, store, tilesRef]);
 }
 
 /**

--- a/app/packages/multimodal/src/adapters/mcap/react/use-mcap-tiles.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-mcap-tiles.ts
@@ -4,6 +4,7 @@ import { useEffect } from "react";
 import { MCAP_SOURCE_TYPE } from "../scene-sources";
 import Mcap3dTile from "./Mcap3dTile";
 import McapImageTile from "./McapImageTile";
+import McapLogConsoleTile from "./McapLogConsoleTile";
 import McapPlotTile from "./McapPlotTile";
 import McapRawMessageTile from "./McapRawMessageTile";
 import {
@@ -36,6 +37,12 @@ const TILE_BY_TYPE: Record<
     icon: IconName.GridView,
     Tile: McapImageTile,
     sourceTypes: [MCAP_SOURCE_TYPE.IMAGE],
+  },
+  [MCAP_TILE_TYPE.LOG]: {
+    typeLabel: "Logs",
+    icon: IconName.Logs,
+    Tile: McapLogConsoleTile,
+    sourceTypes: [MCAP_SOURCE_TYPE.LOG],
   },
   [MCAP_TILE_TYPE.THREE_D]: {
     typeLabel: "3D",

--- a/app/packages/multimodal/src/adapters/mcap/react/use-mcap-tiles.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-mcap-tiles.ts
@@ -5,6 +5,7 @@ import { MCAP_SOURCE_TYPE } from "../scene-sources";
 import Mcap3dTile from "./Mcap3dTile";
 import McapImageTile from "./McapImageTile";
 import McapLogConsoleTile from "./McapLogConsoleTile";
+import McapMapTile from "./McapMapTile";
 import McapPlotTile from "./McapPlotTile";
 import McapRawMessageTile from "./McapRawMessageTile";
 import {
@@ -43,6 +44,12 @@ const TILE_BY_TYPE: Record<
     icon: IconName.Logs,
     Tile: McapLogConsoleTile,
     sourceTypes: [MCAP_SOURCE_TYPE.LOG],
+  },
+  [MCAP_TILE_TYPE.MAP]: {
+    typeLabel: "Map",
+    icon: IconName.Polyline,
+    Tile: McapMapTile,
+    sourceTypes: [MCAP_SOURCE_TYPE.LOCATION],
   },
   [MCAP_TILE_TYPE.THREE_D]: {
     typeLabel: "3D",

--- a/app/packages/multimodal/src/adapters/mcap/react/use-open-mcap-raw-message-tile.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-open-mcap-raw-message-tile.test.tsx
@@ -1,0 +1,185 @@
+import { TilingProvider, useTiling, type TilingTile } from "@fiftyone/tiling";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { useAtomValue, useSetAtom } from "jotai";
+import React, { useEffect } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  mcapRawTileTopicAtom,
+  type McapRawTileTopics,
+} from "./mcap-raw-tile-state";
+import { MCAP_TILE_TYPE } from "./mcap-tile-types";
+import { useOpenMcapRawMessageTile } from "./use-open-mcap-raw-message-tile";
+
+const Probe: React.FC<{ readonly seedTopics?: McapRawTileTopics }> = ({
+  seedTopics,
+}) => {
+  const openRawMessageTile = useOpenMcapRawMessageTile();
+  const { focusedTileId, tiles } = useTiling();
+  const topicsByTile = useAtomValue(mcapRawTileTopicAtom);
+
+  return (
+    <>
+      {seedTopics ? <SeedTopics topics={seedTopics} /> : null}
+      <button onClick={() => openRawMessageTile("/imu")} type="button">
+        open imu
+      </button>
+      <button
+        onClick={() => {
+          openRawMessageTile("/imu");
+          openRawMessageTile("/imu");
+        }}
+        type="button"
+      >
+        open imu twice
+      </button>
+      <span data-testid="probe">
+        {JSON.stringify({
+          focusedTileId,
+          titles: Object.fromEntries(
+            Object.entries(tiles).map(([id, tile]) => [id, tile.title]),
+          ),
+          topicsByTile,
+          types: Object.fromEntries(
+            Object.entries(tiles).map(([id, tile]) => [id, tile.type]),
+          ),
+        })}
+      </span>
+    </>
+  );
+};
+
+const SeedTopics: React.FC<{ readonly topics: McapRawTileTopics }> = ({
+  topics,
+}) => {
+  const setTopics = useSetAtom(mcapRawTileTopicAtom);
+  useEffect(() => {
+    setTopics(topics);
+  }, [setTopics, topics]);
+  return null;
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useOpenMcapRawMessageTile", () => {
+  it("focuses an already-open raw tile for the topic", async () => {
+    renderProbe({
+      initialTiles: {
+        "raw-1": tile(MCAP_TILE_TYPE.RAW),
+        "raw-2": tile(MCAP_TILE_TYPE.RAW),
+      },
+      seedTopics: { "raw-2": "/imu" },
+    });
+    await waitFor(() =>
+      expect(probeState().topicsByTile).toMatchObject({ "raw-2": "/imu" }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "open imu" }));
+
+    expect(probeState()).toMatchObject({
+      focusedTileId: "raw-2",
+      topicsByTile: { "raw-2": "/imu" },
+    });
+  });
+
+  it("reuses an empty raw tile", () => {
+    renderProbe({
+      initialTiles: {
+        "raw-1": tile(MCAP_TILE_TYPE.RAW),
+      },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "open imu" }));
+
+    expect(probeState()).toMatchObject({
+      focusedTileId: "raw-1",
+      titles: { "raw-1": "/imu" },
+      topicsByTile: { "raw-1": "/imu" },
+    });
+  });
+
+  it("skips occupied raw tiles and reuses the first empty one", async () => {
+    renderProbe({
+      initialTiles: {
+        "raw-1": tile(MCAP_TILE_TYPE.RAW),
+        "raw-2": tile(MCAP_TILE_TYPE.RAW),
+      },
+      seedTopics: { "raw-1": "/gps" },
+    });
+    await waitFor(() =>
+      expect(probeState().topicsByTile).toMatchObject({ "raw-1": "/gps" }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "open imu" }));
+
+    expect(probeState()).toMatchObject({
+      focusedTileId: "raw-2",
+      titles: { "raw-2": "/imu" },
+      topicsByTile: { "raw-1": "/gps", "raw-2": "/imu" },
+    });
+  });
+
+  it("creates a raw tile when no raw tile is available", () => {
+    renderProbe();
+
+    fireEvent.click(screen.getByRole("button", { name: "open imu" }));
+
+    expect(probeState()).toMatchObject({
+      focusedTileId: "raw-1",
+      titles: { "raw-1": "/imu" },
+      topicsByTile: { "raw-1": "/imu" },
+      types: { "raw-1": MCAP_TILE_TYPE.RAW },
+    });
+  });
+
+  it("reuses a freshly created raw tile across same-tick calls", () => {
+    renderProbe();
+
+    fireEvent.click(screen.getByRole("button", { name: "open imu twice" }));
+
+    expect(probeState()).toMatchObject({
+      focusedTileId: "raw-1",
+      topicsByTile: { "raw-1": "/imu" },
+      types: { "raw-1": MCAP_TILE_TYPE.RAW },
+    });
+  });
+});
+
+function renderProbe({
+  initialTiles,
+  seedTopics,
+}: {
+  readonly initialTiles?: Record<string, TilingTile>;
+  readonly seedTopics?: McapRawTileTopics;
+} = {}) {
+  return render(
+    <TilingProvider initialTiles={initialTiles}>
+      <Probe seedTopics={seedTopics} />
+    </TilingProvider>,
+  );
+}
+
+function probeState(): {
+  readonly focusedTileId: string | null;
+  readonly titles: Record<string, string>;
+  readonly topicsByTile: McapRawTileTopics;
+  readonly types: Record<string, string>;
+} {
+  const probe = screen.getByTestId("probe");
+  return JSON.parse(probe.textContent ?? "{}");
+}
+
+function tile(type: string): TilingTile {
+  return {
+    render: () => null,
+    title: type,
+    type,
+  };
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/use-open-mcap-raw-message-tile.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-open-mcap-raw-message-tile.tsx
@@ -1,0 +1,74 @@
+import { useTiling } from "@fiftyone/tiling";
+import { useAtomValue, useStore } from "jotai";
+import { useCallback } from "react";
+import {
+  mcapRawTileTopicAtom,
+  type McapRawTileTopics,
+} from "./mcap-raw-tile-state";
+import { MCAP_TILE_TYPE } from "./mcap-tile-types";
+import { getMcapTileDefinition } from "./use-mcap-tiles";
+
+/**
+ * Opens a Message panel for a topic: focus an existing matching raw tile,
+ * reuse an empty raw tile, or create a new raw tile with the topic preselected.
+ */
+export function useOpenMcapRawMessageTile(): (topic: string) => void {
+  const { addTile, setFocusedTileId, tiles } = useTiling();
+  const topicsByTile = useAtomValue(mcapRawTileTopicAtom);
+  const store = useStore();
+
+  return useCallback(
+    (topic: string) => {
+      if (!topic) {
+        return;
+      }
+
+      const rawTileIds = Object.keys(tiles).filter(
+        (tileId) => tiles[tileId]?.type === MCAP_TILE_TYPE.RAW,
+      );
+      const matchingTileId = rawTileIds.find(
+        (tileId) => topicsByTile[tileId] === topic,
+      );
+      if (matchingTileId) {
+        setFocusedTileId(matchingTileId);
+        return;
+      }
+
+      const emptyTileId = rawTileIds.find((tileId) => !topicsByTile[tileId]);
+      if (emptyTileId) {
+        setRawTileTopic(store, emptyTileId, topic);
+        setFocusedTileId(emptyTileId);
+        return;
+      }
+
+      const definition = getMcapTileDefinition(MCAP_TILE_TYPE.RAW);
+      if (!definition) {
+        return;
+      }
+      const Tile = definition.Tile;
+      const tileId = addTile(
+        {
+          render: () => <Tile />,
+          title: topic,
+          type: MCAP_TILE_TYPE.RAW,
+        },
+        { idPrefix: MCAP_TILE_TYPE.RAW },
+      );
+      setRawTileTopic(store, tileId, topic);
+    },
+    [addTile, setFocusedTileId, store, tiles, topicsByTile],
+  );
+}
+
+function setRawTileTopic(
+  store: ReturnType<typeof useStore>,
+  tileId: string,
+  topic: string,
+): void {
+  store.set(mcapRawTileTopicAtom, (previous: McapRawTileTopics) => {
+    if (previous[tileId] === topic) {
+      return previous;
+    }
+    return { ...previous, [tileId]: topic };
+  });
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/use-open-mcap-raw-message-tile.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-open-mcap-raw-message-tile.tsx
@@ -1,6 +1,6 @@
-import { useTiling } from "@fiftyone/tiling";
-import { useAtomValue, useStore } from "jotai";
-import { useCallback } from "react";
+import { useTiling, type TilingTile } from "@fiftyone/tiling";
+import { useAtomValue, useSetAtom } from "jotai";
+import { useCallback, useRef } from "react";
 import {
   mcapRawTileTopicAtom,
   type McapRawTileTopics,
@@ -13,9 +13,11 @@ import { getMcapTileDefinition } from "./use-mcap-tiles";
  * reuse an empty raw tile, or create a new raw tile with the topic preselected.
  */
 export function useOpenMcapRawMessageTile(): (topic: string) => void {
-  const { addTile, setFocusedTileId, tiles } = useTiling();
+  const { addTile, setFocusedTileId, setTileTitle, tiles } = useTiling();
   const topicsByTile = useAtomValue(mcapRawTileTopicAtom);
-  const store = useStore();
+  const setTopicsByTile = useSetAtom(mcapRawTileTopicAtom);
+  const stateRef = useRef({ tiles, topicsByTile });
+  stateRef.current = { tiles, topicsByTile };
 
   return useCallback(
     (topic: string) => {
@@ -23,20 +25,41 @@ export function useOpenMcapRawMessageTile(): (topic: string) => void {
         return;
       }
 
-      const rawTileIds = Object.keys(tiles).filter(
-        (tileId) => tiles[tileId]?.type === MCAP_TILE_TYPE.RAW,
+      const current = stateRef.current;
+      const rawTileIds = Object.keys(current.tiles).filter(
+        (tileId) => current.tiles[tileId]?.type === MCAP_TILE_TYPE.RAW,
       );
       const matchingTileId = rawTileIds.find(
-        (tileId) => topicsByTile[tileId] === topic,
+        (tileId) => current.topicsByTile[tileId] === topic,
       );
       if (matchingTileId) {
         setFocusedTileId(matchingTileId);
         return;
       }
 
-      const emptyTileId = rawTileIds.find((tileId) => !topicsByTile[tileId]);
+      const emptyTileId = rawTileIds.find(
+        (tileId) => !current.topicsByTile[tileId],
+      );
       if (emptyTileId) {
-        setRawTileTopic(store, emptyTileId, topic);
+        const nextTopics = setRawTileTopic(
+          current.topicsByTile,
+          emptyTileId,
+          topic,
+        );
+        const emptyTile = current.tiles[emptyTileId];
+        stateRef.current = {
+          tiles: emptyTile
+            ? {
+                ...current.tiles,
+                [emptyTileId]: { ...emptyTile, title: topic },
+              }
+            : current.tiles,
+          topicsByTile: nextTopics,
+        };
+        setTopicsByTile((previous) =>
+          setRawTileTopic(previous, emptyTileId, topic),
+        );
+        setTileTitle(emptyTileId, topic, { source: "auto" });
         setFocusedTileId(emptyTileId);
         return;
       }
@@ -46,29 +69,33 @@ export function useOpenMcapRawMessageTile(): (topic: string) => void {
         return;
       }
       const Tile = definition.Tile;
-      const tileId = addTile(
-        {
-          render: () => <Tile />,
-          title: topic,
-          type: MCAP_TILE_TYPE.RAW,
-        },
-        { idPrefix: MCAP_TILE_TYPE.RAW },
-      );
-      setRawTileTopic(store, tileId, topic);
+      const tile: TilingTile = {
+        render: () => <Tile />,
+        title: topic,
+        type: MCAP_TILE_TYPE.RAW,
+      };
+      const tileId = addTile(tile, { idPrefix: MCAP_TILE_TYPE.RAW });
+      const nextTopics = setRawTileTopic(current.topicsByTile, tileId, topic);
+      stateRef.current = {
+        tiles: { ...current.tiles, [tileId]: tile },
+        topicsByTile: nextTopics,
+      };
+      setTopicsByTile((previous) => setRawTileTopic(previous, tileId, topic));
+      setFocusedTileId(tileId);
     },
-    [addTile, setFocusedTileId, store, tiles, topicsByTile],
+    // setTopicsByTile is a stable useSetAtom setter; omitted from deps.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [addTile, setFocusedTileId, setTileTitle],
   );
 }
 
 function setRawTileTopic(
-  store: ReturnType<typeof useStore>,
+  previous: McapRawTileTopics,
   tileId: string,
   topic: string,
-): void {
-  store.set(mcapRawTileTopicAtom, (previous: McapRawTileTopics) => {
-    if (previous[tileId] === topic) {
-      return previous;
-    }
-    return { ...previous, [tileId]: topic };
-  });
+): McapRawTileTopics {
+  if (previous[tileId] === topic) {
+    return previous;
+  }
+  return { ...previous, [tileId]: topic };
 }

--- a/app/packages/multimodal/src/adapters/mcap/react/use-register-mcap-data-stream.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-register-mcap-data-stream.test.tsx
@@ -346,6 +346,46 @@ describe("stream status + buffering feedback", () => {
     });
   });
 
+  it("starts playback without buffering when no playback topics are active", async () => {
+    const source = createSource("source");
+    const storeCapture = capturePlaybackStore();
+    let api: ReturnType<typeof usePlayback> | undefined;
+    const client = createClient({
+      readSynchronizedMessageBatch: vi.fn(async () => []),
+      readTimelineRange: vi.fn(async () => createTimelineRange()),
+    });
+
+    render(
+      <PlaybackProvider duration={0}>
+        <McapDataStreamProvider>
+          <Harness
+            client={client}
+            onApi={(value) => {
+              api = value;
+            }}
+            onStore={storeCapture.onStore}
+            source={source}
+            subscribe={false}
+          />
+        </McapDataStreamProvider>
+      </PlaybackProvider>,
+    );
+    const store = storeCapture.store();
+
+    act(() => {
+      api?.play();
+    });
+    expect(getIsPlaying(store)).toBe(false);
+    expect(getIsPlayPending(store)).toBe(true);
+
+    await waitFor(() => {
+      expect(getIsPlaying(store)).toBe(true);
+      expect(getIsPlayPending(store)).toBe(false);
+      expect(getIsBuffering(store)).toBe(false);
+    });
+    expect(client.readSynchronizedMessageBatch).not.toHaveBeenCalled();
+  });
+
   it("warms paused lookahead after the startup window is covered", async () => {
     const source = createSource("source");
     const startupBatch = deferred<readonly McapSynchronizedMessageWindow[]>();

--- a/app/packages/multimodal/src/adapters/mcap/react/use-register-mcap-data-stream.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-register-mcap-data-stream.ts
@@ -1814,10 +1814,14 @@ export function useRegisterMcapDataStream({
       // evaluation, so the getters keep the required runway (and the window
       // its pending prefetches fill) sized to live link throughput. On
       // healthy links both resolve to the static policy floor.
+      // Message-only layouts have no playback-topic caches to warm, so
+      // report zero runway instead of waiting on empty buffered ranges.
       get lookaheadSeconds() {
+        if (getActiveBlockingTopics().length === 0) return 0;
         return resolveStartupCushion().cushionSeconds;
       },
       get startupBufferSeconds() {
+        if (getActiveBlockingTopics().length === 0) return 0;
         return resolveStartupCushion().cushionSeconds;
       },
       bufferedRanges: computeBufferedRanges,

--- a/app/packages/multimodal/src/adapters/mcap/react/wgs84.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/wgs84.ts
@@ -1,0 +1,55 @@
+/**
+ * Minimal WGS84 spherical math shared by the map tile's route and
+ * measurement features.
+ */
+
+export interface GeoPoint {
+  readonly latitude: number;
+  readonly longitude: number;
+}
+
+const MEAN_EARTH_RADIUS_M = 6_371_008.8;
+
+export function degreesToRadians(degrees: number): number {
+  return degrees * (Math.PI / 180);
+}
+
+export function radiansToDegrees(radians: number): number {
+  return radians * (180 / Math.PI);
+}
+
+/**
+ * Initial great-circle bearing from `from` to `to`, in degrees clockwise
+ * from north, or `undefined` for coincident points.
+ */
+export function bearingDegrees(
+  from: GeoPoint,
+  to: GeoPoint,
+): number | undefined {
+  if (from.latitude === to.latitude && from.longitude === to.longitude) {
+    return undefined;
+  }
+  const lat1 = degreesToRadians(from.latitude);
+  const lat2 = degreesToRadians(to.latitude);
+  const deltaLon = degreesToRadians(to.longitude - from.longitude);
+  const y = Math.sin(deltaLon) * Math.cos(lat2);
+  const x =
+    Math.cos(lat1) * Math.sin(lat2) -
+    Math.sin(lat1) * Math.cos(lat2) * Math.cos(deltaLon);
+  return (radiansToDegrees(Math.atan2(y, x)) + 360) % 360;
+}
+
+/** Great-circle (haversine) distance in meters on the mean-radius sphere. */
+export function haversineDistanceMeters(a: GeoPoint, b: GeoPoint): number {
+  const latA = degreesToRadians(a.latitude);
+  const latB = degreesToRadians(b.latitude);
+  const deltaLat = degreesToRadians(b.latitude - a.latitude);
+  const deltaLon = degreesToRadians(b.longitude - a.longitude);
+  const sinHalfLat = Math.sin(deltaLat / 2);
+  const sinHalfLon = Math.sin(deltaLon / 2);
+  const h =
+    sinHalfLat * sinHalfLat +
+    Math.cos(latA) * Math.cos(latB) * sinHalfLon * sinHalfLon;
+
+  return 2 * MEAN_EARTH_RADIUS_M * Math.atan2(Math.sqrt(h), Math.sqrt(1 - h));
+}

--- a/app/packages/multimodal/src/adapters/mcap/resources/inline.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/resources/inline.test.ts
@@ -88,6 +88,29 @@ float64 x
 float64 y
 float64 z
 float64 w`;
+const FOXGLOVE_ROS2_FRAME_TRANSFORMS_SCHEMA = `foxglove_msgs/FrameTransform[] transforms
+===
+MSG: foxglove_msgs/FrameTransform
+builtin_interfaces/Time timestamp
+string parent_frame_id
+string child_frame_id
+foxglove_msgs/Vector3 translation
+foxglove_msgs/Quaternion rotation
+===
+MSG: foxglove_msgs/Vector3
+float64 x
+float64 y
+float64 z
+===
+MSG: foxglove_msgs/Quaternion
+float64 x
+float64 y
+float64 z
+float64 w
+===
+MSG: builtin_interfaces/Time
+int32 sec
+uint32 nanosec`;
 const ROS2_IDL_TF_MESSAGE_SCHEMA = `module tf2_msgs {
   module msg {
     struct TFMessage {
@@ -987,6 +1010,76 @@ describe("MCAP resources", () => {
       timeNs: 9_000_000_030n,
     });
     expect(set.samples[0]?.translation.toArray()).toEqual([4, 5, 6]);
+  });
+
+  it("reads foxglove_msgs cdr FrameTransforms samples from dynamic frame transform windows", async () => {
+    const readMessages = vi.fn(async function* () {
+      yield createMessage(
+        foxgloveRos2FrameTransforms({
+          transforms: [
+            {
+              child_frame_id: "lidar",
+              parent_frame_id: "map",
+              rotation: { w: 1, x: 0, y: 0, z: 0 },
+              timestamp: { nanosec: 40, sec: 8 },
+              translation: { x: 1, y: 2, z: 3 },
+            },
+          ],
+        }),
+        {
+          channelId: 10,
+          logTime: 8_000_000_040n,
+        },
+      );
+    });
+    const client = createInlineMcapResourceClient({
+      byteClient: { readBytes: vi.fn() },
+      decodeClient: createTestDecodeClient(),
+      readerFactory: vi.fn(async () =>
+        createReader({
+          channelsById: new Map([
+            [
+              10,
+              createChannel({
+                id: 10,
+                messageEncoding: "cdr",
+                schemaId: 10,
+                topic: "/tf",
+              }),
+            ],
+          ]),
+          readMessages,
+          schemasById: new Map([
+            [
+              10,
+              createSchema(
+                new TextEncoder().encode(FOXGLOVE_ROS2_FRAME_TRANSFORMS_SCHEMA),
+                {
+                  encoding: "ros2msg",
+                  id: 10,
+                  name: "foxglove_msgs/msg/FrameTransforms",
+                },
+              ),
+            ],
+          ]),
+        }),
+      ),
+    });
+
+    const set = await client.readFrameTransformWindow({
+      endTimeNs: 8_000_000_040n,
+      source: createMcapSourceDescriptor(),
+      startTimeNs: 8_000_000_040n,
+    });
+
+    expect(set.samples).toHaveLength(1);
+    expect(set.samples[0]).toMatchObject({
+      childFrameId: "lidar",
+      parentFrameId: "map",
+      timeNs: 8_000_000_040n,
+    });
+    expect(set.samples[0]?.rotation.toArray()).toEqual([0, 0, 0, 1]);
+    expect(set.samples[0]?.translation.toArray()).toEqual([1, 2, 3]);
   });
 
   it("skips malformed ROS TFMessage payloads without failing the window", async () => {
@@ -2214,6 +2307,17 @@ function ros1TfMessage(record: Record<string, unknown>): Uint8Array {
 function ros2TfMessage(record: Record<string, unknown>): Uint8Array {
   const writer = new Ros2MessageWriter(
     parseRosMessageDefinition(ROS2_TF_MESSAGE_SCHEMA, { ros2: true }),
+  );
+  return writer.writeMessage(record);
+}
+
+function foxgloveRos2FrameTransforms(
+  record: Record<string, unknown>,
+): Uint8Array {
+  const writer = new Ros2MessageWriter(
+    parseRosMessageDefinition(FOXGLOVE_ROS2_FRAME_TRANSFORMS_SCHEMA, {
+      ros2: true,
+    }),
   );
   return writer.writeMessage(record);
 }

--- a/app/packages/multimodal/src/adapters/mcap/resources/inline.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/resources/inline.test.ts
@@ -88,6 +88,26 @@ float64 x
 float64 y
 float64 z
 float64 w`;
+const FOXGLOVE_ROS2_FRAME_TRANSFORM_SCHEMA = `builtin_interfaces/Time timestamp
+string parent_frame_id
+string child_frame_id
+foxglove_msgs/Vector3 translation
+foxglove_msgs/Quaternion rotation
+===
+MSG: foxglove_msgs/Vector3
+float64 x
+float64 y
+float64 z
+===
+MSG: foxglove_msgs/Quaternion
+float64 x
+float64 y
+float64 z
+float64 w
+===
+MSG: builtin_interfaces/Time
+int32 sec
+uint32 nanosec`;
 const FOXGLOVE_ROS2_FRAME_TRANSFORMS_SCHEMA = `foxglove_msgs/FrameTransform[] transforms
 ===
 MSG: foxglove_msgs/FrameTransform
@@ -1080,6 +1100,72 @@ describe("MCAP resources", () => {
     });
     expect(set.samples[0]?.rotation.toArray()).toEqual([0, 0, 0, 1]);
     expect(set.samples[0]?.translation.toArray()).toEqual([1, 2, 3]);
+  });
+
+  it("reads foxglove_msgs cdr FrameTransform samples from dynamic frame transform windows", async () => {
+    const readMessages = vi.fn(async function* () {
+      yield createMessage(
+        foxgloveRos2FrameTransform({
+          child_frame_id: "camera",
+          parent_frame_id: "map",
+          rotation: { w: 1, x: 0, y: 0, z: 0 },
+          timestamp: { nanosec: 50, sec: 8 },
+          translation: { x: 4, y: 5, z: 6 },
+        }),
+        {
+          channelId: 10,
+          logTime: 8_000_000_050n,
+        },
+      );
+    });
+    const client = createInlineMcapResourceClient({
+      byteClient: { readBytes: vi.fn() },
+      decodeClient: createTestDecodeClient(),
+      readerFactory: vi.fn(async () =>
+        createReader({
+          channelsById: new Map([
+            [
+              10,
+              createChannel({
+                id: 10,
+                messageEncoding: "cdr",
+                schemaId: 10,
+                topic: "/tf",
+              }),
+            ],
+          ]),
+          readMessages,
+          schemasById: new Map([
+            [
+              10,
+              createSchema(
+                new TextEncoder().encode(FOXGLOVE_ROS2_FRAME_TRANSFORM_SCHEMA),
+                {
+                  encoding: "ros2msg",
+                  id: 10,
+                  name: "foxglove_msgs/msg/FrameTransform",
+                },
+              ),
+            ],
+          ]),
+        }),
+      ),
+    });
+
+    const set = await client.readFrameTransformWindow({
+      endTimeNs: 8_000_000_050n,
+      source: createMcapSourceDescriptor(),
+      startTimeNs: 8_000_000_050n,
+    });
+
+    expect(set.samples).toHaveLength(1);
+    expect(set.samples[0]).toMatchObject({
+      childFrameId: "camera",
+      parentFrameId: "map",
+      timeNs: 8_000_000_050n,
+    });
+    expect(set.samples[0]?.rotation.toArray()).toEqual([0, 0, 0, 1]);
+    expect(set.samples[0]?.translation.toArray()).toEqual([4, 5, 6]);
   });
 
   it("skips malformed ROS TFMessage payloads without failing the window", async () => {
@@ -2316,6 +2402,17 @@ function foxgloveRos2FrameTransforms(
 ): Uint8Array {
   const writer = new Ros2MessageWriter(
     parseRosMessageDefinition(FOXGLOVE_ROS2_FRAME_TRANSFORMS_SCHEMA, {
+      ros2: true,
+    }),
+  );
+  return writer.writeMessage(record);
+}
+
+function foxgloveRos2FrameTransform(
+  record: Record<string, unknown>,
+): Uint8Array {
+  const writer = new Ros2MessageWriter(
+    parseRosMessageDefinition(FOXGLOVE_ROS2_FRAME_TRANSFORM_SCHEMA, {
       ros2: true,
     }),
   );

--- a/app/packages/multimodal/src/adapters/mcap/resources/numeric-fields.ts
+++ b/app/packages/multimodal/src/adapters/mcap/resources/numeric-fields.ts
@@ -66,8 +66,8 @@ const ROS_NUMERIC_SCALAR_TYPES: ReadonlySet<string> = new Set([
 
 /**
  * Enumerates numeric leaf field paths of a protobufjs message type in
- * declaration order. Repeated and map fields are skipped (v1 plots
- * scalars only); nested messages recurse up to `MAX_FIELD_DEPTH` with a
+ * declaration order. Repeated and map fields are skipped because plots use
+ * scalar series; nested messages recurse up to `MAX_FIELD_DEPTH` with a
  * cycle guard for self-referential schemas.
  */
 export function walkProtobufNumericFields(
@@ -80,8 +80,8 @@ export function walkProtobufNumericFields(
 
 /**
  * Enumerates numeric leaf field paths of parsed ROS message definitions.
- * Arrays are skipped to match the v1 scalar-only plot contract; nested
- * complex fields recurse up to `MAX_FIELD_DEPTH` with a cycle guard.
+ * Arrays are skipped to match the scalar-only plot contract; nested complex
+ * fields recurse up to `MAX_FIELD_DEPTH` with a cycle guard.
  */
 export function walkRosNumericFields(
   definitions: readonly RosMessageDefinition[],

--- a/app/packages/multimodal/src/adapters/mcap/resources/read-frame-transforms.ts
+++ b/app/packages/multimodal/src/adapters/mcap/resources/read-frame-transforms.ts
@@ -33,6 +33,9 @@ import {
 import type { McapReadFrameTransformWindowRequest } from "../types";
 
 const PROTOBUF_ENCODING = "protobuf";
+const FOXGLOVE_FRAME_TRANSFORM_CDR_SCHEMA = "foxglove_msgs/msg/FrameTransform";
+const FOXGLOVE_FRAME_TRANSFORMS_CDR_SCHEMA =
+  "foxglove_msgs/msg/FrameTransforms";
 const FOXGLOVE_FRAME_TRANSFORMS_SCHEMA = "foxglove.FrameTransforms";
 const TF_MESSAGE_BATCH_FIELD = "transforms";
 
@@ -47,6 +50,12 @@ const ROS_TF_MESSAGE_SCHEMAS: ReadonlySet<string> = new Set([
 const ROS_TRANSFORM_STAMPED_SCHEMAS: ReadonlySet<string> = new Set([
   "geometry_msgs/TransformStamped",
   "geometry_msgs/msg/TransformStamped",
+]);
+const FOXGLOVE_CDR_TRANSFORM_SCHEMAS: ReadonlySet<string> = new Set([
+  FOXGLOVE_FRAME_TRANSFORM_CDR_SCHEMA,
+]);
+const FOXGLOVE_CDR_TRANSFORMS_SCHEMAS: ReadonlySet<string> = new Set([
+  FOXGLOVE_FRAME_TRANSFORMS_CDR_SCHEMA,
 ]);
 
 type FrameTransformSchemaMatch =
@@ -612,9 +621,29 @@ function classifyRosFrameTransformSchema(
 ): FrameTransformSchemaMatch | null {
   const definitions = rosMessageDefinitionsForChannel(reader, channel);
   const root = definitions ? rootRosMessageDefinition(definitions) : undefined;
-  if (!root || !isRosTfMessageSchema(schema, root)) {
+  if (!root) {
     return null;
   }
+
+  if (isFoxgloveCdrFrameTransformSchema(schema, root)) {
+    return {
+      format: "foxglove",
+      kind: "single",
+    };
+  }
+
+  if (isFoxgloveCdrFrameTransformsSchema(schema, root)) {
+    return {
+      format: "foxglove",
+      kind: "batch",
+      repeatedFieldName: "transforms",
+    };
+  }
+
+  if (!isRosTfMessageSchema(schema, root)) {
+    return null;
+  }
+
   const transformsField = root.definitions.find(
     (field) => field.name === TF_MESSAGE_BATCH_FIELD,
   );
@@ -641,6 +670,28 @@ function isRosTfMessageSchema(
     ROS_TF_MESSAGE_SCHEMAS.has(schema.name) ||
     (definition.name !== undefined &&
       ROS_TF_MESSAGE_SCHEMAS.has(definition.name))
+  );
+}
+
+function isFoxgloveCdrFrameTransformSchema(
+  schema: McapSchema,
+  definition: RosMessageDefinition,
+): boolean {
+  return (
+    FOXGLOVE_CDR_TRANSFORM_SCHEMAS.has(schema.name) ||
+    (definition.name !== undefined &&
+      FOXGLOVE_CDR_TRANSFORM_SCHEMAS.has(definition.name))
+  );
+}
+
+function isFoxgloveCdrFrameTransformsSchema(
+  schema: McapSchema,
+  definition: RosMessageDefinition,
+): boolean {
+  return (
+    FOXGLOVE_CDR_TRANSFORMS_SCHEMAS.has(schema.name) ||
+    (definition.name !== undefined &&
+      FOXGLOVE_CDR_TRANSFORMS_SCHEMAS.has(definition.name))
   );
 }
 

--- a/app/packages/multimodal/src/adapters/mcap/scene-sources.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/scene-sources.test.ts
@@ -29,7 +29,12 @@ describe("mcapSceneSources", () => {
       createTopic("/odom", "Pose", "json", "jsonschema"),
       createTopic("/gps", "foxglove.LocationFix"),
       createTopic("/tf", "foxglove.FrameTransform"),
-      createTopic("/diagnostics", "diagnostic_msgs/DiagnosticArray", "ros1"),
+      createTopic(
+        "/diagnostics",
+        "diagnostic_msgs/DiagnosticArray",
+        "ros1",
+        "ros1msg",
+      ),
     ]);
 
     expect(sources).toEqual([
@@ -102,6 +107,11 @@ describe("mcapSceneSources", () => {
         id: "/gps",
         type: MCAP_SOURCE_TYPE.LOCATION,
         label: "gps",
+      },
+      {
+        id: "/diagnostics",
+        type: MCAP_SOURCE_TYPE.LOG,
+        label: "diagnostics",
       },
     ]);
   });
@@ -225,6 +235,12 @@ describe("mcapStreamPolicies", () => {
         createTopic("/markers/annotations", "foxglove.SceneUpdate"),
         createTopic("/lidar", "foxglove.PointCloud"),
         createTopic("/map", "foxglove.Grid"),
+        createTopic(
+          "/diagnostics",
+          "diagnostic_msgs/DiagnosticArray",
+          "ros1",
+          "ros1msg",
+        ),
       ]),
     );
 
@@ -245,6 +261,9 @@ describe("mcapStreamPolicies", () => {
     // A one-shot static /map stays resolvable for the whole run through the
     // same unbounded lookback.
     expect(policies["/map"]).toEqual({
+      mode: PlaybackSyncMode.LATEST,
+    });
+    expect(policies["/diagnostics"]).toEqual({
       mode: PlaybackSyncMode.LATEST,
     });
   });

--- a/app/packages/multimodal/src/adapters/mcap/scene-sources.ts
+++ b/app/packages/multimodal/src/adapters/mcap/scene-sources.ts
@@ -92,7 +92,7 @@ export function mcapSceneSources(
     if (!id) {
       continue;
     }
-    const type = sourceTypeFor(topic);
+    const type = mcapSourceTypeForTopic(topic);
     if (!type) {
       continue;
     }
@@ -144,7 +144,9 @@ export function mcapStreamPolicies(
   return policies;
 }
 
-function sourceTypeFor(topic: StreamInventory): McapSourceType | null {
+export function mcapSourceTypeForTopic(
+  topic: StreamInventory,
+): McapSourceType | null {
   if (isImageStream(topic)) {
     return MCAP_SOURCE_TYPE.IMAGE;
   }

--- a/app/packages/multimodal/src/adapters/mcap/scene-sources.ts
+++ b/app/packages/multimodal/src/adapters/mcap/scene-sources.ts
@@ -6,6 +6,7 @@ import {
   isImageAnnotationsStream,
   isImageStream,
   isLocationFixStream,
+  isLogStream,
   isPointCloudStream,
   isPoseStream,
   isSceneUpdateStream,
@@ -31,6 +32,8 @@ export const MCAP_SOURCE_TYPE = {
   // Foxglove LocationFix topics: geographic fixes surfaced as telemetry
   // readouts (and, later, map panels); never a standalone tile.
   LOCATION: "location",
+  // Log and diagnostics topics: console-shaped streams rendered in a log tile.
+  LOG: "log",
   // Foxglove Grid topics: 2D data grids rendered as textured ground/map
   // planes in the 3D scene. Named "map-layer" rather than "grid" because
   // "grid" already means the FiftyOne sample grid throughout the app.
@@ -60,6 +63,7 @@ const SYNC_POLICY_BY_TYPE: Record<McapSourceType, McapStreamSyncPolicy> = {
   [MCAP_SOURCE_TYPE.IMAGE]: LATEST_SYNC_POLICY,
   [MCAP_SOURCE_TYPE.IMAGE_ANNOTATION]: LATEST_SYNC_POLICY,
   [MCAP_SOURCE_TYPE.LOCATION]: LATEST_SYNC_POLICY,
+  [MCAP_SOURCE_TYPE.LOG]: LATEST_SYNC_POLICY,
   // Unbounded lookback is what makes static maps work: a one-shot /map
   // message published at file start stays resolvable for the whole run.
   [MCAP_SOURCE_TYPE.MAP_LAYER]: LATEST_SYNC_POLICY,
@@ -164,6 +168,9 @@ function sourceTypeFor(topic: StreamInventory): McapSourceType | null {
   }
   if (isLocationFixStream(topic)) {
     return MCAP_SOURCE_TYPE.LOCATION;
+  }
+  if (isLogStream(topic)) {
+    return MCAP_SOURCE_TYPE.LOG;
   }
   return null;
 }

--- a/app/packages/multimodal/src/adapters/mcap/stream-topics.ts
+++ b/app/packages/multimodal/src/adapters/mcap/stream-topics.ts
@@ -6,6 +6,8 @@ import {
   JSON_ROS_COMPRESSED_IMAGE_PAYLOADS,
   JSON_ROS_IMAGE_PAYLOADS,
   JSON_ROS_LASER_SCAN_PAYLOADS,
+  JSON_ROS_MARKER_ARRAY_PAYLOADS,
+  JSON_ROS_MARKER_PAYLOADS,
   JSON_ROS_NAV_SAT_FIX_PAYLOADS,
   JSON_ROS_OCCUPANCY_GRID_PAYLOADS,
   JSON_ROS_ODOMETRY_PAYLOADS,
@@ -30,6 +32,8 @@ import {
   ROS_COMPRESSED_IMAGE_PAYLOADS,
   ROS_IMAGE_PAYLOADS,
   ROS_LASER_SCAN_PAYLOADS,
+  ROS_MARKER_ARRAY_PAYLOADS,
+  ROS_MARKER_PAYLOADS,
   ROS_NAV_SAT_FIX_PAYLOADS,
   ROS_OCCUPANCY_GRID_PAYLOADS,
   ROS_ODOMETRY_PAYLOADS,
@@ -144,7 +148,13 @@ export function isPointCloudStream(topic: StreamInventory): boolean {
  * Returns whether a stream inventory item is a supported Foxglove SceneUpdate stream.
  */
 export function isSceneUpdateStream(topic: StreamInventory): boolean {
-  return hasPayload(topic, FOXGLOVE_SCENE_UPDATE_PAYLOAD);
+  return (
+    hasPayload(topic, FOXGLOVE_SCENE_UPDATE_PAYLOAD) ||
+    hasAnyPayload(topic, JSON_ROS_MARKER_PAYLOADS) ||
+    hasAnyPayload(topic, JSON_ROS_MARKER_ARRAY_PAYLOADS) ||
+    hasAnyPayload(topic, ROS_MARKER_PAYLOADS) ||
+    hasAnyPayload(topic, ROS_MARKER_ARRAY_PAYLOADS)
+  );
 }
 
 /**

--- a/app/packages/multimodal/src/adapters/mcap/stream-topics.ts
+++ b/app/packages/multimodal/src/adapters/mcap/stream-topics.ts
@@ -11,7 +11,9 @@ import {
   JSON_ROS_NAV_SAT_FIX_PAYLOADS,
   JSON_ROS_OCCUPANCY_GRID_PAYLOADS,
   JSON_ROS_ODOMETRY_PAYLOADS,
+  JSON_ROS_PATH_PAYLOADS,
   JSON_ROS_POINT_CLOUD2_PAYLOADS,
+  JSON_ROS_POSE_ARRAY_PAYLOADS,
   JSON_ROS_POSE_STAMPED_PAYLOADS,
 } from "./decoders/json/payloads";
 import {
@@ -46,7 +48,9 @@ import {
   ROS_NAV_SAT_FIX_PAYLOADS,
   ROS_OCCUPANCY_GRID_PAYLOADS,
   ROS_ODOMETRY_PAYLOADS,
+  ROS_PATH_PAYLOADS,
   ROS_POINT_CLOUD2_PAYLOADS,
+  ROS_POSE_ARRAY_PAYLOADS,
   ROS_POSE_STAMPED_PAYLOADS,
 } from "./decoders/ros/payloads";
 
@@ -169,8 +173,12 @@ export function isSceneUpdateStream(topic: StreamInventory): boolean {
     hasAnyPayload(topic, FOXGLOVE_SCENE_UPDATE_CDR_PAYLOADS) ||
     hasAnyPayload(topic, JSON_ROS_MARKER_PAYLOADS) ||
     hasAnyPayload(topic, JSON_ROS_MARKER_ARRAY_PAYLOADS) ||
+    hasAnyPayload(topic, JSON_ROS_PATH_PAYLOADS) ||
+    hasAnyPayload(topic, JSON_ROS_POSE_ARRAY_PAYLOADS) ||
     hasAnyPayload(topic, ROS_MARKER_PAYLOADS) ||
-    hasAnyPayload(topic, ROS_MARKER_ARRAY_PAYLOADS)
+    hasAnyPayload(topic, ROS_MARKER_ARRAY_PAYLOADS) ||
+    hasAnyPayload(topic, ROS_PATH_PAYLOADS) ||
+    hasAnyPayload(topic, ROS_POSE_ARRAY_PAYLOADS)
   );
 }
 

--- a/app/packages/multimodal/src/adapters/mcap/stream-topics.ts
+++ b/app/packages/multimodal/src/adapters/mcap/stream-topics.ts
@@ -29,7 +29,9 @@ import {
   FOXGLOVE_COMPRESSED_VIDEO_CDR_PAYLOADS,
   FOXGLOVE_COMPRESSED_VIDEO_PAYLOAD,
   FOXGLOVE_FRAME_TRANSFORM_CDR_PAYLOADS,
+  FOXGLOVE_FRAME_TRANSFORM_PAYLOAD,
   FOXGLOVE_FRAME_TRANSFORMS_CDR_PAYLOADS,
+  FOXGLOVE_FRAME_TRANSFORMS_PAYLOAD,
   FOXGLOVE_GRID_CDR_PAYLOADS,
   FOXGLOVE_GRID_PAYLOAD,
   FOXGLOVE_IMAGE_ANNOTATIONS_CDR_PAYLOADS,
@@ -66,56 +68,9 @@ import {
   ROS_POSE_STAMPED_PAYLOADS,
   ROS_RCL_LOG_PAYLOADS,
   ROS_ROSGRAPH_LOG_PAYLOADS,
+  ROS_TF_MESSAGE_PAYLOADS,
+  ROS_TRANSFORM_STAMPED_PAYLOADS,
 } from "./decoders/ros/payloads";
-
-const FOXGLOVE_FRAME_TRANSFORM_PAYLOADS: readonly PayloadDescriptor[] = [
-  {
-    encoding: "protobuf",
-    schema: "foxglove.FrameTransform",
-    schemaEncoding: "protobuf",
-  },
-  {
-    encoding: "protobuf",
-    schema: "foxglove.FrameTransforms",
-    schemaEncoding: "protobuf",
-  },
-];
-
-const ROS_TF_MESSAGE_PAYLOADS: readonly PayloadDescriptor[] = [
-  {
-    encoding: "ros1",
-    schema: "tf2_msgs/TFMessage",
-    schemaEncoding: "ros1msg",
-  },
-  {
-    encoding: "cdr",
-    schema: "tf2_msgs/msg/TFMessage",
-    schemaEncoding: "ros2msg",
-  },
-  {
-    encoding: "cdr",
-    schema: "tf2_msgs/msg/TFMessage",
-    schemaEncoding: "ros2idl",
-  },
-];
-
-const ROS_TRANSFORM_STAMPED_PAYLOADS: readonly PayloadDescriptor[] = [
-  {
-    encoding: "ros1",
-    schema: "geometry_msgs/TransformStamped",
-    schemaEncoding: "ros1msg",
-  },
-  {
-    encoding: "cdr",
-    schema: "geometry_msgs/msg/TransformStamped",
-    schemaEncoding: "ros2msg",
-  },
-  {
-    encoding: "cdr",
-    schema: "geometry_msgs/msg/TransformStamped",
-    schemaEncoding: "ros2idl",
-  },
-];
 
 /**
  * Supported MCAP topics that the adapter can preview or pair.
@@ -331,7 +286,8 @@ export function isLogStream(topic: StreamInventory): boolean {
  */
 export function isFrameTransformStream(topic: StreamInventory): boolean {
   return (
-    hasAnyPayload(topic, FOXGLOVE_FRAME_TRANSFORM_PAYLOADS) ||
+    hasPayload(topic, FOXGLOVE_FRAME_TRANSFORM_PAYLOAD) ||
+    hasPayload(topic, FOXGLOVE_FRAME_TRANSFORMS_PAYLOAD) ||
     hasAnyPayload(topic, FOXGLOVE_FRAME_TRANSFORM_CDR_PAYLOADS) ||
     hasAnyPayload(topic, FOXGLOVE_FRAME_TRANSFORMS_CDR_PAYLOADS) ||
     hasAnyPayload(topic, ROS_TF_MESSAGE_PAYLOADS) ||

--- a/app/packages/multimodal/src/adapters/mcap/stream-topics.ts
+++ b/app/packages/multimodal/src/adapters/mcap/stream-topics.ts
@@ -28,6 +28,8 @@ import {
   FOXGLOVE_COMPRESSED_IMAGE_PAYLOAD,
   FOXGLOVE_COMPRESSED_VIDEO_CDR_PAYLOADS,
   FOXGLOVE_COMPRESSED_VIDEO_PAYLOAD,
+  FOXGLOVE_FRAME_TRANSFORM_CDR_PAYLOADS,
+  FOXGLOVE_FRAME_TRANSFORMS_CDR_PAYLOADS,
   FOXGLOVE_GRID_CDR_PAYLOADS,
   FOXGLOVE_GRID_PAYLOAD,
   FOXGLOVE_IMAGE_ANNOTATIONS_CDR_PAYLOADS,
@@ -65,6 +67,55 @@ import {
   ROS_RCL_LOG_PAYLOADS,
   ROS_ROSGRAPH_LOG_PAYLOADS,
 } from "./decoders/ros/payloads";
+
+const FOXGLOVE_FRAME_TRANSFORM_PAYLOADS: readonly PayloadDescriptor[] = [
+  {
+    encoding: "protobuf",
+    schema: "foxglove.FrameTransform",
+    schemaEncoding: "protobuf",
+  },
+  {
+    encoding: "protobuf",
+    schema: "foxglove.FrameTransforms",
+    schemaEncoding: "protobuf",
+  },
+];
+
+const ROS_TF_MESSAGE_PAYLOADS: readonly PayloadDescriptor[] = [
+  {
+    encoding: "ros1",
+    schema: "tf2_msgs/TFMessage",
+    schemaEncoding: "ros1msg",
+  },
+  {
+    encoding: "cdr",
+    schema: "tf2_msgs/msg/TFMessage",
+    schemaEncoding: "ros2msg",
+  },
+  {
+    encoding: "cdr",
+    schema: "tf2_msgs/msg/TFMessage",
+    schemaEncoding: "ros2idl",
+  },
+];
+
+const ROS_TRANSFORM_STAMPED_PAYLOADS: readonly PayloadDescriptor[] = [
+  {
+    encoding: "ros1",
+    schema: "geometry_msgs/TransformStamped",
+    schemaEncoding: "ros1msg",
+  },
+  {
+    encoding: "cdr",
+    schema: "geometry_msgs/msg/TransformStamped",
+    schemaEncoding: "ros2msg",
+  },
+  {
+    encoding: "cdr",
+    schema: "geometry_msgs/msg/TransformStamped",
+    schemaEncoding: "ros2idl",
+  },
+];
 
 /**
  * Supported MCAP topics that the adapter can preview or pair.
@@ -270,6 +321,21 @@ export function isLogStream(topic: StreamInventory): boolean {
     hasAnyPayload(topic, ROS_ROSGRAPH_LOG_PAYLOADS) ||
     hasAnyPayload(topic, ROS_RCL_LOG_PAYLOADS) ||
     hasAnyPayload(topic, ROS_DIAGNOSTIC_ARRAY_PAYLOADS)
+  );
+}
+
+/**
+ * Returns whether a stream inventory item can feed the 3D frame-transform
+ * resolver. Transform topics are not scene sources themselves; they support
+ * placement of renderable streams discovered elsewhere.
+ */
+export function isFrameTransformStream(topic: StreamInventory): boolean {
+  return (
+    hasAnyPayload(topic, FOXGLOVE_FRAME_TRANSFORM_PAYLOADS) ||
+    hasAnyPayload(topic, FOXGLOVE_FRAME_TRANSFORM_CDR_PAYLOADS) ||
+    hasAnyPayload(topic, FOXGLOVE_FRAME_TRANSFORMS_CDR_PAYLOADS) ||
+    hasAnyPayload(topic, ROS_TF_MESSAGE_PAYLOADS) ||
+    hasAnyPayload(topic, ROS_TRANSFORM_STAMPED_PAYLOADS)
   );
 }
 

--- a/app/packages/multimodal/src/adapters/mcap/stream-topics.ts
+++ b/app/packages/multimodal/src/adapters/mcap/stream-topics.ts
@@ -15,16 +15,25 @@ import {
   JSON_ROS_POSE_STAMPED_PAYLOADS,
 } from "./decoders/json/payloads";
 import {
+  FOXGLOVE_CAMERA_CALIBRATION_CDR_PAYLOADS,
   FOXGLOVE_CAMERA_CALIBRATION_PAYLOAD,
+  FOXGLOVE_COMPRESSED_IMAGE_CDR_PAYLOADS,
   FOXGLOVE_COMPRESSED_IMAGE_PAYLOAD,
   FOXGLOVE_COMPRESSED_VIDEO_CDR_PAYLOADS,
   FOXGLOVE_COMPRESSED_VIDEO_PAYLOAD,
+  FOXGLOVE_GRID_CDR_PAYLOADS,
   FOXGLOVE_GRID_PAYLOAD,
+  FOXGLOVE_IMAGE_ANNOTATIONS_CDR_PAYLOADS,
+  FOXGLOVE_LASER_SCAN_CDR_PAYLOADS,
   FOXGLOVE_LASER_SCAN_PAYLOAD,
+  FOXGLOVE_LOCATION_FIX_CDR_PAYLOADS,
   FOXGLOVE_LOCATION_FIX_PAYLOAD,
+  FOXGLOVE_POINT_CLOUD_CDR_PAYLOADS,
+  FOXGLOVE_POSE_IN_FRAME_CDR_PAYLOADS,
   FOXGLOVE_POSE_IN_FRAME_PAYLOAD,
   FOXGLOVE_IMAGE_ANNOTATIONS_PAYLOAD,
   FOXGLOVE_POINT_CLOUD_PAYLOAD,
+  FOXGLOVE_SCENE_UPDATE_CDR_PAYLOADS,
   FOXGLOVE_SCENE_UPDATE_PAYLOAD,
 } from "./decoders/foxglove/payloads";
 import {
@@ -102,6 +111,7 @@ export function topicName(topic: StreamInventory): string {
 export function isImageStream(topic: StreamInventory): boolean {
   return (
     hasPayload(topic, FOXGLOVE_COMPRESSED_IMAGE_PAYLOAD) ||
+    hasAnyPayload(topic, FOXGLOVE_COMPRESSED_IMAGE_CDR_PAYLOADS) ||
     hasPayload(topic, FOXGLOVE_COMPRESSED_VIDEO_PAYLOAD) ||
     hasAnyPayload(topic, FOXGLOVE_COMPRESSED_VIDEO_CDR_PAYLOADS) ||
     hasAnyPayload(topic, JSON_ROS_COMPRESSED_IMAGE_PAYLOADS) ||
@@ -117,6 +127,7 @@ export function isImageStream(topic: StreamInventory): boolean {
 export function isCompressedImageStream(topic: StreamInventory): boolean {
   return (
     hasPayload(topic, FOXGLOVE_COMPRESSED_IMAGE_PAYLOAD) ||
+    hasAnyPayload(topic, FOXGLOVE_COMPRESSED_IMAGE_CDR_PAYLOADS) ||
     hasAnyPayload(topic, JSON_ROS_COMPRESSED_IMAGE_PAYLOADS) ||
     hasAnyPayload(topic, ROS_COMPRESSED_IMAGE_PAYLOADS)
   );
@@ -126,7 +137,10 @@ export function isCompressedImageStream(topic: StreamInventory): boolean {
  * Returns whether a stream inventory item is a supported Foxglove image annotation stream.
  */
 export function isImageAnnotationsStream(topic: StreamInventory): boolean {
-  return hasPayload(topic, FOXGLOVE_IMAGE_ANNOTATIONS_PAYLOAD);
+  return (
+    hasPayload(topic, FOXGLOVE_IMAGE_ANNOTATIONS_PAYLOAD) ||
+    hasAnyPayload(topic, FOXGLOVE_IMAGE_ANNOTATIONS_CDR_PAYLOADS)
+  );
 }
 
 /**
@@ -136,7 +150,9 @@ export function isImageAnnotationsStream(topic: StreamInventory): boolean {
 export function isPointCloudStream(topic: StreamInventory): boolean {
   return (
     hasPayload(topic, FOXGLOVE_POINT_CLOUD_PAYLOAD) ||
+    hasAnyPayload(topic, FOXGLOVE_POINT_CLOUD_CDR_PAYLOADS) ||
     hasPayload(topic, FOXGLOVE_LASER_SCAN_PAYLOAD) ||
+    hasAnyPayload(topic, FOXGLOVE_LASER_SCAN_CDR_PAYLOADS) ||
     hasAnyPayload(topic, JSON_ROS_POINT_CLOUD2_PAYLOADS) ||
     hasAnyPayload(topic, JSON_ROS_LASER_SCAN_PAYLOADS) ||
     hasAnyPayload(topic, ROS_POINT_CLOUD2_PAYLOADS) ||
@@ -150,6 +166,7 @@ export function isPointCloudStream(topic: StreamInventory): boolean {
 export function isSceneUpdateStream(topic: StreamInventory): boolean {
   return (
     hasPayload(topic, FOXGLOVE_SCENE_UPDATE_PAYLOAD) ||
+    hasAnyPayload(topic, FOXGLOVE_SCENE_UPDATE_CDR_PAYLOADS) ||
     hasAnyPayload(topic, JSON_ROS_MARKER_PAYLOADS) ||
     hasAnyPayload(topic, JSON_ROS_MARKER_ARRAY_PAYLOADS) ||
     hasAnyPayload(topic, ROS_MARKER_PAYLOADS) ||
@@ -163,6 +180,7 @@ export function isSceneUpdateStream(topic: StreamInventory): boolean {
 export function isGridStream(topic: StreamInventory): boolean {
   return (
     hasPayload(topic, FOXGLOVE_GRID_PAYLOAD) ||
+    hasAnyPayload(topic, FOXGLOVE_GRID_CDR_PAYLOADS) ||
     hasAnyPayload(topic, JSON_ROS_OCCUPANCY_GRID_PAYLOADS) ||
     hasAnyPayload(topic, ROS_OCCUPANCY_GRID_PAYLOADS)
   );
@@ -175,6 +193,7 @@ export function isGridStream(topic: StreamInventory): boolean {
 export function isCameraCalibrationStream(topic: StreamInventory): boolean {
   return (
     hasPayload(topic, FOXGLOVE_CAMERA_CALIBRATION_PAYLOAD) ||
+    hasAnyPayload(topic, FOXGLOVE_CAMERA_CALIBRATION_CDR_PAYLOADS) ||
     hasAnyPayload(topic, JSON_ROS_CAMERA_INFO_PAYLOADS) ||
     hasAnyPayload(topic, ROS_CAMERA_INFO_PAYLOADS)
   );
@@ -187,6 +206,7 @@ export function isCameraCalibrationStream(topic: StreamInventory): boolean {
 export function isPoseStream(topic: StreamInventory): boolean {
   return (
     hasPayload(topic, FOXGLOVE_POSE_IN_FRAME_PAYLOAD) ||
+    hasAnyPayload(topic, FOXGLOVE_POSE_IN_FRAME_CDR_PAYLOADS) ||
     hasPayload(topic, JSON_POSE_PAYLOAD) ||
     hasAnyPayload(topic, JSON_ROS_POSE_STAMPED_PAYLOADS) ||
     hasAnyPayload(topic, JSON_ROS_ODOMETRY_PAYLOADS) ||
@@ -202,6 +222,7 @@ export function isPoseStream(topic: StreamInventory): boolean {
 export function isLocationFixStream(topic: StreamInventory): boolean {
   return (
     hasPayload(topic, FOXGLOVE_LOCATION_FIX_PAYLOAD) ||
+    hasAnyPayload(topic, FOXGLOVE_LOCATION_FIX_CDR_PAYLOADS) ||
     hasAnyPayload(topic, JSON_ROS_NAV_SAT_FIX_PAYLOADS) ||
     hasAnyPayload(topic, ROS_NAV_SAT_FIX_PAYLOADS)
   );

--- a/app/packages/multimodal/src/adapters/mcap/stream-topics.ts
+++ b/app/packages/multimodal/src/adapters/mcap/stream-topics.ts
@@ -4,6 +4,8 @@ import {
   JSON_POSE_PAYLOAD,
   JSON_ROS_CAMERA_INFO_PAYLOADS,
   JSON_ROS_COMPRESSED_IMAGE_PAYLOADS,
+  JSON_ROS_DETECTION_2D_ARRAY_PAYLOADS,
+  JSON_ROS_DETECTION_3D_ARRAY_PAYLOADS,
   JSON_ROS_IMAGE_PAYLOADS,
   JSON_ROS_LASER_SCAN_PAYLOADS,
   JSON_ROS_MARKER_ARRAY_PAYLOADS,
@@ -41,6 +43,8 @@ import {
 import {
   ROS_CAMERA_INFO_PAYLOADS,
   ROS_COMPRESSED_IMAGE_PAYLOADS,
+  ROS_DETECTION_2D_ARRAY_PAYLOADS,
+  ROS_DETECTION_3D_ARRAY_PAYLOADS,
   ROS_IMAGE_PAYLOADS,
   ROS_LASER_SCAN_PAYLOADS,
   ROS_MARKER_ARRAY_PAYLOADS,
@@ -143,7 +147,9 @@ export function isCompressedImageStream(topic: StreamInventory): boolean {
 export function isImageAnnotationsStream(topic: StreamInventory): boolean {
   return (
     hasPayload(topic, FOXGLOVE_IMAGE_ANNOTATIONS_PAYLOAD) ||
-    hasAnyPayload(topic, FOXGLOVE_IMAGE_ANNOTATIONS_CDR_PAYLOADS)
+    hasAnyPayload(topic, FOXGLOVE_IMAGE_ANNOTATIONS_CDR_PAYLOADS) ||
+    hasAnyPayload(topic, JSON_ROS_DETECTION_2D_ARRAY_PAYLOADS) ||
+    hasAnyPayload(topic, ROS_DETECTION_2D_ARRAY_PAYLOADS)
   );
 }
 
@@ -175,10 +181,12 @@ export function isSceneUpdateStream(topic: StreamInventory): boolean {
     hasAnyPayload(topic, JSON_ROS_MARKER_ARRAY_PAYLOADS) ||
     hasAnyPayload(topic, JSON_ROS_PATH_PAYLOADS) ||
     hasAnyPayload(topic, JSON_ROS_POSE_ARRAY_PAYLOADS) ||
+    hasAnyPayload(topic, JSON_ROS_DETECTION_3D_ARRAY_PAYLOADS) ||
     hasAnyPayload(topic, ROS_MARKER_PAYLOADS) ||
     hasAnyPayload(topic, ROS_MARKER_ARRAY_PAYLOADS) ||
     hasAnyPayload(topic, ROS_PATH_PAYLOADS) ||
-    hasAnyPayload(topic, ROS_POSE_ARRAY_PAYLOADS)
+    hasAnyPayload(topic, ROS_POSE_ARRAY_PAYLOADS) ||
+    hasAnyPayload(topic, ROS_DETECTION_3D_ARRAY_PAYLOADS)
   );
 }
 

--- a/app/packages/multimodal/src/adapters/mcap/stream-topics.ts
+++ b/app/packages/multimodal/src/adapters/mcap/stream-topics.ts
@@ -6,6 +6,7 @@ import {
   JSON_ROS_COMPRESSED_IMAGE_PAYLOADS,
   JSON_ROS_DETECTION_2D_ARRAY_PAYLOADS,
   JSON_ROS_DETECTION_3D_ARRAY_PAYLOADS,
+  JSON_ROS_DIAGNOSTIC_ARRAY_PAYLOADS,
   JSON_ROS_IMAGE_PAYLOADS,
   JSON_ROS_LASER_SCAN_PAYLOADS,
   JSON_ROS_MARKER_ARRAY_PAYLOADS,
@@ -17,6 +18,8 @@ import {
   JSON_ROS_POINT_CLOUD2_PAYLOADS,
   JSON_ROS_POSE_ARRAY_PAYLOADS,
   JSON_ROS_POSE_STAMPED_PAYLOADS,
+  JSON_ROS_RCL_LOG_PAYLOADS,
+  JSON_ROS_ROSGRAPH_LOG_PAYLOADS,
 } from "./decoders/json/payloads";
 import {
   FOXGLOVE_CAMERA_CALIBRATION_CDR_PAYLOADS,
@@ -32,6 +35,8 @@ import {
   FOXGLOVE_LASER_SCAN_PAYLOAD,
   FOXGLOVE_LOCATION_FIX_CDR_PAYLOADS,
   FOXGLOVE_LOCATION_FIX_PAYLOAD,
+  FOXGLOVE_LOG_CDR_PAYLOADS,
+  FOXGLOVE_LOG_PAYLOAD,
   FOXGLOVE_POINT_CLOUD_CDR_PAYLOADS,
   FOXGLOVE_POSE_IN_FRAME_CDR_PAYLOADS,
   FOXGLOVE_POSE_IN_FRAME_PAYLOAD,
@@ -45,6 +50,7 @@ import {
   ROS_COMPRESSED_IMAGE_PAYLOADS,
   ROS_DETECTION_2D_ARRAY_PAYLOADS,
   ROS_DETECTION_3D_ARRAY_PAYLOADS,
+  ROS_DIAGNOSTIC_ARRAY_PAYLOADS,
   ROS_IMAGE_PAYLOADS,
   ROS_LASER_SCAN_PAYLOADS,
   ROS_MARKER_ARRAY_PAYLOADS,
@@ -56,6 +62,8 @@ import {
   ROS_POINT_CLOUD2_PAYLOADS,
   ROS_POSE_ARRAY_PAYLOADS,
   ROS_POSE_STAMPED_PAYLOADS,
+  ROS_RCL_LOG_PAYLOADS,
+  ROS_ROSGRAPH_LOG_PAYLOADS,
 } from "./decoders/ros/payloads";
 
 /**
@@ -64,6 +72,7 @@ import {
 export interface McapPreviewTopics {
   readonly annotations: readonly string[];
   readonly image: readonly string[];
+  readonly logs: readonly string[];
   readonly pointCloud: readonly string[];
   readonly previewable: readonly string[];
   readonly sceneUpdates: readonly string[];
@@ -77,6 +86,7 @@ export function streamTopics(
 ): McapPreviewTopics {
   const image: string[] = [];
   const annotations: string[] = [];
+  const logs: string[] = [];
   const pointCloud: string[] = [];
   const sceneUpdates: string[] = [];
 
@@ -94,14 +104,17 @@ export function streamTopics(
       annotations.push(name);
     } else if (isSceneUpdateStream(topic)) {
       sceneUpdates.push(name);
+    } else if (isLogStream(topic)) {
+      logs.push(name);
     }
   }
 
   return {
     annotations,
     image,
+    logs,
     pointCloud,
-    previewable: [...image, ...pointCloud],
+    previewable: [...image, ...pointCloud, ...logs],
     sceneUpdates,
   };
 }
@@ -241,6 +254,22 @@ export function isLocationFixStream(topic: StreamInventory): boolean {
     hasAnyPayload(topic, FOXGLOVE_LOCATION_FIX_CDR_PAYLOADS) ||
     hasAnyPayload(topic, JSON_ROS_NAV_SAT_FIX_PAYLOADS) ||
     hasAnyPayload(topic, ROS_NAV_SAT_FIX_PAYLOADS)
+  );
+}
+
+/**
+ * Returns whether a stream inventory item is a supported log/diagnostic stream.
+ */
+export function isLogStream(topic: StreamInventory): boolean {
+  return (
+    hasPayload(topic, FOXGLOVE_LOG_PAYLOAD) ||
+    hasAnyPayload(topic, FOXGLOVE_LOG_CDR_PAYLOADS) ||
+    hasAnyPayload(topic, JSON_ROS_ROSGRAPH_LOG_PAYLOADS) ||
+    hasAnyPayload(topic, JSON_ROS_RCL_LOG_PAYLOADS) ||
+    hasAnyPayload(topic, JSON_ROS_DIAGNOSTIC_ARRAY_PAYLOADS) ||
+    hasAnyPayload(topic, ROS_ROSGRAPH_LOG_PAYLOADS) ||
+    hasAnyPayload(topic, ROS_RCL_LOG_PAYLOADS) ||
+    hasAnyPayload(topic, ROS_DIAGNOSTIC_ARRAY_PAYLOADS)
   );
 }
 

--- a/app/packages/multimodal/src/adapters/mcap/topic-inventory.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/topic-inventory.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+import type { StreamInventory } from "../../schemas/v1";
+import { mcapSceneSources } from "./scene-sources";
+import {
+  MCAP_TOPIC_CAPABILITY,
+  MCAP_TOPIC_CATEGORY,
+  buildMcapTopicInventoryRows,
+  filterMcapTopicInventoryRows,
+  type McapTopicInventoryRow,
+} from "./topic-inventory";
+
+describe("buildMcapTopicInventoryRows", () => {
+  it("keeps all topics and buckets them by customer job", () => {
+    const topics = [
+      topic("/camera/front", "sensor_msgs/Image", "ros1", "ros1msg", "12"),
+      topic("/lidar/top", "sensor_msgs/PointCloud2", "ros1", "ros1msg", "8"),
+      topic(
+        "/markers",
+        "visualization_msgs/msg/MarkerArray",
+        "cdr",
+        "ros2msg",
+        "4",
+      ),
+      topic("/plan", "nav_msgs/Path", "ros1", "ros1msg", "5"),
+      topic("/odom", "nav_msgs/msg/Odometry", "cdr", "ros2msg", "6"),
+      topic("/tf_static", "tf2_msgs/TFMessage", "ros1", "ros1msg", "2"),
+      topic(
+        "/diagnostics",
+        "diagnostic_msgs/DiagnosticArray",
+        "ros1",
+        "ros1msg",
+        "7",
+      ),
+      topic("/imu", "sensor_msgs/msg/Imu", "cdr", "ros2msg", "9"),
+      topic("/vendor/raw", "vendor_msgs/Widget", "cdr", "ros2msg", "3"),
+      topic(
+        "/broken",
+        "vendor_msgs/Broken",
+        "cdr",
+        "ros2msg",
+        "1",
+        "schema-unavailable",
+      ),
+      topic(
+        "/binary",
+        "vendor.Binary",
+        "cbor",
+        "protobuf",
+        "1",
+        "unsupported-encoding",
+      ),
+    ];
+
+    const rows = buildMcapTopicInventoryRows({
+      sceneSources: mcapSceneSources(topics),
+      topics,
+    });
+
+    expect(rows.map((row) => row.topic)).toEqual([
+      "/camera/front",
+      "/lidar/top",
+      "/markers",
+      "/plan",
+      "/odom",
+      "/tf_static",
+      "/diagnostics",
+      "/imu",
+      "/binary",
+      "/broken",
+      "/vendor/raw",
+    ]);
+    expect(row(rows, "/camera/front")).toMatchObject({
+      category: MCAP_TOPIC_CATEGORY.SENSORS,
+      supportStatus: "renderable",
+      capabilities: [MCAP_TOPIC_CAPABILITY.IMAGE, MCAP_TOPIC_CAPABILITY.RAW],
+    });
+    expect(row(rows, "/markers")).toMatchObject({
+      category: MCAP_TOPIC_CATEGORY.ANNOTATIONS_PLANNING,
+      supportStatus: "renderable",
+      capabilities: [MCAP_TOPIC_CAPABILITY.THREE_D, MCAP_TOPIC_CAPABILITY.RAW],
+    });
+    expect(row(rows, "/tf_static")).toMatchObject({
+      category: MCAP_TOPIC_CATEGORY.TRANSFORMS_POSES,
+      sourceType: null,
+      supportStatus: "renderable",
+      capabilities: [MCAP_TOPIC_CAPABILITY.THREE_D, MCAP_TOPIC_CAPABILITY.RAW],
+    });
+    expect(row(rows, "/diagnostics")).toMatchObject({
+      category: MCAP_TOPIC_CATEGORY.DIAGNOSTICS,
+      supportStatus: "renderable",
+      capabilities: [MCAP_TOPIC_CAPABILITY.LOGS, MCAP_TOPIC_CAPABILITY.RAW],
+    });
+    expect(row(rows, "/imu")).toMatchObject({
+      category: MCAP_TOPIC_CATEGORY.TELEMETRY,
+      supportStatus: "inspectable",
+      capabilities: [MCAP_TOPIC_CAPABILITY.PLOT, MCAP_TOPIC_CAPABILITY.RAW],
+    });
+    expect(row(rows, "/vendor/raw")).toMatchObject({
+      category: MCAP_TOPIC_CATEGORY.CUSTOM,
+      supportStatus: "inspectable",
+      capabilities: [MCAP_TOPIC_CAPABILITY.RAW],
+    });
+    expect(row(rows, "/broken")).toMatchObject({
+      supportStatus: "schema-unavailable",
+      capabilities: [],
+    });
+    expect(row(rows, "/binary")).toMatchObject({
+      supportStatus: "encoding-unsupported",
+      capabilities: [],
+    });
+  });
+
+  it("searches topic names, schema names, categories, support, and capabilities", () => {
+    const rows = buildMcapTopicInventoryRows({
+      sceneSources: [],
+      topics: [
+        topic("/imu", "sensor_msgs/Imu", "ros1", "ros1msg", "9"),
+        topic("/vendor/raw", "vendor_msgs/Widget", "cdr", "ros2msg", "3"),
+      ],
+    });
+
+    expect(
+      filterMcapTopicInventoryRows(rows, "telemetry").map(topicName),
+    ).toEqual(["/imu"]);
+    expect(filterMcapTopicInventoryRows(rows, "Widget").map(topicName)).toEqual(
+      ["/vendor/raw"],
+    );
+    expect(filterMcapTopicInventoryRows(rows, "plot").map(topicName)).toEqual([
+      "/imu",
+    ]);
+    expect(filterMcapTopicInventoryRows(rows, "unsupported")).toEqual([]);
+  });
+});
+
+function row(rows: readonly McapTopicInventoryRow[], topic: string) {
+  const match = rows.find((candidate) => candidate.topic === topic);
+  expect(match).toBeTruthy();
+  return match;
+}
+
+function topicName(row: { readonly topic: string }): string {
+  return row.topic;
+}
+
+function topic(
+  name: string,
+  schema: string,
+  encoding: string,
+  schemaEncoding: string,
+  count: string,
+  decodeStatus = "decodable",
+): StreamInventory {
+  return {
+    $typeName: "fiftyone.multimodal.schemas.v1.StreamInventory",
+    displayName: name,
+    metadata: {
+      "mcap.generic_decode_status": decodeStatus,
+      "mcap.message_encoding": encoding,
+      "mcap.schema_name": schema,
+      "mcap.topic": name,
+    },
+    payload: {
+      $typeName: "fiftyone.multimodal.schemas.v1.PayloadDescriptor",
+      encoding,
+      schema,
+      schemaEncoding,
+    },
+    recordCount: count,
+    streamId: name,
+  };
+}

--- a/app/packages/multimodal/src/adapters/mcap/topic-inventory.ts
+++ b/app/packages/multimodal/src/adapters/mcap/topic-inventory.ts
@@ -1,0 +1,375 @@
+import type { SceneSource } from "../../scene-inventory";
+import type { StreamInventory } from "../../schemas/v1";
+import {
+  MCAP_SOURCE_TYPE,
+  mcapSourceTypeForTopic,
+  type McapSourceType,
+} from "./scene-sources";
+import {
+  isFrameTransformStream,
+  isImageAnnotationsStream,
+  isLogStream,
+  isSceneUpdateStream,
+  topicName,
+} from "./stream-topics";
+
+export const MCAP_TOPIC_CATEGORY = {
+  SENSORS: "sensors",
+  ANNOTATIONS_PLANNING: "annotations-planning",
+  TRANSFORMS_POSES: "transforms-poses",
+  DIAGNOSTICS: "diagnostics",
+  TELEMETRY: "telemetry",
+  CUSTOM: "custom",
+} as const;
+
+export type McapTopicCategory =
+  (typeof MCAP_TOPIC_CATEGORY)[keyof typeof MCAP_TOPIC_CATEGORY];
+
+export const MCAP_TOPIC_CATEGORY_ORDER: readonly McapTopicCategory[] = [
+  MCAP_TOPIC_CATEGORY.SENSORS,
+  MCAP_TOPIC_CATEGORY.ANNOTATIONS_PLANNING,
+  MCAP_TOPIC_CATEGORY.TRANSFORMS_POSES,
+  MCAP_TOPIC_CATEGORY.DIAGNOSTICS,
+  MCAP_TOPIC_CATEGORY.TELEMETRY,
+  MCAP_TOPIC_CATEGORY.CUSTOM,
+];
+
+export const MCAP_TOPIC_CATEGORY_LABEL: Record<McapTopicCategory, string> = {
+  [MCAP_TOPIC_CATEGORY.SENSORS]: "Sensors",
+  [MCAP_TOPIC_CATEGORY.ANNOTATIONS_PLANNING]: "Annotations & Planning",
+  [MCAP_TOPIC_CATEGORY.TRANSFORMS_POSES]: "Transforms & Poses",
+  [MCAP_TOPIC_CATEGORY.DIAGNOSTICS]: "Diagnostics",
+  [MCAP_TOPIC_CATEGORY.TELEMETRY]: "Telemetry",
+  [MCAP_TOPIC_CATEGORY.CUSTOM]: "Custom / Unknown",
+};
+
+export const MCAP_TOPIC_CAPABILITY = {
+  IMAGE: "image",
+  LOGS: "logs",
+  PLOT: "plot",
+  RAW: "raw",
+  THREE_D: "three-d",
+} as const;
+
+export type McapTopicCapability =
+  (typeof MCAP_TOPIC_CAPABILITY)[keyof typeof MCAP_TOPIC_CAPABILITY];
+
+export const MCAP_TOPIC_CAPABILITY_LABEL: Record<McapTopicCapability, string> =
+  {
+    [MCAP_TOPIC_CAPABILITY.IMAGE]: "Image",
+    [MCAP_TOPIC_CAPABILITY.LOGS]: "Logs",
+    [MCAP_TOPIC_CAPABILITY.PLOT]: "Plot",
+    [MCAP_TOPIC_CAPABILITY.RAW]: "Raw",
+    [MCAP_TOPIC_CAPABILITY.THREE_D]: "3D",
+  };
+
+export type McapTopicSupportStatus =
+  | "encoding-unsupported"
+  | "inspectable"
+  | "no-decoder"
+  | "renderable"
+  | "schema-unavailable";
+
+export const MCAP_TOPIC_SUPPORT_LABEL: Record<McapTopicSupportStatus, string> =
+  {
+    "encoding-unsupported": "Encoding unsupported",
+    inspectable: "Inspectable",
+    "no-decoder": "No decoder",
+    renderable: "Supported",
+    "schema-unavailable": "Schema unavailable",
+  };
+
+export interface McapTopicInventoryRow {
+  readonly canInspect: boolean;
+  readonly capabilities: readonly McapTopicCapability[];
+  readonly category: McapTopicCategory;
+  readonly countLabel: string;
+  readonly encoding: string;
+  readonly recordCount: number | null;
+  readonly schemaName: string;
+  readonly sourceType: McapSourceType | null;
+  readonly supportStatus: McapTopicSupportStatus;
+  readonly topic: string;
+}
+
+type GenericDecodeStatus =
+  | "decodable"
+  | "schema-unavailable"
+  | "unsupported-encoding"
+  | "unknown";
+
+const TELEMETRY_SCHEMAS: ReadonlySet<string> = new Set([
+  "ackermann_msgs/AckermannDrive",
+  "ackermann_msgs/AckermannDriveStamped",
+  "ackermann_msgs/msg/AckermannDrive",
+  "ackermann_msgs/msg/AckermannDriveStamped",
+  "geometry_msgs/Twist",
+  "geometry_msgs/TwistStamped",
+  "geometry_msgs/msg/Twist",
+  "geometry_msgs/msg/TwistStamped",
+  "sensor_msgs/BatteryState",
+  "sensor_msgs/FluidPressure",
+  "sensor_msgs/Imu",
+  "sensor_msgs/JointState",
+  "sensor_msgs/MagneticField",
+  "sensor_msgs/Temperature",
+  "sensor_msgs/msg/BatteryState",
+  "sensor_msgs/msg/FluidPressure",
+  "sensor_msgs/msg/Imu",
+  "sensor_msgs/msg/JointState",
+  "sensor_msgs/msg/MagneticField",
+  "sensor_msgs/msg/Temperature",
+]);
+
+/**
+ * Builds the customer-facing topic inventory for the MCAP sidebar. The result
+ * is static and schema-derived: `renderable` means the adapter knows how the
+ * topic participates in a panel, not that the topic is currently visible.
+ */
+export function buildMcapTopicInventoryRows({
+  sceneSources,
+  topics,
+}: {
+  readonly sceneSources: readonly SceneSource[];
+  readonly topics: readonly StreamInventory[];
+}): readonly McapTopicInventoryRow[] {
+  const sceneSourceTypes = new Map(
+    sceneSources.map((source) => [source.id, source.type]),
+  );
+
+  return topics
+    .map((stream) => {
+      const name = topicName(stream);
+      if (!name) {
+        return null;
+      }
+
+      const sourceType =
+        mcapSourceTypeForTopic(stream) ??
+        knownMcapSourceType(sceneSourceTypes.get(name));
+      const frameTransform = isFrameTransformStream(stream);
+      const decodeStatus = genericDecodeStatus(
+        stream.metadata["mcap.generic_decode_status"],
+      );
+      const canInspect = decodeStatus === "decodable";
+      const schemaName = schemaNameFor(stream);
+      const telemetry = isTelemetrySchema(schemaName);
+
+      return {
+        canInspect,
+        capabilities: capabilitiesForTopic({
+          canInspect,
+          frameTransform,
+          sourceType,
+          telemetry,
+        }),
+        category: categoryForTopic({
+          frameTransform,
+          sourceType,
+          stream,
+          telemetry,
+        }),
+        countLabel: messageCountLabel(stream.recordCount),
+        encoding: encodingFor(stream),
+        recordCount: recordCountFor(stream.recordCount),
+        schemaName,
+        sourceType,
+        supportStatus: supportStatusFor({
+          decodeStatus,
+          frameTransform,
+          sourceType,
+        }),
+        topic: name,
+      };
+    })
+    .filter((row): row is McapTopicInventoryRow => row !== null)
+    .sort(compareTopicRows);
+}
+
+export function filterMcapTopicInventoryRows(
+  rows: readonly McapTopicInventoryRow[],
+  search: string,
+): readonly McapTopicInventoryRow[] {
+  const needle = search.trim().toLowerCase();
+  if (!needle) {
+    return rows;
+  }
+
+  return rows.filter((row) =>
+    [
+      row.topic,
+      row.schemaName,
+      row.encoding,
+      MCAP_TOPIC_CATEGORY_LABEL[row.category],
+      MCAP_TOPIC_SUPPORT_LABEL[row.supportStatus],
+      ...row.capabilities.map(
+        (capability) => MCAP_TOPIC_CAPABILITY_LABEL[capability],
+      ),
+    ].some((value) => value.toLowerCase().includes(needle)),
+  );
+}
+
+export function messageCountLabel(recordCount: string | undefined): string {
+  const count = recordCountFor(recordCount);
+  if (count === null) {
+    return "unknown msgs";
+  }
+  return `${count.toLocaleString()} ${count === 1 ? "msg" : "msgs"}`;
+}
+
+function categoryForTopic({
+  frameTransform,
+  sourceType,
+  stream,
+  telemetry,
+}: {
+  readonly frameTransform: boolean;
+  readonly sourceType: McapSourceType | null;
+  readonly stream: StreamInventory;
+  readonly telemetry: boolean;
+}): McapTopicCategory {
+  if (sourceType === MCAP_SOURCE_TYPE.LOG || isLogStream(stream)) {
+    return MCAP_TOPIC_CATEGORY.DIAGNOSTICS;
+  }
+  if (
+    sourceType === MCAP_SOURCE_TYPE.IMAGE_ANNOTATION ||
+    sourceType === MCAP_SOURCE_TYPE.SCENE_ANNOTATION ||
+    isImageAnnotationsStream(stream) ||
+    isSceneUpdateStream(stream)
+  ) {
+    return MCAP_TOPIC_CATEGORY.ANNOTATIONS_PLANNING;
+  }
+  if (sourceType === MCAP_SOURCE_TYPE.POSE || frameTransform) {
+    return MCAP_TOPIC_CATEGORY.TRANSFORMS_POSES;
+  }
+  if (sourceType !== null) {
+    return MCAP_TOPIC_CATEGORY.SENSORS;
+  }
+  if (telemetry) {
+    return MCAP_TOPIC_CATEGORY.TELEMETRY;
+  }
+  return MCAP_TOPIC_CATEGORY.CUSTOM;
+}
+
+function capabilitiesForTopic({
+  canInspect,
+  frameTransform,
+  sourceType,
+  telemetry,
+}: {
+  readonly canInspect: boolean;
+  readonly frameTransform: boolean;
+  readonly sourceType: McapSourceType | null;
+  readonly telemetry: boolean;
+}): readonly McapTopicCapability[] {
+  const capabilities: McapTopicCapability[] = [];
+
+  if (
+    sourceType === MCAP_SOURCE_TYPE.IMAGE ||
+    sourceType === MCAP_SOURCE_TYPE.IMAGE_ANNOTATION ||
+    sourceType === MCAP_SOURCE_TYPE.CAMERA_CALIBRATION
+  ) {
+    capabilities.push(MCAP_TOPIC_CAPABILITY.IMAGE);
+  }
+
+  if (
+    frameTransform ||
+    sourceType === MCAP_SOURCE_TYPE.CAMERA_CALIBRATION ||
+    sourceType === MCAP_SOURCE_TYPE.LOCATION ||
+    sourceType === MCAP_SOURCE_TYPE.MAP_LAYER ||
+    sourceType === MCAP_SOURCE_TYPE.POINT_CLOUD ||
+    sourceType === MCAP_SOURCE_TYPE.POSE ||
+    sourceType === MCAP_SOURCE_TYPE.SCENE_ANNOTATION
+  ) {
+    capabilities.push(MCAP_TOPIC_CAPABILITY.THREE_D);
+  }
+
+  if (sourceType === MCAP_SOURCE_TYPE.LOG) {
+    capabilities.push(MCAP_TOPIC_CAPABILITY.LOGS);
+  }
+
+  if (telemetry) {
+    capabilities.push(MCAP_TOPIC_CAPABILITY.PLOT);
+  }
+
+  if (canInspect) {
+    capabilities.push(MCAP_TOPIC_CAPABILITY.RAW);
+  }
+
+  return Array.from(new Set(capabilities));
+}
+
+function supportStatusFor({
+  decodeStatus,
+  frameTransform,
+  sourceType,
+}: {
+  readonly decodeStatus: GenericDecodeStatus;
+  readonly frameTransform: boolean;
+  readonly sourceType: McapSourceType | null;
+}): McapTopicSupportStatus {
+  if (sourceType !== null || frameTransform) {
+    return "renderable";
+  }
+  if (decodeStatus === "decodable") {
+    return "inspectable";
+  }
+  if (decodeStatus === "schema-unavailable") {
+    return "schema-unavailable";
+  }
+  if (decodeStatus === "unsupported-encoding") {
+    return "encoding-unsupported";
+  }
+  return "no-decoder";
+}
+
+function compareTopicRows(
+  left: McapTopicInventoryRow,
+  right: McapTopicInventoryRow,
+): number {
+  const categoryDelta =
+    MCAP_TOPIC_CATEGORY_ORDER.indexOf(left.category) -
+    MCAP_TOPIC_CATEGORY_ORDER.indexOf(right.category);
+  return categoryDelta || left.topic.localeCompare(right.topic);
+}
+
+function isTelemetrySchema(schemaName: string): boolean {
+  return TELEMETRY_SCHEMAS.has(schemaName);
+}
+
+function genericDecodeStatus(status: string | undefined): GenericDecodeStatus {
+  switch (status) {
+    case "decodable":
+    case "schema-unavailable":
+    case "unsupported-encoding":
+      return status;
+    default:
+      return "unknown";
+  }
+}
+
+function schemaNameFor(topic: StreamInventory): string {
+  return (
+    topic.metadata["mcap.schema_name"] ?? topic.payload?.schema ?? "no schema"
+  );
+}
+
+function encodingFor(topic: StreamInventory): string {
+  return (
+    topic.metadata["mcap.message_encoding"] ??
+    topic.payload?.encoding ??
+    "unknown"
+  );
+}
+
+function recordCountFor(recordCount: string | undefined): number | null {
+  const count = recordCount === undefined ? Number.NaN : Number(recordCount);
+  return Number.isFinite(count) && count >= 0 ? count : null;
+}
+
+function knownMcapSourceType(type: string | undefined): McapSourceType | null {
+  return type !== undefined &&
+    (Object.values(MCAP_SOURCE_TYPE) as readonly string[]).includes(type)
+    ? (type as McapSourceType)
+    : null;
+}

--- a/app/packages/multimodal/src/adapters/mcap/types.ts
+++ b/app/packages/multimodal/src/adapters/mcap/types.ts
@@ -766,7 +766,7 @@ export interface McapResourceClient {
    * clients switch ownership here (cancelling the previous source's pending
    * reads while keeping the worker fleet warm); reads for non-active
    * sources then fail fast with the cancelled error. Callers that never
-   * activate keep legacy request-driven switching.
+   * activate keep request-driven switching.
    */
   activateSource?(source: ByteSourceDescriptor): void;
 

--- a/app/packages/multimodal/src/adapters/mcap/worker/worker-client.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/worker-client.ts
@@ -308,9 +308,9 @@ class WorkerMcapResourceClient implements McapResourceClient {
       throw mcapReadCancelledError();
     }
 
-    // Legacy request-driven switching (callers that never activate a
-    // source): terminate stays the safe preemption — request order cannot
-    // express ownership, so keep-warm would thrash (0.3 s -> ~4.6 s hops).
+    // Request-driven switching for callers that never activate a source:
+    // terminate stays the safe preemption — request order cannot express
+    // ownership, so keep-warm would thrash (0.3 s -> ~4.6 s hops).
     this.resetWorkers("MCAP worker reset for a different source");
     this.activeSourceKey = sourceKey;
   }

--- a/app/packages/multimodal/src/components/MeasureRulerIcon.tsx
+++ b/app/packages/multimodal/src/components/MeasureRulerIcon.tsx
@@ -1,0 +1,25 @@
+/**
+ * Diagonal ruler glyph shared by the point-cloud and map measure toggles —
+ * voodo's IconName has no ruler. Decorative: host buttons carry the
+ * accessible label.
+ */
+export default function MeasureRulerIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      fill="none"
+      height="13"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      viewBox="0 0 24 24"
+      width="13"
+    >
+      <path d="M3 17 17 3l4 4L7 21z" />
+      <path d="m8 12 2 2" />
+      <path d="m11 9 2 2" />
+      <path d="m14 6 2 2" />
+    </svg>
+  );
+}

--- a/app/packages/multimodal/src/decoders/types.ts
+++ b/app/packages/multimodal/src/decoders/types.ts
@@ -203,6 +203,10 @@ export interface LocationVisualization {
    * Per-message source coordinate frame of the reporting sensor.
    */
   readonly coordinateFrameId?: string;
+  /** ROS NavSatStatus.status when present; -1 means no fix. */
+  readonly fixStatus?: number;
+  /** ROS NavSatStatus.service bitmask when present. */
+  readonly fixService?: number;
   readonly latitude: number;
   readonly longitude: number;
   readonly altitude?: number;

--- a/app/packages/multimodal/src/visualization/panels/point-cloud/PointCloudPanel.tsx
+++ b/app/packages/multimodal/src/visualization/panels/point-cloud/PointCloudPanel.tsx
@@ -1,6 +1,7 @@
 import { Icon, IconName, Size } from "@voxel51/voodo";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
+import MeasureRulerIcon from "../../../components/MeasureRulerIcon";
 import { Base3DScene } from "../base-3d-scene";
 import { WebGpuCanvas } from "../webgpu-canvas";
 import {
@@ -435,27 +436,6 @@ function ColorRampLegend({
         </div>
       ))}
     </div>
-  );
-}
-
-/** Diagonal ruler glyph for the measure toggle — IconName has none. */
-function MeasureRulerIcon() {
-  return (
-    <svg
-      width="13"
-      height="13"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M3 17 17 3l4 4L7 21z" />
-      <path d="m8 12 2 2" />
-      <path d="m11 9 2 2" />
-      <path d="m14 6 2 2" />
-    </svg>
   );
 }
 

--- a/app/packages/multimodal/src/visualization/visualization-registry.ts
+++ b/app/packages/multimodal/src/visualization/visualization-registry.ts
@@ -50,7 +50,7 @@ export const VISUALIZATION_PANEL_REGISTRY: Readonly<
   [VISUALIZATION_KIND.ENCODED_VIDEO]: PANEL_TYPE.IMAGE,
   [VISUALIZATION_KIND.GRID]: PANEL_TYPE.THREE_D,
   [VISUALIZATION_KIND.IMAGE_ANNOTATIONS]: PANEL_TYPE.IMAGE,
-  // No MAP panel exists yet; v1 surfaces locations as a 3D-tile HUD
+  // No MAP panel exists yet; locations currently surface as a 3D-tile HUD
   // readout. The mapping records the natural home for the data.
   [VISUALIZATION_KIND.LOCATION]: PANEL_TYPE.MAP,
   [VISUALIZATION_KIND.POINT_CLOUD]: PANEL_TYPE.THREE_D,

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -3225,6 +3225,7 @@ __metadata:
     date-fns: "npm:^4.1.0"
     jotai: "npm:^2.9.3"
     lru-cache: "npm:^11.0.1"
+    maplibre-gl: "npm:^4.7.1"
     meshoptimizer: "npm:^0.22.0"
     protobufjs: "npm:^7.6.4"
     three: "patch:three@npm%3A0.185.1#~/.yarn/patches/three-npm-0.185.1-e07195d8b4.patch"


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

Prev: https://github.com/voxel51/fiftyone/pull/7963
Next: https://github.com/voxel51/fiftyone/pull/7982

Adds MCAP sidebar affordances for other decodable topics: users can search other topics, open one in a Message panel, and add numeric raw-message fields directly to a Plot panel. Message-only MCAP layouts can start without waiting on playback-topic buffers, and MCAP layout persistence now restores only for the exact dataset/source scope so new datasets or explorer files start from defaults.

## 🧪 How is this patch tested? If it is not, please explain why.

- Unit tests

Manual smoke path: open an MCAP with decodable topics outside the rendered scene, search under Other topics, click Inspect, then add a numeric field from the Message tree to a Plot tile.

## Notes to Reviewer

Stacked on `sash/mm-mcap-json-schema-support`.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

N/A

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3207
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added **Logs** support end-to-end: new Logs tile, MCAP-backed log console UI, and playback layout integration.
  - Introduced a **Topics** tab with grouping, search, and quick actions (including opening raw messages).
  - Extended **Add to plot** to numeric leaves in raw message trees.
  - Added map “**location tracks**” and improved **scene update history/interpolation** behavior.

- **Bug Fixes**
  - Expanded decoding coverage for additional ROS/Foxglove message types and **CDR** variants.
  - Improved stream/topic classification and persisted layout isolation across datasets.

- **Tests**
  - Significantly expanded automated coverage for logs, topics UI, and stream classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->