### PR TITLE
e2e: parameterize the runner label via repo var

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -144,7 +144,9 @@ jobs:
     # policy, and the verdict job fails whenever a shard job does.
     # (fiftyone-teams runs the same suite ~1.6x slower.)
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    # downstream repos reusing this workflow can point shards at a
+    # larger runner spec via repo var
+    runs-on: ${{ vars.FIFTYONE_E2E_RUNNER || 'ubuntu-latest' }}
     # The prebaked image (built by build-ci-images.yml) carries Python +
     # fiftyone's dependency tree, Node/Yarn, ffmpeg, and Chromium, so shard
     # jobs skip all toolchain setup.
@@ -281,7 +283,9 @@ jobs:
     # cancellation force-cancels this job anyway.
     if: always() && needs.test-e2e.result != 'skipped'
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    # gates the merge, so it follows the shards' runner rather than
+    # queueing on a busy standard pool
+    runs-on: ${{ vars.FIFTYONE_E2E_RUNNER || 'ubuntu-latest' }}
     container:
       # fiftyone-teams overrides the image name via repo var (superset deps)
       image: ${{ vars.FIFTYONE_E2E_IMAGE_NAME || 'ghcr.io/voxel51/fiftyone-e2e' }}:latest


### PR DESCRIPTION
## What

Makes the e2e runner label configurable via a repo variable, following the existing `FIFTYONE_E2E_IMAGE_NAME` pattern:

- `test-e2e` and `e2e-verdict` now use `runs-on: ${{ vars.FIFTYONE_E2E_RUNNER || 'ubuntu-latest' }}`
- The variable is unset here, so nothing changes in this repo: standard `ubuntu-latest`, 8-way sharding

## Why

Repos that reuse this workflow can move the e2e shards onto a larger runner spec by setting one variable, without forking the workflow. The merge-gating verdict job follows the shards' runner so it isn't stuck waiting on a busy standard-runner pool while holding up a merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added configurable runner selection for end-to-end workflows.
  * Workflows continue using the default Ubuntu runner when no custom setting is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3502
<!-- enterprise-sync-pr:end -->