### PR TITLE
Add TIPSv2 to model zoo

### DIFF
--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -12266,6 +12266,88 @@
             "tags": ["ocr", "detection", "torch"],
             "training_data": [],
             "date_added": "2026-07-13 00:00:00"
+        },
+        {
+            "base_name": "tipsv2-b14-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "TIPSv2 base vision-language encoder for zero-shot image classification and spatially-aware embeddings",
+            "source": "https://huggingface.co/google/tipsv2-b14",
+            "author": "Google DeepMind",
+            "license": "Apache 2.0",
+            "size_bytes": 784561815,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.transformers.FiftyOneZeroShotTransformerForImageClassification",
+                "config": {
+                    "name_or_path": "google/tipsv2-b14"
+                }
+            },
+            "requirements": {
+                "packages": [
+                    "torch",
+                    "torchvision",
+                    "transformers>=5.14",
+                    "sentencepiece"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": [
+                "classification",
+                "logits",
+                "embeddings",
+                "torch",
+                "transformers",
+                "zero-shot",
+                "official"
+            ],
+            "training_data": [],
+            "date_added": "2026-07-22 00:00:00"
+        },
+        {
+            "base_name": "tipsv2-l14-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "TIPSv2 large vision-language encoder for zero-shot image classification and spatially-aware embeddings",
+            "source": "https://huggingface.co/google/tipsv2-l14",
+            "author": "Google DeepMind",
+            "license": "Apache 2.0",
+            "size_bytes": 1952552415,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.transformers.FiftyOneZeroShotTransformerForImageClassification",
+                "config": {
+                    "name_or_path": "google/tipsv2-l14"
+                }
+            },
+            "requirements": {
+                "packages": [
+                    "torch",
+                    "torchvision",
+                    "transformers>=5.14",
+                    "sentencepiece"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": [
+                "classification",
+                "logits",
+                "embeddings",
+                "torch",
+                "transformers",
+                "zero-shot",
+                "official"
+            ],
+            "training_data": [],
+            "date_added": "2026-07-22 00:00:00"
         }
     ]
 }

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -12442,6 +12442,88 @@
                 }
             ],
             "date_added": "2026-07-14 12:00:00"
+        },
+        {
+            "base_name": "tipsv2-b14-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "TIPSv2 base vision-language encoder for zero-shot image classification and spatially-aware embeddings",
+            "source": "https://huggingface.co/google/tipsv2-b14",
+            "author": "Google DeepMind",
+            "license": "Apache 2.0",
+            "size_bytes": 784561815,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.transformers.FiftyOneZeroShotTransformerForImageClassification",
+                "config": {
+                    "name_or_path": "google/tipsv2-b14"
+                }
+            },
+            "requirements": {
+                "packages": [
+                    "torch",
+                    "torchvision",
+                    "transformers>=5.14",
+                    "sentencepiece"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": [
+                "classification",
+                "logits",
+                "embeddings",
+                "torch",
+                "transformers",
+                "zero-shot",
+                "official"
+            ],
+            "training_data": [],
+            "date_added": "2026-07-22 00:00:00"
+        },
+        {
+            "base_name": "tipsv2-l14-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "TIPSv2 large vision-language encoder for zero-shot image classification and spatially-aware embeddings",
+            "source": "https://huggingface.co/google/tipsv2-l14",
+            "author": "Google DeepMind",
+            "license": "Apache 2.0",
+            "size_bytes": 1952552415,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.transformers.FiftyOneZeroShotTransformerForImageClassification",
+                "config": {
+                    "name_or_path": "google/tipsv2-l14"
+                }
+            },
+            "requirements": {
+                "packages": [
+                    "torch",
+                    "torchvision",
+                    "transformers>=5.14",
+                    "sentencepiece"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": [
+                "classification",
+                "logits",
+                "embeddings",
+                "torch",
+                "transformers",
+                "zero-shot",
+                "official"
+            ],
+            "training_data": [],
+            "date_added": "2026-07-22 00:00:00"
         }
     ]
 }


### PR DESCRIPTION
## Summary

Adds **TIPSv2** (Google DeepMind, CVPR 2026) to the model zoo as `tipsv2-b14-torch` and `tipsv2-l14-torch`. TIPSv2 is a contrastive vision-language encoder family distinguished by spatially rich patch-level features with strong patch-text alignment.

Manifest-only change: both checkpoints are native to `transformers` as of v5.14 and load through the existing `FiftyOneZeroShotTransformerForImageClassification` integration, serving zero-shot classification and embeddings like the CLIP/SigLIP entries.

| Model | Params | Size | Embedding dim |
|---|---|---|---|
| `tipsv2-b14-torch` | 196M | 0.78 GB | 768 |
| `tipsv2-l14-torch` | 488M | 1.95 GB | 1024 |

```python
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart", max_samples=5)
model = foz.load_zoo_model("tipsv2-l14-torch", classes=["person", "car", "dog"])
dataset.apply_model(model, label_field="predictions")

embeddings = dataset.compute_embeddings(model)
```

## Notes

Requirements declare `transformers>=5.14` (the release that added the `tipsv2` model type) and `sentencepiece` (its tokenizer). Apache 2.0 weights, ungated.

Verified end-to-end: both entries load via `load_zoo_model`, predict correctly on a test image, and produce embeddings (768-d / 1024-d).

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3499
<!-- enterprise-sync-pr:end -->