### PR TITLE
Fix mask persistence during annotation editing under autosave

### DIFF
--- a/app/packages/lighter/src/overlay/DetectionOverlay.test.ts
+++ b/app/packages/lighter/src/overlay/DetectionOverlay.test.ts
@@ -71,3 +71,46 @@ describe("DetectionOverlay.applyLabel mask drop", () => {
     expect(overlay.hasMask()).toBe(false);
   });
 });
+
+describe("DetectionOverlay.applyLabel gesture guard", () => {
+  // Regression: an autosave-tick reconcile reprojects the OLD committed box
+  // while the user is still painting/resizing. Painting outside the box grows
+  // the live bounds, so the reproject's (narrower) box must not overwrite them —
+  // onPointerUp's paintEnd(this.bounds) would otherwise bake the mask against
+  // the stale bounds and squash it.
+  const setInteracting = (overlay: DetectionOverlay, state: string): void => {
+    (overlay as unknown as { interactionState: string }).interactionState =
+      state;
+  };
+
+  it("does not clobber live bounds while a gesture is in flight", () => {
+    const overlay = makeOverlay();
+    overlay.applyLabel({
+      label: "vehicle",
+      bounding_box: [0.1, 0.1, 0.4, 0.4],
+    });
+    const liveBounds = { ...overlay.relativeBounds };
+
+    setInteracting(overlay, "PAINTING");
+    // the tick reprojects the old, narrow committed box
+    overlay.applyLabel({
+      label: "vehicle",
+      bounding_box: [0.5, 0.1, 0.02, 0.4],
+    });
+
+    expect(overlay.relativeBounds).toEqual(liveBounds);
+  });
+
+  it("does not drop the mask on a mask-less reproject during a gesture", () => {
+    const overlay = makeOverlay();
+    vi.spyOn(maskOf(overlay), "hasPendingEncode").mockReturnValue(false);
+
+    setInteracting(overlay, "PAINTING");
+    overlay.applyLabel({
+      label: "vehicle",
+      bounding_box: [0.1, 0.1, 0.2, 0.2],
+    });
+
+    expect(overlay.hasMask()).toBe(true);
+  });
+});

--- a/app/packages/lighter/src/overlay/DetectionOverlay.ts
+++ b/app/packages/lighter/src/overlay/DetectionOverlay.ts
@@ -154,6 +154,18 @@ export class DetectionOverlay
   applyLabel(label: DetectionLabel) {
     super.applyLabel(label);
 
+    // A reproject (e.g. the autosave tick's server-echo reconcile) must not
+    // clobber an overlay whose gesture is still in flight: the live bounds and
+    // mask canvas are the source of truth until the gesture commits on
+    // pointer-up. Overwriting #relativeBounds mid-paint/resize reverts to the
+    // old committed box, and onPointerUp's paintEnd(this.bounds) then bakes the
+    // mask against those stale bounds — the reported squash. (Painting outside
+    // the box auto-expands it, so the live box is legitimately wider than the
+    // committed one.) Base label metadata is already synced via super above.
+    if (this.isInteracting()) {
+      return;
+    }
+
     if (label.bounding_box) {
       const [x, y, w, h] = label.bounding_box;
       this.#relativeBounds = { x, y, width: w, height: h };

--- a/app/packages/lighter/src/overlay/MaskCanvas.test.ts
+++ b/app/packages/lighter/src/overlay/MaskCanvas.test.ts
@@ -159,6 +159,53 @@ describe("MaskCanvas.mergeFrom", () => {
   });
 });
 
+describe("MaskCanvas.updateSource guards an in-flight paint encode", () => {
+  // Regression: a server-echo reconcile reprojects onto the overlay mid-edit.
+  // While a paint encode is still in flight, those canvas pixels are an
+  // uncommitted stroke absent from any source, so a reset() would drop them (and
+  // abort the encode). Once the encode resolves the pixels live in the source, so
+  // a genuine reproject (e.g. undo) must be free to replace the canvas.
+
+  const flushEncode = async (): Promise<void> => {
+    // paintEnd's encode chain is then→finally; flush enough microtasks for the
+    // finally (which decrements encodingInFlight) to run.
+    for (let i = 0; i < 5; i++) await Promise.resolve();
+  };
+
+  it("keeps the editing canvas while a paint encode is in flight (returns false)", () => {
+    const bounds: Rect = { x: 0, y: 0, width: 10, height: 10 };
+    const mc = seedCanvas(bounds, { x: 0, y: 0, width: 4, height: 4 });
+
+    // paintEnd increments encodingInFlight (and rebuilds the canvas); the encode
+    // has not resolved yet, so capture the post-paint canvas as the baseline.
+    mc.paintEnd(bounds);
+    const canvasInFlight = mc.getPreviewSource();
+    expect(canvasInFlight).toBeInstanceOf(HTMLCanvasElement);
+
+    expect(mc.updateSource("echoed-serialized-mask")).toBe(false);
+    expect(mc.getPreviewSource()).toBe(canvasInFlight);
+  });
+
+  it("adopts a new source once the encode has resolved (returns true)", async () => {
+    const bounds: Rect = { x: 0, y: 0, width: 10, height: 10 };
+    const mc = seedCanvas(bounds, { x: 0, y: 0, width: 4, height: 4 });
+
+    mc.paintEnd(bounds);
+    await flushEncode();
+
+    // An undo / genuine reproject carrying a different value must replace the
+    // canvas — the earlier over-broad "canvas exists" guard blocked this and left
+    // undo restoring bounds but not the mask.
+    expect(mc.updateSource("different-mask")).toBe(true);
+  });
+
+  it("still swaps the source when there is no editing canvas (returns true)", () => {
+    const mc = new MaskCanvas("initial-mask");
+
+    expect(mc.updateSource("different-mask")).toBe(true);
+  });
+});
+
 describe("MaskCanvas.paintEnd shrink", () => {
   it("snaps bounds down to the painted region reported by maskBounds", () => {
     const bounds: Rect = { x: 0, y: 0, width: 20, height: 20 };

--- a/app/packages/lighter/src/overlay/MaskCanvas.ts
+++ b/app/packages/lighter/src/overlay/MaskCanvas.ts
@@ -14,6 +14,7 @@ import type { DrawStyle, Point, Rect } from "../types";
 import {
   createMaskCanvas,
   decodeMask,
+  decodeMaskToRaster,
   encodeMask,
   maskBounds,
   type MaskBounds,
@@ -117,6 +118,14 @@ export class MaskCanvas {
   updateSource(mask?: SerializedMask | OverlayMask): boolean {
     const source = MaskCanvas.extractSource(mask);
     if (source === this.rawMaskData) return false;
+
+    // Never reset while a paint encode is still in flight: those canvas pixels
+    // are an uncommitted stroke not yet reflected in any source, so a reconcile
+    // echo reproject (which carries the older, pre-stroke value) would drop them
+    // — and the in-flight encode bails on the canvas swap, losing the stroke for
+    // good. Once the encode has resolved the pixels live in `source`, so a reset
+    // here is recoverable (ensureCanvas re-seeds from `rawMaskData`).
+    if (this.encodingInFlight > 0) return false;
 
     this.reset();
     this.rawMaskData = source;
@@ -271,9 +280,57 @@ export class MaskCanvas {
       this.context.imageSmoothingEnabled = prevSmoothing;
       this.maskBitmap.close();
       this.maskBitmap = undefined;
+    } else if (this.rawMaskData) {
+      // No decoded bitmap yet — e.g. `updateSource` just reset us from a
+      // reconcile reproject (echo or undo) and the async decode hasn't run. Seed
+      // the canvas synchronously from the raw source so a stroke that begins now
+      // paints onto the existing mask instead of a blank canvas (the mask-drop
+      // bug).
+      this.seedCanvasFromRawSync(width, height);
     }
 
     this.rawMaskData = undefined;
+  }
+
+  /**
+   * Synchronously rasterizes {@link rawMaskData} into the (already-created)
+   * editing canvas, scaled to fit. The raster is color-INDEPENDENT (white+alpha)
+   * to match painted strokes; the display color is applied at draw time via
+   * tint. Best-effort: a decode failure leaves the canvas blank rather than
+   * throwing, matching the pre-seed behavior.
+   */
+  private seedCanvasFromRawSync(width: number, height: number): void {
+    if (!this.rawMaskData || !this.context) return;
+
+    try {
+      const {
+        rgba,
+        width: srcWidth,
+        height: srcHeight,
+        rawPixels,
+      } = decodeMaskToRaster(this.rawMaskData);
+
+      const { maskCanvas: srcCanvas, maskContext: srcContext } =
+        createMaskCanvas(srcWidth, srcHeight);
+      srcContext.putImageData(
+        new ImageData(new Uint8ClampedArray(rgba), srcWidth, srcHeight),
+        0,
+        0,
+      );
+
+      const prevSmoothing = this.context.imageSmoothingEnabled;
+      this.context.imageSmoothingEnabled = false;
+      this.context.drawImage(srcCanvas, 0, 0, width, height);
+      this.context.imageSmoothingEnabled = prevSmoothing;
+
+      // Keep hit-testing working immediately: ensureCanvas clears `rawMaskData`
+      // right after this, so the async decode never runs to backfill
+      // `rawPixels`. Adopt the freshly rasterized pixels now (they're at the
+      // mask's native resolution, which is what containsMaskPixel maps against).
+      this.rawPixels = { src: rawPixels, width: srcWidth, height: srcHeight };
+    } catch (err) {
+      console.error("[MaskCanvas] ensureCanvas sync seed failed:", err);
+    }
   }
 
   /**

--- a/app/packages/lighter/src/utils/index.ts
+++ b/app/packages/lighter/src/utils/index.ts
@@ -1,5 +1,6 @@
 export { createMaskCanvas } from "./createMaskCanvas";
 export { decodeMask } from "./maskDecoding";
+export { decodeMaskToRaster } from "./maskRaster";
 export { encodeMask } from "./maskEncoding";
 export { maskBounds } from "./maskBounds";
 export type { MaskBounds } from "./maskBounds";


### PR DESCRIPTION
## What & why

While annotating detection masks, the autosave tick could corrupt an in-progress edit because a post-persist reconcile **reproject** was applied to an overlay whose gesture had not yet committed. Three distinct symptoms, one root-cause family (a reconcile echo clobbering live, uncommitted edit state):

## Changes

- **`DetectionOverlay.applyLabel`** returns early while `isInteracting()` — a reproject must not overwrite live bounds/mask of an in-flight gesture (base label metadata still syncs). Fixes the squash.
- **`ensureCanvas` now seeds synchronously from `rawMaskData`** when there's no decoded bitmap, so a canvas reset by a reconcile is recoverable on the next stroke. Extracted the synchronous half of decode as `decodeMaskToImageData` (only `createImageBitmap` was ever async).
- **Narrowed the `updateSource` guard** from "canvas exists" to "an encode is in flight" (`encodingInFlight > 0`) — protects only the uncommitted post-stroke window, while letting genuine reprojects (undo, external) replace the mask.

## Test plan

- `app/packages/lighter` unit suite green (147 tests), including new regressions:
  - `DetectionOverlay`: reproject does not clobber live bounds / drop the mask during a gesture.
  - `MaskCanvas`: keeps the canvas while an encode is in flight; adopts a new source once it resolves; swaps source when no canvas.
- Manually verified in the app on an image dataset with masks: (a) paint across an autosave tick, (b) paint-expand the box across a tick, (c) paint then undo — mask reverts to prior pixels, not just resized.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented live overlay bounds and masks from being overwritten while a drag, resize, or paint gesture is in progress.
  * Preserved in-progress paint edits while mask data is being encoded or refreshed.
  * Ensured existing mask content is available immediately when editing begins, preventing strokes from starting on a blank canvas.
* **Tests**
  * Added regression coverage for gesture protection and mask-canvas updates during asynchronous encoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3324
<!-- enterprise-sync-pr:end -->