### PR TITLE
Add TIDE detection evaluation backend

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -4336,6 +4336,7 @@ class SampleCollection(object):
         -   ``"coco"``: :class:`fiftyone.utils.eval.coco.COCOEvaluationConfig`
         -   ``"open-images"``: :class:`fiftyone.utils.eval.openimages.OpenImagesEvaluationConfig`
         -   ``"activitynet"``: :class:`fiftyone.utils.eval.activitynet.ActivityNetEvaluationConfig`
+        -   ``"tide"``: :class:`fiftyone.utils.eval.tide.TIDEEvaluationConfig`
 
         If an ``eval_key`` is provided, a number of fields are populated at the
         object- and sample-level recording the results of the evaluation:

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -731,6 +731,9 @@ class EvaluationConfig(EnvConfig):
             "coco": {
                 "config_cls": "fiftyone.utils.eval.coco.COCOEvaluationConfig",
             },
+            "tide": {
+                "config_cls": "fiftyone.utils.eval.tide.TIDEEvaluationConfig",
+            },
             "open-images": {
                 "config_cls": "fiftyone.utils.eval.openimages.OpenImagesEvaluationConfig",
             },

--- a/fiftyone/core/plots/matplotlib.py
+++ b/fiftyone/core/plots/matplotlib.py
@@ -73,6 +73,7 @@ def plot_confusion_matrix(
     Returns:
         a matplotlib figure
     """
+    close_figure = ax is None and foc.is_jupyter_context()
     if ax is None:
         fig, ax = plt.subplots()
     else:
@@ -132,6 +133,9 @@ def plot_confusion_matrix(
         fig.suptitle(title)
 
     plt.tight_layout()
+
+    if close_figure:
+        plt.close(fig)
 
     return fig
 

--- a/fiftyone/utils/eval/coco.py
+++ b/fiftyone/utils/eval/coco.py
@@ -487,13 +487,21 @@ _NO_MATCH_ID = ""
 _NO_MATCH_IOU = None
 
 
-def _coco_evaluation_single_iou(gts, preds, eval_key, config):
+def _coco_evaluation_single_iou(
+    gts, preds, eval_key, config, max_preds=None, per_class_max_preds=True
+):
     iou_thresh = min(config.iou, 1 - 1e-10)
     id_key = "%s_id" % eval_key
     iou_key = "%s_iou" % eval_key
 
     cats, pred_ious, iscrowd = _coco_evaluation_setup(
-        gts, preds, [id_key], iou_key, config
+        gts,
+        preds,
+        [id_key],
+        iou_key,
+        config,
+        max_preds=max_preds,
+        per_class_max_preds=per_class_max_preds,
     )
 
     matches = _compute_matches(
@@ -534,7 +542,13 @@ def _coco_evaluation_iou_sweep(gts, preds, config):
 
 
 def _coco_evaluation_setup(
-    gts, preds, id_keys, iou_key, config, max_preds=None
+    gts,
+    preds,
+    id_keys,
+    iou_key,
+    config,
+    max_preds=None,
+    per_class_max_preds=True,
 ):
     iscrowd = lambda l: bool(l.get_attribute_value(config.iscrowd, False))
     classwise = config.classwise
@@ -549,6 +563,20 @@ def _coco_evaluation_setup(
 
     if config.keypoint_sigmas is not None:
         iou_kwargs.update(keypoint_sigmas=config.keypoint_sigmas)
+
+    if isinstance(preds, fol.Keypoints):
+        sort_key = lambda p: np.nanmean(p.confidence) if p.confidence else -1
+    else:
+        sort_key = lambda p: p.confidence or -1
+
+    if max_preds is not None and not per_class_max_preds and preds is not None:
+        _preds = preds[preds._LABEL_LIST_FIELD]
+        pred_ids = {
+            pred.id
+            for pred in sorted(_preds, key=sort_key, reverse=True)[:max_preds]
+        }
+    else:
+        pred_ids = None
 
     # Organize ground truth and predictions by category
 
@@ -569,13 +597,11 @@ def _coco_evaluation_setup(
             for id_key in id_keys:
                 obj[id_key] = _NO_MATCH_ID
 
+            if pred_ids is not None and obj.id not in pred_ids:
+                continue
+
             label = obj.label if classwise else "all"
             cats[label]["preds"].append(obj)
-
-    if isinstance(preds, fol.Keypoints):
-        sort_key = lambda p: np.nanmean(p.confidence) if p.confidence else -1
-    else:
-        sort_key = lambda p: p.confidence or -1
 
     # Compute IoUs within each category
     pred_ious = {}
@@ -586,7 +612,7 @@ def _coco_evaluation_setup(
         # Highest confidence predictions first
         preds = sorted(preds, key=sort_key, reverse=True)
 
-        if max_preds is not None:
+        if max_preds is not None and per_class_max_preds:
             preds = preds[:max_preds]
 
         objects["preds"] = preds

--- a/fiftyone/utils/eval/tide.py
+++ b/fiftyone/utils/eval/tide.py
@@ -1,0 +1,735 @@
+"""
+TIDE-style detection error analysis.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+from collections import Counter, defaultdict
+
+import numpy as np
+
+import fiftyone.core.context as foc
+import fiftyone.core.fields as fof
+import fiftyone.core.labels as fol
+import fiftyone.utils.iou as foui
+
+from .coco import (
+    COCOEvaluation,
+    COCOEvaluationConfig,
+    COCODetectionResults,
+    _coco_evaluation_single_iou,
+    _copy_labels,
+    _compute_pr_curves,
+)
+from .detection import DetectionResults
+
+_MAIN_ERRORS = ("cls", "loc", "both", "dupe", "bkg", "miss")
+_SPECIAL_ERRORS = ("false_pos", "false_neg")
+
+
+class TIDEEvaluationConfig(COCOEvaluationConfig):
+    """TIDE-style detection evaluation config.
+
+    This backend classifies false positives and false negatives into
+    classification, localization, both, duplicate, background, and missed
+    errors. It requires classwise matching.
+
+    Args:
+        bg_thresh (0.1): the IoU threshold below which a detection is treated
+            as background
+        max_preds (100): the maximum number of predictions per image to
+            evaluate
+    """
+
+    def __init__(
+        self, pred_field, gt_field, bg_thresh=0.1, max_preds=100, **kwargs
+    ):
+        super().__init__(pred_field, gt_field, max_preds=max_preds, **kwargs)
+        self.bg_thresh = bg_thresh
+
+    @property
+    def method(self):
+        return "tide"
+
+
+class TIDEEvaluation(COCOEvaluation):
+    """TIDE-style detection evaluation."""
+
+    def __init__(self, config):
+        super().__init__(config)
+
+        if not config.classwise:
+            raise ValueError("TIDE evaluation requires classwise=True")
+
+        if not 0 <= config.bg_thresh <= config.iou:
+            raise ValueError("`bg_thresh` must be in [0, iou]")
+
+        self._records = []
+        self._errors = []
+        self._gt_counts = Counter()
+        self._missed = Counter()
+        self._false_negatives = Counter()
+        self._error_counts = Counter()
+
+    def register_samples(self, samples, eval_key, dynamic=True):
+        super().register_samples(samples, eval_key, dynamic=dynamic)
+
+        if eval_key is None or not dynamic:
+            return
+
+        error_key = "%s_error" % eval_key
+        processing_frames = samples._is_frame_field(self.config.pred_field)
+        dataset = samples._dataset
+
+        for field in (self.config.gt_field, self.config.pred_field):
+            _, prefix = samples._get_label_field_path(field)
+            prefix, _ = samples._handle_frame_field(prefix)
+            path = "%s.%s" % (prefix, error_key)
+            if processing_frames:
+                dataset.add_frame_field(path, fof.StringField)
+            else:
+                dataset.add_sample_field(path, fof.StringField)
+
+    def evaluate(self, sample_or_frame, eval_key=None):
+        if eval_key is None:
+            eval_key = "eval"
+            gts = _copy_labels(sample_or_frame[self.gt_field])
+            preds = _copy_labels(sample_or_frame[self.pred_field])
+        else:
+            gts = sample_or_frame[self.gt_field]
+            preds = sample_or_frame[self.pred_field]
+
+        pred_ids = _get_tide_pred_ids(preds, self.config.max_preds)
+        matches = _coco_evaluation_single_iou(
+            gts,
+            preds,
+            eval_key,
+            self.config,
+            max_preds=self.config.max_preds,
+            per_class_max_preds=False,
+        )
+        self._analyze_errors(gts, preds, eval_key, pred_ids)
+
+        return matches
+
+    def generate_results(
+        self,
+        samples,
+        matches,
+        eval_key=None,
+        classes=None,
+        missing=None,
+        progress=None,
+    ):
+        tide_ap, error_deltas, special_error_deltas = _compute_dap(
+            self._records,
+            self._errors,
+            self._gt_counts,
+            self._missed,
+            self._false_negatives,
+        )
+
+        kwargs = {}
+        if self.config.compute_mAP:
+            (
+                precision,
+                recall,
+                thresholds,
+                iou_threshs,
+                classes,
+                recall_sweep,
+            ) = _compute_pr_curves(
+                samples, self.config, classes=classes, progress=progress
+            )
+            kwargs.update(
+                precision=precision,
+                recall=recall,
+                iou_threshs=iou_threshs,
+                recall_sweep=recall_sweep,
+                thresholds=thresholds,
+            )
+
+        return TIDEDetectionResults(
+            samples,
+            self.config,
+            eval_key,
+            matches,
+            classes=classes,
+            missing=missing,
+            error_counts={
+                error: self._error_counts[error] for error in _MAIN_ERRORS
+            },
+            tide_ap=tide_ap,
+            error_deltas=error_deltas,
+            special_error_deltas=special_error_deltas,
+            backend=self,
+            **kwargs,
+        )
+
+    def get_fields(self, samples, eval_key, include_custom_metrics=True):
+        fields = super().get_fields(
+            samples, eval_key, include_custom_metrics=include_custom_metrics
+        )
+        error_key = "%s_error" % eval_key
+
+        for field in (self.config.gt_field, self.config.pred_field):
+            label_type = samples._get_label_field_type(field)
+            fields.append(
+                "%s.%s.%s" % (field, label_type._LABEL_LIST_FIELD, error_key)
+            )
+
+        return fields
+
+    def cleanup(self, samples, eval_key):
+        super().cleanup(samples, eval_key)
+
+        dataset = samples._dataset
+        error_key = "%s_error" % eval_key
+        fields = []
+        for original_field in (self.config.gt_field, self.config.pred_field):
+            try:
+                field, _ = dataset._handle_frame_field(original_field)
+                label_type = dataset._get_label_field_type(original_field)
+                fields.append(
+                    "%s.%s.%s"
+                    % (field, label_type._LABEL_LIST_FIELD, error_key)
+                )
+            except ValueError:
+                pass
+
+        if dataset._is_frame_field(self.config.pred_field):
+            dataset.delete_frame_fields(fields, error_level=1)
+        else:
+            dataset.delete_sample_fields(fields, error_level=1)
+
+    def _analyze_errors(self, gts, preds, eval_key, pred_ids):
+        gt_list = _get_labels(gts)
+        all_preds = _get_labels(preds)
+        pred_list = sorted(
+            (pred for pred in all_preds if pred.id in pred_ids),
+            key=_get_confidence,
+            reverse=True,
+        )
+        error_key = "%s_error" % eval_key
+        id_key = "%s_id" % eval_key
+
+        for obj in gt_list + all_preds:
+            obj[error_key] = None
+
+        for pred in all_preds:
+            if pred.id not in pred_ids:
+                pred[eval_key] = None
+
+        def iscrowd(obj):
+            return bool(obj.get_attribute_value(self.config.iscrowd, False))
+
+        crowd_ids = {gt.id for gt in gt_list if iscrowd(gt)}
+        active_gts = [gt for gt in gt_list if gt.id not in crowd_ids]
+        used_ids = {gt.id for gt in active_gts if gt[eval_key] == "tp"}
+        unused_ids = {gt.id for gt in active_gts if gt.id not in used_ids}
+
+        for gt in active_gts:
+            self._gt_counts[gt.label] += 1
+            if gt.id in unused_ids:
+                self._false_negatives[gt.label] += 1
+
+        ignored_ids = _get_ignored_pred_ids(
+            pred_list, active_gts, gt_list, self.config, iscrowd, id_key
+        )
+
+        fp_preds = [
+            pred
+            for pred in pred_list
+            if pred[eval_key] != "tp" or pred[id_key] in crowd_ids
+        ]
+        fp_preds.sort(key=_get_confidence, reverse=True)
+
+        ious = _compute_ious(fp_preds, active_gts, self.config, iscrowd)
+        error_info = {}
+        usable_ids = set()
+        best_matches = {}
+
+        for pred_idx, pred in enumerate(fp_preds):
+            row = ious[pred_idx]
+            error, target = _classify_error(
+                pred,
+                active_gts,
+                row,
+                used_ids,
+                self.config.iou,
+                self.config.bg_thresh,
+            )
+
+            info = {"error": error, "target": target, "fixable": False}
+            error_info[pred.id] = info
+            pred[error_key] = error
+            self._error_counts[error] += 1
+
+            if target is not None and target.id in unused_ids:
+                usable_ids.add(target.id)
+                confidence = _get_confidence(pred)
+                previous = best_matches.get(target.id, None)
+                if previous is None or confidence > previous[0]:
+                    best_matches[target.id] = (confidence, pred.id)
+
+        for _, pred_id in best_matches.values():
+            error_info[pred_id]["fixable"] = True
+
+        for pred in fp_preds:
+            info = error_info[pred.id]
+            self._errors.append(
+                {
+                    "id": pred.id,
+                    "label": pred.label,
+                    "score": _get_confidence(pred),
+                    "error": info["error"],
+                    "target_label": (
+                        info["target"].label if info["target"] else None
+                    ),
+                    "fixable": info["fixable"],
+                    "original": pred.id not in ignored_ids,
+                }
+            )
+
+        for gt in active_gts:
+            if gt.id in unused_ids and gt.id not in usable_ids:
+                gt[error_key] = "miss"
+                self._error_counts["miss"] += 1
+                self._missed[gt.label] += 1
+
+        for pred in pred_list:
+            if pred.id in ignored_ids:
+                continue
+
+            self._records.append(
+                {
+                    "id": pred.id,
+                    "label": pred.label,
+                    "score": _get_confidence(pred),
+                    "tp": pred[eval_key] == "tp"
+                    and pred[id_key] not in crowd_ids,
+                }
+            )
+
+
+class TIDEDetectionResults(COCODetectionResults):
+    """Class that stores the results of a TIDE detection evaluation.
+
+    The :attr:`error_counts` attribute stores the number of each TIDE error
+    type. :attr:`error_deltas` and :attr:`special_error_deltas` contain dAP
+    values in ``[0, 100]``.
+    """
+
+    def __init__(
+        self,
+        samples,
+        config,
+        eval_key,
+        matches,
+        classes=None,
+        missing=None,
+        custom_metrics=None,
+        backend=None,
+        precision=None,
+        recall=None,
+        iou_threshs=None,
+        recall_sweep=None,
+        thresholds=None,
+        error_counts=None,
+        tide_ap=0,
+        error_deltas=None,
+        special_error_deltas=None,
+    ):
+        if precision is None:
+            DetectionResults.__init__(
+                self,
+                samples,
+                config,
+                eval_key,
+                matches,
+                classes=classes,
+                missing=missing,
+                custom_metrics=custom_metrics,
+                backend=backend,
+            )
+            self.precision = None
+            self.recall = None
+            self.iou_threshs = None
+            self.recall_sweep = None
+            self.thresholds = None
+            self._classwise_AP = None
+            self._classwise_AR = None
+        else:
+            super().__init__(
+                samples,
+                config,
+                eval_key,
+                matches,
+                precision,
+                recall,
+                iou_threshs,
+                classes,
+                recall_sweep=recall_sweep,
+                thresholds=thresholds,
+                missing=missing,
+                custom_metrics=custom_metrics,
+                backend=backend,
+            )
+
+        self.error_counts = error_counts or {}
+        self.tide_ap = tide_ap
+        self.error_deltas = error_deltas or {}
+        self.special_error_deltas = special_error_deltas or {}
+
+    @property
+    def dAP(self):
+        """The main TIDE dAP values in ``[0, 100]``."""
+        return self.error_deltas
+
+    @property
+    def special_dAP(self):
+        """The special TIDE dAP values in ``[0, 100]``."""
+        return self.special_error_deltas
+
+    def metrics(self, classes=None, average="micro", beta=1.0):
+        """Computes standard detection metrics and TIDE AP/dAP metrics.
+
+        TIDE AP/dAP values are reported in ``[0, 100]``.
+        """
+        metrics = super().metrics(
+            classes=classes, average=average, beta=beta
+        )
+        metrics["tide_ap"] = self.tide_ap
+        metrics.update(
+            ("error_count_%s" % error, count)
+            for error, count in self.error_counts.items()
+        )
+        metrics.update(
+            ("dAP_%s" % error, value)
+            for error, value in self.dAP.items()
+        )
+        metrics.update(
+            ("dAP_%s" % error, value)
+            for error, value in self.special_dAP.items()
+        )
+        return metrics
+
+    def plot_error_counts(self, backend="plotly", **kwargs):
+        """Plots the number of detections in each TIDE error category.
+
+        Args:
+            backend ("plotly"): the plotting backend to use. Supported values
+                are ``("plotly", "matplotlib")``
+            **kwargs: optional plotting backend arguments. Pass
+                ``plot="pie"`` to render a pie chart instead of a bar chart
+
+        Returns:
+            a plotly or matplotlib figure
+        """
+        errors = list(_MAIN_ERRORS)
+        counts = [self.error_counts.get(error, 0) for error in errors]
+        plot = kwargs.pop("plot", "bar")
+        title = kwargs.pop("title", "TIDE error counts")
+
+        if plot not in ("bar", "pie"):
+            raise ValueError(
+                "Unsupported plot type '%s'; supported values are %s"
+                % (plot, ("bar", "pie"))
+            )
+
+        if plot == "pie" and not any(counts):
+            raise ValueError("Cannot plot a pie chart with no errors")
+
+        if backend == "matplotlib":
+            import matplotlib.pyplot as plt
+
+            ax = kwargs.pop("ax", None)
+            figsize = kwargs.pop("figsize", None)
+            close_figure = ax is None and foc.is_jupyter_context()
+            if ax is None:
+                figure, ax = plt.subplots(figsize=figsize)
+            else:
+                figure = ax.figure
+
+            if plot == "pie":
+                ax.pie(counts, labels=errors, **kwargs)
+                ax.set_title(title)
+            else:
+                ax.bar(errors, counts, **kwargs)
+                ax.set(xlabel="Error type", ylabel="Count", title=title)
+
+            if close_figure:
+                plt.close(figure)
+
+            return figure
+
+        if backend == "plotly":
+            import plotly.graph_objects as go
+
+            if plot == "pie":
+                trace = go.Pie(labels=errors, values=counts, **kwargs)
+            else:
+                trace = go.Bar(x=errors, y=counts, **kwargs)
+
+            figure = go.Figure(trace)
+            layout = dict(
+                template="ggplot2",
+                margin={"r": 0, "t": 30, "l": 0, "b": 0},
+                title=title,
+            )
+            if plot == "bar":
+                layout.update(
+                    xaxis_title="Error type",
+                    yaxis_title="Count",
+                )
+
+            figure.update_layout(**layout)
+            return figure
+
+        raise ValueError(
+            "Unsupported plotting backend '%s'; supported values are %s"
+            % (backend, ("matplotlib", "plotly"))
+        )
+
+    def mAP(self, classes=None):
+        if self.precision is None:
+            raise ValueError("Set `compute_mAP=True` to compute COCO mAP")
+
+        return super().mAP(classes=classes)
+
+    def mAR(self, classes=None):
+        if self.precision is None:
+            raise ValueError("Set `compute_mAP=True` to compute COCO mAR")
+
+        return super().mAR(classes=classes)
+
+    def plot_pr_curves(
+        self, classes=None, iou_thresh=None, backend="plotly", **kwargs
+    ):
+        if self.precision is None:
+            raise ValueError("Set `compute_mAP=True` to plot PR curves")
+
+        close_figure = (
+            backend == "matplotlib"
+            and kwargs.get("ax", None) is None
+            and foc.is_jupyter_context()
+        )
+        figure = super().plot_pr_curves(
+            classes=classes,
+            iou_thresh=iou_thresh,
+            backend=backend,
+            **kwargs,
+        )
+
+        if backend in (None, "plotly") and foc.is_jupyter_context():
+            return figure._figure
+
+        if close_figure:
+            import matplotlib.pyplot as plt
+
+            plt.close(figure)
+
+        return figure
+
+    @classmethod
+    def _from_dict(cls, d, samples, config, eval_key, **kwargs):
+        return DetectionResults._from_dict.__func__(
+            cls,
+            d,
+            samples,
+            config,
+            eval_key,
+            precision=d.get("precision", None),
+            recall=d.get("recall", None),
+            iou_threshs=d.get("iou_threshs", None),
+            recall_sweep=d.get("recall_sweep", None),
+            thresholds=d.get("thresholds", None),
+            error_counts=d.get("error_counts", None),
+            tide_ap=d.get("tide_ap", 0),
+            error_deltas=d.get("error_deltas", None),
+            special_error_deltas=d.get("special_error_deltas", None),
+            **kwargs,
+        )
+
+
+def _get_labels(labels):
+    if labels is None:
+        return []
+
+    return labels[labels._LABEL_LIST_FIELD]
+
+
+def _get_confidence(label):
+    if isinstance(label, fol.Keypoint):
+        return np.nanmean(label.confidence) if label.confidence else None
+
+    return label.confidence
+
+
+def _get_tide_pred_ids(preds, max_preds):
+    pred_list = _get_labels(preds)
+    for pred in pred_list:
+        if _get_confidence(pred) is None:
+            raise ValueError(
+                "All predicted objects must have their `confidence` attribute "
+                "populated in order to compute TIDE metrics"
+            )
+
+    preds = sorted(pred_list, key=_get_confidence, reverse=True)
+    if max_preds is not None:
+        preds = preds[:max_preds]
+
+    return {pred.id for pred in preds}
+
+
+def _get_ignored_pred_ids(preds, active_gts, gts, config, iscrowd, id_key):
+    crowd_gts = [gt for gt in gts if iscrowd(gt)]
+    active_ids = {gt.id for gt in active_gts}
+    preds = [pred for pred in preds if pred[id_key] not in active_ids]
+    ious = _compute_ious(preds, crowd_gts, config, iscrowd)
+    ignored_ids = set()
+    for pred, row in zip(preds, ious):
+        if any(
+            pred.label == gt.label and iou > config.iou
+            for gt, iou in zip(crowd_gts, row)
+        ):
+            ignored_ids.add(pred.id)
+
+    return ignored_ids
+
+
+def _compute_ious(preds, gts, config, iscrowd):
+    kwargs = {
+        "iscrowd": iscrowd,
+        "error_level": config.error_level,
+    }
+    if config.use_masks:
+        kwargs.update(use_masks=True, tolerance=config.tolerance)
+    if config.use_boxes:
+        kwargs.update(use_boxes=True)
+    if config.keypoint_sigmas is not None:
+        kwargs.update(keypoint_sigmas=config.keypoint_sigmas)
+
+    return foui.compute_ious(preds, gts, **kwargs)
+
+
+def _classify_error(pred, gts, ious, used_ids, pos_thresh, bg_thresh):
+    same_inds = [idx for idx, gt in enumerate(gts) if gt.label == pred.label]
+    if same_inds:
+        same_idx = max(same_inds, key=lambda idx: ious[idx])
+        same_iou = ious[same_idx]
+        if bg_thresh <= same_iou <= pos_thresh:
+            return "loc", gts[same_idx]
+
+    noncls_inds = [idx for idx, gt in enumerate(gts) if gt.label != pred.label]
+    if noncls_inds:
+        noncls_idx = max(noncls_inds, key=lambda idx: ious[idx])
+        if ious[noncls_idx] >= pos_thresh:
+            return "cls", gts[noncls_idx]
+
+    used_same_inds = [
+        idx
+        for idx, gt in enumerate(gts)
+        if gt.id in used_ids and gt.label == pred.label
+    ]
+    if used_same_inds:
+        used_same_iou = max(ious[idx] for idx in used_same_inds)
+        if used_same_iou >= pos_thresh:
+            return "dupe", None
+
+    if not gts or np.max(ious) <= bg_thresh:
+        return "bkg", None
+
+    return "both", None
+
+
+def _compute_dap(records, errors, gt_counts, missed, false_negatives):
+    tide_ap = _compute_map(records, gt_counts)
+    error_deltas = {}
+    for error in _MAIN_ERRORS:
+        fixed_records = []
+        for error_record in errors:
+            record = {
+                "id": error_record["id"],
+                "label": error_record["label"],
+                "score": error_record["score"],
+                "tp": False,
+            }
+            if error_record["error"] != error:
+                if error_record["original"]:
+                    fixed_records.append(record)
+                continue
+
+            if error in ("cls", "loc") and error_record["fixable"]:
+                fixed_records.append(
+                    {
+                        "id": error_record["id"],
+                        "label": error_record["target_label"],
+                        "score": error_record["score"],
+                        "tp": True,
+                    }
+                )
+
+        fixed_records.extend(record for record in records if record["tp"])
+
+        fixed_gt_counts = gt_counts.copy()
+        if error == "miss":
+            for label, count in missed.items():
+                fixed_gt_counts[label] -= count
+
+        error_deltas[error] = max(
+            _compute_map(fixed_records, fixed_gt_counts) - tide_ap, 0
+        )
+
+    perfect_precision = [
+        dict(record, score=1 if record["tp"] else 0) for record in records
+    ]
+    perfect_recall_gt_counts = gt_counts.copy()
+    for label, count in false_negatives.items():
+        perfect_recall_gt_counts[label] -= count
+
+    special_error_deltas = {
+        "false_pos": _compute_map(perfect_precision, gt_counts) - tide_ap,
+        "false_neg": _compute_map(records, perfect_recall_gt_counts) - tide_ap,
+    }
+
+    return tide_ap, error_deltas, special_error_deltas
+
+
+def _compute_map(records, gt_counts):
+    by_label = defaultdict(list)
+    for record in records:
+        by_label[record["label"]].append(record)
+
+    aps = []
+    for label in set(gt_counts) | set(by_label):
+        label_records = by_label[label]
+        num_gt = gt_counts[label]
+        if not label_records and num_gt == 0:
+            continue
+
+        aps.append(_compute_ap(label_records, num_gt))
+
+    return float(np.mean(aps)) if aps else 0
+
+
+def _compute_ap(records, num_gt):
+    if num_gt <= 0 or not records:
+        return 0
+
+    records = sorted(records, key=lambda record: -record["score"])
+    tp = np.array([record["tp"] for record in records], dtype=float)
+    tp_sum = np.cumsum(tp)
+    precision = tp_sum / np.arange(1, len(tp) + 1)
+    recall = tp_sum / num_gt
+
+    for idx in range(len(precision) - 1, 0, -1):
+        if precision[idx] > precision[idx - 1]:
+            precision[idx - 1] = precision[idx]
+
+    recall_grid = np.linspace(0, 1, 101)
+    inds = np.searchsorted(recall, recall_grid, side="left")
+    valid = inds < len(precision)
+    return float(np.mean(precision[inds[valid]]) * 100)

--- a/fiftyone/utils/eval/tide.py
+++ b/fiftyone/utils/eval/tide.py
@@ -46,11 +46,13 @@ class TIDEEvaluationConfig(COCOEvaluationConfig):
     def __init__(
         self, pred_field, gt_field, bg_thresh=0.1, max_preds=100, **kwargs
     ):
+        """Initializes the TIDE evaluation configuration."""
         super().__init__(pred_field, gt_field, max_preds=max_preds, **kwargs)
         self.bg_thresh = bg_thresh
 
     @property
     def method(self):
+        """The evaluation method name."""
         return "tide"
 
 
@@ -58,6 +60,7 @@ class TIDEEvaluation(COCOEvaluation):
     """TIDE-style detection evaluation."""
 
     def __init__(self, config):
+        """Initializes the TIDE evaluation backend."""
         super().__init__(config)
 
         if not config.classwise:
@@ -74,6 +77,7 @@ class TIDEEvaluation(COCOEvaluation):
         self._error_counts = Counter()
 
     def register_samples(self, samples, eval_key, dynamic=True):
+        """Registers TIDE result fields on the sample collection."""
         super().register_samples(samples, eval_key, dynamic=dynamic)
 
         if eval_key is None or not dynamic:
@@ -93,6 +97,7 @@ class TIDEEvaluation(COCOEvaluation):
                 dataset.add_sample_field(path, fof.StringField)
 
     def evaluate(self, sample_or_frame, eval_key=None):
+        """Evaluates the detections in a sample or frame."""
         if eval_key is None:
             eval_key = "eval"
             gts = _copy_labels(sample_or_frame[self.gt_field])
@@ -123,6 +128,7 @@ class TIDEEvaluation(COCOEvaluation):
         missing=None,
         progress=None,
     ):
+        """Generates the results for the TIDE evaluation."""
         tide_ap, error_deltas, special_error_deltas = _compute_dap(
             self._records,
             self._errors,
@@ -169,6 +175,7 @@ class TIDEEvaluation(COCOEvaluation):
         )
 
     def get_fields(self, samples, eval_key, include_custom_metrics=True):
+        """Returns the fields populated by the evaluation."""
         fields = super().get_fields(
             samples, eval_key, include_custom_metrics=include_custom_metrics
         )
@@ -183,6 +190,7 @@ class TIDEEvaluation(COCOEvaluation):
         return fields
 
     def cleanup(self, samples, eval_key):
+        """Removes fields populated by the evaluation."""
         super().cleanup(samples, eval_key)
 
         dataset = samples._dataset
@@ -205,6 +213,7 @@ class TIDEEvaluation(COCOEvaluation):
             dataset.delete_sample_fields(fields, error_level=1)
 
     def _analyze_errors(self, gts, preds, eval_key, pred_ids):
+        """Classifies and records TIDE errors for a sample or frame."""
         gt_list = _get_labels(gts)
         all_preds = _get_labels(preds)
         pred_list = sorted(
@@ -223,6 +232,7 @@ class TIDEEvaluation(COCOEvaluation):
                 pred[eval_key] = None
 
         def iscrowd(obj):
+            """Determines whether the ground-truth object is a crowd."""
             return bool(obj.get_attribute_value(self.config.iscrowd, False))
 
         crowd_ids = {gt.id for gt in gt_list if iscrowd(gt)}
@@ -342,6 +352,7 @@ class TIDEDetectionResults(COCODetectionResults):
         error_deltas=None,
         special_error_deltas=None,
     ):
+        """Initializes TIDE detection results."""
         if precision is None:
             DetectionResults.__init__(
                 self,
@@ -494,12 +505,14 @@ class TIDEDetectionResults(COCODetectionResults):
         )
 
     def mAP(self, classes=None):
+        """Computes COCO-style mean average precision."""
         if self.precision is None:
             raise ValueError("Set `compute_mAP=True` to compute COCO mAP")
 
         return super().mAP(classes=classes)
 
     def mAR(self, classes=None):
+        """Computes COCO-style mean average recall."""
         if self.precision is None:
             raise ValueError("Set `compute_mAP=True` to compute COCO mAR")
 
@@ -508,6 +521,7 @@ class TIDEDetectionResults(COCODetectionResults):
     def plot_pr_curves(
         self, classes=None, iou_thresh=None, backend="plotly", **kwargs
     ):
+        """Plots precision-recall curves for the evaluation results."""
         if self.precision is None:
             raise ValueError("Set `compute_mAP=True` to plot PR curves")
 
@@ -535,6 +549,7 @@ class TIDEDetectionResults(COCODetectionResults):
 
     @classmethod
     def _from_dict(cls, d, samples, config, eval_key, **kwargs):
+        """Builds TIDE detection results from a serialized dictionary."""
         return DetectionResults._from_dict.__func__(
             cls,
             d,
@@ -555,6 +570,7 @@ class TIDEDetectionResults(COCODetectionResults):
 
 
 def _get_labels(labels):
+    """Returns the objects in a label-list container."""
     if labels is None:
         return []
 
@@ -562,6 +578,7 @@ def _get_labels(labels):
 
 
 def _get_confidence(label):
+    """Returns the confidence of a predicted object."""
     if isinstance(label, fol.Keypoint):
         return np.nanmean(label.confidence) if label.confidence else None
 
@@ -569,6 +586,7 @@ def _get_confidence(label):
 
 
 def _get_tide_pred_ids(preds, max_preds):
+    """Returns the prediction IDs included in TIDE evaluation."""
     pred_list = _get_labels(preds)
     for pred in pred_list:
         if _get_confidence(pred) is None:
@@ -585,6 +603,7 @@ def _get_tide_pred_ids(preds, max_preds):
 
 
 def _get_ignored_pred_ids(preds, active_gts, gts, config, iscrowd, id_key):
+    """Returns prediction IDs ignored because they match crowd objects."""
     crowd_gts = [gt for gt in gts if iscrowd(gt)]
     active_ids = {gt.id for gt in active_gts}
     preds = [pred for pred in preds if pred[id_key] not in active_ids]
@@ -601,6 +620,7 @@ def _get_ignored_pred_ids(preds, active_gts, gts, config, iscrowd, id_key):
 
 
 def _compute_ious(preds, gts, config, iscrowd):
+    """Computes IoUs between predictions and ground-truth objects."""
     kwargs = {
         "iscrowd": iscrowd,
         "error_level": config.error_level,
@@ -616,6 +636,7 @@ def _compute_ious(preds, gts, config, iscrowd):
 
 
 def _classify_error(pred, gts, ious, used_ids, pos_thresh, bg_thresh):
+    """Classifies a false positive into a TIDE error category."""
     same_inds = [idx for idx, gt in enumerate(gts) if gt.label == pred.label]
     if same_inds:
         same_idx = max(same_inds, key=lambda idx: ious[idx])
@@ -646,6 +667,7 @@ def _classify_error(pred, gts, ious, used_ids, pos_thresh, bg_thresh):
 
 
 def _compute_dap(records, errors, gt_counts, missed, false_negatives):
+    """Computes TIDE AP and the AP change for each error category."""
     tide_ap = _compute_map(records, gt_counts)
     error_deltas = {}
     for error in _MAIN_ERRORS:
@@ -699,6 +721,7 @@ def _compute_dap(records, errors, gt_counts, missed, false_negatives):
 
 
 def _compute_map(records, gt_counts):
+    """Computes macro average precision across observed classes."""
     by_label = defaultdict(list)
     for record in records:
         by_label[record["label"]].append(record)
@@ -716,6 +739,7 @@ def _compute_map(records, gt_counts):
 
 
 def _compute_ap(records, num_gt):
+    """Computes 101-point interpolated average precision for one class."""
     if num_gt <= 0 or not records:
         return 0
 

--- a/tests/unittests/evaluation_tests.py
+++ b/tests/unittests/evaluation_tests.py
@@ -23,6 +23,7 @@ import fiftyone.utils.eval.coco as coco
 import fiftyone.utils.eval.detection as foud
 import fiftyone.utils.eval.regression as four
 import fiftyone.utils.eval.segmentation as fous
+import fiftyone.utils.eval.tide as tide
 import fiftyone.utils.labels as foul
 import fiftyone.utils.iou as foui
 
@@ -1991,6 +1992,272 @@ class DetectionsTests(unittest.TestCase):
         kwargs = {}
 
         self._evaluate_coco(dataset, kwargs)
+
+    @drop_datasets
+    def test_evaluate_detections_tide(self):
+        dataset = fo.Dataset()
+        dataset.add_samples(
+            [
+                fo.Sample(
+                    filepath="cls.jpg",
+                    ground_truth=fo.Detections(
+                        detections=[
+                            fo.Detection(
+                                label="cat", bounding_box=[0, 0, 0.2, 0.2]
+                            )
+                        ]
+                    ),
+                    predictions=fo.Detections(
+                        detections=[
+                            fo.Detection(
+                                label="dog",
+                                bounding_box=[0, 0, 0.2, 0.2],
+                                confidence=0.9,
+                            )
+                        ]
+                    ),
+                ),
+                fo.Sample(
+                    filepath="loc.jpg",
+                    ground_truth=fo.Detections(
+                        detections=[
+                            fo.Detection(
+                                label="cat", bounding_box=[0, 0, 0.4, 0.4]
+                            )
+                        ]
+                    ),
+                    predictions=fo.Detections(
+                        detections=[
+                            fo.Detection(
+                                label="cat",
+                                bounding_box=[0.2, 0, 0.4, 0.4],
+                                confidence=0.9,
+                            )
+                        ]
+                    ),
+                ),
+                fo.Sample(
+                    filepath="dupe.jpg",
+                    ground_truth=fo.Detections(
+                        detections=[
+                            fo.Detection(
+                                label="cat", bounding_box=[0, 0, 0.2, 0.2]
+                            )
+                        ]
+                    ),
+                    predictions=fo.Detections(
+                        detections=[
+                            fo.Detection(
+                                label="cat",
+                                bounding_box=[0, 0, 0.2, 0.2],
+                                confidence=0.9,
+                            ),
+                            fo.Detection(
+                                label="cat",
+                                bounding_box=[0, 0, 0.2, 0.2],
+                                confidence=0.8,
+                            ),
+                        ]
+                    ),
+                ),
+                fo.Sample(
+                    filepath="bkg.jpg",
+                    predictions=fo.Detections(
+                        detections=[
+                            fo.Detection(
+                                label="cat",
+                                bounding_box=[0, 0, 0.2, 0.2],
+                                confidence=0.9,
+                            )
+                        ]
+                    ),
+                ),
+                fo.Sample(
+                    filepath="both.jpg",
+                    ground_truth=fo.Detections(
+                        detections=[
+                            fo.Detection(
+                                label="cat", bounding_box=[0, 0, 0.4, 0.4]
+                            )
+                        ]
+                    ),
+                    predictions=fo.Detections(
+                        detections=[
+                            fo.Detection(
+                                label="dog",
+                                bounding_box=[0.2, 0, 0.4, 0.4],
+                                confidence=0.9,
+                            )
+                        ]
+                    ),
+                ),
+            ]
+        )
+
+        results = dataset.evaluate_detections(
+            "predictions",
+            gt_field="ground_truth",
+            eval_key="tide",
+            method="tide",
+            compute_mAP=True,
+        )
+
+        self.assertIsInstance(results, tide.TIDEDetectionResults)
+        self.assertEqual(
+            results.error_counts,
+            {"cls": 1, "loc": 1, "dupe": 1, "bkg": 1, "both": 1, "miss": 1},
+        )
+        self.assertSetEqual(set(results.dAP), set(tide._MAIN_ERRORS))
+        self.assertSetEqual(
+            set(results.special_dAP), set(tide._SPECIAL_ERRORS)
+        )
+        self.assertTrue(np.isfinite(results.tide_ap))
+        self.assertTrue(np.isfinite(results.mAP()))
+
+        metrics = results.metrics()
+        self.assertEqual(metrics["tide_ap"], results.tide_ap)
+        self.assertSetEqual(
+            {key for key in metrics if key.startswith("error_count_")},
+            {"error_count_%s" % error for error in tide._MAIN_ERRORS},
+        )
+        self.assertSetEqual(
+            {key for key in metrics if key.startswith("dAP_")},
+            {
+                "dAP_%s" % error
+                for error in tide._MAIN_ERRORS + tide._SPECIAL_ERRORS
+            },
+        )
+
+        figure = results.plot_error_counts(backend="matplotlib")
+        self.assertListEqual(
+            [bar.get_height() for bar in figure.axes[0].patches], [1] * 6
+        )
+        figure.clear()
+
+        figure = results.plot_error_counts(
+            backend="matplotlib", plot="pie"
+        )
+        self.assertEqual(len(figure.axes[0].patches), 6)
+        figure.clear()
+
+        figure = results.plot_error_counts(
+            backend="plotly", plot="pie", hole=0.25
+        )
+        self.assertListEqual(list(figure.data[0].values), [1] * 6)
+        self.assertEqual(figure.data[0].hole, 0.25)
+
+        figure = results.plot_pr_curves(classes=["cat"], backend="plotly")
+        self.assertEqual(len(figure.data), 1)
+        self.assertEqual(len(figure.data[0].x), 101)
+
+        self.assertListEqual(
+            dataset.values("predictions.detections.tide_error"),
+            [["cls"], ["loc"], [None, "dupe"], ["bkg"], ["both"]],
+        )
+        self.assertListEqual(
+            dataset.values("ground_truth.detections.tide_error"),
+            [[None], [None], [None], None, ["miss"]],
+        )
+
+        unsaved_results = dataset.evaluate_detections(
+            "predictions", gt_field="ground_truth", method="tide"
+        )
+        self.assertIsInstance(unsaved_results, tide.TIDEDetectionResults)
+        with self.assertRaises(ValueError):
+            unsaved_results.mAP()
+
+        dataset.rename_evaluation("tide", "tide2")
+        self.assertTrue(
+            dataset.has_field("predictions.detections.tide2_error")
+        )
+
+        dataset.clear_cache()
+        results = dataset.load_evaluation_results("tide2")
+        self.assertIsInstance(results, tide.TIDEDetectionResults)
+        self.assertTrue(np.isfinite(results.mAP()))
+
+        dataset.delete_evaluation("tide2")
+        self.assertFalse(
+            dataset.has_field("predictions.detections.tide2_error")
+        )
+
+    @drop_datasets
+    def test_evaluate_detections_tide_max_preds_and_crowds(self):
+        dataset = fo.Dataset()
+        dataset.add_samples(
+            [
+                fo.Sample(
+                    filepath="max-preds.jpg",
+                    ground_truth=fo.Detections(
+                        detections=[
+                            fo.Detection(
+                                label="cat", bounding_box=[0, 0, 0.2, 0.2]
+                            )
+                        ]
+                    ),
+                    predictions=fo.Detections(
+                        detections=[
+                            fo.Detection(
+                                label="dog",
+                                bounding_box=[0.7, 0.7, 0.2, 0.2],
+                                confidence=0.9,
+                            ),
+                            fo.Detection(
+                                label="cat",
+                                bounding_box=[0, 0, 0.2, 0.2],
+                                confidence=0.8,
+                            ),
+                        ]
+                    ),
+                ),
+                fo.Sample(
+                    filepath="crowd.jpg",
+                    ground_truth=fo.Detections(
+                        detections=[
+                            fo.Detection(
+                                label="cat",
+                                bounding_box=[0, 0, 0.2, 0.2],
+                                iscrowd=True,
+                            )
+                        ]
+                    ),
+                    predictions=fo.Detections(
+                        detections=[
+                            fo.Detection(
+                                label="cat",
+                                bounding_box=[0, 0, 0.2, 0.2],
+                                confidence=0.9,
+                            )
+                        ]
+                    ),
+                ),
+            ]
+        )
+
+        results = dataset.evaluate_detections(
+            "predictions",
+            gt_field="ground_truth",
+            eval_key="tide",
+            method="tide",
+            max_preds=1,
+        )
+
+        self.assertEqual(
+            results.error_counts,
+            {"cls": 0, "loc": 0, "both": 0, "dupe": 0, "bkg": 2, "miss": 1},
+        )
+        self.assertListEqual(
+            dataset.values("predictions.detections.tide"),
+            [["fp", None], ["tp"]],
+        )
+        self.assertListEqual(
+            dataset.values("predictions.detections.tide_error"),
+            [["bkg", None], ["bkg"]],
+        )
+        self.assertListEqual(
+            dataset.values("ground_truth.detections.tide_error"),
+            [["miss"], [None]],
+        )
 
     @drop_datasets
     def test_evaluate_instances_coco(self):


### PR DESCRIPTION
<!--
Community contributors: target the `community` branch, not `develop`. PRs from
non-members are auto-retargeted to `community`. See CONTRIBUTING.md:
https://github.com/voxel51/fiftyone/blob/develop/CONTRIBUTING.md#community-pull-requests
-->

## 🔗 Related Issues

No related issues to link.

## 📋 What changes are proposed in this pull request?

This PR adds `tide` as a detection evaluation backend. It classifies detection
errors as classification, localization, combined classification/localization,
duplicate, background, or missed errors and stores the error type on evaluated
labels.

TIDE results expose TIDE AP, per-error counts, dAP values, persisted results,
PR curves, and Matplotlib/Plotly error-count plots. The shared COCO matching
logic now also supports TIDE's image-wide `max_preds` behavior while preserving
COCO's existing per-class behavior and crowd handling.

The PR also prevents duplicate Matplotlib confusion-matrix output in Jupyter
when the plotting function creates its own figure.

## 🧪 How is this patch tested? If it is not, please explain why.

- Added unit coverage for all six TIDE error categories, special dAP metrics,
  result persistence, plots, maximum predictions, and crowd annotations.
- Ran:

  ```shell
    ../../.venv/bin/python -m unittest \
    evaluation_tests.DetectionsTests.test_evaluate_detections_tide \
    evaluation_tests.DetectionsTests.test_evaluate_detections_tide_max_preds_and_crowds
  ```

  Result: 2 tests passed.
- Executed an end-to-end COCO segmentation notebook and verified TIDE metrics,
  error counts, PR curves, confusion matrices, IoU sensitivity, and result
  persistence.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release
  notes for FiftyOne users.

FiftyOne now supports TIDE detection evaluation for categorizing model errors
and measuring their impact on average precision.

### What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [x] Core: Core `fiftyone` Python library changes
- [x] Documentation: FiftyOne documentation changes
- [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added TIDE-style object detection evaluation with error categories, dAP metrics, AP/AR results, and error and precision-recall visualizations.
  - Added support for limiting COCO evaluation predictions globally or per class.
- **Improvements**
  - TIDE evaluations can annotate classification, localization, duplicate, background, and missed-detection errors.
  - Confusion matrix plots now close automatically when appropriate, reducing unwanted figures outside notebook environments.
- **Documentation**
  - Documented `tide` as a built-in detection evaluation method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->