### PR TITLE
ci: probe GitHub Actions step-level parallelism (do not merge)

### DIFF
--- a/.github/workflows/test-parallel-steps.yml
+++ b/.github/workflows/test-parallel-steps.yml
@@ -1,0 +1,93 @@
+name: Test parallel steps
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/test-parallel-steps.yml
+  workflow_dispatch:
+
+jobs:
+  background-wait-cancel:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Start background sleeper with an output
+        id: sleeper
+        run: |
+          sleep 20
+          echo "result=slept" >> "$GITHUB_OUTPUT"
+        background: true
+
+      - name: Foreground work while sleeper runs
+        run: echo "this ran while the sleeper was in the background"
+
+      - name: Wait for sleeper
+        wait: sleeper
+
+      - name: Verify background step output propagated
+        run: |
+          test "${{ steps.sleeper.outputs.result }}" = "slept"
+
+      - name: Background task A
+        id: task-a
+        run: sleep 10
+        background: true
+
+      - name: Background task B
+        id: task-b
+        run: sleep 10
+        background: true
+
+      - name: Wait for both tasks
+        wait: [task-a, task-b]
+
+      - name: Start long-running monitor
+        id: monitor
+        run: sleep 300
+        background: true
+
+      - name: Cancel the monitor
+        cancel: monitor
+
+      - name: Background straggler for wait-all
+        id: straggler
+        run: sleep 5
+        background: true
+
+      - name: Wait for all remaining background steps
+        wait-all:
+
+  uses-step-in-background:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Set up Node in the background
+        id: setup-node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+        background: true
+
+      - name: Foreground work while setup runs
+        run: echo "this ran while setup-node was in the background"
+
+      - name: Wait for Node setup
+        wait: setup-node
+
+      - name: Use Node
+        run: node --version
+
+  parallel-group:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - parallel:
+          - name: Task one
+            run: sleep 5 && echo one
+          - name: Task two
+            run: sleep 5 && echo two
+          - name: Task three
+            run: sleep 5 && echo three
+
+      - name: After the group
+        run: echo "all parallel tasks finished"


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

Standalone probe workflow to validate the [step-level parallelism feature GitHub announced 2026-06-25](https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/) before reintroducing it in real workflows.

Context: #7916 used this syntax on 6/30 and every `pr.yml` run startup-failed with zero jobs, so it was reverted in #7929. The revert claimed the keys don't exist — that was wrong; the feature had been announced five days earlier and #7916's usage matches the now-published syntax exactly (`jobs.<job_id>.steps[*].background` et al. in the workflow-syntax docs, gated on the `actions-nga` feature which is live for github.com). The likely explanation for the 6/30 failures is rollout timing.

This PR tests every primitive in one throwaway workflow (`test-parallel-steps.yml`, triggered only by changes to itself) so a parse failure cannot take down the `pr.yml` call graph:

- `background: true` on a `run:` step, with `$GITHUB_OUTPUT` read back after `wait` (output propagation)
- `wait: <id>` and `wait: [<id>, <id>]`
- `cancel: <id>` on a long-running background step
- `wait-all:`
- `background: true` on a `uses:` step (the pattern #7916 relied on for artifact downloads)
- a `parallel:` group

**If the three jobs run green, the feature is live for this repo and we can reintroduce #7916's changes where they still pay off post-#8012. Not for merge either way.**

## 🧪 How is this patch tested? If it is not, please explain why.

The PR is the test: the workflow triggers on this PR and its jobs passing/failing is the result.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.

N/A

### What areas of FiftyOne does this PR affect?

- [x] Build: Build and test infrastructure changes