### PR TITLE
fix(app): don't suspend the patches modal behind the global loading screen

### DIFF
--- a/app/packages/core/src/components/Actions/Similarity/index.tsx
+++ b/app/packages/core/src/components/Actions/Similarity/index.tsx
@@ -3,13 +3,12 @@ import { executeOperator } from "@fiftyone/operators";
 import { useOutsideClick, useSimilarityType } from "@fiftyone/state";
 import { Search, Wallpaper } from "@mui/icons-material";
 import { useCallback, useRef, useState } from "react";
-import { useRecoilValueLoadable } from "recoil";
 import Loading from "../Loading";
 import type { ActionProps } from "../types";
 import { ActionDiv, getStringAndNumberProps } from "../utils";
 import { PANEL_NAME } from "./constants";
 import SimilarityPopover from "./Similar";
-import { availableSimilarityKeys } from "./utils";
+import { useAvailableSimilarityKeys } from "./utils";
 
 const Similarity = ({
   modal,
@@ -27,12 +26,7 @@ const Similarity = ({
     isImageSearch,
   });
 
-  // a loadable so a pending dependency (e.g. the modal sample in patches
-  // views) suspends neither the action row nor the global boundary
-  const keysLoadable = useRecoilValueLoadable(
-    availableSimilarityKeys({ modal, isImageSearch: showImageSimilarityIcon }),
-  );
-  const keys = keysLoadable.state === "hasValue" ? keysLoadable.contents : null;
+  const keys = useAvailableSimilarityKeys(modal, showImageSimilarityIcon);
 
   const togglePopover = useCallback(() => {
     if (searching || keys === null) return;

--- a/app/packages/core/src/components/Actions/Similarity/index.tsx
+++ b/app/packages/core/src/components/Actions/Similarity/index.tsx
@@ -3,7 +3,7 @@ import { executeOperator } from "@fiftyone/operators";
 import { useOutsideClick, useSimilarityType } from "@fiftyone/state";
 import { Search, Wallpaper } from "@mui/icons-material";
 import { useCallback, useRef, useState } from "react";
-import { useRecoilValue } from "recoil";
+import { useRecoilValueLoadable } from "recoil";
 import Loading from "../Loading";
 import type { ActionProps } from "../types";
 import { ActionDiv, getStringAndNumberProps } from "../utils";
@@ -27,12 +27,15 @@ const Similarity = ({
     isImageSearch,
   });
 
-  const keys = useRecoilValue(
+  // a loadable so a pending dependency (e.g. the modal sample in patches
+  // views) suspends neither the action row nor the global boundary
+  const keysLoadable = useRecoilValueLoadable(
     availableSimilarityKeys({ modal, isImageSearch: showImageSimilarityIcon }),
   );
+  const keys = keysLoadable.state === "hasValue" ? keysLoadable.contents : null;
 
   const togglePopover = useCallback(() => {
-    if (searching) return;
+    if (searching || keys === null) return;
     if (keys.length === 0) {
       // No applicable keys — open panel directly
       executeOperator("open_panel", {

--- a/app/packages/core/src/components/Actions/Similarity/utils.ts
+++ b/app/packages/core/src/components/Actions/Similarity/utils.ts
@@ -118,6 +118,12 @@ const availablePatchesSimilarityKeys = selectorFamily<
       }
       patches = methods.map(([method, field]) => [method, field]);
 
+      // avoid the async modal sample dependency below when there is nothing
+      // to filter
+      if (!patches.length) {
+        return [];
+      }
+
       if (params.modal) {
         if (get(fos.hasSelectedLabels)) {
           const fields = new Set(

--- a/app/packages/core/src/components/Actions/Similarity/utils.ts
+++ b/app/packages/core/src/components/Actions/Similarity/utils.ts
@@ -2,7 +2,7 @@ import type { Method } from "@fiftyone/state";
 import * as fos from "@fiftyone/state";
 import { selectedLabels } from "@fiftyone/state";
 import type { Snapshot } from "recoil";
-import { selectorFamily } from "recoil";
+import { selectorFamily, useRecoilValueLoadable } from "recoil";
 
 export type QueryIds = {
   queryIds: string[] | string | undefined;
@@ -99,6 +99,27 @@ export const availableSimilarityKeys = selectorFamily<
         .sort();
     },
 });
+
+/**
+ * Reads {@link availableSimilarityKeys} as a loadable so a pending dependency
+ * (e.g. the modal sample in patches views) suspends neither the action row nor
+ * the global boundary. Returns `null` while pending and rethrows selector
+ * errors so they reach the error boundary.
+ */
+export const useAvailableSimilarityKeys = (
+  modal: boolean,
+  isImageSearch: boolean,
+): string[] | null => {
+  const keys = useRecoilValueLoadable(
+    availableSimilarityKeys({ modal, isImageSearch }),
+  );
+
+  if (keys.state === "hasError") {
+    throw keys.contents;
+  }
+
+  return keys.state === "hasValue" ? keys.contents : null;
+};
 
 const availablePatchesSimilarityKeys = selectorFamily<
   Method[],

--- a/e2e-pw/src/oss/specs/one-loading-screen-patches.spec.ts
+++ b/e2e-pw/src/oss/specs/one-loading-screen-patches.spec.ts
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ *
+ * Asserts that the global "Pixelating..." loading screen does not re-trigger
+ * when opening the modal or navigating between samples in a patches view.
+ *
+ * Regression guard: the modal similarity action read the async modal sample
+ * through `availableSimilarityKeys` at mount in patches views, suspending up
+ * to the top-level Suspense boundary.
+ */
+import { test as base } from "src/oss/fixtures";
+import { GridPom } from "src/oss/poms/grid";
+import { ModalPom } from "src/oss/poms/modal";
+import { PagePom } from "src/oss/poms/page";
+import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
+
+const datasetName = getUniqueDatasetNameWithPrefix(
+  "one-loading-screen-patches",
+);
+
+const test = base.extend<{
+  grid: GridPom;
+  modal: ModalPom;
+  pagePom: PagePom;
+}>({
+  grid: async ({ page, eventUtils }, use) => {
+    await use(new GridPom(page, eventUtils));
+  },
+  modal: async ({ page, eventUtils }, use) => {
+    await use(new ModalPom(page, eventUtils));
+  },
+  pagePom: async ({ page, eventUtils }, use) => {
+    await use(new PagePom(page, eventUtils));
+  },
+});
+
+test.afterAll(async ({ foWebServer }) => {
+  await foWebServer.stopWebServer();
+});
+
+test.beforeAll(async ({ datasetFactory, foWebServer }) => {
+  await foWebServer.startWebServer();
+  await datasetFactory.createDataset({
+    datasetName,
+    numSamples: 3,
+    schema: {
+      predictions: "Detections",
+    },
+    withSampleData: (_, { createId }) => ({
+      predictions: {
+        detections: [
+          {
+            _id: createId(),
+            label: "cat",
+            bounding_box: [0.1, 0.1, 0.2, 0.2],
+          },
+          {
+            _id: createId(),
+            label: "dog",
+            bounding_box: [0.3, 0.3, 0.2, 0.2],
+          },
+        ],
+      },
+    }),
+    savedViews: { patches: "dataset.to_patches('predictions')" },
+  });
+});
+
+/**
+ * Asserts that the loading screen appears exactly once (on initial page load)
+ * and is not re-triggered by opening the modal or navigating to the next
+ * patch in a patches view.
+ */
+test("does not show when opening or navigating the modal in a patches view", async ({
+  fiftyoneLoader,
+  grid,
+  modal,
+  page,
+  pagePom,
+}) => {
+  await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
+    searchParams: new URLSearchParams({ view: "patches" }),
+  });
+  await pagePom.assert.hasHadOnlyOneGlobalLoadingScreen();
+
+  await grid.openFirstSample();
+  await modal.waitForSampleLoadDomAttribute();
+  await pagePom.assert.hasHadOnlyOneGlobalLoadingScreen();
+
+  await modal.navigateNextSample();
+  await modal.waitForSampleLoadDomAttribute();
+  await pagePom.assert.hasHadOnlyOneGlobalLoadingScreen();
+});


### PR DESCRIPTION
## What changes

Opening a sample in a patches view re-mounted the global "Pixelating..." loading screen. The modal `Similarity` action reads `availableSimilarityKeys` with a suspending `useRecoilValue` at mount (hoisted from the popover subtree in 3dc98bf8f0 to decide click behavior). In patches views that selector reads the async `fos.modalSample` through `availablePatchesSimilarityKeys`, and nothing around `<Actions />` in `Modal.tsx` has a Suspense boundary — the pending promise escapes to the top-level boundary in `Renderer.tsx`. Normal views take the synchronous `similarityMethods` path, which is why this was patches-only.

Two layers:

- the action reads the keys through a loadable; while pending, clicking the icon is a no-op instead of the modal suspending
- `availablePatchesSimilarityKeys` returns `[]` before touching `modalSample` when there are no patch similarity runs to filter, so datasets without brain runs never take the fetch dependency

## Testing

New `one-loading-screen-patches.spec.ts`, mirroring the grouped-dataset loading-screen spec: a detections dataset with a `to_patches` saved view, asserting the global loading screen fires exactly once after initial load, after opening the first sample, and after navigating to the next sample.

Verified locally red then green: against the unfixed build the spec fails with a loading-screen count of 2 right after opening the modal; with the fix it passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Similarity action behavior while similarity options are loading.
  * Prevented unnecessary modal-related filtering when no patch similarity options are available.
  * Fixed the patches view “Pixelating...” loading screen reappearing when switching samples within the modal.

* **Tests**
  * Added end-to-end Playwright coverage for the patches loading screen showing only once on initial load.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3513
<!-- enterprise-sync-pr:end -->