### PR TITLE
fix(video-annotation): index-based track coalescing

### DIFF
--- a/app/packages/annotation/src/engine/identity/identity.test.ts
+++ b/app/packages/annotation/src/engine/identity/identity.test.ts
@@ -5,7 +5,13 @@ import {
   decodeEntityId,
   encodeEntityId,
 } from "./entityId";
-import { refKey, refsEqual, toLabelRef } from "./ref";
+import {
+  addressIdOf,
+  indexFromAddressId,
+  refKey,
+  refsEqual,
+  toLabelRef,
+} from "./ref";
 import type { LabelRef } from "./ref";
 
 const ref = (overrides: Partial<LabelRef> = {}): LabelRef => ({
@@ -59,6 +65,36 @@ describe("toLabelRef", () => {
     });
 
     expect(bound).toEqual(ref({ sample: "sample-9", frame: 4 }));
+  });
+});
+
+describe("addressIdOf", () => {
+  it("prefers the instance _id when present", () => {
+    expect(
+      addressIdOf({ _id: "doc-1", index: 3, instance: { _id: "inst-1" } }),
+    ).toBe("inst-1");
+  });
+
+  it("falls back to a synthetic track-<index> for an instance-less label", () => {
+    expect(addressIdOf({ _id: "doc-1", index: 3 })).toBe("track-3");
+    // index 0 is a real track, not "absent"
+    expect(addressIdOf({ _id: "doc-1", index: 0 })).toBe("track-0");
+  });
+
+  it("falls back to the doc _id for a bare label (no instance, no index)", () => {
+    expect(addressIdOf({ _id: "doc-1" })).toBe("doc-1");
+  });
+});
+
+describe("indexFromAddressId", () => {
+  it("decodes the index from a track-<index> id", () => {
+    expect(indexFromAddressId("track-3")).toBe(3);
+    expect(indexFromAddressId("track-0")).toBe(0);
+  });
+
+  it("returns undefined for a non-index address id", () => {
+    expect(indexFromAddressId("inst-1")).toBeUndefined();
+    expect(indexFromAddressId("track-nope")).toBeUndefined();
   });
 });
 

--- a/app/packages/annotation/src/engine/identity/ref.ts
+++ b/app/packages/annotation/src/engine/identity/ref.ts
@@ -7,6 +7,44 @@
  * is a separate, derived query; store ops never key on `instanceId` alone.
  */
 
+import type { LabelData } from "@fiftyone/utilities";
+
+/** Synthetic `instanceId` prefix for an index-based track (no `instance._id`). */
+export const TRACK_INDEX_PREFIX = "track-";
+
+/**
+ * The engine `instanceId` for a per-frame label. A tracked instance keys by its
+ * `instance._id`; an instance-less label carrying a persisted track `index`
+ * keys by the synthetic `track-<index>` so its per-frame occurrences coalesce
+ * into one track; a bare detection keys by its own doc `_id`.
+ */
+export const addressIdOf = (label: LabelData): string => {
+  const instance = label.instance as { _id?: string } | undefined;
+
+  if (instance?._id) {
+    return instance._id;
+  }
+
+  const index = label.index as number | undefined;
+
+  if (index != null) {
+    return `${TRACK_INDEX_PREFIX}${index}`;
+  }
+
+  return label._id;
+};
+
+/** The track `index` encoded in a `track-<index>` id, or `undefined`. */
+export const indexFromAddressId = (instanceId: string): number | undefined => {
+  if (!instanceId.startsWith(TRACK_INDEX_PREFIX)) {
+    return undefined;
+  }
+
+  const index = Number(instanceId.slice(TRACK_INDEX_PREFIX.length));
+
+  return Number.isFinite(index) ? index : undefined;
+};
+
 /**
  * Canonical address of an annotation entity. The lingua franca: store keys,
  * change events, selection sets, and signal topics all key on this.

--- a/app/packages/annotation/src/engine/index.ts
+++ b/app/packages/annotation/src/engine/index.ts
@@ -7,7 +7,15 @@
 
 // identity
 export type { LabelRef, ScopedRef } from "./identity/ref";
-export { linkageKey, refKey, refsEqual, toLabelRef } from "./identity/ref";
+export {
+  addressIdOf,
+  indexFromAddressId,
+  linkageKey,
+  refKey,
+  refsEqual,
+  toLabelRef,
+  TRACK_INDEX_PREFIX,
+} from "./identity/ref";
 export { FRAMES_PREFIX, toSchemaField } from "./identity/framePath";
 export type { EntityId, EntityIdentity } from "./identity/entityId";
 export {

--- a/app/packages/annotation/src/engine/store/frameStore.test.ts
+++ b/app/packages/annotation/src/engine/store/frameStore.test.ts
@@ -136,6 +136,58 @@ describe("FrameStore mutation", () => {
   });
 });
 
+describe("FrameStore index-based tracks (no instance)", () => {
+  /** A per-frame detection carrying a track `index` but no `instance`. */
+  const idet = (docId: string, index: number, label = "x"): LabelData => ({
+    _id: docId,
+    _cls: "Detection",
+    index,
+    label,
+    bounding_box: [0, 0, 1, 1],
+  });
+
+  it("coalesces frames sharing an index into one `track-<index>` address", () => {
+    const store = makeStore(
+      frames({
+        1: { [PATH]: [idet("doc-1", 3)] },
+        2: { [PATH]: [idet("doc-2", 3)] },
+      }),
+    );
+
+    // distinct doc ids, one track — addressed by the synthetic track id
+    expect(store.getLabel(ref("track-3", 1))?._id).toBe("doc-1");
+    expect(store.getLabel(ref("track-3", 2))?._id).toBe("doc-2");
+    expect(
+      store
+        .enumerateLabels([LabelType.Detections])
+        .map((r) => `${r.instanceId}@${r.frame}`)
+        .sort(),
+    ).toEqual(["track-3@1", "track-3@2"]);
+  });
+
+  it("an edit preserves the index and mints NO synthetic instance", () => {
+    const store = makeStore({ 1: { [PATH]: [idet("doc-1", 3)] } });
+
+    store.updateLabel(ref("track-3", 1), { label: "cat" });
+
+    const label = store.getLabel(ref("track-3", 1))!;
+    expect(label.label).toBe("cat");
+    expect(label.index).toBe(3);
+    expect(label.instance).toBeUndefined();
+  });
+
+  it("a create on an index track stamps the index, not an instance", () => {
+    const store = makeStore({ 1: { [PATH]: [] } });
+
+    store.updateLabel(ref("track-5", 1), { label: "dog" });
+
+    const label = store.getLabel(ref("track-5", 1))!;
+    expect(label.index).toBe(5);
+    expect(label.instance).toBeUndefined();
+    expect(label._id).not.toBe("track-5"); // doc id minted, not the track id
+  });
+});
+
 describe("FrameStore through the engine: transactions + undo", () => {
   const makeEngine = (data?: FramesData) => {
     const engine = new AnnotationEngine();

--- a/app/packages/annotation/src/engine/store/frameStore.ts
+++ b/app/packages/annotation/src/engine/store/frameStore.ts
@@ -5,8 +5,11 @@
  * other.
  *
  * Identity: `instanceId` is the TRACK's `instance._id`, not the per-frame
- * document `_id`. So `(instanceId, frameN)` and `(instanceId, frameM)` are
- * distinct refs (the same track's box on two frames), and
+ * document `_id` — or, for an instance-less label carrying a persisted track
+ * `index`, the synthetic `track-<index>` (see `addressIdOf`), so a track that
+ * groups its frames by `index` alone still coalesces. So `(instanceId, frameN)`
+ * and `(instanceId, frameM)` are distinct refs (the same track's box on two
+ * frames), and
  * `linkageKey === instanceId` aggregates the whole track — one canvas handle per
  * track, the playhead choosing which frame's geometry it shows. The per-frame
  * document `_id` is minted on create, preserved on edit, and round-tripped as a
@@ -34,6 +37,7 @@ import {
 } from "@fiftyone/utilities";
 
 import { toSchemaField } from "../identity/framePath";
+import { addressIdOf, indexFromAddressId } from "../identity/ref";
 import type { LabelRef } from "../identity/ref";
 import type {
   ChangeListener,
@@ -62,10 +66,20 @@ export interface FrameStoreOptions {
   data?: FramesData;
 }
 
-/** Track identity is `instance._id`; fall back to the doc `_id` (legacy, no instance). */
-const addressIdOf = (label: LabelData): string | undefined => {
-  const instance = label.instance as { _id?: string } | undefined;
-  return instance?._id ?? label._id;
+/**
+ * The identity fields a freshly-born or replayed label carries so it addresses
+ * back to `ref.instanceId`: an index-based track stamps its `index` (no
+ * synthetic `instance._id` gets persisted); everything else stamps the
+ * `instance._id`, which for an untracked detection is its own doc `_id`.
+ */
+const identityFields = (instanceId: string): Partial<LabelData> => {
+  const index = indexFromAddressId(instanceId);
+
+  if (index !== undefined) {
+    return { index };
+  }
+
+  return { instance: { _id: instanceId, _cls: "Instance" } };
 };
 
 export class FrameStore implements LabelStore {
@@ -125,10 +139,7 @@ export class FrameStore implements LabelStore {
 
         for (const label of this.listAt(frame, path)) {
           const instanceId = addressIdOf(label);
-
-          if (instanceId !== undefined) {
-            refs.push({ sample: this.sample, path, instanceId, frame });
-          }
+          refs.push({ sample: this.sample, path, instanceId, frame });
         }
       }
     }
@@ -166,8 +177,10 @@ export class FrameStore implements LabelStore {
     // exact value (undo/redo replays) but identity survives the round-trip
     this.writeFrame(ref, (existing) => ({
       ...value,
+      ...(existing?.instance
+        ? { instance: existing.instance }
+        : identityFields(ref.instanceId)),
       _id: existing?._id ?? objectId(),
-      instance: existing?.instance ?? { _id: ref.instanceId, _cls: "Instance" },
     }));
   }
 
@@ -413,11 +426,7 @@ export class FrameStore implements LabelStore {
       const byId = new Map<string, LabelData>();
 
       for (const label of this.listAt(frame, path)) {
-        const instanceId = addressIdOf(label);
-
-        if (instanceId !== undefined) {
-          byId.set(instanceId, label);
-        }
+        byId.set(addressIdOf(label), label);
       }
 
       byPath.set(path, byId);
@@ -539,12 +548,12 @@ export class FrameStore implements LabelStore {
     this.emit([{ ref, kind: "update" }]);
   }
 
-  /** A freshly born element: minted doc id, instance stamped from the track ref. */
+  /** A freshly born element: minted doc id, identity stamped from the track ref. */
   private born(ref: LabelRef, partial: Partial<LabelData>): LabelData {
     return {
       ...partial,
+      ...identityFields(ref.instanceId),
       _id: objectId(),
-      instance: { _id: ref.instanceId, _cls: "Instance" },
     };
   }
 

--- a/app/packages/video-annotation/src/hooks/useVideoSurfaceActions.test.ts
+++ b/app/packages/video-annotation/src/hooks/useVideoSurfaceActions.test.ts
@@ -415,13 +415,27 @@ describe("track identity ops (split / merge)", () => {
     expect(mockBus.dispatch).not.toHaveBeenCalled();
   });
 
-  it("mergeTracks skips a legacy track-<index> on either side", () => {
-    frameData = { 1: { A: det("d1", "A") } };
+  it("mergeTracks operates on an index-based track-<index> (a real address)", () => {
+    // source is an instance-less index track; the engine addresses it by its
+    // synthetic `track-1` id, so merge treats it like any other track
+    frameData = {
+      1: { "track-1": det("d1", "track-1", { index: 1, instance: undefined }) },
+      2: { A: det("d2", "A") },
+    };
 
     render().current.mergeTracks("track-1", "instance-A");
-    render().current.mergeTracks("instance-A", "track-1");
 
-    expect(mockActions.transaction).not.toHaveBeenCalled();
+    expect(mockActions.transaction).toHaveBeenCalledTimes(1);
+    expect(mockActions.deleteLabel).toHaveBeenCalledWith({
+      path: PATH,
+      instanceId: "track-1",
+      frame: 1,
+    });
+    // frame 1 has no target box → the source content is re-laid onto A
+    expect(mockActions.updateLabel).toHaveBeenCalledWith(
+      { path: PATH, instanceId: "A", frame: 1 },
+      expect.objectContaining({ label: "x", bounding_box: [0, 0, 1, 1] }),
+    );
   });
 });
 

--- a/app/packages/video-annotation/src/tracks/frameTracks.test.ts
+++ b/app/packages/video-annotation/src/tracks/frameTracks.test.ts
@@ -86,7 +86,7 @@ describe("buildPerInstanceTracks", () => {
     expect(tracks[0].label).toBe("person 7");
   });
 
-  it("addresses legacy instance-less detections by their doc _id", () => {
+  it("coalesces instance-less detections by their track index", () => {
     const det: LabelData = {
       _id: "doc-3",
       _cls: "Detection",
@@ -96,9 +96,15 @@ describe("buildPerInstanceTracks", () => {
     };
 
     const resolveColor = vi.fn<ColorResolver>(() => "#fff");
-    const tracks = build(1, { 1: [det] }, resolveColor);
+    // The same index on distinct per-frame doc _ids must be ONE track.
+    const tracks = build(
+      2,
+      { 1: [det], 2: [{ ...det, _id: "doc-3b" }] },
+      resolveColor,
+    );
 
-    expect(tracks[0].id).toBe("doc-3");
+    expect(tracks).toHaveLength(1);
+    expect(tracks[0].id).toBe("track-3");
     expect(resolveColor).toHaveBeenCalledWith(
       {
         label: "vehicle",
@@ -107,6 +113,19 @@ describe("buildPerInstanceTracks", () => {
       },
       PATH,
     );
+  });
+
+  it("addresses a bare detection (no instance, no index) by its doc _id", () => {
+    const det: LabelData = {
+      _id: "doc-bare",
+      _cls: "Detection",
+      label: "vehicle",
+      keyframe: false,
+    };
+
+    const tracks = build(1, { 1: [det] });
+
+    expect(tracks[0].id).toBe("doc-bare");
   });
 
   it("assigns instance-only ordinals as the next free integer above the per-class max", () => {

--- a/app/packages/video-annotation/src/tracks/frameTracks.test.ts
+++ b/app/packages/video-annotation/src/tracks/frameTracks.test.ts
@@ -149,6 +149,28 @@ describe("buildPerInstanceTracks", () => {
     expect(tracks.map((t) => t.label)).toEqual(["person 3", "person 4"]);
   });
 
+  it("orders rows deterministically regardless of label accumulation order", () => {
+    // three instance-only tracks of one class — no persisted index, so the
+    // ordinal is assigned; the resulting row order must not depend on the
+    // order the labels happen to arrive in
+    const mk = (inst: string): LabelData => ({
+      _id: `doc-${inst}`,
+      _cls: "Detection",
+      label: "person",
+      instance: { _cls: "Instance", _id: inst },
+    });
+
+    const forward = build(1, { 1: [mk("a"), mk("b"), mk("c")] }).map(
+      (t) => t.id,
+    );
+    const reversed = build(1, { 1: [mk("c"), mk("b"), mk("a")] }).map(
+      (t) => t.id,
+    );
+
+    expect(forward).toEqual(["a", "b", "c"]);
+    expect(reversed).toEqual(forward);
+  });
+
   it("builds a track per instance across multiple fields, colored by each field's path", () => {
     const POLY_PATH = "frames.polylines";
     const box: LabelData = {

--- a/app/packages/video-annotation/src/tracks/frameTracks.ts
+++ b/app/packages/video-annotation/src/tracks/frameTracks.ts
@@ -562,8 +562,12 @@ function accumulatePresence(
  */
 function assignDisplayOrdinals(states: Map<string, InstanceState>): void {
   const classCounters = new Map<string, number>();
+  // Assign in id order so instance-only ordinals (and thus row order) don't
+  // depend on accumulation/insertion order — the same clip renders the same
+  // rows in the same order every run.
+  const ordered = [...states.entries()].sort(([a], [b]) => a.localeCompare(b));
 
-  for (const state of states.values()) {
+  for (const [, state] of ordered) {
     if (state.persistedIndex === undefined) {
       continue;
     }
@@ -574,7 +578,7 @@ function assignDisplayOrdinals(states: Map<string, InstanceState>): void {
     }
   }
 
-  for (const state of states.values()) {
+  for (const [, state] of ordered) {
     if (state.persistedIndex !== undefined) {
       state.displayIndex = state.persistedIndex;
       continue;
@@ -653,7 +657,13 @@ function sortByClassThenOrdinal(
       return sa.classLabel.localeCompare(sb.classLabel);
     }
 
-    return sa.displayIndex - sb.displayIndex;
+    if (sa.displayIndex !== sb.displayIndex) {
+      return sa.displayIndex - sb.displayIndex;
+    }
+
+    // final tiebreaker on the track id — a total order, so ties never leave
+    // the row sequence to the (unstable) accumulation order
+    return a.id.localeCompare(b.id);
   });
 }
 

--- a/app/packages/video-annotation/src/tracks/frameTracks.ts
+++ b/app/packages/video-annotation/src/tracks/frameTracks.ts
@@ -1,4 +1,4 @@
-import type { AnnotationEngine } from "@fiftyone/annotation";
+import { addressIdOf, type AnnotationEngine } from "@fiftyone/annotation";
 import type { Track, TrackEvent } from "@fiftyone/playback";
 import type { LabelData } from "@fiftyone/utilities";
 import { isEqual } from "lodash";
@@ -136,12 +136,6 @@ export interface BuildPerInstanceTracksInput {
    */
   dynamicAttributes?: string[];
 }
-
-/** Track identity is `instance._id`; fall back to the doc `_id` (legacy). */
-const addressIdOf = (label: LabelData): string => {
-  const instance = label.instance as { _id?: string } | undefined;
-  return instance?._id ?? label._id;
-};
 
 const labelOf = (label: LabelData): string =>
   (label.label as string | undefined) || "unknown";

--- a/app/packages/video-annotation/src/tracks/trackIdentity.test.ts
+++ b/app/packages/video-annotation/src/tracks/trackIdentity.test.ts
@@ -13,7 +13,7 @@ describe("instanceIdFromTrackId", () => {
     );
   });
 
-  it("returns null for a legacy index-only track (no engine identity)", () => {
-    expect(instanceIdFromTrackId("track-4")).toBeNull();
+  it("returns an index-based track id unchanged (its own engine identity)", () => {
+    expect(instanceIdFromTrackId("track-4")).toBe("track-4");
   });
 });

--- a/app/packages/video-annotation/src/tracks/trackIdentity.ts
+++ b/app/packages/video-annotation/src/tracks/trackIdentity.ts
@@ -8,21 +8,16 @@
  * - `instance-<id>` — a tracked instance; `<id>` IS the engine instanceId.
  * - a bare document `_id` — an untracked detection; the engine addresses it by
  *   that same `_id`, so the track id is already the instanceId.
- * - `track-<index>` — a legacy index-only track with no `instance._id`. Its
- *   per-frame docs carry different `_id`s, so there is no single engine
- *   instanceId for the track — returns `null`.
+ * - `track-<index>` — an instance-less track grouped by its persisted `index`.
+ *   The engine addresses it by that same synthetic `track-<index>` id (see
+ *   `addressIdOf`), so the track id is already the instanceId — pass it through.
  */
 
 const INSTANCE_PREFIX = "instance-";
-const LEGACY_INDEX_PREFIX = "track-";
 
 export const instanceIdFromTrackId = (trackId: string): string | null => {
   if (trackId.startsWith(INSTANCE_PREFIX)) {
     return trackId.slice(INSTANCE_PREFIX.length);
-  }
-
-  if (trackId.startsWith(LEGACY_INDEX_PREFIX)) {
-    return null;
   }
 
   return trackId;

--- a/fiftyone/server/routes/video_labels.py
+++ b/fiftyone/server/routes/video_labels.py
@@ -34,6 +34,13 @@ from fiftyone.server.decorators import route
 import fiftyone.server.view as fosv
 
 
+# Synthetic instance-id prefix for an index-based track (a label with no
+# ``instance._id`` but a persisted ``index``). Must match the client's
+# ``TRACK_INDEX_PREFIX`` (``@fiftyone/annotation``) so the baseline index and
+# the engine address the same track by the same id.
+TRACK_INDEX_PREFIX = "track-"
+
+
 def run_length_encode(frames: t.Iterable[int]) -> t.List[t.List[int]]:
     """Fold a set of frame numbers into contiguous ``[start, end]`` runs.
 
@@ -120,10 +127,11 @@ def index_post_pipeline(
 
     Appended after ``frames_only`` makes per-frame documents the pipeline's
     input. Groups by ``instance._id`` (the engine's track keystone), falling
-    back to the per-frame label ``_id`` so instance-less legacy detections
-    fragment into single-frame entries — exactly as the client's frame walk
-    does today. The run-length encoding itself happens in Python on the
-    grouped output; see :func:`run_length_encode`.
+    back to the synthetic ``track-<index>`` for an instance-less label carrying
+    a persisted ``index`` (so its frames coalesce into one track), and finally
+    to the per-frame label ``_id`` for a bare detection with neither. This
+    mirrors the client ``addressIdOf`` exactly. The run-length encoding itself
+    happens in Python on the grouped output; see :func:`run_length_encode`.
 
     When ``dynamic_attributes`` is non-empty the group also pushes each present
     frame's value for those attributes (one ``{fn, <attr>: ...}`` sample per
@@ -134,8 +142,21 @@ def index_post_pipeline(
     """
     labels_expr = "$%s.%s" % (field, list_field) if list_field else "$" + field
 
+    index_track_id = {
+        "$cond": [
+            {"$ne": ["$labels.index", None]},
+            {"$concat": [TRACK_INDEX_PREFIX, {"$toString": "$labels.index"}]},
+            None,
+        ]
+    }
+
     group: dict = {
-        "_id": {"$ifNull": ["$labels.instance._id", "$labels._id"]},
+        "_id": {
+            "$ifNull": [
+                "$labels.instance._id",
+                {"$ifNull": [index_track_id, "$labels._id"]},
+            ]
+        },
         "frames": {"$addToSet": "$fn"},
         "keyframes": {
             "$addToSet": {

--- a/tests/unittests/server_video_labels_tests.py
+++ b/tests/unittests/server_video_labels_tests.py
@@ -208,9 +208,49 @@ class VideoLabelsAggregationTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(by_id[id_b]["segments"], [[2, 4]])
         self.assertEqual(by_id[id_b]["keyframes"], [])
 
-        # The instance-less detection fragments into a single-frame entry.
+        # An instance-less, index-less detection has no track identity, so it
+        # fragments into a single-frame entry keyed by its own doc _id.
         self.assertEqual(by_id[id_legacy]["segments"], [[1, 1]])
         self.assertEqual(by_id[id_legacy]["classLabel"], "car")
+
+    @drop_async_dataset
+    async def test_index_only_tracks_coalesce_by_index(self, dataset):
+        video = fo.Sample(filepath="video.mp4")
+        # An instance-less "vehicle" carrying a stable index across frames 1-3
+        # coalesces into ONE synthetic track-<index>; a bare detection (no
+        # instance, no index) still fragments by its per-frame _id.
+        video[1]["detections"] = fo.Detections(
+            detections=[
+                fo.Detection(label="vehicle", index=0),
+                fo.Detection(label="sign"),
+            ]
+        )
+        video[2]["detections"] = fo.Detections(
+            detections=[fo.Detection(label="vehicle", index=0)]
+        )
+        video[3]["detections"] = fo.Detections(
+            detections=[fo.Detection(label="vehicle", index=0)]
+        )
+        dataset.add_sample(video)
+
+        id_bare = str(video[1]["detections"].detections[1]._id)
+
+        view = fov.make_optimized_select_view(
+            dataset.view(), video.id, flatten=True
+        )
+        result = await aggregate_index(view, ["detections"])
+
+        by_id = {e["instanceId"]: e for e in result["detections"]["instances"]}
+
+        # index 0 → one synthetic track spanning all three frames
+        self.assertIn("track-0", by_id)
+        self.assertEqual(by_id["track-0"]["segments"], [[1, 3]])
+        self.assertEqual(by_id["track-0"]["classLabel"], "vehicle")
+        self.assertEqual(by_id["track-0"]["persistedIndex"], 0)
+
+        # the bare detection still fragments by its own _id
+        self.assertIn(id_bare, by_id)
+        self.assertEqual(by_id[id_bare]["segments"], [[1, 1]])
 
     @drop_async_dataset
     async def test_index_dynamic_attribute_segments(self, dataset):


### PR DESCRIPTION
### What / why

Video labels can be grouped into a track by either a shared `instance._id` (a tracked instance spanning frames) or an integer `index` (a track ordinal shared across frames). For a dataset whose labels carry only `index` and no `instance`, every per-frame document has a distinct `_id`, so each label fragmented into its own single-frame "track" on the timeline instead of coalescing into one track per index.

Track identity was computed in three coordinated places, all keyed on `instance._id ?? doc._id` and none consulting `index`:

- the server presence-index Mongo group key (`fiftyone/server/routes/video_labels.py`)
- the engine store's ref-addressing key (`FrameStore.addressIdOf`)
- the timeline track builder (`frameTracks.addressIdOf`)

### Fix

Make `track-<index>` a first-class track id for instance-less-but-indexed labels, applied identically across all three layers via a single canonical `addressIdOf`. Supporting changes:

- `FrameStore.born`/`replaceLabel` stamp `index` (not a synthetic `instance._id`) for a `track-<index>` ref, so edits keep the track index-based rather than persisting a fabricated instance.
- `instanceIdFromTrackId` passes a `track-<index>` id through (it *is* the engine id now), so timeline edit/delete/split/merge actions resolve for index-based tracks.

### Also: deterministic timeline ordering

Instance-only track ordinals were assigned in accumulation order and the row sort had no final tiebreaker, so row order could vary run-to-run. Ordinals are now assigned in id order and the sort falls back to the track id — the same clip renders the same row order every time.

### Tests

- Engine: `addressIdOf`/`indexFromAddressId` precedence; `FrameStore` coalescing, index-preserving edits, and index-stamping creates.
- Timeline: index coalescing, bare-id fallback, merge on an index track, deterministic ordering.
- Server: `aggregate_index` coalesces instance-less indexed labels into one `track-<index>` while a truly bare detection still fragments by `_id`.

All annotation + video-annotation JS suites (774) and the server video-labels unit tests pass; scoped typecheck and lint clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added consistent support for persisted index-based video tracks using stable `track-<index>` identifiers.
  - Index-based labels now stay grouped across frames, and their index is preserved when edited or created.
  - Track merging now supports merging from index-based `track-<index>` sources.

- **Bug Fixes**
  - Improved aggregation and coalescing for labels missing instance identifiers (and for labels missing both instance and index).
  - Stabilized track ordering/display to be deterministic across load and input order.

- **Tests**
  - Expanded unit test coverage for index-only track identity, merging, and deterministic ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3346
<!-- enterprise-sync-pr:end -->