### PR TITLE
docs: AI-assisted annotation, Services, and cross-links

### DIFF
--- a/docs/source/enterprise/agentic_labeling.rst
+++ b/docs/source/enterprise/agentic_labeling.rst
@@ -30,8 +30,8 @@ labels can go on to train a custom model for large-scale Auto-Labeling.
 Availability and prerequisites
 ______________________________
 
-Agentic Labeling is a FiftyOne Enterprise only feature and requires a running
-Agentic Labeler service.
+Agentic Labeling is a `FiftyOne Enterprise <https://voxel51.com/enterprise/>`_
+only feature and requires a running Agentic Labeler service.
 
 Agentic Labeling is supported for image datasets and frames views of video
 datasets. 3D, grouped, and multimodal datasets are not yet supported.

--- a/docs/source/enterprise/agentic_labeling.rst
+++ b/docs/source/enterprise/agentic_labeling.rst
@@ -278,7 +278,7 @@ Region Captioning      A caption per object
 Classification
 --------------
 
-Assign a single label to the whole image. Your **Text prompt** does the work —
+Assign a single label to the whole image. Use the **Text prompt** to 
 describe the classes and the decision you want. Use **Allowed classes** to hold
 the model to a fixed set of labels, or leave it empty to let the model choose
 freely.
@@ -305,7 +305,7 @@ Caption
 -------
 
 Produce a free-text description of the whole image. Your **Text prompt** fully
-controls the caption's style, length, and focus — be explicit, or you will get
+controls the caption's style, length, and focus. Be explicit, or you will get
 the model's default.
 
 .. image:: https://cdn.voxel51.com/enterprise_agentic_labeling/al_task_caption.webp
@@ -318,18 +318,21 @@ Region tasks
 ------------
 
 **Region Classification** and **Region Captioning** apply the same ideas as
-their whole-image versions, but to **one object at a time**: Region
+their whole-image versions, but to **one object at a time**. Region
 Classification gives each object a label, and Region Captioning gives each
-object a caption. Both add two controls:
+object a caption. 
+
+Region tasks require an existing Detections field on the dataset.
+
+Both add two controls:
 
 - **Regions from** — where the objects come from. On a normal view, pick a
-  source **Detections** field; each detection becomes one object to label. On a
+  source **Detections** field and each detection becomes one object to label. On a
   patches view this control is hidden, because the patches themselves are the
-  objects. A normal view with no Detections field is a mismatch the panel
-  blocks.
+  objects.
 - **Show region as** — **Cropped** (the model sees only the object's patch) or
   **In context** (the model sees the full image with the object highlighted).
-  Use Cropped when the object stands alone; use In context when its
+  Use Cropped when the object stands alone, use In context when its
   surroundings matter.
 
 Predictions attach to each object, so every object carries its own label or
@@ -412,7 +415,6 @@ Using examples
     :alt: agentic-labeling-heads-up-classes
     :align: center
 
-- Examples can come from a different dataset than your targets.
 - Keep the set small — a few clear examples beat a large, noisy one.
 
 .. _agentic-labeling-troubleshooting:

--- a/docs/source/enterprise/agentic_labeling.rst
+++ b/docs/source/enterprise/agentic_labeling.rst
@@ -6,53 +6,45 @@ Agentic Labeling
 .. default-role:: code
 
 Agentic Labeling labels your images with a prompt-driven vision-language
-model. You describe what you want in plain language, optionally show the model
-a few examples, and it produces classifications, detections, captions, or
+model (VLM). You describe what you want in plain language, optionally show the model
+a few examples, and it produces labels like classifications, detections, captions, or
 per-region labels across your dataset for review. Agentic Labeling is
-available as a panel in the FiftyOne Enterprise App, in the **Analyze**
-category above the samples grid.
+available as a panel in the FiftyOne Enterprise App.
 
 .. _agentic-labeling-vs-auto-labeling:
 
 Agentic Labeling vs Auto-Labeling
 _________________________________
 
-Agentic Labeling and :ref:`verified-auto-labeling` are different features.
-Auto-Labeling pre-labels data with FiftyOne model-zoo and foundation models
-through a delegated pipeline, with a built-in, confidence-scored
-review-and-approval workflow. Reach for **Agentic Labeling** when your classes
-are open-world or best expressed as instructions and you want to iterate on a
-prompt; reach for **Auto-Labeling** when a zoo model already covers your task
-and you want managed QA at scale.
+Agentic Labeling is a form of auto-labeling. Where :ref:`verified-auto-labeling`
+applies a fixed set of learned classes from the FiftyOne Model Zoo and foundation models
+through a delegated pipeline with a confidence-scored review-and-approval
+workflow, Agentic Labeling uses a VLM that you steer with natural language and
+visual prompts, then refine until the output matches your ontology. The two are
+complementary: Agentic Labeling is often the first step to produce an initial
+labeled set quickly, and those labels can go on to train a custom model for
+large-scale Auto-Labeling.
 
 .. _agentic-labeling-availability:
 
 Availability and prerequisites
 ______________________________
 
-Agentic Labeling requires FiftyOne Enterprise and a running Agentic Labeler
-service — a GPU application that runs few-shot vision-language inference. The
-service image is maintained by Voxel51 and is deployed and managed by the
-platform; you do not install or configure it yourself.
+Agentic Labeling is a FiftyOne Enterprise only feature and requires a running Agentic Labeler
+service.
 
-The panel connects to the service automatically — there is no manual connect
-step in the normal workflow. A settings cog in the panel header opens a Setup
-view that shows the connection status; it also carries a collapsed **Developer
-/ standalone** option for pointing the panel at a service URL by hand, which
-you do not need in a normal Enterprise deployment. If no service is running,
-the panel reports that it is waiting for a running Agentic Labeler service —
-contact your administrator if this persists.
+Agentic labeling is supported for image datasets and frames views of video datasets. 3D, grouped, and multimodal datasets are not yet supported.
 
-You need an image dataset, or a frames view of a video dataset. 3D and
-point-cloud media are not supported.
+.. note::
+
+    Agentic Labeling is a Beta feature. Its behavior may change in future releases.
 
 .. _agentic-labeling-how-it-works:
 
 How it works
 ____________
 
-You drive Agentic Labeling by building a **Labeling Agent** — a saved snapshot
-of what you author:
+You drive Agentic Labeling by building a **Labeling Agent** which includes:
 
 - **Text prompt** — plain-language instructions for what to label.
 - **Task** — the kind of label to produce (classification, detection, caption,
@@ -67,21 +59,6 @@ samples, refine, **Save** it, then launch a **Run** at scale. Test previews are
 for iteration only and are never written to your dataset; only a run persists
 labels.
 
-The panel has four screens:
-
-===========  ===============================================
-Screen       What you do there
-===========  ===============================================
-Dashboard    Home base — lists your runs and agents
-Train Agent  Author, test, and save a Labeling Agent
-Run Config   Configure and launch a run of a saved agent
-Run Detail   Watch a run's progress and manage its lifecycle
-===========  ===============================================
-
-.. note::
-
-    Agentic Labeling is a Beta feature. The panel shows a **Beta** tag, and
-    its behavior may change in future releases.
 
 .. _agentic-labeling-user-guide:
 
@@ -97,22 +74,10 @@ Opening the panel
 -----------------
 
 Load your image dataset in the FiftyOne App, then open the **Agentic
-Labeling** panel from the new-panel (`+`) menu above the samples grid, under
-the **Analyze** category. The panel opens on the grid and lands on the
-Dashboard.
+Labeling** panel from the new-panel (`+`) menu above the samples grid.
 
 .. image:: https://cdn.voxel51.com/enterprise_agentic_labeling/al_panel_open.webp
     :alt: agentic-labeling-panel-open
-    :align: center
-
-If the current dataset — or the active slice of a grouped dataset — is an
-unsupported media type, the panel body is replaced by a splash screen with no
-controls. Video datasets need a frames view first; a frames view reads as
-images and works normally. 3D and point-cloud media are not supported. Switch
-to an image dataset or a frames view to continue.
-
-.. image:: https://cdn.voxel51.com/enterprise_agentic_labeling/al_unsupported_media.webp
-    :alt: agentic-labeling-unsupported-media
     :align: center
 
 .. _agentic-labeling-dashboard:
@@ -120,14 +85,7 @@ to an image dataset or a frames view to continue.
 Dashboard
 ---------
 
-The Dashboard is your landing page, with **Runs** and **Agents** sub-tabs.
-Before you have built anything, the Runs tab shows a cold-start splash whose
-call-to-action follows what you have:
-
-- With no agents yet, the button reads **Train Agent**.
-- Once you have at least one agent, it reads **New Run**.
-
-Click **Train Agent** to author your first agent.
+The Dashboard is the landing page with **Runs** and **Agents** sub-tabs. Click **Train Agent** to author your first agent.
 
 .. image:: https://cdn.voxel51.com/enterprise_agentic_labeling/al_dashboard_coldstart.webp
     :alt: agentic-labeling-dashboard-coldstart
@@ -138,35 +96,26 @@ Click **Train Agent** to author your first agent.
 Training an agent
 -----------------
 
-The **Train new agent** page is a single scrolling page, top to bottom:
-
-1. **Text prompt** — your instructions.
-2. **Settings** — the task picker and allowed classes.
-3. **Visual prompts** — optional examples.
-4. **Test results** — a preview on grid samples.
-
-A sticky footer holds **Cancel** and **Save agent**. You author, test, and
-save without leaving this page.
+Training an agent consists of writing a **Text prompt**, picking a **Task**, optionally setting **Allowed classes**, and optionally adding a few visual **Examples**. 
+This is an iterative process: test the agent on a few samples, refine the prompt and examples, and repeat until the agent produces the desired outputs.
 
 .. image:: https://cdn.voxel51.com/enterprise_agentic_labeling/al_train_overview.webp
     :alt: agentic-labeling-train-overview
     :align: center
 
-In **Text prompt**, describe what to label, and be specific — for example,
-*frayed cables visible against the sky*. Then choose a **Task** in the
-five-card picker: Classification, Detection, Caption, Region Classification, or
-Region Captioning. Pick the one that matches the labels you want; see
-:ref:`agentic-labeling-tasks` for what each produces.
+In **Text prompt**, describe what to label, and be specific. For example,
+*frayed cables visible against the sky*. Then choose a **Task**: Classification, Detection, Caption, Region Classification, or
+Region Captioning. See
+:ref:`agentic-labeling-tasks` for more information on the task types.
 
 .. image:: https://cdn.voxel51.com/enterprise_agentic_labeling/al_task_picker.webp
     :alt: agentic-labeling-task-picker
     :align: center
 
 For Classification and Detection you can set **Allowed classes** to constrain
-the model's output: type a class and press Enter. Classification accepts
-multiple classes; Detection accepts exactly one — the input locks until you
-remove that class. Leave the field empty to let the model choose any label.
-Allowed classes constrain the output only; define what each class means in the
+the model's output. Classification accepts
+multiple classes and Detection accepts exactly one. Leave the field empty to let the model choose any label.
+Allowed classes constrain the output only, define what each class means in the
 text prompt. See :ref:`agentic-labeling-prompting`.
 
 .. _agentic-labeling-examples:
@@ -175,14 +124,12 @@ Adding examples
 ^^^^^^^^^^^^^^^
 
 A few good examples sharpen the agent's behavior. Select samples in the
-FiftyOne grid, then use the **Visual prompts** section. Each polarity —
-**Positive** and **Negative** — has its own row, capped at **5** examples.
-Click **Pick from grid** on a row to commit your current grid selection:
+FiftyOne grid, then use the **Visual prompts** section. You can provide a max of 5
+**Positive** and **Negative** examples each.
 
-- **Use labels from** — inherit each sample's value from a matching field, or
-  choose **None (no label)**.
-- With **None**, type a manual label or add the samples unlabeled.
-- Click **Done** to commit the selection, or **Cancel** to back out.
+When you choose to **Pick from grid**, you can add selected samples from the grid. Additionally, you can  provide existing labels on your dataset as prompts, or you can manually add example labels directly in the panel by click on the sample thumbnails.
+
+..note 
 
 The **Upload** button next to **Pick from grid** is not yet available.
 
@@ -199,19 +146,19 @@ as `(2/5)`.
 
 .. note::
 
-    Prefer positive examples — they do the real work. Reach for a prompt fix
-    before adding negatives. See :ref:`agentic-labeling-prompting`.
+    Positive examples generally provide a greater benefit to results. See :ref:`agentic-labeling-prompting`.
 
 .. _agentic-labeling-test:
 
 Testing an agent
 ----------------
 
-Scroll to **Test results**, select a few representative samples in the grid,
-then click **Run test** — disabled until you have a grid selection, and while
-the service is unreachable. The agent runs on just those samples and previews
-the result on each: a class chip, drawn boxes, or a caption. Test previews are
-**never written to your dataset**; only a run persists labels.
+With FiftyOne, you can quickly iterate on your prompts by testing your agent on a few samples at a time. 
+
+Scroll to **Test results**, select some representative samples in the grid,
+then click **Run test**. The agent runs on just those samples and previews
+the resulting labels of your selected **Task**. Test previews are
+**never written to your dataset**.
 
 .. image:: https://cdn.voxel51.com/enterprise_agentic_labeling/al_test_results.webp
     :alt: agentic-labeling-test-results
@@ -219,8 +166,7 @@ the result on each: a class chip, drawn boxes, or a caption. Test previews are
 
 Click any thumbnail to open the prediction editor. Inspect or correct a
 prediction and step through the results with **Previous** and **Next**, drop
-one with **Remove from results**, and close the editor with the back arrow in
-its header. Edits change only the preview — they do not persist to your
+one with **Remove from results**. Edits change only the preview, they do not persist to your
 dataset or modify the agent.
 
 .. image:: https://cdn.voxel51.com/enterprise_agentic_labeling/al_prediction_editor.webp
@@ -228,8 +174,7 @@ dataset or modify the agent.
     :align: center
 
 Refine the prompt, adjust allowed classes, add or remove examples, and run the
-test again until the previews are mostly correct on a representative handful. A
-run's output is meant to be reviewed, so you do not need perfection here.
+test again until the previews are mostly correct on a representative handful. 
 
 .. _agentic-labeling-save:
 

--- a/docs/source/enterprise/agentic_labeling.rst
+++ b/docs/source/enterprise/agentic_labeling.rst
@@ -6,38 +6,40 @@ Agentic Labeling
 .. default-role:: code
 
 Agentic Labeling labels your images with a prompt-driven vision-language
-model (VLM). You describe what you want in plain language, optionally show the model
-a few examples, and it produces labels like classifications, detections, captions, or
-per-region labels across your dataset for review. Agentic Labeling is
-available as a panel in the FiftyOne Enterprise App.
+model (VLM). You describe what you want in plain language, optionally show
+the model a few examples, and it produces labels like classifications,
+detections, captions, or per-region labels across your dataset for review.
+Agentic Labeling is available as a panel in the FiftyOne Enterprise App.
 
 .. _agentic-labeling-vs-auto-labeling:
 
 Agentic Labeling vs Auto-Labeling
 _________________________________
 
-Agentic Labeling is a form of auto-labeling. Where :ref:`verified-auto-labeling`
-applies a fixed set of learned classes from the FiftyOne Model Zoo and foundation models
-through a delegated pipeline with a confidence-scored review-and-approval
-workflow, Agentic Labeling uses a VLM that you steer with natural language and
-visual prompts, then refine until the output matches your ontology. The two are
-complementary: Agentic Labeling is often the first step to produce an initial
-labeled set quickly, and those labels can go on to train a custom model for
-large-scale Auto-Labeling.
+Agentic Labeling is a form of auto-labeling. Where
+:ref:`verified-auto-labeling` applies a fixed set of learned classes from the
+FiftyOne Model Zoo and foundation models through a delegated pipeline with a
+confidence-scored review-and-approval workflow, Agentic Labeling uses a VLM
+that you steer with natural language and visual prompts, then refine until the
+output matches your ontology. The two are complementary: Agentic Labeling is
+often the first step to produce an initial labeled set quickly, and those
+labels can go on to train a custom model for large-scale Auto-Labeling.
 
 .. _agentic-labeling-availability:
 
 Availability and prerequisites
 ______________________________
 
-Agentic Labeling is a FiftyOne Enterprise only feature and requires a running Agentic Labeler
-service.
+Agentic Labeling is a FiftyOne Enterprise only feature and requires a running
+Agentic Labeler service.
 
-Agentic labeling is supported for image datasets and frames views of video datasets. 3D, grouped, and multimodal datasets are not yet supported.
+Agentic Labeling is supported for image datasets and frames views of video
+datasets. 3D, grouped, and multimodal datasets are not yet supported.
 
 .. note::
 
-    Agentic Labeling is a Beta feature. Its behavior may change in future releases.
+    Agentic Labeling is a Beta feature. Its behavior may change in future
+    releases.
 
 .. _agentic-labeling-how-it-works:
 
@@ -85,7 +87,8 @@ Labeling** panel from the new-panel (`+`) menu above the samples grid.
 Dashboard
 ---------
 
-The Dashboard is the landing page with **Runs** and **Agents** sub-tabs. Click **Train Agent** to author your first agent.
+The Dashboard is the landing page with **Runs** and **Agents** sub-tabs. Click
+**Train Agent** to author your first agent.
 
 .. image:: https://cdn.voxel51.com/enterprise_agentic_labeling/al_dashboard_coldstart.webp
     :alt: agentic-labeling-dashboard-coldstart
@@ -96,26 +99,30 @@ The Dashboard is the landing page with **Runs** and **Agents** sub-tabs. Click *
 Training an agent
 -----------------
 
-Training an agent consists of writing a **Text prompt**, picking a **Task**, optionally setting **Allowed classes**, and optionally adding a few visual **Examples**. 
-This is an iterative process: test the agent on a few samples, refine the prompt and examples, and repeat until the agent produces the desired outputs.
+Training an agent consists of writing a **Text prompt**, picking a **Task**,
+optionally setting **Allowed classes**, and optionally adding a few visual
+**Examples**. This is an iterative process: test the agent on a few samples,
+refine the prompt and examples, and repeat until the agent produces the
+desired outputs.
 
 .. image:: https://cdn.voxel51.com/enterprise_agentic_labeling/al_train_overview.webp
     :alt: agentic-labeling-train-overview
     :align: center
 
 In **Text prompt**, describe what to label, and be specific. For example,
-*frayed cables visible against the sky*. Then choose a **Task**: Classification, Detection, Caption, Region Classification, or
-Region Captioning. See
-:ref:`agentic-labeling-tasks` for more information on the task types.
+*frayed cables visible against the sky*. Then choose a **Task**:
+Classification, Detection, Caption, Region Classification, or Region
+Captioning. See :ref:`agentic-labeling-tasks` for more information on the task
+types.
 
 .. image:: https://cdn.voxel51.com/enterprise_agentic_labeling/al_task_picker.webp
     :alt: agentic-labeling-task-picker
     :align: center
 
 For Classification and Detection you can set **Allowed classes** to constrain
-the model's output. Classification accepts
-multiple classes and Detection accepts exactly one. Leave the field empty to let the model choose any label.
-Allowed classes constrain the output only, define what each class means in the
+the model's output. Classification accepts multiple classes and Detection
+accepts exactly one. Leave the field empty to let the model choose any label.
+Allowed classes constrain the output only; define what each class means in the
 text prompt. See :ref:`agentic-labeling-prompting`.
 
 .. _agentic-labeling-examples:
@@ -124,14 +131,17 @@ Adding examples
 ^^^^^^^^^^^^^^^
 
 A few good examples sharpen the agent's behavior. Select samples in the
-FiftyOne grid, then use the **Visual prompts** section. You can provide a max of 5
-**Positive** and **Negative** examples each.
+FiftyOne grid, then use the **Visual prompts** section. You can provide a max
+of 5 **Positive** and **Negative** examples each.
 
-When you choose to **Pick from grid**, you can add selected samples from the grid. Additionally, you can  provide existing labels on your dataset as prompts, or you can manually add example labels directly in the panel by click on the sample thumbnails.
+When you choose to **Pick from grid**, you can add selected samples from the
+grid. Additionally, you can provide existing labels on your dataset as
+prompts, or you can manually add example labels directly in the panel by
+clicking on the sample thumbnails.
 
-..note 
+.. note::
 
-The **Upload** button next to **Pick from grid** is not yet available.
+    The **Upload** button next to **Pick from grid** is not yet available.
 
 .. image:: https://cdn.voxel51.com/enterprise_agentic_labeling/al_pick_from_grid.webp
     :alt: agentic-labeling-pick-from-grid
@@ -146,14 +156,16 @@ as `(2/5)`.
 
 .. note::
 
-    Positive examples generally provide a greater benefit to results. See :ref:`agentic-labeling-prompting`.
+    Positive examples generally provide a greater benefit to results. See
+    :ref:`agentic-labeling-prompting`.
 
 .. _agentic-labeling-test:
 
 Testing an agent
 ----------------
 
-With FiftyOne, you can quickly iterate on your prompts by testing your agent on a few samples at a time. 
+With FiftyOne, you can quickly iterate on your prompts by testing your agent
+on a few samples at a time.
 
 Scroll to **Test results**, select some representative samples in the grid,
 then click **Run test**. The agent runs on just those samples and previews
@@ -166,29 +178,31 @@ the resulting labels of your selected **Task**. Test previews are
 
 Click any thumbnail to open the prediction editor. Inspect or correct a
 prediction and step through the results with **Previous** and **Next**, drop
-one with **Remove from results**. Edits change only the preview, they do not persist to your
-dataset or modify the agent.
+one with **Remove from results**. Edits change only the preview; they do not
+persist to your dataset or modify the agent.
 
 .. image:: https://cdn.voxel51.com/enterprise_agentic_labeling/al_prediction_editor.webp
     :alt: agentic-labeling-prediction-editor
     :align: center
 
 Refine the prompt, adjust allowed classes, add or remove examples, and run the
-test again until the previews are mostly correct on a representative handful. 
+test again until the previews are mostly correct on a representative handful.
 
 .. _agentic-labeling-save:
 
 Saving an agent
 ---------------
 
-When you're satisfied with the agent's behavior on test samples, click **Save agent** in the sticky footer to save your prompts and prepare the agent for a Run on the full dataset. 
+When you're satisfied with the agent's behavior on test samples, click **Save
+agent** in the sticky footer to save your prompts and prepare the agent for a
+Run on the full dataset.
 
 .. image:: https://cdn.voxel51.com/enterprise_agentic_labeling/al_save_agent_modal.webp
     :alt: agentic-labeling-save-agent
     :align: center
 
-Saved agents appear on the Dashboard's **Agents** tab with a menu offering **Edit**, **New run**,
-and **Delete** options. 
+Saved agents appear on the Dashboard's **Agents** tab with a menu offering
+**Edit**, **New run**, and **Delete** options.
 
 .. image:: https://cdn.voxel51.com/enterprise_agentic_labeling/al_agents_tab.webp
     :alt: agentic-labeling-agents-tab
@@ -199,8 +213,8 @@ and **Delete** options.
 Configuring and launching a run
 -------------------------------
 
-
-After training and saving an agent, launch a **Run** to label your data at scale.
+After training and saving an agent, launch a **Run** to label your data at
+scale.
 
 Open **Run Config** from the Dashboard's **New Run** button or an agent row's
 **New run** menu item, then configure the run:
@@ -208,7 +222,7 @@ Open **Run Config** from the Dashboard's **New Run** button or an agent row's
 - **Agent** (required) — the saved agent to run.
 - **Target** — the scope to label: **All samples**, **Current view**
   (:ref:`the current view <using-views>`), or **Current selection**
-  (:ref:`currently-selected samples <app-select-samples>`). 
+  (:ref:`currently-selected samples <app-select-samples>`).
 - **Label field** — the name of a new or existing field where predictions are
   written; use a new field name to avoid changing existing labels. On a
   patches target this becomes a **Detection attribute** selector instead — the
@@ -254,7 +268,9 @@ If a run fails, a red banner shows the error and a collapsible **Stack trace**.
     :align: center
 
 When the run completes, its labels are written to your chosen field, ready to
-review in the grid. Consider creating an :ref:`annotation workflow <enterprise-workflows>` for your annotators to review the results.
+review in the grid. Consider creating an
+:ref:`annotation workflow <enterprise-workflows>` for your annotators to
+review the results.
 
 .. _agentic-labeling-tasks:
 
@@ -278,7 +294,7 @@ Region Captioning      A caption per object
 Classification
 --------------
 
-Assign a single label to the whole image. Use the **Text prompt** to 
+Assign a single label to the whole image. Use the **Text prompt** to
 describe the classes and the decision you want. Use **Allowed classes** to hold
 the model to a fixed set of labels, or leave it empty to let the model choose
 freely.
@@ -320,19 +336,19 @@ Region tasks
 **Region Classification** and **Region Captioning** apply the same ideas as
 their whole-image versions, but to **one object at a time**. Region
 Classification gives each object a label, and Region Captioning gives each
-object a caption. 
+object a caption.
 
 Region tasks require an existing Detections field on the dataset.
 
 Both add two controls:
 
 - **Regions from** — where the objects come from. On a normal view, pick a
-  source **Detections** field and each detection becomes one object to label. On a
-  patches view this control is hidden, because the patches themselves are the
-  objects.
+  source **Detections** field and each detection becomes one object to label.
+  On a patches view this control is hidden, because the patches themselves are
+  the objects.
 - **Show region as** — **Cropped** (the model sees only the object's patch) or
   **In context** (the model sees the full image with the object highlighted).
-  Use Cropped when the object stands alone, use In context when its
+  Use Cropped when the object stands alone; use In context when its
   surroundings matter.
 
 Predictions attach to each object, so every object carries its own label or

--- a/docs/source/enterprise/agentic_labeling.rst
+++ b/docs/source/enterprise/agentic_labeling.rst
@@ -181,19 +181,14 @@ test again until the previews are mostly correct on a representative handful.
 Saving an agent
 ---------------
 
-Click **Save agent** in the sticky footer. Save is enabled as soon as the text
-prompt is non-empty — a blank draft cannot be saved — and a saved agent is
-required before you can launch a run. In the dialog, give the agent a **Name**
-(required) and an optional **Description**, then click **Save agent**.
+When you're satisfied with the agent's behavior on test samples, click **Save agent** in the sticky footer to save your prompts and prepare the agent for a Run on the full dataset. 
 
 .. image:: https://cdn.voxel51.com/enterprise_agentic_labeling/al_save_agent_modal.webp
     :alt: agentic-labeling-save-agent
     :align: center
 
-Saved agents appear on the Dashboard's **Agents** tab, one row each, with a
-**Ready** or **Draft** pill and a kebab menu offering **Edit**, **New run**,
-and **Delete**. Use the filter bar — search plus **Dataset**, **Owner**, and
-**Task** filters — to narrow a long list.
+Saved agents appear on the Dashboard's **Agents** tab with a menu offering **Edit**, **New run**,
+and **Delete** options. 
 
 .. image:: https://cdn.voxel51.com/enterprise_agentic_labeling/al_agents_tab.webp
     :alt: agentic-labeling-agents-tab
@@ -204,26 +199,23 @@ and **Delete**. Use the filter bar — search plus **Dataset**, **Owner**, and
 Configuring and launching a run
 -------------------------------
 
+
+After training and saving an agent, launch a **Run** to label your data at scale.
+
 Open **Run Config** from the Dashboard's **New Run** button or an agent row's
 **New run** menu item, then configure the run:
 
 - **Agent** (required) — the saved agent to run.
 - **Target** — the scope to label: **All samples**, **Current view**
   (:ref:`the current view <using-views>`), or **Current selection**
-  (:ref:`currently-selected samples <app-select-samples>`). Each option shows a
-  live count, and **Current selection** is disabled when nothing is selected.
+  (:ref:`currently-selected samples <app-select-samples>`). 
 - **Label field** — the name of a new or existing field where predictions are
   written; use a new field name to avoid changing existing labels. On a
   patches target this becomes a **Detection attribute** selector instead — the
-  attribute written onto each patch detection.
+  attribute written onto each detection.
 - **Run name** (optional) — a human-friendly name for the run.
 - **Advanced** — **Workers** (default **16**) and **Batch size** (default
   **32**).
-
-Click **Start run**. The button is blocked, with an inline message, when the
-agent and target do not match — for example, a whole-image agent pointed at a
-patches target, a Detection agent on a patches view, a region agent with no
-source field, or an empty selection.
 
 .. image:: https://cdn.voxel51.com/enterprise_agentic_labeling/al_run_config.webp
     :alt: agentic-labeling-run-config
@@ -246,12 +238,12 @@ samples.
 
 Click a card to open **Run Detail**, which shows:
 
-- an editable **name** and the current **status**;
-- a **metadata card** (dataset, label field, task, workers, batch size);
-- a **progress bar** with `completed / total` and parse-failure counts;
+- an editable **name** and the current **status**
+- a **metadata card** (dataset, label field, task, workers, batch size)
+- a **progress bar** with `completed / total` and parse-failure counts
 - the read-only **Agent configuration** — the prompt and example thumbnails
-  the run uses;
-- a **Notes** field;
+  the run uses
+- a **Notes** field
 - status-conditional actions: **Pause**, **Resume**, **Cancel**, **Delete**,
   and **New Run**.
 
@@ -262,7 +254,7 @@ If a run fails, a red banner shows the error and a collapsible **Stack trace**.
     :align: center
 
 When the run completes, its labels are written to your chosen field, ready to
-review in the grid like any other FiftyOne labels.
+review in the grid. Consider creating an :ref:`annotation workflow <enterprise-workflows>` for your annotators to review the results.
 
 .. _agentic-labeling-tasks:
 

--- a/docs/source/enterprise/plugins.rst
+++ b/docs/source/enterprise/plugins.rst
@@ -434,8 +434,8 @@ and their status.
 
 .. _enterprise-distributed-execution:
 
-Distributed execution __SUB_NEW__
-_________________________________
+Distributed execution
+_____________________
 
 .. versionadded:: 2.11.0
 
@@ -501,8 +501,8 @@ platform such as Databricks or Anyscale.
 
 .. _enterprise-on-demand-compute:
 
-On-demand compute __SUB_NEW__
------------------------------
+On-demand compute
+-----------------
 
 .. versionadded:: 2.11.0
 
@@ -532,6 +532,33 @@ externally-managed workflow orchestration tools, such as
 `Airflow <https://airflow.apache.org>`_, `Flyte <https://flyte.org>`_, and
 `Spark <https://spark.apache.org/>`_. Please contact your Voxel51 support team
 for further details.
+
+.. _enterprise-services:
+
+Services
+________
+
+Some builtin operators run as long-lived *services*: always-on model servers
+that stay ready between uses instead of spinning up a new job per run. Services
+are hosted by a **service orchestrator** and power GPU-backed, interactive
+features such as :ref:`agentic labeling <agentic-labeling>` and
+:ref:`AI-assisted annotation <in-app-ai-annotation>` (segmentation and video
+tracking), where a per-run cold start would otherwise make the experience too
+slow.
+
+Administrators manage services from the Services page under Settings >
+Services, where you can start, stop, and monitor each service and view its
+status.
+
+.. image:: https://cdn.voxel51.com/plugins/services_page.webp
+   :alt: enterprise-services-page
+   :align: center
+
+Services run on your own GPU infrastructure, provisioned through the service
+orchestrator. Administrators can refer to the
+`deployment guide <https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/docs/configuring-service-orchestrator.md>`_
+to learn how to configure the service orchestrator for their FiftyOne
+Enterprise deployment.
 
 .. _enterprise-managing-delegated-operations:
 
@@ -566,6 +593,17 @@ The table provides options to sort, search, and filter runs shown to refine the
 list as you like:
 
 .. image:: /images/plugins/operators/runs/runs_general.png
+
+.. _enterprise-deployment-runs:
+
+Deployment-level Runs page
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The Runs tab described above lives on a dataset. Users can also reach a
+**deployment-level** Runs page from Settings > Runs that opens the same table
+without first loading a dataset, making it a convenient entry point for
+monitoring delegated operations and long-running
+:ref:`service <enterprise-services>` operations across the whole deployment.
 
 .. _enterprise-runs-statuses:
 

--- a/docs/source/enterprise/verified_auto_labeling.rst
+++ b/docs/source/enterprise/verified_auto_labeling.rst
@@ -17,6 +17,11 @@ Auto-Labeling is powered by
 enabling you to perform Auto-Labeling in the background using your existing GPU
 infrastructure.
 
+.. note::
+
+    Want to try auto-labeling with a VLM? Check out :ref:`Agentic Labeling
+    <agentic-labeling>` in FiftyOne Enterprise.
+
 .. _verified-auto-labeling-how-it-works:
 
 How it works

--- a/docs/source/enterprise/verified_auto_labeling.rst
+++ b/docs/source/enterprise/verified_auto_labeling.rst
@@ -19,8 +19,7 @@ infrastructure.
 
 .. note::
 
-    Want to try auto-labeling with a VLM? Check out :ref:`Agentic Labeling
-    <agentic-labeling>` in FiftyOne Enterprise.
+    Check out :ref:`Agentic Labeling <agentic-labeling>` to explore using a VLM for auto-labeling!
 
 .. _verified-auto-labeling-how-it-works:
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -536,7 +536,7 @@ _________
 
    Data I/O <workflows/ingestion>
    Curation: Pre-Annotation <workflows/curation_pre>
-   Annotation <workflows/annotation>
+   Annotation __SUB_NEW__ <workflows/annotation>
    Curation: Post-Annotation <workflows/curation_post>
    Model Training <workflows/training>
    Model Inference <workflows/inference>

--- a/docs/source/user_guide/annotation.rst
+++ b/docs/source/user_guide/annotation.rst
@@ -349,6 +349,14 @@ Labels are not the only type of metadata available for edits in FiftyOne's in-Ap
 How to: 2D Label Annotation
 ----------------------------
 
+.. admonition:: Label faster with AI
+   :class: tip
+
+   FiftyOne can help you label images with AI: prompt masks with
+   :ref:`AI-assisted segmentation <in-app-ai-segmentation>`, or auto-label a
+   whole dataset from a few examples with
+   :ref:`Agentic Labeling <agentic-labeling>`.
+
 Creating a Classification label
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -379,8 +387,17 @@ A detection label's size and shape can be adjusted directly in the annotation ca
 .. image:: /_static/images/annotation/edit_bounding_box_canvas.gif
    :alt: Editing detection on canvas
 
+.. _creating-a-segmentation-label:
+
 Creating a Segmentation label
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. admonition:: Prompt masks with AI
+   :class: tip
+
+   Rather than painting a mask by hand, you can prompt one with a model using
+   the AI assistance tool — see
+   :ref:`AI-assisted image segmentation <in-app-ai-segmentation>`.
 
 .. image:: /_static/images/annotation/create_mask_button.png
    :alt: Create new mask button
@@ -466,8 +483,16 @@ The editing panel also enables editing the label, tags, confidence, index proper
 
 ----
 
+.. _how-to-video-annotation:
+
 How to: Video Annotation
 ------------------------
+
+.. admonition:: Label faster with AI
+   :class: tip
+
+   Track an object's mask across frames automatically with
+   :ref:`AI-assisted video tracking <in-app-video-tracking>`.
 
 .. |video-kf-icon| image:: https://cdn.voxel51.com/user_guide/annotation/video_toolbar_mark_keyframe_button.webp
    :height: 1.6em
@@ -518,6 +543,13 @@ Video annotation requires:
 
 Creating Object Tracks
 ~~~~~~~~~~~~~~~~~~~~~~
+
+.. admonition:: Track objects with AI
+   :class: tip
+
+   Instead of annotating each frame, you can prompt an object's mask on one
+   frame and track it across the rest — see
+   :ref:`AI-assisted video tracking <in-app-video-tracking>`.
 
 To create an object track, the
 :ref:`Annotation Schema <annotation-schema-format>` needs to contain a
@@ -943,3 +975,76 @@ Clicking on a primitive field in the "Annotate" tab will open the editing panel 
 
 .. image:: /_static/images/annotation/primitive_editing_panel.png
    :alt: Editing primitives in the right sidebar
+
+----
+
+.. _in-app-ai-annotation:
+
+How to: AI assisted annotation 🚀 __SUB_NEW__
+---------------------------------------------
+
+FiftyOne can put models to work in the annotation editor so you spend less time
+labeling by hand. Prompt masks with a segmentation model, track objects across
+video frames, or auto-label a whole dataset from a few examples with Agentic
+Labeling. These are `FiftyOne Enterprise <https://voxel51.com/enterprise/>`_
+features that run on your own GPU infrastructure as
+:ref:`services <enterprise-services>` started by an administrator.
+
+.. _in-app-ai-segmentation:
+
+Image segmentation
+~~~~~~~~~~~~~~~~~~
+
+Instead of drawing a mask by hand, you can prompt one with a segmentation
+model. Select the AI assistance tool in the mask toolbar, then click positive
+points on the object and negative points on regions to exclude; the model
+returns a mask after each click, so you can add points to refine it before
+saving. A built-in model works out of the box, and FiftyOne Enterprise
+deployments can run larger, finetuned models as a
+:ref:`service <enterprise-services>` on their own GPUs.
+
+.. image:: https://cdn.voxel51.com/user_guide/annotation/image_segmentation.webp
+   :alt: in-app-ai-segmentation
+   :align: center
+
+See :ref:`Creating a Segmentation label <creating-a-segmentation-label>` for
+the mask toolbar and drawing basics.
+
+.. _in-app-video-tracking:
+
+Video object tracking
+~~~~~~~~~~~~~~~~~~~~~
+
+On video, prompt an object's mask on one frame and track it across the
+remaining frames automatically. Review the tracked masks and add prompts on
+any frame to correct them. Video tracking is a FiftyOne Enterprise feature
+powered by a segmentation model running as a
+:ref:`service <enterprise-services>`.
+
+.. raw:: html
+
+   <video autoplay controls muted loop playsinline width="100%"
+          style="max-width:720px"
+          aria-label="Tracking an object's mask across video frames">
+     <source src="https://cdn.voxel51.com/user_guide/annotation/video_segmentation.mp4"
+             type="video/mp4">
+   </video>
+
+See :ref:`How to: Video Annotation <how-to-video-annotation>` for the video
+annotation basics.
+
+Agentic Labeling
+~~~~~~~~~~~~~~~~~
+
+Agentic Labeling uses a prompt-driven vision-language model to label an image
+dataset from a few examples: describe what you want, optionally add positive
+and negative example samples, preview the results, then apply the agent across
+your dataset for review. It runs as a FiftyOne Enterprise
+:ref:`service <enterprise-services>` that an administrator starts.
+
+.. image:: https://cdn.voxel51.com/enterprise_agentic_labeling/al_test_results.webp
+   :alt: agentic-labeling-test-results
+   :align: center
+
+See the :ref:`Agentic Labeling <agentic-labeling>` guide for the full
+workflow, supported tasks, and prompting tips.

--- a/docs/source/user_guide/evaluation.rst
+++ b/docs/source/user_guide/evaluation.rst
@@ -194,8 +194,8 @@ are included in the current view.
 
 .. _analyzing-scenarios:
 
-Analyzing scenarios  __SUB_NEW__
---------------------------------
+Analyzing scenarios
+-------------------
 
 .. note::
 
@@ -412,8 +412,8 @@ The example below demonstrates the basic interface:
 
 .. _model-evaluation-panel:
 
-Model Evaluation panel __SUB_NEW__
-__________________________________
+Model Evaluation panel
+______________________
 
 When you load a dataset in the App that contains one or more
 :ref:`evaluations <evaluating-models>`, you can open the

--- a/docs/source/workflows/annotation.rst
+++ b/docs/source/workflows/annotation.rst
@@ -1,7 +1,7 @@
 .. _workflows-annotation:
 
-Annotation
-==========
+Annotation __SUB_NEW__
+======================
 
 Once you know what to label, FiftyOne helps you get it labeled. You can
 annotate :ref:`directly in the FiftyOne App <in-app-annotation>`, or round-trip

--- a/docs/source/workflows/annotation.rst
+++ b/docs/source/workflows/annotation.rst
@@ -1,7 +1,7 @@
 .. _workflows-annotation:
 
-Annotation __SUB_NEW__
-======================
+Annotation
+==========
 
 Once you know what to label, FiftyOne helps you get it labeled. You can
 annotate :ref:`directly in the FiftyOne App <in-app-annotation>`, or round-trip
@@ -20,6 +20,6 @@ Auto-Labeling 🚀 to generate high-quality labels automatically.
 
    Annotating datasets <../user_guide/annotation>
    Annotation Workflows 🚀 __SUB_NEW__ <../enterprise/workflows>
-   Auto-Labeling 🚀 <../enterprise/verified_auto_labeling>
    Agentic Labeling 🚀 __SUB_NEW__ <../enterprise/agentic_labeling>
+   Auto-Labeling 🚀 <../enterprise/verified_auto_labeling>
    Building Annotation Workflows and Ontologies __SUB_NEW__ <../tutorials/fiftyone_annotation_workflows.ipynb>

--- a/docs/source/workflows/evaluation.rst
+++ b/docs/source/workflows/evaluation.rst
@@ -16,6 +16,6 @@ separate model errors from label errors.
    :maxdepth: 1
    :hidden:
 
-   Evaluating models __SUB_NEW__ <../user_guide/evaluation>
+   Evaluating models <../user_guide/evaluation>
    Evaluating object detections <../tutorials/evaluate_detections.ipynb>
    Evaluating a classifier <../tutorials/evaluate_classifications.ipynb>


### PR DESCRIPTION
Draft on top of Jacob's Agentic Labeling docs branch (`docs/agentic-labeling`).

## What's in here
**`user_guide/annotation.rst`**
- Fills the "How to: AI assisted annotation" section — intro (links to FiftyOne Enterprise) + **Image segmentation**, **Video object tracking**, **Agentic Labeling** (points to the full agentic labeling guide), each with CDN-hosted media.
- Adds "Label faster with AI" tip callouts atop the 2D and Video how-to sections and in their relevant subsections (Creating a Segmentation label / Creating Object Tracks).

**`enterprise/plugins.rst`**
- New **Services** section by "Configuring your orchestrator(s)": service-orchestrator use case, Services page screenshot, and a link to the service-orc deployment guide.
- **Deployment-level Runs page**, distinguished from the dataset-level Runs tab.
- Services section links to the AI-assisted annotation guide.

**`enterprise/verified_auto_labeling.rst`**
- Callout cross-linking Agentic Labeling.

**`enterprise/agentic_labeling.rst`**
- RST formatting (79-col wrap, fixed a broken `.. note::`) + reference cleanups; reworded "vs Auto-Labeling" to frame AL as a form of auto-labeling.

## Media
Screenshots/video hosted on the docs CDN (`cdn.voxel51.com/plugins/…` and `.../user_guide/annotation/…`) — no binaries added to the repo.

## Testing
`bash docs/generate_docs.bash -f` builds clean; all new cross-refs resolve with no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)