### PR TITLE
feat(video-annotation): add AI tracking action to the video toolbar

### DIFF
--- a/app/packages/video-annotation/src/components/AiTrackUpsellButton.tsx
+++ b/app/packages/video-annotation/src/components/AiTrackUpsellButton.tsx
@@ -1,0 +1,159 @@
+import {
+  Align,
+  Button,
+  Card,
+  CardBackground,
+  Icon,
+  IconName,
+  Orientation,
+  Size,
+  Spacing,
+  Stack,
+  Text,
+  TextColor,
+  TextVariant,
+  Variant,
+} from "@voxel51/voodo";
+import React, { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+/**
+ * AI accent gradient for the button; applied inline over `Variant.Primary`
+ * since voodo has no gradient variant. `disabled` fades it to the intended
+ * inactive / upsell look.
+ */
+const AI_TRACK_GRADIENT =
+  "linear-gradient(139deg, #CC5200 5.04%, #9A3EDB 103.8%)";
+
+/** Accent for the callout's icon + CTA. */
+const AI_ACCENT = "#F5821F";
+
+/** Upgrade landing URL. */
+const LEARN_MORE_URL = "https://voxel51.com/why-upgrade?utm_source=FiftyOneApp";
+
+/**
+ * Keeps the callout open across the gap between the button and the portaled
+ * card, so the pointer can travel into the card to click "Learn more".
+ */
+const CLOSE_DELAY_MS = 120;
+
+/**
+ * Upsell for AI-powered object tracking — a paid feature not available in the
+ * open-source app. Renders a disabled "AI Track" button whose only action is a
+ * hover callout inviting the user to learn more.
+ *
+ * The callout is a hover popover, not a `Tooltip`: it must portal above both
+ * the annotation modal and the toolbar's clipping (`overflow: hidden`) ancestor,
+ * and it stays open while the pointer is over the button OR the card so the CTA
+ * stays clickable — a tooltip dismisses the moment the pointer leaves the
+ * trigger. Held open by presence of the anchor `rect` (null = closed).
+ */
+export const AiTrackUpsellButton: React.FC = () => {
+  const anchorRef = useRef<HTMLSpanElement>(null);
+  const closeTimer = useRef<ReturnType<typeof setTimeout>>();
+  const [rect, setRect] = useState<DOMRect | null>(null);
+
+  useEffect(() => () => clearTimeout(closeTimer.current), []);
+
+  const open = () => {
+    clearTimeout(closeTimer.current);
+
+    if (anchorRef.current) {
+      setRect(anchorRef.current.getBoundingClientRect());
+    }
+  };
+
+  const scheduleClose = () => {
+    clearTimeout(closeTimer.current);
+    closeTimer.current = setTimeout(() => setRect(null), CLOSE_DELAY_MS);
+  };
+
+  const learnMore = () => {
+    window.open(LEARN_MORE_URL, "_blank", "noopener,noreferrer");
+  };
+
+  return (
+    <span
+      ref={anchorRef}
+      style={{ display: "inline-flex" }}
+      onMouseEnter={open}
+      onMouseLeave={scheduleClose}
+    >
+      {/* `disabled` gives the faded, inactive upsell look. The span (not the
+          disabled button) owns the hover — a disabled button swallows its own
+          pointer events. */}
+      <Button
+        variant={Variant.Primary}
+        size={Size.Xs}
+        leadingIcon={IconName.AI}
+        disabled
+        aria-label="AI Track"
+        data-cy="ai-track-upsell"
+        style={{ background: AI_TRACK_GRADIENT }}
+      >
+        AI Track
+      </Button>
+
+      {rect &&
+        createPortal(
+          <div
+            role="dialog"
+            aria-label="AI Track is available in FiftyOne Enterprise"
+            onMouseEnter={open}
+            onMouseLeave={scheduleClose}
+            style={{
+              position: "fixed",
+              // Anchor above the button: pin the card's bottom just over the
+              // button's top so it grows upward (the toolbar sits low when the
+              // timeline drawer is collapsed, which clips a downward card).
+              bottom: window.innerHeight - rect.top + 6,
+              left: rect.left,
+              width: 320,
+              zIndex: "var(--z-above-modal)",
+            }}
+          >
+            <Card background={CardBackground.Primary} outlined>
+              <Stack orientation={Orientation.Column} spacing={Spacing.Md}>
+                <Stack
+                  orientation={Orientation.Row}
+                  spacing={Spacing.Sm}
+                  align={Align.Center}
+                >
+                  <Icon
+                    name={IconName.AI}
+                    size={Size.Md}
+                    style={{ color: AI_ACCENT }}
+                  />
+                  <Text
+                    variant={TextVariant.Xl}
+                    color={TextColor.Primary}
+                    style={{ fontWeight: 600 }}
+                  >
+                    More powerful AI in Enterprise
+                  </Text>
+                </Stack>
+
+                <Text variant={TextVariant.Md} color={TextColor.Secondary}>
+                  Auto-track objects across frames – available in FiftyOne
+                  Enterprise.
+                </Text>
+
+                <Button
+                  variant={Variant.Primary}
+                  size={Size.Sm}
+                  trailingIcon={IconName.ExternalLink}
+                  onClick={learnMore}
+                  aria-label="Learn more about FiftyOne Enterprise"
+                  data-cy="ai-track-upsell-learn-more"
+                  style={{ background: AI_ACCENT, width: "100%" }}
+                >
+                  Learn more
+                </Button>
+              </Stack>
+            </Card>
+          </div>,
+          document.body,
+        )}
+    </span>
+  );
+};

--- a/app/packages/video-annotation/src/hooks/useVideoAnnotationActions.tsx
+++ b/app/packages/video-annotation/src/hooks/useVideoAnnotationActions.tsx
@@ -18,6 +18,7 @@ import {
 } from "../state/useVideoInteraction";
 import { useFrameKeyframeState } from "./useFrameKeyframeState";
 import { useVideoSurfaceActions } from "./useVideoSurfaceActions";
+import { AiTrackUpsellButton } from "../components/AiTrackUpsellButton";
 
 /**
  * Small SVG diamond glyph used by the Mark Keyframe toolbar button. Filled
@@ -187,6 +188,20 @@ export const useVideoAnnotationActions = (): ToolbarActionGroup[] => {
 
               actions.splitTrack(selectedIds[0], frameAt(playhead, fps));
             },
+          },
+          {
+            // Upsell for AI-powered object tracking (not in the OSS app): an
+            // always-present, disabled-styled button whose only action is a
+            // hover callout. Owns its own presentation via the custom-component
+            // hatch; onClick is a required no-op.
+            id: "ai-track",
+            label: "AI Track",
+            icon: <Icon name={IconName.AI} size={Size.Sm} />,
+            // Required by the item type but unreachable — the toolbar renders
+            // `customComponent` instead of wiring `onClick`.
+            // eslint-disable-next-line @typescript-eslint/no-empty-function
+            onClick: () => {},
+            customComponent: <AiTrackUpsellButton />,
           },
         ],
       },


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

Adds an **"AI Track"** affordance to the video annotation toolbar. The button is disabled in the open-source app with a **"Learn more"** link to the upgrade page.

## 🧪 How is this patch tested?

Manual: opened a video sample in the annotation modal — the button renders in the toolbar, the callout appears on hover above the button (clearing the modal surface), and "Learn more" opens the upgrade page in a new tab. `eslint` and scoped `tsc` are clean.

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3359
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an **AI Track** option to the video annotation toolbar.
  * Added an Enterprise upsell message for AI Track, including a **Learn more** link that opens upgrade information in a new tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->