### PR TITLE
Fix horizontal scrollbar in 3D label tooltip on row hover

### DIFF
--- a/app/packages/core/src/components/Modal/TooltipInfo.tsx
+++ b/app/packages/core/src/components/Modal/TooltipInfo.tsx
@@ -70,9 +70,9 @@ const HiddenItemsContainer = styled.div`
 `;
 
 const HiddenItemRowDiv = styled.div`
+  position: relative;
   display: flex;
   align-items: center;
-  justify-content: space-between;
   height: 1.5rem;
 `;
 
@@ -83,11 +83,11 @@ const Row = styled.div`
 `;
 
 const ContentItemContainer = styled.div`
+  position: relative;
   margin: 0;
   padding: 0;
   display: flex;
   align-items: center;
-  justify-content: space-between;
 `;
 
 const ContentItemDiv = styled.div`
@@ -97,11 +97,11 @@ const ContentItemDiv = styled.div`
 `;
 
 const VisibilityIconContainer = animated(styled.div`
-  width: 1.5rem;
+  position: absolute;
+  inset: 0;
   display: flex;
   align-items: center;
-  justify-content: center;
-  padding-right: 0.5rem;
+  justify-content: flex-end;
 `);
 
 const ContentValue = styled.div`


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

Fixes a horizontal scrollbar that appeared in the label detail tooltip (e.g. hovering a 3D cuboid) when hovering a row revealed the eyeball visibility icon. The icon now overlays via absolute positioning instead of taking flex layout space, so it can no longer push the row width past the tooltip's max-width.

Before:
<img width="452" height="710" alt="screenshot-2026-07-29_11-01-19" src="https://github.com/user-attachments/assets/bf591a85-3090-4d89-aac2-1e2cad0951a9" />

After:
<img width="449" height="681" alt="screenshot-2026-07-29_11-01-01" src="https://github.com/user-attachments/assets/7b97b33d-bfcf-4c8d-a1ea-bf8b05f04267" />

## 🧪 How is this patch tested? If it is not, please explain why.

Manually verified in the app: hovering rows in a 3D scene's cuboid detail tooltip no longer produces a horizontal scrollbar.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3570
<!-- enterprise-sync-pr:end -->