### PR TITLE
Require fiftyone-brain 0.23

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ setup(
         "scikit-image<1",
         "scipy<2",
         # internal packages
-        "fiftyone-brain>=0.22.0,<0.23",
+        "fiftyone-brain>=0.23.0,<0.24",
         "fiftyone-db>=0.4,<2.0",
         "voxel51-eta>=0.16.0,<0.17",
     ],


### PR DESCRIPTION
Bumps the `fiftyone-brain` pin to `>=0.23.0,<0.24` for the brain 0.23.0 release (voxel51/fiftyone-brain#297), which carries the embeddings v2 binary storage format (voxel51/fiftyone-brain#295) used by the new embeddings panel.

Draft until `fiftyone-brain 0.23.0` is published to PyPI — the `>=0.23.0` floor cannot resolve before then.

After merge: cherry-pick to `release/v1.20.0` and redeploy the RC so the embeddings panel can be tested against the published wheel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the required `fiftyone-brain` package version to the latest supported release range.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3582
<!-- enterprise-sync-pr:end -->