### PR TITLE
[4/6] Add App support for VQA label types

### DIFF
--- a/app/packages/looker/src/constants.ts
+++ b/app/packages/looker/src/constants.ts
@@ -8,6 +8,8 @@ import {
   REGRESSION,
   TEMPORAL_DETECTION,
   TEMPORAL_DETECTIONS,
+  VQA,
+  VQAS,
 } from "@fiftyone/utilities";
 
 export const BASE_ALPHA = 0.7;
@@ -39,6 +41,8 @@ export const MOMENT_CLASSIFICATIONS = [
   CLASSIFICATION,
   CLASSIFICATIONS,
   REGRESSION,
+  VQA,
+  VQAS,
 ];
 
 export const LABEL_TAGS_CLASSES = [
@@ -47,4 +51,6 @@ export const LABEL_TAGS_CLASSES = [
   REGRESSION,
   TEMPORAL_DETECTION,
   TEMPORAL_DETECTIONS,
+  VQA,
+  VQAS,
 ];

--- a/app/packages/looker/src/elements/common/bubbles.test.ts
+++ b/app/packages/looker/src/elements/common/bubbles.test.ts
@@ -282,6 +282,55 @@ describe("text bubble tests", () => {
   });
 });
 
+describe("VQA bubbles", () => {
+  it("getBubbles unwraps a VQAs field to its vqas", () => {
+    const schema: Schema = {
+      questions: {
+        dbField: "questions",
+        description: null,
+        embeddedDocType: "fiftyone.core.labels.VQAs",
+        fields: {
+          vqas: {
+            dbField: "vqas",
+            description: null,
+            embeddedDocType: "fiftyone.core.labels.VQA",
+            fields: {},
+            ftype: "fiftyone.core.fields.ListField",
+            info: null,
+            name: "vqas",
+            subfield: "fiftyone.core.fields.EmbeddedDocumentField",
+            path: "questions.vqas",
+          },
+        },
+        ftype: "fiftyone.core.fields.EmbeddedDocumentField",
+        info: null,
+        name: "questions",
+        subfield: null,
+        path: "questions",
+      },
+    };
+
+    const sample = {
+      questions: {
+        _cls: "VQAs",
+        vqas: [
+          { _cls: "VQA", question: "Is there a cat?", answer: "yes" },
+          { _cls: "VQA", question: "How many?", answer: "2" },
+        ],
+      },
+    };
+
+    const [field, values] = getBubbles("questions", sample, schema);
+
+    expect(field.embeddedDocType).toBe("fiftyone.core.labels.VQAs");
+    expect(values).toHaveLength(2);
+    expect((values as { answer?: string }[]).map((v) => v.answer)).toEqual([
+      "yes",
+      "2",
+    ]);
+  });
+});
+
 describe("applyTagValue", () => {
   it("prevents XSS", () => {
     const xss = "<img src=# onerror=alert('XSS')>";

--- a/app/packages/looker/src/elements/common/bubbles.ts
+++ b/app/packages/looker/src/elements/common/bubbles.ts
@@ -7,6 +7,7 @@ import {
   type Schema,
   TEMPORAL_DETECTIONS,
   VALID_PRIMITIVE_TYPES,
+  VQAS,
   withPath,
 } from "@fiftyone/utilities";
 import type { Sample } from "../..";
@@ -63,6 +64,13 @@ export const getBubbles = (
     if (field.embeddedDocType === withPath(LABELS_PATH, TEMPORAL_DETECTIONS)) {
       out.values = unwind(field.dbField, out.values).flatMap(
         (value) => value.detections || [],
+      ) as Sample[];
+      break;
+    }
+
+    if (field.embeddedDocType === withPath(LABELS_PATH, VQAS)) {
+      out.values = unwind(field.dbField, out.values).flatMap(
+        (value) => value.vqas || [],
       ) as Sample[];
       break;
     }

--- a/app/packages/looker/src/elements/common/computeTagData.test.ts
+++ b/app/packages/looker/src/elements/common/computeTagData.test.ts
@@ -430,3 +430,58 @@ describe("computeLabelTagCounts", () => {
     expect(computeLabelTagCounts(sample, schema)).toEqual({});
   });
 });
+
+describe("computeTagData VQA", () => {
+  beforeAll(() => {
+    Object.defineProperty(globalThis, "CSS", {
+      configurable: true,
+      value: { supports: (_prop: string, color?: string) => Boolean(color) },
+    });
+  });
+
+  const VQA_SCHEMA: Schema = {
+    filepath: makeField("filepath"),
+    question: makeField("question", {
+      embeddedDocType: "fiftyone.core.labels.VQA",
+      ftype: EMBEDDED_DOCUMENT_FIELD,
+    }),
+    questions: makeField("questions", {
+      embeddedDocType: "fiftyone.core.labels.VQAs",
+      ftype: EMBEDDED_DOCUMENT_FIELD,
+      fields: {
+        vqas: makeField("vqas", {
+          ftype: LIST_FIELD,
+          path: "questions.vqas",
+          subfield: EMBEDDED_DOCUMENT_FIELD,
+        }),
+      },
+    }),
+  };
+
+  it("renders answer bubbles for VQA and VQAs fields", () => {
+    const result = computeTagData(
+      makeInput({
+        activePaths: ["question", "questions"],
+        fieldSchema: VQA_SCHEMA,
+        sample: {
+          filepath: "/tmp/sample-1.png",
+          question: {
+            _cls: "VQA",
+            question: "Is there a cat?",
+            answer: "yes",
+          },
+          questions: {
+            _cls: "VQAs",
+            vqas: [
+              { _cls: "VQA", question: "How many?", answer: "2" },
+              { _cls: "VQA", question: "What color?", answer: "black" },
+            ],
+          },
+        },
+      }),
+    );
+
+    expect(result.map((item) => item.value)).toEqual(["yes", "2", "black"]);
+    expect(result[0].title).toBe("question: yes");
+  });
+});

--- a/app/packages/looker/src/elements/common/computeTagData.ts
+++ b/app/packages/looker/src/elements/common/computeTagData.ts
@@ -21,6 +21,8 @@ import {
   STRING_FIELD,
   TEMPORAL_DETECTION,
   TEMPORAL_DETECTIONS,
+  VQA,
+  VQAS,
   formatDate,
   formatDateTime,
   getColor,
@@ -30,6 +32,7 @@ import type {
   Classification,
   Regression,
   TemporalDetectionLabel,
+  VQALabel,
 } from "../../overlays/classifications";
 import { isValidColor, shouldShowLabelTag } from "../../overlays/util";
 import type { BaseState, LabelTagColor, NONFINITE, Sample } from "../../state";
@@ -323,6 +326,25 @@ export const computeTagData = ({
     };
   };
 
+  const VQA_RENDERER = (path, param: VQALabel): TagData => {
+    const answer = param.answer ?? "null";
+
+    return {
+      path,
+      value: answer,
+      title: `${path}: ${answer}`,
+      color: getAssignedColor({
+        coloring,
+        path,
+        param,
+        isTagged: shouldShowLabelTag(selectedLabelTags, param.tags),
+        labelTagColors,
+        customizeColorSetting,
+        isValidColor,
+      }),
+    };
+  };
+
   const TEMPORAL_DETECTION_RENDERER = (
     path: string,
     param: TemporalDetectionLabel,
@@ -430,6 +452,8 @@ export const computeTagData = ({
     },
     [withPath(LABELS_PATH, TEMPORAL_DETECTION)]: TEMPORAL_DETECTION_RENDERER,
     [withPath(LABELS_PATH, TEMPORAL_DETECTIONS)]: TEMPORAL_DETECTION_RENDERER,
+    [withPath(LABELS_PATH, VQA)]: VQA_RENDERER,
+    [withPath(LABELS_PATH, VQAS)]: VQA_RENDERER,
   };
 
   for (let index = 0; index < activePaths.length; index++) {

--- a/app/packages/looker/src/overlays/classifications.ts
+++ b/app/packages/looker/src/overlays/classifications.ts
@@ -6,6 +6,8 @@ import {
   REGRESSION,
   TEMPORAL_DETECTION,
   TEMPORAL_DETECTIONS,
+  VQA,
+  VQAS,
   getCls,
   sizeBytesEstimate,
 } from "@fiftyone/utilities";
@@ -38,6 +40,12 @@ export interface Regression {
 }
 
 export type ClassificationLabel = Classification & Regression;
+
+export type VQALabel = {
+  _cls: "VQA";
+  question?: string;
+  answer?: string;
+} & RegularLabel;
 
 export type Labels<T> = [string, T[]][];
 
@@ -409,6 +417,10 @@ export const getClassificationPoints = (
 const getText = (_cls: string, label) => {
   if (_cls === REGRESSION) {
     return label.value;
+  }
+
+  if (_cls === VQA || _cls === VQAS) {
+    return label.answer ?? "null";
   }
 
   return label.label ?? "null";

--- a/app/packages/utilities/src/index.ts
+++ b/app/packages/utilities/src/index.ts
@@ -164,6 +164,8 @@ export const REGRESSION = "Regression";
 export const SEGMENTATION = "Segmentation";
 export const TEMPORAL_DETECTION = "TemporalDetection";
 export const TEMPORAL_DETECTIONS = "TemporalDetections";
+export const VQA = "VQA";
+export const VQAS = "VQAs";
 
 export const LABEL_LISTS_MAP = {
   [CLASSIFICATIONS]: "classifications",
@@ -171,6 +173,7 @@ export const LABEL_LISTS_MAP = {
   [KEYPOINTS]: "keypoints",
   [POLYLINES]: "polylines",
   [TEMPORAL_DETECTIONS]: "detections",
+  [VQAS]: "vqas",
 };
 
 const RESERVED_FIELD_KEYS_MAP = {
@@ -197,6 +200,8 @@ export const LABELS_MAP = {
   [REGRESSION]: REGRESSION,
   [TEMPORAL_DETECTION]: TEMPORAL_DETECTION,
   [TEMPORAL_DETECTIONS]: TEMPORAL_DETECTIONS,
+  [VQA]: VQA,
+  [VQAS]: VQAS,
 };
 
 export const MASK_LABELS = new Set([DETECTION, SEGMENTATION]);
@@ -222,18 +227,21 @@ export const VALID_OBJECT_TYPES = [
 
 export const VALID_CLASS_TYPES = ["Classification", "Classifications"];
 export const VALID_MASK_TYPES = ["Heatmap", "Segmentation"];
+export const VALID_VQA_TYPES = [VQA, VQAS];
 export const VALID_LIST_TYPES = [
   "Classifications",
   "Detections",
   "Keypoints",
   "Polylines",
   "TemporalDetections",
+  "VQAs",
 ];
 
 export const VALID_LABEL_TYPES = [
   ...VALID_CLASS_TYPES,
   ...VALID_OBJECT_TYPES,
   ...VALID_MASK_TYPES,
+  ...VALID_VQA_TYPES,
   "Regression",
 ];
 
@@ -243,6 +251,7 @@ export const LABEL_LISTS = [
   "Keypoints",
   "Polylines",
   "TemporalDetections",
+  "VQAs",
 ];
 
 export const LABEL_LIST = {
@@ -251,6 +260,7 @@ export const LABEL_LIST = {
   Keypoints: "keypoints",
   Polylines: "polylines",
   TemporalDetections: "detections",
+  VQAs: "vqas",
 };
 
 export const LABEL_LIST_PATH = Object.fromEntries(


### PR DESCRIPTION


## 🔗 Related Issues

No related issues to link.

## ⛓️ Depends on PR

To keep the branch stack linear, all preceding PRs must merge first, in order,
before this one lands (this App-side PR has no hard code dependency on them,
but the stack still lands sequentially):

- [ ] **PR 1** · `vqa-lbl-1` — Add first-class VQA/VQAs label types · #8033
- [ ] **PR 2** · `vqa-lbl-2` — Add VQA evaluation (`evaluate_vqa`) · #8034
- [ ] **PR 3** · `vqa-methods` — Add extra VQA scoring protocols · #8035

## 📋 What changes are proposed in this pull request?

Adds App (TypeScript) support for the VQA label types so they render as
classification-style text rather than being ignored.

- Registers `VQA`/`VQAs` across the type system (valid label types, list-type
  mapping to the `vqas` data field).
- Groups them with the sample-level ("moment") classification labels.
- Renders the label's **answer** as its display text, both as an in-sample tag
  and as filterable/taggable sidebar bubbles (with `VQAs` lists unwound to
  their members).
- Adds a `VQALabel` type and the corresponding tag renderer.

**Target base:** `develop`. Purely additive TypeScript with no overlap with
the Python PRs — the App already degrades gracefully on unknown label types,
so this can land independently and in any order.

## 🧪 How is this patch tested? If it is not, please explain why.

- Unit tests added: `bubbles.test.ts` (VQAs sidebar unwinding) and
  `computeTagData.test.ts` (VQA tag rendering / answer-as-text).
- Verified: run under the App's vitest harness (jsdom environment) →
  **25 passed** across the two files (8 + 17). The suite must run with a DOM
  environment (a pre-existing, non-VQA test in `bubbles.test.ts` uses
  `document`).
- Manual: load a dataset with `VQA`/`VQAs` fields and confirm answers render
  in the grid and filter correctly in the sidebar. (Graceful-degradation on
  unknown types was previously verified.)

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

N/A — the VQA feature set is not surfaced to users until the documentation
lands; the consolidated release note is in the final docs PR (`vqa-docs`).

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other
