### PR TITLE
fix(app): don't crash the error screen when a GraphQL error has no extensions

### DIFF
--- a/app/packages/components/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/app/packages/components/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -58,10 +58,14 @@ export const ErrorDisplayMarkup = <T extends AppError>({
   let messages: { message: string; content: string }[] = [];
 
   if (error instanceof GraphQLError) {
-    messages = error.errors.map((e: any) => ({
-      message: e.message,
-      content: "\n\n" + (e.extensions?.stack?.join("\n") ?? ""),
-    }));
+    messages = error.errors.map((e: any) => {
+      const stack = e?.extensions?.stack;
+      const trace = Array.isArray(stack) ? stack.join("\n") : stack;
+      return {
+        message: e?.message,
+        content: typeof trace === "string" && trace ? "\n\n" + trace : "",
+      };
+    });
   } else if (error instanceof NetworkError) {
     messages = [];
     if (error.code)

--- a/app/packages/components/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/app/packages/components/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -60,7 +60,7 @@ export const ErrorDisplayMarkup = <T extends AppError>({
   if (error instanceof GraphQLError) {
     messages = error.errors.map((e: any) => ({
       message: e.message,
-      content: "\n\n" + e.extensions.stack.join("\n"),
+      content: "\n\n" + (e.extensions?.stack?.join("\n") ?? ""),
     }));
   } else if (error instanceof NetworkError) {
     messages = [];


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link.

## 📋 What changes are proposed in this pull request?

Guard the optional `extensions` field when rendering a `GraphQLError` in the
error boundary.

### The bug

Scrolling the grid past the loaded pages surfaces

```
TypeError: Cannot read properties of undefined (reading 'stack')
```

instead of whatever actually went wrong. The TypeError is not the grid failing —
it is the *error screen* failing while trying to render the grid's error.

The path:

1. Spotlight requests the next page, `useSpotlightPager` runs
   `fetchQuery(paginateSamples, ...)` and passes `error: handleError`
   (`app/packages/core/src/components/Grid/useSpotlightPager.ts`).
2. `fetchRelay` throws `GraphQLError` whenever a non-mutation `/graphql`
   response carries an `errors` array (`app/packages/state/src/utils.ts`).
3. `handleError` is `useErrorHandler`, so the error is rethrown into the nearest
   boundary, which renders `ErrorDisplayMarkup`.
4. `ErrorDisplayMarkup` reads `e.extensions.stack` for every entry in
   `error.errors`. `extensions` is optional in the GraphQL spec and is omitted
   from the response when empty, so any error entry without it throws — inside
   the fallback, which is what the user ends up seeing. The real server message
   is lost.

Every error the FiftyOne server itself returns does carry `extensions.stack` —
the `EndSession` extension in `fiftyone/server/extensions.py` rewrites them on
the way out (verified against resolver exceptions, validation errors, syntax
errors, variable-coercion errors and disallowed operation types). The crash
shows up when the `errors` array comes from something that did not run that
extension: a proxy or gateway returning a GraphQL-shaped body, or a backend
whose Strawberry version no longer dispatches the legacy `on_request_end` hook
that `EndSession` is built on.

This is not grid-specific — it is every consumer of `ErrorDisplayMarkup` — but
the grid pager is where it is easy to hit, because paging is the query most
likely to fail mid-session.

### Why the fix works

`e.extensions?.stack?.join("\n") ?? ""` makes the trace best-effort. The error's
`message` still renders, and the boundary still appends the JS trace lower down
via the existing `error.stack` branch, so a missing `extensions` costs a trace
detail rather than replacing the whole error report with a TypeError.

## 🧪 How is this patch tested? If it is not, please explain why.

Reproduced by resolving the App's `/graphql` page request with an error entry
that has no `extensions` key, e.g.

```json
{ "data": null, "errors": [{ "message": "boom" }] }
```

Before: the grid error screen renders as
`TypeError: Cannot read properties of undefined (reading 'stack')`.
After: it renders `GraphQL API Error: boom` with the JS trace.

No new tests: the change is a null-guard on a rendering detail in a component
that has no existing spec, and the failure mode is a runtime property access
rather than logic worth pinning.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

Fixed an error screen that reported
`TypeError: Cannot read properties of undefined (reading 'stack')` instead of
the underlying GraphQL error, most visibly when a page request failed while
scrolling the grid.

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GraphQL error handling to be null-safe when error stack details are missing or malformed.
  * Prevented secondary failures when displaying error messages by safely formatting stack traces only when valid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3493
<!-- enterprise-sync-pr:end -->