### PR TITLE
[FOEPD-4280] Suppress label hover during transforms in the 3D side panels

### DIFF
--- a/app/packages/looker-3d/src/labels/CuboidInstances.tsx
+++ b/app/packages/looker-3d/src/labels/CuboidInstances.tsx
@@ -11,6 +11,7 @@ import {
   useState,
   type RefObject,
 } from "react";
+import { useRecoilValue } from "recoil";
 import * as THREE from "three";
 import { LineMaterial } from "three/examples/jsm/lines/LineMaterial";
 import { LineSegmentsGeometry } from "three/examples/jsm/lines/LineSegmentsGeometry";
@@ -19,6 +20,7 @@ import { PANEL_ID_MAIN } from "../constants";
 import { useFo3dContext } from "../fo3d/context";
 import { use3dLabelColor } from "../hooks/use-3d-label-color";
 import { useSimilarLabels3d } from "../hooks/use-similar-labels-3d";
+import { isCurrentlyTransformingAtom } from "../state";
 import {
   useCurrentSelected3dAnnotationLabel,
   useHoveredLabel3d,
@@ -94,6 +96,7 @@ export const CuboidInstances = ({
 }: CuboidInstancesProps) => {
   const { upVector } = useFo3dContext();
   const hoveredLabel = useHoveredLabel3d();
+  const isCurrentlyTransforming = useRecoilValue(isCurrentlyTransformingAtom);
   const setHoveredLabel = useSetHoveredLabel3d();
 
   const bodyMeshRef = useRef<THREE.InstancedMesh>(null);
@@ -440,7 +443,12 @@ export const CuboidInstances = ({
 
   const handlePointerOver = useCallback(
     (e: ThreeEvent<PointerEvent>) => {
-      if (hoverSource === PANEL_ID_MAIN && e.nativeEvent.buttons !== 0) return;
+      if (
+        isCurrentlyTransforming ||
+        (hoverSource === PANEL_ID_MAIN && e.nativeEvent.buttons !== 0)
+      ) {
+        return;
+      }
       const label = resolveLabel(e.instanceId);
       if (!label) return;
 
@@ -448,7 +456,13 @@ export const CuboidInstances = ({
       setHoveredLabel({ id: label._id, source: hoverSource });
       onPointerOverForLabel(label, e);
     },
-    [resolveLabel, hoverSource, setHoveredLabel, onPointerOverForLabel],
+    [
+      resolveLabel,
+      hoverSource,
+      isCurrentlyTransforming,
+      setHoveredLabel,
+      onPointerOverForLabel,
+    ],
   );
 
   const handlePointerOut = useCallback(() => {

--- a/app/packages/looker-3d/src/labels/CuboidInstances.tsx
+++ b/app/packages/looker-3d/src/labels/CuboidInstances.tsx
@@ -11,7 +11,6 @@ import {
   useState,
   type RefObject,
 } from "react";
-import { useRecoilValue } from "recoil";
 import * as THREE from "three";
 import { LineMaterial } from "three/examples/jsm/lines/LineMaterial";
 import { LineSegmentsGeometry } from "three/examples/jsm/lines/LineSegmentsGeometry";
@@ -20,10 +19,10 @@ import { PANEL_ID_MAIN } from "../constants";
 import { useFo3dContext } from "../fo3d/context";
 import { use3dLabelColor } from "../hooks/use-3d-label-color";
 import { useSimilarLabels3d } from "../hooks/use-similar-labels-3d";
-import { isCurrentlyTransformingAtom } from "../state";
 import {
   useCurrentSelected3dAnnotationLabel,
   useHoveredLabel3d,
+  useIsCurrentlyTransforming,
   useSetHoveredLabel3d,
 } from "../state/accessors";
 import type { HoveredLabelSource } from "../types";
@@ -97,7 +96,7 @@ export const CuboidInstances = ({
 }: CuboidInstancesProps) => {
   const { upVector } = useFo3dContext();
   const hoveredLabel = useHoveredLabel3d();
-  const isCurrentlyTransforming = useRecoilValue(isCurrentlyTransformingAtom);
+  const isCurrentlyTransforming = useIsCurrentlyTransforming();
   const setHoveredLabel = useSetHoveredLabel3d();
 
   const bodyMeshRef = useRef<THREE.InstancedMesh>(null);

--- a/app/packages/looker-3d/src/labels/CuboidInstances.tsx
+++ b/app/packages/looker-3d/src/labels/CuboidInstances.tsx
@@ -54,6 +54,7 @@ import {
   getFiniteMagnitude,
 } from "./shared/cuboid-orientation-geometry";
 import { useEventHandlers } from "./shared/hooks";
+import { shouldSuppressHoverOnPointer } from "./shared/shouldSuppressHoverOnPointer";
 import "./shared/registerLineElements";
 import { useDragGate } from "./shared/useDragGate";
 
@@ -444,8 +445,11 @@ export const CuboidInstances = ({
   const handlePointerOver = useCallback(
     (e: ThreeEvent<PointerEvent>) => {
       if (
-        isCurrentlyTransforming ||
-        (hoverSource === PANEL_ID_MAIN && e.nativeEvent.buttons !== 0)
+        shouldSuppressHoverOnPointer(
+          hoverSource,
+          isCurrentlyTransforming,
+          e.nativeEvent.buttons,
+        )
       ) {
         return;
       }

--- a/app/packages/looker-3d/src/labels/cuboid.tsx
+++ b/app/packages/looker-3d/src/labels/cuboid.tsx
@@ -547,14 +547,17 @@ export const Cuboid = ({
 
   const setHoveredLabelFromPointer = useCallback(
     (e: ThreeEvent<PointerEvent>) => {
-      if (hoverSource === PANEL_ID_MAIN && e.nativeEvent.buttons !== 0) {
+      if (
+        isCurrentlyTransforming ||
+        (hoverSource === PANEL_ID_MAIN && e.nativeEvent.buttons !== 0)
+      ) {
         return false;
       }
 
       setHoveredLabel({ id: label._id, source: hoverSource });
       return true;
     },
-    [hoverSource, label._id, setHoveredLabel],
+    [hoverSource, isCurrentlyTransforming, label._id, setHoveredLabel],
   );
 
   const transformMode = useRecoilValue(transformModeAtom);

--- a/app/packages/looker-3d/src/labels/cuboid.tsx
+++ b/app/packages/looker-3d/src/labels/cuboid.tsx
@@ -30,7 +30,10 @@ import {
   selectedLabelForAnnotationAtom,
   transformModeAtom,
 } from "../state";
-import { useSetCurrent3dAnnotationMode } from "../state/accessors";
+import {
+  useIsCurrentlyTransforming,
+  useSetCurrent3dAnnotationMode,
+} from "../state/accessors";
 import {
   getComplementaryColor,
   getPlaneIntersection,
@@ -409,7 +412,7 @@ export const Cuboid = ({
   const isCreatingCuboidPointerDown = useRecoilValue(
     isCreatingCuboidPointerDownAtom,
   );
-  const isCurrentlyTransforming = useRecoilValue(isCurrentlyTransformingAtom);
+  const isCurrentlyTransforming = useIsCurrentlyTransforming();
   const setIsCurrentlyTransforming = useSetRecoilState(
     isCurrentlyTransformingAtom,
   );

--- a/app/packages/looker-3d/src/labels/cuboid.tsx
+++ b/app/packages/looker-3d/src/labels/cuboid.tsx
@@ -48,6 +48,7 @@ import {
 import { useDisplayCuboidTransform } from "./shared/useDisplayCuboidTransform";
 import { useEventHandlers, useHoverState, useLabelColor } from "./shared/hooks";
 import "./shared/registerLineElements";
+import { shouldSuppressHoverOnPointer } from "./shared/shouldSuppressHoverOnPointer";
 import { Transformable } from "./shared/TransformControls";
 
 const FACE_RESIZE_EDGE_COLOR = "#ff2f2f";
@@ -548,8 +549,11 @@ export const Cuboid = ({
   const setHoveredLabelFromPointer = useCallback(
     (e: ThreeEvent<PointerEvent>) => {
       if (
-        isCurrentlyTransforming ||
-        (hoverSource === PANEL_ID_MAIN && e.nativeEvent.buttons !== 0)
+        shouldSuppressHoverOnPointer(
+          hoverSource,
+          isCurrentlyTransforming,
+          e.nativeEvent.buttons,
+        )
       ) {
         return false;
       }

--- a/app/packages/looker-3d/src/labels/polyline.tsx
+++ b/app/packages/looker-3d/src/labels/polyline.tsx
@@ -7,13 +7,12 @@ import * as THREE from "three";
 import { useTransientPolyline } from "../annotation/store";
 import { usePolylineAnnotation } from "../annotation/usePolylineAnnotation";
 import { FO_USER_DATA, PANEL_ID_MAIN } from "../constants";
-import {
-  hoveredLabelAtom,
-  isCurrentlyTransformingAtom,
-  selectedLabelForAnnotationAtom,
-} from "../state";
+import { hoveredLabelAtom, selectedLabelForAnnotationAtom } from "../state";
 import type { HoveredLabelSource } from "../types";
-import { useSetCurrent3dAnnotationMode } from "../state/accessors";
+import {
+  useIsCurrentlyTransforming,
+  useSetCurrent3dAnnotationMode,
+} from "../state/accessors";
 import {
   isValidPoint3d,
   validatePoints3d,
@@ -52,7 +51,7 @@ export const Polyline = ({
   useHoverState();
   const hoveredLabel = useRecoilValue(hoveredLabelAtom);
   const setHoveredLabel = useSetRecoilState(hoveredLabelAtom);
-  const isCurrentlyTransforming = useRecoilValue(isCurrentlyTransformingAtom);
+  const isCurrentlyTransforming = useIsCurrentlyTransforming();
   const {
     onPointerOver: onPointerOverForLabel,
     onPointerOut: onPointerOutForLabel,

--- a/app/packages/looker-3d/src/labels/polyline.tsx
+++ b/app/packages/looker-3d/src/labels/polyline.tsx
@@ -22,6 +22,7 @@ import {
 import { createFilledPolygonMeshes } from "./polygon-fill-utils";
 import type { OverlayProps } from "./shared";
 import { useEventHandlers, useHoverState, useLabelColor } from "./shared/hooks";
+import { shouldSuppressHoverOnPointer } from "./shared/shouldSuppressHoverOnPointer";
 import { Transformable } from "./shared/TransformControls";
 
 export interface PolyLineProps extends OverlayProps {
@@ -313,8 +314,11 @@ export const Polyline = ({
           {...restEventHandlers}
           onPointerOver={(e) => {
             if (
-              isCurrentlyTransforming ||
-              (hoverSource === PANEL_ID_MAIN && e.nativeEvent.buttons !== 0)
+              shouldSuppressHoverOnPointer(
+                hoverSource,
+                isCurrentlyTransforming,
+                e.nativeEvent.buttons,
+              )
             ) {
               return;
             }

--- a/app/packages/looker-3d/src/labels/polyline.tsx
+++ b/app/packages/looker-3d/src/labels/polyline.tsx
@@ -7,7 +7,11 @@ import * as THREE from "three";
 import { useTransientPolyline } from "../annotation/store";
 import { usePolylineAnnotation } from "../annotation/usePolylineAnnotation";
 import { FO_USER_DATA, PANEL_ID_MAIN } from "../constants";
-import { hoveredLabelAtom, selectedLabelForAnnotationAtom } from "../state";
+import {
+  hoveredLabelAtom,
+  isCurrentlyTransformingAtom,
+  selectedLabelForAnnotationAtom,
+} from "../state";
 import type { HoveredLabelSource } from "../types";
 import { useSetCurrent3dAnnotationMode } from "../state/accessors";
 import {
@@ -47,6 +51,7 @@ export const Polyline = ({
   useHoverState();
   const hoveredLabel = useRecoilValue(hoveredLabelAtom);
   const setHoveredLabel = useSetRecoilState(hoveredLabelAtom);
+  const isCurrentlyTransforming = useRecoilValue(isCurrentlyTransformingAtom);
   const {
     onPointerOver: onPointerOverForLabel,
     onPointerOut: onPointerOutForLabel,
@@ -307,7 +312,10 @@ export const Polyline = ({
         <group
           {...restEventHandlers}
           onPointerOver={(e) => {
-            if (hoverSource === PANEL_ID_MAIN && e.nativeEvent.buttons !== 0) {
+            if (
+              isCurrentlyTransforming ||
+              (hoverSource === PANEL_ID_MAIN && e.nativeEvent.buttons !== 0)
+            ) {
               return;
             }
 

--- a/app/packages/looker-3d/src/labels/shared/index.ts
+++ b/app/packages/looker-3d/src/labels/shared/index.ts
@@ -1,5 +1,6 @@
 export * from "./CuboidOrientationMarkers";
 export * from "./hooks";
+export * from "./shouldSuppressHoverOnPointer";
 export * from "./TransformControls";
 export * from "./useDisplayCuboidTransform";
 export * from "./useDragGate";

--- a/app/packages/looker-3d/src/labels/shared/shouldSuppressHoverOnPointer.test.ts
+++ b/app/packages/looker-3d/src/labels/shared/shouldSuppressHoverOnPointer.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { PANEL_ID_MAIN, PANEL_ID_SIDE_TOP } from "../../constants";
+import { shouldSuppressHoverOnPointer } from "./shouldSuppressHoverOnPointer";
+
+describe("shouldSuppressHoverOnPointer", () => {
+  it("suppresses in the main panel while transforming", () => {
+    expect(shouldSuppressHoverOnPointer(PANEL_ID_MAIN, true, 0)).toBe(true);
+  });
+
+  it("suppresses in a side panel while transforming (FOEPD-4280)", () => {
+    expect(shouldSuppressHoverOnPointer(PANEL_ID_SIDE_TOP, true, 0)).toBe(true);
+  });
+
+  it("does not suppress in a side panel when not transforming, even with a button held", () => {
+    expect(shouldSuppressHoverOnPointer(PANEL_ID_SIDE_TOP, false, 1)).toBe(
+      false,
+    );
+  });
+
+  it("suppresses in the main panel with a button held even when not transforming (crop-drag guard)", () => {
+    expect(shouldSuppressHoverOnPointer(PANEL_ID_MAIN, false, 1)).toBe(true);
+  });
+
+  it("does not suppress in the main panel when idle", () => {
+    expect(shouldSuppressHoverOnPointer(PANEL_ID_MAIN, false, 0)).toBe(false);
+  });
+});

--- a/app/packages/looker-3d/src/labels/shared/shouldSuppressHoverOnPointer.ts
+++ b/app/packages/looker-3d/src/labels/shared/shouldSuppressHoverOnPointer.ts
@@ -1,0 +1,26 @@
+import { PANEL_ID_MAIN } from "../../constants";
+import type { HoveredLabelSource } from "../../types";
+
+/**
+ * Whether a pointer-over on a cuboid/polyline should be ignored rather than
+ * setting hover state.
+ *
+ * `isCurrentlyTransforming` suppresses hover in every panel (main + both
+ * ortho side panels) while a transform/face-resize drag is in progress, so
+ * editing one label's geometry never highlights whatever other label the
+ * cursor happens to pass over mid-drag (FOEPD-4280).
+ *
+ * The `buttons !== 0` check on `PANEL_ID_MAIN` alone is a separate,
+ * pre-existing guard for the main view's point-cloud crop-drag tool, which
+ * doesn't set `isCurrentlyTransforming` but still shouldn't cause incidental
+ * hover while a mouse button is held down.
+ */
+export function shouldSuppressHoverOnPointer(
+  hoverSource: HoveredLabelSource,
+  isCurrentlyTransforming: boolean,
+  buttons: number,
+): boolean {
+  return (
+    isCurrentlyTransforming || (hoverSource === PANEL_ID_MAIN && buttons !== 0)
+  );
+}

--- a/app/packages/looker-3d/src/state/accessors.ts
+++ b/app/packages/looker-3d/src/state/accessors.ts
@@ -13,6 +13,7 @@ import {
   hoveredLabelAtom,
   isActivelySegmentingSelector,
   isCreatingCuboidAtom,
+  isCurrentlyTransformingAtom,
   isFo3dMainPanelPointerDownAtom,
   mainPanelPanSyncIntentAtom,
   mainPanelZoomSyncIntentAtom,
@@ -100,6 +101,14 @@ export const useFo3dPerformanceStats = () => {
 
 export const useSetFo3dPerformanceStats = () => {
   return useSetRecoilState(fo3dPerformanceStatsAtom);
+};
+
+/**
+ * Whether any label is mid-transform (gizmo drag, face-pull resize, heading
+ * drag). Components consume this rather than the atom directly.
+ */
+export const useIsCurrentlyTransforming = () => {
+  return useRecoilValue(isCurrentlyTransformingAtom);
 };
 
 export const useCuboidOrientation = () => {


### PR DESCRIPTION
> [!NOTE]
> Stacked on #8124 (`feat/looker3dInstanceMeshing`), which it needs for `CuboidInstances`.

## 🔗 Related Issues

[FOEPD-4280]

## 📋 What changes are proposed in this pull request?

While dragging a cuboid's transform or resize handles, hovering the cursor over *other* labels shouldn't highlight them. That already held in the main perspective view but not in the orthographic side panels.

The existing guard was:

```ts
hoverSource === PANEL_ID_MAIN && e.nativeEvent.buttons !== 0
```

`hoverSource === PANEL_ID_MAIN` is only ever true for the main view, so for a side panel the whole expression was **always false** regardless of whether a drag was in progress. Those panels were never eligible for suppression at all. The guard wasn't a general drag check — it was written for a narrower main-view-only problem (the point-cloud crop-drag tool causing incidental hover), and the side panels were never in scope.

The fix additionally checks the panel-agnostic transform state, which is already set during both gizmo drags and face-resize drags, and which `useMeshTooltipProps` already used to suppress the *tooltip* correctly across all panels. The condition is extracted into `shouldSuppressHoverOnPointer` rather than repeated at the three call sites (`cuboid.tsx`, `CuboidInstances.tsx`, `polyline.tsx`), since it had to stay identical in all three.

The original `buttons !== 0` main-panel check is preserved: crop-drag doesn't set the transform flag, so removing it would regress that fix.

### Review feedback addressed

The transform state is read through a new `useIsCurrentlyTransforming` domain hook in `state/accessors` rather than `useRecoilValue(isCurrentlyTransformingAtom)` directly, per the repo's guideline that components shouldn't consume raw Recoil. `cuboid.tsx`'s own direct read predates this branch and also *writes* the atom, so it's left alone rather than widening the diff.

## 🧪 How is this patch tested? If it is not, please explain why.

552 unit tests pass in the package.

`shouldSuppressHoverOnPointer.test.ts` (5) covers each branch: suppression while transforming in the main panel *and* in a side panel (the actual bug), no suppression in a side panel when idle with a button held, the pre-existing main-panel crop-drag guard, and the idle case.

The helper is where the whole fix lives, so testing it directly is the meaningful coverage; the three call sites are one-line applications of it.

Manually verified: dragging a cuboid's resize handles in a side panel no longer highlights other labels the cursor passes over.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other

[FOEPD-4280]: https://voxel51.atlassian.net/browse/FOEPD-4280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved label hover stability during active transforms and face-resize interactions across panels.
  * Prevented unintended hover changes while mouse buttons are held in the main view.
  * Preserved side-panel hover responsiveness when not transforming, even during button holds.
* **Tests**
  * Added coverage for hover-suppression behavior across transforming and idle states and different panels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3657
<!-- enterprise-sync-pr:end -->