### PR TITLE
Add geo MCAP map tile

### DIFF
--- a/app/packages/multimodal/package.json
+++ b/app/packages/multimodal/package.json
@@ -84,6 +84,7 @@
         "date-fns": "^4.1.0",
         "jotai": "^2.9.3",
         "lru-cache": "^11.0.1",
+        "maplibre-gl": "^4.7.1",
         "meshoptimizer": "^0.22.0",
         "protobufjs": "^7.6.4",
         "three": "patch:three@npm%3A0.185.1#~/.yarn/patches/three-npm-0.185.1-e07195d8b4.patch",

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros.test.ts
@@ -1588,6 +1588,8 @@ describe("ROS MCAP decoders", () => {
     expect(output.visualization).toMatchObject({
       altitude: 12.5,
       coordinateFrameId: "gps",
+      fixService: 1,
+      fixStatus: 0,
       latitude: 37.77,
       longitude: -122.42,
       positionCovariance: [1, 0, 0, 0, 2, 0, 0, 0, 3],

--- a/app/packages/multimodal/src/adapters/mcap/decoders/ros/nav-sat-fix.ts
+++ b/app/packages/multimodal/src/adapters/mcap/decoders/ros/nav-sat-fix.ts
@@ -67,9 +67,9 @@ export function decodeRosNavSatFixRecord(
       ? covariance(message)
       : undefined;
 
-  const status = statusAttributes(recordField(message, "status"));
-  if (status) {
-    attributes.status = status;
+  const navSatStatus = navSatStatusValues(recordField(message, "status"));
+  if (navSatStatus.attributes) {
+    attributes.status = navSatStatus.attributes;
   }
 
   // Match the Foxglove LocationFix heuristic: many drivers emit altitude 0
@@ -78,6 +78,12 @@ export function decodeRosNavSatFixRecord(
     ...(Number.isFinite(altitude) && altitude !== 0 ? { altitude } : {}),
     ...(frameId ? { coordinateFrameId: frameId } : {}),
     kind: VISUALIZATION_KIND.LOCATION,
+    ...(navSatStatus.fixService !== undefined
+      ? { fixService: navSatStatus.fixService }
+      : {}),
+    ...(navSatStatus.fixStatus !== undefined
+      ? { fixStatus: navSatStatus.fixStatus }
+      : {}),
     latitude,
     longitude,
     ...(positionCovariance ? { positionCovariance } : {}),
@@ -100,22 +106,31 @@ function covariance(
   return values.length === COVARIANCE_LENGTH ? values : undefined;
 }
 
-function statusAttributes(
-  status: Record<string, unknown> | undefined,
-): DecodedAttributeValue | undefined {
+function navSatStatusValues(status: Record<string, unknown> | undefined): {
+  readonly attributes?: DecodedAttributeValue;
+  readonly fixService?: number;
+  readonly fixStatus?: number;
+} {
   if (!status) {
-    return undefined;
+    return {};
   }
 
-  const result: Record<string, DecodedAttributeValue> = {};
   const statusValue = numberField(status, "status", undefined, Number.NaN);
   const service = numberField(status, "service", undefined, Number.NaN);
-  if (Number.isFinite(statusValue)) {
-    result.status = statusValue;
+  const fixStatus = Number.isFinite(statusValue) ? statusValue : undefined;
+  const fixService = Number.isFinite(service) ? service : undefined;
+
+  const result: Record<string, DecodedAttributeValue> = {};
+  if (fixStatus !== undefined) {
+    result.status = fixStatus;
   }
-  if (Number.isFinite(service)) {
-    result.service = service;
+  if (fixService !== undefined) {
+    result.service = fixService;
   }
 
-  return Object.keys(result).length > 0 ? result : undefined;
+  return {
+    attributes: Object.keys(result).length > 0 ? result : undefined,
+    fixService,
+    fixStatus,
+  };
 }

--- a/app/packages/multimodal/src/adapters/mcap/react/McapAddTileMenu.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapAddTileMenu.test.tsx
@@ -10,6 +10,7 @@ import McapAddTileMenu from "./McapAddTileMenu";
 vi.mock("./McapImageTile", () => ({ default: () => null }));
 vi.mock("./Mcap3dTile", () => ({ default: () => null }));
 vi.mock("./McapLogConsoleTile", () => ({ default: () => null }));
+vi.mock("./McapMapTile", () => ({ default: () => null }));
 vi.mock("./McapPlotTile", () => ({ default: () => null }));
 vi.mock("./McapRawMessageTile", () => ({ default: () => null }));
 
@@ -65,6 +66,7 @@ describe("McapAddTileMenu", () => {
 
     expect(screen.getByText("Image")).toBeTruthy();
     expect(screen.getByText("3D")).toBeTruthy();
+    expect(screen.getByText("Map")).toBeTruthy();
     expect(screen.getByText("Logs")).toBeTruthy();
     expect(screen.getByText("Plot")).toBeTruthy();
     expect(screen.getByText("Message")).toBeTruthy();

--- a/app/packages/multimodal/src/adapters/mcap/react/McapAddTileMenu.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapAddTileMenu.tsx
@@ -7,6 +7,7 @@ import { getMcapTileDefinition } from "./use-mcap-tiles";
 const MCAP_ADD_TILE_TYPES: readonly McapTileType[] = [
   MCAP_TILE_TYPE.IMAGE,
   MCAP_TILE_TYPE.THREE_D,
+  MCAP_TILE_TYPE.MAP,
   MCAP_TILE_TYPE.LOG,
   MCAP_TILE_TYPE.PLOT,
   MCAP_TILE_TYPE.RAW,

--- a/app/packages/multimodal/src/adapters/mcap/react/McapMapTile.module.css
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapMapTile.module.css
@@ -1,0 +1,228 @@
+/*
+ * Overlay chrome is keyed to the map imagery (and the fixed-dark no-tile
+ * canvas), not the app theme, so the glass palette is intentionally
+ * literal — but defined once here. The accent is the one theme-sourced
+ * color: Voxel51 primary, matching the ego puck and comet trail drawn in
+ * GL (which resolve the same variable at runtime).
+ */
+.body {
+  --map-surface: #06101a;
+  --map-accent: var(--fo-palette-primary-plainColor, #ff6d04);
+  --map-chrome-bg: rgb(4 12 22 / 76%);
+  --map-chrome-border: rgb(148 163 184 / 28%);
+  --map-chrome-border-subtle: rgb(148 163 184 / 22%);
+  --map-chrome-shadow: 0 8px 20px rgb(0 0 0 / 24%);
+  --map-measure: #22d3ee;
+  --map-text: #e2e8f0;
+  --map-text-muted: #94a3b8;
+
+  background: var(--map-surface);
+  color: var(--map-text);
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+  position: relative;
+  width: 100%;
+}
+
+.map {
+  height: 100%;
+  width: 100%;
+}
+
+.map :global(.maplibregl-ctrl-group) {
+  backdrop-filter: blur(10px);
+  background: var(--map-chrome-bg);
+  border: 1px solid var(--map-chrome-border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.map :global(.maplibregl-ctrl-group:not(:empty)) {
+  box-shadow: var(--map-chrome-shadow);
+}
+
+.map :global(.maplibregl-ctrl-group button) {
+  height: 28px;
+  width: 28px;
+}
+
+.map :global(.maplibregl-ctrl-group button + button) {
+  border-top: 1px solid var(--map-chrome-border-subtle);
+}
+
+.map :global(.maplibregl-ctrl-group button:not(:disabled):hover) {
+  background-color: rgb(56 189 248 / 16%);
+}
+
+.map :global(.maplibregl-ctrl-group button .maplibregl-ctrl-icon) {
+  filter: invert(96%) sepia(7%) saturate(489%) hue-rotate(177deg)
+    brightness(96%) contrast(88%);
+}
+
+.fallback {
+  height: 100%;
+  inset: 0;
+  position: absolute;
+  width: 100%;
+}
+
+.fallback svg {
+  display: block;
+  height: 100%;
+  width: 100%;
+}
+
+.overlay {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  left: 10px;
+  max-width: calc(100% - 20px);
+  pointer-events: none;
+  position: absolute;
+  top: 10px;
+  z-index: 2;
+}
+
+.statusBadge,
+.controlButton {
+  backdrop-filter: blur(10px);
+  background: var(--map-chrome-bg);
+  border: 1px solid var(--map-chrome-border);
+  border-radius: 6px;
+  box-shadow: var(--map-chrome-shadow);
+  color: var(--map-text);
+  font-size: 11px;
+  line-height: 1.2;
+  min-height: 28px;
+  padding: 6px 8px;
+}
+
+.statusBadge {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.controlButton {
+  cursor: pointer;
+  pointer-events: auto;
+}
+
+.controlButton:hover {
+  border-color: var(--map-accent);
+}
+
+.toolOverlay {
+  align-items: flex-end;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  pointer-events: none;
+  position: absolute;
+  right: 10px;
+  top: 78px;
+  z-index: 2;
+}
+
+.iconControlButton,
+.iconControlButtonActive,
+.measureReadout {
+  backdrop-filter: blur(10px);
+  background: var(--map-chrome-bg);
+  border: 1px solid var(--map-chrome-border);
+  border-radius: 6px;
+  box-shadow: var(--map-chrome-shadow);
+  color: var(--map-text);
+}
+
+.iconControlButton,
+.iconControlButtonActive {
+  align-items: center;
+  cursor: pointer;
+  display: inline-flex;
+  height: 28px;
+  justify-content: center;
+  padding: 0;
+  pointer-events: auto;
+  width: 28px;
+}
+
+.iconControlButtonActive {
+  border-color: var(--map-measure);
+  color: var(--map-measure);
+}
+
+.iconControlButton:hover,
+.iconControlButtonActive:hover {
+  border-color: var(--map-accent);
+}
+
+.measureReadout {
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.2;
+  max-width: min(220px, calc(100vw - 40px));
+  padding: 6px 8px;
+  pointer-events: none;
+  text-align: right;
+}
+
+.legend {
+  bottom: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  left: 10px;
+  max-width: min(360px, calc(100% - 20px));
+  pointer-events: none;
+  position: absolute;
+  z-index: 2;
+}
+
+.legendRow {
+  align-items: center;
+  backdrop-filter: blur(10px);
+  background: var(--map-chrome-bg);
+  border: 1px solid var(--map-chrome-border-subtle);
+  border-radius: 6px;
+  display: grid;
+  gap: 6px;
+  grid-template-columns: 10px minmax(0, 1fr) auto;
+  min-height: 24px;
+  padding: 4px 7px;
+}
+
+.legendSwatch {
+  border-radius: 50%;
+  height: 8px;
+  width: 8px;
+}
+
+.legendLabel,
+.legendMeta {
+  font-size: 11px;
+  line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.legendMeta {
+  color: var(--map-text-muted);
+}
+
+.emptyState {
+  align-items: center;
+  color: var(--map-text-muted);
+  display: flex;
+  font-size: 12px;
+  inset: 0;
+  justify-content: center;
+  line-height: 1.35;
+  padding: 16px;
+  position: absolute;
+  text-align: center;
+  z-index: 1;
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/McapMapTile.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapMapTile.tsx
@@ -1,0 +1,1496 @@
+import {
+  getHoverTime,
+  getPlayhead,
+  setHoverTime,
+  subscribeHoverTime,
+  subscribePlayhead,
+  useIsPlaying,
+  usePlayback,
+  usePlaybackStore,
+} from "@fiftyone/playback";
+import { useSetTileTitle } from "@fiftyone/tiling";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import MeasureRulerIcon from "../../../components/MeasureRulerIcon";
+import { useSceneInventory } from "../../../scene-inventory";
+import { MCAP_SOURCE_TYPE } from "../scene-sources";
+import { useMcapLocationTracksContext } from "./mcap-location-tracks-context";
+import {
+  combineLocationBounds,
+  interpolateLocationAtTime,
+  locationBounds,
+  locationTrailCoordinates,
+  type InterpolatedLocation,
+  type LocationBounds,
+  type McapLocationTrackSegment,
+  type McapLocationTrackState,
+} from "./mcap-location-track";
+import {
+  ensurePuckImages,
+  hexColorWithAlpha,
+  puckImageId,
+  PUCK_VARIANT,
+} from "./mcap-map-puck";
+import {
+  formatMapMeasurementDistance,
+  mapMeasurementDistance,
+  nextMapMeasurementState,
+  type MapMeasurementPoint,
+  type MapMeasurementState,
+} from "./mcap-map-measurement";
+import {
+  MCAP_MAP_BASE_LAYER,
+  OPENFREEMAP_LIBERTY_STYLE_URL,
+  type McapMapBaseLayer,
+  useMcapMapTileSettings,
+  useSetMcapMapTileSettings,
+} from "./mcap-map-tile-state";
+import { useMcapDataStream } from "./mcap-data-stream-context";
+import type { McapTileProps } from "./mcap-tile-types";
+import { degreesToRadians } from "./wgs84";
+import McapMapTileSettings from "./McapMapTileSettings";
+import styles from "./McapMapTile.module.css";
+
+const ROUTE_PAST_SOURCE_ID = "mcap-location-route-past";
+const ROUTE_FUTURE_SOURCE_ID = "mcap-location-route-future";
+const HIT_SOURCE_ID = "mcap-location-hit-points";
+const CURRENT_SOURCE_ID = "mcap-location-current";
+const HOVER_SOURCE_ID = "mcap-location-hover";
+const MEASURE_LINE_SOURCE_ID = "mcap-location-measure-line";
+const MEASURE_PREVIEW_SOURCE_ID = "mcap-location-measure-preview";
+const MEASURE_POINTS_SOURCE_ID = "mcap-location-measure-points";
+
+const ROUTE_PAST_LAYER_ID = "mcap-location-route-past";
+const ROUTE_PAST_CASING_LAYER_ID = "mcap-location-route-past-casing";
+const ROUTE_FUTURE_LAYER_ID = "mcap-location-route-future";
+const ROUTE_FUTURE_CASING_LAYER_ID = "mcap-location-route-future-casing";
+const HIT_LAYER_ID = "mcap-location-hit-points";
+const ACCURACY_LAYER_ID = "mcap-location-accuracy";
+const PULSE_LAYER_ID = "mcap-location-pulse";
+const PUCK_LAYER_ID = "mcap-location-puck";
+const HOVER_LAYER_ID = "mcap-location-hover";
+const MEASURE_LINE_LAYER_ID = "mcap-location-measure-line";
+const MEASURE_PREVIEW_LAYER_ID = "mcap-location-measure-preview";
+const MEASURE_POINTS_LAYER_ID = "mcap-location-measure-points";
+
+// Comet-trail sources/layers are per track (line-gradient cannot read
+// feature properties); the color is baked into the id so a palette change
+// recreates the layer.
+const COMET_ID_PREFIX = "mcap-location-comet:";
+const COMET_TRAIL_NS = 15_000_000_000n;
+
+const PULSE_PERIOD_MS = 1_600;
+// Recenter zooms to the recent trail when one exists; otherwise this
+// street-scale zoom around the marker.
+const RECENTER_MARKER_ZOOM = 16;
+// While the recenter animation runs, the follow easeTo must stand down or
+// it freezes the zoom mid-flight (easeTo without zoom keeps current zoom).
+const RECENTER_GUARD_MS = 600;
+const FUTURE_ROUTE_COLOR = "#8b98a9";
+// Dark casing under every route line so the colored strokes hold contrast
+// on light basemaps as well as the dark no-tile canvas.
+const ROUTE_CASING_COLOR = "#0b1220";
+const MEASURE_COLOR = "#22d3ee";
+// Tail alpha of the comet gradient; > 0 keeps the fade gentle rather than
+// a hard laser taper.
+const COMET_TAIL_ALPHA = 0.35;
+
+// Web-mercator ground resolution at zoom 0 on the equator (512px world):
+// 40075016.686m / 512. The accuracy ring stores its radius as
+// pixels-at-zoom-0 so a base-2 zoom interpolation renders a true metric
+// circle at every zoom.
+const METERS_PER_PIXEL_ZOOM_0 = 40075016.686 / 512;
+const MAX_STYLE_ZOOM = 22;
+
+// Type-only imports are erased at compile time, so they do not defeat the
+// dynamic import that keeps maplibre-gl out of the main bundle.
+type MapLibreModule = typeof import("maplibre-gl");
+type MapLibreMap = import("maplibre-gl").Map;
+type MapLibreStyle = import("maplibre-gl").StyleSpecification;
+
+interface MapLayerFeatureEvent {
+  readonly features?: readonly {
+    readonly properties?: Record<string, unknown>;
+  }[];
+}
+
+interface MapPointerEvent {
+  readonly lngLat?: {
+    readonly lat: number;
+    readonly lng: number;
+  };
+}
+
+interface GeoJsonFeature {
+  readonly type: "Feature";
+  readonly geometry: {
+    readonly type: "LineString" | "Point";
+    readonly coordinates: readonly unknown[];
+  };
+  readonly properties: Record<string, string | number | boolean | undefined>;
+}
+
+interface GeoJsonFeatureCollection {
+  readonly type: "FeatureCollection";
+  readonly features: readonly GeoJsonFeature[];
+}
+
+let mapLibreImport: Promise<MapLibreModule> | null = null;
+let mapLibreCssImport: Promise<void> | null = null;
+
+const EMPTY_FEATURE_COLLECTION: GeoJsonFeatureCollection = {
+  type: "FeatureCollection",
+  features: [],
+};
+
+const NO_TILE_STYLE: MapLibreStyle = {
+  version: 8,
+  sources: {},
+  layers: [
+    {
+      id: "mcap-location-background",
+      type: "background",
+      paint: { "background-color": "#06101a" },
+    },
+  ],
+};
+
+const McapMapTile: React.FC<McapTileProps> = () => {
+  const setTileTitle = useSetTileTitle();
+  const sources = useSceneInventory();
+  const tracksByTopic = useMcapLocationTracksContext();
+  const settings = useMcapMapTileSettings();
+  const setSettings = useSetMcapMapTileSettings();
+  const dataStream = useMcapDataStream();
+  const timeline = dataStream?.getTimelineIndex() ?? null;
+  const store = usePlaybackStore();
+  const { seek } = usePlayback();
+  const isPlaying = useIsPlaying();
+  const [playheadSec, setPlayheadSec] = useState(() => getPlayhead(store));
+  const [hoverSec, setHoverSec] = useState<number | null>(() =>
+    getHoverTime(store),
+  );
+  const [recenterNonce, setRecenterNonce] = useState(0);
+  const [measureArmed, setMeasureArmed] = useState(false);
+  const [measurement, setMeasurement] = useState<MapMeasurementState | null>(
+    null,
+  );
+
+  const locationSources = useMemo(
+    () => sources.filter((source) => source.type === MCAP_SOURCE_TYPE.LOCATION),
+    [sources],
+  );
+  const allTopics = useMemo(
+    () => locationSources.map((source) => source.id),
+    [locationSources],
+  );
+  const enabledTopics = useMemo(
+    () => new Set(settings.enabledTopics ?? allTopics),
+    [allTopics, settings.enabledTopics],
+  );
+  const visibleTopics = useMemo(
+    () => allTopics.filter((topic) => enabledTopics.has(topic)),
+    [allTopics, enabledTopics],
+  );
+  const tracks = useMemo(
+    () =>
+      visibleTopics
+        .map((topic) => tracksByTopic.get(topic))
+        .filter((track): track is McapLocationTrackState => Boolean(track)),
+    [tracksByTopic, visibleTopics],
+  );
+  const readyTracks = useMemo(
+    () =>
+      tracks.filter(
+        (track) => track.status === "ready" && track.segments.length > 0,
+      ),
+    [tracks],
+  );
+
+  useEffect(() => {
+    setTileTitle(mapTileTitle(readyTracks, locationSources.length), {
+      source: "auto",
+    });
+  }, [locationSources.length, readyTracks, setTileTitle]);
+
+  useEffect(() => {
+    const unsubscribePlayhead = subscribePlayhead(store, () => {
+      setPlayheadSec(getPlayhead(store));
+    });
+    const unsubscribeHover = subscribeHoverTime(store, () => {
+      setHoverSec(getHoverTime(store));
+    });
+    setPlayheadSec(getPlayhead(store));
+    setHoverSec(getHoverTime(store));
+    return () => {
+      unsubscribePlayhead();
+      unsubscribeHover();
+      setHoverTime(store, null);
+    };
+  }, [store]);
+
+  const playheadNs = useMemo(
+    () => (timeline ? timeline.secToNs(playheadSec) : null),
+    [playheadSec, timeline],
+  );
+  const hoverNs = useMemo(
+    () => (timeline && hoverSec !== null ? timeline.secToNs(hoverSec) : null),
+    [hoverSec, timeline],
+  );
+  const bounds = useMemo(
+    () =>
+      combineLocationBounds(
+        readyTracks.map((track) => locationBounds(track.segments)),
+      ),
+    [readyTracks],
+  );
+  const currentLocations = useMemo(
+    () => trackMarkersAt(readyTracks, playheadNs),
+    [playheadNs, readyTracks],
+  );
+  const hoverLocations = useMemo(
+    () => trackMarkersAt(readyTracks, hoverNs),
+    [hoverNs, readyTracks],
+  );
+
+  const onSeekTimeNs = useCallback(
+    (timeNs: bigint) => {
+      if (!timeline) return;
+      seek(timeline.nsToSec(timeNs));
+    },
+    [seek, timeline],
+  );
+  const onHoverTimeNs = useCallback(
+    (timeNs: bigint | null) => {
+      setHoverTime(
+        store,
+        timeNs !== null && timeline ? timeline.nsToSec(timeNs) : null,
+      );
+    },
+    [store, timeline],
+  );
+  const onMeasurePick = useCallback((point: MapMeasurementPoint) => {
+    setMeasurement((current) => nextMapMeasurementState(current, point));
+  }, []);
+  const onMeasureToggle = useCallback(() => {
+    setMeasureArmed((armed) => {
+      if (armed) setMeasurement(null);
+      return !armed;
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!measureArmed) return undefined;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      if (measurement) {
+        setMeasurement(null);
+      } else {
+        setMeasureArmed(false);
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [measureArmed, measurement]);
+
+  const measuredDistance = mapMeasurementDistance(measurement);
+  const measureReadout = !measureArmed
+    ? null
+    : measuredDistance !== null
+      ? formatMapMeasurementDistance(measuredDistance)
+      : measurement
+        ? "Pick the second map point"
+        : "Pick two map points";
+
+  const loadingCount = tracks.filter(
+    (track) => track.status === "loading",
+  ).length;
+  const errorCount = tracks.filter((track) => track.status === "error").length;
+  const truncated = tracks.some((track) => track.truncated);
+  const statusText = mapStatusText({
+    enabledTopicCount: visibleTopics.length,
+    errorCount,
+    loadingCount,
+    locationTopicCount: locationSources.length,
+    readyTrackCount: readyTracks.length,
+    truncated,
+  });
+
+  return (
+    <>
+      <McapMapTileSettings />
+      <div className={styles.body} data-testid="mcap-map-tile">
+        <McapMapLibreSurface
+          bounds={bounds}
+          currentLocations={currentLocations}
+          followEgo={settings.followEgo}
+          hoverLocations={hoverLocations}
+          measureArmed={measureArmed}
+          measurement={measurement}
+          onHoverTimeNs={onHoverTimeNs}
+          onMeasurePick={onMeasurePick}
+          onSeekTimeNs={onSeekTimeNs}
+          onUserMove={() => setSettings({ followEgo: false })}
+          playheadNs={playheadNs}
+          pulseActive={isPlaying}
+          recenterNonce={recenterNonce}
+          baseLayer={settings.baseLayer}
+          tracks={readyTracks}
+        />
+        <div className={styles.overlay}>
+          {statusText ? (
+            <span className={styles.statusBadge}>{statusText}</span>
+          ) : null}
+          {!settings.followEgo && readyTracks.length > 0 ? (
+            <button
+              className={styles.controlButton}
+              onClick={() => {
+                setSettings({ followEgo: true });
+                setRecenterNonce((value) => value + 1);
+              }}
+              type="button"
+            >
+              Recenter
+            </button>
+          ) : null}
+        </div>
+        {readyTracks.length > 0 ? (
+          <div className={styles.toolOverlay}>
+            <button
+              aria-label="Measure distance"
+              aria-pressed={measureArmed}
+              className={
+                measureArmed
+                  ? styles.iconControlButtonActive
+                  : styles.iconControlButton
+              }
+              onClick={onMeasureToggle}
+              title="Measure distance on the map (Esc clears)"
+              type="button"
+            >
+              <MeasureRulerIcon />
+            </button>
+            {measureReadout ? (
+              <div className={styles.measureReadout}>{measureReadout}</div>
+            ) : null}
+          </div>
+        ) : null}
+        {readyTracks.length > 0 ? <MapLegend tracks={readyTracks} /> : null}
+        {emptyText({
+          enabledTopicCount: visibleTopics.length,
+          locationTopicCount: locationSources.length,
+          loadingCount,
+          readyTrackCount: readyTracks.length,
+        })}
+      </div>
+    </>
+  );
+};
+
+function McapMapLibreSurface({
+  baseLayer,
+  bounds,
+  currentLocations,
+  followEgo,
+  hoverLocations,
+  measureArmed,
+  measurement,
+  onHoverTimeNs,
+  onMeasurePick,
+  onSeekTimeNs,
+  onUserMove,
+  playheadNs,
+  pulseActive,
+  recenterNonce,
+  tracks,
+}: {
+  readonly baseLayer: McapMapBaseLayer;
+  readonly bounds: LocationBounds | null;
+  readonly currentLocations: readonly MapLocationMarker[];
+  readonly followEgo: boolean;
+  readonly hoverLocations: readonly MapLocationMarker[];
+  readonly measureArmed: boolean;
+  readonly measurement: MapMeasurementState | null;
+  readonly onHoverTimeNs: (timeNs: bigint | null) => void;
+  readonly onMeasurePick: (point: MapMeasurementPoint) => void;
+  readonly onSeekTimeNs: (timeNs: bigint) => void;
+  readonly onUserMove: () => void;
+  readonly playheadNs: bigint | null;
+  readonly pulseActive: boolean;
+  readonly recenterNonce: number;
+  readonly tracks: readonly McapLocationTrackState[];
+}) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const mapRef = useRef<MapLibreMap | null>(null);
+  const loadedRef = useRef(false);
+  const fitKeyRef = useRef<string | null>(null);
+  const recenterGuardUntilRef = useRef(0);
+  const [failed, setFailed] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const [measurementHover, setMeasurementHover] =
+    useState<MapMeasurementPoint | null>(null);
+  const onSeekTimeNsRef = useRef(onSeekTimeNs);
+  const onHoverTimeNsRef = useRef(onHoverTimeNs);
+  const onMeasurePickRef = useRef(onMeasurePick);
+  const onUserMoveRef = useRef(onUserMove);
+  const measureArmedRef = useRef(measureArmed);
+  const measurementRef = useRef(measurement);
+  onSeekTimeNsRef.current = onSeekTimeNs;
+  onHoverTimeNsRef.current = onHoverTimeNs;
+  onMeasurePickRef.current = onMeasurePick;
+  onUserMoveRef.current = onUserMove;
+  measureArmedRef.current = measureArmed;
+  measurementRef.current = measurement;
+
+  useEffect(() => {
+    if (!containerRef.current || mapRef.current || failed) {
+      return undefined;
+    }
+    setLoaded(false);
+    loadedRef.current = false;
+    fitKeyRef.current = null;
+    let cancelled = false;
+    let resizeObserver: ResizeObserver | null = null;
+
+    void loadMapLibre()
+      .then((maplibregl) => {
+        if (cancelled || !containerRef.current) return;
+        const map = new maplibregl.Map({
+          attributionControl: false,
+          center: [0, 0],
+          container: containerRef.current,
+          interactive: true,
+          pitchWithRotate: false,
+          style: mapStyleForBaseLayer(baseLayer),
+          zoom: 1,
+        });
+        mapRef.current = map;
+        map.addControl(
+          new maplibregl.NavigationControl({
+            showCompass: false,
+            showZoom: true,
+          }),
+          "top-right",
+        );
+
+        map.on("load", () => {
+          loadedRef.current = true;
+          addMcapMapSourcesAndLayers(map);
+          setLoaded(true);
+        });
+        map.on("error", () => {
+          if (!loadedRef.current) {
+            setFailed(true);
+          }
+        });
+        const handleUserMove = (event: { originalEvent?: unknown }) => {
+          if (event.originalEvent) {
+            onUserMoveRef.current();
+          }
+        };
+        map.on("dragstart", handleUserMove);
+        map.on("zoomstart", handleUserMove);
+        map.on("rotatestart", handleUserMove);
+        map.on("pitchstart", handleUserMove);
+        map.on("click", HIT_LAYER_ID, (event) => {
+          if (measureArmedRef.current) return;
+          const timeNs = timeNsFromMapEvent(event);
+          if (timeNs !== null) {
+            onSeekTimeNsRef.current(timeNs);
+          }
+        });
+        map.on("mousemove", HIT_LAYER_ID, (event) => {
+          if (measureArmedRef.current) return;
+          map.getCanvas().style.cursor = "pointer";
+          onHoverTimeNsRef.current(timeNsFromMapEvent(event));
+        });
+        map.on("mouseleave", HIT_LAYER_ID, () => {
+          if (measureArmedRef.current) return;
+          map.getCanvas().style.cursor = "";
+          onHoverTimeNsRef.current(null);
+        });
+        map.on("click", (event) => {
+          if (!measureArmedRef.current) return;
+          const point = measurementPointFromMapEvent(event);
+          if (point) onMeasurePickRef.current(point);
+        });
+        map.on("mousemove", (event) => {
+          if (!measureArmedRef.current) return;
+          const current = measurementRef.current;
+          if (!current || current.b) {
+            setMeasurementHover(null);
+            return;
+          }
+          setMeasurementHover(measurementPointFromMapEvent(event));
+        });
+        // "mouseleave" only exists as a layer-scoped event; the map-level
+        // pointer-exit event is "mouseout".
+        map.on("mouseout", () => {
+          setMeasurementHover(null);
+        });
+        map.getCanvas().addEventListener("webglcontextlost", () => {
+          setFailed(true);
+        });
+
+        if (typeof ResizeObserver !== "undefined") {
+          resizeObserver = new ResizeObserver(() => map.resize());
+          resizeObserver.observe(containerRef.current);
+        }
+      })
+      .catch(() => setFailed(true));
+
+    return () => {
+      cancelled = true;
+      resizeObserver?.disconnect();
+      const map = mapRef.current;
+      if (map) {
+        map.remove();
+        mapRef.current = null;
+      }
+      loadedRef.current = false;
+    };
+  }, [baseLayer, failed]);
+
+  useEffect(() => {
+    setFailed(false);
+  }, [baseLayer]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+    map.getCanvas().style.cursor = measureArmed ? "crosshair" : "";
+    if (!measureArmed) {
+      setMeasurementHover(null);
+    }
+  }, [measureArmed, loaded]);
+
+  const sourceData = useMemo(
+    () => ({
+      comets: cometTrails(tracks, playheadNs),
+      current: currentPuckFeatures(currentLocations),
+      future: routeFeatures(tracks, playheadNs, "future"),
+      hit: hitPointFeatures(tracks),
+      hover: markerFeatures(hoverLocations),
+      measureLine: measurementLineFeature(measurement),
+      measurePoints: measurementPointFeatures(measurement),
+      measurePreview: measurementPreviewFeature(measurement, measurementHover),
+      past: routeFeatures(tracks, playheadNs, "past"),
+      trackColors: tracks.map((track) => track.color),
+    }),
+    [
+      currentLocations,
+      hoverLocations,
+      measurement,
+      measurementHover,
+      playheadNs,
+      tracks,
+    ],
+  );
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !loadedRef.current) {
+      return;
+    }
+    ensurePuckImages(map, sourceData.trackColors);
+    syncCometLayers(map, sourceData.comets);
+    setGeoJsonSourceData(map, ROUTE_PAST_SOURCE_ID, sourceData.past);
+    setGeoJsonSourceData(map, ROUTE_FUTURE_SOURCE_ID, sourceData.future);
+    setGeoJsonSourceData(map, HIT_SOURCE_ID, sourceData.hit);
+    setGeoJsonSourceData(map, CURRENT_SOURCE_ID, sourceData.current);
+    setGeoJsonSourceData(map, HOVER_SOURCE_ID, sourceData.hover);
+    setGeoJsonSourceData(map, MEASURE_LINE_SOURCE_ID, sourceData.measureLine);
+    setGeoJsonSourceData(
+      map,
+      MEASURE_PREVIEW_SOURCE_ID,
+      sourceData.measurePreview,
+    );
+    setGeoJsonSourceData(
+      map,
+      MEASURE_POINTS_SOURCE_ID,
+      sourceData.measurePoints,
+    );
+  }, [sourceData, loaded]);
+
+  // Sonar pulse under the puck while playing: the marker doubles as the
+  // playback-state indicator. rAF-driven paint updates on one tiny layer.
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !loadedRef.current || !map.getLayer(PULSE_LAYER_ID)) {
+      return undefined;
+    }
+    if (!pulseActive) {
+      map.setPaintProperty(PULSE_LAYER_ID, "circle-opacity", 0);
+      return undefined;
+    }
+    let frame = 0;
+    const tick = (now: number) => {
+      const phase = (now % PULSE_PERIOD_MS) / PULSE_PERIOD_MS;
+      map.setPaintProperty(PULSE_LAYER_ID, "circle-radius", 10 + phase * 16);
+      map.setPaintProperty(PULSE_LAYER_ID, "circle-opacity", 0.4 * (1 - phase));
+      frame = requestAnimationFrame(tick);
+    };
+    frame = requestAnimationFrame(tick);
+    return () => {
+      cancelAnimationFrame(frame);
+      // Skip the reset when this cleanup races a map teardown.
+      if (mapRef.current === map && map.getLayer(PULSE_LAYER_ID)) {
+        map.setPaintProperty(PULSE_LAYER_ID, "circle-opacity", 0);
+      }
+    };
+  }, [pulseActive, loaded]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !loadedRef.current || !bounds) {
+      return;
+    }
+    const fitKey = `${bounds.west}:${bounds.south}:${bounds.east}:${bounds.north}`;
+    if (fitKeyRef.current === fitKey) {
+      return;
+    }
+    fitKeyRef.current = fitKey;
+    map.fitBounds(
+      [
+        [bounds.west, bounds.south],
+        [bounds.east, bounds.north],
+      ],
+      { duration: 240, maxZoom: 17, padding: 42 },
+    );
+  }, [bounds, loaded]);
+
+  // Recenter: re-frame around "now" — fit the recent trail when one
+  // exists (adaptive zoom: a fast vehicle gets a wider view), else ease to
+  // the marker at street zoom, else fall back to the whole track.
+  useEffect(() => {
+    const map = mapRef.current;
+    if (recenterNonce === 0 || !map || !loadedRef.current) {
+      return;
+    }
+    recenterGuardUntilRef.current = performance.now() + RECENTER_GUARD_MS;
+    const trailBounds = coordinateBounds(
+      sourceData.comets.flatMap((trail) => trail.coordinates),
+    );
+    const marker = currentLocations[0]?.location;
+    if (trailBounds) {
+      map.fitBounds(
+        [
+          [trailBounds.west, trailBounds.south],
+          [trailBounds.east, trailBounds.north],
+        ],
+        { duration: 400, maxZoom: 17, padding: 80 },
+      );
+    } else if (marker) {
+      map.easeTo({
+        center: [marker.longitude, marker.latitude],
+        duration: 400,
+        zoom: RECENTER_MARKER_ZOOM,
+      });
+    } else if (bounds) {
+      map.fitBounds(
+        [
+          [bounds.west, bounds.south],
+          [bounds.east, bounds.north],
+        ],
+        { duration: 400, maxZoom: 17, padding: 42 },
+      );
+    }
+    // Latest-closure effect: only the nonce (and load state) may trigger
+    // it — depending on trail/marker would re-run the camera move every
+    // playhead tick — but React runs the freshest closure, so the values
+    // read here are current.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [recenterNonce, loaded]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    const current = currentLocations[0]?.location;
+    if (!map || !loadedRef.current || !followEgo || !current) {
+      return;
+    }
+    if (performance.now() < recenterGuardUntilRef.current) {
+      return;
+    }
+    map.easeTo({
+      center: [current.longitude, current.latitude],
+      duration: 120,
+      essential: false,
+    });
+  }, [currentLocations, followEgo, loaded]);
+
+  return (
+    <>
+      <div className={styles.map} ref={containerRef} />
+      {failed || !loaded ? (
+        <div className={styles.fallback}>
+          <StaticLocationMap tracks={tracks} />
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+interface MapLocationMarker {
+  readonly color: string;
+  readonly label: string;
+  readonly location: InterpolatedLocation;
+  readonly topic: string;
+}
+
+function trackMarkersAt(
+  tracks: readonly McapLocationTrackState[],
+  timeNs: bigint | null,
+): readonly MapLocationMarker[] {
+  if (timeNs === null) return [];
+  const markers: MapLocationMarker[] = [];
+  for (const track of tracks) {
+    const location = interpolateLocationAtTime(track.segments, timeNs);
+    if (location) {
+      markers.push({
+        color: track.color,
+        label: track.label,
+        location,
+        topic: track.topic,
+      });
+    }
+  }
+  return markers;
+}
+
+function MapLegend({
+  tracks,
+}: {
+  readonly tracks: readonly McapLocationTrackState[];
+}) {
+  return (
+    <div className={styles.legend}>
+      {tracks.map((track) => (
+        <div className={styles.legendRow} key={track.topic} title={track.topic}>
+          <span
+            className={styles.legendSwatch}
+            style={{ backgroundColor: track.color }}
+          />
+          <span className={styles.legendLabel}>{track.label}</span>
+          <span className={styles.legendMeta}>
+            {track.pointCount.toLocaleString()}
+            {track.truncated ? " sampled" : ""}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function StaticLocationMap({
+  tracks,
+}: {
+  readonly tracks: readonly McapLocationTrackState[];
+}) {
+  const bounds = combineLocationBounds(
+    tracks.map((track) => locationBounds(track.segments)),
+  );
+  const project = useCallback(
+    (longitude: number, latitude: number): [number, number] => {
+      if (!bounds) return [50, 50];
+      const width = Math.max(bounds.east - bounds.west, 0.000001);
+      const height = Math.max(bounds.north - bounds.south, 0.000001);
+      const x = ((longitude - bounds.west) / width) * 92 + 4;
+      const y = 96 - ((latitude - bounds.south) / height) * 92;
+      return [x, y];
+    },
+    [bounds],
+  );
+
+  return (
+    <svg aria-hidden="true" preserveAspectRatio="none" viewBox="0 0 100 100">
+      <rect fill="#06101a" height="100" width="100" />
+      {Array.from({ length: 6 }, (_, index) => (
+        <React.Fragment key={index}>
+          <line
+            stroke="rgba(148, 163, 184, 0.14)"
+            strokeWidth="0.15"
+            x1={index * 20}
+            x2={index * 20}
+            y1="0"
+            y2="100"
+          />
+          <line
+            stroke="rgba(148, 163, 184, 0.14)"
+            strokeWidth="0.15"
+            x1="0"
+            x2="100"
+            y1={index * 20}
+            y2={index * 20}
+          />
+        </React.Fragment>
+      ))}
+      {tracks.flatMap((track) =>
+        track.segments.map((segment, segmentIndex) => {
+          const points = segment.points
+            .map((point) => project(point.longitude, point.latitude))
+            .map(([x, y]) => `${x},${y}`)
+            .join(" ");
+          return (
+            <polyline
+              fill="none"
+              key={`${track.topic}:${segmentIndex}`}
+              points={points}
+              stroke={track.color}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="0.7"
+            />
+          );
+        }),
+      )}
+    </svg>
+  );
+}
+
+function addMcapMapSourcesAndLayers(map: MapLibreMap) {
+  addGeoJsonSource(map, ROUTE_PAST_SOURCE_ID);
+  addGeoJsonSource(map, ROUTE_FUTURE_SOURCE_ID);
+  addGeoJsonSource(map, HIT_SOURCE_ID);
+  addGeoJsonSource(map, CURRENT_SOURCE_ID);
+  addGeoJsonSource(map, HOVER_SOURCE_ID);
+  addGeoJsonSource(map, MEASURE_LINE_SOURCE_ID);
+  addGeoJsonSource(map, MEASURE_PREVIEW_SOURCE_ID);
+  addGeoJsonSource(map, MEASURE_POINTS_SOURCE_ID);
+
+  map.addLayer({
+    id: ROUTE_FUTURE_CASING_LAYER_ID,
+    type: "line",
+    source: ROUTE_FUTURE_SOURCE_ID,
+    layout: { "line-cap": "round", "line-join": "round" },
+    paint: {
+      "line-color": ROUTE_CASING_COLOR,
+      "line-opacity": 0.55,
+      "line-width": 4.5,
+    },
+  });
+  // Future route is deliberately colorless: track identity lives in the
+  // traveled route, comet trail, puck, and legend.
+  map.addLayer({
+    id: ROUTE_FUTURE_LAYER_ID,
+    type: "line",
+    source: ROUTE_FUTURE_SOURCE_ID,
+    layout: { "line-cap": "round", "line-join": "round" },
+    paint: {
+      "line-color": FUTURE_ROUTE_COLOR,
+      "line-opacity": 0.3,
+      "line-width": 2.5,
+    },
+  });
+  map.addLayer({
+    id: ROUTE_PAST_CASING_LAYER_ID,
+    type: "line",
+    source: ROUTE_PAST_SOURCE_ID,
+    layout: { "line-cap": "round", "line-join": "round" },
+    paint: {
+      "line-color": ROUTE_CASING_COLOR,
+      "line-opacity": 0.85,
+      "line-width": 4.5,
+    },
+  });
+  // Dim history base; the per-track comet-trail layers (inserted above
+  // this, below the pulse) add the bright gradient head behind the puck.
+  map.addLayer({
+    id: ROUTE_PAST_LAYER_ID,
+    type: "line",
+    source: ROUTE_PAST_SOURCE_ID,
+    layout: { "line-cap": "round", "line-join": "round" },
+    paint: {
+      "line-color": ["get", "color"],
+      "line-opacity": 0.5,
+      "line-width": 2.5,
+    },
+  });
+  // Accuracy ring: the receiver's own 2σ horizontal-error estimate as a
+  // metric circle under the puck. Present only when the fix carried a
+  // non-degenerate covariance — no estimate, no ring.
+  map.addLayer({
+    id: ACCURACY_LAYER_ID,
+    type: "circle",
+    source: CURRENT_SOURCE_ID,
+    filter: ["has", "accuracyPx0"],
+    paint: {
+      "circle-color": ["get", "color"],
+      "circle-opacity": 0.12,
+      "circle-pitch-alignment": "map",
+      "circle-radius": [
+        "interpolate",
+        ["exponential", 2],
+        ["zoom"],
+        0,
+        ["get", "accuracyPx0"],
+        MAX_STYLE_ZOOM,
+        ["*", ["get", "accuracyPx0"], 2 ** MAX_STYLE_ZOOM],
+      ],
+      "circle-stroke-color": ["get", "color"],
+      "circle-stroke-opacity": 0.4,
+      "circle-stroke-width": 1,
+    },
+  });
+  map.addLayer({
+    id: PULSE_LAYER_ID,
+    type: "circle",
+    source: CURRENT_SOURCE_ID,
+    paint: {
+      "circle-color": ["get", "color"],
+      "circle-opacity": 0,
+      "circle-radius": 10,
+    },
+  });
+  map.addLayer({
+    id: HOVER_LAYER_ID,
+    type: "circle",
+    source: HOVER_SOURCE_ID,
+    paint: {
+      "circle-color": "#f8fafc",
+      "circle-radius": 5,
+      "circle-stroke-color": ["get", "color"],
+      "circle-stroke-width": 2,
+    },
+  });
+  map.addLayer({
+    id: MEASURE_PREVIEW_LAYER_ID,
+    type: "line",
+    source: MEASURE_PREVIEW_SOURCE_ID,
+    paint: {
+      "line-color": MEASURE_COLOR,
+      "line-dasharray": [1.2, 1.2],
+      "line-opacity": 0.9,
+      "line-width": 2,
+    },
+  });
+  map.addLayer({
+    id: MEASURE_LINE_LAYER_ID,
+    type: "line",
+    source: MEASURE_LINE_SOURCE_ID,
+    paint: {
+      "line-color": MEASURE_COLOR,
+      "line-opacity": 0.95,
+      "line-width": 2.5,
+    },
+  });
+  map.addLayer({
+    id: MEASURE_POINTS_LAYER_ID,
+    type: "circle",
+    source: MEASURE_POINTS_SOURCE_ID,
+    paint: {
+      "circle-color": MEASURE_COLOR,
+      "circle-radius": 4.5,
+      "circle-stroke-color": "#06101a",
+      "circle-stroke-width": 1.5,
+    },
+  });
+  map.addLayer({
+    id: HIT_LAYER_ID,
+    type: "circle",
+    source: HIT_SOURCE_ID,
+    paint: {
+      "circle-opacity": 0,
+      "circle-radius": 8,
+    },
+  });
+  map.addLayer({
+    id: PUCK_LAYER_ID,
+    type: "symbol",
+    source: CURRENT_SOURCE_ID,
+    layout: {
+      "icon-allow-overlap": true,
+      "icon-ignore-placement": true,
+      "icon-image": ["get", "icon"],
+      "icon-rotate": ["get", "bearing"],
+      "icon-rotation-alignment": "map",
+    },
+  });
+}
+
+interface CometTrail {
+  readonly color: string;
+  readonly coordinates: readonly [number, number][];
+  readonly key: string;
+}
+
+function coordinateBounds(
+  coordinates: readonly [number, number][],
+): LocationBounds | null {
+  if (coordinates.length === 0) {
+    return null;
+  }
+  let west = Number.POSITIVE_INFINITY;
+  let east = Number.NEGATIVE_INFINITY;
+  let south = Number.POSITIVE_INFINITY;
+  let north = Number.NEGATIVE_INFINITY;
+  for (const [longitude, latitude] of coordinates) {
+    west = Math.min(west, longitude);
+    east = Math.max(east, longitude);
+    south = Math.min(south, latitude);
+    north = Math.max(north, latitude);
+  }
+  return { east, north, south, west };
+}
+
+function cometTrails(
+  tracks: readonly McapLocationTrackState[],
+  playheadNs: bigint | null,
+): readonly CometTrail[] {
+  if (playheadNs === null) {
+    return [];
+  }
+  const trails: CometTrail[] = [];
+  for (const track of tracks) {
+    const coordinates = locationTrailCoordinates(
+      track.segments,
+      playheadNs,
+      COMET_TRAIL_NS,
+    );
+    if (coordinates.length >= 2) {
+      trails.push({
+        color: track.color,
+        coordinates,
+        key: `${COMET_ID_PREFIX}${track.color}:${track.topic}`,
+      });
+    }
+  }
+  return trails;
+}
+
+/**
+ * Reconciles one gradient line source+layer per comet trail. Layers are
+ * per track because `line-gradient` cannot read feature properties; the
+ * gradient runs transparent → track color toward the puck.
+ */
+function syncCometLayers(
+  map: MapLibreMap,
+  trails: readonly CometTrail[],
+): void {
+  const wanted = new Map(trails.map((trail) => [trail.key, trail]));
+  for (const layer of map.getStyle()?.layers ?? []) {
+    if (layer.id.startsWith(COMET_ID_PREFIX) && !wanted.has(layer.id)) {
+      map.removeLayer(layer.id);
+      map.removeSource(layer.id);
+    }
+  }
+  for (const [id, trail] of wanted) {
+    if (!map.getSource(id)) {
+      map.addSource(id, {
+        type: "geojson",
+        data: EMPTY_FEATURE_COLLECTION,
+        lineMetrics: true,
+      } as never);
+      map.addLayer(
+        {
+          id,
+          type: "line",
+          source: id,
+          layout: { "line-cap": "round", "line-join": "round" },
+          paint: {
+            "line-gradient": [
+              "interpolate",
+              ["linear"],
+              ["line-progress"],
+              0,
+              hexColorWithAlpha(trail.color, COMET_TAIL_ALPHA),
+              1,
+              trail.color,
+            ],
+            // Same width as the base route so the trail reads as part of
+            // the line rather than a bulge riding on top of it.
+            "line-width": 2.5,
+          },
+        },
+        PULSE_LAYER_ID,
+      );
+    }
+    setGeoJsonSourceData(map, id, {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          geometry: { type: "LineString", coordinates: trail.coordinates },
+          properties: {},
+        },
+      ],
+    });
+  }
+}
+
+function addGeoJsonSource(map: MapLibreMap, sourceId: string) {
+  map.addSource(sourceId, {
+    type: "geojson",
+    data: EMPTY_FEATURE_COLLECTION,
+  } as never);
+}
+
+function setGeoJsonSourceData(
+  map: MapLibreMap,
+  sourceId: string,
+  data: GeoJsonFeatureCollection,
+) {
+  const source = map.getSource(sourceId) as
+    | { setData: (data: GeoJsonFeatureCollection) => void }
+    | undefined;
+  source?.setData(data);
+}
+
+function routeFeatures(
+  tracks: readonly McapLocationTrackState[],
+  playheadNs: bigint | null,
+  side: "past" | "future",
+): GeoJsonFeatureCollection {
+  const features: GeoJsonFeature[] = [];
+  for (const track of tracks) {
+    for (const segment of track.segments) {
+      const coordinates = routeCoordinatesForSegment(segment, playheadNs, side);
+      if (coordinates.length < 2) continue;
+      features.push({
+        type: "Feature",
+        geometry: { type: "LineString", coordinates },
+        properties: {
+          color: track.color,
+          topic: track.topic,
+        },
+      });
+    }
+  }
+  return { type: "FeatureCollection", features };
+}
+
+function routeCoordinatesForSegment(
+  segment: McapLocationTrackSegment,
+  playheadNs: bigint | null,
+  side: "past" | "future",
+): readonly [number, number][] {
+  if (playheadNs === null) {
+    return side === "future"
+      ? segment.points.map((point) => [point.longitude, point.latitude])
+      : [];
+  }
+
+  const points =
+    side === "past"
+      ? segment.points.filter((point) => point.timeNs <= playheadNs)
+      : segment.points.filter((point) => point.timeNs >= playheadNs);
+  const interpolated = interpolateLocationAtTime([segment], playheadNs);
+  if (interpolated) {
+    if (side === "past") {
+      points.push({
+        latitude: interpolated.latitude,
+        longitude: interpolated.longitude,
+        timeNs: interpolated.timeNs,
+      });
+    } else {
+      points.unshift({
+        latitude: interpolated.latitude,
+        longitude: interpolated.longitude,
+        timeNs: interpolated.timeNs,
+      });
+    }
+  }
+
+  return points.map((point) => [point.longitude, point.latitude]);
+}
+
+function hitPointFeatures(
+  tracks: readonly McapLocationTrackState[],
+): GeoJsonFeatureCollection {
+  const features: GeoJsonFeature[] = [];
+  for (const track of tracks) {
+    for (const segment of track.segments) {
+      for (const point of segment.points) {
+        features.push({
+          type: "Feature",
+          geometry: {
+            type: "Point",
+            coordinates: [point.longitude, point.latitude],
+          },
+          properties: {
+            color: track.color,
+            timeNs: point.timeNs.toString(),
+            topic: track.topic,
+          },
+        });
+      }
+    }
+  }
+  return { type: "FeatureCollection", features };
+}
+
+function markerFeatures(
+  markers: readonly MapLocationMarker[],
+): GeoJsonFeatureCollection {
+  return {
+    type: "FeatureCollection",
+    features: markers.map((marker) => ({
+      type: "Feature",
+      geometry: {
+        type: "Point",
+        coordinates: [marker.location.longitude, marker.location.latitude],
+      },
+      properties: {
+        color: marker.color,
+        label: marker.label,
+        topic: marker.topic,
+      },
+    })),
+  };
+}
+
+/**
+ * Current-position features carrying the sprite id and bearing for the
+ * puck symbol layer. Stationary markers (no derivable bearing) fall back
+ * to the unrotated dome variant.
+ */
+function currentPuckFeatures(
+  markers: readonly MapLocationMarker[],
+): GeoJsonFeatureCollection {
+  return {
+    type: "FeatureCollection",
+    features: markers.map((marker) => {
+      const bearing = marker.location.bearingDeg;
+      return {
+        type: "Feature",
+        geometry: {
+          type: "Point",
+          coordinates: [marker.location.longitude, marker.location.latitude],
+        },
+        properties: {
+          ...(marker.location.accuracyM !== undefined
+            ? {
+                accuracyPx0: accuracyPixelsAtZoom0(
+                  marker.location.accuracyM,
+                  marker.location.latitude,
+                ),
+              }
+            : {}),
+          bearing: bearing ?? 0,
+          color: marker.color,
+          icon: puckImageId(
+            bearing === undefined ? PUCK_VARIANT.DOT : PUCK_VARIANT.NAV,
+            marker.color,
+          ),
+          label: marker.label,
+          topic: marker.topic,
+        },
+      };
+    }),
+  };
+}
+
+/**
+ * A ground distance in meters as its pixel size at zoom 0, adjusted for
+ * the mercator scale factor at the marker's latitude.
+ */
+function accuracyPixelsAtZoom0(meters: number, latitude: number): number {
+  const groundResolution =
+    METERS_PER_PIXEL_ZOOM_0 * Math.cos(degreesToRadians(latitude));
+  return meters / Math.max(groundResolution, 1e-6);
+}
+
+function measurementLineFeature(
+  measurement: MapMeasurementState | null,
+): GeoJsonFeatureCollection {
+  if (!measurement?.b) {
+    return EMPTY_FEATURE_COLLECTION;
+  }
+  return {
+    type: "FeatureCollection",
+    features: [
+      {
+        type: "Feature",
+        geometry: {
+          type: "LineString",
+          coordinates: [
+            [measurement.a.longitude, measurement.a.latitude],
+            [measurement.b.longitude, measurement.b.latitude],
+          ],
+        },
+        properties: {},
+      },
+    ],
+  };
+}
+
+function measurementPreviewFeature(
+  measurement: MapMeasurementState | null,
+  hover: MapMeasurementPoint | null,
+): GeoJsonFeatureCollection {
+  if (!measurement || measurement.b || !hover) {
+    return EMPTY_FEATURE_COLLECTION;
+  }
+  return {
+    type: "FeatureCollection",
+    features: [
+      {
+        type: "Feature",
+        geometry: {
+          type: "LineString",
+          coordinates: [
+            [measurement.a.longitude, measurement.a.latitude],
+            [hover.longitude, hover.latitude],
+          ],
+        },
+        properties: {},
+      },
+    ],
+  };
+}
+
+function measurementPointFeatures(
+  measurement: MapMeasurementState | null,
+): GeoJsonFeatureCollection {
+  if (!measurement) {
+    return EMPTY_FEATURE_COLLECTION;
+  }
+  const points = [measurement.a, measurement.b].filter(
+    (point): point is MapMeasurementPoint => point !== null,
+  );
+  return {
+    type: "FeatureCollection",
+    features: points.map((point) => ({
+      type: "Feature",
+      geometry: {
+        type: "Point",
+        coordinates: [point.longitude, point.latitude],
+      },
+      properties: {},
+    })),
+  };
+}
+
+function timeNsFromMapEvent(event: MapLayerFeatureEvent): bigint | null {
+  const value = event.features?.[0]?.properties?.timeNs;
+  if (typeof value !== "string" || value.length === 0) {
+    return null;
+  }
+  try {
+    return BigInt(value);
+  } catch {
+    return null;
+  }
+}
+
+function measurementPointFromMapEvent(
+  event: MapPointerEvent,
+): MapMeasurementPoint | null {
+  const lngLat = event.lngLat;
+  if (!lngLat || !Number.isFinite(lngLat.lng) || !Number.isFinite(lngLat.lat)) {
+    return null;
+  }
+  return { latitude: lngLat.lat, longitude: lngLat.lng };
+}
+
+function mapTileTitle(
+  readyTracks: readonly McapLocationTrackState[],
+  locationTopicCount: number,
+): string {
+  if (readyTracks.length === 1) {
+    return readyTracks[0].label;
+  }
+  if (locationTopicCount > 1) {
+    return `Map (${locationTopicCount})`;
+  }
+  return "Map";
+}
+
+function mapStatusText({
+  enabledTopicCount,
+  errorCount,
+  loadingCount,
+  locationTopicCount,
+  readyTrackCount,
+  truncated,
+}: {
+  readonly enabledTopicCount: number;
+  readonly errorCount: number;
+  readonly loadingCount: number;
+  readonly locationTopicCount: number;
+  readonly readyTrackCount: number;
+  readonly truncated: boolean;
+}): string | null {
+  if (locationTopicCount === 0 || enabledTopicCount === 0) {
+    return null;
+  }
+  const notes = [
+    loadingCount > 0 ? `loading ${loadingCount}` : null,
+    errorCount > 0 ? `${errorCount} failed` : null,
+    readyTrackCount > 0 && truncated ? "downsampled" : null,
+  ].filter(Boolean);
+  return notes.length > 0 ? notes.join(" · ") : null;
+}
+
+function emptyText({
+  enabledTopicCount,
+  loadingCount,
+  locationTopicCount,
+  readyTrackCount,
+}: {
+  readonly enabledTopicCount: number;
+  readonly loadingCount: number;
+  readonly locationTopicCount: number;
+  readonly readyTrackCount: number;
+}): React.ReactElement | null {
+  let text: string | null = null;
+  if (locationTopicCount === 0) {
+    text = "No GPS topics in this recording";
+  } else if (enabledTopicCount === 0) {
+    text = "All GPS topics are hidden";
+  } else if (readyTrackCount === 0 && loadingCount === 0) {
+    text = "No valid GPS fixes to render";
+  }
+  return text ? <div className={styles.emptyState}>{text}</div> : null;
+}
+
+function mapStyleForBaseLayer(
+  baseLayer: McapMapBaseLayer,
+): MapLibreStyle | string {
+  return baseLayer === MCAP_MAP_BASE_LAYER.NONE
+    ? NO_TILE_STYLE
+    : OPENFREEMAP_LIBERTY_STYLE_URL;
+}
+
+function loadMapLibre(): Promise<MapLibreModule> {
+  if (!mapLibreImport) {
+    mapLibreImport = Promise.all([
+      import("maplibre-gl"),
+      loadMapLibreStylesheet(),
+    ]).then(([maplibregl]) => maplibregl);
+  }
+  return mapLibreImport;
+}
+
+function loadMapLibreStylesheet(): Promise<void> {
+  if (!mapLibreCssImport) {
+    mapLibreCssImport = import("maplibre-gl/dist/maplibre-gl.css?url").then(
+      ({ default: href }) => {
+        ensureMapLibreStylesheet(href);
+      },
+    );
+  }
+  return mapLibreCssImport;
+}
+
+function ensureMapLibreStylesheet(href: string) {
+  if (typeof document === "undefined") {
+    return;
+  }
+  const linkId = "fiftyone-maplibre-gl-css";
+  if (document.getElementById(linkId)) {
+    return;
+  }
+  const link = document.createElement("link");
+  link.href = href;
+  link.id = linkId;
+  link.rel = "stylesheet";
+  document.head.appendChild(link);
+}
+
+export default McapMapTile;

--- a/app/packages/multimodal/src/adapters/mcap/react/McapMapTile.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapMapTile.tsx
@@ -457,6 +457,9 @@ function McapMapLibreSurface({
     fitKeyRef.current = null;
     let cancelled = false;
     let resizeObserver: ResizeObserver | null = null;
+    let webglCanvas: HTMLCanvasElement | null = null;
+    let handleWebglContextLost: ((event: Event) => void) | null = null;
+    let handleWebglContextRestored: (() => void) | null = null;
 
     void loadMapLibre()
       .then((maplibregl) => {
@@ -534,9 +537,25 @@ function McapMapLibreSurface({
         map.on("mouseout", () => {
           setMeasurementHover(null);
         });
-        map.getCanvas().addEventListener("webglcontextlost", () => {
-          setFailed(true);
-        });
+        webglCanvas = map.getCanvas();
+        handleWebglContextLost = (event: Event) => {
+          event.preventDefault();
+          setLoaded(false);
+        };
+        handleWebglContextRestored = () => {
+          setFailed(false);
+          setLoaded(loadedRef.current);
+          map.resize();
+          map.triggerRepaint();
+        };
+        webglCanvas.addEventListener(
+          "webglcontextlost",
+          handleWebglContextLost,
+        );
+        webglCanvas.addEventListener(
+          "webglcontextrestored",
+          handleWebglContextRestored,
+        );
 
         if (typeof ResizeObserver !== "undefined") {
           resizeObserver = new ResizeObserver(() => map.resize());
@@ -548,6 +567,18 @@ function McapMapLibreSurface({
     return () => {
       cancelled = true;
       resizeObserver?.disconnect();
+      if (webglCanvas && handleWebglContextLost) {
+        webglCanvas.removeEventListener(
+          "webglcontextlost",
+          handleWebglContextLost,
+        );
+      }
+      if (webglCanvas && handleWebglContextRestored) {
+        webglCanvas.removeEventListener(
+          "webglcontextrestored",
+          handleWebglContextRestored,
+        );
+      }
       const map = mapRef.current;
       if (map) {
         map.remove();

--- a/app/packages/multimodal/src/adapters/mcap/react/McapMapTileSettings.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapMapTileSettings.tsx
@@ -1,0 +1,89 @@
+import { TileSettingsContent } from "@fiftyone/tiling";
+import { Checkbox, RadioGroup, Size } from "@voxel51/voodo";
+import React, { useMemo } from "react";
+import { useSceneInventory } from "../../../scene-inventory";
+import { MCAP_SOURCE_TYPE } from "../scene-sources";
+import {
+  MCAP_MAP_BASE_LAYER,
+  type McapMapBaseLayer,
+  useMcapMapTileSettings,
+  useSetMcapMapTileSettings,
+  useToggleMcapMapTileTopic,
+} from "./mcap-map-tile-state";
+import { checkboxNoSpaceToggleProps } from "./mcap-settings-keyboard";
+import plotStyles from "./McapPlotTile.module.css";
+import settingsStyles from "./McapTile.settings.module.css";
+
+const BASE_LAYER_OPTIONS = [
+  {
+    value: MCAP_MAP_BASE_LAYER.DEFAULT,
+    label: "Default basemap (OpenFreeMap)",
+  },
+  { value: MCAP_MAP_BASE_LAYER.NONE, label: "No basemap" },
+];
+
+const McapMapTileSettings: React.FC = () => {
+  const sources = useSceneInventory();
+  const locationSources = useMemo(
+    () => sources.filter((source) => source.type === MCAP_SOURCE_TYPE.LOCATION),
+    [sources],
+  );
+  const topics = useMemo(
+    () => locationSources.map((source) => source.id),
+    [locationSources],
+  );
+  const settings = useMcapMapTileSettings();
+  const setSettings = useSetMcapMapTileSettings();
+  const toggleTopic = useToggleMcapMapTileTopic();
+  const enabledTopics = new Set(settings.enabledTopics ?? topics);
+  const baseLayer = settings.baseLayer ?? MCAP_MAP_BASE_LAYER.DEFAULT;
+
+  return (
+    <TileSettingsContent>
+      <div className={settingsStyles.root}>
+        <div className={settingsStyles.optionStack}>
+          <RadioGroup
+            name="mcap-map-base-layer"
+            onChange={(value) =>
+              setSettings({ baseLayer: value as McapMapBaseLayer })
+            }
+            options={BASE_LAYER_OPTIONS}
+            size={Size.Md}
+            value={baseLayer}
+          />
+          <div className={plotStyles.fieldRow}>
+            <Checkbox
+              checked={settings.followEgo}
+              label="Follow playhead"
+              onChange={(checked) => setSettings({ followEgo: checked })}
+              {...checkboxNoSpaceToggleProps}
+            />
+          </div>
+        </div>
+        {locationSources.length === 0 ? (
+          <span className={settingsStyles.emptyText}>
+            No GPS topics in this recording
+          </span>
+        ) : (
+          <div className={settingsStyles.optionStack}>
+            {locationSources.map((source) => (
+              <div className={plotStyles.fieldRow} key={source.id}>
+                <Checkbox
+                  checked={enabledTopics.has(source.id)}
+                  label={source.label}
+                  onChange={(checked) =>
+                    toggleTopic(source.id, checked, topics)
+                  }
+                  {...checkboxNoSpaceToggleProps}
+                />
+                <span className={settingsStyles.metaText}>{source.id}</span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </TileSettingsContent>
+  );
+};
+
+export default McapMapTileSettings;

--- a/app/packages/multimodal/src/adapters/mcap/react/McapSourcePlayback.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapSourcePlayback.tsx
@@ -20,6 +20,7 @@ import { Mcap3dViewSettingsProvider } from "./mcap-3d-view-settings-context";
 import { McapDataStreamProvider } from "./mcap-data-stream-context";
 import { McapFrameTransformsProvider } from "./mcap-frame-transforms-context";
 import { McapLogConsoleProvider } from "./mcap-log-console-context";
+import { McapLocationTracksProvider } from "./mcap-location-tracks-context";
 import { McapNumericSeriesProvider } from "./mcap-numeric-series-context";
 import { McapPoseTrajectoriesProvider } from "./mcap-pose-trajectories-context";
 import { McapRawMessageProvider } from "./mcap-raw-message-context";
@@ -185,61 +186,65 @@ export const McapSourcePlayback: React.FC<McapSourcePlaybackProps> = ({
     <React.Fragment key={byteSourceAccessKey(source)}>
       <McapFrameTransformsProvider>
         <McapPoseTrajectoriesProvider>
-          <McapSceneUpdateHistoryProvider>
-            <McapNumericSeriesProvider>
-              <McapRawMessageProvider>
-                <McapLogConsoleProvider client={client} source={source}>
-                  <McapDataStreamProvider>
-                    <Mcap3dViewSettingsProvider
-                      sceneUpAxis={sceneUpAxis}
-                      setSceneUpAxis={onSceneUpAxisChange}
-                    >
-                      <MultiModalPlayback
-                        fileName={fileName}
-                        headerCaption={headerCaption}
-                        headerActions={
-                          <McapHeaderActions actions={headerActions} />
-                        }
-                        addTileMenu={<McapAddTileMenu />}
-                        timelineExtraActions={<McapTimestampReadout />}
-                        sceneSources={sources}
-                        deselectFocusedTileOnRepeatSelect={false}
-                        initialTiles={initialTiles}
-                        initialManualTileTitles={initialManualTileTitles}
-                        autoLayoutStrategy={buildMcapAutoLayout}
-                        initialLayout={initialLayout}
-                        initialExpandedTileId={initialExpandedTileId}
-                        tracks={
-                          tracks && tracks.length > 0 ? [...tracks] : undefined
-                        }
-                        onTagDelete={onTagDelete}
-                        leftSidebar={<McapSettingsSidebar topics={topics} />}
-                        rightSidebar={<McapInspectorSidebar />}
-                        defaultRightOpen={false}
-                        defaultLeftOpen={defaultLeftOpen}
-                        onLeftOpenChange={onLeftOpenChange}
-                        leftSidebarWidth={defaultLeftSidebarWidth}
-                        onLeftSidebarWidthChange={onLeftSidebarWidthChange}
-                        onTagCreate={onTagCreate}
+          <McapLocationTracksProvider>
+            <McapSceneUpdateHistoryProvider>
+              <McapNumericSeriesProvider>
+                <McapRawMessageProvider>
+                  <McapLogConsoleProvider client={client} source={source}>
+                    <McapDataStreamProvider>
+                      <Mcap3dViewSettingsProvider
+                        sceneUpAxis={sceneUpAxis}
+                        setSceneUpAxis={onSceneUpAxisChange}
                       >
-                        <McapStreams client={client} source={source} />
-                        <McapNetworkHealthTracker client={client} />
-                        <McapPausedByteBanking
-                          client={client}
-                          source={source}
-                        />
-                        <McapSelectionHotkeys />
-                        {children}
-                        <McapModalLayoutPersistence
-                          datasetId={effectiveLayoutScopeKey}
-                        />
-                      </MultiModalPlayback>
-                    </Mcap3dViewSettingsProvider>
-                  </McapDataStreamProvider>
-                </McapLogConsoleProvider>
-              </McapRawMessageProvider>
-            </McapNumericSeriesProvider>
-          </McapSceneUpdateHistoryProvider>
+                        <MultiModalPlayback
+                          fileName={fileName}
+                          headerCaption={headerCaption}
+                          headerActions={
+                            <McapHeaderActions actions={headerActions} />
+                          }
+                          addTileMenu={<McapAddTileMenu />}
+                          timelineExtraActions={<McapTimestampReadout />}
+                          sceneSources={sources}
+                          deselectFocusedTileOnRepeatSelect={false}
+                          initialTiles={initialTiles}
+                          initialManualTileTitles={initialManualTileTitles}
+                          autoLayoutStrategy={buildMcapAutoLayout}
+                          initialLayout={initialLayout}
+                          initialExpandedTileId={initialExpandedTileId}
+                          tracks={
+                            tracks && tracks.length > 0
+                              ? [...tracks]
+                              : undefined
+                          }
+                          onTagDelete={onTagDelete}
+                          leftSidebar={<McapSettingsSidebar topics={topics} />}
+                          rightSidebar={<McapInspectorSidebar />}
+                          defaultRightOpen={false}
+                          defaultLeftOpen={defaultLeftOpen}
+                          onLeftOpenChange={onLeftOpenChange}
+                          leftSidebarWidth={defaultLeftSidebarWidth}
+                          onLeftSidebarWidthChange={onLeftSidebarWidthChange}
+                          onTagCreate={onTagCreate}
+                        >
+                          <McapStreams client={client} source={source} />
+                          <McapNetworkHealthTracker client={client} />
+                          <McapPausedByteBanking
+                            client={client}
+                            source={source}
+                          />
+                          <McapSelectionHotkeys />
+                          {children}
+                          <McapModalLayoutPersistence
+                            datasetId={effectiveLayoutScopeKey}
+                          />
+                        </MultiModalPlayback>
+                      </Mcap3dViewSettingsProvider>
+                    </McapDataStreamProvider>
+                  </McapLogConsoleProvider>
+                </McapRawMessageProvider>
+              </McapNumericSeriesProvider>
+            </McapSceneUpdateHistoryProvider>
+          </McapLocationTracksProvider>
         </McapPoseTrajectoriesProvider>
       </McapFrameTransformsProvider>
     </React.Fragment>

--- a/app/packages/multimodal/src/adapters/mcap/react/McapStreams.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapStreams.tsx
@@ -7,6 +7,7 @@ import {
   idleMcapFrameTransformsState,
   useSetMcapFrameTransformsContext,
 } from "./mcap-frame-transforms-context";
+import { McapLocationTracksBridge } from "./mcap-location-tracks-context";
 import { McapNumericSeriesBridge } from "./mcap-numeric-series-context";
 import { McapPoseTrajectoriesStartupGate } from "./mcap-pose-trajectories-context";
 import { McapRawMessageBridge } from "./mcap-raw-message-context";
@@ -104,6 +105,10 @@ export function McapStreams({ client, source }: McapStreamsProps) {
       sources.filter((s) => s.type === MCAP_SOURCE_TYPE.POSE).map((s) => s.id),
     [sources],
   );
+  const locationSources = useMemo(
+    () => sources.filter((s) => s.type === MCAP_SOURCE_TYPE.LOCATION),
+    [sources],
+  );
   const sceneAnnotationTopics = useMemo(
     () =>
       sources
@@ -135,6 +140,11 @@ export function McapStreams({ client, source }: McapStreamsProps) {
       <McapPoseTrajectoriesStartupGate
         client={client}
         poseTopics={poseTopics}
+        source={source}
+      />
+      <McapLocationTracksBridge
+        client={client}
+        locationSources={locationSources}
         source={source}
       />
       <McapSceneUpdateHistoryBridge

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-layout-persistence.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-layout-persistence.test.ts
@@ -3,6 +3,7 @@ import {
   isValidMosaicLayout,
   mcapTileTypeFromId,
   readMcapModalLayout,
+  sanitizeMapSettings,
   sanitizePlotSeries,
   sanitizeRawTopics,
   sanitizeTileTitles,
@@ -94,6 +95,7 @@ describe("mcap-layout-persistence", () => {
       JSON.stringify({
         layout: "image-1",
         leftSidebarOpen: true,
+        mapSettings: { "map-1": { enabledTopics: ["/gps"], followEgo: true } },
         rawTopics: { "raw-1": "/imu" },
         sceneUpAxis: "y",
         tileTitles: { "image-1": "Front Camera" },
@@ -115,6 +117,9 @@ describe("mcap-layout-persistence", () => {
           leftSidebarOpen: true,
           plotSeries: {
             "plot-1": [{ color: "#3987e5", fieldPath: "x", topic: "/odom" }],
+          },
+          mapSettings: {
+            "map-1": { enabledTopics: ["/gps"], followEgo: false },
           },
           rawTopics: { "raw-1": "/imu" },
           sceneUpAxis: "z",
@@ -388,6 +393,78 @@ describe("mcap-layout-persistence", () => {
       expect(sanitizeRawTopics([])).toBeUndefined();
       expect(sanitizeRawTopics("x")).toBeUndefined();
       expect(sanitizeRawTopics({})).toBeUndefined();
+    });
+  });
+
+  describe("mapSettings", () => {
+    const SETTINGS = {
+      "map-1": {
+        baseLayer: "none" as const,
+        enabledTopics: ["/gps/front", "/gps/rear"],
+        followEgo: false,
+      },
+    };
+
+    it("round-trips per-dataset map tile settings", () => {
+      writeMcapModalLayout({ mapSettings: SETTINGS }, "ds-a");
+      expect(readMcapModalLayout("ds-a")?.mapSettings).toEqual(SETTINGS);
+    });
+
+    it("never leaks map settings to another dataset", () => {
+      writeMcapModalLayout({ leftSidebarOpen: true }, "ds-b");
+      writeMcapModalLayout({ layout: "map-1", mapSettings: SETTINGS }, "ds-a");
+
+      expect(readMcapModalLayout("ds-b")).toEqual({ leftSidebarOpen: true });
+      expect(readMcapModalLayout("ds-b")?.mapSettings).toBeUndefined();
+    });
+
+    it("sanitizes malformed map settings rows individually", () => {
+      writeMcapModalLayout(
+        {
+          mapSettings: {
+            "map-1": {
+              baseLayer: "none",
+              enabledTopics: ["/gps", "", "/gps", 5],
+              followEgo: false,
+              styleUrl: "https://tiles.example.test/style.json",
+            },
+            "image-1": {
+              enabledTopics: ["/camera"],
+              followEgo: true,
+            },
+            "map-2": {
+              baseLayer: "surprise",
+              enabledTopics: [],
+              followEgo: "yes",
+            },
+            "no-suffix": {
+              enabledTopics: ["/gps"],
+              followEgo: true,
+            },
+          } as never,
+        },
+        "ds-a",
+      );
+
+      expect(readMcapModalLayout("ds-a")?.mapSettings).toEqual({
+        "map-1": {
+          baseLayer: "none",
+          enabledTopics: ["/gps"],
+          followEgo: false,
+        },
+        "map-2": {
+          baseLayer: "default",
+          enabledTopics: [],
+          followEgo: true,
+        },
+      });
+    });
+
+    it("sanitizeMapSettings rejects non-object payloads", () => {
+      expect(sanitizeMapSettings(null)).toBeUndefined();
+      expect(sanitizeMapSettings([])).toBeUndefined();
+      expect(sanitizeMapSettings("x")).toBeUndefined();
+      expect(sanitizeMapSettings({})).toBeUndefined();
     });
   });
 

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-layout-persistence.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-layout-persistence.ts
@@ -3,6 +3,11 @@ import {
   normalizeMcap3dSceneUpAxis,
   type Mcap3dSceneUpAxis,
 } from "./mcap-3d-scene-up";
+import {
+  DEFAULT_MCAP_MAP_TILE_SETTINGS,
+  normalizeMcapMapBaseLayer,
+  type McapMapTileSettings,
+} from "./mcap-map-tile-state";
 import { MCAP_TILE_TYPE } from "./mcap-tile-types";
 
 /**
@@ -37,6 +42,11 @@ export interface McapPersistedModalLayout {
    */
   plotSeries?: Record<string, readonly McapPersistedPlotSeries[]>;
   /**
+   * Map tile topic visibility and follow/basemap preferences. Dataset-scoped:
+   * topic names belong to one recording family.
+   */
+  mapSettings?: Record<string, McapPersistedMapSettings>;
+  /**
    * Inspected topic per raw-message tile id. Topics belong to one
    * dataset's recordings, so this field is dataset-scoped only — like
    * `plotSeries`, never merged into the browser-wide fallback.
@@ -67,12 +77,17 @@ export interface McapPersistedPlotSeries {
   readonly topic: string;
 }
 
+export type McapPersistedMapSettings = McapMapTileSettings;
+
 // Bound the persisted plot config so a corrupt or adversarial payload
 // cannot balloon the localStorage entry parsed on every modal mount.
 const MAX_PLOT_TILES = 32;
 const MAX_PLOT_SERIES_PER_TILE = 64;
 const MAX_RAW_TILES = 32;
 const MAX_RAW_TOPIC_LENGTH = 512;
+const MAX_MAP_TILES = 16;
+const MAX_MAP_TOPICS_PER_TILE = 64;
+const MAX_MAP_TOPIC_LENGTH = 512;
 const MAX_TILE_TITLES = 64;
 const MAX_TILE_TITLE_LENGTH = 160;
 const HEX_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
@@ -92,6 +107,7 @@ interface PersistedStore {
 const STORAGE_KEY = "fiftyone.mcap.modal-layout";
 const STORAGE_VERSION = 1;
 const FALLBACK_OMITTED_FIELDS = [
+  "mapSettings",
   "plotSeries",
   "rawTopics",
   "sceneUpAxis",
@@ -134,6 +150,7 @@ function sanitizeEntry(raw: unknown): McapPersistedModalLayout | undefined {
     layout: isValidMosaicLayout(candidate.layout)
       ? candidate.layout
       : undefined,
+    mapSettings: sanitizeMapSettings(candidate.mapSettings),
     plotSeries: sanitizePlotSeries(candidate.plotSeries),
     rawTopics: sanitizeRawTopics(candidate.rawTopics),
     sceneUpAxis: normalizeMcap3dSceneUpAxis(candidate.sceneUpAxis),
@@ -232,6 +249,74 @@ export function sanitizeRawTopics(
   }
 
   return Object.keys(result).length > 0 ? result : undefined;
+}
+
+/**
+ * Structural validation of per-map tile settings. Topic arrays are allowed
+ * to be empty (the user may hide every GPS topic), topic strings are bounded,
+ * and only map tile ids are restored.
+ */
+export function sanitizeMapSettings(
+  raw: unknown,
+): Record<string, McapPersistedMapSettings> | undefined {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    return undefined;
+  }
+
+  const result: Record<string, McapPersistedMapSettings> = {};
+  let tileCount = 0;
+  for (const [tileId, settings] of Object.entries(raw)) {
+    if (
+      tileCount >= MAX_MAP_TILES ||
+      mcapTileTypeFromId(tileId) !== MCAP_TILE_TYPE.MAP ||
+      typeof settings !== "object" ||
+      settings === null ||
+      Array.isArray(settings)
+    ) {
+      continue;
+    }
+
+    const record = settings as Record<string, unknown>;
+    const baseLayer =
+      normalizeMcapMapBaseLayer(record.baseLayer) ??
+      DEFAULT_MCAP_MAP_TILE_SETTINGS.baseLayer;
+    const enabledTopics = sanitizeMapTopicList(record.enabledTopics);
+    const followEgo =
+      typeof record.followEgo === "boolean"
+        ? record.followEgo
+        : DEFAULT_MCAP_MAP_TILE_SETTINGS.followEgo;
+
+    result[tileId] = {
+      baseLayer,
+      followEgo,
+      ...(enabledTopics !== undefined ? { enabledTopics } : {}),
+    };
+    tileCount += 1;
+  }
+
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+function sanitizeMapTopicList(raw: unknown): readonly string[] | undefined {
+  if (!Array.isArray(raw)) {
+    return undefined;
+  }
+  const topics: string[] = [];
+  const seen = new Set<string>();
+  for (const value of raw) {
+    if (topics.length >= MAX_MAP_TOPICS_PER_TILE) break;
+    if (
+      typeof value !== "string" ||
+      value.length === 0 ||
+      value.length > MAX_MAP_TOPIC_LENGTH ||
+      seen.has(value)
+    ) {
+      continue;
+    }
+    seen.add(value);
+    topics.push(value);
+  }
+  return topics;
 }
 
 /**

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-location-track.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-location-track.test.ts
@@ -66,6 +66,27 @@ describe("decimateLocationTrackSegments", () => {
     expect(result.segments[0].points[0]).toBe(segments[0].points[0]);
     expect(result.segments[0].points[10]).toBe(segments[0].points[100]);
   });
+
+  it("keeps the returned segments under the requested render cap", () => {
+    const segments = Array.from({ length: 20 }, (_, segmentIndex) => ({
+      points: [point(segmentIndex * 2), point(segmentIndex * 2 + 1)],
+    }));
+
+    const result = decimateLocationTrackSegments(segments, 10);
+
+    expect(result.truncated).toBe(true);
+    expect(result.pointCount).toBe(40);
+    expect(
+      result.segments.reduce(
+        (count, segment) => count + segment.points.length,
+        0,
+      ),
+    ).toBeLessThanOrEqual(10);
+    expect(result.segments[0].points[0]).toBe(segments[0].points[0]);
+    expect(result.segments[result.segments.length - 1].points.at(-1)).toBe(
+      segments[segments.length - 1].points[1],
+    );
+  });
 });
 
 describe("interpolateLocationAtTime", () => {

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-location-track.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-location-track.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vitest";
+import {
+  decimateLocationTrackSegments,
+  horizontalAccuracyM,
+  interpolateLocationAtTime,
+  isValidLocationPoint,
+  locationTrailCoordinates,
+  segmentLocationTrack,
+  type McapLocationTrackPoint,
+} from "./mcap-location-track";
+import { bearingDegrees } from "./wgs84";
+
+function point(
+  index: number,
+  overrides: Partial<McapLocationTrackPoint> = {},
+): McapLocationTrackPoint {
+  return {
+    latitude: 37 + index * 0.001,
+    longitude: -122 - index * 0.001,
+    timeNs: BigInt(index) * 1_000_000_000n,
+    ...overrides,
+  };
+}
+
+describe("isValidLocationPoint", () => {
+  it("rejects impossible coordinates and explicit no-fix statuses", () => {
+    expect(isValidLocationPoint(point(0))).toBe(true);
+    expect(isValidLocationPoint(point(0, { latitude: 100 }))).toBe(false);
+    expect(isValidLocationPoint(point(0, { longitude: Number.NaN }))).toBe(
+      false,
+    );
+    expect(isValidLocationPoint(point(0, { fixStatus: -1 }))).toBe(false);
+  });
+});
+
+describe("segmentLocationTrack", () => {
+  it("breaks the route at invalid fixes without interpolating over them", () => {
+    const segments = segmentLocationTrack([
+      point(0),
+      point(1),
+      point(2, { fixStatus: -1 }),
+      point(3),
+      point(4),
+    ]);
+
+    expect(
+      segments.map((segment) => segment.points.map((p) => p.timeNs)),
+    ).toEqual([
+      [0n, 1_000_000_000n],
+      [3_000_000_000n, 4_000_000_000n],
+    ]);
+    expect(interpolateLocationAtTime(segments, 2_000_000_000n)).toBeNull();
+  });
+});
+
+describe("decimateLocationTrackSegments", () => {
+  it("uses a global stride and keeps segment endpoints", () => {
+    const segments = segmentLocationTrack(
+      Array.from({ length: 101 }, (_, index) => point(index)),
+    );
+    const result = decimateLocationTrackSegments(segments, 11);
+
+    expect(result.truncated).toBe(true);
+    expect(result.pointCount).toBe(101);
+    expect(result.segments[0].points).toHaveLength(11);
+    expect(result.segments[0].points[0]).toBe(segments[0].points[0]);
+    expect(result.segments[0].points[10]).toBe(segments[0].points[100]);
+  });
+});
+
+describe("interpolateLocationAtTime", () => {
+  it("interpolates coordinates within a valid GPS segment", () => {
+    const segments = segmentLocationTrack([
+      point(0, {
+        accuracyM: 4,
+        altitude: 10,
+        latitude: 37,
+        longitude: -122,
+      }),
+      point(10, {
+        accuracyM: 8,
+        altitude: 20,
+        latitude: 38,
+        longitude: -123,
+      }),
+    ]);
+
+    const location = interpolateLocationAtTime(segments, 5_000_000_000n);
+
+    expect(location?.latitude).toBeCloseTo(37.5);
+    expect(location?.longitude).toBeCloseTo(-122.5);
+    expect(location?.altitude).toBeCloseTo(15);
+    expect(location?.accuracyM).toBeCloseTo(6);
+    expect(location?.bearingDeg).toBeDefined();
+  });
+});
+
+describe("horizontalAccuracyM", () => {
+  it("is twice the worst-axis standard deviation", () => {
+    // Diagonal: worst axis is north (variance 9 → σ 3).
+    expect(horizontalAccuracyM([4, 0, 0, 0, 9, 0, 0, 0, 1])).toBeCloseTo(6);
+    // Correlated: eigenvalue (4+4)/2 + √(0+3²) = 7.
+    expect(horizontalAccuracyM([4, 3, 0, 3, 4, 0, 0, 0, 1])).toBeCloseTo(
+      2 * Math.sqrt(7),
+    );
+  });
+
+  it("treats degenerate matrices as no estimate", () => {
+    expect(horizontalAccuracyM(undefined)).toBeUndefined();
+    expect(horizontalAccuracyM([1, 2, 3])).toBeUndefined();
+    expect(horizontalAccuracyM([0, 0, 0, 0, 0, 0, 0, 0, 0])).toBeUndefined();
+    expect(horizontalAccuracyM([-1, 0, 0, 0, 4, 0, 0, 0, 1])).toBeUndefined();
+    expect(
+      horizontalAccuracyM([Number.NaN, 0, 0, 0, 4, 0, 0, 0, 1]),
+    ).toBeUndefined();
+  });
+});
+
+describe("locationTrailCoordinates", () => {
+  it("clips the trail to the window and interpolates both endpoints", () => {
+    const segments = segmentLocationTrack(
+      Array.from({ length: 11 }, (_, index) => point(index)),
+    );
+
+    const coords = locationTrailCoordinates(
+      segments,
+      5_250_000_000n,
+      2_500_000_000n,
+    );
+
+    expect(coords).toHaveLength(5);
+    expect(coords[0][1]).toBeCloseTo(37.00275);
+    expect(coords[coords.length - 1][1]).toBeCloseTo(37.00525);
+  });
+
+  it("vanishes in no-fix gaps and freezes past the end of the track", () => {
+    const segments = segmentLocationTrack([
+      point(0),
+      point(1),
+      point(2, { fixStatus: -1 }),
+      point(3),
+      point(4),
+    ]);
+
+    expect(
+      locationTrailCoordinates(segments, 2_000_000_000n, 5_000_000_000n),
+    ).toEqual([]);
+
+    const frozen = locationTrailCoordinates(
+      segments,
+      60_000_000_000n,
+      1_500_000_000n,
+    );
+    expect(frozen.length).toBeGreaterThanOrEqual(2);
+    expect(frozen[frozen.length - 1][1]).toBeCloseTo(37.004);
+  });
+});
+
+describe("bearingDegrees", () => {
+  it("returns geographic bearing clockwise from north", () => {
+    expect(
+      bearingDegrees(
+        { latitude: 0, longitude: 0 },
+        { latitude: 1, longitude: 0 },
+      ),
+    ).toBeCloseTo(0);
+    expect(
+      bearingDegrees(
+        { latitude: 0, longitude: 0 },
+        { latitude: 0, longitude: 1 },
+      ),
+    ).toBeCloseTo(90);
+  });
+});

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-location-track.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-location-track.ts
@@ -160,12 +160,11 @@ export function decimateLocationTrackSegments(
     return { pointCount, segments, truncated: false };
   }
 
-  const stride = Math.max(1, Math.ceil(pointCount / maxPoints));
-  const decimated = segments
-    .map((segment) => ({
-      points: decimateSegmentByStride(segment.points, stride),
-    }))
-    .filter((segment) => segment.points.length > 0);
+  const decimated = decimateSegmentsByGlobalIndex(
+    segments,
+    pointCount,
+    maxPoints,
+  );
 
   return { pointCount, segments: decimated, truncated: true };
 }
@@ -363,15 +362,38 @@ function lastLocationPoint(
   return null;
 }
 
-function decimateSegmentByStride(
-  points: readonly McapLocationTrackPoint[],
-  stride: number,
-): readonly McapLocationTrackPoint[] {
-  if (points.length <= 2 || stride <= 1) return points;
-  const decimated: McapLocationTrackPoint[] = [];
-  for (let index = 0; index < points.length; index += 1) {
-    if (index % stride === 0 || index === points.length - 1) {
-      decimated.push(points[index]);
+function decimateSegmentsByGlobalIndex(
+  segments: readonly McapLocationTrackSegment[],
+  pointCount: number,
+  maxPoints: number,
+): readonly McapLocationTrackSegment[] {
+  if (maxPoints <= 0) {
+    return [];
+  }
+
+  const wantedIndices = new Set<number>();
+  if (maxPoints === 1) {
+    wantedIndices.add(0);
+  } else {
+    for (let sampleIndex = 0; sampleIndex < maxPoints; sampleIndex += 1) {
+      wantedIndices.add(
+        Math.round((sampleIndex * (pointCount - 1)) / (maxPoints - 1)),
+      );
+    }
+  }
+
+  let globalIndex = 0;
+  const decimated: McapLocationTrackSegment[] = [];
+  for (const segment of segments) {
+    const points: McapLocationTrackPoint[] = [];
+    for (const point of segment.points) {
+      if (wantedIndices.has(globalIndex)) {
+        points.push(point);
+      }
+      globalIndex += 1;
+    }
+    if (points.length > 0) {
+      decimated.push({ points });
     }
   }
   return decimated;

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-location-track.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-location-track.ts
@@ -1,0 +1,398 @@
+import type { LocationVisualization } from "../../../decoders";
+import { voxel51PrimaryColor } from "./mcap-map-puck";
+import { bearingDegrees } from "./wgs84";
+
+// Brand orange leads so the (near-universal) single-GPS case reads as
+// "the ego"; the rest are visually distant from it and from each other.
+const SECONDARY_TRACK_COLORS = [
+  "#3b82f6",
+  "#84cc16",
+  "#f472b6",
+  "#a78bfa",
+  "#22c55e",
+] as const;
+
+export function locationTrackColor(index: number): string {
+  const colors = [voxel51PrimaryColor(), ...SECONDARY_TRACK_COLORS];
+  return colors[index % colors.length];
+}
+
+export const MAX_LOCATION_TRACK_RENDER_POINTS = 10_000;
+
+const NO_FIX_STATUS = -1;
+
+export interface McapLocationTrackPoint {
+  /** 95% (2σ) horizontal accuracy in meters, when the fix carried one. */
+  readonly accuracyM?: number;
+  readonly altitude?: number;
+  readonly fixService?: number;
+  readonly fixStatus?: number;
+  readonly latitude: number;
+  readonly longitude: number;
+  readonly timeNs: bigint;
+}
+
+export interface McapLocationTrackSegment {
+  readonly points: readonly McapLocationTrackPoint[];
+}
+
+export interface McapLocationTrackState {
+  readonly color: string;
+  readonly label: string;
+  readonly pointCount: number;
+  readonly segments: readonly McapLocationTrackSegment[];
+  readonly status: "loading" | "ready" | "error";
+  readonly topic: string;
+  readonly truncated?: boolean;
+}
+
+export type McapLocationTracks = ReadonlyMap<string, McapLocationTrackState>;
+
+export interface InterpolatedLocation {
+  readonly accuracyM?: number;
+  readonly altitude?: number;
+  readonly bearingDeg?: number;
+  readonly latitude: number;
+  readonly longitude: number;
+  readonly timeNs: bigint;
+}
+
+export interface LocationBounds {
+  readonly east: number;
+  readonly north: number;
+  readonly south: number;
+  readonly west: number;
+}
+
+export function locationPointFromVisualization(
+  visualization: LocationVisualization,
+  timelineTimeNs: bigint,
+): McapLocationTrackPoint {
+  return {
+    accuracyM: horizontalAccuracyM(visualization.positionCovariance),
+    altitude: finiteOrUndefined(visualization.altitude),
+    fixService: finiteOrUndefined(visualization.fixService),
+    fixStatus: finiteOrUndefined(visualization.fixStatus),
+    latitude: visualization.latitude,
+    longitude: visualization.longitude,
+    timeNs: timelineTimeNs,
+  };
+}
+
+/**
+ * 95% (2σ) horizontal accuracy in meters from a row-major 3×3 ENU
+ * position covariance: twice the square root of the worst-axis eigenvalue
+ * of the East/North block, so a tilted error ellipse is never
+ * understated. Degenerate matrices (all-zero, negative, non-finite) yield
+ * `undefined` — receivers that report no real estimate report zeros, and
+ * drawing "perfect accuracy" from junk would be a lie.
+ */
+export function horizontalAccuracyM(
+  covariance: readonly number[] | undefined,
+): number | undefined {
+  if (!covariance || covariance.length !== 9) {
+    return undefined;
+  }
+  const varEast = covariance[0];
+  const varNorth = covariance[4];
+  const covEastNorth = covariance[1];
+  if (
+    !Number.isFinite(varEast) ||
+    !Number.isFinite(varNorth) ||
+    !Number.isFinite(covEastNorth) ||
+    varEast < 0 ||
+    varNorth < 0
+  ) {
+    return undefined;
+  }
+  const mean = (varEast + varNorth) / 2;
+  const spread = Math.sqrt(((varEast - varNorth) / 2) ** 2 + covEastNorth ** 2);
+  const maxVariance = mean + spread;
+  return maxVariance > 0 ? 2 * Math.sqrt(maxVariance) : undefined;
+}
+
+export function isValidLocationPoint(point: McapLocationTrackPoint): boolean {
+  return (
+    Number.isFinite(point.latitude) &&
+    Number.isFinite(point.longitude) &&
+    point.latitude >= -90 &&
+    point.latitude <= 90 &&
+    point.longitude >= -180 &&
+    point.longitude <= 180 &&
+    point.fixStatus !== NO_FIX_STATUS
+  );
+}
+
+export function segmentLocationTrack(
+  points: readonly McapLocationTrackPoint[],
+): readonly McapLocationTrackSegment[] {
+  const segments: McapLocationTrackSegment[] = [];
+  let current: McapLocationTrackPoint[] = [];
+
+  for (const point of points) {
+    if (!isValidLocationPoint(point)) {
+      if (current.length > 0) {
+        segments.push({ points: current });
+        current = [];
+      }
+      continue;
+    }
+    current.push(point);
+  }
+
+  if (current.length > 0) {
+    segments.push({ points: current });
+  }
+
+  return segments;
+}
+
+export function decimateLocationTrackSegments(
+  segments: readonly McapLocationTrackSegment[],
+  maxPoints = MAX_LOCATION_TRACK_RENDER_POINTS,
+): {
+  readonly pointCount: number;
+  readonly segments: readonly McapLocationTrackSegment[];
+  readonly truncated: boolean;
+} {
+  const pointCount = countLocationTrackPoints(segments);
+  if (pointCount <= maxPoints) {
+    return { pointCount, segments, truncated: false };
+  }
+
+  const stride = Math.max(1, Math.ceil(pointCount / maxPoints));
+  const decimated = segments
+    .map((segment) => ({
+      points: decimateSegmentByStride(segment.points, stride),
+    }))
+    .filter((segment) => segment.points.length > 0);
+
+  return { pointCount, segments: decimated, truncated: true };
+}
+
+export function countLocationTrackPoints(
+  segments: readonly McapLocationTrackSegment[],
+): number {
+  return segments.reduce((count, segment) => count + segment.points.length, 0);
+}
+
+export function interpolateLocationAtTime(
+  segments: readonly McapLocationTrackSegment[],
+  timeNs: bigint,
+): InterpolatedLocation | null {
+  const first = firstLocationPoint(segments);
+  const last = lastLocationPoint(segments);
+  if (!first || !last) return null;
+  if (timeNs <= first.timeNs) return locationFromPoint(first);
+  if (timeNs >= last.timeNs) return locationFromPoint(last);
+
+  for (const segment of segments) {
+    const points = segment.points;
+    if (points.length === 0) continue;
+    const segmentStart = points[0];
+    const segmentEnd = points[points.length - 1];
+    if (timeNs < segmentStart.timeNs || timeNs > segmentEnd.timeNs) {
+      continue;
+    }
+
+    for (let index = 0; index < points.length - 1; index += 1) {
+      const left = points[index];
+      const right = points[index + 1];
+      if (timeNs < left.timeNs || timeNs > right.timeNs) {
+        continue;
+      }
+      return interpolateBetweenPoints(left, right, timeNs);
+    }
+
+    return locationFromPoint(segmentEnd);
+  }
+
+  // A timestamp between valid segments is a no-fix gap; do not draw a
+  // marker there because that would visually bridge invalid GPS.
+  return null;
+}
+
+/**
+ * Coordinates of the "comet trail": the route inside
+ * `[timeNs - windowNs, timeNs]`, clipped to the segment containing the
+ * playhead so the trail never bridges a no-fix gap. Endpoints are
+ * time-interpolated so the trail head sits exactly under the marker.
+ */
+export function locationTrailCoordinates(
+  segments: readonly McapLocationTrackSegment[],
+  timeNs: bigint,
+  windowNs: bigint,
+): readonly [number, number][] {
+  const first = firstLocationPoint(segments);
+  const last = lastLocationPoint(segments);
+  if (!first || !last || timeNs < first.timeNs) {
+    return [];
+  }
+  // Past the end of the track the marker holds at the final fix, so the
+  // trail freezes behind it rather than vanishing.
+  const headNs = timeNs > last.timeNs ? last.timeNs : timeNs;
+
+  for (const segment of segments) {
+    const points = segment.points;
+    if (points.length === 0) continue;
+    const startNs = points[0].timeNs;
+    const endNs = points[points.length - 1].timeNs;
+    if (headNs < startNs || headNs > endNs) {
+      continue;
+    }
+
+    const tailNs = headNs - windowNs > startNs ? headNs - windowNs : startNs;
+    const coordinates: [number, number][] = [];
+    const tail = interpolateLocationAtTime([segment], tailNs);
+    if (tail) {
+      coordinates.push([tail.longitude, tail.latitude]);
+    }
+    for (const point of points) {
+      if (point.timeNs > tailNs && point.timeNs < headNs) {
+        coordinates.push([point.longitude, point.latitude]);
+      }
+    }
+    const head = interpolateLocationAtTime([segment], headNs);
+    if (head) {
+      coordinates.push([head.longitude, head.latitude]);
+    }
+    return coordinates.length >= 2 ? coordinates : [];
+  }
+
+  // The playhead sits in a no-fix gap: no marker, no trail.
+  return [];
+}
+
+export function locationBounds(
+  segments: readonly McapLocationTrackSegment[],
+): LocationBounds | null {
+  let west = Number.POSITIVE_INFINITY;
+  let east = Number.NEGATIVE_INFINITY;
+  let south = Number.POSITIVE_INFINITY;
+  let north = Number.NEGATIVE_INFINITY;
+
+  for (const segment of segments) {
+    for (const point of segment.points) {
+      west = Math.min(west, point.longitude);
+      east = Math.max(east, point.longitude);
+      south = Math.min(south, point.latitude);
+      north = Math.max(north, point.latitude);
+    }
+  }
+
+  if (
+    west === Number.POSITIVE_INFINITY ||
+    east === Number.NEGATIVE_INFINITY ||
+    south === Number.POSITIVE_INFINITY ||
+    north === Number.NEGATIVE_INFINITY
+  ) {
+    return null;
+  }
+
+  return { east, north, south, west };
+}
+
+export function combineLocationBounds(
+  bounds: readonly (LocationBounds | null)[],
+): LocationBounds | null {
+  let combined: LocationBounds | null = null;
+  for (const bound of bounds) {
+    if (!bound) continue;
+    combined = combined
+      ? {
+          east: Math.max(combined.east, bound.east),
+          north: Math.max(combined.north, bound.north),
+          south: Math.min(combined.south, bound.south),
+          west: Math.min(combined.west, bound.west),
+        }
+      : bound;
+  }
+  return combined;
+}
+
+function interpolateBetweenPoints(
+  left: McapLocationTrackPoint,
+  right: McapLocationTrackPoint,
+  timeNs: bigint,
+): InterpolatedLocation {
+  const span = Number(right.timeNs - left.timeNs);
+  if (span <= 0) {
+    return locationFromPoint(right, bearingDegrees(left, right));
+  }
+  const fraction = Number(timeNs - left.timeNs) / span;
+  return {
+    accuracyM: interpolateOptional(left.accuracyM, right.accuracyM, fraction),
+    altitude: interpolateOptional(left.altitude, right.altitude, fraction),
+    bearingDeg: bearingDegrees(left, right),
+    latitude: interpolateNumber(left.latitude, right.latitude, fraction),
+    longitude: interpolateNumber(left.longitude, right.longitude, fraction),
+    timeNs,
+  };
+}
+
+function locationFromPoint(
+  point: McapLocationTrackPoint,
+  bearingDeg?: number,
+): InterpolatedLocation {
+  return {
+    accuracyM: point.accuracyM,
+    altitude: point.altitude,
+    bearingDeg,
+    latitude: point.latitude,
+    longitude: point.longitude,
+    timeNs: point.timeNs,
+  };
+}
+
+function firstLocationPoint(
+  segments: readonly McapLocationTrackSegment[],
+): McapLocationTrackPoint | null {
+  for (const segment of segments) {
+    if (segment.points.length > 0) return segment.points[0];
+  }
+  return null;
+}
+
+function lastLocationPoint(
+  segments: readonly McapLocationTrackSegment[],
+): McapLocationTrackPoint | null {
+  for (let index = segments.length - 1; index >= 0; index -= 1) {
+    const points = segments[index].points;
+    if (points.length > 0) return points[points.length - 1];
+  }
+  return null;
+}
+
+function decimateSegmentByStride(
+  points: readonly McapLocationTrackPoint[],
+  stride: number,
+): readonly McapLocationTrackPoint[] {
+  if (points.length <= 2 || stride <= 1) return points;
+  const decimated: McapLocationTrackPoint[] = [];
+  for (let index = 0; index < points.length; index += 1) {
+    if (index % stride === 0 || index === points.length - 1) {
+      decimated.push(points[index]);
+    }
+  }
+  return decimated;
+}
+
+function finiteOrUndefined(value: number | undefined): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function interpolateNumber(left: number, right: number, fraction: number) {
+  return left + (right - left) * fraction;
+}
+
+function interpolateOptional(
+  left: number | undefined,
+  right: number | undefined,
+  fraction: number,
+): number | undefined {
+  return left === undefined || right === undefined
+    ? undefined
+    : interpolateNumber(left, right, fraction);
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-location-tracks-context.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-location-tracks-context.test.tsx
@@ -1,0 +1,166 @@
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ByteSourceDescriptor } from "../../../query/bytes";
+import type { SceneSource } from "../../../scene-inventory";
+import { VISUALIZATION_KIND } from "../../../visualization";
+import type { McapDecodedMessage, McapResourceClient } from "../types";
+import {
+  McapLocationTracksBridge,
+  McapLocationTracksProvider,
+  useMcapLocationTracksContext,
+} from "./mcap-location-tracks-context";
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("McapLocationTracksBridge", () => {
+  it("delays full-track reads, uses the bulk lane, and publishes no-fix gaps", async () => {
+    vi.useFakeTimers();
+    const source = createSource("drive");
+    const locationSources = [locationSource("/gps")];
+    const client = createClient(async function* () {
+      yield locationMessage(1_000_000_000n, 37, -122, 0);
+      yield locationMessage(2_000_000_000n, 37.001, -122.001, -1);
+      yield locationMessage(3_000_000_000n, 37.002, -122.002, 0);
+    });
+
+    render(
+      <Harness
+        client={client}
+        locationSources={locationSources}
+        source={source}
+      />,
+    );
+
+    await advanceTimers(1_499);
+    expect(client.readDecodedMessages).not.toHaveBeenCalled();
+
+    await advanceTimers(1);
+    expect(client.readDecodedMessages).toHaveBeenCalledWith(
+      {
+        activeTimeline: "log",
+        limit: 25_000,
+        source,
+        topics: ["/gps"],
+      },
+      { priority: "bulk" },
+    );
+    expect(screen.getByTestId("location-tracks").textContent).toBe(
+      "/gps:ready:2:2",
+    );
+  });
+});
+
+function Harness({
+  client,
+  locationSources,
+  source,
+}: {
+  readonly client: McapResourceClient;
+  readonly locationSources: readonly SceneSource[];
+  readonly source: ByteSourceDescriptor;
+}) {
+  return (
+    <McapLocationTracksProvider>
+      <McapLocationTracksBridge
+        client={client}
+        locationSources={locationSources}
+        source={source}
+      />
+      <LocationTracksProbe />
+    </McapLocationTracksProvider>
+  );
+}
+
+function LocationTracksProbe() {
+  const tracks = useMcapLocationTracksContext();
+  return (
+    <div data-testid="location-tracks">
+      {[...tracks.entries()]
+        .map(
+          ([topic, state]) =>
+            `${topic}:${state.status}:${state.pointCount}:${state.segments.length}`,
+        )
+        .join("|")}
+    </div>
+  );
+}
+
+function createClient(
+  messages: () => AsyncGenerator<
+    McapDecodedMessage,
+    void,
+    void
+  > = emptyMessages,
+): McapResourceClient {
+  return {
+    dispose: vi.fn(),
+    enumerateNumericFields: vi.fn(async () => []),
+    readDecodedMessages: vi.fn(messages),
+    readFrameTransformBootstrap: vi.fn(async () => ({ samples: [] })),
+    readFrameTransformWindow: vi.fn(async () => ({ samples: [] })),
+    readNumericSeries: vi.fn(async () => ({
+      baseTimeNs: 0n,
+      fields: [],
+      messageCount: 0,
+      topic: "",
+      truncated: false,
+    })),
+    readRawMessageRecord: vi.fn(),
+    readSynchronizedMessageBatch: vi.fn(async () => []),
+    readSynchronizedMessages: vi.fn(),
+    readTimelineRange: vi.fn(),
+    readTopicTimeBounds: vi.fn(async () => []),
+    readTopics: vi.fn(async () => []),
+  };
+}
+
+async function* emptyMessages(): AsyncGenerator<
+  McapDecodedMessage,
+  void,
+  void
+> {
+  for (const message of [] as McapDecodedMessage[]) {
+    yield message;
+  }
+}
+
+function locationMessage(
+  timelineTimeNs: bigint,
+  latitude: number,
+  longitude: number,
+  fixStatus: number,
+): McapDecodedMessage {
+  return {
+    decoded: {
+      output: {
+        visualization: {
+          fixStatus,
+          kind: VISUALIZATION_KIND.LOCATION,
+          latitude,
+          longitude,
+        },
+      },
+    },
+    timelineTimeNs,
+  } as unknown as McapDecodedMessage;
+}
+
+function locationSource(id: string): SceneSource {
+  return { id, label: id.replace(/^\//, ""), type: "location" };
+}
+
+function createSource(sourceId: string): ByteSourceDescriptor {
+  return {
+    sourceId,
+    url: `memory://${sourceId}.mcap`,
+  };
+}
+
+async function advanceTimers(ms: number) {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-location-tracks-context.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-location-tracks-context.test.tsx
@@ -1,4 +1,7 @@
+import { isPlayingAtom } from "@fiftyone/playback/src/lib/playback/atoms";
+import { PlaybackStoreContext } from "@fiftyone/playback/src/lib/playback/playback-store-context";
 import { act, cleanup, render, screen } from "@testing-library/react";
+import { createStore } from "jotai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ByteSourceDescriptor } from "../../../query/bytes";
 import type { SceneSource } from "../../../scene-inventory";
@@ -9,6 +12,7 @@ import {
   McapLocationTracksProvider,
   useMcapLocationTracksContext,
 } from "./mcap-location-tracks-context";
+import { setMcapNetworkHealth } from "./mcap-network-health";
 
 afterEach(() => {
   cleanup();
@@ -48,7 +52,95 @@ describe("McapLocationTracksBridge", () => {
       { priority: "bulk" },
     );
     expect(screen.getByTestId("location-tracks").textContent).toBe(
-      "/gps:ready:2:2",
+      "/gps:ready:2:2:full",
+    );
+  });
+
+  it("marks topics as error when the bulk read rejects", async () => {
+    vi.useFakeTimers();
+    const source = createSource("drive");
+    const locationSources = [locationSource("/gps")];
+    const client = createClient(async function* () {
+      throw new Error("boom");
+      yield locationMessage(0n, 0, 0, 0);
+    });
+
+    render(
+      <Harness
+        client={client}
+        locationSources={locationSources}
+        source={source}
+      />,
+    );
+
+    await advanceTimers(1_500);
+
+    expect(screen.getByTestId("location-tracks").textContent).toBe(
+      "/gps:error:0:0:full",
+    );
+  });
+
+  it("retries deferred track reads after playback pressure stands down", async () => {
+    vi.useFakeTimers();
+    const source = createSource("drive");
+    const store = createStore();
+    store.set(isPlayingAtom, true);
+    setMcapNetworkHealth(store, {
+      busyFraction: 1,
+      busyThroughputBytesPerSec: 1,
+      limited: true,
+      throughputBytesPerSec: 1,
+      throughputPlannable: true,
+      updatedAtMs: 0,
+    });
+    const client = createClient(async function* () {
+      yield locationMessage(1_000_000_000n, 37, -122, 0);
+    });
+
+    render(
+      <Harness
+        client={client}
+        locationSources={[locationSource("/gps")]}
+        source={source}
+        store={store}
+      />,
+    );
+
+    await advanceTimers(1_500);
+    expect(client.readDecodedMessages).not.toHaveBeenCalled();
+
+    store.set(isPlayingAtom, false);
+    await advanceTimers(1_999);
+    expect(client.readDecodedMessages).not.toHaveBeenCalled();
+
+    await advanceTimers(1);
+    expect(client.readDecodedMessages).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("location-tracks").textContent).toBe(
+      "/gps:ready:1:1:full",
+    );
+  });
+
+  it("marks the track truncated when the read limit is reached before usable fixes", async () => {
+    vi.useFakeTimers();
+    const source = createSource("drive");
+    const client = createClient(async function* () {
+      for (let index = 0; index < 25_000; index += 1) {
+        yield nonLocationMessage(BigInt(index));
+      }
+    });
+
+    render(
+      <Harness
+        client={client}
+        locationSources={[locationSource("/gps")]}
+        source={source}
+      />,
+    );
+
+    await advanceTimers(1_500);
+
+    expect(screen.getByTestId("location-tracks").textContent).toBe(
+      "/gps:ready:0:0:truncated",
     );
   });
 });
@@ -57,12 +149,14 @@ function Harness({
   client,
   locationSources,
   source,
+  store,
 }: {
   readonly client: McapResourceClient;
   readonly locationSources: readonly SceneSource[];
   readonly source: ByteSourceDescriptor;
+  readonly store?: ReturnType<typeof createStore>;
 }) {
-  return (
+  const body = (
     <McapLocationTracksProvider>
       <McapLocationTracksBridge
         client={client}
@@ -71,6 +165,13 @@ function Harness({
       />
       <LocationTracksProbe />
     </McapLocationTracksProvider>
+  );
+  return store ? (
+    <PlaybackStoreContext.Provider value={store}>
+      {body}
+    </PlaybackStoreContext.Provider>
+  ) : (
+    body
   );
 }
 
@@ -81,7 +182,9 @@ function LocationTracksProbe() {
       {[...tracks.entries()]
         .map(
           ([topic, state]) =>
-            `${topic}:${state.status}:${state.pointCount}:${state.segments.length}`,
+            `${topic}:${state.status}:${state.pointCount}:${state.segments.length}:${
+              state.truncated ? "truncated" : "full"
+            }`,
         )
         .join("|")}
     </div>
@@ -142,6 +245,17 @@ function locationMessage(
           latitude,
           longitude,
         },
+      },
+    },
+    timelineTimeNs,
+  } as unknown as McapDecodedMessage;
+}
+
+function nonLocationMessage(timelineTimeNs: bigint): McapDecodedMessage {
+  return {
+    decoded: {
+      output: {
+        visualization: { kind: VISUALIZATION_KIND.POSE },
       },
     },
     timelineTimeNs,

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-location-tracks-context.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-location-tracks-context.tsx
@@ -159,6 +159,7 @@ export function McapLocationTracksBridge({
 
         void (async () => {
           const points: McapLocationTrackPoint[] = [];
+          let messageCount = 0;
           try {
             for await (const message of client.readDecodedMessages(
               {
@@ -172,6 +173,7 @@ export function McapLocationTracksBridge({
               if (cancelled) {
                 return;
               }
+              messageCount += 1;
               if (shouldStandDown()) {
                 fetchedTopicsRef.current.delete(topic);
                 scheduleRetry(LOCATION_TRACK_DEFERRED_RETRY_MS);
@@ -192,7 +194,9 @@ export function McapLocationTracksBridge({
             const result = decimateLocationTrackSegments(
               segmentLocationTrack(points),
             );
-            if (result.truncated) {
+            const truncated =
+              result.truncated || messageCount >= LOCATION_TRACK_READ_LIMIT;
+            if (truncated) {
               markMcapLatencyEvent("location track downsampled", {
                 points: result.pointCount,
                 topic,
@@ -203,7 +207,7 @@ export function McapLocationTracksBridge({
               pointCount: result.pointCount,
               segments: result.segments,
               status: "ready",
-              ...(result.truncated ? { truncated: true } : {}),
+              ...(truncated ? { truncated: true } : {}),
             });
           } catch {
             commit(topic, { ...baseState, status: "error" });

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-location-tracks-context.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-location-tracks-context.tsx
@@ -1,0 +1,244 @@
+// Deep imports on purpose: the playback package root barrel pulls view
+// components whose relay fragments cannot evaluate under vitest, and this
+// bridge mirrors the pose-trajectory bulk fetch path.
+import { PlaybackStoreContext } from "@fiftyone/playback/src/lib/playback/playback-store-context";
+import { getIsPlaying } from "@fiftyone/playback/src/lib/playback/store-access";
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import type { ByteSourceDescriptor } from "../../../query/bytes";
+import { byteSourceAccessKey } from "../../../query/bytes";
+import type { SceneSource } from "../../../scene-inventory";
+import { VISUALIZATION_KIND } from "../../../visualization";
+import { markMcapLatencyEvent } from "../mcap-latency-debug";
+import { MCAP_ACTIVE_TIMELINE, type McapResourceClient } from "../types";
+import {
+  getMcapNetworkHealth,
+  shouldDeferMcapIdleWorkForStore,
+} from "./mcap-network-health";
+import {
+  decimateLocationTrackSegments,
+  locationPointFromVisualization,
+  locationTrackColor,
+  segmentLocationTrack,
+  type McapLocationTrackPoint,
+  type McapLocationTracks,
+  type McapLocationTrackState,
+} from "./mcap-location-track";
+
+const LOCATION_TRACK_READ_LIMIT = 25_000;
+const LOCATION_TRACK_START_DELAY_MS = 1_500;
+const LOCATION_TRACK_DEFERRED_RETRY_MS = 2_000;
+
+const EMPTY_LOCATION_TRACKS: McapLocationTracks = new Map();
+
+interface McapLocationTracksContextValue {
+  readonly setTracks: (state: McapLocationTracks) => void;
+  readonly tracks: McapLocationTracks;
+}
+
+const McapLocationTracksContext =
+  createContext<McapLocationTracksContextValue | null>(null);
+
+/**
+ * Shares full-file geographic tracks with map tiles. The provider lives
+ * outside playback; the bridge inside playback performs one bulk read per
+ * source file and publishes normalized route segments here.
+ */
+export const McapLocationTracksProvider: React.FC<{
+  children: React.ReactNode;
+}> = ({ children }) => {
+  const [tracks, setTracks] = useState<McapLocationTracks>(
+    EMPTY_LOCATION_TRACKS,
+  );
+  const value = useMemo(() => ({ setTracks, tracks }), [tracks]);
+
+  return (
+    <McapLocationTracksContext.Provider value={value}>
+      {children}
+    </McapLocationTracksContext.Provider>
+  );
+};
+
+export function useMcapLocationTracksContext(): McapLocationTracks {
+  return useContextValue().tracks;
+}
+
+/**
+ * Bridge that fetches every location topic's full track once per source.
+ * The track is tiny compared to camera/point-cloud data, and seeing the
+ * whole route is the map tile's core value, so this intentionally uses the
+ * same capped bulk-lane pattern as pose trajectories.
+ */
+export function McapLocationTracksBridge({
+  client,
+  locationSources,
+  source,
+}: {
+  readonly client: McapResourceClient;
+  readonly locationSources: readonly SceneSource[];
+  readonly source: ByteSourceDescriptor | null;
+}) {
+  const { setTracks } = useContextValue();
+  const sourceKey = source ? byteSourceAccessKey(source) : null;
+  const fetchedTopicsRef = useRef(new Set<string>());
+  const tracksRef = useRef(new Map<string, McapLocationTrackState>());
+  const playbackStore = useContext(PlaybackStoreContext);
+
+  useEffect(() => {
+    fetchedTopicsRef.current = new Set();
+    tracksRef.current = new Map();
+    setTracks(EMPTY_LOCATION_TRACKS);
+
+    if (!sourceKey || !source || locationSources.length === 0) {
+      return undefined;
+    }
+
+    let cancelled = false;
+    let retryTimeout: ReturnType<typeof setTimeout> | null = null;
+    const commit = (topic: string, state: McapLocationTrackState) => {
+      if (cancelled) {
+        return;
+      }
+      tracksRef.current.set(topic, state);
+      setTracks(new Map(tracksRef.current));
+    };
+
+    const shouldStandDown = (): boolean => {
+      if (!playbackStore) {
+        return false;
+      }
+      if (
+        getIsPlaying(playbackStore) &&
+        getMcapNetworkHealth(playbackStore).limited
+      ) {
+        return true;
+      }
+      return shouldDeferMcapIdleWorkForStore(playbackStore, null);
+    };
+
+    const scheduleRetry = (delayMs: number) => {
+      if (cancelled || retryTimeout !== null) {
+        return;
+      }
+      retryTimeout = setTimeout(() => {
+        retryTimeout = null;
+        start();
+      }, delayMs);
+    };
+
+    const start = () => {
+      if (cancelled) {
+        return;
+      }
+      if (shouldStandDown()) {
+        scheduleRetry(LOCATION_TRACK_DEFERRED_RETRY_MS);
+        return;
+      }
+
+      locationSources.forEach((locationSource, index) => {
+        const topic = locationSource.id;
+        if (fetchedTopicsRef.current.has(topic)) {
+          return;
+        }
+        fetchedTopicsRef.current.add(topic);
+        const color = locationTrackColor(index);
+        const baseState = {
+          color,
+          label: locationSource.label,
+          pointCount: 0,
+          segments: [],
+          topic,
+        } satisfies Omit<McapLocationTrackState, "status">;
+        commit(topic, { ...baseState, status: "loading" });
+
+        void (async () => {
+          const points: McapLocationTrackPoint[] = [];
+          try {
+            for await (const message of client.readDecodedMessages(
+              {
+                activeTimeline: MCAP_ACTIVE_TIMELINE.LOG,
+                limit: LOCATION_TRACK_READ_LIMIT,
+                source,
+                topics: [topic],
+              },
+              { priority: "bulk" },
+            )) {
+              if (cancelled) {
+                return;
+              }
+              if (shouldStandDown()) {
+                fetchedTopicsRef.current.delete(topic);
+                scheduleRetry(LOCATION_TRACK_DEFERRED_RETRY_MS);
+                return;
+              }
+              const visualization = message.decoded.output.visualization;
+              if (visualization?.kind !== VISUALIZATION_KIND.LOCATION) {
+                continue;
+              }
+              points.push(
+                locationPointFromVisualization(
+                  visualization,
+                  message.timelineTimeNs,
+                ),
+              );
+            }
+
+            const result = decimateLocationTrackSegments(
+              segmentLocationTrack(points),
+            );
+            if (result.truncated) {
+              markMcapLatencyEvent("location track downsampled", {
+                points: result.pointCount,
+                topic,
+              });
+            }
+            commit(topic, {
+              ...baseState,
+              pointCount: result.pointCount,
+              segments: result.segments,
+              status: "ready",
+              ...(result.truncated ? { truncated: true } : {}),
+            });
+          } catch {
+            commit(topic, { ...baseState, status: "error" });
+          }
+        })();
+      });
+    };
+
+    scheduleRetry(LOCATION_TRACK_START_DELAY_MS);
+
+    return () => {
+      cancelled = true;
+      if (retryTimeout !== null) {
+        clearTimeout(retryTimeout);
+      }
+    };
+  }, [client, locationSources, playbackStore, setTracks, source, sourceKey]);
+
+  useEffect(
+    () => () => {
+      setTracks(EMPTY_LOCATION_TRACKS);
+    },
+    [setTracks],
+  );
+
+  return null;
+}
+
+function useContextValue(): McapLocationTracksContextValue {
+  const value = useContext(McapLocationTracksContext);
+  if (!value) {
+    throw new Error(
+      "MCAP location tracks must be used inside <McapLocationTracksProvider>",
+    );
+  }
+
+  return value;
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-map-measurement.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-map-measurement.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatMapMeasurementDistance,
+  mapMeasurementDistance,
+  nextMapMeasurementState,
+} from "./mcap-map-measurement";
+import { haversineDistanceMeters } from "./wgs84";
+
+describe("mcap map measurement", () => {
+  it("advances a two-click measurement and restarts after completion", () => {
+    const first = nextMapMeasurementState(null, {
+      latitude: 37,
+      longitude: -122,
+    });
+    expect(first).toEqual({
+      a: { latitude: 37, longitude: -122 },
+      b: null,
+    });
+
+    const complete = nextMapMeasurementState(first, {
+      latitude: 38,
+      longitude: -123,
+    });
+    expect(complete).toEqual({
+      a: { latitude: 37, longitude: -122 },
+      b: { latitude: 38, longitude: -123 },
+    });
+
+    const restarted = nextMapMeasurementState(complete, {
+      latitude: 39,
+      longitude: -124,
+    });
+    expect(restarted).toEqual({
+      a: { latitude: 39, longitude: -124 },
+      b: null,
+    });
+  });
+
+  it("measures complete WGS84 pairs with great-circle distance", () => {
+    expect(mapMeasurementDistance(null)).toBeNull();
+    expect(
+      mapMeasurementDistance({ a: { latitude: 0, longitude: 0 }, b: null }),
+    ).toBeNull();
+
+    expect(
+      haversineDistanceMeters(
+        { latitude: 0, longitude: 0 },
+        { latitude: 0, longitude: 1 },
+      ),
+    ).toBeCloseTo(111_195, -1);
+  });
+
+  it("formats map-scale distances", () => {
+    expect(formatMapMeasurementDistance(12.345)).toBe("12.35 m");
+    expect(formatMapMeasurementDistance(123.45)).toBe("123.5 m");
+    expect(formatMapMeasurementDistance(1_234.5)).toBe("1.23 km");
+    expect(formatMapMeasurementDistance(123_456)).toBe("123.5 km");
+  });
+});

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-map-measurement.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-map-measurement.ts
@@ -1,0 +1,48 @@
+/**
+ * Pure state + math for the map tile's two-click WGS84 ruler.
+ */
+
+import { haversineDistanceMeters, type GeoPoint } from "./wgs84";
+
+export type MapMeasurementPoint = GeoPoint;
+
+export interface MapMeasurementState {
+  readonly a: MapMeasurementPoint;
+  /** `null` while waiting for the second pick. */
+  readonly b: MapMeasurementPoint | null;
+}
+
+/**
+ * Advance the two-click state machine: first pick anchors, second pick
+ * completes, a third starts a fresh measurement.
+ */
+export function nextMapMeasurementState(
+  current: MapMeasurementState | null,
+  pick: MapMeasurementPoint,
+): MapMeasurementState {
+  if (!current || current.b !== null) {
+    return { a: pick, b: null };
+  }
+  return { a: current.a, b: pick };
+}
+
+/** Great-circle distance of a complete WGS84 measurement, else `null`. */
+export function mapMeasurementDistance(
+  measurement: MapMeasurementState | null,
+): number | null {
+  if (!measurement?.b) return null;
+  return haversineDistanceMeters(measurement.a, measurement.b);
+}
+
+export function formatMapMeasurementDistance(meters: number): string {
+  if (meters < 100) {
+    return `${meters.toFixed(2)} m`;
+  }
+  if (meters < 1_000) {
+    return `${meters.toFixed(1)} m`;
+  }
+  if (meters < 100_000) {
+    return `${(meters / 1_000).toFixed(2)} km`;
+  }
+  return `${(meters / 1_000).toFixed(1)} km`;
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-map-puck.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-map-puck.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   ensurePuckImages,
   hexColorWithAlpha,
@@ -6,6 +6,10 @@ import {
   PUCK_VARIANT,
   voxel51PrimaryColor,
 } from "./mcap-map-puck";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("mcap map puck", () => {
   it("produces stable per-variant, per-color sprite ids", () => {
@@ -32,6 +36,7 @@ describe("mcap map puck", () => {
   });
 
   it("degrades to a no-op without throwing when 2D canvas is unavailable", () => {
+    mockCanvasContext(null);
     const added: string[] = [];
     ensurePuckImages(
       {
@@ -40,11 +45,29 @@ describe("mcap map puck", () => {
         },
         hasImage: () => false,
       },
-      // Duplicate colors must not register twice even when drawing works.
       ["#ff6d04", "#ff6d04"],
     );
-    expect(new Set(added).size).toBe(added.length);
-    expect(added.length === 0 || added.length === 2).toBe(true);
+    expect(added).toEqual([]);
+  });
+
+  it("registers each variant once for duplicate track colors", () => {
+    mockCanvasContext(fakeCanvasContext());
+    const added: string[] = [];
+
+    ensurePuckImages(
+      {
+        addImage: (id) => {
+          added.push(id);
+        },
+        hasImage: () => false,
+      },
+      ["#ff6d04", "#ff6d04"],
+    );
+
+    expect(added).toEqual([
+      puckImageId(PUCK_VARIANT.DOT, "#ff6d04"),
+      puckImageId(PUCK_VARIANT.NAV, "#ff6d04"),
+    ]);
   });
 
   it("falls back to brand orange when the theme variable is absent", () => {
@@ -58,3 +81,42 @@ describe("mcap map puck", () => {
     );
   });
 });
+
+function mockCanvasContext(context: CanvasRenderingContext2D | null) {
+  const createElement = document.createElement.bind(document);
+  vi.spyOn(document, "createElement").mockImplementation((tagName, options) => {
+    if (tagName === "canvas") {
+      return {
+        getContext: () => context,
+        height: 0,
+        width: 0,
+      } as unknown as HTMLCanvasElement;
+    }
+    return createElement(tagName, options);
+  });
+}
+
+function fakeCanvasContext(): CanvasRenderingContext2D {
+  const gradient = { addColorStop: vi.fn() };
+  return {
+    arc: vi.fn(),
+    beginPath: vi.fn(),
+    closePath: vi.fn(),
+    createRadialGradient: vi.fn(() => gradient),
+    ellipse: vi.fn(),
+    fill: vi.fn(),
+    getImageData: vi.fn(
+      () =>
+        ({
+          data: new Uint8ClampedArray(),
+          height: 1,
+          width: 1,
+        }) as ImageData,
+    ),
+    lineJoin: "round",
+    lineWidth: 0,
+    moveTo: vi.fn(),
+    quadraticCurveTo: vi.fn(),
+    stroke: vi.fn(),
+  } as unknown as CanvasRenderingContext2D;
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-map-puck.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-map-puck.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  ensurePuckImages,
+  hexColorWithAlpha,
+  puckImageId,
+  PUCK_VARIANT,
+  voxel51PrimaryColor,
+} from "./mcap-map-puck";
+
+describe("mcap map puck", () => {
+  it("produces stable per-variant, per-color sprite ids", () => {
+    expect(puckImageId(PUCK_VARIANT.NAV, "#ff6d04")).toBe(
+      "mcap-puck-nav-#ff6d04",
+    );
+    expect(puckImageId(PUCK_VARIANT.DOT, "#3b82f6")).toBe(
+      "mcap-puck-dot-#3b82f6",
+    );
+  });
+
+  it("skips registration for ids the map already has", () => {
+    const added: string[] = [];
+    ensurePuckImages(
+      {
+        addImage: (id) => {
+          added.push(id);
+        },
+        hasImage: () => true,
+      },
+      ["#ff6d04", "#3b82f6"],
+    );
+    expect(added).toEqual([]);
+  });
+
+  it("degrades to a no-op without throwing when 2D canvas is unavailable", () => {
+    const added: string[] = [];
+    ensurePuckImages(
+      {
+        addImage: (id) => {
+          added.push(id);
+        },
+        hasImage: () => false,
+      },
+      // Duplicate colors must not register twice even when drawing works.
+      ["#ff6d04", "#ff6d04"],
+    );
+    expect(new Set(added).size).toBe(added.length);
+    expect(added.length === 0 || added.length === 2).toBe(true);
+  });
+
+  it("falls back to brand orange when the theme variable is absent", () => {
+    expect(voxel51PrimaryColor()).toBe("#ff6d04");
+  });
+
+  it("applies alpha to hex colors and passes through unparseable ones", () => {
+    expect(hexColorWithAlpha("#ff6d04", 0)).toBe("rgba(255, 109, 4, 0)");
+    expect(hexColorWithAlpha("hsl(25, 100%, 51%)", 0.5)).toBe(
+      "hsl(25, 100%, 51%)",
+    );
+  });
+});

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-map-puck.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-map-puck.ts
@@ -1,0 +1,269 @@
+/**
+ * Canvas-rendered position "pucks" for the map tile. MapLibre circle
+ * layers cannot render gradients, so the dimensional look — dome shading,
+ * specular highlight, white rim, baked drop shadow — is pre-drawn once per
+ * track color and registered as a symbol icon, the technique behind
+ * Google/Uber-style navigation markers. The nav variant is a teardrop
+ * drawn pointing north; `icon-rotate` supplies the bearing.
+ */
+
+export const PUCK_VARIANT = {
+  /** Plain dome, used when no heading is derivable. */
+  DOT: "dot",
+  /** North-pointing teardrop, rotated to the GPS segment bearing. */
+  NAV: "nav",
+} as const;
+
+export type PuckVariant = (typeof PUCK_VARIANT)[keyof typeof PUCK_VARIANT];
+
+/** CSS size of the rendered sprite; drawn at 2x for retina. */
+const PUCK_SIZE_PX = 40;
+const PUCK_PIXEL_RATIO = 2;
+const PUCK_RADIUS_PX = 9;
+
+const VOXEL51_PRIMARY_FALLBACK = "#ff6d04";
+const VOXEL51_PRIMARY_CSS_VAR = "--fo-palette-primary-plainColor";
+
+let cachedPrimaryColor: string | null = null;
+
+/**
+ * The app's primary (Voxel51 orange) resolved from the theme's CSS
+ * variable, with a literal fallback for standalone/test environments.
+ * MapLibre paint values cannot reference CSS variables, so this is
+ * resolved once and handed over as a concrete color.
+ */
+export function voxel51PrimaryColor(): string {
+  if (cachedPrimaryColor) {
+    return cachedPrimaryColor;
+  }
+  if (typeof document === "undefined") {
+    return VOXEL51_PRIMARY_FALLBACK;
+  }
+  const value = getComputedStyle(document.documentElement)
+    .getPropertyValue(VOXEL51_PRIMARY_CSS_VAR)
+    .trim();
+  // The theme emits hsl() strings; the sprite/gradient math needs hex, so
+  // normalize through canvas (which serializes opaque colors as #rrggbb).
+  cachedPrimaryColor =
+    value.length > 0
+      ? (normalizeCssColorToHex(value) ?? VOXEL51_PRIMARY_FALLBACK)
+      : VOXEL51_PRIMARY_FALLBACK;
+  return cachedPrimaryColor;
+}
+
+function normalizeCssColorToHex(color: string): string | null {
+  if (/^#[0-9a-f]{6}$/i.test(color)) {
+    return color;
+  }
+  const ctx = document.createElement("canvas").getContext("2d");
+  if (!ctx) {
+    return null;
+  }
+  ctx.fillStyle = color;
+  const normalized = ctx.fillStyle;
+  return /^#[0-9a-f]{6}$/i.test(normalized) ? normalized : null;
+}
+
+export function puckImageId(variant: PuckVariant, color: string): string {
+  return `mcap-puck-${variant}-${color}`;
+}
+
+/** The subset of the MapLibre map surface the sprite registry needs. */
+export interface PuckImageHost {
+  hasImage(id: string): boolean;
+  addImage(
+    id: string,
+    image: ImageData,
+    options?: { pixelRatio?: number },
+  ): void;
+}
+
+/**
+ * Registers both puck variants for each track color, skipping ids the map
+ * already has. A no-op where 2D canvas is unavailable (e.g. jsdom) — the
+ * symbol layer simply renders nothing rather than erroring.
+ */
+export function ensurePuckImages(
+  map: PuckImageHost,
+  colors: readonly string[],
+): void {
+  for (const color of new Set(colors)) {
+    for (const variant of Object.values(PUCK_VARIANT)) {
+      const id = puckImageId(variant, color);
+      if (map.hasImage(id)) {
+        continue;
+      }
+      const image = drawPuckImage(variant, color);
+      if (image) {
+        map.addImage(id, image, { pixelRatio: PUCK_PIXEL_RATIO });
+      }
+    }
+  }
+}
+
+export function drawPuckImage(
+  variant: PuckVariant,
+  color: string,
+): ImageData | null {
+  // Partial canvas implementations (jsdom, test stubs) surface as thrown
+  // TypeErrors mid-draw; a puck that cannot draw degrades to no icon.
+  try {
+    return drawPuckImageUnsafe(variant, color);
+  } catch {
+    return null;
+  }
+}
+
+function drawPuckImageUnsafe(
+  variant: PuckVariant,
+  color: string,
+): ImageData | null {
+  if (typeof document === "undefined") {
+    return null;
+  }
+  const size = PUCK_SIZE_PX * PUCK_PIXEL_RATIO;
+  const canvas = document.createElement("canvas");
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) {
+    return null;
+  }
+
+  const center = size / 2;
+  const radius = PUCK_RADIUS_PX * PUCK_PIXEL_RATIO;
+
+  // Baked drop shadow: a soft dark ellipse slightly below the dome.
+  const shadow = ctx.createRadialGradient(
+    center,
+    center + radius * 0.5,
+    radius * 0.2,
+    center,
+    center + radius * 0.5,
+    radius * 1.5,
+  );
+  shadow.addColorStop(0, "rgba(2, 8, 16, 0.4)");
+  shadow.addColorStop(1, "rgba(2, 8, 16, 0)");
+  ctx.fillStyle = shadow;
+  ctx.beginPath();
+  ctx.ellipse(
+    center,
+    center + radius * 0.5,
+    radius * 1.5,
+    radius * 1.1,
+    0,
+    0,
+    Math.PI * 2,
+  );
+  ctx.fill();
+
+  tracePuckPath(ctx, variant, center, radius);
+
+  // White rim first (stroked under the fill so half its width shows),
+  // then the gradient dome.
+  ctx.strokeStyle = "#ffffff";
+  ctx.lineWidth = 3 * PUCK_PIXEL_RATIO;
+  ctx.lineJoin = "round";
+  ctx.stroke();
+
+  const dome = ctx.createRadialGradient(
+    center - radius * 0.45,
+    center - radius * 0.55,
+    radius * 0.15,
+    center,
+    center,
+    radius * 2.1,
+  );
+  dome.addColorStop(0, mixHexColor(color, "#ffffff", 0.45));
+  dome.addColorStop(0.45, color);
+  dome.addColorStop(1, mixHexColor(color, "#000000", 0.35));
+  ctx.fillStyle = dome;
+  ctx.fill();
+
+  // Specular highlight off toward the light source.
+  const specular = ctx.createRadialGradient(
+    center - radius * 0.4,
+    center - radius * 0.5,
+    0,
+    center - radius * 0.4,
+    center - radius * 0.5,
+    radius * 0.8,
+  );
+  specular.addColorStop(0, "rgba(255, 255, 255, 0.55)");
+  specular.addColorStop(1, "rgba(255, 255, 255, 0)");
+  ctx.fillStyle = specular;
+  ctx.beginPath();
+  ctx.arc(
+    center - radius * 0.3,
+    center - radius * 0.4,
+    radius * 0.7,
+    0,
+    Math.PI * 2,
+  );
+  ctx.fill();
+
+  return ctx.getImageData(0, 0, size, size);
+}
+
+function tracePuckPath(
+  ctx: CanvasRenderingContext2D,
+  variant: PuckVariant,
+  center: number,
+  radius: number,
+) {
+  ctx.beginPath();
+  if (variant === PUCK_VARIANT.DOT) {
+    ctx.arc(center, center, radius, 0, Math.PI * 2);
+    return;
+  }
+  // Teardrop pointing north (up): nose tip, left shoulder, around the
+  // bottom of the circle, right shoulder back to the tip.
+  const tipY = center - radius * 2;
+  ctx.moveTo(center, tipY);
+  ctx.quadraticCurveTo(
+    center - radius * 0.95,
+    center - radius * 0.75,
+    center - radius,
+    center,
+  );
+  ctx.arc(center, center, radius, Math.PI, 0, true);
+  ctx.quadraticCurveTo(
+    center + radius * 0.95,
+    center - radius * 0.75,
+    center,
+    tipY,
+  );
+  ctx.closePath();
+}
+
+/** `color` with `alpha` applied, for gradient endpoints. */
+export function hexColorWithAlpha(color: string, alpha: number): string {
+  const rgb = parseHexColor(color);
+  if (!rgb) {
+    return color;
+  }
+  return `rgba(${rgb[0]}, ${rgb[1]}, ${rgb[2]}, ${alpha})`;
+}
+
+function mixHexColor(color: string, target: string, amount: number): string {
+  const from = parseHexColor(color);
+  const to = parseHexColor(target);
+  if (!from || !to) {
+    return color;
+  }
+  const mixed = from.map((channel, index) =>
+    Math.round(channel + (to[index] - channel) * amount),
+  );
+  return `rgb(${mixed[0]}, ${mixed[1]}, ${mixed[2]})`;
+}
+
+function parseHexColor(
+  color: string,
+): readonly [number, number, number] | null {
+  const match = /^#([0-9a-f]{6})$/i.exec(color.trim());
+  if (!match) {
+    return null;
+  }
+  const value = Number.parseInt(match[1], 16);
+  return [(value >> 16) & 0xff, (value >> 8) & 0xff, value & 0xff];
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-map-tile-state.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-map-tile-state.ts
@@ -1,0 +1,123 @@
+import { useTileId } from "@fiftyone/tiling";
+import { atom, useAtomValue, useStore } from "jotai";
+import { useCallback, useMemo } from "react";
+
+export const MCAP_MAP_BASE_LAYER = {
+  DEFAULT: "default",
+  NONE: "none",
+} as const;
+
+export type McapMapBaseLayer =
+  (typeof MCAP_MAP_BASE_LAYER)[keyof typeof MCAP_MAP_BASE_LAYER];
+
+export const OPENFREEMAP_LIBERTY_STYLE_URL =
+  "https://tiles.openfreemap.org/styles/liberty";
+
+export interface McapMapTileSettings {
+  /**
+   * Basemap selection for the geographic view. The default is an OSS
+   * OpenFreeMap style; `none` is the explicit offline/no-tile mode.
+   */
+  readonly baseLayer: McapMapBaseLayer;
+  /**
+   * `undefined` means "all location topics currently present". Once the
+   * user edits topic visibility, this becomes the explicit visible list.
+   */
+  readonly enabledTopics?: readonly string[];
+  /** Follow the playhead marker until the user manually pans/zooms. */
+  readonly followEgo: boolean;
+}
+
+export type McapMapTileSettingsByTile = Readonly<
+  Record<string, McapMapTileSettings>
+>;
+
+export const DEFAULT_MCAP_MAP_TILE_SETTINGS: McapMapTileSettings = {
+  baseLayer: MCAP_MAP_BASE_LAYER.DEFAULT,
+  followEgo: true,
+};
+
+export const mcapMapTileSettingsAtom = atom<McapMapTileSettingsByTile>({});
+
+export function useMcapMapTileSettings(): McapMapTileSettings {
+  const tileId = useTileId();
+  const byTile = useAtomValue(mcapMapTileSettingsAtom);
+  return useMemo(
+    () =>
+      tileId
+        ? { ...DEFAULT_MCAP_MAP_TILE_SETTINGS, ...byTile[tileId] }
+        : DEFAULT_MCAP_MAP_TILE_SETTINGS,
+    [byTile, tileId],
+  );
+}
+
+export function useSetMcapMapTileSettings(): (
+  patch: Partial<McapMapTileSettings>,
+) => void {
+  const tileId = useTileId();
+  const store = useStore();
+  return useCallback(
+    (patch) => {
+      if (!tileId) return;
+      store.set(mcapMapTileSettingsAtom, (previous) => {
+        const current = {
+          ...DEFAULT_MCAP_MAP_TILE_SETTINGS,
+          ...previous[tileId],
+        };
+        const next = { ...current, ...patch };
+        if (
+          next.baseLayer === current.baseLayer &&
+          next.enabledTopics === current.enabledTopics &&
+          next.followEgo === current.followEgo
+        ) {
+          return previous;
+        }
+        return { ...previous, [tileId]: next };
+      });
+    },
+    [store, tileId],
+  );
+}
+
+export function useToggleMcapMapTileTopic(): (
+  topic: string,
+  enabled: boolean,
+  allTopics: readonly string[],
+) => void {
+  const tileId = useTileId();
+  const store = useStore();
+  return useCallback(
+    (topic, enabled, allTopics) => {
+      if (!tileId) return;
+      store.set(mcapMapTileSettingsAtom, (previous) => {
+        const current = {
+          ...DEFAULT_MCAP_MAP_TILE_SETTINGS,
+          ...previous[tileId],
+        };
+        const enabledTopics = new Set(current.enabledTopics ?? allTopics);
+        if (enabled) {
+          enabledTopics.add(topic);
+        } else {
+          enabledTopics.delete(topic);
+        }
+        const nextTopics = allTopics.filter((candidate) =>
+          enabledTopics.has(candidate),
+        );
+        const next: McapMapTileSettings = {
+          ...current,
+          enabledTopics: nextTopics,
+        };
+        return { ...previous, [tileId]: next };
+      });
+    },
+    [store, tileId],
+  );
+}
+
+export function normalizeMcapMapBaseLayer(
+  raw: unknown,
+): McapMapBaseLayer | undefined {
+  return raw === MCAP_MAP_BASE_LAYER.DEFAULT || raw === MCAP_MAP_BASE_LAYER.NONE
+    ? raw
+    : undefined;
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-tile-types.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-tile-types.ts
@@ -11,6 +11,7 @@
 export const MCAP_TILE_TYPE = {
   IMAGE: "image",
   LOG: "log",
+  MAP: "map",
   PLOT: "plot",
   RAW: "raw",
   THREE_D: "3d",

--- a/app/packages/multimodal/src/adapters/mcap/react/playback-layout.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/playback-layout.test.ts
@@ -37,6 +37,15 @@ function logSource(id: string, recordCount?: number): SceneSource {
   };
 }
 
+function locationSource(id: string, recordCount?: number): SceneSource {
+  return {
+    id,
+    label: id.replace(/^\//, ""),
+    type: "location",
+    ...(recordCount !== undefined ? { recordCount } : {}),
+  };
+}
+
 const POINT_CLOUD: SceneSource = {
   id: "/points",
   label: "points",
@@ -268,6 +277,39 @@ describe("resolvePlaybackLayout", () => {
     expect(layout).toBe("3d-1");
   });
 
+  it("opens a map tile for location-only scenes", () => {
+    const { tiles, layout } = resolvePlaybackLayout({
+      capabilities: STRONG_LOCAL,
+      readProfile: "local",
+      sources: [locationSource("/gps/fix", 1_000)],
+    });
+
+    expect(tiles).toEqual([
+      {
+        id: "map-1",
+        tileType: "map",
+        title: "Map",
+      },
+    ]);
+    expect(layout).toBe("map-1");
+  });
+
+  it("places location maps beside the 3d view", () => {
+    const { tiles, layout } = resolvePlaybackLayout({
+      capabilities: STRONG_LOCAL,
+      readProfile: "local",
+      sources: [POINT_CLOUD, locationSource("/gps/fix", 1_000)],
+    });
+
+    expect(tiles.map((tile) => tile.id)).toEqual(["3d-1", "map-1"]);
+    expect(layout).toEqual({
+      direction: "row",
+      first: "3d-1",
+      second: "map-1",
+      splitPercentage: 70,
+    });
+  });
+
   it("opens a log tile for logs-only scenes", () => {
     const { tiles, layout } = resolvePlaybackLayout({
       capabilities: STRONG_LOCAL,
@@ -340,6 +382,20 @@ describe("buildMcapAutoLayout", () => {
     });
   });
 
+  it("places map tiles beside 3d tiles in the top visual region", () => {
+    expect(buildMcapAutoLayout(["image-1", "3d-1", "map-1"])).toEqual({
+      direction: "column",
+      first: {
+        direction: "row",
+        first: "3d-1",
+        second: "map-1",
+        splitPercentage: 70,
+      },
+      second: "image-1",
+      splitPercentage: THREE_D_TOP_SPLIT_PERCENTAGE,
+    });
+  });
+
   it("keeps image tiles co-located in a visual bank", () => {
     expect(buildMcapAutoLayout(["image-1", "image-2", "image-3"])).toEqual({
       direction: "row",
@@ -351,6 +407,15 @@ describe("buildMcapAutoLayout", () => {
       },
       second: "image-3",
       splitPercentage: 50,
+    });
+  });
+
+  it("co-locates maps with images when no 3d tile is present", () => {
+    expect(buildMcapAutoLayout(["image-1", "map-1"])).toEqual({
+      direction: "row",
+      first: "image-1",
+      second: "map-1",
+      splitPercentage: 65,
     });
   });
 

--- a/app/packages/multimodal/src/adapters/mcap/react/playback-layout.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/playback-layout.ts
@@ -32,12 +32,14 @@ const DEFAULT_VIEWPORT_WIDTH_PX = 1280;
 const DEFAULT_VIEWPORT_HEIGHT_PX = 800;
 
 const THREE_D_TOP_SPLIT_PERCENTAGE = 100 * (2 / 3);
+const THREE_D_WITH_MAP_SPLIT_PERCENTAGE = 70;
 const MESSAGE_RAIL_SPLIT_PERCENTAGE = 75;
 const VISUAL_WITH_PLOTS_SPLIT_PERCENTAGE = 70;
 const CONTEXT_SHELF_IMAGE_SPLIT_PERCENTAGE = 65;
 
 // Mosaic leaf id of the single default 3D tile.
 const THREE_D_TILE_ID = `${MCAP_TILE_TYPE.THREE_D}-1`;
+const MAP_TILE_ID = `${MCAP_TILE_TYPE.MAP}-1`;
 const LOG_TILE_ID = `${MCAP_TILE_TYPE.LOG}-1`;
 
 /**
@@ -207,6 +209,9 @@ export function resolvePlaybackLayout({
   const hasLogs = sources.some(
     (source) => source.type === MCAP_SOURCE_TYPE.LOG,
   );
+  const hasMap = sources.some(
+    (source) => source.type === MCAP_SOURCE_TYPE.LOCATION,
+  );
 
   const imageTileCount =
     rankedImages.length === 0
@@ -229,6 +234,13 @@ export function resolvePlaybackLayout({
       id: THREE_D_TILE_ID,
       tileType: MCAP_TILE_TYPE.THREE_D,
       title: "3D",
+    });
+  }
+  if (hasMap) {
+    tiles.push({
+      id: MAP_TILE_ID,
+      tileType: MCAP_TILE_TYPE.MAP,
+      title: "Map",
     });
   }
   if (hasLogs) {
@@ -316,7 +328,7 @@ function remoteNetworkBudget(downlinkMbps: number | null): number {
  * Customer-oriented MCAP arrangement:
  *
  * - images stay co-located as a camera bank
- * - 3D tiles span a full-width top region when present
+ * - 3D and map tiles share the top visual region when both are present
  * - plots stack as time-series diagnostics
  * - raw/message tiles stack as a right inspection rail
  * - unknown tile ids fall into diagnostics after known groups
@@ -326,6 +338,7 @@ export function buildMcapAutoLayout(
 ): MosaicNode<string> | null {
   const images: string[] = [];
   const threeD: string[] = [];
+  const maps: string[] = [];
   const plots: string[] = [];
   const logs: string[] = [];
   const messages: string[] = [];
@@ -338,6 +351,9 @@ export function buildMcapAutoLayout(
         break;
       case MCAP_TILE_TYPE.THREE_D:
         threeD.push(tileId);
+        break;
+      case MCAP_TILE_TYPE.MAP:
+        maps.push(tileId);
         break;
       case MCAP_TILE_TYPE.PLOT:
         plots.push(tileId);
@@ -354,19 +370,20 @@ export function buildMcapAutoLayout(
     }
   }
 
-  const threeDRegion = autoLayout(threeD);
-  const supportingRegion = threeDRegion
+  const topVisualRegion =
+    threeD.length > 0 ? buildTopVisualRegion(threeD, maps) : null;
+  const supportingRegion = topVisualRegion
     ? buildContextShelf(images, plots, logs, messages, unknown)
-    : buildNon3dLayout(images, plots, logs, messages, unknown);
+    : buildNon3dLayout(images, maps, plots, logs, messages, unknown);
 
-  if (threeDRegion) {
+  if (topVisualRegion) {
     if (!supportingRegion) {
-      return threeDRegion;
+      return topVisualRegion;
     }
 
     return {
       direction: "column",
-      first: threeDRegion,
+      first: topVisualRegion,
       second: supportingRegion,
       splitPercentage: THREE_D_TOP_SPLIT_PERCENTAGE,
     };
@@ -377,14 +394,20 @@ export function buildMcapAutoLayout(
 
 function buildNon3dLayout(
   images: readonly string[],
+  maps: readonly string[],
   plots: readonly string[],
   logs: readonly string[],
   messages: readonly string[],
   unknown: readonly string[],
 ): MosaicNode<string> | null {
   const imageBank = autoLayout([...images]);
+  const mapBank = autoLayout([...maps]);
+  const visualBank = stackNodes([imageBank, mapBank], {
+    direction: "row",
+    splitPercentage: CONTEXT_SHELF_IMAGE_SPLIT_PERCENTAGE,
+  });
   const diagnostics = buildDiagnosticsStack(plots, logs, unknown);
-  const left = stackNodes([imageBank, diagnostics], {
+  const left = stackNodes([visualBank, diagnostics], {
     direction: "column",
     splitPercentage: VISUAL_WITH_PLOTS_SPLIT_PERCENTAGE,
   });
@@ -403,6 +426,16 @@ function buildNon3dLayout(
     second: messageRail,
     splitPercentage: MESSAGE_RAIL_SPLIT_PERCENTAGE,
   };
+}
+
+function buildTopVisualRegion(
+  threeD: readonly string[],
+  maps: readonly string[],
+): MosaicNode<string> | null {
+  return stackNodes([autoLayout([...threeD]), autoLayout([...maps])], {
+    direction: "row",
+    splitPercentage: THREE_D_WITH_MAP_SPLIT_PERCENTAGE,
+  });
 }
 
 function buildContextShelf(

--- a/app/packages/multimodal/src/adapters/mcap/react/use-mcap-modal-layout.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-mcap-modal-layout.test.tsx
@@ -22,6 +22,7 @@ vi.mock("./McapImageTile", () => ({
   ),
 }));
 vi.mock("./Mcap3dTile", () => ({ default: () => null }));
+vi.mock("./McapMapTile", () => ({ default: () => null }));
 
 const SCENE_SOURCES: readonly SceneSource[] = [
   { id: "/cam/image_rect_compressed", type: "image", label: "cam" },

--- a/app/packages/multimodal/src/adapters/mcap/react/use-mcap-modal-layout.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-mcap-modal-layout.tsx
@@ -21,6 +21,11 @@ import {
   type McapPersistedModalLayout,
 } from "./mcap-layout-persistence";
 import {
+  DEFAULT_MCAP_MAP_TILE_SETTINGS,
+  mcapMapTileSettingsAtom,
+  type McapMapTileSettings,
+} from "./mcap-map-tile-state";
+import {
   mcapPlotTileSeriesAtom,
   type McapPlotSeriesConfig,
 } from "./mcap-plot-tile-state";
@@ -379,6 +384,38 @@ export function McapModalLayoutPersistence({
     store,
   });
 
+  const seededMapKeyRef = useRef<string | null>(null);
+  useEffect(() => {
+    const persisted = readMcapModalLayout(datasetIdRef.current)?.mapSettings;
+    if (persisted) {
+      store.set(mcapMapTileSettingsAtom, (previous) => {
+        const next = { ...previous };
+        for (const [tileId, settings] of Object.entries(persisted)) {
+          if (!(tileId in tilesRef.current) || next[tileId]) continue;
+          next[tileId] = settings;
+        }
+        return next;
+      });
+    }
+    seededMapKeyRef.current = JSON.stringify(
+      store.get(mcapMapTileSettingsAtom),
+    );
+  }, [store]);
+
+  const mapSettingsPatch = useCallback(
+    (value: Readonly<Record<string, McapMapTileSettings>>) => ({
+      mapSettings: compactMapSettings(value),
+    }),
+    [],
+  );
+  useDebouncedMcapLayoutAtomMirror({
+    atom: mcapMapTileSettingsAtom,
+    datasetIdRef,
+    patchForValue: mapSettingsPatch,
+    seededKeyRef: seededMapKeyRef,
+    store,
+  });
+
   // Write only after the layout actually changes from what this mount
   // started with. Restores can be PRUNED views of the saved arrangement
   // (e.g. an image-only sample drops the 3D leaf); persisting one without
@@ -495,6 +532,31 @@ function compactPlotSeries(
     }
   }
   return compact;
+}
+
+function compactMapSettings(
+  value: Readonly<Record<string, McapMapTileSettings>>,
+): Record<string, McapMapTileSettings> | undefined {
+  const compact: Record<string, McapMapTileSettings> = {};
+  for (const [tileId, settings] of Object.entries(value)) {
+    const baseLayer =
+      settings.baseLayer ?? DEFAULT_MCAP_MAP_TILE_SETTINGS.baseLayer;
+    const isDefault =
+      baseLayer === DEFAULT_MCAP_MAP_TILE_SETTINGS.baseLayer &&
+      settings.followEgo === DEFAULT_MCAP_MAP_TILE_SETTINGS.followEgo &&
+      settings.enabledTopics === undefined;
+    if (isDefault) {
+      continue;
+    }
+    compact[tileId] = {
+      baseLayer,
+      followEgo: settings.followEgo,
+      ...(settings.enabledTopics !== undefined
+        ? { enabledTopics: settings.enabledTopics }
+        : {}),
+    };
+  }
+  return Object.keys(compact).length > 0 ? compact : undefined;
 }
 
 /**

--- a/app/packages/multimodal/src/adapters/mcap/react/use-mcap-modal-layout.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-mcap-modal-layout.tsx
@@ -1,5 +1,5 @@
 import { collectTileIds, useTiling, type TilingTile } from "@fiftyone/tiling";
-import { useStore, type Atom } from "jotai";
+import { useStore, type Atom, type PrimitiveAtom } from "jotai";
 import React, {
   useCallback,
   useEffect,
@@ -321,42 +321,24 @@ export function McapModalLayoutPersistence({
   const tilesRef = useRef(tiles);
   tilesRef.current = tiles;
 
-  // This effect seeds the plot-series atom once per mount from the
-  // persisted dataset entry — persistence is an external system.
-  useEffect(() => {
-    const persisted = readMcapModalLayout(datasetIdRef.current)?.plotSeries;
-    if (persisted) {
-      store.set(mcapPlotTileSeriesAtom, (previous) => {
-        const next = { ...previous };
-        for (const [tileId, series] of Object.entries(persisted)) {
-          if (!(tileId in tilesRef.current) || next[tileId]) continue;
-          next[tileId] = series;
-        }
-        return next;
-      });
-    }
-    seededPlotKeyRef.current = JSON.stringify(
-      store.get(mcapPlotTileSeriesAtom),
-    );
-  }, [store]);
+  useSeedPersistedTileAtom({
+    atom: mcapPlotTileSeriesAtom,
+    datasetIdRef,
+    field: "plotSeries",
+    seededKeyRef: seededPlotKeyRef,
+    store,
+    tilesRef,
+  });
 
-  // This effect seeds the raw-tile topic atom once per mount from the
-  // persisted dataset entry — same contract as the plot series above.
   const seededRawKeyRef = useRef<string | null>(null);
-  useEffect(() => {
-    const persisted = readMcapModalLayout(datasetIdRef.current)?.rawTopics;
-    if (persisted) {
-      store.set(mcapRawTileTopicAtom, (previous) => {
-        const next = { ...previous };
-        for (const [tileId, topic] of Object.entries(persisted)) {
-          if (!(tileId in tilesRef.current) || next[tileId]) continue;
-          next[tileId] = topic;
-        }
-        return next;
-      });
-    }
-    seededRawKeyRef.current = JSON.stringify(store.get(mcapRawTileTopicAtom));
-  }, [store]);
+  useSeedPersistedTileAtom({
+    atom: mcapRawTileTopicAtom,
+    datasetIdRef,
+    field: "rawTopics",
+    seededKeyRef: seededRawKeyRef,
+    store,
+    tilesRef,
+  });
 
   const plotSeriesPatch = useCallback(
     (value: Readonly<Record<string, readonly McapPlotSeriesConfig[]>>) => ({
@@ -385,22 +367,14 @@ export function McapModalLayoutPersistence({
   });
 
   const seededMapKeyRef = useRef<string | null>(null);
-  useEffect(() => {
-    const persisted = readMcapModalLayout(datasetIdRef.current)?.mapSettings;
-    if (persisted) {
-      store.set(mcapMapTileSettingsAtom, (previous) => {
-        const next = { ...previous };
-        for (const [tileId, settings] of Object.entries(persisted)) {
-          if (!(tileId in tilesRef.current) || next[tileId]) continue;
-          next[tileId] = settings;
-        }
-        return next;
-      });
-    }
-    seededMapKeyRef.current = JSON.stringify(
-      store.get(mcapMapTileSettingsAtom),
-    );
-  }, [store]);
+  useSeedPersistedTileAtom({
+    atom: mcapMapTileSettingsAtom,
+    datasetIdRef,
+    field: "mapSettings",
+    seededKeyRef: seededMapKeyRef,
+    store,
+    tilesRef,
+  });
 
   const mapSettingsPatch = useCallback(
     (value: Readonly<Record<string, McapMapTileSettings>>) => ({
@@ -557,6 +531,49 @@ function compactMapSettings(
     };
   }
   return Object.keys(compact).length > 0 ? compact : undefined;
+}
+
+type PersistedTileAtomField = "mapSettings" | "plotSeries" | "rawTopics";
+
+/**
+ * Seeds tile-scoped atoms from the dataset entry once per modal mount.
+ * Persistence is external state, so the effect intentionally owns the
+ * read/seed boundary while callers provide the field-specific atom.
+ */
+function useSeedPersistedTileAtom<TileValue>({
+  atom,
+  datasetIdRef,
+  field,
+  seededKeyRef,
+  store,
+  tilesRef,
+}: {
+  readonly atom: PrimitiveAtom<Readonly<Record<string, TileValue>>>;
+  readonly datasetIdRef: React.MutableRefObject<string | undefined>;
+  readonly field: PersistedTileAtomField;
+  readonly seededKeyRef: React.MutableRefObject<string | null>;
+  readonly store: ReturnType<typeof useStore>;
+  readonly tilesRef: React.MutableRefObject<Record<string, TilingTile>>;
+}) {
+  useEffect(() => {
+    const persisted = readMcapModalLayout(datasetIdRef.current)?.[field] as
+      | Readonly<Record<string, TileValue>>
+      | undefined;
+    if (persisted) {
+      store.set(atom, (previous) => {
+        const next = { ...previous };
+        for (const [tileId, value] of Object.entries(persisted) as [
+          string,
+          TileValue,
+        ][]) {
+          if (!(tileId in tilesRef.current) || next[tileId]) continue;
+          next[tileId] = value;
+        }
+        return next;
+      });
+    }
+    seededKeyRef.current = JSON.stringify(store.get(atom));
+  }, [atom, datasetIdRef, field, seededKeyRef, store, tilesRef]);
 }
 
 /**

--- a/app/packages/multimodal/src/adapters/mcap/react/use-mcap-tiles.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-mcap-tiles.ts
@@ -5,6 +5,7 @@ import { MCAP_SOURCE_TYPE } from "../scene-sources";
 import Mcap3dTile from "./Mcap3dTile";
 import McapImageTile from "./McapImageTile";
 import McapLogConsoleTile from "./McapLogConsoleTile";
+import McapMapTile from "./McapMapTile";
 import McapPlotTile from "./McapPlotTile";
 import McapRawMessageTile from "./McapRawMessageTile";
 import {
@@ -43,6 +44,12 @@ const TILE_BY_TYPE: Record<
     icon: IconName.Logs,
     Tile: McapLogConsoleTile,
     sourceTypes: [MCAP_SOURCE_TYPE.LOG],
+  },
+  [MCAP_TILE_TYPE.MAP]: {
+    typeLabel: "Map",
+    icon: IconName.Polyline,
+    Tile: McapMapTile,
+    sourceTypes: [MCAP_SOURCE_TYPE.LOCATION],
   },
   [MCAP_TILE_TYPE.THREE_D]: {
     typeLabel: "3D",

--- a/app/packages/multimodal/src/adapters/mcap/react/wgs84.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/wgs84.ts
@@ -1,0 +1,55 @@
+/**
+ * Minimal WGS84 spherical math shared by the map tile's route and
+ * measurement features.
+ */
+
+export interface GeoPoint {
+  readonly latitude: number;
+  readonly longitude: number;
+}
+
+const MEAN_EARTH_RADIUS_M = 6_371_008.8;
+
+export function degreesToRadians(degrees: number): number {
+  return degrees * (Math.PI / 180);
+}
+
+export function radiansToDegrees(radians: number): number {
+  return radians * (180 / Math.PI);
+}
+
+/**
+ * Initial great-circle bearing from `from` to `to`, in degrees clockwise
+ * from north, or `undefined` for coincident points.
+ */
+export function bearingDegrees(
+  from: GeoPoint,
+  to: GeoPoint,
+): number | undefined {
+  if (from.latitude === to.latitude && from.longitude === to.longitude) {
+    return undefined;
+  }
+  const lat1 = degreesToRadians(from.latitude);
+  const lat2 = degreesToRadians(to.latitude);
+  const deltaLon = degreesToRadians(to.longitude - from.longitude);
+  const y = Math.sin(deltaLon) * Math.cos(lat2);
+  const x =
+    Math.cos(lat1) * Math.sin(lat2) -
+    Math.sin(lat1) * Math.cos(lat2) * Math.cos(deltaLon);
+  return (radiansToDegrees(Math.atan2(y, x)) + 360) % 360;
+}
+
+/** Great-circle (haversine) distance in meters on the mean-radius sphere. */
+export function haversineDistanceMeters(a: GeoPoint, b: GeoPoint): number {
+  const latA = degreesToRadians(a.latitude);
+  const latB = degreesToRadians(b.latitude);
+  const deltaLat = degreesToRadians(b.latitude - a.latitude);
+  const deltaLon = degreesToRadians(b.longitude - a.longitude);
+  const sinHalfLat = Math.sin(deltaLat / 2);
+  const sinHalfLon = Math.sin(deltaLon / 2);
+  const h =
+    sinHalfLat * sinHalfLat +
+    Math.cos(latA) * Math.cos(latB) * sinHalfLon * sinHalfLon;
+
+  return 2 * MEAN_EARTH_RADIUS_M * Math.atan2(Math.sqrt(h), Math.sqrt(1 - h));
+}

--- a/app/packages/multimodal/src/components/MeasureRulerIcon.tsx
+++ b/app/packages/multimodal/src/components/MeasureRulerIcon.tsx
@@ -1,0 +1,25 @@
+/**
+ * Diagonal ruler glyph shared by the point-cloud and map measure toggles —
+ * voodo's IconName has no ruler. Decorative: host buttons carry the
+ * accessible label.
+ */
+export default function MeasureRulerIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      fill="none"
+      height="13"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      viewBox="0 0 24 24"
+      width="13"
+    >
+      <path d="M3 17 17 3l4 4L7 21z" />
+      <path d="m8 12 2 2" />
+      <path d="m11 9 2 2" />
+      <path d="m14 6 2 2" />
+    </svg>
+  );
+}

--- a/app/packages/multimodal/src/decoders/types.ts
+++ b/app/packages/multimodal/src/decoders/types.ts
@@ -203,6 +203,10 @@ export interface LocationVisualization {
    * Per-message source coordinate frame of the reporting sensor.
    */
   readonly coordinateFrameId?: string;
+  /** ROS NavSatStatus.status when present; -1 means no fix. */
+  readonly fixStatus?: number;
+  /** ROS NavSatStatus.service bitmask when present. */
+  readonly fixService?: number;
   readonly latitude: number;
   readonly longitude: number;
   readonly altitude?: number;

--- a/app/packages/multimodal/src/visualization/panels/point-cloud/PointCloudPanel.tsx
+++ b/app/packages/multimodal/src/visualization/panels/point-cloud/PointCloudPanel.tsx
@@ -1,6 +1,7 @@
 import { Icon, IconName, Size } from "@voxel51/voodo";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
+import MeasureRulerIcon from "../../../components/MeasureRulerIcon";
 import { Base3DScene } from "../base-3d-scene";
 import { WebGpuCanvas } from "../webgpu-canvas";
 import {
@@ -435,27 +436,6 @@ function ColorRampLegend({
         </div>
       ))}
     </div>
-  );
-}
-
-/** Diagonal ruler glyph for the measure toggle — IconName has none. */
-function MeasureRulerIcon() {
-  return (
-    <svg
-      width="13"
-      height="13"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M3 17 17 3l4 4L7 21z" />
-      <path d="m8 12 2 2" />
-      <path d="m11 9 2 2" />
-      <path d="m14 6 2 2" />
-    </svg>
   );
 }
 

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -3221,6 +3221,7 @@ __metadata:
     date-fns: "npm:^4.1.0"
     jotai: "npm:^2.9.3"
     lru-cache: "npm:^11.0.1"
+    maplibre-gl: "npm:^4.7.1"
     meshoptimizer: "npm:^0.22.0"
     protobufjs: "npm:^7.6.4"
     three: "patch:three@npm%3A0.185.1#~/.yarn/patches/three-npm-0.185.1-e07195d8b4.patch"


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

Prev: https://github.com/voxel51/fiftyone/pull/7964

Adds a geographic MCAP map tile for location topics. The tile bulk-loads normalized GPS tracks, renders them with MapLibre and OpenFreeMap by default, syncs hover/click/follow with playback, supports zoom/recenter/ruler controls, and persists map tile settings.

## 🧪 How is this patch tested? If it is not, please explain why.

- Unit tests

Manual verification: open an MCAP with `NavSatFix` or `LocationFix` topics, add the Map tile, and check the OpenFreeMap basemap, no-basemap fallback, track seek/hover/follow behavior, zoom controls, recenter, and ruler.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Adds a geographic Map tile to the MCAP viewer for GPS/location topics, including OpenFreeMap basemap support, playback sync, zoom/recenter controls, and a ruler.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
