### PR TITLE
Add rotated bounding box support to the CVAT annotation integration

### DIFF
--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -548,6 +548,12 @@ provided:
 
     Note that this argument cannot be provided when uploading existing tracks
 
+-   **rotated_boxes** (*False*): whether to upload closed four-point
+    :class:`Polyline <fiftyone.core.labels.Polyline>` instances whose points
+    define (possibly rotated) rectangles as CVAT rotated rectangles rather than
+    polygons, so that they can be edited as boxes in CVAT. Rectangles
+    downloaded into polyline fields are converted back to four-point polylines
+
 .. _cvat-label-schema:
 
 Label schema
@@ -2127,6 +2133,65 @@ attributes between annotation runs.
     dataset.load_annotations(anno_key, cleanup=True)
     dataset.delete_annotation_run(anno_key)
 
+
+.. _cvat-rotated-boxes:
+
+Annotating rotated bounding boxes
+---------------------------------
+
+In FiftyOne, rotated bounding boxes (e.g., oriented object detections) are
+represented as closed four-point
+:class:`Polyline <fiftyone.core.labels.Polyline>` instances. By default,
+polylines are uploaded to CVAT as polygon or polyline shapes, which cannot be
+edited as boxes in CVAT.
+
+Pass `rotated_boxes=True` to
+:meth:`annotate() <fiftyone.core.collections.SampleCollection.annotate>` to
+instead upload any closed four-point polylines whose points define (possibly
+rotated) rectangles as CVAT rotated rectangles. In CVAT, these annotations can
+be moved, resized, and rotated like any other box.
+
+When you load your annotations back into FiftyOne, rectangles in polyline
+fields, including any new boxes you created in CVAT, are converted to closed
+four-point polylines, so the rotated box representation round-trips.
+
+.. code:: python
+    :linenos:
+
+    import fiftyone as fo
+    import fiftyone.zoo as foz
+
+    dataset = foz.load_zoo_dataset("quickstart").clone()
+    view = dataset.take(1)
+
+    # Convert detections to (axis-aligned) rotated boxes for this example
+    sample = view.first()
+    polylines = sample["ground_truth"].to_polylines(filled=True)
+    sample["rotated_boxes"] = polylines
+    sample.save()
+
+    anno_key = "cvat_rotated_boxes"
+
+    view.annotate(
+        anno_key,
+        label_field="rotated_boxes",
+        label_type="polylines",
+        classes=dataset.distinct("ground_truth.detections.label"),
+        rotated_boxes=True,
+        launch_editor=True,
+    )
+    print(dataset.get_annotation_info(anno_key))
+
+    # Rotate and edit the boxes in CVAT...
+
+    dataset.load_annotations(anno_key, cleanup=True)
+    dataset.delete_annotation_run(anno_key)
+
+.. note::
+
+    Polylines that do not define rectangles, e.g., general polygons or
+    multi-shape polylines, are always uploaded as polygon or polyline shapes,
+    even when `rotated_boxes=True`.
 
 .. _cvat-destination-field:
 

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -3153,6 +3153,11 @@ class CVATBackendConfig(foua.AnnotationBackendConfig):
         coerce_text_attrs (True): whether to coerce CVAT text attributes to
             numeric types during annotation download. Set to False to preserve
             text attribute values as strings
+        rotated_boxes (False): whether to upload closed four-point
+            :class:`fiftyone.core.labels.Polyline` instances whose points
+            define (possibly rotated) rectangles as CVAT rotated rectangles
+            rather than polygons. Rectangles downloaded into polyline fields
+            are converted back to four-point polylines
     """
 
     def __init__(
@@ -3185,6 +3190,7 @@ class CVATBackendConfig(foua.AnnotationBackendConfig):
         frame_stop=None,
         frame_step=None,
         coerce_text_attrs=True,
+        rotated_boxes=False,
         **kwargs,
     ):
         super().__init__(name, label_schema, media_field=media_field, **kwargs)
@@ -3209,6 +3215,7 @@ class CVATBackendConfig(foua.AnnotationBackendConfig):
         self.frame_stop = _validate_frame_arg(frame_stop, "frame_stop")
         self.frame_step = _validate_frame_arg(frame_step, "frame_step")
         self.coerce_text_attrs = coerce_text_attrs
+        self.rotated_boxes = rotated_boxes
 
         # store privately so these aren't serialized
         self._username = username
@@ -4418,6 +4425,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         label_schema = config.label_schema
         occluded_attr = config.occluded_attr
         group_id_attr = config.group_id_attr
+        rotated_boxes = getattr(config, "rotated_boxes", False)
         task_size = config.task_size
         config.job_reviewers = self._parse_reviewers(config.job_reviewers)
         project_name, project_id = self._parse_project_details(
@@ -4558,6 +4566,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                             only_keyframes,
                             occluded_attrs,
                             group_id_attrs,
+                            rotated_boxes,
                         )
 
                         if _tracks and _frame_step is not None:
@@ -5654,6 +5663,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         only_keyframes,
         occluded_attrs,
         group_id_attrs,
+        rotated_boxes=False,
     ):
         is_video = samples_batch.media_type == fom.VIDEO
 
@@ -5691,6 +5701,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                 only_keyframes=only_keyframes,
                 occluded_attrs=occluded_attrs,
                 group_id_attrs=group_id_attrs,
+                rotated_boxes=rotated_boxes,
             )
         else:
             # Shape annotations
@@ -5704,6 +5715,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                 frame_step,
                 occluded_attrs=occluded_attrs,
                 group_id_attrs=group_id_attrs,
+                rotated_boxes=rotated_boxes,
             )
 
         id_map[label_field].update(_id_map)
@@ -5994,8 +6006,19 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                 cvat_shape.id = None
 
             if shape_type == "rectangle":
-                label_type = "detections"
-                label = cvat_shape.to_detection()
+                if expected_label_type in (
+                    "polyline",
+                    "polylines",
+                    "polygon",
+                    "polygons",
+                ):
+                    # A (possibly rotated) box in a polyline field
+                    filled = expected_label_type in ("polygon", "polygons")
+                    label_type = "polylines"
+                    label = cvat_shape.to_rotated_box_polyline(filled=filled)
+                else:
+                    label_type = "detections"
+                    label = cvat_shape.to_detection()
             elif shape_type == "cuboid":
                 label_type = "detections"
                 label = cvat_shape.to_detection()
@@ -6254,6 +6277,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         only_keyframes=False,
         occluded_attrs=None,
         group_id_attrs=None,
+        rotated_boxes=False,
     ):
         label_type = label_info["type"]
         classes = label_info["classes"]
@@ -6341,9 +6365,11 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                     func = self._create_detection_shapes
                 elif label_type in ("polyline", "polygon"):
                     labels = [label]
+                    kwargs["rotated_boxes"] = rotated_boxes
                     func = self._create_polyline_shapes
                 elif label_type in ("polylines", "polygons"):
                     labels = label.polylines
+                    kwargs["rotated_boxes"] = rotated_boxes
                     func = self._create_polyline_shapes
                 elif label_type == "keypoint":
                     labels = [label]
@@ -6731,6 +6757,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         load_tracks=False,
         occluded_attrs=None,
         group_id_attrs=None,
+        rotated_boxes=False,
     ):
         ids = []
         shapes = []
@@ -6762,22 +6789,46 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                 if poly.filled and len(points) < 3:
                     continue  # CVAT polygons must contain >= 3 points
 
-                abs_points = HasCVATPoints._to_abs_points(points, frame_size)
-                flattened_points = list(
-                    itertools.chain.from_iterable(abs_points)
-                )
+                box_params = None
+                if rotated_boxes and poly.closed and len(frame_size) == 2:
+                    w, h = frame_size
+                    float_abs_points = [(x * w, y * h) for x, y in points]
+                    box_params = _abs_points_to_rotated_box(float_abs_points)
 
-                shape = {
-                    "type": "polygon" if poly.filled else "polyline",
-                    "occluded": is_occluded,
-                    "z_order": 0,
-                    "points": flattened_points,
-                    "label_id": class_name,
-                    "group": group_id,
-                    "frame": frame_id,
-                    "source": "manual",
-                    "attributes": deepcopy(attributes),
-                }
+                if box_params is not None:
+                    xtl, ytl, xbr, ybr, rotation = box_params
+                    shape = {
+                        "type": "rectangle",
+                        "occluded": is_occluded,
+                        "z_order": 0,
+                        "points": [xtl, ytl, xbr, ybr],
+                        "rotation": rotation,
+                        "label_id": class_name,
+                        "group": group_id,
+                        "frame": frame_id,
+                        "source": "manual",
+                        "attributes": deepcopy(attributes),
+                    }
+                else:
+                    abs_points = HasCVATPoints._to_abs_points(
+                        points, frame_size
+                    )
+                    flattened_points = list(
+                        itertools.chain.from_iterable(abs_points)
+                    )
+
+                    shape = {
+                        "type": "polygon" if poly.filled else "polyline",
+                        "occluded": is_occluded,
+                        "z_order": 0,
+                        "points": flattened_points,
+                        "label_id": class_name,
+                        "group": group_id,
+                        "frame": frame_id,
+                        "source": "manual",
+                        "attributes": deepcopy(attributes),
+                    }
+
                 curr_shapes.append(shape)
 
             if not curr_shapes:
@@ -7376,6 +7427,30 @@ class CVATShape(CVATLabel):
         self._set_attributes(label)
         return label
 
+    def to_rotated_box_polyline(self, filled=False):
+        """Converts this (possibly rotated) rectangle shape to a four-point
+        :class:`fiftyone.core.labels.Polyline`.
+
+        Args:
+            filled (False): whether the polyline should be filled
+
+        Returns:
+            a :class:`fiftyone.core.labels.Polyline`
+        """
+        rotation = float(self.attributes.pop("rotation", 0) or 0)
+        xtl, ytl, xbr, ybr = self.points
+        abs_points = _rotated_box_to_abs_points(xtl, ytl, xbr, ybr, rotation)
+        rel_points = HasCVATPoints._to_rel_points(abs_points, self.frame_size)
+        label = fol.Polyline(
+            label=self.label,
+            points=[rel_points],
+            index=self.index,
+            closed=True,
+            filled=filled,
+        )
+        self._set_attributes(label)
+        return label
+
     def to_keypoint(self):
         """Converts this shape to a :class:`fiftyone.core.labels.Keypoint`.
 
@@ -7738,6 +7813,92 @@ def _parse_value(value, attr_type=None):
             return None
 
     return value
+
+
+def _abs_points_to_rotated_box(abs_points, tolerance=0.01):
+    """Determines whether the given absolute points define a (possibly
+    rotated) rectangle.
+
+    Args:
+        abs_points: a list of ``(x, y)`` pairs in absolute coordinates
+        tolerance (0.01): the maximum deviation from a perfect rectangle to
+            allow, as a fraction of the rectangle's max diagonal length
+
+    Returns:
+        a ``(xtl, ytl, xbr, ybr, rotation)`` tuple defining the equivalent
+        CVAT rotated rectangle, or None if the points do not define a
+        rectangle. The ``(xtl, ytl, xbr, ybr)`` coordinates describe the
+        unrotated box and ``rotation`` is in degrees, clockwise, about the
+        box's center
+    """
+    if len(abs_points) != 4:
+        return None
+
+    p = np.asarray(abs_points, dtype=float)
+
+    # A quadrilateral is a rectangle iff its diagonals bisect each other
+    # (parallelogram) and are of equal length
+    mid1 = (p[0] + p[2]) / 2
+    mid2 = (p[1] + p[3]) / 2
+    len1 = np.linalg.norm(p[2] - p[0])
+    len2 = np.linalg.norm(p[3] - p[1])
+
+    max_len = max(len1, len2)
+    if max_len <= 0:
+        return None
+
+    # The floor absorbs pixel quantization noise in small boxes
+    tol = max(tolerance * max_len, 2.0)
+    if np.linalg.norm(mid1 - mid2) > tol or abs(len1 - len2) > tol:
+        return None
+
+    cx, cy = (mid1 + mid2) / 2
+    width = np.linalg.norm(p[1] - p[0])
+    height = np.linalg.norm(p[3] - p[0])
+    rotation = (
+        np.degrees(np.arctan2(p[1][1] - p[0][1], p[1][0] - p[0][0])) % 360
+    )
+
+    xtl = cx - width / 2
+    ytl = cy - height / 2
+    xbr = cx + width / 2
+    ybr = cy + height / 2
+
+    return (
+        float(xtl),
+        float(ytl),
+        float(xbr),
+        float(ybr),
+        float(rotation),
+    )
+
+
+def _rotated_box_to_abs_points(xtl, ytl, xbr, ybr, rotation):
+    """Converts a CVAT rotated rectangle to its four corner points.
+
+    Args:
+        xtl: the top-left x coordinate of the unrotated box
+        ytl: the top-left y coordinate of the unrotated box
+        xbr: the bottom-right x coordinate of the unrotated box
+        ybr: the bottom-right y coordinate of the unrotated box
+        rotation: the rotation of the box, in degrees, clockwise, about the
+            box's center
+
+    Returns:
+        a list of four ``(x, y)`` pairs in absolute coordinates
+    """
+    cx = (xtl + xbr) / 2
+    cy = (ytl + ybr) / 2
+    hw = (xbr - xtl) / 2
+    hh = (ybr - ytl) / 2
+
+    theta = math.radians(rotation)
+    cos, sin = math.cos(theta), math.sin(theta)
+
+    return [
+        (cx + dx * cos - dy * sin, cy + dx * sin + dy * cos)
+        for dx, dy in ((-hw, -hh), (hw, -hh), (hw, hh), (-hw, hh))
+    ]
 
 
 def _parse_occlusion_value(value):

--- a/tests/unittests/cvat_utils_tests.py
+++ b/tests/unittests/cvat_utils_tests.py
@@ -1,0 +1,174 @@
+"""
+FiftyOne CVAT utilities unit tests.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import unittest
+
+import numpy as np
+
+import fiftyone as fo
+from fiftyone.utils.cvat import (
+    CVATShape,
+    _abs_points_to_rotated_box,
+    _rotated_box_to_abs_points,
+)
+
+
+def _assert_corners_equal(test, corners1, corners2, tol=1e-3):
+    test.assertEqual(len(corners1), len(corners2))
+    remaining = [np.asarray(c) for c in corners2]
+    for corner in corners1:
+        dists = [np.linalg.norm(np.asarray(corner) - c) for c in remaining]
+        idx = int(np.argmin(dists))
+        test.assertLess(dists[idx], tol)
+        remaining.pop(idx)
+
+
+def _make_cvat_shape(points, rotation=None, frame_size=(400, 300)):
+    label_dict = {
+        "label_id": 1,
+        "id": 100,
+        "attributes": [],
+        "points": points,
+    }
+    if rotation is not None:
+        label_dict["rotation"] = rotation
+
+    width, height = frame_size
+    return CVATShape(
+        label_dict,
+        {1: "vehicle"},
+        {1: {}},
+        {},
+        {"width": width, "height": height},
+    )
+
+
+class RotatedBoxHelperTests(unittest.TestCase):
+    def test_axis_aligned_box(self):
+        corners = [(10, 20), (110, 20), (110, 70), (10, 70)]
+        box_params = _abs_points_to_rotated_box(corners)
+
+        self.assertIsNotNone(box_params)
+        xtl, ytl, xbr, ybr, rotation = box_params
+        self.assertAlmostEqual(xtl, 10)
+        self.assertAlmostEqual(ytl, 20)
+        self.assertAlmostEqual(xbr, 110)
+        self.assertAlmostEqual(ybr, 70)
+        self.assertAlmostEqual(rotation, 0)
+
+    def test_round_trip(self):
+        for rotation in (0, 15, 45, 90, 135, 222.5, 359):
+            with self.subTest(rotation=rotation):
+                corners = _rotated_box_to_abs_points(
+                    100, 200, 300, 260, rotation
+                )
+                box_params = _abs_points_to_rotated_box(corners)
+
+                self.assertIsNotNone(box_params)
+                xtl, ytl, xbr, ybr, _rotation = box_params
+                self.assertAlmostEqual(xtl, 100)
+                self.assertAlmostEqual(ytl, 200)
+                self.assertAlmostEqual(xbr, 300)
+                self.assertAlmostEqual(ybr, 260)
+                self.assertAlmostEqual(_rotation, rotation % 360)
+
+    def test_corner_order_invariance(self):
+        corners = _rotated_box_to_abs_points(100, 200, 300, 260, 30)
+
+        for shift in range(4):
+            for _corners in (
+                corners[shift:] + corners[:shift],
+                list(reversed(corners[shift:] + corners[:shift])),
+            ):
+                with self.subTest(corners=_corners):
+                    box_params = _abs_points_to_rotated_box(_corners)
+                    self.assertIsNotNone(box_params)
+                    _assert_corners_equal(
+                        self,
+                        _rotated_box_to_abs_points(*box_params),
+                        corners,
+                    )
+
+    def test_non_rectangles_rejected(self):
+        # Trapezoid
+        self.assertIsNone(
+            _abs_points_to_rotated_box([(0, 0), (100, 0), (90, 50), (0, 50)])
+        )
+
+        # Wrong number of points
+        self.assertIsNone(
+            _abs_points_to_rotated_box([(0, 0), (100, 0), (50, 50)])
+        )
+        self.assertIsNone(
+            _abs_points_to_rotated_box(
+                [(0, 0), (100, 0), (100, 50), (50, 60), (0, 50)]
+            )
+        )
+
+        # Degenerate
+        self.assertIsNone(
+            _abs_points_to_rotated_box([(5, 5), (5, 5), (5, 5), (5, 5)])
+        )
+
+
+class CVATShapeRotatedBoxTests(unittest.TestCase):
+    def test_rectangle_to_rotated_box_polyline(self):
+        shape = _make_cvat_shape([100, 100, 200, 150], rotation=30)
+        polyline = shape.to_rotated_box_polyline(filled=True)
+
+        self.assertTrue(polyline.closed)
+        self.assertTrue(polyline.filled)
+        self.assertEqual(polyline.label, "vehicle")
+        self.assertEqual(len(polyline.points), 1)
+        self.assertEqual(len(polyline.points[0]), 4)
+
+        # The rotation must be consumed as geometry, not stored as a label
+        # attribute
+        self.assertIsNone(polyline.get_attribute_value("rotation", None))
+
+        abs_points = [(x * 400, y * 300) for x, y in polyline.points[0]]
+        expected = _rotated_box_to_abs_points(100, 100, 200, 150, 30)
+        _assert_corners_equal(self, abs_points, expected)
+
+    def test_unrotated_rectangle_to_polyline(self):
+        shape = _make_cvat_shape([100, 100, 200, 150])
+        polyline = shape.to_rotated_box_polyline()
+
+        self.assertTrue(polyline.closed)
+        self.assertFalse(polyline.filled)
+
+        abs_points = [(x * 400, y * 300) for x, y in polyline.points[0]]
+        expected = [(100, 100), (200, 100), (200, 150), (100, 150)]
+        _assert_corners_equal(self, abs_points, expected)
+
+    def test_upload_download_round_trip(self):
+        frame_size = (400, 300)
+        width, height = frame_size
+
+        orig_abs_points = _rotated_box_to_abs_points(120, 80, 280, 160, 42)
+        rel_points = [(x / width, y / height) for x, y in orig_abs_points]
+
+        # Upload-side conversion
+        float_abs_points = [(x * width, y * height) for x, y in rel_points]
+        box_params = _abs_points_to_rotated_box(float_abs_points)
+        self.assertIsNotNone(box_params)
+
+        xtl, ytl, xbr, ybr, rotation = box_params
+
+        # Download-side conversion
+        shape = _make_cvat_shape(
+            [xtl, ytl, xbr, ybr], rotation=rotation, frame_size=frame_size
+        )
+        polyline = shape.to_rotated_box_polyline()
+
+        abs_points = [(x * width, y * height) for x, y in polyline.points[0]]
+        _assert_corners_equal(self, abs_points, orig_abs_points)
+
+
+if __name__ == "__main__":
+    fo.config.show_progress_bars = False
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Resolves #6033

In FiftyOne, rotated bounding boxes are represented as closed four-point `Polyline` instances, but the CVAT integration uploads all polylines as polygon or polyline shapes, which cannot be edited as boxes in CVAT.

This PR adds an opt-in `rotated_boxes` parameter to the CVAT backend:

- **Upload** (`rotated_boxes=True`): closed four-point polylines whose points define a (possibly rotated) rectangle are uploaded as CVAT rectangle shapes with the appropriate `rotation`, so they can be moved, resized, and rotated as boxes in CVAT. Non-rectangular polylines upload as before. The parameter defaults to `False`, so existing behavior is unchanged.
- **Download**: rectangle shapes returned for polyline-typed fields (including new boxes drawn in CVAT) are converted to closed four-point polylines via the box's center, size, and rotation, so the representation round-trips. Rectangles for detection-typed fields behave exactly as before, including the existing `rotation` attribute passthrough for `Detection` labels.

Implementation notes:

- Rectangle detection uses the diagonal property (diagonals bisect each other and are equal length) with a tolerance floor to absorb pixel quantization noise.
- The rectangle path uses unquantized float coordinates rather than the integer-rounded points used for polygons, to preserve precision for small boxes.
- Rotated rectangles in video tracks work; interpolated in-between frames inherit the previous keyframe's rotation (CVAT interpolates rotation server-side for display).
- Docs: new "Annotating rotated bounding boxes" section in the CVAT integration docs plus a parameter listing.

## How is this patch tested?

New unit tests in `tests/unittests/cvat_utils_tests.py` covering:

- axis-aligned and rotated round trips (box params to corners and back) at various angles
- corner-order invariance (any starting corner, both winding directions)
- rejection of non-rectangles (trapezoids, wrong point counts, degenerate quads)
- `CVATShape.to_rotated_box_polyline()` geometry, including that `rotation` is consumed as geometry rather than leaking as a label attribute
- a full upload-side to download-side round trip in relative coordinates

All 7 tests (15 subtests) pass, and `pylint --errors-only` and `black -l 79` are clean on the touched files. If maintainers would like an end-to-end case in `tests/intensive/cvat_tests.py`, happy to add one.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] Yes. Give a description of this change to be included in the release notes for FiftyOne users.

Added an opt-in `rotated_boxes` parameter to the CVAT annotation integration that uploads rotated bounding boxes (closed four-point polylines) as CVAT rotated rectangles so they can be edited as boxes, with round-trip conversion on download.

### What areas of FiftyOne does this PR affect?

- [ ] `App`: FiftyOne application changes
- [ ] `Build`: Build and test infrastructure changes
- [x] `Core`: Core `fiftyone` Python library changes
- [x] `Documentation`: FiftyOne documentation changes
- [ ] `Other`
