### PR TITLE
ci(pr): drop closed-event runs; poll for the real verdict on edited no-ops

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,8 +4,10 @@ on:
   pull_request:
     # `edited` catches base changes — notably GitHub auto-retargeting a stacked
     # PR to develop when the PR below it merges — so the heavy suite runs before
-    # it can land (no `synchronize` fires on an auto-retarget).
-    types: [opened, synchronize, reopened, closed, edited]
+    # it can land (no `synchronize` fires on an auto-retarget). No `closed`:
+    # nothing here runs on it, and its no-op run races the suite still testing
+    # the just-merged SHA, leaving a spurious red X on the merged PR.
+    types: [opened, synchronize, reopened, edited]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -98,7 +100,6 @@ jobs:
   build:
     needs: modified-files
     if: >-
-      github.event.action != 'closed' &&
       needs.modified-files.outputs.heavy == 'true' && (
       needs.modified-files.outputs.app-changes == 'true' ||
       needs.modified-files.outputs.fiftyone-changes == 'true')
@@ -107,7 +108,6 @@ jobs:
   e2e:
     needs: modified-files
     if: >-
-      github.event.action != 'closed' &&
       needs.modified-files.outputs.heavy == 'true' && (
       needs.modified-files.outputs.app-changes == 'true' ||
       needs.modified-files.outputs.e2e-changes == 'true' ||
@@ -120,7 +120,6 @@ jobs:
   lint:
     needs: modified-files
     if: >-
-      github.event.action != 'closed' &&
       needs.modified-files.outputs.run-ci == 'true' && (
       needs.modified-files.outputs.app-changes == 'true' ||
       needs.modified-files.outputs.fiftyone-changes == 'true' ||
@@ -130,7 +129,6 @@ jobs:
   test:
     needs: modified-files
     if: >-
-      github.event.action != 'closed' &&
       needs.modified-files.outputs.heavy == 'true' && (
       needs.modified-files.outputs.app-changes == 'true' ||
       needs.modified-files.outputs.fiftyone-changes == 'true')
@@ -144,7 +142,6 @@ jobs:
   test-windows:
     needs: modified-files
     if: >-
-      github.event.action != 'closed' &&
       needs.modified-files.outputs.heavy == 'true' &&
       needs.modified-files.outputs.fiftyone-changes == 'true'
     uses: ./.github/workflows/windows-test.yml
@@ -159,13 +156,12 @@ jobs:
     needs: [modified-files, build, lint, test, e2e]
     if: always()
     env:
-      # A run that skipped the suite (no-op body edit, `closed`, or a failed
-      # gate) must not aggregate its skipped needs into a vacuous green that
+      # A run that skipped the suite (a no-op body edit, or a failed gate)
+      # must not aggregate its skipped needs into a vacuous green that
       # becomes the latest `all-tests` for a SHA whose real suite failed.
       NO_OP: >-
         ${{ needs.modified-files.result == 'success' &&
-        (needs.modified-files.outputs.run-ci != 'true' ||
-        github.event.action == 'closed') }}
+        needs.modified-files.outputs.run-ci != 'true' }}
     steps:
       - name: Fail when the CI gate did not complete
         if: needs.modified-files.result != 'success'
@@ -175,22 +171,37 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            const { data } = await github.rest.checks.listForRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: context.payload.pull_request.head.sha,
-              check_name: 'all-tests',
-              per_page: 100,
-            });
-            const prior = data.check_runs
-              .filter((c) => c.status === 'completed')
-              .sort((a, b) => new Date(b.started_at) - new Date(a.started_at))[0];
-            if (!prior) {
-              core.setFailed('No completed all-tests for this commit yet — deferring to the run testing it.');
-            } else if (prior.conclusion === 'success') {
-              core.info('Mirroring the previous all-tests result: success');
-            } else {
-              core.setFailed(`Mirroring the previous all-tests result: ${prior.conclusion}`);
+            // A no-op edit usually lands while the run actually testing this
+            // SHA is still in flight (this job's own check run is in_progress,
+            // so it never matches the completed filter). Poll for that run's
+            // verdict rather than failing on the gap — a vacuous green here
+            // could merge the PR before its suite finishes.
+            const deadline = Date.now() + 45 * 60 * 1000;
+            for (;;) {
+              const { data } = await github.rest.checks.listForRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: context.payload.pull_request.head.sha,
+                check_name: 'all-tests',
+                per_page: 100,
+              });
+              const prior = data.check_runs
+                .filter((c) => c.status === 'completed')
+                .sort((a, b) => new Date(b.started_at) - new Date(a.started_at))[0];
+              if (prior) {
+                if (prior.conclusion === 'success') {
+                  core.info('Mirroring the previous all-tests result: success');
+                } else {
+                  core.setFailed(`Mirroring the previous all-tests result: ${prior.conclusion}`);
+                }
+                return;
+              }
+              if (Date.now() >= deadline) {
+                core.setFailed('No completed all-tests for this commit after 45 minutes — deferring to the run testing it.');
+                return;
+              }
+              core.info('No completed all-tests for this commit yet — waiting for the run testing it.');
+              await new Promise((resolve) => setTimeout(resolve, 30 * 1000));
             }
       - name: Aggregate suite results
         if: env.NO_OP != 'true'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -183,6 +183,9 @@ jobs:
                 repo: context.repo.repo,
                 ref: context.payload.pull_request.head.sha,
                 check_name: 'all-tests',
+                // `latest` (the default) returns only the newest run per name —
+                // this job's own in_progress run — hiding the completed verdict.
+                filter: 'all',
                 per_page: 100,
               });
               const prior = data.check_runs


### PR DESCRIPTION
### What

Two changes to the `Pull Request` workflow's no-op-run handling:

1. **Drop `closed` from the trigger types** (and the now-dead `github.event.action != 'closed'` job guards). Nothing in the workflow runs on `closed` — its only product was a no-op run whose `all-tests` mirror step raced the suite still testing the just-merged SHA. Any PR merged before its final suite completes was guaranteed a spurious red X (`No completed all-tests for this commit yet — deferring to the run testing it`), which reads as a broken build on a merged PR.

2. **Poll in the `all-tests` mirror step.** An `edited` no-op run hits the same race on open PRs, but it can't simply exit green: `all-tests` is a required check, and a vacuous success posted while the real suite is in flight could let the PR merge before its suite finishes. Instead, poll every 30s (up to 45 minutes) for a completed `all-tests` on the head SHA and mirror that verdict; only defer with a failure if nothing completes in time. The job's own in-progress check run never matches the completed filter, so it can't mirror itself.

### Why

Merged PRs have been showing red X's from the closed-event race (e.g. every automation-merged PR downstream), confusing engineers into thinking CI is broken.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request automation so CI runs only for active PR events (no longer tied to explicitly excluding closed events).
  * Refined no-op detection for aggregated test runs to reduce skipped or stale status updates.
  * Added polling-based waiting to mirror the most recent completed combined test result, lowering the chance of missed check conclusions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3195
<!-- enterprise-sync-pr:end -->