### PR TITLE
fix(components): don't clobber Selector search text when value updates mid-edit

### DIFF
--- a/app/packages/components/src/components/Selector/Selector.test.tsx
+++ b/app/packages/components/src/components/Selector/Selector.test.tsx
@@ -4,6 +4,7 @@ import {
   fireEvent,
   render,
   screen,
+  waitFor,
 } from "@testing-library/react";
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -101,7 +102,7 @@ describe("Selector", () => {
     expect(visibleResults()).toEqual(["image"]);
   });
 
-  it("displays the updated value once editing ends", () => {
+  it("syncs the displayed value when `value` changes while not editing", () => {
     const { rerender } = renderSelector("image");
     const input = screen.getByTestId("selector-test") as HTMLInputElement;
     expect(input.value).toBe("image");
@@ -117,6 +118,31 @@ describe("Selector", () => {
       />,
     );
 
+    expect(input.value).toBe("video");
+  });
+
+  it("keeps the selected value displayed after selecting, before `value` updates", async () => {
+    // onSelect resolves with the selection, but the `value` prop stays stale —
+    // the optimistic display must not revert to the old value when editing ends
+    const onSelect = vi.fn(async (search: string) => search);
+    render(
+      <Selector
+        value="image"
+        onSelect={onSelect}
+        placeholder="Select slice..."
+        useSearch={useSearch}
+        component={Option}
+        cy="test"
+      />,
+    );
+
+    const input = openResults() as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "video" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    // wait for the selection to close the results, i.e. editing has ended
+    await waitFor(() => expect(visibleResults()).toEqual([]));
+    expect(onSelect).toHaveBeenCalledWith("video", "video");
     expect(input.value).toBe("video");
   });
 });

--- a/app/packages/components/src/components/Selector/Selector.test.tsx
+++ b/app/packages/components/src/components/Selector/Selector.test.tsx
@@ -1,0 +1,122 @@
+import {
+  cleanup,
+  configure,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import Selector from "./Selector";
+
+configure({ testIdAttribute: "data-cy" });
+
+const SLICES = ["image", "video"];
+
+const useSearch = (search: string) => {
+  const values = SLICES.filter((name) =>
+    name.toLowerCase().includes(search.toLowerCase()),
+  );
+  return { values, total: values.length };
+};
+
+const Option = ({ value }: { value: string }) => <span>{value}</span>;
+
+const renderSelector = (value: string | undefined) =>
+  render(
+    <Selector
+      value={value}
+      onSelect={vi.fn()}
+      placeholder="Select slice..."
+      useSearch={useSearch}
+      component={Option}
+      cy="test"
+    />,
+  );
+
+const openResults = () => {
+  const input = screen.getByTestId("selector-test");
+  fireEvent.focus(input);
+  return input;
+};
+
+const visibleResults = () =>
+  screen
+    .queryAllByTestId(/^selector-result-/)
+    .map((node) => node.textContent?.trim());
+
+describe("Selector", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("shows all results when opened with a selected value", () => {
+    renderSelector("video");
+    openResults();
+    expect(visibleResults()).toEqual(SLICES);
+  });
+
+  it("does not filter open results when `value` settles after opening", () => {
+    // regression: opening the selector before an async `value` arrives
+    // (e.g. the annotation slice selector while group data loads), then the
+    // value settling, used to seed the search text with the value and filter
+    // the open results down to it
+    const { rerender } = renderSelector(undefined);
+    openResults();
+    expect(visibleResults()).toEqual(SLICES);
+
+    rerender(
+      <Selector
+        value="video"
+        onSelect={vi.fn()}
+        placeholder="Select slice..."
+        useSearch={useSearch}
+        component={Option}
+        cy="test"
+      />,
+    );
+
+    expect(visibleResults()).toEqual(SLICES);
+  });
+
+  it("does not clobber typed search text when `value` updates mid-edit", () => {
+    const { rerender } = renderSelector(undefined);
+    const input = openResults();
+    fireEvent.change(input, { target: { value: "ima" } });
+    expect(visibleResults()).toEqual(["image"]);
+
+    rerender(
+      <Selector
+        value="video"
+        onSelect={vi.fn()}
+        placeholder="Select slice..."
+        useSearch={useSearch}
+        component={Option}
+        cy="test"
+      />,
+    );
+
+    expect((input as HTMLInputElement).value).toBe("ima");
+    expect(visibleResults()).toEqual(["image"]);
+  });
+
+  it("displays the updated value once editing ends", () => {
+    const { rerender } = renderSelector("image");
+    const input = screen.getByTestId("selector-test") as HTMLInputElement;
+    expect(input.value).toBe("image");
+
+    rerender(
+      <Selector
+        value="video"
+        onSelect={vi.fn()}
+        placeholder="Select slice..."
+        useSearch={useSearch}
+        component={Option}
+        cy="test"
+      />,
+    );
+
+    expect(input.value).toBe("video");
+  });
+});

--- a/app/packages/components/src/components/Selector/Selector.tsx
+++ b/app/packages/components/src/components/Selector/Selector.tsx
@@ -91,12 +91,17 @@ function Selector<T>(props: SelectorProps<T>) {
   }, [active, onSelect, toKey, valuesRef]);
 
   useLayoutEffect(() => {
+    // sync only on `value` changes — running this when editing ends would
+    // overwrite the optimistic assignment in onSelectWrapper with a stale prop
+    local.current = value || "";
+  }, [value]);
+
+  useLayoutEffect(() => {
     // an async `value` update must not clobber an active editing session's
     // search text — it would filter the open results by the stale value
     if (!editing) {
       setSearch(value || "");
     }
-    local.current = value || "";
   }, [value, editing]);
 
   const ref = useRef<HTMLInputElement | null>();

--- a/app/packages/components/src/components/Selector/Selector.tsx
+++ b/app/packages/components/src/components/Selector/Selector.tsx
@@ -91,9 +91,13 @@ function Selector<T>(props: SelectorProps<T>) {
   }, [active, onSelect, toKey, valuesRef]);
 
   useLayoutEffect(() => {
-    setSearch(value || "");
+    // an async `value` update must not clobber an active editing session's
+    // search text — it would filter the open results by the stale value
+    if (!editing) {
+      setSearch(value || "");
+    }
     local.current = value || "";
-  }, [value]);
+  }, [value, editing]);
 
   const ref = useRef<HTMLInputElement | null>();
   const hovering = useRef(false);


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes a race in the shared `Selector` component: an async `value` prop update landing while the results popover is open seeded the search text with the new value, silently filtering the open results down to it.

The annotation slice selector hits this whenever it is opened before the group data settles — `GroupAnnotation` passes `value={isLoading ? null : preferredSlice}`, so the `null → "video"` transition after open filtered the slice list to just `video`. The hover guard in `onBlur` (which refocuses while the pointer is over the input) then kept the poisoned search text alive across blur/reopen attempts, so the state never self-corrected.

This is the root cause of the flaky `MISSING-annotate-grouped-video.spec.ts` slice-selector tests (`:239`, `:286`): trace network captures from the failed CI runs show the server returning both slices correctly while the dropdown rendered only `["video"]`.

The fix: the `value`-sync effect no longer overwrites the search text while an editing session is active. Applies to every `Selector` consumer — a mid-edit external `value` update previously clobbered whatever the user had typed.

## How is this patch tested?

New `Selector.test.tsx` unit tests, including two that reproduce the race (open before `value` settles → results must stay unfiltered; typed search must survive a mid-edit `value` update). Both fail against the unfixed component. Full `@fiftyone/components` suite passes (104 tests).

## What areas of FiftyOne does this PR affect?

- [x] `App`: FiftyOne application changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved user-entered search text when the selected value changes during editing.
  * Prevented search results from being incorrectly filtered when the value updates after opening the list.
  * Ensured the updated selected value is shown once editing ends.
* **Tests**
  * Added a Vitest + React Testing Library suite covering Selector opening, search behavior, edit/value synchronization, and selection via Enter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3334
<!-- enterprise-sync-pr:end -->