### PR TITLE
feat(video-annotation): update track deletion behavior

### DIFF
--- a/app/packages/annotation/src/hooks/index.ts
+++ b/app/packages/annotation/src/hooks/index.ts
@@ -2,6 +2,7 @@ export * from "./useAnnotationEventBus";
 export * from "./useAnnotationEventHandler";
 export * from "./useAnnotationController";
 export * from "./useDeleteAnnotation";
+export * from "./useDeleteTrack";
 export * from "./useGetVersionToken";
 export * from "./usePatchSample";
 export * from "./useRegisterAnnotationEventHandlers";

--- a/app/packages/annotation/src/hooks/useDeleteTrack.ts
+++ b/app/packages/annotation/src/hooks/useDeleteTrack.ts
@@ -1,0 +1,126 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import {
+  useAnnotationEngine,
+  useAnnotationEventBus,
+  usePersistAnnotationDeltas,
+  type LabelRef,
+} from "@fiftyone/annotation";
+import { AnnotationLabel } from "@fiftyone/state";
+import { useCallback } from "react";
+
+/**
+ * Hook returning a callback that deletes an entire object track — every
+ * occurrence of a `(sample, path, instanceId)` across the engine's loaded
+ * frames — and persists the removal. The single-frame {@link useDeleteAnnotation}
+ * drops one occurrence; this drops the whole track so a video Delete matches the
+ * timeline's "Delete track" action.
+ *
+ * All occurrences are removed in one engine transaction, so the track drops on a
+ * single undo unit (Ctrl-Z restores the whole track). Mirrors
+ * {@link useDeleteAnnotation}'s persistence + activity-toast orchestration and
+ * await-and-rollback so a rejected persist restores the track.
+ *
+ * @returns A callback that resolves `true` on success, `false` on failure, and
+ *   rethrows so callers can react to a failed persist.
+ */
+export const useDeleteTrack = (): ((
+  label: AnnotationLabel,
+  ref: LabelRef,
+) => Promise<boolean>) => {
+  const eventBus = useAnnotationEventBus();
+  const engine = useAnnotationEngine();
+  const persistAnnotationDeltas = usePersistAnnotationDeltas();
+
+  return useCallback(
+    async (label, ref) => {
+      const labelId = label.data._id;
+
+      try {
+        // Every frame this track occupies on its own field, read through the
+        // engine — the authoritative loaded window (whole clip today).
+        const frames = engine.loadedFrames(ref.sample).filter((frame) =>
+          engine.getLabel({
+            sample: ref.sample,
+            path: ref.path,
+            instanceId: ref.instanceId,
+            frame,
+          }),
+        );
+
+        // Delete every occurrence as one undo unit; hold the entry it pushes so
+        // a rejected persist can restore the whole track (and drop the entry).
+        const prior = engine.lastUndoEntry();
+
+        engine.transaction(() => {
+          for (const frame of frames) {
+            engine.deleteLabel({
+              sample: ref.sample,
+              path: ref.path,
+              instanceId: ref.instanceId,
+              frame,
+            });
+          }
+        });
+
+        const top = engine.lastUndoEntry();
+        const rollback = top === prior ? undefined : top;
+
+        let success: boolean;
+        try {
+          success = (await persistAnnotationDeltas()) !== false;
+
+          if (success) {
+            eventBus.dispatch("annotation:persistenceSuccess");
+          } else {
+            if (rollback) {
+              engine.rollbackEntry(rollback);
+            }
+
+            eventBus.dispatch("annotation:persistenceError", {
+              error: new Error("Server rejected changes"),
+            });
+          }
+        } catch (error) {
+          if (rollback) {
+            engine.rollbackEntry(rollback);
+          }
+
+          eventBus.dispatch("annotation:persistenceError", {
+            error: error as Error,
+          });
+          throw error;
+        }
+
+        if (success) {
+          eventBus.dispatch("annotation:deleteSuccess", {
+            labelId,
+            type: "delete",
+            labelType: label.type,
+          });
+          // let selection/editing consumers drop state bound to this track
+          eventBus.dispatch("annotation:trackDeleted", {
+            trackId: ref.instanceId,
+          });
+        } else {
+          eventBus.dispatch("annotation:deleteError", {
+            labelId,
+            type: "delete",
+          });
+        }
+
+        return success;
+      } catch (error) {
+        eventBus.dispatch("annotation:deleteError", {
+          labelId,
+          type: "delete",
+          error: error as Error,
+        });
+        throw error;
+      }
+    },
+    [engine, eventBus, persistAnnotationDeltas],
+  );
+};

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useDelete.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useDelete.ts
@@ -3,6 +3,7 @@ import {
   useActiveAnnotationSampleId,
   useAnnotationEngine,
   useDeleteAnnotation,
+  useDeleteTrack,
 } from "@fiftyone/annotation";
 import { useLighter } from "@fiftyone/lighter";
 import { isDetection3dOverlay, isPolyline3dOverlay } from "@fiftyone/looker-3d";
@@ -19,6 +20,24 @@ import { useRecoilValue } from "recoil";
 import { useAnnotationContext } from "./useAnnotationContext";
 import useExit from "./useExit";
 
+interface KeypointVertexSelection {
+  getSelectedPointIndex(): number | null;
+}
+
+/** True while a specific polyline/keypoint vertex is sub-selected on the canvas. */
+const isVertexSubSelected = (overlay: unknown): boolean => {
+  if (
+    !overlay ||
+    typeof (overlay as KeypointVertexSelection).getSelectedPointIndex !==
+      "function"
+  ) {
+    return false;
+  }
+
+  const index = (overlay as KeypointVertexSelection).getSelectedPointIndex();
+  return index != null && index >= 0;
+};
+
 export default function useDelete() {
   const { scene, removeOverlay } = useLighter();
   const { selected } = useAnnotationContext();
@@ -26,8 +45,10 @@ export default function useDelete() {
   // engine identity from the anchor — carries the track instanceId + frame +
   // `frames.<field>` path a video frame label needs; null for sample-level
   const ref = selected?.ref ?? undefined;
+  const selectedOverlay = selected?.overlay;
   const engine = useAnnotationEngine();
   const deleteAnnotation = useDeleteAnnotation();
+  const deleteTrack = useDeleteTrack();
   const sample = useActiveAnnotationSampleId();
   // The combined sample + frame schema: a video frame label's path is
   // `frames.<field>`, and the frame fields live in the FRAME space — absent from
@@ -45,6 +66,14 @@ export default function useDelete() {
   // on Ctrl-Z, so no DelegatingUndoable / command-context undo is registered.
   const performDelete = useCallback(async () => {
     if (!label) {
+      return;
+    }
+
+    // A sub-selected polyline/keypoint vertex is removed by the canvas keydown
+    // handler; defer to it so Backspace edits the vertex instead of deleting
+    // the whole label/track. The command bus fires before that handler, so the
+    // sub-point index still reads its pre-removal value here.
+    if (isVertexSubSelected(selectedOverlay)) {
       return;
     }
 
@@ -85,9 +114,16 @@ export default function useDelete() {
         return;
       }
 
-      // the engine's read-half does the rest: the bridge loop unmounts
-      // the overlay and the list mirror drops the row on the delete tick
-      await deleteAnnotation(label, ref ? { ref } : undefined);
+      // A video frame label's anchor carries a `frame`; Delete removes the
+      // whole track (every occurrence), matching the timeline's "Delete track".
+      // Image / sample-level labels (no `frame`) delete just their one entry.
+      // The engine's read-half does the rest: the bridge loop unmounts the
+      // overlay and the list mirror drops the row(s) on the delete tick.
+      if (ref?.frame != null) {
+        await deleteTrack(label, ref);
+      } else {
+        await deleteAnnotation(label, ref ? { ref } : undefined);
+      }
 
       exit();
     } catch (error) {
@@ -98,6 +134,7 @@ export default function useDelete() {
     }
   }, [
     deleteAnnotation,
+    deleteTrack,
     engine,
     exit,
     label,
@@ -106,6 +143,7 @@ export default function useDelete() {
     sample,
     scene,
     schema,
+    selectedOverlay,
     setNotification,
   ]);
 

--- a/app/packages/playback/src/views/TimelineWithTracks/TimelineWithTracks.tsx
+++ b/app/packages/playback/src/views/TimelineWithTracks/TimelineWithTracks.tsx
@@ -44,7 +44,7 @@ export interface TimelineWithTracksProps {
   /**
    * Whether the drawer starts open. Mount-time only — user toggles thereafter
    * persist until the next remount. Defaults closed; callers that want the
-   * timeline visible immediately (e.g. the annotation surface) pass `true`.
+   * timeline visible immediately pass `true`.
    * @default false
    */
   defaultDrawerOpen?: boolean;
@@ -109,9 +109,7 @@ const TimelineWithTracks: React.FC<TimelineWithTracksProps> = ({
   const tracks = useTracks();
   const { pinnedIds, togglePin } = useTrackPinning();
   const { seekSnapped } = usePlayback();
-  // Uncontrolled open state, seeded once from `defaultDrawerOpen`. The
-  // annotation surface remounts on each entry to annotate mode, so passing
-  // `true` there shows the timeline immediately without a tracks-length effect.
+  // Uncontrolled open state, seeded once from `defaultDrawerOpen`.
   // User-initiated collapses/expands persist until the next remount.
   const [uncontrolledDrawerOpen, setUncontrolledDrawerOpen] =
     useState(defaultDrawerOpen);

--- a/app/packages/playback/src/views/TimelineWithTracks/TimelineWithTracks.tsx
+++ b/app/packages/playback/src/views/TimelineWithTracks/TimelineWithTracks.tsx
@@ -43,10 +43,9 @@ export interface TimelineWithTracksProps {
   className?: string;
   /**
    * Whether the drawer starts open. Mount-time only — user toggles thereafter
-   * persist until the next remount. Defaults to `true` so the annotation
-   * surface shows the timeline immediately; the mcap modal passes `false` when
-   * opened from a temporal-tag filter so only the pinned (filtered) tracks show.
-   * @default true
+   * persist until the next remount. Defaults closed; callers that want the
+   * timeline visible immediately (e.g. the annotation surface) pass `true`.
+   * @default false
    */
   defaultDrawerOpen?: boolean;
   /** Controlled open state for the tracks drawer. */
@@ -97,7 +96,7 @@ const TimelineWithTracks: React.FC<TimelineWithTracksProps> = ({
   labelWidth: requestedLabelWidth = TIMELINE_LABEL_WIDTH,
   maxSize = TIMELINE_DRAWER_MAX_SIZE,
   className,
-  defaultDrawerOpen = true,
+  defaultDrawerOpen = false,
   drawerOpen: controlledDrawerOpen,
   onDrawerOpenChange,
   rulerOverlay,
@@ -110,11 +109,9 @@ const TimelineWithTracks: React.FC<TimelineWithTracksProps> = ({
   const tracks = useTracks();
   const { pinnedIds, togglePin } = useTrackPinning();
   const { seekSnapped } = usePlayback();
-  // Drawer starts open by default: the annotation surface remounts on each
-  // entry to annotate mode (sample change / mode toggle), so an initial-`true`
-  // covers the "make the timeline visible immediately" case without a
-  // tracks-length effect. Callers opened from a temporal-tag filter pass
-  // `defaultDrawerOpen={false}` so only the pinned (filtered) tracks show.
+  // Uncontrolled open state, seeded once from `defaultDrawerOpen`. The
+  // annotation surface remounts on each entry to annotate mode, so passing
+  // `true` there shows the timeline immediately without a tracks-length effect.
   // User-initiated collapses/expands persist until the next remount.
   const [uncontrolledDrawerOpen, setUncontrolledDrawerOpen] =
     useState(defaultDrawerOpen);

--- a/app/packages/video-annotation/src/components/FrameLabels.tsx
+++ b/app/packages/video-annotation/src/components/FrameLabels.tsx
@@ -668,6 +668,7 @@ export const FrameLabelsTracks: React.FC<{
         extraControls={<VideoAnnotationToolbar />}
         loaded={timelineLoaded}
         maxSize={maxSize}
+        defaultDrawerOpen
       />
     </TrackProvider>
   );

--- a/app/packages/video-annotation/src/components/FrameLabels.tsx
+++ b/app/packages/video-annotation/src/components/FrameLabels.tsx
@@ -53,6 +53,7 @@ import { resolveTrackExtentEdit } from "../tracks/trackExtentEdit";
 import { useVideoTrackDecorator } from "../tracks/useVideoTrackDecorator";
 import { useScrollTrackToAnchor } from "../state/useVideoInteraction";
 import { useCurrentFrameGetter } from "../state/useCurrentFrame";
+import { useTimelineDrawerOpen } from "../state/useTimelineDrawer";
 import {
   useVideoSurfaceActions,
   type VideoSurfaceActions,
@@ -579,6 +580,9 @@ export const FrameLabelsTracks: React.FC<{
   const { resolveObjectColor, resolveTemporalDetectionColor } =
     useTrackColorResolvers();
 
+  // Persisted globally so switching samples keeps the drawer open/closed.
+  const [drawerOpen, setDrawerOpen] = useTimelineDrawerOpen();
+
   // Persist pin state per video (dataset + sample) so reopening the same
   // sample restores which tracks the user pinned to the timeline.
   const dataset = useDatasetName();
@@ -668,6 +672,8 @@ export const FrameLabelsTracks: React.FC<{
         extraControls={<VideoAnnotationToolbar />}
         loaded={timelineLoaded}
         maxSize={maxSize}
+        drawerOpen={drawerOpen}
+        onDrawerOpenChange={setDrawerOpen}
       />
     </TrackProvider>
   );

--- a/app/packages/video-annotation/src/components/FrameLabels.tsx
+++ b/app/packages/video-annotation/src/components/FrameLabels.tsx
@@ -571,9 +571,11 @@ function useTrackDecorator({
  * only at mount) bootstraps from the real frame-track list; later recolors
  * update through the live `tracks` prop and preserve the user's pin state.
  */
-export const FrameLabelsTracks: React.FC<{ sample?: ModalSample }> = ({
-  sample,
-}) => {
+export const FrameLabelsTracks: React.FC<{
+  sample?: ModalSample;
+  /** Cap on the timeline drawer body (px); it scrolls internally past this. */
+  maxSize?: number;
+}> = ({ sample, maxSize }) => {
   const { resolveObjectColor, resolveTemporalDetectionColor } =
     useTrackColorResolvers();
 
@@ -665,6 +667,7 @@ export const FrameLabelsTracks: React.FC<{ sample?: ModalSample }> = ({
         decorateTrack={decorateTrack}
         extraControls={<VideoAnnotationToolbar />}
         loaded={timelineLoaded}
+        maxSize={maxSize}
       />
     </TrackProvider>
   );

--- a/app/packages/video-annotation/src/components/FrameLabels.tsx
+++ b/app/packages/video-annotation/src/components/FrameLabels.tsx
@@ -708,6 +708,14 @@ function decorateObjectTrack({
       onSelect: () => actions.deleteTrack(track.id, fieldPath),
     },
     {
+      // deletes only the frame captured when the menu opened (see onContextMenu);
+      // a no-op when the track has no occurrence on that frame
+      label: "Delete current frame",
+      destructive: true,
+      onSelect: () =>
+        actions.trimTrack(track.id, [splitFrameRef.current], fieldPath),
+    },
+    {
       // splits at the frame captured when the menu opened (see onContextMenu)
       label: "Split at playhead",
       onSelect: () =>

--- a/app/packages/video-annotation/src/components/FrameLabels.tsx
+++ b/app/packages/video-annotation/src/components/FrameLabels.tsx
@@ -668,7 +668,6 @@ export const FrameLabelsTracks: React.FC<{
         extraControls={<VideoAnnotationToolbar />}
         loaded={timelineLoaded}
         maxSize={maxSize}
-        defaultDrawerOpen
       />
     </TrackProvider>
   );

--- a/app/packages/video-annotation/src/components/SyntheticLabels.tsx
+++ b/app/packages/video-annotation/src/components/SyntheticLabels.tsx
@@ -101,7 +101,7 @@ export const SyntheticTrackTimeline: React.FC = () => {
       tracks={tracks}
       autoPinNewTracks={false}
     >
-      <TimelineWithTracks decorateTrack={decorateTrack} defaultDrawerOpen />
+      <TimelineWithTracks decorateTrack={decorateTrack} />
     </TrackProvider>
   );
 };

--- a/app/packages/video-annotation/src/components/SyntheticLabels.tsx
+++ b/app/packages/video-annotation/src/components/SyntheticLabels.tsx
@@ -1,6 +1,7 @@
 import { getLabelColorFromContext } from "@fiftyone/lighter";
 import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import { useColorScheme, useColorSeed } from "../state/accessors";
+import { useTimelineDrawerOpen } from "../state/useTimelineDrawer";
 import {
   TimelineWithTracks,
   TrackProvider,
@@ -95,13 +96,19 @@ export const SyntheticTrackTimeline: React.FC = () => {
   // linkage — render them undecorated.
   const decorateTrack = useCallback(() => ({}), []);
 
+  const [drawerOpen, setDrawerOpen] = useTimelineDrawerOpen();
+
   return (
     <TrackProvider
       key={ready ? "ready" : "init"}
       tracks={tracks}
       autoPinNewTracks={false}
     >
-      <TimelineWithTracks decorateTrack={decorateTrack} />
+      <TimelineWithTracks
+        decorateTrack={decorateTrack}
+        drawerOpen={drawerOpen}
+        onDrawerOpenChange={setDrawerOpen}
+      />
     </TrackProvider>
   );
 };

--- a/app/packages/video-annotation/src/components/SyntheticLabels.tsx
+++ b/app/packages/video-annotation/src/components/SyntheticLabels.tsx
@@ -101,7 +101,7 @@ export const SyntheticTrackTimeline: React.FC = () => {
       tracks={tracks}
       autoPinNewTracks={false}
     >
-      <TimelineWithTracks decorateTrack={decorateTrack} />
+      <TimelineWithTracks decorateTrack={decorateTrack} defaultDrawerOpen />
     </TrackProvider>
   );
 };

--- a/app/packages/video-annotation/src/components/VideoAnnotationSurface.tsx
+++ b/app/packages/video-annotation/src/components/VideoAnnotationSurface.tsx
@@ -1,4 +1,4 @@
-import { getSampleSrc } from "@fiftyone/state";
+import { getSampleSrc, useDimensions } from "@fiftyone/state";
 import type { ModalSample } from "@fiftyone/state";
 import React, { useMemo, useState } from "react";
 import { useAutoInterpolate } from "../hooks/useAutoInterpolate";
@@ -11,7 +11,7 @@ import { useFollowAnchorFrame } from "../state/useVideoInteraction";
 import { useAnnotatePrerequisites } from "../hooks/useAnnotatePrerequisites";
 import { useDecodeStrategy } from "../hooks/useDecodeStrategy";
 import type { DecodeStrategy } from "../utils/decodeStrategy";
-import { PlaybackProvider } from "@fiftyone/playback";
+import { PlaybackProvider, TIMELINE_DRAWER_MAX_SIZE } from "@fiftyone/playback";
 import {
   AnnotatePrerequisiteChecking,
   AnnotatePrerequisiteNotice,
@@ -37,6 +37,15 @@ import styles from "./VideoAnnotationSurface.module.css";
  * Read once at mount; flipping requires reopening the modal.
  */
 type LabelsMode = "real" | "synthetic";
+
+/**
+ * Fraction of the surface height the timeline may occupy before its body caps
+ * and scrolls internally — so a growing track list never crowds out the media.
+ */
+const TIMELINE_MAX_HEIGHT_FRACTION = 0.25;
+
+/** Floor for the timeline body cap so it stays usable on a short surface. */
+const TIMELINE_MIN_MAX_SIZE = 160;
 
 function useLabelsMode(): LabelsMode {
   const [mode] = useState<LabelsMode>(() => {
@@ -119,6 +128,20 @@ export const VideoAnnotationSurface: React.FC<VideoAnnotationSurfaceProps> = ({
   const labelsMode = useLabelsMode();
   const prerequisites = useAnnotatePrerequisites(sample);
 
+  // Measure the surface so the timeline body caps at a fraction of it: past the
+  // cap the drawer scrolls internally instead of growing into the media area.
+  const dimensions = useDimensions();
+  const surfaceHeight = dimensions.bounds?.height ?? 0;
+  const timelineMaxSize = surfaceHeight
+    ? Math.min(
+        TIMELINE_DRAWER_MAX_SIZE,
+        Math.max(
+          TIMELINE_MIN_MAX_SIZE,
+          Math.round(surfaceHeight * TIMELINE_MAX_HEIGHT_FRACTION),
+        ),
+      )
+    : undefined;
+
   // Resolved top-level media URL. The `html` tile binds to it and the `extract`
   // source decodes it in a worker; the `fetch` source resolves per-frame URLs
   // instead and ignores it.
@@ -139,7 +162,10 @@ export const VideoAnnotationSurface: React.FC<VideoAnnotationSurfaceProps> = ({
   // actionable prompt instead of a stream that would throw or blank out.
   if (prerequisites.status === "blocked") {
     return (
-      <div className={styles.root}>
+      <div
+        ref={dimensions.ref as React.RefObject<HTMLDivElement>}
+        className={styles.root}
+      >
         <VideoAnnotationTopBar sample={sample} />
         <div className={styles.media}>
           <AnnotatePrerequisiteNotice blocker={prerequisites.blocker} />
@@ -152,7 +178,10 @@ export const VideoAnnotationSurface: React.FC<VideoAnnotationSurfaceProps> = ({
   // hold on a spinner so the scaffolding mounts exactly once, on the winner.
   if (resolution.status !== "resolved" || !resolution.strategy) {
     return (
-      <div className={styles.root}>
+      <div
+        ref={dimensions.ref as React.RefObject<HTMLDivElement>}
+        className={styles.root}
+      >
         <VideoAnnotationTopBar sample={sample} />
         <div className={styles.media}>
           <AnnotatePrerequisiteChecking />
@@ -166,7 +195,10 @@ export const VideoAnnotationSurface: React.FC<VideoAnnotationSurfaceProps> = ({
   const Registrar = STRATEGY_REGISTRAR[strategy];
 
   const layout = (
-    <div className={styles.root}>
+    <div
+      ref={dimensions.ref as React.RefObject<HTMLDivElement>}
+      className={styles.root}
+    >
       <VideoAnnotationTopBar sample={sample} />
       <div className={styles.media}>
         <Tile videoSrc={videoSrc} />
@@ -175,7 +207,7 @@ export const VideoAnnotationSurface: React.FC<VideoAnnotationSurfaceProps> = ({
         {labelsMode === "synthetic" ? (
           <SyntheticTrackTimeline />
         ) : (
-          <FrameLabelsTracks sample={sample} />
+          <FrameLabelsTracks sample={sample} maxSize={timelineMaxSize} />
         )}
       </div>
     </div>

--- a/app/packages/video-annotation/src/state/useTimelineDrawer.ts
+++ b/app/packages/video-annotation/src/state/useTimelineDrawer.ts
@@ -1,0 +1,14 @@
+import { useAtom } from "jotai";
+import { atomWithStorage } from "jotai/utils";
+
+// Global user preference for the annotation timeline drawer's open state.
+// Persisted so it survives the surface remount on every sample switch / mode
+// toggle instead of resetting to the mount-time default.
+const timelineDrawerOpenAtom = atomWithStorage("HA.timelineDrawerOpen", false);
+
+/**
+ * Read/write the persisted annotation timeline drawer open state. Wire the
+ * value and setter into `TimelineWithTracks`'s controlled `drawerOpen` /
+ * `onDrawerOpenChange` so the choice sticks across samples.
+ */
+export const useTimelineDrawerOpen = () => useAtom(timelineDrawerOpenAtom);

--- a/e2e-pw/src/oss/poms/modal/video-annotate.ts
+++ b/e2e-pw/src/oss/poms/modal/video-annotate.ts
@@ -123,6 +123,45 @@ export class VideoAnnotatePom {
   }
 
   /**
+   * Expand the tracks drawer. The playback controls row is the drawer toggle
+   * (`role="button"`); focus it and press Enter so the keypress toggles the
+   * drawer rather than landing on a nested playback button. It toggles, so call
+   * only from the closed default.
+   */
+  async openTracksDrawer() {
+    const toggle = this.page
+      .locator('[data-testid="timeline-controls-root"]')
+      .first();
+    await toggle.focus();
+    await toggle.press("Enter");
+  }
+
+  /** Collapse the tracks drawer back to the closed default — see {@link openTracksDrawer}. */
+  async closeTracksDrawer() {
+    const toggle = this.page
+      .locator('[data-testid="timeline-controls-root"]')
+      .first();
+    await toggle.focus();
+    await toggle.press("Enter");
+  }
+
+  /**
+   * Pin an object track so its row stays in the always-visible timeline header
+   * once the drawer closes. The pin button only mounts while the row is
+   * rendered, so open the drawer to reach it, pin, then restore the closed
+   * default — the pinned row remains in the header, ready for interaction
+   * without the drawer open. Call once from the closed default.
+   */
+  async pinTrack(trackId: string) {
+    await this.openTracksDrawer();
+    await this.page
+      .locator(`[data-testid="timeline-track-pin-${trackId}"]`)
+      .first()
+      .click();
+    await this.closeTracksDrawer();
+  }
+
+  /**
    * The track's presence interval bar (the right-click target for its context
    * menu). The bar carries `data-event-index`; its resize handles also do, so
    * exclude `data-resize-handle` to land on the bar itself.
@@ -395,6 +434,36 @@ class VideoAnnotateAsserter {
     await expect
       .poll(async () => (await this.va.trackIds()).includes(trackId))
       .toBe(present);
+  }
+
+  /**
+   * Assert a track's interval bar is (not) actionable. A closed drawer keeps the
+   * bar mounted and on-screen but non-interactive; pinning the row into the
+   * header or opening the drawer makes it clickable again. Actionability — not
+   * mere visibility — is what timeline interactions (clicks, context menus)
+   * actually depend on.
+   */
+  async trackBarActionable(trackId: string, actionable = true) {
+    const bar = this.va.trackBar(trackId);
+    if (actionable) {
+      await bar.click({ trial: true });
+      return;
+    }
+
+    // the bar must stay mounted and on-screen — otherwise a rejected trial
+    // click would prove "gone", not "non-actionable"
+    await expect(bar).toBeVisible();
+
+    let rejected = false;
+    try {
+      await bar.click({ trial: true, timeout: 1500 });
+    } catch {
+      rejected = true;
+    }
+    expect(
+      rejected,
+      "expected the track bar to be non-actionable while the drawer is closed",
+    ).toBe(true);
   }
 
   /** Assert a label (by class text) is / isn't listed in the annotate sidebar. */

--- a/e2e-pw/src/oss/specs/annotate-video-dynamic-subtracks.spec.ts
+++ b/e2e-pw/src/oss/specs/annotate-video-dynamic-subtracks.spec.ts
@@ -126,6 +126,9 @@ test.describe.serial("video annotation dynamic attribute sub-tracks", () => {
     const va = modal.videoAnnotate;
 
     const parentId = await va.firstObjectTrackId();
+
+    // sub-track expansion lives in the drawer body; the drawer starts closed
+    await va.openTracksDrawer();
     const subId = `${parentId}::${ATTR}`;
 
     // Collapsed by default — no sub-track rows.
@@ -158,6 +161,9 @@ test.describe.serial("video annotation dynamic attribute sub-tracks", () => {
     await setSignal(modal, page, "left");
 
     const parentId = await va.firstObjectTrackId();
+
+    // sub-track expansion lives in the drawer body; the drawer starts closed
+    await va.openTracksDrawer();
     const subId = `${parentId}::${ATTR}`;
 
     await va.toggleTrackExpansion(parentId);
@@ -183,6 +189,9 @@ test.describe.serial("video annotation dynamic attribute sub-tracks", () => {
     await setSignal(modal, page, "left");
 
     const parentId = await va.firstObjectTrackId();
+
+    // sub-track expansion lives in the drawer body; the drawer starts closed
+    await va.openTracksDrawer();
     const subId = `${parentId}::${ATTR}`;
 
     await va.toggleTrackExpansion(parentId);
@@ -209,6 +218,9 @@ test.describe.serial("video annotation dynamic attribute sub-tracks", () => {
     await setSignal(modal, page, "left");
 
     const parentId = await va.firstObjectTrackId();
+
+    // sub-track expansion lives in the drawer body; the drawer starts closed
+    await va.openTracksDrawer();
     const subId = `${parentId}::${ATTR}`;
 
     await va.toggleTrackExpansion(parentId);
@@ -234,6 +246,9 @@ test.describe.serial("video annotation dynamic attribute sub-tracks", () => {
     const va = modal.videoAnnotate;
 
     const parentId = await va.firstObjectTrackId();
+
+    // sub-track expansion lives in the drawer body; the drawer starts closed
+    await va.openTracksDrawer();
     const subId = `${parentId}::${ATTR}`;
 
     // Expand without selecting anything first.
@@ -270,6 +285,9 @@ test.describe.serial("video annotation multiple dynamic attributes", () => {
     const va = modal.videoAnnotate;
 
     const parentId = await va.firstObjectTrackId();
+
+    // sub-track expansion lives in the drawer body; the drawer starts closed
+    await va.openTracksDrawer();
 
     await va.toggleTrackExpansion(parentId);
     await expect

--- a/e2e-pw/src/oss/specs/annotate-video-label-types.spec.ts
+++ b/e2e-pw/src/oss/specs/annotate-video-label-types.spec.ts
@@ -119,6 +119,11 @@ test.describe.serial("video non-box label rendering", () => {
     // swaps the list for its editor), then start on a different label so the
     // timeline click must change the selection.
     const instanceId = await modal.videoAnnotate.labelRowId("person");
+
+    // the tracks drawer starts closed; pin the row so the timeline click below
+    // has a visible target
+    await modal.videoAnnotate.pinTrack(instanceId);
+
     await modal.videoAnnotate.selectLabel("vehicle");
     await modal.sidebar.edit.assert.verifyFieldValue("label", "vehicle");
 

--- a/e2e-pw/src/oss/specs/annotate-video-temporal-crud.spec.ts
+++ b/e2e-pw/src/oss/specs/annotate-video-temporal-crud.spec.ts
@@ -118,6 +118,10 @@ test.describe.serial("video annotation temporal detection CRUD", () => {
     const newTrack = (await va.temporalTrackIds()).find((t) => !before.has(t));
     expect(newTrack).toBeTruthy();
 
+    // the tracks drawer starts closed; pin the new TD row so the timeline click
+    // has a visible target
+    await va.pinTrack(newTrack as string);
+
     const saved = savedResponse(page);
     await va.clickTrack(newTrack as string);
     await expect(modal.sidebar.edit.backButton).toBeVisible();

--- a/e2e-pw/src/oss/specs/annotate-video-temporal-edit.spec.ts
+++ b/e2e-pw/src/oss/specs/annotate-video-temporal-edit.spec.ts
@@ -100,6 +100,11 @@ test.describe.serial("video annotation temporal detection edit", () => {
 
     // "approach" is [1,6] -> rendered span 0.00-0.60s
     const approach = await trackIdForLabel(va, "approach");
+
+    // the tracks drawer starts closed; pin the TD row so its interval bar is
+    // rendered for the reads and drag below
+    await va.pinTrack(approach);
+
     expect(await va.trackBarTitle(approach)).toContain("0.00-0.60s");
 
     // drag the end handle right; resolves to support end frame 7 -> 0.70s

--- a/e2e-pw/src/oss/specs/annotate-video-timeline-drawer.spec.ts
+++ b/e2e-pw/src/oss/specs/annotate-video-timeline-drawer.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ *
+ * The video-annotation tracks drawer opens CLOSED by default (a global user
+ * preference persisted across samples). While closed, a track's interval bar
+ * stays mounted but non-interactive; it becomes clickable again only after
+ * pinning the row into the header or opening the drawer. This covers both
+ * routes back to an actionable track.
+ */
+import { test as base } from "src/oss/fixtures";
+import { ModalPom } from "src/oss/poms/modal";
+import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
+import type { AbstractFiftyoneLoader } from "src/shared/abstract-loader";
+import type { Page } from "src/oss/fixtures";
+
+const datasetName = getUniqueDatasetNameWithPrefix(
+  "annotate-video-timeline-drawer",
+);
+const id = "000000000000000000000000";
+const clip = `/tmp/${datasetName}.webm`;
+
+const test = base.extend<{ modal: ModalPom }>({
+  modal: async ({ page, eventUtils }, use) => {
+    await use(new ModalPom(page, eventUtils));
+  },
+});
+
+test.beforeAll(async ({ foWebServer, mediaFactory }) => {
+  await foWebServer.startWebServer();
+  await mediaFactory.createVideo({
+    outputPath: clip,
+    duration: 2,
+    width: 64,
+    height: 64,
+    frameRate: 10,
+    color: "#3050a0",
+  });
+});
+
+test.afterAll(async ({ foWebServer }) => {
+  await foWebServer.stopWebServer();
+});
+
+test.beforeEach(async ({ videoAnnotateSDK }) => {
+  // one tracked vehicle (index=1) on every frame; no TDs so the timeline holds
+  // a single object track.
+  await videoAnnotateSDK.seed({
+    datasetName,
+    videoPaths: [clip],
+    withEvents: false,
+    trackedSampleIndices: [0],
+  });
+});
+
+const openAnnotate = async (
+  fiftyoneLoader: AbstractFiftyoneLoader,
+  modal: ModalPom,
+  page: Page,
+) => {
+  await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
+    searchParams: new URLSearchParams({ id }),
+  });
+  await modal.assert.isOpen();
+  await modal.sidebar.switchMode("annotate");
+  await modal.videoAnnotate.waitForSurface();
+};
+
+test.describe.serial("video annotation timeline drawer", () => {
+  test("starts closed; pinning a track makes its row actionable in the header", async ({
+    fiftyoneLoader,
+    modal,
+    page,
+  }) => {
+    await openAnnotate(fiftyoneLoader, modal, page);
+    const va = modal.videoAnnotate;
+
+    await va.assert.objectTrackCount(1);
+    const [trackId] = await va.objectTrackIds();
+
+    // closed by default: the bar is on-screen but can't be interacted with
+    await va.assert.trackBarActionable(trackId, false);
+
+    // pinning lifts the row into the always-visible header, drawer still closed
+    await va.pinTrack(trackId);
+    await va.assert.trackBarActionable(trackId, true);
+  });
+
+  test("opening the drawer manually reveals an unpinned track for interaction", async ({
+    fiftyoneLoader,
+    modal,
+    page,
+  }) => {
+    await openAnnotate(fiftyoneLoader, modal, page);
+    const va = modal.videoAnnotate;
+
+    await va.assert.objectTrackCount(1);
+    const [trackId] = await va.objectTrackIds();
+
+    await va.assert.trackBarActionable(trackId, false);
+
+    // opening the drawer brings the unpinned row into the interactive body
+    await va.openTracksDrawer();
+    await va.assert.trackBarActionable(trackId, true);
+
+    // and it's fully interactive there — delete the whole track from the menu
+    await va.deleteTrackViaContextMenu(trackId);
+    await va.assert.objectTrackCount(0);
+  });
+});

--- a/e2e-pw/src/oss/specs/annotate-video-track-delete.spec.ts
+++ b/e2e-pw/src/oss/specs/annotate-video-track-delete.spec.ts
@@ -85,6 +85,10 @@ test.describe.serial("video annotation whole-track delete", () => {
     await va.assert.labelListed("vehicle");
     const [trackId] = await va.objectTrackIds();
 
+    // the tracks drawer starts closed; pin the row into the header to reach its
+    // interval bar
+    await va.pinTrack(trackId);
+
     // delete the whole track via the timeline context menu; autosave persists it
     const saved = page.waitForResponse(
       (r) =>

--- a/e2e-pw/src/oss/specs/annotate-video-track-edit.spec.ts
+++ b/e2e-pw/src/oss/specs/annotate-video-track-edit.spec.ts
@@ -251,6 +251,10 @@ test.describe.serial("video annotation track editing", () => {
     await va.assert.objectTrackCount(1);
     const [trackId] = await va.objectTrackIds();
 
+    // the tracks drawer starts closed; pin the row so the later timeline click
+    // has a visible target
+    await va.pinTrack(trackId);
+
     // sidebar row -> editor
     await va.selectLabel("vehicle");
     await expect(modal.sidebar.edit.backButton).toBeVisible();

--- a/e2e-pw/src/oss/specs/annotate-video-track-split-merge.spec.ts
+++ b/e2e-pw/src/oss/specs/annotate-video-track-split-merge.spec.ts
@@ -99,6 +99,10 @@ test.describe.serial("video annotation track split / merge", () => {
     await va.assert.objectTrackCount(2);
     const vehicleId = await va.labelRowId("vehicle");
 
+    // the tracks drawer starts closed; pin the row so its timeline interactions
+    // have a visible target
+    await va.pinTrack(vehicleId);
+
     // seek mid-clip so the playhead sits between the track's first and last
     // frame — both sides of the split are then non-empty
     await va.clickTrack(vehicleId);
@@ -124,6 +128,10 @@ test.describe.serial("video annotation track split / merge", () => {
 
     await va.assert.objectTrackCount(2);
     const vehicleId = await va.labelRowId("vehicle");
+
+    // the tracks drawer starts closed; pin the row so the timeline click has a
+    // visible target
+    await va.pinTrack(vehicleId);
 
     // select the track (Split enables with one selected), then seek mid-clip
     // (the row click that selects also jumps the playhead to the track start)
@@ -151,6 +159,10 @@ test.describe.serial("video annotation track split / merge", () => {
     await va.assert.objectTrackCount(2);
     await va.assert.labelListed("vehicle");
     const [sourceId] = await va.objectTrackIds();
+
+    // the tracks drawer starts closed; pin the source row so its context menu
+    // is reachable
+    await va.pinTrack(sourceId);
 
     // merge one vehicle INTO the other; both span every frame, so target-wins
     // drops every source frame — one track remains, still "vehicle"
@@ -189,6 +201,10 @@ test.describe.serial("video annotation track split / merge", () => {
     await va.assert.labelListed("vehicle");
     await va.assert.labelListed("person");
     const personId = await va.labelRowId("person");
+
+    // the tracks drawer starts closed; pin the row so its context menu is
+    // reachable
+    await va.pinTrack(personId);
 
     // right-click the person track's bar; the menu opens (Delete track proves
     // it did) but carries no merge target — the only other track is a different

--- a/e2e-pw/src/oss/specs/annotate-video-undo.spec.ts
+++ b/e2e-pw/src/oss/specs/annotate-video-undo.spec.ts
@@ -209,6 +209,10 @@ test.describe.serial("video annotation undo/redo", () => {
     await va.assert.objectTrackCount(1);
     const [trackId] = await va.objectTrackIds();
 
+    // the tracks drawer starts closed, so pin the row into the header to reach
+    // its interval bar without opening the drawer
+    await va.pinTrack(trackId);
+
     // whole-track delete (one engine transaction)
     await va.deleteTrackViaContextMenu(trackId);
     await va.assert.objectTrackCount(0);


### PR DESCRIPTION
## What

Two video-annotation fixes:

### Delete removes the whole track + "Delete current frame" menu

Backspace/Delete on a selected video frame label previously removed only the current frame's instance, leaving the rest of the track behind. It now deletes the entire track, and a new **Delete current frame** entry in the timeline track's right-click menu preserves the old single-frame behavior.

### Cap the annotation timeline height

The timeline grew taller with every added track and would overlap the media. It's now capped at 25% of the surface height (clamped to [160px, 600px]) and scrolls internally past that, so the media keeps its space. The cap is responsive to the surface size.

## Test plan

Video dataset, annotate surface:

- Select a multi-frame track → Backspace/Delete removes the whole track; one Ctrl-Z restores it.
- Right-click a timeline track → **Delete current frame** removes only the playhead frame; a no-op on a frame the track doesn't occupy.
- Sub-select a polyline vertex → Backspace removes just the vertex, the track survives.
- Image dataset → Backspace deletes just the selected label (unchanged).
- Add many tracks → the timeline caps at ~25% of the surface and scrolls internally; the media stays visible. Resize the window → the cap tracks the surface height.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “delete track” to remove an entire video annotation track across all frames in a single undoable action.
  * Added **Delete current frame** to object-track context menus.
  * Preserves vertex-level editing when deleting selected polyline/keypoint vertices.
* **Improvements**
  * Timeline drawer now defaults to **closed**, with open/closed state persisted across surface remounts.
  * Timeline drawer height adapts to available workspace.
* **Bug Fixes**
  * Deletion properly handles persistence failures by reporting errors and restoring prior changes when saving fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3347
<!-- enterprise-sync-pr:end -->