### PR TITLE
[FOEPD-4207] feat: add cgroup-aware get_memory_limit() to core.utils

### DIFF
--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -3128,6 +3128,76 @@ def get_cpu_count():
         return 1
 
 
+# cgroup v1 reports "no limit" as a near-maxint sentinel (rather than a
+# string like v2's "max"); anything at/above this is unlimited.
+_CGROUP_V1_MEMORY_UNLIMITED = 0x7FFFFFFFFFFFF000
+
+
+def get_memory_limit():
+    """Returns the memory limit in bytes available to the current process.
+
+    Analogous to :func:`get_cpu_count`, this reflects container memory
+    limits in environments like Kubernetes (via cgroups) rather than the
+    host's total physical RAM. Use it to size memory-hungry work (e.g. a
+    DuckDB ``memory_limit``) to the container without requiring a
+    hand-set environment variable that matches the deployment's limits.
+
+    The function checks the following sources, in order:
+
+    1. cgroup v2 memory limit (``/sys/fs/cgroup/memory.max``)
+    2. cgroup v1 memory limit
+       (``/sys/fs/cgroup/memory/memory.limit_in_bytes``)
+    3. physical RAM (``os.sysconf``)
+
+    A cgroup limit is capped at physical RAM (a cgroup can nominally be
+    configured above it), and cgroup "unlimited" values (``"max"`` in v2,
+    a near-maxint sentinel in v1) fall through to physical RAM.
+
+    Returns:
+        the memory limit in bytes, or ``None`` if it cannot be determined
+    """
+    try:
+        physical = None
+        try:
+            physical = os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES")
+        except Exception:
+            pass
+
+        cgroup = None
+        if sys.platform.startswith("linux"):
+            # cgroup v2
+            try:
+                with open("/sys/fs/cgroup/memory.max") as f:
+                    value = f.read().strip()
+                    if value != "max":
+                        cgroup = int(value)
+            except Exception:
+                pass
+
+            # cgroup v1 fallback
+            if cgroup is None:
+                try:
+                    with open(
+                        "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+                    ) as f:
+                        value = int(f.read().strip())
+                        if 0 < value < _CGROUP_V1_MEMORY_UNLIMITED:
+                            cgroup = value
+                except Exception:
+                    pass
+
+        candidates = [v for v in (cgroup, physical) if v and v > 0]
+        if not candidates:
+            return None
+
+        # A cgroup can be configured above physical RAM; cap at physical.
+        return min(candidates)
+
+    except Exception:
+        logger.debug("Unable to determine memory limit", exc_info=True)
+        return None
+
+
 sync_task_executor = None
 
 

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -3138,9 +3138,9 @@ def get_memory_limit():
 
     Analogous to :func:`get_cpu_count`, this reflects container memory
     limits in environments like Kubernetes (via cgroups) rather than the
-    host's total physical RAM. Use it to size memory-hungry work (e.g. a
-    DuckDB ``memory_limit``) to the container without requiring a
-    hand-set environment variable that matches the deployment's limits.
+    host's total physical RAM. Use it to size memory-hungry work to the
+    container without requiring a hand-set environment variable that
+    matches the deployment's limits.
 
     The function checks the following sources, in order:
 

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -3147,7 +3147,7 @@ def get_memory_limit():
     1. cgroup v2 memory limit (``/sys/fs/cgroup/memory.max``)
     2. cgroup v1 memory limit
        (``/sys/fs/cgroup/memory/memory.limit_in_bytes``)
-    3. physical RAM (``os.sysconf``)
+    3. physical RAM (``psutil.virtual_memory``)
 
     A cgroup limit is capped at physical RAM (a cgroup can nominally be
     configured above it), and cgroup "unlimited" values (``"max"`` in v2,
@@ -3159,7 +3159,7 @@ def get_memory_limit():
     try:
         physical = None
         try:
-            physical = os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES")
+            physical = psutil.virtual_memory().total
         except Exception:
             pass
 

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -3165,7 +3165,12 @@ def get_memory_limit():
 
         cgroup = None
         if sys.platform.startswith("linux"):
-            # cgroup v2
+            # cgroup v2. Only the leaf ``memory.max`` is read: in a nested
+            # v2 hierarchy this can report "max" while an ancestor cgroup
+            # enforces a lower limit (v2 exposes no "effective" memory file,
+            # unlike cpuset.cpus.effective for CPUs). Same leaf-only
+            # limitation as get_cpu_count(); walking ancestry would be a
+            # larger change.
             try:
                 with open("/sys/fs/cgroup/memory.max") as f:
                     value = f.read().strip()

--- a/tests/unittests/memory_limit_tests.py
+++ b/tests/unittests/memory_limit_tests.py
@@ -5,6 +5,7 @@ FiftyOne memory limit utility unit tests.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+import types
 import unittest
 from unittest.mock import patch
 
@@ -12,7 +13,6 @@ import fiftyone.core.utils as fou
 
 
 _GiB = 1024**3
-_PAGE = 4096
 
 
 def _mock_fs(file_dict):
@@ -28,20 +28,15 @@ def _mock_fs(file_dict):
     return _open
 
 
-def _sysconf(total_bytes):
-    """``os.sysconf`` stand-in reporting ``total_bytes`` of physical RAM."""
-    values = {"SC_PAGE_SIZE": _PAGE, "SC_PHYS_PAGES": total_bytes // _PAGE}
-
-    def _fn(name):
-        return values[name]
-
-    return _fn
+def _vmem(total_bytes):
+    """``psutil.virtual_memory`` stand-in reporting ``total_bytes``."""
+    return types.SimpleNamespace(total=total_bytes)
 
 
 class GetMemoryLimitTests(unittest.TestCase):
     def test_cgroup_v2_limit(self):
         with patch("sys.platform", "linux"), patch(
-            "os.sysconf", side_effect=_sysconf(8 * _GiB)
+            "psutil.virtual_memory", return_value=_vmem(8 * _GiB)
         ), patch(
             "builtins.open",
             _mock_fs({"/sys/fs/cgroup/memory.max": str(2 * _GiB)}),
@@ -50,7 +45,7 @@ class GetMemoryLimitTests(unittest.TestCase):
 
     def test_cgroup_v2_max_falls_through_to_physical(self):
         with patch("sys.platform", "linux"), patch(
-            "os.sysconf", side_effect=_sysconf(8 * _GiB)
+            "psutil.virtual_memory", return_value=_vmem(8 * _GiB)
         ), patch(
             "builtins.open", _mock_fs({"/sys/fs/cgroup/memory.max": "max"})
         ):
@@ -59,7 +54,7 @@ class GetMemoryLimitTests(unittest.TestCase):
     def test_cgroup_v1_limit(self):
         # v2 file absent -> falls back to v1.
         with patch("sys.platform", "linux"), patch(
-            "os.sysconf", side_effect=_sysconf(8 * _GiB)
+            "psutil.virtual_memory", return_value=_vmem(8 * _GiB)
         ), patch(
             "builtins.open",
             _mock_fs(
@@ -71,7 +66,7 @@ class GetMemoryLimitTests(unittest.TestCase):
     def test_cgroup_v1_unlimited_sentinel_falls_through(self):
         sentinel = str(fou._CGROUP_V1_MEMORY_UNLIMITED)
         with patch("sys.platform", "linux"), patch(
-            "os.sysconf", side_effect=_sysconf(8 * _GiB)
+            "psutil.virtual_memory", return_value=_vmem(8 * _GiB)
         ), patch(
             "builtins.open",
             _mock_fs(
@@ -82,7 +77,7 @@ class GetMemoryLimitTests(unittest.TestCase):
 
     def test_cgroup_above_physical_is_capped(self):
         with patch("sys.platform", "linux"), patch(
-            "os.sysconf", side_effect=_sysconf(8 * _GiB)
+            "psutil.virtual_memory", return_value=_vmem(8 * _GiB)
         ), patch(
             "builtins.open",
             _mock_fs({"/sys/fs/cgroup/memory.max": str(16 * _GiB)}),
@@ -91,13 +86,13 @@ class GetMemoryLimitTests(unittest.TestCase):
 
     def test_non_linux_uses_physical(self):
         with patch("sys.platform", "darwin"), patch(
-            "os.sysconf", side_effect=_sysconf(8 * _GiB)
+            "psutil.virtual_memory", return_value=_vmem(8 * _GiB)
         ), patch("builtins.open", _mock_fs({})):
             self.assertEqual(fou.get_memory_limit(), 8 * _GiB)
 
     def test_undeterminable_returns_none(self):
         with patch("sys.platform", "linux"), patch(
-            "os.sysconf", side_effect=OSError
+            "psutil.virtual_memory", side_effect=Exception
         ), patch("builtins.open", _mock_fs({})):
             self.assertIsNone(fou.get_memory_limit())
 

--- a/tests/unittests/memory_limit_tests.py
+++ b/tests/unittests/memory_limit_tests.py
@@ -1,0 +1,106 @@
+"""
+FiftyOne memory limit utility unit tests.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import unittest
+from unittest.mock import patch
+
+import fiftyone.core.utils as fou
+
+
+_GiB = 1024**3
+_PAGE = 4096
+
+
+def _mock_fs(file_dict):
+    """Returns a ``builtins.open`` replacement serving ``file_dict`` and
+    raising ``FileNotFoundError`` for anything else."""
+    from unittest.mock import mock_open
+
+    def _open(path, *args, **kwargs):
+        if path in file_dict:
+            return mock_open(read_data=file_dict[path])()
+        raise FileNotFoundError(path)
+
+    return _open
+
+
+def _sysconf(total_bytes):
+    """``os.sysconf`` stand-in reporting ``total_bytes`` of physical RAM."""
+    values = {"SC_PAGE_SIZE": _PAGE, "SC_PHYS_PAGES": total_bytes // _PAGE}
+
+    def _fn(name):
+        return values[name]
+
+    return _fn
+
+
+class GetMemoryLimitTests(unittest.TestCase):
+    def test_cgroup_v2_limit(self):
+        with patch("sys.platform", "linux"), patch(
+            "os.sysconf", side_effect=_sysconf(8 * _GiB)
+        ), patch(
+            "builtins.open",
+            _mock_fs({"/sys/fs/cgroup/memory.max": str(2 * _GiB)}),
+        ):
+            self.assertEqual(fou.get_memory_limit(), 2 * _GiB)
+
+    def test_cgroup_v2_max_falls_through_to_physical(self):
+        with patch("sys.platform", "linux"), patch(
+            "os.sysconf", side_effect=_sysconf(8 * _GiB)
+        ), patch(
+            "builtins.open", _mock_fs({"/sys/fs/cgroup/memory.max": "max"})
+        ):
+            self.assertEqual(fou.get_memory_limit(), 8 * _GiB)
+
+    def test_cgroup_v1_limit(self):
+        # v2 file absent -> falls back to v1.
+        with patch("sys.platform", "linux"), patch(
+            "os.sysconf", side_effect=_sysconf(8 * _GiB)
+        ), patch(
+            "builtins.open",
+            _mock_fs(
+                {"/sys/fs/cgroup/memory/memory.limit_in_bytes": str(3 * _GiB)}
+            ),
+        ):
+            self.assertEqual(fou.get_memory_limit(), 3 * _GiB)
+
+    def test_cgroup_v1_unlimited_sentinel_falls_through(self):
+        sentinel = str(fou._CGROUP_V1_MEMORY_UNLIMITED)
+        with patch("sys.platform", "linux"), patch(
+            "os.sysconf", side_effect=_sysconf(8 * _GiB)
+        ), patch(
+            "builtins.open",
+            _mock_fs(
+                {"/sys/fs/cgroup/memory/memory.limit_in_bytes": sentinel}
+            ),
+        ):
+            self.assertEqual(fou.get_memory_limit(), 8 * _GiB)
+
+    def test_cgroup_above_physical_is_capped(self):
+        with patch("sys.platform", "linux"), patch(
+            "os.sysconf", side_effect=_sysconf(8 * _GiB)
+        ), patch(
+            "builtins.open",
+            _mock_fs({"/sys/fs/cgroup/memory.max": str(16 * _GiB)}),
+        ):
+            self.assertEqual(fou.get_memory_limit(), 8 * _GiB)
+
+    def test_non_linux_uses_physical(self):
+        with patch("sys.platform", "darwin"), patch(
+            "os.sysconf", side_effect=_sysconf(8 * _GiB)
+        ), patch("builtins.open", _mock_fs({})):
+            self.assertEqual(fou.get_memory_limit(), 8 * _GiB)
+
+    def test_undeterminable_returns_none(self):
+        with patch("sys.platform", "linux"), patch(
+            "os.sysconf", side_effect=OSError
+        ), patch("builtins.open", _mock_fs({})):
+            self.assertIsNone(fou.get_memory_limit())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds `get_memory_limit()` to `fiftyone.core.utils`, the memory counterpart to the existing `get_cpu_count()`. It detects the container memory limit (cgroup v2 `memory.max`, then cgroup v1 `memory.limit_in_bytes`) instead of the host's total physical RAM, caps a cgroup limit at physical RAM, falls back to physical RAM, and returns `None` when it can't be determined.

This lets callers size memory-hungry work to the container in orchestrated environments (e.g. Kubernetes). Pure addition; no existing behavior changes.

## How is this patch tested?

`tests/unittests/memory_limit_tests.py` covers cgroup v2/v1 parsing, the `"max"`/near-maxint "unlimited" sentinels, the physical-RAM fallback, the cap-at-physical rule, and the undeterminable (`None`) case by mocking the filesystem and `os.sysconf`. 7 tests, all passing.

## What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [x] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added container-aware memory limit detection to cap per-process memory based on cgroup settings.
  * Uses cgroup v2 first, then cgroup v1, with a fallback to system physical memory.
  * Handles “unlimited” and invalid configurations safely.

* **Tests**
  * Added unit tests covering cgroup v2/v1 parsing, fallbacks, capping above physical RAM, non-Linux behavior, and undeterminable cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3313
<!-- enterprise-sync-pr:end -->