### PR TITLE
disable annotation sidebar for multimodal datasets

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Annotate.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Annotate.tsx
@@ -46,6 +46,9 @@ const DISABLED_MESSAGES: Record<
     </p>
   ),
   videoDataset: <p>Annotation isn&rsquo;t supported for video datasets.</p>,
+  multimodalDataset: (
+    <p>Annotation isn&rsquo;t supported for multimodal datasets.</p>
+  ),
 };
 
 const Container = styled.div`

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useCanAnnotate.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useCanAnnotate.ts
@@ -7,7 +7,7 @@ import {
   useGroupSlices,
   useIsGroupDataset,
 } from "@fiftyone/state";
-import { isAnnotationSupported } from "@fiftyone/utilities";
+import { isAnnotationSupported, isMultimodal } from "@fiftyone/utilities";
 import { useRecoilValue } from "recoil";
 
 /**
@@ -22,6 +22,7 @@ export type AnnotationDisabledReason =
   | "generatedView"
   | "groupDatasetNoSupportedSlices"
   | "videoDataset"
+  | "multimodalDataset"
   | null;
 
 export interface CanAnnotateResult {
@@ -54,6 +55,13 @@ export default function useCanAnnotate(): CanAnnotateResult {
     return {
       showAnnotationTab: true,
       disabledReason: "groupDatasetNoSupportedSlices",
+    };
+  }
+
+  if (!isGroup && isMultimodal(currentMediaType)) {
+    return {
+      showAnnotationTab: true,
+      disabledReason: "multimodalDataset",
     };
   }
 

--- a/app/packages/utilities/src/media.ts
+++ b/app/packages/utilities/src/media.ts
@@ -26,7 +26,7 @@ export type RecognizedMediaType =
 export const isAnnotationSupported = (
   mediaType: string | null | undefined,
 ): boolean => {
-  return !!mediaType && !["group"].includes(mediaType);
+  return !!mediaType && !["group", "multimodal"].includes(mediaType);
 };
 
 const DIRECT_3D_SAMPLE_EXTENSIONS = new Set([

--- a/e2e-pw/src/oss/specs/MISSING-annotate-multimodal-disabled.spec.ts
+++ b/e2e-pw/src/oss/specs/MISSING-annotate-multimodal-disabled.spec.ts
@@ -1,0 +1,61 @@
+import { test as base } from "src/oss/fixtures";
+import { GridPom } from "src/oss/poms/grid";
+import { ModalPom } from "src/oss/poms/modal";
+import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
+
+const datasetName = getUniqueDatasetNameWithPrefix(
+  "smoke-annotate-multimodal-disabled",
+);
+
+const test = base.extend<{
+  grid: GridPom;
+  modal: ModalPom;
+}>({
+  grid: async ({ page, eventUtils }, use) => {
+    await use(new GridPom(page, eventUtils));
+  },
+  modal: async ({ page, eventUtils }, use) => {
+    await use(new ModalPom(page, eventUtils));
+  },
+});
+
+test.beforeAll(async ({ fiftyoneLoader, foWebServer }) => {
+  await foWebServer.startWebServer();
+  // ``.mcap`` gives the sample the ``multimodal`` media type, which makes the
+  // whole dataset multimodal (media type can't change after creation).
+  await fiftyoneLoader.executePythonCode(`
+    import fiftyone as fo
+
+    dataset = fo.Dataset("${datasetName}")
+    dataset.add_sample(fo.Sample(filepath="/tmp/${datasetName}.mcap"))
+    dataset.persistent = True
+  `);
+});
+
+test.afterAll(async ({ foWebServer }) => {
+  await foWebServer.stopWebServer();
+});
+
+test.beforeEach(async ({ page, fiftyoneLoader }) => {
+  await fiftyoneLoader.waitUntilGridVisible(page, datasetName);
+});
+
+test.describe.serial("annotate-multimodal-disabled", () => {
+  test("annotate sidebar is disabled for multimodal datasets", async ({
+    grid,
+    modal,
+  }) => {
+    await grid.openFirstSample();
+    // multimodal media has no built-in viewer, so allow the error/unsupported
+    // media state while the sample doc loads
+    await modal.waitForSampleLoadDomAttribute(true);
+
+    await modal.sidebar.switchMode("annotate");
+
+    // the annotate sidebar must refuse to load and explain why, rather than
+    // exposing the annotation tools for an unsupported media type
+    await modal.sidebar.assert.hasDisabledMessage(
+      "supported for multimodal datasets",
+    );
+  });
+});


### PR DESCRIPTION
<!--
Community contributors: target the `community` branch, not `develop`. PRs from
non-members are auto-retargeted to `community`. See CONTRIBUTING.md:
https://github.com/voxel51/fiftyone/blob/develop/CONTRIBUTING.md#community-pull-requests
-->

## 🔗 Related Issues

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->

## 📋 What changes are proposed in this pull request?

- disable annotation sidebar for multimodal datasets

## 🧪 How is this patch tested? If it is not, please explain why.

- add test
<img width="372" height="975" alt="image" src="https://github.com/user-attachments/assets/6dd9857f-dceb-4fa3-beb5-c012835ed441" />


## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3294
<!-- enterprise-sync-pr:end -->