### PR TITLE
Don't show copy buttons on code-block:: text output

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -159,6 +159,12 @@ nbsphinx_prolog = """
     ref,
 )
 
+# Don't add copy buttons to ``.. code-block:: text`` blocks, which we use
+# to show the output of code snippets rather than copyable code. Sphinx
+# wraps these blocks in a ``div.highlight-text`` parent, which we exclude
+# from the default ``div.highlight pre`` selector
+copybutton_selector = ":not(.highlight-text) > div.highlight pre"
+
 # Path to the redirects file, relative to `source/`
 redirects_file = "redirects"
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Closes #345.

The docs use `.. code-block:: text` to display the **output** of code snippets, which shouldn't be copyable — the copy button is only meaningful for actual code.

This configures `sphinx-copybutton`'s [`copybutton_selector`](https://sphinx-copybutton.readthedocs.io/en/latest/use.html#modify-the-copy-button-s-css-selector) to exclude those blocks. Sphinx wraps a `.. code-block:: text` directive in a `div.highlight-text` parent, so the selector excludes that wrapper from the default `div.highlight pre`:

```python
copybutton_selector = ":not(.highlight-text) > div.highlight pre"
```

## How is this patch tested?

Verified against a minimal Sphinx build with `sphinx-copybutton==0.5.2` (the pinned version) using a CSS selector engine with browser-equivalent `querySelectorAll` semantics:

- `.. code-block:: text` → **no** copy button (the fix)
- `python`, `shell`, `none`, no-language `code::`, and `:linenos:` / `:caption:` blocks → copy button **retained** (no regression)

## Release notes

Copy buttons no longer appear on `.. code-block:: text` output blocks in the documentation.