### PR TITLE
docs: FiftyOne Enterprise 2.22.1 release notes

### DIFF
--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -3,6 +3,14 @@ FiftyOne Release Notes
 
 .. default-role:: code
 
+FiftyOne Enterprise 2.22.1
+--------------------------
+*Released July 22, 2026*
+
+App
+
+- Fixed a bug that caused the App to crash for users with the Guest role
+
 FiftyOne Enterprise 2.22.0
 --------------------------
 *Released July 14, 2026*


### PR DESCRIPTION
Adds the release notes section for the Enterprise-only 2.22.1 patch release.

After merge, this commit will be cherry-picked to `release/v1.19.0-docs` (cut from the `v1.19.0` tag) for the docs-publish flow.

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3470
<!-- enterprise-sync-pr:end -->