### PR TITLE
docs(enterprise): add CORS setup as a getting-started step + fill gaps

### DIFF
--- a/docs/source/enterprise/getting_started.rst
+++ b/docs/source/enterprise/getting_started.rst
@@ -21,7 +21,8 @@ An :ref:`admin user <enterprise-admin>` must configure cloud credentials
 
     If your workflows use cloud-backed point clouds, segmentation masks,
     in-App annotation, or multimodal (MCAP) datasets, you must also configure
-    :ref:`CORS <enterprise-cors>` on your cloud buckets as part of this step.
+    :ref:`CORS <enterprise-cors>` on your cloud storage buckets/containers as
+    part of this step.
     Without it, those assets fail to load in the App with a
     ``No 'Access-Control-Allow-Origin' header`` error. This is easy to miss and
     a common source of "asset failed to load" issues, so we recommend setting

--- a/docs/source/enterprise/getting_started.rst
+++ b/docs/source/enterprise/getting_started.rst
@@ -17,6 +17,17 @@ An :ref:`admin user <enterprise-admin>` must configure cloud credentials
    :alt: getting-started-cloud-creds
    :align: center
 
+.. note::
+
+    If your workflows use cloud-backed point clouds, segmentation masks,
+    in-App annotation, or multimodal (MCAP) datasets, you must also configure
+    :ref:`CORS <enterprise-cors>` on your cloud buckets as part of this step.
+    Without it, those assets fail to load in the App with a
+    ``No 'Access-Control-Allow-Origin' header`` error. This is easy to miss and
+    a common source of "asset failed to load" issues, so we recommend setting
+    it up now. See :ref:`Cross-origin resource sharing (CORS) <enterprise-cors>`
+    for per-provider instructions.
+
 .. _enterprise-getting-started-sdk:
 
 Create a dataset via the SDK 

--- a/docs/source/enterprise/installation.rst
+++ b/docs/source/enterprise/installation.rst
@@ -161,11 +161,22 @@ credentials for use by all app users <enterprise-cloud-storage-page>`.
 Cross-origin resource sharing (CORS)
 ____________________________________
 
-If your datasets include cloud-backed
-:ref:`point clouds <point-cloud-datasets>` or
-:ref:`segmentation maps <semantic-segmentation>`, you may need to configure
-cross-origin resource sharing (CORS) for your cloud buckets. Details are
-provided below for each cloud platform.
+We strongly recommend configuring cross-origin resource sharing (CORS) on your
+cloud buckets. Most media renders in the App via standard ``<img>``/``<video>``
+elements that do not require CORS, but any media that the App fetches and
+decodes directly in the browser **requires** it, including cloud-backed
+:ref:`point clouds <point-cloud-datasets>`,
+:ref:`segmentation maps <semantic-segmentation>`, in-App annotation, and
+multimodal (MCAP) datasets. Without CORS, these assets fail to load with a
+``No 'Access-Control-Allow-Origin' header is present on the requested resource``
+browser error, even when other media displays correctly in the App.
+
+When configuring CORS, set the allowed origin(s) to the URL(s) from which your
+users access the FiftyOne Enterprise App, and allow the ``GET`` and ``HEAD``
+methods. For media that is read in byte ranges (such as MCAP), also allow the
+``Range`` request header and expose the ``Content-Range``, ``Content-Length``,
+and ``Accept-Ranges`` response headers. Details are provided below for each
+cloud platform.
 
 Browser caching
 _______________
@@ -448,6 +459,25 @@ alias:
     you can provide it by setting the
     `AZURE_STORAGE_ACCOUNT_URL` environment variable or by including the
     `account_url` key in your credentials `.ini` file.
+
+If you need to configure CORS on your Azure Blob storage account, you can do so
+at the storage-account level (Blob service) via the Azure portal
+(**Settings > Resource sharing (CORS)**) or the Azure CLI:
+
+.. code-block:: shell
+
+    az storage cors add \
+        --services b \
+        --methods GET HEAD \
+        --origins "https://fiftyone-enterprise-deployment.yourcompany.com" \
+        --allowed-headers "*" \
+        --exposed-headers "*" \
+        --max-age 3600 \
+        --account-name <account-name>
+
+See the
+`Azure Storage CORS documentation <https://learn.microsoft.com/en-us/rest/api/storageservices/cross-origin-resource-sharing--cors--support-for-the-azure-storage-services>`_
+for more details.
 
 If you would like to take advantage of browser caching you can
 `specify cache-control headers on Azure blobs <https://learn.microsoft.com/en-us/azure/cdn/cdn-manage-expiration-of-blob-content#setting-cache-control-headers-by-using-azure-powershell>`_.

--- a/docs/source/enterprise/installation.rst
+++ b/docs/source/enterprise/installation.rst
@@ -326,7 +326,7 @@ here is an example configuration:
         {
             "origin": ["https://fiftyone-enterprise-deployment.yourcompany.com"],
             "method": ["GET", "HEAD"],
-            "responseHeader": ["*"],
+            "responseHeader": ["Content-Range", "Content-Length", "Accept-Ranges"],
             "maxAgeSeconds": 3600
         }
     ]

--- a/docs/source/enterprise/installation.rst
+++ b/docs/source/enterprise/installation.rst
@@ -162,7 +162,7 @@ Cross-origin resource sharing (CORS)
 ____________________________________
 
 We strongly recommend configuring cross-origin resource sharing (CORS) on your
-cloud buckets. Most media renders in the App via standard ``<img>``/``<video>``
+cloud storage buckets/containers. Most media renders in the App via standard ``<img>``/``<video>``
 elements that do not require CORS, but any media that the App fetches and
 decodes directly in the browser **requires** it, including cloud-backed
 :ref:`point clouds <point-cloud-datasets>`,
@@ -268,7 +268,7 @@ here is an example configuration:
             "AllowedHeaders": ["*"],
             "AllowedMethods": ["GET", "HEAD"],
             "AllowedOrigins": ["https://fiftyone-enterprise-deployment.yourcompany.com"],
-            "ExposeHeaders": [],
+            "ExposeHeaders": ["Content-Range", "Content-Length", "Accept-Ranges"],
             "MaxAgeSeconds": 86400
         }
     ]
@@ -471,9 +471,9 @@ at the storage-account level (Blob service) via the Azure portal
         --methods GET HEAD \
         --origins "https://fiftyone-enterprise-deployment.yourcompany.com" \
         --allowed-headers "*" \
-        --exposed-headers "*" \
+        --exposed-headers "Content-Range" "Content-Length" "Accept-Ranges" \
         --max-age 3600 \
-        --account-name <account-name>
+        --account-name "<account-name>"
 
 See the
 `Azure Storage CORS documentation <https://learn.microsoft.com/en-us/rest/api/storageservices/cross-origin-resource-sharing--cors--support-for-the-azure-storage-services>`_


### PR DESCRIPTION
## Summary

Makes CORS setup a **proactive step** in the enterprise onboarding docs, and fills gaps in the reference CORS instructions. Almost every enterprise customer hits CORS errors because it's set up reactively (after the error) rather than during onboarding.

- **`enterprise/getting_started.rst`** — adds a note under **"Configure cloud credentials"** linking to the CORS section, so customers set it up during onboarding.
- **`enterprise/installation.rst`** — improves the canonical CORS section:
  - Broadens the trigger list beyond point clouds/segmentation to include **in-App annotation** and **multimodal (MCAP) datasets**, and frames it as strongly recommended.
  - Adds the exact browser error string + origin/`GET`/`HEAD` and `Range`/exposed-headers guidance (the byte-range piece matters for MCAP).
  - Adds the **missing Azure Blob CORS example** (`az storage cors add`) — S3 and GCS already had one.

## Motivation

Recurring CS pain: customers can't load point clouds / segmentation masks / annotate labels / MCAP datasets because CORS wasn't configured, and the error (`No 'Access-Control-Allow-Origin' header`) is opaque. Recent real cases across S3 and Azure. Surfacing CORS as an onboarding step (per CS request) should cut these tickets.

## Implementation notes

- Single source of truth: getting_started **links** to the installation CORS section (no content duplication), matching the existing `:ref:` migration-link pattern on that page.
- `:ref:` targets used (`enterprise-cors`, `point-cloud-datasets`, `semantic-segmentation`) are verified anchors; "in-App annotation" and "MCAP" are plain text (no unverified refs).

## Test plan

- [x] Visual preview of both pages (single-page preview per `docs/` README).
- [x] Confirm the `enterprise-cors` `:ref:` link resolves from the getting-started note.
- [x] Sanity-check the new Azure `code-block:: shell` renders.

cc @AdonaiVera (please review 🙏)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded CORS guidance for cloud storage buckets/containers used by cloud-backed point clouds, segmentation masks, in-App annotation, and multimodal (MCAP) datasets.
  * Documented the browser error symptom when CORS is missing and the required CORS settings (matching origins, `GET`/`HEAD`, and byte-range reads via `Range` plus exposed `Content-*`/`Accept-Ranges` headers).
  * Updated the Amazon S3 CORS example to expose `Content-Range`, `Content-Length`, and `Accept-Ranges`.
  * Added Azure Blob Storage CORS configuration instructions with an Azure CLI example and reference links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3507
<!-- enterprise-sync-pr:end -->