### PR TITLE
fix(ci): raise Node heap for the e2e app build

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -110,6 +110,10 @@ jobs:
       - name: Build app
         if: steps.app-static-cache.outputs.cache-hit != 'true'
         run: make app
+        env:
+          # FOE's app graph exceeds Node's default heap; kept in the shared
+          # workflow so OSS and FOE stay consistent
+          NODE_OPTIONS: --max-old-space-size=6144
 
       - name: Bundle built app static assets
         run: tar -czf e2e-app-static.tgz fiftyone/server/static


### PR DESCRIPTION
FOE's `Prepare e2e assets` job OOMs building the app at Node's default heap ([fiftyone-teams run 29755764122](https://github.com/voxel51/fiftyone-teams/actions/runs/29755764122/job/88398260529)); OSS is close enough to the ceiling that its turn is a matter of time. Sets `NODE_OPTIONS: --max-old-space-size=6144` on the `Build app` step — headroom on the 16 GB runners, in the shared workflow so OSS and FOE stay consistent via the enterprise sync.

FOE's docker build already runs its app build with an explicit `--max-old-space-size`.

## Testing

The same option (at 4096) is live on the #8040 sync branch: [fiftyone-teams run 29761236220](https://github.com/voxel51/fiftyone-teams/actions/runs/29761236220) exercises it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build reliability by allocating additional memory during the application build process.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3396
<!-- enterprise-sync-pr:end -->