### PR TITLE
ci: reintroduce step-level parallelism from #7916

### DIFF
--- a/.github/workflows/build-db.yml
+++ b/.github/workflows/build-db.yml
@@ -86,14 +86,18 @@ jobs:
       - name: Clone fiftyone
         uses: actions/checkout@v6
       - name: Download fiftyone-db
+        id: download-fiftyone-db
         uses: actions/download-artifact@v8
         with:
           name: dist-sdist
           path: downloads
+        background: true
       - name: Set up Python 3.10
         uses: actions/setup-python@v6
         with:
           python-version: "3.10"
+      - name: Wait for fiftyone-db
+        wait: download-fiftyone-db
       - name: Install fiftyone-db
         run: |
           pip install downloads/fiftyone_db-*.tar.gz

--- a/.github/workflows/build-docker-internal.yml
+++ b/.github/workflows/build-docker-internal.yml
@@ -27,10 +27,12 @@ jobs:
       - name: Clone fiftyone
         uses: actions/checkout@v6
       - name: Download dist
+        id: download-dist
         uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
+        background: true
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v3
         with:
@@ -52,6 +54,8 @@ jobs:
           echo "today=$(date +%Y%m%d)" >> "$GITHUB_ENV"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+      - name: Wait for dist
+        wait: download-dist
       - name: Build and push internal image
         uses: docker/build-push-action@v7
         with:

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -112,6 +112,7 @@ jobs:
           python -Im build
           pip install ./dist/*.whl
       - name: Install
+        id: install-docs-dependencies
         run: |
           echo "Installing system dependencies"
           sudo apt-get install pandoc
@@ -121,6 +122,7 @@ jobs:
           pip install fiftyone-brain fiftyone-db
           echo "Installing fiftyone"
           pip install .
+        background: true
 
       - name: Setup node 22
         uses: actions/setup-node@v6
@@ -142,6 +144,8 @@ jobs:
           key: node-modules-${{ hashFiles('app/yarn.lock') }}
       - name: Install app
         run: cd app && yarn install
+      - name: Wait for docs dependencies
+        wait: install-docs-dependencies
       - name: Build docs
         run: |
           ./docs/generate_docs.bash -t fiftyone-teams
@@ -161,16 +165,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download docs
+        id: download-docs
         uses: actions/download-artifact@v8
         with:
           name: docs
           path: docs-download/
+        background: true
       - name: Authorize gcloud
         uses: google-github-actions/auth@v3
         with:
           credentials_json: "${{ secrets.DOCS_GCP_CREDENTIALS }}"
       - name: Set up gcloud
         uses: google-github-actions/setup-gcloud@v3
+      - name: Wait for docs
+        wait: download-docs
       - name: publish
         run: gsutil -m rsync -dR -x '^SBOMs/.*' docs-download gs://docs.voxel51.com
 
@@ -182,15 +190,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download docs
+        id: download-docs
         uses: actions/download-artifact@v8
         with:
           name: docs
           path: docs-download/
+        background: true
       - name: Authorize gcloud
         uses: google-github-actions/auth@v3
         with:
           credentials_json: "${{ secrets.DOCS_GCP_CREDENTIALS }}"
       - name: Set up gcloud
         uses: google-github-actions/setup-gcloud@v3
+      - name: Wait for docs
+        wait: download-docs
       - name: publish
         run: gsutil -m rsync -dR -x '^robots.txt' docs-download gs://docs.dev.voxel51.com

--- a/.github/workflows/build-graphql.yml
+++ b/.github/workflows/build-graphql.yml
@@ -45,9 +45,11 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/db-v')
     steps:
       - name: Download wheels
+        id: download-wheels
         uses: actions/download-artifact@v8
         with:
           path: downloads
+        background: true
       - name: Install dependencies
         run: |
           pip install twine
@@ -57,6 +59,8 @@ jobs:
         run: |
           echo "TWINE_PASSWORD=${{ secrets.FIFTYONE_PYPI_TOKEN }}" >> $GITHUB_ENV
           echo "TWINE_REPOSITORY=pypi" >> $GITHUB_ENV
+      - name: Wait for wheels
+        wait: download-wheels
       - name: Upload to pypi
         env:
           TWINE_USERNAME: __token__

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,7 @@ jobs:
         with:
           path: fiftyone/server/static
           key: app-static-${{ runner.os }}-${{ steps.app-tree-hash.outputs.hash }}
+        background: true
 
       - name: Cache Node Modules
         id: node-cache
@@ -63,6 +64,10 @@ jobs:
             app/node_modules
             app/.yarn/cache
           key: node-modules-${{ hashFiles('app/yarn.lock') }}
+        background: true
+
+      - name: Wait for caches
+        wait: [app-static-cache, node-cache]
       - name: Install app
         if: steps.app-static-cache.outputs.cache-hit != 'true'
         run: cd app && yarn install

--- a/.github/workflows/lint-app.yml
+++ b/.github/workflows/lint-app.yml
@@ -38,18 +38,19 @@ jobs:
       - name: Install Dependencies
         run: cd app && yarn install
 
-      - name: Lint ESLint packages
-        run: |
-          cd app
-          ESLINT_PACKAGES=$(grep -v '^#' ./eslint-packages.txt | xargs)
-          yarn eslint $ESLINT_PACKAGES
+      - parallel:
+          - name: Lint ESLint packages
+            run: |
+              cd app
+              ESLINT_PACKAGES=$(grep -v '^#' ./eslint-packages.txt | xargs)
+              yarn eslint $ESLINT_PACKAGES
 
-      - name: Check formatting
-        run: |
-          cd app
-          yarn format:check
+          - name: Check formatting
+            run: |
+              cd app
+              yarn format:check
 
-      - name: Check multimodal package
-        run: |
-          cd app
-          yarn check
+          - name: Check multimodal package
+            run: |
+              cd app
+              yarn check

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -47,6 +47,10 @@ jobs:
             requirements/common.txt
             requirements/github.txt
             requirements/test.txt
+      - name: Setup FFmpeg
+        id: setup-ffmpeg
+        uses: ./.github/actions/setup-ffmpeg
+        background: true
       - name: Install requirements
         run: |
           uv pip install --system -U wheel setuptools
@@ -60,8 +64,8 @@ jobs:
           python tests/utils/setup_config.py
           python tests/utils/github_actions_flags.py
 
-      - name: Setup FFmpeg
-        uses: ./.github/actions/setup-ffmpeg
+      - name: Wait for FFmpeg
+        wait: setup-ffmpeg
 
       # Important: use pytest_wrapper.py instead of pytest directly to ensure
       # that services shut down cleanly and do not conflict with steps later in


### PR DESCRIPTION
## 🔗 Related Issues

Reintroduces #7916, reverted in #7929. Validated by probe #8082.

## 📋 What changes are proposed in this pull request?

GitHub's [step-level parallelism](https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/) (`background`/`wait`/`parallel`) is now rolled out to this repo — probe #8082 ran every primitive green on 2026-07-21, including `background: true` on `uses:` steps and output propagation after `wait`. The #7929 revert was correct at the time (the 6/30 merge startup-failed the `pr.yml` call graph), but the cause was rollout timing, not invalid syntax.

This reapplies #7916 where it still pays off:

- **lint-app.yml**: ESLint, `format:check`, and `yarn check` run as a `parallel:` group after `yarn install`
- **build.yml**: the two cache restores run in background; `wait` before the first `cache-hit` consumer
- **build-db.yml / build-docker-internal.yml / build-graphql.yml / build-docs.yml**: artifact downloads and the docs pip install run in background during unrelated setup (python/node/gcloud/buildx), with `wait` immediately before the first consumer
- **windows-test.yml**: FFmpeg setup runs during pip install

**Excluded from #7916**: `e2e.yml` and `test.yml` — the prebaked CI images from #8012 removed the setup steps it parallelized there; both conflict on reapply and have nothing left worth backgrounding.

Note: `actionlint` has not caught up with the new keys and will flag them; this repo does not run actionlint in CI.

## 🧪 How is this patch tested? If it is not, please explain why.

- Probe #8082: all primitives green in this repo (run 29844785455), with step timings confirming true concurrency
- `ruby -ryaml` parse check on all 7 changed workflows
- This PR's own CI exercises `lint-app.yml`, `build.yml`, and `windows-test.yml` directly; `build-docs.yml`/`build-db.yml`/`build-docker-internal.yml`/`build-graphql.yml` use the identical validated syntax but only run on their own triggers (tags/releases)

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.

N/A

### What areas of FiftyOne does this PR affect?

- [x] Build: Build and test infrastructure changes

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3427
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved CI workflow efficiency by running independent artifact downloads, dependency installation, caching, and checks in parallel across build, publish, lint, and Windows test workflows.
* **Reliability**
  * Added explicit “wait” synchronization steps to ensure downloads and setups (artifacts, docs dependencies, caches, and tools) complete before dependent build, test, publishing, and packaging steps proceed.
* **Tests**
  * Parallelized app quality checks within the lint workflow to reduce overall validation time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->