### PR TITLE
fix(ci): lift the CI comment's stale failure headline after a green rerun

### DIFF
--- a/.github/scripts/refresh-suite-rows.mjs
+++ b/.github/scripts/refresh-suite-rows.mjs
@@ -21,7 +21,7 @@ import {
   collectResults,
   hasPythonJobs,
 } from "./python-section.mjs";
-import { buildSuiteRows, jobsIcon } from "./suite-rows.mjs";
+import { buildSuiteRows, jobsIcon, settleHeadline } from "./suite-rows.mjs";
 
 const [, , jobsPath, bodyPath, junitDir] = process.argv;
 if (!jobsPath || !bodyPath) {
@@ -89,13 +89,7 @@ if (bodyPath === "--new") {
     lines = buildFresh();
   } else {
     lines.splice(header + 2, e2eRow - header - 2, ...rows);
-
-    // The headline is posted by the e2e verdict, which only knows e2e; a
-    // suite that failed after posting must flip it
-    const headline = lines.findIndex((l) => l.startsWith("## "));
-    if (headline !== -1 && rows.some((r) => r.includes("❌"))) {
-      lines[headline] = lines[headline].replace(/^## [✅⚠️]+ CI/u, "## ❌ CI");
-    }
+    settleHeadline(lines, rows);
   }
 }
 

--- a/.github/scripts/suite-rows.mjs
+++ b/.github/scripts/suite-rows.mjs
@@ -41,3 +41,25 @@ export function buildSuiteRows(jobs) {
     .filter(([, js]) => !js.every((j) => j.conclusion === "skipped"))
     .map(([name, js]) => `| ${name} | ${icon(js)} |`);
 }
+
+// The headline is posted by the e2e verdict, which only knows e2e. A suite
+// that failed after posting must flip it to ❌; a rerun that turned every
+// row green again must lift that ❌ — but only the exact plain form
+// `## ❌ CI (FLAVOR)`, which can only be a previous downgrade by this
+// function: the verdict's ❌ always carries a `: reason` suffix and stays
+// authoritative for e2e failures.
+export function settleHeadline(lines, rows) {
+  const headline = lines.findIndex((l) => l.startsWith("## "));
+  if (headline === -1) {
+    return;
+  }
+  const e2eRowLine = lines.find((l) => l.startsWith("| e2e |")) ?? "";
+  if (rows.some((r) => r.includes("❌"))) {
+    lines[headline] = lines[headline].replace(/^## [✅⚠️]+ CI/u, "## ❌ CI");
+  } else if (
+    !e2eRowLine.includes("❌") &&
+    /^## ❌ CI \([A-Z]+\)\s*$/u.test(lines[headline])
+  ) {
+    lines[headline] = lines[headline].replace("## ❌ CI", "## ✅ CI");
+  }
+}

--- a/.github/scripts/suite-rows.test.mjs
+++ b/.github/scripts/suite-rows.test.mjs
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { settleHeadline } from "./suite-rows.mjs";
+
+const body = (headline, e2e = "✅") => [
+  "<!-- ci-report:OSS -->",
+  headline,
+  "",
+  "| suite | result |",
+  "| --- | --- |",
+  "| build | ✅ |",
+  `| e2e | ${e2e} |`,
+];
+
+describe("settleHeadline", () => {
+  it("downgrades the verdict headline when a suite row failed", () => {
+    const lines = body("## ✅ CI (OSS)");
+    settleHeadline(lines, ["| test-windows | ❌ |"]);
+    expect(lines[1]).toBe("## ❌ CI (OSS)");
+  });
+
+  it("downgrades a flaky-run headline the same way", () => {
+    const lines = body("## ⚠️ CI (OSS): incomplete e2e run");
+    settleHeadline(lines, ["| test | ❌ |"]);
+    expect(lines[1]).toBe("## ❌ CI (OSS): incomplete e2e run");
+  });
+
+  it("lifts its own downgrade once a rerun turns every row green", () => {
+    const lines = body("## ❌ CI (OSS)");
+    settleHeadline(lines, ["| test-windows | ✅ |"]);
+    expect(lines[1]).toBe("## ✅ CI (OSS)");
+  });
+
+  it("never lifts a verdict ❌, which always carries a reason", () => {
+    const lines = body("## ❌ CI (OSS): 2 failed specs", "❌");
+    settleHeadline(lines, ["| build | ✅ |"]);
+    expect(lines[1]).toBe("## ❌ CI (OSS): 2 failed specs");
+  });
+
+  it("never lifts a plain ❌ while the e2e row is still red", () => {
+    const lines = body("## ❌ CI (OSS)", "❌");
+    settleHeadline(lines, ["| build | ✅ |"]);
+    expect(lines[1]).toBe("## ❌ CI (OSS)");
+  });
+
+  it("leaves a green headline alone", () => {
+    const lines = body("## ✅ CI (OSS)");
+    settleHeadline(lines, ["| build | ✅ |"]);
+    expect(lines[1]).toBe("## ✅ CI (OSS)");
+  });
+
+  it("tolerates a body with no headline", () => {
+    const lines = ["| suite | result |", "| e2e | ✅ |"];
+    expect(() => settleHeadline(lines, [])).not.toThrow();
+  });
+});


### PR DESCRIPTION
## What changed

The CI comment's suite-row refresher could downgrade the headline (a suite failing after the e2e verdict posted) but never lift it. A `re-run failed jobs` that turned every suite green re-rendered the rows as ✅ yet left the headline stamped ❌ — observed on #8127, where a transient Windows test failure kept the comment red after its rerun passed.

`settleHeadline` (extracted to `suite-rows.mjs`, unit-tested) now lifts the failure headline when no suite row is red — restricted to the exact plain `## ❌ CI (FLAVOR)` form, which only the refresher's own downgrade produces. The e2e verdict's failure headline always carries a `: reason` suffix and remains authoritative for e2e results.

## Verification

- 7 new unit tests cover downgrade, lift, verdict-❌ preservation, red-e2e-row guard, and no-headline bodies
- `yarn vitest run` in `.github/scripts`: 27/27 pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CI status headlines to accurately reflect failed, incomplete, and rerun test suites.
  - Preserved failure reasons when displaying a failed CI status.
  - Prevented CI statuses from being marked successful while end-to-end checks remain failing.

- **Tests**
  - Added coverage for CI headline updates, reruns, failure details, and missing headlines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3577
<!-- enterprise-sync-pr:end -->