### PR TITLE
fix editing primitives

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/serialization.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/serialization.ts
@@ -101,7 +101,7 @@ export function parseDatabaseValue(
   // original database value through setField) are already-serialized ISO
   // strings — parse them back into Date instances so the picker shows the
   // correct value instead of falling back to "now".
-  if ((type === "date" || type === "datetime") && typeof value === "string") {
+  if ((_type === "date" || _type === "datetime") && typeof value === "string") {
     const parsed = new Date(value);
     if (!Number.isNaN(parsed.getTime())) {
       return parsed;


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

resolves a parameter/type issue causing primitive editing to fail

## 🧪 How is this patch tested? If it is not, please explain why.

tested locally

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed date and date-time values imported from ISO strings so they are correctly recognized and handled as dates instead of remaining as raw text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3312
<!-- enterprise-sync-pr:end -->