### PR TITLE
[FOEPD-4261] Don't use temporal tag color for filter label text

### DIFF
--- a/app/packages/core/src/components/Filters/StringFilter/Checkboxes.tsx
+++ b/app/packages/core/src/components/Filters/StringFilter/Checkboxes.tsx
@@ -206,7 +206,7 @@ const Checkboxes = ({
             key={value}
             color={resultColor ? resultColor(value) : color}
             value={selectedSet.has(value)}
-            forceColor={value === null || Boolean(resultColor)}
+            forceColor={value === null}
             name={value === null ? "None" : value}
             loading={loading}
             count={getCount(count, value)}


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

The temporal tags sidebar filter colors each checkbox dot with the tag's own
color via the `resultColor` prop on `StringFilter`/`Checkboxes`. That same
color was also being force-applied to the checkbox's label text, making the
label visually indistinguishable from its selection-state styling and
inconsistent with every other string filter in the sidebar, where label text
never takes on the field/value color.

This fixes `Checkboxes.tsx` so `forceColor` is only set for the `None` row
(as before `resultColor` existed), leaving the per-tag `resultColor` to affect
only the checkbox dot, not the label.

<img width="382" height="380" alt="screenshot-2026-07-27_10-01-15" src="https://github.com/user-attachments/assets/d9d790e0-35fc-4013-b9a8-5ec2a37a4b25" />


## 🧪 How is this patch tested? If it is not, please explain why.

Manually verified in the sidebar temporal tags filter that each tag's
checkbox dot still renders with its own color while the label text renders
in the default sidebar text color, matching other string filters.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checkbox color handling so custom result colors display correctly when a value is present.
  * Preserved forced coloring only for empty or null values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3536
<!-- enterprise-sync-pr:end -->