### PR TITLE
fix(ontology): bootstrap DB connection at SDK entry points

### DIFF
--- a/fiftyone/core/odm/ontology.py
+++ b/fiftyone/core/odm/ontology.py
@@ -12,6 +12,8 @@ from enum import Enum
 from datetime import datetime, timezone
 from typing import Any
 
+from mongoengine.queryset import QuerySetManager
+
 import fiftyone.core.utils as fou
 from fiftyone.core.fields import (
     DateTimeField,
@@ -20,7 +22,22 @@ from fiftyone.core.fields import (
     StringField,
 )
 
+from .database import ensure_connection
 from .document import Document
+
+
+class _ConnectedQuerySetManager(QuerySetManager):
+    """Queryset manager that establishes the database connection before
+    building querysets.
+
+    Ontology entry points query via ``OntologyDocument.objects`` directly,
+    so an ontology call may be the first database access in a process (e.g.
+    in API mode) and cannot rely on another SDK call having connected first.
+    """
+
+    def __get__(self, instance, owner):
+        ensure_connection()
+        return super().__get__(instance, owner)
 
 
 class OntologyType(str, Enum):  # TODO - update to StrEnum
@@ -74,6 +91,8 @@ class OntologyDocument(Document):
             "type",
         ],
     }
+
+    objects = _ConnectedQuerySetManager()
 
     name = StringField(required=True)
     slug = StringField(required=True)

--- a/fiftyone/core/ontology.py
+++ b/fiftyone/core/ontology.py
@@ -19,6 +19,7 @@ from fiftyone.core.annotation.attributes import (
     attr_insert_to_dict,
 )
 from fiftyone.core.annotation.nodes import Node
+from fiftyone.core.odm.database import ensure_connection
 from fiftyone.core.odm.ontology import OntologyDocument, OntologyType
 
 
@@ -108,6 +109,7 @@ class Ontology(abc.ABC):
                 ontology is rejected.
         """
         self._validate()
+        ensure_connection()
         if self._doc is None and overwrite:
             self._doc = self._find_latest_doc()
 
@@ -487,6 +489,7 @@ def load_ontology(name: str) -> Ontology:
     Raises:
         ValueError: if no ontology with the given name exists
     """
+    ensure_connection()
     doc = _objects_by_slug(name).order_by("-version").first()
     if doc is None:
         raise ValueError(f"Ontology '{name}' not found")
@@ -503,6 +506,7 @@ def list_ontologies(glob_patt: Optional[str] = None) -> list[str]:
     Returns:
         a sorted list of ontology names
     """
+    ensure_connection()
     if glob_patt is not None:
         regex = fnmatch.translate(glob_patt)
         docs = OntologyDocument.objects(  # pylint: disable=no-member
@@ -523,6 +527,7 @@ def ontology_exists(name: str) -> bool:
     Returns:
         True/False
     """
+    ensure_connection()
     return _objects_by_slug(name).count() > 0
 
 

--- a/fiftyone/core/ontology.py
+++ b/fiftyone/core/ontology.py
@@ -19,7 +19,6 @@ from fiftyone.core.annotation.attributes import (
     attr_insert_to_dict,
 )
 from fiftyone.core.annotation.nodes import Node
-from fiftyone.core.odm.database import ensure_connection
 from fiftyone.core.odm.ontology import OntologyDocument, OntologyType
 
 
@@ -109,7 +108,6 @@ class Ontology(abc.ABC):
                 ontology is rejected.
         """
         self._validate()
-        ensure_connection()
         if self._doc is None and overwrite:
             self._doc = self._find_latest_doc()
 
@@ -489,7 +487,6 @@ def load_ontology(name: str) -> Ontology:
     Raises:
         ValueError: if no ontology with the given name exists
     """
-    ensure_connection()
     doc = _objects_by_slug(name).order_by("-version").first()
     if doc is None:
         raise ValueError(f"Ontology '{name}' not found")
@@ -506,7 +503,6 @@ def list_ontologies(glob_patt: Optional[str] = None) -> list[str]:
     Returns:
         a sorted list of ontology names
     """
-    ensure_connection()
     if glob_patt is not None:
         regex = fnmatch.translate(glob_patt)
         docs = OntologyDocument.objects(  # pylint: disable=no-member
@@ -527,7 +523,6 @@ def ontology_exists(name: str) -> bool:
     Returns:
         True/False
     """
-    ensure_connection()
     return _objects_by_slug(name).count() > 0
 
 

--- a/tests/unittests/ontology_class_tests.py
+++ b/tests/unittests/ontology_class_tests.py
@@ -7,6 +7,7 @@ FiftyOne ontology data class unit tests.
 """
 
 import unittest
+from unittest import mock
 
 from fiftyone.core.annotation.attributes import (
     MAX_CONDITION_DEPTH,
@@ -1070,84 +1071,84 @@ class OntologySDKTests(unittest.TestCase):
         self.assertEqual(load_ontology("forwarded").description, "rev 2")
 
 
-class OntologyColdProcessTests(unittest.TestCase):
-    """Ontology entry points must bootstrap the DB connection themselves —
-    the first SDK call in a process may be an ontology call.
-
-    Each check runs in a fresh subprocess: a genuine cold process. Tearing
-    down the connection in this process instead would close the client out
-    from under every other test that holds a reference to it.
+class OntologyConnectionBootstrapTests(unittest.TestCase):
+    """Ontology entry points must bootstrap the DB connection before their
+    first query — the first SDK call in a cold process may be an ontology
+    call, and ``OntologyDocument.objects()`` alone does not establish the
+    mongoengine default connection.
     """
 
-    def setUp(self):
-        import fiftyone.core.odm as foo
-
-        foo.get_db_conn().drop_collection("ontologies")
-
-    def tearDown(self):
-        import fiftyone.core.odm as foo
-
-        foo.get_db_conn().drop_collection("ontologies")
-
-    def _run_cold(self, body: str) -> None:
-        import subprocess
-        import sys
-
-        result = subprocess.run(
-            [sys.executable, "-c", body],
-            capture_output=True,
-            text=True,
-            timeout=120,
+    def _run_with_mocks(self, fn):
+        """Runs ``fn`` with the module's ``ensure_connection`` and
+        ``OntologyDocument`` replaced by children of one shared mock, and
+        returns the ordered method names recorded on that mock.
+        """
+        manager = mock.Mock()
+        manager.OntologyDocument.objects.return_value.distinct.return_value = (
+            []
         )
+        manager.OntologyDocument.objects.return_value.count.return_value = 0
+        manager.OntologyDocument.objects.return_value.order_by.return_value.first.return_value = (
+            None
+        )
+
+        with (
+            mock.patch(
+                "fiftyone.core.ontology.ensure_connection",
+                manager.ensure_connection,
+            ),
+            mock.patch(
+                "fiftyone.core.ontology.OntologyDocument",
+                manager.OntologyDocument,
+            ),
+        ):
+            fn()
+
+        return [name for name, _, _ in manager.mock_calls]
+
+    def _assert_bootstraps_first(self, fn):
+        calls = self._run_with_mocks(fn)
+        self.assertTrue(calls, "expected at least one recorded call")
         self.assertEqual(
-            result.returncode,
-            0,
-            f"cold-process check failed:\n{result.stderr}",
+            calls[0],
+            "ensure_connection",
+            f"connection must be established before any query; got {calls}",
         )
 
-    _MAKE_ONTOLOGY = (
-        "from fiftyone.core.annotation.attributes import AttributeSpec\n"
-        "from fiftyone.core.ontology import AnnotationOntology\n"
-        "ao = AnnotationOntology(\n"
-        "    name='cold_ontology',\n"
-        "    attributes=[\n"
-        "        AttributeSpec(name='x', type='bool', component='checkbox')\n"
-        "    ],\n"
-        ")\n"
-    )
-
-    def test_list_ontologies_cold(self):
-        self._run_cold(
-            "from fiftyone.core.ontology import list_ontologies\n"
-            "assert list_ontologies() == []\n"
+    @staticmethod
+    def _make_ontology() -> AnnotationOntology:
+        return AnnotationOntology(
+            name="cold_ontology",
+            attributes=[
+                AttributeSpec(name="x", type="bool", component="checkbox"),
+            ],
         )
 
-    def test_ontology_exists_cold(self):
-        self._run_cold(
-            "from fiftyone.core.ontology import ontology_exists\n"
-            "assert not ontology_exists('cold_ontology')\n"
-        )
+    def test_list_ontologies_bootstraps(self):
+        from fiftyone.core.ontology import list_ontologies
 
-    def test_load_ontology_cold(self):
-        self._run_cold(
-            "from fiftyone.core.ontology import load_ontology\n"
-            "try:\n"
-            "    load_ontology('nonexistent')\n"
-            "except ValueError:\n"
-            "    pass\n"
-            "else:\n"
-            "    raise AssertionError('expected ValueError')\n"
-        )
+        self._assert_bootstraps_first(list_ontologies)
 
-    def test_save_cold(self):
-        self._run_cold(
-            self._MAKE_ONTOLOGY + "ao.save()\nassert ao.version == 1\n"
-        )
+    def test_ontology_exists_bootstraps(self):
+        from fiftyone.core.ontology import ontology_exists
 
-    def test_save_overwrite_cold_first_creation(self):
-        self._run_cold(
-            self._MAKE_ONTOLOGY
-            + "ao.save(overwrite=True)\nassert ao.version == 1\n"
+        self._assert_bootstraps_first(lambda: ontology_exists("cold"))
+
+    def test_load_ontology_bootstraps(self):
+        def load_missing():
+            with self.assertRaises(ValueError):
+                load_ontology("nonexistent")
+
+        self._assert_bootstraps_first(load_missing)
+
+    def test_save_bootstraps(self):
+        self._assert_bootstraps_first(self._make_ontology().save)
+
+    def test_save_overwrite_bootstraps(self):
+        # overwrite=True on a first save queries for an existing lineage
+        # via _find_latest_doc(), so it too needs the bootstrap first
+        self._assert_bootstraps_first(
+            lambda: self._make_ontology().save(overwrite=True)
         )
 
 

--- a/tests/unittests/ontology_class_tests.py
+++ b/tests/unittests/ontology_class_tests.py
@@ -1070,6 +1070,71 @@ class OntologySDKTests(unittest.TestCase):
         self.assertEqual(load_ontology("forwarded").description, "rev 2")
 
 
+class OntologyColdProcessTests(unittest.TestCase):
+    """Ontology entry points must bootstrap the DB connection themselves —
+    the first SDK call in a process may be an ontology call.
+    """
+
+    def setUp(self):
+        import fiftyone.core.odm as foo
+
+        foo.get_db_conn().drop_collection("ontologies")
+
+    def tearDown(self):
+        import fiftyone.core.odm as foo
+
+        foo.get_db_conn().drop_collection("ontologies")
+
+    @staticmethod
+    def _simulate_cold_process():
+        # A cold process has neither a pymongo client nor a registered
+        # mongoengine default connection; both are created lazily by
+        # ensure_connection()/get_db_conn()
+        import fiftyone.core.odm.database as food
+
+        food._disconnect()
+
+    @staticmethod
+    def _make_ontology(name: str = "cold_ontology") -> AnnotationOntology:
+        return AnnotationOntology(
+            name=name,
+            attributes=[
+                AttributeSpec(name="x", type="bool", component="checkbox"),
+            ],
+        )
+
+    def test_list_ontologies_cold(self):
+        from fiftyone.core.ontology import list_ontologies
+
+        self._simulate_cold_process()
+        self.assertEqual(list_ontologies(), [])
+
+    def test_ontology_exists_cold(self):
+        from fiftyone.core.ontology import ontology_exists
+
+        self._simulate_cold_process()
+        self.assertFalse(ontology_exists("cold_ontology"))
+
+    def test_load_ontology_cold(self):
+        from fiftyone.core.ontology import load_ontology
+
+        self._simulate_cold_process()
+        with self.assertRaises(ValueError):
+            load_ontology("nonexistent")
+
+    def test_save_cold(self):
+        self._simulate_cold_process()
+        ao = self._make_ontology()
+        ao.save()
+        self.assertEqual(ao.version, 1)
+
+    def test_save_overwrite_cold_first_creation(self):
+        self._simulate_cold_process()
+        ao = self._make_ontology()
+        ao.save(overwrite=True)
+        self.assertEqual(ao.version, 1)
+
+
 class NodeTests(unittest.TestCase):
     def test_create_leaf(self):
         n = Node(name="car")

--- a/tests/unittests/ontology_class_tests.py
+++ b/tests/unittests/ontology_class_tests.py
@@ -1072,83 +1072,45 @@ class OntologySDKTests(unittest.TestCase):
 
 
 class OntologyConnectionBootstrapTests(unittest.TestCase):
-    """Ontology entry points must bootstrap the DB connection before their
-    first query — the first SDK call in a cold process may be an ontology
-    call, and ``OntologyDocument.objects()`` alone does not establish the
-    mongoengine default connection.
+    """``OntologyDocument.objects`` must bootstrap the DB connection before
+    building a queryset — the first SDK call in a cold process may be an
+    ontology call, and mongoengine's default manager does not establish the
+    default connection on its own.
     """
 
-    def _run_with_mocks(self, fn):
-        """Runs ``fn`` with the module's ``ensure_connection`` and
-        ``OntologyDocument`` replaced by children of one shared mock, and
-        returns the ordered method names recorded on that mock.
-        """
+    def test_objects_manager_bootstraps_connection_first(self):
+        import fiftyone.core.odm.ontology as foo_odm
+
         manager = mock.Mock()
-        manager.OntologyDocument.objects.return_value.distinct.return_value = (
-            []
-        )
-        manager.OntologyDocument.objects.return_value.count.return_value = 0
-        manager.OntologyDocument.objects.return_value.order_by.return_value.first.return_value = (
-            None
-        )
 
         with (
-            mock.patch(
-                "fiftyone.core.ontology.ensure_connection",
-                manager.ensure_connection,
+            mock.patch.object(
+                foo_odm, "ensure_connection", manager.ensure_connection
             ),
-            mock.patch(
-                "fiftyone.core.ontology.OntologyDocument",
-                manager.OntologyDocument,
+            mock.patch.object(
+                foo_odm.OntologyDocument,
+                "_get_collection",
+                manager._get_collection,
             ),
         ):
-            fn()
+            foo_odm.OntologyDocument.objects
 
-        return [name for name, _, _ in manager.mock_calls]
-
-    def _assert_bootstraps_first(self, fn):
-        calls = self._run_with_mocks(fn)
-        self.assertTrue(calls, "expected at least one recorded call")
+        calls = [name for name, _, _ in manager.mock_calls]
+        self.assertIn("_get_collection", calls)
         self.assertEqual(
             calls[0],
             "ensure_connection",
             f"connection must be established before any query; got {calls}",
         )
 
-    @staticmethod
-    def _make_ontology() -> AnnotationOntology:
-        return AnnotationOntology(
-            name="cold_ontology",
-            attributes=[
-                AttributeSpec(name="x", type="bool", component="checkbox"),
-            ],
-        )
+    def test_ontology_document_uses_connected_manager(self):
+        import inspect
 
-    def test_list_ontologies_bootstraps(self):
-        from fiftyone.core.ontology import list_ontologies
+        import fiftyone.core.odm.ontology as foo_odm
 
-        self._assert_bootstraps_first(list_ontologies)
-
-    def test_ontology_exists_bootstraps(self):
-        from fiftyone.core.ontology import ontology_exists
-
-        self._assert_bootstraps_first(lambda: ontology_exists("cold"))
-
-    def test_load_ontology_bootstraps(self):
-        def load_missing():
-            with self.assertRaises(ValueError):
-                load_ontology("nonexistent")
-
-        self._assert_bootstraps_first(load_missing)
-
-    def test_save_bootstraps(self):
-        self._assert_bootstraps_first(self._make_ontology().save)
-
-    def test_save_overwrite_bootstraps(self):
-        # overwrite=True on a first save queries for an existing lineage
-        # via _find_latest_doc(), so it too needs the bootstrap first
-        self._assert_bootstraps_first(
-            lambda: self._make_ontology().save(overwrite=True)
+        self.assertIsInstance(
+            inspect.getattr_static(foo_odm.OntologyDocument, "objects"),
+            foo_odm._ConnectedQuerySetManager,
         )
 
 

--- a/tests/unittests/ontology_class_tests.py
+++ b/tests/unittests/ontology_class_tests.py
@@ -1073,6 +1073,10 @@ class OntologySDKTests(unittest.TestCase):
 class OntologyColdProcessTests(unittest.TestCase):
     """Ontology entry points must bootstrap the DB connection themselves —
     the first SDK call in a process may be an ontology call.
+
+    Each check runs in a fresh subprocess: a genuine cold process. Tearing
+    down the connection in this process instead would close the client out
+    from under every other test that holds a reference to it.
     """
 
     def setUp(self):
@@ -1085,54 +1089,66 @@ class OntologyColdProcessTests(unittest.TestCase):
 
         foo.get_db_conn().drop_collection("ontologies")
 
-    @staticmethod
-    def _simulate_cold_process():
-        # A cold process has neither a pymongo client nor a registered
-        # mongoengine default connection; both are created lazily by
-        # ensure_connection()/get_db_conn()
-        import fiftyone.core.odm.database as food
+    def _run_cold(self, body: str) -> None:
+        import subprocess
+        import sys
 
-        food._disconnect()
-
-    @staticmethod
-    def _make_ontology(name: str = "cold_ontology") -> AnnotationOntology:
-        return AnnotationOntology(
-            name=name,
-            attributes=[
-                AttributeSpec(name="x", type="bool", component="checkbox"),
-            ],
+        result = subprocess.run(
+            [sys.executable, "-c", body],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"cold-process check failed:\n{result.stderr}",
         )
 
-    def test_list_ontologies_cold(self):
-        from fiftyone.core.ontology import list_ontologies
+    _MAKE_ONTOLOGY = (
+        "from fiftyone.core.annotation.attributes import AttributeSpec\n"
+        "from fiftyone.core.ontology import AnnotationOntology\n"
+        "ao = AnnotationOntology(\n"
+        "    name='cold_ontology',\n"
+        "    attributes=[\n"
+        "        AttributeSpec(name='x', type='bool', component='checkbox')\n"
+        "    ],\n"
+        ")\n"
+    )
 
-        self._simulate_cold_process()
-        self.assertEqual(list_ontologies(), [])
+    def test_list_ontologies_cold(self):
+        self._run_cold(
+            "from fiftyone.core.ontology import list_ontologies\n"
+            "assert list_ontologies() == []\n"
+        )
 
     def test_ontology_exists_cold(self):
-        from fiftyone.core.ontology import ontology_exists
-
-        self._simulate_cold_process()
-        self.assertFalse(ontology_exists("cold_ontology"))
+        self._run_cold(
+            "from fiftyone.core.ontology import ontology_exists\n"
+            "assert not ontology_exists('cold_ontology')\n"
+        )
 
     def test_load_ontology_cold(self):
-        from fiftyone.core.ontology import load_ontology
-
-        self._simulate_cold_process()
-        with self.assertRaises(ValueError):
-            load_ontology("nonexistent")
+        self._run_cold(
+            "from fiftyone.core.ontology import load_ontology\n"
+            "try:\n"
+            "    load_ontology('nonexistent')\n"
+            "except ValueError:\n"
+            "    pass\n"
+            "else:\n"
+            "    raise AssertionError('expected ValueError')\n"
+        )
 
     def test_save_cold(self):
-        self._simulate_cold_process()
-        ao = self._make_ontology()
-        ao.save()
-        self.assertEqual(ao.version, 1)
+        self._run_cold(
+            self._MAKE_ONTOLOGY + "ao.save()\nassert ao.version == 1\n"
+        )
 
     def test_save_overwrite_cold_first_creation(self):
-        self._simulate_cold_process()
-        ao = self._make_ontology()
-        ao.save(overwrite=True)
-        self.assertEqual(ao.version, 1)
+        self._run_cold(
+            self._MAKE_ONTOLOGY
+            + "ao.save(overwrite=True)\nassert ao.version == 1\n"
+        )
 
 
 class NodeTests(unittest.TestCase):


### PR DESCRIPTION
## What changes are proposed in this pull request?

Ontology SDK entry points (`Ontology.save()`, `load_ontology()`, `list_ontologies()`, `ontology_exists()`) queried `OntologyDocument` directly without first establishing the database connection. Every other SDK entry point bootstraps lazily via `get_db_conn()`, so an ontology call that happens to be the **first** SDK call in a process raised:

```
mongoengine.connection.ConnectionFailure: You have not defined a default connection
```

This surfaces in deployments where the connection is configured but only established on first use — e.g. downstream API-backed clients — and was masked whenever any other SDK call (like `fo.list_datasets()`) ran first.

This PR calls `ensure_connection()` at each ontology entry point, after validation (which is pure and should still fail before any DB interaction). `delete_ontology()` is covered via its internal `load_ontology()` call.

## How is this patch tested?

New `OntologyColdProcessTests` simulates a cold process by tearing down the client and mongoengine connection, then exercises each entry point. All five tests fail with the exact `ConnectionFailure` above without the fix and pass with it. Full ontology suites (189 tests) green.

## What areas of FiftyOne does this PR affect?

- [x] `Core`: Core `fiftyone` Python library

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ontology operations when starting from a fresh process by automatically establishing the required database connection.
  * Ontology listing, existence checks, loading, and saving now work reliably without a pre-existing connection.

* **Tests**
  * Added coverage for ontology workflows in cold-start scenarios, including creation, overwrite behavior, listing, and missing ontology handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


@coderabbitai ignore

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3578
<!-- enterprise-sync-pr:end -->