### PR TITLE
Synchronize retained Relay state across datasets

### DIFF
--- a/app/packages/relay/src/Writer.test.tsx
+++ b/app/packages/relay/src/Writer.test.tsx
@@ -13,22 +13,25 @@ describe("Writer", () => {
     const synchronize = vi.fn();
     const unregister = registerPageSync("Writer.test", synchronize);
 
-    const { unmount } = render(
-      <RecoilRoot>
-        <Writer<OperationType>
-          read={() => page}
-          setters={new Map()}
-          subscribe={(runner) => {
-            runner(page);
-            return vi.fn();
-          }}
-        />
-      </RecoilRoot>,
-    );
+    try {
+      const { unmount } = render(
+        <RecoilRoot>
+          <Writer<OperationType>
+            read={() => page}
+            setters={new Map()}
+            subscribe={(runner) => {
+              runner(page);
+              return vi.fn();
+            }}
+          />
+        </RecoilRoot>,
+      );
 
-    await waitFor(() => expect(synchronize).toHaveBeenCalledOnce());
+      await waitFor(() => expect(synchronize).toHaveBeenCalledOnce());
 
-    unmount();
-    unregister();
+      unmount();
+    } finally {
+      unregister();
+    }
   });
 });

--- a/app/packages/relay/src/Writer.test.tsx
+++ b/app/packages/relay/src/Writer.test.tsx
@@ -1,0 +1,34 @@
+import { render, waitFor } from "@testing-library/react";
+import React from "react";
+import { RecoilRoot } from "recoil";
+import type { OperationType } from "relay-runtime";
+import { describe, expect, test, vi } from "vitest";
+import type { PageQuery } from "./Writer";
+import { registerPageSync, Writer } from "./Writer";
+
+const page = {} as PageQuery<OperationType>;
+
+describe("Writer", () => {
+  test("publishes pages to persistent synchronization subscribers", async () => {
+    const synchronize = vi.fn();
+    const unregister = registerPageSync("Writer.test", synchronize);
+
+    const { unmount } = render(
+      <RecoilRoot>
+        <Writer<OperationType>
+          read={() => page}
+          setters={new Map()}
+          subscribe={(runner) => {
+            runner(page);
+            return vi.fn();
+          }}
+        />
+      </RecoilRoot>,
+    );
+
+    await waitFor(() => expect(synchronize).toHaveBeenCalledOnce());
+
+    unmount();
+    unregister();
+  });
+});

--- a/app/packages/relay/src/Writer.tsx
+++ b/app/packages/relay/src/Writer.tsx
@@ -27,6 +27,27 @@ let pageQueryReader: <T extends OperationType>() => PageQuery<T>;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const subscribersBefore = new Set<PageSubscription<any>>();
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const pageSyncSubscribers = new Map<string, PageSubscription<any>>();
+
+/**
+ * Registers a keyed subscriber that runs for every published page.
+ * Re-registering a key replaces its callback, and stale cleanup cannot remove
+ * the replacement.
+ */
+export function registerPageSync<T extends OperationType>(
+  key: string,
+  subscription: PageSubscription<T>,
+) {
+  pageSyncSubscribers.set(key, subscription);
+
+  return () => {
+    if (pageSyncSubscribers.get(key) === subscription) {
+      pageSyncSubscribers.delete(key);
+    }
+  };
+}
+
 export function subscribeBefore<T extends OperationType>(
   subscription: PageSubscription<T>,
 ) {
@@ -78,6 +99,8 @@ export const resetEffect = <T,>(viewChange = true): AtomEffect<T> => {
         }
       });
     }
+
+    return undefined;
   };
 };
 
@@ -114,7 +137,11 @@ export function Writer<T extends OperationType>({
       // @ts-ignore
       pageQueryReader = () => pageQuery;
       set((transactionInterface) => {
-        for (const cb of [...subscribersBefore, ...subscribers]) {
+        for (const cb of [
+          ...pageSyncSubscribers.values(),
+          ...subscribersBefore,
+          ...subscribers,
+        ]) {
           cb(pageQuery, transactionInterface, previous);
         }
       });

--- a/app/packages/relay/src/graphQLSyncFragmentAtom.test.ts
+++ b/app/packages/relay/src/graphQLSyncFragmentAtom.test.ts
@@ -1,0 +1,121 @@
+import type { TransactionInterface_UNSTABLE } from "recoil";
+import type { GraphQLTaggedNode, OperationType } from "relay-runtime";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { PageQuery } from "./Writer";
+
+const mocks = vi.hoisted(() => ({
+  loadContext: vi.fn(),
+  registerPageSync: vi.fn(),
+  resolveFragmentChain: vi.fn(),
+}));
+
+vi.mock("./utils", () => ({
+  loadContext: mocks.loadContext,
+  resolveFragmentChain: mocks.resolveFragmentChain,
+}));
+
+vi.mock("./Writer", () => ({
+  getPageQuery: vi.fn(),
+  registerPageSync: mocks.registerPageSync,
+}));
+
+const fragment = {} as GraphQLTaggedNode;
+const page = {
+  data: {},
+  preloadedQuery: { environment: {} },
+} as unknown as PageQuery<OperationType>;
+
+const createPageSync = async (
+  key: string,
+  options: { default: unknown; read?: ReturnType<typeof vi.fn> },
+) => {
+  const { graphQLSyncFragmentAtom } = await import("./graphQLSyncFragmentAtom");
+  const value = graphQLSyncFragmentAtom(
+    {
+      default: options.default,
+      fragments: [fragment],
+      keys: ["dataset"],
+      read: options.read as never,
+    },
+    { key },
+  );
+  const subscriber = mocks.registerPageSync.mock.calls[0][1] as (
+    page: PageQuery<OperationType>,
+    transaction: TransactionInterface_UNSTABLE,
+  ) => void;
+
+  return { subscriber, value };
+};
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.stubEnv("MODE", "development");
+  mocks.loadContext.mockReset();
+  mocks.registerPageSync.mockReset();
+  mocks.resolveFragmentChain.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("graphQLSyncFragmentAtom page synchronization", () => {
+  test("resets when the page is missing a fragment parent", async () => {
+    const defaultValue = { state: "default" };
+    const { subscriber, value } = await createPageSync("page-sync-missing", {
+      default: defaultValue,
+    });
+    const set = vi.fn();
+    mocks.resolveFragmentChain.mockReturnValue({ missing: true });
+
+    subscriber(page, { set } as unknown as TransactionInterface_UNSTABLE);
+
+    expect(set).toHaveBeenCalledWith(value, defaultValue);
+  });
+
+  test("resets when fragment resolution throws", async () => {
+    const defaultValue = { state: "default" };
+    const { subscriber, value } = await createPageSync("page-sync-error", {
+      default: defaultValue,
+    });
+    const set = vi.fn();
+    mocks.resolveFragmentChain.mockImplementation(() => {
+      throw new Error("incompatible fragment");
+    });
+
+    subscriber(page, { set } as unknown as TransactionInterface_UNSTABLE);
+
+    expect(set).toHaveBeenCalledWith(value, defaultValue);
+  });
+
+  test("passes current and previous fragment data to read", async () => {
+    const first = { id: "first" };
+    const second = { id: "second" };
+    const read = vi.fn((current, previous) => ({ current, previous }));
+    const { subscriber, value } = await createPageSync("page-sync-read", {
+      default: null,
+      read,
+    });
+    const set = vi.fn();
+    const transaction = {
+      set,
+    } as unknown as TransactionInterface_UNSTABLE;
+    mocks.resolveFragmentChain
+      .mockReturnValueOnce({ data: first, missing: false })
+      .mockReturnValueOnce({ data: second, missing: false });
+
+    subscriber(page, transaction);
+    subscriber(page, transaction);
+
+    expect(read).toHaveBeenNthCalledWith(1, first, null);
+    expect(read).toHaveBeenNthCalledWith(2, second, first);
+    expect(set).toHaveBeenNthCalledWith(1, value, {
+      current: first,
+      previous: null,
+    });
+    expect(set).toHaveBeenNthCalledWith(2, value, {
+      current: second,
+      previous: first,
+    });
+  });
+});

--- a/app/packages/relay/src/graphQLSyncFragmentAtom.test.ts
+++ b/app/packages/relay/src/graphQLSyncFragmentAtom.test.ts
@@ -1,9 +1,13 @@
+import { cleanup, render } from "@testing-library/react";
+import { createElement } from "react";
+import { RecoilRoot, useRecoilValue } from "recoil";
 import type { TransactionInterface_UNSTABLE } from "recoil";
 import type { GraphQLTaggedNode, OperationType } from "relay-runtime";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { PageQuery } from "./Writer";
 
 const mocks = vi.hoisted(() => ({
+  getPageQuery: vi.fn(),
   loadContext: vi.fn(),
   registerPageSync: vi.fn(),
   resolveFragmentChain: vi.fn(),
@@ -15,7 +19,7 @@ vi.mock("./utils", () => ({
 }));
 
 vi.mock("./Writer", () => ({
-  getPageQuery: vi.fn(),
+  getPageQuery: mocks.getPageQuery,
   registerPageSync: mocks.registerPageSync,
 }));
 
@@ -47,16 +51,80 @@ const createPageSync = async (
   return { subscriber, value };
 };
 
+const mountAtomEffect = async (key: string) => {
+  const subscribe = vi.fn(() => vi.fn());
+  mocks.getPageQuery.mockReturnValue({ pageQuery: page, subscribe });
+  const { graphQLSyncFragmentAtom } = await import("./graphQLSyncFragmentAtom");
+  const value = graphQLSyncFragmentAtom(
+    { default: null, fragments: [fragment], keys: ["dataset"] },
+    { key },
+  );
+  const Reader = () => {
+    useRecoilValue(value);
+    return null;
+  };
+
+  return render(createElement(RecoilRoot, null, createElement(Reader)));
+};
+
 beforeEach(() => {
   vi.resetModules();
   vi.stubEnv("MODE", "development");
+  mocks.getPageQuery.mockReset();
   mocks.loadContext.mockReset();
   mocks.registerPageSync.mockReset();
   mocks.resolveFragmentChain.mockReset();
 });
 
 afterEach(() => {
+  cleanup();
   vi.unstubAllEnvs();
+});
+
+describe("graphQLSyncFragmentAtom effect retries", () => {
+  test("does not subscribe without a resolved fragment context", async () => {
+    mocks.resolveFragmentChain.mockReturnValue({ missing: true });
+
+    const { unmount } = await mountAtomEffect("effect-missing-context");
+
+    unmount();
+  });
+
+  test("tracks the live subscription created by a retry", async () => {
+    const retryDispose = vi.fn();
+    const liveDispose = vi.fn();
+    let retryCallback: (() => void) | undefined;
+    const retryContext = {
+      FragmentResource: {
+        subscribe: vi.fn((_result, callback) => {
+          retryCallback = callback;
+          return { dispose: retryDispose };
+        }),
+      },
+      result: {},
+    };
+    const liveContext = {
+      FragmentResource: {
+        subscribe: vi.fn(() => ({ dispose: liveDispose })),
+      },
+      result: {},
+    };
+    mocks.resolveFragmentChain
+      .mockReturnValueOnce({ context: retryContext, missing: true })
+      .mockReturnValueOnce({
+        context: liveContext,
+        data: { id: "resolved" },
+        missing: false,
+        parent: {},
+      });
+
+    const { unmount } = await mountAtomEffect("effect-retry-subscription");
+    retryCallback?.();
+    unmount();
+
+    expect(retryDispose).toHaveBeenCalled();
+    expect(liveDispose).toHaveBeenCalled();
+  });
 });
 
 describe("graphQLSyncFragmentAtom page synchronization", () => {
@@ -117,5 +185,28 @@ describe("graphQLSyncFragmentAtom page synchronization", () => {
       current: second,
       previous: first,
     });
+  });
+
+  test("clears previous fragment data before resuming after a reset", async () => {
+    const first = { id: "first" };
+    const second = { id: "second" };
+    const read = vi.fn((current, previous) => ({ current, previous }));
+    const { subscriber } = await createPageSync("page-sync-reset-resume", {
+      default: null,
+      read,
+    });
+    const transaction = {
+      set: vi.fn(),
+    } as unknown as TransactionInterface_UNSTABLE;
+    mocks.resolveFragmentChain
+      .mockReturnValueOnce({ data: first, missing: false })
+      .mockReturnValueOnce({ missing: true })
+      .mockReturnValueOnce({ data: second, missing: false });
+
+    subscriber(page, transaction);
+    subscriber(page, transaction);
+    subscriber(page, transaction);
+
+    expect(read).toHaveBeenLastCalledWith(second, null);
   });
 });

--- a/app/packages/relay/src/graphQLSyncFragmentAtom.test.ts
+++ b/app/packages/relay/src/graphQLSyncFragmentAtom.test.ts
@@ -64,7 +64,10 @@ const mountAtomEffect = async (key: string) => {
     return null;
   };
 
-  return render(createElement(RecoilRoot, null, createElement(Reader)));
+  return {
+    ...render(createElement(RecoilRoot, null, createElement(Reader))),
+    subscribe,
+  };
 };
 
 beforeEach(() => {
@@ -83,10 +86,28 @@ afterEach(() => {
 
 describe("graphQLSyncFragmentAtom effect retries", () => {
   test("does not subscribe without a resolved fragment context", async () => {
-    mocks.resolveFragmentChain.mockReturnValue({ missing: true });
+    const fragmentSubscribe = vi.fn(() => ({ dispose: vi.fn() }));
+    mocks.resolveFragmentChain.mockReturnValueOnce({
+      context: {
+        FragmentResource: { subscribe: fragmentSubscribe },
+        result: {},
+      },
+      data: { id: "initial" },
+      missing: false,
+      parent: {},
+    });
 
-    const { unmount } = await mountAtomEffect("effect-missing-context");
+    const { subscribe, unmount } = await mountAtomEffect(
+      "effect-missing-context",
+    );
+    const publishPage = subscribe.mock.calls[0][0] as (
+      page: PageQuery<OperationType>,
+    ) => void;
+    mocks.resolveFragmentChain.mockReturnValueOnce({ missing: true });
 
+    publishPage(page);
+
+    expect(fragmentSubscribe).toHaveBeenCalledOnce();
     unmount();
   });
 

--- a/app/packages/relay/src/graphQLSyncFragmentAtom.ts
+++ b/app/packages/relay/src/graphQLSyncFragmentAtom.ts
@@ -61,8 +61,6 @@ export function graphQLSyncFragmentAtom<T extends KeyType, K = T[" $data"]>(
           return undefined;
         }
         const { pageQuery, subscribe } = getPageQuery();
-        let ctx: ReturnType<typeof loadContext>;
-        let parent: unknown;
         let disposable: Disposable | undefined = undefined;
         let previous: null | T[" $data"] = null;
         const setter = (
@@ -93,17 +91,31 @@ export function graphQLSyncFragmentAtom<T extends KeyType, K = T[" $data"]>(
               fragmentOptions.keys,
               preloadedQuery.environment,
             );
-            ctx = resolved.context ?? ctx;
-            parent = resolved.parent ?? parent;
 
             if (resolved.missing) {
-              const unlisten = ctx.FragmentResource.subscribe(
-                ctx.result,
+              setter(null, transactionInterface);
+              if (!resolved.context) {
+                return undefined;
+              }
+
+              // `subscribe` may invoke its callback before returning, so this
+              // cannot be initialized as a const before the callback closes over it.
+              let retry: Disposable | undefined;
+              let resumed: Disposable | undefined;
+              // eslint-disable-next-line prefer-const
+              retry = resolved.context.FragmentResource.subscribe(
+                resolved.context.result,
                 () => {
-                  run(page);
-                  unlisten();
+                  retry?.dispose();
+                  resumed = run(page);
+                  disposable = resumed;
                 },
               );
+              return resumed ?? retry;
+            }
+
+            const ctx = resolved.context;
+            if (!ctx) {
               setter(null, transactionInterface);
               return undefined;
             }
@@ -115,10 +127,12 @@ export function graphQLSyncFragmentAtom<T extends KeyType, K = T[" $data"]>(
               const update = loadContext(
                 fragmentOptions.fragments[fragmentOptions.fragments.length - 1],
                 preloadedQuery.environment,
-                parent,
+                resolved.parent,
               ).result.data;
               setter(update);
-              !update && run(page);
+              if (!update) {
+                disposable = run(page);
+              }
             });
           } catch (e) {
             setter(null, transactionInterface);

--- a/app/packages/relay/src/graphQLSyncFragmentAtom.ts
+++ b/app/packages/relay/src/graphQLSyncFragmentAtom.ts
@@ -9,7 +9,7 @@ import {
 import { GraphQLTaggedNode, OperationType } from "relay-runtime";
 import { KeyType } from "relay-runtime/lib/store/readInlineData";
 import { selectorWithEffect } from "./selectorWithEffect";
-import { loadContext } from "./utils";
+import { loadContext, resolveFragmentChain } from "./utils";
 import { getPageQuery, PageQuery, registerPageSync } from "./Writer";
 
 export type GraphQLSyncFragmentAtomOptions<K> = Omit<AtomOptions<K>, "default">;
@@ -86,32 +86,29 @@ export function graphQLSyncFragmentAtom<T extends KeyType, K = T[" $data"]>(
           transactionInterface?: TransactionInterface_UNSTABLE,
         ): Disposable | undefined => {
           const preloadedQuery = page.preloadedQuery;
-          let data = page.data;
           try {
-            for (let i = 0; i < fragmentOptions.fragments.length; i++) {
-              const fragment = fragmentOptions.fragments[i];
+            const resolved = resolveFragmentChain(
+              page.data,
+              fragmentOptions.fragments,
+              fragmentOptions.keys,
+              preloadedQuery.environment,
+            );
+            ctx = resolved.context ?? ctx;
+            parent = resolved.parent ?? parent;
 
-              if (fragmentOptions.keys && fragmentOptions.keys[i]) {
-                // @ts-ignore
-                data = data[fragmentOptions.keys[i]];
-              }
-
-              if (!data) {
-                const unlisten = ctx.FragmentResource.subscribe(
-                  ctx.result,
-                  () => {
-                    run(page);
-                    unlisten();
-                  },
-                );
-              }
-
-              // @ts-ignore
-              ctx = loadContext(fragment, preloadedQuery.environment, data);
-              parent = data;
-              data = ctx.result.data;
+            if (resolved.missing) {
+              const unlisten = ctx.FragmentResource.subscribe(
+                ctx.result,
+                () => {
+                  run(page);
+                  unlisten();
+                },
+              );
+              setter(null, transactionInterface);
+              return undefined;
             }
-            setter(data, transactionInterface);
+
+            setter(resolved.data as null | T[" $data"], transactionInterface);
             disposable?.dispose();
 
             return ctx.FragmentResource.subscribe(ctx.result, () => {
@@ -169,37 +166,22 @@ export function graphQLSyncFragmentAtom<T extends KeyType, K = T[" $data"]>(
         previousPageData = null;
       };
 
-      let data: unknown = page.data;
       try {
-        for (let i = 0; i < fragmentOptions.fragments.length; i++) {
-          // `keys[i]` descends from the current operation/fragment result to the
-          // fragment reference consumed at this level. For example, "dataset"
-          // moves from the query response to its Dataset fragment reference.
-          const key = fragmentOptions.keys?.[i];
-          if (key) {
-            data =
-              typeof data === "object" && data !== null
-                ? (data as Record<string, unknown>)[key]
-                : null;
-          }
+        const resolved = resolveFragmentChain(
+          page.data,
+          fragmentOptions.fragments,
+          fragmentOptions.keys,
+          page.preloadedQuery.environment,
+        );
 
-          // A missing parent belongs to the new page. Reset immediately instead
-          // of leaving a valid-looking value from the previous dataset in Recoil.
-          if (!data) {
-            reset();
-            return;
-          }
-
-          // Relay masks fragment data. Resolve the current fragment reference,
-          // then feed its unmasked result into the next fragment in the chain.
-          data = loadContext(
-            fragmentOptions.fragments[i],
-            page.preloadedQuery.environment,
-            data,
-          ).result.data;
+        // A missing parent belongs to the new page. Reset immediately instead
+        // of leaving a valid-looking value from the previous dataset in Recoil.
+        if (resolved.missing) {
+          reset();
+          return;
         }
 
-        const fragmentData = data as T[" $data"];
+        const fragmentData = resolved.data as T[" $data"];
 
         // Keep an independent history for the eager path. Some `read` functions
         // compare dataset IDs with their previous fragment to reset local state;

--- a/app/packages/relay/src/graphQLSyncFragmentAtom.ts
+++ b/app/packages/relay/src/graphQLSyncFragmentAtom.ts
@@ -129,10 +129,11 @@ export function graphQLSyncFragmentAtom<T extends KeyType, K = T[" $data"]>(
                 preloadedQuery.environment,
                 resolved.parent,
               ).result.data;
-              setter(update);
               if (!update) {
                 disposable = run(page);
+                return;
               }
+              setter(update);
             });
           } catch (e) {
             setter(null, transactionInterface);

--- a/app/packages/relay/src/graphQLSyncFragmentAtom.ts
+++ b/app/packages/relay/src/graphQLSyncFragmentAtom.ts
@@ -10,7 +10,7 @@ import { GraphQLTaggedNode, OperationType } from "relay-runtime";
 import { KeyType } from "relay-runtime/lib/store/readInlineData";
 import { selectorWithEffect } from "./selectorWithEffect";
 import { loadContext } from "./utils";
-import { getPageQuery, PageQuery } from "./Writer";
+import { getPageQuery, PageQuery, registerPageSync } from "./Writer";
 
 export type GraphQLSyncFragmentAtomOptions<K> = Omit<AtomOptions<K>, "default">;
 
@@ -30,7 +30,18 @@ const isTest = typeof process !== "undefined" && process.env.MODE === "test";
 /**
  * Creates a recoil atom synced with a relay fragment via its path in a query.
  * If the fragment path cannot be read from given the parent fragment keys and
- * the optional final read function, the atom's default value will be used
+ * the optional final read function, the atom's default value will be used.
+ *
+ * Synchronization happens through two complementary paths:
+ *
+ * 1. The atom effect below initializes active consumers, follows page changes,
+ *    and owns the live Relay fragment subscription.
+ * 2. The page synchronizer registered after the atom definition participates
+ *    in every Writer transaction, including transitions published before this
+ *    atom has an active consumer.
+ *
+ * The second path prevents a long-lived RecoilRoot from exposing a retained
+ * value from the previous dataset while the next dataset's consumers mount.
  */
 export function graphQLSyncFragmentAtom<T extends KeyType, K = T[" $data"]>(
   fragmentOptions: GraphQLSyncFragmentSyncAtomOptions<T, K>,
@@ -44,10 +55,10 @@ export function graphQLSyncFragmentAtom<T extends KeyType, K = T[" $data"]>(
       ({ setSelf, trigger }) => {
         // recoil state should be initialized via RecoilRoot's initializeState
         // during tests
-        if (isTest) return;
+        if (isTest) return undefined;
 
         if (trigger === "set") {
-          return;
+          return undefined;
         }
         const { pageQuery, subscribe } = getPageQuery();
         let ctx: ReturnType<typeof loadContext>;
@@ -128,6 +139,89 @@ export function graphQLSyncFragmentAtom<T extends KeyType, K = T[" $data"]>(
       },
     ],
   });
+
+  /*
+   * The effect subscription above exists only after this atom is initialized
+   * in the current consumer lifecycle. The application keeps its RecoilRoot
+   * mounted while routing between datasets, so a page can be published while
+   * a particular atom has no mounted consumer even though its previous value
+   * is still observable through retained selector state.
+   *
+   * Registering at atom-definition time closes that gap. Writer invokes these
+   * keyed synchronizers before ordinary effect subscribers and inside the same
+   * Recoil transaction, so dataset identity, media type, fields, and other
+   * fragment-backed state all advance as one snapshot. Keying by the Recoil
+   * atom key also makes module replacement overwrite the prior registration
+   * instead of accumulating duplicate callbacks.
+   *
+   * This does not replace the atom effect. The effect still owns live Relay
+   * updates after mount; this callback establishes the page-transition
+   * baseline. An active atom may therefore receive the same page from both
+   * paths, but both writes are derived from the identical page payload.
+   */
+  // Match the atom effect above: tests initialize Recoil state directly and do
+  // not participate in the runtime Writer synchronization lifecycle.
+  if (!isTest) {
+    let previousPageData: null | T[" $data"] = null;
+    registerPageSync(options.key, (page, transactionInterface) => {
+      const reset = () => {
+        transactionInterface.set(value, fragmentOptions.default);
+        previousPageData = null;
+      };
+
+      let data: unknown = page.data;
+      try {
+        for (let i = 0; i < fragmentOptions.fragments.length; i++) {
+          // `keys[i]` descends from the current operation/fragment result to the
+          // fragment reference consumed at this level. For example, "dataset"
+          // moves from the query response to its Dataset fragment reference.
+          const key = fragmentOptions.keys?.[i];
+          if (key) {
+            data =
+              typeof data === "object" && data !== null
+                ? (data as Record<string, unknown>)[key]
+                : null;
+          }
+
+          // A missing parent belongs to the new page. Reset immediately instead
+          // of leaving a valid-looking value from the previous dataset in Recoil.
+          if (!data) {
+            reset();
+            return;
+          }
+
+          // Relay masks fragment data. Resolve the current fragment reference,
+          // then feed its unmasked result into the next fragment in the chain.
+          data = loadContext(
+            fragmentOptions.fragments[i],
+            page.preloadedQuery.environment,
+            data,
+          ).result.data;
+        }
+
+        const fragmentData = data as T[" $data"];
+
+        // Keep an independent history for the eager path. Some `read` functions
+        // compare dataset IDs with their previous fragment to reset local state;
+        // sharing the effect's history would make duplicate page delivery alter
+        // those semantics depending on whether a consumer happened to be mounted.
+        transactionInterface.set(
+          value,
+          fragmentOptions.read && fragmentData !== null
+            ? fragmentOptions.read(fragmentData, previousPageData)
+            : fragmentData === null
+              ? fragmentOptions.default
+              : (fragmentData as K),
+        );
+        previousPageData = fragmentData;
+      } catch {
+        // A missing fragment reference or incompatible query shape must not leak
+        // state across pages. The normal atom effect can populate the value later
+        // if Relay makes the fragment available through a live update.
+        reset();
+      }
+    });
+  }
 
   if (fragmentOptions.selectorEffect) {
     return selectorWithEffect(

--- a/app/packages/relay/src/queries/__generated__/datasetQuery.graphql.ts
+++ b/app/packages/relay/src/queries/__generated__/datasetQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6f5f0c4e9278aa35c02065203033d5e7>>
+ * @generated SignedSource<<859f77bb452be95aa059a20d2c66a3b9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -79,6 +79,7 @@ export type datasetQuery$data = {
       } | null;
     } | null;
     readonly defaultGroupSlice: string | null;
+    readonly mediaType: string | null;
     readonly name: string;
     readonly savedViewSlug: string | null;
     readonly viewName: string | null;
@@ -187,38 +188,45 @@ v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "defaultGroupSlice",
+  "name": "mediaType",
   "storageKey": null
 },
 v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "viewName",
+  "name": "defaultGroupSlice",
   "storageKey": null
 },
 v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "savedViewSlug",
+  "name": "viewName",
   "storageKey": null
 },
 v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "id",
+  "name": "savedViewSlug",
   "storageKey": null
 },
 v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v13 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "color",
   "storageKey": null
 },
-v13 = [
+v14 = [
   {
     "alias": null,
     "args": null,
@@ -226,51 +234,51 @@ v13 = [
     "name": "intTarget",
     "storageKey": null
   },
-  (v12/*: any*/)
+  (v13/*: any*/)
 ],
-v14 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "value",
   "storageKey": null
 },
-v15 = [
-  (v14/*: any*/),
-  (v12/*: any*/)
+v16 = [
+  (v15/*: any*/),
+  (v13/*: any*/)
 ],
-v16 = {
+v17 = {
   "alias": null,
   "args": null,
   "concreteType": "ColorscaleList",
   "kind": "LinkedField",
   "name": "list",
   "plural": true,
-  "selections": (v15/*: any*/),
-  "storageKey": null
-},
-v17 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "rgb",
+  "selections": (v16/*: any*/),
   "storageKey": null
 },
 v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "path",
+  "name": "rgb",
   "storageKey": null
 },
 v19 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "fieldColor",
+  "name": "path",
   "storageKey": null
 },
 v20 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "fieldColor",
+  "storageKey": null
+},
+v21 = {
   "alias": null,
   "args": null,
   "concreteType": "ColorScheme",
@@ -278,7 +286,7 @@ v20 = {
   "name": "colorScheme",
   "plural": false,
   "selections": [
-    (v11/*: any*/),
+    (v12/*: any*/),
     (v1/*: any*/),
     (v2/*: any*/),
     (v4/*: any*/),
@@ -297,7 +305,7 @@ v20 = {
       "kind": "LinkedField",
       "name": "defaultMaskTargetsColors",
       "plural": true,
-      "selections": (v13/*: any*/),
+      "selections": (v14/*: any*/),
       "storageKey": null
     },
     {
@@ -309,8 +317,8 @@ v20 = {
       "plural": false,
       "selections": [
         (v7/*: any*/),
-        (v16/*: any*/),
-        (v17/*: any*/)
+        (v17/*: any*/),
+        (v18/*: any*/)
       ],
       "storageKey": null
     },
@@ -322,10 +330,10 @@ v20 = {
       "name": "colorscales",
       "plural": true,
       "selections": [
-        (v18/*: any*/),
+        (v19/*: any*/),
         (v7/*: any*/),
-        (v16/*: any*/),
-        (v17/*: any*/)
+        (v17/*: any*/),
+        (v18/*: any*/)
       ],
       "storageKey": null
     },
@@ -337,7 +345,7 @@ v20 = {
       "name": "labelTags",
       "plural": false,
       "selections": [
-        (v19/*: any*/),
+        (v20/*: any*/),
         {
           "alias": null,
           "args": null,
@@ -345,7 +353,7 @@ v20 = {
           "kind": "LinkedField",
           "name": "valueColors",
           "plural": true,
-          "selections": (v15/*: any*/),
+          "selections": (v16/*: any*/),
           "storageKey": null
         }
       ],
@@ -366,8 +374,8 @@ v20 = {
           "name": "colorByAttribute",
           "storageKey": null
         },
+        (v20/*: any*/),
         (v19/*: any*/),
-        (v18/*: any*/),
         {
           "alias": null,
           "args": null,
@@ -375,7 +383,7 @@ v20 = {
           "kind": "LinkedField",
           "name": "maskTargetsColors",
           "plural": true,
-          "selections": (v13/*: any*/),
+          "selections": (v14/*: any*/),
           "storageKey": null
         },
         {
@@ -386,8 +394,8 @@ v20 = {
           "name": "valueColors",
           "plural": true,
           "selections": [
-            (v12/*: any*/),
-            (v14/*: any*/)
+            (v13/*: any*/),
+            (v15/*: any*/)
           ],
           "storageKey": null
         }
@@ -397,14 +405,14 @@ v20 = {
   ],
   "storageKey": null
 },
-v21 = {
+v22 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v22 = {
+v23 = {
   "alias": null,
   "args": [
     {
@@ -418,7 +426,7 @@ v22 = {
   "name": "workspace",
   "plural": false,
   "selections": [
-    (v11/*: any*/),
+    (v12/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -426,71 +434,64 @@ v22 = {
       "name": "child",
       "storageKey": null
     },
-    (v21/*: any*/)
+    (v22/*: any*/)
   ],
-  "storageKey": null
-},
-v23 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "disableFrameFiltering",
   "storageKey": null
 },
 v24 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "mediaFallback",
+  "name": "disableFrameFiltering",
   "storageKey": null
 },
 v25 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "plugins",
+  "name": "mediaFallback",
   "storageKey": null
 },
 v26 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "paths",
+  "name": "plugins",
   "storageKey": null
 },
 v27 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "createdAt",
+  "name": "paths",
   "storageKey": null
 },
 v28 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "datasetId",
+  "name": "createdAt",
   "storageKey": null
 },
 v29 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "info",
+  "name": "datasetId",
   "storageKey": null
 },
 v30 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "lastLoadedAt",
+  "name": "info",
   "storageKey": null
 },
 v31 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "mediaType",
+  "name": "lastLoadedAt",
   "storageKey": null
 },
 v32 = {
@@ -543,7 +544,7 @@ v38 = [
     "name": "target",
     "storageKey": null
   },
-  (v14/*: any*/)
+  (v15/*: any*/)
 ],
 v39 = {
   "alias": null,
@@ -654,11 +655,11 @@ v47 = {
   "variableName": "name"
 },
 v48 = [
-  (v18/*: any*/),
+  (v19/*: any*/),
   (v41/*: any*/),
   (v42/*: any*/),
   (v43/*: any*/),
-  (v29/*: any*/),
+  (v30/*: any*/),
   (v45/*: any*/)
 ];
 return {
@@ -696,6 +697,7 @@ return {
           (v8/*: any*/),
           (v9/*: any*/),
           (v10/*: any*/),
+          (v11/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -704,11 +706,11 @@ return {
             "name": "appConfig",
             "plural": false,
             "selections": [
-              (v20/*: any*/)
+              (v21/*: any*/)
             ],
             "storageKey": null
           },
-          (v22/*: any*/),
+          (v23/*: any*/),
           {
             "args": null,
             "kind": "FragmentSpread",
@@ -760,7 +762,7 @@ return {
           (v3/*: any*/),
           (v4/*: any*/),
           (v5/*: any*/),
-          (v23/*: any*/),
+          (v24/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -789,7 +791,7 @@ return {
             "name": "loopVideos",
             "storageKey": null
           },
-          (v24/*: any*/),
+          (v25/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -804,7 +806,7 @@ return {
             "name": "notebookHeight",
             "storageKey": null
           },
-          (v25/*: any*/),
+          (v26/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -869,6 +871,7 @@ return {
           (v8/*: any*/),
           (v9/*: any*/),
           (v10/*: any*/),
+          (v11/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -877,7 +880,7 @@ return {
             "name": "appConfig",
             "plural": false,
             "selections": [
-              (v20/*: any*/),
+              (v21/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -893,11 +896,11 @@ return {
                     "name": "exclude",
                     "storageKey": null
                   },
-                  (v26/*: any*/)
+                  (v27/*: any*/)
                 ],
                 "storageKey": null
               },
-              (v23/*: any*/),
+              (v24/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -926,8 +929,8 @@ return {
                 "name": "modalMediaField",
                 "storageKey": null
               },
-              (v24/*: any*/),
               (v25/*: any*/),
+              (v26/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -943,7 +946,7 @@ return {
                     "name": "expanded",
                     "storageKey": null
                   },
-                  (v26/*: any*/),
+                  (v27/*: any*/),
                   (v7/*: any*/)
                 ],
                 "storageKey": null
@@ -951,9 +954,9 @@ return {
             ],
             "storageKey": null
           },
-          (v22/*: any*/),
-          (v27/*: any*/),
+          (v23/*: any*/),
           (v28/*: any*/),
+          (v29/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -961,8 +964,7 @@ return {
             "name": "groupField",
             "storageKey": null
           },
-          (v11/*: any*/),
-          (v29/*: any*/),
+          (v12/*: any*/),
           (v30/*: any*/),
           (v31/*: any*/),
           {
@@ -1116,7 +1118,7 @@ return {
             "plural": true,
             "selections": [
               (v7/*: any*/),
-              (v31/*: any*/)
+              (v8/*: any*/)
             ],
             "storageKey": null
           },
@@ -1181,10 +1183,10 @@ return {
               (v41/*: any*/),
               (v42/*: any*/),
               (v43/*: any*/),
-              (v18/*: any*/),
+              (v19/*: any*/),
               (v44/*: any*/),
               (v45/*: any*/),
-              (v29/*: any*/)
+              (v30/*: any*/)
             ],
             "storageKey": null
           },
@@ -1216,13 +1218,13 @@ return {
             "name": "sampleFields",
             "plural": true,
             "selections": [
-              (v18/*: any*/),
+              (v19/*: any*/),
               (v41/*: any*/),
               (v42/*: any*/),
               (v43/*: any*/),
               (v44/*: any*/),
               (v45/*: any*/),
-              (v29/*: any*/)
+              (v30/*: any*/)
             ],
             "storageKey": null
           },
@@ -1264,14 +1266,14 @@ return {
         "name": "savedViews",
         "plural": true,
         "selections": [
-          (v11/*: any*/),
-          (v28/*: any*/),
-          (v7/*: any*/),
-          (v21/*: any*/),
-          (v45/*: any*/),
           (v12/*: any*/),
+          (v29/*: any*/),
+          (v7/*: any*/),
+          (v22/*: any*/),
+          (v45/*: any*/),
+          (v13/*: any*/),
           (v35/*: any*/),
-          (v27/*: any*/),
+          (v28/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -1279,7 +1281,7 @@ return {
             "name": "lastModifiedAt",
             "storageKey": null
           },
-          (v30/*: any*/)
+          (v31/*: any*/)
         ],
         "storageKey": null
       },
@@ -1364,16 +1366,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "7aaa32d09d4bb1e93da9bb9803a1b1a0",
+    "cacheID": "020d3edfd5076d9c700df708159aa54d",
     "id": null,
     "metadata": {},
     "name": "datasetQuery",
     "operationKind": "query",
-    "text": "query datasetQuery(\n  $extendedView: BSONArray!\n  $name: String!\n  $savedViewSlug: String\n  $view: BSONArray!\n  $workspaceSlug: String\n) {\n  config {\n    colorBy\n    colorPool\n    colorscale\n    multicolorKeypoints\n    showSkeletons\n  }\n  dataset(name: $name, view: $extendedView, savedViewSlug: $savedViewSlug) {\n    name\n    defaultGroupSlice\n    viewName\n    savedViewSlug\n    appConfig {\n      colorScheme {\n        id\n        colorBy\n        colorPool\n        multicolorKeypoints\n        opacity\n        showSkeletons\n        defaultMaskTargetsColors {\n          intTarget\n          color\n        }\n        defaultColorscale {\n          name\n          list {\n            value\n            color\n          }\n          rgb\n        }\n        colorscales {\n          path\n          name\n          list {\n            value\n            color\n          }\n          rgb\n        }\n        labelTags {\n          fieldColor\n          valueColors {\n            value\n            color\n          }\n        }\n        fields {\n          colorByAttribute\n          fieldColor\n          path\n          maskTargetsColors {\n            intTarget\n            color\n          }\n          valueColors {\n            color\n            value\n          }\n        }\n      }\n    }\n    workspace(slug: $workspaceSlug) {\n      id\n      child\n      slug\n    }\n    ...datasetFragment\n    id\n  }\n  ...savedViewsFragment\n  ...configFragment\n  ...stageDefinitionsFragment\n  ...viewSchemaFragment\n}\n\nfragment colorSchemeFragment on ColorScheme {\n  id\n  colorBy\n  colorPool\n  multicolorKeypoints\n  opacity\n  showSkeletons\n  labelTags {\n    fieldColor\n    valueColors {\n      color\n      value\n    }\n  }\n  defaultMaskTargetsColors {\n    intTarget\n    color\n  }\n  defaultColorscale {\n    name\n    list {\n      value\n      color\n    }\n    rgb\n  }\n  colorscales {\n    path\n    name\n    list {\n      value\n      color\n    }\n    rgb\n  }\n  fields {\n    colorByAttribute\n    fieldColor\n    path\n    valueColors {\n      color\n      value\n    }\n    maskTargetsColors {\n      intTarget\n      color\n    }\n  }\n}\n\nfragment configFragment on Query {\n  config {\n    colorBy\n    colorPool\n    colorscale\n    disableFrameFiltering\n    gridZoom\n    enableQueryPerformance\n    defaultQueryPerformance\n    loopVideos\n    mediaFallback\n    maxQueryTime\n    multicolorKeypoints\n    notebookHeight\n    plugins\n    showConfidence\n    showIndex\n    showLabel\n    showSkeletons\n    showTooltip\n    theme\n    timezone\n    useFrameNumber\n  }\n  colorscale\n}\n\nfragment datasetAppConfigFragment on DatasetAppConfig {\n  activeFields {\n    exclude\n    paths\n  }\n  colorScheme {\n    ...colorSchemeFragment\n    id\n  }\n  disableFrameFiltering\n  dynamicGroupsTargetFrameRate\n  gridMediaField\n  mediaFields\n  modalMediaField\n  mediaFallback\n  plugins\n}\n\nfragment datasetFragment on Dataset {\n  createdAt\n  datasetId\n  groupField\n  id\n  info\n  lastLoadedAt\n  mediaType\n  name\n  parentMediaType\n  version\n  appConfig {\n    ...datasetAppConfigFragment\n  }\n  brainMethods {\n    key\n    version\n    timestamp\n    viewStages\n    config {\n      cls\n      embeddingsField\n      method\n      patchesField\n      supportsPrompts\n      type\n      maxK\n      supportsLeastSimilarity\n    }\n  }\n  defaultMaskTargets {\n    target\n    value\n  }\n  defaultSkeleton {\n    labels\n    edges\n  }\n  evaluations {\n    key\n    version\n    timestamp\n    viewStages\n    config {\n      cls\n      predField\n      gtField\n    }\n  }\n  groupMediaTypes {\n    name\n    mediaType\n  }\n  maskTargets {\n    name\n    targets {\n      target\n      value\n    }\n  }\n  skeletons {\n    name\n    labels\n    edges\n  }\n  ...estimatedCountsFragment\n  ...frameFieldsFragment\n  ...groupSliceFragment\n  ...indexesFragment\n  ...mediaFieldsFragment\n  ...mediaTypeFragment\n  ...sampleFieldsFragment\n  ...sidebarGroupsFragment\n  ...viewFragment\n}\n\nfragment estimatedCountsFragment on Dataset {\n  estimatedFrameCount\n  estimatedSampleCount\n}\n\nfragment frameFieldsFragment on Dataset {\n  frameFields {\n    ftype\n    subfield\n    embeddedDocType\n    path\n    dbField\n    description\n    info\n  }\n}\n\nfragment groupSliceFragment on Dataset {\n  defaultGroupSlice\n}\n\nfragment indexesFragment on Dataset {\n  frameIndexes {\n    name\n    unique\n    key {\n      field\n      type\n    }\n    wildcardProjection {\n      fields\n      inclusion\n    }\n  }\n  sampleIndexes {\n    name\n    unique\n    key {\n      field\n      type\n    }\n    wildcardProjection {\n      fields\n      inclusion\n    }\n  }\n}\n\nfragment mediaFieldsFragment on Dataset {\n  name\n  appConfig {\n    gridMediaField\n    mediaFields\n    modalMediaField\n    mediaFallback\n  }\n  sampleFields {\n    path\n  }\n}\n\nfragment mediaTypeFragment on Dataset {\n  mediaType\n}\n\nfragment sampleFieldsFragment on Dataset {\n  sampleFields {\n    ftype\n    subfield\n    embeddedDocType\n    path\n    dbField\n    description\n    info\n  }\n}\n\nfragment savedViewsFragment on Query {\n  savedViews(datasetName: $name) {\n    id\n    datasetId\n    name\n    slug\n    description\n    color\n    viewStages\n    createdAt\n    lastModifiedAt\n    lastLoadedAt\n  }\n}\n\nfragment sidebarGroupsFragment on Dataset {\n  datasetId\n  appConfig {\n    sidebarGroups {\n      expanded\n      paths\n      name\n    }\n  }\n  ...frameFieldsFragment\n  ...sampleFieldsFragment\n}\n\nfragment stageDefinitionsFragment on Query {\n  stageDefinitions {\n    name\n    params {\n      name\n      type\n      default\n      placeholder\n    }\n  }\n}\n\nfragment viewFragment on Dataset {\n  stages(slug: $savedViewSlug, view: $view)\n  viewCls\n  viewName\n}\n\nfragment viewSchemaFragment on Query {\n  schemaForViewStages(datasetName: $name, viewStages: $view) {\n    fieldSchema {\n      path\n      ftype\n      subfield\n      embeddedDocType\n      info\n      description\n    }\n    frameFieldSchema {\n      path\n      ftype\n      subfield\n      embeddedDocType\n      info\n      description\n    }\n  }\n}\n"
+    "text": "query datasetQuery(\n  $extendedView: BSONArray!\n  $name: String!\n  $savedViewSlug: String\n  $view: BSONArray!\n  $workspaceSlug: String\n) {\n  config {\n    colorBy\n    colorPool\n    colorscale\n    multicolorKeypoints\n    showSkeletons\n  }\n  dataset(name: $name, view: $extendedView, savedViewSlug: $savedViewSlug) {\n    name\n    mediaType\n    defaultGroupSlice\n    viewName\n    savedViewSlug\n    appConfig {\n      colorScheme {\n        id\n        colorBy\n        colorPool\n        multicolorKeypoints\n        opacity\n        showSkeletons\n        defaultMaskTargetsColors {\n          intTarget\n          color\n        }\n        defaultColorscale {\n          name\n          list {\n            value\n            color\n          }\n          rgb\n        }\n        colorscales {\n          path\n          name\n          list {\n            value\n            color\n          }\n          rgb\n        }\n        labelTags {\n          fieldColor\n          valueColors {\n            value\n            color\n          }\n        }\n        fields {\n          colorByAttribute\n          fieldColor\n          path\n          maskTargetsColors {\n            intTarget\n            color\n          }\n          valueColors {\n            color\n            value\n          }\n        }\n      }\n    }\n    workspace(slug: $workspaceSlug) {\n      id\n      child\n      slug\n    }\n    ...datasetFragment\n    id\n  }\n  ...savedViewsFragment\n  ...configFragment\n  ...stageDefinitionsFragment\n  ...viewSchemaFragment\n}\n\nfragment colorSchemeFragment on ColorScheme {\n  id\n  colorBy\n  colorPool\n  multicolorKeypoints\n  opacity\n  showSkeletons\n  labelTags {\n    fieldColor\n    valueColors {\n      color\n      value\n    }\n  }\n  defaultMaskTargetsColors {\n    intTarget\n    color\n  }\n  defaultColorscale {\n    name\n    list {\n      value\n      color\n    }\n    rgb\n  }\n  colorscales {\n    path\n    name\n    list {\n      value\n      color\n    }\n    rgb\n  }\n  fields {\n    colorByAttribute\n    fieldColor\n    path\n    valueColors {\n      color\n      value\n    }\n    maskTargetsColors {\n      intTarget\n      color\n    }\n  }\n}\n\nfragment configFragment on Query {\n  config {\n    colorBy\n    colorPool\n    colorscale\n    disableFrameFiltering\n    gridZoom\n    enableQueryPerformance\n    defaultQueryPerformance\n    loopVideos\n    mediaFallback\n    maxQueryTime\n    multicolorKeypoints\n    notebookHeight\n    plugins\n    showConfidence\n    showIndex\n    showLabel\n    showSkeletons\n    showTooltip\n    theme\n    timezone\n    useFrameNumber\n  }\n  colorscale\n}\n\nfragment datasetAppConfigFragment on DatasetAppConfig {\n  activeFields {\n    exclude\n    paths\n  }\n  colorScheme {\n    ...colorSchemeFragment\n    id\n  }\n  disableFrameFiltering\n  dynamicGroupsTargetFrameRate\n  gridMediaField\n  mediaFields\n  modalMediaField\n  mediaFallback\n  plugins\n}\n\nfragment datasetFragment on Dataset {\n  createdAt\n  datasetId\n  groupField\n  id\n  info\n  lastLoadedAt\n  mediaType\n  name\n  parentMediaType\n  version\n  appConfig {\n    ...datasetAppConfigFragment\n  }\n  brainMethods {\n    key\n    version\n    timestamp\n    viewStages\n    config {\n      cls\n      embeddingsField\n      method\n      patchesField\n      supportsPrompts\n      type\n      maxK\n      supportsLeastSimilarity\n    }\n  }\n  defaultMaskTargets {\n    target\n    value\n  }\n  defaultSkeleton {\n    labels\n    edges\n  }\n  evaluations {\n    key\n    version\n    timestamp\n    viewStages\n    config {\n      cls\n      predField\n      gtField\n    }\n  }\n  groupMediaTypes {\n    name\n    mediaType\n  }\n  maskTargets {\n    name\n    targets {\n      target\n      value\n    }\n  }\n  skeletons {\n    name\n    labels\n    edges\n  }\n  ...estimatedCountsFragment\n  ...frameFieldsFragment\n  ...groupSliceFragment\n  ...indexesFragment\n  ...mediaFieldsFragment\n  ...mediaTypeFragment\n  ...sampleFieldsFragment\n  ...sidebarGroupsFragment\n  ...viewFragment\n}\n\nfragment estimatedCountsFragment on Dataset {\n  estimatedFrameCount\n  estimatedSampleCount\n}\n\nfragment frameFieldsFragment on Dataset {\n  frameFields {\n    ftype\n    subfield\n    embeddedDocType\n    path\n    dbField\n    description\n    info\n  }\n}\n\nfragment groupSliceFragment on Dataset {\n  defaultGroupSlice\n}\n\nfragment indexesFragment on Dataset {\n  frameIndexes {\n    name\n    unique\n    key {\n      field\n      type\n    }\n    wildcardProjection {\n      fields\n      inclusion\n    }\n  }\n  sampleIndexes {\n    name\n    unique\n    key {\n      field\n      type\n    }\n    wildcardProjection {\n      fields\n      inclusion\n    }\n  }\n}\n\nfragment mediaFieldsFragment on Dataset {\n  name\n  appConfig {\n    gridMediaField\n    mediaFields\n    modalMediaField\n    mediaFallback\n  }\n  sampleFields {\n    path\n  }\n}\n\nfragment mediaTypeFragment on Dataset {\n  mediaType\n}\n\nfragment sampleFieldsFragment on Dataset {\n  sampleFields {\n    ftype\n    subfield\n    embeddedDocType\n    path\n    dbField\n    description\n    info\n  }\n}\n\nfragment savedViewsFragment on Query {\n  savedViews(datasetName: $name) {\n    id\n    datasetId\n    name\n    slug\n    description\n    color\n    viewStages\n    createdAt\n    lastModifiedAt\n    lastLoadedAt\n  }\n}\n\nfragment sidebarGroupsFragment on Dataset {\n  datasetId\n  appConfig {\n    sidebarGroups {\n      expanded\n      paths\n      name\n    }\n  }\n  ...frameFieldsFragment\n  ...sampleFieldsFragment\n}\n\nfragment stageDefinitionsFragment on Query {\n  stageDefinitions {\n    name\n    params {\n      name\n      type\n      default\n      placeholder\n    }\n  }\n}\n\nfragment viewFragment on Dataset {\n  stages(slug: $savedViewSlug, view: $view)\n  viewCls\n  viewName\n}\n\nfragment viewSchemaFragment on Query {\n  schemaForViewStages(datasetName: $name, viewStages: $view) {\n    fieldSchema {\n      path\n      ftype\n      subfield\n      embeddedDocType\n      info\n      description\n    }\n    frameFieldSchema {\n      path\n      ftype\n      subfield\n      embeddedDocType\n      info\n      description\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "a5edcbc186105a918451852ba2eecdbe";
+(node as any).hash = "ee54f4e55c20cbfd11663bcf29e3f0ff";
 
 export default node;

--- a/app/packages/relay/src/queries/dataset.ts
+++ b/app/packages/relay/src/queries/dataset.ts
@@ -18,6 +18,7 @@ export default graphql`
 
     dataset(name: $name, view: $extendedView, savedViewSlug: $savedViewSlug) {
       name
+      mediaType
       defaultGroupSlice
       viewName
       savedViewSlug

--- a/app/packages/relay/src/utils.ts
+++ b/app/packages/relay/src/utils.ts
@@ -33,6 +33,42 @@ export function loadContext(
   };
 }
 
+/**
+ * Resolves a nested Relay fragment chain from operation data.
+ *
+ * The returned context and parent belong to the last successfully resolved
+ * fragment so callers can attach their own live subscription behavior.
+ */
+export function resolveFragmentChain(
+  data: unknown,
+  fragments: GraphQLTaggedNode[],
+  keys: string[] | undefined,
+  environment: IEnvironment,
+) {
+  let context: ReturnType<typeof loadContext> | undefined;
+  let parent: unknown;
+
+  for (let i = 0; i < fragments.length; i++) {
+    const key = keys?.[i];
+    if (key) {
+      data =
+        typeof data === "object" && data !== null
+          ? (data as Record<string, unknown>)[key]
+          : null;
+    }
+
+    if (!data) {
+      return { context, data, missing: true, parent };
+    }
+
+    parent = data;
+    context = loadContext(fragments[i], environment, data);
+    data = context.result.data;
+  }
+
+  return { context, data, missing: false, parent };
+}
+
 export function readFragment<TKey extends KeyType>(
   fragmentInput: GraphQLTaggedNode,
   fragmentRef: TKey,


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

Synchronizes retained Relay fragment state during every dataset page transition, including transitions that occur before an atom remounts. Adds the page query media type and a Writer regression test.
(Internal note: this is more relevant in enterprise when we switch datasets)

## 🧪 How is this patch tested? If it is not, please explain why.

- `DISABLE_COVERAGE=true yarn vitest run packages/relay/src/Writer.test.tsx --no-coverage`
- `yarn eslint packages/relay/src/Writer.tsx packages/relay/src/Writer.test.tsx packages/relay/src/graphQLSyncFragmentAtom.ts packages/relay/src/queries/dataset.ts`
- `yarn relay-compiler --validate`
- Manually switched between datasets with different media schemas and verified the destination fields and sample grid replaced the prior dataset state.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

N/A.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added page-wide synchronization for GraphQL fragment data via keyed page sync subscribers, including dataset transition handling.
  * Introduced `resolveFragmentChain` to resolve multi-step fragment chains and drive page synchronization updates.
  * Extended dataset queries to include `mediaType`.
* **Bug Fixes**
  * Improved fragment synchronization by resetting to defaults when context is missing or fragment resolution fails, and correctly maintaining `previous`/`current` across runs.
* **Tests**
  * Added and expanded Vitest coverage for page sync registration/invocation/cleanup and fragment sync retry, success, and fallback behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3263
<!-- enterprise-sync-pr:end -->