### PR TITLE
Group the annotate sidebar into create and edit sections

### DIFF
--- a/app/packages/annotation/src/components/SaveStatusIndicator.module.css
+++ b/app/packages/annotation/src/components/SaveStatusIndicator.module.css
@@ -17,12 +17,6 @@
   line-height: 0;
 }
 
-/* Subtle glow. Colour is omitted so drop-shadow falls back to the icon's
- * `currentColor`, which voodo sets to the health colour. */
-.glow {
-  filter: drop-shadow(0 0 3px);
-}
-
 .pulsing {
   animation: saveStatusPulse 1.6s ease-in-out infinite;
 }

--- a/app/packages/annotation/src/components/SaveStatusIndicator.tsx
+++ b/app/packages/annotation/src/components/SaveStatusIndicator.tsx
@@ -66,7 +66,7 @@ export const SaveStatusIndicator: React.FC<SaveStatusIndicatorProps> = ({
           name={IconName.Circle}
           size={size}
           color={HEALTH_COLOR[health]}
-          className={pulsing ? `${styles.glow} ${styles.pulsing}` : styles.glow}
+          className={pulsing ? styles.pulsing : ""}
         />
       </span>
     </Tooltip>

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Actions.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Actions.tsx
@@ -29,11 +29,29 @@ import {
 } from "@fiftyone/utilities";
 import PolylineIcon from "@mui/icons-material/Timeline";
 import CuboidIcon from "@mui/icons-material/ViewInAr";
-import { Anchor, Text, Tooltip } from "@voxel51/voodo";
+import {
+  Align,
+  Anchor,
+  Clickable,
+  Divider,
+  Icon,
+  IconName,
+  Justify,
+  Orientation,
+  Size,
+  Spacing,
+  Stack,
+  Text,
+  TextColor,
+  TextVariant,
+  Tooltip,
+} from "@voxel51/voodo";
 import { createContext, useCallback, useContext } from "react";
 import { useRecoilValue } from "recoil";
 import styled from "styled-components";
-import { ItemLeft, ItemRight } from "./Components";
+import { ItemRight } from "./Components";
+import { useSchemaManagerModal } from "./SchemaManager/hooks";
+import useCanManageSchema from "./useCanManageSchema";
 import {
   useAnnotationContext,
   useAnnotationFields,
@@ -54,12 +72,6 @@ const ActionsDiv = styled.div`
   padding: 0.25rem 1rem;
   width: 100%;
   max-width: 100%;
-`;
-
-const Row = styled.div`
-  display: flex;
-  justify-content: space-between;
-  width: 100%;
 `;
 
 const Container = styled.div<{ $active?: boolean }>`
@@ -327,6 +339,27 @@ export const Redo = () => {
   );
 };
 
+// Schema manager entry point for the Create section. Gated on manage
+// permission — hidden entirely when the user can't edit the schema.
+const SchemaManager = () => {
+  const canManage = useCanManageSchema();
+  const { openSchemaManager } = useSchemaManagerModal();
+
+  if (!canManage) {
+    return null;
+  }
+
+  return (
+    <Tooltip anchor={Anchor.Top} content={<Text>Manage schema</Text>} portal>
+      <Clickable onClick={openSchemaManager}>
+        <Round data-cy="open-schema-manager">
+          <Icon name={IconName.Settings} size={Size.Md} />
+        </Round>
+      </Clickable>
+    </Tooltip>
+  );
+};
+
 export const ThreeDPolylines = () => {
   const { createNew } = useAnnotationContext();
   const current3dAnnotationMode = useCurrent3dAnnotationMode();
@@ -442,7 +475,9 @@ export const ThreeDCuboids = () => {
   );
 };
 
-const Actions = () => {
+// `hidden` keeps the section mounted (its mode hooks stay live) but visually
+// removed — the label edit view hides Create while depending on those hooks.
+const Actions = ({ hidden = false }: { hidden?: boolean }) => {
   // This checks if media type of the dataset resolved to 3d
   const is3dDataset = useRecoilValue(is3DDataset);
   // Video annotation handles the per-frame spatial label types — boxes,
@@ -481,41 +516,63 @@ const Actions = () => {
 
   return (
     <DeactivateAllContext.Provider value={deactivateAll}>
-      <ActionsDiv style={{ margin: "0 0.25rem", paddingBottom: "0.5rem" }}>
-        <Row>
-          <ItemLeft style={{ columnGap: "0.1rem" }}>
-            <Select active={noActiveActions} />
-            {isVideo ? (
-              <>
-                <Classification />
-                <Detection />
-                <Segmentation />
-                <Polyline />
-              </>
-            ) : (
-              <>
-                <Classification />
-                {toolsResolved &&
-                  (areThreeDActionsVisible ? (
-                    <>
-                      <ThreeDCuboids />
-                      <ThreeDPolylines />
-                    </>
-                  ) : (
-                    <>
-                      <Detection />
-                      <Segmentation />
-                      <Polyline />
-                    </>
-                  ))}
-              </>
-            )}
-          </ItemLeft>
+      <ActionsDiv
+        style={{
+          margin: "0 0.25rem",
+          paddingBottom: "0.5rem",
+          display: hidden ? "none" : undefined,
+        }}
+      >
+        <Stack
+          orientation={Orientation.Row}
+          align={Align.Center}
+          justify={Justify.Between}
+          style={{ width: "100%" }}
+        >
+          <Text variant={TextVariant.Lg} color={TextColor.Primary}>
+            Create
+          </Text>
           <ItemRight style={{ columnGap: "0.1rem" }}>
             <Undo />
             <Redo />
+            <Divider orientation={Orientation.Column} />
+            <SchemaManager />
           </ItemRight>
-        </Row>
+        </Stack>
+        <Stack
+          orientation={Orientation.Row}
+          align={Align.Center}
+          justify={Justify.Center}
+          spacing={Spacing.Xs}
+          style={{ width: "100%" }}
+        >
+          <Select active={noActiveActions} />
+          {isVideo ? (
+            <>
+              <Classification />
+              <Detection />
+              <Segmentation />
+              <Polyline />
+            </>
+          ) : (
+            <>
+              <Classification />
+              {toolsResolved &&
+                (areThreeDActionsVisible ? (
+                  <>
+                    <ThreeDCuboids />
+                    <ThreeDPolylines />
+                  </>
+                ) : (
+                  <>
+                    <Detection />
+                    <Segmentation />
+                    <Polyline />
+                  </>
+                ))}
+            </>
+          )}
+        </Stack>
       </ActionsDiv>
     </DeactivateAllContext.Provider>
   );

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Annotate.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Annotate.tsx
@@ -119,7 +119,7 @@ const AnnotationBody = ({
       {isGroupDataset && !disabledReason && (
         <GroupAnnotation onSliceSelected={loadSchemas} />
       )}
-      {!showSetup && <Actions key="actions" />}
+      {!showSetup && <Actions key="actions" hidden={isEditingValue} />}
       {isEditingValue && <Edit key="edit" />}
       {showSetup ? (
         <ImportSchema

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Header.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Header.tsx
@@ -1,15 +1,36 @@
 import { useAtomValue } from "jotai";
 import { useCallback, useRef, useState } from "react";
-import { Round } from "../Actions";
+import { Redo, Round, Undo } from "../Actions";
 
 import { DetectionOverlay, useLighter } from "@fiftyone/lighter";
 import { West as Back } from "@mui/icons-material";
-import { Box, Menu, MenuItem, Stack } from "@mui/material";
-import { Clickable, Icon, IconName, Size, Text } from "@voxel51/voodo";
+import { Box, Menu, MenuItem } from "@mui/material";
+import {
+  Align,
+  Clickable,
+  Icon,
+  IconName,
+  Orientation,
+  Size,
+  Spacing,
+  Stack,
+  Text,
+} from "@voxel51/voodo";
 import { DETECTION } from "@fiftyone/utilities";
+import styled from "styled-components";
 import { ItemLeft, ItemRight } from "../Components";
 import { ICONS } from "../Icons";
 import { Row } from "./Components";
+
+// The voodo Divider's line renders too faint against the header; an explicit
+// rule in the theme divider colour keeps the status / action groups legible.
+const VerticalDivider = styled.div`
+  width: 1px;
+  height: 1.25rem;
+  flex-shrink: 0;
+  margin-left: 0.5rem;
+  background: ${({ theme }) => theme.divider};
+`;
 
 import { labels } from "../useLabels";
 import * as fos from "@fiftyone/state";
@@ -148,7 +169,11 @@ const LabelHamburgerMenu = () => {
             onClick={deleteCommand.callback}
             data-cy="label-menu-delete"
           >
-            <Stack direction="row" gap={1} alignItems="center">
+            <Stack
+              orientation={Orientation.Row}
+              align={Align.Center}
+              spacing={Spacing.Sm}
+            >
               <Icon name={IconName.Delete} size={Size.Md} />
               <Text>{deleteCommand.descriptor.label}</Text>
             </Stack>
@@ -204,12 +229,19 @@ const Header = () => {
           <Back />
         </Round>
         {Icon && <Icon fill={color} />}
-        <div>Edit {type}</div>
+        <div style={{ marginRight: "0.75rem" }}>Edit {type}</div>
       </ItemLeft>
       {currentFieldIsReadOnly && <span>Read-only</span>}
       <ItemRight>
-        <Stack direction="row" alignItems="center" gap={1}>
+        <Stack
+          orientation={Orientation.Row}
+          align={Align.Center}
+          spacing={Spacing.Xs}
+        >
           <AnnotationSaveIndicator />
+          <VerticalDivider />
+          <Undo />
+          <Redo />
           {annotationContext.selected?.label != null && <LabelHamburgerMenu />}
         </Stack>
       </ItemRight>

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/LabelList.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/LabelList.tsx
@@ -1,15 +1,4 @@
-import {
-  Align,
-  Button,
-  Orientation,
-  Size,
-  Spacing,
-  Stack,
-  Text,
-  TextColor,
-  TextVariant,
-  Variant,
-} from "@voxel51/voodo";
+import { Text, TextColor, TextVariant } from "@voxel51/voodo";
 import { AnnotationSaveIndicator } from "@fiftyone/annotation";
 import { EntryKind, isGeneratedView } from "@fiftyone/state";
 import { useRecoilValue } from "recoil";
@@ -22,8 +11,6 @@ import LoadingEntry from "./LoadingEntry";
 import PrimitiveEntry from "./PrimitiveEntry";
 import useEntries from "./useEntries";
 import { usePrimitivesCount } from "./usePrimitivesCount";
-import { useSchemaManagerModal } from "./SchemaManager/hooks";
-import useCanManageSchema from "./useCanManageSchema";
 
 const EmptyLabelsContainer = styled.div`
   display: flex;
@@ -37,8 +24,6 @@ export default function AnnotateSidebar() {
   usePrimitivesCount();
   const isEditingValue = useAnnotationContext().isEditing;
   const isGenerated = useRecoilValue(isGeneratedView);
-  const { openSchemaManager } = useSchemaManagerModal();
-  const canManage = useCanManageSchema();
 
   // Don't show label list in edit mode or in generated views (patches/clips/frames)
   // In generated views, only the edit panel should be visible
@@ -46,6 +31,7 @@ export default function AnnotateSidebar() {
 
   const headerStyle = {
     display: "flex",
+    alignItems: "center",
     justifyContent: "space-between",
     marginInline: "1rem",
     paddingBottom: "0.5rem",
@@ -54,26 +40,10 @@ export default function AnnotateSidebar() {
   return (
     <>
       <div style={headerStyle}>
-        <Stack
-          orientation={Orientation.Row}
-          align={Align.Center}
-          spacing={Spacing.Sm}
-        >
-          <AnnotationSaveIndicator />
-          <Text variant={TextVariant.Lg} color={TextColor.Secondary}>
-            Click labels to edit
-          </Text>
-        </Stack>
-        {canManage && (
-          <Button
-            variant={Variant.Borderless}
-            size={Size.Sm}
-            data-cy="open-schema-manager"
-            onClick={openSchemaManager}
-          >
-            Schema
-          </Button>
-        )}
+        <Text variant={TextVariant.Lg} color={TextColor.Primary}>
+          Edit
+        </Text>
+        <AnnotationSaveIndicator />
       </div>
       <Sidebar
         isDisabled={() => true}


### PR DESCRIPTION
## What

Cosmetic restructure of the in-app annotate sidebar into two labelled sections, and surfaces the autosave status indicator across them.

> **Stacked on #7970** — base this PR's diff against `feat/anno-save-indicator`. Merge/rebase that first. (This branch also drops the indicator's `.glow` treatment.)

### Create section (`Actions.tsx`)
- New **Create** header: title on the left; **undo / redo · │ · ⚙ schema** on the right.
- The schema manager moved out of the label list into a gear button here (gated on manage permission).

### Edit section (`LabelList.tsx`)
- Header renamed to **Edit** with the save-status indicator

### Label edit view (`Edit/Header.tsx`)
- The **Create** section is hidden while editing a label (kept mounted via `display:none` so its mode hooks stay live — see `Actions` `hidden` prop, passed from `Annotate.tsx`).
- Undo/redo moved into the detail header

## Test plan
- `SaveStatusIndicator` / `saveStatus` unit tests pass.
- Changed files are type-clean and lint-clean (0 errors).
- Manually verified against seeded `annotation-images` / `-video` / `-3d` datasets: Create header + tools + cog, Edit header + status dot, and the label edit view (Create hidden, undo/redo + dot in header).
