### PR TITLE
fix(ci): cherry-pick app build heap fix and e2e spec skips to release/v1.20.0

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -110,10 +110,6 @@ jobs:
       - name: Build app
         if: steps.app-static-cache.outputs.cache-hit != 'true'
         run: make app
-        env:
-          # FOE's app graph exceeds Node's default heap; kept here so the
-          # synced workflow stays consistent across OSS and FOE
-          NODE_OPTIONS: --max-old-space-size=4096
 
       - name: Bundle built app static assets
         run: tar -czf e2e-app-static.tgz fiftyone/server/static

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -110,6 +110,10 @@ jobs:
       - name: Build app
         if: steps.app-static-cache.outputs.cache-hit != 'true'
         run: make app
+        env:
+          # FOE's app graph exceeds Node's default heap; kept here so the
+          # synced workflow stays consistent across OSS and FOE
+          NODE_OPTIONS: --max-old-space-size=4096
 
       - name: Bundle built app static assets
         run: tar -czf e2e-app-static.tgz fiftyone/server/static

--- a/app/packages/app/package.json
+++ b/app/packages/app/package.json
@@ -8,7 +8,7 @@
         "dev": "vite",
         "build": "yarn workspace @fiftyone/fiftyone compile && yarn build-bare && yarn copy-to-python",
         "build:win32": "yarn workspace @fiftyone/fiftyone compile && yarn build-bare && yarn copy-to-python:win32",
-        "build-bare": "NODE_OPTIONS=--max-old-space-size=4096 && vite build",
+        "build-bare": "NODE_OPTIONS=--max-old-space-size=6144 vite build",
         "copy-to-python": "rm -rf ../../../fiftyone/server/static && cp -r ./dist ../../../fiftyone/server/static",
         "copy-to-python:win32": "robocopy './dist' '../../../fiftyone/server/static' /MIR"
     },

--- a/e2e-pw/src/oss/specs/display-options.spec.ts
+++ b/e2e-pw/src/oss/specs/display-options.spec.ts
@@ -38,7 +38,8 @@ test.describe.serial("Display Options", () => {
     await fiftyoneLoader.waitUntilGridVisible(page, datasetName);
   });
 
-  test("switching display options statistics to group should be successful when histogram is open", async ({
+  // flaky: histogram load races the statistics-mode switch (2026-07-20, teams#3392)
+  test.skip("switching display options statistics to group should be successful when histogram is open", async ({
     actionsRow,
     histogram,
     panel,

--- a/e2e-pw/src/oss/specs/saved-views.spec.ts
+++ b/e2e-pw/src/oss/specs/saved-views.spec.ts
@@ -133,7 +133,8 @@ test.describe.serial("saved views", () => {
     await savedViews.assert.verifyUnsavedView();
   });
 
-  test("saving a view with an already existing name fails", async ({
+  // failed: duplicate-name save no longer rejected on FOE (2026-07-20, teams#3392)
+  test.skip("saving a view with an already existing name fails", async ({
     savedViews,
   }) => {
     await savedViews.saveView(testView);


### PR DESCRIPTION
Cherry-picks from #8066 (all with `-x`):

**App-build heap fix** — `build-bare`'s `NODE_OPTIONS=--max-old-space-size=4096 && vite build` assigns a shell variable and drops the flag, so Vite always built at Node's default heap ceiling — causing OOMs in e2e app builds for OSS and FOE. Sets 6144 inline in `build-bare` so every context that builds the app (e2e prep, FOE's build job, docker) gets it. The two heap commits' e2e.yml changes cancel out, netting the one-line `package.json` fix.

**E2E spec skips** — temporarily skips the saved-views duplicate-name spec and the flaky display-options spec.

Slack context: https://voxel51.slack.com/archives/C05L68A72FM/p1784574473998889

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Skipped a flaky display-options test involving histogram loading and statistics-mode switching.
  * Skipped the test for rejecting saved views with duplicate names, reflecting current application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3400
<!-- enterprise-sync-pr:end -->