### PR TITLE
Add more MCAP ROS schema support + top-level topics tab

### DIFF
--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove.test.ts
@@ -956,9 +956,12 @@ describe("Foxglove decoders", () => {
     expect(protobuf.timing?.sourceTimestamps?.messageTime).toBe(8_000_000_009n);
     expect(cdr.attributes?.logRows).toEqual([
       expect.objectContaining({
+        file: "controller.cpp",
         level: "warn",
         levelNumber: 3,
+        line: 10,
         message: "tracking degraded",
+        name: "controller",
         timestampNs: 5_000_000_004n,
       }),
     ]);

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove.test.ts
@@ -14,6 +14,7 @@ import {
   isImageAnnotationsStream,
   isImageStream,
   isLocationFixStream,
+  isLogStream,
   isPointCloudStream,
   isPoseStream,
   isSceneUpdateStream,
@@ -27,6 +28,7 @@ import {
   FOXGLOVE_IMAGE_ANNOTATIONS_CDR_PAYLOADS,
   FOXGLOVE_LASER_SCAN_CDR_PAYLOADS,
   FOXGLOVE_LOCATION_FIX_CDR_PAYLOADS,
+  FOXGLOVE_LOG_CDR_PAYLOADS,
   FOXGLOVE_POINT_CLOUD_CDR_PAYLOADS,
   FOXGLOVE_POSE_IN_FRAME_CDR_PAYLOADS,
   FOXGLOVE_SCENE_UPDATE_CDR_PAYLOADS,
@@ -44,6 +46,8 @@ import {
   foxgloveLaserScanDecoder,
   foxgloveLocationFixCdrDecoders,
   foxgloveLocationFixDecoder,
+  foxgloveLogCdrDecoders,
+  foxgloveLogDecoder,
   foxglovePointCloudCdrDecoders,
   foxglovePointCloudDecoder,
   foxglovePoseInFrameCdrDecoders,
@@ -119,6 +123,10 @@ describe("Foxglove decoders", () => {
       foxgloveLocationFixDecoder,
     );
     for (const decoder of foxgloveLocationFixCdrDecoders) {
+      expect(registry.find(decoder.payload)).toBe(decoder);
+    }
+    expect(registry.find(foxgloveLogDecoder.payload)).toBe(foxgloveLogDecoder);
+    for (const decoder of foxgloveLogCdrDecoders) {
       expect(registry.find(decoder.payload)).toBe(decoder);
     }
     for (const decoder of foxgloveImageAnnotationsCdrDecoders) {
@@ -905,6 +913,57 @@ describe("Foxglove decoders", () => {
     expect(output.timing?.sourceTimestamps?.messageTime).toBe(4_000_000_005n);
   });
 
+  it("decodes Foxglove Log protobuf and CDR payloads into console rows", () => {
+    const Log = LOG_ROOT.lookupType("foxglove.Log");
+    const protobuf = foxgloveLogDecoder.decode(
+      Log.encode(
+        Log.create({
+          file: "planner.cpp",
+          level: 4,
+          line: 42,
+          message: "planner failed",
+          name: "planner",
+          timestamp: { nanos: 9, seconds: 8 },
+        }),
+      ).finish(),
+      { schemaData: LOG_SCHEMA_DATA },
+    );
+    const cdr = decoderForSchemaEncoding(
+      foxgloveLogCdrDecoders,
+      "ros2msg",
+    ).decode(
+      ros2Message(ROS2_LOG_SCHEMA, {
+        file: "controller.cpp",
+        level: 3,
+        line: 10,
+        message: "tracking degraded",
+        name: "controller",
+        timestamp: { nanosec: 4, sec: 5 },
+      }),
+      { schemaData: schemaData(ROS2_LOG_SCHEMA) },
+    );
+
+    expect(protobuf.attributes?.logRows).toEqual([
+      expect.objectContaining({
+        file: "planner.cpp",
+        level: "error",
+        line: 42,
+        message: "planner failed",
+        name: "planner",
+        timestampNs: 8_000_000_009n,
+      }),
+    ]);
+    expect(protobuf.timing?.sourceTimestamps?.messageTime).toBe(8_000_000_009n);
+    expect(cdr.attributes?.logRows).toEqual([
+      expect.objectContaining({
+        level: "warn",
+        levelNumber: 3,
+        message: "tracking degraded",
+        timestampNs: 5_000_000_004n,
+      }),
+    ]);
+  });
+
   it("decodes protobuf scalar grid payloads into translucent masks", () => {
     const output = foxgloveGridDecoder.decode(
       gridWireMessage({
@@ -963,6 +1022,7 @@ describe("Foxglove decoders", () => {
       "/scene",
       FOXGLOVE_SCENE_UPDATE_CDR_PAYLOADS[0],
     );
+    const log = createTopic("/logs", FOXGLOVE_LOG_CDR_PAYLOADS[0]);
 
     expect(isCompressedImageStream(compressedImage)).toBe(true);
     expect(isImageStream(compressedImage)).toBe(true);
@@ -991,6 +1051,7 @@ describe("Foxglove decoders", () => {
         createTopic("/gps", FOXGLOVE_LOCATION_FIX_CDR_PAYLOADS[0]),
       ),
     ).toBe(true);
+    expect(isLogStream(log)).toBe(true);
     expect(
       streamTopics([
         compressedImage,
@@ -998,12 +1059,14 @@ describe("Foxglove decoders", () => {
         laserScan,
         annotations,
         sceneUpdate,
+        log,
       ]),
     ).toMatchObject({
       annotations: ["/camera/annotations"],
       image: ["/camera/compressed"],
+      logs: ["/logs"],
       pointCloud: ["/points", "/scan"],
-      previewable: ["/camera/compressed", "/points", "/scan"],
+      previewable: ["/camera/compressed", "/points", "/scan", "/logs"],
       sceneUpdates: ["/scene"],
     });
   });
@@ -1443,6 +1506,52 @@ bool frame_locked
 MSG: builtin_interfaces/Time
 int32 sec
 uint32 nanosec`;
+
+const ROS2_LOG_SCHEMA = `builtin_interfaces/Time timestamp
+uint8 level
+string message
+string name
+string file
+uint32 line
+================================================================================
+MSG: builtin_interfaces/Time
+int32 sec
+uint32 nanosec`;
+
+const LOG_ROOT = Root.fromJSON({
+  nested: {
+    foxglove: {
+      nested: {
+        Log: {
+          fields: {
+            file: { id: 5, type: "string" },
+            level: { id: 2, type: "uint32" },
+            line: { id: 6, type: "uint32" },
+            message: { id: 3, type: "string" },
+            name: { id: 4, type: "string" },
+            timestamp: { id: 1, type: "google.protobuf.Timestamp" },
+          },
+        },
+      },
+    },
+    google: {
+      nested: {
+        protobuf: {
+          nested: {
+            Timestamp: {
+              fields: {
+                nanos: { id: 2, type: "int32" },
+                seconds: { id: 1, type: "int64" },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+});
+
+const LOG_SCHEMA_DATA = protobufDescriptorData(LOG_ROOT);
 
 function decoderForSchemaEncoding(
   decoders: readonly Decoder[],

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove.test.ts
@@ -4,19 +4,51 @@ import { MessageWriter as Ros2MessageWriter } from "@foxglove/rosmsg2-serializat
 import { Root } from "protobufjs";
 import descriptor from "protobufjs/ext/descriptor";
 import { describe, expect, it } from "vitest";
-import type { Decoder } from "../../../decoders";
+import type { Decoder, PayloadDescriptor } from "../../../decoders";
+import type { StreamInventory } from "../../../schemas/v1";
 import { VISUALIZATION_KIND } from "../../../visualization";
+import {
+  isCameraCalibrationStream,
+  isCompressedImageStream,
+  isGridStream,
+  isImageAnnotationsStream,
+  isImageStream,
+  isLocationFixStream,
+  isPointCloudStream,
+  isPoseStream,
+  isSceneUpdateStream,
+  streamTopics,
+} from "../stream-topics";
 import { createMcapDecoderRegistry } from ".";
 import {
+  FOXGLOVE_CAMERA_CALIBRATION_CDR_PAYLOADS,
+  FOXGLOVE_COMPRESSED_IMAGE_CDR_PAYLOADS,
+  FOXGLOVE_GRID_CDR_PAYLOADS,
+  FOXGLOVE_IMAGE_ANNOTATIONS_CDR_PAYLOADS,
+  FOXGLOVE_LASER_SCAN_CDR_PAYLOADS,
+  FOXGLOVE_LOCATION_FIX_CDR_PAYLOADS,
+  FOXGLOVE_POINT_CLOUD_CDR_PAYLOADS,
+  FOXGLOVE_POSE_IN_FRAME_CDR_PAYLOADS,
+  FOXGLOVE_SCENE_UPDATE_CDR_PAYLOADS,
+  foxgloveCameraCalibrationCdrDecoders,
   foxgloveCameraCalibrationDecoder,
+  foxgloveCompressedImageCdrDecoders,
   foxgloveCompressedImageDecoder,
   foxgloveCompressedVideoCdrDecoders,
   foxgloveCompressedVideoDecoder,
+  foxgloveGridCdrDecoders,
   foxgloveGridDecoder,
+  foxgloveImageAnnotationsCdrDecoders,
+  foxgloveImageAnnotationsDecoder,
+  foxgloveLaserScanCdrDecoders,
   foxgloveLaserScanDecoder,
+  foxgloveLocationFixCdrDecoders,
   foxgloveLocationFixDecoder,
+  foxglovePointCloudCdrDecoders,
   foxglovePointCloudDecoder,
+  foxglovePoseInFrameCdrDecoders,
   foxglovePoseInFrameDecoder,
+  foxgloveSceneUpdateCdrDecoders,
   foxgloveSceneUpdateDecoder,
 } from "./foxglove";
 import { jsonPoseDecoder } from "./json";
@@ -37,6 +69,9 @@ describe("Foxglove decoders", () => {
     expect(registry.find(foxgloveCompressedImageDecoder.payload)).toBe(
       foxgloveCompressedImageDecoder,
     );
+    for (const decoder of foxgloveCompressedImageCdrDecoders) {
+      expect(registry.find(decoder.payload)).toBe(decoder);
+    }
     expect(registry.find(foxgloveCompressedVideoDecoder.payload)).toBe(
       foxgloveCompressedVideoDecoder,
     );
@@ -46,24 +81,51 @@ describe("Foxglove decoders", () => {
     expect(registry.find(foxglovePointCloudDecoder.payload)).toBe(
       foxglovePointCloudDecoder,
     );
+    for (const decoder of foxglovePointCloudCdrDecoders) {
+      expect(registry.find(decoder.payload)).toBe(decoder);
+    }
     expect(registry.find(foxgloveLaserScanDecoder.payload)).toBe(
       foxgloveLaserScanDecoder,
     );
+    for (const decoder of foxgloveLaserScanCdrDecoders) {
+      expect(registry.find(decoder.payload)).toBe(decoder);
+    }
     expect(registry.find(foxgloveSceneUpdateDecoder.payload)).toBe(
       foxgloveSceneUpdateDecoder,
     );
+    for (const decoder of foxgloveSceneUpdateCdrDecoders) {
+      expect(registry.find(decoder.payload)).toBe(decoder);
+    }
     expect(registry.find(foxgloveGridDecoder.payload)).toBe(
       foxgloveGridDecoder,
     );
+    for (const decoder of foxgloveGridCdrDecoders) {
+      expect(registry.find(decoder.payload)).toBe(decoder);
+    }
     expect(registry.find(foxgloveCameraCalibrationDecoder.payload)).toBe(
       foxgloveCameraCalibrationDecoder,
     );
+    for (const decoder of foxgloveCameraCalibrationCdrDecoders) {
+      expect(registry.find(decoder.payload)).toBe(decoder);
+    }
     expect(registry.find(foxglovePoseInFrameDecoder.payload)).toBe(
       foxglovePoseInFrameDecoder,
     );
+    for (const decoder of foxglovePoseInFrameCdrDecoders) {
+      expect(registry.find(decoder.payload)).toBe(decoder);
+    }
     expect(registry.find(jsonPoseDecoder.payload)).toBe(jsonPoseDecoder);
     expect(registry.find(foxgloveLocationFixDecoder.payload)).toBe(
       foxgloveLocationFixDecoder,
+    );
+    for (const decoder of foxgloveLocationFixCdrDecoders) {
+      expect(registry.find(decoder.payload)).toBe(decoder);
+    }
+    for (const decoder of foxgloveImageAnnotationsCdrDecoders) {
+      expect(registry.find(decoder.payload)).toBe(decoder);
+    }
+    expect(registry.find(foxgloveImageAnnotationsDecoder.payload)).toBe(
+      foxgloveImageAnnotationsDecoder,
     );
   });
 
@@ -135,6 +197,34 @@ describe("Foxglove decoders", () => {
     });
     expect(output.timing?.timeRange?.startNs).toBe(10n);
     expect(output.timing?.sourceTimestamps?.messageTime).toBe(123456000000n);
+  });
+
+  it("decodes cdr compressed image messages with Foxglove ROS2 schemas", () => {
+    const output = decoderForSchemaEncoding(
+      foxgloveCompressedImageCdrDecoders,
+      "ros2msg",
+    ).decode(
+      ros2Message(ROS2_COMPRESSED_IMAGE_SCHEMA, {
+        data: Array.from(new TextEncoder().encode("fake-png")),
+        format: "png",
+        frame_id: "CAM_CDR",
+        timestamp: { nanosec: 4, sec: 3 },
+      }),
+      { schemaData: schemaData(ROS2_COMPRESSED_IMAGE_SCHEMA) },
+    );
+
+    expect(output.visualization?.kind).toBe(VISUALIZATION_KIND.ENCODED_IMAGE);
+    if (output.visualization?.kind !== VISUALIZATION_KIND.ENCODED_IMAGE) {
+      throw new Error("Expected encoded image visualization");
+    }
+    expect(text(output.visualization.bytes)).toBe("fake-png");
+    expect(output.visualization.mimeType).toBe("image/png");
+    expect(output.attributes).toMatchObject({
+      byteLength: 8,
+      format: "png",
+      frameId: "CAM_CDR",
+    });
+    expect(output.timing?.sourceTimestamps?.messageTime).toBe(3_000_000_004n);
   });
 
   it("normalizes uppercase compressed image MIME formats", () => {
@@ -778,6 +868,43 @@ describe("Foxglove decoders", () => {
     expect(output.timing?.timeRange?.startNs).toBe(10n);
   });
 
+  it("decodes cdr scene update messages with Foxglove ROS2 schemas", () => {
+    const output = decoderForSchemaEncoding(
+      foxgloveSceneUpdateCdrDecoders,
+      "ros2msg",
+    ).decode(
+      ros2Message(ROS2_SCENE_UPDATE_SCHEMA, {
+        deletions: [],
+        entities: [
+          {
+            frame_id: "map",
+            frame_locked: true,
+            id: "debug/ego",
+            timestamp: { nanosec: 5, sec: 4 },
+          },
+        ],
+      }),
+      { schemaData: schemaData(ROS2_SCENE_UPDATE_SCHEMA) },
+    );
+
+    expect(output.visualization?.kind).toBe(VISUALIZATION_KIND.SCENE_UPDATE);
+    if (output.visualization?.kind !== VISUALIZATION_KIND.SCENE_UPDATE) {
+      throw new Error("Expected scene update visualization");
+    }
+    expect(output.visualization.entities).toHaveLength(1);
+    expect(output.visualization.entities[0]).toMatchObject({
+      frameId: "map",
+      frameLocked: true,
+      id: "debug/ego",
+      timestampNs: 4_000_000_005n,
+    });
+    expect(output.attributes).toMatchObject({
+      deletionCount: 0,
+      entityCount: 1,
+    });
+    expect(output.timing?.sourceTimestamps?.messageTime).toBe(4_000_000_005n);
+  });
+
   it("decodes protobuf scalar grid payloads into translucent masks", () => {
     const output = foxgloveGridDecoder.decode(
       gridWireMessage({
@@ -816,6 +943,69 @@ describe("Foxglove decoders", () => {
         },
       ),
     ).toThrow("Point cloud data length is not aligned to point stride");
+  });
+
+  it("classifies Foxglove ROS2 CDR streams with the same payload descriptors the registry uses", () => {
+    const compressedImage = createTopic(
+      "/camera/compressed",
+      FOXGLOVE_COMPRESSED_IMAGE_CDR_PAYLOADS[1],
+    );
+    const pointCloud = createTopic(
+      "/points",
+      FOXGLOVE_POINT_CLOUD_CDR_PAYLOADS[0],
+    );
+    const laserScan = createTopic("/scan", FOXGLOVE_LASER_SCAN_CDR_PAYLOADS[0]);
+    const annotations = createTopic(
+      "/camera/annotations",
+      FOXGLOVE_IMAGE_ANNOTATIONS_CDR_PAYLOADS[1],
+    );
+    const sceneUpdate = createTopic(
+      "/scene",
+      FOXGLOVE_SCENE_UPDATE_CDR_PAYLOADS[0],
+    );
+
+    expect(isCompressedImageStream(compressedImage)).toBe(true);
+    expect(isImageStream(compressedImage)).toBe(true);
+    expect(isPointCloudStream(pointCloud)).toBe(true);
+    expect(isPointCloudStream(laserScan)).toBe(true);
+    expect(isImageAnnotationsStream(annotations)).toBe(true);
+    expect(isSceneUpdateStream(sceneUpdate)).toBe(true);
+    expect(
+      isGridStream(createTopic("/grid", FOXGLOVE_GRID_CDR_PAYLOADS[0])),
+    ).toBe(true);
+    expect(
+      isCameraCalibrationStream(
+        createTopic(
+          "/camera/info",
+          FOXGLOVE_CAMERA_CALIBRATION_CDR_PAYLOADS[0],
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      isPoseStream(
+        createTopic("/pose", FOXGLOVE_POSE_IN_FRAME_CDR_PAYLOADS[1]),
+      ),
+    ).toBe(true);
+    expect(
+      isLocationFixStream(
+        createTopic("/gps", FOXGLOVE_LOCATION_FIX_CDR_PAYLOADS[0]),
+      ),
+    ).toBe(true);
+    expect(
+      streamTopics([
+        compressedImage,
+        pointCloud,
+        laserScan,
+        annotations,
+        sceneUpdate,
+      ]),
+    ).toMatchObject({
+      annotations: ["/camera/annotations"],
+      image: ["/camera/compressed"],
+      pointCloud: ["/points", "/scan"],
+      previewable: ["/camera/compressed", "/points", "/scan"],
+      sceneUpdates: ["/scene"],
+    });
   });
 });
 
@@ -1196,6 +1386,15 @@ const COMPRESSED_VIDEO_SCHEMA_DATA = protobufDescriptorData(
   COMPRESSED_VIDEO_ROOT,
 );
 
+const ROS2_COMPRESSED_IMAGE_SCHEMA = `builtin_interfaces/Time timestamp
+string frame_id
+uint8[] data
+string format
+================================================================================
+MSG: builtin_interfaces/Time
+int32 sec
+uint32 nanosec`;
+
 const ROS2_COMPRESSED_VIDEO_SCHEMA = `builtin_interfaces/Time timestamp
 string frame_id
 uint8[] data
@@ -1226,6 +1425,24 @@ module builtin_interfaces {
   };
 };
 `;
+
+const ROS2_SCENE_UPDATE_SCHEMA = `foxglove_msgs/SceneEntityDeletion[] deletions
+foxglove_msgs/SceneEntity[] entities
+================================================================================
+MSG: foxglove_msgs/SceneEntityDeletion
+builtin_interfaces/Time timestamp
+string id
+uint8 type
+================================================================================
+MSG: foxglove_msgs/SceneEntity
+builtin_interfaces/Time timestamp
+string frame_id
+string id
+bool frame_locked
+================================================================================
+MSG: builtin_interfaces/Time
+int32 sec
+uint32 nanosec`;
 
 function decoderForSchemaEncoding(
   decoders: readonly Decoder[],
@@ -1275,4 +1492,25 @@ function protobufDescriptorData(root: Root): Uint8Array {
       ).toDescriptor("proto3"),
     ).finish(),
   );
+}
+
+function createTopic(
+  topic: string,
+  payload: PayloadDescriptor,
+): StreamInventory {
+  return {
+    $typeName: "fiftyone.multimodal.schemas.v1.StreamInventory",
+    displayName: topic,
+    metadata: {
+      "mcap.schema_name": payload.schema ?? "",
+      "mcap.topic": topic,
+    },
+    payload: {
+      $typeName: "fiftyone.multimodal.schemas.v1.PayloadDescriptor",
+      encoding: payload.encoding,
+      schema: payload.schema,
+      schemaEncoding: payload.schemaEncoding,
+    },
+    streamId: topic,
+  };
 }

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/camera-calibration.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/camera-calibration.ts
@@ -1,11 +1,17 @@
 import type {
   CameraCalibrationVisualization,
+  DecodeContext,
   DecodedAttributeValue,
+  DecodedOutput,
   Decoder,
 } from "../../../../decoders";
 import { VISUALIZATION_KIND } from "../../../../visualization";
+import { rosDecodersForPayloads } from "../ros/factory";
 import { decodeProtobufMessage } from "./protobuf";
-import { FOXGLOVE_CAMERA_CALIBRATION_PAYLOAD } from "./protobuf/payloads";
+import {
+  FOXGLOVE_CAMERA_CALIBRATION_CDR_PAYLOADS,
+  FOXGLOVE_CAMERA_CALIBRATION_PAYLOAD,
+} from "./payloads";
 import {
   optionalRecord,
   optionalString,
@@ -34,66 +40,82 @@ export const foxgloveCameraCalibrationDecoder: Decoder = {
       FOXGLOVE_CAMERA_CALIBRATION_PAYLOAD,
       context,
     );
-    const width = requiredNumber(message, "width");
-    const height = requiredNumber(message, "height");
-    const frameId = optionalString(message, "frameId", "frame_id");
-    const distortionModel = optionalString(
-      message,
-      "distortionModel",
-      "distortion_model",
-    );
-    const messageTimestamp = timestampNs(optionalRecord(message, "timestamp"));
-
-    if (!Number.isInteger(width) || width <= 0) {
-      throw new Error(`Invalid camera calibration width ${width}`);
-    }
-    if (!Number.isInteger(height) || height <= 0) {
-      throw new Error(`Invalid camera calibration height ${height}`);
-    }
-
-    const K = numberArray(message, "K");
-    if (K.length !== INTRINSIC_MATRIX_LENGTH) {
-      throw new Error(
-        `Camera calibration K must have ${INTRINSIC_MATRIX_LENGTH} values, got ${K.length}`,
-      );
-    }
-    const R = matrixOrUndefined(message, "R", RECTIFICATION_MATRIX_LENGTH);
-    const P = matrixOrUndefined(message, "P", PROJECTION_MATRIX_LENGTH);
-    const D = numberArray(message, "D");
-
-    const attributes: Record<string, DecodedAttributeValue> = {
-      height,
-      width,
-    };
-    if (frameId) {
-      attributes.frameId = frameId;
-    }
-    if (distortionModel) {
-      attributes.distortionModel = distortionModel;
-    }
-
-    const visualization: CameraCalibrationVisualization = {
-      ...(frameId ? { coordinateFrameId: frameId } : {}),
-      ...(D.length > 0 ? { D } : {}),
-      ...(distortionModel ? { distortionModel } : {}),
-      height,
-      K,
-      kind: VISUALIZATION_KIND.CAMERA_CALIBRATION,
-      ...(P ? { P } : {}),
-      ...(R ? { R } : {}),
-      ...(messageTimestamp !== undefined
-        ? { timestampNs: messageTimestamp }
-        : {}),
-      width,
-    };
-
-    return {
-      attributes,
-      timing: timingFromContext(context, messageTimestamp),
-      visualization,
-    };
+    return decodeFoxgloveCameraCalibrationRecord(message, context);
   },
 };
+
+/**
+ * Decoders for Foxglove CameraCalibration messages carried over ROS 2 CDR.
+ */
+export const foxgloveCameraCalibrationCdrDecoders = rosDecodersForPayloads({
+  id: "foxglove.camera-calibration.cdr",
+  map: decodeFoxgloveCameraCalibrationRecord,
+  payloads: FOXGLOVE_CAMERA_CALIBRATION_CDR_PAYLOADS,
+});
+
+export function decodeFoxgloveCameraCalibrationRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+): DecodedOutput {
+  const width = requiredNumber(message, "width");
+  const height = requiredNumber(message, "height");
+  const frameId = optionalString(message, "frameId", "frame_id");
+  const distortionModel = optionalString(
+    message,
+    "distortionModel",
+    "distortion_model",
+  );
+  const messageTimestamp = timestampNs(optionalRecord(message, "timestamp"));
+
+  if (!Number.isInteger(width) || width <= 0) {
+    throw new Error(`Invalid camera calibration width ${width}`);
+  }
+  if (!Number.isInteger(height) || height <= 0) {
+    throw new Error(`Invalid camera calibration height ${height}`);
+  }
+
+  const K = numberArray(message, "K");
+  if (K.length !== INTRINSIC_MATRIX_LENGTH) {
+    throw new Error(
+      `Camera calibration K must have ${INTRINSIC_MATRIX_LENGTH} values, got ${K.length}`,
+    );
+  }
+  const R = matrixOrUndefined(message, "R", RECTIFICATION_MATRIX_LENGTH);
+  const P = matrixOrUndefined(message, "P", PROJECTION_MATRIX_LENGTH);
+  const D = numberArray(message, "D");
+
+  const attributes: Record<string, DecodedAttributeValue> = {
+    height,
+    width,
+  };
+  if (frameId) {
+    attributes.frameId = frameId;
+  }
+  if (distortionModel) {
+    attributes.distortionModel = distortionModel;
+  }
+
+  const visualization: CameraCalibrationVisualization = {
+    ...(frameId ? { coordinateFrameId: frameId } : {}),
+    ...(D.length > 0 ? { D } : {}),
+    ...(distortionModel ? { distortionModel } : {}),
+    height,
+    K,
+    kind: VISUALIZATION_KIND.CAMERA_CALIBRATION,
+    ...(P ? { P } : {}),
+    ...(R ? { R } : {}),
+    ...(messageTimestamp !== undefined
+      ? { timestampNs: messageTimestamp }
+      : {}),
+    width,
+  };
+
+  return {
+    attributes,
+    timing: timingFromContext(context, messageTimestamp),
+    visualization,
+  };
+}
 
 function matrixOrUndefined(
   record: Record<string, unknown>,

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/compressed-image.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/compressed-image.ts
@@ -1,11 +1,17 @@
 import {
   resourceHintsForArrayBufferViews,
+  type DecodeContext,
   type DecodedAttributeValue,
+  type DecodedOutput,
   type Decoder,
 } from "../../../../decoders";
 import { VISUALIZATION_KIND } from "../../../../visualization";
+import { rosDecodersForPayloads } from "../ros/factory";
 import { decodeProtobufMessage } from "./protobuf";
-import { FOXGLOVE_COMPRESSED_IMAGE_PAYLOAD } from "./protobuf/payloads";
+import {
+  FOXGLOVE_COMPRESSED_IMAGE_CDR_PAYLOADS,
+  FOXGLOVE_COMPRESSED_IMAGE_PAYLOAD,
+} from "./payloads";
 import {
   optionalRecord,
   optionalString,
@@ -32,43 +38,59 @@ export const foxgloveCompressedImageDecoder: Decoder = {
       FOXGLOVE_COMPRESSED_IMAGE_PAYLOAD,
       context,
     );
-    const data = requiredBytes(message, "data");
-    const format = optionalString(message, "format") ?? "unknown";
-    const frameId = optionalString(message, "frameId", "frame_id");
-    const messageTimestamp = timestampNs(optionalRecord(message, "timestamp"));
-    const attributes: Record<string, DecodedAttributeValue> = {
-      byteLength: data.byteLength,
-      format,
-    };
-    const mimeType = mimeTypeFromFormat(format);
-    const unsupportedReason =
-      mimeType === null ? unsupportedImageReason(format) : undefined;
+    return decodeFoxgloveCompressedImageRecord(message, context);
+  },
+};
 
-    if (frameId) {
-      attributes.frameId = frameId;
-    }
+/**
+ * Decoders for Foxglove CompressedImage messages carried over ROS 2 CDR.
+ */
+export const foxgloveCompressedImageCdrDecoders = rosDecodersForPayloads({
+  id: "foxglove.compressed-image.cdr",
+  map: decodeFoxgloveCompressedImageRecord,
+  payloads: FOXGLOVE_COMPRESSED_IMAGE_CDR_PAYLOADS,
+});
 
-    if (unsupportedReason) {
-      attributes.unsupportedReason = unsupportedReason;
-      return {
-        attributes,
-        resourceHints: resourceHintsForArrayBufferViews(data),
-        timing: timingFromContext(context, messageTimestamp),
-      };
-    }
+export function decodeFoxgloveCompressedImageRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+): DecodedOutput {
+  const data = requiredBytes(message, "data");
+  const format = optionalString(message, "format") ?? "unknown";
+  const frameId = optionalString(message, "frameId", "frame_id");
+  const messageTimestamp = timestampNs(optionalRecord(message, "timestamp"));
+  const attributes: Record<string, DecodedAttributeValue> = {
+    byteLength: data.byteLength,
+    format,
+  };
+  const mimeType = mimeTypeFromFormat(format);
+  const unsupportedReason =
+    mimeType === null ? unsupportedImageReason(format) : undefined;
 
+  if (frameId) {
+    attributes.frameId = frameId;
+  }
+
+  if (unsupportedReason) {
+    attributes.unsupportedReason = unsupportedReason;
     return {
       attributes,
       resourceHints: resourceHintsForArrayBufferViews(data),
       timing: timingFromContext(context, messageTimestamp),
-      visualization: {
-        bytes: data,
-        kind: VISUALIZATION_KIND.ENCODED_IMAGE,
-        mimeType: mimeType ?? undefined,
-      },
     };
-  },
-};
+  }
+
+  return {
+    attributes,
+    resourceHints: resourceHintsForArrayBufferViews(data),
+    timing: timingFromContext(context, messageTimestamp),
+    visualization: {
+      bytes: data,
+      kind: VISUALIZATION_KIND.ENCODED_IMAGE,
+      mimeType: mimeType ?? undefined,
+    },
+  };
+}
 
 function mimeTypeFromFormat(format: string): string | null | undefined {
   const lowerFormat = format.trim().toLowerCase();

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/grid.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/grid.ts
@@ -1,14 +1,17 @@
 import type {
+  DecodeContext,
   DecodedAttributeValue,
+  DecodedOutput,
   Decoder,
   GridField,
   GridVisualization,
 } from "../../../../decoders";
 import { resourceHintsForArrayBufferViews } from "../../../../decoders";
 import { VISUALIZATION_KIND } from "../../../../visualization";
+import { rosDecodersForPayloads } from "../ros/factory";
 import { decodeProtobufMessage } from "./protobuf";
 import { decodePose } from "./protobuf/geometry";
-import { FOXGLOVE_GRID_PAYLOAD } from "./protobuf/payloads";
+import { FOXGLOVE_GRID_CDR_PAYLOADS, FOXGLOVE_GRID_PAYLOAD } from "./payloads";
 import {
   asRecord,
   numberField,
@@ -56,68 +59,84 @@ export const foxgloveGridDecoder: Decoder = {
       FOXGLOVE_GRID_PAYLOAD,
       context,
     );
-    const data = requiredBytes(message, "data");
-    const cellSize = decodeCellSize(
-      optionalRecord(message, "cellSize", "cell_size"),
-    );
-    const cellStride = requiredNumber(message, "cellStride", "cell_stride");
-    const columnCount = requiredNumber(message, "columnCount", "column_count");
-    const rowStride = requiredNumber(message, "rowStride", "row_stride");
-    const fields = gridFields(requiredArray(message, "fields"));
-    const frameId = optionalString(message, "frameId", "frame_id");
-    const messageTimestamp = timestampNs(optionalRecord(message, "timestamp"));
-    const pose = decodePose(optionalRecord(message, "pose"));
-
-    validateGridLayout({ cellStride, columnCount, rowStride });
-    const rowCount = deriveRowCount(data, rowStride);
-    const { colorMode, rgba } = extractGridRgba({
-      cellStride,
-      columnCount,
-      data,
-      fields,
-      rowCount,
-      rowStride,
-    });
-
-    const fieldMetadata = fields.map((field) => ({
-      name: field.name,
-      offset: field.offset,
-      type: field.type,
-    }));
-    const attributes: Record<string, DecodedAttributeValue> = {
-      cellSize: [cellSize[0], cellSize[1]],
-      cellStride,
-      colorMode,
-      columnCount,
-      fields: fieldMetadata,
-      rowCount,
-      rowStride,
-    };
-    if (frameId) {
-      attributes.frameId = frameId;
-    }
-
-    const visualization: GridVisualization = {
-      ...(frameId ? { coordinateFrameId: frameId } : {}),
-      cellSize,
-      columnCount,
-      kind: VISUALIZATION_KIND.GRID,
-      pose,
-      rgba,
-      rowCount,
-      ...(messageTimestamp !== undefined
-        ? { timestampNs: messageTimestamp }
-        : {}),
-    };
-
-    return {
-      attributes,
-      resourceHints: resourceHintsForArrayBufferViews(rgba),
-      timing: timingFromContext(context, messageTimestamp),
-      visualization,
-    };
+    return decodeFoxgloveGridRecord(message, context);
   },
 };
+
+/**
+ * Decoders for Foxglove Grid messages carried over ROS 2 CDR.
+ */
+export const foxgloveGridCdrDecoders = rosDecodersForPayloads({
+  id: "foxglove.grid.cdr",
+  map: decodeFoxgloveGridRecord,
+  payloads: FOXGLOVE_GRID_CDR_PAYLOADS,
+});
+
+export function decodeFoxgloveGridRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+): DecodedOutput {
+  const data = requiredBytes(message, "data");
+  const cellSize = decodeCellSize(
+    optionalRecord(message, "cellSize", "cell_size"),
+  );
+  const cellStride = requiredNumber(message, "cellStride", "cell_stride");
+  const columnCount = requiredNumber(message, "columnCount", "column_count");
+  const rowStride = requiredNumber(message, "rowStride", "row_stride");
+  const fields = gridFields(requiredArray(message, "fields"));
+  const frameId = optionalString(message, "frameId", "frame_id");
+  const messageTimestamp = timestampNs(optionalRecord(message, "timestamp"));
+  const pose = decodePose(optionalRecord(message, "pose"));
+
+  validateGridLayout({ cellStride, columnCount, rowStride });
+  const rowCount = deriveRowCount(data, rowStride);
+  const { colorMode, rgba } = extractGridRgba({
+    cellStride,
+    columnCount,
+    data,
+    fields,
+    rowCount,
+    rowStride,
+  });
+
+  const fieldMetadata = fields.map((field) => ({
+    name: field.name,
+    offset: field.offset,
+    type: field.type,
+  }));
+  const attributes: Record<string, DecodedAttributeValue> = {
+    cellSize: [cellSize[0], cellSize[1]],
+    cellStride,
+    colorMode,
+    columnCount,
+    fields: fieldMetadata,
+    rowCount,
+    rowStride,
+  };
+  if (frameId) {
+    attributes.frameId = frameId;
+  }
+
+  const visualization: GridVisualization = {
+    ...(frameId ? { coordinateFrameId: frameId } : {}),
+    cellSize,
+    columnCount,
+    kind: VISUALIZATION_KIND.GRID,
+    pose,
+    rgba,
+    rowCount,
+    ...(messageTimestamp !== undefined
+      ? { timestampNs: messageTimestamp }
+      : {}),
+  };
+
+  return {
+    attributes,
+    resourceHints: resourceHintsForArrayBufferViews(rgba),
+    timing: timingFromContext(context, messageTimestamp),
+    visualization,
+  };
+}
 
 function validateGridLayout({
   cellStride,

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/image-annotations.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/image-annotations.ts
@@ -1,5 +1,7 @@
 import {
+  type DecodeContext,
   type DecodedAttributeValue,
+  type DecodedOutput,
   type Decoder,
   type ImageAnnotationCircle,
   type ImageAnnotationPoints,
@@ -9,8 +11,12 @@ import {
   type RgbaColor,
 } from "../../../../decoders";
 import { VISUALIZATION_KIND } from "../../../../visualization";
+import { rosDecodersForPayloads } from "../ros/factory";
 import { decodeProtobufMessage } from "./protobuf";
-import { FOXGLOVE_IMAGE_ANNOTATIONS_PAYLOAD } from "./protobuf/payloads";
+import {
+  FOXGLOVE_IMAGE_ANNOTATIONS_CDR_PAYLOADS,
+  FOXGLOVE_IMAGE_ANNOTATIONS_PAYLOAD,
+} from "./payloads";
 import { asRecord, numberField, optionalRecord } from "./protobuf/records";
 import { timingFromContext, timestampNs } from "./protobuf/timing";
 
@@ -45,42 +51,58 @@ export const foxgloveImageAnnotationsDecoder: Decoder = {
       FOXGLOVE_IMAGE_ANNOTATIONS_PAYLOAD,
       context,
     );
-
-    const rawCircles = optionalArray(message, "circles");
-    const rawPoints = optionalArray(message, "points");
-    const rawTexts = optionalArray(message, "texts");
-
-    const circles = rawCircles.map(decodeCircle);
-    const points = rawPoints.map(decodePoints);
-    const texts = rawTexts.map(decodeText);
-
-    // Per Foxglove schema: top-level timestamp overrides individual annotation timestamps.
-    const topLevelTs = optionalRecord(message, "timestamp");
-    const messageTimestamp = topLevelTs
-      ? timestampNs(topLevelTs)
-      : firstAnnotationTimestamp(rawCircles, rawPoints, rawTexts);
-
-    const visualization: ImageAnnotationsVisualization = {
-      kind: VISUALIZATION_KIND.IMAGE_ANNOTATIONS,
-      circles,
-      points,
-      texts,
-    };
-
-    const attributes: Record<string, DecodedAttributeValue> = {
-      circleCount: circles.length,
-      pointGroupCount: points.length,
-      textCount: texts.length,
-    };
-
-    return {
-      attributes,
-      resourceHints: { sizeBytes: bytes.byteLength },
-      timing: timingFromContext(context, messageTimestamp),
-      visualization,
-    };
+    return decodeFoxgloveImageAnnotationsRecord(message, context, bytes);
   },
 };
+
+/**
+ * Decoders for Foxglove ImageAnnotations messages carried over ROS 2 CDR.
+ */
+export const foxgloveImageAnnotationsCdrDecoders = rosDecodersForPayloads({
+  id: "foxglove.image-annotations.cdr",
+  map: decodeFoxgloveImageAnnotationsRecord,
+  payloads: FOXGLOVE_IMAGE_ANNOTATIONS_CDR_PAYLOADS,
+});
+
+export function decodeFoxgloveImageAnnotationsRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+  bytes?: Uint8Array,
+): DecodedOutput {
+  const rawCircles = optionalArray(message, "circles");
+  const rawPoints = optionalArray(message, "points");
+  const rawTexts = optionalArray(message, "texts");
+
+  const circles = rawCircles.map(decodeCircle);
+  const points = rawPoints.map(decodePoints);
+  const texts = rawTexts.map(decodeText);
+
+  // Per Foxglove schema: top-level timestamp overrides individual annotation timestamps.
+  const topLevelTs = optionalRecord(message, "timestamp");
+  const messageTimestamp = topLevelTs
+    ? timestampNs(topLevelTs)
+    : firstAnnotationTimestamp(rawCircles, rawPoints, rawTexts);
+
+  const visualization: ImageAnnotationsVisualization = {
+    kind: VISUALIZATION_KIND.IMAGE_ANNOTATIONS,
+    circles,
+    points,
+    texts,
+  };
+
+  const attributes: Record<string, DecodedAttributeValue> = {
+    circleCount: circles.length,
+    pointGroupCount: points.length,
+    textCount: texts.length,
+  };
+
+  return {
+    attributes,
+    resourceHints: { sizeBytes: bytes?.byteLength ?? 0 },
+    timing: timingFromContext(context, messageTimestamp),
+    visualization,
+  };
+}
 
 function decodeCircle(value: unknown): ImageAnnotationCircle {
   const record = asRecord(value);

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/index.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/index.ts
@@ -1,27 +1,57 @@
 import type { Decoder } from "../../../../decoders";
-import { foxgloveCameraCalibrationDecoder } from "./camera-calibration";
-import { foxgloveCompressedImageDecoder } from "./compressed-image";
+import {
+  foxgloveCameraCalibrationCdrDecoders,
+  foxgloveCameraCalibrationDecoder,
+} from "./camera-calibration";
+import {
+  foxgloveCompressedImageCdrDecoders,
+  foxgloveCompressedImageDecoder,
+} from "./compressed-image";
 import {
   foxgloveCompressedVideoCdrDecoders,
   foxgloveCompressedVideoDecoder,
 } from "./compressed-video";
-import { foxgloveGridDecoder } from "./grid";
-import { foxgloveImageAnnotationsDecoder } from "./image-annotations";
-import { foxgloveLaserScanDecoder } from "./laser-scan";
-import { foxgloveLocationFixDecoder } from "./location-fix";
-import { foxglovePointCloudDecoder } from "./point-cloud";
-import { foxglovePoseInFrameDecoder } from "./pose-in-frame";
-import { foxgloveSceneUpdateDecoder } from "./scene-update";
+import { foxgloveGridCdrDecoders, foxgloveGridDecoder } from "./grid";
+import {
+  foxgloveImageAnnotationsCdrDecoders,
+  foxgloveImageAnnotationsDecoder,
+} from "./image-annotations";
+import {
+  foxgloveLaserScanCdrDecoders,
+  foxgloveLaserScanDecoder,
+} from "./laser-scan";
+import {
+  foxgloveLocationFixCdrDecoders,
+  foxgloveLocationFixDecoder,
+} from "./location-fix";
+import {
+  foxglovePointCloudCdrDecoders,
+  foxglovePointCloudDecoder,
+} from "./point-cloud";
+import {
+  foxglovePoseInFrameCdrDecoders,
+  foxglovePoseInFrameDecoder,
+} from "./pose-in-frame";
+import {
+  foxgloveSceneUpdateCdrDecoders,
+  foxgloveSceneUpdateDecoder,
+} from "./scene-update";
 
 /**
  * Foxglove camera calibration decoder export.
  */
-export { foxgloveCameraCalibrationDecoder } from "./camera-calibration";
+export {
+  foxgloveCameraCalibrationCdrDecoders,
+  foxgloveCameraCalibrationDecoder,
+} from "./camera-calibration";
 
 /**
  * Foxglove compressed image decoder export.
  */
-export { foxgloveCompressedImageDecoder } from "./compressed-image";
+export {
+  foxgloveCompressedImageCdrDecoders,
+  foxgloveCompressedImageDecoder,
+} from "./compressed-image";
 
 /**
  * Foxglove compressed video decoder export.
@@ -34,37 +64,55 @@ export {
 /**
  * Foxglove Grid decoder export.
  */
-export { foxgloveGridDecoder } from "./grid";
+export { foxgloveGridCdrDecoders, foxgloveGridDecoder } from "./grid";
 
 /**
  * Foxglove image annotations decoder export.
  */
-export { foxgloveImageAnnotationsDecoder } from "./image-annotations";
+export {
+  foxgloveImageAnnotationsCdrDecoders,
+  foxgloveImageAnnotationsDecoder,
+} from "./image-annotations";
 
 /**
  * Foxglove LaserScan decoder export.
  */
-export { foxgloveLaserScanDecoder } from "./laser-scan";
+export {
+  foxgloveLaserScanCdrDecoders,
+  foxgloveLaserScanDecoder,
+} from "./laser-scan";
 
 /**
  * Foxglove point cloud decoder export.
  */
-export { foxglovePointCloudDecoder } from "./point-cloud";
+export {
+  foxglovePointCloudCdrDecoders,
+  foxglovePointCloudDecoder,
+} from "./point-cloud";
 
 /**
  * Foxglove LocationFix decoder export.
  */
-export { foxgloveLocationFixDecoder } from "./location-fix";
+export {
+  foxgloveLocationFixCdrDecoders,
+  foxgloveLocationFixDecoder,
+} from "./location-fix";
 
 /**
  * Foxglove PoseInFrame decoder export.
  */
-export { foxglovePoseInFrameDecoder } from "./pose-in-frame";
+export {
+  foxglovePoseInFrameCdrDecoders,
+  foxglovePoseInFrameDecoder,
+} from "./pose-in-frame";
 
 /**
  * Foxglove SceneUpdate decoder export.
  */
-export { foxgloveSceneUpdateDecoder } from "./scene-update";
+export {
+  foxgloveSceneUpdateCdrDecoders,
+  foxgloveSceneUpdateDecoder,
+} from "./scene-update";
 
 /**
  * Foxglove payload descriptor exports.
@@ -76,14 +124,23 @@ export * from "./payloads";
  */
 export const foxgloveDecoders: readonly Decoder[] = [
   foxgloveCameraCalibrationDecoder,
+  ...foxgloveCameraCalibrationCdrDecoders,
   foxgloveCompressedImageDecoder,
+  ...foxgloveCompressedImageCdrDecoders,
   foxgloveCompressedVideoDecoder,
   ...foxgloveCompressedVideoCdrDecoders,
   foxgloveGridDecoder,
+  ...foxgloveGridCdrDecoders,
   foxgloveImageAnnotationsDecoder,
+  ...foxgloveImageAnnotationsCdrDecoders,
   foxgloveLaserScanDecoder,
+  ...foxgloveLaserScanCdrDecoders,
   foxgloveLocationFixDecoder,
+  ...foxgloveLocationFixCdrDecoders,
   foxglovePointCloudDecoder,
+  ...foxglovePointCloudCdrDecoders,
   foxglovePoseInFrameDecoder,
+  ...foxglovePoseInFrameCdrDecoders,
   foxgloveSceneUpdateDecoder,
+  ...foxgloveSceneUpdateCdrDecoders,
 ];

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/index.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/index.ts
@@ -24,6 +24,7 @@ import {
   foxgloveLocationFixCdrDecoders,
   foxgloveLocationFixDecoder,
 } from "./location-fix";
+import { foxgloveLogCdrDecoders, foxgloveLogDecoder } from "./log";
 import {
   foxglovePointCloudCdrDecoders,
   foxglovePointCloudDecoder,
@@ -99,6 +100,11 @@ export {
 } from "./location-fix";
 
 /**
+ * Foxglove Log decoder export.
+ */
+export { foxgloveLogCdrDecoders, foxgloveLogDecoder } from "./log";
+
+/**
  * Foxglove PoseInFrame decoder export.
  */
 export {
@@ -137,6 +143,8 @@ export const foxgloveDecoders: readonly Decoder[] = [
   ...foxgloveLaserScanCdrDecoders,
   foxgloveLocationFixDecoder,
   ...foxgloveLocationFixCdrDecoders,
+  foxgloveLogDecoder,
+  ...foxgloveLogCdrDecoders,
   foxglovePointCloudDecoder,
   ...foxglovePointCloudCdrDecoders,
   foxglovePoseInFrameDecoder,

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/laser-scan.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/laser-scan.ts
@@ -1,13 +1,22 @@
-import type { DecodedAttributeValue, Decoder } from "../../../../decoders";
+import type {
+  DecodeContext,
+  DecodedAttributeValue,
+  DecodedOutput,
+  Decoder,
+} from "../../../../decoders";
 import { resourceHintsForArrayBufferViews } from "../../../../decoders";
 import { VISUALIZATION_KIND } from "../../../../visualization";
+import { rosDecodersForPayloads } from "../ros/factory";
 import { decodeProtobufMessage } from "./protobuf";
 import {
   decodePose,
   normalizedQuaternion,
   type ProtobufPose3D,
 } from "./protobuf/geometry";
-import { FOXGLOVE_LASER_SCAN_PAYLOAD } from "./protobuf/payloads";
+import {
+  FOXGLOVE_LASER_SCAN_CDR_PAYLOADS,
+  FOXGLOVE_LASER_SCAN_PAYLOAD,
+} from "./payloads";
 import {
   numberField,
   optionalRecord,
@@ -42,62 +51,77 @@ export const foxgloveLaserScanDecoder: Decoder = {
       FOXGLOVE_LASER_SCAN_PAYLOAD,
       context,
     );
-    const frameId = optionalString(message, "frameId", "frame_id");
-    const messageTimestamp = timestampNs(optionalRecord(message, "timestamp"));
-    const startAngle = numberField(message, "startAngle", "start_angle");
-    const endAngle = numberField(message, "endAngle", "end_angle");
-    const ranges = numberArrayField(message, "ranges");
-    const intensities = numberArrayField(message, "intensities");
-    const pose = decodePose(optionalRecord(message, "pose"));
-    const decoded = scanToPoints({
-      endAngle,
-      // Intensities are per-range by schema; a mismatched array is
-      // untrustworthy, so it is dropped rather than misaligned.
-      intensities:
-        intensities.length === ranges.length ? intensities : undefined,
-      pose,
-      ranges,
-      startAngle,
-    });
-    const pointCount =
-      decoded.positions.length / LASER_SCAN_POINT_COMPONENT_COUNT;
-
-    const attributes: Record<string, DecodedAttributeValue> = {
-      endAngle,
-      pointCount,
-      rangeCount: ranges.length,
-      startAngle,
-    };
-    if (frameId) {
-      attributes.frameId = frameId;
-    }
-
-    const transferableViews = [
-      decoded.positions,
-      ...(decoded.intensities ? [decoded.intensities] : []),
-    ];
-
-    return {
-      attributes,
-      resourceHints: resourceHintsForArrayBufferViews(...transferableViews),
-      timing: timingFromContext(context, messageTimestamp),
-      visualization: {
-        ...(frameId ? { coordinateFrameId: frameId } : {}),
-        fields: [],
-        kind: VISUALIZATION_KIND.POINT_CLOUD,
-        pointCount,
-        positions: decoded.positions,
-        ...(decoded.intensities
-          ? {
-              scalarFields: [
-                { name: INTENSITY_FIELD_NAME, values: decoded.intensities },
-              ],
-            }
-          : {}),
-      },
-    };
+    return decodeFoxgloveLaserScanRecord(message, context);
   },
 };
+
+/**
+ * Decoders for Foxglove LaserScan messages carried over ROS 2 CDR.
+ */
+export const foxgloveLaserScanCdrDecoders = rosDecodersForPayloads({
+  id: "foxglove.laser-scan.cdr",
+  map: decodeFoxgloveLaserScanRecord,
+  payloads: FOXGLOVE_LASER_SCAN_CDR_PAYLOADS,
+});
+
+export function decodeFoxgloveLaserScanRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+): DecodedOutput {
+  const frameId = optionalString(message, "frameId", "frame_id");
+  const messageTimestamp = timestampNs(optionalRecord(message, "timestamp"));
+  const startAngle = numberField(message, "startAngle", "start_angle");
+  const endAngle = numberField(message, "endAngle", "end_angle");
+  const ranges = numberArrayField(message, "ranges");
+  const intensities = numberArrayField(message, "intensities");
+  const pose = decodePose(optionalRecord(message, "pose"));
+  const decoded = scanToPoints({
+    endAngle,
+    // Intensities are per-range by schema; a mismatched array is
+    // untrustworthy, so it is dropped rather than misaligned.
+    intensities: intensities.length === ranges.length ? intensities : undefined,
+    pose,
+    ranges,
+    startAngle,
+  });
+  const pointCount =
+    decoded.positions.length / LASER_SCAN_POINT_COMPONENT_COUNT;
+
+  const attributes: Record<string, DecodedAttributeValue> = {
+    endAngle,
+    pointCount,
+    rangeCount: ranges.length,
+    startAngle,
+  };
+  if (frameId) {
+    attributes.frameId = frameId;
+  }
+
+  const transferableViews = [
+    decoded.positions,
+    ...(decoded.intensities ? [decoded.intensities] : []),
+  ];
+
+  return {
+    attributes,
+    resourceHints: resourceHintsForArrayBufferViews(...transferableViews),
+    timing: timingFromContext(context, messageTimestamp),
+    visualization: {
+      ...(frameId ? { coordinateFrameId: frameId } : {}),
+      fields: [],
+      kind: VISUALIZATION_KIND.POINT_CLOUD,
+      pointCount,
+      positions: decoded.positions,
+      ...(decoded.intensities
+        ? {
+            scalarFields: [
+              { name: INTENSITY_FIELD_NAME, values: decoded.intensities },
+            ],
+          }
+        : {}),
+    },
+  };
+}
 
 /**
  * Cartesian points produced from a polar laser scan.

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/location-fix.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/location-fix.ts
@@ -1,11 +1,17 @@
 import type {
+  DecodeContext,
   DecodedAttributeValue,
+  DecodedOutput,
   Decoder,
   LocationVisualization,
 } from "../../../../decoders";
 import { VISUALIZATION_KIND } from "../../../../visualization";
+import { rosDecodersForPayloads } from "../ros/factory";
 import { decodeProtobufMessage } from "./protobuf";
-import { FOXGLOVE_LOCATION_FIX_PAYLOAD } from "./protobuf/payloads";
+import {
+  FOXGLOVE_LOCATION_FIX_CDR_PAYLOADS,
+  FOXGLOVE_LOCATION_FIX_PAYLOAD,
+} from "./payloads";
 import {
   numberField,
   optionalRecord,
@@ -30,46 +36,62 @@ export const foxgloveLocationFixDecoder: Decoder = {
       FOXGLOVE_LOCATION_FIX_PAYLOAD,
       context,
     );
-    const latitude = numberField(message, "latitude");
-    const longitude = numberField(message, "longitude");
-    if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
-      throw new Error("Location fix has no finite latitude/longitude");
-    }
-
-    const altitude = numberField(message, "altitude");
-    const frameId = optionalString(message, "frameId", "frame_id");
-    const messageTimestamp = timestampNs(optionalRecord(message, "timestamp"));
-    const positionCovariance = covariance(
-      message["positionCovariance"] ?? message["position_covariance"],
-    );
-
-    const attributes: Record<string, DecodedAttributeValue> = {
-      latitude,
-      longitude,
-    };
-    if (frameId) {
-      attributes.frameId = frameId;
-    }
-
-    const visualization: LocationVisualization = {
-      ...(altitude !== 0 ? { altitude } : {}),
-      ...(frameId ? { coordinateFrameId: frameId } : {}),
-      kind: VISUALIZATION_KIND.LOCATION,
-      latitude,
-      longitude,
-      ...(positionCovariance ? { positionCovariance } : {}),
-      ...(messageTimestamp !== undefined
-        ? { timestampNs: messageTimestamp }
-        : {}),
-    };
-
-    return {
-      attributes,
-      timing: timingFromContext(context, messageTimestamp),
-      visualization,
-    };
+    return decodeFoxgloveLocationFixRecord(message, context);
   },
 };
+
+/**
+ * Decoders for Foxglove LocationFix messages carried over ROS 2 CDR.
+ */
+export const foxgloveLocationFixCdrDecoders = rosDecodersForPayloads({
+  id: "foxglove.location-fix.cdr",
+  map: decodeFoxgloveLocationFixRecord,
+  payloads: FOXGLOVE_LOCATION_FIX_CDR_PAYLOADS,
+});
+
+export function decodeFoxgloveLocationFixRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+): DecodedOutput {
+  const latitude = numberField(message, "latitude");
+  const longitude = numberField(message, "longitude");
+  if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
+    throw new Error("Location fix has no finite latitude/longitude");
+  }
+
+  const altitude = numberField(message, "altitude");
+  const frameId = optionalString(message, "frameId", "frame_id");
+  const messageTimestamp = timestampNs(optionalRecord(message, "timestamp"));
+  const positionCovariance = covariance(
+    message["positionCovariance"] ?? message["position_covariance"],
+  );
+
+  const attributes: Record<string, DecodedAttributeValue> = {
+    latitude,
+    longitude,
+  };
+  if (frameId) {
+    attributes.frameId = frameId;
+  }
+
+  const visualization: LocationVisualization = {
+    ...(altitude !== 0 ? { altitude } : {}),
+    ...(frameId ? { coordinateFrameId: frameId } : {}),
+    kind: VISUALIZATION_KIND.LOCATION,
+    latitude,
+    longitude,
+    ...(positionCovariance ? { positionCovariance } : {}),
+    ...(messageTimestamp !== undefined
+      ? { timestampNs: messageTimestamp }
+      : {}),
+  };
+
+  return {
+    attributes,
+    timing: timingFromContext(context, messageTimestamp),
+    visualization,
+  };
+}
 
 function covariance(value: unknown): readonly number[] | undefined {
   if (!Array.isArray(value) || value.length !== COVARIANCE_LENGTH) {

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/location-fix.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/location-fix.ts
@@ -53,8 +53,8 @@ export function decodeFoxgloveLocationFixRecord(
   message: Record<string, unknown>,
   context: DecodeContext,
 ): DecodedOutput {
-  const latitude = numberField(message, "latitude");
-  const longitude = numberField(message, "longitude");
+  const latitude = numberField(message, "latitude", undefined, Number.NaN);
+  const longitude = numberField(message, "longitude", undefined, Number.NaN);
   if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
     throw new Error("Location fix has no finite latitude/longitude");
   }

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/location-fix.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/location-fix.ts
@@ -59,7 +59,11 @@ export function decodeFoxgloveLocationFixRecord(
     throw new Error("Location fix has no finite latitude/longitude");
   }
 
-  const altitude = numberField(message, "altitude");
+  const hasAltitude =
+    message.altitude !== undefined && message.altitude !== null;
+  const altitude = hasAltitude
+    ? numberField(message, "altitude", undefined, Number.NaN)
+    : undefined;
   const frameId = optionalString(message, "frameId", "frame_id");
   const messageTimestamp = timestampNs(optionalRecord(message, "timestamp"));
   const positionCovariance = covariance(
@@ -75,7 +79,9 @@ export function decodeFoxgloveLocationFixRecord(
   }
 
   const visualization: LocationVisualization = {
-    ...(altitude !== 0 ? { altitude } : {}),
+    ...(altitude !== undefined && Number.isFinite(altitude)
+      ? { altitude }
+      : {}),
     ...(frameId ? { coordinateFrameId: frameId } : {}),
     kind: VISUALIZATION_KIND.LOCATION,
     latitude,

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/log.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/log.ts
@@ -69,9 +69,10 @@ export function decodeFoxgloveLogRecord(
 function logOutputAttributes(
   row: McapDecodedLogRow,
 ): Record<string, DecodedAttributeValue> {
+  const rows = logRowsAttribute([row]);
   return {
-    ...logRowsAttribute([row])[0],
-    [MCAP_LOG_ATTRIBUTE_ROWS]: logRowsAttribute([row]),
+    ...rows[0],
+    [MCAP_LOG_ATTRIBUTE_ROWS]: rows,
   };
 }
 

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/log.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/log.ts
@@ -1,0 +1,101 @@
+import type {
+  DecodeContext,
+  DecodedAttributeValue,
+  DecodedOutput,
+  Decoder,
+} from "../../../../decoders";
+import {
+  MCAP_LOG_ATTRIBUTE_ROWS,
+  MCAP_LOG_LEVEL,
+  type McapDecodedLogRow,
+  logRowsAttribute,
+} from "../../log-records";
+import { rosDecodersForPayloads } from "../ros/factory";
+import { decodeProtobufMessage } from "./protobuf";
+import {
+  numberField,
+  optionalRecord,
+  optionalString,
+} from "./protobuf/records";
+import { timingFromContext, timestampNs } from "./protobuf/timing";
+import { FOXGLOVE_LOG_CDR_PAYLOADS, FOXGLOVE_LOG_PAYLOAD } from "./payloads";
+
+/**
+ * Decoder for Foxglove Log protobuf messages.
+ */
+export const foxgloveLogDecoder: Decoder = {
+  id: "foxglove.log",
+  payload: FOXGLOVE_LOG_PAYLOAD,
+  version: "1",
+
+  decode(bytes, context) {
+    const message = decodeProtobufMessage(bytes, FOXGLOVE_LOG_PAYLOAD, context);
+    return decodeFoxgloveLogRecord(message, context);
+  },
+};
+
+/**
+ * Decoders for Foxglove Log messages carried over ROS 2 CDR.
+ */
+export const foxgloveLogCdrDecoders = rosDecodersForPayloads({
+  id: "foxglove.log.cdr",
+  map: decodeFoxgloveLogRecord,
+  payloads: FOXGLOVE_LOG_CDR_PAYLOADS,
+});
+
+export function decodeFoxgloveLogRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+): DecodedOutput {
+  const messageTimestamp = timestampNs(optionalRecord(message, "timestamp"));
+  const levelNumber = numberField(message, "level");
+  const row: McapDecodedLogRow = {
+    file: optionalString(message, "file"),
+    kind: "log",
+    level: foxgloveLogLevel(levelNumber),
+    levelNumber,
+    line: positiveNumberField(message, "line"),
+    message: optionalString(message, "message") ?? "",
+    name: optionalString(message, "name"),
+    timestampNs: messageTimestamp,
+  };
+
+  return {
+    attributes: logOutputAttributes(row),
+    timing: timingFromContext(context, messageTimestamp),
+  };
+}
+
+function logOutputAttributes(
+  row: McapDecodedLogRow,
+): Record<string, DecodedAttributeValue> {
+  return {
+    ...logRowsAttribute([row])[0],
+    [MCAP_LOG_ATTRIBUTE_ROWS]: logRowsAttribute([row]),
+  };
+}
+
+function foxgloveLogLevel(level: number) {
+  switch (level) {
+    case 1:
+      return MCAP_LOG_LEVEL.DEBUG;
+    case 2:
+      return MCAP_LOG_LEVEL.INFO;
+    case 3:
+      return MCAP_LOG_LEVEL.WARN;
+    case 4:
+      return MCAP_LOG_LEVEL.ERROR;
+    case 5:
+      return MCAP_LOG_LEVEL.FATAL;
+    default:
+      return MCAP_LOG_LEVEL.UNKNOWN;
+  }
+}
+
+function positiveNumberField(
+  record: Record<string, unknown>,
+  field: string,
+): number | undefined {
+  const value = numberField(record, field, undefined, Number.NaN);
+  return Number.isFinite(value) && value > 0 ? value : undefined;
+}

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/payloads.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/payloads.ts
@@ -2,20 +2,97 @@ import type { PayloadDescriptor } from "../../../../decoders";
 
 export * from "./protobuf/payloads";
 
+function foxgloveCdrPayloads(schema: string): readonly PayloadDescriptor[] {
+  return [
+    {
+      encoding: "cdr",
+      schema: `foxglove_msgs/msg/${schema}`,
+      schemaEncoding: "ros2msg",
+    },
+    {
+      encoding: "cdr",
+      schema: `foxglove_msgs/msg/${schema}`,
+      schemaEncoding: "ros2idl",
+    },
+  ];
+}
+
+/**
+ * Payload identities for foxglove_msgs/msg/CameraCalibration messages carried
+ * over ROS 2 CDR encodings.
+ */
+export const FOXGLOVE_CAMERA_CALIBRATION_CDR_PAYLOADS =
+  foxgloveCdrPayloads("CameraCalibration");
+
+/**
+ * Payload identities for foxglove_msgs/msg/CompressedImage messages carried
+ * over ROS 2 CDR encodings.
+ */
+export const FOXGLOVE_COMPRESSED_IMAGE_CDR_PAYLOADS =
+  foxgloveCdrPayloads("CompressedImage");
+
 /**
  * Payload identities for foxglove_msgs/msg/CompressedVideo messages carried
  * over ROS 2 CDR encodings.
  */
 export const FOXGLOVE_COMPRESSED_VIDEO_CDR_PAYLOADS: readonly PayloadDescriptor[] =
-  [
-    {
-      encoding: "cdr",
-      schema: "foxglove_msgs/msg/CompressedVideo",
-      schemaEncoding: "ros2msg",
-    },
-    {
-      encoding: "cdr",
-      schema: "foxglove_msgs/msg/CompressedVideo",
-      schemaEncoding: "ros2idl",
-    },
-  ];
+  foxgloveCdrPayloads("CompressedVideo");
+
+/**
+ * Payload identities for foxglove_msgs/msg/Grid messages carried over ROS 2
+ * CDR encodings.
+ */
+export const FOXGLOVE_GRID_CDR_PAYLOADS = foxgloveCdrPayloads("Grid");
+
+/**
+ * Payload identities for foxglove_msgs/msg/ImageAnnotations messages carried
+ * over ROS 2 CDR encodings.
+ */
+export const FOXGLOVE_IMAGE_ANNOTATIONS_CDR_PAYLOADS =
+  foxgloveCdrPayloads("ImageAnnotations");
+
+/**
+ * Payload identities for foxglove_msgs/msg/LaserScan messages carried over
+ * ROS 2 CDR encodings.
+ */
+export const FOXGLOVE_LASER_SCAN_CDR_PAYLOADS =
+  foxgloveCdrPayloads("LaserScan");
+
+/**
+ * Payload identities for foxglove_msgs/msg/LocationFix messages carried over
+ * ROS 2 CDR encodings.
+ */
+export const FOXGLOVE_LOCATION_FIX_CDR_PAYLOADS =
+  foxgloveCdrPayloads("LocationFix");
+
+/**
+ * Payload identities for foxglove_msgs/msg/PointCloud messages carried over
+ * ROS 2 CDR encodings.
+ */
+export const FOXGLOVE_POINT_CLOUD_CDR_PAYLOADS =
+  foxgloveCdrPayloads("PointCloud");
+
+/**
+ * Payload identities for foxglove_msgs/msg/PoseInFrame messages carried over
+ * ROS 2 CDR encodings.
+ */
+export const FOXGLOVE_POSE_IN_FRAME_CDR_PAYLOADS =
+  foxgloveCdrPayloads("PoseInFrame");
+
+/**
+ * Payload identities for foxglove_msgs/msg/SceneUpdate messages carried over
+ * ROS 2 CDR encodings.
+ */
+export const FOXGLOVE_SCENE_UPDATE_CDR_PAYLOADS =
+  foxgloveCdrPayloads("SceneUpdate");
+
+/**
+ * Payload identities for foxglove_msgs/msg/FrameTransform(s) messages carried
+ * over ROS 2 CDR encodings. Frame transforms are discovered by the transform
+ * reader rather than the visual decoder registry, but stream classification
+ * and tests need the same canonical spellings.
+ */
+export const FOXGLOVE_FRAME_TRANSFORM_CDR_PAYLOADS =
+  foxgloveCdrPayloads("FrameTransform");
+export const FOXGLOVE_FRAME_TRANSFORMS_CDR_PAYLOADS =
+  foxgloveCdrPayloads("FrameTransforms");

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/payloads.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/payloads.ts
@@ -35,7 +35,7 @@ export const FOXGLOVE_COMPRESSED_IMAGE_CDR_PAYLOADS =
  * Payload identities for foxglove_msgs/msg/CompressedVideo messages carried
  * over ROS 2 CDR encodings.
  */
-export const FOXGLOVE_COMPRESSED_VIDEO_CDR_PAYLOADS: readonly PayloadDescriptor[] =
+export const FOXGLOVE_COMPRESSED_VIDEO_CDR_PAYLOADS =
   foxgloveCdrPayloads("CompressedVideo");
 
 /**

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/payloads.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/payloads.ts
@@ -66,6 +66,12 @@ export const FOXGLOVE_LOCATION_FIX_CDR_PAYLOADS =
   foxgloveCdrPayloads("LocationFix");
 
 /**
+ * Payload identities for foxglove_msgs/msg/Log messages carried over ROS 2
+ * CDR encodings.
+ */
+export const FOXGLOVE_LOG_CDR_PAYLOADS = foxgloveCdrPayloads("Log");
+
+/**
  * Payload identities for foxglove_msgs/msg/PointCloud messages carried over
  * ROS 2 CDR encodings.
  */

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/point-cloud.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/point-cloud.ts
@@ -1,18 +1,24 @@
 import type {
+  DecodeContext,
   DecodedAttributeValue,
+  DecodedOutput,
   Decoder,
   PointCloudField,
   PointCloudScalarField,
 } from "../../../../decoders";
 import { resourceHintsForArrayBufferViews } from "../../../../decoders";
 import { VISUALIZATION_KIND } from "../../../../visualization";
+import { rosDecodersForPayloads } from "../ros/factory";
 import { decodeProtobufMessage } from "./protobuf";
 import {
   decodePose,
   normalizedQuaternion,
   type ProtobufPose3D,
 } from "./protobuf/geometry";
-import { FOXGLOVE_POINT_CLOUD_PAYLOAD } from "./protobuf/payloads";
+import {
+  FOXGLOVE_POINT_CLOUD_CDR_PAYLOADS,
+  FOXGLOVE_POINT_CLOUD_PAYLOAD,
+} from "./payloads";
 import {
   asRecord,
   optionalRecord,
@@ -95,58 +101,74 @@ export const foxglovePointCloudDecoder: Decoder = {
       FOXGLOVE_POINT_CLOUD_PAYLOAD,
       context,
     );
-    const data = requiredBytes(message, "data");
-    const pointStride = requiredNumber(message, "pointStride", "point_stride");
-    const fields = packedFields(requiredArray(message, "fields"));
-    const decodedPoints = extractPointCloudData(data, pointStride, fields);
-    applyPose(
-      decodedPoints.positions,
-      decodePose(optionalRecord(message, "pose")),
-    );
-    // Per-message Foxglove frame_id carried by this point cloud payload. This
-    // is separate from the MCAP channel frame_id metadata fallback.
-    const frameId = optionalString(message, "frameId", "frame_id");
-    const messageTimestamp = timestampNs(optionalRecord(message, "timestamp"));
-    const pointCount = decodedPoints.positions.length / POINT_COMPONENT_COUNT;
-    const packedFieldMetadata = fields.map((field) => ({
-      name: field.name,
-      offset: field.offset,
-      type: field.type,
-    }));
-    const attributes: Record<string, DecodedAttributeValue> = {
-      fields: packedFieldMetadata,
-      pointCount,
-      pointStride,
-    };
-
-    if (frameId) {
-      attributes.frameId = frameId;
-    }
-
-    const transferableViews = [
-      decodedPoints.positions,
-      decodedPoints.colors,
-      ...decodedPoints.scalarFields.map((field) => field.values),
-    ].filter((view): view is Float32Array => view !== undefined);
-
-    return {
-      attributes,
-      resourceHints: resourceHintsForArrayBufferViews(...transferableViews),
-      timing: timingFromContext(context, messageTimestamp),
-      visualization: {
-        ...(frameId ? { coordinateFrameId: frameId } : {}),
-        ...(decodedPoints.colors ? { colors: decodedPoints.colors } : {}),
-        ...(decodedPoints.scalarFields.length
-          ? { scalarFields: decodedPoints.scalarFields }
-          : {}),
-        fields: packedFieldMetadata,
-        kind: VISUALIZATION_KIND.POINT_CLOUD,
-        pointCount,
-        positions: decodedPoints.positions,
-      },
-    };
+    return decodeFoxglovePointCloudRecord(message, context);
   },
 };
+
+/**
+ * Decoders for Foxglove PointCloud messages carried over ROS 2 CDR.
+ */
+export const foxglovePointCloudCdrDecoders = rosDecodersForPayloads({
+  id: "foxglove.point-cloud.cdr",
+  map: decodeFoxglovePointCloudRecord,
+  payloads: FOXGLOVE_POINT_CLOUD_CDR_PAYLOADS,
+});
+
+export function decodeFoxglovePointCloudRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+): DecodedOutput {
+  const data = requiredBytes(message, "data");
+  const pointStride = requiredNumber(message, "pointStride", "point_stride");
+  const fields = packedFields(requiredArray(message, "fields"));
+  const decodedPoints = extractPointCloudData(data, pointStride, fields);
+  applyPose(
+    decodedPoints.positions,
+    decodePose(optionalRecord(message, "pose")),
+  );
+  // Per-message Foxglove frame_id carried by this point cloud payload. This
+  // is separate from the MCAP channel frame_id metadata fallback.
+  const frameId = optionalString(message, "frameId", "frame_id");
+  const messageTimestamp = timestampNs(optionalRecord(message, "timestamp"));
+  const pointCount = decodedPoints.positions.length / POINT_COMPONENT_COUNT;
+  const packedFieldMetadata = fields.map((field) => ({
+    name: field.name,
+    offset: field.offset,
+    type: field.type,
+  }));
+  const attributes: Record<string, DecodedAttributeValue> = {
+    fields: packedFieldMetadata,
+    pointCount,
+    pointStride,
+  };
+
+  if (frameId) {
+    attributes.frameId = frameId;
+  }
+
+  const transferableViews = [
+    decodedPoints.positions,
+    decodedPoints.colors,
+    ...decodedPoints.scalarFields.map((field) => field.values),
+  ].filter((view): view is Float32Array => view !== undefined);
+
+  return {
+    attributes,
+    resourceHints: resourceHintsForArrayBufferViews(...transferableViews),
+    timing: timingFromContext(context, messageTimestamp),
+    visualization: {
+      ...(frameId ? { coordinateFrameId: frameId } : {}),
+      ...(decodedPoints.colors ? { colors: decodedPoints.colors } : {}),
+      ...(decodedPoints.scalarFields.length
+        ? { scalarFields: decodedPoints.scalarFields }
+        : {}),
+      fields: packedFieldMetadata,
+      kind: VISUALIZATION_KIND.POINT_CLOUD,
+      pointCount,
+      positions: decodedPoints.positions,
+    },
+  };
+}
 
 /**
  * Normalized point cloud buffers shared by Foxglove and ROS decoders.

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/pose-in-frame.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/pose-in-frame.ts
@@ -1,12 +1,18 @@
 import type {
+  DecodeContext,
   DecodedAttributeValue,
+  DecodedOutput,
   Decoder,
   PoseVisualization,
 } from "../../../../decoders";
 import { VISUALIZATION_KIND } from "../../../../visualization";
+import { rosDecodersForPayloads } from "../ros/factory";
 import { decodeProtobufMessage } from "./protobuf";
 import { decodeQuaternion, decodeVector3 } from "./protobuf/geometry";
-import { FOXGLOVE_POSE_IN_FRAME_PAYLOAD } from "./protobuf/payloads";
+import {
+  FOXGLOVE_POSE_IN_FRAME_CDR_PAYLOADS,
+  FOXGLOVE_POSE_IN_FRAME_PAYLOAD,
+} from "./payloads";
 import { optionalRecord, optionalString } from "./protobuf/records";
 import { timingFromContext, timestampNs } from "./protobuf/timing";
 
@@ -26,35 +32,51 @@ export const foxglovePoseInFrameDecoder: Decoder = {
       FOXGLOVE_POSE_IN_FRAME_PAYLOAD,
       context,
     );
-    const frameId = optionalString(message, "frameId", "frame_id");
-    const messageTimestamp = timestampNs(optionalRecord(message, "timestamp"));
-    const pose = optionalRecord(message, "pose");
-    const position = decodeVector3(pose && optionalRecord(pose, "position"));
-    const quaternion = decodeQuaternion(
-      pose && optionalRecord(pose, "orientation"),
-    );
-
-    const attributes: Record<string, DecodedAttributeValue> = {
-      position: [position[0], position[1], position[2]],
-    };
-    if (frameId) {
-      attributes.frameId = frameId;
-    }
-
-    const visualization: PoseVisualization = {
-      ...(frameId ? { coordinateFrameId: frameId } : {}),
-      kind: VISUALIZATION_KIND.POSE,
-      position,
-      quaternion,
-      ...(messageTimestamp !== undefined
-        ? { timestampNs: messageTimestamp }
-        : {}),
-    };
-
-    return {
-      attributes,
-      timing: timingFromContext(context, messageTimestamp),
-      visualization,
-    };
+    return decodeFoxglovePoseInFrameRecord(message, context);
   },
 };
+
+/**
+ * Decoders for Foxglove PoseInFrame messages carried over ROS 2 CDR.
+ */
+export const foxglovePoseInFrameCdrDecoders = rosDecodersForPayloads({
+  id: "foxglove.pose-in-frame.cdr",
+  map: decodeFoxglovePoseInFrameRecord,
+  payloads: FOXGLOVE_POSE_IN_FRAME_CDR_PAYLOADS,
+});
+
+export function decodeFoxglovePoseInFrameRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+): DecodedOutput {
+  const frameId = optionalString(message, "frameId", "frame_id");
+  const messageTimestamp = timestampNs(optionalRecord(message, "timestamp"));
+  const pose = optionalRecord(message, "pose");
+  const position = decodeVector3(pose && optionalRecord(pose, "position"));
+  const quaternion = decodeQuaternion(
+    pose && optionalRecord(pose, "orientation"),
+  );
+
+  const attributes: Record<string, DecodedAttributeValue> = {
+    position: [position[0], position[1], position[2]],
+  };
+  if (frameId) {
+    attributes.frameId = frameId;
+  }
+
+  const visualization: PoseVisualization = {
+    ...(frameId ? { coordinateFrameId: frameId } : {}),
+    kind: VISUALIZATION_KIND.POSE,
+    position,
+    quaternion,
+    ...(messageTimestamp !== undefined
+      ? { timestampNs: messageTimestamp }
+      : {}),
+  };
+
+  return {
+    attributes,
+    timing: timingFromContext(context, messageTimestamp),
+    visualization,
+  };
+}

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/protobuf/payloads.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/protobuf/payloads.ts
@@ -101,3 +101,18 @@ export const FOXGLOVE_LOG_PAYLOAD: PayloadDescriptor = {
   schema: "foxglove.Log",
   schemaEncoding: "protobuf",
 };
+
+/**
+ * Payload identities for Foxglove frame transform protobuf messages.
+ */
+export const FOXGLOVE_FRAME_TRANSFORM_PAYLOAD: PayloadDescriptor = {
+  encoding: "protobuf",
+  schema: "foxglove.FrameTransform",
+  schemaEncoding: "protobuf",
+};
+
+export const FOXGLOVE_FRAME_TRANSFORMS_PAYLOAD: PayloadDescriptor = {
+  encoding: "protobuf",
+  schema: "foxglove.FrameTransforms",
+  schemaEncoding: "protobuf",
+};

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/protobuf/payloads.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/protobuf/payloads.ts
@@ -92,3 +92,12 @@ export const FOXGLOVE_LOCATION_FIX_PAYLOAD: PayloadDescriptor = {
   schema: "foxglove.LocationFix",
   schemaEncoding: "protobuf",
 };
+
+/**
+ * Payload identity for foxglove.Log messages.
+ */
+export const FOXGLOVE_LOG_PAYLOAD: PayloadDescriptor = {
+  encoding: "protobuf",
+  schema: "foxglove.Log",
+  schemaEncoding: "protobuf",
+};

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/protobuf/timing.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/protobuf/timing.ts
@@ -49,15 +49,22 @@ export function timingFromContext(
 }
 
 /**
- * Convert a protobuf Timestamp-like record into nanoseconds.
+ * Convert a protobuf Timestamp or ROS 2 Time-like record into nanoseconds.
  */
 export function timestampNs(timestamp: Record<string, unknown> | undefined) {
   if (!timestamp) {
     return undefined;
   }
 
-  const seconds = optionalBigInt(timestamp, "seconds") ?? 0n;
-  const nanos = optionalBigInt(timestamp, "nanos") ?? 0n;
+  const seconds =
+    optionalBigInt(timestamp, "seconds") ??
+    optionalBigInt(timestamp, "sec") ??
+    0n;
+  const nanos =
+    optionalBigInt(timestamp, "nanos") ??
+    optionalBigInt(timestamp, "nanosec") ??
+    optionalBigInt(timestamp, "nsec") ??
+    0n;
 
   return seconds * NANOSECONDS_PER_SECOND + nanos;
 }

--- a/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/scene-update.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/foxglove/scene-update.ts
@@ -1,5 +1,7 @@
 import {
+  type DecodeContext,
   type DecodedAttributeValue,
+  type DecodedOutput,
   type Decoder,
   type RgbaColor,
   resourceHintsForArrayBufferViews,
@@ -19,9 +21,13 @@ import {
   type SceneUpdateVisualization,
 } from "../../../../decoders";
 import { VISUALIZATION_KIND } from "../../../../visualization";
+import { rosDecodersForPayloads } from "../ros/factory";
 import { decodeProtobufMessage } from "./protobuf";
 import { decodePose, decodeVector3 } from "./protobuf/geometry";
-import { FOXGLOVE_SCENE_UPDATE_PAYLOAD } from "./protobuf/payloads";
+import {
+  FOXGLOVE_SCENE_UPDATE_CDR_PAYLOADS,
+  FOXGLOVE_SCENE_UPDATE_PAYLOAD,
+} from "./payloads";
 import { asRecord, numberField, optionalRecord } from "./protobuf/records";
 import { timingFromContext, timestampNs } from "./protobuf/timing";
 
@@ -62,44 +68,60 @@ export const foxgloveSceneUpdateDecoder: Decoder = {
       FOXGLOVE_SCENE_UPDATE_PAYLOAD,
       context,
     );
-
-    const rawDeletions = optionalArray(message, "deletions");
-    const rawEntities = optionalArray(message, "entities");
-    const deletions = rawDeletions.map(decodeDeletion);
-    const entities = rawEntities.map(decodeEntity);
-    const primitiveCounts = primitiveCountsForEntities(entities);
-    const modelDataHints = resourceHintsForArrayBufferViews(
-      ...modelDataViewsForEntities(entities),
-    );
-
-    const visualization: SceneUpdateVisualization = {
-      kind: VISUALIZATION_KIND.SCENE_UPDATE,
-      deletions,
-      entities,
-    };
-    const attributes: Record<string, DecodedAttributeValue> = {
-      deletionCount: deletions.length,
-      entityCount: entities.length,
-      ...primitiveCounts,
-      unsupportedPrimitiveCount: 0,
-    };
-
-    return {
-      attributes,
-      resourceHints: {
-        sizeBytes: bytes.byteLength + (modelDataHints.sizeBytes ?? 0),
-        ...(modelDataHints.transferables?.length
-          ? { transferables: modelDataHints.transferables }
-          : {}),
-      },
-      timing: timingFromContext(
-        context,
-        firstSceneUpdateTimestamp(entities, deletions),
-      ),
-      visualization,
-    };
+    return decodeFoxgloveSceneUpdateRecord(message, context, bytes);
   },
 };
+
+/**
+ * Decoders for Foxglove SceneUpdate messages carried over ROS 2 CDR.
+ */
+export const foxgloveSceneUpdateCdrDecoders = rosDecodersForPayloads({
+  id: "foxglove.scene-update.cdr",
+  map: decodeFoxgloveSceneUpdateRecord,
+  payloads: FOXGLOVE_SCENE_UPDATE_CDR_PAYLOADS,
+});
+
+export function decodeFoxgloveSceneUpdateRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+  bytes?: Uint8Array,
+): DecodedOutput {
+  const rawDeletions = optionalArray(message, "deletions");
+  const rawEntities = optionalArray(message, "entities");
+  const deletions = rawDeletions.map(decodeDeletion);
+  const entities = rawEntities.map(decodeEntity);
+  const primitiveCounts = primitiveCountsForEntities(entities);
+  const modelDataHints = resourceHintsForArrayBufferViews(
+    ...modelDataViewsForEntities(entities),
+  );
+
+  const visualization: SceneUpdateVisualization = {
+    kind: VISUALIZATION_KIND.SCENE_UPDATE,
+    deletions,
+    entities,
+  };
+  const attributes: Record<string, DecodedAttributeValue> = {
+    deletionCount: deletions.length,
+    entityCount: entities.length,
+    ...primitiveCounts,
+    unsupportedPrimitiveCount: 0,
+  };
+
+  return {
+    attributes,
+    resourceHints: {
+      sizeBytes: (bytes?.byteLength ?? 0) + (modelDataHints.sizeBytes ?? 0),
+      ...(modelDataHints.transferables?.length
+        ? { transferables: modelDataHints.transferables }
+        : {}),
+    },
+    timing: timingFromContext(
+      context,
+      firstSceneUpdateTimestamp(entities, deletions),
+    ),
+    visualization,
+  };
+}
 
 function decodeEntity(value: unknown): SceneEntityVisualization {
   const record = asRecord(value);

--- a/app/packages/multimodal/src/adapters/mcap/decoders/json/payloads.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/json/payloads.ts
@@ -114,6 +114,36 @@ export const JSON_ROS_NAV_SAT_FIX_PAYLOADS = jsonRosPayloads(
 );
 
 /**
+ * Payload descriptors for JSON-schema ROS rosgraph Log messages.
+ */
+export const JSON_ROS_ROSGRAPH_LOG_PAYLOADS: readonly PayloadDescriptor[] = [
+  {
+    encoding: "json",
+    schema: "rosgraph_msgs/Log",
+    schemaEncoding: "jsonschema",
+  },
+];
+
+/**
+ * Payload descriptors for JSON-schema ROS 2 rcl_interfaces Log messages.
+ */
+export const JSON_ROS_RCL_LOG_PAYLOADS: readonly PayloadDescriptor[] = [
+  {
+    encoding: "json",
+    schema: "rcl_interfaces/msg/Log",
+    schemaEncoding: "jsonschema",
+  },
+];
+
+/**
+ * Payload descriptors for JSON-schema ROS DiagnosticArray messages.
+ */
+export const JSON_ROS_DIAGNOSTIC_ARRAY_PAYLOADS = jsonRosPayloads(
+  "diagnostic_msgs/DiagnosticArray",
+  "diagnostic_msgs/msg/DiagnosticArray",
+);
+
+/**
  * Payload descriptors for JSON-schema ROS OccupancyGrid messages.
  */
 export const JSON_ROS_OCCUPANCY_GRID_PAYLOADS = jsonRosPayloads(

--- a/app/packages/multimodal/src/adapters/mcap/decoders/json/payloads.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/json/payloads.ts
@@ -104,3 +104,19 @@ export const JSON_ROS_OCCUPANCY_GRID_PAYLOADS = jsonRosPayloads(
   "nav_msgs/OccupancyGrid",
   "nav_msgs/msg/OccupancyGrid",
 );
+
+/**
+ * Payload descriptors for JSON-schema ROS visualization Marker messages.
+ */
+export const JSON_ROS_MARKER_PAYLOADS = jsonRosPayloads(
+  "visualization_msgs/Marker",
+  "visualization_msgs/msg/Marker",
+);
+
+/**
+ * Payload descriptors for JSON-schema ROS visualization MarkerArray messages.
+ */
+export const JSON_ROS_MARKER_ARRAY_PAYLOADS = jsonRosPayloads(
+  "visualization_msgs/MarkerArray",
+  "visualization_msgs/msg/MarkerArray",
+);

--- a/app/packages/multimodal/src/adapters/mcap/decoders/json/payloads.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/json/payloads.ts
@@ -136,3 +136,19 @@ export const JSON_ROS_MARKER_ARRAY_PAYLOADS = jsonRosPayloads(
   "visualization_msgs/MarkerArray",
   "visualization_msgs/msg/MarkerArray",
 );
+
+/**
+ * Payload descriptors for JSON-schema ROS vision Detection2DArray messages.
+ */
+export const JSON_ROS_DETECTION_2D_ARRAY_PAYLOADS = jsonRosPayloads(
+  "vision_msgs/Detection2DArray",
+  "vision_msgs/msg/Detection2DArray",
+);
+
+/**
+ * Payload descriptors for JSON-schema ROS vision Detection3DArray messages.
+ */
+export const JSON_ROS_DETECTION_3D_ARRAY_PAYLOADS = jsonRosPayloads(
+  "vision_msgs/Detection3DArray",
+  "vision_msgs/msg/Detection3DArray",
+);

--- a/app/packages/multimodal/src/adapters/mcap/decoders/json/payloads.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/json/payloads.ts
@@ -82,11 +82,27 @@ export const JSON_ROS_POSE_STAMPED_PAYLOADS = jsonRosPayloads(
 );
 
 /**
+ * Payload descriptors for JSON-schema ROS PoseArray messages.
+ */
+export const JSON_ROS_POSE_ARRAY_PAYLOADS = jsonRosPayloads(
+  "geometry_msgs/PoseArray",
+  "geometry_msgs/msg/PoseArray",
+);
+
+/**
  * Payload descriptors for JSON-schema ROS Odometry messages.
  */
 export const JSON_ROS_ODOMETRY_PAYLOADS = jsonRosPayloads(
   "nav_msgs/Odometry",
   "nav_msgs/msg/Odometry",
+);
+
+/**
+ * Payload descriptors for JSON-schema ROS Path messages.
+ */
+export const JSON_ROS_PATH_PAYLOADS = jsonRosPayloads(
+  "nav_msgs/Path",
+  "nav_msgs/msg/Path",
 );
 
 /**

--- a/app/packages/multimodal/src/adapters/mcap/decoders/json/ros.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/json/ros.test.ts
@@ -14,6 +14,7 @@ import {
   isImageAnnotationsStream,
   isImageStream,
   isLocationFixStream,
+  isLogStream,
   isPointCloudStream,
   isPoseStream,
   isSceneUpdateStream,
@@ -24,6 +25,7 @@ import {
   JSON_ROS_COMPRESSED_IMAGE_PAYLOADS,
   JSON_ROS_DETECTION_2D_ARRAY_PAYLOADS,
   JSON_ROS_DETECTION_3D_ARRAY_PAYLOADS,
+  JSON_ROS_DIAGNOSTIC_ARRAY_PAYLOADS,
   JSON_ROS_IMAGE_PAYLOADS,
   JSON_ROS_LASER_SCAN_PAYLOADS,
   JSON_ROS_NAV_SAT_FIX_PAYLOADS,
@@ -33,10 +35,13 @@ import {
   JSON_ROS_POINT_CLOUD2_PAYLOADS,
   JSON_ROS_POSE_ARRAY_PAYLOADS,
   JSON_ROS_POSE_STAMPED_PAYLOADS,
+  JSON_ROS_RCL_LOG_PAYLOADS,
+  JSON_ROS_ROSGRAPH_LOG_PAYLOADS,
 } from "./payloads";
 import {
   jsonRosCameraInfoDecoders,
   jsonRosCompressedImageDecoders,
+  jsonRosDiagnosticArrayDecoders,
   jsonRosDetection2DArrayDecoders,
   jsonRosDetection3DArrayDecoders,
   jsonRosImageDecoders,
@@ -48,6 +53,8 @@ import {
   jsonRosPointCloud2Decoders,
   jsonRosPoseArrayDecoders,
   jsonRosPoseStampedDecoders,
+  jsonRosRclLogDecoders,
+  jsonRosRosgraphLogDecoders,
 } from "./ros";
 
 const TEXT_ENCODER = new TextEncoder();
@@ -81,6 +88,7 @@ describe("JSON-schema ROS MCAP decoders", () => {
       ...JSON_ROS_COMPRESSED_IMAGE_PAYLOADS,
       ...JSON_ROS_DETECTION_2D_ARRAY_PAYLOADS,
       ...JSON_ROS_DETECTION_3D_ARRAY_PAYLOADS,
+      ...JSON_ROS_DIAGNOSTIC_ARRAY_PAYLOADS,
       ...JSON_ROS_IMAGE_PAYLOADS,
       ...JSON_ROS_LASER_SCAN_PAYLOADS,
       ...JSON_ROS_NAV_SAT_FIX_PAYLOADS,
@@ -90,6 +98,8 @@ describe("JSON-schema ROS MCAP decoders", () => {
       ...JSON_ROS_POINT_CLOUD2_PAYLOADS,
       ...JSON_ROS_POSE_ARRAY_PAYLOADS,
       ...JSON_ROS_POSE_STAMPED_PAYLOADS,
+      ...JSON_ROS_RCL_LOG_PAYLOADS,
+      ...JSON_ROS_ROSGRAPH_LOG_PAYLOADS,
     ];
 
     for (const payload of payloads) {
@@ -211,6 +221,85 @@ describe("JSON-schema ROS MCAP decoders", () => {
       latitude: 37.77,
       longitude: -122.42,
     });
+  });
+
+  it("decodes JSON ROS logs and diagnostics into console rows", () => {
+    const rosgraph = decoderForSchema(
+      jsonRosRosgraphLogDecoders,
+      "rosgraph_msgs/Log",
+    ).decode(
+      jsonMessage({
+        file: "planner.cpp",
+        function: "tick",
+        header: headerRecord("rosout", 7, 8),
+        level: 8,
+        line: 42,
+        msg: "planner failed",
+        name: "planner",
+        topics: ["/plan"],
+      }),
+      {},
+    );
+    const rcl = decoderForSchema(
+      jsonRosRclLogDecoders,
+      "rcl_interfaces/msg/Log",
+    ).decode(
+      jsonMessage({
+        file: "controller.cpp",
+        function: "update",
+        level: 30,
+        line: 10,
+        msg: "tracking degraded",
+        name: "controller",
+        stamp: { nanosec: 4, sec: 5 },
+      }),
+      {},
+    );
+    const diagnostics = decoderForSchema(
+      jsonRosDiagnosticArrayDecoders,
+      "diagnostic_msgs/msg/DiagnosticArray",
+    ).decode(
+      jsonMessage({
+        header: headerRecord("base", 6, 9),
+        status: [
+          {
+            hardware_id: "lidar-top",
+            level: 2,
+            message: "packet drops",
+            name: "driver",
+            values: [{ key: "drop_rate", value: "0.2" }],
+          },
+        ],
+      }),
+      {},
+    );
+
+    expect(rosgraph.attributes?.logRows).toEqual([
+      expect.objectContaining({
+        level: "error",
+        message: "planner failed",
+        timestampNs: 7_000_000_008n,
+      }),
+    ]);
+    expect(rcl.attributes?.logRows).toEqual([
+      expect.objectContaining({
+        level: "warn",
+        levelNumber: 30,
+        message: "tracking degraded",
+        timestampNs: 5_000_000_004n,
+      }),
+    ]);
+    expect(diagnostics.attributes?.logRows).toEqual([
+      expect.objectContaining({
+        details: [{ key: "drop_rate", value: "0.2" }],
+        hardwareId: "lidar-top",
+        kind: "diagnostic",
+        level: "error",
+        message: "packet drops",
+        name: "driver",
+        status: "ERROR",
+      }),
+    ]);
   });
 
   it("decodes JSON CameraInfo records into calibration visualizations", () => {
@@ -577,6 +666,11 @@ describe("JSON-schema ROS MCAP decoders", () => {
       "/detections3d",
       JSON_ROS_DETECTION_3D_ARRAY_PAYLOADS[0],
     );
+    const logs = createTopic("/rosout", JSON_ROS_RCL_LOG_PAYLOADS[0]);
+    const diagnostics = createTopic(
+      "/diagnostics",
+      JSON_ROS_DIAGNOSTIC_ARRAY_PAYLOADS[1],
+    );
 
     expect(isCompressedImageStream(compressed)).toBe(true);
     expect(isCompressedImageStream(rawImage)).toBe(false);
@@ -607,6 +701,8 @@ describe("JSON-schema ROS MCAP decoders", () => {
     expect(isSceneUpdateStream(poseArray)).toBe(true);
     expect(isImageAnnotationsStream(detections2d)).toBe(true);
     expect(isSceneUpdateStream(detections3d)).toBe(true);
+    expect(isLogStream(logs)).toBe(true);
+    expect(isLogStream(diagnostics)).toBe(true);
     expect(
       streamTopics([
         compressed,
@@ -617,12 +713,22 @@ describe("JSON-schema ROS MCAP decoders", () => {
         poseArray,
         detections2d,
         detections3d,
+        logs,
+        diagnostics,
       ]),
     ).toMatchObject({
       annotations: ["/detections2d"],
       image: ["/camera/compressed", "/camera/image"],
+      logs: ["/rosout", "/diagnostics"],
       pointCloud: ["/points", "/scan"],
-      previewable: ["/camera/compressed", "/camera/image", "/points", "/scan"],
+      previewable: [
+        "/camera/compressed",
+        "/camera/image",
+        "/points",
+        "/scan",
+        "/rosout",
+        "/diagnostics",
+      ],
       sceneUpdates: ["/planned_path", "/pose_hypotheses", "/detections3d"],
     });
   });

--- a/app/packages/multimodal/src/adapters/mcap/decoders/json/ros.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/json/ros.test.ts
@@ -15,6 +15,7 @@ import {
   isLocationFixStream,
   isPointCloudStream,
   isPoseStream,
+  isSceneUpdateStream,
   streamTopics,
 } from "../../stream-topics";
 import {
@@ -25,7 +26,9 @@ import {
   JSON_ROS_NAV_SAT_FIX_PAYLOADS,
   JSON_ROS_OCCUPANCY_GRID_PAYLOADS,
   JSON_ROS_ODOMETRY_PAYLOADS,
+  JSON_ROS_PATH_PAYLOADS,
   JSON_ROS_POINT_CLOUD2_PAYLOADS,
+  JSON_ROS_POSE_ARRAY_PAYLOADS,
   JSON_ROS_POSE_STAMPED_PAYLOADS,
 } from "./payloads";
 import {
@@ -36,7 +39,9 @@ import {
   jsonRosNavSatFixDecoders,
   jsonRosOccupancyGridDecoders,
   jsonRosOdometryDecoders,
+  jsonRosPathDecoders,
   jsonRosPointCloud2Decoders,
+  jsonRosPoseArrayDecoders,
   jsonRosPoseStampedDecoders,
 } from "./ros";
 
@@ -74,7 +79,9 @@ describe("JSON-schema ROS MCAP decoders", () => {
       ...JSON_ROS_NAV_SAT_FIX_PAYLOADS,
       ...JSON_ROS_OCCUPANCY_GRID_PAYLOADS,
       ...JSON_ROS_ODOMETRY_PAYLOADS,
+      ...JSON_ROS_PATH_PAYLOADS,
       ...JSON_ROS_POINT_CLOUD2_PAYLOADS,
+      ...JSON_ROS_POSE_ARRAY_PAYLOADS,
       ...JSON_ROS_POSE_STAMPED_PAYLOADS,
     ];
 
@@ -381,6 +388,68 @@ describe("JSON-schema ROS MCAP decoders", () => {
     expect(odometry.attributes).toMatchObject({ childFrameId: "base_link" });
   });
 
+  it("decodes JSON Path and PoseArray records into scene-update overlays", () => {
+    const path = decoderForSchema(
+      jsonRosPathDecoders,
+      "nav_msgs/msg/Path",
+    ).decode(
+      jsonMessage({
+        header: headerRecord("map", 13, 14),
+        poses: [
+          {
+            header: headerRecord("map", 1, 1),
+            pose: poseRecord([1, 2, 0], [0, 0, 0, 1]),
+          },
+          {
+            header: headerRecord("map", 1, 2),
+            pose: poseRecord([3, 4, 0], [0, 0, 0, 1]),
+          },
+        ],
+      }),
+      { streamId: "/planned_path" },
+    );
+    const poseArray = decoderForSchema(
+      jsonRosPoseArrayDecoders,
+      "geometry_msgs/PoseArray",
+    ).decode(
+      jsonMessage({
+        header: headerRecord("map", 15, 16),
+        poses: [
+          poseRecord([5, 6, 0], [0, 0, 0, 1]),
+          poseRecord([7, 8, 0], [0, 0, 1, 0]),
+        ],
+      }),
+      { streamId: "/pose_hypotheses" },
+    );
+
+    expect(path.visualization?.kind).toBe(VISUALIZATION_KIND.SCENE_UPDATE);
+    expect(poseArray.visualization?.kind).toBe(VISUALIZATION_KIND.SCENE_UPDATE);
+    if (
+      path.visualization?.kind !== VISUALIZATION_KIND.SCENE_UPDATE ||
+      poseArray.visualization?.kind !== VISUALIZATION_KIND.SCENE_UPDATE
+    ) {
+      throw new Error("Expected scene update visualizations");
+    }
+    expect(path.visualization.entities[0]?.lines[0]?.points).toEqual([
+      [1, 2, 0],
+      [3, 4, 0],
+    ]);
+    expect(path.visualization.entities[0]).toMatchObject({
+      frameId: "map",
+      id: "/planned_path:path",
+      timestampNs: 13_000_000_014n,
+    });
+    expect(poseArray.visualization.entities[0]).toMatchObject({
+      arrowCount: 2,
+      frameId: "map",
+      id: "/pose_hypotheses:pose-array",
+      timestampNs: 15_000_000_016n,
+    });
+    expect(
+      poseArray.visualization.entities[0]?.arrows[0]?.pose.position,
+    ).toEqual([5, 6, 0]);
+  });
+
   it("degrades invalid JSON and malformed JSON records without throwing", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const decoder = decoderForSchema(
@@ -413,6 +482,11 @@ describe("JSON-schema ROS MCAP decoders", () => {
     const rawImage = createTopic("/camera/image", JSON_ROS_IMAGE_PAYLOADS[1]);
     const cloud = createTopic("/points", JSON_ROS_POINT_CLOUD2_PAYLOADS[0]);
     const scan = createTopic("/scan", JSON_ROS_LASER_SCAN_PAYLOADS[1]);
+    const path = createTopic("/planned_path", JSON_ROS_PATH_PAYLOADS[1]);
+    const poseArray = createTopic(
+      "/pose_hypotheses",
+      JSON_ROS_POSE_ARRAY_PAYLOADS[0],
+    );
 
     expect(isCompressedImageStream(compressed)).toBe(true);
     expect(isCompressedImageStream(rawImage)).toBe(false);
@@ -439,10 +513,15 @@ describe("JSON-schema ROS MCAP decoders", () => {
     expect(
       isGridStream(createTopic("/map", JSON_ROS_OCCUPANCY_GRID_PAYLOADS[1])),
     ).toBe(true);
-    expect(streamTopics([compressed, rawImage, cloud, scan])).toMatchObject({
+    expect(isSceneUpdateStream(path)).toBe(true);
+    expect(isSceneUpdateStream(poseArray)).toBe(true);
+    expect(
+      streamTopics([compressed, rawImage, cloud, scan, path, poseArray]),
+    ).toMatchObject({
       image: ["/camera/compressed", "/camera/image"],
       pointCloud: ["/points", "/scan"],
       previewable: ["/camera/compressed", "/camera/image", "/points", "/scan"],
+      sceneUpdates: ["/planned_path", "/pose_hypotheses"],
     });
   });
 });

--- a/app/packages/multimodal/src/adapters/mcap/decoders/json/ros.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/json/ros.test.ts
@@ -11,6 +11,7 @@ import {
   isCameraCalibrationStream,
   isCompressedImageStream,
   isGridStream,
+  isImageAnnotationsStream,
   isImageStream,
   isLocationFixStream,
   isPointCloudStream,
@@ -21,6 +22,8 @@ import {
 import {
   JSON_ROS_CAMERA_INFO_PAYLOADS,
   JSON_ROS_COMPRESSED_IMAGE_PAYLOADS,
+  JSON_ROS_DETECTION_2D_ARRAY_PAYLOADS,
+  JSON_ROS_DETECTION_3D_ARRAY_PAYLOADS,
   JSON_ROS_IMAGE_PAYLOADS,
   JSON_ROS_LASER_SCAN_PAYLOADS,
   JSON_ROS_NAV_SAT_FIX_PAYLOADS,
@@ -34,6 +37,8 @@ import {
 import {
   jsonRosCameraInfoDecoders,
   jsonRosCompressedImageDecoders,
+  jsonRosDetection2DArrayDecoders,
+  jsonRosDetection3DArrayDecoders,
   jsonRosImageDecoders,
   jsonRosLaserScanDecoders,
   jsonRosNavSatFixDecoders,
@@ -74,6 +79,8 @@ describe("JSON-schema ROS MCAP decoders", () => {
     const payloads = [
       ...JSON_ROS_CAMERA_INFO_PAYLOADS,
       ...JSON_ROS_COMPRESSED_IMAGE_PAYLOADS,
+      ...JSON_ROS_DETECTION_2D_ARRAY_PAYLOADS,
+      ...JSON_ROS_DETECTION_3D_ARRAY_PAYLOADS,
       ...JSON_ROS_IMAGE_PAYLOADS,
       ...JSON_ROS_LASER_SCAN_PAYLOADS,
       ...JSON_ROS_NAV_SAT_FIX_PAYLOADS,
@@ -450,6 +457,81 @@ describe("JSON-schema ROS MCAP decoders", () => {
     ).toEqual([5, 6, 0]);
   });
 
+  it("decodes JSON vision detections into transient viewer overlays", () => {
+    const detections2d = decoderForSchema(
+      jsonRosDetection2DArrayDecoders,
+      "vision_msgs/msg/Detection2DArray",
+    ).decode(
+      jsonMessage({
+        detections: [
+          detection2DRecord({
+            classId: "car",
+            id: "track-1",
+            score: 0.93,
+            x: 50,
+            y: 40,
+          }),
+        ],
+        header: headerRecord("camera", 17, 18),
+      }),
+      {},
+    );
+    const detections3d = decoderForSchema(
+      jsonRosDetection3DArrayDecoders,
+      "vision_msgs/Detection3DArray",
+    ).decode(
+      jsonMessage({
+        detections: [
+          detection3DRecord({
+            classId: "pedestrian",
+            id: "track-9",
+            score: 0.81,
+          }),
+        ],
+        header: headerRecord("map", 19, 20),
+      }),
+      { streamId: "/detections3d" },
+    );
+
+    expect(detections2d.visualization?.kind).toBe(
+      VISUALIZATION_KIND.IMAGE_ANNOTATIONS,
+    );
+    expect(detections3d.visualization?.kind).toBe(
+      VISUALIZATION_KIND.SCENE_UPDATE,
+    );
+    if (
+      detections2d.visualization?.kind !==
+        VISUALIZATION_KIND.IMAGE_ANNOTATIONS ||
+      detections3d.visualization?.kind !== VISUALIZATION_KIND.SCENE_UPDATE
+    ) {
+      throw new Error("Expected detection visualizations");
+    }
+    expect(detections2d.visualization.points[0]?.points).toEqual([
+      [40, 30],
+      [60, 30],
+      [60, 50],
+      [40, 50],
+    ]);
+    expect(detections2d.visualization.texts[0]).toMatchObject({
+      position: [40, 16],
+      text: "car 0.93",
+    });
+    expect(detections3d.visualization.deletions).toEqual([
+      { id: "", timestampNs: 19_000_000_020n, type: "all" },
+    ]);
+    expect(detections3d.visualization.entities[0]).toMatchObject({
+      cubeCount: 1,
+      frameId: "map",
+      id: "/detections3d:detection3d:track-9",
+      metadata: {
+        classId: "pedestrian",
+        id: "track-9",
+        score: "0.8100",
+        source: "vision_msgs",
+      },
+    });
+  });
+
   it("degrades invalid JSON and malformed JSON records without throwing", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const decoder = decoderForSchema(
@@ -487,6 +569,14 @@ describe("JSON-schema ROS MCAP decoders", () => {
       "/pose_hypotheses",
       JSON_ROS_POSE_ARRAY_PAYLOADS[0],
     );
+    const detections2d = createTopic(
+      "/detections2d",
+      JSON_ROS_DETECTION_2D_ARRAY_PAYLOADS[1],
+    );
+    const detections3d = createTopic(
+      "/detections3d",
+      JSON_ROS_DETECTION_3D_ARRAY_PAYLOADS[0],
+    );
 
     expect(isCompressedImageStream(compressed)).toBe(true);
     expect(isCompressedImageStream(rawImage)).toBe(false);
@@ -515,13 +605,25 @@ describe("JSON-schema ROS MCAP decoders", () => {
     ).toBe(true);
     expect(isSceneUpdateStream(path)).toBe(true);
     expect(isSceneUpdateStream(poseArray)).toBe(true);
+    expect(isImageAnnotationsStream(detections2d)).toBe(true);
+    expect(isSceneUpdateStream(detections3d)).toBe(true);
     expect(
-      streamTopics([compressed, rawImage, cloud, scan, path, poseArray]),
+      streamTopics([
+        compressed,
+        rawImage,
+        cloud,
+        scan,
+        path,
+        poseArray,
+        detections2d,
+        detections3d,
+      ]),
     ).toMatchObject({
+      annotations: ["/detections2d"],
       image: ["/camera/compressed", "/camera/image"],
       pointCloud: ["/points", "/scan"],
       previewable: ["/camera/compressed", "/camera/image", "/points", "/scan"],
-      sceneUpdates: ["/planned_path", "/pose_hypotheses"],
+      sceneUpdates: ["/planned_path", "/pose_hypotheses", "/detections3d"],
     });
   });
 });
@@ -604,6 +706,61 @@ function vectorRecord(vector: readonly [number, number, number]) {
     x: vector[0],
     y: vector[1],
     z: vector[2],
+  };
+}
+
+function detection2DRecord({
+  classId,
+  id,
+  score,
+  x,
+  y,
+}: {
+  readonly classId: string;
+  readonly id: string;
+  readonly score: number;
+  readonly x: number;
+  readonly y: number;
+}) {
+  return {
+    bbox: {
+      center: {
+        position: { x, y },
+        theta: 0,
+      },
+      size_x: 20,
+      size_y: 20,
+    },
+    id,
+    results: [detectionResult(classId, score)],
+  };
+}
+
+function detection3DRecord({
+  classId,
+  id,
+  score,
+}: {
+  readonly classId: string;
+  readonly id: string;
+  readonly score: number;
+}) {
+  return {
+    bbox: {
+      center: poseRecord([1, 2, 3], [0, 0, 0, 1]),
+      size: vectorRecord([2, 1, 1.5]),
+    },
+    id,
+    results: [detectionResult(classId, score)],
+  };
+}
+
+function detectionResult(classId: string, score: number) {
+  return {
+    hypothesis: {
+      class_id: classId,
+      score,
+    },
   };
 }
 

--- a/app/packages/multimodal/src/adapters/mcap/decoders/json/ros.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/json/ros.ts
@@ -3,6 +3,10 @@ import { decodeRosCameraInfoRecord } from "../ros/camera-info";
 import { decodeRosCompressedImageRecord } from "../ros/compressed-image";
 import { decodeRosImageRecord } from "../ros/image";
 import { decodeRosLaserScanRecord } from "../ros/laser-scan";
+import {
+  decodeRosMarkerArrayRecord,
+  decodeRosMarkerRecord,
+} from "../ros/marker";
 import { decodeRosNavSatFixRecord } from "../ros/nav-sat-fix";
 import { decodeRosOccupancyGridRecord } from "../ros/occupancy-grid";
 import { decodeRosPointCloud2Record } from "../ros/point-cloud2";
@@ -16,6 +20,8 @@ import {
   JSON_ROS_COMPRESSED_IMAGE_PAYLOADS,
   JSON_ROS_IMAGE_PAYLOADS,
   JSON_ROS_LASER_SCAN_PAYLOADS,
+  JSON_ROS_MARKER_ARRAY_PAYLOADS,
+  JSON_ROS_MARKER_PAYLOADS,
   JSON_ROS_NAV_SAT_FIX_PAYLOADS,
   JSON_ROS_OCCUPANCY_GRID_PAYLOADS,
   JSON_ROS_ODOMETRY_PAYLOADS,
@@ -57,6 +63,24 @@ export const jsonRosLaserScanDecoders = jsonDecodersForPayloads({
   id: "json.ros.laser-scan",
   map: decodeRosLaserScanRecord,
   payloads: JSON_ROS_LASER_SCAN_PAYLOADS,
+});
+
+/**
+ * JSON-schema decoders for ROS Marker records.
+ */
+export const jsonRosMarkerDecoders = jsonDecodersForPayloads({
+  id: "json.ros.marker",
+  map: decodeRosMarkerRecord,
+  payloads: JSON_ROS_MARKER_PAYLOADS,
+});
+
+/**
+ * JSON-schema decoders for ROS MarkerArray records.
+ */
+export const jsonRosMarkerArrayDecoders = jsonDecodersForPayloads({
+  id: "json.ros.marker-array",
+  map: decodeRosMarkerArrayRecord,
+  payloads: JSON_ROS_MARKER_ARRAY_PAYLOADS,
 });
 
 /**
@@ -112,6 +136,8 @@ export const jsonRosDecoders: readonly Decoder[] = [
   ...jsonRosImageDecoders,
   ...jsonRosPointCloud2Decoders,
   ...jsonRosLaserScanDecoders,
+  ...jsonRosMarkerDecoders,
+  ...jsonRosMarkerArrayDecoders,
   ...jsonRosCameraInfoDecoders,
   ...jsonRosNavSatFixDecoders,
   ...jsonRosOccupancyGridDecoders,

--- a/app/packages/multimodal/src/adapters/mcap/decoders/json/ros.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/json/ros.ts
@@ -9,6 +9,7 @@ import {
 } from "../ros/marker";
 import { decodeRosNavSatFixRecord } from "../ros/nav-sat-fix";
 import { decodeRosOccupancyGridRecord } from "../ros/occupancy-grid";
+import { decodeRosPathRecord, decodeRosPoseArrayRecord } from "../ros/path";
 import { decodeRosPointCloud2Record } from "../ros/point-cloud2";
 import {
   decodeRosOdometryRecord,
@@ -25,7 +26,9 @@ import {
   JSON_ROS_NAV_SAT_FIX_PAYLOADS,
   JSON_ROS_OCCUPANCY_GRID_PAYLOADS,
   JSON_ROS_ODOMETRY_PAYLOADS,
+  JSON_ROS_PATH_PAYLOADS,
   JSON_ROS_POINT_CLOUD2_PAYLOADS,
+  JSON_ROS_POSE_ARRAY_PAYLOADS,
   JSON_ROS_POSE_STAMPED_PAYLOADS,
 } from "./payloads";
 
@@ -129,6 +132,24 @@ export const jsonRosOdometryDecoders = jsonDecodersForPayloads({
 });
 
 /**
+ * JSON-schema decoders for ROS Path records.
+ */
+export const jsonRosPathDecoders = jsonDecodersForPayloads({
+  id: "json.ros.path",
+  map: decodeRosPathRecord,
+  payloads: JSON_ROS_PATH_PAYLOADS,
+});
+
+/**
+ * JSON-schema decoders for ROS PoseArray records.
+ */
+export const jsonRosPoseArrayDecoders = jsonDecodersForPayloads({
+  id: "json.ros.pose-array",
+  map: decodeRosPoseArrayRecord,
+  payloads: JSON_ROS_POSE_ARRAY_PAYLOADS,
+});
+
+/**
  * Built-in JSON-schema decoders for supported ROS message families.
  */
 export const jsonRosDecoders: readonly Decoder[] = [
@@ -143,4 +164,6 @@ export const jsonRosDecoders: readonly Decoder[] = [
   ...jsonRosOccupancyGridDecoders,
   ...jsonRosPoseStampedDecoders,
   ...jsonRosOdometryDecoders,
+  ...jsonRosPathDecoders,
+  ...jsonRosPoseArrayDecoders,
 ];

--- a/app/packages/multimodal/src/adapters/mcap/decoders/json/ros.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/json/ros.ts
@@ -15,10 +15,16 @@ import {
   decodeRosOdometryRecord,
   decodeRosPoseStampedRecord,
 } from "../ros/pose";
+import {
+  decodeRosDetection2DArrayRecord,
+  decodeRosDetection3DArrayRecord,
+} from "../ros/vision";
 import { jsonDecodersForPayloads } from "./factory";
 import {
   JSON_ROS_CAMERA_INFO_PAYLOADS,
   JSON_ROS_COMPRESSED_IMAGE_PAYLOADS,
+  JSON_ROS_DETECTION_2D_ARRAY_PAYLOADS,
+  JSON_ROS_DETECTION_3D_ARRAY_PAYLOADS,
   JSON_ROS_IMAGE_PAYLOADS,
   JSON_ROS_LASER_SCAN_PAYLOADS,
   JSON_ROS_MARKER_ARRAY_PAYLOADS,
@@ -150,6 +156,24 @@ export const jsonRosPoseArrayDecoders = jsonDecodersForPayloads({
 });
 
 /**
+ * JSON-schema decoders for ROS Detection2DArray records.
+ */
+export const jsonRosDetection2DArrayDecoders = jsonDecodersForPayloads({
+  id: "json.ros.detection-2d-array",
+  map: decodeRosDetection2DArrayRecord,
+  payloads: JSON_ROS_DETECTION_2D_ARRAY_PAYLOADS,
+});
+
+/**
+ * JSON-schema decoders for ROS Detection3DArray records.
+ */
+export const jsonRosDetection3DArrayDecoders = jsonDecodersForPayloads({
+  id: "json.ros.detection-3d-array",
+  map: decodeRosDetection3DArrayRecord,
+  payloads: JSON_ROS_DETECTION_3D_ARRAY_PAYLOADS,
+});
+
+/**
  * Built-in JSON-schema decoders for supported ROS message families.
  */
 export const jsonRosDecoders: readonly Decoder[] = [
@@ -166,4 +190,6 @@ export const jsonRosDecoders: readonly Decoder[] = [
   ...jsonRosOdometryDecoders,
   ...jsonRosPathDecoders,
   ...jsonRosPoseArrayDecoders,
+  ...jsonRosDetection2DArrayDecoders,
+  ...jsonRosDetection3DArrayDecoders,
 ];

--- a/app/packages/multimodal/src/adapters/mcap/decoders/json/ros.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/json/ros.ts
@@ -4,6 +4,11 @@ import { decodeRosCompressedImageRecord } from "../ros/compressed-image";
 import { decodeRosImageRecord } from "../ros/image";
 import { decodeRosLaserScanRecord } from "../ros/laser-scan";
 import {
+  decodeDiagnosticArrayRecord,
+  decodeRclLogRecord,
+  decodeRosgraphLogRecord,
+} from "../ros/log";
+import {
   decodeRosMarkerArrayRecord,
   decodeRosMarkerRecord,
 } from "../ros/marker";
@@ -25,6 +30,7 @@ import {
   JSON_ROS_COMPRESSED_IMAGE_PAYLOADS,
   JSON_ROS_DETECTION_2D_ARRAY_PAYLOADS,
   JSON_ROS_DETECTION_3D_ARRAY_PAYLOADS,
+  JSON_ROS_DIAGNOSTIC_ARRAY_PAYLOADS,
   JSON_ROS_IMAGE_PAYLOADS,
   JSON_ROS_LASER_SCAN_PAYLOADS,
   JSON_ROS_MARKER_ARRAY_PAYLOADS,
@@ -36,6 +42,8 @@ import {
   JSON_ROS_POINT_CLOUD2_PAYLOADS,
   JSON_ROS_POSE_ARRAY_PAYLOADS,
   JSON_ROS_POSE_STAMPED_PAYLOADS,
+  JSON_ROS_RCL_LOG_PAYLOADS,
+  JSON_ROS_ROSGRAPH_LOG_PAYLOADS,
 } from "./payloads";
 
 /**
@@ -72,6 +80,33 @@ export const jsonRosLaserScanDecoders = jsonDecodersForPayloads({
   id: "json.ros.laser-scan",
   map: decodeRosLaserScanRecord,
   payloads: JSON_ROS_LASER_SCAN_PAYLOADS,
+});
+
+/**
+ * JSON-schema decoders for ROS rosgraph Log records.
+ */
+export const jsonRosRosgraphLogDecoders = jsonDecodersForPayloads({
+  id: "json.ros.rosgraph-log",
+  map: decodeRosgraphLogRecord,
+  payloads: JSON_ROS_ROSGRAPH_LOG_PAYLOADS,
+});
+
+/**
+ * JSON-schema decoders for ROS 2 rcl_interfaces Log records.
+ */
+export const jsonRosRclLogDecoders = jsonDecodersForPayloads({
+  id: "json.ros.rcl-log",
+  map: decodeRclLogRecord,
+  payloads: JSON_ROS_RCL_LOG_PAYLOADS,
+});
+
+/**
+ * JSON-schema decoders for ROS DiagnosticArray records.
+ */
+export const jsonRosDiagnosticArrayDecoders = jsonDecodersForPayloads({
+  id: "json.ros.diagnostic-array",
+  map: decodeDiagnosticArrayRecord,
+  payloads: JSON_ROS_DIAGNOSTIC_ARRAY_PAYLOADS,
 });
 
 /**
@@ -181,6 +216,9 @@ export const jsonRosDecoders: readonly Decoder[] = [
   ...jsonRosImageDecoders,
   ...jsonRosPointCloud2Decoders,
   ...jsonRosLaserScanDecoders,
+  ...jsonRosRosgraphLogDecoders,
+  ...jsonRosRclLogDecoders,
+  ...jsonRosDiagnosticArrayDecoders,
   ...jsonRosMarkerDecoders,
   ...jsonRosMarkerArrayDecoders,
   ...jsonRosCameraInfoDecoders,

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros.test.ts
@@ -17,6 +17,7 @@ import {
   isImageAnnotationsStream,
   isImageStream,
   isLocationFixStream,
+  isLogStream,
   isPointCloudStream,
   isPoseStream,
   isSceneUpdateStream,
@@ -28,6 +29,7 @@ import {
   ROS_COMPRESSED_IMAGE_PAYLOADS,
   ROS_DETECTION_2D_ARRAY_PAYLOADS,
   ROS_DETECTION_3D_ARRAY_PAYLOADS,
+  ROS_DIAGNOSTIC_ARRAY_PAYLOADS,
   ROS_IMAGE_PAYLOADS,
   ROS_LASER_SCAN_PAYLOADS,
   ROS_MARKER_ARRAY_PAYLOADS,
@@ -38,8 +40,11 @@ import {
   ROS_POINT_CLOUD2_PAYLOADS,
   ROS_POSE_ARRAY_PAYLOADS,
   ROS_POSE_STAMPED_PAYLOADS,
+  ROS_RCL_LOG_PAYLOADS,
+  ROS_ROSGRAPH_LOG_PAYLOADS,
   rosCameraInfoDecoders,
   rosCompressedImageDecoders,
+  rosDiagnosticArrayDecoders,
   rosDetection2DArrayDecoders,
   rosDetection3DArrayDecoders,
   rosImageDecoders,
@@ -52,6 +57,8 @@ import {
   rosPointCloud2Decoders,
   rosPoseArrayDecoders,
   rosPoseStampedDecoders,
+  rosRclLogDecoders,
+  rosRosgraphLogDecoders,
 } from "./ros";
 
 const TEXT_ENCODER = new TextEncoder();
@@ -275,6 +282,48 @@ float64 x
 float64 y
 float64 z
 float64 w`;
+
+const ROS1_LOG_SCHEMA = `std_msgs/Header header
+byte level
+string name
+string msg
+string file
+string function
+uint32 line
+string[] topics
+===
+MSG: std_msgs/Header
+uint32 seq
+time stamp
+string frame_id`;
+
+const ROS2_RCL_LOG_SCHEMA = `builtin_interfaces/Time stamp
+uint8 level
+string name
+string msg
+string file
+string function
+uint32 line
+${ROS2_HEADER_DEFINITIONS}`;
+
+const ROS2_DIAGNOSTIC_ARRAY_SCHEMA = `std_msgs/Header header
+diagnostic_msgs/DiagnosticStatus[] status
+${ROS2_HEADER_DEFINITIONS}
+===
+MSG: diagnostic_msgs/DiagnosticStatus
+byte OK=0
+byte WARN=1
+byte ERROR=2
+byte STALE=3
+byte level
+string name
+string message
+string hardware_id
+diagnostic_msgs/KeyValue[] values
+===
+MSG: diagnostic_msgs/KeyValue
+string key
+string value`;
 
 const ROS2_ODOMETRY_SCHEMA = `std_msgs/Header header
 string child_frame_id
@@ -507,6 +556,7 @@ describe("ROS MCAP decoders", () => {
       ...ROS_COMPRESSED_IMAGE_PAYLOADS,
       ...ROS_DETECTION_2D_ARRAY_PAYLOADS,
       ...ROS_DETECTION_3D_ARRAY_PAYLOADS,
+      ...ROS_DIAGNOSTIC_ARRAY_PAYLOADS,
       ...ROS_IMAGE_PAYLOADS,
       ...ROS_LASER_SCAN_PAYLOADS,
       ...ROS_NAV_SAT_FIX_PAYLOADS,
@@ -516,6 +566,8 @@ describe("ROS MCAP decoders", () => {
       ...ROS_POINT_CLOUD2_PAYLOADS,
       ...ROS_POSE_ARRAY_PAYLOADS,
       ...ROS_POSE_STAMPED_PAYLOADS,
+      ...ROS_RCL_LOG_PAYLOADS,
+      ...ROS_ROSGRAPH_LOG_PAYLOADS,
     ];
 
     for (const payload of payloads) {
@@ -615,6 +667,93 @@ describe("ROS MCAP decoders", () => {
       frameId: "lidar",
       unsupportedReason: "ROS PointCloud2 big-endian data is unsupported",
     });
+  });
+
+  it("decodes ROS log and diagnostics records into console rows", () => {
+    const rosgraph = decoderForSchemaEncoding(
+      rosRosgraphLogDecoders,
+      "ros1msg",
+    ).decode(
+      ros1Message(ROS1_LOG_SCHEMA, {
+        file: "planner.cpp",
+        function: "tick",
+        header: ros1Header({ frameId: "rosout", nsec: 8, sec: 7, seq: 3 }),
+        level: 8,
+        line: 42,
+        msg: "planner failed",
+        name: "planner",
+        topics: ["/plan"],
+      }),
+      { schemaData: schemaData(ROS1_LOG_SCHEMA) },
+    );
+    const rcl = decoderForSchemaEncoding(rosRclLogDecoders, "ros2msg").decode(
+      ros2Message(ROS2_RCL_LOG_SCHEMA, {
+        file: "controller.cpp",
+        function: "update",
+        level: 30,
+        line: 10,
+        msg: "tracking degraded",
+        name: "controller",
+        stamp: { nanosec: 4, sec: 5 },
+      }),
+      { schemaData: schemaData(ROS2_RCL_LOG_SCHEMA) },
+    );
+    const diagnostics = decoderForSchemaEncoding(
+      rosDiagnosticArrayDecoders,
+      "ros2msg",
+    ).decode(
+      ros2Message(ROS2_DIAGNOSTIC_ARRAY_SCHEMA, {
+        header: ros2Header({ frameId: "base", nanosec: 9, sec: 6 }),
+        status: [
+          {
+            hardware_id: "lidar-top",
+            level: 2,
+            message: "packet drops",
+            name: "driver",
+            values: [{ key: "drop_rate", value: "0.2" }],
+          },
+        ],
+      }),
+      { schemaData: schemaData(ROS2_DIAGNOSTIC_ARRAY_SCHEMA) },
+    );
+
+    expect(rosgraph.attributes?.logRows).toEqual([
+      expect.objectContaining({
+        file: "planner.cpp",
+        functionName: "tick",
+        level: "error",
+        line: 42,
+        message: "planner failed",
+        name: "planner",
+        timestampNs: 7_000_000_008n,
+        topics: ["/plan"],
+      }),
+    ]);
+    expect(rosgraph.timing?.sourceTimestamps?.messageTime).toBe(7_000_000_008n);
+    expect(rcl.attributes?.logRows).toEqual([
+      expect.objectContaining({
+        level: "warn",
+        levelNumber: 30,
+        message: "tracking degraded",
+        timestampNs: 5_000_000_004n,
+      }),
+    ]);
+    expect(diagnostics.attributes).toMatchObject({
+      diagnosticCount: 1,
+      errorCount: 1,
+    });
+    expect(diagnostics.attributes?.logRows).toEqual([
+      expect.objectContaining({
+        details: [{ key: "drop_rate", value: "0.2" }],
+        hardwareId: "lidar-top",
+        kind: "diagnostic",
+        level: "error",
+        message: "packet drops",
+        name: "driver",
+        status: "ERROR",
+        timestampNs: 6_000_000_009n,
+      }),
+    ]);
   });
 
   it("decodes ros2 idl CompressedImage into an encoded image visualization", () => {
@@ -1519,6 +1658,11 @@ describe("ROS MCAP decoders", () => {
       "/detections3d",
       ROS_DETECTION_3D_ARRAY_PAYLOADS[1],
     );
+    const logs = createTopic("/rosout", ROS_RCL_LOG_PAYLOADS[0]);
+    const diagnostics = createTopic(
+      "/diagnostics",
+      ROS_DIAGNOSTIC_ARRAY_PAYLOADS[1],
+    );
 
     expect(isCompressedImageStream(compressed)).toBe(true);
     expect(isCompressedImageStream(rawImage)).toBe(false);
@@ -1548,6 +1692,8 @@ describe("ROS MCAP decoders", () => {
     expect(isSceneUpdateStream(poseArray)).toBe(true);
     expect(isImageAnnotationsStream(detections2d)).toBe(true);
     expect(isSceneUpdateStream(detections3d)).toBe(true);
+    expect(isLogStream(logs)).toBe(true);
+    expect(isLogStream(diagnostics)).toBe(true);
     expect(
       streamTopics([
         compressed,
@@ -1559,12 +1705,22 @@ describe("ROS MCAP decoders", () => {
         poseArray,
         detections2d,
         detections3d,
+        logs,
+        diagnostics,
       ]),
     ).toMatchObject({
       annotations: ["/detections2d"],
       image: ["/camera/compressed", "/camera/image"],
+      logs: ["/rosout", "/diagnostics"],
       pointCloud: ["/points", "/scan"],
-      previewable: ["/camera/compressed", "/camera/image", "/points", "/scan"],
+      previewable: [
+        "/camera/compressed",
+        "/camera/image",
+        "/points",
+        "/scan",
+        "/rosout",
+        "/diagnostics",
+      ],
       sceneUpdates: [
         "/markers",
         "/planned_path",

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros.test.ts
@@ -14,6 +14,7 @@ import {
   isCameraCalibrationStream,
   isCompressedImageStream,
   isGridStream,
+  isImageAnnotationsStream,
   isImageStream,
   isLocationFixStream,
   isPointCloudStream,
@@ -25,6 +26,8 @@ import { createMcapDecoderRegistry } from ".";
 import {
   ROS_CAMERA_INFO_PAYLOADS,
   ROS_COMPRESSED_IMAGE_PAYLOADS,
+  ROS_DETECTION_2D_ARRAY_PAYLOADS,
+  ROS_DETECTION_3D_ARRAY_PAYLOADS,
   ROS_IMAGE_PAYLOADS,
   ROS_LASER_SCAN_PAYLOADS,
   ROS_MARKER_ARRAY_PAYLOADS,
@@ -37,6 +40,8 @@ import {
   ROS_POSE_STAMPED_PAYLOADS,
   rosCameraInfoDecoders,
   rosCompressedImageDecoders,
+  rosDetection2DArrayDecoders,
+  rosDetection3DArrayDecoders,
   rosImageDecoders,
   rosLaserScanDecoders,
   rosMarkerArrayDecoders,
@@ -192,6 +197,75 @@ geometry_msgs/Point position
 geometry_msgs/Quaternion orientation
 ===
 MSG: geometry_msgs/Point
+float64 x
+float64 y
+float64 z
+===
+MSG: geometry_msgs/Quaternion
+float64 x
+float64 y
+float64 z
+float64 w`;
+
+const ROS2_DETECTION_2D_ARRAY_SCHEMA = `std_msgs/Header header
+vision_msgs/Detection2D[] detections
+${ROS2_HEADER_DEFINITIONS}
+===
+MSG: vision_msgs/Detection2D
+vision_msgs/ObjectHypothesisWithPose[] results
+vision_msgs/BoundingBox2D bbox
+string id
+===
+MSG: vision_msgs/ObjectHypothesisWithPose
+vision_msgs/ObjectHypothesis hypothesis
+===
+MSG: vision_msgs/ObjectHypothesis
+string class_id
+float64 score
+===
+MSG: vision_msgs/BoundingBox2D
+vision_msgs/Pose2D center
+float64 size_x
+float64 size_y
+===
+MSG: vision_msgs/Pose2D
+vision_msgs/Point2D position
+float64 theta
+===
+MSG: vision_msgs/Point2D
+float64 x
+float64 y`;
+
+const ROS2_DETECTION_3D_ARRAY_SCHEMA = `std_msgs/Header header
+vision_msgs/Detection3D[] detections
+${ROS2_HEADER_DEFINITIONS}
+===
+MSG: vision_msgs/Detection3D
+vision_msgs/ObjectHypothesisWithPose[] results
+vision_msgs/BoundingBox3D bbox
+string id
+===
+MSG: vision_msgs/ObjectHypothesisWithPose
+vision_msgs/ObjectHypothesis hypothesis
+===
+MSG: vision_msgs/ObjectHypothesis
+string class_id
+float64 score
+===
+MSG: vision_msgs/BoundingBox3D
+geometry_msgs/Pose center
+geometry_msgs/Vector3 size
+===
+MSG: geometry_msgs/Pose
+geometry_msgs/Point position
+geometry_msgs/Quaternion orientation
+===
+MSG: geometry_msgs/Point
+float64 x
+float64 y
+float64 z
+===
+MSG: geometry_msgs/Vector3
 float64 x
 float64 y
 float64 z
@@ -431,6 +505,8 @@ describe("ROS MCAP decoders", () => {
     const payloads = [
       ...ROS_CAMERA_INFO_PAYLOADS,
       ...ROS_COMPRESSED_IMAGE_PAYLOADS,
+      ...ROS_DETECTION_2D_ARRAY_PAYLOADS,
+      ...ROS_DETECTION_3D_ARRAY_PAYLOADS,
       ...ROS_IMAGE_PAYLOADS,
       ...ROS_LASER_SCAN_PAYLOADS,
       ...ROS_NAV_SAT_FIX_PAYLOADS,
@@ -1106,6 +1182,99 @@ describe("ROS MCAP decoders", () => {
     });
   });
 
+  it("decodes ros2 vision detections into transient viewer overlays", () => {
+    const detections2d = decoderForSchemaEncoding(
+      rosDetection2DArrayDecoders,
+      "ros2msg",
+    ).decode(
+      ros2Message(ROS2_DETECTION_2D_ARRAY_SCHEMA, {
+        detections: [
+          detection2DRecord({
+            classId: "car",
+            id: "track-1",
+            score: 0.93,
+            x: 50,
+            y: 40,
+          }),
+        ],
+        header: ros2Header({ frameId: "camera", nanosec: 18, sec: 17 }),
+      }),
+      { schemaData: schemaData(ROS2_DETECTION_2D_ARRAY_SCHEMA) },
+    );
+    const detections3d = decoderForSchemaEncoding(
+      rosDetection3DArrayDecoders,
+      "ros2msg",
+    ).decode(
+      ros2Message(ROS2_DETECTION_3D_ARRAY_SCHEMA, {
+        detections: [
+          detection3DRecord({
+            classId: "pedestrian",
+            id: "track-9",
+            score: 0.81,
+          }),
+        ],
+        header: ros2Header({ frameId: "map", nanosec: 20, sec: 19 }),
+      }),
+      {
+        schemaData: schemaData(ROS2_DETECTION_3D_ARRAY_SCHEMA),
+        streamId: "/detections3d",
+      },
+    );
+
+    expect(detections2d.visualization?.kind).toBe(
+      VISUALIZATION_KIND.IMAGE_ANNOTATIONS,
+    );
+    expect(detections3d.visualization?.kind).toBe(
+      VISUALIZATION_KIND.SCENE_UPDATE,
+    );
+    if (
+      detections2d.visualization?.kind !==
+        VISUALIZATION_KIND.IMAGE_ANNOTATIONS ||
+      detections3d.visualization?.kind !== VISUALIZATION_KIND.SCENE_UPDATE
+    ) {
+      throw new Error("Expected detection visualizations");
+    }
+    expect(detections2d.visualization.points[0]).toMatchObject({
+      points: [
+        [40, 30],
+        [60, 30],
+        [60, 50],
+        [40, 50],
+      ],
+      type: "line-loop",
+    });
+    expect(detections2d.visualization.texts[0]).toMatchObject({
+      position: [40, 16],
+      text: "car 0.93",
+    });
+    expect(detections2d.attributes).toMatchObject({
+      boxCount: 1,
+      classIds: ["car"],
+      detectionCount: 1,
+      frameId: "camera",
+      textCount: 1,
+    });
+    expect(detections3d.visualization.deletions).toEqual([
+      { id: "", timestampNs: 19_000_000_020n, type: "all" },
+    ]);
+    expect(detections3d.visualization.entities[0]).toMatchObject({
+      cubeCount: 1,
+      frameId: "map",
+      id: "/detections3d:detection3d:track-9",
+      metadata: {
+        classId: "pedestrian",
+        id: "track-9",
+        score: "0.8100",
+        source: "vision_msgs",
+      },
+      textCount: 1,
+      timestampNs: 19_000_000_020n,
+    });
+    expect(detections3d.visualization.entities[0]?.cubes[0]?.size).toEqual([
+      2, 1, 1.5,
+    ]);
+  });
+
   it("decodes ros2 MarkerArray into scene-update entities and deletions", () => {
     const output = decoderForSchemaEncoding(
       rosMarkerArrayDecoders,
@@ -1342,6 +1511,14 @@ describe("ROS MCAP decoders", () => {
       "/pose_hypotheses",
       ROS_POSE_ARRAY_PAYLOADS[1],
     );
+    const detections2d = createTopic(
+      "/detections2d",
+      ROS_DETECTION_2D_ARRAY_PAYLOADS[1],
+    );
+    const detections3d = createTopic(
+      "/detections3d",
+      ROS_DETECTION_3D_ARRAY_PAYLOADS[1],
+    );
 
     expect(isCompressedImageStream(compressed)).toBe(true);
     expect(isCompressedImageStream(rawImage)).toBe(false);
@@ -1369,6 +1546,8 @@ describe("ROS MCAP decoders", () => {
     expect(isSceneUpdateStream(markers)).toBe(true);
     expect(isSceneUpdateStream(path)).toBe(true);
     expect(isSceneUpdateStream(poseArray)).toBe(true);
+    expect(isImageAnnotationsStream(detections2d)).toBe(true);
+    expect(isSceneUpdateStream(detections3d)).toBe(true);
     expect(
       streamTopics([
         compressed,
@@ -1378,12 +1557,20 @@ describe("ROS MCAP decoders", () => {
         markers,
         path,
         poseArray,
+        detections2d,
+        detections3d,
       ]),
     ).toMatchObject({
+      annotations: ["/detections2d"],
       image: ["/camera/compressed", "/camera/image"],
       pointCloud: ["/points", "/scan"],
       previewable: ["/camera/compressed", "/camera/image", "/points", "/scan"],
-      sceneUpdates: ["/markers", "/planned_path", "/pose_hypotheses"],
+      sceneUpdates: [
+        "/markers",
+        "/planned_path",
+        "/pose_hypotheses",
+        "/detections3d",
+      ],
     });
   });
 });
@@ -1640,6 +1827,61 @@ function vectorRecord(vector: readonly [number, number, number]) {
     x: vector[0],
     y: vector[1],
     z: vector[2],
+  };
+}
+
+function detection2DRecord({
+  classId,
+  id,
+  score,
+  x,
+  y,
+}: {
+  readonly classId: string;
+  readonly id: string;
+  readonly score: number;
+  readonly x: number;
+  readonly y: number;
+}) {
+  return {
+    bbox: {
+      center: {
+        position: { x, y },
+        theta: 0,
+      },
+      size_x: 20,
+      size_y: 20,
+    },
+    id,
+    results: [detectionResult(classId, score)],
+  };
+}
+
+function detection3DRecord({
+  classId,
+  id,
+  score,
+}: {
+  readonly classId: string;
+  readonly id: string;
+  readonly score: number;
+}) {
+  return {
+    bbox: {
+      center: poseRecord([1, 2, 3], [0, 0, 0, 1]),
+      size: vectorRecord([2, 1, 1.5]),
+    },
+    id,
+    results: [detectionResult(classId, score)],
+  };
+}
+
+function detectionResult(classId: string, score: number) {
+  return {
+    hypothesis: {
+      class_id: classId,
+      score,
+    },
   };
 }
 

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros.test.ts
@@ -31,7 +31,9 @@ import {
   ROS_NAV_SAT_FIX_PAYLOADS,
   ROS_OCCUPANCY_GRID_PAYLOADS,
   ROS_ODOMETRY_PAYLOADS,
+  ROS_PATH_PAYLOADS,
   ROS_POINT_CLOUD2_PAYLOADS,
+  ROS_POSE_ARRAY_PAYLOADS,
   ROS_POSE_STAMPED_PAYLOADS,
   rosCameraInfoDecoders,
   rosCompressedImageDecoders,
@@ -41,7 +43,9 @@ import {
   rosNavSatFixDecoders,
   rosOccupancyGridDecoders,
   rosOdometryDecoders,
+  rosPathDecoders,
   rosPointCloud2Decoders,
+  rosPoseArrayDecoders,
   rosPoseStampedDecoders,
 } from "./ros";
 
@@ -139,6 +143,48 @@ ${ROS2_HEADER_DEFINITIONS}`;
 
 const ROS2_POSE_STAMPED_SCHEMA = `std_msgs/Header header
 geometry_msgs/Pose pose
+${ROS2_HEADER_DEFINITIONS}
+===
+MSG: geometry_msgs/Pose
+geometry_msgs/Point position
+geometry_msgs/Quaternion orientation
+===
+MSG: geometry_msgs/Point
+float64 x
+float64 y
+float64 z
+===
+MSG: geometry_msgs/Quaternion
+float64 x
+float64 y
+float64 z
+float64 w`;
+
+const ROS2_PATH_SCHEMA = `std_msgs/Header header
+geometry_msgs/PoseStamped[] poses
+${ROS2_HEADER_DEFINITIONS}
+===
+MSG: geometry_msgs/PoseStamped
+std_msgs/Header header
+geometry_msgs/Pose pose
+===
+MSG: geometry_msgs/Pose
+geometry_msgs/Point position
+geometry_msgs/Quaternion orientation
+===
+MSG: geometry_msgs/Point
+float64 x
+float64 y
+float64 z
+===
+MSG: geometry_msgs/Quaternion
+float64 x
+float64 y
+float64 z
+float64 w`;
+
+const ROS2_POSE_ARRAY_SCHEMA = `std_msgs/Header header
+geometry_msgs/Pose[] poses
 ${ROS2_HEADER_DEFINITIONS}
 ===
 MSG: geometry_msgs/Pose
@@ -390,7 +436,9 @@ describe("ROS MCAP decoders", () => {
       ...ROS_NAV_SAT_FIX_PAYLOADS,
       ...ROS_OCCUPANCY_GRID_PAYLOADS,
       ...ROS_ODOMETRY_PAYLOADS,
+      ...ROS_PATH_PAYLOADS,
       ...ROS_POINT_CLOUD2_PAYLOADS,
+      ...ROS_POSE_ARRAY_PAYLOADS,
       ...ROS_POSE_STAMPED_PAYLOADS,
     ];
 
@@ -985,6 +1033,79 @@ describe("ROS MCAP decoders", () => {
     expect(odometry.attributes).toMatchObject({ childFrameId: "base_link" });
   });
 
+  it("decodes ros2 Path and PoseArray into scene-update overlays", () => {
+    const path = decoderForSchemaEncoding(rosPathDecoders, "ros2msg").decode(
+      ros2Message(ROS2_PATH_SCHEMA, {
+        header: ros2Header({ frameId: "map", nanosec: 14, sec: 13 }),
+        poses: [
+          {
+            header: ros2Header({ frameId: "map", nanosec: 1, sec: 1 }),
+            pose: poseRecord([1, 2, 0], [0, 0, 0, 1]),
+          },
+          {
+            header: ros2Header({ frameId: "map", nanosec: 2, sec: 1 }),
+            pose: poseRecord([3, 4, 0], [0, 0, 0, 1]),
+          },
+        ],
+      }),
+      { schemaData: schemaData(ROS2_PATH_SCHEMA), streamId: "/planned_path" },
+    );
+    const poseArray = decoderForSchemaEncoding(
+      rosPoseArrayDecoders,
+      "ros2msg",
+    ).decode(
+      ros2Message(ROS2_POSE_ARRAY_SCHEMA, {
+        header: ros2Header({ frameId: "map", nanosec: 16, sec: 15 }),
+        poses: [
+          poseRecord([5, 6, 0], [0, 0, 0, 1]),
+          poseRecord([7, 8, 0], [0, 0, 1, 0]),
+        ],
+      }),
+      {
+        schemaData: schemaData(ROS2_POSE_ARRAY_SCHEMA),
+        streamId: "/pose_hypotheses",
+      },
+    );
+
+    expect(path.visualization?.kind).toBe(VISUALIZATION_KIND.SCENE_UPDATE);
+    expect(poseArray.visualization?.kind).toBe(VISUALIZATION_KIND.SCENE_UPDATE);
+    if (
+      path.visualization?.kind !== VISUALIZATION_KIND.SCENE_UPDATE ||
+      poseArray.visualization?.kind !== VISUALIZATION_KIND.SCENE_UPDATE
+    ) {
+      throw new Error("Expected scene update visualizations");
+    }
+    expect(path.visualization.entities[0]).toMatchObject({
+      frameId: "map",
+      id: "/planned_path:path",
+      lineCount: 1,
+      timestampNs: 13_000_000_014n,
+    });
+    expect(path.visualization.entities[0]?.lines[0]?.points).toEqual([
+      [1, 2, 0],
+      [3, 4, 0],
+    ]);
+    expect(path.attributes).toMatchObject({
+      frameId: "map",
+      pointCount: 2,
+      poseCount: 2,
+    });
+    expect(poseArray.visualization.entities[0]).toMatchObject({
+      arrowCount: 2,
+      frameId: "map",
+      id: "/pose_hypotheses:pose-array",
+      timestampNs: 15_000_000_016n,
+    });
+    expect(
+      poseArray.visualization.entities[0]?.arrows[0]?.pose.position,
+    ).toEqual([5, 6, 0]);
+    expect(poseArray.attributes).toMatchObject({
+      frameId: "map",
+      poseCount: 2,
+      renderedPoseCount: 2,
+    });
+  });
+
   it("decodes ros2 MarkerArray into scene-update entities and deletions", () => {
     const output = decoderForSchemaEncoding(
       rosMarkerArrayDecoders,
@@ -1216,6 +1337,11 @@ describe("ROS MCAP decoders", () => {
       schemaEncoding: "ros2msg",
     });
     const markers = createTopic("/markers", ROS_MARKER_ARRAY_PAYLOADS[1]);
+    const path = createTopic("/planned_path", ROS_PATH_PAYLOADS[1]);
+    const poseArray = createTopic(
+      "/pose_hypotheses",
+      ROS_POSE_ARRAY_PAYLOADS[1],
+    );
 
     expect(isCompressedImageStream(compressed)).toBe(true);
     expect(isCompressedImageStream(rawImage)).toBe(false);
@@ -1241,13 +1367,23 @@ describe("ROS MCAP decoders", () => {
       isGridStream(createTopic("/map", ROS_OCCUPANCY_GRID_PAYLOADS[0])),
     ).toBe(true);
     expect(isSceneUpdateStream(markers)).toBe(true);
+    expect(isSceneUpdateStream(path)).toBe(true);
+    expect(isSceneUpdateStream(poseArray)).toBe(true);
     expect(
-      streamTopics([compressed, rawImage, cloud, scan, markers]),
+      streamTopics([
+        compressed,
+        rawImage,
+        cloud,
+        scan,
+        markers,
+        path,
+        poseArray,
+      ]),
     ).toMatchObject({
       image: ["/camera/compressed", "/camera/image"],
       pointCloud: ["/points", "/scan"],
       previewable: ["/camera/compressed", "/camera/image", "/points", "/scan"],
-      sceneUpdates: ["/markers"],
+      sceneUpdates: ["/markers", "/planned_path", "/pose_hypotheses"],
     });
   });
 });

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros.test.ts
@@ -18,6 +18,7 @@ import {
   isLocationFixStream,
   isPointCloudStream,
   isPoseStream,
+  isSceneUpdateStream,
   streamTopics,
 } from "../stream-topics";
 import { createMcapDecoderRegistry } from ".";
@@ -26,6 +27,7 @@ import {
   ROS_COMPRESSED_IMAGE_PAYLOADS,
   ROS_IMAGE_PAYLOADS,
   ROS_LASER_SCAN_PAYLOADS,
+  ROS_MARKER_ARRAY_PAYLOADS,
   ROS_NAV_SAT_FIX_PAYLOADS,
   ROS_OCCUPANCY_GRID_PAYLOADS,
   ROS_ODOMETRY_PAYLOADS,
@@ -35,6 +37,7 @@ import {
   rosCompressedImageDecoders,
   rosImageDecoders,
   rosLaserScanDecoders,
+  rosMarkerArrayDecoders,
   rosNavSatFixDecoders,
   rosOccupancyGridDecoders,
   rosOdometryDecoders,
@@ -190,6 +193,52 @@ float64 x
 float64 y
 float64 z
 float64 w`;
+
+const ROS2_MARKER_ARRAY_SCHEMA = `visualization_msgs/Marker[] markers
+===
+MSG: visualization_msgs/Marker
+std_msgs/Header header
+string ns
+int32 id
+int32 type
+int32 action
+geometry_msgs/Pose pose
+geometry_msgs/Vector3 scale
+std_msgs/ColorRGBA color
+builtin_interfaces/Duration lifetime
+bool frame_locked
+geometry_msgs/Point[] points
+std_msgs/ColorRGBA[] colors
+string text
+string mesh_resource
+bool mesh_use_embedded_materials
+${ROS2_HEADER_DEFINITIONS}
+===
+MSG: geometry_msgs/Pose
+geometry_msgs/Point position
+geometry_msgs/Quaternion orientation
+===
+MSG: geometry_msgs/Point
+float64 x
+float64 y
+float64 z
+===
+MSG: geometry_msgs/Vector3
+float64 x
+float64 y
+float64 z
+===
+MSG: geometry_msgs/Quaternion
+float64 x
+float64 y
+float64 z
+float64 w
+===
+MSG: std_msgs/ColorRGBA
+float32 r
+float32 g
+float32 b
+float32 a`;
 
 const ROS1_NAV_SAT_FIX_SCHEMA = `std_msgs/Header header
 sensor_msgs/NavSatStatus status
@@ -936,6 +985,113 @@ describe("ROS MCAP decoders", () => {
     expect(odometry.attributes).toMatchObject({ childFrameId: "base_link" });
   });
 
+  it("decodes ros2 MarkerArray into scene-update entities and deletions", () => {
+    const output = decoderForSchemaEncoding(
+      rosMarkerArrayDecoders,
+      "ros2msg",
+    ).decode(
+      ros2Message(ROS2_MARKER_ARRAY_SCHEMA, {
+        markers: [
+          markerRecord({
+            color: colorRecord([1, 0, 0, 0.5]),
+            frameLocked: true,
+            id: 7,
+            lifetime: { nanosec: 4, sec: 3 },
+            ns: "boxes",
+            pose: poseRecord([1, 2, 3], [0, 0, 0, 1]),
+            scale: vectorRecord([4, 5, 6]),
+            type: 1,
+          }),
+          markerRecord({
+            color: colorRecord([0, 1, 0, 1]),
+            id: 2,
+            ns: "plan",
+            points: [
+              vectorRecord([0, 0, 0]),
+              vectorRecord([1, 0, 0]),
+              vectorRecord([1, 1, 0]),
+            ],
+            scale: vectorRecord([2, 1, 1]),
+            type: 4,
+          }),
+          markerRecord({
+            color: colorRecord([0, 0, 1, 1]),
+            id: 3,
+            ns: "labels",
+            pose: poseRecord([0, 0, 2], [0, 0, 0, 1]),
+            scale: vectorRecord([1, 1, 1.5]),
+            text: "car",
+            type: 9,
+          }),
+          markerRecord({ action: 2, id: 8, ns: "boxes", type: 1 }),
+          markerRecord({ action: 3, id: 0, ns: "ignored", type: 1 }),
+        ],
+      }),
+      {
+        schemaData: schemaData(ROS2_MARKER_ARRAY_SCHEMA),
+        streamId: "/markers",
+      },
+    );
+
+    expect(output.visualization?.kind).toBe(VISUALIZATION_KIND.SCENE_UPDATE);
+    if (output.visualization?.kind !== VISUALIZATION_KIND.SCENE_UPDATE) {
+      throw new Error("Expected scene update visualization");
+    }
+
+    expect(output.attributes).toMatchObject({
+      deletionCount: 2,
+      entityCount: 3,
+      markerCount: 5,
+      transparentMarkerCount: 0,
+      unsupportedMarkerCount: 0,
+    });
+    expect(output.visualization.entities[0]).toMatchObject({
+      cubeCount: 1,
+      frameId: "map",
+      frameLocked: true,
+      id: "/markers:boxes:7",
+      lifetimeNs: 3_000_000_004n,
+      metadata: {
+        id: "7",
+        namespace: "boxes",
+        source: "visualization_msgs/Marker",
+        type: "CUBE",
+      },
+      timestampNs: 21_000_000_022n,
+    });
+    expect(output.visualization.entities[0]?.cubes[0]).toMatchObject({
+      color: [1, 0, 0, 0.5],
+      pose: { position: [1, 2, 3], quaternion: [0, 0, 0, 1] },
+      size: [4, 5, 6],
+    });
+    expect(output.visualization.entities[1]?.lines[0]).toMatchObject({
+      points: [
+        [0, 0, 0],
+        [1, 0, 0],
+        [1, 1, 0],
+      ],
+      thickness: 2,
+      type: "line-strip",
+    });
+    expect(output.visualization.entities[2]?.texts[0]).toMatchObject({
+      billboard: true,
+      fontSize: 1.5,
+      text: "car",
+    });
+    expect(output.visualization.deletions).toEqual([
+      {
+        id: "/markers:boxes:8",
+        timestampNs: 21_000_000_022n,
+        type: "matching-id",
+      },
+      {
+        id: "",
+        timestampNs: 21_000_000_022n,
+        type: "all",
+      },
+    ]);
+  });
+
   it("decodes ros1 NavSatFix into a location visualization", () => {
     const output = decoderForSchemaEncoding(
       rosNavSatFixDecoders,
@@ -1059,6 +1215,7 @@ describe("ROS MCAP decoders", () => {
       schema: "sensor_msgs/msg/LaserScan",
       schemaEncoding: "ros2msg",
     });
+    const markers = createTopic("/markers", ROS_MARKER_ARRAY_PAYLOADS[1]);
 
     expect(isCompressedImageStream(compressed)).toBe(true);
     expect(isCompressedImageStream(rawImage)).toBe(false);
@@ -1083,10 +1240,14 @@ describe("ROS MCAP decoders", () => {
     expect(
       isGridStream(createTopic("/map", ROS_OCCUPANCY_GRID_PAYLOADS[0])),
     ).toBe(true);
-    expect(streamTopics([compressed, rawImage, cloud, scan])).toMatchObject({
+    expect(isSceneUpdateStream(markers)).toBe(true);
+    expect(
+      streamTopics([compressed, rawImage, cloud, scan, markers]),
+    ).toMatchObject({
       image: ["/camera/compressed", "/camera/image"],
       pointCloud: ["/points", "/scan"],
       previewable: ["/camera/compressed", "/camera/image", "/points", "/scan"],
+      sceneUpdates: ["/markers"],
     });
   });
 });
@@ -1343,6 +1504,65 @@ function vectorRecord(vector: readonly [number, number, number]) {
     x: vector[0],
     y: vector[1],
     z: vector[2],
+  };
+}
+
+function markerRecord({
+  action = 0,
+  color = colorRecord([1, 1, 1, 1]),
+  colors = [],
+  frameLocked = false,
+  id,
+  lifetime = { nanosec: 0, sec: 0 },
+  meshResource = "",
+  meshUseEmbeddedMaterials = false,
+  ns,
+  points = [],
+  pose = poseRecord([0, 0, 0], [0, 0, 0, 1]),
+  scale = vectorRecord([1, 1, 1]),
+  text = "",
+  type,
+}: {
+  readonly action?: number;
+  readonly color?: ReturnType<typeof colorRecord>;
+  readonly colors?: readonly ReturnType<typeof colorRecord>[];
+  readonly frameLocked?: boolean;
+  readonly id: number;
+  readonly lifetime?: { readonly nanosec: number; readonly sec: number };
+  readonly meshResource?: string;
+  readonly meshUseEmbeddedMaterials?: boolean;
+  readonly ns: string;
+  readonly points?: readonly ReturnType<typeof vectorRecord>[];
+  readonly pose?: ReturnType<typeof poseRecord>;
+  readonly scale?: ReturnType<typeof vectorRecord>;
+  readonly text?: string;
+  readonly type: number;
+}) {
+  return {
+    action,
+    color,
+    colors,
+    frame_locked: frameLocked,
+    header: ros2Header({ frameId: "map", nanosec: 22, sec: 21 }),
+    id,
+    lifetime,
+    mesh_resource: meshResource,
+    mesh_use_embedded_materials: meshUseEmbeddedMaterials,
+    ns,
+    points,
+    pose,
+    scale,
+    text,
+    type,
+  };
+}
+
+function colorRecord(color: readonly [number, number, number, number]) {
+  return {
+    a: color[3],
+    b: color[2],
+    g: color[1],
+    r: color[0],
   };
 }
 

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/factory.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/factory.ts
@@ -9,6 +9,7 @@ import { decodeRosMessage } from "./common";
 type RosMapper = (
   record: Record<string, unknown>,
   context: DecodeContext,
+  bytes: Uint8Array,
 ) => DecodedOutput;
 
 /**
@@ -28,7 +29,7 @@ export function rosDecodersForPayloads({
     payload,
     version: "1",
     decode(bytes, context) {
-      return map(decodeRosMessage(bytes, payload, context), context);
+      return map(decodeRosMessage(bytes, payload, context), context, bytes);
     },
   }));
 }

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/index.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/index.ts
@@ -7,6 +7,7 @@ import { rosMarkerArrayDecoders, rosMarkerDecoders } from "./marker";
 import { rosNavSatFixDecoders } from "./nav-sat-fix";
 import { rosOccupancyGridDecoders } from "./occupancy-grid";
 import { rosOdometryDecoders, rosPoseStampedDecoders } from "./pose";
+import { rosPathDecoders, rosPoseArrayDecoders } from "./path";
 import { rosPointCloud2Decoders } from "./point-cloud2";
 
 export { rosCameraInfoDecoders } from "./camera-info";
@@ -17,6 +18,7 @@ export { rosMarkerArrayDecoders, rosMarkerDecoders } from "./marker";
 export { rosNavSatFixDecoders } from "./nav-sat-fix";
 export { rosOccupancyGridDecoders } from "./occupancy-grid";
 export { rosOdometryDecoders, rosPoseStampedDecoders } from "./pose";
+export { rosPathDecoders, rosPoseArrayDecoders } from "./path";
 export { rosPointCloud2Decoders } from "./point-cloud2";
 export * from "./payloads";
 
@@ -33,6 +35,8 @@ export const rosDecoders: readonly Decoder[] = [
   ...rosNavSatFixDecoders,
   ...rosOccupancyGridDecoders,
   ...rosOdometryDecoders,
+  ...rosPathDecoders,
+  ...rosPoseArrayDecoders,
   ...rosPoseStampedDecoders,
   ...rosPointCloud2Decoders,
 ];

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/index.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/index.ts
@@ -3,6 +3,7 @@ import { rosCameraInfoDecoders } from "./camera-info";
 import { rosCompressedImageDecoders } from "./compressed-image";
 import { rosImageDecoders } from "./image";
 import { rosLaserScanDecoders } from "./laser-scan";
+import { rosMarkerArrayDecoders, rosMarkerDecoders } from "./marker";
 import { rosNavSatFixDecoders } from "./nav-sat-fix";
 import { rosOccupancyGridDecoders } from "./occupancy-grid";
 import { rosOdometryDecoders, rosPoseStampedDecoders } from "./pose";
@@ -12,6 +13,7 @@ export { rosCameraInfoDecoders } from "./camera-info";
 export { rosCompressedImageDecoders } from "./compressed-image";
 export { rosImageDecoders } from "./image";
 export { rosLaserScanDecoders } from "./laser-scan";
+export { rosMarkerArrayDecoders, rosMarkerDecoders } from "./marker";
 export { rosNavSatFixDecoders } from "./nav-sat-fix";
 export { rosOccupancyGridDecoders } from "./occupancy-grid";
 export { rosOdometryDecoders, rosPoseStampedDecoders } from "./pose";
@@ -26,6 +28,8 @@ export const rosDecoders: readonly Decoder[] = [
   ...rosCompressedImageDecoders,
   ...rosImageDecoders,
   ...rosLaserScanDecoders,
+  ...rosMarkerDecoders,
+  ...rosMarkerArrayDecoders,
   ...rosNavSatFixDecoders,
   ...rosOccupancyGridDecoders,
   ...rosOdometryDecoders,

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/index.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/index.ts
@@ -3,6 +3,11 @@ import { rosCameraInfoDecoders } from "./camera-info";
 import { rosCompressedImageDecoders } from "./compressed-image";
 import { rosImageDecoders } from "./image";
 import { rosLaserScanDecoders } from "./laser-scan";
+import {
+  rosDiagnosticArrayDecoders,
+  rosRclLogDecoders,
+  rosRosgraphLogDecoders,
+} from "./log";
 import { rosMarkerArrayDecoders, rosMarkerDecoders } from "./marker";
 import { rosNavSatFixDecoders } from "./nav-sat-fix";
 import { rosOccupancyGridDecoders } from "./occupancy-grid";
@@ -18,6 +23,11 @@ export { rosCameraInfoDecoders } from "./camera-info";
 export { rosCompressedImageDecoders } from "./compressed-image";
 export { rosImageDecoders } from "./image";
 export { rosLaserScanDecoders } from "./laser-scan";
+export {
+  rosDiagnosticArrayDecoders,
+  rosRclLogDecoders,
+  rosRosgraphLogDecoders,
+} from "./log";
 export { rosMarkerArrayDecoders, rosMarkerDecoders } from "./marker";
 export { rosNavSatFixDecoders } from "./nav-sat-fix";
 export { rosOccupancyGridDecoders } from "./occupancy-grid";
@@ -38,6 +48,9 @@ export const rosDecoders: readonly Decoder[] = [
   ...rosCompressedImageDecoders,
   ...rosImageDecoders,
   ...rosLaserScanDecoders,
+  ...rosRosgraphLogDecoders,
+  ...rosRclLogDecoders,
+  ...rosDiagnosticArrayDecoders,
   ...rosMarkerDecoders,
   ...rosMarkerArrayDecoders,
   ...rosNavSatFixDecoders,

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/index.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/index.ts
@@ -9,6 +9,10 @@ import { rosOccupancyGridDecoders } from "./occupancy-grid";
 import { rosOdometryDecoders, rosPoseStampedDecoders } from "./pose";
 import { rosPathDecoders, rosPoseArrayDecoders } from "./path";
 import { rosPointCloud2Decoders } from "./point-cloud2";
+import {
+  rosDetection2DArrayDecoders,
+  rosDetection3DArrayDecoders,
+} from "./vision";
 
 export { rosCameraInfoDecoders } from "./camera-info";
 export { rosCompressedImageDecoders } from "./compressed-image";
@@ -20,6 +24,10 @@ export { rosOccupancyGridDecoders } from "./occupancy-grid";
 export { rosOdometryDecoders, rosPoseStampedDecoders } from "./pose";
 export { rosPathDecoders, rosPoseArrayDecoders } from "./path";
 export { rosPointCloud2Decoders } from "./point-cloud2";
+export {
+  rosDetection2DArrayDecoders,
+  rosDetection3DArrayDecoders,
+} from "./vision";
 export * from "./payloads";
 
 /**
@@ -39,4 +47,6 @@ export const rosDecoders: readonly Decoder[] = [
   ...rosPoseArrayDecoders,
   ...rosPoseStampedDecoders,
   ...rosPointCloud2Decoders,
+  ...rosDetection2DArrayDecoders,
+  ...rosDetection3DArrayDecoders,
 ];

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/log.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/log.ts
@@ -135,10 +135,11 @@ function logOutputAttributes(
   row: McapDecodedLogRow,
   base: Record<string, DecodedAttributeValue> = {},
 ): Record<string, DecodedAttributeValue> {
+  const rows = logRowsAttribute([row]);
   return {
     ...base,
-    ...logRowsAttribute([row])[0],
-    [MCAP_LOG_ATTRIBUTE_ROWS]: logRowsAttribute([row]),
+    ...rows[0],
+    [MCAP_LOG_ATTRIBUTE_ROWS]: rows,
   };
 }
 
@@ -146,7 +147,7 @@ function diagnosticStatusRow(
   status: Record<string, unknown>,
   timestampNs: bigint | undefined,
 ): McapDecodedLogRow {
-  const levelNumber = numberField(status, "level", undefined, 0);
+  const levelNumber = numberValue(status.level);
   const statusName = diagnosticStatusName(levelNumber);
   const name = optionalString(status, "name");
   const message = optionalString(status, "message") ?? statusName;
@@ -157,11 +158,11 @@ function diagnosticStatusRow(
     hardwareId,
     kind: "diagnostic",
     level: diagnosticLogLevel(levelNumber),
-    levelNumber,
     message,
     name,
     status: statusName,
     timestampNs,
+    ...(levelNumber !== undefined ? { levelNumber } : {}),
   };
 }
 
@@ -223,14 +224,14 @@ function rclLogLevel(level: number) {
   return MCAP_LOG_LEVEL.UNKNOWN;
 }
 
-function diagnosticLogLevel(level: number) {
+function diagnosticLogLevel(level: number | undefined) {
   if (level === 2) return MCAP_LOG_LEVEL.ERROR;
   if (level === 1 || level === 3) return MCAP_LOG_LEVEL.WARN;
   if (level === 0) return MCAP_LOG_LEVEL.INFO;
   return MCAP_LOG_LEVEL.UNKNOWN;
 }
 
-function diagnosticStatusName(level: number): string {
+function diagnosticStatusName(level: number | undefined): string {
   switch (level) {
     case 0:
       return "OK";

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/log.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/log.ts
@@ -1,0 +1,293 @@
+import type {
+  DecodeContext,
+  DecodedAttributeValue,
+  DecodedOutput,
+} from "../../../../decoders";
+import {
+  MCAP_LOG_ATTRIBUTE_ROWS,
+  MCAP_LOG_LEVEL,
+  type McapDecodedLogRow,
+  logRowsAttribute,
+} from "../../log-records";
+import { optionalString } from "../foxglove/protobuf/records";
+import { timingFromContext } from "../foxglove/protobuf/timing";
+import {
+  arrayField,
+  numberField,
+  recordField,
+  rosHeader,
+  rosHeaderAttributes,
+  rosHeaderTimestampNs,
+  rosTimestampNs,
+  timingFromRosHeader,
+} from "./common";
+import { rosDecodersForPayloads } from "./factory";
+import {
+  ROS_DIAGNOSTIC_ARRAY_PAYLOADS,
+  ROS_RCL_LOG_PAYLOADS,
+  ROS_ROSGRAPH_LOG_PAYLOADS,
+} from "./payloads";
+
+/**
+ * Decoders for ROS1 rosgraph_msgs/Log messages.
+ */
+export const rosRosgraphLogDecoders = rosDecodersForPayloads({
+  id: "ros.rosgraph-log",
+  map: decodeRosgraphLogRecord,
+  payloads: ROS_ROSGRAPH_LOG_PAYLOADS,
+});
+
+/**
+ * Decoders for ROS2 rcl_interfaces/msg/Log messages.
+ */
+export const rosRclLogDecoders = rosDecodersForPayloads({
+  id: "ros.rcl-log",
+  map: decodeRclLogRecord,
+  payloads: ROS_RCL_LOG_PAYLOADS,
+});
+
+/**
+ * Decoders for ROS diagnostic_msgs/(msg/)DiagnosticArray messages.
+ */
+export const rosDiagnosticArrayDecoders = rosDecodersForPayloads({
+  id: "ros.diagnostic-array",
+  map: decodeDiagnosticArrayRecord,
+  payloads: ROS_DIAGNOSTIC_ARRAY_PAYLOADS,
+});
+
+export function decodeRosgraphLogRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+): DecodedOutput {
+  const header = rosHeader(message);
+  const timestampNs = rosHeaderTimestampNs(header);
+  const levelNumber = numberField(message, "level", undefined, 0);
+  const row: McapDecodedLogRow = {
+    file: optionalString(message, "file"),
+    functionName: optionalString(message, "function"),
+    kind: "log",
+    level: rosgraphLogLevel(levelNumber),
+    levelNumber,
+    line: positiveNumberField(message, "line"),
+    message: optionalString(message, "msg") ?? "",
+    name: optionalString(message, "name"),
+    timestampNs,
+    topics: stringArrayField(message, "topics"),
+  };
+
+  return {
+    attributes: logOutputAttributes(row, rosHeaderAttributes(header)),
+    timing: timingFromRosHeader(context, header),
+  };
+}
+
+export function decodeRclLogRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+): DecodedOutput {
+  const timestampNs = rosTimestampNs(recordField(message, "stamp"));
+  const levelNumber = numberField(message, "level", undefined, 0);
+  const row: McapDecodedLogRow = {
+    file: optionalString(message, "file"),
+    functionName: optionalString(message, "function"),
+    kind: "log",
+    level: rclLogLevel(levelNumber),
+    levelNumber,
+    line: positiveNumberField(message, "line"),
+    message: optionalString(message, "msg") ?? "",
+    name: optionalString(message, "name"),
+    timestampNs,
+  };
+
+  return {
+    attributes: logOutputAttributes(row),
+    timing: timingFromContext(context, timestampNs),
+  };
+}
+
+export function decodeDiagnosticArrayRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+): DecodedOutput {
+  const header = rosHeader(message);
+  const timestampNs = rosHeaderTimestampNs(header);
+  const rows = arrayField(message, "status")
+    .map(asRecord)
+    .filter(isRecord)
+    .map((status) => diagnosticStatusRow(status, timestampNs));
+  const counts = diagnosticCounts(rows);
+
+  return {
+    attributes: {
+      ...rosHeaderAttributes(header),
+      [MCAP_LOG_ATTRIBUTE_ROWS]: logRowsAttribute(rows),
+      diagnosticCount: rows.length,
+      errorCount: counts.error,
+      okCount: counts.ok,
+      staleCount: counts.stale,
+      warnCount: counts.warn,
+    },
+    timing: timingFromRosHeader(context, header),
+  };
+}
+
+function logOutputAttributes(
+  row: McapDecodedLogRow,
+  base: Record<string, DecodedAttributeValue> = {},
+): Record<string, DecodedAttributeValue> {
+  return {
+    ...base,
+    ...logRowsAttribute([row])[0],
+    [MCAP_LOG_ATTRIBUTE_ROWS]: logRowsAttribute([row]),
+  };
+}
+
+function diagnosticStatusRow(
+  status: Record<string, unknown>,
+  timestampNs: bigint | undefined,
+): McapDecodedLogRow {
+  const levelNumber = numberField(status, "level", undefined, 0);
+  const statusName = diagnosticStatusName(levelNumber);
+  const name = optionalString(status, "name");
+  const message = optionalString(status, "message") ?? statusName;
+  const hardwareId = optionalString(status, "hardware_id", "hardwareId");
+
+  return {
+    details: diagnosticDetails(status),
+    hardwareId,
+    kind: "diagnostic",
+    level: diagnosticLogLevel(levelNumber),
+    levelNumber,
+    message,
+    name,
+    status: statusName,
+    timestampNs,
+  };
+}
+
+function diagnosticDetails(
+  status: Record<string, unknown>,
+): readonly { readonly key: string; readonly value: string }[] {
+  return arrayField(status, "values")
+    .map(asRecord)
+    .filter(isRecord)
+    .map((value) => ({
+      key: optionalString(value, "key") ?? "",
+      value: stringValue(value["value"]) ?? "",
+    }))
+    .filter((value) => value.key || value.value);
+}
+
+function diagnosticCounts(rows: readonly McapDecodedLogRow[]) {
+  const counts = {
+    error: 0,
+    ok: 0,
+    stale: 0,
+    warn: 0,
+  };
+  for (const row of rows) {
+    switch (row.status) {
+      case "ERROR":
+        counts.error += 1;
+        break;
+      case "STALE":
+        counts.stale += 1;
+        break;
+      case "WARN":
+        counts.warn += 1;
+        break;
+      case "OK":
+        counts.ok += 1;
+        break;
+    }
+  }
+
+  return counts;
+}
+
+function rosgraphLogLevel(level: number) {
+  if ((level & 16) !== 0) return MCAP_LOG_LEVEL.FATAL;
+  if ((level & 8) !== 0) return MCAP_LOG_LEVEL.ERROR;
+  if ((level & 4) !== 0) return MCAP_LOG_LEVEL.WARN;
+  if ((level & 2) !== 0) return MCAP_LOG_LEVEL.INFO;
+  if ((level & 1) !== 0) return MCAP_LOG_LEVEL.DEBUG;
+  return MCAP_LOG_LEVEL.UNKNOWN;
+}
+
+function rclLogLevel(level: number) {
+  if (level >= 50) return MCAP_LOG_LEVEL.FATAL;
+  if (level >= 40) return MCAP_LOG_LEVEL.ERROR;
+  if (level >= 30) return MCAP_LOG_LEVEL.WARN;
+  if (level >= 20) return MCAP_LOG_LEVEL.INFO;
+  if (level >= 10) return MCAP_LOG_LEVEL.DEBUG;
+  return MCAP_LOG_LEVEL.UNKNOWN;
+}
+
+function diagnosticLogLevel(level: number) {
+  if (level === 2) return MCAP_LOG_LEVEL.ERROR;
+  if (level === 1 || level === 3) return MCAP_LOG_LEVEL.WARN;
+  if (level === 0) return MCAP_LOG_LEVEL.INFO;
+  return MCAP_LOG_LEVEL.UNKNOWN;
+}
+
+function diagnosticStatusName(level: number): string {
+  switch (level) {
+    case 0:
+      return "OK";
+    case 1:
+      return "WARN";
+    case 2:
+      return "ERROR";
+    case 3:
+      return "STALE";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+function positiveNumberField(
+  record: Record<string, unknown>,
+  field: string,
+): number | undefined {
+  const value = numberValue(record[field]);
+  return value !== undefined && value > 0 ? value : undefined;
+}
+
+function stringArrayField(
+  record: Record<string, unknown>,
+  field: string,
+): readonly string[] | undefined {
+  const values = arrayField(record, field).filter(
+    (value): value is string => typeof value === "string" && value.length > 0,
+  );
+  return values.length > 0 ? values : undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function isRecord(
+  value: Record<string, unknown> | null,
+): value is Record<string, unknown> {
+  return value !== null;
+}
+
+function stringValue(value: unknown): string | undefined {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+  return undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "bigint") return Number(value);
+  return undefined;
+}

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/marker.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/marker.ts
@@ -441,14 +441,15 @@ function markerArrows({
     totalLength,
     positiveOr(scale[2], totalLength * DEFAULT_ARROW_HEAD_FRACTION),
   );
+  const headDiameter = positiveOr(scale[1], 0.2);
 
   return [
     {
       color,
-      headDiameter: positiveOr(scale[1], 0.2),
+      headDiameter,
       headLength,
       pose,
-      shaftDiameter: positiveOr(scale[1], 0.1),
+      shaftDiameter: headDiameter * 0.5,
       shaftLength: Math.max(0, totalLength - headLength),
     },
   ];

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/marker.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/marker.ts
@@ -1,0 +1,722 @@
+import { Quaternion, Vector3 } from "three";
+
+import type {
+  DecodeContext,
+  DecodedAttributeValue,
+  DecodedOutput,
+  RgbaColor,
+  SceneArrowPrimitive,
+  SceneCubePrimitive,
+  SceneCylinderPrimitive,
+  SceneEntityDeletionKind,
+  SceneEntityDeletionVisualization,
+  SceneEntityVisualization,
+  SceneLinePrimitive,
+  SceneLinePrimitiveKind,
+  SceneModelPrimitive,
+  ScenePoint3D,
+  ScenePose3D,
+  SceneSpherePrimitive,
+  SceneTextPrimitive,
+  SceneTrianglePrimitive,
+} from "../../../../decoders";
+import { VISUALIZATION_KIND } from "../../../../visualization";
+import {
+  decodePose,
+  decodeQuaternion,
+  decodeVector3,
+  IDENTITY_QUATERNION,
+  ZERO_VECTOR3,
+} from "../foxglove/protobuf/geometry";
+import {
+  arrayField,
+  numberField,
+  recordField,
+  rosHeader,
+  rosHeaderFrameId,
+  rosHeaderTimestampNs,
+  rosTimestampNs,
+  stringField,
+  timingFromRosHeader,
+} from "./common";
+import { rosDecodersForPayloads } from "./factory";
+import { ROS_MARKER_ARRAY_PAYLOADS, ROS_MARKER_PAYLOADS } from "./payloads";
+
+const MARKER_TYPE = {
+  ARROW: 0,
+  CUBE: 1,
+  SPHERE: 2,
+  CYLINDER: 3,
+  LINE_STRIP: 4,
+  LINE_LIST: 5,
+  CUBE_LIST: 6,
+  SPHERE_LIST: 7,
+  POINTS: 8,
+  TEXT_VIEW_FACING: 9,
+  MESH_RESOURCE: 10,
+  TRIANGLE_LIST: 11,
+} as const;
+
+const MARKER_ACTION = {
+  ADD: 0,
+  DELETE: 2,
+  DELETEALL: 3,
+} as const;
+
+const MARKER_TYPE_BY_NAME: Readonly<Record<string, number>> = {
+  ARROW: MARKER_TYPE.ARROW,
+  CUBE: MARKER_TYPE.CUBE,
+  CUBE_LIST: MARKER_TYPE.CUBE_LIST,
+  CYLINDER: MARKER_TYPE.CYLINDER,
+  LINE_LIST: MARKER_TYPE.LINE_LIST,
+  LINE_STRIP: MARKER_TYPE.LINE_STRIP,
+  MESH_RESOURCE: MARKER_TYPE.MESH_RESOURCE,
+  POINTS: MARKER_TYPE.POINTS,
+  SPHERE: MARKER_TYPE.SPHERE,
+  SPHERE_LIST: MARKER_TYPE.SPHERE_LIST,
+  TEXT_VIEW_FACING: MARKER_TYPE.TEXT_VIEW_FACING,
+  TRIANGLE_LIST: MARKER_TYPE.TRIANGLE_LIST,
+};
+
+const MARKER_ACTION_BY_NAME: Readonly<Record<string, number>> = {
+  ADD: MARKER_ACTION.ADD,
+  DELETE: MARKER_ACTION.DELETE,
+  DELETEALL: MARKER_ACTION.DELETEALL,
+  MODIFY: MARKER_ACTION.ADD,
+};
+
+const DEFAULT_LINE_THICKNESS = 1;
+const DEFAULT_POINT_SIZE = 0.1;
+const DEFAULT_ARROW_HEAD_FRACTION = 0.2;
+const MAX_POINT_MARKER_SPHERES = 512;
+
+interface MarkerDecodeStats {
+  readonly transparentMarkers: number;
+  readonly unsupportedTypes: readonly string[];
+}
+
+interface MarkerEntityResult {
+  readonly entity?: SceneEntityVisualization;
+  readonly unsupportedType?: string;
+}
+
+/**
+ * Decoders for ROS visualization Marker messages.
+ */
+export const rosMarkerDecoders = rosDecodersForPayloads({
+  id: "ros.marker",
+  map: decodeRosMarkerRecord,
+  payloads: ROS_MARKER_PAYLOADS,
+});
+
+/**
+ * Decoders for ROS visualization MarkerArray messages.
+ */
+export const rosMarkerArrayDecoders = rosDecodersForPayloads({
+  id: "ros.marker-array",
+  map: decodeRosMarkerArrayRecord,
+  payloads: ROS_MARKER_ARRAY_PAYLOADS,
+});
+
+/**
+ * Normalizes one ROS Marker into a SceneUpdate delta.
+ */
+export function decodeRosMarkerRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+): DecodedOutput {
+  return markerOutput([message], context);
+}
+
+/**
+ * Normalizes one ROS MarkerArray into a SceneUpdate delta.
+ */
+export function decodeRosMarkerArrayRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+): DecodedOutput {
+  return markerOutput(
+    arrayField(message, "markers").map((marker) =>
+      recordField({ marker }, "marker"),
+    ),
+    context,
+  );
+}
+
+function markerOutput(
+  markers: readonly (Record<string, unknown> | undefined)[],
+  context: DecodeContext,
+): DecodedOutput {
+  const entities: SceneEntityVisualization[] = [];
+  const deletions: SceneEntityDeletionVisualization[] = [];
+  const unsupportedTypes: string[] = [];
+  let transparentMarkers = 0;
+
+  for (const marker of markers) {
+    if (!marker) {
+      continue;
+    }
+
+    const action = markerAction(marker["action"]);
+    if (action === MARKER_ACTION.DELETE || action === MARKER_ACTION.DELETEALL) {
+      deletions.push(deletionForMarker(marker, context, action));
+      continue;
+    }
+
+    if (markerAlpha(marker) <= 0) {
+      transparentMarkers += 1;
+    }
+
+    const result = entityForMarker(marker, context);
+    if (result.entity) {
+      entities.push(result.entity);
+    }
+    if (result.unsupportedType) {
+      unsupportedTypes.push(result.unsupportedType);
+    }
+  }
+
+  const stats: MarkerDecodeStats = {
+    transparentMarkers,
+    unsupportedTypes,
+  };
+
+  return {
+    attributes: markerAttributes(markers.length, entities, deletions, stats),
+    timing: markerTiming(context, markers),
+    visualization: {
+      deletions,
+      entities,
+      kind: VISUALIZATION_KIND.SCENE_UPDATE,
+    },
+  };
+}
+
+function deletionForMarker(
+  marker: Record<string, unknown>,
+  context: DecodeContext,
+  action: number,
+): SceneEntityDeletionVisualization {
+  const timestampNs = markerTimestampNs(marker);
+  const type: SceneEntityDeletionKind =
+    action === MARKER_ACTION.DELETEALL ? "all" : "matching-id";
+
+  return {
+    id: type === "all" ? "" : markerEntityId(marker, context),
+    ...(timestampNs !== undefined ? { timestampNs } : {}),
+    type,
+  };
+}
+
+function entityForMarker(
+  marker: Record<string, unknown>,
+  context: DecodeContext,
+): MarkerEntityResult {
+  const markerType = markerTypeValue(marker["type"]);
+  const color = markerColor(marker);
+  const colors = markerColors(marker);
+  const pose = markerPose(marker);
+  const points = markerPoints(marker);
+  const scale = markerScale(marker);
+  const metadata = markerMetadata(marker, markerType);
+
+  const base = {
+    arrows: [] as SceneArrowPrimitive[],
+    cubes: [] as SceneCubePrimitive[],
+    cylinders: [] as SceneCylinderPrimitive[],
+    lines: [] as SceneLinePrimitive[],
+    models: [] as SceneModelPrimitive[],
+    spheres: [] as SceneSpherePrimitive[],
+    texts: [] as SceneTextPrimitive[],
+    triangles: [] as SceneTrianglePrimitive[],
+  };
+  let unsupportedType: string | undefined;
+
+  switch (markerType) {
+    case MARKER_TYPE.ARROW:
+      base.arrows.push(...markerArrows({ color, points, pose, scale }));
+      break;
+    case MARKER_TYPE.CUBE:
+      base.cubes.push({ color, pose, size: scale });
+      break;
+    case MARKER_TYPE.SPHERE:
+      base.spheres.push({ color, pose, size: scale });
+      break;
+    case MARKER_TYPE.CYLINDER:
+      base.cylinders.push({
+        bottomScale: 1,
+        color,
+        pose,
+        size: scale,
+        topScale: 1,
+      });
+      break;
+    case MARKER_TYPE.LINE_STRIP:
+      base.lines.push(
+        markerLine({
+          color,
+          colors,
+          points,
+          pose,
+          scale,
+          type: "line-strip",
+        }),
+      );
+      break;
+    case MARKER_TYPE.LINE_LIST:
+      base.lines.push(
+        markerLine({
+          color,
+          colors,
+          points,
+          pose,
+          scale,
+          type: "line-list",
+        }),
+      );
+      break;
+    case MARKER_TYPE.CUBE_LIST:
+      base.cubes.push(
+        ...points.map((point, index) => ({
+          color: colors[index] ?? color,
+          pose: composeMarkerPointPose(pose, point),
+          size: scale,
+        })),
+      );
+      break;
+    case MARKER_TYPE.SPHERE_LIST:
+      base.spheres.push(
+        ...points.map((point, index) => ({
+          color: colors[index] ?? color,
+          pose: composeMarkerPointPose(pose, point),
+          size: scale,
+        })),
+      );
+      break;
+    case MARKER_TYPE.POINTS:
+      if (points.length <= MAX_POINT_MARKER_SPHERES) {
+        base.spheres.push(
+          ...points.map((point, index) => ({
+            color: colors[index] ?? color,
+            pose: composeMarkerPointPose(pose, point),
+            size: markerPointSize(scale),
+          })),
+        );
+      } else {
+        unsupportedType = `POINTS(${points.length})`;
+      }
+      break;
+    case MARKER_TYPE.TEXT_VIEW_FACING:
+      base.texts.push({
+        billboard: true,
+        color,
+        fontSize: positiveOr(scale[2], 1),
+        pose,
+        scaleInvariant: false,
+        text: stringField(marker, "text"),
+      });
+      break;
+    case MARKER_TYPE.MESH_RESOURCE: {
+      const model = markerModel(marker, color, pose, scale);
+      if (model) {
+        base.models.push(model);
+      } else {
+        unsupportedType = "MESH_RESOURCE";
+      }
+      break;
+    }
+    case MARKER_TYPE.TRIANGLE_LIST:
+      base.triangles.push({
+        color,
+        colors,
+        indices: [],
+        points,
+        pose,
+      });
+      break;
+    default:
+      unsupportedType = `type:${String(marker["type"])}`;
+      break;
+  }
+
+  const primitiveCount =
+    base.arrows.length +
+    base.cubes.length +
+    base.cylinders.length +
+    base.lines.length +
+    base.models.length +
+    base.spheres.length +
+    base.texts.length +
+    base.triangles.length;
+  if (primitiveCount === 0) {
+    return { ...(unsupportedType ? { unsupportedType } : {}) };
+  }
+
+  const header = rosHeader(marker);
+  const frameId = rosHeaderFrameId(header);
+  const lifetimeNs = rosTimestampNs(recordField(marker, "lifetime"));
+  const timestampNs = markerTimestampNs(marker);
+
+  const entity: SceneEntityVisualization = {
+    arrowCount: base.arrows.length,
+    arrows: base.arrows,
+    cubeCount: base.cubes.length,
+    cubes: base.cubes,
+    cylinderCount: base.cylinders.length,
+    cylinders: base.cylinders,
+    ...(frameId ? { frameId } : {}),
+    frameLocked: booleanField(marker, "frame_locked", "frameLocked"),
+    id: markerEntityId(marker, context),
+    lineCount: base.lines.length,
+    lines: base.lines,
+    ...(lifetimeNs !== undefined ? { lifetimeNs } : {}),
+    metadata,
+    modelCount: base.models.length,
+    models: base.models,
+    sphereCount: base.spheres.length,
+    spheres: base.spheres,
+    textCount: base.texts.length,
+    texts: base.texts,
+    ...(timestampNs !== undefined ? { timestampNs } : {}),
+    triangleCount: base.triangles.length,
+    triangles: base.triangles,
+  };
+
+  return {
+    entity,
+    ...(unsupportedType ? { unsupportedType } : {}),
+  };
+}
+
+function markerArrows({
+  color,
+  points,
+  pose,
+  scale,
+}: {
+  readonly color: RgbaColor | null;
+  readonly points: readonly ScenePoint3D[];
+  readonly pose: ScenePose3D;
+  readonly scale: ScenePoint3D;
+}): readonly SceneArrowPrimitive[] {
+  if (points.length >= 2) {
+    const start = transformPointByPose(pose, points[0]);
+    const end = transformPointByPose(pose, points[1]);
+    const delta = new Vector3(
+      end[0] - start[0],
+      end[1] - start[1],
+      end[2] - start[2],
+    );
+    const length = delta.length();
+    if (!Number.isFinite(length) || length <= 0) {
+      return [];
+    }
+    const headLength = positiveOr(
+      scale[2],
+      length * DEFAULT_ARROW_HEAD_FRACTION,
+    );
+    const shaftLength = Math.max(0, length - headLength);
+    const quaternion = new Quaternion().setFromUnitVectors(
+      new Vector3(1, 0, 0),
+      delta.normalize(),
+    );
+
+    return [
+      {
+        color,
+        headDiameter: positiveOr(scale[1], positiveOr(scale[0], 0.1) * 2),
+        headLength,
+        pose: {
+          position: start,
+          quaternion: [quaternion.x, quaternion.y, quaternion.z, quaternion.w],
+        },
+        shaftDiameter: positiveOr(scale[0], 0.05),
+        shaftLength,
+      },
+    ];
+  }
+
+  const totalLength = positiveOr(scale[0], 1);
+  const headLength = Math.min(
+    totalLength,
+    positiveOr(scale[2], totalLength * DEFAULT_ARROW_HEAD_FRACTION),
+  );
+
+  return [
+    {
+      color,
+      headDiameter: positiveOr(scale[1], 0.2),
+      headLength,
+      pose,
+      shaftDiameter: positiveOr(scale[1], 0.1),
+      shaftLength: Math.max(0, totalLength - headLength),
+    },
+  ];
+}
+
+function markerLine({
+  color,
+  colors,
+  points,
+  pose,
+  scale,
+  type,
+}: {
+  readonly color: RgbaColor | null;
+  readonly colors: readonly RgbaColor[];
+  readonly points: readonly ScenePoint3D[];
+  readonly pose: ScenePose3D;
+  readonly scale: ScenePoint3D;
+  readonly type: SceneLinePrimitiveKind;
+}): SceneLinePrimitive {
+  return {
+    color,
+    colors,
+    indices: [],
+    points,
+    pose,
+    scaleInvariant: false,
+    thickness: positiveOr(scale[0], DEFAULT_LINE_THICKNESS),
+    type,
+  };
+}
+
+function markerModel(
+  marker: Record<string, unknown>,
+  color: RgbaColor | null,
+  pose: ScenePose3D,
+  scale: ScenePoint3D,
+): SceneModelPrimitive | null {
+  const url = stringField(marker, "mesh_resource", "");
+  if (!url.startsWith("data:")) {
+    return null;
+  }
+
+  return {
+    color,
+    mediaType: mediaTypeFromDataUri(url),
+    overrideColor: !booleanField(marker, "mesh_use_embedded_materials"),
+    pose,
+    scale,
+    url,
+  };
+}
+
+function markerAttributes(
+  markerCount: number,
+  entities: readonly SceneEntityVisualization[],
+  deletions: readonly SceneEntityDeletionVisualization[],
+  { transparentMarkers, unsupportedTypes }: MarkerDecodeStats,
+): Record<string, DecodedAttributeValue> {
+  const attributes: Record<string, DecodedAttributeValue> = {
+    deletionCount: deletions.length,
+    entityCount: entities.length,
+    markerCount,
+    transparentMarkerCount: transparentMarkers,
+    unsupportedMarkerCount: unsupportedTypes.length,
+  };
+  if (unsupportedTypes.length > 0) {
+    attributes.unsupportedMarkerTypes = [...new Set(unsupportedTypes)].sort();
+  }
+
+  return attributes;
+}
+
+function markerMetadata(
+  marker: Record<string, unknown>,
+  markerType: number,
+): Readonly<Record<string, string>> {
+  const metadata: Record<string, string> = {
+    id: String(integerField(marker, "id", 0)),
+    namespace: stringField(marker, "ns"),
+    source: "visualization_msgs/Marker",
+    type: markerTypeName(markerType),
+  };
+  const meshResource = stringField(marker, "mesh_resource");
+  if (meshResource) {
+    metadata.meshResource = meshResource;
+    if (!meshResource.startsWith("data:")) {
+      metadata.unsupportedReason =
+        "Only inline data: mesh resources are supported";
+    }
+  }
+
+  return metadata;
+}
+
+function markerTiming(
+  context: DecodeContext,
+  markers: readonly (Record<string, unknown> | undefined)[],
+) {
+  const firstHeader = markers.find((marker) => marker && rosHeader(marker));
+  return timingFromRosHeader(
+    context,
+    firstHeader ? rosHeader(firstHeader) : undefined,
+  );
+}
+
+function markerTimestampNs(
+  marker: Record<string, unknown>,
+): bigint | undefined {
+  return rosHeaderTimestampNs(rosHeader(marker));
+}
+
+function markerEntityId(
+  marker: Record<string, unknown>,
+  context: DecodeContext,
+): string {
+  const topic = context.streamId ?? "marker";
+  return `${topic}:${stringField(marker, "ns")}:${integerField(marker, "id", 0)}`;
+}
+
+function markerPose(marker: Record<string, unknown>): ScenePose3D {
+  const pose = decodePose(recordField(marker, "pose"));
+  return {
+    position: pose.position,
+    quaternion: pose.quaternion,
+  };
+}
+
+function markerScale(marker: Record<string, unknown>): ScenePoint3D {
+  const scale = decodeVector3(recordField(marker, "scale"), [1, 1, 1]);
+  return [
+    positiveOr(scale[0], 1),
+    positiveOr(scale[1], 1),
+    positiveOr(scale[2], 1),
+  ];
+}
+
+function markerPointSize(scale: ScenePoint3D): ScenePoint3D {
+  return [
+    positiveOr(scale[0], DEFAULT_POINT_SIZE),
+    positiveOr(scale[1], DEFAULT_POINT_SIZE),
+    positiveOr(scale[1], DEFAULT_POINT_SIZE),
+  ];
+}
+
+function markerPoints(
+  marker: Record<string, unknown>,
+): readonly ScenePoint3D[] {
+  return arrayField(marker, "points").map((point) =>
+    decodeVector3(recordField({ point }, "point"), ZERO_VECTOR3),
+  );
+}
+
+function markerColor(marker: Record<string, unknown>): RgbaColor | null {
+  return colorFromRecord(recordField(marker, "color"));
+}
+
+function markerColors(marker: Record<string, unknown>): readonly RgbaColor[] {
+  return arrayField(marker, "colors").map((color) =>
+    colorFromRecord(recordField({ color }, "color")),
+  );
+}
+
+function markerAlpha(marker: Record<string, unknown>): number {
+  return markerColor(marker)?.[3] ?? 0;
+}
+
+function colorFromRecord(
+  record: Record<string, unknown> | undefined,
+): RgbaColor {
+  return [
+    numberField(record, "r", undefined, 0),
+    numberField(record, "g", undefined, 0),
+    numberField(record, "b", undefined, 0),
+    numberField(record, "a", undefined, 0),
+  ];
+}
+
+function composeMarkerPointPose(
+  markerPoseValue: ScenePose3D,
+  point: ScenePoint3D,
+): ScenePose3D {
+  return {
+    position: transformPointByPose(markerPoseValue, point),
+    quaternion: markerPoseValue.quaternion,
+  };
+}
+
+function transformPointByPose(
+  pose: ScenePose3D,
+  point: ScenePoint3D,
+): ScenePoint3D {
+  const q = decodeQuaternion(
+    {
+      w: pose.quaternion[3],
+      x: pose.quaternion[0],
+      y: pose.quaternion[1],
+      z: pose.quaternion[2],
+    },
+    IDENTITY_QUATERNION,
+  );
+  const quaternion = new Quaternion(q[0], q[1], q[2], q[3]);
+  if (quaternion.lengthSq() === 0) {
+    quaternion.identity();
+  } else {
+    quaternion.normalize();
+  }
+  const transformed = new Vector3(...point)
+    .applyQuaternion(quaternion)
+    .add(new Vector3(...pose.position));
+
+  return [transformed.x, transformed.y, transformed.z];
+}
+
+function mediaTypeFromDataUri(uri: string): string {
+  const match = /^data:([^;,]+)/.exec(uri);
+  return match?.[1] || "model/gltf-binary";
+}
+
+function markerTypeValue(value: unknown): number {
+  if (typeof value === "number") return value;
+  if (typeof value === "bigint") return Number(value);
+  if (typeof value === "string") {
+    const numeric = Number(value);
+    if (Number.isFinite(numeric)) return numeric;
+    return MARKER_TYPE_BY_NAME[value] ?? -1;
+  }
+  return -1;
+}
+
+function markerAction(value: unknown): number {
+  if (typeof value === "number") return value;
+  if (typeof value === "bigint") return Number(value);
+  if (typeof value === "string") {
+    const numeric = Number(value);
+    if (Number.isFinite(numeric)) return numeric;
+    return MARKER_ACTION_BY_NAME[value] ?? MARKER_ACTION.ADD;
+  }
+  return MARKER_ACTION.ADD;
+}
+
+function markerTypeName(type: number): string {
+  return (
+    Object.entries(MARKER_TYPE_BY_NAME).find(
+      ([, value]) => value === type,
+    )?.[0] ?? String(type)
+  );
+}
+
+function booleanField(
+  record: Record<string, unknown>,
+  field: string,
+  fallbackField?: string,
+): boolean {
+  const value =
+    record[field] ?? (fallbackField ? record[fallbackField] : undefined);
+  return typeof value === "boolean" ? value : Boolean(value);
+}
+
+function integerField(
+  record: Record<string, unknown>,
+  field: string,
+  defaultValue: number,
+): number {
+  const value = numberField(record, field, undefined, defaultValue);
+  return Number.isFinite(value) ? Math.trunc(value) : defaultValue;
+}
+
+function positiveOr(value: number, fallback: number): number {
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/path.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/path.ts
@@ -110,15 +110,16 @@ export function decodeRosPoseArrayRecord(
   const header = rosHeader(message);
   const frameId = rosHeaderFrameId(header);
   const timestampNs = rosHeaderTimestampNs(header);
-  const poses = poseArrayPoses(message);
-  const renderedPoses = poses.slice(0, MAX_POSE_ARRAY_ARROWS);
+  const poseRecords = arrayRecords(message, "poses");
+  const renderedPoseRecords = poseRecords.slice(0, MAX_POSE_ARRAY_ARROWS);
+  const renderedPoses = poseArrayPoses(renderedPoseRecords);
   const attributes: Record<string, DecodedAttributeValue> = {
     ...rosHeaderAttributes(header),
-    poseCount: poses.length,
+    poseCount: poseRecords.length,
     renderedPoseCount: renderedPoses.length,
   };
-  if (poses.length > renderedPoses.length) {
-    attributes.truncatedPoseCount = poses.length - renderedPoses.length;
+  if (poseRecords.length > renderedPoses.length) {
+    attributes.truncatedPoseCount = poseRecords.length - renderedPoses.length;
   }
   const entities =
     renderedPoses.length > 0
@@ -128,7 +129,7 @@ export function decodeRosPoseArrayRecord(
             frameId,
             id: `${context.streamId ?? "pose-array"}:pose-array`,
             metadata: {
-              poseCount: String(poses.length),
+              poseCount: String(poseRecords.length),
               renderedPoseCount: String(renderedPoses.length),
               source: "geometry_msgs/PoseArray",
             },
@@ -158,9 +159,9 @@ function pathPoints(message: Record<string, unknown>): readonly ScenePoint3D[] {
 }
 
 function poseArrayPoses(
-  message: Record<string, unknown>,
+  poses: readonly Record<string, unknown>[],
 ): readonly ScenePose3D[] {
-  return arrayRecords(message, "poses").map((pose) => {
+  return poses.map((pose) => {
     const decoded = decodePose(pose);
     return {
       position: decoded.position,
@@ -237,9 +238,13 @@ function arrayRecords(
   record: Record<string, unknown>,
   field: string,
 ): readonly Record<string, unknown>[] {
-  return arrayField(record, field).map(
-    (value) => recordField({ value }, "value") ?? {},
+  return arrayField(record, field).map((value) =>
+    isRecord(value) ? value : {},
   );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
 function identityPose(): ScenePose3D {

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/path.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/path.ts
@@ -1,0 +1,250 @@
+import type {
+  DecodeContext,
+  DecodedAttributeValue,
+  DecodedOutput,
+  RgbaColor,
+  SceneArrowPrimitive,
+  SceneEntityVisualization,
+  SceneLinePrimitive,
+  ScenePoint3D,
+  ScenePose3D,
+} from "../../../../decoders";
+import { VISUALIZATION_KIND } from "../../../../visualization";
+import {
+  decodePose,
+  decodeVector3,
+  IDENTITY_QUATERNION,
+  ZERO_VECTOR3,
+} from "../foxglove/protobuf/geometry";
+import {
+  arrayField,
+  recordField,
+  rosHeader,
+  rosHeaderAttributes,
+  rosHeaderFrameId,
+  rosHeaderTimestampNs,
+  timingFromRosHeader,
+} from "./common";
+import { rosDecodersForPayloads } from "./factory";
+import { ROS_PATH_PAYLOADS, ROS_POSE_ARRAY_PAYLOADS } from "./payloads";
+
+const PATH_COLOR: RgbaColor = [0.2, 0.72, 1, 1];
+const PATH_THICKNESS = 2;
+const POSE_ARRAY_COLOR: RgbaColor = [1, 0.62, 0.18, 1];
+const POSE_ARROW_SHAFT_LENGTH = 0.35;
+const POSE_ARROW_SHAFT_DIAMETER = 0.04;
+const POSE_ARROW_HEAD_LENGTH = 0.12;
+const POSE_ARROW_HEAD_DIAMETER = 0.12;
+const MAX_POSE_ARRAY_ARROWS = 1_024;
+
+/**
+ * Decoders for ROS Path messages.
+ */
+export const rosPathDecoders = rosDecodersForPayloads({
+  id: "ros.path",
+  map: decodeRosPathRecord,
+  payloads: ROS_PATH_PAYLOADS,
+});
+
+/**
+ * Decoders for ROS PoseArray messages.
+ */
+export const rosPoseArrayDecoders = rosDecodersForPayloads({
+  id: "ros.pose-array",
+  map: decodeRosPoseArrayRecord,
+  payloads: ROS_POSE_ARRAY_PAYLOADS,
+});
+
+/**
+ * Normalizes a ROS nav_msgs/Path record into a SceneUpdate line-strip overlay.
+ */
+export function decodeRosPathRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+): DecodedOutput {
+  const header = rosHeader(message);
+  const frameId = rosHeaderFrameId(header);
+  const timestampNs = rosHeaderTimestampNs(header);
+  const points = pathPoints(message);
+  const attributes: Record<string, DecodedAttributeValue> = {
+    ...rosHeaderAttributes(header),
+    pointCount: points.length,
+    poseCount: points.length,
+  };
+  const entities =
+    points.length > 0
+      ? [
+          sceneEntity({
+            frameId,
+            id: `${context.streamId ?? "path"}:path`,
+            lines: [pathLine(points)],
+            metadata: {
+              poseCount: String(points.length),
+              source: "nav_msgs/Path",
+            },
+            timestampNs,
+          }),
+        ]
+      : [];
+
+  return {
+    attributes,
+    timing: timingFromRosHeader(context, header),
+    visualization: {
+      deletions: [],
+      entities,
+      kind: VISUALIZATION_KIND.SCENE_UPDATE,
+    },
+  };
+}
+
+/**
+ * Normalizes a ROS geometry_msgs/PoseArray record into a SceneUpdate overlay.
+ * Each pose renders as one orientation arrow to keep large hypothesis clouds
+ * fast enough for interactive playback.
+ */
+export function decodeRosPoseArrayRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+): DecodedOutput {
+  const header = rosHeader(message);
+  const frameId = rosHeaderFrameId(header);
+  const timestampNs = rosHeaderTimestampNs(header);
+  const poses = poseArrayPoses(message);
+  const renderedPoses = poses.slice(0, MAX_POSE_ARRAY_ARROWS);
+  const attributes: Record<string, DecodedAttributeValue> = {
+    ...rosHeaderAttributes(header),
+    poseCount: poses.length,
+    renderedPoseCount: renderedPoses.length,
+  };
+  if (poses.length > renderedPoses.length) {
+    attributes.truncatedPoseCount = poses.length - renderedPoses.length;
+  }
+  const entities =
+    renderedPoses.length > 0
+      ? [
+          sceneEntity({
+            arrows: renderedPoses.map(poseArrow),
+            frameId,
+            id: `${context.streamId ?? "pose-array"}:pose-array`,
+            metadata: {
+              poseCount: String(poses.length),
+              renderedPoseCount: String(renderedPoses.length),
+              source: "geometry_msgs/PoseArray",
+            },
+            timestampNs,
+          }),
+        ]
+      : [];
+
+  return {
+    attributes,
+    timing: timingFromRosHeader(context, header),
+    visualization: {
+      deletions: [],
+      entities,
+      kind: VISUALIZATION_KIND.SCENE_UPDATE,
+    },
+  };
+}
+
+function pathPoints(message: Record<string, unknown>): readonly ScenePoint3D[] {
+  return arrayRecords(message, "poses").map((poseStamped) =>
+    decodeVector3(
+      recordField(recordField(poseStamped, "pose"), "position"),
+      ZERO_VECTOR3,
+    ),
+  );
+}
+
+function poseArrayPoses(
+  message: Record<string, unknown>,
+): readonly ScenePose3D[] {
+  return arrayRecords(message, "poses").map((pose) => {
+    const decoded = decodePose(pose);
+    return {
+      position: decoded.position,
+      quaternion: decoded.quaternion,
+    };
+  });
+}
+
+function pathLine(points: readonly ScenePoint3D[]): SceneLinePrimitive {
+  return {
+    color: PATH_COLOR,
+    colors: [],
+    indices: [],
+    points,
+    pose: identityPose(),
+    scaleInvariant: false,
+    thickness: PATH_THICKNESS,
+    type: "line-strip",
+  };
+}
+
+function poseArrow(pose: ScenePose3D): SceneArrowPrimitive {
+  return {
+    color: POSE_ARRAY_COLOR,
+    headDiameter: POSE_ARROW_HEAD_DIAMETER,
+    headLength: POSE_ARROW_HEAD_LENGTH,
+    pose,
+    shaftDiameter: POSE_ARROW_SHAFT_DIAMETER,
+    shaftLength: POSE_ARROW_SHAFT_LENGTH,
+  };
+}
+
+function sceneEntity({
+  arrows = [],
+  frameId,
+  id,
+  lines = [],
+  metadata,
+  timestampNs,
+}: {
+  readonly arrows?: readonly SceneArrowPrimitive[];
+  readonly frameId: string | undefined;
+  readonly id: string;
+  readonly lines?: readonly SceneLinePrimitive[];
+  readonly metadata: Readonly<Record<string, string>>;
+  readonly timestampNs: bigint | undefined;
+}): SceneEntityVisualization {
+  return {
+    arrowCount: arrows.length,
+    arrows,
+    cubeCount: 0,
+    cubes: [],
+    cylinderCount: 0,
+    cylinders: [],
+    ...(frameId ? { frameId } : {}),
+    frameLocked: false,
+    id,
+    lineCount: lines.length,
+    lines,
+    metadata,
+    modelCount: 0,
+    models: [],
+    sphereCount: 0,
+    spheres: [],
+    textCount: 0,
+    texts: [],
+    ...(timestampNs !== undefined ? { timestampNs } : {}),
+    triangleCount: 0,
+    triangles: [],
+  };
+}
+
+function arrayRecords(
+  record: Record<string, unknown>,
+  field: string,
+): readonly Record<string, unknown>[] {
+  return arrayField(record, field).map(
+    (value) => recordField({ value }, "value") ?? {},
+  );
+}
+
+function identityPose(): ScenePose3D {
+  return {
+    position: ZERO_VECTOR3,
+    quaternion: IDENTITY_QUATERNION,
+  };
+}

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/path.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/path.ts
@@ -30,6 +30,7 @@ import { ROS_PATH_PAYLOADS, ROS_POSE_ARRAY_PAYLOADS } from "./payloads";
 
 const PATH_COLOR: RgbaColor = [0.2, 0.72, 1, 1];
 const PATH_THICKNESS = 2;
+const MAX_PATH_POINTS = 4_096;
 const POSE_ARRAY_COLOR: RgbaColor = [1, 0.62, 0.18, 1];
 const POSE_ARROW_SHAFT_LENGTH = 0.35;
 const POSE_ARROW_SHAFT_DIAMETER = 0.04;
@@ -150,12 +151,14 @@ export function decodeRosPoseArrayRecord(
 }
 
 function pathPoints(message: Record<string, unknown>): readonly ScenePoint3D[] {
-  return arrayRecords(message, "poses").map((poseStamped) =>
-    decodeVector3(
-      recordField(recordField(poseStamped, "pose"), "position"),
-      ZERO_VECTOR3,
-    ),
-  );
+  return arrayRecords(message, "poses")
+    .slice(0, MAX_PATH_POINTS)
+    .map((poseStamped) =>
+      decodeVector3(
+        recordField(recordField(poseStamped, "pose"), "position"),
+        ZERO_VECTOR3,
+      ),
+    );
 }
 
 function poseArrayPoses(

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/payloads.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/payloads.ts
@@ -177,3 +177,16 @@ export const ROS_DETECTION_3D_ARRAY_PAYLOADS = rosPayloads(
   "vision_msgs/Detection3DArray",
   "vision_msgs/msg/Detection3DArray",
 );
+
+/**
+ * Payload descriptors for ROS TF transform messages.
+ */
+export const ROS_TF_MESSAGE_PAYLOADS = rosPayloads(
+  "tf2_msgs/TFMessage",
+  "tf2_msgs/msg/TFMessage",
+);
+
+export const ROS_TRANSFORM_STAMPED_PAYLOADS = rosPayloads(
+  "geometry_msgs/TransformStamped",
+  "geometry_msgs/msg/TransformStamped",
+);

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/payloads.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/payloads.ts
@@ -104,6 +104,41 @@ export const ROS_NAV_SAT_FIX_PAYLOADS = rosPayloads(
 );
 
 /**
+ * Payload descriptors for ROS rosgraph Log messages.
+ */
+export const ROS_ROSGRAPH_LOG_PAYLOADS: readonly PayloadDescriptor[] = [
+  {
+    encoding: "ros1",
+    schema: "rosgraph_msgs/Log",
+    schemaEncoding: "ros1msg",
+  },
+];
+
+/**
+ * Payload descriptors for ROS 2 rcl_interfaces Log messages.
+ */
+export const ROS_RCL_LOG_PAYLOADS: readonly PayloadDescriptor[] = [
+  {
+    encoding: "cdr",
+    schema: "rcl_interfaces/msg/Log",
+    schemaEncoding: "ros2msg",
+  },
+  {
+    encoding: "cdr",
+    schema: "rcl_interfaces/msg/Log",
+    schemaEncoding: "ros2idl",
+  },
+];
+
+/**
+ * Payload descriptors for ROS DiagnosticArray messages.
+ */
+export const ROS_DIAGNOSTIC_ARRAY_PAYLOADS = rosPayloads(
+  "diagnostic_msgs/DiagnosticArray",
+  "diagnostic_msgs/msg/DiagnosticArray",
+);
+
+/**
  * Payload descriptors for ROS OccupancyGrid messages.
  */
 export const ROS_OCCUPANCY_GRID_PAYLOADS = rosPayloads(

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/payloads.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/payloads.ts
@@ -72,11 +72,27 @@ export const ROS_POSE_STAMPED_PAYLOADS = rosPayloads(
 );
 
 /**
+ * Payload descriptors for ROS PoseArray messages.
+ */
+export const ROS_POSE_ARRAY_PAYLOADS = rosPayloads(
+  "geometry_msgs/PoseArray",
+  "geometry_msgs/msg/PoseArray",
+);
+
+/**
  * Payload descriptors for ROS Odometry messages.
  */
 export const ROS_ODOMETRY_PAYLOADS = rosPayloads(
   "nav_msgs/Odometry",
   "nav_msgs/msg/Odometry",
+);
+
+/**
+ * Payload descriptors for ROS Path messages.
+ */
+export const ROS_PATH_PAYLOADS = rosPayloads(
+  "nav_msgs/Path",
+  "nav_msgs/msg/Path",
 );
 
 /**

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/payloads.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/payloads.ts
@@ -126,3 +126,19 @@ export const ROS_MARKER_ARRAY_PAYLOADS = rosPayloads(
   "visualization_msgs/MarkerArray",
   "visualization_msgs/msg/MarkerArray",
 );
+
+/**
+ * Payload descriptors for ROS vision Detection2DArray messages.
+ */
+export const ROS_DETECTION_2D_ARRAY_PAYLOADS = rosPayloads(
+  "vision_msgs/Detection2DArray",
+  "vision_msgs/msg/Detection2DArray",
+);
+
+/**
+ * Payload descriptors for ROS vision Detection3DArray messages.
+ */
+export const ROS_DETECTION_3D_ARRAY_PAYLOADS = rosPayloads(
+  "vision_msgs/Detection3DArray",
+  "vision_msgs/msg/Detection3DArray",
+);

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/payloads.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/payloads.ts
@@ -94,3 +94,19 @@ export const ROS_OCCUPANCY_GRID_PAYLOADS = rosPayloads(
   "nav_msgs/OccupancyGrid",
   "nav_msgs/msg/OccupancyGrid",
 );
+
+/**
+ * Payload descriptors for ROS visualization Marker messages.
+ */
+export const ROS_MARKER_PAYLOADS = rosPayloads(
+  "visualization_msgs/Marker",
+  "visualization_msgs/msg/Marker",
+);
+
+/**
+ * Payload descriptors for ROS visualization MarkerArray messages.
+ */
+export const ROS_MARKER_ARRAY_PAYLOADS = rosPayloads(
+  "visualization_msgs/MarkerArray",
+  "visualization_msgs/msg/MarkerArray",
+);

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/vision.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/vision.ts
@@ -76,14 +76,13 @@ export function decodeRosDetection2DArrayRecord(
 ): DecodedOutput {
   const header = rosHeader(message);
   const detections = detectionRecords(message);
+  const labels = detections.map(detectionLabel);
   const detectionBoxes = detections.map(detection2DBox);
   const boxes = detectionBoxes.filter(isPresent);
-  const labels = detections
-    .map((detection, index) =>
-      detection2DText(detection, detectionBoxes[index]),
-    )
+  const textLabels = labels
+    .map((label, index) => detection2DText(label, detectionBoxes[index]))
     .filter(isPresent);
-  const classIds = uniqueClassIds(detections);
+  const classIds = uniqueClassIds(labels);
 
   return {
     attributes: detectionAttributes({
@@ -91,14 +90,14 @@ export function decodeRosDetection2DArrayRecord(
       classIds,
       detectionCount: detections.length,
       header,
-      textCount: labels.length,
+      textCount: textLabels.length,
     }),
     timing: timingFromRosHeader(context, header),
     visualization: {
       circles: [],
       kind: VISUALIZATION_KIND.IMAGE_ANNOTATIONS,
       points: boxes,
-      texts: labels,
+      texts: textLabels,
     },
   };
 }
@@ -115,6 +114,7 @@ export function decodeRosDetection3DArrayRecord(
   const frameId = rosHeaderFrameId(header);
   const timestampNs = rosHeaderTimestampNs(header);
   const detections = detectionRecords(message);
+  const labels = detections.map(detectionLabel);
   const entities = detections
     .map((detection, index) =>
       detection3DEntity({
@@ -122,11 +122,12 @@ export function decodeRosDetection3DArrayRecord(
         detection,
         frameId,
         index,
+        label: labels[index] ?? null,
         timestampNs,
       }),
     )
     .filter(isPresent);
-  const classIds = uniqueClassIds(detections);
+  const classIds = uniqueClassIds(labels);
   const deletions: readonly SceneEntityDeletionVisualization[] =
     timestampNs !== undefined
       ? [{ id: "", timestampNs, type: "all" }]
@@ -178,10 +179,9 @@ function detection2DBox(
 }
 
 function detection2DText(
-  detection: Record<string, unknown>,
+  label: DetectionLabel | null | undefined,
   box: ImageAnnotationPoints | null | undefined,
 ): ImageAnnotationText | null {
-  const label = detectionLabel(detection);
   if (!label || !box || box.points.length === 0) {
     return null;
   }
@@ -202,12 +202,14 @@ function detection3DEntity({
   detection,
   frameId,
   index,
+  label,
   timestampNs,
 }: {
   readonly context: DecodeContext;
   readonly detection: Record<string, unknown>;
   readonly frameId: string | undefined;
   readonly index: number;
+  readonly label: DetectionLabel | null;
   readonly timestampNs: bigint | undefined;
 }): SceneEntityVisualization | null {
   const bbox = recordField(detection, "bbox");
@@ -220,7 +222,6 @@ function detection3DEntity({
     pose: decodePose(recordField(bbox, "center")),
     size,
   };
-  const label = detectionLabel(detection);
   const texts = label ? [detection3DText(cube.pose, size, label.text)] : [];
   const id = detectionId(detection) ?? String(index);
 
@@ -338,12 +339,12 @@ function detectionMetadata(
 }
 
 function uniqueClassIds(
-  detections: readonly Record<string, unknown>[],
+  labels: readonly (DetectionLabel | null)[],
 ): readonly string[] {
   return [
     ...new Set(
-      detections
-        .map((detection) => detectionLabel(detection)?.classId)
+      labels
+        .map((label) => label?.classId)
         .filter((classId): classId is string => Boolean(classId)),
     ),
   ].sort();
@@ -442,9 +443,13 @@ function arrayRecords(
   record: Record<string, unknown>,
   field: string,
 ): readonly Record<string, unknown>[] {
-  return arrayField(record, field).map(
-    (value) => recordField({ value }, "value") ?? {},
+  return arrayField(record, field).map((value) =>
+    isRecord(value) ? value : {},
   );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
 function stringFromValue(value: unknown): string | undefined {

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/vision.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/vision.ts
@@ -223,7 +223,9 @@ function detection3DEntity({
     size,
   };
   const texts = label ? [detection3DText(cube.pose, size, label.text)] : [];
-  const id = detectionId(detection) ?? String(index);
+  const id =
+    detectionId(detection) ??
+    detectionFallbackId({ context, index, timestampNs });
 
   return sceneEntity({
     cubes: [cube],
@@ -315,6 +317,24 @@ function detectionId(detection: Record<string, unknown>): string | undefined {
     stringFromValue(detection["tracking_id"]) ??
     stringFromValue(detection["trackingId"])
   );
+}
+
+function detectionFallbackId({
+  context,
+  index,
+  timestampNs,
+}: {
+  readonly context: DecodeContext;
+  readonly index: number;
+  readonly timestampNs: bigint | undefined;
+}): string {
+  const messageSalt =
+    timestampNs?.toString() ??
+    context.sourceTimestamps?.messageTime?.toString() ??
+    context.timeRangeStartNs?.toString() ??
+    context.streamId ??
+    "message";
+  return `${messageSalt}:${index}`;
 }
 
 function detectionMetadata(

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/vision.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/vision.ts
@@ -1,0 +1,467 @@
+import type {
+  DecodeContext,
+  DecodedAttributeValue,
+  DecodedOutput,
+  ImageAnnotationPoints,
+  ImageAnnotationText,
+  RgbaColor,
+  SceneCubePrimitive,
+  SceneEntityDeletionVisualization,
+  SceneEntityVisualization,
+  ScenePose3D,
+  SceneTextPrimitive,
+} from "../../../../decoders";
+import { VISUALIZATION_KIND } from "../../../../visualization";
+import {
+  decodePose,
+  decodeVector3,
+  IDENTITY_QUATERNION,
+} from "../foxglove/protobuf/geometry";
+import {
+  arrayField,
+  numberField,
+  recordField,
+  rosHeader,
+  rosHeaderAttributes,
+  rosHeaderFrameId,
+  rosHeaderTimestampNs,
+  timingFromRosHeader,
+} from "./common";
+import { rosDecodersForPayloads } from "./factory";
+import {
+  ROS_DETECTION_2D_ARRAY_PAYLOADS,
+  ROS_DETECTION_3D_ARRAY_PAYLOADS,
+} from "./payloads";
+
+const BOX_2D_COLOR: RgbaColor = [0.16, 0.9, 0.42, 1];
+const BOX_2D_FILL: RgbaColor = [0.16, 0.9, 0.42, 0.08];
+const BOX_2D_LABEL_BACKGROUND: RgbaColor = [0, 0, 0, 0.72];
+const BOX_2D_THICKNESS = 2;
+const BOX_2D_FONT_SIZE = 14;
+
+const BOX_3D_COLOR: RgbaColor = [0.16, 0.9, 0.42, 0.35];
+const BOX_3D_LABEL_COLOR: RgbaColor = [0.9, 1, 0.92, 1];
+const BOX_3D_LABEL_FONT_SIZE = 16;
+
+interface DetectionLabel {
+  readonly classId: string;
+  readonly score?: number;
+  readonly text: string;
+}
+
+/**
+ * Decoders for ROS vision Detection2DArray messages.
+ */
+export const rosDetection2DArrayDecoders = rosDecodersForPayloads({
+  id: "ros.detection-2d-array",
+  map: decodeRosDetection2DArrayRecord,
+  payloads: ROS_DETECTION_2D_ARRAY_PAYLOADS,
+});
+
+/**
+ * Decoders for ROS vision Detection3DArray messages.
+ */
+export const rosDetection3DArrayDecoders = rosDecodersForPayloads({
+  id: "ros.detection-3d-array",
+  map: decodeRosDetection3DArrayRecord,
+  payloads: ROS_DETECTION_3D_ARRAY_PAYLOADS,
+});
+
+/**
+ * Normalizes a ROS vision_msgs/Detection2DArray record into image overlays.
+ */
+export function decodeRosDetection2DArrayRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+): DecodedOutput {
+  const header = rosHeader(message);
+  const detections = detectionRecords(message);
+  const detectionBoxes = detections.map(detection2DBox);
+  const boxes = detectionBoxes.filter(isPresent);
+  const labels = detections
+    .map((detection, index) =>
+      detection2DText(detection, detectionBoxes[index]),
+    )
+    .filter(isPresent);
+  const classIds = uniqueClassIds(detections);
+
+  return {
+    attributes: detectionAttributes({
+      boxCount: boxes.length,
+      classIds,
+      detectionCount: detections.length,
+      header,
+      textCount: labels.length,
+    }),
+    timing: timingFromRosHeader(context, header),
+    visualization: {
+      circles: [],
+      kind: VISUALIZATION_KIND.IMAGE_ANNOTATIONS,
+      points: boxes,
+      texts: labels,
+    },
+  };
+}
+
+/**
+ * Normalizes a ROS vision_msgs/Detection3DArray record into transient 3D
+ * scene overlays.
+ */
+export function decodeRosDetection3DArrayRecord(
+  message: Record<string, unknown>,
+  context: DecodeContext,
+): DecodedOutput {
+  const header = rosHeader(message);
+  const frameId = rosHeaderFrameId(header);
+  const timestampNs = rosHeaderTimestampNs(header);
+  const detections = detectionRecords(message);
+  const entities = detections
+    .map((detection, index) =>
+      detection3DEntity({
+        context,
+        detection,
+        frameId,
+        index,
+        timestampNs,
+      }),
+    )
+    .filter(isPresent);
+  const classIds = uniqueClassIds(detections);
+  const deletions: readonly SceneEntityDeletionVisualization[] =
+    timestampNs !== undefined
+      ? [{ id: "", timestampNs, type: "all" }]
+      : [{ id: "", type: "all" }];
+
+  return {
+    attributes: detectionAttributes({
+      boxCount: entities.length,
+      classIds,
+      detectionCount: detections.length,
+      header,
+      textCount: sum(entities, (entity) => entity.textCount),
+    }),
+    timing: timingFromRosHeader(context, header),
+    visualization: {
+      deletions,
+      entities,
+      kind: VISUALIZATION_KIND.SCENE_UPDATE,
+    },
+  };
+}
+
+function detection2DBox(
+  detection: Record<string, unknown>,
+): ImageAnnotationPoints | null {
+  const bbox = recordField(detection, "bbox");
+  if (!bbox) {
+    return null;
+  }
+  const width = numberField(bbox, "size_x", "sizeX", Number.NaN);
+  const height = numberField(bbox, "size_y", "sizeY", Number.NaN);
+  if (!Number.isFinite(width) || !Number.isFinite(height)) {
+    return null;
+  }
+
+  return {
+    fillColor: BOX_2D_FILL,
+    outlineColor: BOX_2D_COLOR,
+    outlineColors: [],
+    points: rotatedBoxCorners({
+      center: detection2DCenter(bbox),
+      height,
+      theta: detection2DTheta(bbox),
+      width,
+    }),
+    thickness: BOX_2D_THICKNESS,
+    type: "line-loop",
+  };
+}
+
+function detection2DText(
+  detection: Record<string, unknown>,
+  box: ImageAnnotationPoints | null | undefined,
+): ImageAnnotationText | null {
+  const label = detectionLabel(detection);
+  if (!label || !box || box.points.length === 0) {
+    return null;
+  }
+  const x = Math.min(...box.points.map((point) => point[0]));
+  const y = Math.min(...box.points.map((point) => point[1]));
+
+  return {
+    backgroundColor: BOX_2D_LABEL_BACKGROUND,
+    fontSize: BOX_2D_FONT_SIZE,
+    position: [x, Math.max(0, y - BOX_2D_FONT_SIZE)],
+    text: label.text,
+    textColor: BOX_2D_COLOR,
+  };
+}
+
+function detection3DEntity({
+  context,
+  detection,
+  frameId,
+  index,
+  timestampNs,
+}: {
+  readonly context: DecodeContext;
+  readonly detection: Record<string, unknown>;
+  readonly frameId: string | undefined;
+  readonly index: number;
+  readonly timestampNs: bigint | undefined;
+}): SceneEntityVisualization | null {
+  const bbox = recordField(detection, "bbox");
+  if (!bbox) {
+    return null;
+  }
+  const size = decodeVector3(recordField(bbox, "size"));
+  const cube: SceneCubePrimitive = {
+    color: BOX_3D_COLOR,
+    pose: decodePose(recordField(bbox, "center")),
+    size,
+  };
+  const label = detectionLabel(detection);
+  const texts = label ? [detection3DText(cube.pose, size, label.text)] : [];
+  const id = detectionId(detection) ?? String(index);
+
+  return sceneEntity({
+    cubes: [cube],
+    frameId,
+    id: `${context.streamId ?? "detections3d"}:detection3d:${id}`,
+    metadata: detectionMetadata(detection, label),
+    texts,
+    timestampNs,
+  });
+}
+
+function detection3DText(
+  pose: ScenePose3D,
+  size: readonly [number, number, number],
+  text: string,
+): SceneTextPrimitive {
+  return {
+    billboard: true,
+    color: BOX_3D_LABEL_COLOR,
+    fontSize: BOX_3D_LABEL_FONT_SIZE,
+    pose: {
+      position: [
+        pose.position[0],
+        pose.position[1],
+        pose.position[2] + Math.max(0, size[2]) / 2,
+      ],
+      quaternion: IDENTITY_QUATERNION,
+    },
+    scaleInvariant: true,
+    text,
+  };
+}
+
+function detectionAttributes({
+  boxCount,
+  classIds,
+  detectionCount,
+  header,
+  textCount,
+}: {
+  readonly boxCount: number;
+  readonly classIds: readonly string[];
+  readonly detectionCount: number;
+  readonly header: Record<string, unknown> | undefined;
+  readonly textCount: number;
+}): Record<string, DecodedAttributeValue> {
+  return {
+    ...rosHeaderAttributes(header),
+    boxCount,
+    classIds,
+    detectionCount,
+    textCount,
+  };
+}
+
+function detectionRecords(
+  message: Record<string, unknown>,
+): readonly Record<string, unknown>[] {
+  return arrayRecords(message, "detections");
+}
+
+function detectionLabel(
+  detection: Record<string, unknown>,
+): DetectionLabel | null {
+  const result = arrayRecords(detection, "results")[0];
+  if (!result) {
+    return null;
+  }
+  const hypothesis = recordField(result, "hypothesis") ?? result;
+  const classId =
+    stringFromValue(hypothesis["class_id"]) ??
+    stringFromValue(hypothesis["classId"]) ??
+    stringFromValue(hypothesis["id"]);
+  const score = numberField(hypothesis, "score", undefined, Number.NaN);
+  if (!classId) {
+    return null;
+  }
+
+  return {
+    classId,
+    ...(Number.isFinite(score) ? { score } : {}),
+    text: Number.isFinite(score) ? `${classId} ${score.toFixed(2)}` : classId,
+  };
+}
+
+function detectionId(detection: Record<string, unknown>): string | undefined {
+  return (
+    stringFromValue(detection["id"]) ??
+    stringFromValue(detection["tracking_id"]) ??
+    stringFromValue(detection["trackingId"])
+  );
+}
+
+function detectionMetadata(
+  detection: Record<string, unknown>,
+  label: DetectionLabel | null,
+): Readonly<Record<string, string>> {
+  const metadata: Record<string, string> = {
+    source: "vision_msgs",
+  };
+  const id = detectionId(detection);
+  if (id) {
+    metadata.id = id;
+  }
+  if (label) {
+    metadata.classId = label.classId;
+    if (label.score !== undefined) {
+      metadata.score = label.score.toFixed(4);
+    }
+  }
+
+  return metadata;
+}
+
+function uniqueClassIds(
+  detections: readonly Record<string, unknown>[],
+): readonly string[] {
+  return [
+    ...new Set(
+      detections
+        .map((detection) => detectionLabel(detection)?.classId)
+        .filter((classId): classId is string => Boolean(classId)),
+    ),
+  ].sort();
+}
+
+function detection2DCenter(
+  bbox: Record<string, unknown>,
+): readonly [number, number] {
+  const center = recordField(bbox, "center");
+  const position = recordField(center, "position");
+  if (position) {
+    return [
+      numberField(position, "x", undefined, 0),
+      numberField(position, "y", undefined, 0),
+    ];
+  }
+
+  return [
+    numberField(center, "x", undefined, 0),
+    numberField(center, "y", undefined, 0),
+  ];
+}
+
+function detection2DTheta(bbox: Record<string, unknown>): number {
+  return numberField(recordField(bbox, "center"), "theta", undefined, 0);
+}
+
+function rotatedBoxCorners({
+  center,
+  height,
+  theta,
+  width,
+}: {
+  readonly center: readonly [number, number];
+  readonly height: number;
+  readonly theta: number;
+  readonly width: number;
+}): readonly (readonly [number, number])[] {
+  const halfWidth = width / 2;
+  const halfHeight = height / 2;
+  const cos = Math.cos(theta);
+  const sin = Math.sin(theta);
+
+  return [
+    [-halfWidth, -halfHeight],
+    [halfWidth, -halfHeight],
+    [halfWidth, halfHeight],
+    [-halfWidth, halfHeight],
+  ].map(([x, y]) => [
+    center[0] + x * cos - y * sin,
+    center[1] + x * sin + y * cos,
+  ]);
+}
+
+function sceneEntity({
+  cubes,
+  frameId,
+  id,
+  metadata,
+  texts,
+  timestampNs,
+}: {
+  readonly cubes: readonly SceneCubePrimitive[];
+  readonly frameId: string | undefined;
+  readonly id: string;
+  readonly metadata: Readonly<Record<string, string>>;
+  readonly texts: readonly SceneTextPrimitive[];
+  readonly timestampNs: bigint | undefined;
+}): SceneEntityVisualization {
+  return {
+    arrowCount: 0,
+    arrows: [],
+    cubeCount: cubes.length,
+    cubes,
+    cylinderCount: 0,
+    cylinders: [],
+    ...(frameId ? { frameId } : {}),
+    frameLocked: false,
+    id,
+    lineCount: 0,
+    lines: [],
+    metadata,
+    modelCount: 0,
+    models: [],
+    sphereCount: 0,
+    spheres: [],
+    textCount: texts.length,
+    texts,
+    ...(timestampNs !== undefined ? { timestampNs } : {}),
+    triangleCount: 0,
+    triangles: [],
+  };
+}
+
+function arrayRecords(
+  record: Record<string, unknown>,
+  field: string,
+): readonly Record<string, unknown>[] {
+  return arrayField(record, field).map(
+    (value) => recordField({ value }, "value") ?? {},
+  );
+}
+
+function stringFromValue(value: unknown): string | undefined {
+  if (typeof value === "string" && value) {
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "bigint") {
+    return String(value);
+  }
+
+  return undefined;
+}
+
+function isPresent<T>(value: T | null | undefined): value is T {
+  return value !== null && value !== undefined;
+}
+
+function sum<T>(values: readonly T[], select: (value: T) => number): number {
+  return values.reduce((total, value) => total + select(value), 0);
+}

--- a/app/packages/multimodal/src/adapters/mcap/grid-preview.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/grid-preview.test.ts
@@ -474,6 +474,7 @@ describe("MCAP grid preview", () => {
     ).toEqual({
       annotations: ["/camera/front/annotations"],
       image: ["/camera/front"],
+      logs: [],
       pointCloud: ["/lidar/points"],
       previewable: ["/camera/front", "/lidar/points"],
       sceneUpdates: ["/markers"],
@@ -495,6 +496,7 @@ describe("MCAP grid preview", () => {
     ).toEqual({
       annotations: [],
       image: [],
+      logs: [],
       pointCloud: [],
       previewable: [],
       sceneUpdates: [],
@@ -508,6 +510,7 @@ describe("MCAP grid preview", () => {
         "/CAM_FRONT/image_rect_compressed",
         "/CAM_BACK/image_rect_compressed",
       ],
+      logs: [],
       pointCloud: [],
       previewable: [
         "/CAM_FRONT/image_rect_compressed",

--- a/app/packages/multimodal/src/adapters/mcap/log-records.ts
+++ b/app/packages/multimodal/src/adapters/mcap/log-records.ts
@@ -1,0 +1,91 @@
+import type { DecodedAttributeValue } from "../../decoders";
+
+export const MCAP_LOG_ATTRIBUTE_ROWS = "logRows";
+
+export const MCAP_LOG_LEVEL = {
+  DEBUG: "debug",
+  ERROR: "error",
+  FATAL: "fatal",
+  INFO: "info",
+  UNKNOWN: "unknown",
+  WARN: "warn",
+} as const;
+
+export type McapLogLevel = (typeof MCAP_LOG_LEVEL)[keyof typeof MCAP_LOG_LEVEL];
+
+export const MCAP_LOG_LEVELS: readonly McapLogLevel[] = [
+  MCAP_LOG_LEVEL.DEBUG,
+  MCAP_LOG_LEVEL.INFO,
+  MCAP_LOG_LEVEL.WARN,
+  MCAP_LOG_LEVEL.ERROR,
+  MCAP_LOG_LEVEL.FATAL,
+  MCAP_LOG_LEVEL.UNKNOWN,
+];
+
+export interface McapLogDetail {
+  readonly key: string;
+  readonly value: string;
+}
+
+export interface McapDecodedLogRow {
+  readonly details?: readonly McapLogDetail[];
+  readonly file?: string;
+  readonly functionName?: string;
+  readonly hardwareId?: string;
+  readonly kind?: "diagnostic" | "log";
+  readonly level: McapLogLevel;
+  readonly levelNumber?: number;
+  readonly line?: number;
+  readonly message: string;
+  readonly name?: string;
+  readonly status?: string;
+  readonly timestampNs?: bigint;
+  readonly topics?: readonly string[];
+}
+
+export function logRowsAttribute(
+  rows: readonly McapDecodedLogRow[],
+): readonly Record<string, DecodedAttributeValue>[] {
+  return rows.map(logRowAttribute);
+}
+
+export function logRowAttribute(
+  row: McapDecodedLogRow,
+): Record<string, DecodedAttributeValue> {
+  const attributes: Record<string, DecodedAttributeValue> = {
+    level: row.level,
+    message: row.message,
+  };
+  assignOptional(attributes, "details", row.details?.map(logDetailAttribute));
+  assignOptional(attributes, "file", row.file);
+  assignOptional(attributes, "functionName", row.functionName);
+  assignOptional(attributes, "hardwareId", row.hardwareId);
+  assignOptional(attributes, "kind", row.kind);
+  assignOptional(attributes, "levelNumber", row.levelNumber);
+  assignOptional(attributes, "line", row.line);
+  assignOptional(attributes, "name", row.name);
+  assignOptional(attributes, "status", row.status);
+  assignOptional(attributes, "timestampNs", row.timestampNs);
+  assignOptional(attributes, "topics", row.topics);
+
+  return attributes;
+}
+
+function logDetailAttribute(
+  detail: McapLogDetail,
+): Record<string, DecodedAttributeValue> {
+  return {
+    key: detail.key,
+    value: detail.value,
+  };
+}
+
+function assignOptional(
+  target: Record<string, DecodedAttributeValue>,
+  key: string,
+  value: DecodedAttributeValue | undefined,
+) {
+  if (value !== undefined) {
+    target[key] = value;
+  }
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/McapAddTileMenu.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapAddTileMenu.test.tsx
@@ -9,6 +9,7 @@ import McapAddTileMenu from "./McapAddTileMenu";
 // bodies.
 vi.mock("./McapImageTile", () => ({ default: () => null }));
 vi.mock("./Mcap3dTile", () => ({ default: () => null }));
+vi.mock("./McapLogConsoleTile", () => ({ default: () => null }));
 vi.mock("./McapPlotTile", () => ({ default: () => null }));
 vi.mock("./McapRawMessageTile", () => ({ default: () => null }));
 
@@ -64,6 +65,7 @@ describe("McapAddTileMenu", () => {
 
     expect(screen.getByText("Image")).toBeTruthy();
     expect(screen.getByText("3D")).toBeTruthy();
+    expect(screen.getByText("Logs")).toBeTruthy();
     expect(screen.getByText("Plot")).toBeTruthy();
     expect(screen.getByText("Message")).toBeTruthy();
     expect(screen.queryByText("Image streams")).toBeNull();
@@ -93,6 +95,21 @@ describe("McapAddTileMenu", () => {
     expect(rawIds).toEqual(["raw-1", "raw-2"]);
     for (const id of rawIds) {
       expect(titles[id]).toBe("Message");
+    }
+  });
+
+  it("spawns additive log tiles", () => {
+    renderMenu();
+    openMenu();
+    fireEvent.click(screen.getByText("Logs"));
+    openMenu();
+    fireEvent.click(screen.getByText("Logs"));
+
+    const { titles } = probeState();
+    const logIds = Object.keys(titles).filter((id) => id.startsWith("log-"));
+    expect(logIds).toEqual(["log-1", "log-2"]);
+    for (const id of logIds) {
+      expect(titles[id]).toBe("Logs");
     }
   });
 });

--- a/app/packages/multimodal/src/adapters/mcap/react/McapAddTileMenu.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapAddTileMenu.tsx
@@ -7,6 +7,7 @@ import { getMcapTileDefinition } from "./use-mcap-tiles";
 const MCAP_ADD_TILE_TYPES: readonly McapTileType[] = [
   MCAP_TILE_TYPE.IMAGE,
   MCAP_TILE_TYPE.THREE_D,
+  MCAP_TILE_TYPE.LOG,
   MCAP_TILE_TYPE.PLOT,
   MCAP_TILE_TYPE.RAW,
 ];

--- a/app/packages/multimodal/src/adapters/mcap/react/McapLogConsoleTile.module.css
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapLogConsoleTile.module.css
@@ -1,0 +1,140 @@
+.body {
+  background: var(--plot-surface, #050b12);
+  color: var(--color-content-text-primary);
+  display: flex;
+  flex-direction: column;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  height: 100%;
+  min-width: 0;
+  overflow: hidden;
+  width: 100%;
+}
+
+.toolbar {
+  align-items: center;
+  border-bottom: 1px solid var(--color-content-border-default, #383835);
+  color: var(--color-content-text-secondary);
+  display: flex;
+  flex: none;
+  flex-wrap: wrap;
+  font-size: 11px;
+  gap: 8px 12px;
+  min-height: 34px;
+  padding: 6px 10px;
+}
+
+.controlGroup {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  min-width: 0;
+}
+
+.meta {
+  color: var(--color-content-text-secondary);
+  margin-left: auto;
+  white-space: nowrap;
+}
+
+.scroll {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+}
+
+.row {
+  align-items: baseline;
+  background: transparent;
+  border: 0;
+  border-bottom: 1px solid
+    color-mix(
+      in srgb,
+      var(--color-content-border-default, #383835) 45%,
+      transparent
+    );
+  color: inherit;
+  cursor: pointer;
+  display: grid;
+  font: inherit;
+  grid-template-columns: 74px 54px minmax(120px, 0.28fr) minmax(0, 1fr);
+  gap: 10px;
+  line-height: 1.45;
+  min-height: 30px;
+  padding: 5px 10px;
+  text-align: left;
+  width: 100%;
+}
+
+.row:hover,
+.row:focus-visible {
+  background: color-mix(
+    in srgb,
+    var(--color-content-text-secondary) 8%,
+    transparent
+  );
+  outline: none;
+}
+
+.time,
+.source,
+.message,
+.level {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.time {
+  color: var(--color-content-text-secondary);
+}
+
+.source {
+  color: var(--color-content-text-secondary);
+}
+
+.message {
+  color: var(--color-content-text-primary);
+}
+
+.level {
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.debug {
+  color: #7eb6ff;
+}
+
+.info {
+  color: #86d88f;
+}
+
+.warn {
+  color: #f1c75b;
+}
+
+.error {
+  color: #ff837a;
+}
+
+.fatal {
+  color: #ff5ea8;
+}
+
+.unknown {
+  color: var(--color-content-text-secondary);
+}
+
+.empty {
+  align-items: center;
+  color: var(--color-content-text-secondary);
+  display: flex;
+  flex: 1;
+  font-size: 12px;
+  justify-content: center;
+  min-height: 0;
+  padding: 16px;
+  text-align: center;
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/McapLogConsoleTile.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapLogConsoleTile.tsx
@@ -1,0 +1,305 @@
+import {
+  getPlayhead,
+  subscribePlayhead,
+  usePlayback,
+  usePlaybackStore,
+} from "@fiftyone/playback";
+import { useSetTileTitle } from "@fiftyone/tiling";
+import { Checkbox } from "@voxel51/voodo";
+import clsx from "clsx";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { useSceneSourcesByType } from "../../../scene-inventory";
+import { MCAP_LOG_LEVELS, type McapLogLevel } from "../log-records";
+import { MCAP_SOURCE_TYPE } from "../scene-sources";
+import { useMcapDataStream } from "./mcap-data-stream-context";
+import {
+  logConsoleRowsFromDecodedMessage,
+  type McapLogConsoleRow,
+} from "./mcap-log-console-rows";
+import { useMcapLogConsoleContext } from "./mcap-log-console-context";
+import { checkboxNoSpaceToggleProps } from "./mcap-settings-keyboard";
+import styles from "./McapLogConsoleTile.module.css";
+import tileStyles from "./McapTile.module.css";
+import type { McapTileProps } from "./mcap-tile-types";
+
+const PLAYHEAD_REFRESH_MS = 500;
+const LOG_WINDOW_BEFORE_NS = 30_000_000_000n;
+const LOG_WINDOW_AFTER_NS = 2_000_000_000n;
+const LOG_WINDOW_LABEL = "32s";
+const LOG_READ_LIMIT = 600;
+
+interface LogRowsState {
+  readonly error?: string;
+  readonly rows: readonly McapLogConsoleRow[];
+  readonly status: "idle" | "loading" | "ready" | "error";
+}
+
+const INITIAL_ROWS: LogRowsState = { rows: [], status: "idle" };
+
+const McapLogConsoleTile: React.FC<McapTileProps> = () => {
+  const logSources = useSceneSourcesByType(MCAP_SOURCE_TYPE.LOG);
+  const { client, source } = useMcapLogConsoleContext();
+  const dataStream = useMcapDataStream();
+  const timelineIndex = dataStream?.getTimelineIndex() ?? null;
+  const store = usePlaybackStore();
+  const { seek } = usePlayback();
+  const setTileTitle = useSetTileTitle();
+  const [followPlayhead, setFollowPlayhead] = useState(true);
+  const [centerTimeNs, setCenterTimeNs] = useState<bigint | undefined>();
+  const [selectedTopics, setSelectedTopics] = useState<readonly string[]>([]);
+  const [selectedLevels, setSelectedLevels] =
+    useState<readonly McapLogLevel[]>(MCAP_LOG_LEVELS);
+  const [state, setState] = useState<LogRowsState>(INITIAL_ROWS);
+
+  useEffect(() => {
+    setTileTitle("Logs", { source: "auto" });
+  }, [setTileTitle]);
+
+  useEffect(() => {
+    const ids = logSources.map((entry) => entry.id);
+    setSelectedTopics((current) => {
+      const valid = current.filter((topic) => ids.includes(topic));
+      return valid.length > 0 ? valid : ids;
+    });
+  }, [logSources]);
+
+  useEffect(() => {
+    if (!followPlayhead || !timelineIndex) {
+      return undefined;
+    }
+
+    let lastPublishMs = 0;
+    const publish = () => {
+      const now = Date.now();
+      if (now - lastPublishMs < PLAYHEAD_REFRESH_MS) {
+        return;
+      }
+      lastPublishMs = now;
+      setCenterTimeNs(timelineIndex.nearestTick(getPlayhead(store)));
+    };
+
+    publish();
+    return subscribePlayhead(store, publish);
+  }, [followPlayhead, store, timelineIndex]);
+
+  useEffect(() => {
+    if (centerTimeNs === undefined && timelineIndex) {
+      setCenterTimeNs(timelineIndex.startTimeNs);
+    }
+  }, [centerTimeNs, timelineIndex]);
+
+  const selectedLevelSet = useMemo(
+    () => new Set(selectedLevels),
+    [selectedLevels],
+  );
+
+  useEffect(() => {
+    if (!source || centerTimeNs === undefined || selectedTopics.length === 0) {
+      setState(INITIAL_ROWS);
+      return undefined;
+    }
+
+    let cancelled = false;
+    setState((current) => ({ ...current, status: "loading" }));
+
+    const startTimeNs =
+      centerTimeNs > LOG_WINDOW_BEFORE_NS
+        ? centerTimeNs - LOG_WINDOW_BEFORE_NS
+        : 0n;
+    const endTimeNs = centerTimeNs + LOG_WINDOW_AFTER_NS;
+
+    void (async () => {
+      try {
+        const rows: McapLogConsoleRow[] = [];
+        for await (const message of client.readDecodedMessages(
+          {
+            endTimeNs,
+            limit: LOG_READ_LIMIT,
+            source,
+            startTimeNs,
+            topics: selectedTopics,
+          },
+          { priority: "current" },
+        )) {
+          rows.push(...logConsoleRowsFromDecodedMessage(message));
+        }
+
+        if (cancelled) {
+          return;
+        }
+
+        setState({
+          rows: rows
+            .filter((row) => selectedLevelSet.has(row.level))
+            .sort((left, right) => compareBigInt(left.timeNs, right.timeNs)),
+          status: "ready",
+        });
+      } catch (error) {
+        if (!cancelled) {
+          setState({
+            error: error instanceof Error ? error.message : String(error),
+            rows: [],
+            status: "error",
+          });
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [centerTimeNs, client, selectedLevelSet, selectedTopics, source]);
+
+  const handleRowClick = useCallback(
+    (row: McapLogConsoleRow) => {
+      if (!timelineIndex) {
+        return;
+      }
+      setCenterTimeNs(row.timeNs);
+      seek(timelineIndex.nsToSec(row.timeNs));
+    },
+    [seek, timelineIndex],
+  );
+
+  const toggleTopic = useCallback((topic: string, checked: boolean) => {
+    setSelectedTopics((current) =>
+      checked
+        ? [...new Set([...current, topic])]
+        : current.filter((entry) => entry !== topic),
+    );
+  }, []);
+
+  const toggleLevel = useCallback((level: McapLogLevel, checked: boolean) => {
+    setSelectedLevels((current) =>
+      checked
+        ? [...new Set([...current, level])]
+        : current.filter((entry) => entry !== level),
+    );
+  }, []);
+
+  const windowStartNs =
+    centerTimeNs !== undefined && centerTimeNs > LOG_WINDOW_BEFORE_NS
+      ? centerTimeNs - LOG_WINDOW_BEFORE_NS
+      : 0n;
+  const timeOriginNs = timelineIndex?.startTimeNs;
+
+  if (logSources.length === 0) {
+    return (
+      <div className={styles.body} data-testid="mcap-log-console-tile">
+        <div className={styles.empty}>No log streams in this recording</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.body} data-testid="mcap-log-console-tile">
+      <div className={styles.toolbar}>
+        <div className={styles.controlGroup}>
+          <Checkbox
+            checked={followPlayhead}
+            label="Follow"
+            onChange={setFollowPlayhead}
+            {...checkboxNoSpaceToggleProps}
+          />
+        </div>
+        <div className={styles.controlGroup}>
+          {MCAP_LOG_LEVELS.map((level) => (
+            <Checkbox
+              key={level}
+              checked={selectedLevels.includes(level)}
+              label={level}
+              onChange={(checked) => toggleLevel(level, checked)}
+              {...checkboxNoSpaceToggleProps}
+            />
+          ))}
+        </div>
+        {logSources.length > 1 ? (
+          <div className={styles.controlGroup}>
+            {logSources.map((logSource) => (
+              <Checkbox
+                key={logSource.id}
+                checked={selectedTopics.includes(logSource.id)}
+                label={logSource.label}
+                onChange={(checked) => toggleTopic(logSource.id, checked)}
+                {...checkboxNoSpaceToggleProps}
+              />
+            ))}
+          </div>
+        ) : null}
+        <span className={styles.meta}>
+          {state.status === "loading" ? "loading" : state.rows.length} ·{" "}
+          {LOG_WINDOW_LABEL}
+        </span>
+      </div>
+      {state.status === "error" ? (
+        <div className={tileStyles.loading}>
+          <span className={tileStyles.emptyTextError}>
+            Could not read logs{state.error ? `: ${state.error}` : ""}
+          </span>
+        </div>
+      ) : state.rows.length === 0 ? (
+        <div className={styles.empty}>
+          {selectedTopics.length === 0 || selectedLevels.length === 0
+            ? "No filters selected"
+            : "No log rows in this time window"}
+        </div>
+      ) : (
+        <div className={styles.scroll}>
+          {state.rows.map((row) => (
+            <button
+              key={row.id}
+              className={styles.row}
+              onClick={() => handleRowClick(row)}
+              title={rowTitle(row)}
+              type="button"
+            >
+              <span className={styles.time}>
+                {timeOriginNs !== undefined
+                  ? formatRelativeTime(row.timeNs, timeOriginNs)
+                  : formatWindowOffset(row.timeNs, windowStartNs)}
+              </span>
+              <span className={clsx(styles.level, styles[row.level])}>
+                {row.status ?? row.level}
+              </span>
+              <span className={styles.source}>
+                {row.groupLabel ?? row.topic}
+              </span>
+              <span className={styles.message}>{row.message}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+function compareBigInt(left: bigint, right: bigint): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function formatRelativeTime(timeNs: bigint, originNs: bigint): string {
+  const deltaNs = timeNs - originNs;
+  const sign = deltaNs < 0n ? "-" : "";
+  const absoluteNs = deltaNs < 0n ? -deltaNs : deltaNs;
+  const seconds = absoluteNs / 1_000_000_000n;
+  const millis = (absoluteNs % 1_000_000_000n) / 1_000_000n;
+  return `${sign}${seconds.toString()}.${millis.toString().padStart(3, "0")}s`;
+}
+
+function formatWindowOffset(timeNs: bigint, windowStartNs: bigint): string {
+  return `+${formatRelativeTime(timeNs, windowStartNs)}`;
+}
+
+function rowTitle(row: McapLogConsoleRow): string {
+  const location =
+    row.file && row.line ? `${row.file}:${row.line}` : (row.file ?? null);
+  const details =
+    row.details.length > 0
+      ? row.details.map((entry) => `${entry.key}=${entry.value}`).join(", ")
+      : null;
+  return [row.topic, row.groupLabel, location, row.functionName, details]
+    .filter(Boolean)
+    .join(" · ");
+}
+
+export default McapLogConsoleTile;

--- a/app/packages/multimodal/src/adapters/mcap/react/McapLogConsoleTile.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapLogConsoleTile.tsx
@@ -101,7 +101,12 @@ const McapLogConsoleTile: React.FC<McapTileProps> = () => {
   );
 
   useEffect(() => {
-    if (!source || centerTimeNs === undefined || selectedTopics.length === 0) {
+    if (
+      !source ||
+      centerTimeNs === undefined ||
+      selectedTopics.length === 0 ||
+      selectedLevels.length === 0
+    ) {
       setState(INITIAL_ROWS);
       return undefined;
     }
@@ -156,7 +161,7 @@ const McapLogConsoleTile: React.FC<McapTileProps> = () => {
     return () => {
       cancelled = true;
     };
-  }, [centerTimeNs, client, selectedTopics, source]);
+  }, [centerTimeNs, client, selectedLevels.length, selectedTopics, source]);
 
   const handleRowClick = useCallback(
     (row: McapLogConsoleRow) => {
@@ -300,7 +305,9 @@ function formatWindowOffset(timeNs: bigint, windowStartNs: bigint): string {
 
 function rowTitle(row: McapLogConsoleRow): string {
   const location =
-    row.file && row.line ? `${row.file}:${row.line}` : (row.file ?? null);
+    row.file && row.line !== undefined
+      ? `${row.file}:${row.line}`
+      : (row.file ?? null);
   const details =
     row.details.length > 0
       ? row.details.map((entry) => `${entry.key}=${entry.value}`).join(", ")

--- a/app/packages/multimodal/src/adapters/mcap/react/McapLogConsoleTile.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapLogConsoleTile.tsx
@@ -8,7 +8,7 @@ import { useSetTileTitle } from "@fiftyone/tiling";
 import { Checkbox } from "@voxel51/voodo";
 import clsx from "clsx";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { useSceneSourcesByType } from "../../../scene-inventory";
+import { useSceneSourcesByType } from "../../../scene-inventory/SceneInventoryProvider";
 import { MCAP_LOG_LEVELS, type McapLogLevel } from "../log-records";
 import { MCAP_SOURCE_TYPE } from "../scene-sources";
 import { useMcapDataStream } from "./mcap-data-stream-context";
@@ -30,11 +30,11 @@ const LOG_READ_LIMIT = 600;
 
 interface LogRowsState {
   readonly error?: string;
-  readonly rows: readonly McapLogConsoleRow[];
+  readonly rawRows: readonly McapLogConsoleRow[];
   readonly status: "idle" | "loading" | "ready" | "error";
 }
 
-const INITIAL_ROWS: LogRowsState = { rows: [], status: "idle" };
+const INITIAL_ROWS: LogRowsState = { rawRows: [], status: "idle" };
 
 const McapLogConsoleTile: React.FC<McapTileProps> = () => {
   const logSources = useSceneSourcesByType(MCAP_SOURCE_TYPE.LOG);
@@ -92,6 +92,13 @@ const McapLogConsoleTile: React.FC<McapTileProps> = () => {
     () => new Set(selectedLevels),
     [selectedLevels],
   );
+  const rows = useMemo(
+    () =>
+      state.rawRows
+        .filter((row) => selectedLevelSet.has(row.level))
+        .sort((left, right) => compareBigInt(left.timeNs, right.timeNs)),
+    [selectedLevelSet, state.rawRows],
+  );
 
   useEffect(() => {
     if (!source || centerTimeNs === undefined || selectedTopics.length === 0) {
@@ -110,7 +117,7 @@ const McapLogConsoleTile: React.FC<McapTileProps> = () => {
 
     void (async () => {
       try {
-        const rows: McapLogConsoleRow[] = [];
+        const fetchedRows: McapLogConsoleRow[] = [];
         for await (const message of client.readDecodedMessages(
           {
             endTimeNs,
@@ -121,7 +128,10 @@ const McapLogConsoleTile: React.FC<McapTileProps> = () => {
           },
           { priority: "current" },
         )) {
-          rows.push(...logConsoleRowsFromDecodedMessage(message));
+          if (cancelled) {
+            break;
+          }
+          fetchedRows.push(...logConsoleRowsFromDecodedMessage(message));
         }
 
         if (cancelled) {
@@ -129,16 +139,14 @@ const McapLogConsoleTile: React.FC<McapTileProps> = () => {
         }
 
         setState({
-          rows: rows
-            .filter((row) => selectedLevelSet.has(row.level))
-            .sort((left, right) => compareBigInt(left.timeNs, right.timeNs)),
+          rawRows: fetchedRows,
           status: "ready",
         });
       } catch (error) {
         if (!cancelled) {
           setState({
             error: error instanceof Error ? error.message : String(error),
-            rows: [],
+            rawRows: [],
             status: "error",
           });
         }
@@ -148,7 +156,7 @@ const McapLogConsoleTile: React.FC<McapTileProps> = () => {
     return () => {
       cancelled = true;
     };
-  }, [centerTimeNs, client, selectedLevelSet, selectedTopics, source]);
+  }, [centerTimeNs, client, selectedTopics, source]);
 
   const handleRowClick = useCallback(
     (row: McapLogConsoleRow) => {
@@ -227,7 +235,7 @@ const McapLogConsoleTile: React.FC<McapTileProps> = () => {
           </div>
         ) : null}
         <span className={styles.meta}>
-          {state.status === "loading" ? "loading" : state.rows.length} ·{" "}
+          {state.status === "loading" ? "loading" : rows.length} ·{" "}
           {LOG_WINDOW_LABEL}
         </span>
       </div>
@@ -237,7 +245,7 @@ const McapLogConsoleTile: React.FC<McapTileProps> = () => {
             Could not read logs{state.error ? `: ${state.error}` : ""}
           </span>
         </div>
-      ) : state.rows.length === 0 ? (
+      ) : rows.length === 0 ? (
         <div className={styles.empty}>
           {selectedTopics.length === 0 || selectedLevels.length === 0
             ? "No filters selected"
@@ -245,7 +253,7 @@ const McapLogConsoleTile: React.FC<McapTileProps> = () => {
         </div>
       ) : (
         <div className={styles.scroll}>
-          {state.rows.map((row) => (
+          {rows.map((row) => (
             <button
               key={row.id}
               className={styles.row}

--- a/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.module.css
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.module.css
@@ -102,6 +102,12 @@
   gap: 8px;
 }
 
+.topicGroups {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
 .topicSearchInput {
   min-width: 0;
   width: 100%;
@@ -116,26 +122,59 @@
   padding-left: 8px;
 }
 
-.topicMeta {
-  color: var(--color-content-text-muted);
+.topicRowHeader {
+  align-items: baseline;
+  display: flex;
+  gap: 8px;
+  min-width: 0;
+}
+
+.topicName {
+  color: var(--color-content-text);
+  flex: 1 1 auto;
   font-size: 11px;
   line-height: 1.25;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.topicMetaLine {
+  align-items: baseline;
+  display: flex;
+  gap: 8px;
+  justify-content: space-between;
+  min-width: 0;
+}
+
+.topicActions {
+  align-items: baseline;
+  display: flex;
+  flex: 0 0 auto;
+  gap: 8px;
+}
+
+.topicMeta {
+  color: var(--color-content-text-muted);
+  flex: 1 1 auto;
+  font-size: 11px;
+  line-height: 1.25;
+  min-width: 0;
   overflow-wrap: anywhere;
 }
 
 .topicStatus {
-  align-self: flex-start;
+  flex: 0 0 auto;
   color: var(--color-content-text-muted);
   font-size: 10px;
   line-height: 1.2;
 }
 
-.topicInspectButton {
-  align-self: flex-start;
+.topicActionButton {
   background: transparent;
   border: 0;
   color: var(--color-content-text-muted);
   cursor: pointer;
+  flex: 0 0 auto;
   font-family: inherit;
   font-size: 10px;
   line-height: 1.2;
@@ -145,7 +184,7 @@
   text-underline-offset: 3px;
 }
 
-.topicInspectButton:focus-visible {
+.topicActionButton:focus-visible {
   outline: 1px solid var(--color-border);
   outline-offset: 2px;
 }

--- a/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.test.tsx
@@ -129,6 +129,7 @@ describe("McapSettingsSidebar", () => {
     renderSidebar();
 
     expect(screen.getByRole("tab", { name: "Scene" })).toBeTruthy();
+    expect(screen.getByRole("tab", { name: "Topics" })).toBeTruthy();
     expect(screen.queryByRole("tab", { name: "Camera" })).toBeNull();
     expect(screen.queryByRole("heading", { name: "Settings" })).toBeNull();
     expect(screen.getByText("Advanced timing")).toBeTruthy();
@@ -173,7 +174,7 @@ describe("McapSettingsSidebar", () => {
     expect(screen.getByText("Reset to defaults")).toBeTruthy();
   });
 
-  it("lists non-renderable topics in scene settings", () => {
+  it("lists all topics by category in the topics tab", () => {
     renderSidebar({
       topics: [
         topic("/lidar/top", {
@@ -187,6 +188,12 @@ describe("McapSettingsSidebar", () => {
           decodeStatus: "decodable",
           encoding: "ros1",
           schema: "sensor_msgs/Imu",
+        }),
+        topic("/tf_static", {
+          count: "2",
+          decodeStatus: "decodable",
+          encoding: "ros1",
+          schema: "tf2_msgs/TFMessage",
         }),
         topic("/broken", {
           count: "3",
@@ -203,18 +210,41 @@ describe("McapSettingsSidebar", () => {
       ],
     });
 
-    fireEvent.click(screen.getByRole("button", { name: /Other topics/ }));
+    expect(screen.queryByRole("button", { name: /Other topics/ })).toBeNull();
 
-    expect(screen.queryByLabelText("Search other topics")).toBeNull();
-    expect(screen.queryByText("/lidar/top")).toBeNull();
+    fireEvent.click(screen.getByRole("tab", { name: "Topics" }));
+
+    expect(screen.queryByLabelText("Search topics")).toBeNull();
+    expect(screen.getByRole("button", { name: /Sensors/ })).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: /Transforms & Poses/ }),
+    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Telemetry/ })).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: /Custom \/ Unknown/ }),
+    ).toBeTruthy();
+    expect(screen.getByText("/lidar/top")).toBeTruthy();
     expect(screen.getByText("/imu")).toBeTruthy();
-    expect(screen.getByText("sensor_msgs/Imu · ros1 · 8 msgs")).toBeTruthy();
+    expect(screen.getByText("8 msgs · Plot · Raw")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Inspect /imu" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "3D /lidar/top" })).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Inspect /tf_static" }),
+    ).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Open 3D/ })).toBeNull();
+    expect(screen.queryByRole("button", { name: /^Open / })).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Inspect /broken" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Inspect /binary" }),
+    ).toBeTruthy();
+    expect(screen.queryByText("Inspectable")).toBeNull();
     expect(screen.getByText("Schema unavailable")).toBeTruthy();
     expect(screen.getByText("Encoding unsupported")).toBeTruthy();
   });
 
-  it("opens decodable other topics in a Message panel", () => {
+  it("opens decodable topics in a Message panel without leaving Topics", () => {
     const { probeState } = renderSidebar({
       topics: [
         topic("/imu", {
@@ -226,16 +256,19 @@ describe("McapSettingsSidebar", () => {
       ],
     });
 
-    fireEvent.click(screen.getByRole("button", { name: /Other topics/ }));
+    fireEvent.click(screen.getByRole("tab", { name: "Topics" }));
     fireEvent.click(screen.getByRole("button", { name: "Inspect /imu" }));
 
     const focusedTileId = probeState.current?.focusedTileId;
     expect(focusedTileId?.startsWith("raw-")).toBe(true);
     expect(probeState.current?.titles[focusedTileId ?? ""]).toBe("/imu");
     expect(probeState.current?.topicsByTile[focusedTileId ?? ""]).toBe("/imu");
+    expect(
+      screen.getByRole("tab", { name: "Topics" }).getAttribute("aria-selected"),
+    ).toBe("true");
   });
 
-  it("searches long other topic lists", () => {
+  it("searches long topic lists", () => {
     renderSidebar({
       topics: [
         topic("/alpha", {
@@ -283,13 +316,17 @@ describe("McapSettingsSidebar", () => {
       ],
     });
 
-    fireEvent.click(screen.getByRole("button", { name: /Other topics/ }));
+    fireEvent.click(screen.getByRole("tab", { name: "Topics" }));
 
-    const search = screen.getByLabelText(
-      "Search other topics",
-    ) as HTMLInputElement;
+    const search = screen.getByLabelText("Search topics") as HTMLInputElement;
     expect(search).toBeTruthy();
-    expect(screen.getByText("/alpha")).toBeTruthy();
+    expect(screen.getByText("/camera/front")).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Image /camera/front" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Inspect /camera/front" }),
+    ).toBeTruthy();
 
     fireEvent.change(search, { target: { value: "navsat" } });
 
@@ -299,7 +336,7 @@ describe("McapSettingsSidebar", () => {
 
     fireEvent.change(search, { target: { value: "nothing" } });
 
-    expect(screen.getByText('No other topics match "nothing"')).toBeTruthy();
+    expect(screen.getByText('No topics match "nothing"')).toBeTruthy();
   });
 
   it("switches to the panel tab when a panel tab first appears", () => {

--- a/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.tsx
@@ -1,7 +1,5 @@
 import { useTiling } from "@fiftyone/tiling";
 import {
-  Input,
-  InputType,
   Size,
   Text,
   TextColor,
@@ -16,9 +14,7 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { useSceneInventory } from "../../../scene-inventory/SceneInventoryProvider";
 import type { StreamInventory } from "../../../schemas/v1";
-import { topicName } from "../stream-topics";
 import {
   type McapPlaybackFidelityMode,
   type McapTemporalPolicySettings,
@@ -27,11 +23,9 @@ import {
 } from "./mcap-modal-settings";
 import McapSidebarGroup from "./McapSidebarGroup";
 import styles from "./McapSettingsSidebar.module.css";
-import { useOpenMcapRawMessageTile } from "./use-open-mcap-raw-message-tile";
+import McapTopicsSettings from "./McapTopicsSettings";
 
-type ActiveSettingsTab = "scene" | "panel";
-
-const OTHER_TOPICS_SEARCH_THRESHOLD = 5;
+type ActiveSettingsTab = "panel" | "scene" | "topics";
 
 /**
  * MCAP-specific left sidebar. Panel settings stay on an explicit tab while
@@ -48,19 +42,27 @@ const McapSettingsSidebar: React.FC<{
   const hasPanelTab = focusedTileTitle !== null;
   const [activeTab, setActiveTab] = useState<ActiveSettingsTab>("scene");
   const hadPanelTabRef = useRef(false);
+  const suppressNextPanelAutoSwitchRef = useRef(false);
   const slotRef = useCallback(
     (el: HTMLDivElement | null) => setSettingsSlotEl(el),
     [setSettingsSlotEl],
   );
+  const suppressNextPanelAutoSwitch = useCallback(() => {
+    suppressNextPanelAutoSwitchRef.current = true;
+  }, []);
 
   useLayoutEffect(() => {
     if (hasPanelTab && !hadPanelTabRef.current) {
-      setActiveTab("panel");
-    } else if (!hasPanelTab) {
+      if (suppressNextPanelAutoSwitchRef.current) {
+        suppressNextPanelAutoSwitchRef.current = false;
+      } else {
+        setActiveTab("panel");
+      }
+    } else if (!hasPanelTab && activeTab === "panel") {
       setActiveTab("scene");
     }
     hadPanelTabRef.current = hasPanelTab;
-  }, [hasPanelTab]);
+  }, [activeTab, hasPanelTab]);
 
   const tabs = useMemo<Descriptor<ToggleSwitchTab>[]>(() => {
     const nextTabs: Descriptor<ToggleSwitchTab>[] = [
@@ -68,7 +70,19 @@ const McapSettingsSidebar: React.FC<{
         id: "scene",
         data: {
           label: "Scene",
-          content: <GlobalSceneSettings topics={topics} />,
+          content: <GlobalSceneSettings />,
+        },
+      },
+      {
+        id: "topics",
+        data: {
+          label: "Topics",
+          content: (
+            <McapTopicsSettings
+              onTopicActionStart={suppressNextPanelAutoSwitch}
+              topics={topics}
+            />
+          ),
         },
       },
     ];
@@ -84,13 +98,18 @@ const McapSettingsSidebar: React.FC<{
     }
 
     return nextTabs;
-  }, [focusedTileTitle, slotRef, topics]);
-  const defaultIndex = activeTab === "panel" && hasPanelTab ? 1 : 0;
+  }, [focusedTileTitle, slotRef, suppressNextPanelAutoSwitch, topics]);
+  const defaultIndex = Math.max(
+    0,
+    tabs.findIndex((tab) => tab.id === activeTab),
+  );
   const handleTabChange = useCallback(
     (index: number) => {
-      setActiveTab(index === 1 && hasPanelTab ? "panel" : "scene");
+      setActiveTab(
+        (tabs[index]?.id as ActiveSettingsTab | undefined) ?? "scene",
+      );
     },
-    [hasPanelTab],
+    [tabs],
   );
 
   return (
@@ -119,176 +138,13 @@ function PanelSettingsContent({
   );
 }
 
-function GlobalSceneSettings({
-  topics,
-}: {
-  readonly topics: readonly StreamInventory[];
-}) {
+function GlobalSceneSettings() {
   return (
     <div className={`${styles.root} ${styles.tabContent}`}>
-      <OtherTopicsSettings topics={topics} />
       <PlaybackFidelitySettings />
       <TimeResolutionSettings />
     </div>
   );
-}
-
-interface OtherTopicRow {
-  readonly canInspect: boolean;
-  readonly countLabel: string;
-  readonly encoding: string;
-  readonly schemaName: string;
-  readonly statusLabel: string;
-  readonly topic: string;
-}
-
-function OtherTopicsSettings({
-  topics,
-}: {
-  readonly topics: readonly StreamInventory[];
-}) {
-  const sceneSources = useSceneInventory();
-  const openRawMessageTile = useOpenMcapRawMessageTile();
-  const [search, setSearch] = useState("");
-  const rows = useMemo(
-    () =>
-      otherTopicRows(
-        topics,
-        sceneSources.map((source) => source.id),
-      ),
-    [sceneSources, topics],
-  );
-  const showSearch = rows.length > OTHER_TOPICS_SEARCH_THRESHOLD;
-  const filteredRows = useMemo(
-    () => (showSearch ? filterOtherTopicRows(rows, search) : rows),
-    [rows, search, showSearch],
-  );
-
-  if (rows.length === 0) {
-    return null;
-  }
-
-  return (
-    <McapSidebarGroup
-      defaultExpanded={false}
-      summary={`${rows.length} not rendered`}
-      title="Other topics"
-    >
-      {showSearch ? (
-        <Input
-          aria-label="Search other topics"
-          className={styles.topicSearchInput}
-          onChange={(event) => setSearch(event.target.value)}
-          placeholder="Search topics"
-          size={Size.Sm}
-          type={InputType.Search}
-          value={search}
-        />
-      ) : null}
-      <div className={styles.topicList}>
-        {filteredRows.map((row) => (
-          <div className={styles.topicRow} key={row.topic}>
-            <Text variant={TextVariant.Xs} color={TextColor.Primary}>
-              {row.topic}
-            </Text>
-            <span className={styles.topicMeta}>
-              {row.schemaName} · {row.encoding} · {row.countLabel}
-            </span>
-            {row.canInspect ? (
-              <button
-                aria-label={`Inspect ${row.topic}`}
-                className={styles.topicInspectButton}
-                onClick={() => openRawMessageTile(row.topic)}
-                type="button"
-              >
-                {row.statusLabel}
-              </button>
-            ) : (
-              <span className={styles.topicStatus}>{row.statusLabel}</span>
-            )}
-          </div>
-        ))}
-        {filteredRows.length === 0 ? (
-          <span className={styles.topicEmpty}>
-            No other topics match &quot;{search}&quot;
-          </span>
-        ) : null}
-      </div>
-    </McapSidebarGroup>
-  );
-}
-
-function filterOtherTopicRows(
-  rows: readonly OtherTopicRow[],
-  search: string,
-): readonly OtherTopicRow[] {
-  const needle = search.trim().toLowerCase();
-  if (!needle) {
-    return rows;
-  }
-
-  return rows.filter((row) =>
-    [row.topic, row.schemaName, row.encoding, row.statusLabel].some((value) =>
-      value.toLowerCase().includes(needle),
-    ),
-  );
-}
-
-function otherTopicRows(
-  topics: readonly StreamInventory[],
-  renderedTopicIds: readonly string[],
-): readonly OtherTopicRow[] {
-  const rendered = new Set(renderedTopicIds);
-  return topics
-    .map((topic) => {
-      const name = topicName(topic);
-      if (!name || rendered.has(name)) {
-        return null;
-      }
-      const decodeStatus = genericDecodeStatus(
-        topic.metadata["mcap.generic_decode_status"],
-      );
-      return {
-        canInspect: decodeStatus.canInspect,
-        countLabel: messageCountLabel(topic.recordCount),
-        encoding:
-          topic.metadata["mcap.message_encoding"] ??
-          topic.payload?.encoding ??
-          "unknown",
-        schemaName:
-          topic.metadata["mcap.schema_name"] ??
-          topic.payload?.schema ??
-          "no schema",
-        statusLabel: decodeStatus.label,
-        topic: name,
-      };
-    })
-    .filter((row): row is OtherTopicRow => row !== null)
-    .sort((left, right) => left.topic.localeCompare(right.topic));
-}
-
-function genericDecodeStatus(status: string | undefined): {
-  readonly canInspect: boolean;
-  readonly label: string;
-} {
-  switch (status) {
-    case "decodable":
-      return { canInspect: true, label: "Inspect" };
-    case "schema-unavailable":
-      return { canInspect: false, label: "Schema unavailable" };
-    case "unsupported-encoding":
-      return { canInspect: false, label: "Encoding unsupported" };
-    default:
-      return { canInspect: false, label: "Raw status unknown" };
-  }
-}
-
-function messageCountLabel(recordCount: string | undefined): string {
-  const count = recordCount === undefined ? Number.NaN : Number(recordCount);
-  if (!Number.isFinite(count) || count < 0) {
-    return "unknown msgs";
-  }
-  return `${count.toLocaleString()} ${count === 1 ? "msg" : "msgs"}`;
 }
 
 const FIDELITY_OPTIONS: readonly {

--- a/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.tsx
@@ -52,15 +52,15 @@ const McapSettingsSidebar: React.FC<{
   }, []);
 
   useLayoutEffect(() => {
+    const suppressPanelAutoSwitch = suppressNextPanelAutoSwitchRef.current;
     if (hasPanelTab && !hadPanelTabRef.current) {
-      if (suppressNextPanelAutoSwitchRef.current) {
-        suppressNextPanelAutoSwitchRef.current = false;
-      } else {
+      if (!suppressPanelAutoSwitch) {
         setActiveTab("panel");
       }
     } else if (!hasPanelTab && activeTab === "panel") {
       setActiveTab("scene");
     }
+    suppressNextPanelAutoSwitchRef.current = false;
     hadPanelTabRef.current = hasPanelTab;
   }, [activeTab, hasPanelTab]);
 

--- a/app/packages/multimodal/src/adapters/mcap/react/McapSourcePlayback.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapSourcePlayback.tsx
@@ -22,6 +22,7 @@ import { McapFrameTransformsProvider } from "./mcap-frame-transforms-context";
 import { McapNumericSeriesProvider } from "./mcap-numeric-series-context";
 import { McapPoseTrajectoriesProvider } from "./mcap-pose-trajectories-context";
 import { McapRawMessageProvider } from "./mcap-raw-message-context";
+import { McapSceneUpdateHistoryProvider } from "./mcap-scene-update-history-context";
 import { McapSelectionHotkeys } from "./mcap-selected-object";
 import McapAddTileMenu from "./McapAddTileMenu";
 import McapInspectorSidebar from "./McapInspectorSidebar";
@@ -183,54 +184,56 @@ export const McapSourcePlayback: React.FC<McapSourcePlaybackProps> = ({
     <React.Fragment key={byteSourceAccessKey(source)}>
       <McapFrameTransformsProvider>
         <McapPoseTrajectoriesProvider>
-          <McapNumericSeriesProvider>
-            <McapRawMessageProvider>
-              <McapDataStreamProvider>
-                <Mcap3dViewSettingsProvider
-                  sceneUpAxis={sceneUpAxis}
-                  setSceneUpAxis={onSceneUpAxisChange}
-                >
-                  <MultiModalPlayback
-                    fileName={fileName}
-                    headerCaption={headerCaption}
-                    headerActions={
-                      <McapHeaderActions actions={headerActions} />
-                    }
-                    addTileMenu={<McapAddTileMenu />}
-                    timelineExtraActions={<McapTimestampReadout />}
-                    sceneSources={sources}
-                    deselectFocusedTileOnRepeatSelect={false}
-                    initialTiles={initialTiles}
-                    initialManualTileTitles={initialManualTileTitles}
-                    autoLayoutStrategy={buildMcapAutoLayout}
-                    initialLayout={initialLayout}
-                    initialExpandedTileId={initialExpandedTileId}
-                    tracks={
-                      tracks && tracks.length > 0 ? [...tracks] : undefined
-                    }
-                    onTagDelete={onTagDelete}
-                    leftSidebar={<McapSettingsSidebar topics={topics} />}
-                    rightSidebar={<McapInspectorSidebar />}
-                    defaultRightOpen={false}
-                    defaultLeftOpen={defaultLeftOpen}
-                    onLeftOpenChange={onLeftOpenChange}
-                    leftSidebarWidth={defaultLeftSidebarWidth}
-                    onLeftSidebarWidthChange={onLeftSidebarWidthChange}
-                    onTagCreate={onTagCreate}
+          <McapSceneUpdateHistoryProvider>
+            <McapNumericSeriesProvider>
+              <McapRawMessageProvider>
+                <McapDataStreamProvider>
+                  <Mcap3dViewSettingsProvider
+                    sceneUpAxis={sceneUpAxis}
+                    setSceneUpAxis={onSceneUpAxisChange}
                   >
-                    <McapStreams client={client} source={source} />
-                    <McapNetworkHealthTracker client={client} />
-                    <McapPausedByteBanking client={client} source={source} />
-                    <McapSelectionHotkeys />
-                    {children}
-                    <McapModalLayoutPersistence
-                      datasetId={effectiveLayoutScopeKey}
-                    />
-                  </MultiModalPlayback>
-                </Mcap3dViewSettingsProvider>
-              </McapDataStreamProvider>
-            </McapRawMessageProvider>
-          </McapNumericSeriesProvider>
+                    <MultiModalPlayback
+                      fileName={fileName}
+                      headerCaption={headerCaption}
+                      headerActions={
+                        <McapHeaderActions actions={headerActions} />
+                      }
+                      addTileMenu={<McapAddTileMenu />}
+                      timelineExtraActions={<McapTimestampReadout />}
+                      sceneSources={sources}
+                      deselectFocusedTileOnRepeatSelect={false}
+                      initialTiles={initialTiles}
+                      initialManualTileTitles={initialManualTileTitles}
+                      autoLayoutStrategy={buildMcapAutoLayout}
+                      initialLayout={initialLayout}
+                      initialExpandedTileId={initialExpandedTileId}
+                      tracks={
+                        tracks && tracks.length > 0 ? [...tracks] : undefined
+                      }
+                      onTagDelete={onTagDelete}
+                      leftSidebar={<McapSettingsSidebar topics={topics} />}
+                      rightSidebar={<McapInspectorSidebar />}
+                      defaultRightOpen={false}
+                      defaultLeftOpen={defaultLeftOpen}
+                      onLeftOpenChange={onLeftOpenChange}
+                      leftSidebarWidth={defaultLeftSidebarWidth}
+                      onLeftSidebarWidthChange={onLeftSidebarWidthChange}
+                      onTagCreate={onTagCreate}
+                    >
+                      <McapStreams client={client} source={source} />
+                      <McapNetworkHealthTracker client={client} />
+                      <McapPausedByteBanking client={client} source={source} />
+                      <McapSelectionHotkeys />
+                      {children}
+                      <McapModalLayoutPersistence
+                        datasetId={effectiveLayoutScopeKey}
+                      />
+                    </MultiModalPlayback>
+                  </Mcap3dViewSettingsProvider>
+                </McapDataStreamProvider>
+              </McapRawMessageProvider>
+            </McapNumericSeriesProvider>
+          </McapSceneUpdateHistoryProvider>
         </McapPoseTrajectoriesProvider>
       </McapFrameTransformsProvider>
     </React.Fragment>

--- a/app/packages/multimodal/src/adapters/mcap/react/McapSourcePlayback.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapSourcePlayback.tsx
@@ -19,6 +19,7 @@ import { clearMcap3dViewState } from "./mcap-3d-view-state";
 import { Mcap3dViewSettingsProvider } from "./mcap-3d-view-settings-context";
 import { McapDataStreamProvider } from "./mcap-data-stream-context";
 import { McapFrameTransformsProvider } from "./mcap-frame-transforms-context";
+import { McapLogConsoleProvider } from "./mcap-log-console-context";
 import { McapNumericSeriesProvider } from "./mcap-numeric-series-context";
 import { McapPoseTrajectoriesProvider } from "./mcap-pose-trajectories-context";
 import { McapRawMessageProvider } from "./mcap-raw-message-context";
@@ -187,50 +188,55 @@ export const McapSourcePlayback: React.FC<McapSourcePlaybackProps> = ({
           <McapSceneUpdateHistoryProvider>
             <McapNumericSeriesProvider>
               <McapRawMessageProvider>
-                <McapDataStreamProvider>
-                  <Mcap3dViewSettingsProvider
-                    sceneUpAxis={sceneUpAxis}
-                    setSceneUpAxis={onSceneUpAxisChange}
-                  >
-                    <MultiModalPlayback
-                      fileName={fileName}
-                      headerCaption={headerCaption}
-                      headerActions={
-                        <McapHeaderActions actions={headerActions} />
-                      }
-                      addTileMenu={<McapAddTileMenu />}
-                      timelineExtraActions={<McapTimestampReadout />}
-                      sceneSources={sources}
-                      deselectFocusedTileOnRepeatSelect={false}
-                      initialTiles={initialTiles}
-                      initialManualTileTitles={initialManualTileTitles}
-                      autoLayoutStrategy={buildMcapAutoLayout}
-                      initialLayout={initialLayout}
-                      initialExpandedTileId={initialExpandedTileId}
-                      tracks={
-                        tracks && tracks.length > 0 ? [...tracks] : undefined
-                      }
-                      onTagDelete={onTagDelete}
-                      leftSidebar={<McapSettingsSidebar topics={topics} />}
-                      rightSidebar={<McapInspectorSidebar />}
-                      defaultRightOpen={false}
-                      defaultLeftOpen={defaultLeftOpen}
-                      onLeftOpenChange={onLeftOpenChange}
-                      leftSidebarWidth={defaultLeftSidebarWidth}
-                      onLeftSidebarWidthChange={onLeftSidebarWidthChange}
-                      onTagCreate={onTagCreate}
+                <McapLogConsoleProvider client={client} source={source}>
+                  <McapDataStreamProvider>
+                    <Mcap3dViewSettingsProvider
+                      sceneUpAxis={sceneUpAxis}
+                      setSceneUpAxis={onSceneUpAxisChange}
                     >
-                      <McapStreams client={client} source={source} />
-                      <McapNetworkHealthTracker client={client} />
-                      <McapPausedByteBanking client={client} source={source} />
-                      <McapSelectionHotkeys />
-                      {children}
-                      <McapModalLayoutPersistence
-                        datasetId={effectiveLayoutScopeKey}
-                      />
-                    </MultiModalPlayback>
-                  </Mcap3dViewSettingsProvider>
-                </McapDataStreamProvider>
+                      <MultiModalPlayback
+                        fileName={fileName}
+                        headerCaption={headerCaption}
+                        headerActions={
+                          <McapHeaderActions actions={headerActions} />
+                        }
+                        addTileMenu={<McapAddTileMenu />}
+                        timelineExtraActions={<McapTimestampReadout />}
+                        sceneSources={sources}
+                        deselectFocusedTileOnRepeatSelect={false}
+                        initialTiles={initialTiles}
+                        initialManualTileTitles={initialManualTileTitles}
+                        autoLayoutStrategy={buildMcapAutoLayout}
+                        initialLayout={initialLayout}
+                        initialExpandedTileId={initialExpandedTileId}
+                        tracks={
+                          tracks && tracks.length > 0 ? [...tracks] : undefined
+                        }
+                        onTagDelete={onTagDelete}
+                        leftSidebar={<McapSettingsSidebar topics={topics} />}
+                        rightSidebar={<McapInspectorSidebar />}
+                        defaultRightOpen={false}
+                        defaultLeftOpen={defaultLeftOpen}
+                        onLeftOpenChange={onLeftOpenChange}
+                        leftSidebarWidth={defaultLeftSidebarWidth}
+                        onLeftSidebarWidthChange={onLeftSidebarWidthChange}
+                        onTagCreate={onTagCreate}
+                      >
+                        <McapStreams client={client} source={source} />
+                        <McapNetworkHealthTracker client={client} />
+                        <McapPausedByteBanking
+                          client={client}
+                          source={source}
+                        />
+                        <McapSelectionHotkeys />
+                        {children}
+                        <McapModalLayoutPersistence
+                          datasetId={effectiveLayoutScopeKey}
+                        />
+                      </MultiModalPlayback>
+                    </Mcap3dViewSettingsProvider>
+                  </McapDataStreamProvider>
+                </McapLogConsoleProvider>
               </McapRawMessageProvider>
             </McapNumericSeriesProvider>
           </McapSceneUpdateHistoryProvider>

--- a/app/packages/multimodal/src/adapters/mcap/react/McapStreams.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapStreams.tsx
@@ -10,6 +10,7 @@ import {
 import { McapNumericSeriesBridge } from "./mcap-numeric-series-context";
 import { McapPoseTrajectoriesStartupGate } from "./mcap-pose-trajectories-context";
 import { McapRawMessageBridge } from "./mcap-raw-message-context";
+import { McapSceneUpdateHistoryBridge } from "./mcap-scene-update-history-context";
 import { useMcapDataStream } from "./mcap-data-stream-context";
 import { markMcapLatencyEvent } from "../mcap-latency-debug";
 import {
@@ -102,6 +103,13 @@ export function McapStreams({ client, source }: McapStreamsProps) {
       sources.filter((s) => s.type === MCAP_SOURCE_TYPE.POSE).map((s) => s.id),
     [sources],
   );
+  const sceneAnnotationTopics = useMemo(
+    () =>
+      sources
+        .filter((s) => s.type === MCAP_SOURCE_TYPE.SCENE_ANNOTATION)
+        .map((s) => s.id),
+    [sources],
+  );
 
   useRegisterMcapDataStream({
     blockingTopics,
@@ -126,6 +134,11 @@ export function McapStreams({ client, source }: McapStreamsProps) {
       <McapPoseTrajectoriesStartupGate
         client={client}
         poseTopics={poseTopics}
+        source={source}
+      />
+      <McapSceneUpdateHistoryBridge
+        client={client}
+        sceneAnnotationTopics={sceneAnnotationTopics}
         source={source}
       />
       <McapNumericSeriesBridge client={client} source={source} />

--- a/app/packages/multimodal/src/adapters/mcap/react/McapStreams.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapStreams.tsx
@@ -77,7 +77,8 @@ export function McapStreams({ client, source }: McapStreamsProps) {
             s.type !== MCAP_SOURCE_TYPE.MAP_LAYER &&
             s.type !== MCAP_SOURCE_TYPE.CAMERA_CALIBRATION &&
             s.type !== MCAP_SOURCE_TYPE.POSE &&
-            s.type !== MCAP_SOURCE_TYPE.LOCATION,
+            s.type !== MCAP_SOURCE_TYPE.LOCATION &&
+            s.type !== MCAP_SOURCE_TYPE.LOG,
         )
         .map((s) => s.id),
     [sources],

--- a/app/packages/multimodal/src/adapters/mcap/react/McapTopicsSettings.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapTopicsSettings.tsx
@@ -1,7 +1,7 @@
 import { useTiling } from "@fiftyone/tiling";
 import { Input, InputType, Size } from "@voxel51/voodo";
 import React, { useCallback, useMemo, useState } from "react";
-import { useSceneInventory } from "../../../scene-inventory";
+import { useSceneInventory } from "../../../scene-inventory/SceneInventoryProvider";
 import type { StreamInventory } from "../../../schemas/v1";
 import { MCAP_SOURCE_TYPE } from "../scene-sources";
 import {

--- a/app/packages/multimodal/src/adapters/mcap/react/McapTopicsSettings.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapTopicsSettings.tsx
@@ -1,0 +1,272 @@
+import { useTiling } from "@fiftyone/tiling";
+import { Input, InputType, Size } from "@voxel51/voodo";
+import React, { useCallback, useMemo, useState } from "react";
+import { useSceneInventory } from "../../../scene-inventory";
+import type { StreamInventory } from "../../../schemas/v1";
+import { MCAP_SOURCE_TYPE } from "../scene-sources";
+import {
+  MCAP_TOPIC_CAPABILITY,
+  MCAP_TOPIC_CAPABILITY_LABEL,
+  MCAP_TOPIC_CATEGORY,
+  MCAP_TOPIC_CATEGORY_LABEL,
+  MCAP_TOPIC_CATEGORY_ORDER,
+  MCAP_TOPIC_SUPPORT_LABEL,
+  buildMcapTopicInventoryRows,
+  filterMcapTopicInventoryRows,
+  type McapTopicInventoryRow,
+} from "../topic-inventory";
+import McapSidebarGroup from "./McapSidebarGroup";
+import styles from "./McapSettingsSidebar.module.css";
+import { MCAP_TILE_TYPE, type McapTileType } from "./mcap-tile-types";
+import { getMcapTileDefinition } from "./use-mcap-tiles";
+import { useOpenMcapImageTile } from "./use-open-mcap-image-tile";
+import { useOpenMcapRawMessageTile } from "./use-open-mcap-raw-message-tile";
+
+const TOPICS_SEARCH_THRESHOLD = 5;
+
+const McapTopicsSettings: React.FC<{
+  readonly onTopicActionStart?: () => void;
+  readonly topics: readonly StreamInventory[];
+}> = ({ onTopicActionStart, topics }) => {
+  const sceneSources = useSceneInventory();
+  const openImageTile = useOpenMcapImageTile();
+  const openRawMessageTile = useOpenMcapRawMessageTile();
+  const open3dTile = useOpenMcapPanelTile(MCAP_TILE_TYPE.THREE_D);
+  const openLogTile = useOpenMcapPanelTile(MCAP_TILE_TYPE.LOG);
+  const [search, setSearch] = useState("");
+  const rows = useMemo(
+    () => buildMcapTopicInventoryRows({ sceneSources, topics }),
+    [sceneSources, topics],
+  );
+  const showSearch = rows.length > TOPICS_SEARCH_THRESHOLD;
+  const filteredRows = useMemo(
+    () => (showSearch ? filterMcapTopicInventoryRows(rows, search) : rows),
+    [rows, search, showSearch],
+  );
+  const groups = useMemo(
+    () =>
+      MCAP_TOPIC_CATEGORY_ORDER.map((category) => ({
+        category,
+        rows: filteredRows.filter((row) => row.category === category),
+      })).filter((group) => group.rows.length > 0),
+    [filteredRows],
+  );
+  const actionHandlers = useMemo(
+    () => ({
+      open3dTile,
+      openImageTile,
+      openLogTile,
+      openRawMessageTile,
+    }),
+    [open3dTile, openImageTile, openLogTile, openRawMessageTile],
+  );
+
+  return (
+    <div className={`${styles.root} ${styles.tabContent}`}>
+      {rows.length === 0 ? (
+        <span className={styles.topicEmpty}>No topics found</span>
+      ) : (
+        <>
+          {showSearch ? (
+            <Input
+              aria-label="Search topics"
+              className={styles.topicSearchInput}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Search topics"
+              size={Size.Sm}
+              type={InputType.Search}
+              value={search}
+            />
+          ) : null}
+          <div className={styles.topicGroups}>
+            {groups.map((group) => (
+              <McapSidebarGroup
+                key={group.category}
+                summary={topicCountLabel(group.rows.length)}
+                title={MCAP_TOPIC_CATEGORY_LABEL[group.category]}
+              >
+                <div className={styles.topicList}>
+                  {group.rows.map((row) => (
+                    <TopicRow
+                      actionHandlers={actionHandlers}
+                      key={row.topic}
+                      onTopicActionStart={onTopicActionStart}
+                      row={row}
+                    />
+                  ))}
+                </div>
+              </McapSidebarGroup>
+            ))}
+            {filteredRows.length === 0 ? (
+              <span className={styles.topicEmpty}>
+                No topics match &quot;{search}&quot;
+              </span>
+            ) : null}
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+function TopicRow({
+  actionHandlers,
+  onTopicActionStart,
+  row,
+}: {
+  readonly actionHandlers: TopicActionHandlers;
+  readonly onTopicActionStart?: () => void;
+  readonly row: McapTopicInventoryRow;
+}) {
+  const actions = topicActionsForRow(row, actionHandlers);
+  const statusLabel = visibleTopicStatusLabel(row);
+  const capabilitySummary = row.capabilities
+    .map((capability) => MCAP_TOPIC_CAPABILITY_LABEL[capability])
+    .join(" · ");
+
+  return (
+    <div className={styles.topicRow} title={topicDetails(row)}>
+      <div className={styles.topicRowHeader}>
+        <span className={styles.topicName}>{row.topic}</span>
+        {statusLabel ? (
+          <span className={styles.topicStatus}>{statusLabel}</span>
+        ) : null}
+      </div>
+      <div className={styles.topicMetaLine}>
+        <span className={styles.topicMeta}>
+          {row.countLabel}
+          {capabilitySummary ? ` · ${capabilitySummary}` : ""}
+        </span>
+        <div className={styles.topicActions}>
+          {actions.map((action) => (
+            <button
+              aria-label={action.ariaLabel}
+              className={styles.topicActionButton}
+              key={action.id}
+              onClick={() => {
+                onTopicActionStart?.();
+                action.onClick();
+              }}
+              type="button"
+            >
+              {action.label}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface TopicActionHandlers {
+  readonly open3dTile: () => void;
+  readonly openImageTile: (sourceId: string) => void;
+  readonly openLogTile: () => void;
+  readonly openRawMessageTile: (topic: string) => void;
+}
+
+interface TopicAction {
+  readonly ariaLabel: string;
+  readonly id: string;
+  readonly label: string;
+  readonly onClick: () => void;
+}
+
+function topicActionsForRow(
+  row: McapTopicInventoryRow,
+  handlers: TopicActionHandlers,
+): readonly TopicAction[] {
+  const actions: TopicAction[] = [];
+
+  if (row.sourceType === MCAP_SOURCE_TYPE.IMAGE) {
+    actions.push({
+      ariaLabel: `Image ${row.topic}`,
+      id: "image",
+      label: "Image",
+      onClick: () => handlers.openImageTile(row.topic),
+    });
+  }
+
+  if (
+    row.category !== MCAP_TOPIC_CATEGORY.TRANSFORMS_POSES &&
+    row.capabilities.includes(MCAP_TOPIC_CAPABILITY.THREE_D)
+  ) {
+    actions.push({
+      ariaLabel: `3D ${row.topic}`,
+      id: "3d",
+      label: "3D",
+      onClick: handlers.open3dTile,
+    });
+  }
+
+  if (row.capabilities.includes(MCAP_TOPIC_CAPABILITY.LOGS)) {
+    actions.push({
+      ariaLabel: `Logs ${row.topic}`,
+      id: "logs",
+      label: "Logs",
+      onClick: handlers.openLogTile,
+    });
+  }
+
+  actions.push({
+    ariaLabel: `Inspect ${row.topic}`,
+    id: "inspect",
+    label: "Inspect",
+    onClick: () => handlers.openRawMessageTile(row.topic),
+  });
+
+  return actions;
+}
+
+function visibleTopicStatusLabel(row: McapTopicInventoryRow): string | null {
+  if (
+    row.supportStatus === "renderable" ||
+    row.supportStatus === "inspectable"
+  ) {
+    return null;
+  }
+  return MCAP_TOPIC_SUPPORT_LABEL[row.supportStatus];
+}
+
+function useOpenMcapPanelTile(type: McapTileType): () => void {
+  const { addTile, setFocusedTileId, tiles } = useTiling();
+
+  return useCallback(() => {
+    const existingTileId = Object.keys(tiles).find(
+      (tileId) => tiles[tileId]?.type === type,
+    );
+    if (existingTileId) {
+      setFocusedTileId(existingTileId);
+      return;
+    }
+
+    const definition = getMcapTileDefinition(type);
+    if (!definition) {
+      return;
+    }
+    const Tile = definition.Tile;
+    addTile(
+      {
+        render: () => <Tile />,
+        title: definition.typeLabel,
+        type,
+      },
+      { idPrefix: type },
+    );
+  }, [addTile, setFocusedTileId, tiles, type]);
+}
+
+function topicDetails(row: McapTopicInventoryRow): string {
+  return [
+    row.schemaName,
+    row.encoding,
+    MCAP_TOPIC_CATEGORY_LABEL[row.category],
+    MCAP_TOPIC_SUPPORT_LABEL[row.supportStatus],
+  ].join(" · ");
+}
+
+function topicCountLabel(count: number): string {
+  return `${count.toLocaleString()} ${count === 1 ? "topic" : "topics"}`;
+}
+
+export default McapTopicsSettings;

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-log-console-context.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-log-console-context.tsx
@@ -1,0 +1,35 @@
+import React, { createContext, useContext, useMemo } from "react";
+import type { ByteSourceDescriptor } from "../../../query/bytes";
+import type { McapResourceClient } from "../types";
+
+export interface McapLogConsoleContextValue {
+  readonly client: McapResourceClient;
+  readonly source: ByteSourceDescriptor | null;
+}
+
+const McapLogConsoleContext = createContext<McapLogConsoleContextValue | null>(
+  null,
+);
+
+export const McapLogConsoleProvider: React.FC<{
+  readonly children: React.ReactNode;
+  readonly client: McapResourceClient;
+  readonly source: ByteSourceDescriptor | null;
+}> = ({ children, client, source }) => {
+  const value = useMemo(() => ({ client, source }), [client, source]);
+  return (
+    <McapLogConsoleContext.Provider value={value}>
+      {children}
+    </McapLogConsoleContext.Provider>
+  );
+};
+
+export function useMcapLogConsoleContext(): McapLogConsoleContextValue {
+  const value = useContext(McapLogConsoleContext);
+  if (!value) {
+    throw new Error(
+      "useMcapLogConsoleContext must be used inside <McapLogConsoleProvider>",
+    );
+  }
+  return value;
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-log-console-rows.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-log-console-rows.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import type { McapDecodedMessage } from "../types";
+import { logConsoleRowsFromDecodedMessage } from "./mcap-log-console-rows";
+
+describe("logConsoleRowsFromDecodedMessage", () => {
+  it("expands decoder logRows into console rows with diagnostic grouping", () => {
+    const rows = logConsoleRowsFromDecodedMessage(
+      decodedMessage({
+        attributes: {
+          logRows: [
+            {
+              details: [{ key: "drop_rate", value: "0.2" }],
+              hardwareId: "lidar-top",
+              kind: "diagnostic",
+              level: "error",
+              message: "packet drops",
+              name: "driver",
+              status: "ERROR",
+              timestampNs: 7_000_000_009n,
+            },
+          ],
+        },
+        topic: "/diagnostics",
+      }),
+    );
+
+    expect(rows).toEqual([
+      expect.objectContaining({
+        details: [{ key: "drop_rate", value: "0.2" }],
+        groupLabel: "lidar-top / driver",
+        kind: "diagnostic",
+        level: "error",
+        message: "packet drops",
+        status: "ERROR",
+        timeNs: 7_000_000_009n,
+        topic: "/diagnostics",
+      }),
+    ]);
+  });
+
+  it("falls back to top-level message attributes and timeline time", () => {
+    const rows = logConsoleRowsFromDecodedMessage(
+      decodedMessage({
+        attributes: {
+          level: "warn",
+          message: "tracking degraded",
+          name: "controller",
+        },
+        timelineTimeNs: 5_000_000_004n,
+        topic: "/rosout",
+      }),
+    );
+
+    expect(rows).toEqual([
+      expect.objectContaining({
+        groupLabel: "controller",
+        level: "warn",
+        message: "tracking degraded",
+        timeNs: 5_000_000_004n,
+        topic: "/rosout",
+      }),
+    ]);
+  });
+});
+
+function decodedMessage({
+  attributes,
+  timelineTimeNs = 1n,
+  topic,
+}: {
+  readonly attributes: NonNullable<
+    McapDecodedMessage["decoded"]["output"]["attributes"]
+  >;
+  readonly timelineTimeNs?: bigint;
+  readonly topic: string;
+}): McapDecodedMessage {
+  return {
+    activeTimeline: "log",
+    channelId: 1,
+    decoded: {
+      decoderId: "test",
+      decoderVersion: "1",
+      output: { attributes },
+      payload: {
+        encoding: "json",
+        schema: "test",
+        schemaEncoding: "jsonschema",
+      },
+    },
+    encodedPayloadBytes: 1,
+    logTimeNs: timelineTimeNs,
+    publishTimeNs: timelineTimeNs,
+    sequence: 3,
+    timelineTimeNs,
+    topic,
+  };
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-log-console-rows.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-log-console-rows.test.ts
@@ -61,6 +61,17 @@ describe("logConsoleRowsFromDecodedMessage", () => {
       }),
     ]);
   });
+
+  it("returns no rows when logRows is empty and no fallback message exists", () => {
+    const rows = logConsoleRowsFromDecodedMessage(
+      decodedMessage({
+        attributes: {},
+        topic: "/empty",
+      }),
+    );
+
+    expect(rows).toEqual([]);
+  });
 });
 
 function decodedMessage({

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-log-console-rows.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-log-console-rows.ts
@@ -1,0 +1,158 @@
+import type { DecodedAttributeValue } from "../../../decoders";
+import {
+  MCAP_LOG_ATTRIBUTE_ROWS,
+  MCAP_LOG_LEVEL,
+  MCAP_LOG_LEVELS,
+  type McapLogLevel,
+} from "../log-records";
+import type { McapDecodedMessage } from "../types";
+
+export interface McapLogConsoleRow {
+  readonly details: readonly { readonly key: string; readonly value: string }[];
+  readonly file?: string;
+  readonly functionName?: string;
+  readonly groupLabel?: string;
+  readonly hardwareId?: string;
+  readonly id: string;
+  readonly kind: "diagnostic" | "log";
+  readonly level: McapLogLevel;
+  readonly levelNumber?: number;
+  readonly line?: number;
+  readonly message: string;
+  readonly name?: string;
+  readonly status?: string;
+  readonly timeNs: bigint;
+  readonly topic: string;
+}
+
+const LOG_LEVEL_SET = new Set(MCAP_LOG_LEVELS);
+
+export function logConsoleRowsFromDecodedMessage(
+  message: McapDecodedMessage,
+): readonly McapLogConsoleRow[] {
+  const attributes = message.decoded.output.attributes ?? {};
+  const rows = arrayValue(attributes[MCAP_LOG_ATTRIBUTE_ROWS])
+    .map(recordValue)
+    .filter(isRecord);
+
+  if (rows.length === 0) {
+    const fallbackMessage = stringValue(attributes.message);
+    if (!fallbackMessage) {
+      return [];
+    }
+    return [
+      buildRow({
+        index: 0,
+        message,
+        record: attributes,
+      }),
+    ];
+  }
+
+  return rows.map((record, index) =>
+    buildRow({
+      index,
+      message,
+      record,
+    }),
+  );
+}
+
+function buildRow({
+  index,
+  message,
+  record,
+}: {
+  readonly index: number;
+  readonly message: McapDecodedMessage;
+  readonly record: Record<string, DecodedAttributeValue>;
+}): McapLogConsoleRow {
+  const hardwareId = stringValue(record.hardwareId);
+  const name = stringValue(record.name);
+
+  return {
+    details: arrayValue(record.details)
+      .map(recordValue)
+      .filter(isRecord)
+      .map((detail) => ({
+        key: stringValue(detail.key) ?? "",
+        value: stringValue(detail.value) ?? "",
+      }))
+      .filter((detail) => detail.key || detail.value),
+    file: stringValue(record.file),
+    functionName: stringValue(record.functionName),
+    groupLabel: logGroupLabel(hardwareId, name),
+    hardwareId,
+    id: `${message.topic}:${message.timelineTimeNs.toString()}:${message.sequence}:${index}`,
+    kind: stringValue(record.kind) === "diagnostic" ? "diagnostic" : "log",
+    level: logLevelValue(record.level),
+    levelNumber: numberValue(record.levelNumber),
+    line: numberValue(record.line),
+    message: stringValue(record.message) ?? "",
+    name,
+    status: stringValue(record.status),
+    timeNs: bigintValue(record.timestampNs) ?? message.timelineTimeNs,
+    topic: message.topic,
+  };
+}
+
+function logGroupLabel(
+  hardwareId: string | undefined,
+  name: string | undefined,
+): string | undefined {
+  if (hardwareId && name) return `${hardwareId} / ${name}`;
+  return hardwareId ?? name;
+}
+
+function logLevelValue(value: DecodedAttributeValue | undefined): McapLogLevel {
+  return typeof value === "string" && LOG_LEVEL_SET.has(value as McapLogLevel)
+    ? (value as McapLogLevel)
+    : MCAP_LOG_LEVEL.UNKNOWN;
+}
+
+function arrayValue(
+  value: DecodedAttributeValue | undefined,
+): readonly DecodedAttributeValue[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function recordValue(
+  value: DecodedAttributeValue,
+): Record<string, DecodedAttributeValue> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, DecodedAttributeValue>)
+    : null;
+}
+
+function isRecord(
+  value: Record<string, DecodedAttributeValue> | null,
+): value is Record<string, DecodedAttributeValue> {
+  return value !== null;
+}
+
+function stringValue(value: DecodedAttributeValue | undefined) {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function numberValue(value: DecodedAttributeValue | undefined) {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : typeof value === "bigint"
+      ? Number(value)
+      : undefined;
+}
+
+function bigintValue(value: DecodedAttributeValue | undefined) {
+  if (typeof value === "bigint") return value;
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return BigInt(Math.round(value));
+  }
+  if (typeof value === "string" && value) {
+    try {
+      return BigInt(value);
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-scene-update-history-context.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-scene-update-history-context.tsx
@@ -1,0 +1,223 @@
+import { PlaybackStoreContext } from "@fiftyone/playback/src/lib/playback/playback-store-context";
+import { getIsPlaying } from "@fiftyone/playback/src/lib/playback/store-access";
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import type { ByteSourceDescriptor } from "../../../query/bytes";
+import { byteSourceAccessKey } from "../../../query/bytes";
+import { VISUALIZATION_KIND } from "../../../visualization";
+import { MCAP_ACTIVE_TIMELINE, type McapResourceClient } from "../types";
+import {
+  getMcapNetworkHealth,
+  shouldDeferMcapIdleWorkForStore,
+} from "./mcap-network-health";
+import type { McapSceneUpdateDelta } from "./mcap-scene-update-state";
+
+const SCENE_UPDATE_HISTORY_READ_LIMIT = 50_000;
+const SCENE_UPDATE_HISTORY_START_DELAY_MS = 1_500;
+const SCENE_UPDATE_HISTORY_DEFERRED_RETRY_MS = 2_000;
+
+export interface McapSceneUpdateHistoryTopic {
+  readonly deltas: readonly McapSceneUpdateDelta[];
+  readonly status: "error" | "loading" | "ready";
+  readonly truncated?: boolean;
+}
+
+export type McapSceneUpdateHistory = ReadonlyMap<
+  string,
+  McapSceneUpdateHistoryTopic
+>;
+
+const EMPTY_HISTORY: McapSceneUpdateHistory = new Map();
+
+interface McapSceneUpdateHistoryContextValue {
+  readonly history: McapSceneUpdateHistory;
+  readonly setHistory: (state: McapSceneUpdateHistory) => void;
+}
+
+const McapSceneUpdateHistoryContext =
+  createContext<McapSceneUpdateHistoryContextValue | null>(null);
+
+/**
+ * Shares full-topic scene-update histories with 3D tiles. These histories are
+ * needed for correctness on stateful streams such as ROS MarkerArray: the
+ * latest delta at a seek target is not enough to reconstruct older persistent
+ * marker ids.
+ */
+export const McapSceneUpdateHistoryProvider: React.FC<{
+  children: React.ReactNode;
+}> = ({ children }) => {
+  const [history, setHistory] = useState<McapSceneUpdateHistory>(EMPTY_HISTORY);
+  const value = useMemo(() => ({ history, setHistory }), [history]);
+
+  return (
+    <McapSceneUpdateHistoryContext.Provider value={value}>
+      {children}
+    </McapSceneUpdateHistoryContext.Provider>
+  );
+};
+
+export function useMcapSceneUpdateHistoryContext(): McapSceneUpdateHistory {
+  return useContext(McapSceneUpdateHistoryContext)?.history ?? EMPTY_HISTORY;
+}
+
+export function McapSceneUpdateHistoryBridge({
+  client,
+  sceneAnnotationTopics,
+  source,
+}: {
+  readonly client: McapResourceClient;
+  readonly sceneAnnotationTopics: readonly string[];
+  readonly source: ByteSourceDescriptor | null;
+}) {
+  const { setHistory } = useContextValue();
+  const sourceKey = source ? byteSourceAccessKey(source) : null;
+  const fetchedTopicsRef = useRef(new Set<string>());
+  const historyRef = useRef(new Map<string, McapSceneUpdateHistoryTopic>());
+  const playbackStore = useContext(PlaybackStoreContext);
+
+  useEffect(() => {
+    fetchedTopicsRef.current = new Set();
+    historyRef.current = new Map();
+    setHistory(EMPTY_HISTORY);
+
+    if (!sourceKey || !source || sceneAnnotationTopics.length === 0) {
+      return undefined;
+    }
+
+    let cancelled = false;
+    let retryTimeout: ReturnType<typeof setTimeout> | null = null;
+    const activeTopics = new Set(sceneAnnotationTopics);
+    const commit = (topic: string, state: McapSceneUpdateHistoryTopic) => {
+      if (cancelled) {
+        return;
+      }
+      historyRef.current.set(topic, state);
+      setHistory(new Map(historyRef.current));
+    };
+
+    const shouldStandDown = (): boolean => {
+      if (!playbackStore) {
+        return false;
+      }
+      if (
+        getIsPlaying(playbackStore) &&
+        getMcapNetworkHealth(playbackStore).limited
+      ) {
+        return true;
+      }
+      return shouldDeferMcapIdleWorkForStore(playbackStore, null);
+    };
+
+    const scheduleRetry = (delayMs: number) => {
+      if (cancelled || retryTimeout !== null) {
+        return;
+      }
+      retryTimeout = setTimeout(() => {
+        retryTimeout = null;
+        start();
+      }, delayMs);
+    };
+
+    const start = () => {
+      if (cancelled) {
+        return;
+      }
+      if (shouldStandDown()) {
+        scheduleRetry(SCENE_UPDATE_HISTORY_DEFERRED_RETRY_MS);
+        return;
+      }
+
+      for (const topic of sceneAnnotationTopics) {
+        if (!activeTopics.has(topic) || fetchedTopicsRef.current.has(topic)) {
+          continue;
+        }
+        fetchedTopicsRef.current.add(topic);
+        commit(topic, { deltas: [], status: "loading" });
+
+        void (async () => {
+          const deltas: McapSceneUpdateDelta[] = [];
+          try {
+            for await (const message of client.readDecodedMessages(
+              {
+                activeTimeline: MCAP_ACTIVE_TIMELINE.LOG,
+                limit: SCENE_UPDATE_HISTORY_READ_LIMIT,
+                source,
+                topics: [topic],
+              },
+              { priority: "bulk" },
+            )) {
+              if (cancelled) {
+                return;
+              }
+              if (shouldStandDown()) {
+                fetchedTopicsRef.current.delete(topic);
+                scheduleRetry(SCENE_UPDATE_HISTORY_DEFERRED_RETRY_MS);
+                return;
+              }
+              const visualization = message.decoded.output.visualization;
+              if (visualization?.kind !== VISUALIZATION_KIND.SCENE_UPDATE) {
+                continue;
+              }
+              deltas.push({
+                timeNs: message.timelineTimeNs,
+                update: visualization,
+              });
+            }
+
+            commit(topic, {
+              deltas,
+              status: "ready",
+              ...(deltas.length >= SCENE_UPDATE_HISTORY_READ_LIMIT
+                ? { truncated: true }
+                : {}),
+            });
+          } catch {
+            commit(topic, { deltas: [], status: "error" });
+          }
+        })();
+      }
+    };
+
+    scheduleRetry(SCENE_UPDATE_HISTORY_START_DELAY_MS);
+
+    return () => {
+      cancelled = true;
+      if (retryTimeout !== null) {
+        clearTimeout(retryTimeout);
+      }
+    };
+  }, [
+    client,
+    playbackStore,
+    sceneAnnotationTopics,
+    setHistory,
+    source,
+    sourceKey,
+  ]);
+
+  useEffect(
+    () => () => {
+      setHistory(EMPTY_HISTORY);
+    },
+    [setHistory],
+  );
+
+  return null;
+}
+
+function useContextValue(): McapSceneUpdateHistoryContextValue {
+  const value = useContext(McapSceneUpdateHistoryContext);
+  if (!value) {
+    throw new Error(
+      "MCAP scene update history must be used inside <McapSceneUpdateHistoryProvider>",
+    );
+  }
+  return value;
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-scene-update-history-context.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-scene-update-history-context.tsx
@@ -143,6 +143,7 @@ export function McapSceneUpdateHistoryBridge({
 
         void (async () => {
           const deltas: McapSceneUpdateDelta[] = [];
+          let messageCount = 0;
           try {
             for await (const message of client.readDecodedMessages(
               {
@@ -161,6 +162,7 @@ export function McapSceneUpdateHistoryBridge({
                 scheduleRetry(SCENE_UPDATE_HISTORY_DEFERRED_RETRY_MS);
                 return;
               }
+              messageCount += 1;
               const visualization = message.decoded.output.visualization;
               if (visualization?.kind !== VISUALIZATION_KIND.SCENE_UPDATE) {
                 continue;
@@ -174,7 +176,7 @@ export function McapSceneUpdateHistoryBridge({
             commit(topic, {
               deltas,
               status: "ready",
-              ...(deltas.length >= SCENE_UPDATE_HISTORY_READ_LIMIT
+              ...(messageCount >= SCENE_UPDATE_HISTORY_READ_LIMIT
                 ? { truncated: true }
                 : {}),
             });

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-scene-update-state.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-scene-update-state.test.ts
@@ -21,6 +21,19 @@ describe("sceneUpdateSnapshotAt", () => {
     expect(snapshot.entities[0]?.metadata.label).toBe("new");
   });
 
+  it("sorts deltas before folding", () => {
+    const snapshot = sceneUpdateSnapshotAt(
+      [
+        updateDelta(20n, [entity("box", { label: "new" })]),
+        updateDelta(10n, [entity("box", { label: "old" })]),
+      ],
+      20n,
+    );
+
+    expect(snapshot.entities).toHaveLength(1);
+    expect(snapshot.entities[0]?.metadata.label).toBe("new");
+  });
+
   it("applies matching and all-entity deletions before upserts", () => {
     const snapshot = sceneUpdateSnapshotAt(
       [

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-scene-update-state.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-scene-update-state.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  SceneEntityVisualization,
+  SceneUpdateVisualization,
+} from "../../../decoders";
+import { VISUALIZATION_KIND } from "../../../visualization";
+import { sceneUpdateSnapshotAt } from "./mcap-scene-update-state";
+
+describe("sceneUpdateSnapshotAt", () => {
+  it("upserts scene entities by id", () => {
+    const snapshot = sceneUpdateSnapshotAt(
+      [
+        updateDelta(10n, [entity("box", { label: "old" })]),
+        updateDelta(20n, [entity("box", { label: "new" })]),
+      ],
+      20n,
+    );
+
+    expect(snapshot.entities).toHaveLength(1);
+    expect(snapshot.entities[0]?.metadata.label).toBe("new");
+  });
+
+  it("applies matching and all-entity deletions before upserts", () => {
+    const snapshot = sceneUpdateSnapshotAt(
+      [
+        updateDelta(10n, [entity("old"), entity("kept")]),
+        {
+          timeNs: 20n,
+          update: {
+            deletions: [
+              { id: "old", type: "matching-id" },
+              { id: "", type: "all" },
+            ],
+            entities: [entity("replacement")],
+            kind: VISUALIZATION_KIND.SCENE_UPDATE,
+          },
+        },
+      ],
+      20n,
+    );
+
+    expect(snapshot.entities.map((e) => e.id)).toEqual(["replacement"]);
+  });
+
+  it("expires entity lifetimes relative to entity timestamps", () => {
+    const beforeExpiry = sceneUpdateSnapshotAt(
+      [updateDelta(10n, [entity("short", {}, 10n, 5n)])],
+      14n,
+    );
+    const afterExpiry = sceneUpdateSnapshotAt(
+      [updateDelta(10n, [entity("short", {}, 10n, 5n)])],
+      15n,
+    );
+
+    expect(beforeExpiry.entities.map((e) => e.id)).toEqual(["short"]);
+    expect(afterExpiry.entities).toEqual([]);
+  });
+});
+
+function updateDelta(
+  timeNs: bigint,
+  entities: readonly SceneEntityVisualization[],
+) {
+  return {
+    timeNs,
+    update: {
+      deletions: [],
+      entities,
+      kind: VISUALIZATION_KIND.SCENE_UPDATE,
+    } satisfies SceneUpdateVisualization,
+  };
+}
+
+function entity(
+  id: string,
+  metadata: Readonly<Record<string, string>> = {},
+  timestampNs?: bigint,
+  lifetimeNs?: bigint,
+): SceneEntityVisualization {
+  return {
+    arrowCount: 0,
+    arrows: [],
+    cubeCount: 0,
+    cubes: [],
+    cylinderCount: 0,
+    cylinders: [],
+    frameLocked: false,
+    id,
+    lineCount: 0,
+    lines: [],
+    ...(lifetimeNs !== undefined ? { lifetimeNs } : {}),
+    metadata,
+    modelCount: 0,
+    models: [],
+    sphereCount: 0,
+    spheres: [],
+    textCount: 0,
+    texts: [],
+    ...(timestampNs !== undefined ? { timestampNs } : {}),
+    triangleCount: 0,
+    triangles: [],
+  };
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-scene-update-state.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-scene-update-state.test.ts
@@ -43,6 +43,25 @@ describe("sceneUpdateSnapshotAt", () => {
     expect(snapshot.entities.map((e) => e.id)).toEqual(["replacement"]);
   });
 
+  it("skips deletions whose own timestamp is after the playhead", () => {
+    const snapshot = sceneUpdateSnapshotAt(
+      [
+        updateDelta(10n, [entity("kept")]),
+        {
+          timeNs: 20n,
+          update: {
+            deletions: [{ id: "kept", timestampNs: 30n, type: "matching-id" }],
+            entities: [],
+            kind: VISUALIZATION_KIND.SCENE_UPDATE,
+          },
+        },
+      ],
+      20n,
+    );
+
+    expect(snapshot.entities.map((e) => e.id)).toEqual(["kept"]);
+  });
+
   it("expires entity lifetimes relative to entity timestamps", () => {
     const beforeExpiry = sceneUpdateSnapshotAt(
       [updateDelta(10n, [entity("short", {}, 10n, 5n)])],

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-scene-update-state.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-scene-update-state.ts
@@ -14,6 +14,11 @@ interface SceneEntityRecord {
   readonly updatedAtNs: bigint;
 }
 
+const SORTED_DELTAS_CACHE = new WeakMap<
+  readonly McapSceneUpdateDelta[],
+  readonly McapSceneUpdateDelta[]
+>();
+
 /**
  * Folds scene-update deltas into a render snapshot at one playhead time.
  *
@@ -36,7 +41,7 @@ export function sceneUpdateSnapshotAt(
 ): SceneUpdateVisualization {
   const state = new Map<string, SceneEntityRecord>();
 
-  for (const delta of [...deltas].sort(compareSceneUpdateDeltas)) {
+  for (const delta of sortedSceneUpdateDeltas(deltas)) {
     if (delta.timeNs > timeNs) {
       break;
     }
@@ -49,6 +54,35 @@ export function sceneUpdateSnapshotAt(
     entities: [...state.values()].map((record) => record.entity),
     kind: VISUALIZATION_KIND.SCENE_UPDATE,
   };
+}
+
+function sortedSceneUpdateDeltas(
+  deltas: readonly McapSceneUpdateDelta[],
+): readonly McapSceneUpdateDelta[] {
+  const cached = SORTED_DELTAS_CACHE.get(deltas);
+  if (cached) {
+    return cached;
+  }
+
+  const sorted = isSortedByTime(deltas)
+    ? deltas
+    : [...deltas].sort(compareSceneUpdateDeltas);
+  SORTED_DELTAS_CACHE.set(deltas, sorted);
+  return sorted;
+}
+
+function isSortedByTime(deltas: readonly McapSceneUpdateDelta[]): boolean {
+  for (let index = 1; index < deltas.length; index++) {
+    const previous = deltas[index - 1];
+    const current = deltas[index];
+    if (!previous || !current) {
+      continue;
+    }
+    if (previous.timeNs > current.timeNs) {
+      return false;
+    }
+  }
+  return true;
 }
 
 function applySceneUpdateDelta(

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-scene-update-state.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-scene-update-state.ts
@@ -1,0 +1,118 @@
+import { VISUALIZATION_KIND } from "../../../visualization";
+import type {
+  SceneEntityVisualization,
+  SceneUpdateVisualization,
+} from "../../../decoders";
+
+export interface McapSceneUpdateDelta {
+  readonly timeNs: bigint;
+  readonly update: SceneUpdateVisualization;
+}
+
+interface SceneEntityRecord {
+  readonly entity: SceneEntityVisualization;
+  readonly expiresAtNs?: bigint;
+  readonly updatedAtNs: bigint;
+}
+
+/**
+ * Folds scene-update deltas into a render snapshot at one playhead time.
+ *
+ * SceneUpdate and ROS MarkerArray are state-update streams: ADD/MODIFY
+ * upserts by id, DELETE removes by id, DELETEALL clears the topic, and
+ * lifetimes expire relative to the message/entity timestamp. The renderer
+ * wants a full entity snapshot, so this fold is intentionally pure and
+ * deterministic; callers can cache or rebuild around it depending on the
+ * playback path.
+ *
+ * Within one SceneUpdate message, deletions are applied before entity upserts.
+ * The wire shape stores them in separate arrays, so true interleaving order is
+ * unavailable. This ordering supports the common "clear all, then publish a
+ * full replacement snapshot" pattern while remaining stable for Foxglove and
+ * ROS marker streams.
+ */
+export function sceneUpdateSnapshotAt(
+  deltas: readonly McapSceneUpdateDelta[],
+  timeNs: bigint,
+): SceneUpdateVisualization {
+  const state = new Map<string, SceneEntityRecord>();
+
+  for (const delta of [...deltas].sort(compareSceneUpdateDeltas)) {
+    if (delta.timeNs > timeNs) {
+      break;
+    }
+
+    expireEntities(state, timeNs);
+    applySceneUpdateDelta(state, delta, timeNs);
+  }
+  expireEntities(state, timeNs);
+
+  return {
+    deletions: [],
+    entities: [...state.values()].map((record) => record.entity),
+    kind: VISUALIZATION_KIND.SCENE_UPDATE,
+  };
+}
+
+function applySceneUpdateDelta(
+  state: Map<string, SceneEntityRecord>,
+  { timeNs, update }: McapSceneUpdateDelta,
+  targetTimeNs: bigint,
+): void {
+  for (const deletion of update.deletions) {
+    const deletionTimeNs = deletion.timestampNs ?? timeNs;
+    if (deletionTimeNs > targetTimeNs) {
+      continue;
+    }
+    if (deletion.type === "all") {
+      state.clear();
+    } else {
+      state.delete(deletion.id);
+    }
+  }
+
+  for (const entity of update.entities) {
+    const updatedAtNs = entity.timestampNs ?? timeNs;
+    if (updatedAtNs > targetTimeNs) {
+      continue;
+    }
+    const expiresAtNs =
+      entity.lifetimeNs !== undefined && entity.lifetimeNs > 0n
+        ? updatedAtNs + entity.lifetimeNs
+        : undefined;
+    if (expiresAtNs !== undefined && expiresAtNs <= targetTimeNs) {
+      state.delete(entity.id);
+      continue;
+    }
+
+    state.set(entity.id, {
+      entity,
+      ...(expiresAtNs !== undefined ? { expiresAtNs } : {}),
+      updatedAtNs,
+    });
+  }
+}
+
+function expireEntities(
+  state: Map<string, SceneEntityRecord>,
+  targetTimeNs: bigint,
+): void {
+  for (const [id, record] of state) {
+    if (
+      record.expiresAtNs !== undefined &&
+      record.expiresAtNs <= targetTimeNs
+    ) {
+      state.delete(id);
+    }
+  }
+}
+
+function compareSceneUpdateDeltas(
+  left: McapSceneUpdateDelta,
+  right: McapSceneUpdateDelta,
+): number {
+  if (left.timeNs === right.timeNs) {
+    return 0;
+  }
+  return left.timeNs < right.timeNs ? -1 : 1;
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-scene-update-state.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-scene-update-state.ts
@@ -11,7 +11,6 @@ export interface McapSceneUpdateDelta {
 
 interface SceneEntityRecord {
   readonly entity: SceneEntityVisualization;
-  readonly expiresAtNs?: bigint;
   readonly updatedAtNs: bigint;
 }
 
@@ -42,10 +41,8 @@ export function sceneUpdateSnapshotAt(
       break;
     }
 
-    expireEntities(state, timeNs);
     applySceneUpdateDelta(state, delta, timeNs);
   }
-  expireEntities(state, timeNs);
 
   return {
     deletions: [],
@@ -87,23 +84,8 @@ function applySceneUpdateDelta(
 
     state.set(entity.id, {
       entity,
-      ...(expiresAtNs !== undefined ? { expiresAtNs } : {}),
       updatedAtNs,
     });
-  }
-}
-
-function expireEntities(
-  state: Map<string, SceneEntityRecord>,
-  targetTimeNs: bigint,
-): void {
-  for (const [id, record] of state) {
-    if (
-      record.expiresAtNs !== undefined &&
-      record.expiresAtNs <= targetTimeNs
-    ) {
-      state.delete(id);
-    }
   }
 }
 

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-tile-types.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-tile-types.ts
@@ -10,6 +10,7 @@
  */
 export const MCAP_TILE_TYPE = {
   IMAGE: "image",
+  LOG: "log",
   PLOT: "plot",
   RAW: "raw",
   THREE_D: "3d",

--- a/app/packages/multimodal/src/adapters/mcap/react/playback-layout.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/playback-layout.test.ts
@@ -28,6 +28,15 @@ function imageSource(id: string, recordCount?: number): SceneSource {
   };
 }
 
+function logSource(id: string, recordCount?: number): SceneSource {
+  return {
+    id,
+    label: id.replace(/^\//, ""),
+    type: "log",
+    ...(recordCount !== undefined ? { recordCount } : {}),
+  };
+}
+
 const POINT_CLOUD: SceneSource = {
   id: "/points",
   label: "points",
@@ -259,6 +268,23 @@ describe("resolvePlaybackLayout", () => {
     expect(layout).toBe("3d-1");
   });
 
+  it("opens a log tile for logs-only scenes", () => {
+    const { tiles, layout } = resolvePlaybackLayout({
+      capabilities: STRONG_LOCAL,
+      readProfile: "local",
+      sources: [logSource("/diagnostics", 12)],
+    });
+
+    expect(tiles).toEqual([
+      {
+        id: "log-1",
+        tileType: "log",
+        title: "Logs",
+      },
+    ]);
+    expect(layout).toBe("log-1");
+  });
+
   it("returns no tiles for scenes without renderable sources", () => {
     const { tiles, layout } = resolvePlaybackLayout({
       capabilities: STRONG_LOCAL,
@@ -339,6 +365,15 @@ describe("buildMcapAutoLayout", () => {
         splitPercentage: 50,
       },
       splitPercentage: 100 / 3,
+    });
+  });
+
+  it("stacks log tiles vertically", () => {
+    expect(buildMcapAutoLayout(["log-1", "log-2"])).toEqual({
+      direction: "column",
+      first: "log-1",
+      second: "log-2",
+      splitPercentage: 50,
     });
   });
 

--- a/app/packages/multimodal/src/adapters/mcap/react/playback-layout.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/playback-layout.ts
@@ -38,6 +38,7 @@ const CONTEXT_SHELF_IMAGE_SPLIT_PERCENTAGE = 65;
 
 // Mosaic leaf id of the single default 3D tile.
 const THREE_D_TILE_ID = `${MCAP_TILE_TYPE.THREE_D}-1`;
+const LOG_TILE_ID = `${MCAP_TILE_TYPE.LOG}-1`;
 
 /**
  * Device/runtime signals the layout resolver weighs. Collected once per
@@ -203,6 +204,9 @@ export function resolvePlaybackLayout({
       source.type === MCAP_SOURCE_TYPE.MAP_LAYER ||
       source.type === MCAP_SOURCE_TYPE.POSE,
   );
+  const hasLogs = sources.some(
+    (source) => source.type === MCAP_SOURCE_TYPE.LOG,
+  );
 
   const imageTileCount =
     rankedImages.length === 0
@@ -225,6 +229,13 @@ export function resolvePlaybackLayout({
       id: THREE_D_TILE_ID,
       tileType: MCAP_TILE_TYPE.THREE_D,
       title: "3D",
+    });
+  }
+  if (hasLogs) {
+    tiles.push({
+      id: LOG_TILE_ID,
+      tileType: MCAP_TILE_TYPE.LOG,
+      title: "Logs",
     });
   }
 
@@ -316,6 +327,7 @@ export function buildMcapAutoLayout(
   const images: string[] = [];
   const threeD: string[] = [];
   const plots: string[] = [];
+  const logs: string[] = [];
   const messages: string[] = [];
   const unknown: string[] = [];
 
@@ -330,6 +342,9 @@ export function buildMcapAutoLayout(
       case MCAP_TILE_TYPE.PLOT:
         plots.push(tileId);
         break;
+      case MCAP_TILE_TYPE.LOG:
+        logs.push(tileId);
+        break;
       case MCAP_TILE_TYPE.RAW:
         messages.push(tileId);
         break;
@@ -341,8 +356,8 @@ export function buildMcapAutoLayout(
 
   const threeDRegion = autoLayout(threeD);
   const supportingRegion = threeDRegion
-    ? buildContextShelf(images, plots, messages, unknown)
-    : buildNon3dLayout(images, plots, messages, unknown);
+    ? buildContextShelf(images, plots, logs, messages, unknown)
+    : buildNon3dLayout(images, plots, logs, messages, unknown);
 
   if (threeDRegion) {
     if (!supportingRegion) {
@@ -363,11 +378,12 @@ export function buildMcapAutoLayout(
 function buildNon3dLayout(
   images: readonly string[],
   plots: readonly string[],
+  logs: readonly string[],
   messages: readonly string[],
   unknown: readonly string[],
 ): MosaicNode<string> | null {
   const imageBank = autoLayout([...images]);
-  const diagnostics = buildDiagnosticsStack(plots, unknown);
+  const diagnostics = buildDiagnosticsStack(plots, logs, unknown);
   const left = stackNodes([imageBank, diagnostics], {
     direction: "column",
     splitPercentage: VISUAL_WITH_PLOTS_SPLIT_PERCENTAGE,
@@ -392,11 +408,12 @@ function buildNon3dLayout(
 function buildContextShelf(
   images: readonly string[],
   plots: readonly string[],
+  logs: readonly string[],
   messages: readonly string[],
   unknown: readonly string[],
 ): MosaicNode<string> | null {
   const imageBank = autoLayout([...images]);
-  const diagnostics = buildDiagnosticsStack(plots, unknown);
+  const diagnostics = buildDiagnosticsStack(plots, logs, unknown);
   const left = stackNodes([imageBank, diagnostics], {
     direction: "row",
     splitPercentage: CONTEXT_SHELF_IMAGE_SPLIT_PERCENTAGE,
@@ -426,10 +443,12 @@ function buildLayoutTree(
 
 function buildDiagnosticsStack(
   plots: readonly string[],
+  logs: readonly string[],
   unknown: readonly string[],
 ): MosaicNode<string> | null {
   return stackNodes([
     stackTiles(plots, "column"),
+    stackTiles(logs, "column"),
     stackTiles(unknown, "column"),
   ]);
 }

--- a/app/packages/multimodal/src/adapters/mcap/react/use-interpolated-scene-updates.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-interpolated-scene-updates.ts
@@ -48,8 +48,8 @@ export function useInterpolatedSceneUpdateFrames({
   // lerp even while the playhead is paused mid-gap.
   const cacheSnapshot = useTopicCacheSnapshot(dataStream, topics);
 
-  return useMemo(() => {
-    const resolvedFrames = frames.map((playbackFrame, index) => {
+  const resolvedFrames = useMemo(() => {
+    return frames.map((playbackFrame, index) => {
       const topic = topics[index];
       if (!playbackFrame || !topic) {
         return playbackFrame;
@@ -72,7 +72,10 @@ export function useInterpolatedSceneUpdateFrames({
         frame: sceneUpdateSnapshotAt(deltas, playbackFrame.requestedTimeNs),
       };
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- cacheSnapshot is the caches' change digest
+  }, [cacheSnapshot, dataStream, frames, history, topics]);
 
+  return useMemo(() => {
     if (!interpolate || !dataStream || !timeline) {
       return resolvedFrames;
     }
@@ -143,15 +146,13 @@ export function useInterpolatedSceneUpdateFrames({
       };
     });
 
-    return changed ? interpolated : frames;
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- cacheSnapshot is the caches' change digest
+    return changed ? interpolated : resolvedFrames;
   }, [
-    cacheSnapshot,
     dataStream,
-    frames,
     history,
     interpolate,
     playhead,
+    resolvedFrames,
     timeline,
     topics,
   ]);

--- a/app/packages/multimodal/src/adapters/mcap/react/use-interpolated-scene-updates.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-interpolated-scene-updates.ts
@@ -6,6 +6,12 @@ import type { McapDecodedMessage } from "../types";
 import { interpolationFraction } from "./interpolate-image-annotations";
 import { interpolateSceneUpdate } from "./interpolate-scene-entities";
 import { useMcapDataStream } from "./mcap-data-stream-context";
+import { useMcapSceneUpdateHistoryContext } from "./mcap-scene-update-history-context";
+import {
+  sceneUpdateSnapshotAt,
+  type McapSceneUpdateDelta,
+} from "./mcap-scene-update-state";
+import type { McapTopicCache } from "./mcap-topic-cache";
 import {
   nextDistinctCachedMessage,
   useTopicCacheSnapshot,
@@ -34,29 +40,51 @@ export function useInterpolatedSceneUpdateFrames({
   readonly topics: readonly string[];
 }): readonly (McapTopicPlaybackFrame<SceneUpdateVisualization> | null)[] {
   const dataStream = useMcapDataStream();
+  const history = useMcapSceneUpdateHistoryContext();
   // Re-render every RAF tick so the lerp tracks the playhead.
   const playhead = usePlayhead();
   const timeline = dataStream?.getTimelineIndex() ?? null;
-  // Late-arriving lookahead messages must re-derive the lerp even while the
-  // playhead is paused mid-gap.
-  const cacheSnapshot = useTopicCacheSnapshot(
-    interpolate ? dataStream : null,
-    topics,
-  );
+  // Late-arriving lookahead messages must re-derive the lifecycle snapshot and
+  // lerp even while the playhead is paused mid-gap.
+  const cacheSnapshot = useTopicCacheSnapshot(dataStream, topics);
 
   return useMemo(() => {
+    const resolvedFrames = frames.map((playbackFrame, index) => {
+      const topic = topics[index];
+      if (!playbackFrame || !topic) {
+        return playbackFrame;
+      }
+      const cache = dataStream?.getTopicCache(topic) ?? null;
+      const deltas = sceneUpdateDeltasForTopic({
+        cache,
+        fallbackFrame: playbackFrame.frame,
+        fallbackTimeNs: playbackFrame.contentTimeNs,
+        historyDeltas: history.get(topic)?.deltas,
+        historyReady: history.get(topic)?.status === "ready",
+        targetTimeNs: playbackFrame.requestedTimeNs,
+      });
+      if (deltas.length === 0) {
+        return playbackFrame;
+      }
+
+      return {
+        ...playbackFrame,
+        frame: sceneUpdateSnapshotAt(deltas, playbackFrame.requestedTimeNs),
+      };
+    });
+
     if (!interpolate || !dataStream || !timeline) {
-      return frames;
+      return resolvedFrames;
     }
 
     const currentTick = timeline.nearestTick(playhead);
     if (currentTick === undefined) {
-      return frames;
+      return resolvedFrames;
     }
     const playheadNs = timeline.secToNs(playhead);
 
     let changed = false;
-    const interpolated = frames.map((playbackFrame, index) => {
+    const interpolated = resolvedFrames.map((playbackFrame, index) => {
       const topic = topics[index];
       if (!playbackFrame || !topic) {
         return playbackFrame;
@@ -79,6 +107,18 @@ export function useInterpolatedSceneUpdateFrames({
       if (!nextViz) {
         return playbackFrame;
       }
+      const nextDeltas = sceneUpdateDeltasForTopic({
+        cache,
+        fallbackFrame: nextViz,
+        fallbackTimeNs: nextMsg.timelineTimeNs,
+        historyDeltas: history.get(topic)?.deltas,
+        historyReady: history.get(topic)?.status === "ready",
+        targetTimeNs: nextMsg.timelineTimeNs,
+      });
+      const nextFrame =
+        nextDeltas.length > 0
+          ? sceneUpdateSnapshotAt(nextDeltas, nextMsg.timelineTimeNs)
+          : nextViz;
 
       const f = interpolationFraction({
         nextTimelineTimeNs: nextMsg.timelineTimeNs,
@@ -96,7 +136,7 @@ export function useInterpolatedSceneUpdateFrames({
         contentTimeNs: playheadNs,
         frame: interpolateSceneUpdate(
           playbackFrame.frame,
-          nextViz,
+          nextFrame,
           f,
           playheadNs,
         ),
@@ -109,11 +149,68 @@ export function useInterpolatedSceneUpdateFrames({
     cacheSnapshot,
     dataStream,
     frames,
+    history,
     interpolate,
     playhead,
     timeline,
     topics,
   ]);
+}
+
+function sceneUpdateDeltasForTopic({
+  cache,
+  fallbackFrame,
+  fallbackTimeNs,
+  historyDeltas,
+  historyReady,
+  targetTimeNs,
+}: {
+  readonly cache: McapTopicCache | null;
+  readonly fallbackFrame: SceneUpdateVisualization;
+  readonly fallbackTimeNs: bigint;
+  readonly historyDeltas: readonly McapSceneUpdateDelta[] | undefined;
+  readonly historyReady: boolean;
+  readonly targetTimeNs: bigint;
+}): readonly McapSceneUpdateDelta[] {
+  if (historyReady && historyDeltas) {
+    return historyDeltas;
+  }
+
+  const cachedDeltas = cachedSceneUpdateDeltas(cache, targetTimeNs);
+  if (cachedDeltas.length > 0) {
+    return cachedDeltas;
+  }
+
+  return [{ timeNs: fallbackTimeNs, update: fallbackFrame }];
+}
+
+function cachedSceneUpdateDeltas(
+  cache: McapTopicCache | null,
+  targetTimeNs: bigint,
+): readonly McapSceneUpdateDelta[] {
+  if (!cache) {
+    return [];
+  }
+
+  const deltas: McapSceneUpdateDelta[] = [];
+  const seenMessages = new Set<string>();
+  for (const tick of cache.cachedTicks()) {
+    const msg = cache.get(tick);
+    if (!msg || msg.timelineTimeNs > targetTimeNs) {
+      continue;
+    }
+    const update = sceneUpdateOf(msg);
+    if (!update) {
+      continue;
+    }
+    const key = `${msg.channelId}:${msg.sequence}:${msg.timelineTimeNs}`;
+    if (seenMessages.has(key)) {
+      continue;
+    }
+    seenMessages.add(key);
+    deltas.push({ timeNs: msg.timelineTimeNs, update });
+  }
+  return deltas;
 }
 
 function sceneUpdateOf(

--- a/app/packages/multimodal/src/adapters/mcap/react/use-mcap-tiles.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-mcap-tiles.ts
@@ -4,6 +4,7 @@ import { useEffect } from "react";
 import { MCAP_SOURCE_TYPE } from "../scene-sources";
 import Mcap3dTile from "./Mcap3dTile";
 import McapImageTile from "./McapImageTile";
+import McapLogConsoleTile from "./McapLogConsoleTile";
 import McapPlotTile from "./McapPlotTile";
 import McapRawMessageTile from "./McapRawMessageTile";
 import {
@@ -36,6 +37,12 @@ const TILE_BY_TYPE: Record<
     icon: IconName.GridView,
     Tile: McapImageTile,
     sourceTypes: [MCAP_SOURCE_TYPE.IMAGE],
+  },
+  [MCAP_TILE_TYPE.LOG]: {
+    typeLabel: "Logs",
+    icon: IconName.Logs,
+    Tile: McapLogConsoleTile,
+    sourceTypes: [MCAP_SOURCE_TYPE.LOG],
   },
   [MCAP_TILE_TYPE.THREE_D]: {
     typeLabel: "3D",

--- a/app/packages/multimodal/src/adapters/mcap/resources/inline.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/resources/inline.test.ts
@@ -88,6 +88,29 @@ float64 x
 float64 y
 float64 z
 float64 w`;
+const FOXGLOVE_ROS2_FRAME_TRANSFORMS_SCHEMA = `foxglove_msgs/FrameTransform[] transforms
+===
+MSG: foxglove_msgs/FrameTransform
+builtin_interfaces/Time timestamp
+string parent_frame_id
+string child_frame_id
+foxglove_msgs/Vector3 translation
+foxglove_msgs/Quaternion rotation
+===
+MSG: foxglove_msgs/Vector3
+float64 x
+float64 y
+float64 z
+===
+MSG: foxglove_msgs/Quaternion
+float64 x
+float64 y
+float64 z
+float64 w
+===
+MSG: builtin_interfaces/Time
+int32 sec
+uint32 nanosec`;
 const ROS2_IDL_TF_MESSAGE_SCHEMA = `module tf2_msgs {
   module msg {
     struct TFMessage {
@@ -987,6 +1010,76 @@ describe("MCAP resources", () => {
       timeNs: 9_000_000_030n,
     });
     expect(set.samples[0]?.translation.toArray()).toEqual([4, 5, 6]);
+  });
+
+  it("reads foxglove_msgs cdr FrameTransforms samples from dynamic frame transform windows", async () => {
+    const readMessages = vi.fn(async function* () {
+      yield createMessage(
+        foxgloveRos2FrameTransforms({
+          transforms: [
+            {
+              child_frame_id: "lidar",
+              parent_frame_id: "map",
+              rotation: { w: 1, x: 0, y: 0, z: 0 },
+              timestamp: { nanosec: 40, sec: 8 },
+              translation: { x: 1, y: 2, z: 3 },
+            },
+          ],
+        }),
+        {
+          channelId: 10,
+          logTime: 8_000_000_040n,
+        },
+      );
+    });
+    const client = createInlineMcapResourceClient({
+      byteClient: { readBytes: vi.fn() },
+      decodeClient: createTestDecodeClient(),
+      readerFactory: vi.fn(async () =>
+        createReader({
+          channelsById: new Map([
+            [
+              10,
+              createChannel({
+                id: 10,
+                messageEncoding: "cdr",
+                schemaId: 10,
+                topic: "/tf",
+              }),
+            ],
+          ]),
+          readMessages,
+          schemasById: new Map([
+            [
+              10,
+              createSchema(
+                new TextEncoder().encode(FOXGLOVE_ROS2_FRAME_TRANSFORMS_SCHEMA),
+                {
+                  encoding: "ros2msg",
+                  id: 10,
+                  name: "foxglove_msgs/msg/FrameTransforms",
+                },
+              ),
+            ],
+          ]),
+        }),
+      ),
+    });
+
+    const set = await client.readFrameTransformWindow({
+      endTimeNs: 8_000_000_040n,
+      source: createMcapSourceDescriptor(),
+      startTimeNs: 8_000_000_040n,
+    });
+
+    expect(set.samples).toHaveLength(1);
+    expect(set.samples[0]).toMatchObject({
+      childFrameId: "lidar",
+      parentFrameId: "map",
+      timeNs: 8_000_000_040n,
+    });
+    expect(set.samples[0]?.rotation.toArray()).toEqual([0, 0, 0, 1]);
+    expect(set.samples[0]?.translation.toArray()).toEqual([1, 2, 3]);
   });
 
   it("skips malformed ROS TFMessage payloads without failing the window", async () => {
@@ -2214,6 +2307,17 @@ function ros1TfMessage(record: Record<string, unknown>): Uint8Array {
 function ros2TfMessage(record: Record<string, unknown>): Uint8Array {
   const writer = new Ros2MessageWriter(
     parseRosMessageDefinition(ROS2_TF_MESSAGE_SCHEMA, { ros2: true }),
+  );
+  return writer.writeMessage(record);
+}
+
+function foxgloveRos2FrameTransforms(
+  record: Record<string, unknown>,
+): Uint8Array {
+  const writer = new Ros2MessageWriter(
+    parseRosMessageDefinition(FOXGLOVE_ROS2_FRAME_TRANSFORMS_SCHEMA, {
+      ros2: true,
+    }),
   );
   return writer.writeMessage(record);
 }

--- a/app/packages/multimodal/src/adapters/mcap/resources/inline.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/resources/inline.test.ts
@@ -88,6 +88,26 @@ float64 x
 float64 y
 float64 z
 float64 w`;
+const FOXGLOVE_ROS2_FRAME_TRANSFORM_SCHEMA = `builtin_interfaces/Time timestamp
+string parent_frame_id
+string child_frame_id
+foxglove_msgs/Vector3 translation
+foxglove_msgs/Quaternion rotation
+===
+MSG: foxglove_msgs/Vector3
+float64 x
+float64 y
+float64 z
+===
+MSG: foxglove_msgs/Quaternion
+float64 x
+float64 y
+float64 z
+float64 w
+===
+MSG: builtin_interfaces/Time
+int32 sec
+uint32 nanosec`;
 const FOXGLOVE_ROS2_FRAME_TRANSFORMS_SCHEMA = `foxglove_msgs/FrameTransform[] transforms
 ===
 MSG: foxglove_msgs/FrameTransform
@@ -1080,6 +1100,72 @@ describe("MCAP resources", () => {
     });
     expect(set.samples[0]?.rotation.toArray()).toEqual([0, 0, 0, 1]);
     expect(set.samples[0]?.translation.toArray()).toEqual([1, 2, 3]);
+  });
+
+  it("reads foxglove_msgs cdr FrameTransform samples from dynamic frame transform windows", async () => {
+    const readMessages = vi.fn(async function* () {
+      yield createMessage(
+        foxgloveRos2FrameTransform({
+          child_frame_id: "camera",
+          parent_frame_id: "map",
+          rotation: { w: 1, x: 0, y: 0, z: 0 },
+          timestamp: { nanosec: 50, sec: 8 },
+          translation: { x: 4, y: 5, z: 6 },
+        }),
+        {
+          channelId: 10,
+          logTime: 8_000_000_050n,
+        },
+      );
+    });
+    const client = createInlineMcapResourceClient({
+      byteClient: { readBytes: vi.fn() },
+      decodeClient: createTestDecodeClient(),
+      readerFactory: vi.fn(async () =>
+        createReader({
+          channelsById: new Map([
+            [
+              10,
+              createChannel({
+                id: 10,
+                messageEncoding: "cdr",
+                schemaId: 10,
+                topic: "/tf",
+              }),
+            ],
+          ]),
+          readMessages,
+          schemasById: new Map([
+            [
+              10,
+              createSchema(
+                new TextEncoder().encode(FOXGLOVE_ROS2_FRAME_TRANSFORM_SCHEMA),
+                {
+                  encoding: "ros2msg",
+                  id: 10,
+                  name: "foxglove_msgs/msg/FrameTransform",
+                },
+              ),
+            ],
+          ]),
+        }),
+      ),
+    });
+
+    const set = await client.readFrameTransformWindow({
+      endTimeNs: 8_000_000_050n,
+      source: createMcapSourceDescriptor(),
+      startTimeNs: 8_000_000_050n,
+    });
+
+    expect(set.samples).toHaveLength(1);
+    expect(set.samples[0]).toMatchObject({
+      childFrameId: "camera",
+      parentFrameId: "map",
+      timeNs: 8_000_000_050n,
+    });
+    expect(set.samples[0]?.rotation.toArray()).toEqual([0, 0, 0, 1]);
+    expect(set.samples[0]?.translation.toArray()).toEqual([4, 5, 6]);
   });
 
   it("skips malformed ROS TFMessage payloads without failing the window", async () => {
@@ -2316,6 +2402,17 @@ function foxgloveRos2FrameTransforms(
 ): Uint8Array {
   const writer = new Ros2MessageWriter(
     parseRosMessageDefinition(FOXGLOVE_ROS2_FRAME_TRANSFORMS_SCHEMA, {
+      ros2: true,
+    }),
+  );
+  return writer.writeMessage(record);
+}
+
+function foxgloveRos2FrameTransform(
+  record: Record<string, unknown>,
+): Uint8Array {
+  const writer = new Ros2MessageWriter(
+    parseRosMessageDefinition(FOXGLOVE_ROS2_FRAME_TRANSFORM_SCHEMA, {
       ros2: true,
     }),
   );

--- a/app/packages/multimodal/src/adapters/mcap/resources/read-frame-transforms.ts
+++ b/app/packages/multimodal/src/adapters/mcap/resources/read-frame-transforms.ts
@@ -33,6 +33,9 @@ import {
 import type { McapReadFrameTransformWindowRequest } from "../types";
 
 const PROTOBUF_ENCODING = "protobuf";
+const FOXGLOVE_FRAME_TRANSFORM_CDR_SCHEMA = "foxglove_msgs/msg/FrameTransform";
+const FOXGLOVE_FRAME_TRANSFORMS_CDR_SCHEMA =
+  "foxglove_msgs/msg/FrameTransforms";
 const FOXGLOVE_FRAME_TRANSFORMS_SCHEMA = "foxglove.FrameTransforms";
 const TF_MESSAGE_BATCH_FIELD = "transforms";
 
@@ -47,6 +50,12 @@ const ROS_TF_MESSAGE_SCHEMAS: ReadonlySet<string> = new Set([
 const ROS_TRANSFORM_STAMPED_SCHEMAS: ReadonlySet<string> = new Set([
   "geometry_msgs/TransformStamped",
   "geometry_msgs/msg/TransformStamped",
+]);
+const FOXGLOVE_CDR_TRANSFORM_SCHEMAS: ReadonlySet<string> = new Set([
+  FOXGLOVE_FRAME_TRANSFORM_CDR_SCHEMA,
+]);
+const FOXGLOVE_CDR_TRANSFORMS_SCHEMAS: ReadonlySet<string> = new Set([
+  FOXGLOVE_FRAME_TRANSFORMS_CDR_SCHEMA,
 ]);
 
 type FrameTransformSchemaMatch =
@@ -612,9 +621,29 @@ function classifyRosFrameTransformSchema(
 ): FrameTransformSchemaMatch | null {
   const definitions = rosMessageDefinitionsForChannel(reader, channel);
   const root = definitions ? rootRosMessageDefinition(definitions) : undefined;
-  if (!root || !isRosTfMessageSchema(schema, root)) {
+  if (!root) {
     return null;
   }
+
+  if (isFoxgloveCdrFrameTransformSchema(schema, root)) {
+    return {
+      format: "foxglove",
+      kind: "single",
+    };
+  }
+
+  if (isFoxgloveCdrFrameTransformsSchema(schema, root)) {
+    return {
+      format: "foxglove",
+      kind: "batch",
+      repeatedFieldName: "transforms",
+    };
+  }
+
+  if (!isRosTfMessageSchema(schema, root)) {
+    return null;
+  }
+
   const transformsField = root.definitions.find(
     (field) => field.name === TF_MESSAGE_BATCH_FIELD,
   );
@@ -641,6 +670,28 @@ function isRosTfMessageSchema(
     ROS_TF_MESSAGE_SCHEMAS.has(schema.name) ||
     (definition.name !== undefined &&
       ROS_TF_MESSAGE_SCHEMAS.has(definition.name))
+  );
+}
+
+function isFoxgloveCdrFrameTransformSchema(
+  schema: McapSchema,
+  definition: RosMessageDefinition,
+): boolean {
+  return (
+    FOXGLOVE_CDR_TRANSFORM_SCHEMAS.has(schema.name) ||
+    (definition.name !== undefined &&
+      FOXGLOVE_CDR_TRANSFORM_SCHEMAS.has(definition.name))
+  );
+}
+
+function isFoxgloveCdrFrameTransformsSchema(
+  schema: McapSchema,
+  definition: RosMessageDefinition,
+): boolean {
+  return (
+    FOXGLOVE_CDR_TRANSFORMS_SCHEMAS.has(schema.name) ||
+    (definition.name !== undefined &&
+      FOXGLOVE_CDR_TRANSFORMS_SCHEMAS.has(definition.name))
   );
 }
 

--- a/app/packages/multimodal/src/adapters/mcap/scene-sources.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/scene-sources.test.ts
@@ -29,7 +29,12 @@ describe("mcapSceneSources", () => {
       createTopic("/odom", "Pose", "json", "jsonschema"),
       createTopic("/gps", "foxglove.LocationFix"),
       createTopic("/tf", "foxglove.FrameTransform"),
-      createTopic("/diagnostics", "diagnostic_msgs/DiagnosticArray", "ros1"),
+      createTopic(
+        "/diagnostics",
+        "diagnostic_msgs/DiagnosticArray",
+        "ros1",
+        "ros1msg",
+      ),
     ]);
 
     expect(sources).toEqual([
@@ -102,6 +107,11 @@ describe("mcapSceneSources", () => {
         id: "/gps",
         type: MCAP_SOURCE_TYPE.LOCATION,
         label: "gps",
+      },
+      {
+        id: "/diagnostics",
+        type: MCAP_SOURCE_TYPE.LOG,
+        label: "diagnostics",
       },
     ]);
   });
@@ -225,6 +235,12 @@ describe("mcapStreamPolicies", () => {
         createTopic("/markers/annotations", "foxglove.SceneUpdate"),
         createTopic("/lidar", "foxglove.PointCloud"),
         createTopic("/map", "foxglove.Grid"),
+        createTopic(
+          "/diagnostics",
+          "diagnostic_msgs/DiagnosticArray",
+          "ros1",
+          "ros1msg",
+        ),
       ]),
     );
 
@@ -245,6 +261,9 @@ describe("mcapStreamPolicies", () => {
     // A one-shot static /map stays resolvable for the whole run through the
     // same unbounded lookback.
     expect(policies["/map"]).toEqual({
+      mode: PlaybackSyncMode.LATEST,
+    });
+    expect(policies["/diagnostics"]).toEqual({
       mode: PlaybackSyncMode.LATEST,
     });
   });

--- a/app/packages/multimodal/src/adapters/mcap/scene-sources.ts
+++ b/app/packages/multimodal/src/adapters/mcap/scene-sources.ts
@@ -92,7 +92,7 @@ export function mcapSceneSources(
     if (!id) {
       continue;
     }
-    const type = sourceTypeFor(topic);
+    const type = mcapSourceTypeForTopic(topic);
     if (!type) {
       continue;
     }
@@ -144,7 +144,9 @@ export function mcapStreamPolicies(
   return policies;
 }
 
-function sourceTypeFor(topic: StreamInventory): McapSourceType | null {
+export function mcapSourceTypeForTopic(
+  topic: StreamInventory,
+): McapSourceType | null {
   if (isImageStream(topic)) {
     return MCAP_SOURCE_TYPE.IMAGE;
   }

--- a/app/packages/multimodal/src/adapters/mcap/scene-sources.ts
+++ b/app/packages/multimodal/src/adapters/mcap/scene-sources.ts
@@ -6,6 +6,7 @@ import {
   isImageAnnotationsStream,
   isImageStream,
   isLocationFixStream,
+  isLogStream,
   isPointCloudStream,
   isPoseStream,
   isSceneUpdateStream,
@@ -31,6 +32,8 @@ export const MCAP_SOURCE_TYPE = {
   // Foxglove LocationFix topics: geographic fixes surfaced as telemetry
   // readouts (and, later, map panels); never a standalone tile.
   LOCATION: "location",
+  // Log and diagnostics topics: console-shaped streams rendered in a log tile.
+  LOG: "log",
   // Foxglove Grid topics: 2D data grids rendered as textured ground/map
   // planes in the 3D scene. Named "map-layer" rather than "grid" because
   // "grid" already means the FiftyOne sample grid throughout the app.
@@ -60,6 +63,7 @@ const SYNC_POLICY_BY_TYPE: Record<McapSourceType, McapStreamSyncPolicy> = {
   [MCAP_SOURCE_TYPE.IMAGE]: LATEST_SYNC_POLICY,
   [MCAP_SOURCE_TYPE.IMAGE_ANNOTATION]: LATEST_SYNC_POLICY,
   [MCAP_SOURCE_TYPE.LOCATION]: LATEST_SYNC_POLICY,
+  [MCAP_SOURCE_TYPE.LOG]: LATEST_SYNC_POLICY,
   // Unbounded lookback is what makes static maps work: a one-shot /map
   // message published at file start stays resolvable for the whole run.
   [MCAP_SOURCE_TYPE.MAP_LAYER]: LATEST_SYNC_POLICY,
@@ -164,6 +168,9 @@ function sourceTypeFor(topic: StreamInventory): McapSourceType | null {
   }
   if (isLocationFixStream(topic)) {
     return MCAP_SOURCE_TYPE.LOCATION;
+  }
+  if (isLogStream(topic)) {
+    return MCAP_SOURCE_TYPE.LOG;
   }
   return null;
 }

--- a/app/packages/multimodal/src/adapters/mcap/stream-topics.ts
+++ b/app/packages/multimodal/src/adapters/mcap/stream-topics.ts
@@ -6,6 +6,8 @@ import {
   JSON_ROS_COMPRESSED_IMAGE_PAYLOADS,
   JSON_ROS_IMAGE_PAYLOADS,
   JSON_ROS_LASER_SCAN_PAYLOADS,
+  JSON_ROS_MARKER_ARRAY_PAYLOADS,
+  JSON_ROS_MARKER_PAYLOADS,
   JSON_ROS_NAV_SAT_FIX_PAYLOADS,
   JSON_ROS_OCCUPANCY_GRID_PAYLOADS,
   JSON_ROS_ODOMETRY_PAYLOADS,
@@ -30,6 +32,8 @@ import {
   ROS_COMPRESSED_IMAGE_PAYLOADS,
   ROS_IMAGE_PAYLOADS,
   ROS_LASER_SCAN_PAYLOADS,
+  ROS_MARKER_ARRAY_PAYLOADS,
+  ROS_MARKER_PAYLOADS,
   ROS_NAV_SAT_FIX_PAYLOADS,
   ROS_OCCUPANCY_GRID_PAYLOADS,
   ROS_ODOMETRY_PAYLOADS,
@@ -144,7 +148,13 @@ export function isPointCloudStream(topic: StreamInventory): boolean {
  * Returns whether a stream inventory item is a supported Foxglove SceneUpdate stream.
  */
 export function isSceneUpdateStream(topic: StreamInventory): boolean {
-  return hasPayload(topic, FOXGLOVE_SCENE_UPDATE_PAYLOAD);
+  return (
+    hasPayload(topic, FOXGLOVE_SCENE_UPDATE_PAYLOAD) ||
+    hasAnyPayload(topic, JSON_ROS_MARKER_PAYLOADS) ||
+    hasAnyPayload(topic, JSON_ROS_MARKER_ARRAY_PAYLOADS) ||
+    hasAnyPayload(topic, ROS_MARKER_PAYLOADS) ||
+    hasAnyPayload(topic, ROS_MARKER_ARRAY_PAYLOADS)
+  );
 }
 
 /**

--- a/app/packages/multimodal/src/adapters/mcap/stream-topics.ts
+++ b/app/packages/multimodal/src/adapters/mcap/stream-topics.ts
@@ -11,7 +11,9 @@ import {
   JSON_ROS_NAV_SAT_FIX_PAYLOADS,
   JSON_ROS_OCCUPANCY_GRID_PAYLOADS,
   JSON_ROS_ODOMETRY_PAYLOADS,
+  JSON_ROS_PATH_PAYLOADS,
   JSON_ROS_POINT_CLOUD2_PAYLOADS,
+  JSON_ROS_POSE_ARRAY_PAYLOADS,
   JSON_ROS_POSE_STAMPED_PAYLOADS,
 } from "./decoders/json/payloads";
 import {
@@ -46,7 +48,9 @@ import {
   ROS_NAV_SAT_FIX_PAYLOADS,
   ROS_OCCUPANCY_GRID_PAYLOADS,
   ROS_ODOMETRY_PAYLOADS,
+  ROS_PATH_PAYLOADS,
   ROS_POINT_CLOUD2_PAYLOADS,
+  ROS_POSE_ARRAY_PAYLOADS,
   ROS_POSE_STAMPED_PAYLOADS,
 } from "./decoders/ros/payloads";
 
@@ -169,8 +173,12 @@ export function isSceneUpdateStream(topic: StreamInventory): boolean {
     hasAnyPayload(topic, FOXGLOVE_SCENE_UPDATE_CDR_PAYLOADS) ||
     hasAnyPayload(topic, JSON_ROS_MARKER_PAYLOADS) ||
     hasAnyPayload(topic, JSON_ROS_MARKER_ARRAY_PAYLOADS) ||
+    hasAnyPayload(topic, JSON_ROS_PATH_PAYLOADS) ||
+    hasAnyPayload(topic, JSON_ROS_POSE_ARRAY_PAYLOADS) ||
     hasAnyPayload(topic, ROS_MARKER_PAYLOADS) ||
-    hasAnyPayload(topic, ROS_MARKER_ARRAY_PAYLOADS)
+    hasAnyPayload(topic, ROS_MARKER_ARRAY_PAYLOADS) ||
+    hasAnyPayload(topic, ROS_PATH_PAYLOADS) ||
+    hasAnyPayload(topic, ROS_POSE_ARRAY_PAYLOADS)
   );
 }
 

--- a/app/packages/multimodal/src/adapters/mcap/stream-topics.ts
+++ b/app/packages/multimodal/src/adapters/mcap/stream-topics.ts
@@ -29,7 +29,9 @@ import {
   FOXGLOVE_COMPRESSED_VIDEO_CDR_PAYLOADS,
   FOXGLOVE_COMPRESSED_VIDEO_PAYLOAD,
   FOXGLOVE_FRAME_TRANSFORM_CDR_PAYLOADS,
+  FOXGLOVE_FRAME_TRANSFORM_PAYLOAD,
   FOXGLOVE_FRAME_TRANSFORMS_CDR_PAYLOADS,
+  FOXGLOVE_FRAME_TRANSFORMS_PAYLOAD,
   FOXGLOVE_GRID_CDR_PAYLOADS,
   FOXGLOVE_GRID_PAYLOAD,
   FOXGLOVE_IMAGE_ANNOTATIONS_CDR_PAYLOADS,
@@ -66,56 +68,9 @@ import {
   ROS_POSE_STAMPED_PAYLOADS,
   ROS_RCL_LOG_PAYLOADS,
   ROS_ROSGRAPH_LOG_PAYLOADS,
+  ROS_TF_MESSAGE_PAYLOADS,
+  ROS_TRANSFORM_STAMPED_PAYLOADS,
 } from "./decoders/ros/payloads";
-
-const FOXGLOVE_FRAME_TRANSFORM_PAYLOADS: readonly PayloadDescriptor[] = [
-  {
-    encoding: "protobuf",
-    schema: "foxglove.FrameTransform",
-    schemaEncoding: "protobuf",
-  },
-  {
-    encoding: "protobuf",
-    schema: "foxglove.FrameTransforms",
-    schemaEncoding: "protobuf",
-  },
-];
-
-const ROS_TF_MESSAGE_PAYLOADS: readonly PayloadDescriptor[] = [
-  {
-    encoding: "ros1",
-    schema: "tf2_msgs/TFMessage",
-    schemaEncoding: "ros1msg",
-  },
-  {
-    encoding: "cdr",
-    schema: "tf2_msgs/msg/TFMessage",
-    schemaEncoding: "ros2msg",
-  },
-  {
-    encoding: "cdr",
-    schema: "tf2_msgs/msg/TFMessage",
-    schemaEncoding: "ros2idl",
-  },
-];
-
-const ROS_TRANSFORM_STAMPED_PAYLOADS: readonly PayloadDescriptor[] = [
-  {
-    encoding: "ros1",
-    schema: "geometry_msgs/TransformStamped",
-    schemaEncoding: "ros1msg",
-  },
-  {
-    encoding: "cdr",
-    schema: "geometry_msgs/msg/TransformStamped",
-    schemaEncoding: "ros2msg",
-  },
-  {
-    encoding: "cdr",
-    schema: "geometry_msgs/msg/TransformStamped",
-    schemaEncoding: "ros2idl",
-  },
-];
 
 /**
  * Supported MCAP topics that the adapter can preview or pair.
@@ -331,7 +286,8 @@ export function isLogStream(topic: StreamInventory): boolean {
  */
 export function isFrameTransformStream(topic: StreamInventory): boolean {
   return (
-    hasAnyPayload(topic, FOXGLOVE_FRAME_TRANSFORM_PAYLOADS) ||
+    hasPayload(topic, FOXGLOVE_FRAME_TRANSFORM_PAYLOAD) ||
+    hasPayload(topic, FOXGLOVE_FRAME_TRANSFORMS_PAYLOAD) ||
     hasAnyPayload(topic, FOXGLOVE_FRAME_TRANSFORM_CDR_PAYLOADS) ||
     hasAnyPayload(topic, FOXGLOVE_FRAME_TRANSFORMS_CDR_PAYLOADS) ||
     hasAnyPayload(topic, ROS_TF_MESSAGE_PAYLOADS) ||

--- a/app/packages/multimodal/src/adapters/mcap/stream-topics.ts
+++ b/app/packages/multimodal/src/adapters/mcap/stream-topics.ts
@@ -28,6 +28,8 @@ import {
   FOXGLOVE_COMPRESSED_IMAGE_PAYLOAD,
   FOXGLOVE_COMPRESSED_VIDEO_CDR_PAYLOADS,
   FOXGLOVE_COMPRESSED_VIDEO_PAYLOAD,
+  FOXGLOVE_FRAME_TRANSFORM_CDR_PAYLOADS,
+  FOXGLOVE_FRAME_TRANSFORMS_CDR_PAYLOADS,
   FOXGLOVE_GRID_CDR_PAYLOADS,
   FOXGLOVE_GRID_PAYLOAD,
   FOXGLOVE_IMAGE_ANNOTATIONS_CDR_PAYLOADS,
@@ -65,6 +67,55 @@ import {
   ROS_RCL_LOG_PAYLOADS,
   ROS_ROSGRAPH_LOG_PAYLOADS,
 } from "./decoders/ros/payloads";
+
+const FOXGLOVE_FRAME_TRANSFORM_PAYLOADS: readonly PayloadDescriptor[] = [
+  {
+    encoding: "protobuf",
+    schema: "foxglove.FrameTransform",
+    schemaEncoding: "protobuf",
+  },
+  {
+    encoding: "protobuf",
+    schema: "foxglove.FrameTransforms",
+    schemaEncoding: "protobuf",
+  },
+];
+
+const ROS_TF_MESSAGE_PAYLOADS: readonly PayloadDescriptor[] = [
+  {
+    encoding: "ros1",
+    schema: "tf2_msgs/TFMessage",
+    schemaEncoding: "ros1msg",
+  },
+  {
+    encoding: "cdr",
+    schema: "tf2_msgs/msg/TFMessage",
+    schemaEncoding: "ros2msg",
+  },
+  {
+    encoding: "cdr",
+    schema: "tf2_msgs/msg/TFMessage",
+    schemaEncoding: "ros2idl",
+  },
+];
+
+const ROS_TRANSFORM_STAMPED_PAYLOADS: readonly PayloadDescriptor[] = [
+  {
+    encoding: "ros1",
+    schema: "geometry_msgs/TransformStamped",
+    schemaEncoding: "ros1msg",
+  },
+  {
+    encoding: "cdr",
+    schema: "geometry_msgs/msg/TransformStamped",
+    schemaEncoding: "ros2msg",
+  },
+  {
+    encoding: "cdr",
+    schema: "geometry_msgs/msg/TransformStamped",
+    schemaEncoding: "ros2idl",
+  },
+];
 
 /**
  * Supported MCAP topics that the adapter can preview or pair.
@@ -270,6 +321,21 @@ export function isLogStream(topic: StreamInventory): boolean {
     hasAnyPayload(topic, ROS_ROSGRAPH_LOG_PAYLOADS) ||
     hasAnyPayload(topic, ROS_RCL_LOG_PAYLOADS) ||
     hasAnyPayload(topic, ROS_DIAGNOSTIC_ARRAY_PAYLOADS)
+  );
+}
+
+/**
+ * Returns whether a stream inventory item can feed the 3D frame-transform
+ * resolver. Transform topics are not scene sources themselves; they support
+ * placement of renderable streams discovered elsewhere.
+ */
+export function isFrameTransformStream(topic: StreamInventory): boolean {
+  return (
+    hasAnyPayload(topic, FOXGLOVE_FRAME_TRANSFORM_PAYLOADS) ||
+    hasAnyPayload(topic, FOXGLOVE_FRAME_TRANSFORM_CDR_PAYLOADS) ||
+    hasAnyPayload(topic, FOXGLOVE_FRAME_TRANSFORMS_CDR_PAYLOADS) ||
+    hasAnyPayload(topic, ROS_TF_MESSAGE_PAYLOADS) ||
+    hasAnyPayload(topic, ROS_TRANSFORM_STAMPED_PAYLOADS)
   );
 }
 

--- a/app/packages/multimodal/src/adapters/mcap/stream-topics.ts
+++ b/app/packages/multimodal/src/adapters/mcap/stream-topics.ts
@@ -15,16 +15,25 @@ import {
   JSON_ROS_POSE_STAMPED_PAYLOADS,
 } from "./decoders/json/payloads";
 import {
+  FOXGLOVE_CAMERA_CALIBRATION_CDR_PAYLOADS,
   FOXGLOVE_CAMERA_CALIBRATION_PAYLOAD,
+  FOXGLOVE_COMPRESSED_IMAGE_CDR_PAYLOADS,
   FOXGLOVE_COMPRESSED_IMAGE_PAYLOAD,
   FOXGLOVE_COMPRESSED_VIDEO_CDR_PAYLOADS,
   FOXGLOVE_COMPRESSED_VIDEO_PAYLOAD,
+  FOXGLOVE_GRID_CDR_PAYLOADS,
   FOXGLOVE_GRID_PAYLOAD,
+  FOXGLOVE_IMAGE_ANNOTATIONS_CDR_PAYLOADS,
+  FOXGLOVE_LASER_SCAN_CDR_PAYLOADS,
   FOXGLOVE_LASER_SCAN_PAYLOAD,
+  FOXGLOVE_LOCATION_FIX_CDR_PAYLOADS,
   FOXGLOVE_LOCATION_FIX_PAYLOAD,
+  FOXGLOVE_POINT_CLOUD_CDR_PAYLOADS,
+  FOXGLOVE_POSE_IN_FRAME_CDR_PAYLOADS,
   FOXGLOVE_POSE_IN_FRAME_PAYLOAD,
   FOXGLOVE_IMAGE_ANNOTATIONS_PAYLOAD,
   FOXGLOVE_POINT_CLOUD_PAYLOAD,
+  FOXGLOVE_SCENE_UPDATE_CDR_PAYLOADS,
   FOXGLOVE_SCENE_UPDATE_PAYLOAD,
 } from "./decoders/foxglove/payloads";
 import {
@@ -102,6 +111,7 @@ export function topicName(topic: StreamInventory): string {
 export function isImageStream(topic: StreamInventory): boolean {
   return (
     hasPayload(topic, FOXGLOVE_COMPRESSED_IMAGE_PAYLOAD) ||
+    hasAnyPayload(topic, FOXGLOVE_COMPRESSED_IMAGE_CDR_PAYLOADS) ||
     hasPayload(topic, FOXGLOVE_COMPRESSED_VIDEO_PAYLOAD) ||
     hasAnyPayload(topic, FOXGLOVE_COMPRESSED_VIDEO_CDR_PAYLOADS) ||
     hasAnyPayload(topic, JSON_ROS_COMPRESSED_IMAGE_PAYLOADS) ||
@@ -117,6 +127,7 @@ export function isImageStream(topic: StreamInventory): boolean {
 export function isCompressedImageStream(topic: StreamInventory): boolean {
   return (
     hasPayload(topic, FOXGLOVE_COMPRESSED_IMAGE_PAYLOAD) ||
+    hasAnyPayload(topic, FOXGLOVE_COMPRESSED_IMAGE_CDR_PAYLOADS) ||
     hasAnyPayload(topic, JSON_ROS_COMPRESSED_IMAGE_PAYLOADS) ||
     hasAnyPayload(topic, ROS_COMPRESSED_IMAGE_PAYLOADS)
   );
@@ -126,7 +137,10 @@ export function isCompressedImageStream(topic: StreamInventory): boolean {
  * Returns whether a stream inventory item is a supported Foxglove image annotation stream.
  */
 export function isImageAnnotationsStream(topic: StreamInventory): boolean {
-  return hasPayload(topic, FOXGLOVE_IMAGE_ANNOTATIONS_PAYLOAD);
+  return (
+    hasPayload(topic, FOXGLOVE_IMAGE_ANNOTATIONS_PAYLOAD) ||
+    hasAnyPayload(topic, FOXGLOVE_IMAGE_ANNOTATIONS_CDR_PAYLOADS)
+  );
 }
 
 /**
@@ -136,7 +150,9 @@ export function isImageAnnotationsStream(topic: StreamInventory): boolean {
 export function isPointCloudStream(topic: StreamInventory): boolean {
   return (
     hasPayload(topic, FOXGLOVE_POINT_CLOUD_PAYLOAD) ||
+    hasAnyPayload(topic, FOXGLOVE_POINT_CLOUD_CDR_PAYLOADS) ||
     hasPayload(topic, FOXGLOVE_LASER_SCAN_PAYLOAD) ||
+    hasAnyPayload(topic, FOXGLOVE_LASER_SCAN_CDR_PAYLOADS) ||
     hasAnyPayload(topic, JSON_ROS_POINT_CLOUD2_PAYLOADS) ||
     hasAnyPayload(topic, JSON_ROS_LASER_SCAN_PAYLOADS) ||
     hasAnyPayload(topic, ROS_POINT_CLOUD2_PAYLOADS) ||
@@ -150,6 +166,7 @@ export function isPointCloudStream(topic: StreamInventory): boolean {
 export function isSceneUpdateStream(topic: StreamInventory): boolean {
   return (
     hasPayload(topic, FOXGLOVE_SCENE_UPDATE_PAYLOAD) ||
+    hasAnyPayload(topic, FOXGLOVE_SCENE_UPDATE_CDR_PAYLOADS) ||
     hasAnyPayload(topic, JSON_ROS_MARKER_PAYLOADS) ||
     hasAnyPayload(topic, JSON_ROS_MARKER_ARRAY_PAYLOADS) ||
     hasAnyPayload(topic, ROS_MARKER_PAYLOADS) ||
@@ -163,6 +180,7 @@ export function isSceneUpdateStream(topic: StreamInventory): boolean {
 export function isGridStream(topic: StreamInventory): boolean {
   return (
     hasPayload(topic, FOXGLOVE_GRID_PAYLOAD) ||
+    hasAnyPayload(topic, FOXGLOVE_GRID_CDR_PAYLOADS) ||
     hasAnyPayload(topic, JSON_ROS_OCCUPANCY_GRID_PAYLOADS) ||
     hasAnyPayload(topic, ROS_OCCUPANCY_GRID_PAYLOADS)
   );
@@ -175,6 +193,7 @@ export function isGridStream(topic: StreamInventory): boolean {
 export function isCameraCalibrationStream(topic: StreamInventory): boolean {
   return (
     hasPayload(topic, FOXGLOVE_CAMERA_CALIBRATION_PAYLOAD) ||
+    hasAnyPayload(topic, FOXGLOVE_CAMERA_CALIBRATION_CDR_PAYLOADS) ||
     hasAnyPayload(topic, JSON_ROS_CAMERA_INFO_PAYLOADS) ||
     hasAnyPayload(topic, ROS_CAMERA_INFO_PAYLOADS)
   );
@@ -187,6 +206,7 @@ export function isCameraCalibrationStream(topic: StreamInventory): boolean {
 export function isPoseStream(topic: StreamInventory): boolean {
   return (
     hasPayload(topic, FOXGLOVE_POSE_IN_FRAME_PAYLOAD) ||
+    hasAnyPayload(topic, FOXGLOVE_POSE_IN_FRAME_CDR_PAYLOADS) ||
     hasPayload(topic, JSON_POSE_PAYLOAD) ||
     hasAnyPayload(topic, JSON_ROS_POSE_STAMPED_PAYLOADS) ||
     hasAnyPayload(topic, JSON_ROS_ODOMETRY_PAYLOADS) ||
@@ -202,6 +222,7 @@ export function isPoseStream(topic: StreamInventory): boolean {
 export function isLocationFixStream(topic: StreamInventory): boolean {
   return (
     hasPayload(topic, FOXGLOVE_LOCATION_FIX_PAYLOAD) ||
+    hasAnyPayload(topic, FOXGLOVE_LOCATION_FIX_CDR_PAYLOADS) ||
     hasAnyPayload(topic, JSON_ROS_NAV_SAT_FIX_PAYLOADS) ||
     hasAnyPayload(topic, ROS_NAV_SAT_FIX_PAYLOADS)
   );

--- a/app/packages/multimodal/src/adapters/mcap/stream-topics.ts
+++ b/app/packages/multimodal/src/adapters/mcap/stream-topics.ts
@@ -4,6 +4,8 @@ import {
   JSON_POSE_PAYLOAD,
   JSON_ROS_CAMERA_INFO_PAYLOADS,
   JSON_ROS_COMPRESSED_IMAGE_PAYLOADS,
+  JSON_ROS_DETECTION_2D_ARRAY_PAYLOADS,
+  JSON_ROS_DETECTION_3D_ARRAY_PAYLOADS,
   JSON_ROS_IMAGE_PAYLOADS,
   JSON_ROS_LASER_SCAN_PAYLOADS,
   JSON_ROS_MARKER_ARRAY_PAYLOADS,
@@ -41,6 +43,8 @@ import {
 import {
   ROS_CAMERA_INFO_PAYLOADS,
   ROS_COMPRESSED_IMAGE_PAYLOADS,
+  ROS_DETECTION_2D_ARRAY_PAYLOADS,
+  ROS_DETECTION_3D_ARRAY_PAYLOADS,
   ROS_IMAGE_PAYLOADS,
   ROS_LASER_SCAN_PAYLOADS,
   ROS_MARKER_ARRAY_PAYLOADS,
@@ -143,7 +147,9 @@ export function isCompressedImageStream(topic: StreamInventory): boolean {
 export function isImageAnnotationsStream(topic: StreamInventory): boolean {
   return (
     hasPayload(topic, FOXGLOVE_IMAGE_ANNOTATIONS_PAYLOAD) ||
-    hasAnyPayload(topic, FOXGLOVE_IMAGE_ANNOTATIONS_CDR_PAYLOADS)
+    hasAnyPayload(topic, FOXGLOVE_IMAGE_ANNOTATIONS_CDR_PAYLOADS) ||
+    hasAnyPayload(topic, JSON_ROS_DETECTION_2D_ARRAY_PAYLOADS) ||
+    hasAnyPayload(topic, ROS_DETECTION_2D_ARRAY_PAYLOADS)
   );
 }
 
@@ -175,10 +181,12 @@ export function isSceneUpdateStream(topic: StreamInventory): boolean {
     hasAnyPayload(topic, JSON_ROS_MARKER_ARRAY_PAYLOADS) ||
     hasAnyPayload(topic, JSON_ROS_PATH_PAYLOADS) ||
     hasAnyPayload(topic, JSON_ROS_POSE_ARRAY_PAYLOADS) ||
+    hasAnyPayload(topic, JSON_ROS_DETECTION_3D_ARRAY_PAYLOADS) ||
     hasAnyPayload(topic, ROS_MARKER_PAYLOADS) ||
     hasAnyPayload(topic, ROS_MARKER_ARRAY_PAYLOADS) ||
     hasAnyPayload(topic, ROS_PATH_PAYLOADS) ||
-    hasAnyPayload(topic, ROS_POSE_ARRAY_PAYLOADS)
+    hasAnyPayload(topic, ROS_POSE_ARRAY_PAYLOADS) ||
+    hasAnyPayload(topic, ROS_DETECTION_3D_ARRAY_PAYLOADS)
   );
 }
 

--- a/app/packages/multimodal/src/adapters/mcap/stream-topics.ts
+++ b/app/packages/multimodal/src/adapters/mcap/stream-topics.ts
@@ -6,6 +6,7 @@ import {
   JSON_ROS_COMPRESSED_IMAGE_PAYLOADS,
   JSON_ROS_DETECTION_2D_ARRAY_PAYLOADS,
   JSON_ROS_DETECTION_3D_ARRAY_PAYLOADS,
+  JSON_ROS_DIAGNOSTIC_ARRAY_PAYLOADS,
   JSON_ROS_IMAGE_PAYLOADS,
   JSON_ROS_LASER_SCAN_PAYLOADS,
   JSON_ROS_MARKER_ARRAY_PAYLOADS,
@@ -17,6 +18,8 @@ import {
   JSON_ROS_POINT_CLOUD2_PAYLOADS,
   JSON_ROS_POSE_ARRAY_PAYLOADS,
   JSON_ROS_POSE_STAMPED_PAYLOADS,
+  JSON_ROS_RCL_LOG_PAYLOADS,
+  JSON_ROS_ROSGRAPH_LOG_PAYLOADS,
 } from "./decoders/json/payloads";
 import {
   FOXGLOVE_CAMERA_CALIBRATION_CDR_PAYLOADS,
@@ -32,6 +35,8 @@ import {
   FOXGLOVE_LASER_SCAN_PAYLOAD,
   FOXGLOVE_LOCATION_FIX_CDR_PAYLOADS,
   FOXGLOVE_LOCATION_FIX_PAYLOAD,
+  FOXGLOVE_LOG_CDR_PAYLOADS,
+  FOXGLOVE_LOG_PAYLOAD,
   FOXGLOVE_POINT_CLOUD_CDR_PAYLOADS,
   FOXGLOVE_POSE_IN_FRAME_CDR_PAYLOADS,
   FOXGLOVE_POSE_IN_FRAME_PAYLOAD,
@@ -45,6 +50,7 @@ import {
   ROS_COMPRESSED_IMAGE_PAYLOADS,
   ROS_DETECTION_2D_ARRAY_PAYLOADS,
   ROS_DETECTION_3D_ARRAY_PAYLOADS,
+  ROS_DIAGNOSTIC_ARRAY_PAYLOADS,
   ROS_IMAGE_PAYLOADS,
   ROS_LASER_SCAN_PAYLOADS,
   ROS_MARKER_ARRAY_PAYLOADS,
@@ -56,6 +62,8 @@ import {
   ROS_POINT_CLOUD2_PAYLOADS,
   ROS_POSE_ARRAY_PAYLOADS,
   ROS_POSE_STAMPED_PAYLOADS,
+  ROS_RCL_LOG_PAYLOADS,
+  ROS_ROSGRAPH_LOG_PAYLOADS,
 } from "./decoders/ros/payloads";
 
 /**
@@ -64,6 +72,7 @@ import {
 export interface McapPreviewTopics {
   readonly annotations: readonly string[];
   readonly image: readonly string[];
+  readonly logs: readonly string[];
   readonly pointCloud: readonly string[];
   readonly previewable: readonly string[];
   readonly sceneUpdates: readonly string[];
@@ -77,6 +86,7 @@ export function streamTopics(
 ): McapPreviewTopics {
   const image: string[] = [];
   const annotations: string[] = [];
+  const logs: string[] = [];
   const pointCloud: string[] = [];
   const sceneUpdates: string[] = [];
 
@@ -94,14 +104,17 @@ export function streamTopics(
       annotations.push(name);
     } else if (isSceneUpdateStream(topic)) {
       sceneUpdates.push(name);
+    } else if (isLogStream(topic)) {
+      logs.push(name);
     }
   }
 
   return {
     annotations,
     image,
+    logs,
     pointCloud,
-    previewable: [...image, ...pointCloud],
+    previewable: [...image, ...pointCloud, ...logs],
     sceneUpdates,
   };
 }
@@ -241,6 +254,22 @@ export function isLocationFixStream(topic: StreamInventory): boolean {
     hasAnyPayload(topic, FOXGLOVE_LOCATION_FIX_CDR_PAYLOADS) ||
     hasAnyPayload(topic, JSON_ROS_NAV_SAT_FIX_PAYLOADS) ||
     hasAnyPayload(topic, ROS_NAV_SAT_FIX_PAYLOADS)
+  );
+}
+
+/**
+ * Returns whether a stream inventory item is a supported log/diagnostic stream.
+ */
+export function isLogStream(topic: StreamInventory): boolean {
+  return (
+    hasPayload(topic, FOXGLOVE_LOG_PAYLOAD) ||
+    hasAnyPayload(topic, FOXGLOVE_LOG_CDR_PAYLOADS) ||
+    hasAnyPayload(topic, JSON_ROS_ROSGRAPH_LOG_PAYLOADS) ||
+    hasAnyPayload(topic, JSON_ROS_RCL_LOG_PAYLOADS) ||
+    hasAnyPayload(topic, JSON_ROS_DIAGNOSTIC_ARRAY_PAYLOADS) ||
+    hasAnyPayload(topic, ROS_ROSGRAPH_LOG_PAYLOADS) ||
+    hasAnyPayload(topic, ROS_RCL_LOG_PAYLOADS) ||
+    hasAnyPayload(topic, ROS_DIAGNOSTIC_ARRAY_PAYLOADS)
   );
 }
 

--- a/app/packages/multimodal/src/adapters/mcap/topic-inventory.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/topic-inventory.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+import type { StreamInventory } from "../../schemas/v1";
+import { mcapSceneSources } from "./scene-sources";
+import {
+  MCAP_TOPIC_CAPABILITY,
+  MCAP_TOPIC_CATEGORY,
+  buildMcapTopicInventoryRows,
+  filterMcapTopicInventoryRows,
+  type McapTopicInventoryRow,
+} from "./topic-inventory";
+
+describe("buildMcapTopicInventoryRows", () => {
+  it("keeps all topics and buckets them by customer job", () => {
+    const topics = [
+      topic("/camera/front", "sensor_msgs/Image", "ros1", "ros1msg", "12"),
+      topic("/lidar/top", "sensor_msgs/PointCloud2", "ros1", "ros1msg", "8"),
+      topic(
+        "/markers",
+        "visualization_msgs/msg/MarkerArray",
+        "cdr",
+        "ros2msg",
+        "4",
+      ),
+      topic("/plan", "nav_msgs/Path", "ros1", "ros1msg", "5"),
+      topic("/odom", "nav_msgs/msg/Odometry", "cdr", "ros2msg", "6"),
+      topic("/tf_static", "tf2_msgs/TFMessage", "ros1", "ros1msg", "2"),
+      topic(
+        "/diagnostics",
+        "diagnostic_msgs/DiagnosticArray",
+        "ros1",
+        "ros1msg",
+        "7",
+      ),
+      topic("/imu", "sensor_msgs/msg/Imu", "cdr", "ros2msg", "9"),
+      topic("/vendor/raw", "vendor_msgs/Widget", "cdr", "ros2msg", "3"),
+      topic(
+        "/broken",
+        "vendor_msgs/Broken",
+        "cdr",
+        "ros2msg",
+        "1",
+        "schema-unavailable",
+      ),
+      topic(
+        "/binary",
+        "vendor.Binary",
+        "cbor",
+        "protobuf",
+        "1",
+        "unsupported-encoding",
+      ),
+    ];
+
+    const rows = buildMcapTopicInventoryRows({
+      sceneSources: mcapSceneSources(topics),
+      topics,
+    });
+
+    expect(rows.map((row) => row.topic)).toEqual([
+      "/camera/front",
+      "/lidar/top",
+      "/markers",
+      "/plan",
+      "/odom",
+      "/tf_static",
+      "/diagnostics",
+      "/imu",
+      "/binary",
+      "/broken",
+      "/vendor/raw",
+    ]);
+    expect(row(rows, "/camera/front")).toMatchObject({
+      category: MCAP_TOPIC_CATEGORY.SENSORS,
+      supportStatus: "renderable",
+      capabilities: [MCAP_TOPIC_CAPABILITY.IMAGE, MCAP_TOPIC_CAPABILITY.RAW],
+    });
+    expect(row(rows, "/markers")).toMatchObject({
+      category: MCAP_TOPIC_CATEGORY.ANNOTATIONS_PLANNING,
+      supportStatus: "renderable",
+      capabilities: [MCAP_TOPIC_CAPABILITY.THREE_D, MCAP_TOPIC_CAPABILITY.RAW],
+    });
+    expect(row(rows, "/tf_static")).toMatchObject({
+      category: MCAP_TOPIC_CATEGORY.TRANSFORMS_POSES,
+      sourceType: null,
+      supportStatus: "renderable",
+      capabilities: [MCAP_TOPIC_CAPABILITY.THREE_D, MCAP_TOPIC_CAPABILITY.RAW],
+    });
+    expect(row(rows, "/diagnostics")).toMatchObject({
+      category: MCAP_TOPIC_CATEGORY.DIAGNOSTICS,
+      supportStatus: "renderable",
+      capabilities: [MCAP_TOPIC_CAPABILITY.LOGS, MCAP_TOPIC_CAPABILITY.RAW],
+    });
+    expect(row(rows, "/imu")).toMatchObject({
+      category: MCAP_TOPIC_CATEGORY.TELEMETRY,
+      supportStatus: "inspectable",
+      capabilities: [MCAP_TOPIC_CAPABILITY.PLOT, MCAP_TOPIC_CAPABILITY.RAW],
+    });
+    expect(row(rows, "/vendor/raw")).toMatchObject({
+      category: MCAP_TOPIC_CATEGORY.CUSTOM,
+      supportStatus: "inspectable",
+      capabilities: [MCAP_TOPIC_CAPABILITY.RAW],
+    });
+    expect(row(rows, "/broken")).toMatchObject({
+      supportStatus: "schema-unavailable",
+      capabilities: [],
+    });
+    expect(row(rows, "/binary")).toMatchObject({
+      supportStatus: "encoding-unsupported",
+      capabilities: [],
+    });
+  });
+
+  it("searches topic names, schema names, categories, support, and capabilities", () => {
+    const rows = buildMcapTopicInventoryRows({
+      sceneSources: [],
+      topics: [
+        topic("/imu", "sensor_msgs/Imu", "ros1", "ros1msg", "9"),
+        topic("/vendor/raw", "vendor_msgs/Widget", "cdr", "ros2msg", "3"),
+      ],
+    });
+
+    expect(
+      filterMcapTopicInventoryRows(rows, "telemetry").map(topicName),
+    ).toEqual(["/imu"]);
+    expect(filterMcapTopicInventoryRows(rows, "Widget").map(topicName)).toEqual(
+      ["/vendor/raw"],
+    );
+    expect(filterMcapTopicInventoryRows(rows, "plot").map(topicName)).toEqual([
+      "/imu",
+    ]);
+    expect(filterMcapTopicInventoryRows(rows, "unsupported")).toEqual([]);
+  });
+});
+
+function row(rows: readonly McapTopicInventoryRow[], topic: string) {
+  const match = rows.find((candidate) => candidate.topic === topic);
+  expect(match).toBeTruthy();
+  return match;
+}
+
+function topicName(row: { readonly topic: string }): string {
+  return row.topic;
+}
+
+function topic(
+  name: string,
+  schema: string,
+  encoding: string,
+  schemaEncoding: string,
+  count: string,
+  decodeStatus = "decodable",
+): StreamInventory {
+  return {
+    $typeName: "fiftyone.multimodal.schemas.v1.StreamInventory",
+    displayName: name,
+    metadata: {
+      "mcap.generic_decode_status": decodeStatus,
+      "mcap.message_encoding": encoding,
+      "mcap.schema_name": schema,
+      "mcap.topic": name,
+    },
+    payload: {
+      $typeName: "fiftyone.multimodal.schemas.v1.PayloadDescriptor",
+      encoding,
+      schema,
+      schemaEncoding,
+    },
+    recordCount: count,
+    streamId: name,
+  };
+}

--- a/app/packages/multimodal/src/adapters/mcap/topic-inventory.ts
+++ b/app/packages/multimodal/src/adapters/mcap/topic-inventory.ts
@@ -1,0 +1,375 @@
+import type { SceneSource } from "../../scene-inventory";
+import type { StreamInventory } from "../../schemas/v1";
+import {
+  MCAP_SOURCE_TYPE,
+  mcapSourceTypeForTopic,
+  type McapSourceType,
+} from "./scene-sources";
+import {
+  isFrameTransformStream,
+  isImageAnnotationsStream,
+  isLogStream,
+  isSceneUpdateStream,
+  topicName,
+} from "./stream-topics";
+
+export const MCAP_TOPIC_CATEGORY = {
+  SENSORS: "sensors",
+  ANNOTATIONS_PLANNING: "annotations-planning",
+  TRANSFORMS_POSES: "transforms-poses",
+  DIAGNOSTICS: "diagnostics",
+  TELEMETRY: "telemetry",
+  CUSTOM: "custom",
+} as const;
+
+export type McapTopicCategory =
+  (typeof MCAP_TOPIC_CATEGORY)[keyof typeof MCAP_TOPIC_CATEGORY];
+
+export const MCAP_TOPIC_CATEGORY_ORDER: readonly McapTopicCategory[] = [
+  MCAP_TOPIC_CATEGORY.SENSORS,
+  MCAP_TOPIC_CATEGORY.ANNOTATIONS_PLANNING,
+  MCAP_TOPIC_CATEGORY.TRANSFORMS_POSES,
+  MCAP_TOPIC_CATEGORY.DIAGNOSTICS,
+  MCAP_TOPIC_CATEGORY.TELEMETRY,
+  MCAP_TOPIC_CATEGORY.CUSTOM,
+];
+
+export const MCAP_TOPIC_CATEGORY_LABEL: Record<McapTopicCategory, string> = {
+  [MCAP_TOPIC_CATEGORY.SENSORS]: "Sensors",
+  [MCAP_TOPIC_CATEGORY.ANNOTATIONS_PLANNING]: "Annotations & Planning",
+  [MCAP_TOPIC_CATEGORY.TRANSFORMS_POSES]: "Transforms & Poses",
+  [MCAP_TOPIC_CATEGORY.DIAGNOSTICS]: "Diagnostics",
+  [MCAP_TOPIC_CATEGORY.TELEMETRY]: "Telemetry",
+  [MCAP_TOPIC_CATEGORY.CUSTOM]: "Custom / Unknown",
+};
+
+export const MCAP_TOPIC_CAPABILITY = {
+  IMAGE: "image",
+  LOGS: "logs",
+  PLOT: "plot",
+  RAW: "raw",
+  THREE_D: "three-d",
+} as const;
+
+export type McapTopicCapability =
+  (typeof MCAP_TOPIC_CAPABILITY)[keyof typeof MCAP_TOPIC_CAPABILITY];
+
+export const MCAP_TOPIC_CAPABILITY_LABEL: Record<McapTopicCapability, string> =
+  {
+    [MCAP_TOPIC_CAPABILITY.IMAGE]: "Image",
+    [MCAP_TOPIC_CAPABILITY.LOGS]: "Logs",
+    [MCAP_TOPIC_CAPABILITY.PLOT]: "Plot",
+    [MCAP_TOPIC_CAPABILITY.RAW]: "Raw",
+    [MCAP_TOPIC_CAPABILITY.THREE_D]: "3D",
+  };
+
+export type McapTopicSupportStatus =
+  | "encoding-unsupported"
+  | "inspectable"
+  | "no-decoder"
+  | "renderable"
+  | "schema-unavailable";
+
+export const MCAP_TOPIC_SUPPORT_LABEL: Record<McapTopicSupportStatus, string> =
+  {
+    "encoding-unsupported": "Encoding unsupported",
+    inspectable: "Inspectable",
+    "no-decoder": "No decoder",
+    renderable: "Supported",
+    "schema-unavailable": "Schema unavailable",
+  };
+
+export interface McapTopicInventoryRow {
+  readonly canInspect: boolean;
+  readonly capabilities: readonly McapTopicCapability[];
+  readonly category: McapTopicCategory;
+  readonly countLabel: string;
+  readonly encoding: string;
+  readonly recordCount: number | null;
+  readonly schemaName: string;
+  readonly sourceType: McapSourceType | null;
+  readonly supportStatus: McapTopicSupportStatus;
+  readonly topic: string;
+}
+
+type GenericDecodeStatus =
+  | "decodable"
+  | "schema-unavailable"
+  | "unsupported-encoding"
+  | "unknown";
+
+const TELEMETRY_SCHEMAS: ReadonlySet<string> = new Set([
+  "ackermann_msgs/AckermannDrive",
+  "ackermann_msgs/AckermannDriveStamped",
+  "ackermann_msgs/msg/AckermannDrive",
+  "ackermann_msgs/msg/AckermannDriveStamped",
+  "geometry_msgs/Twist",
+  "geometry_msgs/TwistStamped",
+  "geometry_msgs/msg/Twist",
+  "geometry_msgs/msg/TwistStamped",
+  "sensor_msgs/BatteryState",
+  "sensor_msgs/FluidPressure",
+  "sensor_msgs/Imu",
+  "sensor_msgs/JointState",
+  "sensor_msgs/MagneticField",
+  "sensor_msgs/Temperature",
+  "sensor_msgs/msg/BatteryState",
+  "sensor_msgs/msg/FluidPressure",
+  "sensor_msgs/msg/Imu",
+  "sensor_msgs/msg/JointState",
+  "sensor_msgs/msg/MagneticField",
+  "sensor_msgs/msg/Temperature",
+]);
+
+/**
+ * Builds the customer-facing topic inventory for the MCAP sidebar. The result
+ * is static and schema-derived: `renderable` means the adapter knows how the
+ * topic participates in a panel, not that the topic is currently visible.
+ */
+export function buildMcapTopicInventoryRows({
+  sceneSources,
+  topics,
+}: {
+  readonly sceneSources: readonly SceneSource[];
+  readonly topics: readonly StreamInventory[];
+}): readonly McapTopicInventoryRow[] {
+  const sceneSourceTypes = new Map(
+    sceneSources.map((source) => [source.id, source.type]),
+  );
+
+  return topics
+    .map((stream) => {
+      const name = topicName(stream);
+      if (!name) {
+        return null;
+      }
+
+      const sourceType =
+        mcapSourceTypeForTopic(stream) ??
+        knownMcapSourceType(sceneSourceTypes.get(name));
+      const frameTransform = isFrameTransformStream(stream);
+      const decodeStatus = genericDecodeStatus(
+        stream.metadata["mcap.generic_decode_status"],
+      );
+      const canInspect = decodeStatus === "decodable";
+      const schemaName = schemaNameFor(stream);
+      const telemetry = isTelemetrySchema(schemaName);
+
+      return {
+        canInspect,
+        capabilities: capabilitiesForTopic({
+          canInspect,
+          frameTransform,
+          sourceType,
+          telemetry,
+        }),
+        category: categoryForTopic({
+          frameTransform,
+          sourceType,
+          stream,
+          telemetry,
+        }),
+        countLabel: messageCountLabel(stream.recordCount),
+        encoding: encodingFor(stream),
+        recordCount: recordCountFor(stream.recordCount),
+        schemaName,
+        sourceType,
+        supportStatus: supportStatusFor({
+          decodeStatus,
+          frameTransform,
+          sourceType,
+        }),
+        topic: name,
+      };
+    })
+    .filter((row): row is McapTopicInventoryRow => row !== null)
+    .sort(compareTopicRows);
+}
+
+export function filterMcapTopicInventoryRows(
+  rows: readonly McapTopicInventoryRow[],
+  search: string,
+): readonly McapTopicInventoryRow[] {
+  const needle = search.trim().toLowerCase();
+  if (!needle) {
+    return rows;
+  }
+
+  return rows.filter((row) =>
+    [
+      row.topic,
+      row.schemaName,
+      row.encoding,
+      MCAP_TOPIC_CATEGORY_LABEL[row.category],
+      MCAP_TOPIC_SUPPORT_LABEL[row.supportStatus],
+      ...row.capabilities.map(
+        (capability) => MCAP_TOPIC_CAPABILITY_LABEL[capability],
+      ),
+    ].some((value) => value.toLowerCase().includes(needle)),
+  );
+}
+
+export function messageCountLabel(recordCount: string | undefined): string {
+  const count = recordCountFor(recordCount);
+  if (count === null) {
+    return "unknown msgs";
+  }
+  return `${count.toLocaleString()} ${count === 1 ? "msg" : "msgs"}`;
+}
+
+function categoryForTopic({
+  frameTransform,
+  sourceType,
+  stream,
+  telemetry,
+}: {
+  readonly frameTransform: boolean;
+  readonly sourceType: McapSourceType | null;
+  readonly stream: StreamInventory;
+  readonly telemetry: boolean;
+}): McapTopicCategory {
+  if (sourceType === MCAP_SOURCE_TYPE.LOG || isLogStream(stream)) {
+    return MCAP_TOPIC_CATEGORY.DIAGNOSTICS;
+  }
+  if (
+    sourceType === MCAP_SOURCE_TYPE.IMAGE_ANNOTATION ||
+    sourceType === MCAP_SOURCE_TYPE.SCENE_ANNOTATION ||
+    isImageAnnotationsStream(stream) ||
+    isSceneUpdateStream(stream)
+  ) {
+    return MCAP_TOPIC_CATEGORY.ANNOTATIONS_PLANNING;
+  }
+  if (sourceType === MCAP_SOURCE_TYPE.POSE || frameTransform) {
+    return MCAP_TOPIC_CATEGORY.TRANSFORMS_POSES;
+  }
+  if (sourceType !== null) {
+    return MCAP_TOPIC_CATEGORY.SENSORS;
+  }
+  if (telemetry) {
+    return MCAP_TOPIC_CATEGORY.TELEMETRY;
+  }
+  return MCAP_TOPIC_CATEGORY.CUSTOM;
+}
+
+function capabilitiesForTopic({
+  canInspect,
+  frameTransform,
+  sourceType,
+  telemetry,
+}: {
+  readonly canInspect: boolean;
+  readonly frameTransform: boolean;
+  readonly sourceType: McapSourceType | null;
+  readonly telemetry: boolean;
+}): readonly McapTopicCapability[] {
+  const capabilities: McapTopicCapability[] = [];
+
+  if (
+    sourceType === MCAP_SOURCE_TYPE.IMAGE ||
+    sourceType === MCAP_SOURCE_TYPE.IMAGE_ANNOTATION ||
+    sourceType === MCAP_SOURCE_TYPE.CAMERA_CALIBRATION
+  ) {
+    capabilities.push(MCAP_TOPIC_CAPABILITY.IMAGE);
+  }
+
+  if (
+    frameTransform ||
+    sourceType === MCAP_SOURCE_TYPE.CAMERA_CALIBRATION ||
+    sourceType === MCAP_SOURCE_TYPE.LOCATION ||
+    sourceType === MCAP_SOURCE_TYPE.MAP_LAYER ||
+    sourceType === MCAP_SOURCE_TYPE.POINT_CLOUD ||
+    sourceType === MCAP_SOURCE_TYPE.POSE ||
+    sourceType === MCAP_SOURCE_TYPE.SCENE_ANNOTATION
+  ) {
+    capabilities.push(MCAP_TOPIC_CAPABILITY.THREE_D);
+  }
+
+  if (sourceType === MCAP_SOURCE_TYPE.LOG) {
+    capabilities.push(MCAP_TOPIC_CAPABILITY.LOGS);
+  }
+
+  if (telemetry) {
+    capabilities.push(MCAP_TOPIC_CAPABILITY.PLOT);
+  }
+
+  if (canInspect) {
+    capabilities.push(MCAP_TOPIC_CAPABILITY.RAW);
+  }
+
+  return Array.from(new Set(capabilities));
+}
+
+function supportStatusFor({
+  decodeStatus,
+  frameTransform,
+  sourceType,
+}: {
+  readonly decodeStatus: GenericDecodeStatus;
+  readonly frameTransform: boolean;
+  readonly sourceType: McapSourceType | null;
+}): McapTopicSupportStatus {
+  if (sourceType !== null || frameTransform) {
+    return "renderable";
+  }
+  if (decodeStatus === "decodable") {
+    return "inspectable";
+  }
+  if (decodeStatus === "schema-unavailable") {
+    return "schema-unavailable";
+  }
+  if (decodeStatus === "unsupported-encoding") {
+    return "encoding-unsupported";
+  }
+  return "no-decoder";
+}
+
+function compareTopicRows(
+  left: McapTopicInventoryRow,
+  right: McapTopicInventoryRow,
+): number {
+  const categoryDelta =
+    MCAP_TOPIC_CATEGORY_ORDER.indexOf(left.category) -
+    MCAP_TOPIC_CATEGORY_ORDER.indexOf(right.category);
+  return categoryDelta || left.topic.localeCompare(right.topic);
+}
+
+function isTelemetrySchema(schemaName: string): boolean {
+  return TELEMETRY_SCHEMAS.has(schemaName);
+}
+
+function genericDecodeStatus(status: string | undefined): GenericDecodeStatus {
+  switch (status) {
+    case "decodable":
+    case "schema-unavailable":
+    case "unsupported-encoding":
+      return status;
+    default:
+      return "unknown";
+  }
+}
+
+function schemaNameFor(topic: StreamInventory): string {
+  return (
+    topic.metadata["mcap.schema_name"] ?? topic.payload?.schema ?? "no schema"
+  );
+}
+
+function encodingFor(topic: StreamInventory): string {
+  return (
+    topic.metadata["mcap.message_encoding"] ??
+    topic.payload?.encoding ??
+    "unknown"
+  );
+}
+
+function recordCountFor(recordCount: string | undefined): number | null {
+  const count = recordCount === undefined ? Number.NaN : Number(recordCount);
+  return Number.isFinite(count) && count >= 0 ? count : null;
+}
+
+function knownMcapSourceType(type: string | undefined): McapSourceType | null {
+  return type !== undefined &&
+    (Object.values(MCAP_SOURCE_TYPE) as readonly string[]).includes(type)
+    ? (type as McapSourceType)
+    : null;
+}


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

Adds MCAP rendering and inspection support for ROS markers, scene updates, paths, pose arrays, vision detections, Foxglove ROS2 CDR schemas, logs, diagnostics, and a categorized Topics tab in the MCAP settings sidebar.

## 🧪 How is this patch tested? If it is not, please explain why.

- `yarn vitest run --no-coverage packages/multimodal/src/adapters/mcap`
- `yarn workspace @fiftyone/multimodal check`
- `coderabbit review --agent -t committed --base origin/sash/mm-mcap-other-topics-support -c .coderabbit.yaml`

## Notes to Reviewer

Stacked on #7964. Best reviewed commit-by-commit.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Adds MCAP support for additional ROS/Foxglove streams, including markers, scene updates, paths, pose arrays, vision detections, logs/diagnostics, and categorized topic inspection.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
