### PR TITLE
fix(ci): no-op all-tests stays pending until the run testing the SHA concludes

### DIFF
--- a/.github/workflows/enterprise-sync.yml
+++ b/.github/workflows/enterprise-sync.yml
@@ -98,6 +98,10 @@ jobs:
                 state: 'pending',
                 context: 'enterprise / ci',
                 description: 'Awaiting Enterprise sync workflow…',
+                // The sync workflows overwrite this with links to the run
+                // doing the work; until then, link the dispatching run so
+                // a status stuck here is diagnosable from the merge box.
+                target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
               });
             }
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -226,6 +226,7 @@ jobs:
       # the mirror lists the SHA's workflow runs to find the run testing it;
       # implicit on public repos, required on private fiftyone-teams
       actions: read
+      # the mirror reads the SHA's all-tests check runs for the verdict
       checks: read
     env:
       # A run that skipped the suite (a no-op body edit, or a failed gate)
@@ -256,7 +257,7 @@ jobs:
               repo: context.repo.repo,
               run_id: context.runId,
             });
-            const deadline = Date.now() + 2 * 60 * 60 * 1000;
+            const deadline = Date.now() + 90 * 60 * 1000;
             let emptyPolls = 0;
             for (;;) {
               const runs = await github.paginate(
@@ -311,7 +312,7 @@ jobs:
               if (live.length > 0) {
                 emptyPolls = 0;
                 if (Date.now() >= deadline) {
-                  core.setFailed(`Still waiting on ${live[0].html_url} after 2 hours — re-run this job once it completes.`);
+                  core.setFailed(`Still waiting on ${live[0].html_url} after 90 minutes — re-run this job once it completes.`);
                   return;
                 }
                 core.info(`Waiting on the run testing this SHA: ${live.map((r) => r.html_url).join(', ')}`);
@@ -319,13 +320,13 @@ jobs:
                 // Nothing is testing the SHA and no verdict exists (e.g.
                 // every real run was cancelled). Give races a short grace,
                 // then defer to a human rather than inventing a verdict.
-                if (++emptyPolls >= 10) {
+                if (++emptyPolls >= 3) {
                   core.setFailed('No run is testing this SHA and no completed all-tests verdict exists — re-run the Pull Request workflow.');
                   return;
                 }
                 core.info('No verdict and no live run for this SHA yet — waiting.');
               }
-              await new Promise((resolve) => setTimeout(resolve, 30 * 1000));
+              await new Promise((resolve) => setTimeout(resolve, 2 * 60 * 1000));
             }
       - name: Fail when a draft deferred the e2e suite
         # A draft run must not publish a successful merge-authoritative

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -218,7 +218,15 @@ jobs:
   all-tests:
     runs-on: ubuntu-latest
     needs: [modified-files, build, lint, test, e2e]
-    if: always()
+    # not `always()`: a concurrency-cancelled run (an edit displaced by the
+    # next edit) must conclude cancelled, not turn the failed gate into a
+    # red `all-tests` on a SHA it never tested.
+    if: ${{ !cancelled() }}
+    permissions:
+      # the mirror lists the SHA's workflow runs to find the run testing it;
+      # implicit on public repos, required on private fiftyone-teams
+      actions: read
+      checks: read
     env:
       # A run that skipped the suite (a no-op body edit, or a failed gate)
       # must not aggregate its skipped needs into a vacuous green that
@@ -236,70 +244,87 @@ jobs:
         with:
           script: |
             // A no-op edit usually lands while the run actually testing this
-            // SHA is still in flight (this job's own check run is in_progress,
-            // so it never matches the completed filter). Poll for that run's
-            // verdict rather than failing on the gap — a vacuous green here
-            // could merge the PR before its suite finishes.
-            const deadline = Date.now() + 60 * 60 * 1000;
+            // SHA is still in flight. Its all-tests check run doesn't exist
+            // until its needs finish, so watch this workflow's *runs* on the
+            // SHA instead: stay pending while one is live, then mirror its
+            // verdict. Completed check runs only count as a verdict when
+            // their workflow run finished uncancelled — a run displaced by
+            // concurrency reds its always() gate without testing anything.
+            const sha = context.payload.pull_request.head.sha;
+            const { data: self } = await github.rest.actions.getWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId,
+            });
+            const deadline = Date.now() + 2 * 60 * 60 * 1000;
+            let emptyPolls = 0;
             for (;;) {
+              const runs = await github.paginate(
+                github.rest.actions.listWorkflowRunsForRepo,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  head_sha: sha,
+                  per_page: 100,
+                },
+              );
+              const live = runs.filter(
+                (r) =>
+                  r.workflow_id === self.workflow_id &&
+                  r.id !== context.runId &&
+                  r.status !== 'completed',
+              );
+              const finished = new Set(
+                runs
+                  .filter((r) => r.status === 'completed' && r.conclusion !== 'cancelled')
+                  .map((r) => `/runs/${r.id}/`),
+              );
               const { data } = await github.rest.checks.listForRef({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                ref: context.payload.pull_request.head.sha,
+                ref: sha,
                 check_name: 'all-tests',
                 // `latest` (the default) returns only the newest run per name —
                 // this job's own in_progress run — hiding the completed verdict.
                 filter: 'all',
                 per_page: 100,
               });
-              // Never mirror while another suite run is in flight — a
-              // stale completed green (e.g. a draft-era run whose e2e was
-              // skipped) must not shadow the run actually testing this SHA.
-              const isSelf = (c) =>
-                (c.details_url ?? '').includes(`/runs/${context.runId}/`);
-              const inFlight = data.check_runs.some(
-                (c) => c.status !== 'completed' && !isSelf(c),
-              );
               const prior = data.check_runs
-                .filter((c) => c.status === 'completed')
+                .filter(
+                  (c) =>
+                    c.status === 'completed' &&
+                    (c.conclusion === 'success' || c.conclusion === 'failure') &&
+                    [...finished].some((p) => (c.details_url ?? '').includes(p)),
+                )
                 .sort((a, b) => new Date(b.started_at) - new Date(a.started_at))[0];
-              // A rerun of failed jobs leaves the prior attempt's check run
-              // completed while its workflow run is live again; the next
-              // attempt's check run doesn't exist until its needs finish.
-              // Any non-completed sibling check run from the same workflow
-              // run reveals the rerun.
-              let rerunning = false;
-              if (prior && !inFlight) {
-                const runPath = (prior.details_url ?? '').match(/\/runs\/\d+\//)?.[0];
-                if (runPath) {
-                  const siblings = await github.paginate(github.rest.checks.listForRef, {
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    ref: context.payload.pull_request.head.sha,
-                    filter: 'all',
-                    per_page: 100,
-                  });
-                  rerunning = siblings.some(
-                    (c) =>
-                      c.status !== 'completed' &&
-                      !isSelf(c) &&
-                      (c.details_url ?? '').includes(runPath),
-                  );
-                }
-              }
-              if (prior && !inFlight && !rerunning) {
+              // Never mirror while another suite run is in flight — a stale
+              // completed verdict (e.g. a draft-era run, or the attempt a
+              // rerun is replacing) must not shadow the run testing this SHA.
+              if (live.length === 0 && prior) {
                 if (prior.conclusion === 'success') {
-                  core.info('Mirroring the previous all-tests result: success');
+                  core.info(`Mirroring the real all-tests result: success — ${prior.details_url}`);
                 } else {
-                  core.setFailed(`Mirroring the previous all-tests result: ${prior.conclusion}`);
+                  core.setFailed(`Mirroring the real all-tests result: failure — see ${prior.details_url}`);
                 }
                 return;
               }
-              if (Date.now() >= deadline) {
-                core.setFailed('No completed all-tests for this commit after 60 minutes — deferring to the run testing it.');
-                return;
+              if (live.length > 0) {
+                emptyPolls = 0;
+                if (Date.now() >= deadline) {
+                  core.setFailed(`Still waiting on ${live[0].html_url} after 2 hours — re-run this job once it completes.`);
+                  return;
+                }
+                core.info(`Waiting on the run testing this SHA: ${live.map((r) => r.html_url).join(', ')}`);
+              } else {
+                // Nothing is testing the SHA and no verdict exists (e.g.
+                // every real run was cancelled). Give races a short grace,
+                // then defer to a human rather than inventing a verdict.
+                if (++emptyPolls >= 10) {
+                  core.setFailed('No run is testing this SHA and no completed all-tests verdict exists — re-run the Pull Request workflow.');
+                  return;
+                }
+                core.info('No verdict and no live run for this SHA yet — waiting.');
               }
-              core.info('No completed all-tests for this commit yet — waiting for the run testing it.');
               await new Promise((resolve) => setTimeout(resolve, 30 * 1000));
             }
       - name: Fail when a draft deferred the e2e suite


### PR DESCRIPTION
### What happened

On #8092, two red `all-tests` entries appeared on a SHA whose suite passed:

1. A PR title/body edit spawned a no-op run that the next edit immediately displaced (shared `noop` concurrency group, `cancel-in-progress`). The cancellation killed its `modified-files` job, but `all-tests` ran anyway under `if: always()` and its fail-closed gate turned the cancellation into a **completed `all-tests` = failure** check run on the SHA.
2. The later no-op runs' mirror step picked that artifact as "the last real all-tests result" and re-reported failure. The run actually testing the SHA looked invisible to them: its `all-tests` check run doesn't exist until its needs finish, so the in-flight guard saw nothing.

The real run finished green 15 minutes later, so the newest `all-tests` was correct — but the rollup showed false-alarm red ✗s the whole time.

### Fix

- `all-tests` runs under `!cancelled()` instead of `always()`: a displaced run concludes cancelled instead of minting a red verdict for a SHA it never tested. A genuinely failed gate still fails closed.
- The mirror step watches this workflow's **runs** on the SHA (which exist immediately) instead of inferring flight status from check runs: it stays **pending** while a run is live and logs a link to it, then mirrors the verdict — and only from check runs whose workflow run completed uncancelled.
- The polling deadline is now 90 minutes (2-minute interval) with an explicit "re-run this job" message, and a no-runs/no-verdict stall (e.g. every real run was cancelled) defers to a human after a short grace instead of inventing a verdict.

The job-level `actions: read` grant is implicit on public repos but required on private downstream repos this workflow syncs to.

### Replay of the incident with this fix

The displaced run's `all-tests` concludes cancelled (no red ✗), and the two no-op runs sit yellow for ~15 minutes, then flip green alongside the real run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test status reporting for pull requests with no-op changes.
  * Prevented cancelled or displaced workflow runs from publishing incorrect test results.
  * Improved mirroring logic to track the specific workflow run tied to the PR’s head SHA.
  * Added more reliable waiting, polling, and failure behavior when test results are delayed or unavailable.
* **Other**
  * Updated Enterprise sync workflow status to include a temporary target link for easier visibility in the merge UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Also in this PR

The initial `enterprise / ci` pending status ("Awaiting Enterprise sync workflow…") now links its dispatching run — previously it was a dead label, so a status stuck at that stage gave no way to find the dispatch from the merge box. Downstream workflows overwrite it with links to the runs doing the actual work (that side ships separately).

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3508
<!-- enterprise-sync-pr:end -->
