### PR TITLE
[HA] Persist pinned tracks per sample on the client

### DIFF
--- a/app/packages/playback/src/lib/tracks/TrackProvider.test.tsx
+++ b/app/packages/playback/src/lib/tracks/TrackProvider.test.tsx
@@ -131,4 +131,77 @@ describe("TrackProvider", () => {
       expect(Array.from(captured.pinnedIds)).toEqual([]);
     });
   });
+
+  describe("persistKey", () => {
+    const KEY = "fo-va-pinned-tracks:ds:sample-1";
+
+    afterEach(() => window.localStorage.clear());
+
+    const persistWrap =
+      (persistKey?: string, initialPinnedIds: string[] = []) =>
+      ({ children }: { children: React.ReactNode }) => (
+        <TrackProvider
+          tracks={TRACKS}
+          initialPinnedIds={initialPinnedIds}
+          persistKey={persistKey}
+        >
+          {children}
+        </TrackProvider>
+      );
+
+    it("hydrates the initial pin state from storage", () => {
+      window.localStorage.setItem(KEY, JSON.stringify(["dog", "person"]));
+      const { result } = renderHook(() => usePinnedTracks(), {
+        wrapper: persistWrap(KEY),
+      });
+      expect(result.current.map((t) => t.id).sort()).toEqual(["dog", "person"]);
+    });
+
+    it("falls back to initialPinnedIds when storage is empty", () => {
+      const { result } = renderHook(() => usePinnedTracks(), {
+        wrapper: persistWrap(KEY, ["cat"]),
+      });
+      expect(result.current.map((t) => t.id)).toEqual(["cat"]);
+    });
+
+    it("stored pins win over initialPinnedIds", () => {
+      window.localStorage.setItem(KEY, JSON.stringify(["dog"]));
+      const { result } = renderHook(() => usePinnedTracks(), {
+        wrapper: persistWrap(KEY, ["cat"]),
+      });
+      expect(result.current.map((t) => t.id)).toEqual(["dog"]);
+    });
+
+    it("writes pin changes back to storage", () => {
+      const { result } = renderHook(() => useTrackPinning(), {
+        wrapper: persistWrap(KEY),
+      });
+      act(() => result.current.togglePin("dog"));
+      expect(JSON.parse(window.localStorage.getItem(KEY)!)).toEqual(["dog"]);
+      act(() => result.current.togglePin("cat"));
+      expect(JSON.parse(window.localStorage.getItem(KEY)!).sort()).toEqual([
+        "cat",
+        "dog",
+      ]);
+      act(() => result.current.togglePin("dog"));
+      expect(JSON.parse(window.localStorage.getItem(KEY)!)).toEqual(["cat"]);
+    });
+
+    it("leaves storage untouched when no persistKey is given", () => {
+      const { result } = renderHook(() => useTrackPinning(), {
+        wrapper: persistWrap(undefined),
+      });
+      act(() => result.current.togglePin("dog"));
+      expect(window.localStorage.getItem(KEY)).toBeNull();
+      expect(window.localStorage.length).toBe(0);
+    });
+
+    it("ignores malformed stored values and uses initialPinnedIds", () => {
+      window.localStorage.setItem(KEY, "not json");
+      const { result } = renderHook(() => usePinnedTracks(), {
+        wrapper: persistWrap(KEY, ["person"]),
+      });
+      expect(result.current.map((t) => t.id)).toEqual(["person"]);
+    });
+  });
 });

--- a/app/packages/playback/src/lib/tracks/TrackProvider.tsx
+++ b/app/packages/playback/src/lib/tracks/TrackProvider.tsx
@@ -94,7 +94,41 @@ export interface TrackProviderProps {
    * explicit user action.
    */
   autoPinNewTracks?: boolean;
+  /**
+   * When set, the pinned-id set is persisted client-side under this
+   * `localStorage` key: it hydrates the initial pin state (falling back to
+   * `initialPinnedIds` when nothing is stored) and re-writes on every change.
+   * Callers own the key's scope (e.g. dataset + sample). **Read at mount** like
+   * `initialPinnedIds` — remount (re-key) to switch scopes. Omit for pure
+   * in-memory pinning.
+   */
+  persistKey?: string;
   children: React.ReactNode;
+}
+
+/** Read a persisted pinned-id set; null when absent, empty, or unparseable. */
+function readPersistedPinnedIds(key: string): Set<string> | null {
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return null;
+
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return null;
+
+    return new Set(parsed.filter((id): id is string => typeof id === "string"));
+  } catch {
+    // storage unavailable / malformed — fall back to the seeded ids.
+    return null;
+  }
+}
+
+/** Best-effort write of the pinned-id set; swallows quota / unavailable. */
+function writePersistedPinnedIds(key: string, ids: ReadonlySet<string>): void {
+  try {
+    window.localStorage.setItem(key, JSON.stringify([...ids]));
+  } catch {
+    // persistence is best-effort; ignore storage failures.
+  }
 }
 
 /**
@@ -116,11 +150,24 @@ export const TrackProvider: React.FC<TrackProviderProps> = ({
   tracks = [],
   initialPinnedIds = [],
   autoPinNewTracks = true,
+  persistKey,
   children,
 }) => {
-  const [pinnedIds, setPinnedSet] = useState<Set<string>>(
-    () => new Set(initialPinnedIds),
-  );
+  const [pinnedIds, setPinnedSet] = useState<Set<string>>(() => {
+    if (persistKey) {
+      const persisted = readPersistedPinnedIds(persistKey);
+      if (persisted) return persisted;
+    }
+
+    return new Set(initialPinnedIds);
+  });
+
+  // Mirror every pin change into client storage when a key is provided.
+  useEffect(() => {
+    if (!persistKey) return;
+
+    writePersistedPinnedIds(persistKey, pinnedIds);
+  }, [persistKey, pinnedIds]);
 
   // Auto-pin tracks added one-at-a-time after the initial load (e.g. a
   // newly created temporal tag). We distinguish "initial hydration" from

--- a/app/packages/video-annotation/src/components/FrameLabels.tsx
+++ b/app/packages/video-annotation/src/components/FrameLabels.tsx
@@ -576,6 +576,15 @@ export const FrameLabelsTracks: React.FC<{ sample?: ModalSample }> = ({
   const { resolveObjectColor, resolveTemporalDetectionColor } =
     useTrackColorResolvers();
 
+  // Persist pin state per video (dataset + sample) so reopening the same
+  // sample restores which tracks the user pinned to the timeline.
+  const dataset = useDatasetName();
+  const sampleId = useModalSampleId();
+  const persistKey =
+    dataset && sampleId
+      ? `fo-va-pinned-tracks:${dataset}:${sampleId}`
+      : undefined;
+
   // Dynamic attributes are declared per field, so resolve them per-path when
   // building tracks — a single primary-field lookup leaks one field's dynamic
   // attributes onto every other field's tracks.
@@ -637,6 +646,7 @@ export const FrameLabelsTracks: React.FC<{ sample?: ModalSample }> = ({
       key={ready ? "ready" : "init"}
       tracks={visibleTracks}
       autoPinNewTracks={false}
+      persistKey={persistKey}
     >
       <TimelineWithTracks
         decorateTrack={decorateTrack}


### PR DESCRIPTION
## What

Pin/unpin state on the video-annotation timeline is now persisted client-side, so it survives reopening the modal, navigating away and back, and page reloads. Previously pin state lived only in `TrackProvider`'s in-memory React state and reset on every remount (including the internal `init→ready` re-key).

## How

- **`@fiftyone/playback` — `TrackProvider`**: new optional `persistKey?: string` prop. When set, the initial pinned-id set hydrates from `localStorage[persistKey]` (falling back to `initialPinnedIds` when nothing is stored or the value is malformed), and every pin change writes back. All storage access is `try/catch`-guarded, so an unavailable/quota-limited store is a silent no-op. Omitting `persistKey` preserves today's exact in-memory behavior — the generic timeline, multimodal playback, and temporal-tag surfaces are untouched.
- **`@fiftyone/video-annotation` — `FrameLabelsTracks`**: passes a `persistKey` scoped per **dataset + sample** (`fo-va-pinned-tracks:<dataset>:<sampleId>`). Pins are conceptually per-video, so reopening the same sample restores its pins while a different video keeps its own set. Track ids are the stable `instance-<instance._id>`, so persistence is robust across reloads.

## Testing

- `TrackProvider.test.tsx`: 6 new cases covering hydrate-from-storage, stored-wins-over-initial, fallback-when-empty, write-back-on-toggle, storage-untouched-without-key, and malformed-value fallback. Full file 16/16 green.
- Scoped type-check clean on both changed packages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pinned track state can now persist across sessions when available, so previously pinned items are restored automatically.
  * Pinning changes are saved as you use the app, keeping your track layout consistent on return.
  * Video-specific persistence helps keep pinned tracks separate for different videos.

* **Bug Fixes**
  * If saved pin data is missing or invalid, the app now safely falls back to the default pinned tracks instead of failing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3237
<!-- enterprise-sync-pr:end -->