### PR TITLE
Scale timeline ruler tick spacing to file duration

### DIFF
--- a/app/packages/playback/src/views/TimelineRuler/TimelineRuler.test.tsx
+++ b/app/packages/playback/src/views/TimelineRuler/TimelineRuler.test.tsx
@@ -255,6 +255,46 @@ describe("TimelineRuler", () => {
       expect(inlineStyle(ticks[0])).toContain("left: 0%");
       expect(inlineStyle(ticks[ticks.length - 1])).toContain("left: 100%");
     });
+
+    it("widens the interval on long files so ticks stay uncramped", () => {
+      // A 60s file zoomed all the way out used to render one label per second
+      // (61 ticks). It now scales up to a nicer interval.
+      const { container } = renderRuler({
+        duration: 60,
+        viewStart: 0,
+        viewEnd: 60,
+      });
+      const ticks = container.querySelectorAll(`.${styles.tick}`);
+      // 10s spacing → 7 ticks (0..60), well under the old crush.
+      expect(ticks).toHaveLength(7);
+    });
+
+    it("keeps a bounded tick count regardless of duration", () => {
+      const { container } = renderRuler({
+        duration: 300,
+        viewStart: 0,
+        viewEnd: 300,
+      });
+      const ticks = container.querySelectorAll(`.${styles.tick}`);
+      // 30s spacing → 11 ticks (0..300), never hundreds.
+      expect(ticks.length).toBeLessThanOrEqual(12);
+    });
+
+    it("labels ticks past a minute as m:ss", () => {
+      const { container } = renderRuler({
+        duration: 120,
+        viewStart: 0,
+        viewEnd: 120,
+      });
+      const labels = Array.from(
+        container.querySelectorAll(`.${styles.tick}`),
+      ).map((el) => el.textContent);
+      // Sub-minute ticks stay in seconds; minute+ ticks read as m:ss.
+      expect(labels).toContain("30s");
+      expect(labels).toContain("1:00");
+      expect(labels).toContain("1:30");
+      expect(labels).toContain("2:00");
+    });
   });
 
   describe("playhead positioning", () => {

--- a/app/packages/playback/src/views/TimelineRuler/TimelineRuler.tsx
+++ b/app/packages/playback/src/views/TimelineRuler/TimelineRuler.tsx
@@ -19,9 +19,33 @@ import styles from "./TimelineRuler.module.css";
 const MIN_VIEW = 0.25;
 const CLICK_PX_THRESHOLD = 3;
 
+// Nice tick spacings in seconds, ascending. We pick the smallest one that
+// keeps the visible tick count at or below TARGET_TICK_DIVISIONS. Without
+// this the interval capped at 1s, so a long file zoomed out crammed a label
+// into every single second.
+const TICK_INTERVALS = [
+  0.1, 0.2, 0.25, 0.5, 1, 2, 5, 10, 15, 30, 60, 120, 300, 600, 900, 1800, 3600,
+];
+const TARGET_TICK_DIVISIONS = 10;
+
+function chooseTickInterval(viewDuration: number): number {
+  for (const interval of TICK_INTERVALS) {
+    if (viewDuration / interval <= TARGET_TICK_DIVISIONS) return interval;
+  }
+  return TICK_INTERVALS[TICK_INTERVALS.length - 1];
+}
+
 function tickLabel(t: number): string {
   const s = Math.floor(t);
   const frac = Math.round((t - s) * 10) / 10;
+  // Past a minute, seconds-only labels ("150s") get hard to read on long
+  // files; switch to m:ss. Intervals at this scale are whole seconds, so the
+  // fractional branch below only matters for sub-minute zoomed-in views.
+  if (t >= 60) {
+    const minutes = Math.floor(s / 60);
+    const seconds = s - minutes * 60;
+    return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+  }
   return frac === 0 ? `${s}s` : `${(s + frac).toFixed(1)}s`;
 }
 
@@ -263,7 +287,7 @@ const TimelineRuler: React.FC<TimelineRulerProps> = ({
   const loopStartRatio = clamp((loopStart - viewStart) / viewDuration, 0, 1);
   const loopEndRatio = clamp((loopEnd - viewStart) / viewDuration, 0, 1);
 
-  const tickInterval = viewDuration <= 1 ? 0.1 : viewDuration <= 3 ? 0.5 : 1;
+  const tickInterval = chooseTickInterval(viewDuration);
   const ticks: number[] = [];
   const firstTick = Math.ceil(viewStart / tickInterval - 1e-9) * tickInterval;
   for (


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

The timeline ruler hard-capped its tick interval at 1 second, so any view
wider than 3s always drew one label per second. On short clips (~10s) this
looked fine, but longer files crammed a label into every second when zoomed
out — e.g. a 60s file rendered 61 ticks and a 5-minute file rendered 300,
making the ruler unreadable.

This PR makes tick spacing scale with the visible view duration:

- `chooseTickInterval` picks the smallest "nice" spacing
  (`0.1, 0.2, 0.25, 0.5, 1, 2, 5, 10, 15, 30, 60, 120, 300, 600, …` seconds)
  that keeps the visible tick count at or below ~10, so the ruler stays
  uncramped at any duration. Behavior for views ≤10s is unchanged.
- Tick labels at or past a minute now render as `m:ss` (e.g. `1:30` instead
  of `90s`), which is much easier to read on long files.

This is a spoofed 5min file:
<img width="1537" height="142" alt="screenshot-2026-07-08_09-13-13" src="https://github.com/user-attachments/assets/f288d2ae-9cd7-4264-a760-29ea158ac16d" />

## 🧪 How is this patch tested? If it is not, please explain why.

- Added unit tests in `TimelineRuler.test.tsx` covering long-file spacing
  (60s → 10s intervals), a bounded tick count on a 300s view, and `m:ss`
  label formatting past a minute. Existing tick tests (≤10s ranges) still
  pass, confirming no regression to short-clip behavior.
- Full `TimelineRuler` suite passes (26 tests).

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

Timeline ruler tick marks now scale their spacing to the length of the media,
so longer files no longer cram a label into every second, and labels past a
minute are shown as `m:ss`.

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3208
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved timeline ruler labels for longer durations, showing times in `m:ss` format once the view reaches one minute or more.
  * Adjusted tick spacing so long recordings display fewer, more readable markers instead of crowded labels.

* **Bug Fixes**
  * Kept timeline tick counts bounded at large durations, improving readability and consistency across wide views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->