### PR TITLE
Improve MCAP viewer interactions and playback efficiency

### DIFF
--- a/app/packages/core/src/components/Grid/GridCustomRendererItem.test.tsx
+++ b/app/packages/core/src/components/Grid/GridCustomRendererItem.test.tsx
@@ -109,6 +109,9 @@ describe("GridCustomRendererItem", () => {
 
     const openButton = getOpenModalButton(host) as HTMLElement | null;
     expect(openButton).toBeTruthy();
+    expect(
+      openButton?.querySelector("[data-testid='OpenInFullIcon']"),
+    ).toBeTruthy();
     openButton?.click();
     expect(hostClickSpy).toHaveBeenCalledTimes(1);
 
@@ -138,6 +141,41 @@ describe("GridCustomRendererItem", () => {
       expect(getOpenModalButton(host)).toBeNull();
       expect(getSelectControl(host)).toBeTruthy();
     });
+
+    looker.destroy();
+    host.remove();
+  });
+
+  it("passes unhandled tile activation through when configured", async () => {
+    const Renderer = () => <div data-testid="renderer">preview</div>;
+    const looker = new GridCustomRendererItem({
+      clickBehavior: "passthrough",
+      pluginName: "passive-renderer",
+      Renderer,
+      RecoilBridge: TestBridge,
+      ctx: BASE_CTX as any,
+      symbol: BASE_SYMBOL,
+    });
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const hostClickSpy = vi.fn();
+    const hostContextMenuSpy = vi.fn();
+    host.addEventListener("click", hostClickSpy);
+    host.addEventListener("contextmenu", hostContextMenuSpy);
+
+    looker.attach(host, [200, 120], 12);
+
+    const renderer = await waitFor(() => {
+      const element = host.querySelector("[data-testid='renderer']");
+      expect(element).toBeTruthy();
+      return element as HTMLElement;
+    });
+
+    fireEvent.click(renderer);
+    fireEvent.contextMenu(renderer);
+
+    expect(hostClickSpy).toHaveBeenCalledTimes(1);
+    expect(hostContextMenuSpy).toHaveBeenCalledTimes(1);
 
     looker.destroy();
     host.remove();

--- a/app/packages/core/src/components/Grid/GridCustomRendererItem.tsx
+++ b/app/packages/core/src/components/Grid/GridCustomRendererItem.tsx
@@ -1,11 +1,13 @@
 import { buildThumbnailSelectionDetail } from "@fiftyone/looker/src/selection";
 import {
+  type SampleRendererGridClickBehavior,
   type SampleRendererProps,
   type SampleRendererRenderContext,
 } from "@fiftyone/plugins";
 import type { ID } from "@fiftyone/spotlight";
 import * as fos from "@fiftyone/state";
 import { MEDIA_TYPE_MULTIMODAL } from "@fiftyone/utilities";
+import OpenInFullIcon from "@mui/icons-material/OpenInFull";
 import { Checkbox } from "@mui/material";
 import React from "react";
 import { createRoot, type Root } from "react-dom/client";
@@ -16,6 +18,7 @@ type GridCustomRendererItemConfig = {
   Renderer: React.ComponentType<SampleRendererProps>;
   RecoilBridge: React.ComponentType<React.PropsWithChildren>;
   ctx: SampleRendererRenderContext;
+  clickBehavior?: SampleRendererGridClickBehavior;
   symbol: ID;
 };
 
@@ -90,8 +93,9 @@ const OPEN_MODAL_BUTTON_STYLES: React.CSSProperties = {
   background: "rgba(18, 18, 18, 0.72)",
   color: "#f5f5f5",
   fontSize: "14px",
-  lineHeight: "20px",
-  textAlign: "center",
+  alignItems: "center",
+  display: "flex",
+  justifyContent: "center",
   padding: 0,
   cursor: "pointer",
   zIndex: 20,
@@ -153,6 +157,7 @@ function getSourceSizeHintBytes(
 }
 
 type GridCustomRendererWrapperProps = React.PropsWithChildren<{
+  clickBehavior?: SampleRendererGridClickBehavior;
   selected: boolean;
   onOpenModal: React.MouseEventHandler<HTMLButtonElement>;
   onSelect: React.MouseEventHandler<HTMLButtonElement>;
@@ -166,12 +171,14 @@ const stopGridActivationPropagation: React.MouseEventHandler<HTMLElement> = (
 
 const GridCustomRendererWrapper = ({
   children,
+  clickBehavior = "renderer",
   selected,
   onOpenModal,
   onSelect,
 }: GridCustomRendererWrapperProps) => {
   const [hovering, setHovering] = React.useState(false);
   const showSelectionControl = hovering || selected;
+  const passThroughGridActivation = clickBehavior === "passthrough";
 
   return (
     <div
@@ -179,8 +186,12 @@ const GridCustomRendererWrapper = ({
       onMouseEnter={() => setHovering(true)}
       onMouseMove={() => setHovering(true)}
       onMouseLeave={() => setHovering(false)}
-      onClick={stopGridActivationPropagation}
-      onContextMenu={stopGridActivationPropagation}
+      onClick={
+        passThroughGridActivation ? undefined : stopGridActivationPropagation
+      }
+      onContextMenu={
+        passThroughGridActivation ? undefined : stopGridActivationPropagation
+      }
     >
       {children}
       {showSelectionControl && (
@@ -192,15 +203,14 @@ const GridCustomRendererWrapper = ({
         />
       )}
       {hovering && (
-        <>
-          <button
-            title="Open sample modal"
-            onClick={onOpenModal}
-            style={OPEN_MODAL_BUTTON_STYLES}
-          >
-            ↩
-          </button>
-        </>
+        <button
+          aria-label="Open sample modal"
+          title="Open sample modal"
+          onClick={onOpenModal}
+          style={OPEN_MODAL_BUTTON_STYLES}
+        >
+          <OpenInFullIcon fontSize="inherit" />
+        </button>
       )}
     </div>
   );
@@ -287,6 +297,7 @@ export class GridCustomRendererItem {
           key={ctx.media.url ?? this.config.pluginName}
         >
           <GridCustomRendererWrapper
+            clickBehavior={this.config.clickBehavior}
             selected={this.selected}
             onOpenModal={this.handleOpenModalClick}
             onSelect={this.handleSelectSampleClick}

--- a/app/packages/core/src/components/Grid/useGridCustomRendererItem.ts
+++ b/app/packages/core/src/components/Grid/useGridCustomRendererItem.ts
@@ -108,6 +108,9 @@ export function useGridCustomRendererItem(
 
       try {
         const item = new GridCustomRendererItem({
+          clickBehavior:
+            resolvedRenderer.registration.sampleRendererOptions.grid
+              ?.clickBehavior,
           pluginName: resolvedRenderer.registration.name,
           Renderer: resolvedRenderer.Renderer,
           RecoilBridge:

--- a/app/packages/multimodal/src/adapters/mcap/entry.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/entry.tsx
@@ -20,6 +20,7 @@ registerComponent({
     // per-sample state swaps by source (activateSource + keyed shell).
     modal: { persistAcrossSamples: true },
     grid: {
+      clickBehavior: "passthrough",
       enabled: true,
       overrideComponent: GridRenderer,
       slots: {

--- a/app/packages/multimodal/src/adapters/mcap/react/GridRenderer.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/GridRenderer.test.tsx
@@ -204,6 +204,60 @@ describe("GridRenderer", () => {
     expect(overlay.getAttribute("data-image-height")).toBe("480");
   });
 
+  it("allows ready image tile activation to pass through", () => {
+    previewHarness.preview.frame = imageFrame(new Uint8Array([1]));
+    previewHarness.preview.status = "ready";
+    const onClick = vi.fn();
+    const onContextMenu = vi.fn();
+
+    render(
+      <div onClick={onClick} onContextMenu={onContextMenu}>
+        <GridRenderer ctx={rendererCtx()} />
+      </div>,
+    );
+
+    const image = screen.getByTestId("bitmap-image-view");
+    fireEvent.click(image);
+    fireEvent.contextMenu(image);
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onContextMenu).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps point-cloud and unresolved tile activation inside the renderer", () => {
+    previewHarness.preview.frame = pointCloudFrame();
+    previewHarness.preview.status = "ready";
+    const onClick = vi.fn();
+    const onContextMenu = vi.fn();
+    const { rerender } = render(
+      <div onClick={onClick} onContextMenu={onContextMenu}>
+        <GridRenderer ctx={rendererCtx()} />
+      </div>,
+    );
+
+    const pointCloud = screen.getByTestId("bitmap-canvas-host");
+    fireEvent.click(pointCloud);
+    fireEvent.contextMenu(pointCloud);
+
+    expect(onClick).not.toHaveBeenCalled();
+    expect(onContextMenu).not.toHaveBeenCalled();
+
+    previewHarness.preview.frame = null;
+    previewHarness.preview.status = "loading";
+    rerender(
+      <div onClick={onClick} onContextMenu={onContextMenu}>
+        <GridRenderer ctx={rendererCtx()} />
+      </div>,
+    );
+
+    const loading = screen.getByTestId("mcap-loading-ascii");
+    fireEvent.click(loading);
+    fireEvent.contextMenu(loading);
+
+    expect(onClick).not.toHaveBeenCalled();
+    expect(onContextMenu).not.toHaveBeenCalled();
+  });
+
   it("renders point-cloud cells as a snapshot bitmap at rest with NO live panel", async () => {
     const frame = pointCloudFrame();
     previewHarness.preview.frame = frame;

--- a/app/packages/multimodal/src/adapters/mcap/react/GridRenderer.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/GridRenderer.tsx
@@ -71,6 +71,9 @@ export function GridRenderer({ ctx }: SampleRendererProps) {
   const stableStreamTopics = useStableGridStreamTopics(preview.streamTopics);
   const allowGridActivation =
     preview.status === "ready" && preview.frame?.kind === "image";
+  const gridActivationHandler = allowGridActivation
+    ? undefined
+    : stopGridActivationPropagation;
 
   useEffect(() => {
     return registerStreamTopics({
@@ -84,10 +87,8 @@ export function GridRenderer({ ctx }: SampleRendererProps) {
   return (
     <div
       className={classes.root}
-      onClick={allowGridActivation ? undefined : stopGridActivationPropagation}
-      onContextMenu={
-        allowGridActivation ? undefined : stopGridActivationPropagation
-      }
+      onClick={gridActivationHandler}
+      onContextMenu={gridActivationHandler}
       onPointerEnter={preview.play}
       onPointerLeave={preview.pause}
     >

--- a/app/packages/multimodal/src/adapters/mcap/react/GridRenderer.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/GridRenderer.tsx
@@ -41,6 +41,12 @@ const SNAPSHOT_REFRESH_DEBOUNCE_MS = 250;
 // exactly what the lease pool exists to prevent). Exported for tests.
 export const HOVER_INTENT_DELAY_MS = 120;
 
+const stopGridActivationPropagation = (
+  event: React.MouseEvent<HTMLElement>,
+) => {
+  event.stopPropagation();
+};
+
 /**
  * Grid renderer for MCAP-backed multimodal samples. Shows one camera
  * preview frame and plays the stream while hovered.
@@ -63,6 +69,8 @@ export function GridRenderer({ ctx }: SampleRendererProps) {
   });
   const registerStreamTopics = useRegisterMcapGridStreamTopics();
   const stableStreamTopics = useStableGridStreamTopics(preview.streamTopics);
+  const allowGridActivation =
+    preview.status === "ready" && preview.frame?.kind === "image";
 
   useEffect(() => {
     return registerStreamTopics({
@@ -76,6 +84,10 @@ export function GridRenderer({ ctx }: SampleRendererProps) {
   return (
     <div
       className={classes.root}
+      onClick={allowGridActivation ? undefined : stopGridActivationPropagation}
+      onContextMenu={
+        allowGridActivation ? undefined : stopGridActivationPropagation
+      }
       onPointerEnter={preview.play}
       onPointerLeave={preview.pause}
     >

--- a/app/packages/multimodal/src/adapters/mcap/react/McapImageAnnotationOverlay.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapImageAnnotationOverlay.tsx
@@ -109,6 +109,7 @@ const McapImageAnnotationOverlay: React.FC<McapImageAnnotationOverlayProps> = ({
   return (
     <ImageAnnotationsOverlay
       annotations={annotationSets.map((set) => set.frame)}
+      renderMetadata={annotationSets.map((set) => set.renderMetadata)}
       imageWidth={imageWidth}
       imageHeight={imageHeight}
       fit={fit}

--- a/app/packages/multimodal/src/adapters/mcap/react/McapMapTile.module.css
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapMapTile.module.css
@@ -116,13 +116,13 @@
 
 .toolOverlay {
   align-items: flex-end;
+  bottom: 78px;
   display: flex;
   flex-direction: column;
   gap: 8px;
   pointer-events: none;
   position: absolute;
   right: 10px;
-  top: 78px;
   z-index: 2;
 }
 

--- a/app/packages/multimodal/src/adapters/mcap/react/McapMapTile.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapMapTile.tsx
@@ -479,7 +479,7 @@ function McapMapLibreSurface({
             showCompass: false,
             showZoom: true,
           }),
-          "top-right",
+          "bottom-right",
         );
 
         map.on("load", () => {

--- a/app/packages/multimodal/src/adapters/mcap/react/McapPerformanceStats.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapPerformanceStats.test.tsx
@@ -1,0 +1,73 @@
+import { PlaybackProvider, usePlayback } from "@fiftyone/playback";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import McapPerformanceStats from "./McapPerformanceStats";
+
+type Playback = ReturnType<typeof usePlayback>;
+
+function PlaybackProbe({
+  playbackRef,
+}: {
+  readonly playbackRef: { current: Playback | null };
+}) {
+  playbackRef.current = usePlayback();
+  return null;
+}
+
+describe("McapPerformanceStats", () => {
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("samples the visible playhead but copies the latest committed time", async () => {
+    vi.useFakeTimers({ toFake: ["clearTimeout", "setTimeout"] });
+    const writeText = vi.fn(async (_text: string) => undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    const playbackRef: { current: Playback | null } = { current: null };
+
+    render(
+      <PlaybackProvider duration={10}>
+        <PlaybackProbe playbackRef={playbackRef} />
+        <McapPerformanceStats sampling={null} />
+      </PlaybackProvider>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Stats" }));
+
+    expect(screen.getByText("0.000 s")).toBeTruthy();
+    act(() => playbackRef.current?.play());
+    expect(screen.getByText("Playing")).toBeTruthy();
+    act(() => playbackRef.current?.pause());
+    expect(screen.getByText("Paused")).toBeTruthy();
+
+    act(() => {
+      playbackRef.current?.seek(1.25);
+      playbackRef.current?.seek(2.5);
+    });
+
+    // Rapid playback commits do not immediately update the diagnostics UI.
+    expect(screen.getByText("0.000 s")).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Copy JSON" }));
+      await Promise.resolve();
+    });
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(writeText.mock.calls[0][0]).playback.currentTimeSec).toBe(
+      2.5,
+    );
+
+    act(() => vi.advanceTimersByTime(249));
+    expect(screen.getByText("0.000 s")).toBeTruthy();
+
+    act(() => vi.advanceTimersByTime(1));
+    expect(screen.getByText("2.500 s")).toBeTruthy();
+  });
+});

--- a/app/packages/multimodal/src/adapters/mcap/react/McapPerformanceStats.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapPerformanceStats.test.tsx
@@ -11,6 +11,8 @@ import McapPerformanceStats from "./McapPerformanceStats";
 
 type Playback = ReturnType<typeof usePlayback>;
 
+let clipboardDescriptor: PropertyDescriptor | undefined;
+
 function PlaybackProbe({
   playbackRef,
 }: {
@@ -24,11 +26,21 @@ describe("McapPerformanceStats", () => {
   afterEach(() => {
     cleanup();
     vi.useRealTimers();
+    if (clipboardDescriptor) {
+      Object.defineProperty(navigator, "clipboard", clipboardDescriptor);
+    } else {
+      Reflect.deleteProperty(navigator, "clipboard");
+    }
+    clipboardDescriptor = undefined;
   });
 
   it("samples the visible playhead but copies the latest committed time", async () => {
     vi.useFakeTimers({ toFake: ["clearTimeout", "setTimeout"] });
     const writeText = vi.fn(async (_text: string) => undefined);
+    clipboardDescriptor = Object.getOwnPropertyDescriptor(
+      navigator,
+      "clipboard",
+    );
     Object.assign(navigator, { clipboard: { writeText } });
     const playbackRef: { current: Playback | null } = { current: null };
 

--- a/app/packages/multimodal/src/adapters/mcap/react/McapPerformanceStats.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapPerformanceStats.tsx
@@ -1,8 +1,10 @@
 import {
+  getCurrentTime,
+  subscribeCurrentTime,
   useBufferingDetail,
-  useCurrentTime,
   useDuration,
   useIsPlaying,
+  usePlaybackStore,
 } from "@fiftyone/playback";
 import {
   Button,
@@ -17,7 +19,16 @@ import {
   TextVariant,
   Variant,
 } from "@voxel51/voodo";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+  type ReactNode,
+} from "react";
 import { gpuPointCloudProjectionResourceStats } from "../../../visualization/panels/gpu/gpu-point-cloud-projection-resources";
 import { gridLiveLeaseStats } from "../../../visualization/panels/gpu/webgpu-live-lease";
 import { webGpuDeviceStats } from "../../../visualization/panels/gpu/webgpu-device-registry";
@@ -27,6 +38,7 @@ import { gpuPointCloudColormapTextureStats } from "../../../visualization/panels
 import styles from "./McapSettingsSidebar.module.css";
 
 const STATS_REFRESH_INTERVAL_MS = 1_000;
+const PLAYHEAD_REFRESH_INTERVAL_MS = 250;
 const COPY_CONFIRMATION_MS = 1_500;
 
 interface PointCloudSamplingSummary {
@@ -78,7 +90,7 @@ function LivePerformanceStats({
 }: {
   readonly sampling: PointCloudSamplingSummary | null;
 }) {
-  const currentTime = useCurrentTime();
+  const playbackStore = usePlaybackStore();
   const duration = useDuration();
   const isPlaying = useIsPlaying();
   const bufferingDetail = useBufferingDetail();
@@ -104,30 +116,28 @@ function LivePerformanceStats({
     [],
   );
 
-  const snapshot = useMemo(
+  const snapshotBase = useMemo(
     () => ({
       ...runtime,
       playback: {
         buffering: bufferingDetail,
-        currentTimeSec: currentTime,
         durationSec: duration,
         playing: isPlaying,
       },
       rendering: framePerformance,
       pointCloudSampling: sampling,
     }),
-    [
-      bufferingDetail,
-      currentTime,
-      duration,
-      framePerformance,
-      isPlaying,
-      runtime,
-      sampling,
-    ],
+    [bufferingDetail, duration, framePerformance, isPlaying, runtime, sampling],
   );
   const copySnapshot = useCallback(async () => {
     if (!navigator.clipboard?.writeText) return;
+    const snapshot = {
+      ...snapshotBase,
+      playback: {
+        ...snapshotBase.playback,
+        currentTimeSec: getCurrentTime(playbackStore),
+      },
+    };
     try {
       await navigator.clipboard.writeText(JSON.stringify(snapshot, null, 2));
     } catch {
@@ -141,7 +151,7 @@ function LivePerformanceStats({
       () => setCopied(false),
       COPY_CONFIRMATION_MS,
     );
-  }, [snapshot]);
+  }, [playbackStore, snapshotBase]);
 
   const {
     environment,
@@ -150,7 +160,7 @@ function LivePerformanceStats({
     projection,
     snapshotRenderer,
     webGpu,
-  } = snapshot;
+  } = snapshotBase;
 
   return (
     <Card background={CardBackground.Secondary} compact outlined>
@@ -171,7 +181,7 @@ function LivePerformanceStats({
         <StatsGroup
           rows={[
             ["State", isPlaying ? "Playing" : "Paused"],
-            ["Playhead", formatSeconds(currentTime)],
+            ["Playhead", <SampledPlayheadValue key="playhead" />],
             ["Duration", formatSeconds(duration)],
             ["Buffering", bufferingDetail ?? "No"],
           ]}
@@ -288,6 +298,37 @@ function LivePerformanceStats({
   );
 }
 
+const SampledPlayheadValue = memo(function SampledPlayheadValue() {
+  const currentTime = useSampledCurrentTime();
+  return <>{formatSeconds(currentTime)}</>;
+});
+
+/** Coalesces playback commits so only this tiny readout updates at 4 Hz. */
+function useSampledCurrentTime(): number {
+  const store = usePlaybackStore();
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      let refreshTimer: ReturnType<typeof setTimeout> | null = null;
+      const unsubscribe = subscribeCurrentTime(store, () => {
+        if (refreshTimer !== null) return;
+        refreshTimer = setTimeout(() => {
+          refreshTimer = null;
+          onStoreChange();
+        }, PLAYHEAD_REFRESH_INTERVAL_MS);
+      });
+
+      return () => {
+        unsubscribe();
+        if (refreshTimer !== null) clearTimeout(refreshTimer);
+      };
+    },
+    [store],
+  );
+  const getSnapshot = useCallback(() => getCurrentTime(store), [store]);
+
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
 function useFramePerformanceStats(): FramePerformanceStats {
   const [stats, setStats] = useState<FramePerformanceStats>({
     averageFrameTimeMs: null,
@@ -348,7 +389,7 @@ function StatsGroup({
   rows,
   title,
 }: {
-  readonly rows: readonly (readonly [string, string])[];
+  readonly rows: readonly (readonly [string, ReactNode])[];
   readonly title: string;
 }) {
   return (

--- a/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.test.tsx
@@ -277,7 +277,6 @@ describe("McapSettingsSidebar", () => {
     expect(
       screen.getByRole("button", { name: /Transforms & Poses/ }),
     ).toBeTruthy();
-    expect(screen.getByRole("button", { name: /Telemetry/ })).toBeTruthy();
     expect(
       screen.getByRole("button", { name: /Custom \/ Unknown/ }),
     ).toBeTruthy();

--- a/app/packages/multimodal/src/adapters/mcap/react/interpolate-image-annotations.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/interpolate-image-annotations.test.ts
@@ -20,6 +20,8 @@ import {
   lowerBoundBigInt,
   makeGroup,
   matchLineListGroups,
+  prepareImageAnnotationInterpolation,
+  sampleImageAnnotationInterpolation,
   vizOf,
   type Point2,
 } from "./interpolate-image-annotations";
@@ -578,6 +580,42 @@ describe("interpolateImageAnnotations", () => {
     expect(out.points[0].type).toBe("line-list");
     expect(out.points[0].points).toHaveLength(8);
     expect(out.points[0].points[0]).toEqual([2.5, 0]);
+  });
+
+  it("samples one prepared pair immutably at multiple fractions", () => {
+    const prev = viz({
+      circles: [circle([0, 0], 10)],
+      points: [lineList(boxPoints(0, 0, 10, 10))],
+      texts: [text("car", [0, 0])],
+    });
+    const next = viz({
+      circles: [circle([20, 10], 30)],
+      points: [lineList(boxPoints(5, 0, 10, 10))],
+      texts: [text("car", [20, 10])],
+    });
+    const prepared = prepareImageAnnotationInterpolation(prev, next);
+
+    const quarterSample = sampleImageAnnotationInterpolation(prepared, 0.25);
+    const quarter = quarterSample.frame;
+    const quarterSnapshot = structuredClone(quarter);
+    const threeQuarters = sampleImageAnnotationInterpolation(
+      prepared,
+      0.75,
+    ).frame;
+
+    expect(quarter.circles[0].position).toEqual([5, 2.5]);
+    expect(quarter.points[0].points[0]).toEqual([1.25, 0]);
+    expect(quarter.texts[0].position).toEqual([5, 2.5]);
+    expect(quarterSample.renderMetadata.lineListGroups[0]?.[0].bounds).toEqual({
+      minX: 1.25,
+      minY: 0,
+      maxX: 11.25,
+      maxY: 10,
+    });
+    expect(threeQuarters.circles[0].position).toEqual([15, 7.5]);
+    expect(quarter).toEqual(quarterSnapshot);
+    expect(prev.circles[0].position).toEqual([0, 0]);
+    expect(next.circles[0].position).toEqual([20, 10]);
   });
 
   it("preserves the kind discriminant", () => {

--- a/app/packages/multimodal/src/adapters/mcap/react/interpolate-image-annotations.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/interpolate-image-annotations.ts
@@ -22,6 +22,11 @@ import type {
 } from "../../../decoders";
 import { groupLineSegmentsByLabel } from "../../../utils/line-segment-grouping";
 import type { McapDecodedMessage } from "../types";
+import type {
+  ImageAnnotationBounds,
+  ImageAnnotationLineListGroup,
+  ImageAnnotationRenderMetadata,
+} from "../../../visualization/panels/image-annotation-render-metadata";
 
 function interpolationFraction({
   nextTimelineTimeNs,
@@ -56,17 +61,167 @@ type Point2 = readonly [number, number];
 const MATCH_DISTANCE_PX = 200;
 const MIN_MATCH_IOU = 0.15;
 
+interface PointTrack {
+  readonly deltaX: number;
+  readonly deltaY: number;
+  readonly x: number;
+  readonly y: number;
+}
+
+interface CircleTrack {
+  readonly deltaDiameter: number;
+  readonly position: PointTrack;
+  readonly previous: ImageAnnotationCircle;
+}
+
+interface TextTrack {
+  readonly position: PointTrack | null;
+  readonly previous: ImageAnnotationText;
+}
+
+interface PreparedLineGroup {
+  readonly label: string | null;
+  readonly previousBounds: ImageAnnotationBounds;
+  readonly previousPoints: readonly Point2[];
+  readonly previousSegments: readonly [Point2, Point2][];
+  readonly segmentTracks: readonly [PointTrack, PointTrack][] | null;
+}
+
+type PreparedCircles =
+  | {
+      readonly kind: "interpolate";
+      readonly tracks: readonly CircleTrack[];
+    }
+  | {
+      readonly kind: "passthrough";
+      readonly value: readonly ImageAnnotationCircle[];
+    };
+
+type PreparedPointPrimitive =
+  | {
+      readonly kind: "indexed";
+      readonly pointTracks: readonly PointTrack[];
+      readonly previous: ImageAnnotationPoints;
+    }
+  | {
+      readonly groups: readonly PreparedLineGroup[];
+      readonly kind: "line-list";
+      readonly previous: ImageAnnotationPoints;
+    }
+  | {
+      readonly groups: readonly ImageAnnotationLineListGroup[] | null;
+      readonly kind: "passthrough";
+      readonly value: ImageAnnotationPoints;
+    };
+
+type PreparedPoints =
+  | {
+      readonly items: readonly PreparedPointPrimitive[];
+      readonly kind: "interpolate";
+    }
+  | {
+      readonly kind: "passthrough";
+      readonly renderMetadata: ImageAnnotationRenderMetadata;
+      readonly value: readonly ImageAnnotationPoints[];
+    };
+
+interface SampledPoints {
+  readonly lineListGroups: ImageAnnotationRenderMetadata["lineListGroups"];
+  readonly points: readonly ImageAnnotationPoints[];
+}
+
+interface SampledLineList {
+  readonly groups: readonly ImageAnnotationLineListGroup[];
+  readonly primitive: ImageAnnotationPoints;
+}
+
+export interface SampledImageAnnotationInterpolation {
+  readonly frame: ImageAnnotationsVisualization;
+  readonly renderMetadata: ImageAnnotationRenderMetadata;
+}
+
+/** Fraction-independent render plan for one immutable annotation pair. */
+export interface PreparedImageAnnotationInterpolation {
+  readonly circles: PreparedCircles;
+  readonly kind: ImageAnnotationsVisualization["kind"];
+  readonly points: PreparedPoints;
+  readonly texts: readonly TextTrack[];
+}
+
+/**
+ * Performs all topology discovery and object matching once for a source-message
+ * pair. The returned plan is immutable and safe to sample from every visual
+ * playback tick.
+ */
+export function prepareImageAnnotationInterpolation(
+  previous: ImageAnnotationsVisualization,
+  next: ImageAnnotationsVisualization,
+): PreparedImageAnnotationInterpolation {
+  return {
+    circles: prepareCircles(previous.circles, next.circles),
+    kind: previous.kind,
+    points: preparePoints(previous, next),
+    texts: prepareTexts(previous.texts, next.texts),
+  };
+}
+
+/** Allocates one immutable frame by applying only fraction-dependent lerps. */
+export function sampleImageAnnotationInterpolation(
+  prepared: PreparedImageAnnotationInterpolation,
+  fraction: number,
+): SampledImageAnnotationInterpolation {
+  const sampledPoints = samplePoints(prepared.points, fraction);
+  return {
+    frame: {
+      kind: prepared.kind,
+      circles: sampleCircles(prepared.circles, fraction),
+      points: sampledPoints.points,
+      texts: sampleTexts(prepared.texts, fraction),
+    },
+    renderMetadata: {
+      lineListGroups: sampledPoints.lineListGroups,
+    },
+  };
+}
+
 function interpolateImageAnnotations(
   prev: ImageAnnotationsVisualization,
   next: ImageAnnotationsVisualization,
   f: number,
 ): ImageAnnotationsVisualization {
+  return sampleImageAnnotationInterpolation(
+    prepareImageAnnotationInterpolation(prev, next),
+    f,
+  ).frame;
+}
+
+function prepareCircles(
+  previous: readonly ImageAnnotationCircle[],
+  next: readonly ImageAnnotationCircle[],
+): PreparedCircles {
+  if (previous.length !== next.length) {
+    return { kind: "passthrough", value: previous };
+  }
   return {
-    kind: prev.kind,
-    circles: interpolateCircles(prev.circles, next.circles, f),
-    points: interpolatePointsArray(prev, next, f),
-    texts: interpolateTexts(prev.texts, next.texts, f),
+    kind: "interpolate",
+    tracks: previous.map((circle, index) => ({
+      deltaDiameter: next[index].diameter - circle.diameter,
+      position: preparePointTrack(circle.position, next[index].position),
+      previous: circle,
+    })),
   };
+}
+
+function sampleCircles(
+  prepared: PreparedCircles,
+  fraction: number,
+): readonly ImageAnnotationCircle[] {
+  if (prepared.kind === "passthrough") return prepared.value;
+  return prepared.tracks.map(({ deltaDiameter, position, previous }) => ({
+    ...previous,
+    diameter: previous.diameter + deltaDiameter * fraction,
+    position: samplePointTrack(position, fraction),
+  }));
 }
 
 function interpolateCircles(
@@ -74,17 +229,52 @@ function interpolateCircles(
   next: readonly ImageAnnotationCircle[],
   f: number,
 ): readonly ImageAnnotationCircle[] {
-  // Index matching is acceptable for circles — they're rare in this data
-  // and tend to stay in order; if counts differ we just keep prev.
-  if (prev.length !== next.length) return prev;
-  return prev.map((p, i) => {
-    const n = next[i];
-    return {
-      ...p,
-      position: lerpPoint(p.position, n.position, f),
-      diameter: lerp(p.diameter, n.diameter, f),
-    };
-  });
+  return sampleCircles(prepareCircles(prev, next), f);
+}
+
+function prepareTexts(
+  previous: readonly ImageAnnotationText[],
+  next: readonly ImageAnnotationText[],
+): readonly TextTrack[] {
+  const tracks: TextTrack[] = [];
+  const usedNext = new Set<number>();
+  for (const text of previous) {
+    let bestIdx = -1;
+    let bestDist = Infinity;
+    for (let index = 0; index < next.length; index++) {
+      if (usedNext.has(index)) continue;
+      const candidate = next[index];
+      if (candidate.text !== text.text) continue;
+      const distance = squaredDistance(text.position, candidate.position);
+      if (distance < bestDist) {
+        bestDist = distance;
+        bestIdx = index;
+      }
+    }
+    const matched =
+      bestIdx !== -1 && bestDist <= MATCH_DISTANCE_PX * MATCH_DISTANCE_PX
+        ? next[bestIdx]
+        : null;
+    if (matched) usedNext.add(bestIdx);
+    tracks.push({
+      position: matched
+        ? preparePointTrack(text.position, matched.position)
+        : null,
+      previous: text,
+    });
+  }
+  return tracks;
+}
+
+function sampleTexts(
+  prepared: readonly TextTrack[],
+  fraction: number,
+): readonly ImageAnnotationText[] {
+  return prepared.map(({ position, previous }) =>
+    position
+      ? { ...previous, position: samplePointTrack(position, fraction) }
+      : previous,
+  );
 }
 
 function interpolateTexts(
@@ -92,31 +282,7 @@ function interpolateTexts(
   next: readonly ImageAnnotationText[],
   f: number,
 ): readonly ImageAnnotationText[] {
-  // Match texts by `text` content + nearest position, greedy per content.
-  const out: ImageAnnotationText[] = [];
-  const usedNext = new Set<number>();
-  for (const p of prev) {
-    let bestIdx = -1;
-    let bestDist = Infinity;
-    for (let j = 0; j < next.length; j++) {
-      if (usedNext.has(j)) continue;
-      const n = next[j];
-      if (n.text !== p.text) continue;
-      const d = squaredDistance(p.position, n.position);
-      if (d < bestDist) {
-        bestDist = d;
-        bestIdx = j;
-      }
-    }
-    if (bestIdx === -1 || bestDist > MATCH_DISTANCE_PX * MATCH_DISTANCE_PX) {
-      out.push(p);
-      continue;
-    }
-    usedNext.add(bestIdx);
-    const n = next[bestIdx];
-    out.push({ ...p, position: lerpPoint(p.position, n.position, f) });
-  }
-  return out;
+  return sampleTexts(prepareTexts(prev, next), f);
 }
 
 /**
@@ -131,19 +297,90 @@ function interpolatePointsArray(
   next: ImageAnnotationsVisualization,
   f: number,
 ): readonly ImageAnnotationPoints[] {
-  if (prev.points.length !== next.points.length) return prev.points;
-  return prev.points.map((pp, idx) => {
-    const np = next.points[idx];
-    if (pp.type !== np.type) return pp;
-    if (pp.type === "line-list") {
-      return interpolateLineList(pp, np, prev.texts, next.texts, f);
-    }
-    if (pp.points.length !== np.points.length) return pp;
+  return samplePoints(preparePoints(prev, next), f).points;
+}
+
+function preparePoints(
+  previous: ImageAnnotationsVisualization,
+  next: ImageAnnotationsVisualization,
+): PreparedPoints {
+  if (previous.points.length !== next.points.length) {
     return {
-      ...pp,
-      points: pp.points.map((pt, j) => lerpPoint(pt, np.points[j], f)),
+      kind: "passthrough",
+      renderMetadata: prepareImageAnnotationRenderMetadata(previous),
+      value: previous.points,
     };
-  });
+  }
+
+  return {
+    items: previous.points.map((primitive, index) => {
+      const nextPrimitive = next.points[index];
+      if (primitive.type !== nextPrimitive.type) {
+        return {
+          groups:
+            primitive.type === "line-list"
+              ? prepareLineListRenderGroups(primitive, previous.texts)
+              : null,
+          kind: "passthrough",
+          value: primitive,
+        };
+      }
+      if (primitive.type === "line-list") {
+        return prepareLineList(
+          primitive,
+          nextPrimitive,
+          previous.texts,
+          next.texts,
+        );
+      }
+      if (primitive.points.length !== nextPrimitive.points.length) {
+        return { groups: null, kind: "passthrough", value: primitive };
+      }
+      return {
+        kind: "indexed",
+        pointTracks: primitive.points.map((point, pointIndex) =>
+          preparePointTrack(point, nextPrimitive.points[pointIndex]),
+        ),
+        previous: primitive,
+      };
+    }),
+    kind: "interpolate",
+  };
+}
+
+function samplePoints(
+  prepared: PreparedPoints,
+  fraction: number,
+): SampledPoints {
+  if (prepared.kind === "passthrough") {
+    return {
+      lineListGroups: prepared.renderMetadata.lineListGroups,
+      points: prepared.value,
+    };
+  }
+  const lineListGroups: (readonly ImageAnnotationLineListGroup[] | null)[] = [];
+  const points: ImageAnnotationPoints[] = [];
+  for (const item of prepared.items) {
+    if (item.kind === "passthrough") {
+      points.push(item.value);
+      lineListGroups.push(item.groups);
+      continue;
+    }
+    if (item.kind === "line-list") {
+      const sampled = sampleLineList(item, fraction);
+      points.push(sampled.primitive);
+      lineListGroups.push(sampled.groups);
+      continue;
+    }
+    points.push({
+      ...item.previous,
+      points: item.pointTracks.map((point) =>
+        samplePointTrack(point, fraction),
+      ),
+    });
+    lineListGroups.push(null);
+  }
+  return { lineListGroups, points };
 }
 
 function interpolateLineList(
@@ -153,16 +390,88 @@ function interpolateLineList(
   nextTexts: readonly ImageAnnotationText[],
   f: number,
 ): ImageAnnotationPoints {
+  return sampleLineList(
+    prepareLineList(prevPrim, nextPrim, prevTexts, nextTexts),
+    f,
+  ).primitive;
+}
+
+function prepareLineList(
+  prevPrim: ImageAnnotationPoints,
+  nextPrim: ImageAnnotationPoints,
+  prevTexts: readonly ImageAnnotationText[],
+  nextTexts: readonly ImageAnnotationText[],
+): Extract<PreparedPointPrimitive, { readonly kind: "line-list" }> {
   const prevGroups = groupLineList(prevPrim.points, prevTexts);
   const nextGroups = groupLineList(nextPrim.points, nextTexts);
   const matchedPairs = matchLineListGroups(prevGroups, nextGroups);
 
+  return {
+    groups: matchedPairs.map(({ prev, next }) => ({
+      label: prev.label,
+      previousBounds: prev.bounds,
+      previousPoints: prev.segments.flatMap(([a, b]) => [a, b]),
+      previousSegments: prev.segments,
+      segmentTracks:
+        next && prev.segments.length === next.segments.length
+          ? prev.segments.map(([previousA, previousB], index) => {
+              const [nextA, nextB] = next.segments[index];
+              return [
+                preparePointTrack(previousA, nextA),
+                preparePointTrack(previousB, nextB),
+              ];
+            })
+          : null,
+    })),
+    kind: "line-list",
+    previous: prevPrim,
+  };
+}
+
+function sampleLineList(
+  prepared: Extract<PreparedPointPrimitive, { readonly kind: "line-list" }>,
+  fraction: number,
+): SampledLineList {
+  const groups: ImageAnnotationLineListGroup[] = [];
   const out: Point2[] = [];
-  for (const { prev, next } of matchedPairs) {
-    appendInterpolatedSegments(out, prev, next, f);
+  for (const {
+    label,
+    previousBounds,
+    previousPoints,
+    previousSegments,
+    segmentTracks,
+  } of prepared.groups) {
+    if (!segmentTracks) {
+      appendSegments(out, previousSegments);
+      groups.push({
+        bounds: previousBounds,
+        label,
+        points: previousPoints,
+        segments: previousSegments,
+      });
+      continue;
+    }
+    const segments: [Point2, Point2][] = [];
+    const points: Point2[] = [];
+    for (const [a, b] of segmentTracks) {
+      const sampledA = samplePointTrack(a, fraction);
+      const sampledB = samplePointTrack(b, fraction);
+      out.push(sampledA, sampledB);
+      points.push(sampledA, sampledB);
+      segments.push([sampledA, sampledB]);
+    }
+    groups.push({
+      bounds: segmentsBounds(segments),
+      label,
+      points,
+      segments,
+    });
   }
 
-  return { ...prevPrim, points: out };
+  return {
+    groups,
+    primitive: { ...prepared.previous, points: out },
+  };
 }
 
 interface MatchedGroupPair {
@@ -216,23 +525,6 @@ function bestNextGroupIndex(
   return bestIdx;
 }
 
-function appendInterpolatedSegments(
-  out: Point2[],
-  prev: Group,
-  next: Group | null,
-  f: number,
-): void {
-  if (!next || prev.segments.length !== next.segments.length) {
-    appendSegments(out, prev.segments);
-    return;
-  }
-  for (let i = 0; i < prev.segments.length; i++) {
-    const [pa, pb] = prev.segments[i];
-    const [na, nb] = next.segments[i];
-    out.push(lerpPoint(pa, na, f), lerpPoint(pb, nb, f));
-  }
-}
-
 function appendSegments(
   out: Point2[],
   segments: readonly [Point2, Point2][],
@@ -260,6 +552,33 @@ function groupLineList(
 ): readonly Group[] {
   return groupLineSegmentsByLabel(points, texts).map(({ label, segments }) =>
     makeGroup(segments, label),
+  );
+}
+
+/** Prepares renderer grouping once for a non-interpolated annotation frame. */
+export function prepareImageAnnotationRenderMetadata(
+  frame: ImageAnnotationsVisualization,
+): ImageAnnotationRenderMetadata {
+  return {
+    lineListGroups: frame.points.map((primitive) =>
+      primitive.type === "line-list"
+        ? prepareLineListRenderGroups(primitive, frame.texts)
+        : null,
+    ),
+  };
+}
+
+function prepareLineListRenderGroups(
+  primitive: ImageAnnotationPoints,
+  texts: readonly ImageAnnotationText[],
+): readonly ImageAnnotationLineListGroup[] {
+  return groupLineSegmentsByLabel(primitive.points, texts).map(
+    ({ label, segments }) => ({
+      bounds: segmentsBounds(segments),
+      label,
+      points: segments.flatMap(([a, b]) => [a, b]),
+      segments,
+    }),
   );
 }
 
@@ -338,12 +657,7 @@ function chamferDistance(a: readonly Point2[], b: readonly Point2[]): number {
   return (sumAB / a.length + sumBA / b.length) / 2;
 }
 
-interface Bounds {
-  minX: number;
-  minY: number;
-  maxX: number;
-  maxY: number;
-}
+type Bounds = ImageAnnotationBounds;
 
 function segmentsBounds(segments: readonly [Point2, Point2][]): Bounds {
   if (segments.length === 0) {
@@ -373,12 +687,17 @@ function squaredDistance(a: Point2, b: Point2): number {
   return dx * dx + dy * dy;
 }
 
-function lerpPoint(a: Point2, b: Point2, f: number): Point2 {
-  return [a[0] + (b[0] - a[0]) * f, a[1] + (b[1] - a[1]) * f];
+function preparePointTrack(previous: Point2, next: Point2): PointTrack {
+  return {
+    deltaX: next[0] - previous[0],
+    deltaY: next[1] - previous[1],
+    x: previous[0],
+    y: previous[1],
+  };
 }
 
-function lerp(a: number, b: number, f: number): number {
-  return a + (b - a) * f;
+function samplePointTrack(track: PointTrack, fraction: number): Point2 {
+  return [track.x + track.deltaX * fraction, track.y + track.deltaY * fraction];
 }
 
 function lowerBoundBigInt(arr: readonly bigint[], target: bigint): number {

--- a/app/packages/multimodal/src/adapters/mcap/react/use-interpolated-image-annotations.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-interpolated-image-annotations.test.tsx
@@ -13,6 +13,8 @@ import {
 import type { McapTimelineIndex } from "./mcap-timeline-index";
 import { McapTopicCache } from "./mcap-topic-cache";
 import {
+  nextDistinctCachedMessage,
+  preparedImageAnnotationInterpolation,
   useInterpolatedImageAnnotations,
   useInterpolatedImageAnnotationSets,
 } from "./use-interpolated-image-annotations";
@@ -655,6 +657,142 @@ describe("useInterpolatedImageAnnotationSets — interpolation seam", () => {
       cacheA.set(TICKS[0], message(TICKS[0], emptyViz()));
     });
     expect(latest()?.kind).toBe(VISUALIZATION_KIND.IMAGE_ANNOTATIONS);
+  });
+});
+
+describe("image annotation interpolation caches", () => {
+  it("reuses the prepared plan only for the same visualization pair", () => {
+    const cache = new WeakMap() as Parameters<
+      typeof preparedImageAnnotationInterpolation
+    >[0];
+    const previous = circleViz([0, 0]);
+    const next = circleViz([10, 0]);
+
+    const first = preparedImageAnnotationInterpolation(cache, previous, next);
+    const second = preparedImageAnnotationInterpolation(cache, previous, next);
+    const differentPair = preparedImageAnnotationInterpolation(
+      cache,
+      previous,
+      circleViz([20, 0]),
+    );
+
+    expect(second).toBe(first);
+    expect(differentPair).not.toBe(first);
+  });
+
+  it("reuses a positive next-message lookup while the pair remains current", () => {
+    const ticks = Array.from({ length: 130 }, (_, index) => BigInt(index));
+    const timeline = makeTimeline(ticks);
+    const cache = new McapTopicCache();
+    const current = message(0n, emptyViz());
+    const next = message(125n, emptyViz());
+    cache.set(6n, current);
+    cache.set(125n, next);
+    const lookupCache = new WeakMap();
+
+    expect(
+      nextDistinctCachedMessage({
+        cache,
+        currentMessage: current,
+        currentTick: 6n,
+        currentTimelineTimeNs: 0n,
+        lookupCache,
+        timeline,
+      }),
+    ).toBe(next);
+
+    const get = vi.spyOn(cache, "get");
+    expect(
+      nextDistinctCachedMessage({
+        cache,
+        currentMessage: current,
+        currentTick: 7n,
+        currentTimelineTimeNs: 0n,
+        lookupCache,
+        timeline,
+      }),
+    ).toBe(next);
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it("rescans a cached miss as its bounded window advances", () => {
+    const ticks = Array.from({ length: 130 }, (_, index) => BigInt(index));
+    const timeline = makeTimeline(ticks);
+    const cache = new McapTopicCache();
+    const current = message(0n, emptyViz());
+    const next = message(125n, emptyViz());
+    cache.set(0n, current);
+    cache.set(6n, current);
+    cache.set(125n, next);
+    const lookupCache = new WeakMap();
+
+    expect(
+      nextDistinctCachedMessage({
+        cache,
+        currentMessage: current,
+        currentTick: 0n,
+        currentTimelineTimeNs: 0n,
+        lookupCache,
+        timeline,
+      }),
+    ).toBeNull();
+    expect(
+      nextDistinctCachedMessage({
+        cache,
+        currentMessage: current,
+        currentTick: 6n,
+        currentTimelineTimeNs: 0n,
+        lookupCache,
+        timeline,
+      }),
+    ).toBe(next);
+  });
+
+  it("invalidates a cached miss when late lookahead arrives", () => {
+    const timeline = makeTimeline(TICKS);
+    const cache = new McapTopicCache();
+    const current = message(TICKS[0], emptyViz());
+    const next = message(TICKS[2], emptyViz());
+    cache.set(TICKS[0], current);
+    const lookupCache = new WeakMap();
+    const lookup = () =>
+      nextDistinctCachedMessage({
+        cache,
+        currentMessage: current,
+        currentTick: TICKS[0],
+        currentTimelineTimeNs: current.timelineTimeNs,
+        lookupCache,
+        timeline,
+      });
+
+    expect(lookup()).toBeNull();
+    cache.set(TICKS[2], next);
+    expect(lookup()).toBe(next);
+  });
+
+  it("replaces a cached positive lookup when earlier lookahead arrives", () => {
+    const ticks = [0n, 1n, 2n, 3n, 4n];
+    const timeline = makeTimeline(ticks);
+    const cache = new McapTopicCache();
+    const current = message(0n, emptyViz());
+    const later = message(4n, circleViz([40, 0]));
+    const earlier = message(2n, circleViz([20, 0]));
+    cache.set(0n, current);
+    cache.set(4n, later);
+    const lookupCache = new WeakMap();
+    const lookup = () =>
+      nextDistinctCachedMessage({
+        cache,
+        currentMessage: current,
+        currentTick: 0n,
+        currentTimelineTimeNs: current.timelineTimeNs,
+        lookupCache,
+        timeline,
+      });
+
+    expect(lookup()).toBe(later);
+    cache.set(2n, earlier);
+    expect(lookup()).toBe(earlier);
   });
 });
 

--- a/app/packages/multimodal/src/adapters/mcap/react/use-interpolated-image-annotations.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-interpolated-image-annotations.ts
@@ -8,10 +8,14 @@ import {
 } from "react";
 
 import type { ImageAnnotationsVisualization } from "../../../decoders";
+import type { ImageAnnotationRenderMetadata } from "../../../visualization/panels/image-annotation-render-metadata";
 import type { McapDecodedMessage } from "../types";
 import {
-  interpolateImageAnnotations,
   interpolationFraction,
+  prepareImageAnnotationInterpolation,
+  prepareImageAnnotationRenderMetadata,
+  sampleImageAnnotationInterpolation,
+  type PreparedImageAnnotationInterpolation,
   vizOf,
 } from "./interpolate-image-annotations";
 import {
@@ -59,6 +63,7 @@ export function useInterpolatedImageAnnotationSets(
   { interpolate = true }: UseInterpolatedImageAnnotationsOptions = {},
 ): readonly {
   readonly frame: ImageAnnotationsVisualization;
+  readonly renderMetadata: ImageAnnotationRenderMetadata;
   readonly topic: string;
 }[] {
   const stableTopics = useStableTopics(topics);
@@ -106,6 +111,18 @@ export function useInterpolatedImageAnnotationSets(
   const playhead = usePlayhead();
   const timeline = dataStream?.getTimelineIndex() ?? null;
   const cacheSnapshot = useTopicCacheSnapshot(dataStream, stableTopics);
+  const interpolationCache = useMemo(
+    () => createInterpolationCache(dataStream, timeline),
+    [dataStream, timeline],
+  );
+  const nextMessageCache = useMemo(
+    () => createNextMessageCache(dataStream, timeline),
+    [dataStream, timeline],
+  );
+  const renderMetadataCache = useMemo(
+    () => createRenderMetadataCache(dataStream, timeline),
+    [dataStream, timeline],
+  );
 
   return useMemo(
     () =>
@@ -113,20 +130,55 @@ export function useInterpolatedImageAnnotationSets(
         cacheSnapshot,
         dataStream,
         interpolate,
+        interpolationCache,
+        nextMessageCache,
         playhead,
+        renderMetadataCache,
         timeline,
         topics: stableTopics,
       }),
-    [cacheSnapshot, dataStream, interpolate, playhead, stableTopics, timeline],
+    [
+      cacheSnapshot,
+      dataStream,
+      interpolate,
+      interpolationCache,
+      nextMessageCache,
+      playhead,
+      renderMetadataCache,
+      stableTopics,
+      timeline,
+    ],
   );
 }
+
+type InterpolationCache = WeakMap<
+  ImageAnnotationsVisualization,
+  WeakMap<ImageAnnotationsVisualization, PreparedImageAnnotationInterpolation>
+>;
+
+interface NextMessageCacheEntry {
+  readonly currentIndex: number;
+  readonly currentMessage: McapDecodedMessage;
+  readonly nextIndex: number | null;
+  readonly nextMessage: McapDecodedMessage | null;
+  readonly revision: number;
+  readonly timeline: McapTimelineIndex;
+}
+
+type RenderMetadataCache = WeakMap<
+  ImageAnnotationsVisualization,
+  ImageAnnotationRenderMetadata
+>;
 
 interface AnnotationSetsFromCachesArgs {
   /** Invalidation token from `useSyncExternalStore`; frame derivation reads caches below. */
   readonly cacheSnapshot: string;
   readonly dataStream: McapDataStream | null;
   readonly interpolate: boolean;
+  readonly interpolationCache: InterpolationCache;
+  readonly nextMessageCache: WeakMap<McapTopicCache, NextMessageCacheEntry>;
   readonly playhead: number;
+  readonly renderMetadataCache: RenderMetadataCache;
   readonly timeline: McapTimelineIndex | null;
   readonly topics: readonly string[];
 }
@@ -134,17 +186,22 @@ interface AnnotationSetsFromCachesArgs {
 function annotationSetsFromCaches({
   dataStream,
   interpolate,
+  interpolationCache,
+  nextMessageCache,
   playhead,
+  renderMetadataCache,
   timeline,
   topics,
 }: AnnotationSetsFromCachesArgs): readonly {
   readonly frame: ImageAnnotationsVisualization;
+  readonly renderMetadata: ImageAnnotationRenderMetadata;
   readonly topic: string;
 }[] {
   if (!dataStream || !timeline) return [];
 
   const sets: {
     frame: ImageAnnotationsVisualization;
+    renderMetadata: ImageAnnotationRenderMetadata;
     topic: string;
   }[] = [];
   for (const topic of topics) {
@@ -153,12 +210,15 @@ function annotationSetsFromCaches({
       ? currentAnnotationFrame({
           cache,
           interpolate,
+          interpolationCache,
+          nextMessageCache,
           playhead,
+          renderMetadataCache,
           timeline,
         })
       : null;
     if (frame) {
-      sets.push({ frame, topic });
+      sets.push({ ...frame, topic });
     }
   }
   return sets;
@@ -260,40 +320,118 @@ function normalizeTopics(topics: readonly string[]): readonly string[] {
 function currentAnnotationFrame({
   cache,
   interpolate,
+  interpolationCache,
+  nextMessageCache,
   playhead,
+  renderMetadataCache,
   timeline,
 }: {
   readonly cache: McapTopicCache;
   readonly interpolate: boolean;
+  readonly interpolationCache: InterpolationCache;
+  readonly nextMessageCache: WeakMap<McapTopicCache, NextMessageCacheEntry>;
   readonly playhead: number;
+  readonly renderMetadataCache: RenderMetadataCache;
   readonly timeline: McapTimelineIndex;
-}): ImageAnnotationsVisualization | null {
+}): {
+  readonly frame: ImageAnnotationsVisualization;
+  readonly renderMetadata: ImageAnnotationRenderMetadata;
+} | null {
   const currentTick = timeline.nearestTick(playhead);
   if (currentTick === undefined) return null;
   const currentMsg = cache.get(currentTick);
   if (!currentMsg) return null;
   const currentViz = vizOf(currentMsg);
   if (!currentViz) return null;
-  if (!interpolate) return currentViz;
+  if (!interpolate) {
+    return annotationFrameWithMetadata(renderMetadataCache, currentViz);
+  }
 
   const nextMsg = nextDistinctCachedMessage({
     cache,
     currentTick,
     currentTimelineTimeNs: currentMsg.timelineTimeNs,
+    lookupCache: nextMessageCache,
+    currentMessage: currentMsg,
     timeline,
   });
-  if (!nextMsg) return currentViz;
+  if (!nextMsg) {
+    return annotationFrameWithMetadata(renderMetadataCache, currentViz);
+  }
   const nextViz = vizOf(nextMsg);
-  if (!nextViz) return currentViz;
+  if (!nextViz) {
+    return annotationFrameWithMetadata(renderMetadataCache, currentViz);
+  }
 
   const f = interpolationFraction({
     nextTimelineTimeNs: nextMsg.timelineTimeNs,
     playheadNs: timeline.secToNs(playhead),
     previousTimelineTimeNs: currentMsg.timelineTimeNs,
   });
-  if (f === null) return currentViz;
+  if (f === null) {
+    return annotationFrameWithMetadata(renderMetadataCache, currentViz);
+  }
 
-  return interpolateImageAnnotations(currentViz, nextViz, f);
+  const prepared = preparedImageAnnotationInterpolation(
+    interpolationCache,
+    currentViz,
+    nextViz,
+  );
+  return sampleImageAnnotationInterpolation(prepared, f);
+}
+
+function createInterpolationCache(
+  _dataStream: McapDataStream | null,
+  _timeline: McapTimelineIndex | null,
+): InterpolationCache {
+  return new WeakMap();
+}
+
+function createNextMessageCache(
+  _dataStream: McapDataStream | null,
+  _timeline: McapTimelineIndex | null,
+): WeakMap<McapTopicCache, NextMessageCacheEntry> {
+  return new WeakMap();
+}
+
+function createRenderMetadataCache(
+  _dataStream: McapDataStream | null,
+  _timeline: McapTimelineIndex | null,
+): RenderMetadataCache {
+  return new WeakMap();
+}
+
+function annotationFrameWithMetadata(
+  cache: RenderMetadataCache,
+  frame: ImageAnnotationsVisualization,
+): {
+  readonly frame: ImageAnnotationsVisualization;
+  readonly renderMetadata: ImageAnnotationRenderMetadata;
+} {
+  let renderMetadata = cache.get(frame);
+  if (!renderMetadata) {
+    renderMetadata = prepareImageAnnotationRenderMetadata(frame);
+    cache.set(frame, renderMetadata);
+  }
+  return { frame, renderMetadata };
+}
+
+export function preparedImageAnnotationInterpolation(
+  cache: InterpolationCache,
+  previous: ImageAnnotationsVisualization,
+  next: ImageAnnotationsVisualization,
+): PreparedImageAnnotationInterpolation {
+  let byNext = cache.get(previous);
+  if (!byNext) {
+    byNext = new WeakMap();
+    cache.set(previous, byNext);
+  }
+  let prepared = byNext.get(next);
+  if (!prepared) {
+    prepared = prepareImageAnnotationInterpolation(previous, next);
+    byNext.set(next, prepared);
+  }
+  return prepared;
 }
 
 /**
@@ -305,11 +443,15 @@ export function nextDistinctCachedMessage({
   cache,
   currentTick,
   currentTimelineTimeNs,
+  currentMessage,
+  lookupCache,
   timeline,
 }: {
   readonly cache: McapTopicCache;
   readonly currentTick: bigint;
   readonly currentTimelineTimeNs: bigint;
+  readonly currentMessage?: McapDecodedMessage;
+  readonly lookupCache?: WeakMap<McapTopicCache, NextMessageCacheEntry>;
   readonly timeline: McapTimelineIndex;
 }): McapDecodedMessage | null {
   // Ticks are synchronized with LATEST semantics, so several cached ticks can
@@ -318,6 +460,28 @@ export function nextDistinctCachedMessage({
   // current frame is cheaper and visually safer than scanning the full file.
   const currentIndex = timeline.indexOfTick(currentTick);
   if (currentIndex === undefined) return null;
+  const cached = lookupCache?.get(cache);
+  if (
+    currentMessage &&
+    cached?.timeline === timeline &&
+    cached.revision === cache.revision &&
+    cached.currentMessage === currentMessage
+  ) {
+    if (
+      cached.nextMessage &&
+      cached.nextIndex !== null &&
+      currentIndex >= cached.currentIndex &&
+      currentIndex < cached.nextIndex
+    ) {
+      return cached.nextMessage;
+    }
+    // A miss is only reusable at the exact scan frontier. As the playhead
+    // advances, the bounded search window slides and can expose a sparse next
+    // message without any cache revision or current-message change.
+    if (!cached.nextMessage && currentIndex === cached.currentIndex) {
+      return null;
+    }
+  }
   const startIndex = currentIndex + 1;
   const endIndex = Math.min(
     timeline.tickCount,
@@ -327,7 +491,29 @@ export function nextDistinctCachedMessage({
     const tick = timeline.tickAt(i);
     if (tick === undefined) break;
     const msg = cache.get(tick);
-    if (msg && msg.timelineTimeNs !== currentTimelineTimeNs) return msg;
+    if (msg && msg.timelineTimeNs !== currentTimelineTimeNs) {
+      if (lookupCache && currentMessage) {
+        lookupCache.set(cache, {
+          currentIndex,
+          currentMessage,
+          nextIndex: i,
+          nextMessage: msg,
+          revision: cache.revision,
+          timeline,
+        });
+      }
+      return msg;
+    }
+  }
+  if (lookupCache && currentMessage) {
+    lookupCache.set(cache, {
+      currentIndex,
+      currentMessage,
+      nextIndex: null,
+      nextMessage: null,
+      revision: cache.revision,
+      timeline,
+    });
   }
   return null;
 }

--- a/app/packages/multimodal/src/adapters/mcap/topic-inventory.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/topic-inventory.test.ts
@@ -110,14 +110,18 @@ describe("buildMcapTopicInventoryRows", () => {
     });
   });
 
-  it("classifies topics containing imu as sensors", () => {
+  it("classifies imu path segments as sensors", () => {
     const topics = [
       topic("/vehicle/IMU/data", "vendor_msgs/Widget", "cdr", "ros2msg", "3"),
+      topic("/simulated_pose", "vendor_msgs/Widget", "cdr", "ros2msg", "3"),
     ];
 
     const rows = buildMcapTopicInventoryRows({ sceneSources: [], topics });
 
     expect(row(rows, "/vehicle/IMU/data").category).toBe(
+      MCAP_TOPIC_CATEGORY.SENSORS,
+    );
+    expect(row(rows, "/simulated_pose").category).not.toBe(
       MCAP_TOPIC_CATEGORY.SENSORS,
     );
   });
@@ -146,7 +150,9 @@ describe("buildMcapTopicInventoryRows", () => {
 
 function row(rows: readonly McapTopicInventoryRow[], topic: string) {
   const match = rows.find((candidate) => candidate.topic === topic);
-  expect(match).toBeTruthy();
+  if (!match) {
+    throw new Error(`Missing topic inventory row: ${topic}`);
+  }
   return match;
 }
 

--- a/app/packages/multimodal/src/adapters/mcap/topic-inventory.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/topic-inventory.test.ts
@@ -58,13 +58,13 @@ describe("buildMcapTopicInventoryRows", () => {
 
     expect(rows.map((row) => row.topic)).toEqual([
       "/camera/front",
+      "/imu",
       "/lidar/top",
       "/markers",
       "/plan",
       "/odom",
       "/tf_static",
       "/diagnostics",
-      "/imu",
       "/binary",
       "/broken",
       "/vendor/raw",
@@ -91,7 +91,7 @@ describe("buildMcapTopicInventoryRows", () => {
       capabilities: [MCAP_TOPIC_CAPABILITY.LOGS, MCAP_TOPIC_CAPABILITY.RAW],
     });
     expect(row(rows, "/imu")).toMatchObject({
-      category: MCAP_TOPIC_CATEGORY.TELEMETRY,
+      category: MCAP_TOPIC_CATEGORY.SENSORS,
       supportStatus: "inspectable",
       capabilities: [MCAP_TOPIC_CAPABILITY.PLOT, MCAP_TOPIC_CAPABILITY.RAW],
     });
@@ -110,6 +110,18 @@ describe("buildMcapTopicInventoryRows", () => {
     });
   });
 
+  it("classifies topics containing imu as sensors", () => {
+    const topics = [
+      topic("/vehicle/IMU/data", "vendor_msgs/Widget", "cdr", "ros2msg", "3"),
+    ];
+
+    const rows = buildMcapTopicInventoryRows({ sceneSources: [], topics });
+
+    expect(row(rows, "/vehicle/IMU/data").category).toBe(
+      MCAP_TOPIC_CATEGORY.SENSORS,
+    );
+  });
+
   it("searches topic names, schema names, categories, support, and capabilities", () => {
     const rows = buildMcapTopicInventoryRows({
       sceneSources: [],
@@ -120,7 +132,7 @@ describe("buildMcapTopicInventoryRows", () => {
     });
 
     expect(
-      filterMcapTopicInventoryRows(rows, "telemetry").map(topicName),
+      filterMcapTopicInventoryRows(rows, "sensors").map(topicName),
     ).toEqual(["/imu"]);
     expect(filterMcapTopicInventoryRows(rows, "Widget").map(topicName)).toEqual(
       ["/vendor/raw"],

--- a/app/packages/multimodal/src/adapters/mcap/topic-inventory.ts
+++ b/app/packages/multimodal/src/adapters/mcap/topic-inventory.ts
@@ -231,7 +231,7 @@ function categoryForTopic({
   readonly telemetry: boolean;
   readonly topic: string;
 }): McapTopicCategory {
-  if (topic.toLowerCase().includes("imu")) {
+  if (/(?:^|\/)imu(?:\/|$)/i.test(topic)) {
     return MCAP_TOPIC_CATEGORY.SENSORS;
   }
   if (sourceType === MCAP_SOURCE_TYPE.LOG || isLogStream(stream)) {

--- a/app/packages/multimodal/src/adapters/mcap/topic-inventory.ts
+++ b/app/packages/multimodal/src/adapters/mcap/topic-inventory.ts
@@ -168,6 +168,7 @@ export function buildMcapTopicInventoryRows({
           sourceType,
           stream,
           telemetry,
+          topic: name,
         }),
         countLabel: messageCountLabel(stream.recordCount),
         encoding: encodingFor(stream),
@@ -222,12 +223,17 @@ function categoryForTopic({
   sourceType,
   stream,
   telemetry,
+  topic,
 }: {
   readonly frameTransform: boolean;
   readonly sourceType: McapSourceType | null;
   readonly stream: StreamInventory;
   readonly telemetry: boolean;
+  readonly topic: string;
 }): McapTopicCategory {
+  if (topic.toLowerCase().includes("imu")) {
+    return MCAP_TOPIC_CATEGORY.SENSORS;
+  }
   if (sourceType === MCAP_SOURCE_TYPE.LOG || isLogStream(stream)) {
     return MCAP_TOPIC_CATEGORY.DIAGNOSTICS;
   }

--- a/app/packages/multimodal/src/visualization/panels/ImageAnnotationsOverlay.test.tsx
+++ b/app/packages/multimodal/src/visualization/panels/ImageAnnotationsOverlay.test.tsx
@@ -410,6 +410,61 @@ describe("ImageAnnotationsOverlay", () => {
     expect(lines[0].getAttribute("y2")).toBe("10");
   });
 
+  it("renders prepared line-list groups without regrouping the raw primitive", () => {
+    const annotation = {
+      ...emptySet(),
+      points: [
+        {
+          type: "line-list" as const,
+          points: [
+            [0, 0],
+            [10, 10],
+          ] as const,
+          thickness: 2,
+          outlineColor: RED,
+          outlineColors: [],
+          fillColor: null,
+        },
+      ],
+    };
+    const { container } = render(
+      <ImageAnnotationsOverlay
+        annotations={[annotation]}
+        fit="contain"
+        imageHeight={100}
+        imageWidth={200}
+        renderMetadata={[
+          {
+            lineListGroups: [
+              [
+                {
+                  bounds: { minX: 50, minY: 20, maxX: 70, maxY: 40 },
+                  label: "car",
+                  points: [
+                    [50, 20],
+                    [70, 40],
+                  ],
+                  segments: [
+                    [
+                      [50, 20],
+                      [70, 40],
+                    ],
+                  ],
+                },
+              ],
+            ],
+          },
+        ]}
+      />,
+    );
+
+    const line = requireElement<SVGLineElement>(container, "line");
+    expect(line.getAttribute("x1")).toBe("50");
+    expect(line.getAttribute("y1")).toBe("20");
+    expect(line.getAttribute("x2")).toBe("70");
+    expect(line.getAttribute("y2")).toBe("40");
+  });
+
   it("renders one circle per individual point", () => {
     // The interactive renderer draws a <circle> for each point; colour is
     // applied via CSS custom property, not the fill attribute.

--- a/app/packages/multimodal/src/visualization/panels/ImageAnnotationsOverlay.tsx
+++ b/app/packages/multimodal/src/visualization/panels/ImageAnnotationsOverlay.tsx
@@ -1,6 +1,13 @@
 import clsx from "clsx";
 import type { CSSProperties } from "react";
-import React, { Fragment, useEffect, useRef, useState } from "react";
+import React, {
+  Fragment,
+  createContext,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 
 import type {
   ImageAnnotationCircle,
@@ -32,6 +39,15 @@ export type ImageAnnotationSelectHandler = (
   modifiers: { readonly shiftKey: boolean },
 ) => void;
 
+export type ImagePixelTransform = (
+  u: number,
+  v: number,
+) => readonly [number, number] | null;
+
+const ImagePixelTransformContext = createContext<ImagePixelTransform | null>(
+  null,
+);
+
 export interface ImageAnnotationPickedPrimitive {
   readonly key: string;
   readonly setIndex: number;
@@ -57,6 +73,8 @@ export interface ImageAnnotationsOverlayProps {
   readonly onSelectPrimitive?: ImageAnnotationSelectHandler;
   /** Optional render-ready grouping prepared with interpolated geometry. */
   readonly renderMetadata?: readonly ImageAnnotationRenderMetadata[];
+  /** Optional nonlinear source-pixel to displayed-pixel mapping. */
+  readonly pixelTransform?: ImagePixelTransform;
   readonly viewTransform?: ImageViewTransform;
 }
 
@@ -81,6 +99,7 @@ export function ImageAnnotationsOverlay({
   highlightLabel,
   onSelectPrimitive,
   renderMetadata,
+  pixelTransform,
   viewTransform,
 }: ImageAnnotationsOverlayProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -89,6 +108,7 @@ export function ImageAnnotationsOverlay({
     height: number;
   } | null>(null);
 
+  // This effect tracks the overlay container size for image-space transforms.
   useEffect(() => {
     const el = containerRef.current;
     if (!el) return undefined;
@@ -132,19 +152,21 @@ export function ImageAnnotationsOverlay({
             pointerEvents: "none",
           }}
         >
-          {annotations.map((set, i) => (
-            <Fragment key={i}>
-              <SetPrimitives
-                set={set}
-                setIndex={i}
-                strokeWidth={strokeWidth}
-                selectedKey={selectedKey ?? null}
-                highlightLabel={highlightLabel ?? null}
-                onSelectPrimitive={onSelectPrimitive}
-                renderMetadata={renderMetadata?.[i]}
-              />
-            </Fragment>
-          ))}
+          <ImagePixelTransformContext.Provider value={pixelTransform ?? null}>
+            {annotations.map((set, i) => (
+              <Fragment key={i}>
+                <SetPrimitives
+                  set={set}
+                  setIndex={i}
+                  strokeWidth={strokeWidth}
+                  selectedKey={selectedKey ?? null}
+                  highlightLabel={highlightLabel ?? null}
+                  onSelectPrimitive={onSelectPrimitive}
+                  renderMetadata={renderMetadata?.[i]}
+                />
+              </Fragment>
+            ))}
+          </ImagePixelTransformContext.Provider>
         </svg>
       ) : null}
     </div>
@@ -249,6 +271,7 @@ function CirclePrimitive({
   highlightLabel,
   onSelectPrimitive,
 }: CirclePrimitiveProps) {
+  const pixelTransform = useContext(ImagePixelTransformContext);
   const [x, y] = primitive.position;
   const radius = Math.max(0, primitive.diameter / 2);
   const label = nearestLabel(texts, [x, y]);
@@ -265,6 +288,9 @@ function CirclePrimitive({
   const isSelected =
     selectedKey === key ||
     (highlightLabel !== null && label === highlightLabel);
+  const transformedCircle = pixelTransform
+    ? transformedCirclePoints(primitive, pixelTransform)
+    : null;
   return (
     <g
       className={clsx(
@@ -275,15 +301,33 @@ function CirclePrimitive({
       style={primitiveStyle(color, INTERIOR_FILL)}
       onClick={onClick}
     >
-      <circle cx={x} cy={y} r={radius} className={styles.fillInterior} />
-      <circle
-        cx={x}
-        cy={y}
-        r={radius}
-        strokeWidth={lineWidth(primitive.thickness, strokeWidth)}
-        vectorEffect="non-scaling-stroke"
-        fill="none"
-      />
+      {transformedCircle ? (
+        <>
+          <polygon
+            points={svgPoints(transformedCircle)}
+            className={styles.fillInterior}
+          />
+          <polygon
+            points={svgPoints(transformedCircle)}
+            strokeWidth={lineWidth(primitive.thickness, strokeWidth)}
+            strokeLinejoin="round"
+            vectorEffect="non-scaling-stroke"
+            fill="none"
+          />
+        </>
+      ) : pixelTransform ? null : (
+        <>
+          <circle cx={x} cy={y} r={radius} className={styles.fillInterior} />
+          <circle
+            cx={x}
+            cy={y}
+            r={radius}
+            strokeWidth={lineWidth(primitive.thickness, strokeWidth)}
+            vectorEffect="non-scaling-stroke"
+            fill="none"
+          />
+        </>
+      )}
     </g>
   );
 }
@@ -309,6 +353,7 @@ function PolylinePrimitive({
   highlightLabel,
   onSelectPrimitive,
 }: PolylinePrimitiveProps) {
+  const pixelTransform = useContext(ImagePixelTransformContext);
   const thickness = lineWidth(primitive.thickness, strokeWidth);
   const centroid = pointsCentroid(primitive.points);
   const label = centroid ? nearestLabel(texts, centroid) : null;
@@ -325,6 +370,13 @@ function PolylinePrimitive({
   const isSelected =
     selectedKey === key ||
     (highlightLabel !== null && label === highlightLabel);
+  const displayPoints = pixelTransform
+    ? transformedPrimitivePoints(primitive, pixelTransform)
+    : primitive.points;
+
+  if (displayPoints.length === 0) {
+    return null;
+  }
 
   if (primitive.type === "points") {
     return (
@@ -337,7 +389,7 @@ function PolylinePrimitive({
         style={primitiveStyle(color, undefined)}
         onClick={onClick}
       >
-        {primitive.points.map(([x, y], i) => (
+        {displayPoints.map(([x, y], i) => (
           <circle
             key={i}
             cx={x}
@@ -351,7 +403,7 @@ function PolylinePrimitive({
   }
 
   const closed = primitive.type === "line-loop";
-  const pointsAttr = primitive.points.map(([x, y]) => `${x},${y}`).join(" ");
+  const pointsAttr = svgPoints(displayPoints);
   return (
     <g
       className={clsx(
@@ -411,6 +463,7 @@ function LineListGroups({
   onSelectPrimitive,
   preparedGroups,
 }: LineListGroupsProps) {
+  const pixelTransform = useContext(ImagePixelTransformContext);
   const thickness = lineWidth(primitive.thickness, strokeWidth);
   const groups =
     preparedGroups ?? groupLineListByLabel(primitive.points, texts);
@@ -439,7 +492,19 @@ function LineListGroups({
         const isSelected =
           selectedKey === key ||
           (highlightLabel !== null && group.label === highlightLabel);
-        const b = group.bounds;
+        const displaySegments = pixelTransform
+          ? group.segments
+              .map((segment) =>
+                transformedSegment(segment[0], segment[1], pixelTransform),
+              )
+              .filter((segment) => segment.length >= 2)
+          : group.segments;
+        if (displaySegments.length === 0) {
+          return null;
+        }
+        const b = pixelTransform
+          ? (pointsBounds(displaySegments.flat()) ?? group.bounds)
+          : group.bounds;
         return (
           <g
             key={gi}
@@ -458,17 +523,29 @@ function LineListGroups({
               height={b.maxY - b.minY}
               className={styles.fillInterior}
             />
-            {group.segments.map(([[x1, y1], [x2, y2]], si) => (
-              <line
-                key={si}
-                x1={x1}
-                y1={y1}
-                x2={x2}
-                y2={y2}
-                strokeWidth={thickness}
-                strokeLinecap="round"
-                vectorEffect="non-scaling-stroke"
-              />
+            {displaySegments.map((segment, si) => (
+              <Fragment key={si}>
+                {pixelTransform ? (
+                  <polyline
+                    points={svgPoints(segment)}
+                    strokeWidth={thickness}
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    vectorEffect="non-scaling-stroke"
+                    fill="none"
+                  />
+                ) : (
+                  <line
+                    x1={segment[0][0]}
+                    y1={segment[0][1]}
+                    x2={segment[1][0]}
+                    y2={segment[1][1]}
+                    strokeWidth={thickness}
+                    strokeLinecap="round"
+                    vectorEffect="non-scaling-stroke"
+                  />
+                )}
+              </Fragment>
             ))}
           </g>
         );
@@ -494,7 +571,14 @@ function TextPrimitive({
   highlightLabel,
   onSelectPrimitive,
 }: TextPrimitiveProps) {
-  const [x, y] = primitive.position;
+  const pixelTransform = useContext(ImagePixelTransformContext);
+  const displayPosition = pixelTransform
+    ? pixelTransform(...primitive.position)
+    : primitive.position;
+  if (!displayPosition) {
+    return null;
+  }
+  const [x, y] = displayPosition;
   const fontSize = Math.max(1, primitive.fontSize);
   const background = rgbaToCss(primitive.backgroundColor);
   const label = primitive.text || null;
@@ -622,6 +706,110 @@ function pointsCentroid(points: readonly Point2[]): Point2 | null {
     sy += y;
   }
   return [sx / points.length, sy / points.length];
+}
+
+function transformedCirclePoints(
+  circle: ImageAnnotationCircle,
+  transform: ImagePixelTransform,
+): readonly Point2[] | null {
+  const radius = Math.max(0, circle.diameter / 2);
+  const sampleCount = Math.min(
+    96,
+    Math.max(24, Math.ceil((Math.PI * Math.max(1, circle.diameter)) / 8)),
+  );
+  const points: Point2[] = [];
+  for (let index = 0; index < sampleCount; index++) {
+    const angle = (Math.PI * 2 * index) / sampleCount;
+    const point = transform(
+      circle.position[0] + Math.cos(angle) * radius,
+      circle.position[1] + Math.sin(angle) * radius,
+    );
+    if (!point) {
+      return null;
+    }
+    points.push(point);
+  }
+  return points;
+}
+
+function transformedPrimitivePoints(
+  primitive: ImageAnnotationPoints,
+  transform: ImagePixelTransform,
+): readonly Point2[] {
+  if (primitive.type === "points") {
+    return primitive.points.flatMap((point) => {
+      const transformed = transform(...point);
+      return transformed ? [transformed] : [];
+    });
+  }
+  if (primitive.points.length < 2) {
+    return primitive.points.flatMap((point) => {
+      const transformed = transform(...point);
+      return transformed ? [transformed] : [];
+    });
+  }
+
+  const output: Point2[] = [];
+  const segmentCount =
+    primitive.type === "line-loop"
+      ? primitive.points.length
+      : primitive.points.length - 1;
+  for (let index = 0; index < segmentCount; index++) {
+    const start = primitive.points[index];
+    const end = primitive.points[(index + 1) % primitive.points.length];
+    const segment = transformedSegment(start, end, transform);
+    if (segment.length === 0) {
+      // A missing sample means the source curve left the camera model's
+      // invertible domain. Withhold the whole connected primitive instead of
+      // joining the valid pieces across an untrusted gap.
+      return [];
+    }
+    output.push(...(output.length > 0 ? segment.slice(1) : segment));
+  }
+  return output;
+}
+
+function transformedSegment(
+  start: Point2,
+  end: Point2,
+  transform: ImagePixelTransform,
+): readonly Point2[] {
+  const sourceLength = Math.hypot(end[0] - start[0], end[1] - start[1]);
+  const steps = Math.min(128, Math.max(1, Math.ceil(sourceLength / 8)));
+  const output: Point2[] = [];
+  for (let step = 0; step <= steps; step++) {
+    const fraction = step / steps;
+    const point = transform(
+      start[0] + (end[0] - start[0]) * fraction,
+      start[1] + (end[1] - start[1]) * fraction,
+    );
+    if (!point) {
+      return [];
+    }
+    output.push(point);
+  }
+  return output;
+}
+
+function pointsBounds(points: readonly Point2[]): Bounds | null {
+  if (points.length === 0) {
+    return null;
+  }
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const [x, y] of points) {
+    minX = Math.min(minX, x);
+    minY = Math.min(minY, y);
+    maxX = Math.max(maxX, x);
+    maxY = Math.max(maxY, y);
+  }
+  return { minX, minY, maxX, maxY };
+}
+
+function svgPoints(points: readonly Point2[]): string {
+  return points.map(([x, y]) => `${x},${y}`).join(" ");
 }
 
 // Subset of `@fiftyone/utilities`' default app color pool with the orange

--- a/app/packages/multimodal/src/visualization/panels/ImageAnnotationsOverlay.tsx
+++ b/app/packages/multimodal/src/visualization/panels/ImageAnnotationsOverlay.tsx
@@ -1,13 +1,6 @@
 import clsx from "clsx";
 import type { CSSProperties } from "react";
-import React, {
-  Fragment,
-  createContext,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
+import React, { Fragment, useEffect, useRef, useState } from "react";
 
 import type {
   ImageAnnotationCircle,
@@ -17,6 +10,11 @@ import type {
   RgbaColor,
 } from "../../decoders";
 import { groupLineSegmentsByLabel } from "../../utils/line-segment-grouping";
+import type {
+  ImageAnnotationBounds,
+  ImageAnnotationLineListGroup,
+  ImageAnnotationRenderMetadata,
+} from "./image-annotation-render-metadata";
 import {
   imageDisplayRect,
   transformedImageDisplayRect,
@@ -33,15 +31,6 @@ export type ImageAnnotationSelectHandler = (
   picked: ImageAnnotationPickedPrimitive,
   modifiers: { readonly shiftKey: boolean },
 ) => void;
-
-export type ImagePixelTransform = (
-  u: number,
-  v: number,
-) => readonly [number, number] | null;
-
-const ImagePixelTransformContext = createContext<ImagePixelTransform | null>(
-  null,
-);
 
 export interface ImageAnnotationPickedPrimitive {
   readonly key: string;
@@ -66,8 +55,8 @@ export interface ImageAnnotationsOverlayProps {
    */
   readonly highlightLabel?: string | null;
   readonly onSelectPrimitive?: ImageAnnotationSelectHandler;
-  /** Optional nonlinear source-pixel to displayed-pixel mapping. */
-  readonly pixelTransform?: ImagePixelTransform;
+  /** Optional render-ready grouping prepared with interpolated geometry. */
+  readonly renderMetadata?: readonly ImageAnnotationRenderMetadata[];
   readonly viewTransform?: ImageViewTransform;
 }
 
@@ -91,7 +80,7 @@ export function ImageAnnotationsOverlay({
   selectedKey,
   highlightLabel,
   onSelectPrimitive,
-  pixelTransform,
+  renderMetadata,
   viewTransform,
 }: ImageAnnotationsOverlayProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -100,7 +89,6 @@ export function ImageAnnotationsOverlay({
     height: number;
   } | null>(null);
 
-  // This effect tracks the overlay container size for image-space transforms.
   useEffect(() => {
     const el = containerRef.current;
     if (!el) return undefined;
@@ -144,20 +132,19 @@ export function ImageAnnotationsOverlay({
             pointerEvents: "none",
           }}
         >
-          <ImagePixelTransformContext.Provider value={pixelTransform ?? null}>
-            {annotations.map((set, i) => (
-              <Fragment key={i}>
-                <SetPrimitives
-                  set={set}
-                  setIndex={i}
-                  strokeWidth={strokeWidth}
-                  selectedKey={selectedKey ?? null}
-                  highlightLabel={highlightLabel ?? null}
-                  onSelectPrimitive={onSelectPrimitive}
-                />
-              </Fragment>
-            ))}
-          </ImagePixelTransformContext.Provider>
+          {annotations.map((set, i) => (
+            <Fragment key={i}>
+              <SetPrimitives
+                set={set}
+                setIndex={i}
+                strokeWidth={strokeWidth}
+                selectedKey={selectedKey ?? null}
+                highlightLabel={highlightLabel ?? null}
+                onSelectPrimitive={onSelectPrimitive}
+                renderMetadata={renderMetadata?.[i]}
+              />
+            </Fragment>
+          ))}
         </svg>
       ) : null}
     </div>
@@ -171,6 +158,7 @@ interface SetPrimitivesProps {
   readonly selectedKey: string | null;
   readonly highlightLabel: string | null;
   readonly onSelectPrimitive?: ImageAnnotationSelectHandler;
+  readonly renderMetadata?: ImageAnnotationRenderMetadata;
 }
 
 function SetPrimitives({
@@ -180,6 +168,7 @@ function SetPrimitives({
   selectedKey,
   highlightLabel,
   onSelectPrimitive,
+  renderMetadata,
 }: SetPrimitivesProps) {
   return (
     <>
@@ -195,6 +184,7 @@ function SetPrimitives({
             selectedKey={selectedKey}
             highlightLabel={highlightLabel}
             onSelectPrimitive={onSelectPrimitive}
+            preparedGroups={renderMetadata?.lineListGroups[j] ?? undefined}
           />
         ) : (
           <PolylinePrimitive
@@ -259,7 +249,6 @@ function CirclePrimitive({
   highlightLabel,
   onSelectPrimitive,
 }: CirclePrimitiveProps) {
-  const pixelTransform = useContext(ImagePixelTransformContext);
   const [x, y] = primitive.position;
   const radius = Math.max(0, primitive.diameter / 2);
   const label = nearestLabel(texts, [x, y]);
@@ -276,9 +265,6 @@ function CirclePrimitive({
   const isSelected =
     selectedKey === key ||
     (highlightLabel !== null && label === highlightLabel);
-  const transformedCircle = pixelTransform
-    ? transformedCirclePoints(primitive, pixelTransform)
-    : null;
   return (
     <g
       className={clsx(
@@ -289,33 +275,15 @@ function CirclePrimitive({
       style={primitiveStyle(color, INTERIOR_FILL)}
       onClick={onClick}
     >
-      {transformedCircle ? (
-        <>
-          <polygon
-            points={svgPoints(transformedCircle)}
-            className={styles.fillInterior}
-          />
-          <polygon
-            points={svgPoints(transformedCircle)}
-            strokeWidth={lineWidth(primitive.thickness, strokeWidth)}
-            strokeLinejoin="round"
-            vectorEffect="non-scaling-stroke"
-            fill="none"
-          />
-        </>
-      ) : pixelTransform ? null : (
-        <>
-          <circle cx={x} cy={y} r={radius} className={styles.fillInterior} />
-          <circle
-            cx={x}
-            cy={y}
-            r={radius}
-            strokeWidth={lineWidth(primitive.thickness, strokeWidth)}
-            vectorEffect="non-scaling-stroke"
-            fill="none"
-          />
-        </>
-      )}
+      <circle cx={x} cy={y} r={radius} className={styles.fillInterior} />
+      <circle
+        cx={x}
+        cy={y}
+        r={radius}
+        strokeWidth={lineWidth(primitive.thickness, strokeWidth)}
+        vectorEffect="non-scaling-stroke"
+        fill="none"
+      />
     </g>
   );
 }
@@ -341,7 +309,6 @@ function PolylinePrimitive({
   highlightLabel,
   onSelectPrimitive,
 }: PolylinePrimitiveProps) {
-  const pixelTransform = useContext(ImagePixelTransformContext);
   const thickness = lineWidth(primitive.thickness, strokeWidth);
   const centroid = pointsCentroid(primitive.points);
   const label = centroid ? nearestLabel(texts, centroid) : null;
@@ -358,13 +325,6 @@ function PolylinePrimitive({
   const isSelected =
     selectedKey === key ||
     (highlightLabel !== null && label === highlightLabel);
-  const displayPoints = pixelTransform
-    ? transformedPrimitivePoints(primitive, pixelTransform)
-    : primitive.points;
-
-  if (displayPoints.length === 0) {
-    return null;
-  }
 
   if (primitive.type === "points") {
     return (
@@ -377,7 +337,7 @@ function PolylinePrimitive({
         style={primitiveStyle(color, undefined)}
         onClick={onClick}
       >
-        {displayPoints.map(([x, y], i) => (
+        {primitive.points.map(([x, y], i) => (
           <circle
             key={i}
             cx={x}
@@ -391,7 +351,7 @@ function PolylinePrimitive({
   }
 
   const closed = primitive.type === "line-loop";
-  const pointsAttr = svgPoints(displayPoints);
+  const pointsAttr = primitive.points.map(([x, y]) => `${x},${y}`).join(" ");
   return (
     <g
       className={clsx(
@@ -437,6 +397,7 @@ interface LineListGroupsProps {
   readonly selectedKey: string | null;
   readonly highlightLabel: string | null;
   readonly onSelectPrimitive?: ImageAnnotationSelectHandler;
+  readonly preparedGroups?: readonly ImageAnnotationLineListGroup[];
 }
 
 function LineListGroups({
@@ -448,10 +409,11 @@ function LineListGroups({
   selectedKey,
   highlightLabel,
   onSelectPrimitive,
+  preparedGroups,
 }: LineListGroupsProps) {
-  const pixelTransform = useContext(ImagePixelTransformContext);
   const thickness = lineWidth(primitive.thickness, strokeWidth);
-  const groups = groupLineListByLabel(primitive.points, texts);
+  const groups =
+    preparedGroups ?? groupLineListByLabel(primitive.points, texts);
 
   return (
     <>
@@ -468,7 +430,7 @@ function LineListGroups({
             kind: "points",
             value: {
               ...primitive,
-              points: group.segments.flatMap((s) => [s[0], s[1]]),
+              points: group.points,
             },
           },
           color,
@@ -477,17 +439,7 @@ function LineListGroups({
         const isSelected =
           selectedKey === key ||
           (highlightLabel !== null && group.label === highlightLabel);
-        const displaySegments = group.segments
-          .map((segment) =>
-            pixelTransform
-              ? transformedSegment(segment[0], segment[1], pixelTransform)
-              : [segment[0], segment[1]],
-          )
-          .filter((segment) => segment.length >= 2);
-        if (displaySegments.length === 0) {
-          return null;
-        }
-        const b = pointsBounds(displaySegments.flat()) ?? group.bounds;
+        const b = group.bounds;
         return (
           <g
             key={gi}
@@ -506,29 +458,17 @@ function LineListGroups({
               height={b.maxY - b.minY}
               className={styles.fillInterior}
             />
-            {displaySegments.map((segment, si) => (
-              <Fragment key={si}>
-                {pixelTransform ? (
-                  <polyline
-                    points={svgPoints(segment)}
-                    strokeWidth={thickness}
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    vectorEffect="non-scaling-stroke"
-                    fill="none"
-                  />
-                ) : (
-                  <line
-                    x1={segment[0][0]}
-                    y1={segment[0][1]}
-                    x2={segment[1][0]}
-                    y2={segment[1][1]}
-                    strokeWidth={thickness}
-                    strokeLinecap="round"
-                    vectorEffect="non-scaling-stroke"
-                  />
-                )}
-              </Fragment>
+            {group.segments.map(([[x1, y1], [x2, y2]], si) => (
+              <line
+                key={si}
+                x1={x1}
+                y1={y1}
+                x2={x2}
+                y2={y2}
+                strokeWidth={thickness}
+                strokeLinecap="round"
+                vectorEffect="non-scaling-stroke"
+              />
             ))}
           </g>
         );
@@ -554,14 +494,7 @@ function TextPrimitive({
   highlightLabel,
   onSelectPrimitive,
 }: TextPrimitiveProps) {
-  const pixelTransform = useContext(ImagePixelTransformContext);
-  const displayPosition = pixelTransform
-    ? pixelTransform(...primitive.position)
-    : primitive.position;
-  if (!displayPosition) {
-    return null;
-  }
-  const [x, y] = displayPosition;
+  const [x, y] = primitive.position;
   const fontSize = Math.max(1, primitive.fontSize);
   const background = rgbaToCss(primitive.backgroundColor);
   const label = primitive.text || null;
@@ -615,20 +548,11 @@ function TextPrimitive({
 // Helpers
 // ---------------------------------------------------------------------------
 
-interface Bounds {
-  readonly minX: number;
-  readonly minY: number;
-  readonly maxX: number;
-  readonly maxY: number;
-}
+type Bounds = ImageAnnotationBounds;
 
 type Point2 = readonly [number, number];
 
-interface LineListGroup {
-  readonly label: string | null;
-  readonly segments: readonly [Point2, Point2][];
-  readonly bounds: Bounds;
-}
+type LineListGroup = ImageAnnotationLineListGroup;
 
 function groupLineListByLabel(
   points: readonly Point2[],
@@ -636,6 +560,7 @@ function groupLineListByLabel(
 ): readonly LineListGroup[] {
   return groupLineSegmentsByLabel(points, texts).map(({ label, segments }) => ({
     label,
+    points: segments.flatMap(([a, b]) => [a, b]),
     segments,
     bounds: segmentsBounds(segments),
   }));
@@ -697,110 +622,6 @@ function pointsCentroid(points: readonly Point2[]): Point2 | null {
     sy += y;
   }
   return [sx / points.length, sy / points.length];
-}
-
-function transformedCirclePoints(
-  circle: ImageAnnotationCircle,
-  transform: ImagePixelTransform,
-): readonly Point2[] | null {
-  const radius = Math.max(0, circle.diameter / 2);
-  const sampleCount = Math.min(
-    96,
-    Math.max(24, Math.ceil((Math.PI * Math.max(1, circle.diameter)) / 8)),
-  );
-  const points: Point2[] = [];
-  for (let index = 0; index < sampleCount; index++) {
-    const angle = (Math.PI * 2 * index) / sampleCount;
-    const point = transform(
-      circle.position[0] + Math.cos(angle) * radius,
-      circle.position[1] + Math.sin(angle) * radius,
-    );
-    if (!point) {
-      return null;
-    }
-    points.push(point);
-  }
-  return points;
-}
-
-function transformedPrimitivePoints(
-  primitive: ImageAnnotationPoints,
-  transform: ImagePixelTransform,
-): readonly Point2[] {
-  if (primitive.type === "points") {
-    return primitive.points.flatMap((point) => {
-      const transformed = transform(...point);
-      return transformed ? [transformed] : [];
-    });
-  }
-  if (primitive.points.length < 2) {
-    return primitive.points.flatMap((point) => {
-      const transformed = transform(...point);
-      return transformed ? [transformed] : [];
-    });
-  }
-
-  const output: Point2[] = [];
-  const segmentCount =
-    primitive.type === "line-loop"
-      ? primitive.points.length
-      : primitive.points.length - 1;
-  for (let index = 0; index < segmentCount; index++) {
-    const start = primitive.points[index];
-    const end = primitive.points[(index + 1) % primitive.points.length];
-    const segment = transformedSegment(start, end, transform);
-    if (segment.length === 0) {
-      // A missing sample means the source curve left the camera model's
-      // invertible domain. Withhold the whole connected primitive instead of
-      // joining the valid pieces across an untrusted gap.
-      return [];
-    }
-    output.push(...(output.length > 0 ? segment.slice(1) : segment));
-  }
-  return output;
-}
-
-function transformedSegment(
-  start: Point2,
-  end: Point2,
-  transform: ImagePixelTransform,
-): readonly Point2[] {
-  const sourceLength = Math.hypot(end[0] - start[0], end[1] - start[1]);
-  const steps = Math.min(128, Math.max(1, Math.ceil(sourceLength / 8)));
-  const output: Point2[] = [];
-  for (let step = 0; step <= steps; step++) {
-    const fraction = step / steps;
-    const point = transform(
-      start[0] + (end[0] - start[0]) * fraction,
-      start[1] + (end[1] - start[1]) * fraction,
-    );
-    if (!point) {
-      return [];
-    }
-    output.push(point);
-  }
-  return output;
-}
-
-function pointsBounds(points: readonly Point2[]): Bounds | null {
-  if (points.length === 0) {
-    return null;
-  }
-  let minX = Infinity;
-  let minY = Infinity;
-  let maxX = -Infinity;
-  let maxY = -Infinity;
-  for (const [x, y] of points) {
-    minX = Math.min(minX, x);
-    minY = Math.min(minY, y);
-    maxX = Math.max(maxX, x);
-    maxY = Math.max(maxY, y);
-  }
-  return { minX, minY, maxX, maxY };
-}
-
-function svgPoints(points: readonly Point2[]): string {
-  return points.map(([x, y]) => `${x},${y}`).join(" ");
 }
 
 // Subset of `@fiftyone/utilities`' default app color pool with the orange

--- a/app/packages/multimodal/src/visualization/panels/image-annotation-render-metadata.ts
+++ b/app/packages/multimodal/src/visualization/panels/image-annotation-render-metadata.ts
@@ -1,0 +1,27 @@
+export type ImageAnnotationPoint2 = readonly [number, number];
+
+export interface ImageAnnotationBounds {
+  readonly minX: number;
+  readonly minY: number;
+  readonly maxX: number;
+  readonly maxY: number;
+}
+
+/** Render-ready LINE_LIST group prepared alongside interpolated geometry. */
+export interface ImageAnnotationLineListGroup {
+  readonly bounds: ImageAnnotationBounds;
+  readonly label: string | null;
+  readonly points: readonly ImageAnnotationPoint2[];
+  readonly segments: readonly (readonly [
+    ImageAnnotationPoint2,
+    ImageAnnotationPoint2,
+  ])[];
+}
+
+/** Per-points-primitive metadata; non-LINE_LIST entries are null. */
+export interface ImageAnnotationRenderMetadata {
+  readonly lineListGroups: readonly (
+    | readonly ImageAnnotationLineListGroup[]
+    | null
+  )[];
+}

--- a/app/packages/multimodal/src/visualization/panels/timeseries/TimeseriesChart.module.css
+++ b/app/packages/multimodal/src/visualization/panels/timeseries/TimeseriesChart.module.css
@@ -21,6 +21,46 @@
   width: 100%;
 }
 
+.controls {
+  bottom: calc(var(--timeseries-legend-height, 0px) + 8px);
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  position: absolute;
+  right: 8px;
+  z-index: 5;
+}
+
+.controlButton {
+  align-items: center;
+  background: rgba(5, 11, 18, 0.76);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 4px;
+  color: #cbd5e1;
+  cursor: pointer;
+  display: inline-flex;
+  height: 18px;
+  justify-content: center;
+  padding: 0;
+  width: 18px;
+}
+
+.controlIcon {
+  height: 10px;
+  width: 10px;
+}
+
+.controlButton:hover,
+.controlButton:focus-visible {
+  background: rgba(30, 41, 59, 0.9);
+  border-color: rgba(203, 213, 225, 0.48);
+}
+
+.controlButton:focus-visible {
+  outline: 2px solid #60a5fa;
+  outline-offset: 1px;
+}
+
 .playhead {
   border-left: 1px solid rgba(255, 255, 255, 0.65);
   bottom: 0;
@@ -48,10 +88,10 @@
   z-index: 1;
 }
 
-/* The plot area is click-to-seek; say so. Overrides uPlot's default
-   crosshair on its cursor overlay. */
+/* The plot area supports click-to-seek and drag-to-zoom. */
 .root :global(.u-over) {
-  cursor: pointer;
+  cursor: crosshair;
+  touch-action: none;
 }
 
 .root :global(.u-legend) {
@@ -79,5 +119,6 @@
 }
 
 .root :global(.u-select) {
-  display: none;
+  background: rgba(96, 165, 250, 0.16);
+  border: 1px solid rgba(147, 197, 253, 0.72);
 }

--- a/app/packages/multimodal/src/visualization/panels/timeseries/TimeseriesChart.test.tsx
+++ b/app/packages/multimodal/src/visualization/panels/timeseries/TimeseriesChart.test.tsx
@@ -1,0 +1,281 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { AlignedData } from "uplot";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import TimeseriesChart from "./TimeseriesChart";
+
+interface MockHookPlugin {
+  readonly hooks: {
+    readonly destroy?: MockHook | readonly MockHook[];
+    readonly init?: MockHook | readonly MockHook[];
+  };
+}
+
+type MockHook = (
+  chart: MockChart,
+  options?: MockOptions,
+  data?: unknown,
+) => void;
+
+interface MockOptions {
+  readonly axes?: readonly {
+    readonly size?:
+      | number
+      | ((
+          chart: MockChart,
+          values: string[],
+          axisIdx: number,
+          cycleNum: number,
+        ) => number);
+  }[];
+  readonly cursor?: {
+    readonly drag?: {
+      readonly dist?: number;
+      readonly setScale?: boolean;
+      readonly x?: boolean;
+      readonly y?: boolean;
+    };
+  };
+  readonly plugins?: readonly MockHookPlugin[];
+  readonly scales?: {
+    readonly x?: {
+      readonly range?: readonly [number, number];
+    };
+  };
+}
+
+interface MockChart {
+  readonly ctx: {
+    font: string;
+    readonly measureText: (value: string) => { readonly width: number };
+    readonly restore: () => void;
+    readonly save: () => void;
+  };
+  readonly data: unknown;
+  readonly options: MockOptions;
+  readonly over: HTMLDivElement;
+  readonly root: HTMLDivElement;
+  readonly scales: {
+    readonly x: { max: number; min: number };
+    readonly y: { max: number; min: number };
+  };
+  readonly setData: ReturnType<typeof vi.fn>;
+  readonly setScale: ReturnType<typeof vi.fn>;
+}
+
+const uPlotMock = vi.hoisted(() => ({
+  instances: [] as MockChart[],
+}));
+
+vi.mock("uplot", () => ({
+  default: class MockUPlot {
+    data: unknown;
+    ctx = {
+      font: "",
+      measureText: (value: string) => ({ width: value.length * 7 }),
+      restore: vi.fn(),
+      save: vi.fn(),
+    };
+    options: MockOptions;
+    over = document.createElement("div");
+    root = document.createElement("div");
+    scales = {
+      x: { max: 20, min: 0 },
+      y: { max: 10, min: 0 },
+    };
+    setData = vi.fn((data: unknown, _resetScales?: boolean) => {
+      this.data = data;
+    });
+    setScale = vi.fn(
+      (
+        key: "x" | "y",
+        range: { readonly max: number; readonly min: number },
+      ) => {
+        const configuredRange =
+          key === "x" ? this.options.scales?.x?.range : undefined;
+        this.scales[key] = configuredRange
+          ? { max: configuredRange[1], min: configuredRange[0] }
+          : { max: range.max, min: range.min };
+      },
+    );
+    setSize = vi.fn();
+
+    constructor(options: MockOptions, data: unknown, host: HTMLElement) {
+      this.options = options;
+      this.data = data;
+      this.over.className = "u-over";
+      this.root.appendChild(this.over);
+      const legend = document.createElement("div");
+      legend.className = "u-legend";
+      this.root.appendChild(legend);
+      host.appendChild(this.root);
+      this.over.addEventListener("dblclick", () => {
+        this.setData(this.data, true);
+      });
+      uPlotMock.instances.push(this as unknown as MockChart);
+      for (const plugin of options.plugins ?? []) {
+        runHooks(
+          plugin.hooks.init,
+          this as unknown as MockChart,
+          options,
+          data,
+        );
+      }
+    }
+
+    batch(callback: () => void) {
+      callback();
+    }
+
+    destroy() {
+      for (const plugin of this.options.plugins ?? []) {
+        runHooks(plugin.hooks.destroy, this as unknown as MockChart);
+      }
+      this.root.remove();
+    }
+
+    posToVal(position: number) {
+      return position;
+    }
+
+    valToPos(value: number) {
+      return value;
+    }
+  },
+}));
+
+vi.mock("@voxel51/voodo", () => ({
+  Icon: ({ name }: { readonly name: string }) => <span>{name}</span>,
+  IconName: { Add: "add", Fullscreen: "fullscreen", Remove: "remove" },
+  Size: { Xs: "xs" },
+}));
+
+afterEach(() => {
+  uPlotMock.instances.length = 0;
+  vi.restoreAllMocks();
+});
+
+describe("TimeseriesChart interactions", () => {
+  it("renders zoom controls and resets only from the explicit button", () => {
+    const { unmount } = renderChart();
+    const chart = lastChart();
+    chart.setData.mockClear();
+
+    fireEvent.click(screen.getByLabelText("Zoom in"));
+    expect(chart.scales.x).toEqual({ min: 2, max: 18 });
+    expect(chart.scales.y).toEqual({ min: 1, max: 9 });
+    expect(chart.setScale).toHaveBeenCalledWith("x", {
+      min: 2,
+      max: 18,
+    });
+    expect(chart.setScale).toHaveBeenCalledWith("y", {
+      min: 1,
+      max: 9,
+    });
+
+    fireEvent.click(screen.getByLabelText("Zoom out"));
+    expect(chart.scales.x).toEqual({ min: 0, max: 20 });
+    expect(chart.scales.y).toEqual({ min: 0, max: 10 });
+
+    chart.setData.mockClear();
+    chart.over.dispatchEvent(new MouseEvent("dblclick", { bubbles: true }));
+    expect(chart.setData).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByLabelText("Reset zoom"));
+    expect(chart.setData).toHaveBeenCalledWith(DATA, true);
+    unmount();
+  });
+
+  it("configures region selection and a label-sized y-axis gutter", () => {
+    const { unmount } = renderChart();
+    const chart = lastChart();
+
+    expect(chart.options.cursor?.drag).toEqual({
+      dist: 4,
+      setScale: true,
+      x: true,
+      y: true,
+    });
+    expect(chart.options.scales?.x?.range).toBeUndefined();
+
+    const size = chart.options.axes?.[1]?.size;
+    if (typeof size !== "function") {
+      throw new Error("expected a dynamic y-axis size");
+    }
+    expect(size(chart, ["100000", "-123456.7"], 1, 1)).toBe(79);
+    unmount();
+  });
+
+  it("keeps tap-to-seek and ignores pointer travel from a pan", () => {
+    const onSeek = vi.fn();
+    const { unmount } = renderChart(onSeek);
+    const over = lastChart().over;
+
+    dispatchPointer(over, "pointerdown", 5, 5);
+    dispatchPointer(over, "pointerup", 5, 5);
+    expect(onSeek).toHaveBeenCalledOnce();
+    expect(onSeek).toHaveBeenCalledWith(5);
+
+    dispatchPointer(over, "pointerdown", 5, 5);
+    dispatchPointer(over, "pointerup", 5, 20);
+    expect(onSeek).toHaveBeenCalledOnce();
+
+    dispatchPointer(over, "pointerdown", 5, 5, 1);
+    dispatchPointer(over, "pointerdown", 15, 5, 2);
+    dispatchPointer(over, "pointerup", 15, 5, 2);
+    dispatchPointer(over, "pointerup", 5, 5, 1);
+    expect(onSeek).toHaveBeenCalledOnce();
+    unmount();
+  });
+});
+
+const DATA = [
+  [0, 20],
+  [1, 2],
+] as AlignedData;
+
+function renderChart(onSeek = vi.fn()) {
+  return render(
+    <TimeseriesChart
+      data={DATA}
+      durationSec={20}
+      onSeek={onSeek}
+      series={[{ color: "#f00", label: "speed" }]}
+    />,
+  );
+}
+
+function lastChart(): MockChart {
+  const chart = uPlotMock.instances.at(-1);
+  if (!chart) {
+    throw new Error("expected a uPlot instance");
+  }
+  return chart;
+}
+
+function runHooks(
+  hooks: MockHook | readonly MockHook[] | undefined,
+  chart: MockChart,
+  options?: MockOptions,
+  data?: unknown,
+): void {
+  if (typeof hooks === "function") {
+    hooks(chart, options, data);
+    return;
+  }
+  for (const hook of hooks ?? []) {
+    hook(chart, options, data);
+  }
+}
+
+function dispatchPointer(
+  target: EventTarget,
+  type: string,
+  clientX: number,
+  clientY: number,
+  pointerId = 1,
+): void {
+  const event = new MouseEvent(type, { bubbles: true, clientX, clientY });
+  Object.defineProperty(event, "pointerId", { value: pointerId });
+  target.dispatchEvent(event);
+}

--- a/app/packages/multimodal/src/visualization/panels/timeseries/TimeseriesChart.tsx
+++ b/app/packages/multimodal/src/visualization/panels/timeseries/TimeseriesChart.tsx
@@ -1,8 +1,15 @@
+import { Icon, IconName, Size } from "@voxel51/voodo";
 import React, { useEffect, useRef } from "react";
 import uPlot, { type AlignedData } from "uplot";
 import "uplot/dist/uPlot.min.css";
 import { CLICK_DRAG_TOLERANCE_PX } from "../interaction";
 import styles from "./TimeseriesChart.module.css";
+import {
+  TIMESERIES_ZOOM_IN_FACTOR,
+  TIMESERIES_ZOOM_OUT_FACTOR,
+  touchZoomPanPlugin,
+  zoomTimeseriesChart,
+} from "./timeseries-zoom";
 
 /** Identity of one drawn series: legend label + mark color. */
 export interface TimeseriesChartSeries {
@@ -47,8 +54,7 @@ export interface TimeseriesChartProps {
   ) => () => void;
 
   /**
-   * Drawn series. Identity changes rebuild the chart — memoize in the
-   * caller.
+   * Drawn series. Label, color, or order changes rebuild the chart.
    */
   readonly series: readonly TimeseriesChartSeries[];
 }
@@ -57,12 +63,46 @@ const AXIS_INK = "#898781";
 const GRID_STROKE = "#2c2c2a";
 const TICK_STROKE = "#383835";
 const CHART_FONT = '11px system-ui, -apple-system, "Segoe UI", sans-serif';
+const MIN_Y_AXIS_SIZE_PX = 52;
+const Y_AXIS_LABEL_GUTTER_PX = 16;
+
+const yAxisSize: uPlot.Axis.Size = (chart, values) => {
+  if (!values || values.length === 0) {
+    return MIN_Y_AXIS_SIZE_PX;
+  }
+  chart.ctx.save();
+  chart.ctx.font = CHART_FONT;
+  let widestLabel = 0;
+  for (const value of values) {
+    widestLabel = Math.max(
+      widestLabel,
+      chart.ctx.measureText(String(value)).width,
+    );
+  }
+  chart.ctx.restore();
+  return Math.max(
+    MIN_Y_AXIS_SIZE_PX,
+    Math.ceil(widestLabel + Y_AXIS_LABEL_GUTTER_PX),
+  );
+};
+
+function resetTimeseriesChart(
+  chart: uPlot,
+  data: AlignedData,
+  xMax: number,
+): void {
+  chart.batch(() => {
+    chart.setData(data, true);
+    chart.setScale("x", { min: 0, max: xMax });
+  });
+}
+
 /**
  * Dense multi-series line chart on uPlot. Renders on the shared dark
  * visualization surface; identity is carried by the always-present
  * legend (live cursor values) plus mark color, never color alone. The
- * x scale is fixed to the full recording so the playhead overlay and
- * click-to-seek map 1:1 onto playback time.
+ * x scale starts at the full recording and stays constrained to it while
+ * touch gestures or controls change the visible range.
  */
 export const TimeseriesChart: React.FC<TimeseriesChartProps> = ({
   data,
@@ -80,12 +120,44 @@ export const TimeseriesChart: React.FC<TimeseriesChartProps> = ({
   const hoverLineRef = useRef<HTMLDivElement | null>(null);
   const hoverSecRef = useRef<number | null>(null);
   const pointerInsideRef = useRef(false);
+  const hasInteractiveScaleRef = useRef(false);
   const dataRef = useRef(data);
   dataRef.current = data;
+  const seriesRef = useRef(series);
+  seriesRef.current = series;
   const onSeekRef = useRef(onSeek);
   onSeekRef.current = onSeek;
   const onHoverTimeRef = useRef(onHoverTime);
   onHoverTimeRef.current = onHoverTime;
+  const seriesIdentity = JSON.stringify(series);
+  const xMax = Math.max(durationSec, 1e-9);
+
+  const handleZoomIn = () => {
+    const chart = chartRef.current;
+    if (!chart) {
+      return;
+    }
+    zoomTimeseriesChart(chart, TIMESERIES_ZOOM_IN_FACTOR, [0, xMax]);
+    hasInteractiveScaleRef.current = true;
+  };
+
+  const handleZoomOut = () => {
+    const chart = chartRef.current;
+    if (!chart) {
+      return;
+    }
+    zoomTimeseriesChart(chart, TIMESERIES_ZOOM_OUT_FACTOR, [0, xMax]);
+    hasInteractiveScaleRef.current = true;
+  };
+
+  const handleResetZoom = () => {
+    const chart = chartRef.current;
+    if (!chart) {
+      return;
+    }
+    hasInteractiveScaleRef.current = false;
+    resetTimeseriesChart(chart, dataRef.current, xMax);
+  };
 
   // This effect owns the uPlot instance lifecycle: create per series
   // identity / duration change, resize with the tile, destroy on
@@ -93,9 +165,12 @@ export const TimeseriesChart: React.FC<TimeseriesChartProps> = ({
   // live inside uPlot's plot-area overlay (axes and legend excluded).
   useEffect(() => {
     const host = plotRef.current;
-    if (!host || series.length === 0) {
+    const currentSeries = seriesRef.current;
+    if (!host || currentSeries.length === 0) {
       return undefined;
     }
+    hasInteractiveScaleRef.current = false;
+    const xLimits = [0, xMax] as const;
 
     const positionPlayhead = (chart: uPlot) => {
       const line = playheadLineRef.current;
@@ -144,26 +219,44 @@ export const TimeseriesChart: React.FC<TimeseriesChartProps> = ({
         {
           font: CHART_FONT,
           grid: { stroke: GRID_STROKE, width: 1 },
-          size: 48,
+          size: yAxisSize,
           stroke: AXIS_INK,
           ticks: { stroke: TICK_STROKE, width: 1 },
         },
       ],
       cursor: {
-        drag: { setScale: false, x: false, y: false },
+        drag: {
+          dist: CLICK_DRAG_TOLERANCE_PX,
+          setScale: true,
+          x: true,
+          y: true,
+        },
         y: false,
       },
       height: Math.max(host.clientHeight, 80),
       hooks: {
         draw: [positionPlayhead, positionHoverCaret],
+        setSelect: [
+          () => {
+            hasInteractiveScaleRef.current = true;
+          },
+        ],
       },
       legend: { live: true },
+      plugins: [
+        touchZoomPanPlugin({
+          onInteraction: () => {
+            hasInteractiveScaleRef.current = true;
+          },
+          xLimits,
+        }),
+      ],
       scales: {
-        x: { range: [0, Math.max(durationSec, 1e-9)], time: false },
+        x: { time: false },
       },
       series: [
         {},
-        ...series.map((entry) => ({
+        ...currentSeries.map((entry) => ({
           label: entry.label,
           points: { show: false },
           spanGaps: false,
@@ -176,6 +269,7 @@ export const TimeseriesChart: React.FC<TimeseriesChartProps> = ({
 
     const chart = new uPlot(options, dataRef.current, host);
     chartRef.current = chart;
+    chart.setScale("x", { min: 0, max: xMax });
 
     const line = document.createElement("div");
     line.className = styles.playhead;
@@ -194,16 +288,45 @@ export const TimeseriesChart: React.FC<TimeseriesChartProps> = ({
     // Click-to-seek listens on uPlot's own overlay so plot-area padding
     // and axes never miscount; pointer travel separates click from drag.
     const over = chart.over;
-    let downX: number | null = null;
+    const activePointerIds = new Set<number>();
+    let downPoint: {
+      readonly pointerId: number;
+      readonly x: number;
+      readonly y: number;
+    } | null = null;
+    let suppressSeek = false;
     const onPointerDown = (event: PointerEvent) => {
-      downX = event.clientX;
+      activePointerIds.add(event.pointerId);
+      if (activePointerIds.size === 1) {
+        downPoint = {
+          pointerId: event.pointerId,
+          x: event.clientX,
+          y: event.clientY,
+        };
+        suppressSeek = false;
+      } else {
+        suppressSeek = true;
+      }
     };
     const onPointerUp = (event: PointerEvent) => {
-      const startX = downX;
-      downX = null;
+      activePointerIds.delete(event.pointerId);
+      const start = downPoint;
+      if (start?.pointerId !== event.pointerId) {
+        if (activePointerIds.size === 0) {
+          suppressSeek = false;
+        }
+        return;
+      }
+      const shouldSuppressSeek = suppressSeek;
+      downPoint = null;
+      if (activePointerIds.size === 0) {
+        suppressSeek = false;
+      }
       if (
-        startX === null ||
-        Math.abs(event.clientX - startX) > CLICK_DRAG_TOLERANCE_PX
+        start === null ||
+        shouldSuppressSeek ||
+        Math.hypot(event.clientX - start.x, event.clientY - start.y) >
+          CLICK_DRAG_TOLERANCE_PX
       ) {
         return;
       }
@@ -215,6 +338,15 @@ export const TimeseriesChart: React.FC<TimeseriesChartProps> = ({
       const sec = chart.posToVal(event.clientX - rect.left, "x");
       if (Number.isFinite(sec)) {
         seek(Math.min(Math.max(sec, 0), durationSec));
+      }
+    };
+    const onPointerCancel = (event: PointerEvent) => {
+      activePointerIds.delete(event.pointerId);
+      if (downPoint?.pointerId === event.pointerId) {
+        downPoint = null;
+      }
+      if (activePointerIds.size === 0) {
+        suppressSeek = false;
       }
     };
     const onPointerEnter = () => {
@@ -233,36 +365,52 @@ export const TimeseriesChart: React.FC<TimeseriesChartProps> = ({
       }
     };
     const onPointerLeave = () => {
+      activePointerIds.clear();
+      downPoint = null;
+      suppressSeek = false;
       pointerInsideRef.current = false;
       positionHoverCaret(chart);
       onHoverTimeRef.current?.(null);
     };
+    // uPlot resets its scales on double click. In this surface a double click
+    // is also two seek clicks, so keep seek semantics and make reset an
+    // explicit control instead.
+    const onDoubleClickCapture = (event: MouseEvent) => {
+      event.stopImmediatePropagation();
+    };
     over.addEventListener("pointerdown", onPointerDown);
     over.addEventListener("pointerup", onPointerUp);
+    over.addEventListener("pointercancel", onPointerCancel);
     over.addEventListener("pointerenter", onPointerEnter);
     over.addEventListener("pointermove", onPointerMove);
     over.addEventListener("pointerleave", onPointerLeave);
+    over.addEventListener("dblclick", onDoubleClickCapture, true);
 
     // The chart fills the tile; the legend below the canvas is part of
     // the measured host, so size to the remainder.
-    const observer = new ResizeObserver(() => {
+    const resizeChart = () => {
       const legendHeight =
         host.querySelector<HTMLElement>(".u-legend")?.offsetHeight ?? 0;
+      host.style.setProperty("--timeseries-legend-height", `${legendHeight}px`);
       const width = host.clientWidth;
       const height = host.clientHeight - legendHeight;
       if (width > 0 && height > 40) {
         chart.setSize({ height, width });
       }
-    });
+    };
+    const observer = new ResizeObserver(resizeChart);
     observer.observe(host);
+    resizeChart();
 
     return () => {
       observer.disconnect();
       over.removeEventListener("pointerdown", onPointerDown);
       over.removeEventListener("pointerup", onPointerUp);
+      over.removeEventListener("pointercancel", onPointerCancel);
       over.removeEventListener("pointerenter", onPointerEnter);
       over.removeEventListener("pointermove", onPointerMove);
       over.removeEventListener("pointerleave", onPointerLeave);
+      over.removeEventListener("dblclick", onDoubleClickCapture, true);
       // A chart torn down mid-hover must not leave a stale caret in
       // sibling surfaces.
       if (pointerInsideRef.current) {
@@ -274,13 +422,21 @@ export const TimeseriesChart: React.FC<TimeseriesChartProps> = ({
       chartRef.current = null;
       chart.destroy();
     };
-  }, [durationSec, series]);
+  }, [durationSec, seriesIdentity, xMax]);
 
-  // This effect pushes new data into the existing instance without a
-  // rebuild.
+  // This effect pushes new data into the existing instance. Auto-range while
+  // untouched, but preserve a user-controlled viewport across data updates.
   useEffect(() => {
-    chartRef.current?.setData(data, true);
-  }, [data]);
+    const chart = chartRef.current;
+    if (!chart) {
+      return;
+    }
+    if (hasInteractiveScaleRef.current) {
+      chart.setData(data, false);
+    } else {
+      resetTimeseriesChart(chart, data, xMax);
+    }
+  }, [data, xMax]);
 
   // This effect subscribes the echo caret to the shared hover-time feed;
   // caret moves are DOM transforms, never chart redraws.
@@ -333,9 +489,50 @@ export const TimeseriesChart: React.FC<TimeseriesChartProps> = ({
 
   return (
     <div className={styles.root} data-testid="timeseries-chart">
-      <div className={styles.plot} ref={plotRef} />
+      <div className={styles.plot} ref={plotRef}>
+        <div className={styles.controls}>
+          <ChartControl
+            icon={IconName.Add}
+            label="Zoom in"
+            onClick={handleZoomIn}
+          />
+          <ChartControl
+            icon={IconName.Remove}
+            label="Zoom out"
+            onClick={handleZoomOut}
+          />
+          <ChartControl
+            icon={IconName.Fullscreen}
+            label="Reset zoom"
+            onClick={handleResetZoom}
+          />
+        </div>
+      </div>
     </div>
   );
 };
+
+interface ChartControlProps {
+  readonly icon: IconName;
+  readonly label: string;
+  readonly onClick: () => void;
+}
+
+const ChartControl: React.FC<ChartControlProps> = ({
+  icon,
+  label,
+  onClick,
+}) => (
+  <button
+    aria-label={label}
+    className={styles.controlButton}
+    onClick={onClick}
+    onPointerDown={(event) => event.stopPropagation()}
+    title={label}
+    type="button"
+  >
+    <Icon className={styles.controlIcon} name={icon} size={Size.Xs} />
+  </button>
+);
 
 export default TimeseriesChart;

--- a/app/packages/multimodal/src/visualization/panels/timeseries/timeseries-zoom.test.ts
+++ b/app/packages/multimodal/src/visualization/panels/timeseries/timeseries-zoom.test.ts
@@ -1,0 +1,205 @@
+import type uPlot from "uplot";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  TIMESERIES_ZOOM_IN_FACTOR,
+  TIMESERIES_ZOOM_OUT_FACTOR,
+  touchZoomPanPlugin,
+  zoomTimeseriesChart,
+} from "./timeseries-zoom";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("zoomTimeseriesChart", () => {
+  it("zooms both axes around their midpoint", () => {
+    const chart = chartStub({ x: [0, 100], y: [-50, 50] });
+
+    zoomTimeseriesChart(chart.value, TIMESERIES_ZOOM_IN_FACTOR, [0, 100]);
+
+    expect(chart.setScale).toHaveBeenNthCalledWith(1, "x", {
+      min: 10,
+      max: 90,
+    });
+    expect(chart.setScale).toHaveBeenNthCalledWith(2, "y", {
+      min: -40,
+      max: 40,
+    });
+  });
+
+  it("clamps zoom-out to the recording domain", () => {
+    const chart = chartStub({ x: [10, 90], y: [-40, 40] });
+
+    zoomTimeseriesChart(chart.value, TIMESERIES_ZOOM_OUT_FACTOR, [0, 100]);
+
+    expect(chart.setScale).toHaveBeenNthCalledWith(1, "x", {
+      min: 0,
+      max: 100,
+    });
+    expect(chart.setScale).toHaveBeenNthCalledWith(2, "y", {
+      min: -50,
+      max: 50,
+    });
+  });
+
+  it("does nothing until uPlot has finite scale bounds", () => {
+    const chart = chartStub({
+      x: [undefined, undefined],
+      y: [undefined, undefined],
+    });
+
+    zoomTimeseriesChart(chart.value, TIMESERIES_ZOOM_IN_FACTOR, [0, 100]);
+
+    expect(chart.setScale).not.toHaveBeenCalled();
+  });
+});
+
+describe("touchZoomPanPlugin", () => {
+  it("pans with one finger without leaving the recording domain", () => {
+    const chart = interactiveChartStub({ x: [20, 80], y: [20, 80] });
+    const onInteraction = vi.fn();
+    const plugin = touchZoomPanPlugin({
+      onInteraction,
+      xLimits: [0, 100],
+    });
+    initializePlugin(plugin, chart.value);
+    const runFrame = captureAnimationFrame();
+
+    dispatchTouch(chart.over, "touchstart", [[50, 50]]);
+    dispatchTouch(document, "touchmove", [[60, 50]]);
+    runFrame();
+
+    expect(chart.scales.x).toEqual({ min: 14, max: 74 });
+    expect(chart.scales.y).toEqual({ min: 20, max: 80 });
+    expect(onInteraction).toHaveBeenCalledOnce();
+
+    destroyPlugin(plugin, chart.value);
+  });
+
+  it("pinches uniformly around the gesture midpoint", () => {
+    const chart = interactiveChartStub({ x: [20, 80], y: [20, 80] });
+    const plugin = touchZoomPanPlugin({ xLimits: [0, 100] });
+    initializePlugin(plugin, chart.value);
+    const runFrame = captureAnimationFrame();
+
+    dispatchTouch(chart.over, "touchstart", [
+      [40, 50],
+      [60, 50],
+    ]);
+    dispatchTouch(document, "touchmove", [
+      [30, 50],
+      [70, 50],
+    ]);
+    runFrame();
+
+    expect(chart.scales.x).toEqual({ min: 35, max: 65 });
+    expect(chart.scales.y).toEqual({ min: 35, max: 65 });
+
+    destroyPlugin(plugin, chart.value);
+  });
+});
+
+function chartStub({
+  x,
+  y,
+}: {
+  readonly x: readonly [number | undefined, number | undefined];
+  readonly y: readonly [number | undefined, number | undefined];
+}) {
+  const setScale = vi.fn();
+  return {
+    setScale,
+    value: {
+      batch: (callback: () => void) => callback(),
+      scales: {
+        x: { max: x[1], min: x[0] },
+        y: { max: y[1], min: y[0] },
+      },
+      setScale,
+    } as never,
+  };
+}
+
+function interactiveChartStub({
+  x,
+  y,
+}: {
+  readonly x: readonly [number, number];
+  readonly y: readonly [number, number];
+}) {
+  const over = document.createElement("div");
+  vi.spyOn(over, "getBoundingClientRect").mockReturnValue({
+    bottom: 100,
+    height: 100,
+    left: 0,
+    right: 100,
+    top: 0,
+    width: 100,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+  });
+  const scales = {
+    x: { max: x[1], min: x[0] },
+    y: { max: y[1], min: y[0] },
+  };
+  const value = {
+    batch: (callback: () => void) => callback(),
+    over,
+    posToVal: (position: number, key: "x" | "y") => {
+      const scale = scales[key];
+      const size = scale.max - scale.min;
+      return key === "x"
+        ? scale.min + (position / 100) * size
+        : scale.max - (position / 100) * size;
+    },
+    scales,
+    setScale: (key: "x" | "y", range: { min: number; max: number }) => {
+      scales[key] = range;
+    },
+  };
+  return { over, scales, value: value as never };
+}
+
+function initializePlugin(plugin: uPlot.Plugin, chart: uPlot): void {
+  const init = plugin.hooks.init;
+  if (typeof init !== "function") {
+    throw new Error("expected one init hook");
+  }
+  init(chart, {} as uPlot.Options, []);
+}
+
+function destroyPlugin(plugin: uPlot.Plugin, chart: uPlot): void {
+  const destroy = plugin.hooks.destroy;
+  if (typeof destroy !== "function") {
+    throw new Error("expected one destroy hook");
+  }
+  destroy(chart);
+}
+
+function captureAnimationFrame(): () => void {
+  let callback: FrameRequestCallback | undefined;
+  vi.spyOn(window, "requestAnimationFrame").mockImplementation((next) => {
+    callback = next;
+    return 1;
+  });
+  return () => {
+    if (!callback) {
+      throw new Error("expected an animation frame");
+    }
+    callback(0);
+  };
+}
+
+function dispatchTouch(
+  target: EventTarget,
+  type: string,
+  points: readonly (readonly [x: number, y: number])[],
+): void {
+  const event = new Event(type, { bubbles: true });
+  Object.defineProperty(event, "touches", {
+    value: points.map(([clientX, clientY]) => ({ clientX, clientY })),
+  });
+  target.dispatchEvent(event);
+}

--- a/app/packages/multimodal/src/visualization/panels/timeseries/timeseries-zoom.ts
+++ b/app/packages/multimodal/src/visualization/panels/timeseries/timeseries-zoom.ts
@@ -1,0 +1,271 @@
+import type uPlot from "uplot";
+
+export const TIMESERIES_ZOOM_IN_FACTOR = 0.8;
+export const TIMESERIES_ZOOM_OUT_FACTOR = 1 / TIMESERIES_ZOOM_IN_FACTOR;
+
+type Range = readonly [min: number, max: number];
+
+interface TouchPosition {
+  readonly distance: number;
+  readonly x: number;
+  readonly y: number;
+}
+
+interface TouchZoomPanPluginOptions {
+  readonly onInteraction?: () => void;
+  readonly xLimits: Range;
+}
+
+/**
+ * Zooms both chart axes around their current midpoint. The x range is
+ * constrained to the recording while y remains free so signal offsets can be
+ * inspected without losing the time domain.
+ */
+export function zoomTimeseriesChart(
+  chart: uPlot,
+  factor: number,
+  xLimits: Range,
+): void {
+  if (!Number.isFinite(factor) || factor <= 0) {
+    return;
+  }
+
+  const xRange = scaledRange(chart.scales.x, factor, xLimits);
+  const yRange = scaledRange(chart.scales.y, factor);
+  if (!xRange && !yRange) {
+    return;
+  }
+
+  chart.batch(() => {
+    if (xRange) {
+      chart.setScale("x", { min: xRange[0], max: xRange[1] });
+    }
+    if (yRange) {
+      chart.setScale("y", { min: yRange[0], max: yRange[1] });
+    }
+  });
+}
+
+/**
+ * uPlot touch plugin based on its pinch-zoom demo. One finger pans and two
+ * fingers pinch uniformly across x/y. Gesture state and document listeners
+ * stay outside React so move-frequency work never causes component renders.
+ */
+export function touchZoomPanPlugin({
+  onInteraction,
+  xLimits,
+}: TouchZoomPanPluginOptions): uPlot.Plugin {
+  let destroyInteraction: (() => void) | undefined;
+
+  return {
+    hooks: {
+      destroy: () => {
+        destroyInteraction?.();
+        destroyInteraction = undefined;
+      },
+      init: (chart) => {
+        const over = chart.over;
+        let frame: number | null = null;
+        let initialPosition: TouchPosition | null = null;
+        let currentPosition: TouchPosition | null = null;
+        let initialXRange = 0;
+        let initialYRange = 0;
+        let rect: DOMRect | null = null;
+        let xAnchor = 0;
+        let yAnchor = 0;
+        let tracking = false;
+
+        const stopTracking = () => {
+          if (!tracking) {
+            return;
+          }
+          tracking = false;
+          document.removeEventListener("touchmove", handleTouchMove);
+          document.removeEventListener("touchend", handleTouchEnd);
+          document.removeEventListener("touchcancel", handleTouchCancel);
+        };
+
+        const applyGesture = () => {
+          frame = null;
+          if (!rect || !initialPosition || !currentPosition) {
+            return;
+          }
+
+          const factor = initialPosition.distance / currentPosition.distance;
+          if (!Number.isFinite(factor) || factor <= 0) {
+            return;
+          }
+
+          const xSize = initialXRange * factor;
+          const xMin = xAnchor - (currentPosition.x / rect.width) * xSize;
+          const nextXRange = clampRange([xMin, xMin + xSize], xLimits);
+
+          const ySize = initialYRange * factor;
+          const bottomFraction = 1 - currentPosition.y / rect.height;
+          const yMin = yAnchor - bottomFraction * ySize;
+
+          chart.batch(() => {
+            chart.setScale("x", {
+              min: nextXRange[0],
+              max: nextXRange[1],
+            });
+            chart.setScale("y", { min: yMin, max: yMin + ySize });
+          });
+          onInteraction?.();
+        };
+
+        const beginGesture = (event: TouchEvent) => {
+          rect = over.getBoundingClientRect();
+          if (rect.width <= 0 || rect.height <= 0) {
+            return;
+          }
+
+          const position = touchPosition(event.touches, rect);
+          const xScale = finiteScaleRange(chart.scales.x);
+          const yScale = finiteScaleRange(chart.scales.y);
+          if (!position || !xScale || !yScale) {
+            return;
+          }
+
+          initialPosition = position;
+          currentPosition = position;
+          initialXRange = xScale[1] - xScale[0];
+          initialYRange = yScale[1] - yScale[0];
+          xAnchor = chart.posToVal(position.x, "x");
+          yAnchor = chart.posToVal(position.y, "y");
+
+          if (!tracking) {
+            tracking = true;
+            document.addEventListener("touchmove", handleTouchMove, {
+              passive: true,
+            });
+            document.addEventListener("touchend", handleTouchEnd, {
+              passive: true,
+            });
+            document.addEventListener("touchcancel", handleTouchCancel, {
+              passive: true,
+            });
+          }
+        };
+
+        function handleTouchMove(event: TouchEvent) {
+          if (!rect) {
+            return;
+          }
+          const position = touchPosition(event.touches, rect);
+          if (!position) {
+            return;
+          }
+          currentPosition = position;
+          if (frame === null) {
+            frame = window.requestAnimationFrame(applyGesture);
+          }
+        }
+
+        function handleTouchEnd(event: TouchEvent) {
+          if (frame !== null) {
+            window.cancelAnimationFrame(frame);
+            applyGesture();
+          }
+          if (event.touches.length > 0) {
+            beginGesture(event);
+          } else {
+            stopTracking();
+          }
+        }
+
+        function handleTouchCancel() {
+          if (frame !== null) {
+            window.cancelAnimationFrame(frame);
+            frame = null;
+          }
+          stopTracking();
+        }
+
+        over.addEventListener("touchstart", beginGesture, { passive: true });
+
+        destroyInteraction = () => {
+          if (frame !== null) {
+            window.cancelAnimationFrame(frame);
+            frame = null;
+          }
+          stopTracking();
+          over.removeEventListener("touchstart", beginGesture);
+        };
+      },
+    },
+  };
+}
+
+function touchPosition(
+  touches: TouchList,
+  rect: DOMRect,
+): TouchPosition | null {
+  if (touches.length === 0) {
+    return null;
+  }
+
+  const first = touches[0];
+  const firstX = first.clientX - rect.left;
+  const firstY = first.clientY - rect.top;
+  if (touches.length === 1) {
+    return { distance: 1, x: firstX, y: firstY };
+  }
+
+  const second = touches[1];
+  const secondX = second.clientX - rect.left;
+  const secondY = second.clientY - rect.top;
+  const deltaX = secondX - firstX;
+  const deltaY = secondY - firstY;
+
+  return {
+    distance: Math.max(Math.hypot(deltaX, deltaY), Number.EPSILON),
+    x: (firstX + secondX) / 2,
+    y: (firstY + secondY) / 2,
+  };
+}
+
+function scaledRange(
+  scale: uPlot.Scale | undefined,
+  factor: number,
+  limits?: Range,
+): Range | null {
+  const range = finiteScaleRange(scale);
+  if (!range) {
+    return null;
+  }
+  const midpoint = (range[0] + range[1]) / 2;
+  const halfSize = ((range[1] - range[0]) * factor) / 2;
+  const scaled: Range = [midpoint - halfSize, midpoint + halfSize];
+  return limits ? clampRange(scaled, limits) : scaled;
+}
+
+function finiteScaleRange(scale: uPlot.Scale | undefined): Range | null {
+  const min = scale?.min;
+  const max = scale?.max;
+  if (
+    min === undefined ||
+    max === undefined ||
+    !Number.isFinite(min) ||
+    !Number.isFinite(max) ||
+    min >= max
+  ) {
+    return null;
+  }
+  return [min, max];
+}
+
+function clampRange(range: Range, limits: Range): Range {
+  const limitSize = limits[1] - limits[0];
+  const rangeSize = range[1] - range[0];
+  if (rangeSize >= limitSize) {
+    return limits;
+  }
+  if (range[0] < limits[0]) {
+    return [limits[0], limits[0] + rangeSize];
+  }
+  if (range[1] > limits[1]) {
+    return [limits[1] - rangeSize, limits[1]];
+  }
+  return range;
+}

--- a/app/packages/playback/src/lib/playback/store-access.ts
+++ b/app/packages/playback/src/lib/playback/store-access.ts
@@ -1,8 +1,9 @@
 // ---------------------------------------------------------------------------
 // Imperative access to playback state for code that already holds a
 // PlaybackStore: PlaybackStream implementations (e.g. the MCAP data
-// stream), component event handlers, and tests. React components subscribe
-// through the hooks in `use-playback-state.ts` / `use-stream.ts` instead.
+// stream), component event handlers, tests, and specialized hooks that sample
+// a high-frequency value. React components normally subscribe through the
+// hooks in `use-playback-state.ts` / `use-stream.ts` instead.
 //
 // This surface is deliberately narrower than the atom set — it encodes who
 // may write what. There is no setPlayhead / setIsPlaying here: the engine
@@ -14,6 +15,7 @@
 import {
   bufferedRangesAtom,
   bufferingDetailAtom,
+  currentTimeAtom,
   hoverTimeAtom,
   isBufferingAtom,
   isPlayPendingAtom,
@@ -29,6 +31,19 @@ import type { BufferedRanges, PlaybackStore } from "./types";
 /** Non-reactive read of the visual playhead position, in seconds. */
 export function getPlayhead(store: PlaybackStore): number {
   return store.get(playheadAtom);
+}
+
+/** Non-reactive read of the latest time committed by the playback engine. */
+export function getCurrentTime(store: PlaybackStore): number {
+  return store.get(currentTimeAtom);
+}
+
+/** Watch playback commits; returns the unsubscribe function. */
+export function subscribeCurrentTime(
+  store: PlaybackStore,
+  callback: () => void,
+): () => void {
+  return store.sub(currentTimeAtom, callback);
 }
 
 /** Non-reactive read of the active loop start, in seconds. */

--- a/app/packages/plugins/src/index.ts
+++ b/app/packages/plugins/src/index.ts
@@ -226,6 +226,7 @@ export type {
   GridConfig,
   MatchMedia,
   ModalConfig,
+  SampleRendererGridClickBehavior,
   SampleRendererGridSlot,
   SampleRendererMatchContext,
   SampleRendererMediaContext,

--- a/app/packages/plugins/src/sample-renderer-registration.typecheck.ts
+++ b/app/packages/plugins/src/sample-renderer-registration.typecheck.ts
@@ -32,6 +32,7 @@ export function typecheckRegisterComponent() {
     sampleRendererOptions: {
       supports: { extensions: ["pdf"] },
       grid: {
+        clickBehavior: "passthrough",
         enabled: true,
         slots: {
           [SAMPLE_RENDERER_GRID_SLOT.HEADER_AFTER_RESOURCE_COUNT]:

--- a/app/packages/plugins/src/sample-renderer.test.tsx
+++ b/app/packages/plugins/src/sample-renderer.test.tsx
@@ -44,6 +44,7 @@ const createRegistration = (
         }
       | ((ctx: any) => boolean);
     grid?: {
+      clickBehavior?: "renderer" | "passthrough";
       enabled?: boolean;
       overrideComponent?: React.FunctionComponent<{ ctx: any }>;
       slots?: Partial<Record<string, React.FunctionComponent>>;

--- a/app/packages/plugins/src/sample-renderer.ts
+++ b/app/packages/plugins/src/sample-renderer.ts
@@ -82,11 +82,45 @@ export type SampleRendererGridSlot =
   (typeof SAMPLE_RENDERER_GRID_SLOT)[keyof typeof SAMPLE_RENDERER_GRID_SLOT];
 
 /**
+ * Controls how otherwise-unhandled grid-tile activation events are routed.
+ *
+ * - `"renderer"` (default) keeps click and context-menu events inside the
+ *   sample renderer. Users open the sample modal with the grid's explicit
+ *   open-modal control.
+ * - `"passthrough"` allows those events to bubble to the host grid, where a
+ *   normal tile click opens the sample modal. Renderer-owned interactive
+ *   regions can still call `stopPropagation()` to retain their interactions.
+ *
+ * This option does not disable pointer events or affect hover behavior,
+ * renderer-owned controls, the sample-selection checkbox, or the explicit
+ * open-modal control.
+ */
+export type SampleRendererGridClickBehavior = "renderer" | "passthrough";
+
+/**
  * Grid-specific renderer behavior, including enablement and optional override.
  */
 export type GridConfig = {
+  /**
+   * Enables the sample renderer on the grid surface. Grid rendering is
+   * disabled unless this is explicitly set to `true`.
+   */
   enabled?: boolean;
+  /**
+   * Optional component used only on the grid surface. When omitted, the
+   * renderer's canonical component is used in both the grid and modal.
+   */
   overrideComponent?: React.FunctionComponent<SampleRendererProps>;
+  /**
+   * Controls whether otherwise-unhandled tile activation events stay within
+   * the renderer or pass through to the host grid. Defaults to `"renderer"`.
+   *
+   * Use `"passthrough"` for non-interactive previews that should behave like
+   * native grid tiles. A renderer that mixes interactive and non-interactive
+   * regions may opt into passthrough and call `stopPropagation()` only from
+   * the interactive regions.
+   */
+  clickBehavior?: SampleRendererGridClickBehavior;
   /**
    * Components rendered in named grid slots while this renderer is active.
    */


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

Improve MCAP viewer interactions and playback efficiency. This adds plot zoom, lets passive grid renderers open sample modals, classifies IMU topics as sensors, samples performance updates, and caches image-annotation interpolation work.

## 🧪 How is this patch tested? If it is not, please explain why.

Ran 134 focused assertions across the changed viewer, grid, plugin, performance, interpolation, and annotation-overlay suites. Also ran `yarn workspace @fiftyone/multimodal check:types` and `yarn workspace @fiftyone/multimodal check:lint`.

Manual check: open an MCAP sample, zoom a plot, open the sample from its grid renderer, and scrub image annotations while watching the performance readout.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

MCAP plots now support zooming, and MCAP playback interactions are smoother across grids, performance monitoring, and image annotations.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added timeseries zoom controls (zoom in/out, reset), pan, and pinch-zoom.
  * Introduced configurable grid-tile click behavior with a passthrough mode for native-like host activation.
  * Added improved image annotation rendering for line-list annotations using precomputed render metadata.
* **Bug Fixes**
  * Prevented grid activation when previews aren’t in an eligible ready image state.
  * Updated IMU topic classification to Sensors.
* **Improvements**
  * Performance stats now sample playhead timing, and “Copy JSON” includes the latest committed time.
  * Updated UI/iconography and alignment (open-in-full), plus map navigation and overlay positioning tweaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3261
<!-- enterprise-sync-pr:end -->