### PR TITLE
fix(components): AdaptiveMenu overflow states with 0 or 1 visible items

### DIFF
--- a/app/packages/components/src/components/AdaptiveMenu/index.tsx
+++ b/app/packages/components/src/components/AdaptiveMenu/index.tsx
@@ -60,10 +60,9 @@ export default function AdaptiveMenu<T extends AdaptiveMenuItemPropsType>(
     if (!containerElem) return;
     hideOverflowingNodes(containerElem, (_: number, lastVisibleItemId) => {
       const lastVisibleItem = itemsById[lastVisibleItemId];
-      if (lastVisibleItem?.index) {
-        const computedHidden = items.length - lastVisibleItem.index - 1;
-        setHidden(computedHidden);
-      }
+      // -1 when nothing fits; index 0 (only the first item fits) counts too
+      const idx = lastVisibleItem?.index ?? -1;
+      setHidden(Math.max(0, items.length - idx - 1));
     });
   }
 


### PR DESCRIPTION
`AdaptiveMenu`'s fit callback guards on the last visible item's truthy `index`:

```js
if (lastVisibleItem?.index) { setHidden(items.length - lastVisibleItem.index - 1); }
```

Two overflow states therefore never update the hidden count:

- **only the first item fits** — `index` is `0`, which is falsy;
- **nothing fits** — `lastVisibleItemId` is empty, so the lookup is `undefined`.

In both, `hideOverflowingNodes` has already width-clipped the items container, so items disappear with **no "More items" pill** to reach them. The samples-grid action row rarely hits these geometries (wide row, many small pills), but any narrower usage does — FiftyOne Enterprise's workflow Metrics board hit both (chips vanished with the row half empty; teams carries the same two-line fix, to be reconciled by the next OSS→teams merge).

Fix: treat those states as "hide N items" — `idx = lastVisibleItem?.index ?? -1; setHidden(max(0, length - idx - 1))`. States that render correctly today compute identical results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed adaptive menu item visibility when only the first item fits.
  * Corrected behavior when none of the menu items can fit, ensuring hidden items are counted accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3587
<!-- enterprise-sync-pr:end -->