### PR TITLE
Cherry-pick #8137 (embeddings-v2 UI fixes and polish) into release/v1.20.0

### DIFF
--- a/.github/workflows/lint-app.yml
+++ b/.github/workflows/lint-app.yml
@@ -49,7 +49,7 @@ jobs:
           cd app
           yarn format:check
 
-      - name: Check multimodal package
+      - name: Check strict packages (multimodal, embeddings-v2)
         run: |
           cd app
           yarn check

--- a/app/package.json
+++ b/app/package.json
@@ -8,8 +8,8 @@
     "scripts": {
         "build": "yarn check:strict && yarn workspace @fiftyone/app build",
         "build:win32": "yarn check:strict && yarn workspace @fiftyone/app build:win32",
-        "check:strict": "echo 'Running strict lint checks...' && yarn workspace @fiftyone/multimodal check",
-        "check": "yarn workspace @fiftyone/multimodal check",
+        "check:strict": "echo 'Running strict lint checks...' && yarn workspace @fiftyone/multimodal check && yarn workspace @fiftyone/embeddings-v2 check",
+        "check": "yarn workspace @fiftyone/multimodal check && yarn workspace @fiftyone/embeddings-v2 check",
         "typecheck": "tsc --noEmit -p tsconfig.check.json",
         "typecheck:error-count": "yarn typecheck | grep -c \"error TS\"",
         "compile": "yarn relay-compiler",

--- a/app/packages/embeddings-v2/src/ColorLegend.test.tsx
+++ b/app/packages/embeddings-v2/src/ColorLegend.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ColorLegend } from "./ColorLegend";
+import type { ColorMeta } from "./protocol";
+
+// RTL only auto-cleans up with vitest globals enabled; ours are off
+afterEach(cleanup);
+
+const meta: ColorMeta = {
+  style: "categorical",
+  classes: [
+    { label: "cat", count: 10 },
+    { label: "dog", count: 5 },
+  ],
+} as ColorMeta;
+
+function renderLegend() {
+  const onToggle = vi.fn();
+  const onSolo = vi.fn();
+  render(
+    <ColorLegend
+      field="label"
+      meta={meta}
+      offLabels={new Set()}
+      onToggle={onToggle}
+      onSolo={onSolo}
+    />,
+  );
+  return { onToggle, onSolo };
+}
+
+describe("ColorLegend click handling", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("defers a single click's toggle so an isolate never flashes it", () => {
+    const { onToggle, onSolo } = renderLegend();
+
+    fireEvent.click(screen.getByText("cat"), { detail: 1 });
+    expect(onToggle).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(400);
+    expect(onToggle).toHaveBeenCalledTimes(1);
+    expect(onToggle).toHaveBeenCalledWith("cat");
+    expect(onSolo).not.toHaveBeenCalled();
+  });
+
+  it("double click isolates and cancels the pending toggle", () => {
+    const { onToggle, onSolo } = renderLegend();
+
+    const row = screen.getByText("cat");
+    fireEvent.click(row, { detail: 1 });
+    fireEvent.click(row, { detail: 2 });
+
+    vi.advanceTimersByTime(400);
+    expect(onSolo).toHaveBeenCalledTimes(1);
+    expect(onSolo).toHaveBeenCalledWith("cat");
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+
+  it("rapid clicks on different rows toggle both", () => {
+    // regression: a shared timer let a click on one row cancel another
+    // row's pending toggle, silently dropping the first action
+    const { onToggle, onSolo } = renderLegend();
+
+    fireEvent.click(screen.getByText("cat"), { detail: 1 });
+    fireEvent.click(screen.getByText("dog"), { detail: 1 });
+
+    vi.advanceTimersByTime(400);
+    expect(onToggle).toHaveBeenCalledTimes(2);
+    expect(onToggle).toHaveBeenCalledWith("cat");
+    expect(onToggle).toHaveBeenCalledWith("dog");
+    expect(onSolo).not.toHaveBeenCalled();
+  });
+
+  it("keyboard activation toggles immediately", () => {
+    // Enter/Space on a button fires a click with detail 0; no double
+    // press exists on that path, so there is nothing to wait for
+    const { onToggle } = renderLegend();
+
+    fireEvent.click(screen.getByText("dog"), { detail: 0 });
+    expect(onToggle).toHaveBeenCalledTimes(1);
+    expect(onToggle).toHaveBeenCalledWith("dog");
+  });
+});

--- a/app/packages/embeddings-v2/src/ColorLegend.tsx
+++ b/app/packages/embeddings-v2/src/ColorLegend.tsx
@@ -8,10 +8,18 @@
  * Continuous fields render no legend.
  */
 import { Text, TextBadge, TextColor, TextVariant } from "@voxel51/voodo";
+import { useEffect, useRef } from "react";
 import { categoryHex } from "./colors";
 import { FloatingPanel } from "./FloatingPanel";
 import "./panel.css";
 import type { ColorMeta } from "./protocol";
+
+// A double click physically contains a single click, so the toggle is
+// deferred by this window and cancelled when the second click arrives —
+// otherwise every isolate flashes the toggled state first. Matches the
+// legacy panel, whose plotly legend used the same deferral (plotly.js
+// DBLCLICKDELAY).
+const DOUBLE_CLICK_DELAY_MS = 300;
 
 export function ColorLegend({
   field,
@@ -27,6 +35,45 @@ export function ColorLegend({
   onToggle: (label: string) => void;
   onSolo: (label: string) => void;
 }) {
+  // per-label: a pending single-click toggle on one row must only be
+  // cancelled by a second click on the same row, not a click elsewhere
+  const clickTimeouts = useRef(
+    new Map<string, ReturnType<typeof setTimeout>>(),
+  );
+  useEffect(
+    () => () => {
+      for (const timeout of clickTimeouts.current.values()) {
+        clearTimeout(timeout);
+      }
+    },
+    [],
+  );
+
+  const handleRowClick = (label: string, detail: number) => {
+    const pending = clickTimeouts.current.get(label);
+    if (pending) {
+      clearTimeout(pending);
+      clickTimeouts.current.delete(label);
+    }
+    if (detail >= 2) {
+      onSolo(label);
+      return;
+    }
+    if (detail === 0) {
+      // keyboard activation reports detail 0; no double press exists on
+      // that path, so the toggle applies immediately
+      onToggle(label);
+      return;
+    }
+    clickTimeouts.current.set(
+      label,
+      setTimeout(() => {
+        clickTimeouts.current.delete(label);
+        onToggle(label);
+      }, DOUBLE_CLICK_DELAY_MS),
+    );
+  };
+
   const classes = meta.style === "categorical" ? (meta.classes ?? []) : [];
   if (!classes.length) return null;
 
@@ -55,8 +102,7 @@ export function ColorLegend({
                 className="emb-legend-row"
                 disabled={!interactive}
                 data-off={offLabels?.has(label) ? "true" : "false"}
-                onClick={() => onToggle(label)}
-                onDoubleClick={() => onSolo(label)}
+                onClick={(event) => handleRowClick(label, event.detail)}
               >
                 <span
                   className="emb-legend-swatch"
@@ -67,7 +113,11 @@ export function ColorLegend({
                     {label}
                   </Text>
                 </span>
-                <Text variant={TextVariant.Md} color={TextColor.Tertiary}>
+                <Text
+                  className="emb-legend-count"
+                  variant={TextVariant.Md}
+                  color={TextColor.Tertiary}
+                >
                   {cls.count.toLocaleString()}
                 </Text>
               </button>

--- a/app/packages/embeddings-v2/src/EmbeddingsV2Panel.tsx
+++ b/app/packages/embeddings-v2/src/EmbeddingsV2Panel.tsx
@@ -2,15 +2,20 @@
  * Panel controller: the runs list is the landing view; opening a run
  * shows the plot. `openKey` lives in panel state (local) so the
  * selection survives the remounts that view changes cause, per panel
- * instance. Run deletion executes the builtin delete_brain_run
+ * instance — but it is deliberately NOT restored across page loads or
+ * dataset switches: the panel always lands on the runs list, and
+ * color-by resets when a run is opened, so no run ever renders with
+ * view state it can't vouch for (a restored field choice can be
+ * invalid for the run, and a restored key can collide across
+ * datasets). Run deletion executes the builtin delete_brain_run
  * operator, which enforces permissions where the deployment defines
  * them; the panel renders its own confirmation, so the operator's
  * prompt is bypassed.
  */
 import { useOperatorExecutor } from "@fiftyone/operators";
-import { usePanelStatePartial } from "@fiftyone/spaces";
+import { usePanelId, usePanelStatePartial } from "@fiftyone/spaces";
 import * as fos from "@fiftyone/state";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRecoilValue } from "recoil";
 import PlotView from "./PlotView";
 import RunsList from "./RunsList";
@@ -18,18 +23,64 @@ import { useVisualizationRuns } from "./useVisualizationRuns";
 
 const DELETE_RUN_OPERATOR = "@voxel51/operators/delete_brain_run";
 
+// Panel instances that have already mounted since this page load.
+// Module-scoped on purpose: panel state survives reloads via the
+// session, but view-change remounts recreate the component — this set
+// distinguishes "first mount after a page load" (reset to the runs
+// list) from "remount mid-session" (preserve the open run).
+const mountedPanels = new Set<string>();
+
 export default function EmbeddingsV2Panel() {
   const datasetName = useRecoilValue(fos.datasetName) ?? null;
+  const panelId = usePanelId();
   const [openKeyState, setOpenKey] = usePanelStatePartial<string | null>(
     "openKey",
     null,
     true,
   );
-  const openKey = openKeyState ?? null;
+  const [, setColorField] = usePanelStatePartial<string | null>(
+    "colorField",
+    null,
+    true,
+  );
+
+  // Switching datasets mid-session must not carry the open run along:
+  // brain keys are not unique across datasets, so a stale key could
+  // silently open a same-named run on the new dataset. The render-time
+  // check covers the frame before the effect persists the reset
+  const prevDataset = useRef(datasetName);
+  const datasetSwitched = prevDataset.current !== datasetName;
+
+  const isFirstMountThisPageLoad = !mountedPanels.has(panelId);
+  const openKey =
+    isFirstMountThisPageLoad || datasetSwitched ? null : (openKeyState ?? null);
+
+  useEffect(() => {
+    if (!mountedPanels.has(panelId)) {
+      mountedPanels.add(panelId);
+      setOpenKey(null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [panelId]);
+
+  useEffect(() => {
+    if (prevDataset.current !== datasetName) {
+      prevDataset.current = datasetName;
+      setOpenKey(null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [datasetName]);
 
   const { runs, error, refresh } = useVisualizationRuns(datasetName);
   const deleteExecutor = useOperatorExecutor(DELETE_RUN_OPERATOR);
   const [actionError, setActionError] = useState<string | null>(null);
+
+  const handleOpen = (brainKey: string) => {
+    // every run opens uncolored: a carried-over choice can be invalid
+    // for the run (patches fields) or mismatch its geometry
+    setColorField(null);
+    setOpenKey(brainKey);
+  };
 
   const handleDelete = (brainKey: string) => {
     setActionError(null);
@@ -64,7 +115,7 @@ export default function EmbeddingsV2Panel() {
       runs={runs}
       error={error}
       actionError={actionError}
-      onOpen={setOpenKey}
+      onOpen={handleOpen}
       onDelete={handleDelete}
     />
   );

--- a/app/packages/embeddings-v2/src/RunsList.tsx
+++ b/app/packages/embeddings-v2/src/RunsList.tsx
@@ -27,7 +27,7 @@ import {
   TextVariant,
   Variant,
 } from "@voxel51/voodo";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import "./panel.css";
 import type { VisualizationRun } from "./protocol";
 import { RunCard } from "./RunCard";
@@ -73,6 +73,60 @@ export default function RunsList({
     key: string;
     anchor: HTMLElement;
   } | null>(null);
+
+  // Polling can delete a run or flip its readiness under an open menu or
+  // an armed confirmation; both must not outlive the ready card they
+  // belong to (a recreated same-name run must not inherit them)
+  useEffect(() => {
+    const isReady = (key: string | null) =>
+      Boolean(key && runs?.some((r) => r.brainKey === key && r.ready));
+    if (menu && !isReady(menu.key)) setMenu(null);
+    if (confirmKey && !isReady(confirmKey)) setConfirmKey(null);
+  }, [runs, menu, confirmKey]);
+
+  const runActions = (run: VisualizationRun) => {
+    // No actions on pending runs: Refresh needs results, and Delete
+    // would remove the run record without stopping the computation
+    // writing it (manage those from the Runs page)
+    if (!run.ready) return undefined;
+    if (confirmKey === run.brainKey) {
+      return (
+        <>
+          <Button
+            variant={Variant.Secondary}
+            size={Size.Xs}
+            onClick={() => setConfirmKey(null)}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant={Variant.Danger}
+            size={Size.Xs}
+            onClick={() => {
+              setConfirmKey(null);
+              onDelete(run.brainKey);
+            }}
+          >
+            Delete run
+          </Button>
+        </>
+      );
+    }
+    return (
+      <IconButton
+        size="small"
+        aria-label="Run actions"
+        onClick={(event) =>
+          setMenu({
+            key: run.brainKey,
+            anchor: event.currentTarget,
+          })
+        }
+      >
+        <MoreHoriz fontSize="small" />
+      </IconButton>
+    );
+  };
 
   if (error) {
     return (
@@ -149,7 +203,7 @@ export default function RunsList({
             )}
           </div>
         ) : (
-          <div className="emb-runs-stack" style={{ marginTop: "1rem" }}>
+          <div className="emb-runs-stack">
             {runs.map((run) => (
               <RunCard
                 key={run.brainKey}
@@ -173,42 +227,7 @@ export default function RunsList({
                   formatTimestamp(run.timestamp),
                 ].filter((item): item is string => Boolean(item))}
                 onClick={run.ready ? () => onOpen(run.brainKey) : undefined}
-                actions={
-                  confirmKey === run.brainKey ? (
-                    <>
-                      <Button
-                        variant={Variant.Secondary}
-                        size={Size.Xs}
-                        onClick={() => setConfirmKey(null)}
-                      >
-                        Cancel
-                      </Button>
-                      <Button
-                        variant={Variant.Danger}
-                        size={Size.Xs}
-                        onClick={() => {
-                          setConfirmKey(null);
-                          onDelete(run.brainKey);
-                        }}
-                      >
-                        Delete run
-                      </Button>
-                    </>
-                  ) : (
-                    <IconButton
-                      size="small"
-                      aria-label="Run actions"
-                      onClick={(event) =>
-                        setMenu({
-                          key: run.brainKey,
-                          anchor: event.currentTarget,
-                        })
-                      }
-                    >
-                      <MoreHoriz fontSize="small" />
-                    </IconButton>
-                  )
-                }
+                actions={runActions(run)}
               />
             ))}
           </div>

--- a/app/packages/embeddings-v2/src/panel.css
+++ b/app/packages/embeddings-v2/src/panel.css
@@ -113,6 +113,12 @@
   background: color-mix(in srgb, var(--emb-brand) 6%, transparent);
 }
 
+/* In the runs list the banner needs air before the first card; the card
+   stack itself has no top margin (the runs header sits tight on purpose) */
+.emb-runs-scroll > .emb-callout {
+  margin-bottom: 0.75rem;
+}
+
 .emb-callout[data-aside="true"] {
   grid-template-columns: auto minmax(0, 1fr);
   align-items: stretch;
@@ -440,6 +446,20 @@
   width: 0.5rem;
   border-radius: 9999px;
   flex-shrink: 0;
+  /* optical: center against the glyphs' x-height rather than the full
+     line box, which reads a hair high next to lowercase labels */
+  position: relative;
+  top: 1px;
+}
+
+/* Strip the labels' leading so the flex centering aligns glyph-sized
+   boxes; with the default line-height the extra descent space made both
+   the text and the dot read high against the row. VOODO Text variants
+   set their own line-height (e.g. text-md/7), so the rule needs two
+   classes to out-specify that utility regardless of stylesheet order */
+.emb-legend-row .emb-legend-label,
+.emb-legend-row .emb-legend-count {
+  line-height: 1;
 }
 
 /* --- Continuous (spectrum) legend -------------------------------------- */
@@ -530,7 +550,10 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.75rem 1rem;
+  /* top-heavy on purpose per design review: clear separation from the
+     panel chrome above, while the count/button stay tight to the run
+     cards they describe (~2:1 against .emb-runs-scroll's top padding) */
+  padding: 2rem 1rem 0.25rem;
   flex-shrink: 0;
 }
 

--- a/app/packages/embeddings-v2/src/renderer/interaction/ClickDetector.test.ts
+++ b/app/packages/embeddings-v2/src/renderer/interaction/ClickDetector.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
 import { ClickDetector } from "./ClickDetector";
 
 const fire = (
@@ -22,7 +22,7 @@ const fire = (
 
 describe("ClickDetector", () => {
   let container: HTMLDivElement;
-  let onClick: ReturnType<typeof vi.fn>;
+  let onClick: Mock<(x: number, y: number) => void>;
 
   beforeEach(() => {
     container = document.createElement("div");

--- a/app/packages/embeddings-v2/src/renderer/interaction/HoverPicker.test.ts
+++ b/app/packages/embeddings-v2/src/renderer/interaction/HoverPicker.test.ts
@@ -1,5 +1,13 @@
 // @vitest-environment jsdom
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type Mock,
+  vi,
+} from "vitest";
 import { HOVER_DEBOUNCE_MS } from "../constants";
 import type { HoverHit } from "../types";
 import { HoverPicker } from "./HoverPicker";
@@ -26,8 +34,8 @@ const HIT: HoverHit = { index: 3, id: "abc", label: "cat", x: 10, y: 10 };
 
 describe("HoverPicker", () => {
   let container: HTMLDivElement;
-  let pick: ReturnType<typeof vi.fn>;
-  let onHover: ReturnType<typeof vi.fn>;
+  let pick: Mock<(x: number, y: number) => HoverHit | null>;
+  let onHover: Mock<(hit: HoverHit | null) => void>;
   let blocked: boolean;
   let picker: HoverPicker;
 
@@ -36,7 +44,7 @@ describe("HoverPicker", () => {
     container = document.createElement("div");
     document.body.appendChild(container);
     blocked = false;
-    pick = vi.fn(() => HIT);
+    pick = vi.fn((_x: number, _y: number) => HIT as HoverHit | null);
     onHover = vi.fn();
     picker = new HoverPicker(container, {
       isBlocked: () => blocked,

--- a/app/packages/embeddings-v2/src/renderer/interaction/LassoOverlay.test.ts
+++ b/app/packages/embeddings-v2/src/renderer/interaction/LassoOverlay.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
 import type { Polygon } from "../types";
 import { LassoOverlay } from "./LassoOverlay";
 
@@ -24,7 +24,9 @@ const fire = (
 describe("LassoOverlay", () => {
   let parent: HTMLDivElement;
   let container: HTMLDivElement;
-  let onComplete: ReturnType<typeof vi.fn>;
+  let onComplete: Mock<
+    (screenPolygon: Polygon | null, x: number, y: number) => void
+  >;
   let overlay: LassoOverlay;
 
   beforeEach(() => {

--- a/app/packages/embeddings-v2/src/useVisualizationRuns.ts
+++ b/app/packages/embeddings-v2/src/useVisualizationRuns.ts
@@ -21,18 +21,35 @@ export function useVisualizationRuns(datasetName: string | null): {
   error: string | null;
   refresh: () => void;
 } {
-  const [runs, setRuns] = useState<VisualizationRun[] | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  // runs/error are tagged with the dataset they were fetched for so a
+  // dataset switch never serves the previous dataset's state, even for
+  // the one render before the fetch effect runs
+  const [state, setState] = useState<{
+    dataset: string | null;
+    runs: VisualizationRun[] | null;
+    error: string | null;
+  }>({ dataset: null, runs: null, error: null });
   const [nonce, setNonce] = useState(0);
+
+  const current = state.dataset === datasetName ? state : null;
+  const runs = current?.runs ?? null;
+  const error = current?.error ?? null;
 
   useEffect(() => {
     if (!datasetName) return undefined;
     let stale = false;
-    setRuns(null);
-    setError(null);
+    setState({ dataset: datasetName, runs: null, error: null });
     fetchRuns(datasetName)
-      .then((result) => !stale && setRuns(result))
-      .catch((e) => !stale && setError(String(e)));
+      .then(
+        (result) =>
+          !stale &&
+          setState({ dataset: datasetName, runs: result, error: null }),
+      )
+      .catch(
+        (e) =>
+          !stale &&
+          setState({ dataset: datasetName, runs: null, error: String(e) }),
+      );
     return () => {
       stale = true;
     };
@@ -47,10 +64,11 @@ export function useVisualizationRuns(datasetName: string | null): {
       fetchRuns(datasetName)
         .then((result) => {
           if (stale) return;
-          setRuns((current) =>
-            JSON.stringify(current) === JSON.stringify(result)
-              ? current
-              : result,
+          setState((prev) =>
+            prev.dataset === datasetName &&
+            JSON.stringify(prev.runs) === JSON.stringify(result)
+              ? prev
+              : { dataset: datasetName, runs: result, error: null },
           );
         })
         .catch(() => undefined);


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link. Cherry-pick of #8137 (merge commit b952a2bf) into `release/v1.20.0`, requested by product for the 1.20.0 release.

## 📋 What changes are proposed in this pull request?

Clean cherry-pick of the embeddings-v2 UI fixes and polish PR (#8137, approved by @mozabes and @kevin-dimichel, merged to `develop` today):

- Runs list: per-run pending guard (no actions on runs without results), stale menu/confirm state cleanup, spacing polish
- Color legend: per-label click timers (rapid clicks on different rows no longer swallow toggles), keyboard-click handling, swatch/text alignment
- Panel controller: runs list is always the landing view after a page load or dataset switch; color-by resets when opening a run
- Runs polling: dataset-tagged state so a dataset switch never renders the previous dataset's runs
- CI: embeddings-v2 added to the strict lint/typecheck job

One conflict during the pick: `.github/workflows/lint-app.yml` step rename (`develop` restructured the file's nesting separately); resolved to the new step name at this branch's indentation.

## 🧪 How is this patch tested? If it is not, please explain why.

- 172/172 embeddings-v2 unit tests pass on this branch (includes the new ColorLegend regression test added in #8137)
- Full manual test pass of the panel UI was done on #8137; the 2.23.0 RC smoke test today exercised the synced panel end to end

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

UI fixes and polish for the new Embeddings panel: reliable legend click/double-click behavior, correct state reset when switching datasets, and no actions offered on runs that are still computing.

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [x] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Single-clicking a legend item now toggles it after a brief delay, while double-clicking isolates that item.
  - Keyboard activation toggles legend items immediately.
  - Opening a run resets incompatible visualization settings.
  - Run actions are hidden while runs are processing, and stale menus close automatically.

- **Bug Fixes**
  - Improved dataset switching and run loading state handling.
  - Prevented outdated polling results from appearing after changes.
  - Refined spacing and alignment across the runs panel and legend.

- **Tests**
  - Added coverage for legend click, double-click, keyboard, and rapid-interaction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3594
<!-- enterprise-sync-pr:end -->