### PR TITLE
feat(video-annotation): update shift-drag to pan the canvas in overlay creation modes

### DIFF
--- a/app/packages/lighter/src/interaction/InteractionManager.ts
+++ b/app/packages/lighter/src/interaction/InteractionManager.ts
@@ -284,6 +284,15 @@ export class InteractionManager {
     return this.currentPixelCoordinates;
   }
 
+  /**
+   * Whether the camera-pan modifier (shift) is held. A shift-drag pans over
+   * anything under the cursor — empty canvas or an overlay — so it never draws,
+   * selects, or resizes. Aspect-ratio-locked resize lives on alt/meta instead.
+   */
+  private isPanModifierActive(): boolean {
+    return this.currentModifiers.shiftKey;
+  }
+
   private setupEventListeners(): void {
     this.canvas.addEventListener("pointerdown", this.handlePointerDown);
     this.canvas.addEventListener("pointermove", this.handlePointerMove);
@@ -325,6 +334,16 @@ export class InteractionManager {
       }
     } else {
       handler = this.findHandlerAtPoint(point);
+      const isNonOverlay = !handler || handler.id === this.canonicalMediaId;
+
+      // Modifier-drag pans the camera over anything under the cursor — empty
+      // canvas or an overlay. Leave the viewport drag plugin active (no
+      // disableZoomPan / capture / pendingAction) and bail before any selection,
+      // draw, or resize so the drag only pans.
+      if (this.isPanModifierActive()) {
+        return;
+      }
+
       // Prevent pan/zoom when target is selectable
       if (handler && TypeGuards.isSelectable(handler)) {
         this.renderer.disableZoomPan();
@@ -362,8 +381,6 @@ export class InteractionManager {
       // If the user releases without dragging (a click), exit detection mode.
       // Clicking on an existing overlay selects it normally instead.
       if (detectionModeBridge.isActive() || segmentationModeBridge.isActive()) {
-        const isNonOverlay = !handler || handler.id === this.canonicalMediaId;
-
         const isSelectInSegmentation =
           segmentationModeBridge.isActive() &&
           segmentationModeBridge.getActiveTool() === SegmentationTool.Select;
@@ -980,8 +997,10 @@ export class InteractionManager {
 
     this.syncModifiersFromEvent(event);
 
-    if (event.shiftKey) {
-      this.maintainAspectRatio = event.shiftKey;
+    // Alt (Windows/Linux) or Cmd/Meta (macOS) locks the resize aspect ratio;
+    // shift is reserved for camera pan.
+    if (event.altKey || event.metaKey) {
+      this.maintainAspectRatio = true;
       return;
     }
 
@@ -1002,7 +1021,7 @@ export class InteractionManager {
   };
 
   /**
-   * Handles keyboard events for release of shift modifier to maintain aspect ratio.
+   * Handles release of the aspect-ratio-lock modifier (alt/meta).
    * @param event - The keyboard event.
    */
   private handleKeyUp = (event: KeyboardEvent): void => {
@@ -1019,7 +1038,7 @@ export class InteractionManager {
 
     this.syncModifiersFromEvent(event);
 
-    this.maintainAspectRatio = event.shiftKey;
+    this.maintainAspectRatio = event.altKey || event.metaKey;
   };
 
   /**


### PR DESCRIPTION
## What

Shift-drag now pans the annotation canvas over **anything** under the cursor — empty canvas or an overlay. Previously a shift-drag that started on a bbox (or other overlay) got captured for selection/resize instead of panning, so the user lost the pan gesture the moment they crossed a label.

- `InteractionManager.handlePointerDown` bails to the viewport pan plugin as soon as the pan modifier is held — before any selection, draw, or resize — so the drag only pans, regardless of what's under the cursor.
- Aspect-ratio-locked resize moves off shift onto **Alt** (Windows/Linux) or **Cmd/Meta** (macOS), since shift is now reserved for pan.

## Test plan

Annotation surface, image or video:

- Shift-drag starting on empty canvas → pans (unchanged).
- Shift-drag starting **on a bbox / overlay** → pans, without selecting or resizing it.
- Resize a bbox handle while holding **Alt** (or **Cmd** on macOS) → aspect ratio locks; shift no longer locks it.
- A plain (no-modifier) drag on an overlay still selects/moves/resizes as before.

## Known limitation / follow-up

In polyline mode, **shift-click** starts a new segment, so a shift-**drag** there is ambiguous between "new segment" and "pan". This PR does not rebind that; a universal pan-while-drawing gesture that works on a trackpad needs its own always-live pan channel, which is out of scope here. Product to decide the desired polyline-mode pan behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Shift-drag now consistently pans the canvas without triggering selection, drawing, or resizing.
  * Hold **Alt** (Windows/Linux) or **Cmd/Meta** (macOS) while resizing to maintain the object’s aspect ratio.

* **Bug Fixes**
  * Improved modifier-key logic to ensure panning and aspect-ratio locking work reliably without interfering with editing or resize behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3350
<!-- enterprise-sync-pr:end -->