### PR TITLE
fix(annotation): serialize SAM2 worker inference to prevent overlapping session runs

### DIFF
--- a/app/packages/annotation/src/providers/taskQueue.test.ts
+++ b/app/packages/annotation/src/providers/taskQueue.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { createTaskQueue } from "./taskQueue";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("createTaskQueue", () => {
+  it("resolves with each task's result", async () => {
+    const enqueue = createTaskQueue();
+
+    await expect(enqueue(async () => 1)).resolves.toBe(1);
+    await expect(enqueue(async () => "two")).resolves.toBe("two");
+  });
+
+  it("does not start a task until the previous one settles", async () => {
+    const enqueue = createTaskQueue();
+    const first = deferred<void>();
+    let secondStarted = false;
+
+    const firstResult = enqueue(() => first.promise);
+    const secondResult = enqueue(async () => {
+      secondStarted = true;
+    });
+
+    await Promise.resolve();
+    expect(secondStarted).toBe(false);
+
+    first.resolve();
+    await firstResult;
+    await secondResult;
+    expect(secondStarted).toBe(true);
+  });
+
+  it("runs tasks in submission order", async () => {
+    const enqueue = createTaskQueue();
+    const order: number[] = [];
+
+    await Promise.all(
+      [0, 1, 2, 3].map((i) =>
+        enqueue(async () => {
+          order.push(i);
+        }),
+      ),
+    );
+
+    expect(order).toEqual([0, 1, 2, 3]);
+  });
+
+  it("rejects the failing task's caller without blocking later tasks", async () => {
+    const enqueue = createTaskQueue();
+
+    const failing = enqueue(async () => {
+      throw new Error("boom");
+    });
+    const following = enqueue(async () => "ok");
+
+    await expect(failing).rejects.toThrow("boom");
+    await expect(following).resolves.toBe("ok");
+  });
+});

--- a/app/packages/annotation/src/providers/taskQueue.ts
+++ b/app/packages/annotation/src/providers/taskQueue.ts
@@ -1,0 +1,14 @@
+/**
+ * Create a FIFO async task queue. The returned `enqueue` runs tasks strictly
+ * one at a time in submission order; a task's failure rejects its own caller
+ * but never blocks later tasks.
+ */
+export const createTaskQueue = () => {
+  let tail: Promise<unknown> = Promise.resolve();
+
+  return <T>(task: () => Promise<T>): Promise<T> => {
+    const result = tail.then(task);
+    tail = result.catch(() => undefined);
+    return result;
+  };
+};

--- a/app/packages/annotation/src/providers/worker.ts
+++ b/app/packages/annotation/src/providers/worker.ts
@@ -23,6 +23,7 @@ import {
 } from "./math";
 import { loadModelWeights } from "./modelCache";
 import { getEmbedding, putEmbedding } from "./embeddingCache";
+import { createTaskQueue } from "./taskQueue";
 
 // Typed helpers to enforce message shapes at compile time.
 
@@ -141,6 +142,11 @@ if (!import.meta.env?.DEV && import.meta.env?.ORT_WASM_PATH) {
 
 let encoderSession: ort.InferenceSession | null = null;
 let decoderSession: ort.InferenceSession | null = null;
+
+// onnxruntime-web's WASM backend rejects overlapping run() calls with
+// "Session already started", so all model work is serialized FIFO — a
+// prompt arriving mid-encode waits for the active run instead of failing.
+const enqueueModelTask = createTaskQueue();
 
 /**
  * Fetch an image URL and decode it into ImageData.
@@ -798,30 +804,33 @@ self.onmessage = async (e: MessageEvent<WorkerInbound>) => {
 
   try {
     if (msg.type === "loadModel") {
-      await loadModel();
+      await enqueueModelTask(loadModel);
       postResponse(id, "loadModel", undefined as void);
     } else if (msg.type === "embedAndDecode") {
-      const result = await embedAndDecode(
-        msg.payload.imageUrl,
-        msg.payload.points,
+      const result = await enqueueModelTask(() =>
+        embedAndDecode(msg.payload.imageUrl, msg.payload.points),
       );
       postStatusNotification("ready");
       postResponse(id, "embedAndDecode", result, [
         result.mask.buffer as ArrayBuffer,
       ]);
     } else if (msg.type === "embedAndDecodeBitmap") {
-      const result = await embedAndDecodeBitmap(
-        msg.payload.bitmap,
-        msg.payload.cacheKey,
-        msg.payload.points,
-        msg.payload.useEmbeddingCache,
+      const result = await enqueueModelTask(() =>
+        embedAndDecodeBitmap(
+          msg.payload.bitmap,
+          msg.payload.cacheKey,
+          msg.payload.points,
+          msg.payload.useEmbeddingCache,
+        ),
       );
       postStatusNotification("ready");
       postResponse(id, "embedAndDecodeBitmap", result, [
         result.mask.buffer as ArrayBuffer,
       ]);
     } else if (msg.type === "encodeBitmap") {
-      await encodeBitmap(msg.payload.bitmap, msg.payload.cacheKey);
+      await enqueueModelTask(() =>
+        encodeBitmap(msg.payload.bitmap, msg.payload.cacheKey),
+      );
       postResponse(id, "encodeBitmap", undefined as void);
     }
   } catch (err) {


### PR DESCRIPTION
Fixes "Inference failed: session already started" in the in-browser SAM2 segmentation flow.

### What
- Serializes all model work in the SAM2 inference worker through a FIFO task queue (`loadModel`, `embedAndDecode`, `embedAndDecodeBitmap`, `encodeBitmap`).
- Adds `providers/taskQueue.ts`, a small FIFO async queue where a failing task rejects its own caller but never blocks later tasks.

### Notes
- onnxruntime-web's WASM backend rejects any overlapping `session.run()` with "Session already started" — the guard is global to the WASM module, not per session.
- The worker's async `onmessage` dispatched requests concurrently, and the annotation tool triggers inference on every prompt change without waiting for the previous run. Since a cold SAM2 encode takes seconds on single-threaded WASM, adding a second prompt point mid-encode reliably collided.
- With the queue, a prompt arriving mid-encode waits for the active run instead of failing; superseded results are still discarded client-side as before. Queued bursts are cheap in practice: repeat prompts on the same image hit the embedding cache and run decoder-only.

### Tests
- Unit coverage for the task queue: result propagation, strict FIFO ordering, no-overlap guarantee, and failure isolation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model processing reliability by ensuring tasks run one at a time and in submission order.
  * Prevented a failed task from blocking subsequent model operations.
  * Preserved existing error reporting and result handling while reducing failures caused by overlapping processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3491
<!-- enterprise-sync-pr:end -->