### PR TITLE
[release] cherry-pick: misc annotation ux improvements

### DIFF
--- a/app/packages/annotation/src/agents/hooks/index.ts
+++ b/app/packages/annotation/src/agents/hooks/index.ts
@@ -5,6 +5,8 @@ export * from "./useAgentSelector";
 export * from "./useAIAnnotationActionGroup";
 export * from "./useAnnotationAgent";
 export * from "./useApplyInferenceResult";
+export * from "./useClearPointPrompts";
+export * from "./useEndPointSession";
 export { useInferenceStatus } from "./useInferenceStatus";
 export type {
   InferenceError,

--- a/app/packages/annotation/src/agents/hooks/useAgentSelector.test.ts
+++ b/app/packages/annotation/src/agents/hooks/useAgentSelector.test.ts
@@ -1,0 +1,75 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentDescriptor } from "../registry";
+import type { InferenceResultProxy } from "../types";
+
+const descriptor = (id: string) =>
+  ({
+    id,
+    label: id,
+    agent: {},
+  }) as unknown as AgentDescriptor<InferenceResultProxy>;
+
+const hoisted = vi.hoisted(() => ({
+  agents: [] as unknown[],
+}));
+
+// Stable identity: `useAgentSelector` re-loads (and re-renders) whenever the
+// registry object changes, so a fresh literal per render would never settle.
+const registry = {
+  listAgents: async () => hoisted.agents,
+  register: async () => undefined,
+};
+
+vi.mock("./useAgentRegistry", () => ({
+  useAgentRegistry: () => registry,
+}));
+
+import { useAgentSelector } from "./useAgentSelector";
+
+const STORAGE_KEY = "HA.lastAnnotationAgentId";
+
+describe("useAgentSelector", () => {
+  beforeEach(() => {
+    hoisted.agents = [descriptor("agent-1"), descriptor("agent-2")];
+    localStorage.clear();
+  });
+
+  it("persists the selected agent's id", async () => {
+    const { result } = renderHook(() => useAgentSelector());
+    await waitFor(() => expect(result.current.isResolved).toBe(true));
+
+    act(() => result.current.setActiveAgent(descriptor("agent-2")));
+
+    expect(result.current.activeAgent?.id).toBe("agent-2");
+    expect(result.current.lastAgentId).toBe("agent-2");
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('"agent-2"');
+  });
+
+  // The bootstrap's fallback isn't a user choice: remembering it would
+  // overwrite the real pick before a late-registering agent shows up.
+  it("does not persist a default-agent selection", async () => {
+    const { result } = renderHook(() => useAgentSelector());
+    await waitFor(() => expect(result.current.isResolved).toBe(true));
+
+    act(() => result.current.setActiveAgent(descriptor("agent-2")));
+    act(() => result.current.setDefaultAgent(descriptor("agent-1")));
+
+    expect(result.current.activeAgent?.id).toBe("agent-1");
+    expect(result.current.lastAgentId).toBe("agent-2");
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('"agent-2"');
+  });
+
+  // The dropdown clears the selection when an agent's service goes down;
+  // forgetting the pick there would lose it for good.
+  it("keeps the remembered id when the selection is cleared", async () => {
+    const { result } = renderHook(() => useAgentSelector());
+    await waitFor(() => expect(result.current.isResolved).toBe(true));
+
+    act(() => result.current.setActiveAgent(descriptor("agent-2")));
+    act(() => result.current.setActiveAgent(null));
+
+    expect(result.current.activeAgent).toBeNull();
+    expect(result.current.lastAgentId).toBe("agent-2");
+  });
+});

--- a/app/packages/annotation/src/agents/hooks/useAgentSelector.test.ts
+++ b/app/packages/annotation/src/agents/hooks/useAgentSelector.test.ts
@@ -25,9 +25,18 @@ vi.mock("./useAgentRegistry", () => ({
   useAgentRegistry: () => registry,
 }));
 
-import { useAgentSelector } from "./useAgentSelector";
-
 const STORAGE_KEY = "HA.lastAnnotationAgentId";
+
+/**
+ * Load a fresh copy of the module. The persisted atom is module-scoped in
+ * jotai's default store, so clearing `localStorage` alone leaves a previous
+ * case's selection in memory — and because the atom hydrates with `getOnInit`,
+ * a stored id is only read at creation time. Both need a new module instance.
+ */
+const loadSelector = async () => {
+  vi.resetModules();
+  return (await import("./useAgentSelector")).useAgentSelector;
+};
 
 describe("useAgentSelector", () => {
   beforeEach(() => {
@@ -36,6 +45,7 @@ describe("useAgentSelector", () => {
   });
 
   it("persists the selected agent's id", async () => {
+    const useAgentSelector = await loadSelector();
     const { result } = renderHook(() => useAgentSelector());
     await waitFor(() => expect(result.current.isResolved).toBe(true));
 
@@ -49,6 +59,7 @@ describe("useAgentSelector", () => {
   // The bootstrap's fallback isn't a user choice: remembering it would
   // overwrite the real pick before a late-registering agent shows up.
   it("does not persist a default-agent selection", async () => {
+    const useAgentSelector = await loadSelector();
     const { result } = renderHook(() => useAgentSelector());
     await waitFor(() => expect(result.current.isResolved).toBe(true));
 
@@ -63,6 +74,7 @@ describe("useAgentSelector", () => {
   // The dropdown clears the selection when an agent's service goes down;
   // forgetting the pick there would lose it for good.
   it("keeps the remembered id when the selection is cleared", async () => {
+    const useAgentSelector = await loadSelector();
     const { result } = renderHook(() => useAgentSelector());
     await waitFor(() => expect(result.current.isResolved).toBe(true));
 
@@ -71,5 +83,26 @@ describe("useAgentSelector", () => {
 
     expect(result.current.activeAgent).toBeNull();
     expect(result.current.lastAgentId).toBe("agent-2");
+  });
+
+  // The reload path, and the reason the atom hydrates with `getOnInit`: the
+  // bootstrap reads `lastAgentId` as soon as the registry resolves, which can
+  // beat a mount-time hydration — so it has to be there on the FIRST render.
+  // Sampled in the render body, not from `result.current`: by the time the
+  // latter is readable, effects have flushed and a mount-time hydration would
+  // look identical.
+  it("hydrates the remembered id from storage on the first render", async () => {
+    localStorage.setItem(STORAGE_KEY, '"agent-2"');
+
+    const useAgentSelector = await loadSelector();
+    const seen: (string | null)[] = [];
+
+    renderHook(() => {
+      const selector = useAgentSelector();
+      seen.push(selector.lastAgentId);
+      return selector;
+    });
+
+    expect(seen[0]).toBe("agent-2");
   });
 });

--- a/app/packages/annotation/src/agents/hooks/useAgentSelector.ts
+++ b/app/packages/annotation/src/agents/hooks/useAgentSelector.ts
@@ -1,7 +1,8 @@
 import { atom, useAtom } from "jotai";
+import { atomWithStorage } from "jotai/utils";
 import { AgentDescriptor } from "../registry";
 import { useAgentRegistry } from "./useAgentRegistry";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { InferenceResultProxy } from "../types";
 
 /**
@@ -17,23 +18,53 @@ export interface AgentSelector {
   /** `true` once the `agents` query has completed */
   isResolved: boolean;
 
-  /** Set the active agent. */
+  /**
+   * Id of the agent the user last picked, persisted across reloads. The
+   * default-agent bootstrap prefers it over the first selectable agent so the
+   * pick sticks. `null` until the user has chosen one.
+   */
+  lastAgentId: string | null;
+
+  /** Set the active agent, remembering it as {@link lastAgentId}. */
   setActiveAgent: (
     descriptor: AgentDescriptor<InferenceResultProxy> | null,
   ) => void;
+
+  /**
+   * Set the active agent WITHOUT remembering it — for the default-agent
+   * bootstrap. Persisting a fallback would overwrite the user's pick with
+   * whatever happened to be registered first, which is the whole thing
+   * {@link lastAgentId} exists to survive.
+   */
+  setDefaultAgent: (descriptor: AgentDescriptor<InferenceResultProxy>) => void;
 }
 
-const activeAgentAtom = atom<AgentDescriptor<InferenceResultProxy> | null>(
-  null,
+// The initial value carries its type rather than `atom<T | null>(null)`: a bare
+// `null` argument matches jotai's read-only `atom(read)` overload under this
+// project's non-strict null checks, which types the atom's setter as `never`.
+const activeAgentAtom = atom(
+  null as AgentDescriptor<InferenceResultProxy> | null,
 );
 const isResolvedAtom = atom<boolean>(false);
+
+// Only the id is persisted — a descriptor carries a live agent instance, which
+// is rebuilt by the registry on every load. `getOnInit` so the stored id is
+// readable on the very first render: the default-agent bootstrap fires as soon
+// as the registry resolves, which can beat this atom's mount-time hydration.
+const lastAgentIdAtom = atomWithStorage<string | null>(
+  "HA.lastAnnotationAgentId",
+  null,
+  undefined,
+  { getOnInit: true },
+);
 
 /**
  * Hook providing the current {@link AgentSelector} state.
  */
 export const useAgentSelector = (): AgentSelector => {
-  const [activeAgent, setActiveAgent] = useAtom(activeAgentAtom);
+  const [activeAgent, setAgent] = useAtom(activeAgentAtom);
   const [isResolved, setIsResolved] = useAtom(isResolvedAtom);
+  const [lastAgentId, setLastAgentId] = useAtom(lastAgentIdAtom);
 
   const [agents, setAgents] = useState<AgentDescriptor<InferenceResultProxy>[]>(
     () => [],
@@ -61,13 +92,29 @@ export const useAgentSelector = (): AgentSelector => {
     };
   }, [registry]);
 
+  // A cleared selection (the dropdown drops an agent whose service went down)
+  // deliberately leaves `lastAgentId` alone, so the same agent is re-adopted
+  // once it's selectable again instead of being forgotten.
+  const setActiveAgent = useCallback(
+    (descriptor: AgentDescriptor<InferenceResultProxy> | null) => {
+      setAgent(descriptor);
+
+      if (descriptor) {
+        setLastAgentId(descriptor.id);
+      }
+    },
+    [setAgent, setLastAgentId],
+  );
+
   return useMemo(
     () => ({
       activeAgent,
       agents,
       isResolved,
+      lastAgentId,
       setActiveAgent,
+      setDefaultAgent: setAgent,
     }),
-    [activeAgent, agents, isResolved, setActiveAgent],
+    [activeAgent, agents, isResolved, lastAgentId, setActiveAgent, setAgent],
   );
 };

--- a/app/packages/annotation/src/agents/hooks/useClearPointPrompts.test.ts
+++ b/app/packages/annotation/src/agents/hooks/useClearPointPrompts.test.ts
@@ -1,0 +1,38 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  pointSelection: {
+    clearPoints: vi.fn(),
+  },
+  toolsState: {
+    reset: vi.fn(),
+  },
+}));
+
+vi.mock("./usePointSelection", () => ({
+  usePointSelection: () => hoisted.pointSelection,
+}));
+
+vi.mock("./useToolsContext", () => ({
+  useToolsState: () => hoisted.toolsState,
+}));
+
+import { useClearPointPrompts } from "./useClearPointPrompts";
+
+describe("useClearPointPrompts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // The overlay doesn't emit per-point delete events, so wiping only the
+  // rendered keypoints would leave the cleared points in the next infer() call.
+  it("clears the rendered points AND the prompt state", () => {
+    const { result } = renderHook(() => useClearPointPrompts());
+
+    result.current();
+
+    expect(hoisted.pointSelection.clearPoints).toHaveBeenCalledTimes(1);
+    expect(hoisted.toolsState.reset).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/packages/annotation/src/agents/hooks/useClearPointPrompts.ts
+++ b/app/packages/annotation/src/agents/hooks/useClearPointPrompts.ts
@@ -1,0 +1,22 @@
+import { useCallback } from "react";
+import { usePointSelection } from "./usePointSelection";
+import { useToolsState } from "./useToolsContext";
+
+/**
+ * Clears the pending point prompts, leaving point selection active so the user
+ * can keep placing points on an empty canvas.
+ *
+ * Both halves are required: `clearPoints` only wipes the rendered keypoints,
+ * and the overlay doesn't emit the per-point delete events the tools state is
+ * fed from — so without the reset the cleared points would still reach the
+ * next `infer()` call.
+ */
+export const useClearPointPrompts = (): (() => void) => {
+  const { clearPoints } = usePointSelection();
+  const { reset: resetToolsState } = useToolsState();
+
+  return useCallback(() => {
+    clearPoints();
+    resetToolsState();
+  }, [clearPoints, resetToolsState]);
+};

--- a/app/packages/annotation/src/agents/hooks/useEndPointSession.test.ts
+++ b/app/packages/annotation/src/agents/hooks/useEndPointSession.test.ts
@@ -1,0 +1,40 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  clearPointPrompts: vi.fn(),
+  seed: {
+    markSeedNew: vi.fn(),
+    shouldSeedNew: vi.fn(() => false),
+    consumeSeedNew: vi.fn(() => false),
+    clearSeedNew: vi.fn(),
+  },
+}));
+
+vi.mock("./useClearPointPrompts", () => ({
+  useClearPointPrompts: () => hoisted.clearPointPrompts,
+}));
+
+vi.mock("./usePointSelectionSeed", () => ({
+  usePointSelectionSeed: () => hoisted.seed,
+}));
+
+import { useEndPointSession } from "./useEndPointSession";
+
+describe("useEndPointSession", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Clearing alone leaves the committed detection selected — and auto-extend
+  // put it on the next frame too — so the next click would refine (overwrite)
+  // its mask instead of creating the new object being pointed at.
+  it("clears the prompts AND seeds a new label for the next point", () => {
+    const { result } = renderHook(() => useEndPointSession());
+
+    result.current();
+
+    expect(hoisted.clearPointPrompts).toHaveBeenCalledTimes(1);
+    expect(hoisted.seed.markSeedNew).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/packages/annotation/src/agents/hooks/useEndPointSession.ts
+++ b/app/packages/annotation/src/agents/hooks/useEndPointSession.ts
@@ -1,0 +1,28 @@
+import { useCallback } from "react";
+import { useClearPointPrompts } from "./useClearPointPrompts";
+import { usePointSelectionSeed } from "./usePointSelectionSeed";
+
+/**
+ * Ends the current point-prompt session: drops the pending prompts AND makes
+ * the next point seed a NEW label rather than refining whatever is still
+ * selected.
+ *
+ * Both halves are the session boundary. Clearing alone leaves the previous
+ * target selected — and a committed detection stays selected (auto-extended
+ * onto later frames), so the next click would land as a refinement that
+ * overwrites that label's mask instead of creating the new object the user is
+ * pointing at.
+ *
+ * A right-click commit runs the same transition through
+ * `finalizePointSelection`; use this at the boundaries that aren't a commit —
+ * the playhead moving off the prompted frame, or a tracking run starting.
+ */
+export const useEndPointSession = (): (() => void) => {
+  const clearPointPrompts = useClearPointPrompts();
+  const { markSeedNew } = usePointSelectionSeed();
+
+  return useCallback(() => {
+    clearPointPrompts();
+    markSeedNew();
+  }, [clearPointPrompts, markSeedNew]);
+};

--- a/app/packages/annotation/src/agents/hooks/useToolsContext.ts
+++ b/app/packages/annotation/src/agents/hooks/useToolsContext.ts
@@ -51,7 +51,10 @@ export interface ToolsState extends ToolsContext {
 const positivePointsAtom = atom<PointDescriptor[]>([]);
 const negativePointsAtom = atom<PointDescriptor[]>([]);
 const regionsOfInterestAtom = atom<ROI[]>([]);
-const textPromptAtom = atom<string | null>(null);
+// The initial value carries its type rather than `atom<string | null>(null)`: a
+// bare `null` argument matches jotai's read-only `atom(read)` overload under
+// this project's non-strict null checks, which types the setter as `never`.
+const textPromptAtom = atom(null as string | null);
 
 /**
  * Hook which returns the current {@link ToolsContext} (read-only).
@@ -138,11 +141,14 @@ export const useToolsState = (): ToolsState => {
     [positivePoints, setNegativePoints, setPositivePoints],
   );
 
+  // Each write keeps the previous value when it's already empty so a reset on
+  // already-clear state doesn't re-render subscribers — callers reset on
+  // recurring signals (every playhead move), not just at session edges.
   const reset = useCallback(() => {
-    setPositivePoints([]);
-    setNegativePoints([]);
-    setRegionsOfInterest([]);
-    setTextPrompt(null);
+    setPositivePoints((prev) => (prev.length > 0 ? [] : prev));
+    setNegativePoints((prev) => (prev.length > 0 ? [] : prev));
+    setRegionsOfInterest((prev) => (prev.length > 0 ? [] : prev));
+    setTextPrompt((prev) => (prev === null ? prev : null));
   }, [
     setPositivePoints,
     setNegativePoints,

--- a/app/packages/annotation/src/index.ts
+++ b/app/packages/annotation/src/index.ts
@@ -14,6 +14,8 @@ export type {
   PropagationInferenceResult,
 } from "./agents/types";
 export { useAgentRegistry } from "./agents/hooks/useAgentRegistry";
+export { useClearPointPrompts } from "./agents/hooks/useClearPointPrompts";
+export { useEndPointSession } from "./agents/hooks/useEndPointSession";
 export { useSampleDescriptor } from "./agents/hooks/useSampleDescriptor";
 export {
   useSetSegmentBitmapSource,

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useAIAnnotationMode.test.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useAIAnnotationMode.test.ts
@@ -39,6 +39,9 @@ const hoisted = vi.hoisted(() => ({
     consumeSeedNew: vi.fn(() => false),
     clearSeedNew: vi.fn(),
   },
+  // The combined overlay-points + prompt-state clear; covered end to end in
+  // `useClearPointPrompts.test.ts`.
+  clearPointPrompts: vi.fn(),
   selectedLabelRef: {
     value: null as null | { overlay?: { id: string } },
   },
@@ -53,6 +56,7 @@ vi.mock("@fiftyone/annotation/src/agents", () => ({
     setActiveTask: hoisted.activeTaskSpies.setActiveTask,
   }),
   useAgentSelector: () => hoisted.agentSelectorRef.value,
+  useClearPointPrompts: () => hoisted.clearPointPrompts,
   usePointSelection: () => hoisted.pointSelectionSpies,
   usePointSelectionSeed: () => hoisted.pointSelectionSeedSpies,
   useToolsState: () => hoisted.toolsStateSpies,
@@ -131,7 +135,7 @@ describe("useAIAnnotationMode", () => {
   });
 
   describe("deactivate", () => {
-    it("deactivates point selection, clears prompt + tools state, clears task, flips isActive", () => {
+    it("deactivates point selection, clears the point prompts, clears task, flips isActive", () => {
       const { result } = renderHook(() => useAIAnnotationMode());
       act(() => result.current.activate());
 
@@ -139,8 +143,7 @@ describe("useAIAnnotationMode", () => {
       act(() => result.current.deactivate());
 
       expect(hoisted.pointSelectionSpies.deactivate).toHaveBeenCalledTimes(1);
-      expect(hoisted.pointSelectionSpies.clearPoints).toHaveBeenCalledTimes(1);
-      expect(hoisted.toolsStateSpies.reset).toHaveBeenCalledTimes(1);
+      expect(hoisted.clearPointPrompts).toHaveBeenCalledTimes(1);
       expect(hoisted.activeTaskSpies.setActiveTask).toHaveBeenCalledWith(null);
       expect(result.current.isActive).toBe(false);
     });
@@ -224,8 +227,7 @@ describe("useAIAnnotationMode", () => {
       hoisted.selectedLabelRef.value = { overlay: { id: "label-b" } };
       rerender();
 
-      expect(hoisted.pointSelectionSpies.clearPoints).not.toHaveBeenCalled();
-      expect(hoisted.toolsStateSpies.reset).not.toHaveBeenCalled();
+      expect(hoisted.clearPointPrompts).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useAIAnnotationMode.test.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useAIAnnotationMode.test.ts
@@ -80,6 +80,26 @@ const resetMode = (result: {
   act(() => result.current.deactivate());
 };
 
+type SelectorSpies = {
+  setActiveAgent: ReturnType<typeof vi.fn>;
+  setDefaultAgent: ReturnType<typeof vi.fn>;
+};
+
+/** Installs a selector state for the bootstrap to read; returns its spies. */
+const givenSelector = (state: Record<string, unknown>): SelectorSpies => {
+  hoisted.agentSelectorRef.value = {
+    isResolved: true,
+    activeAgent: undefined,
+    agents: [],
+    lastAgentId: null,
+    setActiveAgent: vi.fn(),
+    setDefaultAgent: vi.fn(),
+    ...state,
+  };
+
+  return hoisted.agentSelectorRef.value as SelectorSpies;
+};
+
 // ── Tests ────────────────────────────────────────────────────────────────────
 
 describe("useAIAnnotationMode", () => {
@@ -92,6 +112,7 @@ describe("useAIAnnotationMode", () => {
       activeAgent: { id: "agent-1" },
       agents: [{ id: "agent-1" }],
       setActiveAgent: vi.fn(),
+      setDefaultAgent: vi.fn(),
     };
   });
 
@@ -160,52 +181,90 @@ describe("useAIAnnotationMode", () => {
 
   describe("default-agent bootstrap", () => {
     it("auto-selects the first agent when none is active and the selector has resolved", () => {
-      hoisted.agentSelectorRef.value = {
-        isResolved: true,
-        activeAgent: undefined,
+      const spies = givenSelector({
         agents: [{ id: "agent-1" }, { id: "agent-2" }],
-        setActiveAgent: vi.fn(),
-      };
+      });
 
       renderHook(() => useAIAnnotationMode());
 
-      expect(
-        (
-          hoisted.agentSelectorRef.value as {
-            setActiveAgent: ReturnType<typeof vi.fn>;
-          }
-        ).setActiveAgent,
-      ).toHaveBeenCalledWith({ id: "agent-1" });
+      expect(spies.setDefaultAgent).toHaveBeenCalledWith({ id: "agent-1" });
+    });
+
+    // The fallback is not a user choice. Persisting it would overwrite the
+    // remembered pick on every reload — and it always would, because a
+    // service-backed agent isn't registered yet on the first resolve.
+    it("does NOT remember the fallback it picked", () => {
+      const spies = givenSelector({
+        agents: [{ id: "agent-1" }],
+        lastAgentId: "agent-2",
+      });
+
+      renderHook(() => useAIAnnotationMode());
+
+      expect(spies.setDefaultAgent).toHaveBeenCalledWith({ id: "agent-1" });
+      expect(spies.setActiveAgent).not.toHaveBeenCalled();
     });
 
     it("does NOT change the active agent when one is already selected", () => {
       renderHook(() => useAIAnnotationMode());
-      expect(
-        (
-          hoisted.agentSelectorRef.value as {
-            setActiveAgent: ReturnType<typeof vi.fn>;
-          }
-        ).setActiveAgent,
-      ).not.toHaveBeenCalled();
+
+      const spies = hoisted.agentSelectorRef.value as SelectorSpies;
+      expect(spies.setDefaultAgent).not.toHaveBeenCalled();
+      expect(spies.setActiveAgent).not.toHaveBeenCalled();
     });
 
-    it("does NOT auto-select before the selector has resolved", () => {
-      hoisted.agentSelectorRef.value = {
-        isResolved: false,
-        activeAgent: undefined,
-        agents: [],
-        setActiveAgent: vi.fn(),
-      };
+    it("restores the remembered agent rather than the first one", () => {
+      const spies = givenSelector({
+        agents: [{ id: "agent-1" }, { id: "agent-2" }],
+        lastAgentId: "agent-2",
+      });
 
       renderHook(() => useAIAnnotationMode());
 
-      expect(
-        (
-          hoisted.agentSelectorRef.value as {
-            setActiveAgent: ReturnType<typeof vi.fn>;
-          }
-        ).setActiveAgent,
-      ).not.toHaveBeenCalled();
+      expect(spies.setDefaultAgent).toHaveBeenCalledWith({ id: "agent-2" });
+    });
+
+    it("falls back to the first agent when the remembered one isn't selectable", () => {
+      const spies = givenSelector({
+        // The remembered agent is registered but its service is down.
+        agents: [{ id: "agent-1" }, { id: "agent-2", available: false }],
+        lastAgentId: "agent-2",
+      });
+
+      renderHook(() => useAIAnnotationMode());
+
+      expect(spies.setDefaultAgent).toHaveBeenCalledWith({ id: "agent-1" });
+    });
+
+    // Service-backed agents register after the static ones, so the remembered
+    // pick is routinely absent on the first resolve and must still be adopted
+    // when it lands.
+    it("adopts the remembered agent when it registers after the fallback", () => {
+      const spies = givenSelector({
+        activeAgent: { id: "agent-1" },
+        agents: [{ id: "agent-1" }],
+        lastAgentId: "agent-2",
+      });
+
+      const { rerender } = renderHook(() => useAIAnnotationMode());
+      expect(spies.setDefaultAgent).not.toHaveBeenCalled();
+
+      const late = givenSelector({
+        activeAgent: { id: "agent-1" },
+        agents: [{ id: "agent-1" }, { id: "agent-2" }],
+        lastAgentId: "agent-2",
+      });
+      rerender();
+
+      expect(late.setDefaultAgent).toHaveBeenCalledWith({ id: "agent-2" });
+    });
+
+    it("does NOT auto-select before the selector has resolved", () => {
+      const spies = givenSelector({ isResolved: false });
+
+      renderHook(() => useAIAnnotationMode());
+
+      expect(spies.setDefaultAgent).not.toHaveBeenCalled();
     });
   });
 

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useAIAnnotationMode.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useAIAnnotationMode.ts
@@ -3,9 +3,9 @@ import {
   isAgentSelectable,
   useActiveTask,
   useAgentSelector,
+  useClearPointPrompts,
   usePointSelection,
   usePointSelectionSeed,
-  useToolsState,
 } from "@fiftyone/annotation/src/agents";
 import { useCallback, useEffect, useMemo } from "react";
 import { atom, getDefaultStore, useAtom, useAtomValue } from "jotai";
@@ -57,7 +57,6 @@ export const useAIAnnotationMode = (): AIAnnotationMode => {
   const [isActive, setIsActive] = useAtom(isActiveAtom);
 
   const { setActiveTask } = useActiveTask();
-  const { reset: resetToolsState } = useToolsState();
   const pointSelection = usePointSelection();
   const { clearSeedNew } = usePointSelectionSeed();
 
@@ -65,15 +64,14 @@ export const useAIAnnotationMode = (): AIAnnotationMode => {
   useDefaultAgent();
 
   // Clears prompt state without tearing down point selection. The SAM2 point
-  // context is reset only at real session boundaries — here on deactivate, and
-  // implicitly on the deactivate→activate cycle a right-click finalize runs.
-  // It is deliberately NOT cleared on selection changes: an inference creating
-  // and selecting a fresh mask IS a selection change, so clearing there wiped
-  // the seed point of every mask after the first.
-  const resetTools = useCallback(() => {
-    pointSelection.clearPoints();
-    resetToolsState();
-  }, [pointSelection, resetToolsState]);
+  // context is reset at real session boundaries — here on deactivate, and
+  // implicitly on the deactivate→activate cycle a right-click finalize runs —
+  // plus wherever the prompted frame stops being the frame on screen (see
+  // `useEndPointSessionOnFrameChange`). It is deliberately NOT cleared on
+  // selection changes: an inference creating and selecting a fresh mask IS a
+  // selection change, so clearing there wiped the seed point of every mask
+  // after the first.
+  const clearPointPrompts = useClearPointPrompts();
 
   // Guards read fresh from the jotai store so back-to-back deactivate /
   // activate calls (e.g. AI right-click finalize) don't no-op on a stale
@@ -96,11 +94,11 @@ export const useAIAnnotationMode = (): AIAnnotationMode => {
     if (!getDefaultStore().get(isActiveAtom)) return;
 
     pointSelection.deactivate();
-    resetTools();
+    clearPointPrompts();
 
     setActiveTask(null);
     setIsActive(false);
-  }, [resetTools, pointSelection, setActiveTask, setIsActive]);
+  }, [clearPointPrompts, pointSelection, setActiveTask, setIsActive]);
 
   return useMemo(
     () => ({

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useAIAnnotationMode.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useAIAnnotationMode.ts
@@ -35,17 +35,34 @@ export const useIsAIAnnotationModeActive = (): boolean =>
 const useDefaultAgent = () => {
   const agentSelector = useAgentSelector();
 
-  // Select the first *selectable* agent as the default once the agents have
-  // resolved; the user can change it from the AgentSelect dropdown. Bootstrap
-  // from the same filter the selector uses — picking a hidden/unavailable
-  // entry here would just be cleared by the dropdown and reselected in a loop.
+  // Restore the remembered agent once it's selectable, else fall back to the
+  // first selectable one. Bootstrap from the same filter the selector uses —
+  // picking a hidden/unavailable entry here would just be cleared by the
+  // dropdown and reselected in a loop.
+  //
+  // Keeps re-evaluating rather than firing once: service-backed agents register
+  // a beat after the static ones (their binding resolves async), so the
+  // remembered pick often isn't selectable yet on the first resolve. Adopting
+  // it whenever it shows up is safe because a user pick writes `lastAgentId`
+  // too — once the two agree, this can't fight the dropdown.
   useEffect(() => {
     if (!agentSelector.isResolved) return;
-    if (agentSelector.activeAgent) return;
 
-    const [first] = agentSelector.agents.filter(isAgentSelectable);
-    if (first) {
-      agentSelector.setActiveAgent(first);
+    const selectable = agentSelector.agents.filter(isAgentSelectable);
+    const remembered = selectable.find(
+      (d) => d.id === agentSelector.lastAgentId,
+    );
+
+    if (remembered) {
+      if (remembered.id !== agentSelector.activeAgent?.id) {
+        agentSelector.setDefaultAgent(remembered);
+      }
+
+      return;
+    }
+
+    if (!agentSelector.activeAgent && selectable[0]) {
+      agentSelector.setDefaultAgent(selectable[0]);
     }
   }, [agentSelector]);
 };

--- a/app/packages/video-annotation/src/components/AiTrackUpsellButton.tsx
+++ b/app/packages/video-annotation/src/components/AiTrackUpsellButton.tsx
@@ -1,7 +1,7 @@
 import { EnterpriseUpsellCallout } from "@fiftyone/components";
 import { Button, IconName, Size, Variant } from "@voxel51/voodo";
-import React, { useEffect, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import React from "react";
+import { HoverPopover } from "./HoverPopover";
 
 /**
  * AI accent gradient for the button; applied inline over `Variant.Primary`
@@ -12,90 +12,35 @@ const AI_TRACK_GRADIENT =
   "linear-gradient(139deg, #CC5200 5.04%, #9A3EDB 103.8%)";
 
 /**
- * Keeps the callout open across the gap between the button and the portaled
- * card, so the pointer can travel into the card to click "Learn more".
- */
-const CLOSE_DELAY_MS = 120;
-
-/**
  * Upsell for AI-powered object tracking — a paid feature not available in the
  * open-source app. Renders a disabled "AI Track" button whose only action is a
  * hover callout inviting the user to learn more.
  *
- * The callout is a hover popover, not a `Tooltip`: it must portal above both
- * the annotation modal and the toolbar's clipping (`overflow: hidden`) ancestor,
- * and it stays open while the pointer is over the button OR the card so the CTA
- * stays clickable — a tooltip dismisses the moment the pointer leaves the
- * trigger. Held open by presence of the anchor `rect` (null = closed).
+ * The callout is a {@link HoverPopover}, not a `Tooltip`, so the pointer can
+ * travel into the card to click "Learn more".
  */
-export const AiTrackUpsellButton: React.FC = () => {
-  const anchorRef = useRef<HTMLSpanElement>(null);
-  const closeTimer = useRef<ReturnType<typeof setTimeout>>();
-  const [rect, setRect] = useState<DOMRect | null>(null);
-
-  useEffect(() => () => clearTimeout(closeTimer.current), []);
-
-  const open = () => {
-    clearTimeout(closeTimer.current);
-
-    if (anchorRef.current) {
-      setRect(anchorRef.current.getBoundingClientRect());
+export const AiTrackUpsellButton: React.FC = () => (
+  <HoverPopover
+    label="AI Track is available in FiftyOne Enterprise"
+    content={
+      <EnterpriseUpsellCallout
+        data-cy="ai-track-upsell-callout"
+        title="More powerful AI in Enterprise"
+        description="Auto-track objects across frames – available in FiftyOne Enterprise."
+      />
     }
-  };
-
-  const scheduleClose = () => {
-    clearTimeout(closeTimer.current);
-    closeTimer.current = setTimeout(() => setRect(null), CLOSE_DELAY_MS);
-  };
-
-  return (
-    <span
-      ref={anchorRef}
-      style={{ display: "inline-flex" }}
-      onMouseEnter={open}
-      onMouseLeave={scheduleClose}
+  >
+    {/* `disabled` gives the faded, inactive upsell look. */}
+    <Button
+      variant={Variant.Primary}
+      size={Size.Xs}
+      leadingIcon={IconName.AI}
+      disabled
+      aria-label="AI Track"
+      data-cy="ai-track-upsell"
+      style={{ background: AI_TRACK_GRADIENT }}
     >
-      {/* `disabled` gives the faded, inactive upsell look. The span (not the
-          disabled button) owns the hover — a disabled button swallows its own
-          pointer events. */}
-      <Button
-        variant={Variant.Primary}
-        size={Size.Xs}
-        leadingIcon={IconName.AI}
-        disabled
-        aria-label="AI Track"
-        data-cy="ai-track-upsell"
-        style={{ background: AI_TRACK_GRADIENT }}
-      >
-        AI Track
-      </Button>
-
-      {rect &&
-        createPortal(
-          <div
-            role="dialog"
-            aria-label="AI Track is available in FiftyOne Enterprise"
-            onMouseEnter={open}
-            onMouseLeave={scheduleClose}
-            style={{
-              position: "fixed",
-              // Anchor above the button: pin the card's bottom just over the
-              // button's top so it grows upward (the toolbar sits low when the
-              // timeline drawer is collapsed, which clips a downward card).
-              bottom: window.innerHeight - rect.top + 6,
-              left: rect.left,
-              width: 320,
-              zIndex: "var(--z-above-modal)",
-            }}
-          >
-            <EnterpriseUpsellCallout
-              data-cy="ai-track-upsell-callout"
-              title="More powerful AI in Enterprise"
-              description="Auto-track objects across frames – available in FiftyOne Enterprise."
-            />
-          </div>,
-          document.body,
-        )}
-    </span>
-  );
-};
+      AI Track
+    </Button>
+  </HoverPopover>
+);

--- a/app/packages/video-annotation/src/components/HoverPopover.test.tsx
+++ b/app/packages/video-annotation/src/components/HoverPopover.test.tsx
@@ -11,9 +11,7 @@ import {
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { HoverPopover } from "./HoverPopover";
-
-const CLOSE_DELAY_MS = 120;
+import { CLOSE_DELAY_MS, HoverPopover } from "./HoverPopover";
 
 const subject = () => (
   <HoverPopover label="Status" content={<div>the card</div>}>

--- a/app/packages/video-annotation/src/components/HoverPopover.test.tsx
+++ b/app/packages/video-annotation/src/components/HoverPopover.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { HoverPopover } from "./HoverPopover";
+
+const CLOSE_DELAY_MS = 120;
+
+const subject = () => (
+  <HoverPopover label="Status" content={<div>the card</div>}>
+    <button disabled>trigger</button>
+  </HoverPopover>
+);
+
+// The trigger is disabled — it swallows its own pointer events, so the hover
+// lands on the wrapper span. `mouseOver` bubbles, so React synthesizes the
+// enter event the wrapper listens for.
+const hoverTrigger = () => fireEvent.mouseOver(screen.getByText("trigger"));
+
+const leave = (element: Element) => fireEvent.mouseOut(element);
+
+const settle = (ms: number) =>
+  act(() => {
+    vi.advanceTimersByTime(ms);
+  });
+
+describe("HoverPopover", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("opens the card on hover and closes it after the leave delay", () => {
+    render(subject());
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+
+    hoverTrigger();
+    expect(screen.getByRole("dialog", { name: "Status" })).toBeTruthy();
+
+    leave(screen.getByText("trigger"));
+    settle(CLOSE_DELAY_MS);
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  // The point of the component: the pointer has to be able to cross the gap
+  // into the card to reach the links and buttons the card holds.
+  it("stays open when the pointer moves into the card", () => {
+    render(subject());
+
+    hoverTrigger();
+    const card = screen.getByRole("dialog");
+
+    leave(screen.getByText("trigger"));
+    fireEvent.mouseOver(card);
+    settle(CLOSE_DELAY_MS);
+
+    expect(screen.getByRole("dialog")).toBeTruthy();
+
+    leave(card);
+    settle(CLOSE_DELAY_MS);
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+});

--- a/app/packages/video-annotation/src/components/HoverPopover.tsx
+++ b/app/packages/video-annotation/src/components/HoverPopover.tsx
@@ -1,0 +1,94 @@
+import React, { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+/**
+ * Keeps the card open across the gap between the trigger and the portaled
+ * card, so the pointer can travel into the card to reach its actions.
+ */
+const CLOSE_DELAY_MS = 120;
+
+/** Default card width; wide enough for a title plus a line or two of copy. */
+const DEFAULT_WIDTH = 320;
+
+export interface HoverPopoverProps {
+  /** Accessible name for the card. */
+  label: string;
+  /** The card. Mounted only while open, so it reads state at open time. */
+  content: React.ReactNode;
+  /** Card width in px. */
+  width?: number;
+  /** The trigger. Wrapped in an inline-flex span that owns the hover. */
+  children: React.ReactNode;
+}
+
+/**
+ * Hover-opened card anchored above its trigger.
+ *
+ * Deliberately not a `Tooltip`: it portals above both the annotation modal and
+ * any clipping (`overflow: hidden`) ancestor, and it stays open while the
+ * pointer is over the trigger OR the card so the card's links and buttons stay
+ * clickable — a tooltip dismisses the moment the pointer leaves the trigger.
+ * Held open by presence of the anchor `rect` (null = closed).
+ *
+ * The trigger may be disabled: the wrapper span owns the hover, since a
+ * disabled control swallows its own pointer events.
+ */
+export const HoverPopover: React.FC<HoverPopoverProps> = ({
+  label,
+  content,
+  width = DEFAULT_WIDTH,
+  children,
+}) => {
+  const anchorRef = useRef<HTMLSpanElement>(null);
+  const closeTimer = useRef<ReturnType<typeof setTimeout>>();
+  const [rect, setRect] = useState<DOMRect | null>(null);
+
+  useEffect(() => () => clearTimeout(closeTimer.current), []);
+
+  const open = () => {
+    clearTimeout(closeTimer.current);
+
+    if (anchorRef.current) {
+      setRect(anchorRef.current.getBoundingClientRect());
+    }
+  };
+
+  const scheduleClose = () => {
+    clearTimeout(closeTimer.current);
+    closeTimer.current = setTimeout(() => setRect(null), CLOSE_DELAY_MS);
+  };
+
+  return (
+    <span
+      ref={anchorRef}
+      style={{ display: "inline-flex" }}
+      onMouseEnter={open}
+      onMouseLeave={scheduleClose}
+    >
+      {children}
+
+      {rect &&
+        createPortal(
+          <div
+            role="dialog"
+            aria-label={label}
+            onMouseEnter={open}
+            onMouseLeave={scheduleClose}
+            style={{
+              position: "fixed",
+              // Anchor above the trigger: pin the card's bottom just over the
+              // trigger's top so it grows upward (a toolbar sits low when the
+              // timeline drawer is collapsed, which clips a downward card).
+              bottom: window.innerHeight - rect.top + 6,
+              left: rect.left,
+              width,
+              zIndex: "var(--z-above-modal)",
+            }}
+          >
+            {content}
+          </div>,
+          document.body,
+        )}
+    </span>
+  );
+};

--- a/app/packages/video-annotation/src/components/HoverPopover.tsx
+++ b/app/packages/video-annotation/src/components/HoverPopover.tsx
@@ -4,8 +4,13 @@ import { createPortal } from "react-dom";
 /**
  * Keeps the card open across the gap between the trigger and the portaled
  * card, so the pointer can travel into the card to reach its actions.
+ *
+ * Exported so tests advance timers by the real delay rather than a copy of it.
  */
-const CLOSE_DELAY_MS = 120;
+export const CLOSE_DELAY_MS = 120;
+
+/** Gap between the card and the trigger / the viewport edge it's clamped to. */
+const CARD_MARGIN = 6;
 
 /** Default card width; wide enough for a title plus a line or two of copy. */
 const DEFAULT_WIDTH = 320;
@@ -79,8 +84,14 @@ export const HoverPopover: React.FC<HoverPopoverProps> = ({
               // Anchor above the trigger: pin the card's bottom just over the
               // trigger's top so it grows upward (a toolbar sits low when the
               // timeline drawer is collapsed, which clips a downward card).
-              bottom: window.innerHeight - rect.top + 6,
-              left: rect.left,
+              bottom: window.innerHeight - rect.top + CARD_MARGIN,
+              // Left-aligned to the trigger, but pulled back in when that would
+              // hang the card off the right edge — nothing clips a fixed,
+              // portaled element back into view.
+              left: Math.max(
+                CARD_MARGIN,
+                Math.min(rect.left, window.innerWidth - width - CARD_MARGIN),
+              ),
               width,
               zIndex: "var(--z-above-modal)",
             }}

--- a/app/packages/video-annotation/src/components/VideoAnnotationSurface.tsx
+++ b/app/packages/video-annotation/src/components/VideoAnnotationSurface.tsx
@@ -2,6 +2,7 @@ import { getSampleSrc, useDimensions } from "@fiftyone/state";
 import type { ModalSample } from "@fiftyone/state";
 import React, { useMemo, useState } from "react";
 import { useAutoInterpolate } from "../hooks/useAutoInterpolate";
+import { useEndPointSessionOnFrameChange } from "../hooks/useEndPointSessionOnFrameChange";
 import { useRegisterVideoAnnotationKeybindings } from "../hooks/useRegisterVideoAnnotationKeybindings";
 import { useRegisterVideoSegmentBitmap } from "../hooks/useRegisterVideoSegmentBitmap";
 import { useSyncAnnotationFrameClock } from "../hooks/useSyncAnnotationFrameClock";
@@ -269,6 +270,8 @@ const VideoAnnotationHandlerRegistration: React.FC = () => {
   useRegisterVideoAnnotationKeybindings();
   // expose the active ImaVid frame to the SAM2 agent for click-to-segment
   useRegisterVideoSegmentBitmap();
+  // a point session belongs to the frame it started on; end it on a move
+  useEndPointSessionOnFrameChange();
   useAutoInterpolate();
   // editing a frame label: keep the anchor (and the form) on the playhead's
   // occurrence of the same track as the playhead moves

--- a/app/packages/video-annotation/src/hooks/useEndPointSessionOnFrameChange.test.ts
+++ b/app/packages/video-annotation/src/hooks/useEndPointSessionOnFrameChange.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  endPointSession: vi.fn(),
+  frame: { value: 1 },
+}));
+
+vi.mock("@fiftyone/annotation", () => ({
+  useEndPointSession: () => hoisted.endPointSession,
+}));
+
+vi.mock("../state/useCurrentFrame", () => ({
+  useCurrentFrame: () => hoisted.frame.value,
+}));
+
+import { useEndPointSessionOnFrameChange } from "./useEndPointSessionOnFrameChange";
+
+describe("useEndPointSessionOnFrameChange", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.frame.value = 1;
+  });
+
+  it("ends the session when the playhead moves to another frame", () => {
+    const { rerender } = renderHook(() => useEndPointSessionOnFrameChange());
+    vi.clearAllMocks();
+
+    hoisted.frame.value = 2;
+    rerender();
+
+    expect(hoisted.endPointSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing on a re-render that stays on the same frame", () => {
+    const { rerender } = renderHook(() => useEndPointSessionOnFrameChange());
+    vi.clearAllMocks();
+
+    rerender();
+
+    expect(hoisted.endPointSession).not.toHaveBeenCalled();
+  });
+});

--- a/app/packages/video-annotation/src/hooks/useEndPointSessionOnFrameChange.test.ts
+++ b/app/packages/video-annotation/src/hooks/useEndPointSessionOnFrameChange.test.ts
@@ -26,9 +26,16 @@ describe("useEndPointSessionOnFrameChange", () => {
     hoisted.frame.value = 1;
   });
 
+  // Mounting isn't a frame change, and AI mode survives a surface remount, so
+  // a session in progress must survive one too.
+  it("does nothing on mount", () => {
+    renderHook(() => useEndPointSessionOnFrameChange());
+
+    expect(hoisted.endPointSession).not.toHaveBeenCalled();
+  });
+
   it("ends the session when the playhead moves to another frame", () => {
     const { rerender } = renderHook(() => useEndPointSessionOnFrameChange());
-    vi.clearAllMocks();
 
     hoisted.frame.value = 2;
     rerender();
@@ -38,7 +45,6 @@ describe("useEndPointSessionOnFrameChange", () => {
 
   it("does nothing on a re-render that stays on the same frame", () => {
     const { rerender } = renderHook(() => useEndPointSessionOnFrameChange());
-    vi.clearAllMocks();
 
     rerender();
 

--- a/app/packages/video-annotation/src/hooks/useEndPointSessionOnFrameChange.ts
+++ b/app/packages/video-annotation/src/hooks/useEndPointSessionOnFrameChange.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { useEndPointSession } from "@fiftyone/annotation";
+import { useEffect, useRef } from "react";
+import { useCurrentFrame } from "../state/useCurrentFrame";
+
+/**
+ * End the AI point-prompt session whenever the playhead lands on a different
+ * frame. Points describe the pixels of one frame, so carrying them across a
+ * frame change would prompt the new frame with stale coordinates while the user
+ * looks at keypoints that no longer mark anything on screen — and carrying the
+ * *target* across would make the next click refine the previous object (whose
+ * track the commit auto-extended onto this frame) rather than start a new one.
+ *
+ * Cheap when nothing is pending, so ticking through frames during playback
+ * costs nothing.
+ *
+ * **Mount once** in the video surface, inside the `<PlaybackProvider>`.
+ */
+export const useEndPointSessionOnFrameChange = (): void => {
+  const frame = useCurrentFrame();
+  const endPointSession = useEndPointSession();
+
+  // Ref so the effect fires on frame changes alone — the callback's identity
+  // churns with every render of the surface.
+  const endRef = useRef(endPointSession);
+  endRef.current = endPointSession;
+
+  useEffect(() => {
+    endRef.current();
+  }, [frame]);
+};

--- a/app/packages/video-annotation/src/hooks/useEndPointSessionOnFrameChange.ts
+++ b/app/packages/video-annotation/src/hooks/useEndPointSessionOnFrameChange.ts
@@ -28,7 +28,19 @@ export const useEndPointSessionOnFrameChange = (): void => {
   const endRef = useRef(endPointSession);
   endRef.current = endPointSession;
 
+  const lastFrame = useRef<number | null>(null);
+
   useEffect(() => {
+    const previousFrame = lastFrame.current;
+    lastFrame.current = frame;
+
+    // Mounting is not a transition. AI mode outlives a surface remount (its
+    // state is module-scoped), so ending the session on the effect's first run
+    // would drop a live one — the very thing this hook exists to scope.
+    if (previousFrame === null) {
+      return;
+    }
+
     endRef.current();
   }, [frame]);
 };


### PR DESCRIPTION
Cherry-pick of voxel51/fiftyone#8129 onto `release/v1.20.0` — same three commits, applied clean (every file it touches is identical between `develop` and this branch).

1. `extract a shared hover popover for the AI Track upsell`
2. `end the AI point session on a frame change`
3. `remember the last selected annotation agent`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remember the last selected AI annotation agent across reloads and restore it when available.
  * Added point-prompt clearing and endpoint-session ending actions.
  * Endpoint point sessions now end automatically when changing video frames.
  * Introduced hover-based upsell popovers for improved accessibility.
* **Bug Fixes**
  * Deactivation now consistently clears pending prompts.
  * Resetting tool state no longer triggers extra updates when already cleared.
  * Improved restoring behavior for the preferred/default agent when it becomes selectable.
* **Tests**
  * Expanded coverage for agent persistence, prompt clearing, endpoint sessions, and hover popover interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3555
<!-- enterprise-sync-pr:end -->