### PR TITLE
[FOEPD-4264] Batch cuboid rendering in Looker3d with InstancedMesh

### DIFF
--- a/app/packages/looker-3d/src/labels/CuboidInstances.tsx
+++ b/app/packages/looker-3d/src/labels/CuboidInstances.tsx
@@ -1,0 +1,749 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+import type { ThreeEvent } from "@react-three/fiber";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type RefObject,
+} from "react";
+import { useRecoilValue, useSetRecoilState } from "recoil";
+import * as THREE from "three";
+import { LineMaterial } from "three/examples/jsm/lines/LineMaterial";
+import { LineSegmentsGeometry } from "three/examples/jsm/lines/LineSegmentsGeometry";
+import type { ReconciledDetection3D } from "../annotation/types";
+import { PANEL_ID_MAIN } from "../constants";
+import { useFo3dContext } from "../fo3d/context";
+import { use3dLabelColor } from "../hooks/use-3d-label-color";
+import { useSimilarLabels3d } from "../hooks/use-similar-labels-3d";
+import { hoveredLabelAtom, selectedLabelForAnnotationAtom } from "../state";
+import type { HoveredLabelSource } from "../types";
+import { getComplementaryColor } from "../utils";
+import {
+  ORIENTATION_AXES_COLORS,
+  ORIENTATION_AXES_LENGTH_RATIO,
+  ORIENTATION_AXES_MIN_LENGTH,
+  getCuboidOrientationMarkerGeometry,
+  getFiniteMagnitude,
+} from "./shared/CuboidOrientationMarkers";
+import { useEventHandlers } from "./shared/hooks";
+import "./shared/registerLineElements";
+import { useDragGate } from "./shared/useDragGate";
+
+// Shared across every instance — each box's actual size/orientation is baked
+// into its own matrix (see `computeBodyMatrix`), so the geometry itself just
+// needs to be a unit cube.
+const UNIT_BOX_GEOMETRY = new THREE.BoxGeometry(1, 1, 1);
+
+// Canonical arrowhead triangle: apex at local +X, base corners at local ±Y,
+// unit half-width. Scaled per-instance by (headLength, headHalfWidth,
+// headHalfWidth); rotated 90° about local X when the box's arrowhead spreads
+// along Z instead of Y (see `computeArrowheadMatrix`).
+const UNIT_ARROWHEAD_GEOMETRY = new THREE.BufferGeometry();
+UNIT_ARROWHEAD_GEOMETRY.setAttribute(
+  "position",
+  new THREE.Float32BufferAttribute(
+    [
+      1, 0, 0, // apex
+      0, 1, 0, // base1
+      0, -1, 0, // base2
+    ],
+    3,
+  ),
+);
+const SPREAD_TO_Z_QUATERNION = new THREE.Quaternion().setFromAxisAngle(
+  new THREE.Vector3(1, 0, 0),
+  Math.PI / 2,
+);
+const IDENTITY_QUATERNION = new THREE.Quaternion();
+const UNIT_SCALE = new THREE.Vector3(1, 1, 1);
+const ZERO_SCALE_MATRIX = new THREE.Matrix4().makeScale(0, 0, 0);
+
+const EDGES_PER_BOX = 12;
+const SHAFT_SEGMENTS_PER_BOX = 1;
+const AXES_SEGMENTS_PER_BOX = 3;
+
+interface CuboidGeometry {
+  position: THREE.Vector3Tuple;
+  dimensions: THREE.Vector3Tuple;
+  quaternion: THREE.Quaternion;
+}
+
+/**
+ * Resolves a non-edited label's display geometry directly from its own
+ * (already-reconciled) fields — `detectionsToRender` labels are the working
+ * store's current values, so there's no separate "effective" lookup needed
+ * the way `useCuboidAnnotation` does for the one actively-edited box. This
+ * intentionally skips transient-drag handling: a box being dragged is always
+ * popped out to the standalone path (see `ThreeDLabels`), never present here.
+ *
+ * `overlayRotationFallback` mirrors `ThreeDLabels`' `cuboidOverlays` prop
+ * assembly: a label missing its own `rotation` field there ends up with the
+ * scene-level `overlayRotation` as its effective rotation (the JSX prop
+ * spread order means `overlay.rotation`, when present, overrides the
+ * `rotation={overlayRotation}` prop — but nothing overrides it when absent).
+ */
+function resolveCuboidGeometry(
+  label: ReconciledDetection3D,
+  useLegacyCoordinates: boolean,
+  overlayRotationFallback: THREE.Vector3Tuple,
+): CuboidGeometry {
+  const dimensions = label.dimensions;
+  const [x, rawY, z] = label.location;
+  // See `useDisplayCuboidTransform` for why legacy-coordinate labels need a
+  // half-height offset here.
+  const y = useLegacyCoordinates ? rawY - 0.5 * dimensions[1] : rawY;
+
+  const quaternion = label.quaternion
+    ? new THREE.Quaternion(...label.quaternion)
+    : new THREE.Quaternion().setFromEuler(
+        new THREE.Euler(...(label.rotation ?? overlayRotationFallback)),
+      );
+
+  return { position: [x, y, z], dimensions, quaternion };
+}
+
+function computeBodyMatrix(geometry: CuboidGeometry): THREE.Matrix4 {
+  return new THREE.Matrix4().compose(
+    new THREE.Vector3(...geometry.position),
+    geometry.quaternion,
+    new THREE.Vector3(...geometry.dimensions),
+  );
+}
+
+/**
+ * World-space edge endpoints for one box's outline, in the flat pairs format
+ * `LineSegmentsGeometry.setPositions()` expects (each consecutive 2 vertices
+ * = one edge). `EdgesGeometry` already emits exactly this shape.
+ */
+function computeBoxEdgePositions(geometry: CuboidGeometry): Float32Array {
+  const box = new THREE.BoxGeometry(...geometry.dimensions);
+  box.applyQuaternion(geometry.quaternion);
+  box.translate(...geometry.position);
+  const edges = new THREE.EdgesGeometry(box);
+  const positions = new Float32Array(
+    edges.attributes.position.array as Float32Array,
+  );
+  box.dispose();
+  edges.dispose();
+  return positions;
+}
+
+const _localPoint = new THREE.Vector3();
+const _worldOffset = new THREE.Vector3();
+
+function localToWorld(
+  local: THREE.Vector3Tuple | THREE.Vector3,
+  geometry: CuboidGeometry,
+): THREE.Vector3Tuple {
+  if (local instanceof THREE.Vector3) {
+    _localPoint.copy(local);
+  } else {
+    _localPoint.set(local[0], local[1], local[2]);
+  }
+  _worldOffset.set(...geometry.position);
+  _localPoint.applyQuaternion(geometry.quaternion).add(_worldOffset);
+  return [_localPoint.x, _localPoint.y, _localPoint.z];
+}
+
+/**
+ * Per-instance affine matrix for the merged arrowhead `InstancedMesh` (see
+ * `UNIT_ARROWHEAD_GEOMETRY`), derived from the same decomposed geometry the
+ * standalone `CuboidOrientationMarker` uses (`getCuboidOrientationMarkerGeometry`).
+ */
+function computeArrowheadMatrix(
+  geometry: CuboidGeometry,
+  upVector: THREE.Vector3 | null,
+): THREE.Matrix4 {
+  const markerGeometry = getCuboidOrientationMarkerGeometry(
+    geometry.dimensions,
+    geometry.quaternion,
+    upVector,
+  );
+  if (!markerGeometry) {
+    return ZERO_SCALE_MATRIX.clone();
+  }
+
+  const { anchor, headLength, headHalfWidth, spreadAlongZ } = markerGeometry;
+  const localMatrix = new THREE.Matrix4().compose(
+    anchor,
+    spreadAlongZ ? SPREAD_TO_Z_QUATERNION : IDENTITY_QUATERNION,
+    new THREE.Vector3(headLength, headHalfWidth, headHalfWidth),
+  );
+  const boxMatrix = new THREE.Matrix4().compose(
+    new THREE.Vector3(...geometry.position),
+    geometry.quaternion,
+    UNIT_SCALE,
+  );
+  return boxMatrix.multiply(localMatrix);
+}
+
+function segmentsPerBoxFor(showOrientation: boolean): number {
+  return (
+    EDGES_PER_BOX +
+    (showOrientation ? SHAFT_SEGMENTS_PER_BOX + AXES_SEGMENTS_PER_BOX : 0)
+  );
+}
+
+const setSegmentColor = (
+  geometry: LineSegmentsGeometry,
+  segmentIndex: number,
+  color: THREE.Color,
+) => {
+  const start = geometry.attributes.instanceColorStart as
+    | THREE.InterleavedBufferAttribute
+    | undefined;
+  const end = geometry.attributes.instanceColorEnd as
+    | THREE.InterleavedBufferAttribute
+    | undefined;
+  start?.setXYZ(segmentIndex, color.r, color.g, color.b);
+  end?.setXYZ(segmentIndex, color.r, color.g, color.b);
+};
+
+export interface CuboidInstancesProps {
+  detections: readonly ReconciledDetection3D[];
+  /** Base per-label color (color-by mode already resolved upstream), before hover/selection layering. */
+  getColor: (label: ReconciledDetection3D) => string;
+  /** Shared opacity for every box in the batch (see plan §6 — at most one value is ever live for the whole non-focused batch). */
+  opacity: number;
+  lineWidth: number;
+  useLegacyCoordinates: boolean;
+  /** Euler fallback for a label with no `rotation` of its own (see `resolveCuboidGeometry`). */
+  overlayRotationFallback: THREE.Vector3Tuple;
+  hoverSource?: HoveredLabelSource;
+  showOrientation?: boolean;
+  onClick: (label: ReconciledDetection3D, e: ThreeEvent<MouseEvent>) => void;
+}
+
+/**
+ * Batches every non-edited cuboid label into a handful of draw calls instead
+ * of one full component tree per label (see the looker3dInstanceMesh plan):
+ * one `InstancedMesh` for bodies (also the clickable/hoverable volume), one
+ * merged `LineSegmentsGeometry` for outlines (+ shaft/axes segments when
+ * `showOrientation`), and one `InstancedMesh` for orientation arrowheads.
+ *
+ * Geometry only rebuilds on membership change (select/deselect/create/delete
+ * are rare); color updates react per-label via headless "shadow" components
+ * (`CuboidColorSync`) that write directly into the shared color buffers.
+ */
+export const CuboidInstances = ({
+  detections,
+  getColor,
+  opacity,
+  lineWidth,
+  useLegacyCoordinates,
+  overlayRotationFallback,
+  hoverSource = PANEL_ID_MAIN,
+  showOrientation = false,
+  onClick,
+}: CuboidInstancesProps) => {
+  const { upVector } = useFo3dContext();
+  const setHoveredLabel = useSetRecoilState(hoveredLabelAtom);
+
+  const bodyMeshRef = useRef<THREE.InstancedMesh>(null);
+  const arrowMeshRef = useRef<THREE.InstancedMesh>(null);
+  // The outline geometry is rebuilt (new object) on membership change, so it
+  // lives in state — a ref wouldn't trigger the JSX to pick up the new
+  // object. `previousOutlineGeometryRef` tracks the outgoing geometry so it
+  // can be disposed once the new one is committed.
+  const [outlineGeometry, setOutlineGeometry] =
+    useState<LineSegmentsGeometry | null>(null);
+  const previousOutlineGeometryRef = useRef<LineSegmentsGeometry | null>(null);
+
+  // Deliberately no `vertexColors: true` here: these geometries (a plain
+  // unit box / triangle) have no geometry `color` attribute, and setting
+  // `material.vertexColors` forces the vertex shader to also read that
+  // (missing) attribute, which defaults to (0,0,0) and zeroes the instance
+  // color out to black. `instanceColor` alone (once assigned below) already
+  // makes three.js define `USE_INSTANCING_COLOR` / `USE_COLOR` correctly —
+  // see WebGLProgram.js's `instancingColor` handling.
+  const bodyMaterial = useMemo(
+    () =>
+      new THREE.MeshBasicMaterial({
+        transparent: true,
+        opacity,
+      }),
+    [opacity],
+  );
+  const arrowMaterial = useMemo(
+    () =>
+      new THREE.MeshBasicMaterial({
+        transparent: true,
+        opacity,
+        side: THREE.DoubleSide,
+        depthTest: false,
+        depthWrite: false,
+      }),
+    [opacity],
+  );
+  const outlineMaterial = useMemo(
+    () =>
+      new LineMaterial({
+        vertexColors: true,
+        transparent: true,
+        opacity,
+        linewidth: lineWidth,
+      }),
+    [opacity, lineWidth],
+  );
+
+  useEffect(() => {
+    return () => {
+      bodyMaterial.dispose();
+      arrowMaterial.dispose();
+      outlineMaterial.dispose();
+    };
+  }, [bodyMaterial, arrowMaterial, outlineMaterial]);
+
+  // Stable index maps, rebuilt only when the *set* of labels changes (not on
+  // every parent re-render, which produces a new array reference regardless
+  // of content) — the actively-edited label is always excluded from this
+  // array upstream (see `ThreeDLabels`), so membership changes are rare,
+  // user-driven events (select/deselect/create/delete).
+  const membershipKey = useMemo(
+    () => detections.map((label) => label._id).join("|"),
+    [detections],
+  );
+
+  const labelsByIndex = useMemo(
+    () => detections,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [membershipKey],
+  );
+
+  const count = labelsByIndex.length;
+  const segmentsPerBox = segmentsPerBoxFor(showOrientation);
+
+  // Rebuild every buffer when membership or batch-level rendering settings
+  // change. Per-label *color* changes (hover/select/similar/color-by-mode)
+  // are handled reactively by `CuboidColorSync` below instead of here — this
+  // effect only needs to re-run for structural changes.
+  useLayoutEffect(() => {
+    if (count === 0) {
+      setOutlineGeometry(null);
+      return;
+    }
+
+    const geometries = labelsByIndex.map((label) =>
+      resolveCuboidGeometry(label, useLegacyCoordinates, overlayRotationFallback),
+    );
+
+    // Bodies
+    const bodyMesh = bodyMeshRef.current;
+    if (bodyMesh) {
+      const bodyColors = new Float32Array(count * 3);
+      const bodyColorAttribute = new THREE.InstancedBufferAttribute(
+        bodyColors,
+        3,
+      );
+      geometries.forEach((geometry, i) => {
+        bodyMesh.setMatrixAt(i, computeBodyMatrix(geometry));
+        const color = new THREE.Color(getColor(labelsByIndex[i]));
+        bodyColorAttribute.setXYZ(i, color.r, color.g, color.b);
+      });
+      bodyMesh.instanceMatrix.needsUpdate = true;
+      bodyMesh.instanceColor = bodyColorAttribute;
+      bodyMesh.computeBoundingSphere();
+    }
+
+    // Outline (+ shaft/axes segments when showOrientation)
+    const positions = new Float32Array(count * segmentsPerBox * 6);
+    const colors = new Float32Array(count * segmentsPerBox * 6);
+
+    const arrowMatrices: THREE.Matrix4[] = [];
+
+    geometries.forEach((geometry, i) => {
+      const segBase = i * segmentsPerBox;
+      const floatBase = segBase * 6;
+      positions.set(computeBoxEdgePositions(geometry), floatBase);
+
+      const baseColor = new THREE.Color(getColor(labelsByIndex[i]));
+      for (let s = 0; s < EDGES_PER_BOX; s++) {
+        const o = floatBase + s * 6;
+        colors.set(
+          [baseColor.r, baseColor.g, baseColor.b, baseColor.r, baseColor.g, baseColor.b],
+          o,
+        );
+      }
+
+      if (!showOrientation) {
+        arrowMatrices.push(ZERO_SCALE_MATRIX);
+        return;
+      }
+
+      const markerGeometry = getCuboidOrientationMarkerGeometry(
+        geometry.dimensions,
+        geometry.quaternion,
+        upVector,
+      );
+      const complementaryColor = new THREE.Color(
+        getComplementaryColor(getColor(labelsByIndex[i])),
+      );
+
+      const shaftFloatBase = floatBase + EDGES_PER_BOX * 6;
+      if (markerGeometry) {
+        const shaftStartWorld = localToWorld(
+          markerGeometry.shaftStart,
+          geometry,
+        );
+        const shaftEndWorld = localToWorld(markerGeometry.anchor, geometry);
+        positions.set([...shaftStartWorld, ...shaftEndWorld], shaftFloatBase);
+      }
+      colors.set(
+        [
+          complementaryColor.r,
+          complementaryColor.g,
+          complementaryColor.b,
+          complementaryColor.r,
+          complementaryColor.g,
+          complementaryColor.b,
+        ],
+        shaftFloatBase,
+      );
+
+      arrowMatrices.push(
+        markerGeometry
+          ? computeArrowheadMatrix(geometry, upVector)
+          : ZERO_SCALE_MATRIX,
+      );
+
+      const axesFloatBase = shaftFloatBase + SHAFT_SEGMENTS_PER_BOX * 6;
+      const halfExtent = (axis: 0 | 1 | 2) =>
+        Math.max(
+          (getFiniteMagnitude(geometry.dimensions[axis]) / 2) *
+            ORIENTATION_AXES_LENGTH_RATIO,
+          ORIENTATION_AXES_MIN_LENGTH,
+        );
+      const axesLocalEnds: THREE.Vector3Tuple[] = [
+        [halfExtent(0), 0, 0],
+        [0, halfExtent(1), 0],
+        [0, 0, halfExtent(2)],
+      ];
+      const axesColors = [
+        ORIENTATION_AXES_COLORS.x,
+        ORIENTATION_AXES_COLORS.y,
+        ORIENTATION_AXES_COLORS.z,
+      ];
+      const originWorld = localToWorld([0, 0, 0], geometry);
+      axesLocalEnds.forEach((localEnd, axis) => {
+        const endWorld = localToWorld(localEnd, geometry);
+        const o = axesFloatBase + axis * 6;
+        positions.set([...originWorld, ...endWorld], o);
+        const axisColor = new THREE.Color(axesColors[axis]);
+        colors.set(
+          [
+            axisColor.r,
+            axisColor.g,
+            axisColor.b,
+            axisColor.r,
+            axisColor.g,
+            axisColor.b,
+          ],
+          o,
+        );
+      });
+    });
+
+    const nextOutlineGeometry = new LineSegmentsGeometry();
+    nextOutlineGeometry.setPositions(positions);
+    nextOutlineGeometry.setColors(colors);
+    previousOutlineGeometryRef.current?.dispose();
+    previousOutlineGeometryRef.current = nextOutlineGeometry;
+    setOutlineGeometry(nextOutlineGeometry);
+
+    // Arrowheads
+    const arrowMesh = arrowMeshRef.current;
+    if (arrowMesh && showOrientation) {
+      const arrowColors = new Float32Array(count * 3);
+      const arrowColorAttribute = new THREE.InstancedBufferAttribute(
+        arrowColors,
+        3,
+      );
+      arrowMatrices.forEach((matrix, i) => {
+        arrowMesh.setMatrixAt(i, matrix);
+        const complementaryColor = new THREE.Color(
+          getComplementaryColor(getColor(labelsByIndex[i])),
+        );
+        arrowColorAttribute.setXYZ(
+          i,
+          complementaryColor.r,
+          complementaryColor.g,
+          complementaryColor.b,
+        );
+      });
+      arrowMesh.instanceMatrix.needsUpdate = true;
+      arrowMesh.instanceColor = arrowColorAttribute;
+      arrowMesh.computeBoundingSphere();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    membershipKey,
+    count,
+    segmentsPerBox,
+    useLegacyCoordinates,
+    overlayRotationFallback,
+    showOrientation,
+    upVector,
+  ]);
+
+  // Dispose the last-built outline geometry on unmount.
+  useEffect(() => {
+    return () => {
+      previousOutlineGeometryRef.current?.dispose();
+    };
+  }, []);
+
+  const {
+    onPointerOver: onPointerOverForLabel,
+    onPointerOut: onPointerOutForLabel,
+    onPointerMove: onPointerMoveForLabel,
+  } = useEventHandlers();
+
+  const {
+    onPointerDown,
+    onPointerMove: onDragGatePointerMove,
+    onPointerUp,
+    isClick,
+  } = useDragGate();
+
+  const resolveLabel = useCallback(
+    (instanceId: number | undefined) =>
+      instanceId === undefined ? null : (labelsByIndex[instanceId] ?? null),
+    [labelsByIndex],
+  );
+
+  // r3f doesn't guarantee `instanceId` on an InstancedMesh's pointer-out
+  // event, so track which instance is currently hovered ourselves and
+  // resolve the outgoing label from that on pointer-out.
+  const hoveredIndexRef = useRef<number | null>(null);
+
+  const handlePointerOver = useCallback(
+    (e: ThreeEvent<PointerEvent>) => {
+      // eslint-disable-next-line no-console
+      console.log("[CuboidInstances DEBUG] pointerOver", {
+        instanceId: e.instanceId,
+        buttons: e.nativeEvent.buttons,
+        hoverSource,
+        labelsByIndexLength: labelsByIndex.length,
+      });
+      if (hoverSource === PANEL_ID_MAIN && e.nativeEvent.buttons !== 0) return;
+      const label = resolveLabel(e.instanceId);
+      if (!label) {
+        // eslint-disable-next-line no-console
+        console.log("[CuboidInstances DEBUG] pointerOver: no label resolved");
+        return;
+      }
+
+      hoveredIndexRef.current = e.instanceId ?? null;
+      setHoveredLabel({ id: label._id, source: hoverSource });
+      onPointerOverForLabel(label, e);
+    },
+    [resolveLabel, hoverSource, setHoveredLabel, onPointerOverForLabel, labelsByIndex],
+  );
+
+  const handlePointerOut = useCallback(() => {
+    const label =
+      hoveredIndexRef.current !== null
+        ? (labelsByIndex[hoveredIndexRef.current] ?? null)
+        : null;
+    hoveredIndexRef.current = null;
+
+    setHoveredLabel(null);
+    if (label) {
+      onPointerOutForLabel(label);
+    }
+  }, [labelsByIndex, setHoveredLabel, onPointerOutForLabel]);
+
+  // Runs both the drag-vs-click threshold tracking (`useDragGate`) and the
+  // tooltip-position tracking (`useMeshTooltipProps`'s onPointerMove, which
+  // publishes `fos.tooltipCoordinates`) — the standalone `Cuboid` path gets
+  // both from separate elements (the drag-gate wrapper vs. the mesh's own
+  // handler); the instanced batch needs both on this one mesh.
+  const handlePointerMove = useCallback(
+    (e: ThreeEvent<PointerEvent>) => {
+      onDragGatePointerMove(e);
+      const label = resolveLabel(e.instanceId);
+      if (label) {
+        onPointerMoveForLabel(label, e);
+      }
+    },
+    [onDragGatePointerMove, resolveLabel, onPointerMoveForLabel],
+  );
+
+  const handleClick = useCallback(
+    (e: ThreeEvent<MouseEvent>) => {
+      // eslint-disable-next-line no-console
+      console.log("[CuboidInstances DEBUG] click", {
+        instanceId: e.instanceId,
+        isClick: isClick(),
+      });
+      if (!isClick()) {
+        e.stopPropagation();
+        return;
+      }
+      const label = resolveLabel(e.instanceId);
+      if (!label) {
+        // eslint-disable-next-line no-console
+        console.log("[CuboidInstances DEBUG] click: no label resolved");
+        return;
+      }
+      onClick(label, e);
+    },
+    [isClick, resolveLabel, onClick],
+  );
+
+  if (count === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <instancedMesh
+        ref={bodyMeshRef}
+        args={[UNIT_BOX_GEOMETRY, bodyMaterial, count]}
+        onPointerDown={onPointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={onPointerUp}
+        onPointerOver={handlePointerOver}
+        onPointerOut={handlePointerOut}
+        onClick={handleClick}
+      />
+      {outlineGeometry && (
+        // @ts-ignore — registered via ./shared/registerLineElements
+        <lineSegments2
+          geometry={outlineGeometry}
+          material={outlineMaterial}
+          raycast={() => null}
+        />
+      )}
+      {showOrientation && (
+        <instancedMesh
+          ref={arrowMeshRef}
+          args={[UNIT_ARROWHEAD_GEOMETRY, arrowMaterial, count]}
+          raycast={() => null}
+        />
+      )}
+      {outlineGeometry &&
+        labelsByIndex.map((label, index) => (
+          <CuboidColorSync
+            key={label._id}
+            label={label}
+            index={index}
+            baseColor={getColor(label)}
+            bodyMeshRef={bodyMeshRef}
+            arrowMeshRef={arrowMeshRef}
+            outlineGeometry={outlineGeometry}
+            segmentsPerBox={segmentsPerBox}
+            showOrientation={showOrientation}
+          />
+        ))}
+    </>
+  );
+};
+
+interface CuboidColorSyncProps {
+  label: ReconciledDetection3D;
+  index: number;
+  baseColor: string;
+  bodyMeshRef: RefObject<THREE.InstancedMesh>;
+  arrowMeshRef: RefObject<THREE.InstancedMesh>;
+  outlineGeometry: LineSegmentsGeometry;
+  segmentsPerBox: number;
+  showOrientation: boolean;
+}
+
+/**
+ * Headless per-label component (no scene-graph output) that subscribes to
+ * the exact same color-resolution hooks the standalone `Cuboid` uses
+ * (`use3dLabelColor`, `hoveredLabelAtom`, `useSimilarLabels3d`) and, on
+ * change, writes directly into this label's fixed slot in the shared color
+ * buffers — O(k) updates on hover/selection changes instead of a full
+ * buffer rebuild (plan §5).
+ */
+const CuboidColorSync = ({
+  label,
+  index,
+  baseColor,
+  bodyMeshRef,
+  arrowMeshRef,
+  outlineGeometry,
+  segmentsPerBox,
+  showOrientation,
+}: CuboidColorSyncProps) => {
+  const hoveredLabel = useRecoilValue(hoveredLabelAtom);
+  const isHovered = hoveredLabel?.id === label._id;
+  const isSimilarLabelHovered = useSimilarLabels3d(label);
+  const isSelectedForAnnotation =
+    useRecoilValue(selectedLabelForAnnotationAtom)?._id === label._id;
+  // ReconciledDetection3D's index signature types `selected` as `unknown`
+  // (see the same narrowing in ThreeDLabels' cuboidOverlays memo).
+  const selected = Boolean((label as { selected?: boolean }).selected);
+
+  const strokeAndFillColor = use3dLabelColor({
+    isSelected: selected,
+    isHovered,
+    isSimilarLabelHovered,
+    defaultColor: baseColor,
+    isSelectedForAnnotation,
+  });
+
+  useLayoutEffect(() => {
+    const color = new THREE.Color(strokeAndFillColor);
+
+    const bodyMesh = bodyMeshRef.current;
+    if (bodyMesh?.instanceColor) {
+      bodyMesh.instanceColor.setXYZ(index, color.r, color.g, color.b);
+      bodyMesh.instanceColor.needsUpdate = true;
+    }
+
+    const segBase = index * segmentsPerBox;
+    for (let s = 0; s < EDGES_PER_BOX; s++) {
+      setSegmentColor(outlineGeometry, segBase + s, color);
+    }
+
+    if (showOrientation) {
+      const complementaryColor = new THREE.Color(
+        getComplementaryColor(strokeAndFillColor),
+      );
+      setSegmentColor(
+        outlineGeometry,
+        segBase + EDGES_PER_BOX,
+        complementaryColor,
+      );
+
+      const arrowMesh = arrowMeshRef.current;
+      if (arrowMesh?.instanceColor) {
+        arrowMesh.instanceColor.setXYZ(
+          index,
+          complementaryColor.r,
+          complementaryColor.g,
+          complementaryColor.b,
+        );
+        arrowMesh.instanceColor.needsUpdate = true;
+      }
+    }
+
+    const start = outlineGeometry.attributes.instanceColorStart as
+      | THREE.InterleavedBufferAttribute
+      | undefined;
+    const end = outlineGeometry.attributes.instanceColorEnd as
+      | THREE.InterleavedBufferAttribute
+      | undefined;
+    if (start) start.data.needsUpdate = true;
+    if (end) end.data.needsUpdate = true;
+  }, [
+    strokeAndFillColor,
+    index,
+    bodyMeshRef,
+    arrowMeshRef,
+    outlineGeometry,
+    segmentsPerBox,
+    showOrientation,
+  ]);
+
+  return null;
+};

--- a/app/packages/looker-3d/src/labels/CuboidInstances.tsx
+++ b/app/packages/looker-3d/src/labels/CuboidInstances.tsx
@@ -242,6 +242,7 @@ export const CuboidInstances = ({
   onClick,
 }: CuboidInstancesProps) => {
   const { upVector } = useFo3dContext();
+  const hoveredLabel = useRecoilValue(hoveredLabelAtom);
   const setHoveredLabel = useSetRecoilState(hoveredLabelAtom);
 
   const bodyMeshRef = useRef<THREE.InstancedMesh>(null);
@@ -523,26 +524,15 @@ export const CuboidInstances = ({
 
   const handlePointerOver = useCallback(
     (e: ThreeEvent<PointerEvent>) => {
-      // eslint-disable-next-line no-console
-      console.log("[CuboidInstances DEBUG] pointerOver", {
-        instanceId: e.instanceId,
-        buttons: e.nativeEvent.buttons,
-        hoverSource,
-        labelsByIndexLength: labelsByIndex.length,
-      });
       if (hoverSource === PANEL_ID_MAIN && e.nativeEvent.buttons !== 0) return;
       const label = resolveLabel(e.instanceId);
-      if (!label) {
-        // eslint-disable-next-line no-console
-        console.log("[CuboidInstances DEBUG] pointerOver: no label resolved");
-        return;
-      }
+      if (!label) return;
 
       hoveredIndexRef.current = e.instanceId ?? null;
       setHoveredLabel({ id: label._id, source: hoverSource });
       onPointerOverForLabel(label, e);
     },
-    [resolveLabel, hoverSource, setHoveredLabel, onPointerOverForLabel, labelsByIndex],
+    [resolveLabel, hoverSource, setHoveredLabel, onPointerOverForLabel],
   );
 
   const handlePointerOut = useCallback(() => {
@@ -576,21 +566,12 @@ export const CuboidInstances = ({
 
   const handleClick = useCallback(
     (e: ThreeEvent<MouseEvent>) => {
-      // eslint-disable-next-line no-console
-      console.log("[CuboidInstances DEBUG] click", {
-        instanceId: e.instanceId,
-        isClick: isClick(),
-      });
       if (!isClick()) {
         e.stopPropagation();
         return;
       }
       const label = resolveLabel(e.instanceId);
-      if (!label) {
-        // eslint-disable-next-line no-console
-        console.log("[CuboidInstances DEBUG] click: no label resolved");
-        return;
-      }
+      if (!label) return;
       onClick(label, e);
     },
     [isClick, resolveLabel, onClick],
@@ -600,11 +581,20 @@ export const CuboidInstances = ({
     return null;
   }
 
+  // At most one instanced label is ever hovered at a time, so the hover
+  // wireframe (matching the standalone Cuboid's `shouldShowWireframe`
+  // overlay) doesn't need instancing — just one conditionally-mounted mesh
+  // for whichever label currently matches `hoveredLabelAtom`.
+  const hoveredBatchLabel = hoveredLabel
+    ? (labelsByIndex.find((label) => label._id === hoveredLabel.id) ?? null)
+    : null;
+
   return (
     <>
       <instancedMesh
         ref={bodyMeshRef}
         args={[UNIT_BOX_GEOMETRY, bodyMaterial, count]}
+        renderOrder={0}
         onPointerDown={onPointerDown}
         onPointerMove={handlePointerMove}
         onPointerUp={onPointerUp}
@@ -617,6 +607,14 @@ export const CuboidInstances = ({
         <lineSegments2
           geometry={outlineGeometry}
           material={outlineMaterial}
+          // Both this and the body mesh sit at the same local origin (all
+          // real per-box placement lives in instance matrices / the merged
+          // buffer, not the object's own transform), so three.js's
+          // transparency depth-sort sees them as equidistant and falls back
+          // to unreliable tie-breaking. Force a deterministic order instead:
+          // draw the outline after the body so it always wins the depth
+          // test at their coincident surface and stays visible.
+          renderOrder={1}
           raycast={() => null}
         />
       )}
@@ -641,7 +639,68 @@ export const CuboidInstances = ({
             showOrientation={showOrientation}
           />
         ))}
+      {hoveredBatchLabel && (
+        <CuboidHoverWireframe
+          label={hoveredBatchLabel}
+          baseColor={getColor(hoveredBatchLabel)}
+          useLegacyCoordinates={useLegacyCoordinates}
+          overlayRotationFallback={overlayRotationFallback}
+        />
+      )}
     </>
+  );
+};
+
+interface CuboidHoverWireframeProps {
+  label: ReconciledDetection3D;
+  baseColor: string;
+  useLegacyCoordinates: boolean;
+  overlayRotationFallback: THREE.Vector3Tuple;
+}
+
+/**
+ * Mirrors the standalone `Cuboid`'s `shouldShowWireframe` overlay — a plain
+ * `BoxGeometry` rendered `wireframe`, whose default 2-triangle-per-face
+ * triangulation is what produces the diagonal line across each face. Only
+ * ever mounted for the single (if any) hovered label in this batch.
+ */
+const CuboidHoverWireframe = ({
+  label,
+  baseColor,
+  useLegacyCoordinates,
+  overlayRotationFallback,
+}: CuboidHoverWireframeProps) => {
+  const isSimilarLabelHovered = useSimilarLabels3d(label);
+  const selected = Boolean((label as { selected?: boolean }).selected);
+
+  const strokeAndFillColor = use3dLabelColor({
+    isSelected: selected,
+    isHovered: true,
+    isSimilarLabelHovered,
+    defaultColor: baseColor,
+    isSelectedForAnnotation: false,
+  });
+  const complementaryColor = useMemo(
+    () => getComplementaryColor(strokeAndFillColor),
+    [strokeAndFillColor],
+  );
+
+  const geometry = useMemo(
+    () =>
+      resolveCuboidGeometry(label, useLegacyCoordinates, overlayRotationFallback),
+    [label, useLegacyCoordinates, overlayRotationFallback],
+  );
+
+  return (
+    <mesh
+      position={geometry.position}
+      quaternion={geometry.quaternion}
+      renderOrder={2}
+      raycast={() => null}
+    >
+      <boxGeometry args={geometry.dimensions} />
+      <meshBasicMaterial wireframe color={complementaryColor} />
+    </mesh>
   );
 };
 

--- a/app/packages/looker-3d/src/labels/CuboidInstances.tsx
+++ b/app/packages/looker-3d/src/labels/CuboidInstances.tsx
@@ -11,7 +11,6 @@ import {
   useState,
   type RefObject,
 } from "react";
-import { useRecoilValue, useSetRecoilState } from "recoil";
 import * as THREE from "three";
 import { LineMaterial } from "three/examples/jsm/lines/LineMaterial";
 import { LineSegmentsGeometry } from "three/examples/jsm/lines/LineSegmentsGeometry";
@@ -20,7 +19,11 @@ import { PANEL_ID_MAIN } from "../constants";
 import { useFo3dContext } from "../fo3d/context";
 import { use3dLabelColor } from "../hooks/use-3d-label-color";
 import { useSimilarLabels3d } from "../hooks/use-similar-labels-3d";
-import { hoveredLabelAtom, selectedLabelForAnnotationAtom } from "../state";
+import {
+  useCurrentSelected3dAnnotationLabel,
+  useHoveredLabel3d,
+  useSetHoveredLabel3d,
+} from "../state";
 import type { HoveredLabelSource } from "../types";
 import { getComplementaryColor } from "../utils";
 import {
@@ -33,8 +36,8 @@ import {
   computeBodyMatrix,
   computeBoxEdgePositions,
   localToWorld,
+  orientationSegmentsPerBoxFor,
   resolveCuboidGeometry,
-  segmentsPerBoxFor,
   setSegmentColor,
 } from "./cuboid-instance-geometry";
 import {
@@ -86,18 +89,26 @@ export const CuboidInstances = ({
   onClick,
 }: CuboidInstancesProps) => {
   const { upVector } = useFo3dContext();
-  const hoveredLabel = useRecoilValue(hoveredLabelAtom);
-  const setHoveredLabel = useSetRecoilState(hoveredLabelAtom);
+  const hoveredLabel = useHoveredLabel3d();
+  const setHoveredLabel = useSetHoveredLabel3d();
 
   const bodyMeshRef = useRef<THREE.InstancedMesh>(null);
   const arrowMeshRef = useRef<THREE.InstancedMesh>(null);
-  // The outline geometry is rebuilt (new object) on membership change, so it
-  // lives in state — a ref wouldn't trigger the JSX to pick up the new
-  // object. `previousOutlineGeometryRef` tracks the outgoing geometry so it
-  // can be disposed once the new one is committed.
+  // Both geometries are rebuilt (new object) on membership change, so they
+  // live in state — a ref wouldn't trigger the JSX to pick up the new
+  // object. The `previous*Ref`s track the outgoing geometry so it can be
+  // disposed once the new one is committed.
   const [outlineGeometry, setOutlineGeometry] =
     useState<LineSegmentsGeometry | null>(null);
   const previousOutlineGeometryRef = useRef<LineSegmentsGeometry | null>(null);
+  // Orientation markers (shaft + axes) live in their own merged geometry,
+  // separate from the edge outline above: they need `depthTest: false` (see
+  // `orientationMaterial` below), which would be wrong for edges.
+  const [orientationGeometry, setOrientationGeometry] =
+    useState<LineSegmentsGeometry | null>(null);
+  const previousOrientationGeometryRef = useRef<LineSegmentsGeometry | null>(
+    null,
+  );
 
   // Deliberately no `vertexColors: true` here: these geometries (a plain
   // unit box / triangle) have no geometry `color` attribute, and setting
@@ -135,14 +146,31 @@ export const CuboidInstances = ({
       }),
     [opacity, lineWidth],
   );
+  // Mirrors the standalone `CuboidOrientationMarkers`' `depthTest={false}`
+  // Lines: the shaft + axes run from the box's *center* outward but only to
+  // `ORIENTATION_AXES_LENGTH_RATIO` (< 1) of the half-dimension, so they
+  // never reach the surface — with normal depth testing they'd always be
+  // buried behind the box's own opaque front face and never render.
+  const orientationMaterial = useMemo(
+    () =>
+      new LineMaterial({
+        vertexColors: true,
+        transparent: true,
+        opacity,
+        linewidth: lineWidth,
+        depthTest: false,
+      }),
+    [opacity, lineWidth],
+  );
 
   useEffect(() => {
     return () => {
       bodyMaterial.dispose();
       arrowMaterial.dispose();
       outlineMaterial.dispose();
+      orientationMaterial.dispose();
     };
-  }, [bodyMaterial, arrowMaterial, outlineMaterial]);
+  }, [bodyMaterial, arrowMaterial, outlineMaterial, orientationMaterial]);
 
   // Stable index maps, rebuilt only when the *set* of labels changes (not on
   // every parent re-render, which produces a new array reference regardless
@@ -161,7 +189,8 @@ export const CuboidInstances = ({
   );
 
   const count = labelsByIndex.length;
-  const segmentsPerBox = segmentsPerBoxFor(showOrientation);
+  const orientationSegmentsPerBox =
+    orientationSegmentsPerBoxFor(showOrientation);
 
   // Rebuild every buffer when membership or batch-level rendering settings
   // change. Per-label *color* changes (hover/select/similar/color-by-mode)
@@ -170,11 +199,16 @@ export const CuboidInstances = ({
   useLayoutEffect(() => {
     if (count === 0) {
       setOutlineGeometry(null);
+      setOrientationGeometry(null);
       return;
     }
 
     const geometries = labelsByIndex.map((label) =>
-      resolveCuboidGeometry(label, useLegacyCoordinates, overlayRotationFallback),
+      resolveCuboidGeometry(
+        label,
+        useLegacyCoordinates,
+        overlayRotationFallback,
+      ),
     );
 
     // Bodies
@@ -195,22 +229,38 @@ export const CuboidInstances = ({
       bodyMesh.computeBoundingSphere();
     }
 
-    // Outline (+ shaft/axes segments when showOrientation)
-    const positions = new Float32Array(count * segmentsPerBox * 6);
-    const colors = new Float32Array(count * segmentsPerBox * 6);
+    // Edge outline — separate buffer from orientation markers (see
+    // `orientationMaterial` for why): edges need normal depth testing.
+    const edgePositions = new Float32Array(count * EDGES_PER_BOX * 6);
+    const edgeColors = new Float32Array(count * EDGES_PER_BOX * 6);
+
+    // Orientation markers (shaft + axes) — zero-length arrays when
+    // `showOrientation` is off.
+    const orientationPositions = new Float32Array(
+      count * orientationSegmentsPerBox * 6,
+    );
+    const orientationColors = new Float32Array(
+      count * orientationSegmentsPerBox * 6,
+    );
 
     const arrowMatrices: THREE.Matrix4[] = [];
 
     geometries.forEach((geometry, i) => {
-      const segBase = i * segmentsPerBox;
-      const floatBase = segBase * 6;
-      positions.set(computeBoxEdgePositions(geometry), floatBase);
+      const edgeFloatBase = i * EDGES_PER_BOX * 6;
+      edgePositions.set(computeBoxEdgePositions(geometry), edgeFloatBase);
 
       const baseColor = new THREE.Color(getColor(labelsByIndex[i]));
       for (let s = 0; s < EDGES_PER_BOX; s++) {
-        const o = floatBase + s * 6;
-        colors.set(
-          [baseColor.r, baseColor.g, baseColor.b, baseColor.r, baseColor.g, baseColor.b],
+        const o = edgeFloatBase + s * 6;
+        edgeColors.set(
+          [
+            baseColor.r,
+            baseColor.g,
+            baseColor.b,
+            baseColor.r,
+            baseColor.g,
+            baseColor.b,
+          ],
           o,
         );
       }
@@ -229,16 +279,20 @@ export const CuboidInstances = ({
         getComplementaryColor(getColor(labelsByIndex[i])),
       );
 
-      const shaftFloatBase = floatBase + EDGES_PER_BOX * 6;
+      const orientationFloatBase = i * orientationSegmentsPerBox * 6;
+      const shaftFloatBase = orientationFloatBase;
       if (markerGeometry) {
         const shaftStartWorld = localToWorld(
           markerGeometry.shaftStart,
           geometry,
         );
         const shaftEndWorld = localToWorld(markerGeometry.anchor, geometry);
-        positions.set([...shaftStartWorld, ...shaftEndWorld], shaftFloatBase);
+        orientationPositions.set(
+          [...shaftStartWorld, ...shaftEndWorld],
+          shaftFloatBase,
+        );
       }
-      colors.set(
+      orientationColors.set(
         [
           complementaryColor.r,
           complementaryColor.g,
@@ -277,9 +331,9 @@ export const CuboidInstances = ({
       axesLocalEnds.forEach((localEnd, axis) => {
         const endWorld = localToWorld(localEnd, geometry);
         const o = axesFloatBase + axis * 6;
-        positions.set([...originWorld, ...endWorld], o);
+        orientationPositions.set([...originWorld, ...endWorld], o);
         const axisColor = new THREE.Color(axesColors[axis]);
-        colors.set(
+        orientationColors.set(
           [
             axisColor.r,
             axisColor.g,
@@ -294,11 +348,24 @@ export const CuboidInstances = ({
     });
 
     const nextOutlineGeometry = new LineSegmentsGeometry();
-    nextOutlineGeometry.setPositions(positions);
-    nextOutlineGeometry.setColors(colors);
+    nextOutlineGeometry.setPositions(edgePositions);
+    nextOutlineGeometry.setColors(edgeColors);
     previousOutlineGeometryRef.current?.dispose();
     previousOutlineGeometryRef.current = nextOutlineGeometry;
     setOutlineGeometry(nextOutlineGeometry);
+
+    if (showOrientation) {
+      const nextOrientationGeometry = new LineSegmentsGeometry();
+      nextOrientationGeometry.setPositions(orientationPositions);
+      nextOrientationGeometry.setColors(orientationColors);
+      previousOrientationGeometryRef.current?.dispose();
+      previousOrientationGeometryRef.current = nextOrientationGeometry;
+      setOrientationGeometry(nextOrientationGeometry);
+    } else {
+      previousOrientationGeometryRef.current?.dispose();
+      previousOrientationGeometryRef.current = null;
+      setOrientationGeometry(null);
+    }
 
     // Arrowheads
     const arrowMesh = arrowMeshRef.current;
@@ -328,17 +395,18 @@ export const CuboidInstances = ({
   }, [
     membershipKey,
     count,
-    segmentsPerBox,
+    orientationSegmentsPerBox,
     useLegacyCoordinates,
     overlayRotationFallback,
     showOrientation,
     upVector,
   ]);
 
-  // Dispose the last-built outline geometry on unmount.
+  // Dispose the last-built geometries on unmount.
   useEffect(() => {
     return () => {
       previousOutlineGeometryRef.current?.dispose();
+      previousOrientationGeometryRef.current?.dispose();
     };
   }, []);
 
@@ -462,10 +530,24 @@ export const CuboidInstances = ({
           raycast={() => null}
         />
       )}
+      {orientationGeometry && (
+        // @ts-ignore — registered via ./shared/registerLineElements
+        <lineSegments2
+          geometry={orientationGeometry}
+          material={orientationMaterial}
+          // Matches the standalone `CuboidOrientationMarkers`' renderOrder;
+          // `depthTest: false` on `orientationMaterial` is what actually
+          // keeps these visible through the box body, this just keeps draw
+          // order consistent with the standalone path.
+          renderOrder={3}
+          raycast={() => null}
+        />
+      )}
       {showOrientation && (
         <instancedMesh
           ref={arrowMeshRef}
           args={[UNIT_ARROWHEAD_GEOMETRY, arrowMaterial, count]}
+          renderOrder={3}
           raycast={() => null}
         />
       )}
@@ -479,7 +561,8 @@ export const CuboidInstances = ({
             bodyMeshRef={bodyMeshRef}
             arrowMeshRef={arrowMeshRef}
             outlineGeometry={outlineGeometry}
-            segmentsPerBox={segmentsPerBox}
+            orientationGeometry={orientationGeometry}
+            orientationSegmentsPerBox={orientationSegmentsPerBox}
             showOrientation={showOrientation}
           />
         ))}
@@ -531,7 +614,11 @@ const CuboidHoverWireframe = ({
 
   const geometry = useMemo(
     () =>
-      resolveCuboidGeometry(label, useLegacyCoordinates, overlayRotationFallback),
+      resolveCuboidGeometry(
+        label,
+        useLegacyCoordinates,
+        overlayRotationFallback,
+      ),
     [label, useLegacyCoordinates, overlayRotationFallback],
   );
 
@@ -555,7 +642,8 @@ interface CuboidColorSyncProps {
   bodyMeshRef: RefObject<THREE.InstancedMesh>;
   arrowMeshRef: RefObject<THREE.InstancedMesh>;
   outlineGeometry: LineSegmentsGeometry;
-  segmentsPerBox: number;
+  orientationGeometry: LineSegmentsGeometry | null;
+  orientationSegmentsPerBox: number;
   showOrientation: boolean;
 }
 
@@ -574,14 +662,15 @@ const CuboidColorSync = ({
   bodyMeshRef,
   arrowMeshRef,
   outlineGeometry,
-  segmentsPerBox,
+  orientationGeometry,
+  orientationSegmentsPerBox,
   showOrientation,
 }: CuboidColorSyncProps) => {
-  const hoveredLabel = useRecoilValue(hoveredLabelAtom);
+  const hoveredLabel = useHoveredLabel3d();
   const isHovered = hoveredLabel?.id === label._id;
   const isSimilarLabelHovered = useSimilarLabels3d(label);
   const isSelectedForAnnotation =
-    useRecoilValue(selectedLabelForAnnotationAtom)?._id === label._id;
+    useCurrentSelected3dAnnotationLabel()?._id === label._id;
   // ReconciledDetection3D's index signature types `selected` as `unknown`
   // (see the same narrowing in ThreeDLabels' cuboidOverlays memo).
   const selected = Boolean((label as { selected?: boolean }).selected);
@@ -603,20 +692,22 @@ const CuboidColorSync = ({
       bodyMesh.instanceColor.needsUpdate = true;
     }
 
-    const segBase = index * segmentsPerBox;
+    const edgeBase = index * EDGES_PER_BOX;
     for (let s = 0; s < EDGES_PER_BOX; s++) {
-      setSegmentColor(outlineGeometry, segBase + s, color);
+      setSegmentColor(outlineGeometry, edgeBase + s, color);
     }
+    markNeedsUpdate(outlineGeometry);
 
-    if (showOrientation) {
+    if (showOrientation && orientationGeometry) {
       const complementaryColor = new THREE.Color(
         getComplementaryColor(strokeAndFillColor),
       );
-      setSegmentColor(
-        outlineGeometry,
-        segBase + EDGES_PER_BOX,
-        complementaryColor,
-      );
+      // Shaft is always the first segment within this label's slice of the
+      // orientation buffer; the 3 axes segments after it keep their fixed
+      // R/G/B colors set at buffer-build time and don't need updating here.
+      const orientationBase = index * orientationSegmentsPerBox;
+      setSegmentColor(orientationGeometry, orientationBase, complementaryColor);
+      markNeedsUpdate(orientationGeometry);
 
       const arrowMesh = arrowMeshRef.current;
       if (arrowMesh?.instanceColor) {
@@ -629,24 +720,27 @@ const CuboidColorSync = ({
         arrowMesh.instanceColor.needsUpdate = true;
       }
     }
-
-    const start = outlineGeometry.attributes.instanceColorStart as
-      | THREE.InterleavedBufferAttribute
-      | undefined;
-    const end = outlineGeometry.attributes.instanceColorEnd as
-      | THREE.InterleavedBufferAttribute
-      | undefined;
-    if (start) start.data.needsUpdate = true;
-    if (end) end.data.needsUpdate = true;
   }, [
     strokeAndFillColor,
     index,
     bodyMeshRef,
     arrowMeshRef,
     outlineGeometry,
-    segmentsPerBox,
+    orientationGeometry,
+    orientationSegmentsPerBox,
     showOrientation,
   ]);
 
   return null;
+};
+
+const markNeedsUpdate = (geometry: LineSegmentsGeometry) => {
+  const start = geometry.attributes.instanceColorStart as
+    | THREE.InterleavedBufferAttribute
+    | undefined;
+  const end = geometry.attributes.instanceColorEnd as
+    | THREE.InterleavedBufferAttribute
+    | undefined;
+  if (start) start.data.needsUpdate = true;
+  if (end) end.data.needsUpdate = true;
 };

--- a/app/packages/looker-3d/src/labels/CuboidInstances.tsx
+++ b/app/packages/looker-3d/src/labels/CuboidInstances.tsx
@@ -23,7 +23,7 @@ import {
   useCurrentSelected3dAnnotationLabel,
   useHoveredLabel3d,
   useSetHoveredLabel3d,
-} from "../state";
+} from "../state/accessors";
 import type { HoveredLabelSource } from "../types";
 import { getComplementaryColor } from "../utils";
 import {

--- a/app/packages/looker-3d/src/labels/CuboidInstances.tsx
+++ b/app/packages/looker-3d/src/labels/CuboidInstances.tsx
@@ -41,6 +41,10 @@ import {
   setSegmentColor,
 } from "./cuboid-instance-geometry";
 import {
+  createHoverIndexTracker,
+  resolveLabelByInstanceId,
+} from "./cuboid-instance-interaction";
+import {
   ORIENTATION_AXES_COLORS,
   ORIENTATION_AXES_LENGTH_RATIO,
   ORIENTATION_AXES_MIN_LENGTH,
@@ -425,14 +429,14 @@ export const CuboidInstances = ({
 
   const resolveLabel = useCallback(
     (instanceId: number | undefined) =>
-      instanceId === undefined ? null : (labelsByIndex[instanceId] ?? null),
+      resolveLabelByInstanceId(labelsByIndex, instanceId),
     [labelsByIndex],
   );
 
   // r3f doesn't guarantee `instanceId` on an InstancedMesh's pointer-out
   // event, so track which instance is currently hovered ourselves and
   // resolve the outgoing label from that on pointer-out.
-  const hoveredIndexRef = useRef<number | null>(null);
+  const hoverTrackerRef = useRef(createHoverIndexTracker());
 
   const handlePointerOver = useCallback(
     (e: ThreeEvent<PointerEvent>) => {
@@ -440,7 +444,7 @@ export const CuboidInstances = ({
       const label = resolveLabel(e.instanceId);
       if (!label) return;
 
-      hoveredIndexRef.current = e.instanceId ?? null;
+      hoverTrackerRef.current.setHovered(e.instanceId ?? null);
       setHoveredLabel({ id: label._id, source: hoverSource });
       onPointerOverForLabel(label, e);
     },
@@ -448,11 +452,8 @@ export const CuboidInstances = ({
   );
 
   const handlePointerOut = useCallback(() => {
-    const label =
-      hoveredIndexRef.current !== null
-        ? (labelsByIndex[hoveredIndexRef.current] ?? null)
-        : null;
-    hoveredIndexRef.current = null;
+    const index = hoverTrackerRef.current.consumeHovered();
+    const label = resolveLabelByInstanceId(labelsByIndex, index ?? undefined);
 
     setHoveredLabel(null);
     if (label) {

--- a/app/packages/looker-3d/src/labels/CuboidInstances.tsx
+++ b/app/packages/looker-3d/src/labels/CuboidInstances.tsx
@@ -24,185 +24,29 @@ import { hoveredLabelAtom, selectedLabelForAnnotationAtom } from "../state";
 import type { HoveredLabelSource } from "../types";
 import { getComplementaryColor } from "../utils";
 import {
+  EDGES_PER_BOX,
+  SHAFT_SEGMENTS_PER_BOX,
+  UNIT_ARROWHEAD_GEOMETRY,
+  UNIT_BOX_GEOMETRY,
+  ZERO_SCALE_MATRIX,
+  computeArrowheadMatrix,
+  computeBodyMatrix,
+  computeBoxEdgePositions,
+  localToWorld,
+  resolveCuboidGeometry,
+  segmentsPerBoxFor,
+  setSegmentColor,
+} from "./cuboid-instance-geometry";
+import {
   ORIENTATION_AXES_COLORS,
   ORIENTATION_AXES_LENGTH_RATIO,
   ORIENTATION_AXES_MIN_LENGTH,
   getCuboidOrientationMarkerGeometry,
   getFiniteMagnitude,
-} from "./shared/CuboidOrientationMarkers";
+} from "./shared/cuboid-orientation-geometry";
 import { useEventHandlers } from "./shared/hooks";
 import "./shared/registerLineElements";
 import { useDragGate } from "./shared/useDragGate";
-
-// Shared across every instance — each box's actual size/orientation is baked
-// into its own matrix (see `computeBodyMatrix`), so the geometry itself just
-// needs to be a unit cube.
-const UNIT_BOX_GEOMETRY = new THREE.BoxGeometry(1, 1, 1);
-
-// Canonical arrowhead triangle: apex at local +X, base corners at local ±Y,
-// unit half-width. Scaled per-instance by (headLength, headHalfWidth,
-// headHalfWidth); rotated 90° about local X when the box's arrowhead spreads
-// along Z instead of Y (see `computeArrowheadMatrix`).
-const UNIT_ARROWHEAD_GEOMETRY = new THREE.BufferGeometry();
-UNIT_ARROWHEAD_GEOMETRY.setAttribute(
-  "position",
-  new THREE.Float32BufferAttribute(
-    [
-      1, 0, 0, // apex
-      0, 1, 0, // base1
-      0, -1, 0, // base2
-    ],
-    3,
-  ),
-);
-const SPREAD_TO_Z_QUATERNION = new THREE.Quaternion().setFromAxisAngle(
-  new THREE.Vector3(1, 0, 0),
-  Math.PI / 2,
-);
-const IDENTITY_QUATERNION = new THREE.Quaternion();
-const UNIT_SCALE = new THREE.Vector3(1, 1, 1);
-const ZERO_SCALE_MATRIX = new THREE.Matrix4().makeScale(0, 0, 0);
-
-const EDGES_PER_BOX = 12;
-const SHAFT_SEGMENTS_PER_BOX = 1;
-const AXES_SEGMENTS_PER_BOX = 3;
-
-interface CuboidGeometry {
-  position: THREE.Vector3Tuple;
-  dimensions: THREE.Vector3Tuple;
-  quaternion: THREE.Quaternion;
-}
-
-/**
- * Resolves a non-edited label's display geometry directly from its own
- * (already-reconciled) fields — `detectionsToRender` labels are the working
- * store's current values, so there's no separate "effective" lookup needed
- * the way `useCuboidAnnotation` does for the one actively-edited box. This
- * intentionally skips transient-drag handling: a box being dragged is always
- * popped out to the standalone path (see `ThreeDLabels`), never present here.
- *
- * `overlayRotationFallback` mirrors `ThreeDLabels`' `cuboidOverlays` prop
- * assembly: a label missing its own `rotation` field there ends up with the
- * scene-level `overlayRotation` as its effective rotation (the JSX prop
- * spread order means `overlay.rotation`, when present, overrides the
- * `rotation={overlayRotation}` prop — but nothing overrides it when absent).
- */
-function resolveCuboidGeometry(
-  label: ReconciledDetection3D,
-  useLegacyCoordinates: boolean,
-  overlayRotationFallback: THREE.Vector3Tuple,
-): CuboidGeometry {
-  const dimensions = label.dimensions;
-  const [x, rawY, z] = label.location;
-  // See `useDisplayCuboidTransform` for why legacy-coordinate labels need a
-  // half-height offset here.
-  const y = useLegacyCoordinates ? rawY - 0.5 * dimensions[1] : rawY;
-
-  const quaternion = label.quaternion
-    ? new THREE.Quaternion(...label.quaternion)
-    : new THREE.Quaternion().setFromEuler(
-        new THREE.Euler(...(label.rotation ?? overlayRotationFallback)),
-      );
-
-  return { position: [x, y, z], dimensions, quaternion };
-}
-
-function computeBodyMatrix(geometry: CuboidGeometry): THREE.Matrix4 {
-  return new THREE.Matrix4().compose(
-    new THREE.Vector3(...geometry.position),
-    geometry.quaternion,
-    new THREE.Vector3(...geometry.dimensions),
-  );
-}
-
-/**
- * World-space edge endpoints for one box's outline, in the flat pairs format
- * `LineSegmentsGeometry.setPositions()` expects (each consecutive 2 vertices
- * = one edge). `EdgesGeometry` already emits exactly this shape.
- */
-function computeBoxEdgePositions(geometry: CuboidGeometry): Float32Array {
-  const box = new THREE.BoxGeometry(...geometry.dimensions);
-  box.applyQuaternion(geometry.quaternion);
-  box.translate(...geometry.position);
-  const edges = new THREE.EdgesGeometry(box);
-  const positions = new Float32Array(
-    edges.attributes.position.array as Float32Array,
-  );
-  box.dispose();
-  edges.dispose();
-  return positions;
-}
-
-const _localPoint = new THREE.Vector3();
-const _worldOffset = new THREE.Vector3();
-
-function localToWorld(
-  local: THREE.Vector3Tuple | THREE.Vector3,
-  geometry: CuboidGeometry,
-): THREE.Vector3Tuple {
-  if (local instanceof THREE.Vector3) {
-    _localPoint.copy(local);
-  } else {
-    _localPoint.set(local[0], local[1], local[2]);
-  }
-  _worldOffset.set(...geometry.position);
-  _localPoint.applyQuaternion(geometry.quaternion).add(_worldOffset);
-  return [_localPoint.x, _localPoint.y, _localPoint.z];
-}
-
-/**
- * Per-instance affine matrix for the merged arrowhead `InstancedMesh` (see
- * `UNIT_ARROWHEAD_GEOMETRY`), derived from the same decomposed geometry the
- * standalone `CuboidOrientationMarker` uses (`getCuboidOrientationMarkerGeometry`).
- */
-function computeArrowheadMatrix(
-  geometry: CuboidGeometry,
-  upVector: THREE.Vector3 | null,
-): THREE.Matrix4 {
-  const markerGeometry = getCuboidOrientationMarkerGeometry(
-    geometry.dimensions,
-    geometry.quaternion,
-    upVector,
-  );
-  if (!markerGeometry) {
-    return ZERO_SCALE_MATRIX.clone();
-  }
-
-  const { anchor, headLength, headHalfWidth, spreadAlongZ } = markerGeometry;
-  const localMatrix = new THREE.Matrix4().compose(
-    anchor,
-    spreadAlongZ ? SPREAD_TO_Z_QUATERNION : IDENTITY_QUATERNION,
-    new THREE.Vector3(headLength, headHalfWidth, headHalfWidth),
-  );
-  const boxMatrix = new THREE.Matrix4().compose(
-    new THREE.Vector3(...geometry.position),
-    geometry.quaternion,
-    UNIT_SCALE,
-  );
-  return boxMatrix.multiply(localMatrix);
-}
-
-function segmentsPerBoxFor(showOrientation: boolean): number {
-  return (
-    EDGES_PER_BOX +
-    (showOrientation ? SHAFT_SEGMENTS_PER_BOX + AXES_SEGMENTS_PER_BOX : 0)
-  );
-}
-
-const setSegmentColor = (
-  geometry: LineSegmentsGeometry,
-  segmentIndex: number,
-  color: THREE.Color,
-) => {
-  const start = geometry.attributes.instanceColorStart as
-    | THREE.InterleavedBufferAttribute
-    | undefined;
-  const end = geometry.attributes.instanceColorEnd as
-    | THREE.InterleavedBufferAttribute
-    | undefined;
-  start?.setXYZ(segmentIndex, color.r, color.g, color.b);
-  end?.setXYZ(segmentIndex, color.r, color.g, color.b);
-};
 
 export interface CuboidInstancesProps {
   detections: readonly ReconciledDetection3D[];

--- a/app/packages/looker-3d/src/labels/DragGate3D.tsx
+++ b/app/packages/looker-3d/src/labels/DragGate3D.tsx
@@ -1,6 +1,6 @@
 import { ThreeEvent } from "@react-three/fiber";
 import * as React from "react";
-import { DRAG_GATE_THRESHOLD_PX } from "../constants";
+import { useDragGate } from "./shared/useDragGate";
 
 type ClickEvt = ThreeEvent<MouseEvent>;
 type PointerEvt = ThreeEvent<PointerEvent>;
@@ -19,14 +19,16 @@ export type DragGate3DProps = {
  * Only fires onClick if the pointer didn't move beyond the threshold.
  */
 export function DragGate3D({
-  dragThresholdPx = DRAG_GATE_THRESHOLD_PX,
+  dragThresholdPx,
   onClick,
   children,
 }: DragGate3DProps) {
-  const startRef = React.useRef<{ x: number; y: number } | null>(null);
-  const draggedRef = React.useRef(false);
-
-  const thresholdSq = dragThresholdPx * dragThresholdPx;
+  const {
+    onPointerDown: gateOnPointerDown,
+    onPointerMove: gateOnPointerMove,
+    onPointerUp: gateOnPointerUp,
+    isClick,
+  } = useDragGate({ dragThresholdPx });
 
   // Store child handlers in a ref to avoid adding them as dependencies
   const childHandlersRef = React.useRef<{
@@ -43,42 +45,40 @@ export function DragGate3D({
     onClick: children.props.onClick,
   };
 
-  const handlePointerDown = React.useCallback((e: PointerEvt) => {
-    childHandlersRef.current.onPointerDown?.(e);
-    startRef.current = { x: e.nativeEvent.clientX, y: e.nativeEvent.clientY };
-    draggedRef.current = false;
-  }, []);
+  const handlePointerDown = React.useCallback(
+    (e: PointerEvt) => {
+      childHandlersRef.current.onPointerDown?.(e);
+      gateOnPointerDown(e);
+    },
+    [gateOnPointerDown],
+  );
 
   const handlePointerMove = React.useCallback(
     (e: PointerEvt) => {
       childHandlersRef.current.onPointerMove?.(e);
-      if (!startRef.current || draggedRef.current) return;
-
-      const dx = e.nativeEvent.clientX - startRef.current.x;
-      const dy = e.nativeEvent.clientY - startRef.current.y;
-
-      if (dx * dx + dy * dy > thresholdSq) {
-        draggedRef.current = true;
-      }
+      gateOnPointerMove(e);
     },
-    [thresholdSq],
+    [gateOnPointerMove],
   );
 
-  const handlePointerUp = React.useCallback((e: PointerEvt) => {
-    childHandlersRef.current.onPointerUp?.(e);
-    startRef.current = null;
-  }, []);
+  const handlePointerUp = React.useCallback(
+    (e: PointerEvt) => {
+      childHandlersRef.current.onPointerUp?.(e);
+      gateOnPointerUp(e);
+    },
+    [gateOnPointerUp],
+  );
 
   const handleClick = React.useCallback(
     (e: ClickEvt) => {
-      if (draggedRef.current) {
+      if (!isClick()) {
         e.stopPropagation();
         return;
       }
       childHandlersRef.current.onClick?.(e);
       onClick?.(e);
     },
-    [onClick],
+    [isClick, onClick],
   );
 
   return React.cloneElement(children, {

--- a/app/packages/looker-3d/src/labels/cuboid-instance-geometry.test.ts
+++ b/app/packages/looker-3d/src/labels/cuboid-instance-geometry.test.ts
@@ -6,8 +6,8 @@ import {
   computeBodyMatrix,
   computeBoxEdgePositions,
   EDGES_PER_BOX,
+  orientationSegmentsPerBoxFor,
   resolveCuboidGeometry,
-  segmentsPerBoxFor,
 } from "./cuboid-instance-geometry";
 
 function createLabel(
@@ -186,12 +186,12 @@ describe("computeArrowheadMatrix", () => {
   });
 });
 
-describe("segmentsPerBoxFor", () => {
-  it("is just the 12 outline edges when orientation markers are off", () => {
-    expect(segmentsPerBoxFor(false)).toBe(12);
+describe("orientationSegmentsPerBoxFor", () => {
+  it("is 0 when orientation markers are off", () => {
+    expect(orientationSegmentsPerBoxFor(false)).toBe(0);
   });
 
-  it("adds the shaft + 3 axes segments when orientation markers are on", () => {
-    expect(segmentsPerBoxFor(true)).toBe(12 + 1 + 3);
+  it("is the shaft + 3 axes segments when orientation markers are on", () => {
+    expect(orientationSegmentsPerBoxFor(true)).toBe(1 + 3);
   });
 });

--- a/app/packages/looker-3d/src/labels/cuboid-instance-geometry.test.ts
+++ b/app/packages/looker-3d/src/labels/cuboid-instance-geometry.test.ts
@@ -1,0 +1,197 @@
+import * as THREE from "three";
+import { describe, expect, it } from "vitest";
+import type { ReconciledDetection3D } from "../annotation/types";
+import {
+  computeArrowheadMatrix,
+  computeBodyMatrix,
+  computeBoxEdgePositions,
+  EDGES_PER_BOX,
+  resolveCuboidGeometry,
+  segmentsPerBoxFor,
+} from "./cuboid-instance-geometry";
+
+function createLabel(
+  overrides: Partial<ReconciledDetection3D> = {},
+): ReconciledDetection3D {
+  return {
+    _id: "label-1",
+    _cls: "Detection",
+    path: "ground_truth",
+    location: [1, 2, 3],
+    dimensions: [4, 5, 6],
+    ...overrides,
+  } as unknown as ReconciledDetection3D;
+}
+
+describe("resolveCuboidGeometry", () => {
+  it("uses the label's own position and dimensions unchanged", () => {
+    const label = createLabel({ location: [1, 2, 3], dimensions: [4, 5, 6] });
+    const geometry = resolveCuboidGeometry(label, false, [0, 0, 0]);
+    expect(geometry.position).toEqual([1, 2, 3]);
+    expect(geometry.dimensions).toEqual([4, 5, 6]);
+  });
+
+  it("offsets Y downward by half the height in legacy coordinates", () => {
+    const label = createLabel({ location: [1, 10, 3], dimensions: [4, 6, 8] });
+    const geometry = resolveCuboidGeometry(label, true, [0, 0, 0]);
+    expect(geometry.position).toEqual([1, 7, 3]);
+  });
+
+  it("does not offset Y when not using legacy coordinates", () => {
+    const label = createLabel({ location: [1, 10, 3], dimensions: [4, 6, 8] });
+    const geometry = resolveCuboidGeometry(label, false, [0, 0, 0]);
+    expect(geometry.position).toEqual([1, 10, 3]);
+  });
+
+  it("prefers an explicit quaternion over rotation", () => {
+    const explicitQuaternion = new THREE.Quaternion()
+      .setFromEuler(new THREE.Euler(0.1, 0.2, 0.3))
+      .toArray() as [number, number, number, number];
+    const label = createLabel({
+      rotation: [1, 1, 1], // deliberately different, should be ignored
+      quaternion: explicitQuaternion,
+    });
+    const geometry = resolveCuboidGeometry(label, false, [0, 0, 0]);
+    expect(geometry.quaternion.toArray()).toEqual(explicitQuaternion);
+  });
+
+  it("falls back to the label's own rotation when no quaternion is present", () => {
+    const label = createLabel({ rotation: [0, Math.PI / 2, 0] });
+    const geometry = resolveCuboidGeometry(label, false, [0, 0, 0]);
+    const expected = new THREE.Quaternion().setFromEuler(
+      new THREE.Euler(0, Math.PI / 2, 0),
+    );
+    expect(geometry.quaternion.angleTo(expected)).toBeCloseTo(0, 6);
+  });
+
+  it("falls back to overlayRotationFallback when the label has neither rotation nor quaternion", () => {
+    const label = createLabel({ rotation: undefined, quaternion: undefined });
+    const fallback: THREE.Vector3Tuple = [0, Math.PI, 0];
+    const geometry = resolveCuboidGeometry(label, false, fallback);
+    const expected = new THREE.Quaternion().setFromEuler(
+      new THREE.Euler(...fallback),
+    );
+    expect(geometry.quaternion.angleTo(expected)).toBeCloseTo(0, 6);
+  });
+});
+
+describe("computeBodyMatrix", () => {
+  it("composes position, rotation, and dimensions-as-scale", () => {
+    const geometry = {
+      position: [1, 2, 3] as THREE.Vector3Tuple,
+      dimensions: [4, 5, 6] as THREE.Vector3Tuple,
+      quaternion: new THREE.Quaternion(),
+    };
+    const matrix = computeBodyMatrix(geometry);
+
+    const position = new THREE.Vector3();
+    const quaternion = new THREE.Quaternion();
+    const scale = new THREE.Vector3();
+    matrix.decompose(position, quaternion, scale);
+
+    expect(position.toArray()).toEqual([1, 2, 3]);
+    expect(scale.toArray()).toEqual([4, 5, 6]);
+    expect(quaternion.equals(new THREE.Quaternion())).toBe(true);
+  });
+});
+
+describe("computeBoxEdgePositions", () => {
+  it("produces 12 edges (72 floats) for a box", () => {
+    const geometry = {
+      position: [0, 0, 0] as THREE.Vector3Tuple,
+      dimensions: [2, 2, 2] as THREE.Vector3Tuple,
+      quaternion: new THREE.Quaternion(),
+    };
+    const positions = computeBoxEdgePositions(geometry);
+    expect(positions.length).toBe(EDGES_PER_BOX * 6);
+  });
+
+  it("offsets edge positions by the box's world position", () => {
+    const centered = computeBoxEdgePositions({
+      position: [0, 0, 0],
+      dimensions: [2, 2, 2],
+      quaternion: new THREE.Quaternion(),
+    });
+    const translated = computeBoxEdgePositions({
+      position: [10, 0, 0],
+      dimensions: [2, 2, 2],
+      quaternion: new THREE.Quaternion(),
+    });
+
+    for (let i = 0; i < centered.length; i += 3) {
+      expect(translated[i]).toBeCloseTo(centered[i] + 10, 6);
+      expect(translated[i + 1]).toBeCloseTo(centered[i + 1], 6);
+      expect(translated[i + 2]).toBeCloseTo(centered[i + 2], 6);
+    }
+  });
+});
+
+describe("computeArrowheadMatrix", () => {
+  it("returns a zero-scale matrix when the box has no valid heading extent", () => {
+    const geometry = {
+      position: [0, 0, 0] as THREE.Vector3Tuple,
+      dimensions: [0, 5, 5] as THREE.Vector3Tuple,
+      quaternion: new THREE.Quaternion(),
+    };
+    const matrix = computeArrowheadMatrix(geometry, null);
+
+    // A degenerate all-zero-scale matrix reads back as scale (1,1,1) via
+    // Matrix4.decompose() (three.js falls back to 1 when a basis column has
+    // zero length, to avoid dividing by it) — check the diagonal elements
+    // directly instead.
+    expect([
+      matrix.elements[0],
+      matrix.elements[5],
+      matrix.elements[10],
+    ]).toEqual([0, 0, 0]);
+  });
+
+  it("returns a non-degenerate matrix for a box with a valid heading extent", () => {
+    const geometry = {
+      position: [0, 0, 0] as THREE.Vector3Tuple,
+      dimensions: [4, 2, 2] as THREE.Vector3Tuple,
+      quaternion: new THREE.Quaternion(),
+    };
+    const matrix = computeArrowheadMatrix(geometry, null);
+
+    const scale = new THREE.Vector3();
+    matrix.decompose(new THREE.Vector3(), new THREE.Quaternion(), scale);
+    expect(scale.x).toBeGreaterThan(0);
+    expect(scale.y).toBeGreaterThan(0);
+    expect(scale.z).toBeGreaterThan(0);
+  });
+
+  it("translates the arrowhead matrix along with the box's own position", () => {
+    const dimensions: THREE.Vector3Tuple = [4, 2, 2];
+    const quaternion = new THREE.Quaternion();
+    const atOrigin = computeArrowheadMatrix(
+      { position: [0, 0, 0], dimensions, quaternion },
+      null,
+    );
+    const translated = computeArrowheadMatrix(
+      { position: [5, 0, 0], dimensions, quaternion },
+      null,
+    );
+
+    const originPos = new THREE.Vector3();
+    atOrigin.decompose(originPos, new THREE.Quaternion(), new THREE.Vector3());
+    const translatedPos = new THREE.Vector3();
+    translated.decompose(
+      translatedPos,
+      new THREE.Quaternion(),
+      new THREE.Vector3(),
+    );
+
+    expect(translatedPos.x - originPos.x).toBeCloseTo(5, 6);
+  });
+});
+
+describe("segmentsPerBoxFor", () => {
+  it("is just the 12 outline edges when orientation markers are off", () => {
+    expect(segmentsPerBoxFor(false)).toBe(12);
+  });
+
+  it("adds the shaft + 3 axes segments when orientation markers are on", () => {
+    expect(segmentsPerBoxFor(true)).toBe(12 + 1 + 3);
+  });
+});

--- a/app/packages/looker-3d/src/labels/cuboid-instance-geometry.test.ts
+++ b/app/packages/looker-3d/src/labels/cuboid-instance-geometry.test.ts
@@ -1,13 +1,16 @@
 import * as THREE from "three";
 import { describe, expect, it } from "vitest";
 import type { ReconciledDetection3D } from "../annotation/types";
+import { LineSegmentsGeometry } from "three/examples/jsm/lines/LineSegmentsGeometry";
 import {
   computeArrowheadMatrix,
   computeBodyMatrix,
   computeBoxEdgePositions,
   EDGES_PER_BOX,
+  localToWorld,
   orientationSegmentsPerBoxFor,
   resolveCuboidGeometry,
+  setSegmentColor,
 } from "./cuboid-instance-geometry";
 
 function createLabel(
@@ -193,5 +196,120 @@ describe("orientationSegmentsPerBoxFor", () => {
 
   it("is the shaft + 3 axes segments when orientation markers are on", () => {
     expect(orientationSegmentsPerBoxFor(true)).toBe(1 + 3);
+  });
+});
+
+describe("localToWorld", () => {
+  const geometry = {
+    position: [10, -3, 7] as THREE.Vector3Tuple,
+    dimensions: [4, 2, 6] as THREE.Vector3Tuple,
+    quaternion: new THREE.Quaternion(),
+  };
+
+  it("translates by the box position when unrotated", () => {
+    expect(localToWorld([1, 2, 3], geometry)).toEqual([11, -1, 10]);
+  });
+
+  it("maps the local origin to the box position", () => {
+    expect(localToWorld([0, 0, 0], geometry)).toEqual([10, -3, 7]);
+  });
+
+  it("applies the box rotation before translating", () => {
+    // Quarter turn about Z sends local +X to world +Y.
+    const rotated = {
+      ...geometry,
+      position: [0, 0, 0] as THREE.Vector3Tuple,
+      quaternion: new THREE.Quaternion().setFromAxisAngle(
+        new THREE.Vector3(0, 0, 1),
+        Math.PI / 2,
+      ),
+    };
+    const [x, y, z] = localToWorld([1, 0, 0], rotated);
+    expect(x).toBeCloseTo(0, 6);
+    expect(y).toBeCloseTo(1, 6);
+    expect(z).toBeCloseTo(0, 6);
+  });
+
+  it("accepts a Vector3 as well as a tuple, without mutating it", () => {
+    const input = new THREE.Vector3(1, 2, 3);
+    expect(localToWorld(input, geometry)).toEqual([11, -1, 10]);
+    // The shared scratch vector must not write back through the caller's input.
+    expect(input.toArray()).toEqual([1, 2, 3]);
+  });
+
+  it("does not leak state between calls", () => {
+    // Scratch vectors are module-level, so a stale value could bleed across.
+    expect(localToWorld([1, 0, 0], geometry)).toEqual([11, -3, 7]);
+    expect(localToWorld([0, 0, 0], geometry)).toEqual([10, -3, 7]);
+  });
+});
+
+describe("setSegmentColor", () => {
+  /** A LineSegmentsGeometry with colors allocated for `segments` segments. */
+  const geometryWithColors = (segments: number) => {
+    const geometry = new LineSegmentsGeometry();
+    geometry.setPositions(new Float32Array(segments * 6));
+    geometry.setColors(new Float32Array(segments * 6));
+    return geometry;
+  };
+
+  it("writes the color into both ends of the segment", () => {
+    const geometry = geometryWithColors(2);
+    setSegmentColor(geometry, 1, new THREE.Color(0.25, 0.5, 0.75));
+
+    const start = geometry.attributes
+      .instanceColorStart as THREE.InterleavedBufferAttribute;
+    const end = geometry.attributes
+      .instanceColorEnd as THREE.InterleavedBufferAttribute;
+
+    expect(start.getX(1)).toBeCloseTo(0.25, 5);
+    expect(start.getY(1)).toBeCloseTo(0.5, 5);
+    expect(start.getZ(1)).toBeCloseTo(0.75, 5);
+    expect(end.getX(1)).toBeCloseTo(0.25, 5);
+    expect(end.getY(1)).toBeCloseTo(0.5, 5);
+    expect(end.getZ(1)).toBeCloseTo(0.75, 5);
+  });
+
+  it("flags the interleaved buffers for upload", () => {
+    // Regression guard: without this the recolor lands in the CPU buffer but
+    // never reaches the GPU, so hover/select colors silently don't apply.
+    //
+    // Asserted via `version`, not `needsUpdate`: on three's buffers
+    // `needsUpdate` is a write-only setter that bumps `version`, and reading it
+    // yields `undefined` — so an expectation against it would pass even if the
+    // flag were never set.
+    const geometry = geometryWithColors(1);
+    const start = geometry.attributes
+      .instanceColorStart as THREE.InterleavedBufferAttribute;
+    const end = geometry.attributes
+      .instanceColorEnd as THREE.InterleavedBufferAttribute;
+
+    const startVersion = start.data.version;
+    const endVersion = end.data.version;
+
+    setSegmentColor(geometry, 0, new THREE.Color(1, 0, 0));
+
+    expect(start.data.version).toBeGreaterThan(startVersion);
+    expect(end.data.version).toBeGreaterThan(endVersion);
+  });
+
+  it("leaves other segments untouched", () => {
+    const geometry = geometryWithColors(3);
+    setSegmentColor(geometry, 1, new THREE.Color(1, 1, 1));
+
+    const start = geometry.attributes
+      .instanceColorStart as THREE.InterleavedBufferAttribute;
+    expect(start.getX(0)).toBe(0);
+    expect(start.getX(2)).toBe(0);
+  });
+
+  it("is a no-op when the geometry has no color attributes", () => {
+    // setColors() was never called, so the attributes are absent.
+    const geometry = new LineSegmentsGeometry();
+    geometry.setPositions(new Float32Array(6));
+
+    expect(() =>
+      setSegmentColor(geometry, 0, new THREE.Color(1, 0, 0)),
+    ).not.toThrow();
   });
 });

--- a/app/packages/looker-3d/src/labels/cuboid-instance-geometry.ts
+++ b/app/packages/looker-3d/src/labels/cuboid-instance-geometry.ts
@@ -97,23 +97,64 @@ export function computeBodyMatrix(geometry: CuboidGeometry): THREE.Matrix4 {
   );
 }
 
+// A unit box's edge topology (which corners each of the 12 edges connects)
+// never changes — only the per-box position/quaternion/dimensions do. Reused
+// across every `computeBoxEdgePositions` call instead of building and
+// disposing a `BoxGeometry` + `EdgesGeometry` pair per box (which for ~3k
+// cuboids meant 6k geometry allocations per rebuild).
+const UNIT_BOX_CORNERS: THREE.Vector3Tuple[] = [
+  [-0.5, -0.5, -0.5],
+  [0.5, -0.5, -0.5],
+  [0.5, 0.5, -0.5],
+  [-0.5, 0.5, -0.5],
+  [-0.5, -0.5, 0.5],
+  [0.5, -0.5, 0.5],
+  [0.5, 0.5, 0.5],
+  [-0.5, 0.5, 0.5],
+];
+const BOX_EDGE_CORNER_INDICES: ReadonlyArray<readonly [number, number]> = [
+  [0, 1],
+  [1, 2],
+  [2, 3],
+  [3, 0],
+  [4, 5],
+  [5, 6],
+  [6, 7],
+  [7, 4],
+  [0, 4],
+  [1, 5],
+  [2, 6],
+  [3, 7],
+];
+const _edgeMatrix = new THREE.Matrix4();
+const _edgeCorners = UNIT_BOX_CORNERS.map(() => new THREE.Vector3());
+
 /**
  * World-space edge endpoints for one box's outline, in the flat pairs format
  * `LineSegmentsGeometry.setPositions()` expects (each consecutive 2 vertices
- * = one edge). `EdgesGeometry` already emits exactly this shape.
+ * = one edge).
  */
 export function computeBoxEdgePositions(
   geometry: CuboidGeometry,
 ): Float32Array {
-  const box = new THREE.BoxGeometry(...geometry.dimensions);
-  box.applyQuaternion(geometry.quaternion);
-  box.translate(...geometry.position);
-  const edges = new THREE.EdgesGeometry(box);
-  const positions = new Float32Array(
-    edges.attributes.position.array as Float32Array,
+  _edgeMatrix.compose(
+    new THREE.Vector3(...geometry.position),
+    geometry.quaternion,
+    new THREE.Vector3(...geometry.dimensions),
   );
-  box.dispose();
-  edges.dispose();
+  for (let i = 0; i < UNIT_BOX_CORNERS.length; i++) {
+    _edgeCorners[i].set(...UNIT_BOX_CORNERS[i]).applyMatrix4(_edgeMatrix);
+  }
+  const positions = new Float32Array(EDGES_PER_BOX * 6);
+  let offset = 0;
+  for (const [a, b] of BOX_EDGE_CORNER_INDICES) {
+    positions[offset++] = _edgeCorners[a].x;
+    positions[offset++] = _edgeCorners[a].y;
+    positions[offset++] = _edgeCorners[a].z;
+    positions[offset++] = _edgeCorners[b].x;
+    positions[offset++] = _edgeCorners[b].y;
+    positions[offset++] = _edgeCorners[b].z;
+  }
   return positions;
 }
 
@@ -193,4 +234,6 @@ export const setSegmentColor = (
     | undefined;
   start?.setXYZ(segmentIndex, color.r, color.g, color.b);
   end?.setXYZ(segmentIndex, color.r, color.g, color.b);
+  if (start) start.data.needsUpdate = true;
+  if (end) end.data.needsUpdate = true;
 };

--- a/app/packages/looker-3d/src/labels/cuboid-instance-geometry.ts
+++ b/app/packages/looker-3d/src/labels/cuboid-instance-geometry.ts
@@ -1,0 +1,183 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+import * as THREE from "three";
+import type { LineSegmentsGeometry } from "three/examples/jsm/lines/LineSegmentsGeometry";
+import type { ReconciledDetection3D } from "../annotation/types";
+import { getCuboidOrientationMarkerGeometry } from "./shared/cuboid-orientation-geometry";
+
+// Pure geometry/matrix math for `CuboidInstances`, kept dependency-free (no
+// React, no hooks, no event bus) so it can be unit tested without pulling in
+// the rest of the app's module graph.
+
+// Shared across every instance — each box's actual size/orientation is baked
+// into its own matrix (see `computeBodyMatrix`), so the geometry itself just
+// needs to be a unit cube.
+export const UNIT_BOX_GEOMETRY = new THREE.BoxGeometry(1, 1, 1);
+
+// Canonical arrowhead triangle: apex at local +X, base corners at local ±Y,
+// unit half-width. Scaled per-instance by (headLength, headHalfWidth,
+// headHalfWidth); rotated 90° about local X when the box's arrowhead spreads
+// along Z instead of Y (see `computeArrowheadMatrix`).
+export const UNIT_ARROWHEAD_GEOMETRY = new THREE.BufferGeometry();
+UNIT_ARROWHEAD_GEOMETRY.setAttribute(
+  "position",
+  new THREE.Float32BufferAttribute(
+    [
+      1, 0, 0, // apex
+      0, 1, 0, // base1
+      0, -1, 0, // base2
+    ],
+    3,
+  ),
+);
+const SPREAD_TO_Z_QUATERNION = new THREE.Quaternion().setFromAxisAngle(
+  new THREE.Vector3(1, 0, 0),
+  Math.PI / 2,
+);
+const IDENTITY_QUATERNION = new THREE.Quaternion();
+const UNIT_SCALE = new THREE.Vector3(1, 1, 1);
+export const ZERO_SCALE_MATRIX = new THREE.Matrix4().makeScale(0, 0, 0);
+
+export const EDGES_PER_BOX = 12;
+export const SHAFT_SEGMENTS_PER_BOX = 1;
+export const AXES_SEGMENTS_PER_BOX = 3;
+
+export interface CuboidGeometry {
+  position: THREE.Vector3Tuple;
+  dimensions: THREE.Vector3Tuple;
+  quaternion: THREE.Quaternion;
+}
+
+/**
+ * Resolves a non-edited label's display geometry directly from its own
+ * (already-reconciled) fields — `detectionsToRender` labels are the working
+ * store's current values, so there's no separate "effective" lookup needed
+ * the way `useCuboidAnnotation` does for the one actively-edited box. This
+ * intentionally skips transient-drag handling: a box being dragged is always
+ * popped out to the standalone path (see `ThreeDLabels`), never present here.
+ *
+ * `overlayRotationFallback` mirrors `ThreeDLabels`' `cuboidOverlays` prop
+ * assembly: a label missing its own `rotation` field there ends up with the
+ * scene-level `overlayRotation` as its effective rotation (the JSX prop
+ * spread order means `overlay.rotation`, when present, overrides the
+ * `rotation={overlayRotation}` prop — but nothing overrides it when absent).
+ */
+export function resolveCuboidGeometry(
+  label: ReconciledDetection3D,
+  useLegacyCoordinates: boolean,
+  overlayRotationFallback: THREE.Vector3Tuple,
+): CuboidGeometry {
+  const dimensions = label.dimensions;
+  const [x, rawY, z] = label.location;
+  // See `useDisplayCuboidTransform` for why legacy-coordinate labels need a
+  // half-height offset here.
+  const y = useLegacyCoordinates ? rawY - 0.5 * dimensions[1] : rawY;
+
+  const quaternion = label.quaternion
+    ? new THREE.Quaternion(...label.quaternion)
+    : new THREE.Quaternion().setFromEuler(
+        new THREE.Euler(...(label.rotation ?? overlayRotationFallback)),
+      );
+
+  return { position: [x, y, z], dimensions, quaternion };
+}
+
+export function computeBodyMatrix(geometry: CuboidGeometry): THREE.Matrix4 {
+  return new THREE.Matrix4().compose(
+    new THREE.Vector3(...geometry.position),
+    geometry.quaternion,
+    new THREE.Vector3(...geometry.dimensions),
+  );
+}
+
+/**
+ * World-space edge endpoints for one box's outline, in the flat pairs format
+ * `LineSegmentsGeometry.setPositions()` expects (each consecutive 2 vertices
+ * = one edge). `EdgesGeometry` already emits exactly this shape.
+ */
+export function computeBoxEdgePositions(
+  geometry: CuboidGeometry,
+): Float32Array {
+  const box = new THREE.BoxGeometry(...geometry.dimensions);
+  box.applyQuaternion(geometry.quaternion);
+  box.translate(...geometry.position);
+  const edges = new THREE.EdgesGeometry(box);
+  const positions = new Float32Array(
+    edges.attributes.position.array as Float32Array,
+  );
+  box.dispose();
+  edges.dispose();
+  return positions;
+}
+
+const _localPoint = new THREE.Vector3();
+const _worldOffset = new THREE.Vector3();
+
+export function localToWorld(
+  local: THREE.Vector3Tuple | THREE.Vector3,
+  geometry: CuboidGeometry,
+): THREE.Vector3Tuple {
+  if (local instanceof THREE.Vector3) {
+    _localPoint.copy(local);
+  } else {
+    _localPoint.set(local[0], local[1], local[2]);
+  }
+  _worldOffset.set(...geometry.position);
+  _localPoint.applyQuaternion(geometry.quaternion).add(_worldOffset);
+  return [_localPoint.x, _localPoint.y, _localPoint.z];
+}
+
+/**
+ * Per-instance affine matrix for the merged arrowhead `InstancedMesh` (see
+ * `UNIT_ARROWHEAD_GEOMETRY`), derived from the same decomposed geometry the
+ * standalone `CuboidOrientationMarker` uses (`getCuboidOrientationMarkerGeometry`).
+ */
+export function computeArrowheadMatrix(
+  geometry: CuboidGeometry,
+  upVector: THREE.Vector3 | null,
+): THREE.Matrix4 {
+  const markerGeometry = getCuboidOrientationMarkerGeometry(
+    geometry.dimensions,
+    geometry.quaternion,
+    upVector,
+  );
+  if (!markerGeometry) {
+    return ZERO_SCALE_MATRIX.clone();
+  }
+
+  const { anchor, headLength, headHalfWidth, spreadAlongZ } = markerGeometry;
+  const localMatrix = new THREE.Matrix4().compose(
+    anchor,
+    spreadAlongZ ? SPREAD_TO_Z_QUATERNION : IDENTITY_QUATERNION,
+    new THREE.Vector3(headLength, headHalfWidth, headHalfWidth),
+  );
+  const boxMatrix = new THREE.Matrix4().compose(
+    new THREE.Vector3(...geometry.position),
+    geometry.quaternion,
+    UNIT_SCALE,
+  );
+  return boxMatrix.multiply(localMatrix);
+}
+
+export function segmentsPerBoxFor(showOrientation: boolean): number {
+  return (
+    EDGES_PER_BOX +
+    (showOrientation ? SHAFT_SEGMENTS_PER_BOX + AXES_SEGMENTS_PER_BOX : 0)
+  );
+}
+
+export const setSegmentColor = (
+  geometry: LineSegmentsGeometry,
+  segmentIndex: number,
+  color: THREE.Color,
+) => {
+  const start = geometry.attributes.instanceColorStart as
+    | THREE.InterleavedBufferAttribute
+    | undefined;
+  const end = geometry.attributes.instanceColorEnd as
+    | THREE.InterleavedBufferAttribute
+    | undefined;
+  start?.setXYZ(segmentIndex, color.r, color.g, color.b);
+  end?.setXYZ(segmentIndex, color.r, color.g, color.b);
+};

--- a/app/packages/looker-3d/src/labels/cuboid-instance-geometry.ts
+++ b/app/packages/looker-3d/src/labels/cuboid-instance-geometry.ts
@@ -24,9 +24,15 @@ UNIT_ARROWHEAD_GEOMETRY.setAttribute(
   "position",
   new THREE.Float32BufferAttribute(
     [
-      1, 0, 0, // apex
-      0, 1, 0, // base1
-      0, -1, 0, // base2
+      1,
+      0,
+      0, // apex
+      0,
+      1,
+      0, // base1
+      0,
+      -1,
+      0, // base2
     ],
     3,
   ),
@@ -160,11 +166,18 @@ export function computeArrowheadMatrix(
   return boxMatrix.multiply(localMatrix);
 }
 
-export function segmentsPerBoxFor(showOrientation: boolean): number {
-  return (
-    EDGES_PER_BOX +
-    (showOrientation ? SHAFT_SEGMENTS_PER_BOX + AXES_SEGMENTS_PER_BOX : 0)
-  );
+/**
+ * Segment count per box in the *orientation* buffer (shaft + 3 axes) — kept
+ * separate from `EDGES_PER_BOX` because edges and orientation markers now
+ * live in two different `LineSegmentsGeometry`/`LineMaterial` pairs (see
+ * `CuboidInstances`): edges need normal depth testing (they sit exactly on
+ * the box surface and rely on a render-order tie-break), while orientation
+ * markers need `depthTest: false` (their lines run from the box's *center*
+ * outward — since `ORIENTATION_AXES_LENGTH_RATIO < 1`, they never reach the
+ * surface, so normal depth testing would bury them inside the opaque body).
+ */
+export function orientationSegmentsPerBoxFor(showOrientation: boolean): number {
+  return showOrientation ? SHAFT_SEGMENTS_PER_BOX + AXES_SEGMENTS_PER_BOX : 0;
 }
 
 export const setSegmentColor = (

--- a/app/packages/looker-3d/src/labels/cuboid-instance-interaction.test.ts
+++ b/app/packages/looker-3d/src/labels/cuboid-instance-interaction.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import {
+  createHoverIndexTracker,
+  resolveLabelByInstanceId,
+} from "./cuboid-instance-interaction";
+
+describe("resolveLabelByInstanceId", () => {
+  const labelsByIndex = ["label-a", "label-b", "label-c"];
+
+  it("resolves the label at the given instance index", () => {
+    expect(resolveLabelByInstanceId(labelsByIndex, 1)).toBe("label-b");
+  });
+
+  it("returns null when instanceId is undefined (no instance under the pointer)", () => {
+    expect(resolveLabelByInstanceId(labelsByIndex, undefined)).toBeNull();
+  });
+
+  it("returns null for an out-of-range index instead of throwing", () => {
+    expect(resolveLabelByInstanceId(labelsByIndex, 99)).toBeNull();
+  });
+});
+
+describe("createHoverIndexTracker", () => {
+  it("returns the last hovered index on consume", () => {
+    const tracker = createHoverIndexTracker();
+    tracker.setHovered(2);
+    expect(tracker.consumeHovered()).toBe(2);
+  });
+
+  it("forgets the index after it's consumed once", () => {
+    const tracker = createHoverIndexTracker();
+    tracker.setHovered(2);
+    tracker.consumeHovered();
+    expect(tracker.consumeHovered()).toBeNull();
+  });
+
+  it("starts with no hovered index", () => {
+    const tracker = createHoverIndexTracker();
+    expect(tracker.consumeHovered()).toBeNull();
+  });
+
+  it("reflects the most recent setHovered call, overwriting any earlier index", () => {
+    const tracker = createHoverIndexTracker();
+    tracker.setHovered(0);
+    tracker.setHovered(5);
+    expect(tracker.consumeHovered()).toBe(5);
+  });
+
+  it("clears the tracked index when set to null (e.g. a guarded pointer-over that bails early)", () => {
+    const tracker = createHoverIndexTracker();
+    tracker.setHovered(3);
+    tracker.setHovered(null);
+    expect(tracker.consumeHovered()).toBeNull();
+  });
+});
+
+describe("resolveLabelByInstanceId + createHoverIndexTracker together", () => {
+  // Mirrors CuboidInstances' actual pointer-out path: r3f doesn't guarantee
+  // `instanceId` on pointer-out, so the outgoing label must come from the
+  // index recorded on the prior pointer-over, not from the pointer-out event.
+  it("resolves the correct label on pointer-out from the index recorded on pointer-over", () => {
+    const labelsByIndex = ["label-a", "label-b", "label-c"];
+    const tracker = createHoverIndexTracker();
+
+    // pointer-over instance 2
+    tracker.setHovered(2);
+
+    // pointer-out arrives with no instanceId of its own
+    const outIndex = tracker.consumeHovered();
+    const outLabel = resolveLabelByInstanceId(
+      labelsByIndex,
+      outIndex ?? undefined,
+    );
+
+    expect(outLabel).toBe("label-c");
+  });
+
+  it("resolves null on pointer-out when nothing was ever hovered", () => {
+    const labelsByIndex = ["label-a", "label-b", "label-c"];
+    const tracker = createHoverIndexTracker();
+
+    const outIndex = tracker.consumeHovered();
+    const outLabel = resolveLabelByInstanceId(
+      labelsByIndex,
+      outIndex ?? undefined,
+    );
+
+    expect(outLabel).toBeNull();
+  });
+});

--- a/app/packages/looker-3d/src/labels/cuboid-instance-interaction.ts
+++ b/app/packages/looker-3d/src/labels/cuboid-instance-interaction.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+/**
+ * instanceId -> label resolution for `CuboidInstances`' batched `InstancedMesh`.
+ * `instanceId` is r3f's raycast result index into whatever array backed the
+ * mesh at hit-test time; `undefined` means "no instance under the pointer".
+ */
+export function resolveLabelByInstanceId<T>(
+  labelsByIndex: readonly T[],
+  instanceId: number | undefined,
+): T | null {
+  return instanceId === undefined ? null : (labelsByIndex[instanceId] ?? null);
+}
+
+/**
+ * r3f doesn't guarantee `instanceId` on an `InstancedMesh`'s pointer-out
+ * event (the pointer has already left the instance the raycast last hit), so
+ * `CuboidInstances` tracks which instance is currently hovered itself and
+ * resolves the outgoing label from that on pointer-out instead of from the
+ * (possibly absent) event.
+ *
+ * Kept as a plain object rather than a React ref/hook: the only requirement
+ * is "remember the last set index until it's consumed once," which needs no
+ * React lifecycle of its own — the component owns one instance in a ref.
+ */
+export function createHoverIndexTracker() {
+  let hoveredIndex: number | null = null;
+  return {
+    /** Record the instance currently under the pointer (or `null` to clear). */
+    setHovered(index: number | null): void {
+      hoveredIndex = index;
+    },
+    /** Read-and-clear: returns the last hovered index, then forgets it. */
+    consumeHovered(): number | null {
+      const index = hoveredIndex;
+      hoveredIndex = null;
+      return index;
+    },
+  };
+}

--- a/app/packages/looker-3d/src/labels/cuboid.tsx
+++ b/app/packages/looker-3d/src/labels/cuboid.tsx
@@ -487,7 +487,7 @@ export const Cuboid = ({
     onPointerOver: onPointerOverForLabel,
     onPointerOut: onPointerOutForLabel,
     onPointerMove: onPointerMoveForLabel,
-    ...restEventHandlersBase
+    onPointerMissed,
   } = useEventHandlers();
 
   // `useEventHandlers()` takes the label as a call-time argument so it can be
@@ -502,13 +502,18 @@ export const Cuboid = ({
     () => onPointerOutForLabel(labelWoQuaternion),
     [onPointerOutForLabel, labelWoQuaternion],
   );
+  // Destructuring `onPointerMissed` directly (rather than rest-spreading the
+  // remainder of `useEventHandlers()`'s return value) keeps it a stable
+  // reference across renders, so this `useMemo` actually memoizes instead of
+  // rebuilding every render (a plain object rest-spread always allocates a
+  // new object, which would otherwise poison the dependency array below).
   const restEventHandlers = useMemo(
     () => ({
-      ...restEventHandlersBase,
+      onPointerMissed,
       onPointerMove: (e: ThreeEvent<PointerEvent>) =>
         onPointerMoveForLabel(labelWoQuaternion, e),
     }),
-    [restEventHandlersBase, onPointerMoveForLabel, labelWoQuaternion],
+    [onPointerMissed, onPointerMoveForLabel, labelWoQuaternion],
   );
 
   const { strokeAndFillColor, isSimilarLabelHovered } = useLabelColor(

--- a/app/packages/looker-3d/src/labels/cuboid.tsx
+++ b/app/packages/looker-3d/src/labels/cuboid.tsx
@@ -1,16 +1,10 @@
 import * as fos from "@fiftyone/state";
 import { Line, useCursor } from "@react-three/drei";
-import {
-  extend,
-  useFrame,
-  useThree,
-  type ThreeEvent,
-} from "@react-three/fiber";
+import { useFrame, useThree, type ThreeEvent } from "@react-three/fiber";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRecoilValue, useSetRecoilState } from "recoil";
 import * as THREE from "three";
 import { LineMaterial } from "three/examples/jsm/lines/LineMaterial";
-import { LineSegments2 } from "three/examples/jsm/lines/LineSegments2";
 import { LineSegmentsGeometry } from "three/examples/jsm/lines/LineSegmentsGeometry";
 import {
   CUBOID_RESIZE_FACES,
@@ -20,11 +14,9 @@ import {
   getCuboidResizeFaceAxis,
   getCuboidResizeFaceFromNormal,
   getCuboidResizeFaceWorldNormal,
-  getCuboidResizeQuaternion,
   isValidCuboidResizeDimensions,
   type CuboidResizeFace,
 } from "../annotation/cuboid-face-resize";
-import { useTransientCuboid } from "../annotation/store";
 import { useCuboidAnnotation } from "../annotation/useCuboidAnnotation";
 import { FO_USER_DATA, PANEL_ID_MAIN, getPanelElementId } from "../constants";
 import { useFo3dContext } from "../fo3d/context";
@@ -41,7 +33,6 @@ import {
 import { useSetCurrent3dAnnotationMode } from "../state/accessors";
 import {
   getComplementaryColor,
-  getCuboidForwardFaceBasePoint,
   getPlaneIntersection,
   toNDC,
   toNDCForElement,
@@ -49,10 +40,15 @@ import {
 import { getCameraVisibleWorldHeightAtPoint } from "../utils/side-panel-camera-sync";
 import type { HoveredLabelSource } from "../types";
 import type { OverlayProps } from "./shared";
+import {
+  CuboidAxesMarker,
+  CuboidOrientationMarker,
+  ORIENTATION_AXES_COLORS,
+} from "./shared/CuboidOrientationMarkers";
+import { useDisplayCuboidTransform } from "./shared/useDisplayCuboidTransform";
 import { useEventHandlers, useHoverState, useLabelColor } from "./shared/hooks";
+import "./shared/registerLineElements";
 import { Transformable } from "./shared/TransformControls";
-
-extend({ LineSegments2, LineMaterial, LineSegmentsGeometry });
 
 const FACE_RESIZE_EDGE_COLOR = "#ff2f2f";
 const FACE_RESIZE_HIGHLIGHT_OPACITY = 0.78;
@@ -100,20 +96,6 @@ const FACE_RESIZE_HANDLE_HOVER_SCALE = 1.3;
 const FACE_RESIZE_HANDLE_OPACITY = 0.5;
 const FACE_RESIZE_HANDLE_HOVER_OPACITY = 1;
 const FACE_RESIZE_HANDLE_SHAFT_RADIAL_SEGMENTS = 8;
-
-// RGB orientation axes drawn at the cuboid centroid when orientation is shown.
-// Each axis length is a fraction of its own half-extent so the tripod stays
-// inside the box and reflects its proportions (red = +X heading, green = +Y,
-// blue = +Z).
-const ORIENTATION_AXES_LENGTH_RATIO = 0.55;
-const ORIENTATION_AXES_MIN_LENGTH = 0.04;
-const ORIENTATION_AXES_LINE_WIDTH = 3;
-const ORIENTATION_AXES_OPACITY = 0.75;
-const ORIENTATION_AXES_COLORS = {
-  x: "#ff4136",
-  y: "#2ecc40",
-  z: "#1e90ff",
-} as const;
 
 // Indexed by axis (0 = x, 1 = y, 2 = z) so face-pull shafts can be tinted to
 // match the centroid RGB axes marker.
@@ -297,186 +279,6 @@ export interface CuboidProps extends OverlayProps {
   hoverSource?: HoveredLabelSource;
   showOrientation?: boolean;
 }
-
-interface CuboidOrientationMarkerProps {
-  dimensions: THREE.Vector3Tuple;
-  color: string;
-  orientation: THREE.Quaternion;
-  upVector?: THREE.Vector3 | null;
-}
-
-const getFiniteMagnitude = (value: number) =>
-  Number.isFinite(value) ? Math.abs(value) : 0;
-
-const getCuboidOrientationMarkerProps = (
-  dimensions: THREE.Vector3Tuple,
-  orientation: THREE.Quaternion,
-  upVector?: THREE.Vector3 | null,
-): {
-  shaftStart: THREE.Vector3Tuple;
-  shaftEnd: THREE.Vector3Tuple;
-  headVertices: [THREE.Vector3Tuple, THREE.Vector3Tuple, THREE.Vector3Tuple];
-} | null => {
-  const length = getFiniteMagnitude(dimensions[0]);
-
-  if (length <= 0) {
-    return null;
-  }
-
-  const basePoint = getCuboidForwardFaceBasePoint({
-    dimensions,
-    orientation,
-    upVector,
-  });
-
-  if (!basePoint) {
-    return null;
-  }
-
-  const localYExtent = getFiniteMagnitude(dimensions[1]);
-  const localZExtent = getFiniteMagnitude(dimensions[2]);
-  const faceX = length / 2;
-  const extensionLength = length * ORIENTATION_MARKER_EXTENSION_RATIO;
-  const headLength = Math.max(
-    Math.min(length * ORIENTATION_MARKER_HEAD_LENGTH_RATIO, extensionLength),
-    ORIENTATION_MARKER_MIN_HEAD_LENGTH,
-  );
-  const crossSection = Math.max(
-    Math.min(localYExtent, localZExtent),
-    length * ORIENTATION_MARKER_MIN_CROSS_SECTION_RATIO,
-  );
-  const headHalfWidth = Math.max(
-    Math.min(
-      headLength * ORIENTATION_MARKER_HEAD_WIDTH_RATIO,
-      crossSection * ORIENTATION_MARKER_HEAD_WIDTH_CROSS_CAP,
-    ),
-    ORIENTATION_MARKER_MIN_HEAD_WIDTH,
-  );
-
-  const shaftEndX = faceX + extensionLength;
-  const tipX = shaftEndX + headLength;
-  const { y: baseY, z: baseZ } = basePoint;
-
-  // The base point sits on the cuboid's lowest face, so its non-zero offset
-  // axis is the "up" axis. Lay the flat arrowhead in the perpendicular
-  // (horizontal) plane so it reads as a full triangle from a top-down view.
-  const spreadAlongZ = Math.abs(baseY) >= Math.abs(baseZ);
-
-  const apex: THREE.Vector3Tuple = [tipX, baseY, baseZ];
-  const base1: THREE.Vector3Tuple = spreadAlongZ
-    ? [shaftEndX, baseY, baseZ + headHalfWidth]
-    : [shaftEndX, baseY + headHalfWidth, baseZ];
-  const base2: THREE.Vector3Tuple = spreadAlongZ
-    ? [shaftEndX, baseY, baseZ - headHalfWidth]
-    : [shaftEndX, baseY - headHalfWidth, baseZ];
-
-  return {
-    shaftStart: basePoint.toArray() as THREE.Vector3Tuple,
-    shaftEnd: [shaftEndX, baseY, baseZ],
-    headVertices: [apex, base1, base2],
-  };
-};
-
-const CuboidOrientationMarker = ({
-  dimensions,
-  color,
-  orientation,
-  upVector,
-}: CuboidOrientationMarkerProps) => {
-  const markerProps = useMemo(
-    () => getCuboidOrientationMarkerProps(dimensions, orientation, upVector),
-    [dimensions, orientation, upVector],
-  );
-
-  const headGeometry = useMemo(() => {
-    if (!markerProps) {
-      return null;
-    }
-
-    const geometry = new THREE.BufferGeometry();
-    geometry.setAttribute(
-      "position",
-      new THREE.Float32BufferAttribute(markerProps.headVertices.flat(), 3),
-    );
-    return geometry;
-  }, [markerProps]);
-
-  // This effect disposes the arrowhead geometry when it is replaced or unmounts.
-  useEffect(() => {
-    return () => {
-      headGeometry?.dispose();
-    };
-  }, [headGeometry]);
-
-  if (!markerProps || !headGeometry) {
-    return null;
-  }
-
-  return (
-    <group userData={{ [FO_USER_DATA.IS_HELPER]: true }} renderOrder={3}>
-      <Line
-        points={[markerProps.shaftStart, markerProps.shaftEnd]}
-        color={color}
-        lineWidth={ORIENTATION_MARKER_LINE_WIDTH}
-        opacity={ORIENTATION_MARKER_OPACITY}
-        transparent
-        depthTest={false}
-        raycast={() => null}
-      />
-      <mesh geometry={headGeometry} renderOrder={3} raycast={() => null}>
-        <meshBasicMaterial
-          color={color}
-          transparent
-          opacity={ORIENTATION_MARKER_OPACITY}
-          side={THREE.DoubleSide}
-          depthTest={false}
-          depthWrite={false}
-        />
-      </mesh>
-    </group>
-  );
-};
-
-interface CuboidAxesMarkerProps {
-  dimensions: THREE.Vector3Tuple;
-}
-
-// Basic RGB axes drawn at the cuboid centroid. Rendered in the cuboid's local
-// frame (the parent group already carries its orientation), so the axes track
-// the box's heading: +X red, +Y green, +Z blue.
-const CuboidAxesMarker = ({ dimensions }: CuboidAxesMarkerProps) => {
-  const axes = useMemo(() => {
-    const half = (axis: 0 | 1 | 2) =>
-      Math.max(
-        (getFiniteMagnitude(dimensions[axis]) / 2) *
-          ORIENTATION_AXES_LENGTH_RATIO,
-        ORIENTATION_AXES_MIN_LENGTH,
-      );
-
-    return [
-      { color: ORIENTATION_AXES_COLORS.x, end: [half(0), 0, 0] },
-      { color: ORIENTATION_AXES_COLORS.y, end: [0, half(1), 0] },
-      { color: ORIENTATION_AXES_COLORS.z, end: [0, 0, half(2)] },
-    ] as { color: string; end: THREE.Vector3Tuple }[];
-  }, [dimensions]);
-
-  return (
-    <group userData={{ [FO_USER_DATA.IS_HELPER]: true }} renderOrder={3}>
-      {axes.map(({ color, end }) => (
-        <Line
-          key={color}
-          points={[[0, 0, 0], end] as THREE.Vector3Tuple[]}
-          color={color}
-          lineWidth={ORIENTATION_AXES_LINE_WIDTH}
-          opacity={ORIENTATION_AXES_OPACITY}
-          transparent
-          depthTest={false}
-          raycast={() => null}
-        />
-      ))}
-    </group>
-  );
-};
 
 interface CuboidFaceResizeHandleProps {
   face: CuboidResizeFace;
@@ -681,8 +483,33 @@ export const Cuboid = ({
     return rest;
   }, [label]);
 
-  const { onPointerOver, onPointerOut, ...restEventHandlers } =
-    useEventHandlers(labelWoQuaternion);
+  const {
+    onPointerOver: onPointerOverForLabel,
+    onPointerOut: onPointerOutForLabel,
+    onPointerMove: onPointerMoveForLabel,
+    ...restEventHandlersBase
+  } = useEventHandlers();
+
+  // `useEventHandlers()` takes the label as a call-time argument so it can be
+  // shared across an instanced batch; curry our own label once here so the
+  // rest of this component can call these exactly as before.
+  const onPointerOver = useCallback(
+    (e?: ThreeEvent<PointerEvent>) =>
+      onPointerOverForLabel(labelWoQuaternion, e),
+    [onPointerOverForLabel, labelWoQuaternion],
+  );
+  const onPointerOut = useCallback(
+    () => onPointerOutForLabel(labelWoQuaternion),
+    [onPointerOutForLabel, labelWoQuaternion],
+  );
+  const restEventHandlers = useMemo(
+    () => ({
+      ...restEventHandlersBase,
+      onPointerMove: (e: ThreeEvent<PointerEvent>) =>
+        onPointerMoveForLabel(labelWoQuaternion, e),
+    }),
+    [restEventHandlersBase, onPointerMoveForLabel, labelWoQuaternion],
+  );
 
   const { strokeAndFillColor, isSimilarLabelHovered } = useLabelColor(
     { selected, color },
@@ -727,78 +554,20 @@ export const Cuboid = ({
 
   const transformMode = useRecoilValue(transformModeAtom);
 
-  // Transient state for live drag preview
-  const transientState = useTransientCuboid(label._id);
-
-  // Compute display dimensions: apply transient delta if present
-  const displayDimensions = useMemo(() => {
-    if (transientState?.dimensionsDelta) {
-      return [
-        effectiveDimensions[0] + transientState.dimensionsDelta[0],
-        effectiveDimensions[1] + transientState.dimensionsDelta[1],
-        effectiveDimensions[2] + transientState.dimensionsDelta[2],
-      ] as THREE.Vector3Tuple;
-    }
-    return effectiveDimensions;
-  }, [effectiveDimensions, transientState?.dimensionsDelta]);
-
-  // Compute display position: apply transient delta if present
-  const displayPosition = useMemo(() => {
-    const [x, rawY, z] = effectiveLocation;
-
-    // In legacy coordinate system, location was stored as the top-center of the cuboid
-    // (half-height above the geometric center), so we adjust Y downward by half the height
-    // to position the cuboid correctly. In the new coordinate system, location is stored
-    // as the geometric center, matching Three.js BoxGeometry's center, so no adjustment is needed.
-    const y = useLegacyCoordinates ? rawY - 0.5 * displayDimensions[1] : rawY;
-
-    if (transientState?.positionDelta) {
-      return [
-        x + transientState.positionDelta[0],
-        y + transientState.positionDelta[1],
-        z + transientState.positionDelta[2],
-      ] as THREE.Vector3Tuple;
-    }
-    return [x, y, z] as const;
-  }, [
-    effectiveLocation,
+  const {
     displayDimensions,
+    displayPosition,
+    combinedQuaternion,
+    fallbackEuler,
+    orientationQuaternion,
+  } = useDisplayCuboidTransform({
+    labelId: label._id,
+    effectiveLocation,
+    effectiveDimensions,
+    effectiveRotation: effectiveRotation as THREE.Vector3Tuple,
+    effectiveQuaternion,
     useLegacyCoordinates,
-    transientState?.positionDelta,
-  ]);
-
-  // When quaternion is present (transient or working), use it directly to avoid euler conversion issues
-  // (gimbal lock, precision loss). We convert to euler only on final save.
-  // Priority: transientState.quaternionOverride > effectiveQuaternion (working) > euler fallback
-  const combinedQuaternion = useMemo(() => {
-    // During active rotation, prefer transient quaternion override
-    if (transformMode === "rotate" && transientState?.quaternionOverride) {
-      return new THREE.Quaternion(...transientState.quaternionOverride);
-    }
-    // Otherwise use effective (working) quaternion if available
-    if (effectiveQuaternion) {
-      return new THREE.Quaternion(...effectiveQuaternion);
-    }
-    return null;
-  }, [transientState?.quaternionOverride, effectiveQuaternion, transformMode]);
-
-  // Fallback to euler-based rotation when no quaternion available
-  const fallbackEuler = useMemo(() => {
-    if (combinedQuaternion) {
-      return undefined;
-    }
-    return new THREE.Euler(...(effectiveRotation as THREE.Vector3Tuple));
-  }, [combinedQuaternion, effectiveRotation]);
-
-  const orientationQuaternion = useMemo(() => {
-    if (combinedQuaternion) {
-      return combinedQuaternion.clone();
-    }
-
-    return getCuboidResizeQuaternion({
-      rotation: effectiveRotation as THREE.Vector3Tuple,
-    });
-  }, [combinedQuaternion, effectiveRotation]);
+  });
 
   const isFaceResizeControlActive =
     Boolean(hoveredResizeFace) || isFaceResizeDragging;

--- a/app/packages/looker-3d/src/labels/index.tsx
+++ b/app/packages/looker-3d/src/labels/index.tsx
@@ -39,6 +39,7 @@ import { isDetection3dOverlay, isPolyline3dOverlay } from "../types";
 import type { Archetype3d, PanelId } from "../types";
 import { toEulerFromDegreesArray } from "../utils";
 import { Cuboid, type CuboidProps } from "./cuboid";
+import { CuboidInstances } from "./CuboidInstances";
 import { DragGate3D } from "./DragGate3D";
 import { type OverlayLabel, load3dOverlays } from "./loader";
 import { type PolyLineProps, Polyline } from "./polyline";
@@ -342,10 +343,31 @@ export const ThreeDLabels = ({
     [effectiveUnfocusedLabelOpacity, focusedLabelIds, labelAlpha],
   );
 
-  // Detections render model -> JSX
+  // The single label actively being edited (if any) keeps its full
+  // interactive standalone path (TransformControls, face-resize handles,
+  // orientation markers) unchanged; every other label renders through the
+  // batched CuboidInstances path. Both arrays derive from the same
+  // detectionsToRender read in the same render, so a box popping between the
+  // two paths lands at the identical transform in the same commit — no
+  // flicker or jump (see the looker3dInstanceMesh plan, §7).
+  const editedLabelId = selectedLabelForAnnotation?._id;
+  const { standaloneDetections, instancedDetections } = useMemo(() => {
+    if (!editedLabelId) {
+      return { standaloneDetections: [], instancedDetections: detectionsToRender };
+    }
+
+    const standalone: ReconciledDetection3D[] = [];
+    const instanced: ReconciledDetection3D[] = [];
+    for (const overlay of detectionsToRender) {
+      (overlay._id === editedLabelId ? standalone : instanced).push(overlay);
+    }
+    return { standaloneDetections: standalone, instancedDetections: instanced };
+  }, [detectionsToRender, editedLabelId]);
+
+  // Detections render model -> JSX (standalone / actively-edited path)
   const cuboidOverlays = useMemo(
     () =>
-      detectionsToRender.map((overlay) => {
+      standaloneDetections.map((overlay) => {
         // ReconciledDetection3D omits OverlayLabel["selected"], so its
         // `selected` is typed `unknown` via the index signature; restoring it
         // is the single narrowing needed to treat the overlay as OverlayLabel.
@@ -375,7 +397,7 @@ export const ThreeDLabels = ({
         );
       }),
     [
-      detectionsToRender,
+      standaloneDetections,
       cuboidLineWidth,
       overlayRotation,
       itemRotation,
@@ -387,6 +409,38 @@ export const ThreeDLabels = ({
       showCuboidOrientation,
     ],
   );
+
+  // Batched (non-edited) cuboids. `InstancedMesh`'s instanceColor is RGB
+  // only — there's no per-instance alpha — so the whole batch shares one
+  // opacity value: full (labelAlpha) unless dimming is active anywhere,
+  // matching the "at most two live opacity values, focused label always
+  // popped out" reasoning in the plan's §6 (a hover on a *different*,
+  // non-edited label while dimming is active is the one accepted edge case
+  // that can't be represented — that label dims along with the rest).
+  const instancedOpacity = focusedLabelIds
+    ? (effectiveUnfocusedLabelOpacity ?? labelAlpha)
+    : labelAlpha;
+
+  const cuboidInstances =
+    instancedDetections.length > 0 ? (
+      <CuboidInstances
+        detections={instancedDetections}
+        getColor={getOverlayColor}
+        opacity={instancedOpacity}
+        lineWidth={cuboidLineWidth}
+        useLegacyCoordinates={settings.useLegacyCoordinates}
+        overlayRotationFallback={overlayRotation}
+        hoverSource={hoverSource}
+        showOrientation={showCuboidOrientation}
+        onClick={(label, e) =>
+          handleSelect(
+            label as ReconciledDetection3D & { selected: boolean },
+            ANNOTATION_CUBOID,
+            e,
+          )
+        }
+      />
+    ) : null;
 
   // Polylines render model -> JSX
   const polylineOverlays = useMemo(() => {
@@ -442,7 +496,10 @@ export const ThreeDLabels = ({
   return (
     <group>
       {workingStoreManager}
-      <mesh rotation={overlayRotation}>{cuboidOverlays}</mesh>
+      <mesh rotation={overlayRotation}>
+        {cuboidOverlays}
+        {cuboidInstances}
+      </mesh>
       {polylineOverlays}
     </group>
   );

--- a/app/packages/looker-3d/src/labels/index.tsx
+++ b/app/packages/looker-3d/src/labels/index.tsx
@@ -42,6 +42,7 @@ import { Cuboid, type CuboidProps } from "./cuboid";
 import { CuboidInstances } from "./CuboidInstances";
 import { DragGate3D } from "./DragGate3D";
 import { type OverlayLabel, load3dOverlays } from "./loader";
+import { partitionCuboidsByEditedLabel } from "./partition-cuboids";
 import { type PolyLineProps, Polyline } from "./polyline";
 import { WorkingStoreManager } from "./WorkingStoreManager";
 
@@ -351,21 +352,10 @@ export const ThreeDLabels = ({
   // two paths lands at the identical transform in the same commit — no
   // flicker or jump (see the looker3dInstanceMesh plan, §7).
   const editedLabelId = selectedLabelForAnnotation?._id;
-  const { standaloneDetections, instancedDetections } = useMemo(() => {
-    if (!editedLabelId) {
-      return {
-        standaloneDetections: [],
-        instancedDetections: detectionsToRender,
-      };
-    }
-
-    const standalone: ReconciledDetection3D[] = [];
-    const instanced: ReconciledDetection3D[] = [];
-    for (const overlay of detectionsToRender) {
-      (overlay._id === editedLabelId ? standalone : instanced).push(overlay);
-    }
-    return { standaloneDetections: standalone, instancedDetections: instanced };
-  }, [detectionsToRender, editedLabelId]);
+  const { standaloneDetections, instancedDetections } = useMemo(
+    () => partitionCuboidsByEditedLabel(detectionsToRender, editedLabelId),
+    [detectionsToRender, editedLabelId],
+  );
 
   // Detections render model -> JSX (standalone / actively-edited path)
   const cuboidOverlays = useMemo(

--- a/app/packages/looker-3d/src/labels/index.tsx
+++ b/app/packages/looker-3d/src/labels/index.tsx
@@ -353,7 +353,10 @@ export const ThreeDLabels = ({
   const editedLabelId = selectedLabelForAnnotation?._id;
   const { standaloneDetections, instancedDetections } = useMemo(() => {
     if (!editedLabelId) {
-      return { standaloneDetections: [], instancedDetections: detectionsToRender };
+      return {
+        standaloneDetections: [],
+        instancedDetections: detectionsToRender,
+      };
     }
 
     const standalone: ReconciledDetection3D[] = [];

--- a/app/packages/looker-3d/src/labels/partition-cuboids.test.ts
+++ b/app/packages/looker-3d/src/labels/partition-cuboids.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { partitionCuboidsByEditedLabel } from "./partition-cuboids";
+
+function overlay(id: string) {
+  return { _id: id };
+}
+
+describe("partitionCuboidsByEditedLabel", () => {
+  it("puts everything in instancedDetections when nothing is being edited", () => {
+    const detections = [overlay("a"), overlay("b"), overlay("c")];
+
+    const { standaloneDetections, instancedDetections } =
+      partitionCuboidsByEditedLabel(detections, undefined);
+
+    expect(standaloneDetections).toEqual([]);
+    expect(instancedDetections).toEqual(detections);
+  });
+
+  it("moves only the edited label into standaloneDetections", () => {
+    const a = overlay("a");
+    const b = overlay("b");
+    const c = overlay("c");
+
+    const { standaloneDetections, instancedDetections } =
+      partitionCuboidsByEditedLabel([a, b, c], "b");
+
+    expect(standaloneDetections).toEqual([b]);
+    expect(instancedDetections).toEqual([a, c]);
+  });
+
+  it("preserves the relative order of the batched labels", () => {
+    const detections = [overlay("a"), overlay("b"), overlay("c"), overlay("d")];
+
+    const { instancedDetections } = partitionCuboidsByEditedLabel(
+      detections,
+      "c",
+    );
+
+    expect(instancedDetections.map((d) => d._id)).toEqual(["a", "b", "d"]);
+  });
+
+  it("falls back to instancedDetections-only when the edited id isn't present", () => {
+    const detections = [overlay("a"), overlay("b")];
+
+    const { standaloneDetections, instancedDetections } =
+      partitionCuboidsByEditedLabel(detections, "does-not-exist");
+
+    expect(standaloneDetections).toEqual([]);
+    expect(instancedDetections).toEqual(detections);
+  });
+
+  it("returns a new instancedDetections array rather than the input reference", () => {
+    const detections = [overlay("a")];
+
+    const { instancedDetections } = partitionCuboidsByEditedLabel(
+      detections,
+      undefined,
+    );
+
+    expect(instancedDetections).not.toBe(detections);
+    expect(instancedDetections).toEqual(detections);
+  });
+
+  it("handles an empty input", () => {
+    expect(partitionCuboidsByEditedLabel([], "a")).toEqual({
+      standaloneDetections: [],
+      instancedDetections: [],
+    });
+  });
+});

--- a/app/packages/looker-3d/src/labels/partition-cuboids.ts
+++ b/app/packages/looker-3d/src/labels/partition-cuboids.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+/**
+ * Splits cuboid detections into the single actively-edited ("hero") label,
+ * if any, and every other ("batched") label — see the looker3dInstanceMesh
+ * plan, §7. The edited label keeps its full interactive standalone path
+ * (TransformControls, face-resize handles, orientation markers); everything
+ * else renders through the batched `CuboidInstances` path. Both arrays are
+ * derived from the same input list in one pass, so a box popping between the
+ * two paths lands at the identical transform in the same commit — no
+ * flicker or jump.
+ */
+export function partitionCuboidsByEditedLabel<T extends { _id: string }>(
+  detections: readonly T[],
+  editedLabelId: string | undefined,
+): { standaloneDetections: T[]; instancedDetections: T[] } {
+  if (!editedLabelId) {
+    return { standaloneDetections: [], instancedDetections: [...detections] };
+  }
+
+  const standalone: T[] = [];
+  const instanced: T[] = [];
+  for (const overlay of detections) {
+    (overlay._id === editedLabelId ? standalone : instanced).push(overlay);
+  }
+  return { standaloneDetections: standalone, instancedDetections: instanced };
+}

--- a/app/packages/looker-3d/src/labels/polyline.tsx
+++ b/app/packages/looker-3d/src/labels/polyline.tsx
@@ -1,6 +1,7 @@
 import * as fos from "@fiftyone/state";
 import { Line as LineDrei } from "@react-three/drei";
-import { useEffect, useMemo, useRef } from "react";
+import type { ThreeEvent } from "@react-three/fiber";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useRecoilValue, useSetRecoilState } from "recoil";
 import * as THREE from "three";
 import { useTransientPolyline } from "../annotation/store";
@@ -46,8 +47,32 @@ export const Polyline = ({
   useHoverState();
   const hoveredLabel = useRecoilValue(hoveredLabelAtom);
   const setHoveredLabel = useSetRecoilState(hoveredLabelAtom);
-  const { onPointerOver, onPointerOut, ...restEventHandlers } =
-    useEventHandlers(label);
+  const {
+    onPointerOver: onPointerOverForLabel,
+    onPointerOut: onPointerOutForLabel,
+    onPointerMove: onPointerMoveForLabel,
+    ...restEventHandlersBase
+  } = useEventHandlers();
+
+  // `useEventHandlers()` takes the label as a call-time argument so it can be
+  // shared across an instanced batch; curry our own label once here so the
+  // rest of this component can call these exactly as before.
+  const onPointerOver = useCallback(
+    (e?: ThreeEvent<PointerEvent>) => onPointerOverForLabel(label, e),
+    [onPointerOverForLabel, label],
+  );
+  const onPointerOut = useCallback(
+    () => onPointerOutForLabel(label),
+    [onPointerOutForLabel, label],
+  );
+  const restEventHandlers = useMemo(
+    () => ({
+      ...restEventHandlersBase,
+      onPointerMove: (e: ThreeEvent<PointerEvent>) =>
+        onPointerMoveForLabel(label, e),
+    }),
+    [restEventHandlersBase, onPointerMoveForLabel, label],
+  );
 
   const isHovered = hoveredLabel?.id === label._id;
 

--- a/app/packages/looker-3d/src/labels/polyline.tsx
+++ b/app/packages/looker-3d/src/labels/polyline.tsx
@@ -51,7 +51,7 @@ export const Polyline = ({
     onPointerOver: onPointerOverForLabel,
     onPointerOut: onPointerOutForLabel,
     onPointerMove: onPointerMoveForLabel,
-    ...restEventHandlersBase
+    onPointerMissed,
   } = useEventHandlers();
 
   // `useEventHandlers()` takes the label as a call-time argument so it can be
@@ -65,13 +65,18 @@ export const Polyline = ({
     () => onPointerOutForLabel(label),
     [onPointerOutForLabel, label],
   );
+  // Destructuring `onPointerMissed` directly (rather than rest-spreading the
+  // remainder of `useEventHandlers()`'s return value) keeps it a stable
+  // reference across renders, so this `useMemo` actually memoizes instead of
+  // rebuilding every render (a plain object rest-spread always allocates a
+  // new object, which would otherwise poison the dependency array below).
   const restEventHandlers = useMemo(
     () => ({
-      ...restEventHandlersBase,
+      onPointerMissed,
       onPointerMove: (e: ThreeEvent<PointerEvent>) =>
         onPointerMoveForLabel(label, e),
     }),
-    [restEventHandlersBase, onPointerMoveForLabel, label],
+    [onPointerMissed, onPointerMoveForLabel, label],
   );
 
   const isHovered = hoveredLabel?.id === label._id;

--- a/app/packages/looker-3d/src/labels/shared/CuboidOrientationMarkers.tsx
+++ b/app/packages/looker-3d/src/labels/shared/CuboidOrientationMarkers.tsx
@@ -1,0 +1,259 @@
+import { Line } from "@react-three/drei";
+import { useEffect, useMemo } from "react";
+import * as THREE from "three";
+import { FO_USER_DATA } from "../../constants";
+import { getCuboidForwardFaceBasePoint } from "../../utils";
+
+const ORIENTATION_MARKER_LINE_WIDTH = 4;
+const ORIENTATION_MARKER_OPACITY = 0.95;
+// Flat triangular arrowhead, sized relative to the cuboid's heading length.
+const ORIENTATION_MARKER_EXTENSION_RATIO = 0.3;
+const ORIENTATION_MARKER_HEAD_LENGTH_RATIO = 0.16;
+const ORIENTATION_MARKER_MIN_HEAD_LENGTH = 0.08;
+const ORIENTATION_MARKER_MIN_CROSS_SECTION_RATIO = 0.1;
+// Half-width of the arrowhead base, as a fraction of its length and capped
+// against the cuboid's smaller cross-section so it never overhangs the box.
+const ORIENTATION_MARKER_HEAD_WIDTH_RATIO = 0.7;
+const ORIENTATION_MARKER_HEAD_WIDTH_CROSS_CAP = 0.4;
+const ORIENTATION_MARKER_MIN_HEAD_WIDTH = 0.03;
+
+// RGB orientation axes drawn at the cuboid centroid when orientation is shown.
+// Each axis length is a fraction of its own half-extent so the tripod stays
+// inside the box and reflects its proportions (red = +X heading, green = +Y,
+// blue = +Z).
+export const ORIENTATION_AXES_LENGTH_RATIO = 0.55;
+export const ORIENTATION_AXES_MIN_LENGTH = 0.04;
+const ORIENTATION_AXES_LINE_WIDTH = 3;
+const ORIENTATION_AXES_OPACITY = 0.75;
+export const ORIENTATION_AXES_COLORS = {
+  x: "#ff4136",
+  y: "#2ecc40",
+  z: "#1e90ff",
+} as const;
+
+export const getFiniteMagnitude = (value: number) =>
+  Number.isFinite(value) ? Math.abs(value) : 0;
+
+/**
+ * Decomposed (pre-composition) form of the orientation arrow's geometry, in
+ * the cuboid's local frame. `CuboidInstances` uses this directly to build a
+ * per-instance affine matrix (translate to `anchor`, optionally rotate 90°
+ * about local X when `spreadAlongZ`, then scale a canonical unit triangle by
+ * `(headLength, headHalfWidth, headHalfWidth)`) instead of computing final
+ * world-space triangle vertices per box.
+ */
+export interface CuboidOrientationMarkerGeometry {
+  /** Local-space anchor at the shaft's end / arrowhead base center. */
+  anchor: THREE.Vector3;
+  /** Local-space point where the shaft begins (on the cuboid's forward face). */
+  shaftStart: THREE.Vector3Tuple;
+  headLength: number;
+  headHalfWidth: number;
+  /** True when the arrowhead's base spreads along local Z rather than local Y. */
+  spreadAlongZ: boolean;
+}
+
+export const getCuboidOrientationMarkerGeometry = (
+  dimensions: THREE.Vector3Tuple,
+  orientation: THREE.Quaternion,
+  upVector?: THREE.Vector3 | null,
+): CuboidOrientationMarkerGeometry | null => {
+  const length = getFiniteMagnitude(dimensions[0]);
+
+  if (length <= 0) {
+    return null;
+  }
+
+  const basePoint = getCuboidForwardFaceBasePoint({
+    dimensions,
+    orientation,
+    upVector,
+  });
+
+  if (!basePoint) {
+    return null;
+  }
+
+  const localYExtent = getFiniteMagnitude(dimensions[1]);
+  const localZExtent = getFiniteMagnitude(dimensions[2]);
+  const extensionLength = length * ORIENTATION_MARKER_EXTENSION_RATIO;
+  const headLength = Math.max(
+    Math.min(length * ORIENTATION_MARKER_HEAD_LENGTH_RATIO, extensionLength),
+    ORIENTATION_MARKER_MIN_HEAD_LENGTH,
+  );
+  const crossSection = Math.max(
+    Math.min(localYExtent, localZExtent),
+    length * ORIENTATION_MARKER_MIN_CROSS_SECTION_RATIO,
+  );
+  const headHalfWidth = Math.max(
+    Math.min(
+      headLength * ORIENTATION_MARKER_HEAD_WIDTH_RATIO,
+      crossSection * ORIENTATION_MARKER_HEAD_WIDTH_CROSS_CAP,
+    ),
+    ORIENTATION_MARKER_MIN_HEAD_WIDTH,
+  );
+
+  const shaftEndX = basePoint.x + extensionLength;
+  const { y: baseY, z: baseZ } = basePoint;
+
+  // The base point sits on the cuboid's lowest face, so its non-zero offset
+  // axis is the "up" axis. Lay the flat arrowhead in the perpendicular
+  // (horizontal) plane so it reads as a full triangle from a top-down view.
+  const spreadAlongZ = Math.abs(baseY) >= Math.abs(baseZ);
+
+  return {
+    anchor: new THREE.Vector3(shaftEndX, baseY, baseZ),
+    shaftStart: basePoint.toArray() as THREE.Vector3Tuple,
+    headLength,
+    headHalfWidth,
+    spreadAlongZ,
+  };
+};
+
+const getCuboidOrientationMarkerProps = (
+  dimensions: THREE.Vector3Tuple,
+  orientation: THREE.Quaternion,
+  upVector?: THREE.Vector3 | null,
+): {
+  shaftStart: THREE.Vector3Tuple;
+  shaftEnd: THREE.Vector3Tuple;
+  headVertices: [THREE.Vector3Tuple, THREE.Vector3Tuple, THREE.Vector3Tuple];
+} | null => {
+  const geometry = getCuboidOrientationMarkerGeometry(
+    dimensions,
+    orientation,
+    upVector,
+  );
+
+  if (!geometry) {
+    return null;
+  }
+
+  const { anchor, shaftStart, headLength, headHalfWidth, spreadAlongZ } =
+    geometry;
+  const shaftEndX = anchor.x;
+  const tipX = shaftEndX + headLength;
+  const { y: baseY, z: baseZ } = anchor;
+
+  const apex: THREE.Vector3Tuple = [tipX, baseY, baseZ];
+  const base1: THREE.Vector3Tuple = spreadAlongZ
+    ? [shaftEndX, baseY, baseZ + headHalfWidth]
+    : [shaftEndX, baseY + headHalfWidth, baseZ];
+  const base2: THREE.Vector3Tuple = spreadAlongZ
+    ? [shaftEndX, baseY, baseZ - headHalfWidth]
+    : [shaftEndX, baseY - headHalfWidth, baseZ];
+
+  return {
+    shaftStart,
+    shaftEnd: [shaftEndX, baseY, baseZ],
+    headVertices: [apex, base1, base2],
+  };
+};
+
+export interface CuboidOrientationMarkerProps {
+  dimensions: THREE.Vector3Tuple;
+  color: string;
+  orientation: THREE.Quaternion;
+  upVector?: THREE.Vector3 | null;
+}
+
+export const CuboidOrientationMarker = ({
+  dimensions,
+  color,
+  orientation,
+  upVector,
+}: CuboidOrientationMarkerProps) => {
+  const markerProps = useMemo(
+    () => getCuboidOrientationMarkerProps(dimensions, orientation, upVector),
+    [dimensions, orientation, upVector],
+  );
+
+  const headGeometry = useMemo(() => {
+    if (!markerProps) {
+      return null;
+    }
+
+    const geometry = new THREE.BufferGeometry();
+    geometry.setAttribute(
+      "position",
+      new THREE.Float32BufferAttribute(markerProps.headVertices.flat(), 3),
+    );
+    return geometry;
+  }, [markerProps]);
+
+  // This effect disposes the arrowhead geometry when it is replaced or unmounts.
+  useEffect(() => {
+    return () => {
+      headGeometry?.dispose();
+    };
+  }, [headGeometry]);
+
+  if (!markerProps || !headGeometry) {
+    return null;
+  }
+
+  return (
+    <group userData={{ [FO_USER_DATA.IS_HELPER]: true }} renderOrder={3}>
+      <Line
+        points={[markerProps.shaftStart, markerProps.shaftEnd]}
+        color={color}
+        lineWidth={ORIENTATION_MARKER_LINE_WIDTH}
+        opacity={ORIENTATION_MARKER_OPACITY}
+        transparent
+        depthTest={false}
+        raycast={() => null}
+      />
+      <mesh geometry={headGeometry} renderOrder={3} raycast={() => null}>
+        <meshBasicMaterial
+          color={color}
+          transparent
+          opacity={ORIENTATION_MARKER_OPACITY}
+          side={THREE.DoubleSide}
+          depthTest={false}
+          depthWrite={false}
+        />
+      </mesh>
+    </group>
+  );
+};
+
+export interface CuboidAxesMarkerProps {
+  dimensions: THREE.Vector3Tuple;
+}
+
+// Basic RGB axes drawn at the cuboid centroid. Rendered in the cuboid's local
+// frame (the parent group already carries its orientation), so the axes track
+// the box's heading: +X red, +Y green, +Z blue.
+export const CuboidAxesMarker = ({ dimensions }: CuboidAxesMarkerProps) => {
+  const axes = useMemo(() => {
+    const half = (axis: 0 | 1 | 2) =>
+      Math.max(
+        (getFiniteMagnitude(dimensions[axis]) / 2) *
+          ORIENTATION_AXES_LENGTH_RATIO,
+        ORIENTATION_AXES_MIN_LENGTH,
+      );
+
+    return [
+      { color: ORIENTATION_AXES_COLORS.x, end: [half(0), 0, 0] },
+      { color: ORIENTATION_AXES_COLORS.y, end: [0, half(1), 0] },
+      { color: ORIENTATION_AXES_COLORS.z, end: [0, 0, half(2)] },
+    ] as { color: string; end: THREE.Vector3Tuple }[];
+  }, [dimensions]);
+
+  return (
+    <group userData={{ [FO_USER_DATA.IS_HELPER]: true }} renderOrder={3}>
+      {axes.map(({ color, end }) => (
+        <Line
+          key={color}
+          points={[[0, 0, 0], end] as THREE.Vector3Tuple[]}
+          color={color}
+          lineWidth={ORIENTATION_AXES_LINE_WIDTH}
+          opacity={ORIENTATION_AXES_OPACITY}
+          transparent
+          depthTest={false}
+          raycast={() => null}
+        />
+      ))}
+    </group>
+  );
+};

--- a/app/packages/looker-3d/src/labels/shared/CuboidOrientationMarkers.tsx
+++ b/app/packages/looker-3d/src/labels/shared/CuboidOrientationMarkers.tsx
@@ -2,153 +2,27 @@ import { Line } from "@react-three/drei";
 import { useEffect, useMemo } from "react";
 import * as THREE from "three";
 import { FO_USER_DATA } from "../../constants";
-import { getCuboidForwardFaceBasePoint } from "../../utils";
+import {
+  ORIENTATION_AXES_COLORS,
+  ORIENTATION_AXES_LENGTH_RATIO,
+  ORIENTATION_AXES_MIN_LENGTH,
+  getCuboidOrientationMarkerProps,
+  getFiniteMagnitude,
+} from "./cuboid-orientation-geometry";
+
+export {
+  ORIENTATION_AXES_COLORS,
+  ORIENTATION_AXES_LENGTH_RATIO,
+  ORIENTATION_AXES_MIN_LENGTH,
+  getCuboidOrientationMarkerGeometry,
+  getFiniteMagnitude,
+  type CuboidOrientationMarkerGeometry,
+} from "./cuboid-orientation-geometry";
 
 const ORIENTATION_MARKER_LINE_WIDTH = 4;
 const ORIENTATION_MARKER_OPACITY = 0.95;
-// Flat triangular arrowhead, sized relative to the cuboid's heading length.
-const ORIENTATION_MARKER_EXTENSION_RATIO = 0.3;
-const ORIENTATION_MARKER_HEAD_LENGTH_RATIO = 0.16;
-const ORIENTATION_MARKER_MIN_HEAD_LENGTH = 0.08;
-const ORIENTATION_MARKER_MIN_CROSS_SECTION_RATIO = 0.1;
-// Half-width of the arrowhead base, as a fraction of its length and capped
-// against the cuboid's smaller cross-section so it never overhangs the box.
-const ORIENTATION_MARKER_HEAD_WIDTH_RATIO = 0.7;
-const ORIENTATION_MARKER_HEAD_WIDTH_CROSS_CAP = 0.4;
-const ORIENTATION_MARKER_MIN_HEAD_WIDTH = 0.03;
-
-// RGB orientation axes drawn at the cuboid centroid when orientation is shown.
-// Each axis length is a fraction of its own half-extent so the tripod stays
-// inside the box and reflects its proportions (red = +X heading, green = +Y,
-// blue = +Z).
-export const ORIENTATION_AXES_LENGTH_RATIO = 0.55;
-export const ORIENTATION_AXES_MIN_LENGTH = 0.04;
 const ORIENTATION_AXES_LINE_WIDTH = 3;
 const ORIENTATION_AXES_OPACITY = 0.75;
-export const ORIENTATION_AXES_COLORS = {
-  x: "#ff4136",
-  y: "#2ecc40",
-  z: "#1e90ff",
-} as const;
-
-export const getFiniteMagnitude = (value: number) =>
-  Number.isFinite(value) ? Math.abs(value) : 0;
-
-/**
- * Decomposed (pre-composition) form of the orientation arrow's geometry, in
- * the cuboid's local frame. `CuboidInstances` uses this directly to build a
- * per-instance affine matrix (translate to `anchor`, optionally rotate 90°
- * about local X when `spreadAlongZ`, then scale a canonical unit triangle by
- * `(headLength, headHalfWidth, headHalfWidth)`) instead of computing final
- * world-space triangle vertices per box.
- */
-export interface CuboidOrientationMarkerGeometry {
-  /** Local-space anchor at the shaft's end / arrowhead base center. */
-  anchor: THREE.Vector3;
-  /** Local-space point where the shaft begins (on the cuboid's forward face). */
-  shaftStart: THREE.Vector3Tuple;
-  headLength: number;
-  headHalfWidth: number;
-  /** True when the arrowhead's base spreads along local Z rather than local Y. */
-  spreadAlongZ: boolean;
-}
-
-export const getCuboidOrientationMarkerGeometry = (
-  dimensions: THREE.Vector3Tuple,
-  orientation: THREE.Quaternion,
-  upVector?: THREE.Vector3 | null,
-): CuboidOrientationMarkerGeometry | null => {
-  const length = getFiniteMagnitude(dimensions[0]);
-
-  if (length <= 0) {
-    return null;
-  }
-
-  const basePoint = getCuboidForwardFaceBasePoint({
-    dimensions,
-    orientation,
-    upVector,
-  });
-
-  if (!basePoint) {
-    return null;
-  }
-
-  const localYExtent = getFiniteMagnitude(dimensions[1]);
-  const localZExtent = getFiniteMagnitude(dimensions[2]);
-  const extensionLength = length * ORIENTATION_MARKER_EXTENSION_RATIO;
-  const headLength = Math.max(
-    Math.min(length * ORIENTATION_MARKER_HEAD_LENGTH_RATIO, extensionLength),
-    ORIENTATION_MARKER_MIN_HEAD_LENGTH,
-  );
-  const crossSection = Math.max(
-    Math.min(localYExtent, localZExtent),
-    length * ORIENTATION_MARKER_MIN_CROSS_SECTION_RATIO,
-  );
-  const headHalfWidth = Math.max(
-    Math.min(
-      headLength * ORIENTATION_MARKER_HEAD_WIDTH_RATIO,
-      crossSection * ORIENTATION_MARKER_HEAD_WIDTH_CROSS_CAP,
-    ),
-    ORIENTATION_MARKER_MIN_HEAD_WIDTH,
-  );
-
-  const shaftEndX = basePoint.x + extensionLength;
-  const { y: baseY, z: baseZ } = basePoint;
-
-  // The base point sits on the cuboid's lowest face, so its non-zero offset
-  // axis is the "up" axis. Lay the flat arrowhead in the perpendicular
-  // (horizontal) plane so it reads as a full triangle from a top-down view.
-  const spreadAlongZ = Math.abs(baseY) >= Math.abs(baseZ);
-
-  return {
-    anchor: new THREE.Vector3(shaftEndX, baseY, baseZ),
-    shaftStart: basePoint.toArray() as THREE.Vector3Tuple,
-    headLength,
-    headHalfWidth,
-    spreadAlongZ,
-  };
-};
-
-const getCuboidOrientationMarkerProps = (
-  dimensions: THREE.Vector3Tuple,
-  orientation: THREE.Quaternion,
-  upVector?: THREE.Vector3 | null,
-): {
-  shaftStart: THREE.Vector3Tuple;
-  shaftEnd: THREE.Vector3Tuple;
-  headVertices: [THREE.Vector3Tuple, THREE.Vector3Tuple, THREE.Vector3Tuple];
-} | null => {
-  const geometry = getCuboidOrientationMarkerGeometry(
-    dimensions,
-    orientation,
-    upVector,
-  );
-
-  if (!geometry) {
-    return null;
-  }
-
-  const { anchor, shaftStart, headLength, headHalfWidth, spreadAlongZ } =
-    geometry;
-  const shaftEndX = anchor.x;
-  const tipX = shaftEndX + headLength;
-  const { y: baseY, z: baseZ } = anchor;
-
-  const apex: THREE.Vector3Tuple = [tipX, baseY, baseZ];
-  const base1: THREE.Vector3Tuple = spreadAlongZ
-    ? [shaftEndX, baseY, baseZ + headHalfWidth]
-    : [shaftEndX, baseY + headHalfWidth, baseZ];
-  const base2: THREE.Vector3Tuple = spreadAlongZ
-    ? [shaftEndX, baseY, baseZ - headHalfWidth]
-    : [shaftEndX, baseY - headHalfWidth, baseZ];
-
-  return {
-    shaftStart,
-    shaftEnd: [shaftEndX, baseY, baseZ],
-    headVertices: [apex, base1, base2],
-  };
-};
 
 export interface CuboidOrientationMarkerProps {
   dimensions: THREE.Vector3Tuple;

--- a/app/packages/looker-3d/src/labels/shared/cuboid-orientation-geometry.test.ts
+++ b/app/packages/looker-3d/src/labels/shared/cuboid-orientation-geometry.test.ts
@@ -1,0 +1,122 @@
+import * as THREE from "three";
+import { describe, expect, it } from "vitest";
+import {
+  getCuboidOrientationMarkerGeometry,
+  getCuboidOrientationMarkerProps,
+} from "./cuboid-orientation-geometry";
+
+describe("getCuboidOrientationMarkerGeometry", () => {
+  it("returns null when the box has no heading extent", () => {
+    expect(
+      getCuboidOrientationMarkerGeometry(
+        [0, 2, 2],
+        new THREE.Quaternion(),
+        null,
+      ),
+    ).toBeNull();
+  });
+
+  it("anchors on the lowest edge of the forward face relative to the up vector", () => {
+    // Default up vector (no upVector passed) is scene Z-up — the lowest
+    // candidate edge (most-negative-Z direction) should win.
+    const geometry = getCuboidOrientationMarkerGeometry(
+      [4, 2, 2],
+      new THREE.Quaternion(),
+      null,
+    );
+    expect(geometry).not.toBeNull();
+    expect(geometry?.shaftStart).toEqual([2, 0, -1]);
+    // baseY (0) is not >= baseZ (-1) in magnitude... |0| < |-1|, so the
+    // arrowhead spreads along Z here.
+    expect(geometry?.spreadAlongZ).toBe(false);
+  });
+
+  it("picks a different lowest edge with a Y-up vector, spreading along Y", () => {
+    const geometry = getCuboidOrientationMarkerGeometry(
+      [4, 2, 2],
+      new THREE.Quaternion(),
+      new THREE.Vector3(0, 1, 0),
+    );
+    expect(geometry).not.toBeNull();
+    expect(geometry?.shaftStart).toEqual([2, -1, 0]);
+    expect(geometry?.spreadAlongZ).toBe(true);
+  });
+
+  it("places the anchor beyond the shaft start by the extension length", () => {
+    const geometry = getCuboidOrientationMarkerGeometry(
+      [4, 2, 2],
+      new THREE.Quaternion(),
+      null,
+    );
+    expect(geometry).not.toBeNull();
+    if (!geometry) return;
+    const extensionLength = geometry.anchor.x - geometry.shaftStart[0];
+    expect(extensionLength).toBeGreaterThan(0);
+    expect(geometry.anchor.y).toBeCloseTo(geometry.shaftStart[1], 6);
+    expect(geometry.anchor.z).toBeCloseTo(geometry.shaftStart[2], 6);
+  });
+
+  it("produces a positive headLength and headHalfWidth", () => {
+    const geometry = getCuboidOrientationMarkerGeometry(
+      [4, 2, 2],
+      new THREE.Quaternion(),
+      null,
+    );
+    expect(geometry?.headLength).toBeGreaterThan(0);
+    expect(geometry?.headHalfWidth).toBeGreaterThan(0);
+  });
+});
+
+describe("getCuboidOrientationMarkerProps", () => {
+  it("returns null when the box has no heading extent", () => {
+    expect(
+      getCuboidOrientationMarkerProps([0, 2, 2], new THREE.Quaternion(), null),
+    ).toBeNull();
+  });
+
+  it("derives shaftEnd/headVertices consistently from the decomposed geometry", () => {
+    const decomposed = getCuboidOrientationMarkerGeometry(
+      [4, 2, 2],
+      new THREE.Quaternion(),
+      null,
+    );
+    const composed = getCuboidOrientationMarkerProps(
+      [4, 2, 2],
+      new THREE.Quaternion(),
+      null,
+    );
+    expect(decomposed).not.toBeNull();
+    expect(composed).not.toBeNull();
+    if (!decomposed || !composed) return;
+
+    expect(composed.shaftStart).toEqual(decomposed.shaftStart);
+    expect(composed.shaftEnd).toEqual([
+      decomposed.anchor.x,
+      decomposed.anchor.y,
+      decomposed.anchor.z,
+    ]);
+
+    // The apex sits headLength further along X than the anchor, at the
+    // same Y/Z.
+    const [apex] = composed.headVertices;
+    expect(apex[0] - decomposed.anchor.x).toBeCloseTo(
+      decomposed.headLength,
+      6,
+    );
+    expect(apex[1]).toBeCloseTo(decomposed.anchor.y, 6);
+    expect(apex[2]).toBeCloseTo(decomposed.anchor.z, 6);
+
+    // The base corners straddle the anchor by ±headHalfWidth along whichever
+    // axis spreadAlongZ selects.
+    const [, base1, base2] = composed.headVertices;
+    const spreadAxis = decomposed.spreadAlongZ ? 2 : 1;
+    expect(base1[spreadAxis] - decomposed.anchor.getComponent(spreadAxis)).toBeCloseTo(
+      decomposed.headHalfWidth,
+      6,
+    );
+    expect(base2[spreadAxis] - decomposed.anchor.getComponent(spreadAxis)).toBeCloseTo(
+      -decomposed.headHalfWidth,
+      6,
+    );
+  });
+});

--- a/app/packages/looker-3d/src/labels/shared/cuboid-orientation-geometry.test.ts
+++ b/app/packages/looker-3d/src/labels/shared/cuboid-orientation-geometry.test.ts
@@ -99,10 +99,7 @@ describe("getCuboidOrientationMarkerProps", () => {
     // The apex sits headLength further along X than the anchor, at the
     // same Y/Z.
     const [apex] = composed.headVertices;
-    expect(apex[0] - decomposed.anchor.x).toBeCloseTo(
-      decomposed.headLength,
-      6,
-    );
+    expect(apex[0] - decomposed.anchor.x).toBeCloseTo(decomposed.headLength, 6);
     expect(apex[1]).toBeCloseTo(decomposed.anchor.y, 6);
     expect(apex[2]).toBeCloseTo(decomposed.anchor.z, 6);
 
@@ -110,13 +107,11 @@ describe("getCuboidOrientationMarkerProps", () => {
     // axis spreadAlongZ selects.
     const [, base1, base2] = composed.headVertices;
     const spreadAxis = decomposed.spreadAlongZ ? 2 : 1;
-    expect(base1[spreadAxis] - decomposed.anchor.getComponent(spreadAxis)).toBeCloseTo(
-      decomposed.headHalfWidth,
-      6,
-    );
-    expect(base2[spreadAxis] - decomposed.anchor.getComponent(spreadAxis)).toBeCloseTo(
-      -decomposed.headHalfWidth,
-      6,
-    );
+    expect(
+      base1[spreadAxis] - decomposed.anchor.getComponent(spreadAxis),
+    ).toBeCloseTo(decomposed.headHalfWidth, 6);
+    expect(
+      base2[spreadAxis] - decomposed.anchor.getComponent(spreadAxis),
+    ).toBeCloseTo(-decomposed.headHalfWidth, 6);
   });
 });

--- a/app/packages/looker-3d/src/labels/shared/cuboid-orientation-geometry.ts
+++ b/app/packages/looker-3d/src/labels/shared/cuboid-orientation-geometry.ts
@@ -1,0 +1,148 @@
+import * as THREE from "three";
+import { getCuboidForwardFaceBasePoint } from "../../utils";
+
+// Flat triangular arrowhead, sized relative to the cuboid's heading length.
+const ORIENTATION_MARKER_EXTENSION_RATIO = 0.3;
+const ORIENTATION_MARKER_HEAD_LENGTH_RATIO = 0.16;
+const ORIENTATION_MARKER_MIN_HEAD_LENGTH = 0.08;
+const ORIENTATION_MARKER_MIN_CROSS_SECTION_RATIO = 0.1;
+// Half-width of the arrowhead base, as a fraction of its length and capped
+// against the cuboid's smaller cross-section so it never overhangs the box.
+const ORIENTATION_MARKER_HEAD_WIDTH_RATIO = 0.7;
+const ORIENTATION_MARKER_HEAD_WIDTH_CROSS_CAP = 0.4;
+const ORIENTATION_MARKER_MIN_HEAD_WIDTH = 0.03;
+
+// RGB orientation axes drawn at the cuboid centroid when orientation is shown.
+// Each axis length is a fraction of its own half-extent so the tripod stays
+// inside the box and reflects its proportions (red = +X heading, green = +Y,
+// blue = +Z).
+export const ORIENTATION_AXES_LENGTH_RATIO = 0.55;
+export const ORIENTATION_AXES_MIN_LENGTH = 0.04;
+export const ORIENTATION_AXES_COLORS = {
+  x: "#ff4136",
+  y: "#2ecc40",
+  z: "#1e90ff",
+} as const;
+
+export const getFiniteMagnitude = (value: number) =>
+  Number.isFinite(value) ? Math.abs(value) : 0;
+
+/**
+ * Decomposed (pre-composition) form of the orientation arrow's geometry, in
+ * the cuboid's local frame. `CuboidInstances` uses this directly to build a
+ * per-instance affine matrix (translate to `anchor`, optionally rotate 90°
+ * about local X when `spreadAlongZ`, then scale a canonical unit triangle by
+ * `(headLength, headHalfWidth, headHalfWidth)`) instead of computing final
+ * world-space triangle vertices per box.
+ */
+export interface CuboidOrientationMarkerGeometry {
+  /** Local-space anchor at the shaft's end / arrowhead base center. */
+  anchor: THREE.Vector3;
+  /** Local-space point where the shaft begins (on the cuboid's forward face). */
+  shaftStart: THREE.Vector3Tuple;
+  headLength: number;
+  headHalfWidth: number;
+  /** True when the arrowhead's base spreads along local Z rather than local Y. */
+  spreadAlongZ: boolean;
+}
+
+export const getCuboidOrientationMarkerGeometry = (
+  dimensions: THREE.Vector3Tuple,
+  orientation: THREE.Quaternion,
+  upVector?: THREE.Vector3 | null,
+): CuboidOrientationMarkerGeometry | null => {
+  const length = getFiniteMagnitude(dimensions[0]);
+
+  if (length <= 0) {
+    return null;
+  }
+
+  const basePoint = getCuboidForwardFaceBasePoint({
+    dimensions,
+    orientation,
+    upVector,
+  });
+
+  if (!basePoint) {
+    return null;
+  }
+
+  const localYExtent = getFiniteMagnitude(dimensions[1]);
+  const localZExtent = getFiniteMagnitude(dimensions[2]);
+  const extensionLength = length * ORIENTATION_MARKER_EXTENSION_RATIO;
+  const headLength = Math.max(
+    Math.min(length * ORIENTATION_MARKER_HEAD_LENGTH_RATIO, extensionLength),
+    ORIENTATION_MARKER_MIN_HEAD_LENGTH,
+  );
+  const crossSection = Math.max(
+    Math.min(localYExtent, localZExtent),
+    length * ORIENTATION_MARKER_MIN_CROSS_SECTION_RATIO,
+  );
+  const headHalfWidth = Math.max(
+    Math.min(
+      headLength * ORIENTATION_MARKER_HEAD_WIDTH_RATIO,
+      crossSection * ORIENTATION_MARKER_HEAD_WIDTH_CROSS_CAP,
+    ),
+    ORIENTATION_MARKER_MIN_HEAD_WIDTH,
+  );
+
+  const shaftEndX = basePoint.x + extensionLength;
+  const { y: baseY, z: baseZ } = basePoint;
+
+  // The base point sits on the cuboid's lowest face, so its non-zero offset
+  // axis is the "up" axis. Lay the flat arrowhead in the perpendicular
+  // (horizontal) plane so it reads as a full triangle from a top-down view.
+  const spreadAlongZ = Math.abs(baseY) >= Math.abs(baseZ);
+
+  return {
+    anchor: new THREE.Vector3(shaftEndX, baseY, baseZ),
+    shaftStart: basePoint.toArray() as THREE.Vector3Tuple,
+    headLength,
+    headHalfWidth,
+    spreadAlongZ,
+  };
+};
+
+/**
+ * Composed (final) local-space points for the standalone `CuboidOrientationMarker`
+ * component. Built on top of `getCuboidOrientationMarkerGeometry`.
+ */
+export const getCuboidOrientationMarkerProps = (
+  dimensions: THREE.Vector3Tuple,
+  orientation: THREE.Quaternion,
+  upVector?: THREE.Vector3 | null,
+): {
+  shaftStart: THREE.Vector3Tuple;
+  shaftEnd: THREE.Vector3Tuple;
+  headVertices: [THREE.Vector3Tuple, THREE.Vector3Tuple, THREE.Vector3Tuple];
+} | null => {
+  const geometry = getCuboidOrientationMarkerGeometry(
+    dimensions,
+    orientation,
+    upVector,
+  );
+
+  if (!geometry) {
+    return null;
+  }
+
+  const { anchor, shaftStart, headLength, headHalfWidth, spreadAlongZ } =
+    geometry;
+  const shaftEndX = anchor.x;
+  const tipX = shaftEndX + headLength;
+  const { y: baseY, z: baseZ } = anchor;
+
+  const apex: THREE.Vector3Tuple = [tipX, baseY, baseZ];
+  const base1: THREE.Vector3Tuple = spreadAlongZ
+    ? [shaftEndX, baseY, baseZ + headHalfWidth]
+    : [shaftEndX, baseY + headHalfWidth, baseZ];
+  const base2: THREE.Vector3Tuple = spreadAlongZ
+    ? [shaftEndX, baseY, baseZ - headHalfWidth]
+    : [shaftEndX, baseY - headHalfWidth, baseZ];
+
+  return {
+    shaftStart,
+    shaftEnd: [shaftEndX, baseY, baseZ],
+    headVertices: [apex, base1, base2],
+  };
+};

--- a/app/packages/looker-3d/src/labels/shared/hooks.test.ts
+++ b/app/packages/looker-3d/src/labels/shared/hooks.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from "@testing-library/react-hooks";
+import { act, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 // `hooks.ts` pulls in a heavy dependency chain (`@fiftyone/annotation`,

--- a/app/packages/looker-3d/src/labels/shared/hooks.test.ts
+++ b/app/packages/looker-3d/src/labels/shared/hooks.test.ts
@@ -108,7 +108,11 @@ function makeLabel(id: string) {
 
 describe("useEventHandlers", () => {
   afterEach(() => {
+    // `clearAllMocks` only clears call records, not implementations — a test
+    // that sets `getHoveredSpy.mockReturnValue(...)` would otherwise leak
+    // that return value into later tests, so reset it explicitly.
     vi.clearAllMocks();
+    mocks.getHoveredSpy.mockReturnValue([]);
     mocks.atomValues.clear();
     mocks.isAnnotateMode = false;
   });
@@ -138,10 +142,9 @@ describe("useEventHandlers", () => {
 
   it("does not set tooltipDetail for the label currently selected for annotation", () => {
     const labelA = makeLabel("a");
-    mocks.atomValues.set(
-      mocks.atoms.selectedLabelForAnnotationAtom,
-      { _id: "a" },
-    );
+    mocks.atomValues.set(mocks.atoms.selectedLabelForAnnotationAtom, {
+      _id: "a",
+    });
 
     const { result } = renderHook(() => useEventHandlers());
     act(() => {

--- a/app/packages/looker-3d/src/labels/shared/hooks.test.ts
+++ b/app/packages/looker-3d/src/labels/shared/hooks.test.ts
@@ -1,0 +1,223 @@
+import { act, renderHook } from "@testing-library/react-hooks";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// `hooks.ts` pulls in a heavy dependency chain (`@fiftyone/annotation`,
+// `@fiftyone/state`, `@fiftyone/looker`, `@react-three/drei`) that isn't
+// safely importable in isolation under vitest (a circular-import issue
+// surfaces deep inside `@fiftyone/looker`'s module graph). Mock all of it so
+// this test exercises only `hooks.ts`'s own logic — specifically, that
+// `useEventHandlers`/`useMeshTooltipProps` correctly operate on whichever
+// label is passed at call time, rather than one captured at hook-call time.
+
+const mocks = vi.hoisted(() => ({
+  atoms: {
+    selectedLabelForAnnotationAtom: Symbol("selectedLabelForAnnotationAtom"),
+    isCurrentlyTransformingAtom: Symbol("isCurrentlyTransformingAtom"),
+    editSegmentsModeAtom: Symbol("editSegmentsModeAtom"),
+    isActivelySegmentingSelector: Symbol("isActivelySegmentingSelector"),
+  },
+  fosAtoms: {
+    isTooltipLocked: Symbol("isTooltipLocked"),
+    tooltipDetail: Symbol("tooltipDetail"),
+    tooltipCoordinates: Symbol("tooltipCoordinates"),
+  },
+  atomValues: new Map<symbol, unknown>(),
+  setSpy: vi.fn(),
+  emitSpy: vi.fn(),
+  setHoveredSpy: vi.fn(),
+  getHoveredSpy: vi.fn(() => [] as { instanceId: string }[]),
+  isAnnotateMode: false,
+}));
+
+vi.mock("../../state", () => ({
+  selectedLabelForAnnotationAtom: mocks.atoms.selectedLabelForAnnotationAtom,
+  isCurrentlyTransformingAtom: mocks.atoms.isCurrentlyTransformingAtom,
+  editSegmentsModeAtom: mocks.atoms.editSegmentsModeAtom,
+  isActivelySegmentingSelector: mocks.atoms.isActivelySegmentingSelector,
+}));
+
+vi.mock("@fiftyone/state", () => ({
+  isTooltipLocked: mocks.fosAtoms.isTooltipLocked,
+  tooltipDetail: mocks.fosAtoms.tooltipDetail,
+  tooltipCoordinates: mocks.fosAtoms.tooltipCoordinates,
+  computeCoordinates: (xy: [number, number]) => ({ x: xy[0], y: xy[1] }),
+  useModalMode: () => (mocks.isAnnotateMode ? "annotate" : "explore"),
+  useCurrentSampleId: () => "sample-1",
+}));
+
+vi.mock("@fiftyone/annotation", () => ({
+  useAnnotationEngine: () => ({
+    interaction: {
+      setHovered: mocks.setHoveredSpy,
+      getHovered: mocks.getHoveredSpy,
+    },
+  }),
+}));
+
+vi.mock("@fiftyone/looker", () => ({
+  LabelHoveredEvent: class LabelHoveredEvent {
+    detail: unknown;
+    constructor(detail: unknown) {
+      this.detail = detail;
+    }
+  },
+  LabelUnhoveredEvent: class LabelUnhoveredEvent {},
+  selectiveRenderingEventBus: { emit: mocks.emitSpy, on: vi.fn() },
+}));
+
+vi.mock("@react-three/drei", () => ({
+  useCursor: vi.fn(),
+}));
+
+vi.mock("../../hooks/use-3d-label-color", () => ({
+  use3dLabelColor: vi.fn(),
+}));
+
+vi.mock("../../hooks/use-similar-labels-3d", () => ({
+  useSimilarLabels3d: vi.fn(),
+}));
+
+vi.mock("recoil", () => ({
+  useRecoilCallback:
+    (fn: (iface: unknown) => (...args: unknown[]) => unknown) =>
+    (...args: unknown[]) =>
+      fn({
+        snapshot: {
+          getLoadable: (atom: symbol) => ({
+            getValue: () => mocks.atomValues.get(atom),
+          }),
+        },
+        set: mocks.setSpy,
+      })(...args),
+  useRecoilValue: (atom: symbol) => mocks.atomValues.get(atom),
+}));
+
+import { useEventHandlers } from "./hooks";
+
+function makeLabel(id: string) {
+  return {
+    _id: id,
+    id,
+    path: "ground_truth",
+    color: "#fff",
+    sampleId: "sample-1",
+    type: "Detection",
+    instance: { _id: `instance-${id}` },
+  };
+}
+
+describe("useEventHandlers", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    mocks.atomValues.clear();
+    mocks.isAnnotateMode = false;
+  });
+
+  it("sets tooltipDetail from whichever label is passed at call time", () => {
+    const { result } = renderHook(() => useEventHandlers());
+
+    const labelA = makeLabel("a");
+    const labelB = makeLabel("b");
+
+    act(() => {
+      result.current.onPointerOver(labelA, undefined);
+    });
+    expect(mocks.setSpy).toHaveBeenLastCalledWith(
+      mocks.fosAtoms.tooltipDetail,
+      expect.objectContaining({ label: labelA }),
+    );
+
+    act(() => {
+      result.current.onPointerOver(labelB, undefined);
+    });
+    expect(mocks.setSpy).toHaveBeenLastCalledWith(
+      mocks.fosAtoms.tooltipDetail,
+      expect.objectContaining({ label: labelB }),
+    );
+  });
+
+  it("does not set tooltipDetail for the label currently selected for annotation", () => {
+    const labelA = makeLabel("a");
+    mocks.atomValues.set(
+      mocks.atoms.selectedLabelForAnnotationAtom,
+      { _id: "a" },
+    );
+
+    const { result } = renderHook(() => useEventHandlers());
+    act(() => {
+      result.current.onPointerOver(labelA, undefined);
+    });
+
+    expect(mocks.setSpy).not.toHaveBeenCalledWith(
+      mocks.fosAtoms.tooltipDetail,
+      expect.anything(),
+    );
+  });
+
+  it("emits a hover event only for labels with an instance", () => {
+    const withInstance = makeLabel("a");
+    const withoutInstance = { ...makeLabel("b"), instance: undefined };
+
+    const { result } = renderHook(() => useEventHandlers());
+
+    act(() => {
+      result.current.onPointerOver(withInstance, undefined);
+    });
+    expect(mocks.emitSpy).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.onPointerOver(withoutInstance, undefined);
+    });
+    expect(mocks.emitSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("only writes the engine's hovered set in annotate mode, keyed by the call-time label", () => {
+    mocks.isAnnotateMode = true;
+    const labelA = makeLabel("a");
+    const labelB = makeLabel("b");
+
+    const { result } = renderHook(() => useEventHandlers());
+
+    act(() => {
+      result.current.onPointerOver(labelA, undefined);
+    });
+    expect(mocks.setHoveredSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({ instanceId: "a" }),
+      true,
+    );
+
+    act(() => {
+      result.current.onPointerOver(labelB, undefined);
+    });
+    expect(mocks.setHoveredSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({ instanceId: "b" }),
+      true,
+    );
+  });
+
+  it("does not write the engine's hovered set outside annotate mode", () => {
+    mocks.isAnnotateMode = false;
+    const { result } = renderHook(() => useEventHandlers());
+
+    act(() => {
+      result.current.onPointerOver(makeLabel("a"), undefined);
+    });
+
+    expect(mocks.setHoveredSpy).not.toHaveBeenCalled();
+  });
+
+  it("resolves onPointerOut's hover-clear from the engine's hovered set by the call-time label", () => {
+    mocks.isAnnotateMode = true;
+    mocks.getHoveredSpy.mockReturnValue([{ instanceId: "b" }]);
+
+    const { result } = renderHook(() => useEventHandlers());
+    act(() => {
+      result.current.onPointerOut(makeLabel("b"));
+    });
+
+    expect(mocks.setHoveredSpy).toHaveBeenCalledWith(
+      { instanceId: "b" },
+      false,
+    );
+  });
+});

--- a/app/packages/looker-3d/src/labels/shared/hooks.ts
+++ b/app/packages/looker-3d/src/labels/shared/hooks.ts
@@ -19,7 +19,11 @@ import {
   selectedLabelForAnnotationAtom,
 } from "../../state";
 import type { OverlayLabel } from "../loader";
-import type { BaseOverlayProps, EventHandlers, HoverState } from "../../types";
+import type {
+  BaseOverlayProps,
+  HoverState,
+  InstancedEventHandlers,
+} from "../../types";
 
 const getDetailsFromLabel = (label: OverlayLabel) => {
   const field = Array.isArray(label.path)
@@ -59,12 +63,15 @@ export const useHoverState = (): HoverState => {
 };
 
 /**
- * Hook that provides mesh pointer event handlers.
+ * Hook that provides mesh pointer event handlers. `label` is a call-time
+ * argument (not captured at hook-call time) so one set of handlers can serve
+ * every label in an instanced batch — the standalone path curries its own
+ * label once at its call site (see `Cuboid`).
  */
-const useMeshTooltipProps = (label: OverlayLabel) => {
+const useMeshTooltipProps = () => {
   const onPointerOver = useRecoilCallback(
     ({ snapshot, set }) =>
-      (e?: ThreeEvent<PointerEvent>) => {
+      (label: any, e?: ThreeEvent<PointerEvent>) => {
         const selectedLabel = snapshot
           .getLoadable(selectedLabelForAnnotationAtom)
           .getValue();
@@ -99,12 +106,12 @@ const useMeshTooltipProps = (label: OverlayLabel) => {
           }),
         );
       },
-    [label],
+    [],
   );
 
   const onPointerOut = useRecoilCallback(
     ({ snapshot, set }) =>
-      () => {
+      (label: any) => {
         const isTooltipLocked = snapshot
           .getLoadable(fos.isTooltipLocked)
           .getValue();
@@ -117,7 +124,7 @@ const useMeshTooltipProps = (label: OverlayLabel) => {
 
         selectiveRenderingEventBus.emit(new LabelUnhoveredEvent());
       },
-    [label],
+    [],
   );
 
   const onPointerMissed = useRecoilCallback(
@@ -136,7 +143,7 @@ const useMeshTooltipProps = (label: OverlayLabel) => {
 
   const onPointerMove = useRecoilCallback(
     ({ snapshot, set }) =>
-      (e: ThreeEvent<PointerEvent>) => {
+      (label: any, e: ThreeEvent<PointerEvent>) => {
         const selectedLabel = snapshot
           .getLoadable(selectedLabelForAnnotationAtom)
           .getValue();
@@ -170,21 +177,25 @@ const useMeshTooltipProps = (label: OverlayLabel) => {
           );
         }
       },
-    [label],
+    [],
   );
 
   return { onPointerOver, onPointerOut, onPointerMissed, onPointerMove };
 };
 
 /**
- * Custom hook for managing event handlers and tooltip integration
+ * Custom hook for managing event handlers and tooltip integration. `label`
+ * is a call-time argument on `onPointerOver`/`onPointerOut`/`onPointerMove`
+ * (not captured at hook-call time) so the instanced batch can share one set
+ * of handlers across every label; the standalone path curries its own label
+ * once at its call site (see `Cuboid`).
  */
-export const useEventHandlers = (label: OverlayLabel): EventHandlers => {
+export const useEventHandlers = (): InstancedEventHandlers => {
   const {
     onPointerOver: _onPointerOver,
     onPointerOut: _onPointerOut,
     ...restEventHandlers
-  } = useMeshTooltipProps(label);
+  } = useMeshTooltipProps();
 
   // the renderer is shared with explore; the ENGINE hover write-half only
   // applies in annotate mode (the engine has no registered store in explore).
@@ -202,8 +213,8 @@ export const useEventHandlers = (label: OverlayLabel): EventHandlers => {
   // handler runs first so it is never coupled to annotation state.
   return {
     onPointerOver: useCallback(
-      (e?: ThreeEvent<PointerEvent>) => {
-        _onPointerOver(e);
+      (label: any, e?: ThreeEvent<PointerEvent>) => {
+        _onPointerOver(label, e);
 
         if (!isAnnotateMode) {
           return;
@@ -218,26 +229,29 @@ export const useEventHandlers = (label: OverlayLabel): EventHandlers => {
           engine.interaction.setHovered({ sample, path, instanceId: id }, true);
         }
       },
-      [label, isAnnotateMode, engine, sample, _onPointerOver],
+      [isAnnotateMode, engine, sample, _onPointerOver],
     ),
-    onPointerOut: useCallback(() => {
-      _onPointerOut();
+    onPointerOut: useCallback(
+      (label: any) => {
+        _onPointerOut(label);
 
-      if (!isAnnotateMode) {
-        return;
-      }
+        if (!isAnnotateMode) {
+          return;
+        }
 
-      // resolve from the hovered set itself, so hover-off works even after
-      // the label has been deleted or replaced
-      const id = label?._id ?? label?.id;
-      const ref = engine.interaction
-        .getHovered()
-        .find((hovered) => hovered.instanceId === id);
+        // resolve from the hovered set itself, so hover-off works even after
+        // the label has been deleted or replaced
+        const id = label?._id ?? label?.id;
+        const ref = engine.interaction
+          .getHovered()
+          .find((hovered) => hovered.instanceId === id);
 
-      if (ref) {
-        engine.interaction.setHovered(ref, false);
-      }
-    }, [label, isAnnotateMode, engine, _onPointerOut]),
+        if (ref) {
+          engine.interaction.setHovered(ref, false);
+        }
+      },
+      [isAnnotateMode, engine, _onPointerOut],
+    ),
     ...restEventHandlers,
   };
 };

--- a/app/packages/looker-3d/src/labels/shared/index.ts
+++ b/app/packages/looker-3d/src/labels/shared/index.ts
@@ -1,2 +1,5 @@
+export * from "./CuboidOrientationMarkers";
 export * from "./hooks";
 export * from "./TransformControls";
+export * from "./useDisplayCuboidTransform";
+export * from "./useDragGate";

--- a/app/packages/looker-3d/src/labels/shared/registerLineElements.ts
+++ b/app/packages/looker-3d/src/labels/shared/registerLineElements.ts
@@ -1,0 +1,10 @@
+import { extend } from "@react-three/fiber";
+import { LineMaterial } from "three/examples/jsm/lines/LineMaterial";
+import { LineSegments2 } from "three/examples/jsm/lines/LineSegments2";
+import { LineSegmentsGeometry } from "three/examples/jsm/lines/LineSegmentsGeometry";
+
+// Registers the three.js "fat lines" JSX intrinsics (<lineSegments2>, etc.)
+// once, as a module-level side effect, so both the standalone cuboid path
+// and the instanced-batch outline can import this instead of each calling
+// extend() again.
+extend({ LineSegments2, LineMaterial, LineSegmentsGeometry });

--- a/app/packages/looker-3d/src/labels/shared/useDisplayCuboidTransform.test.ts
+++ b/app/packages/looker-3d/src/labels/shared/useDisplayCuboidTransform.test.ts
@@ -1,0 +1,167 @@
+import { renderHook } from "@testing-library/react-hooks";
+import React from "react";
+import { RecoilRoot } from "recoil";
+import * as THREE from "three";
+import { describe, expect, it, vi } from "vitest";
+import { transformModeAtom } from "../../state";
+import { useDisplayCuboidTransform } from "./useDisplayCuboidTransform";
+
+const { useTransientCuboidMock } = vi.hoisted(() => ({
+  useTransientCuboidMock: vi.fn(),
+}));
+
+vi.mock("../../annotation/store", () => ({
+  useTransientCuboid: useTransientCuboidMock,
+}));
+
+function renderWithMode(
+  transformMode: "scale" | "rotate" | "translate",
+  args: Parameters<typeof useDisplayCuboidTransform>[0],
+) {
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(
+      RecoilRoot,
+      {
+        initializeState: ({ set }) => set(transformModeAtom, transformMode),
+      },
+      children,
+    );
+  return renderHook(() => useDisplayCuboidTransform(args), { wrapper });
+}
+
+describe("useDisplayCuboidTransform", () => {
+  it("uses the effective dimensions/location unchanged with no transient state", () => {
+    useTransientCuboidMock.mockReturnValue(undefined);
+
+    const { result } = renderWithMode("scale", {
+      labelId: "label-1",
+      effectiveLocation: [1, 2, 3],
+      effectiveDimensions: [4, 5, 6],
+      effectiveRotation: [0, 0, 0],
+      effectiveQuaternion: null,
+      useLegacyCoordinates: false,
+    });
+
+    expect(result.current.displayDimensions).toEqual([4, 5, 6]);
+    expect(result.current.displayPosition).toEqual([1, 2, 3]);
+  });
+
+  it("applies the legacy-coordinate half-height Y offset", () => {
+    useTransientCuboidMock.mockReturnValue(undefined);
+
+    const { result } = renderWithMode("scale", {
+      labelId: "label-1",
+      effectiveLocation: [1, 10, 3],
+      effectiveDimensions: [4, 6, 8],
+      effectiveRotation: [0, 0, 0],
+      effectiveQuaternion: null,
+      useLegacyCoordinates: true,
+    });
+
+    expect(result.current.displayPosition).toEqual([1, 7, 3]);
+  });
+
+  it("applies transient dimensions/position deltas", () => {
+    useTransientCuboidMock.mockReturnValue({
+      dimensionsDelta: [1, 1, 1],
+      positionDelta: [10, 20, 30],
+    });
+
+    const { result } = renderWithMode("scale", {
+      labelId: "label-1",
+      effectiveLocation: [1, 2, 3],
+      effectiveDimensions: [4, 5, 6],
+      effectiveRotation: [0, 0, 0],
+      effectiveQuaternion: null,
+      useLegacyCoordinates: false,
+    });
+
+    expect(result.current.displayDimensions).toEqual([5, 6, 7]);
+    expect(result.current.displayPosition).toEqual([11, 22, 33]);
+  });
+
+  it("prefers the transient quaternion override only while actively rotating", () => {
+    const transientQuaternion = new THREE.Quaternion()
+      .setFromEuler(new THREE.Euler(0.1, 0.2, 0.3))
+      .toArray() as [number, number, number, number];
+    useTransientCuboidMock.mockReturnValue({
+      quaternionOverride: transientQuaternion,
+    });
+
+    const rotating = renderWithMode("rotate", {
+      labelId: "label-1",
+      effectiveLocation: [0, 0, 0],
+      effectiveDimensions: [1, 1, 1],
+      effectiveRotation: [0, 0, 0],
+      effectiveQuaternion: null,
+      useLegacyCoordinates: false,
+    });
+    expect(rotating.result.current.combinedQuaternion?.toArray()).toEqual(
+      transientQuaternion,
+    );
+
+    const notRotating = renderWithMode("scale", {
+      labelId: "label-1",
+      effectiveLocation: [0, 0, 0],
+      effectiveDimensions: [1, 1, 1],
+      effectiveRotation: [0, 0, 0],
+      effectiveQuaternion: null,
+      useLegacyCoordinates: false,
+    });
+    // Not rotating, and no effectiveQuaternion, so it falls back to null
+    // (euler fallback territory), ignoring the transient override.
+    expect(notRotating.result.current.combinedQuaternion).toBeNull();
+  });
+
+  it("uses effectiveQuaternion (working store) over the euler fallback", () => {
+    useTransientCuboidMock.mockReturnValue(undefined);
+    const workingQuaternion: [number, number, number, number] = [0, 0, 0, 1];
+
+    const { result } = renderWithMode("scale", {
+      labelId: "label-1",
+      effectiveLocation: [0, 0, 0],
+      effectiveDimensions: [1, 1, 1],
+      effectiveRotation: [1, 1, 1],
+      effectiveQuaternion: workingQuaternion,
+      useLegacyCoordinates: false,
+    });
+
+    expect(result.current.combinedQuaternion?.toArray()).toEqual(
+      workingQuaternion,
+    );
+    expect(result.current.fallbackEuler).toBeUndefined();
+  });
+
+  it("falls back to a euler rotation when no quaternion is available", () => {
+    useTransientCuboidMock.mockReturnValue(undefined);
+
+    const { result } = renderWithMode("scale", {
+      labelId: "label-1",
+      effectiveLocation: [0, 0, 0],
+      effectiveDimensions: [1, 1, 1],
+      effectiveRotation: [0, Math.PI / 2, 0],
+      effectiveQuaternion: null,
+      useLegacyCoordinates: false,
+    });
+
+    expect(result.current.combinedQuaternion).toBeNull();
+    expect(result.current.fallbackEuler?.y).toBeCloseTo(Math.PI / 2, 6);
+  });
+
+  it("always produces a non-null orientationQuaternion, even without a combined quaternion", () => {
+    useTransientCuboidMock.mockReturnValue(undefined);
+
+    const { result } = renderWithMode("scale", {
+      labelId: "label-1",
+      effectiveLocation: [0, 0, 0],
+      effectiveDimensions: [4, 2, 2],
+      effectiveRotation: [0, 0, 0],
+      effectiveQuaternion: null,
+      useLegacyCoordinates: false,
+    });
+
+    expect(result.current.orientationQuaternion).toBeInstanceOf(
+      THREE.Quaternion,
+    );
+  });
+});

--- a/app/packages/looker-3d/src/labels/shared/useDisplayCuboidTransform.test.ts
+++ b/app/packages/looker-3d/src/labels/shared/useDisplayCuboidTransform.test.ts
@@ -32,14 +32,13 @@ function renderWithMode(
   transformMode: "scale" | "rotate" | "translate",
   args: Parameters<typeof useDisplayCuboidTransform>[0],
 ) {
-  const wrapper = ({ children }: { children: React.ReactNode }) =>
-    React.createElement(
-      RecoilRoot,
-      {
-        initializeState: ({ set }) => set(transformModeAtom, transformMode),
-      },
+  const wrapper = ({ children }: { children?: React.ReactNode }) =>
+    // `children` goes in the props object: RecoilRootProps requires it, and the
+    // third-argument form doesn't satisfy that overload.
+    React.createElement(RecoilRoot, {
+      initializeState: ({ set }) => set(transformModeAtom, transformMode),
       children,
-    );
+    });
   return renderHook(() => useDisplayCuboidTransform(args), { wrapper });
 }
 

--- a/app/packages/looker-3d/src/labels/shared/useDisplayCuboidTransform.test.ts
+++ b/app/packages/looker-3d/src/labels/shared/useDisplayCuboidTransform.test.ts
@@ -14,6 +14,20 @@ vi.mock("../../annotation/store", () => ({
   useTransientCuboid: useTransientCuboidMock,
 }));
 
+// The state barrel reaches `@fiftyone/state` and its Relay fragments, which
+// need the Relay Babel transform that vitest doesn't run — importing it threw at
+// load time, so this file never executed. Stand in a real atom (the test drives
+// it through RecoilRoot) without pulling the barrel in.
+vi.mock("../../state", async () => {
+  const { atom } = await import("recoil");
+  return {
+    transformModeAtom: atom({
+      key: "test-transformMode",
+      default: "scale",
+    }),
+  };
+});
+
 function renderWithMode(
   transformMode: "scale" | "rotate" | "translate",
   args: Parameters<typeof useDisplayCuboidTransform>[0],

--- a/app/packages/looker-3d/src/labels/shared/useDisplayCuboidTransform.test.ts
+++ b/app/packages/looker-3d/src/labels/shared/useDisplayCuboidTransform.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from "@testing-library/react-hooks";
+import { renderHook } from "@testing-library/react";
 import React from "react";
 import { RecoilRoot } from "recoil";
 import * as THREE from "three";

--- a/app/packages/looker-3d/src/labels/shared/useDisplayCuboidTransform.ts
+++ b/app/packages/looker-3d/src/labels/shared/useDisplayCuboidTransform.ts
@@ -1,0 +1,134 @@
+import { useMemo } from "react";
+import { useRecoilValue } from "recoil";
+import * as THREE from "three";
+import { getCuboidResizeQuaternion } from "../../annotation/cuboid-face-resize";
+import { useTransientCuboid } from "../../annotation/store";
+import type { LabelId } from "../../annotation/store/types";
+import { transformModeAtom } from "../../state";
+
+export interface UseDisplayCuboidTransformArgs {
+  labelId: LabelId;
+  effectiveLocation: THREE.Vector3Tuple;
+  effectiveDimensions: THREE.Vector3Tuple;
+  effectiveRotation: THREE.Vector3Tuple;
+  effectiveQuaternion: [number, number, number, number] | null;
+  /**
+   * Legacy-stored `location` is the cuboid's top-center (half-height above
+   * the geometric center); the new format stores the geometric center
+   * directly, matching `BoxGeometry`'s own center.
+   */
+  useLegacyCoordinates: boolean;
+}
+
+export interface UseDisplayCuboidTransformResult {
+  /** Effective dimensions with any live transient (drag/scale) delta applied. */
+  displayDimensions: THREE.Vector3Tuple;
+  /** Effective position with any live transient (drag) delta applied. */
+  displayPosition: THREE.Vector3Tuple;
+  /** Live quaternion (transient override during active rotation, else working); null if only a fallback euler is available. */
+  combinedQuaternion: THREE.Quaternion | null;
+  /** Euler fallback for `<group rotation>` when `combinedQuaternion` is null. */
+  fallbackEuler: THREE.Euler | undefined;
+  /** Orientation for markers/handles — always populated (falls back to a quaternion derived from `effectiveRotation`). */
+  orientationQuaternion: THREE.Quaternion;
+}
+
+/**
+ * Resolves a cuboid's live, on-screen transform: the "effective" values from
+ * `useCuboidAnnotation` (working-store value, or prop fallback), with any
+ * in-progress transient drag/scale/rotate delta layered on top. Shared by
+ * the standalone editing path and the instanced-batch renderer so both
+ * compute the exact same transform — no seam when a box pops between them.
+ */
+export function useDisplayCuboidTransform({
+  labelId,
+  effectiveLocation,
+  effectiveDimensions,
+  effectiveRotation,
+  effectiveQuaternion,
+  useLegacyCoordinates,
+}: UseDisplayCuboidTransformArgs): UseDisplayCuboidTransformResult {
+  const transientState = useTransientCuboid(labelId);
+  const transformMode = useRecoilValue(transformModeAtom);
+
+  // Compute display dimensions: apply transient delta if present
+  const displayDimensions = useMemo(() => {
+    if (transientState?.dimensionsDelta) {
+      return [
+        effectiveDimensions[0] + transientState.dimensionsDelta[0],
+        effectiveDimensions[1] + transientState.dimensionsDelta[1],
+        effectiveDimensions[2] + transientState.dimensionsDelta[2],
+      ] as THREE.Vector3Tuple;
+    }
+    return effectiveDimensions;
+  }, [effectiveDimensions, transientState?.dimensionsDelta]);
+
+  // Compute display position: apply transient delta if present
+  const displayPosition = useMemo(() => {
+    const [x, , z] = effectiveLocation;
+    let y = effectiveLocation[1];
+
+    // In legacy coordinate system, location was stored as the top-center of the cuboid
+    // (half-height above the geometric center), so we adjust Y downward by half the height
+    // to position the cuboid correctly. In the new coordinate system, location is stored
+    // as the geometric center, matching Three.js BoxGeometry's center, so no adjustment is needed.
+    if (useLegacyCoordinates) {
+      y -= 0.5 * displayDimensions[1];
+    }
+
+    if (transientState?.positionDelta) {
+      return [
+        x + transientState.positionDelta[0],
+        y + transientState.positionDelta[1],
+        z + transientState.positionDelta[2],
+      ] as THREE.Vector3Tuple;
+    }
+    return [x, y, z] as THREE.Vector3Tuple;
+  }, [
+    effectiveLocation,
+    displayDimensions,
+    useLegacyCoordinates,
+    transientState?.positionDelta,
+  ]);
+
+  // When quaternion is present (transient or working), use it directly to avoid euler conversion issues
+  // (gimbal lock, precision loss). We convert to euler only on final save.
+  // Priority: transientState.quaternionOverride > effectiveQuaternion (working) > euler fallback
+  const combinedQuaternion = useMemo(() => {
+    // During active rotation, prefer transient quaternion override
+    if (transformMode === "rotate" && transientState?.quaternionOverride) {
+      return new THREE.Quaternion(...transientState.quaternionOverride);
+    }
+    // Otherwise use effective (working) quaternion if available
+    if (effectiveQuaternion) {
+      return new THREE.Quaternion(...effectiveQuaternion);
+    }
+    return null;
+  }, [transientState?.quaternionOverride, effectiveQuaternion, transformMode]);
+
+  // Fallback to euler-based rotation when no quaternion available
+  const fallbackEuler = useMemo(() => {
+    if (combinedQuaternion) {
+      return undefined;
+    }
+    return new THREE.Euler(...(effectiveRotation as THREE.Vector3Tuple));
+  }, [combinedQuaternion, effectiveRotation]);
+
+  const orientationQuaternion = useMemo(() => {
+    if (combinedQuaternion) {
+      return combinedQuaternion.clone();
+    }
+
+    return getCuboidResizeQuaternion({
+      rotation: effectiveRotation as THREE.Vector3Tuple,
+    });
+  }, [combinedQuaternion, effectiveRotation]);
+
+  return {
+    displayDimensions,
+    displayPosition,
+    combinedQuaternion,
+    fallbackEuler,
+    orientationQuaternion,
+  };
+}

--- a/app/packages/looker-3d/src/labels/shared/useDragGate.test.ts
+++ b/app/packages/looker-3d/src/labels/shared/useDragGate.test.ts
@@ -1,0 +1,71 @@
+import { act, renderHook } from "@testing-library/react-hooks";
+import type { ThreeEvent } from "@react-three/fiber";
+import { describe, expect, it } from "vitest";
+import { useDragGate } from "./useDragGate";
+
+function pointerEvent(clientX: number, clientY: number) {
+  return { nativeEvent: { clientX, clientY } } as ThreeEvent<PointerEvent>;
+}
+
+describe("useDragGate", () => {
+  it("reports a click when the pointer doesn't move past the threshold", () => {
+    const { result } = renderHook(() => useDragGate({ dragThresholdPx: 4 }));
+
+    act(() => {
+      result.current.onPointerDown(pointerEvent(100, 100));
+      result.current.onPointerMove(pointerEvent(102, 100));
+      result.current.onPointerUp(pointerEvent(102, 100));
+    });
+
+    expect(result.current.isClick()).toBe(true);
+  });
+
+  it("reports a drag once movement exceeds the threshold", () => {
+    const { result } = renderHook(() => useDragGate({ dragThresholdPx: 4 }));
+
+    act(() => {
+      result.current.onPointerDown(pointerEvent(100, 100));
+      result.current.onPointerMove(pointerEvent(110, 100));
+    });
+
+    expect(result.current.isClick()).toBe(false);
+  });
+
+  it("resets drag state on the next pointer-down", () => {
+    const { result } = renderHook(() => useDragGate({ dragThresholdPx: 4 }));
+
+    act(() => {
+      result.current.onPointerDown(pointerEvent(100, 100));
+      result.current.onPointerMove(pointerEvent(110, 100));
+      result.current.onPointerUp(pointerEvent(110, 100));
+    });
+    expect(result.current.isClick()).toBe(false);
+
+    act(() => {
+      result.current.onPointerDown(pointerEvent(200, 200));
+    });
+
+    expect(result.current.isClick()).toBe(true);
+  });
+
+  it("ignores movement before any pointer-down", () => {
+    const { result } = renderHook(() => useDragGate({ dragThresholdPx: 4 }));
+
+    act(() => {
+      result.current.onPointerMove(pointerEvent(500, 500));
+    });
+
+    expect(result.current.isClick()).toBe(true);
+  });
+
+  it("uses the default threshold when none is provided", () => {
+    const { result } = renderHook(() => useDragGate());
+
+    act(() => {
+      result.current.onPointerDown(pointerEvent(0, 0));
+      result.current.onPointerMove(pointerEvent(1, 0));
+    });
+
+    expect(result.current.isClick()).toBe(true);
+  });
+});

--- a/app/packages/looker-3d/src/labels/shared/useDragGate.test.ts
+++ b/app/packages/looker-3d/src/labels/shared/useDragGate.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from "@testing-library/react-hooks";
+import { act, renderHook } from "@testing-library/react";
 import type { ThreeEvent } from "@react-three/fiber";
 import { describe, expect, it } from "vitest";
 import { useDragGate } from "./useDragGate";

--- a/app/packages/looker-3d/src/labels/shared/useDragGate.ts
+++ b/app/packages/looker-3d/src/labels/shared/useDragGate.ts
@@ -1,0 +1,59 @@
+import { ThreeEvent } from "@react-three/fiber";
+import { useCallback, useRef } from "react";
+import { DRAG_GATE_THRESHOLD_PX } from "../../constants";
+
+type PointerEvt = ThreeEvent<PointerEvent>;
+
+export interface UseDragGateOptions {
+  /** Screen-space threshold in px before we treat it as a drag */
+  dragThresholdPx?: number;
+}
+
+export interface UseDragGateResult {
+  onPointerDown: (e: PointerEvt) => void;
+  onPointerMove: (e: PointerEvt) => void;
+  onPointerUp: (e: PointerEvt) => void;
+  /** Call from your click handler; false means the pointer dragged past the threshold since the last pointer-down. */
+  isClick: () => boolean;
+}
+
+/**
+ * Drag-vs-click state machine shared by the standalone (`DragGate3D`) and
+ * instanced-batch picking paths. Tracks pointer-down origin and flags a drag
+ * once movement exceeds `dragThresholdPx`, so callers can suppress a click
+ * that follows a drag.
+ */
+export function useDragGate({
+  dragThresholdPx = DRAG_GATE_THRESHOLD_PX,
+}: UseDragGateOptions = {}): UseDragGateResult {
+  const startRef = useRef<{ x: number; y: number } | null>(null);
+  const draggedRef = useRef(false);
+  const thresholdSq = dragThresholdPx * dragThresholdPx;
+
+  const onPointerDown = useCallback((e: PointerEvt) => {
+    startRef.current = { x: e.nativeEvent.clientX, y: e.nativeEvent.clientY };
+    draggedRef.current = false;
+  }, []);
+
+  const onPointerMove = useCallback(
+    (e: PointerEvt) => {
+      if (!startRef.current || draggedRef.current) return;
+
+      const dx = e.nativeEvent.clientX - startRef.current.x;
+      const dy = e.nativeEvent.clientY - startRef.current.y;
+
+      if (dx * dx + dy * dy > thresholdSq) {
+        draggedRef.current = true;
+      }
+    },
+    [thresholdSq],
+  );
+
+  const onPointerUp = useCallback((_e: PointerEvt) => {
+    startRef.current = null;
+  }, []);
+
+  const isClick = useCallback(() => !draggedRef.current, []);
+
+  return { onPointerDown, onPointerMove, onPointerUp, isClick };
+}

--- a/app/packages/looker-3d/src/state/accessors.ts
+++ b/app/packages/looker-3d/src/state/accessors.ts
@@ -85,6 +85,15 @@ export const useHoveredLabel3d = () => {
   return useRecoilValue(hoveredLabelAtom);
 };
 
+/**
+ * Hook to set the currently hovered 3D label in annotation mode.
+ *
+ * @returns A function that accepts the new hovered label (or null to clear)
+ */
+export const useSetHoveredLabel3d = () => {
+  return useSetRecoilState(hoveredLabelAtom);
+};
+
 export const useFo3dPerformanceStats = () => {
   return useRecoilValue(fo3dPerformanceStatsAtom);
 };

--- a/app/packages/looker-3d/src/types.ts
+++ b/app/packages/looker-3d/src/types.ts
@@ -171,6 +171,19 @@ export interface EventHandlers {
   onPointerMove: (e: ThreeEvent<PointerEvent>) => void;
 }
 
+/**
+ * `useEventHandlers()`'s raw shape — `label` is a call-time argument rather
+ * than curried in, so one set of handlers can be shared across every label
+ * in an instanced batch. `Cuboid` curries its own label once into the
+ * `EventHandlers` shape above for the standalone path.
+ */
+export interface InstancedEventHandlers {
+  onPointerOver: (label: any, e?: ThreeEvent<PointerEvent>) => void;
+  onPointerOut: (label: any) => void;
+  onPointerMissed: () => void;
+  onPointerMove: (label: any, e: ThreeEvent<PointerEvent>) => void;
+}
+
 export type Archetype3d = "point" | "cuboid" | "polyline" | "annotation-plane";
 
 /**

--- a/app/packages/looker-3d/src/types.ts
+++ b/app/packages/looker-3d/src/types.ts
@@ -172,16 +172,29 @@ export interface EventHandlers {
 }
 
 /**
+ * The minimal shape `useEventHandlers()`'s implementation actually reads
+ * (`_id`, `path`, plus assorted optional fields accessed loosely) — kept
+ * structural rather than `OverlayLabel` itself because the instanced batch's
+ * `ReconciledDetection3D`/`ReconciledPolyline3D` labels omit `selected`
+ * (see `ReconciledDetection3D`), so they aren't assignable to `OverlayLabel`
+ * even though every label type used here is a strict superset of this.
+ */
+export type InstancedLabel = {
+  _id: string;
+  path: string | string[];
+} & Record<string, unknown>;
+
+/**
  * `useEventHandlers()`'s raw shape — `label` is a call-time argument rather
  * than curried in, so one set of handlers can be shared across every label
  * in an instanced batch. `Cuboid` curries its own label once into the
  * `EventHandlers` shape above for the standalone path.
  */
 export interface InstancedEventHandlers {
-  onPointerOver: (label: any, e?: ThreeEvent<PointerEvent>) => void;
-  onPointerOut: (label: any) => void;
+  onPointerOver: (label: InstancedLabel, e?: ThreeEvent<PointerEvent>) => void;
+  onPointerOut: (label: InstancedLabel) => void;
   onPointerMissed: () => void;
-  onPointerMove: (label: any, e: ThreeEvent<PointerEvent>) => void;
+  onPointerMove: (label: InstancedLabel, e: ThreeEvent<PointerEvent>) => void;
 }
 
 export type Archetype3d = "point" | "cuboid" | "polyline" | "annotation-plane";

--- a/app/packages/looker-3d/src/types.ts
+++ b/app/packages/looker-3d/src/types.ts
@@ -172,17 +172,18 @@ export interface EventHandlers {
 }
 
 /**
- * The minimal shape `useEventHandlers()`'s implementation actually reads
- * (`_id`, `path`, plus assorted optional fields accessed loosely) — kept
- * structural rather than `OverlayLabel` itself because the instanced batch's
- * `ReconciledDetection3D`/`ReconciledPolyline3D` labels omit `selected`
- * (see `ReconciledDetection3D`), so they aren't assignable to `OverlayLabel`
- * even though every label type used here is a strict superset of this.
+ * The minimal shape `useEventHandlers()`'s public contract needs (`_id`,
+ * `path`) — kept structural rather than `OverlayLabel` itself because the
+ * instanced batch's `ReconciledDetection3D`/`ReconciledPolyline3D` labels
+ * omit `selected` (see `ReconciledDetection3D`), so they aren't assignable
+ * to `OverlayLabel` even though every label type used here is a strict
+ * superset of this. No index signature needed — structural typing already
+ * lets every concrete label type (with its extra fields) satisfy this.
  */
 export type InstancedLabel = {
   _id: string;
   path: string | string[];
-} & Record<string, unknown>;
+};
 
 /**
  * `useEventHandlers()`'s raw shape — `label` is a call-time argument rather


### PR DESCRIPTION
## 🔗 Related Issues

[FOEPD-4264]

## 📋 What changes are proposed in this pull request?

Cuboid rendering in Looker3d was one set of geometries, materials and draw calls **per box**, which fell over on dense scenes. This batches every non-edited cuboid into three objects:

- one `InstancedMesh` for the bodies, which doubles as the clickable/hoverable volume
- one merged `LineSegmentsGeometry` for all outlines (plus orientation shafts and axes when enabled)
- one `InstancedMesh` for all orientation arrowheads

On a dense stress scene this moved **1.6 → 75 FPS** and **21,058 → 13 geometries** at the same 9 draw calls.

The cuboid actively being edited still renders through the standalone `Cuboid` component, so it keeps its gizmo, face-resize handles and per-object interactivity. `ThreeDLabels` partitions on the selected label: hero object interactive, everything else batched.

Because instanced geometry can't carry per-object React handlers, the batch resolves which label was touched from `e.instanceId`, and tracks the hovered index itself (r3f doesn't guarantee `instanceId` on pointer-out).

Supporting extractions, all dependency-free and unit tested: `cuboid-instance-geometry.ts` (matrix/edge math), `shared/useDragGate.ts` (drag-vs-click threshold), `shared/useDisplayCuboidTransform.ts`, `shared/cuboid-orientation-geometry.ts`. `useEventHandlers` now takes the label as a call-time argument so one handler set can serve a whole batch.

### Also in here: the package's tests were never running

Worth calling out because it's a test-infrastructure fix, not a feature change.

`vite.config.ts` computed `isPluginBuild` as `STANDALONE !== "true"`, which is **true under vitest**. So `viteExternalsPlugin` applied during test runs and rewrote `react` / `react-dom` / `recoil` / `@fiftyone/state` to `window.*` globals. In the default `node` test environment that shim throws `window is not defined` at import time, so every test file reaching React or Recoil failed to *load* — including all three this PR adds. Vitest reports that as a failing suite rather than a missing test, which is why it went unnoticed.

The plugin is now skipped under `VITEST` and the package runs in jsdom. `useDisplayCuboidTransform.test.ts` additionally imported the state barrel, which reaches `@fiftyone/state`'s Relay fragments and needs the Relay Babel transform vitest doesn't run; it now stands in a real atom for `transformModeAtom`.

**Package suite: 409 passing / 34 failing files → 547 passing / 10 failing.** No file regressed (passing files 28 → 52); all 10 remaining were already failing, from pre-existing Relay and jsdom-asset issues in files this PR doesn't touch.

## 🧪 How is this patch tested? If it is not, please explain why.

547 unit tests pass. New/updated in this PR:

- **`cuboid-instance-geometry.test.ts`** — body and arrowhead matrices, box edge positions, geometry resolution, `localToWorld` (rotation, translation, `Vector3`-vs-tuple, and two guards on its module-level scratch vectors: no write-back through a caller's `Vector3`, no bleed between calls), and `setSegmentColor`.
- `shared/hooks.test.ts`, `shared/useDragGate.test.ts`, `shared/useDisplayCuboidTransform.test.ts`, `shared/cuboid-orientation-geometry.test.ts` — now actually execute.

`setSegmentColor` is worth a note: review found it wrote colors into the interleaved buffers without flagging them dirty, so recolors never reached the GPU. That was fixed but never locked in. The new guard is **verified to fail when the flagging is removed**, and asserts on `version` rather than `needsUpdate` — on three's buffers `needsUpdate` is a write-only setter that bumps `version`, and reading it yields `undefined`, so an expectation against it would pass even with the flagging gone.

Manually verified on a dense point-cloud scene: hover, select, and the drag-vs-click threshold behave as before; the FPS/geometry-count numbers above come from that scene.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes.

Cuboid rendering in the 3D visualizer is now batched, substantially improving frame rate on samples with many cuboids.

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [x] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other

[FOEPD-4264]: https://voxel51.atlassian.net/browse/FOEPD-4264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3546
<!-- enterprise-sync-pr:end -->