### PR TITLE
docs: cherry-pick the Enterprise 2.22.1 release notes

### DIFF
--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -3,6 +3,14 @@ FiftyOne Release Notes
 
 .. default-role:: code
 
+FiftyOne Enterprise 2.22.1
+--------------------------
+*Released July 22, 2026*
+
+App
+
+- Fixed a bug that caused the App to crash for users with the Guest role
+
 FiftyOne Enterprise 2.22.0
 --------------------------
 *Released July 14, 2026*


### PR DESCRIPTION
Cherry-pick of the 2.22.1 release-notes commit from #8095 (`b0e45963`) onto `docs/v1.19.0`, the docs-publish line cut from the `v1.19.0` tag.

Docs-only. At ship time, `main` fast-forwards to this branch head and `docs-publish` is re-tagged. The `docs/` prefix (not `release/`) keeps the enterprise sync and the daily digest from picking this up.