### PR TITLE
Swap the embeddings panel: unplug the legacy panel, new one takes its name

### DIFF
--- a/app/packages/app/src/pages/datasets/DatasetPage.tsx
+++ b/app/packages/app/src/pages/datasets/DatasetPage.tsx
@@ -11,7 +11,6 @@ import {
   Snackbar,
   Starter,
 } from "@fiftyone/core";
-import "@fiftyone/embeddings";
 import "@fiftyone/embeddings-v2";
 import "@fiftyone/map";
 import { OperatorCore } from "@fiftyone/operators";

--- a/app/packages/embeddings-v2/src/index.ts
+++ b/app/packages/embeddings-v2/src/index.ts
@@ -11,8 +11,8 @@ import TabIndicator from "./TabIndicator";
 const EmbeddingsV2Panel = lazy(() => import("./EmbeddingsV2Panel"));
 
 registerComponent({
-  name: "EmbeddingsV2",
-  label: "Embeddings v2",
+  name: "Embeddings",
+  label: "Embeddings",
   component: EmbeddingsV2Panel,
   type: PluginComponentType.Panel,
   activator: () => true,


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link.

## 📋 What changes are proposed in this pull request?

Makes the rebuilt embeddings panel (#8042) the one and only Embeddings panel in the App menu:

- Removes the legacy panel's side-effect import from `DatasetPage.tsx`, so it no longer registers. The legacy package and its routes stay in the repo untouched (full deletion is a separate follow-up); this just unplugs it.
- The new panel takes over the legacy panel's registered identity: `name` and `label` both become `"Embeddings"` (previously `"EmbeddingsV2"` / `"Embeddings v2"`). Saved workspaces reference panels by registered name, so existing workspaces that contained the legacy panel now open the new panel instead of dangling.

> [!IMPORTANT]
> **Merge order:** do not merge until voxel51/fiftyone-teams#3410 is in Enterprise `develop`. That PR relocates the multimodal operator views out of the legacy package's index; until it lands, the Enterprise side still needs the legacy import to register them.

## 🧪 How is this patch tested? If it is not, please explain why.

embeddings-v2 package suite passes (168 tests), and nothing references the old registered name outside the package (verified by search). The change itself is one import removal and two registration lines.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] Yes. Give a description of this change to be included in the release notes for FiftyOne users.

The Embeddings panel has been rebuilt for large-scale visualizations (500K–1M points). It replaces the previous Plotly-based panel.

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes

### Does this area need RPC Testing?

- [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Embeddings panel registration so it displays the consistent name “Embeddings.”
  * Updated dataset pages to load the latest Embeddings integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3411
<!-- enterprise-sync-pr:end -->