### PR TITLE
ci(docs): faster PR docs builds — skip markdown pass, pip cache, tighter triggers

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -27,10 +27,9 @@ on:
       - docs/**
       - examples/**
       - fiftyone/**
+      - plugins/**
       - requirements/**
-      - "**.py"
-      - "**.md"
-      - "**.rst"
+      - setup.py
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -100,6 +99,10 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            requirements/docs.txt
+            setup.py
       - name: Free Disk Space (Ubuntu) # standard runner's 14 GB available disk size isn't enough. Need at least 22 GB free.
         uses: ./.github/actions/free-disk-space
       - name: Install pip dependencies
@@ -143,8 +146,10 @@ jobs:
       - name: Install app
         run: cd app && yarn install
       - name: Build docs
+        # PR builds skip the markdown mirror pass; it is only needed for
+        # the published site
         run: |
-          ./docs/generate_docs.bash -t fiftyone-teams
+          ./docs/generate_docs.bash -t fiftyone-teams ${{ github.event_name == 'pull_request' && '-m' || '' }}
       - name: Upload docs
         uses: actions/upload-artifact@v7
         with:

--- a/docs/generate_docs.bash
+++ b/docs/generate_docs.bash
@@ -8,13 +8,14 @@
 
 # Show usage information
 usage() {
-    echo "Usage:  bash $0 [-h] [-f] [-c] [-s] [-t]
+    echo "Usage:  bash $0 [-h] [-f] [-c] [-s] [-m] [-t]
 
 Options:
 -h      Display this help message.
 -f      Perform a fast build (don't regenerate zoo/plugin docs).
 -c      Perform a clean build (deletes existing build directory).
 -s      Copy static files only (CSS, JS).
+-m      Skip the markdown build (HTML only).
 -t      Path to fiftyone-teams clone to use for Teams docs
 "
 }
@@ -25,13 +26,15 @@ SHOW_HELP=false
 FAST_BUILD=false
 CLEAN_BUILD=false
 STATIC_ONLY=false
+SKIP_MARKDOWN=false
 PATH_TO_TEAMS=""
-while getopts "hfcst:" FLAG; do
+while getopts "hfcsmt:" FLAG; do
     case "${FLAG}" in
         h) SHOW_HELP=true ;;
         f) FAST_BUILD=true ;;
         c) CLEAN_BUILD=true ;;
         s) STATIC_ONLY=true ;;
+        m) SKIP_MARKDOWN=true ;;
         t) PATH_TO_TEAMS=$OPTARG;;
         *) usage; exit 2 ;;
     esac
@@ -139,11 +142,13 @@ echo "Building HTML docs"
 # sphinx-build [OPTIONS] SOURCEDIR OUTPUTDIR [FILENAMES...]
 sphinx-build -M html source build --jobs auto $SPHINXOPTS
 
-echo "Building Markdown docs"
-sphinx-build -M markdown source build --jobs auto $SPHINXOPTS
+if [[ ${SKIP_MARKDOWN} = false ]]; then
+    echo "Building Markdown docs"
+    sphinx-build -M markdown source build --jobs auto $SPHINXOPTS
 
-echo "Copying markdown files to HTML output"
-cp -r build/markdown/* build/html/
+    echo "Copying markdown files to HTML output"
+    cp -r build/markdown/* build/html/
+fi
 
 
 echo "Post-processing docs"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -87,6 +87,10 @@ if teams_dir:
     autoapi_dirs = [os.path.join(teams_dir, "fiftyone")]
     autoapi_generate_api_docs = False
     autoapi_options = ["members", "undoc-members", "show-inheritance"]
+    # multimodal is feature-gated and excluded from public API docs; its
+    # protobuf __generated__ modules defeat astroid and spam
+    # "Cannot resolve import" warnings
+    autoapi_ignore = ["*migrations*", "*/multimodal/*"]
 
 # Types of class members to generate documentation for.
 autodoc_default_options = {


### PR DESCRIPTION
## 🔗 Related Issues

Docs CI speed work.

## 📋 What changes are proposed in this pull request?

Baseline: green docs runs are 58–67 min (sphinx HTML ~43, markdown mirror pass ~8.4, mid-build zoo-model pip installs ~5, setup ~6). Nearly every PR triggers the job via `**.py`/`**.md`/`**.rst` filters.

- `generate_docs.bash -m`: skip the markdown mirror pass; used by PR builds only. Measured: `Build docs` 55 → 44.3 min
- pip cache on `setup-python` (~2 min + fewer network failures)
- `autoapi_ignore` for the teams multimodal tree: feature-gated, zero cross-references in docs, and its protobuf `__generated__` modules spam astroid "Cannot resolve import" warnings. No output change
- Tighter `pull_request` path filters: drop `**.py`/`**.md`/`**.rst`; add `plugins/**`, `setup.py`. App/e2e/CI-only PRs skip docs (docs-CI changes themselves still build: `build-docs.yml` stays in the filters)

## 🔬 Profiling: where the 43-min sphinx pass goes

py-spy over the full build ([baseline](https://github.com/voxel51/fiftyone/actions/runs/29854177126) / [experiment](https://github.com/voxel51/fiftyone/actions/runs/29859021937), speedscope artifacts attached):

- **>60% of CPU: deep-copying the global toctree per page** (`_copy_except__document`). `sidebar-nav.html` renders the whole-site tree on every page (`startdepth=0`, no collapse); hrefs are page-relative so sphinx re-resolves per page → O(pages × tree)
- Content cost (autodoc, inherited-members) is ~1–2%. Markdown builder (no sidebars): same sources in 8.4 min. pandas (same theme, default nav): ~12 min
- **`collapse_navigation: True` → 52.3 → 19.2 min (−63%)**. Awaiting sidebar-UX signoff; rendered site = `docs` artifact on the experiment run. Fallback that keeps the full tree: render nav once + JS current-marking (custom template)

Deferred: collapse flag (above); `-f` on PRs (generated .rst files aren't committed → breaks fresh checkouts); larger runner; apidoc write-if-changed + doctree cache; typedoc cache.

## 🧪 How is this patch tested? If it is not, please explain why.

- `bash -n` / `ruby -ryaml` syntax checks
- This PR's own docs build ran the `-m` path: 52 min vs 58–67 baseline (cold pip cache, now primed)

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.

N/A

### What areas of FiftyOne does this PR affect?

- [x] Build: Build and test infrastructure changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved the documentation build workflow efficiency by narrowing the build trigger scope and cache invalidation inputs.
  * Added a documentation build option to generate HTML without the Markdown mirror.
  * Pull request documentation builds now skip the Markdown generation step.
  * Updated API documentation settings to ignore additional modules for more reliable builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3430
<!-- enterprise-sync-pr:end -->
