### PR TITLE
Split `Tag` superclass of `TemporalTag`

### DIFF
--- a/fiftyone/core/tags.py
+++ b/fiftyone/core/tags.py
@@ -38,6 +38,7 @@ foms = fou.lazy_import("fiftyone.multimodal.schemas.v1")
 
 __all__ = [
     "TAGS_EXPORT_FILENAME",
+    "TAGS_COLLECTION_NAME",
     "TemporalTagNotFoundError",
     "clone_tags",
     "count_for_dataset_id",
@@ -48,6 +49,15 @@ __all__ = [
     "export_tags",
     "get_orphan_dataset_ids",
     "import_tags",
+    "TagKind",
+    "TemporalTag",
+    "TemporalTagFilter",
+    "TemporalTags",
+    "add_temporal_tags",
+    "count_temporal_tags",
+    "delete_temporal_tags",
+    "list_temporal_tags",
+    "update_temporal_tag",
 ]
 
 TAGS_COLLECTION_NAME = "tags"
@@ -1622,18 +1632,3 @@ def _ensure_indexes(collection) -> None:
         ],
         name="temporal_tag_counts",
     )
-
-
-__all__ = [
-    "TAGS_EXPORT_FILENAME",
-    "TAGS_COLLECTION_NAME",
-    "TagKind",
-    "TemporalTag",
-    "TemporalTagFilter",
-    "TemporalTags",
-    "add_temporal_tags",
-    "count_temporal_tags",
-    "delete_temporal_tags",
-    "list_temporal_tags",
-    "update_temporal_tag",
-]

--- a/fiftyone/core/tags.py
+++ b/fiftyone/core/tags.py
@@ -1215,7 +1215,7 @@ def _from_storage_doc(doc) -> TemporalTag:
             last_modified_at=doc.get("last_modified_at", None),
         )
     raise ValueError(
-        "Expected a temporal tag document, but found kind=%s" % kind
+        "Expected a temporal tag document, but found kind=%s" % kind.value
     )
 
 
@@ -1270,7 +1270,7 @@ def _from_export_doc(doc) -> TemporalTag:
             last_modified_at=doc.get("last_modified_at", None),
         )
     raise ValueError(
-        "Expected a temporal tag document, but found kind=%s" % kind
+        "Expected a temporal tag document, but found kind=%s" % kind.value
     )
 
 

--- a/fiftyone/core/tags.py
+++ b/fiftyone/core/tags.py
@@ -354,7 +354,10 @@ class TemporalTags(object):
             return 0
 
         query = _build_query(
-            self._dataset._doc.id, None, sample_ids=self._sample_ids
+            self._dataset._doc.id,
+            None,
+            sample_ids=self._sample_ids,
+            kind=TagKind.TEMPORAL,
         )
         return collection.count_documents(query)
 
@@ -426,7 +429,10 @@ class TemporalTags(object):
             an iterator over :class:`TemporalTag` instances
         """
         query = _build_query(
-            self._dataset._doc.id, filter, sample_ids=self._sample_ids
+            self._dataset._doc.id,
+            filter,
+            sample_ids=self._sample_ids,
+            kind=TagKind.TEMPORAL,
         )
         collection = _get_existing_collection()
         if collection is None:
@@ -620,7 +626,10 @@ class TemporalTags(object):
             the number of deleted temporal tags
         """
         query = _build_query(
-            self._dataset._doc.id, filter, sample_ids=self._sample_ids
+            self._dataset._doc.id,
+            filter,
+            sample_ids=self._sample_ids,
+            kind=TagKind.TEMPORAL,
         )
         has_selector = filter is not None and not _is_empty_filter(filter)
 
@@ -683,6 +692,7 @@ class TemporalTags(object):
                 self._dataset._doc.id,
                 filter,
                 sample_ids=self._sample_ids,
+                kind=TagKind.TEMPORAL,
             )
         }
         if by_sample:
@@ -850,9 +860,7 @@ def delete_for_dataset_id(dataset_id) -> int:
     if collection is None:
         return 0
 
-    return collection.delete_many(
-        {"_dataset_id": dataset_id, "kind": TagKind.TEMPORAL.value}
-    ).deleted_count
+    return collection.delete_many({"_dataset_id": dataset_id}).deleted_count
 
 
 def delete_for_sample_ids(dataset_id, sample_ids) -> int:
@@ -874,7 +882,6 @@ def delete_for_sample_ids(dataset_id, sample_ids) -> int:
         num_deleted += collection.delete_many(
             {
                 "_dataset_id": dataset_id,
-                "kind": TagKind.TEMPORAL.value,
                 "_sample_id": {"$in": sample_oids},
             }
         ).deleted_count
@@ -887,9 +894,7 @@ def count_for_dataset_id(dataset_id) -> int:
     if collection is None:
         return 0
 
-    return collection.count_documents(
-        {"_dataset_id": dataset_id, "kind": TagKind.TEMPORAL.value}
-    )
+    return collection.count_documents({"_dataset_id": dataset_id})
 
 
 def get_orphan_dataset_ids(dataset_ids) -> list:
@@ -919,7 +924,6 @@ def count_for_dataset_ids(dataset_ids) -> int:
     return collection.count_documents(
         {
             "_dataset_id": _build_in_query(dataset_ids),
-            "kind": TagKind.TEMPORAL.value,
         }
     )
 
@@ -936,7 +940,6 @@ def delete_for_dataset_ids(dataset_ids) -> int:
     return collection.delete_many(
         {
             "_dataset_id": _build_in_query(dataset_ids),
-            "kind": TagKind.TEMPORAL.value,
         }
     ).deleted_count
 
@@ -1272,9 +1275,11 @@ def _from_export_doc(doc) -> TemporalTag:
 
 
 def _build_query(
-    dataset_id, filter: TemporalTagFilter | None, sample_ids=None
+    dataset_id, filter: TemporalTagFilter | None, sample_ids=None, kind=None
 ):
-    query = {"_dataset_id": dataset_id, "kind": TagKind.TEMPORAL.value}
+    query = {"_dataset_id": dataset_id}
+    if kind is not None:
+        query["kind"] = kind.value
 
     if sample_ids is not None:
         query["_sample_id"] = _build_in_query(list(sample_ids))

--- a/fiftyone/core/tags.py
+++ b/fiftyone/core/tags.py
@@ -1586,8 +1586,8 @@ def _ensure_kind(kind):
         try:
             return TagKind(kind)
         except ValueError as e:
-            raise ValueError("Invalid temporal tag kind: %r" % kind) from e
-    raise ValueError("Invalid temporal tag kind: %r" % kind)
+            raise ValueError("Invalid tag kind: %r" % kind) from e
+    raise ValueError("Invalid tag kind: %r" % kind)
 
 
 __all__ = [

--- a/fiftyone/core/tags.py
+++ b/fiftyone/core/tags.py
@@ -69,6 +69,19 @@ class TagKind(str, enum.Enum):
     TEMPORAL = "temporal"
 
 
+def _ensure_kind(kind):
+    if kind is None:
+        raise ValueError("Tag kind must be specified")
+    elif isinstance(kind, TagKind):
+        return kind
+    elif isinstance(kind, str):
+        try:
+            return TagKind(kind)
+        except ValueError as e:
+            raise ValueError("Invalid tag kind: %r" % kind) from e
+    raise ValueError("Invalid tag kind: %r" % kind)
+
+
 class Tag(object):
     """A tag.
 
@@ -1609,19 +1622,6 @@ def _ensure_indexes(collection) -> None:
         ],
         name="temporal_tag_counts",
     )
-
-
-def _ensure_kind(kind):
-    if kind is None:
-        return TagKind.TEMPORAL
-    elif isinstance(kind, TagKind):
-        return kind
-    elif isinstance(kind, str):
-        try:
-            return TagKind(kind)
-        except ValueError as e:
-            raise ValueError("Invalid tag kind: %r" % kind) from e
-    raise ValueError("Invalid tag kind: %r" % kind)
 
 
 __all__ = [

--- a/fiftyone/core/tags.py
+++ b/fiftyone/core/tags.py
@@ -70,7 +70,17 @@ class TagKind(str, enum.Enum):
 
 
 class Tag(object):
-    """Base class for tags."""
+    """A tag.
+
+    Args:
+        sample_id: the sample ID this tag applies to
+        tag: the tag value
+        created_by (None): an optional actor that created the tag
+        last_modified_by (None): an optional actor that last modified the tag
+        created_at (None): the creation timestamp, when available
+        last_modified_at (None): the last-modified timestamp, when available
+        id: the persisted tag ID, when available
+    """
 
     def __init__(
         self,

--- a/fiftyone/core/tags.py
+++ b/fiftyone/core/tags.py
@@ -69,7 +69,34 @@ class TagKind(str, enum.Enum):
     TEMPORAL = "temporal"
 
 
-class TemporalTag(object):
+class Tag(object):
+    """Base class for tags."""
+
+    def __init__(
+        self,
+        *,
+        created_at=None,
+        created_by=None,
+        id=None,
+        kind=None,
+        last_modified_at=None,
+        last_modified_by=None,
+        sample_id=None,
+        tag=None,
+    ):
+        self.created_at = _coerce_optional_datetime(created_at, "created_at")
+        self.created_by = created_by
+        self.id = id
+        self.kind = _ensure_kind(kind)
+        self.last_modified_at = _coerce_optional_datetime(
+            last_modified_at, "last_modified_at"
+        )
+        self.last_modified_by = last_modified_by
+        self.sample_id = sample_id
+        self.tag = tag
+
+
+class TemporalTag(Tag):
     """A temporal tag interval on one multimodal sample.
 
     Args:
@@ -102,26 +129,25 @@ class TemporalTag(object):
         created_at=None,
         last_modified_at=None,
         id=None,
-        kind=TagKind.TEMPORAL,
     ):
-        self.sample_id = sample_id
+        super().__init__(
+            created_at=created_at,
+            created_by=created_by,
+            id=id,
+            kind=TagKind.TEMPORAL,
+            last_modified_at=last_modified_at,
+            last_modified_by=last_modified_by,
+            sample_id=sample_id,
+            tag=tag,
+        )
         self.start = start
         self.end = end
-        self.tag = tag
         self.index_type = (
             index_type
             if index_type is not None
             else foms.TimeTrackType.TIME_TRACK_TYPE_DURATION_NS
         )
         self.anchor = anchor
-        self.created_by = created_by
-        self.last_modified_by = last_modified_by
-        self.created_at = _coerce_optional_datetime(created_at, "created_at")
-        self.last_modified_at = _coerce_optional_datetime(
-            last_modified_at, "last_modified_at"
-        )
-        self.id = id
-        self.kind = _ensure_kind(kind)
 
     def __repr__(self):
         return (
@@ -164,7 +190,6 @@ class TemporalTag(object):
             created_at=self.created_at,
             last_modified_at=self.last_modified_at,
             id=self.id,
-            kind=self.kind,
         )
 
     def to_dict(self):
@@ -1114,19 +1139,23 @@ def _build_update_fields(
 
 
 def _from_storage_doc(doc) -> TemporalTag:
-    return TemporalTag(
-        id=str(doc["_id"]),
-        kind=TagKind(doc.get("kind", TagKind.TEMPORAL)),
-        sample_id=str(doc["_sample_id"]),
-        index_type=doc["index_type"],
-        anchor=doc.get("anchor", None),
-        start=doc["start"],
-        end=doc["end"],
-        tag=doc["tag"],
-        created_by=doc.get("created_by", None),
-        last_modified_by=doc.get("last_modified_by", None),
-        created_at=doc.get("created_at", None),
-        last_modified_at=doc.get("last_modified_at", None),
+    kind = TagKind(doc.get("kind", TagKind.TEMPORAL))
+    if kind == TagKind.TEMPORAL:
+        return TemporalTag(
+            id=str(doc["_id"]),
+            sample_id=str(doc["_sample_id"]),
+            index_type=doc["index_type"],
+            anchor=doc.get("anchor", None),
+            start=doc["start"],
+            end=doc["end"],
+            tag=doc["tag"],
+            created_by=doc.get("created_by", None),
+            last_modified_by=doc.get("last_modified_by", None),
+            created_at=doc.get("created_at", None),
+            last_modified_at=doc.get("last_modified_at", None),
+        )
+    raise ValueError(
+        "Expected a temporal tag document, but found kind=%s" % kind
     )
 
 
@@ -1166,18 +1195,22 @@ def _to_export_doc(doc):
 
 def _from_export_doc(doc) -> TemporalTag:
     kind = doc.get("kind", None)
-    return TemporalTag(
-        sample_id=doc.get("sample_id", None),
-        index_type=doc.get("index_type", None),
-        start=doc.get("start", None),
-        end=doc.get("end", None),
-        tag=doc.get("tag", None),
-        anchor=doc.get("anchor", None),
-        kind=TagKind.TEMPORAL if kind is None else TagKind(kind),
-        created_by=doc.get("created_by", None),
-        last_modified_by=doc.get("last_modified_by", None),
-        created_at=doc.get("created_at", None),
-        last_modified_at=doc.get("last_modified_at", None),
+    tag_kind = TagKind.TEMPORAL if kind is None else TagKind(kind)
+    if tag_kind == TagKind.TEMPORAL:
+        return TemporalTag(
+            sample_id=doc.get("sample_id", None),
+            index_type=doc.get("index_type", None),
+            start=doc.get("start", None),
+            end=doc.get("end", None),
+            tag=doc.get("tag", None),
+            anchor=doc.get("anchor", None),
+            created_by=doc.get("created_by", None),
+            last_modified_by=doc.get("last_modified_by", None),
+            created_at=doc.get("created_at", None),
+            last_modified_at=doc.get("last_modified_at", None),
+        )
+    raise ValueError(
+        "Expected a temporal tag document, but found kind=%s" % kind
     )
 
 

--- a/fiftyone/core/tags.py
+++ b/fiftyone/core/tags.py
@@ -105,6 +105,59 @@ class Tag(object):
         self.sample_id = sample_id
         self.tag = tag
 
+    def __repr__(self):
+        return (
+            "%s(sample_id=%r, tag=%r, created_by=%r, "
+            "last_modified_by=%r, created_at=%r, last_modified_at=%r, id=%r)"
+            % (
+                self.__class__.__name__,
+                self.sample_id,
+                self.tag,
+                self.created_by,
+                self.last_modified_by,
+                self.created_at,
+                self.last_modified_at,
+                self.id,
+            )
+        )
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
+
+        return self.to_dict() == other.to_dict()
+
+    def to_dict(self):
+        """Serializes the tag to a JSON dictionary."""
+        d = {
+            "sample_id": self.sample_id,
+            "tag": self.tag,
+        }
+
+        if self.created_by is not None:
+            d["created_by"] = self.created_by
+
+        if self.last_modified_by is not None:
+            d["last_modified_by"] = self.last_modified_by
+
+        if self.created_at is not None:
+            d["created_at"] = _serialize_datetime(
+                self.created_at, "created_at"
+            )
+
+        if self.last_modified_at is not None:
+            d["last_modified_at"] = _serialize_datetime(
+                self.last_modified_at, "last_modified_at"
+            )
+
+        if self.id is not None:
+            d["id"] = self.id
+
+        if self.kind is not None:
+            d["kind"] = self.kind
+
+        return d
+
 
 class TemporalTag(Tag):
     """A temporal tag interval on one multimodal sample.
@@ -180,12 +233,6 @@ class TemporalTag(Tag):
             )
         )
 
-    def __eq__(self, other):
-        if not isinstance(other, TemporalTag):
-            return False
-
-        return self.to_dict() == other.to_dict()
-
     def copy(self):
         """Returns a copy of this temporal tag."""
         return self.__class__(
@@ -204,37 +251,14 @@ class TemporalTag(Tag):
 
     def to_dict(self):
         """Serializes the temporal tag to a JSON dictionary."""
-        d = {
-            "sample_id": self.sample_id,
-            "index_type": self.index_type,
-            "start": self.start,
-            "end": self.end,
-            "tag": self.tag,
-        }
+        d = super().to_dict()
+        d.update(
+            index_type=self.index_type,
+            start=self.start,
+            end=self.end,
+        )
         if self.anchor is not None:
             d["anchor"] = self.anchor
-
-        if self.created_by is not None:
-            d["created_by"] = self.created_by
-
-        if self.last_modified_by is not None:
-            d["last_modified_by"] = self.last_modified_by
-
-        if self.created_at is not None:
-            d["created_at"] = _serialize_datetime(
-                self.created_at, "created_at"
-            )
-
-        if self.last_modified_at is not None:
-            d["last_modified_at"] = _serialize_datetime(
-                self.last_modified_at, "last_modified_at"
-            )
-
-        if self.id is not None:
-            d["id"] = self.id
-
-        if self.kind is not None:
-            d["kind"] = self.kind
 
         return d
 

--- a/fiftyone/core/tags.py
+++ b/fiftyone/core/tags.py
@@ -177,7 +177,7 @@ class Tag(object):
             d["id"] = self.id
 
         if self.kind is not None:
-            d["kind"] = self.kind
+            d["kind"] = self.kind.value
 
         return d
 

--- a/fiftyone/multimodal/server/routes.py
+++ b/fiftyone/multimodal/server/routes.py
@@ -228,7 +228,6 @@ def _temporal_tags_from_create_payload(
                 tag=record.get("tag", None),
                 index_type=record.get("index_type"),
                 anchor=record.get("anchor", None),
-                kind=record.get("kind", None),
                 created_by=record.get("created_by", None),
                 last_modified_by=record.get("last_modified_by", None),
             )

--- a/tests/unittests/import_export_tests.py
+++ b/tests/unittests/import_export_tests.py
@@ -375,7 +375,6 @@ class TagsImportExportTests(ImageDatasetTests):
                     "keep",
                     anchor="camera_front",
                     created_by="alice",
-                    kind=fota.TagKind.TEMPORAL,
                 ),
                 fota.TemporalTag(
                     sample_ids[1],
@@ -384,14 +383,12 @@ class TagsImportExportTests(ImageDatasetTests):
                     "drop",
                     anchor="lidar_top",
                     last_modified_by="carol",
-                    kind=fota.TagKind.TEMPORAL,
                 ),
                 fota.TemporalTag(
                     sample_ids[2],
                     20,
                     30,
                     "keep",
-                    kind=fota.TagKind.TEMPORAL,
                 ),
             ],
         )

--- a/tests/unittests/multimodal/temporal_tags_tests.py
+++ b/tests/unittests/multimodal/temporal_tags_tests.py
@@ -42,7 +42,6 @@ class TemporalTagTests(unittest.TestCase):
                 0,
                 1,
                 "review",
-                kind=fota.TagKind.TEMPORAL,
             ),
         )
 
@@ -84,35 +83,30 @@ class TemporalTagTests(unittest.TestCase):
                 0,
                 1,
                 "missing",
-                kind=fota.TagKind.TEMPORAL,
             ),
             fota.TemporalTag(
                 sample_id,
                 1,
                 1,
                 "same",
-                kind=fota.TagKind.TEMPORAL,
             ),
             fota.TemporalTag(
                 sample_id,
                 2,
                 1,
                 "backwards",
-                kind=fota.TagKind.TEMPORAL,
             ),
             fota.TemporalTag(
                 sample_id,
                 0.5,
                 1,
                 "fractional",
-                kind=fota.TagKind.TEMPORAL,
             ),
             fota.TemporalTag(
                 sample_id,
                 0,
                 1,
                 "",
-                kind=fota.TagKind.TEMPORAL,
             ),
             fota.TemporalTag(
                 sample_id,
@@ -120,7 +114,6 @@ class TemporalTagTests(unittest.TestCase):
                 1,
                 "empty-anchor",
                 anchor="",
-                kind=fota.TagKind.TEMPORAL,
             ),
             fota.TemporalTag(
                 sample_id,
@@ -128,7 +121,6 @@ class TemporalTagTests(unittest.TestCase):
                 1,
                 "blank-anchor",
                 anchor="   ",
-                kind=fota.TagKind.TEMPORAL,
             ),
             fota.TemporalTag(
                 sample_id,
@@ -136,7 +128,6 @@ class TemporalTagTests(unittest.TestCase):
                 1,
                 "bad-anchor",
                 anchor=3,
-                kind=fota.TagKind.TEMPORAL,
             ),
             fota.TemporalTag(
                 sample_id,
@@ -144,7 +135,6 @@ class TemporalTagTests(unittest.TestCase):
                 1,
                 "bool-anchor",
                 anchor=False,
-                kind=fota.TagKind.TEMPORAL,
             ),
             fota.TemporalTag(
                 sample_id,
@@ -152,7 +142,6 @@ class TemporalTagTests(unittest.TestCase):
                 1,
                 "empty-created-by",
                 created_by="",
-                kind=fota.TagKind.TEMPORAL,
             ),
             fota.TemporalTag(
                 sample_id,
@@ -160,7 +149,6 @@ class TemporalTagTests(unittest.TestCase):
                 1,
                 "blank-last-modified-by",
                 last_modified_by="   ",
-                kind=fota.TagKind.TEMPORAL,
             ),
             fota.TemporalTag(
                 sample_id,
@@ -168,7 +156,6 @@ class TemporalTagTests(unittest.TestCase):
                 1,
                 "bad-created-by",
                 created_by=3,
-                kind=fota.TagKind.TEMPORAL,
             ),
             fota.TemporalTag(
                 sample_id,
@@ -176,7 +163,6 @@ class TemporalTagTests(unittest.TestCase):
                 1,
                 "bool-last-modified-by",
                 last_modified_by=False,
-                kind=fota.TagKind.TEMPORAL,
             ),
             fota.TemporalTag(
                 sample_id,
@@ -184,7 +170,6 @@ class TemporalTagTests(unittest.TestCase):
                 1,
                 "unsupported",
                 index_type=foms.TimeTrackType.TIME_TRACK_TYPE_UNSPECIFIED,
-                kind=fota.TagKind.TEMPORAL,
             ),
         ]
 
@@ -212,7 +197,6 @@ class TemporalTagTests(unittest.TestCase):
                 10,
                 "review",
                 created_by="alice",
-                kind=fota.TagKind.TEMPORAL,
             ),
         )[0]
 
@@ -236,7 +220,6 @@ class TemporalTagTests(unittest.TestCase):
                 10,
                 "review",
                 created_by="bob",
-                kind=fota.TagKind.TEMPORAL,
             ),
         )[0]
 
@@ -257,7 +240,6 @@ class TemporalTagTests(unittest.TestCase):
                 10,
                 "review",
                 last_modified_by="carol",
-                kind=fota.TagKind.TEMPORAL,
             ),
         )[0]
 
@@ -278,7 +260,6 @@ class TemporalTagTests(unittest.TestCase):
                 "manual",
                 created_at="2026-01-01T00:00:00Z",
                 last_modified_at="2026-01-02T00:00:00+00:00",
-                kind=fota.TagKind.TEMPORAL,
             ),
         )[0]
 
@@ -304,7 +285,6 @@ class TemporalTagTests(unittest.TestCase):
                 0,
                 10,
                 "review",
-                kind=fota.TagKind.TEMPORAL,
             ),
         )[0]
         after_add_dataset, after_add_first = _modified_timestamps(
@@ -324,7 +304,6 @@ class TemporalTagTests(unittest.TestCase):
                 0,
                 10,
                 "review",
-                kind=fota.TagKind.TEMPORAL,
             ),
         )[0]
         after_repeat_dataset, after_repeat_first = _modified_timestamps(
@@ -370,14 +349,12 @@ class TemporalTagTests(unittest.TestCase):
                     20,
                     30,
                     "clear",
-                    kind=fota.TagKind.TEMPORAL,
                 ),
                 fota.TemporalTag(
                     second_id,
                     20,
                     30,
                     "clear",
-                    kind=fota.TagKind.TEMPORAL,
                 ),
             ],
         )
@@ -411,7 +388,6 @@ class TemporalTagTests(unittest.TestCase):
                 10,
                 "review",
                 created_by="alice",
-                kind=fota.TagKind.TEMPORAL,
             ),
         )[0]
         fota.add_temporal_tags(
@@ -421,7 +397,6 @@ class TemporalTagTests(unittest.TestCase):
                 0,
                 10,
                 "other",
-                kind=fota.TagKind.TEMPORAL,
             ),
         )
         before_dataset, before_first = _modified_timestamps(dataset, first_id)
@@ -481,7 +456,6 @@ class TemporalTagTests(unittest.TestCase):
                 0,
                 10,
                 "review",
-                kind=fota.TagKind.TEMPORAL,
             ),
         )[0]
         second = fota.add_temporal_tags(
@@ -491,7 +465,6 @@ class TemporalTagTests(unittest.TestCase):
                 20,
                 30,
                 "other",
-                kind=fota.TagKind.TEMPORAL,
             ),
         )[0]
 
@@ -533,7 +506,6 @@ class TemporalTagTests(unittest.TestCase):
             0,
             10,
             "review",
-            kind=fota.TagKind.TEMPORAL,
         )
 
         inserted = fota.add_temporal_tags(dataset, first)
@@ -550,14 +522,12 @@ class TemporalTagTests(unittest.TestCase):
                     5,
                     15,
                     "review",
-                    kind=fota.TagKind.TEMPORAL,
                 ),
                 fota.TemporalTag(
                     sample_ids[0],
                     0,
                     10,
                     "keep",
-                    kind=fota.TagKind.TEMPORAL,
                 ),
                 fota.TemporalTag(
                     sample_ids[1],
@@ -565,7 +535,6 @@ class TemporalTagTests(unittest.TestCase):
                     1,
                     "review",
                     index_type=foms.TimeTrackType.TIME_TRACK_TYPE_SEQUENCE,
-                    kind=fota.TagKind.TEMPORAL,
                 ),
             ],
         )
@@ -642,7 +611,6 @@ class TemporalTagTests(unittest.TestCase):
             0,
             10,
             "review",
-            kind=fota.TagKind.TEMPORAL,
         )
         camera = fota.TemporalTag(
             sample_id,
@@ -650,7 +618,6 @@ class TemporalTagTests(unittest.TestCase):
             10,
             "review",
             anchor="camera_front",
-            kind=fota.TagKind.TEMPORAL,
         )
         lidar = fota.TemporalTag(
             sample_id,
@@ -658,7 +625,6 @@ class TemporalTagTests(unittest.TestCase):
             10,
             "review",
             anchor="lidar_top",
-            kind=fota.TagKind.TEMPORAL,
         )
 
         inserted = fota.add_temporal_tags(dataset, [unanchored, camera, lidar])
@@ -715,7 +681,6 @@ class TemporalTagTests(unittest.TestCase):
                 10,
                 "review",
                 anchor="camera_front",
-                kind=fota.TagKind.TEMPORAL,
             ),
         )
 
@@ -754,21 +719,18 @@ class TemporalTagTests(unittest.TestCase):
                     0,
                     10,
                     "shared",
-                    kind=fota.TagKind.TEMPORAL,
                 ),
                 fota.TemporalTag(
                     sample_ids[1],
                     0,
                     10,
                     "shared",
-                    kind=fota.TagKind.TEMPORAL,
                 ),
                 fota.TemporalTag(
                     sample_ids[2],
                     0,
                     10,
                     "other",
-                    kind=fota.TagKind.TEMPORAL,
                 ),
             ],
         )
@@ -802,7 +764,6 @@ class TemporalTagTests(unittest.TestCase):
                 10,
                 20,
                 "view",
-                kind=fota.TagKind.TEMPORAL,
             ),
         )
         with self.assertRaises(ValueError):
@@ -813,7 +774,6 @@ class TemporalTagTests(unittest.TestCase):
                     10,
                     20,
                     "missing",
-                    kind=fota.TagKind.TEMPORAL,
                 ),
             )
 
@@ -873,14 +833,12 @@ class TemporalTagTests(unittest.TestCase):
                     0,
                     10,
                     "shared",
-                    kind=fota.TagKind.TEMPORAL,
                 ),
                 fota.TemporalTag(
                     sample_ids[1],
                     10,
                     20,
                     "shared",
-                    kind=fota.TagKind.TEMPORAL,
                 ),
             ]
         )
@@ -914,7 +872,6 @@ class TemporalTagTests(unittest.TestCase):
                     20,
                     30,
                     "outside",
-                    kind=fota.TagKind.TEMPORAL,
                 )
             )
 
@@ -934,7 +891,6 @@ class TemporalTagTests(unittest.TestCase):
                     10,
                     "review",
                     anchor="camera_front",
-                    kind=fota.TagKind.TEMPORAL,
                 ),
                 fota.TemporalTag(
                     sample_ids[1],
@@ -942,14 +898,12 @@ class TemporalTagTests(unittest.TestCase):
                     15,
                     "review",
                     anchor="lidar_top",
-                    kind=fota.TagKind.TEMPORAL,
                 ),
                 fota.TemporalTag(
                     sample_ids[2],
                     20,
                     30,
                     "other",
-                    kind=fota.TagKind.TEMPORAL,
                 ),
             ],
         )
@@ -1019,7 +973,6 @@ class TemporalTagTests(unittest.TestCase):
                 0,
                 1,
                 "patch",
-                kind=fota.TagKind.TEMPORAL,
             ),
         )
 
@@ -1039,7 +992,6 @@ class TemporalTagTests(unittest.TestCase):
                     10,
                     "first",
                     anchor="camera_front",
-                    kind=fota.TagKind.TEMPORAL,
                 ),
                 fota.TemporalTag(
                     sample_ids[1],
@@ -1047,14 +999,12 @@ class TemporalTagTests(unittest.TestCase):
                     20,
                     "second",
                     anchor="lidar_top",
-                    kind=fota.TagKind.TEMPORAL,
                 ),
                 fota.TemporalTag(
                     sample_ids[2],
                     20,
                     30,
                     "third",
-                    kind=fota.TagKind.TEMPORAL,
                 ),
             ],
         )
@@ -1086,7 +1036,6 @@ class TemporalTagTests(unittest.TestCase):
                     "first",
                     anchor="camera_front",
                     created_by="alice",
-                    kind=fota.TagKind.TEMPORAL,
                 ),
                 fota.TemporalTag(
                     sample_ids[1],
@@ -1094,7 +1043,6 @@ class TemporalTagTests(unittest.TestCase):
                     20,
                     "second",
                     last_modified_by="bob",
-                    kind=fota.TagKind.TEMPORAL,
                 ),
             ],
         )
@@ -1140,14 +1088,12 @@ class TemporalTagTests(unittest.TestCase):
                     10,
                     "first",
                     anchor="camera_front",
-                    kind=fota.TagKind.TEMPORAL,
                 ),
                 fota.TemporalTag(
                     sample_ids[1],
                     10,
                     20,
                     "second",
-                    kind=fota.TagKind.TEMPORAL,
                 ),
             ],
         )
@@ -1184,7 +1130,6 @@ class TemporalTagTests(unittest.TestCase):
                 10,
                 "orphan",
                 anchor="camera_front",
-                kind=fota.TagKind.TEMPORAL,
             ),
         )
         fota.add_temporal_tags(
@@ -1195,7 +1140,6 @@ class TemporalTagTests(unittest.TestCase):
                 10,
                 "active",
                 anchor="lidar_top",
-                kind=fota.TagKind.TEMPORAL,
             ),
         )
 

--- a/tests/unittests/multimodal/temporal_tags_view_tests.py
+++ b/tests/unittests/multimodal/temporal_tags_view_tests.py
@@ -105,13 +105,12 @@ def _make_tagged_dataset():
     dataset.add_samples(samples)
     ids = [str(sample.id) for sample in samples]
 
-    temporal = fota.TagKind.TEMPORAL
     fota.add_temporal_tags(
         dataset,
         [
-            fota.TemporalTag(ids[0], 0, 1, "review", kind=temporal),
-            fota.TemporalTag(ids[1], 0, 1, "keep", kind=temporal),
-            fota.TemporalTag(ids[2], 2, 3, "review", kind=temporal),
+            fota.TemporalTag(ids[0], 0, 1, "review"),
+            fota.TemporalTag(ids[1], 0, 1, "keep"),
+            fota.TemporalTag(ids[2], 2, 3, "review"),
         ],
     )
 

--- a/tests/unittests/server/routes/test_multimodal_temporal_tags.py
+++ b/tests/unittests/server/routes/test_multimodal_temporal_tags.py
@@ -222,22 +222,18 @@ class TestTagsRoute:
         fota.add_temporal_tags(
             dataset,
             [
-                fota.TemporalTag(
-                    sample_ids[0], 0, 10, "clip", kind=fota.TagKind.TEMPORAL
-                ),
+                fota.TemporalTag(sample_ids[0], 0, 10, "clip"),
                 fota.TemporalTag(
                     sample_ids[0],
                     30,
                     40,
                     "outside",
-                    kind=fota.TagKind.TEMPORAL,
                 ),
                 fota.TemporalTag(
                     sample_ids[1],
                     5,
                     15,
                     "other-sample",
-                    kind=fota.TagKind.TEMPORAL,
                 ),
             ],
         )
@@ -271,7 +267,6 @@ class TestTagsRoute:
                 10,
                 "review",
                 created_by="alice",
-                kind=fota.TagKind.TEMPORAL,
             ),
         )[0]
         before_patch = _modified_timestamps(dataset, sample_ids[0])
@@ -329,21 +324,18 @@ class TestTagsRoute:
                     0,
                     10,
                     "clip",
-                    kind=fota.TagKind.TEMPORAL,
                 ),
                 fota.TemporalTag(
                     sample_ids[1],
                     10,
                     20,
                     "clip",
-                    kind=fota.TagKind.TEMPORAL,
                 ),
                 fota.TemporalTag(
                     sample_ids[2],
                     30,
                     40,
                     "outside",
-                    kind=fota.TagKind.TEMPORAL,
                 ),
             ],
         )
@@ -390,28 +382,24 @@ class TestTagsRoute:
                     0,
                     10,
                     "candidate",
-                    kind=fota.TagKind.TEMPORAL,
                 ),
                 fota.TemporalTag(
                     sample_ids[1],
                     10,
                     20,
                     "candidate",
-                    kind=fota.TagKind.TEMPORAL,
                 ),
                 fota.TemporalTag(
                     sample_ids[2],
                     20,
                     30,
                     "review",
-                    kind=fota.TagKind.TEMPORAL,
                 ),
                 fota.TemporalTag(
                     sample_ids[2],
                     30,
                     40,
                     "other",
-                    kind=fota.TagKind.TEMPORAL,
                 ),
             ],
         )
@@ -507,21 +495,18 @@ class TestTagsRoute:
                     0,
                     10,
                     "first",
-                    kind=fota.TagKind.TEMPORAL,
                 ),
                 fota.TemporalTag(
                     sample_ids[0],
                     10,
                     20,
                     "second",
-                    kind=fota.TagKind.TEMPORAL,
                 ),
                 fota.TemporalTag(
                     sample_ids[1],
                     0,
                     10,
                     "other",
-                    kind=fota.TagKind.TEMPORAL,
                 ),
             ],
         )
@@ -557,7 +542,6 @@ class TestTagsRoute:
                 0,
                 10,
                 "review",
-                kind=fota.TagKind.TEMPORAL,
             ),
         )[0]
         cases = [
@@ -729,7 +713,6 @@ class TestTagsRoute:
                 0,
                 10,
                 "review",
-                kind=fota.TagKind.TEMPORAL,
             ),
         )[0]
 


### PR DESCRIPTION
## 🔗 Related Issues

[FOEPD-3956](https://voxel51.atlassian.net/browse/FOEPD-3956)

## 📋 What changes are proposed in this pull request?

- Splits a `Tag` superclass out of `TemporalTag`, moving generic tag attributes to it but leaving time-related attributes in `TemporalTag`
- Moves filtering on `kind` out of generic functions and uses a passed-in parameter

## 🧪 How is this patch tested? If it is not, please explain why.

Unit tests.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [x] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other

[FOEPD-3956]: https://voxel51.atlassian.net/browse/FOEPD-3956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public `Tag` base class with standardized provenance fields and unified serialization.
  * Temporal tags now inherit common behavior and internally fix to the temporal kind.
  * Exposed the tags collection name in the public API.
* **Bug Fixes**
  * Improved kind-dispatched storage/export deserialization with clearer errors for unsupported kinds.
  * Refined temporal tag CRUD/query handling, including removing redundant explicit kind filtering in related dataset/sample operations.
  * Updated multimodal temporal tag payload parsing to populate interval fields directly.
* **Tests**
  * Updated unit and route tests to construct temporal tags without explicitly passing the temporal kind.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3254
<!-- enterprise-sync-pr:end -->