### PR TITLE
Bump develop to 1.20.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ Installs FiftyOne.
 import os
 from setuptools import setup, find_packages
 
-VERSION = "1.19.0"
+VERSION = "1.20.0"
 
 
 def get_version():


### PR DESCRIPTION
Advances develop's dev version now that release/v1.19.0 has been cut for the OSS 1.19.0 / Enterprise 2.22.0 release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package to version 1.20.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3245
<!-- enterprise-sync-pr:end -->