### PR TITLE
[release] cherry-pick(7970): updated sidebar ux

### DIFF
--- a/app/packages/annotation/src/components/AnnotationSaveIndicator.tsx
+++ b/app/packages/annotation/src/components/AnnotationSaveIndicator.tsx
@@ -1,0 +1,30 @@
+import { Size } from "@voxel51/voodo";
+import React from "react";
+import { useSaveStatus } from "../persistence";
+import { SaveStatusIndicator } from "./SaveStatusIndicator";
+
+export interface AnnotationSaveIndicatorProps {
+  /** Icon size, forwarded to the base indicator. */
+  size?: Size;
+}
+
+/**
+ * Annotation-bound save-status light. Binds the shared autosave status (health
+ * + in-flight) published by the persistence composition root and renders the
+ * presentational {@link SaveStatusIndicator}. Mount this wherever the save
+ * status should surface in the annotation UI.
+ */
+export const AnnotationSaveIndicator: React.FC<
+  AnnotationSaveIndicatorProps
+> = ({ size }) => {
+  const { health, inFlight, lastSavedAt } = useSaveStatus();
+
+  return (
+    <SaveStatusIndicator
+      health={health}
+      pulsing={inFlight}
+      lastSavedAt={lastSavedAt}
+      size={size}
+    />
+  );
+};

--- a/app/packages/annotation/src/components/SaveStatusIndicator.module.css
+++ b/app/packages/annotation/src/components/SaveStatusIndicator.module.css
@@ -1,0 +1,29 @@
+/* Slow opacity pulse for the in-flight state. A local keyframe until a shared
+ * animation token lands in voodo. */
+@keyframes save-status-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
+}
+
+.indicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 0;
+}
+
+.pulsing {
+  animation: save-status-pulse 1.6s ease-in-out infinite;
+}
+
+/* Respect users who opt out of motion — hold the icon steady. */
+@media (prefers-reduced-motion: reduce) {
+  .pulsing {
+    animation: none;
+  }
+}

--- a/app/packages/annotation/src/components/SaveStatusIndicator.test.tsx
+++ b/app/packages/annotation/src/components/SaveStatusIndicator.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { SaveHealth } from "../persistence";
+import { SaveStatusIndicator } from "./SaveStatusIndicator";
+
+const labelOf = (container: HTMLElement): string =>
+  container.querySelector('[role="status"]')?.getAttribute("aria-label") ?? "";
+
+describe("SaveStatusIndicator", () => {
+  it("shows the last synced time", () => {
+    const savedAt = new Date("2026-07-07T14:34:07").getTime();
+    const { container } = render(
+      <SaveStatusIndicator health={SaveHealth.Healthy} lastSavedAt={savedAt} />,
+    );
+
+    expect(labelOf(container)).toContain("Last synced at");
+    expect(labelOf(container)).toMatch(/34/);
+  });
+
+  it("falls back to the current time before the first save", () => {
+    const { container } = render(
+      <SaveStatusIndicator health={SaveHealth.Healthy} lastSavedAt={null} />,
+    );
+    expect(labelOf(container)).toContain("Last synced at");
+  });
+
+  it("applies the pulse class to the icon only when in flight", () => {
+    const { container, rerender } = render(
+      <SaveStatusIndicator health={SaveHealth.Healthy} pulsing={false} />,
+    );
+    const iconClass = () =>
+      container.querySelector("svg")?.getAttribute("class") ?? "";
+    const idleClass = iconClass();
+
+    rerender(<SaveStatusIndicator health={SaveHealth.Healthy} pulsing />);
+    const pulsingClass = iconClass();
+
+    expect(pulsingClass).not.toBe(idleClass);
+    expect(pulsingClass.length).toBeGreaterThan(idleClass.length);
+  });
+});

--- a/app/packages/annotation/src/components/SaveStatusIndicator.tsx
+++ b/app/packages/annotation/src/components/SaveStatusIndicator.tsx
@@ -1,0 +1,74 @@
+import {
+  Anchor,
+  Icon,
+  IconColor,
+  IconName,
+  Size,
+  Text,
+  TextVariant,
+  Tooltip,
+} from "@voxel51/voodo";
+import React from "react";
+import { SaveHealth } from "../persistence";
+import styles from "./SaveStatusIndicator.module.css";
+
+/** Semantic icon colour per save-health state. */
+const HEALTH_COLOR: Record<SaveHealth, IconColor> = {
+  [SaveHealth.Healthy]: IconColor.Success,
+  [SaveHealth.Unhealthy]: IconColor.Warning,
+  [SaveHealth.Stopped]: IconColor.Destructive,
+};
+
+const formatSyncedAt = (timestamp: number): string =>
+  new Date(timestamp).toLocaleTimeString([], {
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+
+export interface SaveStatusIndicatorProps {
+  /** Which health state to render. */
+  health: SaveHealth;
+  /** When true, the icon slowly pulses to signal an in-flight request. */
+  pulsing?: boolean;
+  /**
+   * Epoch ms of the last successful save. Falls back to the current time for
+   * the initial render, before anything has been saved this session.
+   */
+  lastSavedAt?: number | null;
+  /** Icon size. Defaults to {@link Size.Sm}. */
+  size?: Size;
+}
+
+/**
+ * Presentational save-status light: a coloured, softly glowing dot that mirrors
+ * annotation autosave health (green healthy / amber unhealthy / red stopped),
+ * slowly pulses while a request is in flight, and shows the last sync time on
+ * hover. Fully controlled — see {@link AnnotationSaveIndicator} for the
+ * annotation-bound wrapper.
+ */
+export const SaveStatusIndicator: React.FC<SaveStatusIndicatorProps> = ({
+  health,
+  pulsing = false,
+  lastSavedAt = null,
+  size = Size.Sm,
+}) => {
+  const syncedLine = `Last synced at ${formatSyncedAt(lastSavedAt ?? Date.now())}`;
+
+  return (
+    <Tooltip
+      anchor={Anchor.Top}
+      portal
+      content={<Text variant={TextVariant.Sm}>{syncedLine}</Text>}
+    >
+      <span className={styles.indicator} role="status" aria-label={syncedLine}>
+        <Icon
+          name={IconName.Circle}
+          size={size}
+          color={HEALTH_COLOR[health]}
+          className={pulsing ? styles.pulsing : ""}
+        />
+      </span>
+    </Tooltip>
+  );
+};

--- a/app/packages/annotation/src/components/index.ts
+++ b/app/packages/annotation/src/components/index.ts
@@ -1,0 +1,2 @@
+export * from "./AnnotationSaveIndicator";
+export * from "./SaveStatusIndicator";

--- a/app/packages/annotation/src/hooks/useRegisterAnnotationEventHandlers.ts
+++ b/app/packages/annotation/src/hooks/useRegisterAnnotationEventHandlers.ts
@@ -1,10 +1,12 @@
 import { useAnnotationEventHandler } from "./useAnnotationEventHandler";
 import { INDEFINITE_TOAST_TIMEOUT, useActivityToast } from "@fiftyone/state";
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
 import { IconName, Variant } from "@voxel51/voodo";
 import {
+  deriveSaveHealth,
   usePersistenceEventHandler,
   usePersistenceRetryController,
+  usePublishSaveStatus,
 } from "../persistence";
 
 /**
@@ -15,6 +17,20 @@ export const useRegisterAnnotationEventHandlers = () => {
   const { setConfig } = useActivityToast();
   const handlePersistenceRequest = usePersistenceEventHandler();
   const retryController = usePersistenceRetryController();
+  const publishSaveStatus = usePublishSaveStatus();
+
+  // mirror the retry controller's health onto the shared save status the
+  // indicator reads; the toasts above and this light share one controller
+  useEffect(() => {
+    publishSaveStatus((prev) => ({
+      ...prev,
+      health: deriveSaveHealth(retryController),
+    }));
+  }, [
+    publishSaveStatus,
+    retryController.canAttempt,
+    retryController.isUnhealthy,
+  ]);
 
   useAnnotationEventHandler(
     "annotation:persistenceRequested",
@@ -29,30 +45,20 @@ export const useRegisterAnnotationEventHandlers = () => {
     "annotation:persistenceInFlight",
     useCallback(() => {
       retryController.recordAttempt();
-
-      // silence notifications when unhealthy
-      if (!retryController.isUnhealthy) {
-        setConfig({
-          iconName: IconName.Spinner,
-          message: "Saving changes...",
-          variant: Variant.Secondary,
-          timeout: INDEFINITE_TOAST_TIMEOUT,
-        });
-      }
-    }, [retryController, setConfig]),
+      publishSaveStatus((prev) => ({ ...prev, inFlight: true }));
+    }, [publishSaveStatus, retryController]),
   );
 
   useAnnotationEventHandler(
     "annotation:persistenceSuccess",
     useCallback(() => {
-      setConfig({
-        iconName: IconName.Check,
-        message: "Changes saved successfully",
-        variant: Variant.Success,
-      });
-
+      publishSaveStatus((prev) => ({
+        ...prev,
+        inFlight: false,
+        lastSavedAt: Date.now(),
+      }));
       retryController.reset();
-    }, [retryController, setConfig]),
+    }, [publishSaveStatus, retryController]),
   );
 
   useAnnotationEventHandler(
@@ -60,6 +66,8 @@ export const useRegisterAnnotationEventHandlers = () => {
     useCallback(
       ({ error }) => {
         console.error(error);
+
+        publishSaveStatus((prev) => ({ ...prev, inFlight: false }));
 
         if (retryController.isUnhealthy) {
           setConfig({
@@ -69,15 +77,9 @@ export const useRegisterAnnotationEventHandlers = () => {
             variant: Variant.Danger,
             timeout: INDEFINITE_TOAST_TIMEOUT,
           });
-        } else {
-          setConfig({
-            iconName: IconName.Error,
-            message: "Unable to save changes. Please try again.",
-            variant: Variant.Danger,
-          });
         }
       },
-      [retryController.isUnhealthy, setConfig],
+      [publishSaveStatus, retryController.isUnhealthy, setConfig],
     ),
   );
 };

--- a/app/packages/annotation/src/index.ts
+++ b/app/packages/annotation/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./components";
 export * from "./engine";
 // Seam for the video-annotation surface (which owns the video-coupled
 // hooks). Explicit re-exports rather than `export * from "./agents"` so the

--- a/app/packages/annotation/src/persistence/index.ts
+++ b/app/packages/annotation/src/persistence/index.ts
@@ -1,4 +1,5 @@
 export * from "./deltaSupplier";
+export * from "./saveStatus";
 export * from "./useAnnotationDeltaSupplier";
 export * from "./useAutoSave";
 export * from "./usePersistAnnotationDeltas";

--- a/app/packages/annotation/src/persistence/saveStatus.test.ts
+++ b/app/packages/annotation/src/persistence/saveStatus.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { describe, expect, it } from "vitest";
+import { SaveHealth, deriveSaveHealth } from "./saveStatus";
+
+describe("deriveSaveHealth", () => {
+  it("is healthy when attempts are allowed and not unhealthy", () => {
+    expect(deriveSaveHealth({ canAttempt: true, isUnhealthy: false })).toBe(
+      SaveHealth.Healthy,
+    );
+  });
+
+  it("is unhealthy when flagged but retries remain", () => {
+    expect(deriveSaveHealth({ canAttempt: true, isUnhealthy: true })).toBe(
+      SaveHealth.Unhealthy,
+    );
+  });
+
+  it("is stopped once attempts are exhausted, regardless of the unhealthy flag", () => {
+    expect(deriveSaveHealth({ canAttempt: false, isUnhealthy: true })).toBe(
+      SaveHealth.Stopped,
+    );
+    expect(deriveSaveHealth({ canAttempt: false, isUnhealthy: false })).toBe(
+      SaveHealth.Stopped,
+    );
+  });
+});

--- a/app/packages/annotation/src/persistence/saveStatus.ts
+++ b/app/packages/annotation/src/persistence/saveStatus.ts
@@ -1,0 +1,63 @@
+import { atom, useAtomValue, useSetAtom } from "jotai";
+import type { AnnotationRetryController } from "./usePersistenceRetryController";
+
+/**
+ * Health of annotation autosave, mirrored from the persistence retry
+ * controller's tri-state. Drives the {@link SaveStatusIndicator} colour.
+ */
+export enum SaveHealth {
+  /** Saves are succeeding. */
+  Healthy = "healthy",
+  /** Saves are failing but retries are still in progress. */
+  Unhealthy = "unhealthy",
+  /** Retries are exhausted; the user must reload to recover. */
+  Stopped = "stopped",
+}
+
+/**
+ * Collapses the retry controller's two booleans onto {@link SaveHealth}.
+ * `canAttempt` false means retries are given up (stopped); `isUnhealthy`
+ * true means the fallback window is active (unhealthy); otherwise healthy.
+ */
+export const deriveSaveHealth = (
+  controller: Pick<AnnotationRetryController, "canAttempt" | "isUnhealthy">,
+): SaveHealth => {
+  if (!controller.canAttempt) {
+    return SaveHealth.Stopped;
+  }
+
+  if (controller.isUnhealthy) {
+    return SaveHealth.Unhealthy;
+  }
+
+  return SaveHealth.Healthy;
+};
+
+export interface SaveStatus {
+  /** Current autosave health. */
+  health: SaveHealth;
+  /** True while a persistence request is in flight. */
+  inFlight: boolean;
+  /** Epoch ms of the last successful save, or null if none yet this session. */
+  lastSavedAt: number | null;
+}
+
+// Module-level atom so the single publisher (the annotation composition root,
+// which owns the retry controller and persistence event stream) and the
+// indicator's reader resolve to the same default jotai store — mirrors the
+// videoAnnotationStatus pattern.
+const saveStatusAtom = atom<SaveStatus>({
+  health: SaveHealth.Healthy,
+  inFlight: false,
+  lastSavedAt: null,
+});
+
+/**
+ * Write access to the shared save status. Called once from the composition
+ * root; accepts a `SaveStatus` or an updater so health and in-flight can be
+ * set independently.
+ */
+export const usePublishSaveStatus = () => useSetAtom(saveStatusAtom);
+
+/** Reads the current save status. Consumed by the save-status indicator. */
+export const useSaveStatus = (): SaveStatus => useAtomValue(saveStatusAtom);

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Actions.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Actions.tsx
@@ -29,11 +29,29 @@ import {
 } from "@fiftyone/utilities";
 import PolylineIcon from "@mui/icons-material/Timeline";
 import CuboidIcon from "@mui/icons-material/ViewInAr";
-import { Anchor, Text, Tooltip } from "@voxel51/voodo";
+import {
+  Align,
+  Anchor,
+  Clickable,
+  Divider,
+  Icon,
+  IconName,
+  Justify,
+  Orientation,
+  Size,
+  Spacing,
+  Stack,
+  Text,
+  TextColor,
+  TextVariant,
+  Tooltip,
+} from "@voxel51/voodo";
 import { createContext, useCallback, useContext } from "react";
 import { useRecoilValue } from "recoil";
 import styled from "styled-components";
-import { ItemLeft, ItemRight } from "./Components";
+import { ItemRight } from "./Components";
+import { useSchemaManagerModal } from "./SchemaManager/hooks";
+import useCanManageSchema from "./useCanManageSchema";
 import {
   useAnnotationContext,
   useAnnotationFields,
@@ -54,12 +72,6 @@ const ActionsDiv = styled.div`
   padding: 0.25rem 1rem;
   width: 100%;
   max-width: 100%;
-`;
-
-const Row = styled.div`
-  display: flex;
-  justify-content: space-between;
-  width: 100%;
 `;
 
 const Container = styled.div<{ $active?: boolean }>`
@@ -327,6 +339,27 @@ export const Redo = () => {
   );
 };
 
+// Schema manager entry point for the Create section. Gated on manage
+// permission — hidden entirely when the user can't edit the schema.
+const SchemaManager = () => {
+  const canManage = useCanManageSchema();
+  const { openSchemaManager } = useSchemaManagerModal();
+
+  if (!canManage) {
+    return null;
+  }
+
+  return (
+    <Tooltip anchor={Anchor.Top} content={<Text>Manage schema</Text>} portal>
+      <Clickable onClick={openSchemaManager}>
+        <Round data-cy="open-schema-manager">
+          <Icon name={IconName.Settings} size={Size.Md} />
+        </Round>
+      </Clickable>
+    </Tooltip>
+  );
+};
+
 export const ThreeDPolylines = () => {
   const { createNew } = useAnnotationContext();
   const current3dAnnotationMode = useCurrent3dAnnotationMode();
@@ -442,7 +475,9 @@ export const ThreeDCuboids = () => {
   );
 };
 
-const Actions = () => {
+// `hidden` keeps the section mounted (its mode hooks stay live) but visually
+// removed — the label edit view hides Create while depending on those hooks.
+const Actions = ({ hidden = false }: { hidden?: boolean }) => {
   // This checks if media type of the dataset resolved to 3d
   const is3dDataset = useRecoilValue(is3DDataset);
   // Video annotation handles the per-frame spatial label types — boxes,
@@ -481,41 +516,63 @@ const Actions = () => {
 
   return (
     <DeactivateAllContext.Provider value={deactivateAll}>
-      <ActionsDiv style={{ margin: "0 0.25rem", paddingBottom: "0.5rem" }}>
-        <Row>
-          <ItemLeft style={{ columnGap: "0.1rem" }}>
-            <Select active={noActiveActions} />
-            {isVideo ? (
-              <>
-                <Classification />
-                <Detection />
-                <Segmentation />
-                <Polyline />
-              </>
-            ) : (
-              <>
-                <Classification />
-                {toolsResolved &&
-                  (areThreeDActionsVisible ? (
-                    <>
-                      <ThreeDCuboids />
-                      <ThreeDPolylines />
-                    </>
-                  ) : (
-                    <>
-                      <Detection />
-                      <Segmentation />
-                      <Polyline />
-                    </>
-                  ))}
-              </>
-            )}
-          </ItemLeft>
+      <ActionsDiv
+        style={{
+          margin: "0 0.25rem",
+          paddingBottom: "0.5rem",
+          display: hidden ? "none" : undefined,
+        }}
+      >
+        <Stack
+          orientation={Orientation.Row}
+          align={Align.Center}
+          justify={Justify.Between}
+          style={{ width: "100%" }}
+        >
+          <Text variant={TextVariant.Lg} color={TextColor.Primary}>
+            Create
+          </Text>
           <ItemRight style={{ columnGap: "0.1rem" }}>
             <Undo />
             <Redo />
+            <Divider orientation={Orientation.Column} />
+            <SchemaManager />
           </ItemRight>
-        </Row>
+        </Stack>
+        <Stack
+          orientation={Orientation.Row}
+          align={Align.Center}
+          justify={Justify.Center}
+          spacing={Spacing.Xs}
+          style={{ width: "100%" }}
+        >
+          <Select active={noActiveActions} />
+          {isVideo ? (
+            <>
+              <Classification />
+              <Detection />
+              <Segmentation />
+              <Polyline />
+            </>
+          ) : (
+            <>
+              <Classification />
+              {toolsResolved &&
+                (areThreeDActionsVisible ? (
+                  <>
+                    <ThreeDCuboids />
+                    <ThreeDPolylines />
+                  </>
+                ) : (
+                  <>
+                    <Detection />
+                    <Segmentation />
+                    <Polyline />
+                  </>
+                ))}
+            </>
+          )}
+        </Stack>
       </ActionsDiv>
     </DeactivateAllContext.Provider>
   );

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Annotate.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Annotate.tsx
@@ -119,7 +119,7 @@ const AnnotationBody = ({
       {isGroupDataset && !disabledReason && (
         <GroupAnnotation onSliceSelected={loadSchemas} />
       )}
-      {!showSetup && <Actions key="actions" />}
+      {!showSetup && <Actions key="actions" hidden={isEditingValue} />}
       {isEditingValue && <Edit key="edit" />}
       {showSetup ? (
         <ImportSchema

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Header.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/Header.tsx
@@ -1,15 +1,36 @@
 import { useAtomValue } from "jotai";
 import { useCallback, useRef, useState } from "react";
-import { Round } from "../Actions";
+import { Redo, Round, Undo } from "../Actions";
 
 import { DetectionOverlay, useLighter } from "@fiftyone/lighter";
 import { West as Back } from "@mui/icons-material";
-import { Box, Menu, MenuItem, Stack } from "@mui/material";
-import { Clickable, Icon, IconName, Size, Text } from "@voxel51/voodo";
+import { Box, Menu, MenuItem } from "@mui/material";
+import {
+  Align,
+  Clickable,
+  Icon,
+  IconName,
+  Orientation,
+  Size,
+  Spacing,
+  Stack,
+  Text,
+} from "@voxel51/voodo";
 import { DETECTION } from "@fiftyone/utilities";
+import styled from "styled-components";
 import { ItemLeft, ItemRight } from "../Components";
 import { ICONS } from "../Icons";
 import { Row } from "./Components";
+
+// The voodo Divider's line renders too faint against the header; an explicit
+// rule in the theme divider colour keeps the status / action groups legible.
+const VerticalDivider = styled.div`
+  width: 1px;
+  height: 1.25rem;
+  flex-shrink: 0;
+  margin-left: 0.5rem;
+  background: ${({ theme }) => theme.divider};
+`;
 
 import { labels } from "../useLabels";
 import * as fos from "@fiftyone/state";
@@ -24,6 +45,7 @@ import useExit from "./useExit";
 import { useDetectionMode } from "./useDetectionMode";
 import { useSegmentationMode } from "./useSegmentationMode";
 import {
+  AnnotationSaveIndicator,
   useAnnotationController,
   useAnnotationEngine,
 } from "@fiftyone/annotation";
@@ -147,7 +169,11 @@ const LabelHamburgerMenu = () => {
             onClick={deleteCommand.callback}
             data-cy="label-menu-delete"
           >
-            <Stack direction="row" gap={1} alignItems="center">
+            <Stack
+              orientation={Orientation.Row}
+              align={Align.Center}
+              spacing={Spacing.Sm}
+            >
               <Icon name={IconName.Delete} size={Size.Md} />
               <Text>{deleteCommand.descriptor.label}</Text>
             </Stack>
@@ -203,11 +229,19 @@ const Header = () => {
           <Back />
         </Round>
         {Icon && <Icon fill={color} />}
-        <div>Edit {type}</div>
+        <div style={{ marginRight: "0.75rem" }}>Edit {type}</div>
       </ItemLeft>
       {currentFieldIsReadOnly && <span>Read-only</span>}
       <ItemRight>
-        <Stack direction="row" alignItems="center">
+        <Stack
+          orientation={Orientation.Row}
+          align={Align.Center}
+          spacing={Spacing.Xs}
+        >
+          <AnnotationSaveIndicator />
+          <VerticalDivider />
+          <Undo />
+          <Redo />
           {annotationContext.selected?.label != null && <LabelHamburgerMenu />}
         </Stack>
       </ItemRight>

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/LabelList.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/LabelList.tsx
@@ -1,11 +1,5 @@
-import {
-  Button,
-  Size,
-  Text,
-  TextColor,
-  TextVariant,
-  Variant,
-} from "@voxel51/voodo";
+import { Text, TextColor, TextVariant } from "@voxel51/voodo";
+import { AnnotationSaveIndicator } from "@fiftyone/annotation";
 import { EntryKind, isGeneratedView } from "@fiftyone/state";
 import { useRecoilValue } from "recoil";
 import styled from "styled-components";
@@ -17,8 +11,6 @@ import LoadingEntry from "./LoadingEntry";
 import PrimitiveEntry from "./PrimitiveEntry";
 import useEntries from "./useEntries";
 import { usePrimitivesCount } from "./usePrimitivesCount";
-import { useSchemaManagerModal } from "./SchemaManager/hooks";
-import useCanManageSchema from "./useCanManageSchema";
 
 const EmptyLabelsContainer = styled.div`
   display: flex;
@@ -32,8 +24,6 @@ export default function AnnotateSidebar() {
   usePrimitivesCount();
   const isEditingValue = useAnnotationContext().isEditing;
   const isGenerated = useRecoilValue(isGeneratedView);
-  const { openSchemaManager } = useSchemaManagerModal();
-  const canManage = useCanManageSchema();
 
   // Don't show label list in edit mode or in generated views (patches/clips/frames)
   // In generated views, only the edit panel should be visible
@@ -41,6 +31,7 @@ export default function AnnotateSidebar() {
 
   const headerStyle = {
     display: "flex",
+    alignItems: "center",
     justifyContent: "space-between",
     marginInline: "1rem",
     paddingBottom: "0.5rem",
@@ -49,19 +40,10 @@ export default function AnnotateSidebar() {
   return (
     <>
       <div style={headerStyle}>
-        <Text variant={TextVariant.Lg} color={TextColor.Secondary}>
-          Click labels to edit
+        <Text variant={TextVariant.Lg} color={TextColor.Primary}>
+          Edit
         </Text>
-        {canManage && (
-          <Button
-            variant={Variant.Borderless}
-            size={Size.Sm}
-            data-cy="open-schema-manager"
-            onClick={openSchemaManager}
-          >
-            Schema
-          </Button>
-        )}
+        <AnnotationSaveIndicator />
       </div>
       <Sidebar
         isDisabled={() => true}

--- a/e2e-pw/src/oss/poms/modal/annotate-edit.ts
+++ b/e2e-pw/src/oss/poms/modal/annotate-edit.ts
@@ -15,18 +15,22 @@ export class ModalAnnotateEditPom {
     this.locator = page.getByTestId("modal").getByTestId("sidebar");
   }
 
+  // Undo/redo render in both the create toolbar and the edit-form header; only
+  // one is on-screen at a time (the create toolbar is hidden while editing), so
+  // scope to the visible instance to avoid a strict-mode match on both.
+
   /**
    * The undo button locator
    */
   get undoButton() {
-    return this.locator.getByTestId("undo-button");
+    return this.locator.locator('[data-cy="undo-button"]:visible');
   }
 
   /**
    * The redo button locator
    */
   get redoButton() {
-    return this.locator.getByTestId("redo-button");
+    return this.locator.locator('[data-cy="redo-button"]:visible');
   }
 
   /**

--- a/e2e-pw/src/oss/specs/annotate-action-switching.spec.ts
+++ b/e2e-pw/src/oss/specs/annotate-action-switching.spec.ts
@@ -124,6 +124,9 @@ test.describe.serial("action switching", () => {
     await modal.sidebar.annotate.createClassification();
     await modal.sidebar.annotate.assert.classificationIsActive();
 
+    // Creating a classification opens its edit form, which hides the create
+    // toolbar; exit back to the label list to reach the detection tool
+    await modal.sidebar.edit.exitToList();
     await modal.sidebar.annotate.detectionMode("Detections");
 
     await modal.sidebar.annotate.assert.detectionModeIsActive();
@@ -148,7 +151,7 @@ test.describe.serial("action switching", () => {
     await modal.sidebar.annotate.assert.selectIsActive(false);
   });
 
-  test("Select button deactivates Classification", async ({ modal }) => {
+  test("exiting a classification edit returns to Select", async ({ modal }) => {
     await modal.assert.isOpen();
     await modal.waitForSampleLoadDomAttribute();
     await modal.sidebar.switchMode("annotate");
@@ -156,7 +159,9 @@ test.describe.serial("action switching", () => {
     await modal.sidebar.annotate.createClassification();
     await modal.sidebar.annotate.assert.classificationIsActive();
 
-    await modal.sidebar.annotate.selectAction();
+    // The create toolbar (incl. Select) is hidden while editing; exiting the
+    // edit form returns to the default Select action
+    await modal.sidebar.edit.exitToList();
 
     await modal.sidebar.annotate.assert.selectIsActive();
     await modal.sidebar.annotate.assert.classificationIsActive(false);

--- a/e2e-pw/src/oss/specs/annotate-canvas-actions.spec.ts
+++ b/e2e-pw/src/oss/specs/annotate-canvas-actions.spec.ts
@@ -149,9 +149,9 @@ test.describe.serial("canvas interactions and action state", () => {
     await modal.sidebar.annotate.assert.detectionModeIsActive();
 
     // The label list should be hidden (edit form is showing)
-    const labelListHeader = modal.sidebar.locator.getByText(
-      "Click labels to edit",
-    );
+    const labelListHeader = modal.sidebar.locator.getByText("Edit", {
+      exact: true,
+    });
     await expect(labelListHeader).toBeHidden();
   });
 
@@ -174,9 +174,9 @@ test.describe.serial("canvas interactions and action state", () => {
     await modal.sidebar.annotate.assert.detectionModeIsActive();
 
     // The label list should be hidden (edit form is showing)
-    const labelListHeader = modal.sidebar.locator.getByText(
-      "Click labels to edit",
-    );
+    const labelListHeader = modal.sidebar.locator.getByText("Edit", {
+      exact: true,
+    });
     await expect(labelListHeader).toBeHidden();
   });
 
@@ -260,8 +260,9 @@ test.describe.serial("canvas interactions and action state", () => {
     await modal.sidebar.annotate.assert.classificationIsActive();
     await modal.sidebar.annotate.assert.detectionModeIsActive(false);
 
-    // 3. Click Select to return to default
-    await modal.sidebar.annotate.selectAction();
+    // 3. Exit the edit form to return to default (the create toolbar's Select
+    // button is hidden while a label is selected)
+    await modal.sidebar.edit.exitToList();
     await modal.sidebar.annotate.assert.selectIsActive();
 
     // 4. Click a detection overlay on canvas → detection mode active
@@ -300,7 +301,7 @@ test.describe.serial("canvas interactions and action state", () => {
     // Wait for the new detection's edit form to open; quitting before the
     // async establish flow commits would re-activate detection mode
     await expect(
-      modal.sidebar.locator.getByText("Click labels to edit"),
+      modal.sidebar.locator.getByText("Edit", { exact: true }),
     ).toBeHidden();
 
     await modal.sidebar.annotate.assert.detectionModeIsActive();

--- a/e2e-pw/src/oss/specs/annotate-segmentation-ai-sam2.spec.ts
+++ b/e2e-pw/src/oss/specs/annotate-segmentation-ai-sam2.spec.ts
@@ -105,8 +105,9 @@ test.describe.serial("segmentation AI (SAM2) round-trip", () => {
     // the label exists, so wait on the persisted state itself
     await annotateSDK.waitForDetectionCount(datasetName, "instances");
 
-    await modal.sidebar.annotate.segmentationMode();
-    await modal.sidebar.annotate.assert.segmentationModeIsActive(false);
+    // The inferred detection is left selected; the create toolbar is hidden
+    // while editing, so exit via the edit form rather than the toolbar.
+    await modal.sidebar.edit.exitToList();
 
     // ── 4. Reload and verify the Detection survived ─────────────────────────
     await page.reload();

--- a/e2e-pw/src/oss/specs/annotate-segmentation-pen-roundtrip.spec.ts
+++ b/e2e-pw/src/oss/specs/annotate-segmentation-pen-roundtrip.spec.ts
@@ -94,11 +94,12 @@ test.describe.serial("segmentation pen-tool round-trip", () => {
 
     await modal.sampleCanvas.rightClick(0.5, 0.5);
 
-    // ── 3. Wait for autosave to flush, then exit segmentation mode ──────────
+    // ── 3. Wait for autosave to flush, then exit the edit form ──────────────
+    // The pen commit leaves the new detection selected; the create toolbar is
+    // hidden while editing, so exit via the edit form rather than the toolbar.
     await modal.sidebar.annotate.waitForSavesSettled();
 
-    await modal.sidebar.annotate.segmentationMode();
-    await modal.sidebar.annotate.assert.segmentationModeIsActive(false);
+    await modal.sidebar.edit.exitToList();
 
     // ── 4. Reload the page; verify it doesn't drop the persisted Detection ──
     await page.reload();

--- a/e2e-pw/src/oss/specs/annotate-static-actions.spec.ts
+++ b/e2e-pw/src/oss/specs/annotate-static-actions.spec.ts
@@ -1,9 +1,9 @@
 /**
  * Copyright 2017-2026, Voxel51, Inc.
  *
- * Tests that the Actions toolbar remains visible during annotation editing,
- * that the schema manager opens from the label list, and that exiting
- * detection mode closes the edit form.
+ * Tests that the create toolbar is hidden while editing a label (the edit form
+ * carries its own undo/redo), that the mode toggle stays visible, that the
+ * schema manager opens, and that exiting the edit form restores the label list.
  */
 import { expect, test as base } from "src/oss/fixtures";
 import { ModalPom } from "src/oss/poms/modal";
@@ -77,7 +77,7 @@ test.afterEach(async ({ modal, page }) => {
 });
 
 test.describe.serial("static actions toolbar", () => {
-  test("actions toolbar remains visible while editing a label", async ({
+  test("create toolbar is hidden while editing a label", async ({
     modal,
     page,
   }) => {
@@ -85,19 +85,18 @@ test.describe.serial("static actions toolbar", () => {
     await modal.waitForSampleLoadDomAttribute();
     await modal.sidebar.switchMode("annotate");
 
-    // Verify actions toolbar is visible before editing
-    const sidebar = modal.sidebar.locator;
-    const undoButton = sidebar.getByTestId("undo-button");
+    // The create toolbar is visible before editing
     const detectionModeButton = page.getByTestId("detection-mode");
-    await expect(undoButton).toBeVisible();
     await expect(detectionModeButton).toBeVisible();
+    await expect(modal.sidebar.edit.undoButton).toBeVisible();
 
     // Click a label to enter edit mode
     await modal.sidebar.annotate.selectActiveLabel("bird", 0);
 
-    // Actions toolbar should still be visible
-    await expect(undoButton).toBeVisible();
-    await expect(detectionModeButton).toBeVisible();
+    // The create toolbar is hidden while editing; the edit form keeps its own
+    // undo/redo
+    await expect(detectionModeButton).toBeHidden();
+    await expect(modal.sidebar.edit.undoButton).toBeVisible();
   });
 
   test("mode toggle remains visible while editing a label", async ({
@@ -136,16 +135,14 @@ test.describe.serial("static actions toolbar", () => {
     await schemaManager.assert.isClosed();
   });
 
-  test("exiting detection mode via toggle closes the edit form", async ({
-    modal,
-  }) => {
+  test("exiting the edit form restores the label list", async ({ modal }) => {
     await modal.assert.isOpen();
     await modal.waitForSampleLoadDomAttribute();
     await modal.sidebar.switchMode("annotate");
 
-    const labelListHeader = modal.sidebar.locator.getByText(
-      "Click labels to edit",
-    );
+    const labelListHeader = modal.sidebar.locator.getByText("Edit", {
+      exact: true,
+    });
 
     // Label list is visible before editing
     await expect(labelListHeader).toBeVisible();
@@ -160,14 +157,11 @@ test.describe.serial("static actions toolbar", () => {
     await modal.sampleCanvas.up();
     await modal.sampleCanvas.assert.hasCursor("nwse-resize");
 
-    // Edit form is showing — label list is hidden during editing
+    // Edit form is showing — the label list (and create toolbar) are hidden
     await expect(labelListHeader).toBeHidden();
 
-    // Exit detection mode via the toggle button
-    await modal.sidebar.annotate.detectionMode("Detections");
-    await modal.sidebar.annotate.assert.detectionModeIsActive(false);
-
-    // Edit form should be closed — label list should reappear
+    // Exit the edit form via the back button — the label list reappears
+    await modal.sidebar.edit.exitToList();
     await expect(labelListHeader).toBeVisible();
   });
 });


### PR DESCRIPTION
Cherry-pick of #7970 into `release/v1.20.0`.

Original: feat(annotation): updated sidebar ux (merged to `develop` as bc1d1f2c).

Clean cherry-pick (`-m 1`), no conflicts — 20 files, +493/-138, identical to the develop diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a save-status indicator showing sync health, save activity, and the latest sync time.
  * Added pulsing feedback while changes are being saved, with reduced-motion support.
  * Added schema management access for users with the required permissions.
* **Improvements**
  * Updated annotation editing layout and controls for clearer navigation.
  * Create actions are hidden while editing labels; exiting edit mode returns to the label list and Select mode.
* **Bug Fixes**
  * Improved visibility and behavior of undo/redo and annotation actions across editing states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->