### PR TITLE
Prevent recursive MCAP placement prefetch retries

### DIFF
--- a/app/packages/multimodal/src/adapters/mcap/react/use-mcap-3d-placement-stream.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-mcap-3d-placement-stream.test.tsx
@@ -1,0 +1,144 @@
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  PlaybackProvider,
+  usePlayback,
+} from "@fiftyone/playback/src/lib/playback/PlaybackProvider";
+import { useIsPlayPending } from "@fiftyone/playback/src/lib/playback/use-playback-state";
+import { useEffect, useMemo, useState } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EMPTY_MCAP_FRAME_GRAPH_SUMMARY } from "../frame-transforms";
+import { MCAP_ACTIVE_TIMELINE } from "../types";
+import {
+  McapDataStreamProvider,
+  type McapDataStream,
+  useMcapDataStream,
+  useSetMcapDataStream,
+} from "./mcap-data-stream-context";
+import { createMcapTimelineIndex } from "./mcap-timeline-index";
+import { useMcap3dPlacementStream } from "./use-mcap-3d-placement-stream";
+import type {
+  McapFramePlacementReadinessStatus,
+  McapFrameTransformsState,
+} from "./use-mcap-frame-transforms";
+
+const TIMELINE = createMcapTimelineIndex({
+  activeTimeline: MCAP_ACTIVE_TIMELINE.LOG,
+  endTimeNs: 10_000_000_000n,
+  startTimeNs: 0n,
+});
+
+const DATA_STREAM: McapDataStream = {
+  getTimelineIndex: () => TIMELINE,
+  getTopicCache: () => undefined,
+  sourceKey: "placement-test",
+  subscribeToTopic: () => () => undefined,
+};
+
+afterEach(cleanup);
+
+describe("useMcap3dPlacementStream", () => {
+  it("does not recursively notify playback while prefetching placement", async () => {
+    let playback: ReturnType<typeof usePlayback> | null = null;
+    const prefetchPlacement = vi.fn();
+    const onPlayback = (next: ReturnType<typeof usePlayback>) => {
+      playback = next;
+    };
+
+    render(
+      <PlaybackProvider duration={10} stepInterval={1 / 30}>
+        <McapDataStreamProvider>
+          <DataStreamPublisher />
+          <PlacementHarness
+            onPlayback={onPlayback}
+            onPrefetchPlacement={prefetchPlacement}
+          />
+        </McapDataStreamProvider>
+      </PlaybackProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("placement-status").textContent).toBe(
+        "placement-test:idle:needsFetch",
+      );
+    });
+
+    await act(async () => {
+      playback?.play();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("placement-status").textContent).toBe(
+        "placement-test:pending:loading",
+      );
+    });
+    expect(prefetchPlacement).toHaveBeenCalledWith(0n);
+  });
+});
+
+function DataStreamPublisher() {
+  const publish = useSetMcapDataStream();
+
+  // This effect provides the placement stream with a concrete MCAP timeline.
+  useEffect(() => {
+    publish(DATA_STREAM);
+    return () => publish(null);
+  }, [publish]);
+
+  return null;
+}
+
+function PlacementHarness({
+  onPlayback,
+  onPrefetchPlacement,
+}: {
+  readonly onPlayback: (playback: ReturnType<typeof usePlayback>) => void;
+  readonly onPrefetchPlacement: (timeNs: bigint) => void;
+}) {
+  const dataStream = useMcapDataStream();
+  const isPlayPending = useIsPlayPending();
+  const playback = usePlayback();
+  const [status, setStatus] =
+    useState<McapFramePlacementReadinessStatus>("needsFetch");
+  const frameTransforms = useMemo<McapFrameTransformsState>(
+    () => ({
+      error: null,
+      frameIds: ["lidar"],
+      getPlacementReadiness: ({ frameIds }) => ({ frameIds, status }),
+      indexedDynamicRanges: () => [],
+      prefetchPlacement: (timeNs) => {
+        onPrefetchPlacement(timeNs);
+        setStatus("loading");
+      },
+      resolve: (sourceFrameId, targetFrameId) => ({
+        sourceFrameId,
+        status: "missing",
+        targetFrameId,
+      }),
+      status: "ready",
+      summarizeGraph: () => EMPTY_MCAP_FRAME_GRAPH_SUMMARY,
+    }),
+    [onPrefetchPlacement, status],
+  );
+  const readiness = useMcap3dPlacementStream({
+    active: true,
+    frameIds: ["lidar"],
+    frameTransforms,
+    playbackTimeNs: 0n,
+    streamId: "placement",
+    worldFrameId: "map",
+  });
+
+  // This effect exposes playback controls to the test after the provider mounts.
+  useEffect(() => {
+    onPlayback(playback);
+  }, [onPlayback, playback]);
+
+  return (
+    <div data-testid="placement-status">
+      {`${dataStream?.sourceKey ?? "none"}:${
+        isPlayPending ? "pending" : "idle"
+      }:${readiness.status}`}
+    </div>
+  );
+}

--- a/app/packages/multimodal/src/adapters/mcap/react/use-mcap-3d-placement-stream.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-mcap-3d-placement-stream.ts
@@ -122,7 +122,6 @@ export function useMcap3dPlacementStream({
           return;
         }
         currentTransforms.prefetchPlacement(tick);
-        bumpStreamRangesVersion(store);
       },
     }),
     [active, streamId, store, timeline?.stepNs],


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

Remove the synchronous stream-range notification from MCAP 3D placement prefetch. Pending playback already retries when placement readiness or indexed ranges change; notifying from inside prefetch could re-enter the same retry path until the stack overflowed.

Add a regression test that drives the placement stream from `needsFetch` to `loading` through the real playback provider.

## 🧪 How is this patch tested? If it is not, please explain why.

- `yarn vitest run --no-coverage packages/multimodal/src/adapters/mcap/react/use-mcap-3d-placement-stream.test.tsx packages/multimodal/src/adapters/mcap/react/use-mcap-frame-transforms.test.tsx packages/playback/src/lib/playback/PlaybackProvider.test.tsx` (79 tests)
- `yarn workspace @fiftyone/multimodal check:types`
- `yarn workspace @fiftyone/multimodal check:lint`
- `yarn prettier --check packages/multimodal/src/adapters/mcap/react/use-mcap-3d-placement-stream.ts packages/multimodal/src/adapters/mcap/react/use-mcap-3d-placement-stream.test.tsx`
- Opened a NuScenes MCAP sample, expanded and pinned label tracks, sought repeatedly while paused and playing, and verified placement buffering settled without a crash.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fixes a crash that could occur when seeking or starting playback in MCAP scenes while 3D placement transforms were loading.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved 3D placement stream prefetch behavior by preventing unnecessary stream updates when requesting placement transforms.
  * Added coverage to verify playback readiness transitions and placement prefetch requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3307
<!-- enterprise-sync-pr:end -->