### PR TITLE
Skip docs builds on fork PRs

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -37,6 +37,11 @@ concurrency:
 
 jobs:
   build:
+    # Fork PRs cannot access the secrets this job requires (RO_FOT_FG_PAT,
+    # FIFTYONE_GITHUB_TOKEN), so the build is guaranteed to fail; skip it
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     env:
       FIFTYONE_DO_NOT_TRACK: true


### PR DESCRIPTION
## Summary

The `Build docs` job requires repository secrets (`RO_FOT_FG_PAT` for the private checkout, `FIFTYONE_GITHUB_TOKEN`) that `pull_request` runs from forks never receive, so the check is guaranteed red on community contributions — e.g. [this run](https://github.com/voxel51/fiftyone/actions/runs/30568276860/job/90958209981) on #7557 failed with `Input required and not supplied: token` before doing any work.

This adds a job-level condition that skips the build for fork PRs while leaving same-repo PRs, branch pushes, and tag publishes untouched.

## Test plan

- Same-repo PR (this one): the docs build should trigger and run as usual
- Fork PRs: job is skipped instead of failing at checkout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Documentation builds now skip pull requests from forked repositories when required secrets are unavailable, preventing guaranteed build failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3593
<!-- enterprise-sync-pr:end -->