### PR TITLE
fix(ci): security PR notifications post once, not per label event

### DIFF
--- a/.github/workflows/notify-security-prs.yml
+++ b/.github/workflows/notify-security-prs.yml
@@ -4,10 +4,14 @@ name: Notify security PRs
 # PR. Those PRs carry the `security` label (renovate.json -> vulnerabilityAlerts)
 # and are authored by voxel51-bot. Routine version bumps are intentionally not
 # announced — only CVE/security PRs reach the channel.
+#
+# Renovate attaches labels at PR creation, so the label is already present in
+# the `opened` payload. Do not add a `labeled` trigger: each labeled event
+# posts again, duplicating the notification.
 
 on:
   pull_request:
-    types: [opened, reopened, labeled]
+    types: [opened, reopened]
 
 permissions:
   contents: read
@@ -17,10 +21,7 @@ jobs:
     if: >-
       github.repository_owner == 'voxel51' &&
       github.event.pull_request.user.login == 'voxel51-bot' &&
-      (
-        (github.event.action == 'labeled' && github.event.label.name == 'security') ||
-        (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'security'))
-      )
+      contains(github.event.pull_request.labels.*.name, 'security')
     runs-on: ubuntu-latest
     steps:
       - name: "Post to #compliance-security"


### PR DESCRIPTION
## What

`notify-security-prs.yml` was posting each Renovate security PR to #compliance-security 2-3 times.

## Why

The workflow triggered on `pull_request: [opened, reopened, labeled]` and its `if` passed for both the `opened` event (Renovate attaches labels at PR creation, so `security` is already in the payload) and each `labeled` event for `security`. Renovate currently applies its label set in two passes (e.g. #8093's timeline shows `security` labeled at 14:51:17 and again at 14:51:18), so a single PR produced three successful notify runs — the run history for #8093 and #8082 shows 3 `success` conclusions each within the same second.

## Fix

Trigger only on `opened`/`reopened` and check for the `security` label in the payload. One event per PR open, one Slack post. A comment in the workflow warns against re-adding the `labeled` trigger.

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3469
<!-- enterprise-sync-pr:end -->