### PR TITLE
fix(video-annotation): fix polyline/keypoint point editing behavior

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/usePolylineMode.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/usePolylineMode.ts
@@ -8,31 +8,28 @@ import {
   PolylineOverlay,
   useLighter,
 } from "@fiftyone/lighter";
-import {
-  AnnotationLabel,
-  isPatchesView,
-  PolylineAnnotationLabel,
-} from "@fiftyone/state";
+import { isPatchesView } from "@fiftyone/state";
 import { POLYLINE } from "@fiftyone/utilities";
 import { atom, useAtom, useAtomValue, useSetAtom } from "jotai";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useRecoilValue } from "recoil";
 import {
+  type AnnotationContextSelected,
   type CreateOptions,
   useAnnotationContext,
   useAnnotationFields,
 } from "./useAnnotationContext";
 
 /**
- * Utility method to determine if an {@link AnnotationLabel} is a 2d polyline.
- *
- * @param label Label to check
+ * Whether a 2D polyline is the current selection. Keys off the normalized
+ * selection `type`: a committed polyline reconciles back under the plural
+ * `Polylines` field type, which `currentType` folds into `Polyline` — the raw
+ * `label.type` would miss it and leave the edit tool disarmed.
  */
-const is2dPolyline = (
-  label: AnnotationLabel,
-): label is PolylineAnnotationLabel => {
-  return label?.type === "Polyline" && label.overlay instanceof PolylineOverlay;
-};
+const is2dPolylineSelected = (
+  selected: AnnotationContextSelected | null | undefined,
+): boolean =>
+  selected?.type === POLYLINE && selected.overlay instanceof PolylineOverlay;
 
 /**
  * Active flag for 2D polyline annotation mode. While `true`, selecting a
@@ -168,13 +165,13 @@ export const usePolylineModeInstaller = (): void => {
   // exits it. Deselecting entirely leaves the mode active so the user can
   // immediately draw another polyline — exiting requires an explicit gesture
   // (toolbar toggle or generic mode-quit).
-  const prevSelectedLabelRef = useRef(selected?.label);
+  const prevSelectedRef = useRef(selected);
   useEffect(() => {
-    const prev = prevSelectedLabelRef.current;
-    prevSelectedLabelRef.current = selected?.label;
+    const prev = prevSelectedRef.current;
+    prevSelectedRef.current = selected;
 
-    const isPolyline2d = is2dPolyline(selected?.label);
-    const wasPolyline2d = is2dPolyline(prev);
+    const isPolyline2d = is2dPolylineSelected(selected);
+    const wasPolyline2d = is2dPolylineSelected(prev);
 
     if (isPolyline2d) {
       setPolylineModeActive(true);
@@ -182,7 +179,7 @@ export const usePolylineModeInstaller = (): void => {
       // Switched from a polyline to a different non-polyline label.
       setPolylineModeActive(false);
     }
-  }, [selected?.label, setPolylineModeActive]);
+  }, [selected, setPolylineModeActive]);
 
   // Stable ref so the creation handler's `onCreate` always sees the latest
   // create function without needing to swap the installed handler.
@@ -203,7 +200,7 @@ export const usePolylineModeInstaller = (): void => {
       return;
     }
 
-    const isPolyline2d = is2dPolyline(selected?.label);
+    const isPolyline2d = is2dPolylineSelected(selected);
 
     if (!polylineModeActive) {
       exitInstalledHandler();
@@ -262,7 +259,7 @@ export const usePolylineModeInstaller = (): void => {
 
     scene.enterInteractiveMode(handler);
     installedHandlerRef.current = handler;
-  }, [exitInstalledHandler, polylineModeActive, scene, selected?.label]);
+  }, [exitInstalledHandler, polylineModeActive, scene, selected]);
 
   // Tear down on unmount (e.g., scene swap, modal close).
   useEffect(() => {

--- a/app/packages/lighter/src/interaction/InteractivePolylineHandler.ts
+++ b/app/packages/lighter/src/interaction/InteractivePolylineHandler.ts
@@ -288,9 +288,12 @@ export class InteractivePolylineHandler implements InteractionHandler {
 
   onMove({ worldPoint, event }: OverlayEvent): boolean {
     if (this.dragPointId !== null) {
+      // Move silently while dragging; onPointerUp emits the single committed
+      // move so the engine writes once per gesture, not once per frame.
       this.overlay.movePointById(
         this.dragPointId,
         this.overlay.absolutePointToRelative(worldPoint),
+        false,
       );
       // Hide new point preview while dragging
       this.overlay.setPreviewPoint(null);
@@ -386,6 +389,10 @@ export class InteractivePolylineHandler implements InteractionHandler {
     if (from[0] === to[0] && from[1] === to[1]) {
       return true;
     }
+
+    // Live drag moved the point silently; emit the committed move now so the
+    // engine records one write for the whole gesture.
+    this.overlay.emitPointMoved(id, from, to);
 
     const cmd = new MoveKeypointPointCommand(
       this.overlay as unknown as KeypointOverlay,

--- a/app/packages/lighter/src/overlay/KeypointOverlay.ts
+++ b/app/packages/lighter/src/overlay/KeypointOverlay.ts
@@ -307,6 +307,10 @@ export class KeypointOverlay
     return this._relativeBoundsCache;
   }
 
+  isInteracting(): boolean {
+    return this.dragPointIndex !== null;
+  }
+
   isDragging(): boolean {
     return this.dragPointIndex !== null;
   }

--- a/app/packages/lighter/src/overlay/KeypointOverlay.ts
+++ b/app/packages/lighter/src/overlay/KeypointOverlay.ts
@@ -876,8 +876,12 @@ export class KeypointOverlay
    *
    * @param pointId - ID of the point to move
    * @param to - [x, y] destination coordinates
+   * @param emit - When `false`, moves silently (re-render only, no
+   *   `keypoint-point-moved`). Interactive handlers use this to update the point
+   *   live during a drag and emit a single committed move on pointer-up, so the
+   *   engine writes once per gesture rather than once per frame.
    */
-  movePointById(pointId: string, to: [number, number]): void {
+  movePointById(pointId: string, to: [number, number], emit = true): void {
     const entry = this.#points.find((p) => p.id === pointId);
     if (!entry) {
       return;
@@ -886,6 +890,23 @@ export class KeypointOverlay
     const from: [number, number] = entry.position;
     entry.position = [to[0], to[1]];
 
+    if (emit) {
+      this.emitPointMoved(pointId, from, entry.position);
+    }
+
+    this.markDirty();
+  }
+
+  /**
+   * Dispatches a committed `keypoint-point-moved`. Handlers that drag a point
+   * silently (see {@link movePointById}) call this once on pointer-up to
+   * finalize the gesture with its true start/end positions.
+   */
+  emitPointMoved(
+    pointId: string,
+    from: [number, number],
+    to: [number, number],
+  ): void {
     this.eventBus.dispatch("lighter:keypoint-point-moved", {
       id: this.id,
       overlayId: this.id,
@@ -893,8 +914,6 @@ export class KeypointOverlay
       from: { x: from[0], y: from[1] },
       to: { x: to[0], y: to[1] },
     });
-
-    this.markDirty();
   }
 
   /**

--- a/app/packages/video-annotation/src/hooks/useKeyframePromotionOnEdit.test.ts
+++ b/app/packages/video-annotation/src/hooks/useKeyframePromotionOnEdit.test.ts
@@ -1,8 +1,8 @@
 /**
- * The bridge's `onEditCommit` callback: after a box drag / resize commits,
+ * The bridge's `onEditCommit` callback: after a geometry drag / resize commits,
  * promote the touched frame to a keyframe and dispatch `keyframeChanged` so the
- * auto-interpolate hook re-lerps. Bbox-only, frame-scoped, and folded into the
- * edit's undo unit via the commit's `undoKey`.
+ * auto-interpolate hook re-lerps. Frame-scoped, geometry-bearing (box or
+ * points), and folded into the edit's undo unit via the commit's `undoKey`.
  */
 
 import { renderHook } from "@testing-library/react";
@@ -103,12 +103,43 @@ describe("useKeyframePromotionOnEdit", () => {
     expect(mockBus.dispatch).not.toHaveBeenCalled();
   });
 
-  it("ignores a label without a bounding box — the lerp interpolates bbox only", () => {
+  it("promotes a points-based (keypoint / polyline) frame — points persist as keyframes", () => {
+    frameData = {
+      A: det({
+        _cls: "Polyline",
+        keyframe: false,
+        bounding_box: undefined,
+        points: [[[0, 0]]],
+      }),
+    };
+
+    render()("A", "frames.polylines", "gesture:4");
+
+    expect(mockEngine.updateLabel).toHaveBeenCalledWith(
+      {
+        sample: SAMPLE,
+        path: "frames.polylines",
+        instanceId: "A",
+        frame: FRAME,
+      },
+      { keyframe: true },
+    );
+    expect(mockBus.dispatch).toHaveBeenCalledWith(
+      "annotation:keyframeChanged",
+      expect.objectContaining({
+        instanceId: "A",
+        kind: "set",
+        path: "frames.polylines",
+      }),
+    );
+  });
+
+  it("ignores a label with neither bounding box nor points", () => {
     frameData = {
       A: det({ keyframe: false, bounding_box: undefined }),
     };
 
-    render()("A", PATH, "gesture:4");
+    render()("A", PATH, "gesture:6");
 
     expect(mockEngine.updateLabel).not.toHaveBeenCalled();
     expect(mockBus.dispatch).not.toHaveBeenCalled();

--- a/app/packages/video-annotation/src/hooks/useKeyframePromotionOnEdit.ts
+++ b/app/packages/video-annotation/src/hooks/useKeyframePromotionOnEdit.ts
@@ -12,17 +12,14 @@ import { useCallback } from "react";
 import { useCurrentFrameGetter } from "../state/useCurrentFrame";
 
 /**
- * Builds the bridge's `onEditCommit` callback: after a box drag / resize lands
- * on the engine, promote the touched frame to a keyframe (clearing any
+ * Builds the bridge's `onEditCommit` callback: after a geometry drag / resize
+ * lands on the engine, promote the touched frame to a keyframe (clearing any
  * interpolation provenance) and dispatch `annotation:keyframeChanged` so
  * {@link useAutoInterpolate} re-lerps the bracketing segments against the new
- * geometry. This is the engine-era equivalent of the wiring the pre-engine
- * `upsertFromOverlay` carried via `toLocalDetection`. The promotion write folds
- * into the edit's undo unit via the gesture `undoKey` the commit landed under,
- * so one Ctrl-Z reverts the whole nudge.
+ * geometry. The promotion write folds into the edit's undo unit via the gesture
+ * `undoKey` the commit landed under, so one Ctrl-Z reverts the whole nudge.
  *
- * Bbox-only and frame-scoped: a sample-level temporal detection has no keyframe,
- * and a keypoint / polyline carries no `bounding_box` for the linear lerp.
+ * Frame-scoped: a sample-level temporal detection has no keyframe.
  */
 export const useKeyframePromotionOnEdit = (): ((
   overlayId: string,
@@ -44,8 +41,14 @@ export const useKeyframePromotionOnEdit = (): ((
       const ref = { sample, path, instanceId: overlayId, frame };
       const det = engine.getLabel(ref);
 
-      // bbox tracks only — the linear interpolation lerps `bounding_box`
-      if (!det || !Array.isArray(det.bounding_box)) {
+      if (!det) {
+        return;
+      }
+
+      // geometry-bearing frame labels only: box tracks lerp `bounding_box`;
+      // keypoint / polyline tracks carry `points` and persist as keyframes
+      // (points don't interpolate, so the keyframe is what makes the edit stick)
+      if (!Array.isArray(det.bounding_box) && !Array.isArray(det.points)) {
         return;
       }
 


### PR DESCRIPTION
## What

Four fixes for editing polylines and keypoints on the video annotation surface (FOEPD-4230, FOEPD-4231), plus two polyline-editing bugs surfaced while verifying them.

### Keep keypoint/polyline point drags sticky

Dragging a vertex dropped the grab the moment the cursor outran the point. `KeypointOverlay.isInteracting()` now reports an active point drag, so the interaction manager pins the drag handler for the whole gesture instead of re-resolving it under the cursor. `PolylineOverlay` inherits this, so both keypoints and polylines are covered.

### Promote points-based edits to keyframes on commit

A points-based edit (keypoint / polyline) on a video frame committed without promoting the frame to a keyframe, so the change wasn't anchored in time. The keyframe-promotion gate now accepts a `points` edit alongside `bounding_box`. Points don't interpolate by design, so keyframe promotion is the durable anchor.

### Re-arm the polyline edit tool when a committed polyline is reselected

After committing a polyline, reselecting it for editing let you drag existing vertices but not add new points — the edit tool never re-armed. The mode gated on the raw `label.type`, which reconciles back as the plural container type `Polylines` after commit (it's `Polyline` only mid-draw). It now keys off the normalized `selected.type` — the same signal `useDetectionMode` uses — which folds `Polylines` into `Polyline`, so the tool arms in both cases.

### Commit polyline point drags once on release, not every frame

Dragging a polyline vertex wrote to the engine on every pointer-move frame, firing a save on each tick. The interactive handler now moves the point silently during the drag and emits a single committed move on pointer-up — matching how bbox drag/resize commit only on `*-end`, and how the overlay's own native keypoint drag already behaved. `movePointById` gains an `emit` flag (default `true`, so undo/redo is unchanged) and a paired `emitPointMoved` for the finalizing dispatch.

## Test plan

Video dataset, annotate surface (experimental annotation on):

- Drag a keypoint/polyline vertex so the cursor moves faster than the point — the grab holds for the whole drag.
- Edit a keypoint/polyline on a non-keyframe video frame — the frame becomes a keyframe on commit.
- Draw + commit a polyline, reselect it — clicking empty space adds points; shift-click starts a new segment; alt-click deletes a vertex.
- Drag a polyline vertex — no save fires mid-drag, one save on release, and a single Ctrl-Z reverts the move.
- Selecting a detection after a polyline still switches modes cleanly; image-dataset editing is unaffected.

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3348
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary of Changes
* **New Features**
  * Point-based and polyline edits now better promote to keyframes when supported geometry is present.
* **Bug Fixes**
  * Polyline annotations now more reliably switch into and out of edit mode based on the actual current selection context.
  * Dragging point/polyline handles no longer floods intermediate updates; the final committed position is emitted once per drag.
* **Tests**
  * Added and expanded coverage for point-based keyframe promotion and updated gesture handling expectations.
* **Documentation**
  * Refreshed hook behavior notes to reflect geometry-based promotion rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->