### PR TITLE
Reorg multimodal code

### DIFF
--- a/app/packages/multimodal/.dependency-cruiser.cjs
+++ b/app/packages/multimodal/.dependency-cruiser.cjs
@@ -1,6 +1,6 @@
 const SRC = "^packages/multimodal/src/";
 const ENTERPRISE = `${SRC}enterprise/`;
-const ENTERPRISE_BOOTSTRAP = `${SRC}inject/enterprise\\.ts$`;
+const INJECT_ENTRY = `${SRC}inject/index\\.ts$`;
 const ENTERPRISE_SHARED_FACADES =
   `${SRC}(extensions/mcap/(index|runtime)\\.ts$|` +
   `query/bytes/index\\.ts$|visualization/index\\.ts$)`;
@@ -13,21 +13,21 @@ module.exports = {
       severity: "error",
       from: {
         path: SRC,
-        pathNot: `${SRC}(enterprise/|inject/enterprise\\.ts$)`,
+        pathNot: `${SRC}(enterprise/|inject/index\\.ts$)`,
       },
       to: { path: ENTERPRISE },
     },
     {
-      name: "enterprise-bootstrap-imports-only-enterprise-entry",
+      name: "inject-entry-imports-only-enterprise-entry",
       severity: "error",
-      from: { path: ENTERPRISE_BOOTSTRAP },
+      from: { path: INJECT_ENTRY },
       to: {
-        path: SRC,
+        path: ENTERPRISE,
         pathNot: `${ENTERPRISE}inject\\.ts$`,
       },
     },
     {
-      name: "enterprise-imports-shared-only-through-public-facades",
+      name: "enterprise-imports-shared-only-through-facades",
       severity: "error",
       from: { path: ENTERPRISE },
       to: {
@@ -45,7 +45,7 @@ module.exports = {
       to: { path: MCAP },
     },
     {
-      name: "oss-multimodal-does-not-import-teams",
+      name: "multimodal-does-not-import-teams",
       severity: "error",
       from: { path: SRC },
       to: { path: `${SRC}teams/|^teams-app/|@fiftyone/teams-multimodal` },

--- a/app/packages/multimodal/.dependency-cruiser.cjs
+++ b/app/packages/multimodal/.dependency-cruiser.cjs
@@ -36,7 +36,7 @@ module.exports = {
       },
     },
     {
-      name: "only-mcap-adapter-and-inject-entry-can-import-mcap",
+      name: "only-mcap-adapters-extensions-and-inject-entry-can-import-mcap",
       severity: "error",
       from: {
         path: SRC,

--- a/app/packages/multimodal/.dependency-cruiser.cjs
+++ b/app/packages/multimodal/.dependency-cruiser.cjs
@@ -1,16 +1,54 @@
 const SRC = "^packages/multimodal/src/";
+const ENTERPRISE = `${SRC}enterprise/`;
+const ENTERPRISE_BOOTSTRAP = `${SRC}inject/enterprise\\.ts$`;
+const ENTERPRISE_SHARED_FACADES =
+  `${SRC}(extensions/mcap/(index|runtime)\\.ts$|` +
+  `query/bytes/index\\.ts$|visualization/index\\.ts$)`;
 const MCAP = `${SRC}adapters/mcap/`;
 
 module.exports = {
   forbidden: [
     {
+      name: "shared-multimodal-does-not-import-enterprise",
+      severity: "error",
+      from: {
+        path: SRC,
+        pathNot: `${SRC}(enterprise/|inject/enterprise\\.ts$)`,
+      },
+      to: { path: ENTERPRISE },
+    },
+    {
+      name: "enterprise-bootstrap-imports-only-enterprise-entry",
+      severity: "error",
+      from: { path: ENTERPRISE_BOOTSTRAP },
+      to: {
+        path: SRC,
+        pathNot: `${ENTERPRISE}inject\\.ts$`,
+      },
+    },
+    {
+      name: "enterprise-imports-shared-only-through-public-facades",
+      severity: "error",
+      from: { path: ENTERPRISE },
+      to: {
+        path: SRC,
+        pathNot: `${ENTERPRISE}|${ENTERPRISE_SHARED_FACADES}`,
+      },
+    },
+    {
       name: "only-mcap-adapter-and-inject-entry-can-import-mcap",
       severity: "error",
       from: {
         path: SRC,
-        pathNot: `${SRC}(adapters/mcap/|inject/index\\.ts$)`,
+        pathNot: `${SRC}(adapters/mcap/|extensions/mcap/|inject/index\\.ts$)`,
       },
       to: { path: MCAP },
+    },
+    {
+      name: "oss-multimodal-does-not-import-teams",
+      severity: "error",
+      from: { path: SRC },
+      to: { path: `${SRC}teams/|^teams-app/|@fiftyone/teams-multimodal` },
     },
     {
       name: "generic-multimodal-layers-do-not-import-adapters",

--- a/app/packages/multimodal/package.json
+++ b/app/packages/multimodal/package.json
@@ -69,8 +69,7 @@
     },
     "scripts": {
         "lint": "yarn check",
-        "check": "yarn check:lint && yarn check:deps && yarn check:boundary && yarn check:types",
-        "check:boundary": "node --test ./scripts/module-specifiers.node-test.mjs && node ./scripts/check-boundary.mjs",
+        "check": "yarn check:lint && yarn check:deps && yarn check:types",
         "check:types": "node ./scripts/check-types.mjs",
         "check:lint": "node ./scripts/check-lint.mjs",
         "check:deps": "node ./scripts/check-deps.mjs"

--- a/app/packages/multimodal/package.json
+++ b/app/packages/multimodal/package.json
@@ -12,6 +12,8 @@
         "./decoders": "./src/decoders/index.ts",
         "./temporal-tags": "./src/temporal-tags/index.ts",
         "./inject": "./src/inject/index.ts",
+        "./extensions/mcap": "./src/extensions/mcap/index.ts",
+        "./extensions/mcap/runtime": "./src/extensions/mcap/runtime.ts",
         "./adapters/mcap": "./src/adapters/mcap/index.ts",
         "./adapters/mcap/react/TemporalTagGridOverlay": "./src/adapters/mcap/react/TemporalTagGridOverlay.tsx",
         "./schemas/v1": "./src/schemas/v1/index.ts",
@@ -39,6 +41,12 @@
             "inject": [
                 "src/inject/index.ts"
             ],
+            "extensions/mcap": [
+                "src/extensions/mcap/index.ts"
+            ],
+            "extensions/mcap/runtime": [
+                "src/extensions/mcap/runtime.ts"
+            ],
             "adapters/mcap": [
                 "src/adapters/mcap/index.ts"
             ],
@@ -61,7 +69,8 @@
     },
     "scripts": {
         "lint": "yarn check",
-        "check": "yarn check:lint && yarn check:deps && yarn check:types",
+        "check": "yarn check:lint && yarn check:deps && yarn check:boundary && yarn check:types",
+        "check:boundary": "node --test ./scripts/module-specifiers.node-test.mjs && node ./scripts/check-boundary.mjs",
         "check:types": "node ./scripts/check-types.mjs",
         "check:lint": "node ./scripts/check-lint.mjs",
         "check:deps": "node ./scripts/check-deps.mjs"

--- a/app/packages/multimodal/package.json
+++ b/app/packages/multimodal/package.json
@@ -13,7 +13,6 @@
         "./temporal-tags": "./src/temporal-tags/index.ts",
         "./inject": "./src/inject/index.ts",
         "./extensions/mcap": "./src/extensions/mcap/index.ts",
-        "./extensions/mcap/runtime": "./src/extensions/mcap/runtime.ts",
         "./adapters/mcap": "./src/adapters/mcap/index.ts",
         "./adapters/mcap/react/TemporalTagGridOverlay": "./src/adapters/mcap/react/TemporalTagGridOverlay.tsx",
         "./schemas/v1": "./src/schemas/v1/index.ts",
@@ -43,9 +42,6 @@
             ],
             "extensions/mcap": [
                 "src/extensions/mcap/index.ts"
-            ],
-            "extensions/mcap/runtime": [
-                "src/extensions/mcap/runtime.ts"
             ],
             "adapters/mcap": [
                 "src/adapters/mcap/index.ts"

--- a/app/packages/multimodal/src/adapters/mcap/react/Mcap3dTile.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/Mcap3dTile.tsx
@@ -8,6 +8,7 @@ import React, {
   useRef,
   useState,
 } from "react";
+import { usePublishMcapAnnotationTopics } from "../../../extensions/mcap";
 import type {
   CameraCalibrationVisualization,
   GridVisualization,
@@ -208,6 +209,7 @@ const Mcap3dTile: React.FC<McapTileProps> = () => {
     setSourcesEnabled,
     toggleSource,
   } = useMcap3dSelection({ restore: viewStateRestore, sourceKey });
+  usePublishMcapAnnotationTopics(sceneAnnotationTopics);
   const selectedTopicStatuses = useMcapTopicStatuses(selectedTopics);
   const selectedSourcePending = selectedTopicStatuses.some(
     (status) => status === "loading",

--- a/app/packages/multimodal/src/adapters/mcap/react/McapImageTile.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapImageTile.tsx
@@ -19,6 +19,7 @@ import {
 } from "@voxel51/voodo";
 import { useStore } from "jotai";
 import React, { useEffect, useMemo, useRef, useState } from "react";
+import { usePublishMcapAnnotationTopics } from "../../../extensions/mcap";
 import type {
   CameraCalibrationVisualization,
   ImageVisualization,
@@ -346,6 +347,7 @@ const McapImageTile: React.FC<McapTileProps> = ({ initialSourceId }) => {
     const available = new Set(annotationTopics);
     return storedLabelTopics.filter((labelTopic) => available.has(labelTopic));
   }, [annotationTopics, storedLabelTopics, topic]);
+  usePublishMcapAnnotationTopics(selectedLabelTopics);
   const activeTopics = useMemo(
     () => (topic ? [topic, ...selectedLabelTopics] : []),
     [selectedLabelTopics, topic],

--- a/app/packages/multimodal/src/adapters/mcap/react/McapModalRenderer.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapModalRenderer.tsx
@@ -1,5 +1,10 @@
 import type { SampleRendererProps } from "@fiftyone/plugins";
-import React from "react";
+import React, { useMemo } from "react";
+import {
+  McapAnnotationTopicsProvider,
+  McapTimelineExtensionHost,
+  type McapTimelineSection,
+} from "../../../extensions/mcap";
 import { McapAdjacentSamplePrewarm } from "./McapAdjacentSamplePrewarm";
 import { McapSourcePlayback } from "./McapSourcePlayback";
 import { mcapSourceDisplayName } from "./mcap-source-display-name";
@@ -20,28 +25,66 @@ const McapModalRenderer: React.FC<SampleRendererProps> = ({ ctx }) => {
   const source = useStableMcapSource(ctx);
   const fileName = mcapSourceDisplayName(ctx.media.path) ?? "recording.mcap";
   const datasetId = ctx.dataset.datasetId;
-  const { tracks, onTagCreate, onTagUpdate, onTagDelete } =
-    useMcapTemporalTags(ctx);
+  const {
+    tracks: tagTracks,
+    onTagCreate,
+    onTagUpdate,
+    onTagDelete,
+  } = useMcapTemporalTags(ctx);
   // Auto-pin the timeline tracks for the temporal tags the grid was filtered
   // by, so opening a filtered sample surfaces the relevant tags immediately.
   const defaultPinnedTrackIds = useFilteredTemporalTagPinnedIds();
+  const builtInSections = useMemo<readonly McapTimelineSection[]>(
+    () => [
+      {
+        id: "fiftyone:temporal-tags",
+        label: "Temporal tags",
+        order: 200,
+        tracks: tagTracks,
+      },
+    ],
+    [tagTracks],
+  );
 
   return (
-    <McapSourcePlayback
-      client={client}
-      defaultPinnedTrackIds={defaultPinnedTrackIds}
-      fileName={fileName}
-      layoutScopeKey={datasetId}
-      cameraPreferenceField={ctx.media.field}
-      onTagCreate={onTagCreate}
-      onTagUpdate={onTagUpdate}
-      onTagDelete={onTagDelete}
-      navigationPending={ctx.transitioning === true}
-      source={source}
-      tracks={tracks}
-    >
-      <McapAdjacentSamplePrewarm ctx={ctx} />
-    </McapSourcePlayback>
+    <McapAnnotationTopicsProvider>
+      <McapTimelineExtensionHost
+        builtInSections={builtInSections}
+        client={client}
+        ctx={ctx}
+        layoutScopeKey={datasetId}
+        navigationPending={ctx.transitioning === true}
+        source={source}
+      >
+        {({
+          decorateTrack,
+          onDrawerOpenChange,
+          preferences,
+          runtime,
+          tracks,
+        }) => (
+          <McapSourcePlayback
+            client={client}
+            defaultPinnedTrackIds={defaultPinnedTrackIds}
+            decorateTrack={decorateTrack}
+            fileName={fileName}
+            layoutScopeKey={datasetId}
+            cameraPreferenceField={ctx.media.field}
+            onTagCreate={onTagCreate}
+            onTagUpdate={onTagUpdate}
+            onTagDelete={onTagDelete}
+            onTimelineDrawerOpenChange={onDrawerOpenChange}
+            timelineDrawerMaxSize={preferences.drawerMaxSize}
+            navigationPending={ctx.transitioning === true}
+            source={source}
+            tracks={tracks}
+          >
+            <McapAdjacentSamplePrewarm ctx={ctx} />
+            {runtime}
+          </McapSourcePlayback>
+        )}
+      </McapTimelineExtensionHost>
+    </McapAnnotationTopicsProvider>
   );
 };
 

--- a/app/packages/multimodal/src/adapters/mcap/react/McapSourcePlayback.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapSourcePlayback.test.tsx
@@ -1,3 +1,4 @@
+import { PlaybackProvider } from "@fiftyone/playback";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -64,20 +65,22 @@ vi.mock("../../../components/MultiModalPlayback/MultiModalPlayback", () => {
       };
     }, []);
     return (
-      <div data-instance-id={instanceId} data-testid="playback-shell">
-        <span data-testid="shell-file-name">{fileName}</span>
-        <span data-testid="shell-sources">
-          {sceneSources?.map((source) => source.id).join(",") ?? ""}
-        </span>
-        <button
-          data-testid="shell-state"
-          onClick={() => setShellState((value) => value + 1)}
-        >
-          {shellState}
-        </button>
-        {children}
-        <div data-testid="mock-main-viewport">{mainOverlay}</div>
-      </div>
+      <PlaybackProvider>
+        <div data-instance-id={instanceId} data-testid="playback-shell">
+          <span data-testid="shell-file-name">{fileName}</span>
+          <span data-testid="shell-sources">
+            {sceneSources?.map((source) => source.id).join(",") ?? ""}
+          </span>
+          <button
+            data-testid="shell-state"
+            onClick={() => setShellState((value) => value + 1)}
+          >
+            {shellState}
+          </button>
+          {children}
+          <div data-testid="mock-main-viewport">{mainOverlay}</div>
+        </div>
+      </PlaybackProvider>
     );
   };
   return { default: MockMultiModalPlayback };
@@ -321,10 +324,53 @@ describe("McapSourcePlayback", () => {
     expect(playbackHarness.shellMounts).toBe(1);
     expect(playbackHarness.shellUnmounts).toBe(0);
   });
+
+  it("treats an etag-only rewrite as a new source transition", () => {
+    const client = {
+      activateSource: vi.fn(),
+    } as unknown as McapResourceClient;
+    const initial = createSource("rewritten", "etag-a");
+    const replacement = createSource("rewritten", "etag-b");
+    playbackHarness.sceneInventory = readyInventory("/camera");
+
+    const view = render(
+      <McapSourcePlayback
+        client={client}
+        fileName="rewritten.mcap"
+        source={initial}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("stream-ready"));
+    expect(
+      document
+        .querySelector("[data-mcap-playback-shell]")
+        ?.hasAttribute("data-mcap-source-transitioning"),
+    ).toBe(false);
+
+    view.rerender(
+      <McapSourcePlayback
+        client={client}
+        fileName="rewritten.mcap"
+        source={replacement}
+      />,
+    );
+    expect(
+      document
+        .querySelector("[data-mcap-playback-shell]")
+        ?.getAttribute("data-mcap-source-transitioning"),
+    ).toBe("true");
+
+    fireEvent.click(screen.getByTestId("stream-ready"));
+    expect(
+      document
+        .querySelector("[data-mcap-playback-shell]")
+        ?.hasAttribute("data-mcap-source-transitioning"),
+    ).toBe(false);
+  });
 });
 
-function createSource(sourceId: string): ByteSourceDescriptor {
-  return { sourceId, url: `memory://${sourceId}.mcap` };
+function createSource(sourceId: string, etag?: string): ByteSourceDescriptor {
+  return { sourceId, url: `memory://${sourceId}.mcap`, etag };
 }
 
 function readyInventory(topic: string) {

--- a/app/packages/multimodal/src/adapters/mcap/react/McapSourcePlayback.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapSourcePlayback.tsx
@@ -1,6 +1,10 @@
 import { humanReadableBytes } from "@fiftyone/utilities";
 import type { TilingLayoutMetrics } from "@fiftyone/tiling";
-import type { TemporalTagTimelineProps, Track } from "@fiftyone/playback";
+import {
+  usePlaybackStore,
+  type TemporalTagTimelineProps,
+  type Track,
+} from "@fiftyone/playback";
 import { Size, Spinner } from "@voxel51/voodo";
 import clsx from "clsx";
 import React, {
@@ -15,6 +19,7 @@ import MultiModalPlayback from "../../../components/MultiModalPlayback/MultiModa
 import { byteSourceAccessKey } from "../../../query/bytes/cache";
 import type { ByteSourceDescriptor } from "../../../query/bytes/types";
 import type { SceneSource } from "../../../scene-inventory";
+import { McapExtensionPlaybackStoreProvider } from "../../../extensions/mcap/playback-store";
 import type { StreamInventory } from "../../../schemas/v1";
 import { releaseRetainedImageTextures } from "../../../visualization/panels/image-texture-cache";
 import {
@@ -23,7 +28,10 @@ import {
 } from "../../../visualization/panels/gpu/gpu-point-cloud-projection-resources";
 import { releaseGpuPointCloudColormapTextures } from "../../../visualization/panels/point-cloud/gpu/gpu-point-cloud-colormap-texture";
 import { BitmapImageFrameView } from "../../../visualization/panels/bitmap-image-view";
-import { getMcapSourceBootstrap } from "../source-bootstrap-cache";
+import {
+  getMcapSourceBootstrap,
+  mcapSourceBootstrapKey,
+} from "../source-bootstrap-cache";
 import type { McapResourceClient } from "../types";
 import { Mcap3dViewStateProvider } from "./mcap-3d-view-state-context";
 import { Mcap3dViewSettingsProvider } from "./mcap-3d-view-settings-context";
@@ -82,12 +90,15 @@ type McapPosterImage = Extract<
   { kind: "image" }
 >;
 
+/** Inputs for the source-oriented MCAP playback host. */
 export interface McapSourcePlaybackProps {
   readonly cameraPreferenceField?: string;
   readonly children?: React.ReactNode;
   readonly client: McapResourceClient;
   /** Track ids to start pinned to the timeline (e.g. from a grid tag filter). */
   readonly defaultPinnedTrackIds?: readonly string[];
+  /** Per-row timeline decoration contributed by timeline sources. */
+  readonly decorateTrack?: TemporalTagTimelineProps["decorateTrack"];
   readonly fileName: string;
   readonly headerActions?: React.ReactNode;
   readonly layoutScopeKey?: string;
@@ -98,6 +109,10 @@ export interface McapSourcePlaybackProps {
   readonly onTagDelete?: NonNullable<
     TemporalTagTimelineProps["eventMenuItems"]
   >[number]["onSelect"];
+  /** Reports timeline drawer visibility to registered runtime contributions. */
+  readonly onTimelineDrawerOpenChange?: (open: boolean) => void;
+  /** Optional maximum expanded track-body height. */
+  readonly timelineDrawerMaxSize?: number;
   readonly source: ByteSourceDescriptor | null;
   readonly tracks?: readonly Track[];
 }
@@ -112,6 +127,7 @@ export const McapSourcePlayback: React.FC<McapSourcePlaybackProps> = ({
   children,
   client,
   defaultPinnedTrackIds,
+  decorateTrack,
   fileName,
   headerActions,
   layoutScopeKey,
@@ -119,6 +135,8 @@ export const McapSourcePlayback: React.FC<McapSourcePlaybackProps> = ({
   onTagCreate,
   onTagUpdate,
   onTagDelete,
+  onTimelineDrawerOpenChange,
+  timelineDrawerMaxSize,
   source,
   tracks,
 }) => {
@@ -165,6 +183,10 @@ export const McapSourcePlayback: React.FC<McapSourcePlaybackProps> = ({
     source,
   });
   const sourceKey = useMemo(
+    () => (source ? mcapSourceBootstrapKey(source) : ""),
+    [source],
+  );
+  const sourceAccessKey = useMemo(
     () => (source ? byteSourceAccessKey(source) : ""),
     [source],
   );
@@ -304,7 +326,9 @@ export const McapSourcePlayback: React.FC<McapSourcePlaybackProps> = ({
                       source={playbackSource}
                     >
                       <McapDataStreamProvider
-                        expectedSourceKey={playbackSource ? sourceKey : null}
+                        expectedSourceKey={
+                          playbackSource ? sourceAccessKey : null
+                        }
                       >
                         <McapProjectionResourceBoundary />
                         <Mcap3dViewSettingsProvider
@@ -328,6 +352,7 @@ export const McapSourcePlayback: React.FC<McapSourcePlaybackProps> = ({
                           >
                             <MultiModalPlayback
                               fileName={fileName}
+                              decorateTrack={decorateTrack}
                               headerCaption={headerCaption}
                               headerActions={
                                 <McapHeaderActions actions={headerActions} />
@@ -386,6 +411,10 @@ export const McapSourcePlayback: React.FC<McapSourcePlaybackProps> = ({
                               }
                               onTagCreate={onTagCreate}
                               onTagUpdate={onTagUpdate}
+                              onTimelineDrawerOpenChange={
+                                onTimelineDrawerOpenChange
+                              }
+                              timelineDrawerMaxSize={timelineDrawerMaxSize}
                             >
                               <McapStreams
                                 client={client}
@@ -398,7 +427,9 @@ export const McapSourcePlayback: React.FC<McapSourcePlaybackProps> = ({
                                 source={playbackSource}
                               />
                               <McapSelectionHotkeys />
-                              {children}
+                              <McapExtensionRuntimeBoundary>
+                                {children}
+                              </McapExtensionRuntimeBoundary>
                               <McapModalLayoutPersistence
                                 datasetId={effectiveLayoutScopeKey}
                               />
@@ -440,6 +471,19 @@ const McapPlaybackSessionStateProviders: React.FC<{
     </McapPanelVisibilityProvider>
   </Mcap3dViewStateProvider>
 );
+
+function McapExtensionRuntimeBoundary({
+  children,
+}: {
+  readonly children: React.ReactNode;
+}) {
+  const store = usePlaybackStore();
+  return (
+    <McapExtensionPlaybackStoreProvider store={store}>
+      {children}
+    </McapExtensionPlaybackStoreProvider>
+  );
+}
 
 /** Retires only the previous recording's GPU buffers on an in-place swap. */
 function McapProjectionResourceBoundary() {

--- a/app/packages/multimodal/src/adapters/mcap/source-bootstrap-cache.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/source-bootstrap-cache.test.ts
@@ -65,6 +65,19 @@ describe("MCAP source bootstrap cache", () => {
       poster: replacementPoster,
     });
   });
+
+  it("does not reuse bootstrap facts after the source validator changes", () => {
+    resetMcapSourceBootstrapCacheForTests();
+    const initial = createSource("rewritten", "etag-a");
+    const replacement = createSource("rewritten", "etag-b");
+
+    publishMcapSourceBootstrap(initial, { topics: [createTopic("initial")] });
+
+    expect(peekMcapSourceBootstrap(initial)?.topics).toEqual([
+      createTopic("initial"),
+    ]);
+    expect(peekMcapSourceBootstrap(replacement)).toBeNull();
+  });
 });
 
 function createTimelineRange(): McapTimelineRange {
@@ -75,8 +88,8 @@ function createTimelineRange(): McapTimelineRange {
   };
 }
 
-function createSource(sourceId: string): ByteSourceDescriptor {
-  return { sourceId, url: `memory://${sourceId}.mcap` };
+function createSource(sourceId: string, etag?: string): ByteSourceDescriptor {
+  return { sourceId, url: `memory://${sourceId}.mcap`, etag };
 }
 
 function createTopic(streamId: string): StreamInventory {

--- a/app/packages/multimodal/src/adapters/mcap/source-bootstrap-cache.ts
+++ b/app/packages/multimodal/src/adapters/mcap/source-bootstrap-cache.ts
@@ -39,7 +39,7 @@ export function publishMcapSourceBootstrap(
   source: ByteSourceDescriptor,
   bootstrap: McapSourceBootstrap,
 ): void {
-  const key = byteSourceAccessKey(source);
+  const key = mcapSourceBootstrapKey(source);
   const current = entries.get(key);
   if (current) {
     retainedPosterBytes -= current.posterBytes;
@@ -70,14 +70,14 @@ export function publishMcapSourceBootstrap(
 export function peekMcapSourceBootstrap(
   source: ByteSourceDescriptor,
 ): McapSourceBootstrap | null {
-  return copyEntry(entries.get(byteSourceAccessKey(source)));
+  return copyEntry(entries.get(mcapSourceBootstrapKey(source)));
 }
 
 /** Returns the current source bootstrap and promotes it as recently used. */
 export function getMcapSourceBootstrap(
   source: ByteSourceDescriptor,
 ): McapSourceBootstrap | null {
-  const key = byteSourceAccessKey(source);
+  const key = mcapSourceBootstrapKey(source);
   const entry = entries.get(key);
   if (!entry) {
     return null;
@@ -92,7 +92,7 @@ export function getMcapSourceBootstrap(
 export function getMcapSourceBootstrapSnapshot(
   source: ByteSourceDescriptor,
 ): McapSourceBootstrap | null {
-  return entries.get(byteSourceAccessKey(source)) ?? null;
+  return entries.get(mcapSourceBootstrapKey(source)) ?? null;
 }
 
 /** Subscribes to source-bootstrap publications for one source. */
@@ -100,7 +100,7 @@ export function subscribeMcapSourceBootstrap(
   source: ByteSourceDescriptor,
   listener: () => void,
 ): () => void {
-  const key = byteSourceAccessKey(source);
+  const key = mcapSourceBootstrapKey(source);
   const listeners = listenersBySource.get(key) ?? new Set<() => void>();
   listeners.add(listener);
   listenersBySource.set(key, listeners);
@@ -110,6 +110,11 @@ export function subscribeMcapSourceBootstrap(
       listenersBySource.delete(key);
     }
   };
+}
+
+/** Cache identity for bootstrap facts, including transport validators. */
+export function mcapSourceBootstrapKey(source: ByteSourceDescriptor): string {
+  return JSON.stringify([byteSourceAccessKey(source), source.etag ?? null]);
 }
 
 function copyEntry(entry: CacheEntry | undefined): McapSourceBootstrap | null {

--- a/app/packages/multimodal/src/components/MultiModalPlayback/MultiModalPlayback.tsx
+++ b/app/packages/multimodal/src/components/MultiModalPlayback/MultiModalPlayback.tsx
@@ -51,6 +51,7 @@ export function clampSidebarWidth(px: number): number {
   );
 }
 
+/** Inputs for the reusable multimodal playback shell. */
 export interface MultiModalPlaybackProps {
   /** Filename rendered on the left of the top bar. */
   fileName: string;
@@ -78,6 +79,8 @@ export interface MultiModalPlaybackProps {
   tracks?: Track[];
   /** Track ids that should start pinned to the timeline. */
   defaultPinnedTrackIds?: string[];
+  /** Per-row behavior composed from shared and registered timeline sources. */
+  decorateTrack?: TemporalTagTimelineProps["decorateTrack"];
 
   /** Initial tile entries seeded into the embedded TilingProvider. */
   initialTiles?: Record<string, TilingTile>;
@@ -168,6 +171,10 @@ export interface MultiModalPlaybackProps {
   onTagDelete?: NonNullable<
     TemporalTagTimelineProps["eventMenuItems"]
   >[number]["onSelect"];
+  /** Reports the timeline drawer's seeded and user-controlled visibility. */
+  onTimelineDrawerOpenChange?: (open: boolean) => void;
+  /** Optional maximum expanded track-body height. */
+  timelineDrawerMaxSize?: number;
 
   /**
    * Rendered inside the providers this component owns. Use it for
@@ -219,6 +226,7 @@ const MultiModalPlayback: React.FC<MultiModalPlaybackProps> = ({
   timelineExtraActions,
   tracks,
   defaultPinnedTrackIds,
+  decorateTrack,
   initialTiles,
   initialManualTileTitles,
   autoLayoutStrategy,
@@ -243,6 +251,8 @@ const MultiModalPlayback: React.FC<MultiModalPlaybackProps> = ({
   onTagCreate,
   onTagUpdate,
   onTagDelete,
+  onTimelineDrawerOpenChange,
+  timelineDrawerMaxSize,
   children,
   className,
 }) => {
@@ -290,11 +300,14 @@ const MultiModalPlayback: React.FC<MultiModalPlaybackProps> = ({
               onTagCreate={onTagCreate}
               onTagUpdate={onTagUpdate}
               onTagDelete={onTagDelete}
+              onTimelineDrawerOpenChange={onTimelineDrawerOpenChange}
+              timelineDrawerMaxSize={timelineDrawerMaxSize}
               sharedImageWebGpuViews={sharedImageWebGpuViews}
               className={className}
               // Start with the tracks drawer collapsed. Pinned tracks remain
               // visible below the ruler until the user expands the drawer.
               timelineDrawerDefaultOpen={false}
+              decorateTrack={decorateTrack}
             />
           </TilingProvider>
         </SceneInventoryProvider>
@@ -322,10 +335,13 @@ interface LayoutProps {
   onTagCreate?: MultiModalPlaybackProps["onTagCreate"];
   onTagUpdate?: MultiModalPlaybackProps["onTagUpdate"];
   onTagDelete?: MultiModalPlaybackProps["onTagDelete"];
+  onTimelineDrawerOpenChange?: MultiModalPlaybackProps["onTimelineDrawerOpenChange"];
+  timelineDrawerMaxSize?: number;
   sharedImageWebGpuViews: boolean;
   className?: string;
   /** Initial open state for the timeline drawer. */
   timelineDrawerDefaultOpen: boolean;
+  decorateTrack?: MultiModalPlaybackProps["decorateTrack"];
 }
 
 function Layout({
@@ -347,9 +363,12 @@ function Layout({
   onTagCreate,
   onTagUpdate,
   onTagDelete,
+  onTimelineDrawerOpenChange,
+  timelineDrawerMaxSize,
   sharedImageWebGpuViews,
   className,
   timelineDrawerDefaultOpen,
+  decorateTrack,
 }: LayoutProps) {
   const {
     layout,
@@ -399,6 +418,14 @@ function Layout({
     },
     [onRightOpenChange],
   );
+  const updateTimelineTracksOpen = useCallback((open: boolean) => {
+    setTimelineTracksOpen(open);
+  }, []);
+  // This effect reports both the seeded drawer state and subsequent user
+  // changes to runtime contributions that gate work on drawer visibility.
+  useEffect(() => {
+    onTimelineDrawerOpenChange?.(timelineTracksOpen);
+  }, [onTimelineDrawerOpenChange, timelineTracksOpen]);
 
   // A newly spawned panel is focused immediately, so reveal the settings it
   // can configure even when the user previously collapsed the left sidebar.
@@ -477,7 +504,9 @@ function Layout({
         timelineTracksOpen={timelineTracksOpen}
         rightSidebarOpen={rightOpen}
         onToggleLeftSidebar={() => updateLeftOpen(!leftOpen)}
-        onToggleTimelineTracks={() => setTimelineTracksOpen((open) => !open)}
+        onToggleTimelineTracks={() =>
+          updateTimelineTracksOpen(!timelineTracksOpen)
+        }
         onToggleRightSidebar={
           hasRightSidebar ? () => updateRightOpen(!rightOpen) : undefined
         }
@@ -545,7 +574,9 @@ function Layout({
 
       <TemporalTagTimeline
         drawerOpen={timelineTracksOpen}
-        onDrawerOpenChange={setTimelineTracksOpen}
+        maxSize={timelineDrawerMaxSize}
+        onDrawerOpenChange={updateTimelineTracksOpen}
+        decorateTrack={decorateTrack}
         extraActions={timelineExtraActions}
         onTagCreate={onTagCreate}
         onTagUpdate={onTagUpdate}

--- a/app/packages/multimodal/src/extensions/mcap/host.test.tsx
+++ b/app/packages/multimodal/src/extensions/mcap/host.test.tsx
@@ -42,7 +42,7 @@ afterEach(() => {
 });
 
 describe("MCAP timeline extension host", () => {
-  it("keeps the OSS-only path functional with no registration", () => {
+  it("keeps the built-in timeline functional with no registration", () => {
     renderHost();
     expect(screen.getByTestId("tracks").textContent).toBe("Tag");
     expect(screen.queryByTestId("runtime")).toBeNull();

--- a/app/packages/multimodal/src/extensions/mcap/host.test.tsx
+++ b/app/packages/multimodal/src/extensions/mcap/host.test.tsx
@@ -1,0 +1,298 @@
+/* eslint-disable react/prop-types */
+import type { Track } from "@fiftyone/playback";
+import type { SampleRendererProps } from "@fiftyone/plugins";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  MCAP_ACTIVE_TIMELINE,
+  type McapResourceClient,
+  type McapTimelineRange,
+} from "../../adapters/mcap";
+import {
+  publishMcapSourceBootstrap,
+  resetMcapSourceBootstrapCacheForTests,
+} from "../../adapters/mcap/source-bootstrap-cache";
+import type { ByteSourceDescriptor } from "../../query/bytes";
+import { McapTimelineExtensionHost } from "./host";
+import {
+  registerMcapTimelineExtension,
+  resetMcapTimelineExtensionsForTests,
+} from "./registry";
+import type { McapTimelineExtension } from "./types";
+
+const TAG_TRACK: Track = {
+  id: "temporal-tag::one",
+  label: "Tag",
+  color: "#000",
+  events: [],
+};
+const EVENT_TRACK: Track = {
+  id: "test-event::one",
+  label: "Event",
+  color: "#111",
+  events: [],
+};
+const CLIENT = {} as McapResourceClient;
+const CTX = {} as SampleRendererProps["ctx"];
+
+afterEach(() => {
+  cleanup();
+  resetMcapTimelineExtensionsForTests();
+  resetMcapSourceBootstrapCacheForTests();
+});
+
+describe("MCAP timeline extension host", () => {
+  it("keeps the OSS-only path functional with no registration", () => {
+    renderHost();
+    expect(screen.getByTestId("tracks").textContent).toBe("Tag");
+    expect(screen.queryByTestId("runtime")).toBeNull();
+  });
+
+  it("composes a fake extension by explicit section order", () => {
+    const extension: McapTimelineExtension = {
+      id: "test:events",
+      order: 10,
+      Component: ({ children, selectedAnnotationTopics, timelineRange }) => (
+        <>
+          {children({
+            sections: [
+              {
+                id: "test:events",
+                label: "Events",
+                order: 100,
+                tracks: [EVENT_TRACK],
+              },
+            ],
+            preferences: {
+              drawerMaxSize: 480,
+              drawerSizeStorageKey: "test:drawer-size",
+              labelWidthStorageKey: "test:label-width",
+              timelineSearchEnabled: true,
+            },
+            runtime: <span data-testid="runtime">runtime</span>,
+          })}
+          <span data-testid="context">
+            {JSON.stringify({ selectedAnnotationTopics, timelineRange })}
+          </span>
+        </>
+      ),
+    };
+    registerMcapTimelineExtension(extension);
+
+    renderHost();
+    expect(screen.getByTestId("tracks").textContent).toBe(
+      "Events|Event|Temporal tags|Tag",
+    );
+    expect(screen.getByTestId("max-size").textContent).toBe("480");
+    expect(screen.getByTestId("drawer-size-key").textContent).toBe(
+      "test:drawer-size",
+    );
+    expect(screen.getByTestId("label-width-key").textContent).toBe(
+      "test:label-width",
+    );
+    expect(screen.getByTestId("search-enabled").textContent).toBe("true");
+    expect(screen.getByTestId("runtime").textContent).toBe("runtime");
+    expect(screen.getByTestId("context").textContent).toBe(
+      '{"selectedAnnotationTopics":[],"timelineRange":null}',
+    );
+  });
+
+  it("rejects duplicate and unnamespaced extension ids", () => {
+    const extension: McapTimelineExtension = {
+      id: "test:one",
+      order: 1,
+      Component: ({ children }) => <>{children({})}</>,
+    };
+    registerMcapTimelineExtension(extension);
+    expect(() => registerMcapTimelineExtension(extension)).not.toThrow();
+    expect(() => registerMcapTimelineExtension({ ...extension })).toThrowError(
+      "Duplicate MCAP timeline extension id: test:one",
+    );
+    expect(() =>
+      registerMcapTimelineExtension({ ...extension, id: "missing-namespace" }),
+    ).toThrowError(
+      "MCAP timeline extension ids must be namespaced: missing-namespace",
+    );
+  });
+
+  it("prefers a source bootstrap range over a client read", () => {
+    const source = createSource("cached");
+    const range = createRange(10n, 20n);
+    publishMcapSourceBootstrap(source, { timelineRange: range });
+    const readTimelineRange = vi.fn(async () => createRange(0n, 1n));
+    registerRangeProbe();
+
+    renderHost({
+      client: { readTimelineRange } as unknown as McapResourceClient,
+      source,
+    });
+
+    expect(screen.getByTestId("timeline-range").textContent).toBe("10:20");
+    expect(readTimelineRange).not.toHaveBeenCalled();
+  });
+
+  it("invalidates a bootstrap range when rewritten content has a new etag", async () => {
+    const initial = createSource("rewritten", "etag-a");
+    const replacement = createSource("rewritten", "etag-b");
+    publishMcapSourceBootstrap(initial, {
+      timelineRange: createRange(10n, 20n),
+    });
+    const readTimelineRange = vi.fn(async () => createRange(30n, 40n));
+    const client = { readTimelineRange } as unknown as McapResourceClient;
+    registerRangeProbe();
+
+    const view = renderHost({ client, source: initial });
+    expect(screen.getByTestId("timeline-range").textContent).toBe("10:20");
+
+    view.rerender(hostElement({ client, source: replacement }));
+    expect(screen.getByTestId("timeline-range").textContent).toBe("none");
+    await waitFor(() =>
+      expect(screen.getByTestId("timeline-range").textContent).toBe("30:40"),
+    );
+    expect(readTimelineRange).toHaveBeenCalledWith({
+      activeTimeline: MCAP_ACTIVE_TIMELINE.LOG,
+      source: replacement,
+    });
+  });
+
+  it("falls back to resolving the range from the client", async () => {
+    const source = createSource("fallback");
+    const readTimelineRange = vi.fn(async () => createRange(30n, 40n));
+    registerRangeProbe();
+
+    renderHost({
+      client: { readTimelineRange } as unknown as McapResourceClient,
+      source,
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId("timeline-range").textContent).toBe("30:40"),
+    );
+    expect(readTimelineRange).toHaveBeenCalledWith({
+      activeTimeline: MCAP_ACTIVE_TIMELINE.LOG,
+      source,
+    });
+  });
+
+  it("suppresses a stale range when the source changes", async () => {
+    const first = deferred<McapTimelineRange>();
+    const second = deferred<McapTimelineRange>();
+    const firstSource = createSource("first");
+    const secondSource = createSource("second");
+    const readTimelineRange = vi.fn(
+      ({ source }: { readonly source: ByteSourceDescriptor }) =>
+        source.sourceId === firstSource.sourceId
+          ? first.promise
+          : second.promise,
+    );
+    registerRangeProbe();
+
+    const view = renderHost({
+      client: { readTimelineRange } as unknown as McapResourceClient,
+      source: firstSource,
+    });
+    view.rerender(
+      hostElement({
+        client: { readTimelineRange } as unknown as McapResourceClient,
+        source: secondSource,
+      }),
+    );
+
+    await act(async () => second.resolve(createRange(50n, 60n)));
+    await waitFor(() =>
+      expect(screen.getByTestId("timeline-range").textContent).toBe("50:60"),
+    );
+    await act(async () => first.resolve(createRange(1n, 2n)));
+    expect(screen.getByTestId("timeline-range").textContent).toBe("50:60");
+  });
+});
+
+function renderHost(options: HostOptions = {}) {
+  return render(hostElement(options));
+}
+
+interface HostOptions {
+  readonly client?: McapResourceClient;
+  readonly source?: ByteSourceDescriptor | null;
+}
+
+function hostElement({ client = CLIENT, source = null }: HostOptions = {}) {
+  return (
+    <McapTimelineExtensionHost
+      builtInSections={[
+        {
+          id: "fiftyone:temporal-tags",
+          label: "Temporal tags",
+          order: 200,
+          tracks: [TAG_TRACK],
+        },
+      ]}
+      client={client}
+      ctx={CTX}
+      layoutScopeKey="dataset"
+      navigationPending={false}
+      source={source}
+    >
+      {({ preferences, runtime, tracks }) => (
+        <>
+          <span data-testid="tracks">
+            {tracks.map((track) => track.label).join("|")}
+          </span>
+          <span data-testid="max-size">
+            {String(preferences.drawerMaxSize)}
+          </span>
+          <span data-testid="drawer-size-key">
+            {preferences.drawerSizeStorageKey}
+          </span>
+          <span data-testid="label-width-key">
+            {preferences.labelWidthStorageKey}
+          </span>
+          <span data-testid="search-enabled">
+            {String(preferences.timelineSearchEnabled)}
+          </span>
+          {runtime}
+        </>
+      )}
+    </McapTimelineExtensionHost>
+  );
+}
+
+function registerRangeProbe() {
+  registerMcapTimelineExtension({
+    id: "test:range",
+    order: 1,
+    Component: ({ children, timelineRange }) => (
+      <>
+        {children({})}
+        <span data-testid="timeline-range">
+          {timelineRange
+            ? `${timelineRange.startTimeNs}:${timelineRange.endTimeNs}`
+            : "none"}
+        </span>
+      </>
+    ),
+  });
+}
+
+function createSource(sourceId: string, etag?: string): ByteSourceDescriptor {
+  return { sourceId, url: `memory://${sourceId}.mcap`, etag };
+}
+
+function createRange(
+  startTimeNs: bigint,
+  endTimeNs: bigint,
+): McapTimelineRange {
+  return {
+    activeTimeline: MCAP_ACTIVE_TIMELINE.LOG,
+    endTimeNs,
+    startTimeNs,
+  };
+}
+
+function deferred<Value>() {
+  let resolve!: (value: Value) => void;
+  const promise = new Promise<Value>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}

--- a/app/packages/multimodal/src/extensions/mcap/host.tsx
+++ b/app/packages/multimodal/src/extensions/mcap/host.tsx
@@ -33,7 +33,12 @@ interface McapTimelineExtensionHostProps extends Omit<
   readonly children: (composition: McapTimelineComposition) => React.ReactNode;
 }
 
-/** Composes OSS timeline sources with every registered downstream extension. */
+/**
+ * Runs the registered timeline extensions, collects their contributions, and
+ * combines them with the built-in sections before rendering the playback
+ * shell. Extensions stay mounted in a nested chain so each one can use React
+ * hooks and providers while contributing tracks, preferences, and runtime UI.
+ */
 export const McapTimelineExtensionHost: React.FC<
   McapTimelineExtensionHostProps
 > = ({ builtInSections, children, ...context }) => {
@@ -87,6 +92,9 @@ const ExtensionChain: React.FC<ExtensionChainProps> = ({
   extensions,
   index,
 }) => {
+  // Each extension is render-prop middleware: it receives the same host
+  // context, reports one contribution, and wraps the rest of the chain. The
+  // nesting preserves any providers an extension mounts for later extensions.
   const extension = extensions[index];
   if (!extension) return <>{children(contributions)}</>;
   const Component = extension.Component;
@@ -114,6 +122,9 @@ const ComposedTimeline: React.FC<{
   readonly children: (composition: McapTimelineComposition) => React.ReactNode;
   readonly contributions: readonly RegisteredContribution[];
 }> = ({ builtInSections, children, contributions }) => {
+  // This is the merge boundary. Section ordering and track decoration are
+  // resolved together, preference fields use registration order as their
+  // override order, and runtime nodes mount alongside the playback shell.
   const sections = useMemo(
     () => [
       ...builtInSections,

--- a/app/packages/multimodal/src/extensions/mcap/host.tsx
+++ b/app/packages/multimodal/src/extensions/mcap/host.tsx
@@ -1,0 +1,215 @@
+import React, {
+  Fragment,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  useSyncExternalStore,
+} from "react";
+import {
+  getMcapSourceBootstrapSnapshot,
+  mcapSourceBootstrapKey,
+  subscribeMcapSourceBootstrap,
+} from "../../adapters/mcap/source-bootstrap-cache";
+import { MCAP_ACTIVE_TIMELINE } from "../../adapters/mcap/types";
+import type { McapTimelineRange } from "../../adapters/mcap";
+import { useMcapTimelineExtensions } from "./registry";
+import { useMcapSelectedAnnotationTopics } from "./selected-annotation-topics";
+import { useMcapTimelineSections } from "./sections";
+import type {
+  McapTimelineComposition,
+  McapTimelineContribution,
+  McapTimelineExtension,
+  McapTimelineExtensionContext,
+  McapTimelinePreferences,
+  McapTimelineSection,
+} from "./types";
+
+interface McapTimelineExtensionHostProps extends Omit<
+  McapTimelineExtensionContext,
+  "selectedAnnotationTopics" | "timelineRange"
+> {
+  readonly builtInSections: readonly McapTimelineSection[];
+  readonly children: (composition: McapTimelineComposition) => React.ReactNode;
+}
+
+/** Composes OSS timeline sources with every registered downstream extension. */
+export const McapTimelineExtensionHost: React.FC<
+  McapTimelineExtensionHostProps
+> = ({ builtInSections, children, ...context }) => {
+  const extensions = useMcapTimelineExtensions();
+  const selectedAnnotationTopics = useMcapSelectedAnnotationTopics();
+  const timelineRange = useMcapTimelineRange(context.client, context.source);
+  const extensionContext: McapTimelineExtensionContext = {
+    ...context,
+    selectedAnnotationTopics,
+    timelineRange,
+  };
+
+  return (
+    <ExtensionChain
+      context={extensionContext}
+      extensions={extensions}
+      index={0}
+      contributions={[]}
+    >
+      {(contributions) => (
+        <ComposedTimeline
+          builtInSections={builtInSections}
+          contributions={contributions}
+        >
+          {children}
+        </ComposedTimeline>
+      )}
+    </ExtensionChain>
+  );
+};
+
+interface ExtensionChainProps {
+  readonly children: (
+    contributions: readonly RegisteredContribution[],
+  ) => React.ReactNode;
+  readonly context: McapTimelineExtensionContext;
+  readonly contributions: readonly RegisteredContribution[];
+  readonly extensions: readonly McapTimelineExtension[];
+  readonly index: number;
+}
+
+interface RegisteredContribution {
+  readonly extensionId: string;
+  readonly value: McapTimelineContribution;
+}
+
+const ExtensionChain: React.FC<ExtensionChainProps> = ({
+  children,
+  context,
+  contributions,
+  extensions,
+  index,
+}) => {
+  const extension = extensions[index];
+  if (!extension) return <>{children(contributions)}</>;
+  const Component = extension.Component;
+  return (
+    <Component {...context}>
+      {(contribution) => (
+        <ExtensionChain
+          context={context}
+          contributions={[
+            ...contributions,
+            { extensionId: extension.id, value: contribution },
+          ]}
+          extensions={extensions}
+          index={index + 1}
+        >
+          {children}
+        </ExtensionChain>
+      )}
+    </Component>
+  );
+};
+
+const ComposedTimeline: React.FC<{
+  readonly builtInSections: readonly McapTimelineSection[];
+  readonly children: (composition: McapTimelineComposition) => React.ReactNode;
+  readonly contributions: readonly RegisteredContribution[];
+}> = ({ builtInSections, children, contributions }) => {
+  const sections = useMemo(
+    () => [
+      ...builtInSections,
+      ...contributions.flatMap(
+        (contribution) => contribution.value.sections ?? [],
+      ),
+    ],
+    [builtInSections, contributions],
+  );
+  const { decorateTrack, tracks } = useMcapTimelineSections(sections);
+  const preferences = useMemo(
+    () => mergePreferences(contributions),
+    [contributions],
+  );
+  const onDrawerOpenChange = useMemo(() => {
+    const listeners = contributions.flatMap((contribution) =>
+      contribution.value.onDrawerOpenChange
+        ? [contribution.value.onDrawerOpenChange]
+        : [],
+    );
+    return listeners.length === 0
+      ? undefined
+      : (open: boolean) => {
+          for (const listener of listeners) listener(open);
+        };
+  }, [contributions]);
+  const runtime = contributions.map((contribution) => (
+    <Fragment key={contribution.extensionId}>
+      {contribution.value.runtime}
+    </Fragment>
+  ));
+
+  return (
+    <>
+      {children({
+        decorateTrack,
+        onDrawerOpenChange,
+        preferences,
+        runtime,
+        tracks,
+      })}
+    </>
+  );
+};
+
+function mergePreferences(
+  contributions: readonly RegisteredContribution[],
+): McapTimelinePreferences {
+  const preferences: McapTimelinePreferences = {};
+  for (const contribution of contributions) {
+    Object.assign(preferences, contribution.value.preferences);
+  }
+  return preferences;
+}
+
+/** Resolves one exact range per source and suppresses stale async commits. */
+function useMcapTimelineRange(
+  client: McapTimelineExtensionContext["client"],
+  source: McapTimelineExtensionContext["source"],
+): McapTimelineRange | null {
+  const subscribe = useCallback(
+    (listener: () => void) =>
+      source ? subscribeMcapSourceBootstrap(source, listener) : () => undefined,
+    [source],
+  );
+  const getSnapshot = useCallback(
+    () => (source ? getMcapSourceBootstrapSnapshot(source) : null),
+    [source],
+  );
+  const bootstrap = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  const sourceKey = source ? mcapSourceBootstrapKey(source) : null;
+  const [resolved, setResolved] = useState<{
+    readonly range: McapTimelineRange;
+    readonly sourceKey: string;
+  } | null>(null);
+  const cachedRange = bootstrap?.timelineRange;
+
+  // This effect resolves a missing range for the current source and ignores a
+  // result if that source is replaced before the read completes.
+  useEffect(() => {
+    if (!source || !sourceKey || cachedRange) return undefined;
+    let cancelled = false;
+    void client
+      .readTimelineRange({ activeTimeline: MCAP_ACTIVE_TIMELINE.LOG, source })
+      .then((range) => {
+        if (!cancelled) setResolved({ range, sourceKey });
+      })
+      .catch(() => {
+        // Inventory owns the source error; extensions remain withheld.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [cachedRange, client, source, sourceKey]);
+
+  return (
+    cachedRange ?? (resolved?.sourceKey === sourceKey ? resolved.range : null)
+  );
+}

--- a/app/packages/multimodal/src/extensions/mcap/index.ts
+++ b/app/packages/multimodal/src/extensions/mcap/index.ts
@@ -8,31 +8,6 @@ export {
   useMcapSelectedAnnotationTopics,
   usePublishMcapAnnotationTopics,
 } from "./selected-annotation-topics";
-export {
-  addCoveredRange,
-  createMcapTimelineIndex,
-  MCAP_ACTIVE_TIMELINE,
-  McapDataStreamProvider,
-  removeCoveredRange,
-  startMcapDemandBridge,
-  subtractCoveredRanges,
-  useMcapDataStream,
-  useMcapDemandRegistry,
-  useMcapExtensionPlaybackStore,
-  useSetMcapDataStream,
-} from "./runtime";
-export type {
-  McapDataStream,
-  McapDemandBridgeFillContext,
-  McapDemandBridgeOptions,
-  McapDemandHandlers,
-  McapDemandRegistry,
-  McapDecodedMessage,
-  McapReadDecodedMessagesRequest,
-  McapResourceClient,
-  McapTimelineIndex,
-  NsRange,
-} from "./runtime";
 export type {
   McapTimelineComposition,
   McapTimelineContribution,

--- a/app/packages/multimodal/src/extensions/mcap/index.ts
+++ b/app/packages/multimodal/src/extensions/mcap/index.ts
@@ -1,0 +1,45 @@
+export { McapTimelineExtensionHost } from "./host";
+export {
+  registerMcapTimelineExtension,
+  useMcapTimelineExtensions,
+} from "./registry";
+export {
+  McapAnnotationTopicsProvider,
+  useMcapSelectedAnnotationTopics,
+  usePublishMcapAnnotationTopics,
+} from "./selected-annotation-topics";
+export {
+  addCoveredRange,
+  createMcapTimelineIndex,
+  MCAP_ACTIVE_TIMELINE,
+  McapDataStreamProvider,
+  removeCoveredRange,
+  startMcapDemandBridge,
+  subtractCoveredRanges,
+  useMcapDataStream,
+  useMcapDemandRegistry,
+  useMcapExtensionPlaybackStore,
+  useSetMcapDataStream,
+} from "./runtime";
+export type {
+  McapDataStream,
+  McapDemandBridgeFillContext,
+  McapDemandBridgeOptions,
+  McapDemandHandlers,
+  McapDemandRegistry,
+  McapDecodedMessage,
+  McapReadDecodedMessagesRequest,
+  McapResourceClient,
+  McapTimelineIndex,
+  NsRange,
+} from "./runtime";
+export type {
+  McapTimelineComposition,
+  McapTimelineContribution,
+  McapTimelineExtension,
+  McapTimelineExtensionComponentProps,
+  McapTimelineExtensionContext,
+  McapTimelinePreferences,
+  McapTimelineSection,
+  McapTimelineTrackDecorator,
+} from "./types";

--- a/app/packages/multimodal/src/extensions/mcap/playback-store.tsx
+++ b/app/packages/multimodal/src/extensions/mcap/playback-store.tsx
@@ -1,0 +1,27 @@
+import type { PlaybackStore } from "@fiftyone/playback";
+import React, { createContext, useContext } from "react";
+
+const McapExtensionPlaybackStoreContext = createContext<PlaybackStore | null>(
+  null,
+);
+
+/** Supplies the host playback store to runtime contributions. */
+export const McapExtensionPlaybackStoreProvider: React.FC<{
+  readonly children: React.ReactNode;
+  readonly store: PlaybackStore;
+}> = ({ children, store }) => (
+  <McapExtensionPlaybackStoreContext.Provider value={store}>
+    {children}
+  </McapExtensionPlaybackStoreContext.Provider>
+);
+
+/** Playback store handle for runtime nodes mounted by an MCAP extension. */
+export function useMcapExtensionPlaybackStore(): PlaybackStore {
+  const store = useContext(McapExtensionPlaybackStoreContext);
+  if (!store) {
+    throw new Error(
+      "MCAP extension runtime must be mounted inside its playback host",
+    );
+  }
+  return store;
+}

--- a/app/packages/multimodal/src/extensions/mcap/registry.test.tsx
+++ b/app/packages/multimodal/src/extensions/mcap/registry.test.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { McapTimelineExtension } from "./types";
+import {
+  registerMcapTimelineExtension,
+  resetMcapTimelineExtensionsForTests,
+} from "./registry";
+
+const extension: McapTimelineExtension = {
+  id: "test:registry",
+  order: 1,
+  // eslint-disable-next-line react/prop-types
+  Component: ({ children }) =>
+    React.createElement(React.Fragment, null, children({})),
+};
+
+afterEach(async () => {
+  resetMcapTimelineExtensionsForTests();
+  const current = await import("./registry");
+  current.resetMcapTimelineExtensionsForTests();
+});
+
+describe("MCAP timeline extension registry", () => {
+  it("shares one registry across duplicate module evaluations", async () => {
+    registerMcapTimelineExtension(extension);
+    vi.resetModules();
+    const reloaded = await import("./registry");
+
+    expect(() =>
+      reloaded.registerMcapTimelineExtension({ ...extension }),
+    ).toThrow("Duplicate MCAP timeline extension id: test:registry");
+  });
+
+  it("keeps cleanup scoped to the object that owns the registration", () => {
+    const unregister = registerMcapTimelineExtension(extension);
+    unregister();
+    unregister();
+
+    expect(() => registerMcapTimelineExtension({ ...extension })).not.toThrow();
+  });
+});

--- a/app/packages/multimodal/src/extensions/mcap/registry.ts
+++ b/app/packages/multimodal/src/extensions/mcap/registry.ts
@@ -1,0 +1,82 @@
+import { useSyncExternalStore } from "react";
+import type { McapTimelineExtension } from "./types";
+
+interface McapTimelineExtensionRegistry {
+  readonly extensions: Map<string, McapTimelineExtension>;
+  readonly listeners: Set<() => void>;
+  snapshot: readonly McapTimelineExtension[];
+}
+
+const REGISTRY_KEY = Symbol.for(
+  "@fiftyone/multimodal:mcap-timeline-extension-registry",
+);
+const globalRegistry = globalThis as Record<PropertyKey, unknown>;
+const registry = (globalRegistry[REGISTRY_KEY] ??=
+  createRegistry()) as McapTimelineExtensionRegistry;
+
+function createRegistry(): McapTimelineExtensionRegistry {
+  return {
+    extensions: new Map(),
+    listeners: new Set(),
+    snapshot: [],
+  };
+}
+
+function rebuildSnapshot(): void {
+  registry.snapshot = [...registry.extensions.values()].sort(
+    (left, right) =>
+      left.order - right.order || left.id.localeCompare(right.id),
+  );
+  for (const listener of registry.listeners) listener();
+}
+
+/**
+ * Registers one product-neutral MCAP timeline extension.
+ *
+ * Registering the same object twice is an idempotent no-op for module reloads.
+ * A different extension reusing an existing id is an architectural error and
+ * fails loudly instead of making product behavior depend on import order.
+ */
+export function registerMcapTimelineExtension(
+  extension: McapTimelineExtension,
+): () => void {
+  if (!extension.id.includes(":")) {
+    throw new Error(
+      `MCAP timeline extension ids must be namespaced: ${extension.id}`,
+    );
+  }
+  const existing = registry.extensions.get(extension.id);
+  if (existing === extension) return () => undefined;
+  if (existing) {
+    throw new Error(`Duplicate MCAP timeline extension id: ${extension.id}`);
+  }
+
+  registry.extensions.set(extension.id, extension);
+  rebuildSnapshot();
+  let active = true;
+  return () => {
+    if (!active || registry.extensions.get(extension.id) !== extension) return;
+    active = false;
+    registry.extensions.delete(extension.id);
+    rebuildSnapshot();
+  };
+}
+
+/** Returns the registered extensions in deterministic product-policy order. */
+export function useMcapTimelineExtensions(): readonly McapTimelineExtension[] {
+  return useSyncExternalStore(
+    (listener) => {
+      registry.listeners.add(listener);
+      return () => registry.listeners.delete(listener);
+    },
+    () => registry.snapshot,
+    () => registry.snapshot,
+  );
+}
+
+/** Test-only reset kept out of the public package barrel. */
+export function resetMcapTimelineExtensionsForTests(): void {
+  if (registry.extensions.size === 0) return;
+  registry.extensions.clear();
+  rebuildSnapshot();
+}

--- a/app/packages/multimodal/src/extensions/mcap/runtime.ts
+++ b/app/packages/multimodal/src/extensions/mcap/runtime.ts
@@ -1,3 +1,11 @@
+/**
+ * Data-plane facade for timeline extension implementations.
+ *
+ * Extensions sometimes need the active MCAP stream, demand bridge, or
+ * playback store. Keeping those adapter imports here gives extension code one
+ * narrow dependency boundary without adding lower-level runtime APIs to the
+ * extension registration barrel in `index.ts`.
+ */
 import {
   startMcapDemandBridge,
   useMcapDemandRegistry,

--- a/app/packages/multimodal/src/extensions/mcap/runtime.ts
+++ b/app/packages/multimodal/src/extensions/mcap/runtime.ts
@@ -1,0 +1,44 @@
+import {
+  startMcapDemandBridge,
+  useMcapDemandRegistry,
+} from "../../adapters/mcap/react/mcap-demand-bridge";
+import {
+  McapDataStreamProvider,
+  useMcapDataStream,
+  useSetMcapDataStream,
+} from "../../adapters/mcap/react/mcap-data-stream-context";
+import { createMcapTimelineIndex } from "../../adapters/mcap/react/mcap-timeline-index";
+import { MCAP_ACTIVE_TIMELINE } from "../../adapters/mcap/types";
+
+export {
+  createMcapTimelineIndex,
+  MCAP_ACTIVE_TIMELINE,
+  McapDataStreamProvider,
+  startMcapDemandBridge,
+  useMcapDataStream,
+  useMcapDemandRegistry,
+  useSetMcapDataStream,
+};
+export {
+  McapExtensionPlaybackStoreProvider,
+  useMcapExtensionPlaybackStore,
+} from "./playback-store";
+export type { McapDataStream } from "../../adapters/mcap/react/mcap-data-stream-context";
+export type {
+  McapDemandBridgeFillContext,
+  McapDemandBridgeOptions,
+  McapDemandHandlers,
+  McapDemandRegistry,
+} from "../../adapters/mcap/react/mcap-demand-bridge";
+export type { McapTimelineIndex } from "../../adapters/mcap/react/mcap-timeline-index";
+export type {
+  McapDecodedMessage,
+  McapReadDecodedMessagesRequest,
+  McapResourceClient,
+} from "../../adapters/mcap/types";
+export {
+  addCoveredRange,
+  removeCoveredRange,
+  subtractCoveredRanges,
+} from "../../adapters/mcap/react/numeric-series-window";
+export type { NsRange } from "../../adapters/mcap/react/numeric-series-window";

--- a/app/packages/multimodal/src/extensions/mcap/sections.module.css
+++ b/app/packages/multimodal/src/extensions/mcap/sections.module.css
@@ -1,0 +1,3 @@
+.hiddenTrack {
+  display: none;
+}

--- a/app/packages/multimodal/src/extensions/mcap/sections.test.tsx
+++ b/app/packages/multimodal/src/extensions/mcap/sections.test.tsx
@@ -1,0 +1,137 @@
+import type { Track } from "@fiftyone/playback";
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useMcapTimelineSections } from "./sections";
+import type { McapTimelineSection } from "./types";
+
+const TAG_TRACK: Track = {
+  id: "temporal-tag::one",
+  label: "Tag",
+  color: "#000",
+  events: [],
+};
+const EVENT_TRACK: Track = {
+  id: "test-event::one",
+  label: "Event",
+  color: "#111",
+  events: [],
+};
+const TAGS_HEADER_ID = "mcap-timeline-section::fiftyone:temporal-tags";
+const EVENTS_HEADER_ID = "mcap-timeline-section::test:events";
+
+describe("useMcapTimelineSections", () => {
+  it("keeps a single section as real tracks only", () => {
+    const { result } = renderHook(() =>
+      useMcapTimelineSections([
+        section("fiftyone:temporal-tags", 200, TAG_TRACK),
+      ]),
+    );
+
+    expect(result.current.tracks).toEqual([TAG_TRACK]);
+  });
+
+  it("orders multiple sections behind non-pinnable compatibility headers", () => {
+    const { result } = renderHook(() =>
+      useMcapTimelineSections([
+        section("fiftyone:temporal-tags", 200, TAG_TRACK),
+        section("test:events", 100, EVENT_TRACK),
+      ]),
+    );
+
+    expect(result.current.tracks.map((track) => track.id)).toEqual([
+      EVENTS_HEADER_ID,
+      EVENT_TRACK.id,
+      TAGS_HEADER_ID,
+      TAG_TRACK.id,
+    ]);
+    const header = result.current.tracks[0];
+    const decoration = result.current.decorateTrack(header, false);
+    expect(decoration).toMatchObject({
+      expandable: true,
+      expanded: true,
+      expansionGutter: true,
+      onPinClick: undefined,
+    });
+  });
+
+  it("collapses only unpinned children and preserves source decoration", () => {
+    const sections: McapTimelineSection[] = [
+      section("fiftyone:temporal-tags", 200, TAG_TRACK),
+      {
+        ...section("test:events", 100, EVENT_TRACK),
+        decorateTrack: () => ({
+          className: "source-row",
+          depth: 2,
+          eventMenuItems: [],
+        }),
+      },
+    ];
+    const { result } = renderHook(() => useMcapTimelineSections(sections));
+    const header = result.current.tracks.find(
+      (track) => track.id === EVENTS_HEADER_ID,
+    );
+    if (!header) throw new Error("missing section header");
+
+    act(() => result.current.decorateTrack(header, false).onToggleExpand?.());
+
+    expect(result.current.decorateTrack(header, false).expanded).toBe(false);
+    const unpinned = result.current.decorateTrack(EVENT_TRACK, false);
+    expect(unpinned).toMatchObject({
+      className: expect.stringContaining("source-row"),
+      depth: 2,
+      eventMenuItems: [],
+      expansionGutter: true,
+    });
+    expect(unpinned.className).toMatch(/hiddenTrack/);
+    expect(result.current.decorateTrack(EVENT_TRACK, true)).toEqual({
+      className: "source-row",
+      depth: 2,
+      eventMenuItems: [],
+    });
+  });
+
+  it("rejects duplicate sections, tracks, and header collisions", () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    try {
+      expect(() =>
+        renderHook(() =>
+          useMcapTimelineSections([
+            section("test:duplicate", 100, EVENT_TRACK),
+            section("test:duplicate", 200, TAG_TRACK),
+          ]),
+        ),
+      ).toThrow("Duplicate MCAP timeline section id: test:duplicate");
+
+      expect(() =>
+        renderHook(() =>
+          useMcapTimelineSections([
+            section("test:events", 100, EVENT_TRACK),
+            section("fiftyone:temporal-tags", 200, EVENT_TRACK),
+          ]),
+        ),
+      ).toThrow(`Duplicate MCAP timeline track id ${EVENT_TRACK.id}`);
+
+      expect(() =>
+        renderHook(() =>
+          useMcapTimelineSections([
+            section("test:events", 100, EVENT_TRACK),
+            section("fiftyone:temporal-tags", 200, {
+              ...TAG_TRACK,
+              id: EVENTS_HEADER_ID,
+            }),
+          ]),
+        ),
+      ).toThrow(
+        `MCAP timeline section header id collides with a track: ${EVENTS_HEADER_ID}`,
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+});
+
+function section(id: string, order: number, track: Track): McapTimelineSection {
+  return { id, label: id, order, tracks: [track] };
+}

--- a/app/packages/multimodal/src/extensions/mcap/sections.ts
+++ b/app/packages/multimodal/src/extensions/mcap/sections.ts
@@ -1,0 +1,130 @@
+import type { Track } from "@fiftyone/playback";
+import clsx from "clsx";
+import { useCallback, useMemo, useState } from "react";
+import type { McapTimelineSection, McapTimelineTrackDecorator } from "./types";
+import styles from "./sections.module.css";
+
+const SECTION_HEADER_ID_PREFIX = "mcap-timeline-section::";
+const SECTION_HEADER_COLOR = "#8f9199";
+
+function sectionHeader(section: McapTimelineSection): Track {
+  return {
+    id: `${SECTION_HEADER_ID_PREFIX}${section.id}`,
+    label: section.label,
+    color: SECTION_HEADER_COLOR,
+    events: [],
+  };
+}
+
+/**
+ * Validates and adapts explicitly ordered sections for the current playback
+ * package. Section metadata remains first-class at the extension boundary.
+ * Until playback has a section-row primitive, two or more non-empty sections
+ * receive non-pinnable compatibility header tracks so existing grouping and
+ * collapse behavior remains intact.
+ */
+export function useMcapTimelineSections(
+  sections: readonly McapTimelineSection[],
+): {
+  readonly decorateTrack: McapTimelineTrackDecorator;
+  readonly tracks: Track[];
+} {
+  const [collapsed, setCollapsed] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+  const toggle = useCallback((sectionId: string) => {
+    setCollapsed((previous) => {
+      const next = new Set(previous);
+      if (next.has(sectionId)) next.delete(sectionId);
+      else next.add(sectionId);
+      return next;
+    });
+  }, []);
+
+  return useMemo(() => {
+    const ordered = [...sections].sort(
+      (left, right) =>
+        left.order - right.order || left.id.localeCompare(right.id),
+    );
+    const ids = new Set<string>();
+    const sourceByTrackId = new Map<string, McapTimelineSection>();
+    for (const section of ordered) {
+      if (!section.id.includes(":")) {
+        throw new Error(
+          `MCAP timeline section ids must be namespaced: ${section.id}`,
+        );
+      }
+      if (ids.has(section.id)) {
+        throw new Error(`Duplicate MCAP timeline section id: ${section.id}`);
+      }
+      ids.add(section.id);
+      for (const track of section.tracks) {
+        const existing = sourceByTrackId.get(track.id);
+        if (existing) {
+          throw new Error(
+            `Duplicate MCAP timeline track id ${track.id} in ${existing.id} and ${section.id}`,
+          );
+        }
+        sourceByTrackId.set(track.id, section);
+      }
+    }
+    const nonEmpty = ordered.filter((section) => section.tracks.length > 0);
+    const decorateSourceTrack: McapTimelineTrackDecorator = (track, pinned) =>
+      sourceByTrackId.get(track.id)?.decorateTrack?.(track, pinned) ?? {};
+
+    if (nonEmpty.length < 2) {
+      return {
+        tracks: nonEmpty.flatMap((section) => section.tracks),
+        decorateTrack: decorateSourceTrack,
+      };
+    }
+
+    const headerIds = new Set<string>();
+    const sectionByChildId = new Map<string, string>();
+    const tracks: Track[] = [];
+    for (const section of nonEmpty) {
+      const header = sectionHeader(section);
+      if (sourceByTrackId.has(header.id)) {
+        throw new Error(
+          `MCAP timeline section header id collides with a track: ${header.id}`,
+        );
+      }
+      headerIds.add(header.id);
+      tracks.push(header);
+      for (const track of section.tracks) {
+        sectionByChildId.set(track.id, header.id);
+        tracks.push(track);
+      }
+    }
+
+    return {
+      tracks,
+      decorateTrack: (track, pinned) => {
+        if (headerIds.has(track.id)) {
+          return {
+            expandable: true,
+            expanded: !collapsed.has(track.id),
+            expansionGutter: true,
+            onPinClick: undefined,
+            onToggleExpand: () => toggle(track.id),
+          };
+        }
+
+        const headerId = sectionByChildId.get(track.id);
+        const sourceDecoration = decorateSourceTrack(track, pinned);
+        if (!pinned && headerId) {
+          return {
+            ...sourceDecoration,
+            depth: sourceDecoration.depth ?? 1,
+            expansionGutter: true,
+            className: clsx(
+              sourceDecoration.className,
+              collapsed.has(headerId) && styles.hiddenTrack,
+            ),
+          };
+        }
+        return sourceDecoration;
+      },
+    };
+  }, [collapsed, sections, toggle]);
+}

--- a/app/packages/multimodal/src/extensions/mcap/selected-annotation-topics.test.tsx
+++ b/app/packages/multimodal/src/extensions/mcap/selected-annotation-topics.test.tsx
@@ -1,0 +1,77 @@
+import { TileIdScope, TilingProvider } from "@fiftyone/tiling";
+import { cleanup, render, screen } from "@testing-library/react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  McapAnnotationTopicsProvider,
+  useMcapSelectedAnnotationTopics,
+  usePublishMcapAnnotationTopics,
+} from "./selected-annotation-topics";
+
+const Publisher: React.FC<{
+  readonly tileId: string;
+  readonly topics: readonly string[];
+}> = ({ tileId, topics }) => (
+  <TileIdScope tileId={tileId}>
+    <PublisherHook topics={topics} />
+  </TileIdScope>
+);
+
+const PublisherHook: React.FC<{ readonly topics: readonly string[] }> = ({
+  topics,
+}) => {
+  publisherRenders += 1;
+  usePublishMcapAnnotationTopics(topics);
+  return null;
+};
+
+const Probe = () => (
+  <span data-testid="topics">
+    {JSON.stringify(useMcapSelectedAnnotationTopics())}
+  </span>
+);
+
+let publisherRenders = 0;
+
+describe("MCAP selected annotation topics", () => {
+  beforeEach(() => {
+    publisherRenders = 0;
+  });
+  afterEach(() => cleanup());
+
+  it("publishes a sorted viewer-local union and cleans up by tile", () => {
+    const view = render(
+      <McapAnnotationTopicsProvider>
+        <TilingProvider>
+          <Publisher tileId="image" topics={["/b", "/a", "/a"]} />
+          <Publisher tileId="3d" topics={["/b", "/c"]} />
+          <Probe />
+        </TilingProvider>
+      </McapAnnotationTopicsProvider>,
+    );
+    expect(screen.getByTestId("topics").textContent).toBe('["/a","/b","/c"]');
+    expect(publisherRenders).toBe(2);
+
+    view.rerender(
+      <McapAnnotationTopicsProvider>
+        <TilingProvider>
+          <Publisher tileId="image" topics={["/a"]} />
+          <Probe />
+        </TilingProvider>
+      </McapAnnotationTopicsProvider>,
+    );
+    expect(screen.getByTestId("topics").textContent).toBe('["/a"]');
+  });
+
+  it("does not retain empty selections", () => {
+    render(
+      <McapAnnotationTopicsProvider>
+        <TilingProvider>
+          <Publisher tileId="image" topics={[]} />
+          <Probe />
+        </TilingProvider>
+      </McapAnnotationTopicsProvider>,
+    );
+    expect(screen.getByTestId("topics").textContent).toBe("[]");
+  });
+});

--- a/app/packages/multimodal/src/extensions/mcap/selected-annotation-topics.tsx
+++ b/app/packages/multimodal/src/extensions/mcap/selected-annotation-topics.tsx
@@ -1,0 +1,78 @@
+import { useTileId } from "@fiftyone/tiling";
+import { atom, createStore, useAtomValue } from "jotai";
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+const EMPTY_TOPICS: readonly string[] = [];
+const topicsByTileAtom = atom<ReadonlyMap<string, readonly string[]>>(
+  new Map(),
+);
+const selectedTopicsAtom = atom((get) =>
+  [
+    ...new Set([...get(topicsByTileAtom).values()].flatMap((value) => value)),
+  ].sort(),
+);
+type McapAnnotationTopicsStore = ReturnType<typeof createStore>;
+const fallbackStore = createStore();
+const McapAnnotationTopicsContext =
+  createContext<McapAnnotationTopicsStore | null>(null);
+
+/** Viewer-local registry shared by the host and its mounted MCAP tiles. */
+export const McapAnnotationTopicsProvider: React.FC<{
+  readonly children: React.ReactNode;
+}> = ({ children }) => {
+  const [store] = useState(createStore);
+
+  return (
+    <McapAnnotationTopicsContext.Provider value={store}>
+      {children}
+    </McapAnnotationTopicsContext.Provider>
+  );
+};
+
+/** Publishes one tile's resolved annotation topics for neutral extensions. */
+export function usePublishMcapAnnotationTopics(
+  topics: readonly string[],
+): void {
+  const tileId = useTileId();
+  const store = useContext(McapAnnotationTopicsContext);
+  const topicsKey = [...new Set(topics)].sort().join("\0");
+  const normalized = useMemo(
+    () => (topicsKey ? topicsKey.split("\0") : EMPTY_TOPICS),
+    [topicsKey],
+  );
+
+  // This effect publishes the tile's current topics and removes only the
+  // snapshot owned by this effect instance during cleanup.
+  useEffect(() => {
+    if (!tileId || !store) return undefined;
+    store.set(topicsByTileAtom, (previous) => {
+      const next = new Map(previous);
+      if (normalized.length === 0) next.delete(tileId);
+      else next.set(tileId, normalized);
+      return next;
+    });
+    return () => {
+      store.set(topicsByTileAtom, (previous) => {
+        if (previous.get(tileId) !== normalized) return previous;
+        const next = new Map(previous);
+        next.delete(tileId);
+        return next;
+      });
+    };
+  }, [normalized, store, tileId]);
+}
+
+/** Returns the sorted annotation-topic union for the current MCAP viewer. */
+export function useMcapSelectedAnnotationTopics(): readonly string[] {
+  const store = useContext(McapAnnotationTopicsContext);
+  const topics = useAtomValue(selectedTopicsAtom, {
+    store: store ?? fallbackStore,
+  });
+  return store ? topics : EMPTY_TOPICS;
+}

--- a/app/packages/multimodal/src/extensions/mcap/types.ts
+++ b/app/packages/multimodal/src/extensions/mcap/types.ts
@@ -1,0 +1,79 @@
+import type { TemporalTagTimelineProps, Track } from "@fiftyone/playback";
+import type { SampleRendererProps } from "@fiftyone/plugins";
+import type React from "react";
+import type { ByteSourceDescriptor } from "../../query/bytes";
+import type {
+  McapResourceClient,
+  McapTimelineRange,
+} from "../../adapters/mcap";
+
+/** Row-level behavior contributed by an MCAP timeline source. */
+export type McapTimelineTrackDecorator = NonNullable<
+  TemporalTagTimelineProps["decorateTrack"]
+>;
+
+/** A real group of tracks contributed to the MCAP timeline. */
+export interface McapTimelineSection {
+  /** Stable, globally namespaced identity. */
+  readonly id: string;
+  /** Explicit product-policy order; import order never decides placement. */
+  readonly order: number;
+  readonly label: string;
+  readonly tracks: readonly Track[];
+  /** Optional source-owned row behavior. */
+  readonly decorateTrack?: McapTimelineTrackDecorator;
+}
+
+/** Generic preferences an extension may request from the timeline host. */
+export interface McapTimelinePreferences {
+  readonly drawerMaxSize?: number;
+  /** Browser-local key for a host-supported track-body height preference. */
+  readonly drawerSizeStorageKey?: string;
+  /** Browser-local key for a host-supported track-label width preference. */
+  readonly labelWidthStorageKey?: string;
+  /** Enables the host's compact track search affordance. */
+  readonly timelineSearchEnabled?: boolean;
+}
+
+/** Values contributed by one registered extension for the current viewer. */
+export interface McapTimelineContribution {
+  readonly sections?: readonly McapTimelineSection[];
+  /** Runs inside the playback, track, tiling, and MCAP data-stream providers. */
+  readonly runtime?: React.ReactNode;
+  readonly preferences?: McapTimelinePreferences;
+  readonly onDrawerOpenChange?: (open: boolean) => void;
+}
+
+/** Product-neutral source and lifecycle facts exposed to extensions. */
+export interface McapTimelineExtensionContext {
+  readonly client: McapResourceClient;
+  readonly ctx: SampleRendererProps["ctx"];
+  readonly layoutScopeKey: string;
+  readonly navigationPending: boolean;
+  readonly selectedAnnotationTopics: readonly string[];
+  readonly source: ByteSourceDescriptor | null;
+  readonly timelineRange: McapTimelineRange | null;
+}
+
+/** Props supplied to every registered MCAP timeline extension component. */
+export interface McapTimelineExtensionComponentProps extends McapTimelineExtensionContext {
+  readonly children: (
+    contribution: McapTimelineContribution,
+  ) => React.ReactNode;
+}
+
+/** One independently registered MCAP timeline extension. */
+export interface McapTimelineExtension {
+  readonly id: string;
+  readonly order: number;
+  readonly Component: React.ComponentType<McapTimelineExtensionComponentProps>;
+}
+
+/** Fully composed values consumed by the shared MCAP playback shell. */
+export interface McapTimelineComposition {
+  readonly decorateTrack: McapTimelineTrackDecorator;
+  readonly onDrawerOpenChange?: (open: boolean) => void;
+  readonly preferences: McapTimelinePreferences;
+  readonly runtime: React.ReactNode;
+  readonly tracks: readonly Track[];
+}

--- a/app/packages/multimodal/src/inject/enterprise.ts
+++ b/app/packages/multimodal/src/inject/enterprise.ts
@@ -1,9 +1,0 @@
-/**
- * Product-edition bootstrap seam.
- *
- * Open source intentionally performs no work here. The Teams fork replaces
- * this one file with an import of its private implementation under
- * `src/enterprise`, keeping the ordinary `@fiftyone/multimodal/inject`
- * entrypoint identical for both products.
- */
-export {};

--- a/app/packages/multimodal/src/inject/enterprise.ts
+++ b/app/packages/multimodal/src/inject/enterprise.ts
@@ -1,0 +1,9 @@
+/**
+ * Product-edition bootstrap seam.
+ *
+ * Open source intentionally performs no work here. The Teams fork replaces
+ * this one file with an import of its private implementation under
+ * `src/enterprise`, keeping the ordinary `@fiftyone/multimodal/inject`
+ * entrypoint identical for both products.
+ */
+export {};

--- a/app/packages/multimodal/src/inject/index.ts
+++ b/app/packages/multimodal/src/inject/index.ts
@@ -2,4 +2,3 @@
 // plugins, we can do so here
 
 import "../adapters/mcap/entry";
-import "./enterprise";

--- a/app/packages/multimodal/src/inject/index.ts
+++ b/app/packages/multimodal/src/inject/index.ts
@@ -2,3 +2,4 @@
 // plugins, we can do so here
 
 import "../adapters/mcap/entry";
+import "./enterprise";


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

Paired teams PRs: voxel51/fiftyone-teams#3386 (sync PR), teams feature PR (https://github.com/voxel51/fiftyone-teams/pull/3387)

## 📋 What changes are proposed in this pull request?

Adds a neutral extension seam for multimodal timeline capabilities and moves shared MCAP composition behind it.

## 🧪 How is this patch tested? If it is not, please explain why.

- `cd app && yarn check`
- `cd app && yarn test packages/multimodal` — 210 files and 1,949 tests passed

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

N/A

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [x] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3386
<!-- enterprise-sync-pr:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an extensible MCAP timeline extension system with a host, registry, and composable sections/tracks.
  * Enabled cross-tile sharing of selected annotation topics.
  * Added timeline drawer controls (track decoration, open/close notifications, and configurable max size) to the playback UI.
* **Bug Fixes**
  * Prevented reuse of cached MCAP bootstrap data when `etag` changes.
  * Fixed timeline range updates to avoid applying stale results during source transitions.
* **Tests**
  * Expanded coverage for extension composition, topic selection, source transition behavior, caching behavior, and timeline range resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->