### PR TITLE
fix(state): guard modal variables against undefined modalSelector

### DIFF
--- a/app/packages/state/src/recoil/modal.ts
+++ b/app/packages/state/src/recoil/modal.ts
@@ -194,7 +194,7 @@ export const modalSample = graphQLSelector<
   variables: ({ get }) => {
     const current = get(modalSelector);
 
-    if (current === null) return null;
+    if (current === null || current === undefined) return null;
 
     const slice = get(groupSlice);
     const sliceSelect = get(modalGroupSlice);
@@ -248,7 +248,7 @@ export const groupSampleAtMainSlice = graphQLSelector<
   variables: ({ get }) => {
     const current = get(modalSelector);
 
-    if (current === null) return null;
+    if (current === null || current === undefined) return null;
 
     const slice = get(groupSlice);
 

--- a/app/packages/state/src/session.test.tsx
+++ b/app/packages/state/src/session.test.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { act, renderHook } from "@testing-library/react-hooks";
+import { RecoilRoot, useRecoilValue } from "recoil";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { ModalSelector, Session } from "./session";
+
+const Root: React.FC<React.PropsWithChildren<unknown>> = ({ children }) => (
+  <RecoilRoot>{children}</RecoilRoot>
+);
+
+// `session.ts` reads `process.env.MODE` at module load time to decide whether
+// `sessionRef` writes are skipped (they are, under vitest's default "test"
+// mode). Re-importing with MODE stubbed to something else exercises the real
+// production code path, including the `sessionRef` bookkeeping.
+beforeEach(() => {
+  vi.resetModules();
+  vi.stubEnv("MODE", "development");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("sessionAtom", () => {
+  test("setting a session value to undefined resolves to its declared default instead of leaving the atom (and sessionRef) undefined", async () => {
+    const { sessionAtom, useSession, useSessionSetter, SESSION_DEFAULT } =
+      await import("./session");
+
+    const modalSelectorAtom = sessionAtom({
+      key: "modalSelector",
+      default: null,
+    });
+
+    const sessionRef: Session = { ...SESSION_DEFAULT, modalSelector: null };
+
+    const { result } = renderHook(
+      () => {
+        useSession(() => {}, sessionRef);
+        return {
+          value: useRecoilValue(modalSelectorAtom),
+          setSession: useSessionSetter(),
+        };
+      },
+      { wrapper: Root },
+    );
+
+    expect(result.current.value).toBeNull();
+
+    const selection: ModalSelector = { id: "sample-1" };
+    act(() => {
+      result.current.setSession("modalSelector", selection);
+    });
+    expect(result.current.value).toEqual(selection);
+    expect(sessionRef.modalSelector).toEqual(selection);
+
+    // Reproduces the race from the modal open/close TypeError: something
+    // sets the session value to `undefined` rather than its actual "empty"
+    // state (`null`).
+    act(() => {
+      result.current.setSession("modalSelector", undefined);
+    });
+
+    expect(result.current.value).toBeNull();
+    expect(sessionRef.modalSelector).toBeNull();
+  });
+});

--- a/app/packages/state/src/session.ts
+++ b/app/packages/state/src/session.ts
@@ -162,8 +162,11 @@ export const getSessionRef = () => {
 export const useSessionSetter = () => {
   return useCallback(<K extends SetterKeys>(key: K, value: Session[K]) => {
     const setter = setters[key];
-    setter && setter(value);
-    sessionRef[key] = value;
+    if (setter) {
+      setter(value);
+    } else {
+      sessionRef[key] = value;
+    }
   }, []);
 };
 
@@ -196,9 +199,10 @@ export function sessionAtom<K extends keyof Session>(
 
         // @ts-ignore
         setters[options.key] = (value: Session[K]) => {
-          setSelf(value);
+          const resolved = value === undefined ? options.default : value;
+          setSelf(resolved);
           if (!isTest) {
-            sessionRef[options.key] = value;
+            sessionRef[options.key] = resolved;
           }
         };
 


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

Fixes a `TypeError: Cannot read properties of undefined (reading 'id')` that could occur when closing/opening the sample modal.

**The problem:** `modalSelector` is a session atom (`app/packages/state/src/recoil/modal.ts`) whose declared default is `null`, but its `Session` type (`app/packages/state/src/session.ts`) allows the value to be `undefined` as well (`modalSelector?: ModalSelector`). Several consumers (`modalSample`, `groupSampleAtMainSlice`) only checked `current === null` before reading `current.id`, so a transient `undefined` value slipped through and threw.

Tracing why the atom could ever hold `undefined` instead of coercing to its `null` default led to the actual bug in `sessionAtom` (`session.ts`): the `"get"` trigger and the `subscribe` callback both coerce `sessionRef[key] === undefined` to `options.default`, but the registered `setters[key]` function did not — it passed whatever value it was given straight to `setSelf` and `sessionRef`. On top of that, `useSessionSetter` re-assigned `sessionRef[key] = value` with the raw, uncoerced value immediately after calling the setter, silently undoing any coercion the setter tried to do. Together these meant any caller that set a session value to `undefined` (rather than its intended default) would leave both the atom and `sessionRef` in an `undefined` state indefinitely.

**The fix:**
- `app/packages/state/src/recoil/modal.ts`: guard `modalSample` and `groupSampleAtMainSlice`'s `variables` functions against `current === undefined` in addition to `current === null` (fixes the immediate symptom).
- `app/packages/state/src/session.ts`: close the root cause in `sessionAtom` — `setters[options.key]` now coerces an `undefined` value to `options.default` before calling `setSelf`/writing `sessionRef`, matching the coercion already done on `"get"` and `subscribe`. Also fixed `useSessionSetter` so it no longer clobbers that coercion with a redundant raw write to `sessionRef`.

With both changes, a session atom like `modalSelector` can no longer end up holding `undefined` when its type/behavior expects `null`, so downstream consumers don't need ad-hoc `=== undefined` checks to stay safe.

## 🧪 How is this patch tested? If it is not, please explain why.

Manual testing in the app; existing lint/typecheck pass. No behavior change for the already-handled `null` case or for any session atom that is never set to `undefined`.

Added unit test for session fix.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved modal handling when no modal selection is available.
  * Fixed session updates so clearing a value correctly restores its default state.
  * Prevented session values from becoming inconsistent after updates.

* **Tests**
  * Added coverage for session defaults and clearing previously selected values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3569
<!-- enterprise-sync-pr:end -->