### PR TITLE
ci(community): update the community→develop PR body via REST

### DIFF
--- a/.github/workflows/community-to-develop.yml
+++ b/.github/workflows/community-to-develop.yml
@@ -73,7 +73,9 @@ jobs:
           number="$(gh pr list --repo "$REPO" --head community --base develop \
             --state open --json number --jq '.[0].number // empty')"
           if [ -n "$number" ]; then
-            gh pr edit "$number" --repo "$REPO" --body "$body"
+            # REST, not `gh pr edit`: edit's GraphQL metadata prefetch needs
+            # read:org, which the PAT doesn't have.
+            gh api --silent -X PATCH "repos/$REPO/pulls/$number" -f body="$body"
             action="updated"
           else
             gh pr create --repo "$REPO" --head community --base develop \


### PR DESCRIPTION
The update path of `community-to-develop.yml` calls `gh pr edit`, whose GraphQL metadata prefetch requires `read:org` — `FIFTYONE_GITHUB_TOKEN` has only `repo` + `workflow`, so every update-path run fails before refreshing the PR body or posting to #community (the create path uses `gh pr create`/`gh api` and is unaffected; that's why the PR-opened notification worked on Jul 6 17:43 while the update run at 19:21 for the CVAT contribution died with the scope error).

Replace it with a plain REST `PATCH /repos/{repo}/pulls/{number}`, which needs nothing beyond `repo` scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of the community-to-develop automation when updating an existing pull request.
  * Existing PRs are now updated through a more dependable request path, reducing failures caused by metadata lookup issues.
* **Chores**
  * The PR creation flow remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3198
<!-- enterprise-sync-pr:end -->