### PR TITLE
[1/6] Add VQA and VQAs label types

### DIFF
--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -131,6 +131,8 @@ from .core.labels import (
     Regression,
     Classification,
     Classifications,
+    VQA,
+    VQAs,
     Detection,
     Detections,
     Polyline,

--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -435,6 +435,45 @@ class Classifications(_HasLabelList, Label):
     logits = fof.VectorField()
 
 
+class VQA(_HasID, Label):
+    """A visual question answering (VQA) label.
+
+    Args:
+        question (None): the question about the media
+        answer (None): the answer to the question
+        answers (None): a list of reference answers to the question, for
+            datasets that provide multiple ground truth answers
+        choices (None): a list of allowed answers to the question, for
+            multiple-choice datasets
+        question_type (None): the type of the question
+        answer_type (None): the type of the answer
+        question_id (None): an identifier for the question that can be used
+            to match corresponding labels across fields
+        confidence (None): a confidence in ``[0, 1]`` for the answer
+    """
+
+    question = fof.StringField()
+    answer = fof.StringField()
+    answers = fof.ListField(fof.StringField())
+    choices = fof.ListField(fof.StringField())
+    question_type = fof.StringField()
+    answer_type = fof.StringField()
+    question_id = fof.StringField()
+    confidence = fof.FloatField()
+
+
+class VQAs(_HasLabelList, Label):
+    """A list of VQA labels for a sample.
+
+    Args:
+        vqas (None): a list of :class:`VQA` instances
+    """
+
+    _LABEL_LIST_FIELD = "vqas"
+
+    vqas = fof.ListField(fof.EmbeddedDocumentField(VQA))
+
+
 class Detection(_HasAttributesDict, _HasID, _HasMedia, _HasInstance, Label):
     """An object detection.
 
@@ -1594,6 +1633,7 @@ _LABEL_LIST_FIELDS = (
     Keypoints,
     Polylines,
     TemporalDetections,
+    VQAs,
 )
 
 _PATCHES_FIELDS = (
@@ -1620,6 +1660,7 @@ _SINGLE_LABEL_TO_LIST_MAP = {
     Keypoint: Keypoints,
     Polyline: Polylines,
     TemporalDetection: TemporalDetections,
+    VQA: VQAs,
 }
 
 _LABEL_LIST_TO_SINGLE_MAP = {
@@ -1628,6 +1669,7 @@ _LABEL_LIST_TO_SINGLE_MAP = {
     Keypoints: Keypoint,
     Polylines: Polyline,
     TemporalDetections: TemporalDetection,
+    VQAs: VQA,
 }
 
 

--- a/tests/unittests/label_tests.py
+++ b/tests/unittests/label_tests.py
@@ -1010,6 +1010,94 @@ class ExportMaskTests(unittest.TestCase):
                         )
 
 
+class VQATests(unittest.TestCase):
+    def test_vqa(self):
+        vqa = fo.VQA()
+
+        self.assertIsInstance(vqa.id, str)
+        self.assertIsNone(vqa.question)
+        self.assertIsNone(vqa.answer)
+
+        vqa = fo.VQA(
+            question="What color is the cat?",
+            answer="black",
+            answers=["black", "black", "gray"],
+            choices=["black", "white", "orange"],
+            question_type="what color",
+            answer_type="other",
+            question_id="q1",
+            confidence=0.9,
+        )
+
+        self.assertEqual(vqa.question, "What color is the cat?")
+        self.assertEqual(vqa.answer, "black")
+        self.assertListEqual(vqa.answers, ["black", "black", "gray"])
+        self.assertListEqual(vqa.choices, ["black", "white", "orange"])
+        self.assertEqual(vqa.question_type, "what color")
+        self.assertEqual(vqa.answer_type, "other")
+        self.assertEqual(vqa.question_id, "q1")
+        self.assertAlmostEqual(vqa.confidence, 0.9)
+
+    def test_vqa_serialization(self):
+        vqa = fo.VQA(
+            question="Is there a dog?",
+            answer="yes",
+            answers=["yes", "yes", "no"],
+            question_id="q1",
+            confidence=0.5,
+        )
+
+        d = vqa.to_dict()
+
+        self.assertIsInstance(d["_id"], ObjectId)
+
+        vqa2 = fo.VQA.from_dict(d)
+
+        self.assertEqual(vqa2.id, vqa.id)
+        self.assertEqual(vqa2.question, vqa.question)
+        self.assertEqual(vqa2.answer, vqa.answer)
+        self.assertListEqual(vqa2.answers, vqa.answers)
+        self.assertEqual(vqa2.question_id, vqa.question_id)
+        self.assertAlmostEqual(vqa2.confidence, vqa.confidence)
+
+    def test_vqa_dynamic_attributes(self):
+        vqa = fo.VQA(
+            question="Which option?",
+            answer="a cat",
+            choices=["a cat", "a dog"],
+        )
+
+        vqa["answer_index"] = 0
+        vqa.set_field("grounding_ids", ["abc123"])
+
+        self.assertEqual(vqa["answer_index"], 0)
+        self.assertListEqual(vqa.get_field("grounding_ids"), ["abc123"])
+
+        vqa2 = fo.VQA.from_dict(vqa.to_dict())
+
+        self.assertEqual(vqa2["answer_index"], 0)
+        self.assertListEqual(vqa2["grounding_ids"], ["abc123"])
+
+    def test_vqas_list(self):
+        vqas = fo.VQAs(
+            vqas=[
+                fo.VQA(question="Q1", answer="yes", question_id="q1"),
+                fo.VQA(question="Q2", answer="two", question_id="q2"),
+            ]
+        )
+
+        self.assertEqual(fo.VQAs._LABEL_LIST_FIELD, "vqas")
+        self.assertEqual(len(vqas.vqas), 2)
+        for vqa in vqas.vqas:
+            self.assertIsInstance(vqa, fo.VQA)
+
+        vqas2 = fo.VQAs.from_dict(vqas.to_dict())
+
+        self.assertEqual(len(vqas2.vqas), 2)
+        self.assertEqual(vqas2.vqas[0].question_id, "q1")
+        self.assertEqual(vqas2.vqas[1].answer, "two")
+
+
 if __name__ == "__main__":
     fo.config.show_progress_bars = False
     unittest.main(verbosity=2)

--- a/tests/unittests/label_tests.py
+++ b/tests/unittests/label_tests.py
@@ -1097,6 +1097,56 @@ class VQATests(unittest.TestCase):
         self.assertEqual(vqas2.vqas[0].question_id, "q1")
         self.assertEqual(vqas2.vqas[1].answer, "two")
 
+    @drop_datasets
+    def test_vqas_filter_and_count(self):
+        dataset = fo.Dataset()
+        dataset.add_samples(
+            [
+                fo.Sample(
+                    filepath="image1.jpg",
+                    questions=fo.VQAs(
+                        vqas=[
+                            fo.VQA(
+                                question="Is there a cat?",
+                                answer="yes",
+                                question_id="q1",
+                            ),
+                            fo.VQA(
+                                question="How many cats?",
+                                answer="two",
+                                question_id="q2",
+                            ),
+                        ]
+                    ),
+                ),
+                fo.Sample(
+                    filepath="image2.jpg",
+                    questions=fo.VQAs(
+                        vqas=[
+                            fo.VQA(
+                                question="Is there a dog?",
+                                answer="yes",
+                                question_id="q3",
+                            )
+                        ]
+                    ),
+                ),
+            ]
+        )
+
+        sample = dataset.first()
+
+        self.assertIsInstance(sample["questions"], fo.VQAs)
+        self.assertIsInstance(sample["questions"].vqas[0], fo.VQA)
+
+        counts = dataset.count_values("questions.vqas.answer")
+
+        self.assertDictEqual(counts, {"yes": 2, "two": 1})
+
+        view = dataset.filter_labels("questions", F("answer") == "yes")
+
+        self.assertEqual(view.count("questions.vqas"), 2)
+
 
 if __name__ == "__main__":
     fo.config.show_progress_bars = False


### PR DESCRIPTION


## 🔗 Related Issues

No related issues to link.

## 📋 What changes are proposed in this pull request?

Introduces a first-class **VQA** (visual question answering) label type, the
foundation for VQA data in FiftyOne.

- Adds `VQA` (a single question/answer label) with fields for the question,
  answer, multiple reference answers, allowed choices (multiple-choice),
  question/answer types, a matching ID, and a confidence.
- Adds `VQAs`, the list label holding many `VQA` instances per sample.
- Registers both in the label-list mappings and public exports so they behave
  like every other built-in label across the generic machinery (filtering,
  aggregation, DB round-trip).

**Target base:** `develop`. This is the base of the VQA branch stack — the
evaluation PR (PR 2) and the dataset-format PR (PR 5) build on it.

## 🧪 How is this patch tested? If it is not, please explain why.

- New `VQATests` in `tests/unittests/label_tests.py` cover construction and
  field defaults.
- A DB round-trip test exercises the generic label machinery — value
  aggregation over a nested answer field and `filter_labels` on the answer.
- Verified: `python -m pytest tests/unittests/label_tests.py` → **24 passed**
  (VQA subset `-k vqa` → **5 passed**). TDD history: red without the type →
  green after.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

N/A — the VQA feature set is not surfaced to users until the documentation
lands; the consolidated release note is in the final docs PR (`vqa-docs`).

### What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [x] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `VQA` labels for representing visual question-answer pairs, including questions, answers, choices, types, identifiers, and confidence.
  * Added `VQAs` collections for managing multiple VQA labels.
  * Made VQA labels available through FiftyOne’s top-level interface.
  * Added support for serialization, dynamic attributes, filtering, and counting of VQA labels.

* **Tests**
  * Added coverage for VQA creation, serialization, collections, filtering, and dataset-level operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3331
<!-- enterprise-sync-pr:end -->