### PR TITLE
Improve MCAP playback responsiveness

### DIFF
--- a/app/packages/multimodal/src/adapters/mcap/react/Mcap3dTile.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/Mcap3dTile.tsx
@@ -24,13 +24,11 @@ import { DEFAULT_POINT_CLOUD_CAMERA_PROJECTION } from "../../../visualization/pa
 import { PointCloudPanel } from "../../../visualization/panels/point-cloud/PointCloudPanel";
 import {
   type CameraFrustumPanelLayer,
-  type GridPanelLayer,
   type PointCloudCameraPose,
   type PointCloudCameraProjection,
   type PointCloudPanelLayer,
   type PointCloudPanelRenderStats,
   type PointCloudPointPick,
-  type SceneAnnotationPanelLayer,
   type SceneRayPanelLayer,
 } from "../../../visualization/panels/point-cloud/types";
 import { Mcap3dCameraRig } from "./Mcap3dCameraRig";
@@ -38,9 +36,12 @@ import Mcap3dTileSettings from "./Mcap3dTileSettings";
 import { Mcap3dViewControls } from "./Mcap3dViewControls";
 import { build3dLayers } from "./mcap-3d-layers";
 import {
+  mcap3dSceneSnapshotHasLayers,
+  restrictHeldMcap3dSceneSnapshotToTopics,
   selectMcap3dSceneSnapshot,
   type HeldMcap3dSceneSnapshot,
   type Mcap3dHeldSceneReason,
+  type Mcap3dSceneSnapshot,
 } from "./mcap-3d-scene-snapshot";
 import { useMcap3dViewSettings } from "./mcap-3d-view-settings-context";
 import {
@@ -246,6 +247,7 @@ const Mcap3dTile: React.FC<McapTileProps> = () => {
   const { focusedTileId } = useTiling();
   const sceneSnapshotRef =
     useRef<HeldMcap3dSceneSnapshot<Mcap3dSceneSnapshot> | null>(null);
+  const panelHasCommittedRef = useRef(false);
   const [, refreshSceneSnapshot] = useState(0);
   const panelBackground = useMemo<ThreeSceneBackground>(() => {
     switch (sceneBackground.mode) {
@@ -497,7 +499,9 @@ const Mcap3dTile: React.FC<McapTileProps> = () => {
       };
     },
     inputs: (layer) => [
-      layer,
+      layer.frame,
+      layer.contentTimeNs,
+      ...mcap3dFrameTransformIdentityInputs(layer.frameTransform),
       pointCloudColors[layer.id],
       pointCloudSourceById.get(layer.id),
       pointCloudSources,
@@ -622,7 +626,9 @@ const Mcap3dTile: React.FC<McapTileProps> = () => {
       const index = cameraTopics.indexOf(layer.id);
       const imageTopic = index >= 0 ? (frustumImageTopics[index] ?? "") : "";
       return [
-        layer,
+        layer.frame,
+        layer.contentTimeNs,
+        ...mcap3dFrameTransformIdentityInputs(layer.frameTransform),
         index >= 0 ? frustumImageFrames[index] : null,
         index >= 0 ? frustumImageDecodeRunways[index] : null,
         imageTopic,
@@ -710,11 +716,19 @@ const Mcap3dTile: React.FC<McapTileProps> = () => {
     // not every annotation in the scene.
     inputs: (layer) => {
       const entity = layer.frame.entities[0];
-      if (!entity) return [layer];
+      if (!entity) {
+        return [
+          layer.frame,
+          layer.sourceId,
+          ...mcap3dFrameTransformIdentityInputs(layer.frameTransform),
+        ];
+      }
       const topic = layer.sourceId ?? "";
       const entityId = entity.id || layer.id;
       return [
-        layer,
+        entity,
+        layer.sourceId,
+        ...mcap3dFrameTransformIdentityInputs(layer.frameTransform),
         isMcapSceneEntitySelected(selectedObject, topic, entityId),
         isMcapLabelEcho(selectedObject, mcapEntityLabel(entity)),
         onHoverEntity,
@@ -782,6 +796,15 @@ const Mcap3dTile: React.FC<McapTileProps> = () => {
       key: (layer) => layer.id,
     },
   );
+  const stableGridLayers = useKeyedIdentityMap(gridLayers, {
+    build: (layer) => layer,
+    inputs: (layer) => [
+      layer.frame,
+      layer.contentTimeNs,
+      ...mcap3dFrameTransformIdentityInputs(layer.frameTransform),
+    ],
+    key: (layer) => layer.id,
+  });
   // Schema-driven telemetry: speed from the first enabled pose stream whose
   // latest sample carries velocity, coordinates from the first LocationFix
   // stream — never keyed on topic names.
@@ -977,20 +1000,14 @@ const Mcap3dTile: React.FC<McapTileProps> = () => {
   // scene health reads identically in the canvas chip and the sidebar.
   usePublishMcapSceneNotices(tileId, panelNotices);
   const sceneSnapshotKey = useMemo(
-    () =>
-      JSON.stringify([
-        sourceKey,
-        selectedTopicsKey,
-        worldFrameId,
-        fidelityMode,
-      ]),
-    [fidelityMode, selectedTopicsKey, sourceKey, worldFrameId],
+    () => JSON.stringify([sourceKey, worldFrameId, fidelityMode]),
+    [fidelityMode, sourceKey, worldFrameId],
   );
   const currentSceneSnapshot = useMemo<Mcap3dSceneSnapshot>(
     () => ({
       annotationLayers,
       frustumLayers,
-      gridLayers,
+      gridLayers: stableGridLayers,
       notices: panelNotices,
       placementStatus,
       pointCloudLayers: hoverablePointCloudLayers,
@@ -999,7 +1016,7 @@ const Mcap3dTile: React.FC<McapTileProps> = () => {
       annotationLayers,
       hoverablePointCloudLayers,
       frustumLayers,
-      gridLayers,
+      stableGridLayers,
       panelNotices,
       placementStatus,
     ],
@@ -1010,17 +1027,21 @@ const Mcap3dTile: React.FC<McapTileProps> = () => {
     gridFrames.some(Boolean) ||
     calibrationFrames.some(Boolean);
   const currentSceneRetainable =
-    currentSceneSnapshot.pointCloudLayers.length > 0 ||
-    currentSceneSnapshot.annotationLayers.length > 0 ||
-    currentSceneSnapshot.gridLayers.length > 0 ||
-    currentSceneSnapshot.frustumLayers.length > 0;
+    mcap3dSceneSnapshotHasLayers(currentSceneSnapshot);
+  const selectedTopicSet = useMemo(
+    () => new Set(selectedTopics),
+    [selectedTopics],
+  );
   const sceneSnapshotSelection = selectMcap3dSceneSnapshot({
     current: currentSceneSnapshot,
     currentRetainable: currentSceneRetainable,
     definitiveMissingGraceMs: DEFINITIVE_MISSING_SCENE_GRACE_MS,
     empty: emptyMcap3dSceneSnapshot(currentSceneSnapshot.placementStatus),
     hasSourceData: hasSceneSourceData,
-    held: sceneSnapshotRef.current,
+    held: restrictHeldMcap3dSceneSnapshotToTopics(
+      sceneSnapshotRef.current,
+      selectedTopicSet,
+    ),
     key: sceneSnapshotKey,
     nowMs: Date.now(),
     readiness: selectedSourcePending
@@ -1070,6 +1091,21 @@ const Mcap3dTile: React.FC<McapTileProps> = () => {
     depthRayResolution?.status === "ready"
       ? [depthRayResolution.layer]
       : EMPTY_SCENE_RAYS;
+  const sceneHasRenderableContent =
+    mcap3dSceneSnapshotHasLayers(displayedScene) || depthRayLayers.length > 0;
+  const sceneRequiresPanel =
+    sceneHasRenderableContent || producedNotices.length > 0;
+  const shouldRenderPanel =
+    selectedTopics.length > 0 &&
+    (sceneRequiresPanel || panelHasCommittedRef.current);
+
+  // This layout effect records that source-backed scene content committed,
+  // allowing later source-loading transitions to keep WebGPU mounted.
+  useLayoutEffect(() => {
+    if (sceneHasRenderableContent) {
+      panelHasCommittedRef.current = true;
+    }
+  }, [sceneHasRenderableContent]);
   const prefetchFramePlacement = frameTransforms.prefetchPlacement;
 
   // This effect requests the transform window needed by a hovered camera ray.
@@ -1181,16 +1217,7 @@ const Mcap3dTile: React.FC<McapTileProps> = () => {
         <div className={styles.loading}>
           <span className={styles.emptyText}>No sources selected</span>
         </div>
-      ) : // Gate on the UNSTABILIZED notices: a live notice condition must keep
-      // the panel (and its GL canvas) mounted even while the stabilizer's
-      // appearance floor still hides it from the chip — otherwise short
-      // transform dropouts would flash the empty state and churn the canvas.
-      displayedScene.pointCloudLayers.length > 0 ||
-        displayedScene.annotationLayers.length > 0 ||
-        displayedScene.gridLayers.length > 0 ||
-        displayedScene.frustumLayers.length > 0 ||
-        depthRayLayers.length > 0 ||
-        producedNotices.length > 0 ? (
+      ) : shouldRenderPanel ? (
         <div className={styles.panelStack} {...hoverTooltipContainerProps}>
           <PointCloudPanel
             annotationLayers={displayedScene.annotationLayers}
@@ -1240,15 +1267,6 @@ function msToNs(value: number): bigint {
   return BigInt(Math.max(0, Math.round(value))) * 1_000_000n;
 }
 
-interface Mcap3dSceneSnapshot {
-  readonly annotationLayers: readonly SceneAnnotationPanelLayer[];
-  readonly frustumLayers: readonly CameraFrustumPanelLayer[];
-  readonly gridLayers: readonly GridPanelLayer[];
-  readonly notices: readonly McapHealthNotice[];
-  readonly placementStatus: Mcap3dPlacementStatus;
-  readonly pointCloudLayers: readonly PointCloudPanelLayer[];
-}
-
 function emptyMcap3dSceneSnapshot(
   placementStatus: Mcap3dPlacementStatus,
 ): Mcap3dSceneSnapshot {
@@ -1260,6 +1278,25 @@ function emptyMcap3dSceneSnapshot(
     placementStatus,
     pointCloudLayers: [],
   };
+}
+
+function mcap3dFrameTransformIdentityInputs(
+  transform: PointCloudPanelLayer["frameTransform"],
+): readonly unknown[] {
+  return transform
+    ? [
+        transform.resolutionKind,
+        transform.sourceFrameId,
+        transform.targetFrameId,
+        transform.translation.x,
+        transform.translation.y,
+        transform.translation.z,
+        transform.rotation.x,
+        transform.rotation.y,
+        transform.rotation.z,
+        transform.rotation.w,
+      ]
+    : [null];
 }
 
 const McapHeldSceneStatusBadge: React.FC<{

--- a/app/packages/multimodal/src/adapters/mcap/react/Mcap3dTile.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/Mcap3dTile.tsx
@@ -1094,7 +1094,7 @@ const Mcap3dTile: React.FC<McapTileProps> = () => {
   const sceneHasRenderableContent =
     mcap3dSceneSnapshotHasLayers(displayedScene) || depthRayLayers.length > 0;
   const sceneRequiresPanel =
-    sceneHasRenderableContent || producedNotices.length > 0;
+    sceneHasRenderableContent || displayedScene.notices.length > 0;
   const shouldRenderPanel =
     selectedTopics.length > 0 &&
     (sceneRequiresPanel || panelHasCommittedRef.current);

--- a/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.test.tsx
@@ -280,23 +280,23 @@ describe("McapSettingsSidebar", () => {
     expect(screen.queryByText("Performance diagnostics")).toBeNull();
   });
 
-  it("persists fidelity mode changes through the select", () => {
+  it("starts as-recorded and persists fidelity mode changes", () => {
     renderSidebar();
 
     const select = screen.getByLabelText(
       "Between messages",
     ) as HTMLSelectElement;
-    expect(select.value).toBe("smooth");
+    expect(select.value).toBe("as-recorded");
 
-    fireEvent.change(select, { target: { value: "as-recorded" } });
+    fireEvent.change(select, { target: { value: "smooth" } });
 
     expect(
       (screen.getByLabelText("Between messages") as HTMLSelectElement).value,
-    ).toBe("as-recorded");
+    ).toBe("smooth");
     expect(
-      JSON.parse(localStorage.getItem("fiftyone.mcap.modal-settings") ?? "{}")
+      JSON.parse(localStorage.getItem("fiftyone.mcap.modal-settings-1") ?? "{}")
         .fidelityMode,
-    ).toBe("as-recorded");
+    ).toBe("smooth");
   });
 
   it("collapses the advanced timing tuning by default", () => {

--- a/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.test.tsx
@@ -552,19 +552,32 @@ describe("McapSettingsSidebar", () => {
   });
 
   it("frames registered stream tiles with their status strip", () => {
-    renderSidebar({
-      registeredTileSettings: [LIDAR_TILE_ID],
-      registeredStreamTopics: ["/lidar/top"],
-    });
+    vi.useFakeTimers();
+    try {
+      renderSidebar({
+        registeredTileSettings: [LIDAR_TILE_ID],
+        registeredStreamTopics: ["/lidar/top"],
+      });
 
-    fireEvent.click(screen.getByTestId("focus-lidar"));
+      fireEvent.click(screen.getByTestId("focus-lidar"));
 
-    // No stream state has been written for the topic, so the strip
-    // surfaces the buffering notice above the tile's controls.
-    expect(screen.getByText(/Buffering/)).toBeTruthy();
-    expect(screen.getByTestId(PANEL_SETTINGS_TEST_ID).textContent).toBe(
-      "lidar registered knobs",
-    );
+      // No stream state has been written for the topic, but the strip waits
+      // out brief loading transitions so enabling a source cannot shift the
+      // controls down and immediately back up.
+      expect(screen.queryByText(/Buffering/)).toBeNull();
+      expect(screen.getByTestId(PANEL_SETTINGS_TEST_ID).textContent).toBe(
+        "lidar registered knobs",
+      );
+
+      act(() => {
+        vi.advanceTimersByTime(600);
+      });
+
+      // A sustained loading condition remains visible and actionable.
+      expect(screen.getByText(/Buffering/)).toBeTruthy();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("falls back to the DOM slot when switching to a portal tile", () => {

--- a/app/packages/multimodal/src/adapters/mcap/react/McapTileStreamState.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapTileStreamState.test.tsx
@@ -1,8 +1,13 @@
 import { PlaybackProvider, usePlaybackStore } from "@fiftyone/playback";
 import { act, cleanup, render, screen } from "@testing-library/react";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { McapTileEmptyState, McapTileStatusBadge } from "./McapTileStreamState";
+import {
+  McapTileEmptyState,
+  McapTileStatusBadge,
+  McapTileStreamNoticeStrip,
+} from "./McapTileStreamState";
+import { MCAP_NOTICE_APPEARANCE_FLOOR_MS } from "./mcap-health";
 import {
   setMcapTopicStartTimeSec,
   setMcapTopicStaleAgeNs,
@@ -10,6 +15,7 @@ import {
 } from "./mcap-stream-status-state";
 
 const TOPIC = "/camera";
+const SECOND_TOPIC = "/labels";
 
 afterEach(() => {
   cleanup();
@@ -64,6 +70,41 @@ describe("McapTileEmptyState", () => {
   });
 });
 
+describe("McapTileStreamNoticeStrip", () => {
+  it("suppresses a transient loading notice when a source is enabled", () => {
+    vi.useFakeTimers();
+    render(
+      <PlaybackProvider>
+        <StreamNoticeHarness />
+      </PlaybackProvider>,
+    );
+
+    act(() => screen.getByRole("button", { name: "Enable labels" }).click());
+    expect(screen.queryByText(/Buffering/)).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(MCAP_NOTICE_APPEARANCE_FLOOR_MS - 1);
+      screen.getByRole("button", { name: "Labels ready" }).click();
+      vi.advanceTimersByTime(1_000);
+    });
+    expect(screen.queryByText(/Buffering/)).toBeNull();
+  });
+
+  it("shows a loading notice that survives the appearance floor", () => {
+    vi.useFakeTimers();
+    render(
+      <PlaybackProvider>
+        <StreamNoticeHarness />
+      </PlaybackProvider>,
+    );
+
+    act(() => screen.getByRole("button", { name: "Enable labels" }).click());
+    act(() => vi.advanceTimersByTime(MCAP_NOTICE_APPEARANCE_FLOOR_MS));
+
+    expect(screen.getByText(/Buffering/)).toBeTruthy();
+  });
+});
+
 function SeedGap({ startSec }: { readonly startSec: number }) {
   const store = usePlaybackStore();
 
@@ -84,4 +125,28 @@ function SeedStaleBadge({ ageNs }: { readonly ageNs: bigint }) {
   }, [ageNs, store]);
 
   return <McapTileStatusBadge topics={[TOPIC]} />;
+}
+
+function StreamNoticeHarness() {
+  const store = usePlaybackStore();
+  const [topics, setTopics] = useState<readonly string[]>([TOPIC]);
+
+  useEffect(() => {
+    setMcapTopicStatus(store, TOPIC, "ready");
+  }, [store]);
+
+  return (
+    <>
+      <button onClick={() => setTopics([TOPIC, SECOND_TOPIC])} type="button">
+        Enable labels
+      </button>
+      <button
+        onClick={() => setMcapTopicStatus(store, SECOND_TOPIC, "ready")}
+        type="button"
+      >
+        Labels ready
+      </button>
+      <McapTileStreamNoticeStrip topics={topics} />
+    </>
+  );
 }

--- a/app/packages/multimodal/src/adapters/mcap/react/McapTileStreamState.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapTileStreamState.test.tsx
@@ -108,6 +108,7 @@ describe("McapTileStreamNoticeStrip", () => {
 function SeedGap({ startSec }: { readonly startSec: number }) {
   const store = usePlaybackStore();
 
+  // This effect seeds the playback state exercised by the empty-state view.
   useEffect(() => {
     setMcapTopicStatus(store, TOPIC, "gap");
     setMcapTopicStartTimeSec(store, TOPIC, startSec);
@@ -119,6 +120,7 @@ function SeedGap({ startSec }: { readonly startSec: number }) {
 function SeedStaleBadge({ ageNs }: { readonly ageNs: bigint }) {
   const store = usePlaybackStore();
 
+  // This effect seeds the stale frame displayed by the status badge.
   useEffect(() => {
     setMcapTopicStatus(store, TOPIC, "stale");
     setMcapTopicStaleAgeNs(store, TOPIC, ageNs);
@@ -131,6 +133,7 @@ function StreamNoticeHarness() {
   const store = usePlaybackStore();
   const [topics, setTopics] = useState<readonly string[]>([TOPIC]);
 
+  // This effect starts the existing source ready before toggling a new one.
   useEffect(() => {
     setMcapTopicStatus(store, TOPIC, "ready");
   }, [store]);

--- a/app/packages/multimodal/src/adapters/mcap/react/McapTileStreamState.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapTileStreamState.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import {
   buildMcapTileEmptyStateModel,
   buildMcapTileStreamNotice,
+  useStabilizedMcapNotices,
 } from "./mcap-health";
 import {
   useMcapTopicStartTimes,
@@ -73,7 +74,9 @@ export const McapTileStatusBadge: React.FC<{
  * The same per-topic stream summary as the corner badge, rendered as the
  * tile settings' status strip: buffering, gap, stale, and failure states
  * read identically whether the user is looking at the tile or its
- * settings. Renders nothing while every topic is current.
+ * settings. Brief state changes are stabilized so admitting a new source
+ * does not insert and immediately remove a card above the controls. Renders
+ * nothing while every topic is current.
  */
 export const McapTileStreamNoticeStrip: React.FC<{
   topics: readonly string[];
@@ -88,8 +91,9 @@ export const McapTileStreamNoticeStrip: React.FC<{
     statuses,
     topics: stableTopics,
   });
+  const notices = useStabilizedMcapNotices(notice ? [notice] : []);
 
-  return <McapNoticeStrip notices={notice ? [notice] : []} />;
+  return <McapNoticeStrip notices={notices} />;
 };
 
 /**

--- a/app/packages/multimodal/src/adapters/mcap/react/McapTileStreamState.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapTileStreamState.tsx
@@ -74,10 +74,8 @@ export const McapTileStatusBadge: React.FC<{
  * The same per-topic stream summary as the corner badge, rendered as the
  * tile settings' status strip: buffering, gap, stale, and failure states
  * read identically whether the user is looking at the tile or its
- * settings. Brief state changes are stabilized so admitting a new source
- * does not insert and immediately remove a card above the controls. Renders
- * nothing while every topic is current.
- */
+ * settings.
+ **/
 export const McapTileStreamNoticeStrip: React.FC<{
   topics: readonly string[];
 }> = ({ topics }) => {

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-3d-scene-snapshot.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-3d-scene-snapshot.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  restrictHeldMcap3dSceneSnapshotToTopics,
   selectMcap3dSceneSnapshot,
   type HeldMcap3dSceneSnapshot,
+  type Mcap3dSceneSnapshot,
 } from "./mcap-3d-scene-snapshot";
 
 const EMPTY = "empty";
@@ -89,12 +91,109 @@ describe("selectMcap3dSceneSnapshot", () => {
   });
 });
 
+describe("restrictHeldMcap3dSceneSnapshotToTopics", () => {
+  it("retains an existing scene while an additive source is pending", () => {
+    const snapshot = sceneSnapshot({ pointCloudTopics: ["lidar"] });
+    const held = sceneHeld(snapshot);
+
+    const restricted = restrictHeldMcap3dSceneSnapshotToTopics(
+      held,
+      new Set(["lidar", "boxes"]),
+    );
+    const selection = selectMcap3dSceneSnapshot({
+      current: sceneSnapshot(),
+      currentRetainable: false,
+      definitiveMissingGraceMs: GRACE_MS,
+      empty: sceneSnapshot(),
+      hasSourceData: true,
+      held: restricted,
+      key: KEY,
+      nowMs: 0,
+      readiness: "pending",
+    });
+
+    expect(restricted?.snapshot).toBe(snapshot);
+    expect(selection.snapshot).toBe(snapshot);
+    expect(selection.heldReason).toBe("pending");
+  });
+
+  it("removes a disabled source from a retained scene immediately", () => {
+    const snapshot = sceneSnapshot({
+      annotationTopics: ["boxes"],
+      pointCloudTopics: ["lidar", "radar"],
+    });
+
+    const restricted = restrictHeldMcap3dSceneSnapshotToTopics(
+      sceneHeld(snapshot),
+      new Set(["radar", "boxes"]),
+    );
+
+    expect(
+      restricted?.snapshot.pointCloudLayers.map((layer) => layer.id),
+    ).toEqual(["radar"]);
+    expect(
+      restricted?.snapshot.annotationLayers.map((layer) => layer.sourceId),
+    ).toEqual(["boxes"]);
+    expect(restricted?.retainable).toBe(true);
+  });
+
+  it("marks a retained scene empty after its final source is disabled", () => {
+    const restricted = restrictHeldMcap3dSceneSnapshotToTopics(
+      sceneHeld(sceneSnapshot({ gridTopics: ["map"] })),
+      new Set(),
+    );
+
+    expect(restricted?.snapshot.gridLayers).toEqual([]);
+    expect(restricted?.retainable).toBe(false);
+  });
+});
+
 function readyHeld(): HeldMcap3dSceneSnapshot<string> {
   return {
     definitiveMissingSinceMs: null,
     key: KEY,
     retainable: true,
     snapshot: READY,
+  };
+}
+
+function sceneHeld(
+  snapshot: Mcap3dSceneSnapshot,
+): HeldMcap3dSceneSnapshot<Mcap3dSceneSnapshot> {
+  return {
+    definitiveMissingSinceMs: null,
+    key: KEY,
+    retainable: true,
+    snapshot,
+  };
+}
+
+function sceneSnapshot({
+  annotationTopics = [],
+  gridTopics = [],
+  pointCloudTopics = [],
+}: {
+  readonly annotationTopics?: readonly string[];
+  readonly gridTopics?: readonly string[];
+  readonly pointCloudTopics?: readonly string[];
+} = {}): Mcap3dSceneSnapshot {
+  return {
+    annotationLayers: annotationTopics.map(
+      (sourceId) =>
+        ({
+          id: `${sourceId}:entity`,
+          sourceId,
+        }) as Mcap3dSceneSnapshot["annotationLayers"][number],
+    ),
+    frustumLayers: [],
+    gridLayers: gridTopics.map(
+      (id) => ({ id }) as Mcap3dSceneSnapshot["gridLayers"][number],
+    ),
+    notices: [],
+    placementStatus: "transformed",
+    pointCloudLayers: pointCloudTopics.map(
+      (id) => ({ id }) as Mcap3dSceneSnapshot["pointCloudLayers"][number],
+    ),
   };
 }
 

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-3d-scene-snapshot.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-3d-scene-snapshot.test.ts
@@ -120,12 +120,35 @@ describe("restrictHeldMcap3dSceneSnapshotToTopics", () => {
   it("removes a disabled source from a retained scene immediately", () => {
     const snapshot = sceneSnapshot({
       annotationTopics: ["boxes"],
+      frustumTopics: ["camera", "rear-camera"],
+      notices: [
+        {
+          id: "global",
+          message: "Global notice",
+          scope: "scene",
+          severity: "info",
+        },
+        {
+          id: "camera",
+          message: "Camera notice",
+          scope: "topic",
+          severity: "warning",
+          topicId: "camera",
+        },
+        {
+          id: "lidar",
+          message: "Lidar notice",
+          scope: "topic",
+          severity: "warning",
+          topicId: "lidar",
+        },
+      ],
       pointCloudTopics: ["lidar", "radar"],
     });
 
     const restricted = restrictHeldMcap3dSceneSnapshotToTopics(
       sceneHeld(snapshot),
-      new Set(["radar", "boxes"]),
+      new Set(["radar", "boxes", "camera"]),
     );
 
     expect(
@@ -134,6 +157,13 @@ describe("restrictHeldMcap3dSceneSnapshotToTopics", () => {
     expect(
       restricted?.snapshot.annotationLayers.map((layer) => layer.sourceId),
     ).toEqual(["boxes"]);
+    expect(restricted?.snapshot.frustumLayers.map((layer) => layer.id)).toEqual(
+      ["camera"],
+    );
+    expect(restricted?.snapshot.notices.map((notice) => notice.id)).toEqual([
+      "global",
+      "camera",
+    ]);
     expect(restricted?.retainable).toBe(true);
   });
 
@@ -170,11 +200,15 @@ function sceneHeld(
 
 function sceneSnapshot({
   annotationTopics = [],
+  frustumTopics = [],
   gridTopics = [],
+  notices = [],
   pointCloudTopics = [],
 }: {
   readonly annotationTopics?: readonly string[];
+  readonly frustumTopics?: readonly string[];
   readonly gridTopics?: readonly string[];
+  readonly notices?: Mcap3dSceneSnapshot["notices"];
   readonly pointCloudTopics?: readonly string[];
 } = {}): Mcap3dSceneSnapshot {
   return {
@@ -185,11 +219,13 @@ function sceneSnapshot({
           sourceId,
         }) as Mcap3dSceneSnapshot["annotationLayers"][number],
     ),
-    frustumLayers: [],
+    frustumLayers: frustumTopics.map(
+      (id) => ({ id }) as Mcap3dSceneSnapshot["frustumLayers"][number],
+    ),
     gridLayers: gridTopics.map(
       (id) => ({ id }) as Mcap3dSceneSnapshot["gridLayers"][number],
     ),
-    notices: [],
+    notices,
     placementStatus: "transformed",
     pointCloudLayers: pointCloudTopics.map(
       (id) => ({ id }) as Mcap3dSceneSnapshot["pointCloudLayers"][number],

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-3d-scene-snapshot.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-3d-scene-snapshot.ts
@@ -1,3 +1,12 @@
+import type {
+  CameraFrustumPanelLayer,
+  GridPanelLayer,
+  PointCloudPanelLayer,
+  SceneAnnotationPanelLayer,
+} from "../../../visualization/panels/point-cloud/types";
+import type { McapHealthNotice } from "./mcap-health";
+import type { Mcap3dPlacementStatus } from "./use-mcap-3d-camera-tracking";
+
 /** Placement state relevant to retaining the last valid 3D scene. */
 export type Mcap3dSceneSnapshotReadiness =
   | "ready"
@@ -21,6 +30,74 @@ export interface Mcap3dSceneSnapshotSelection<Snapshot> {
   readonly heldReason: Mcap3dHeldSceneReason | null;
   readonly nextHeld: HeldMcap3dSceneSnapshot<Snapshot> | null;
   readonly snapshot: Snapshot;
+}
+
+/** Renderable 3D scene state committed atomically across stream transitions. */
+export interface Mcap3dSceneSnapshot {
+  readonly annotationLayers: readonly SceneAnnotationPanelLayer[];
+  readonly frustumLayers: readonly CameraFrustumPanelLayer[];
+  readonly gridLayers: readonly GridPanelLayer[];
+  readonly notices: readonly McapHealthNotice[];
+  readonly placementStatus: Mcap3dPlacementStatus;
+  readonly pointCloudLayers: readonly PointCloudPanelLayer[];
+}
+
+/**
+ * Removes disabled sources from a held scene without disturbing layers that
+ * are still selected. This lets an additive source transition retain useful
+ * work while ensuring a source the user disabled disappears immediately.
+ */
+export function restrictHeldMcap3dSceneSnapshotToTopics(
+  held: HeldMcap3dSceneSnapshot<Mcap3dSceneSnapshot> | null,
+  selectedTopics: ReadonlySet<string>,
+): HeldMcap3dSceneSnapshot<Mcap3dSceneSnapshot> | null {
+  if (!held) return null;
+
+  const snapshot = held.snapshot;
+  const nextSnapshot: Mcap3dSceneSnapshot = {
+    annotationLayers: filterPreservingIdentity(
+      snapshot.annotationLayers,
+      (layer) =>
+        layer.sourceId === undefined || selectedTopics.has(layer.sourceId),
+    ),
+    frustumLayers: filterPreservingIdentity(snapshot.frustumLayers, (layer) =>
+      selectedTopics.has(layer.id),
+    ),
+    gridLayers: filterPreservingIdentity(snapshot.gridLayers, (layer) =>
+      selectedTopics.has(layer.id),
+    ),
+    notices: filterPreservingIdentity(
+      snapshot.notices,
+      (notice) =>
+        notice.topicId === undefined || selectedTopics.has(notice.topicId),
+    ),
+    placementStatus: snapshot.placementStatus,
+    pointCloudLayers: filterPreservingIdentity(
+      snapshot.pointCloudLayers,
+      (layer) => selectedTopics.has(layer.id),
+    ),
+  };
+  const retainable = mcap3dSceneSnapshotHasLayers(nextSnapshot);
+
+  return {
+    ...held,
+    retainable,
+    snapshot: sceneSnapshotArraysMatch(snapshot, nextSnapshot)
+      ? snapshot
+      : nextSnapshot,
+  };
+}
+
+/** Returns whether a 3D scene contains any source-backed render layers. */
+export function mcap3dSceneSnapshotHasLayers(
+  snapshot: Mcap3dSceneSnapshot,
+): boolean {
+  return (
+    snapshot.pointCloudLayers.length > 0 ||
+    snapshot.annotationLayers.length > 0 ||
+    snapshot.gridLayers.length > 0 ||
+    snapshot.frustumLayers.length > 0
+  );
 }
 
 /**
@@ -115,4 +192,25 @@ function committedSelection<Snapshot>(
     },
     snapshot,
   };
+}
+
+function filterPreservingIdentity<Item>(
+  items: readonly Item[],
+  predicate: (item: Item) => boolean,
+): readonly Item[] {
+  const filtered = items.filter(predicate);
+  return filtered.length === items.length ? items : filtered;
+}
+
+function sceneSnapshotArraysMatch(
+  first: Mcap3dSceneSnapshot,
+  second: Mcap3dSceneSnapshot,
+): boolean {
+  return (
+    first.annotationLayers === second.annotationLayers &&
+    first.frustumLayers === second.frustumLayers &&
+    first.gridLayers === second.gridLayers &&
+    first.notices === second.notices &&
+    first.pointCloudLayers === second.pointCloudLayers
+  );
 }

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-modal-settings-storage.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-modal-settings-storage.ts
@@ -138,12 +138,13 @@ export interface McapPersistedModalSettings {
   readonly temporalPolicy: McapTemporalPolicySettings;
 }
 
-const STORAGE_KEY = "fiftyone.mcap.modal-settings";
+const STORAGE_KEY = "fiftyone.mcap.modal-settings-1";
 
 /**
  * Default interpolation policy for newly initialized MCAP modal settings.
  */
-export const DEFAULT_MCAP_FIDELITY_MODE: McapPlaybackFidelityMode = "smooth";
+export const DEFAULT_MCAP_FIDELITY_MODE: McapPlaybackFidelityMode =
+  "as-recorded";
 
 const FIDELITY_MODES: readonly McapPlaybackFidelityMode[] = [
   "smooth",

--- a/app/packages/multimodal/src/adapters/mcap/react/mcap-modal-settings.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/mcap-modal-settings.test.tsx
@@ -530,7 +530,9 @@ describe("mcap-modal-settings", () => {
       </>,
     );
 
-    expect(screen.getByTestId("fidelity-mode").textContent).toBe("smooth");
+    expect(screen.getByTestId("fidelity-mode").textContent).toBe(
+      DEFAULT_MCAP_FIDELITY_MODE,
+    );
     const playbackRendersBeforeUpdate = playbackRenders;
     const sceneBackgroundRendersBeforeUpdate = sceneBackgroundRenders;
 

--- a/app/packages/multimodal/src/adapters/mcap/react/use-interpolated-scene-updates.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-interpolated-scene-updates.test.tsx
@@ -1,0 +1,63 @@
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useInterpolatedSceneUpdateFrames } from "./use-interpolated-scene-updates";
+
+const useOptionalPlayhead = vi.hoisted(() => vi.fn(() => 0));
+const dataStream = vi.hoisted(() => ({
+  getTimelineIndex: () => ({
+    nearestTick: () => 0n,
+    secToNs: () => 0n,
+  }),
+  getTopicCache: () => undefined,
+  sourceKey: "test-source",
+  subscribeToTopic: () => () => undefined,
+}));
+
+vi.mock("./use-optional-playhead", () => ({ useOptionalPlayhead }));
+vi.mock("./mcap-data-stream-context", () => ({
+  useMcapDataStream: () => dataStream,
+}));
+
+afterEach(() => {
+  cleanup();
+  useOptionalPlayhead.mockClear();
+});
+
+describe("useInterpolatedSceneUpdateFrames", () => {
+  it("does not subscribe to RAF playhead updates without annotation topics", () => {
+    renderHook(() =>
+      useInterpolatedSceneUpdateFrames({
+        frames: [],
+        interpolate: true,
+        topics: [],
+      }),
+    );
+
+    expect(useOptionalPlayhead).toHaveBeenLastCalledWith(false);
+  });
+
+  it("subscribes to RAF playhead updates for smooth annotation playback", () => {
+    renderHook(() =>
+      useInterpolatedSceneUpdateFrames({
+        frames: [],
+        interpolate: true,
+        topics: ["/annotations"],
+      }),
+    );
+
+    expect(useOptionalPlayhead).toHaveBeenLastCalledWith(true);
+  });
+
+  it("does not subscribe to RAF playhead updates in as-recorded mode", () => {
+    renderHook(() =>
+      useInterpolatedSceneUpdateFrames({
+        frames: [],
+        interpolate: false,
+        topics: ["/annotations"],
+      }),
+    );
+
+    expect(useOptionalPlayhead).toHaveBeenLastCalledWith(false);
+  });
+});

--- a/app/packages/multimodal/src/adapters/mcap/react/use-interpolated-scene-updates.ts
+++ b/app/packages/multimodal/src/adapters/mcap/react/use-interpolated-scene-updates.ts
@@ -41,9 +41,11 @@ export function useInterpolatedSceneUpdateFrames({
 }): readonly (McapTopicPlaybackFrame<SceneUpdateVisualization> | null)[] {
   const dataStream = useMcapDataStream();
   const history = useMcapSceneUpdateHistoryContext();
-  // Smooth mode tracks every RAF tick. As-recorded mode samples placement time
-  // only when its content-driven parent renders, avoiding a broad 60 Hz root.
-  const playhead = useOptionalPlayhead(interpolate);
+  // Smooth mode tracks every RAF tick only when there is annotation work to
+  // interpolate. Otherwise, sample placement time only when the content-driven
+  // parent renders, avoiding an empty high-frequency subscription.
+  const tracksPlayhead = interpolate && topics.length > 0;
+  const playhead = useOptionalPlayhead(tracksPlayhead);
   const timeline = dataStream?.getTimelineIndex() ?? null;
   // Late-arriving lookahead messages must re-derive the lifecycle snapshot and
   // lerp even while the playhead is paused mid-gap.
@@ -78,7 +80,7 @@ export function useInterpolatedSceneUpdateFrames({
   }, [cacheSnapshot, dataStream, frames, history, topics]);
 
   return useMemo(() => {
-    if (!interpolate || !dataStream || !timeline) {
+    if (!interpolate || topics.length === 0 || !dataStream || !timeline) {
       return resolvedFrames;
     }
 

--- a/app/packages/multimodal/src/adapters/mcap/reader.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/reader.test.ts
@@ -59,6 +59,117 @@ describe("MCAP indexed message times", () => {
     expect(exactReads).toEqual(reads);
   });
 
+  it("batches nearby requested ranges across an unselected index", async () => {
+    const cameraIndex = createMessageIndexRecord(7, [[10n, 1n]]);
+    const skippedIndex = createMessageIndexRecord(9, [[10n, 9n]]);
+    const lidarIndex = createMessageIndexRecord(8, [[11n, 2n]]);
+    const cameraOffset = 64n;
+    const skippedOffset = cameraOffset + BigInt(cameraIndex.byteLength);
+    const lidarOffset = skippedOffset + BigInt(skippedIndex.byteLength);
+    const { exactReads, readable } = createReadable([
+      { bytes: cameraIndex, offset: cameraOffset },
+      { bytes: skippedIndex, offset: skippedOffset },
+      { bytes: lidarIndex, offset: lidarOffset },
+    ]);
+    const reader = createReader({
+      chunkIndexes: [
+        createChunkIndex({
+          messageEndTime: 11n,
+          messageIndexLength: BigInt(
+            cameraIndex.byteLength +
+              skippedIndex.byteLength +
+              lidarIndex.byteLength,
+          ),
+          messageIndexOffsets: new Map([
+            [7, cameraOffset],
+            [9, skippedOffset],
+            [8, lidarOffset],
+          ]),
+          messageStartTime: 10n,
+        }),
+      ],
+    });
+
+    const entries = await collect(
+      readIndexedMessageTimesForReader(reader, readable, {
+        topics: ["/camera", "/lidar"],
+      }),
+    );
+
+    expect(
+      entries.map(({ logTimeNs, topic }) => ({ logTimeNs, topic })),
+    ).toEqual([
+      { logTimeNs: 10n, topic: "/camera" },
+      { logTimeNs: 11n, topic: "/lidar" },
+    ]);
+    expect(exactReads).toEqual([
+      {
+        offset: cameraOffset,
+        size: BigInt(
+          cameraIndex.byteLength +
+            skippedIndex.byteLength +
+            lidarIndex.byteLength,
+        ),
+      },
+    ]);
+  });
+
+  it("keeps sparse requested message index ranges in bounded reads", async () => {
+    const cameraIndex = createMessageIndexRecord(7, [[10n, 1n]]);
+    const skippedIndex = createMessageIndexRecord(
+      9,
+      Array.from(
+        { length: 4_096 },
+        (_, index) => [BigInt(index), BigInt(index)] as const,
+      ),
+    );
+    const lidarIndex = createMessageIndexRecord(8, [[11n, 2n]]);
+    const cameraOffset = 64n;
+    const skippedOffset = cameraOffset + BigInt(cameraIndex.byteLength);
+    const lidarOffset = skippedOffset + BigInt(skippedIndex.byteLength);
+    const { exactReads, readable } = createReadable([
+      { bytes: cameraIndex, offset: cameraOffset },
+      { bytes: skippedIndex, offset: skippedOffset },
+      { bytes: lidarIndex, offset: lidarOffset },
+    ]);
+    const reader = createReader({
+      chunkIndexes: [
+        createChunkIndex({
+          messageEndTime: 11n,
+          messageIndexLength: BigInt(
+            cameraIndex.byteLength +
+              skippedIndex.byteLength +
+              lidarIndex.byteLength,
+          ),
+          messageIndexOffsets: new Map([
+            [7, cameraOffset],
+            [9, skippedOffset],
+            [8, lidarOffset],
+          ]),
+          messageStartTime: 10n,
+        }),
+      ],
+    });
+
+    const entries = await collect(
+      readIndexedMessageTimesForReader(reader, readable, {
+        topics: ["/camera", "/lidar"],
+      }),
+    );
+
+    expect(entries.map((entry) => entry.topic)).toEqual(["/camera", "/lidar"]);
+    expect(exactReads).toEqual([
+      {
+        offset: cameraOffset,
+        size: BigInt(cameraIndex.byteLength),
+      },
+      {
+        offset: lidarOffset,
+        size: BigInt(lidarIndex.byteLength),
+      },
+    ]);
+  });
+
   it("stops after the limit for ordered chunks", async () => {
     const firstIndex = createMessageIndexRecord(7, [[10n, 1n]]);
     const secondIndex = createMessageIndexRecord(7, [[20n, 2n]]);

--- a/app/packages/multimodal/src/adapters/mcap/reader/message-index.ts
+++ b/app/packages/multimodal/src/adapters/mcap/reader/message-index.ts
@@ -22,6 +22,15 @@ const MESSAGE_INDEX_RECORD_READER_OPTIONS: NonNullable<
 };
 const MCAP_RECORD_HEADER_BYTES = 9;
 const MESSAGE_INDEX_CONTENT_HEADER_BYTES = 6;
+const MAX_MESSAGE_INDEX_BATCH_SPAN_BYTES = 64n * 1024n;
+
+interface MessageIndexRead {
+  readonly channel: McapTypes.TypedMcapRecords["Channel"];
+  readonly range: {
+    readonly length: bigint;
+    readonly offset: bigint;
+  };
+}
 
 /**
  * Reads ordered MCAP message times directly from chunk message-index records.
@@ -205,6 +214,7 @@ export async function readChunkIndexedMessageTimes({
   readonly startTimeNs: bigint | undefined;
 }): Promise<readonly McapIndexedMessageTime[]> {
   const entries: McapIndexedMessageTime[] = [];
+  const reads: MessageIndexRead[] = [];
 
   for (const channelId of channelIds) {
     const channel = reader.channelsById.get(channelId);
@@ -217,30 +227,83 @@ export async function readChunkIndexedMessageTimes({
       continue;
     }
 
-    const bytes = await readExactRange(readable, range.offset, range.length);
-    const messageIndex = parseMcapMessageIndexRecord(bytes);
-    if (messageIndex.channelId !== channelId) {
-      throw new Error(
-        `MCAP MessageIndex channel ${messageIndex.channelId} did not match expected channel ${channelId}`,
-      );
-    }
+    reads.push({ channel, range });
+  }
 
-    for (const [logTimeNs, messageOffset] of messageIndex.records) {
-      if (!isWithinIndexedRange(logTimeNs, startTimeNs, endTimeNs)) {
-        continue;
+  reads.sort((left, right) =>
+    compareBigInt(left.range.offset, right.range.offset),
+  );
+
+  for (const batch of batchMessageIndexReads(reads)) {
+    const batchEnd = batch.reduce((end, read) => {
+      const readEnd = read.range.offset + read.range.length;
+      return readEnd > end ? readEnd : end;
+    }, batch[0].range.offset);
+    const batchOffset = batch[0].range.offset;
+    const batchBytes = await readExactRange(
+      readable,
+      batchOffset,
+      batchEnd - batchOffset,
+    );
+
+    for (const { channel, range } of batch) {
+      const relativeOffset = Number(range.offset - batchOffset);
+      const relativeEnd = relativeOffset + Number(range.length);
+      const bytes = batchBytes.subarray(relativeOffset, relativeEnd);
+      const messageIndex = parseMcapMessageIndexRecord(bytes);
+      if (messageIndex.channelId !== channel.id) {
+        throw new Error(
+          `MCAP MessageIndex channel ${messageIndex.channelId} did not match expected channel ${channel.id}`,
+        );
       }
 
-      entries.push({
-        channelId,
-        chunkStartOffset: chunkIndex.chunkStartOffset,
-        logTimeNs,
-        messageOffset,
-        topic: channel.topic,
-      });
+      for (const [logTimeNs, messageOffset] of messageIndex.records) {
+        if (!isWithinIndexedRange(logTimeNs, startTimeNs, endTimeNs)) {
+          continue;
+        }
+
+        entries.push({
+          channelId: channel.id,
+          chunkStartOffset: chunkIndex.chunkStartOffset,
+          logTimeNs,
+          messageOffset,
+          topic: channel.topic,
+        });
+      }
     }
   }
 
   return entries.sort(compareIndexedMessageTimes);
+}
+
+/**
+ * Coalesces nearby selected MessageIndex records into bounded exact reads.
+ * The MCAP footer stores these records contiguously by chunk, so this avoids
+ * paying one remote round trip per active channel without turning sparse
+ * selections into an unbounded footer fetch.
+ */
+function batchMessageIndexReads(
+  reads: readonly MessageIndexRead[],
+): readonly (readonly MessageIndexRead[])[] {
+  const batches: MessageIndexRead[][] = [];
+
+  for (const read of reads) {
+    const batch = batches.at(-1);
+    if (!batch) {
+      batches.push([read]);
+      continue;
+    }
+
+    const span = read.range.offset + read.range.length - batch[0].range.offset;
+    if (span > MAX_MESSAGE_INDEX_BATCH_SPAN_BYTES) {
+      batches.push([read]);
+      continue;
+    }
+
+    batch.push(read);
+  }
+
+  return batches;
 }
 
 function readExactRange(

--- a/app/packages/multimodal/src/adapters/mcap/worker/playback-worker-types.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/playback-worker-types.ts
@@ -65,9 +65,9 @@ export type McapPlaybackWorkerPriority =
  */
 export type McapPlaybackWorkerFetchParameters = {
   /**
-   * Fill-slot class for this worker's remote block fills: the foreground
-   * playback lane declares "priority" (reserved slot access), idle and
-   * bulk lanes declare "background".
+   * Fill-slot class for this worker's remote block fills: interactive and
+   * foreground playback lanes declare "priority" (reserved slot access);
+   * idle and bulk lanes declare "background".
    */
   readonly fillSlotClass?: "background" | "priority";
   readonly headers: Record<string, string>;

--- a/app/packages/multimodal/src/adapters/mcap/worker/transport-meter.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/transport-meter.ts
@@ -7,7 +7,7 @@ import {
  * Worker lane a transport snapshot came from. Kept structural here so the
  * resource-client contract can reference it without importing worker internals.
  */
-export type McapTransportLane = "foreground" | "idle" | "bulk";
+export type McapTransportLane = "interactive" | "foreground" | "idle" | "bulk";
 
 /**
  * One lane's cumulative transport counters, forwarded to health listeners.

--- a/app/packages/multimodal/src/adapters/mcap/worker/worker-client.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/worker-client.test.ts
@@ -74,7 +74,7 @@ describe("worker-backed MCAP resource client", () => {
     });
 
     expect(onTransport).toHaveBeenCalledWith({
-      lane: "foreground",
+      lane: "interactive",
       snapshot,
     });
 
@@ -287,7 +287,7 @@ describe("worker-backed MCAP resource client", () => {
     await expect(windows).resolves.toEqual([]);
   });
 
-  it("uses a separate foreground worker while idle-prefetch work is pending", async () => {
+  it("uses a separate interactive worker while idle-prefetch work is pending", async () => {
     const { client, workers } = createClientHarness();
     const source = createSource("source:1");
 
@@ -316,6 +316,12 @@ describe("worker-backed MCAP resource client", () => {
       priority: MCAP_PLAYBACK_WORKER_PRIORITY.CURRENT_FRAME,
       type: "readSynchronizedMessages",
     });
+    expect(workers[1].messages[0]).toMatchObject({
+      payload: {
+        fillSlotClass: "priority",
+      },
+      type: "init",
+    });
 
     const currentWindow = createSynchronizedWindow(1n);
     workers[1].respond({ id: 1, ok: true, result: currentWindow });
@@ -323,6 +329,56 @@ describe("worker-backed MCAP resource client", () => {
 
     workers[0].respond({ id: 1, ok: true, result: [] });
     await expect(idle).resolves.toEqual([]);
+  });
+
+  it("admits a current frame while foreground playback is unresolved", async () => {
+    const { client, workers } = createClientHarness();
+    const source = createSource("source:1");
+    const playback = client.readSynchronizedMessageBatch({
+      timeNs: [1n, 2n],
+      source,
+      topics: ["/camera"],
+    });
+    const current = client.readSynchronizedMessages({
+      timeNs: 1n,
+      source,
+      topics: ["/labels"],
+    });
+
+    expect(workers).toHaveLength(2);
+    expect(workers[0].messages).toEqual([
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          fillSlotClass: "priority",
+        }),
+        type: "init",
+      }),
+      expect.objectContaining({
+        id: 1,
+        priority: MCAP_PLAYBACK_WORKER_PRIORITY.PLAYBACK_BATCH,
+        type: "readSynchronizedMessageBatch",
+      }),
+    ]);
+    expect(workers[1].messages).toEqual([
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          fillSlotClass: "priority",
+        }),
+        type: "init",
+      }),
+      expect.objectContaining({
+        id: 1,
+        priority: MCAP_PLAYBACK_WORKER_PRIORITY.CURRENT_FRAME,
+        type: "readSynchronizedMessages",
+      }),
+    ]);
+
+    const currentWindow = createSynchronizedWindow(1n);
+    workers[1].respond({ id: 1, ok: true, result: currentWindow });
+    await expect(current).resolves.toEqual(currentWindow);
+
+    workers[0].respond({ id: 1, ok: true, result: [] });
+    await expect(playback).resolves.toEqual([]);
   });
 
   it("keeps workers warm and fails stale reads under explicit ownership", async () => {

--- a/app/packages/multimodal/src/adapters/mcap/worker/worker-client.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/worker-client.ts
@@ -4,6 +4,7 @@ import { mcapPlaybackWorkerOperation } from "./playback-worker-rpc";
 import { McapPlaybackWorkerTransport } from "./playback-worker-transport";
 import type {
   McapLaneTransportSnapshot,
+  McapTransportLane,
   McapTransportSnapshot,
 } from "./transport-meter";
 import { workerFetchParameters } from "./worker-resource-client";
@@ -44,10 +45,8 @@ import type {
 } from "../types";
 import type { StreamInventory } from "../../../schemas/v1";
 
-type WorkerLaneName = "interactive" | "foreground" | "idle" | "bulk";
-
 type WorkerLane = {
-  readonly name: WorkerLaneName;
+  readonly name: McapTransportLane;
   readonly transport: McapPlaybackWorkerTransport;
   worker?: Worker;
 };
@@ -387,7 +386,7 @@ class WorkerMcapResourceClient implements McapResourceClient {
     });
   }
 
-  private createLane(name: WorkerLaneName): WorkerLane {
+  private createLane(name: McapTransportLane): WorkerLane {
     return {
       name,
       transport: new McapPlaybackWorkerTransport(
@@ -398,7 +397,7 @@ class WorkerMcapResourceClient implements McapResourceClient {
   }
 
   private emitTransport(
-    lane: WorkerLaneName,
+    lane: McapTransportLane,
     snapshot: McapTransportSnapshot,
   ): void {
     if (this.transportListeners.size === 0) {

--- a/app/packages/multimodal/src/adapters/mcap/worker/worker-client.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/worker-client.ts
@@ -44,7 +44,7 @@ import type {
 } from "../types";
 import type { StreamInventory } from "../../../schemas/v1";
 
-type WorkerLaneName = "foreground" | "idle" | "bulk";
+type WorkerLaneName = "interactive" | "foreground" | "idle" | "bulk";
 
 type WorkerLane = {
   readonly name: WorkerLaneName;
@@ -79,10 +79,12 @@ class WorkerMcapResourceClient implements McapResourceClient {
   private readonly transportListeners = new Set<
     (sample: McapLaneTransportSnapshot) => void
   >();
+  private readonly interactiveLane = this.createLane("interactive");
   private readonly foregroundLane = this.createLane("foreground");
   private readonly idleLane = this.createLane("idle");
   private readonly bulkLane = this.createLane("bulk");
   private readonly lanes = [
+    this.interactiveLane,
     this.foregroundLane,
     this.idleLane,
     this.bulkLane,
@@ -322,6 +324,9 @@ class WorkerMcapResourceClient implements McapResourceClient {
     if (priority === MCAP_PLAYBACK_WORKER_PRIORITY.IDLE_PREFETCH) {
       return this.idleLane;
     }
+    if (priority === MCAP_PLAYBACK_WORKER_PRIORITY.CURRENT_FRAME) {
+      return this.interactiveLane;
+    }
     return this.foregroundLane;
   }
 
@@ -346,9 +351,13 @@ class WorkerMcapResourceClient implements McapResourceClient {
       const initRequest: McapPlaybackWorkerRequest = {
         payload: {
           ...workerFetchParameters(),
-          // Only the foreground lane serves playback-critical reads; the
-          // idle and bulk lanes must never occupy the reserved fill slot.
-          fillSlotClass: lane.name === "foreground" ? "priority" : "background",
+          // Current-frame and ordinary foreground playback remain eligible
+          // for priority fill slots. Idle and bulk work cannot occupy the
+          // reserved slot while either user-visible lane needs the link.
+          fillSlotClass:
+            lane.name === "interactive" || lane.name === "foreground"
+              ? "priority"
+              : "background",
         },
         type: "init",
       };


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

- Cuts remote MCAP index round trips by batching nearby footer records and gives current-frame reads a dedicated worker lane.
- Avoids empty interpolation work and keeps rendered 3D scenes and canvases stable while sources are enabled or disabled.
- Defaults modal playback fidelity to as-recorded and rotates the persisted settings key so the previous smooth default does not carry forward.

## 🧪 How is this patch tested? If it is not, please explain why.

Unit tests

## Notes to Reviewer

Best reviewed commit-by-commit. The settings-key change intentionally reapplies the new as-recorded default to existing clients.

## High Level Architecture

- The reader coalesces selected message-index records into exact reads capped at a 64 KiB span.
- The worker client routes current-frame requests through an interactive lane separate from foreground playback batches.
- The 3D tile retains per-topic scene snapshots and committed panel state across source transitions.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

MCAP playback now defaults to as-recorded fidelity. The 3D view also stays mounted and retains selected scene content while sources load or are toggled.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

- **New Features**
  - Current-frame MCAP requests now use an additional **interactive** priority lane.
  - MCAP playback defaults to **“As recorded”** for newly initialized settings.

- **Improvements**
  - 3D panels render more consistently, with steadier identity and scene snapshot handling.
  - Retained 3D scenes are restricted/pruned immediately when topics are disabled.
  - More efficient MCAP message-index reading with fewer bounded fetches.

- **Bug Fixes**
  - Buffering/loading notices now follow the intended timed appearance.
  - Smooth interpolation updates are skipped when no topics are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3447
<!-- enterprise-sync-pr:end -->