### PR TITLE
Add reload_plugins operator to refresh installed plugins

### DIFF
--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -24,8 +24,10 @@ import {
   useRecoilValue,
   useSetRecoilState,
 } from "recoil";
+import { loadPlugins } from "@fiftyone/plugins";
 import { useOperatorExecutor } from ".";
 import useRefetchableSavedViews from "../../core/src/hooks/useRefetchableSavedViews";
+import { useRefreshOperators } from "./loader";
 import registerPanel from "./Panel/register";
 import "./builtin";
 import {
@@ -81,6 +83,26 @@ class ReloadDataset extends Operator {
   }
   async execute({ hooks }) {
     hooks.refresh();
+  }
+}
+class ReloadPlugins extends Operator {
+  _builtIn = true;
+  get config(): OperatorConfig {
+    return new OperatorConfig({
+      name: "reload_plugins",
+      label: "Reload plugins",
+    });
+  }
+  // loadPlugins() only runs once, at mount; a later install needs this.
+  useHooks() {
+    return {
+      refreshOperators: useRefreshOperators(),
+      datasetName: useRecoilValue(fos.datasetName),
+    };
+  }
+  async execute({ hooks }) {
+    await loadPlugins();
+    await hooks.refreshOperators(hooks.datasetName);
   }
 }
 class ClearSelectedSamples extends Operator {
@@ -1746,6 +1768,7 @@ export function registerBuiltInOperators() {
     _registerBuiltInOperator(ViewFromJSON);
     _registerBuiltInOperator(ReloadSamples);
     _registerBuiltInOperator(ReloadDataset);
+    _registerBuiltInOperator(ReloadPlugins);
     _registerBuiltInOperator(ClearSelectedSamples);
     _registerBuiltInOperator(OpenAllPanels);
     _registerBuiltInOperator(CloseAllPanels);

--- a/app/packages/operators/src/index.ts
+++ b/app/packages/operators/src/index.ts
@@ -1,6 +1,6 @@
 export { OPERATOR_PROMPT_AREAS, RiskLevel } from "./constants";
 export { useFirstExistingUri } from "./hooks";
-export { useOperators } from "./loader";
+export { useOperators, useRefreshOperators } from "./loader";
 export { default as OperatorBrowser } from "./OperatorBrowser";
 export { default as OperatorCore } from "./OperatorCore";
 export { default as OperatorInvocationRequestExecutor } from "./OperatorInvocationRequestExecutor";

--- a/app/packages/operators/src/loader.tsx
+++ b/app/packages/operators/src/loader.tsx
@@ -1,6 +1,6 @@
 import { datasetName as datasetNameAtom } from "@fiftyone/state";
 import { isPrimitiveString } from "@fiftyone/utilities";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useRecoilValue, useSetRecoilState } from "recoil";
 import { registerBuiltInOperators } from "./built-in-operators";
 import { useOperatorPlacementsResolver } from "./hooks";
@@ -14,7 +14,13 @@ import {
 let startupOperatorsExecuted = false;
 const registeredPanels = new Set<string>();
 
-async function loadOperators(datasetName: string) {
+/**
+ * Fetch operator/panel definitions for `datasetName` and register any not
+ * already known. Shared by the mount-time loader below and by
+ * `useRefreshOperators`, which needs the same fetch-and-register step
+ * without `loadOperators`' one-time dataset-open/startup side effects.
+ */
+async function fetchAndRegisterOperators(datasetName: string) {
   registerBuiltInOperators();
   const panels = await loadOperatorsFromServer(datasetName);
   for (const panel of panels) {
@@ -23,6 +29,10 @@ async function loadOperators(datasetName: string) {
       registerPanel(panel);
     }
   }
+}
+
+async function loadOperators(datasetName: string) {
+  await fetchAndRegisterOperators(datasetName);
   executeOperatorsForEvent("onDatasetOpen");
   if (!startupOperatorsExecuted) {
     executeOperatorsForEvent("onStartup");
@@ -72,4 +82,23 @@ export function useOperators(datasetLess?: boolean) {
     error,
     state,
   };
+}
+
+/**
+ * Re-fetches and registers operators/panels, then bumps the refresh count
+ * so mounted consumers see anything new without a reload. Skips
+ * `loadOperators`' one-time `onDatasetOpen`/`onStartup` side effects.
+ */
+export function useRefreshOperators() {
+  const setAvailableOperatorsRefreshCount = useSetRecoilState(
+    availableOperatorsRefreshCount,
+  );
+
+  return useCallback(
+    async (datasetName: string) => {
+      await fetchAndRegisterOperators(datasetName);
+      setAvailableOperatorsRefreshCount((count) => count + 1);
+    },
+    [setAvailableOperatorsRefreshCount],
+  );
 }


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link.

## 📋 What changes are proposed in this pull request?

Adds a `reload_plugins` built-in operator so plugins installed while the app is running can be loaded **without a full page refresh**. Plugin JS bundles are loaded by `loadPlugins()` only once, when the app mounts. Refreshing `/operators` alone isn't enough because newly installed hybrid JS panels don't exist in the app until their bundle is loaded.

This is a partial port of [voxel51/fiftyone-teams#3524](https://github.com/voxel51/fiftyone-teams/pull/3524), which fixes the same issue in FiftyOne Enterprise. After this PR is merged, I'll rebease FOE. 

## 🧪 How is this patch tested? If it is not, please explain why.

Tested manually by installing a new plugin during an active FiftyOne session and using the new `reload_plugins` operator to load and register it without refreshing the page, you can test this functionality in my ephemeral [here](adonai.ephem.fiftyone.ai). 

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

* [ ] No. You can skip the rest of this section.
* [x] Yes. Give a description of this change to be included in the release
  notes for FiftyOne users.

Added support for reloading newly installed plugins during an active session, allowing new operators and panels to be used without manually refreshing the page.

### What areas of FiftyOne does this PR affect?

- [X] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Reload plugins** action to refresh available plugins and operators for the current dataset.
  * Operator and panel updates can now be refreshed without reopening the dataset.
  * Refreshing plugins avoids repeating one-time startup actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3529
<!-- enterprise-sync-pr:end -->