### PR TITLE
Infer multimodal media type from sample filepaths

### DIFF
--- a/app/packages/state/src/accessors/dataset.ts
+++ b/app/packages/state/src/accessors/dataset.ts
@@ -61,7 +61,7 @@ export const useIsGroupDataset = () => {
   return useRecoilValue(isGroup);
 };
 
-export type GroupSliceMediaType = "video" | "3d" | "image";
+export type GroupSliceMediaType = "video" | "3d" | "image" | "multimodal";
 
 /**
  * Hook which provides a function to get the default keypoint skeleton for a

--- a/app/packages/state/src/hooks/useSchemaSettings.utils.test.ts
+++ b/app/packages/state/src/hooks/useSchemaSettings.utils.test.ts
@@ -973,6 +973,12 @@ describe("Disabled field types in schema fields", () => {
       );
     });
 
+    it("getPath should return original path when dataset.mediaType is 'multimodal'", () => {
+      expect(
+        getPath(FIELDS.SAMPLE_ID_FIELD.path, "multimodal", SCHEMA),
+      ).toEqual(FIELDS.SAMPLE_ID_FIELD.path);
+    });
+
     it("getPath should return [frames.]path when dataset.mediaType is 'video'", () => {
       expect(getPath(FIELDS.SAMPLE_ID_FIELD.path, "video", SCHEMA)).toEqual(
         `frames.${FIELDS.SAMPLE_ID_FIELD.path}`,
@@ -1009,6 +1015,15 @@ describe("Disabled field types in schema fields", () => {
       ).toContain(FIELDS.METADATA_FIELD.path);
       expect(
         getSubPaths(FIELDS.METADATA_FIELD.path, SCHEMA, "image"),
+      ).toContain(FIELDS.METADATA_WIDTH_FIELD.path);
+    });
+
+    it("getSubPaths should return correct subpaths in a multimodal dataset", () => {
+      expect(
+        getSubPaths(FIELDS.METADATA_FIELD.path, SCHEMA, "multimodal"),
+      ).toContain(FIELDS.METADATA_FIELD.path);
+      expect(
+        getSubPaths(FIELDS.METADATA_FIELD.path, SCHEMA, "multimodal"),
       ).toContain(FIELDS.METADATA_WIDTH_FIELD.path);
     });
 

--- a/app/packages/state/src/hooks/useSchemaSettings.utils.ts
+++ b/app/packages/state/src/hooks/useSchemaSettings.utils.ts
@@ -1,4 +1,3 @@
-import { MediaType } from "@fiftyone/relay";
 import {
   CLASSIFICATION_DISABLED_SUB_PATHS,
   CLASSIFICATION_FIELD,
@@ -35,6 +34,9 @@ import {
   VALID_LABEL_TYPES,
   VALID_LIST_LABEL_FIELDS,
 } from "@fiftyone/utilities";
+import type { State } from "../recoil/types";
+
+type MediaType = State.MediaType;
 
 const isMetadataField = (path: string) => {
   return path === "metadata" || path.startsWith("metadata.");

--- a/app/packages/state/src/recoil/types.ts
+++ b/app/packages/state/src/recoil/types.ts
@@ -1,5 +1,6 @@
 import type { CustomizeColorInput } from "@fiftyone/relay";
 import type { SpaceNodeJSON } from "@fiftyone/spaces";
+import type { RecognizedMediaType } from "@fiftyone/utilities";
 
 export type SelectionType = "default" | "alt";
 export type SelectionIconStyle =
@@ -35,13 +36,9 @@ export const DEFAULT_LABEL_SELECTION_STYLE: LabelSelectionStyle = {
 
 export namespace State {
   export type MediaType =
-    | "image"
-    | "group"
+    | RecognizedMediaType
     | "point_cloud"
-    | "point-cloud"
     | "three_d"
-    | "3d"
-    | "video"
     | "unknown";
 
   export enum SPACE {

--- a/app/packages/utilities/src/media.test.ts
+++ b/app/packages/utilities/src/media.test.ts
@@ -5,6 +5,8 @@ import {
   isDirect3dSamplePath,
   isFo3d,
   isFo3dSamplePath,
+  isMultimodal,
+  isNativeMediaType,
   isPointCloud,
   isWrappableDirect3dSamplePath,
   setContains3d,
@@ -47,6 +49,24 @@ describe("media utils", () => {
 
     it("should return false for other types", () => {
       otherTypes.forEach((mt) => expect(is3d(mt)).toBeFalsy());
+    });
+  });
+
+  describe("isMultimodal", () => {
+    it("should return true for multimodal media types", () => {
+      expect(isMultimodal("multimodal")).toBeTruthy();
+    });
+
+    it("should return false for other media types", () => {
+      [...fo3dTypes, ...pointCloudTypes, ...otherTypes, null].forEach((mt) =>
+        expect(isMultimodal(mt)).toBeFalsy(),
+      );
+    });
+  });
+
+  describe("isNativeMediaType", () => {
+    it("should return false for multimodal media types", () => {
+      expect(isNativeMediaType("multimodal")).toBeFalsy();
     });
   });
 

--- a/app/packages/utilities/src/media.test.ts
+++ b/app/packages/utilities/src/media.test.ts
@@ -14,7 +14,7 @@ import {
   setContainsPointCloud,
 } from "./media";
 
-const pointCloudTypes = ["point-cloud", "point_cloud"];
+const pointCloudTypes = ["pcd", "point-cloud", "point_cloud"];
 const fo3dTypes = ["3d", "three_d"];
 const otherTypes = ["image", "video", "other", undefined];
 
@@ -65,6 +65,16 @@ describe("media utils", () => {
   });
 
   describe("isNativeMediaType", () => {
+    it("should return true for native media types", () => {
+      [null, undefined, "image", "video", "group"].forEach((mt) =>
+        expect(isNativeMediaType(mt)).toBeTruthy(),
+      );
+      fo3dTypes.forEach((mt) => expect(isNativeMediaType(mt)).toBeTruthy());
+      pointCloudTypes.forEach((mt) =>
+        expect(isNativeMediaType(mt)).toBeTruthy(),
+      );
+    });
+
     it("should return false for multimodal media types", () => {
       expect(isNativeMediaType("multimodal")).toBeFalsy();
     });

--- a/fiftyone/core/media.py
+++ b/fiftyone/core/media.py
@@ -41,7 +41,7 @@ def get_media_type(filepath):
     if etav.is_video_mime_type(filepath):
         return VIDEO
 
-    ext = os.path.splitext(filepath)[1]
+    ext = os.path.splitext(filepath)[1].lower()
 
     if ext == ".pcd":
         return POINT_CLOUD
@@ -49,7 +49,7 @@ def get_media_type(filepath):
     if ext == ".fo3d":
         return THREE_D
 
-    if ext.lower() in MULTIMODAL_EXTENSIONS:
+    if ext in MULTIMODAL_EXTENSIONS:
         return MULTIMODAL
 
     return UNKNOWN

--- a/fiftyone/core/media.py
+++ b/fiftyone/core/media.py
@@ -6,6 +6,8 @@ Sample media utilities.
 |
 """
 
+import os
+
 import eta.core.image as etai
 import eta.core.video as etav
 
@@ -14,8 +16,10 @@ VIDEO = "video"
 IMAGE = "image"
 POINT_CLOUD = "point-cloud"
 THREE_D = "3d"
+MULTIMODAL = "multimodal"
 UNKNOWN = "unknown"
-MEDIA_TYPES = {IMAGE, VIDEO, POINT_CLOUD, THREE_D, UNKNOWN}
+MEDIA_TYPES = {IMAGE, VIDEO, POINT_CLOUD, THREE_D, MULTIMODAL, UNKNOWN}
+MULTIMODAL_EXTENSIONS = {".mcap", ".bag", ".rrd"}
 
 # Special media types
 GROUP = "group"
@@ -37,11 +41,16 @@ def get_media_type(filepath):
     if etav.is_video_mime_type(filepath):
         return VIDEO
 
-    if filepath.endswith(".pcd"):
+    ext = os.path.splitext(filepath)[1]
+
+    if ext == ".pcd":
         return POINT_CLOUD
 
-    if filepath.endswith(".fo3d"):
+    if ext == ".fo3d":
         return THREE_D
+
+    if ext.lower() in MULTIMODAL_EXTENSIONS:
+        return MULTIMODAL
 
     return UNKNOWN
 

--- a/tests/unittests/utils_tests.py
+++ b/tests/unittests/utils_tests.py
@@ -727,6 +727,12 @@ class MediaTypeTests(unittest.TestCase):
         self.assertEqual(self.vid_sample.media_type, fom.VIDEO)
         self.assertEqual(self.vid_dataset.media_type, fom.VIDEO)
 
+    def test_3d_types(self):
+        self.assertEqual(fom.get_media_type("scene.pcd"), fom.POINT_CLOUD)
+        self.assertEqual(fom.get_media_type("scene.PCD"), fom.POINT_CLOUD)
+        self.assertEqual(fom.get_media_type("scene.fo3d"), fom.THREE_D)
+        self.assertEqual(fom.get_media_type("scene.FO3D"), fom.THREE_D)
+
     def test_multimodal_types(self):
         for ext in fom.MULTIMODAL_EXTENSIONS:
             self.assertEqual(

--- a/tests/unittests/utils_tests.py
+++ b/tests/unittests/utils_tests.py
@@ -727,6 +727,32 @@ class MediaTypeTests(unittest.TestCase):
         self.assertEqual(self.vid_sample.media_type, fom.VIDEO)
         self.assertEqual(self.vid_dataset.media_type, fom.VIDEO)
 
+    def test_multimodal_types(self):
+        for ext in fom.MULTIMODAL_EXTENSIONS:
+            self.assertEqual(
+                fom.get_media_type("scene" + ext),
+                fom.MULTIMODAL,
+            )
+            self.assertEqual(
+                fom.get_media_type("scene" + ext.upper()),
+                fom.MULTIMODAL,
+            )
+
+        sample = fo.Sample(filepath="scene.mcap")
+        self.assertEqual(sample.media_type, fom.MULTIMODAL)
+
+        dataset = fo.Dataset()
+        dataset.add_sample(sample)
+        self.assertEqual(dataset.media_type, fom.MULTIMODAL)
+
+    def test_explicit_multimodal_dataset(self):
+        dataset = fo.Dataset(media_type=fom.MULTIMODAL)
+        self.assertEqual(dataset.media_type, fom.MULTIMODAL)
+
+    def test_generic_types_remain_unknown(self):
+        for ext in (".json", ".jsonl", ".parquet"):
+            self.assertEqual(fom.get_media_type("scene" + ext), fom.UNKNOWN)
+
     def test_img_change_attempts(self):
         with self.assertRaises(fom.MediaTypeError):
             self.img_sample.filepath = "video.mp4"
@@ -734,6 +760,12 @@ class MediaTypeTests(unittest.TestCase):
     def test_vid_change_attempts(self):
         with self.assertRaises(fom.MediaTypeError):
             self.vid_sample.filepath = "image.png"
+
+    def test_multimodal_change_attempts(self):
+        sample = fo.Sample(filepath="scene.mcap")
+
+        with self.assertRaises(fom.MediaTypeError):
+            sample.filepath = "image.png"
 
 
 class MigrationTests(unittest.TestCase):


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

Adds SDK media-type inference for `.mcap`, `.bag`, and `.rrd` files and syncs app-side media-type typing with the new `multimodal` value. Multimodal stays non-native in the app so plugin and custom renderers can handle it without changing built-in looker behavior.

## 🧪 How is this patch tested? If it is not, please explain why.

- `python -m pytest tests/unittests/utils_tests.py -k MediaTypeTests -q`
- `yarn vitest run packages/utilities/src/media.test.ts packages/state/src/hooks/useSchemaSettings.utils.test.ts`
- `yarn typecheck` fails on existing unrelated app type errors outside this patch.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

FiftyOne now infers the `multimodal` media type for `.mcap`, `.bag`, and `.rrd` sample filepaths.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a new **multimodal** media type, including recognition of common multimodal file extensions.
  * Multimodal samples and datasets now retain the correct media type when created from supported files.

* **Bug Fixes**
  * Improved media-type detection by handling file extensions more reliably (including case-insensitive matching).
  * Prevented invalid media-type changes when switching a multimodal item to an incompatible file type.

* **Tests**
  * Expanded coverage for multimodal media detection and schema/path handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3230
<!-- enterprise-sync-pr:end -->