### PR TITLE
Recognize manual back-merge PRs in the enterprise-sync skip

### DIFF
--- a/.github/workflows/enterprise-sync.yml
+++ b/.github/workflows/enterprise-sync.yml
@@ -47,14 +47,22 @@ jobs:
             // Bases mirrored into Enterprise.
             const isSyncBase = (b) => b === 'develop' || b.startsWith('release/');
 
-            // Back-merge PRs (`merge/<ref> → develop`, opened by the
-            // develop-back-merge workflow as voxel51-bot) are *vertical*
-            // reconciliation, handled independently by each repo's own
-            // back-merge. Mirroring one would be a diagonal whole-branch merge
-            // that re-surfaces the entire OSS↔Enterprise divergence and
-            // duplicates the Enterprise repo's own back-merge. Skip the sync;
-            // mark the gate green so the OSS back-merge isn't blocked.
-            if (pr.head.ref.startsWith('merge/') && pr.user.login === 'voxel51-bot') {
+            // Back-merge PRs are *vertical* reconciliation, handled
+            // independently by each repo's own back-merge. Mirroring one would
+            // be a diagonal whole-branch merge that re-surfaces the entire
+            // OSS↔Enterprise divergence and duplicates the Enterprise repo's
+            // own back-merge. Skip the sync; mark the gate green so the OSS
+            // back-merge isn't blocked. Two conventions:
+            //  - `merge/<ref>` — opened by the develop-back-merge workflow
+            //  - `main-to-develop` / `release/v*-to-develop` — opened by hand
+            //    when conflicts need resolving (the merge/* ruleset blocks
+            //    human pushes). Head branches live in this repo (see job if),
+            //    so these are member-created.
+            const isBackMerge =
+              (pr.head.ref.startsWith('merge/') && pr.user.login === 'voxel51-bot') ||
+              pr.head.ref === 'main-to-develop' ||
+              /^release\/v[\d.]+-to-develop$/.test(pr.head.ref);
+            if (isBackMerge) {
               if (action !== 'closed') {
                 await github.rest.repos.createCommitStatus({
                   owner: context.repo.owner,

--- a/.github/workflows/enterprise-sync.yml
+++ b/.github/workflows/enterprise-sync.yml
@@ -54,10 +54,9 @@ jobs:
             // own back-merge. Skip the sync; mark the gate green so the OSS
             // back-merge isn't blocked. Two conventions:
             //  - `merge/<ref>` — opened by the develop-back-merge workflow
-            //  - `main-to-develop` — opened by hand when conflicts need
-            //    resolving (the merge/* ruleset blocks human pushes). Head
-            //    branches live in this repo (see job if), so these are
-            //    member-created.
+            //  - `main-to-develop` — opened by hand at the end of a release
+            //    (the merge/* ruleset blocks human pushes). Head branches
+            //    live in this repo (see job if), so these are member-created.
             const isBackMerge =
               (pr.head.ref.startsWith('merge/') && pr.user.login === 'voxel51-bot') ||
               pr.head.ref === 'main-to-develop';

--- a/.github/workflows/enterprise-sync.yml
+++ b/.github/workflows/enterprise-sync.yml
@@ -54,14 +54,13 @@ jobs:
             // own back-merge. Skip the sync; mark the gate green so the OSS
             // back-merge isn't blocked. Two conventions:
             //  - `merge/<ref>` — opened by the develop-back-merge workflow
-            //  - `main-to-develop` / `release/v*-to-develop` — opened by hand
-            //    when conflicts need resolving (the merge/* ruleset blocks
-            //    human pushes). Head branches live in this repo (see job if),
-            //    so these are member-created.
+            //  - `main-to-develop` — opened by hand when conflicts need
+            //    resolving (the merge/* ruleset blocks human pushes). Head
+            //    branches live in this repo (see job if), so these are
+            //    member-created.
             const isBackMerge =
               (pr.head.ref.startsWith('merge/') && pr.user.login === 'voxel51-bot') ||
-              pr.head.ref === 'main-to-develop' ||
-              /^release\/v[\d.]+-to-develop$/.test(pr.head.ref);
+              pr.head.ref === 'main-to-develop';
             if (isBackMerge) {
               if (action !== 'closed') {
                 await github.rest.repos.createCommitStatus({


### PR DESCRIPTION
## What changes

`enterprise-sync` skips back-merge PRs (stamping `enterprise / ci = success`) since they are reconciled natively on the Enterprise side, but the skip only matched the `develop-back-merge` workflow's convention: head `merge/*` authored by `voxel51-bot`.

Release close-out back-merges are opened by hand as `main-to-develop` (the `merge/*` ruleset blocks human pushes, and these PRs always need hand-resolved conflicts). Those fell through to the normal sync path, which attempts a whole-branch mirror with an ancient merge-base — the required `enterprise / ci` check then fails with "Merge conflict with Enterprise `develop`" and merging requires an admin bypass. See #7943.

This broadens the skip to also match `main-to-develop` heads. Trust level is unchanged: the job already requires the head branch to live in this repo, so only members with push access can trigger the skip.

## How is this tested

Condition-only change to the `github-script` step; verified the branch matching against the head refs of #7943 (`main-to-develop`, previously falling through) and the standing bot back-merge PRs (`merge/*`, unchanged behavior).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of back-merge pull requests to prevent unnecessary Enterprise sync dispatch.
  * Expanded back-merge recognition to include additional branch naming (including `main-to-develop`).
  * For skipped non-closed pull requests, the Enterprise CI commit status is now set to success with a back-merge-specific description.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->