### PR TITLE
feat(playback): sequence & absolute timeline modes (FOEPD-3811)

### DIFF
--- a/app/packages/multimodal/src/adapters/mcap/react/McapSourcePlayback.test.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapSourcePlayback.test.tsx
@@ -6,6 +6,7 @@ import {
   BYTE_SOURCE_READ_PROFILE,
   type ByteSourceDescriptor,
 } from "../../../query/bytes";
+import type { StreamInventory } from "../../../schemas/v1";
 import type { McapResourceClient } from "../types";
 import { McapSourcePlayback } from "./McapSourcePlayback";
 
@@ -16,7 +17,7 @@ const playbackHarness = vi.hoisted(() => {
       error: null as string | null,
       sources: [] as Array<{ id: string; label: string; type: string }>,
       status: "ready" as "error" | "idle" | "loading" | "ready",
-      topics: [] as never[],
+      topics: [] as StreamInventory[],
       topicCount: 3,
     },
     shellMounts: 0,
@@ -367,18 +368,73 @@ describe("McapSourcePlayback", () => {
         ?.hasAttribute("data-mcap-source-transitioning"),
     ).toBe(false);
   });
+
+  it("remounts the shell when the resolved timeline mode changes across a source navigation", () => {
+    const client = {
+      activateSource: vi.fn(),
+    } as unknown as McapResourceClient;
+    const firstSource = createSource("sample-a");
+    const secondSource = createSource("sample-b");
+    playbackHarness.sceneInventory = readyInventory("/camera/a");
+
+    const { rerender } = render(
+      <McapSourcePlayback
+        client={client}
+        fileName="sample-a.mcap"
+        source={firstSource}
+      />,
+    );
+    const durationInstance = screen
+      .getByTestId("playback-shell")
+      .getAttribute("data-instance-id");
+
+    playbackHarness.sceneInventory = readyInventory("/camera/b", [
+      timelineModeTopic("sequence", {
+        "mcap.channel_metadata.timeline_fps": "24",
+      }),
+    ]);
+    rerender(
+      <McapSourcePlayback
+        client={client}
+        fileName="sample-b.mcap"
+        source={secondSource}
+      />,
+    );
+
+    expect(
+      screen.getByTestId("playback-shell").getAttribute("data-instance-id"),
+    ).not.toBe(durationInstance);
+  });
 });
 
 function createSource(sourceId: string, etag?: string): ByteSourceDescriptor {
   return { sourceId, url: `memory://${sourceId}.mcap`, etag };
 }
 
-function readyInventory(topic: string) {
+function timelineModeTopic(
+  mode: "sequence" | "absolute",
+  extraMetadata: Record<string, string> = {},
+): StreamInventory {
+  return {
+    $typeName: "fiftyone.multimodal.schemas.v1.StreamInventory",
+    displayName: "/topic",
+    metadata: { "mcap.channel_metadata.timeline_mode": mode, ...extraMetadata },
+    payload: {
+      $typeName: "fiftyone.multimodal.schemas.v1.PayloadDescriptor",
+      encoding: "protobuf",
+      schema: "foxglove.CompressedImage",
+      schemaEncoding: "protobuf",
+    },
+    streamId: "/topic",
+  };
+}
+
+function readyInventory(topic: string, topics: StreamInventory[] = []) {
   return {
     error: null,
     sources: [{ id: topic, label: topic, type: "image" }],
     status: "ready" as const,
-    topics: [],
+    topics,
     topicCount: 1,
   };
 }

--- a/app/packages/multimodal/src/adapters/mcap/react/McapSourcePlayback.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapSourcePlayback.tsx
@@ -230,6 +230,17 @@ export const McapSourcePlayback: React.FC<McapSourcePlaybackProps> = ({
     () => resolveMcapTimelineMode(shellTopics),
     [shellTopics],
   );
+  // PlaybackProvider reads `mode` only at creation (see MultiModalPlayback's
+  // `mode` prop doc). Keying MultiModalPlayback by every resolved mode field
+  // forces a remount — and a fresh provider/store — whenever navigating to a
+  // source resolves a different timeline mode, instead of silently retaining
+  // the previous mode's stale presentation.
+  const timelineModeKey =
+    timelineMode.kind === "sequence"
+      ? `sequence:${timelineMode.fps}`
+      : timelineMode.kind === "absolute"
+        ? `absolute:${timelineMode.epochAnchorMs}`
+        : "duration";
   const playbackSource = readyInventory && !navigationPending ? source : null;
   const effectiveLayoutScopeKey =
     layoutScopeKey ?? (source ? `mcap-source:${source.sourceId}` : undefined);
@@ -356,6 +367,7 @@ export const McapSourcePlayback: React.FC<McapSourcePlaybackProps> = ({
                             onChange={onImageAspectRatioChange}
                           >
                             <MultiModalPlayback
+                              key={timelineModeKey}
                               fileName={fileName}
                               decorateTrack={decorateTrack}
                               headerCaption={headerCaption}

--- a/app/packages/multimodal/src/adapters/mcap/react/McapSourcePlayback.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapSourcePlayback.tsx
@@ -76,6 +76,7 @@ import {
   useMcapModalLayout,
 } from "./use-mcap-modal-layout";
 import { useMcapSceneInventory } from "./use-mcap-scene-inventory";
+import { resolveMcapTimelineMode } from "../timeline-mode";
 
 const EMPTY_MANUAL_TILE_TITLES: Record<string, string> = {};
 
@@ -225,6 +226,10 @@ export const McapSourcePlayback: React.FC<McapSourcePlaybackProps> = ({
   const shellInventory = readyInventory ?? retainedInventoryRef.current;
   const shellSources = shellInventory?.sources ?? sources;
   const shellTopics = shellInventory?.topics ?? topics;
+  const timelineMode = useMemo(
+    () => resolveMcapTimelineMode(shellTopics),
+    [shellTopics],
+  );
   const playbackSource = readyInventory && !navigationPending ? source : null;
   const effectiveLayoutScopeKey =
     layoutScopeKey ?? (source ? `mcap-source:${source.sourceId}` : undefined);
@@ -360,6 +365,7 @@ export const McapSourcePlayback: React.FC<McapSourcePlaybackProps> = ({
                               addTileMenu={<McapAddTileMenu />}
                               timelineExtraActions={<McapTimestampReadout />}
                               sceneSources={shellSources}
+                              mode={timelineMode}
                               deselectFocusedTileOnRepeatSelect={false}
                               initialTiles={initialTiles}
                               initialManualTileTitles={initialManualTileTitles}

--- a/app/packages/multimodal/src/adapters/mcap/resources/read-topics.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/resources/read-topics.test.ts
@@ -1,0 +1,99 @@
+import type { McapTypes } from "@mcap/core";
+import { describe, expect, it } from "vitest";
+import type { McapIndexedReaderLike } from "../reader";
+import { readMcapTopics } from "./read-topics";
+
+function createChannel(
+  options: Partial<McapTypes.TypedMcapRecords["Channel"]> = {},
+): McapTypes.TypedMcapRecords["Channel"] {
+  return {
+    id: options.id ?? 1,
+    messageEncoding: options.messageEncoding ?? "json",
+    metadata: options.metadata ?? new Map(),
+    schemaId: options.schemaId ?? 0,
+    topic: options.topic ?? "/topic",
+    type: "Channel",
+  };
+}
+
+function createReader(
+  options: Partial<McapIndexedReaderLike> = {},
+): McapIndexedReaderLike {
+  return {
+    channelsById: options.channelsById ?? new Map(),
+    chunkIndexes: options.chunkIndexes ?? [],
+    schemasById: options.schemasById ?? new Map(),
+    statistics: options.statistics,
+  };
+}
+
+describe("readMcapTopics", () => {
+  it("stamps every topic with the scene's start time", () => {
+    const reader = createReader({
+      channelsById: new Map([
+        [1, createChannel({ id: 1, topic: "/a" })],
+        [2, createChannel({ id: 2, topic: "/b" })],
+      ]),
+      statistics: {
+        attachmentCount: 0,
+        channelCount: 2,
+        channelMessageCounts: new Map(),
+        chunkCount: 0,
+        messageCount: 0n,
+        messageEndTime: 0n,
+        messageStartTime: 1700000000000000000n,
+        metadataCount: 0,
+        schemaCount: 0,
+        type: "Statistics",
+      },
+    });
+
+    const topics = readMcapTopics(reader);
+
+    expect(
+      topics.map((topic) => topic.metadata["mcap.scene_start_time_ns"]),
+    ).toEqual(["1700000000000000000", "1700000000000000000"]);
+  });
+
+  it("defaults the scene start time to 0 when statistics are unavailable", () => {
+    const reader = createReader({
+      channelsById: new Map([[1, createChannel({ id: 1 })]]),
+    });
+
+    const topics = readMcapTopics(reader);
+
+    expect(topics[0]?.metadata["mcap.scene_start_time_ns"]).toBe("0");
+  });
+
+  it("doesn't clobber a channel that already has a literal mcap.scene_start_time_ns key", () => {
+    // Matches the existing putDerivedMetadata convention used by every
+    // other derived key in this function (e.g. mcap.channel_id).
+    const reader = createReader({
+      channelsById: new Map([
+        [
+          1,
+          createChannel({
+            id: 1,
+            metadata: new Map([["mcap.scene_start_time_ns", "42"]]),
+          }),
+        ],
+      ]),
+      statistics: {
+        attachmentCount: 0,
+        channelCount: 1,
+        channelMessageCounts: new Map(),
+        chunkCount: 0,
+        messageCount: 0n,
+        messageEndTime: 0n,
+        messageStartTime: 999n,
+        metadataCount: 0,
+        schemaCount: 0,
+        type: "Statistics",
+      },
+    });
+
+    const topics = readMcapTopics(reader);
+
+    expect(topics[0]?.metadata["mcap.scene_start_time_ns"]).toBe("42");
+  });
+});

--- a/app/packages/multimodal/src/adapters/mcap/resources/read-topics.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/resources/read-topics.test.ts
@@ -1,5 +1,5 @@
 import type { McapTypes } from "@mcap/core";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { McapIndexedReaderLike } from "../reader";
 import { readMcapTopics } from "./read-topics";
 
@@ -22,6 +22,13 @@ function createReader(
   return {
     channelsById: options.channelsById ?? new Map(),
     chunkIndexes: options.chunkIndexes ?? [],
+    readMessages:
+      options.readMessages ??
+      vi.fn(async function* () {
+        for (const message of [] as McapTypes.TypedMcapRecords["Message"][]) {
+          yield message;
+        }
+      }),
     schemasById: options.schemasById ?? new Map(),
     statistics: options.statistics,
   };

--- a/app/packages/multimodal/src/adapters/mcap/resources/read-topics.ts
+++ b/app/packages/multimodal/src/adapters/mcap/resources/read-topics.ts
@@ -50,6 +50,15 @@ function channelMetadata(
     "mcap.generic_decode_status",
     genericDecodeStatusForChannel(reader, channel),
   );
+  // Needed to resolve `absolute`-mode's epoch anchor before the engine
+  // mounts (see resolveMcapTimelineMode in ../timeline-mode.ts) — the
+  // engine's internal clock is always 0-based from the scene's first
+  // message, so mapping back to real wall-clock time requires this value.
+  putDerivedMetadata(
+    metadata,
+    "mcap.scene_start_time_ns",
+    (reader.statistics?.messageStartTime ?? 0n).toString(),
+  );
 
   if (schema) {
     putDerivedMetadata(metadata, "mcap.schema_encoding", schema.encoding);

--- a/app/packages/multimodal/src/adapters/mcap/timeline-mode.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/timeline-mode.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import type { StreamInventory } from "../../schemas/v1";
+import { resolveMcapTimelineMode } from "./timeline-mode";
+
+function createTopic(metadata: Record<string, string> = {}): StreamInventory {
+  return {
+    $typeName: "fiftyone.multimodal.schemas.v1.StreamInventory",
+    displayName: "/topic",
+    metadata,
+    payload: {
+      $typeName: "fiftyone.multimodal.schemas.v1.PayloadDescriptor",
+      encoding: "protobuf",
+      schema: "foxglove.CompressedImage",
+      schemaEncoding: "protobuf",
+    },
+    streamId: "/topic",
+  };
+}
+
+describe("resolveMcapTimelineMode", () => {
+  it("defaults to duration mode when no topic declares timeline_mode", () => {
+    expect(resolveMcapTimelineMode([createTopic(), createTopic()])).toEqual({
+      kind: "duration",
+    });
+  });
+
+  it("defaults to duration mode for an empty topic list", () => {
+    expect(resolveMcapTimelineMode([])).toEqual({ kind: "duration" });
+  });
+
+  it("resolves sequence mode with the declared fps", () => {
+    const topics = [
+      createTopic(),
+      createTopic({
+        "mcap.channel_metadata.timeline_mode": "sequence",
+        "mcap.channel_metadata.timeline_fps": "12",
+      }),
+    ];
+    expect(resolveMcapTimelineMode(topics)).toEqual({
+      kind: "sequence",
+      fps: 12,
+    });
+  });
+
+  it("falls back to duration when sequence mode's fps is missing or invalid", () => {
+    const missingFps = [
+      createTopic({ "mcap.channel_metadata.timeline_mode": "sequence" }),
+    ];
+    expect(resolveMcapTimelineMode(missingFps)).toEqual({ kind: "duration" });
+
+    const zeroFps = [
+      createTopic({
+        "mcap.channel_metadata.timeline_mode": "sequence",
+        "mcap.channel_metadata.timeline_fps": "0",
+      }),
+    ];
+    expect(resolveMcapTimelineMode(zeroFps)).toEqual({ kind: "duration" });
+
+    const nonNumericFps = [
+      createTopic({
+        "mcap.channel_metadata.timeline_mode": "sequence",
+        "mcap.channel_metadata.timeline_fps": "not-a-number",
+      }),
+    ];
+    expect(resolveMcapTimelineMode(nonNumericFps)).toEqual({
+      kind: "duration",
+    });
+  });
+
+  it("resolves absolute mode's epoch anchor from an explicit override", () => {
+    const topics = [
+      createTopic({
+        "mcap.channel_metadata.timeline_mode": "absolute",
+        "mcap.channel_metadata.timeline_epoch_anchor_ms": "1700000000000",
+      }),
+    ];
+    expect(resolveMcapTimelineMode(topics)).toEqual({
+      kind: "absolute",
+      epochAnchorMs: 1700000000000,
+    });
+  });
+
+  it("derives absolute mode's epoch anchor from the scene start time when no override is given", () => {
+    const topics = [
+      createTopic({
+        "mcap.channel_metadata.timeline_mode": "absolute",
+        "mcap.scene_start_time_ns": "1700000000000000000",
+      }),
+    ];
+    expect(resolveMcapTimelineMode(topics)).toEqual({
+      kind: "absolute",
+      epochAnchorMs: 1700000000000,
+    });
+  });
+
+  it("defaults absolute mode's epoch anchor to 0 when neither is present", () => {
+    const topics = [
+      createTopic({ "mcap.channel_metadata.timeline_mode": "absolute" }),
+    ];
+    expect(resolveMcapTimelineMode(topics)).toEqual({
+      kind: "absolute",
+      epochAnchorMs: 0,
+    });
+  });
+
+  it("uses the first topic that declares a timeline_mode", () => {
+    const topics = [
+      createTopic(),
+      createTopic({
+        "mcap.channel_metadata.timeline_mode": "sequence",
+        "mcap.channel_metadata.timeline_fps": "24",
+      }),
+      createTopic({
+        "mcap.channel_metadata.timeline_mode": "absolute",
+      }),
+    ];
+    expect(resolveMcapTimelineMode(topics)).toEqual({
+      kind: "sequence",
+      fps: 24,
+    });
+  });
+
+  it("falls back to duration for an unrecognized timeline_mode value", () => {
+    const topics = [
+      createTopic({ "mcap.channel_metadata.timeline_mode": "bogus" }),
+    ];
+    expect(resolveMcapTimelineMode(topics)).toEqual({ kind: "duration" });
+  });
+});

--- a/app/packages/multimodal/src/adapters/mcap/timeline-mode.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/timeline-mode.test.ts
@@ -93,6 +93,16 @@ describe("resolveMcapTimelineMode", () => {
     });
   });
 
+  it("falls back to duration when scene_start_time_ns is malformed", () => {
+    const topics = [
+      createTopic({
+        "mcap.channel_metadata.timeline_mode": "absolute",
+        "mcap.scene_start_time_ns": "not-an-integer",
+      }),
+    ];
+    expect(resolveMcapTimelineMode(topics)).toEqual({ kind: "duration" });
+  });
+
   it("defaults absolute mode's epoch anchor to 0 when neither is present", () => {
     const topics = [
       createTopic({ "mcap.channel_metadata.timeline_mode": "absolute" }),

--- a/app/packages/multimodal/src/adapters/mcap/timeline-mode.ts
+++ b/app/packages/multimodal/src/adapters/mcap/timeline-mode.ts
@@ -1,0 +1,57 @@
+import type { TimelineMode } from "@fiftyone/playback";
+import type { StreamInventory } from "../../schemas/v1";
+
+// Placeholder metadata convention written by
+// datasets/timing_mode_test/tools/rewrite-timing-mode.mjs — not a finalized
+// ingestion contract (see "Open concern: sequence mode's fps vs. the
+// ingestion schema" in /home/mikeobrien/Voxel51/plans/TIMELINE_MODES_DESIGN.md).
+// Rename/restructure freely once a real ingestion bridge design lands.
+const TIMELINE_MODE_METADATA_KEY = "mcap.channel_metadata.timeline_mode";
+const TIMELINE_FPS_METADATA_KEY = "mcap.channel_metadata.timeline_fps";
+const TIMELINE_EPOCH_ANCHOR_METADATA_KEY =
+  "mcap.channel_metadata.timeline_epoch_anchor_ms";
+const SCENE_START_TIME_NS_METADATA_KEY = "mcap.scene_start_time_ns";
+
+/**
+ * Resolves a scene's `TimelineMode` from topic metadata. Looks at the first
+ * topic carrying a `timeline_mode` key; falls back to `duration` if no topic
+ * declares one, or if a declared `sequence`/`absolute` mode is missing the
+ * data it needs to convert.
+ */
+export function resolveMcapTimelineMode(
+  topics: readonly StreamInventory[],
+): TimelineMode {
+  const tagged = topics.find(
+    (topic) => topic.metadata[TIMELINE_MODE_METADATA_KEY] !== undefined,
+  );
+  if (!tagged) return { kind: "duration" };
+
+  switch (tagged.metadata[TIMELINE_MODE_METADATA_KEY]) {
+    case "sequence": {
+      const fps = Number(tagged.metadata[TIMELINE_FPS_METADATA_KEY]);
+      return Number.isFinite(fps) && fps > 0
+        ? { kind: "sequence", fps }
+        : { kind: "duration" };
+    }
+    case "absolute": {
+      const explicitAnchorMs = Number(
+        tagged.metadata[TIMELINE_EPOCH_ANCHOR_METADATA_KEY],
+      );
+      if (Number.isFinite(explicitAnchorMs)) {
+        return { kind: "absolute", epochAnchorMs: explicitAnchorMs };
+      }
+      // No explicit anchor override — the engine's internal clock is
+      // 0-based from the scene's first message, so the anchor is that
+      // message's real time.
+      const sceneStartTimeNs = BigInt(
+        tagged.metadata[SCENE_START_TIME_NS_METADATA_KEY] ?? "0",
+      );
+      return {
+        kind: "absolute",
+        epochAnchorMs: Number(sceneStartTimeNs / 1_000_000n),
+      };
+    }
+    default:
+      return { kind: "duration" };
+  }
+}

--- a/app/packages/multimodal/src/adapters/mcap/timeline-mode.ts
+++ b/app/packages/multimodal/src/adapters/mcap/timeline-mode.ts
@@ -43,9 +43,16 @@ export function resolveMcapTimelineMode(
       // No explicit anchor override — the engine's internal clock is
       // 0-based from the scene's first message, so the anchor is that
       // message's real time.
-      const sceneStartTimeNs = BigInt(
-        tagged.metadata[SCENE_START_TIME_NS_METADATA_KEY] ?? "0",
-      );
+      let sceneStartTimeNs: bigint;
+      try {
+        sceneStartTimeNs = BigInt(
+          tagged.metadata[SCENE_START_TIME_NS_METADATA_KEY] ?? "0",
+        );
+      } catch {
+        // Malformed metadata (e.g. non-integer) — fall back to duration
+        // rather than crashing playback.
+        return { kind: "duration" };
+      }
       return {
         kind: "absolute",
         epochAnchorMs: Number(sceneStartTimeNs / 1_000_000n),

--- a/app/packages/multimodal/src/components/MultiModalPlayback/MultiModalPlayback.test.tsx
+++ b/app/packages/multimodal/src/components/MultiModalPlayback/MultiModalPlayback.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { useMode } from "@fiftyone/playback";
 import { useTiling } from "@fiftyone/tiling";
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -132,6 +133,29 @@ describe("MultiModalPlayback shell", () => {
     expect(screen.getByTestId("webgpu-view-stage").className).toContain(
       "sharedViewStage",
     );
+  });
+
+  it("defaults the playback engine to duration mode", () => {
+    const ModeReadout = () => <span data-testid="mode">{useMode().kind}</span>;
+    render(
+      <MultiModalPlayback fileName="session.fo">
+        <ModeReadout />
+      </MultiModalPlayback>,
+    );
+    expect(screen.getByTestId("mode").textContent).toBe("duration");
+  });
+
+  it("forwards the mode prop through to the playback engine", () => {
+    const ModeReadout = () => <span data-testid="mode">{useMode().kind}</span>;
+    render(
+      <MultiModalPlayback
+        fileName="session.fo"
+        mode={{ kind: "sequence", fps: 12 }}
+      >
+        <ModeReadout />
+      </MultiModalPlayback>,
+    );
+    expect(screen.getByTestId("mode").textContent).toBe("sequence");
   });
 
   it("does not mount the shared WebGPU view stage by default", () => {

--- a/app/packages/multimodal/src/components/MultiModalPlayback/MultiModalPlayback.tsx
+++ b/app/packages/multimodal/src/components/MultiModalPlayback/MultiModalPlayback.tsx
@@ -25,6 +25,7 @@ import {
   TemporalTagTimeline,
   TrackProvider,
   type TemporalTagTimelineProps,
+  type TimelineMode,
   type Track,
 } from "@fiftyone/playback";
 import {
@@ -108,6 +109,15 @@ export interface MultiModalPlaybackProps {
 
   /** Discoverable data sources for the current scene. */
   sceneSources?: readonly SceneSource[];
+
+  /**
+   * Presentation mode for the shared timeline ruler / scrub UI — frame
+   * numbers (`sequence`), wall-clock timestamps (`absolute`), or elapsed
+   * seconds (`duration`, the default). Resolved once, before mount; per
+   * `PlaybackProvider`'s contract this is read only at creation and won't
+   * react to later prop changes.
+   */
+  mode?: TimelineMode;
 
   /**
    * Hosts compatible image panels in one lazily-mounted WebGPU canvas.
@@ -237,6 +247,7 @@ const MultiModalPlayback: React.FC<MultiModalPlaybackProps> = ({
   resetLayout,
   resetLayoutStrategy,
   sceneSources = EMPTY_SOURCES,
+  mode,
   sharedImageWebGpuViews = false,
   deselectFocusedTileOnRepeatSelect = true,
   leftSidebar = <TileSettingsSidebar />,
@@ -257,7 +268,7 @@ const MultiModalPlayback: React.FC<MultiModalPlaybackProps> = ({
   className,
 }) => {
   return (
-    <PlaybackProvider>
+    <PlaybackProvider mode={mode}>
       {/* Only the grid-filtered tags (initialPinnedIds) start pinned. Auto-pin
           is off so tracks arriving in async batches don't each pin themselves,
           which would pin everything as the batches land. */}

--- a/app/packages/playback/index.ts
+++ b/app/packages/playback/index.ts
@@ -39,13 +39,13 @@ export type { TemporalTagTimelineProps } from "./src/views/TemporalTag/TemporalT
 // re-exported above / via the `export *` lines.)
 export {
   PlaybackProvider,
+  useMode,
   usePlayback,
 } from "./src/lib/playback/PlaybackProvider";
 export {
   useCurrentTime,
   useDuration,
   useIsPlaying,
-  useMode,
   usePlayhead,
 } from "./src/lib/playback/use-playback-state";
 export {

--- a/app/packages/playback/index.ts
+++ b/app/packages/playback/index.ts
@@ -16,6 +16,7 @@ export type {
   PlaybackStore,
   PlaybackStream,
   SeekEvent,
+  TimelineMode,
 } from "./src/lib/playback/types";
 export * from "./src/lib/tracks/TrackProvider";
 export * from "./src/views/Timeline/Timeline";
@@ -44,8 +45,17 @@ export {
   useCurrentTime,
   useDuration,
   useIsPlaying,
+  useMode,
   usePlayhead,
 } from "./src/lib/playback/use-playback-state";
+export {
+  createTimelineDisplayConversion,
+  useTimelineDisplay,
+} from "./src/lib/playback/timeline-display";
+export type {
+  TimelineDisplayConversion,
+  TimelineDisplayValue,
+} from "./src/lib/playback/timeline-display";
 export { usePlaybackStream } from "./src/lib/playback/use-playback-stream";
 export {
   usePresentedMediaTime,

--- a/app/packages/playback/src/lib/playback/PlaybackProvider.test.tsx
+++ b/app/packages/playback/src/lib/playback/PlaybackProvider.test.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, renderHook } from "@testing-library/react";
+import { act, cleanup, render, renderHook } from "@testing-library/react";
 import { useAtomValue } from "jotai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -18,11 +18,12 @@ import {
 } from "./atoms";
 import {
   PlaybackProvider,
+  useMode,
   usePlayback,
   usePlaybackStore,
 } from "./PlaybackProvider";
 import { bumpStreamRangesVersion, setBufferedRanges } from "./store-access";
-import type { PlaybackStream } from "./types";
+import type { PlaybackStream, TimelineMode } from "./types";
 import { MAX_SPEED } from "../constants";
 
 interface RenderOpts {
@@ -1150,6 +1151,57 @@ describe("PlaybackProvider engine actions", () => {
       });
       // No step declared → still the provider fallback.
       expect(result.current.store.get(stepIntervalAtom)).toBeCloseTo(1 / 30, 6);
+    });
+  });
+
+  describe("timeline mode", () => {
+    // useMode()'s value must stay fixed for the provider's lifetime — the
+    // engine's stepInterval fallback is captured once at mount (see
+    // usePlaybackEngine's mount-scoped store useMemo), so a `mode` prop
+    // change without a remount must NOT update what useMode() returns;
+    // otherwise consumers would see a new display domain while the engine's
+    // mode-dependent state stays stale. Callers that need a new mode must
+    // remount the provider (e.g. keyed on the resolved mode).
+    it("freezes the resolved mode at mount despite a later prop change", () => {
+      function Probe({ onRender }: { onRender: (m: TimelineMode) => void }) {
+        onRender(useMode());
+        return null;
+      }
+      const seen: TimelineMode[] = [];
+      const { rerender } = render(
+        <PlaybackProvider duration={10} mode={{ kind: "sequence", fps: 30 }}>
+          <Probe onRender={(m) => seen.push(m)} />
+        </PlaybackProvider>,
+      );
+      expect(seen.at(-1)).toEqual({ kind: "sequence", fps: 30 });
+
+      rerender(
+        <PlaybackProvider duration={10} mode={{ kind: "sequence", fps: 60 }}>
+          <Probe onRender={(m) => seen.push(m)} />
+        </PlaybackProvider>,
+      );
+      expect(seen.at(-1)).toEqual({ kind: "sequence", fps: 30 });
+
+      rerender(
+        <PlaybackProvider
+          duration={10}
+          mode={{ kind: "absolute", epochAnchorMs: 12345 }}
+        >
+          <Probe onRender={(m) => seen.push(m)} />
+        </PlaybackProvider>,
+      );
+      expect(seen.at(-1)).toEqual({ kind: "sequence", fps: 30 });
+    });
+
+    it("falls back to duration mode when the mount-time fps is invalid", () => {
+      const { result } = renderHook(() => useMode(), {
+        wrapper: ({ children }) => (
+          <PlaybackProvider duration={10} mode={{ kind: "sequence", fps: 0 }}>
+            {children}
+          </PlaybackProvider>
+        ),
+      });
+      expect(result.current).toEqual({ kind: "duration" });
     });
   });
 

--- a/app/packages/playback/src/lib/playback/PlaybackProvider.tsx
+++ b/app/packages/playback/src/lib/playback/PlaybackProvider.tsx
@@ -45,6 +45,7 @@ export function PlaybackProvider({
   defaultLoopEnd,
   defaultSpeed = 1.0,
   snapToFrameOnSettle,
+  mode,
 }: PlaybackConfig & { children: React.ReactNode }) {
   const { store, contextValue } = usePlaybackEngine({
     duration,
@@ -53,6 +54,7 @@ export function PlaybackProvider({
     defaultLoopEnd,
     defaultSpeed,
     snapToFrameOnSettle,
+    mode,
   });
 
   // We deliberately do NOT mount a Jotai `<Provider>` here. Every reactive

--- a/app/packages/playback/src/lib/playback/PlaybackProvider.tsx
+++ b/app/packages/playback/src/lib/playback/PlaybackProvider.tsx
@@ -1,10 +1,54 @@
 import React, { createContext, useContext, useMemo } from "react";
 import { PlaybackStoreContext } from "./playback-store-context";
-import type { PlaybackConfig, PlaybackContextValue } from "./types";
+import type {
+  PlaybackConfig,
+  PlaybackContextValue,
+  TimelineMode,
+} from "./types";
 import { useDuration, useStepInterval } from "./use-playback-state";
 import { usePlaybackEngine } from "./use-playback-engine";
 
 const PlaybackContext = createContext<PlaybackContextValue | null>(null);
+
+const DEFAULT_MODE: TimelineMode = { kind: "duration" };
+
+/**
+ * Falls back to `duration` mode when a caller-provided `TimelineMode`'s
+ * numeric fields can't produce a sane conversion — a non-finite/non-positive
+ * `sequence.fps` would make `stepInterval` (and every frame conversion)
+ * `Infinity`/`NaN`/`0`; a non-finite `absolute.epochAnchorMs` would make
+ * every converted timestamp an Invalid Date. Validated once here so every
+ * consumer (the engine's stepInterval fallback, `TimelineModeContext`,
+ * ruler tick math) sees only sane values.
+ */
+function normalizeTimelineMode(mode: TimelineMode): TimelineMode {
+  switch (mode.kind) {
+    case "sequence":
+      return Number.isFinite(mode.fps) && mode.fps > 0 ? mode : DEFAULT_MODE;
+    case "absolute":
+      return Number.isFinite(mode.epochAnchorMs) ? mode : DEFAULT_MODE;
+    default:
+      return mode;
+  }
+}
+
+/**
+ * How the timeline's shared clock is presented to and driven by consumers.
+ * Static for the lifetime of the provider — set once from
+ * `PlaybackConfig.mode` when `PlaybackProvider` mounts. This is Context
+ * rather than a Jotai atom because it's static-ish config for a bounded
+ * tree, not reactive global state (see CODING_STANDARDS.md).
+ */
+const TimelineModeContext = createContext<TimelineMode>(DEFAULT_MODE);
+
+/**
+ * How the timeline's shared clock is presented to and driven by consumers.
+ * Most components should use `useTimelineDisplay()` (in `timeline-display.ts`)
+ * instead of reading this directly.
+ */
+export function useMode(): TimelineMode {
+  return useContext(TimelineModeContext);
+}
 
 /**
  * Reads the live duration / stepInterval (which our reactive hooks pull
@@ -47,6 +91,10 @@ export function PlaybackProvider({
   snapToFrameOnSettle,
   mode,
 }: PlaybackConfig & { children: React.ReactNode }) {
+  const resolvedMode = useMemo(
+    () => normalizeTimelineMode(mode ?? DEFAULT_MODE),
+    [mode],
+  );
   const { store, contextValue } = usePlaybackEngine({
     duration,
     stepInterval,
@@ -54,7 +102,7 @@ export function PlaybackProvider({
     defaultLoopEnd,
     defaultSpeed,
     snapToFrameOnSettle,
-    mode,
+    mode: resolvedMode,
   });
 
   // We deliberately do NOT mount a Jotai `<Provider>` here. Every reactive
@@ -65,11 +113,13 @@ export function PlaybackProvider({
   // TilingProvider) used to shadow the playback store and silently
   // route every read to the wrong atoms — that's the bug this avoids.
   return (
-    <PlaybackStoreContext.Provider value={store}>
-      <PlaybackContextHost baseContext={contextValue}>
-        {children}
-      </PlaybackContextHost>
-    </PlaybackStoreContext.Provider>
+    <TimelineModeContext.Provider value={resolvedMode}>
+      <PlaybackStoreContext.Provider value={store}>
+        <PlaybackContextHost baseContext={contextValue}>
+          {children}
+        </PlaybackContextHost>
+      </PlaybackStoreContext.Provider>
+    </TimelineModeContext.Provider>
   );
 }
 

--- a/app/packages/playback/src/lib/playback/PlaybackProvider.tsx
+++ b/app/packages/playback/src/lib/playback/PlaybackProvider.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useMemo } from "react";
+import React, { createContext, useContext, useMemo, useRef } from "react";
 import { PlaybackStoreContext } from "./playback-store-context";
 import type {
   PlaybackConfig,
@@ -91,10 +91,18 @@ export function PlaybackProvider({
   snapToFrameOnSettle,
   mode,
 }: PlaybackConfig & { children: React.ReactNode }) {
-  const resolvedMode = useMemo(
-    () => normalizeTimelineMode(mode ?? DEFAULT_MODE),
-    [mode],
-  );
+  // Frozen at mount to match `usePlaybackEngine`'s mount-scoped store: that
+  // store's `resolvedStepInterval` (derived from `mode`) is captured once in
+  // a `useMemo(() => ..., [])`, so a later `mode` prop change without a
+  // remount would otherwise update this context while the engine's
+  // mode-dependent state stays stale. A caller that needs a new mode must
+  // remount the provider (e.g. keyed on the resolved mode, as
+  // `McapSourcePlayback` does).
+  const resolvedModeRef = useRef<TimelineMode>();
+  if (resolvedModeRef.current === undefined) {
+    resolvedModeRef.current = normalizeTimelineMode(mode ?? DEFAULT_MODE);
+  }
+  const resolvedMode = resolvedModeRef.current;
   const { store, contextValue } = usePlaybackEngine({
     duration,
     stepInterval,

--- a/app/packages/playback/src/lib/playback/atoms.ts
+++ b/app/packages/playback/src/lib/playback/atoms.ts
@@ -21,7 +21,7 @@
 
 import { atom, type PrimitiveAtom } from "jotai";
 import { atomFamily } from "jotai/utils";
-import type { BufferedRanges, SeekEvent, TimelineMode } from "./types";
+import type { BufferedRanges, SeekEvent } from "./types";
 
 /**
  * Per-stream reactive value atom, keyed by stream id. Lazily created on first
@@ -125,16 +125,6 @@ export const loopEndAtom = atom(0); // initialised to duration by PlaybackProvid
 // Static config — set once by PlaybackProvider, never changed.
 export const durationAtom = atom(0);
 export const stepIntervalAtom = atom(1 / 30);
-
-/**
- * How the timeline's shared clock is presented to and driven by consumers.
- * See {@link TimelineMode}. Static config, set once by PlaybackProvider from
- * `PlaybackConfig.mode` — never changed after creation. The engine's
- * internal clock domain (this atom's presence notwithstanding) is always
- * seconds; consumers convert via `useTimelineDisplay()` in
- * `timeline-display.ts`.
- */
-export const modeAtom = atom<TimelineMode>({ kind: "duration" });
 
 /**
  * Playback speed multiplier. 1.0 = normal speed, 2.0 = double speed,

--- a/app/packages/playback/src/lib/playback/atoms.ts
+++ b/app/packages/playback/src/lib/playback/atoms.ts
@@ -21,7 +21,7 @@
 
 import { atom, type PrimitiveAtom } from "jotai";
 import { atomFamily } from "jotai/utils";
-import type { BufferedRanges, SeekEvent } from "./types";
+import type { BufferedRanges, SeekEvent, TimelineMode } from "./types";
 
 /**
  * Per-stream reactive value atom, keyed by stream id. Lazily created on first
@@ -125,6 +125,16 @@ export const loopEndAtom = atom(0); // initialised to duration by PlaybackProvid
 // Static config — set once by PlaybackProvider, never changed.
 export const durationAtom = atom(0);
 export const stepIntervalAtom = atom(1 / 30);
+
+/**
+ * How the timeline's shared clock is presented to and driven by consumers.
+ * See {@link TimelineMode}. Static config, set once by PlaybackProvider from
+ * `PlaybackConfig.mode` — never changed after creation. The engine's
+ * internal clock domain (this atom's presence notwithstanding) is always
+ * seconds; consumers convert via `useTimelineDisplay()` in
+ * `timeline-display.ts`.
+ */
+export const modeAtom = atom<TimelineMode>({ kind: "duration" });
 
 /**
  * Playback speed multiplier. 1.0 = normal speed, 2.0 = double speed,

--- a/app/packages/playback/src/lib/playback/timeline-display.test.tsx
+++ b/app/packages/playback/src/lib/playback/timeline-display.test.tsx
@@ -6,11 +6,22 @@ import {
   createTimelineDisplayConversion,
   useTimelineDisplay,
 } from "./timeline-display";
-import { useLoopEnd, useLoopStart, usePlayhead } from "./use-playback-state";
+import {
+  useLoopEnd,
+  useLoopStart,
+  usePlayhead,
+  useStepInterval,
+} from "./use-playback-state";
 import type { TimelineMode } from "./types";
 
 const wrap =
-  (config: { duration?: number; mode?: TimelineMode } = {}) =>
+  (
+    config: {
+      duration?: number;
+      mode?: TimelineMode;
+      stepInterval?: number;
+    } = {},
+  ) =>
   ({ children }: { children: React.ReactNode }) => (
     <PlaybackProvider {...config}>{children}</PlaybackProvider>
   );
@@ -68,6 +79,22 @@ describe("useTimelineDisplay", () => {
     });
     expect(result.current.mode).toEqual({ kind: "duration" });
     expect(result.current.toDisplay(4)).toBe(4);
+  });
+
+  it("sequence mode derives the fallback step interval from fps unless overridden", () => {
+    const { result: derived } = renderHook(() => useStepInterval(), {
+      wrapper: wrap({ duration: 10, mode: { kind: "sequence", fps: 24 } }),
+    });
+    expect(derived.current).toBeCloseTo(1 / 24);
+
+    const { result: overridden } = renderHook(() => useStepInterval(), {
+      wrapper: wrap({
+        duration: 10,
+        mode: { kind: "sequence", fps: 24 },
+        stepInterval: 1 / 12,
+      }),
+    });
+    expect(overridden.current).toBeCloseTo(1 / 12);
   });
 
   it("seekDisplay converts through fromDisplay and drives the real playhead", () => {

--- a/app/packages/playback/src/lib/playback/timeline-display.test.tsx
+++ b/app/packages/playback/src/lib/playback/timeline-display.test.tsx
@@ -1,0 +1,115 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import { PlaybackProvider } from "./PlaybackProvider";
+import {
+  createTimelineDisplayConversion,
+  useTimelineDisplay,
+} from "./timeline-display";
+import { useLoopEnd, useLoopStart, usePlayhead } from "./use-playback-state";
+import type { TimelineMode } from "./types";
+
+const wrap =
+  (config: { duration?: number; mode?: TimelineMode } = {}) =>
+  ({ children }: { children: React.ReactNode }) => (
+    <PlaybackProvider {...config}>{children}</PlaybackProvider>
+  );
+
+describe("createTimelineDisplayConversion", () => {
+  it("duration mode: identity conversion, no scrub quantization", () => {
+    const c = createTimelineDisplayConversion({ kind: "duration" });
+    expect(c.toDisplay(12.5)).toBe(12.5);
+    expect(c.fromDisplay(12.5)).toBe(12.5);
+    expect(c.quantizeDuringScrub).toBe(false);
+  });
+
+  it("duration mode: fromDisplay accepts a Date as seconds-since-epoch/1000 fallback", () => {
+    const c = createTimelineDisplayConversion({ kind: "duration" });
+    const d = new Date(5000);
+    expect(c.fromDisplay(d)).toBe(5);
+  });
+
+  it("sequence mode: converts seconds <-> 0-indexed frame number", () => {
+    const c = createTimelineDisplayConversion({ kind: "sequence", fps: 30 });
+    expect(c.toDisplay(0)).toBe(0);
+    expect(c.toDisplay(1)).toBe(30);
+    expect(c.toDisplay(1 / 30)).toBe(1);
+    expect(c.fromDisplay(30)).toBeCloseTo(1);
+    expect(c.fromDisplay(0)).toBe(0);
+    expect(c.quantizeDuringScrub).toBe(true);
+  });
+
+  it("sequence mode: fromDisplay rounds fractional frames defensively", () => {
+    const c = createTimelineDisplayConversion({ kind: "sequence", fps: 10 });
+    // frame 2.5 doesn't exist -> rounds to frame 3 (Math.round ties toward +Infinity)
+    expect(c.fromDisplay(2.5)).toBeCloseTo(0.3);
+  });
+
+  it("absolute mode: converts seconds <-> Date via the epoch anchor", () => {
+    const epochAnchorMs = 1_700_000_000_000;
+    const c = createTimelineDisplayConversion({
+      kind: "absolute",
+      epochAnchorMs,
+    });
+    expect(c.toDisplay(0)).toEqual(new Date(epochAnchorMs));
+    expect(c.toDisplay(10)).toEqual(new Date(epochAnchorMs + 10_000));
+    expect(c.fromDisplay(new Date(epochAnchorMs + 10_000))).toBeCloseTo(10);
+    expect(c.fromDisplay(epochAnchorMs + 10_000)).toBeCloseTo(10);
+    expect(c.quantizeDuringScrub).toBe(false);
+  });
+});
+
+describe("useTimelineDisplay", () => {
+  afterEach(() => cleanup());
+
+  it("defaults to duration mode when the provider doesn't configure one", () => {
+    const { result } = renderHook(() => useTimelineDisplay(), {
+      wrapper: wrap({ duration: 10 }),
+    });
+    expect(result.current.mode).toEqual({ kind: "duration" });
+    expect(result.current.toDisplay(4)).toBe(4);
+  });
+
+  it("seekDisplay converts through fromDisplay and drives the real playhead", () => {
+    const { result } = renderHook(
+      () => ({
+        display: useTimelineDisplay(),
+        playhead: usePlayhead(),
+      }),
+      { wrapper: wrap({ duration: 10, mode: { kind: "sequence", fps: 10 } }) },
+    );
+
+    act(() => {
+      result.current.display.seekDisplay(5); // frame 5 @ 10fps -> 0.5s
+    });
+
+    expect(result.current.playhead).toBeCloseTo(0.5);
+  });
+
+  it("setLoopDisplay converts display-domain bounds and calls the real setLoop", () => {
+    const epochAnchorMs = 1_700_000_000_000;
+    const { result } = renderHook(
+      () => ({
+        display: useTimelineDisplay(),
+        loopStart: useLoopStart(),
+        loopEnd: useLoopEnd(),
+      }),
+      {
+        wrapper: wrap({
+          duration: 100,
+          mode: { kind: "absolute", epochAnchorMs },
+        }),
+      },
+    );
+
+    act(() => {
+      result.current.display.setLoopDisplay(
+        new Date(epochAnchorMs + 10_000),
+        new Date(epochAnchorMs + 20_000),
+      );
+    });
+
+    expect(result.current.loopStart).toBeCloseTo(10);
+    expect(result.current.loopEnd).toBeCloseTo(20);
+  });
+});

--- a/app/packages/playback/src/lib/playback/timeline-display.ts
+++ b/app/packages/playback/src/lib/playback/timeline-display.ts
@@ -10,8 +10,7 @@
 // ---------------------------------------------------------------------------
 
 import { useCallback, useMemo } from "react";
-import { usePlayback } from "./PlaybackProvider";
-import { useMode } from "./use-playback-state";
+import { useMode, usePlayback } from "./PlaybackProvider";
 import type { TimelineMode } from "./types";
 
 export interface TimelineDisplayConversion {

--- a/app/packages/playback/src/lib/playback/timeline-display.ts
+++ b/app/packages/playback/src/lib/playback/timeline-display.ts
@@ -1,0 +1,145 @@
+// ---------------------------------------------------------------------------
+// Mode-aware presentation layer over the playback engine's clock (FOEPD-3811).
+//
+// The engine's internal clock domain never changes: `currentTimeAtom`,
+// `playheadAtom`, `seek()`, `setLoop()`, `setView()` all continue to mean
+// "seconds from timeline start," always, regardless of `TimelineMode`. This
+// file is the thin conversion layer on top, so ruler labels / scrub inputs /
+// loop-bound editors can work in frame numbers or wall-clock timestamps
+// without the engine ever exposing anything but seconds.
+// ---------------------------------------------------------------------------
+
+import { useCallback, useMemo } from "react";
+import { usePlayback } from "./PlaybackProvider";
+import { useMode } from "./use-playback-state";
+import type { TimelineMode } from "./types";
+
+export interface TimelineDisplayConversion {
+  /** Convert internal seconds to the value the UI should render/accept. */
+  toDisplay(seconds: number): number | Date;
+  /** Convert a UI-facing value back to internal seconds. */
+  fromDisplay(value: number | Date): number;
+  /**
+   * Sequence mode only: true when scrub UI should quantize intermediate
+   * drag positions to whole frames as the user drags, rather than staying
+   * continuous and only snapping at settle (the `duration`-mode behavior
+   * `snapToFrameOnSettle` opts into). There's no such thing as frame 2.5, so
+   * mid-drag continuity would show a value the mode can't represent.
+   *
+   * This is an explicit **design decision, not a validated one** — a UX
+   * call made without user testing. Revisit if it feels wrong in practice.
+   */
+  quantizeDuringScrub: boolean;
+}
+
+/**
+ * Pure conversion functions for a given `TimelineMode` — no React or store
+ * dependency, so this is unit-testable directly and reusable outside a
+ * component (e.g. a non-React track-label formatter).
+ *
+ * Note: `sequence` mode's frame numbering is 0-indexed (frame 0, 1, 2, ...),
+ * per the FOEPD-3811 ticket's own example. This is deliberately unrelated
+ * to `utils.ts::frameAt`, which is 1-indexed for the existing `/frames`
+ * server-query convention — different domain, don't conflate the two.
+ */
+export function createTimelineDisplayConversion(
+  mode: TimelineMode,
+): TimelineDisplayConversion {
+  switch (mode.kind) {
+    case "sequence": {
+      const step = 1 / mode.fps;
+      return {
+        toDisplay: (seconds) => Math.round(seconds / step),
+        fromDisplay: (value) => {
+          const frame = typeof value === "number" ? value : Number(value);
+          // Round defensively — even if a caller passes a fractional
+          // "frame", there's no such thing as frame 2.5.
+          return Math.round(frame) * step;
+        },
+        quantizeDuringScrub: true,
+      };
+    }
+    case "absolute": {
+      const { epochAnchorMs } = mode;
+      return {
+        toDisplay: (seconds) => new Date(epochAnchorMs + seconds * 1000),
+        fromDisplay: (value) => {
+          const ms = value instanceof Date ? value.getTime() : Number(value);
+          return (ms - epochAnchorMs) / 1000;
+        },
+        quantizeDuringScrub: false,
+      };
+    }
+    case "duration":
+    default:
+      return {
+        toDisplay: (seconds) => seconds,
+        fromDisplay: (value) =>
+          value instanceof Date ? value.getTime() / 1000 : value,
+        quantizeDuringScrub: false,
+      };
+  }
+}
+
+export interface TimelineDisplayValue extends TimelineDisplayConversion {
+  mode: TimelineMode;
+  /** Seek by a display-domain value (frame number / Date / seconds). */
+  seekDisplay(value: number | Date): void;
+  /**
+   * `setLoop` convenience wrapper accepting display-domain bounds — mirrors
+   * `setLoop`'s validation (invalid/collapsed windows are silently
+   * rejected); see `utils.ts::clampAndValidateBounds`.
+   */
+  setLoopDisplay(start: number | Date, end: number | Date): void;
+  /** `setView` convenience wrapper accepting display-domain bounds. */
+  setViewDisplay(start: number | Date, end: number | Date): void;
+}
+
+/**
+ * Mode-aware presentation layer over the playback engine's always-seconds
+ * clock. Components that render or accept timeline positions (ruler labels,
+ * scrub inputs, loop/view bound editors) should go through this instead of
+ * assuming seconds, so they work unmodified across `duration`, `sequence`,
+ * and `absolute` timelines.
+ *
+ * The play-loop RAF tick and any internal engine code MUST keep using the
+ * plain `seek`/`setLoop`/`setView` (seconds) from `usePlayback()` directly —
+ * this hook is for human-facing display/input surfaces only.
+ */
+export function useTimelineDisplay(): TimelineDisplayValue {
+  const mode = useMode();
+  const { seek, setLoop, setView } = usePlayback();
+
+  const conversion = useMemo(
+    () => createTimelineDisplayConversion(mode),
+    [mode],
+  );
+
+  const seekDisplay = useCallback(
+    (value: number | Date) => seek(conversion.fromDisplay(value)),
+    [seek, conversion],
+  );
+
+  const setLoopDisplay = useCallback(
+    (start: number | Date, end: number | Date) =>
+      setLoop(conversion.fromDisplay(start), conversion.fromDisplay(end)),
+    [setLoop, conversion],
+  );
+
+  const setViewDisplay = useCallback(
+    (start: number | Date, end: number | Date) =>
+      setView(conversion.fromDisplay(start), conversion.fromDisplay(end)),
+    [setView, conversion],
+  );
+
+  return useMemo(
+    () => ({
+      mode,
+      ...conversion,
+      seekDisplay,
+      setLoopDisplay,
+      setViewDisplay,
+    }),
+    [mode, conversion, seekDisplay, setLoopDisplay, setViewDisplay],
+  );
+}

--- a/app/packages/playback/src/lib/playback/types.ts
+++ b/app/packages/playback/src/lib/playback/types.ts
@@ -213,6 +213,40 @@ export interface PlaybackClockSource {
 }
 
 // ---------------------------------------------------------------------------
+// Timeline mode (FOEPD-3811)
+// ---------------------------------------------------------------------------
+
+/**
+ * How the timeline's shared clock is presented to and driven by consumers.
+ * This is a display/seek-boundary concern only — the engine's internal
+ * clock domain is always a continuous number of seconds from timeline
+ * start, regardless of `mode`. See `timeline-display.ts::useTimelineDisplay`
+ * for the conversion layer this drives.
+ *
+ * - `duration`   — elapsed seconds, YouTube-style. The default; unchanged
+ *                  behavior for every existing consumer that doesn't pass
+ *                  `mode`.
+ * - `sequence`   — frame-index based (frame 0, 1, 2, ...). `fps` derives
+ *                  the engine's `nativeStepSeconds` (1/fps) and the
+ *                  seconds<->frame-number conversion.
+ * - `absolute`   — anchored to a real-world clock. `epochAnchorMs` is the
+ *                  Unix-epoch millisecond timestamp that internal second 0
+ *                  corresponds to; display converts to/from `Date`.
+ *
+ * A dataset with streams in more than one of these domains does not need a
+ * "mixed" mode: each `PlaybackStream` already privately converts its own
+ * native units (frame numbers, epoch timestamps, ...) into the engine's
+ * shared seconds domain before calling into the engine (this is exactly
+ * what `nativeStepSeconds` / `duration` do today). `mode` only governs what
+ * the *shared* timeline ruler / scrub UI displays and accepts — pick
+ * whichever representation is primary for the dataset.
+ */
+export type TimelineMode =
+  | { kind: "duration" }
+  | { kind: "sequence"; fps: number }
+  | { kind: "absolute"; epochAnchorMs: number };
+
+// ---------------------------------------------------------------------------
 // Config passed to PlaybackProvider
 // ---------------------------------------------------------------------------
 
@@ -247,6 +281,12 @@ export interface PlaybackConfig {
    * @default false
    */
   snapToFrameOnSettle?: boolean;
+  /**
+   * How the timeline's shared clock is presented to and driven by
+   * consumers. See {@link TimelineMode}.
+   * @default { kind: "duration" }
+   */
+  mode?: TimelineMode;
 }
 
 // ---------------------------------------------------------------------------

--- a/app/packages/playback/src/lib/playback/use-playback-engine.ts
+++ b/app/packages/playback/src/lib/playback/use-playback-engine.ts
@@ -10,6 +10,7 @@ import {
   isPlayingAtom,
   loopEndAtom,
   loopStartAtom,
+  modeAtom,
   playheadAtom,
   seekEventAtom,
   speedAtom,
@@ -105,6 +106,7 @@ export function usePlaybackEngine({
   defaultLoopEnd,
   defaultSpeed = 1.0,
   snapToFrameOnSettle = false,
+  mode = { kind: "duration" },
 }: PlaybackConfig = {}): {
   store: PlaybackStore;
   contextValue: PlaybackContextValue;
@@ -140,6 +142,7 @@ export function usePlaybackEngine({
     s.set(viewEndAtom, initialDuration);
     s.set(loopStartAtom, loopStart);
     s.set(loopEndAtom, loopEnd);
+    s.set(modeAtom, mode);
     return s;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // store is created once at mount; config is treated as mount-time

--- a/app/packages/playback/src/lib/playback/use-playback-engine.ts
+++ b/app/packages/playback/src/lib/playback/use-playback-engine.ts
@@ -10,7 +10,6 @@ import {
   isPlayingAtom,
   loopEndAtom,
   loopStartAtom,
-  modeAtom,
   playheadAtom,
   seekEventAtom,
   speedAtom,
@@ -149,7 +148,6 @@ export function usePlaybackEngine({
     s.set(viewEndAtom, initialDuration);
     s.set(loopStartAtom, loopStart);
     s.set(loopEndAtom, loopEnd);
-    s.set(modeAtom, mode);
     return s;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // store is created once at mount; config is treated as mount-time

--- a/app/packages/playback/src/lib/playback/use-playback-engine.ts
+++ b/app/packages/playback/src/lib/playback/use-playback-engine.ts
@@ -101,7 +101,7 @@ const DEFAULT_PREFETCH_LOOKAHEAD_SECONDS = 3;
 
 export function usePlaybackEngine({
   duration = 0,
-  stepInterval = 1 / 30,
+  stepInterval,
   defaultLoopStart,
   defaultLoopEnd,
   defaultSpeed = 1.0,
@@ -111,13 +111,20 @@ export function usePlaybackEngine({
   store: PlaybackStore;
   contextValue: PlaybackContextValue;
 } {
+  // `sequence` mode's fps IS the native step rate, so default the fallback
+  // step interval to `1/fps` unless the caller explicitly overrides it —
+  // otherwise a caller could declare `mode: { kind: "sequence", fps: 24 }`
+  // and still get `1/30` until a stream registers, silently mismatched.
+  const resolvedStepInterval =
+    stepInterval ?? (mode.kind === "sequence" ? 1 / mode.fps : 1 / 30);
+
   // The duration / stepInterval props are FALLBACKS when no stream
   // provides them. Stored in refs so the recompute functions can read
   // the latest values without capturing them.
   const fallbackDurationRef = useRef(duration);
   fallbackDurationRef.current = duration;
-  const fallbackStepIntervalRef = useRef(stepInterval);
-  fallbackStepIntervalRef.current = stepInterval;
+  const fallbackStepIntervalRef = useRef(resolvedStepInterval);
+  fallbackStepIntervalRef.current = resolvedStepInterval;
   const snapToFrameRef = useRef(snapToFrameOnSettle);
   snapToFrameRef.current = snapToFrameOnSettle;
 
@@ -137,7 +144,7 @@ export function usePlaybackEngine({
       Number.isFinite(defaultSpeed) && defaultSpeed > 0 ? defaultSpeed : 1;
 
     s.set(durationAtom, initialDuration);
-    s.set(stepIntervalAtom, stepInterval);
+    s.set(stepIntervalAtom, resolvedStepInterval);
     s.set(speedAtom, initialSpeed);
     s.set(viewEndAtom, initialDuration);
     s.set(loopStartAtom, loopStart);
@@ -840,8 +847,8 @@ export function usePlaybackEngine({
   ]);
 
   const contextValue = useMemo<PlaybackContextValue>(
-    () => ({ duration, stepInterval, ...actions }),
-    [duration, stepInterval, actions],
+    () => ({ duration, stepInterval: resolvedStepInterval, ...actions }),
+    [duration, resolvedStepInterval, actions],
   );
 
   return { store, contextValue };

--- a/app/packages/playback/src/lib/playback/use-playback-state.ts
+++ b/app/packages/playback/src/lib/playback/use-playback-state.ts
@@ -25,7 +25,6 @@ import {
   isPlayingAtom,
   loopEndAtom,
   loopStartAtom,
-  modeAtom,
   playheadAtom,
   seekEventAtom,
   speedAtom,
@@ -34,7 +33,7 @@ import {
   viewStartAtom,
 } from "./atoms";
 import { usePlaybackStore } from "./playback-store-context";
-import type { BufferedRanges, SeekEvent, TimelineMode } from "./types";
+import type { BufferedRanges, SeekEvent } from "./types";
 
 /** Visual playhead position in seconds — updates every RAF tick + on scrub. */
 export function usePlayhead(): number {
@@ -104,18 +103,6 @@ export function useDuration(): number {
 export function useStepInterval(): number {
   const store = usePlaybackStore();
   return useAtomValue(stepIntervalAtom, { store });
-}
-
-/**
- * How the timeline's shared clock is presented to and driven by consumers.
- * Static for the lifetime of the provider — set once from
- * `PlaybackConfig.mode`, defaulting to `{ kind: "duration" }`. Most
- * components should use `useTimelineDisplay()` (in `timeline-display.ts`)
- * instead of reading this directly.
- */
-export function useMode(): TimelineMode {
-  const store = usePlaybackStore();
-  return useAtomValue(modeAtom, { store });
 }
 
 /** Left edge of the visible timeline window, in seconds. */

--- a/app/packages/playback/src/lib/playback/use-playback-state.ts
+++ b/app/packages/playback/src/lib/playback/use-playback-state.ts
@@ -25,6 +25,7 @@ import {
   isPlayingAtom,
   loopEndAtom,
   loopStartAtom,
+  modeAtom,
   playheadAtom,
   seekEventAtom,
   speedAtom,
@@ -33,7 +34,7 @@ import {
   viewStartAtom,
 } from "./atoms";
 import { usePlaybackStore } from "./playback-store-context";
-import type { BufferedRanges, SeekEvent } from "./types";
+import type { BufferedRanges, SeekEvent, TimelineMode } from "./types";
 
 /** Visual playhead position in seconds — updates every RAF tick + on scrub. */
 export function usePlayhead(): number {
@@ -103,6 +104,18 @@ export function useDuration(): number {
 export function useStepInterval(): number {
   const store = usePlaybackStore();
   return useAtomValue(stepIntervalAtom, { store });
+}
+
+/**
+ * How the timeline's shared clock is presented to and driven by consumers.
+ * Static for the lifetime of the provider — set once from
+ * `PlaybackConfig.mode`, defaulting to `{ kind: "duration" }`. Most
+ * components should use `useTimelineDisplay()` (in `timeline-display.ts`)
+ * instead of reading this directly.
+ */
+export function useMode(): TimelineMode {
+  const store = usePlaybackStore();
+  return useAtomValue(modeAtom, { store });
 }
 
 /** Left edge of the visible timeline window, in seconds. */

--- a/app/packages/playback/src/views/Loop/LoopBounds.test.tsx
+++ b/app/packages/playback/src/views/Loop/LoopBounds.test.tsx
@@ -1,12 +1,14 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { PlaybackProvider } from "../../lib/playback/PlaybackProvider";
+import type { TimelineMode } from "../../lib/playback/types";
 import LoopBounds from "./LoopBounds";
 
 function renderInProvider(opts: {
   duration: number;
   defaultLoopStart?: number;
   defaultLoopEnd?: number;
+  mode?: TimelineMode;
 }) {
   return render(
     <PlaybackProvider
@@ -14,6 +16,7 @@ function renderInProvider(opts: {
       stepInterval={1 / 30}
       defaultLoopStart={opts.defaultLoopStart}
       defaultLoopEnd={opts.defaultLoopEnd}
+      mode={opts.mode}
     >
       <LoopBounds />
     </PlaybackProvider>,
@@ -118,5 +121,27 @@ describe("LoopBounds", () => {
     expect(screen.getByTitle("Reset loop start to 0")).toBeTruthy();
     expect(screen.getByTitle("Reset loop end to duration")).toBeTruthy();
     expect(screen.getAllByRole("button")).toHaveLength(2);
+  });
+
+  it("renders frame numbers for loop bounds in sequence mode", () => {
+    renderInProvider({
+      duration: 1,
+      defaultLoopStart: 0.2,
+      defaultLoopEnd: 0.8,
+      mode: { kind: "sequence", fps: 10 },
+    });
+    expect(screen.getByText("#2")).toBeTruthy();
+    expect(screen.getByText("#8")).toBeTruthy();
+  });
+
+  it("renders wall-clock time for loop bounds in absolute mode", () => {
+    renderInProvider({
+      duration: 10,
+      defaultLoopStart: 1,
+      defaultLoopEnd: 9,
+      mode: { kind: "absolute", epochAnchorMs: 0 },
+    });
+    expect(screen.getByText("00:00:01.000")).toBeTruthy();
+    expect(screen.getByText("00:00:09.000")).toBeTruthy();
   });
 });

--- a/app/packages/playback/src/views/Loop/LoopBounds.tsx
+++ b/app/packages/playback/src/views/Loop/LoopBounds.tsx
@@ -1,12 +1,14 @@
 import { Text, TextColor, TextVariant } from "@voxel51/voodo";
 import React, { useCallback } from "react";
 import { usePlayback } from "../../lib/playback/PlaybackProvider";
+import { useTimelineDisplay } from "../../lib/playback/timeline-display";
 import {
   useLoopEnd,
   useLoopStart,
 } from "../../lib/playback/use-playback-state";
 import {
   fmtBound,
+  formatDisplayValue,
   LOOP_EDGE_EPSILON,
 } from "../TimelineControls/timeline-controls-utils";
 import styles from "./LoopBounds.module.css";
@@ -23,6 +25,7 @@ const LoopBounds: React.FC = () => {
   const loopStart = useLoopStart();
   const loopEnd = useLoopEnd();
   const { duration, setLoop } = usePlayback();
+  const { mode, toDisplay } = useTimelineDisplay();
 
   const hasLoop = duration !== undefined;
   const atStart = hasLoop && loopStart < LOOP_EDGE_EPSILON;
@@ -65,7 +68,7 @@ const LoopBounds: React.FC = () => {
           title="Reset loop start to 0"
           role="button"
         >
-          {fmtBound(loopStart)}
+          {formatDisplayValue(toDisplay(loopStart), mode, fmtBound)}
         </Text>
         <Text variant={TextVariant.Xs} color={TextColor.Muted}>
           {" / "}
@@ -80,7 +83,7 @@ const LoopBounds: React.FC = () => {
           title="Reset loop end to duration"
           role="button"
         >
-          {fmtBound(loopEnd)}
+          {formatDisplayValue(toDisplay(loopEnd), mode, fmtBound)}
         </Text>
         <Text variant={TextVariant.Xs} color={TextColor.Muted}>
           {" ) "}

--- a/app/packages/playback/src/views/Playhead/PlayheadTime.test.tsx
+++ b/app/packages/playback/src/views/Playhead/PlayheadTime.test.tsx
@@ -5,6 +5,7 @@ import {
   PlaybackProvider,
   usePlayback,
 } from "../../lib/playback/PlaybackProvider";
+import type { TimelineMode } from "../../lib/playback/types";
 import PlayheadTime from "./PlayheadTime";
 
 /**
@@ -21,9 +22,9 @@ function Seeker({ time }: { time: number }) {
   return null;
 }
 
-function renderTime(duration: number, seekTo?: number) {
+function renderTime(duration: number, seekTo?: number, mode?: TimelineMode) {
   return render(
-    <PlaybackProvider duration={duration} stepInterval={1 / 30}>
+    <PlaybackProvider duration={duration} stepInterval={1 / 30} mode={mode}>
       {seekTo !== undefined ? <Seeker time={seekTo} /> : null}
       <PlayheadTime />
     </PlaybackProvider>,
@@ -65,5 +66,16 @@ describe("PlayheadTime", () => {
     const { container } = renderTime(8);
     // Just one <span> — the voodo Text wrapper.
     expect(container.querySelectorAll("span")).toHaveLength(1);
+  });
+
+  it("renders frame numbers in sequence mode", () => {
+    // 10fps -> step 0.1s; playhead 0.5s = frame 5, duration 1s = frame 10.
+    renderTime(1, 0.5, { kind: "sequence", fps: 10 });
+    expect(screen.getByText("#5 / #10")).toBeTruthy();
+  });
+
+  it("renders wall-clock time in absolute mode", () => {
+    renderTime(2, 1, { kind: "absolute", epochAnchorMs: 10_000 });
+    expect(screen.getByText("00:00:11.000 / 00:00:12.000")).toBeTruthy();
   });
 });

--- a/app/packages/playback/src/views/Playhead/PlayheadTime.tsx
+++ b/app/packages/playback/src/views/Playhead/PlayheadTime.tsx
@@ -1,8 +1,9 @@
 import { Text, TextColor, TextVariant } from "@voxel51/voodo";
 import React from "react";
 import { usePlayback } from "../../lib/playback/PlaybackProvider";
+import { useTimelineDisplay } from "../../lib/playback/timeline-display";
 import { usePlayhead } from "../../lib/playback/use-playback-state";
-import { formatTime } from "../TimelineControls/timeline-controls-utils";
+import { formatDisplayValue } from "../TimelineControls/timeline-controls-utils";
 
 /**
  * Live playhead time readout, displayed as `currentTime / duration`.
@@ -12,6 +13,7 @@ import { formatTime } from "../TimelineControls/timeline-controls-utils";
 const PlayheadTime: React.FC = () => {
   const playhead = usePlayhead();
   const { duration } = usePlayback();
+  const { mode, toDisplay } = useTimelineDisplay();
   // `duration` is optional on the context (the engine can be mounted
   // without a fallback prop and before any stream has registered); guard
   // here so the readout never shows `NaN`.
@@ -26,7 +28,7 @@ const PlayheadTime: React.FC = () => {
           "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
       }}
     >
-      {`${formatTime(safePlayhead)} / ${formatTime(safeDuration)}`}
+      {`${formatDisplayValue(toDisplay(safePlayhead), mode)} / ${formatDisplayValue(toDisplay(safeDuration), mode)}`}
     </Text>
   );
 };

--- a/app/packages/playback/src/views/TimelineControls/timeline-controls-utils.test.ts
+++ b/app/packages/playback/src/views/TimelineControls/timeline-controls-utils.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { formatTime } from "./timeline-controls-utils";
+import {
+  fmtBound,
+  formatDisplayValue,
+  formatTime,
+  formatTimeOfDay,
+} from "./timeline-controls-utils";
 
 describe("formatTime", () => {
   it("renders sub-minute values as 0:ss.cs", () => {
@@ -22,5 +27,44 @@ describe("formatTime", () => {
     expect(formatTime(NaN)).toBe("0:00.00");
     expect(formatTime(-5)).toBe("0:00.00");
     expect(formatTime(Infinity)).toBe("0:00.00");
+  });
+});
+
+describe("formatTimeOfDay", () => {
+  it("renders a Date as HH:MM:SS.mmm", () => {
+    expect(formatTimeOfDay(new Date("1970-01-01T00:00:10.500Z"))).toBe(
+      "00:00:10.500",
+    );
+  });
+
+  it("renders a sentinel instead of throwing on an out-of-range Date", () => {
+    // Date's valid range is ~±8.64e15ms from the epoch.
+    expect(formatTimeOfDay(new Date(1e17))).toBe("--:--:--.---");
+  });
+});
+
+describe("formatDisplayValue", () => {
+  it("formats sequence mode as a #-prefixed frame number", () => {
+    expect(formatDisplayValue(5, { kind: "sequence", fps: 12 })).toBe("#5");
+    expect(formatDisplayValue(5.9, { kind: "sequence", fps: 12 })).toBe("#6");
+  });
+
+  it("formats absolute mode as a wall-clock time", () => {
+    expect(
+      formatDisplayValue(new Date("1970-01-01T00:00:10.000Z"), {
+        kind: "absolute",
+        epochAnchorMs: 0,
+      }),
+    ).toBe("00:00:10.000");
+  });
+
+  it("defaults duration mode to formatTime (m:ss.cs)", () => {
+    expect(formatDisplayValue(83.45, { kind: "duration" })).toBe("1:23.45");
+  });
+
+  it("uses a caller-supplied formatter for duration mode", () => {
+    expect(formatDisplayValue(2.5, { kind: "duration" }, fmtBound)).toBe(
+      "2.50s",
+    );
   });
 });

--- a/app/packages/playback/src/views/TimelineControls/timeline-controls-utils.test.ts
+++ b/app/packages/playback/src/views/TimelineControls/timeline-controls-utils.test.ts
@@ -41,6 +41,13 @@ describe("formatTimeOfDay", () => {
     // Date's valid range is ~±8.64e15ms from the epoch.
     expect(formatTimeOfDay(new Date(1e17))).toBe("--:--:--.---");
   });
+
+  it("renders the time-of-day correctly for extended-year (year > 9999) dates", () => {
+    // Years outside 0000-9999 make toISOString() emit an extended
+    // `±YYYYYY-MM-DD` date portion, shifting where the time substring
+    // starts — a fixed slice(11, 23) would grab the wrong characters.
+    expect(formatTimeOfDay(new Date(8.64e15))).toBe("00:00:00.000");
+  });
 });
 
 describe("formatDisplayValue", () => {

--- a/app/packages/playback/src/views/TimelineControls/timeline-controls-utils.ts
+++ b/app/packages/playback/src/views/TimelineControls/timeline-controls-utils.ts
@@ -1,3 +1,5 @@
+import type { TimelineMode } from "../../lib/playback/types";
+
 /**
  * Formats a time in seconds as `m:ss.cs` (e.g. 1:23.45). Used by the
  * playhead time readout. Clamps non-finite / negative input to 0.
@@ -14,6 +16,45 @@ export function formatTime(t: number): string {
 /** Formats a loop bound as `1.23s`. Used by the loop bound readouts. */
 export function fmtBound(t: number): string {
   return `${t.toFixed(2)}s`;
+}
+
+/**
+ * Formats an `absolute`-mode display `Date` as `HH:MM:SS.mmm`. Guards
+ * against `Invalid Date` — `toDisplay()` can produce one from an
+ * out-of-range `epochAnchorMs`/seconds combination (`Date`'s range is
+ * ~±8.64e15ms from the epoch), and `toISOString()` throws on those rather
+ * than returning a sentinel string.
+ */
+export function formatTimeOfDay(d: Date): string {
+  return Number.isFinite(d.getTime())
+    ? d.toISOString().slice(11, 23)
+    : "--:--:--.---";
+}
+
+/**
+ * Formats a `TimelineDisplayConversion.toDisplay()` result according to
+ * `mode`: a frame index for `sequence`, a time-of-day for `absolute`, or (for
+ * `duration`) `formatSeconds` — callers keep their own seconds formatting
+ * (`formatTime`'s `m:ss.cs` for the playhead readout, `fmtBound`'s `X.XXs`
+ * for loop bounds) since those predate this mode-aware layer and have their
+ * own established expectations. Used anywhere a raw seconds-domain readout
+ * needs to become mode-aware — ruler ticks, the playhead readout, loop
+ * bound readouts.
+ */
+export function formatDisplayValue(
+  value: number | Date,
+  mode: TimelineMode,
+  formatSeconds: (t: number) => string = formatTime,
+): string {
+  switch (mode.kind) {
+    case "sequence":
+      return `#${Math.round(value as number)}`;
+    case "absolute":
+      return formatTimeOfDay(value as Date);
+    case "duration":
+    default:
+      return formatSeconds(value as number);
+  }
 }
 
 /**

--- a/app/packages/playback/src/views/TimelineControls/timeline-controls-utils.ts
+++ b/app/packages/playback/src/views/TimelineControls/timeline-controls-utils.ts
@@ -26,9 +26,12 @@ export function fmtBound(t: number): string {
  * than returning a sentinel string.
  */
 export function formatTimeOfDay(d: Date): string {
-  return Number.isFinite(d.getTime())
-    ? d.toISOString().slice(11, 23)
-    : "--:--:--.---";
+  if (!Number.isFinite(d.getTime())) return "--:--:--.---";
+  // Slice relative to the `T` separator rather than a fixed index — years
+  // outside 0000-9999 make `toISOString()` emit an extended `±YYYYYY-MM-DD`
+  // date portion, which shifts where the time-of-day substring starts.
+  const iso = d.toISOString();
+  return iso.slice(iso.indexOf("T") + 1, -1);
 }
 
 /**

--- a/app/packages/playback/src/views/TimelineRuler/TimelineRuler.test.tsx
+++ b/app/packages/playback/src/views/TimelineRuler/TimelineRuler.test.tsx
@@ -10,7 +10,10 @@ import {
 import { viewEndAtom, viewStartAtom } from "../../lib/playback/atoms";
 import { setHoverTime } from "../../lib/playback/store-access";
 import type { TimelineMode } from "../../lib/playback/types";
-import { useHoverTime } from "../../lib/playback/use-playback-state";
+import {
+  useHoverTime,
+  usePlayhead,
+} from "../../lib/playback/use-playback-state";
 import TimelineRuler from "./TimelineRuler";
 import styles from "./TimelineRuler.module.css";
 
@@ -33,6 +36,12 @@ function HoverReadout() {
       {hover === null ? "none" : hover.toFixed(3)}
     </span>
   );
+}
+
+// Renders the playhead so tests can assert on it after a drag/click-to-seek.
+function PlayheadReadout() {
+  const playhead = usePlayhead();
+  return <span data-testid="playhead">{playhead.toFixed(2)}</span>;
 }
 
 function Seeker({ time }: { time: number }) {
@@ -93,6 +102,7 @@ function renderRuler(opts: RenderOpts = {}) {
       <TimelineRuler labelWidth={labelWidth} />
       <ViewReadout />
       <HoverReadout />
+      <PlayheadReadout />
     </PlaybackProvider>,
   );
 }
@@ -124,6 +134,7 @@ describe("TimelineRuler", () => {
   // Save the original so afterEach can restore Element.prototype — otherwise
   // the stub leaks into later test suites that share the test runner.
   const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
+  const originalSetPointerCapture = Element.prototype.setPointerCapture;
 
   beforeEach(() => {
     // The wheel handler reads getBoundingClientRect to convert the cursor's
@@ -139,11 +150,15 @@ describe("TimelineRuler", () => {
       height: 24,
       toJSON: () => ({}),
     }));
+    // useDragDelta calls setPointerCapture on drag start; jsdom doesn't
+    // implement it.
+    Element.prototype.setPointerCapture = vi.fn();
   });
 
   afterEach(() => {
     cleanup();
     Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+    Element.prototype.setPointerCapture = originalSetPointerCapture;
   });
 
   describe("structure", () => {
@@ -355,6 +370,68 @@ describe("TimelineRuler", () => {
       });
       const ticks = container.querySelectorAll(`.${styles.tick}`);
       expect(ticks.length).toBeLessThanOrEqual(500);
+    });
+  });
+
+  describe("scrub quantization", () => {
+    // Sequence mode has no such thing as frame 2.5 — click-to-seek and
+    // playhead drag should quantize onto whole frames, independent of the
+    // (unrelated) snapToFrameOnSettle provider option, which defaults off
+    // here and is never set in these tests.
+    //
+    // jsdom's PointerEvent constructor doesn't propagate clientX from an
+    // init object the way `fireEvent.pointerDown(el, { clientX })` expects
+    // (same class of issue as the offsetX note in SimplePlaybackBar's
+    // tests) — build a plain MouseEvent instead, matching the convention
+    // already used for pointermove in the hover-caret tests below.
+    const pointerDownAt = (el: Element, clientX: number) =>
+      fireEvent(el, new MouseEvent("pointerdown", { bubbles: true, clientX }));
+    const pointerUpAt = (el: Element, clientX: number) =>
+      fireEvent(el, new MouseEvent("pointerup", { bubbles: true, clientX }));
+    const pointerMoveAt = (el: Element, clientX: number) =>
+      fireEvent(el, new MouseEvent("pointermove", { bubbles: true, clientX }));
+
+    it("quantizes a lane click to the nearest frame in sequence mode", () => {
+      const { getByTestId } = renderRuler({
+        duration: 10,
+        viewStart: 0,
+        viewEnd: 10,
+        mode: { kind: "sequence", fps: 10 },
+      });
+      const ruler = getByTestId("timeline-ruler");
+      // Lane is 1000px wide (stubbed) for a 10s view → clientX=533 is 5.33s,
+      // which at 10fps (0.1s/frame) quantizes to frame 53 → 5.3s exactly.
+      pointerDownAt(ruler, 533);
+      pointerUpAt(ruler, 533);
+      expect(getByTestId("playhead").textContent).toBe("5.30");
+    });
+
+    it("does not quantize a lane click in duration mode", () => {
+      const { getByTestId } = renderRuler({
+        duration: 10,
+        viewStart: 0,
+        viewEnd: 10,
+      });
+      const ruler = getByTestId("timeline-ruler");
+      pointerDownAt(ruler, 533);
+      pointerUpAt(ruler, 533);
+      expect(getByTestId("playhead").textContent).toBe("5.33");
+    });
+
+    it("quantizes a playhead drag to the nearest frame in sequence mode", () => {
+      const { getByTestId } = renderRuler({
+        duration: 10,
+        viewStart: 0,
+        viewEnd: 10,
+        seekTo: 0,
+        mode: { kind: "sequence", fps: 10 },
+      });
+      const handle = document.querySelector(`.${styles.playheadHandle}`)!;
+      pointerDownAt(handle, 0);
+      // +533px of delta over a 1000px/10s lane → +5.33s from the seekTo=0
+      // start, which quantizes to frame 53 → 5.3s exactly.
+      pointerMoveAt(handle, 533);
+      expect(getByTestId("playhead").textContent).toBe("5.30");
     });
   });
 

--- a/app/packages/playback/src/views/TimelineRuler/TimelineRuler.test.tsx
+++ b/app/packages/playback/src/views/TimelineRuler/TimelineRuler.test.tsx
@@ -9,6 +9,7 @@ import {
 } from "../../lib/playback/PlaybackProvider";
 import { viewEndAtom, viewStartAtom } from "../../lib/playback/atoms";
 import { setHoverTime } from "../../lib/playback/store-access";
+import type { TimelineMode } from "../../lib/playback/types";
 import { useHoverTime } from "../../lib/playback/use-playback-state";
 import TimelineRuler from "./TimelineRuler";
 import styles from "./TimelineRuler.module.css";
@@ -62,6 +63,7 @@ interface RenderOpts {
   viewEnd?: number;
   defaultLoopStart?: number;
   defaultLoopEnd?: number;
+  mode?: TimelineMode;
 }
 
 /** Renders the ruler inside a positioned outer so getBoundingClientRect-driven math works. */
@@ -74,6 +76,7 @@ function renderRuler(opts: RenderOpts = {}) {
     viewEnd,
     defaultLoopStart,
     defaultLoopEnd,
+    mode,
   } = opts;
   return render(
     <PlaybackProvider
@@ -81,6 +84,7 @@ function renderRuler(opts: RenderOpts = {}) {
       stepInterval={1 / 30}
       defaultLoopStart={defaultLoopStart}
       defaultLoopEnd={defaultLoopEnd}
+      mode={mode}
     >
       {viewStart !== undefined && viewEnd !== undefined ? (
         <ViewSetter start={viewStart} end={viewEnd} />
@@ -294,6 +298,63 @@ describe("TimelineRuler", () => {
       expect(labels).toContain("1:00");
       expect(labels).toContain("1:30");
       expect(labels).toContain("2:00");
+    });
+  });
+
+  describe("mode-aware ticks", () => {
+    it("labels sequence-mode ticks as frame numbers, spaced on frame boundaries", () => {
+      const { container } = renderRuler({
+        duration: 1,
+        viewStart: 0,
+        viewEnd: 1,
+        mode: { kind: "sequence", fps: 10 },
+      });
+      const labels = Array.from(
+        container.querySelectorAll(`.${styles.tick}`),
+      ).map((el) => el.textContent);
+      // 1s at 10fps = frames 0..10, one tick per frame (smallest interval).
+      expect(labels).toEqual([
+        "0",
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8",
+        "9",
+        "10",
+      ]);
+    });
+
+    it("labels absolute-mode ticks as HH:MM:SS.mmm wall-clock time", () => {
+      const { container } = renderRuler({
+        duration: 2,
+        viewStart: 0,
+        viewEnd: 2,
+        // 1970-01-01T00:00:10.000Z
+        mode: { kind: "absolute", epochAnchorMs: 10_000 },
+      });
+      const labels = Array.from(
+        container.querySelectorAll(`.${styles.tick}`),
+      ).map((el) => el.textContent);
+      expect(labels[0]).toBe("00:00:10.000");
+      expect(labels[labels.length - 1]).toBe("00:00:12.000");
+    });
+
+    it("caps the tick count instead of hanging on a corrupt/huge duration", () => {
+      // A mismeasured scene (e.g. streams disagreeing on epoch vs. elapsed
+      // time) can blow the duration out to years; the ruler must degrade
+      // gracefully rather than render millions of ticks.
+      const { container } = renderRuler({
+        duration: 1_600_000_000,
+        viewStart: 0,
+        viewEnd: 1_600_000_000,
+        mode: { kind: "sequence", fps: 12 },
+      });
+      const ticks = container.querySelectorAll(`.${styles.tick}`);
+      expect(ticks.length).toBeLessThanOrEqual(500);
     });
   });
 

--- a/app/packages/playback/src/views/TimelineRuler/TimelineRuler.tsx
+++ b/app/packages/playback/src/views/TimelineRuler/TimelineRuler.tsx
@@ -111,6 +111,17 @@ const TimelineRuler: React.FC<TimelineRulerProps> = ({
   const hoverTime = useHoverTime();
   const store = usePlaybackStore();
 
+  // Sequence mode has no such thing as frame 2.5 — `quantizeDuringScrub`
+  // (see timeline-display.ts) says the display conversion should round
+  // mid-drag positions onto whole frames. This is mode-intrinsic and
+  // independent of `snapToFrameOnSettle` (a separate, provider-level
+  // opt-in for snapping only at drag-end), so it's applied here before
+  // handing the value to `seekSnapped` rather than left to that setting.
+  const quantizeForScrub = (seconds: number): number =>
+    displayConversion.quantizeDuringScrub
+      ? displayConversion.fromDisplay(displayConversion.toDisplay(seconds))
+      : seconds;
+
   const rulerRef = useRef<HTMLDivElement>(null);
 
   // Publish the timeline time under the pointer so every hover-capable
@@ -192,7 +203,11 @@ const TimelineRuler: React.FC<TimelineRulerProps> = ({
       // playhead now tracks discrete frame numbers continuously during the
       // drag, matching the frame-indexed mental model the annotation surface
       // uses elsewhere.
-      seekSnapped(clamp(startValue + (delta / laneWidth) * vd, 0, duration));
+      seekSnapped(
+        quantizeForScrub(
+          clamp(startValue + (delta / laneWidth) * vd, 0, duration),
+        ),
+      );
     },
     // Redundant when `seekSnapped` already landed each mid-drag tick on a
     // frame boundary — kept as a belt-and-suspenders settle (cheap no-op
@@ -270,7 +285,11 @@ const TimelineRuler: React.FC<TimelineRulerProps> = ({
       const ve = dragRef.current.startVe;
       // `seekSnapped` lands the click on a frame boundary in one step when
       // snapping is enabled; falls back to a continuous seek otherwise.
-      seekSnapped(clamp(vs + (laneX / laneWidth) * (ve - vs), 0, duration));
+      seekSnapped(
+        quantizeForScrub(
+          clamp(vs + (laneX / laneWidth) * (ve - vs), 0, duration),
+        ),
+      );
     },
   });
 

--- a/app/packages/playback/src/views/TimelineRuler/TimelineRuler.tsx
+++ b/app/packages/playback/src/views/TimelineRuler/TimelineRuler.tsx
@@ -4,6 +4,9 @@ import React, { type ReactNode, useEffect, useRef } from "react";
 import { usePlayback } from "../../lib/playback/PlaybackProvider";
 import { usePlaybackStore } from "../../lib/playback/playback-store-context";
 import { setHoverTime } from "../../lib/playback/store-access";
+import type { TimelineDisplayConversion } from "../../lib/playback/timeline-display";
+import { useTimelineDisplay } from "../../lib/playback/timeline-display";
+import type { TimelineMode } from "../../lib/playback/types";
 import {
   useHoverTime,
   useLoopEnd,
@@ -13,6 +16,7 @@ import {
   useViewStart,
 } from "../../lib/playback/use-playback-state";
 import { clamp } from "../../lib/playback/utils";
+import { formatTimeOfDay } from "../TimelineControls/timeline-controls-utils";
 import BufferedLaneShading from "./BufferedLaneShading";
 import styles from "./TimelineRuler.module.css";
 
@@ -26,16 +30,32 @@ const CLICK_PX_THRESHOLD = 3;
 const TICK_INTERVALS = [
   0.1, 0.2, 0.25, 0.5, 1, 2, 5, 10, 15, 30, 60, 120, 300, 600, 900, 1800, 3600,
 ];
+// Nice tick spacings in *frames* for sequence mode — ticks should land on
+// whole frames, not arbitrary fractions of a second.
+const SEQUENCE_FRAME_INTERVALS = [
+  1, 2, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000,
+];
 const TARGET_TICK_DIVISIONS = 10;
 
-function chooseTickInterval(viewDuration: number): number {
+// Tick positions always stay in the engine's internal seconds domain (see
+// timeline-display.ts) — only the interval choice and the label text become
+// mode-aware.
+function chooseTickInterval(viewDuration: number, mode: TimelineMode): number {
+  if (mode.kind === "sequence") {
+    const step = 1 / mode.fps;
+    for (const frames of SEQUENCE_FRAME_INTERVALS) {
+      const interval = frames * step;
+      if (viewDuration / interval <= TARGET_TICK_DIVISIONS) return interval;
+    }
+    return SEQUENCE_FRAME_INTERVALS[SEQUENCE_FRAME_INTERVALS.length - 1] * step;
+  }
   for (const interval of TICK_INTERVALS) {
     if (viewDuration / interval <= TARGET_TICK_DIVISIONS) return interval;
   }
   return TICK_INTERVALS[TICK_INTERVALS.length - 1];
 }
 
-function tickLabel(t: number): string {
+function durationTickLabel(t: number): string {
   const s = Math.floor(t);
   const frac = Math.round((t - s) * 10) / 10;
   // Past a minute, seconds-only labels ("150s") get hard to read on long
@@ -47,6 +67,18 @@ function tickLabel(t: number): string {
     return `${minutes}:${seconds.toString().padStart(2, "0")}`;
   }
   return frac === 0 ? `${s}s` : `${(s + frac).toFixed(1)}s`;
+}
+
+function tickLabel(
+  t: number,
+  mode: TimelineMode,
+  conversion: TimelineDisplayConversion,
+): string {
+  if (mode.kind === "duration") return durationTickLabel(t);
+  const displayValue = conversion.toDisplay(t);
+  if (mode.kind === "sequence") return `${Math.round(displayValue as number)}`;
+  // absolute: HH:MM:SS.mmm — a full date is redundant tick-over-tick.
+  return formatTimeOfDay(displayValue as Date);
 }
 
 export interface TimelineRulerProps {
@@ -75,6 +107,7 @@ const TimelineRuler: React.FC<TimelineRulerProps> = ({
   const loopEnd = useLoopEnd();
   const { duration, seekSnapped, setView, setLoop, snapPlayheadToFrame } =
     usePlayback();
+  const { mode, ...displayConversion } = useTimelineDisplay();
   const hoverTime = useHoverTime();
   const store = usePlaybackStore();
 
@@ -300,12 +333,18 @@ const TimelineRuler: React.FC<TimelineRulerProps> = ({
   const loopStartRatio = clamp((loopStart - viewStart) / viewDuration, 0, 1);
   const loopEndRatio = clamp((loopEnd - viewStart) / viewDuration, 0, 1);
 
-  const tickInterval = chooseTickInterval(viewDuration);
+  const tickInterval = chooseTickInterval(viewDuration, mode);
   const ticks: number[] = [];
   const firstTick = Math.ceil(viewStart / tickInterval - 1e-9) * tickInterval;
+  // `chooseTickInterval` targets ~TARGET_TICK_DIVISIONS ticks per view, but
+  // it can't fully protect against a corrupt/mismeasured duration (e.g. a
+  // scene whose streams disagree on epoch vs. elapsed time) blowing the
+  // view out to years. This cap is the last line of defense against
+  // rendering millions of tick nodes and hanging the tab.
+  const MAX_TICKS = 500;
   for (
     let t = Math.round(firstTick * 1e4) / 1e4;
-    t <= viewEnd + 1e-9;
+    t <= viewEnd + 1e-9 && ticks.length < MAX_TICKS;
     t = Math.round((t + tickInterval) * 1e4) / 1e4
   ) {
     ticks.push(t);
@@ -364,7 +403,7 @@ const TimelineRuler: React.FC<TimelineRulerProps> = ({
               left: `${((t - viewStart) / viewDuration) * 100}%`,
             }}
           >
-            {tickLabel(t)}
+            {tickLabel(t, mode, displayConversion)}
           </span>
         ))}
       </div>


### PR DESCRIPTION
## 🔗 Related Issues

FOEPD-3811

## 📋 What changes are proposed in this pull request?

Adds `sequence` (frame-index) and `absolute` (epoch-clock) timeline modes alongside the existing `duration` mode, and wires them into the actual UI and into real MCAP sources.

- `TimelineMode` added to `PlaybackConfig`, defaulting to `duration` — no behavior change for existing consumers. The engine's internal clock stays seconds-based throughout; a new `useTimelineDisplay()` layer converts to frame numbers / `Date` / seconds only at the display and seek boundary.
- `TimelineRuler`, `PlayheadTime`, and `LoopBounds` now render through that layer. Ruler ticks are also capped at 500 and `absolute` formatting guards against invalid dates, after a corrupted test scene's duration came out to ~48 years and hung a tab.
- New `resolveMcapTimelineMode()` derives a scene's mode from channel metadata and threads it through `McapSourcePlayback` → `MultiModalPlayback` → `PlaybackProvider`. This metadata convention is a stopgap, not a finalized ingestion contract — see the planning doc.
- Design call, not user-validated: `sequence` mode scrubbing quantizes to whole frames immediately rather than only on settle.

Single self-contained PR per discussion — scope didn't warrant splitting it.

## 🧪 How is this patch tested? If it is not, please explain why.

Added appropriate unit tests for all of the above. Full `playback` and `multimodal` suites pass, typecheck is clean, and it's been manually tested against a real MCAP dataset rewritten into duration/sequence/absolute variants.

<img width="600" height="172" alt="screenshot-2026-07-27_09-08-44" src="https://github.com/user-attachments/assets/639df091-3d86-453a-b8ab-0c132818c6a6" />
<img width="838" height="181" alt="screenshot-2026-07-27_09-08-36" src="https://github.com/user-attachments/assets/476b28f4-72de-44a5-90ce-832ec3f7a7f4" />

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for FiftyOne users.

Adds frame-sequence and absolute-clock timeline modes to the playback engine, alongside the existing elapsed-duration mode, for frame-accurate and real-world-clock-synchronized playback (e.g. multi-sensor/MCAP data).

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3533
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added duration, frame-sequence, and absolute-time timeline modes across playback UI (ruler, playhead, controls, loop bounds).
  * MultiModal playback and playback provider now accept an optional mode prop; timeline display converts and supports mode-aware seeking.
  * MCAP playback derives timeline settings from topic metadata, including sequence FPS and absolute epoch anchoring.
* **Bug Fixes**
  * Improved safe fallbacks for missing/invalid timeline metadata and hardened tick rendering.
* **Tests**
  * Expanded unit and component tests for mode resolution, display conversions, quantization, and remounting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->