### PR TITLE
Shut down the database instead of terminating it

### DIFF
--- a/fiftyone/service/main.py
+++ b/fiftyone/service/main.py
@@ -41,7 +41,12 @@ import psutil
 
 os.environ["FIFTYONE_DISABLE_SERVICES"] = "1"
 from fiftyone.service.ipc import IPCServer
+import fiftyone.service.util as fosu
 
+
+# the maximum time to wait for the database to shut itself down before it is
+# forcibly terminated
+DATABASE_SHUTDOWN_TIMEOUT = 60
 
 lock = threading.Lock()
 
@@ -291,6 +296,14 @@ def shutdown():
 
     Also dumps output if the main child process fails to exit cleanly.
     """
+
+    # the database must be given the chance to shut itself down, as terminating
+    # it leaves its cached collection metadata stale, which makes datasets
+    # appear to be empty the next time the database starts
+    if args.service_name == "db" and fosu.shutdown_mongod(
+        child, timeout=DATABASE_SHUTDOWN_TIMEOUT
+    ):
+        return
 
     # "yarn dev" doesn't pass SIGTERM to its children - to be safe, kill all
     # subprocesses of the child process first

--- a/fiftyone/service/util.py
+++ b/fiftyone/service/util.py
@@ -119,6 +119,80 @@ def get_listening_tcp_ports(process):
             yield conn.laddr[1]  # port
 
 
+def shutdown_mongod(process, timeout=60):
+    """Asks the given ``mongod`` process to shut itself down, and waits for it
+    to exit.
+
+    Terminating ``mongod`` rather than letting it shut itself down leaves its
+    cached collection metadata stale, because that metadata is only persisted
+    when the storage engine checkpoints (every 60 seconds, by default). The
+    documents themselves are recovered from the journal when the database next
+    starts, but the stale metadata is not, so collections can report a document
+    count of 0 while actually containing documents, which makes datasets appear
+    to be empty.
+
+    This is not hypothetical on Windows, where terminating a process maps to
+    ``TerminateProcess()``, which ``mongod`` cannot handle; on other platforms
+    it maps to ``SIGTERM``, which ``mongod`` does handle.
+
+    Args:
+        process (psutil.Process): the ``mongod`` process
+        timeout (60): the number of seconds to wait for the process to exit
+
+    Returns:
+        True if the process exited, and False if it must be terminated instead
+    """
+    try:
+        import pymongo
+        from pymongo.errors import AutoReconnect, ServerSelectionTimeoutError
+    except ImportError:
+        return False
+
+    try:
+        ports = list(get_listening_tcp_ports(process))
+    except psutil.Error:
+        return False
+
+    if not ports:
+        # the database never started listening, so it has nothing to persist
+        return False
+
+    try:
+        client = pymongo.MongoClient(
+            host="127.0.0.1",
+            port=ports[0],
+            directConnection=True,
+            # the database is local and known to be listening, so these only
+            # bound the failure case, in which the process is terminated
+            serverSelectionTimeoutMS=5000,
+            connectTimeoutMS=5000,
+        )
+    except Exception:
+        return False
+
+    try:
+        client.admin.command("shutdown", 1)
+    except ServerSelectionTimeoutError:
+        # NB: this is a subclass of `AutoReconnect`, but unlike the disconnect
+        # below, it means the database was never reached, so it did not shut
+        # down and must be terminated instead
+        return False
+    except AutoReconnect:
+        # expected: the database closes its connections while shutting down
+        pass
+    except Exception:
+        return False
+    finally:
+        client.close()
+
+    try:
+        process.wait(timeout=timeout)
+    except psutil.TimeoutExpired:
+        return False
+
+    return True
+
+
 def send_ipc_message(process, message):
     """Sends a message to a process's IPCServer.
 

--- a/tests/unittests/service_utils_tests.py
+++ b/tests/unittests/service_utils_tests.py
@@ -1,0 +1,105 @@
+"""
+FiftyOne service utilities unit tests.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import unittest
+from unittest import mock
+
+import psutil
+from pymongo.errors import AutoReconnect, ServerSelectionTimeoutError
+
+import fiftyone.service.util as fosu
+
+
+def _mock_process(wait_side_effect=None):
+    process = mock.Mock(spec=psutil.Process)
+    if wait_side_effect is not None:
+        process.wait.side_effect = wait_side_effect
+    return process
+
+
+class ShutdownMongodTests(unittest.TestCase):
+    """Tests that the database is asked to shut itself down rather than being
+    terminated, which would leave its cached collection metadata stale.
+    """
+
+    def test_sends_shutdown_command(self):
+        process = _mock_process()
+
+        with mock.patch.object(
+            fosu, "get_listening_tcp_ports", return_value=iter([27017])
+        ), mock.patch("pymongo.MongoClient") as mock_client:
+            self.assertTrue(fosu.shutdown_mongod(process))
+
+        mock_client.assert_called_once()
+        self.assertEqual(mock_client.call_args.kwargs["port"], 27017)
+        mock_client.return_value.admin.command.assert_called_once_with(
+            "shutdown", 1
+        )
+        mock_client.return_value.close.assert_called_once()
+        process.wait.assert_called_once()
+
+    def test_disconnect_during_shutdown_is_expected(self):
+        # The database closes its connections as it shuts down, so the command
+        # does not return normally
+        process = _mock_process()
+
+        with mock.patch.object(
+            fosu, "get_listening_tcp_ports", return_value=iter([27017])
+        ), mock.patch("pymongo.MongoClient") as mock_client:
+            mock_client.return_value.admin.command.side_effect = AutoReconnect(
+                "connection closed"
+            )
+            self.assertTrue(fosu.shutdown_mongod(process))
+
+        mock_client.return_value.close.assert_called_once()
+
+    def test_not_listening(self):
+        process = _mock_process()
+
+        with mock.patch.object(
+            fosu, "get_listening_tcp_ports", return_value=iter([])
+        ), mock.patch("pymongo.MongoClient") as mock_client:
+            self.assertFalse(fosu.shutdown_mongod(process))
+
+        mock_client.assert_not_called()
+
+    def test_unreachable_database(self):
+        process = _mock_process()
+
+        with mock.patch.object(
+            fosu, "get_listening_tcp_ports", return_value=iter([27017])
+        ), mock.patch("pymongo.MongoClient") as mock_client:
+            mock_client.return_value.admin.command.side_effect = (
+                ServerSelectionTimeoutError("no server")
+            )
+            self.assertFalse(fosu.shutdown_mongod(process))
+
+    def test_shutdown_times_out(self):
+        process = _mock_process(
+            wait_side_effect=psutil.TimeoutExpired(seconds=1)
+        )
+
+        with mock.patch.object(
+            fosu, "get_listening_tcp_ports", return_value=iter([27017])
+        ), mock.patch("pymongo.MongoClient"):
+            self.assertFalse(fosu.shutdown_mongod(process, timeout=1))
+
+        process.wait.assert_called_once_with(timeout=1)
+
+    def test_process_gone(self):
+        process = _mock_process()
+
+        with mock.patch.object(
+            fosu,
+            "get_listening_tcp_ports",
+            side_effect=psutil.NoSuchProcess(pid=1),
+        ):
+            self.assertFalse(fosu.shutdown_mongod(process))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Resolves #6498, where a persistent dataset is reported as empty when it is loaded in a new session.

**No data is actually lost.** The documents are still in MongoDB; only the cached count is wrong, which makes datasets look empty.

`fiftyone/service/main.py` terminates `mongod` when the last client exits. On Windows, `psutil`'s `terminate()` maps to `TerminateProcess()`, which the database cannot handle, so it never gets to shut itself down (`mongod` confirms this on its next startup with `"Startup from clean shutdown?": false`).

WiredTiger then recovers the documents from the journal, but not its cached collection metadata, which is only persisted when the storage engine checkpoints (every 60 seconds, by default). That metadata is exactly what `estimatedDocumentCount()` reads, and it is what FiftyOne uses to count samples in `Dataset._estimated_count()`. So the collection contains the documents but reports a count of zero, and `len(dataset)`, `dataset.stats()` and the App all show an empty dataset.

This also explains the workaround reported in the issue: sleeping for 60 seconds before exiting is exactly WiredTiger's default checkpoint interval, so the correct metadata gets checkpointed before the process is killed. Sleeping 5 seconds does not work; sleeping 60 seconds does.

This PR asks the database to shut itself down and waits for it to exit, falling back to terminating it if it cannot be reached, so the behavior is unchanged when the database is unresponsive.

Notes:

- Only FiftyOne-managed databases are affected. When `database_uri` is set, no `DatabaseService` is started, so this code path never runs.
- The graceful shutdown happens in the service wrapper process, after the user's process has already exited, so it adds no latency to interpreter shutdown.
- `ServerSelectionTimeoutError` is deliberately caught before `AutoReconnect` (it is a subclass): a dropped connection means the database is shutting down as expected, but a server selection timeout means it was never reached, and it must be terminated instead.

A "verify the count when it is zero" fix would not be sufficient, for what it is worth: once the metadata is stale, writes increment it from the wrong base, so a corrupted collection with 5 documents that receives 1 more reports `estimated=1, accurate=6`, which is silently wrong rather than obviously wrong. Preventing the unclean shutdown is the durable fix.

## How is this patch tested?

New unit tests in `tests/unittests/service_utils_tests.py` cover the contract of `shutdown_mongod()`: that the shutdown command is sent rather than the process being terminated, that the disconnect during shutdown is treated as success, and that it reports failure (so the caller terminates the process instead) when the database is not listening, is unreachable, does not exit within the timeout, or is already gone.

Verified end to end on Windows 11, with `mongod` from `fiftyone-db`:

```python
# session 1, exits immediately
ds = fo.Dataset("repro", persistent=True, overwrite=True)
ds.add_samples([fo.Sample(filepath="C:/fake/image_%d.jpg" % i) for i in range(5)])

# session 2
ds = fo.load_dataset("repro")
print(len(ds))
```

| | `len(ds)` in session 2 | `mongod` startup |
| --- | --- | --- |
| before | `0` | `"Startup from clean shutdown?": false` |
| after | `5` | `"Startup from clean shutdown?": true` |

Also ran `tests/unittests/dataset_tests.py`, `tests/unittests/view_tests.py` and the new tests: 241 passed, 13 skipped. `black -l 79` and `pylint --errors-only` are clean on the touched files.

### Databases that are already affected

Collections that were corrupted by earlier runs keep their stale counts, since nothing recomputes them. `validate` recomputes the cached count and `fsync` checkpoints it, and I verified the repair survives even an unclean kill afterwards:

```python
import fiftyone as fo
import fiftyone.core.odm as foo

db = foo.get_db_conn()

repaired = []
for name in fo.list_datasets():
    ds = fo.load_dataset(name)
    coll = db[ds._sample_collection_name]
    if coll.estimated_document_count() != coll.count_documents({}):
        db.command("validate", ds._sample_collection_name)
        repaired.append(name)

if repaired:
    db.client.admin.command("fsync")
```

I left this out of the PR because running `validate` implicitly takes a collection lock, and doing that from a read path such as `len(dataset)` seemed like the wrong tradeoff to make without a maintainer's call. Happy to add it as a migration or a documented utility if you would like it in the box.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] Yes. Give a description of this change to be included in the release notes for FiftyOne users.

Fixed a bug where persistent datasets could be reported as empty when loaded in a new session, caused by the database being terminated rather than shut down.

### What areas of FiftyOne does this PR affect?

- [ ] `App`: FiftyOne application changes
- [ ] `Build`: Build and test infrastructure changes
- [x] `Core`: Core `fiftyone` Python library changes
- [ ] `Documentation`: FiftyOne documentation changes
- [ ] `Other`
