### PR TITLE
chore(annotation): add upgrade callouts for annotation

### DIFF
--- a/app/packages/annotation/src/agents/AgentSelect.test.tsx
+++ b/app/packages/annotation/src/agents/AgentSelect.test.tsx
@@ -1,0 +1,117 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const selector = vi.fn();
+vi.mock("./hooks", () => ({ useAgentSelector: () => selector() }));
+
+// Avoid loading the full components barrel; only the URL constant is used.
+vi.mock("@fiftyone/components", () => ({
+  ENTERPRISE_LEARN_MORE_URL:
+    "https://voxel51.com/why-upgrade?utm_source=FiftyOneApp",
+}));
+
+// Stub voodo: render each option as a clickable button so the test can drive
+// the Select's onChange, and read which options were offered.
+vi.mock("@voxel51/voodo", () => ({
+  FormField: ({ control }: { control: unknown }) => control,
+  Select: ({
+    options,
+    onChange,
+  }: {
+    options: { id: string; data: { label: string } }[];
+    onChange: (id: string) => void;
+  }) => (
+    <div data-testid="opts">
+      {options.map((o) => (
+        <button
+          key={o.id}
+          data-testid={`opt-${o.id}`}
+          onClick={() => onChange(o.id)}
+        >
+          {o.data.label}
+        </button>
+      ))}
+    </div>
+  ),
+  Icon: () => null,
+  Text: ({ children }: { children: unknown }) => <span>{children}</span>,
+  Stack: ({ children }: { children: unknown }) => <div>{children}</div>,
+  Align: {},
+  Justify: {},
+  Orientation: {},
+  Size: {},
+  Spacing: {},
+  TextColor: {},
+  TextVariant: {},
+  IconName: { ExternalLink: "ExternalLink" },
+}));
+
+import { AgentSelect } from "./AgentSelect";
+
+const agent = (id: string, unlisted?: boolean) => ({
+  id,
+  label: id,
+  agent: {} as never,
+  unlisted,
+});
+
+const selectorState = (agents: ReturnType<typeof agent>[]) => ({
+  agents,
+  isResolved: true,
+  activeAgent: null,
+  setActiveAgent: vi.fn(),
+});
+
+const UPSELL_ID = "enterprise:sam2-large";
+
+beforeEach(() => selector.mockReset());
+afterEach(cleanup);
+
+describe("AgentSelect", () => {
+  it("lists selectable agents and hides unlisted ones", () => {
+    selector.mockReturnValue(
+      selectorState([agent("a"), agent("b", true), agent("c")]),
+    );
+    render(<AgentSelect />);
+
+    expect(screen.queryByTestId("opt-a")).toBeTruthy();
+    expect(screen.queryByTestId("opt-b")).toBeNull(); // unlisted -> dropped
+    expect(screen.queryByTestId("opt-c")).toBeTruthy();
+  });
+
+  it("omits the Enterprise upsell by default and appends it when opted in", () => {
+    selector.mockReturnValue(selectorState([agent("a")]));
+    const { rerender } = render(<AgentSelect />);
+    expect(screen.queryByTestId(`opt-${UPSELL_ID}`)).toBeNull();
+
+    rerender(<AgentSelect showEnterpriseUpsell />);
+    expect(screen.queryByTestId(`opt-${UPSELL_ID}`)).toBeTruthy();
+  });
+
+  it("opens pricing and does not change selection when the upsell row is clicked", () => {
+    const onChange = vi.fn();
+    const open = vi.spyOn(window, "open").mockImplementation(() => null);
+    selector.mockReturnValue(selectorState([agent("a")]));
+    render(<AgentSelect onChange={onChange} showEnterpriseUpsell />);
+
+    fireEvent.click(screen.getByTestId(`opt-${UPSELL_ID}`));
+
+    expect(open).toHaveBeenCalledWith(
+      expect.stringContaining("voxel51.com/why-upgrade"),
+      "_blank",
+      "noopener,noreferrer",
+    );
+    expect(onChange).not.toHaveBeenCalled();
+    open.mockRestore();
+  });
+
+  it("selects a real agent through onChange", () => {
+    const onChange = vi.fn();
+    selector.mockReturnValue(selectorState([agent("a")]));
+    render(<AgentSelect onChange={onChange} />);
+
+    fireEvent.click(screen.getByTestId("opt-a"));
+
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ id: "a" }));
+  });
+});

--- a/app/packages/annotation/src/agents/AgentSelect.tsx
+++ b/app/packages/annotation/src/agents/AgentSelect.tsx
@@ -1,21 +1,73 @@
 import { AgentDescriptor } from "./registry";
-import { FormField, Select } from "@voxel51/voodo";
+import { ENTERPRISE_LEARN_MORE_URL } from "@fiftyone/components";
+import {
+  Align,
+  FormField,
+  Icon,
+  IconName,
+  Justify,
+  Orientation,
+  Select,
+  Size,
+  Spacing,
+  Stack,
+  Text,
+  TextColor,
+  TextVariant,
+} from "@voxel51/voodo";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useAgentSelector } from "./hooks";
 import { InferenceResultProxy } from "./types";
+
+/** Sentinel option id for the non-selectable Enterprise upsell row. */
+const ENTERPRISE_UPSELL_ID = "enterprise:sam2-large";
+
+/**
+ * A muted, link-out row for a model only available in FiftyOne Enterprise.
+ * voodo's `Select` has no per-option disabled state, so the "disabled" look is
+ * styling only; the click is intercepted in `handleChange` (opens the upgrade
+ * page, leaves the selection unchanged) rather than selecting the row.
+ */
+const enterpriseUpsellOption = (label: string) => ({
+  id: ENTERPRISE_UPSELL_ID,
+  data: {
+    label,
+    content: (
+      <Stack
+        orientation={Orientation.Row}
+        align={Align.Center}
+        justify={Justify.Between}
+        spacing={Spacing.Sm}
+      >
+        <Text variant={TextVariant.Md} color={TextColor.Secondary}>
+          {label}
+        </Text>
+        <Icon
+          name={IconName.ExternalLink}
+          size={Size.Sm}
+          color={TextColor.Secondary}
+        />
+      </Stack>
+    ),
+  },
+});
 
 /**
  * Dropdown for selecting an annotation agent from the registry.
  *
  * @param value Currently selected agent descriptor.
  * @param onChange Called when the user picks a different agent.
+ * @param showEnterpriseUpsell Appends a non-selectable "Enterprise only" row
+ *  that links out to the upgrade page. Off by default.
  */
 export const AgentSelect = ({
   value,
   onChange,
+  showEnterpriseUpsell = false,
 }: {
   value?: AgentDescriptor<InferenceResultProxy> | null;
   onChange?: (agent: AgentDescriptor<InferenceResultProxy> | null) => void;
+  showEnterpriseUpsell?: boolean;
 }) => {
   const [agent, setAgent] =
     useState<AgentDescriptor<InferenceResultProxy> | null>(value);
@@ -25,19 +77,59 @@ export const AgentSelect = ({
     setAgent(value ?? null);
   }, [value]);
 
-  const selectOptions = useMemo(
+  // Only agents the user may pick: excludes the unavailable (a service-backed
+  // agent whose service isn't running) and the unlisted (resolved
+  // programmatically, never surfaced). voodo's Select has no per-option
+  // disabled, so an excluded agent is dropped entirely.
+  const selectableAgents = useMemo(
     () =>
-      agentSelector.agents?.map((descriptor) => ({
+      agentSelector.agents?.filter(
+        (d) => d.available !== false && !d.unlisted,
+      ) ?? [],
+    [agentSelector.agents],
+  );
+
+  // If the selected agent drops out of the selectable list, clear the stale
+  // selection and notify the parent so Select never holds a value that isn't
+  // an option. Gate on `isResolved` so a preselected agent isn't wiped on the
+  // first render before the registry has loaded.
+  useEffect(() => {
+    if (
+      agentSelector.isResolved &&
+      agent &&
+      !selectableAgents.some((d) => d.id === agent.id)
+    ) {
+      setAgent(null);
+      onChange?.(null);
+    }
+  }, [agentSelector.isResolved, agent, selectableAgents, onChange]);
+
+  // The registry's real agents, plus (when opted in) a trailing
+  // Enterprise-only upsell row.
+  const selectOptions = useMemo(
+    () => [
+      ...selectableAgents.map((descriptor) => ({
         id: descriptor.id,
         data: {
           label: descriptor.label,
         },
-      })) ?? [],
-    [agentSelector.agents],
+      })),
+      ...(showEnterpriseUpsell
+        ? [enterpriseUpsellOption("SAM2 Large (FiftyOne Enterprise Only)")]
+        : []),
+    ],
+    [selectableAgents, showEnterpriseUpsell],
   );
 
   const handleChange = useCallback(
     (value: string | null) => {
+      // The upsell row isn't a real option; open the upgrade page and leave
+      // the current selection intact.
+      if (value === ENTERPRISE_UPSELL_ID) {
+        window.open(ENTERPRISE_LEARN_MORE_URL, "_blank", "noopener,noreferrer");
+        return;
+      }
+
       const selected = value
         ? (agentSelector.agents?.find((e) => e.id === value) ?? null)
         : null;

--- a/app/packages/annotation/src/agents/AgentSelect.tsx
+++ b/app/packages/annotation/src/agents/AgentSelect.tsx
@@ -1,4 +1,4 @@
-import { AgentDescriptor } from "./registry";
+import { AgentDescriptor, isAgentSelectable } from "./registry";
 import { ENTERPRISE_LEARN_MORE_URL } from "@fiftyone/components";
 import {
   Align,
@@ -82,10 +82,7 @@ export const AgentSelect = ({
   // programmatically, never surfaced). voodo's Select has no per-option
   // disabled, so an excluded agent is dropped entirely.
   const selectableAgents = useMemo(
-    () =>
-      agentSelector.agents?.filter(
-        (d) => d.available !== false && !d.unlisted,
-      ) ?? [],
+    () => agentSelector.agents?.filter(isAgentSelectable) ?? [],
     [agentSelector.agents],
   );
 

--- a/app/packages/annotation/src/agents/hooks/useAgentRegistry.ts
+++ b/app/packages/annotation/src/agents/hooks/useAgentRegistry.ts
@@ -13,18 +13,20 @@ const registryAtom = atom<RegistryMap>({
   // built-in agents defined statically
   "sam2-tiny-onnx": {
     id: "sam2-tiny-onnx",
-    label: "SAM2",
+    label: "SAM2 Tiny",
     agent: new SAM2BrowserAnnotationAgent(),
   },
   "propagate-linear": {
     id: "propagate-linear",
     label: "Linear interpolation",
     agent: new PropagationBrowserAgent(),
+    unlisted: true,
   },
   "propagate-sam2": {
     id: "propagate-sam2",
     label: "SAM2 tracking",
     agent: new SAM2PropagationBrowserAgent(),
+    unlisted: true,
   },
 });
 
@@ -42,7 +44,13 @@ export const useAgentRegistry = (): AgentRegistry => {
       id: string,
       label: string,
       agent: AnnotationAgent<InferenceResultProxy>,
-    ) => setRegistry((prev) => ({ ...prev, [id]: { id, label, agent } })),
+      available = true,
+      unlisted = false,
+    ) =>
+      setRegistry((prev) => ({
+        ...prev,
+        [id]: { id, label, agent, available, unlisted },
+      })),
     [setRegistry],
   );
 

--- a/app/packages/annotation/src/agents/registry.ts
+++ b/app/packages/annotation/src/agents/registry.ts
@@ -22,6 +22,16 @@ export type AgentDescriptor<T extends InferenceResultProxy> = {
 };
 
 /**
+ * Whether an agent may be chosen by the user: excludes the unavailable (a
+ * service-backed agent whose service isn't running) and the unlisted (resolved
+ * programmatically, never surfaced). The selector and the default-agent
+ * bootstrap both filter on this so they can't disagree about the valid set.
+ */
+export const isAgentSelectable = <T extends InferenceResultProxy>(
+  descriptor: AgentDescriptor<T>,
+): boolean => descriptor.available !== false && !descriptor.unlisted;
+
+/**
  * Provides discovery and registration of {@link AnnotationAgent}s.
  *
  * Obtain an instance via {@link useAgentRegistry}.

--- a/app/packages/annotation/src/agents/registry.ts
+++ b/app/packages/annotation/src/agents/registry.ts
@@ -8,6 +8,17 @@ export type AgentDescriptor<T extends InferenceResultProxy> = {
   id: string;
   label: string;
   agent: AnnotationAgent<T>;
+  /**
+   * Whether the agent can currently be selected. Service-backed agents set
+   * this to `false` while their service isn't running so the selector hides
+   * them. Omitted/`true` means always selectable (e.g. in-browser agents).
+   */
+  available?: boolean;
+  /**
+   * Whether the agent is hidden from user selection; intended for use by
+   * internal agents.
+   */
+  unlisted?: boolean;
 };
 
 /**
@@ -16,11 +27,18 @@ export type AgentDescriptor<T extends InferenceResultProxy> = {
  * Obtain an instance via {@link useAgentRegistry}.
  */
 export interface AgentRegistry {
-  /** Registers a new agent under the given `id` and human-readable `label`. */
+  /**
+   * Registers (or updates) an agent under the given `id` and human-readable
+   * `label`. Pass `available: false` to keep it registered but unselectable;
+   * pass `unlisted: true` for an agent resolved programmatically that should
+   * never appear in the selector.
+   */
   register(
     id: string,
     label: string,
     agent: AnnotationAgent<InferenceResultProxy>,
+    available?: boolean,
+    unlisted?: boolean,
   ): Promise<void>;
 
   /** Returns all currently registered {@link AgentDescriptor}s. */

--- a/app/packages/components/src/components/EnterpriseUpsellCallout.test.tsx
+++ b/app/packages/components/src/components/EnterpriseUpsellCallout.test.tsx
@@ -1,0 +1,86 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@voxel51/voodo", () => ({
+  Card: ({ children }: { children: unknown }) => <div>{children}</div>,
+  Stack: ({ children }: { children: unknown }) => <div>{children}</div>,
+  Text: ({ children }: { children: unknown }) => <span>{children}</span>,
+  Icon: () => null,
+  Button: ({
+    children,
+    onClick,
+  }: {
+    children: unknown;
+    onClick?: () => void;
+  }) => <button onClick={onClick}>{children}</button>,
+  Align: {},
+  CardBackground: {},
+  IconName: { AI: "AI", ExternalLink: "ExternalLink" },
+  Orientation: {},
+  Size: {},
+  Spacing: {},
+  TextColor: {},
+  TextVariant: {},
+  Variant: {},
+}));
+
+import EnterpriseUpsellCallout from "./EnterpriseUpsellCallout";
+
+const props = {
+  title: "More powerful AI in Enterprise",
+  description: "Upgrade to unlock more.",
+  learnMoreUrl: "https://voxel51.com/why-upgrade",
+};
+
+afterEach(cleanup);
+
+describe("EnterpriseUpsellCallout", () => {
+  it("renders the title and description", () => {
+    render(<EnterpriseUpsellCallout {...props} />);
+    expect(screen.getByText(props.title)).toBeTruthy();
+    expect(screen.getByText(props.description)).toBeTruthy();
+  });
+
+  it("opens the provided learn-more url in a new tab", () => {
+    const open = vi.spyOn(window, "open").mockImplementation(() => null);
+    render(<EnterpriseUpsellCallout {...props} />);
+
+    fireEvent.click(screen.getByText("Learn more"));
+
+    expect(open).toHaveBeenCalledWith(
+      props.learnMoreUrl,
+      "_blank",
+      "noopener,noreferrer",
+    );
+    open.mockRestore();
+  });
+
+  it("falls back to the default learn-more url when none is provided", () => {
+    const open = vi.spyOn(window, "open").mockImplementation(() => null);
+    render(
+      <EnterpriseUpsellCallout
+        title={props.title}
+        description={props.description}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Learn more"));
+
+    expect(open).toHaveBeenCalledWith(
+      expect.stringContaining("voxel51.com/why-upgrade"),
+      "_blank",
+      "noopener,noreferrer",
+    );
+    open.mockRestore();
+  });
+
+  it("renders Dismiss only when onDismiss is provided and fires it", () => {
+    const onDismiss = vi.fn();
+    const { rerender } = render(<EnterpriseUpsellCallout {...props} />);
+    expect(screen.queryByText("Dismiss")).toBeNull();
+
+    rerender(<EnterpriseUpsellCallout {...props} onDismiss={onDismiss} />);
+    fireEvent.click(screen.getByText("Dismiss"));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/packages/components/src/components/EnterpriseUpsellCallout.tsx
+++ b/app/packages/components/src/components/EnterpriseUpsellCallout.tsx
@@ -1,0 +1,106 @@
+import {
+  Align,
+  Button,
+  Card,
+  CardBackground,
+  Icon,
+  IconName,
+  Orientation,
+  Size,
+  Spacing,
+  Stack,
+  Text,
+  TextColor,
+  TextVariant,
+  Variant,
+} from "@voxel51/voodo";
+
+/** Accent for the icon, border, and CTA — the "AI" orange used across upsells. */
+const AI_ACCENT = "#F5821F";
+
+/** Default destination for the "Learn more" CTA. */
+export const ENTERPRISE_LEARN_MORE_URL =
+  "https://voxel51.com/why-upgrade?utm_source=FiftyOneApp";
+
+export interface EnterpriseUpsellCalloutProps {
+  title: string;
+  description: string;
+  /**
+   * Destination opened by the primary CTA in a new tab. Defaults to
+   * {@link ENTERPRISE_LEARN_MORE_URL}.
+   */
+  learnMoreUrl?: string;
+  /** CTA copy; defaults to "Learn more". */
+  learnMoreLabel?: string;
+  /**
+   * When provided, renders a secondary "Dismiss" button wired to this. Omit
+   * for a persistent (non-dismissible) callout.
+   */
+  onDismiss?: () => void;
+  /** Leading icon; defaults to the AI sparkle. */
+  icon?: IconName;
+  "data-cy"?: string;
+}
+
+/**
+ * Enterprise-upgrade callout card: an AI-accented heading, body copy, a
+ * link-out CTA, and an optional dismiss action. Shared across surfaces that
+ * promote FiftyOne Enterprise (annotation sidebar, agent selector).
+ */
+export default function EnterpriseUpsellCallout({
+  title,
+  description,
+  learnMoreUrl = ENTERPRISE_LEARN_MORE_URL,
+  learnMoreLabel = "Learn more",
+  onDismiss,
+  icon = IconName.AI,
+  "data-cy": dataCy,
+}: EnterpriseUpsellCalloutProps) {
+  const learnMore = () =>
+    window.open(learnMoreUrl, "_blank", "noopener,noreferrer");
+
+  return (
+    <Card
+      background={CardBackground.Primary}
+      outlined
+      style={{ borderColor: AI_ACCENT }}
+      data-cy={dataCy}
+    >
+      <Stack orientation={Orientation.Column} spacing={Spacing.Md}>
+        <Stack
+          orientation={Orientation.Row}
+          spacing={Spacing.Sm}
+          align={Align.Center}
+        >
+          <Icon name={icon} size={Size.Md} style={{ color: AI_ACCENT }} />
+          <Text>{title}</Text>
+        </Stack>
+
+        <Text variant={TextVariant.Md} color={TextColor.Secondary}>
+          {description}
+        </Text>
+
+        <Stack orientation={Orientation.Row} spacing={Spacing.Sm}>
+          <Button
+            variant={Variant.Primary}
+            size={Size.Sm}
+            trailingIcon={IconName.ExternalLink}
+            onClick={learnMore}
+            aria-label={`${learnMoreLabel} about FiftyOne Enterprise`}
+          >
+            {learnMoreLabel}
+          </Button>
+          {onDismiss && (
+            <Button
+              variant={Variant.Secondary}
+              size={Size.Sm}
+              onClick={onDismiss}
+            >
+              Dismiss
+            </Button>
+          )}
+        </Stack>
+      </Stack>
+    </Card>
+  );
+}

--- a/app/packages/components/src/components/index.ts
+++ b/app/packages/components/src/components/index.ts
@@ -10,6 +10,11 @@ export { default as ColoredDot } from "./ColoredDot";
 export { default as CopyButton } from "./CopyButton";
 export { default as Dialog } from "./Dialog";
 export { default as EditableLabel } from "./EditableLabel";
+export {
+  default as EnterpriseUpsellCallout,
+  ENTERPRISE_LEARN_MORE_URL,
+} from "./EnterpriseUpsellCallout";
+export type { EnterpriseUpsellCalloutProps } from "./EnterpriseUpsellCallout";
 export { default as ErrorBoundary, ErrorDisplayMarkup } from "./ErrorBoundary";
 export { default as ExternalLink } from "./ExternalLink";
 export { default as FilterAndSelectionIndicator } from "./FilterAndSelectionIndicator";

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/AIAnnotationPanel.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/AIAnnotationPanel.tsx
@@ -1,0 +1,39 @@
+import { AgentSelect } from "@fiftyone/annotation/src/agents/AgentSelect";
+import { useAgentSelector } from "@fiftyone/annotation/src/agents/hooks";
+import type React from "react";
+import styled from "styled-components";
+import { useIsAIAnnotationModeActive } from "./Edit/useAIAnnotationMode";
+
+const Panel = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem 1rem;
+`;
+
+/**
+ * Sidebar controls for AI-assisted annotation, shown while AI segmentation
+ * mode is active: the agent picker.
+ *
+ * Point selection is toggled from the SegmentationToolbar's AI tool (selecting
+ * it enters AI mode). This panel only hosts the agent picker, which has no
+ * toolbar-action equivalent.
+ */
+const AIAnnotationPanel: React.FC = () => {
+  const isAIMode = useIsAIAnnotationModeActive();
+  const agentSelector = useAgentSelector();
+
+  if (!isAIMode) return null;
+
+  return (
+    <Panel>
+      <AgentSelect
+        value={agentSelector.activeAgent}
+        onChange={(a) => agentSelector.setActiveAgent(a)}
+        showEnterpriseUpsell
+      />
+    </Panel>
+  );
+};
+
+export default AIAnnotationPanel;

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Annotate.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Annotate.tsx
@@ -1,12 +1,18 @@
 import { useRegisterAIAnnotationEventHandlers } from "@fiftyone/annotation/src/agents/hooks/useRegisterAIAnnotationEventHandlers";
 import { KnownContexts, useUndoRedo } from "@fiftyone/commands";
-import { LoadingSpinner } from "@fiftyone/components";
-import { useCurrentSampleId, useIsGroupDataset } from "@fiftyone/state";
+import { EnterpriseUpsellCallout, LoadingSpinner } from "@fiftyone/components";
+import {
+  useBrowserStorage,
+  useCurrentSampleId,
+  useIsGroupDataset,
+  useIsVideo,
+} from "@fiftyone/state";
 import { Text, TextColor, TextVariant } from "@voxel51/voodo";
 import { useAtomValue } from "jotai";
 import React, { useEffect } from "react";
 import styled from "styled-components";
 import Actions from "./Actions";
+import AIAnnotationPanel from "./AIAnnotationPanel";
 import Edit from "./Edit";
 import useDelete from "./Edit/useDelete";
 import { useAnnotationContext } from "./Edit/useAnnotationContext";
@@ -30,6 +36,10 @@ import {
 import { useLighterAnnotationBridge } from "./useLighterAnnotationBridge";
 import { useLooker3dAnnotationBridge } from "./useLooker3dAnnotationBridge";
 import { useSyncAnnotationSliceMediaType } from "./useSyncAnnotationSliceMediaType";
+import { Box } from "@mui/material";
+
+/** Persists (per browser) the user's dismissal of the video-AI upsell. */
+const AI_UPSELL_DISMISSED_KEY = "fo-annotate-video-ai-upsell-dismissed";
 
 const DISABLED_MESSAGES: Record<
   Exclude<AnnotationDisabledReason, null>,
@@ -113,13 +123,29 @@ const AnnotationBody = ({
   const isGroupDataset = useIsGroupDataset();
   const disabledMessage = useDisabledMessage(disabledReason);
   const showSetup = useShowImportSchema(!!disabledReason, requiredField);
+  const isVideo = useIsVideo();
+  const [upsellDismissed, setUpsellDismissed] = useBrowserStorage<boolean>(
+    AI_UPSELL_DISMISSED_KEY,
+    false,
+  );
 
   return (
     <>
       {isGroupDataset && !disabledReason && (
         <GroupAnnotation onSliceSelected={loadSchemas} />
       )}
+      {!showSetup && !disabledReason && isVideo && !upsellDismissed && (
+        <Box sx={{ m: 2 }}>
+          <EnterpriseUpsellCallout
+            data-cy="annotate-video-ai-upsell"
+            title="More powerful AI in Enterprise"
+            description="Annotate with built-in AI – segment, detect, and track objects right now. Upgrade to FiftyOne Enterprise to switch to more powerful models and unlock the full AI toolset across every annotation type."
+            onDismiss={() => setUpsellDismissed(true)}
+          />
+        </Box>
+      )}
       {!showSetup && <Actions key="actions" hidden={isEditingValue} />}
+      {!showSetup && <AIAnnotationPanel key="ai-panel" />}
       {isEditingValue && <Edit key="edit" />}
       {showSetup ? (
         <ImportSchema

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useAIAnnotationMode.test.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useAIAnnotationMode.test.ts
@@ -46,6 +46,8 @@ const hoisted = vi.hoisted(() => ({
 
 vi.mock("@fiftyone/annotation/src/agents", () => ({
   AgentTaskType: hoisted.AgentTaskType,
+  isAgentSelectable: (d: { available?: boolean; unlisted?: boolean }) =>
+    d.available !== false && !d.unlisted,
   useActiveTask: () => ({
     activeTask: null,
     setActiveTask: hoisted.activeTaskSpies.setActiveTask,

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useAIAnnotationMode.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useAIAnnotationMode.ts
@@ -34,8 +34,8 @@ export const useIsAIAnnotationModeActive = (): boolean =>
 const useDefaultAgent = () => {
   const agentSelector = useAgentSelector();
 
-  // We don't currently expose agent selection capabilities in the UX.
-  // Select the first available agent once the agents have resolved.
+  // Select the first available agent as the default once the agents have
+  // resolved; the user can change it from the AgentSelect dropdown.
   useEffect(() => {
     if (agentSelector.isResolved && !agentSelector.activeAgent) {
       agentSelector.setActiveAgent(agentSelector.agents[0]);

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useAIAnnotationMode.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useAIAnnotationMode.ts
@@ -1,5 +1,6 @@
 import {
   AgentTaskType,
+  isAgentSelectable,
   useActiveTask,
   useAgentSelector,
   usePointSelection,
@@ -34,11 +35,17 @@ export const useIsAIAnnotationModeActive = (): boolean =>
 const useDefaultAgent = () => {
   const agentSelector = useAgentSelector();
 
-  // Select the first available agent as the default once the agents have
-  // resolved; the user can change it from the AgentSelect dropdown.
+  // Select the first *selectable* agent as the default once the agents have
+  // resolved; the user can change it from the AgentSelect dropdown. Bootstrap
+  // from the same filter the selector uses — picking a hidden/unavailable
+  // entry here would just be cleared by the dropdown and reselected in a loop.
   useEffect(() => {
-    if (agentSelector.isResolved && !agentSelector.activeAgent) {
-      agentSelector.setActiveAgent(agentSelector.agents[0]);
+    if (!agentSelector.isResolved) return;
+    if (agentSelector.activeAgent) return;
+
+    const [first] = agentSelector.agents.filter(isAgentSelectable);
+    if (first) {
+      agentSelector.setActiveAgent(first);
     }
   }, [agentSelector]);
 };

--- a/app/packages/video-annotation/src/components/AiTrackUpsellButton.tsx
+++ b/app/packages/video-annotation/src/components/AiTrackUpsellButton.tsx
@@ -1,19 +1,5 @@
-import {
-  Align,
-  Button,
-  Card,
-  CardBackground,
-  Icon,
-  IconName,
-  Orientation,
-  Size,
-  Spacing,
-  Stack,
-  Text,
-  TextColor,
-  TextVariant,
-  Variant,
-} from "@voxel51/voodo";
+import { EnterpriseUpsellCallout } from "@fiftyone/components";
+import { Button, IconName, Size, Variant } from "@voxel51/voodo";
 import React, { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
@@ -24,12 +10,6 @@ import { createPortal } from "react-dom";
  */
 const AI_TRACK_GRADIENT =
   "linear-gradient(139deg, #CC5200 5.04%, #9A3EDB 103.8%)";
-
-/** Accent for the callout's icon + CTA. */
-const AI_ACCENT = "#F5821F";
-
-/** Upgrade landing URL. */
-const LEARN_MORE_URL = "https://voxel51.com/why-upgrade?utm_source=FiftyOneApp";
 
 /**
  * Keeps the callout open across the gap between the button and the portaled
@@ -66,10 +46,6 @@ export const AiTrackUpsellButton: React.FC = () => {
   const scheduleClose = () => {
     clearTimeout(closeTimer.current);
     closeTimer.current = setTimeout(() => setRect(null), CLOSE_DELAY_MS);
-  };
-
-  const learnMore = () => {
-    window.open(LEARN_MORE_URL, "_blank", "noopener,noreferrer");
   };
 
   return (
@@ -112,45 +88,11 @@ export const AiTrackUpsellButton: React.FC = () => {
               zIndex: "var(--z-above-modal)",
             }}
           >
-            <Card background={CardBackground.Primary} outlined>
-              <Stack orientation={Orientation.Column} spacing={Spacing.Md}>
-                <Stack
-                  orientation={Orientation.Row}
-                  spacing={Spacing.Sm}
-                  align={Align.Center}
-                >
-                  <Icon
-                    name={IconName.AI}
-                    size={Size.Md}
-                    style={{ color: AI_ACCENT }}
-                  />
-                  <Text
-                    variant={TextVariant.Xl}
-                    color={TextColor.Primary}
-                    style={{ fontWeight: 600 }}
-                  >
-                    More powerful AI in Enterprise
-                  </Text>
-                </Stack>
-
-                <Text variant={TextVariant.Md} color={TextColor.Secondary}>
-                  Auto-track objects across frames – available in FiftyOne
-                  Enterprise.
-                </Text>
-
-                <Button
-                  variant={Variant.Primary}
-                  size={Size.Sm}
-                  trailingIcon={IconName.ExternalLink}
-                  onClick={learnMore}
-                  aria-label="Learn more about FiftyOne Enterprise"
-                  data-cy="ai-track-upsell-learn-more"
-                  style={{ background: AI_ACCENT, width: "100%" }}
-                >
-                  Learn more
-                </Button>
-              </Stack>
-            </Card>
+            <EnterpriseUpsellCallout
+              data-cy="ai-track-upsell-callout"
+              title="More powerful AI in Enterprise"
+              description="Auto-track objects across frames – available in FiftyOne Enterprise."
+            />
           </div>,
           document.body,
         )}


### PR DESCRIPTION
Adds upgrade callouts to the in-app annotation surface.

### What
- **Annotate sidebar (video):** a dismissible callout shown when annotating a video dataset, promoting more capable annotation AI. Dismissal is remembered per browser (localStorage).
- **AI model selector:** an extra, non-selectable option in the annotation model dropdown that links out to more capable models. It's gated by a `showEnterpriseUpsell` prop that is **off by default**, so builds where those models are available simply don't opt in.
- **Reusable component:** a shared callout component in `@fiftyone/components` used by the sidebar callout.

### Notes
- The AI panel / model selector is now rendered in the annotate sidebar (previously the first agent was auto-selected with no UI).
- The agent registry `register()` signature is aligned (adds an optional `available` flag) so the shape is consistent.

### Tests
- Unit coverage for the callout component (render, learn-more, dismiss) and the selector (listing/filtering, the gated option, and its link-out behavior).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an AI agent selector that hides unavailable and unlisted agents.
  * Added an Enterprise-only upsell option to the agent dropdown, opening the upgrade details in a new tab.
  * Introduced a reusable Enterprise upsell callout and integrated it into AI annotation/video experiences, including “dismiss” persistence for the video upsell.
  * Clears the current agent selection if the previously selected agent is no longer selectable.
* **Tests**
  * Added React Testing Library + Vitest coverage for agent filtering, upsell visibility/interactions, selection updates, and callout rendering/dismissal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3489
<!-- enterprise-sync-pr:end -->