### PR TITLE
[release] cherry-pick: add Agentic Labeling reference page

### DIFF
--- a/docs/source/enterprise/agentic_labeling.rst
+++ b/docs/source/enterprise/agentic_labeling.rst
@@ -1,0 +1,466 @@
+.. _agentic-labeling:
+
+Agentic Labeling
+================
+
+.. default-role:: code
+
+Agentic Labeling labels your images with a prompt-driven vision-language
+model (VLM). You describe what you want in plain language, optionally show
+the model a few examples, and it produces labels like classifications,
+detections, captions, or per-region labels across your dataset for review.
+Agentic Labeling is available as a panel in the FiftyOne Enterprise App.
+
+.. _agentic-labeling-vs-auto-labeling:
+
+Agentic Labeling vs Auto-Labeling
+_________________________________
+
+Agentic Labeling is a form of auto-labeling. Where
+:ref:`verified-auto-labeling` applies a fixed set of learned classes from the
+FiftyOne Model Zoo and foundation models through a delegated pipeline with a
+confidence-scored review-and-approval workflow, Agentic Labeling uses a VLM
+that you steer with natural language and visual prompts, then refine until the
+output matches your ontology. The two are complementary: Agentic Labeling is
+often the first step to produce an initial labeled set quickly, and those
+labels can go on to train a custom model for large-scale Auto-Labeling.
+
+.. _agentic-labeling-availability:
+
+Availability and prerequisites
+______________________________
+
+Agentic Labeling is a `FiftyOne Enterprise <https://voxel51.com/enterprise/>`_
+only feature and requires a running Agentic Labeler service.
+
+Agentic Labeling is supported for image datasets and frames views of video
+datasets. 3D, grouped, and multimodal datasets are not yet supported.
+
+.. note::
+
+    Agentic Labeling is a Beta feature. Its behavior may change in future
+    releases.
+
+.. _agentic-labeling-how-it-works:
+
+How it works
+____________
+
+You drive Agentic Labeling by building a **Labeling Agent** which includes:
+
+- **Text prompt** — plain-language instructions for what to label.
+- **Task** — the kind of label to produce (classification, detection, caption,
+  or a region variant).
+- **Allowed classes** — an optional list constraining which class labels the
+  model may use.
+- **Examples** — an optional handful of sample images showing what "right"
+  looks like.
+
+The workflow is a short loop: author an agent, **Test** it on a few grid
+samples, refine, **Save** it, then launch a **Run** at scale. Test previews are
+for iteration only and are never written to your dataset; only a run persists
+labels.
+
+
+.. _agentic-labeling-user-guide:
+
+User guide
+__________
+
+This section walks through the full labeling loop: open the panel, train an
+agent, test it, save it, launch a run, and monitor it.
+
+.. _agentic-labeling-open:
+
+Opening the panel
+-----------------
+
+Load your image dataset in the FiftyOne App, then open the **Agentic
+Labeling** panel from the new-panel (`+`) menu above the samples grid.
+
+.. image:: https://cdn.voxel51.com/enterprise_agentic_labeling/al_panel_open.webp
+    :alt: agentic-labeling-panel-open
+    :align: center
+
+.. _agentic-labeling-dashboard:
+
+Dashboard
+---------
+
+The Dashboard is the landing page with **Runs** and **Agents** sub-tabs. Click
+**Train Agent** to author your first agent.
+
+.. image:: https://cdn.voxel51.com/enterprise_agentic_labeling/al_dashboard_coldstart.webp
+    :alt: agentic-labeling-dashboard-coldstart
+    :align: center
+
+.. _agentic-labeling-train:
+
+Training an agent
+-----------------
+
+Training an agent consists of writing a **Text prompt**, picking a **Task**,
+optionally setting **Allowed classes**, and optionally adding a few visual
+**Examples**. This is an iterative process: test the agent on a few samples,
+refine the prompt and examples, and repeat until the agent produces the
+desired outputs.
+
+.. image:: https://cdn.voxel51.com/enterprise_agentic_labeling/al_train_overview.webp
+    :alt: agentic-labeling-train-overview
+    :align: center
+
+In **Text prompt**, describe what to label, and be specific. For example,
+*frayed cables visible against the sky*. Then choose a **Task**:
+Classification, Detection, Caption, Region Classification, or Region
+Captioning. See :ref:`agentic-labeling-tasks` for more information on the task
+types.
+
+.. image:: https://cdn.voxel51.com/enterprise_agentic_labeling/al_task_picker.webp
+    :alt: agentic-labeling-task-picker
+    :align: center
+
+For Classification and Detection you can set **Allowed classes** to constrain
+the model's output. Classification accepts multiple classes and Detection
+accepts exactly one. Leave the field empty to let the model choose any label.
+Allowed classes constrain the output only; define what each class means in the
+text prompt. See :ref:`agentic-labeling-prompting`.
+
+.. _agentic-labeling-examples:
+
+Adding examples
+^^^^^^^^^^^^^^^
+
+A few good examples sharpen the agent's behavior. Select samples in the
+FiftyOne grid, then use the **Visual prompts** section. You can provide a max
+of 5 **Positive** and **Negative** examples each.
+
+When you choose to **Pick from grid**, you can add selected samples from the
+grid. Additionally, you can provide existing labels on your dataset as
+prompts, or you can manually add example labels directly in the panel by
+clicking on the sample thumbnails.
+
+.. note::
+
+    The **Upload** button next to **Pick from grid** is not yet available.
+
+.. image:: https://cdn.voxel51.com/enterprise_agentic_labeling/al_pick_from_grid.webp
+    :alt: agentic-labeling-pick-from-grid
+    :align: center
+
+Committed examples appear as thumbnails in their row, with a running count such
+as `(2/5)`.
+
+.. image:: https://cdn.voxel51.com/enterprise_agentic_labeling/al_examples_row.webp
+    :alt: agentic-labeling-examples-row
+    :align: center
+
+.. note::
+
+    Positive examples generally provide a greater benefit to results. See
+    :ref:`agentic-labeling-prompting`.
+
+.. _agentic-labeling-test:
+
+Testing an agent
+----------------
+
+With FiftyOne, you can quickly iterate on your prompts by testing your agent
+on a few samples at a time.
+
+Scroll to **Test results**, select some representative samples in the grid,
+then click **Run test**. The agent runs on just those samples and previews
+the resulting labels of your selected **Task**. Test previews are
+**never written to your dataset**.
+
+.. image:: https://cdn.voxel51.com/enterprise_agentic_labeling/al_test_results.webp
+    :alt: agentic-labeling-test-results
+    :align: center
+
+Click any thumbnail to open the prediction editor. Inspect or correct a
+prediction and step through the results with **Previous** and **Next**, drop
+one with **Remove from results**. Edits change only the preview; they do not
+persist to your dataset or modify the agent.
+
+.. image:: https://cdn.voxel51.com/enterprise_agentic_labeling/al_prediction_editor.webp
+    :alt: agentic-labeling-prediction-editor
+    :align: center
+
+Refine the prompt, adjust allowed classes, add or remove examples, and run the
+test again until the previews are mostly correct on a representative handful.
+
+.. _agentic-labeling-save:
+
+Saving an agent
+---------------
+
+When you're satisfied with the agent's behavior on test samples, click **Save
+agent** in the sticky footer to save your prompts and prepare the agent for a
+Run on the full dataset.
+
+.. image:: https://cdn.voxel51.com/enterprise_agentic_labeling/al_save_agent_modal.webp
+    :alt: agentic-labeling-save-agent
+    :align: center
+
+Saved agents appear on the Dashboard's **Agents** tab with a menu offering
+**Edit**, **New run**, and **Delete** options.
+
+.. image:: https://cdn.voxel51.com/enterprise_agentic_labeling/al_agents_tab.webp
+    :alt: agentic-labeling-agents-tab
+    :align: center
+
+.. _agentic-labeling-run:
+
+Configuring and launching a run
+-------------------------------
+
+After training and saving an agent, launch a **Run** to label your data at
+scale.
+
+Open **Run Config** from the Dashboard's **New Run** button or an agent row's
+**New run** menu item, then configure the run:
+
+- **Agent** (required) — the saved agent to run.
+- **Target** — the scope to label: **All samples**, **Current view**
+  (:ref:`the current view <using-views>`), or **Current selection**
+  (:ref:`currently-selected samples <app-select-samples>`).
+- **Label field** — the name of a new or existing field where predictions are
+  written; use a new field name to avoid changing existing labels. On a
+  patches target this becomes a **Detection attribute** selector instead — the
+  attribute written onto each detection.
+- **Run name** (optional) — a human-friendly name for the run.
+- **Advanced** — **Workers** (default **16**) and **Batch size** (default
+  **32**).
+
+.. image:: https://cdn.voxel51.com/enterprise_agentic_labeling/al_run_config.webp
+    :alt: agentic-labeling-run-config
+    :align: center
+
+.. _agentic-labeling-monitor:
+
+Monitoring a run
+----------------
+
+Starting a run returns you to the **Runs** tab, where each run is a card with a
+status badge and, while active, a progress bar. The card's kebab menu offers
+**Pause** / **Resume** and **Delete**. Pausing stops issuing new work; a
+resumed run continues from where it left off rather than re-labeling completed
+samples.
+
+.. image:: https://cdn.voxel51.com/enterprise_agentic_labeling/al_dashboard_runs.webp
+    :alt: agentic-labeling-runs
+    :align: center
+
+Click a card to open **Run Detail**, which shows:
+
+- an editable **name** and the current **status**
+- a **metadata card** (dataset, label field, task, workers, batch size)
+- a **progress bar** with `completed / total` and parse-failure counts
+- the read-only **Agent configuration** — the prompt and example thumbnails
+  the run uses
+- a **Notes** field
+- status-conditional actions: **Pause**, **Resume**, **Cancel**, **Delete**,
+  and **New Run**.
+
+If a run fails, a red banner shows the error and a collapsible **Stack trace**.
+
+.. image:: https://cdn.voxel51.com/enterprise_agentic_labeling/al_run_detail.webp
+    :alt: agentic-labeling-run-detail
+    :align: center
+
+When the run completes, its labels are written to your chosen field, ready to
+review in the grid. Consider creating an
+:ref:`annotation workflow <enterprise-workflows>` for your annotators to
+review the results.
+
+.. _agentic-labeling-tasks:
+
+Labeling tasks
+______________
+
+The **Task** you pick under **Settings** decides what kind of label the agent
+produces and what the model is asked to do. The first three tasks label the
+**whole image**; the two region tasks label **one object at a time**.
+
+=====================  =================================
+Task                   Produces
+=====================  =================================
+Classification         One label for the whole image
+Detection              Bounding boxes on the whole image
+Caption                Free text for the whole image
+Region Classification  One label per object
+Region Captioning      A caption per object
+=====================  =================================
+
+Classification
+--------------
+
+Assign a single label to the whole image. Use the **Text prompt** to
+describe the classes and the decision you want. Use **Allowed classes** to hold
+the model to a fixed set of labels, or leave it empty to let the model choose
+freely.
+
+.. image:: https://cdn.voxel51.com/enterprise_agentic_labeling/al_task_classification.webp
+    :alt: agentic-labeling-task-classification
+    :align: center
+
+Detection
+---------
+
+Find and box every object you ask for. Detection always returns boxes, so your
+**Text prompt** only needs to say *what* to find — for example, *detect every
+forklift and pallet*. You never describe the output format or the image size.
+**Allowed classes** here takes at most one class: set it and every box is
+relabeled to that class; leave it empty to keep the model's own labels.
+Detection is whole-image only — on a patches view its card is greyed out.
+
+.. image:: https://cdn.voxel51.com/enterprise_agentic_labeling/al_task_detection.webp
+    :alt: agentic-labeling-task-detection
+    :align: center
+
+Caption
+-------
+
+Produce a free-text description of the whole image. Your **Text prompt** fully
+controls the caption's style, length, and focus. Be explicit, or you will get
+the model's default.
+
+.. image:: https://cdn.voxel51.com/enterprise_agentic_labeling/al_task_caption.webp
+    :alt: agentic-labeling-task-caption
+    :align: center
+
+.. _agentic-labeling-region-tasks:
+
+Region tasks
+------------
+
+**Region Classification** and **Region Captioning** apply the same ideas as
+their whole-image versions, but to **one object at a time**. Region
+Classification gives each object a label, and Region Captioning gives each
+object a caption.
+
+Region tasks require an existing Detections field on the dataset.
+
+Both add two controls:
+
+- **Regions from** — where the objects come from. On a normal view, pick a
+  source **Detections** field and each detection becomes one object to label.
+  On a patches view this control is hidden, because the patches themselves are
+  the objects.
+- **Show region as** — **Cropped** (the model sees only the object's patch) or
+  **In context** (the model sees the full image with the object highlighted).
+  Use Cropped when the object stands alone; use In context when its
+  surroundings matter.
+
+Predictions attach to each object, so every object carries its own label or
+caption. **Allowed classes** for Region Classification works just like
+whole-image Classification.
+
+.. image:: https://cdn.voxel51.com/enterprise_agentic_labeling/al_task_region_cropped.webp
+    :alt: agentic-labeling-region-cropped
+    :align: center
+
+.. image:: https://cdn.voxel51.com/enterprise_agentic_labeling/al_task_region_incontext.webp
+    :alt: agentic-labeling-region-in-context
+    :align: center
+
+Choosing a task
+---------------
+
+- **Labeling the whole scene?** Use a whole-image task — Classification,
+  Detection, or Caption.
+- **Labeling individual objects?** Use a region task. It needs a source of
+  objects: either a source **Detections** field or a patches view.
+- **Want boxes plus per-object labels?** Detection is whole-image only, so run
+  Detection first to produce the boxes, then run a region task against that
+  Detections field.
+- **Working with video?** Create a frames view first, then label each frame as
+  a whole image — video cannot be labeled directly.
+
+.. _agentic-labeling-prompting:
+
+Prompting guidance
+__________________
+
+Your labels come from three things you author on the Train Agent page: the
+**Text prompt**, the **examples**, and the **allowed classes**.
+
+Writing the prompt
+------------------
+
+- Be specific and describe the visible evidence. Prefer concrete visual
+  language (*frayed cables against the sky*) over abstract category names
+  (*cables*).
+- Name and define your classes in the prompt. The allowed-classes list is
+  **not** shown to the model, so if a class needs explaining, define it here.
+- Always write a prompt for **Classification** and **Caption**. With an empty
+  prompt the model gets no instruction and simply guesses.
+- For **Detection**, define what counts as a target (*only fully-visible
+  vehicles, ignore partial ones*). Do not ask for a custom output format.
+- For **Caption**, state the style and length you want (*one sentence, under
+  12 words, main subject only*).
+
+Allowed classes
+---------------
+
+The **Allowed classes** field means different things per task:
+
+- **Classification** — a hard constraint. The model can output only a class you
+  listed. Leave it empty to let the model choose any label (open-world).
+- **Detection** — capped at exactly one class. Every returned box is relabeled
+  to it; it does **not** filter what gets detected — narrow that in the prompt.
+  Leave it empty to keep the model's own label for each box.
+
+If an expected Classification label never appears, confirm it is in the list.
+
+.. image:: https://cdn.voxel51.com/enterprise_agentic_labeling/al_allowed_classes.webp
+    :alt: agentic-labeling-allowed-classes
+    :align: center
+
+Using examples
+--------------
+
+- Add up to **5 positive** and **5 negative** examples per agent.
+- Prefer positive examples — they do the heavy lifting. Negatives are sent to
+  the model as examples to avoid; reach for a prompt fix before leaning on
+  them.
+- Keep example labels inside your allowed classes. The panel warns you with a
+  **Heads up** message when an example label is outside the allowed set; the
+  model still sees it in the prompt but cannot emit it.
+
+.. image:: https://cdn.voxel51.com/enterprise_agentic_labeling/al_heads_up_classes.webp
+    :alt: agentic-labeling-heads-up-classes
+    :align: center
+
+- Keep the set small — a few clear examples beat a large, noisy one.
+
+.. _agentic-labeling-troubleshooting:
+
+Troubleshooting
+_______________
+
+Run a test on a few selected samples before saving, and match the symptom to a
+fix. When a prediction fails, the panel keeps the model's raw output so you can
+inspect or hand-fix it in the prediction editor. Failed predictions are
+flagged with a marker in the result card and a red banner:
+
+- `[PARSE ERROR]` — the banner header reads **Couldn't parse model output**.
+  The model returned text the panel could not turn into labels. This almost
+  always points at a **Detection** task; simplify the prompt and do not ask for
+  a custom output format. Classification and Caption essentially never hit this
+  error.
+- `[INFERENCE ERROR]` — the banner header reads **Inference error**. The
+  request was too large for the service; use fewer or smaller images.
+
+.. image:: https://cdn.voxel51.com/enterprise_agentic_labeling/al_parse_error_chip.webp
+    :alt: agentic-labeling-parse-error
+    :align: center
+
+Other common symptoms:
+
+- **An expected Classification class never appears** — add it to allowed
+  classes, or clear the list to let the model choose freely.
+- **Random-looking Classification or Caption output** — the prompt is probably
+  empty; write one.
+
+The red banner shows the friendly header; the raw `[PARSE ERROR]` or
+`[INFERENCE ERROR]` output is available in the banner's expandable body.

--- a/docs/source/enterprise/index.rst
+++ b/docs/source/enterprise/index.rst
@@ -105,6 +105,12 @@ pages on this site apply to Enterprise deployments as well.
     :button_link: verified_auto_labeling.html
 
 .. customcalloutitem::
+    :header: Agentic Labeling __SUB_NEW__
+    :description: Label images with a prompt-driven vision-language model — classify, detect, caption, or label regions for review.
+    :button_text: Label with natural language
+    :button_link: agentic_labeling.html
+
+.. customcalloutitem::
     :header: Data Lens
     :description: Use FiftyOne Enterprise to explore and import samples from external data sources.
     :button_text: Connect your data lake

--- a/docs/source/enterprise/overview.rst
+++ b/docs/source/enterprise/overview.rst
@@ -62,6 +62,13 @@ source project:
         Pre-label data with foundation and zoo models, then verify it with
         built-in QA workflows.
 
+    .. grid-item-card:: Agentic Labeling
+        :link: agentic_labeling
+        :link-type: doc
+
+        Label images with a prompt-driven vision-language model — classify,
+        detect, caption, or label regions for review.
+
     .. grid-item-card:: FiftyOne Agent __SUB_NEW__
         :link: agent
         :link-type: doc
@@ -223,6 +230,11 @@ links in each row for details.
     <th class="stub"><p><a href="verified_auto_labeling.html">Auto-labeling &amp; QA</a></p></th>
     <td><p class="none">Not available</p></td>
     <td><p>Auto-label with foundation and zoo models, with confidence scoring and verified review</p></td>
+    </tr>
+    <tr>
+    <th class="stub"><p><a href="agentic_labeling.html">Agentic Labeling</a></p></th>
+    <td><p class="none">Not available</p></td>
+    <td><p>Prompt-driven VLM labeling: classification, detection, captioning, and region labels</p></td>
     </tr>
     <tr>
     <th class="stub"><p><a href="data_quality.html">Data quality</a></p></th>

--- a/docs/source/enterprise/plugins.rst
+++ b/docs/source/enterprise/plugins.rst
@@ -434,8 +434,8 @@ and their status.
 
 .. _enterprise-distributed-execution:
 
-Distributed execution __SUB_NEW__
-_________________________________
+Distributed execution
+_____________________
 
 .. versionadded:: 2.11.0
 
@@ -501,8 +501,8 @@ platform such as Databricks or Anyscale.
 
 .. _enterprise-on-demand-compute:
 
-On-demand compute __SUB_NEW__
------------------------------
+On-demand compute
+-----------------
 
 .. versionadded:: 2.11.0
 
@@ -532,6 +532,33 @@ externally-managed workflow orchestration tools, such as
 `Airflow <https://airflow.apache.org>`_, `Flyte <https://flyte.org>`_, and
 `Spark <https://spark.apache.org/>`_. Please contact your Voxel51 support team
 for further details.
+
+.. _enterprise-services:
+
+Services
+________
+
+Some builtin operators run as long-lived *services*: always-on model servers
+that stay ready between uses instead of spinning up a new job per run. Services
+are hosted by a **service orchestrator** and power GPU-backed, interactive
+features such as :ref:`agentic labeling <agentic-labeling>` and
+:ref:`AI-assisted annotation <in-app-ai-annotation>` (segmentation and video
+tracking), where a per-run cold start would otherwise make the experience too
+slow.
+
+Administrators manage services from the Services page under Settings >
+Services, where you can start, stop, and monitor each service and view its
+status.
+
+.. image:: https://cdn.voxel51.com/plugins/services_page.webp
+   :alt: enterprise-services-page
+   :align: center
+
+Services run on your own GPU infrastructure, provisioned through the service
+orchestrator. Administrators can refer to the
+`deployment guide <https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/docs/configuring-service-orchestrator.md>`_
+to learn how to configure the service orchestrator for their FiftyOne
+Enterprise deployment.
 
 .. _enterprise-managing-delegated-operations:
 
@@ -566,6 +593,17 @@ The table provides options to sort, search, and filter runs shown to refine the
 list as you like:
 
 .. image:: /images/plugins/operators/runs/runs_general.png
+
+.. _enterprise-deployment-runs:
+
+Deployment-level Runs page
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The Runs tab described above lives on a dataset. Users can also reach a
+**deployment-level** Runs page from Settings > Runs that opens the same table
+without first loading a dataset, making it a convenient entry point for
+monitoring delegated operations and long-running
+:ref:`service <enterprise-services>` operations across the whole deployment.
 
 .. _enterprise-runs-statuses:
 

--- a/docs/source/enterprise/verified_auto_labeling.rst
+++ b/docs/source/enterprise/verified_auto_labeling.rst
@@ -17,6 +17,10 @@ Auto-Labeling is powered by
 enabling you to perform Auto-Labeling in the background using your existing GPU
 infrastructure.
 
+.. note::
+
+    Check out :ref:`Agentic Labeling <agentic-labeling>` to explore using a VLM for auto-labeling!
+
 .. _verified-auto-labeling-how-it-works:
 
 How it works

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -536,7 +536,7 @@ _________
 
    Data I/O <workflows/ingestion>
    Curation: Pre-Annotation <workflows/curation_pre>
-   Annotation <workflows/annotation>
+   Annotation __SUB_NEW__ <workflows/annotation>
    Curation: Post-Annotation <workflows/curation_post>
    Model Training <workflows/training>
    Model Inference <workflows/inference>

--- a/docs/source/user_guide/annotation.rst
+++ b/docs/source/user_guide/annotation.rst
@@ -349,6 +349,14 @@ Labels are not the only type of metadata available for edits in FiftyOne's in-Ap
 How to: 2D Label Annotation
 ----------------------------
 
+.. admonition:: Label faster with AI
+   :class: tip
+
+   FiftyOne can help you label images with AI: prompt masks with
+   :ref:`AI-assisted segmentation <in-app-ai-segmentation>`, or auto-label a
+   whole dataset from a few examples with
+   :ref:`Agentic Labeling <agentic-labeling>`.
+
 Creating a Classification label
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -379,8 +387,17 @@ A detection label's size and shape can be adjusted directly in the annotation ca
 .. image:: /_static/images/annotation/edit_bounding_box_canvas.gif
    :alt: Editing detection on canvas
 
+.. _creating-a-segmentation-label:
+
 Creating a Segmentation label
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. admonition:: Prompt masks with AI
+   :class: tip
+
+   Rather than painting a mask by hand, you can prompt one with a model using
+   the AI assistance tool — see
+   :ref:`AI-assisted image segmentation <in-app-ai-segmentation>`.
 
 .. image:: /_static/images/annotation/create_mask_button.png
    :alt: Create new mask button
@@ -466,8 +483,16 @@ The editing panel also enables editing the label, tags, confidence, index proper
 
 ----
 
+.. _how-to-video-annotation:
+
 How to: Video Annotation
 ------------------------
+
+.. admonition:: Label faster with AI
+   :class: tip
+
+   Track an object's mask across frames automatically with
+   :ref:`AI-assisted video tracking <in-app-video-tracking>`.
 
 .. |video-kf-icon| image:: https://cdn.voxel51.com/user_guide/annotation/video_toolbar_mark_keyframe_button.webp
    :height: 1.6em
@@ -518,6 +543,13 @@ Video annotation requires:
 
 Creating Object Tracks
 ~~~~~~~~~~~~~~~~~~~~~~
+
+.. admonition:: Track objects with AI
+   :class: tip
+
+   Instead of annotating each frame, you can prompt an object's mask on one
+   frame and track it across the rest — see
+   :ref:`AI-assisted video tracking <in-app-video-tracking>`.
 
 To create an object track, the
 :ref:`Annotation Schema <annotation-schema-format>` needs to contain a
@@ -943,3 +975,76 @@ Clicking on a primitive field in the "Annotate" tab will open the editing panel 
 
 .. image:: /_static/images/annotation/primitive_editing_panel.png
    :alt: Editing primitives in the right sidebar
+
+----
+
+.. _in-app-ai-annotation:
+
+How to: AI assisted annotation 🚀 __SUB_NEW__
+---------------------------------------------
+
+FiftyOne can put models to work in the annotation editor so you spend less time
+labeling by hand. Prompt masks with a segmentation model, track objects across
+video frames, or auto-label a whole dataset from a few examples with Agentic
+Labeling. These are `FiftyOne Enterprise <https://voxel51.com/enterprise/>`_
+features that run on your own GPU infrastructure as
+:ref:`services <enterprise-services>` started by an administrator.
+
+.. _in-app-ai-segmentation:
+
+Image segmentation
+~~~~~~~~~~~~~~~~~~
+
+Instead of drawing a mask by hand, you can prompt one with a segmentation
+model. Select the AI assistance tool in the mask toolbar, then click positive
+points on the object and negative points on regions to exclude; the model
+returns a mask after each click, so you can add points to refine it before
+saving. A built-in model works out of the box, and FiftyOne Enterprise
+deployments can run larger, finetuned models as a
+:ref:`service <enterprise-services>` on their own GPUs.
+
+.. image:: https://cdn.voxel51.com/user_guide/annotation/image_segmentation.webp
+   :alt: in-app-ai-segmentation
+   :align: center
+
+See :ref:`Creating a Segmentation label <creating-a-segmentation-label>` for
+the mask toolbar and drawing basics.
+
+.. _in-app-video-tracking:
+
+Video object tracking
+~~~~~~~~~~~~~~~~~~~~~
+
+On video, prompt an object's mask on one frame and track it across the
+remaining frames automatically. Review the tracked masks and add prompts on
+any frame to correct them. Video tracking is a FiftyOne Enterprise feature
+powered by a segmentation model running as a
+:ref:`service <enterprise-services>`.
+
+.. raw:: html
+
+   <video autoplay controls muted loop playsinline width="100%"
+          style="max-width:720px"
+          aria-label="Tracking an object's mask across video frames">
+     <source src="https://cdn.voxel51.com/user_guide/annotation/video_segmentation.mp4"
+             type="video/mp4">
+   </video>
+
+See :ref:`How to: Video Annotation <how-to-video-annotation>` for the video
+annotation basics.
+
+Agentic Labeling
+~~~~~~~~~~~~~~~~~
+
+Agentic Labeling uses a prompt-driven vision-language model to label an image
+dataset from a few examples: describe what you want, optionally add positive
+and negative example samples, preview the results, then apply the agent across
+your dataset for review. It runs as a FiftyOne Enterprise
+:ref:`service <enterprise-services>` that an administrator starts.
+
+.. image:: https://cdn.voxel51.com/enterprise_agentic_labeling/al_test_results.webp
+   :alt: agentic-labeling-test-results
+   :align: center
+
+See the :ref:`Agentic Labeling <agentic-labeling>` guide for the full
+workflow, supported tasks, and prompting tips.

--- a/docs/source/user_guide/evaluation.rst
+++ b/docs/source/user_guide/evaluation.rst
@@ -194,8 +194,8 @@ are included in the current view.
 
 .. _analyzing-scenarios:
 
-Analyzing scenarios  __SUB_NEW__
---------------------------------
+Analyzing scenarios
+-------------------
 
 .. note::
 
@@ -412,8 +412,8 @@ The example below demonstrates the basic interface:
 
 .. _model-evaluation-panel:
 
-Model Evaluation panel __SUB_NEW__
-__________________________________
+Model Evaluation panel
+______________________
 
 When you load a dataset in the App that contains one or more
 :ref:`evaluations <evaluating-models>`, you can open the

--- a/docs/source/workflows/annotation.rst
+++ b/docs/source/workflows/annotation.rst
@@ -20,5 +20,6 @@ Auto-Labeling 🚀 to generate high-quality labels automatically.
 
    Annotating datasets <../user_guide/annotation>
    Annotation Workflows 🚀 __SUB_NEW__ <../enterprise/workflows>
+   Agentic Labeling 🚀 __SUB_NEW__ <../enterprise/agentic_labeling>
    Auto-Labeling 🚀 <../enterprise/verified_auto_labeling>
    Building Annotation Workflows and Ontologies __SUB_NEW__ <../tutorials/fiftyone_annotation_workflows.ipynb>

--- a/docs/source/workflows/evaluation.rst
+++ b/docs/source/workflows/evaluation.rst
@@ -16,6 +16,6 @@ separate model errors from label errors.
    :maxdepth: 1
    :hidden:
 
-   Evaluating models __SUB_NEW__ <../user_guide/evaluation>
+   Evaluating models <../user_guide/evaluation>
    Evaluating object detections <../tutorials/evaluate_detections.ipynb>
    Evaluating a classifier <../tutorials/evaluate_classifications.ipynb>


### PR DESCRIPTION
Cherry-picks #8100 onto `release/v1.20.0`.

Docs-only. Adds the Agentic Labeling (Beta) reference page for FiftyOne
Enterprise, registers it in the annotation workflows toctree, and adds the
"AI assisted annotation" / Services content and cross-links that shipped with
it via #8128.

The cherry-picked diff is byte-identical to the net diff of the merge commit
(`f29a2c9`) on `develop` — 10 files, +643/-11, all under `docs/source/`.
Figures are hosted on the docs CDN, so no image binaries are added.

## 🔗 Related Issues

#8100

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASv4rWypHrdirmikTKMfmW

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3580
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added comprehensive documentation for Enterprise Agentic Labeling, including supported tasks, setup, prompting, workflows, monitoring, and troubleshooting.
  - Added Agentic Labeling links and highlights throughout Enterprise, annotation, and workflow documentation.
  - Added guidance for AI-assisted image and video annotation.

- **Documentation**
  - Documented Enterprise services and deployment-level run monitoring.
  - Improved cross-references, navigation labels, and section formatting across the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->