### PR TITLE
Add PP-OCRv6 (PaddleOCR) text detection and OCR models to zoo

### DIFF
--- a/fiftyone/utils/paddleocr.py
+++ b/fiftyone/utils/paddleocr.py
@@ -10,7 +10,6 @@
 import logging
 
 import numpy as np
-from PIL import Image as PILImage
 
 import fiftyone.core.labels as fol
 import fiftyone.core.utils as fou
@@ -49,39 +48,10 @@ def _map_device(device):
 
 
 def _to_numpy_bgr(img):
-    """Converts a raw model input (PIL image, HWC uint8 numpy array, or CHW
-    torch tensor) to a contiguous HWC uint8 BGR numpy array, the format
-    paddleocr's predictors consume for in-memory inputs."""
-    try:
-        import torch
-
-        if isinstance(img, torch.Tensor):
-            img = img.detach().cpu().numpy()
-            if img.ndim == 3 and img.shape[0] in (1, 3, 4):
-                img = np.transpose(img, (1, 2, 0))
-    except ImportError:
-        pass
-
-    if isinstance(img, PILImage.Image):
-        img = np.asarray(img.convert("RGB"))
-
-    img = np.asarray(img)
-
-    if np.issubdtype(img.dtype, np.floating):
-        if img.max() <= 1.0:
-            img = img * 255.0
-        img = np.clip(img, 0, 255)
-    img = img.astype(np.uint8)
-
-    if img.ndim == 2:
-        img = np.stack([img] * 3, axis=-1)
-    elif img.shape[2] == 1:
-        img = np.repeat(img, 3, axis=2)
-    elif img.shape[2] == 4:
-        img = img[:, :, :3]
-
-    # RGB (FiftyOne/PIL) -> BGR (paddleocr/cv2)
-    return np.ascontiguousarray(img[:, :, ::-1])
+    """Converts a raw model input to a contiguous HWC uint8 BGR numpy array,
+    the format paddleocr's predictors consume for in-memory inputs."""
+    rgb = np.asarray(fout.to_rgb_pil(img))
+    return np.ascontiguousarray(rgb[:, :, ::-1])
 
 
 def _normalize_quad(poly, width, height):

--- a/fiftyone/utils/paddleocr.py
+++ b/fiftyone/utils/paddleocr.py
@@ -84,19 +84,15 @@ def _to_numpy_bgr(img):
     return np.ascontiguousarray(img[:, :, ::-1])
 
 
-def _quad_to_bbox(poly, width, height):
-    """Axis-aligned ``[x, y, w, h]`` in ``[0, 1]`` enclosing a quad polygon."""
-    xs = [float(p[0]) for p in poly]
-    ys = [float(p[1]) for p in poly]
-    x0 = min(max(min(xs), 0.0), float(width))
-    y0 = min(max(min(ys), 0.0), float(height))
-    x1 = min(max(max(xs), 0.0), float(width))
-    y1 = min(max(max(ys), 0.0), float(height))
+def _normalize_quad(poly, width, height):
+    """Normalizes a pixel-coordinate quad into ``[0, 1]``, clamped to the
+    frame."""
     return [
-        x0 / width,
-        y0 / height,
-        max(x1 - x0, 0.0) / width,
-        max(y1 - y0, 0.0) / height,
+        (
+            min(max(float(x) / width, 0.0), 1.0),
+            min(max(float(y) / height, 0.0), 1.0),
+        )
+        for x, y in poly
     ]
 
 
@@ -162,9 +158,7 @@ class PaddleOCRDetectionOutputProcessor(fout.OutputProcessor):
                 score = float(score)
                 if confidence_thresh is not None and score < confidence_thresh:
                     continue
-                points = [
-                    [(float(x) / width, float(y) / height) for x, y in poly]
-                ]
+                points = [_normalize_quad(poly, width, height)]
                 polylines.append(
                     fol.Polyline(
                         label="text",
@@ -212,7 +206,9 @@ class PaddleOCROutputProcessor(fout.OutputProcessor):
                     continue
                 detection = fol.Detection(
                     label=text,
-                    bounding_box=_quad_to_bbox(poly, width, height),
+                    bounding_box=fout._polyline_to_bbox(
+                        [_normalize_quad(poly, width, height)]
+                    ),
                     confidence=rec_score,
                 )
                 detection["det_confidence"] = float(det_score)

--- a/fiftyone/utils/paddleocr.py
+++ b/fiftyone/utils/paddleocr.py
@@ -1,0 +1,412 @@
+"""
+`PP-OCRv6 <https://huggingface.co/collections/PaddlePaddle/pp-ocrv6>`_
+(PaddleOCR) wrapper for the FiftyOne Model Zoo.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import logging
+
+import numpy as np
+
+import fiftyone.core.labels as fol
+import fiftyone.core.utils as fou
+import fiftyone.utils.torch as fout
+import fiftyone.zoo.models as fozm
+
+fou.ensure_torch()
+
+logger = logging.getLogger(__name__)
+
+# The PP-OCRv6 safetensors weights are run through paddleocr's ``transformers``
+# engine (torch only, no paddlepaddle). That engine needs a transformers new
+# enough to expose ``AutoModelForTextRecognition`` and the PP-OCR model types;
+# 5.0.0 (the version pinned in some enterprise images) is too old.
+_MIN_TRANSFORMERS = "transformers>=5.13"
+
+
+def _ensure_paddleocr():
+    fou.ensure_package("paddleocr")
+    fou.ensure_package(_MIN_TRANSFORMERS)
+
+
+paddleocr = fou.lazy_import("paddleocr", callback=_ensure_paddleocr)
+
+from PIL import Image as PILImage
+
+DEFAULT_DET_MODEL = "PP-OCRv6_medium_det"
+DEFAULT_REC_MODEL = "PP-OCRv6_medium_rec"
+
+
+def _to_numpy_bgr(img):
+    """Converts a raw model input (PIL image, HWC uint8 numpy array, or CHW
+    torch tensor) to a contiguous HWC uint8 BGR numpy array, the format
+    paddleocr's predictors consume for in-memory inputs."""
+    try:
+        import torch
+
+        if isinstance(img, torch.Tensor):
+            img = img.detach().cpu().numpy()
+            if img.ndim == 3 and img.shape[0] in (1, 3, 4):
+                img = np.transpose(img, (1, 2, 0))
+    except ImportError:
+        pass
+
+    if isinstance(img, PILImage.Image):
+        img = np.asarray(img.convert("RGB"))
+
+    img = np.asarray(img)
+
+    if np.issubdtype(img.dtype, np.floating):
+        if img.max() <= 1.0:
+            img = img * 255.0
+        img = np.clip(img, 0, 255)
+    img = img.astype(np.uint8)
+
+    if img.ndim == 2:
+        img = np.stack([img] * 3, axis=-1)
+    if img.shape[2] == 4:
+        img = img[:, :, :3]
+
+    # RGB (FiftyOne/PIL) -> BGR (paddleocr/cv2)
+    return np.ascontiguousarray(img[:, :, ::-1])
+
+
+def _quad_to_bbox(poly, width, height):
+    """Axis-aligned ``[x, y, w, h]`` in ``[0, 1]`` enclosing a quad polygon."""
+    xs = [float(p[0]) for p in poly]
+    ys = [float(p[1]) for p in poly]
+    x0 = max(min(xs), 0.0)
+    y0 = max(min(ys), 0.0)
+    x1 = min(max(xs), float(width))
+    y1 = min(max(ys), float(height))
+    return [
+        x0 / width,
+        y0 / height,
+        max(x1 - x0, 0.0) / width,
+        max(y1 - y0, 0.0) / height,
+    ]
+
+
+def _rotate_crop(img_bgr, poly):
+    """Perspective-warps a detected quad to a horizontal text-line crop, the
+    standard PaddleOCR ``get_rotate_crop_image`` used before recognition so
+    rotated text lines are read correctly."""
+    import cv2
+
+    points = np.array(poly, dtype=np.float32)
+    crop_w = int(
+        max(
+            np.linalg.norm(points[0] - points[1]),
+            np.linalg.norm(points[2] - points[3]),
+        )
+    )
+    crop_h = int(
+        max(
+            np.linalg.norm(points[0] - points[3]),
+            np.linalg.norm(points[1] - points[2]),
+        )
+    )
+    if crop_w < 1 or crop_h < 1:
+        return None
+
+    pts_std = np.float32([[0, 0], [crop_w, 0], [crop_w, crop_h], [0, crop_h]])
+    matrix = cv2.getPerspectiveTransform(points, pts_std)
+    dst = cv2.warpPerspective(
+        img_bgr,
+        matrix,
+        (crop_w, crop_h),
+        borderMode=cv2.BORDER_REPLICATE,
+        flags=cv2.INTER_CUBIC,
+    )
+    # Rotate near-vertical crops upright, as PaddleOCR does.
+    if dst.shape[0] * 1.0 / max(dst.shape[1], 1) >= 1.5:
+        dst = np.rot90(dst)
+    return np.ascontiguousarray(dst)
+
+
+class PaddleOCRDetectionOutputProcessor(fout.OutputProcessor):
+    """Output processor for :class:`PaddleOCRDetectionModel`.
+
+    Converts per-image ``dt_polys`` / ``dt_scores`` into
+    :class:`fiftyone.core.labels.Polylines`, one closed polyline per detected
+    text region. Each image carries its own ``(width, height)``, so the
+    normalization is correct for mixed-size batches.
+    """
+
+    def __init__(self, classes=None, **kwargs):
+        self.classes = classes
+
+    def __call__(self, output, frame_size, confidence_thresh=None, **kwargs):
+        results = []
+        for res in output:
+            width = res["width"]
+            height = res["height"]
+            polylines = []
+            for poly, score in zip(res["polys"], res["scores"]):
+                score = float(score)
+                if confidence_thresh is not None and score < confidence_thresh:
+                    continue
+                points = [
+                    [(float(x) / width, float(y) / height) for x, y in poly]
+                ]
+                polylines.append(
+                    fol.Polyline(
+                        label="text",
+                        points=points,
+                        confidence=score,
+                        closed=True,
+                        filled=False,
+                    )
+                )
+            results.append(fol.Polylines(polylines=polylines))
+        return results
+
+
+class PaddleOCROutputProcessor(fout.OutputProcessor):
+    """Output processor for :class:`PaddleOCRModel`.
+
+    Converts per-image detection + recognition output into
+    :class:`fiftyone.core.labels.Detections`, one detection per text region
+    whose ``label`` is the recognized string, ``confidence`` is the
+    recognition score, and ``det_confidence`` attribute is the detection score.
+    """
+
+    def __init__(self, classes=None, **kwargs):
+        self.classes = classes
+
+    def __call__(self, output, frame_size, confidence_thresh=None, **kwargs):
+        results = []
+        for res in output:
+            width = res["width"]
+            height = res["height"]
+            detections = []
+            for poly, det_score, text, rec_score in zip(
+                res["polys"],
+                res["det_scores"],
+                res["texts"],
+                res["rec_scores"],
+            ):
+                if not text:
+                    continue
+                rec_score = float(rec_score)
+                if (
+                    confidence_thresh is not None
+                    and rec_score < confidence_thresh
+                ):
+                    continue
+                detection = fol.Detection(
+                    label=text,
+                    bounding_box=_quad_to_bbox(poly, width, height),
+                    confidence=rec_score,
+                )
+                detection["det_confidence"] = float(det_score)
+                detections.append(detection)
+            results.append(fol.Detections(detections=detections))
+        return results
+
+
+class PaddleOCRDetectionModelConfig(
+    fout.TorchImageModelConfig, fozm.HasZooModel
+):
+    """Configuration for running a :class:`PaddleOCRDetectionModel`.
+
+    Args:
+        det_model_name ("PP-OCRv6_medium_det"): the PP-OCR text-detection model
+            name to run through paddleocr's ``transformers`` engine
+    """
+
+    def __init__(self, d):
+        d = self.init(d)
+        super().__init__(d)
+        self.det_model_name = self.parse_string(
+            d, "det_model_name", default=DEFAULT_DET_MODEL
+        )
+        self.raw_inputs = True
+        if self.output_processor_cls is None:
+            self.output_processor_cls = (
+                "fiftyone.utils.paddleocr.PaddleOCRDetectionOutputProcessor"
+            )
+
+
+class PaddleOCRDetectionModel(fout.TorchImageModel):
+    """FiftyOne wrapper for PP-OCRv6 text detection.
+
+    Detects text regions and returns a
+    :class:`fiftyone.core.labels.Polylines` per image (one closed quad per
+    text region, ``label="text"``, ``confidence`` = detection score). Runs on
+    torch via paddleocr's ``transformers`` engine (no paddlepaddle).
+
+    Example::
+
+        import fiftyone as fo
+        import fiftyone.zoo as foz
+
+        dataset = foz.load_zoo_dataset("quickstart", max_samples=5)
+        model = foz.load_zoo_model("paddle-ocr-v6-medium-det-torch")
+        dataset.apply_model(model, label_field="text_regions")
+        session = fo.launch_app(dataset)
+
+    Args:
+        config: a :class:`PaddleOCRDetectionModelConfig`
+    """
+
+    def _download_model(self, config):
+        pass  # paddleocr downloads the model on first load
+
+    def _load_model(self, config):
+        return paddleocr.TextDetection(
+            model_name=config.det_model_name, engine="transformers"
+        )
+
+    @property
+    def media_type(self):
+        return "image"
+
+    def _forward_pass(self, imgs):
+        out = []
+        for img in imgs:
+            arr = _to_numpy_bgr(img)
+            height, width = arr.shape[:2]
+            polys, scores = [], []
+            try:
+                for res in self._model.predict(input=arr, batch_size=1):
+                    r = res.json["res"]
+                    polys.extend(r.get("dt_polys") or [])
+                    scores.extend(r.get("dt_scores") or [])
+            except Exception as e:  # per-image guard
+                logger.warning("PP-OCR detection failed on an image: %s", e)
+            out.append(
+                {
+                    "width": width,
+                    "height": height,
+                    "polys": polys,
+                    "scores": scores,
+                }
+            )
+        return out
+
+
+class PaddleOCRModelConfig(fout.TorchImageModelConfig, fozm.HasZooModel):
+    """Configuration for running a :class:`PaddleOCRModel`.
+
+    Args:
+        det_model_name ("PP-OCRv6_medium_det"): the PP-OCR text-detection model
+        rec_model_name ("PP-OCRv6_medium_rec"): the PP-OCR text-recognition
+            model
+    """
+
+    def __init__(self, d):
+        d = self.init(d)
+        super().__init__(d)
+        self.det_model_name = self.parse_string(
+            d, "det_model_name", default=DEFAULT_DET_MODEL
+        )
+        self.rec_model_name = self.parse_string(
+            d, "rec_model_name", default=DEFAULT_REC_MODEL
+        )
+        self.raw_inputs = True
+        if self.output_processor_cls is None:
+            self.output_processor_cls = (
+                "fiftyone.utils.paddleocr.PaddleOCROutputProcessor"
+            )
+
+
+class PaddleOCRModel(fout.TorchImageModel):
+    """FiftyOne wrapper for the PP-OCRv6 OCR pipeline (detection + recognition).
+
+    Detects text regions with a PP-OCR detection model, crops each region, and
+    reads it with a PP-OCR recognition model, returning a
+    :class:`fiftyone.core.labels.Detections` per image whose ``label`` is the
+    recognized string and ``confidence`` is the recognition score (the
+    detection score is stored in a ``det_confidence`` attribute). The two
+    component predictors are chained directly (rather than via paddleocr's
+    ``PaddleOCR`` pipeline class) so the crop and the FiftyOne mapping stay
+    under the wrapper's control. Runs on torch via paddleocr's ``transformers``
+    engine (no paddlepaddle).
+
+    Example::
+
+        import fiftyone as fo
+        import fiftyone.zoo as foz
+
+        dataset = foz.load_zoo_dataset("quickstart", max_samples=5)
+        model = foz.load_zoo_model("paddle-ocr-v6-medium-torch")
+        dataset.apply_model(model, label_field="ocr")
+        session = fo.launch_app(dataset)
+
+    Args:
+        config: a :class:`PaddleOCRModelConfig`
+    """
+
+    def __init__(self, config):
+        self._rec_model = None
+        super().__init__(config)
+
+    def _download_model(self, config):
+        pass  # paddleocr downloads the models on first load
+
+    def _load_model(self, config):
+        self._rec_model = paddleocr.TextRecognition(
+            model_name=config.rec_model_name, engine="transformers"
+        )
+        return paddleocr.TextDetection(
+            model_name=config.det_model_name, engine="transformers"
+        )
+
+    @property
+    def media_type(self):
+        return "image"
+
+    def _forward_pass(self, imgs):
+        out = []
+        for img in imgs:
+            arr = _to_numpy_bgr(img)
+            height, width = arr.shape[:2]
+            polys, det_scores = [], []
+            try:
+                for res in self._model.predict(input=arr, batch_size=1):
+                    r = res.json["res"]
+                    polys.extend(r.get("dt_polys") or [])
+                    det_scores.extend(r.get("dt_scores") or [])
+            except Exception as e:
+                logger.warning("PP-OCR detection failed on an image: %s", e)
+
+            texts = [""] * len(polys)
+            rec_scores = [0.0] * len(polys)
+            crops, crop_idx = [], []
+            for i, poly in enumerate(polys):
+                crop = _rotate_crop(arr, poly)
+                if crop is not None and crop.size > 0:
+                    crops.append(crop)
+                    crop_idx.append(i)
+
+            if crops:
+                try:
+                    rec_out = list(
+                        self._rec_model.predict(
+                            input=crops, batch_size=len(crops)
+                        )
+                    )
+                    for i, res in zip(crop_idx, rec_out):
+                        r = res.json["res"]
+                        texts[i] = r.get("rec_text", "")
+                        rec_scores[i] = r.get("rec_score", 0.0)
+                except Exception as e:
+                    logger.warning(
+                        "PP-OCR recognition failed on an image: %s", e
+                    )
+
+            out.append(
+                {
+                    "width": width,
+                    "height": height,
+                    "polys": polys,
+                    "det_scores": det_scores,
+                    "texts": texts,
+                    "rec_scores": rec_scores,
+                }
+            )
+        return out

--- a/fiftyone/utils/paddleocr.py
+++ b/fiftyone/utils/paddleocr.py
@@ -10,6 +10,7 @@
 import logging
 
 import numpy as np
+from PIL import Image as PILImage
 
 import fiftyone.core.labels as fol
 import fiftyone.core.utils as fou
@@ -20,24 +21,31 @@ fou.ensure_torch()
 
 logger = logging.getLogger(__name__)
 
-# The PP-OCRv6 safetensors weights are run through paddleocr's ``transformers``
-# engine (torch only, no paddlepaddle). That engine needs a transformers new
-# enough to expose ``AutoModelForTextRecognition`` and the PP-OCR model types;
-# 5.0.0 (the version pinned in some enterprise images) is too old.
+# PP-OCRv6 models and the ``transformers`` engine require paddleocr>=3.7. The
+# engine needs a transformers version that provides
+# ``AutoModelForTextRecognition`` and the PP-OCR model types
+_MIN_PADDLEOCR = "paddleocr>=3.7"
 _MIN_TRANSFORMERS = "transformers>=5.13"
 
 
 def _ensure_paddleocr():
-    fou.ensure_package("paddleocr")
+    fou.ensure_package(_MIN_PADDLEOCR)
     fou.ensure_package(_MIN_TRANSFORMERS)
 
 
 paddleocr = fou.lazy_import("paddleocr", callback=_ensure_paddleocr)
 
-from PIL import Image as PILImage
-
 DEFAULT_DET_MODEL = "PP-OCRv6_medium_det"
 DEFAULT_REC_MODEL = "PP-OCRv6_medium_rec"
+
+
+def _map_device(device):
+    """Maps a torch device string to paddleocr's device convention."""
+    device = str(device)
+    if device.startswith("cuda"):
+        return "gpu" + device[4:]
+
+    return device
 
 
 def _to_numpy_bgr(img):
@@ -67,7 +75,9 @@ def _to_numpy_bgr(img):
 
     if img.ndim == 2:
         img = np.stack([img] * 3, axis=-1)
-    if img.shape[2] == 4:
+    elif img.shape[2] == 1:
+        img = np.repeat(img, 3, axis=2)
+    elif img.shape[2] == 4:
         img = img[:, :, :3]
 
     # RGB (FiftyOne/PIL) -> BGR (paddleocr/cv2)
@@ -78,10 +88,10 @@ def _quad_to_bbox(poly, width, height):
     """Axis-aligned ``[x, y, w, h]`` in ``[0, 1]`` enclosing a quad polygon."""
     xs = [float(p[0]) for p in poly]
     ys = [float(p[1]) for p in poly]
-    x0 = max(min(xs), 0.0)
-    y0 = max(min(ys), 0.0)
-    x1 = min(max(xs), float(width))
-    y1 = min(max(ys), float(height))
+    x0 = min(max(min(xs), 0.0), float(width))
+    y0 = min(max(min(ys), 0.0), float(height))
+    x1 = min(max(max(xs), 0.0), float(width))
+    y1 = min(max(max(ys), 0.0), float(height))
     return [
         x0 / width,
         y0 / height,
@@ -97,6 +107,9 @@ def _rotate_crop(img_bgr, poly):
     import cv2
 
     points = np.array(poly, dtype=np.float32)
+    if points.shape != (4, 2):
+        return None
+
     crop_w = int(
         max(
             np.linalg.norm(points[0] - points[1]),
@@ -258,7 +271,9 @@ class PaddleOCRDetectionModel(fout.TorchImageModel):
 
     def _load_model(self, config):
         return paddleocr.TextDetection(
-            model_name=config.det_model_name, engine="transformers"
+            model_name=config.det_model_name,
+            engine="transformers",
+            device=_map_device(self._device),
         )
 
     @property
@@ -274,8 +289,10 @@ class PaddleOCRDetectionModel(fout.TorchImageModel):
             try:
                 for res in self._model.predict(input=arr, batch_size=1):
                     r = res.json["res"]
-                    polys.extend(r.get("dt_polys") or [])
-                    scores.extend(r.get("dt_scores") or [])
+                    if r.get("dt_polys") is not None:
+                        polys.extend(r["dt_polys"])
+                    if r.get("dt_scores") is not None:
+                        scores.extend(r["dt_scores"])
             except Exception as e:  # per-image guard
                 logger.warning("PP-OCR detection failed on an image: %s", e)
             out.append(
@@ -296,6 +313,8 @@ class PaddleOCRModelConfig(fout.TorchImageModelConfig, fozm.HasZooModel):
         det_model_name ("PP-OCRv6_medium_det"): the PP-OCR text-detection model
         rec_model_name ("PP-OCRv6_medium_rec"): the PP-OCR text-recognition
             model
+        rec_batch_size (32): the batch size to use when recognizing the
+            detected text-region crops
     """
 
     def __init__(self, d):
@@ -307,6 +326,7 @@ class PaddleOCRModelConfig(fout.TorchImageModelConfig, fozm.HasZooModel):
         self.rec_model_name = self.parse_string(
             d, "rec_model_name", default=DEFAULT_REC_MODEL
         )
+        self.rec_batch_size = self.parse_int(d, "rec_batch_size", default=32)
         self.raw_inputs = True
         if self.output_processor_cls is None:
             self.output_processor_cls = (
@@ -349,11 +369,16 @@ class PaddleOCRModel(fout.TorchImageModel):
         pass  # paddleocr downloads the models on first load
 
     def _load_model(self, config):
+        device = _map_device(self._device)
         self._rec_model = paddleocr.TextRecognition(
-            model_name=config.rec_model_name, engine="transformers"
+            model_name=config.rec_model_name,
+            engine="transformers",
+            device=device,
         )
         return paddleocr.TextDetection(
-            model_name=config.det_model_name, engine="transformers"
+            model_name=config.det_model_name,
+            engine="transformers",
+            device=device,
         )
 
     @property
@@ -369,8 +394,10 @@ class PaddleOCRModel(fout.TorchImageModel):
             try:
                 for res in self._model.predict(input=arr, batch_size=1):
                     r = res.json["res"]
-                    polys.extend(r.get("dt_polys") or [])
-                    det_scores.extend(r.get("dt_scores") or [])
+                    if r.get("dt_polys") is not None:
+                        polys.extend(r["dt_polys"])
+                    if r.get("dt_scores") is not None:
+                        det_scores.extend(r["dt_scores"])
             except Exception as e:
                 logger.warning("PP-OCR detection failed on an image: %s", e)
 
@@ -387,7 +414,10 @@ class PaddleOCRModel(fout.TorchImageModel):
                 try:
                     rec_out = list(
                         self._rec_model.predict(
-                            input=crops, batch_size=len(crops)
+                            input=crops,
+                            batch_size=min(
+                                len(crops), self.config.rec_batch_size
+                            ),
                         )
                     )
                     for i, res in zip(crop_idx, rec_out):

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -11999,6 +11999,177 @@
             ],
             "training_data": [],
             "date_added": "2026-01-28 12:00:00"
+        },
+        {
+            "base_name": "paddle-ocr-v6-medium-det-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "PP-OCRv6 medium text detection model that locates text regions in images",
+            "source": "https://huggingface.co/collections/PaddlePaddle/pp-ocrv6",
+            "author": "PaddlePaddle Authors",
+            "license": "Apache 2.0",
+            "size_bytes": 88020412,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.paddleocr.PaddleOCRDetectionModel",
+                "config": {
+                    "det_model_name": "PP-OCRv6_medium_det"
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "paddleocr", "transformers>=5.13"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["detection", "ocr", "torch"],
+            "training_data": [],
+            "date_added": "2026-07-13 00:00:00"
+        },
+        {
+            "base_name": "paddle-ocr-v6-small-det-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "PP-OCRv6 small text detection model that locates text regions in images",
+            "source": "https://huggingface.co/collections/PaddlePaddle/pp-ocrv6",
+            "author": "PaddlePaddle Authors",
+            "license": "Apache 2.0",
+            "size_bytes": 9938124,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.paddleocr.PaddleOCRDetectionModel",
+                "config": {
+                    "det_model_name": "PP-OCRv6_small_det"
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "paddleocr", "transformers>=5.13"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["detection", "ocr", "torch"],
+            "training_data": [],
+            "date_added": "2026-07-13 00:00:00"
+        },
+        {
+            "base_name": "paddle-ocr-v6-tiny-det-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "PP-OCRv6 tiny text detection model that locates text regions in images",
+            "source": "https://huggingface.co/collections/PaddlePaddle/pp-ocrv6",
+            "author": "PaddlePaddle Authors",
+            "license": "Apache 2.0",
+            "size_bytes": 1786412,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.paddleocr.PaddleOCRDetectionModel",
+                "config": {
+                    "det_model_name": "PP-OCRv6_tiny_det"
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "paddleocr", "transformers>=5.13"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["detection", "ocr", "torch"],
+            "training_data": [],
+            "date_added": "2026-07-13 00:00:00"
+        },
+        {
+            "base_name": "paddle-ocr-v6-medium-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "PP-OCRv6 medium OCR model that detects and reads text in images",
+            "source": "https://huggingface.co/collections/PaddlePaddle/pp-ocrv6",
+            "author": "PaddlePaddle Authors",
+            "license": "Apache 2.0",
+            "size_bytes": 164762132,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.paddleocr.PaddleOCRModel",
+                "config": {
+                    "det_model_name": "PP-OCRv6_medium_det",
+                    "rec_model_name": "PP-OCRv6_medium_rec"
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "paddleocr", "transformers>=5.13"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["ocr", "detection", "torch"],
+            "training_data": [],
+            "date_added": "2026-07-13 00:00:00"
+        },
+        {
+            "base_name": "paddle-ocr-v6-small-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "PP-OCRv6 small OCR model that detects and reads text in images",
+            "source": "https://huggingface.co/collections/PaddlePaddle/pp-ocrv6",
+            "author": "PaddlePaddle Authors",
+            "license": "Apache 2.0",
+            "size_bytes": 31142860,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.paddleocr.PaddleOCRModel",
+                "config": {
+                    "det_model_name": "PP-OCRv6_small_det",
+                    "rec_model_name": "PP-OCRv6_small_rec"
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "paddleocr", "transformers>=5.13"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["ocr", "detection", "torch"],
+            "training_data": [],
+            "date_added": "2026-07-13 00:00:00"
+        },
+        {
+            "base_name": "paddle-ocr-v6-tiny-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "PP-OCRv6 tiny OCR model that detects and reads text in images",
+            "source": "https://huggingface.co/collections/PaddlePaddle/pp-ocrv6",
+            "author": "PaddlePaddle Authors",
+            "license": "Apache 2.0",
+            "size_bytes": 6260676,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.paddleocr.PaddleOCRModel",
+                "config": {
+                    "det_model_name": "PP-OCRv6_tiny_det",
+                    "rec_model_name": "PP-OCRv6_tiny_rec"
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "paddleocr", "transformers>=5.13"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["ocr", "detection", "torch"],
+            "training_data": [],
+            "date_added": "2026-07-13 00:00:00"
         }
     ]
 }

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -12016,7 +12016,7 @@
                 }
             },
             "requirements": {
-                "packages": ["torch", "paddleocr", "transformers>=5.13"],
+                "packages": ["torch", "paddleocr>=3.7", "transformers>=5.13"],
                 "cpu": {
                     "support": true
                 },
@@ -12044,7 +12044,7 @@
                 }
             },
             "requirements": {
-                "packages": ["torch", "paddleocr", "transformers>=5.13"],
+                "packages": ["torch", "paddleocr>=3.7", "transformers>=5.13"],
                 "cpu": {
                     "support": true
                 },
@@ -12072,7 +12072,7 @@
                 }
             },
             "requirements": {
-                "packages": ["torch", "paddleocr", "transformers>=5.13"],
+                "packages": ["torch", "paddleocr>=3.7", "transformers>=5.13"],
                 "cpu": {
                     "support": true
                 },
@@ -12101,7 +12101,7 @@
                 }
             },
             "requirements": {
-                "packages": ["torch", "paddleocr", "transformers>=5.13"],
+                "packages": ["torch", "paddleocr>=3.7", "transformers>=5.13"],
                 "cpu": {
                     "support": true
                 },
@@ -12130,7 +12130,7 @@
                 }
             },
             "requirements": {
-                "packages": ["torch", "paddleocr", "transformers>=5.13"],
+                "packages": ["torch", "paddleocr>=3.7", "transformers>=5.13"],
                 "cpu": {
                     "support": true
                 },
@@ -12159,7 +12159,7 @@
                 }
             },
             "requirements": {
-                "packages": ["torch", "paddleocr", "transformers>=5.13"],
+                "packages": ["torch", "paddleocr>=3.7", "transformers>=5.13"],
                 "cpu": {
                     "support": true
                 },

--- a/tests/unittests/utils/test_paddleocr.py
+++ b/tests/unittests/utils/test_paddleocr.py
@@ -123,21 +123,22 @@ class TestPaddleOCRHelpers:
         assert out.dtype == np.uint8
         assert out.max() == 255
 
-    def test_quad_to_bbox(self):
-        from fiftyone.utils.paddleocr import _quad_to_bbox
+    def test_normalize_quad(self):
+        from fiftyone.utils.paddleocr import _normalize_quad
 
         poly = [[20, 40], [120, 40], [120, 90], [20, 90]]
-        bbox = _quad_to_bbox(poly, width=200, height=100)
-        assert bbox == pytest.approx([0.1, 0.4, 0.5, 0.5])
+        pts = _normalize_quad(poly, width=200, height=100)
+        assert np.allclose(
+            pts, [(0.1, 0.4), (0.6, 0.4), (0.6, 0.9), (0.1, 0.9)]
+        )
 
-    def test_quad_to_bbox_out_of_frame(self):
-        from fiftyone.utils.paddleocr import _quad_to_bbox
+    def test_normalize_quad_out_of_frame(self):
+        from fiftyone.utils.paddleocr import _normalize_quad
 
         # polygon lying wholly outside the frame clamps into [0, 1]
         poly = [[250, 150], [300, 150], [300, 180], [250, 180]]
-        bbox = _quad_to_bbox(poly, width=200, height=100)
-        assert bbox == pytest.approx([1.0, 1.0, 0.0, 0.0])
-        assert all(0.0 <= v <= 1.0 for v in bbox)
+        pts = _normalize_quad(poly, width=200, height=100)
+        assert all(v == 1.0 for p in pts for v in p)
 
     def test_map_device(self):
         from fiftyone.utils.paddleocr import _map_device

--- a/tests/unittests/utils/test_paddleocr.py
+++ b/tests/unittests/utils/test_paddleocr.py
@@ -1,0 +1,269 @@
+"""
+Tests for fiftyone/utils/paddleocr.py PP-OCRv6 model wrappers.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import numpy as np
+from PIL import Image
+import pytest
+
+import fiftyone.core.labels as fol
+
+
+class _FakeRes:
+    """Mimics a paddleocr result object exposing ``.json`` -> {"res": {...}}."""
+
+    def __init__(self, res):
+        self._res = {"res": res}
+
+    @property
+    def json(self):
+        return self._res
+
+
+class _FakeDet:
+    def __init__(self, polys, scores):
+        self._polys = polys
+        self._scores = scores
+
+    def predict(self, input, batch_size=1):
+        return [_FakeRes({"dt_polys": self._polys, "dt_scores": self._scores})]
+
+
+class _FakeRec:
+    def __init__(self, texts_scores):
+        self._texts_scores = texts_scores
+
+    def predict(self, input, batch_size=1):
+        # input is a list of crops; one result per crop, in order
+        return [
+            _FakeRes({"rec_text": t, "rec_score": s})
+            for t, s in self._texts_scores
+        ]
+
+
+class TestPaddleOCRConfig:
+    def test_detection_config_defaults(self):
+        from fiftyone.utils.paddleocr import PaddleOCRDetectionModelConfig
+
+        config = PaddleOCRDetectionModelConfig({})
+        assert config.det_model_name == "PP-OCRv6_medium_det"
+        assert config.raw_inputs is True
+        assert config.output_processor_cls == (
+            "fiftyone.utils.paddleocr.PaddleOCRDetectionOutputProcessor"
+        )
+
+    def test_detection_config_custom_model(self):
+        from fiftyone.utils.paddleocr import PaddleOCRDetectionModelConfig
+
+        config = PaddleOCRDetectionModelConfig(
+            {"det_model_name": "PP-OCRv6_tiny_det"}
+        )
+        assert config.det_model_name == "PP-OCRv6_tiny_det"
+
+    def test_ocr_config_defaults(self):
+        from fiftyone.utils.paddleocr import PaddleOCRModelConfig
+
+        config = PaddleOCRModelConfig({})
+        assert config.det_model_name == "PP-OCRv6_medium_det"
+        assert config.rec_model_name == "PP-OCRv6_medium_rec"
+        assert config.raw_inputs is True
+        assert config.output_processor_cls == (
+            "fiftyone.utils.paddleocr.PaddleOCROutputProcessor"
+        )
+
+
+class TestPaddleOCRHelpers:
+    def test_to_numpy_bgr_flips_channels(self):
+        from fiftyone.utils.paddleocr import _to_numpy_bgr
+
+        # pure-red RGB image -> BGR should put 255 in the last channel
+        rgb = np.zeros((4, 5, 3), dtype=np.uint8)
+        rgb[..., 0] = 255  # red
+        bgr = _to_numpy_bgr(Image.fromarray(rgb))
+        assert bgr.shape == (4, 5, 3)
+        assert bgr.dtype == np.uint8
+        assert np.all(bgr[..., 2] == 255)  # red now in BGR blue-last slot
+        assert np.all(bgr[..., 0] == 0)
+
+    def test_to_numpy_bgr_grayscale_and_rgba(self):
+        from fiftyone.utils.paddleocr import _to_numpy_bgr
+
+        gray = np.full((3, 3), 128, dtype=np.uint8)
+        out = _to_numpy_bgr(gray)
+        assert out.shape == (3, 3, 3)
+
+        rgba = np.zeros((3, 3, 4), dtype=np.uint8)
+        out = _to_numpy_bgr(rgba)
+        assert out.shape == (3, 3, 3)
+
+    def test_to_numpy_bgr_float_input(self):
+        from fiftyone.utils.paddleocr import _to_numpy_bgr
+
+        f = np.ones((2, 2, 3), dtype=np.float32)  # max <= 1.0 -> scaled by 255
+        out = _to_numpy_bgr(f)
+        assert out.dtype == np.uint8
+        assert out.max() == 255
+
+    def test_quad_to_bbox(self):
+        from fiftyone.utils.paddleocr import _quad_to_bbox
+
+        poly = [[20, 40], [120, 40], [120, 90], [20, 90]]
+        bbox = _quad_to_bbox(poly, width=200, height=100)
+        assert bbox == pytest.approx([0.1, 0.4, 0.5, 0.5])
+
+
+class TestPaddleOCRDetectionOutputProcessor:
+    def test_polys_to_polylines(self):
+        from fiftyone.utils.paddleocr import PaddleOCRDetectionOutputProcessor
+
+        proc = PaddleOCRDetectionOutputProcessor()
+        output = [
+            {
+                "width": 100,
+                "height": 50,
+                "polys": [[[10, 5], [90, 5], [90, 45], [10, 45]]],
+                "scores": [0.8],
+            }
+        ]
+        labels = proc(output, (100, 50))
+        assert len(labels) == 1
+        assert isinstance(labels[0], fol.Polylines)
+        pl = labels[0].polylines[0]
+        assert pl.label == "text"
+        assert pl.closed is True
+        assert pl.filled is False
+        assert pl.confidence == pytest.approx(0.8)
+        assert pl.points[0][0] == pytest.approx((0.1, 0.1))
+        assert pl.points[0][2] == pytest.approx((0.9, 0.9))
+
+    def test_confidence_threshold_filters(self):
+        from fiftyone.utils.paddleocr import PaddleOCRDetectionOutputProcessor
+
+        proc = PaddleOCRDetectionOutputProcessor()
+        output = [
+            {
+                "width": 100,
+                "height": 100,
+                "polys": [
+                    [[0, 0], [10, 0], [10, 10], [0, 10]],
+                    [[0, 0], [10, 0], [10, 10], [0, 10]],
+                ],
+                "scores": [0.9, 0.2],
+            }
+        ]
+        labels = proc(output, (100, 100), confidence_thresh=0.5)
+        assert len(labels[0].polylines) == 1
+        assert labels[0].polylines[0].confidence == pytest.approx(0.9)
+
+    def test_empty_image(self):
+        from fiftyone.utils.paddleocr import PaddleOCRDetectionOutputProcessor
+
+        proc = PaddleOCRDetectionOutputProcessor()
+        labels = proc(
+            [{"width": 10, "height": 10, "polys": [], "scores": []}], (10, 10)
+        )
+        assert labels[0].polylines == []
+
+
+class TestPaddleOCROutputProcessor:
+    def test_ocr_to_detections(self):
+        from fiftyone.utils.paddleocr import PaddleOCROutputProcessor
+
+        proc = PaddleOCROutputProcessor()
+        output = [
+            {
+                "width": 200,
+                "height": 100,
+                "polys": [[[20, 40], [120, 40], [120, 90], [20, 90]]],
+                "det_scores": [0.88],
+                "texts": ["Hello"],
+                "rec_scores": [0.97],
+            }
+        ]
+        labels = proc(output, (200, 100))
+        assert isinstance(labels[0], fol.Detections)
+        det = labels[0].detections[0]
+        assert det.label == "Hello"
+        assert det.confidence == pytest.approx(0.97)
+        assert det.get_attribute_value("det_confidence") == pytest.approx(0.88)
+        assert det.bounding_box == pytest.approx([0.1, 0.4, 0.5, 0.5])
+
+    def test_empty_text_skipped(self):
+        from fiftyone.utils.paddleocr import PaddleOCROutputProcessor
+
+        proc = PaddleOCROutputProcessor()
+        output = [
+            {
+                "width": 100,
+                "height": 100,
+                "polys": [
+                    [[0, 0], [10, 0], [10, 10], [0, 10]],
+                    [[0, 0], [10, 0], [10, 10], [0, 10]],
+                ],
+                "det_scores": [0.9, 0.9],
+                "texts": ["", "world"],
+                "rec_scores": [0.0, 0.9],
+            }
+        ]
+        labels = proc(output, (100, 100))
+        assert [d.label for d in labels[0].detections] == ["world"]
+
+    def test_confidence_threshold_filters(self):
+        from fiftyone.utils.paddleocr import PaddleOCROutputProcessor
+
+        proc = PaddleOCROutputProcessor()
+        output = [
+            {
+                "width": 100,
+                "height": 100,
+                "polys": [
+                    [[0, 0], [10, 0], [10, 10], [0, 10]],
+                    [[0, 0], [10, 0], [10, 10], [0, 10]],
+                ],
+                "det_scores": [0.9, 0.9],
+                "texts": ["keep", "drop"],
+                "rec_scores": [0.8, 0.3],
+            }
+        ]
+        labels = proc(output, (100, 100), confidence_thresh=0.5)
+        assert [d.label for d in labels[0].detections] == ["keep"]
+
+
+class TestPaddleOCRForwardPass:
+    def test_detection_forward_pass(self):
+        from fiftyone.utils.paddleocr import PaddleOCRDetectionModel
+
+        model = PaddleOCRDetectionModel.__new__(PaddleOCRDetectionModel)
+        model._model = _FakeDet(
+            polys=[[[10, 10], [50, 10], [50, 30], [10, 30]]], scores=[0.9]
+        )
+        img = np.zeros((100, 200, 3), dtype=np.uint8)
+        out = model._forward_pass([img])
+        assert out[0]["width"] == 200
+        assert out[0]["height"] == 100
+        assert out[0]["polys"] == [[[10, 10], [50, 10], [50, 30], [10, 30]]]
+        assert out[0]["scores"] == [0.9]
+
+    def test_ocr_forward_pass_chains_det_and_rec(self):
+        pytest.importorskip("cv2")
+        from fiftyone.utils.paddleocr import PaddleOCRModel
+
+        model = PaddleOCRModel.__new__(PaddleOCRModel)
+        model._model = _FakeDet(
+            polys=[[[10, 10], [50, 10], [50, 30], [10, 30]]], scores=[0.9]
+        )
+        model._rec_model = _FakeRec([("hello", 0.95)])
+        img = np.zeros((100, 200, 3), dtype=np.uint8)
+        out = model._forward_pass([img])
+        assert out[0]["polys"] == [[[10, 10], [50, 10], [50, 30], [10, 30]]]
+        assert out[0]["det_scores"] == [0.9]
+        assert out[0]["texts"] == ["hello"]
+        assert out[0]["rec_scores"] == [0.95]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unittests/utils/test_paddleocr.py
+++ b/tests/unittests/utils/test_paddleocr.py
@@ -26,8 +26,9 @@ class _FakeRes:
 
 class _FakeDet:
     def __init__(self, polys, scores):
-        self._polys = polys
-        self._scores = scores
+        # paddleocr returns arrays, not lists
+        self._polys = np.asarray(polys, dtype=np.float32)
+        self._scores = np.asarray(scores, dtype=np.float32)
 
     def predict(self, input, batch_size=1):
         return [_FakeRes({"dt_polys": self._polys, "dt_scores": self._scores})]
@@ -36,9 +37,11 @@ class _FakeDet:
 class _FakeRec:
     def __init__(self, texts_scores):
         self._texts_scores = texts_scores
+        self.last_batch_size = None
 
     def predict(self, input, batch_size=1):
         # input is a list of crops; one result per crop, in order
+        self.last_batch_size = batch_size
         return [
             _FakeRes({"rec_text": t, "rec_score": s})
             for t, s in self._texts_scores
@@ -70,10 +73,17 @@ class TestPaddleOCRConfig:
         config = PaddleOCRModelConfig({})
         assert config.det_model_name == "PP-OCRv6_medium_det"
         assert config.rec_model_name == "PP-OCRv6_medium_rec"
+        assert config.rec_batch_size == 32
         assert config.raw_inputs is True
         assert config.output_processor_cls == (
             "fiftyone.utils.paddleocr.PaddleOCROutputProcessor"
         )
+
+    def test_ocr_config_custom_rec_batch_size(self):
+        from fiftyone.utils.paddleocr import PaddleOCRModelConfig
+
+        config = PaddleOCRModelConfig({"rec_batch_size": 8})
+        assert config.rec_batch_size == 8
 
 
 class TestPaddleOCRHelpers:
@@ -96,6 +106,11 @@ class TestPaddleOCRHelpers:
         out = _to_numpy_bgr(gray)
         assert out.shape == (3, 3, 3)
 
+        gray_hw1 = np.full((3, 3, 1), 128, dtype=np.uint8)
+        out = _to_numpy_bgr(gray_hw1)
+        assert out.shape == (3, 3, 3)
+        assert np.all(out == 128)
+
         rgba = np.zeros((3, 3, 4), dtype=np.uint8)
         out = _to_numpy_bgr(rgba)
         assert out.shape == (3, 3, 3)
@@ -114,6 +129,22 @@ class TestPaddleOCRHelpers:
         poly = [[20, 40], [120, 40], [120, 90], [20, 90]]
         bbox = _quad_to_bbox(poly, width=200, height=100)
         assert bbox == pytest.approx([0.1, 0.4, 0.5, 0.5])
+
+    def test_quad_to_bbox_out_of_frame(self):
+        from fiftyone.utils.paddleocr import _quad_to_bbox
+
+        # polygon lying wholly outside the frame clamps into [0, 1]
+        poly = [[250, 150], [300, 150], [300, 180], [250, 180]]
+        bbox = _quad_to_bbox(poly, width=200, height=100)
+        assert bbox == pytest.approx([1.0, 1.0, 0.0, 0.0])
+        assert all(0.0 <= v <= 1.0 for v in bbox)
+
+    def test_map_device(self):
+        from fiftyone.utils.paddleocr import _map_device
+
+        assert _map_device("cpu") == "cpu"
+        assert _map_device("cuda") == "gpu"
+        assert _map_device("cuda:1") == "gpu:1"
 
 
 class TestPaddleOCRDetectionOutputProcessor:
@@ -245,24 +276,54 @@ class TestPaddleOCRForwardPass:
         out = model._forward_pass([img])
         assert out[0]["width"] == 200
         assert out[0]["height"] == 100
-        assert out[0]["polys"] == [[[10, 10], [50, 10], [50, 30], [10, 30]]]
-        assert out[0]["scores"] == [0.9]
+        assert np.allclose(
+            out[0]["polys"], [[[10, 10], [50, 10], [50, 30], [10, 30]]]
+        )
+        assert np.allclose(out[0]["scores"], [0.9])
 
     def test_ocr_forward_pass_chains_det_and_rec(self):
         pytest.importorskip("cv2")
-        from fiftyone.utils.paddleocr import PaddleOCRModel
+        from fiftyone.utils.paddleocr import (
+            PaddleOCRModel,
+            PaddleOCRModelConfig,
+        )
 
         model = PaddleOCRModel.__new__(PaddleOCRModel)
+        model.config = PaddleOCRModelConfig({})
         model._model = _FakeDet(
             polys=[[[10, 10], [50, 10], [50, 30], [10, 30]]], scores=[0.9]
         )
         model._rec_model = _FakeRec([("hello", 0.95)])
         img = np.zeros((100, 200, 3), dtype=np.uint8)
         out = model._forward_pass([img])
-        assert out[0]["polys"] == [[[10, 10], [50, 10], [50, 30], [10, 30]]]
-        assert out[0]["det_scores"] == [0.9]
+        assert np.allclose(
+            out[0]["polys"], [[[10, 10], [50, 10], [50, 30], [10, 30]]]
+        )
+        assert np.allclose(out[0]["det_scores"], [0.9])
         assert out[0]["texts"] == ["hello"]
         assert out[0]["rec_scores"] == [0.95]
+        assert model._rec_model.last_batch_size == 1
+
+    def test_ocr_forward_pass_caps_rec_batch_size(self):
+        pytest.importorskip("cv2")
+        from fiftyone.utils.paddleocr import (
+            PaddleOCRModel,
+            PaddleOCRModelConfig,
+        )
+
+        polys = [
+            [[10, 10], [50, 10], [50, 30], [10, 30]],
+            [[60, 10], [100, 10], [100, 30], [60, 30]],
+            [[110, 10], [150, 10], [150, 30], [110, 30]],
+        ]
+        model = PaddleOCRModel.__new__(PaddleOCRModel)
+        model.config = PaddleOCRModelConfig({"rec_batch_size": 2})
+        model._model = _FakeDet(polys=polys, scores=[0.9, 0.9, 0.9])
+        model._rec_model = _FakeRec([("a", 0.9), ("b", 0.9), ("c", 0.9)])
+        img = np.zeros((100, 200, 3), dtype=np.uint8)
+        out = model._forward_pass([img])
+        assert out[0]["texts"] == ["a", "b", "c"]
+        assert model._rec_model.last_batch_size == 2
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Add PP-OCRv6 (PaddleOCR) text detection and OCR models to the model zoo
- New `fiftyone/utils/paddleocr.py` wrapper around the `paddleocr` package's `transformers` engine
- 6 models total: 3 text detection + 3 full OCR (detection + recognition), all Apache-2.0

## Models Added

### Text detection → `fol.Polylines` of text regions
| Model | Params | Size |
|-------|--------|------|
| `paddle-ocr-v6-tiny-det-torch` | 0.44M | 1.8 MB |
| `paddle-ocr-v6-small-det-torch` | 2.5M | 9.9 MB |
| `paddle-ocr-v6-medium-det-torch` | 22M | 88 MB |

### OCR (detection + recognition) → `fol.Detections` with recognized text
| Model | Params (det+rec) | Size |
|-------|------------------|------|
| `paddle-ocr-v6-tiny-torch` | 1.5M | 6.3 MB |
| `paddle-ocr-v6-small-torch` | 7.8M | 31 MB |
| `paddle-ocr-v6-medium-torch` | 41M | 165 MB |

## Usage
```python
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart", max_samples=25)

# Text detection: polylines around text regions
det_model = foz.load_zoo_model("paddle-ocr-v6-medium-det-torch")
dataset.apply_model(det_model, label_field="text_regions")

# OCR: detections whose label is the recognized string
ocr_model = foz.load_zoo_model("paddle-ocr-v6-medium-torch")
dataset.apply_model(ocr_model, label_field="ocr")

session = fo.launch_app(dataset)
```

## Notes

Detection models produce `fol.Polylines`, one per text region. OCR models produce `fol.Detections` whose `label` is the recognized string, `confidence` is the recognition score, and `det_confidence` is the detection score.

## Test plan

- [x] `foz.load_zoo_model()` resolves all 6 manifest entries
- [x] Detection models produce `fol.Polylines` of text regions
- [x] OCR models produce `fol.Detections` with recognized text
- [x] `dataset.apply_model()` for detection and OCR
- [x] Multiple input types (PIL, NumPy)
- [x] Unit tests for output processors, helpers, and detection→recognition chaining


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end PaddleOCR (PP-OCRv6) text detection and recognition support.
  * Outputs detected text regions as polygons and recognition results as FiftyOne detections, including detection confidence.
  * Includes configurable model selection and confidence threshold filtering, with robust preprocessing for different input image formats.
  * Improves resilience by handling per-image failures without stopping the full run.
* **Tests**
  * Added unit tests for preprocessing, quad-to-box conversion, output processors, confidence filtering, and forward-pass behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3285
<!-- enterprise-sync-pr:end -->