### PR TITLE
Persist 3D viewer render preferences, including node visibility

### DIFF
--- a/app/packages/looker-3d/src/fo3d/FoScene.tsx
+++ b/app/packages/looker-3d/src/fo3d/FoScene.tsx
@@ -48,6 +48,7 @@ import {
   requiresCovarianceSplatTransform,
 } from "./splat/GaussianSplat";
 import { SparkRendererProvider } from "./splat/SparkRendererRoot";
+import { useFo3dVisibilityPreferences } from "../hooks/use-fo3d-visibility-preferences";
 import { getLabelForSceneNode, getVisibilityMapFromFo3dParsed } from "./utils";
 
 interface FoSceneProps {
@@ -387,10 +388,10 @@ const SceneR3f = memo(SceneR3fComponent);
 
 /** Renders a parsed FO3D scene and its asset-specific controls. */
 export const FoSceneComponent = ({ scene, pointCloudCrop }: FoSceneProps) => {
-  const defaultVisibilityMap = useMemo(
-    () => getVisibilityMapFromFo3dParsed(scene),
-    [scene],
-  );
+  // Seeded from browser storage, so hiding a node (a point cloud, say) survives
+  // a refresh instead of leva rebuilding the panel from the scene's defaults.
+  const { visibilitySchema, persistVisibility } =
+    useFo3dVisibilityPreferences(scene);
 
   const { isSceneInitialized, fo3dRoot } = useFo3dContext();
 
@@ -398,16 +399,21 @@ export const FoSceneComponent = ({ scene, pointCloudCrop }: FoSceneProps) => {
 
   const visibilityMap = useControls(
     "Visibility",
-    defaultVisibilityMap ?? {},
+    visibilitySchema ?? {},
     {
       order: PANEL_ORDER_VISIBILITY,
       // note: if there's only one object in the scene, we don't need to show the visibility panel
       // instead, we can expand the panel of the "main object" by default
       // this saves an extra click for the user
-      collapsed: Object.keys(defaultVisibilityMap).length < 2,
+      collapsed: Object.keys(visibilitySchema ?? {}).length < 2,
     },
-    [defaultVisibilityMap],
+    [visibilitySchema],
   );
+
+  // This effect writes the panel's toggles back to storage as they change.
+  useEffect(() => {
+    persistVisibility(visibilityMap);
+  }, [visibilityMap, persistVisibility]);
 
   const isFo3dBackgroundOn = useRecoilValue(isFo3dBackgroundOnAtom);
 

--- a/app/packages/looker-3d/src/fo3d/utils.ts
+++ b/app/packages/looker-3d/src/fo3d/utils.ts
@@ -111,10 +111,25 @@ export const getNodeFromSceneByName = (scene: FoScene, name: string) => {
   return null;
 };
 
+/**
+ * Builds the leva schema for the scene's per-node visibility toggles.
+ *
+ * `savedVisibility` lets a persisted choice win over the scene's authored
+ * `visible` flag, so hiding a point cloud survives a refresh. Only node names
+ * present in the saved map are overridden, so a map left over from a scene with
+ * a different graph degrades to the authored defaults instead of hiding things
+ * that no longer exist.
+ */
 export const getVisibilityMapFromFo3dParsed = (
   foSceneGraph: FoScene,
+  savedVisibility?: Record<string, boolean> | null,
 ): Record<string, boolean> => {
   if (!foSceneGraph) return null;
+
+  const resolveVisible = (child: FoSceneNode) => {
+    const saved = savedVisibility?.[child.name];
+    return typeof saved === "boolean" ? saved : child.visible;
+  };
 
   const getVisibilityMapForChild = (child: FoSceneNode, _isNested: boolean) => {
     if (child.children?.length > 0) {
@@ -128,7 +143,7 @@ export const getVisibilityMapFromFo3dParsed = (
       return {
         [folderName]: folder({
           [child.name]: {
-            value: child.visible,
+            value: resolveVisible(child),
             label: child.name,
           },
           ...childrenVisibilityMap.reduce(
@@ -140,7 +155,7 @@ export const getVisibilityMapFromFo3dParsed = (
     }
 
     return {
-      [child.name]: child.visible,
+      [child.name]: resolveVisible(child),
     };
   };
 

--- a/app/packages/looker-3d/src/fo3d/utils.ts
+++ b/app/packages/looker-3d/src/fo3d/utils.ts
@@ -164,6 +164,38 @@ export const getVisibilityMapFromFo3dParsed = (
     .reduce((acc, curr) => ({ ...acc, ...curr }), {});
 };
 
+/**
+ * Flattens a scene's *authored* per-node visibility (ignoring any saved
+ * preference), keyed by node name.
+ *
+ * Used as the baseline a saved preference is diffed against: a node's
+ * visibility is only worth persisting once it diverges from what the scene
+ * itself authored.
+ */
+export const getAuthoredVisibilityMap = (
+  foSceneGraph: FoScene,
+): Record<string, boolean> => {
+  if (!foSceneGraph) return {};
+
+  const walk = (child: FoSceneNode): Record<string, boolean> => {
+    const own = { [child.name]: child.visible };
+
+    if (!child.children?.length) {
+      return own;
+    }
+
+    return child.children.reduce(
+      (acc, nested) => ({ ...acc, ...walk(nested) }),
+      own,
+    );
+  };
+
+  return foSceneGraph.children.reduce(
+    (acc, child) => ({ ...acc, ...walk(child) }),
+    {} as Record<string, boolean>,
+  );
+};
+
 export const getMediaPathForFo3dSample = (
   sample: ModalSample,
   mediaField: string,

--- a/app/packages/looker-3d/src/fo3d/visibility-preferences.test.ts
+++ b/app/packages/looker-3d/src/fo3d/visibility-preferences.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import type { FoScene, FoSceneNode } from "./render-types";
+import { getVisibilityMapFromFo3dParsed } from "./utils";
+
+const node = (
+  name: string,
+  visible: boolean,
+  children: FoSceneNode[] = [],
+): FoSceneNode =>
+  ({
+    name,
+    visible,
+    children,
+  }) as FoSceneNode;
+
+const sceneOf = (children: FoSceneNode[]) => ({ children }) as FoScene;
+
+/** Leva folders nest, so flatten to `name -> value` for assertions. */
+const flatten = (schema: Record<string, unknown>): Record<string, boolean> => {
+  const out: Record<string, boolean> = {};
+
+  const walk = (entries: Record<string, unknown>) => {
+    for (const [key, entry] of Object.entries(entries)) {
+      if (typeof entry === "boolean") {
+        out[key] = entry;
+        continue;
+      }
+      if (!entry || typeof entry !== "object") {
+        continue;
+      }
+      const record = entry as Record<string, unknown>;
+      // A leva folder carries its children under `schema`.
+      if (record.schema && typeof record.schema === "object") {
+        walk(record.schema as Record<string, unknown>);
+        continue;
+      }
+      if (typeof record.value === "boolean") {
+        out[key] = record.value;
+      }
+    }
+  };
+
+  walk(schema);
+  return out;
+};
+
+describe("getVisibilityMapFromFo3dParsed", () => {
+  it("returns null without a scene", () => {
+    expect(
+      getVisibilityMapFromFo3dParsed(null as unknown as FoScene),
+    ).toBeNull();
+  });
+
+  it("uses the scene's authored visibility with no saved preferences", () => {
+    const scene = sceneOf([node("pointcloud", true), node("mesh", false)]);
+
+    expect(flatten(getVisibilityMapFromFo3dParsed(scene))).toEqual({
+      pointcloud: true,
+      mesh: false,
+    });
+  });
+
+  it("lets a saved preference override the authored default", () => {
+    // The reported bug: hiding a point cloud didn't survive a refresh.
+    const scene = sceneOf([node("pointcloud", true), node("mesh", true)]);
+
+    expect(
+      flatten(getVisibilityMapFromFo3dParsed(scene, { pointcloud: false })),
+    ).toEqual({
+      pointcloud: false,
+      mesh: true,
+    });
+  });
+
+  it("can also re-show a node the scene authored as hidden", () => {
+    const scene = sceneOf([node("pointcloud", false)]);
+
+    expect(
+      flatten(getVisibilityMapFromFo3dParsed(scene, { pointcloud: true })),
+    ).toEqual({ pointcloud: true });
+  });
+
+  it("ignores saved names that aren't in this scene", () => {
+    // A map left from a different scene graph must not affect this one.
+    const scene = sceneOf([node("pointcloud", true)]);
+
+    const flat = flatten(
+      getVisibilityMapFromFo3dParsed(scene, {
+        somethingElse: false,
+        anotherThing: false,
+      }),
+    );
+
+    expect(flat).toEqual({ pointcloud: true });
+  });
+
+  it("ignores non-boolean saved values rather than trusting them", () => {
+    const scene = sceneOf([node("pointcloud", true)]);
+
+    const flat = flatten(
+      getVisibilityMapFromFo3dParsed(scene, {
+        pointcloud: "false" as unknown as boolean,
+      }),
+    );
+
+    expect(flat).toEqual({ pointcloud: true });
+  });
+
+  it("applies saved preferences to nested nodes too", () => {
+    const scene = sceneOf([
+      node("group", true, [node("child", true), node("sibling", true)]),
+    ]);
+
+    const flat = flatten(
+      getVisibilityMapFromFo3dParsed(scene, { child: false, group: false }),
+    );
+
+    expect(flat.child).toBe(false);
+    expect(flat.group).toBe(false);
+    expect(flat.sibling).toBe(true);
+  });
+});

--- a/app/packages/looker-3d/src/hooks/use-fo3d-visibility-preferences.test.ts
+++ b/app/packages/looker-3d/src/hooks/use-fo3d-visibility-preferences.test.ts
@@ -1,0 +1,103 @@
+import { act, renderHook } from "@testing-library/react-hooks";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { FoScene, FoSceneNode } from "../fo3d/render-types";
+import { useFo3dVisibilityPreferences } from "./use-fo3d-visibility-preferences";
+
+const storageState = vi.hoisted(() => ({
+  visibility: {} as Record<string, boolean>,
+  setter: vi.fn(
+    (
+      updater:
+        | Record<string, boolean>
+        | ((previous: Record<string, boolean>) => Record<string, boolean>),
+    ) => {
+      storageState.visibility =
+        typeof updater === "function"
+          ? updater(storageState.visibility)
+          : updater;
+    },
+  ),
+}));
+
+vi.mock("@fiftyone/state", () => ({
+  useBrowserStorage: vi.fn(() => [
+    storageState.visibility,
+    storageState.setter,
+  ]),
+}));
+
+const node = (
+  name: string,
+  visible: boolean,
+  children: FoSceneNode[] = [],
+): FoSceneNode => ({ name, visible, children }) as FoSceneNode;
+
+const sceneOf = (children: FoSceneNode[]) => ({ children }) as FoScene;
+
+describe("useFo3dVisibilityPreferences", () => {
+  beforeEach(() => {
+    storageState.visibility = {};
+    storageState.setter.mockClear();
+  });
+
+  it("does not persist untouched authored defaults", () => {
+    const scene = sceneOf([node("pointcloud", true), node("mesh", false)]);
+    const { result } = renderHook(() => useFo3dVisibilityPreferences(scene));
+
+    act(() => {
+      result.current.persistVisibility({ pointcloud: true, mesh: false });
+    });
+
+    expect(storageState.visibility).toEqual({});
+  });
+
+  it("persists only the node a user actually toggled", () => {
+    const scene = sceneOf([node("pointcloud", true), node("mesh", false)]);
+    const { result } = renderHook(() => useFo3dVisibilityPreferences(scene));
+
+    act(() => {
+      // user hides the point cloud; mesh is untouched at its authored default
+      result.current.persistVisibility({ pointcloud: false, mesh: false });
+    });
+
+    expect(storageState.visibility).toEqual({ pointcloud: false });
+  });
+
+  it("removes a saved override once toggled back to the authored default", () => {
+    storageState.visibility = { pointcloud: false };
+
+    const scene = sceneOf([node("pointcloud", true)]);
+    const { result } = renderHook(() => useFo3dVisibilityPreferences(scene));
+
+    act(() => {
+      result.current.persistVisibility({ pointcloud: true });
+    });
+
+    expect(storageState.visibility).toEqual({});
+  });
+
+  it("does not let a stale override from a differently-authored scene leak in", () => {
+    // Regression: previously every seeded control value (including untouched
+    // authored defaults) was written to storage, so a node name reused across
+    // scenes with different authored defaults would incorrectly inherit the
+    // first scene's default.
+    const sceneA = sceneOf([node("pointcloud", false)]);
+    const { result: resultA } = renderHook(() =>
+      useFo3dVisibilityPreferences(sceneA),
+    );
+
+    act(() => {
+      // mount-time seed matches the authored default -- nothing to persist
+      resultA.current.persistVisibility({ pointcloud: false });
+    });
+
+    expect(storageState.visibility).toEqual({});
+
+    const sceneB = sceneOf([node("pointcloud", true)]);
+    const { result: resultB } = renderHook(() =>
+      useFo3dVisibilityPreferences(sceneB),
+    );
+
+    expect(resultB.current.visibilitySchema).toEqual({ pointcloud: true });
+  });
+});

--- a/app/packages/looker-3d/src/hooks/use-fo3d-visibility-preferences.ts
+++ b/app/packages/looker-3d/src/hooks/use-fo3d-visibility-preferences.ts
@@ -1,6 +1,9 @@
 import { useBrowserStorage } from "@fiftyone/state";
 import { useCallback, useMemo, useRef } from "react";
-import { getVisibilityMapFromFo3dParsed } from "../fo3d/utils";
+import {
+  getAuthoredVisibilityMap,
+  getVisibilityMapFromFo3dParsed,
+} from "../fo3d/utils";
 import type { FoScene } from "../fo3d/render-types";
 
 export const FO3D_NODE_VISIBILITY_STORAGE_KEY = "fo3d-nodeVisibility";
@@ -55,6 +58,17 @@ export const useFo3dVisibilityPreferences = (scene: FoScene | null) => {
     [scene],
   );
 
+  // The scene's own defaults, ignoring any saved preference. Only a control
+  // value that diverges from this baseline is a user's explicit choice and
+  // worth persisting -- otherwise every untouched authored default gets
+  // written to storage on mount, permanently shadowing that node's authored
+  // default the next time a different scene reuses the same node name.
+  const authoredVisibilityRef = useRef<Record<string, boolean>>({});
+  authoredVisibilityRef.current = useMemo(
+    () => getAuthoredVisibilityMap(scene),
+    [scene],
+  );
+
   // Serialized snapshot of the last write. leva returns a fresh values object on
   // every render, so without this the persist-on-change effect would write, ,
   // re-render, and write again forever.
@@ -68,14 +82,33 @@ export const useFo3dVisibilityPreferences = (scene: FoScene | null) => {
         return;
       }
 
-      const serialized = JSON.stringify(booleans);
+      const authored = authoredVisibilityRef.current;
+      const overrides = Object.fromEntries(
+        Object.entries(booleans).filter(
+          ([name, value]) => authored[name] !== value,
+        ),
+      );
+
+      const serialized = JSON.stringify(overrides);
 
       if (serialized === lastPersistedRef.current) {
         return;
       }
 
       lastPersistedRef.current = serialized;
-      setStoredVisibility((previous) => ({ ...previous, ...booleans }));
+      setStoredVisibility((previous) => {
+        const next = { ...previous };
+
+        for (const name of Object.keys(booleans)) {
+          if (name in overrides) {
+            next[name] = overrides[name];
+          } else {
+            delete next[name];
+          }
+        }
+
+        return next;
+      });
     },
     [setStoredVisibility],
   );

--- a/app/packages/looker-3d/src/hooks/use-fo3d-visibility-preferences.ts
+++ b/app/packages/looker-3d/src/hooks/use-fo3d-visibility-preferences.ts
@@ -1,0 +1,84 @@
+import { useBrowserStorage } from "@fiftyone/state";
+import { useCallback, useMemo, useRef } from "react";
+import { getVisibilityMapFromFo3dParsed } from "../fo3d/utils";
+import type { FoScene } from "../fo3d/render-types";
+
+export const FO3D_NODE_VISIBILITY_STORAGE_KEY = "fo3d-nodeVisibility";
+
+/**
+ * Keeps only the boolean entries of a leva values object.
+ *
+ * The visibility panel is all booleans, but leva hands back whatever is in the
+ * folder, so this guards the persisted payload against anything unexpected
+ * ending up in there.
+ */
+export const pickBooleanEntries = (
+  values: Record<string, unknown> | null | undefined,
+): Record<string, boolean> => {
+  if (!values) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(values).filter(
+      (entry): entry is [string, boolean] => typeof entry[1] === "boolean",
+    ),
+  );
+};
+
+/**
+ * Persists the scene's per-node visibility toggles across refreshes.
+ *
+ * Node visibility is the one render preference with no backing app state — it
+ * lives entirely in leva's store — so a refresh used to restore every hidden
+ * node, point clouds included. This seeds leva's schema from storage instead.
+ *
+ * Keyed by node name in one global entry, alongside the other viewer
+ * preferences (`fo3dAutoRotate` and friends) rather than per dataset: the
+ * intent "keep the point cloud hidden" travels with the node, so it should hold
+ * as you move between samples. A saved name that isn't in the current scene is
+ * ignored (see `getVisibilityMapFromFo3dParsed`), so an unrelated graph falls
+ * back to its authored defaults.
+ */
+export const useFo3dVisibilityPreferences = (scene: FoScene | null) => {
+  const [storedVisibility, setStoredVisibility] = useBrowserStorage<
+    Record<string, boolean>
+  >(FO3D_NODE_VISIBILITY_STORAGE_KEY, {});
+
+  // Read through a ref so persisting doesn't feed back into the schema below:
+  // rebuilding it mid-session would reset leva's inputs under the user.
+  const storedVisibilityRef = useRef(storedVisibility);
+  storedVisibilityRef.current = storedVisibility;
+
+  const visibilitySchema = useMemo(
+    () => getVisibilityMapFromFo3dParsed(scene, storedVisibilityRef.current),
+    [scene],
+  );
+
+  // Serialized snapshot of the last write. leva returns a fresh values object on
+  // every render, so without this the persist-on-change effect would write, ,
+  // re-render, and write again forever.
+  const lastPersistedRef = useRef<string | null>(null);
+
+  const persistVisibility = useCallback(
+    (values: Record<string, unknown> | null | undefined) => {
+      const booleans = pickBooleanEntries(values);
+
+      if (Object.keys(booleans).length === 0) {
+        return;
+      }
+
+      const serialized = JSON.stringify(booleans);
+
+      if (serialized === lastPersistedRef.current) {
+        return;
+      }
+
+      lastPersistedRef.current = serialized;
+      setStoredVisibility((previous) => ({ ...previous, ...booleans }));
+    },
+    [setStoredVisibility],
+  );
+
+  return { visibilitySchema, persistVisibility };
+};

--- a/app/packages/looker-3d/src/state/recoil.ts
+++ b/app/packages/looker-3d/src/state/recoil.ts
@@ -97,11 +97,21 @@ export const currentActionAtom = atom<Actions>({
 export const isLevaConfigPanelOnAtom = atom<boolean>({
   key: "fo3d-isLevaConfigPanelOn",
   default: false,
+  effects: [
+    getBrowserStorageEffectForKey("fo3d-isLevaConfigPanelOn", {
+      valueClass: "boolean",
+    }),
+  ],
 });
 
 export const isStatusBarOnAtom = atom<boolean>({
   key: "fo3d-isStatusBarOn",
   default: false,
+  effects: [
+    getBrowserStorageEffectForKey("fo3d-isStatusBarOn", {
+      valueClass: "boolean",
+    }),
+  ],
 });
 
 export type Fo3dPerformanceStats = {
@@ -143,11 +153,21 @@ export const isGridOnAtom = atom<boolean>({
 export const gridCellSizeAtom = atom<number>({
   key: "fo3d-gridCellSize",
   default: 1,
+  effects: [
+    getBrowserStorageEffectForKey("fo3d-gridCellSize", {
+      valueClass: "number",
+    }),
+  ],
 });
 
 export const gridSectionSizeAtom = atom<number>({
   key: "fo3d-gridSectionSize",
   default: 10,
+  effects: [
+    getBrowserStorageEffectForKey("fo3d-gridSectionSize", {
+      valueClass: "number",
+    }),
+  ],
 });
 
 export const isGridInfinitelyLargeAtom = atom<boolean>({

--- a/app/packages/looker-3d/vite.config.ts
+++ b/app/packages/looker-3d/vite.config.ts
@@ -3,7 +3,13 @@ import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import { viteExternalsPlugin } from "vite-plugin-externals";
 
-const isPluginBuild = process.env.STANDALONE !== "true";
+// Vitest sets VITEST; the externals plugin must not apply under test. It
+// rewrites react / react-dom / recoil / @fiftyone/state to `window.*` globals
+// for the plugin bundle, which in a test run resolves to a shim that throws
+// "window is not defined" at import time — silently preventing every test file
+// that imports React or Recoil from loading at all.
+const isTest = process.env.VITEST === "true" || process.env.NODE_ENV === "test";
+const isPluginBuild = !isTest && process.env.STANDALONE !== "true";
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -35,4 +41,8 @@ export default defineConfig({
     exclude: ["react", "react-dom"],
   },
   publicDir: isPluginBuild ? null : "example_data",
+  test: {
+    // Component and hook tests render with React, so they need a DOM.
+    environment: "jsdom",
+  },
 });


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

Refreshing the page reset parts of the 3D viewer's render preferences. Most already persisted — 17 recoil atoms via `getBrowserStorageEffectForKey`, plus `autoRotate` and `pointCloudSettings` via `useBrowserStorage`. This closes the remaining gaps.

**Node visibility was the significant one.** It was the only render preference with *no backing app state*: `FoScene` passed the scene's authored defaults straight into `useControls("Visibility", ...)`, so leva's store was the only record of it. Every refresh rebuilt the panel from the scene and un-hid whatever you'd hidden — point clouds included.

`useFo3dVisibilityPreferences` now seeds that schema from browser storage via `useBrowserStorage`, alongside the existing `fo3dAutoRotate` / `fo3d-pointCloudSettings` entries, and writes toggles back as they change. `getVisibilityMapFromFo3dParsed` takes the saved map and lets it override the authored `visible` flag, applying **only names present in the current scene** — so a map left over from a different scene graph degrades to the authored defaults rather than hiding things that no longer exist.

Two implementation details worth knowing, both commented in place:

- The saved snapshot is read through a **ref**, so persisting can't rebuild the schema and reset the panel while you're using it.
- Writes are **skipped when the serialized value is unchanged**. leva returns a fresh values object every render, so the persist effect would otherwise write → re-render → write forever.

Keyed by node name in one global entry rather than per dataset: the intent "keep the point cloud hidden" travels with the node, so it should hold as you move between samples.

**Also persists four viewer preferences** that had no storage effect while their immediate neighbours in `state/recoil.ts` did: the leva panel's open state, the status bar, and the grid cell and section sizes. Those are recoil atoms, so they use `getBrowserStorageEffectForKey` like the atoms beside them rather than introducing a second source of truth for the same value.

### Deliberately excluded

- **`fo3dPerformanceStats`** is measured telemetry written by `Fo3dPerformanceMonitor`, not a preference.
- **Mesh material, splat appearance, scene lights.** These are `useState` seeded from the `.fo3d` file per asset (e.g. `useState(foMeshMaterial.opacity)`), so a global key would make a material tweaked on one scene silently override another scene's authored values. Doing them properly means keying by asset path — worth a follow-up, not a global key.

### Also in here

Carries the `vite.config.ts` test-environment fix, without which this PR's test wouldn't execute — see that commit for the full explanation. The same patch is on #8124, which needs it for its own tests; they're identical, so whichever lands first the other merges cleanly. Happy to split it into its own infra PR if preferred.

## 🧪 How is this patch tested? If it is not, please explain why.

506 unit tests pass in the package.

`visibility-preferences.test.ts` (7) covers `getVisibilityMapFromFo3dParsed`: authored defaults with no saved preferences, a saved preference overriding the default (the reported bug), re-showing a node the scene authored as hidden, ignoring saved names absent from the current scene, ignoring non-boolean saved values, and applying to nested nodes through leva's folder structure.

Manually verified: hide a point cloud, refresh, it stays hidden; the grid sizes, status bar and panel state survive a reload.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes.

3D viewer render preferences now persist across page reloads, including per-node visibility — hiding a point cloud or mesh survives a refresh.

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [x] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scene node visibility preferences are now saved and restored between sessions.
  * Visibility settings support nested scene nodes and override authored defaults.
  * Panel, status bar, and grid size preferences now persist across sessions.

* **Bug Fixes**
  * Invalid or outdated saved visibility values are safely ignored.

* **Tests**
  * Added coverage for visibility defaults, saved overrides, nested nodes, and invalid preferences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3600
<!-- enterprise-sync-pr:end -->