### PR TITLE
Enable video annotation for grouped datasets with video slices

### DIFF
--- a/app/packages/annotation/src/engine/README.md
+++ b/app/packages/annotation/src/engine/README.md
@@ -333,8 +333,8 @@ const Sidebar = ({ engine, sample }: Props) => {
         anchor ? e.getLabel(anchor) : undefined,
     );
 
-    // writes: the shared ref-addressed write-half
-    const actions = useSurfaceActions(engine, "sidebar");
+    // writes: the shared ref-addressed write-half, scoped to this surface's sample
+    const actions = useSurfaceActions(engine, "sidebar", sample);
 
     return (
         <>

--- a/app/packages/annotation/src/engine/integration.test.tsx
+++ b/app/packages/annotation/src/engine/integration.test.tsx
@@ -190,7 +190,7 @@ const useMockSidebar = (engine: AnnotationEngine, sample: string) => {
   const form = useEngineSelector(engine, (e) =>
     anchor ? e.getLabel(anchor) : undefined,
   );
-  const actions = useSurfaceActions(engine, "mock-sidebar");
+  const actions = useSurfaceActions(engine, "mock-sidebar", "sample-1");
 
   return { entries, anchor, activeIds, hoveredIds, form, actions };
 };

--- a/app/packages/annotation/src/engine/react/hooks.test.tsx
+++ b/app/packages/annotation/src/engine/react/hooks.test.tsx
@@ -131,12 +131,14 @@ describe("useTemporal", () => {
 });
 
 describe("useSurfaceActions", () => {
-  it("writes through the ambient sample scope", () => {
+  it("writes through the given sample scope", () => {
     const { engine } = makeEngine("sample-1", {
       ground_truth: { detections: [makeDet("d1", "cat")] },
     });
 
-    const { result } = renderHook(() => useSurfaceActions(engine, "sidebar"));
+    const { result } = renderHook(() =>
+      useSurfaceActions(engine, "sidebar", "sample-1"),
+    );
 
     act(() => {
       result.current.updateLabel(
@@ -152,7 +154,7 @@ describe("useSurfaceActions", () => {
   it("is referentially stable across re-renders", () => {
     const { engine } = makeEngine();
     const { result, rerender } = renderHook(() =>
-      useSurfaceActions(engine, "sidebar"),
+      useSurfaceActions(engine, "sidebar", "sample-1"),
     );
     const first = result.current;
 

--- a/app/packages/annotation/src/engine/react/hooks.ts
+++ b/app/packages/annotation/src/engine/react/hooks.ts
@@ -193,17 +193,23 @@ export const useSignalValue = <T>(
   return value;
 };
 
-/** The shared ref-addressed write-half, bound to the ambient sample. */
+/**
+ * The shared ref-addressed write-half, bound to an explicit sample scope. The
+ * caller injects the surface's sample (like a bridge carries `bridge.sample`) —
+ * relying on `engine.ambientSample()` would throw once a grouped modal
+ * registers more than one store.
+ */
 export const useSurfaceActions = (
   engine: AnnotationEngine,
   surface: string,
+  sample: string,
 ): SurfaceActions =>
   useMemo(
     () =>
       createSurfaceActions({
         engine,
         surface,
-        getSample: () => engine.ambientSample(),
+        getSample: () => sample,
       }),
-    [engine, surface],
+    [engine, surface, sample],
   );

--- a/app/packages/annotation/src/state/useEngine.test.tsx
+++ b/app/packages/annotation/src/state/useEngine.test.tsx
@@ -4,10 +4,10 @@ import { describe, expect, it, vi } from "vitest";
 import { useAnnotationEngine, useSyncAnnotationEngine } from "./useEngine";
 import { useSampleInstance } from "./useSample";
 
-let mockModalSample: { sample?: { _id: string } } | undefined;
+let mockModalSample:
+  | { sample?: { _id: string; media_type?: string } }
+  | undefined;
 let mockSceneSample: { sample?: { _id: string } } | undefined;
-
-let mockIsVideo = false;
 
 vi.mock("@fiftyone/state", () => ({
   useModalSample: () => mockModalSample,
@@ -16,8 +16,6 @@ vi.mock("@fiftyone/state", () => ({
   // collapses to one
   useStableSceneSample3d: () => mockSceneSample,
   useCurrentSampleId: () => mockModalSample?.sample?._id ?? null,
-  // a video modal sample is owned by the video surface, not this hook
-  useIsVideo: () => mockIsVideo,
 }));
 
 const schema = {
@@ -69,9 +67,10 @@ describe("useSyncAnnotationEngine", () => {
   });
 
   it("skips a video modal sample — the video surface owns it", () => {
-    mockModalSample = { sample: { _id: "vid" } };
+    // a video modal sample (media_type "video") is owned by the video surface,
+    // not this hook
+    mockModalSample = { sample: { _id: "vid", media_type: "video" } };
     mockSceneSample = undefined;
-    mockIsVideo = true;
 
     const { result, unmount } = renderSync();
 
@@ -84,7 +83,6 @@ describe("useSyncAnnotationEngine", () => {
     ).toThrow(/no store/);
 
     unmount();
-    mockIsVideo = false;
   });
 
   it("registers nothing without a modal sample", () => {

--- a/app/packages/annotation/src/state/useEngine.ts
+++ b/app/packages/annotation/src/state/useEngine.ts
@@ -1,4 +1,4 @@
-import { useIsVideo } from "@fiftyone/state";
+import { useModalSample } from "@fiftyone/state";
 import { atom, useAtomValue } from "jotai";
 import { useEffect, useMemo } from "react";
 import { AnnotationEngine } from "../engine/core/engine";
@@ -43,7 +43,16 @@ export const useSyncAnnotationEngine = (): void => {
   const getSample = useSampleInstanceGetter();
   const modalId = useActiveSampleId();
   const sceneId = useThreeDSceneSampleId();
-  const isVideo = useIsVideo();
+
+  // Whether the SELECTED modal sample is a video — true for a video dataset or
+  // a grouped dataset whose selected slice is a video sample. The dataset-level
+  // media type is "group" for a group, so decide from the open sample (matches
+  // ModalLooker's video-surface decision). The video surface owns that sample's
+  // store, so the root must skip it in both cases.
+  const modalSample = useModalSample();
+  const isVideo =
+    ((modalSample?.sample?.media_type as unknown as string) ??
+      modalSample?.sample?._media_type) === "video";
 
   // the modal's distinct sample documents — a grouped 2D + 3D modal renders
   // two at once (the selected slice and the pinned 3D scene, already guaranteed

--- a/app/packages/core/src/components/Modal/ModalLooker.tsx
+++ b/app/packages/core/src/components/Modal/ModalLooker.tsx
@@ -76,11 +76,16 @@ const ModalLookerContent = React.memo(
     const shouldRenderImavid = useRecoilValue(
       fos.shouldRenderImaVidLooker(true),
     );
-    const video = useRecoilValue(fos.isVideoDataset);
+    const isVideoDataset = useRecoilValue(fos.isVideoDataset);
 
     const mediaType =
       (sample.sample.media_type as unknown as string) ??
       sample.sample._media_type;
+
+    // the root dataset media type is "group" for grouped datasets, so decide
+    // the video surface from the open sample: true for a video dataset or a
+    // grouped dataset whose active slice is a video sample
+    const video = isVideoDataset || mediaType === "video";
 
     const isNative = isNativeMediaType(mediaType as string);
     const isAnnotate = mode === fos.ModalMode.ANNOTATE;

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Annotate.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Annotate.tsx
@@ -28,6 +28,7 @@ import {
 } from "@fiftyone/annotation";
 import { useLighterAnnotationBridge } from "./useLighterAnnotationBridge";
 import { useLooker3dAnnotationBridge } from "./useLooker3dAnnotationBridge";
+import { useSyncAnnotationSliceMediaType } from "./useSyncAnnotationSliceMediaType";
 
 const DISABLED_MESSAGES: Record<
   Exclude<AnnotationDisabledReason, null>,
@@ -120,6 +121,7 @@ const Annotate = ({ disabledReason, loadSchemas }: AnnotateProps) => {
   useSyncModalSample();
   useSync3dModalSample();
   useSyncAnnotationEngine();
+  useSyncAnnotationSliceMediaType();
   useEngineUndoableBridge();
   useLighterAnnotationBridge();
   useLooker3dAnnotationBridge();

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/state.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/state.ts
@@ -35,9 +35,68 @@ export const activeLabelSchemas = atom<string[] | null>(null);
 export const exploreActiveFields = atom<string[] | null>(null);
 
 /**
- * Intersection of activeLabelSchemas and exploreActiveFields.
+ * Media type of the group slice currently being annotated, mirrored from Recoil
+ * by `useSyncAnnotationSliceMediaType`. null when the dataset isn't grouped — in
+ * that case visibleLabelSchemas applies no per-slice filtering. Recoil can't be
+ * read from inside a Jotai getter, so the slice media type is bridged in (same
+ * pattern as exploreActiveFields).
+ */
+export const annotationSliceMediaType = atom<string | null>(null);
+
+const FRAMES_PREFIX = "frames.";
+const CLASSIFICATION_TYPES = new Set(["classification", "classifications"]);
+const TEMPORAL_TYPES = new Set(["temporaldetection", "temporaldetections"]);
+
+/**
+ * Whether an active-schema path is annotatable on a slice of the given media
+ * type. In a grouped dataset the active schema is a superset across slices, so
+ * navigating to a slice must hide the paths that slice can't carry:
+ *   - frame fields (`frames.*`) exist only on video slices;
+ *   - temporal detections span frames, so they're video-only;
+ *   - spatial sample-level labels (detection/polyline/keypoint/seg) live in
+ *     `frames.*` on video, so at the sample level they belong to image/3d;
+ *   - classifications and primitive scalars are whole-sample — valid anywhere.
+ * `sliceMediaType == null` means the dataset isn't grouped → no filtering.
+ */
+const isPathAnnotatableOnSlice = (
+  path: string,
+  rawType: string | undefined,
+  isPrimitive: boolean,
+  sliceMediaType: string | null,
+): boolean => {
+  if (sliceMediaType == null) {
+    return true;
+  }
+
+  const isVideo = sliceMediaType === "video";
+
+  if (path.startsWith(FRAMES_PREFIX)) {
+    return isVideo;
+  }
+
+  if (isPrimitive) {
+    return true;
+  }
+
+  const type = (rawType ?? "").toLowerCase();
+
+  if (CLASSIFICATION_TYPES.has(type)) {
+    return true;
+  }
+
+  if (TEMPORAL_TYPES.has(type)) {
+    return isVideo;
+  }
+
+  return !isVideo;
+};
+
+/**
+ * Intersection of activeLabelSchemas and exploreActiveFields, further narrowed
+ * to the paths the current group slice supports (see isPathAnnotatableOnSlice).
  * Display consumers should read this instead of activeLabelSchemas so that
- * hiding a field in the Explore sidebar also hides it in Annotate.
+ * hiding a field in the Explore sidebar also hides it in Annotate, and so that
+ * navigating between slices only offers schemas valid for the open slice.
  */
 export const visibleLabelSchemas = atom((get) => {
   const active = get(activeLabelSchemas);
@@ -45,14 +104,23 @@ export const visibleLabelSchemas = atom((get) => {
 
   const explore = get(exploreActiveFields);
   const exploreSet = new Set(explore ?? []);
+  const sliceMediaType = get(annotationSliceMediaType);
+
   return active.filter((field) => {
     const type = get(fieldType(field));
     // Primitive fields don't appear in the Explore sidebar — always show them.
     // Everything else is a label (embedded doc) type — filter by explore visibility.
-    if (type && PRIMITIVE_FIELD_TYPES.has(type)) {
-      return true;
+    const isPrimitive = !!type && PRIMITIVE_FIELD_TYPES.has(type);
+    if (!isPrimitive && !exploreSet.has(field)) {
+      return false;
     }
-    return exploreSet.has(field);
+
+    return isPathAnnotatableOnSlice(
+      field,
+      get(labelSchemaData(field))?.type,
+      isPrimitive,
+      sliceMediaType,
+    );
   });
 });
 

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useCanAnnotate.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useCanAnnotate.ts
@@ -12,10 +12,10 @@ import { useRecoilValue } from "recoil";
 
 /**
  * Returns true if the current group dataset has at least one slice with a
- * media type that supports annotation (image or 3D).
+ * media type that supports annotation (image, video, or 3D).
  */
 function useHasAnnotationSupportedSlices(): boolean {
-  return useGroupSlices(["image", "3d"]).length > 0;
+  return useGroupSlices(["image", "video", "3d"]).length > 0;
 }
 
 export type AnnotationDisabledReason =

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useSyncAnnotationSliceMediaType.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useSyncAnnotationSliceMediaType.ts
@@ -1,0 +1,31 @@
+import { currentSlice, groupMediaTypesMap, isGroup } from "@fiftyone/state";
+import { useSetAtom } from "jotai";
+import { useEffect } from "react";
+import { useRecoilValue } from "recoil";
+import { annotationSliceMediaType } from "./state";
+
+/**
+ * Bridge the media type of the slice currently open in the modal into the Jotai
+ * `annotationSliceMediaType` atom, so `visibleLabelSchemas` can narrow the
+ * dataset-wide schema to what the open slice supports (a grouped dataset's
+ * active schema is a superset across slices). Writes null for a non-grouped
+ * dataset — no per-slice filtering then. Recoil can't be read from inside a
+ * Jotai getter, hence this mirror (same pattern as exploreActiveFields).
+ *
+ * Mount once at the annotation root.
+ */
+export const useSyncAnnotationSliceMediaType = (): void => {
+  const grouped = useRecoilValue(isGroup);
+  const slice = useRecoilValue(currentSlice(true));
+  const mediaTypes = useRecoilValue(groupMediaTypesMap);
+  const setSliceMediaType = useSetAtom(annotationSliceMediaType);
+
+  useEffect(() => {
+    if (!grouped || !slice) {
+      setSliceMediaType(null);
+      return;
+    }
+
+    setSliceMediaType(mediaTypes[slice] ?? null);
+  }, [grouped, slice, mediaTypes, setSliceMediaType]);
+};

--- a/app/packages/video-annotation/src/hooks/useAutoInterpolate.ts
+++ b/app/packages/video-annotation/src/hooks/useAutoInterpolate.ts
@@ -74,7 +74,7 @@ export const useAutoInterpolate = (): void => {
   const sampleId = useActiveSampleId();
   const stream = useFrameLabelsStream();
   const propagate = useVideoPropagate();
-  const actions = useSurfaceActions(engine, SURFACE);
+  const actions = useSurfaceActions(engine, SURFACE, sampleId);
 
   // The presence/keyframe baseline for every active frame field. `keyframes`
   // rides the index for free, so no dynamic-attribute projection is needed.

--- a/app/packages/video-annotation/src/hooks/useVideoSurfaceActions.ts
+++ b/app/packages/video-annotation/src/hooks/useVideoSurfaceActions.ts
@@ -578,8 +578,8 @@ const makeTemporalDetectionOps = (actions: SurfaceActions) => {
  */
 export const useVideoSurfaceActions = (): VideoSurfaceActions => {
   const engine = useAnnotationEngine();
-  const actions = useSurfaceActions(engine, SURFACE);
   const sampleId = useActiveSampleId();
+  const actions = useSurfaceActions(engine, SURFACE, sampleId);
   const stream = useFrameLabelsStream();
   const eventBus = useAnnotationEventBus();
 

--- a/app/packages/video-annotation/src/propagation/useApplyPropagationResult.test.ts
+++ b/app/packages/video-annotation/src/propagation/useApplyPropagationResult.test.ts
@@ -14,6 +14,7 @@ const h = vi.hoisted(() => ({ stream: null as unknown }));
 
 vi.mock("@fiftyone/annotation", () => ({
   useAnnotationEngine: () => ({}),
+  useActiveSampleId: () => "sample-1",
   useSurfaceActions: () => mockActions,
 }));
 

--- a/app/packages/video-annotation/src/propagation/useApplyPropagationResult.ts
+++ b/app/packages/video-annotation/src/propagation/useApplyPropagationResult.ts
@@ -2,6 +2,7 @@ import {
   type InferenceResult,
   type PropagatedDetection,
   type PropagationInferenceResult,
+  useActiveSampleId,
   useAnnotationEngine,
   useSurfaceActions,
 } from "@fiftyone/annotation";
@@ -46,7 +47,8 @@ const SURFACE = "video";
  */
 export const useApplyPropagatedDetection = (): PropagatedDetectionWriter => {
   const engine = useAnnotationEngine();
-  const actions = useSurfaceActions(engine, SURFACE);
+  const sampleId = useActiveSampleId();
+  const actions = useSurfaceActions(engine, SURFACE, sampleId);
   const stream = useFrameLabelsStream();
 
   return useCallback(
@@ -85,7 +87,8 @@ export const useApplyPropagatedDetection = (): PropagatedDetectionWriter => {
  */
 export const useApplyPropagationResult = (): PropagationResultHandler => {
   const engine = useAnnotationEngine();
-  const actions = useSurfaceActions(engine, SURFACE);
+  const sampleId = useActiveSampleId();
+  const actions = useSurfaceActions(engine, SURFACE, sampleId);
   const applyDetection = useApplyPropagatedDetection();
 
   return useCallback(

--- a/app/packages/video-annotation/src/state/useVideoInteraction.ts
+++ b/app/packages/video-annotation/src/state/useVideoInteraction.ts
@@ -4,6 +4,7 @@
 
 import {
   type ScopedRef,
+  useActiveSampleId,
   useAnnotationEngine,
   useInteraction,
   useSurfaceActions,
@@ -130,7 +131,8 @@ export const useHoveredTrackIds = (): ReadonlySet<string> => {
 /** The full select / hover seam for timeline rows. */
 export const useVideoInteraction = (): VideoInteraction => {
   const engine = useAnnotationEngine();
-  const actions = useSurfaceActions(engine, SURFACE);
+  const sampleId = useActiveSampleId();
+  const actions = useSurfaceActions(engine, SURFACE, sampleId);
   const getFrame = useCurrentFrameGetter();
 
   const selectedTrackIds = useSelectedTrackIds();

--- a/e2e-pw/src/oss/poms/modal/video-annotate.ts
+++ b/e2e-pw/src/oss/poms/modal/video-annotate.ts
@@ -276,6 +276,19 @@ export class VideoAnnotatePom {
     );
   }
 
+  /**
+   * The distinct field PATHS of every label row currently listed in the sidebar
+   * (read off `data-cy-path`, e.g. `frames.detections`, `detections`, `events`).
+   * The annotate sidebar list is gated on the per-slice schema filter, so this
+   * reflects which schema paths the open slice offers for annotation.
+   */
+  async listedLabelPaths(): Promise<string[]> {
+    const paths = await this.labelRows.evaluateAll((els) =>
+      els.map((e) => e.getAttribute("data-cy-path") ?? ""),
+    );
+    return [...new Set(paths.filter(Boolean))];
+  }
+
   /** Select a listed label row by its class text (opens its editor). */
   async selectLabel(labelText: string) {
     await this.labelRow(labelText).first().click();

--- a/e2e-pw/src/oss/specs/MISSING-annotate-grouped-video.spec.ts
+++ b/e2e-pw/src/oss/specs/MISSING-annotate-grouped-video.spec.ts
@@ -1,0 +1,307 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ *
+ * Video annotation on a GROUPED dataset (an image slice + a video slice):
+ *
+ *  - the Annotate tab is available and the video slice mounts the video
+ *    annotation surface (guards the grouped-video gating + the ModalLooker /
+ *    engine-store fixes — a grouped video slice is decided per-sample, not from
+ *    the dataset-level media type);
+ *  - the per-slice schema filter narrows the dataset-wide active schema to what
+ *    the open slice supports: the video slice offers frame detections +
+ *    sample-level classification + temporal detections but NOT sample-level
+ *    spatial detections; the image slice offers sample-level detections +
+ *    classification but NOT frame fields or temporal detections;
+ *  - editing in EACH slice writes to THAT slice's own sample — the guard against
+ *    the sample-scope regression (a surface resolving its sample via the ambient
+ *    sole store throws / mis-scopes once a grouped modal registers a second
+ *    store; every surface must scope to its own sample).
+ *
+ * One group: image slice (`image`) + video slice (`video`, the default). Fixed
+ * sample ids so an edit's autosave PATCH can be checked against the slice it
+ * must land on. Re-seeded per test so a persisting edit can't leak into the next.
+ */
+import { expect, test as base } from "src/oss/fixtures";
+import { GridPom } from "src/oss/poms/grid";
+import { ModalPom } from "src/oss/poms/modal";
+import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
+
+const datasetName = getUniqueDatasetNameWithPrefix("annotate-grouped-video");
+const videoId = "000000000000000000000000";
+const imageId = "000000000000000000000001";
+const clip = `/tmp/${datasetName}.webm`;
+const image = `/tmp/${datasetName}.png`;
+
+const test = base.extend<{ grid: GridPom; modal: ModalPom }>({
+  grid: async ({ page, eventUtils }, use) => use(new GridPom(page, eventUtils)),
+  modal: async ({ page, eventUtils }, use) =>
+    use(new ModalPom(page, eventUtils)),
+});
+
+const seedCode = `
+import fiftyone as fo
+from bson import ObjectId
+
+DET = ["vehicle", "person", "road sign"]
+CLS = ["sunny", "rainy", "night"]
+EVT = ["approach", "pass", "depart"]
+
+if fo.dataset_exists("${datasetName}"):
+    fo.delete_dataset("${datasetName}")
+
+d = fo.Dataset("${datasetName}")
+d.persistent = True
+d.add_group_field("group", default="video")
+# register the slices explicitly: the raw insert below (for forced ids) bypasses
+# the schema expansion add_samples would do, so group_media_types would be empty
+d.add_group_slice("image", "image")
+d.add_group_slice("video", "video")
+
+# forced ids so an edit's PATCH can be checked against the slice's sample
+group = fo.Group()
+samples = [
+    fo.Sample(_id=ObjectId("${imageId}"), filepath="${image}", group=group.element("image")),
+    fo.Sample(_id=ObjectId("${videoId}"), filepath="${clip}", group=group.element("video")),
+]
+d._sample_collection.insert_many([d._make_dict(s, include_id=True) for s in samples])
+d.reload()
+
+d.compute_metadata()
+# materialize per-frame images for the video slice (writes frames.filepath)
+d.select_group_slices("video").to_frames(sample_frames=True)
+
+d.add_frame_field("detections", fo.EmbeddedDocumentField, embedded_doc_type=fo.Detections)
+d.add_frame_field("detections.detections.keyframe", fo.BooleanField)
+d.add_frame_field("detections.detections.propagation", fo.DictField)
+d.add_sample_field("detections", fo.EmbeddedDocumentField, embedded_doc_type=fo.Detections)
+d.add_sample_field("classification", fo.EmbeddedDocumentField, embedded_doc_type=fo.Classification)
+d.add_sample_field("events", fo.EmbeddedDocumentField, embedded_doc_type=fo.TemporalDetections)
+
+# video slice: a per-frame tracked detection (frames.detections) across all
+# frames + sample-level detections/classification/events. The sample-level
+# detection is present but must be FILTERED OUT of the video annotate schema.
+d.group_slice = "video"
+vid = d.first()
+n = int(vid.metadata.total_frame_count)
+inst = fo.Instance()
+for fn in range(1, n + 1):
+    vid.frames[fn]["detections"] = fo.Detections(
+        detections=[
+            fo.Detection(
+                label="vehicle",
+                bounding_box=[0.3, 0.3, 0.2, 0.2],
+                index=1,
+                instance=inst,
+            )
+        ]
+    )
+vid["detections"] = fo.Detections(
+    detections=[fo.Detection(label="vehicle", bounding_box=[0.25, 0.25, 0.4, 0.4], index=1)]
+)
+vid["classification"] = fo.Classification(label="sunny")
+a = max(1, n // 3)
+b = max(a + 1, (2 * n) // 3)
+vid["events"] = fo.TemporalDetections(
+    detections=[
+        fo.TemporalDetection(label="approach", support=[1, a]),
+        fo.TemporalDetection(label="pass", support=[a + 1, b]),
+        fo.TemporalDetection(label="depart", support=[b + 1, n]),
+    ]
+)
+vid.save()
+
+# image slice: a sample-level detection + classification
+d.group_slice = "image"
+img = d.first()
+img["detections"] = fo.Detections(
+    detections=[fo.Detection(label="vehicle", bounding_box=[0.25, 0.25, 0.4, 0.4], index=1)]
+)
+img["classification"] = fo.Classification(label="rainy")
+img.save()
+
+
+def schema(kind, classes, extra=None):
+    return {
+        "type": kind,
+        "component": "dropdown",
+        "attributes": [
+            {"name": "id", "type": "id", "component": "text", "read_only": True}
+        ]
+        + (extra or []),
+        "classes": classes,
+    }
+
+
+idx = [{"name": "index", "type": "int", "component": "text"}]
+d.update_label_schema("frames.detections", schema("detections", DET, idx), allow_new_attrs=True)
+d.update_label_schema("detections", schema("detections", DET, idx), allow_new_attrs=True)
+d.update_label_schema("classification", schema("classification", CLS), allow_new_attrs=True)
+d.update_label_schema("events", schema("temporaldetections", EVT), allow_new_attrs=True)
+d.active_label_schemas = ["frames.detections", "detections", "classification", "events"]
+d.save()
+`;
+
+test.beforeAll(async ({ foWebServer, mediaFactory }) => {
+  await foWebServer.startWebServer();
+  await mediaFactory.createVideo({
+    outputPath: clip,
+    duration: 2,
+    width: 64,
+    height: 64,
+    frameRate: 5,
+    color: "#3050a0",
+  });
+  await mediaFactory.createImage({
+    outputPath: image,
+    width: 64,
+    height: 64,
+    fillColor: "#a03050",
+  });
+});
+
+test.afterAll(async ({ foWebServer }) => {
+  await foWebServer.stopWebServer();
+});
+
+test.beforeEach(async ({ fiftyoneLoader, modal, page }) => {
+  await fiftyoneLoader.executePythonCode(seedCode);
+  await fiftyoneLoader.waitUntilGridVisible(page, datasetName);
+  // serial describe shares one page; close any modal a prior test left open so
+  // openFirstSample's grid click below isn't intercepted
+  await modal.close({ ignoreError: true });
+});
+
+/**
+ * Open the first group (its default slice is `video`) and enter annotate mode
+ * on the video surface. Opening from the grid (vs a deep link) loads the full
+ * group so its slice membership resolves — the annotation slice selector needs
+ * it.
+ */
+const enterVideoAnnotate = async (grid: GridPom, modal: ModalPom) => {
+  await grid.openFirstSample();
+  await modal.waitForSampleLoadDomAttribute();
+  await modal.sidebar.switchMode("annotate");
+  await modal.videoAnnotate.waitForSurface();
+};
+
+test.describe.serial("grouped video annotation", () => {
+  test("the video slice mounts the video annotation surface", async ({
+    grid,
+    modal,
+  }) => {
+    // gating + surface mount: entering annotate on a grouped video slice must
+    // reach the video surface (not fall back to the image renderer) and must
+    // not throw on store registration
+    await enterVideoAnnotate(grid, modal);
+  });
+
+  test("the video slice offers frame + classification + temporal schemas, not sample detections", async ({
+    grid,
+    modal,
+  }) => {
+    await enterVideoAnnotate(grid, modal);
+
+    await expect
+      .poll(() => modal.videoAnnotate.listedLabelPaths())
+      .toEqual(
+        expect.arrayContaining([
+          "frames.detections",
+          "classification",
+          "events",
+        ]),
+      );
+
+    // the sample-level `detections` field is filtered out on a video slice
+    // (spatial sample-level labels live in `frames.*` on video)
+    expect(await modal.videoAnnotate.listedLabelPaths()).not.toContain(
+      "detections",
+    );
+  });
+
+  test("the image slice offers sample detections + classification, not frame or temporal schemas", async ({
+    grid,
+    modal,
+  }) => {
+    await enterVideoAnnotate(grid, modal);
+
+    await modal.sidebar.annotate.selectAnnotationSlice("image");
+    await modal.waitForLighterReady();
+
+    await expect
+      .poll(() => modal.videoAnnotate.listedLabelPaths())
+      .toEqual(expect.arrayContaining(["detections", "classification"]));
+
+    const paths = await modal.videoAnnotate.listedLabelPaths();
+    expect(paths).not.toContain("frames.detections");
+    expect(paths).not.toContain("events");
+  });
+
+  test("the annotation slice selector offers both the video and image slices", async ({
+    grid,
+    modal,
+  }) => {
+    await enterVideoAnnotate(grid, modal);
+
+    const slices = (
+      await modal.sidebar.annotate.getAvailableAnnotationSlices()
+    ).map((s) => s.trim());
+    expect(slices).toContain("image");
+    expect(slices).toContain("video");
+  });
+
+  test("editing on the video slice writes to the video sample", async ({
+    grid,
+    modal,
+    page,
+  }) => {
+    // the sample-scope guard: selecting + editing a track on a grouped video
+    // slice drives the exact path that regressed (surface actions resolving the
+    // sample), and the autosave must PATCH the VIDEO sample — not the image one.
+    const pageErrors: string[] = [];
+    page.on("pageerror", (e) => pageErrors.push(e.message));
+
+    await enterVideoAnnotate(grid, modal);
+
+    await modal.videoAnnotate.assert.labelListed("vehicle");
+    await modal.videoAnnotate.selectLabel("vehicle");
+    // the editor opened => select() didn't throw resolving its sample scope
+    await expect(modal.sidebar.edit.backButton).toBeVisible();
+
+    const patch = modal.sidebar.annotate.waitForPatch();
+    await modal.sidebar.edit.setFieldValue("position.x", "0.5");
+    const response = await patch;
+
+    // scoped to the video sample
+    expect(response.url()).toContain(videoId);
+    expect(response.url()).not.toContain(imageId);
+    await expect
+      .poll(async () =>
+        Number(await modal.sidebar.edit.getFieldValue("position.x")),
+      )
+      .toBeCloseTo(0.5, 4);
+
+    expect(pageErrors).toEqual([]);
+  });
+
+  test("editing on the image slice writes to the image sample", async ({
+    grid,
+    modal,
+  }) => {
+    await enterVideoAnnotate(grid, modal);
+
+    await modal.sidebar.annotate.selectAnnotationSlice("image");
+    await modal.waitForLighterReady();
+
+    await modal.videoAnnotate.assert.labelListed("vehicle");
+    await modal.videoAnnotate.selectLabel("vehicle");
+    await expect(modal.sidebar.edit.backButton).toBeVisible();
+
+    const patch = modal.sidebar.annotate.waitForPatch();
+    await modal.sidebar.edit.setFieldValue("position.x", "0.5");
+    const response = await patch;
+
+    // scoped to the image sample
+    expect(response.url()).toContain(imageId);
+    expect(response.url()).not.toContain(videoId);
+  });
+});

--- a/e2e-pw/src/oss/specs/MISSING-schema-manager.spec.ts
+++ b/e2e-pw/src/oss/specs/MISSING-schema-manager.spec.ts
@@ -252,23 +252,23 @@ test.describe.serial("schema manager", () => {
     await expect(page.getByRole("button", { name: "Schema" })).toBeHidden();
   });
 
-  test("annotation disabled for grouped dataset with no supported slices", async ({
+  test("annotation enabled for a grouped dataset with a video slice", async ({
     fiftyoneLoader,
     page,
     modal,
     schemaManager,
   }) => {
-    // Navigate to grouped video dataset
+    // A grouped dataset whose slice is a video now supports annotation. Video
+    // slices are annotatable, so the tab is enabled rather than reporting "no
+    // slices that support annotation" (previously video was omitted from the
+    // supported group slice types). Every real group slice media type
+    // (image/video/3d/point-cloud) is now annotatable.
     await fiftyoneLoader.waitUntilGridVisible(page, groupVideoDatasetName, {
       searchParams: new URLSearchParams({ id: groupVideoId }),
     });
     await modal.assert.isOpen();
     await modal.sidebar.switchMode("annotate");
 
-    // Annotation should be disabled for grouped datasets with no supported slices
-    await modal.sidebar.assert.hasDisabledMessage(
-      "has no slices that support annotation",
-    );
-    await schemaManager.assert.isDisabled();
+    await schemaManager.assert.isEnabled();
   });
 });


### PR DESCRIPTION
## What

Enable the annotation surface for **grouped datasets that have a video slice**.

## Changes

**1. Enable annotation on grouped video slices via per-sample media type**
**2. Filter the annotation schema to the open slice's supported field types**
**3. Scope video surface actions to their own sample instead of the ambient store**
**4. E2E coverage**
- `MISSING-annotate-grouped-video.spec.ts` (6 tests): the video slice mounts the annotation surface; the per-slice schema filter narrows correctly on both the video and image slices; the annotation slice selector offers both slices; and **editing in each slice writes to that slice's own sample** (asserts the autosave PATCH targets the correct slice id) — a regression guard for the sample-scope bug in change 3.

## Testing

- `vitest` for `annotation` + `video-annotation` packages: green.
- e2e (`USE_DEV_BUILD=false yarn e2e --workers=1`): all 6 grouped-video tests pass.
- Scoped type-check clean (`app` packages touched + `e2e-pw`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary of changes

- **New Features**
  - Enabled annotation for grouped dataset video slices.
  - Slice-aware label/schema options are now filtered by the active slice’s media type.
  - Annotation actions and autosave are now scoped to the currently active sample.

- **Bug Fixes**
  - Corrected video vs. non-video rendering and schema selection in modals and grouped selections.
  - Prevented annotation writes from targeting the wrong sample.

- **Tests**
  - Added end-to-end coverage for grouped video/image annotation workflows.
  - Updated grouped dataset schema-manager expectations for video slice scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3259
<!-- enterprise-sync-pr:end -->