### PR TITLE
[HA] Create temporal detections on the active field

### DIFF
--- a/app/packages/video-annotation/src/hooks/useVideoAnnotationActions.tsx
+++ b/app/packages/video-annotation/src/hooks/useVideoAnnotationActions.tsx
@@ -8,8 +8,10 @@ import { getModalSampleFrameRate } from "../utils/modalSample";
 import {
   labelSchemaData,
   useTemporalDetectionFieldPaths,
+  useVisibleLabelSchemas,
 } from "../state/accessors";
 import {
+  useSelectedTemporalDetectionField,
   useSelectedTrackIds,
   useSelectionIsInstanceTrack,
   useSelectionIsKeyframeable,
@@ -66,15 +68,27 @@ export const useVideoAnnotationActions = (): ToolbarActionGroup[] => {
   const selected = useSelectedTrackIds();
   const modalSample = useModalSample();
 
-  // Resolve from the dataset schema
+  // Resolve from the dataset schema, narrowed to the schema-active set.
   const tdFieldPaths = useTemporalDetectionFieldPaths();
+  const visible = useVisibleLabelSchemas();
+  const selectedTdField = useSelectedTemporalDetectionField();
 
-  const tdFieldPath = useMemo(
+  const tdFieldPath = useMemo(() => {
     // Sample-level only — temporal detections are video-level; the create
-    // command targets a top-level field path.
-    () => tdFieldPaths.find((p) => !p.startsWith("frames.")) ?? null,
-    [tdFieldPaths],
-  );
+    // command targets a top-level field path. Honor schema activity so a
+    // deactivated field isn't a create target, matching the detection path.
+    const active = tdFieldPaths.filter(
+      (p) => !p.startsWith("frames.") && visible.has(p),
+    );
+
+    // Prefer the field of the TD the user is editing;
+    // else the first active field.
+    if (selectedTdField && active.includes(selectedTdField)) {
+      return selectedTdField;
+    }
+
+    return active[0] ?? null;
+  }, [tdFieldPaths, visible, selectedTdField]);
   const fps = getModalSampleFrameRate(modalSample);
   const canCreateTd =
     !!tdFieldPath && Number.isFinite(fps) && fps !== undefined && fps > 0;

--- a/app/packages/video-annotation/src/hooks/useVideoSurfaceActions.test.ts
+++ b/app/packages/video-annotation/src/hooks/useVideoSurfaceActions.test.ts
@@ -36,6 +36,7 @@ const mockActions = {
     path: "events",
     instanceId: "new-td",
   })),
+  setActive: vi.fn(),
 };
 
 const mockBus = { dispatch: vi.fn() };
@@ -439,6 +440,10 @@ describe("temporal-detection ops", () => {
       tags: [],
       label: "speaking",
     });
+    // the fresh TD becomes the selection, replacing any prior one
+    expect(mockActions.setActive).toHaveBeenCalledWith([
+      { sample: SAMPLE, path: "events", instanceId: "new-td" },
+    ]);
   });
 
   it("editTemporalDetection updates by id with no frame", () => {

--- a/app/packages/video-annotation/src/hooks/useVideoSurfaceActions.ts
+++ b/app/packages/video-annotation/src/hooks/useVideoSurfaceActions.ts
@@ -538,6 +538,9 @@ const makeTemporalDetectionOps = (actions: SurfaceActions) => {
       ...(label !== undefined ? { label } : {}),
     });
 
+    // Select the fresh TD so it becomes the editing target
+    actions.setActive([ref]);
+
     return ref.instanceId;
   };
 

--- a/app/packages/video-annotation/src/state/useVideoInteraction.ts
+++ b/app/packages/video-annotation/src/state/useVideoInteraction.ts
@@ -30,6 +30,11 @@ const INSTANCE_TRACK_TYPES: ReadonlySet<LabelType> = new Set([
   LabelType.Polylines,
 ]);
 
+const TEMPORAL_TYPES: ReadonlySet<LabelType> = new Set([
+  LabelType.TemporalDetection,
+  LabelType.TemporalDetections,
+]);
+
 /** Membership equality so a selector only re-renders on an id set change. */
 const sameIds = (a: ReadonlySet<string>, b: ReadonlySet<string>): boolean => {
   if (a.size !== b.size) {
@@ -116,6 +121,23 @@ export const useSelectionIsKeyframeable = (): boolean =>
  */
 export const useSelectionIsInstanceTrack = (): boolean =>
   useSelectionTypeGate(INSTANCE_TRACK_TYPES);
+
+/**
+ * The field path of the selected temporal detection, or `null` when the
+ * selection isn't a TD. Read from engine interaction — active refs carry their
+ * `.path`, and the field's type comes from `engine.getLabelType` — so "New TD"
+ * targets the field the user is working in without reaching into the sidebar's
+ * editing pointer.
+ */
+export const useSelectedTemporalDetectionField = (): string | null => {
+  const engine = useAnnotationEngine();
+  return useInteraction(engine, (i) => {
+    const td = i
+      .getActive()
+      .find((ref) => TEMPORAL_TYPES.has(engine.getLabelType(ref.path)));
+    return td?.path ?? null;
+  });
+};
 
 /** Read hovered track ids (engine instanceIds) from interaction state. */
 export const useHoveredTrackIds = (): ReadonlySet<string> => {


### PR DESCRIPTION
## What

The video annotation toolbar's **New TD** button always created a `TemporalDetection` on the *first* sample-level `TemporalDetections` field in the dataset schema, ignoring which field the user actually has active/selected. On a dataset with more than one TD field, every new TD landed on the wrong field.


## Changes

- **`useVideoInteraction.ts`** — add `useSelectedTemporalDetectionField`, an engine-native accessor that reads the selected TD's field from interaction state (active refs carry their `.path`; the field's type comes from `engine.getLabelType`). No reaching into the sidebar's editing pointer.
- **`useVideoAnnotationActions.tsx`** — resolve the create target against the schema-active set (`useVisibleLabelSchemas`), preferring the field of a selected TD, falling back to the first *active* TD field.
- **`useVideoSurfaceActions.ts`** — `createTemporalDetection` now selects the freshly-created TD (`setActive([ref])`), so the new label becomes the editing target instead of leaving the prior selection in place.

## Testing

- `useVideoSurfaceActions.test.ts` — assert the new TD is selected on create.
- `packages/video-annotation` suite green (32/32 in the touched files), scoped typecheck + eslint clean.
- Manually verified in the app: deactivating/activating TD fields in the schema manager retargets New TD; selecting an existing TD on another field targets that field; creating replaces the selection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New Temporal Detection creation now automatically opens the newly created item for editing.
  * The toolbar now chooses the most relevant visible temporal detection field, preferring the currently selected field when applicable.

* **Bug Fixes**
  * Improved field selection behavior so hidden or unrelated temporal detection fields are no longer chosen first.
  * Updated selection handling to replace any previous active item when creating a new Temporal Detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->