### PR TITLE
feat(video-annotation): enable click-to-segment

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSegmentationActions.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSegmentationActions.tsx
@@ -5,8 +5,6 @@
 import { SelectIcon } from "@fiftyone/components";
 import { KnownContexts, useKeyBindings } from "@fiftyone/commands";
 import { buildBrushCursor } from "@fiftyone/lighter";
-import { isVideoDataset } from "@fiftyone/state";
-import { useRecoilValue } from "recoil";
 import {
   Add,
   ArrowDropDown,
@@ -182,11 +180,6 @@ export const useSegmentationActions = (): {
   const { isEditing } = useAnnotationContext();
   const onExit = useExit();
 
-  // AI click-to-segment (SAM2 point selection) is image-only for now — the
-  // video surface's session lifecycle doesn't yet support it cleanly, so the
-  // tool is omitted from the toolbar on video datasets.
-  const isVideo = useRecoilValue(isVideoDataset);
-
   // Three-tier Escape behaviour, mirroring the right-click flow in
   // InteractionManager:
   //   1. close any open label (clear the editing focus)
@@ -260,14 +253,9 @@ export const useSegmentationActions = (): {
             label: "AI",
             icon: <AutoAwesome />,
             shortcut: "A",
-            // AI click-to-segment is image-only for now — the video surface's
-            // session lifecycle doesn't support it cleanly yet.
-            tooltip: isVideo
-              ? "AI-assisted segmentation is not yet supported for video datasets"
-              : "AI",
+            tooltip: "AI",
             isActive: tool === SegmentationTool.AI,
-            isDisabled: isVideo,
-            onClick: () => !isVideo && switchTool(SegmentationTool.AI),
+            onClick: () => switchTool(SegmentationTool.AI),
           },
           {
             id: SegmentationTool.Merge,
@@ -381,7 +369,6 @@ export const useSegmentationActions = (): {
       decreaseToolSize,
       handleEscape,
       increaseToolSize,
-      isVideo,
       mergeTool.disabled,
       setToolSize,
       switchTool,

--- a/app/packages/video-annotation/src/hooks/useVideoSurfaceActions.test.ts
+++ b/app/packages/video-annotation/src/hooks/useVideoSurfaceActions.test.ts
@@ -162,6 +162,26 @@ describe("track ops", () => {
     );
   });
 
+  it("extendTrack carries the source frame's mask onto the filler frames", () => {
+    const mask = { shape: [2, 2], counts: "abcd" };
+    frameData = {
+      1: { A: det("d1", "A", { keyframe: true, mask }) },
+    };
+
+    render().current.extendTrack("instance-A", 1, [2]);
+
+    expect(mockActions.updateLabel).toHaveBeenCalledWith(
+      { path: PATH, instanceId: "A", frame: 2 },
+      {
+        _cls: "Detection",
+        label: "x",
+        bounding_box: [0, 0, 1, 1],
+        mask,
+        keyframe: false,
+      },
+    );
+  });
+
   it("trimTrack deletes only frames where the track is present", () => {
     frameData = { 2: { A: det("d2", "A") } };
 

--- a/app/packages/video-annotation/src/hooks/useVideoSurfaceActions.ts
+++ b/app/packages/video-annotation/src/hooks/useVideoSurfaceActions.ts
@@ -254,12 +254,12 @@ const makeTrackOps = (
       return;
     }
 
-    // non-keyframe filler — a later propagate overwrites these in place.
-    // Deny-list the mask: filler frames share the keyframe's geometry, but a
-    // mask is per-frame pixels — copying it would paste the keyframe's mask onto
-    // every frame (and bloat storage). Every other field carries forward.
-    const { mask, mask_path, ...rest } = r.content(source);
-    const filler = { ...rest, keyframe: false };
+    // non-keyframe filler — a later propagate overwrites these in place. Carry
+    // the source frame's mask forward when it has one so an extended detection
+    // reads as segmented on every filler frame, not just the keyframe. The mask
+    // is stored relative to the (copied) bounding_box, so it stays geometrically
+    // consistent across the filler.
+    const filler = { ...r.content(source), keyframe: false };
 
     actions.transaction(
       () => {

--- a/app/packages/video-annotation/src/sync/useSyncLighterAnnotation.ts
+++ b/app/packages/video-annotation/src/sync/useSyncLighterAnnotation.ts
@@ -262,6 +262,30 @@ const useRegisterModeQuitHandlers = ({
 };
 
 /**
+ * Point-selection finalize: right-click during an AI click-to-segment session
+ * commits the in-progress mask and re-arms a fresh point session for the next
+ * detection. The committed label stays selected; `finalizePointSelection` flags
+ * the next click to seed a NEW mask rather than refine the just-committed one.
+ * Mirrors the image surface's `useBridge`.
+ */
+const useRegisterPointSelectionFinalizeHandler = ({
+  registerHandler,
+  segmentationMode,
+}: {
+  registerHandler: RegisterLighterHandler;
+  segmentationMode: SegmentationMode;
+}): void => {
+  registerHandler(
+    "lighter:point-selection-finalize",
+    useCallback(() => {
+      if (segmentationMode.segmentationModeActive) {
+        segmentationMode.finalizePointSelection();
+      }
+    }, [segmentationMode]),
+  );
+};
+
+/**
  * Track deleted: deleting a track leaves no useful edit/draw state to keep open,
  * so tear detection mode down.
  */
@@ -317,6 +341,10 @@ export const useSyncLighterAnnotation = (scene: Scene2D | null): void => {
     detectionMode,
     segmentationMode,
     polylineMode,
+  });
+  useRegisterPointSelectionFinalizeHandler({
+    registerHandler,
+    segmentationMode,
   });
   useRegisterTrackDeletedHandler({ detectionMode });
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Enables AI click-to-segment (SAM2 point selection) on the video annotation surface, and improves track extension for segmented detections.

**Enable AI click-to-segment on video**
- The AI segmentation tool was hard-disabled on video datasets in the segmentation toolbar; the underlying pipeline (point selection, frame-bitmap inference, and the establish → auto-extend track flow) is already video-aware, so this removes the UI gate.
- Adds the `lighter:point-selection-finalize` handler to the video Lighter bridge (the image bridge already had it), so a right-click commits the in-progress mask and re-arms a fresh point session for the next detection.

**Carry the mask forward when extending a track**
- `extendTrack` previously deny-listed `mask`/`mask_path` when copying a detection onto filler frames. It now carries the source frame's mask forward when present, so an extended segmented detection reads as masked on every filler frame rather than only the keyframe. The mask is stored relative to the (copied) bounding box, so it stays geometrically consistent.

### How is this patch tested?

- `useVideoSurfaceActions` unit tests updated with a case asserting the mask carries onto filler frames (23 passing).
- Manual: click-to-segment on a video sample produces a masked detection on the current frame; extending a segmented track carries the mask across filler frames.

### Release notes

Adds AI click-to-segment (point-prompted SAM2 masks) to the video annotation surface, and carries a detection's mask forward when its track is extended.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI-assisted segmentation is now available from the annotation toolbar without video-specific restrictions.
  * AI click-to-segment selections can be finalized directly from the active annotation workflow.

* **Bug Fixes**
  * Extended video tracks now preserve mask data when creating filler frames while keeping them non-keyframes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3394
<!-- enterprise-sync-pr:end -->