### PR TITLE
Fix detached-bitmap crash during native video annotation playback

### DIFF
--- a/app/packages/video-annotation/src/components/ImaVidLighterTile.tsx
+++ b/app/packages/video-annotation/src/components/ImaVidLighterTile.tsx
@@ -40,8 +40,15 @@ function usePaintFrameToCanvas(
       return;
     }
 
+    // A closed `ImageBitmap` reports zero dimensions; drawing it throws
+    // ("image source is detached"). Skip rather than crash — the current
+    // canvas contents linger until the next live frame commits.
     const w = frame.bitmap.width;
     const h = frame.bitmap.height;
+    if (w === 0 || h === 0) {
+      return;
+    }
+
     if (canvasEl.width !== w) {
       canvasEl.width = w;
     }

--- a/app/packages/video-annotation/src/streams/frameBitmapCache.test.ts
+++ b/app/packages/video-annotation/src/streams/frameBitmapCache.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { CachedFrameBitmap, FrameBitmapCache } from "./frameBitmapCache";
+
+/**
+ * A fake `ImageBitmap` whose `close()` is a spy. The cache only ever calls
+ * `close()` and reads the entry's own `width`/`height`, so this stands in.
+ */
+function makeEntry(
+  size = 5,
+): CachedFrameBitmap & { close: ReturnType<typeof vi.fn> } {
+  const close = vi.fn();
+  const bitmap = { close, width: size, height: size } as unknown as ImageBitmap;
+  return { bitmap, width: size, height: size, meta: {}, close };
+}
+
+/** A 5x5 entry is 100 bytes; this budget holds two of them. */
+const TWO_FRAME_BUDGET = 250;
+
+describe("FrameBitmapCache eviction", () => {
+  it("closes non-pinned bitmaps when evicted under budget pressure", () => {
+    const cache = new FrameBitmapCache(TWO_FRAME_BUDGET);
+    const e1 = makeEntry();
+    const e2 = makeEntry();
+    const e3 = makeEntry();
+
+    cache.set(1, e1);
+    cache.set(2, e2);
+    cache.set(3, e3); // evicts frame 1 (least-recently-used)
+
+    expect(e1.close).toHaveBeenCalledTimes(1);
+    expect(cache.has(1)).toBe(false);
+    expect(e2.close).not.toHaveBeenCalled();
+    expect(e3.close).not.toHaveBeenCalled();
+  });
+});
+
+describe("FrameBitmapCache pinning", () => {
+  it("does not close the pinned frame when the LRU evicts it", () => {
+    const cache = new FrameBitmapCache(TWO_FRAME_BUDGET);
+    const e1 = makeEntry();
+    const e2 = makeEntry();
+    const e3 = makeEntry();
+
+    cache.set(1, e1);
+    cache.pin(1); // frame 1 is on screen
+    cache.set(2, e2);
+    cache.set(3, e3); // would evict frame 1, but it's pinned
+
+    // The LRU dropped it, but the bitmap stays alive and retrievable.
+    expect(e1.close).not.toHaveBeenCalled();
+    expect(cache.has(1)).toBe(true);
+    expect(cache.get(1)).toBe(e1);
+  });
+
+  it("closes the previously-pinned frame once it falls out of the LRU and is unpinned", () => {
+    const cache = new FrameBitmapCache(TWO_FRAME_BUDGET);
+    const e1 = makeEntry();
+
+    cache.set(1, e1);
+    cache.pin(1);
+    cache.set(2, makeEntry());
+    cache.set(3, makeEntry()); // frame 1 evicted from LRU but pinned-alive
+
+    cache.unpin();
+
+    expect(e1.close).toHaveBeenCalledTimes(1);
+    expect(cache.has(1)).toBe(false);
+  });
+
+  it("re-pinning the same frame is a no-op", () => {
+    const cache = new FrameBitmapCache(TWO_FRAME_BUDGET);
+    const e1 = makeEntry();
+
+    cache.set(1, e1);
+    cache.pin(1);
+    cache.pin(1);
+
+    expect(e1.close).not.toHaveBeenCalled();
+    expect(cache.get(1)).toBe(e1);
+  });
+
+  it("does not close a still-cached frame when the pin moves off it", () => {
+    // Budget holds both frames, so moving the pin leaves frame 1 in the LRU;
+    // the cache still owns it and must not close it early.
+    const cache = new FrameBitmapCache(TWO_FRAME_BUDGET);
+    const e1 = makeEntry();
+    const e2 = makeEntry();
+
+    cache.set(1, e1);
+    cache.pin(1);
+    cache.set(2, e2);
+    cache.pin(2); // playhead advanced to frame 2
+
+    expect(e1.close).not.toHaveBeenCalled();
+    expect(cache.has(1)).toBe(true);
+  });
+
+  it("closes an evicted-while-pinned frame on clear", () => {
+    const cache = new FrameBitmapCache(TWO_FRAME_BUDGET);
+    const e1 = makeEntry();
+    const e2 = makeEntry();
+
+    cache.set(1, e1);
+    cache.pin(1);
+    cache.set(2, e2);
+    cache.set(3, makeEntry()); // frame 1 evicted from LRU, pinned-alive
+
+    cache.clear();
+
+    expect(e1.close).toHaveBeenCalledTimes(1);
+    expect(e2.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/packages/video-annotation/src/streams/frameBitmapCache.ts
+++ b/app/packages/video-annotation/src/streams/frameBitmapCache.ts
@@ -27,23 +27,44 @@ const DEFAULT_MAX_BYTES = 1e9;
  * immediately rather than waiting on GC (decoded RGBA is large — without this
  * we blow well past the byte cap before memory is reclaimed).
  *
+ * The one exception is the {@link pin}ned frame — the frame currently on
+ * screen. Consumers draw a bitmap by reference, so closing it under eviction
+ * would detach the image mid-draw. The pinned frame is exempt from the
+ * close-on-evict and held by a strong reference here until it's unpinned, so
+ * it survives even when the LRU drops it under budget pressure.
+ *
  * Shared by every {@link FrameBitmapStream} (the `/frames` image stream and the
  * WebCodecs video stream) so both get identical memory behaviour.
  */
 export class FrameBitmapCache<M = unknown> {
   private readonly cache: LRUCache<number, CachedFrameBitmap<M>>;
+  /** The frame currently on screen; exempt from close-on-evict. */
+  private pinnedFrame: number | null = null;
+  /** Strong ref to the pinned entry so it survives eviction from the LRU. */
+  private pinnedEntry: CachedFrameBitmap<M> | null = null;
 
   constructor(maxBytes: number = DEFAULT_MAX_BYTES) {
     this.cache = new LRUCache<number, CachedFrameBitmap<M>>({
       maxSize: maxBytes,
       sizeCalculation: (entry) => Math.max(1, entry.width * entry.height * 4),
-      dispose: (entry) => {
+      dispose: (entry, key) => {
+        // Never close the frame on screen; the renderer still holds it and may
+        // redraw it. `pinnedEntry` keeps it alive; `releasePinned` closes it
+        // once the playhead moves on.
+        if (key === this.pinnedFrame) {
+          return;
+        }
+
         entry.bitmap.close();
       },
     });
   }
 
   get(frame: number): CachedFrameBitmap<M> | undefined {
+    if (frame === this.pinnedFrame && this.pinnedEntry) {
+      return this.pinnedEntry;
+    }
+
     return this.cache.get(frame);
   }
 
@@ -52,15 +73,72 @@ export class FrameBitmapCache<M = unknown> {
   }
 
   has(frame: number): boolean {
-    return this.cache.has(frame);
+    return frame === this.pinnedFrame || this.cache.has(frame);
   }
 
   delete(frame: number): void {
+    if (frame === this.pinnedFrame) {
+      this.releasePinned();
+    }
+
     this.cache.delete(frame);
+  }
+
+  /**
+   * Pin the frame currently being displayed so eviction can't close its bitmap
+   * underneath the renderer. Releases the previous pin (see
+   * {@link releasePinned}). Refreshes the frame's recency and takes a strong
+   * reference, so the frame is served even after the LRU drops it under budget
+   * pressure.
+   */
+  pin(frame: number): void {
+    if (frame === this.pinnedFrame) {
+      return;
+    }
+
+    const entry = this.cache.get(frame) ?? null;
+    this.releasePinned();
+    this.pinnedFrame = frame;
+    this.pinnedEntry = entry;
+  }
+
+  /** Drop the current pin, closing its bitmap if the LRU no longer holds it. */
+  unpin(): void {
+    this.releasePinned();
+  }
+
+  private releasePinned(): void {
+    const frame = this.pinnedFrame;
+    const entry = this.pinnedEntry;
+    this.pinnedFrame = null;
+    this.pinnedEntry = null;
+
+    if (frame === null || !entry) {
+      return;
+    }
+
+    // If the LRU still holds this frame it owns the bitmap and will close it on
+    // a future eviction. If eviction already dropped it (dispose skipped the
+    // close because it was pinned), this strong ref is the only one left —
+    // close it now so the memory is reclaimed.
+    if (!this.cache.has(frame)) {
+      entry.bitmap.close();
+    }
   }
 
   /** Drop every entry, closing each held bitmap. */
   clear(): void {
+    const pinnedFrame = this.pinnedFrame;
+    const pinnedEntry = this.pinnedEntry;
+    this.pinnedFrame = null;
+    this.pinnedEntry = null;
+
+    // A pinned frame the LRU already dropped is held only here — close it. One
+    // still in the LRU is closed by `cache.clear()` below.
+    if (pinnedEntry && pinnedFrame !== null && !this.cache.has(pinnedFrame)) {
+      pinnedEntry.bitmap.close();
+    }
+
     this.cache.clear();
   }
 }

--- a/app/packages/video-annotation/src/streams/frameBitmapStream.ts
+++ b/app/packages/video-annotation/src/streams/frameBitmapStream.ts
@@ -279,11 +279,17 @@ export abstract class FrameBitmapStream<
       return;
     }
 
-    // Advancing to a new committed frame — proactively pull the next chunk into
-    // flight so it lands before the playhead reaches it (the engine only gives
-    // a 1-frame warning).
+    // Pin the frame we're about to publish so the LRU can't close its bitmap
+    // while the tile is still drawing it; unpin when we publish "no frame".
     if (next) {
+      this.cache.pin(next.frameNumber);
+
+      // Advancing to a new committed frame — proactively pull the next chunk
+      // into flight so it lands before the playhead reaches it (the engine
+      // only gives a 1-frame warning).
       this.prefetch([time, time + this.lookaheadSeconds]);
+    } else {
+      this.cache.unpin();
     }
 
     this.publish(store, next);


### PR DESCRIPTION
## Problem

During playback of the native-decoded video annotation surface, long clips can
crash with:

```
InvalidStateError: Failed to execute 'drawImage' on 'CanvasRenderingContext2D':
The image source is detached
```

## Root cause

`FrameBitmapCache` closes each decoded `ImageBitmap` on LRU eviction to reclaim
memory promptly. The playback tile draws the currently-displayed frame by
reference. On a long clip the cache exceeds its byte budget mid-playback and can
evict — and close — the bitmap that is still on screen, so a subsequent
`drawImage` hits a detached source. Short clips never exceed the budget, so this
only surfaces on long videos and is timing-dependent (intermittent).

## Fix

Pin the currently-published frame so the LRU cannot close its bitmap while the
tile is still drawing it: the pinned frame is exempt from close-on-evict, held
by a strong reference, and closed only once the playhead moves off it. A
defensive guard also skips drawing a zero-dimension (closed) bitmap rather than
throwing.

## Tests

- New `frameBitmapCache` unit tests: the pinned frame survives eviction and is
  retrievable; non-pinned frames are still closed on eviction; the pinned frame
  is closed on unpin/clear.
- Reproduced the exact error in a browser with close-on-evict, and confirmed
  pinning prevents it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved video annotation rendering when an invalid or closed frame is encountered, preserving the last valid canvas content until a usable frame is available.
  - Prevented active video frames from being prematurely discarded while they are being rendered.
  - Improved frame cache cleanup and eviction behavior, including pinned frames and cache clearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3269
<!-- enterprise-sync-pr:end -->