### PR TITLE
[release] cherry-pick(8068): click-to-segment for video annotation

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSegmentationActions.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useSegmentationActions.tsx
@@ -5,8 +5,6 @@
 import { SelectIcon } from "@fiftyone/components";
 import { KnownContexts, useKeyBindings } from "@fiftyone/commands";
 import { buildBrushCursor } from "@fiftyone/lighter";
-import { isVideoDataset } from "@fiftyone/state";
-import { useRecoilValue } from "recoil";
 import {
   Add,
   ArrowDropDown,
@@ -182,11 +180,6 @@ export const useSegmentationActions = (): {
   const { isEditing } = useAnnotationContext();
   const onExit = useExit();
 
-  // AI click-to-segment (SAM2 point selection) is image-only for now — the
-  // video surface's session lifecycle doesn't yet support it cleanly, so the
-  // tool is omitted from the toolbar on video datasets.
-  const isVideo = useRecoilValue(isVideoDataset);
-
   // Three-tier Escape behaviour, mirroring the right-click flow in
   // InteractionManager:
   //   1. close any open label (clear the editing focus)
@@ -260,14 +253,9 @@ export const useSegmentationActions = (): {
             label: "AI",
             icon: <AutoAwesome />,
             shortcut: "A",
-            // AI click-to-segment is image-only for now — the video surface's
-            // session lifecycle doesn't support it cleanly yet.
-            tooltip: isVideo
-              ? "AI-assisted segmentation is not yet supported for video datasets"
-              : "AI",
+            tooltip: "AI",
             isActive: tool === SegmentationTool.AI,
-            isDisabled: isVideo,
-            onClick: () => !isVideo && switchTool(SegmentationTool.AI),
+            onClick: () => switchTool(SegmentationTool.AI),
           },
           {
             id: SegmentationTool.Merge,
@@ -381,7 +369,6 @@ export const useSegmentationActions = (): {
       decreaseToolSize,
       handleEscape,
       increaseToolSize,
-      isVideo,
       mergeTool.disabled,
       setToolSize,
       switchTool,

--- a/app/packages/video-annotation/src/hooks/useVideoSurfaceActions.test.ts
+++ b/app/packages/video-annotation/src/hooks/useVideoSurfaceActions.test.ts
@@ -162,6 +162,26 @@ describe("track ops", () => {
     );
   });
 
+  it("extendTrack carries the source frame's mask onto the filler frames", () => {
+    const mask = { shape: [2, 2], counts: "abcd" };
+    frameData = {
+      1: { A: det("d1", "A", { keyframe: true, mask }) },
+    };
+
+    render().current.extendTrack("instance-A", 1, [2]);
+
+    expect(mockActions.updateLabel).toHaveBeenCalledWith(
+      { path: PATH, instanceId: "A", frame: 2 },
+      {
+        _cls: "Detection",
+        label: "x",
+        bounding_box: [0, 0, 1, 1],
+        mask,
+        keyframe: false,
+      },
+    );
+  });
+
   it("trimTrack deletes only frames where the track is present", () => {
     frameData = { 2: { A: det("d2", "A") } };
 

--- a/app/packages/video-annotation/src/hooks/useVideoSurfaceActions.ts
+++ b/app/packages/video-annotation/src/hooks/useVideoSurfaceActions.ts
@@ -254,12 +254,12 @@ const makeTrackOps = (
       return;
     }
 
-    // non-keyframe filler — a later propagate overwrites these in place.
-    // Deny-list the mask: filler frames share the keyframe's geometry, but a
-    // mask is per-frame pixels — copying it would paste the keyframe's mask onto
-    // every frame (and bloat storage). Every other field carries forward.
-    const { mask, mask_path, ...rest } = r.content(source);
-    const filler = { ...rest, keyframe: false };
+    // non-keyframe filler — a later propagate overwrites these in place. Carry
+    // the source frame's mask forward when it has one so an extended detection
+    // reads as segmented on every filler frame, not just the keyframe. The mask
+    // is stored relative to the (copied) bounding_box, so it stays geometrically
+    // consistent across the filler.
+    const filler = { ...r.content(source), keyframe: false };
 
     actions.transaction(
       () => {

--- a/app/packages/video-annotation/src/sync/useSyncLighterAnnotation.ts
+++ b/app/packages/video-annotation/src/sync/useSyncLighterAnnotation.ts
@@ -262,6 +262,30 @@ const useRegisterModeQuitHandlers = ({
 };
 
 /**
+ * Point-selection finalize: right-click during an AI click-to-segment session
+ * commits the in-progress mask and re-arms a fresh point session for the next
+ * detection. The committed label stays selected; `finalizePointSelection` flags
+ * the next click to seed a NEW mask rather than refine the just-committed one.
+ * Mirrors the image surface's `useBridge`.
+ */
+const useRegisterPointSelectionFinalizeHandler = ({
+  registerHandler,
+  segmentationMode,
+}: {
+  registerHandler: RegisterLighterHandler;
+  segmentationMode: SegmentationMode;
+}): void => {
+  registerHandler(
+    "lighter:point-selection-finalize",
+    useCallback(() => {
+      if (segmentationMode.segmentationModeActive) {
+        segmentationMode.finalizePointSelection();
+      }
+    }, [segmentationMode]),
+  );
+};
+
+/**
  * Track deleted: deleting a track leaves no useful edit/draw state to keep open,
  * so tear detection mode down.
  */
@@ -317,6 +341,10 @@ export const useSyncLighterAnnotation = (scene: Scene2D | null): void => {
     detectionMode,
     segmentationMode,
     polylineMode,
+  });
+  useRegisterPointSelectionFinalizeHandler({
+    registerHandler,
+    segmentationMode,
   });
   useRegisterTrackDeletedHandler({ detectionMode });
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Cherry-pick of #8068 onto `release/v1.20.0`.

Enables AI click-to-segment (SAM2 point selection) on the video annotation surface, and carries a detection's mask forward when its track is extended.

- Removes the UI gate that hard-disabled the AI segmentation tool on video datasets.
- Adds the `lighter:point-selection-finalize` handler to the video Lighter bridge so a right-click commits the in-progress mask and re-arms a fresh point session.
- `extendTrack` now carries the source frame's `mask`/`mask_path` onto filler frames when present, so an extended segmented detection reads as masked on every filler frame.

### How is this patch tested?

- `useVideoSurfaceActions` unit tests, including a case asserting the mask carries onto filler frames (23 passing).

### Release notes

Adds AI click-to-segment (point-prompted SAM2 masks) to the video annotation surface, and carries a detection's mask forward when its track is extended.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - AI segmentation is now available for video annotation workflows.
  - Point-selection actions in AI segmentation now finalize the current mask and prepare the next selection automatically.

- **Bug Fixes**
  - Extended video tracks now preserve mask data on newly filled frames, ensuring masks remain visible and consistent across the track.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->