### PR TITLE
[release] cherry-pick: bump @voxel51/voodo to 0.1.0

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -74,7 +74,7 @@
     "resolutions": {
         "@types/mapbox-gl": "2.7.21",
         "@types/react": "18.3.12",
-        "@voxel51/voodo": "^0.0.41",
+        "@voxel51/voodo": "^0.1.0",
         "brace-expansion": "^5.0.6",
         "minimatch": "9.0.7",
         "prettier": "~3.8.4",

--- a/app/package.json
+++ b/app/package.json
@@ -74,7 +74,7 @@
     "resolutions": {
         "@types/mapbox-gl": "2.7.21",
         "@types/react": "18.3.12",
-        "@voxel51/voodo": "^0.0.39",
+        "@voxel51/voodo": "^0.0.41",
         "brace-expansion": "^5.0.6",
         "minimatch": "9.0.7",
         "prettier": "~3.8.4",

--- a/app/packages/components/package.json
+++ b/app/packages/components/package.json
@@ -53,7 +53,7 @@
         "@mui/material": "^5.9.0",
         "@react-spring/web": "^9.7.3",
         "@textea/json-viewer": "^3.4.1",
-        "@voxel51/voodo": "^0.0.39",
+        "@voxel51/voodo": "^0.0.41",
         "classnames": "^2.3.1",
         "framer-motion": "^6.2.7",
         "material-icons": "^1.13.12",

--- a/app/packages/components/package.json
+++ b/app/packages/components/package.json
@@ -53,7 +53,7 @@
         "@mui/material": "^5.9.0",
         "@react-spring/web": "^9.7.3",
         "@textea/json-viewer": "^3.4.1",
-        "@voxel51/voodo": "^0.0.41",
+        "@voxel51/voodo": "^0.1.0",
         "classnames": "^2.3.1",
         "framer-motion": "^6.2.7",
         "material-icons": "^1.13.12",

--- a/app/packages/core/package.json
+++ b/app/packages/core/package.json
@@ -24,7 +24,7 @@
         "@mui/material": "^5.9.0",
         "@react-spring/web": "^9.4.3",
         "@use-gesture/react": "^10.3.0",
-        "@voxel51/voodo": "^0.0.39",
+        "@voxel51/voodo": "^0.0.41",
         "@xstate/react": "1.3.3",
         "classnames": "^2.2.6",
         "color": "^4.2.3",

--- a/app/packages/core/package.json
+++ b/app/packages/core/package.json
@@ -24,7 +24,7 @@
         "@mui/material": "^5.9.0",
         "@react-spring/web": "^9.4.3",
         "@use-gesture/react": "^10.3.0",
-        "@voxel51/voodo": "^0.0.41",
+        "@voxel51/voodo": "^0.1.0",
         "@xstate/react": "1.3.3",
         "classnames": "^2.2.6",
         "color": "^4.2.3",

--- a/app/packages/multimodal/package.json
+++ b/app/packages/multimodal/package.json
@@ -82,7 +82,7 @@
         "@mcap/support": "^1.1.0",
         "@react-three/drei": "9.105.4",
         "@react-three/fiber": "^8.18.0",
-        "@voxel51/voodo": "^0.0.39",
+        "@voxel51/voodo": "^0.0.41",
         "buffer": "^6.0.3",
         "colormap": "^2.3.2",
         "date-fns": "^4.1.0",

--- a/app/packages/multimodal/package.json
+++ b/app/packages/multimodal/package.json
@@ -82,7 +82,7 @@
         "@mcap/support": "^1.1.0",
         "@react-three/drei": "9.105.4",
         "@react-three/fiber": "^8.18.0",
-        "@voxel51/voodo": "^0.0.41",
+        "@voxel51/voodo": "^0.1.0",
         "buffer": "^6.0.3",
         "colormap": "^2.3.2",
         "date-fns": "^4.1.0",

--- a/app/packages/playback/package.json
+++ b/app/packages/playback/package.json
@@ -15,7 +15,7 @@
     "dependencies": {
         "@fiftyone/commands": "workspace:^",
         "@fiftyone/tiling": "*",
-        "@voxel51/voodo": "^0.0.39",
+        "@voxel51/voodo": "^0.0.41",
         "jotai": "^2.9.3",
         "jotai-optics": "^0.4.0",
         "vite-plugin-svgr": "^4.2.0"

--- a/app/packages/playback/package.json
+++ b/app/packages/playback/package.json
@@ -15,7 +15,7 @@
     "dependencies": {
         "@fiftyone/commands": "workspace:^",
         "@fiftyone/tiling": "*",
-        "@voxel51/voodo": "^0.0.41",
+        "@voxel51/voodo": "^0.1.0",
         "jotai": "^2.9.3",
         "jotai-optics": "^0.4.0",
         "vite-plugin-svgr": "^4.2.0"

--- a/app/packages/similarity-search/package.json
+++ b/app/packages/similarity-search/package.json
@@ -17,7 +17,7 @@
         "@fiftyone/plugins": "*",
         "@fiftyone/spaces": "*",
         "@fiftyone/state": "*",
-        "@voxel51/voodo": "^0.0.39"
+        "@voxel51/voodo": "^0.0.41"
     },
     "devDependencies": {
         "vite": "^7.3.2",

--- a/app/packages/similarity-search/package.json
+++ b/app/packages/similarity-search/package.json
@@ -17,7 +17,7 @@
         "@fiftyone/plugins": "*",
         "@fiftyone/spaces": "*",
         "@fiftyone/state": "*",
-        "@voxel51/voodo": "^0.0.41"
+        "@voxel51/voodo": "^0.1.0"
     },
     "devDependencies": {
         "vite": "^7.3.2",

--- a/app/packages/state/package.json
+++ b/app/packages/state/package.json
@@ -35,7 +35,7 @@
         "@fiftyone/relay": "*",
         "@fiftyone/utilities": "*",
         "@microsoft/fetch-event-source": "^2.0.1",
-        "@voxel51/voodo": "^0.0.41",
+        "@voxel51/voodo": "^0.1.0",
         "html2canvas": "1.0.0-rc.7",
         "lodash": "^4.18.1"
     }

--- a/app/packages/state/package.json
+++ b/app/packages/state/package.json
@@ -35,7 +35,7 @@
         "@fiftyone/relay": "*",
         "@fiftyone/utilities": "*",
         "@microsoft/fetch-event-source": "^2.0.1",
-        "@voxel51/voodo": "^0.0.39",
+        "@voxel51/voodo": "^0.0.41",
         "html2canvas": "1.0.0-rc.7",
         "lodash": "^4.18.1"
     }

--- a/app/packages/tiling/package.json
+++ b/app/packages/tiling/package.json
@@ -5,7 +5,7 @@
     "types": "./src/index.ts",
     "packageManager": "yarn@4.9.1",
     "dependencies": {
-        "@voxel51/voodo": "^0.0.39",
+        "@voxel51/voodo": "^0.0.41",
         "clsx": "^2.1.1",
         "jotai": "^2.9.3",
         "react-mosaic-component": "^6.1.1"

--- a/app/packages/tiling/package.json
+++ b/app/packages/tiling/package.json
@@ -5,7 +5,7 @@
     "types": "./src/index.ts",
     "packageManager": "yarn@4.9.1",
     "dependencies": {
-        "@voxel51/voodo": "^0.0.41",
+        "@voxel51/voodo": "^0.1.0",
         "clsx": "^2.1.1",
         "jotai": "^2.9.3",
         "react-mosaic-component": "^6.1.1"

--- a/app/packages/video-annotation/package.json
+++ b/app/packages/video-annotation/package.json
@@ -17,7 +17,7 @@
         "@fiftyone/state": "workspace:*",
         "@fiftyone/tiling": "workspace:*",
         "@fiftyone/utilities": "workspace:*",
-        "@voxel51/voodo": "^0.0.41",
+        "@voxel51/voodo": "^0.1.0",
         "clsx": "^2.1.0",
         "jotai": "^2.9.3",
         "lru-cache": "^11.0.1",

--- a/app/packages/video-annotation/package.json
+++ b/app/packages/video-annotation/package.json
@@ -17,7 +17,7 @@
         "@fiftyone/state": "workspace:*",
         "@fiftyone/tiling": "workspace:*",
         "@fiftyone/utilities": "workspace:*",
-        "@voxel51/voodo": "^0.0.39",
+        "@voxel51/voodo": "^0.0.41",
         "clsx": "^2.1.0",
         "jotai": "^2.9.3",
         "lru-cache": "^11.0.1",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2882,7 +2882,7 @@ __metadata:
     "@textea/json-viewer": "npm:^3.4.1"
     "@types/react-input-autosize": "npm:^2.2.1"
     "@types/react-syntax-highlighter": "npm:^15.5.6"
-    "@voxel51/voodo": "npm:^0.0.41"
+    "@voxel51/voodo": "npm:^0.1.0"
     classnames: "npm:^2.3.1"
     framer-motion: "npm:^6.2.7"
     material-icons: "npm:^1.13.12"
@@ -2936,7 +2936,7 @@ __metadata:
     "@types/styled-components": "npm:^5.1.23"
     "@use-gesture/react": "npm:^10.3.0"
     "@vitejs/plugin-react-refresh": "npm:^1.3.3"
-    "@voxel51/voodo": "npm:^0.0.41"
+    "@voxel51/voodo": "npm:^0.1.0"
     "@xstate/react": "npm:1.3.3"
     classnames: "npm:^2.2.6"
     color: "npm:^4.2.3"
@@ -3250,7 +3250,7 @@ __metadata:
     "@react-three/drei": "npm:9.105.4"
     "@react-three/fiber": "npm:^8.18.0"
     "@types/three": "npm:^0.182.0"
-    "@voxel51/voodo": "npm:^0.0.41"
+    "@voxel51/voodo": "npm:^0.1.0"
     buffer: "npm:^6.0.3"
     colormap: "npm:^2.3.2"
     date-fns: "npm:^4.1.0"
@@ -3289,7 +3289,7 @@ __metadata:
     "@eslint/compat": "npm:^1.1.1"
     "@fiftyone/commands": "workspace:^"
     "@fiftyone/tiling": "npm:*"
-    "@voxel51/voodo": "npm:^0.0.41"
+    "@voxel51/voodo": "npm:^0.1.0"
     eslint: "npm:9.7.0"
     eslint-plugin-react: "npm:^7.35.0"
     eslint-plugin-react-hooks: "npm:rc"
@@ -3341,7 +3341,7 @@ __metadata:
     "@fiftyone/plugins": "npm:*"
     "@fiftyone/spaces": "npm:*"
     "@fiftyone/state": "npm:*"
-    "@voxel51/voodo": "npm:^0.0.41"
+    "@voxel51/voodo": "npm:^0.1.0"
     vite: "npm:^7.3.2"
     vite-plugin-externals: "npm:^0.5.0"
   peerDependencies:
@@ -3388,7 +3388,7 @@ __metadata:
     "@fiftyone/utilities": "npm:*"
     "@microsoft/fetch-event-source": "npm:^2.0.1"
     "@testing-library/react-hooks": "npm:latest"
-    "@voxel51/voodo": "npm:^0.0.41"
+    "@voxel51/voodo": "npm:^0.1.0"
     babel-plugin-relay: "npm:^14.1.0"
     html2canvas: "npm:1.0.0-rc.7"
     lodash: "npm:^4.18.1"
@@ -3407,7 +3407,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fiftyone/tiling@workspace:packages/tiling"
   dependencies:
-    "@voxel51/voodo": "npm:^0.0.41"
+    "@voxel51/voodo": "npm:^0.1.0"
     clsx: "npm:^2.1.1"
     jotai: "npm:^2.9.3"
     react-mosaic-component: "npm:^6.1.1"
@@ -3452,7 +3452,7 @@ __metadata:
     "@fiftyone/tiling": "workspace:*"
     "@fiftyone/utilities": "workspace:*"
     "@types/dom-webcodecs": "npm:^0.1.18"
-    "@voxel51/voodo": "npm:^0.0.41"
+    "@voxel51/voodo": "npm:^0.1.0"
     clsx: "npm:^2.1.0"
     eslint: "npm:9.7.0"
     eslint-plugin-react: "npm:^7.35.0"
@@ -8888,9 +8888,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@voxel51/voodo@npm:^0.0.41":
-  version: 0.0.41
-  resolution: "@voxel51/voodo@npm:0.0.41"
+"@voxel51/voodo@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "@voxel51/voodo@npm:0.1.0"
   dependencies:
     "@dnd-kit/core": "npm:^6.3.1"
     "@dnd-kit/sortable": "npm:^10.0.0"
@@ -8906,7 +8906,7 @@ __metadata:
     react: ^18.0.0
     react-dom: ^18.0.0
     react-is: ^18.0.0
-  checksum: 10/6bc0b3e25e7d2cd91c355a064e3fc0de5b29d0c6202ae1d1c7b8c6322f285e104382e06603879b66faaa474ebb0d9cfc286f6c329bce16f89559193306b0aaf1
+  checksum: 10/fb6f49778b5ad74527b110bbd5a091c24c22dd795f6b3307ed518cbb72426d83cf9511e7f393e63d6b6827db4060085aec5de14f2af7445ef27e6d5770154bc9
   languageName: node
   linkType: hard
 

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2882,7 +2882,7 @@ __metadata:
     "@textea/json-viewer": "npm:^3.4.1"
     "@types/react-input-autosize": "npm:^2.2.1"
     "@types/react-syntax-highlighter": "npm:^15.5.6"
-    "@voxel51/voodo": "npm:^0.0.39"
+    "@voxel51/voodo": "npm:^0.0.41"
     classnames: "npm:^2.3.1"
     framer-motion: "npm:^6.2.7"
     material-icons: "npm:^1.13.12"
@@ -2936,7 +2936,7 @@ __metadata:
     "@types/styled-components": "npm:^5.1.23"
     "@use-gesture/react": "npm:^10.3.0"
     "@vitejs/plugin-react-refresh": "npm:^1.3.3"
-    "@voxel51/voodo": "npm:^0.0.39"
+    "@voxel51/voodo": "npm:^0.0.41"
     "@xstate/react": "npm:1.3.3"
     classnames: "npm:^2.2.6"
     color: "npm:^4.2.3"
@@ -3250,7 +3250,7 @@ __metadata:
     "@react-three/drei": "npm:9.105.4"
     "@react-three/fiber": "npm:^8.18.0"
     "@types/three": "npm:^0.182.0"
-    "@voxel51/voodo": "npm:^0.0.39"
+    "@voxel51/voodo": "npm:^0.0.41"
     buffer: "npm:^6.0.3"
     colormap: "npm:^2.3.2"
     date-fns: "npm:^4.1.0"
@@ -3289,7 +3289,7 @@ __metadata:
     "@eslint/compat": "npm:^1.1.1"
     "@fiftyone/commands": "workspace:^"
     "@fiftyone/tiling": "npm:*"
-    "@voxel51/voodo": "npm:^0.0.39"
+    "@voxel51/voodo": "npm:^0.0.41"
     eslint: "npm:9.7.0"
     eslint-plugin-react: "npm:^7.35.0"
     eslint-plugin-react-hooks: "npm:rc"
@@ -3341,7 +3341,7 @@ __metadata:
     "@fiftyone/plugins": "npm:*"
     "@fiftyone/spaces": "npm:*"
     "@fiftyone/state": "npm:*"
-    "@voxel51/voodo": "npm:^0.0.39"
+    "@voxel51/voodo": "npm:^0.0.41"
     vite: "npm:^7.3.2"
     vite-plugin-externals: "npm:^0.5.0"
   peerDependencies:
@@ -3388,7 +3388,7 @@ __metadata:
     "@fiftyone/utilities": "npm:*"
     "@microsoft/fetch-event-source": "npm:^2.0.1"
     "@testing-library/react-hooks": "npm:latest"
-    "@voxel51/voodo": "npm:^0.0.39"
+    "@voxel51/voodo": "npm:^0.0.41"
     babel-plugin-relay: "npm:^14.1.0"
     html2canvas: "npm:1.0.0-rc.7"
     lodash: "npm:^4.18.1"
@@ -3407,7 +3407,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fiftyone/tiling@workspace:packages/tiling"
   dependencies:
-    "@voxel51/voodo": "npm:^0.0.39"
+    "@voxel51/voodo": "npm:^0.0.41"
     clsx: "npm:^2.1.1"
     jotai: "npm:^2.9.3"
     react-mosaic-component: "npm:^6.1.1"
@@ -3452,7 +3452,7 @@ __metadata:
     "@fiftyone/tiling": "workspace:*"
     "@fiftyone/utilities": "workspace:*"
     "@types/dom-webcodecs": "npm:^0.1.18"
-    "@voxel51/voodo": "npm:^0.0.39"
+    "@voxel51/voodo": "npm:^0.0.41"
     clsx: "npm:^2.1.0"
     eslint: "npm:9.7.0"
     eslint-plugin-react: "npm:^7.35.0"
@@ -8888,9 +8888,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@voxel51/voodo@npm:^0.0.39":
-  version: 0.0.39
-  resolution: "@voxel51/voodo@npm:0.0.39"
+"@voxel51/voodo@npm:^0.0.41":
+  version: 0.0.41
+  resolution: "@voxel51/voodo@npm:0.0.41"
   dependencies:
     "@dnd-kit/core": "npm:^6.3.1"
     "@dnd-kit/sortable": "npm:^10.0.0"
@@ -8906,7 +8906,7 @@ __metadata:
     react: ^18.0.0
     react-dom: ^18.0.0
     react-is: ^18.0.0
-  checksum: 10/96c469628e093db589b292bd80c1aa5aa532da6de570c621cc61996ff525dda3d1b2d4764d03bd7f57b133d0f86162f3f5c1aa1c36f1d645bd20f29af7879466
+  checksum: 10/6bc0b3e25e7d2cd91c355a064e3fc0de5b29d0c6202ae1d1c7b8c6322f285e104382e06603879b66faaa474ebb0d9cfc286f6c329bce16f89559193306b0aaf1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Cherry-pick of #8125 onto `release/v1.20.0`.

Bumps `@voxel51/voodo` 0.0.39 → 0.1.0, a fix-only release: 0.0.39 plus [design-system#169](https://github.com/voxel51/design-system/pull/169) — open menus no longer scroll-lock the page, which fixes the grid re-rendering whenever a voodo dropdown is opened. Found during release testing. Excludes the 0.0.40/0.0.41 icons API changes.

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3544
<!-- enterprise-sync-pr:end -->