### PR TITLE
[release] cherry-pick: remove propagation provenance blob

### DIFF
--- a/app/packages/annotation/src/agents/PropagationBrowserAgent.test.ts
+++ b/app/packages/annotation/src/agents/PropagationBrowserAgent.test.ts
@@ -20,7 +20,6 @@ function keyframe(
     label: "car",
     bounding_box: bbox,
     keyframe: true,
-    propagation: null,
   };
 }
 
@@ -34,7 +33,7 @@ describe("PropagationBrowserAgent.infer", () => {
   it("lerps a bbox between two keyframes and emits one Detection per in-between frame", async () => {
     const agent = new PropagationBrowserAgent();
     // For a tracked object both keyframes share one synthetic overlay id
-    // (`instance-<...>`); provenance must record their distinct mongo `_id`s.
+    // (`instance-<...>`); their distinct mongo `_id`s are carried for identity.
     const left = keyframe("instance-inst-1", [0.0, 0.0, 0.1, 0.1], "oid-left");
     const right = keyframe(
       "instance-inst-1",
@@ -65,9 +64,35 @@ describe("PropagationBrowserAgent.infer", () => {
       _cls: "Instance",
       _id: "inst-1",
     });
-    expect(midpoint?.detection.propagation).toMatchObject({
-      method: "linear",
-      parent_keyframes: ["oid-left", "oid-right"],
-    });
+  });
+
+  // Interpolated detections must carry no `propagation` provenance blob. The
+  // client persisted that blob against a baseline that held `propagation: null`
+  // (written on keyframe promotion) while the server stored the field as
+  // absent, so a later null→blob transition diffed as a `replace` over a
+  // path the server can't resolve — the frame-patch error. No blob, no replace.
+  it("emits no propagation provenance on interpolated detections", async () => {
+    const agent = new PropagationBrowserAgent();
+    const left = keyframe("instance-inst-1", [0.0, 0.0, 0.1, 0.1], "oid-left");
+    const right = keyframe(
+      "instance-inst-1",
+      [1.0, 1.0, 0.1, 0.1],
+      "oid-right",
+    );
+
+    const context: PropagationContext = {
+      ...baseContext,
+      fromFrame: 5,
+      toFrame: 15,
+      parentKeyframes: [left, right],
+    };
+
+    const result = (await agent.infer(
+      context,
+    )) as SyncInferenceResult<PropagationInferenceResult> & { labelId: string };
+
+    for (const { detection } of result.response.perFrame) {
+      expect(detection).not.toHaveProperty("propagation");
+    }
   });
 });

--- a/app/packages/annotation/src/agents/PropagationBrowserAgent.ts
+++ b/app/packages/annotation/src/agents/PropagationBrowserAgent.ts
@@ -82,16 +82,6 @@ export class PropagationBrowserAgent implements AnnotationAgent<PropagationInfer
       const left: Bbox = leftKeyframe.bounding_box;
       const right: Bbox = rightKeyframe.bounding_box;
       const span: number = context.toFrame - context.fromFrame;
-      const runId: string = generateObjectIdHex();
-
-      // Provenance records the *mongo* `_id`s of the two source keyframes,
-      // not their cross-frame-stable synthetic overlay ids (`instance-<...>`,
-      // identical for both ends of a tracked object). Fall back to the
-      // synthetic id only if a keyframe somehow lacks a persisted `_id`.
-      const parentKeyframeIds: [string, string] = [
-        leftKeyframe._id ?? leftKeyframe.id,
-        rightKeyframe._id ?? rightKeyframe.id,
-      ];
 
       const perFrame: PropagationInferenceResult["perFrame"] = [];
       range(context.fromFrame + 1, context.toFrame).forEach((n) => {
@@ -104,11 +94,6 @@ export class PropagationBrowserAgent implements AnnotationAgent<PropagationInfer
           index: leftKeyframe.index,
           instance: { _cls: "Instance", _id: context.instanceId },
           keyframe: false,
-          propagation: {
-            method: "linear",
-            run_id: runId,
-            parent_keyframes: parentKeyframeIds,
-          },
         };
         perFrame.push({ frameNumber: n, detection });
       });

--- a/app/packages/annotation/src/agents/SAM2PropagationBrowserAgent.test.ts
+++ b/app/packages/annotation/src/agents/SAM2PropagationBrowserAgent.test.ts
@@ -17,7 +17,6 @@ const keyframe = (
   index: 2,
   instance: { _cls: "Instance", _id: INSTANCE },
   keyframe: true,
-  propagation: null,
   ...overrides,
 });
 
@@ -56,7 +55,7 @@ const baseArgs = (
 });
 
 describe("SAM2PropagationBrowserAgent forward run", () => {
-  it("emits the horizon frame and records a single parent keyframe", async () => {
+  it("emits the horizon frame with no propagation provenance", async () => {
     const emitted: Array<{ frame: number; det: PropagatedDetection }> = [];
     const { agent } = makeAgent();
 
@@ -68,14 +67,15 @@ describe("SAM2PropagationBrowserAgent forward run", () => {
     for (const { det } of emitted) {
       expect(det.keyframe).toBe(false);
       expect(det.instance?._id).toBe(INSTANCE);
-      expect(det.propagation?.method).toBe("sam2");
-      expect(det.propagation?.parent_keyframes).toEqual(["seed"]);
+      // No `propagation` blob: it would persist as a `replace` over a
+      // server-absent path on the next edit (the frame-patch error).
+      expect(det).not.toHaveProperty("propagation");
     }
   });
 });
 
 describe("SAM2PropagationBrowserAgent bracketed run", () => {
-  it("leaves both keyframe endpoints untouched and records two parents", async () => {
+  it("leaves both keyframe endpoints untouched and writes no provenance", async () => {
     const emitted: Array<{ frame: number; det: PropagatedDetection }> = [];
     const { agent } = makeAgent();
 
@@ -86,9 +86,6 @@ describe("SAM2PropagationBrowserAgent bracketed run", () => {
 
     // Both endpoints (frames 1 and 3) are user keyframes → only frame 2.
     expect(emitted.map((e) => e.frame)).toEqual([2]);
-    expect(emitted[0].det.propagation?.parent_keyframes).toEqual([
-      "seed",
-      "end",
-    ]);
+    expect(emitted[0].det).not.toHaveProperty("propagation");
   });
 });

--- a/app/packages/annotation/src/agents/SAM2PropagationBrowserAgent.ts
+++ b/app/packages/annotation/src/agents/SAM2PropagationBrowserAgent.ts
@@ -107,18 +107,6 @@ export class SAM2PropagationBrowserAgent implements AnnotationAgent<PropagationI
 
     await this.ensureInitialized();
 
-    const runId = objectId();
-    // Provenance records the source keyframes' mongo `_id`s (not the
-    // cross-frame-stable synthetic overlay id, which is identical for both
-    // ends of a track); fall back to the synthetic id only if unpersisted.
-    // A forward run has a single parent (the seed); a bracketed run has two.
-    const parentKeyframes: [string, ...string[]] = args.endKeyframe
-      ? [
-          args.seedKeyframe._id ?? args.seedKeyframe.id,
-          args.endKeyframe._id ?? args.endKeyframe.id,
-        ]
-      : [args.seedKeyframe._id ?? args.seedKeyframe.id];
-
     this.setStatus("inferring");
 
     try {
@@ -162,11 +150,6 @@ export class SAM2PropagationBrowserAgent implements AnnotationAgent<PropagationI
             index: args.seedKeyframe.index,
             instance: { _cls: "Instance", _id: args.instanceId },
             keyframe: false,
-            propagation: {
-              method: "sam2",
-              run_id: runId,
-              parent_keyframes: parentKeyframes,
-            },
           };
 
           args.onDetection(frameIdx, detection);

--- a/app/packages/annotation/src/agents/types.ts
+++ b/app/packages/annotation/src/agents/types.ts
@@ -1,7 +1,7 @@
 import type { ClassificationLabel } from "@fiftyone/looker/src/overlays/classifications";
 import type { DetectionLabel } from "@fiftyone/looker/src/overlays/detection";
 import type { PolylineLabel } from "@fiftyone/looker/src/overlays/polyline";
-import type { PropagationBlob, SyntheticBox } from "@fiftyone/utilities";
+import type { SyntheticBox } from "@fiftyone/utilities";
 import type { ProviderError } from "../providers";
 
 /** Helper type representing a `fo.Polylines`-like element. */
@@ -203,7 +203,6 @@ export type SegmentationInferenceResult = DetectionsParent;
 export type PropagatedDetection = DetectionLabel & {
   bounding_box: [number, number, number, number];
   keyframe: boolean;
-  propagation: PropagationBlob | null;
 };
 
 /**

--- a/app/packages/utilities/src/videoLabels.ts
+++ b/app/packages/utilities/src/videoLabels.ts
@@ -9,23 +9,6 @@
  * shapes with no React / state deps.
  */
 
-/** ObjectId hex string. */
-export type ObjectIdHex = string;
-
-export type PropagationMethod = "linear" | "sam2";
-
-/** Provenance written on labels created by a propagation run. */
-export interface PropagationBlob {
-  method: PropagationMethod;
-  run_id: ObjectIdHex;
-  /**
-   * Source keyframes' `_id`s. Two for a bracketed run (linear interp,
-   * or SAM2 between two keyframes); one for a SAM2 forward run that tracks
-   * from a single seed keyframe to the end of the clip.
-   */
-  parent_keyframes: [ObjectIdHex, ...ObjectIdHex[]];
-}
-
 export interface SyntheticBox {
   id: string;
   /**
@@ -56,8 +39,6 @@ export interface SyntheticBox {
   instance?: { _cls: "Instance"; _id?: string };
   /** `true` for user-authored / propagation source; `false` for interpolated. */
   keyframe: boolean;
-  /** Provenance for propagation-created labels; `null` for keyframes. */
-  propagation: PropagationBlob | null;
 }
 
 export interface FrameLabelSnapshot {
@@ -75,7 +56,6 @@ export interface RawDetection {
   mask_path?: string;
   mask?: unknown;
   keyframe?: boolean;
-  propagation?: PropagationBlob | null;
 }
 
 export interface RawDetectionsField {
@@ -92,7 +72,6 @@ export interface RawPolyline {
   filled?: boolean;
   instance?: { _cls: "Instance"; _id?: string } | null;
   keyframe?: boolean;
-  propagation?: PropagationBlob | null;
 }
 
 export interface RawPolylinesField {
@@ -119,9 +98,4 @@ export interface LocalDetection {
    * value through `updateLabel`'s shallow merge.
    */
   keyframe?: boolean;
-  /**
-   * Propagation provenance. User edits clear this (`null`); leave
-   * undefined to preserve the existing value through the shallow merge.
-   */
-  propagation?: PropagationBlob | null;
 }

--- a/app/packages/video-annotation/index.ts
+++ b/app/packages/video-annotation/index.ts
@@ -2,8 +2,6 @@ export { VideoAnnotationSurface } from "./src/components/VideoAnnotationSurface"
 export { SyntheticLabelStream } from "./src/streams/SyntheticLabelStream";
 export type {
   FrameLabelSnapshot,
-  PropagationBlob,
-  PropagationMethod,
   SyntheticBox,
 } from "./src/streams/SyntheticLabelStream";
 export {

--- a/app/packages/video-annotation/src/hooks/useKeyframePromotionOnEdit.test.ts
+++ b/app/packages/video-annotation/src/hooks/useKeyframePromotionOnEdit.test.ts
@@ -56,6 +56,8 @@ beforeEach(() => {
 
 describe("useKeyframePromotionOnEdit", () => {
   it("promotes a non-keyframe frame and re-lerps, folded into the edit's undo unit", () => {
+    // Legacy data may still carry a `propagation` blob; promotion must NOT
+    // try to clear it with `propagation: null` (that null is the poison).
     frameData = { A: det({ keyframe: false, propagation: { foo: 1 } }) };
 
     render()("A", PATH, "gesture:1");
@@ -64,9 +66,12 @@ describe("useKeyframePromotionOnEdit", () => {
     expect(mockEngine.transaction.mock.calls[0][1]).toEqual({
       undoKey: "gesture:1",
     });
+    // Promotion writes only `keyframe: true` — no `propagation: null`, which
+    // would seed a null baseline that the next re-lerp diffs as a `replace`
+    // over a server-absent path (the frame-patch error).
     expect(mockEngine.updateLabel).toHaveBeenCalledWith(
       { sample: SAMPLE, path: PATH, instanceId: "A", frame: FRAME },
-      { keyframe: true, propagation: null },
+      { keyframe: true },
     );
     expect(mockBus.dispatch).toHaveBeenCalledWith(
       "annotation:keyframeChanged",

--- a/app/packages/video-annotation/src/hooks/useKeyframePromotionOnEdit.ts
+++ b/app/packages/video-annotation/src/hooks/useKeyframePromotionOnEdit.ts
@@ -13,8 +13,8 @@ import { useCurrentFrameGetter } from "../state/useCurrentFrame";
 
 /**
  * Builds the bridge's `onEditCommit` callback: after a geometry drag / resize
- * lands on the engine, promote the touched frame to a keyframe (clearing any
- * interpolation provenance) and dispatch `annotation:keyframeChanged` so
+ * lands on the engine, promote the touched frame to a keyframe and dispatch
+ * `annotation:keyframeChanged` so
  * {@link useAutoInterpolate} re-lerps the bracketing segments against the new
  * geometry. The promotion write folds into the edit's undo unit via the gesture
  * `undoKey` the commit landed under, so one Ctrl-Z reverts the whole nudge.
@@ -53,16 +53,13 @@ export const useKeyframePromotionOnEdit = (): ((
       }
 
       // Promote the touched frame to a keyframe when it isn't one already,
-      // clearing interpolation provenance, folded into the edit's undo unit (the
-      // commit's `undoKey`). An already-keyframe edit writes nothing here (no
-      // empty undo entry) but still re-lerps below against its new geometry.
+      // folded into the edit's undo unit (the commit's `undoKey`). An
+      // already-keyframe edit writes nothing here (no empty undo entry) but
+      // still re-lerps below against its new geometry.
       if (!det.keyframe) {
         engine.transaction(
           () => {
-            engine.updateLabel(ref, {
-              keyframe: true,
-              ...(det.propagation ? { propagation: null } : {}),
-            });
+            engine.updateLabel(ref, { keyframe: true });
           },
           { undoKey },
         );

--- a/app/packages/video-annotation/src/hooks/useVideoPropagate.ts
+++ b/app/packages/video-annotation/src/hooks/useVideoPropagate.ts
@@ -12,7 +12,6 @@ import {
 import {
   type LabelData,
   LabelType,
-  type PropagationBlob,
   type SyntheticBox,
 } from "@fiftyone/utilities";
 import { createElement, useCallback } from "react";
@@ -40,7 +39,6 @@ const toSyntheticBox = (label: LabelData): SyntheticBox => ({
   index: label.index as number | undefined,
   instance: label.instance as SyntheticBox["instance"],
   keyframe: (label.keyframe as boolean) ?? false,
-  propagation: (label.propagation as PropagationBlob | null) ?? null,
 });
 
 /**

--- a/app/packages/video-annotation/src/hooks/useVideoSurfaceActions.test.ts
+++ b/app/packages/video-annotation/src/hooks/useVideoSurfaceActions.test.ts
@@ -78,6 +78,8 @@ beforeEach(() => {
 
 describe("track ops", () => {
   it("markKeyframe toggles keyframe on the addressed frame and notifies", () => {
+    // Legacy data may still carry a `propagation` blob; markKeyframe must NOT
+    // try to clear it with `propagation: null` (that null is the poison).
     frameData = {
       2: { A: det("d2", "A", { keyframe: false, propagation: { foo: 1 } }) },
     };
@@ -85,9 +87,12 @@ describe("track ops", () => {
     render().current.markKeyframe(2, ["instance-A"]);
 
     expect(mockActions.transaction).toHaveBeenCalledTimes(1);
+    // Only `keyframe: true` is written — no `propagation: null`, which would
+    // seed a null baseline that a later re-lerp diffs as a `replace` over a
+    // server-absent path (the frame-patch error).
     expect(mockActions.updateLabel).toHaveBeenCalledWith(
       { path: PATH, instanceId: "A", frame: 2 },
-      { keyframe: true, propagation: null },
+      { keyframe: true },
     );
     expect(mockBus.dispatch).toHaveBeenCalledWith(
       "annotation:keyframeChanged",

--- a/app/packages/video-annotation/src/hooks/useVideoSurfaceActions.ts
+++ b/app/packages/video-annotation/src/hooks/useVideoSurfaceActions.ts
@@ -209,12 +209,6 @@ const makeTrackOps = (
           const set = !det.keyframe;
           const update: Partial<LabelData> = { keyframe: set };
 
-          // promotion clears interpolation provenance — only when present, so
-          // an unchanged baseline doesn't accrue a no-op `propagation: null` op
-          if (set && det.propagation) {
-            update.propagation = null;
-          }
-
           actions.updateLabel({ path: labelPath, instanceId, frame }, update);
           changed.push({ trackId, instanceId, set, path: labelPath });
         }

--- a/app/packages/video-annotation/src/streams/SyntheticLabelStream.ts
+++ b/app/packages/video-annotation/src/streams/SyntheticLabelStream.ts
@@ -2,12 +2,7 @@ import type { FrameLabelSnapshot, SyntheticBox } from "@fiftyone/utilities";
 import { PlaybackStreamBase } from "@fiftyone/playback";
 
 // Re-exported from `@fiftyone/utilities` for the package barrel.
-export type {
-  FrameLabelSnapshot,
-  PropagationBlob,
-  PropagationMethod,
-  SyntheticBox,
-} from "@fiftyone/utilities";
+export type { FrameLabelSnapshot, SyntheticBox } from "@fiftyone/utilities";
 
 export interface SyntheticActor {
   id: string;
@@ -213,7 +208,6 @@ function snapshotAtTime(
       // — synthetic actors have no numeric index by design).
       instance: { _cls: "Instance", _id: actor.id },
       keyframe: true,
-      propagation: null,
     });
   }
   return { frameNumber, detections };

--- a/app/packages/video-annotation/src/streams/VideoFrameLabelsStream.test.ts
+++ b/app/packages/video-annotation/src/streams/VideoFrameLabelsStream.test.ts
@@ -38,7 +38,7 @@ describe("VideoFrameLabelsStream fetched-empty", () => {
 });
 
 describe("VideoFrameLabelsStream extractDetections", () => {
-  it("defaults missing keyframe to false and propagation to null", () => {
+  it("defaults missing keyframe to false", () => {
     const stream = buildStream();
     // @ts-expect-error — test-only: populate the private cache
     stream.cache.set(10, {
@@ -52,7 +52,7 @@ describe("VideoFrameLabelsStream extractDetections", () => {
 
     const value = stream.getValue(timeOfFrame(10, 30));
     expect(value?.detections[0].keyframe).toBe(false);
-    expect(value?.detections[0].propagation).toBeNull();
+    expect(value?.detections[0]).not.toHaveProperty("propagation");
   });
 });
 

--- a/app/packages/video-annotation/src/streams/VideoFrameLabelsStream.ts
+++ b/app/packages/video-annotation/src/streams/VideoFrameLabelsStream.ts
@@ -421,7 +421,6 @@ function extractDetections(
       index: det.index,
       instance: det.instance ?? undefined,
       keyframe: det.keyframe ?? false,
-      propagation: det.propagation ?? null,
     });
   }
 


### PR DESCRIPTION
Cherry-pick of #7930 to `release/v1.20.0` (one trivial doc-comment conflict, resolved identically to the develop merge).

Removes the `propagation` provenance blob (`{method, run_id, parent_keyframes}`) that the propagation agents stamped onto interpolated video detections. The blob was write-only — nothing reads it — and it just clutters the sample. It can be reintroduced later if a richer interpolation method needs real provenance.

## Testing

- `vitest` green across `annotation`, `video-annotation`, `utilities` (1052 passed); changed files type-check clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Propagated and interpolated detections no longer include propagation metadata.
  * Promoting or editing keyframes no longer clears existing propagation information.
  * Detection outputs now omit absent propagation fields instead of returning them as `null`.

* **Refactor**
  * Removed propagation metadata types from the public annotation data structures and exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3509
<!-- enterprise-sync-pr:end -->