### PR TITLE
Add PaddleOCR-VL to model zoo

### DIFF
--- a/fiftyone/utils/paddleocr_vl.py
+++ b/fiftyone/utils/paddleocr_vl.py
@@ -47,6 +47,15 @@ _LOC_BINS = 1000
 _SPOT_PATTERN = re.compile(r"(.*?)((?:<\|LOC_\d+\|>){8})", re.DOTALL)
 _LOC_TOKEN = re.compile(r"<\|LOC_(\d+)\|>")
 
+# The reference spotting pipeline doubles images whose dimensions are both
+# under this threshold and raises the processor's pixel budget, so fine text
+# survives the resize. Coordinates are normalized, so the upscale does not
+# change the returned boxes.
+_SPOTTING_UPSCALE_THRESHOLD = 1500
+_SPOTTING_MAX_PIXELS = 2048 * 28 * 28
+_DEFAULT_MAX_PIXELS = 1280 * 28 * 28
+_MIN_PIXELS = 4 * 28 * 28
+
 
 def _ensure_paddleocr_vl():
     fou.ensure_package(_MIN_TRANSFORMERS)
@@ -80,12 +89,26 @@ def _to_pil(img):
         img = np.repeat(img, 3, axis=2)
     elif img.shape[2] == 4:
         img = img[:, :, :3]
-    return PILImage.fromarray(img)
+    return PILImage.fromarray(img).convert("RGB")
 
 
-def _select_dtype(device):
+def _select_dtype(device) -> "torch.dtype":
     """bfloat16 is a CUDA optimization; CPU inference wants float32."""
     return torch.bfloat16 if "cuda" in str(device) else torch.float32
+
+
+def _upscale_for_spotting(pil):
+    """Doubles images whose dimensions are both under 1500 px, matching the
+    reference spotting pipeline, which upscales small inputs so fine text
+    survives the processor's resize."""
+    width, height = pil.size
+    if (
+        width < _SPOTTING_UPSCALE_THRESHOLD
+        and height < _SPOTTING_UPSCALE_THRESHOLD
+    ):
+        resample = getattr(PILImage, "Resampling", PILImage).LANCZOS
+        return pil.resize((width * 2, height * 2), resample)
+    return pil
 
 
 def _parse_spotting(text):
@@ -201,10 +224,15 @@ class PaddleOCRVLModel(fout.TorchImageModel):
         # Only spotting emits geometry; the recognition-only tasks return
         # content without boxes, so they map to empty detections
         is_spotting = self.config.task == "spotting"
+        max_pixels = (
+            _SPOTTING_MAX_PIXELS if is_spotting else _DEFAULT_MAX_PIXELS
+        )
         results = []
         for img in imgs:
             try:
                 pil = _to_pil(img)
+                if is_spotting:
+                    pil = _upscale_for_spotting(pil)
                 messages = [
                     {
                         "role": "user",
@@ -220,6 +248,17 @@ class PaddleOCRVLModel(fout.TorchImageModel):
                     tokenize=True,
                     return_dict=True,
                     return_tensors="pt",
+                    images_kwargs={
+                        "size": {
+                            "shortest_edge": getattr(
+                                self._processor.image_processor,
+                                "min_pixels",
+                                None,
+                            )
+                            or _MIN_PIXELS,
+                            "longest_edge": max_pixels,
+                        }
+                    },
                 ).to(self._device)
                 with torch.inference_mode():
                     out = self._model.generate(

--- a/fiftyone/utils/paddleocr_vl.py
+++ b/fiftyone/utils/paddleocr_vl.py
@@ -1,0 +1,233 @@
+"""
+`PaddleOCR-VL <https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.6>`_ wrapper
+for the FiftyOne Model Zoo.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import logging
+import re
+
+import numpy as np
+
+import fiftyone.core.labels as fol
+import fiftyone.core.utils as fou
+import fiftyone.utils.torch as fout
+import fiftyone.zoo.models as fozm
+
+fou.ensure_torch()
+import torch
+
+logger = logging.getLogger(__name__)
+
+# PaddleOCR-VL is native to transformers as ``AutoModelForImageTextToText``,
+# but its config trips the strict dataclass validation in the transformers
+# 5.4.x line (``tie_word_embeddings`` typed ``int`` vs the checkpoint's
+# ``bool``); 5.13 restored the coercion.
+_MIN_TRANSFORMERS = "transformers>=5.13"
+
+DEFAULT_PADDLEOCR_VL_MODEL = "PaddlePaddle/PaddleOCR-VL-1.6"
+
+# Spotting (detection + recognition) is the only task that emits geometry, so
+# it is the default; the text/table/formula/chart/seal tasks emit content only.
+_TASK_PROMPTS = {
+    "spotting": "Spotting:",
+    "ocr": "OCR:",
+    "table": "Table Recognition:",
+    "formula": "Formula Recognition:",
+    "chart": "Chart Recognition:",
+    "seal": "Seal Recognition:",
+}
+
+# Spotting output is a reading-order stream of ``text`` followed by eight
+# ``<|LOC_n|>`` tokens (a four-point quad), coordinates normalized to [0, 1000].
+_LOC_BINS = 1000
+_SPOT_PATTERN = re.compile(r"(.*?)((?:<\|LOC_\d+\|>){8})", re.DOTALL)
+_LOC_TOKEN = re.compile(r"<\|LOC_(\d+)\|>")
+
+
+def _ensure_paddleocr_vl():
+    fou.ensure_package(_MIN_TRANSFORMERS)
+
+
+transformers = fou.lazy_import("transformers", callback=_ensure_paddleocr_vl)
+
+from PIL import Image as PILImage
+
+
+def _to_pil(img):
+    """Converts a raw model input (PIL image, HWC numpy array, or CHW torch
+    tensor) to an RGB PIL image, the form PaddleOCR-VL's processor consumes."""
+    if isinstance(img, PILImage.Image):
+        return img.convert("RGB")
+
+    if isinstance(img, torch.Tensor):
+        img = img.detach().cpu().numpy()
+        if img.ndim == 3 and img.shape[0] in (1, 3, 4):
+            img = np.transpose(img, (1, 2, 0))
+
+    img = np.asarray(img)
+    if np.issubdtype(img.dtype, np.floating):
+        if img.max() <= 1.0:
+            img = img * 255.0
+        img = np.clip(img, 0, 255)
+    img = img.astype(np.uint8)
+    if img.ndim == 2:
+        img = np.stack([img] * 3, axis=-1)
+    if img.shape[2] == 4:
+        img = img[:, :, :3]
+    return PILImage.fromarray(img)
+
+
+def _parse_spotting(text):
+    """Parses PaddleOCR-VL spotting output into text regions.
+
+    The model emits a reading-order stream of ``content`` spans, each followed
+    by eight ``<|LOC_n|>`` tokens forming a four-point quad with coordinates
+    normalized to ``[0, 1000]``. Returns a list of ``(content, [x, y, w, h])``
+    tuples with the box normalized to ``[0, 1]``.
+    """
+    regions = []
+    for match in _SPOT_PATTERN.finditer(text):
+        content = match.group(1).strip()
+        if not content:
+            continue
+        locs = [int(v) for v in _LOC_TOKEN.findall(match.group(2))]
+        if len(locs) != 8:
+            continue
+        xs = [locs[i] / _LOC_BINS for i in range(0, 8, 2)]
+        ys = [locs[i] / _LOC_BINS for i in range(1, 8, 2)]
+        x0 = min(max(min(xs), 0.0), 1.0)
+        y0 = min(max(min(ys), 0.0), 1.0)
+        xf = min(max(max(xs), 0.0), 1.0)
+        yf = min(max(max(ys), 0.0), 1.0)
+        w, h = xf - x0, yf - y0
+        if w <= 0 or h <= 0:
+            continue
+        regions.append((content, [x0, y0, w, h]))
+    return regions
+
+
+class PaddleOCRVLModelConfig(fout.TorchImageModelConfig, fozm.HasZooModel):
+    """Configuration for running a :class:`PaddleOCRVLModel`.
+
+    Args:
+        name_or_path ("PaddlePaddle/PaddleOCR-VL-1.6"): the HuggingFace model to
+            load
+        task ("spotting"): the recognition task. One of ``"spotting"``,
+            ``"ocr"``, ``"table"``, ``"formula"``, ``"chart"``, ``"seal"``.
+            Only ``"spotting"`` produces localized text regions
+        max_new_tokens (1024): the maximum number of tokens to generate
+    """
+
+    def __init__(self, d):
+        d = self.init(d)
+        super().__init__(d)
+
+        self.name_or_path = self.parse_string(
+            d, "name_or_path", default=DEFAULT_PADDLEOCR_VL_MODEL
+        )
+        self.task = self.parse_string(d, "task", default="spotting")
+        if self.task not in _TASK_PROMPTS:
+            raise ValueError(
+                "Unsupported task '%s'. Supported tasks are: %s"
+                % (self.task, ", ".join(_TASK_PROMPTS))
+            )
+        self.max_new_tokens = self.parse_int(d, "max_new_tokens", default=1024)
+
+        # PaddleOCR-VL consumes the raw image via its own processor
+        self.raw_inputs = True
+
+
+class PaddleOCRVLModel(fout.TorchImageModel):
+    """FiftyOne wrapper for `PaddleOCR-VL
+    <https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.6>`_.
+
+    PaddleOCR-VL is a 0.9B vision-language document parser. Under the default
+    ``"spotting"`` task it detects and recognizes text in one pass, returning a
+    :class:`fiftyone.core.labels.Detections` per image, one detection per text
+    region whose ``label`` is the recognized string and ``bounding_box`` is the
+    region. The other tasks (``"ocr"``, ``"table"``, ``"formula"``,
+    ``"chart"``, ``"seal"``) recognize content without geometry and return an
+    empty :class:`fiftyone.core.labels.Detections`.
+
+    Example::
+
+        import fiftyone as fo
+        import fiftyone.zoo as foz
+
+        dataset = foz.load_zoo_dataset("quickstart", max_samples=5)
+
+        model = foz.load_zoo_model("paddle-ocr-vl-torch")
+        dataset.apply_model(model, label_field="ocr")
+
+        session = fo.launch_app(dataset)
+
+    Args:
+        config: a :class:`PaddleOCRVLModelConfig`
+    """
+
+    def __init__(self, config):
+        self._processor = None
+        super().__init__(config)
+
+    def _download_model(self, config):
+        pass  # transformers downloads the model on first load
+
+    def _load_model(self, config):
+        self._processor = transformers.AutoProcessor.from_pretrained(
+            config.name_or_path
+        )
+        model = transformers.AutoModelForImageTextToText.from_pretrained(
+            config.name_or_path, dtype=torch.bfloat16
+        ).eval()
+        return model.to(self._device)
+
+    @property
+    def media_type(self):
+        return "image"
+
+    def _predict_all(self, imgs):
+        prompt = _TASK_PROMPTS[self.config.task]
+        results = []
+        for img in imgs:
+            try:
+                pil = _to_pil(img)
+                messages = [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "image", "image": pil},
+                            {"type": "text", "text": prompt},
+                        ],
+                    }
+                ]
+                inputs = self._processor.apply_chat_template(
+                    messages,
+                    add_generation_prompt=True,
+                    tokenize=True,
+                    return_dict=True,
+                    return_tensors="pt",
+                ).to(self._device)
+                with torch.inference_mode():
+                    out = self._model.generate(
+                        **inputs, max_new_tokens=self.config.max_new_tokens
+                    )
+                text = self._processor.decode(
+                    out[0][inputs["input_ids"].shape[-1] :],
+                    skip_special_tokens=False,
+                )
+            except Exception as e:  # per-image guard
+                logger.warning("PaddleOCR-VL failed on an image: %s", e)
+                results.append(fol.Detections())
+                continue
+
+            detections = [
+                fol.Detection(label=content, bounding_box=box)
+                for content, box in _parse_spotting(text)
+            ]
+            results.append(fol.Detections(detections=detections))
+
+        return results

--- a/fiftyone/utils/paddleocr_vl.py
+++ b/fiftyone/utils/paddleocr_vl.py
@@ -1,0 +1,285 @@
+"""
+`PaddleOCR-VL <https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.6>`_ wrapper
+for the FiftyOne Model Zoo.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import logging
+import re
+
+import numpy as np
+
+import fiftyone.core.labels as fol
+import fiftyone.core.utils as fou
+import fiftyone.utils.torch as fout
+import fiftyone.zoo.models as fozm
+
+fou.ensure_torch()
+import torch
+
+logger = logging.getLogger(__name__)
+
+# PaddleOCR-VL is native to transformers as ``AutoModelForImageTextToText``,
+# but its config trips the strict dataclass validation in the transformers
+# 5.4.x line (``tie_word_embeddings`` typed ``int`` vs the checkpoint's
+# ``bool``); 5.13 restored the coercion.
+_MIN_TRANSFORMERS = "transformers>=5.13"
+
+DEFAULT_PADDLEOCR_VL_MODEL = "PaddlePaddle/PaddleOCR-VL-1.6"
+
+# Spotting (detection + recognition) is the only task that emits geometry, so
+# it is the default; the text/table/formula/chart/seal tasks emit content only.
+_TASK_PROMPTS = {
+    "spotting": "Spotting:",
+    "ocr": "OCR:",
+    "table": "Table Recognition:",
+    "formula": "Formula Recognition:",
+    "chart": "Chart Recognition:",
+    "seal": "Seal Recognition:",
+}
+
+# Spotting output is a reading-order stream of ``text`` followed by eight
+# ``<|LOC_n|>`` tokens (a four-point quad), coordinates normalized to [0, 1000].
+_LOC_BINS = 1000
+_SPOT_PATTERN = re.compile(r"(.*?)((?:<\|LOC_\d+\|>){8})", re.DOTALL)
+_LOC_TOKEN = re.compile(r"<\|LOC_(\d+)\|>")
+
+# The reference spotting pipeline doubles images whose dimensions are both
+# under this threshold and raises the processor's pixel budget, so fine text
+# survives the resize. Coordinates are normalized, so the upscale does not
+# change the returned boxes.
+_SPOTTING_UPSCALE_THRESHOLD = 1500
+_SPOTTING_MAX_PIXELS = 2048 * 28 * 28
+_DEFAULT_MAX_PIXELS = 1280 * 28 * 28
+_MIN_PIXELS = 4 * 28 * 28
+
+
+def _ensure_paddleocr_vl():
+    fou.ensure_package(_MIN_TRANSFORMERS)
+
+
+transformers = fou.lazy_import("transformers", callback=_ensure_paddleocr_vl)
+
+from PIL import Image as PILImage
+
+
+def _to_pil(img):
+    """Converts a raw model input (PIL image, HWC numpy array, or CHW torch
+    tensor) to an RGB PIL image, the form PaddleOCR-VL's processor consumes."""
+    if isinstance(img, PILImage.Image):
+        return img.convert("RGB")
+
+    if isinstance(img, torch.Tensor):
+        img = img.detach().cpu().numpy()
+        if img.ndim == 3 and img.shape[0] in (1, 3, 4):
+            img = np.transpose(img, (1, 2, 0))
+
+    img = np.asarray(img)
+    if np.issubdtype(img.dtype, np.floating):
+        if img.max() <= 1.0:
+            img = img * 255.0
+        img = np.clip(img, 0, 255)
+    img = img.astype(np.uint8)
+    if img.ndim == 2:
+        img = np.stack([img] * 3, axis=-1)
+    if img.shape[2] == 1:
+        img = np.repeat(img, 3, axis=2)
+    elif img.shape[2] == 4:
+        img = img[:, :, :3]
+    return PILImage.fromarray(img).convert("RGB")
+
+
+def _select_dtype(device) -> "torch.dtype":
+    """bfloat16 is a CUDA optimization; CPU inference wants float32."""
+    return torch.bfloat16 if "cuda" in str(device) else torch.float32
+
+
+def _upscale_for_spotting(pil) -> "PILImage.Image":
+    """Doubles images whose dimensions are both under 1500 px, matching the
+    reference spotting pipeline, which upscales small inputs so fine text
+    survives the processor's resize."""
+    width, height = pil.size
+    if (
+        width < _SPOTTING_UPSCALE_THRESHOLD
+        and height < _SPOTTING_UPSCALE_THRESHOLD
+    ):
+        resample = getattr(PILImage, "Resampling", PILImage).LANCZOS
+        return pil.resize((width * 2, height * 2), resample)
+    return pil
+
+
+def _parse_spotting(text):
+    """Parses PaddleOCR-VL spotting output into text regions.
+
+    The model emits a reading-order stream of ``content`` spans, each followed
+    by eight ``<|LOC_n|>`` tokens forming a four-point quad with coordinates
+    normalized to ``[0, 1000]``. Returns a list of ``(content, [x, y, w, h])``
+    tuples with the box normalized to ``[0, 1]``.
+    """
+    regions = []
+    for match in _SPOT_PATTERN.finditer(text):
+        content = match.group(1).strip()
+        if not content:
+            continue
+        locs = [int(v) for v in _LOC_TOKEN.findall(match.group(2))]
+        if len(locs) != 8:
+            continue
+        xs = [locs[i] / _LOC_BINS for i in range(0, 8, 2)]
+        ys = [locs[i] / _LOC_BINS for i in range(1, 8, 2)]
+        x0 = min(max(min(xs), 0.0), 1.0)
+        y0 = min(max(min(ys), 0.0), 1.0)
+        xf = min(max(max(xs), 0.0), 1.0)
+        yf = min(max(max(ys), 0.0), 1.0)
+        w, h = xf - x0, yf - y0
+        if w <= 0 or h <= 0:
+            continue
+        regions.append((content, [x0, y0, w, h]))
+    return regions
+
+
+class PaddleOCRVLModelConfig(fout.TorchImageModelConfig, fozm.HasZooModel):
+    """Configuration for running a :class:`PaddleOCRVLModel`.
+
+    Args:
+        name_or_path ("PaddlePaddle/PaddleOCR-VL-1.6"): the HuggingFace model to
+            load
+        task ("spotting"): the recognition task. One of ``"spotting"``,
+            ``"ocr"``, ``"table"``, ``"formula"``, ``"chart"``, ``"seal"``.
+            Only ``"spotting"`` produces localized text regions
+        max_new_tokens (1024): the maximum number of tokens to generate
+    """
+
+    def __init__(self, d):
+        d = self.init(d)
+        super().__init__(d)
+
+        self.name_or_path = self.parse_string(
+            d, "name_or_path", default=DEFAULT_PADDLEOCR_VL_MODEL
+        )
+        self.task = self.parse_string(d, "task", default="spotting")
+        if self.task not in _TASK_PROMPTS:
+            raise ValueError(
+                "Unsupported task '%s'. Supported tasks are: %s"
+                % (self.task, ", ".join(_TASK_PROMPTS))
+            )
+        self.max_new_tokens = self.parse_int(d, "max_new_tokens", default=1024)
+
+        # PaddleOCR-VL consumes the raw image via its own processor
+        self.raw_inputs = True
+
+
+class PaddleOCRVLModel(fout.TorchImageModel):
+    """FiftyOne wrapper for `PaddleOCR-VL
+    <https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.6>`_.
+
+    PaddleOCR-VL is a 0.9B vision-language document parser. Under the default
+    ``"spotting"`` task it detects and recognizes text in one pass, returning a
+    :class:`fiftyone.core.labels.Detections` per image, one detection per text
+    region whose ``label`` is the recognized string and ``bounding_box`` is the
+    region. The other tasks (``"ocr"``, ``"table"``, ``"formula"``,
+    ``"chart"``, ``"seal"``) recognize content without geometry and return an
+    empty :class:`fiftyone.core.labels.Detections`.
+
+    Example::
+
+        import fiftyone as fo
+        import fiftyone.zoo as foz
+
+        dataset = foz.load_zoo_dataset("quickstart", max_samples=5)
+
+        model = foz.load_zoo_model("paddle-ocr-vl-torch")
+        dataset.apply_model(model, label_field="ocr")
+
+        session = fo.launch_app(dataset)
+
+    Args:
+        config: a :class:`PaddleOCRVLModelConfig`
+    """
+
+    def __init__(self, config):
+        self._processor = None
+        super().__init__(config)
+
+    def _download_model(self, config):
+        pass  # transformers downloads the model on first load
+
+    def _load_model(self, config):
+        self._processor = transformers.AutoProcessor.from_pretrained(
+            config.name_or_path
+        )
+        model = transformers.AutoModelForImageTextToText.from_pretrained(
+            config.name_or_path, dtype=_select_dtype(self._device)
+        ).eval()
+        return model.to(self._device)
+
+    @property
+    def media_type(self):
+        return "image"
+
+    def _predict_all(self, imgs):
+        prompt = _TASK_PROMPTS[self.config.task]
+        # Only spotting emits geometry; the recognition-only tasks return
+        # content without boxes, so they map to empty detections
+        is_spotting = self.config.task == "spotting"
+        max_pixels = (
+            _SPOTTING_MAX_PIXELS if is_spotting else _DEFAULT_MAX_PIXELS
+        )
+        results = []
+        for img in imgs:
+            try:
+                pil = _to_pil(img)
+                if is_spotting:
+                    pil = _upscale_for_spotting(pil)
+                messages = [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "image", "image": pil},
+                            {"type": "text", "text": prompt},
+                        ],
+                    }
+                ]
+                inputs = self._processor.apply_chat_template(
+                    messages,
+                    add_generation_prompt=True,
+                    tokenize=True,
+                    return_dict=True,
+                    return_tensors="pt",
+                    images_kwargs={
+                        "size": {
+                            "shortest_edge": getattr(
+                                self._processor.image_processor,
+                                "min_pixels",
+                                None,
+                            )
+                            or _MIN_PIXELS,
+                            "longest_edge": max_pixels,
+                        }
+                    },
+                ).to(self._device)
+                with torch.inference_mode():
+                    out = self._model.generate(
+                        **inputs, max_new_tokens=self.config.max_new_tokens
+                    )
+                text = self._processor.decode(
+                    out[0][inputs["input_ids"].shape[-1] :],
+                    skip_special_tokens=False,
+                )
+            except Exception as e:  # per-image guard
+                logger.warning("PaddleOCR-VL failed on an image: %s", e)
+                results.append(fol.Detections())
+                continue
+
+            if is_spotting:
+                detections = [
+                    fol.Detection(label=content, bounding_box=box)
+                    for content, box in _parse_spotting(text)
+                ]
+            else:
+                detections = []
+            results.append(fol.Detections(detections=detections))
+
+        return results

--- a/fiftyone/utils/paddleocr_vl.py
+++ b/fiftyone/utils/paddleocr_vl.py
@@ -76,9 +76,16 @@ def _to_pil(img):
     img = img.astype(np.uint8)
     if img.ndim == 2:
         img = np.stack([img] * 3, axis=-1)
-    if img.shape[2] == 4:
+    if img.shape[2] == 1:
+        img = np.repeat(img, 3, axis=2)
+    elif img.shape[2] == 4:
         img = img[:, :, :3]
     return PILImage.fromarray(img)
+
+
+def _select_dtype(device):
+    """bfloat16 is a CUDA optimization; CPU inference wants float32."""
+    return torch.bfloat16 if "cuda" in str(device) else torch.float32
 
 
 def _parse_spotting(text):
@@ -181,7 +188,7 @@ class PaddleOCRVLModel(fout.TorchImageModel):
             config.name_or_path
         )
         model = transformers.AutoModelForImageTextToText.from_pretrained(
-            config.name_or_path, dtype=torch.bfloat16
+            config.name_or_path, dtype=_select_dtype(self._device)
         ).eval()
         return model.to(self._device)
 
@@ -191,6 +198,9 @@ class PaddleOCRVLModel(fout.TorchImageModel):
 
     def _predict_all(self, imgs):
         prompt = _TASK_PROMPTS[self.config.task]
+        # Only spotting emits geometry; the recognition-only tasks return
+        # content without boxes, so they map to empty detections
+        is_spotting = self.config.task == "spotting"
         results = []
         for img in imgs:
             try:
@@ -224,10 +234,13 @@ class PaddleOCRVLModel(fout.TorchImageModel):
                 results.append(fol.Detections())
                 continue
 
-            detections = [
-                fol.Detection(label=content, bounding_box=box)
-                for content, box in _parse_spotting(text)
-            ]
+            if is_spotting:
+                detections = [
+                    fol.Detection(label=content, bounding_box=box)
+                    for content, box in _parse_spotting(text)
+                ]
+            else:
+                detections = []
             results.append(fol.Detections(detections=detections))
 
         return results

--- a/fiftyone/utils/paddleocr_vl.py
+++ b/fiftyone/utils/paddleocr_vl.py
@@ -97,7 +97,7 @@ def _select_dtype(device) -> "torch.dtype":
     return torch.bfloat16 if "cuda" in str(device) else torch.float32
 
 
-def _upscale_for_spotting(pil):
+def _upscale_for_spotting(pil) -> "PILImage.Image":
     """Doubles images whose dimensions are both under 1500 px, matching the
     reference spotting pipeline, which upscales small inputs so fine text
     survives the processor's resize."""

--- a/fiftyone/utils/paddleocr_vl.py
+++ b/fiftyone/utils/paddleocr_vl.py
@@ -92,12 +92,12 @@ def _to_pil(img):
     return PILImage.fromarray(img).convert("RGB")
 
 
-def _select_dtype(device) -> "torch.dtype":
+def _select_dtype(device):
     """bfloat16 is a CUDA optimization; CPU inference wants float32."""
     return torch.bfloat16 if "cuda" in str(device) else torch.float32
 
 
-def _upscale_for_spotting(pil) -> "PILImage.Image":
+def _upscale_for_spotting(pil):
     """Doubles images whose dimensions are both under 1500 px, matching the
     reference spotting pipeline, which upscales small inputs so fine text
     survives the processor's resize."""

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -12266,6 +12266,35 @@
             "tags": ["ocr", "detection", "torch"],
             "training_data": [],
             "date_added": "2026-07-13 00:00:00"
+        },
+        {
+            "base_name": "paddle-ocr-vl-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "PaddleOCR-VL 1.6, a 0.9B vision-language document parser that detects and reads text in one pass",
+            "source": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.6",
+            "author": "PaddlePaddle Authors",
+            "license": "Apache 2.0",
+            "size_bytes": 1930059391,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.paddleocr_vl.PaddleOCRVLModel",
+                "config": {
+                    "name_or_path": "PaddlePaddle/PaddleOCR-VL-1.6",
+                    "task": "spotting"
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "transformers>=5.13"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["ocr", "detection", "torch"],
+            "training_data": [],
+            "date_added": "2026-07-21 00:00:00"
         }
     ]
 }

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -12442,6 +12442,35 @@
                 }
             ],
             "date_added": "2026-07-14 12:00:00"
+        },
+        {
+            "base_name": "paddle-ocr-vl-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "PaddleOCR-VL 1.6, a 0.9B vision-language document parser that detects and reads text in one pass",
+            "source": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.6",
+            "author": "PaddlePaddle Authors",
+            "license": "Apache 2.0",
+            "size_bytes": 1930059391,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.paddleocr_vl.PaddleOCRVLModel",
+                "config": {
+                    "name_or_path": "PaddlePaddle/PaddleOCR-VL-1.6",
+                    "task": "spotting"
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "transformers>=5.13"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["ocr", "detection", "torch"],
+            "training_data": [],
+            "date_added": "2026-07-21 00:00:00"
         }
     ]
 }

--- a/tests/unittests/utils/test_paddleocr_vl.py
+++ b/tests/unittests/utils/test_paddleocr_vl.py
@@ -117,6 +117,43 @@ class ConfigTests(unittest.TestCase):
         self.assertEqual(config.task, "table")
 
 
+class PixelBudgetEffectTests(unittest.TestCase):
+    """Verifies the size bounds change the processor's output resolution,
+    not merely that they are forwarded."""
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            import transformers
+
+            cls.image_processor = (
+                transformers.AutoImageProcessor.from_pretrained(
+                    "PaddlePaddle/PaddleOCR-VL-1.6"
+                )
+            )
+        except Exception as e:
+            raise unittest.SkipTest(
+                "PaddleOCR-VL image processor unavailable: %s" % e
+            )
+
+    def test_spotting_budget_raises_resolution(self):
+        from PIL import Image
+
+        big = Image.new("RGB", (2800, 2800))
+        base = self.image_processor(images=big, return_tensors="pt")
+        raised = self.image_processor(
+            images=big,
+            return_tensors="pt",
+            size={
+                "shortest_edge": foup._MIN_PIXELS,
+                "longest_edge": foup._SPOTTING_MAX_PIXELS,
+            },
+        )
+        self.assertGreater(
+            raised["pixel_values"].shape[0], base["pixel_values"].shape[0]
+        )
+
+
 class UpscaleForSpottingTests(unittest.TestCase):
     def test_small_image_doubled(self):
         from PIL import Image

--- a/tests/unittests/utils/test_paddleocr_vl.py
+++ b/tests/unittests/utils/test_paddleocr_vl.py
@@ -1,0 +1,146 @@
+"""
+PaddleOCR-VL wrapper unit tests.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import unittest
+from unittest import mock
+
+import numpy as np
+
+import fiftyone.core.labels as fol
+import fiftyone.utils.paddleocr_vl as foup
+
+
+class ParseSpottingTests(unittest.TestCase):
+    def test_parses_text_and_quads(self):
+        text = (
+            "Invoice Total: 42.50"
+            "<|LOC_48|><|LOC_210|><|LOC_732|><|LOC_210|>"
+            "<|LOC_732|><|LOC_383|><|LOC_48|><|LOC_383|>\n"
+            "Date 2026-07-21"
+            "<|LOC_50|><|LOC_571|><|LOC_632|><|LOC_571|>"
+            "<|LOC_632|><|LOC_747|><|LOC_50|><|LOC_747|></s>"
+        )
+        regions = foup._parse_spotting(text)
+        self.assertEqual(len(regions), 2)
+
+        content, box = regions[0]
+        self.assertEqual(content, "Invoice Total: 42.50")
+        self.assertEqual(len(box), 4)
+        # quad (48, 210) .. (732, 383) normalized by 1000
+        self.assertAlmostEqual(box[0], 0.048)
+        self.assertAlmostEqual(box[1], 0.210)
+        self.assertAlmostEqual(box[2], 0.684)
+        self.assertAlmostEqual(box[3], 0.173)
+
+        self.assertEqual(regions[1][0], "Date 2026-07-21")
+
+    def test_skips_empty_content(self):
+        text = "<|LOC_10|><|LOC_10|><|LOC_20|><|LOC_10|><|LOC_20|><|LOC_20|><|LOC_10|><|LOC_20|>"
+        self.assertEqual(foup._parse_spotting(text), [])
+
+    def test_skips_degenerate_box(self):
+        # zero-width quad
+        text = "x<|LOC_10|><|LOC_10|><|LOC_10|><|LOC_10|><|LOC_10|><|LOC_20|><|LOC_10|><|LOC_20|>"
+        self.assertEqual(foup._parse_spotting(text), [])
+
+    def test_no_locations_returns_empty(self):
+        self.assertEqual(foup._parse_spotting("plain text</s>"), [])
+
+    def test_clamps_out_of_range_coords(self):
+        text = "x<|LOC_0|><|LOC_0|><|LOC_1200|><|LOC_0|><|LOC_1200|><|LOC_1200|><|LOC_0|><|LOC_1200|>"
+        ((_, box),) = foup._parse_spotting(text)
+        self.assertGreaterEqual(box[0], 0.0)
+        self.assertLessEqual(box[0] + box[2], 1.0)
+        self.assertLessEqual(box[1] + box[3], 1.0)
+
+
+class ToPilTests(unittest.TestCase):
+    def test_numpy_hwc_uint8(self):
+        arr = np.zeros((8, 12, 3), dtype=np.uint8)
+        pil = foup._to_pil(arr)
+        self.assertEqual(pil.mode, "RGB")
+        self.assertEqual(pil.size, (12, 8))
+
+    def test_grayscale(self):
+        arr = np.zeros((8, 12), dtype=np.uint8)
+        self.assertEqual(foup._to_pil(arr).mode, "RGB")
+
+    def test_rgba_dropped_to_rgb(self):
+        arr = np.zeros((8, 12, 4), dtype=np.uint8)
+        pil = foup._to_pil(arr)
+        self.assertEqual(pil.mode, "RGB")
+
+    def test_float_scaled(self):
+        arr = np.ones((4, 4, 3), dtype=np.float32)
+        pil = foup._to_pil(arr)
+        self.assertEqual(np.asarray(pil).max(), 255)
+
+    def test_torch_chw(self):
+        import torch
+
+        t = torch.zeros(3, 8, 12, dtype=torch.uint8)
+        pil = foup._to_pil(t)
+        self.assertEqual(pil.size, (12, 8))
+
+
+class ConfigTests(unittest.TestCase):
+    def test_defaults(self):
+        config = foup.PaddleOCRVLModelConfig({})
+        self.assertEqual(config.name_or_path, "PaddlePaddle/PaddleOCR-VL-1.6")
+        self.assertEqual(config.task, "spotting")
+        self.assertEqual(config.max_new_tokens, 1024)
+        self.assertTrue(config.raw_inputs)
+
+    def test_invalid_task_raises(self):
+        with self.assertRaises(ValueError):
+            foup.PaddleOCRVLModelConfig({"task": "nonsense"})
+
+    def test_recognition_task_accepted(self):
+        config = foup.PaddleOCRVLModelConfig({"task": "table"})
+        self.assertEqual(config.task, "table")
+
+
+class PredictTests(unittest.TestCase):
+    def _model(self, decoded):
+        config = foup.PaddleOCRVLModelConfig({})
+        model = foup.PaddleOCRVLModel.__new__(foup.PaddleOCRVLModel)
+        model.config = config
+        model._device = "cpu"
+        model._model = mock.MagicMock()
+        model._processor = mock.MagicMock()
+        model._processor.apply_chat_template.return_value = mock.MagicMock()
+        model._processor.decode.return_value = decoded
+        # inputs["input_ids"].shape[-1] and .to(device) chains
+        inputs = model._processor.apply_chat_template.return_value
+        inputs.to.return_value = {"input_ids": mock.MagicMock()}
+        inputs.to.return_value["input_ids"].shape = [1, 0]
+        return model
+
+    def test_spotting_maps_to_detections(self):
+        decoded = (
+            "hello<|LOC_100|><|LOC_100|><|LOC_500|><|LOC_100|>"
+            "<|LOC_500|><|LOC_300|><|LOC_100|><|LOC_300|></s>"
+        )
+        model = self._model(decoded)
+        with mock.patch("torch.inference_mode"):
+            out = model._predict_all([np.zeros((16, 16, 3), dtype=np.uint8)])
+        self.assertEqual(len(out), 1)
+        self.assertIsInstance(out[0], fol.Detections)
+        self.assertEqual(len(out[0].detections), 1)
+        self.assertEqual(out[0].detections[0].label, "hello")
+
+    def test_failure_yields_empty_detections(self):
+        model = self._model("")
+        model._processor.apply_chat_template.side_effect = RuntimeError("boom")
+        out = model._predict_all([np.zeros((16, 16, 3), dtype=np.uint8)])
+        self.assertIsInstance(out[0], fol.Detections)
+        self.assertEqual(len(out[0].detections), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unittests/utils/test_paddleocr_vl.py
+++ b/tests/unittests/utils/test_paddleocr_vl.py
@@ -1,0 +1,255 @@
+"""
+PaddleOCR-VL wrapper unit tests.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import unittest
+from unittest import mock
+
+import numpy as np
+
+import fiftyone.core.labels as fol
+import fiftyone.utils.paddleocr_vl as foup
+
+
+class ParseSpottingTests(unittest.TestCase):
+    def test_parses_text_and_quads(self):
+        text = (
+            "Invoice Total: 42.50"
+            "<|LOC_48|><|LOC_210|><|LOC_732|><|LOC_210|>"
+            "<|LOC_732|><|LOC_383|><|LOC_48|><|LOC_383|>\n"
+            "Date 2026-07-21"
+            "<|LOC_50|><|LOC_571|><|LOC_632|><|LOC_571|>"
+            "<|LOC_632|><|LOC_747|><|LOC_50|><|LOC_747|></s>"
+        )
+        regions = foup._parse_spotting(text)
+        self.assertEqual(len(regions), 2)
+
+        content, box = regions[0]
+        self.assertEqual(content, "Invoice Total: 42.50")
+        self.assertEqual(len(box), 4)
+        # quad (48, 210) .. (732, 383) normalized by 1000
+        self.assertAlmostEqual(box[0], 0.048)
+        self.assertAlmostEqual(box[1], 0.210)
+        self.assertAlmostEqual(box[2], 0.684)
+        self.assertAlmostEqual(box[3], 0.173)
+
+        self.assertEqual(regions[1][0], "Date 2026-07-21")
+
+    def test_skips_empty_content(self):
+        text = "<|LOC_10|><|LOC_10|><|LOC_20|><|LOC_10|><|LOC_20|><|LOC_20|><|LOC_10|><|LOC_20|>"
+        self.assertEqual(foup._parse_spotting(text), [])
+
+    def test_skips_degenerate_box(self):
+        # zero-width quad
+        text = "x<|LOC_10|><|LOC_10|><|LOC_10|><|LOC_10|><|LOC_10|><|LOC_20|><|LOC_10|><|LOC_20|>"
+        self.assertEqual(foup._parse_spotting(text), [])
+
+    def test_no_locations_returns_empty(self):
+        self.assertEqual(foup._parse_spotting("plain text</s>"), [])
+
+    def test_clamps_out_of_range_coords(self):
+        text = "x<|LOC_0|><|LOC_0|><|LOC_1200|><|LOC_0|><|LOC_1200|><|LOC_1200|><|LOC_0|><|LOC_1200|>"
+        ((_, box),) = foup._parse_spotting(text)
+        self.assertGreaterEqual(box[0], 0.0)
+        self.assertLessEqual(box[0] + box[2], 1.0)
+        self.assertLessEqual(box[1] + box[3], 1.0)
+
+
+class ToPilTests(unittest.TestCase):
+    def test_numpy_hwc_uint8(self):
+        arr = np.zeros((8, 12, 3), dtype=np.uint8)
+        pil = foup._to_pil(arr)
+        self.assertEqual(pil.mode, "RGB")
+        self.assertEqual(pil.size, (12, 8))
+
+    def test_grayscale(self):
+        arr = np.zeros((8, 12), dtype=np.uint8)
+        self.assertEqual(foup._to_pil(arr).mode, "RGB")
+
+    def test_single_channel_hwc(self):
+        arr = np.zeros((8, 12, 1), dtype=np.uint8)
+        pil = foup._to_pil(arr)
+        self.assertEqual(pil.mode, "RGB")
+        self.assertEqual(pil.size, (12, 8))
+
+    def test_two_channel_la(self):
+        arr = np.zeros((8, 12, 2), dtype=np.uint8)
+        pil = foup._to_pil(arr)
+        self.assertEqual(pil.mode, "RGB")
+        self.assertEqual(pil.size, (12, 8))
+
+    def test_rgba_dropped_to_rgb(self):
+        arr = np.zeros((8, 12, 4), dtype=np.uint8)
+        pil = foup._to_pil(arr)
+        self.assertEqual(pil.mode, "RGB")
+
+    def test_float_scaled(self):
+        arr = np.ones((4, 4, 3), dtype=np.float32)
+        pil = foup._to_pil(arr)
+        self.assertEqual(np.asarray(pil).max(), 255)
+
+    def test_torch_chw(self):
+        import torch
+
+        t = torch.zeros(3, 8, 12, dtype=torch.uint8)
+        pil = foup._to_pil(t)
+        self.assertEqual(pil.size, (12, 8))
+
+
+class ConfigTests(unittest.TestCase):
+    def test_defaults(self):
+        config = foup.PaddleOCRVLModelConfig({})
+        self.assertEqual(config.name_or_path, "PaddlePaddle/PaddleOCR-VL-1.6")
+        self.assertEqual(config.task, "spotting")
+        self.assertEqual(config.max_new_tokens, 1024)
+        self.assertTrue(config.raw_inputs)
+
+    def test_invalid_task_raises(self):
+        with self.assertRaises(ValueError):
+            foup.PaddleOCRVLModelConfig({"task": "nonsense"})
+
+    def test_recognition_task_accepted(self):
+        config = foup.PaddleOCRVLModelConfig({"task": "table"})
+        self.assertEqual(config.task, "table")
+
+
+class PixelBudgetEffectTests(unittest.TestCase):
+    """Verifies the size bounds change the processor's output resolution,
+    not merely that they are forwarded."""
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            import transformers
+
+            cls.image_processor = (
+                transformers.AutoImageProcessor.from_pretrained(
+                    "PaddlePaddle/PaddleOCR-VL-1.6"
+                )
+            )
+        except Exception as e:
+            raise unittest.SkipTest(
+                "PaddleOCR-VL image processor unavailable: %s" % e
+            )
+
+    def test_spotting_budget_raises_resolution(self):
+        from PIL import Image
+
+        big = Image.new("RGB", (2800, 2800))
+        base = self.image_processor(images=big, return_tensors="pt")
+        raised = self.image_processor(
+            images=big,
+            return_tensors="pt",
+            size={
+                "shortest_edge": foup._MIN_PIXELS,
+                "longest_edge": foup._SPOTTING_MAX_PIXELS,
+            },
+        )
+        self.assertGreater(
+            raised["pixel_values"].shape[0], base["pixel_values"].shape[0]
+        )
+
+
+class UpscaleForSpottingTests(unittest.TestCase):
+    def test_small_image_doubled(self):
+        from PIL import Image
+
+        pil = Image.new("RGB", (640, 200))
+        self.assertEqual(foup._upscale_for_spotting(pil).size, (1280, 400))
+
+    def test_large_image_unchanged(self):
+        from PIL import Image
+
+        pil = Image.new("RGB", (1600, 200))
+        self.assertEqual(foup._upscale_for_spotting(pil).size, (1600, 200))
+
+
+class SelectDtypeTests(unittest.TestCase):
+    def test_cuda_uses_bfloat16(self):
+        import torch
+
+        self.assertEqual(foup._select_dtype("cuda:0"), torch.bfloat16)
+        self.assertEqual(
+            foup._select_dtype(torch.device("cuda:0")), torch.bfloat16
+        )
+
+    def test_cpu_uses_float32(self):
+        import torch
+
+        self.assertEqual(foup._select_dtype("cpu"), torch.float32)
+        self.assertEqual(
+            foup._select_dtype(torch.device("cpu")), torch.float32
+        )
+
+
+class PredictTests(unittest.TestCase):
+    def _model(self, decoded, task="spotting"):
+        config = foup.PaddleOCRVLModelConfig({"task": task})
+        model = foup.PaddleOCRVLModel.__new__(foup.PaddleOCRVLModel)
+        model.config = config
+        model._device = "cpu"
+        model._model = mock.MagicMock()
+        model._processor = mock.MagicMock()
+        model._processor.apply_chat_template.return_value = mock.MagicMock()
+        model._processor.decode.return_value = decoded
+        # inputs["input_ids"].shape[-1] and .to(device) chains
+        inputs = model._processor.apply_chat_template.return_value
+        inputs.to.return_value = {"input_ids": mock.MagicMock()}
+        inputs.to.return_value["input_ids"].shape = [1, 0]
+        return model
+
+    def test_spotting_maps_to_detections(self):
+        decoded = (
+            "hello<|LOC_100|><|LOC_100|><|LOC_500|><|LOC_100|>"
+            "<|LOC_500|><|LOC_300|><|LOC_100|><|LOC_300|></s>"
+        )
+        model = self._model(decoded)
+        with mock.patch("torch.inference_mode"):
+            out = model._predict_all([np.zeros((16, 16, 3), dtype=np.uint8)])
+        self.assertEqual(len(out), 1)
+        self.assertIsInstance(out[0], fol.Detections)
+        self.assertEqual(len(out[0].detections), 1)
+        self.assertEqual(out[0].detections[0].label, "hello")
+
+    def test_failure_yields_empty_detections(self):
+        model = self._model("")
+        model._processor.apply_chat_template.side_effect = RuntimeError("boom")
+        out = model._predict_all([np.zeros((16, 16, 3), dtype=np.uint8)])
+        self.assertIsInstance(out[0], fol.Detections)
+        self.assertEqual(len(out[0].detections), 0)
+
+    def test_spotting_pixel_budget(self):
+        model = self._model("</s>")
+        with mock.patch("torch.inference_mode"):
+            model._predict_all([np.zeros((16, 16, 3), dtype=np.uint8)])
+        kwargs = model._processor.apply_chat_template.call_args.kwargs
+        size = kwargs["images_kwargs"]["size"]
+        self.assertEqual(size["longest_edge"], foup._SPOTTING_MAX_PIXELS)
+
+    def test_recognition_pixel_budget(self):
+        model = self._model("</s>", task="table")
+        with mock.patch("torch.inference_mode"):
+            model._predict_all([np.zeros((16, 16, 3), dtype=np.uint8)])
+        kwargs = model._processor.apply_chat_template.call_args.kwargs
+        size = kwargs["images_kwargs"]["size"]
+        self.assertEqual(size["longest_edge"], foup._DEFAULT_MAX_PIXELS)
+
+    def test_non_spotting_task_ignores_locations(self):
+        # location-like tokens in a non-spotting task must not be parsed
+        decoded = (
+            "hello<|LOC_100|><|LOC_100|><|LOC_500|><|LOC_100|>"
+            "<|LOC_500|><|LOC_300|><|LOC_100|><|LOC_300|></s>"
+        )
+        model = self._model(decoded, task="table")
+        with mock.patch("torch.inference_mode"):
+            out = model._predict_all([np.zeros((16, 16, 3), dtype=np.uint8)])
+        self.assertIsInstance(out[0], fol.Detections)
+        self.assertEqual(len(out[0].detections), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unittests/utils/test_paddleocr_vl.py
+++ b/tests/unittests/utils/test_paddleocr_vl.py
@@ -76,6 +76,12 @@ class ToPilTests(unittest.TestCase):
         self.assertEqual(pil.mode, "RGB")
         self.assertEqual(pil.size, (12, 8))
 
+    def test_two_channel_la(self):
+        arr = np.zeros((8, 12, 2), dtype=np.uint8)
+        pil = foup._to_pil(arr)
+        self.assertEqual(pil.mode, "RGB")
+        self.assertEqual(pil.size, (12, 8))
+
     def test_rgba_dropped_to_rgb(self):
         arr = np.zeros((8, 12, 4), dtype=np.uint8)
         pil = foup._to_pil(arr)
@@ -109,6 +115,20 @@ class ConfigTests(unittest.TestCase):
     def test_recognition_task_accepted(self):
         config = foup.PaddleOCRVLModelConfig({"task": "table"})
         self.assertEqual(config.task, "table")
+
+
+class UpscaleForSpottingTests(unittest.TestCase):
+    def test_small_image_doubled(self):
+        from PIL import Image
+
+        pil = Image.new("RGB", (640, 200))
+        self.assertEqual(foup._upscale_for_spotting(pil).size, (1280, 400))
+
+    def test_large_image_unchanged(self):
+        from PIL import Image
+
+        pil = Image.new("RGB", (1600, 200))
+        self.assertEqual(foup._upscale_for_spotting(pil).size, (1600, 200))
 
 
 class SelectDtypeTests(unittest.TestCase):
@@ -164,6 +184,22 @@ class PredictTests(unittest.TestCase):
         out = model._predict_all([np.zeros((16, 16, 3), dtype=np.uint8)])
         self.assertIsInstance(out[0], fol.Detections)
         self.assertEqual(len(out[0].detections), 0)
+
+    def test_spotting_pixel_budget(self):
+        model = self._model("</s>")
+        with mock.patch("torch.inference_mode"):
+            model._predict_all([np.zeros((16, 16, 3), dtype=np.uint8)])
+        kwargs = model._processor.apply_chat_template.call_args.kwargs
+        size = kwargs["images_kwargs"]["size"]
+        self.assertEqual(size["longest_edge"], foup._SPOTTING_MAX_PIXELS)
+
+    def test_recognition_pixel_budget(self):
+        model = self._model("</s>", task="table")
+        with mock.patch("torch.inference_mode"):
+            model._predict_all([np.zeros((16, 16, 3), dtype=np.uint8)])
+        kwargs = model._processor.apply_chat_template.call_args.kwargs
+        size = kwargs["images_kwargs"]["size"]
+        self.assertEqual(size["longest_edge"], foup._DEFAULT_MAX_PIXELS)
 
     def test_non_spotting_task_ignores_locations(self):
         # location-like tokens in a non-spotting task must not be parsed

--- a/tests/unittests/utils/test_paddleocr_vl.py
+++ b/tests/unittests/utils/test_paddleocr_vl.py
@@ -70,6 +70,12 @@ class ToPilTests(unittest.TestCase):
         arr = np.zeros((8, 12), dtype=np.uint8)
         self.assertEqual(foup._to_pil(arr).mode, "RGB")
 
+    def test_single_channel_hwc(self):
+        arr = np.zeros((8, 12, 1), dtype=np.uint8)
+        pil = foup._to_pil(arr)
+        self.assertEqual(pil.mode, "RGB")
+        self.assertEqual(pil.size, (12, 8))
+
     def test_rgba_dropped_to_rgb(self):
         arr = np.zeros((8, 12, 4), dtype=np.uint8)
         pil = foup._to_pil(arr)
@@ -105,9 +111,27 @@ class ConfigTests(unittest.TestCase):
         self.assertEqual(config.task, "table")
 
 
+class SelectDtypeTests(unittest.TestCase):
+    def test_cuda_uses_bfloat16(self):
+        import torch
+
+        self.assertEqual(foup._select_dtype("cuda:0"), torch.bfloat16)
+        self.assertEqual(
+            foup._select_dtype(torch.device("cuda:0")), torch.bfloat16
+        )
+
+    def test_cpu_uses_float32(self):
+        import torch
+
+        self.assertEqual(foup._select_dtype("cpu"), torch.float32)
+        self.assertEqual(
+            foup._select_dtype(torch.device("cpu")), torch.float32
+        )
+
+
 class PredictTests(unittest.TestCase):
-    def _model(self, decoded):
-        config = foup.PaddleOCRVLModelConfig({})
+    def _model(self, decoded, task="spotting"):
+        config = foup.PaddleOCRVLModelConfig({"task": task})
         model = foup.PaddleOCRVLModel.__new__(foup.PaddleOCRVLModel)
         model.config = config
         model._device = "cpu"
@@ -138,6 +162,18 @@ class PredictTests(unittest.TestCase):
         model = self._model("")
         model._processor.apply_chat_template.side_effect = RuntimeError("boom")
         out = model._predict_all([np.zeros((16, 16, 3), dtype=np.uint8)])
+        self.assertIsInstance(out[0], fol.Detections)
+        self.assertEqual(len(out[0].detections), 0)
+
+    def test_non_spotting_task_ignores_locations(self):
+        # location-like tokens in a non-spotting task must not be parsed
+        decoded = (
+            "hello<|LOC_100|><|LOC_100|><|LOC_500|><|LOC_100|>"
+            "<|LOC_500|><|LOC_300|><|LOC_100|><|LOC_300|></s>"
+        )
+        model = self._model(decoded, task="table")
+        with mock.patch("torch.inference_mode"):
+            out = model._predict_all([np.zeros((16, 16, 3), dtype=np.uint8)])
         self.assertIsInstance(out[0], fol.Detections)
         self.assertEqual(len(out[0].detections), 0)
 


### PR DESCRIPTION
## Summary

Adds **PaddleOCR-VL 1.6** to the model zoo as `paddle-ocr-vl-torch`, a 0.9B vision-language document parser (SOTA on OmniDocBench v1.6). New `fiftyone/utils/paddleocr_vl.py` wrapper.

Unlike the existing `paddle-ocr-v6` family, which runs through the `paddleocr` package, this model is native to `transformers` (`AutoModelForImageTextToText`), so the only requirements are `torch` and `transformers>=5.13`.

## Behavior

Under the default `spotting` task the model detects and recognizes text in one pass. The wrapper parses its `<|LOC_n|>` quad stream and returns a `fiftyone.core.labels.Detections` per image, one detection per text region whose `label` is the recognized string and `bounding_box` is the region. The other tasks (`ocr`, `table`, `formula`, `chart`, `seal`) recognize content without geometry and return empty `Detections`.

```python
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart", max_samples=5)
model = foz.load_zoo_model("paddle-ocr-vl-torch")
dataset.apply_model(model, label_field="ocr")
session = fo.launch_app(dataset)
```

## Notes

`transformers>=5.13` is required: the checkpoint's config trips the strict dataclass validation in the transformers 5.4.x line (`tie_word_embeddings` typed `int` vs the checkpoint's `bool`), which 5.13 fixed. This is the same floor the `paddle-ocr-v6` entries already declare.

Verified end-to-end (load + apply_model → Detections with correct text and boxes); unit tests in `tests/unittests/utils/test_paddleocr_vl.py`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the PaddleOCR-VL-1.6 model for image analysis across spotting, OCR, tables, formulas, charts, and seals.
  * Spotting results include recognized text and normalized, range-checked bounding boxes.
  * Supports common image inputs with automatic RGB conversion, device-aware precision, and upscaling for small spotting images.

* **Reliability**
  * Invalid tasks are rejected, and per-image failures return empty results without interrupting processing.

* **Tests**
  * Added coverage for parsing, preprocessing, validation, upscaling, precision, and predictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3445
<!-- enterprise-sync-pr:end -->