### PR TITLE
fix(formatting): fix linter regression

### DIFF
--- a/app/packages/lighter/src/overlay/PolylineOverlay.ts
+++ b/app/packages/lighter/src/overlay/PolylineOverlay.ts
@@ -887,7 +887,7 @@ export class PolylineOverlay extends KeypointOverlay {
    */
   protected override renderLabelText(
     renderer: Renderer2D,
-    ctx: KeypointRenderContext
+    ctx: KeypointRenderContext,
   ): void {
     // Reset first so a no-draw frame clears any stale hit region.
     this.textBounds = undefined;
@@ -916,7 +916,7 @@ export class PolylineOverlay extends KeypointOverlay {
         backgroundColor: ctx.style.fillStyle || ctx.style.strokeStyle || "#000",
         anchor: { vertical: "center", horizontal: "center" },
       },
-      this.containerId
+      this.containerId,
     );
   }
 


### PR DESCRIPTION
PR #7719 merged `app/packages/lighter/src/overlay/PolylineOverlay.ts` with two missing trailing commas. `Check formatting` is a non-required check, so the unformatted file landed on `develop` and now fails the `lint / eslint` job's format step on every open PR.

This runs `prettier --write` on that one file (the two trailing commas) to clear it fleet-wide.

```
- ctx: KeypointRenderContext        +  ctx: KeypointRenderContext,
- this.containerId                  +  this.containerId,
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted internal code for consistency.
  * No user-visible behavior or functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->