### PR TITLE
[1.19] [HA] Add support for native video decoding

### DIFF
--- a/app/packages/video-annotation/package.json
+++ b/app/packages/video-annotation/package.json
@@ -20,10 +20,12 @@
         "@voxel51/voodo": "^0.0.37",
         "clsx": "^2.1.0",
         "jotai": "^2.9.3",
-        "lru-cache": "^11.0.1"
+        "lru-cache": "^11.0.1",
+        "mp4box": "^2.4.1"
     },
     "devDependencies": {
         "@eslint/compat": "^1.1.1",
+        "@types/dom-webcodecs": "^0.1.18",
         "eslint": "9.7.0",
         "eslint-plugin-react": "^7.35.0",
         "eslint-plugin-react-hooks": "rc",

--- a/app/packages/video-annotation/src/components/AnnotatePrerequisiteNotice.test.tsx
+++ b/app/packages/video-annotation/src/components/AnnotatePrerequisiteNotice.test.tsx
@@ -18,15 +18,6 @@ describe("AnnotatePrerequisiteNotice", () => {
     getByText(/frame count is unknown/);
     getByText("Compute metadata");
   });
-
-  it("renders the frames prompt", () => {
-    const { getByText } = render(
-      <AnnotatePrerequisiteNotice blocker="frames" />,
-    );
-
-    getByText("Frames not sampled");
-    getByText(/to_frames/);
-  });
 });
 
 describe("AnnotatePrerequisiteChecking", () => {

--- a/app/packages/video-annotation/src/components/AnnotatePrerequisiteNotice.tsx
+++ b/app/packages/video-annotation/src/components/AnnotatePrerequisiteNotice.tsx
@@ -37,26 +37,11 @@ const COPY: Record<
     title: "Computed metadata required",
     description: (
       <>
-        This video's frame count is unknown.{" "}
+        This video&apos;s frame count is unknown.{" "}
         <DocsLink href="https://docs.voxel51.com/enterprise/getting_started.html#compute-metadata">
           Compute metadata
         </DocsLink>{" "}
         to annotate it or switch to Explore to view the sample.
-      </>
-    ),
-  },
-  frames: {
-    icon: "image_search",
-    title: "Frames not sampled",
-    description: (
-      <>
-        This video's frames haven't been sampled to images, which annotation
-        requires.{" "}
-        <DocsLink href="https://docs.voxel51.com/user_guide/using_views.html#frame-views">
-          Run dataset.to_frames(sample_frames=True) or populate filepaths to
-          existing frame images
-        </DocsLink>{" "}
-        to annotate it.
       </>
     ),
   },
@@ -72,9 +57,9 @@ const center: React.CSSProperties = {
 
 /**
  * Media-region takeover shown when the video annotation surface can't mount
- * its playback stream because a prerequisite is missing. Replaces the old
- * hard throw in `RegisterImaVidImage` (which crashed the whole modal) and the
- * silent blank when frames aren't sampled.
+ * any media path because a prerequisite is missing (currently only computed
+ * metadata) — an actionable prompt in the media region instead of a stream
+ * that would throw.
  */
 export const AnnotatePrerequisiteNotice: React.FC<{
   blocker: AnnotateBlocker;
@@ -102,7 +87,7 @@ export const AnnotatePrerequisiteNotice: React.FC<{
   );
 };
 
-/** Shown while a prerequisite (e.g. the sampled-frames probe) is resolving. */
+/** Shown while the decode strategy is resolving (frames / native-decode probe). */
 export const AnnotatePrerequisiteChecking: React.FC = () => (
   <div data-cy="video-annotate-prerequisite-checking" style={center}>
     <Spinner size={Size.Lg} />

--- a/app/packages/video-annotation/src/components/ImaVidLighterTile.tsx
+++ b/app/packages/video-annotation/src/components/ImaVidLighterTile.tsx
@@ -105,7 +105,11 @@ export const ImaVidLighterTile: React.FC = () => {
 
   return (
     <div className={styles.body}>
-      <canvas ref={frameCanvasRef} className={styles.frame} />
+      <canvas
+        ref={frameCanvasRef}
+        className={styles.frame}
+        data-cy="imavid-frame-canvas"
+      />
       <div ref={lighterHostRef} className={styles.lighterHost} />
     </div>
   );

--- a/app/packages/video-annotation/src/components/RegisterImaVidImage.tsx
+++ b/app/packages/video-annotation/src/components/RegisterImaVidImage.tsx
@@ -9,29 +9,45 @@ import {
   useView,
 } from "../state/accessors";
 import { IMAVID_STREAM_ID } from "../utils/ids";
+import type { FrameBitmapStream } from "../streams/frameBitmapStream";
 import { ImaVidImageStream } from "../streams/ImaVidImageStream";
+import { NativeVideoFrameStream } from "../streams/NativeVideoFrameStream";
 import { usePublishImaVidImageStream } from "../streams/imaVidImageStreamHandle";
 
+/** How the per-frame bitmaps are sourced for the ImaVid tile. */
+export type DecodeMode = "frames" | "native";
+
 /**
- * Construct and register `ImaVidImageStream` as soon as the sample's
- * params resolve. The image stream contributes `duration = frameCount/fps`
- * back to the engine, which is what unblocks `RegisterFrameLabels`
- * downstream — in the native-video tile the `<video>` element plays
- * this role via `useVideoStream`.
+ * Construct and register the ImaVid-tile frame stream as soon as the sample's
+ * params resolve. The stream contributes `duration = frameCount/fps` back to
+ * the engine, which unblocks `RegisterFrameLabels` downstream.
  *
- * `frameCount` and `frameRate` are resolved + validated upstream by
- * `useAnnotatePrerequisites` (which gates this component behind a
- * "compute metadata" prompt when they're absent), so they arrive as
- * positive finite numbers — no resolution or throwing here.
+ * Two bitmap sources, same tile + engine-clock lock-step (see
+ * {@link FrameBitmapStream}):
+ * - `frames` (default): `POST /frames` over `to_frames(sample_frames=True)`.
+ * - `native`: on-demand WebCodecs decode of the source video (no `to_frames`),
+ *   used when `?decode=native` AND the browser has `VideoDecoder` AND a video
+ *   URL resolved; otherwise falls back to `frames`.
  *
- * Re-keys on any identity change so a fresh stream replaces the old
- * one via `usePlaybackStream`'s standard cleanup.
+ * `frameCount` / `frameRate` are resolved + validated upstream by
+ * `useAnnotatePrerequisites`, so they arrive as positive finite numbers.
+ *
+ * Re-keys on any identity change (incl. decode mode) so a fresh stream replaces
+ * the old one via `usePlaybackStream`'s standard cleanup.
  */
 export const RegisterImaVidImage: React.FC<{
   frameCount: number;
   frameRate: number;
+  decodeMode?: DecodeMode;
+  videoSrc?: string | null;
   children: React.ReactNode;
-}> = ({ frameCount, frameRate, children }) => {
+}> = ({
+  frameCount,
+  frameRate,
+  decodeMode = "frames",
+  videoSrc = null,
+  children,
+}) => {
   const dataset = useDatasetName();
   const view = useView();
   const slice = useGroupSlice();
@@ -42,19 +58,25 @@ export const RegisterImaVidImage: React.FC<{
     return <>{children}</>;
   }
 
-  const key = `${sampleId}|${dataset}|${
+  const useNative =
+    decodeMode === "native" && !!videoSrc && nativeDecodeSupported();
+  const source: DecodeMode = useNative ? "native" : "frames";
+
+  const key = `${source}|${sampleId}|${dataset}|${
     slice ?? ""
   }|${frameRate}|${frameCount}`;
 
   return (
     <ImaVidImageRegistration
       key={key}
+      source={source}
       sampleId={sampleId}
       dataset={dataset}
       view={view}
       groupSlice={slice ?? null}
       frameCount={frameCount}
       frameRate={frameRate}
+      videoSrc={videoSrc}
     >
       {children}
     </ImaVidImageRegistration>
@@ -62,12 +84,14 @@ export const RegisterImaVidImage: React.FC<{
 };
 
 interface ImaVidImageRegistrationProps {
+  source: DecodeMode;
   sampleId: string;
   dataset: string;
   view: Stage[];
   groupSlice: string | null;
   frameCount: number;
   frameRate: number;
+  videoSrc: string | null;
   children: React.ReactNode;
 }
 
@@ -75,23 +99,32 @@ const ImaVidImageRegistration: React.FC<ImaVidImageRegistrationProps> = ({
   children,
   ...props
 }) => {
-  const streamRef = useRef<ImaVidImageStream | null>(null);
+  const streamRef = useRef<FrameBitmapStream | null>(null);
   if (streamRef.current === null) {
-    streamRef.current = new ImaVidImageStream({
-      id: IMAVID_STREAM_ID,
-      sampleId: props.sampleId,
-      dataset: props.dataset,
-      view: props.view,
-      groupSlice: props.groupSlice,
-      frameCount: props.frameCount,
-      frameRate: props.frameRate,
-    });
+    streamRef.current =
+      props.source === "native" && props.videoSrc
+        ? new NativeVideoFrameStream({
+            id: IMAVID_STREAM_ID,
+            sampleId: props.sampleId,
+            frameCount: props.frameCount,
+            frameRate: props.frameRate,
+            videoSrc: props.videoSrc,
+          })
+        : new ImaVidImageStream({
+            id: IMAVID_STREAM_ID,
+            sampleId: props.sampleId,
+            dataset: props.dataset,
+            view: props.view,
+            groupSlice: props.groupSlice,
+            frameCount: props.frameCount,
+            frameRate: props.frameRate,
+          });
   }
 
   // Tear down the worker on unmount. The effect is declared BEFORE
   // `usePlaybackStream` so React runs its cleanup AFTER the playback
-  // registration's cleanup (LIFO order): the engine unregisters the
-  // stream first, then we terminate the worker.
+  // registration's cleanup (LIFO): the engine unregisters the stream first,
+  // then we terminate the worker.
   useEffect(() => {
     const stream = streamRef.current;
 
@@ -102,13 +135,18 @@ const ImaVidImageRegistration: React.FC<ImaVidImageRegistrationProps> = ({
 
   usePlaybackStream(streamRef.current);
 
-  // Publish the stream instance so off-tile consumers
-  // can pull arbitrary frame bitmaps by index via warmup/getValue.
+  // Publish the stream instance so off-tile consumers can pull arbitrary frame
+  // bitmaps by index via warmup/getValue.
   usePublishImaVidImageStream(streamRef.current);
 
-  // Pre-warm the first chunk and seek to t=0 so the first paint isn't
-  // a blank tile waiting on the network + decode.
+  // Pre-warm the first chunk and seek to t=0 so the first paint isn't a blank
+  // tile waiting on the network + decode.
   useWarmupThenSeek(streamRef.current);
 
   return <>{children}</>;
 };
+
+/** WebCodecs presence gate. Codec support is confirmed later, worker-side. */
+function nativeDecodeSupported(): boolean {
+  return typeof window !== "undefined" && "VideoDecoder" in window;
+}

--- a/app/packages/video-annotation/src/components/RegisterImaVidImage.tsx
+++ b/app/packages/video-annotation/src/components/RegisterImaVidImage.tsx
@@ -14,40 +14,35 @@ import { ImaVidImageStream } from "../streams/ImaVidImageStream";
 import { NativeVideoFrameStream } from "../streams/NativeVideoFrameStream";
 import { usePublishImaVidImageStream } from "../streams/imaVidImageStreamHandle";
 
-/** How the per-frame bitmaps are sourced for the ImaVid tile. */
-export type DecodeMode = "frames" | "native";
+/**
+ * The two ImaVid-tile-backed bitmap sources. Which one is chosen is decided
+ * upstream by {@link useDecodeStrategy} — this registrar just constructs it.
+ *
+ * - `fetch` — `POST /frames` over `to_frames(sample_frames=True)` images.
+ * - `extract` — on-demand WebCodecs decode of the source video (no `to_frames`).
+ */
+export type ImaVidSource = "fetch" | "extract";
 
 /**
  * Construct and register the ImaVid-tile frame stream as soon as the sample's
  * params resolve. The stream contributes `duration = frameCount/fps` back to
  * the engine, which unblocks `RegisterFrameLabels` downstream.
  *
- * Two bitmap sources, same tile + engine-clock lock-step (see
- * {@link FrameBitmapStream}):
- * - `frames` (default): `POST /frames` over `to_frames(sample_frames=True)`.
- * - `native`: on-demand WebCodecs decode of the source video (no `to_frames`),
- *   used when `?decode=native` AND the browser has `VideoDecoder` AND a video
- *   URL resolved; otherwise falls back to `frames`.
- *
+ * Both sources feed the same tile + engine-clock lock-step (see
+ * {@link FrameBitmapStream}); `extract` additionally needs a `videoSrc`.
  * `frameCount` / `frameRate` are resolved + validated upstream by
  * `useAnnotatePrerequisites`, so they arrive as positive finite numbers.
  *
- * Re-keys on any identity change (incl. decode mode) so a fresh stream replaces
+ * Re-keys on any identity change (incl. `source`) so a fresh stream replaces
  * the old one via `usePlaybackStream`'s standard cleanup.
  */
 export const RegisterImaVidImage: React.FC<{
+  source: ImaVidSource;
   frameCount: number;
   frameRate: number;
-  decodeMode?: DecodeMode;
   videoSrc?: string | null;
   children: React.ReactNode;
-}> = ({
-  frameCount,
-  frameRate,
-  decodeMode = "frames",
-  videoSrc = null,
-  children,
-}) => {
+}> = ({ source, frameCount, frameRate, videoSrc = null, children }) => {
   const dataset = useDatasetName();
   const view = useView();
   const slice = useGroupSlice();
@@ -57,10 +52,6 @@ export const RegisterImaVidImage: React.FC<{
   if (!ready) {
     return <>{children}</>;
   }
-
-  const useNative =
-    decodeMode === "native" && !!videoSrc && nativeDecodeSupported();
-  const source: DecodeMode = useNative ? "native" : "frames";
 
   const key = `${source}|${sampleId}|${dataset}|${
     slice ?? ""
@@ -84,7 +75,7 @@ export const RegisterImaVidImage: React.FC<{
 };
 
 interface ImaVidImageRegistrationProps {
-  source: DecodeMode;
+  source: ImaVidSource;
   sampleId: string;
   dataset: string;
   view: Stage[];
@@ -102,7 +93,7 @@ const ImaVidImageRegistration: React.FC<ImaVidImageRegistrationProps> = ({
   const streamRef = useRef<FrameBitmapStream | null>(null);
   if (streamRef.current === null) {
     streamRef.current =
-      props.source === "native" && props.videoSrc
+      props.source === "extract" && props.videoSrc
         ? new NativeVideoFrameStream({
             id: IMAVID_STREAM_ID,
             sampleId: props.sampleId,
@@ -145,8 +136,3 @@ const ImaVidImageRegistration: React.FC<ImaVidImageRegistrationProps> = ({
 
   return <>{children}</>;
 };
-
-/** WebCodecs presence gate. Codec support is confirmed later, worker-side. */
-function nativeDecodeSupported(): boolean {
-  return typeof window !== "undefined" && "VideoDecoder" in window;
-}

--- a/app/packages/video-annotation/src/components/VideoAnnotationSurface.tsx
+++ b/app/packages/video-annotation/src/components/VideoAnnotationSurface.tsx
@@ -9,6 +9,8 @@ import { useSyncAnnotationVideoStore } from "../hooks/useSyncAnnotationVideoStor
 import { useVideoLighterEngineBridge } from "../hooks/useVideoLighterEngineBridge";
 import { useFollowAnchorFrame } from "../state/useVideoInteraction";
 import { useAnnotatePrerequisites } from "../hooks/useAnnotatePrerequisites";
+import { useDecodeStrategy } from "../hooks/useDecodeStrategy";
+import type { DecodeStrategy } from "../utils/decodeStrategy";
 import { PlaybackProvider } from "@fiftyone/playback";
 import {
   AnnotatePrerequisiteChecking,
@@ -16,7 +18,7 @@ import {
 } from "./AnnotatePrerequisiteNotice";
 import { FrameLabelsTracks, RegisterFrameLabels } from "./FrameLabels";
 import { ImaVidLighterTile } from "./ImaVidLighterTile";
-import { RegisterImaVidImage, type DecodeMode } from "./RegisterImaVidImage";
+import { RegisterImaVidImage } from "./RegisterImaVidImage";
 import {
   RegisterSyntheticLabels,
   SyntheticTrackTimeline,
@@ -36,17 +38,6 @@ import styles from "./VideoAnnotationSurface.module.css";
  */
 type LabelsMode = "real" | "synthetic";
 
-/**
- * Switch between the ImaVid (image-per-frame) tile and the native
- * `<video>` tile.
- *
- * - default: imavid (the demo's locked-in target — `to_frames(sample_frames=True)` data)
- * - `?tile=video`: native video tile (kept around for the existing path)
- *
- * Read once at mount; flipping requires reopening the modal.
- */
-type TileMode = "imavid" | "video";
-
 function useLabelsMode(): LabelsMode {
   const [mode] = useState<LabelsMode>(() => {
     if (typeof window === "undefined") {
@@ -60,36 +51,50 @@ function useLabelsMode(): LabelsMode {
   return mode;
 }
 
-function useTileMode(): TileMode {
-  const [mode] = useState<TileMode>(() => {
-    if (typeof window === "undefined") {
-      return "imavid";
-    }
+interface MediaProps {
+  videoSrc: string | null;
+}
 
-    const param = new URLSearchParams(window.location.search).get("tile");
-    return param === "video" ? "video" : "imavid";
-  });
-
-  return mode;
+interface RegistrarProps {
+  frameCount: number;
+  frameRate: number;
+  videoSrc: string | null;
+  children: React.ReactNode;
 }
 
 /**
- * Bitmap source for the ImaVid tile: `frames` (default, `/frames` over
- * `to_frames` data) or `native` (`?decode=native`, on-demand WebCodecs decode
- * of the source video — no `to_frames`). Read once at mount.
+ * The one place a resolved {@link DecodeStrategy} maps to a rendering path.
+ * Add a strategy by adding a row here + a branch in `resolveDecodeStrategy`.
+ *
+ * `TILE` picks the media element; `REGISTRAR` wraps the surface with the stream
+ * that drives the timeline's duration (`extract`/`fetch` register an ImaVid
+ * frame stream; `html` registers nothing — the `<video>` element is its own
+ * clock source).
  */
-function useDecodeMode(): DecodeMode {
-  const [mode] = useState<DecodeMode>(() => {
-    if (typeof window === "undefined") {
-      return "frames";
-    }
+const STRATEGY_TILE: Record<DecodeStrategy, React.FC<MediaProps>> = {
+  extract: () => <ImaVidLighterTile />,
+  fetch: () => <ImaVidLighterTile />,
+  html: ({ videoSrc }) =>
+    videoSrc ? (
+      <VideoLighterTile videoSrc={videoSrc} />
+    ) : (
+      <div className={styles.empty}>No media URL on this sample.</div>
+    ),
+};
 
-    const param = new URLSearchParams(window.location.search).get("decode");
-    return param === "native" ? "native" : "frames";
-  });
-
-  return mode;
-}
+const STRATEGY_REGISTRAR: Record<DecodeStrategy, React.FC<RegistrarProps>> = {
+  extract: ({ children, ...props }) => (
+    <RegisterImaVidImage source="extract" {...props}>
+      {children}
+    </RegisterImaVidImage>
+  ),
+  fetch: ({ children, ...props }) => (
+    <RegisterImaVidImage source="fetch" {...props}>
+      {children}
+    </RegisterImaVidImage>
+  ),
+  html: ({ children }) => <>{children}</>,
+};
 
 export interface VideoAnnotationSurfaceProps {
   sample: ModalSample;
@@ -101,9 +106,9 @@ export interface VideoAnnotationSurfaceProps {
  * stream (real `/frames` by default; synthetic when `?labels=synthetic`),
  * and renders media (top) + timeline (bottom).
  *
- * Tile mode (`?tile=imavid|video`) picks between an ImaVid tile (default,
- * one materialized image per frame via `to_frames(sample_frames=True)`)
- * and the native `<video>` tile.
+ * How frames are sourced is decided once by {@link useDecodeStrategy}
+ * (`extract` | `fetch` | `html`) — resolved BEFORE the media scaffolding
+ * mounts, so the timeline/sidebar mount exactly once.
  *
  * Lives inside the modal's media region — the existing right-side
  * annotation sidebar continues to render outside this component.
@@ -112,52 +117,60 @@ export const VideoAnnotationSurface: React.FC<VideoAnnotationSurfaceProps> = ({
   sample,
 }) => {
   const labelsMode = useLabelsMode();
-  const tileMode = useTileMode();
-  const decodeMode = useDecodeMode();
   const prerequisites = useAnnotatePrerequisites(sample);
 
-  // Resolved top-level media URL. The native-`<video>` tile binds to it, and
-  // the ImaVid tile's native-decode source (`?decode=native`) fetches it in a
-  // worker. The `/frames` ImaVid source resolves per-frame URLs instead and
-  // ignores this. Computed before the prerequisite gate so hook order stays
-  // stable across the checking → ready transition.
+  // Resolved top-level media URL. The `html` tile binds to it and the `extract`
+  // source decodes it in a worker; the `fetch` source resolves per-frame URLs
+  // instead and ignores it.
   const videoSrc = useMemo(() => {
     const url = sample.urls?.[0]?.url;
     return url ? getSampleSrc(url) : null;
   }, [sample]);
 
-  // Annotation needs computed metadata (frame count + fps) and sampled frame
-  // images. When a prerequisite is missing, show an actionable prompt instead
-  // of mounting the playback stream — which used to throw and take the whole
-  // modal down (metadata), or render a silent blank (frames).
-  if (prerequisites.status !== "ready") {
+  // Decide the decode strategy up front. Runs unconditionally (before the gates
+  // below) to keep hook order stable across the resolving → resolved transition.
+  const resolution = useDecodeStrategy({
+    videoSrc,
+    frameCount: prerequisites.frameCount,
+    enabled: prerequisites.status === "ready",
+  });
+
+  // Metadata gate: without a frame count no strategy can mount, so show an
+  // actionable prompt instead of a stream that would throw or blank out.
+  if (prerequisites.status === "blocked") {
     return (
       <div className={styles.root}>
         <VideoAnnotationTopBar sample={sample} />
         <div className={styles.media}>
-          {prerequisites.status === "blocked" ? (
-            <AnnotatePrerequisiteNotice blocker={prerequisites.blocker} />
-          ) : (
-            <AnnotatePrerequisiteChecking />
-          )}
+          <AnnotatePrerequisiteNotice blocker={prerequisites.blocker} />
         </div>
       </div>
     );
   }
 
-  const media =
-    tileMode === "imavid" ? (
-      <ImaVidLighterTile />
-    ) : videoSrc ? (
-      <VideoLighterTile videoSrc={videoSrc} />
-    ) : (
-      <div className={styles.empty}>No media URL on this sample.</div>
+  // Strategy still resolving (a frames / native-decode probe is in flight):
+  // hold on a spinner so the scaffolding mounts exactly once, on the winner.
+  if (resolution.status !== "resolved" || !resolution.strategy) {
+    return (
+      <div className={styles.root}>
+        <VideoAnnotationTopBar sample={sample} />
+        <div className={styles.media}>
+          <AnnotatePrerequisiteChecking />
+        </div>
+      </div>
     );
+  }
+
+  const strategy = resolution.strategy;
+  const Tile = STRATEGY_TILE[strategy];
+  const Registrar = STRATEGY_REGISTRAR[strategy];
 
   const layout = (
     <div className={styles.root}>
       <VideoAnnotationTopBar sample={sample} />
-      <div className={styles.media}>{media}</div>
+      <div className={styles.media}>
+        <Tile videoSrc={videoSrc} />
+      </div>
       <div className={styles.timeline}>
         {labelsMode === "synthetic" ? (
           <SyntheticTrackTimeline />
@@ -169,9 +182,9 @@ export const VideoAnnotationSurface: React.FC<VideoAnnotationSurfaceProps> = ({
   );
 
   // Both registrars run against the same PlaybackProvider. In the ImaVid
-  // path the image stream is the timeline's duration source (analogous to
-  // `<video>` in the native tile), so it has to mount OUTSIDE the labels
-  // registrar — `RegisterFrameLabels` gates on `useDuration() > 0` and
+  // (`extract`/`fetch`) path the image stream is the timeline's duration source
+  // (analogous to `<video>` in the `html` tile), so it has to mount OUTSIDE the
+  // labels registrar — `RegisterFrameLabels` gates on `useDuration() > 0` and
   // swaps its wrapper component when it flips ready, which would otherwise
   // remount whatever's nested inside it.
   const labels =
@@ -184,19 +197,15 @@ export const VideoAnnotationSurface: React.FC<VideoAnnotationSurfaceProps> = ({
       <RegisterFrameLabels sample={sample}>{layout}</RegisterFrameLabels>
     );
 
-  const registered =
-    tileMode === "imavid" ? (
-      <RegisterImaVidImage
-        frameCount={prerequisites.frameCount}
-        frameRate={prerequisites.frameRate}
-        decodeMode={decodeMode}
-        videoSrc={videoSrc}
-      >
-        {labels}
-      </RegisterImaVidImage>
-    ) : (
-      labels
-    );
+  const registered = (
+    <Registrar
+      frameCount={prerequisites.frameCount as number}
+      frameRate={prerequisites.frameRate as number}
+      videoSrc={videoSrc}
+    >
+      {labels}
+    </Registrar>
+  );
 
   // No TilingProvider: it mounts an isolated jotai store, which would
   // shadow modal-scoped atoms the sidebar writes to (lighterSceneAtom,

--- a/app/packages/video-annotation/src/components/VideoAnnotationSurface.tsx
+++ b/app/packages/video-annotation/src/components/VideoAnnotationSurface.tsx
@@ -16,7 +16,7 @@ import {
 } from "./AnnotatePrerequisiteNotice";
 import { FrameLabelsTracks, RegisterFrameLabels } from "./FrameLabels";
 import { ImaVidLighterTile } from "./ImaVidLighterTile";
-import { RegisterImaVidImage } from "./RegisterImaVidImage";
+import { RegisterImaVidImage, type DecodeMode } from "./RegisterImaVidImage";
 import {
   RegisterSyntheticLabels,
   SyntheticTrackTimeline,
@@ -73,6 +73,24 @@ function useTileMode(): TileMode {
   return mode;
 }
 
+/**
+ * Bitmap source for the ImaVid tile: `frames` (default, `/frames` over
+ * `to_frames` data) or `native` (`?decode=native`, on-demand WebCodecs decode
+ * of the source video — no `to_frames`). Read once at mount.
+ */
+function useDecodeMode(): DecodeMode {
+  const [mode] = useState<DecodeMode>(() => {
+    if (typeof window === "undefined") {
+      return "frames";
+    }
+
+    const param = new URLSearchParams(window.location.search).get("decode");
+    return param === "native" ? "native" : "frames";
+  });
+
+  return mode;
+}
+
 export interface VideoAnnotationSurfaceProps {
   sample: ModalSample;
 }
@@ -95,20 +113,18 @@ export const VideoAnnotationSurface: React.FC<VideoAnnotationSurfaceProps> = ({
 }) => {
   const labelsMode = useLabelsMode();
   const tileMode = useTileMode();
+  const decodeMode = useDecodeMode();
   const prerequisites = useAnnotatePrerequisites(sample);
 
-  // The native-video tile binds to a single top-level URL. The ImaVid
-  // tile resolves a per-frame URL through the image stream, so it does
-  // not need (and ignores) this value. Computed before the prerequisite
-  // gate so hook order stays stable across the checking → ready transition.
+  // Resolved top-level media URL. The native-`<video>` tile binds to it, and
+  // the ImaVid tile's native-decode source (`?decode=native`) fetches it in a
+  // worker. The `/frames` ImaVid source resolves per-frame URLs instead and
+  // ignores this. Computed before the prerequisite gate so hook order stays
+  // stable across the checking → ready transition.
   const videoSrc = useMemo(() => {
-    if (tileMode !== "video") {
-      return null;
-    }
-
     const url = sample.urls?.[0]?.url;
     return url ? getSampleSrc(url) : null;
-  }, [sample, tileMode]);
+  }, [sample]);
 
   // Annotation needs computed metadata (frame count + fps) and sampled frame
   // images. When a prerequisite is missing, show an actionable prompt instead
@@ -173,6 +189,8 @@ export const VideoAnnotationSurface: React.FC<VideoAnnotationSurfaceProps> = ({
       <RegisterImaVidImage
         frameCount={prerequisites.frameCount}
         frameRate={prerequisites.frameRate}
+        decodeMode={decodeMode}
+        videoSrc={videoSrc}
       >
         {labels}
       </RegisterImaVidImage>

--- a/app/packages/video-annotation/src/hooks/useAnnotatePrerequisites.test.ts
+++ b/app/packages/video-annotation/src/hooks/useAnnotatePrerequisites.test.ts
@@ -1,14 +1,7 @@
 import type { ModalSample } from "@fiftyone/state";
 import { renderHook } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { useAnnotatePrerequisites } from "./useAnnotatePrerequisites";
-import type { SampledFramesState } from "./useSampledFramesProbe";
-
-let probeState: SampledFramesState = "sampled";
-
-vi.mock("./useSampledFramesProbe", () => ({
-  useSampledFramesProbe: () => probeState,
-}));
 
 const sampleWith = (
   frameRate: unknown,
@@ -16,46 +9,14 @@ const sampleWith = (
 ): ModalSample =>
   ({ frameRate, sample: { metadata } }) as unknown as ModalSample;
 
-beforeEach(() => {
-  probeState = "sampled";
-});
-
 describe("useAnnotatePrerequisites", () => {
-  it("is ready when metadata is present and frames are sampled", () => {
-    probeState = "sampled";
+  it("is ready when metadata resolves a frame rate + count", () => {
     const { result } = renderHook(() =>
       useAnnotatePrerequisites(sampleWith(30, { total_frame_count: 90 })),
     );
 
     expect(result.current).toEqual({
       status: "ready",
-      frameRate: 30,
-      frameCount: 90,
-    });
-  });
-
-  it("reports checking while the frames probe is in flight", () => {
-    probeState = "checking";
-    const { result } = renderHook(() =>
-      useAnnotatePrerequisites(sampleWith(30, { total_frame_count: 90 })),
-    );
-
-    expect(result.current).toEqual({
-      status: "checking",
-      frameRate: 30,
-      frameCount: 90,
-    });
-  });
-
-  it("blocks on frames when the video isn't sampled", () => {
-    probeState = "unsampled";
-    const { result } = renderHook(() =>
-      useAnnotatePrerequisites(sampleWith(30, { total_frame_count: 90 })),
-    );
-
-    expect(result.current).toEqual({
-      status: "blocked",
-      blocker: "frames",
       frameRate: 30,
       frameCount: 90,
     });

--- a/app/packages/video-annotation/src/hooks/useAnnotatePrerequisites.ts
+++ b/app/packages/video-annotation/src/hooks/useAnnotatePrerequisites.ts
@@ -1,24 +1,20 @@
 import type { ModalSample } from "@fiftyone/state";
 import { resolveFrameCount } from "../utils/frameCount";
 import { getModalSampleFrameRate } from "../utils/modalSample";
-import { useSampledFramesProbe } from "./useSampledFramesProbe";
 
-/** Why the annotate surface can't mount its playback stream. */
-export type AnnotateBlocker = "metadata" | "frames";
+/** Why the annotate surface can't mount any media path. */
+export type AnnotateBlocker = "metadata";
 
-/**
- * `checking` — still resolving a prerequisite (a `/frames` probe is in
- * flight); `ready` — the playback stream can mount; `blocked` — a `blocker`
- * needs user action first.
- */
-export type AnnotateStatus = "checking" | "ready" | "blocked";
+/** `ready` — the surface can resolve a decode strategy; `blocked` — a
+ * `blocker` needs user action first. */
+export type AnnotateStatus = "ready" | "blocked";
 
 /**
  * Flat (not discriminated-union) shape: this codebase compiles with
  * `strict: false`, so `if (status === ...)` can't narrow a union — keep every
  * field accessible and switch on `status` at runtime. `blocker` is set iff
  * `status` is "blocked"; `frameRate`/`frameCount` are valid once metadata
- * resolves (i.e. for every status except a "metadata" block).
+ * resolves (i.e. when not blocked).
  */
 export interface AnnotatePrerequisites {
   status: AnnotateStatus;
@@ -28,17 +24,15 @@ export interface AnnotatePrerequisites {
 }
 
 /**
- * Resolve everything the ImaVid playback stream needs before it mounts:
+ * Resolve the one prerequisite every decode strategy needs up front: a
+ * positive fps + a frame count (from `total_frame_count`, else
+ * `duration * fps`). Absent when `VideoMetadata` wasn't computed → `metadata`
+ * block, which the surface renders as an actionable prompt instead of mounting
+ * a stream that would throw.
  *
- * 1. a positive fps + a frame count (from `total_frame_count`, else
- *    `duration * fps`) — absent when `VideoMetadata` wasn't computed →
- *    `metadata` block;
- * 2. materialized per-frame images — absent when the video wasn't
- *    `to_frames(sample_frames=True)`'d → `frames` block.
- *
- * Reporting a block (instead of mounting + throwing/blank) lets the surface
- * show an actionable prompt. The frames probe only runs once metadata is
- * resolved, since it needs the frame count.
+ * Whether per-frame images were materialized is not a prerequisite: it's one
+ * input to the decode-strategy resolver (fetch vs. extract vs. the `<video>`
+ * tile), not a hard gate — see {@link useDecodeStrategy}.
  */
 export const useAnnotatePrerequisites = (
   sample: ModalSample,
@@ -53,20 +47,8 @@ export const useAnnotatePrerequisites = (
 
   const metadataOk = hasFrameRate && frameCount !== undefined;
 
-  // Hooks can't be conditional — the probe always runs but no-ops (stays
-  // "checking") until metadata resolves and enables it.
-  const framesState = useSampledFramesProbe(frameCount, metadataOk);
-
   if (!metadataOk) {
     return { status: "blocked", blocker: "metadata" };
-  }
-
-  if (framesState === "checking") {
-    return { status: "checking", frameRate, frameCount };
-  }
-
-  if (framesState === "unsampled") {
-    return { status: "blocked", blocker: "frames", frameRate, frameCount };
   }
 
   return { status: "ready", frameRate, frameCount };

--- a/app/packages/video-annotation/src/hooks/useDecodeStrategy.ts
+++ b/app/packages/video-annotation/src/hooks/useDecodeStrategy.ts
@@ -1,0 +1,177 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { useEffect, useState } from "react";
+import { useDatasetName, useModalSampleId } from "../state/accessors";
+import { probeNativeDecode } from "../streams/probeNativeDecode";
+import {
+  type DecodeStrategy,
+  parseForcedStrategy,
+  resolveDecodeStrategy,
+} from "../utils/decodeStrategy";
+import { nativeDecodeCache } from "../utils/nativeDecodeCache";
+import {
+  looksDemuxable,
+  webCodecsAvailable,
+} from "../utils/nativeDecodeSupport";
+import { useSampledFramesProbe } from "./useSampledFramesProbe";
+
+/**
+ * Resolution of the decode strategy. `resolving` while an async capability
+ * (frames probe / native decode probe) is still in flight — the surface shows
+ * its checking state and mounts nothing yet, so the media scaffolding mounts
+ * exactly once, on the settled `strategy`.
+ */
+export interface DecodeResolution {
+  status: "resolving" | "resolved";
+  strategy?: DecodeStrategy;
+}
+
+export interface DecodeStrategyInput {
+  /** Resolved source video URL, or null when the sample has no media URL. */
+  videoSrc: string | null;
+  /** Clip frame count (gates the frames probe); from `useAnnotatePrerequisites`. */
+  frameCount: number | undefined;
+  /** Metadata is resolved — safe to probe. */
+  enabled: boolean;
+}
+
+/**
+ * Decide how the surface sources its frames: `extract` (WebCodecs on demand),
+ * `fetch` (`to_frames` images), or `html` (`<video>` element). Gathers the
+ * capability flags — a forced URL override, whether the source is natively
+ * decodable, and whether `to_frames` frames exist — and feeds the pure
+ * {@link resolveDecodeStrategy} policy.
+ *
+ * A forced override short-circuits both probes. Otherwise the frames probe and
+ * the native-decode probe run in parallel; resolution reports `resolving` until
+ * both settle, then applies the policy once.
+ */
+export function useDecodeStrategy(
+  input: DecodeStrategyInput,
+): DecodeResolution {
+  const { videoSrc, frameCount, enabled } = input;
+  const dataset = useDatasetName();
+  const sampleId = useModalSampleId();
+
+  const forced = useForcedStrategy();
+  const active = enabled && !forced;
+
+  const framesState = useSampledFramesProbe(frameCount, active);
+  const native = useNativeDecodable({
+    videoSrc,
+    dataset,
+    sampleId,
+    enabled: active,
+  });
+
+  // A manual override wins outright — don't wait on probes.
+  if (forced) {
+    return { status: "resolved", strategy: forced };
+  }
+
+  if (!enabled || native.checking || framesState === "checking") {
+    return { status: "resolving" };
+  }
+
+  return {
+    status: "resolved",
+    strategy: resolveDecodeStrategy({
+      hasVideoSrc: Boolean(videoSrc),
+      nativeDecodable: native.decodable,
+      hasFrames: framesState === "sampled",
+    }),
+  };
+}
+
+interface NativeDecodableState {
+  checking: boolean;
+  decodable: boolean;
+}
+
+interface NativeDecodableInput {
+  videoSrc: string | null;
+  dataset: string | null;
+  sampleId: string | null;
+  enabled: boolean;
+}
+
+/**
+ * Whether the source video is decodable via WebCodecs. Cheap sync gates first
+ * (WebCodecs present, ISO-BMFF-looking container); then a cached per-sample
+ * verdict; only on a cache miss do we run the (moov-only) worker probe and
+ * memoize its result. A verdict is cached only when the probe demuxed a codec,
+ * so a transient fetch failure isn't remembered as "not decodable".
+ */
+function useNativeDecodable(input: NativeDecodableInput): NativeDecodableState {
+  const { videoSrc, dataset, sampleId, enabled } = input;
+  const [state, setState] = useState<NativeDecodableState>({
+    checking: false,
+    decodable: false,
+  });
+
+  useEffect(() => {
+    if (
+      !enabled ||
+      !videoSrc ||
+      !dataset ||
+      !sampleId ||
+      !webCodecsAvailable() ||
+      !looksDemuxable(videoSrc)
+    ) {
+      setState({ checking: false, decodable: false });
+      return undefined;
+    }
+
+    const cached = nativeDecodeCache.getSampleVerdict(dataset, sampleId);
+    if (cached) {
+      setState({ checking: false, decodable: cached.decodable });
+      return undefined;
+    }
+
+    let cancelled = false;
+    const controller = new AbortController();
+    setState({ checking: true, decodable: false });
+
+    // No custom headers: the probe fetches `videoSrc` with `<video src>`
+    // semantics (cors, default credentials), matching how the decode worker and
+    // `framesWorker` fetch media — so probe reachability tracks the real fetch.
+    probeNativeDecode(videoSrc, { signal: controller.signal }).then(
+      (result) => {
+        if (cancelled) {
+          return;
+        }
+
+        if (result.codec) {
+          nativeDecodeCache.setSampleVerdict(dataset, sampleId, {
+            codec: result.codec,
+            decodable: result.decodable,
+          });
+        }
+
+        setState({ checking: false, decodable: result.decodable });
+      },
+    );
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [enabled, videoSrc, dataset, sampleId]);
+
+  return state;
+}
+
+/** Read a forced-strategy URL override once at mount (see `parseForcedStrategy`). */
+function useForcedStrategy(): DecodeStrategy | undefined {
+  const [forced] = useState<DecodeStrategy | undefined>(() => {
+    if (typeof window === "undefined") {
+      return undefined;
+    }
+
+    return parseForcedStrategy(window.location.search);
+  });
+
+  return forced;
+}

--- a/app/packages/video-annotation/src/streams/ImaVidImageStream.ts
+++ b/app/packages/video-annotation/src/streams/ImaVidImageStream.ts
@@ -1,158 +1,60 @@
 import { getFetchParameters, type Stage } from "@fiftyone/utilities";
-import { LRUCache } from "lru-cache";
+import type { GetFramesRequest } from "../../../core/src/client/framesClient";
 import {
-  frameAt,
-  PlaybackStreamBase,
-  type BufferReadiness,
-  type PlaybackStore,
-} from "@fiftyone/playback";
-import { mergeRange, toSecondRanges } from "./fetchedRanges";
-import type {
-  ChunkDoneMessage,
-  ChunkFailedMessage,
-  FrameReadyMessage,
-  OutboundMessage,
-} from "./framesWorker";
+  FrameBitmapStream,
+  type FrameBitmap,
+  type FrameBitmapStreamOptions,
+} from "./frameBitmapStream";
+import type { FrameReadyMessage } from "./frameWorkerProtocol";
 
 /**
- * What the stream publishes per tick. Consumers (the ImaVid tile) draw
- * `bitmap` into a canvas; `sampleId` and `frameNumber` are exposed for
- * commands / persistence that need to know which frame this is. `src`
- * is kept for debugging / dev-tools inspection — production rendering
- * does not use it.
+ * What the ImaVid stream publishes per frame. Alias of the shared
+ * {@link FrameBitmap} — kept for the tile's existing import.
  */
-export interface ImaVidImageFrame {
-  bitmap: ImageBitmap;
-  src: string;
-  sampleId: string;
-  frameNumber: number;
-}
+export type ImaVidImageFrame = FrameBitmap;
 
-/**
- * What we keep in the LRU. Decoded `ImageBitmap`s are sized by pixel
- * bytes; on eviction we call `.close()` to free the underlying GPU /
- * native memory immediately rather than waiting on GC.
- */
-interface CachedFrame extends ImaVidImageFrame {
-  sizeBytes: number;
-}
-
-export interface ImaVidImageStreamOptions {
-  id: string;
-  /** Sample id for the parent video document. */
-  sampleId: string;
+export interface ImaVidImageStreamOptions extends FrameBitmapStreamOptions {
   /** Current dataset name (POST /frames requires it). */
   dataset: string;
   /** Active view stages — same shape sent on every dataset query. */
   view: Stage[];
   /** Group slice name, when the dataset is grouped. */
   groupSlice?: string | null;
-  /** Total frame count of the clip (1-indexed up to this number). */
-  frameCount: number;
-  /** Frame rate in frames per second. */
-  frameRate: number;
-  /**
-   * Number of frames to request in a single `/frames` chunk. Larger
-   * values mean fewer round trips but larger payloads.
-   *
-   * @default 60
-   */
-  chunkSize?: number;
-  /**
-   * Cap on cached pixel bytes. Defaults to 1 GB which matches looker's
-   * ImaVid path. The LRU evicts the oldest frames first once this is
-   * exceeded.
-   *
-   * @default 1e9
-   */
-  maxBytes?: number;
 }
-
-const DEFAULT_CHUNK_SIZE = 60;
-const DEFAULT_MAX_BYTES = 1e9;
 
 /**
  * Image stream backed by `POST /frames` for ImaVid-style playback
- * (i.e. `to_frames(sample_frames=True)` data, one materialized image
- * per frame).
+ * (`to_frames(sample_frames=True)` data — one materialized image per frame).
  *
- * Both the JSON fetch and the per-image fetch+decode run inside a
- * `framesWorker` so the main thread never has to parse a `/frames`
- * response or decode an image. The worker transfers `ImageBitmap`s
- * back zero-copy; the tile renders them via `<canvas>` + `drawImage`.
- *
- * `bufferState` reports `ready` only after a frame's bitmap has landed
- * in the cache — so the engine never tries to render a half-decoded
- * frame.
+ * The JSON fetch and per-image fetch+decode both run inside a `framesWorker`
+ * so the main thread never parses a `/frames` response or decodes an image;
+ * the worker transfers `ImageBitmap`s back zero-copy. All the chunking / cache
+ * / readiness machinery lives in {@link FrameBitmapStream}; this subclass only
+ * supplies the `/frames` source.
  */
-export class ImaVidImageStream extends PlaybackStreamBase<ImaVidImageFrame> {
-  private readonly sampleId: string;
+export class ImaVidImageStream extends FrameBitmapStream<{ src: string }> {
   private readonly dataset: string;
   private readonly view: Stage[];
   private readonly groupSlice: string | null;
-  private readonly frameCount: number;
-  private readonly frameRate: number;
-  private readonly chunkSize: number;
-
-  private readonly cache: LRUCache<number, CachedFrame>;
-  private readonly inflight = new Map<number, InflightEntry>();
-  /** reqId → frame numbers that request asked for. */
-  private readonly requestFrames = new Map<number, number[]>();
-  /**
-   * Frames that settled without a bitmap — unresolvable `filepath`, decode
-   * error, or a failed `/frames` chunk. Terminal: we never re-request them, so
-   * a bad frame can't drive an infinite `/frames` loop. Cleared only on
-   * `destroy` (a re-sampled clip arrives as a fresh, re-keyed stream).
-   */
-  private readonly failed = new Set<number>();
-  private readonly fetchedRanges: Array<[number, number]> = [];
-
-  private readonly worker: Worker;
-  private nextReqId = 1;
-  private destroyed = false;
 
   constructor(opts: ImaVidImageStreamOptions) {
-    super(opts.id, {
-      blocking: true,
-      duration: opts.frameCount / opts.frameRate,
-      nativeStepSeconds: 1 / opts.frameRate,
-      lookupPolicy: {
-        type: "nearestPrevious",
-        thresholdSeconds: 1 / opts.frameRate,
-      },
-    });
-
-    this.sampleId = opts.sampleId;
+    super(opts);
     this.dataset = opts.dataset;
     this.view = opts.view;
     this.groupSlice = opts.groupSlice ?? null;
-    this.frameCount = opts.frameCount;
-    this.frameRate = opts.frameRate;
-    this.chunkSize = opts.chunkSize ?? DEFAULT_CHUNK_SIZE;
+  }
 
-    this.cache = new LRUCache<number, CachedFrame>({
-      maxSize: opts.maxBytes ?? DEFAULT_MAX_BYTES,
-      sizeCalculation: (entry) => entry.sizeBytes,
-      dispose: (entry) => {
-        // Free the underlying decoded pixels immediately. Without
-        // .close(), the bitmap sits in GPU / native memory until GC
-        // runs, which can push us well past the byte cap before
-        // memory is actually reclaimed.
-        entry.bitmap.close();
-      },
-    });
-
-    this.worker = new Worker(new URL("./framesWorker.ts", import.meta.url), {
+  protected createWorker(): Worker {
+    return new Worker(new URL("./framesWorker.ts", import.meta.url), {
       type: "module",
     });
-    this.worker.addEventListener("message", this.handleWorkerMessage);
+  }
 
-    // Hand the worker the same fetch context the main thread uses.
-    // Normalize HeadersInit → Record<string, string> so it's structured-
-    // cloneable (Headers objects and arrays both serialize fine, but
-    // the worker side is simpler if it can spread headers verbatim).
+  protected postInit(worker: Worker): void {
+    // Hand the worker the same fetch context the main thread uses. Normalize
+    // HeadersInit → Record so it's structured-cloneable.
     const params = getFetchParameters();
-    this.worker.postMessage({
+    worker.postMessage({
       type: "init",
       origin: params.origin,
       pathPrefix: params.pathPrefix,
@@ -160,294 +62,27 @@ export class ImaVidImageStream extends PlaybackStreamBase<ImaVidImageFrame> {
     });
   }
 
-  /**
-   * Resolve once the frame containing `time` has been fetched and
-   * decoded. Use in tandem with `seek(time)` on mount so the first
-   * paint isn't a blank tile waiting for the network.
-   */
-  async warmup(time = 0): Promise<void> {
-    const frame = this.timeToFrame(time);
-    if (this.cache.has(frame) || this.failed.has(frame)) {
-      return;
-    }
-
-    const existing = this.inflight.get(frame);
-    if (existing) {
-      await existing.promise;
-      return;
-    }
-
-    this.requestChunkStartingAt(frame);
-    const entry = this.inflight.get(frame);
-    if (entry) {
-      await entry.promise;
-    }
-  }
-
-  /** Terminate the worker. Call when the stream is being replaced. */
-  destroy(): void {
-    if (this.destroyed) {
-      return;
-    }
-
-    this.destroyed = true;
-
-    this.worker.removeEventListener("message", this.handleWorkerMessage);
-    this.worker.terminate();
-
-    // Settle anyone awaiting a frame that will never arrive.
-    for (const entry of this.inflight.values()) {
-      entry.resolve();
-    }
-    this.inflight.clear();
-    this.requestFrames.clear();
-    this.failed.clear();
-    this.cache.clear();
-  }
-
-  /** Total frames in the clip. */
-  get totalFrames(): number {
-    return this.frameCount;
-  }
-
-  /** Frame rate in fps. */
-  get fps(): number {
-    return this.frameRate;
-  }
-
-  bufferState(time: number): BufferReadiness {
-    const frame = this.timeToFrame(time);
-
-    if (this.cache.has(frame)) {
-      return "ready";
-    }
-
-    // A terminally-failed frame is reported "ready" (it just has no bitmap):
-    // the engine's buffer barrier plays through to a blank frame instead of
-    // stalling on it forever and re-issuing prefetch every tick.
-    if (this.failed.has(frame)) {
-      return "ready";
-    }
-
-    if (this.inflight.has(frame)) {
-      return "loading";
-    }
-
-    return "missing";
-  }
-
-  prefetch(range: [number, number]): void {
-    const [startSec, endSec] = range;
-    const startFrame = this.timeToFrame(startSec);
-    const endFrame = this.timeToFrame(endSec);
-
-    // First missing frame wins — the engine re-calls prefetch as the
-    // playhead advances, so we don't need to fan out here.
-    for (let f = startFrame; f <= endFrame; f++) {
-      if (this.cache.has(f) || this.inflight.has(f) || this.failed.has(f)) {
-        continue;
-      }
-
-      this.requestChunkStartingAt(f);
-      return;
-    }
-  }
-
-  getValue(time: number): ImaVidImageFrame | null {
-    const frame = this.timeToFrame(time);
-    const entry = this.cache.get(frame);
-    if (!entry) {
-      return null;
-    }
-
+  protected buildChunkRequest(
+    startFrame: number,
+    numFrames: number,
+  ): GetFramesRequest {
     return {
-      bitmap: entry.bitmap,
-      src: entry.src,
-      sampleId: entry.sampleId,
-      frameNumber: entry.frameNumber,
+      frameNumber: startFrame,
+      numFrames,
+      frameCount: this.frameCount,
+      sampleId: this.sampleId,
+      dataset: this.dataset,
+      view: this.view,
+      slice: this.groupSlice ?? undefined,
+      // The image stream only needs each frame's media path; project to it so
+      // `/frames` doesn't ship every label field per frame.
+      fields: ["filepath"],
     };
   }
 
-  /**
-   * Custom `onCommit`: dedupe by `frameNumber`. The engine ticks several
-   * times per frame; without dedupe each tick republishes an identical
-   * value and kicks every `useStream` consumer into a re-render.
-   */
-  override onCommit(time: number, store: PlaybackStore): void {
-    const next = this.getValue(time);
-    const prev = this.readPublished(store);
-
-    if (prev && next && prev.frameNumber === next.frameNumber) {
-      return;
-    }
-
-    if (prev === null && next === null) {
-      return;
-    }
-
-    // We're advancing to a new committed frame; proactively pull the next
-    // chunk into flight so it lands before the playhead reaches it. The engine
-    // only gives us a 1-frame warning, so we want to get ahead of that.
-    if (next) {
-      this.prefetch([time, time + this.lookaheadSeconds]);
-    }
-
-    this.publish(store, next);
+  protected override toMeta(msg: FrameReadyMessage): { src: string } {
+    return { src: (msg.meta as { src?: string } | undefined)?.src ?? "" };
   }
-
-  bufferedRanges(): Array<[number, number]> {
-    return toSecondRanges(this.fetchedRanges, this.frameRate);
-  }
-
-  private timeToFrame(time: number): number {
-    return frameAt(time, this.frameRate, this.frameCount);
-  }
-
-  private requestChunkStartingAt(startFrame: number): void {
-    if (this.destroyed) {
-      return;
-    }
-
-    const numFrames = Math.min(
-      this.chunkSize,
-      this.frameCount - startFrame + 1,
-    );
-    if (numFrames <= 0) {
-      return;
-    }
-
-    const reqId = this.nextReqId++;
-    const frames: number[] = [];
-    for (let f = startFrame; f < startFrame + numFrames; f++) {
-      // Skip frames the cache already has, another request is fetching, or
-      // that already failed terminally; the worker doesn't dedupe so we have to.
-      if (this.cache.has(f) || this.inflight.has(f) || this.failed.has(f)) {
-        continue;
-      }
-
-      const entry = createInflightEntry();
-
-      this.inflight.set(f, entry);
-      frames.push(f);
-    }
-
-    if (frames.length === 0) {
-      return;
-    }
-
-    this.requestFrames.set(reqId, frames);
-
-    this.worker.postMessage({
-      type: "fetchChunk",
-      reqId,
-      request: {
-        frameNumber: startFrame,
-        numFrames,
-        frameCount: this.frameCount,
-        sampleId: this.sampleId,
-        dataset: this.dataset,
-        view: this.view,
-        slice: this.groupSlice ?? undefined,
-        // The image stream only needs each frame's media path; project to it
-        // so `/frames` doesn't ship every label field per frame.
-        fields: ["filepath"],
-      },
-    });
-  }
-
-  private handleWorkerMessage = (
-    event: MessageEvent<OutboundMessage>,
-  ): void => {
-    const msg = event.data;
-    switch (msg.type) {
-      case "frameReady":
-        this.onFrameReady(msg);
-        break;
-      case "chunkDone":
-        this.onChunkDone(msg);
-        break;
-      case "chunkFailed":
-        this.onChunkFailed(msg);
-        break;
-    }
-  };
-
-  private onFrameReady(msg: FrameReadyMessage): void {
-    // If the stream was destroyed between request and reply, the bitmap
-    // would leak — close it explicitly.
-    if (this.destroyed) {
-      msg.bitmap.close();
-      return;
-    }
-
-    const sizeBytes = Math.max(1, msg.width * msg.height * 4);
-    this.cache.set(msg.frameNumber, {
-      bitmap: msg.bitmap,
-      src: msg.src,
-      sampleId: this.sampleId,
-      frameNumber: msg.frameNumber,
-      sizeBytes,
-    });
-
-    const entry = this.inflight.get(msg.frameNumber);
-    if (entry) {
-      entry.resolve();
-      this.inflight.delete(msg.frameNumber);
-    }
-  }
-
-  private onChunkDone(msg: ChunkDoneMessage): void {
-    mergeRange(this.fetchedRanges, msg.range);
-    this.resolveOutstandingFrames(msg.reqId);
-  }
-
-  private onChunkFailed(msg: ChunkFailedMessage): void {
-    console.error(
-      `[ImaVidImageStream] worker chunk ${msg.reqId} failed: ${msg.error}`,
-    );
-    this.resolveOutstandingFrames(msg.reqId);
-  }
-
-  /**
-   * Settle any in-flight frames from this request that never received a
-   * `frameReady` (missing/unresolvable filepath, decode error, or a failed
-   * chunk). They're marked terminally `failed` so we never re-request them —
-   * otherwise the engine, seeing them perpetually un-ready, would re-prefetch
-   * every tick and hammer `/frames` forever. Anyone awaiting `warmup` unblocks.
-   */
-  private resolveOutstandingFrames(reqId: number): void {
-    const frames = this.requestFrames.get(reqId);
-    if (!frames) {
-      return;
-    }
-
-    this.requestFrames.delete(reqId);
-
-    for (const f of frames) {
-      const entry = this.inflight.get(f);
-      if (!entry) {
-        continue;
-      }
-
-      this.failed.add(f);
-      entry.resolve();
-      this.inflight.delete(f);
-    }
-  }
-}
-
-interface InflightEntry {
-  promise: Promise<void>;
-  resolve: () => void;
-}
-
-function createInflightEntry(): InflightEntry {
-  let resolve!: () => void;
-  const promise = new Promise<void>((r) => {
-    resolve = r;
-  });
-
-  return { promise, resolve };
 }
 
 function normalizeHeaders(

--- a/app/packages/video-annotation/src/streams/NativeVideoFrameStream.ts
+++ b/app/packages/video-annotation/src/streams/NativeVideoFrameStream.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import {
+  FrameBitmapStream,
+  type FrameBitmapStreamOptions,
+} from "./frameBitmapStream";
+
+export interface NativeVideoFrameStreamOptions extends FrameBitmapStreamOptions {
+  /** Resolved media URL for the source video (e.g. `getSampleSrc(...)`). */
+  videoSrc: string;
+  /** Extra headers for the media fetch (auth); usually none for presigned. */
+  headers?: Record<string, string>;
+  /** Worker-side frame-exactness instrumentation (dev only). */
+  debug?: boolean;
+}
+
+/**
+ * Frame stream backed by on-demand WebCodecs decode of the source video (no
+ * `to_frames` preprocessing). A `videoDecodeWorker` demuxes with mp4box and
+ * decodes frames with a `VideoDecoder`, transferring `ImageBitmap`s back
+ * zero-copy — the same shape {@link FrameBitmapStream} feeds the ImaVid tile,
+ * so playback stays single-clock lock-step.
+ *
+ * All chunking / cache / readiness machinery is inherited; this subclass only
+ * points the base at the WebCodecs source. GOP keyframe-snapping is handled
+ * worker-side, so `buildChunkRequest` stays a plain frame range.
+ */
+export class NativeVideoFrameStream extends FrameBitmapStream<{
+  timestamp: number;
+}> {
+  private readonly videoSrc: string;
+  private readonly headers: Record<string, string>;
+  private readonly debug: boolean;
+
+  constructor(opts: NativeVideoFrameStreamOptions) {
+    super(opts);
+    this.videoSrc = opts.videoSrc;
+    this.headers = opts.headers ?? {};
+    this.debug = opts.debug ?? false;
+  }
+
+  protected createWorker(): Worker {
+    return new Worker(new URL("./videoDecodeWorker.ts", import.meta.url), {
+      type: "module",
+    });
+  }
+
+  protected postInit(worker: Worker): void {
+    worker.postMessage({
+      type: "init",
+      videoSrc: this.videoSrc,
+      headers: this.headers,
+      debug: this.debug,
+    });
+  }
+
+  protected buildChunkRequest(
+    startFrame: number,
+    numFrames: number,
+  ): { startFrame: number; numFrames: number } {
+    // The worker owns keyframe snapping (decode from the GOP keyframe ≤ start),
+    // so a plain presentation-frame range is all it needs.
+    return { startFrame, numFrames };
+  }
+}

--- a/app/packages/video-annotation/src/streams/NativeVideoFrameStream.ts
+++ b/app/packages/video-annotation/src/streams/NativeVideoFrameStream.ts
@@ -10,7 +10,13 @@ import {
 export interface NativeVideoFrameStreamOptions extends FrameBitmapStreamOptions {
   /** Resolved media URL for the source video (e.g. `getSampleSrc(...)`). */
   videoSrc: string;
-  /** Extra headers for the media fetch (auth); usually none for presigned. */
+  /**
+   * Optional headers for the worker's media fetch. Empty by default: the worker
+   * fetches `videoSrc` with `<video src>` semantics (cors, default credentials,
+   * no custom headers) — the same way `framesWorker` fetches image bytes — so
+   * native decode works wherever the `<video>` tile does (presigned URL or
+   * same-origin cookies).
+   */
   headers?: Record<string, string>;
   /** Worker-side frame-exactness instrumentation (dev only). */
   debug?: boolean;

--- a/app/packages/video-annotation/src/streams/NativeVideoFrameStream.ts
+++ b/app/packages/video-annotation/src/streams/NativeVideoFrameStream.ts
@@ -18,8 +18,6 @@ export interface NativeVideoFrameStreamOptions extends FrameBitmapStreamOptions 
    * same-origin cookies).
    */
   headers?: Record<string, string>;
-  /** Worker-side frame-exactness instrumentation (dev only). */
-  debug?: boolean;
 }
 
 /**
@@ -38,13 +36,11 @@ export class NativeVideoFrameStream extends FrameBitmapStream<{
 }> {
   private readonly videoSrc: string;
   private readonly headers: Record<string, string>;
-  private readonly debug: boolean;
 
   constructor(opts: NativeVideoFrameStreamOptions) {
     super(opts);
     this.videoSrc = opts.videoSrc;
     this.headers = opts.headers ?? {};
-    this.debug = opts.debug ?? false;
   }
 
   protected createWorker(): Worker {
@@ -58,7 +54,6 @@ export class NativeVideoFrameStream extends FrameBitmapStream<{
       type: "init",
       videoSrc: this.videoSrc,
       headers: this.headers,
-      debug: this.debug,
     });
   }
 

--- a/app/packages/video-annotation/src/streams/frameBitmapCache.ts
+++ b/app/packages/video-annotation/src/streams/frameBitmapCache.ts
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+/// <reference types="dom-webcodecs" />
+
+import { LRUCache } from "lru-cache";
+
+/**
+ * A decoded frame held in the cache. `meta` is stream-specific opaque payload
+ * (imavid: `{ src }`; native: `{ timestamp }`) — the cache never reads it.
+ */
+export interface CachedFrameBitmap<M = unknown> {
+  bitmap: ImageBitmap;
+  width: number;
+  height: number;
+  meta: M;
+}
+
+/** Default cache cap — 1 GB of decoded pixels, matching looker's ImaVid path. */
+const DEFAULT_MAX_BYTES = 1e9;
+
+/**
+ * LRU of decoded frame bitmaps keyed by 1-indexed frame number. Entries are
+ * sized by pixel bytes (`w * h * 4`); on eviction / overwrite / clear the
+ * `ImageBitmap` is `.close()`d so the underlying GPU / native memory is freed
+ * immediately rather than waiting on GC (decoded RGBA is large — without this
+ * we blow well past the byte cap before memory is reclaimed).
+ *
+ * Shared by every {@link FrameBitmapStream} (the `/frames` image stream and the
+ * WebCodecs video stream) so both get identical memory behaviour.
+ */
+export class FrameBitmapCache<M = unknown> {
+  private readonly cache: LRUCache<number, CachedFrameBitmap<M>>;
+
+  constructor(maxBytes: number = DEFAULT_MAX_BYTES) {
+    this.cache = new LRUCache<number, CachedFrameBitmap<M>>({
+      maxSize: maxBytes,
+      sizeCalculation: (entry) => Math.max(1, entry.width * entry.height * 4),
+      dispose: (entry) => {
+        entry.bitmap.close();
+      },
+    });
+  }
+
+  get(frame: number): CachedFrameBitmap<M> | undefined {
+    return this.cache.get(frame);
+  }
+
+  set(frame: number, entry: CachedFrameBitmap<M>): void {
+    this.cache.set(frame, entry);
+  }
+
+  has(frame: number): boolean {
+    return this.cache.has(frame);
+  }
+
+  delete(frame: number): void {
+    this.cache.delete(frame);
+  }
+
+  /** Drop every entry, closing each held bitmap. */
+  clear(): void {
+    this.cache.clear();
+  }
+}

--- a/app/packages/video-annotation/src/streams/frameBitmapStream.ts
+++ b/app/packages/video-annotation/src/streams/frameBitmapStream.ts
@@ -1,0 +1,434 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+/// <reference types="dom-webcodecs" />
+
+import {
+  frameAt,
+  PlaybackStreamBase,
+  type BufferReadiness,
+  type PlaybackStore,
+} from "@fiftyone/playback";
+import { FrameBitmapCache } from "./frameBitmapCache";
+import { mergeRange, toSecondRanges } from "./fetchedRanges";
+import type {
+  ChunkDoneMessage,
+  ChunkFailedMessage,
+  FrameReadyMessage,
+  FrameWorkerOutbound,
+} from "./frameWorkerProtocol";
+
+/**
+ * What the stream publishes per committed frame. Consumers (the ImaVid tile,
+ * SAM2 propagation) draw `bitmap`; `frameNumber` / `sampleId` identify which
+ * frame this is for commands / persistence.
+ */
+export interface FrameBitmap {
+  bitmap: ImageBitmap;
+  frameNumber: number;
+  sampleId: string;
+}
+
+export interface FrameBitmapStreamOptions {
+  id: string;
+  /** Sample id for the parent video document. */
+  sampleId: string;
+  /** Total frame count of the clip (1-indexed up to this number). */
+  frameCount: number;
+  /** Frame rate in frames per second. */
+  frameRate: number;
+  /**
+   * Number of frames to request per chunk. Larger = fewer round trips, bigger
+   * payloads.
+   *
+   * @default 60
+   */
+  chunkSize?: number;
+  /**
+   * Cap on cached pixel bytes.
+   *
+   * @default 1e9
+   */
+  maxBytes?: number;
+}
+
+const DEFAULT_CHUNK_SIZE = 60;
+
+interface InflightEntry {
+  promise: Promise<void>;
+  resolve: () => void;
+}
+
+/**
+ * Abstract chunked bitmap stream for ImaVid-style playback: a decode worker
+ * fills an LRU of decoded frame bitmaps keyed by frame number, off the main
+ * thread; the tile renders them one-per-commit via a single engine clock (so
+ * media + overlays stay lock-step).
+ *
+ * This base owns everything source-agnostic — the LRU cache, the
+ * inflight/failed/fetched-range bookkeeping, the buffer-readiness barrier,
+ * prefetch / warmup / onCommit, and the shared worker message protocol.
+ * Subclasses supply only the decode SOURCE:
+ *
+ * - {@link createWorker} — construct the worker (image `/frames` vs WebCodecs).
+ * - {@link postInit} — send the source-specific `init` message.
+ * - {@link buildChunkRequest} — the `fetchChunk` `request` payload.
+ * - {@link toMeta} — derive the cached meta from a `frameReady`.
+ * - {@link disposeSource} — optional extra teardown.
+ *
+ * `bufferState` reports `ready` only once a frame's bitmap has landed, so the
+ * engine never renders a half-decoded frame.
+ */
+export abstract class FrameBitmapStream<
+  M = unknown,
+> extends PlaybackStreamBase<FrameBitmap> {
+  protected readonly sampleId: string;
+  protected readonly frameCount: number;
+  protected readonly frameRate: number;
+  protected readonly chunkSize: number;
+
+  protected readonly cache: FrameBitmapCache<M>;
+  private readonly inflight = new Map<number, InflightEntry>();
+  /** reqId → frame numbers that request asked for. */
+  private readonly requestFrames = new Map<number, number[]>();
+  /**
+   * Frames that settled without a bitmap — unresolvable source, decode error,
+   * or a failed chunk. Terminal: never re-requested, so a bad frame can't drive
+   * an infinite fetch loop. Cleared only on `destroy`.
+   */
+  private readonly failed = new Set<number>();
+  private readonly fetchedRanges: Array<[number, number]> = [];
+
+  private readonly worker: Worker;
+  private initialized = false;
+  private nextReqId = 1;
+  private destroyed = false;
+
+  constructor(opts: FrameBitmapStreamOptions) {
+    super(opts.id, {
+      blocking: true,
+      duration: opts.frameCount / opts.frameRate,
+      nativeStepSeconds: 1 / opts.frameRate,
+      lookupPolicy: {
+        type: "nearestPrevious",
+        thresholdSeconds: 1 / opts.frameRate,
+      },
+    });
+
+    this.sampleId = opts.sampleId;
+    this.frameCount = opts.frameCount;
+    this.frameRate = opts.frameRate;
+    this.chunkSize = opts.chunkSize ?? DEFAULT_CHUNK_SIZE;
+    this.cache = new FrameBitmapCache<M>(opts.maxBytes);
+
+    // `createWorker` is field-independent (just `new Worker(url)`), so it's
+    // safe to call from the base constructor before subclass fields are set.
+    // `postInit` is deferred (see `ensureInit`) because it CAN read subclass
+    // fields (e.g. the native stream's `videoSrc`), which aren't assigned until
+    // the subclass constructor body runs after `super()`.
+    this.worker = this.createWorker();
+    this.worker.addEventListener("message", this.handleWorkerMessage);
+  }
+
+  // ---- subclass supplies the decode source -------------------------------
+
+  /** Construct the decode worker. MUST NOT read subclass fields. */
+  protected abstract createWorker(): Worker;
+
+  /** Send the source-specific `init` message. Runs on first fetch. */
+  protected abstract postInit(worker: Worker): void;
+
+  /** Build the `fetchChunk` `request` payload for `[start, start+n)`. */
+  protected abstract buildChunkRequest(
+    startFrame: number,
+    numFrames: number,
+  ): unknown;
+
+  /** Derive the cached meta from a `frameReady`. Default: the message's meta. */
+  protected toMeta(msg: FrameReadyMessage): M {
+    return (msg.meta ?? {}) as M;
+  }
+
+  /** Optional extra teardown (beyond terminating the worker). */
+  protected disposeSource(): void {}
+
+  // ---- shared machinery --------------------------------------------------
+
+  /** Total frames in the clip. */
+  get totalFrames(): number {
+    return this.frameCount;
+  }
+
+  /** Frame rate in fps. */
+  get fps(): number {
+    return this.frameRate;
+  }
+
+  /**
+   * Resolve once the frame containing `time` has been fetched + decoded. Use
+   * with `seek(time)` on mount so the first paint isn't a blank tile.
+   */
+  async warmup(time = 0): Promise<void> {
+    const frame = this.timeToFrame(time);
+    if (this.cache.has(frame) || this.failed.has(frame)) {
+      return;
+    }
+
+    const existing = this.inflight.get(frame);
+    if (existing) {
+      await existing.promise;
+      return;
+    }
+
+    this.requestChunkStartingAt(frame);
+    const entry = this.inflight.get(frame);
+    if (entry) {
+      await entry.promise;
+    }
+  }
+
+  /** Terminate the worker + free the cache. Call when the stream is replaced. */
+  destroy(): void {
+    if (this.destroyed) {
+      return;
+    }
+
+    this.destroyed = true;
+    this.disposeSource();
+
+    this.worker.removeEventListener("message", this.handleWorkerMessage);
+    this.worker.terminate();
+
+    // Settle anyone awaiting a frame that will never arrive.
+    for (const entry of this.inflight.values()) {
+      entry.resolve();
+    }
+    this.inflight.clear();
+    this.requestFrames.clear();
+    this.failed.clear();
+    this.cache.clear();
+  }
+
+  bufferState(time: number): BufferReadiness {
+    const frame = this.timeToFrame(time);
+
+    if (this.cache.has(frame)) {
+      return "ready";
+    }
+
+    // A terminally-failed frame reports "ready" (it just has no bitmap): the
+    // engine plays through to a blank frame instead of stalling forever and
+    // re-issuing prefetch every tick.
+    if (this.failed.has(frame)) {
+      return "ready";
+    }
+
+    if (this.inflight.has(frame)) {
+      return "loading";
+    }
+
+    return "missing";
+  }
+
+  prefetch(range: [number, number]): void {
+    const [startSec, endSec] = range;
+    const startFrame = this.timeToFrame(startSec);
+    const endFrame = this.timeToFrame(endSec);
+
+    // First missing frame wins — the engine re-calls prefetch as the playhead
+    // advances, so we don't fan out here.
+    for (let f = startFrame; f <= endFrame; f++) {
+      if (this.cache.has(f) || this.inflight.has(f) || this.failed.has(f)) {
+        continue;
+      }
+
+      this.requestChunkStartingAt(f);
+      return;
+    }
+  }
+
+  getValue(time: number): FrameBitmap | null {
+    const frame = this.timeToFrame(time);
+    const entry = this.cache.get(frame);
+    if (!entry) {
+      return null;
+    }
+
+    return {
+      bitmap: entry.bitmap,
+      frameNumber: frame,
+      sampleId: this.sampleId,
+    };
+  }
+
+  /**
+   * Dedupe by `frameNumber`. The engine ticks several times per frame; without
+   * dedupe each tick republishes an identical value and re-renders every
+   * consumer.
+   */
+  override onCommit(time: number, store: PlaybackStore): void {
+    const next = this.getValue(time);
+    const prev = this.readPublished(store);
+
+    if (prev && next && prev.frameNumber === next.frameNumber) {
+      return;
+    }
+
+    if (prev === null && next === null) {
+      return;
+    }
+
+    // Advancing to a new committed frame — proactively pull the next chunk into
+    // flight so it lands before the playhead reaches it (the engine only gives
+    // a 1-frame warning).
+    if (next) {
+      this.prefetch([time, time + this.lookaheadSeconds]);
+    }
+
+    this.publish(store, next);
+  }
+
+  bufferedRanges(): Array<[number, number]> {
+    return toSecondRanges(this.fetchedRanges, this.frameRate);
+  }
+
+  protected timeToFrame(time: number): number {
+    return frameAt(time, this.frameRate, this.frameCount);
+  }
+
+  private ensureInit(): void {
+    if (this.initialized) {
+      return;
+    }
+
+    this.initialized = true;
+    this.postInit(this.worker);
+  }
+
+  private requestChunkStartingAt(startFrame: number): void {
+    if (this.destroyed) {
+      return;
+    }
+
+    this.ensureInit();
+
+    const numFrames = Math.min(
+      this.chunkSize,
+      this.frameCount - startFrame + 1,
+    );
+    if (numFrames <= 0) {
+      return;
+    }
+
+    const reqId = this.nextReqId++;
+    const frames: number[] = [];
+    for (let f = startFrame; f < startFrame + numFrames; f++) {
+      // Skip frames the cache has, another request is fetching, or that failed
+      // terminally; the worker doesn't dedupe so we have to.
+      if (this.cache.has(f) || this.inflight.has(f) || this.failed.has(f)) {
+        continue;
+      }
+
+      this.inflight.set(f, createInflightEntry());
+      frames.push(f);
+    }
+
+    if (frames.length === 0) {
+      return;
+    }
+
+    this.requestFrames.set(reqId, frames);
+    this.worker.postMessage({
+      type: "fetchChunk",
+      reqId,
+      request: this.buildChunkRequest(startFrame, numFrames),
+    });
+  }
+
+  private handleWorkerMessage = (
+    event: MessageEvent<FrameWorkerOutbound>,
+  ): void => {
+    const msg = event.data;
+    switch (msg.type) {
+      case "frameReady":
+        this.onFrameReady(msg);
+        break;
+      case "chunkDone":
+        this.onChunkDone(msg);
+        break;
+      case "chunkFailed":
+        this.onChunkFailed(msg);
+        break;
+    }
+  };
+
+  private onFrameReady(msg: FrameReadyMessage): void {
+    // If the stream was destroyed between request and reply, the bitmap would
+    // leak — close it explicitly.
+    if (this.destroyed) {
+      msg.bitmap.close();
+      return;
+    }
+
+    this.cache.set(msg.frameNumber, {
+      bitmap: msg.bitmap,
+      width: msg.width,
+      height: msg.height,
+      meta: this.toMeta(msg),
+    });
+
+    const entry = this.inflight.get(msg.frameNumber);
+    if (entry) {
+      entry.resolve();
+      this.inflight.delete(msg.frameNumber);
+    }
+  }
+
+  private onChunkDone(msg: ChunkDoneMessage): void {
+    mergeRange(this.fetchedRanges, msg.range);
+    this.resolveOutstandingFrames(msg.reqId);
+  }
+
+  private onChunkFailed(msg: ChunkFailedMessage): void {
+    console.error(
+      `[FrameBitmapStream:${this.id}] worker chunk ${msg.reqId} failed: ${msg.error}`,
+    );
+    this.resolveOutstandingFrames(msg.reqId);
+  }
+
+  /**
+   * Settle any in-flight frames from this request that never received a
+   * `frameReady`. They're marked terminally `failed` so we never re-request
+   * them (else the engine, seeing them perpetually un-ready, re-prefetches
+   * every tick). Anyone awaiting `warmup` unblocks.
+   */
+  private resolveOutstandingFrames(reqId: number): void {
+    const frames = this.requestFrames.get(reqId);
+    if (!frames) {
+      return;
+    }
+
+    this.requestFrames.delete(reqId);
+
+    for (const f of frames) {
+      const entry = this.inflight.get(f);
+      if (!entry) {
+        continue;
+      }
+
+      this.failed.add(f);
+      entry.resolve();
+      this.inflight.delete(f);
+    }
+  }
+}
+
+function createInflightEntry(): InflightEntry {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+
+  return { promise, resolve };
+}

--- a/app/packages/video-annotation/src/streams/frameWorkerProtocol.ts
+++ b/app/packages/video-annotation/src/streams/frameWorkerProtocol.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+/**
+ * Wire protocol shared by every frame-decode worker (the `/frames` image
+ * worker and the WebCodecs video worker). Both decode source media off the
+ * main thread and transfer `ImageBitmap`s back zero-copy, keyed by 1-indexed
+ * presentation-order frame number — so the {@link FrameBitmapStream} base can
+ * drive either worker through one contract.
+ *
+ * The `init` payload is source-specific (the base's `postInit` supplies it),
+ * so this file only fixes the *shape* of `init` (a `type` tag) and leaves its
+ * fields to the concrete stream. `fetchChunk` carries an opaque `request` that
+ * the base builds via `buildChunkRequest`; the worker knows how to read it.
+ */
+
+/** main → worker: install fetch/demux context. Extended per source. */
+export interface InitMessage {
+  type: "init";
+}
+
+/** main → worker: decode frames `[startFrame, startFrame+numFrames)`. */
+export interface FetchChunkMessage {
+  type: "fetchChunk";
+  reqId: number;
+  /** Source-specific payload built by the stream's `buildChunkRequest`. */
+  request: unknown;
+}
+
+export type FrameWorkerInbound = InitMessage | FetchChunkMessage;
+
+/**
+ * worker → main: one decoded frame. `bitmap` is transferred (zero-copy), so
+ * the sender must not touch it afterwards. `meta` is stream-specific opaque
+ * payload the base hands to `toMeta` for caching (imavid: `{ src }`; native:
+ * `{ timestamp }`).
+ */
+export interface FrameReadyMessage {
+  type: "frameReady";
+  reqId: number;
+  /** 1-indexed presentation-order frame number. */
+  frameNumber: number;
+  bitmap: ImageBitmap;
+  width: number;
+  height: number;
+  meta?: unknown;
+}
+
+/** worker → main: every frame in a chunk has been processed (or skipped). */
+export interface ChunkDoneMessage {
+  type: "chunkDone";
+  reqId: number;
+  /** Inclusive `[startFrame, endFrame]` frame-number range this chunk covered. */
+  range: [number, number];
+}
+
+/** worker → main: a chunk failed at the top level (fetch / demux / decode). */
+export interface ChunkFailedMessage {
+  type: "chunkFailed";
+  reqId: number;
+  error: string;
+}
+
+export type FrameWorkerOutbound =
+  | FrameReadyMessage
+  | ChunkDoneMessage
+  | ChunkFailedMessage;

--- a/app/packages/video-annotation/src/streams/frameWorkerProtocol.ts
+++ b/app/packages/video-annotation/src/streams/frameWorkerProtocol.ts
@@ -62,7 +62,23 @@ export interface ChunkFailedMessage {
   error: string;
 }
 
+/**
+ * worker → main: the verdict of a `probeOnly` init — whether the source video
+ * is decodable via WebCodecs. Emitted only by the WebCodecs worker's probe
+ * branch (the decode-strategy resolver awaits it); the full-decode init and the
+ * `/frames` worker never send it.
+ */
+export interface CapabilityMessage {
+  type: "capability";
+  decodable: boolean;
+  /** Demuxed codec string when known (absent on fetch/demux failure). */
+  codec?: string;
+  /** Human-readable reason when not decodable (diagnostics). */
+  reason?: string;
+}
+
 export type FrameWorkerOutbound =
   | FrameReadyMessage
   | ChunkDoneMessage
-  | ChunkFailedMessage;
+  | ChunkFailedMessage
+  | CapabilityMessage;

--- a/app/packages/video-annotation/src/streams/framesWorker.ts
+++ b/app/packages/video-annotation/src/streams/framesWorker.ts
@@ -19,9 +19,13 @@
  *     { type: "fetchChunk", reqId, request }             // per chunk
  *
  *   worker → main:
- *     { type: "frameReady", reqId, frameNumber, src, bitmap, width, height }
+ *     { type: "frameReady", reqId, frameNumber, bitmap, width, height, meta: { src } }
  *     { type: "chunkDone", reqId, range }                // all frames in chunk processed
  *     { type: "chunkFailed", reqId, error }              // top-level fetch / parse failure
+ *
+ * The worker → main messages follow the shared {@link ./frameWorkerProtocol}
+ * so the `FrameBitmapStream` base can consume this and the WebCodecs worker
+ * through one contract.
  */
 
 /// <reference lib="webworker" />
@@ -31,9 +35,13 @@ import {
   getFrames,
   type GetFramesRequest,
 } from "../../../core/src/client/framesClient";
+import type {
+  FrameWorkerOutbound,
+  InitMessage as BaseInitMessage,
+} from "./frameWorkerProtocol";
 
-interface InitMessage {
-  type: "init";
+/** Source-specific `init` for the `/frames` worker: the fetch context. */
+interface InitMessage extends BaseInitMessage {
   origin: string;
   pathPrefix: string;
   headers: Record<string, string>;
@@ -46,33 +54,6 @@ interface FetchChunkMessage {
 }
 
 type InboundMessage = InitMessage | FetchChunkMessage;
-
-export interface FrameReadyMessage {
-  type: "frameReady";
-  reqId: number;
-  frameNumber: number;
-  src: string;
-  bitmap: ImageBitmap;
-  width: number;
-  height: number;
-}
-
-export interface ChunkDoneMessage {
-  type: "chunkDone";
-  reqId: number;
-  range: [number, number];
-}
-
-export interface ChunkFailedMessage {
-  type: "chunkFailed";
-  reqId: number;
-  error: string;
-}
-
-export type OutboundMessage =
-  | FrameReadyMessage
-  | ChunkDoneMessage
-  | ChunkFailedMessage;
 
 let initialized = false;
 let origin = "";
@@ -162,10 +143,10 @@ async function decodeAndDispatch(
       type: "frameReady",
       reqId,
       frameNumber: frame.frame_number,
-      src,
       bitmap,
       width: bitmap.width,
       height: bitmap.height,
+      meta: { src },
     },
     [bitmap],
   );
@@ -192,7 +173,10 @@ function joinUrl(origin: string, pathPrefix: string, suffix: string): string {
   return `${origin}${pathPrefix}${suffix}`.replace(/([^:]\/)\/+/g, "$1");
 }
 
-function postOutbound(msg: OutboundMessage, transfer?: Transferable[]): void {
+function postOutbound(
+  msg: FrameWorkerOutbound,
+  transfer?: Transferable[],
+): void {
   // self.postMessage's typing varies by lib; the cast is to the worker
   // DedicatedWorkerGlobalScope signature.
   (self as unknown as DedicatedWorkerGlobalScope).postMessage(

--- a/app/packages/video-annotation/src/streams/imaVidImageStreamHandle.ts
+++ b/app/packages/video-annotation/src/streams/imaVidImageStreamHandle.ts
@@ -1,7 +1,10 @@
 import { createStreamHandle } from "./createStreamHandle";
-import type { ImaVidImageStream } from "./ImaVidImageStream";
+import type { FrameBitmapStream } from "./frameBitmapStream";
 
-const { useStream, usePublishStream } = createStreamHandle<ImaVidImageStream>();
+// Typed to the base so either backing stream (the `/frames` ImaVidImageStream
+// or the WebCodecs NativeVideoFrameStream) can be published/consumed — the tile
+// and SAM2 consumers only touch base methods (getValue/warmup/fps/totalFrames).
+const { useStream, usePublishStream } = createStreamHandle<FrameBitmapStream>();
 
 /**
  * Active ImaVid image stream (decoded per-frame bitmaps). Published so

--- a/app/packages/video-annotation/src/streams/mp4box.d.ts
+++ b/app/packages/video-annotation/src/streams/mp4box.d.ts
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+/**
+ * Focused ambient shim for mp4box 2.4.1. The package ships real types, but its
+ * `main`/`types` fields point at files that only exist under the `exports`
+ * map, which classic (`node`) module resolution — what this repo's TS is
+ * pinned to — doesn't read. Vite resolves the package fine at runtime via
+ * `exports`; this only covers the demux surface {@link ./videoDecodeWorker}
+ * uses so type-checking resolves too.
+ */
+declare module "mp4box" {
+  /** A demuxed sample (one frame of encoded video). */
+  export interface Sample {
+    /** Composition (presentation) timestamp, in track timescale units. */
+    cts: number;
+    /** Decode timestamp, in track timescale units. */
+    dts: number;
+    /** Sample duration, in track timescale units. */
+    duration: number;
+    /** True for sync (keyframe) samples. */
+    is_sync: boolean;
+    /** Encoded bytes. Present once extraction is enabled. */
+    data?: Uint8Array;
+    /** Sample number (decode order, 1-indexed). */
+    number: number;
+    size: number;
+    timescale: number;
+    track_id: number;
+  }
+
+  export interface Track {
+    id: number;
+    /** RFC 6381 codec string, e.g. `"avc1.640028"`. */
+    codec: string;
+    nb_samples: number;
+    timescale: number;
+    track_width: number;
+    track_height: number;
+    type?: "audio" | "video" | "subtitles" | "metadata";
+  }
+
+  export interface Movie {
+    videoTracks: Track[];
+    audioTracks: Track[];
+    tracks: Track[];
+    duration: number;
+    timescale: number;
+  }
+
+  export interface ISOFile {
+    onReady?: (info: Movie) => void;
+    onError?: (error: string) => void;
+    onSamples?: (id: number, user: unknown, samples: Sample[]) => void;
+    setExtractionOptions(
+      id: number,
+      user?: unknown,
+      options?: { nbSamples?: number },
+    ): void;
+    start(): void;
+    stop(): void;
+    flush(): void;
+    appendBuffer(data: MP4BoxBuffer, last?: boolean): number;
+    getTrackById(id: number): unknown;
+  }
+
+  export function createFile(keepMdatData?: boolean): ISOFile;
+
+  export class MP4BoxBuffer extends ArrayBuffer {
+    fileStart: number;
+    static fromArrayBuffer(
+      buffer: ArrayBufferLike,
+      fileStart: number,
+    ): MP4BoxBuffer;
+  }
+
+  export class DataStream {
+    constructor(
+      arrayBuffer?: ArrayBuffer | number,
+      byteOffset?: number,
+      endianness?: number,
+    );
+    get buffer(): ArrayBuffer;
+    get byteLength(): number;
+  }
+}

--- a/app/packages/video-annotation/src/streams/mp4box.d.ts
+++ b/app/packages/video-annotation/src/streams/mp4box.d.ts
@@ -25,6 +25,8 @@ declare module "mp4box" {
     data?: Uint8Array;
     /** Sample number (decode order, 1-indexed). */
     number: number;
+    /** Absolute byte offset of the sample in the file (from `stbl`, moov-only). */
+    offset: number;
     size: number;
     timescale: number;
     track_id: number;
@@ -63,6 +65,12 @@ declare module "mp4box" {
     flush(): void;
     appendBuffer(data: MP4BoxBuffer, last?: boolean): number;
     getTrackById(id: number): unknown;
+    /**
+     * The full sample table for a track (offset/size/cts/dts/is_sync per
+     * sample), computed from the `moov`'s `stbl` — available after `onReady`
+     * without the `mdat` bytes. This is what lets decode range-fetch samples.
+     */
+    getTrackSamplesInfo(id: number): Sample[];
   }
 
   export function createFile(keepMdatData?: boolean): ISOFile;

--- a/app/packages/video-annotation/src/streams/probeNativeDecode.ts
+++ b/app/packages/video-annotation/src/streams/probeNativeDecode.ts
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import type {
+  CapabilityMessage,
+  FrameWorkerOutbound,
+} from "./frameWorkerProtocol";
+
+/** The answer to "can WebCodecs decode this source video on demand?". */
+export interface NativeDecodeProbeResult {
+  decodable: boolean;
+  /** Demuxed codec string when known. */
+  codec?: string;
+  /** Why not, when `decodable` is false (diagnostics). */
+  reason?: string;
+}
+
+/** Give up (report not-decodable) if the probe hasn't answered by now. */
+const PROBE_TIMEOUT_MS = 15_000;
+
+/**
+ * Probe whether `videoSrc` is decodable via WebCodecs, without mounting
+ * anything. Spins up the WebCodecs worker in `probeOnly` mode — it streams only
+ * far enough to demux the `moov` and run `isConfigSupported`, then this
+ * terminates it. Cheap (a few hundred KB for faststart files) and keeps mp4box
+ * in the worker chunk.
+ *
+ * Never rejects: any failure (fetch, demux, unsupported codec, timeout, worker
+ * error, abort) resolves to `{ decodable: false }` so the resolver can fall
+ * through. The caller should memoize the result (see `nativeDecodeCache`).
+ */
+export function probeNativeDecode(
+  videoSrc: string,
+  opts: { headers?: Record<string, string>; signal?: AbortSignal } = {},
+): Promise<NativeDecodeProbeResult> {
+  return new Promise((resolve) => {
+    const worker = new Worker(
+      new URL("./videoDecodeWorker.ts", import.meta.url),
+      { type: "module" },
+    );
+
+    let settled = false;
+
+    const finish = (result: NativeDecodeProbeResult) => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      clearTimeout(timer);
+      worker.removeEventListener("message", onMessage);
+      worker.removeEventListener("error", onError);
+      opts.signal?.removeEventListener("abort", onAbort);
+      worker.terminate();
+      resolve(result);
+    };
+
+    const onMessage = (event: MessageEvent<FrameWorkerOutbound>) => {
+      if (event.data?.type === "capability") {
+        const msg = event.data as CapabilityMessage;
+        finish({
+          decodable: msg.decodable,
+          codec: msg.codec,
+          reason: msg.reason,
+        });
+      }
+    };
+
+    const onError = () => finish({ decodable: false, reason: "worker error" });
+    const onAbort = () => finish({ decodable: false, reason: "aborted" });
+
+    const timer = setTimeout(
+      () => finish({ decodable: false, reason: "probe timeout" }),
+      PROBE_TIMEOUT_MS,
+    );
+
+    worker.addEventListener("message", onMessage);
+    worker.addEventListener("error", onError);
+    opts.signal?.addEventListener("abort", onAbort);
+
+    if (opts.signal?.aborted) {
+      onAbort();
+      return;
+    }
+
+    worker.postMessage({
+      type: "init",
+      videoSrc,
+      headers: opts.headers,
+      probeOnly: true,
+    });
+  });
+}

--- a/app/packages/video-annotation/src/streams/videoByteRange.test.ts
+++ b/app/packages/video-annotation/src/streams/videoByteRange.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  ByteRangeCache,
+  type ByteRange,
+  type SampleLocation,
+  classifyRangeResponse,
+  parseContentRangeStart,
+  rangeRequestHeader,
+  sliceSampleBytes,
+  spanByteRange,
+} from "./videoByteRange";
+
+/** A sample table: sizes chosen so offsets are easy to reason about. */
+const SAMPLES: SampleLocation[] = [
+  { offset: 100, size: 50 }, // [100, 150)
+  { offset: 150, size: 20 }, // [150, 170)
+  { offset: 170, size: 30 }, // [170, 200)
+  { offset: 200, size: 10 }, // [200, 210)
+];
+
+describe("spanByteRange", () => {
+  it("covers a single sample exactly", () => {
+    expect(spanByteRange(SAMPLES, 0, 0)).toEqual({ start: 100, end: 150 });
+  });
+
+  it("covers a contiguous span from first offset to last end", () => {
+    expect(spanByteRange(SAMPLES, 1, 3)).toEqual({ start: 150, end: 210 });
+  });
+
+  it("is order-agnostic in its index arguments", () => {
+    expect(spanByteRange(SAMPLES, 3, 1)).toEqual({ start: 150, end: 210 });
+  });
+
+  it("clamps indices to the array bounds", () => {
+    expect(spanByteRange(SAMPLES, -5, 99)).toEqual({ start: 100, end: 210 });
+  });
+
+  it("takes min offset / max end when samples are not offset-sorted", () => {
+    const unsorted: SampleLocation[] = [
+      { offset: 500, size: 10 }, // [500, 510)
+      { offset: 100, size: 40 }, // [100, 140)
+      { offset: 300, size: 10 }, // [300, 310)
+    ];
+    // Superset span across an out-of-order (interleaved) mdat.
+    expect(spanByteRange(unsorted, 0, 2)).toEqual({ start: 100, end: 510 });
+  });
+
+  it("skips holes (missing entries) in the span", () => {
+    const sparse = [
+      { offset: 100, size: 50 },
+      undefined,
+      { offset: 200, size: 10 },
+    ] as unknown as SampleLocation[];
+    expect(spanByteRange(sparse, 0, 2)).toEqual({ start: 100, end: 210 });
+  });
+
+  it("returns null for an empty table", () => {
+    expect(spanByteRange([], 0, 5)).toBeNull();
+  });
+});
+
+describe("rangeRequestHeader", () => {
+  it("formats an inclusive-end HTTP byte range", () => {
+    // [150, 210) exclusive-end → bytes=150-209 inclusive-end.
+    expect(rangeRequestHeader({ start: 150, end: 210 })).toBe("bytes=150-209");
+  });
+
+  it("formats a single-byte range", () => {
+    expect(rangeRequestHeader({ start: 0, end: 1 })).toBe("bytes=0-0");
+  });
+});
+
+describe("parseContentRangeStart", () => {
+  it("reads the start offset from a well-formed header", () => {
+    expect(parseContentRangeStart("bytes 200-999/12345")).toBe(200);
+  });
+
+  it("handles an unknown total size (`*`)", () => {
+    expect(parseContentRangeStart("bytes 200-999/*")).toBe(200);
+  });
+
+  it("returns null for null / empty", () => {
+    expect(parseContentRangeStart(null)).toBeNull();
+    expect(parseContentRangeStart(undefined)).toBeNull();
+    expect(parseContentRangeStart("")).toBeNull();
+  });
+
+  it("returns null for a non-byte or malformed unit", () => {
+    expect(parseContentRangeStart("items 0-1/2")).toBeNull();
+    expect(parseContentRangeStart("bytes */12345")).toBeNull();
+  });
+});
+
+describe("classifyRangeResponse", () => {
+  it("maps 206 to a range body", () => {
+    expect(classifyRangeResponse(206)).toBe("range");
+  });
+
+  it("maps 200 to a whole-file body", () => {
+    expect(classifyRangeResponse(200)).toBe("whole");
+  });
+
+  it("rejects any other status (e.g. 416, 500)", () => {
+    expect(classifyRangeResponse(416)).toBe("reject");
+    expect(classifyRangeResponse(500)).toBe("reject");
+  });
+});
+
+describe("sliceSampleBytes", () => {
+  /** A 20-byte buffer whose byte `i` holds value `i`. */
+  const buf = (() => {
+    const b = new Uint8Array(20);
+    b.forEach((_, i) => (b[i] = i));
+    return b.buffer;
+  })();
+
+  it("slices from a whole-file buffer (fileStart 0)", () => {
+    const bytes = sliceSampleBytes(buf, 0, { offset: 4, size: 3 });
+    expect(Array.from(bytes)).toEqual([4, 5, 6]);
+  });
+
+  it("slices from a 206 range buffer (nonzero fileStart)", () => {
+    // Buffer covers file bytes [10, 30); sample at file offset 12.
+    const bytes = sliceSampleBytes(buf, 10, { offset: 12, size: 2 });
+    expect(Array.from(bytes)).toEqual([2, 3]);
+  });
+
+  it("throws when the sample starts before the buffer", () => {
+    expect(() => sliceSampleBytes(buf, 10, { offset: 8, size: 2 })).toThrow(
+      /outside/,
+    );
+  });
+
+  it("throws when the sample runs past the buffer end", () => {
+    expect(() => sliceSampleBytes(buf, 0, { offset: 18, size: 5 })).toThrow(
+      /outside/,
+    );
+  });
+});
+
+describe("ByteRangeCache", () => {
+  const r = (start: number, end: number): ByteRange => ({ start, end });
+  const ab = (n: number): ArrayBuffer => new ArrayBuffer(n);
+
+  it("misses then hits an exact range", () => {
+    const cache = new ByteRangeCache(1000);
+    expect(cache.get(r(0, 100))).toBeUndefined();
+
+    const buffer = ab(100);
+    cache.set(r(0, 100), buffer);
+    expect(cache.get(r(0, 100))).toBe(buffer);
+  });
+
+  it("keys on the exact range (a different span misses)", () => {
+    const cache = new ByteRangeCache(1000);
+    cache.set(r(0, 100), ab(100));
+    expect(cache.get(r(0, 99))).toBeUndefined();
+    expect(cache.get(r(1, 100))).toBeUndefined();
+  });
+
+  it("tracks total bytes and entry count", () => {
+    const cache = new ByteRangeCache(1000);
+    cache.set(r(0, 100), ab(100));
+    cache.set(r(100, 250), ab(150));
+    expect(cache.sizeBytes).toBe(250);
+    expect(cache.count).toBe(2);
+  });
+
+  it("evicts least-recently-used entries past the budget", () => {
+    const cache = new ByteRangeCache(250);
+    cache.set(r(0, 100), ab(100)); // LRU
+    cache.set(r(100, 200), ab(100));
+    cache.set(r(200, 300), ab(100)); // 300 > 250 → evict oldest (0-100)
+
+    expect(cache.get(r(0, 100))).toBeUndefined();
+    expect(cache.get(r(100, 200))).toBeDefined();
+    expect(cache.get(r(200, 300))).toBeDefined();
+    expect(cache.sizeBytes).toBe(200);
+  });
+
+  it("a hit refreshes recency so a later insert evicts the other entry", () => {
+    const cache = new ByteRangeCache(250);
+    cache.set(r(0, 100), ab(100));
+    cache.set(r(100, 200), ab(100));
+
+    // Touch the older entry → now (100,200) is the LRU.
+    expect(cache.get(r(0, 100))).toBeDefined();
+
+    cache.set(r(200, 300), ab(100)); // evicts LRU = (100,200)
+    expect(cache.get(r(0, 100))).toBeDefined();
+    expect(cache.get(r(100, 200))).toBeUndefined();
+    expect(cache.get(r(200, 300))).toBeDefined();
+  });
+
+  it("replacing a key updates size without double-counting", () => {
+    const cache = new ByteRangeCache(1000);
+    cache.set(r(0, 100), ab(100));
+    cache.set(r(0, 100), ab(60));
+    expect(cache.count).toBe(1);
+    expect(cache.sizeBytes).toBe(60);
+    expect(cache.get(r(0, 100))?.byteLength).toBe(60);
+  });
+
+  it("declines to cache a buffer larger than the whole budget", () => {
+    const cache = new ByteRangeCache(100);
+    cache.set(r(0, 200), ab(200));
+    expect(cache.get(r(0, 200))).toBeUndefined();
+    expect(cache.sizeBytes).toBe(0);
+    expect(cache.count).toBe(0);
+  });
+});

--- a/app/packages/video-annotation/src/streams/videoByteRange.ts
+++ b/app/packages/video-annotation/src/streams/videoByteRange.ts
@@ -1,0 +1,215 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+/**
+ * Pure chunking/streaming helpers for range-based video fetching.
+ *
+ * The native decode worker parses the `moov` (sample table) up front, then
+ * fetches only the byte ranges a chunk's GOP needs via HTTP `Range` requests,
+ * so it never loads the whole source video into memory. This module holds the
+ * arithmetic and response-shape logic for that — deliberately free of `fetch`,
+ * workers, and mp4box so it is exhaustively unit-testable; the worker wires
+ * these into the network + decoder.
+ */
+
+/** The byte location of one encoded sample within the source file. */
+export interface SampleLocation {
+  /** Absolute byte offset of the sample in the file. */
+  offset: number;
+  /** Encoded byte length of the sample. */
+  size: number;
+}
+
+/** A half-open byte range `[start, end)` within the source file. */
+export interface ByteRange {
+  /** First byte, inclusive. */
+  start: number;
+  /** One past the last byte, exclusive. */
+  end: number;
+}
+
+/**
+ * Smallest byte range covering samples `[startIndex, endIndex]` (inclusive,
+ * order-agnostic) of `samples`. Since a GOP's samples are usually — but not
+ * always — contiguous in `mdat`, we take the min offset → max end across the
+ * span; fetching a superset (a few interleaved non-video bytes) is harmless.
+ * Returns `null` when the span covers no samples.
+ */
+export function spanByteRange(
+  samples: readonly SampleLocation[],
+  startIndex: number,
+  endIndex: number,
+): ByteRange | null {
+  const lo = Math.max(0, Math.min(startIndex, endIndex));
+  const hi = Math.min(samples.length - 1, Math.max(startIndex, endIndex));
+
+  let start = Number.POSITIVE_INFINITY;
+  let end = -1;
+  for (let i = lo; i <= hi; i++) {
+    const s = samples[i];
+    if (!s) {
+      continue;
+    }
+
+    start = Math.min(start, s.offset);
+    end = Math.max(end, s.offset + s.size);
+  }
+
+  if (end < 0) {
+    return null;
+  }
+
+  return { start, end };
+}
+
+/** The `Range` request header value for a byte range (`bytes=start-lastByte`). */
+export function rangeRequestHeader(range: ByteRange): string {
+  return `bytes=${range.start}-${range.end - 1}`;
+}
+
+/**
+ * The absolute file offset the body of a `206` response starts at, read from
+ * its `Content-Range` (`bytes 200-999/12345`). Returns `null` when the header
+ * is absent or unparseable, so the caller can fall back to the offset it asked
+ * for.
+ */
+export function parseContentRangeStart(
+  header: string | null | undefined,
+): number | null {
+  if (!header) {
+    return null;
+  }
+
+  const match = /bytes\s+(\d+)-(\d+)\//i.exec(header);
+  if (!match) {
+    return null;
+  }
+
+  return Number(match[1]);
+}
+
+/** What a media response's status means for range fetching. */
+export type RangeResponseKind =
+  /** `206` — the body is exactly the requested range. */
+  | "range"
+  /** `200` — the server ignored `Range` and returned the whole file. */
+  | "whole"
+  /** Anything else (e.g. `416`) — give up on ranges, fetch whole-file. */
+  | "reject";
+
+/** Classify a media response status for the range-fetch state machine. */
+export function classifyRangeResponse(status: number): RangeResponseKind {
+  if (status === 206) {
+    return "range";
+  }
+
+  if (status === 200) {
+    return "whole";
+  }
+
+  return "reject";
+}
+
+/**
+ * View of one sample's encoded bytes within a fetched buffer. `bufferFileStart`
+ * is the buffer's absolute file offset (`0` for a whole-file body, the range
+ * start for a `206` body). Throws when the sample falls outside the buffer —
+ * that means the fetched range didn't actually cover it (a bug, not a
+ * recoverable state).
+ */
+export function sliceSampleBytes(
+  buffer: ArrayBuffer,
+  bufferFileStart: number,
+  sample: SampleLocation,
+): Uint8Array {
+  const localStart = sample.offset - bufferFileStart;
+  const localEnd = localStart + sample.size;
+
+  if (localStart < 0 || localEnd > buffer.byteLength) {
+    throw new Error(
+      `sample [${sample.offset}, ${sample.offset + sample.size}) outside ` +
+        `fetched buffer [${bufferFileStart}, ` +
+        `${bufferFileStart + buffer.byteLength})`,
+    );
+  }
+
+  return new Uint8Array(buffer, localStart, sample.size);
+}
+
+/**
+ * A tiny LRU of fetched byte ranges, bounded by a total-bytes budget. Keyed by
+ * the exact range, so it pays off when the base re-requests an identical chunk
+ * span after its decoded bitmaps were evicted — cheap insurance against
+ * re-downloading a GOP during long playback. Encoded GOP spans are small next
+ * to the decoded-bitmap LRU, so the budget stays modest.
+ */
+export class ByteRangeCache {
+  private readonly budgetBytes: number;
+  private totalBytes = 0;
+  /** Insertion-ordered; a hit re-inserts to mark most-recently-used. */
+  private readonly entries = new Map<string, ArrayBuffer>();
+
+  constructor(budgetBytes: number) {
+    this.budgetBytes = budgetBytes;
+  }
+
+  private static key(range: ByteRange): string {
+    return `${range.start}-${range.end}`;
+  }
+
+  /** Cached bytes for an exact range, or `undefined`. Marks the entry MRU. */
+  get(range: ByteRange): ArrayBuffer | undefined {
+    const key = ByteRangeCache.key(range);
+    const buffer = this.entries.get(key);
+    if (!buffer) {
+      return undefined;
+    }
+
+    this.entries.delete(key);
+    this.entries.set(key, buffer);
+    return buffer;
+  }
+
+  /** Cache bytes for a range, evicting LRU entries to stay within budget. */
+  set(range: ByteRange, buffer: ArrayBuffer): void {
+    const key = ByteRangeCache.key(range);
+    const existing = this.entries.get(key);
+    if (existing) {
+      this.totalBytes -= existing.byteLength;
+      this.entries.delete(key);
+    }
+
+    // A buffer larger than the whole budget would evict everything and still
+    // not fit — don't bother caching it.
+    if (buffer.byteLength > this.budgetBytes) {
+      return;
+    }
+
+    this.entries.set(key, buffer);
+    this.totalBytes += buffer.byteLength;
+    this.evict();
+  }
+
+  private evict(): void {
+    while (this.totalBytes > this.budgetBytes && this.entries.size > 0) {
+      const oldest = this.entries.keys().next().value as string;
+      const buffer = this.entries.get(oldest);
+      if (buffer) {
+        this.totalBytes -= buffer.byteLength;
+      }
+
+      this.entries.delete(oldest);
+    }
+  }
+
+  /** Bytes currently held. */
+  get sizeBytes(): number {
+    return this.totalBytes;
+  }
+
+  /** Number of ranges currently cached. */
+  get count(): number {
+    return this.entries.size;
+  }
+}

--- a/app/packages/video-annotation/src/streams/videoDecodeWorker.ts
+++ b/app/packages/video-annotation/src/streams/videoDecodeWorker.ts
@@ -1,0 +1,506 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+/// <reference lib="webworker" />
+/// <reference types="dom-webcodecs" />
+
+/**
+ * WebCodecs video-decode worker. Demuxes the source video with mp4box.js,
+ * then decodes frames on demand with a `VideoDecoder`, transferring each
+ * decoded frame back as an `ImageBitmap` (zero-copy) keyed by 1-indexed
+ * presentation-order frame number. Same wire protocol as the `/frames` image
+ * worker (see {@link ./frameWorkerProtocol}) so the {@link FrameBitmapStream}
+ * base can drive either.
+ *
+ * Why a worker: demux + decode + `createImageBitmap` all run off the main
+ * thread, and bitmaps transfer without a copy — the tile just `drawImage`s
+ * them. This gives ImaVid-style, single-clock lock-step playback WITHOUT the
+ * `to_frames` preprocessing/storage cost.
+ *
+ * Frame-exactness (the load-bearing property): the demuxer's sample table maps
+ * each frame's presentation timestamp (`cts`) to a 1-indexed frame number. We
+ * stamp every `EncodedVideoChunk` with that timestamp; the decoder echoes it
+ * onto the output `VideoFrame`, so we can assign the correct frame number on
+ * the way out regardless of decode order (B-frames) or GOP boundaries.
+ *
+ * GOP handling lives entirely here (the stream base stays source-agnostic): a
+ * chunk request for presentation frames `[start, start+n)` is snapped back to
+ * the keyframe at/-before the earliest of those frames in DECODE order, and we
+ * decode forward through the latest. Lead-in frames are emitted as bonus —
+ * they're already decoded and help scrub-back.
+ *
+ * Scope: MP4 / H.264 first (mp4box + the common `avcC`/`hvcC`/`av1C`/`vpcC`
+ * description boxes). Other containers/codecs are follow-ons gated on
+ * `VideoDecoder.isConfigSupported`.
+ */
+
+import { createFile, DataStream, MP4BoxBuffer } from "mp4box";
+import type { ISOFile, Movie, Sample } from "mp4box";
+import type {
+  FetchChunkMessage,
+  FrameWorkerInbound,
+  FrameWorkerOutbound,
+  InitMessage,
+} from "./frameWorkerProtocol";
+
+interface NativeInitMessage extends InitMessage {
+  /** Resolved media URL for the source video. */
+  videoSrc: string;
+  /** Extra headers for the media fetch (auth); usually none for presigned. */
+  headers?: Record<string, string>;
+  /** Phase-1 frame-exactness instrumentation. */
+  debug?: boolean;
+}
+
+/** The `request` payload the native stream's `buildChunkRequest` produces. */
+interface NativeChunkRequest {
+  startFrame: number;
+  numFrames: number;
+}
+
+/** A demuxed sample, enriched with the mappings decode needs. */
+interface DemuxedSample {
+  /** 1-indexed presentation-order frame number. */
+  frameNumber: number;
+  /** Position in decode order (index into `decodeOrder`). */
+  decodeIndex: number;
+  /** Presentation timestamp in integer microseconds (chunk/frame key). */
+  tsMicros: number;
+  /** Sample duration in microseconds. */
+  durMicros: number;
+  isSync: boolean;
+  data: Uint8Array;
+}
+
+let debug = false;
+
+/** Samples in decode order (as delivered by the demuxer). */
+let decodeOrder: DemuxedSample[] = [];
+/** Samples by 1-indexed presentation frame number (`[frame - 1]`). */
+let byFrameNumber: DemuxedSample[] = [];
+/** Decode-order indices of sync (keyframe) samples, ascending. */
+let keyframeIndices: number[] = [];
+/** Presentation-timestamp (µs) → 1-indexed frame number. */
+const microsToFrame = new Map<number, number>();
+let config: VideoDecoderConfig | null = null;
+let totalFrames = 0;
+
+let ready = false;
+let unsupportedReason: string | null = null;
+
+/** Chunk requests that arrived before demux finished. */
+const pendingChunks: FetchChunkMessage[] = [];
+
+let decoder: VideoDecoder | null = null;
+
+/** The chunk decode currently in flight; output callback reads it. */
+interface Job {
+  reqId: number;
+  startFrame: number;
+  endFrame: number;
+  kf: number;
+  dEnd: number;
+  pending: Promise<void>[];
+}
+let currentJob: Job | null = null;
+/** Serializes decode jobs — the decoder is single, stateful. */
+let jobChain: Promise<void> = Promise.resolve();
+
+self.addEventListener("message", (event: MessageEvent<FrameWorkerInbound>) => {
+  const msg = event.data;
+
+  switch (msg.type) {
+    case "init":
+      void handleInit(msg as NativeInitMessage);
+      break;
+
+    case "fetchChunk":
+      handleFetchChunk(msg);
+      break;
+  }
+});
+
+async function handleInit(msg: NativeInitMessage): Promise<void> {
+  debug = msg.debug ?? false;
+
+  try {
+    const bytes = await fetchVideoBytes(msg.videoSrc, msg.headers);
+    await demux(bytes);
+  } catch (error) {
+    // Demux/fetch failure is terminal for this source: fail everything queued
+    // so the stream marks those frames failed and (later) falls back.
+    unsupportedReason = errorMessage(error);
+    ready = true;
+    drainPending();
+
+    return;
+  }
+
+  ready = true;
+  drainPending();
+}
+
+async function fetchVideoBytes(
+  videoSrc: string,
+  headers?: Record<string, string>,
+): Promise<ArrayBuffer> {
+  // Match `<video src>` semantics: default credentials, cors. Whole-file fetch
+  // for now — mp4box parses progressively, so byte-range streaming is a later
+  // optimization (see design §5).
+  const resp = await fetch(videoSrc, { mode: "cors", headers });
+  if (!resp.ok) {
+    throw new Error(`video fetch failed: ${resp.status}`);
+  }
+
+  return resp.arrayBuffer();
+}
+
+/**
+ * Demux `bytes` into a sample table + a `VideoDecoderConfig`. Builds the
+ * presentation-order frame numbering and the µs→frame map decode assigns by.
+ */
+async function demux(bytes: ArrayBuffer): Promise<void> {
+  const file = createFile();
+  const collected: Sample[] = [];
+  let videoTrack: Movie["videoTracks"][number] | null = null;
+  let readyError: string | null = null;
+
+  file.onError = (error: string) => {
+    readyError = error;
+  };
+
+  file.onReady = (info: Movie) => {
+    const track = info.videoTracks[0];
+    if (!track) {
+      readyError = "no video track";
+      return;
+    }
+
+    videoTrack = track;
+    config = buildDecoderConfig(file, track);
+    // Request every sample in one shot; `flush` forces delivery of the tail.
+    file.setExtractionOptions(track.id, null, { nbSamples: track.nb_samples });
+    file.start();
+  };
+
+  file.onSamples = (_id: number, _user: unknown, samples: Sample[]) => {
+    for (const s of samples) {
+      collected.push(s);
+    }
+  };
+
+  const mbuf = MP4BoxBuffer.fromArrayBuffer(bytes, 0);
+  file.appendBuffer(mbuf, true);
+  file.flush();
+
+  if (readyError) {
+    throw new Error(readyError);
+  }
+
+  if (!videoTrack || !config) {
+    throw new Error("demux produced no video track / decoder config");
+  }
+
+  if (collected.length === 0) {
+    throw new Error("demux produced no samples");
+  }
+
+  if (debug) {
+    const d = config.description as Uint8Array | undefined;
+    const head = d ? Array.from(d.slice(0, 6)) : null;
+    log(
+      `config: codec=${config.codec} ${config.codedWidth}x${config.codedHeight} ` +
+        `descLen=${d?.byteLength ?? "none"} descHead=${JSON.stringify(head)}`,
+    );
+  }
+
+  const support = await VideoDecoder.isConfigSupported(config);
+  if (debug) {
+    log(`isConfigSupported => ${JSON.stringify(support?.supported)}`);
+  }
+  if (!support.supported) {
+    throw new Error(`codec unsupported: ${config.codec}`);
+  }
+
+  buildSampleTable(
+    collected,
+    (videoTrack as Movie["videoTracks"][number]).timescale,
+  );
+}
+
+/**
+ * Turn raw demuxed samples into `decodeOrder` (decode order, as delivered),
+ * assign each its 1-indexed presentation frame number (sort by `cts`), and
+ * build the µs→frame map + keyframe index list.
+ */
+function buildSampleTable(samples: Sample[], timescale: number): void {
+  decodeOrder = samples.map((s, decodeIndex) => ({
+    frameNumber: 0, // filled below once we know presentation order
+    decodeIndex,
+    tsMicros: Math.round((s.cts * 1e6) / timescale),
+    durMicros: Math.round((s.duration * 1e6) / timescale),
+    isSync: Boolean(s.is_sync),
+    data: (s.data ?? new Uint8Array(0)) as Uint8Array,
+  }));
+
+  // Presentation order = ascending composition timestamp. 1-indexed frame
+  // numbers match `to_frames` / looker's ImaVid numbering (frame 1 = t≈0).
+  byFrameNumber = [...decodeOrder].sort((a, b) => a.tsMicros - b.tsMicros);
+  byFrameNumber.forEach((sample, i) => {
+    sample.frameNumber = i + 1;
+    microsToFrame.set(sample.tsMicros, sample.frameNumber);
+  });
+
+  keyframeIndices = decodeOrder
+    .filter((s) => s.isSync)
+    .map((s) => s.decodeIndex);
+
+  totalFrames = decodeOrder.length;
+
+  if (debug) {
+    log(
+      `demux ok: ${totalFrames} frames, ${keyframeIndices.length} keyframes, ` +
+        `codec=${config?.codec}`,
+    );
+  }
+}
+
+/**
+ * Extract the codec-private description (`avcC`/`hvcC`/`av1C`/`vpcC`) for the
+ * `VideoDecoderConfig`. Walks the sample-description box tree; casts through
+ * `any` because these are dynamic box shapes mp4box doesn't statically type.
+ */
+function buildDecoderConfig(
+  file: ISOFile,
+  track: Movie["videoTracks"][number],
+): VideoDecoderConfig {
+  const config: VideoDecoderConfig = {
+    codec: track.codec,
+    codedWidth: track.track_width,
+    codedHeight: track.track_height,
+    // Random access decodes short spans from a keyframe; low latency helps.
+    optimizeForLatency: true,
+  };
+
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  const trak = file.getTrackById(track.id) as any;
+  const entries: any[] = trak?.mdia?.minf?.stbl?.stsd?.entries ?? [];
+
+  for (const entry of entries) {
+    const box = entry.avcC ?? entry.hvcC ?? entry.av1C ?? entry.vpcC;
+    if (!box) {
+      continue;
+    }
+
+    const stream = new DataStream(undefined, 0);
+    box.write(stream);
+    // Drop the 8-byte box header (size + fourcc); WebCodecs wants the payload.
+    config.description = new Uint8Array(stream.buffer, 8);
+    break;
+  }
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+
+  return config;
+}
+
+function handleFetchChunk(msg: FetchChunkMessage): void {
+  if (!ready) {
+    pendingChunks.push(msg);
+    return;
+  }
+
+  if (unsupportedReason) {
+    postFailed(msg.reqId, unsupportedReason);
+    return;
+  }
+
+  enqueueJob(msg);
+}
+
+function drainPending(): void {
+  const queued = pendingChunks.splice(0, pendingChunks.length);
+  for (const msg of queued) {
+    handleFetchChunk(msg);
+  }
+}
+
+/** Chain a chunk decode after any in-flight one (the decoder is single). */
+function enqueueJob(msg: FetchChunkMessage): void {
+  jobChain = jobChain
+    .then(() => runJob(msg))
+    .catch((error) => {
+      postFailed(msg.reqId, errorMessage(error));
+    });
+}
+
+async function runJob(msg: FetchChunkMessage): Promise<void> {
+  const request = msg.request as NativeChunkRequest;
+  const startFrame = request.startFrame;
+  const endFrame = Math.min(startFrame + request.numFrames - 1, totalFrames);
+
+  // Presentation range → decode-order span → keyframe snap.
+  let dStart = Number.POSITIVE_INFINITY;
+  let dEnd = -1;
+  for (let frame = startFrame; frame <= endFrame; frame++) {
+    const sample = byFrameNumber[frame - 1];
+    if (!sample) {
+      continue;
+    }
+
+    dStart = Math.min(dStart, sample.decodeIndex);
+    dEnd = Math.max(dEnd, sample.decodeIndex);
+  }
+
+  if (dEnd < 0) {
+    // Nothing to decode (out-of-range request) — settle the chunk cleanly.
+    post({
+      type: "chunkDone",
+      reqId: msg.reqId,
+      range: [startFrame, endFrame],
+    });
+    return;
+  }
+
+  const kf = keyframeAtOrBefore(dStart);
+
+  const t0 = debug ? performance.now() : 0;
+
+  const dec = ensureDecoder();
+  dec.configure(config as VideoDecoderConfig);
+
+  currentJob = {
+    reqId: msg.reqId,
+    startFrame,
+    endFrame,
+    kf,
+    dEnd,
+    pending: [],
+  };
+
+  for (let i = kf; i <= dEnd; i++) {
+    const s = decodeOrder[i];
+    dec.decode(
+      new EncodedVideoChunk({
+        type: s.isSync ? "key" : "delta",
+        timestamp: s.tsMicros,
+        duration: s.durMicros,
+        data: s.data,
+      }),
+    );
+  }
+
+  await dec.flush();
+  await Promise.all(currentJob.pending);
+
+  if (debug) {
+    const dt = (performance.now() - t0).toFixed(1);
+    log(
+      `chunk req=${msg.reqId} frames[${startFrame}..${endFrame}] ` +
+        `kf-snap=${decodeOrder[kf]?.frameNumber} lead-in=${dStart - kf} ` +
+        `decoded=${currentJob.pending.length} in ${dt}ms`,
+    );
+  }
+
+  post({ type: "chunkDone", reqId: msg.reqId, range: [startFrame, endFrame] });
+  currentJob = null;
+}
+
+function ensureDecoder(): VideoDecoder {
+  if (decoder) {
+    return decoder;
+  }
+
+  decoder = new VideoDecoder({
+    output: onDecoderOutput,
+    error: (error: DOMException) => {
+      if (debug) {
+        log(`decoder error: ${error.message}`);
+      }
+    },
+  });
+
+  return decoder;
+}
+
+function onDecoderOutput(frame: VideoFrame): void {
+  const job = currentJob;
+  const frameNumber = microsToFrame.get(frame.timestamp);
+
+  if (job == null || frameNumber == null) {
+    // A frame we can't place (stray timestamp) — drop it; never leak.
+    frame.close();
+    return;
+  }
+
+  const width = frame.displayWidth;
+  const height = frame.displayHeight;
+  const timestamp = frame.timestamp;
+
+  // `VideoFrame` must be closed promptly (small decoder pool). Convert to a
+  // transferable bitmap, then close.
+  const p = createImageBitmap(frame)
+    .then((bitmap) => {
+      post(
+        {
+          type: "frameReady",
+          reqId: job.reqId,
+          frameNumber,
+          bitmap,
+          width,
+          height,
+          meta: { timestamp },
+        },
+        [bitmap],
+      );
+
+      if (debug) {
+        log(`  frame ${frameNumber} decoded (ts=${timestamp})`);
+      }
+    })
+    .catch(() => {
+      // Skip a single bad frame — the stream re-requests on the next prefetch.
+    })
+    .finally(() => {
+      frame.close();
+    });
+
+  job.pending.push(p);
+}
+
+/** Largest keyframe decode-index at or before `decodeIndex`. */
+function keyframeAtOrBefore(decodeIndex: number): number {
+  let kf = 0;
+  for (const k of keyframeIndices) {
+    if (k <= decodeIndex) {
+      kf = k;
+    } else {
+      break;
+    }
+  }
+
+  return kf;
+}
+
+function post(msg: FrameWorkerOutbound, transfer?: Transferable[]): void {
+  (self as unknown as DedicatedWorkerGlobalScope).postMessage(
+    msg,
+    transfer ?? [],
+  );
+}
+
+function postFailed(reqId: number, error: string): void {
+  post({ type: "chunkFailed", reqId, error });
+}
+
+function log(message: string): void {
+  console.log(`[native-decode] ${message}`);
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+}

--- a/app/packages/video-annotation/src/streams/videoDecodeWorker.ts
+++ b/app/packages/video-annotation/src/streams/videoDecodeWorker.ts
@@ -59,8 +59,6 @@ interface NativeInitMessage extends InitMessage {
   videoSrc: string;
   /** Extra headers for the media fetch (auth); usually none for presigned. */
   headers?: Record<string, string>;
-  /** Phase-1 frame-exactness instrumentation. */
-  debug?: boolean;
   /**
    * Capability probe only: stream just far enough to demux the `moov` +
    * `isConfigSupported`, post a `capability` verdict, and stop — no decode.
@@ -95,8 +93,6 @@ interface DemuxedSample {
   /** Encoded byte length of the sample. */
   size: number;
 }
-
-let debug = false;
 
 /** Samples in decode order (as delivered by the demuxer). */
 let decodeOrder: DemuxedSample[] = [];
@@ -161,8 +157,6 @@ self.addEventListener("message", (event: MessageEvent<FrameWorkerInbound>) => {
 });
 
 async function handleInit(msg: NativeInitMessage): Promise<void> {
-  debug = msg.debug ?? false;
-
   // Capability probe: demux the header only, report a verdict, and stop.
   if (msg.probeOnly) {
     await handleProbe(msg);
@@ -201,19 +195,7 @@ async function initSampleTable(
 
   config = buildDecoderConfig(file, track);
 
-  if (debug) {
-    const d = config.description as Uint8Array | undefined;
-    const head = d ? Array.from(d.slice(0, 6)) : null;
-    log(
-      `config: codec=${config.codec} ${config.codedWidth}x${config.codedHeight} ` +
-        `descLen=${d?.byteLength ?? "none"} descHead=${JSON.stringify(head)}`,
-    );
-  }
-
   const support = await VideoDecoder.isConfigSupported(config);
-  if (debug) {
-    log(`isConfigSupported => ${JSON.stringify(support?.supported)}`);
-  }
   if (!support.supported) {
     throw new Error(`codec unsupported: ${config.codec}`);
   }
@@ -352,13 +334,6 @@ function buildSampleTable(samples: Sample[], timescale: number): void {
     .map((s) => s.decodeIndex);
 
   totalFrames = decodeOrder.length;
-
-  if (debug) {
-    log(
-      `demux ok: ${totalFrames} frames, ${keyframeIndices.length} keyframes, ` +
-        `codec=${config?.codec}`,
-    );
-  }
 }
 
 /**
@@ -459,8 +434,6 @@ async function runJob(msg: FetchChunkMessage): Promise<void> {
 
   const kf = keyframeAtOrBefore(dStart);
 
-  const t0 = debug ? performance.now() : 0;
-
   // Fetch just the bytes for this GOP span (keyframe → last needed sample).
   const range = spanByteRange(decodeOrder, kf, dEnd);
   if (!range) {
@@ -500,17 +473,6 @@ async function runJob(msg: FetchChunkMessage): Promise<void> {
 
   await dec.flush();
   await Promise.all(currentJob.pending);
-
-  if (debug) {
-    const dt = (performance.now() - t0).toFixed(1);
-    const bytes = range.end - range.start;
-    log(
-      `chunk req=${msg.reqId} frames[${startFrame}..${endFrame}] ` +
-        `kf-snap=${decodeOrder[kf]?.frameNumber} lead-in=${dStart - kf} ` +
-        `bytes=${bytes} fileStart=${span.fileStart} ` +
-        `decoded=${currentJob.pending.length} in ${dt}ms`,
-    );
-  }
 
   post({ type: "chunkDone", reqId: msg.reqId, range: [startFrame, endFrame] });
   currentJob = null;
@@ -574,15 +536,10 @@ async function fetchSpanBuffer(range: ByteRange): Promise<SpanBuffer> {
 
       // Unexpected status (e.g. 416): abandon ranges, fall through to whole.
       rangeFetchDisabled = true;
-    } catch (error) {
+    } catch {
       // Network / CORS-preflight failure on the ranged request — abandon
       // ranges and fall through to a plain whole-file fetch.
       rangeFetchDisabled = true;
-      if (debug) {
-        log(
-          `range fetch failed, falling back to whole-file: ${errorMessage(error)}`,
-        );
-      }
     }
   }
 
@@ -611,11 +568,9 @@ function ensureDecoder(): VideoDecoder {
 
   decoder = new VideoDecoder({
     output: onDecoderOutput,
-    error: (error: DOMException) => {
-      if (debug) {
-        log(`decoder error: ${error.message}`);
-      }
-    },
+    // A decoder error fails the current chunk; the base re-requests it on the
+    // next prefetch, so there is nothing to recover here.
+    error: () => {},
   });
 
   return decoder;
@@ -651,10 +606,6 @@ function onDecoderOutput(frame: VideoFrame): void {
         },
         [bitmap],
       );
-
-      if (debug) {
-        log(`  frame ${frameNumber} decoded (ts=${timestamp})`);
-      }
     })
     .catch(() => {
       // Skip a single bad frame — the stream re-requests on the next prefetch.
@@ -703,10 +654,6 @@ function postCapability(
     reason,
   };
   post(msg);
-}
-
-function log(message: string): void {
-  console.log(`[native-decode] ${message}`);
 }
 
 function errorMessage(error: unknown): string {

--- a/app/packages/video-annotation/src/streams/videoDecodeWorker.ts
+++ b/app/packages/video-annotation/src/streams/videoDecodeWorker.ts
@@ -38,6 +38,7 @@
 import { createFile, DataStream, MP4BoxBuffer } from "mp4box";
 import type { ISOFile, Movie, Sample } from "mp4box";
 import type {
+  CapabilityMessage,
   FetchChunkMessage,
   FrameWorkerInbound,
   FrameWorkerOutbound,
@@ -51,6 +52,12 @@ interface NativeInitMessage extends InitMessage {
   headers?: Record<string, string>;
   /** Phase-1 frame-exactness instrumentation. */
   debug?: boolean;
+  /**
+   * Capability probe only: stream just far enough to demux the `moov` +
+   * `isConfigSupported`, post a `capability` verdict, and stop — no decode.
+   * Drives the decode-strategy resolver (which then terminates this worker).
+   */
+  probeOnly?: boolean;
 }
 
 /** The `request` payload the native stream's `buildChunkRequest` produces. */
@@ -124,6 +131,12 @@ self.addEventListener("message", (event: MessageEvent<FrameWorkerInbound>) => {
 async function handleInit(msg: NativeInitMessage): Promise<void> {
   debug = msg.debug ?? false;
 
+  // Capability probe: demux the header only, report a verdict, and stop.
+  if (msg.probeOnly) {
+    await handleProbe(msg);
+    return;
+  }
+
   try {
     const bytes = await fetchVideoBytes(msg.videoSrc, msg.headers);
     await demux(bytes);
@@ -154,6 +167,97 @@ async function fetchVideoBytes(
   }
 
   return resp.arrayBuffer();
+}
+
+/**
+ * Capability probe: stream just enough of the source to demux its `moov`,
+ * build a `VideoDecoderConfig`, and ask `isConfigSupported`. Posts a single
+ * `capability` verdict and does no decode — the resolver terminates this worker
+ * once it has the answer.
+ */
+async function handleProbe(msg: NativeInitMessage): Promise<void> {
+  try {
+    const cfg = await demuxHeaderConfig(msg.videoSrc, msg.headers);
+    const support = await VideoDecoder.isConfigSupported(cfg);
+    postCapability(
+      Boolean(support.supported),
+      cfg.codec,
+      support.supported ? undefined : `codec unsupported: ${cfg.codec}`,
+    );
+  } catch (error) {
+    postCapability(false, undefined, errorMessage(error));
+  }
+}
+
+/**
+ * Stream `videoSrc` through mp4box only until it parses the `moov` (the header
+ * carrying codec + sample-description boxes), then stop — so a decodability
+ * check costs a few hundred KB, not the whole clip. Faststart files resolve on
+ * the first read; a trailing `moov` (non-faststart) degrades to reading the
+ * whole stream, same as decode would.
+ */
+async function demuxHeaderConfig(
+  videoSrc: string,
+  headers?: Record<string, string>,
+): Promise<VideoDecoderConfig> {
+  const resp = await fetch(videoSrc, { mode: "cors", headers });
+  if (!resp.ok) {
+    throw new Error(`video fetch failed: ${resp.status}`);
+  }
+
+  const file = createFile();
+  let headerConfig: VideoDecoderConfig | null = null;
+  let headerError: string | null = null;
+
+  file.onError = (error: string) => {
+    headerError = error;
+  };
+
+  file.onReady = (info: Movie) => {
+    const track = info.videoTracks[0];
+    if (!track) {
+      headerError = "no video track";
+      return;
+    }
+
+    headerConfig = buildDecoderConfig(file, track);
+  };
+
+  // No streaming body (some environments): fall back to a whole-file demux.
+  if (!resp.body) {
+    const bytes = await resp.arrayBuffer();
+    file.appendBuffer(MP4BoxBuffer.fromArrayBuffer(bytes, 0));
+  } else {
+    const reader = resp.body.getReader();
+    let offset = 0;
+
+    while (!headerConfig && !headerError) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+
+      const chunk = value.buffer.slice(
+        value.byteOffset,
+        value.byteOffset + value.byteLength,
+      );
+      file.appendBuffer(MP4BoxBuffer.fromArrayBuffer(chunk, offset));
+      offset += value.byteLength;
+    }
+
+    // We have (or failed to get) the header — don't drain the rest.
+    void reader.cancel().catch(() => {});
+  }
+
+  if (headerError) {
+    throw new Error(headerError);
+  }
+
+  if (!headerConfig) {
+    throw new Error("demux produced no decoder config");
+  }
+
+  return headerConfig;
 }
 
 /**
@@ -491,6 +595,20 @@ function post(msg: FrameWorkerOutbound, transfer?: Transferable[]): void {
 
 function postFailed(reqId: number, error: string): void {
   post({ type: "chunkFailed", reqId, error });
+}
+
+function postCapability(
+  decodable: boolean,
+  codec?: string,
+  reason?: string,
+): void {
+  const msg: CapabilityMessage = {
+    type: "capability",
+    decodable,
+    codec,
+    reason,
+  };
+  post(msg);
 }
 
 function log(message: string): void {

--- a/app/packages/video-annotation/src/streams/videoDecodeWorker.ts
+++ b/app/packages/video-annotation/src/streams/videoDecodeWorker.ts
@@ -44,6 +44,15 @@ import type {
   FrameWorkerOutbound,
   InitMessage,
 } from "./frameWorkerProtocol";
+import {
+  ByteRangeCache,
+  type ByteRange,
+  classifyRangeResponse,
+  parseContentRangeStart,
+  rangeRequestHeader,
+  sliceSampleBytes,
+  spanByteRange,
+} from "./videoByteRange";
 
 interface NativeInitMessage extends InitMessage {
   /** Resolved media URL for the source video. */
@@ -66,7 +75,11 @@ interface NativeChunkRequest {
   numFrames: number;
 }
 
-/** A demuxed sample, enriched with the mappings decode needs. */
+/**
+ * A demuxed sample, enriched with the mappings decode needs. Carries the
+ * sample's byte location (from the `moov`), not its bytes — the encoded data is
+ * range-fetched on demand when a chunk decodes.
+ */
 interface DemuxedSample {
   /** 1-indexed presentation-order frame number. */
   frameNumber: number;
@@ -77,7 +90,10 @@ interface DemuxedSample {
   /** Sample duration in microseconds. */
   durMicros: number;
   isSync: boolean;
-  data: Uint8Array;
+  /** Absolute byte offset of the sample in the source file. */
+  offset: number;
+  /** Encoded byte length of the sample. */
+  size: number;
 }
 
 let debug = false;
@@ -92,6 +108,22 @@ let keyframeIndices: number[] = [];
 const microsToFrame = new Map<number, number>();
 let config: VideoDecoderConfig | null = null;
 let totalFrames = 0;
+
+/** Resolved media URL + fetch headers for the source video (set on init). */
+let videoSrc = "";
+let mediaHeaders: Record<string, string> | undefined;
+
+/** Cap on cached encoded byte ranges — small next to the decoded-bitmap LRU. */
+const RANGE_CACHE_BUDGET_BYTES = 64 * 1024 * 1024;
+const rangeCache = new ByteRangeCache(RANGE_CACHE_BUDGET_BYTES);
+/**
+ * Set once a server proves it won't honor `Range` (returned `200`, or the
+ * ranged request failed CORS/preflight). From then on we serve every chunk
+ * from `wholeFileBuffer` instead of retrying ranges.
+ */
+let rangeFetchDisabled = false;
+/** The whole file, held only when we fell back to a non-ranged fetch. */
+let wholeFileBuffer: ArrayBuffer | null = null;
 
 let ready = false;
 let unsupportedReason: string | null = null;
@@ -137,9 +169,11 @@ async function handleInit(msg: NativeInitMessage): Promise<void> {
     return;
   }
 
+  videoSrc = msg.videoSrc;
+  mediaHeaders = msg.headers;
+
   try {
-    const bytes = await fetchVideoBytes(msg.videoSrc, msg.headers);
-    await demux(bytes);
+    await initSampleTable(msg.videoSrc, msg.headers);
   } catch (error) {
     // Demux/fetch failure is terminal for this source: fail everything queued
     // so the stream marks those frames failed and (later) falls back.
@@ -154,161 +188,18 @@ async function handleInit(msg: NativeInitMessage): Promise<void> {
   drainPending();
 }
 
-async function fetchVideoBytes(
-  videoSrc: string,
+/**
+ * Parse the source's `moov` (streaming just far enough — see {@link streamMoov})
+ * and build the data-less sample table + `VideoDecoderConfig` decode works from.
+ * No `mdat` is fetched here; each sample's bytes are range-fetched on demand.
+ */
+async function initSampleTable(
+  src: string,
   headers?: Record<string, string>,
-): Promise<ArrayBuffer> {
-  // Match `<video src>` semantics: default credentials, cors. Whole-file fetch
-  // for now — mp4box parses progressively, so byte-range streaming is a later
-  // optimization (see design §5).
-  const resp = await fetch(videoSrc, { mode: "cors", headers });
-  if (!resp.ok) {
-    throw new Error(`video fetch failed: ${resp.status}`);
-  }
+): Promise<void> {
+  const { file, track } = await streamMoov(src, headers);
 
-  return resp.arrayBuffer();
-}
-
-/**
- * Capability probe: stream just enough of the source to demux its `moov`,
- * build a `VideoDecoderConfig`, and ask `isConfigSupported`. Posts a single
- * `capability` verdict and does no decode — the resolver terminates this worker
- * once it has the answer.
- */
-async function handleProbe(msg: NativeInitMessage): Promise<void> {
-  try {
-    const cfg = await demuxHeaderConfig(msg.videoSrc, msg.headers);
-    const support = await VideoDecoder.isConfigSupported(cfg);
-    postCapability(
-      Boolean(support.supported),
-      cfg.codec,
-      support.supported ? undefined : `codec unsupported: ${cfg.codec}`,
-    );
-  } catch (error) {
-    postCapability(false, undefined, errorMessage(error));
-  }
-}
-
-/**
- * Stream `videoSrc` through mp4box only until it parses the `moov` (the header
- * carrying codec + sample-description boxes), then stop — so a decodability
- * check costs a few hundred KB, not the whole clip. Faststart files resolve on
- * the first read; a trailing `moov` (non-faststart) degrades to reading the
- * whole stream, same as decode would.
- */
-async function demuxHeaderConfig(
-  videoSrc: string,
-  headers?: Record<string, string>,
-): Promise<VideoDecoderConfig> {
-  const resp = await fetch(videoSrc, { mode: "cors", headers });
-  if (!resp.ok) {
-    throw new Error(`video fetch failed: ${resp.status}`);
-  }
-
-  const file = createFile();
-  let headerConfig: VideoDecoderConfig | null = null;
-  let headerError: string | null = null;
-
-  file.onError = (error: string) => {
-    headerError = error;
-  };
-
-  file.onReady = (info: Movie) => {
-    const track = info.videoTracks[0];
-    if (!track) {
-      headerError = "no video track";
-      return;
-    }
-
-    headerConfig = buildDecoderConfig(file, track);
-  };
-
-  // No streaming body (some environments): fall back to a whole-file demux.
-  if (!resp.body) {
-    const bytes = await resp.arrayBuffer();
-    file.appendBuffer(MP4BoxBuffer.fromArrayBuffer(bytes, 0));
-  } else {
-    const reader = resp.body.getReader();
-    let offset = 0;
-
-    while (!headerConfig && !headerError) {
-      const { done, value } = await reader.read();
-      if (done) {
-        break;
-      }
-
-      const chunk = value.buffer.slice(
-        value.byteOffset,
-        value.byteOffset + value.byteLength,
-      );
-      file.appendBuffer(MP4BoxBuffer.fromArrayBuffer(chunk, offset));
-      offset += value.byteLength;
-    }
-
-    // We have (or failed to get) the header — don't drain the rest.
-    void reader.cancel().catch(() => {});
-  }
-
-  if (headerError) {
-    throw new Error(headerError);
-  }
-
-  if (!headerConfig) {
-    throw new Error("demux produced no decoder config");
-  }
-
-  return headerConfig;
-}
-
-/**
- * Demux `bytes` into a sample table + a `VideoDecoderConfig`. Builds the
- * presentation-order frame numbering and the µs→frame map decode assigns by.
- */
-async function demux(bytes: ArrayBuffer): Promise<void> {
-  const file = createFile();
-  const collected: Sample[] = [];
-  let videoTrack: Movie["videoTracks"][number] | null = null;
-  let readyError: string | null = null;
-
-  file.onError = (error: string) => {
-    readyError = error;
-  };
-
-  file.onReady = (info: Movie) => {
-    const track = info.videoTracks[0];
-    if (!track) {
-      readyError = "no video track";
-      return;
-    }
-
-    videoTrack = track;
-    config = buildDecoderConfig(file, track);
-    // Request every sample in one shot; `flush` forces delivery of the tail.
-    file.setExtractionOptions(track.id, null, { nbSamples: track.nb_samples });
-    file.start();
-  };
-
-  file.onSamples = (_id: number, _user: unknown, samples: Sample[]) => {
-    for (const s of samples) {
-      collected.push(s);
-    }
-  };
-
-  const mbuf = MP4BoxBuffer.fromArrayBuffer(bytes, 0);
-  file.appendBuffer(mbuf, true);
-  file.flush();
-
-  if (readyError) {
-    throw new Error(readyError);
-  }
-
-  if (!videoTrack || !config) {
-    throw new Error("demux produced no video track / decoder config");
-  }
-
-  if (collected.length === 0) {
-    throw new Error("demux produced no samples");
-  }
+  config = buildDecoderConfig(file, track);
 
   if (debug) {
     const d = config.description as Uint8Array | undefined;
@@ -327,10 +218,109 @@ async function demux(bytes: ArrayBuffer): Promise<void> {
     throw new Error(`codec unsupported: ${config.codec}`);
   }
 
-  buildSampleTable(
-    collected,
-    (videoTrack as Movie["videoTracks"][number]).timescale,
-  );
+  // The sample table (offset/size/cts/is_sync per sample) comes straight from
+  // the `moov`'s `stbl` — no `mdat` needed.
+  const samples = file.getTrackSamplesInfo(track.id);
+  if (!samples || samples.length === 0) {
+    throw new Error("demux produced no samples");
+  }
+
+  buildSampleTable(samples, track.timescale);
+}
+
+/**
+ * Capability probe: stream just enough of the source to demux its `moov`,
+ * build a `VideoDecoderConfig`, and ask `isConfigSupported`. Posts a single
+ * `capability` verdict and does no decode — the resolver terminates this worker
+ * once it has the answer.
+ */
+async function handleProbe(msg: NativeInitMessage): Promise<void> {
+  try {
+    const { file, track } = await streamMoov(msg.videoSrc, msg.headers);
+    const cfg = buildDecoderConfig(file, track);
+    const support = await VideoDecoder.isConfigSupported(cfg);
+    postCapability(
+      Boolean(support.supported),
+      cfg.codec,
+      support.supported ? undefined : `codec unsupported: ${cfg.codec}`,
+    );
+  } catch (error) {
+    postCapability(false, undefined, errorMessage(error));
+  }
+}
+
+/**
+ * Stream `src` through mp4box only until it parses the `moov` (the header
+ * carrying codec, sample-description boxes, and the sample table), then stop —
+ * so both the decodability probe and decode-init cost a few hundred KB, not the
+ * whole clip. Faststart files resolve on the first read; a trailing `moov`
+ * (non-faststart) degrades to reading the whole stream. Shared by the probe and
+ * decode-init; the returned `file` has its sample table ready
+ * (`getTrackSamplesInfo`).
+ */
+async function streamMoov(
+  src: string,
+  headers?: Record<string, string>,
+): Promise<{ file: ISOFile; track: Movie["videoTracks"][number] }> {
+  // `<video src>` semantics: cors, default credentials, no custom auth headers.
+  const resp = await fetch(src, { mode: "cors", headers });
+  if (!resp.ok) {
+    throw new Error(`video fetch failed: ${resp.status}`);
+  }
+
+  const file = createFile();
+  let videoTrack: Movie["videoTracks"][number] | null = null;
+  let readyError: string | null = null;
+
+  file.onError = (error: string) => {
+    readyError = error;
+  };
+
+  file.onReady = (info: Movie) => {
+    const track = info.videoTracks[0];
+    if (!track) {
+      readyError = "no video track";
+      return;
+    }
+
+    videoTrack = track;
+  };
+
+  // No streaming body (some environments): fall back to a whole-file append.
+  if (!resp.body) {
+    const bytes = await resp.arrayBuffer();
+    file.appendBuffer(MP4BoxBuffer.fromArrayBuffer(bytes, 0), true);
+  } else {
+    const reader = resp.body.getReader();
+    let offset = 0;
+
+    while (!videoTrack && !readyError) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+
+      const chunk = value.buffer.slice(
+        value.byteOffset,
+        value.byteOffset + value.byteLength,
+      );
+      file.appendBuffer(MP4BoxBuffer.fromArrayBuffer(chunk, offset));
+      offset += value.byteLength;
+    }
+
+    // We have (or failed to get) the header — don't drain the rest.
+    void reader.cancel().catch(() => {});
+  }
+
+  if (readyError) {
+    throw new Error(readyError);
+  }
+
+  if (!videoTrack) {
+    throw new Error("demux produced no video track");
+  }
+
+  return { file, track: videoTrack };
 }
 
 /**
@@ -345,7 +335,8 @@ function buildSampleTable(samples: Sample[], timescale: number): void {
     tsMicros: Math.round((s.cts * 1e6) / timescale),
     durMicros: Math.round((s.duration * 1e6) / timescale),
     isSync: Boolean(s.is_sync),
-    data: (s.data ?? new Uint8Array(0)) as Uint8Array,
+    offset: s.offset,
+    size: s.size,
   }));
 
   // Presentation order = ascending composition timestamp. 1-indexed frame
@@ -470,6 +461,19 @@ async function runJob(msg: FetchChunkMessage): Promise<void> {
 
   const t0 = debug ? performance.now() : 0;
 
+  // Fetch just the bytes for this GOP span (keyframe → last needed sample).
+  const range = spanByteRange(decodeOrder, kf, dEnd);
+  if (!range) {
+    post({
+      type: "chunkDone",
+      reqId: msg.reqId,
+      range: [startFrame, endFrame],
+    });
+    return;
+  }
+
+  const span = await fetchSpanBuffer(range);
+
   const dec = ensureDecoder();
   dec.configure(config as VideoDecoderConfig);
 
@@ -489,7 +493,7 @@ async function runJob(msg: FetchChunkMessage): Promise<void> {
         type: s.isSync ? "key" : "delta",
         timestamp: s.tsMicros,
         duration: s.durMicros,
-        data: s.data,
+        data: sliceSampleBytes(span.buffer, span.fileStart, s),
       }),
     );
   }
@@ -499,15 +503,105 @@ async function runJob(msg: FetchChunkMessage): Promise<void> {
 
   if (debug) {
     const dt = (performance.now() - t0).toFixed(1);
+    const bytes = range.end - range.start;
     log(
       `chunk req=${msg.reqId} frames[${startFrame}..${endFrame}] ` +
         `kf-snap=${decodeOrder[kf]?.frameNumber} lead-in=${dStart - kf} ` +
+        `bytes=${bytes} fileStart=${span.fileStart} ` +
         `decoded=${currentJob.pending.length} in ${dt}ms`,
     );
   }
 
   post({ type: "chunkDone", reqId: msg.reqId, range: [startFrame, endFrame] });
   currentJob = null;
+}
+
+/** A slice of the source file plus the absolute offset its byte 0 maps to. */
+interface SpanBuffer {
+  buffer: ArrayBuffer;
+  /** Absolute file offset of `buffer[0]` (`0` for a whole-file buffer). */
+  fileStart: number;
+}
+
+/**
+ * Fetch the encoded bytes covering `range`, preferring an HTTP `Range` request
+ * so decode streams on demand rather than downloading the whole clip. Degrades
+ * gracefully:
+ *
+ * - `206` — the body is exactly the range; cache it and slice at `range.start`.
+ * - `200` — the server ignored `Range` and sent the whole file; keep it and
+ *   serve every future chunk from it (no more network).
+ * - ranged request rejected / failed (`416`, CORS preflight on a bucket without
+ *   `OPTIONS`, …) — fall back once to a plain (no-`Range`) whole-file fetch,
+ *   matching `<video src>` semantics, and latch off ranges.
+ *
+ * Never fabricates bytes: a hard fetch failure throws, failing the chunk.
+ */
+async function fetchSpanBuffer(range: ByteRange): Promise<SpanBuffer> {
+  // Server already proved it won't range-serve — everything lives in memory.
+  if (rangeFetchDisabled && wholeFileBuffer) {
+    return { buffer: wholeFileBuffer, fileStart: 0 };
+  }
+
+  const cached = rangeCache.get(range);
+  if (cached) {
+    return { buffer: cached, fileStart: range.start };
+  }
+
+  if (!rangeFetchDisabled) {
+    try {
+      const resp = await fetch(videoSrc, {
+        mode: "cors",
+        headers: { ...mediaHeaders, Range: rangeRequestHeader(range) },
+      });
+      const kind = classifyRangeResponse(resp.status);
+
+      if (kind === "range") {
+        const buffer = await resp.arrayBuffer();
+        const fileStart =
+          parseContentRangeStart(resp.headers.get("Content-Range")) ??
+          range.start;
+        rangeCache.set(range, buffer);
+        return { buffer, fileStart };
+      }
+
+      if (kind === "whole") {
+        // Ranges ignored — take the whole file we were handed and stop asking.
+        rangeFetchDisabled = true;
+        wholeFileBuffer = await resp.arrayBuffer();
+        return { buffer: wholeFileBuffer, fileStart: 0 };
+      }
+
+      // Unexpected status (e.g. 416): abandon ranges, fall through to whole.
+      rangeFetchDisabled = true;
+    } catch (error) {
+      // Network / CORS-preflight failure on the ranged request — abandon
+      // ranges and fall through to a plain whole-file fetch.
+      rangeFetchDisabled = true;
+      if (debug) {
+        log(
+          `range fetch failed, falling back to whole-file: ${errorMessage(error)}`,
+        );
+      }
+    }
+  }
+
+  return { buffer: await fetchWholeFile(), fileStart: 0 };
+}
+
+/** Plain (no-`Range`) whole-file fetch; the result is memoized for reuse. */
+async function fetchWholeFile(): Promise<ArrayBuffer> {
+  if (wholeFileBuffer) {
+    return wholeFileBuffer;
+  }
+
+  const resp = await fetch(videoSrc, { mode: "cors", headers: mediaHeaders });
+  if (!resp.ok) {
+    throw new Error(`video fetch failed: ${resp.status}`);
+  }
+
+  wholeFileBuffer = await resp.arrayBuffer();
+  return wholeFileBuffer;
 }
 
 function ensureDecoder(): VideoDecoder {

--- a/app/packages/video-annotation/src/utils/decodeStrategy.test.ts
+++ b/app/packages/video-annotation/src/utils/decodeStrategy.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  type DecodeCapabilities,
+  type DecodeStrategy,
+  parseForcedStrategy,
+  resolveDecodeStrategy,
+} from "./decodeStrategy";
+
+const caps = (over: Partial<DecodeCapabilities> = {}): DecodeCapabilities => ({
+  hasVideoSrc: false,
+  nativeDecodable: false,
+  hasFrames: false,
+  ...over,
+});
+
+describe("resolveDecodeStrategy", () => {
+  it("extracts when the source video is natively decodable", () => {
+    expect(
+      resolveDecodeStrategy(caps({ hasVideoSrc: true, nativeDecodable: true })),
+    ).toBe("extract");
+  });
+
+  it("prefers extract over fetch when both are possible", () => {
+    expect(
+      resolveDecodeStrategy(
+        caps({ hasVideoSrc: true, nativeDecodable: true, hasFrames: true }),
+      ),
+    ).toBe("extract");
+  });
+
+  it("fetches materialized frames when not natively decodable", () => {
+    expect(
+      resolveDecodeStrategy(caps({ hasVideoSrc: true, hasFrames: true })),
+    ).toBe("fetch");
+  });
+
+  it("fetches when frames exist but there is no source video URL", () => {
+    expect(resolveDecodeStrategy(caps({ hasFrames: true }))).toBe("fetch");
+  });
+
+  it("falls back to the html tile when neither extract nor fetch is possible", () => {
+    expect(resolveDecodeStrategy(caps({ hasVideoSrc: true }))).toBe("html");
+  });
+
+  it("falls back to html even with no usable media (degenerate case)", () => {
+    expect(resolveDecodeStrategy(caps())).toBe("html");
+  });
+
+  it("does not extract when decodable but the source URL is missing", () => {
+    // nativeDecodable can't truly be set without a src, but the guard keeps
+    // the policy honest against an inconsistent snapshot.
+    expect(resolveDecodeStrategy(caps({ nativeDecodable: true }))).toBe("html");
+  });
+
+  describe("forced override", () => {
+    const strategies: DecodeStrategy[] = ["extract", "fetch", "html"];
+
+    for (const forced of strategies) {
+      it(`honors forced="${forced}" regardless of capabilities`, () => {
+        expect(
+          resolveDecodeStrategy(
+            caps({
+              forced,
+              // Capabilities that would otherwise resolve differently.
+              hasVideoSrc: true,
+              nativeDecodable: forced !== "extract",
+              hasFrames: forced === "html",
+            }),
+          ),
+        ).toBe(forced);
+      });
+    }
+  });
+});
+
+describe("parseForcedStrategy", () => {
+  it("returns undefined when nothing forces", () => {
+    expect(parseForcedStrategy("")).toBeUndefined();
+    expect(parseForcedStrategy("?foo=bar")).toBeUndefined();
+    expect(parseForcedStrategy("?tile=imavid")).toBeUndefined();
+  });
+
+  it("honors the canonical video-decode param", () => {
+    expect(parseForcedStrategy("?video-decode=extract")).toBe("extract");
+    expect(parseForcedStrategy("?video-decode=fetch")).toBe("fetch");
+    expect(parseForcedStrategy("?video-decode=html")).toBe("html");
+  });
+
+  it("ignores an unknown canonical value", () => {
+    expect(parseForcedStrategy("?video-decode=bogus")).toBeUndefined();
+  });
+
+  it("maps the legacy decode param", () => {
+    expect(parseForcedStrategy("?decode=native")).toBe("extract");
+    expect(parseForcedStrategy("?decode=frames")).toBe("fetch");
+  });
+
+  it("maps the legacy tile=video param", () => {
+    expect(parseForcedStrategy("?tile=video")).toBe("html");
+  });
+
+  it("prefers the canonical param over legacy params", () => {
+    expect(parseForcedStrategy("?video-decode=html&decode=native")).toBe(
+      "html",
+    );
+  });
+});

--- a/app/packages/video-annotation/src/utils/decodeStrategy.ts
+++ b/app/packages/video-annotation/src/utils/decodeStrategy.ts
@@ -1,0 +1,100 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+/**
+ * How the video-annotation surface sources its media frames:
+ *
+ * - `extract` — decode frames on demand from the source video via WebCodecs
+ *   (no `to_frames` preprocessing). Frame-exact via the demux sample table.
+ * - `fetch` — fetch materialized per-frame images (`to_frames(sample_frames=True)`,
+ *   `POST /frames`). The ImaVid image path.
+ * - `html` — a live `<video>` element tile. Last resort; needs no preprocessing
+ *   and no WebCodecs, but its overlay layer can trail the picture under load.
+ */
+export type DecodeStrategy = "extract" | "fetch" | "html";
+
+/**
+ * The capability snapshot the policy decides from. Deliberately plain data (no
+ * React, no async) so {@link resolveDecodeStrategy} is a pure, exhaustively
+ * unit-testable function; the async gathering of these flags lives in the hook.
+ */
+export interface DecodeCapabilities {
+  /** A source video URL resolved on the sample (extract + html need it). */
+  hasVideoSrc: boolean;
+  /** The source video is decodable on demand via WebCodecs — `canDecode(uri)`. */
+  nativeDecodable: boolean;
+  /** Materialized per-frame images exist (`to_frames(sample_frames=True)`). */
+  hasFrames: boolean;
+  /**
+   * A manual override (e.g. `?decode=`/`?tile=`) that short-circuits the
+   * policy. Honored verbatim as a debug/testing escape hatch — capability
+   * flags are not re-checked.
+   */
+  forced?: DecodeStrategy;
+}
+
+/**
+ * The one place the strategy is decided: `canDecode ? extract : hasFrames ?
+ * fetch : html`. Total over its inputs (always returns one of the three), so
+ * every branch has a concrete rendering path; the degenerate "no media at all"
+ * case falls through to `html`, whose tile renders its own empty state.
+ */
+export function resolveDecodeStrategy(
+  caps: DecodeCapabilities,
+): DecodeStrategy {
+  // A manual override wins outright — it's a debug/testing escape hatch, so we
+  // honor it verbatim without re-checking capabilities.
+  if (caps.forced) {
+    return caps.forced;
+  }
+
+  // Preferred: extract frames on demand from the source video (no `to_frames`).
+  if (caps.hasVideoSrc && caps.nativeDecodable) {
+    return "extract";
+  }
+
+  // Next: materialized per-frame images.
+  if (caps.hasFrames) {
+    return "fetch";
+  }
+
+  // Last resort: the live `<video>` element tile.
+  return "html";
+}
+
+/**
+ * Parse a forced-strategy override from a URL query string, for debugging and
+ * e2e (bypasses capability detection). Precedence: the canonical
+ * `?video-decode=extract|fetch|html` wins; the legacy `?decode=`/`?tile=`
+ * params are honored for back-compat. Returns `undefined` when nothing forces.
+ */
+export function parseForcedStrategy(
+  search: string,
+): DecodeStrategy | undefined {
+  const params = new URLSearchParams(search);
+
+  const canonical = params.get("video-decode");
+  if (
+    canonical === "extract" ||
+    canonical === "fetch" ||
+    canonical === "html"
+  ) {
+    return canonical;
+  }
+
+  const decode = params.get("decode");
+  if (decode === "native") {
+    return "extract";
+  }
+
+  if (decode === "frames") {
+    return "fetch";
+  }
+
+  if (params.get("tile") === "video") {
+    return "html";
+  }
+
+  return undefined;
+}

--- a/app/packages/video-annotation/src/utils/nativeDecodeCache.test.ts
+++ b/app/packages/video-annotation/src/utils/nativeDecodeCache.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { type KeyValueStore, NativeDecodeCache } from "./nativeDecodeCache";
+
+/** Map-backed `KeyValueStore` for asserting persistence. */
+class FakeStore implements KeyValueStore {
+  readonly map = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.map.has(key) ? (this.map.get(key) as string) : null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.map.set(key, value);
+  }
+}
+
+describe("NativeDecodeCache — sample verdicts", () => {
+  let store: FakeStore;
+  let cache: NativeDecodeCache;
+
+  beforeEach(() => {
+    store = new FakeStore();
+    cache = new NativeDecodeCache(store);
+  });
+
+  it("returns undefined for an unknown sample", () => {
+    expect(cache.getSampleVerdict("ds", "s1")).toBeUndefined();
+  });
+
+  it("round-trips a verdict through memory", () => {
+    cache.setSampleVerdict("ds", "s1", {
+      codec: "avc1.64000d",
+      decodable: true,
+    });
+    expect(cache.getSampleVerdict("ds", "s1")).toEqual({
+      codec: "avc1.64000d",
+      decodable: true,
+    });
+  });
+
+  it("persists a verdict so a fresh cache over the same store reads it", () => {
+    cache.setSampleVerdict("ds", "s1", { codec: "vp09", decodable: false });
+
+    const reloaded = new NativeDecodeCache(store);
+    expect(reloaded.getSampleVerdict("ds", "s1")).toEqual({
+      codec: "vp09",
+      decodable: false,
+    });
+  });
+
+  it("scopes verdicts by dataset + sample id", () => {
+    cache.setSampleVerdict("ds", "s1", { codec: "avc1", decodable: true });
+    expect(cache.getSampleVerdict("ds", "s2")).toBeUndefined();
+    expect(cache.getSampleVerdict("other", "s1")).toBeUndefined();
+  });
+
+  it("ignores corrupt persisted JSON", () => {
+    store.setItem("fo:nd:v1:sample:ds:s1", "{not json");
+    expect(cache.getSampleVerdict("ds", "s1")).toBeUndefined();
+  });
+
+  it("ignores a persisted value with the wrong shape", () => {
+    store.setItem("fo:nd:v1:sample:ds:s1", JSON.stringify({ codec: 5 }));
+    expect(cache.getSampleVerdict("ds", "s1")).toBeUndefined();
+  });
+});
+
+describe("NativeDecodeCache — codec support", () => {
+  let store: FakeStore;
+  let cache: NativeDecodeCache;
+
+  beforeEach(() => {
+    store = new FakeStore();
+    cache = new NativeDecodeCache(store);
+  });
+
+  it("returns undefined for an unknown codec", () => {
+    expect(cache.getCodecSupport("avc1.64000d")).toBeUndefined();
+  });
+
+  it("round-trips and persists codec support", () => {
+    cache.setCodecSupport("avc1.64000d", true);
+    expect(cache.getCodecSupport("avc1.64000d")).toBe(true);
+    expect(new NativeDecodeCache(store).getCodecSupport("avc1.64000d")).toBe(
+      true,
+    );
+  });
+
+  it("distinguishes false from unknown", () => {
+    cache.setCodecSupport("hev1", false);
+    expect(cache.getCodecSupport("hev1")).toBe(false);
+  });
+
+  it("back-fills codec support from a sample verdict", () => {
+    cache.setSampleVerdict("ds", "s1", {
+      codec: "avc1.64000d",
+      decodable: true,
+    });
+    // A sibling sample with the same codec is answerable without its own probe.
+    expect(cache.getCodecSupport("avc1.64000d")).toBe(true);
+  });
+});
+
+describe("NativeDecodeCache — memory-only (no store)", () => {
+  it("works without a backing store", () => {
+    const cache = new NativeDecodeCache(null);
+    cache.setSampleVerdict("ds", "s1", { codec: "avc1", decodable: true });
+    expect(cache.getSampleVerdict("ds", "s1")).toEqual({
+      codec: "avc1",
+      decodable: true,
+    });
+  });
+
+  it("degrades to memory-only when the store throws", () => {
+    const throwing: KeyValueStore = {
+      getItem: vi.fn(() => {
+        throw new Error("blocked");
+      }),
+      setItem: vi.fn(() => {
+        throw new Error("blocked");
+      }),
+    };
+
+    const cache = new NativeDecodeCache(throwing);
+    cache.setCodecSupport("avc1", true);
+    // The write threw and was swallowed, but the in-memory memo still answers.
+    expect(cache.getCodecSupport("avc1")).toBe(true);
+  });
+});

--- a/app/packages/video-annotation/src/utils/nativeDecodeCache.ts
+++ b/app/packages/video-annotation/src/utils/nativeDecodeCache.ts
@@ -1,0 +1,192 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+/**
+ * Remembers whether a video is decodable on demand via WebCodecs, so the
+ * decode-strategy resolver can skip the fetch+demux probe on revisits.
+ *
+ * Two tiers, both memoized in-process and mirrored to a persistent
+ * key-value store (localStorage by default) so the answer survives reloads:
+ *
+ * - per-codec support (`codec → bool`): the browser's capability for a codec
+ *   string (e.g. `avc1.64000d`). Stable across files and sessions — the
+ *   highest-value memo, and all a fresh sample needs once its codec is known.
+ * - per-sample verdict (`dataset:sampleId → {codec, decodable}`): lets a
+ *   revisited sample resolve with no probe at all.
+ *
+ * The worker's `isConfigSupported` stays authoritative, so a stale entry can't
+ * cause a hard failure — at worst one avoidable re-probe.
+ */
+
+/** The decodability answer for a specific sample's source video. */
+export interface DecodeVerdict {
+  /** The demuxed codec string (e.g. `avc1.64000d`). */
+  codec: string;
+  /** Whether `VideoDecoder.isConfigSupported` accepted it. */
+  decodable: boolean;
+}
+
+/** The slice of the `Storage` interface we use (so tests inject a fake). */
+export interface KeyValueStore {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+// Bump to invalidate every persisted entry (keys are namespaced by version, so
+// old entries simply stop being read).
+const VERSION = "v1";
+const PREFIX = `fo:nd:${VERSION}`;
+
+const sampleKey = (dataset: string, sampleId: string): string =>
+  `${PREFIX}:sample:${dataset}:${sampleId}`;
+
+const codecKey = (codec: string): string => `${PREFIX}:codec:${codec}`;
+
+export class NativeDecodeCache {
+  private readonly store: KeyValueStore | null;
+  private readonly codecMemo = new Map<string, boolean>();
+  private readonly sampleMemo = new Map<string, DecodeVerdict>();
+
+  /**
+   * `store` defaults to a guarded `localStorage`; pass `null` for a
+   * memory-only cache (or a fake in tests). A store whose access throws
+   * (privacy mode, SSR) degrades transparently to memory-only.
+   */
+  constructor(store: KeyValueStore | null = safeLocalStorage()) {
+    this.store = store;
+  }
+
+  /** Cached verdict for a sample's source video, or `undefined` if unknown. */
+  getSampleVerdict(
+    dataset: string,
+    sampleId: string,
+  ): DecodeVerdict | undefined {
+    const key = sampleKey(dataset, sampleId);
+
+    const cached = this.sampleMemo.get(key);
+    if (cached) {
+      return cached;
+    }
+
+    const verdict = this.readJSON(key, isVerdict);
+    if (verdict) {
+      this.sampleMemo.set(key, verdict);
+    }
+
+    return verdict;
+  }
+
+  /**
+   * Record a sample's verdict. Also back-fills the per-codec memo — a verdict
+   * for one file settles decodability for every sibling with the same codec.
+   */
+  setSampleVerdict(
+    dataset: string,
+    sampleId: string,
+    verdict: DecodeVerdict,
+  ): void {
+    const key = sampleKey(dataset, sampleId);
+    this.sampleMemo.set(key, verdict);
+    this.writeJSON(key, verdict);
+    this.setCodecSupport(verdict.codec, verdict.decodable);
+  }
+
+  /** Cached browser support for a codec string, or `undefined` if unknown. */
+  getCodecSupport(codec: string): boolean | undefined {
+    const cached = this.codecMemo.get(codec);
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    const raw = this.read(codecKey(codec));
+    if (raw === "1" || raw === "0") {
+      const supported = raw === "1";
+      this.codecMemo.set(codec, supported);
+      return supported;
+    }
+
+    return undefined;
+  }
+
+  /** Record browser support for a codec string. */
+  setCodecSupport(codec: string, supported: boolean): void {
+    this.codecMemo.set(codec, supported);
+    this.write(codecKey(codec), supported ? "1" : "0");
+  }
+
+  private read(key: string): string | null {
+    if (!this.store) {
+      return null;
+    }
+
+    try {
+      return this.store.getItem(key);
+    } catch {
+      return null;
+    }
+  }
+
+  private write(key: string, value: string): void {
+    if (!this.store) {
+      return;
+    }
+
+    try {
+      this.store.setItem(key, value);
+    } catch {
+      // Quota / privacy-mode failures are non-fatal — the in-memory memo still
+      // serves this session.
+    }
+  }
+
+  private readJSON<T>(
+    key: string,
+    guard: (v: unknown) => v is T,
+  ): T | undefined {
+    const raw = this.read(key);
+    if (raw === null) {
+      return undefined;
+    }
+
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      return guard(parsed) ? parsed : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private writeJSON(key: string, value: unknown): void {
+    try {
+      this.write(key, JSON.stringify(value));
+    } catch {
+      // Non-serializable / stringify failure — skip persistence.
+    }
+  }
+}
+
+function isVerdict(value: unknown): value is DecodeVerdict {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const v = value as Record<string, unknown>;
+  return typeof v.codec === "string" && typeof v.decodable === "boolean";
+}
+
+/** A guarded `localStorage`, or `null` where it's unavailable (SSR/privacy). */
+function safeLocalStorage(): KeyValueStore | null {
+  try {
+    if (typeof localStorage === "undefined") {
+      return null;
+    }
+
+    return localStorage;
+  } catch {
+    return null;
+  }
+}
+
+/** Process-wide cache instance the app uses. */
+export const nativeDecodeCache = new NativeDecodeCache();

--- a/app/packages/video-annotation/src/utils/nativeDecodeSupport.test.ts
+++ b/app/packages/video-annotation/src/utils/nativeDecodeSupport.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { describe, expect, it } from "vitest";
+import { looksDemuxable } from "./nativeDecodeSupport";
+
+describe("looksDemuxable", () => {
+  it("accepts MP4/MOV extensions", () => {
+    expect(looksDemuxable("/media/clip.mp4")).toBe(true);
+    expect(looksDemuxable("/media/clip.mov")).toBe(true);
+    expect(looksDemuxable("/media/clip.m4v")).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(looksDemuxable("/media/CLIP.MP4")).toBe(true);
+    expect(looksDemuxable("/media/CLIP.WEBM")).toBe(false);
+  });
+
+  it("rejects known non-ISO-BMFF containers", () => {
+    expect(looksDemuxable("/media/clip.webm")).toBe(false);
+    expect(looksDemuxable("/media/clip.mkv")).toBe(false);
+    expect(looksDemuxable("/media/clip.avi")).toBe(false);
+  });
+
+  it("ignores query strings and fragments (presigned URLs)", () => {
+    expect(looksDemuxable("https://x/clip.mp4?sig=abc&exp=1")).toBe(true);
+    expect(looksDemuxable("https://x/clip.webm?sig=abc")).toBe(false);
+    expect(looksDemuxable("https://x/clip.mp4#t=1")).toBe(true);
+  });
+
+  it("permits an absent extension (let the probe decide)", () => {
+    expect(looksDemuxable("https://x/presigned-object-id")).toBe(true);
+    expect(looksDemuxable("https://x/media/")).toBe(true);
+  });
+
+  it("does not treat a dotted directory as an extension", () => {
+    expect(looksDemuxable("https://x/v1.2/object")).toBe(true);
+  });
+});

--- a/app/packages/video-annotation/src/utils/nativeDecodeSupport.ts
+++ b/app/packages/video-annotation/src/utils/nativeDecodeSupport.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+/**
+ * Cheap, synchronous gates for whether a source video is worth probing for
+ * WebCodecs decode. The authoritative answer comes from the worker probe
+ * (`probeNativeDecode`); these just avoid probing when it's pointless.
+ */
+
+/** WebCodecs `VideoDecoder` is present in this environment. */
+export function webCodecsAvailable(): boolean {
+  return typeof globalThis !== "undefined" && "VideoDecoder" in globalThis;
+}
+
+/**
+ * Containers mp4box can't demux — probing them wastes a fetch (mp4box would
+ * read looking for a `moov` that never comes). We only skip a container we're
+ * *sure* about: an unknown/absent extension still gets probed (presigned URLs
+ * often carry no extension), and the probe is authoritative + cached.
+ */
+const NON_ISOBMFF_EXTENSIONS = new Set([
+  "webm",
+  "mkv",
+  "ogg",
+  "ogv",
+  "avi",
+  "flv",
+  "wmv",
+  "ts",
+  "mpg",
+  "mpeg",
+]);
+
+/**
+ * Whether `url` plausibly holds an ISO-BMFF (MP4/MOV) stream mp4box can demux.
+ * Extension-based and deliberately permissive: only a *known* non-ISO-BMFF
+ * extension returns false; no extension → true (let the probe decide).
+ */
+export function looksDemuxable(url: string): boolean {
+  const path = url.split("?")[0].split("#")[0];
+  const slash = path.lastIndexOf("/");
+  const name = slash >= 0 ? path.slice(slash + 1) : path;
+
+  const dot = name.lastIndexOf(".");
+  if (dot <= 0) {
+    return true;
+  }
+
+  const ext = name.slice(dot + 1).toLowerCase();
+  return !NON_ISOBMFF_EXTENSIONS.has(ext);
+}

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -3420,6 +3420,7 @@ __metadata:
     "@fiftyone/state": "workspace:*"
     "@fiftyone/tiling": "workspace:*"
     "@fiftyone/utilities": "workspace:*"
+    "@types/dom-webcodecs": "npm:^0.1.18"
     "@voxel51/voodo": "npm:^0.0.37"
     clsx: "npm:^2.1.0"
     eslint: "npm:9.7.0"
@@ -3428,6 +3429,7 @@ __metadata:
     globals: "npm:^15.8.0"
     jotai: "npm:^2.9.3"
     lru-cache: "npm:^11.0.1"
+    mp4box: "npm:^2.4.1"
     typescript-eslint: "npm:^7.17.0"
     vite: "npm:^7.3.2"
   languageName: unknown
@@ -7298,6 +7300,13 @@ __metadata:
   version: 0.0.9
   resolution: "@types/doctrine@npm:0.0.9"
   checksum: 10/64ef06e6eea2f4f9684d259fedbcb8bf21c954630b96ea2e04875ca42763552b0ba3b01b3dd27ec0f9ea6f8b3b0dba4965d31d5a925cd4c6225fd13a93ae9354
+  languageName: node
+  linkType: hard
+
+"@types/dom-webcodecs@npm:^0.1.18":
+  version: 0.1.18
+  resolution: "@types/dom-webcodecs@npm:0.1.18"
+  checksum: 10/889ffea2c849ed3d23a2486b9eb3ad4da038cacc2bfe538da87e19cf9cad3c98fd29046e36c21725f01bb75d556eec85119ad39575a455d8b1529be95660c966
   languageName: node
   linkType: hard
 
@@ -17488,6 +17497,13 @@ __metadata:
     signum: "npm:^1.0.0"
     to-px: "npm:^1.0.1"
   checksum: 10/28e41ccac43fb4e284cfbbe348c0c5e391417bb997a3f8ad2e280152883721ad55aec1596200060ad4d99b256f5b167dbdf35d4dd83c84c80401a95fa0e5725c
+  languageName: node
+  linkType: hard
+
+"mp4box@npm:^2.4.1":
+  version: 2.4.1
+  resolution: "mp4box@npm:2.4.1"
+  checksum: 10/6c0e9c7a0026176374ec7534c4679cd9b9312ef0b5a849d59e41cb156d9d0b13b68b5801c7da9780d29ae7cb979cd038f9a5bc8350e7cb148f61eb6527734374
   languageName: node
   linkType: hard
 

--- a/fiftyone/utils/video.py
+++ b/fiftyone/utils/video.py
@@ -901,9 +901,17 @@ def _transform_video(
                 frames = _frames
 
         if reencode:
-            # Use default reencoding parameters from ``eta.core.video.FFmpeg``
+            # Use default reencoding parameters from ``eta.core.video.FFmpeg``.
+            # For MP4/MOV outputs, write the moov atom at the front of the file
+            # so players can start playback without seeking to the end.
             kwargs["in_opts"] = None
-            kwargs["out_opts"] = None
+            if out_ext.lower() in (".mp4", ".mov", ".m4v"):
+                kwargs["out_opts"] = list(etav.FFmpeg.DEFAULT_VIDEO_OUT_OPTS) + [
+                    "-movflags",
+                    "+faststart",
+                ]
+            else:
+                kwargs["out_opts"] = None
         else:
             # No reencoding parameters
             if "in_opts" not in kwargs:


### PR DESCRIPTION
Cherry-picks #7976 into `release/v1.19.0`.

**Commits (6, in order):**
- `e72e443bf18b` extract FrameBitmapCache and FrameBitmapStream base from ImaVidImageStream
- `18301622a9aa` add native WebCodecs video decode stream for annotation playback
- `492a9f68b9ec` resolve the video decode strategy (extract/fetch/html) before mounting the annotation surface
- `890e6da95179` range-fetch GOP byte spans in the native decode worker instead of downloading the whole video
- `f284b19e4619` write the moov atom at the front of reencoded MP4/MOV videos
- `49c6aea8d335` remove debug instrumentation from the native video decode stream and worker

Diff verified identical to the original range. No conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Video annotation now automatically selects the best available playback method, including native video decoding, frame fetching, or HTML playback.
  * Added on-demand frame decoding with improved buffering and caching for smoother annotation playback.
  * Added support for switching between video sources and frame extraction modes.

* **Bug Fixes**
  * Improved prerequisite messaging when video metadata is unavailable.
  * Re-encoded MP4, MOV, and M4V files now start playback more efficiently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3255
<!-- enterprise-sync-pr:end -->