### PR TITLE
fix: unblock CI from develop merge fallout (formatting + unused import)

### DIFF
--- a/app/packages/commands/src/actions/Undoable.ts
+++ b/app/packages/commands/src/actions/Undoable.ts
@@ -27,7 +27,7 @@ export class DelegatingUndoable extends DelegatingAction implements Undoable {
     id: string,
     execFn: () => void | Promise<void>,
     undoFn: () => void | Promise<void>,
-    describeFn?: () => string
+    describeFn?: () => string,
   ) {
     super(id, execFn);
     this._undoFn = undoFn;

--- a/app/packages/commands/src/keys/KeyManager.ts
+++ b/app/packages/commands/src/keys/KeyManager.ts
@@ -60,7 +60,7 @@ export class KeyManager {
             //If there are no more sequences to match, return the command
             if (index === sequences.length - 1) {
               command = commands.find(({ command: cmd }) =>
-                cmd.isEnabled()
+                cmd.isEnabled(),
               )?.command;
               break;
             }
@@ -102,7 +102,7 @@ export class KeyManager {
     const command = this.commandRegistry.getCommand(commandId);
     if (!command) {
       throw new Error(
-        `The command id ${commandId} is not registered for binding ${sequence}`
+        `The command id ${commandId} is not registered for binding ${sequence}`,
       );
     }
 
@@ -117,7 +117,7 @@ export class KeyManager {
           priority,
           order: this.bindingOrder++,
         },
-      ].sort((a, b) => b.priority - a.priority || a.order - b.order)
+      ].sort((a, b) => b.priority - a.priority || a.order - b.order),
     );
   }
 
@@ -143,7 +143,7 @@ export class KeyManager {
     }
 
     const remainingCommands = commands.filter(
-      ({ command }) => command.id !== commandId
+      ({ command }) => command.id !== commandId,
     );
     if (remainingCommands.length === 0) {
       this.bindings.delete(binding);

--- a/app/packages/core/src/components/Modal/Modal.tsx
+++ b/app/packages/core/src/components/Modal/Modal.tsx
@@ -140,7 +140,7 @@ const Modal = () => {
       // Reset the tracked target
       pointerDownTargetRef.current = null;
     },
-    [clearModal]
+    [clearModal],
   );
 
   const { jsonPanel, helpPanel } = useLookerHelpers();
@@ -149,7 +149,7 @@ const Modal = () => {
     ({ snapshot, set }) =>
       async () => {
         const isTooltipCurrentlyLocked = await snapshot.getPromise(
-          fos.isTooltipLocked
+          fos.isTooltipLocked,
         );
         if (isTooltipCurrentlyLocked) {
           set(fos.isTooltipLocked, false);
@@ -169,14 +169,14 @@ const Modal = () => {
         clearModal();
         activeLookerRef.current?.removeEventListener(
           "close",
-          modalCloseHandler
+          modalCloseHandler,
         );
 
         selectiveRenderingEventBus.removeAllListeners();
 
         jotaiStore.set(currentModalUniqueIdJotaiAtom, "");
       },
-    [clearModal, jsonPanel, helpPanel]
+    [clearModal, jsonPanel, helpPanel],
   );
 
   const selectCallback = useRecoilCallback(
@@ -195,7 +195,7 @@ const Modal = () => {
           return newSelected;
         });
       },
-    []
+    [],
   );
 
   const sidebarFn = useRecoilCallback(
@@ -203,7 +203,7 @@ const Modal = () => {
       async () => {
         set(fos.sidebarVisible(true), (prev) => !prev);
       },
-    []
+    [],
   );
 
   const fullscreenFn = useRecoilCallback(
@@ -211,7 +211,7 @@ const Modal = () => {
       async () => {
         set(fos.fullscreen, (prev) => !prev);
       },
-    []
+    [],
   );
 
   const closeFn = useRecoilCallback(
@@ -235,7 +235,7 @@ const Modal = () => {
 
         await modalCloseHandler();
       },
-    [is3dVisible, modalCloseHandler]
+    [is3dVisible, modalCloseHandler],
   );
 
   const isSidebarVisible = useRecoilValue(fos.sidebarVisible(true));
@@ -301,10 +301,10 @@ const Modal = () => {
           currentModalUniqueIdJotaiAtom,
           `${snapshot.getLoadable(fos.groupId).getValue()}-${snapshot
             .getLoadable(fos.nullableModalSampleId)
-            .getValue()}`
+            .getValue()}`,
         );
       },
-    [modalCloseHandler, addTooltipEventHandler]
+    [modalCloseHandler, addTooltipEventHandler],
   );
 
   const setActiveLookerRef = useCallback(
@@ -312,7 +312,7 @@ const Modal = () => {
       activeLookerRef.current = looker;
       onLookerSet(looker);
     },
-    [onLookerSet]
+    [onLookerSet],
   );
 
   return ReactDOM.createPortal(
@@ -369,7 +369,7 @@ const Modal = () => {
         </ModalContainer>
       </ModalWrapper>
     </modalContext.Provider>,
-    document.getElementById("modal") as HTMLDivElement
+    document.getElementById("modal") as HTMLDivElement,
   );
 };
 

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/serialization.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/serialization.ts
@@ -29,7 +29,7 @@ export function serializeDateValue(type: string, date: Date): string {
  * @returns The serialized value
  */
 export function serializeDatabaseDateValue(
-  value: Primitive | { datetime: number }
+  value: Primitive | { datetime: number },
 ): Primitive {
   if (!isDateInDatabaseFormat(value)) return value;
   return new Date(value.datetime).toISOString();
@@ -41,7 +41,7 @@ export function serializeDatabaseDateValue(
  * @returns True if the value is in the format { _cls: "DateTime", datetime: number }, false otherwise
  */
 export function isDateInDatabaseFormat(
-  value: unknown
+  value: unknown,
 ): value is { datetime: number } {
   return !isNullish(value) && typeof value === "object" && "datetime" in value;
 }
@@ -55,7 +55,7 @@ export function isDateInDatabaseFormat(
  */
 export function serializeFieldValue(
   fieldValue: Primitive | Date,
-  type: string
+  type: string,
 ): Primitive {
   if (fieldValue instanceof Date) {
     return serializeDateValue(type, fieldValue);
@@ -86,7 +86,7 @@ export function serializeFieldValue(
  */
 export function parseDatabaseValue(
   _type: string,
-  value: unknown
+  value: unknown,
 ): Primitive | Date {
   /**
    * from the backend we get: { datetime: number, '_cls': 'datetime' }

--- a/app/packages/lighter/src/core/Scene2D.ts
+++ b/app/packages/lighter/src/core/Scene2D.ts
@@ -57,19 +57,19 @@ import type { Scene2DConfig, SceneOptions } from "./SceneConfig";
 
 export const TypeGuards = {
   isHoverable: (
-    body: Partial<BaseOverlay & Hoverable>
+    body: Partial<BaseOverlay & Hoverable>,
   ): body is BaseOverlay & Hoverable =>
     "getTooltipInfo" in body &&
     "onHoverEnter" in body &&
     "onHoverLeave" in body &&
     "onHoverMove" in body,
   isSelectable: (
-    body: BaseOverlay | InteractionHandler
+    body: BaseOverlay | InteractionHandler,
   ): body is BaseOverlay & InteractionHandler & Selectable =>
     "id" in body && "isSelected" in body && "setSelected" in body,
 
   isSpatial: (
-    body: BaseOverlay | InteractionHandler
+    body: BaseOverlay | InteractionHandler,
   ): body is BaseOverlay & Spatial => "bounds" in body,
 
   isInteractionHandler: (value: unknown): value is InteractionHandler =>
@@ -173,7 +173,7 @@ export class Scene2D {
       config.canvas,
       this.selectionManager,
       config.renderer,
-      this.eventChannel
+      this.eventChannel,
     );
 
     this.eventBus = getEventBus<LighterEventGroup>(this.eventChannel);
@@ -187,7 +187,7 @@ export class Scene2D {
         this.overlays.forEach((overlay) => {
           overlay.markDirty();
         });
-      }
+      },
     );
 
     // Listen for scene options changes to trigger re-rendering
@@ -259,7 +259,7 @@ export class Scene2D {
             overlay,
             event.id,
             startBounds,
-            bounds
+            bounds,
           );
           CommandContextManager.instance()
             .getActiveContext()
@@ -286,7 +286,7 @@ export class Scene2D {
             overlay,
             event.id,
             startBounds,
-            endBounds
+            endBounds,
           );
           CommandContextManager.instance()
             .getActiveContext()
@@ -318,14 +318,14 @@ export class Scene2D {
             beforeSnapshot,
             beforeBounds,
             afterSnapshot,
-            afterBounds
+            afterBounds,
           );
 
           CommandContextManager.instance()
             .getActiveContext()
             .pushUndoable(command);
         }
-      }
+      },
     );
 
     // Listen for DO_OVERLAY_HOVER events to force hover state
@@ -364,7 +364,7 @@ export class Scene2D {
    */
   private registerEventHandler<K extends keyof LighterEventGroup>(
     event: K,
-    handler: EventHandler<LighterEventGroup[K]>
+    handler: EventHandler<LighterEventGroup[K]>,
   ): void {
     const offHandler = this.eventBus.on(event, handler);
     this.abortController.signal.addEventListener("abort", offHandler);
@@ -421,7 +421,7 @@ export class Scene2D {
    */
   private createFieldBins(
     overlays: Map<string, BaseOverlay>,
-    activePaths: string[]
+    activePaths: string[],
   ): Record<string, string[]> {
     const bins: Record<string, string[]> = {};
 
@@ -446,7 +446,7 @@ export class Scene2D {
   private buildInitialOrder(
     bins: Record<string, string[]>,
     activePaths: string[],
-    overlays?: Map<string, BaseOverlay>
+    overlays?: Map<string, BaseOverlay>,
   ): string[] {
     const ordered: string[] = [];
 
@@ -470,7 +470,7 @@ export class Scene2D {
    */
   private addRemainingOverlays(
     ordered: string[],
-    overlays: Map<string, BaseOverlay>
+    overlays: Map<string, BaseOverlay>,
   ): string[] {
     const result = [...ordered];
 
@@ -506,7 +506,7 @@ export class Scene2D {
    */
   private rotateOverlays(
     overlays: string[],
-    rotate: number
+    rotate: number,
   ): [string[], number] {
     if (overlays.length === 0) {
       return [overlays, 0];
@@ -540,7 +540,7 @@ export class Scene2D {
 
     const newRotation = Math.min(
       this.rotation + 1,
-      this.overlayOrder.length - 1
+      this.overlayOrder.length - 1,
     );
 
     if (newRotation !== this.rotation) {
@@ -1029,7 +1029,7 @@ export class Scene2D {
    * @returns A function to unregister the callback.
    */
   registerRenderCallback(
-    callback: Omit<RenderCallback, "id"> & { id?: string }
+    callback: Omit<RenderCallback, "id"> & { id?: string },
   ): () => void {
     const id = callback.id || `render-callback-${Date.now()}-${Math.random()}`;
 
@@ -1058,10 +1058,10 @@ export class Scene2D {
    * @param phase - The phase to execute callbacks for.
    */
   private async executeRenderCallbacks(
-    phase: "before" | "after"
+    phase: "before" | "after",
   ): Promise<void> {
     const callbacks = Array.from(this.renderCallbacks.values()).filter(
-      (callback) => callback.phase === phase
+      (callback) => callback.phase === phase,
     );
 
     for (const callback of callbacks) {
@@ -1088,7 +1088,7 @@ export class Scene2D {
         this,
         overlay,
         undefined,
-        undefined
+        undefined,
       );
       this.executeCommand(command);
       return;
@@ -1142,7 +1142,7 @@ export class Scene2D {
   removeOverlay(
     id: string,
     withUndo: boolean = false,
-    lifecycle: boolean = false
+    lifecycle: boolean = false,
   ): void {
     if (withUndo) {
       const overlay = this.overlays.get(id);
@@ -1166,7 +1166,7 @@ export class Scene2D {
 
       this.overlays.delete(id);
       this.overlayOrder = this.overlayOrder.filter(
-        (overlayId) => overlayId !== id
+        (overlayId) => overlayId !== id,
       );
       this.renderingState.clear(id);
     }
@@ -1217,7 +1217,7 @@ export class Scene2D {
    */
   async transformOverlay(
     id: string,
-    options: TransformOptions
+    options: TransformOptions,
   ): Promise<boolean> {
     const overlay = this.overlays.get(id);
     if (!overlay) {
@@ -1254,7 +1254,7 @@ export class Scene2D {
       overlay,
       id,
       oldBounds,
-      newBounds
+      newBounds,
     );
 
     await this.executeCommand(command);
@@ -1276,7 +1276,7 @@ export class Scene2D {
    */
   getVisibleOverlays(): BaseOverlay[] {
     return Array.from(this.overlays.values()).filter((overlay) =>
-      this.shouldShowOverlay(overlay)
+      this.shouldShowOverlay(overlay),
     );
   }
 
@@ -1297,7 +1297,7 @@ export class Scene2D {
   getVisibleSelectableOverlays(): BaseOverlay[] {
     return Array.from(this.overlays.values()).filter(
       (overlay) =>
-        this.shouldShowOverlay(overlay) && TypeGuards.isSelectable(overlay)
+        this.shouldShowOverlay(overlay) && TypeGuards.isSelectable(overlay),
     );
   }
 
@@ -1602,7 +1602,7 @@ export class Scene2D {
    */
   private shouldRenderOverlay(
     overlay: BaseOverlay | undefined,
-    status: string
+    status: string,
   ): boolean {
     return (
       overlay !== undefined &&
@@ -1650,7 +1650,7 @@ export class Scene2D {
         this.createOverlayStyle(overlay),
         {
           canonicalMediaBounds,
-        }
+        },
       );
 
       if (ret instanceof Promise) {
@@ -1691,7 +1691,7 @@ export class Scene2D {
    * @param handler - The interaction handler to use for interactive mode.
    */
   public enterInteractiveMode(
-    handler: InteractionHandler | InteractiveDetectionHandler
+    handler: InteractionHandler | InteractiveDetectionHandler,
   ): void {
     if (this.interactiveMode) {
       return;
@@ -1743,7 +1743,7 @@ export class Scene2D {
    * coupling lighter to the consumer's identity.
    */
   public setEmptyCanvasClickHandler(
-    handler: EmptyCanvasClickHandler | null
+    handler: EmptyCanvasClickHandler | null,
   ): void {
     this.interactionManager.setEmptyCanvasClickHandler(handler);
   }

--- a/app/packages/lighter/src/interaction/InteractionManager.ts
+++ b/app/packages/lighter/src/interaction/InteractionManager.ts
@@ -56,7 +56,7 @@ export interface OverlayEvent {
 export type EmptyCanvasClickHandler = (
   worldPoint: Point,
   point: Point,
-  event: PointerEvent
+  event: PointerEvent,
 ) => boolean | void;
 
 /**
@@ -84,7 +84,7 @@ export interface KeypointMutationHandler {
 }
 
 function hasKeypointMutation(
-  h: InteractionHandler
+  h: InteractionHandler,
 ): h is InteractionHandler & KeypointMutationHandler {
   return (
     "getSelectedPointIndex" in h &&
@@ -133,7 +133,7 @@ export interface InteractionHandler {
   getCursor?(
     worldPoint: Point,
     scale: number,
-    modifiers?: ClickEventModifiers
+    modifiers?: ClickEventModifiers,
   ): string;
 
   /**
@@ -147,7 +147,7 @@ export interface InteractionHandler {
    */
   onModifiersChanged?(
     modifiers: ClickEventModifiers,
-    worldPoint: Point | null
+    worldPoint: Point | null,
   ): void;
 
   /** Returns the current state of the handler */
@@ -259,7 +259,7 @@ export class InteractionManager {
     private canvas: HTMLCanvasElement,
     private selectionManager: SelectionManager,
     private renderer: Renderer2D,
-    eventChannel: string
+    eventChannel: string,
   ) {
     this.eventBus = getEventBus<LighterEventGroup>(eventChannel);
     this.setupEventListeners();
@@ -397,7 +397,7 @@ export class InteractionManager {
       const cursor = handler.getCursor?.(
         worldPoint,
         scale,
-        this.currentModifiers
+        this.currentModifiers,
       );
       if (cursor) {
         this.canvas.style.cursor = cursor;
@@ -440,7 +440,7 @@ export class InteractionManager {
   private configureCursorStyle(
     handler: InteractionHandler,
     worldPoint: Point,
-    scale: number
+    scale: number,
   ): void {
     if (
       segmentationModeBridge.isActive() &&
@@ -458,13 +458,13 @@ export class InteractionManager {
       this.canvas.style.cursor = "pointer";
     } else if (segmentationModeBridge.isActive()) {
       this.canvas.style.cursor = buildBrushCursor(
-        segmentationModeBridge.getToolState(scale)!
+        segmentationModeBridge.getToolState(scale)!,
       );
     } else if (TypeGuards.isInteractionHandler(handler) && handler.getCursor) {
       this.canvas.style.cursor = handler.getCursor(
         worldPoint,
         scale,
-        this.currentModifiers
+        this.currentModifiers,
       );
     }
   }
@@ -571,7 +571,7 @@ export class InteractionManager {
         event,
         scale: pending.scale,
         segmentationToolState: segmentationModeBridge.getToolState(
-          pending.scale
+          pending.scale,
         ),
       });
 
@@ -607,7 +607,7 @@ export class InteractionManager {
 
     const distance = Math.hypot(
       point.x - this.pendingAction.point.x,
-      point.y - this.pendingAction.point.y
+      point.y - this.pendingAction.point.y,
     );
 
     if (distance > this.CLICK_THRESHOLD) {
@@ -652,7 +652,7 @@ export class InteractionManager {
         this.scheduleHoverUpdate(
           this.currentPixelCoordinates,
           event,
-          undefined
+          undefined,
         );
       }
     } else {
@@ -1065,7 +1065,7 @@ export class InteractionManager {
       const cursor = interactiveHandler.getCursor(
         worldPoint,
         this.renderer.getScale(),
-        this.currentModifiers
+        this.currentModifiers,
       );
       if (cursor) {
         this.canvas.style.cursor = cursor;
@@ -1248,7 +1248,7 @@ export class InteractionManager {
   private scheduleHoverUpdate(
     point: Point,
     event: PointerEvent,
-    resolvedHandler: InteractionHandler | undefined
+    resolvedHandler: InteractionHandler | undefined,
   ): void {
     this.latestHoverPoint = point;
     this.latestHoverEvent = event;
@@ -1293,7 +1293,7 @@ export class InteractionManager {
   private handleHover(
     point: Point,
     event: PointerEvent,
-    resolvedHandler: InteractionHandler | undefined
+    resolvedHandler: InteractionHandler | undefined,
   ): void {
     const worldPoint = this.renderer.screenToWorld(point);
     const scale = this.renderer.getScale();
@@ -1390,7 +1390,7 @@ export class InteractionManager {
   }
 
   private handleZoomed = (
-    _event: LighterEventGroup["lighter:zoomed"]
+    _event: LighterEventGroup["lighter:zoomed"],
   ): void => {
     this.handlers?.forEach((handler) => handler.markDirty());
 
@@ -1409,7 +1409,7 @@ export class InteractionManager {
 
     const scale = this.renderer.getScale();
     this.canvas.style.cursor = buildBrushCursor(
-      segmentationModeBridge.getToolState(scale)!
+      segmentationModeBridge.getToolState(scale)!,
     );
   };
 
@@ -1419,7 +1419,7 @@ export class InteractionManager {
     const timeDiff = now - this.lastClickTime;
     const distance = Math.sqrt(
       Math.pow(point.x - this.lastClickPoint.x, 2) +
-        Math.pow(point.y - this.lastClickPoint.y, 2)
+        Math.pow(point.y - this.lastClickPoint.y, 2),
     );
 
     return (
@@ -1432,7 +1432,7 @@ export class InteractionManager {
     // self-managed handlers take precedence to allow editing on top of
     // other overlays
     const selfManaged = this.handlers.find((h) =>
-      isSelfManagedInteractiveHandler(h)
+      isSelfManagedInteractiveHandler(h),
     );
 
     return (
@@ -1466,7 +1466,7 @@ export class InteractionManager {
    */
   private findHandlerAtPoint(
     point: Point,
-    skipCanonicalMedia: boolean = false
+    skipCanonicalMedia: boolean = false,
   ): InteractionHandler | undefined {
     // Single-pass: find best handler at point using priority rules.
     // Priority: selected > highest selectable priority > topmost (reverse order).

--- a/app/packages/lighter/src/overlay/BaseOverlay.ts
+++ b/app/packages/lighter/src/overlay/BaseOverlay.ts
@@ -23,9 +23,9 @@ import type {
 /**
  * Base abstract class for all overlays.
  */
-export abstract class BaseOverlay<Label extends RawLookerLabel = RawLookerLabel>
-  implements InteractionHandler
-{
+export abstract class BaseOverlay<
+  Label extends RawLookerLabel = RawLookerLabel,
+> implements InteractionHandler {
   readonly id: string;
   readonly cursor?: string;
 
@@ -93,7 +93,7 @@ export abstract class BaseOverlay<Label extends RawLookerLabel = RawLookerLabel>
     if (!bounds) return false;
 
     return ["x", "y", "width", "height"].every(
-      (prop) => !Number.isNaN(bounds[prop])
+      (prop) => !Number.isNaN(bounds[prop]),
     );
   }
 
@@ -140,7 +140,7 @@ export abstract class BaseOverlay<Label extends RawLookerLabel = RawLookerLabel>
   render(
     renderer: Renderer2D,
     style: DrawStyle | null,
-    meta: RenderMeta
+    meta: RenderMeta,
   ): void | Promise<void> {
     // Store the current style for use in other methods
     this.currentStyle = style || undefined;
@@ -155,7 +155,7 @@ export abstract class BaseOverlay<Label extends RawLookerLabel = RawLookerLabel>
    */
   protected abstract renderImpl(
     renderer: Renderer2D,
-    meta: RenderMeta
+    meta: RenderMeta,
   ): void | Promise<void>;
 
   /**

--- a/app/packages/looker-3d/src/annotation/CustomAnnotationGizmo.tsx
+++ b/app/packages/looker-3d/src/annotation/CustomAnnotationGizmo.tsx
@@ -56,7 +56,7 @@ type CameraRenderState = {
 const hasCameraRenderStateChanged = (
   previousState: CameraRenderState | null,
   camera: THREE.PerspectiveCamera,
-  target: THREE.Vector3
+  target: THREE.Vector3,
 ) => {
   return (
     previousState === null ||
@@ -99,7 +99,9 @@ const GizmoContainer = styled.div`
   }
 
   .fo3d-gizmo-axis circle {
-    transition: r 120ms ease, filter 120ms ease;
+    transition:
+      r 120ms ease,
+      filter 120ms ease;
   }
 
   .fo3d-gizmo-axis:hover circle {
@@ -115,7 +117,7 @@ const GizmoContainer = styled.div`
 const projectAxis = (
   direction: THREE.Vector3,
   inverseCameraQuaternion: THREE.Quaternion,
-  length: number
+  length: number,
 ) => {
   const cameraSpaceDirection = direction
     .clone()
@@ -129,7 +131,7 @@ const projectAxis = (
 };
 
 const getAxisRenderState = (
-  cameraQuaternion: THREE.Quaternion
+  cameraQuaternion: THREE.Quaternion,
 ): AxisRenderState[] => {
   const inverseCameraQuaternion = cameraQuaternion.clone().invert();
 
@@ -137,13 +139,13 @@ const getAxisRenderState = (
     const positive = projectAxis(
       direction,
       inverseCameraQuaternion,
-      AXIS_LENGTH
+      AXIS_LENGTH,
     );
     const negativeDirection = direction.clone().negate();
     const negative = projectAxis(
       negativeDirection,
       inverseCameraQuaternion,
-      NEGATIVE_AXIS_LENGTH
+      NEGATIVE_AXIS_LENGTH,
     );
 
     const depthRatio = (positive.depth + 1) / 2;
@@ -185,7 +187,7 @@ const AnnotationOrientationGizmoSvg = ({
 }) => {
   const axes = useMemo(
     () => getAxisRenderState(cameraQuaternion),
-    [cameraQuaternion]
+    [cameraQuaternion],
   );
 
   return (
@@ -343,7 +345,7 @@ const AnnotationOrientationGizmo = ({
         position: direction.clone().multiplyScalar(radius).add(target),
       });
     },
-    [mainCamera, cameraControlsRef, mainCameraState]
+    [mainCamera, cameraControlsRef, mainCameraState],
   );
 
   return (

--- a/app/packages/multimodal/src/query/query.test.ts
+++ b/app/packages/multimodal/src/query/query.test.ts
@@ -11,7 +11,6 @@ import {
   createMemoryByteRangeCache,
   createCachedByteClient,
   createHttpByteClient,
-  BYTE_SOURCE_READ_PROFILE,
   DEFAULT_LOCAL_BYTE_CACHE_BLOCK_SIZE_BYTES,
   DEFAULT_REMOTE_BYTE_CACHE_BLOCK_SIZE_BYTES,
   type ByteRangeReadRequest,

--- a/app/packages/playback/src/lib/playback/PlaybackProvider.test.tsx
+++ b/app/packages/playback/src/lib/playback/PlaybackProvider.test.tsx
@@ -66,7 +66,7 @@ function renderEngine(opts: RenderOpts = {}) {
           {children}
         </PlaybackProvider>
       ),
-    }
+    },
   );
 }
 
@@ -959,7 +959,7 @@ describe("PlaybackProvider engine actions", () => {
       });
       expect(result.current.store.get(stepIntervalAtom)).toBeCloseTo(
         1 / 100,
-        6
+        6,
       );
     });
 

--- a/app/packages/playback/src/lib/playback/use-playback-engine.ts
+++ b/app/packages/playback/src/lib/playback/use-playback-engine.ts
@@ -46,7 +46,7 @@ import type {
 function frameBoundaryStep(
   time: number,
   step: number,
-  direction: "forward" | "back"
+  direction: "forward" | "back",
 ): number {
   if (!(step > 0)) {
     return direction === "forward" ? time + step : time - step;
@@ -124,7 +124,7 @@ export function usePlaybackEngine({
     const rawLoopEnd = clamp(
       defaultLoopEnd ?? initialDuration,
       0,
-      initialDuration
+      initialDuration,
     );
     // Inverted / collapsed window → fall back to the full timeline so the
     // RAF wrap path isn't trapped in a zero-width loop.
@@ -223,7 +223,7 @@ export function usePlaybackEngine({
         seekDebounceRef.current = setTimeout(fire, SEEK_BAR_DEBOUNCE);
       }
     },
-    [store]
+    [store],
   );
 
   const doCommit = useCallback(
@@ -234,7 +234,7 @@ export function usePlaybackEngine({
         s.onCommit?.(time, store);
       }
     },
-    [store, isActive]
+    [store, isActive],
   );
 
   /**
@@ -280,7 +280,7 @@ export function usePlaybackEngine({
 
       return !isBuffering;
     },
-    [store, isActive]
+    [store, isActive],
   );
 
   /**
@@ -353,7 +353,7 @@ export function usePlaybackEngine({
 
       rafIdRef.current = requestAnimationFrame(tick);
     },
-    [store, fireSeekEvent, doCommit, runBarrier]
+    [store, fireSeekEvent, doCommit, runBarrier],
   );
 
   useEffect(() => {
@@ -440,7 +440,7 @@ export function usePlaybackEngine({
 
       return ready;
     },
-    [isActive, store]
+    [isActive, store],
   );
 
   const clearPendingPlay = useCallback(
@@ -449,7 +449,7 @@ export function usePlaybackEngine({
       store.set(isPlayPendingAtom, false);
       if (clearBuffering) store.set(isBufferingAtom, false);
     },
-    [store]
+    [store],
   );
 
   const startPlayback = useCallback(() => {
@@ -468,7 +468,7 @@ export function usePlaybackEngine({
       store.set(isPlayPendingAtom, true);
       store.set(isBufferingAtom, true);
     },
-    [evaluatePlaybackStart, startPlayback, store]
+    [evaluatePlaybackStart, startPlayback, store],
   );
 
   const tryStartPendingPlayback = useCallback(() => {
@@ -490,11 +490,11 @@ export function usePlaybackEngine({
   useEffect(() => {
     const unsubscribeBufferedRanges = store.sub(
       bufferedRangesAtom,
-      tryStartPendingPlayback
+      tryStartPendingPlayback,
     );
     const unsubscribeStreamRanges = store.sub(
       streamRangesVersionAtom,
-      tryStartPendingPlayback
+      tryStartPendingPlayback,
     );
     return () => {
       unsubscribeBufferedRanges();
@@ -520,7 +520,7 @@ export function usePlaybackEngine({
         settleRafRef.current = requestAnimationFrame(settleTick);
       }
     },
-    [runBarrier, doCommit, settleTick]
+    [runBarrier, doCommit, settleTick],
   );
 
   const actions = useMemo(() => {
@@ -543,7 +543,7 @@ export function usePlaybackEngine({
       const snapped = clamp(
         displayedFrameStart(current, step),
         0,
-        store.get(durationAtom)
+        store.get(durationAtom),
       );
 
       if (Math.abs(snapped - current) < step * 1e-6) {
@@ -635,10 +635,10 @@ export function usePlaybackEngine({
           frameBoundaryStep(
             store.get(playheadAtom),
             store.get(stepIntervalAtom),
-            "back"
+            "back",
           ),
           0,
-          store.get(durationAtom)
+          store.get(durationAtom),
         );
         store.set(playheadAtom, next);
         fireSeekEvent(next, true);
@@ -650,10 +650,10 @@ export function usePlaybackEngine({
           frameBoundaryStep(
             store.get(playheadAtom),
             store.get(stepIntervalAtom),
-            "forward"
+            "forward",
           ),
           0,
-          store.get(durationAtom)
+          store.get(durationAtom),
         );
         store.set(playheadAtom, next);
         fireSeekEvent(next, true);
@@ -664,7 +664,7 @@ export function usePlaybackEngine({
         const bounds = clampAndValidateBounds(
           start,
           end,
-          store.get(durationAtom)
+          store.get(durationAtom),
         );
         if (!bounds) return;
         store.set(viewStartAtom, bounds.start);
@@ -674,7 +674,7 @@ export function usePlaybackEngine({
         const bounds = clampAndValidateBounds(
           start,
           end,
-          store.get(durationAtom)
+          store.get(durationAtom),
         );
         if (!bounds) return;
         store.set(loopStartAtom, bounds.start);
@@ -707,7 +707,7 @@ export function usePlaybackEngine({
       subscribeStream: (id: string) => {
         subscribersRef.current.set(
           id,
-          (subscribersRef.current.get(id) ?? 0) + 1
+          (subscribersRef.current.get(id) ?? 0) + 1,
         );
         tryStartPendingPlayback();
         // One-shot cleanup. StrictMode's setup→cleanup→setup cycle (and
@@ -754,7 +754,7 @@ export function usePlaybackEngine({
 
   const contextValue = useMemo<PlaybackContextValue>(
     () => ({ duration, stepInterval, ...actions }),
-    [duration, stepInterval, actions]
+    [duration, stepInterval, actions],
   );
 
   return { store, contextValue };
@@ -763,7 +763,7 @@ export function usePlaybackEngine({
 function streamHasStartupCoverage(
   stream: PlaybackStream,
   time: number,
-  duration: number
+  duration: number,
 ): boolean {
   const startupSeconds = stream.startupBufferSeconds ?? 0;
   if (startupSeconds <= 0) return true;
@@ -775,7 +775,7 @@ function streamHasStartupCoverage(
     ranges,
     time,
     Math.min(duration, time + startupSeconds),
-    startupCoverageStartTolerance(stream)
+    startupCoverageStartTolerance(stream),
   );
 }
 
@@ -791,11 +791,11 @@ function startupCoverageStartTolerance(stream: PlaybackStream): number {
 function startupPrefetchEnd(
   stream: PlaybackStream,
   time: number,
-  duration: number
+  duration: number,
 ): number {
   const lookaheadSeconds = Math.max(
     stream.startupBufferSeconds ?? 0,
-    stream.lookaheadSeconds ?? DEFAULT_PREFETCH_LOOKAHEAD_SECONDS
+    stream.lookaheadSeconds ?? DEFAULT_PREFETCH_LOOKAHEAD_SECONDS,
   );
   return Math.min(duration, time + lookaheadSeconds);
 }
@@ -804,7 +804,7 @@ function rangesCoverInterval(
   ranges: ReturnType<NonNullable<PlaybackStream["bufferedRanges"]>>,
   start: number,
   end: number,
-  startTolerance = 0
+  startTolerance = 0,
 ): boolean {
   if (end <= start) return true;
 

--- a/app/packages/playback/src/views/TimelineControls/TimelineControls.tsx
+++ b/app/packages/playback/src/views/TimelineControls/TimelineControls.tsx
@@ -93,7 +93,7 @@ const TimelineControls: React.FC<TimelineControlsProps> = ({
     ? (e: React.MouseEvent<HTMLDivElement>) => {
         const target = e.target as HTMLElement;
         const interactive = target.closest(
-          'button, [role="button"], a, input, select, textarea'
+          'button, [role="button"], a, input, select, textarea',
         );
         if (interactive && interactive !== e.currentTarget) return;
         onToggle();

--- a/app/packages/playback/src/views/TimelineHeader/TimelineHeader.test.tsx
+++ b/app/packages/playback/src/views/TimelineHeader/TimelineHeader.test.tsx
@@ -102,7 +102,7 @@ describe("TimelineHeader", () => {
     render(
       <HeaderHarness
         rulerOverlay={<div data-testid="my-overlay">overlay</div>}
-      />
+      />,
     );
     const ruler = screen.getByTestId("timeline-ruler");
     expect(ruler.querySelector('[data-testid="my-overlay"]')).not.toBeNull();
@@ -122,7 +122,7 @@ describe("TimelineHeader", () => {
     render(
       <HeaderHarness>
         <div data-testid="pinned-section">pinned tracks</div>
-      </HeaderHarness>
+      </HeaderHarness>,
     );
     expect(screen.getByTestId("pinned-section")).toBeTruthy();
     // The root should gain a third child (the belowRuler wrapper).
@@ -165,7 +165,7 @@ describe("TimelineHeader", () => {
               [6, 8],
             ]}
           />
-        </HeaderHarness>
+        </HeaderHarness>,
       );
       const strip = screen.getByTestId("buffered-ranges-strip");
       // Rendered inside the ruler's tick lane (which carries the label
@@ -186,7 +186,7 @@ describe("TimelineHeader", () => {
       render(
         <HeaderHarness duration={10}>
           <SetBufferedRanges ranges={[[-2, 25]]} />
-        </HeaderHarness>
+        </HeaderHarness>,
       );
       const strip = screen.getByTestId("buffered-ranges-strip");
       const segment = strip.children[0] as HTMLElement;

--- a/app/packages/playback/src/views/TimelineRuler/TimelineRuler.tsx
+++ b/app/packages/playback/src/views/TimelineRuler/TimelineRuler.tsx
@@ -80,8 +80,8 @@ const TimelineRuler: React.FC<TimelineRulerProps> = ({
       clamp(
         viewStart + (laneX / laneWidth) * (viewEnd - viewStart),
         0,
-        duration
-      )
+        duration,
+      ),
     );
   };
 
@@ -91,7 +91,7 @@ const TimelineRuler: React.FC<TimelineRulerProps> = ({
     () => () => {
       setHoverTime(store, null);
     },
-    [store]
+    [store],
   );
 
   // Capture state at drag-start so onDelta can compute against it without
@@ -128,7 +128,7 @@ const TimelineRuler: React.FC<TimelineRulerProps> = ({
       const vd = startVe - startVs;
       dragRef.current.maxAbsDelta = Math.max(
         dragRef.current.maxAbsDelta,
-        Math.abs(delta)
+        Math.abs(delta),
       );
       // `seekSnapped` quantizes to the displayed-frame start when the
       // provider opted into snap-to-frame; otherwise it's a plain seek. The
@@ -156,7 +156,7 @@ const TimelineRuler: React.FC<TimelineRulerProps> = ({
       const t = clamp(
         startValue + (delta / laneWidth) * vd,
         0,
-        loopEnd - 1 / 60
+        loopEnd - 1 / 60,
       );
       setLoop(t, loopEnd);
     },
@@ -174,7 +174,7 @@ const TimelineRuler: React.FC<TimelineRulerProps> = ({
       const t = clamp(
         startValue + (delta / laneWidth) * vd,
         loopStart + 1 / 60,
-        duration
+        duration,
       );
       setLoop(loopStart, t);
     },
@@ -191,7 +191,7 @@ const TimelineRuler: React.FC<TimelineRulerProps> = ({
       const { startVs, startVe, laneWidth } = dragRef.current;
       dragRef.current.maxAbsDelta = Math.max(
         dragRef.current.maxAbsDelta,
-        Math.abs(delta)
+        Math.abs(delta),
       );
       const vd = startVe - startVs;
       const dt = (delta / laneWidth) * vd;
@@ -247,7 +247,7 @@ const TimelineRuler: React.FC<TimelineRulerProps> = ({
         const ratio = clamp(
           (e.clientX - rect.left - labelWidth) / laneWidth,
           0,
-          1
+          1,
         );
         const pivotTime = vs + ratio * (ve - vs);
         const factor = e.deltaY > 0 ? 1.15 : 1 / 1.15;
@@ -255,7 +255,7 @@ const TimelineRuler: React.FC<TimelineRulerProps> = ({
         const newStart = clamp(
           pivotTime - ratio * newDuration,
           0,
-          duration - newDuration
+          duration - newDuration,
         );
         setViewRef.current(newStart, newStart + newDuration);
       } else if (Math.abs(e.deltaX) > Math.abs(e.deltaY)) {
@@ -311,8 +311,8 @@ const TimelineRuler: React.FC<TimelineRulerProps> = ({
   const cursor = playheadDrag.isDragging
     ? "grabbing"
     : loopStartDrag.isDragging || loopEndDrag.isDragging
-    ? "ew-resize"
-    : undefined;
+      ? "ew-resize"
+      : undefined;
 
   return (
     <div

--- a/app/packages/playback/src/views/TimelineWithTracks/TimelineWithTracks.test.tsx
+++ b/app/packages/playback/src/views/TimelineWithTracks/TimelineWithTracks.test.tsx
@@ -33,7 +33,7 @@ function renderTimeline(opts: RenderOpts = {}) {
       <TrackProvider tracks={tracks} initialPinnedIds={pinnedIds}>
         <TimelineWithTracks labelWidth={labelWidth} />
       </TrackProvider>
-    </PlaybackProvider>
+    </PlaybackProvider>,
   );
 }
 

--- a/app/packages/playback/src/views/TimelineWithTracks/TimelineWithTracks.tsx
+++ b/app/packages/playback/src/views/TimelineWithTracks/TimelineWithTracks.tsx
@@ -61,7 +61,7 @@ export interface TimelineWithTracksProps {
    */
   decorateTrack?: (
     track: Track,
-    pinned: boolean
+    pinned: boolean,
   ) => Partial<TimelineTrackProps>;
 }
 
@@ -101,7 +101,7 @@ const TimelineWithTracks: React.FC<TimelineWithTracksProps> = ({
   // {@link partitionTracksByPin}.
   const { pinned, unpinned } = useMemo(
     () => partitionTracksByPin(tracks, pinnedIds),
-    [tracks, pinnedIds]
+    [tracks, pinnedIds],
   );
 
   const renderPinnedTrack = (track: Track) => (

--- a/app/packages/utilities/src/fetch.ts
+++ b/app/packages/utilities/src/fetch.ts
@@ -89,7 +89,7 @@ export interface FetchFunction {
     retries?: number,
     retryCodes?: number[],
     errorHandler?: (response: Response) => void | Promise<void>,
-    headers?: Record<string, string>
+    headers?: Record<string, string>,
   ): Promise<R>;
 }
 
@@ -105,7 +105,7 @@ export interface FetchFunctionExtended {
     retries?: number,
     retryCodes?: number[],
     errorHandler?: (response: Response) => void | Promise<void>,
-    headers?: Record<string, string>
+    headers?: Record<string, string>,
   ): Promise<FetchFunctionResult<R>>;
 }
 
@@ -127,7 +127,7 @@ export type GetFetchFunctionOptions = {
  */
 const withCache = <T>(
   cacheKey: string,
-  fetchFn: () => Promise<T>
+  fetchFn: () => Promise<T>,
 ): Promise<T> => {
   if (fetchCache.has(cacheKey)) {
     return Promise.resolve(fetchCache.get(cacheKey) as T);
@@ -177,7 +177,7 @@ export const getFetchFunction = (options?: GetFetchFunctionOptions) => {
     retries?: number,
     retryCodes?: number[],
     errorHandler?: (response: Response) => void | Promise<void>,
-    headers?: Record<string, string>
+    headers?: Record<string, string>,
   ): Promise<R> =>
     withCache(buildCacheKey(method, path, body), () =>
       fetchFunctionSingleton<A, R>(
@@ -188,8 +188,8 @@ export const getFetchFunction = (options?: GetFetchFunctionOptions) => {
         retries,
         retryCodes,
         errorHandler,
-        headers
-      )
+        headers,
+      ),
     );
 };
 
@@ -199,7 +199,7 @@ export const getFetchFunction = (options?: GetFetchFunctionOptions) => {
  */
 export const getFetchFunctionExtended =
   (): (<A, R>(
-    config: FetchFunctionConfig<A>
+    config: FetchFunctionConfig<A>,
   ) => Promise<FetchFunctionResult<R>>) =>
   <A, R>(config: FetchFunctionConfig<A>): Promise<FetchFunctionResult<R>> => {
     const doFetch = () =>
@@ -211,13 +211,13 @@ export const getFetchFunctionExtended =
         config.retries,
         config.retryCodes,
         config.errorHandler,
-        config.headers
+        config.headers,
       );
 
     if (config.cache) {
       return withCache(
         buildCacheKey(config.method, config.path, config.body),
-        doFetch
+        doFetch,
       );
     }
 
@@ -258,7 +258,7 @@ export const mergeHeaders = (
       // convert everything to Record<string, string>
       .map((h) => headersAsRecord(h))
       // reduce with spread, ignoring any undefined values
-      .reduce((a, b) => (a && b ? { ...a, ...b } : a ?? b), {})
+      .reduce((a, b) => (a && b ? { ...a, ...b } : (a ?? b)), {})
   );
 };
 
@@ -287,7 +287,7 @@ export function getFetchPathPrefix(): string {
 export const setFetchParameters = (
   origin: string,
   headers: HeadersInit = {},
-  pathPrefix = ""
+  pathPrefix = "",
 ) => {
   fetchHeaders = headers;
   fetchOrigin = origin;
@@ -305,7 +305,7 @@ export const getFetchParameters = () => {
 export const setFetchFunction = (
   origin: string,
   defaultHeaders: HeadersInit = {},
-  pathPrefix = ""
+  pathPrefix = "",
 ) => {
   setFetchParameters(origin, defaultHeaders, pathPrefix);
 
@@ -317,7 +317,7 @@ export const setFetchFunction = (
     retries = 2,
     retryCodes = [502, 503, 504],
     errorHandler,
-    headers
+    headers,
   ) => {
     let url: string;
     const controller = new AbortController();
@@ -341,7 +341,7 @@ export const setFetchFunction = (
     headers = mergeHeaders(
       body ? { "Content-Type": "application/json" } : {},
       defaultHeaders,
-      headers
+      headers,
     );
 
     const fetchCall = retries
@@ -437,7 +437,7 @@ export const setFetchFunction = (
     retries: number = 2,
     retryCodes: number[] = [502, 503, 504],
     errorHandler: (response: Response) => void | Promise<void>,
-    headers: Record<string, string>
+    headers: Record<string, string>,
   ) =>
     fetchFunctionExtended<A, R>(
       method,
@@ -447,12 +447,15 @@ export const setFetchFunction = (
       retries,
       retryCodes,
       errorHandler,
-      headers
+      headers,
     ).then((res) => res.response);
 };
 
 class JSONStreamParser {
-  constructor(response, private controller: AbortController) {
+  constructor(
+    response,
+    private controller: AbortController,
+  ) {
     this.reader = response.body.getReader();
     this.decoder = new TextDecoder();
     this.partialLine = "";
@@ -533,7 +536,7 @@ export const getEventSource = (
     onerror?: (error: Error) => void;
   },
   signal: AbortSignal,
-  body = {}
+  body = {},
 ): void => {
   if (polling) {
     pollingEventSource(path, events, signal, body);
@@ -609,7 +612,7 @@ export const getEventSource = (
                 stack: (err as unknown as { stack?: string }).stack,
               },
               (err as unknown as { message?: string }).message ??
-                `${response.status} ${response.url}`
+                `${response.status} ${response.url}`,
             );
           }
 
@@ -644,7 +647,7 @@ const pollingEventSource = (
   },
   signal: AbortSignal,
   body = {},
-  opened = false
+  opened = false,
 ): void => {
   if (signal.aborted) {
     return;
@@ -672,7 +675,7 @@ const pollingEventSource = (
 
       setTimeout(
         () => pollingEventSource(path, events, signal, body, opened),
-        2000
+        2000,
       );
     })
     .catch((error) => {
@@ -689,7 +692,7 @@ const pollingEventSource = (
 
       setTimeout(
         () => pollingEventSource(path, events, signal, body, opened),
-        2000
+        2000,
       );
     });
 };


### PR DESCRIPTION
## What

Fixes the CI failures the recent main→develop merge (#7943) left on **every** PR against `develop`:

1. **Formatting** — runs Prettier over 16 source files that landed unformatted, so `format:check` (whole-repo) passes again.
2. **Unused import** — drops a dead `BYTE_SOURCE_READ_PROFILE` import in `multimodal/src/query/query.test.ts` (leftover from a removed test). It tripped `noUnusedLocals` (TS6133), failing both `build` (`check:strict`) and the `lint` job's multimodal type check.

## Why

Both issues are repo-wide, so CI was red on any PR regardless of its contents. This restores a green baseline (`build`, `lint`, and the `e2e` asset prep that depends on `build`).

## How

- Formatting: `prettier --write` using the repo's pinned binary (`app/node_modules/.bin/prettier` 3.8.4 — the same one CI's `format:check` and the pre-commit hook use). Formatting only, no logic changes.
- Import: removed the single unused named import.

Verified locally: `prettier --check` clean on all tracked files, `yarn check` (multimodal) and `yarn check:strict` both exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Summary by CodeRabbit

* **Style**
  * Improved formatting consistency across command handling, modal UI, interaction logic, overlays, 3D gizmos, scene/scene2D helpers, and timeline playback components (e.g., trailing commas and reflowed multi-line arguments).
  * Minor structural reformatting in key binding/matching and timeline hover/drag logic without altering behavior.

* **Tests**
  * Updated a handful of tests to match the same formatting conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3201
<!-- enterprise-sync-pr:end -->