### PR TITLE
Cherry-pick the embeddings panel (#8042) to release/v1.20.0

### DIFF
--- a/app/packages/app/package.json
+++ b/app/packages/app/package.json
@@ -8,7 +8,7 @@
         "dev": "vite",
         "build": "yarn workspace @fiftyone/fiftyone compile && yarn build-bare && yarn copy-to-python",
         "build:win32": "yarn workspace @fiftyone/fiftyone compile && yarn build-bare && yarn copy-to-python:win32",
-        "build-bare": "NODE_OPTIONS=--max-old-space-size=6144 vite build",
+        "build-bare": "NODE_OPTIONS=--max-old-space-size=8192 vite build",
         "copy-to-python": "rm -rf ../../../fiftyone/server/static && cp -r ./dist ../../../fiftyone/server/static",
         "copy-to-python:win32": "robocopy './dist' '../../../fiftyone/server/static' /MIR"
     },

--- a/app/packages/app/src/pages/datasets/DatasetPage.tsx
+++ b/app/packages/app/src/pages/datasets/DatasetPage.tsx
@@ -12,6 +12,7 @@ import {
   Starter,
 } from "@fiftyone/core";
 import "@fiftyone/embeddings";
+import "@fiftyone/embeddings-v2";
 import "@fiftyone/map";
 import { OperatorCore } from "@fiftyone/operators";
 import "@fiftyone/relay";

--- a/app/packages/embeddings-v2/.dependency-cruiser.cjs
+++ b/app/packages/embeddings-v2/.dependency-cruiser.cjs
@@ -1,0 +1,95 @@
+const PKG = "^packages/embeddings-v2/src/";
+const SRC = "^packages/embeddings-v2/src/renderer/";
+
+module.exports = {
+  forbidden: [
+    {
+      // The renderer was a standalone package before it merged into the
+      // panel; these three boundary rules preserve that shape. First:
+      // panel code reaches the renderer only through its barrel — the
+      // barrel is three.js-free at runtime (EmbeddingsView lazy-loads
+      // the chart), so a deep import could silently pull WebGL code
+      // into the panel's initial chunk.
+      name: "panel-uses-the-renderer-barrel",
+      severity: "error",
+      from: { path: PKG, pathNot: SRC },
+      to: { path: SRC, pathNot: `${SRC}index\\.ts$` },
+    },
+    {
+      // Second: the renderer is host-agnostic — no imports upward into
+      // the panel, so it stays extractable (and Teams-reusable) as-is.
+      name: "renderer-stays-below-the-panel",
+      severity: "error",
+      from: { path: SRC },
+      to: { path: PKG, pathNot: SRC },
+    },
+    {
+      // Third: the renderer keeps zero workspace dependencies — three
+      // is its only runtime dep; React appears solely in the wrapper
+      // layer via the host.
+      name: "renderer-keeps-no-workspace-deps",
+      severity: "error",
+      from: { path: SRC },
+      to: {
+        path: "node_modules/@fiftyone(/|$)|^packages/",
+        pathNot: "^packages/embeddings-v2/",
+      },
+    },
+    {
+      // The renderer's central constraint: everything except the React
+      // wrapper layer is vanilla three.js + DOM, so the core stays
+      // usable (and testable) without React.
+      name: "core-stays-react-free",
+      severity: "error",
+      from: {
+        path: SRC,
+        pathNot: `${SRC}(EmbeddingsView|ChartTooltip)\\.tsx$`,
+      },
+      to: { path: "^react$|node_modules/react(/|$)" },
+    },
+    {
+      // math and columns are pure geometry/data — no three.js, no DOM
+      // modules — so they stay directly unit-testable.
+      name: "pure-modules-stay-pure",
+      severity: "error",
+      from: { path: `${SRC}(math|columns)(\\.test)?\\.ts$` },
+      to: {
+        path: `node_modules/three(/|$)|${SRC}(cameras|interaction)/|${SRC}(pipeline|shaders|EmbeddingsChart)\\.ts$`,
+      },
+    },
+    {
+      // Helper layers never import upward into their orchestrators
+      name: "helpers-stay-below-the-chart",
+      severity: "error",
+      from: { path: `${SRC}(cameras|interaction)/` },
+      to: {
+        path: `${SRC}(EmbeddingsChart\\.ts|EmbeddingsView\\.tsx|ChartTooltip\\.tsx|pipeline\\.ts)$`,
+      },
+    },
+    {
+      // The GPU pass plumbing has no business in input handling
+      name: "pipeline-and-shaders-stay-below-interaction",
+      severity: "error",
+      from: { path: `${SRC}(pipeline|shaders)\\.ts$` },
+      to: { path: `${SRC}(cameras|interaction)/` },
+    },
+    {
+      // The renderer uses three's core only. Alternative camera adapters
+      // (which is where addons like controls come from) are injected by
+      // hosts through the CameraAdapterFactory seam, not shipped here.
+      name: "no-three-addons",
+      severity: "error",
+      from: { path: SRC },
+      to: { path: "node_modules/three/examples" },
+    },
+  ],
+  options: {
+    // Keep react/three/workspace edges in the graph (a bare package-path
+    // includeOnly would silently disable the rules above that target
+    // them), but never traverse beyond the first hop into node_modules
+    // or a sibling package's sources.
+    includeOnly: "^(packages/|node_modules/(react|three|@fiftyone)(/|$))",
+    doNotFollow: { path: "node_modules|^packages/(?!embeddings-v2/)" },
+    tsPreCompilationDeps: true,
+  },
+};

--- a/app/packages/embeddings-v2/.eslintrc.js
+++ b/app/packages/embeddings-v2/.eslintrc.js
@@ -1,0 +1,40 @@
+module.exports = {
+  env: {
+    browser: true,
+    es6: true,
+  },
+  extends: [
+    "eslint:recommended",
+    "plugin:react/recommended",
+    "plugin:react-hooks/recommended",
+    "plugin:react/jsx-runtime",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:prettier/recommended",
+  ],
+  globals: {
+    JSX: true,
+  },
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    ecmaVersion: 2021,
+    sourceType: "module",
+  },
+  plugins: ["react", "@typescript-eslint", "prettier", "react-hooks"],
+  rules: {
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      {
+        argsIgnorePattern: "^_",
+        varsIgnorePattern: "^_|React",
+        caughtErrorsIgnorePattern: "^_",
+      },
+    ],
+    "@typescript-eslint/no-explicit-any": "error",
+  },
+  settings: {
+    react: {
+      version: "detect",
+    },
+  },
+};

--- a/app/packages/embeddings-v2/package.json
+++ b/app/packages/embeddings-v2/package.json
@@ -1,0 +1,39 @@
+{
+    "name": "@fiftyone/embeddings-v2",
+    "author": "Voxel51, Inc.",
+    "version": "0.0.0",
+    "private": true,
+    "description": "Embeddings panel v2: high-performance Three.js renderer + panel",
+    "license": "Apache-2.0",
+    "main": "./src/index.ts",
+    "types": "./src/index.ts",
+    "scripts": {
+        "lint": "yarn check",
+        "check": "yarn check:lint && yarn check:deps && yarn check:types",
+        "check:types": "node ./scripts/check-types.mjs",
+        "check:lint": "node ./scripts/check-lint.mjs",
+        "check:deps": "node ./scripts/check-deps.mjs",
+        "test": "vitest"
+    },
+    "dependencies": {
+        "@fiftyone/components": "*",
+        "@fiftyone/operators": "*",
+        "@fiftyone/plugins": "*",
+        "@fiftyone/spaces": "*",
+        "@fiftyone/state": "*",
+        "@fiftyone/utilities": "*",
+        "@mui/icons-material": "*",
+        "@mui/material": "*",
+        "@voxel51/voodo": "^0.0.35",
+        "three": "^0.182.0"
+    },
+    "devDependencies": {
+        "@testing-library/react": "^14.0.0",
+        "@types/three": "^0.182.0",
+        "vitest": "^3.2.6"
+    },
+    "peerDependencies": {
+        "react": "*",
+        "recoil": "*"
+    }
+}

--- a/app/packages/embeddings-v2/scripts/check-deps.mjs
+++ b/app/packages/embeddings-v2/scripts/check-deps.mjs
@@ -1,0 +1,23 @@
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import { bin } from "./process.mjs";
+
+console.log("Checking dependencies integrity for embeddings-v2");
+
+const appRoot = fileURLToPath(new URL("../../..", import.meta.url));
+
+execFileSync(
+  bin("yarn"),
+  [
+    "exec",
+    "depcruise",
+    "--config",
+    "packages/embeddings-v2/.dependency-cruiser.cjs",
+    "packages/embeddings-v2",
+  ],
+  {
+    cwd: appRoot,
+    stdio: "inherit",
+  },
+);

--- a/app/packages/embeddings-v2/scripts/check-lint.mjs
+++ b/app/packages/embeddings-v2/scripts/check-lint.mjs
@@ -1,0 +1,26 @@
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import { bin } from "./process.mjs";
+
+console.log("Running lint for embeddings-v2");
+
+const appRoot = fileURLToPath(new URL("../../..", import.meta.url));
+
+execFileSync(
+  bin("yarn"),
+  [
+    "exec",
+    "eslint",
+    // Top level eslint has too-liberal rules and plugins like "only-warn"
+    // that we want to supersede
+    "--no-eslintrc",
+    "--config",
+    "packages/embeddings-v2/.eslintrc.js",
+    "packages/embeddings-v2/src/**/*.{ts,tsx}",
+  ],
+  {
+    cwd: appRoot,
+    stdio: "inherit",
+  },
+);

--- a/app/packages/embeddings-v2/scripts/check-types.mjs
+++ b/app/packages/embeddings-v2/scripts/check-types.mjs
@@ -1,0 +1,59 @@
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import { bin } from "./process.mjs";
+
+console.log("Checking types for embeddings-v2");
+
+const localDiagnosticPattern =
+  /^(packages[\\/]embeddings-v2|node_modules[\\/]@fiftyone[\\/]embeddings-v2)[\\/]/;
+const appRoot = fileURLToPath(new URL("../../..", import.meta.url));
+
+let output = "";
+
+try {
+  execFileSync(
+    bin("yarn"),
+    [
+      "exec",
+      "tsc",
+      "--noEmit",
+      "-p",
+      "packages/embeddings-v2/tsconfig.json",
+      "--pretty",
+      "false",
+    ],
+    {
+      cwd: appRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+} catch (error) {
+  const stdout = typeof error.stdout === "string" ? error.stdout : "";
+  const stderr = typeof error.stderr === "string" ? error.stderr : "";
+  output = [stdout, stderr].filter(Boolean).join("\n");
+  if (!output) {
+    throw error;
+  }
+}
+
+const lines = output.split("\n");
+const localDiagnostics = lines
+  // Workspace source dependencies still surface in this package check, so only
+  // fail diagnostics owned by the embeddings-v2 package boundary.
+  .filter((line) => localDiagnosticPattern.test(line));
+// Config-level failures (broken tsconfig, bad flags) carry no file prefix
+// and must not read as success
+const globalDiagnostics = lines.filter((line) => /^error TS\d+:/.test(line));
+
+if (localDiagnostics.length || globalDiagnostics.length) {
+  console.error([...globalDiagnostics, ...localDiagnostics].join("\n"));
+  process.exit(1);
+}
+
+if (output) {
+  console.log(
+    "No type issues in packages/embeddings-v2 🚀. TypeScript reported diagnostics outside packages/embeddings-v2; ignoring them for this package-local check.",
+  );
+}

--- a/app/packages/embeddings-v2/scripts/process.mjs
+++ b/app/packages/embeddings-v2/scripts/process.mjs
@@ -1,0 +1,5 @@
+/**
+ * Resolves the platform-specific executable name for a package binary.
+ */
+export const bin = (name) =>
+  process.platform === "win32" ? `${name}.cmd` : name;

--- a/app/packages/embeddings-v2/src/Callout.tsx
+++ b/app/packages/embeddings-v2/src/Callout.tsx
@@ -1,0 +1,71 @@
+/**
+ * Generic inline callout: icon + title + description, an optional
+ * actions row, and an optional leading aside (media, animation).
+ * Colors resolve through design-system token enums via CSS custom
+ * properties (see panel.css). Kept intentionally generic so it can
+ * graduate to @voxel51/voodo.
+ */
+import {
+  BackgroundColor,
+  BorderColor,
+  BrandColor,
+  getColorCssVar,
+  Icon,
+  IconName,
+  Size,
+  Text,
+  TextColor,
+  TextVariant,
+} from "@voxel51/voodo";
+import type { CSSProperties, ReactNode } from "react";
+import "./panel.css";
+
+export interface CalloutProps {
+  icon?: IconName;
+  title: string;
+  description?: string;
+  /** Action buttons row, rendered under the copy */
+  actions?: ReactNode;
+  /** Decorative leading region (media, animation) */
+  aside?: ReactNode;
+}
+
+const TOKEN_VARS = {
+  "--emb-brand": `var(${getColorCssVar(BrandColor.Primary)})`,
+  "--emb-card-bg": `var(${getColorCssVar(BackgroundColor.Card1)})`,
+  "--emb-border-subtle": `var(${getColorCssVar(BorderColor.Subtle)})`,
+} as CSSProperties;
+
+export function Callout({
+  icon,
+  title,
+  description,
+  actions,
+  aside,
+}: CalloutProps) {
+  return (
+    <div
+      className="emb-callout"
+      data-aside={aside ? "true" : "false"}
+      style={TOKEN_VARS}
+    >
+      {aside}
+      <div className="emb-callout-copy">
+        <div className="emb-callout-heading">
+          {icon && (
+            <Icon name={icon} size={Size.Sm} color={BrandColor.Primary} />
+          )}
+          <Text variant={TextVariant.Md} color={TextColor.Fg}>
+            {title}
+          </Text>
+        </div>
+        {description && (
+          <Text variant={TextVariant.Md} color={TextColor.Secondary}>
+            {description}
+          </Text>
+        )}
+        {actions && <div className="emb-callout-actions">{actions}</div>}
+      </div>
+    </div>
+  );
+}

--- a/app/packages/embeddings-v2/src/ColorLegend.tsx
+++ b/app/packages/embeddings-v2/src/ColorLegend.tsx
@@ -1,0 +1,85 @@
+/**
+ * Floating legend for categorical color-by fields: one row per class
+ * (swatch, label, count). The legend is a view over the sidebar filter
+ * for the field — rows the filter hides render greyed — and clicks ask
+ * the host for the next filter: single click toggles a class, double
+ * click isolates it. Hosts that cannot filter the field (non-string
+ * classes) pass `offLabels: null` and the rows render inert.
+ * Continuous fields render no legend.
+ */
+import { Text, TextBadge, TextColor, TextVariant } from "@voxel51/voodo";
+import { categoryHex } from "./colors";
+import { FloatingPanel } from "./FloatingPanel";
+import "./panel.css";
+import type { ColorMeta } from "./protocol";
+
+export function ColorLegend({
+  field,
+  meta,
+  offLabels,
+  onToggle,
+  onSolo,
+}: {
+  field: string;
+  meta: ColorMeta;
+  /** Classes the field's filter hides; null = filtering unavailable */
+  offLabels: ReadonlySet<string> | null;
+  onToggle: (label: string) => void;
+  onSolo: (label: string) => void;
+}) {
+  const classes = meta.style === "categorical" ? (meta.classes ?? []) : [];
+  if (!classes.length) return null;
+
+  const interactive = offLabels !== null;
+
+  return (
+    <FloatingPanel
+      aria-label="Color legend"
+      title={<TextBadge color={TextColor.Secondary}>{field}</TextBadge>}
+      footer={
+        interactive ? (
+          <Text variant={TextVariant.Sm} color={TextColor.Muted}>
+            Click to hide · Double-click to isolate
+          </Text>
+        ) : undefined
+      }
+    >
+      <div className="emb-legend">
+        <div className="emb-legend-rows">
+          {classes.map((cls, index) => {
+            const label = String(cls.label);
+            return (
+              <button
+                type="button"
+                key={label}
+                className="emb-legend-row"
+                disabled={!interactive}
+                data-off={offLabels?.has(label) ? "true" : "false"}
+                onClick={() => onToggle(label)}
+                onDoubleClick={() => onSolo(label)}
+              >
+                <span
+                  className="emb-legend-swatch"
+                  style={{ background: categoryHex(index) }}
+                />
+                <span className="emb-legend-label">
+                  <Text variant={TextVariant.Md} color={TextColor.Secondary}>
+                    {label}
+                  </Text>
+                </span>
+                <Text variant={TextVariant.Md} color={TextColor.Tertiary}>
+                  {cls.count.toLocaleString()}
+                </Text>
+              </button>
+            );
+          })}
+        </div>
+        {meta.truncated && (
+          <Text variant={TextVariant.Sm} color={TextColor.Muted}>
+            Top {classes.length} classes
+          </Text>
+        )}
+      </div>
+    </FloatingPanel>
+  );
+}

--- a/app/packages/embeddings-v2/src/ContinuousLegend.test.tsx
+++ b/app/packages/embeddings-v2/src/ContinuousLegend.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { ContinuousLegend, formatRampValue } from "./ContinuousLegend";
+import { buildColors, rampCss } from "./colors";
+
+afterEach(cleanup);
+
+describe("formatRampValue", () => {
+  it("shows floats to three significant digits and integers verbatim", () => {
+    expect(formatRampValue(0.512345)).toBe("0.512");
+    expect(formatRampValue(0.0312)).toBe("0.0312");
+    // High-cardinality int fields render continuous; their bounds must
+    // not be rounded like floats
+    expect(formatRampValue(12345)).toBe((12345).toLocaleString());
+  });
+});
+
+describe("ContinuousLegend", () => {
+  // The legend's gradient and the plot's point colors must share one
+  // ramp; buildColors is what actually colors the points
+  it("draws the same ramp buildColors paints with", () => {
+    const column = {
+      style: "continuous" as const,
+      values: new Float32Array([0, 1]),
+    };
+    const rgb = buildColors(column, { min: 0, max: 1 });
+    const css = (offset: number) =>
+      `rgb(${Math.round(rgb[offset] * 255)}, ${Math.round(
+        rgb[offset + 1] * 255,
+      )}, ${Math.round(rgb[offset + 2] * 255)})`;
+
+    expect(rampCss(0)).toBe(css(0));
+    expect(rampCss(1)).toBe(css(3));
+  });
+
+  it("renders nothing without bounds (all values missing)", () => {
+    const { container } = render(
+      <ContinuousLegend
+        field="uniqueness"
+        meta={{ style: "continuous", min: null, max: null }}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/app/packages/embeddings-v2/src/ContinuousLegend.tsx
+++ b/app/packages/embeddings-v2/src/ContinuousLegend.tsx
@@ -1,0 +1,60 @@
+/**
+ * Floating legend for continuous color-by fields: the color ramp as a
+ * spectrum bar with the field's min/max at the ends. Purely a readout —
+ * which fields are continuous is the server's style decision
+ * (float fields, and high-cardinality int fields), and the plot
+ * already colors them; this shows what the colors mean.
+ */
+import { Text, TextBadge, TextColor, TextVariant } from "@voxel51/voodo";
+import { rampCss } from "./colors";
+import { FloatingPanel } from "./FloatingPanel";
+import "./panel.css";
+import type { ColorMeta } from "./protocol";
+
+const FLOAT_FORMAT = new Intl.NumberFormat(undefined, {
+  maximumSignificantDigits: 3,
+});
+
+/** Compact display for a ramp endpoint: integers verbatim, floats to
+ * three significant digits (uniqueness-style scores read as "0.512") */
+export function formatRampValue(value: number): string {
+  if (Number.isInteger(value)) return value.toLocaleString();
+  return FLOAT_FORMAT.format(value);
+}
+
+export function ContinuousLegend({
+  field,
+  meta,
+}: {
+  field: string;
+  meta: ColorMeta;
+}) {
+  const { min, max } = meta;
+  if (meta.style !== "continuous" || min == null || max == null) return null;
+
+  return (
+    <FloatingPanel
+      aria-label="Color legend"
+      title={<TextBadge color={TextColor.Secondary}>{field}</TextBadge>}
+    >
+      <div className="emb-legend-ramp">
+        <div
+          className="emb-legend-ramp-track"
+          style={{
+            background: `linear-gradient(90deg, ${rampCss(0)}, ${rampCss(
+              0.5,
+            )}, ${rampCss(1)})`,
+          }}
+        />
+        <div className="emb-legend-ramp-labels">
+          <Text variant={TextVariant.Sm} color={TextColor.Tertiary}>
+            {formatRampValue(min)}
+          </Text>
+          <Text variant={TextVariant.Sm} color={TextColor.Tertiary}>
+            {formatRampValue(max)}
+          </Text>
+        </div>
+      </div>
+    </FloatingPanel>
+  );
+}

--- a/app/packages/embeddings-v2/src/EmbeddingsV2Panel.tsx
+++ b/app/packages/embeddings-v2/src/EmbeddingsV2Panel.tsx
@@ -1,0 +1,71 @@
+/**
+ * Panel controller: the runs list is the landing view; opening a run
+ * shows the plot. `openKey` lives in panel state (local) so the
+ * selection survives the remounts that view changes cause, per panel
+ * instance. Run deletion executes the builtin delete_brain_run
+ * operator, which enforces permissions where the deployment defines
+ * them; the panel renders its own confirmation, so the operator's
+ * prompt is bypassed.
+ */
+import { useOperatorExecutor } from "@fiftyone/operators";
+import { usePanelStatePartial } from "@fiftyone/spaces";
+import * as fos from "@fiftyone/state";
+import { useState } from "react";
+import { useRecoilValue } from "recoil";
+import PlotView from "./PlotView";
+import RunsList from "./RunsList";
+import { useVisualizationRuns } from "./useVisualizationRuns";
+
+const DELETE_RUN_OPERATOR = "@voxel51/operators/delete_brain_run";
+
+export default function EmbeddingsV2Panel() {
+  const datasetName = useRecoilValue(fos.datasetName) ?? null;
+  const [openKeyState, setOpenKey] = usePanelStatePartial<string | null>(
+    "openKey",
+    null,
+    true,
+  );
+  const openKey = openKeyState ?? null;
+
+  const { runs, error, refresh } = useVisualizationRuns(datasetName);
+  const deleteExecutor = useOperatorExecutor(DELETE_RUN_OPERATOR);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const handleDelete = (brainKey: string) => {
+    setActionError(null);
+    deleteExecutor.execute(
+      { brain_key: brainKey },
+      {
+        callback: (result: { error?: unknown } | null) => {
+          if (result?.error) {
+            setActionError(String(result.error));
+          }
+          refresh();
+        },
+      },
+    );
+  };
+
+  // A stale key (deleted run, switched dataset, results not yet
+  // saved) falls back to the list — a pending run has nothing to plot
+  const openRun = runs?.find((r) => r.brainKey === openKey && r.ready) ?? null;
+
+  if (openRun) {
+    return (
+      <PlotView
+        datasetName={datasetName}
+        run={openRun}
+        onBack={() => setOpenKey(null)}
+      />
+    );
+  }
+  return (
+    <RunsList
+      runs={runs}
+      error={error}
+      actionError={actionError}
+      onOpen={setOpenKey}
+      onDelete={handleDelete}
+    />
+  );
+}

--- a/app/packages/embeddings-v2/src/FloatingPanel.test.tsx
+++ b/app/packages/embeddings-v2/src/FloatingPanel.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { FloatingPanel } from "./FloatingPanel";
+
+// RTL only auto-cleans up with vitest globals enabled; ours are off
+afterEach(cleanup);
+
+describe("FloatingPanel", () => {
+  it("collapses to the header and back via the chevron", () => {
+    render(
+      <FloatingPanel title="legend" footer="hint">
+        content
+      </FloatingPanel>,
+    );
+
+    fireEvent.click(screen.getByLabelText("Collapse"));
+    expect(screen.queryByText("content")).toBeNull();
+    expect(screen.queryByText("hint")).toBeNull();
+
+    fireEvent.click(screen.getByLabelText("Expand"));
+    expect(screen.getByText("content")).toBeDefined();
+    expect(screen.getByText("hint")).toBeDefined();
+  });
+
+  it("swaps the CSS anchor for pixel coordinates once dragged", () => {
+    const { container } = render(
+      <FloatingPanel title="legend">content</FloatingPanel>,
+    );
+    const panel = container.firstElementChild as HTMLElement;
+    expect(panel.style.left).toContain("calc");
+
+    // jsdom has no layout, so useDraggable clamps to its 0-width parent
+    // — the point here is the wiring: grip drag converts the anchor to
+    // pixel coordinates, and drag-end stops tracking
+    fireEvent.mouseDown(screen.getByLabelText("Drag to reposition"), {
+      clientX: 100,
+      clientY: 100,
+    });
+    fireEvent.mouseMove(document, { clientX: 120, clientY: 130 });
+    fireEvent.mouseUp(document);
+
+    expect(panel.style.left).toBe("0px");
+    expect(panel.style.top).toBe("0px");
+
+    fireEvent.mouseMove(document, { clientX: 500, clientY: 500 });
+    expect(panel.style.left).toBe("0px");
+  });
+
+  it("keeps pointer gestures off the surface underneath", () => {
+    const onPointerDown = vi.fn();
+    render(
+      <div onPointerDown={onPointerDown}>
+        <FloatingPanel title="legend">content</FloatingPanel>
+      </div>,
+    );
+
+    fireEvent.pointerDown(screen.getByText("content"));
+    expect(onPointerDown).not.toHaveBeenCalled();
+  });
+});

--- a/app/packages/embeddings-v2/src/FloatingPanel.tsx
+++ b/app/packages/embeddings-v2/src/FloatingPanel.tsx
@@ -1,0 +1,99 @@
+/**
+ * Generic floating, draggable, collapsible panel: a header row with a
+ * drag grip, title, and collapse chevron; a body; and an optional
+ * footer under a hairline. Anchored top-right until first dragged,
+ * then positioned in pixels, clamped inside the nearest positioned
+ * ancestor (via useDraggable, vendored from @voxel51/voodo). Kept
+ * intentionally generic so it can graduate to the design system.
+ */
+import {
+  BackgroundColor,
+  BorderColor,
+  Button,
+  DragHandleIcon,
+  getColorCssVar,
+  IconColor,
+  IconName,
+  Size,
+  Variant,
+} from "@voxel51/voodo";
+import {
+  useState,
+  type CSSProperties,
+  type ReactNode,
+  type RefObject,
+} from "react";
+import "./panel.css";
+import { useDraggable } from "./useDraggable";
+
+const TOKEN_VARS = {
+  "--emb-card-bg": `var(${getColorCssVar(BackgroundColor.Card2)})`,
+  "--emb-card-elevated": `var(${getColorCssVar(BackgroundColor.CardElevated)})`,
+  "--emb-border-subtle": `var(${getColorCssVar(BorderColor.Subtle)})`,
+  "--emb-icon-muted": `var(${getColorCssVar(IconColor.Muted)})`,
+} as CSSProperties;
+
+/** Panel width 13rem + the 0.75rem inset the overlays use */
+const ANCHOR_X = "calc(100% - 13.75rem)";
+const ANCHOR_Y = 12;
+
+export interface FloatingPanelProps {
+  /** Header label, rendered beside the drag grip */
+  title: ReactNode;
+  /** Muted helper row under a hairline */
+  footer?: ReactNode;
+  children: ReactNode;
+  "aria-label"?: string;
+}
+
+export function FloatingPanel({
+  title,
+  footer,
+  children,
+  "aria-label": ariaLabel,
+}: FloatingPanelProps) {
+  const { position, isDragging, containerRef, handleDragStart } = useDraggable({
+    initialX: ANCHOR_X,
+    initialY: ANCHOR_Y,
+  });
+  const [collapsed, setCollapsed] = useState(false);
+
+  return (
+    <div
+      ref={containerRef as RefObject<HTMLDivElement>}
+      role="group"
+      aria-label={ariaLabel}
+      data-dragging={isDragging || undefined}
+      className="emb-floating-panel"
+      style={{ ...TOKEN_VARS, left: position.x, top: position.y }}
+      // The panel floats over the chart: gestures must not reach it
+      onPointerDown={(event) => event.stopPropagation()}
+      onClick={(event) => event.stopPropagation()}
+    >
+      <div className="emb-floating-panel-header">
+        <div
+          role="button"
+          aria-label="Drag to reposition"
+          className="emb-floating-panel-grip"
+          onMouseDown={handleDragStart}
+        >
+          <DragHandleIcon />
+        </div>
+        <span className="emb-floating-panel-title">{title}</span>
+        <Button
+          variant={Variant.Icon}
+          size={Size.Xs}
+          leadingIcon={collapsed ? IconName.ChevronTop : IconName.ChevronBottom}
+          aria-label={collapsed ? "Expand" : "Collapse"}
+          onClick={() => setCollapsed((current) => !current)}
+        />
+      </div>
+      {!collapsed && (
+        <>
+          <div className="emb-floating-panel-body">{children}</div>
+          {footer && <div className="emb-floating-panel-footer">{footer}</div>}
+        </>
+      )}
+    </div>
+  );
+}

--- a/app/packages/embeddings-v2/src/HoverCard.tsx
+++ b/app/packages/embeddings-v2/src/HoverCard.tsx
@@ -1,0 +1,111 @@
+/**
+ * Hover card for the plot: thumbnail, the point's color-by value (with
+ * a swatch matching the point's rendered color), and the sample's
+ * filename. Sample ids are intentionally not shown — they carry no
+ * meaning for readers, and clicking the point selects the sample in
+ * the grid. Renders nothing until the image has loaded (or the sample
+ * has no hover media) — an empty box must never appear.
+ */
+import {
+  BackgroundColor,
+  BorderColor,
+  getColorCssVar,
+  Text,
+  TextColor,
+  TextVariant,
+} from "@voxel51/voodo";
+import { useEffect, useState, type CSSProperties } from "react";
+import "./panel.css";
+import type { HoverHit } from "./renderer";
+
+const TOKEN_VARS = {
+  "--emb-popover": `var(${getColorCssVar(BackgroundColor.Popover)})`,
+  "--emb-border-subtle": `var(${getColorCssVar(BorderColor.Subtle)})`,
+} as CSSProperties;
+
+export interface HoverContent {
+  hit: HoverHit;
+  /** Resolved image URL, or null when hover media is unavailable */
+  src: string | null;
+  /** The point's color-by value, when a color field is active */
+  value: { label: string; swatch: string | null } | null;
+  /** The sample's media filename (basename), when known */
+  filename: string | null;
+}
+
+export default function HoverCard({
+  content,
+  containerWidth,
+  containerHeight,
+}: {
+  content: HoverContent;
+  containerWidth: number;
+  containerHeight: number;
+}) {
+  const { hit, src, value, filename } = content;
+  const [settled, setSettled] = useState<{ src: string; ok: boolean } | null>(
+    null,
+  );
+
+  // Preload off-DOM; the card appears only once the image is ready — or
+  // has failed, in which case the metadata still shows (an unloadable
+  // thumbnail must not suppress the value/filename lines)
+  useEffect(() => {
+    if (!src) return undefined;
+    let stale = false;
+    const image = new Image();
+    image.onload = () => !stale && setSettled({ src, ok: true });
+    image.onerror = () => !stale && setSettled({ src, ok: false });
+    image.src = src;
+    return () => {
+      stale = true;
+    };
+  }, [src]);
+
+  if (src && settled?.src !== src) return null;
+  const showImage = src !== null && settled?.ok === true;
+
+  // Flip the card's quadrant so it stays inside the plot container
+  const flipX = hit.x > containerWidth / 2;
+  const flipY = hit.y > containerHeight / 2;
+
+  return (
+    <div
+      className="emb-hover-card"
+      style={{
+        ...TOKEN_VARS,
+        left: hit.x,
+        top: hit.y,
+        transform: `translate(${flipX ? "calc(-100% - 14px)" : "14px"}, ${
+          flipY ? "calc(-100% - 14px)" : "14px"
+        })`,
+      }}
+    >
+      {showImage && (
+        <img key={src} src={src} alt="" className="emb-hover-image" />
+      )}
+      {value && (
+        <div className="emb-hover-value">
+          {value.swatch && (
+            <span
+              className="emb-legend-swatch"
+              style={{ background: value.swatch }}
+            />
+          )}
+          <span className="emb-hover-text">
+            <Text variant={TextVariant.Md} color={TextColor.Fg}>
+              {value.label}
+            </Text>
+          </span>
+        </div>
+      )}
+      {filename && (
+        <span className="emb-hover-text">
+          <Text variant={TextVariant.Sm} color={TextColor.Muted}>
+            {filename}
+          </Text>
+        </span>
+      )}
+    </div>
+  );
+}

--- a/app/packages/embeddings-v2/src/PlotView.tsx
+++ b/app/packages/embeddings-v2/src/PlotView.tsx
@@ -1,0 +1,511 @@
+/**
+ * The plot view for one visualization run: fetches the run's columns
+ * over the v2 protocol and renders them with the in-package renderer.
+ * Header: back, title, color-by, the explore/select mode toggle, and
+ * camera reset. Overlays: a mode hint or selection-count chip
+ * (top-left), the color legend (top-right), and a load-progress
+ * counter (bottom-left).
+ *
+ * The component is hook composition: each concern lives in its own
+ * use* module beside this file, provider-free so it renderHook-tests
+ * without Recoil. Only this component touches App state — atom values
+ * in, setters out. Two layers of point treatment: view stages and
+ * sidebar filters HIDE points (scope); grid selections EMPHASIZE them
+ * (focus). The legend is a view over the sidebar filter for the
+ * color-by field — see legendFilter.ts for the click semantics.
+ */
+import { usePanelStatePartial } from "@fiftyone/spaces";
+import * as fos from "@fiftyone/state";
+import {
+  BackgroundColor,
+  BorderColor,
+  Button,
+  getColorCssVar,
+  Icon,
+  IconColor,
+  IconName,
+  Select,
+  Size,
+  Text,
+  TextColor,
+  TextVariant,
+  Tooltip,
+  Variant,
+} from "@voxel51/voodo";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+} from "react";
+import {
+  useRecoilCallback,
+  useRecoilState,
+  useRecoilValue,
+  useSetRecoilState,
+} from "recoil";
+import { ColorLegend } from "./ColorLegend";
+import { ContinuousLegend } from "./ContinuousLegend";
+import { categoryHex, MISSING_CATEGORY } from "./colors";
+import HoverCard from "./HoverCard";
+import {
+  legendLabels,
+  soloLabel,
+  toggleLabel,
+  type CategoricalFilter,
+} from "./legendFilter";
+import "./panel.css";
+import type { VisualizationRun } from "./protocol";
+import {
+  EmbeddingsView,
+  type CameraAdapterFactory,
+  type EmbeddingsViewHandle,
+  type InteractionMode,
+} from "./renderer";
+import { clearSelectionNonceState, selectionCountState } from "./state";
+import { useColorColumn } from "./useColorColumn";
+import { useHoverInfo } from "./useHoverInfo";
+import { useLocalColorMask } from "./useLocalColorMask";
+import { useMasks } from "./useMasks";
+import { useRunColumns } from "./useRunColumns";
+import { useSelectionBridge } from "./useSelectionBridge";
+
+const TOKEN_VARS = {
+  "--emb-bg": `var(${getColorCssVar(BackgroundColor.Background)})`,
+  "--emb-card-bg": `var(${getColorCssVar(BackgroundColor.Card2)})`,
+  "--emb-card-elevated": `var(${getColorCssVar(BackgroundColor.CardElevated)})`,
+  "--emb-border-subtle": `var(${getColorCssVar(BorderColor.Subtle)})`,
+  "--emb-border-strong": `var(${getColorCssVar(BorderColor.Strong)})`,
+  "--emb-fg": `var(${getColorCssVar(TextColor.Fg)})`,
+} as CSSProperties;
+
+/** Select option id for the uncolored state (fields are never empty) */
+const NONE_FIELD = "";
+
+function ModeSegment({
+  active,
+  icon,
+  label,
+  onClick,
+}: {
+  active: boolean;
+  icon: IconName;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className="emb-mode-segment"
+      data-active={active ? "true" : "false"}
+      onClick={onClick}
+    >
+      <Icon
+        name={icon}
+        size={Size.Md}
+        color={active ? TextColor.Fg : TextColor.Secondary}
+      />
+      <Text
+        variant={TextVariant.Md}
+        color={active ? TextColor.Fg : TextColor.Secondary}
+      >
+        {label}
+      </Text>
+    </button>
+  );
+}
+
+export default function PlotView({
+  datasetName,
+  run,
+  onBack,
+  zCamera,
+}: {
+  datasetName: string | null;
+  run: VisualizationRun;
+  onBack: () => void;
+  /** Loads a camera for runs whose points carry a third coordinate */
+  zCamera?: () => Promise<CameraAdapterFactory>;
+}) {
+  const view = useRecoilValue(fos.view) as unknown[];
+  const filters = useRecoilValue(fos.filters);
+  const setOverrideStage = useSetRecoilState(
+    fos.extendedSelectionOverrideStage,
+  );
+  const resetExtended = fos.useResetExtendedSelection();
+  const [selectedSamples, setSelectedSamples] = useRecoilState(
+    fos.selectedSamples,
+  );
+
+  // Panel state (local: plot-only state must not reload the page query)
+  // survives the remounts that view changes cause. Values normalize to
+  // null: partials are undefined until first set
+  const [colorFieldState, setColorField] = usePanelStatePartial<string | null>(
+    "colorField",
+    null,
+    true,
+  );
+  const colorField = colorFieldState ?? null;
+  const brainKey = run.brainKey;
+
+  const plotRef = useRef<HTMLDivElement>(null);
+  const viewRef = useRef<EmbeddingsViewHandle>(null);
+
+  const { loaded, error: loadError } = useRunColumns(datasetName, brainKey);
+  const {
+    choices,
+    colors,
+    values: colorValues,
+    meta: colorMeta,
+    loading: colorLoading,
+    error: colorError,
+  } = useColorColumn(datasetName, brainKey, run, colorField);
+  // The color-by field's filter evaluates client-side when provably
+  // faithful (legend clicks never wait on the masks round trip); the
+  // rest ships to the masks endpoint, identity-stable
+  const { localMask, serverFilters } = useLocalColorMask(
+    filters,
+    colorField,
+    colorValues,
+    colorMeta,
+  );
+
+  const {
+    visibleMask,
+    visibleCount,
+    error: masksError,
+  } = useMasks(
+    datasetName,
+    brainKey,
+    view,
+    serverFilters,
+    loaded?.points.length ?? 0,
+    localMask,
+  );
+  // The hover card's swatch mirrors the point's rendered color, which
+  // buildColors derives from the same class column
+  const pointSwatch = (index: number): string | null => {
+    if (colorValues?.style !== "categorical") return null;
+    const classIndex = colorValues.indices[index];
+    return classIndex === MISSING_CATEGORY ? null : categoryHex(classIndex);
+  };
+
+  const { hover, handleHover } = useHoverInfo(
+    datasetName,
+    brainKey,
+    colorField,
+    fos.getSampleSrc,
+    pointSwatch,
+  );
+  const {
+    selectedIndices,
+    selectionCount,
+    handleSelection,
+    handlePointClick,
+    clearAll,
+    error: selectionError,
+  } = useSelectionBridge({
+    datasetName,
+    brainKey,
+    view,
+    loaded,
+    patchesField: run.patchesField,
+    chart: viewRef,
+    setOverrideStage,
+    resetExtended,
+    selectedSamples,
+    setSelectedSamples,
+  });
+
+  const [mode, setMode] = useState<InteractionMode>("explore");
+  const [rendererError, setRendererError] = useState<string | null>(null);
+
+  // The legend has no state of its own: which classes are on derives
+  // from the App's sidebar filter for the color-by field, and clicks
+  // write the next filter back. The masks path consumes the same
+  // fos.filters, so the plot and grid scope together. String classes
+  // only: the sidebar's numeric filters are range-shaped, not value
+  // lists, so numeric-class legends render inert
+  const fieldFilter = useRecoilValue(
+    fos.filter({ path: colorField ?? "", modal: false }),
+  );
+  const legendFilter = (fieldFilter ?? null) as CategoricalFilter | null;
+
+  const legend = useMemo(
+    () => legendLabels(colorMeta, legendFilter),
+    [colorMeta, legendFilter],
+  );
+
+  // Writes read the filter from a fresh snapshot, not the render-time
+  // value — rapid clicks must each transform the latest state, or a
+  // click can silently compute from a stale base and drop its
+  // predecessor. A dblclick arrives as click-click-dblclick; the two
+  // toggles cancel (toggle is its own inverse), then the solo lands —
+  // no click timers
+  const handleLegendClick = useRecoilCallback(
+    ({ snapshot, set, reset }) =>
+      (label: string, solo: boolean) => {
+        if (!colorField || !legend) return;
+        const filterState = fos.filter({ path: colorField, modal: false });
+        const current = (snapshot.getLoadable(filterState).valueMaybe() ??
+          null) as CategoricalFilter | null;
+        const transform = solo ? soloLabel : toggleLabel;
+        const next = transform(current, legend.labels, label);
+        if (next) {
+          set(filterState, next);
+        } else {
+          reset(filterState);
+        }
+      },
+    [colorField, legend],
+  );
+  const handleLegendToggle = (label: string) => handleLegendClick(label, false);
+  const handleLegendSolo = (label: string) => handleLegendClick(label, true);
+
+  const resetLegendFilter = useRecoilCallback(
+    ({ reset }) =>
+      () => {
+        if (colorField) {
+          reset(fos.filter({ path: colorField, modal: false }));
+        }
+      },
+    [colorField],
+  );
+
+  const error =
+    loadError ?? rendererError ?? colorError ?? masksError ?? selectionError;
+
+  const colorOptions = useMemo(
+    () => [
+      { id: NONE_FIELD, data: { label: "None" } },
+      ...choices
+        // A run's own spatial-index field colors by x-coordinate;
+        // not a useful choice
+        .filter((field) => field !== run.pointsField)
+        .map((field) => ({ id: field, data: { label: field } })),
+    ],
+    [choices, run.pointsField],
+  );
+
+  // A completed lasso returns gestures to the camera, so the
+  // selection can be explored immediately without switching modes
+  const handleLasso = (
+    indices: number[],
+    polygon?: Array<[number, number]> | null,
+  ) => {
+    handleSelection(indices, polygon);
+    if (indices.length) setMode("explore");
+  };
+
+  const chipCount = selectionCount ?? (selectedSamples.size || null);
+
+  // Background clicks clear in stages, topmost layer first: an existing
+  // selection (focus) on the first click, the color-by filter (scope)
+  // on the next. chipCount is the pre-click value — the chart clears
+  // its own lasso layer before this fires
+  const handleBackgroundClick = () => {
+    if (chipCount) {
+      clearAll();
+      return;
+    }
+    if (legendFilter) resetLegendFilter();
+  };
+
+  // The panel tab's selection pill lives outside this tree; it mirrors
+  // the chip's count through the package atom and requests clears back
+  // through a nonce
+  const publishCount = useSetRecoilState(selectionCountState);
+  useEffect(() => {
+    publishCount(chipCount);
+    return () => publishCount(null);
+  }, [chipCount, publishCount]);
+
+  const clearNonce = useRecoilValue(clearSelectionNonceState);
+  const seenClearNonce = useRef(clearNonce);
+  useEffect(() => {
+    if (clearNonce !== seenClearNonce.current) {
+      seenClearNonce.current = clearNonce;
+      clearAll();
+    }
+  }, [clearAll, clearNonce]);
+
+  const subtitle = `${run.method ?? "visualization"}${
+    run.dims ? ` (${run.dims}D)` : ""
+  }`;
+
+  return (
+    <div className="emb-plot" style={TOKEN_VARS}>
+      <div className="emb-plot-header">
+        <Button
+          variant={Variant.Icon}
+          size={Size.Sm}
+          leadingIcon={IconName.ArrowLeft}
+          aria-label="Back to visualizations"
+          onClick={onBack}
+        />
+        <div className="emb-plot-title">
+          <Text variant={TextVariant.Md} color={TextColor.Fg}>
+            {run.brainKey}
+          </Text>
+          <Text variant={TextVariant.Sm} color={TextColor.Tertiary}>
+            {subtitle}
+          </Text>
+        </div>
+        <div className="emb-plot-controls">
+          {/* Fixed-width slot so the spinner's appearance never nudges
+              the control row */}
+          <span className="emb-colorby-spinner">
+            {colorLoading && (
+              <Icon
+                name={IconName.Spinner}
+                size={Size.Sm}
+                color={IconColor.Decorative}
+              />
+            )}
+          </span>
+          <Text
+            variant={TextVariant.Md}
+            color={TextColor.Secondary}
+            className="emb-nowrap"
+          >
+            Color by
+          </Text>
+          <div className="emb-colorby">
+            <Select
+              exclusive
+              disabled={!choices.length}
+              value={colorField ?? NONE_FIELD}
+              options={colorOptions}
+              onChange={(value) => {
+                setColorField(
+                  typeof value === "string" && value !== NONE_FIELD
+                    ? value
+                    : null,
+                );
+              }}
+            />
+          </div>
+          <span className="emb-plot-divider" />
+          <div className="emb-mode-toggle">
+            <ModeSegment
+              active={mode === "explore"}
+              icon={IconName.Move}
+              label="Explore"
+              onClick={() => setMode("explore")}
+            />
+            <ModeSegment
+              active={mode === "select"}
+              icon={IconName.Draw}
+              label="Select"
+              onClick={() => setMode("select")}
+            />
+          </div>
+          {/* portal: inline rendering clips against the panel chrome */}
+          <Tooltip content="Reset view" portal>
+            <Button
+              variant={Variant.Icon}
+              size={Size.Md}
+              leadingIcon={IconName.Undo}
+              aria-label="Reset view"
+              onClick={() => viewRef.current?.resetCamera()}
+            />
+          </Tooltip>
+        </div>
+      </div>
+      {error && (
+        <div className="emb-plot-error">
+          <Text variant={TextVariant.Sm} color={TextColor.Destructive}>
+            {error}
+          </Text>
+        </div>
+      )}
+      <div ref={plotRef} className="emb-plot-scene">
+        {!loaded && !error && (
+          <div className="emb-plot-loading">
+            <Icon
+              name={IconName.Spinner}
+              size={Size.Lg}
+              color={IconColor.Decorative}
+            />
+          </div>
+        )}
+        {loaded && (
+          <EmbeddingsView
+            ref={viewRef}
+            points={loaded.points}
+            colors={colors}
+            visible={visibleMask}
+            selected={selectedIndices}
+            tooltip={false}
+            mode={mode}
+            zCamera={zCamera}
+            onSelection={handleLasso}
+            onPointClick={mode === "select" ? handlePointClick : undefined}
+            onBackgroundClick={handleBackgroundClick}
+            onError={(e) => setRendererError(e.message)}
+            onHover={handleHover}
+          />
+        )}
+        {hover && (
+          <HoverCard
+            content={hover}
+            containerWidth={plotRef.current?.clientWidth ?? 0}
+            containerHeight={plotRef.current?.clientHeight ?? 0}
+          />
+        )}
+        {colorField && colorMeta && colorMeta.style === "categorical" && (
+          <ColorLegend
+            field={colorField}
+            meta={colorMeta}
+            offLabels={legend?.off ?? null}
+            onToggle={handleLegendToggle}
+            onSolo={handleLegendSolo}
+          />
+        )}
+        {colorField && colorMeta && colorMeta.style === "continuous" && (
+          <ContinuousLegend field={colorField} meta={colorMeta} />
+        )}
+        {chipCount ? (
+          <div className="emb-plot-overlay emb-plot-chip">
+            <Icon
+              name={IconName.Check}
+              size={Size.Md}
+              color={TextColor.Secondary}
+            />
+            <Text variant={TextVariant.Sm} color={TextColor.Secondary}>
+              <strong>{chipCount.toLocaleString()}</strong> selected
+            </Text>
+            <Button
+              variant={Variant.Icon}
+              size={Size.Xs}
+              leadingIcon={IconName.Close}
+              aria-label="Clear selection"
+              onClick={clearAll}
+            />
+          </div>
+        ) : (
+          <div className="emb-plot-overlay emb-plot-hint">
+            <Text variant={TextVariant.Sm} color={TextColor.Secondary}>
+              {mode === "explore"
+                ? "Drag to pan · scroll to zoom"
+                : "Drag to lasso · click points to toggle"}
+            </Text>
+          </div>
+        )}
+        {loaded && (
+          <div className="emb-plot-overlay emb-plot-counter">
+            <Text variant={TextVariant.Sm} color={TextColor.Tertiary}>
+              {loaded.points.length.toLocaleString()}
+              {loaded.points.length < loaded.total &&
+                ` / ${loaded.total.toLocaleString()}`}{" "}
+              points
+              {visibleCount !== null &&
+                ` · ${visibleCount.toLocaleString()} in view`}
+            </Text>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/packages/embeddings-v2/src/RunCard.test.tsx
+++ b/app/packages/embeddings-v2/src/RunCard.test.tsx
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { RunCard } from "./RunCard";
+
+// RTL only auto-cleans up with vitest globals enabled; ours are off
+afterEach(cleanup);
+
+describe("RunCard", () => {
+  it("is a button only when clickable, and clicks fire", () => {
+    const onClick = vi.fn();
+    const { rerender } = render(<RunCard title="viz" onClick={onClick} />);
+
+    fireEvent.click(screen.getByRole("button"));
+    expect(onClick).toHaveBeenCalledTimes(1);
+
+    fireEvent.keyDown(screen.getByRole("button"), { key: "Enter" });
+    expect(onClick).toHaveBeenCalledTimes(2);
+
+    rerender(<RunCard title="viz" />);
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("keeps action clicks off the card", () => {
+    const onClick = vi.fn();
+    render(
+      <RunCard
+        title="viz"
+        onClick={onClick}
+        actions={<button type="button">kebab</button>}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("kebab"));
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});

--- a/app/packages/embeddings-v2/src/RunCard.tsx
+++ b/app/packages/embeddings-v2/src/RunCard.tsx
@@ -1,0 +1,143 @@
+/**
+ * Generic card for a run-like entity: icon well, title, small keyed
+ * badge, status pill, dot-separated metadata line, and a trailing
+ * actions cluster whose clicks do not activate the card. Colors
+ * resolve through design-system token enums via CSS custom properties
+ * (see panel.css). Kept intentionally generic so it can graduate to
+ * @voxel51/voodo.
+ */
+import {
+  BackgroundColor,
+  BorderColor,
+  BrandColor,
+  getColorCssVar,
+  Icon,
+  IconColor,
+  IconName,
+  Pill,
+  Size,
+  Text,
+  TextColor,
+  TextVariant,
+} from "@voxel51/voodo";
+import { Fragment, type CSSProperties, type ReactNode } from "react";
+import "./panel.css";
+
+export interface RunCardStatus {
+  label: string;
+  /** Any content color; icon-tier tokens give the softer status tones */
+  color: TextColor | IconColor;
+}
+
+export interface RunCardProps {
+  icon?: IconName;
+  title: string;
+  /** Small keyed badge next to the title, e.g. "2D" */
+  badge?: string;
+  /** Brand-tinted badge treatment (e.g. capability tiers) */
+  badgeAccent?: boolean;
+  /** Status pill in the trailing cluster */
+  status?: RunCardStatus;
+  /** Dot-separated metadata line under the title */
+  meta?: ReactNode[];
+  /** Trailing action cluster; clicks do not bubble to the card */
+  actions?: ReactNode;
+  onClick?: () => void;
+}
+
+const TOKEN_VARS = {
+  "--emb-card-bg": `var(${getColorCssVar(BackgroundColor.Card2)})`,
+  "--emb-card-hover": `var(${getColorCssVar(BackgroundColor.CardElevated)})`,
+  "--emb-border-subtle": `var(${getColorCssVar(BorderColor.Subtle)})`,
+  "--emb-border-strong": `var(${getColorCssVar(BorderColor.Strong)})`,
+  "--emb-brand": `var(${getColorCssVar(BrandColor.Primary)})`,
+  "--emb-text-secondary": `var(${getColorCssVar(TextColor.Secondary)})`,
+} as CSSProperties;
+
+export function RunCard({
+  icon,
+  title,
+  badge,
+  badgeAccent = false,
+  status,
+  meta,
+  actions,
+  onClick,
+}: RunCardProps) {
+  const interactive = Boolean(onClick);
+  return (
+    <div
+      className="emb-run-card"
+      data-interactive={interactive ? "true" : "false"}
+      style={TOKEN_VARS}
+      role={interactive ? "button" : undefined}
+      tabIndex={interactive ? 0 : undefined}
+      onClick={onClick}
+      onKeyDown={
+        interactive
+          ? (event) => {
+              if (event.key === "Enter" || event.key === " ") {
+                event.preventDefault();
+                onClick?.();
+              }
+            }
+          : undefined
+      }
+    >
+      <div className="emb-run-card-row">
+        <div className="emb-run-card-lead">
+          {icon && (
+            <div className="emb-run-card-iconwell">
+              <Icon name={icon} size={Size.Sm} color={TextColor.Secondary} />
+            </div>
+          )}
+          <span className="emb-run-card-title">
+            <Text variant={TextVariant.Lg} color={TextColor.Fg}>
+              {title}
+            </Text>
+          </span>
+          {badge && (
+            <span
+              className="emb-run-card-badge"
+              data-accent={badgeAccent ? "true" : "false"}
+            >
+              {badge}
+            </span>
+          )}
+        </div>
+        <div
+          className="emb-run-card-trail"
+          onClick={(event) => event.stopPropagation()}
+          onKeyDown={(event) => event.stopPropagation()}
+        >
+          {status && (
+            <Pill
+              size={Size.Xs}
+              isStatus
+              backgroundColor={BackgroundColor.CardElevated}
+              // Pill's prop is under-typed: the class map underneath
+              // (textColorMap) is Record<Color, string>, icon tokens
+              // included — the cast widens types to match the runtime
+              color={status.color as TextColor}
+            >
+              {status.label}
+            </Pill>
+          )}
+          {actions}
+        </div>
+      </div>
+      {meta && meta.length > 0 && (
+        <div className="emb-run-card-meta">
+          {meta.map((item, index) => (
+            <Fragment key={index}>
+              {index > 0 && <span className="emb-run-card-meta-dot" />}
+              <Text variant={TextVariant.Md} color={TextColor.Tertiary}>
+                {item}
+              </Text>
+            </Fragment>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/packages/embeddings-v2/src/RunsList.test.tsx
+++ b/app/packages/embeddings-v2/src/RunsList.test.tsx
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { VisualizationRun } from "./protocol";
+import RunsList from "./RunsList";
+
+const run = (
+  brainKey: string,
+  extra: Partial<VisualizationRun> = {},
+): VisualizationRun => ({
+  brainKey,
+  method: "umap",
+  dims: 2,
+  patchesField: null,
+  pointsField: null,
+  model: "clip-vit-base32-torch",
+  ready: true,
+  timestamp: null,
+  ...extra,
+});
+
+// RTL only auto-cleans up with vitest globals enabled; ours are off
+afterEach(cleanup);
+
+describe("RunsList", () => {
+  // Runs with 3D points are listed and open in the 2D plot; guards
+  // against filtering them out of the list
+  it("lists 3D runs and opens runs on click", () => {
+    const onOpen = vi.fn();
+    render(
+      <RunsList
+        runs={[run("clip_umap"), run("viz3d", { dims: 3 })]}
+        error={null}
+        onOpen={onOpen}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("viz3d")).toBeDefined();
+
+    fireEvent.click(screen.getByText("clip_umap"));
+    expect(onOpen).toHaveBeenCalledWith("clip_umap");
+  });
+
+  // Clicking a run without results crashed the plot view; pending runs
+  // must render inert until the poll flips them ready
+  it("marks runs without results Pending and inert", () => {
+    const onOpen = vi.fn();
+    render(
+      <RunsList
+        runs={[run("cooking", { ready: false })]}
+        error={null}
+        onOpen={onOpen}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Pending")).toBeDefined();
+    fireEvent.click(screen.getByText("cooking"));
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it("shows the upsell until dismissed", () => {
+    render(
+      <RunsList
+        runs={[run("clip_umap")]}
+        error={null}
+        onOpen={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText("Explore clusters in three dimensions"),
+    ).toBeDefined();
+
+    fireEvent.click(screen.getByText("Dismiss"));
+    expect(
+      screen.queryByText("Explore clusters in three dimensions"),
+    ).toBeNull();
+  });
+
+  // The create affordance is capability-gated by the host: no onCreate
+  // (builds that can't compute) must mean no button anywhere
+  it("renders the create button only when the host provides onCreate", () => {
+    const { rerender } = render(
+      <RunsList
+        runs={[run("clip_umap")]}
+        error={null}
+        onOpen={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText("New visualization")).toBeNull();
+
+    const onCreate = vi.fn();
+    rerender(
+      <RunsList
+        runs={[run("clip_umap")]}
+        error={null}
+        onCreate={onCreate}
+        onOpen={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByText("New visualization"));
+    expect(onCreate).toHaveBeenCalled();
+  });
+
+  it("deletes only through the armed confirm step", () => {
+    const onDelete = vi.fn();
+    const onOpen = vi.fn();
+    render(
+      <RunsList
+        runs={[run("clip_umap")]}
+        error={null}
+        onOpen={onOpen}
+        onDelete={onDelete}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("Run actions"));
+    fireEvent.click(screen.getByText("Delete"));
+    expect(onDelete).not.toHaveBeenCalled();
+
+    // Cancel disarms
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(screen.queryByText("Delete run")).toBeNull();
+
+    // Arm again and confirm; the card click must not fire either way
+    fireEvent.click(screen.getByLabelText("Run actions"));
+    fireEvent.click(screen.getByText("Delete"));
+    fireEvent.click(screen.getByText("Delete run"));
+    expect(onDelete).toHaveBeenCalledWith("clip_umap");
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+});

--- a/app/packages/embeddings-v2/src/RunsList.tsx
+++ b/app/packages/embeddings-v2/src/RunsList.tsx
@@ -1,0 +1,252 @@
+/**
+ * The panel's landing view: one card per visualization run on the
+ * dataset. Every run is listed and viewable regardless of its
+ * dimensionality — the plot renders with whatever camera the build
+ * provides. Deleting a run is a two-step confirmation handled inline
+ * on the card.
+ */
+import { DeleteOutlined, MoreHoriz } from "@mui/icons-material";
+import {
+  IconButton,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
+} from "@mui/material";
+import {
+  BackgroundColor,
+  Button,
+  EmptyState,
+  getColorCssVar,
+  IconColor,
+  IconName,
+  Size,
+  Spinner,
+  Text,
+  TextColor,
+  TextVariant,
+  Variant,
+} from "@voxel51/voodo";
+import { useState } from "react";
+import "./panel.css";
+import type { VisualizationRun } from "./protocol";
+import { RunCard } from "./RunCard";
+import { UpsellBanner } from "./UpsellBanner";
+
+const formatTimestamp = (timestamp: string | null): string | null => {
+  if (!timestamp) return null;
+  const date = new Date(timestamp);
+  return Number.isNaN(date.getTime()) ? null : date.toLocaleDateString();
+};
+
+export default function RunsList({
+  runs,
+  error,
+  actionError = null,
+  showUpsell = true,
+  onCreate,
+  onOpen,
+  onDelete,
+}: {
+  runs: VisualizationRun[] | null;
+  error: string | null;
+  /** A failed mutation (e.g. delete); shown without replacing the list */
+  actionError?: string | null;
+  /** Advertise capabilities this build lacks; off where they exist */
+  showUpsell?: boolean;
+  /**
+   * Launches the compute-visualization flow. Only builds that can
+   * compute (operator present, user permitted) pass this; without it
+   * no create affordance renders.
+   */
+  onCreate?: () => void;
+  onOpen: (brainKey: string) => void;
+  onDelete: (brainKey: string) => void;
+}) {
+  // Banner dismissal lasts for the session only
+  const [dismissed, setDismissed] = useState(false);
+  // Delete confirmation: the kebab arms one card, whose inline
+  // buttons then confirm or cancel
+  const [confirmKey, setConfirmKey] = useState<string | null>(null);
+  // At most one kebab menu is open; the anchor pairs with its run
+  const [menu, setMenu] = useState<{
+    key: string;
+    anchor: HTMLElement;
+  } | null>(null);
+
+  if (error) {
+    return (
+      <div className="emb-runs-page">
+        <div className="emb-runs-center">
+          <Text variant={TextVariant.Md} color={TextColor.Destructive}>
+            {error}
+          </Text>
+        </div>
+      </div>
+    );
+  }
+
+  if (!runs) {
+    return (
+      <div className="emb-runs-page">
+        <div className="emb-runs-center">
+          <Spinner size={Size.Md} />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="emb-runs-page">
+      {runs.length > 0 && (
+        <div className="emb-runs-header">
+          <Text variant={TextVariant.Md} color={TextColor.Secondary}>
+            {runs.length} visualization{runs.length === 1 ? "" : "s"}
+          </Text>
+          {onCreate && (
+            <Button
+              size={Size.Sm}
+              leadingIcon={IconName.Add}
+              onClick={onCreate}
+            >
+              New visualization
+            </Button>
+          )}
+        </div>
+      )}
+      <div className="emb-runs-scroll">
+        {showUpsell && !dismissed && (
+          <UpsellBanner onDismiss={() => setDismissed(true)} />
+        )}
+        {actionError && (
+          <div className="emb-runs-action-error">
+            <Text variant={TextVariant.Md} color={TextColor.Destructive}>
+              {actionError}
+            </Text>
+          </div>
+        )}
+        {runs.length === 0 ? (
+          <div className="emb-runs-center emb-runs-overlay">
+            <EmptyState
+              icon={IconName.Embeddings}
+              title="Visualize your embeddings"
+              description="Compute a visualization to explore your dataset in a low-dimensional embedding space."
+            />
+            {onCreate ? (
+              <Button
+                size={Size.Sm}
+                leadingIcon={IconName.Add}
+                onClick={onCreate}
+              >
+                New visualization
+              </Button>
+            ) : (
+              <Text variant={TextVariant.Sm} color={TextColor.Muted}>
+                <code>
+                  {'fob.compute_visualization(dataset, brain_key="viz")'}
+                </code>
+              </Text>
+            )}
+          </div>
+        ) : (
+          <div className="emb-runs-stack" style={{ marginTop: "1rem" }}>
+            {runs.map((run) => (
+              <RunCard
+                key={run.brainKey}
+                icon={IconName.Embeddings}
+                title={run.brainKey}
+                badge={run.dims ? `${run.dims}D` : undefined}
+                badgeAccent={run.dims === 3}
+                status={
+                  run.ready
+                    ? // Icon-tier success: the soft sage the design
+                      // reference uses, not the saturated text green
+                      { label: "Ready", color: IconColor.Success }
+                    : // Deliberately status-agnostic: without run-status
+                      // bookkeeping, "no results yet" cannot distinguish
+                      // still-computing from failed
+                      { label: "Pending", color: TextColor.Secondary }
+                }
+                meta={[
+                  run.method,
+                  run.model,
+                  formatTimestamp(run.timestamp),
+                ].filter((item): item is string => Boolean(item))}
+                onClick={run.ready ? () => onOpen(run.brainKey) : undefined}
+                actions={
+                  confirmKey === run.brainKey ? (
+                    <>
+                      <Button
+                        variant={Variant.Secondary}
+                        size={Size.Xs}
+                        onClick={() => setConfirmKey(null)}
+                      >
+                        Cancel
+                      </Button>
+                      <Button
+                        variant={Variant.Danger}
+                        size={Size.Xs}
+                        onClick={() => {
+                          setConfirmKey(null);
+                          onDelete(run.brainKey);
+                        }}
+                      >
+                        Delete run
+                      </Button>
+                    </>
+                  ) : (
+                    <IconButton
+                      size="small"
+                      aria-label="Run actions"
+                      onClick={(event) =>
+                        setMenu({
+                          key: run.brainKey,
+                          anchor: event.currentTarget,
+                        })
+                      }
+                    >
+                      <MoreHoriz fontSize="small" />
+                    </IconButton>
+                  )
+                }
+              />
+            ))}
+          </div>
+        )}
+        <Menu
+          anchorEl={menu?.anchor ?? null}
+          open={Boolean(menu)}
+          onClose={() => setMenu(null)}
+          anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+          transformOrigin={{ vertical: "top", horizontal: "right" }}
+          sx={{
+            zIndex: 9999,
+            "& .MuiPaper-root": {
+              backgroundColor: `var(${getColorCssVar(BackgroundColor.Muted)})`,
+              // Kill MUI's elevation overlay so the grey matches exactly.
+              backgroundImage: "none",
+            },
+          }}
+        >
+          <MenuItem
+            onClick={() => {
+              if (menu) setConfirmKey(menu.key);
+              setMenu(null);
+            }}
+            sx={{
+              color: `var(${getColorCssVar(TextColor.Destructive)})`,
+              "& .MuiListItemIcon-root, & .MuiListItemText-primary": {
+                color: "inherit",
+              },
+            }}
+          >
+            <ListItemIcon>
+              <DeleteOutlined fontSize="small" />
+            </ListItemIcon>
+            <ListItemText>Delete</ListItemText>
+          </MenuItem>
+        </Menu>
+      </div>
+    </div>
+  );
+}

--- a/app/packages/embeddings-v2/src/TabIndicator.test.tsx
+++ b/app/packages/embeddings-v2/src/TabIndicator.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { RecoilRoot, useRecoilValue } from "recoil";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { clearSelectionNonceState, selectionCountState } from "./state";
+import TabIndicator from "./TabIndicator";
+
+// The real pill lives in (and is tested by) @fiftyone/components, whose
+// barrel needs the app's relay/babel toolchain; this test pins our side
+// of the contract — the props handed across and the atom protocol
+vi.mock("@fiftyone/components", () => ({
+  FilterAndSelectionIndicator: ({
+    selectionCount,
+    onClickSelection,
+  }: {
+    selectionCount?: string;
+    onClickSelection?: () => void;
+  }) => (
+    <button type="button" onClick={onClickSelection}>
+      {selectionCount}
+    </button>
+  ),
+}));
+
+function NonceProbe() {
+  const nonce = useRecoilValue(clearSelectionNonceState);
+  return <span data-testid="nonce">{nonce}</span>;
+}
+
+describe("TabIndicator", () => {
+  afterEach(cleanup);
+
+  it("renders nothing without a selection", () => {
+    const { container } = render(
+      <RecoilRoot>
+        <TabIndicator />
+      </RecoilRoot>,
+    );
+    expect(container.textContent).toBe("");
+  });
+
+  it("shows the count and requests a clear on click", () => {
+    render(
+      <RecoilRoot initializeState={({ set }) => set(selectionCountState, 1234)}>
+        <TabIndicator />
+        <NonceProbe />
+      </RecoilRoot>,
+    );
+
+    // The pill carries the plot selection's size, formatted
+    const pill = screen.getByText((1234).toLocaleString());
+    fireEvent.click(pill);
+
+    // Clearing is a request through the nonce — the plot view owns the
+    // actual teardown (chart state + Recoil selection atoms)
+    expect(screen.getByTestId("nonce").textContent).toBe("1");
+  });
+});

--- a/app/packages/embeddings-v2/src/TabIndicator.tsx
+++ b/app/packages/embeddings-v2/src/TabIndicator.tsx
@@ -1,0 +1,22 @@
+import { FilterAndSelectionIndicator } from "@fiftyone/components";
+import { useRecoilValue, useSetRecoilState } from "recoil";
+import { clearSelectionNonceState, selectionCountState } from "./state";
+
+/**
+ * Selection pill in the panel's tab: shows the active plot selection's
+ * size and clears it on click. Mounted by the spaces tab bar, outside
+ * the panel tree, so it talks to the plot through the package atoms.
+ */
+export default function TabIndicator() {
+  const count = useRecoilValue(selectionCountState);
+  const requestClear = useSetRecoilState(clearSelectionNonceState);
+
+  if (!count) return null;
+
+  return (
+    <FilterAndSelectionIndicator
+      selectionCount={count.toLocaleString()}
+      onClickSelection={() => requestClear((nonce) => nonce + 1)}
+    />
+  );
+}

--- a/app/packages/embeddings-v2/src/TeaserCloud.tsx
+++ b/app/packages/embeddings-v2/src/TeaserCloud.tsx
@@ -1,0 +1,151 @@
+/**
+ * Decorative spinning point cloud for the upsell banner: a fixed
+ * synthetic cluster scene with no controls, picking, or data
+ * dependencies. three.js is imported dynamically, so rendering the
+ * runs page loads no WebGL code up front; if a WebGL context is
+ * unavailable (tests, headless browsers), the tinted well renders
+ * empty.
+ */
+import { useEffect, useRef } from "react";
+import "./panel.css";
+
+// Scatter-class colors and cluster layout for the synthetic scene
+const PALETTE = [
+  "#FF6D04",
+  "#86B5F6",
+  "#7AB87C",
+  "#CBA6FF",
+  "#FCCB58",
+  "#FF6767",
+];
+const CENTERS: Array<[number, number, number]> = [
+  [-6, 3, -2],
+  [5, 4, 3],
+  [-2, -4, 4],
+  [6, -3, -4],
+  [0, 5, -6],
+  [-5, -5, -5],
+];
+const SPREAD = 2.6;
+
+/** Deterministic PRNG so the cloud looks identical every load */
+const makeRand = (seed: number) => {
+  let h = seed >>> 0;
+  return () => {
+    h = (h * 1103515245 + 12345) & 0x7fffffff;
+    return (h % 100000) / 100000;
+  };
+};
+
+export function TeaserCloud() {
+  const hostRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return undefined;
+    let disposed = false;
+    let cleanup: (() => void) | null = null;
+
+    import("three").then((THREE) => {
+      if (disposed) return;
+      let renderer: import("three").WebGLRenderer;
+      try {
+        renderer = new THREE.WebGLRenderer({ alpha: true, antialias: true });
+      } catch {
+        return;
+      }
+      const size = host.clientWidth || 112;
+      renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+      renderer.setSize(size, size);
+      host.appendChild(renderer.domElement);
+
+      const camera = new THREE.PerspectiveCamera(45, 1, 0.1, 100);
+      camera.position.set(14, 12, 16);
+      camera.lookAt(0, 0, 0);
+
+      // ~420 points across 6 clusters; ~12% receive another cluster's
+      // color, mimicking the class overlap of real prediction data
+      const rand = makeRand(987654321);
+      const positions: number[] = [];
+      const colorChannels: number[] = [];
+      const color = new THREE.Color();
+      CENTERS.forEach(([cx, cy, cz], cluster) => {
+        const n = 60 + Math.floor(rand() * 20);
+        for (let i = 0; i < n; i++) {
+          positions.push(
+            cx + (rand() - 0.5) * SPREAD * 2,
+            cy + (rand() - 0.5) * SPREAD * 2,
+            cz + (rand() - 0.5) * SPREAD * 2,
+          );
+          const wrong = rand() < 0.12;
+          color.set(
+            PALETTE[wrong ? Math.floor(rand() * PALETTE.length) : cluster],
+          );
+          colorChannels.push(color.r, color.g, color.b);
+        }
+      });
+      const geometry = new THREE.BufferGeometry();
+      geometry.setAttribute(
+        "position",
+        new THREE.BufferAttribute(new Float32Array(positions), 3),
+      );
+      geometry.setAttribute(
+        "color",
+        new THREE.BufferAttribute(new Float32Array(colorChannels), 3),
+      );
+
+      // Round sprites: a canvas-drawn circle with an alpha cutout
+      const sprite = document.createElement("canvas");
+      sprite.width = sprite.height = 64;
+      const ctx = sprite.getContext("2d");
+      if (ctx) {
+        ctx.beginPath();
+        ctx.arc(32, 32, 30, 0, Math.PI * 2);
+        ctx.fillStyle = "#ffffff";
+        ctx.fill();
+      }
+      const texture = new THREE.CanvasTexture(sprite);
+
+      const material = new THREE.PointsMaterial({
+        vertexColors: true,
+        size: 4,
+        sizeAttenuation: false,
+        transparent: true,
+        opacity: 0.95,
+        depthWrite: false,
+        map: texture,
+        alphaTest: 0.5,
+      });
+      const points = new THREE.Points(geometry, material);
+      const scene = new THREE.Scene();
+      scene.add(points);
+
+      let frame = 0;
+      let last = performance.now();
+      const tick = (now: number) => {
+        points.rotation.y += ((now - last) / 1000) * 0.35;
+        last = now;
+        renderer.render(scene, camera);
+        frame = requestAnimationFrame(tick);
+      };
+      frame = requestAnimationFrame(tick);
+
+      cleanup = () => {
+        cancelAnimationFrame(frame);
+        geometry.dispose();
+        material.dispose();
+        texture.dispose();
+        renderer.dispose();
+        renderer.forceContextLoss();
+        renderer.domElement.remove();
+      };
+    });
+
+    return () => {
+      disposed = true;
+      cleanup?.();
+    };
+  }, []);
+
+  return <div ref={hostRef} className="emb-teaser" aria-hidden />;
+}

--- a/app/packages/embeddings-v2/src/UpsellBanner.tsx
+++ b/app/packages/embeddings-v2/src/UpsellBanner.tsx
@@ -1,0 +1,40 @@
+/**
+ * Banner promoting FiftyOne Enterprise's 3D embeddings exploration,
+ * shown at the top of the runs page with a decorative animated aside.
+ */
+import { Button, IconName, Size, Variant } from "@voxel51/voodo";
+import "./panel.css";
+import { Callout } from "./Callout";
+import { TeaserCloud } from "./TeaserCloud";
+
+const LEARN_MORE_URL = "https://voxel51.com/enterprise";
+
+export function UpsellBanner({ onDismiss }: { onDismiss: () => void }) {
+  return (
+    <Callout
+      icon={IconName.Embeddings}
+      title="Explore clusters in three dimensions"
+      description="Rotate, zoom, and explore clusters in 3D — available in FiftyOne Enterprise."
+      aside={<TeaserCloud />}
+      actions={
+        <>
+          <Button
+            variant={Variant.Primary}
+            size={Size.Sm}
+            trailingIcon={IconName.ExternalLink}
+            onClick={() => window.open(LEARN_MORE_URL, "_blank", "noopener")}
+          >
+            Learn more
+          </Button>
+          <Button
+            variant={Variant.Secondary}
+            size={Size.Sm}
+            onClick={onDismiss}
+          >
+            Dismiss
+          </Button>
+        </>
+      }
+    />
+  );
+}

--- a/app/packages/embeddings-v2/src/colorMask.test.ts
+++ b/app/packages/embeddings-v2/src/colorMask.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { localColorMask } from "./colorMask";
+import { MISSING_CATEGORY } from "./colors";
+import type { ColorMeta, ColorValues } from "./protocol";
+
+const META: ColorMeta = {
+  style: "categorical",
+  exact: true,
+  classes: [
+    { label: "cat", count: 2 },
+    { label: "dog", count: 1 },
+  ],
+};
+
+// Points: cat, dog, cat, missing
+const COLUMN: ColorValues = {
+  style: "categorical",
+  indices: new Uint16Array([0, 1, 0, MISSING_CATEGORY]),
+};
+
+describe("localColorMask", () => {
+  it("evaluates exclusion filters, keeping missing values", () => {
+    const mask = localColorMask(
+      { values: ["cat"], exclude: true },
+      COLUMN,
+      META,
+    );
+    expect(mask && [...mask]).toEqual([0, 1, 0, 1]);
+  });
+
+  it("evaluates inclusion filters, hiding missing values", () => {
+    const mask = localColorMask(
+      { values: ["cat"], exclude: false },
+      COLUMN,
+      META,
+    );
+    expect(mask && [...mask]).toEqual([1, 0, 1, 0]);
+  });
+
+  // The server's mask applies grid semantics we don't reproduce; every
+  // shape we can't prove identical must fall back to it
+  it("refuses anything it cannot evaluate faithfully", () => {
+    const plain = { values: ["cat"], exclude: true };
+
+    // Values the column has no vocabulary for (e.g. beyond the top-N cap)
+    expect(
+      localColorMask({ values: ["zebra"], exclude: true }, COLUMN, META),
+    ).toBeNull();
+
+    // Extra keys carry matching semantics (isMatching et al)
+    expect(
+      localColorMask({ ...plain, isMatching: true }, COLUMN, META),
+    ).toBeNull();
+
+    // Columns that collapsed list values are lossy
+    expect(
+      localColorMask(plain, COLUMN, { ...META, exact: undefined }),
+    ).toBeNull();
+
+    // Continuous filters are range-shaped, not value sets
+    expect(
+      localColorMask(
+        plain,
+        { style: "continuous", values: new Float32Array(4) },
+        { style: "continuous" },
+      ),
+    ).toBeNull();
+
+    // No value list at all (range or malformed filters)
+    expect(localColorMask({ exclude: true }, COLUMN, META)).toBeNull();
+  });
+});

--- a/app/packages/embeddings-v2/src/colorMask.ts
+++ b/app/packages/embeddings-v2/src/colorMask.ts
@@ -1,0 +1,64 @@
+/**
+ * Client-side evaluation of the color-by field's sidebar filter against
+ * the color column already in memory — the mask that makes legend
+ * clicks instant instead of a masks-endpoint round trip (a full
+ * server-side aggregation, seconds at scale).
+ *
+ * Fidelity rule: the server's match mask is the truth (it applies
+ * filters through the same view compiler the grid uses), so this
+ * evaluates locally ONLY when the result is provably identical —
+ * otherwise it returns null and the caller must leave the filter to
+ * the server. Local evaluation requires:
+ *
+ * - a categorical column whose values are the field's full values
+ *   (`meta.exact` — list fields collapse to their first element, where
+ *   a column match proves nothing about the field), and
+ * - a plain `{values, exclude}` filter whose values all map to listed
+ *   classes (foreign values — e.g. beyond the top-N cap — aren't in
+ *   the column's vocabulary; extra keys like `isMatching` carry
+ *   matching semantics we don't reproduce).
+ *
+ * Missing values (no value in the field) mirror the server: excluded
+ * value sets keep them, included value sets hide them.
+ */
+import { MISSING_CATEGORY } from "./colors";
+import type { CategoricalFilter } from "./legendFilter";
+import type { ColorMeta, ColorValues } from "./protocol";
+
+export function localColorMask(
+  filter: CategoricalFilter,
+  column: ColorValues,
+  meta: ColorMeta,
+): Uint8Array | null {
+  if (column.style !== "categorical" || meta.style !== "categorical") {
+    return null;
+  }
+  if (meta.exact !== true) return null;
+  if (!Array.isArray(filter.values)) return null;
+  for (const key of Object.keys(filter)) {
+    if (key !== "values" && key !== "exclude" && filter[key] !== undefined) {
+      return null;
+    }
+  }
+
+  const indexByLabel = new Map(
+    (meta.classes ?? []).map((cls, index) => [cls.label, index]),
+  );
+  const filterIndices = new Set<number>();
+  for (const value of filter.values) {
+    const index = indexByLabel.get(value as string | number | boolean);
+    if (index === undefined) return null;
+    filterIndices.add(index);
+  }
+
+  const exclude = filter.exclude === true;
+  const { indices } = column;
+  const mask = new Uint8Array(indices.length);
+  for (let i = 0; i < indices.length; i++) {
+    const classIndex = indices[i];
+    const inSet =
+      classIndex !== MISSING_CATEGORY && filterIndices.has(classIndex);
+    mask[i] = (exclude ? !inSet : inSet) ? 1 : 0;
+  }
+  return mask;
+}

--- a/app/packages/embeddings-v2/src/colors.test.ts
+++ b/app/packages/embeddings-v2/src/colors.test.ts
@@ -1,0 +1,91 @@
+import { PALETTE } from "./renderer";
+import { describe, expect, it } from "vitest";
+import { buildColors, categoryHex, MISSING_CATEGORY } from "./colors";
+
+const rgbAt = (colors: Float32Array, i: number) => [
+  colors[i * 3],
+  colors[i * 3 + 1],
+  colors[i * 3 + 2],
+];
+
+const hexToRgb = (hex: string) => [
+  parseInt(hex.slice(1, 3), 16) / 255,
+  parseInt(hex.slice(3, 5), 16) / 255,
+  parseInt(hex.slice(5, 7), 16) / 255,
+];
+
+describe("buildColors categorical", () => {
+  it("gives legend swatches the exact color the points get", () => {
+    // The drift guard: categoryHex (legend) and buildColors (points)
+    // must agree for every class index, including past the palette wrap
+    const count = PALETTE.length + 2;
+    const indices = new Uint16Array(count).map((_, i) => i);
+    const colors = buildColors({ style: "categorical", indices });
+
+    for (let i = 0; i < count; i++) {
+      hexToRgb(categoryHex(i)).forEach((channel, c) => {
+        expect(rgbAt(colors, i)[c]).toBeCloseTo(channel, 6);
+      });
+    }
+  });
+
+  it("maps class indices through the palette, cycling past its length", () => {
+    const count = PALETTE.length + 1;
+    const indices = new Uint16Array(count).map((_, i) => i);
+    const colors = buildColors({ style: "categorical", indices });
+
+    // Float32Array storage truncates the float64 palette math
+    hexToRgb(PALETTE[0]).forEach((channel, c) => {
+      expect(rgbAt(colors, 0)[c]).toBeCloseTo(channel, 6);
+      // One past the palette wraps to the first entry
+      expect(rgbAt(colors, PALETTE.length)[c]).toBeCloseTo(channel, 6);
+    });
+  });
+
+  it("renders missing values gray", () => {
+    const indices = new Uint16Array([0, MISSING_CATEGORY]);
+    const colors = buildColors({ style: "categorical", indices });
+    const [r, g, b] = rgbAt(colors, 1);
+    expect(r).toBe(g);
+    expect(g).toBe(b);
+  });
+});
+
+describe("buildColors continuous", () => {
+  it("ramps between the endpoints across the range", () => {
+    const values = new Float32Array([0, 10]);
+    const colors = buildColors(
+      { style: "continuous", values },
+      { min: 0, max: 10 },
+    );
+    // Low end is bluer than the high end; high end is redder
+    expect(rgbAt(colors, 0)[2]).toBeGreaterThan(rgbAt(colors, 1)[2]);
+    expect(rgbAt(colors, 1)[0]).toBeGreaterThan(rgbAt(colors, 0)[0]);
+  });
+
+  it("clamps out-of-range values and grays NaN", () => {
+    const range = { min: 0, max: 10 };
+    const clamped = buildColors(
+      { style: "continuous", values: new Float32Array([-100, 100, NaN]) },
+      range,
+    );
+    const exact = buildColors(
+      { style: "continuous", values: new Float32Array([0, 10]) },
+      range,
+    );
+    expect(rgbAt(clamped, 0)).toEqual(rgbAt(exact, 0));
+    expect(rgbAt(clamped, 1)).toEqual(rgbAt(exact, 1));
+    const [r, g, b] = rgbAt(clamped, 2);
+    expect(r).toBe(g);
+    expect(g).toBe(b);
+  });
+
+  it("survives a degenerate range (min == max)", () => {
+    const values = new Float32Array([5, 5]);
+    const colors = buildColors(
+      { style: "continuous", values },
+      { min: 5, max: 5 },
+    );
+    expect(Number.isNaN(colors[0])).toBe(false);
+  });
+});

--- a/app/packages/embeddings-v2/src/colors.ts
+++ b/app/packages/embeddings-v2/src/colors.ts
@@ -1,0 +1,84 @@
+/**
+ * Maps v2 color columns to the renderer's flat rgb triplets. The
+ * palettes are placeholders pending integration with the App's
+ * configurable color scheme.
+ */
+import { PALETTE } from "./renderer";
+import type { ColorValues } from "./protocol";
+
+export const MISSING_CATEGORY = 0xffff;
+
+const MISSING_RGB: [number, number, number] = [0.45, 0.45, 0.45];
+// Continuous ramp endpoints (cool blue -> Voxel51 orange)
+const RAMP_LO: [number, number, number] = [0.15, 0.4, 0.9];
+const RAMP_HI: [number, number, number] = [1.0, 0.65, 0.0];
+
+const hexToRgb = (hex: string): [number, number, number] => [
+  parseInt(hex.slice(1, 3), 16) / 255,
+  parseInt(hex.slice(3, 5), 16) / 255,
+  parseInt(hex.slice(5, 7), 16) / 255,
+];
+
+const PALETTE_RGB = PALETTE.map(hexToRgb);
+
+/**
+ * The CSS color a categorical class index maps to. The single source
+ * for legend swatches, so they cannot drift from the point colors
+ * buildColors assigns.
+ */
+export const categoryHex = (index: number): string =>
+  PALETTE[index % PALETTE.length];
+
+/**
+ * The CSS color at position t ∈ [0, 1] on the continuous ramp — the
+ * same per-channel interpolation buildColors applies (including its
+ * float32 quantization), so a legend gradient built from this cannot
+ * drift from the point colors.
+ */
+export const rampCss = (t: number): string => {
+  const at = (channel: number) =>
+    Math.round(
+      Math.fround(
+        RAMP_LO[channel] + t * (RAMP_HI[channel] - RAMP_LO[channel]),
+      ) * 255,
+    );
+  return `rgb(${at(0)}, ${at(1)}, ${at(2)})`;
+};
+
+/** Expands a color column into Float32Array(n*3) rgb for the renderer */
+export function buildColors(
+  column: ColorValues,
+  range?: { min: number | null; max: number | null },
+): Float32Array {
+  if (column.style === "categorical") {
+    const { indices } = column;
+    const colors = new Float32Array(indices.length * 3);
+    for (let i = 0; i < indices.length; i++) {
+      const index = indices[i];
+      const rgb =
+        index === MISSING_CATEGORY
+          ? MISSING_RGB
+          : PALETTE_RGB[index % PALETTE_RGB.length];
+      colors.set(rgb, i * 3);
+    }
+    return colors;
+  }
+
+  const { values } = column;
+  const lo = range?.min ?? 0;
+  const hi = range?.max ?? 1;
+  const span = hi - lo || 1;
+  const colors = new Float32Array(values.length * 3);
+  for (let i = 0; i < values.length; i++) {
+    const value = values[i];
+    if (Number.isNaN(value)) {
+      colors.set(MISSING_RGB, i * 3);
+      continue;
+    }
+    const t = Math.min(1, Math.max(0, (value - lo) / span));
+    colors[i * 3] = RAMP_LO[0] + t * (RAMP_HI[0] - RAMP_LO[0]);
+    colors[i * 3 + 1] = RAMP_LO[1] + t * (RAMP_HI[1] - RAMP_LO[1]);
+    colors[i * 3 + 2] = RAMP_LO[2] + t * (RAMP_HI[2] - RAMP_LO[2]);
+  }
+  return colors;
+}

--- a/app/packages/embeddings-v2/src/index.ts
+++ b/app/packages/embeddings-v2/src/index.ts
@@ -1,0 +1,25 @@
+import {
+  Categories,
+  PluginComponentType,
+  registerComponent,
+} from "@fiftyone/plugins";
+import ScatterPlotIcon from "@mui/icons-material/ScatterPlot";
+import { BUILT_IN_PANEL_PRIORITY_CONST } from "@fiftyone/utilities";
+import { lazy } from "react";
+import TabIndicator from "./TabIndicator";
+
+const EmbeddingsV2Panel = lazy(() => import("./EmbeddingsV2Panel"));
+
+registerComponent({
+  name: "EmbeddingsV2",
+  label: "Embeddings v2",
+  component: EmbeddingsV2Panel,
+  type: PluginComponentType.Panel,
+  activator: () => true,
+  Icon: ScatterPlotIcon,
+  panelOptions: {
+    TabIndicator,
+    priority: BUILT_IN_PANEL_PRIORITY_CONST,
+    category: Categories.Curate,
+  },
+});

--- a/app/packages/embeddings-v2/src/legendFilter.test.ts
+++ b/app/packages/embeddings-v2/src/legendFilter.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+import { legendLabels, onLabels, soloLabel, toggleLabel } from "./legendFilter";
+
+const LABELS = ["cat", "dog", "bird"];
+
+describe("onLabels", () => {
+  it("treats no filter as every class on", () => {
+    expect(onLabels(null, LABELS)).toEqual(new Set(LABELS));
+    expect(onLabels({ isMatching: false }, LABELS)).toEqual(new Set(LABELS));
+  });
+
+  it("reads inclusion and exclusion filters", () => {
+    expect(onLabels({ values: ["cat"], exclude: false }, LABELS)).toEqual(
+      new Set(["cat"]),
+    );
+    expect(onLabels({ values: ["cat"], exclude: true }, LABELS)).toEqual(
+      new Set(["dog", "bird"]),
+    );
+  });
+
+  it("ignores non-string filter values", () => {
+    expect(onLabels({ values: [7, null], exclude: true }, LABELS)).toEqual(
+      new Set(LABELS),
+    );
+  });
+});
+
+describe("toggleLabel", () => {
+  it("writes exclusion filters", () => {
+    expect(toggleLabel(null, LABELS, "dog")).toEqual({
+      values: ["dog"],
+      exclude: true,
+    });
+
+    const one = toggleLabel(null, LABELS, "cat");
+    expect(toggleLabel(one, LABELS, "dog")).toEqual({
+      values: ["cat", "dog"],
+      exclude: true,
+    });
+  });
+
+  // The dblclick gesture arrives as click-click-dblclick and relies on
+  // the two toggles cancelling
+  it("is its own inverse", () => {
+    const once = toggleLabel(null, LABELS, "dog");
+    expect(toggleLabel(once, LABELS, "dog")).toBeNull();
+  });
+
+  // Representation is a pure function of the toggle set: an inclusion
+  // filter (e.g. hand-written in the sidebar) converts to the
+  // equivalent exclusion on the first legend click
+  it("converts inclusion filters to exclusion", () => {
+    const included = { values: ["cat"], exclude: false };
+    expect(toggleLabel(included, LABELS, "dog")).toEqual({
+      values: ["bird"],
+      exclude: true,
+    });
+  });
+
+  it("collapses to no filter when every class is back on", () => {
+    expect(
+      toggleLabel({ values: ["cat"], exclude: true }, LABELS, "cat"),
+    ).toBeNull();
+    expect(
+      toggleLabel({ values: ["cat", "dog"], exclude: false }, LABELS, "bird"),
+    ).toBeNull();
+  });
+
+  it("allows toggling every class off", () => {
+    let filter = toggleLabel(null, LABELS, "cat");
+    filter = toggleLabel(filter, LABELS, "dog");
+    filter = toggleLabel(filter, LABELS, "bird");
+    expect(filter).toEqual({
+      values: ["cat", "dog", "bird"],
+      exclude: true,
+    });
+    expect(onLabels(filter, LABELS).size).toBe(0);
+  });
+
+  it("preserves excluded sidebar values outside the legend's class list", () => {
+    // e.g. a >top-N class the user excluded directly in the sidebar
+    const filter = { values: ["zebra"], exclude: true };
+    expect(toggleLabel(filter, LABELS, "cat")).toEqual({
+      values: ["cat", "zebra"],
+      exclude: true,
+    });
+  });
+
+  it("drops an inclusion filter's foreign values", () => {
+    // Inclusion of an unlisted value cannot survive in exclusion form —
+    // carrying "zebra" into the exclusion list would invert its meaning
+    const filter = { values: ["zebra"], exclude: false };
+    expect(toggleLabel(filter, LABELS, "cat")).toEqual({
+      values: ["dog", "bird"],
+      exclude: true,
+    });
+  });
+
+  it("preserves extra filter properties", () => {
+    const filter = { values: ["cat"], exclude: true, isMatching: true };
+    expect(toggleLabel(filter, LABELS, "dog")).toMatchObject({
+      isMatching: true,
+    });
+  });
+});
+
+describe("legendLabels", () => {
+  const meta = (labels: Array<string | number>) => ({
+    style: "categorical" as const,
+    classes: labels.map((label) => ({ label, count: 1 })),
+  });
+
+  it("derives the off-set from the filter", () => {
+    expect(
+      legendLabels(meta(["cat", "dog"]), { values: ["dog"], exclude: true }),
+    ).toEqual({ labels: ["cat", "dog"], off: new Set(["dog"]) });
+    expect(legendLabels(meta(["cat", "dog"]), null)).toEqual({
+      labels: ["cat", "dog"],
+      off: new Set(),
+    });
+  });
+
+  // Numeric classes can't map to a value-list sidebar filter; the
+  // legend must render inert rather than write a broken filter
+  it("is null for non-string classes and non-categorical fields", () => {
+    expect(legendLabels(meta(["cat", 7]), null)).toBeNull();
+    expect(legendLabels({ style: "continuous" }, null)).toBeNull();
+    expect(legendLabels(null, null)).toBeNull();
+  });
+});
+
+describe("soloLabel", () => {
+  it("writes the exclusion of every other class", () => {
+    expect(soloLabel(null, LABELS, "dog")).toEqual({
+      values: ["cat", "bird"],
+      exclude: true,
+    });
+  });
+
+  // Identical toggle states must produce identical filters no matter
+  // the click path — otherwise the same legend state renders
+  // differently (sidebar mode, grey/unlisted points) by history
+  it("is exactly equivalent to single-clicking every other class off", () => {
+    const viaSolo = soloLabel(null, LABELS, "dog");
+    let viaToggles = toggleLabel(null, LABELS, "cat");
+    viaToggles = toggleLabel(viaToggles, LABELS, "bird");
+    expect(viaSolo).toEqual(viaToggles);
+  });
+
+  it("restores all classes when the lone visible class is solo'd again", () => {
+    const solo = soloLabel(null, LABELS, "dog");
+    expect(soloLabel(solo, LABELS, "dog")).toBeNull();
+  });
+});

--- a/app/packages/embeddings-v2/src/legendFilter.ts
+++ b/app/packages/embeddings-v2/src/legendFilter.ts
@@ -1,0 +1,122 @@
+/**
+ * Legend click semantics as pure transforms over the App's sidebar
+ * filter for the color-by field. The legend keeps no selection state of
+ * its own: which classes are "on" derives from that filter, and a click
+ * maps the current filter to the next one — so sidebar edits and legend
+ * clicks can never disagree. `null` stands for "no filter" (every class
+ * on) in both directions.
+ *
+ * The legend writes EXCLUSION filters, always. The filter is a pure
+ * function of the toggle set — identical toggle states produce
+ * identical filters no matter the click path, so the sidebar can never
+ * flip between "omit" and "show" for the same legend state, and a solo
+ * (double-click) is exactly equivalent to single-clicking every other
+ * class off. Consequences accepted with that choice: points with no
+ * value in the field, and a capped field's unlisted (>top-N) classes,
+ * are never hidden by legend clicks — exclusion can't name them.
+ *
+ * Other rules:
+ * - Excluded values outside the legend's class list (sidebar entries
+ *   for uncapped classes) ride along untouched; an inclusion filter's
+ *   foreign values cannot be expressed in exclusion form and are
+ *   dropped on the first legend click.
+ * - A filter that turns every class back on collapses to `null`.
+ */
+import type { ColorMeta } from "./protocol";
+
+/** One value in a sidebar filter, mirroring fos.Filter's value type */
+type FilterValue = string | boolean | number | null | undefined;
+
+/** The sidebar's categorical filter shape; extra keys (`isMatching`,
+ * ...) are preserved verbatim across transforms. Structurally a
+ * fos.Filter, so transforms write straight back to the filter atom. */
+export interface CategoricalFilter {
+  values?: FilterValue[];
+  exclude?: boolean;
+  [key: string]: FilterValue | FilterValue[];
+}
+
+/**
+ * The legend's view of a color-by field: its string class labels and
+ * which of them the filter currently hides. Null when the field's
+ * classes are not filterable — non-string labels (the sidebar's
+ * numeric filters are range-shaped, not value lists) or no categorical
+ * classes at all — in which case the legend renders inert.
+ */
+export function legendLabels(
+  meta: ColorMeta | null,
+  filter: CategoricalFilter | null,
+): { labels: string[]; off: Set<string> } | null {
+  const classes = meta?.style === "categorical" ? meta.classes : undefined;
+  if (!classes?.length) return null;
+  const labels = classes.map((cls) => cls.label);
+  if (!labels.every((label): label is string => typeof label === "string")) {
+    return null;
+  }
+  const on = onLabels(filter, labels);
+  return { labels, off: new Set(labels.filter((label) => !on.has(label))) };
+}
+
+/** The classes `filter` leaves visible; no value filter means all */
+export function onLabels(
+  filter: CategoricalFilter | null,
+  labels: readonly string[],
+): Set<string> {
+  if (!filter?.values) return new Set(labels);
+  const values = new Set(
+    filter.values.filter((value): value is string => typeof value === "string"),
+  );
+  return new Set(
+    filter.exclude
+      ? labels.filter((label) => !values.has(label))
+      : labels.filter((label) => values.has(label)),
+  );
+}
+
+/** Single click: toggle one class in or out of view */
+export function toggleLabel(
+  filter: CategoricalFilter | null,
+  labels: readonly string[],
+  label: string,
+): CategoricalFilter | null {
+  const on = onLabels(filter, labels);
+  if (on.has(label)) {
+    on.delete(label);
+  } else {
+    on.add(label);
+  }
+  return build(filter, on, labels);
+}
+
+/** Double click: isolate one class — a bulk toggle, writing the exact
+ * filter that single-clicking every other class off would. On the lone
+ * visible class, restore all (the escape hatch) */
+export function soloLabel(
+  filter: CategoricalFilter | null,
+  labels: readonly string[],
+  label: string,
+): CategoricalFilter | null {
+  const on = onLabels(filter, labels);
+  if (on.size === 1 && on.has(label)) return null;
+  return build(filter, new Set([label]), labels);
+}
+
+function build(
+  base: CategoricalFilter | null,
+  on: ReadonlySet<string>,
+  labels: readonly string[],
+): CategoricalFilter | null {
+  const known = new Set(labels);
+  // Only exclusions can carry foreign values forward — an inclusion
+  // filter's foreign values would invert meaning in exclusion form
+  const foreign =
+    base?.exclude === true
+      ? (base.values ?? []).filter(
+          (value) => !(typeof value === "string" && known.has(value)),
+        )
+      : [];
+  const off = labels.filter((label) => !on.has(label));
+  if (!off.length && !foreign.length) return null;
+
+  return { ...base, values: [...off, ...foreign], exclude: true };
+}

--- a/app/packages/embeddings-v2/src/panel.css
+++ b/app/packages/embeddings-v2/src/panel.css
@@ -1,0 +1,575 @@
+/*
+ * Styles for the runs page. Every color flows through an --emb-* custom
+ * property that the components set from VOODO token enums (via
+ * getColorCssVar) — no raw token names live in this file, so the page
+ * tracks theme changes exactly like VOODO components do.
+ */
+
+/* --- RunCard (generic; VOODO candidate) ------------------------------ */
+
+.emb-run-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+  padding: 0.875rem 1rem;
+  border-radius: 0.5rem;
+  background: var(--emb-card-bg);
+  border: 1px solid var(--emb-border-subtle);
+  transition: background-color 0.15s ease;
+}
+
+.emb-run-card[data-interactive="true"] {
+  cursor: pointer;
+}
+
+.emb-run-card[data-interactive="true"]:hover {
+  background: var(--emb-card-hover);
+}
+
+.emb-run-card-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.emb-run-card-lead {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  min-width: 0;
+}
+
+.emb-run-card-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.emb-run-card-iconwell {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 1.75rem;
+  width: 1.75rem;
+  border-radius: 9999px;
+  background: var(--emb-card-hover);
+  flex-shrink: 0;
+  transition: background-color 0.2s ease;
+}
+
+.emb-run-card[data-interactive="true"]:hover .emb-run-card-iconwell {
+  background: color-mix(in srgb, var(--emb-brand) 10%, transparent);
+}
+
+.emb-run-card-badge {
+  border-radius: 0.25rem;
+  padding: 0.125rem 0.375rem;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: 0.025em;
+  font-variant-numeric: tabular-nums;
+  background: var(--emb-card-hover);
+  color: var(--emb-text-secondary);
+  flex-shrink: 0;
+}
+
+.emb-run-card-badge[data-accent="true"] {
+  background: color-mix(in srgb, var(--emb-brand) 15%, transparent);
+  color: var(--emb-brand);
+}
+
+.emb-run-card-trail {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  flex-shrink: 0;
+}
+
+.emb-run-card-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  min-width: 0;
+}
+
+.emb-run-card-meta-dot {
+  height: 0.25rem;
+  width: 0.25rem;
+  border-radius: 9999px;
+  background: var(--emb-border-strong);
+  flex-shrink: 0;
+}
+
+/* --- Callout (generic; VOODO candidate) ------------------------------ */
+
+.emb-callout {
+  display: grid;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px solid color-mix(in srgb, var(--emb-brand) 30%, transparent);
+  background: color-mix(in srgb, var(--emb-brand) 6%, transparent);
+}
+
+.emb-callout[data-aside="true"] {
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: stretch;
+}
+
+.emb-callout-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  min-width: 0;
+}
+
+.emb-callout-heading {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.emb-callout-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.375rem;
+}
+
+/* --- Decorative point-cloud teaser (see TeaserCloud.tsx) --------------- */
+
+.emb-teaser {
+  position: relative;
+  overflow: hidden;
+  width: 7rem;
+  height: 100%;
+  min-height: 6.5rem;
+  border-radius: 0.5rem;
+  background: var(--emb-card-bg);
+  box-shadow: inset 0 0 0 1px var(--emb-border-subtle);
+}
+
+.emb-teaser canvas {
+  display: block;
+}
+
+/* --- Plot view chrome -------------------------------------------------- */
+
+.emb-plot {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+.emb-plot-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1rem;
+  flex-shrink: 0;
+  min-width: 0;
+  /* Above the scene's overlays (hint/chip/legend/hover card), which
+     follow in the DOM: anything opening out of the header (the
+     color-by dropdown) must cover them */
+  position: relative;
+  z-index: 10;
+}
+
+.emb-plot-title {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.25;
+  min-width: 0;
+  flex: 1;
+}
+
+.emb-plot-title > * {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.emb-plot-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  flex-shrink: 0;
+}
+
+.emb-nowrap {
+  white-space: nowrap;
+}
+
+/* Compact pill-sized trigger: the Select root is w-full, so the width
+ * lives here; the inner input is styled like a full-size form Input */
+.emb-colorby {
+  width: 10.5rem;
+  flex-shrink: 0;
+}
+
+.emb-colorby input {
+  height: 2rem;
+  padding-top: 0;
+  padding-bottom: 0;
+  font-size: 0.875rem;
+}
+
+.emb-plot-divider {
+  height: 1.25rem;
+  width: 1px;
+  background: var(--emb-border-strong);
+  flex-shrink: 0;
+}
+
+.emb-mode-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.125rem;
+  border-radius: 0.375rem;
+  background: var(--emb-card-bg);
+  padding: 0.25rem;
+}
+
+.emb-mode-segment {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  border: none;
+  border-radius: 0.25rem;
+  background: transparent;
+  padding: 0.25rem 0.625rem;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.emb-mode-segment[data-active="true"] {
+  background: var(--emb-card-elevated);
+}
+
+.emb-plot-error {
+  padding: 0 1rem 0.5rem;
+  flex-shrink: 0;
+}
+
+.emb-plot-scene {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  margin: 0 1rem 1rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--emb-border-subtle);
+  background: color-mix(in srgb, var(--emb-card-bg) 30%, transparent);
+}
+
+.emb-plot-overlay {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  border-radius: 0.375rem;
+  background: color-mix(in srgb, var(--emb-bg) 70%, transparent);
+  backdrop-filter: blur(6px);
+  padding: 0.25rem 0.5rem;
+  z-index: 2;
+}
+
+.emb-plot-hint {
+  left: 0.75rem;
+  top: 0.75rem;
+  pointer-events: none;
+}
+
+/* Centered while the run's columns stream in */
+.emb-plot-loading {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+
+.emb-plot-chip {
+  left: 0.75rem;
+  top: 0.75rem;
+  /* Tighter than the generic overlay: hairline chip hugging its clear
+     button, count emphasized by weight and tone rather than color */
+  gap: 0.25rem;
+  padding: 0.125rem 0.25rem 0.125rem 0.5rem;
+}
+
+.emb-plot-chip strong {
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+  color: var(--emb-fg);
+}
+
+.emb-plot-counter {
+  left: 0.75rem;
+  bottom: 0.75rem;
+  pointer-events: none;
+}
+
+/* Color-by column fetch in flight; fixed-size slot beside the label */
+.emb-colorby-spinner {
+  display: inline-flex;
+  width: 1rem;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+/* --- FloatingPanel (generic; VOODO candidate) -------------------------- */
+
+.emb-floating-panel {
+  position: absolute;
+  z-index: 5;
+  display: flex;
+  flex-direction: column;
+  width: 13rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--emb-border-subtle);
+  background: color-mix(in srgb, var(--emb-card-bg) 92%, transparent);
+  backdrop-filter: blur(8px);
+}
+
+.emb-floating-panel-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.625rem;
+}
+
+.emb-floating-panel-grip {
+  display: flex;
+  align-items: center;
+  cursor: grab;
+  touch-action: none;
+  color: var(--emb-icon-muted);
+}
+
+.emb-floating-panel-grip:active {
+  cursor: grabbing;
+}
+
+.emb-floating-panel-title {
+  display: block;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.emb-floating-panel-body {
+  padding: 0 0.625rem 0.5rem;
+}
+
+.emb-floating-panel-footer {
+  border-top: 1px solid var(--emb-border-subtle);
+  padding: 0.5rem 0.625rem;
+}
+
+/* --- Floating color legend --------------------------------------------- */
+
+.emb-legend {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.emb-legend-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  max-height: 14rem;
+  overflow-y: auto;
+  /* overflow-y forces horizontal clipping at the padding box; the rows
+     bleed 0.25rem outside it (hover background) — widen the padding
+     box so it doesn't get cut */
+  margin: 0 -0.375rem;
+  padding: 0 0.375rem;
+}
+
+.emb-legend-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+  border: none;
+  background: transparent;
+  border-radius: 0.25rem;
+  padding: 0.125rem 0.25rem;
+  margin: 0 -0.25rem;
+  cursor: pointer;
+  text-align: left;
+  transition: background-color 0.15s ease;
+  /* Double-click isolates a class; without this it also selects text */
+  user-select: none;
+}
+
+.emb-legend-row:disabled {
+  cursor: default;
+}
+
+.emb-legend-row:focus {
+  /* Pointer clicks keep focus on the row; the default focus ring is
+     keyboard chrome, so reserve it for :focus-visible */
+  outline: none;
+}
+
+.emb-legend-row:focus-visible {
+  outline: 1px solid var(--emb-border-strong);
+}
+
+.emb-legend-row:hover:enabled {
+  background: var(--emb-card-elevated);
+}
+
+/* A class the field's filter hides */
+.emb-legend-row[data-off="true"] {
+  opacity: 0.4;
+}
+
+.emb-legend-swatch {
+  height: 0.5rem;
+  width: 0.5rem;
+  border-radius: 9999px;
+  flex-shrink: 0;
+}
+
+/* --- Continuous (spectrum) legend -------------------------------------- */
+
+.emb-legend-ramp {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  /* Match the categorical legend's row width so switching color-by
+     fields doesn't resize the floating panel */
+  min-width: 10rem;
+  padding: 0.25rem 0;
+}
+
+.emb-legend-ramp-track {
+  height: 0.375rem;
+  border-radius: 9999px;
+}
+
+.emb-legend-ramp-labels {
+  display: flex;
+  justify-content: space-between;
+  font-variant-numeric: tabular-nums;
+}
+
+.emb-legend-label {
+  display: block;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* --- Hover card --------------------------------------------------------- */
+
+.emb-hover-card {
+  position: absolute;
+  z-index: 3;
+  pointer-events: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  width: 10.5rem;
+  padding: 0.375rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--emb-border-subtle);
+  background: var(--emb-popover);
+  box-shadow: 0 4px 16px rgb(0 0 0 / 0.35);
+}
+
+.emb-hover-image {
+  display: block;
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+  border-radius: 0.25rem;
+}
+
+.emb-hover-value {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  min-width: 0;
+  padding: 0 0.125rem;
+}
+
+.emb-hover-text {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding: 0 0.125rem;
+}
+
+/* --- Runs page --------------------------------------------------------- */
+
+.emb-runs-page {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+.emb-runs-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  flex-shrink: 0;
+}
+
+.emb-runs-scroll {
+  position: relative;
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.75rem 0.75rem 1rem;
+}
+
+/* Centers content against the whole scroll area, out of the document
+   flow, so a banner above never pushes it — the empty state sits in
+   the same spot whether or not a banner shows. Pointer events pass
+   through the (mostly empty) overlay to keep the banner clickable */
+.emb-runs-overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.emb-runs-overlay > * {
+  pointer-events: auto;
+}
+
+.emb-runs-action-error {
+  padding: 0.75rem 0.25rem 0;
+}
+
+.emb-runs-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.emb-runs-center {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  gap: 0.75rem;
+}

--- a/app/packages/embeddings-v2/src/protocol.fetch.test.ts
+++ b/app/packages/embeddings-v2/src/protocol.fetch.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Decode-path tests for the fetch functions: buffer layouts, header
+ * flags, and dtype discrimination, against canned binary responses.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const fetchMock = vi.fn();
+vi.mock("@fiftyone/utilities", () => ({
+  getFetchFunction: () => fetchMock,
+}));
+
+import {
+  DTYPE_BITMASK,
+  DTYPE_F32,
+  DTYPE_U16,
+  FLAG_ALL_MATCH,
+  FLAG_ALL_VISIBLE,
+  HEADER_BYTES,
+  MAGIC,
+  fetchColor,
+  fetchGeometry,
+  fetchMasks,
+} from "./protocol";
+
+const makeColumn = (
+  dtype: number,
+  width: number,
+  n: number,
+  payload: Uint8Array,
+  flags = 0,
+): ArrayBuffer => {
+  const buffer = new ArrayBuffer(HEADER_BYTES + payload.byteLength);
+  const view = new DataView(buffer);
+  view.setUint32(0, MAGIC, true);
+  view.setUint16(4, 1, true);
+  view.setUint8(6, dtype);
+  view.setUint8(7, width);
+  view.setUint32(8, n, true);
+  view.setUint32(12, flags, true);
+  new Uint8Array(buffer, HEADER_BYTES).set(payload);
+  return buffer;
+};
+
+beforeEach(() => {
+  fetchMock.mockReset();
+});
+
+describe("fetchGeometry", () => {
+  it("splits planar columns into per-axis views", async () => {
+    const payload = new Uint8Array(2 * 4 * 3);
+    new Float32Array(payload.buffer).set([1, 2, 3, 10, 20, 30]);
+    fetchMock.mockResolvedValue(makeColumn(DTYPE_F32, 2, 3, payload));
+
+    const geometry = await fetchGeometry("d", "k");
+    expect(geometry.n).toBe(3);
+    expect(Array.from(geometry.columns[0])).toEqual([1, 2, 3]);
+    expect(Array.from(geometry.columns[1])).toEqual([10, 20, 30]);
+  });
+
+  it("rejects a non-f32 response", async () => {
+    fetchMock.mockResolvedValue(makeColumn(DTYPE_U16, 1, 1, new Uint8Array(2)));
+    await expect(fetchGeometry("d", "k")).rejects.toThrow(/f32/);
+  });
+});
+
+describe("fetchMasks", () => {
+  it("unpacks both masks from their offsets", async () => {
+    // n=10 -> 2 bytes per mask. visible: bits 0,1 set; match: bit 9 set
+    const payload = new Uint8Array([0b0000_0011, 0, 0, 0b0000_0010]);
+    fetchMock.mockResolvedValue(makeColumn(DTYPE_BITMASK, 2, 10, payload));
+
+    const masks = await fetchMasks("d", "k", [], null);
+    expect(Array.from(masks.visible!)).toEqual([1, 1, 0, 0, 0, 0, 0, 0, 0, 0]);
+    expect(Array.from(masks.match!)).toEqual([0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
+  });
+
+  it("returns null columns for the early-out flags", async () => {
+    fetchMock.mockResolvedValue(
+      makeColumn(
+        DTYPE_BITMASK,
+        2,
+        10,
+        new Uint8Array(4),
+        FLAG_ALL_VISIBLE | FLAG_ALL_MATCH,
+      ),
+    );
+
+    const masks = await fetchMasks("d", "k", [], null);
+    expect(masks.visible).toBeNull();
+    expect(masks.match).toBeNull();
+  });
+});
+
+/** Column bytes + a JSON tail, as /v2/color responds */
+const withTail = (column: Uint8Array, meta: object): Uint8Array => {
+  const tail = new TextEncoder().encode(JSON.stringify(meta));
+  const combined = new Uint8Array(column.byteLength + tail.byteLength);
+  combined.set(column);
+  combined.set(tail, column.byteLength);
+  return combined;
+};
+
+describe("fetchColor", () => {
+  it("splits a categorical response at the header-determined boundary", async () => {
+    const column = new Uint8Array(6);
+    new Uint16Array(column.buffer).set([0, 2, 0xffff]);
+    const meta = {
+      style: "categorical",
+      classes: [{ label: "cat", count: 2 }],
+      truncated: false,
+    };
+    fetchMock.mockResolvedValue(
+      makeColumn(DTYPE_U16, 1, 3, withTail(column, meta)),
+    );
+
+    const response = await fetchColor("d", "k", "f");
+    expect(response.values.style).toBe("categorical");
+    if (response.values.style === "categorical") {
+      expect(Array.from(response.values.indices)).toEqual([0, 2, 0xffff]);
+    }
+    expect(response.meta).toEqual(meta);
+  });
+
+  it("splits a continuous response and its min/max tail", async () => {
+    const column = new Uint8Array(8);
+    new Float32Array(column.buffer).set([0.5, 2.5]);
+    fetchMock.mockResolvedValue(
+      makeColumn(
+        DTYPE_F32,
+        1,
+        2,
+        withTail(column, { style: "continuous", min: 0.5, max: 2.5 }),
+      ),
+    );
+
+    const response = await fetchColor("d", "k", "f");
+    expect(response.values.style).toBe("continuous");
+    if (response.values.style === "continuous") {
+      expect(Array.from(response.values.values)).toEqual([0.5, 2.5]);
+    }
+    expect(response.meta.min).toBe(0.5);
+    expect(response.meta.max).toBe(2.5);
+  });
+});

--- a/app/packages/embeddings-v2/src/protocol.test.ts
+++ b/app/packages/embeddings-v2/src/protocol.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { DTYPE_F32, HEADER_BYTES, MAGIC, idAt, parseHeader } from "./protocol";
+
+const makeColumn = (
+  dtype: number,
+  width: number,
+  n: number,
+  payload: Uint8Array,
+  flags = 0,
+): ArrayBuffer => {
+  const buffer = new ArrayBuffer(HEADER_BYTES + payload.byteLength);
+  const view = new DataView(buffer);
+  view.setUint32(0, MAGIC, true);
+  view.setUint16(4, 1, true);
+  view.setUint8(6, dtype);
+  view.setUint8(7, width);
+  view.setUint32(8, n, true);
+  view.setUint32(12, flags, true);
+  new Uint8Array(buffer, HEADER_BYTES).set(payload);
+  return buffer;
+};
+
+describe("parseHeader", () => {
+  it("round-trips header fields", () => {
+    const buffer = makeColumn(DTYPE_F32, 2, 100, new Uint8Array(800), 3);
+    expect(parseHeader(buffer)).toEqual({
+      version: 1,
+      dtype: DTYPE_F32,
+      width: 2,
+      n: 100,
+      flags: 3,
+    });
+  });
+
+  // Version exists for exactly this: newer layouts must fail loudly,
+  // not decode as garbage
+  it("rejects an unsupported version", () => {
+    const buffer = new ArrayBuffer(16);
+    const view = new DataView(buffer);
+    view.setUint32(0, MAGIC, true);
+    view.setUint16(4, 2, true);
+    expect(() => parseHeader(buffer)).toThrow(/version/i);
+  });
+
+  it("rejects a bad magic", () => {
+    const buffer = makeColumn(DTYPE_F32, 1, 1, new Uint8Array(4));
+    new DataView(buffer).setUint32(0, 0xdeadbeef, true);
+    expect(() => parseHeader(buffer)).toThrow(/magic/);
+  });
+
+  it("rejects a truncated response", () => {
+    expect(() => parseHeader(new ArrayBuffer(4))).toThrow(/short/);
+  });
+});
+
+describe("unpackBits", () => {
+  it("unpacks little bit-order masks to bytes", async () => {
+    const { unpackBits } = await import("./protocol");
+    // bits 0, 2, 8 set across two bytes
+    const packed = new Uint8Array([0b0000_0101, 0b0000_0001]);
+    expect(Array.from(unpackBits(packed, 10))).toEqual([
+      1, 0, 1, 0, 0, 0, 0, 0, 1, 0,
+    ]);
+  });
+});
+
+describe("buildIdIndex", () => {
+  it("maps hex ids to wire indices, honoring the count cap", async () => {
+    const { buildIdIndex } = await import("./protocol");
+    const bytes = new Uint8Array(36);
+    bytes[11] = 1; // id 0 ends ...01
+    bytes[23] = 2; // id 1 ends ...02
+    // id 2 stays all zeros (an "unloaded" progressive slot)
+
+    const map = buildIdIndex(bytes, 2);
+    expect(map.size).toBe(2);
+    expect(map.get("000000000000000000000001")).toBe(0);
+    expect(map.get("000000000000000000000002")).toBe(1);
+    expect(map.get("000000000000000000000000")).toBeUndefined();
+  });
+});
+
+describe("idAt", () => {
+  it("decodes 12-byte ids to hex on demand", () => {
+    const bytes = new Uint8Array([
+      // id 0
+      0x65, 0x00, 0xff, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09,
+      // id 1
+      0xab, 0xcd, 0xef, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+    ]);
+    expect(idAt(bytes, 0)).toBe("6500ff010203040506070809");
+    expect(idAt(bytes, 1)).toBe("abcdef001122334455667788");
+  });
+});

--- a/app/packages/embeddings-v2/src/protocol.ts
+++ b/app/packages/embeddings-v2/src/protocol.ts
@@ -1,0 +1,376 @@
+/**
+ * Client for the `/embeddings/v2` column protocol.
+ *
+ * Binary responses share a 16-byte little-endian header
+ * (`u32 magic "FOE1" | u16 version | u8 dtype | u8 width | u32 n |
+ * u32 flags`) followed by `width` contiguous columns of `n` values in
+ * wire order — the brain run's row order, which is the join key for
+ * every per-point datum.
+ */
+import { getFetchFunction } from "@fiftyone/utilities";
+
+export const MAGIC = 0x464f4531; // "FOE1"
+export const VERSION = 1;
+export const HEADER_BYTES = 16;
+
+export const DTYPE_F32 = 1;
+export const DTYPE_U16 = 2;
+export const DTYPE_BITMASK = 3;
+export const DTYPE_BYTES12 = 4;
+
+export interface ColumnHeader {
+  version: number;
+  dtype: number;
+  width: number;
+  n: number;
+  flags: number;
+}
+
+export interface VisualizationRun {
+  brainKey: string;
+  method: string | null;
+  dims: number | null;
+  patchesField: string | null;
+  pointsField: string | null;
+  model: string | null;
+  /** The run's results blob exists (readiness says nothing about how a
+   * computation ended — only whether there is anything to load) */
+  ready: boolean;
+  timestamp: string | null;
+}
+
+export function parseHeader(buffer: ArrayBuffer): ColumnHeader {
+  if (buffer.byteLength < HEADER_BYTES) {
+    throw new Error(`Column response too short: ${buffer.byteLength} bytes`);
+  }
+  const view = new DataView(buffer);
+  const magic = view.getUint32(0, true);
+  if (magic !== MAGIC) {
+    throw new Error(`Bad column magic: 0x${magic.toString(16)}`);
+  }
+  // The version exists for exactly this: decoding a column laid out by
+  // a newer server would be silent corruption, not an error
+  const version = view.getUint16(4, true);
+  if (version !== VERSION) {
+    throw new Error(`Unsupported column version ${version}`);
+  }
+  return {
+    version,
+    dtype: view.getUint8(6),
+    width: view.getUint8(7),
+    n: view.getUint32(8, true),
+    flags: view.getUint32(12, true),
+  };
+}
+
+export interface Geometry {
+  n: number;
+  /** One Float32Array per axis, zero-copy views into the response */
+  columns: Float32Array[];
+}
+
+/** Raw 12-byte ObjectIds in wire order; decode lazily via idAt() */
+export type IdColumn = Uint8Array;
+
+export async function fetchRuns(
+  datasetName: string,
+): Promise<VisualizationRun[]> {
+  const response = await getFetchFunction()<
+    { datasetName: string },
+    { runs: (Omit<VisualizationRun, "ready"> & { ready?: boolean })[] }
+  >("POST", "/embeddings/v2/runs", { datasetName });
+  // Servers predating the flag omit it; absent means ready, or every
+  // run on an older deployment would render pending forever
+  return response.runs.map((run) => ({ ...run, ready: run.ready !== false }));
+}
+
+export interface RunInfo extends VisualizationRun {
+  n: number;
+}
+
+/** Also warms the server's results cache — call before column fetches */
+export async function fetchRunInfo(
+  datasetName: string,
+  brainKey: string,
+): Promise<RunInfo> {
+  const info = await getFetchFunction()<
+    Record<string, unknown>,
+    Omit<RunInfo, "ready"> & { ready?: boolean }
+  >("POST", "/embeddings/v2/run-info", { datasetName, brainKey });
+  // run-info answering at all implies loadable results; the endpoint
+  // doesn't send the flag
+  return { ...info, ready: info.ready !== false };
+}
+
+export interface Slice {
+  offset: number;
+  limit: number;
+}
+
+export async function fetchGeometry(
+  datasetName: string,
+  brainKey: string,
+  slice?: Slice,
+): Promise<Geometry> {
+  const buffer = await fetchColumn("/embeddings/v2/geometry", {
+    datasetName,
+    brainKey,
+    ...slice,
+  });
+  const header = parseHeader(buffer);
+  if (header.dtype !== DTYPE_F32) {
+    throw new Error(`Expected f32 geometry, got dtype ${header.dtype}`);
+  }
+
+  const { n, width } = header;
+  const columns: Float32Array[] = [];
+  for (let i = 0; i < width; i++) {
+    columns.push(new Float32Array(buffer, HEADER_BYTES + 4 * n * i, n));
+  }
+  return { n, columns };
+}
+
+export async function fetchIds(
+  datasetName: string,
+  brainKey: string,
+  slice?: Slice,
+): Promise<IdColumn> {
+  const buffer = await fetchColumn("/embeddings/v2/ids", {
+    datasetName,
+    brainKey,
+    ...slice,
+  });
+  const header = parseHeader(buffer);
+  if (header.dtype !== DTYPE_BYTES12) {
+    throw new Error(`Expected id bytes, got dtype ${header.dtype}`);
+  }
+  return new Uint8Array(buffer, HEADER_BYTES, header.n * 12);
+}
+
+// Byte -> two hex chars, precomputed
+const HEX: string[] = Array.from({ length: 256 }, (_, byte) =>
+  byte.toString(16).padStart(2, "0"),
+);
+
+/**
+ * Decodes the id at a wire-order index to its hex string. On-demand by
+ * design: the column stays raw bytes and only ids that are actually
+ * used (clicked, hovered, listed) ever become strings.
+ */
+export function idAt(ids: IdColumn, index: number): string {
+  const start = index * 12;
+  let id = "";
+  for (let i = start; i < start + 12; i++) {
+    id += HEX[ids[i]];
+  }
+  return id;
+}
+
+export interface ColorMeta {
+  style: "categorical" | "continuous";
+  classes?: { label: string | number | boolean; count: number }[];
+  truncated?: boolean;
+  /** Each point's column value IS its full field value (no list
+   * flattening) — the precondition for evaluating filters against the
+   * column client-side */
+  exact?: boolean;
+  min?: number | null;
+  max?: number | null;
+}
+
+export type ColorValues =
+  | { style: "categorical"; indices: Uint16Array }
+  | { style: "continuous"; values: Float32Array };
+
+/** Fields eligible for color-by (via the legacy schema-only endpoint) */
+export async function fetchColorByChoices(
+  datasetName: string,
+  patchesField: string | null,
+): Promise<string[]> {
+  const response = await getFetchFunction()<
+    Record<string, unknown>,
+    { fields: string[] }
+  >("POST", "/embeddings/color-by-choices", {
+    datasetName,
+    view: [],
+    slices: null,
+    patchesField,
+  });
+  return response.fields;
+}
+
+export interface ColorResponse {
+  values: ColorValues;
+  meta: ColorMeta;
+}
+
+/**
+ * The color-by column and its legend meta in one response. The 16-byte
+ * header determines the column's extent (`n` values of the dtype's
+ * width), and every byte after the column is a UTF-8 JSON tail — no
+ * delimiter is needed. One request drives one server-side values
+ * aggregation, which produces both the column and the meta.
+ */
+export async function fetchColor(
+  datasetName: string,
+  brainKey: string,
+  field: string,
+): Promise<ColorResponse> {
+  const buffer = await fetchColumn("/embeddings/v2/color", {
+    datasetName,
+    brainKey,
+    field,
+  });
+  const header = parseHeader(buffer);
+  const bytesPerValue =
+    header.dtype === DTYPE_U16 ? 2 : header.dtype === DTYPE_F32 ? 4 : null;
+  if (bytesPerValue === null) {
+    throw new Error(`Unexpected color dtype ${header.dtype}`);
+  }
+
+  const tailStart = HEADER_BYTES + header.n * bytesPerValue;
+  const meta = JSON.parse(
+    new TextDecoder().decode(new Uint8Array(buffer, tailStart)),
+  ) as ColorMeta;
+
+  const values: ColorValues =
+    header.dtype === DTYPE_U16
+      ? {
+          style: "categorical",
+          indices: new Uint16Array(buffer, HEADER_BYTES, header.n),
+        }
+      : {
+          style: "continuous",
+          values: new Float32Array(buffer, HEADER_BYTES, header.n),
+        };
+  return { values, meta };
+}
+
+export const FLAG_ALL_VISIBLE = 1;
+export const FLAG_ALL_MATCH = 2;
+
+export interface Masks {
+  /** Point's sample is in the current view; null = everything visible */
+  visible: Uint8Array | null;
+  /** Point survives the sidebar filters; null = everything matches */
+  match: Uint8Array | null;
+}
+
+/**
+ * The run's visible/match bitmasks for the current view + filters,
+ * unpacked to one byte per point (null when the header's early-out
+ * flags say a column is all ones).
+ */
+export async function fetchMasks(
+  datasetName: string,
+  brainKey: string,
+  view: unknown[],
+  filters: unknown,
+): Promise<Masks> {
+  const buffer = await fetchColumn("/embeddings/v2/masks", {
+    datasetName,
+    brainKey,
+    view,
+    filters,
+    slices: null,
+  });
+  const header = parseHeader(buffer);
+  if (header.dtype !== DTYPE_BITMASK) {
+    throw new Error(`Expected bitmasks, got dtype ${header.dtype}`);
+  }
+
+  const { n, flags } = header;
+  const nbytes = Math.ceil(n / 8);
+  return {
+    visible:
+      flags & FLAG_ALL_VISIBLE
+        ? null
+        : unpackBits(new Uint8Array(buffer, HEADER_BYTES, nbytes), n),
+    match:
+      flags & FLAG_ALL_MATCH
+        ? null
+        : unpackBits(new Uint8Array(buffer, HEADER_BYTES + nbytes, nbytes), n),
+  };
+}
+
+/** Little bit-order bitmask -> one 0/1 byte per point */
+export function unpackBits(packed: Uint8Array, n: number): Uint8Array {
+  const out = new Uint8Array(n);
+  for (let i = 0; i < n; i++) {
+    out[i] = (packed[i >> 3] >> (i & 7)) & 1;
+  }
+  return out;
+}
+
+export interface LassoStage {
+  _cls: string;
+  kwargs: Record<string, unknown>;
+  count: number | null;
+}
+
+/**
+ * Resolves a lasso to a serialized view stage. Selections travel as the
+ * data-space polygon (constant size, resolved server-side) — indices are
+ * the fallback for cameras without an exact screen -> data mapping. Id
+ * lists never go over the wire.
+ */
+export async function fetchLassoStage(
+  datasetName: string,
+  brainKey: string,
+  view: unknown[],
+  selection: { polygon: Array<[number, number]> } | { indices: number[] },
+): Promise<LassoStage> {
+  return getFetchFunction()<Record<string, unknown>, LassoStage>(
+    "POST",
+    "/embeddings/v2/lasso-stage",
+    { datasetName, brainKey, view, slices: null, ...selection },
+  );
+}
+
+export interface SampleInfo {
+  id: string;
+  sampleId: string;
+  filepath: string | null;
+  /** Feed through the App's getSampleSrc(); null = no hover media */
+  media: string | null;
+  value: unknown;
+}
+
+export async function fetchSampleInfo(
+  datasetName: string,
+  brainKey: string,
+  index: number,
+  field: string | null,
+): Promise<SampleInfo> {
+  return getFetchFunction()<Record<string, unknown>, SampleInfo>(
+    "POST",
+    "/embeddings/v2/sample-info",
+    { datasetName, brainKey, index, field },
+  );
+}
+
+/** Id -> wire-order-index map over the first `count` (default: all)
+ * entries, for styling external selections */
+export function buildIdIndex(
+  ids: IdColumn,
+  count?: number,
+): Map<string, number> {
+  const n = count ?? ids.length / 12;
+  const map = new Map<string, number>();
+  for (let i = 0; i < n; i++) {
+    map.set(idAt(ids, i), i);
+  }
+  return map;
+}
+
+async function fetchColumn(
+  path: string,
+  body: Record<string, unknown>,
+): Promise<ArrayBuffer> {
+  return getFetchFunction()<Record<string, unknown>, ArrayBuffer>(
+    "POST",
+    path,
+    body,
+    "arrayBuffer",
+  );
+}

--- a/app/packages/embeddings-v2/src/renderer/ChartTooltip.tsx
+++ b/app/packages/embeddings-v2/src/renderer/ChartTooltip.tsx
@@ -1,0 +1,44 @@
+import type { HoverHit } from "./types";
+
+export interface TooltipState {
+  hit: HoverHit;
+  /** Flip the tooltip left/up when the point sits past the midlines */
+  flipX: boolean;
+  flipY: boolean;
+}
+
+interface ChartTooltipProps {
+  state: TooltipState;
+  /** Sample image URL for a point index; omit for text-only tooltips */
+  thumbUrl?: (index: number) => string;
+}
+
+/**
+ * Hover tooltip anchored to the hovered point (not the cursor).
+ * Display-only: pointer-events none, so it can never steal the hover
+ * it's anchored to. Styles live in embeddings.css.
+ */
+export function ChartTooltip({ state, thumbUrl }: ChartTooltipProps) {
+  const { hit, flipX, flipY } = state;
+  return (
+    <div
+      className="embeddings-renderer-tooltip"
+      style={{
+        left: hit.x,
+        top: hit.y,
+        transform: `translate(${flipX ? "calc(-100% - 12px)" : "12px"}, ${
+          flipY ? "calc(-100% - 12px)" : "12px"
+        })`,
+      }}
+    >
+      {thumbUrl && (
+        // key remounts the img per point so a stale thumbnail never
+        // lingers while the next one loads
+        <img key={hit.index} src={thumbUrl(hit.index)} alt="" />
+      )}
+      <div className="embeddings-renderer-tooltip-meta">
+        {hit.label} · {hit.id}
+      </div>
+    </div>
+  );
+}

--- a/app/packages/embeddings-v2/src/renderer/EmbeddingsChart.ts
+++ b/app/packages/embeddings-v2/src/renderer/EmbeddingsChart.ts
@@ -1,0 +1,595 @@
+import {
+  BufferAttribute,
+  BufferGeometry,
+  CustomBlending,
+  DynamicDrawUsage,
+  Matrix4,
+  NormalBlending,
+  OneFactor,
+  Points,
+  RawShaderMaterial,
+  Scene,
+  Sphere,
+  Vector3,
+  WebGLRenderer,
+} from "three";
+import { PlanarCamera } from "./cameras/PlanarCamera";
+import {
+  buildColumns,
+  colorsFromLabels,
+  visibleBounds,
+  type Columns,
+} from "./columns";
+import {
+  DEFAULT_SETTINGS,
+  EMPHASIS_SIZE_PX,
+  HOVER_RADIUS_PX,
+  PALETTE,
+  POINT_SIZE,
+} from "./constants";
+import { ClickDetector } from "./interaction/ClickDetector";
+import { HoverPicker } from "./interaction/HoverPicker";
+import { LassoOverlay } from "./interaction/LassoOverlay";
+import { nearestPoint, selectInPolygon } from "./math";
+import { SelectionLayers } from "./selectionLayers";
+import { DensityPipeline } from "./pipeline";
+import {
+  EMPHASIS_FRAGMENT,
+  EMPHASIS_VERTEX,
+  POINTS_FRAGMENT,
+  POINTS_VERTEX,
+} from "./shaders";
+import type {
+  CameraAdapter,
+  CameraAdapterFactory,
+  EmbeddingPoint,
+  HoverHit,
+  InteractionMode,
+  Polygon,
+  RenderSettings,
+} from "./types";
+
+export interface EmbeddingsChartCallbacks {
+  /**
+   * Point indices selected by the lasso (empty = cleared), plus the
+   * lasso polygon in data space when the active camera adapter can
+   * provide one — hosts resolve selections server-side from the tiny
+   * polygon instead of materializing id lists. External selections
+   * applied via setSelected() do NOT echo through this.
+   */
+  onSelection?: (
+    indices: number[],
+    dataPolygon?: Array<[number, number]> | null,
+  ) => void;
+  /** Debounced hover hit, or null the moment hovering breaks */
+  onHover?: (hit: HoverHit | null) => void;
+  /**
+   * A plain click landed on a point. The chart does not change its own
+   * selection for point clicks — the host owns click semantics (toggle,
+   * replace, open, …). Plain clicks on empty space clear the lasso
+   * layer (a host-layer selection resurfaces; the host clears its own
+   * state through its own paths).
+   */
+  onPointClick?: (hit: HoverHit) => void;
+  /**
+   * A plain click landed on empty space, after the chart cleared its
+   * selection and echoed onSelection([]) — for hosts that clear their
+   * own layers (filters, chrome) beyond the selection.
+   */
+  onBackgroundClick?: () => void;
+}
+
+export interface EmbeddingsChartOptions {
+  /**
+   * Camera adapter for data whose points carry a z value. Without it,
+   * z is ignored and the data renders flat with the built-in planar
+   * camera.
+   */
+  zCamera?: CameraAdapterFactory;
+}
+
+/**
+ * The embeddings renderer: one gl.POINTS draw call of typed arrays in
+ * data space, custom GLSL for styling and density, and a pluggable
+ * camera adapter (built-in planar by default). All vanilla three.js and
+ * DOM, no React — any host can drive it directly.
+ *
+ * Host API: setData / setColors / setVisible / setSelected /
+ * clearSelection / setRenderSettings. Selection renders one emphasis
+ * channel fed by two retained layers — the host's (setSelected) and the
+ * lasso's — composed most-recent-writer-wins (selectionLayers.ts).
+ * Non-members recede (dim + desaturate) and the selected points redraw
+ * at full opacity in an overlay pass above the composite, where
+ * blending cannot swallow them. Visibility is a
+ * second, independent mechanism (view-stage subsetting): hidden points
+ * don't render and can't be hovered, clicked, or lassoed.
+ */
+export class EmbeddingsChart {
+  private readonly container: HTMLElement;
+  private readonly callbacks: EmbeddingsChartCallbacks;
+  private readonly zCamera: CameraAdapterFactory | null;
+  private readonly canvas: HTMLCanvasElement;
+  private readonly renderer: WebGLRenderer;
+  private readonly scene = new Scene();
+  private readonly points: Points;
+  private readonly material: RawShaderMaterial;
+  // Selected points draw a second time, over the composite (own scene:
+  // they must not join the density accumulation)
+  private readonly overlayScene = new Scene();
+  private readonly emphasisPoints: Points;
+  private readonly emphasisMaterial: RawShaderMaterial;
+  private hasSelection = false;
+  private readonly selection = new SelectionLayers();
+  private readonly pipeline = new DensityPipeline();
+  private readonly lasso: LassoOverlay;
+  private readonly picker: HoverPicker;
+  private readonly clicks: ClickDetector;
+  private readonly resizeObserver: ResizeObserver;
+  private readonly listeners = new AbortController();
+  private readonly viewProjection = new Matrix4();
+
+  private adapter: CameraAdapter | null = null;
+  private adapterHasZ = false;
+  private cols: Columns | null = null;
+  private colorAttribute: BufferAttribute | null = null;
+  private emphasisMask = new Float32Array(0);
+  private emphasisAttribute: BufferAttribute | null = null;
+  /** Null means all points visible (no unpacked mask to scan) */
+  private visibleMask: Uint8Array | null = null;
+  private visibleAttribute: BufferAttribute | null = null;
+  private settings: RenderSettings = DEFAULT_SETTINGS;
+  private interactionMode: InteractionMode = "select";
+  private width = 0;
+  private height = 0;
+  private renderQueued = false;
+  private rafHandle: number | null = null;
+  private disposed = false;
+
+  constructor(
+    container: HTMLElement,
+    callbacks: EmbeddingsChartCallbacks = {},
+    options: EmbeddingsChartOptions = {},
+  ) {
+    this.container = container;
+    this.callbacks = callbacks;
+    this.zCamera = options.zCamera ?? null;
+
+    if (getComputedStyle(container).position === "static") {
+      container.style.position = "relative";
+    }
+
+    // Sized by CSS; the drawing buffer follows in resize()
+    this.canvas = document.createElement("canvas");
+    Object.assign(this.canvas.style, {
+      position: "absolute",
+      inset: "0",
+      width: "100%",
+      height: "100%",
+    });
+    container.prepend(this.canvas);
+
+    this.renderer = new WebGLRenderer({
+      canvas: this.canvas,
+      alpha: true,
+      // No MSAA: the fragment shader anti-aliases circle edges
+      antialias: false,
+      powerPreference: "high-performance",
+    });
+    this.renderer.setPixelRatio(window.devicePixelRatio || 1);
+    this.renderer.sortObjects = false;
+    this.renderer.setClearColor(0x000000, 0);
+
+    this.material = new RawShaderMaterial({
+      vertexShader: POINTS_VERTEX,
+      fragmentShader: POINTS_FRAGMENT,
+      uniforms: {
+        uPointSize: { value: POINT_SIZE * (window.devicePixelRatio || 1) },
+        uHasSelection: { value: 0 },
+        uMode: { value: 1 },
+        uOpacity: { value: DEFAULT_SETTINGS.singleAlpha },
+      },
+      // Density accumulation: additive ONE/ONE on color and alpha
+      // (setRenderSettings swaps blending/depth state per mode)
+      transparent: true,
+      blending: CustomBlending,
+      blendSrc: OneFactor,
+      blendDst: OneFactor,
+      blendSrcAlpha: OneFactor,
+      blendDstAlpha: OneFactor,
+      depthTest: false,
+      depthWrite: false,
+    });
+    this.points = new Points(new BufferGeometry(), this.material);
+    this.points.frustumCulled = false;
+    this.scene.add(this.points);
+
+    this.emphasisMaterial = new RawShaderMaterial({
+      vertexShader: EMPHASIS_VERTEX,
+      fragmentShader: EMPHASIS_FRAGMENT,
+      uniforms: {
+        uPointSize: {
+          value:
+            (POINT_SIZE + EMPHASIS_SIZE_PX) * (window.devicePixelRatio || 1),
+        },
+      },
+      // Plain alpha compositing over the finished frame, no depth
+      transparent: true,
+      depthTest: false,
+      depthWrite: false,
+    });
+    // The geometry is shared with the main pass — the emphasis shader
+    // clips out everything that isn't selected
+    this.emphasisPoints = new Points(
+      this.points.geometry,
+      this.emphasisMaterial,
+    );
+    this.emphasisPoints.frustumCulled = false;
+    this.overlayScene.add(this.emphasisPoints);
+
+    this.lasso = new LassoOverlay(container, {
+      shouldStart: (event) => this.adapter?.isLassoStart(event) ?? false,
+      onComplete: (polygon, x, y) => this.handleLasso(polygon, x, y),
+    });
+    this.picker = new HoverPicker(container, {
+      isBlocked: () => this.lasso.isDrawing(),
+      pick: (x, y) => this.pick(x, y),
+      onHover: (hit) => this.callbacks.onHover?.(hit),
+    });
+    // Covers plain clicks the lasso doesn't own (camera adapters that use
+    // plain drags to move the camera); with the planar camera, plain
+    // clicks arrive through the lasso's onComplete(null) instead
+    this.clicks = new ClickDetector(container, {
+      onClick: (x, y) => this.handleClick(x, y),
+    });
+
+    container.addEventListener(
+      "dblclick",
+      () => {
+        this.adapter?.reset();
+        this.requestRender();
+      },
+      { signal: this.listeners.signal },
+    );
+
+    this.resizeObserver = new ResizeObserver(() => this.resize());
+    this.resizeObserver.observe(container);
+    this.resize();
+  }
+
+  /**
+   * Rebuild GPU buffers for a new dataset. The camera adapter follows
+   * the data: points carrying a z use the host's zCamera when provided;
+   * otherwise z is ignored and the built-in planar camera renders the
+   * data flat. Colors reset to the default label palette and all points
+   * become visible until setColors/setVisible.
+   */
+  setData(points: EmbeddingPoint[]): void {
+    // Without a zCamera, flatten z at the column level so the data
+    // renders flat instead of clipping against the planar frustum
+    const cols = buildColumns(points, this.zCamera === null);
+    this.cols = cols;
+
+    const positions = new Float32Array(cols.n * 3);
+    for (let i = 0; i < cols.n; i++) {
+      positions[i * 3] = cols.xs[i];
+      positions[i * 3 + 1] = cols.ys[i];
+      positions[i * 3 + 2] = cols.zs[i];
+    }
+    this.points.geometry.dispose();
+    const geometry = new BufferGeometry();
+    geometry.setAttribute("position", new BufferAttribute(positions, 3));
+    this.colorAttribute = new BufferAttribute(
+      colorsFromLabels(cols, PALETTE),
+      3,
+    );
+    geometry.setAttribute("color", this.colorAttribute);
+    this.emphasisMask = new Float32Array(cols.n);
+    this.emphasisAttribute = new BufferAttribute(this.emphasisMask, 1).setUsage(
+      DynamicDrawUsage,
+    );
+    geometry.setAttribute("emphasis", this.emphasisAttribute);
+    this.visibleMask = null;
+    this.visibleAttribute = new BufferAttribute(
+      new Uint8Array(cols.n).fill(1),
+      1,
+    ).setUsage(DynamicDrawUsage);
+    geometry.setAttribute("visible", this.visibleAttribute);
+    // Pre-set so nothing ever calls computeBoundingSphere() at render
+    // time (the camera adapters own all framing anyway)
+    geometry.boundingSphere = new Sphere(new Vector3(0, 0, 0), 1);
+    this.points.geometry = geometry;
+    this.emphasisPoints.geometry = geometry;
+    this.clearSelection();
+
+    this.ensureAdapter(cols.hasZ);
+    this.adapter?.setBounds(cols, this.width, this.height);
+    this.picker.reset();
+    this.requestRender();
+    this.callbacks.onSelection?.([]);
+  }
+
+  /**
+   * Per-point colors as flat rgb triplets in [0, 1] — class palettes,
+   * scalar colormaps, anything; the shader has no concept of labels.
+   * Null restores the default label palette (the uncolored state).
+   */
+  setColors(colors: Float32Array | null): void {
+    const { cols, colorAttribute } = this;
+    if (!cols || !colorAttribute) return;
+    const next = colors ?? colorsFromLabels(cols, PALETTE);
+    if (next.length !== cols.n * 3) {
+      throw new Error(
+        `setColors expects ${cols.n * 3} floats (n·rgb), got ${next.length}`,
+      );
+    }
+    (colorAttribute.array as Float32Array).set(next);
+    colorAttribute.needsUpdate = true;
+    this.requestRender();
+  }
+
+  /**
+   * Per-point visibility as 0/1 bytes (null = all visible) — in FiftyOne
+   * terms, the current view's membership mask. Hidden points are clipped
+   * in the vertex shader and skipped by every hit-test. The current view
+   * never moves when visibility changes, but the camera's FOCUS follows
+   * the visible subset: reset() re-frames to it, and orbit-style cameras
+   * pivot around it.
+   */
+  setVisible(mask: Uint8Array | null): void {
+    const { cols, visibleAttribute } = this;
+    if (!cols || !visibleAttribute) return;
+    if (mask && mask.length !== cols.n) {
+      throw new Error(
+        `setVisible expects ${cols.n} bytes (one per point), got ${mask.length}`,
+      );
+    }
+    const array = visibleAttribute.array as Uint8Array;
+    if (mask) {
+      array.set(mask);
+      // Point hit-tests at the chart-owned copy the GPU renders from —
+      // holding the caller's array would let later caller mutations
+      // desynchronize picking from what's drawn
+      this.visibleMask = array;
+    } else {
+      array.fill(1);
+      this.visibleMask = null;
+    }
+    if (this.adapter?.setFocus) {
+      // An empty visible subset keeps the previous focus — framing
+      // nothing helps no one
+      const focus = mask ? visibleBounds(cols, mask) : null;
+      if (!mask || focus) this.adapter.setFocus(focus);
+    }
+    visibleAttribute.needsUpdate = true;
+    // The point under a still cursor may just have vanished (or appeared)
+    this.picker.viewChanged();
+    this.requestRender();
+  }
+
+  /**
+   * The HOST selection layer, by index (null clears the layer). The
+   * chart's own lasso keeps a separate layer beneath it: the most
+   * recent writer renders, and clearing this layer restores a live
+   * lasso instead of erasing it (see selectionLayers.ts). Members keep
+   * their exact color and size, everything else dims.
+   */
+  setSelected(indices: ArrayLike<number> | null): void {
+    this.applySelection(this.selection.writeHost(indices));
+  }
+
+  /** Drop every selection layer (host and lasso) */
+  clearSelection(): void {
+    this.applySelection(this.selection.clear());
+  }
+
+  /** Push the composed selection into the emphasis channel */
+  private applySelection(indices: ArrayLike<number> | null): void {
+    const { cols, emphasisAttribute } = this;
+    if (!cols || !emphasisAttribute) return;
+    this.emphasisMask.fill(0);
+    if (indices) {
+      for (let i = 0; i < indices.length; i++) {
+        const index = indices[i];
+        if (index >= 0 && index < cols.n) this.emphasisMask[index] = 1;
+      }
+    }
+    this.hasSelection = indices !== null;
+    this.material.uniforms.uHasSelection.value = this.hasSelection ? 1 : 0;
+    emphasisAttribute.needsUpdate = true;
+    this.requestRender();
+  }
+
+  /** Snap the camera back to its home framing */
+  resetCamera(): void {
+    this.adapter?.reset();
+    this.requestRender();
+  }
+
+  /** Hand plain drags to the lasso ("select") or the camera ("explore") */
+  setInteractionMode(mode: InteractionMode): void {
+    this.interactionMode = mode;
+    this.adapter?.setMode?.(mode);
+    this.applyCursor();
+  }
+
+  /** Compositing mode + tone map parameters, applied live */
+  setRenderSettings(settings: RenderSettings): void {
+    this.settings = settings;
+    const { mode, singleAlpha } = settings;
+    const opaque = mode === "opaque";
+    this.material.uniforms.uMode.value =
+      mode === "density" ? 1 : opaque ? 2 : 0;
+    // density accumulates additively (ONE/ONE); alpha and opaque both
+    // composite with src-alpha — opaque adds the depth test/write
+    this.material.blending =
+      mode === "density" ? CustomBlending : NormalBlending;
+    this.material.depthTest = opaque;
+    this.material.depthWrite = opaque;
+    // In opaque mode the same knob doubles as per-point opacity
+    this.material.uniforms.uOpacity.value = singleAlpha;
+    this.pipeline.applySettings(settings);
+    this.requestRender();
+  }
+
+  /** Full teardown; forceContextLoss releases the GL context immediately */
+  destroy(): void {
+    // A queued frame after disposal would render with disposed GL state
+    this.disposed = true;
+    if (this.rafHandle !== null) {
+      cancelAnimationFrame(this.rafHandle);
+      this.rafHandle = null;
+    }
+    this.picker.destroy();
+    this.lasso.destroy();
+    this.clicks.destroy();
+    this.adapter?.destroy();
+    this.listeners.abort();
+    this.resizeObserver.disconnect();
+    this.points.geometry.dispose();
+    this.material.dispose();
+    this.emphasisMaterial.dispose();
+    this.pipeline.dispose();
+    this.renderer.dispose();
+    this.renderer.forceContextLoss();
+    this.canvas.remove();
+  }
+
+  /** Swap the camera adapter when the data's shape changes */
+  private ensureAdapter(hasZ: boolean): void {
+    if (this.adapter && this.adapterHasZ === hasZ) return;
+    this.adapter?.destroy();
+    const onChange = () => {
+      this.requestRender();
+      this.picker.viewChanged();
+    };
+    this.adapter =
+      hasZ && this.zCamera
+        ? this.zCamera(this.container, onChange)
+        : new PlanarCamera(this.container, onChange);
+    this.adapter.setMode?.(this.interactionMode);
+    this.adapterHasZ = hasZ;
+    this.applyCursor();
+  }
+
+  /**
+   * Crosshair advertises the plain-drag lasso, grab the plain-drag pan;
+   * injected adapters without modes keep the default cursor.
+   */
+  private applyCursor(): void {
+    if (!this.adapter?.setMode) {
+      this.container.style.cursor = "";
+      return;
+    }
+    this.container.style.cursor =
+      this.interactionMode === "select" ? "crosshair" : "grab";
+  }
+
+  /** The vertex shader's projection, for CPU-side hit-testing */
+  private currentViewProjection(): ArrayLike<number> | null {
+    const camera = this.adapter?.camera;
+    if (!camera) return null;
+    camera.updateMatrixWorld();
+    return this.viewProjection.multiplyMatrices(
+      camera.projectionMatrix,
+      camera.matrixWorldInverse,
+    ).elements;
+  }
+
+  private pick(x: number, y: number): HoverHit | null {
+    const { cols } = this;
+    const m = this.currentViewProjection();
+    if (!cols || !m) return null;
+    return nearestPoint(
+      cols,
+      m,
+      this.width,
+      this.height,
+      x,
+      y,
+      HOVER_RADIUS_PX,
+      this.visibleMask,
+    );
+  }
+
+  private handleLasso(polygon: Polygon | null, x: number, y: number): void {
+    if (!polygon) {
+      // Too short to enclose anything: the gesture was a click
+      this.handleClick(x, y);
+      return;
+    }
+    const { cols } = this;
+    const m = this.currentViewProjection();
+    if (!cols || !m) return;
+    const indices = selectInPolygon(
+      cols,
+      m,
+      this.width,
+      this.height,
+      polygon,
+      this.visibleMask,
+    );
+    this.applySelection(
+      this.selection.writeLasso(indices.length > 0 ? indices : null),
+    );
+    this.callbacks.onSelection?.(
+      indices,
+      this.adapter?.toDataPolygon?.(polygon) ?? null,
+    );
+  }
+
+  /** Point hit → the host decides; empty space → clear, as ever */
+  private handleClick(x: number, y: number): void {
+    const hit = this.pick(x, y);
+    if (hit && this.callbacks.onPointClick) {
+      this.callbacks.onPointClick(hit);
+      return;
+    }
+    this.applySelection(this.selection.writeLasso(null));
+    this.callbacks.onSelection?.([]);
+    // A point hit with no onPointClick host falls through to the clear
+    // above, but it is not a background click
+    if (!hit) this.callbacks.onBackgroundClick?.();
+  }
+
+  private resize(): void {
+    const width = this.container.clientWidth || 1;
+    const height = this.container.clientHeight || 1;
+    if (width === this.width && height === this.height) return;
+    this.width = width;
+    this.height = height;
+    const dpr = window.devicePixelRatio || 1;
+    // updateStyle=false: CSS owns the canvas size (see constructor)
+    this.renderer.setSize(width, height, false);
+    this.pipeline.setSize(Math.round(width * dpr), Math.round(height * dpr));
+    this.adapter?.resize(width, height);
+    this.requestRender();
+  }
+
+  /** Coalesce render requests into one render per animation frame */
+  private requestRender(): void {
+    if (this.renderQueued || this.disposed) return;
+    this.renderQueued = true;
+    this.rafHandle = requestAnimationFrame(() => {
+      this.rafHandle = null;
+      this.renderQueued = false;
+      this.render();
+    });
+  }
+
+  private render(): void {
+    const camera = this.adapter?.camera;
+    if (!camera) return;
+    this.pipeline.render(
+      this.renderer,
+      this.scene,
+      camera,
+      this.settings.mode === "density",
+    );
+    if (this.hasSelection) {
+      // Composite the selection markers over the finished frame
+      this.renderer.autoClear = false;
+      this.renderer.render(this.overlayScene, camera);
+      this.renderer.autoClear = true;
+    }
+  }
+}

--- a/app/packages/embeddings-v2/src/renderer/EmbeddingsView.test.tsx
+++ b/app/packages/embeddings-v2/src/renderer/EmbeddingsView.test.tsx
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EmbeddingsView } from "./EmbeddingsView";
+import type { EmbeddingPoint } from "./types";
+
+// The chart needs a real WebGL context; for wrapper plumbing tests a
+// call recorder is the whole point
+const instances: MockChart[] = [];
+class MockChart {
+  setData = vi.fn();
+  setColors = vi.fn();
+  setVisible = vi.fn();
+  setSelected = vi.fn();
+  clearSelection = vi.fn();
+  setRenderSettings = vi.fn();
+  setInteractionMode = vi.fn();
+  resetCamera = vi.fn();
+  destroy = vi.fn();
+  constructor() {
+    instances.push(this);
+  }
+}
+vi.mock("./EmbeddingsChart", () => ({ EmbeddingsChart: MockChart }));
+
+// Stale instances let a test observe the PREVIOUS test's chart before
+// its own lazy import resolves
+beforeEach(() => {
+  instances.length = 0;
+});
+
+const POINTS: EmbeddingPoint[] = [
+  { id: "a", x: 0, y: 0, label: null },
+  { id: "b", x: 1, y: 1, label: null },
+];
+
+describe("EmbeddingsView prop plumbing", () => {
+  it("forwards data, visibility, and selection to the chart in order", async () => {
+    const visible = new Uint8Array([1, 0]);
+    render(<EmbeddingsView points={POINTS} visible={visible} selected={[1]} />);
+
+    await waitFor(() => expect(instances.length).toBeGreaterThan(0));
+    const chart = instances[instances.length - 1];
+
+    await waitFor(() => expect(chart.setVisible).toHaveBeenCalled());
+    expect(chart.setData).toHaveBeenCalledWith(POINTS);
+    expect(chart.setVisible).toHaveBeenLastCalledWith(visible);
+    expect(chart.setSelected).toHaveBeenLastCalledWith([1]);
+
+    // setData must precede setVisible (setData resets the mask)
+    const dataOrder = chart.setData.mock.invocationCallOrder[0];
+    const visibleOrder =
+      chart.setVisible.mock.invocationCallOrder[
+        chart.setVisible.mock.calls.length - 1
+      ];
+    expect(dataOrder).toBeLessThan(visibleOrder);
+  });
+
+  it("applies a visibility mask that arrives after mount", async () => {
+    const { rerender } = render(<EmbeddingsView points={POINTS} />);
+    await waitFor(() => expect(instances.length).toBeGreaterThan(0));
+    const chart = instances[instances.length - 1];
+    await waitFor(() => expect(chart.setData).toHaveBeenCalled());
+
+    const visible = new Uint8Array([0, 1]);
+    rerender(<EmbeddingsView points={POINTS} visible={visible} />);
+    await waitFor(() =>
+      expect(chart.setVisible).toHaveBeenLastCalledWith(visible),
+    );
+  });
+
+  it("exposes camera reset and selection clearing through the handle", async () => {
+    const ref = {
+      current: null as null | {
+        resetCamera(): void;
+        clearSelection(): void;
+      },
+    };
+    render(<EmbeddingsView ref={ref} points={POINTS} />);
+    await waitFor(() => expect(instances.length).toBeGreaterThan(0));
+    const chart = instances[instances.length - 1];
+    await waitFor(() => expect(ref.current).not.toBeNull());
+
+    ref.current?.resetCamera();
+    expect(chart.resetCamera).toHaveBeenCalled();
+
+    ref.current?.clearSelection();
+    // The explicit clear drops both layers, not just the host one
+    expect(chart.clearSelection).toHaveBeenCalled();
+  });
+
+  it("forwards mode changes to the chart", async () => {
+    const { rerender } = render(
+      <EmbeddingsView points={POINTS} mode="explore" />,
+    );
+    await waitFor(() => expect(instances.length).toBeGreaterThan(0));
+    const chart = instances[instances.length - 1];
+
+    await waitFor(() =>
+      expect(chart.setInteractionMode).toHaveBeenLastCalledWith("explore"),
+    );
+    rerender(<EmbeddingsView points={POINTS} mode="select" />);
+    await waitFor(() =>
+      expect(chart.setInteractionMode).toHaveBeenLastCalledWith("select"),
+    );
+  });
+
+  // Color-by None must not leave the previous field's colors on the GPU
+  it("restores the default palette when colors clear", async () => {
+    const colors = new Float32Array(POINTS.length * 3);
+    const { rerender } = render(
+      <EmbeddingsView points={POINTS} colors={colors} />,
+    );
+    await waitFor(() => expect(instances.length).toBeGreaterThan(0));
+    const chart = instances[instances.length - 1];
+    await waitFor(() =>
+      expect(chart.setColors).toHaveBeenLastCalledWith(colors),
+    );
+
+    rerender(<EmbeddingsView points={POINTS} colors={null} />);
+    await waitFor(() => expect(chart.setColors).toHaveBeenLastCalledWith(null));
+  });
+
+  it("drops a stale mask whose length mismatches the points", async () => {
+    const { rerender } = render(<EmbeddingsView points={POINTS} />);
+    await waitFor(() => expect(instances.length).toBeGreaterThan(0));
+    const chart = instances[instances.length - 1];
+    await waitFor(() => expect(chart.setData).toHaveBeenCalled());
+    chart.setVisible.mockClear();
+
+    rerender(
+      <EmbeddingsView points={POINTS} visible={new Uint8Array([1, 0, 1])} />,
+    );
+    // Length mismatch: neither applied nor cleared
+    expect(chart.setVisible).not.toHaveBeenCalled();
+  });
+});

--- a/app/packages/embeddings-v2/src/renderer/EmbeddingsView.tsx
+++ b/app/packages/embeddings-v2/src/renderer/EmbeddingsView.tsx
@@ -1,0 +1,225 @@
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react";
+import { ChartTooltip, type TooltipState } from "./ChartTooltip";
+import "./embeddings.css";
+// Type-only: erased at runtime, so three.js stays out of this chunk
+import type { EmbeddingsChart } from "./EmbeddingsChart";
+import type {
+  CameraAdapterFactory,
+  EmbeddingPoint,
+  HoverHit,
+  InteractionMode,
+  RenderSettings,
+} from "./types";
+
+export interface EmbeddingsViewProps {
+  points: EmbeddingPoint[];
+  /** Per-point rgb triplets in [0, 1]; omit for the default label palette */
+  colors?: Float32Array | null;
+  /** Per-point 0/1 visibility (view membership); omit for all visible */
+  visible?: Uint8Array | null;
+  /** External selection by point index; the lasso replaces it on drag */
+  selected?: number[] | null;
+  settings?: RenderSettings;
+  /** Tooltip image URL per point index; omit for text-only tooltips */
+  thumbUrl?: (index: number) => string;
+  /** Lasso selections: point indices (empty = cleared) + the data-space
+   * polygon when the camera adapter can provide one */
+  onSelection?: (
+    indices: number[],
+    dataPolygon?: Array<[number, number]> | null,
+  ) => void;
+  /** A plain click on a point; the host owns click semantics */
+  onPointClick?: (hit: HoverHit) => void;
+  /** A plain click on empty space, after the chart clears its selection
+   * — for hosts with layers of their own to clear */
+  onBackgroundClick?: () => void;
+  /** The lazy renderer chunk (or an injected camera) failed to load —
+   * without this the chart is a permanently blank surface */
+  onError?: (error: Error) => void;
+  /** Debounced hover hit, or null the moment hovering breaks */
+  onHover?: (hit: HoverHit | null) => void;
+  /** Render the built-in tooltip (default). Hosts with their own hover
+   * card pass false and drive it from onHover. */
+  tooltip?: boolean;
+  /** Plain-drag owner: "select" lassos (default), "explore" pans */
+  mode?: InteractionMode;
+  /**
+   * Loads a camera adapter for z-carrying data; without one z is
+   * ignored and the data renders flat. Async so the camera's module
+   * can ship in the lazily loaded WebGL chunk instead of the host's.
+   * Fixed for the lifetime of the view.
+   */
+  zCamera?: () => Promise<CameraAdapterFactory>;
+}
+
+/** Imperative escape hatch for host chrome (e.g. a reset-view button) */
+export interface EmbeddingsViewHandle {
+  resetCamera(): void;
+  /** Clears the chart's local selection dimming (lasso state) */
+  clearSelection(): void;
+}
+
+/**
+ * Thin React wrapper around the vanilla EmbeddingsChart: React manages
+ * lifecycle and the tooltip DOM; all rendering stays in the chart.
+ *
+ * The chart module (and with it all of three.js) loads lazily on first
+ * mount — importing this wrapper costs no WebGL code. Imperative hosts
+ * that want the chart eagerly import "./EmbeddingsChart" directly
+ * instead.
+ */
+export const EmbeddingsView = forwardRef<
+  EmbeddingsViewHandle,
+  EmbeddingsViewProps
+>(function EmbeddingsView(
+  {
+    points,
+    colors = null,
+    visible = null,
+    selected = null,
+    settings,
+    thumbUrl,
+    onSelection,
+    onPointClick,
+    onBackgroundClick,
+    onHover,
+    onError,
+    tooltip = true,
+    mode,
+    zCamera,
+  }: EmbeddingsViewProps,
+  ref,
+) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const onSelectionRef = useRef(onSelection);
+  const onPointClickRef = useRef(onPointClick);
+  const onBackgroundClickRef = useRef(onBackgroundClick);
+  const onHoverRef = useRef(onHover);
+  const onErrorRef = useRef(onError);
+  // Captured once: the chart is constructed a single time per mount
+  const zCameraRef = useRef(zCamera);
+  const [chart, setChart] = useState<EmbeddingsChart | null>(null);
+  const [tooltipState, setTooltipState] = useState<TooltipState | null>(null);
+
+  useEffect(() => {
+    onSelectionRef.current = onSelection;
+    onPointClickRef.current = onPointClick;
+    onBackgroundClickRef.current = onBackgroundClick;
+    onHoverRef.current = onHover;
+    onErrorRef.current = onError;
+  }, [onSelection, onPointClick, onBackgroundClick, onHover, onError]);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      resetCamera: () => chart?.resetCamera(),
+      // Drops BOTH selection layers (host + lasso) — this is the
+      // explicit-clear path (Esc, clear affordances)
+      clearSelection: () => chart?.clearSelection(),
+    }),
+    [chart],
+  );
+
+  // One chart per mount, created as soon as the lazy chunk lands; props
+  // flow in through the effects below, which re-fire when it does
+  useEffect(() => {
+    const host = containerRef.current;
+    if (!host) return undefined;
+    let disposed = false;
+    let instance: EmbeddingsChart | null = null;
+    Promise.all([import("./EmbeddingsChart"), zCameraRef.current?.()])
+      .then(([{ EmbeddingsChart }, zCamera]) => {
+        if (disposed) return;
+        instance = new EmbeddingsChart(
+          host,
+          {
+            onSelection: (indices, dataPolygon) =>
+              onSelectionRef.current?.(indices, dataPolygon),
+            onPointClick: (hit) => onPointClickRef.current?.(hit),
+            onBackgroundClick: () => onBackgroundClickRef.current?.(),
+            onHover: (hit) => {
+              onHoverRef.current?.(hit);
+              setTooltipState(
+                hit && {
+                  hit,
+                  flipX: hit.x > host.clientWidth / 2,
+                  flipY: hit.y > host.clientHeight / 2,
+                },
+              );
+            },
+          },
+          { zCamera },
+        );
+        setChart(instance);
+      })
+      .catch((error) => {
+        // eslint-disable-next-line no-console
+        console.error("Failed to load the embeddings renderer", error);
+        if (disposed) return;
+        onErrorRef.current?.(
+          error instanceof Error ? error : new Error(String(error)),
+        );
+      });
+    return () => {
+      disposed = true;
+      setChart(null);
+      instance?.destroy();
+    };
+  }, []);
+
+  useEffect(() => {
+    // A visible tooltip clears via the chart's own onHover(null): setData
+    // resets its hover picker, which fires the callback
+    chart?.setData(points);
+  }, [chart, points]);
+
+  useEffect(() => {
+    if (mode) chart?.setInteractionMode(mode);
+  }, [chart, mode]);
+
+  useEffect(() => {
+    // Stale colors for a previous dataset are dropped, not an error —
+    // the matching colors prop lands with the host's next render. Null
+    // restores the default palette (color-by None, or a column fetch
+    // in flight)
+    if (!colors) {
+      chart?.setColors(null);
+    } else if (colors.length === points.length * 3) {
+      chart?.setColors(colors);
+    }
+  }, [chart, colors, points]);
+
+  useEffect(() => {
+    // Same stale-prop rule as colors; null restores full visibility
+    if (!visible) {
+      chart?.setVisible(null);
+    } else if (visible.length === points.length) {
+      chart?.setVisible(visible);
+    }
+    // points is a dep because setData resets visibility
+  }, [chart, visible, points]);
+
+  useEffect(() => {
+    chart?.setSelected(selected);
+    // points is a dep because setData clears the chart's selection mask
+  }, [chart, selected, points]);
+
+  useEffect(() => {
+    if (settings) chart?.setRenderSettings(settings);
+  }, [chart, settings]);
+
+  return (
+    <div style={{ position: "relative", width: "100%", height: "100%" }}>
+      <div ref={containerRef} style={{ width: "100%", height: "100%" }} />
+      {tooltip && tooltipState && (
+        <ChartTooltip state={tooltipState} thumbUrl={thumbUrl} />
+      )}
+    </div>
+  );
+});

--- a/app/packages/embeddings-v2/src/renderer/README.md
+++ b/app/packages/embeddings-v2/src/renderer/README.md
@@ -1,0 +1,72 @@
+# The embeddings renderer (`src/renderer/`)
+
+A high-performance Three.js renderer for embeddings scatter plots: one
+`gl.POINTS` draw call over typed arrays in data space, custom GLSL for styling
+and density compositing, and a pluggable camera adapter — the built-in adapter
+is a planar orthographic camera with wheel zoom, pan, and a plain-drag lasso.
+
+The core (`EmbeddingsChart`) is vanilla Three.js + DOM with no React
+dependency; `EmbeddingsView` is a thin React wrapper. All rendering is
+on-demand — there is no animation loop.
+
+**Three.js loads lazily.** The renderer barrel (`index.ts`) is three.js-free at
+runtime; `EmbeddingsView` dynamically imports the chart (and with it all WebGL
+code) on first mount, so consumers pay nothing at startup. A depcruise rule
+keeps panel imports on the barrel — an eager, imperative host would import
+`./EmbeddingsChart` directly. Note for bundling: this split survives only in
+output formats that support code-splitting — a single-file UMD build inlines
+it.
+
+## API
+
+```tsx
+import { EmbeddingsView } from "./renderer";
+
+<EmbeddingsView
+    points={points} // { id, x, y, z?, label }[]
+    colors={colors} // Float32Array(n*3) rgb in [0,1]; omit for the default label palette
+    visible={visible} // Uint8Array(n) 0/1; hidden points don't render or hit-test
+    selected={selected} // number[] point indices; non-members dim
+    settings={settings} // { mode: "density" | "alpha" | "opaque", gamma, glow, singleAlpha }
+    onSelection={onLasso} // lasso results as point indices (empty = cleared)
+    onPointClick={onClick} // plain click on a point (click-to-select)
+    thumbUrl={(i) => url} // optional hover tooltip thumbnails
+/>;
+```
+
+Or imperatively (eager three.js):
+
+```ts
+import { EmbeddingsChart } from "./renderer/EmbeddingsChart";
+
+const chart = new EmbeddingsChart(container, callbacks, options);
+// setData / setColors / setVisible / setSelected / setRenderSettings / destroy
+```
+
+Selection semantics: the lasso and the host both call `setSelected`; its only
+visual effect is dimming non-members. External selections set via `setSelected`
+do **not** echo back through `onSelection`. Visibility (`setVisible`) is a
+separate mechanism: hidden points are excluded from rendering, hover, lasso,
+and click hit-tests (view-stage subsetting, per the panel's protocol).
+
+Cameras are an extension seam: hosts may supply a `CameraAdapterFactory`
+(`zCamera` option/prop) to handle data whose points carry a `z` value. Without
+one, `z` is ignored and the data renders flat with the planar camera.
+
+## Checks
+
+Strict TypeScript, package-local eslint, and dependency-cruiser layering rules
+(the React-free core, the purity of `math.ts`/`columns.ts`, the core-three-only
+import boundary, and the panel/renderer boundary are machine-enforced; run from
+the `embeddings-v2` package root):
+
+```sh
+yarn check          # check:lint + check:deps + check:types
+yarn test           # vitest over the pure modules
+```
+
+## Testing
+
+The pure modules (`math.ts`, `columns.ts`, the interaction helpers) are covered
+by vitest; `EmbeddingsView`'s prop plumbing is tested against a mocked chart.
+The chart itself requires a real WebGL context and is exercised in the App.

--- a/app/packages/embeddings-v2/src/renderer/cameras/PlanarCamera.test.ts
+++ b/app/packages/embeddings-v2/src/renderer/cameras/PlanarCamera.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+import { PlanarCamera } from "./PlanarCamera";
+
+const BOUNDS = {
+  xMin: 0,
+  xMax: 10,
+  yMin: 0,
+  yMax: 10,
+  zMin: 0,
+  zMax: 0,
+};
+
+describe("PlanarCamera.isLassoStart", () => {
+  // jsdom has no PointerEvent constructor; the method reads two fields
+  const down = (init: { button?: number; shiftKey?: boolean }) =>
+    ({ button: 0, shiftKey: false, ...init }) as PointerEvent;
+
+  it("gives plain drags to the lasso in select mode only", () => {
+    const element = document.createElement("div");
+    const camera = new PlanarCamera(element, vi.fn());
+
+    // Default mode is select: plain drag lassos, shift-drag pans
+    expect(camera.isLassoStart(down({}))).toBe(true);
+    expect(camera.isLassoStart(down({ shiftKey: true }))).toBe(false);
+
+    camera.setMode("explore");
+    expect(camera.isLassoStart(down({}))).toBe(false);
+
+    camera.setMode("select");
+    expect(camera.isLassoStart(down({}))).toBe(true);
+
+    camera.destroy();
+  });
+});
+
+describe("PlanarCamera.toDataPolygon", () => {
+  it("maps screen vertices into the data window", () => {
+    const element = document.createElement("div");
+    const camera = new PlanarCamera(element, vi.fn());
+    camera.setBounds(BOUNDS, 100, 100);
+
+    // The viewport center is the data center regardless of margin
+    const [center] = camera.toDataPolygon([[50, 50]]);
+    expect(center[0]).toBeCloseTo(5);
+    expect(center[1]).toBeCloseTo(5);
+
+    // Screen y points down: below-center maps to smaller data y
+    const [below] = camera.toDataPolygon([[50, 75]]);
+    expect(below[1]).toBeLessThan(5);
+
+    camera.destroy();
+  });
+});
+
+describe("PlanarCamera focus", () => {
+  const center = (camera: PlanarCamera["camera"]) => [
+    (camera.left + camera.right) / 2,
+    (camera.bottom + camera.top) / 2,
+  ];
+
+  // Legend/filter hides move the interesting region; reset must follow
+  // it — and forget it again when everything is visible or data changes
+  it("reset frames the focus, and setBounds clears it", () => {
+    const element = document.createElement("div");
+    const camera = new PlanarCamera(element, vi.fn());
+    camera.setBounds(BOUNDS, 100, 100);
+    const homeWidth = camera.camera.right - camera.camera.left;
+
+    camera.setFocus({ xMin: 7, xMax: 9, yMin: 1, yMax: 3, zMin: 0, zMax: 0 });
+    // No immediate movement — focus only steers the next reset
+    expect(center(camera.camera)).toEqual([5, 5]);
+
+    camera.reset();
+    const [cx, cy] = center(camera.camera);
+    expect(cx).toBeCloseTo(8);
+    expect(cy).toBeCloseTo(2);
+    expect(camera.camera.right - camera.camera.left).toBeLessThan(homeWidth);
+
+    camera.setFocus(null);
+    camera.reset();
+    expect(center(camera.camera)).toEqual([5, 5]);
+
+    camera.setFocus({ xMin: 7, xMax: 9, yMin: 1, yMax: 3, zMin: 0, zMax: 0 });
+    camera.setBounds(BOUNDS, 100, 100);
+    camera.reset();
+    expect(center(camera.camera)).toEqual([5, 5]);
+
+    camera.destroy();
+  });
+});

--- a/app/packages/embeddings-v2/src/renderer/cameras/PlanarCamera.ts
+++ b/app/packages/embeddings-v2/src/renderer/cameras/PlanarCamera.ts
@@ -1,0 +1,204 @@
+import { OrthographicCamera } from "three";
+import { MARGIN, MAX_ZOOM } from "../constants";
+import {
+  clampToHome,
+  fitRect,
+  panRect,
+  pxToData,
+  zoomOf,
+  zoomRect,
+  type Rect,
+} from "../math";
+import type { Bounds, CameraAdapter, InteractionMode, Polygon } from "../types";
+
+/**
+ * 2D camera: an orthographic frustum window over the data, driven by our
+ * own pointer/wheel handling (no d3). Interactions match the FiftyOne
+ * embeddings panel conventions: wheel zooms toward the cursor,
+ * shift-drag or middle-drag pans, plain drag is left to the lasso.
+ * No smoothing or easing anywhere — renders track input exactly.
+ */
+export class PlanarCamera implements CameraAdapter {
+  readonly camera: OrthographicCamera;
+
+  private readonly element: HTMLElement;
+  private readonly onChange: () => void;
+  private readonly listeners = new AbortController();
+
+  private bounds: Bounds | null = null;
+  private focus: Bounds | null = null;
+  private home: Rect = { x0: -1, y0: -1, x1: 1, y1: 1 };
+  private rect: Rect = this.home;
+  private width = 1;
+  private height = 1;
+  private panPointer: number | null = null;
+  private panLast: [number, number] = [0, 0];
+  private mode: InteractionMode = "select";
+
+  constructor(element: HTMLElement, onChange: () => void) {
+    this.element = element;
+    this.onChange = onChange;
+    // Frustum in data units; the data plane sits at z=0, camera at z=1
+    this.camera = new OrthographicCamera(-1, 1, 1, -1, 0.1, 10);
+    this.camera.position.set(0, 0, 1);
+
+    const { signal } = this.listeners;
+    // Non-passive: without preventDefault, trackpad pinches page-zoom
+    // the browser instead of the chart
+    element.addEventListener("wheel", (e) => this.handleWheel(e), {
+      passive: false,
+      signal,
+    });
+    element.addEventListener("pointerdown", (e) => this.handlePanStart(e), {
+      signal,
+    });
+    element.addEventListener("pointermove", (e) => this.handlePanMove(e), {
+      signal,
+    });
+    for (const type of ["pointerup", "pointercancel"] as const) {
+      element.addEventListener(type, (e) => this.handlePanEnd(e), { signal });
+    }
+  }
+
+  /**
+   * In select mode a plain left-drag draws the lasso and pans need
+   * shift or middle button; in explore mode the camera owns plain drags
+   * and no gesture lassos.
+   */
+  isLassoStart(event: PointerEvent): boolean {
+    return this.mode === "select" && event.button === 0 && !event.shiftKey;
+  }
+
+  setMode(mode: InteractionMode): void {
+    this.mode = mode;
+  }
+
+  /** Orthographic window: screen -> data is exact rectangle algebra */
+  toDataPolygon(polygon: Polygon): Array<[number, number]> {
+    return polygon.map(([x, y]) =>
+      pxToData(this.rect, this.width, this.height, x, y),
+    );
+  }
+
+  setBounds(bounds: Bounds, width: number, height: number): void {
+    this.bounds = bounds;
+    this.focus = null;
+    this.width = width;
+    this.height = height;
+    this.home = fitRect(bounds, width, height, MARGIN);
+    this.rect = this.home;
+    this.apply();
+  }
+
+  /** No immediate view change — the focus only steers the next reset() */
+  setFocus(bounds: Bounds | null): void {
+    this.focus = bounds;
+  }
+
+  /** Keep the current zoom + center; re-fit the home rect to the new size */
+  resize(width: number, height: number): void {
+    this.width = width;
+    this.height = height;
+    if (!this.bounds) return;
+    const k = zoomOf(this.rect, this.home);
+    const cx = (this.rect.x0 + this.rect.x1) / 2;
+    const cy = (this.rect.y0 + this.rect.y1) / 2;
+    this.home = fitRect(this.bounds, width, height, MARGIN);
+    const w = (this.home.x1 - this.home.x0) / k;
+    const h = (this.home.y1 - this.home.y0) / k;
+    this.rect = clampToHome(
+      { x0: cx - w / 2, x1: cx + w / 2, y0: cy - h / 2, y1: cy + h / 2 },
+      this.home,
+    );
+    this.apply();
+  }
+
+  reset(): void {
+    this.rect = this.focus ? this.frameFocus(this.focus) : this.home;
+    this.apply();
+  }
+
+  /**
+   * Fit the focus region like a home rect, but capped at the
+   * interactive zoom limit (a tiny cluster must not out-zoom what the
+   * wheel allows) and clamped to the pannable area, so a reset never
+   * lands somewhere the user couldn't reach by hand.
+   */
+  private frameFocus(focus: Bounds): Rect {
+    const fitted = fitRect(focus, this.width, this.height, MARGIN);
+    const k = Math.min(zoomOf(fitted, this.home), MAX_ZOOM);
+    const w = (this.home.x1 - this.home.x0) / k;
+    const h = (this.home.y1 - this.home.y0) / k;
+    const cx = (focus.xMin + focus.xMax) / 2;
+    const cy = (focus.yMin + focus.yMax) / 2;
+    return clampToHome(
+      { x0: cx - w / 2, x1: cx + w / 2, y0: cy - h / 2, y1: cy + h / 2 },
+      this.home,
+    );
+  }
+
+  destroy(): void {
+    this.listeners.abort();
+  }
+
+  /** Push the rect into the camera frustum and notify */
+  private apply(): void {
+    const { x0, y0, x1, y1 } = this.rect;
+    this.camera.left = x0;
+    this.camera.right = x1;
+    this.camera.top = y1;
+    this.camera.bottom = y0;
+    this.camera.updateProjectionMatrix();
+    this.onChange();
+  }
+
+  private handleWheel(event: WheelEvent): void {
+    event.preventDefault();
+    // Exponential zoom per wheel tick; pinch gestures arrive as
+    // ctrl+wheel with small deltas, so they get a stronger factor
+    const speed = event.ctrlKey ? 0.02 : 0.002;
+    const factor = Math.pow(2, -event.deltaY * speed);
+    const focus = pxToData(
+      this.rect,
+      this.width,
+      this.height,
+      event.offsetX,
+      event.offsetY,
+    );
+    this.rect = zoomRect(this.rect, this.home, focus, factor, MAX_ZOOM);
+    this.apply();
+  }
+
+  private handlePanStart(event: PointerEvent): void {
+    const pan =
+      event.button === 1 ||
+      (event.button === 0 && (event.shiftKey || this.mode === "explore"));
+    if (!pan) return;
+    event.preventDefault();
+    this.panPointer = event.pointerId;
+    this.panLast = [event.offsetX, event.offsetY];
+    this.element.setPointerCapture(event.pointerId);
+  }
+
+  private handlePanMove(event: PointerEvent): void {
+    if (this.panPointer !== event.pointerId) return;
+    const [lastX, lastY] = this.panLast;
+    this.panLast = [event.offsetX, event.offsetY];
+    // Content follows the cursor: the window moves opposite the drag
+    // (screen y points down, data y points up — hence the sign split)
+    const perPxX = (this.rect.x1 - this.rect.x0) / this.width;
+    const perPxY = (this.rect.y1 - this.rect.y0) / this.height;
+    this.rect = panRect(
+      this.rect,
+      this.home,
+      -(event.offsetX - lastX) * perPxX,
+      (event.offsetY - lastY) * perPxY,
+    );
+    this.apply();
+  }
+
+  private handlePanEnd(event: PointerEvent): void {
+    if (this.panPointer !== event.pointerId) return;
+    this.panPointer = null;
+  }
+}

--- a/app/packages/embeddings-v2/src/renderer/columns.test.ts
+++ b/app/packages/embeddings-v2/src/renderer/columns.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import { buildColumns, colorsFromLabels, visibleBounds } from "./columns";
+import type { EmbeddingPoint } from "./types";
+
+const point = (
+  x: number,
+  y: number,
+  z?: number,
+  label: string | null = null,
+): EmbeddingPoint => ({ id: `${x},${y},${z ?? ""}`, x, y, z, label });
+
+describe("buildColumns", () => {
+  it("builds flat columns with zeroed zs", () => {
+    const cols = buildColumns([point(1, 2), point(-3, 4)]);
+    expect(cols.n).toBe(2);
+    expect(cols.hasZ).toBe(false);
+    expect(Array.from(cols.xs)).toEqual([1, -3]);
+    expect(Array.from(cols.ys)).toEqual([2, 4]);
+    expect(Array.from(cols.zs)).toEqual([0, 0]);
+  });
+
+  it("detects z when any point carries one", () => {
+    const cols = buildColumns([point(0, 0), point(1, 1, 5)]);
+    expect(cols.hasZ).toBe(true);
+    expect(Array.from(cols.zs)).toEqual([0, 5]);
+  });
+
+  it("ignores z entirely when flattenZ is set", () => {
+    const cols = buildColumns([point(0, 0, 5), point(1, 1, -2)], true);
+    expect(cols.hasZ).toBe(false);
+    expect(Array.from(cols.zs)).toEqual([0, 0]);
+    expect(cols.zMin).toBe(0);
+    expect(cols.zMax).toBe(0);
+  });
+
+  // Infinite bounds would poison the camera framing downstream
+  it("normalizes empty datasets to finite bounds", () => {
+    const cols = buildColumns([]);
+    expect(cols.n).toBe(0);
+    expect(Number.isFinite(cols.xMin)).toBe(true);
+    expect(Number.isFinite(cols.xMax)).toBe(true);
+    expect(cols.xMax).toBeGreaterThan(cols.xMin);
+  });
+
+  it("accumulates bounds in the same pass", () => {
+    const cols = buildColumns([point(-1, 10, 3), point(7, -2, -4)]);
+    expect(cols.xMin).toBe(-1);
+    expect(cols.xMax).toBe(7);
+    expect(cols.yMin).toBe(-2);
+    expect(cols.yMax).toBe(10);
+    expect(cols.zMin).toBe(-4);
+    expect(cols.zMax).toBe(3);
+  });
+
+  it("interns labels in first-seen order, null included", () => {
+    const cols = buildColumns([
+      point(0, 0, undefined, "cat"),
+      point(1, 1, undefined, null),
+      point(2, 2, undefined, "dog"),
+      point(3, 3, undefined, "cat"),
+    ]);
+    expect(cols.labelKeys).toEqual(["cat", "null", "dog"]);
+    expect(Array.from(cols.labelIndex)).toEqual([0, 1, 2, 0]);
+  });
+
+  it("keeps ids aligned with point order", () => {
+    const cols = buildColumns([point(1, 2), point(3, 4)]);
+    expect(cols.ids).toEqual(["1,2,", "3,4,"]);
+  });
+});
+
+describe("visibleBounds", () => {
+  const cols = buildColumns([
+    { id: "a", x: 0, y: 0, z: 0, label: null },
+    { id: "b", x: 10, y: -5, z: 2, label: null },
+    { id: "c", x: 4, y: 3, z: 8, label: null },
+  ]);
+
+  it("bounds only the masked-in points", () => {
+    const bounds = visibleBounds(cols, new Uint8Array([0, 1, 1]));
+    expect(bounds).toEqual({
+      xMin: 4,
+      xMax: 10,
+      yMin: -5,
+      yMax: 3,
+      zMin: 2,
+      zMax: 8,
+    });
+  });
+
+  it("uses the full columns for a null mask", () => {
+    expect(visibleBounds(cols, null)).toEqual({
+      xMin: 0,
+      xMax: 10,
+      yMin: -5,
+      yMax: 3,
+      zMin: 0,
+      zMax: 8,
+    });
+  });
+
+  // Callers keep their previous framing; an empty region frames nothing
+  it("returns null when nothing is visible", () => {
+    expect(visibleBounds(cols, new Uint8Array([0, 0, 0]))).toBeNull();
+  });
+});
+
+describe("colorsFromLabels", () => {
+  it("parses hex to rgb in [0, 1]", () => {
+    const cols = buildColumns([point(0, 0, undefined, "a")]);
+    const colors = colorsFromLabels(cols, ["#ffa500"]);
+    expect(colors[0]).toBeCloseTo(1);
+    expect(colors[1]).toBeCloseTo(165 / 255);
+    expect(colors[2]).toBeCloseTo(0);
+  });
+
+  it("cycles the palette past its length", () => {
+    const cols = buildColumns([
+      point(0, 0, undefined, "a"),
+      point(1, 1, undefined, "b"),
+      point(2, 2, undefined, "c"),
+    ]);
+    const colors = colorsFromLabels(cols, ["#ff0000", "#00ff00"]);
+    // Third label wraps back to the first palette entry
+    expect(Array.from(colors.slice(6, 9))).toEqual([1, 0, 0]);
+  });
+
+  it("expands one rgb triplet per point", () => {
+    const cols = buildColumns([
+      point(0, 0, undefined, "a"),
+      point(1, 1, undefined, "a"),
+    ]);
+    const colors = colorsFromLabels(cols, ["#0000ff"]);
+    expect(colors.length).toBe(6);
+    expect(Array.from(colors)).toEqual([0, 0, 1, 0, 0, 1]);
+  });
+});

--- a/app/packages/embeddings-v2/src/renderer/columns.ts
+++ b/app/packages/embeddings-v2/src/renderer/columns.ts
@@ -1,0 +1,149 @@
+import type { Bounds, EmbeddingPoint } from "./types";
+
+/**
+ * Columnar copy of the data: typed arrays upload straight to the GPU and
+ * scan fast for hit-testing. Built once per setData.
+ */
+export interface Columns extends Bounds {
+  n: number;
+  xs: Float32Array;
+  ys: Float32Array;
+  /** All zeros when the input carries no z (or z was flattened) */
+  zs: Float32Array;
+  /** True if any point carried a z and flattening was off */
+  hasZ: boolean;
+  ids: string[];
+  labelIndex: Uint32Array;
+  labelKeys: string[];
+}
+
+/**
+ * `flattenZ` ignores z entirely (zs stay zero, hasZ stays false) — used
+ * when the host provides no camera for z data, so it renders flat
+ * instead of clipping against the planar camera's frustum.
+ */
+export function buildColumns(
+  points: EmbeddingPoint[],
+  flattenZ = false,
+): Columns {
+  const n = points.length;
+  const xs = new Float32Array(n);
+  const ys = new Float32Array(n);
+  const zs = new Float32Array(n);
+  const ids = new Array<string>(n);
+  // u32: u16 would silently wrap (and recycle colors) past 65535 labels
+  const labelIndex = new Uint32Array(n);
+  const labelKeys: string[] = [];
+  const indexByLabel = new Map<string, number>();
+  let hasZ = false;
+  let xMin = Infinity;
+  let xMax = -Infinity;
+  let yMin = Infinity;
+  let yMax = -Infinity;
+  let zMin = Infinity;
+  let zMax = -Infinity;
+
+  for (let i = 0; i < n; i++) {
+    const { id, x, y, z, label } = points[i];
+    if (z !== undefined && !flattenZ) hasZ = true;
+    const zValue = flattenZ ? 0 : (z ?? 0);
+    xs[i] = x;
+    ys[i] = y;
+    zs[i] = zValue;
+    ids[i] = id;
+    if (x < xMin) xMin = x;
+    if (x > xMax) xMax = x;
+    if (y < yMin) yMin = y;
+    if (y > yMax) yMax = y;
+    if (zValue < zMin) zMin = zValue;
+    if (zValue > zMax) zMax = zValue;
+    const key = String(label);
+    let index = indexByLabel.get(key);
+    if (index === undefined) {
+      index = labelKeys.length;
+      labelKeys.push(key);
+      indexByLabel.set(key, index);
+    }
+    labelIndex[i] = index;
+  }
+
+  if (n === 0) {
+    // Infinite bounds would poison the camera's framing; a unit box is
+    // an arbitrary-but-finite stand-in until real data arrives
+    xMin = yMin = zMin = 0;
+    xMax = yMax = zMax = 1;
+  }
+
+  return {
+    n,
+    xs,
+    ys,
+    zs,
+    hasZ,
+    ids,
+    labelIndex,
+    labelKeys,
+    xMin,
+    xMax,
+    yMin,
+    yMax,
+    zMin,
+    zMax,
+  };
+}
+
+/**
+ * Bounds of the mask's visible subset (null mask = every point).
+ * Returns null when nothing is visible — callers keep their previous
+ * framing rather than framing an empty region.
+ */
+export function visibleBounds(
+  cols: Columns,
+  mask: Uint8Array | null,
+): Bounds | null {
+  if (!mask) {
+    const { xMin, xMax, yMin, yMax, zMin, zMax } = cols;
+    return { xMin, xMax, yMin, yMax, zMin, zMax };
+  }
+  let xMin = Infinity;
+  let xMax = -Infinity;
+  let yMin = Infinity;
+  let yMax = -Infinity;
+  let zMin = Infinity;
+  let zMax = -Infinity;
+  for (let i = 0; i < cols.n; i++) {
+    if (!mask[i]) continue;
+    const x = cols.xs[i];
+    const y = cols.ys[i];
+    const z = cols.zs[i];
+    if (x < xMin) xMin = x;
+    if (x > xMax) xMax = x;
+    if (y < yMin) yMin = y;
+    if (y > yMax) yMax = y;
+    if (z < zMin) zMin = z;
+    if (z > zMax) zMax = z;
+  }
+  if (xMin === Infinity) return null;
+
+  return { xMin, xMax, yMin, yMax, zMin, zMax };
+}
+
+/** Default coloring: label index -> palette, as flat rgb triplets */
+export function colorsFromLabels(
+  cols: Columns,
+  palette: readonly string[],
+): Float32Array {
+  const paletteRgb = cols.labelKeys.map((_, i) => {
+    const hex = palette[i % palette.length];
+    return [
+      parseInt(hex.slice(1, 3), 16) / 255,
+      parseInt(hex.slice(3, 5), 16) / 255,
+      parseInt(hex.slice(5, 7), 16) / 255,
+    ];
+  });
+  const colors = new Float32Array(cols.n * 3);
+  for (let i = 0; i < cols.n; i++) {
+    colors.set(paletteRgb[cols.labelIndex[i]], i * 3);
+  }
+  return colors;
+}

--- a/app/packages/embeddings-v2/src/renderer/constants.ts
+++ b/app/packages/embeddings-v2/src/renderer/constants.ts
@@ -1,0 +1,59 @@
+import type { RenderSettings } from "./types";
+
+// FiftyOne embeddings style: the Voxel51 orange (the app's default marker
+// color) leads, so uncolored data renders solid orange. Hosts override
+// per-point colors entirely via setColors().
+export const PALETTE = ["#ffa500", "#19a7ce", "#9b5de5", "#02c39a", "#ef476f"];
+
+/** Lasso stroke/fill color (the selection itself never recolors points) */
+export const LASSO_COLOR = "#ffa500";
+
+/** Point diameter in CSS px — constant at every zoom level */
+export const POINT_SIZE = 6;
+
+/** Weight of non-selected points while a selection is active */
+export const DIM_ALPHA = 0.15;
+
+/**
+ * How far non-selected points desaturate toward neutral gray while a
+ * selection is active (0 = keep hue, 1 = fully gray). Weight alone
+ * cannot carry the dimming: density accumulation sums weights, so a
+ * deep pile of weight-cut points re-saturates to full opacity. Color
+ * survives accumulation — the tone map averages it — so gray piles
+ * stay visibly "not selected" at any depth.
+ */
+export const DIM_DESATURATION = 0.7;
+
+/** The neutral the dimmed points desaturate toward (works on dark bg) */
+export const DIM_TINT = 0.4;
+
+/**
+ * Extra diameter (CSS px) of the selection overlay's markers over the
+ * base point size. Subjective — tune freely.
+ */
+export const EMPHASIS_SIZE_PX = 4;
+
+/** Per-point alpha in "alpha" compositing mode */
+export const BASE_ALPHA = 0.85;
+
+/** Plot padding in CSS px (planar camera framing) */
+export const MARGIN = 24;
+
+/** Max planar zoom-in factor relative to the home view */
+export const MAX_ZOOM = 50;
+
+/** Pointer must sit still this long before a hover hit-test runs */
+export const HOVER_DEBOUNCE_MS = 120;
+
+/** Hover pick radius around the cursor, CSS px */
+export const HOVER_RADIUS_PX = 8;
+
+/** A press+release that travels no farther than this is a click, CSS px */
+export const CLICK_SLOP_PX = 4;
+
+export const DEFAULT_SETTINGS: RenderSettings = {
+  mode: "density",
+  gamma: 1,
+  glow: 1,
+  singleAlpha: 0.55,
+};

--- a/app/packages/embeddings-v2/src/renderer/embeddings.css
+++ b/app/packages/embeddings-v2/src/renderer/embeddings.css
@@ -1,0 +1,32 @@
+.embeddings-renderer-tooltip {
+  position: absolute;
+  z-index: 2;
+  pointer-events: none;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 6px;
+  background: #16181d;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 6px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
+}
+
+.embeddings-renderer-tooltip img {
+  display: block;
+  width: 160px;
+  height: 120px;
+  border-radius: 3px;
+  /* Visible while the thumbnail request is in flight */
+  background: #14161a;
+}
+
+.embeddings-renderer-tooltip-meta {
+  max-width: 160px;
+  font-family: monospace;
+  font-size: 11px;
+  color: rgb(134, 140, 148);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/app/packages/embeddings-v2/src/renderer/index.ts
+++ b/app/packages/embeddings-v2/src/renderer/index.ts
@@ -1,0 +1,26 @@
+// This barrel is deliberately three.js-free at runtime: the chart (and
+// all WebGL code) loads lazily inside EmbeddingsView on first mount.
+// Statically re-exporting the chart here would fold three.js back into
+// the panel's initial chunk — which is why depcruise routes all panel
+// imports through this file and nowhere deeper.
+export { buildColumns, colorsFromLabels, type Columns } from "./columns";
+export { DEFAULT_SETTINGS, PALETTE } from "./constants";
+export type {
+  EmbeddingsChartCallbacks,
+  EmbeddingsChartOptions,
+} from "./EmbeddingsChart";
+export {
+  EmbeddingsView,
+  type EmbeddingsViewHandle,
+  type EmbeddingsViewProps,
+} from "./EmbeddingsView";
+export type {
+  Bounds,
+  CameraAdapter,
+  CameraAdapterFactory,
+  EmbeddingPoint,
+  HoverHit,
+  InteractionMode,
+  Polygon,
+  RenderSettings,
+} from "./types";

--- a/app/packages/embeddings-v2/src/renderer/interaction/ClickDetector.test.ts
+++ b/app/packages/embeddings-v2/src/renderer/interaction/ClickDetector.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ClickDetector } from "./ClickDetector";
+
+const fire = (
+  target: HTMLElement,
+  type: string,
+  props: Record<string, unknown> = {},
+) => {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  Object.assign(event, {
+    button: 0,
+    buttons: 0,
+    shiftKey: false,
+    pointerId: 1,
+    offsetX: 0,
+    offsetY: 0,
+    ...props,
+  });
+  target.dispatchEvent(event);
+};
+
+describe("ClickDetector", () => {
+  let container: HTMLDivElement;
+  let onClick: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    onClick = vi.fn();
+    new ClickDetector(container, { onClick });
+  });
+
+  it("reports a press+release within the slop as a click", () => {
+    fire(container, "pointerdown", { offsetX: 10, offsetY: 10 });
+    fire(container, "pointerup", { offsetX: 12, offsetY: 11 });
+    expect(onClick).toHaveBeenCalledExactlyOnceWith(12, 11);
+  });
+
+  it("ignores drags beyond the slop", () => {
+    fire(container, "pointerdown", { offsetX: 10, offsetY: 10 });
+    fire(container, "pointerup", { offsetX: 30, offsetY: 30 });
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("ignores modified and non-primary presses", () => {
+    fire(container, "pointerdown", { shiftKey: true });
+    fire(container, "pointerup", {});
+    fire(container, "pointerdown", { button: 1 });
+    fire(container, "pointerup", { button: 1 });
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("resets on pointercancel", () => {
+    fire(container, "pointerdown", {});
+    fire(container, "pointercancel", {});
+    fire(container, "pointerup", {});
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("matches press and release by pointer id", () => {
+    fire(container, "pointerdown", { pointerId: 1 });
+    fire(container, "pointerup", { pointerId: 2 });
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("stops listening after destroy", () => {
+    const detector = new ClickDetector(container, { onClick });
+    detector.destroy();
+    fire(container, "pointerdown", {});
+    fire(container, "pointerup", {});
+    // The beforeEach detector still fires; the destroyed one must not
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/packages/embeddings-v2/src/renderer/interaction/ClickDetector.ts
+++ b/app/packages/embeddings-v2/src/renderer/interaction/ClickDetector.ts
@@ -1,0 +1,60 @@
+import { CLICK_SLOP_PX } from "../constants";
+
+interface ClickCallbacks {
+  /** A plain left click (no modifier, no drag) at container CSS px */
+  onClick: (x: number, y: number) => void;
+}
+
+/**
+ * Plain-click detection for gestures the lasso doesn't own. With the
+ * planar camera the lasso claims plain left pointer-downs in the
+ * capture phase (with stopPropagation), so these bubble-phase listeners
+ * never fire there — short lasso gestures report clicks through
+ * LassoOverlay's onComplete instead. Camera adapters that keep plain
+ * drags for camera movement let those events bubble, so this detector
+ * supplies their click path: a press+release within CLICK_SLOP_PX that
+ * no other interaction consumed.
+ */
+export class ClickDetector {
+  private readonly listeners = new AbortController();
+  private pointerId: number | null = null;
+  private downX = 0;
+  private downY = 0;
+
+  constructor(container: HTMLElement, callbacks: ClickCallbacks) {
+    const { signal } = this.listeners;
+    container.addEventListener(
+      "pointerdown",
+      (event) => {
+        if (event.button !== 0 || event.shiftKey) return;
+        this.pointerId = event.pointerId;
+        this.downX = event.offsetX;
+        this.downY = event.offsetY;
+      },
+      { signal },
+    );
+    container.addEventListener(
+      "pointerup",
+      (event) => {
+        if (this.pointerId !== event.pointerId) return;
+        this.pointerId = null;
+        const dx = event.offsetX - this.downX;
+        const dy = event.offsetY - this.downY;
+        if (dx * dx + dy * dy > CLICK_SLOP_PX * CLICK_SLOP_PX) return;
+        callbacks.onClick(event.offsetX, event.offsetY);
+      },
+      { signal },
+    );
+    container.addEventListener(
+      "pointercancel",
+      () => {
+        this.pointerId = null;
+      },
+      { signal },
+    );
+  }
+
+  destroy(): void {
+    this.listeners.abort();
+  }
+}

--- a/app/packages/embeddings-v2/src/renderer/interaction/HoverPicker.test.ts
+++ b/app/packages/embeddings-v2/src/renderer/interaction/HoverPicker.test.ts
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HOVER_DEBOUNCE_MS } from "../constants";
+import type { HoverHit } from "../types";
+import { HoverPicker } from "./HoverPicker";
+
+const fire = (
+  target: HTMLElement,
+  type: string,
+  props: Record<string, unknown> = {},
+) => {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  Object.assign(event, {
+    button: 0,
+    buttons: 0,
+    shiftKey: false,
+    pointerId: 1,
+    offsetX: 0,
+    offsetY: 0,
+    ...props,
+  });
+  target.dispatchEvent(event);
+};
+
+const HIT: HoverHit = { index: 3, id: "abc", label: "cat", x: 10, y: 10 };
+
+describe("HoverPicker", () => {
+  let container: HTMLDivElement;
+  let pick: ReturnType<typeof vi.fn>;
+  let onHover: ReturnType<typeof vi.fn>;
+  let blocked: boolean;
+  let picker: HoverPicker;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    blocked = false;
+    pick = vi.fn(() => HIT);
+    onHover = vi.fn();
+    picker = new HoverPicker(container, {
+      isBlocked: () => blocked,
+      pick,
+      onHover,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("hit-tests only after the pointer settles", () => {
+    fire(container, "pointermove", { offsetX: 5, offsetY: 6 });
+    expect(pick).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(HOVER_DEBOUNCE_MS);
+    expect(pick).toHaveBeenCalledExactlyOnceWith(5, 6);
+    expect(onHover).toHaveBeenCalledExactlyOnceWith(HIT);
+  });
+
+  it("hides a shown hit the moment the pointer moves again", () => {
+    fire(container, "pointermove", { offsetX: 5, offsetY: 6 });
+    vi.advanceTimersByTime(HOVER_DEBOUNCE_MS);
+    expect(onHover).toHaveBeenLastCalledWith(HIT);
+
+    fire(container, "pointermove", { offsetX: 7, offsetY: 8 });
+    expect(onHover).toHaveBeenLastCalledWith(null);
+  });
+
+  it("stays quiet when nothing is hit", () => {
+    pick.mockReturnValue(null);
+    fire(container, "pointermove", {});
+    vi.advanceTimersByTime(HOVER_DEBOUNCE_MS);
+    expect(onHover).not.toHaveBeenCalled();
+  });
+
+  it("ignores movement while buttons are down (camera drags)", () => {
+    fire(container, "pointermove", { offsetX: 5, offsetY: 6, buttons: 1 });
+    vi.advanceTimersByTime(HOVER_DEBOUNCE_MS);
+    expect(pick).not.toHaveBeenCalled();
+  });
+
+  it("ignores movement while another interaction owns the pointer", () => {
+    blocked = true;
+    fire(container, "pointermove", {});
+    vi.advanceTimersByTime(HOVER_DEBOUNCE_MS);
+    expect(pick).not.toHaveBeenCalled();
+  });
+
+  it("clears on pointerdown and on pointerleave", () => {
+    fire(container, "pointermove", { offsetX: 5, offsetY: 6 });
+    vi.advanceTimersByTime(HOVER_DEBOUNCE_MS);
+    expect(onHover).toHaveBeenLastCalledWith(HIT);
+
+    fire(container, "pointerdown", {});
+    expect(onHover).toHaveBeenLastCalledWith(null);
+
+    fire(container, "pointerup", {});
+    fire(container, "pointermove", { offsetX: 5, offsetY: 6 });
+    vi.advanceTimersByTime(HOVER_DEBOUNCE_MS);
+    expect(onHover).toHaveBeenLastCalledWith(HIT);
+
+    fire(container, "pointerleave", {});
+    expect(onHover).toHaveBeenLastCalledWith(null);
+  });
+
+  it("re-tests after the view changes under a still pointer", () => {
+    fire(container, "pointermove", { offsetX: 5, offsetY: 6 });
+    vi.advanceTimersByTime(HOVER_DEBOUNCE_MS);
+    expect(pick).toHaveBeenCalledTimes(1);
+
+    // A wheel zoom: same pointer position, new projection
+    picker.viewChanged();
+    vi.advanceTimersByTime(HOVER_DEBOUNCE_MS);
+    expect(pick).toHaveBeenCalledTimes(2);
+  });
+
+  it("forgets the pointer position on reset (new data)", () => {
+    fire(container, "pointermove", { offsetX: 5, offsetY: 6 });
+    picker.reset();
+    vi.advanceTimersByTime(HOVER_DEBOUNCE_MS);
+    expect(pick).not.toHaveBeenCalled();
+  });
+});

--- a/app/packages/embeddings-v2/src/renderer/interaction/HoverPicker.ts
+++ b/app/packages/embeddings-v2/src/renderer/interaction/HoverPicker.ts
@@ -1,0 +1,118 @@
+import { HOVER_DEBOUNCE_MS } from "../constants";
+import type { HoverHit } from "../types";
+
+interface HoverCallbacks {
+  /** True while another interaction owns the pointer (e.g. lasso) */
+  isBlocked: () => boolean;
+  /** Hit-test the pointer position; the chart owns the projection */
+  pick: (x: number, y: number) => HoverHit | null;
+  /** Hits fire debounced; null fires as soon as hover breaks */
+  onHover: (hit: HoverHit | null) => void;
+}
+
+/**
+ * Debounced hover: any movement hides the current hit immediately; the
+ * hit-test runs only after the pointer sits still for HOVER_DEBOUNCE_MS.
+ * Camera drags never trigger it (buttons are tracked in capture phase so
+ * this stays true even when other handlers stopPropagation), and camera
+ * changes without pointer movement — wheel zooms — re-test after
+ * settling via viewChanged().
+ */
+export class HoverPicker {
+  private readonly callbacks: HoverCallbacks;
+  private readonly listeners = new AbortController();
+  private handle: number | null = null;
+  /** Last idle pointer position (CSS px); null once the pointer leaves */
+  private pointer: [number, number] | null = null;
+  private hitShown = false;
+  private buttonsDown = false;
+
+  constructor(container: HTMLElement, callbacks: HoverCallbacks) {
+    this.callbacks = callbacks;
+    const { signal } = this.listeners;
+    container.addEventListener(
+      "pointerdown",
+      () => {
+        this.buttonsDown = true;
+        this.clear();
+      },
+      { capture: true, signal },
+    );
+    for (const type of ["pointerup", "pointercancel"] as const) {
+      container.addEventListener(
+        type,
+        () => {
+          this.buttonsDown = false;
+        },
+        { capture: true, signal },
+      );
+    }
+    container.addEventListener(
+      "pointermove",
+      (event) => {
+        if (this.callbacks.isBlocked() || event.buttons !== 0) return;
+        this.pointer = [event.offsetX, event.offsetY];
+        this.schedule();
+      },
+      { signal },
+    );
+    container.addEventListener(
+      "pointerleave",
+      () => {
+        this.pointer = null;
+        this.clear();
+      },
+      { signal },
+    );
+  }
+
+  /** The view moved under a still pointer; hide and re-test after settle */
+  viewChanged(): void {
+    if (this.buttonsDown) this.clear();
+    else this.schedule();
+  }
+
+  /** New data: the remembered pointer position no longer means anything */
+  reset(): void {
+    this.pointer = null;
+    this.clear();
+  }
+
+  destroy(): void {
+    this.cancel();
+    this.listeners.abort();
+  }
+
+  /** Hide any current hit now, hit-test once the pointer settles */
+  private schedule(): void {
+    this.clear();
+    if (!this.pointer) return;
+    this.handle = window.setTimeout(() => {
+      this.handle = null;
+      this.hitTest();
+    }, HOVER_DEBOUNCE_MS);
+  }
+
+  private clear(): void {
+    this.cancel();
+    if (this.hitShown) {
+      this.hitShown = false;
+      this.callbacks.onHover(null);
+    }
+  }
+
+  private cancel(): void {
+    if (this.handle !== null) {
+      window.clearTimeout(this.handle);
+      this.handle = null;
+    }
+  }
+
+  private hitTest(): void {
+    if (!this.pointer || this.callbacks.isBlocked()) return;
+    const hit = this.callbacks.pick(this.pointer[0], this.pointer[1]);
+    if (!hit) return;
+    this.hitShown = true;
+    this.callbacks.onHover(hit);
+  }
+}

--- a/app/packages/embeddings-v2/src/renderer/interaction/LassoOverlay.test.ts
+++ b/app/packages/embeddings-v2/src/renderer/interaction/LassoOverlay.test.ts
@@ -1,0 +1,176 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Polygon } from "../types";
+import { LassoOverlay } from "./LassoOverlay";
+
+const fire = (
+  target: HTMLElement,
+  type: string,
+  props: Record<string, unknown> = {},
+) => {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  Object.assign(event, {
+    button: 0,
+    buttons: 1,
+    shiftKey: false,
+    pointerId: 1,
+    offsetX: 0,
+    offsetY: 0,
+    ...props,
+  });
+  target.dispatchEvent(event);
+};
+
+describe("LassoOverlay", () => {
+  let parent: HTMLDivElement;
+  let container: HTMLDivElement;
+  let onComplete: ReturnType<typeof vi.fn>;
+  let overlay: LassoOverlay;
+
+  beforeEach(() => {
+    parent = document.createElement("div");
+    container = document.createElement("div");
+    parent.appendChild(container);
+    document.body.appendChild(parent);
+    // jsdom has no pointer capture; the overlay only needs it to exist
+    (container as unknown as Record<string, unknown>).setPointerCapture = () =>
+      undefined;
+    onComplete = vi.fn();
+    overlay = new LassoOverlay(container, {
+      shouldStart: (event) => event.button === 0 && !event.shiftKey,
+      onComplete,
+    });
+  });
+
+  const drag = (points: Polygon) => {
+    const [first, ...rest] = points;
+    fire(container, "pointerdown", { offsetX: first[0], offsetY: first[1] });
+    for (const [x, y] of rest) {
+      fire(container, "pointermove", { offsetX: x, offsetY: y });
+    }
+    const last = points[points.length - 1];
+    fire(container, "pointerup", { offsetX: last[0], offsetY: last[1] });
+  };
+
+  // A cancelled gesture (touch takeover, capture loss) must abandon the
+  // draw without completing — and must release the drawing flag, which
+  // used to leak and suppress hover forever
+  it("abandons the draw on pointercancel", () => {
+    fire(container, "pointerdown", { offsetX: 0, offsetY: 0 });
+    fire(container, "pointermove", { offsetX: 20, offsetY: 0 });
+    expect(overlay.isDrawing()).toBe(true);
+
+    fire(container, "pointercancel");
+    expect(overlay.isDrawing()).toBe(false);
+    expect(onComplete).not.toHaveBeenCalled();
+
+    // The next gesture starts clean
+    drag([
+      [0, 0],
+      [30, 0],
+      [30, 30],
+      [0, 30],
+    ]);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  // A second pointer (other mouse button path, stray touch) must not
+  // steer or terminate another pointer's lasso
+  it("ignores moves and releases from other pointers", () => {
+    fire(container, "pointerdown", { offsetX: 0, offsetY: 0, pointerId: 1 });
+    fire(container, "pointermove", { offsetX: 20, offsetY: 0, pointerId: 2 });
+    fire(container, "pointerup", { offsetX: 20, offsetY: 0, pointerId: 2 });
+    expect(overlay.isDrawing()).toBe(true);
+    expect(onComplete).not.toHaveBeenCalled();
+
+    fire(container, "pointermove", { offsetX: 20, offsetY: 0, pointerId: 1 });
+    fire(container, "pointermove", { offsetX: 20, offsetY: 20, pointerId: 1 });
+    fire(container, "pointerup", { offsetX: 20, offsetY: 20, pointerId: 1 });
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    const [polygon] = onComplete.mock.calls[0];
+    expect(polygon).toHaveLength(3);
+  });
+
+  it("delivers the polygon for a real lasso drag", () => {
+    drag([
+      [0, 0],
+      [10, 0],
+      [10, 10],
+      [0, 10],
+    ]);
+    expect(onComplete).toHaveBeenCalledExactlyOnceWith(
+      [
+        [0, 0],
+        [10, 0],
+        [10, 10],
+        [0, 10],
+      ],
+      0,
+      10,
+    );
+  });
+
+  it("reports a too-short gesture as a click with its release position", () => {
+    drag([
+      [5, 5],
+      [6, 6],
+    ]);
+    expect(onComplete).toHaveBeenCalledExactlyOnceWith(null, 6, 6);
+  });
+
+  it("skips sub-3px moves to keep the polygon small", () => {
+    drag([
+      [0, 0],
+      [1, 1],
+      [2, 2],
+      [10, 10],
+      [20, 20],
+    ]);
+    const polygon = onComplete.mock.calls[0][0];
+    expect(polygon).toEqual([
+      [0, 0],
+      [10, 10],
+      [20, 20],
+    ]);
+  });
+
+  it("never starts when the adapter declines the gesture", () => {
+    fire(container, "pointerdown", { shiftKey: true });
+    expect(overlay.isDrawing()).toBe(false);
+    fire(container, "pointermove", { offsetX: 10, offsetY: 10 });
+    fire(container, "pointerup", { offsetX: 10, offsetY: 10 });
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it("keeps drawing drags away from other listeners", () => {
+    const parentMove = vi.fn();
+    parent.addEventListener("pointermove", parentMove);
+
+    fire(container, "pointerdown", { offsetX: 0, offsetY: 0 });
+    expect(overlay.isDrawing()).toBe(true);
+    fire(container, "pointermove", { offsetX: 10, offsetY: 10 });
+    expect(parentMove).not.toHaveBeenCalled();
+
+    fire(container, "pointerup", { offsetX: 10, offsetY: 10 });
+    expect(overlay.isDrawing()).toBe(false);
+
+    // Not drawing: moves propagate normally (camera pans need them)
+    fire(container, "pointermove", { offsetX: 20, offsetY: 20, buttons: 0 });
+    expect(parentMove).toHaveBeenCalledTimes(1);
+  });
+
+  it("draws and clears the SVG path", () => {
+    const path = container.querySelector("path");
+    fire(container, "pointerdown", { offsetX: 0, offsetY: 0 });
+    fire(container, "pointermove", { offsetX: 10, offsetY: 0 });
+    expect(path?.getAttribute("d")).toContain("M0,0L10,0");
+    fire(container, "pointerup", { offsetX: 10, offsetY: 0 });
+    expect(path?.getAttribute("d")).toBe("");
+  });
+
+  it("removes its overlay on destroy", () => {
+    expect(container.querySelector("svg")).not.toBeNull();
+    overlay.destroy();
+    expect(container.querySelector("svg")).toBeNull();
+  });
+});

--- a/app/packages/embeddings-v2/src/renderer/interaction/LassoOverlay.ts
+++ b/app/packages/embeddings-v2/src/renderer/interaction/LassoOverlay.ts
@@ -1,0 +1,126 @@
+import { LASSO_COLOR } from "../constants";
+import type { Polygon } from "../types";
+
+interface LassoCallbacks {
+  /** Which pointer-downs begin a lasso (the camera adapter decides) */
+  shouldStart: (event: PointerEvent) => boolean;
+  /**
+   * Fired once per completed gesture. A real lasso passes its polygon; a
+   * gesture too short to enclose anything (a click) passes null with the
+   * release position, so the chart can treat it as a point click.
+   */
+  onComplete: (screenPolygon: Polygon | null, x: number, y: number) => void;
+}
+
+/**
+ * Freehand lasso: captures the polygon with capture-phase pointer
+ * listeners (so a drawing drag never reaches the camera's handlers) and
+ * draws it on a pointer-transparent SVG overlay above the canvas.
+ */
+export class LassoOverlay {
+  private readonly svg: SVGSVGElement;
+  private readonly path: SVGPathElement;
+  private readonly listeners = new AbortController();
+  private polygon: Polygon = [];
+  private drawing = false;
+  private pointerId: number | null = null;
+
+  constructor(container: HTMLElement, callbacks: LassoCallbacks) {
+    const ns = "http://www.w3.org/2000/svg";
+    this.svg = document.createElementNS(ns, "svg");
+    Object.assign(this.svg.style, {
+      position: "absolute",
+      inset: "0",
+      width: "100%",
+      height: "100%",
+      // Purely visual; all pointer events belong to the canvas below
+      pointerEvents: "none",
+      // Must sit above the canvas regardless of DOM order
+      zIndex: "1",
+    });
+    this.path = document.createElementNS(ns, "path");
+    this.path.setAttribute("fill", LASSO_COLOR);
+    this.path.setAttribute("fill-opacity", "0.08");
+    this.path.setAttribute("stroke", LASSO_COLOR);
+    this.path.setAttribute("stroke-width", "1.5");
+    this.svg.appendChild(this.path);
+    container.appendChild(this.svg);
+
+    // Capture phase: while drawing, stopPropagation keeps the events
+    // away from the camera adapter's own drag handlers
+    const { signal } = this.listeners;
+    container.addEventListener(
+      "pointerdown",
+      (event) => {
+        if (this.drawing || !callbacks.shouldStart(event)) return;
+        event.stopPropagation();
+        event.preventDefault();
+        this.drawing = true;
+        this.pointerId = event.pointerId;
+        this.polygon = [[event.offsetX, event.offsetY]];
+        container.setPointerCapture(event.pointerId);
+      },
+      { capture: true, signal },
+    );
+    container.addEventListener(
+      "pointermove",
+      (event) => {
+        if (!this.drawing || event.pointerId !== this.pointerId) return;
+        event.stopPropagation();
+        const [lastX, lastY] = this.polygon[this.polygon.length - 1];
+        const dx = event.offsetX - lastX;
+        const dy = event.offsetY - lastY;
+        // Skip sub-3px moves: keeps the polygon small for hit-testing
+        if (dx * dx + dy * dy < 9) return;
+        this.polygon.push([event.offsetX, event.offsetY]);
+        this.path.setAttribute(
+          "d",
+          `M${this.polygon.map((p) => p.join(",")).join("L")}Z`,
+        );
+      },
+      { capture: true, signal },
+    );
+    container.addEventListener(
+      "pointerup",
+      (event) => {
+        if (!this.drawing || event.pointerId !== this.pointerId) return;
+        event.stopPropagation();
+        this.drawing = false;
+        this.pointerId = null;
+        const polygon = this.polygon;
+        this.polygon = [];
+        this.path.setAttribute("d", "");
+        callbacks.onComplete(
+          polygon.length >= 3 ? polygon : null,
+          event.offsetX,
+          event.offsetY,
+        );
+      },
+      { capture: true, signal },
+    );
+    // A cancelled gesture (touch scroll takeover, capture loss) is
+    // neither a lasso nor a click: abandon silently or `drawing` leaks
+    // and suppresses hover forever
+    container.addEventListener(
+      "pointercancel",
+      (event) => {
+        if (!this.drawing || event.pointerId !== this.pointerId) return;
+        this.drawing = false;
+        this.pointerId = null;
+        this.polygon = [];
+        this.path.setAttribute("d", "");
+      },
+      { capture: true, signal },
+    );
+  }
+
+  /** True while a lasso drag is in progress (suppresses hover) */
+  isDrawing(): boolean {
+    return this.drawing;
+  }
+
+  destroy(): void {
+    this.listeners.abort();
+    this.svg.remove();
+  }
+}

--- a/app/packages/embeddings-v2/src/renderer/math.test.ts
+++ b/app/packages/embeddings-v2/src/renderer/math.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it } from "vitest";
+import { buildColumns } from "./columns";
+import {
+  clampToHome,
+  fitRect,
+  nearestPoint,
+  panRect,
+  pointInPolygon,
+  pxToData,
+  selectInPolygon,
+  zoomOf,
+  zoomRect,
+  type Rect,
+} from "./math";
+import type { EmbeddingPoint, Polygon } from "./types";
+
+// Identity view-projection: data is already in NDC, so a point (x, y)
+// projects to ((x/2 + 0.5) * width, (0.5 - y/2) * height). Column-major
+// like three.js Matrix4.elements.
+// prettier-ignore
+const IDENTITY = [
+  1, 0, 0, 0,
+  0, 1, 0, 0,
+  0, 0, 1, 0,
+  0, 0, 0, 1,
+];
+
+// w = -z: points with z >= 0 land at or behind the camera (w <= 0)
+// prettier-ignore
+const NEGATIVE_W = [
+  1, 0, 0, 0,
+  0, 1, 0, 0,
+  0, 0, 1, -1,
+  0, 0, 0, 0,
+];
+
+const cols = (points: Array<[number, number, number?]>) =>
+  buildColumns(
+    points.map(
+      ([x, y, z], i): EmbeddingPoint => ({ id: `${i}`, x, y, z, label: null }),
+    ),
+  );
+
+describe("fitRect", () => {
+  it("insets the data extent by the margin in px", () => {
+    // 100x100 viewport, 10px margin: 80 usable px span the data
+    const rect = fitRect({ xMin: 0, xMax: 8, yMin: 0, yMax: 8 }, 100, 100, 10);
+    expect(rect.x0).toBeCloseTo(-1);
+    expect(rect.x1).toBeCloseTo(9);
+    expect(rect.y0).toBeCloseTo(-1);
+    expect(rect.y1).toBeCloseTo(9);
+  });
+
+  it("keeps one data-per-px scale in a wide viewport (contain-fit)", () => {
+    const rect = fitRect({ xMin: 0, xMax: 8, yMin: 0, yMax: 8 }, 200, 100, 10);
+    // Height is the tight axis: 80 usable px -> 0.1 data/px everywhere
+    expect((rect.y1 - rect.y0) / 100).toBeCloseTo(0.1);
+    expect((rect.x1 - rect.x0) / 200).toBeCloseTo(0.1);
+    // The slack axis centers the data
+    expect(rect.x0).toBeCloseTo(-6);
+    expect(rect.x1).toBeCloseTo(14);
+    expect(rect.y0).toBeCloseTo(-1);
+    expect(rect.y1).toBeCloseTo(9);
+  });
+
+  it("keeps wide data fully in view in a tall viewport", () => {
+    const bounds = { xMin: 0, xMax: 16, yMin: 0, yMax: 4 };
+    const rect = fitRect(bounds, 100, 200, 10);
+    // Width is the tight axis: 80 usable px -> 0.2 data/px
+    const perPx = (rect.x1 - rect.x0) / 100;
+    expect(perPx).toBeCloseTo(0.2);
+    expect((rect.y1 - rect.y0) / 200).toBeCloseTo(perPx);
+    // The whole extent sits inside the rect with at least the margin
+    expect((bounds.xMin - rect.x0) / perPx).toBeCloseTo(10);
+    expect((rect.y1 - bounds.yMax) / perPx).toBeGreaterThanOrEqual(10);
+  });
+
+  it("gives degenerate extents a nonzero span, margin or not", () => {
+    for (const margin of [0, 10]) {
+      const rect = fitRect(
+        { xMin: 5, xMax: 5, yMin: 5, yMax: 5 },
+        100,
+        100,
+        margin,
+      );
+      expect(rect.x1 - rect.x0).toBeGreaterThan(0);
+      expect(rect.y1 - rect.y0).toBeGreaterThan(0);
+      // Centered on the point
+      expect((rect.x0 + rect.x1) / 2).toBeCloseTo(5);
+      expect((rect.y0 + rect.y1) / 2).toBeCloseTo(5);
+    }
+  });
+});
+
+describe("pxToData", () => {
+  const rect: Rect = { x0: 0, y0: 0, x1: 10, y1: 10 };
+
+  it("maps corners with the y flip", () => {
+    // Screen top-left is data (x0, y1): screen y points down
+    expect(pxToData(rect, 100, 100, 0, 0)).toEqual([0, 10]);
+    expect(pxToData(rect, 100, 100, 100, 100)).toEqual([10, 0]);
+    expect(pxToData(rect, 100, 100, 50, 50)).toEqual([5, 5]);
+  });
+});
+
+describe("zoomRect / panRect / clampToHome", () => {
+  const home: Rect = { x0: 0, y0: 0, x1: 10, y1: 10 };
+
+  it("keeps the focus point stationary while zooming", () => {
+    const zoomed = zoomRect(home, home, [2, 2], 2, 50);
+    // Focus sat at 20% of the span; it must still sit at 20%
+    expect((2 - zoomed.x0) / (zoomed.x1 - zoomed.x0)).toBeCloseTo(0.2);
+    expect(zoomOf(zoomed, home)).toBeCloseTo(2);
+  });
+
+  it("never zooms out past home", () => {
+    const rect = zoomRect(home, home, [5, 5], 0.5, 50);
+    expect(rect).toEqual(home);
+  });
+
+  it("clamps zoom-in at maxZoom", () => {
+    let rect = home;
+    for (let i = 0; i < 10; i++) rect = zoomRect(rect, home, [5, 5], 4, 8);
+    expect(zoomOf(rect, home)).toBeCloseTo(8);
+  });
+
+  it("clamps pans to home's edges", () => {
+    const rect: Rect = { x0: 2, y0: 2, x1: 4, y1: 4 };
+    expect(panRect(rect, home, -5, 0)).toEqual({ x0: 0, y0: 2, x1: 2, y1: 4 });
+    expect(panRect(rect, home, 0, 100)).toEqual({
+      x0: 2,
+      y0: 8,
+      x1: 4,
+      y1: 10,
+    });
+  });
+
+  it("slides an out-of-bounds rect back inside home", () => {
+    expect(clampToHome({ x0: -1, y0: 3, x1: 1, y1: 5 }, home)).toEqual({
+      x0: 0,
+      y0: 3,
+      x1: 2,
+      y1: 5,
+    });
+  });
+});
+
+describe("pointInPolygon", () => {
+  const square: Polygon = [
+    [0, 0],
+    [10, 0],
+    [10, 10],
+    [0, 10],
+  ];
+
+  it("detects inside and outside for a square", () => {
+    expect(pointInPolygon(square, 5, 5)).toBe(true);
+    expect(pointInPolygon(square, 15, 5)).toBe(false);
+    expect(pointInPolygon(square, -1, -1)).toBe(false);
+  });
+
+  it("handles concave polygons", () => {
+    // A "C" shape: the notch on the right is outside
+    const c: Polygon = [
+      [0, 0],
+      [10, 0],
+      [10, 3],
+      [3, 3],
+      [3, 7],
+      [10, 7],
+      [10, 10],
+      [0, 10],
+    ];
+    expect(pointInPolygon(c, 1, 5)).toBe(true);
+    expect(pointInPolygon(c, 8, 5)).toBe(false);
+  });
+});
+
+describe("selectInPolygon", () => {
+  // Points in NDC; with IDENTITY on a 100x100 viewport, (0,0) is screen
+  // (50,50), (0.5,0.5) is (75,25), (-0.5,-0.5) is (25,75)
+  const data = cols([
+    [0, 0],
+    [0.5, 0.5],
+    [-0.5, -0.5],
+  ]);
+  const around = (x: number, y: number, r: number): Polygon => [
+    [x - r, y - r],
+    [x + r, y - r],
+    [x + r, y + r],
+    [x - r, y + r],
+  ];
+
+  it("selects exactly the enclosed points", () => {
+    expect(
+      selectInPolygon(data, IDENTITY, 100, 100, around(50, 50, 5)),
+    ).toEqual([0]);
+    expect(
+      selectInPolygon(data, IDENTITY, 100, 100, around(50, 50, 40)),
+    ).toEqual([0, 1, 2]);
+  });
+
+  it("skips points hidden by the visibility mask", () => {
+    const visible = new Uint8Array([1, 0, 1]);
+    expect(
+      selectInPolygon(data, IDENTITY, 100, 100, around(50, 50, 40), visible),
+    ).toEqual([0, 2]);
+  });
+
+  it("never selects points at or behind the camera (w <= 0)", () => {
+    const behind = cols([[0, 0, 1]]);
+    expect(
+      selectInPolygon(behind, NEGATIVE_W, 100, 100, around(50, 50, 60)),
+    ).toEqual([]);
+  });
+});
+
+describe("nearestPoint", () => {
+  const data = cols([
+    [0, 0],
+    [0.5, 0.5],
+  ]);
+
+  it("returns the nearest point within the radius", () => {
+    const hit = nearestPoint(data, IDENTITY, 100, 100, 52, 52, 8);
+    expect(hit?.index).toBe(0);
+    expect(hit?.x).toBeCloseTo(50);
+    expect(hit?.y).toBeCloseTo(50);
+  });
+
+  it("returns null when nothing is within the radius", () => {
+    expect(nearestPoint(data, IDENTITY, 100, 100, 10, 90, 8)).toBeNull();
+  });
+
+  it("prefers the closer of two candidates", () => {
+    // (62, 38) sits between screen points (50,50) and (75,25), nearer #1
+    const hit = nearestPoint(data, IDENTITY, 100, 100, 65, 35, 50);
+    expect(hit?.index).toBe(1);
+  });
+
+  it("skips points hidden by the visibility mask", () => {
+    const visible = new Uint8Array([0, 1]);
+    const hit = nearestPoint(data, IDENTITY, 100, 100, 52, 52, 50, visible);
+    expect(hit?.index).toBe(1);
+  });
+
+  it("skips points at or behind the camera (w <= 0)", () => {
+    const behind = cols([[0, 0, 1]]);
+    expect(nearestPoint(behind, NEGATIVE_W, 100, 100, 50, 50, 100)).toBeNull();
+  });
+});

--- a/app/packages/embeddings-v2/src/renderer/math.ts
+++ b/app/packages/embeddings-v2/src/renderer/math.ts
@@ -1,0 +1,257 @@
+// Pure geometry — no three.js, no DOM. Everything here is directly
+// unit-testable: the planar camera's viewport algebra, the lasso's
+// point-in-polygon test, and the projected hit-tests shared by both
+// camera modes.
+import type { Columns } from "./columns";
+import type { Bounds, HoverHit, Polygon } from "./types";
+
+/** A visible data-space window (y up, like the data — not screen y) */
+export interface Rect {
+  x0: number;
+  y0: number;
+  x1: number;
+  y1: number;
+}
+
+/**
+ * Home view for the planar camera: the data extent contain-fit in the
+ * viewport, inset by `margin` px on every side. One shared data-per-px
+ * scale serves both axes, so the plot keeps its shape at any viewport
+ * size — the axis with slack gets centered padding instead of a
+ * stretch. Degenerate extents (single point) get a unit span so the
+ * math stays finite.
+ */
+export function fitRect(
+  bounds: Pick<Bounds, "xMin" | "xMax" | "yMin" | "yMax">,
+  width: number,
+  height: number,
+  margin: number,
+): Rect {
+  const spanX = bounds.xMax - bounds.xMin || 1;
+  const spanY = bounds.yMax - bounds.yMin || 1;
+  // Guard tiny viewports: never let the usable area hit zero
+  const usableX = Math.max(width - 2 * margin, 1);
+  const usableY = Math.max(height - 2 * margin, 1);
+  // The tighter axis picks the scale, so the data always fits whole
+  const perPx = Math.max(spanX / usableX, spanY / usableY);
+  const cx = (bounds.xMin + bounds.xMax) / 2;
+  const cy = (bounds.yMin + bounds.yMax) / 2;
+  const halfX = (width * perPx) / 2;
+  const halfY = (height * perPx) / 2;
+  return { x0: cx - halfX, x1: cx + halfX, y0: cy - halfY, y1: cy + halfY };
+}
+
+/** Zoom level of a rect relative to home (1 = home, bigger = closer) */
+export function zoomOf(rect: Rect, home: Rect): number {
+  return (home.x1 - home.x0) / (rect.x1 - rect.x0);
+}
+
+/** Map a CSS-px position inside the viewport to data coordinates */
+export function pxToData(
+  rect: Rect,
+  width: number,
+  height: number,
+  px: number,
+  py: number,
+): [number, number] {
+  return [
+    rect.x0 + (px / width) * (rect.x1 - rect.x0),
+    // Screen y points down, data y points up
+    rect.y1 - (py / height) * (rect.y1 - rect.y0),
+  ];
+}
+
+/** Slide a rect so it stays fully inside home (assumes rect fits) */
+export function clampToHome(rect: Rect, home: Rect): Rect {
+  let { x0, y0, x1, y1 } = rect;
+  if (x0 < home.x0) {
+    x1 += home.x0 - x0;
+    x0 = home.x0;
+  }
+  if (x1 > home.x1) {
+    x0 -= x1 - home.x1;
+    x1 = home.x1;
+  }
+  if (y0 < home.y0) {
+    y1 += home.y0 - y0;
+    y0 = home.y0;
+  }
+  if (y1 > home.y1) {
+    y0 -= y1 - home.y1;
+    y1 = home.y1;
+  }
+  return { x0, y0, x1, y1 };
+}
+
+/**
+ * Zoom by `factor` (>1 = in) keeping the data point under `focus`
+ * stationary, clamped to [1, maxZoom] relative to home and panned back
+ * inside home's bounds.
+ */
+export function zoomRect(
+  rect: Rect,
+  home: Rect,
+  focus: [number, number],
+  factor: number,
+  maxZoom: number,
+): Rect {
+  const k = Math.min(Math.max(zoomOf(rect, home) * factor, 1), maxZoom);
+  const w = (home.x1 - home.x0) / k;
+  const h = (home.y1 - home.y0) / k;
+  const [fx, fy] = focus;
+  // Keep the focus point at the same relative position in the new rect
+  const rx = (fx - rect.x0) / (rect.x1 - rect.x0);
+  const ry = (fy - rect.y0) / (rect.y1 - rect.y0);
+  return clampToHome(
+    {
+      x0: fx - rx * w,
+      x1: fx + (1 - rx) * w,
+      y0: fy - ry * h,
+      y1: fy + (1 - ry) * h,
+    },
+    home,
+  );
+}
+
+/** Pan by a data-space delta, clamped inside home */
+export function panRect(rect: Rect, home: Rect, dx: number, dy: number): Rect {
+  return clampToHome(
+    { x0: rect.x0 + dx, x1: rect.x1 + dx, y0: rect.y0 + dy, y1: rect.y1 + dy },
+    home,
+  );
+}
+
+/**
+ * Ray-casting point-in-polygon: shoot a horizontal ray from (x, y) to the
+ * right and count edge crossings — odd = inside. Works for any simple
+ * polygon, concave included.
+ */
+export function pointInPolygon(
+  polygon: Polygon,
+  x: number,
+  y: number,
+): boolean {
+  let inside = false;
+  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+    const [xi, yi] = polygon[i];
+    const [xj, yj] = polygon[j];
+    if (yi > y !== yj > y && x < ((xj - xi) * (y - yi)) / (yj - yi) + xi) {
+      inside = !inside;
+    }
+  }
+  return inside;
+}
+
+// Both hit-tests below replicate the vertex shader's projection on the
+// CPU: clip = ViewProjection · (x, y, z, 1), then perspective divide and
+// viewport mapping. `m` is the combined matrix in three.js column-major
+// element order, so column c / row r lives at m[c * 4 + r] — e.g. row 3
+// (producing clip.w) is m[3], m[7], m[11], m[15]. For an orthographic
+// camera clip.w is 1 and the same code path applies.
+//
+// An optional `visible` mask (0/1 per point, the setVisible mask) excludes
+// hidden points, matching the vertex shader's clip-out exactly.
+
+/**
+ * Indices of all points whose projection falls inside a screen-space
+ * lasso polygon. A bbox pre-filter keeps the polygon test off most
+ * points; w <= 0 (at or behind the camera) can never be inside.
+ */
+export function selectInPolygon(
+  cols: Columns,
+  m: ArrayLike<number>,
+  width: number,
+  height: number,
+  polygon: Polygon,
+  visible?: Uint8Array | null,
+): number[] {
+  let minX = Infinity;
+  let maxX = -Infinity;
+  let minY = Infinity;
+  let maxY = -Infinity;
+  for (const [x, y] of polygon) {
+    if (x < minX) minX = x;
+    if (x > maxX) maxX = x;
+    if (y < minY) minY = y;
+    if (y > maxY) maxY = y;
+  }
+
+  const { n, xs, ys, zs } = cols;
+  const selected: number[] = [];
+  for (let i = 0; i < n; i++) {
+    if (visible && visible[i] === 0) continue;
+    const x = xs[i];
+    const y = ys[i];
+    const z = zs[i];
+    const w = m[3] * x + m[7] * y + m[11] * z + m[15];
+    if (w <= 0) continue;
+    const sx =
+      (((m[0] * x + m[4] * y + m[8] * z + m[12]) / w) * 0.5 + 0.5) * width;
+    // NDC y points up but screen y points down
+    const sy =
+      (0.5 - ((m[1] * x + m[5] * y + m[9] * z + m[13]) / w) * 0.5) * height;
+    if (
+      sx >= minX &&
+      sx <= maxX &&
+      sy >= minY &&
+      sy <= maxY &&
+      pointInPolygon(polygon, sx, sy)
+    ) {
+      selected.push(i);
+    }
+  }
+  return selected;
+}
+
+/**
+ * The point nearest to (px, py) within radiusPx of the cursor, or null.
+ * Linear scan on purpose: millions of points is single-digit ms and
+ * hover hit-tests are debounced — no spatial index at this stage.
+ * Nearest in screen distance only; with no depth buffer there is no
+ * "topmost" point to prefer.
+ */
+export function nearestPoint(
+  cols: Columns,
+  m: ArrayLike<number>,
+  width: number,
+  height: number,
+  px: number,
+  py: number,
+  radiusPx: number,
+  visible?: Uint8Array | null,
+): HoverHit | null {
+  const { n, xs, ys, zs } = cols;
+  let best = -1;
+  let bestD = radiusPx * radiusPx;
+  let bestX = 0;
+  let bestY = 0;
+  for (let i = 0; i < n; i++) {
+    if (visible && visible[i] === 0) continue;
+    const x = xs[i];
+    const y = ys[i];
+    const z = zs[i];
+    const w = m[3] * x + m[7] * y + m[11] * z + m[15];
+    if (w <= 0) continue;
+    const sx =
+      (((m[0] * x + m[4] * y + m[8] * z + m[12]) / w) * 0.5 + 0.5) * width;
+    const sy =
+      (0.5 - ((m[1] * x + m[5] * y + m[9] * z + m[13]) / w) * 0.5) * height;
+    const dx = sx - px;
+    const dy = sy - py;
+    const d = dx * dx + dy * dy;
+    if (d < bestD) {
+      bestD = d;
+      best = i;
+      bestX = sx;
+      bestY = sy;
+    }
+  }
+  if (best < 0) return null;
+  return {
+    index: best,
+    id: cols.ids[best],
+    label: cols.labelKeys[cols.labelIndex[best]],
+    x: bestX,
+    y: bestY,
+  };
+}

--- a/app/packages/embeddings-v2/src/renderer/pipeline.ts
+++ b/app/packages/embeddings-v2/src/renderer/pipeline.ts
@@ -1,0 +1,105 @@
+import {
+  BufferAttribute,
+  BufferGeometry,
+  HalfFloatType,
+  Mesh,
+  NearestFilter,
+  OrthographicCamera,
+  RawShaderMaterial,
+  Scene,
+  Sphere,
+  Vector3,
+  WebGLRenderTarget,
+  type Camera,
+  type WebGLRenderer,
+} from "three";
+import { DEFAULT_SETTINGS } from "./constants";
+import { SCREEN_FRAGMENT, SCREEN_VERTEX } from "./shaders";
+import type { RenderSettings } from "./types";
+
+/**
+ * The density half of the renderer: an off-screen half-float target the
+ * points accumulate into additively, plus a fullscreen tone-map pass.
+ * render() runs either the two-pass density pipeline or a plain direct
+ * pass (alpha/opaque modes need no accumulation).
+ */
+export class DensityPipeline {
+  private readonly accumTarget: WebGLRenderTarget;
+  private readonly screenScene = new Scene();
+  private readonly screenMaterial: RawShaderMaterial;
+  // The screen pass ignores cameras; any camera object satisfies render()
+  private readonly screenCamera = new OrthographicCamera(-1, 1, 1, -1, 0, 1);
+
+  constructor() {
+    // Accumulated weights exceed 1, so the buffer must be float
+    this.accumTarget = new WebGLRenderTarget(1, 1, {
+      type: HalfFloatType,
+      magFilter: NearestFilter,
+      minFilter: NearestFilter,
+      depthBuffer: false,
+      stencilBuffer: false,
+    });
+
+    // Fullscreen triangle (covers the viewport with 3 vertices, no seam)
+    const quad = new BufferGeometry();
+    quad.setAttribute(
+      "position",
+      new BufferAttribute(new Float32Array([-1, -1, 3, -1, -1, 3]), 2),
+    );
+    // Pre-set so nothing ever calls computeBoundingSphere(), which can't
+    // handle itemSize-2 positions
+    quad.boundingSphere = new Sphere(new Vector3(0, 0, 0), 1);
+    this.screenMaterial = new RawShaderMaterial({
+      vertexShader: SCREEN_VERTEX,
+      fragmentShader: SCREEN_FRAGMENT,
+      uniforms: {
+        uAcc: { value: this.accumTarget.texture },
+        uGamma: { value: DEFAULT_SETTINGS.gamma },
+        uGlow: { value: DEFAULT_SETTINGS.glow },
+        uAlphaSingle: { value: DEFAULT_SETTINGS.singleAlpha },
+      },
+      transparent: true,
+      depthTest: false,
+      depthWrite: false,
+    });
+    const screenMesh = new Mesh(quad, this.screenMaterial);
+    screenMesh.frustumCulled = false;
+    this.screenScene.add(screenMesh);
+  }
+
+  /** Physical pixels — match the canvas drawing buffer exactly */
+  setSize(width: number, height: number): void {
+    this.accumTarget.setSize(width, height);
+  }
+
+  applySettings({ gamma, glow, singleAlpha }: RenderSettings): void {
+    this.screenMaterial.uniforms.uGamma.value = gamma;
+    this.screenMaterial.uniforms.uGlow.value = glow;
+    this.screenMaterial.uniforms.uAlphaSingle.value = singleAlpha;
+  }
+
+  /** Pass 1: accumulate density off-screen; pass 2: tone-map to screen.
+   *  Non-density modes: one pass, points straight onto the canvas. */
+  render(
+    renderer: WebGLRenderer,
+    scene: Scene,
+    camera: Camera,
+    density: boolean,
+  ): void {
+    if (density) {
+      renderer.setRenderTarget(this.accumTarget);
+      renderer.clear();
+      renderer.render(scene, camera);
+      renderer.setRenderTarget(null);
+      renderer.render(this.screenScene, this.screenCamera);
+    } else {
+      renderer.setRenderTarget(null);
+      renderer.render(scene, camera);
+    }
+  }
+
+  dispose(): void {
+    this.screenMaterial.dispose();
+    this.accumTarget.dispose();
+  }
+}

--- a/app/packages/embeddings-v2/src/renderer/selectionLayers.test.ts
+++ b/app/packages/embeddings-v2/src/renderer/selectionLayers.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { SelectionLayers } from "./selectionLayers";
+
+describe("SelectionLayers", () => {
+  // The reported bug, end to end: lasso 5 points, check a grid sample,
+  // uncheck it — the lasso's emphasis must come back, not vanish
+  it("restores the lasso when the host selection clears", () => {
+    const layers = new SelectionLayers();
+    expect(layers.writeLasso([1, 2, 3, 4, 5])).toEqual([1, 2, 3, 4, 5]);
+    expect(layers.writeHost([1])).toEqual([1]);
+    expect(layers.writeHost(null)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("restores the host when the lasso clears", () => {
+    const layers = new SelectionLayers();
+    layers.writeHost([7]);
+    expect(layers.writeLasso([1, 2])).toEqual([1, 2]);
+    // Empty-space click / empty lasso: back to the checkbox emphasis
+    expect(layers.writeLasso(null)).toEqual([7]);
+  });
+
+  // Plain precedence fails here in one direction or the other; the
+  // most recent writer must render
+  it("renders the most recent writer, either order", () => {
+    const layers = new SelectionLayers();
+    layers.writeHost([7]);
+    expect(layers.writeLasso([1, 2])).toEqual([1, 2]);
+    expect(layers.writeHost([8])).toEqual([8]);
+  });
+
+  it("clear drops both layers", () => {
+    const layers = new SelectionLayers();
+    layers.writeLasso([1, 2]);
+    layers.writeHost([7]);
+    expect(layers.clear()).toBeNull();
+    expect(layers.current()).toBeNull();
+    // Nothing resurrects after an explicit clear
+    expect(layers.writeHost(null)).toBeNull();
+    expect(layers.writeLasso(null)).toBeNull();
+  });
+
+  it("is empty until someone writes", () => {
+    expect(new SelectionLayers().current()).toBeNull();
+  });
+});

--- a/app/packages/embeddings-v2/src/renderer/selectionLayers.ts
+++ b/app/packages/embeddings-v2/src/renderer/selectionLayers.ts
@@ -1,0 +1,49 @@
+/**
+ * Two retained selection layers sharing the chart's one emphasis
+ * channel: the HOST layer (external selections — in FiftyOne terms,
+ * grid checkboxes arriving through the `selected` prop) and the LASSO
+ * layer (the chart's own gesture). One channel, last-writer-wins, was
+ * the bug this replaces: checking then unchecking a grid sample
+ * clobbered a live lasso's emphasis with no way back, while the grid
+ * itself stayed scoped to the lasso — the plot alone forgot.
+ *
+ * The rule: the most recent non-null writer renders; clearing the
+ * active layer falls back to the other (which is what makes uncheck
+ * RESTORE the lasso); an explicit clear drops both. Plain precedence
+ * fails in one direction or the other — "host wins" hides a new lasso
+ * drawn while a checkbox is ticked, "lasso wins" hides the checkbox —
+ * recency matches the user's intent in both.
+ */
+export class SelectionLayers {
+  private host: ArrayLike<number> | null = null;
+  private lasso: ArrayLike<number> | null = null;
+  private active: "host" | "lasso" | null = null;
+
+  /** External selection changed; returns what should render */
+  writeHost(indices: ArrayLike<number> | null): ArrayLike<number> | null {
+    this.host = indices;
+    this.active = indices ? "host" : this.lasso ? "lasso" : null;
+    return this.current();
+  }
+
+  /** The chart's lasso changed; returns what should render */
+  writeLasso(indices: ArrayLike<number> | null): ArrayLike<number> | null {
+    this.lasso = indices;
+    this.active = indices ? "lasso" : this.host ? "host" : null;
+    return this.current();
+  }
+
+  /** Drop both layers (Esc, clear affordances, new data) */
+  clear(): null {
+    this.host = null;
+    this.lasso = null;
+    this.active = null;
+    return null;
+  }
+
+  current(): ArrayLike<number> | null {
+    if (this.active === "host") return this.host;
+    if (this.active === "lasso") return this.lasso;
+    return null;
+  }
+}

--- a/app/packages/embeddings-v2/src/renderer/shaders.ts
+++ b/app/packages/embeddings-v2/src/renderer/shaders.ts
@@ -1,0 +1,193 @@
+// All GLSL lives here — the shaders ARE the renderer; the host library
+// is a commodity. This file is the swap point for visual experiments.
+import { BASE_ALPHA, DIM_ALPHA, DIM_DESATURATION, DIM_TINT } from "./constants";
+
+// One vertex shader for every camera adapter: projectionMatrix ·
+// modelViewMatrix covers any projection (three.js binds both for
+// RawShaderMaterial when declared). Selection never restyles the
+// emphasized points — they keep their exact color and size; everything
+// else recedes (weight cut + desaturation toward gray). Visibility is
+// a separate mechanism: visible=0 points (view-stage subsetting) clip
+// out entirely, costing only a vertex shader run.
+export const POINTS_VERTEX = /* glsl */ `
+  precision highp float;
+
+  attribute vec3 position;
+  attribute vec3 color;
+  attribute float emphasis;
+  attribute float visible;
+
+  uniform mat4 projectionMatrix;
+  uniform mat4 modelViewMatrix;
+  uniform float uPointSize;
+  uniform float uHasSelection;
+
+  varying vec3 vColor;
+  varying float vWeight;
+
+  void main() {
+    // dim = 1 for a non-selected point while a selection is active.
+    // Dimming cuts the point's weight AND desaturates it toward gray:
+    // the weight cut fades isolated points, the desaturation is what
+    // survives density accumulation in deep piles (see constants.ts)
+    float dim = uHasSelection * (1.0 - emphasis);
+    vColor = mix(color, vec3(${DIM_TINT}), dim * ${DIM_DESATURATION});
+    vWeight = mix(1.0, ${DIM_ALPHA}, dim);
+    if (visible < 0.5) {
+      // Outside the clip volume (z > w): never rasterized
+      gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
+      gl_PointSize = 0.0;
+      return;
+    }
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+    gl_PointSize = uPointSize;
+  }
+`;
+
+// uMode: 0 = alpha compositing, 1 = density accumulation, 2 = opaque
+export const POINTS_FRAGMENT = /* glsl */ `
+  precision highp float;
+
+  uniform float uMode;
+  uniform float uOpacity;
+
+  varying vec3 vColor;
+  varying float vWeight;
+
+  void main() {
+    float dist = length(gl_PointCoord - 0.5);
+    if (uMode > 1.5) {
+      // opaque(ish): depth-tested occlusion, AA edges via blending, and
+      // uOpacity leaves a hint of see-through. Unsorted, so at low
+      // opacity rear points pop instead of fading — keep it near 1.
+      // Dimming darkens (a depth-written low-alpha point would block
+      // whatever sits behind it)
+      float edge = 1.0 - smoothstep(0.4, 0.5, dist);
+      if (edge == 0.0) discard;
+      gl_FragColor = vec4(vColor * vWeight, edge * uOpacity);
+    } else {
+      float edge = 1.0 - smoothstep(0.4, 0.5, dist);
+      if (edge == 0.0) discard;
+      float w = edge * vWeight;
+      // density: premultiplied (color·w, w) for additive accumulation;
+      // alpha: plain (color, coverage·alpha) for classic compositing
+      gl_FragColor = mix(
+        vec4(vColor, w * ${BASE_ALPHA}),
+        vec4(vColor * w, w),
+        uMode
+      );
+    }
+  }
+`;
+
+// Selection overlay pass: only emphasized points survive; everything
+// else clips out exactly like visible=0 does in the main pass. Drawn
+// AFTER the density/tone-map composite, straight onto the canvas —
+// inside the accumulation a lone selected point is averaged against
+// every overlapping neighbor and disappears into deep piles; on top it
+// cannot lose. Same attributes, so the geometry is shared verbatim.
+export const EMPHASIS_VERTEX = /* glsl */ `
+  precision highp float;
+
+  attribute vec3 position;
+  attribute vec3 color;
+  attribute float emphasis;
+  attribute float visible;
+
+  uniform mat4 projectionMatrix;
+  uniform mat4 modelViewMatrix;
+  uniform float uPointSize;
+
+  varying vec3 vColor;
+
+  void main() {
+    vColor = color;
+    if (emphasis < 0.5 || visible < 0.5) {
+      // Outside the clip volume (z > w): never rasterized
+      gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
+      gl_PointSize = 0.0;
+      return;
+    }
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+    gl_PointSize = uPointSize;
+  }
+`;
+
+// A plain disc of the point's own color at full opacity, slightly
+// larger than the base marker (EMPHASIS_SIZE_PX). Full opacity over
+// the finished composite IS the emphasis — deliberately no extra
+// ornament, so a thousands-deep lasso selection stays calm.
+export const EMPHASIS_FRAGMENT = /* glsl */ `
+  precision highp float;
+
+  varying vec3 vColor;
+
+  void main() {
+    float dist = length(gl_PointCoord - 0.5);
+    float edge = 1.0 - smoothstep(0.44, 0.5, dist);
+    if (edge == 0.0) discard;
+    gl_FragColor = vec4(vColor, edge);
+  }
+`;
+
+/**
+ * Density tone map (screen pass). Input: additively accumulated
+ * rgb = sum(pointColor · weight), a = sum(weight). A single point stays
+ * clearly visible; piles asymptote to full opacity and glow toward
+ * white so thousands-deep cores read differently than ten-deep.
+ *
+ * uGamma reshapes the curve around d=1 (pow(1, g) == 1, so a single
+ * point's visibility never changes); uGlow scales the white-glow term
+ * (0 = piles keep their label hue); uAlphaSingle is the alpha of an
+ * isolated point. Returns non-premultiplied rgba.
+ */
+export const TONEMAP_GLSL = /* glsl */ `
+  uniform float uGamma;
+  uniform float uGlow;
+  uniform float uAlphaSingle;
+
+  vec4 toneMap(vec4 acc) {
+    if (acc.a <= 0.0) return vec4(0.0);
+    // rgb summed color*weight and a summed weight, so rgb/a is the
+    // density-weighted average color at this pixel
+    vec3 base = acc.rgb / acc.a;
+    float d = pow(acc.a, uGamma);
+    // Opacity: linear ramp up to the single-point alpha while coverage
+    // is partial (d < 1), then exponential saturation toward 1.0 as the
+    // pile deepens (d=2 ≈ 0.7, d=5 ≈ 0.95)
+    float alpha = uAlphaSingle * min(d, 1.0) +
+      (1.0 - uAlphaSingle) * (1.0 - exp(-max(d - 1.0, 0.0) * 0.35));
+    // Glow: blend toward white with the log of density so 1000-deep
+    // cores read hotter than 10-deep ones; capped at 45% so the point
+    // hue stays recognizable
+    vec3 color = mix(base, vec3(1.0), uGlow * min(0.45, 0.06 * log2(1.0 + d)));
+    return vec4(color, alpha);
+  }
+`;
+
+export const SCREEN_VERTEX = /* glsl */ `
+  precision highp float;
+
+  attribute vec2 position;
+  varying vec2 vUv;
+
+  void main() {
+    vUv = position * 0.5 + 0.5;
+    gl_Position = vec4(position, 0.0, 1.0);
+  }
+`;
+
+export const SCREEN_FRAGMENT = /* glsl */ `
+  precision highp float;
+
+  varying vec2 vUv;
+  uniform sampler2D uAcc;
+
+  ${TONEMAP_GLSL}
+
+  void main() {
+    vec4 mapped = toneMap(texture2D(uAcc, vUv));
+    if (mapped.a <= 0.0) discard;
+    gl_FragColor = mapped;
+  }
+`;

--- a/app/packages/embeddings-v2/src/renderer/types.ts
+++ b/app/packages/embeddings-v2/src/renderer/types.ts
@@ -1,0 +1,107 @@
+import type { Camera } from "three";
+
+/** One embedding point as delivered by the host application */
+export interface EmbeddingPoint {
+  id: string;
+  x: number;
+  y: number;
+  /**
+   * Optional third coordinate. Ignored (the data renders flat) unless
+   * the host supplies a zCamera adapter for it.
+   */
+  z?: number;
+  label: string | null;
+}
+
+/**
+ * Compositing mode + tone-map tuning, applied live.
+ *
+ * - "density": two-pass accumulate-then-tone-map — order-independent,
+ *   single outliers stay visible, piles saturate and glow
+ * - "alpha": classic src-alpha compositing straight to the canvas
+ * - "opaque": depth test + write — real occlusion; dimming darkens
+ *   instead of fading, and singleAlpha doubles as per-point opacity
+ */
+export interface RenderSettings {
+  mode: "density" | "alpha" | "opaque";
+  /** Density tone-map curve; pivots at d=1 so lone points never change */
+  gamma: number;
+  /** 0..1 scale on the toward-white glow of dense piles (density only) */
+  glow: number;
+  /** Alpha of an isolated point (density) / point opacity (opaque) */
+  singleAlpha: number;
+}
+
+/** One hovered or clicked point, reported through the chart's callbacks */
+export interface HoverHit {
+  index: number;
+  id: string;
+  label: string;
+  /** The point's projected position in CSS px relative to the container */
+  x: number;
+  y: number;
+}
+
+/** Screen-space polygon, CSS px */
+export type Polygon = Array<[number, number]>;
+
+/**
+ * Who owns a plain drag: "select" draws the lasso (the default),
+ * "explore" gives it to the camera. Modified gestures (wheel zoom,
+ * shift/middle-drag pan) work in both modes.
+ */
+export type InteractionMode = "explore" | "select";
+
+/**
+ * Everything the chart needs from a camera: a three.js camera kept
+ * current, framing/reset driven by data bounds, and the gesture split
+ * (which pointer-down starts a lasso vs. a camera drag).
+ */
+export interface CameraAdapter {
+  readonly camera: Camera;
+  /** Frame the camera on new data bounds; also becomes the reset target
+   * and clears any focus (new data, stale focus) */
+  setBounds(bounds: Bounds, width: number, height: number): void;
+  resize(width: number, height: number): void;
+  reset(): void;
+  /**
+   * Direct the camera's attention to a sub-region — the bounds of the
+   * currently visible points: reset() re-frames to the focus instead
+   * of the full data bounds, and orbit-style cameras move their pivot
+   * there. Must never yank the current view. Null restores full-data
+   * attention (everything visible). Optional; adapters without it keep
+   * full-bounds framing.
+   */
+  setFocus?(bounds: Bounds | null): void;
+  /** True when this pointer-down should draw a lasso, not move the camera */
+  isLassoStart(event: PointerEvent): boolean;
+  /** Adopt an interaction mode; adapters without modes may omit this */
+  setMode?(mode: InteractionMode): void;
+  /**
+   * Converts a screen-space polygon (CSS px) to data-space vertices,
+   * when the projection makes that well-defined — hosts send the tiny
+   * data polygon to a server instead of materializing selection ids.
+   * Adapters without an exact mapping return null.
+   */
+  toDataPolygon?(polygon: Polygon): Array<[number, number]> | null;
+  destroy(): void;
+}
+
+/**
+ * Builds a camera adapter — the chart's extension seam for alternative
+ * cameras. `onChange` must fire whenever the camera moves so the chart
+ * can re-render and re-test hover.
+ */
+export type CameraAdapterFactory = (
+  container: HTMLElement,
+  onChange: () => void,
+) => CameraAdapter;
+
+export interface Bounds {
+  xMin: number;
+  xMax: number;
+  yMin: number;
+  yMax: number;
+  zMin: number;
+  zMax: number;
+}

--- a/app/packages/embeddings-v2/src/state.ts
+++ b/app/packages/embeddings-v2/src/state.ts
@@ -1,0 +1,23 @@
+import { atom } from "recoil";
+
+/**
+ * The active plot selection's size, published by the plot view for
+ * chrome that lives outside it (the panel tab's selection pill). Null
+ * when nothing is selected or no plot is open. This is deliberately a
+ * count, not an id list — selections resolve server-side as view
+ * stages and ids are never materialized on the client.
+ */
+export const selectionCountState = atom<number | null>({
+  key: "embeddings-v2/selection-count",
+  default: null,
+});
+
+/**
+ * Clear-selection requests from outside the plot view (the tab pill's
+ * dismiss). A monotonic nonce rather than a boolean: the plot view
+ * reacts to changes, so repeated requests always fire.
+ */
+export const clearSelectionNonceState = atom<number>({
+  key: "embeddings-v2/clear-selection-nonce",
+  default: 0,
+});

--- a/app/packages/embeddings-v2/src/useColorColumn.test.ts
+++ b/app/packages/embeddings-v2/src/useColorColumn.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  fetchColor,
+  fetchColorByChoices,
+  type ColorResponse,
+  type VisualizationRun,
+} from "./protocol";
+import { useColorColumn } from "./useColorColumn";
+
+vi.mock("./protocol", () => ({
+  fetchColorByChoices: vi.fn(),
+  fetchColor: vi.fn(),
+}));
+
+const RUN: VisualizationRun = {
+  brainKey: "viz",
+  method: null,
+  dims: 2,
+  patchesField: null,
+  pointsField: null,
+  model: null,
+  ready: true,
+  timestamp: null,
+};
+
+const RESPONSE: ColorResponse = {
+  values: { style: "categorical", indices: new Uint16Array([0, 1, 0]) },
+  meta: { style: "categorical" },
+};
+
+describe("useColorColumn", () => {
+  it("loads field choices for the run", async () => {
+    vi.mocked(fetchColorByChoices).mockResolvedValue(["a", "b"]);
+    const { result } = renderHook(() => useColorColumn("ds", "viz", RUN, null));
+
+    await waitFor(() => expect(result.current.choices).toEqual(["a", "b"]));
+    expect(result.current.colors).toBeNull();
+    expect(fetchColor).not.toHaveBeenCalled();
+  });
+
+  it("falls back to no choices when the endpoint fails", async () => {
+    vi.mocked(fetchColorByChoices).mockResolvedValueOnce(["a"]);
+    const { result, rerender } = renderHook(
+      ({ run }: { run: VisualizationRun }) =>
+        useColorColumn("ds", "viz", run, null),
+      { initialProps: { run: RUN } },
+    );
+    await waitFor(() => expect(result.current.choices).toEqual(["a"]));
+
+    vi.mocked(fetchColorByChoices).mockRejectedValueOnce(new Error("nope"));
+    rerender({ run: { ...RUN } });
+    await waitFor(() => expect(result.current.choices).toEqual([]));
+    expect(result.current.error).toBeNull();
+  });
+
+  it("builds the rgb column for the selected field", async () => {
+    vi.mocked(fetchColorByChoices).mockResolvedValue(["label"]);
+    vi.mocked(fetchColor).mockResolvedValue(RESPONSE);
+    const { result } = renderHook(() =>
+      useColorColumn("ds", "viz", RUN, "label"),
+    );
+
+    await waitFor(() => expect(result.current.colors).not.toBeNull());
+    // One rgb triplet per point, same class -> same color
+    const colors = result.current.colors as Float32Array;
+    expect(colors.length).toBe(9);
+    expect([...colors.slice(0, 3)]).toEqual([...colors.slice(6, 9)]);
+  });
+
+  it("clears the column immediately when the field changes", async () => {
+    vi.mocked(fetchColorByChoices).mockResolvedValue(["a", "b"]);
+    vi.mocked(fetchColor).mockResolvedValueOnce(RESPONSE);
+    const { result, rerender } = renderHook(
+      ({ field }: { field: string | null }) =>
+        useColorColumn("ds", "viz", RUN, field),
+      { initialProps: { field: "a" as string | null } },
+    );
+    await waitFor(() => expect(result.current.colors).not.toBeNull());
+
+    // The next fetch never resolves; a stale column must not linger
+    vi.mocked(fetchColor).mockImplementationOnce(
+      () => new Promise<ColorResponse>(() => undefined),
+    );
+    rerender({ field: "b" });
+    expect(result.current.colors).toBeNull();
+
+    // Deselecting also clears without fetching
+    rerender({ field: null });
+    expect(result.current.colors).toBeNull();
+  });
+
+  it("reports color fetch failures", async () => {
+    vi.mocked(fetchColorByChoices).mockResolvedValue(["a"]);
+    vi.mocked(fetchColor).mockRejectedValue(new Error("boom"));
+    const { result } = renderHook(() => useColorColumn("ds", "viz", RUN, "a"));
+
+    await waitFor(() => expect(result.current.error).toMatch("boom"));
+    // Failure also ends the loading state, or the spinner never leaves
+    expect(result.current.loading).toBe(false);
+  });
+
+  // Column fetches take seconds at scale; hosts need a progress signal
+  it("reports loading while a column fetch is in flight", async () => {
+    vi.mocked(fetchColorByChoices).mockResolvedValue(["a"]);
+    let resolve: (response: ColorResponse) => void = () => undefined;
+    vi.mocked(fetchColor).mockImplementationOnce(
+      () => new Promise<ColorResponse>((r) => (resolve = r)),
+    );
+    const { result, rerender } = renderHook(
+      ({ field }: { field: string | null }) =>
+        useColorColumn("ds", "viz", RUN, field),
+      { initialProps: { field: "a" as string | null } },
+    );
+
+    expect(result.current.loading).toBe(true);
+    resolve(RESPONSE);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.colors).not.toBeNull();
+
+    // Deselecting the field never enters a loading state
+    rerender({ field: null });
+    expect(result.current.loading).toBe(false);
+  });
+});

--- a/app/packages/embeddings-v2/src/useColorColumn.ts
+++ b/app/packages/embeddings-v2/src/useColorColumn.ts
@@ -1,0 +1,88 @@
+import { useEffect, useState } from "react";
+import { buildColors } from "./colors";
+import {
+  fetchColor,
+  fetchColorByChoices,
+  type ColorMeta,
+  type ColorValues,
+  type VisualizationRun,
+} from "./protocol";
+
+/**
+ * Color-by support: the run-dependent field choices, the built rgb
+ * column for the selected field, the raw value column (`values` — the
+ * hover card's swatch reads it), and the field's meta (classes/counts
+ * for the legend). All of `colors`/`values`/`meta` are null while no
+ * field is selected or a fetch is in flight — they clear immediately
+ * on any input change so a stale column never colors another run's
+ * points.
+ */
+export function useColorColumn(
+  datasetName: string | null,
+  brainKey: string | null,
+  run: VisualizationRun | null,
+  colorField: string | null,
+): {
+  choices: string[];
+  colors: Float32Array | null;
+  values: ColorValues | null;
+  meta: ColorMeta | null;
+  /** A column fetch is in flight — the field's first hit aggregates
+   * server-side and can take seconds at scale, so hosts show progress */
+  loading: boolean;
+  error: string | null;
+} {
+  const [choices, setChoices] = useState<string[]>([]);
+  const [colors, setColors] = useState<Float32Array | null>(null);
+  const [values, setValues] = useState<ColorValues | null>(null);
+  const [meta, setMeta] = useState<ColorMeta | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Color-by field choices depend on the run (patches vs samples)
+  useEffect(() => {
+    // The previous run's fields must not populate the new run's menu
+    setChoices([]);
+    if (!datasetName || !run) return undefined;
+    let stale = false;
+    fetchColorByChoices(datasetName, run.patchesField)
+      .then((fields) => !stale && setChoices(fields))
+      .catch(() => !stale && setChoices([]));
+    return () => {
+      stale = true;
+    };
+  }, [datasetName, run]);
+
+  useEffect(() => {
+    setColors(null);
+    setValues(null);
+    setMeta(null);
+    // A stale failure must not banner over a later successful field
+    setError(null);
+    if (!datasetName || !brainKey || !colorField) {
+      setLoading(false);
+      return undefined;
+    }
+    let stale = false;
+    setLoading(true);
+    fetchColor(datasetName, brainKey, colorField)
+      .then(({ values: column, meta: fieldMeta }) => {
+        if (stale) return;
+        setColors(
+          buildColors(column, {
+            min: fieldMeta.min ?? null,
+            max: fieldMeta.max ?? null,
+          }),
+        );
+        setValues(column);
+        setMeta(fieldMeta);
+      })
+      .catch((e) => !stale && setError(String(e)))
+      .finally(() => !stale && setLoading(false));
+    return () => {
+      stale = true;
+    };
+  }, [datasetName, brainKey, colorField]);
+
+  return { choices, colors, values, meta, loading, error };
+}

--- a/app/packages/embeddings-v2/src/useDraggable.ts
+++ b/app/packages/embeddings-v2/src/useDraggable.ts
@@ -1,0 +1,179 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ *
+ * Copied verbatim from @voxel51/voodo `src/util/useDraggable.ts`, which
+ * the library uses for Toolbar but does not (yet) export from its root.
+ * Delete this copy and import from the package once VOODO exports it.
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from "react";
+
+const clamp = (
+  lock: boolean,
+  pos: number,
+  delta: number,
+  max: number,
+): number => (lock ? pos : Math.max(0, Math.min(max, pos + delta)));
+
+export interface UseDraggableOptions {
+  /** Initial offset from the left edge of the bounding container. Accepts any CSS length (e.g. `0`, `"10%"`, `"2rem"`). Default `0`. */
+  initialX?: string | number;
+  /** Initial offset from the top edge of the bounding container. Accepts any CSS length (e.g. `0`, `"10%"`, `"2rem"`). Default `0`. */
+  initialY?: string | number;
+  /** Lock horizontal (x-axis) movement. Default `false`. */
+  lockX?: boolean;
+  /** Lock vertical (y-axis) movement. Default `false`. */
+  lockY?: boolean;
+  /**
+   * When `true`, bounds are computed against the viewport (`window.innerWidth` /
+   * `window.innerHeight`) instead of the element's parent. Use together with
+   * `position: fixed`. Default `false`.
+   */
+  portal?: boolean;
+  /**
+   * Called after every drag move with the new pixel position.
+   * Always delivers pixel values regardless of what type `initialX`/`initialY` were.
+   */
+  onPositionChange?: (pos: { x: number; y: number }) => void;
+}
+
+export interface UseDraggableReturn {
+  /** Current `{ x, y }` position. Before the first drag this reflects the initial CSS value; after the first drag it is always a pixel number. */
+  position: { x: string | number; y: string | number };
+  /** `true` while the user is actively dragging. */
+  isDragging: boolean;
+  /** Attach to the element that should be repositioned. */
+  containerRef: React.RefObject<HTMLElement | null>;
+  /**
+   * `onMouseDown` handler for the drag-handle element.
+   * Only has an effect when both `lockX` and `lockY` are not both `true`.
+   */
+  handleDragStart: (e: React.MouseEvent) => void;
+}
+
+/**
+ * Hook that provides drag-to-reposition behaviour for a floating element.
+ *
+ * The hook tracks mouse interactions and keeps the element within the bounds of
+ * either its nearest parent element or the viewport (when `portal` is `true`).
+ *
+ * @example
+ * ```tsx
+ * const { position, isDragging, containerRef, handleDragStart } = useDraggable({
+ *   initialX: 20,
+ *   initialY: 100,
+ * });
+ *
+ * return (
+ *   <div
+ *     ref={containerRef}
+ *     data-dragging={isDragging || undefined}
+ *     style={{ position: "absolute", left: position.x, top: position.y }}
+ *   >
+ *     <button onMouseDown={handleDragStart}>drag me</button>
+ *   </div>
+ * );
+ * ```
+ */
+export const useDraggable = ({
+  initialX = 0,
+  initialY = 0,
+  lockX = false,
+  lockY = false,
+  portal = false,
+  onPositionChange,
+}: UseDraggableOptions = {}): UseDraggableReturn => {
+  const canDrag = !(lockX && lockY);
+
+  const [position, setPosition] = useState<{
+    x: string | number;
+    y: string | number;
+  }>({ x: initialX, y: initialY });
+  const [isDragging, setIsDragging] = useState(false);
+
+  const containerRef = useRef<HTMLElement | null>(null);
+  const dragStartRef = useRef<{
+    clientX: number;
+    clientY: number;
+    pos: { x: number; y: number };
+  }>({
+    clientX: 0,
+    clientY: 0,
+    pos: { x: 0, y: 0 },
+  });
+  // Mutable mirror of position so handleDragStart can read the current numeric
+  // position without being listed as a useCallback dependency.
+  const positionRef = useRef<{ x: string | number; y: string | number }>({
+    x: initialX,
+    y: initialY,
+  });
+
+  const handleDragStart = useCallback(
+    (e: React.MouseEvent) => {
+      if (!canDrag) return;
+      e.preventDefault();
+      e.stopPropagation();
+      setIsDragging(true);
+      const el = containerRef.current;
+      const cur = positionRef.current;
+      // For numeric positions use the tracked value (avoids jsdom offsetLeft=0).
+      // For CSS string positions (e.g. "4rem", "22%") read offsetLeft/offsetTop
+      // so the browser-resolved pixel value is used as the drag origin.
+      dragStartRef.current = {
+        clientX: e.clientX,
+        clientY: e.clientY,
+        pos: {
+          x: typeof cur.x === "number" ? cur.x : (el?.offsetLeft ?? 0),
+          y: typeof cur.y === "number" ? cur.y : (el?.offsetTop ?? 0),
+        },
+      };
+    },
+    [canDrag],
+  );
+
+  const handleMouseMove = useCallback(
+    (e: MouseEvent) => {
+      const el = containerRef.current;
+      const fallback = {
+        clientWidth: window.innerWidth,
+        clientHeight: window.innerHeight,
+      };
+      const parent = portal ? fallback : (el?.parentElement ?? fallback);
+
+      const toolbarW = el?.offsetWidth ?? 0;
+      const toolbarH = el?.offsetHeight ?? 0;
+      const { clientX, clientY, pos } = dragStartRef.current;
+
+      const nextX = clamp(
+        lockX,
+        pos.x,
+        e.clientX - clientX,
+        parent.clientWidth - toolbarW,
+      );
+      const nextY = clamp(
+        lockY,
+        pos.y,
+        e.clientY - clientY,
+        parent.clientHeight - toolbarH,
+      );
+
+      positionRef.current = { x: nextX, y: nextY };
+      setPosition({ x: nextX, y: nextY });
+      onPositionChange?.({ x: nextX, y: nextY });
+    },
+    [lockX, lockY, portal, onPositionChange],
+  );
+
+  useEffect(() => {
+    if (!isDragging) return;
+    const handleMouseUp = (): void => setIsDragging(false);
+    document.addEventListener("mousemove", handleMouseMove);
+    document.addEventListener("mouseup", handleMouseUp);
+    return () => {
+      document.removeEventListener("mousemove", handleMouseMove);
+      document.removeEventListener("mouseup", handleMouseUp);
+    };
+  }, [isDragging, handleMouseMove]);
+
+  return { position, isDragging, containerRef, handleDragStart };
+};

--- a/app/packages/embeddings-v2/src/useHoverInfo.test.ts
+++ b/app/packages/embeddings-v2/src/useHoverInfo.test.ts
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { fetchSampleInfo, type SampleInfo } from "./protocol";
+import type { HoverHit } from "./renderer";
+import { useHoverInfo } from "./useHoverInfo";
+
+vi.mock("./protocol", () => ({ fetchSampleInfo: vi.fn() }));
+
+const hit = (index: number): HoverHit => ({
+  index,
+  id: `id${index}`,
+  label: "",
+  x: 0,
+  y: 0,
+});
+
+const info = (index: number): SampleInfo => ({
+  id: `id${index}`,
+  sampleId: `sample${index}`,
+  filepath: `/data/nested/img${index}.jpg`,
+  media: `media${index}.jpg`,
+  value: `value${index}`,
+});
+
+const mediaUrl = (media: string) => `url:${media}`;
+
+describe("useHoverInfo", () => {
+  it("resolves sample info into hover content", async () => {
+    vi.mocked(fetchSampleInfo).mockResolvedValue(info(1));
+    const { result } = renderHook(() =>
+      useHoverInfo("ds", "viz", "label", mediaUrl, () => "#abcdef"),
+    );
+
+    act(() => result.current.handleHover(hit(1)));
+
+    await waitFor(() => expect(result.current.hover).not.toBeNull());
+    expect(result.current.hover?.src).toBe("url:media1.jpg");
+    // Value pairs with the point's rendered color; the filename is the
+    // basename; ids never surface
+    expect(result.current.hover?.value).toEqual({
+      label: "value1",
+      swatch: "#abcdef",
+    });
+    expect(result.current.hover?.filename).toBe("img1.jpg");
+  });
+
+  it("serves repeat hovers from the cache", async () => {
+    vi.mocked(fetchSampleInfo).mockClear().mockResolvedValue(info(1));
+    const { result } = renderHook(() =>
+      useHoverInfo("ds", "viz", null, mediaUrl),
+    );
+
+    act(() => result.current.handleHover(hit(1)));
+    await waitFor(() => expect(result.current.hover).not.toBeNull());
+    act(() => result.current.handleHover(null));
+    act(() => result.current.handleHover(hit(1)));
+
+    await waitFor(() => expect(result.current.hover).not.toBeNull());
+    expect(fetchSampleInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops info that resolves after the pointer moved on", async () => {
+    let release!: (value: SampleInfo) => void;
+    vi.mocked(fetchSampleInfo)
+      .mockImplementationOnce(
+        () => new Promise<SampleInfo>((res) => (release = res)),
+      )
+      .mockResolvedValueOnce(info(2));
+    const { result } = renderHook(() =>
+      useHoverInfo("ds", "viz", null, mediaUrl),
+    );
+
+    act(() => result.current.handleHover(hit(1)));
+    act(() => result.current.handleHover(hit(2)));
+    await waitFor(() => expect(result.current.hover).not.toBeNull());
+
+    act(() => release(info(1)));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(result.current.hover?.hit.index).toBe(2);
+  });
+
+  it("clears on hover-out", async () => {
+    vi.mocked(fetchSampleInfo).mockResolvedValue(info(1));
+    const { result } = renderHook(() =>
+      useHoverInfo("ds", "viz", null, mediaUrl),
+    );
+
+    act(() => result.current.handleHover(hit(1)));
+    await waitFor(() => expect(result.current.hover).not.toBeNull());
+    act(() => result.current.handleHover(null));
+    expect(result.current.hover).toBeNull();
+  });
+
+  // The guard must be the FULL request identity: same index, previous
+  // run — the stale response used to land because only the index matched
+  it("drops an in-flight response that resolves after a run change", async () => {
+    let resolveInfo: (value: ReturnType<typeof info>) => void = () => undefined;
+    vi.mocked(fetchSampleInfo).mockImplementationOnce(
+      () => new Promise((resolve) => (resolveInfo = resolve)),
+    );
+    const { result, rerender } = renderHook(
+      ({ brainKey }: { brainKey: string }) =>
+        useHoverInfo("ds", brainKey, null, mediaUrl),
+      { initialProps: { brainKey: "viz" } },
+    );
+
+    act(() => result.current.handleHover(hit(1)));
+    rerender({ brainKey: "viz2" });
+    // Same index, new run: hover the new run's point 1 with a pending
+    // fetch, then let the OLD run's response arrive
+    vi.mocked(fetchSampleInfo).mockImplementationOnce(
+      () => new Promise(() => undefined),
+    );
+    act(() => result.current.handleHover(hit(1)));
+    await act(async () => {
+      resolveInfo(info(1));
+    });
+    expect(result.current.hover).toBeNull();
+  });
+
+  it("clears the card when the run changes", async () => {
+    vi.mocked(fetchSampleInfo).mockResolvedValue(info(1));
+    const { result, rerender } = renderHook(
+      ({ brainKey }: { brainKey: string }) =>
+        useHoverInfo("ds", brainKey, null, mediaUrl),
+      { initialProps: { brainKey: "viz" } },
+    );
+
+    act(() => result.current.handleHover(hit(1)));
+    await waitFor(() => expect(result.current.hover).not.toBeNull());
+
+    rerender({ brainKey: "viz2" });
+    expect(result.current.hover).toBeNull();
+  });
+});

--- a/app/packages/embeddings-v2/src/useHoverInfo.ts
+++ b/app/packages/embeddings-v2/src/useHoverInfo.ts
@@ -1,0 +1,81 @@
+import { useEffect, useRef, useState } from "react";
+import type { HoverContent } from "./HoverCard";
+import { fetchSampleInfo, type SampleInfo } from "./protocol";
+import type { HoverHit } from "./renderer";
+
+/**
+ * Hover -> lazy sample info, cached per run/field/index. `mediaUrl`
+ * maps a server media path to a browser URL (the App's getSampleSrc)
+ * — injected because URL resolution is deployment-specific.
+ * `pointSwatch` resolves a wire-order index to the point's rendered
+ * color, so the card's value line matches the plot exactly.
+ */
+export function useHoverInfo(
+  datasetName: string | null,
+  brainKey: string | null,
+  colorField: string | null,
+  mediaUrl: (media: string) => string,
+  pointSwatch?: (index: number) => string | null,
+): {
+  hover: HoverContent | null;
+  handleHover: (hit: HoverHit | null) => void;
+} {
+  const [hover, setHover] = useState<HoverContent | null>(null);
+  const hoverKeyRef = useRef<string | null>(null);
+  const infoCache = useRef(new Map<string, SampleInfo>());
+
+  // A new run reorders the wire, invalidating cached indices
+  useEffect(() => {
+    infoCache.current.clear();
+    setHover(null);
+  }, [datasetName, brainKey]);
+
+  const handleHover = (hit: HoverHit | null) => {
+    if (!hit || !datasetName || !brainKey) {
+      hoverKeyRef.current = null;
+      setHover(null);
+      return;
+    }
+    // The FULL request identity: a response for the same index but a
+    // previous dataset/run/field must not land on the current hover
+    const key = `${datasetName}::${brainKey}::${colorField ?? ""}::${hit.index}`;
+    hoverKeyRef.current = key;
+    const apply = (info: SampleInfo) => {
+      // The pointer (or the run) may have moved on while this resolved
+      if (hoverKeyRef.current !== key) return;
+
+      let value: HoverContent["value"] = null;
+      if (info.value !== null && info.value !== undefined) {
+        const raw = info.value;
+        const label =
+          typeof raw === "number"
+            ? String(Number(raw.toFixed(4)))
+            : String(raw);
+        value = { label, swatch: pointSwatch?.(hit.index) ?? null };
+      }
+
+      setHover({
+        hit,
+        src: info.media ? mediaUrl(info.media) : null,
+        value,
+        filename: info.filepath
+          ? (info.filepath.split(/[\\/]/).pop() ?? null)
+          : null,
+      });
+    };
+
+    const cached = infoCache.current.get(key);
+    if (cached) {
+      apply(cached);
+      return;
+    }
+    fetchSampleInfo(datasetName, brainKey, hit.index, colorField)
+      .then((info) => {
+        infoCache.current.set(key, info);
+        apply(info);
+      })
+      .catch(() => undefined);
+  };
+
+  return { hover, handleHover };
+}

--- a/app/packages/embeddings-v2/src/useLocalColorMask.test.ts
+++ b/app/packages/embeddings-v2/src/useLocalColorMask.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { ColorMeta, ColorValues } from "./protocol";
+import { useLocalColorMask } from "./useLocalColorMask";
+
+const META: ColorMeta = {
+  style: "categorical",
+  exact: true,
+  classes: [
+    { label: "cat", count: 2 },
+    { label: "dog", count: 1 },
+  ],
+};
+const COLUMN: ColorValues = {
+  style: "categorical",
+  indices: new Uint16Array([0, 1, 0]),
+};
+
+const render = (filters: unknown) =>
+  renderHook(
+    ({ f }: { f: unknown }) => useLocalColorMask(f, "cluster", COLUMN, META),
+    { initialProps: { f: filters } },
+  );
+
+describe("useLocalColorMask", () => {
+  it("evaluates the color-field filter locally and strips it from the server's", () => {
+    const { result } = render({
+      cluster: { values: ["cat"], exclude: true },
+      other: { values: ["x"], exclude: false },
+    });
+
+    expect(result.current.localMask).not.toBeNull();
+    expect([...(result.current.localMask as Uint8Array)]).toEqual([0, 1, 0]);
+    expect(result.current.serverFilters).toEqual({
+      other: { values: ["x"], exclude: false },
+    });
+  });
+
+  // The load-bearing contract: a legend click replaces the filters
+  // object but only changes the locally-handled entry — the masks
+  // fetch must NOT re-fire, so serverFilters must keep its identity
+  it("keeps serverFilters identity across local-only filter changes", () => {
+    const { result, rerender } = render({
+      cluster: { values: ["cat"], exclude: true },
+      other: { values: ["x"], exclude: false },
+    });
+    const before = result.current.serverFilters;
+
+    rerender({
+      f: {
+        cluster: { values: ["dog"], exclude: true },
+        other: { values: ["x"], exclude: false },
+      },
+    });
+    expect(result.current.serverFilters).toBe(before);
+    // ...while the local mask did change
+    expect([...(result.current.localMask as Uint8Array)]).toEqual([1, 0, 1]);
+
+    // A change to another field's filter must re-fire
+    rerender({
+      f: {
+        cluster: { values: ["dog"], exclude: true },
+        other: { values: ["y"], exclude: false },
+      },
+    });
+    expect(result.current.serverFilters).not.toBe(before);
+  });
+
+  it("leaves unevaluable filters on the server path", () => {
+    // "zebra" is not in the class list — the server's mask is truth
+    const { result } = render({
+      cluster: { values: ["zebra"], exclude: true },
+    });
+
+    expect(result.current.localMask).toBeNull();
+    expect(result.current.serverFilters).toEqual({
+      cluster: { values: ["zebra"], exclude: true },
+    });
+  });
+});

--- a/app/packages/embeddings-v2/src/useLocalColorMask.ts
+++ b/app/packages/embeddings-v2/src/useLocalColorMask.ts
@@ -1,0 +1,49 @@
+import { useMemo } from "react";
+import { localColorMask } from "./colorMask";
+import type { CategoricalFilter } from "./legendFilter";
+import type { ColorMeta, ColorValues } from "./protocol";
+
+/**
+ * Splits the App's filters between client and server: the color-by
+ * field's filter is evaluated locally against the color column when
+ * provably faithful (see colorMask.ts) — legend clicks then never wait
+ * on the masks round trip — and everything else ships to the masks
+ * endpoint as `serverFilters`.
+ *
+ * A locally-handled filter must not also reach the server (the whole
+ * point is skipping that aggregation), and `serverFilters` is
+ * identity-stabilized through JSON so a legend click — which only
+ * changes the locally-handled entry — does not refetch the unchanged
+ * remainder. Filters the client cannot evaluate faithfully fall back
+ * to the server path untouched.
+ */
+export function useLocalColorMask(
+  filters: unknown,
+  colorField: string | null,
+  colorValues: ColorValues | null,
+  colorMeta: ColorMeta | null,
+): {
+  localMask: Uint8Array | null;
+  serverFilters: Record<string, unknown>;
+} {
+  const localMask = useMemo(() => {
+    if (!colorField || !colorValues || !colorMeta) return null;
+    const fieldFilter = (filters as Record<string, CategoricalFilter> | null)?.[
+      colorField
+    ];
+    if (!fieldFilter) return null;
+    return localColorMask(fieldFilter, colorValues, colorMeta);
+  }, [filters, colorField, colorValues, colorMeta]);
+
+  const serverFiltersJson = useMemo(() => {
+    const record = { ...((filters ?? {}) as Record<string, unknown>) };
+    if (localMask && colorField) delete record[colorField];
+    return JSON.stringify(record);
+  }, [filters, localMask, colorField]);
+  const serverFilters = useMemo(
+    () => JSON.parse(serverFiltersJson) as Record<string, unknown>,
+    [serverFiltersJson],
+  );
+
+  return { localMask, serverFilters };
+}

--- a/app/packages/embeddings-v2/src/useMasks.test.ts
+++ b/app/packages/embeddings-v2/src/useMasks.test.ts
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { fetchMasks, type Masks } from "./protocol";
+import { useMasks } from "./useMasks";
+
+vi.mock("./protocol", () => ({ fetchMasks: vi.fn() }));
+
+const masks = (partial: Partial<Masks>): Masks => ({
+  visible: null,
+  match: null,
+  ...partial,
+});
+
+describe("useMasks", () => {
+  it("passes early-out masks through as nulls", async () => {
+    vi.mocked(fetchMasks).mockResolvedValue(masks({}));
+    const { result } = renderHook(() => useMasks("ds", "viz", [], null, 4));
+
+    await waitFor(() => expect(fetchMasks).toHaveBeenCalled());
+    expect(result.current.visibleMask).toBeNull();
+    expect(result.current.visibleCount).toBeNull();
+  });
+
+  it("slices the visible mask to the loaded prefix mid-load", async () => {
+    vi.mocked(fetchMasks).mockResolvedValue(
+      masks({ visible: new Uint8Array([1, 0, 1, 1]) }),
+    );
+    const { result, rerender } = renderHook(
+      ({ count }: { count: number }) => useMasks("ds", "viz", [], null, count),
+      { initialProps: { count: 2 } },
+    );
+
+    await waitFor(() => expect(result.current.visibleMask).not.toBeNull());
+    // Wire order makes the prefix valid while chunks are still landing
+    expect([...(result.current.visibleMask as Uint8Array)]).toEqual([1, 0]);
+    // The count reflects the full mask, not the loaded prefix
+    expect(result.current.visibleCount).toBe(3);
+
+    rerender({ count: 4 });
+    expect(result.current.visibleMask?.length).toBe(4);
+  });
+
+  // Sidebar filters scope the plot: the match mask hides non-matching
+  // points rather than dimming them
+  it("folds the filter match mask into visibility", async () => {
+    vi.mocked(fetchMasks).mockResolvedValue(
+      masks({
+        visible: new Uint8Array([1, 1, 0, 1]),
+        match: new Uint8Array([0, 1, 0, 1]),
+      }),
+    );
+    const { result } = renderHook(() => useMasks("ds", "viz", [], null, 4));
+
+    await waitFor(() => expect(result.current.visibleMask).not.toBeNull());
+    expect([...(result.current.visibleMask as Uint8Array)]).toEqual([
+      0, 1, 0, 1,
+    ]);
+    expect(result.current.visibleCount).toBe(2);
+  });
+
+  it("hides by the match mask alone when no view stages exist", async () => {
+    vi.mocked(fetchMasks).mockResolvedValue(
+      masks({ match: new Uint8Array([0, 1, 0, 1]) }),
+    );
+    const { result } = renderHook(() => useMasks("ds", "viz", [], null, 4));
+
+    await waitFor(() => expect(result.current.visibleMask).not.toBeNull());
+    expect([...(result.current.visibleMask as Uint8Array)]).toEqual([
+      0, 1, 0, 1,
+    ]);
+  });
+
+  // A client-computed filter mask (colorMask.ts) must scope the plot
+  // without waiting on — or being overridden by — the server masks
+  it("folds a local mask in with the server masks", async () => {
+    vi.mocked(fetchMasks).mockResolvedValue(
+      masks({ visible: new Uint8Array([1, 1, 1, 0]) }),
+    );
+    const local = new Uint8Array([1, 0, 1, 1]);
+    const { result } = renderHook(() =>
+      useMasks("ds", "viz", [], null, 4, local),
+    );
+
+    // Applies alone before the fetch resolves (the instant path) ...
+    expect([...(result.current.visibleMask as Uint8Array)]).toEqual([
+      1, 0, 1, 1,
+    ]);
+    // ... and composes once the server masks land
+    await waitFor(() =>
+      expect([...(result.current.visibleMask as Uint8Array)]).toEqual([
+        1, 0, 1, 0,
+      ]),
+    );
+    expect(result.current.visibleCount).toBe(2);
+  });
+
+  // A run switch changes the wire order itself; yesterday's mask must
+  // not style today's points while the replacement is in flight
+  it("drops masks the moment the run changes", async () => {
+    vi.mocked(fetchMasks).mockResolvedValue(
+      masks({ visible: new Uint8Array([1, 0, 1, 1]) }),
+    );
+    const { result, rerender } = renderHook(
+      ({ key }: { key: string }) => useMasks("ds", key, [], null, 4),
+      { initialProps: { key: "viz" } },
+    );
+    await waitFor(() => expect(result.current.visibleMask).not.toBeNull());
+
+    vi.mocked(fetchMasks).mockImplementationOnce(
+      () => new Promise(() => undefined),
+    );
+    rerender({ key: "viz2" });
+    expect(result.current.visibleMask).toBeNull();
+  });
+
+  it("clears masks when no run is selected", async () => {
+    vi.mocked(fetchMasks).mockClear();
+    const { result } = renderHook(() => useMasks("ds", null, [], null, 0));
+
+    expect(fetchMasks).not.toHaveBeenCalled();
+    expect(result.current.visibleMask).toBeNull();
+  });
+
+  it("reports mask fetch failures", async () => {
+    vi.mocked(fetchMasks).mockRejectedValue(new Error("boom"));
+    const { result } = renderHook(() => useMasks("ds", "viz", [], null, 0));
+
+    await waitFor(() => expect(result.current.error).toMatch("boom"));
+  });
+});

--- a/app/packages/embeddings-v2/src/useMasks.ts
+++ b/app/packages/embeddings-v2/src/useMasks.ts
@@ -1,0 +1,85 @@
+import { useEffect, useMemo, useState } from "react";
+import { fetchMasks, type Masks } from "./protocol";
+
+/**
+ * The run's view/filter masks, shaped for the renderer: view stages
+ * and sidebar filters both scope the plot, so their masks combine into
+ * one `visibleMask` that hides non-members. `localMask` is a mask the
+ * host computed client-side (the color-by field's filter evaluated
+ * against the color column — see colorMask.ts); it ANDs in without a
+ * network round trip, so the filters passed here must EXCLUDE whatever
+ * the local mask already covers. Masks cover the run's full wire
+ * order; during a progressive load the loaded prefix is valid by
+ * construction, so `visibleMask` is sliced to `loadedCount`.
+ */
+export function useMasks(
+  datasetName: string | null,
+  brainKey: string | null,
+  view: unknown[],
+  filters: unknown,
+  loadedCount: number,
+  localMask: Uint8Array | null = null,
+): {
+  visibleMask: Uint8Array | null;
+  visibleCount: number | null;
+  error: string | null;
+} {
+  const [masks, setMasks] = useState<Masks | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // A run switch invalidates the wire order itself — the previous
+  // run's masks must not style the new run's points for even a frame.
+  // (Filter/view changes deliberately keep the old mask until the new
+  // one lands: same wire order, no flash.)
+  useEffect(() => {
+    setMasks(null);
+    setError(null);
+  }, [datasetName, brainKey]);
+
+  useEffect(() => {
+    if (!datasetName || !brainKey) {
+      setMasks(null);
+      return undefined;
+    }
+    let stale = false;
+    fetchMasks(datasetName, brainKey, view, filters)
+      .then((result) => !stale && setMasks(result))
+      .catch((e) => !stale && setError(String(e)));
+    return () => {
+      stale = true;
+    };
+  }, [datasetName, brainKey, view, filters]);
+
+  // The endpoint early-outs each mask to null when its inputs are empty
+  // (no view stages / no filters), so combining only pays when needed
+  const combined = useMemo(() => {
+    const parts = [masks?.visible, masks?.match, localMask].filter(
+      (part): part is Uint8Array => Boolean(part),
+    );
+    if (!parts.length) return null;
+    if (parts.length === 1) return parts[0];
+    const out = new Uint8Array(parts[0].length);
+    for (let i = 0; i < out.length; i++) {
+      out[i] = parts.every((part) => part[i]) ? 1 : 0;
+    }
+    return out;
+  }, [masks, localMask]);
+
+  const visibleMask = useMemo(() => {
+    if (!combined || !loadedCount) return null;
+    return combined.length === loadedCount
+      ? combined
+      : combined.subarray(0, loadedCount);
+  }, [combined, loadedCount]);
+
+  const visibleCount = useMemo(() => {
+    if (!combined) return null;
+    let count = 0;
+    for (let i = 0; i < combined.length; i++) {
+      count += combined[i];
+    }
+    return count;
+  }, [combined]);
+
+  return { visibleMask, visibleCount, error };
+}

--- a/app/packages/embeddings-v2/src/useRunColumns.test.ts
+++ b/app/packages/embeddings-v2/src/useRunColumns.test.ts
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  fetchGeometry,
+  fetchIds,
+  fetchRunInfo,
+  type Geometry,
+  type RunInfo,
+  type Slice,
+} from "./protocol";
+import { CHUNK, useRunColumns } from "./useRunColumns";
+
+vi.mock("@fiftyone/utilities", () => ({
+  getFetchFunction: () => {
+    throw new Error("network use in a unit test");
+  },
+}));
+vi.mock("./protocol", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./protocol")>()),
+  fetchRunInfo: vi.fn(),
+  fetchGeometry: vi.fn(),
+  fetchIds: vi.fn(),
+}));
+
+const info = (n: number): RunInfo => ({
+  brainKey: "viz",
+  method: null,
+  dims: 2,
+  patchesField: null,
+  pointsField: null,
+  model: null,
+  ready: true,
+  timestamp: null,
+  n,
+});
+
+const geometry = (slice?: Slice): Geometry => {
+  const n = slice?.limit ?? 0;
+  return { n, columns: [new Float32Array(n), new Float32Array(n)] };
+};
+
+const arm = (n: number) => {
+  vi.mocked(fetchRunInfo).mockResolvedValue(info(n));
+  vi.mocked(fetchGeometry).mockImplementation(async (_d, _b, slice) =>
+    geometry(slice),
+  );
+  vi.mocked(fetchIds).mockImplementation(
+    async (_d, _b, slice) => new Uint8Array((slice?.limit ?? 0) * 12),
+  );
+};
+
+describe("useRunColumns", () => {
+  it("assembles a multi-chunk run in wire-order slices", async () => {
+    const total = 2 * CHUNK + 50_000;
+    arm(total);
+    const { result } = renderHook(() => useRunColumns("ds", "viz"));
+
+    await waitFor(
+      () => expect(result.current.loaded?.points.length).toBe(total),
+      { timeout: 10_000 },
+    );
+
+    expect(result.current.loaded?.total).toBe(total);
+    expect(result.current.loaded?.ids.length).toBe(total * 12);
+    expect(vi.mocked(fetchGeometry).mock.calls.map(([, , s]) => s)).toEqual([
+      { offset: 0, limit: CHUNK },
+      { offset: CHUNK, limit: CHUNK },
+      { offset: 2 * CHUNK, limit: 50_000 },
+    ]);
+  }, 15_000);
+
+  it("abandons an in-flight run when the key changes", async () => {
+    let releaseFirst!: (value: RunInfo) => void;
+    vi.mocked(fetchRunInfo)
+      .mockImplementationOnce(
+        () => new Promise<RunInfo>((res) => (releaseFirst = res)),
+      )
+      .mockImplementationOnce(async () => ({ ...info(5), brainKey: "b" }));
+    vi.mocked(fetchGeometry).mockImplementation(async (_d, _b, slice) =>
+      geometry(slice),
+    );
+    vi.mocked(fetchIds).mockImplementation(
+      async (_d, _b, slice) => new Uint8Array((slice?.limit ?? 0) * 12),
+    );
+
+    const { result, rerender } = renderHook(
+      ({ brainKey }: { brainKey: string }) => useRunColumns("ds", brainKey),
+      { initialProps: { brainKey: "a" } },
+    );
+    rerender({ brainKey: "b" });
+
+    await waitFor(() => expect(result.current.loaded?.brainKey).toBe("b"));
+
+    // Run a resolves late; nothing of it may publish
+    releaseFirst(info(9));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(result.current.loaded?.brainKey).toBe("b");
+    expect(result.current.loaded?.points.length).toBe(5);
+  });
+
+  it("reports a failed load and releases the in-flight guard", async () => {
+    vi.mocked(fetchRunInfo).mockRejectedValue(new Error("cold cache"));
+    const { result } = renderHook(() => useRunColumns("ds", "viz"));
+
+    await waitFor(() => expect(result.current.error).toMatch("cold cache"));
+    expect(result.current.loaded).toBeNull();
+  });
+
+  // No chunks means no publishes — the empty run must still resolve or
+  // the loading spinner never leaves
+  it("publishes an empty run immediately", async () => {
+    vi.mocked(fetchRunInfo).mockResolvedValue(info(0));
+    vi.mocked(fetchGeometry).mockClear();
+    const { result } = renderHook(() => useRunColumns("ds", "empty"));
+
+    await waitFor(() => expect(result.current.loaded).not.toBeNull());
+    expect(result.current.loaded?.points).toEqual([]);
+    expect(result.current.loaded?.total).toBe(0);
+    expect(fetchGeometry).not.toHaveBeenCalled();
+  });
+
+  it("does nothing without a run selected", () => {
+    vi.mocked(fetchRunInfo).mockClear();
+    renderHook(() => useRunColumns("ds", null));
+    expect(fetchRunInfo).not.toHaveBeenCalled();
+  });
+});

--- a/app/packages/embeddings-v2/src/useRunColumns.ts
+++ b/app/packages/embeddings-v2/src/useRunColumns.ts
@@ -1,0 +1,101 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  fetchGeometry,
+  fetchIds,
+  fetchRunInfo,
+  idAt,
+  type IdColumn,
+} from "./protocol";
+import type { EmbeddingPoint } from "./renderer";
+
+/** Wire-order slice size for progressive loading */
+export const CHUNK = 100_000;
+
+/** A run's columns as loaded so far; republished after every chunk */
+export interface Loaded {
+  brainKey: string;
+  points: EmbeddingPoint[];
+  ids: IdColumn;
+  total: number;
+}
+
+/**
+ * Geometry + ids for the selected run, loaded progressively in
+ * wire-order chunks: the plot paints as each slice lands. The
+ * in-flight guard is a ref, NOT state: keying the effect on `loaded`
+ * would make each chunk's setLoaded cancel its own loop.
+ */
+export function useRunColumns(
+  datasetName: string | null,
+  brainKey: string | null,
+): { loaded: Loaded | null; error: string | null } {
+  const [loaded, setLoaded] = useState<Loaded | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const loadingKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!datasetName || !brainKey) return undefined;
+    const loadKey = `${datasetName}::${brainKey}`;
+    if (loadingKeyRef.current === loadKey) return undefined;
+    loadingKeyRef.current = loadKey;
+    let stale = false;
+    // The previous run's points must not linger while the new one
+    // loads (and a failed load must not strand them either)
+    setLoaded(null);
+    setError(null);
+    (async () => {
+      // run-info first: reports n AND warms the server's results cache,
+      // so the parallel column fetches below don't race a cold load
+      const info = await fetchRunInfo(datasetName, brainKey);
+      if (stale) return;
+
+      const total = info.n;
+      const ids: IdColumn = new Uint8Array(total * 12);
+      const points: EmbeddingPoint[] = [];
+
+      // A zero-point run has no chunks: publish the empty columns or
+      // the loading spinner never resolves
+      if (total === 0) {
+        setLoaded({ brainKey, points: [], ids, total });
+        return;
+      }
+
+      for (let offset = 0; offset < total; offset += CHUNK) {
+        const slice = { offset, limit: Math.min(CHUNK, total - offset) };
+        const [geometry, sliceIds] = await Promise.all([
+          fetchGeometry(datasetName, brainKey, slice),
+          fetchIds(datasetName, brainKey, slice),
+        ]);
+        if (stale) return;
+
+        ids.set(sliceIds, offset * 12);
+        // Runs may carry a third coordinate; it rides along on the
+        // point and the renderer decides whether it has a camera for it
+        const [xs, ys, zs] = geometry.columns;
+        for (let i = 0; i < geometry.n; i++) {
+          points.push({
+            id: idAt(ids, offset + i),
+            x: xs[i],
+            y: ys[i],
+            ...(zs ? { z: zs[i] } : null),
+            label: null,
+          });
+        }
+        setLoaded({ brainKey, points: points.slice(), ids, total });
+      }
+    })().catch((e) => {
+      if (stale) return;
+      loadingKeyRef.current = null;
+      setError(String(e));
+    });
+    return () => {
+      stale = true;
+      // An aborted load (run switch mid-flight) may retry later
+      if (loadingKeyRef.current === loadKey) {
+        loadingKeyRef.current = null;
+      }
+    };
+  }, [datasetName, brainKey]);
+
+  return { loaded, error };
+}

--- a/app/packages/embeddings-v2/src/useSelectionBridge.test.ts
+++ b/app/packages/embeddings-v2/src/useSelectionBridge.test.ts
@@ -1,0 +1,286 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { SelectionType } from "@fiftyone/state";
+import { fetchLassoStage, fetchSampleInfo, idAt } from "./protocol";
+import type { SampleInfo } from "./protocol";
+import type { Loaded } from "./useRunColumns";
+import {
+  useSelectionBridge,
+  type SelectionBridgeOptions,
+} from "./useSelectionBridge";
+
+vi.mock("@fiftyone/utilities", () => ({
+  getFetchFunction: () => {
+    throw new Error("network use in a unit test");
+  },
+}));
+vi.mock("./protocol", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./protocol")>()),
+  fetchLassoStage: vi.fn(),
+  fetchSampleInfo: vi.fn(),
+}));
+
+// Two real 12-byte ObjectIds in wire order
+const IDS = new Uint8Array(24).map((_, i) => i);
+const LOADED: Loaded = {
+  brainKey: "viz",
+  points: [
+    { id: idAt(IDS, 0), x: 0, y: 0, label: null },
+    { id: idAt(IDS, 1), x: 1, y: 1, label: null },
+  ],
+  ids: IDS,
+  total: 2,
+};
+
+const options = (
+  overrides: Partial<SelectionBridgeOptions> = {},
+): SelectionBridgeOptions => ({
+  datasetName: "ds",
+  brainKey: "viz",
+  view: [],
+  loaded: LOADED,
+  patchesField: null,
+  chart: { current: { resetCamera: vi.fn(), clearSelection: vi.fn() } },
+  setOverrideStage: vi.fn(),
+  resetExtended: vi.fn(),
+  selectedSamples: new Map<string, SelectionType>(),
+  setSelectedSamples: vi.fn(),
+  ...overrides,
+});
+
+describe("useSelectionBridge", () => {
+  it("resolves a lasso polygon to a view stage on the grid", async () => {
+    vi.mocked(fetchLassoStage).mockResolvedValue({
+      _cls: "fiftyone.core.stages.GeoWithin",
+      kwargs: { boundary: [] },
+      count: 2,
+    });
+    const opts = options();
+    const { result } = renderHook(() => useSelectionBridge(opts));
+
+    const polygon: Array<[number, number]> = [
+      [0, 0],
+      [1, 0],
+      [1, 1],
+    ];
+    act(() => result.current.handleSelection([0, 1], polygon));
+
+    await waitFor(() =>
+      expect(opts.setOverrideStage).toHaveBeenCalledWith({
+        "fiftyone.core.stages.GeoWithin": { boundary: [] },
+      }),
+    );
+    expect(fetchLassoStage).toHaveBeenCalledWith("ds", "viz", [], { polygon });
+  });
+
+  it("falls back to indices when no data polygon exists", async () => {
+    vi.mocked(fetchLassoStage).mockClear().mockResolvedValue({
+      _cls: "fiftyone.core.stages.Select",
+      kwargs: {},
+      count: 1,
+    });
+    const opts = options();
+    const { result } = renderHook(() => useSelectionBridge(opts));
+
+    act(() => result.current.handleSelection([1], null));
+
+    await waitFor(() => expect(fetchLassoStage).toHaveBeenCalled());
+    expect(fetchLassoStage).toHaveBeenCalledWith("ds", "viz", [], {
+      indices: [1],
+    });
+  });
+
+  it("treats an empty lasso as a selection reset", () => {
+    vi.mocked(fetchLassoStage).mockClear();
+    const opts = options();
+    const { result } = renderHook(() => useSelectionBridge(opts));
+
+    act(() => result.current.handleSelection([]));
+
+    expect(opts.resetExtended).toHaveBeenCalled();
+    expect(fetchLassoStage).not.toHaveBeenCalled();
+  });
+
+  // Responses must apply in request order: a slow first lasso resolving
+  // after a quick second one used to overwrite the newer selection
+  it("ignores a lasso response that arrives after a newer lasso", async () => {
+    const stage = (count: number) => ({
+      _cls: "S",
+      kwargs: { n: count },
+      count,
+    });
+    let resolveFirst: (v: ReturnType<typeof stage>) => void = () => undefined;
+    vi.mocked(fetchLassoStage)
+      .mockClear()
+      .mockImplementationOnce(
+        () => new Promise((resolve) => (resolveFirst = resolve)),
+      )
+      .mockResolvedValueOnce(stage(2));
+    const setOverrideStage = vi.fn();
+    const { result } = renderHook(() =>
+      useSelectionBridge(options({ setOverrideStage })),
+    );
+
+    act(() => result.current.handleSelection([0], null));
+    act(() => result.current.handleSelection([0, 1], null));
+    await waitFor(() => expect(result.current.selectionCount).toBe(2));
+
+    await act(async () => {
+      resolveFirst(stage(1));
+    });
+    // The newer selection stands
+    expect(result.current.selectionCount).toBe(2);
+    expect(setOverrideStage).toHaveBeenCalledTimes(1);
+    expect(setOverrideStage).toHaveBeenCalledWith({ S: { n: 2 } });
+  });
+
+  // A failure banner describes the gesture that failed; it must not
+  // linger over a newer pending lasso or survive an explicit clear
+  it("drops a stale failure banner when a new lasso begins", async () => {
+    vi.mocked(fetchLassoStage)
+      .mockClear()
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockImplementationOnce(() => new Promise(() => undefined));
+    const { result } = renderHook(() => useSelectionBridge(options()));
+
+    act(() => result.current.handleSelection([0], null));
+    await waitFor(() => expect(result.current.error).toMatch("boom"));
+
+    act(() => result.current.handleSelection([0, 1], null));
+    expect(result.current.error).toBeNull();
+  });
+
+  it("clears a failure banner on clearAll", async () => {
+    vi.mocked(fetchLassoStage)
+      .mockClear()
+      .mockRejectedValueOnce(new Error("boom"));
+    const { result } = renderHook(() => useSelectionBridge(options()));
+
+    act(() => result.current.handleSelection([0], null));
+    await waitFor(() => expect(result.current.error).toMatch("boom"));
+
+    act(() => result.current.clearAll());
+    expect(result.current.error).toBeNull();
+  });
+
+  it("toggles a sample on plain click", () => {
+    const opts = options();
+    const { result } = renderHook(() => useSelectionBridge(opts));
+
+    act(() =>
+      result.current.handlePointClick({
+        index: 0,
+        id: "sample0",
+        label: "",
+        x: 0,
+        y: 0,
+      }),
+    );
+
+    const updater = vi.mocked(opts.setSelectedSamples).mock.calls[0][0] as (
+      current: Map<string, SelectionType>,
+    ) => Map<string, SelectionType>;
+    expect(updater(new Map())).toEqual(new Map([["sample0", "default"]]));
+    expect(updater(new Map([["sample0", "default" as SelectionType]]))).toEqual(
+      new Map(),
+    );
+  });
+
+  it("resolves the owning sample for patches runs before toggling", async () => {
+    vi.mocked(fetchSampleInfo).mockResolvedValue({
+      id: "label7",
+      sampleId: "sample7",
+      filepath: null,
+      media: null,
+      value: null,
+    } satisfies SampleInfo);
+    const opts = options({ patchesField: "ground_truth" });
+    const { result } = renderHook(() => useSelectionBridge(opts));
+
+    act(() =>
+      result.current.handlePointClick({
+        index: 7,
+        id: "label7",
+        label: "",
+        x: 0,
+        y: 0,
+      }),
+    );
+
+    await waitFor(() => expect(opts.setSelectedSamples).toHaveBeenCalled());
+    expect(fetchSampleInfo).toHaveBeenCalledWith("ds", "viz", 7, null);
+    const updater = vi.mocked(opts.setSelectedSamples).mock.calls[0][0] as (
+      current: Map<string, SelectionType>,
+    ) => Map<string, SelectionType>;
+    expect(updater(new Map()).has("sample7")).toBe(true);
+  });
+
+  it("maps grid-selected ids to wire indices for the plot", () => {
+    const selected = new Map<string, SelectionType>([
+      [idAt(IDS, 1), "default"],
+      ["not-in-this-run", "default"],
+    ]);
+    const opts = options({ selectedSamples: selected });
+    const { result } = renderHook(() => useSelectionBridge(opts));
+
+    expect(result.current.selectedIndices).toEqual([1]);
+  });
+
+  it("reports no plot styling without a grid selection", () => {
+    const { result } = renderHook(() => useSelectionBridge(options()));
+    expect(result.current.selectedIndices).toBeNull();
+  });
+
+  it("treats a selection that maps to nothing as no selection", () => {
+    // Sample ids never resolve against a patches run's label-id wire
+    // order. An empty array here would dim the whole plot and outrank
+    // the filter-match layer in the host's precedence chain
+    const selected = new Map<string, SelectionType>([
+      ["not-in-this-run", "default"],
+    ]);
+    const opts = options({ selectedSamples: selected });
+    const { result } = renderHook(() => useSelectionBridge(opts));
+
+    expect(result.current.selectedIndices).toBeNull();
+  });
+
+  it("tracks the lasso's point count for chrome, until cleared", async () => {
+    vi.mocked(fetchLassoStage).mockClear().mockResolvedValue({
+      _cls: "fiftyone.core.stages.GeoWithin",
+      kwargs: {},
+      count: 42,
+    });
+    const opts = options();
+    const { result } = renderHook(() => useSelectionBridge(opts));
+    expect(result.current.selectionCount).toBeNull();
+
+    act(() =>
+      result.current.handleSelection(
+        [0, 1],
+        [
+          [0, 0],
+          [1, 0],
+          [1, 1],
+        ],
+      ),
+    );
+    await waitFor(() => expect(result.current.selectionCount).toBe(42));
+
+    act(() => result.current.clearAll());
+    expect(result.current.selectionCount).toBeNull();
+  });
+
+  it("clears every selection layer on Escape", () => {
+    const opts = options();
+    renderHook(() => useSelectionBridge(opts));
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    });
+
+    expect(opts.resetExtended).toHaveBeenCalled();
+    expect(opts.setSelectedSamples).toHaveBeenCalledWith(new Map());
+    expect(opts.chart.current?.clearSelection).toHaveBeenCalled();
+  });
+});

--- a/app/packages/embeddings-v2/src/useSelectionBridge.ts
+++ b/app/packages/embeddings-v2/src/useSelectionBridge.ts
@@ -1,0 +1,179 @@
+import type { SelectionType } from "@fiftyone/state";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type RefObject,
+} from "react";
+import type { SetterOrUpdater } from "recoil";
+import { buildIdIndex, fetchLassoStage, fetchSampleInfo } from "./protocol";
+import type { EmbeddingsViewHandle, HoverHit } from "./renderer";
+import type { Loaded } from "./useRunColumns";
+
+export interface SelectionBridgeOptions {
+  datasetName: string | null;
+  brainKey: string | null;
+  view: unknown[];
+  loaded: Loaded | null;
+  /** The run's patches field; point ids are label ids when set */
+  patchesField: string | null;
+  /** Renderer handle, for clearing the chart's local dim layer */
+  chart: RefObject<EmbeddingsViewHandle | null>;
+  /** fos.extendedSelectionOverrideStage setter */
+  setOverrideStage: (stage: Record<string, unknown>) => void;
+  /** fos.useResetExtendedSelection() */
+  resetExtended: () => void;
+  selectedSamples: Map<string, SelectionType>;
+  setSelectedSamples: SetterOrUpdater<Map<string, SelectionType>>;
+}
+
+/**
+ * Two-way selection wiring between the plot and the App. Plot -> grid:
+ * a lasso resolves server-side to a view stage and lands on the grid
+ * via the override stage — no id lists exist client-side or on the
+ * wire; a plain click toggles the sample in the App's selection.
+ * Grid -> plot: selected sample ids style the plot through a lazily
+ * built id -> wire-index map. Esc (and `clearAll`) clears every layer.
+ */
+export function useSelectionBridge({
+  datasetName,
+  brainKey,
+  view,
+  loaded,
+  patchesField,
+  chart,
+  setOverrideStage,
+  resetExtended,
+  selectedSamples,
+  setSelectedSamples,
+}: SelectionBridgeOptions): {
+  selectedIndices: number[] | null;
+  /** Points in the last lasso selection, for chrome (null = none) */
+  selectionCount: number | null;
+  handleSelection: (
+    indices: number[],
+    polygon?: Array<[number, number]> | null,
+  ) => void;
+  handlePointClick: (hit: HoverHit) => void;
+  clearAll: () => void;
+  error: string | null;
+} {
+  const [error, setError] = useState<string | null>(null);
+  const [selectionCount, setSelectionCount] = useState<number | null>(null);
+  // Monotonic lasso-request id: a slow older response must not
+  // overwrite a newer selection (or resurrect one that was cleared)
+  const lassoSeq = useRef(0);
+
+  // Stable because the Esc effect below depends on it
+  const clearAll = useCallback(() => {
+    lassoSeq.current++;
+    resetExtended();
+    setSelectedSamples(new Map());
+    setSelectionCount(null);
+    setError(null);
+    chart.current?.clearSelection();
+  }, [resetExtended, setSelectedSamples, chart]);
+
+  // Esc clears every selection layer (App state + the chart's local dim)
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      clearAll();
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [clearAll]);
+
+  // Grid/checkbox selections style the plot (id -> wire index). The map
+  // is built lazily — only when a grid selection actually exists — and
+  // cached per loaded snapshot
+  const idIndexRef = useRef<{
+    token: Loaded;
+    map: Map<string, number>;
+  } | null>(null);
+  const selectedIndices = useMemo(() => {
+    if (!loaded || !selectedSamples.size) return null;
+    if (idIndexRef.current?.token !== loaded) {
+      idIndexRef.current = {
+        token: loaded,
+        map: buildIdIndex(loaded.ids, loaded.points.length),
+      };
+    }
+    const indices: number[] = [];
+    for (const id of selectedSamples.keys()) {
+      const index = idIndexRef.current.map.get(id);
+      if (index !== undefined) indices.push(index);
+    }
+    // No id resolving means the selection is not representable in this
+    // plot's id space (sample selections against a patches run, whose
+    // wire ids are label ids). That is "no selection" (null) — an empty
+    // selection would dim every point and outrank the filter-match
+    // layer in the host's precedence
+    return indices.length ? indices : null;
+  }, [loaded, selectedSamples]);
+
+  // Lasso -> data-space polygon -> server-resolved view stage -> the
+  // grid. The override stage alone drives the grid
+  const handleSelection = (
+    indices: number[],
+    polygon?: Array<[number, number]> | null,
+  ) => {
+    if (!datasetName || !brainKey) return;
+    const seq = ++lassoSeq.current;
+    // A failure banner describes the previous gesture; a new one starts
+    // clean (the success path below still resets, as a race safeguard)
+    setError(null);
+    if (!indices.length) {
+      resetExtended();
+      setSelectionCount(null);
+      return;
+    }
+    const selection = polygon?.length ? { polygon } : { indices };
+    fetchLassoStage(datasetName, brainKey, view, selection)
+      .then((stage) => {
+        if (seq !== lassoSeq.current) return;
+        // A stale failure banner must not outlive the success after it
+        setError(null);
+        setOverrideStage({ [stage._cls]: stage.kwargs });
+        setSelectionCount(stage.count ?? indices.length);
+      })
+      .catch((e) => seq === lassoSeq.current && setError(String(e)));
+  };
+
+  // Plain click toggles the sample in the App's selection. For patches
+  // runs the point id is a label id; the owning sample id resolves
+  // through sample-info (clicks are human-rate)
+  const toggleSample = (sampleId: string) => {
+    setSelectedSamples((current) => {
+      const next = new Map(current);
+      if (next.has(sampleId)) {
+        next.delete(sampleId);
+      } else {
+        next.set(sampleId, "default");
+      }
+      return next;
+    });
+  };
+
+  const handlePointClick = (hit: HoverHit) => {
+    if (!patchesField) {
+      toggleSample(hit.id);
+      return;
+    }
+    if (!datasetName || !brainKey) return;
+    fetchSampleInfo(datasetName, brainKey, hit.index, null)
+      .then((info) => toggleSample(info.sampleId))
+      .catch(() => undefined);
+  };
+
+  return {
+    selectedIndices,
+    selectionCount,
+    handleSelection,
+    handlePointClick,
+    clearAll,
+    error,
+  };
+}

--- a/app/packages/embeddings-v2/src/useVisualizationRuns.test.ts
+++ b/app/packages/embeddings-v2/src/useVisualizationRuns.test.ts
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { fetchRuns, type VisualizationRun } from "./protocol";
+import { PENDING_POLL_MS, useVisualizationRuns } from "./useVisualizationRuns";
+
+vi.mock("./protocol", () => ({ fetchRuns: vi.fn() }));
+
+const run = (brainKey: string): VisualizationRun => ({
+  brainKey,
+  method: null,
+  dims: 2,
+  patchesField: null,
+  pointsField: null,
+  model: null,
+  ready: true,
+  timestamp: null,
+});
+
+const RUNS = [run("umap"), run("tsne")];
+
+describe("useVisualizationRuns", () => {
+  it("resets to loading when the dataset changes", async () => {
+    vi.mocked(fetchRuns).mockResolvedValue(RUNS);
+    const { result, rerender } = renderHook(
+      ({ dataset }: { dataset: string }) => useVisualizationRuns(dataset),
+      { initialProps: { dataset: "ds" } },
+    );
+    await waitFor(() => expect(result.current.runs).toEqual(RUNS));
+
+    vi.mocked(fetchRuns).mockResolvedValue([]);
+    rerender({ dataset: "other" });
+    expect(result.current.runs).toBeNull();
+    await waitFor(() => expect(result.current.runs).toEqual([]));
+  });
+
+  it("reports fetch failures", async () => {
+    vi.mocked(fetchRuns).mockRejectedValue(new Error("boom"));
+    const { result } = renderHook(() => useVisualizationRuns("ds"));
+
+    await waitFor(() => expect(result.current.error).toMatch("boom"));
+    expect(result.current.runs).toBeNull();
+  });
+
+  it("does nothing without a dataset", () => {
+    vi.mocked(fetchRuns).mockClear();
+    const { result } = renderHook(() => useVisualizationRuns(null));
+
+    expect(fetchRuns).not.toHaveBeenCalled();
+    expect(result.current.runs).toBeNull();
+  });
+
+  // A run without results must flip to ready without a page reload —
+  // and the poll must stop the moment nothing is pending
+  it("polls while any run is pending, then stops", async () => {
+    vi.useFakeTimers();
+    try {
+      const pending = { ...run("umap"), ready: false };
+      vi.mocked(fetchRuns).mockClear();
+      vi.mocked(fetchRuns).mockResolvedValue([pending]);
+      const { result } = renderHook(() => useVisualizationRuns("ds"));
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(result.current.runs).toEqual([pending]);
+
+      vi.mocked(fetchRuns).mockClear();
+      vi.mocked(fetchRuns).mockResolvedValue([run("umap")]);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(PENDING_POLL_MS);
+      });
+      expect(fetchRuns).toHaveBeenCalledTimes(1);
+      expect(result.current.runs).toEqual([run("umap")]);
+
+      // Everything ready: no further ticks
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(PENDING_POLL_MS * 3);
+      });
+      expect(fetchRuns).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/app/packages/embeddings-v2/src/useVisualizationRuns.ts
+++ b/app/packages/embeddings-v2/src/useVisualizationRuns.ts
@@ -1,0 +1,67 @@
+import { useCallback, useEffect, useState } from "react";
+import { fetchRuns, type VisualizationRun } from "./protocol";
+
+/** Poll cadence while any run is awaiting results */
+export const PENDING_POLL_MS = 5_000;
+
+/**
+ * The dataset's visualization runs. `runs` is null while loading —
+ * the runs page is the landing view, so there is no auto-selection;
+ * callers resolve their own active run from the list. `refresh`
+ * re-fetches after a mutation (e.g. deleting a run).
+ *
+ * While any run is pending (no results yet), the list re-fetches every
+ * few seconds so a finished computation appears without a reload. The
+ * poll stops the moment every run is ready, skips ticks while the tab
+ * is hidden, keeps the last list on transient errors, and only
+ * publishes a new list when something actually changed.
+ */
+export function useVisualizationRuns(datasetName: string | null): {
+  runs: VisualizationRun[] | null;
+  error: string | null;
+  refresh: () => void;
+} {
+  const [runs, setRuns] = useState<VisualizationRun[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [nonce, setNonce] = useState(0);
+
+  useEffect(() => {
+    if (!datasetName) return undefined;
+    let stale = false;
+    setRuns(null);
+    setError(null);
+    fetchRuns(datasetName)
+      .then((result) => !stale && setRuns(result))
+      .catch((e) => !stale && setError(String(e)));
+    return () => {
+      stale = true;
+    };
+  }, [datasetName, nonce]);
+
+  const pending = Boolean(runs?.some((run) => !run.ready));
+  useEffect(() => {
+    if (!datasetName || !pending) return undefined;
+    let stale = false;
+    const id = window.setInterval(() => {
+      if (document.hidden) return;
+      fetchRuns(datasetName)
+        .then((result) => {
+          if (stale) return;
+          setRuns((current) =>
+            JSON.stringify(current) === JSON.stringify(result)
+              ? current
+              : result,
+          );
+        })
+        .catch(() => undefined);
+    }, PENDING_POLL_MS);
+    return () => {
+      stale = true;
+      window.clearInterval(id);
+    };
+  }, [datasetName, pending]);
+
+  const refresh = useCallback(() => setNonce((n) => n + 1), []);
+
+  return { runs, error, refresh };
+}

--- a/app/packages/embeddings-v2/tsconfig.json
+++ b/app/packages/embeddings-v2/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": {
+        "strict": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true
+    },
+    "include": ["./src"]
+}

--- a/app/packages/embeddings-v2/vitest.config.ts
+++ b/app/packages/embeddings-v2/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/app/packages/spaces/src/components/AddPanelItem.tsx
+++ b/app/packages/spaces/src/components/AddPanelItem.tsx
@@ -32,10 +32,19 @@ export default function AddPanelItem({
         const newNode = new SpaceNode();
         newNode.type = name;
         spaces.addNodeAfter(node, newNode);
-        if (e.altKey) {
+        if (e.altKey && e.shiftKey) {
+          // Shift+Alt opens the panel full-screen: it was already added as a
+          // tab above, so we intentionally skip splitting the layout. This
+          // preserves full-screen open, which split-by-default would otherwise
+          // remove entirely.
+        } else if (e.altKey) {
           spaces.splitLayout(node, Layout.Horizontal);
         } else if (e.shiftKey) {
           spaces.splitLayout(node, Layout.Vertical);
+        } else if (!node.parent?.isSpaceContainer()) {
+          // by default, open the panel side-by-side with the current view;
+          // if the layout is already split, just add it as a tab
+          spaces.splitLayout(node, Layout.Horizontal);
         }
         if (onClick) onClick();
       }}

--- a/app/packages/state/src/recoil/filters.test.ts
+++ b/app/packages/state/src/recoil/filters.test.ts
@@ -50,4 +50,21 @@ describe("hasFilter resolves correctly", () => {
     );
     expect(test2()).toBe(true);
   });
+
+  // An extended selection can arrive as a view-stage override (e.g. the
+  // embeddings panel's lasso) instead of an id list; both must count,
+  // or the grid's count/save-filters affordances ignore the selection
+  it("hasFilter resolves correctly when a selection override stage is set", () => {
+    setMockAtoms({
+      filters: {},
+      extendedSelection: null,
+      extendedSelectionOverrideStage: {
+        "fiftyone.core.stages.GeoWithin": { boundary: [] },
+      },
+    });
+    expect(test()).toBe(true);
+
+    setMockAtoms({ extendedSelectionOverrideStage: null });
+    expect(test()).toBe(false);
+  });
 });

--- a/app/packages/state/src/recoil/filters.ts
+++ b/app/packages/state/src/recoil/filters.ts
@@ -6,7 +6,7 @@ import {
 import { VALID_PRIMITIVE_TYPES } from "@fiftyone/utilities";
 import { DefaultValue, selectorFamily } from "recoil";
 import { getSessionRef, sessionAtom } from "../session";
-import { extendedSelection } from "./atoms";
+import { extendedSelection, extendedSelectionOverrideStage } from "./atoms";
 import { pathHasIndexes, queryPerformance } from "./queryPerformance";
 import { expandPath, fields } from "./schema";
 import { hiddenLabelIds, isFrameField } from "./selectors";
@@ -110,8 +110,11 @@ export const hasFilters = selectorFamily<boolean, boolean>({
       const hidden = Boolean(modal && get(hiddenLabelIds).size);
       const selection =
         !modal && Boolean(get(extendedSelection)?.selection?.length);
+      // An extended selection expressed as a view-stage override (e.g. a
+      // plot lasso) scopes the grid just like an id-list selection does
+      const override = !modal && Boolean(get(extendedSelectionOverrideStage));
 
-      return f || hidden || selection;
+      return f || hidden || selection || override;
     },
 });
 

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1345,6 +1345,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.29.2":
+  version: 7.29.7
+  resolution: "@babel/runtime@npm:7.29.7"
+  checksum: 10/9883b4951787779fd382b121f22f92966d85f19434841f65fb00b2dfec232107e139683f47c6f252891826ad8ee18317b46c3a0e4819116a9885f47b46d7126a
+  languageName: node
+  linkType: hard
+
 "@babel/runtime@npm:^7.9.2":
   version: 7.29.2
   resolution: "@babel/runtime@npm:7.29.2"
@@ -2980,6 +2987,29 @@ __metadata:
     "@react-spring/web": "*"
     react: 18.2.0
     react-dom: 18.2.0
+  languageName: unknown
+  linkType: soft
+
+"@fiftyone/embeddings-v2@workspace:packages/embeddings-v2":
+  version: 0.0.0-use.local
+  resolution: "@fiftyone/embeddings-v2@workspace:packages/embeddings-v2"
+  dependencies:
+    "@fiftyone/components": "npm:*"
+    "@fiftyone/operators": "npm:*"
+    "@fiftyone/plugins": "npm:*"
+    "@fiftyone/spaces": "npm:*"
+    "@fiftyone/state": "npm:*"
+    "@fiftyone/utilities": "npm:*"
+    "@mui/icons-material": "npm:*"
+    "@mui/material": "npm:*"
+    "@testing-library/react": "npm:^14.0.0"
+    "@types/three": "npm:^0.182.0"
+    "@voxel51/voodo": "npm:^0.0.35"
+    three: "npm:^0.182.0"
+    vitest: "npm:^3.2.6"
+  peerDependencies:
+    react: "*"
+    recoil: "*"
   languageName: unknown
   linkType: soft
 
@@ -4697,6 +4727,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mui/core-downloads-tracker@npm:^9.2.0":
+  version: 9.2.0
+  resolution: "@mui/core-downloads-tracker@npm:9.2.0"
+  checksum: 10/2eb99863b867be8936ffc59b8cd280ae8da282db0e72c84a338d6392a650a16f559f2debaf8c693cd96053bbab8df6a19a921d968de2939a7a4fe380d68596c4
+  languageName: node
+  linkType: hard
+
+"@mui/icons-material@npm:*":
+  version: 9.2.0
+  resolution: "@mui/icons-material@npm:9.2.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.29.2"
+  peerDependencies:
+    "@mui/material": ^9.2.0
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/53e9a9124ef298b6afd10467f0cd07e5b7a51d99dfa994d7385aeedf83e29c184a47aaab472b5c7980cd5dffc3fe716daa32124b7786a13621cd7cc351d081c3
+  languageName: node
+  linkType: hard
+
 "@mui/icons-material@npm:^5.16.7":
   version: 5.16.7
   resolution: "@mui/icons-material@npm:5.16.7"
@@ -4710,6 +4763,42 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10/39bd989f566951e8898e955309506b4f37eeed50bc3631869b5967ecb143c19372ea13e49994504f6c0e3969e8b73ad17cdc6cfc4eaff1201a852231539b83df
+  languageName: node
+  linkType: hard
+
+"@mui/material@npm:*":
+  version: 9.2.0
+  resolution: "@mui/material@npm:9.2.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.29.2"
+    "@mui/core-downloads-tracker": "npm:^9.2.0"
+    "@mui/system": "npm:^9.2.0"
+    "@mui/types": "npm:^9.1.1"
+    "@mui/utils": "npm:^9.2.0"
+    "@popperjs/core": "npm:^2.11.8"
+    "@types/react-transition-group": "npm:^4.4.12"
+    clsx: "npm:^2.1.1"
+    csstype: "npm:^3.2.3"
+    prop-types: "npm:^15.8.1"
+    react-is: "npm:^19.2.6"
+    react-transition-group: "npm:^4.4.5"
+  peerDependencies:
+    "@emotion/react": ^11.5.0
+    "@emotion/styled": ^11.3.0
+    "@mui/material-pigment-css": ^9.2.0
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@emotion/react":
+      optional: true
+    "@emotion/styled":
+      optional: true
+    "@mui/material-pigment-css":
+      optional: true
+    "@types/react":
+      optional: true
+  checksum: 10/2ed35cecd0e4628ab952be93914c6d6b8fa647541cd77bf8c098dd0795a1623b0532c5fb4bfa1409ff6fa3b1349b6ffa6eaf36675e2fd432f6248e60c47310c1
   languageName: node
   linkType: hard
 
@@ -4763,6 +4852,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mui/private-theming@npm:^9.2.0":
+  version: 9.2.0
+  resolution: "@mui/private-theming@npm:9.2.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.29.2"
+    "@mui/utils": "npm:^9.2.0"
+    prop-types: "npm:^15.8.1"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/6381bbaaa2df6b59bff9bf4ed71ff91dc1a3ec0767d31d22ebe007dac7569a1a8a2dcf790a334cc3c4751e01c196315e66b9e6aa3d08f23fad1337eef5b03cd5
+  languageName: node
+  linkType: hard
+
 "@mui/styled-engine@npm:^5.15.14":
   version: 5.15.14
   resolution: "@mui/styled-engine@npm:5.15.14"
@@ -4781,6 +4887,29 @@ __metadata:
     "@emotion/styled":
       optional: true
   checksum: 10/2a5e03bb20502aef94cfb908898c50abb769192deb32d7f4237039683ce5266104cdc4055a7f0a8342aa62447d52b7439a4f2d0dda0fa6709c227c3621468cab
+  languageName: node
+  linkType: hard
+
+"@mui/styled-engine@npm:^9.1.1":
+  version: 9.1.1
+  resolution: "@mui/styled-engine@npm:9.1.1"
+  dependencies:
+    "@babel/runtime": "npm:^7.29.2"
+    "@emotion/cache": "npm:^11.14.0"
+    "@emotion/serialize": "npm:^1.3.3"
+    "@emotion/sheet": "npm:^1.4.0"
+    csstype: "npm:^3.2.3"
+    prop-types: "npm:^15.8.1"
+  peerDependencies:
+    "@emotion/react": ^11.4.1
+    "@emotion/styled": ^11.3.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@emotion/react":
+      optional: true
+    "@emotion/styled":
+      optional: true
+  checksum: 10/f7ccfda76a4b8c8189a54f0a53775792c0bff50cda529d2a8cda5948a90cd0f8aa5152446e785d64276efbaf5acc99946cd7f8e12e450757615d4e2bbdc93a91
   languageName: node
   linkType: hard
 
@@ -4812,6 +4941,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mui/system@npm:^9.2.0":
+  version: 9.2.0
+  resolution: "@mui/system@npm:9.2.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.29.2"
+    "@mui/private-theming": "npm:^9.2.0"
+    "@mui/styled-engine": "npm:^9.1.1"
+    "@mui/types": "npm:^9.1.1"
+    "@mui/utils": "npm:^9.2.0"
+    clsx: "npm:^2.1.1"
+    csstype: "npm:^3.2.3"
+    prop-types: "npm:^15.8.1"
+  peerDependencies:
+    "@emotion/react": ^11.5.0
+    "@emotion/styled": ^11.3.0
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@emotion/react":
+      optional: true
+    "@emotion/styled":
+      optional: true
+    "@types/react":
+      optional: true
+  checksum: 10/3b682d7576490fa9427859225e5c359c80734525036063fcc531d45aedbe5fac1877ebf7ac611cbd7347692bf4c3f617c03063194f02f86a11727b01c5aaf96a
+  languageName: node
+  linkType: hard
+
 "@mui/types@npm:^7.2.14":
   version: 7.2.14
   resolution: "@mui/types@npm:7.2.14"
@@ -4821,6 +4978,20 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10/b10cca8f63ea522be4f7c185acd1f4d031947e53824cbf9dc5649c165bcfa8a2749e83fd0bd1809b8e2698f58638ab2b4ce03550095989189d14434ea5c6c0b6
+  languageName: node
+  linkType: hard
+
+"@mui/types@npm:^9.1.1":
+  version: 9.1.1
+  resolution: "@mui/types@npm:9.1.1"
+  dependencies:
+    "@babel/runtime": "npm:^7.29.2"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/a5d1fd6e418150a3d2bd8772d337c284061e15ca517ce8443f73b0f00d6a98e011c8e93c321d5c35bee7f9d483b7f0f5aeb3cdfdab682e84a40bad6feb04ba66
   languageName: node
   linkType: hard
 
@@ -4839,6 +5010,26 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10/b3cbe2d0aa7ec65969752dababc39fc6e0b8bb1a9cf8b9bac42ca40e3dd3eaa59b79765bd259019318acc7421d64b9f421bc67e776a581d7c9da6a1c0c50bfbc
+  languageName: node
+  linkType: hard
+
+"@mui/utils@npm:^9.2.0":
+  version: 9.2.0
+  resolution: "@mui/utils@npm:9.2.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.29.2"
+    "@mui/types": "npm:^9.1.1"
+    "@types/prop-types": "npm:^15.7.15"
+    clsx: "npm:^2.1.1"
+    prop-types: "npm:^15.8.1"
+    react-is: "npm:^19.2.6"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/7e91a8b880216722eff09190a964749d74aa1ddc37ece225f8c121bef85c5a68a5b0446abe54d067a7194af4d1d5f2f7773532df670ec2e927ac32948727df87
   languageName: node
   linkType: hard
 
@@ -7623,6 +7814,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/prop-types@npm:^15.7.15":
+  version: 15.7.15
+  resolution: "@types/prop-types@npm:15.7.15"
+  checksum: 10/31aa2f59b28f24da6fb4f1d70807dae2aedfce090ec63eaf9ea01727a9533ef6eaf017de5bff99fbccad7d1c9e644f52c6c2ba30869465dd22b1a7221c29f356
+  languageName: node
+  linkType: hard
+
 "@types/react-color@npm:^3.0.6":
   version: 3.0.12
   resolution: "@types/react-color@npm:3.0.12"
@@ -7735,6 +7933,15 @@ __metadata:
   dependencies:
     "@types/react": "npm:*"
   checksum: 10/b429f3bd54d9aea6c0395943ce2dda6b76fb458e902365bd91fd99bf72064fb5d59e2b74e78d10f2871908501d350da63e230d81bda2b616c967cab8dc51bd16
+  languageName: node
+  linkType: hard
+
+"@types/react-transition-group@npm:^4.4.12":
+  version: 4.4.12
+  resolution: "@types/react-transition-group@npm:4.4.12"
+  peerDependencies:
+    "@types/react": "*"
+  checksum: 10/ea14bc84f529a3887f9954b753843820ac8a3c49fcdfec7840657ecc6a8800aad98afdbe4b973eb96c7252286bde38476fcf64b1c09527354a9a9366e516d9a2
   languageName: node
   linkType: hard
 
@@ -10719,7 +10926,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"csstype@npm:^3.0.10":
+"csstype@npm:^3.0.10, csstype@npm:^3.2.3":
   version: 3.2.3
   resolution: "csstype@npm:3.2.3"
   checksum: 10/ad41baf7e2ffac65ab544d79107bf7cd1a4bb9bab9ac3302f59ab4ba655d5e30942a8ae46e10ba160c6f4ecea464cc95b975ca2fefbdeeacd6ac63f12f99fe1f
@@ -19292,6 +19499,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-is@npm:^19.2.6":
+  version: 19.2.7
+  resolution: "react-is@npm:19.2.7"
+  checksum: 10/ae0d3ae7638aa2fa2a82a78a817daf2806e57fa0aef357d07e1e8d1e9a301902e5967168e9334b5816db0df8fa980a725cd57569ba5a9e6e76a71e117b18be04
+  languageName: node
+  linkType: hard
+
 "react-laag@npm:^2.0.3":
   version: 2.0.5
   resolution: "react-laag@npm:2.0.5"
@@ -21734,6 +21948,13 @@ __metadata:
   version: 0.170.0
   resolution: "three@npm:0.170.0"
   checksum: 10/ce523a35b17b47526df7d21323afeac3482ef69a67d9304ed2d71877c079debfb1e77249af8a55ab376b48ee8265488da1bb0912200c170a6874f574f19f63c9
+  languageName: node
+  linkType: hard
+
+"three@npm:^0.182.0":
+  version: 0.182.0
+  resolution: "three@npm:0.182.0"
+  checksum: 10/37bbc10cea96e001ca7485cfe120e1bc8bcff0c448c492140ce9db8bd113efb6972d6cc71f8426a257eb569bf9aa136fd8887f803435d057ea963c815fe9248a
   languageName: node
   linkType: hard
 

--- a/e2e-pw/src/oss/poms/panels/grid-panel.ts
+++ b/e2e-pw/src/oss/poms/panels/grid-panel.ts
@@ -46,7 +46,10 @@ export class GridPanelPom {
 
   async open(panelName: GridPanelName) {
     await this.newPanelBtn.click();
-    await this.getPanelOption(panelName).click();
+    // Open full-screen (Shift+Alt) so the panel fills the view as it did
+    // before split-by-default. Keeps layout-sensitive assertions stable and
+    // independent of the default split behavior.
+    await this.getPanelOption(panelName).click({ modifiers: ["Alt", "Shift"] });
   }
 
   async close() {

--- a/fiftyone/server/routes/__init__.py
+++ b/fiftyone/server/routes/__init__.py
@@ -13,6 +13,7 @@ from fiftyone.operators.server import OperatorRoutes
 from .aggregate import Aggregate
 from .camera import CameraRoutes
 from .embeddings import EmbeddingsRoutes
+from .embeddings_v2 import EmbeddingsV2Routes
 from .event import Event
 from .events import Events
 from .features import Features
@@ -43,6 +44,7 @@ if is_feature_enabled("VFF_MULTIMODAL"):
 routes = (
     CameraRoutes
     + EmbeddingsRoutes
+    + EmbeddingsV2Routes
     + GroupsRoutes
     + multimodal_routes
     + OperatorRoutes

--- a/fiftyone/server/routes/embeddings_v2.py
+++ b/fiftyone/server/routes/embeddings_v2.py
@@ -1,0 +1,794 @@
+"""
+FiftyOne Server ``/embeddings/v2`` routes.
+
+The v2 embeddings protocol is column-oriented: every per-point datum is a
+column in a single canonical order (the "wire order" — the row order of the
+brain run's points array), and a point's position in that order is its key.
+Geometry ships once per run as binary Float32 columns; view and filter
+changes ship compact bitmasks; per-point identity is resolved lazily (the
+raw id column, or index lookups server-side). See ``/embeddings`` for the
+legacy JSON protocol this replaces.
+
+Binary responses share a 16-byte little-endian header::
+
+    u32 magic "FOE1" | u16 version | u8 dtype | u8 width | u32 n | u32 flags
+
+followed by ``width`` contiguous columns of ``n`` values each (bitmask
+columns are ``ceil(n / 8)`` bytes, packed little bit-order). The color
+response appends a UTF-8 JSON meta tail after its column — the header
+determines where the column ends, so no delimiter is needed.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import json
+import logging
+import struct
+import threading
+from collections import OrderedDict
+
+import numpy as np
+from starlette.endpoints import HTTPEndpoint
+from starlette.requests import Request
+from starlette.responses import Response
+
+import fiftyone.core.fields as fof
+import fiftyone.core.media as fom
+import fiftyone.core.stages as fos
+import fiftyone.core.storage as fost
+from fiftyone.core.utils import run_sync_task
+
+from fiftyone.server.decorators import route
+import fiftyone.server.utils as fosu
+import fiftyone.server.view as fosv
+from fiftyone.server.filters import GroupElementFilter, SampleFilter
+
+logger = logging.getLogger(__name__)
+
+MAGIC = 0x464F4531  # "FOE1"
+VERSION = 1
+
+DTYPE_F32 = 1
+DTYPE_U16 = 2
+DTYPE_BITMASK = 3
+DTYPE_BYTES12 = 4
+
+# Header flags (masks responses)
+FLAG_ALL_VISIBLE = 1
+FLAG_ALL_MATCH = 2
+
+MAX_CATEGORIES = 100
+MISSING_CATEGORY = 0xFFFF
+
+# Lasso selections at or below this size become explicit id stages
+SELECT_STAGE_MAX = 10000
+
+_HEADER_FORMAT = "<IHBBII"
+
+_VISUALIZATION_CLS = "fiftyone.brain.visualization."
+
+
+def get_sample_filter(slices):
+    if slices:
+        return SampleFilter(group=GroupElementFilter(id=None, slices=slices))
+
+
+class EmbeddingsV2Runs(HTTPEndpoint):
+    @route
+    async def post(self, request: Request, data: dict) -> dict:
+        """Lists the dataset's visualization runs (cheap; run docs only)."""
+        return await run_sync_task(self._post_sync, data)
+
+    def _post_sync(self, data):
+        dataset_name = data["datasetName"]
+        dataset = fosu.load_and_cache_dataset(dataset_name)
+
+        runs = []
+        for brain_key in dataset.list_brain_runs():
+            info = dataset.get_brain_info(brain_key)
+            config = info.config
+            if not config.cls.startswith(_VISUALIZATION_CLS):
+                continue
+
+            # Results-blob POINTER presence, not a blob load: the run
+            # doc's GridFS reference is only set once results are saved,
+            # so a run mid-computation (or whose computation died) lists
+            # as not ready. Presence says nothing about how the run
+            # ended — status semantics beyond ready/pending need the
+            # run-status sidecar
+            ready = bool(dataset._doc.brain_methods[brain_key].results)
+
+            runs.append(
+                {
+                    "brainKey": brain_key,
+                    "method": getattr(config, "method", None),
+                    "dims": getattr(config, "num_dims", None),
+                    "patchesField": getattr(config, "patches_field", None),
+                    "pointsField": getattr(config, "points_field", None),
+                    "model": getattr(config, "model", None),
+                    "ready": ready,
+                    "timestamp": _timestamp(info),
+                }
+            )
+
+        return {"runs": runs}
+
+
+class EmbeddingsV2RunInfo(HTTPEndpoint):
+    @route
+    async def post(self, request: Request, data: dict) -> dict:
+        """Loads a run's results and reports its column metadata.
+
+        The returned ``timestamp`` is the cache key for all column payloads
+        of this run.
+        """
+        return await run_sync_task(self._post_sync, data)
+
+    def _post_sync(self, data):
+        dataset, results = _load_results(data)
+        info = dataset.get_brain_info(data["brainKey"])
+        config = results.config
+
+        return {
+            "brainKey": data["brainKey"],
+            "n": len(results.points),
+            "dims": int(results.points.shape[1]),
+            "patchesField": config.patches_field,
+            "pointsField": config.points_field,
+            "method": getattr(config, "method", None),
+            "model": getattr(config, "model", None),
+            "timestamp": _timestamp(info),
+        }
+
+
+class EmbeddingsV2Geometry(HTTPEndpoint):
+    @route
+    async def post(self, request: Request, data: dict) -> Response:
+        """The run's coordinates as planar Float32 columns, wire order.
+
+        Optional ``offset``/``limit`` select a wire-order slice for
+        progressive loading; the header's ``n`` is the slice length.
+        """
+        return await run_sync_task(self._post_sync, data)
+
+    def _post_sync(self, data):
+        _, results = _load_results(data)
+        points = _slice(results.points, data)
+        n, width = points.shape
+
+        columns = [
+            np.ascontiguousarray(points[:, i], dtype="<f4").tobytes()
+            for i in range(width)
+        ]
+        return _column_response(DTYPE_F32, width, n, b"".join(columns))
+
+
+class EmbeddingsV2Ids(HTTPEndpoint):
+    @route
+    async def post(self, request: Request, data: dict) -> Response:
+        """The run's ids as raw 12-byte ObjectIds, wire order.
+
+        ``kind="points"`` (default) returns each point's identity: label ids
+        for patches runs, sample ids otherwise. ``kind="samples"`` returns
+        the owning sample ids (only distinct from ``"points"`` for patches
+        runs).
+        """
+        return await run_sync_task(self._post_sync, data)
+
+    def _post_sync(self, data):
+        _, results = _load_results(data)
+        kind = data.get("kind", "points")
+
+        is_patches = results.config.patches_field is not None
+        if kind == "points" and is_patches:
+            ids = results.label_ids
+        else:
+            ids = results.sample_ids
+
+        ids = _slice(ids, data)
+        payload = bytes.fromhex("".join(_as_list(ids)))
+        return _column_response(DTYPE_BYTES12, 1, len(ids), payload)
+
+
+class EmbeddingsV2Color(HTTPEndpoint):
+    @route
+    async def post(self, request: Request, data: dict) -> Response:
+        """Everything color-by in one response: the per-point value column
+        (wire order) followed by a UTF-8 JSON meta tail.
+
+        The 16-byte header fully determines the column's extent (``n``
+        values of the dtype's width); every remaining body byte is the
+        meta tail. Categorical fields encode as u16 class indices into the
+        tail's ``classes`` list (``0xFFFF`` = missing) with a ``truncated``
+        flag; continuous fields encode as Float32 (``NaN`` = missing) with
+        ``min``/``max`` in the tail.
+
+        One response means the values aggregation — the expensive step —
+        runs once per (run, field). Bodies are cached in a small LRU
+        keyed by the run's identity (dataset, brain key, run timestamp,
+        field), so re-selecting a recent field skips the aggregation
+        entirely.
+        """
+        return await run_sync_task(self._post_sync, data)
+
+    def _post_sync(self, data):
+        dataset, results = _load_results(data)
+        field_path = data["field"]
+
+        info = dataset.get_brain_info(data["brainKey"])
+        key = (
+            data["datasetName"],
+            data["brainKey"],
+            _timestamp(info),
+            field_path,
+        )
+        body = _color_cache_get(key)
+        if body is None:
+            body = _build_color_body(dataset, results, field_path)
+            _color_cache_put(key, body)
+
+        return Response(content=body, media_type="application/octet-stream")
+
+
+class EmbeddingsV2Masks(HTTPEndpoint):
+    @route
+    async def post(self, request: Request, data: dict) -> Response:
+        """Two bitmasks over the run, wire order.
+
+        ``visible``: the point's sample/patch is in the current view (view
+        stages) — drives rendering visibility. ``match``: the point survives
+        the sidebar filters / extended stages / extended selection — drives
+        dimming. Header flags: bit 0 = all visible, bit 1 = all match (the
+        corresponding column is all ones and may be skipped client-side).
+        """
+        return await run_sync_task(self._post_sync, data)
+
+    def _post_sync(self, data):
+        dataset, results = _load_results(data)
+        dataset_name = data["datasetName"]
+        stages = data.get("view", None)
+        filters = data.get("filters", None)
+        slices = data.get("slices", None)
+        extended_stages = data.get("extended", None)
+        extended_selection = data.get("extendedSelection", None)
+
+        n = len(results.points)
+        flags = 0
+
+        # Visible: membership in the view (stages only, no filters).
+        # Group slices scope visibility too, even with no view stages
+        if stages or slices:
+            view = fosv.get_view(
+                dataset,
+                stages=stages,
+                sample_filter=get_sample_filter(slices),
+            )
+            if view.view() != results.view.view():
+                results.use_view(view, allow_missing=True)
+
+            keep_inds = results._curr_keep_inds
+            if keep_inds is None:
+                visible = np.ones(n, dtype=bool)
+                flags |= FLAG_ALL_VISIBLE
+            else:
+                visible = np.zeros(n, dtype=bool)
+                visible[keep_inds] = True
+        else:
+            visible = np.ones(n, dtype=bool)
+            flags |= FLAG_ALL_VISIBLE
+
+        # Match: membership in the filtered/extended view
+        if filters or extended_stages or extended_selection:
+            match = _match_mask(
+                dataset_name,
+                results,
+                stages,
+                filters,
+                slices,
+                extended_stages,
+                extended_selection,
+            )
+        else:
+            match = np.ones(n, dtype=bool)
+            flags |= FLAG_ALL_MATCH
+
+        payload = np.packbits(visible, bitorder="little").tobytes()
+        payload += np.packbits(match, bitorder="little").tobytes()
+        return _column_response(DTYPE_BITMASK, 2, n, payload, flags=flags)
+
+
+class EmbeddingsV2LassoStage(HTTPEndpoint):
+    @route
+    async def post(self, request: Request, data: dict) -> dict:
+        """Resolves a lasso selection into a serialized view stage.
+
+        The selection arrives as either ``polygon`` (data-space vertices,
+        resolved against the run's points server-side) or ``indices``
+        (wire-order point indices). When a spatial index exists and the
+        view/plot sources match, polygon selections compile to a constant
+        size ``$geoWithin`` stage; otherwise an id-based stage is returned.
+        """
+        return await run_sync_task(self._post_sync, data)
+
+    def _post_sync(self, data):
+        dataset, results = _load_results(data)
+        dataset_name = data["datasetName"]
+        stages = data.get("view", None)
+        slices = data.get("slices", None)
+        polygon = data.get("polygon", None)
+
+        patches_field = results.config.patches_field
+        points_field = results.config.points_field
+
+        view = fosv.get_view(
+            dataset_name,
+            stages=stages,
+            sample_filter=get_sample_filter(slices),
+        )
+
+        is_patches_view = view._is_patches
+        is_patches_plot = patches_field is not None
+        sources_equal = is_patches_view == is_patches_plot
+
+        if polygon is not None and points_field is not None and sources_equal:
+            # Constant-size spatial stage; no ids on the wire.
+            # $geoWithin can't filter nested arrays, so patches plots
+            # require a patches view here (sources_equal guarantees it)
+            if patches_field is not None:
+                _, points_field = view._get_label_field_path(
+                    patches_field, points_field
+                )
+
+            stage = fos.Mongo(
+                [
+                    {
+                        "$match": {
+                            points_field: {
+                                "$geoWithin": {"$polygon": list(polygon)}
+                            }
+                        }
+                    }
+                ]
+            )
+            d = stage._serialize(include_uuid=False)
+            return {
+                "_cls": d["_cls"],
+                "kwargs": dict(d["kwargs"]),
+                "count": None,
+            }
+
+        matched = _resolve_selection(data, results)
+
+        if is_patches_plot:
+            selected_ids = _as_list(results.label_ids[matched])
+        else:
+            selected_ids = _as_list(results.sample_ids[matched])
+
+        count = len(selected_ids)
+        if count > SELECT_STAGE_MAX:
+            logger.warning(
+                "Lasso selection of %d ids exceeds SELECT_STAGE_MAX (%d); "
+                "returning an id stage anyway",
+                count,
+                SELECT_STAGE_MAX,
+            )
+
+        if is_patches_view == is_patches_plot:
+            # Patch ids equal sample ids in a matching patches view
+            stage = fos.Select(selected_ids)
+        elif is_patches_plot:
+            stage = fos.MatchLabels(fields=[patches_field], ids=selected_ids)
+        else:
+            stage = fos.SelectBy("sample_id", selected_ids)
+
+        d = stage._serialize(include_uuid=False)
+        return {"_cls": d["_cls"], "kwargs": dict(d["kwargs"]), "count": count}
+
+
+class EmbeddingsV2SampleInfo(HTTPEndpoint):
+    @route
+    async def post(self, request: Request, data: dict) -> dict:
+        """Resolves a wire-order index to its sample's hover-card data.
+
+        ``media`` is a filepath for the client to resolve through the
+        App's ``getSampleSrc()`` (which owns proxy/prefix handling), or
+        null when hover media is unavailable for the sample's media type
+        (anything but images). Samples deleted since the run was computed
+        resolve to null fields rather than an error.
+        """
+        return await run_sync_task(self._post_sync, data)
+
+    def _post_sync(self, data):
+        dataset, results = _load_results(data)
+        index = data["index"]
+        color_field = data.get("field", None)
+
+        n = len(results.points)
+        if not 0 <= index < n:
+            raise ValueError(f"Index {index} out of range [0, {n})")
+
+        sample_id = str(results.sample_ids[index])
+        point_id = sample_id
+        if results.config.patches_field is not None:
+            point_id = str(results.label_ids[index])
+
+        try:
+            sample = dataset[sample_id]
+        except KeyError:
+            # Deleted since the brain run was computed
+            return {
+                "id": point_id,
+                "sampleId": sample_id,
+                "filepath": None,
+                "media": None,
+                "value": None,
+            }
+
+        value = None
+        if color_field is not None:
+            try:
+                value = sample.get_field(color_field)
+            except (AttributeError, KeyError, ValueError):
+                value = None
+
+        return {
+            "id": point_id,
+            "sampleId": sample_id,
+            "filepath": sample.filepath,
+            "media": _hover_media(sample),
+            "value": value,
+        }
+
+
+EmbeddingsV2Routes = [
+    ("/embeddings/v2/runs", EmbeddingsV2Runs),
+    ("/embeddings/v2/run-info", EmbeddingsV2RunInfo),
+    ("/embeddings/v2/geometry", EmbeddingsV2Geometry),
+    ("/embeddings/v2/ids", EmbeddingsV2Ids),
+    ("/embeddings/v2/color", EmbeddingsV2Color),
+    ("/embeddings/v2/masks", EmbeddingsV2Masks),
+    ("/embeddings/v2/lasso-stage", EmbeddingsV2LassoStage),
+    ("/embeddings/v2/sample-info", EmbeddingsV2SampleInfo),
+]
+
+# Color bodies are ~1-2 MB at 500K points and a session of color-by
+# switching revisits few fields, so a small cap covers it
+_COLOR_CACHE_MAX = 8
+_color_cache = OrderedDict()
+# Route handlers run on a thread pool; unsynchronized get/move_to_end
+# can race an eviction into a KeyError
+_color_cache_lock = threading.Lock()
+
+
+def _color_cache_get(key) -> bytes | None:
+    with _color_cache_lock:
+        body = _color_cache.get(key)
+        if body is not None:
+            _color_cache.move_to_end(key)
+
+        return body
+
+
+def _color_cache_put(key, body) -> None:
+    with _color_cache_lock:
+        _color_cache[key] = body
+        while len(_color_cache) > _COLOR_CACHE_MAX:
+            _color_cache.popitem(last=False)
+
+
+def _build_color_body(dataset, results, field_path):
+    """Builds a complete ``/v2/color`` response body: header, value
+    column, JSON meta tail. Immutable bytes, safe to cache and share.
+    """
+    style, values, classes, truncated, exact = _color_data(
+        dataset, results, field_path
+    )
+    n = len(values)
+
+    if style == "categorical":
+        index_by_label = {c["label"]: i for i, c in enumerate(classes)}
+        column = np.full(n, MISSING_CATEGORY, dtype="<u2")
+        for i, value in enumerate(values):
+            # Values beyond the class-list cap encode as missing
+            index = index_by_label.get(value)
+            if index is not None:
+                column[i] = index
+
+        dtype = DTYPE_U16
+        meta = {
+            "style": style,
+            "classes": classes,
+            "truncated": truncated,
+            "exact": exact,
+        }
+    else:
+        column = np.array(
+            [float(v) if v is not None else np.nan for v in values],
+            dtype="<f4",
+        )
+        present = [float(v) for v in values if v is not None]
+        dtype = DTYPE_F32
+        meta = {
+            "style": style,
+            "min": min(present) if present else None,
+            "max": max(present) if present else None,
+        }
+
+    header = struct.pack(_HEADER_FORMAT, MAGIC, VERSION, dtype, 1, n, 0)
+    return header + column.tobytes() + json.dumps(meta).encode("utf-8")
+
+
+def _load_results(data):
+    """Loads (dataset, results) for a request, with legacy-equivalent
+    caching (dataset TTL cache + per-dataset brain results cache).
+    """
+    dataset_name = data["datasetName"]
+    brain_key = data["brainKey"]
+
+    dataset = fosu.load_and_cache_dataset(dataset_name)
+    results = dataset.load_brain_results(brain_key)
+    if results is None:
+        raise ValueError(
+            f"Results for brain run with key '{brain_key}' are not yet "
+            "available"
+        )
+
+    return dataset, results
+
+
+def _slice(array, data):
+    """Applies a request's optional wire-order ``offset``/``limit``."""
+    offset = data.get("offset", None)
+    limit = data.get("limit", None)
+    if offset is None and limit is None:
+        return array
+
+    for name, value in (("offset", offset), ("limit", limit)):
+        # Validate BEFORE coercion: int() would truncate fractions into
+        # a silently different slice
+        if value is not None and (
+            not isinstance(value, (int, float)) or value != int(value)
+        ):
+            raise ValueError(f"{name} must be an integer")
+
+    start = int(offset or 0)
+    length = int(limit) if limit is not None else None
+    # Negative values would silently slice from the wrong end
+    if start < 0 or (length is not None and length < 0):
+        raise ValueError("offset and limit must be non-negative")
+
+    stop = start + length if length is not None else None
+    return array[start:stop]
+
+
+def _column_response(dtype, width, n, payload, flags=0):
+    header = struct.pack(
+        _HEADER_FORMAT, MAGIC, VERSION, dtype, width, n, flags
+    )
+    return Response(
+        content=header + payload, media_type="application/octet-stream"
+    )
+
+
+def _timestamp(info):
+    timestamp = getattr(info, "timestamp", None)
+    return timestamp.isoformat() if timestamp is not None else None
+
+
+def _as_list(ids):
+    return ids.tolist() if isinstance(ids, np.ndarray) else list(ids)
+
+
+def _first_value(value):
+    if isinstance(value, (list, tuple)):
+        return value[0] if value else None
+
+    return value
+
+
+def _color_data(dataset, results, field_path):
+    """Resolves per-point color-by values (wire order) and the style
+    decision.
+
+    Rules follow the legacy endpoint with one correction: only numeric
+    fields can be continuous. High-cardinality non-numeric fields stay
+    categorical with the class list capped to the ``MAX_CATEGORIES``
+    most frequent values (the remainder encode as missing), reported via
+    the ``truncated`` flag. (Legacy marked those "continuous", which is
+    meaningless for strings.)
+
+    Returns:
+        a ``(style, values, classes, truncated, exact)`` tuple, where
+        ``exact`` says each point's column value IS the point's full
+        field value (list fields keep only their first element, so a
+        filter evaluated against the column could disagree with the
+        same filter evaluated against the field — clients must not
+        compute filter masks locally unless ``exact`` is true)
+    """
+    patches_field = results.config.patches_field
+    is_patches = patches_field is not None
+
+    ids = results.label_ids if is_patches else results.sample_ids
+    values = dataset._get_values_by_id(
+        field_path, _as_list(ids), link_field=patches_field
+    )
+
+    exact = True
+    field = dataset.get_field(field_path)
+    if isinstance(field, fof.ListField):
+        field = field.field
+
+    # Paths through label lists (e.g. ``detections.label``) yield a
+    # LIST per point even though the leaf field is scalar, so listiness
+    # must be detected in the values, not the schema. Collapse to the
+    # first element; the column is then lossy (see ``exact`` above)
+    if any(isinstance(v, (list, tuple)) for v in values):
+        values = [_first_value(v) for v in values]
+        exact = False
+
+    if isinstance(field, fof.FloatField):
+        return "continuous", values, None, False, exact
+
+    distinct = {}
+    for value in values:
+        if value is not None:
+            distinct[value] = distinct.get(value, 0) + 1
+
+    if len(distinct) > MAX_CATEGORIES and isinstance(field, fof.IntField):
+        return "continuous", values, None, False, exact
+
+    ranked = sorted(
+        distinct.items(), key=lambda item: (-item[1], str(item[0]))
+    )
+    truncated = len(ranked) > MAX_CATEGORIES
+    classes = [
+        {"label": label, "count": count}
+        for label, count in ranked[:MAX_CATEGORIES]
+    ]
+    return "categorical", values, classes, truncated, exact
+
+
+def _match_mask(
+    dataset_name,
+    results,
+    stages,
+    filters,
+    slices,
+    extended_stages,
+    extended_selection,
+):
+    """Membership of each run point in the filtered/extended view."""
+    patches_field = results.config.patches_field
+    is_patches_plot = patches_field is not None
+    ids = results.label_ids if is_patches_plot else results.sample_ids
+
+    matched_ids = None
+    if filters or extended_stages:
+        extended_view = fosv.get_view(
+            dataset_name,
+            stages=stages,
+            filters=filters,
+            extended_stages=extended_stages,
+            sample_filter=get_sample_filter(slices),
+        )
+        is_patches_view = extended_view._is_patches
+
+        if is_patches_plot and not is_patches_view:
+            _, id_path = extended_view._get_label_field_path(
+                patches_field, "id"
+            )
+            extended_ids = extended_view.values(id_path, unwind=True)
+        elif is_patches_view and not is_patches_plot:
+            extended_ids = extended_view.values("sample_id")
+        else:
+            extended_ids = extended_view.values("id")
+
+        matched_ids = set(extended_ids)
+
+    if extended_selection is not None:
+        selection = set(extended_selection)
+        matched_ids = (
+            matched_ids & selection if matched_ids is not None else selection
+        )
+
+    n = len(ids)
+    if matched_ids is None:
+        return np.ones(n, dtype=bool)
+
+    return np.fromiter(
+        (str(_id) in matched_ids for _id in _as_list(ids)), bool, count=n
+    )
+
+
+def _hover_media(sample):
+    """Resolves what the hover card should load for a sample: a filepath
+    the client passes through the App's ``getSampleSrc()``, or None when
+    hover media is unavailable for the sample's media type.
+
+    When the installed storage layer can mint URLs for the path (e.g.
+    pre-signed object-store URLs), the browser fetches the media
+    directly; ``getSampleSrc()`` passes fully qualified URLs through
+    untouched. Local paths — and installs whose storage layer has no
+    URL support — fall through to the raw filepath, which the App
+    serves via its ``/media`` endpoint.
+    """
+    if sample.media_type != fom.IMAGE:
+        return None
+
+    filepath = sample.filepath
+    get_url = getattr(fost, "get_url", None)
+    if get_url is not None:
+        try:
+            return get_url(filepath)
+        except Exception:
+            pass
+
+    return filepath
+
+
+def _resolve_selection(data, results):
+    """Resolves a selection request to matched wire-order indices.
+
+    Deliberately a single extension point: alternative selection encodings
+    add branches here without touching the stage-building logic.
+    """
+    polygon = data.get("polygon", None)
+    if polygon is not None:
+        points = results.points
+        inside = _points_in_polygon(
+            points[:, 0], points[:, 1], np.asarray(polygon, dtype=float)
+        )
+        (matched,) = np.nonzero(inside)
+        return matched
+
+    indices = data.get("indices", None)
+    if indices is not None:
+        raw = np.asarray(indices)
+        # Validate BEFORE the int cast: it would truncate fractions to
+        # neighboring, unintended points
+        if raw.dtype.kind not in "iu" and not (
+            raw.dtype.kind == "f" and (raw == np.floor(raw)).all()
+        ):
+            raise ValueError("indices must be integers")
+
+        matched = raw.astype(int)
+        n = len(results.points)
+        # Negative values silently select from the end; >= n raises an
+        # opaque IndexError downstream — reject both here
+        if matched.ndim != 1 or (
+            matched.size and ((matched < 0) | (matched >= n)).any()
+        ):
+            raise ValueError(
+                f"indices must be a flat list of ints in [0, {n})"
+            )
+
+        return matched
+
+    raise ValueError("Either 'polygon' or 'indices' is required")
+
+
+def _points_in_polygon(xs, ys, polygon):
+    """Vectorized ray-casting point-in-polygon test.
+
+    A horizontal ray from each point crosses polygon edges; an odd crossing
+    count means inside. Handles concave polygons.
+    """
+    inside = np.zeros(len(xs), dtype=bool)
+    px = polygon[:, 0]
+    py = polygon[:, 1]
+    j = len(polygon) - 1
+    # Horizontal edges (yi == yj) can't satisfy the crossing condition,
+    # but the division still evaluates — suppress the harmless warnings
+    with np.errstate(divide="ignore", invalid="ignore"):
+        for i in range(len(polygon)):
+            xi, yi = px[i], py[i]
+            xj, yj = px[j], py[j]
+            crosses = ((yi > ys) != (yj > ys)) & (
+                xs < (xj - xi) * (ys - yi) / (yj - yi) + xi
+            )
+            inside ^= crosses
+            j = i
+
+    return inside

--- a/plugins/operators/__init__.py
+++ b/plugins/operators/__init__.py
@@ -40,7 +40,7 @@ from .annotation import (
     UpdateLabelSchema,
     ValidateLabelSchemas,
 )
-from .dataset import GetFieldSchema
+from .dataset import DeleteBrainRun, GetFieldSchema
 
 logger = logging.getLogger(__name__)
 
@@ -3530,4 +3530,5 @@ def register(p):
     p.register(ValidateLabelSchemas)
 
     # dataset
+    p.register(DeleteBrainRun)
     p.register(GetFieldSchema)

--- a/plugins/operators/dataset.py
+++ b/plugins/operators/dataset.py
@@ -9,7 +9,67 @@ Builtin operators.
 from dataclasses import asdict
 
 import fiftyone.operators as foo
+import fiftyone.operators.types as types
 from fiftyone.core.state import serialize_fields
+
+
+class DeleteBrainRun(foo.Operator):
+    @property
+    def config(self):
+        return foo.OperatorConfig(
+            name="delete_brain_run",
+            label="Delete brain run",
+            dynamic=True,
+            risk_level=types.RiskLevel.HIGH,
+        )
+
+    def resolve_input(self, ctx):
+        inputs = types.Object()
+
+        brain_keys = ctx.dataset.list_brain_runs()
+        if brain_keys:
+            choices = types.DropdownView()
+            for brain_key in brain_keys:
+                choices.add_choice(brain_key, label=brain_key)
+
+            inputs.enum(
+                "brain_key",
+                choices.values(),
+                required=True,
+                label="Brain key",
+                description="The brain run to delete",
+                view=choices,
+            )
+
+            brain_key = ctx.params.get("brain_key", None)
+            if brain_key:
+                inputs.str(
+                    "msg",
+                    label=(
+                        f"Delete brain run '{brain_key}'? This deletes its "
+                        "results and cannot be undone"
+                    ),
+                    view=types.Warning(),
+                )
+        else:
+            prop = inputs.str(
+                "msg",
+                label="This dataset has no brain runs",
+                view=types.Warning(),
+            )
+            prop.invalid = True
+
+        view = types.View(label="Delete brain run")
+        return types.Property(inputs, view=view)
+
+    def execute(self, ctx):
+        brain_key = ctx.params["brain_key"]
+
+        # Cascades to the run's cleanup() (e.g. spatial index fields),
+        # hence the dataset reload below
+        ctx.dataset.delete_brain_run(brain_key)
+
+        ctx.trigger("reload_dataset")
 
 
 class GetFieldSchema(foo.Operator):

--- a/plugins/operators/fiftyone.yml
+++ b/plugins/operators/fiftyone.yml
@@ -66,4 +66,5 @@ operators:
   - validate_label_schemas
 
   # dataset
+  - delete_brain_run
   - get_field_schema

--- a/tests/unittests/server_embeddings_v2_tests.py
+++ b/tests/unittests/server_embeddings_v2_tests.py
@@ -1,0 +1,632 @@
+"""
+FiftyOne Server ``/embeddings/v2`` route tests.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import json
+import struct
+import unittest
+from unittest import mock
+
+import numpy as np
+
+import fiftyone as fo
+import fiftyone.brain as fob
+
+from fiftyone.server.routes import embeddings_v2 as v2
+
+from decorators import drop_datasets
+
+
+def _parse(response):
+    body = response.body
+    magic, version, dtype, width, n, flags = struct.unpack(
+        "<IHBBII", body[:16]
+    )
+    assert magic == v2.MAGIC
+    assert version == v2.VERSION
+    return dtype, width, n, flags, body[16:]
+
+
+def _parse_color(response):
+    """Splits a /v2/color body into (dtype, n, column bytes, meta dict)."""
+    dtype, _, n, _, payload = _parse(response)
+    itemsize = 2 if dtype == v2.DTYPE_U16 else 4
+    column = payload[: n * itemsize]
+    meta = json.loads(payload[n * itemsize :].decode("utf-8"))
+    return dtype, n, column, meta
+
+
+def _unpack_masks(payload, n):
+    nbytes = (n + 7) // 8
+    visible = np.unpackbits(
+        np.frombuffer(payload[:nbytes], dtype=np.uint8), bitorder="little"
+    )[:n]
+    match = np.unpackbits(
+        np.frombuffer(payload[nbytes:], dtype=np.uint8), bitorder="little"
+    )[:n]
+    return visible.astype(bool), match.astype(bool)
+
+
+def _make_samples_run(n=20):
+    dataset = fo.Dataset()
+    dataset.add_samples(
+        [
+            fo.Sample(
+                filepath=f"/tmp/img{i}.png",
+                cluster=f"c{i % 3}",
+                score=float(i),
+            )
+            for i in range(n)
+        ]
+    )
+    points = np.stack(
+        [np.arange(n, dtype=float), -np.arange(n, dtype=float)], axis=1
+    )
+    fob.compute_visualization(dataset, points=points, brain_key="viz")
+    return dataset, points
+
+
+def _make_patches_run():
+    dataset = fo.Dataset()
+    samples = []
+    for i in range(5):
+        detections = [
+            fo.Detection(label=f"d{j}", bounding_box=[0.1, 0.1, 0.2, 0.2])
+            for j in range(2)
+        ]
+        samples.append(
+            fo.Sample(
+                filepath=f"/tmp/img{i}.png",
+                ground_truth=fo.Detections(detections=detections),
+            )
+        )
+
+    dataset.add_samples(samples)
+    num_patches = dataset.count("ground_truth.detections")
+    points = np.random.default_rng(51).normal(size=(num_patches, 2))
+    fob.compute_visualization(
+        dataset,
+        patches_field="ground_truth",
+        points=points,
+        brain_key="viz_patches",
+    )
+    return dataset, points
+
+
+class ServerEmbeddingsV2Tests(unittest.TestCase):
+    @drop_datasets
+    def test_runs_and_run_info(self):
+        dataset, points = _make_samples_run()
+        base = {"datasetName": dataset.name, "brainKey": "viz"}
+
+        runs = v2.EmbeddingsV2Runs._post_sync(
+            None, {"datasetName": dataset.name}
+        )["runs"]
+        self.assertEqual(len(runs), 1)
+        self.assertEqual(runs[0]["brainKey"], "viz")
+        self.assertEqual(runs[0]["method"], "manual")
+        self.assertEqual(runs[0]["dims"], 2)
+        self.assertTrue(runs[0]["ready"])
+        self.assertIsNotNone(runs[0]["timestamp"])
+
+        info = v2.EmbeddingsV2RunInfo._post_sync(None, base)
+        self.assertEqual(info["n"], len(points))
+        self.assertEqual(info["dims"], 2)
+        self.assertIsNone(info["patchesField"])
+        self.assertIsNotNone(info["timestamp"])
+
+    @drop_datasets
+    def test_runs_without_results_are_not_ready(self):
+        # A run doc exists as soon as a computation registers, but its
+        # results-blob pointer is only set when results save — clicking
+        # such a run must be preventable, so the list reports readiness
+        dataset, _ = _make_samples_run()
+        run_doc = dataset._doc.brain_methods["viz"]
+        run_doc.results = None
+        run_doc.save()
+
+        runs = v2.EmbeddingsV2Runs._post_sync(
+            None, {"datasetName": dataset.name}
+        )["runs"]
+        self.assertFalse(runs[0]["ready"])
+
+    @drop_datasets
+    def test_geometry_columns(self):
+        dataset, points = _make_samples_run()
+        base = {"datasetName": dataset.name, "brainKey": "viz"}
+
+        dtype, width, n, _, payload = _parse(
+            v2.EmbeddingsV2Geometry._post_sync(None, base)
+        )
+        self.assertEqual((dtype, width, n), (v2.DTYPE_F32, 2, len(points)))
+
+        xs = np.frombuffer(payload[: 4 * n], dtype="<f4")
+        ys = np.frombuffer(payload[4 * n :], dtype="<f4")
+        np.testing.assert_allclose(xs, points[:, 0].astype("f4"))
+        np.testing.assert_allclose(ys, points[:, 1].astype("f4"))
+
+    @drop_datasets
+    def test_column_slicing(self):
+        dataset, points = _make_samples_run()
+        base = {"datasetName": dataset.name, "brainKey": "viz"}
+        results = dataset.load_brain_results("viz")
+
+        dtype, width, n, _, payload = _parse(
+            v2.EmbeddingsV2Geometry._post_sync(
+                None, {**base, "offset": 5, "limit": 7}
+            )
+        )
+        self.assertEqual(n, 7)
+        xs = np.frombuffer(payload[: 4 * n], dtype="<f4")
+        np.testing.assert_allclose(xs, points[5:12, 0].astype("f4"))
+
+        _, _, n, _, payload = _parse(
+            v2.EmbeddingsV2Ids._post_sync(
+                None, {**base, "offset": 5, "limit": 7}
+            )
+        )
+        self.assertEqual(n, 7)
+        self.assertEqual(payload[:12].hex(), str(results.sample_ids[5]))
+
+        # A limit past the end clamps
+        _, _, n, _, _ = _parse(
+            v2.EmbeddingsV2Geometry._post_sync(
+                None, {**base, "offset": 15, "limit": 100}
+            )
+        )
+        self.assertEqual(n, 5)
+
+    @drop_datasets
+    def test_ids_column(self):
+        dataset, points = _make_samples_run()
+        base = {"datasetName": dataset.name, "brainKey": "viz"}
+        results = dataset.load_brain_results("viz")
+
+        dtype, width, n, _, payload = _parse(
+            v2.EmbeddingsV2Ids._post_sync(None, base)
+        )
+        self.assertEqual((dtype, width, n), (v2.DTYPE_BYTES12, 1, len(points)))
+        self.assertEqual(len(payload), n * 12)
+
+        for i in (0, n - 1):
+            self.assertEqual(
+                payload[i * 12 : (i + 1) * 12].hex(),
+                str(results.sample_ids[i]),
+            )
+
+    @drop_datasets
+    def test_color_categorical(self):
+        dataset, points = _make_samples_run()
+        base = {"datasetName": dataset.name, "brainKey": "viz"}
+
+        dtype, n, column, meta = _parse_color(
+            v2.EmbeddingsV2Color._post_sync(None, {**base, "field": "cluster"})
+        )
+        self.assertEqual(dtype, v2.DTYPE_U16)
+        self.assertEqual(n, len(points))
+        self.assertEqual(meta["style"], "categorical")
+        self.assertEqual(len(meta["classes"]), 3)
+        self.assertEqual(sum(c["count"] for c in meta["classes"]), len(points))
+        # Scalar field: column values ARE the field values, so clients
+        # may evaluate filters against the column locally
+        self.assertTrue(meta["exact"])
+
+        indices = np.frombuffer(column, dtype="<u2")
+        labels = [meta["classes"][i]["label"] for i in indices]
+        self.assertEqual(labels, dataset.values("cluster"))
+
+    @drop_datasets
+    def test_color_continuous(self):
+        dataset, points = _make_samples_run()
+        base = {"datasetName": dataset.name, "brainKey": "viz"}
+
+        dtype, _, column, meta = _parse_color(
+            v2.EmbeddingsV2Color._post_sync(None, {**base, "field": "score"})
+        )
+        self.assertEqual(dtype, v2.DTYPE_F32)
+        self.assertEqual(meta["style"], "continuous")
+        self.assertEqual(meta["min"], 0.0)
+        self.assertEqual(meta["max"], float(len(points) - 1))
+
+        values = np.frombuffer(column, dtype="<f4")
+        np.testing.assert_allclose(values, dataset.values("score"))
+
+    @drop_datasets
+    def test_color_aggregates_once_and_caches(self):
+        dataset, _ = _make_samples_run()
+        base = {
+            "datasetName": dataset.name,
+            "brainKey": "viz",
+            "field": "cluster",
+        }
+        v2._color_cache.clear()
+
+        # The whole point of the merged endpoint: one values aggregation
+        # per (run, field), and the cache absorbs repeat selections
+        with mock.patch.object(
+            v2, "_color_data", wraps=v2._color_data
+        ) as color_data:
+            first = v2.EmbeddingsV2Color._post_sync(None, base)
+            second = v2.EmbeddingsV2Color._post_sync(None, base)
+
+        self.assertEqual(color_data.call_count, 1)
+        self.assertEqual(first.body, second.body)
+
+        # A different field is a different cache entry
+        with mock.patch.object(
+            v2, "_color_data", wraps=v2._color_data
+        ) as color_data:
+            v2.EmbeddingsV2Color._post_sync(None, {**base, "field": "score"})
+
+        self.assertEqual(color_data.call_count, 1)
+
+    @drop_datasets
+    def test_masks(self):
+        dataset, points = _make_samples_run()
+        base = {"datasetName": dataset.name, "brainKey": "viz"}
+        results = dataset.load_brain_results("viz")
+        n = len(points)
+
+        # No view, no filters: early-out flags, all ones
+        _, width, _, flags, payload = _parse(
+            v2.EmbeddingsV2Masks._post_sync(None, base)
+        )
+        self.assertEqual(width, 2)
+        self.assertEqual(flags, v2.FLAG_ALL_VISIBLE | v2.FLAG_ALL_MATCH)
+        visible, match = _unpack_masks(payload, n)
+        self.assertTrue(visible.all())
+        self.assertTrue(match.all())
+
+        # A view subsets visibility; a selection subsets match
+        view = dataset.take(7, seed=51)
+        view_ids = set(view.values("id"))
+        selection = dataset.values("id")[:3]
+
+        _, _, _, flags, payload = _parse(
+            v2.EmbeddingsV2Masks._post_sync(
+                None,
+                {
+                    **base,
+                    "view": view._serialize(),
+                    "extendedSelection": selection,
+                },
+            )
+        )
+        self.assertEqual(flags, 0)
+        visible, match = _unpack_masks(payload, n)
+        run_ids = np.array([str(_id) for _id in results.sample_ids])
+        self.assertEqual(set(run_ids[visible]), view_ids)
+        self.assertEqual(set(run_ids[match]), set(selection))
+
+    @drop_datasets
+    def test_lasso_polygon(self):
+        dataset, points = _make_samples_run()
+        base = {"datasetName": dataset.name, "brainKey": "viz"}
+        results = dataset.load_brain_results("viz")
+
+        # Points are (i, -i); enclose the first five
+        polygon = [[-0.5, 0.5], [4.5, 0.5], [4.5, -4.5], [-0.5, -4.5]]
+        res = v2.EmbeddingsV2LassoStage._post_sync(
+            None, {**base, "view": None, "polygon": polygon}
+        )
+        self.assertTrue(res["_cls"].endswith("Select"))
+        self.assertEqual(res["count"], 5)
+        self.assertEqual(
+            set(res["kwargs"]["sample_ids"]),
+            {str(_id) for _id in results.sample_ids[:5]},
+        )
+
+    @drop_datasets
+    def test_lasso_indices(self):
+        dataset, points = _make_samples_run()
+        base = {"datasetName": dataset.name, "brainKey": "viz"}
+        results = dataset.load_brain_results("viz")
+
+        res = v2.EmbeddingsV2LassoStage._post_sync(
+            None, {**base, "view": None, "indices": [1, 3]}
+        )
+        self.assertEqual(res["count"], 2)
+        self.assertEqual(
+            res["kwargs"]["sample_ids"],
+            [str(results.sample_ids[1]), str(results.sample_ids[3])],
+        )
+
+    @drop_datasets
+    def test_lasso_patches_plot_samples_view(self):
+        dataset, _ = _make_patches_run()
+        res = v2.EmbeddingsV2LassoStage._post_sync(
+            None,
+            {
+                "datasetName": dataset.name,
+                "brainKey": "viz_patches",
+                "view": None,
+                "indices": [0, 1],
+            },
+        )
+        self.assertTrue(res["_cls"].endswith("MatchLabels"))
+        self.assertEqual(res["count"], 2)
+
+    @drop_datasets
+    def test_patches_ids_kinds(self):
+        dataset, points = _make_patches_run()
+        base = {"datasetName": dataset.name, "brainKey": "viz_patches"}
+        results = dataset.load_brain_results("viz_patches")
+        n = len(points)
+
+        _, _, _, _, payload = _parse(
+            v2.EmbeddingsV2Ids._post_sync(None, {**base, "kind": "points"})
+        )
+        self.assertEqual(payload[:12].hex(), str(results.label_ids[0]))
+
+        _, _, _, _, payload = _parse(
+            v2.EmbeddingsV2Ids._post_sync(None, {**base, "kind": "samples"})
+        )
+        self.assertEqual(payload[:12].hex(), str(results.sample_ids[0]))
+
+    @drop_datasets
+    def test_sample_info(self):
+        dataset, points = _make_samples_run()
+        base = {"datasetName": dataset.name, "brainKey": "viz"}
+        results = dataset.load_brain_results("viz")
+
+        res = v2.EmbeddingsV2SampleInfo._post_sync(
+            None, {**base, "index": 4, "field": "cluster"}
+        )
+        self.assertEqual(res["sampleId"], str(results.sample_ids[4]))
+        self.assertEqual(res["id"], res["sampleId"])
+        self.assertEqual(res["value"], "c1")
+        # Media is a filepath for the client's getSampleSrc(), not a URL
+        self.assertEqual(res["media"], res["filepath"])
+
+        with self.assertRaises(ValueError):
+            v2.EmbeddingsV2SampleInfo._post_sync(
+                None, {**base, "index": len(points)}
+            )
+
+    @drop_datasets
+    def test_sample_info_deleted_sample(self):
+        dataset, points = _make_samples_run()
+        base = {"datasetName": dataset.name, "brainKey": "viz"}
+        results = dataset.load_brain_results("viz")
+
+        deleted_id = str(results.sample_ids[0])
+        dataset.delete_samples([deleted_id])
+
+        res = v2.EmbeddingsV2SampleInfo._post_sync(None, {**base, "index": 0})
+        self.assertEqual(res["sampleId"], deleted_id)
+        self.assertIsNone(res["media"])
+        self.assertIsNone(res["filepath"])
+        self.assertIsNone(res["value"])
+
+    @drop_datasets
+    def test_color_high_cardinality_strings(self):
+        # More distinct string values than MAX_CATEGORIES: must stay
+        # categorical (strings can't encode as f32), capped to the top
+        # MAX_CATEGORIES classes by count, remainder marked missing
+        n = v2.MAX_CATEGORIES + 50
+        dataset = fo.Dataset()
+        dataset.add_samples(
+            [
+                fo.Sample(filepath=f"/tmp/img{i}.png", name=f"unique_{i:04d}")
+                for i in range(n)
+            ]
+        )
+        points = np.zeros((n, 2))
+        fob.compute_visualization(dataset, points=points, brain_key="viz")
+        base = {"datasetName": dataset.name, "brainKey": "viz"}
+
+        dtype, _, column, meta = _parse_color(
+            v2.EmbeddingsV2Color._post_sync(None, {**base, "field": "name"})
+        )
+        self.assertEqual(meta["style"], "categorical")
+        self.assertEqual(len(meta["classes"]), v2.MAX_CATEGORIES)
+        self.assertTrue(meta["truncated"])
+
+        self.assertEqual(dtype, v2.DTYPE_U16)
+        indices = np.frombuffer(column, dtype="<u2")
+        missing = int((indices == v2.MISSING_CATEGORY).sum())
+        self.assertEqual(missing, n - v2.MAX_CATEGORIES)
+
+    @drop_datasets
+    def test_color_int_high_cardinality_is_continuous(self):
+        n = v2.MAX_CATEGORIES + 50
+        dataset = fo.Dataset()
+        dataset.add_samples(
+            [fo.Sample(filepath=f"/tmp/img{i}.png", index=i) for i in range(n)]
+        )
+        points = np.zeros((n, 2))
+        fob.compute_visualization(dataset, points=points, brain_key="viz")
+        base = {"datasetName": dataset.name, "brainKey": "viz"}
+
+        _, _, _, meta = _parse_color(
+            v2.EmbeddingsV2Color._post_sync(None, {**base, "field": "index"})
+        )
+        self.assertEqual(meta["style"], "continuous")
+        self.assertEqual(meta["max"], float(n - 1))
+
+    @drop_datasets
+    def test_color_list_field_collapses_to_first(self):
+        dataset = fo.Dataset()
+        dataset.add_samples(
+            [
+                fo.Sample(filepath="/tmp/a.png", letters=["a", "b"]),
+                fo.Sample(filepath="/tmp/b.png", letters=["c"]),
+                fo.Sample(filepath="/tmp/c.png", letters=[]),
+            ]
+        )
+        points = np.zeros((3, 2))
+        fob.compute_visualization(dataset, points=points, brain_key="viz")
+        base = {"datasetName": dataset.name, "brainKey": "viz"}
+
+        _, _, column, meta = _parse_color(
+            v2.EmbeddingsV2Color._post_sync(None, {**base, "field": "letters"})
+        )
+        self.assertEqual(meta["style"], "categorical")
+        self.assertEqual({c["label"] for c in meta["classes"]}, {"a", "c"})
+        # Collapsed values are lossy: the ["a", "b"] sample's column
+        # value says nothing about "b", so filters must NOT be
+        # evaluated against the column client-side
+        self.assertFalse(meta["exact"])
+
+        indices = np.frombuffer(column, dtype="<u2")
+        # The empty-list sample is missing
+        self.assertEqual(indices[2], v2.MISSING_CATEGORY)
+
+    @drop_datasets
+    def test_color_label_list_field(self):
+        # Label-list paths (detections.label) yield a LIST per point
+        # while the schema's leaf field is a scalar StringField — the
+        # values, not the schema, carry the listiness. Regression: this
+        # crashed the endpoint (unhashable list) on any detections
+        # dataset
+        dataset = fo.Dataset()
+        dataset.add_samples(
+            [
+                fo.Sample(
+                    filepath="/tmp/a.png",
+                    gt=fo.Detections(
+                        detections=[
+                            fo.Detection(label="cat"),
+                            fo.Detection(label="dog"),
+                        ]
+                    ),
+                ),
+                fo.Sample(filepath="/tmp/b.png", gt=fo.Detections()),
+            ]
+        )
+        points = np.zeros((2, 2))
+        fob.compute_visualization(dataset, points=points, brain_key="viz")
+        base = {"datasetName": dataset.name, "brainKey": "viz"}
+
+        _, _, column, meta = _parse_color(
+            v2.EmbeddingsV2Color._post_sync(
+                None, {**base, "field": "gt.detections.label"}
+            )
+        )
+        self.assertEqual(meta["style"], "categorical")
+        self.assertEqual({c["label"] for c in meta["classes"]}, {"cat"})
+        self.assertFalse(meta["exact"])
+
+        indices = np.frombuffer(column, dtype="<u2")
+        self.assertEqual(indices[1], v2.MISSING_CATEGORY)
+
+    @drop_datasets
+    def test_color_missing_values(self):
+        dataset = fo.Dataset()
+        dataset.add_samples(
+            [
+                fo.Sample(filepath="/tmp/a.png", grade="x", score=1.0),
+                fo.Sample(filepath="/tmp/b.png"),
+            ]
+        )
+        points = np.zeros((2, 2))
+        fob.compute_visualization(dataset, points=points, brain_key="viz")
+        base = {"datasetName": dataset.name, "brainKey": "viz"}
+
+        _, _, column, meta = _parse_color(
+            v2.EmbeddingsV2Color._post_sync(None, {**base, "field": "grade"})
+        )
+        self.assertEqual(sum(c["count"] for c in meta["classes"]), 1)
+
+        indices = np.frombuffer(column, dtype="<u2")
+        self.assertEqual(indices[1], v2.MISSING_CATEGORY)
+
+        _, _, column, meta = _parse_color(
+            v2.EmbeddingsV2Color._post_sync(None, {**base, "field": "score"})
+        )
+        self.assertEqual((meta["min"], meta["max"]), (1.0, 1.0))
+
+        values = np.frombuffer(column, dtype="<f4")
+        self.assertTrue(np.isnan(values[1]))
+
+    @drop_datasets
+    def test_sample_info_video_media_is_null(self):
+        dataset = fo.Dataset()
+        dataset.add_sample(fo.Sample(filepath="/tmp/clip.mp4"))
+        points = np.zeros((1, 2))
+        fob.compute_visualization(dataset, points=points, brain_key="viz")
+
+        res = v2.EmbeddingsV2SampleInfo._post_sync(
+            None,
+            {"datasetName": dataset.name, "brainKey": "viz", "index": 0},
+        )
+        self.assertIsNone(res["media"])
+        self.assertTrue(res["filepath"].endswith("clip.mp4"))
+
+    @drop_datasets
+    def test_negative_slices_are_rejected(self):
+        # Python's negative slicing would "work" and return unrelated
+        # wire-order rows — a protocol violation must raise instead
+        dataset, _ = _make_samples_run()
+        base = {"datasetName": dataset.name, "brainKey": "viz"}
+
+        for bad in (
+            {"offset": -1},
+            {"limit": -5},
+            # Fractions must reject, not truncate into a different slice
+            {"offset": 0.5},
+            {"limit": 1.5},
+        ):
+            with self.assertRaises(ValueError):
+                v2.EmbeddingsV2Geometry._post_sync(None, {**base, **bad})
+
+    @drop_datasets
+    def test_invalid_lasso_indices_are_rejected(self):
+        # Negative indices silently select from the end of the arrays
+        dataset, points = _make_samples_run()
+        base = {"datasetName": dataset.name, "brainKey": "viz", "view": []}
+
+        for bad in ([-1], [len(points)], [[0, 1]], [1.5]):
+            with self.assertRaises(ValueError):
+                v2.EmbeddingsV2LassoStage._post_sync(
+                    None, {**base, "indices": bad}
+                )
+
+    @drop_datasets
+    def test_unknown_brain_key_raises(self):
+        dataset = fo.Dataset()
+        dataset.add_sample(fo.Sample(filepath="/tmp/a.png"))
+
+        with self.assertRaises(ValueError):
+            v2.EmbeddingsV2RunInfo._post_sync(
+                None,
+                {"datasetName": dataset.name, "brainKey": "nope"},
+            )
+
+    def test_points_in_polygon(self):
+        xs = np.array([0.5, 2.0, 0.5, -1.0])
+        ys = np.array([0.5, 0.5, 2.0, 0.5])
+        square = np.array([[0, 0], [1, 0], [1, 1], [0, 1]], dtype=float)
+        np.testing.assert_array_equal(
+            v2._points_in_polygon(xs, ys, square),
+            [True, False, False, False],
+        )
+
+        # Concave "C": the notch on the right is outside
+        c_shape = np.array(
+            [
+                [0, 0],
+                [10, 0],
+                [10, 3],
+                [3, 3],
+                [3, 7],
+                [10, 7],
+                [10, 10],
+                [0, 10],
+            ],
+            dtype=float,
+        )
+        xs = np.array([1.0, 8.0])
+        ys = np.array([5.0, 5.0])
+        np.testing.assert_array_equal(
+            v2._points_in_polygon(xs, ys, c_shape), [True, False]
+        )
+
+
+if __name__ == "__main__":
+    fo.config.show_progress_bars = False
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Cherry-pick of #8042 (the rebuilt embeddings panel) onto the release branch — one `cherry-pick -m 1` of its merge commit, applied with zero conflicts.

Contents are identical to what merged into `develop` and was reviewed there (3 approvals): the new `embeddings-v2` panel, the `/embeddings/v2/*` server routes and tests, and the small App integrations (`hasFilters`, panel registration, delete-run operator).

Follow-up cherry-pick coming behind this one: #8073 (the panel swap), which depends on this landing first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Embeddings V2 panel for exploring visualization runs with interactive 2D/3D plots.
  * Added color-by controls, categorical and continuous legends, hover previews, zooming, panning, lasso selection, and sample selection synchronization.
  * Added visualization run management, including pending states, refresh behavior, and confirmed deletion.
  * Added server support for embeddings data, filtering, selections, and sample details.
* **Bug Fixes**
  * Improved panel-opening behavior and filter indicators for active selections.
* **Tests**
  * Added comprehensive coverage for visualization, selection, filtering, and interaction workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3415
<!-- enterprise-sync-pr:end -->