### PR TITLE
[FOEPD-4207] perf(app): parallelize sidebar filter aggregation reads

### DIFF
--- a/app/__mocks__/recoil.ts
+++ b/app/__mocks__/recoil.ts
@@ -13,6 +13,18 @@ export function setMockAtoms(newMockValues: { [key: string]: any }) {
 }
 
 export const getValue = (atom) => {
+  // ``waitForAll`` resolves its dependencies eagerly here (the mock has no
+  // async/loadable machinery): map ``getValue`` over the deps, preserving the
+  // array/object shape the caller passed.
+  if (atom && atom.__waitForAll) {
+    const { deps } = atom;
+    return Array.isArray(deps)
+      ? deps.map(getValue)
+      : Object.fromEntries(
+          Object.entries(deps).map(([k, v]) => [k, getValue(v)]),
+        );
+  }
+
   if (mockValuesStore[atom.key]) {
     const str = JSON.stringify(atom.params);
     if (Object.hasOwn(mockValuesStore[atom.key], str)) {
@@ -51,6 +63,10 @@ const setValue = (atom, value) => {
     mockValues[atom.key] = value instanceof Function ? value(current) : value;
   }
 };
+
+export function waitForAll<T>(deps: T) {
+  return { __waitForAll: true, deps };
+}
 
 export function atom<T>(options: Parameters<typeof recoil.atom<T>>[0]) {
   return { key: options.key };

--- a/app/packages/core/src/components/Filters/NumericFieldFilter/NumericFieldFilter.tsx
+++ b/app/packages/core/src/components/Filters/NumericFieldFilter/NumericFieldFilter.tsx
@@ -38,6 +38,11 @@ const NumericFieldFilter = ({ color, modal, named = true, path }: Props) => {
   // suspends on the field (via hasBounds). Otherwise the tree waterfalls:
   // useShow reads the field, suspends, and RangeSlider/<Nonfinites> only
   // request the parent once it resolves. No-op on the lightning path.
+  //
+  // The discarded value is the point — this is a render-phase read purely to
+  // start the fetches. It can't be an effect: React won't commit a tree
+  // containing a suspended component, so an effect here wouldn't fire until
+  // the bounds read had already resolved, leaving the fetches serial.
   useRecoilValue(state.numericFilterPrefetch({ path, modal }));
   const show = useShow(modal, named, path);
   const icon = useQueryPerformanceIcon(modal, named, path, color);

--- a/app/packages/core/src/components/Filters/NumericFieldFilter/NumericFieldFilter.tsx
+++ b/app/packages/core/src/components/Filters/NumericFieldFilter/NumericFieldFilter.tsx
@@ -4,8 +4,10 @@ import styled from "styled-components";
 import FieldLabelAndInfo from "../../FieldLabelAndInfo";
 import useQueryPerformanceIcon from "../use-query-performance-icon";
 import useQueryPerformanceTimeout from "../use-query-performance-timeout";
+import { useRecoilValue } from "recoil";
 import Box from "./Box";
 import RangeSlider from "./RangeSlider";
+import * as state from "./state";
 import useShow from "./use-show";
 
 const Container = styled.div`
@@ -32,6 +34,11 @@ const NumericFieldFilter = ({ color, modal, named = true, path }: Props) => {
   const name = path.split(".").slice(-1)[0];
   const field = fos.useAssertedRecoilValue(fos.field(path));
 
+  // Issue the field + parent aggregations together, before useShow
+  // suspends on the field (via hasBounds). Otherwise the tree waterfalls:
+  // useShow reads the field, suspends, and RangeSlider/<Nonfinites> only
+  // request the parent once it resolves. No-op on the lightning path.
+  useRecoilValue(state.numericFilterPrefetch({ path, modal }));
   const show = useShow(modal, named, path);
   const icon = useQueryPerformanceIcon(modal, named, path, color);
   if (!show) {

--- a/app/packages/core/src/components/Filters/NumericFieldFilter/state.test.ts
+++ b/app/packages/core/src/components/Filters/NumericFieldFilter/state.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+vi.mock("recoil");
+vi.mock("recoil-relay");
+
+import {
+  setMockAtoms,
+  TestSelectorFamily,
+} from "../../../../../../__mocks__/recoil";
+import * as state from "./state";
+
+// Tracks every ``nonfiniteData`` read so tests can assert whether the
+// prefetch actually issued the parent aggregation.
+const nonfiniteDataCalls: {
+  path: string;
+  modal: boolean;
+  extended: boolean;
+}[] = [];
+
+setMockAtoms({
+  queryPerformance: false,
+  hasDefaultRange: () => true,
+  nonfiniteData: (params: {
+    path: string;
+    modal: boolean;
+    extended: boolean;
+  }) => {
+    nonfiniteDataCalls.push(params);
+    return { none: 0, inf: 0, ninf: 0, nan: 0 };
+  },
+});
+
+const prefetch = (params: { path: string; modal: boolean }) =>
+  (<TestSelectorFamily<typeof state.numericFilterPrefetch>>(
+    (<unknown>state.numericFilterPrefetch(params))
+  ))();
+
+describe("numericFilterPrefetch", () => {
+  beforeEach(() => {
+    nonfiniteDataCalls.length = 0;
+  });
+
+  it("prefetches the parent aggregation on a default range", () => {
+    setMockAtoms({ queryPerformance: false, hasDefaultRange: () => true });
+
+    prefetch({ path: "a.b", modal: false });
+
+    expect(nonfiniteDataCalls).toHaveLength(1);
+    expect(nonfiniteDataCalls[0]).toMatchObject({
+      path: "a.b",
+      modal: false,
+      extended: false,
+    });
+  });
+
+  it("does not prefetch once a range filter is applied (non-default range)", () => {
+    setMockAtoms({ queryPerformance: false, hasDefaultRange: () => false });
+
+    prefetch({ path: "a.b", modal: false });
+
+    expect(nonfiniteDataCalls).toHaveLength(0);
+  });
+
+  it("is a no-op under query performance (non-modal)", () => {
+    setMockAtoms({ queryPerformance: true, hasDefaultRange: () => true });
+
+    prefetch({ path: "a.b", modal: false });
+
+    expect(nonfiniteDataCalls).toHaveLength(0);
+  });
+
+  it("still prefetches in the modal even under query performance", () => {
+    // The query-performance no-op is gated on ``!modal``; the modal has no
+    // lightning prefetch, so the waterfall still needs collapsing there.
+    setMockAtoms({ queryPerformance: true, hasDefaultRange: () => true });
+
+    prefetch({ path: "a.b", modal: true });
+
+    expect(nonfiniteDataCalls).toHaveLength(1);
+  });
+});

--- a/app/packages/core/src/components/Filters/NumericFieldFilter/state.ts
+++ b/app/packages/core/src/components/Filters/NumericFieldFilter/state.ts
@@ -1,5 +1,10 @@
 import type { Nonfinite } from "@fiftyone/state";
-import { boundsAtom, nonfiniteData, rangeAtom } from "@fiftyone/state";
+import {
+  boundsAtom,
+  nonfiniteData,
+  queryPerformance,
+  rangeAtom,
+} from "@fiftyone/state";
 import { selectorFamily } from "recoil";
 
 export const FLOAT_NONFINITES: Nonfinite[] = ["inf", "ninf", "nan"];
@@ -18,11 +23,43 @@ export const hasBounds = selectorFamily({
 });
 
 export const hasDefaultRange = selectorFamily({
-  key: "hasBounds",
+  key: "hasDefaultRange",
   get:
     (params: { modal: boolean; path: string }) =>
     ({ get }) => {
       return Boolean(get(rangeAtom(params))?.every((r) => r === null));
+    },
+});
+
+export const numericFilterPrefetch = selectorFamily({
+  key: "numericFilterPrefetch",
+  get:
+    (params: { path: string; modal: boolean }) =>
+    ({ get }) => {
+      // Opening a numeric filter reads the field aggregation (via
+      // hasBounds, up in useShow/NumericFieldFilter) and, when
+      // unfiltered, the parent aggregation (via Nonfinites ->
+      // nonfiniteData, down in RangeSlider). Rendered top-down the tree
+      // suspends on the field first and only requests the parent once it
+      // resolves — a render waterfall that doubles latency when each
+      // aggregation is expensive (large datasets, cold caches, slower
+      // backends). Read at the top of NumericFieldFilter
+      // (before useShow), this issues both aggregations in one
+      // waitForAll so they load concurrently.
+      //
+      // No-op on the lightning path: under query performance the sidebar
+      // already prefetches the lightning data and useShow doesn't
+      // calculate bounds, so there's no waterfall to fix and we avoid
+      // perturbing that path. Gated on the default range to match when
+      // <Nonfinites> actually reads the parent (no extra fetch once a
+      // range filter is applied).
+      if (!params.modal && get(queryPerformance)) {
+        return null;
+      }
+      if (get(hasDefaultRange(params))) {
+        get(nonfiniteData({ ...params, extended: false }));
+      }
+      return null;
     },
 });
 

--- a/app/packages/state/src/recoil/pathData/counts.ts
+++ b/app/packages/state/src/recoil/pathData/counts.ts
@@ -1,5 +1,5 @@
 import { VALID_KEYPOINTS } from "@fiftyone/utilities";
-import { selectorFamily } from "recoil";
+import { selectorFamily, waitForAll } from "recoil";
 import { aggregation } from "../aggregations";
 import { datasetSampleCount } from "../dataset";
 import * as filterAtoms from "../filters";
@@ -208,12 +208,21 @@ export const noneCount = selectorFamily<
   get:
     (params) =>
     ({ get }) => {
-      const { count: aggCount = 0 } = get(aggregation(params)) ?? {};
+      // List fields and label-tags have no meaningful none bucket — bail
+      // before touching aggregations (and avoid an unused fetch).
+      const isLabelTag = params.path.startsWith("_label_tags");
+      if (isLabelTag || get(schemaAtoms.isListField(params.path))) {
+        return 0;
+      }
 
       const parent = params.path.split(".").slice(0, -1).join(".");
-      const isLabelTag = params.path.startsWith("_label_tags");
-      return get(schemaAtoms.isListField(params.path)) || isLabelTag
-        ? 0
-        : (get(count({ ...params, path: parent })) as number) - aggCount;
+      // Fetch the field aggregation and the parent count concurrently;
+      // sequential ``get``s waterfall (suspend on one, then fire the
+      // other), doubling latency when each aggregation is expensive
+      // (large datasets, cold caches, slower backends).
+      const [fieldAgg, parentCount] = get(
+        waitForAll([aggregation(params), count({ ...params, path: parent })]),
+      );
+      return (parentCount as number) - ((fieldAgg?.count as number) ?? 0);
     },
 });

--- a/app/packages/state/src/recoil/pathData/numeric.ts
+++ b/app/packages/state/src/recoil/pathData/numeric.ts
@@ -1,4 +1,4 @@
-import { selectorFamily } from "recoil";
+import { selectorFamily, waitForAll } from "recoil";
 import { aggregation } from "../aggregations";
 import { queryPerformance } from "../queryPerformance";
 import { count } from "./counts";
@@ -34,12 +34,20 @@ export const nonfiniteData = selectorFamily({
         return get(lightningNonfinites(params.path));
       }
 
-      const data = get(aggregation(params));
-      const { count: parentCount } = get(
-        aggregation({
-          ...params,
-          path: params.path.split(".").slice(0, -1).join("."),
-        }),
+      // Fetch the field's aggregation and its parent's concurrently:
+      // reading them with sequential ``get``s makes Recoil suspend on
+      // the first, then fire the second only after it resolves — a
+      // waterfall that doubles latency when each aggregation is
+      // expensive (large datasets, cold caches, slower backends).
+      // ``waitForAll`` puts both in flight at once.
+      const [data, { count: parentCount }] = get(
+        waitForAll([
+          aggregation(params),
+          aggregation({
+            ...params,
+            path: params.path.split(".").slice(0, -1).join("."),
+          }),
+        ]),
       );
 
       if (data.__typename === "IntAggregation") {


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link.

## 📋 What changes are proposed in this pull request?

Opening a sidebar filter fetched its aggregations serially, so the widget stayed on its loading state for the sum of two round-trips instead of the slower one. Two separate waterfalls caused this, and this PR fixes both.

**Within a selector.** `noneCount` (string filters) and `nonfiniteData` (numeric filters) each read a field aggregation and its parent aggregation. Reading them with sequential Recoil `get`s suspends on the first and only issues the second once it resolves. Each pair is now batched into a single `waitForAll` so they load concurrently. `noneCount` also short-circuits its list/label-tag guard before the `isListField` atom read, so those paths bail without touching aggregations at all.

**Across the component tree.** The numeric filter reads the field aggregation near the top of the tree (via `hasBounds` in `useShow`) and, when unfiltered, the parent aggregation further down (via `Nonfinites`). Rendered top-down, the tree suspends on the field first and only requests the parent once it resolves — a second waterfall stacked on the first. A new `numericFilterPrefetch` selector, read at the top of `NumericFieldFilter` before `useShow`, issues both in one `waitForAll`.

The prefetch is deliberately gated to request exactly what the tree was already going to request, just earlier: it is a no-op on the query-performance path (the sidebar already prefetches lightning data there and `useShow` doesn't calculate bounds), and it only prefetches the parent on a default range, matching when `Nonfinites` actually reads it.

Behavior is unchanged throughout — same selectors, same params, same resolved values. Only the fetch scheduling differs.

## 🧪 How is this patch tested? If it is not, please explain why.

New and updated unit tests, all passing (352 tests across 30 files in `packages/state` and `packages/core/src/components/Filters`):

- `NumericFieldFilter/state.test.ts` (new) pins the prefetch gating in both directions: prefetch on a default range, no prefetch once a range filter is applied, no-op under query performance when not in the modal, and still prefetching in the modal. Inverting or dropping either gate fails a test.
- `waitForAll` support added to the shared Recoil test mock. The mock represents selectors as plain functions and passed the real `waitForAll` through, which threw `Attempt to serialize function in a Recoil cache key` once these selectors started using it. It now resolves dependencies eagerly, preserving array/object shape. This fixes `pathData/counts.test.ts`, which the selector change would otherwise break.

The `waitForAll` changes are behavior-preserving (same values, concurrent instead of serial), so they are covered by the existing selector tests rather than new assertions.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

Sidebar filters now load their aggregations concurrently instead of serially, so expanding a string or numeric filter is noticeably faster the first time — most visibly on datasets where aggregations are expensive.

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3535
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance Improvements**
  - Improved numeric filter loading by prefetching needed bounds-related data earlier.
  - Reduced loading delays by fetching related aggregation and parent counts in parallel.
  - Avoided unnecessary prefetch/aggregation work for unsupported views (e.g., label-tags and non-default ranges).

- **Bug Fixes**
  - Corrected default-range detection for numeric filters.

- **Tests**
  - Added coverage to verify numeric filter prefetch behavior across default/non-default and modal/non-modal contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->