### PR TITLE
[release] cherry-pick: cache masks during annotation playback

### DIFF
--- a/app/packages/lighter/src/index.ts
+++ b/app/packages/lighter/src/index.ts
@@ -129,6 +129,9 @@ export {
   type ColorMappingContext,
 } from "./utils/colorMapping";
 export { decodeMaskPath } from "./utils/maskPathDecoding";
+export { MaskBitmapCache, maskBitmapCache } from "./utils/maskBitmapCache";
+export type { MaskSource } from "./utils/maskBitmapCache";
+export { maskSourceOf } from "./utils/maskSource";
 
 // Constants
 export { DEFAULT_ZOOM_PAD } from "./constants";

--- a/app/packages/lighter/src/overlay/MaskCanvas.test.ts
+++ b/app/packages/lighter/src/overlay/MaskCanvas.test.ts
@@ -7,7 +7,7 @@ import {
   SegmentationToolMode,
   SegmentationToolShape,
 } from "@fiftyone/core/src/components/Modal/Sidebar/Annotate/Edit/useSegmentationMode";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MaskCanvas } from "./MaskCanvas";
 import type { Rect } from "../types";
 import { maskBounds } from "../utils";
@@ -16,12 +16,90 @@ import { maskBounds } from "../utils";
 // the jsdom canvas mock in vitest.setup.ts has no real pixel storage, so we
 // can't compute a tight bbox from painted pixels at runtime. encodeMask is
 // stubbed to a known string so tests can observe what onEncoded receives.
+/**
+ * Controllable stand-in for the shared mask bitmap cache, so decode resolution
+ * order can be driven explicitly — the convergence bug only appears when a
+ * decode resolves AFTER the source it was started for has been replaced.
+ */
+const maskCacheStub = vi.hoisted(() => {
+  interface Pending {
+    bitmap: { close: () => void };
+    resolve: () => void;
+    promise: Promise<unknown>;
+    stored: boolean;
+  }
+
+  const pending = new Map<string, Pending>();
+
+  const decodedOf = (entry: Pending) => ({
+    bitmap: entry.bitmap,
+    rawPixels: { src: new Uint8Array(4), width: 2, height: 2 },
+  });
+
+  return {
+    /** Register a decode that will not resolve until `resolve(source)`. */
+    enqueue(source: string) {
+      let release!: () => void;
+      const promise = new Promise<void>((r) => {
+        release = r;
+      });
+
+      const entry: Pending = {
+        bitmap: { close: () => undefined },
+        resolve: release,
+        promise,
+        stored: false,
+      };
+
+      pending.set(source, entry);
+
+      return entry.bitmap;
+    },
+
+    resolve(source: string) {
+      const entry = pending.get(source);
+      if (!entry) throw new Error(`nothing enqueued for ${source}`);
+      entry.stored = true;
+      entry.resolve();
+    },
+
+    /** Flush the microtask queue so awaiting code advances. */
+    async settle() {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    },
+
+    reset() {
+      pending.clear();
+    },
+
+    // ---- the surface MaskCanvas consumes ----
+    acquire(source: string) {
+      const entry = pending.get(source);
+      return entry?.stored ? decodedOf(entry) : undefined;
+    },
+    async acquireAsync(source: string) {
+      const entry = pending.get(source);
+      if (!entry) throw new Error(`nothing enqueued for ${source}`);
+      await entry.promise;
+      return decodedOf(entry);
+    },
+    release: () => undefined,
+    has(source: string) {
+      return pending.get(source)?.stored ?? false;
+    },
+  };
+});
+
 vi.mock("../utils", async () => {
   const actual = await vi.importActual<typeof import("../utils")>("../utils");
   return {
     ...actual,
     maskBounds: vi.fn(),
     encodeMask: vi.fn().mockResolvedValue("encoded-mask"),
+    maskBitmapCache: maskCacheStub,
   };
 });
 const mockedMaskBounds = vi.mocked(maskBounds);
@@ -61,6 +139,87 @@ const seedCanvas = (bounds: Rect, paintRect: Rect): MaskCanvas => {
   );
   return mc;
 };
+
+describe("MaskCanvas decode convergence", () => {
+  /** A renderer stub that records what `drawImage` was handed. */
+  const recordingRenderer = () => {
+    const drawn: unknown[] = [];
+
+    return {
+      drawn,
+      renderer: {
+        drawImage: (image: { bitmap?: unknown; canvas?: unknown }) => {
+          drawn.push(image.bitmap ?? image.canvas);
+        },
+      } as unknown as Parameters<MaskCanvas["render"]>[0],
+    };
+  };
+
+  const BOUNDS: Rect = { x: 0, y: 0, width: 10, height: 10 };
+
+  const draw = (
+    mc: MaskCanvas,
+    r: ReturnType<typeof recordingRenderer>,
+    onDecoded: () => void = () => {},
+  ) => mc.render(r.renderer, BOUNDS, "c", WHITE, 1, onDecoded);
+
+  beforeEach(() => {
+    maskCacheStub.reset();
+  });
+
+  it("repaints with the current source when a decode resolves stale", async () => {
+    maskCacheStub.enqueue("mask-1");
+    const second = maskCacheStub.enqueue("mask-2");
+
+    const mc = new MaskCanvas("mask-1");
+    const r = recordingRenderer();
+    // `onDecoded` is the ONLY repaint trigger (DetectionOverlay wires it to
+    // markDirty). Asserting on it — rather than on a render we call ourselves —
+    // is what distinguishes converging from sitting stale until an unrelated
+    // event happens to repaint.
+    const onDecoded = vi.fn();
+
+    draw(mc, r, onDecoded);
+
+    // Playhead advances and settles WHILE mask-1 is still decoding; this render
+    // is gated on `decoding` and starts no decode of its own.
+    mc.updateSource("mask-2");
+    draw(mc, r, onDecoded);
+
+    // mask-1 resolves stale. Without the retry, nothing further happens: no
+    // decode for mask-2, and no repaint request ever.
+    maskCacheStub.resolve("mask-1");
+    await maskCacheStub.settle();
+    maskCacheStub.resolve("mask-2");
+    await maskCacheStub.settle();
+
+    expect(onDecoded).toHaveBeenCalled();
+
+    // And the repaint it asked for lands on the current frame's mask.
+    draw(mc, r, onDecoded);
+    expect(r.drawn.at(-1)).toBe(second);
+  });
+
+  it("holds the previous mask while the next one decodes", async () => {
+    const first = maskCacheStub.enqueue("mask-1");
+    maskCacheStub.enqueue("mask-2");
+
+    const mc = new MaskCanvas("mask-1");
+    const r = recordingRenderer();
+
+    draw(mc, r);
+    maskCacheStub.resolve("mask-1");
+    await maskCacheStub.settle();
+    draw(mc, r);
+    expect(r.drawn.at(-1)).toBe(first);
+
+    // mask-2 is undecoded, so the frame draws mask-1 rather than nothing.
+    mc.updateSource("mask-2");
+    draw(mc, r);
+
+    expect(r.drawn.at(-1)).toBe(first);
+  });
+});
 
 describe("MaskCanvas.mergeFrom", () => {
   it("expands bounds to the union of target and source", () => {

--- a/app/packages/lighter/src/overlay/MaskCanvas.test.ts
+++ b/app/packages/lighter/src/overlay/MaskCanvas.test.ts
@@ -248,6 +248,27 @@ describe("MaskCanvas decode convergence", () => {
     expect(r.drawn.length).toBe(drawsBefore);
     expect(maskCacheStub.released).toContain("mask-1");
   });
+
+  it("does not restart a decode that already failed for the same source", async () => {
+    const errors = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    // Never enqueued, so the stub's acquireAsync rejects — a broken source.
+    const mc = new MaskCanvas("mask-err");
+    const r = recordingRenderer();
+
+    draw(mc, r);
+    await maskCacheStub.settle();
+    expect(errors).toHaveBeenCalledTimes(1);
+
+    // A repaint must not pay for (or log) the same doomed decode again.
+    draw(mc, r);
+    await maskCacheStub.settle();
+    expect(errors).toHaveBeenCalledTimes(1);
+
+    errors.mockRestore();
+  });
 });
 
 describe("MaskCanvas.mergeFrom", () => {

--- a/app/packages/lighter/src/overlay/MaskCanvas.test.ts
+++ b/app/packages/lighter/src/overlay/MaskCanvas.test.ts
@@ -30,6 +30,8 @@ const maskCacheStub = vi.hoisted(() => {
   }
 
   const pending = new Map<string, Pending>();
+  /** Sources handed back, so tests can assert borrows don't leak. */
+  const released: string[] = [];
 
   const decodedOf = (entry: Pending) => ({
     bitmap: entry.bitmap,
@@ -73,7 +75,10 @@ const maskCacheStub = vi.hoisted(() => {
 
     reset() {
       pending.clear();
+      released.length = 0;
     },
+
+    released,
 
     // ---- the surface MaskCanvas consumes ----
     acquire(source: string) {
@@ -86,7 +91,9 @@ const maskCacheStub = vi.hoisted(() => {
       await entry.promise;
       return decodedOf(entry);
     },
-    release: () => undefined,
+    release(source: string) {
+      released.push(source);
+    },
     has(source: string) {
       return pending.get(source)?.stored ?? false;
     },
@@ -218,6 +225,28 @@ describe("MaskCanvas decode convergence", () => {
     draw(mc, r);
 
     expect(r.drawn.at(-1)).toBe(first);
+  });
+
+  it("drops the held mask when the source is removed", async () => {
+    const first = maskCacheStub.enqueue("mask-1");
+
+    const mc = new MaskCanvas("mask-1");
+    const r = recordingRenderer();
+
+    draw(mc, r);
+    maskCacheStub.resolve("mask-1");
+    await maskCacheStub.settle();
+    draw(mc, r);
+    expect(r.drawn.at(-1)).toBe(first);
+
+    // No incoming source means nothing will ever converge — unlike a swap,
+    // hold-last must not kick in, and the borrow has to go back.
+    mc.updateSource(undefined);
+    const drawsBefore = r.drawn.length;
+    draw(mc, r);
+
+    expect(r.drawn.length).toBe(drawsBefore);
+    expect(maskCacheStub.released).toContain("mask-1");
   });
 });
 

--- a/app/packages/lighter/src/overlay/MaskCanvas.ts
+++ b/app/packages/lighter/src/overlay/MaskCanvas.ts
@@ -76,6 +76,13 @@ export class MaskCanvas {
   private staleSource?: MaskSource;
   private stalePixels?: { src: Uint8Array; width: number; height: number };
   /**
+   * Source whose decode failed. Skipped by {@link decodeMaskIfNeeded} so a
+   * permanently broken mask costs one decode, not one per render. Never
+   * cleared: a decode is a pure function of its source, and any edit yields a
+   * different source anyway.
+   */
+  private failedSource?: MaskSource;
+  /**
    * Raw mask source awaiting decode (deferred until color is known). Either
    * a base64-encoded numpy string (inline `mask` field) or a pre-decoded
    * {@link OverlayMask} produced from a `mask_path` fetch.
@@ -256,6 +263,12 @@ export class MaskCanvas {
       return;
     }
 
+    // After the cache probe, not before: if this source ever does become
+    // resident (another consumer decoded it), the hit above still draws it.
+    if (sourceToken === this.failedSource) {
+      return;
+    }
+
     this.decoding = true;
     void this.decodeUntilCurrent(onDecoded);
   }
@@ -275,9 +288,13 @@ export class MaskCanvas {
    * {@link decodeMaskIfNeeded} so a hit is still adopted in the calling tick.
    */
   private async decodeUntilCurrent(onDecoded?: () => void): Promise<void> {
+    // Tracked outside the loop so the catch blacklists the source that
+    // actually failed, not whatever `rawMaskData` has moved on to since.
+    let sourceToken = this.rawMaskData;
+
     try {
       for (;;) {
-        const sourceToken = this.rawMaskData;
+        sourceToken = this.rawMaskData;
 
         if (!sourceToken) {
           return;
@@ -307,6 +324,7 @@ export class MaskCanvas {
       }
     } catch (err) {
       console.error("[MaskCanvas] mask decode failed:", err);
+      this.failedSource = sourceToken;
 
       // Nothing is coming, so stop showing the previous frame's mask — a stale
       // mask held indefinitely is worse than none.

--- a/app/packages/lighter/src/overlay/MaskCanvas.ts
+++ b/app/packages/lighter/src/overlay/MaskCanvas.ts
@@ -143,12 +143,18 @@ export class MaskCanvas {
     // here is recoverable (ensureCanvas re-seeds from `rawMaskData`).
     if (this.encodingInFlight > 0) return false;
 
-    // Hold the outgoing bitmap as a fallback so the mask doesn't blink out
-    // while the incoming source decodes. Playback advances frames faster than
-    // an uncached decode resolves, so clearing here shows a maskless frame and
-    // reads as flicker; the previous frame's mask is a far better stand-in for
-    // the fraction of a frame it takes the real one to land.
-    this.retainStale();
+    if (source) {
+      // Hold the outgoing bitmap as a fallback so the mask doesn't blink out
+      // while the incoming source decodes. Playback advances frames faster
+      // than an uncached decode resolves, so clearing here shows a maskless
+      // frame and reads as flicker; the previous frame's mask is a far better
+      // stand-in for the fraction of a frame it takes the real one to land.
+      this.retainStale();
+    } else {
+      // A vanishing mask has no incoming decode to converge on — a retained
+      // fallback would be drawn (and hit-tested) forever.
+      this.releaseStale();
+    }
 
     this.reset();
     this.rawMaskData = source;

--- a/app/packages/lighter/src/overlay/MaskCanvas.ts
+++ b/app/packages/lighter/src/overlay/MaskCanvas.ts
@@ -13,12 +13,16 @@ import type { Renderer2D } from "../renderer/Renderer2D";
 import type { DrawStyle, Point, Rect } from "../types";
 import {
   createMaskCanvas,
-  decodeMask,
   decodeMaskToRaster,
   encodeMask,
+  maskBitmapCache,
   maskBounds,
+  maskSourceOf,
   type MaskBounds,
+  type MaskSource,
 } from "../utils";
+
+import type { DecodedMask } from "../utils/maskDecoding";
 
 export interface MaskSnapshot {
   imageData: ImageData;
@@ -56,6 +60,21 @@ export interface PaintStrokeData {
 export class MaskCanvas {
   // Cached decoded mask bitmap, keyed by the raw mask source to detect changes.
   private maskBitmap?: ImageBitmap;
+  /**
+   * Source whose cache entry {@link maskBitmap} is borrowed from, when it came
+   * from {@link maskBitmapCache}. Held separately from `rawMaskData`, which
+   * `ensureCanvas` clears while the borrow is still outstanding.
+   */
+  private borrowedSource?: MaskSource;
+
+  /**
+   * Previous frame's decoded mask, drawn while the current frame's source is
+   * still decoding so the overlay never blinks to nothing mid-playback. Cleared
+   * as soon as the real bitmap lands, or if its decode fails.
+   */
+  private staleBitmap?: ImageBitmap;
+  private staleSource?: MaskSource;
+  private stalePixels?: { src: Uint8Array; width: number; height: number };
   /**
    * Raw mask source awaiting decode (deferred until color is known). Either
    * a base64-encoded numpy string (inline `mask` field) or a pre-decoded
@@ -96,17 +115,14 @@ export class MaskCanvas {
   }
 
   /**
-   * Normalizes the input mask source to either a base64 string (for inline
-   * `mask` data) or a pre-decoded {@link OverlayMask} (for `mask_path` data).
-   * Plain `undefined` and `{ $binary: { base64 } }` wrappers are unwrapped.
+   * Normalizes the input mask source to the value the decode pipeline consumes.
+   * Delegates to the shared helper so the cache key derived here matches the one
+   * readiness checks derive from the same label.
    */
   private static extractSource(
     mask?: SerializedMask | OverlayMask,
-  ): string | OverlayMask | undefined {
-    if (!mask) return undefined;
-    if (typeof mask === "string") return mask;
-    if ("$binary" in mask) return mask.$binary.base64;
-    return mask;
+  ): MaskSource | undefined {
+    return maskSourceOf(mask);
   }
 
   /**
@@ -127,9 +143,51 @@ export class MaskCanvas {
     // here is recoverable (ensureCanvas re-seeds from `rawMaskData`).
     if (this.encodingInFlight > 0) return false;
 
+    // Hold the outgoing bitmap as a fallback so the mask doesn't blink out
+    // while the incoming source decodes. Playback advances frames faster than
+    // an uncached decode resolves, so clearing here shows a maskless frame and
+    // reads as flicker; the previous frame's mask is a far better stand-in for
+    // the fraction of a frame it takes the real one to land.
+    this.retainStale();
+
     this.reset();
     this.rawMaskData = source;
     return true;
+  }
+
+  /**
+   * Move the current bitmap aside as the hold-last fallback, transferring its
+   * cache borrow rather than releasing it. `rawPixels` moves with it so
+   * hit-testing agrees with what is actually on screen.
+   */
+  private retainStale(): void {
+    if (!this.maskBitmap) {
+      return;
+    }
+
+    this.releaseStale();
+
+    this.staleBitmap = this.maskBitmap;
+    this.staleSource = this.borrowedSource;
+    this.stalePixels = this.rawPixels;
+
+    // Ownership moved to the stale slot — clear these so `reset`'s
+    // `releaseBitmap` doesn't hand the borrow back while we're still drawing it.
+    this.maskBitmap = undefined;
+    this.borrowedSource = undefined;
+  }
+
+  /** Drop the hold-last fallback, returning its borrow. */
+  private releaseStale(): void {
+    if (this.staleSource !== undefined) {
+      maskBitmapCache.release(this.staleSource);
+    } else {
+      this.staleBitmap?.close();
+    }
+
+    this.staleBitmap = undefined;
+    this.staleSource = undefined;
+    this.stalePixels = undefined;
   }
 
   /**
@@ -139,8 +197,7 @@ export class MaskCanvas {
    * one is set afterward.
    */
   private reset(): void {
-    this.maskBitmap?.close();
-    this.maskBitmap = undefined;
+    this.releaseBitmap();
     this.rawMaskData = undefined;
     this.rawPixels = undefined;
 
@@ -160,7 +217,9 @@ export class MaskCanvas {
    * Returns true if a mask is available for rendering (editing canvas or decoded bitmap).
    */
   private hasRenderable(): boolean {
-    return this.canvas != null || this.maskBitmap != null;
+    return (
+      this.canvas != null || this.maskBitmap != null || this.staleBitmap != null
+    );
   }
 
   /**
@@ -180,32 +239,107 @@ export class MaskCanvas {
     // Snapshot the source so a concurrent updateSource() can invalidate this
     // decode without stale data overwriting the new source on resolution.
     const sourceToken = this.rawMaskData;
+
+    // A cache hit is adopted synchronously so the mask paints in the same tick
+    // as the frame advance that asked for it. Deferring a hit to a microtask
+    // would reintroduce exactly the one-frame lag the cache exists to remove.
+    const cached = maskBitmapCache.acquire(sourceToken);
+
+    if (cached) {
+      this.adoptDecoded(sourceToken, cached);
+      return;
+    }
+
     this.decoding = true;
+    void this.decodeUntilCurrent(onDecoded);
+  }
 
-    decodeMask(sourceToken)
-      .then(({ bitmap, rawPixels }) => {
-        this.decoding = false;
+  /**
+   * Decode until the result matches the CURRENT source, then adopt it.
+   *
+   * Retrying rather than discarding is what makes the mask converge. A single
+   * attempt that resolves stale has nowhere to hand off to: `decodeMaskIfNeeded`
+   * is gated on `decoding`, so a frame advance during the decode gets no decode
+   * of its own, and the stale resolution triggers no re-render — leaving the
+   * previous frame's mask on screen until some unrelated event repaints. Under
+   * CPU load that window covers most frame advances.
+   *
+   * Mirrors the retry in the engine's Lighter bridge (`mountWhenDecoded`), which
+   * loops for the same reason. The synchronous cache-hit path stays in
+   * {@link decodeMaskIfNeeded} so a hit is still adopted in the calling tick.
+   */
+  private async decodeUntilCurrent(onDecoded?: () => void): Promise<void> {
+    try {
+      for (;;) {
+        const sourceToken = this.rawMaskData;
 
-        // Source changed mid-decode — discard this result. The next render
-        // will re-trigger decodeMaskIfNeeded against the current rawMaskData.
-        if (this.rawMaskData !== sourceToken) {
-          bitmap.close();
+        if (!sourceToken) {
           return;
         }
 
-        this.maskBitmap?.close();
-        this.maskBitmap = bitmap;
+        const cached = maskBitmapCache.acquire(sourceToken);
 
-        if (rawPixels) {
-          this.rawPixels = rawPixels;
+        if (cached) {
+          this.adoptDecoded(sourceToken, cached);
+          onDecoded?.();
+          return;
         }
 
+        const decoded = await maskBitmapCache.acquireAsync(sourceToken);
+
+        // Source moved on while we were decoding — return this borrow and go
+        // again against whatever is current now.
+        if (this.rawMaskData !== sourceToken) {
+          maskBitmapCache.release(sourceToken);
+          continue;
+        }
+
+        this.adoptDecoded(sourceToken, decoded);
         onDecoded?.();
-      })
-      .catch((err) => {
-        console.error("[MaskCanvas] mask decode failed:", err);
-        this.decoding = false;
-      });
+
+        return;
+      }
+    } catch (err) {
+      console.error("[MaskCanvas] mask decode failed:", err);
+
+      // Nothing is coming, so stop showing the previous frame's mask — a stale
+      // mask held indefinitely is worse than none.
+      this.releaseStale();
+      onDecoded?.();
+    } finally {
+      this.decoding = false;
+    }
+  }
+
+  /** Take up a freshly-acquired borrow, returning any previous one. */
+  private adoptDecoded(source: MaskSource, decoded: DecodedMask): void {
+    this.releaseBitmap();
+
+    this.maskBitmap = decoded.bitmap;
+    this.borrowedSource = source;
+
+    if (decoded.rawPixels) {
+      // Shared with every other borrower of this source — read-only.
+      this.rawPixels = decoded.rawPixels;
+    }
+
+    // The real mask is up; the hold-last fallback has done its job.
+    this.releaseStale();
+  }
+
+  /**
+   * Give up the current bitmap: a borrow goes back to the cache (which decides
+   * when to close it), anything self-owned is closed here.
+   */
+  private releaseBitmap(): void {
+    if (this.borrowedSource !== undefined) {
+      maskBitmapCache.release(this.borrowedSource);
+    } else {
+      this.maskBitmap?.close();
+    }
+
+    this.borrowedSource = undefined;
+    this.maskBitmap = undefined;
   }
 
   /**
@@ -249,6 +383,18 @@ export class MaskCanvas {
 
       return;
     }
+
+    if (this.staleBitmap) {
+      // Hold-last: the incoming source is still decoding. Drawn at the CURRENT
+      // frame's bounds, so a moving track's mask tracks the box rather than
+      // lagging a frame behind it.
+      renderer.drawImage(
+        { type: "bitmap", bitmap: this.staleBitmap },
+        bounds,
+        { opacity, tint: color },
+        containerId,
+      );
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -278,8 +424,9 @@ export class MaskCanvas {
       this.context.imageSmoothingEnabled = false;
       this.context.drawImage(this.maskBitmap, 0, 0, width, height);
       this.context.imageSmoothingEnabled = prevSmoothing;
-      this.maskBitmap.close();
-      this.maskBitmap = undefined;
+      // `drawImage` copied the pixels into our canvas, so the borrow is done.
+      // Releasing rather than closing leaves the entry usable by other frames.
+      this.releaseBitmap();
     } else if (this.rawMaskData) {
       // No decoded bitmap yet — e.g. `updateSource` just reset us from a
       // reconcile reproject (echo or undo) and the async decode hasn't run. Seed
@@ -359,7 +506,7 @@ export class MaskCanvas {
    * Prefers the editing canvas (most up-to-date), falls back to decoded bitmap.
    */
   getPreviewSource(): HTMLCanvasElement | ImageBitmap | undefined {
-    return this.canvas ?? this.maskBitmap;
+    return this.canvas ?? this.maskBitmap ?? this.staleBitmap;
   }
 
   /**
@@ -368,7 +515,11 @@ export class MaskCanvas {
    * is outside the given relative bounding box.
    */
   containsMaskPixel(relativePoint: Point, relativeBounds: Rect): boolean {
-    if (!this.rawPixels) return false;
+    // Fall back to the hold-last pixels so hit-testing agrees with whatever is
+    // actually on screen while an incoming source decodes.
+    const pixels = this.rawPixels ?? this.stalePixels;
+
+    if (!pixels) return false;
 
     const { x, y, width: bw, height: bh } = relativeBounds;
 
@@ -381,7 +532,7 @@ export class MaskCanvas {
       return false;
     }
 
-    const { src, width, height } = this.rawPixels;
+    const { src, width, height } = pixels;
     const px = Math.floor(((relativePoint.x - x) / bw) * (width - 1));
     const py = Math.floor(((relativePoint.y - y) / bh) * (height - 1));
 
@@ -935,5 +1086,8 @@ export class MaskCanvas {
 
   destroy(): void {
     this.reset();
+    // `reset` deliberately leaves the hold-last slot alone (a source swap moves
+    // the bitmap there and then resets); teardown has to return that borrow.
+    this.releaseStale();
   }
 }

--- a/app/packages/lighter/src/utils/index.ts
+++ b/app/packages/lighter/src/utils/index.ts
@@ -1,5 +1,8 @@
 export { createMaskCanvas } from "./createMaskCanvas";
 export { decodeMask } from "./maskDecoding";
+export { MaskBitmapCache, maskBitmapCache } from "./maskBitmapCache";
+export type { MaskSource } from "./maskBitmapCache";
+export { maskSourceOf } from "./maskSource";
 export { decodeMaskToRaster } from "./maskRaster";
 export { encodeMask } from "./maskEncoding";
 export { maskBounds } from "./maskBounds";

--- a/app/packages/lighter/src/utils/maskBitmapCache.test.ts
+++ b/app/packages/lighter/src/utils/maskBitmapCache.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { MaskBitmapCache } from "./maskBitmapCache";
+import { decodeMask } from "./maskDecoding";
+
+vi.mock("./maskDecoding", () => ({ decodeMask: vi.fn() }));
+
+const mockedDecodeMask = vi.mocked(decodeMask);
+
+/** A decode result whose bitmap records its own `close()`. */
+const decoded = (width = 10, height = 10) => {
+  const bitmap = { close: vi.fn() } as unknown as ImageBitmap;
+
+  return {
+    bitmap,
+    rawPixels: { src: new Uint8Array(width * height), width, height },
+  };
+};
+
+/** Bytes one `decoded(w, h)` entry occupies, per the cache's accounting. */
+const bytesFor = (width: number, height: number) => width * height * 5;
+
+beforeEach(() => {
+  mockedDecodeMask.mockReset();
+});
+
+describe("MaskBitmapCache", () => {
+  test("a repeat source is a synchronous hit — no second decode", async () => {
+    const cache = new MaskBitmapCache();
+    const first = decoded();
+    mockedDecodeMask.mockResolvedValueOnce(first);
+
+    await cache.acquireAsync("mask-a");
+
+    // The frame-advance path calls `acquire` from inside render and must be
+    // able to draw the result in that same tick.
+    const hit = cache.acquire("mask-a");
+
+    expect(hit).toBe(first);
+    expect(mockedDecodeMask).toHaveBeenCalledTimes(1);
+  });
+
+  test("distinct sources are distinct entries", async () => {
+    const cache = new MaskBitmapCache();
+    mockedDecodeMask
+      .mockResolvedValueOnce(decoded())
+      .mockResolvedValueOnce(decoded());
+
+    const a = await cache.acquireAsync("mask-a");
+    const b = await cache.acquireAsync("mask-b");
+
+    expect(a).not.toBe(b);
+    expect(mockedDecodeMask).toHaveBeenCalledTimes(2);
+  });
+
+  test("an edited mask is a different source, so it misses", async () => {
+    const cache = new MaskBitmapCache();
+    mockedDecodeMask
+      .mockResolvedValueOnce(decoded())
+      .mockResolvedValueOnce(decoded());
+
+    await cache.acquireAsync("mask-a");
+    await cache.acquireAsync("mask-a-after-paint");
+
+    expect(mockedDecodeMask).toHaveBeenCalledTimes(2);
+  });
+
+  test("an unchanged mask repeated across frames shares one entry", async () => {
+    const cache = new MaskBitmapCache();
+    const only = decoded();
+    mockedDecodeMask.mockResolvedValueOnce(only);
+
+    // Equal base64 built independently — a track holding still across frames,
+    // serialized once per frame. String keys compare by value, so both frames
+    // draw the same bitmap, which is sound because a decode is a pure function
+    // of its source.
+    const frameOne = "mask-a";
+    const frameTwo = ["mask", "a"].join("-");
+
+    const a = await cache.acquireAsync(frameOne);
+    const b = await cache.acquireAsync(frameTwo);
+
+    expect(mockedDecodeMask).toHaveBeenCalledTimes(1);
+    expect(a).toBe(b);
+  });
+
+  test("a miss returns undefined rather than blocking", () => {
+    const cache = new MaskBitmapCache();
+
+    expect(cache.acquire("never-decoded")).toBeUndefined();
+    expect(mockedDecodeMask).not.toHaveBeenCalled();
+  });
+
+  test("concurrent callers share one decode and one bitmap", async () => {
+    const cache = new MaskBitmapCache();
+    const only = decoded();
+    mockedDecodeMask.mockResolvedValueOnce(only);
+
+    const [a, b] = await Promise.all([
+      cache.acquireAsync("mask-a"),
+      cache.acquireAsync("mask-a"),
+    ]);
+
+    expect(mockedDecodeMask).toHaveBeenCalledTimes(1);
+    expect(a).toBe(only);
+    expect(b).toBe(only);
+  });
+
+  test("an evicted entry with no borrowers is closed", async () => {
+    // Budget fits exactly one 10x10 entry.
+    const cache = new MaskBitmapCache(bytesFor(10, 10));
+    const first = decoded();
+    mockedDecodeMask
+      .mockResolvedValueOnce(first)
+      .mockResolvedValueOnce(decoded());
+
+    await cache.acquireAsync("mask-a");
+    cache.release("mask-a");
+
+    await cache.acquireAsync("mask-b");
+
+    expect(first.bitmap.close).toHaveBeenCalled();
+    expect(cache.acquire("mask-a")).toBeUndefined();
+  });
+
+  test("an evicted entry that is still borrowed stays open until released", async () => {
+    const cache = new MaskBitmapCache(bytesFor(10, 10));
+    const first = decoded();
+    mockedDecodeMask
+      .mockResolvedValueOnce(first)
+      .mockResolvedValueOnce(decoded());
+
+    // Borrow and hold — an overlay mid-draw.
+    await cache.acquireAsync("mask-a");
+
+    // Evict it under budget pressure.
+    await cache.acquireAsync("mask-b");
+
+    // Drawing a closed ImageBitmap throws at texture upload, so the borrow has
+    // to outlive eviction.
+    expect(first.bitmap.close).not.toHaveBeenCalled();
+
+    cache.release("mask-a");
+
+    expect(first.bitmap.close).toHaveBeenCalled();
+  });
+
+  test("closes only when the last borrower releases", async () => {
+    const cache = new MaskBitmapCache(bytesFor(10, 10));
+    const first = decoded();
+    mockedDecodeMask
+      .mockResolvedValueOnce(first)
+      .mockResolvedValueOnce(decoded());
+
+    await cache.acquireAsync("mask-a");
+    cache.acquire("mask-a");
+
+    await cache.acquireAsync("mask-b");
+
+    cache.release("mask-a");
+    expect(first.bitmap.close).not.toHaveBeenCalled();
+
+    cache.release("mask-a");
+    expect(first.bitmap.close).toHaveBeenCalled();
+  });
+
+  test("a released, still-cached entry is reusable rather than closed", async () => {
+    const cache = new MaskBitmapCache();
+    const first = decoded();
+    mockedDecodeMask.mockResolvedValueOnce(first);
+
+    await cache.acquireAsync("mask-a");
+    cache.release("mask-a");
+
+    expect(first.bitmap.close).not.toHaveBeenCalled();
+    expect(cache.acquire("mask-a")).toBe(first);
+  });
+
+  test("a mask larger than the whole cap is still closed on release", async () => {
+    // The LRU silently refuses an oversize entry, so nothing would track it and
+    // its bitmap would leak. Reachable whenever the cap is shrunk for testing.
+    const cache = new MaskBitmapCache(bytesFor(4, 4));
+    const oversize = decoded(100, 100);
+    mockedDecodeMask.mockResolvedValueOnce(oversize);
+
+    const borrowed = await cache.acquireAsync("huge");
+
+    expect(borrowed).toBe(oversize);
+    expect(oversize.bitmap.close).not.toHaveBeenCalled();
+
+    cache.release("huge");
+
+    expect(oversize.bitmap.close).toHaveBeenCalled();
+  });
+
+  test("stats separate real decodes from cache hits", async () => {
+    const cache = new MaskBitmapCache();
+    mockedDecodeMask
+      .mockResolvedValueOnce(decoded())
+      .mockResolvedValueOnce(decoded());
+
+    await cache.acquireAsync("mask-a");
+    cache.acquire("mask-a");
+    await cache.acquireAsync("mask-b");
+
+    const stats = cache.stats();
+
+    // Decodes far exceeding the clip's distinct mask count across a loop is the
+    // signature of a working set that doesn't fit.
+    expect(stats.decodes).toBe(2);
+    expect(stats.hits).toBe(1);
+    expect(stats.entries).toBe(2);
+  });
+
+  test("warm decodes into the cache without retaining a borrow", async () => {
+    const cache = new MaskBitmapCache(bytesFor(10, 10));
+    const first = decoded();
+    mockedDecodeMask
+      .mockResolvedValueOnce(first)
+      .mockResolvedValueOnce(decoded());
+
+    await cache.warm("mask-a");
+
+    expect(cache.has("mask-a")).toBe(true);
+
+    // Holding no reference, a warmed entry is evictable like any other —
+    // otherwise decode-ahead would pin the whole lookahead window.
+    await cache.acquireAsync("mask-b");
+
+    expect(first.bitmap.close).toHaveBeenCalled();
+  });
+
+  test("clear keeps borrowed entries alive but drops the rest", async () => {
+    const cache = new MaskBitmapCache();
+    const held = decoded();
+    const free = decoded();
+    mockedDecodeMask.mockResolvedValueOnce(held).mockResolvedValueOnce(free);
+
+    await cache.acquireAsync("held");
+    await cache.acquireAsync("free");
+    cache.release("free");
+
+    cache.clear();
+
+    expect(free.bitmap.close).toHaveBeenCalled();
+    expect(held.bitmap.close).not.toHaveBeenCalled();
+
+    cache.release("held");
+    expect(held.bitmap.close).toHaveBeenCalled();
+  });
+});

--- a/app/packages/lighter/src/utils/maskBitmapCache.ts
+++ b/app/packages/lighter/src/utils/maskBitmapCache.ts
@@ -1,0 +1,342 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { LRUCache } from "lru-cache";
+import type { OverlayMask } from "@fiftyone/looker/src/numpy";
+
+import { decodeMask, type DecodedMask } from "./maskDecoding";
+
+/** A mask's raw source — the same value {@link decodeMask} consumes. */
+export type MaskSource = string | OverlayMask;
+
+/** Default cap — 256 MB of decoded mask pixels. */
+const DEFAULT_MAX_BYTES = 256e6;
+
+/** localStorage key + Vite env var for the cap override (see below). */
+const MAX_BYTES_LOCALSTORAGE_KEY = "fo:maskCacheBytes";
+
+/**
+ * Resolve a cap override so eviction can be exercised at a size a dev machine
+ * actually reaches during playback — the real cap holds thousands of masks, so
+ * nothing is ever evicted in a local session. Precedence: `localStorage`
+ * (runtime, no rebuild) then `VITE_MASK_CACHE_BYTES` (build-time). Returns
+ * `null` when unset, so the default cap applies.
+ */
+const readMaxBytesOverride = (): number | null => {
+  if (typeof window !== "undefined") {
+    try {
+      const stored = window.localStorage?.getItem(MAX_BYTES_LOCALSTORAGE_KEY);
+      const parsed = stored === null ? Number.NaN : Number(stored);
+
+      if (Number.isFinite(parsed) && parsed > 0) {
+        return parsed;
+      }
+    } catch {
+      // localStorage can throw in locked-down contexts; fall through to env.
+    }
+  }
+
+  const env = (import.meta as unknown as { env?: Record<string, string> }).env;
+  const parsed = Number(env?.VITE_MASK_CACHE_BYTES);
+
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+};
+
+interface Entry {
+  decoded: DecodedMask;
+  /** Live borrows. An entry is only closeable at zero. */
+  refs: number;
+  bytes: number;
+}
+
+/**
+ * Cache of decoded mask bitmaps, keyed by raw mask source identity.
+ *
+ * Decoding a mask is the expensive step of drawing one: base64 → RGBA raster →
+ * `ImageBitmap` → GPU upload. Without a cache the video surface repeats all of
+ * it on every frame advance, because the frame-locked bridge reuses one overlay
+ * per track and hands it a new label — and therefore a new mask source — each
+ * frame. Re-visiting a frame (scrubbing back, replaying) then costs a full
+ * decode it has already paid for.
+ *
+ * ## Keying
+ *
+ * Entries are keyed by the raw source itself rather than by `(track, frame)`,
+ * so nothing has to hash a mask on the hot path and invalidation is automatic:
+ * an edit yields a different source and therefore a miss.
+ *
+ * The backing map compares keys as a `Map` does, which splits by source type.
+ * Inline base64 sources — the common case — compare by VALUE, so a mask
+ * repeated unchanged across frames (a track holding still) collapses to one
+ * entry no matter how many times it was serialized. That is sound because a
+ * decode is a pure function of its source: the raster is color-independent,
+ * with display color applied as a GPU tint at draw time. `OverlayMask` sources
+ * from `mask_path` are objects and so compare by REFERENCE; re-decoding the
+ * same path yields a fresh object and misses here, but `decodeMaskPath` already
+ * dedupes those by URL upstream.
+ *
+ * ## Ownership
+ *
+ * Consumers BORROW bitmaps: {@link acquire} / {@link acquireAsync} hand back an
+ * entry and take a reference, {@link release} gives it back. A borrowed entry
+ * is never closed, even when the LRU evicts it under budget pressure — it is
+ * held aside and closed on final release instead. Drawing a closed
+ * `ImageBitmap` throws at texture upload, so this is load-bearing rather than
+ * merely tidy.
+ *
+ * Borrowers share one entry, so a borrowed {@link DecodedMask} — its bitmap and
+ * its `rawPixels` alike — is read-only. Derive rather than mutate in place.
+ */
+export class MaskBitmapCache {
+  private readonly cache: LRUCache<MaskSource, Entry>;
+
+  /**
+   * Entries the LRU has dropped but a consumer still holds. Kept alive here so
+   * the borrow stays valid; closed once the last reference is released.
+   */
+  private readonly detached = new Map<MaskSource, Entry>();
+
+  /** In-flight decodes, so concurrent callers share one worker round-trip. */
+  private readonly inflight = new Map<MaskSource, Promise<DecodedMask>>();
+
+  private decodes = 0;
+  private hits = 0;
+  private evictions = 0;
+  /**
+   * Misses that joined a decode already in flight. High `joins` with low `hits`
+   * means warming isn't running far enough ahead of the draw: the work is
+   * shared rather than wasted, but it still lands late.
+   */
+  private joins = 0;
+
+  /** @param maxBytes - Cap on decoded pixels held. */
+  constructor(maxBytes: number = DEFAULT_MAX_BYTES) {
+    this.cache = new LRUCache<MaskSource, Entry>({
+      maxSize: maxBytes,
+      sizeCalculation: (entry) => entry.bytes,
+      dispose: (entry, key) => {
+        this.evictions++;
+
+        if (entry.refs > 0) {
+          this.detached.set(key, entry);
+        } else {
+          entry.decoded.bitmap.close();
+        }
+      },
+    });
+  }
+
+  /**
+   * Borrow an already-decoded mask, or `undefined` on a miss.
+   *
+   * Synchronous by design: a hit must be drawable in the same tick as the frame
+   * advance that asked for it, since resolving a tick later is precisely the
+   * lag this cache exists to remove.
+   */
+  acquire(source: MaskSource): DecodedMask | undefined {
+    const entry = this.lookup(source);
+
+    if (!entry) {
+      return undefined;
+    }
+
+    this.hits++;
+    entry.refs++;
+
+    return entry.decoded;
+  }
+
+  /**
+   * Counters for diagnosing playback behavior. `decodes` far exceeding the
+   * clip's distinct mask count across a loop means the working set doesn't fit
+   * and entries are being re-decoded every pass.
+   */
+  stats(): {
+    decodes: number;
+    hits: number;
+    joins: number;
+    evictions: number;
+    entries: number;
+    sizeBytes: number;
+    maxBytes: number;
+  } {
+    return {
+      decodes: this.decodes,
+      hits: this.hits,
+      joins: this.joins,
+      evictions: this.evictions,
+      entries: this.cache.size,
+      sizeBytes: this.cache.calculatedSize ?? 0,
+      maxBytes: this.cache.maxSize,
+    };
+  }
+
+  resetStats(): void {
+    this.decodes = 0;
+    this.hits = 0;
+    this.joins = 0;
+    this.evictions = 0;
+  }
+
+  /**
+   * Borrow a mask, decoding it if absent. Concurrent callers for the same
+   * source share a single decode.
+   */
+  async acquireAsync(source: MaskSource): Promise<DecodedMask> {
+    const hit = this.acquire(source);
+
+    if (hit) {
+      return hit;
+    }
+
+    const decoded = await this.decodeOnce(source);
+
+    // Another caller may have stored this source while we awaited; prefer the
+    // stored entry so every borrower shares one bitmap and one refcount.
+    const existing = this.lookup(source);
+
+    if (existing) {
+      if (existing.decoded !== decoded) {
+        decoded.bitmap.close();
+      }
+
+      existing.refs++;
+
+      return existing.decoded;
+    }
+
+    this.store(source, decoded);
+
+    return decoded;
+  }
+
+  /**
+   * Whether a source is decoded and drawable right now, WITHOUT taking a
+   * reference. For readiness checks, which ask about many masks per tick and
+   * must not accumulate borrows.
+   */
+  has(source: MaskSource): boolean {
+    return this.cache.has(source) || this.detached.has(source);
+  }
+
+  /** Whether a decode for this source is already in flight. */
+  isWarming(source: MaskSource): boolean {
+    return this.inflight.has(source);
+  }
+
+  /**
+   * Decode a source into the cache without holding it. Resolves once the entry
+   * is drawable (or the decode has failed), so a caller can warm ahead of the
+   * playhead and let {@link has} report readiness afterwards.
+   */
+  async warm(source: MaskSource): Promise<void> {
+    if (this.has(source)) {
+      return;
+    }
+
+    try {
+      await this.acquireAsync(source);
+    } finally {
+      // Warming takes no lasting reference — hand the borrow straight back so
+      // the entry is evictable like any other.
+      this.release(source);
+    }
+  }
+
+  /**
+   * Return a borrow. Closes the bitmap if this was the last reference to an
+   * entry the LRU has already dropped.
+   */
+  release(source: MaskSource): void {
+    const entry = this.cache.peek(source) ?? this.detached.get(source);
+
+    if (!entry || entry.refs === 0) {
+      return;
+    }
+
+    entry.refs--;
+
+    if (entry.refs > 0) {
+      return;
+    }
+
+    if (this.detached.delete(source)) {
+      entry.decoded.bitmap.close();
+    }
+  }
+
+  /**
+   * Drop every entry. Borrowed entries are detached rather than closed, so a
+   * consumer mid-draw keeps a valid bitmap until it releases.
+   */
+  clear(): void {
+    this.cache.clear();
+    this.inflight.clear();
+  }
+
+  /** Total bytes currently held by the LRU (excludes detached borrows). */
+  get sizeBytes(): number {
+    return this.cache.calculatedSize ?? 0;
+  }
+
+  private lookup(source: MaskSource): Entry | undefined {
+    return this.cache.get(source) ?? this.detached.get(source);
+  }
+
+  private decodeOnce(source: MaskSource): Promise<DecodedMask> {
+    const pending = this.inflight.get(source);
+
+    if (pending) {
+      this.joins++;
+      return pending;
+    }
+
+    this.decodes++;
+
+    const decode = decodeMask(source).finally(() => {
+      this.inflight.delete(source);
+    });
+
+    this.inflight.set(source, decode);
+
+    return decode;
+  }
+
+  private store(source: MaskSource, decoded: DecodedMask): void {
+    const { width, height } = decoded.rawPixels;
+
+    const entry: Entry = {
+      decoded,
+      // The caller of `acquireAsync` is the first borrower.
+      refs: 1,
+      // Decoded RGBA plus the single-channel hit-test copy.
+      bytes: Math.max(1, width * height * 5),
+    };
+
+    this.cache.set(source, entry);
+
+    // An entry bigger than the whole cap is silently NOT stored (no throw, and
+    // `dispose` never runs for it). Track it as a detached borrow so `release`
+    // still closes its bitmap; otherwise it leaks. Out of reach at the default
+    // cap, but a shrunk one makes single masks oversize easily.
+    if (!this.cache.has(source)) {
+      this.detached.set(source, entry);
+    }
+  }
+}
+
+/**
+ * Process-wide mask bitmap cache. Masks are borrowed by overlays whose
+ * lifetimes are shorter than the cache's usefulness (the frame-locked bridge
+ * rebuilds an overlay's mask state on every frame advance), so the cache
+ * deliberately outlives any one scene.
+ *
+ * Shrink the cap to exercise eviction locally — at the default a dev session
+ * never evicts anything:
+ *
+ *   localStorage.setItem("fo:maskCacheBytes", "8000000")  // then reload
+ */
+export const maskBitmapCache = new MaskBitmapCache(
+  readMaxBytesOverride() ?? DEFAULT_MAX_BYTES,
+);

--- a/app/packages/lighter/src/utils/maskSource.ts
+++ b/app/packages/lighter/src/utils/maskSource.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import type { OverlayMask } from "@fiftyone/looker/src/numpy";
+import type { SerializedMask } from "@fiftyone/utilities";
+
+import type { MaskSource } from "./maskBitmapCache";
+
+/**
+ * Normalize a label's mask field to the value the decode pipeline consumes:
+ * a base64 string for inline `mask` data, or a pre-decoded {@link OverlayMask}
+ * for `mask_path` data. Plain `undefined` and `{ $binary: { base64 } }`
+ * wrappers are unwrapped.
+ *
+ * Shared so that everything keying the mask bitmap cache derives the SAME key
+ * from a label — a readiness check that computed its key differently would
+ * report misses for masks that are in fact cached.
+ */
+export const maskSourceOf = (
+  mask?: SerializedMask | OverlayMask,
+): MaskSource | undefined => {
+  if (!mask) {
+    return undefined;
+  }
+
+  if (typeof mask === "string") {
+    return mask;
+  }
+
+  if ("$binary" in mask) {
+    return mask.$binary.base64;
+  }
+
+  return mask;
+};

--- a/app/packages/playback/index.ts
+++ b/app/packages/playback/index.ts
@@ -52,7 +52,7 @@ export {
   useVideoStream,
 } from "./src/lib/playback/use-video-stream";
 export { useVideoSync } from "./src/lib/playback/use-video-sync";
-export { useStream } from "./src/lib/playback/use-stream";
+export { useActivateStream, useStream } from "./src/lib/playback/use-stream";
 export { frameAt } from "./src/lib/playback/utils";
 export { PlaybackStreamBase } from "./src/lib/playback/stream-base";
 export type { BufferReadiness } from "./src/lib/playback/types";

--- a/app/packages/playback/src/lib/playback/use-stream.test.tsx
+++ b/app/packages/playback/src/lib/playback/use-stream.test.tsx
@@ -5,13 +5,29 @@ import { PlaybackProvider, usePlayback } from "./PlaybackProvider";
 import { PlaybackStreamBase } from "./stream-base";
 import type { BufferReadiness } from "./types";
 import {
+  useActivateStream,
   useStream,
+  useStreamValue,
   useStreamValueSelector,
   useStreamValuesSelector,
 } from "./use-stream";
 
 class StaticStream extends PlaybackStreamBase<{ at: number }> {
   bufferState(): BufferReadiness {
+    return "ready";
+  }
+  prefetch(): void {}
+  getValue(time: number): { at: number } {
+    return { at: time };
+  }
+}
+
+/** Counts readiness checks so tests can tell "driven" from "skipped". */
+class CountingStream extends PlaybackStreamBase<{ at: number }> {
+  bufferStateCalls = 0;
+
+  bufferState(): BufferReadiness {
+    this.bufferStateCalls++;
     return "ready";
   }
   prefetch(): void {}
@@ -43,6 +59,88 @@ const CAMERA_STREAM_IDS = ["camera"] as const;
 const wrap = ({ children }: { children: React.ReactNode }) => (
   <PlaybackProvider duration={10}>{children}</PlaybackProvider>
 );
+
+describe("useActivateStream", () => {
+  afterEach(() => cleanup());
+
+  it("leaves a registered stream dormant when nothing subscribes", () => {
+    const stream = new CountingStream("camera");
+    const { result } = renderHook(
+      () => {
+        // Non-activating read, so registration is the only thing in play.
+        const value = useStreamValue<{ at: number }>("camera");
+        const { registerStream, seek } = usePlayback();
+        return { value, registerStream, seek };
+      },
+      { wrapper: wrap },
+    );
+
+    act(() => {
+      result.current.registerStream(stream);
+    });
+    act(() => {
+      result.current.seek(3.5);
+    });
+
+    // The engine neither consults readiness nor publishes for a dormant stream.
+    expect(stream.bufferStateCalls).toBe(0);
+    expect(result.current.value).toBeNull();
+  });
+
+  it("activates a stream whose committed value has no consumer", () => {
+    const stream = new CountingStream("camera");
+    const { result } = renderHook(
+      () => {
+        useActivateStream("camera");
+        const value = useStreamValue<{ at: number }>("camera");
+        const { registerStream, seek } = usePlayback();
+        return { value, registerStream, seek };
+      },
+      { wrapper: wrap },
+    );
+
+    act(() => {
+      result.current.registerStream(stream);
+    });
+    act(() => {
+      result.current.seek(3.5);
+    });
+
+    expect(stream.bufferStateCalls).toBeGreaterThan(0);
+    expect(result.current.value).toEqual({ at: 3.5 });
+  });
+
+  it("returns the stream to dormancy when activation stops", () => {
+    const stream = new CountingStream("camera");
+    const { result, rerender } = renderHook(
+      // An empty id is the documented no-op, so this toggles activation without
+      // conditionally calling the hook.
+      ({ id }: { id: string }) => {
+        useActivateStream(id);
+        const { registerStream, seek } = usePlayback();
+        return { registerStream, seek };
+      },
+      { wrapper: wrap, initialProps: { id: "camera" } },
+    );
+
+    act(() => {
+      result.current.registerStream(stream);
+    });
+    act(() => {
+      result.current.seek(1);
+    });
+
+    const driven = stream.bufferStateCalls;
+    expect(driven).toBeGreaterThan(0);
+
+    rerender({ id: "" });
+    act(() => {
+      result.current.seek(2);
+    });
+
+    expect(stream.bufferStateCalls).toBe(driven);
+  });
+});
 
 describe("useStream", () => {
   afterEach(() => cleanup());

--- a/app/packages/playback/src/lib/playback/use-stream.ts
+++ b/app/packages/playback/src/lib/playback/use-stream.ts
@@ -97,6 +97,29 @@ function equalSelectedArrays<Value>(
 }
 
 /**
+ * Mark a stream active WITHOUT reading its value.
+ *
+ * Activation is what makes the engine drive a stream at all — a registered but
+ * dormant stream is skipped by the readiness barrier, so its `blocking` flag is
+ * inert and it receives no `bufferState` / `prefetch` / `onCommit`. For streams
+ * whose committed value has a React consumer, `useStream` covers this as a side
+ * effect of reading. This hook is for the case with no such consumer: a stream
+ * that seeds another store directly and needs only its readiness respected.
+ *
+ * The inverse is {@link useStreamValue} — read without activating.
+ */
+export function useActivateStream(id: string): void {
+  const { subscribeStream } = usePlayback();
+
+  // This effect keeps the engine subscription aligned with the requested id.
+  // An empty id is a no-op because the engine never registers one.
+  useEffect(() => {
+    if (!id) return undefined;
+    return subscribeStream(id);
+  }, [id, subscribeStream]);
+}
+
+/**
  * Subscribe to a stream's current data and re-render when it changes.
  *
  * Returns `null` until the stream is registered and produces its first
@@ -113,14 +136,7 @@ function equalSelectedArrays<Value>(
  * ```
  */
 export function useStream<T = unknown>(id: string): T | null {
-  const { subscribeStream } = usePlayback();
-
-  // This effect keeps the engine subscription aligned with the requested id.
-  // An empty id is a no-op because the engine never registers one.
-  useEffect(() => {
-    if (!id) return undefined;
-    return subscribeStream(id);
-  }, [id, subscribeStream]);
+  useActivateStream(id);
 
   return useStreamValue<T>(id);
 }

--- a/app/packages/video-annotation/src/components/FrameLabels.tsx
+++ b/app/packages/video-annotation/src/components/FrameLabels.tsx
@@ -27,6 +27,7 @@ import {
   TrackProvider,
   type Track,
   type TrackEventMenuItem,
+  useActivateStream,
   useDuration,
   usePlaybackStream,
 } from "@fiftyone/playback";
@@ -227,7 +228,20 @@ const FrameLabelsRegistration: React.FC<FrameLabelsRegistrationProps> = ({
     stream.setPrimaryField(props.frameField);
   }, [stream, props.frameField]);
 
+  // The stream holds mask borrows in the process-wide bitmap cache; nothing
+  // else can return them after unmount, so this teardown is what keeps a
+  // sample change from pinning cache entries forever. (A StrictMode re-mount
+  // is fine: the next commit's hold window simply re-borrows.)
+  useEffect(() => () => stream.dispose(), [stream]);
+
   usePlaybackStream(streamRef.current);
+
+  // Registration alone leaves the stream dormant, which the engine skips
+  // entirely — no readiness barrier, no prefetch. Nothing renders from its
+  // published snapshot (the engine owns labels; this stream seeds them via
+  // `subscribeToEdits`), so activate it explicitly: the clock must wait on
+  // label readiness rather than run ahead of the overlays.
+  useActivateStream(LABELS_STREAM_ID);
 
   // Publish so consumers above the surface reach it via useFrameLabelsStream.
   usePublishFrameLabelsStream(streamRef.current);

--- a/app/packages/video-annotation/src/streams/VideoFrameLabelsStream.test.ts
+++ b/app/packages/video-annotation/src/streams/VideoFrameLabelsStream.test.ts
@@ -1,8 +1,80 @@
-import { describe, expect, it } from "vitest";
+import { createStore } from "jotai";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   resolveSyntheticId,
   VideoFrameLabelsStream,
 } from "./VideoFrameLabelsStream";
+
+/**
+ * Stand-in for the shared mask bitmap cache, so gate tests drive readiness
+ * directly instead of running real decodes.
+ */
+const maskCache = vi.hoisted(() => ({
+  decoded: new Set<string>(),
+  warmed: [] as string[],
+  /** Outstanding borrow count per source, so tests can assert pinning. */
+  refs: new Map<string, number>(),
+  /** Sources whose decode should reject. */
+  undecodable: new Set<string>(),
+
+  has(source: string): boolean {
+    return this.decoded.has(source);
+  },
+  isWarming(): boolean {
+    return false;
+  },
+  acquire(source: string): { bitmap: unknown } | undefined {
+    if (!this.decoded.has(source)) {
+      return undefined;
+    }
+
+    this.refs.set(source, (this.refs.get(source) ?? 0) + 1);
+    return { bitmap: source };
+  },
+  async acquireAsync(source: string): Promise<{ bitmap: unknown }> {
+    this.warmed.push(source);
+
+    if (this.undecodable.has(source)) {
+      throw new Error(`undecodable: ${source}`);
+    }
+
+    this.decoded.add(source);
+    this.refs.set(source, (this.refs.get(source) ?? 0) + 1);
+    return { bitmap: source };
+  },
+  release(source: string): void {
+    const refs = this.refs.get(source) ?? 0;
+
+    if (refs <= 1) {
+      this.refs.delete(source);
+      return;
+    }
+
+    this.refs.set(source, refs - 1);
+  },
+  borrows(source: string): number {
+    return this.refs.get(source) ?? 0;
+  },
+  /** Simulates eviction of anything not currently borrowed. */
+  evictUnborrowed(): void {
+    for (const source of [...this.decoded]) {
+      if (!this.refs.has(source)) {
+        this.decoded.delete(source);
+      }
+    }
+  },
+  reset(): void {
+    this.decoded.clear();
+    this.warmed = [];
+    this.refs.clear();
+    this.undecodable.clear();
+  },
+}));
+
+vi.mock("@fiftyone/lighter", () => ({
+  maskBitmapCache: maskCache,
+  maskSourceOf: (mask?: unknown) => mask ?? undefined,
+}));
 
 function buildStream(): VideoFrameLabelsStream {
   return new VideoFrameLabelsStream({
@@ -82,5 +154,242 @@ describe("resolveSyntheticId", () => {
 
   it("returns null when no usable identifier is present", () => {
     expect(resolveSyntheticId({ label: "car" })).toBeNull();
+  });
+});
+
+describe("VideoFrameLabelsStream onCommit", () => {
+  /** Seed a frame document carrying one detection. */
+  const seedFrame = (stream: VideoFrameLabelsStream, frame: number): void => {
+    // @ts-expect-error — test-only: populate the private frame-doc cache
+    stream.cache.set(frame, {
+      frame_number: frame,
+      detections: {
+        detections: [{ _id: "a", bounding_box: [0, 0, 0.1, 0.1] }],
+      },
+    });
+  };
+
+  const published = (
+    stream: VideoFrameLabelsStream,
+    store: ReturnType<typeof createStore>,
+  ): unknown =>
+    // @ts-expect-error — test-only: read back through the protected accessor
+    stream.readPublished(store);
+
+  it("builds no snapshot on repeat commits within the same frame", () => {
+    const stream = buildStream();
+    const store = createStore();
+    seedFrame(stream, 10);
+
+    const getValue = vi.spyOn(stream, "getValue");
+
+    stream.onCommit(timeOfFrame(10, 30), store);
+    expect(getValue).toHaveBeenCalledTimes(1);
+
+    // The engine commits several times per frame; extracting the frame's
+    // detections again would throw the result away.
+    stream.onCommit(timeOfFrame(10, 30) + 0.001, store);
+    expect(getValue).toHaveBeenCalledTimes(1);
+  });
+
+  it("publishes again once the frame changes", () => {
+    const stream = buildStream();
+    const store = createStore();
+    seedFrame(stream, 10);
+    seedFrame(stream, 11);
+
+    stream.onCommit(timeOfFrame(10, 30), store);
+    stream.onCommit(timeOfFrame(11, 30), store);
+
+    expect(published(stream, store)).toMatchObject({ frameNumber: 11 });
+  });
+
+  it("publishes null when a frame's document goes away", () => {
+    const stream = buildStream();
+    const store = createStore();
+    seedFrame(stream, 10);
+
+    stream.onCommit(timeOfFrame(10, 30), store);
+    expect(published(stream, store)).toMatchObject({ frameNumber: 10 });
+
+    // Same frame number, no longer available: the frame-dedupe must not swallow
+    // this — overlays would keep drawing labels the stream no longer has.
+    // @ts-expect-error — test-only: drop the private cache entry
+    stream.cache.delete(10);
+
+    stream.onCommit(timeOfFrame(10, 30), store);
+    expect(published(stream, store)).toBeNull();
+  });
+});
+
+describe("VideoFrameLabelsStream mask gate", () => {
+  /** Seed a frame document carrying `masks` inline detection masks. */
+  const seedFrame = (
+    stream: VideoFrameLabelsStream,
+    frame: number,
+    masks: string[],
+  ): void => {
+    // @ts-expect-error — test-only: populate the private frame-doc cache
+    stream.cache.set(frame, {
+      frame_number: frame,
+      detections: {
+        detections: masks.map((mask, i) => ({
+          _id: `d${i}`,
+          bounding_box: [0, 0, 1, 1],
+          mask,
+        })),
+      },
+    });
+  };
+
+  /** Let the warm pass' `allSettled(...).then(...)` chain run to completion. */
+  const flush = async (): Promise<void> => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  };
+
+  beforeEach(() => {
+    maskCache.reset();
+  });
+
+  it("reports 'missing' while a cached frame's masks are undecoded", () => {
+    const stream = buildStream();
+    seedFrame(stream, 10, ["mask-a"]);
+
+    // The document has landed — pre-gate this was unconditionally "ready".
+    expect(stream.bufferState(timeOfFrame(10, 30))).toBe("missing");
+  });
+
+  it("stays 'missing' until every mask on the frame is held", async () => {
+    const stream = buildStream();
+    seedFrame(stream, 10, ["mask-a", "mask-b"]);
+    maskCache.decoded.add("mask-a");
+
+    // Resident is not enough — a resident mask can still be evicted.
+    expect(stream.bufferState(timeOfFrame(10, 30))).toBe("missing");
+
+    stream.prefetch([timeOfFrame(10, 30), timeOfFrame(10, 30)]);
+    await flush();
+
+    expect(stream.bufferState(timeOfFrame(10, 30))).toBe("ready");
+    expect(maskCache.borrows("mask-a")).toBe(1);
+    expect(maskCache.borrows("mask-b")).toBe(1);
+  });
+
+  it("reports 'ready' for a frame carrying no masks", () => {
+    const stream = buildStream();
+    seedFrame(stream, 10, []);
+
+    expect(stream.bufferState(timeOfFrame(10, 30))).toBe("ready");
+  });
+
+  it("prefetch decodes masks ahead of the playhead", async () => {
+    const stream = buildStream();
+    seedFrame(stream, 10, ["mask-a"]);
+    seedFrame(stream, 11, ["mask-b"]);
+
+    stream.prefetch([timeOfFrame(10, 30), timeOfFrame(11, 30)]);
+    await flush();
+
+    // Warms across the whole lookahead, not just the first missing frame.
+    expect(maskCache.warmed).toEqual(["mask-a", "mask-b"]);
+    expect(stream.bufferState(timeOfFrame(11, 30))).toBe("ready");
+  });
+
+  it("keeps a held frame ready across an eviction sweep", async () => {
+    const stream = buildStream();
+    seedFrame(stream, 10, ["mask-a"]);
+
+    stream.prefetch([timeOfFrame(10, 30), timeOfFrame(10, 30)]);
+    await flush();
+    expect(stream.bufferState(timeOfFrame(10, 30))).toBe("ready");
+
+    // The regression this replaces: a frame settled once stayed ready forever,
+    // so a looping play-through advanced the clock against evicted masks. A
+    // borrow is what makes readiness survive the sweep.
+    maskCache.evictUnborrowed();
+
+    expect(maskCache.has("mask-a")).toBe(true);
+    expect(stream.bufferState(timeOfFrame(10, 30))).toBe("ready");
+  });
+
+  it("plays through a frame whose mask cannot be decoded", async () => {
+    const stream = buildStream();
+    seedFrame(stream, 10, ["mask-bad"]);
+    maskCache.undecodable.add("mask-bad");
+
+    stream.prefetch([timeOfFrame(10, 30), timeOfFrame(10, 30)]);
+    await flush();
+
+    // Never held, so without this escape hatch the clock would stall forever.
+    expect(maskCache.borrows("mask-bad")).toBe(0);
+    expect(stream.bufferState(timeOfFrame(10, 30))).toBe("ready");
+  });
+
+  it("releases masks the playhead has left behind", async () => {
+    const stream = buildStream();
+    seedFrame(stream, 10, ["mask-a"]);
+    seedFrame(stream, 60, ["mask-far"]);
+
+    stream.prefetch([timeOfFrame(10, 30), timeOfFrame(10, 30)]);
+    await flush();
+    expect(maskCache.borrows("mask-a")).toBe(1);
+
+    // Playhead jumps well past the hold window.
+    stream.prefetch([timeOfFrame(60, 30), timeOfFrame(60, 30)]);
+    await flush();
+
+    expect(maskCache.borrows("mask-a")).toBe(0);
+    expect(maskCache.borrows("mask-far")).toBe(1);
+    expect(stream.bufferState(timeOfFrame(10, 30))).toBe("missing");
+  });
+
+  it("dispose returns every held borrow", async () => {
+    const stream = buildStream();
+    seedFrame(stream, 10, ["mask-a", "mask-b"]);
+
+    stream.prefetch([timeOfFrame(10, 30), timeOfFrame(10, 30)]);
+    await flush();
+    expect(maskCache.borrows("mask-a")).toBe(1);
+    expect(maskCache.borrows("mask-b")).toBe(1);
+
+    stream.dispose();
+
+    expect(maskCache.borrows("mask-a")).toBe(0);
+    expect(maskCache.borrows("mask-b")).toBe(0);
+  });
+
+  it("a warm pass resolving after dispose releases its borrows", async () => {
+    const stream = buildStream();
+    seedFrame(stream, 10, ["mask-a"]);
+
+    stream.prefetch([timeOfFrame(10, 30), timeOfFrame(10, 30)]);
+    // Dispose while the hold pass is still in flight — the unmount race.
+    stream.dispose();
+    await flush();
+
+    expect(maskCache.borrows("mask-a")).toBe(0);
+    expect(stream.bufferState(timeOfFrame(10, 30))).toBe("missing");
+  });
+
+  it("re-gates a frame whose document is replaced", async () => {
+    const stream = buildStream();
+    seedFrame(stream, 10, ["mask-a"]);
+
+    stream.prefetch([timeOfFrame(10, 30), timeOfFrame(10, 30)]);
+    await flush();
+    expect(stream.bufferState(timeOfFrame(10, 30))).toBe("ready");
+
+    // A replaced doc may carry different masks, so the frame must re-gate — and
+    // the hold on the old masks has to come off.
+    // @ts-expect-error — test-only: mimic a window chunk landing over the frame
+    stream.maskSourceCache.delete(10);
+    // @ts-expect-error — test-only: the release path a landed chunk triggers
+    stream.releaseMasksAt(10);
+    seedFrame(stream, 10, ["mask-c"]);
+
+    expect(maskCache.borrows("mask-a")).toBe(0);
+    expect(stream.bufferState(timeOfFrame(10, 30))).toBe("missing");
   });
 });

--- a/app/packages/video-annotation/src/streams/VideoFrameLabelsStream.test.ts
+++ b/app/packages/video-annotation/src/streams/VideoFrameLabelsStream.test.ts
@@ -373,6 +373,27 @@ describe("VideoFrameLabelsStream mask gate", () => {
     expect(stream.bufferState(timeOfFrame(10, 30))).toBe("missing");
   });
 
+  it("does not hold stale masks when the document is replaced mid-decode", async () => {
+    const stream = buildStream();
+    seedFrame(stream, 10, ["mask-a"]);
+
+    stream.prefetch([timeOfFrame(10, 30), timeOfFrame(10, 30)]);
+
+    // The chunk lands over the frame while the hold pass is still in flight.
+    // @ts-expect-error — test-only: the invalidation a landed chunk performs
+    stream.maskSourceCache.delete(10);
+    // @ts-expect-error — test-only: the release path a landed chunk triggers
+    stream.releaseMasksAt(10);
+    seedFrame(stream, 10, ["mask-c"]);
+
+    await flush();
+
+    // Without source revalidation the pass holds mask-a and the frame reports
+    // ready while mask-c is undecoded.
+    expect(maskCache.borrows("mask-a")).toBe(0);
+    expect(stream.bufferState(timeOfFrame(10, 30))).toBe("missing");
+  });
+
   it("re-gates a frame whose document is replaced", async () => {
     const stream = buildStream();
     seedFrame(stream, 10, ["mask-a"]);

--- a/app/packages/video-annotation/src/streams/VideoFrameLabelsStream.ts
+++ b/app/packages/video-annotation/src/streams/VideoFrameLabelsStream.ts
@@ -3,9 +3,15 @@ import {
   type LocalDetection,
   type RawDetection,
   type RawDetectionsField,
+  type SerializedMask,
   type Stage,
   type SyntheticBox,
 } from "@fiftyone/utilities";
+import {
+  maskBitmapCache,
+  maskSourceOf,
+  type MaskSource,
+} from "@fiftyone/lighter";
 import { type FrameDoc } from "../../../core/src/client/framesClient";
 import { getVideoLabelsWindow } from "../../../core/src/client/videoLabelsClient";
 import {
@@ -58,6 +64,49 @@ export interface VideoFrameLabelsStreamOptions {
 const DEFAULT_CHUNK_SIZE = 60;
 const DEFAULT_FRAME_FIELD = "detections";
 
+/** localStorage key + Vite env var for the mask gate toggle (see below). */
+const MASK_GATE_LOCALSTORAGE_KEY = "fo:maskGate";
+
+/**
+ * Whether the clock waits for a frame's masks to be decoded and pinned, not just
+ * fetched. On by default: an annotation surface should stall rather than present
+ * a frame alongside another frame's mask. Kill switch for comparing behavior, or
+ * for a session where stalling is worse than staleness:
+ *
+ *   localStorage.setItem("fo:maskGate", "0")   // off
+ *   localStorage.removeItem("fo:maskGate")     // back to the default
+ */
+const readMaskGateEnabled = (): boolean => {
+  if (typeof window !== "undefined") {
+    try {
+      const stored = window.localStorage?.getItem(MASK_GATE_LOCALSTORAGE_KEY);
+
+      if (stored !== null && stored !== undefined) {
+        return stored !== "0" && stored !== "false";
+      }
+    } catch {
+      // localStorage can throw in locked-down contexts; fall through to env.
+    }
+  }
+
+  const env = (import.meta as unknown as { env?: Record<string, string> }).env;
+  const fromEnv = env?.VITE_MASK_GATE;
+
+  return fromEnv ? fromEnv !== "0" && fromEnv !== "false" : true;
+};
+
+const MASK_GATE_ENABLED = readMaskGateEnabled();
+
+/**
+ * Frames whose masks are decoded and pinned ahead of the playhead — the
+ * decode-ahead lead. Sized so the pinned set stays small next to any sane cache
+ * capacity, since held masks are exempt from eviction.
+ */
+const MASK_HOLD_AHEAD_FRAMES = 12;
+
+/** Frames kept pinned behind the playhead, so small jitter doesn't re-decode. */
+const MASK_HOLD_BEHIND_FRAMES = 2;
+
 /**
  * Labels stream backed by the `POST /video-labels/window` endpoint.
  *
@@ -85,6 +134,30 @@ export class VideoFrameLabelsStream extends PlaybackStreamBase<FrameLabelSnapsho
   private readonly cache = new Map<number, FrameDoc>();
   private readonly inflight = new Map<number, Promise<void>>();
   private readonly fetchedRanges: Array<[number, number]> = [];
+  /**
+   * Frames whose masks are decoded AND borrowed, keyed to the sources borrowed
+   * for them — see {@link holdMasks}. A borrow is what makes readiness mean
+   * something: the cache can't evict a mask the gate has promised.
+   */
+  private readonly maskHeld = new Map<number, MaskSource[]>();
+  /** Current hold window in frames — see {@link holdWindow}. */
+  private maskHoldStart = 0;
+  private maskHoldEnd = -1;
+  /** Frames with a hold pass currently running. */
+  private readonly maskWarmInFlight = new Set<number>();
+  /**
+   * Frames whose masks failed to decode. Reported ready so one broken mask can't
+   * stall the clock forever — same escape hatch `frameBitmapStream` uses to play
+   * through a frame whose bitmap will never arrive.
+   */
+  private readonly maskUndecodable = new Set<number>();
+  /**
+   * Memoized per-frame mask sources. Deriving these walks every detection on the
+   * frame, and the hold window re-checks the same frames on every commit, so
+   * without memoization that walk dominates the commit. Invalidated when a
+   * frame's document is replaced.
+   */
+  private readonly maskSourceCache = new Map<number, MaskSource[]>();
   // Notified whenever a chunk lands. The annotation engine's frame store
   // re-seeds from `cachedFrames()` on this signal (via `subscribeToEdits`);
   // the stream itself holds no edit state — it is a read-only window seed
@@ -216,7 +289,7 @@ export class VideoFrameLabelsStream extends PlaybackStreamBase<FrameLabelSnapsho
     const frame = this.timeToFrame(time);
 
     if (this.cache.has(frame)) {
-      return "ready";
+      return this.maskReadiness(frame);
     }
 
     if (this.isInflight(frame)) {
@@ -230,10 +303,296 @@ export class VideoFrameLabelsStream extends PlaybackStreamBase<FrameLabelSnapsho
     return "missing";
   }
 
+  /**
+   * Readiness of this frame's decoded masks, folded into {@link bufferState} so
+   * the clock waits for masks it can actually draw rather than merely for the
+   * bytes they decode from. Without this the stream reports ready as soon as
+   * the label document lands, and a mask decoded a few frames later paints
+   * against whatever frame the playhead has since reached.
+   *
+   * Ready means this frame's masks are BORROWED, not merely that a decode pass
+   * ran for it once. An earlier version settled a frame permanently after one
+   * pass, which made the gate a first-visit-only check: on a looping play-through
+   * every frame was already settled, so the clock advanced against masks the
+   * cache had long since evicted and the draw path decoded them late. Holding
+   * borrows re-gates every visit and keeps the cache from evicting what the gate
+   * has promised.
+   */
+  private maskReadiness(frame: number): BufferReadiness {
+    if (!MASK_GATE_ENABLED) {
+      return "ready";
+    }
+
+    if (this.maskHeld.has(frame) || this.maskUndecodable.has(frame)) {
+      return "ready";
+    }
+
+    if (this.maskWarmInFlight.has(frame)) {
+      return "loading";
+    }
+
+    // Nothing to hold, so nothing to wait for. Cheap (sources are memoized) and
+    // load-bearing: without it every frame of a maskless clip would cost an
+    // extra barrier round-trip waiting on a hold pass with no work to do.
+    if (this.maskSourcesAt(frame).length === 0) {
+      return "ready";
+    }
+
+    // Not held yet — `prefetch`/`onCommit` will start the hold. Reporting
+    // missing (not loading) is what keeps the engine calling prefetch.
+    return "missing";
+  }
+
+  /**
+   * Distinct inline mask sources across every cached frame — the clip's mask
+   * working set. Compare against `entries` from {@link maskBitmapCache}'s stats:
+   * a working set larger than what the cache holds at capacity means a looping
+   * playthrough re-decodes on every pass rather than reusing, because LRU evicts
+   * whichever frame the loop is about to come back around to.
+   */
+  maskWorkingSetSize(): number {
+    const distinct = new Set<MaskSource>();
+
+    for (const frame of this.cache.keys()) {
+      for (const source of this.maskSourcesAt(frame)) {
+        distinct.add(source);
+      }
+    }
+
+    return distinct.size;
+  }
+
+  /** Every inline mask source carried by this frame's cached document. */
+  private maskSourcesAt(frame: number): MaskSource[] {
+    const memoized = this.maskSourceCache.get(frame);
+
+    if (memoized) {
+      return memoized;
+    }
+
+    const sources = this.deriveMaskSourcesAt(frame);
+
+    // Only memoize once the document has landed; an empty result for an
+    // unfetched frame would otherwise stick after the chunk arrives.
+    if (this.cache.has(frame)) {
+      this.maskSourceCache.set(frame, sources);
+    }
+
+    return sources;
+  }
+
+  private deriveMaskSourcesAt(frame: number): MaskSource[] {
+    const doc = this.cache.get(frame);
+
+    if (!doc) {
+      return [];
+    }
+
+    const sources: MaskSource[] = [];
+
+    for (const field of this.frameFields) {
+      const raw = doc[field] as RawDetectionsField | undefined;
+
+      for (const detection of raw?.detections ?? []) {
+        const source = maskSourceOf(detection.mask as SerializedMask);
+
+        if (source) {
+          sources.push(source);
+        }
+      }
+    }
+
+    return sources;
+  }
+
+  /**
+   * Decode this frame's masks and BORROW them, so the cache cannot evict them
+   * out from under the readiness this frame is about to report.
+   *
+   * Borrows are released as the playhead leaves the frame (see
+   * {@link releaseMasksOutside}), which bounds what is pinned to the hold window
+   * regardless of cache capacity — the reason this can hold without starving a
+   * cache too small for the whole clip.
+   */
+  private holdMasks(frame: number): void {
+    if (this.maskHeld.has(frame) || this.maskUndecodable.has(frame)) {
+      return;
+    }
+
+    if (this.maskWarmInFlight.has(frame)) {
+      return;
+    }
+
+    const sources = this.maskSourcesAt(frame);
+
+    if (sources.length === 0) {
+      // Held with no borrows: nothing to draw, so the frame is ready, and the
+      // entry doubles as the "already checked" marker.
+      this.maskHeld.set(frame, []);
+      return;
+    }
+
+    // Every source already resident: acquire synchronously so this frame is
+    // ready within the current tick rather than a microtask later.
+    if (sources.every((source) => maskBitmapCache.has(source))) {
+      const borrowed = sources.filter(
+        (source) => maskBitmapCache.acquire(source) !== undefined,
+      );
+
+      if (borrowed.length === sources.length) {
+        this.maskHeld.set(frame, borrowed);
+        return;
+      }
+
+      // Raced an eviction between `has` and `acquire` — hand back whatever we
+      // took and fall through to the async path.
+      for (const source of borrowed) {
+        maskBitmapCache.release(source);
+      }
+    }
+
+    this.maskWarmInFlight.add(frame);
+
+    void Promise.allSettled(
+      sources.map((source) => maskBitmapCache.acquireAsync(source)),
+    ).then((results) => {
+      this.maskWarmInFlight.delete(frame);
+
+      const borrowed: MaskSource[] = [];
+      let failed = false;
+
+      results.forEach((result, index) => {
+        if (result.status === "fulfilled") {
+          borrowed.push(sources[index]);
+        } else {
+          failed = true;
+        }
+      });
+
+      // A frame the playhead has already left, or whose document was replaced
+      // mid-decode, must not become held — its borrows would never be released.
+      if (!this.maskHoldWanted(frame)) {
+        for (const source of borrowed) {
+          maskBitmapCache.release(source);
+        }
+        return;
+      }
+
+      if (failed) {
+        for (const source of borrowed) {
+          maskBitmapCache.release(source);
+        }
+        this.maskUndecodable.add(frame);
+        return;
+      }
+
+      this.maskHeld.set(frame, borrowed);
+    });
+  }
+
+  /**
+   * Whether `frame` is still inside the window the hold pass was started for.
+   * Guards the async completion against a playhead that has moved on.
+   */
+  private maskHoldWanted(frame: number): boolean {
+    return (
+      frame >= this.maskHoldStart &&
+      frame <= this.maskHoldEnd &&
+      !this.maskHeld.has(frame)
+    );
+  }
+
+  /** Return the borrows for every held frame outside the current hold window. */
+  private releaseMasksOutside(start: number, end: number): void {
+    for (const [frame, sources] of this.maskHeld) {
+      if (frame >= start && frame <= end) {
+        continue;
+      }
+
+      for (const source of sources) {
+        maskBitmapCache.release(source);
+      }
+
+      this.maskHeld.delete(frame);
+    }
+  }
+
+  /**
+   * Return every mask borrow this stream holds. Must be called when the
+   * surface unmounts (sample change, modal close): the stream is the sole
+   * owner of its holds, and an unreturned borrow pins its entry in the
+   * process-wide cache for good — the bitmap can never be closed.
+   *
+   * The window is emptied FIRST so a warm pass still in flight releases its
+   * borrows on completion instead of re-holding ({@link maskHoldWanted} is
+   * window-scoped).
+   */
+  dispose(): void {
+    this.maskHoldStart = 0;
+    this.maskHoldEnd = -1;
+
+    // Nothing is inside an empty window, so this releases every held frame.
+    this.releaseMasksOutside(this.maskHoldStart, this.maskHoldEnd);
+  }
+
+  /** Drop any hold on `frame` — its masks may no longer be the right ones. */
+  private releaseMasksAt(frame: number): void {
+    const sources = this.maskHeld.get(frame);
+
+    if (!sources) {
+      return;
+    }
+
+    for (const source of sources) {
+      maskBitmapCache.release(source);
+    }
+
+    this.maskHeld.delete(frame);
+  }
+
+  /**
+   * Re-centre the hold window on the committed frame: hold forward, release
+   * behind.
+   *
+   * Called from `onCommit` as well as `prefetch` because the engine only calls
+   * `prefetch` while a stream reports NOT ready — decode-ahead has to keep
+   * running through the ready stretches too, which is what `frameBitmapStream`
+   * does for the same reason.
+   *
+   * The window is sized in FRAMES rather than from `lookaheadSeconds` (~58
+   * frames here) because every frame in it pins its masks: a window that large
+   * would hold most of a small cache, and holds are exempt from eviction.
+   */
+  private holdWindow(time: number): void {
+    const frame = this.timeToFrame(time);
+    const start = Math.max(1, frame - MASK_HOLD_BEHIND_FRAMES);
+    const end = Math.min(this.frameCount, frame + MASK_HOLD_AHEAD_FRAMES);
+
+    this.maskHoldStart = start;
+    this.maskHoldEnd = end;
+
+    this.releaseMasksOutside(start, end);
+
+    // Forward only — decoding frames the playhead has already passed buys
+    // nothing, though ones still held from behind stay held for jitter.
+    for (let f = frame; f <= end; f++) {
+      this.holdMasks(f);
+    }
+  }
+
   prefetch(range: [number, number]): void {
     const [startSec, endSec] = range;
     const startFrame = this.timeToFrame(startSec);
     const endFrame = this.timeToFrame(endSec);
+
+    // Decode-ahead: frames whose documents are already cached still need their
+    // masks rasterized before they can be drawn, and that is the stage the
+    // playhead actually outruns. Holding across the window (rather than
+    // first-missing-wins, as the chunk fetch below does) is what turns a cold
+    // play-through into cache hits.
+    if (MASK_GATE_ENABLED) {
+      this.holdWindow(startSec);
+    }
 
     // Find the first missing frame in the range and issue one chunk
     // starting there. The engine calls prefetch again as the playhead
@@ -249,22 +608,30 @@ export class VideoFrameLabelsStream extends PlaybackStreamBase<FrameLabelSnapsho
     }
   }
 
+  /**
+   * Whether a frame has a publishable snapshot — the cheap half of
+   * {@link getValue}, which `onCommit` uses to decide whether building one is
+   * worth it. Keep in step with `getValue`'s null case.
+   */
+  private hasSnapshotAt(frame: number): boolean {
+    return this.cache.has(frame) || isInFetchedRange(this.fetchedRanges, frame);
+  }
+
   getValue(time: number): FrameLabelSnapshot | null {
     const frame = this.timeToFrame(time);
-    const sample = this.cache.get(frame);
-    if (!sample) {
-      // Chunk fetched, this frame had no labels — return an empty
-      // snapshot so consumers can tell "no labels here" from "not fetched".
-      if (isInFetchedRange(this.fetchedRanges, frame)) {
-        return { frameNumber: frame, detections: [] };
-      }
+
+    if (!this.hasSnapshotAt(frame)) {
       return null;
     }
 
+    const sample = this.cache.get(frame);
+
     return {
       frameNumber: frame,
+      // No cached sample but the chunk was fetched: this frame genuinely has no
+      // labels, and an empty list tells consumers that apart from "not fetched".
       // todo - adapter pattern for other label types
-      detections: extractDetections(sample, this.frameField),
+      detections: sample ? extractDetections(sample, this.frameField) : [],
     };
   }
 
@@ -274,18 +641,31 @@ export class VideoFrameLabelsStream extends PlaybackStreamBase<FrameLabelSnapsho
    * re-publishing identical content on every intra-frame tick.
    */
   override onCommit(time: number, store: PlaybackStore): void {
-    const next = this.getValue(time);
+    const frame = this.timeToFrame(time);
     const prev = this.readPublished(store);
 
-    if (prev && next && prev.frameNumber === next.frameNumber) {
+    if (MASK_GATE_ENABLED) {
+      // Before the frame-dedupe below: warming has to keep running even on ticks
+      // that publish nothing new, since that is most of them.
+      this.holdWindow(time);
+    }
+
+    // Dedupe BEFORE building the snapshot. The engine commits several times per
+    // frame and `getValue` walks every detection on the frame, so the snapshots
+    // thrown away here outnumber the ones published — a cost that scales with
+    // labels per frame, i.e. worst on exactly the dense samples this stream
+    // gates for.
+    const hasSnapshot = this.hasSnapshotAt(frame);
+
+    if (prev !== null && prev.frameNumber === frame && hasSnapshot) {
       return;
     }
 
-    if (prev === null && next === null) {
+    if (prev === null && !hasSnapshot) {
       return;
     }
 
-    this.publish(store, next);
+    this.publish(store, this.getValue(time));
   }
 
   /**
@@ -365,6 +745,11 @@ export class VideoFrameLabelsStream extends PlaybackStreamBase<FrameLabelSnapsho
           frame_number: Number(frameNumber),
           ...fields,
         });
+        // A replaced document may carry different masks, so drop the memoized
+        // sources and any hold taken against the old ones.
+        this.maskSourceCache.delete(Number(frameNumber));
+        this.maskUndecodable.delete(Number(frameNumber));
+        this.releaseMasksAt(Number(frameNumber));
         landed++;
       }
 

--- a/app/packages/video-annotation/src/streams/VideoFrameLabelsStream.ts
+++ b/app/packages/video-annotation/src/streams/VideoFrameLabelsStream.ts
@@ -470,8 +470,10 @@ export class VideoFrameLabelsStream extends PlaybackStreamBase<FrameLabelSnapsho
       });
 
       // A frame the playhead has already left, or whose document was replaced
-      // mid-decode, must not become held — its borrows would never be released.
-      if (!this.maskHoldWanted(frame)) {
+      // mid-decode, must not become held — its borrows would never be released,
+      // and holding the old document's masks would report the frame ready
+      // while the new document's are undecoded.
+      if (!this.maskHoldWanted(frame, sources)) {
         for (const source of borrowed) {
           maskBitmapCache.release(source);
         }
@@ -491,10 +493,20 @@ export class VideoFrameLabelsStream extends PlaybackStreamBase<FrameLabelSnapsho
   }
 
   /**
-   * Whether `frame` is still inside the window the hold pass was started for.
-   * Guards the async completion against a playhead that has moved on.
+   * Whether `frame` still wants the hold pass it started: inside the window,
+   * not already held, and — because a document replaced mid-decode carries
+   * different masks — still describing the same sources the pass decoded.
    */
-  private maskHoldWanted(frame: number): boolean {
+  private maskHoldWanted(frame: number, startedFor: MaskSource[]): boolean {
+    const current = this.maskSourcesAt(frame);
+
+    if (
+      current.length !== startedFor.length ||
+      current.some((source, index) => source !== startedFor[index])
+    ) {
+      return false;
+    }
+
     return (
       frame >= this.maskHoldStart &&
       frame <= this.maskHoldEnd &&


### PR DESCRIPTION
Cherry-pick of #8131 into `release/v1.20.0` — both commits, applied clean with no conflicts.

See #8131 for the full description: decoded video-annotation masks become a shared, refcounted LRU resource, the playback clock gates on mask readiness (decoded **and** held for a window around the playhead), hold-last prevents mid-decode flicker, and `useActivateStream` fixes the labels stream being dormant so the gate actually runs. Includes the review-round hardening: mask holds are revalidated against the frame's current document on warm-pass completion, and a removed mask source releases the hold-last fallback.

## Testing

- CI green on #8131 (develop).
- All 59 unit tests across the four touched suites pass on this branch's own toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a process-wide cache for decoded mask bitmaps to reduce repeated decoding.
  * Playback stream activation can now be triggered separately from reading values.
  * Added mask-gated readiness for frame labels, with configurable hold window for steadier playback.
* **Bug Fixes**
  * Improved handling of stale, replaced, removed, and failed masks to prevent flicker and unstable hit-testing.
  * Decode failures no longer trigger repeated retries/logging across repaints.
* **Tests**
  * Expanded coverage for mask caching, decode convergence, and playback readiness/activation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3558
<!-- enterprise-sync-pr:end -->