### PR TITLE
fix(annotation): persist schema attributes named after reserved keys

### DIFF
--- a/app/packages/annotation/src/state/build3dLabel.test.ts
+++ b/app/packages/annotation/src/state/build3dLabel.test.ts
@@ -3,7 +3,7 @@ import type {
   ReconciledPolyline3D,
 } from "@fiftyone/looker-3d";
 import { describe, expect, it } from "vitest";
-import { build3dLabel } from "./build3dLabel";
+import { build3dLabel, stripReservedLabelAttributes } from "./build3dLabel";
 
 const baseDetection = (
   overrides: Partial<ReconciledDetection3D> = {},
@@ -125,5 +125,40 @@ describe("build3dLabel", () => {
     build3dLabel(label);
     expect(label).toHaveProperty("color", "#ff0000");
     expect(label).toHaveProperty("path", "ground_truth_3d");
+  });
+});
+
+describe("stripReservedLabelAttributes", () => {
+  it("keeps a reserved-named key listed in `keep`", () => {
+    const result = stripReservedLabelAttributes(
+      { label: "car", type: "sedan", color: "#ff0000", isNew: true },
+      new Set(["type"]),
+    );
+
+    expect(result).toEqual({ label: "car", type: "sedan" });
+  });
+
+  it("ignores `keep` names outside the reserved set", () => {
+    const result = stripReservedLabelAttributes(
+      { label: "car", confidence: 0.9, path: "ground_truth" },
+      new Set(["label", "confidence"]),
+    );
+
+    expect(result).toEqual({ label: "car", confidence: 0.9 });
+  });
+
+  it("strips the full reserved set without `keep`", () => {
+    const result = stripReservedLabelAttributes({
+      label: "car",
+      color: "#ff0000",
+      id: "legacy",
+      isNew: true,
+      path: "ground_truth",
+      selected: true,
+      sampleId: "sample-1",
+      type: "Detection",
+    });
+
+    expect(result).toEqual({ label: "car" });
   });
 });

--- a/app/packages/annotation/src/state/build3dLabel.ts
+++ b/app/packages/annotation/src/state/build3dLabel.ts
@@ -26,12 +26,19 @@ export const reservedLabelAttributes = [
  * Drop the {@link reservedLabelAttributes} from a label-data partial — the
  * sanitizer for any path that commits a working/overlay-shaped label into the
  * engine or {@link Sample}.
+ *
+ * A label schema may declare a real attribute whose name collides with the
+ * reserved set (e.g. a "type" attribute on a Detection). Callers that know
+ * which names the schema owns pass them via `keep` so those values survive
+ * the strip.
  */
 export const stripReservedLabelAttributes = <T extends Record<string, unknown>>(
   data: T,
+  keep?: ReadonlySet<string>,
 ): T => {
   const out = { ...data };
   for (const key of reservedLabelAttributes) {
+    if (keep?.has(key)) continue;
     delete out[key];
   }
   return out;

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/AnnotationSchema.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/AnnotationSchema.tsx
@@ -251,8 +251,21 @@ const useHandleSchemaChange = (readOnly: boolean) => {
       // overlay shape (type/isNew/color/path/sampleId), and committing those
       // pollutes Sample — the write-half's `build3dLabel` strips the same set,
       // so the idempotent guard would never match and the sync loops forever.
+      // A schema-declared attribute may share a reserved name (e.g. "type");
+      // when the form (or a conditional owner-change) produced a value for it,
+      // that value is real label data and must survive the strip.
+      const schemaOwnedNames = new Set(
+        allAttributes
+          .map((attr) => attr.name)
+          .filter(
+            (name): name is string =>
+              !!name &&
+              (name in formResult || uniqueConditionalNames.has(name)),
+          ),
+      );
       const persistableValue = stripReservedLabelAttributes(
         value as Record<string, unknown>,
+        schemaOwnedNames,
       );
 
       // A video frame label belongs to a track. A static track-level edit


### PR DESCRIPTION
## 🔗 Related Issues

FOEPD-4255

## 📋 What changes are proposed in this pull request?

A label-schema attribute named `type` (or `color`, `isNew`, `path`, `selected`, `sampleId`) rendered in the annotation editor, but its edits were silently dropped: the form's save path strips a reserved set of overlay-bookkeeping keys before committing to the engine, and a user attribute sharing one of those names was stripped with them.

- `stripReservedLabelAttributes` accepts an optional `keep` set of names that survive the strip.
- The annotation form's commit path keeps reserved-named keys that are declared in the label schema and were produced by the form (or touched by a conditional owner-change rule). Overlay bookkeeping only enters the merged value via the overlay-label merge base, never from the form, so it still cannot leak into the sample document. The 3D write-half serializer (`build3dLabel`) is unchanged, so its idempotency guard is unaffected.

## 🧪 How is this patch tested? If it is not, please explain why.

- New unit tests for the `keep` behavior of `stripReservedLabelAttributes`
- `@fiftyone/annotation` suite (503 tests) and the Annotate sidebar suites in `@fiftyone/core` (312 tests) pass
- Manually: an integer and a string attribute named `type` now persist edits (the ticket's repro)

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

Fixed annotation editing for label attributes whose names collide with internal reserved keys (e.g. `type`) — their values now save correctly.

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed annotation schema values that use reserved attribute names, such as `type`, being removed when changes are saved.
  - Preserved schema-owned attributes during label updates while continuing to remove unrelated reserved attributes.

- **Tests**
  - Added coverage for preserving selected reserved attributes and removing reserved attributes when no exceptions are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3483
<!-- enterprise-sync-pr:end -->