### PR TITLE
fix(annotation): render annotate-sidebar date pickers in the app timezone

### DIFF
--- a/app/packages/components/src/components/SmartForm/RJSF/widgets/DatePickerWidget.tsx
+++ b/app/packages/components/src/components/SmartForm/RJSF/widgets/DatePickerWidget.tsx
@@ -1,5 +1,8 @@
+import { useTimeZone } from "@fiftyone/state";
+import { serializeDateValue, toPickerDate } from "@fiftyone/utilities";
 import { WidgetProps } from "@rjsf/utils";
 import { DatePicker, FormField } from "@voxel51/voodo";
+import { useMemo } from "react";
 
 export default function DatePickerWidget(props: WidgetProps) {
   const {
@@ -12,17 +15,33 @@ export default function DatePickerWidget(props: WidgetProps) {
     options,
   } = props;
 
+  const timeZone = useTimeZone();
   const dateOnly = !!options?.dateOnly;
+  const type = dateOnly ? "date" : "datetime";
+
+  // form data holds an ISO instant string; render it as the wall clock the
+  // app displays for the field (UTC calendar date for date fields, the app
+  // timezone for datetime fields)
+  const selected = useMemo(() => {
+    if (typeof value !== "string" || !value) return null;
+    const timestamp = new Date(value).getTime();
+    if (Number.isNaN(timestamp)) return null;
+    return toPickerDate(type, timestamp, timeZone);
+  }, [value, type, timeZone]);
 
   const inputComponent = (
     <DatePicker
       disabled={disabled || readonly}
       autoFocus={autofocus}
-      selected={value}
+      selected={selected}
       showTimeSelect={!dateOnly}
       onChange={(date: Date | null) => {
         if (date && !Number.isNaN(date.getTime())) {
-          onChange(date.toISOString());
+          try {
+            onChange(serializeDateValue(type, date, timeZone));
+          } catch (error) {
+            console.warn("unserializable date", date, error);
+          }
         } else {
           onChange(undefined);
         }

--- a/app/packages/components/src/components/SmartForm/RJSF/widgets/DatePickerWidget.tsx
+++ b/app/packages/components/src/components/SmartForm/RJSF/widgets/DatePickerWidget.tsx
@@ -6,8 +6,9 @@ import { useCallback, useMemo } from "react";
 
 /**
  * Form data carries dates as ISO instant strings. The picker renders and
- * edits them as the wall clock the app displays for the field: the UTC
- * calendar date for date fields, the app timezone for datetime fields.
+ * edits them as the local date and time the app displays for the field:
+ * the UTC calendar date for date fields, the time in the app timezone for
+ * datetime fields.
  */
 export default function DatePickerWidget(props: WidgetProps) {
   const { label, value, disabled, readonly, autofocus, onChange, options } =

--- a/app/packages/components/src/components/SmartForm/RJSF/widgets/DatePickerWidget.tsx
+++ b/app/packages/components/src/components/SmartForm/RJSF/widgets/DatePickerWidget.tsx
@@ -2,52 +2,63 @@ import { useTimeZone } from "@fiftyone/state";
 import { serializeDateValue, toPickerDate } from "@fiftyone/utilities";
 import { WidgetProps } from "@rjsf/utils";
 import { DatePicker, FormField } from "@voxel51/voodo";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 
+/**
+ * Form data carries dates as ISO instant strings. The picker renders and
+ * edits them as the wall clock the app displays for the field: the UTC
+ * calendar date for date fields, the app timezone for datetime fields.
+ */
 export default function DatePickerWidget(props: WidgetProps) {
-  const {
-    label,
-    value,
-    disabled,
-    readonly,
-    autofocus,
-    onChange = () => {},
-    options,
-  } = props;
+  const { label, value, disabled, readonly, autofocus, onChange, options } =
+    props;
 
   const timeZone = useTimeZone();
-  const dateOnly = !!options?.dateOnly;
-  const type = dateOnly ? "date" : "datetime";
+  const type = options?.dateOnly ? "date" : "datetime";
 
-  // form data holds an ISO instant string; render it as the wall clock the
-  // app displays for the field (UTC calendar date for date fields, the app
-  // timezone for datetime fields)
   const selected = useMemo(() => {
-    if (typeof value !== "string" || !value) return null;
-    const timestamp = new Date(value).getTime();
-    if (Number.isNaN(timestamp)) return null;
-    return toPickerDate(type, timestamp, timeZone);
+    const timestamp =
+      typeof value === "string" ? Date.parse(value) : Number.NaN;
+    if (Number.isNaN(timestamp)) {
+      return null;
+    }
+
+    try {
+      return toPickerDate(type, timestamp, timeZone);
+    } catch (error) {
+      console.warn("unrenderable date", value, error);
+      return null;
+    }
   }, [value, type, timeZone]);
 
-  const inputComponent = (
-    <DatePicker
-      disabled={disabled || readonly}
-      autoFocus={autofocus}
-      selected={selected}
-      showTimeSelect={!dateOnly}
-      onChange={(date: Date | null) => {
-        if (date && !Number.isNaN(date.getTime())) {
-          try {
-            onChange(serializeDateValue(type, date, timeZone));
-          } catch (error) {
-            console.warn("unserializable date", date, error);
-          }
-        } else {
-          onChange(undefined);
-        }
-      }}
-    />
+  const handleChange = useCallback(
+    (date: Date | null) => {
+      if (!date || Number.isNaN(date.getTime())) {
+        onChange(undefined);
+        return;
+      }
+
+      try {
+        onChange(serializeDateValue(type, date, timeZone));
+      } catch (error) {
+        console.warn("unserializable date", date, error);
+      }
+    },
+    [onChange, type, timeZone],
   );
 
-  return <FormField control={inputComponent} label={label} />;
+  return (
+    <FormField
+      label={label}
+      control={
+        <DatePicker
+          disabled={disabled || readonly}
+          autoFocus={autofocus}
+          selected={selected}
+          showTimeSelect={type === "datetime"}
+          onChange={handleChange}
+        />
+      }
+    />
+  );
 }

--- a/app/packages/core/package.json
+++ b/app/packages/core/package.json
@@ -35,7 +35,6 @@
         "json-edit-react": "^1.28.2",
         "lodash": "^4.18.1",
         "lru-cache": "^11.0.1",
-        "luxon": "^3.6.1",
         "numeral": "^2.0.6",
         "re-resizable": "^6.9.17",
         "react-color": "^2.19.3",
@@ -64,7 +63,6 @@
     },
     "devDependencies": {
         "@types/lodash": "^4.14.182",
-        "@types/luxon": "^3.6.2",
         "@types/mime": "^2.0.3",
         "@types/react-color": "^3.0.6",
         "@types/react-grid-layout": "^1.3.5",

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/PrimitiveEdit.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/PrimitiveEdit.tsx
@@ -4,9 +4,11 @@ import {
   KnownContexts,
   useCreateCommand,
 } from "@fiftyone/commands";
+import * as fos from "@fiftyone/state";
 import { isNullish, Primitive, Sample } from "@fiftyone/utilities";
 import { Orientation, Stack } from "@voxel51/voodo";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useRecoilValue } from "recoil";
 import PrimitiveRenderer from "./PrimitiveRenderer";
 import { generatePrimitiveSchema, PrimitiveSchema } from "./schemaHelpers";
 import {
@@ -28,17 +30,18 @@ export default function PrimitiveEdit({
 
   const sample = useSampleInstance();
   const value = useSampleSelector((s) => s.getResolved<Primitive>(path));
+  const timeZone = useRecoilValue(fos.timeZone);
 
   const primitiveSchema = generatePrimitiveSchema(path, currentLabelSchema);
 
   const [fieldValue, setFieldValue] = useState<Primitive | Date>(
-    parseDatabaseValue(type, value),
+    parseDatabaseValue(type, value, timeZone),
   );
 
   // synchronize external value changes with field
   useEffect(
-    () => setFieldValue(parseDatabaseValue(type, value)),
-    [type, value],
+    () => setFieldValue(parseDatabaseValue(type, value, timeZone)),
+    [type, value, timeZone],
   );
 
   // need to use a ref to access field value in command callback;
@@ -59,7 +62,11 @@ export default function PrimitiveEdit({
         // stage mutation on execute
         () => {
           try {
-            const serializedValue = serializeFieldValue(newValue, type);
+            const serializedValue = serializeFieldValue(
+              newValue,
+              type,
+              timeZone,
+            );
             if (
               !isAddOperation &&
               (isNullish(serializedValue) || serializedValue === "")
@@ -87,7 +94,7 @@ export default function PrimitiveEdit({
           }
         },
       );
-    }, [path, sample, type, value]),
+    }, [path, sample, type, value, timeZone]),
     () => true,
   );
 

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/PrimitiveEdit.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/PrimitiveEdit.tsx
@@ -4,7 +4,6 @@ import {
   KnownContexts,
   useCreateCommand,
 } from "@fiftyone/commands";
-import { useTimeZone } from "@fiftyone/state";
 import { isNullish, Primitive, Sample } from "@fiftyone/utilities";
 import { Orientation, Stack } from "@voxel51/voodo";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -29,23 +28,19 @@ export default function PrimitiveEdit({
 
   const sample = useSampleInstance();
   const value = useSampleSelector((s) => s.getResolved<Primitive>(path));
-  const timeZone = useTimeZone();
 
   const primitiveSchema = generatePrimitiveSchema(path, currentLabelSchema);
 
-  const [fieldValue, setFieldValue] = useState<Primitive | Date>(
-    parseDatabaseValue(type, value, timeZone),
+  const [fieldValue, setFieldValue] = useState<Primitive>(
+    parseDatabaseValue(value),
   );
 
   // synchronize external value changes with field
-  useEffect(
-    () => setFieldValue(parseDatabaseValue(type, value, timeZone)),
-    [type, value, timeZone],
-  );
+  useEffect(() => setFieldValue(parseDatabaseValue(value)), [value]);
 
   // need to use a ref to access field value in command callback;
   // command will run before the next render loop when `fieldValue` is updated.
-  const transientFieldValue = useRef<Primitive>(fieldValue as Primitive);
+  const transientFieldValue = useRef<Primitive>(fieldValue);
 
   // undoable command which handles primitive edits
   const editCommand = useCreateCommand(
@@ -61,11 +56,7 @@ export default function PrimitiveEdit({
         // stage mutation on execute
         () => {
           try {
-            const serializedValue = serializeFieldValue(
-              newValue,
-              type,
-              timeZone,
-            );
+            const serializedValue = serializeFieldValue(newValue, type);
             if (
               !isAddOperation &&
               (isNullish(serializedValue) || serializedValue === "")
@@ -93,7 +84,7 @@ export default function PrimitiveEdit({
           }
         },
       );
-    }, [path, sample, type, value, timeZone]),
+    }, [path, sample, type, value]),
     () => true,
   );
 

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/PrimitiveEdit.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/PrimitiveEdit.tsx
@@ -4,11 +4,10 @@ import {
   KnownContexts,
   useCreateCommand,
 } from "@fiftyone/commands";
-import * as fos from "@fiftyone/state";
+import { useTimeZone } from "@fiftyone/state";
 import { isNullish, Primitive, Sample } from "@fiftyone/utilities";
 import { Orientation, Stack } from "@voxel51/voodo";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useRecoilValue } from "recoil";
 import PrimitiveRenderer from "./PrimitiveRenderer";
 import { generatePrimitiveSchema, PrimitiveSchema } from "./schemaHelpers";
 import {
@@ -30,7 +29,7 @@ export default function PrimitiveEdit({
 
   const sample = useSampleInstance();
   const value = useSampleSelector((s) => s.getResolved<Primitive>(path));
-  const timeZone = useRecoilValue(fos.timeZone);
+  const timeZone = useTimeZone();
 
   const primitiveSchema = generatePrimitiveSchema(path, currentLabelSchema);
 

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/PrimitiveRenderer.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/PrimitiveRenderer.tsx
@@ -1,6 +1,5 @@
 import type { SchemaType } from "@fiftyone/core/src/plugins/SchemaIO/utils/types";
 import { Primitive } from "@fiftyone/utilities";
-import { DatePicker } from "@voxel51/voodo";
 import styled from "styled-components";
 import { SchemaIOComponent } from "../../../../../plugins/SchemaIO";
 import JSONEditor, {
@@ -15,7 +14,7 @@ const EditorContainer = styled.div`
 
 interface PrimitiveRendererProps {
   type: string;
-  fieldValue: Primitive | Date;
+  fieldValue: Primitive;
   handleChange: (data: unknown) => void;
   primitiveSchema: SchemaType | undefined;
 }
@@ -27,7 +26,6 @@ export default function PrimitiveRenderer({
   primitiveSchema,
 }: PrimitiveRendererProps) {
   const isJson = type === "dict";
-  const isDate = type === "date" || type === "datetime";
   if (isJson) {
     return (
       <EditorContainer>
@@ -39,22 +37,6 @@ export default function PrimitiveRenderer({
           showDocumentation={false}
         />
       </EditorContainer>
-    );
-  }
-
-  if (isDate) {
-    return (
-      <DatePicker
-        selected={fieldValue as Date}
-        showTimeSelect={type === "datetime"}
-        onChange={(date: Date | null) => {
-          if (date && !Number.isNaN(date.getTime())) {
-            handleChange(date.toISOString());
-          } else {
-            handleChange(undefined);
-          }
-        }}
-      />
     );
   }
 

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/serialization.test.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/serialization.test.ts
@@ -1,153 +1,45 @@
-import { DateTime } from "luxon";
 import { describe, expect, it } from "vitest";
-import {
-  dateOnlyToUTC,
-  parseDatabaseValue,
-  serializeDateValue,
-  serializeFieldValue,
-  toPickerDate,
-} from "./serialization";
-
-// midnight UTC, July 22 2026 — how a `date` field value is stored
-const JULY_22_DATE_MS = Date.UTC(2026, 6, 22);
+import { parseDatabaseValue, serializeFieldValue } from "./serialization";
 
 // an arbitrary instant: 2026-07-22T00:30:00Z
 const INSTANT_MS = Date.UTC(2026, 6, 22, 0, 30);
 
-describe("toPickerDate", () => {
-  it("preserves the UTC calendar date for date fields in any local timezone", () => {
-    const picker = toPickerDate("date", JULY_22_DATE_MS, "UTC");
-    expect(picker.getFullYear()).toBe(2026);
-    expect(picker.getMonth()).toBe(6);
-    expect(picker.getDate()).toBe(22);
-  });
-
-  it("shows datetime fields as the wall clock in the app timezone", () => {
-    // 2026-07-22T00:30Z is 2026-07-21T20:30 in New York (EDT)
-    const picker = toPickerDate("datetime", INSTANT_MS, "America/New_York");
-    expect(picker.getFullYear()).toBe(2026);
-    expect(picker.getMonth()).toBe(6);
-    expect(picker.getDate()).toBe(21);
-    expect(picker.getHours()).toBe(20);
-    expect(picker.getMinutes()).toBe(30);
-  });
-
-  it("shows datetime fields as the UTC wall clock for the default timezone", () => {
-    const picker = toPickerDate("datetime", INSTANT_MS, "UTC");
-    expect(picker.getFullYear()).toBe(2026);
-    expect(picker.getMonth()).toBe(6);
-    expect(picker.getDate()).toBe(22);
-    expect(picker.getHours()).toBe(0);
-    expect(picker.getMinutes()).toBe(30);
-  });
-});
-
-describe("serializeDateValue", () => {
-  it("stores date fields at noon UTC of the picked calendar date", () => {
-    const picker = toPickerDate("date", JULY_22_DATE_MS, "UTC");
-    expect(serializeDateValue("date", picker, "UTC")).toBe(
-      "2026-07-22T12:00:00.000Z",
-    );
-  });
-
-  it("interprets datetime picker values in the app timezone", () => {
-    const picker = toPickerDate("datetime", INSTANT_MS, "America/New_York");
-    expect(serializeDateValue("datetime", picker, "America/New_York")).toBe(
-      new Date(INSTANT_MS).toISOString(),
-    );
-  });
-
-  it("round-trips datetime values through the picker in UTC", () => {
-    const picker = toPickerDate("datetime", INSTANT_MS, "UTC");
-    expect(serializeDateValue("datetime", picker, "UTC")).toBe(
-      new Date(INSTANT_MS).toISOString(),
-    );
-  });
-
-  it("throws on an invalid timezone instead of returning null", () => {
-    const picker = new Date(INSTANT_MS);
-    expect(() => serializeDateValue("datetime", picker, "Not/AZone")).toThrow(
-      "invalid date or timezone",
-    );
-  });
-});
-
-describe("dateOnlyToUTC", () => {
-  it("keeps the same calendar date when re-parsed", () => {
-    const picker = toPickerDate("date", JULY_22_DATE_MS, "UTC");
-    const stored = dateOnlyToUTC(picker);
-    const roundTripped = toPickerDate(
-      "date",
-      new Date(stored).getTime(),
-      "UTC",
-    );
-    expect(roundTripped.getDate()).toBe(picker.getDate());
-    expect(roundTripped.getMonth()).toBe(picker.getMonth());
-    expect(roundTripped.getFullYear()).toBe(picker.getFullYear());
-  });
-});
-
 describe("parseDatabaseValue", () => {
-  it("converts database date wrappers to picker dates", () => {
-    const parsed = parseDatabaseValue(
-      "date",
-      { _cls: "DateTime", datetime: JULY_22_DATE_MS },
-      "UTC",
-    );
-    expect(parsed).toBeInstanceOf(Date);
-    expect((parsed as Date).getDate()).toBe(22);
-  });
-
-  it("converts transient ISO strings to picker dates", () => {
-    const parsed = parseDatabaseValue(
-      "datetime",
-      new Date(INSTANT_MS).toISOString(),
-      "America/New_York",
-    );
-    expect(parsed).toBeInstanceOf(Date);
-    expect((parsed as Date).getDate()).toBe(21);
-    expect((parsed as Date).getHours()).toBe(20);
+  it("converts database date wrappers to ISO instant strings", () => {
+    const parsed = parseDatabaseValue({
+      _cls: "DateTime",
+      datetime: INSTANT_MS,
+    });
+    expect(parsed).toBe(new Date(INSTANT_MS).toISOString());
   });
 
   it("returns non-date values unchanged", () => {
-    expect(parseDatabaseValue("str", "hello", "UTC")).toBe("hello");
-    expect(parseDatabaseValue("int", 5, "UTC")).toBe(5);
+    expect(parseDatabaseValue("hello")).toBe("hello");
+    expect(parseDatabaseValue(5)).toBe(5);
   });
 
-  it("returns invalid date strings unchanged", () => {
-    expect(parseDatabaseValue("datetime", "not a date", "UTC")).toBe(
-      "not a date",
-    );
+  it("returns transient ISO strings unchanged", () => {
+    const iso = new Date(INSTANT_MS).toISOString();
+    expect(parseDatabaseValue(iso)).toBe(iso);
   });
 });
 
 describe("serializeFieldValue", () => {
-  it("round-trips a datetime edit end to end in a non-UTC app timezone", () => {
-    const zone = "America/New_York";
-    const parsed = parseDatabaseValue(
-      "datetime",
-      { _cls: "DateTime", datetime: INSTANT_MS },
-      zone,
-    ) as Date;
-    // simulate the user picking a new time on the previous local day
-    const picked = new Date(parsed);
-    picked.setHours(9, 15, 0, 0);
-    const stored = serializeFieldValue(picked, "datetime", zone);
-    expect(stored).toBe(
-      DateTime.fromObject(
-        { year: 2026, month: 7, day: 21, hour: 9, minute: 15 },
-        { zone },
-      )
-        .toUTC()
-        .toISO(),
-    );
-  });
-
-  it("passes non-date primitives through", () => {
-    expect(serializeFieldValue(3.14, "float", "UTC")).toBe(3.14);
+  it("passes non-dict primitives through", () => {
+    expect(serializeFieldValue(3.14, "float")).toBe(3.14);
+    const iso = new Date(INSTANT_MS).toISOString();
+    expect(serializeFieldValue(iso, "datetime")).toBe(iso);
   });
 
   it("parses dict fields from JSON strings", () => {
-    expect(serializeFieldValue('{"a": 1}', "dict", "UTC")).toEqual({ a: 1 });
+    expect(serializeFieldValue('{"a": 1}', "dict")).toEqual({ a: 1 });
+  });
+
+  it("returns null for empty dict fields", () => {
+    expect(serializeFieldValue("  ", "dict")).toBe(null);
+  });
+
+  it("throws on invalid JSON for dict fields", () => {
+    expect(() => serializeFieldValue("{nope", "dict")).toThrow("Invalid JSON");
   });
 });

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/serialization.test.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/serialization.test.ts
@@ -1,0 +1,146 @@
+import { DateTime } from "luxon";
+import { describe, expect, it } from "vitest";
+import {
+  dateOnlyToUTC,
+  parseDatabaseValue,
+  serializeDateValue,
+  serializeFieldValue,
+  toPickerDate,
+} from "./serialization";
+
+// midnight UTC, July 22 2026 — how a `date` field value is stored
+const JULY_22_DATE_MS = Date.UTC(2026, 6, 22);
+
+// an arbitrary instant: 2026-07-22T00:30:00Z
+const INSTANT_MS = Date.UTC(2026, 6, 22, 0, 30);
+
+describe("toPickerDate", () => {
+  it("preserves the UTC calendar date for date fields in any local timezone", () => {
+    const picker = toPickerDate("date", JULY_22_DATE_MS, "UTC");
+    expect(picker.getFullYear()).toBe(2026);
+    expect(picker.getMonth()).toBe(6);
+    expect(picker.getDate()).toBe(22);
+  });
+
+  it("shows datetime fields as the wall clock in the app timezone", () => {
+    // 2026-07-22T00:30Z is 2026-07-21T20:30 in New York (EDT)
+    const picker = toPickerDate("datetime", INSTANT_MS, "America/New_York");
+    expect(picker.getFullYear()).toBe(2026);
+    expect(picker.getMonth()).toBe(6);
+    expect(picker.getDate()).toBe(21);
+    expect(picker.getHours()).toBe(20);
+    expect(picker.getMinutes()).toBe(30);
+  });
+
+  it("shows datetime fields as the UTC wall clock for the default timezone", () => {
+    const picker = toPickerDate("datetime", INSTANT_MS, "UTC");
+    expect(picker.getFullYear()).toBe(2026);
+    expect(picker.getMonth()).toBe(6);
+    expect(picker.getDate()).toBe(22);
+    expect(picker.getHours()).toBe(0);
+    expect(picker.getMinutes()).toBe(30);
+  });
+});
+
+describe("serializeDateValue", () => {
+  it("stores date fields at noon UTC of the picked calendar date", () => {
+    const picker = toPickerDate("date", JULY_22_DATE_MS, "UTC");
+    expect(serializeDateValue("date", picker, "UTC")).toBe(
+      "2026-07-22T12:00:00.000Z",
+    );
+  });
+
+  it("interprets datetime picker values in the app timezone", () => {
+    const picker = toPickerDate("datetime", INSTANT_MS, "America/New_York");
+    expect(serializeDateValue("datetime", picker, "America/New_York")).toBe(
+      new Date(INSTANT_MS).toISOString(),
+    );
+  });
+
+  it("round-trips datetime values through the picker in UTC", () => {
+    const picker = toPickerDate("datetime", INSTANT_MS, "UTC");
+    expect(serializeDateValue("datetime", picker, "UTC")).toBe(
+      new Date(INSTANT_MS).toISOString(),
+    );
+  });
+});
+
+describe("dateOnlyToUTC", () => {
+  it("keeps the same calendar date when re-parsed", () => {
+    const picker = toPickerDate("date", JULY_22_DATE_MS, "UTC");
+    const stored = dateOnlyToUTC(picker);
+    const roundTripped = toPickerDate(
+      "date",
+      new Date(stored).getTime(),
+      "UTC",
+    );
+    expect(roundTripped.getDate()).toBe(picker.getDate());
+    expect(roundTripped.getMonth()).toBe(picker.getMonth());
+    expect(roundTripped.getFullYear()).toBe(picker.getFullYear());
+  });
+});
+
+describe("parseDatabaseValue", () => {
+  it("converts database date wrappers to picker dates", () => {
+    const parsed = parseDatabaseValue(
+      "date",
+      { _cls: "DateTime", datetime: JULY_22_DATE_MS },
+      "UTC",
+    );
+    expect(parsed).toBeInstanceOf(Date);
+    expect((parsed as Date).getDate()).toBe(22);
+  });
+
+  it("converts transient ISO strings to picker dates", () => {
+    const parsed = parseDatabaseValue(
+      "datetime",
+      new Date(INSTANT_MS).toISOString(),
+      "America/New_York",
+    );
+    expect(parsed).toBeInstanceOf(Date);
+    expect((parsed as Date).getDate()).toBe(21);
+    expect((parsed as Date).getHours()).toBe(20);
+  });
+
+  it("returns non-date values unchanged", () => {
+    expect(parseDatabaseValue("str", "hello", "UTC")).toBe("hello");
+    expect(parseDatabaseValue("int", 5, "UTC")).toBe(5);
+  });
+
+  it("returns invalid date strings unchanged", () => {
+    expect(parseDatabaseValue("datetime", "not a date", "UTC")).toBe(
+      "not a date",
+    );
+  });
+});
+
+describe("serializeFieldValue", () => {
+  it("round-trips a datetime edit end to end in a non-UTC app timezone", () => {
+    const zone = "America/New_York";
+    const parsed = parseDatabaseValue(
+      "datetime",
+      { _cls: "DateTime", datetime: INSTANT_MS },
+      zone,
+    ) as Date;
+    // simulate the user picking a new time on the previous local day
+    const picked = new Date(parsed);
+    picked.setHours(9, 15, 0, 0);
+    const stored = serializeFieldValue(picked, "datetime", zone);
+    expect(stored).toBe(
+      DateTime.fromObject(
+        { year: 2026, month: 7, day: 21, hour: 9, minute: 15 },
+        { zone },
+      )
+        .toUTC()
+        .toISO(),
+    );
+  });
+
+  it("passes non-date primitives through", () => {
+    expect(serializeFieldValue(3.14, "float", "UTC")).toBe(3.14);
+  });
+
+  it("parses dict fields from JSON strings", () => {
+    expect(serializeFieldValue('{"a": 1}', "dict", "UTC")).toEqual({ a: 1 });
+  });
+});

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/serialization.test.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/serialization.test.ts
@@ -63,6 +63,13 @@ describe("serializeDateValue", () => {
       new Date(INSTANT_MS).toISOString(),
     );
   });
+
+  it("throws on an invalid timezone instead of returning null", () => {
+    const picker = new Date(INSTANT_MS);
+    expect(() => serializeDateValue("datetime", picker, "Not/AZone")).toThrow(
+      "invalid date or timezone",
+    );
+  });
 });
 
 describe("dateOnlyToUTC", () => {

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/serialization.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/serialization.ts
@@ -1,26 +1,88 @@
 import { isNullish, Primitive } from "@fiftyone/utilities";
+import { DateTime } from "luxon";
 
 /**
- * Problem: user is in EST, server is in UTC. User picks a
- * date-only value, we need to convert it to UTC. This makes the
- * date appear to be a day ahead when it is rendered in the UI back
- * in UTC/server format.
+ * FiftyOne renders `date` fields as the UTC calendar date and `datetime`
+ * fields in the app timezone (`fo.config.timezone`, "UTC" by default),
+ * while react-datepicker only operates on Date objects interpreted in the
+ * browser's local timezone. The helpers below translate between the two so
+ * the picker shows and stores the same wall-clock values the rest of the
+ * app displays.
+ */
+
+/**
+ * Convert an absolute timestamp into a Date whose local-timezone components
+ * match what the app displays for the field, suitable for react-datepicker
+ * @param type - the type of the field ("date" or "datetime")
+ * @param timestamp - epoch milliseconds
+ * @param timeZone - the app display timezone (IANA name, "UTC", or "local")
+ * @returns a Date carrying the displayed wall-clock values in local time
+ */
+export function toPickerDate(
+  type: string,
+  timestamp: number,
+  timeZone: string,
+): Date {
+  if (type === "date") {
+    const date = new Date(timestamp);
+    return new Date(
+      date.getUTCFullYear(),
+      date.getUTCMonth(),
+      date.getUTCDate(),
+      12,
+    );
+  }
+
+  const dt = DateTime.fromMillis(timestamp, { zone: timeZone });
+  return new Date(
+    dt.year,
+    dt.month - 1,
+    dt.day,
+    dt.hour,
+    dt.minute,
+    dt.second,
+    dt.millisecond,
+  );
+}
+
+/**
+ * Serialize a picker Date's calendar date to an absolute instant at noon
+ * UTC, so the stored value renders as the same calendar date in every
+ * timezone
  */
 export function dateOnlyToUTC(date: Date): string {
-  // Extract year, month, day from the date object (in local timezone)
   const year = date.getFullYear();
   const month = date.getMonth();
   const day = date.getDate();
 
-  // Create date at noon UTC (avoids timezone boundary issues)
   return new Date(Date.UTC(year, month, day, 12, 0, 0, 0)).toISOString();
 }
 
-export function serializeDateValue(type: string, date: Date): string {
+export function serializeDateValue(
+  type: string,
+  date: Date,
+  timeZone: string,
+): string {
   if (type === "date") {
     return dateOnlyToUTC(date);
   }
-  return date.toISOString();
+
+  // the picker's Date components are wall-clock values in the app display
+  // timezone; interpret them there to recover the absolute instant
+  return DateTime.fromObject(
+    {
+      year: date.getFullYear(),
+      month: date.getMonth() + 1,
+      day: date.getDate(),
+      hour: date.getHours(),
+      minute: date.getMinutes(),
+      second: date.getSeconds(),
+      millisecond: date.getMilliseconds(),
+    },
+    { zone: timeZone },
+  )
+    .toUTC()
+    .toISO();
 }
 
 /**
@@ -51,14 +113,16 @@ export function isDateInDatabaseFormat(
  * input value for other field types
  * @param fieldValue - the value of the field
  * @param type - the type of the field
+ * @param timeZone - the app display timezone
  * @returns the processed value of the field
  */
 export function serializeFieldValue(
   fieldValue: Primitive | Date,
   type: string,
+  timeZone: string,
 ): Primitive {
   if (fieldValue instanceof Date) {
-    return serializeDateValue(type, fieldValue);
+    return serializeDateValue(type, fieldValue, timeZone);
   }
 
   if (type !== "dict") {
@@ -82,29 +146,29 @@ export function serializeFieldValue(
  * pass to SmartForm and handle date/dict fields correctly
  * @param type - the type of the field
  * @param value - the value of the field
+ * @param timeZone - the app display timezone
  * @returns the initial value of the field
  */
 export function parseDatabaseValue(
-  _type: string,
+  type: string,
   value: unknown,
+  timeZone: string,
 ): Primitive | Date {
   /**
    * from the backend we get: { datetime: number, '_cls': 'datetime' }
    */
-  if (value && typeof value === "object" && "datetime" in value) {
-    const timestamp = value.datetime as number;
-    // within editor we use Date objects, parse the timestamp to a Date
-    // and then we will serialize it back on submission to the server
-    return new Date(timestamp);
+  if (isDateInDatabaseFormat(value)) {
+    return toPickerDate(type, value.datetime, timeZone);
   }
+
   // Transient values stored on Sample (e.g. after an undo restored the
   // original database value through setField) are already-serialized ISO
-  // strings — parse them back into Date instances so the picker shows the
+  // strings — parse them back into picker Dates so the picker shows the
   // correct value instead of falling back to "now".
-  if ((_type === "date" || _type === "datetime") && typeof value === "string") {
+  if ((type === "date" || type === "datetime") && typeof value === "string") {
     const parsed = new Date(value);
     if (!Number.isNaN(parsed.getTime())) {
-      return parsed;
+      return toPickerDate(type, parsed.getTime(), timeZone);
     }
   }
   return value as Primitive;

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/serialization.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/serialization.ts
@@ -69,7 +69,7 @@ export function serializeDateValue(
 
   // the picker's Date components are wall-clock values in the app display
   // timezone; interpret them there to recover the absolute instant
-  return DateTime.fromObject(
+  const iso = DateTime.fromObject(
     {
       year: date.getFullYear(),
       month: date.getMonth() + 1,
@@ -83,6 +83,14 @@ export function serializeDateValue(
   )
     .toUTC()
     .toISO();
+
+  // an invalid zone or date yields null; throw so the caller skips the
+  // mutation instead of treating the value as missing and deleting the field
+  if (iso === null) {
+    throw new Error(`invalid date or timezone: ${date} (${timeZone})`);
+  }
+
+  return iso;
 }
 
 /**

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/serialization.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/serialization.ts
@@ -1,97 +1,4 @@
 import { isNullish, Primitive } from "@fiftyone/utilities";
-import { DateTime } from "luxon";
-
-/**
- * FiftyOne renders `date` fields as the UTC calendar date and `datetime`
- * fields in the app timezone (`fo.config.timezone`, "UTC" by default),
- * while react-datepicker only operates on Date objects interpreted in the
- * browser's local timezone. The helpers below translate between the two so
- * the picker shows and stores the same wall-clock values the rest of the
- * app displays.
- */
-
-/**
- * Convert an absolute timestamp into a Date whose local-timezone components
- * match what the app displays for the field, suitable for react-datepicker
- * @param type - the type of the field ("date" or "datetime")
- * @param timestamp - epoch milliseconds
- * @param timeZone - the app display timezone (IANA name, "UTC", or "local")
- * @returns a Date carrying the displayed wall-clock values in local time
- */
-export function toPickerDate(
-  type: string,
-  timestamp: number,
-  timeZone: string,
-): Date {
-  if (type === "date") {
-    const date = new Date(timestamp);
-    return new Date(
-      date.getUTCFullYear(),
-      date.getUTCMonth(),
-      date.getUTCDate(),
-      12,
-    );
-  }
-
-  const dt = DateTime.fromMillis(timestamp, { zone: timeZone });
-  return new Date(
-    dt.year,
-    dt.month - 1,
-    dt.day,
-    dt.hour,
-    dt.minute,
-    dt.second,
-    dt.millisecond,
-  );
-}
-
-/**
- * Serialize a picker Date's calendar date to an absolute instant at noon
- * UTC, so the stored value renders as the same calendar date in every
- * timezone
- */
-export function dateOnlyToUTC(date: Date): string {
-  const year = date.getFullYear();
-  const month = date.getMonth();
-  const day = date.getDate();
-
-  return new Date(Date.UTC(year, month, day, 12, 0, 0, 0)).toISOString();
-}
-
-export function serializeDateValue(
-  type: string,
-  date: Date,
-  timeZone: string,
-): string {
-  if (type === "date") {
-    return dateOnlyToUTC(date);
-  }
-
-  // the picker's Date components are wall-clock values in the app display
-  // timezone; interpret them there to recover the absolute instant
-  const iso = DateTime.fromObject(
-    {
-      year: date.getFullYear(),
-      month: date.getMonth() + 1,
-      day: date.getDate(),
-      hour: date.getHours(),
-      minute: date.getMinutes(),
-      second: date.getSeconds(),
-      millisecond: date.getMilliseconds(),
-    },
-    { zone: timeZone },
-  )
-    .toUTC()
-    .toISO();
-
-  // an invalid zone or date yields null; throw so the caller skips the
-  // mutation instead of treating the value as missing and deleting the field
-  if (iso === null) {
-    throw new Error(`invalid date or timezone: ${date} (${timeZone})`);
-  }
-
-  return iso;
-}
 
 /**
  * Serialize a date value from the database back to an ISO string
@@ -121,20 +28,14 @@ export function isDateInDatabaseFormat(
  * input value for other field types
  * @param fieldValue - the value of the field
  * @param type - the type of the field
- * @param timeZone - the app display timezone
  * @returns the processed value of the field
  */
 export function serializeFieldValue(
-  fieldValue: Primitive | Date,
+  fieldValue: Primitive,
   type: string,
-  timeZone: string,
 ): Primitive {
-  if (fieldValue instanceof Date) {
-    return serializeDateValue(type, fieldValue, timeZone);
-  }
-
   if (type !== "dict") {
-    return fieldValue as Primitive;
+    return fieldValue;
   }
 
   // handle dict fields
@@ -151,33 +52,19 @@ export function serializeFieldValue(
 
 /**
  * Convert raw value into a primitive of the format that we can
- * pass to SmartForm and handle date/dict fields correctly
- * @param type - the type of the field
+ * pass to SmartForm and handle date/dict fields correctly. Date and
+ * datetime values become ISO instant strings; the SmartForm datepicker
+ * widget translates them to and from display-timezone wall clocks.
  * @param value - the value of the field
- * @param timeZone - the app display timezone
  * @returns the initial value of the field
  */
-export function parseDatabaseValue(
-  type: string,
-  value: unknown,
-  timeZone: string,
-): Primitive | Date {
+export function parseDatabaseValue(value: unknown): Primitive {
   /**
    * from the backend we get: { datetime: number, '_cls': 'datetime' }
    */
   if (isDateInDatabaseFormat(value)) {
-    return toPickerDate(type, value.datetime, timeZone);
+    return new Date(value.datetime).toISOString();
   }
 
-  // Transient values stored on Sample (e.g. after an undo restored the
-  // original database value through setField) are already-serialized ISO
-  // strings — parse them back into picker Dates so the picker shows the
-  // correct value instead of falling back to "now".
-  if ((type === "date" || type === "datetime") && typeof value === "string") {
-    const parsed = new Date(value);
-    if (!Number.isNaN(parsed.getTime())) {
-      return toPickerDate(type, parsed.getTime(), timeZone);
-    }
-  }
   return value as Primitive;
 }

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/serialization.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/serialization.ts
@@ -54,7 +54,7 @@ export function serializeFieldValue(
  * Convert raw value into a primitive of the format that we can
  * pass to SmartForm and handle date/dict fields correctly. Date and
  * datetime values become ISO instant strings; the SmartForm datepicker
- * widget translates them to and from display-timezone wall clocks.
+ * widget translates them to and from the displayed date and time.
  * @param value - the value of the field
  * @returns the initial value of the field
  */

--- a/app/packages/core/src/plugins/SchemaIO/components/FileExplorerView/FileTable.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/FileExplorerView/FileTable.tsx
@@ -11,9 +11,8 @@ import {
 import { Button } from "@fiftyone/components";
 import FolderIcon from "@mui/icons-material/Folder";
 import InsertDriveFileIcon from "@mui/icons-material/InsertDriveFile";
-import { DateTime } from "luxon";
 import { scrollable } from "@fiftyone/components";
-import { humanReadableBytes } from "@fiftyone/utilities";
+import { formatRelativeTime, humanReadableBytes } from "@fiftyone/utilities";
 
 const Wrapper = ({ children }) => (
   <Paper
@@ -94,9 +93,7 @@ function FileTable({
               </TableCell>
               <TableCell>
                 {file.date_modified &&
-                  DateTime.fromJSDate(
-                    new Date(file.date_modified),
-                  ).toRelative()}
+                  formatRelativeTime(new Date(file.date_modified).getTime())}
               </TableCell>
               <TableCell>{humanReadableBytes(file.size)}</TableCell>
             </TableRow>

--- a/app/packages/state/src/hooks/index.ts
+++ b/app/packages/state/src/hooks/index.ts
@@ -48,6 +48,7 @@ export { default as useSetSessionColorScheme } from "./useSetSessionColorScheme"
 export { default as useSetSpaces } from "./useSetSpaces";
 export { default as useSetView } from "./useSetView";
 export { default as useTimeout } from "./useTimeout";
+export { default as useTimeZone } from "./useTimeZone";
 export { default as useToClips } from "./useToClips";
 export { default as useToEvaluationPatches } from "./useToEvaluationPatches";
 export { default as useTooltip } from "./useTooltip";

--- a/app/packages/state/src/hooks/useTimeZone.ts
+++ b/app/packages/state/src/hooks/useTimeZone.ts
@@ -1,0 +1,9 @@
+import { useRecoilValue } from "recoil";
+import { timeZone } from "../recoil/selectors";
+
+/**
+ * Returns the app display timezone (`fo.config.timezone`, "UTC" by default)
+ */
+const useTimeZone = (): string => useRecoilValue(timeZone);
+
+export default useTimeZone;

--- a/app/packages/utilities/package.json
+++ b/app/packages/utilities/package.json
@@ -29,6 +29,7 @@
         "fetch-retry": "^5.0.3",
         "lodash": "^4.18.1",
         "lru-cache": "^11.0.1",
+        "luxon": "^3.6.1",
         "mime": "^2.5.2",
         "path-browserify": "^1.0.1"
     },

--- a/app/packages/utilities/package.json
+++ b/app/packages/utilities/package.json
@@ -18,6 +18,7 @@
         "README.md"
     ],
     "devDependencies": {
+        "@types/luxon": "^3.6.2",
         "prettier": "^3.8.4",
         "typescript-plugin-css-modules": "^5.1.0",
         "vite": "^7.3.2"

--- a/app/packages/utilities/src/datetime.test.ts
+++ b/app/packages/utilities/src/datetime.test.ts
@@ -6,6 +6,7 @@ import {
   dateOnlyToUTC,
   formatDatePicker,
   formatDateTimePicker,
+  formatRelativeTime,
   serializeDateValue,
   toPickerDate,
 } from "./datetime";
@@ -96,6 +97,16 @@ describe("formatDatePicker", () => {
     const utcMidnight = 1704067200000;
     const result = formatDatePicker(utcMidnight);
     expect(result).toBe("2024-01-01");
+  });
+});
+
+describe("formatRelativeTime", () => {
+  it("formats past timestamps relative to now", () => {
+    expect(formatRelativeTime(Date.now() - 3_600_000)).toMatch(/ago/);
+  });
+
+  it("returns null for invalid timestamps", () => {
+    expect(formatRelativeTime(Number.NaN)).toBeNull();
   });
 });
 

--- a/app/packages/utilities/src/datetime.test.ts
+++ b/app/packages/utilities/src/datetime.test.ts
@@ -136,6 +136,19 @@ describe("toPickerDate", () => {
     expect(picker.getHours()).toBe(0);
     expect(picker.getMinutes()).toBe(30);
   });
+
+  it("ignores the app timezone for date fields", () => {
+    const picker = toPickerDate("date", JULY_22_DATE_MS, "America/New_York");
+    expect(picker.getFullYear()).toBe(2026);
+    expect(picker.getMonth()).toBe(6);
+    expect(picker.getDate()).toBe(22);
+  });
+
+  it("throws on an invalid timezone instead of returning an Invalid Date", () => {
+    expect(() => toPickerDate("datetime", INSTANT_MS, "Not/AZone")).toThrow(
+      "invalid date or timezone",
+    );
+  });
 });
 
 describe("serializeDateValue", () => {

--- a/app/packages/utilities/src/datetime.test.ts
+++ b/app/packages/utilities/src/datetime.test.ts
@@ -3,9 +3,18 @@ import { describe, expect, it } from "vitest";
 import {
   dateFromDateString,
   dateFromDateTimeString,
+  dateOnlyToUTC,
   formatDatePicker,
   formatDateTimePicker,
+  serializeDateValue,
+  toPickerDate,
 } from "./datetime";
+
+// midnight UTC, July 22 2026 — how a `date` field value is stored
+const JULY_22_DATE_MS = Date.UTC(2026, 6, 22);
+
+// an arbitrary instant: 2026-07-22T00:30:00Z
+const INSTANT_MS = Date.UTC(2026, 6, 22, 0, 30);
 
 describe("dateFromDateString", () => {
   it("returns the UTC timestamp for a valid date string", () => {
@@ -87,5 +96,78 @@ describe("formatDatePicker", () => {
     const utcMidnight = 1704067200000;
     const result = formatDatePicker(utcMidnight);
     expect(result).toBe("2024-01-01");
+  });
+});
+
+describe("toPickerDate", () => {
+  it("preserves the UTC calendar date for date fields in any local timezone", () => {
+    const picker = toPickerDate("date", JULY_22_DATE_MS, "UTC");
+    expect(picker.getFullYear()).toBe(2026);
+    expect(picker.getMonth()).toBe(6);
+    expect(picker.getDate()).toBe(22);
+  });
+
+  it("shows datetime fields as the wall clock in the app timezone", () => {
+    // 2026-07-22T00:30Z is 2026-07-21T20:30 in New York (EDT)
+    const picker = toPickerDate("datetime", INSTANT_MS, "America/New_York");
+    expect(picker.getFullYear()).toBe(2026);
+    expect(picker.getMonth()).toBe(6);
+    expect(picker.getDate()).toBe(21);
+    expect(picker.getHours()).toBe(20);
+    expect(picker.getMinutes()).toBe(30);
+  });
+
+  it("shows datetime fields as the UTC wall clock for the default timezone", () => {
+    const picker = toPickerDate("datetime", INSTANT_MS, "UTC");
+    expect(picker.getFullYear()).toBe(2026);
+    expect(picker.getMonth()).toBe(6);
+    expect(picker.getDate()).toBe(22);
+    expect(picker.getHours()).toBe(0);
+    expect(picker.getMinutes()).toBe(30);
+  });
+});
+
+describe("serializeDateValue", () => {
+  it("stores date fields at noon UTC of the picked calendar date", () => {
+    const picker = toPickerDate("date", JULY_22_DATE_MS, "UTC");
+    expect(serializeDateValue("date", picker, "UTC")).toBe(
+      "2026-07-22T12:00:00.000Z",
+    );
+  });
+
+  it("interprets datetime picker values in the app timezone", () => {
+    const picker = toPickerDate("datetime", INSTANT_MS, "America/New_York");
+    expect(serializeDateValue("datetime", picker, "America/New_York")).toBe(
+      new Date(INSTANT_MS).toISOString(),
+    );
+  });
+
+  it("round-trips datetime values through the picker in UTC", () => {
+    const picker = toPickerDate("datetime", INSTANT_MS, "UTC");
+    expect(serializeDateValue("datetime", picker, "UTC")).toBe(
+      new Date(INSTANT_MS).toISOString(),
+    );
+  });
+
+  it("throws on an invalid timezone instead of returning null", () => {
+    const picker = new Date(INSTANT_MS);
+    expect(() => serializeDateValue("datetime", picker, "Not/AZone")).toThrow(
+      "invalid date or timezone",
+    );
+  });
+});
+
+describe("dateOnlyToUTC", () => {
+  it("keeps the same calendar date when re-parsed", () => {
+    const picker = toPickerDate("date", JULY_22_DATE_MS, "UTC");
+    const stored = dateOnlyToUTC(picker);
+    const roundTripped = toPickerDate(
+      "date",
+      new Date(stored).getTime(),
+      "UTC",
+    );
+    expect(roundTripped.getDate()).toBe(picker.getDate());
+    expect(roundTripped.getMonth()).toBe(picker.getMonth());
+    expect(roundTripped.getFullYear()).toBe(picker.getFullYear());
   });
 });

--- a/app/packages/utilities/src/datetime.test.ts
+++ b/app/packages/utilities/src/datetime.test.ts
@@ -118,7 +118,7 @@ describe("toPickerDate", () => {
     expect(picker.getDate()).toBe(22);
   });
 
-  it("shows datetime fields as the wall clock in the app timezone", () => {
+  it("shows datetime fields as the local time in the app timezone", () => {
     // 2026-07-22T00:30Z is 2026-07-21T20:30 in New York (EDT)
     const picker = toPickerDate("datetime", INSTANT_MS, "America/New_York");
     expect(picker.getFullYear()).toBe(2026);
@@ -128,7 +128,7 @@ describe("toPickerDate", () => {
     expect(picker.getMinutes()).toBe(30);
   });
 
-  it("shows datetime fields as the UTC wall clock for the default timezone", () => {
+  it("shows datetime fields as UTC time for the default timezone", () => {
     const picker = toPickerDate("datetime", INSTANT_MS, "UTC");
     expect(picker.getFullYear()).toBe(2026);
     expect(picker.getMonth()).toBe(6);

--- a/app/packages/utilities/src/datetime.ts
+++ b/app/packages/utilities/src/datetime.ts
@@ -99,7 +99,7 @@ export function formatRelativeTime(timestamp: number): string | null {
  * fields in the app timezone (`fo.config.timezone`, "UTC" by default),
  * while react-datepicker only operates on Date objects interpreted in the
  * browser's local timezone. The helpers below translate between the two so
- * pickers show and store the same wall-clock values the rest of the app
+ * pickers show and store the same dates and times the rest of the app
  * displays.
  */
 
@@ -111,7 +111,7 @@ export type DateFieldType = "date" | "datetime";
  * @param type - the type of the field
  * @param timestamp - epoch milliseconds
  * @param timeZone - the app display timezone (IANA name, "UTC", or "local")
- * @returns a Date carrying the displayed wall-clock values in local time
+ * @returns a Date whose local-time components carry the displayed date and time
  */
 export function toPickerDate(
   type: DateFieldType,
@@ -169,7 +169,7 @@ export function serializeDateValue(
     return dateOnlyToUTC(date);
   }
 
-  // the picker's Date components are wall-clock values in the app display
+  // the picker's Date components are the displayed date and time in the app
   // timezone; interpret them there to recover the absolute instant
   const iso = DateTime.fromObject(
     {

--- a/app/packages/utilities/src/datetime.ts
+++ b/app/packages/utilities/src/datetime.ts
@@ -84,3 +84,95 @@ const handleDigits = (digits: string) => {
     useGrouping: false,
   });
 };
+
+/**
+ * FiftyOne renders `date` fields as the UTC calendar date and `datetime`
+ * fields in the app timezone (`fo.config.timezone`, "UTC" by default),
+ * while react-datepicker only operates on Date objects interpreted in the
+ * browser's local timezone. The helpers below translate between the two so
+ * pickers show and store the same wall-clock values the rest of the app
+ * displays.
+ */
+
+/**
+ * Convert an absolute timestamp into a Date whose local-timezone components
+ * match what the app displays for the field, suitable for react-datepicker
+ * @param type - the type of the field ("date" or "datetime")
+ * @param timestamp - epoch milliseconds
+ * @param timeZone - the app display timezone (IANA name, "UTC", or "local")
+ * @returns a Date carrying the displayed wall-clock values in local time
+ */
+export function toPickerDate(
+  type: string,
+  timestamp: number,
+  timeZone: string,
+): Date {
+  if (type === "date") {
+    const date = new Date(timestamp);
+    return new Date(
+      date.getUTCFullYear(),
+      date.getUTCMonth(),
+      date.getUTCDate(),
+      12,
+    );
+  }
+
+  const dt = DateTime.fromMillis(timestamp, { zone: timeZone });
+  return new Date(
+    dt.year,
+    dt.month - 1,
+    dt.day,
+    dt.hour,
+    dt.minute,
+    dt.second,
+    dt.millisecond,
+  );
+}
+
+/**
+ * Serialize a picker Date's calendar date to an absolute instant at noon
+ * UTC, so the stored value renders as the same calendar date in every
+ * timezone
+ */
+export function dateOnlyToUTC(date: Date): string {
+  const year = date.getFullYear();
+  const month = date.getMonth();
+  const day = date.getDate();
+
+  return new Date(Date.UTC(year, month, day, 12, 0, 0, 0)).toISOString();
+}
+
+export function serializeDateValue(
+  type: string,
+  date: Date,
+  timeZone: string,
+): string {
+  if (type === "date") {
+    return dateOnlyToUTC(date);
+  }
+
+  // the picker's Date components are wall-clock values in the app display
+  // timezone; interpret them there to recover the absolute instant
+  const iso = DateTime.fromObject(
+    {
+      year: date.getFullYear(),
+      month: date.getMonth() + 1,
+      day: date.getDate(),
+      hour: date.getHours(),
+      minute: date.getMinutes(),
+      second: date.getSeconds(),
+      millisecond: date.getMilliseconds(),
+    },
+    { zone: timeZone },
+  )
+    .toUTC()
+    .toISO();
+
+  // an invalid zone or date yields null; throw so callers skip the mutation
+  // instead of treating the value as missing and deleting the field
+  if (iso === null) {
+    throw new Error(`invalid date or timezone: ${date} (${timeZone})`);
+  }
+
+  return iso;
+}

--- a/app/packages/utilities/src/datetime.ts
+++ b/app/packages/utilities/src/datetime.ts
@@ -103,16 +103,18 @@ export function formatRelativeTime(timestamp: number): string | null {
  * displays.
  */
 
+export type DateFieldType = "date" | "datetime";
+
 /**
  * Convert an absolute timestamp into a Date whose local-timezone components
  * match what the app displays for the field, suitable for react-datepicker
- * @param type - the type of the field ("date" or "datetime")
+ * @param type - the type of the field
  * @param timestamp - epoch milliseconds
  * @param timeZone - the app display timezone (IANA name, "UTC", or "local")
  * @returns a Date carrying the displayed wall-clock values in local time
  */
 export function toPickerDate(
-  type: string,
+  type: DateFieldType,
   timestamp: number,
   timeZone: string,
 ): Date {
@@ -127,6 +129,13 @@ export function toPickerDate(
   }
 
   const dt = DateTime.fromMillis(timestamp, { zone: timeZone });
+
+  // an invalid zone or timestamp yields NaN components; throw instead of
+  // handing the picker an Invalid Date
+  if (!dt.isValid) {
+    throw new Error(`invalid date or timezone: ${timestamp} (${timeZone})`);
+  }
+
   return new Date(
     dt.year,
     dt.month - 1,
@@ -152,7 +161,7 @@ export function dateOnlyToUTC(date: Date): string {
 }
 
 export function serializeDateValue(
-  type: string,
+  type: DateFieldType,
   date: Date,
   timeZone: string,
 ): string {

--- a/app/packages/utilities/src/datetime.ts
+++ b/app/packages/utilities/src/datetime.ts
@@ -86,6 +86,15 @@ const handleDigits = (digits: string) => {
 };
 
 /**
+ * Format an absolute timestamp as a relative time string, e.g. "3 hours ago"
+ * @param timestamp - epoch milliseconds
+ * @returns the relative time string, or null for an invalid timestamp
+ */
+export function formatRelativeTime(timestamp: number): string | null {
+  return DateTime.fromMillis(timestamp).toRelative();
+}
+
+/**
  * FiftyOne renders `date` fields as the UTC calendar date and `datetime`
  * fields in the app timezone (`fo.config.timezone`, "UTC" by default),
  * while react-datepicker only operates on Date objects interpreted in the

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2926,7 +2926,6 @@ __metadata:
     "@mui/material": "npm:^5.9.0"
     "@react-spring/web": "npm:^9.4.3"
     "@types/lodash": "npm:^4.14.182"
-    "@types/luxon": "npm:^3.6.2"
     "@types/mime": "npm:^2.0.3"
     "@types/react-color": "npm:^3.0.6"
     "@types/react-grid-layout": "npm:^1.3.5"
@@ -2947,7 +2946,6 @@ __metadata:
     json-edit-react: "npm:^1.28.2"
     lodash: "npm:^4.18.1"
     lru-cache: "npm:^11.0.1"
-    luxon: "npm:^3.6.1"
     numeral: "npm:^2.0.6"
     prettier: "npm:^3.8.4"
     re-resizable: "npm:^6.9.17"
@@ -3424,6 +3422,7 @@ __metadata:
   dependencies:
     "@chainner/node-path": "npm:^0.1.1"
     "@microsoft/fetch-event-source": "npm:^2.0.1"
+    "@types/luxon": "npm:^3.6.2"
     fast-json-patch: "npm:^3.1.1"
     fetch-retry: "npm:^5.0.3"
     lodash: "npm:^4.18.1"

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -3428,6 +3428,7 @@ __metadata:
     fetch-retry: "npm:^5.0.3"
     lodash: "npm:^4.18.1"
     lru-cache: "npm:^11.0.1"
+    luxon: "npm:^3.6.1"
     mime: "npm:^2.5.2"
     path-browserify: "npm:^1.0.1"
     prettier: "npm:^3.8.4"


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes [FOEPD-4254](https://voxel51.atlassian.net/browse/FOEPD-4254): date fields in the annotate sidebar rendered one day off for users west of UTC.

Both date edit paths — `PrimitiveEdit`'s inline picker (sample primitives) and the SmartForm's `DatePickerWidget` (label attributes) — fed stored UTC instants into `react-datepicker`, which renders in the browser's local timezone. The rest of the app shows `date` fields as the UTC calendar date and `datetime` fields in `fo.config.timezone`.

This PR unifies both paths on one timezone-aware widget:

- picker/timezone conversion helpers move to `@fiftyone/utilities` `datetime.ts`; `serializeDateValue()` throws on an invalid instant instead of returning a `null` that callers treat as a field deletion
- `DatePickerWidget` uses them: UTC calendar date for `date` fields, local time in the app timezone for `datetime`
- `PrimitiveRenderer` drops its date special-case; both paths carry dates as ISO strings through the SmartForm
- luxon consolidates behind `@fiftyone/utilities`: declared there (it was imported undeclared), and core drops its direct usage — `FileTable` renders relative times via a new `formatRelativeTime()` helper

## How is this patch tested?

Unit tests for the conversion helpers (UTC-calendar invariant, `America/New_York` local time, round trips, invalid-timezone throw) and the parse/serialize glue; 358 tests across Edit, SmartForm, and utilities pass. Manual check with date/datetime fields at sample level and as label attributes, under UTC and non-UTC `FIFTYONE_TIMEZONE`.

## What areas of FiftyOne does this PR affect?

- [x] `App`: FiftyOne application changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date and datetime editing to consistently respect the app’s configured time zone.
  * Preserved calendar dates and wall-clock times more accurately when converting between editor values and stored data.
  * Improved parsing/serialization for database date values and dict inputs, with safer handling of invalid or transient values.
* **New Features**
  * Added time-zone support utilities for date/time picker conversions and relative time formatting.
* **Tests**
  * Added coverage for time-zone-aware date serialization/parsing, editor round-trips, and dict/date error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3458
<!-- enterprise-sync-pr:end -->


[FOEPD-4254]: https://voxel51.atlassian.net/browse/FOEPD-4254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ