### PR TITLE
Require fiftyone-brain 0.23 (release/v1.20.0)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ setup(
         "scikit-image<1",
         "scipy<2",
         # internal packages
-        "fiftyone-brain>=0.22.0,<0.23",
+        "fiftyone-brain>=0.23.0,<0.24",
         "fiftyone-db>=0.4,<2.0",
         "voxel51-eta>=0.16.0,<0.17",
     ],


### PR DESCRIPTION
Cherry-pick of #8076 to `release/v1.20.0`.

Bumps the `fiftyone-brain` pin to `>=0.23.0,<0.24` so the release picks up brain 0.23.0 (voxel51/fiftyone-brain#297) with the embeddings v2 binary storage format used by the new embeddings panel.

Draft until `fiftyone-brain 0.23.0` is published to PyPI — the `>=0.23.0` floor cannot resolve before then. Merge #8076 into `develop` first, per the cherry-pick gate.

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3581
<!-- enterprise-sync-pr:end -->