### PR TITLE
[FOEPD-3965] Render stored 2D labels on the 3D annotate camera slices

### DIFF
--- a/app/packages/looker-3d/src/annotation/ImageSlicePanel.tsx
+++ b/app/packages/looker-3d/src/annotation/ImageSlicePanel.tsx
@@ -1,9 +1,13 @@
+import * as fos from "@fiftyone/state";
 import { useEffect, useMemo } from "react";
+import { useRecoilValue } from "recoil";
 import styled from "styled-components";
 import type { Vector3 } from "three";
 import { PANEL_ID_SIDE_TOP, VIEW_TYPE_LEFT, VIEW_TYPE_TOP } from "../constants";
 import { useFetchFrustumParameters } from "../frustum/hooks/internal/useFetchFrustumParameters";
 import type { SidePanelId, SidePanelViewType } from "../types";
+import { Native2dAnnotations } from "./native2d/Native2dAnnotations";
+import type { Native2dLabel } from "./native2d/types";
 import { Projected3dOverlays } from "./projection";
 
 const ImageSliceContainer = styled.div`
@@ -85,6 +89,7 @@ export interface ImageSlicePanelProps {
   imageSlices: string[];
   isLoadingImageSlices: boolean;
   resolveUrlForImageSlice: (sliceName: string) => string | null;
+  resolveLabelsForImageSlice: (sliceName: string) => Native2dLabel[];
   upVector?: Vector3 | null;
 }
 
@@ -101,6 +106,7 @@ export const ImageSlicePanel = ({
   imageSlices,
   isLoadingImageSlices,
   resolveUrlForImageSlice,
+  resolveLabelsForImageSlice,
   upVector,
 }: ImageSlicePanelProps) => {
   const { data: frustumData } = useFetchFrustumParameters();
@@ -111,6 +117,18 @@ export const ImageSlicePanel = ({
     if (!sliceName) return null;
     return frustumData.find((f) => f.sliceName === sliceName) ?? null;
   }, [frustumData, view]);
+
+  // Stored 2D labels for this slice, filtered to the sidebar's active fields so
+  // they toggle in sync with the rest of the app.
+  const activeFields = useRecoilValue(fos.activeFields({ modal: true }));
+  const native2dLabels = useMemo(() => {
+    const sliceName = decodeImageSliceView(view);
+    if (!sliceName) return [];
+    const active = new Set(activeFields);
+    return resolveLabelsForImageSlice(sliceName).filter((l) =>
+      active.has(l.path),
+    );
+  }, [view, activeFields, resolveLabelsForImageSlice]);
 
   /**
    * Validation effect: restore view to a cardinal view only if absolutely certain
@@ -155,6 +173,7 @@ export const ImageSlicePanel = ({
   return (
     <ImageSliceContainer>
       <ImageSliceImg src={imageUrl} />
+      <Native2dAnnotations labels={native2dLabels} imageUrl={imageUrl} />
       {activeFrustum && (
         <Projected3dOverlays
           frustumData={activeFrustum}

--- a/app/packages/looker-3d/src/annotation/ImageSlicePanel.tsx
+++ b/app/packages/looker-3d/src/annotation/ImageSlicePanel.tsx
@@ -138,21 +138,6 @@ export const ImageSlicePanel = ({
     const all = resolveLabelsForImageSlice(sliceName);
     const visible = all.filter((l) => !known.has(l.path) || active.has(l.path));
 
-    if (process.env.NODE_ENV !== "production") {
-      // eslint-disable-next-line no-console
-      console.debug("[native2d] slice", sliceName, {
-        fetched: all.length,
-        visible: visible.length,
-        paths: [...new Set(all.map((l) => l.path))],
-        sidebarKnows: [...new Set(all.map((l) => l.path))].filter((p) =>
-          known.has(p),
-        ),
-        sidebarActive: [...new Set(all.map((l) => l.path))].filter((p) =>
-          active.has(p),
-        ),
-      });
-    }
-
     return visible;
   }, [view, activeFields, knownLabelFields, resolveLabelsForImageSlice]);
 

--- a/app/packages/looker-3d/src/annotation/ImageSlicePanel.tsx
+++ b/app/packages/looker-3d/src/annotation/ImageSlicePanel.tsx
@@ -1,6 +1,4 @@
-import * as fos from "@fiftyone/state";
 import { useEffect, useMemo } from "react";
-import { useRecoilValue } from "recoil";
 import styled from "styled-components";
 import type { Vector3 } from "three";
 import { PANEL_ID_SIDE_TOP, VIEW_TYPE_LEFT, VIEW_TYPE_TOP } from "../constants";
@@ -8,6 +6,7 @@ import { useFetchFrustumParameters } from "../frustum/hooks/internal/useFetchFru
 import type { SidePanelId, SidePanelViewType } from "../types";
 import { Native2dAnnotations } from "./native2d/Native2dAnnotations";
 import type { Native2dLabel } from "./native2d/types";
+import { useVisibleNative2dLabels } from "./native2d/useVisibleNative2dLabels";
 import { Projected3dOverlays } from "./projection";
 
 const ImageSliceContainer = styled.div`
@@ -118,28 +117,13 @@ export const ImageSlicePanel = ({
     return frustumData.find((f) => f.sliceName === sliceName) ?? null;
   }, [frustumData, view]);
 
-  // Stored 2D labels for this slice.
-  //
-  // Visibility follows the sidebar, but only for paths the sidebar actually
-  // knows about. A field that lives on the image slices without being in the
-  // main (point-cloud slice) schema never appears in `activeFields`, so keying
-  // purely off membership there hid every such label — which is why none of
-  // these were showing up at all.
-  const activeFields = useRecoilValue(fos.activeFields({ modal: true }));
-  const knownLabelFields = useRecoilValue(
-    fos.labelFields({ space: fos.State.SPACE.SAMPLE }),
-  );
-  const native2dLabels = useMemo(() => {
+  // Stored 2D labels for this slice, filtered to what the sidebar would show.
+  const allNative2dLabels = useMemo(() => {
     const sliceName = decodeImageSliceView(view);
     if (!sliceName) return [];
-
-    const active = new Set(activeFields);
-    const known = new Set(knownLabelFields);
-    const all = resolveLabelsForImageSlice(sliceName);
-    const visible = all.filter((l) => !known.has(l.path) || active.has(l.path));
-
-    return visible;
-  }, [view, activeFields, knownLabelFields, resolveLabelsForImageSlice]);
+    return resolveLabelsForImageSlice(sliceName);
+  }, [view, resolveLabelsForImageSlice]);
+  const native2dLabels = useVisibleNative2dLabels(allNative2dLabels);
 
   /**
    * Validation effect: restore view to a cardinal view only if absolutely certain

--- a/app/packages/looker-3d/src/annotation/ImageSlicePanel.tsx
+++ b/app/packages/looker-3d/src/annotation/ImageSlicePanel.tsx
@@ -118,17 +118,43 @@ export const ImageSlicePanel = ({
     return frustumData.find((f) => f.sliceName === sliceName) ?? null;
   }, [frustumData, view]);
 
-  // Stored 2D labels for this slice, filtered to the sidebar's active fields so
-  // they toggle in sync with the rest of the app.
+  // Stored 2D labels for this slice.
+  //
+  // Visibility follows the sidebar, but only for paths the sidebar actually
+  // knows about. A field that lives on the image slices without being in the
+  // main (point-cloud slice) schema never appears in `activeFields`, so keying
+  // purely off membership there hid every such label — which is why none of
+  // these were showing up at all.
   const activeFields = useRecoilValue(fos.activeFields({ modal: true }));
+  const knownLabelFields = useRecoilValue(
+    fos.labelFields({ space: fos.State.SPACE.SAMPLE }),
+  );
   const native2dLabels = useMemo(() => {
     const sliceName = decodeImageSliceView(view);
     if (!sliceName) return [];
+
     const active = new Set(activeFields);
-    return resolveLabelsForImageSlice(sliceName).filter((l) =>
-      active.has(l.path),
-    );
-  }, [view, activeFields, resolveLabelsForImageSlice]);
+    const known = new Set(knownLabelFields);
+    const all = resolveLabelsForImageSlice(sliceName);
+    const visible = all.filter((l) => !known.has(l.path) || active.has(l.path));
+
+    if (process.env.NODE_ENV !== "production") {
+      // eslint-disable-next-line no-console
+      console.debug("[native2d] slice", sliceName, {
+        fetched: all.length,
+        visible: visible.length,
+        paths: [...new Set(all.map((l) => l.path))],
+        sidebarKnows: [...new Set(all.map((l) => l.path))].filter((p) =>
+          known.has(p),
+        ),
+        sidebarActive: [...new Set(all.map((l) => l.path))].filter((p) =>
+          active.has(p),
+        ),
+      });
+    }
+
+    return visible;
+  }, [view, activeFields, knownLabelFields, resolveLabelsForImageSlice]);
 
   /**
    * Validation effect: restore view to a cardinal view only if absolutely certain

--- a/app/packages/looker-3d/src/annotation/SidePanel.tsx
+++ b/app/packages/looker-3d/src/annotation/SidePanel.tsx
@@ -171,8 +171,12 @@ export const SidePanel = ({
   sample,
 }: SidePanelProps) => {
   const { activeSampleMap: labelSampleMap } = fos.useRenderConfig3dState();
-  const { imageSlices, resolveUrlForImageSlice, isLoadingImageSlices } =
-    useImageSlicesIfAvailable(sample);
+  const {
+    imageSlices,
+    resolveUrlForImageSlice,
+    resolveLabelsForImageSlice,
+    isLoadingImageSlices,
+  } = useImageSlicesIfAvailable(sample);
 
   // While a label transform is in progress (e.g. a cuboid face-pull resize
   // started in this panel), suspend panning so the drag doesn't also move the
@@ -239,6 +243,7 @@ export const SidePanel = ({
           imageSlices={imageSlices}
           isLoadingImageSlices={isLoadingImageSlices}
           resolveUrlForImageSlice={resolveUrlForImageSlice}
+          resolveLabelsForImageSlice={resolveLabelsForImageSlice}
           upVector={upVector}
         />
       ) : (

--- a/app/packages/looker-3d/src/annotation/native2d/Native2dAnnotations.tsx
+++ b/app/packages/looker-3d/src/annotation/native2d/Native2dAnnotations.tsx
@@ -1,0 +1,70 @@
+import { OverlaySvg, resolveVisualProps } from "../projection/shared";
+import { SvgPolylineProjection } from "../projection/SvgPolylineProjection";
+import { buildPolylinePixelData } from "./geometry";
+import type { Native2dLabel } from "./types";
+import { useImageNaturalSize } from "./useImageNaturalSize";
+import { useNative2dLabelColor } from "./useNative2dLabelColor";
+
+interface Native2dAnnotationsProps {
+  labels: Native2dLabel[];
+  imageUrl: string | null;
+}
+
+/**
+ * Renders a camera slice's stored 2D `Detection`/`Polyline` labels as an SVG
+ * overlay, reusing the same overlay layer/primitives as the projected-3D
+ * annotations. Unlike the 3D projection, these labels are already in normalized
+ * image space, so we scale by the image's natural dimensions rather than
+ * projecting through the camera frustum.
+ */
+export function Native2dAnnotations({
+  labels,
+  imageUrl,
+}: Native2dAnnotationsProps) {
+  const size = useImageNaturalSize(imageUrl);
+  const colorOf = useNative2dLabelColor();
+
+  if (!size || labels.length === 0) return null;
+
+  const { w, h } = size;
+
+  return (
+    <OverlaySvg viewBox={`0 0 ${w} ${h}`} preserveAspectRatio="xMidYMid meet">
+      {labels.map((label) => {
+        const { color, opacity } = resolveVisualProps(
+          colorOf(label),
+          false,
+          false,
+          false,
+        );
+
+        if (label._cls === "Detection") {
+          const [x, y, bw, bh] = label.boundingBox;
+          return (
+            <rect
+              key={`native-det-${label._id}`}
+              x={x * w}
+              y={y * h}
+              width={bw * w}
+              height={bh * h}
+              fill="none"
+              stroke={color}
+              strokeWidth={2}
+              vectorEffect="non-scaling-stroke"
+              opacity={opacity}
+            />
+          );
+        }
+
+        return (
+          <SvgPolylineProjection
+            key={`native-poly-${label._id}`}
+            data={buildPolylinePixelData(label, w, h)}
+            color={color}
+            opacity={opacity}
+          />
+        );
+      })}
+    </OverlaySvg>
+  );
+}

--- a/app/packages/looker-3d/src/annotation/native2d/Native2dAnnotations.tsx
+++ b/app/packages/looker-3d/src/annotation/native2d/Native2dAnnotations.tsx
@@ -5,6 +5,11 @@ import type { Native2dLabel } from "./types";
 import { useImageNaturalSize } from "./useImageNaturalSize";
 import { useNative2dLabelColor } from "./useNative2dLabelColor";
 
+const LABEL_FONT_SIZE = 14;
+const LABEL_TEXT_OFFSET = 6;
+// Filled polylines wash out the image at full strength.
+const FILL_OPACITY = 0.3;
+
 interface Native2dAnnotationsProps {
   labels: Native2dLabel[];
   imageUrl: string | null;
@@ -24,6 +29,15 @@ export function Native2dAnnotations({
   const size = useImageNaturalSize(imageUrl);
   const colorOf = useNative2dLabelColor();
 
+  if (process.env.NODE_ENV !== "production" && labels.length > 0 && !size) {
+    // eslint-disable-next-line no-console
+    console.debug(
+      "[native2d] have labels but no image size yet",
+      labels.length,
+      imageUrl,
+    );
+  }
+
   if (!size || labels.length === 0) return null;
 
   const { w, h } = size;
@@ -41,28 +55,60 @@ export function Native2dAnnotations({
         if (label._cls === "Detection") {
           const [x, y, bw, bh] = label.boundingBox;
           return (
-            <rect
-              key={`native-det-${label._id}`}
-              x={x * w}
-              y={y * h}
-              width={bw * w}
-              height={bh * h}
-              fill="none"
-              stroke={color}
-              strokeWidth={2}
-              vectorEffect="non-scaling-stroke"
-              opacity={opacity}
-            />
+            <g key={`native-det-${label._id}`} opacity={opacity}>
+              <rect
+                x={x * w}
+                y={y * h}
+                width={bw * w}
+                height={bh * h}
+                fill="none"
+                stroke={color}
+                strokeWidth={2}
+                vectorEffect="non-scaling-stroke"
+              />
+              {label.label && (
+                <text
+                  x={x * w}
+                  // Sits just above the box, dropping inside it near the top
+                  // edge so it can't be clipped off the image.
+                  y={Math.max(y * h - LABEL_TEXT_OFFSET, LABEL_FONT_SIZE)}
+                  fill={color}
+                  fontSize={LABEL_FONT_SIZE}
+                  // Keeps the caption readable regardless of the viewBox scale.
+                  style={{ paintOrder: "stroke" }}
+                  stroke="rgba(0, 0, 0, 0.65)"
+                  strokeWidth={3}
+                  strokeLinejoin="round"
+                >
+                  {label.label}
+                </text>
+              )}
+            </g>
           );
         }
 
+        const polylineData = buildPolylinePixelData(label, w, h);
+
         return (
-          <SvgPolylineProjection
-            key={`native-poly-${label._id}`}
-            data={buildPolylinePixelData(label, w, h)}
-            color={color}
-            opacity={opacity}
-          />
+          <g key={`native-poly-${label._id}`}>
+            {label.filled &&
+              polylineData.segments.map((segment, i) =>
+                segment.length > 2 ? (
+                  <polygon
+                    key={`fill-${i}`}
+                    points={segment.map((p) => `${p.u},${p.v}`).join(" ")}
+                    fill={color}
+                    opacity={opacity * FILL_OPACITY}
+                    stroke="none"
+                  />
+                ) : null,
+              )}
+            <SvgPolylineProjection
+              data={polylineData}
+              color={color}
+              opacity={opacity}
+            />
+          </g>
         );
       })}
     </OverlaySvg>

--- a/app/packages/looker-3d/src/annotation/native2d/Native2dAnnotations.tsx
+++ b/app/packages/looker-3d/src/annotation/native2d/Native2dAnnotations.tsx
@@ -29,15 +29,6 @@ export function Native2dAnnotations({
   const size = useImageNaturalSize(imageUrl);
   const colorOf = useNative2dLabelColor();
 
-  if (process.env.NODE_ENV !== "production" && labels.length > 0 && !size) {
-    // eslint-disable-next-line no-console
-    console.debug(
-      "[native2d] have labels but no image size yet",
-      labels.length,
-      imageUrl,
-    );
-  }
-
   if (!size || labels.length === 0) return null;
 
   const { w, h } = size;

--- a/app/packages/looker-3d/src/annotation/native2d/geometry.test.ts
+++ b/app/packages/looker-3d/src/annotation/native2d/geometry.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+import { buildPolylinePixelData } from "./geometry";
+import type { Native2dPolyline } from "./types";
+
+const W = 200;
+const H = 100;
+
+const polyline = (
+  points: [number, number][][],
+  overrides: Partial<Native2dPolyline> = {},
+): Native2dPolyline => ({
+  _id: "poly-1",
+  _cls: "Polyline",
+  path: "lanes",
+  points,
+  ...overrides,
+});
+
+describe("buildPolylinePixelData", () => {
+  it("scales normalized points by the image dimensions", () => {
+    const data = buildPolylinePixelData(
+      polyline([
+        [
+          [0, 0],
+          [0.5, 1],
+        ],
+      ]),
+      W,
+      H,
+    );
+
+    expect(data.segments[0]).toEqual([
+      { u: 0, v: 0, z: 0 },
+      { u: 100, v: 100, z: 0 },
+    ]);
+  });
+
+  it("emits one edge per consecutive pair", () => {
+    const data = buildPolylinePixelData(
+      polyline([
+        [
+          [0, 0],
+          [0.5, 0],
+          [1, 0],
+        ],
+      ]),
+      W,
+      H,
+    );
+    expect(data.edges).toHaveLength(2);
+    expect(data.edges[0]).toEqual({ x1: 0, y1: 0, x2: 100, y2: 0 });
+    expect(data.edges[1]).toEqual({ x1: 100, y1: 0, x2: 200, y2: 0 });
+  });
+
+  it("adds a closing edge back to the first point when closed", () => {
+    const open = buildPolylinePixelData(
+      polyline([
+        [
+          [0, 0],
+          [1, 0],
+          [1, 1],
+        ],
+      ]),
+      W,
+      H,
+    );
+    const closed = buildPolylinePixelData(
+      polyline(
+        [
+          [
+            [0, 0],
+            [1, 0],
+            [1, 1],
+          ],
+        ],
+        { closed: true },
+      ),
+      W,
+      H,
+    );
+
+    expect(open.edges).toHaveLength(2);
+    expect(closed.edges).toHaveLength(3);
+    // The extra edge runs last -> first.
+    expect(closed.edges[2]).toEqual({ x1: 200, y1: 100, x2: 0, y2: 0 });
+  });
+
+  it("does not close a segment with fewer than 3 points", () => {
+    // A 2-point "closed" polyline would otherwise draw the same edge twice.
+    const data = buildPolylinePixelData(
+      polyline(
+        [
+          [
+            [0, 0],
+            [1, 1],
+          ],
+        ],
+        { closed: true },
+      ),
+      W,
+      H,
+    );
+    expect(data.edges).toHaveLength(1);
+  });
+
+  it("keeps multiple segments separate and does not join them", () => {
+    const data = buildPolylinePixelData(
+      polyline([
+        [
+          [0, 0],
+          [0.5, 0],
+        ],
+        [
+          [0, 1],
+          [0.5, 1],
+        ],
+      ]),
+      W,
+      H,
+    );
+
+    expect(data.segments).toHaveLength(2);
+    // One edge per segment, and none bridging the two.
+    expect(data.edges).toHaveLength(2);
+    expect(data.vertices).toHaveLength(4);
+  });
+
+  it("skips empty and non-array segments", () => {
+    const data = buildPolylinePixelData(
+      polyline([
+        [],
+        undefined as unknown as [number, number][],
+        [
+          [0, 0],
+          [1, 1],
+        ],
+      ]),
+      W,
+      H,
+    );
+
+    expect(data.segments).toHaveLength(1);
+    expect(data.edges).toHaveLength(1);
+  });
+
+  it("returns every point as a vertex for the dot markers", () => {
+    const data = buildPolylinePixelData(
+      polyline([
+        [
+          [0, 0],
+          [0.5, 0.5],
+          [1, 1],
+        ],
+      ]),
+      W,
+      H,
+    );
+    expect(data.vertices).toHaveLength(3);
+    expect(data.vertices[1]).toEqual({ u: 100, v: 50, z: 0 });
+  });
+
+  it("produces no geometry for a polyline with no segments", () => {
+    const data = buildPolylinePixelData(polyline([]), W, H);
+    expect(data.edges).toEqual([]);
+    expect(data.vertices).toEqual([]);
+    expect(data.segments).toEqual([]);
+  });
+});

--- a/app/packages/looker-3d/src/annotation/native2d/geometry.ts
+++ b/app/packages/looker-3d/src/annotation/native2d/geometry.ts
@@ -5,6 +5,11 @@ import type {
 } from "../projection/types";
 import type { Native2dPolyline } from "./types";
 
+export interface Native2dPolylinePixelData extends PolylineProjectionData {
+  /** Per-segment pixel points, so a `filled` polyline can be drawn as polygons. */
+  segments: ProjectedCorner[][];
+}
+
 /**
  * Converts a stored 2D polyline (normalized [x, y] points) into the pixel-space
  * {@link PolylineProjectionData} consumed by `SvgPolylineProjection`.
@@ -17,21 +22,28 @@ export const buildPolylinePixelData = (
   polyline: Native2dPolyline,
   imgW: number,
   imgH: number,
-): PolylineProjectionData => {
+): Native2dPolylinePixelData => {
   const edges: ProjectedEdge[] = [];
   const vertices: (ProjectedCorner | null)[] = [];
+  const segments: ProjectedCorner[][] = [];
 
   for (const segment of polyline.points) {
     if (!Array.isArray(segment) || segment.length === 0) continue;
 
     const pts = segment.map(([x, y]) => ({ u: x * imgW, v: y * imgH, z: 0 }));
+    segments.push(pts);
 
     for (const p of pts) {
       vertices.push(p);
     }
 
     for (let i = 0; i < pts.length - 1; i++) {
-      edges.push({ x1: pts[i].u, y1: pts[i].v, x2: pts[i + 1].u, y2: pts[i + 1].v });
+      edges.push({
+        x1: pts[i].u,
+        y1: pts[i].v,
+        x2: pts[i + 1].u,
+        y2: pts[i + 1].v,
+      });
     }
 
     if (polyline.closed && pts.length > 2) {
@@ -41,5 +53,5 @@ export const buildPolylinePixelData = (
     }
   }
 
-  return { edges, vertices };
+  return { edges, vertices, segments };
 };

--- a/app/packages/looker-3d/src/annotation/native2d/geometry.ts
+++ b/app/packages/looker-3d/src/annotation/native2d/geometry.ts
@@ -1,0 +1,45 @@
+import type {
+  PolylineProjectionData,
+  ProjectedCorner,
+  ProjectedEdge,
+} from "../projection/types";
+import type { Native2dPolyline } from "./types";
+
+/**
+ * Converts a stored 2D polyline (normalized [x, y] points) into the pixel-space
+ * {@link PolylineProjectionData} consumed by `SvgPolylineProjection`.
+ *
+ * This is the non-frustum analog of `useProjectedPolyline`: the points are
+ * already in image space, so we simply scale the normalized coordinates by the
+ * image dimensions instead of projecting through the camera.
+ */
+export const buildPolylinePixelData = (
+  polyline: Native2dPolyline,
+  imgW: number,
+  imgH: number,
+): PolylineProjectionData => {
+  const edges: ProjectedEdge[] = [];
+  const vertices: (ProjectedCorner | null)[] = [];
+
+  for (const segment of polyline.points) {
+    if (!Array.isArray(segment) || segment.length === 0) continue;
+
+    const pts = segment.map(([x, y]) => ({ u: x * imgW, v: y * imgH, z: 0 }));
+
+    for (const p of pts) {
+      vertices.push(p);
+    }
+
+    for (let i = 0; i < pts.length - 1; i++) {
+      edges.push({ x1: pts[i].u, y1: pts[i].v, x2: pts[i + 1].u, y2: pts[i + 1].v });
+    }
+
+    if (polyline.closed && pts.length > 2) {
+      const last = pts[pts.length - 1];
+      const first = pts[0];
+      edges.push({ x1: last.u, y1: last.v, x2: first.u, y2: first.v });
+    }
+  }
+
+  return { edges, vertices };
+};

--- a/app/packages/looker-3d/src/annotation/native2d/parse.test.ts
+++ b/app/packages/looker-3d/src/annotation/native2d/parse.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest";
+import { extractNative2dLabels } from "./parse";
+import type { Native2dDetection, Native2dPolyline } from "./types";
+
+const detections = (items: Record<string, unknown>[]) => ({
+  _cls: "Detections",
+  detections: items,
+});
+
+const polylines = (items: Record<string, unknown>[]) => ({
+  _cls: "Polylines",
+  polylines: items,
+});
+
+const detection = (overrides: Record<string, unknown> = {}) => ({
+  _id: "det-1",
+  _cls: "Detection",
+  label: "car",
+  bounding_box: [0.1, 0.2, 0.3, 0.4],
+  ...overrides,
+});
+
+const polyline = (overrides: Record<string, unknown> = {}) => ({
+  _id: "poly-1",
+  _cls: "Polyline",
+  label: "lane",
+  points: [
+    [
+      [0, 0],
+      [1, 1],
+    ],
+  ],
+  ...overrides,
+});
+
+describe("extractNative2dLabels", () => {
+  it("returns nothing for missing slice data", () => {
+    expect(extractNative2dLabels(null)).toEqual([]);
+    expect(extractNative2dLabels(undefined)).toEqual([]);
+  });
+
+  it("discovers label fields from the payload's own _cls", () => {
+    // The whole point of payload-driven discovery: no schema path list is
+    // supplied, yet both fields are found.
+    const labels = extractNative2dLabels({
+      filepath: "/data/img.png",
+      ground_truth: detections([detection()]),
+      lanes: polylines([polyline()]),
+    });
+
+    expect(labels).toHaveLength(2);
+    expect(labels.map((l) => l.path).sort()).toEqual(["ground_truth", "lanes"]);
+  });
+
+  it("tags each label with the field path it came from", () => {
+    const [label] = extractNative2dLabels({
+      predictions: detections([detection()]),
+    });
+    // Coloring is by field, so the path has to survive.
+    expect(label.path).toBe("predictions");
+  });
+
+  it("flattens a Detections list", () => {
+    const labels = extractNative2dLabels({
+      gt: detections([
+        detection({ _id: "a" }),
+        detection({ _id: "b" }),
+        detection({ _id: "c" }),
+      ]),
+    });
+    expect(labels.map((l) => l._id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("handles a singular Detection field", () => {
+    const labels = extractNative2dLabels({ gt: detection({ _id: "solo" }) });
+    expect(labels).toHaveLength(1);
+    expect(labels[0]._id).toBe("solo");
+  });
+
+  it("handles Polylines and singular Polyline", () => {
+    const list = extractNative2dLabels({ a: polylines([polyline()]) });
+    const single = extractNative2dLabels({ b: polyline({ _id: "solo" }) });
+    expect(list).toHaveLength(1);
+    expect(single).toHaveLength(1);
+    expect(single[0]._cls).toBe("Polyline");
+  });
+
+  it("normalizes the bounding box into a 4-tuple", () => {
+    const [label] = extractNative2dLabels({
+      gt: detections([detection({ bounding_box: [0.1, 0.2, 0.3, 0.4, 0.5] })]),
+    });
+    // Extra trailing values are dropped rather than passed through.
+    expect((label as Native2dDetection).boundingBox).toEqual([
+      0.1, 0.2, 0.3, 0.4,
+    ]);
+  });
+
+  it("accepts extended-JSON ids as well as plain strings", () => {
+    // The group endpoint serializes nested ids as { $oid: ... } while
+    // top-level ids come back as plain strings.
+    const labels = extractNative2dLabels({
+      gt: detections([
+        detection({ _id: { $oid: "deadbeef" } }),
+        detection({ _id: "plain" }),
+      ]),
+    });
+    expect(labels.map((l) => l._id)).toEqual(["deadbeef", "plain"]);
+  });
+
+  it("falls back to `id` when `_id` is absent", () => {
+    const labels = extractNative2dLabels({
+      gt: detections([{ id: "from-id", bounding_box: [0, 0, 1, 1] }]),
+    });
+    expect(labels).toHaveLength(1);
+    expect(labels[0]._id).toBe("from-id");
+  });
+
+  it("drops labels with no usable id", () => {
+    const labels = extractNative2dLabels({
+      gt: detections([detection({ _id: undefined, id: undefined })]),
+    });
+    expect(labels).toEqual([]);
+  });
+
+  it("drops detections with a missing or short bounding box", () => {
+    const labels = extractNative2dLabels({
+      gt: detections([
+        detection({ _id: "no-bbox", bounding_box: undefined }),
+        detection({ _id: "short", bounding_box: [0.1, 0.2] }),
+        detection({ _id: "ok" }),
+      ]),
+    });
+    expect(labels.map((l) => l._id)).toEqual(["ok"]);
+  });
+
+  it("drops polylines with no points array", () => {
+    const labels = extractNative2dLabels({
+      a: polylines([polyline({ _id: "bad", points: undefined })]),
+    });
+    expect(labels).toEqual([]);
+  });
+
+  it("carries the polyline's closed/filled flags", () => {
+    const [label] = extractNative2dLabels({
+      a: polylines([polyline({ closed: true, filled: true })]),
+    });
+    expect((label as Native2dPolyline).closed).toBe(true);
+    expect((label as Native2dPolyline).filled).toBe(true);
+  });
+
+  it("skips filepath, id and underscore-prefixed keys", () => {
+    // Those aren't labels, and _cls on the sample itself must not be mistaken
+    // for a label field.
+    const labels = extractNative2dLabels({
+      _cls: "Sample",
+      _media_type: "image",
+      id: "sample-1",
+      filepath: "/data/img.png",
+      gt: detections([detection()]),
+    });
+    expect(labels).toHaveLength(1);
+    expect(labels[0].path).toBe("gt");
+  });
+
+  it("ignores fields that aren't label types", () => {
+    const labels = extractNative2dLabels({
+      metadata: { width: 100, height: 50, _cls: "ImageMetadata" },
+      tags: ["a", "b"],
+      confidence: 0.9,
+      segmentation: { _cls: "Segmentation", mask_path: "/m.png" },
+      gt: detections([detection()]),
+    });
+    expect(labels).toHaveLength(1);
+  });
+
+  it("honours an explicit path restriction when given", () => {
+    const labels = extractNative2dLabels(
+      {
+        wanted: detections([detection({ _id: "yes" })]),
+        ignored: detections([detection({ _id: "no" })]),
+      },
+      ["wanted"],
+    );
+    expect(labels.map((l) => l._id)).toEqual(["yes"]);
+  });
+
+  it("falls back to scanning everything when the restriction is empty", () => {
+    // An empty schema-derived list must not mean "no labels" — that was the
+    // bug that left the overlays blank.
+    const labels = extractNative2dLabels({ gt: detections([detection()]) }, []);
+    expect(labels).toHaveLength(1);
+  });
+});

--- a/app/packages/looker-3d/src/annotation/native2d/parse.ts
+++ b/app/packages/looker-3d/src/annotation/native2d/parse.ts
@@ -1,0 +1,103 @@
+import { DETECTION, DETECTIONS, POLYLINE, POLYLINES } from "@fiftyone/utilities";
+import type { Native2dLabel } from "./types";
+
+/**
+ * Extracts an ObjectId string from a serialized value. The REST group endpoint
+ * serializes nested ids as extended JSON (`{ $oid: "..." }`) while top-level
+ * ids are normalized to plain strings, so handle both.
+ */
+const oid = (value: unknown): string | undefined => {
+  if (typeof value === "string") return value;
+  if (value && typeof value === "object" && "$oid" in value) {
+    const raw = (value as { $oid?: unknown }).$oid;
+    return typeof raw === "string" ? raw : undefined;
+  }
+  return undefined;
+};
+
+const detectionFrom = (
+  raw: Record<string, any>,
+  path: string,
+): Native2dLabel | null => {
+  const _id = oid(raw?._id) ?? oid(raw?.id);
+  const bbox = raw?.bounding_box;
+  if (!_id || !Array.isArray(bbox) || bbox.length < 4) return null;
+  return {
+    _id,
+    _cls: "Detection",
+    path,
+    label: raw.label,
+    boundingBox: [bbox[0], bbox[1], bbox[2], bbox[3]],
+  };
+};
+
+const polylineFrom = (
+  raw: Record<string, any>,
+  path: string,
+): Native2dLabel | null => {
+  const _id = oid(raw?._id) ?? oid(raw?.id);
+  if (!_id || !Array.isArray(raw?.points)) return null;
+  return {
+    _id,
+    _cls: "Polyline",
+    path,
+    label: raw.label,
+    points: raw.points as [number, number][][],
+    closed: raw.closed,
+    filled: raw.filled,
+  };
+};
+
+/**
+ * Flattens the serialized 2D label fields of a single image-slice sample into a
+ * list of normalized {@link Native2dLabel}s ready for SVG rendering.
+ *
+ * @param sliceData - the serialized slice sample (field name -> value)
+ * @param labelPaths - the sample field paths that hold Detection(s)/Polyline(s)
+ */
+export const extractNative2dLabels = (
+  sliceData: Record<string, any> | undefined | null,
+  labelPaths: string[],
+): Native2dLabel[] => {
+  if (!sliceData) return [];
+
+  const out: Native2dLabel[] = [];
+
+  for (const path of labelPaths) {
+    const value = sliceData[path];
+    if (!value || typeof value !== "object") continue;
+
+    switch (value._cls) {
+      case DETECTIONS:
+        if (Array.isArray(value.detections)) {
+          for (const d of value.detections) {
+            const label = detectionFrom(d, path);
+            if (label) out.push(label);
+          }
+        }
+        break;
+      case DETECTION: {
+        const label = detectionFrom(value, path);
+        if (label) out.push(label);
+        break;
+      }
+      case POLYLINES:
+        if (Array.isArray(value.polylines)) {
+          for (const p of value.polylines) {
+            const label = polylineFrom(p, path);
+            if (label) out.push(label);
+          }
+        }
+        break;
+      case POLYLINE: {
+        const label = polylineFrom(value, path);
+        if (label) out.push(label);
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  return out;
+};

--- a/app/packages/looker-3d/src/annotation/native2d/parse.ts
+++ b/app/packages/looker-3d/src/annotation/native2d/parse.ts
@@ -1,4 +1,9 @@
-import { DETECTION, DETECTIONS, POLYLINE, POLYLINES } from "@fiftyone/utilities";
+import {
+  DETECTION,
+  DETECTIONS,
+  POLYLINE,
+  POLYLINES,
+} from "@fiftyone/utilities";
 import type { Native2dLabel } from "./types";
 
 /**
@@ -52,18 +57,30 @@ const polylineFrom = (
  * Flattens the serialized 2D label fields of a single image-slice sample into a
  * list of normalized {@link Native2dLabel}s ready for SVG rendering.
  *
+ * Discovery is driven by the payload's own `_cls` tags rather than by a list of
+ * schema paths. The schema route was fragile here: a field that only exists on
+ * the image slices doesn't necessarily appear in the group's active-slice sample
+ * schema, so schema-derived paths came back empty and nothing was ever parsed.
+ * The response already says what each field is, so trust that.
+ *
  * @param sliceData - the serialized slice sample (field name -> value)
- * @param labelPaths - the sample field paths that hold Detection(s)/Polyline(s)
+ * @param labelPaths - optional restriction to specific field paths; when
+ *   omitted every top-level field is considered.
  */
 export const extractNative2dLabels = (
   sliceData: Record<string, any> | undefined | null,
-  labelPaths: string[],
+  labelPaths?: string[],
 ): Native2dLabel[] => {
   if (!sliceData) return [];
 
+  const paths =
+    labelPaths && labelPaths.length > 0 ? labelPaths : Object.keys(sliceData);
+
   const out: Native2dLabel[] = [];
 
-  for (const path of labelPaths) {
+  for (const path of paths) {
+    if (path.startsWith("_") || path === "filepath" || path === "id") continue;
+
     const value = sliceData[path];
     if (!value || typeof value !== "object") continue;
 

--- a/app/packages/looker-3d/src/annotation/native2d/types.ts
+++ b/app/packages/looker-3d/src/annotation/native2d/types.ts
@@ -1,0 +1,31 @@
+/**
+ * Types for stored 2D labels rendered on Annotate-mode camera slices.
+ *
+ * These are the image-native `Detection`/`Polyline` labels that live on each
+ * image slice sample (already in normalized image coordinates), as opposed to
+ * the 3D working-doc labels that are projected through the camera frustum.
+ */
+
+export interface Native2dDetection {
+  _id: string;
+  _cls: "Detection";
+  /** Sample field path the label came from (used for color-by-field). */
+  path: string;
+  label?: string;
+  /** Normalized [top-left-x, top-left-y, width, height]. */
+  boundingBox: [number, number, number, number];
+}
+
+export interface Native2dPolyline {
+  _id: string;
+  _cls: "Polyline";
+  /** Sample field path the label came from (used for color-by-field). */
+  path: string;
+  label?: string;
+  /** Normalized segments, each a list of [x, y] points. */
+  points: [number, number][][];
+  closed?: boolean;
+  filled?: boolean;
+}
+
+export type Native2dLabel = Native2dDetection | Native2dPolyline;

--- a/app/packages/looker-3d/src/annotation/native2d/useImageNaturalSize.test.ts
+++ b/app/packages/looker-3d/src/annotation/native2d/useImageNaturalSize.test.ts
@@ -1,0 +1,92 @@
+import { act, renderHook } from "@testing-library/react-hooks";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useImageNaturalSize } from "./useImageNaturalSize";
+
+class FakeImage {
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  complete = false;
+  naturalWidth = 0;
+  naturalHeight = 0;
+  private _src = "";
+
+  get src() {
+    return this._src;
+  }
+
+  set src(value: string) {
+    this._src = value;
+  }
+}
+
+let instances: FakeImage[] = [];
+const originalImage = global.Image;
+
+beforeEach(() => {
+  instances = [];
+  // @ts-expect-error -- test double, not a full Image implementation
+  global.Image = function () {
+    const img = new FakeImage();
+    instances.push(img);
+    return img;
+  };
+});
+
+afterEach(() => {
+  global.Image = originalImage;
+});
+
+const resolveLoad = (index: number, w: number, h: number) => {
+  const img = instances[index];
+  img.naturalWidth = w;
+  img.naturalHeight = h;
+  act(() => {
+    img.onload?.();
+  });
+};
+
+describe("useImageNaturalSize", () => {
+  it("resolves the natural size once the image loads", () => {
+    const { result } = renderHook(() => useImageNaturalSize("a.jpg"));
+
+    expect(result.current).toBeNull();
+
+    resolveLoad(0, 640, 480);
+
+    expect(result.current).toEqual({ w: 640, h: 480 });
+  });
+
+  it("clears the previous size as soon as the url changes, before the new image loads", () => {
+    const { result, rerender } = renderHook(
+      ({ url }) => useImageNaturalSize(url),
+      { initialProps: { url: "a.jpg" } },
+    );
+
+    resolveLoad(0, 640, 480);
+    expect(result.current).toEqual({ w: 640, h: 480 });
+
+    // New url; the second image hasn't fired onload yet.
+    rerender({ url: "b.jpg" });
+
+    // Regression: the stale size from "a.jpg" must not leak into "b.jpg"'s
+    // dimensions while the new image is still loading.
+    expect(result.current).toBeNull();
+
+    resolveLoad(1, 100, 200);
+    expect(result.current).toEqual({ w: 100, h: 200 });
+  });
+
+  it("warns and leaves size unset on a failed load", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { result } = renderHook(() => useImageNaturalSize("broken.jpg"));
+
+    act(() => {
+      instances[0].onerror?.();
+    });
+
+    expect(result.current).toBeNull();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("broken.jpg"));
+
+    warn.mockRestore();
+  });
+});

--- a/app/packages/looker-3d/src/annotation/native2d/useImageNaturalSize.ts
+++ b/app/packages/looker-3d/src/annotation/native2d/useImageNaturalSize.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from "react";
+
+export interface ImageSize {
+  w: number;
+  h: number;
+}
+
+/**
+ * Resolves the natural (pixel) dimensions of an image URL. Used to size the 2D
+ * overlay's SVG viewBox so normalized label coordinates map to the same
+ * `object-fit: contain` box the <img> is displayed in.
+ *
+ * The browser caches the decoded image (the slice <img> loads the same URL), so
+ * this is effectively free after the first paint.
+ */
+export const useImageNaturalSize = (url: string | null): ImageSize | null => {
+  const [size, setSize] = useState<ImageSize | null>(null);
+
+  useEffect(() => {
+    if (!url) {
+      setSize(null);
+      return undefined;
+    }
+
+    let cancelled = false;
+    const img = new Image();
+
+    const apply = () => {
+      if (!cancelled && img.naturalWidth && img.naturalHeight) {
+        setSize({ w: img.naturalWidth, h: img.naturalHeight });
+      }
+    };
+
+    img.onload = apply;
+    img.src = url;
+
+    // Already cached/decoded.
+    if (img.complete) {
+      apply();
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, [url]);
+
+  return size;
+};

--- a/app/packages/looker-3d/src/annotation/native2d/useImageNaturalSize.ts
+++ b/app/packages/looker-3d/src/annotation/native2d/useImageNaturalSize.ts
@@ -32,6 +32,11 @@ export const useImageNaturalSize = (url: string | null): ImageSize | null => {
     };
 
     img.onload = apply;
+    img.onerror = () => {
+      if (!cancelled) {
+        console.warn(`Failed to load image for natural-size lookup: ${url}`);
+      }
+    };
     img.src = url;
 
     // Already cached/decoded.

--- a/app/packages/looker-3d/src/annotation/native2d/useImageNaturalSize.ts
+++ b/app/packages/looker-3d/src/annotation/native2d/useImageNaturalSize.ts
@@ -23,6 +23,7 @@ export const useImageNaturalSize = (url: string | null): ImageSize | null => {
     }
 
     let cancelled = false;
+    setSize(null);
     const img = new Image();
 
     const apply = () => {

--- a/app/packages/looker-3d/src/annotation/native2d/useNative2dLabelColor.ts
+++ b/app/packages/looker-3d/src/annotation/native2d/useNative2dLabelColor.ts
@@ -1,4 +1,8 @@
-import { getLabelColor } from "@fiftyone/looker/src/overlays/util";
+import {
+  getLabelColor,
+  type CustomizeColor,
+  type LabelTagColor,
+} from "@fiftyone/looker";
 import * as fos from "@fiftyone/state";
 import { useCallback } from "react";
 import { useRecoilValue } from "recoil";
@@ -19,13 +23,16 @@ export const useNative2dLabelColor = (): ((label: Native2dLabel) => string) => {
         coloring,
         path: label.path,
         // Minimal label shape: color-by-field uses `path`, color-by-value uses
-        // `label`. We don't carry tags into the side-slice overlay.
-        label: { id: label._id, label: label.label, tags: [] },
+        // `label`. We don't carry tags into the side-slice overlay. `id` (not
+        // just `_id`) is set too since instance-coloring's fallback keys off it.
+        label: { _id: label._id, id: label._id, label: label.label, tags: [] },
         isTagged: false,
-        labelTagColors: colorScheme.labelTags,
-        customizeColorSetting: colorScheme.fields ?? [],
+        // GraphQL input types (readonly arrays, nullable fields) vs. the mutable
+        // shapes `getLabelColor` expects -- same fields, same values at runtime.
+        labelTagColors: colorScheme.labelTags as LabelTagColor,
+        customizeColorSetting: (colorScheme.fields ?? []) as CustomizeColor[],
         embeddedDocType: label._cls,
-      } as Parameters<typeof getLabelColor>[0]),
+      }),
     [coloring, colorScheme],
   );
 };

--- a/app/packages/looker-3d/src/annotation/native2d/useNative2dLabelColor.ts
+++ b/app/packages/looker-3d/src/annotation/native2d/useNative2dLabelColor.ts
@@ -1,0 +1,31 @@
+import { getLabelColor } from "@fiftyone/looker/src/overlays/util";
+import * as fos from "@fiftyone/state";
+import { useCallback } from "react";
+import { useRecoilValue } from "recoil";
+import type { Native2dLabel } from "./types";
+
+/**
+ * Returns a resolver that colors a stored 2D label using the app's color scheme
+ * (color-by-field / value / instance), matching how the same labels are colored
+ * in Explore mode.
+ */
+export const useNative2dLabelColor = (): ((label: Native2dLabel) => string) => {
+  const coloring = useRecoilValue(fos.coloring);
+  const colorScheme = useRecoilValue(fos.colorScheme);
+
+  return useCallback(
+    (label: Native2dLabel): string =>
+      getLabelColor({
+        coloring,
+        path: label.path,
+        // Minimal label shape: color-by-field uses `path`, color-by-value uses
+        // `label`. We don't carry tags into the side-slice overlay.
+        label: { id: label._id, label: label.label, tags: [] },
+        isTagged: false,
+        labelTagColors: colorScheme.labelTags,
+        customizeColorSetting: colorScheme.fields ?? [],
+        embeddedDocType: label._cls,
+      } as Parameters<typeof getLabelColor>[0]),
+    [coloring, colorScheme],
+  );
+};

--- a/app/packages/looker-3d/src/annotation/native2d/useVisibleNative2dLabels.ts
+++ b/app/packages/looker-3d/src/annotation/native2d/useVisibleNative2dLabels.ts
@@ -1,0 +1,28 @@
+import * as fos from "@fiftyone/state";
+import { useMemo } from "react";
+import { useRecoilValue } from "recoil";
+import type { Native2dLabel } from "./types";
+
+/**
+ * Filters stored 2D labels down to the ones the sidebar would show.
+ *
+ * Visibility follows the sidebar, but only for paths the sidebar actually
+ * knows about. A field that lives on the image slices without being in the
+ * main (point-cloud slice) schema never appears in `activeFields`, so keying
+ * purely off membership there hid every such label -- which is why none of
+ * these were showing up at all.
+ */
+export const useVisibleNative2dLabels = (
+  labels: Native2dLabel[],
+): Native2dLabel[] => {
+  const activeFields = useRecoilValue(fos.activeFields({ modal: true }));
+  const knownLabelFields = useRecoilValue(
+    fos.labelFields({ space: fos.State.SPACE.SAMPLE }),
+  );
+
+  return useMemo(() => {
+    const active = new Set(activeFields);
+    const known = new Set(knownLabelFields);
+    return labels.filter((l) => !known.has(l.path) || active.has(l.path));
+  }, [labels, activeFields, knownLabelFields]);
+};

--- a/app/packages/looker-3d/src/annotation/useImageSlicesIfAvailable.ts
+++ b/app/packages/looker-3d/src/annotation/useImageSlicesIfAvailable.ts
@@ -1,11 +1,22 @@
 import {
   ModalSample,
+  State,
   datasetId,
+  fieldPaths,
   getSampleSrc as resolveUrl,
 } from "@fiftyone/state";
-import { getFetchFunction } from "@fiftyone/utilities";
-import { useCallback, useEffect, useState } from "react";
+import {
+  DETECTIONS_FIELD,
+  DETECTION_FIELD,
+  EMBEDDED_DOCUMENT_FIELD,
+  POLYLINES_FIELD,
+  POLYLINE_FIELD,
+  getFetchFunction,
+} from "@fiftyone/utilities";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRecoilValue } from "recoil";
+import { extractNative2dLabels } from "./native2d/parse";
+import type { Native2dLabel } from "./native2d/types";
 
 type GroupResponse = {
   group: Record<string, any>;
@@ -27,12 +38,32 @@ export const useImageSlicesIfAvailable = (
 ): {
   imageSlices: string[];
   resolveUrlForImageSlice: (sliceName: string) => string | null;
+  resolveLabelsForImageSlice: (sliceName: string) => Native2dLabel[];
   isLoadingImageSlices: boolean;
 } => {
   const [isLoadingImageSlices, setIsLoadingImageSlices] = useState(false);
   const [imageSlices, setImageSlices] = useState<string[]>([]);
   const [sliceUrls, setSliceUrls] = useState<Record<string, string>>({});
+  const [sliceLabels, setSliceLabels] = useState<
+    Record<string, Native2dLabel[]>
+  >({});
   const dataset = useRecoilValue(datasetId);
+
+  // Sample-level Detection(s)/Polyline(s) fields — the 2D labels we render on
+  // the camera slices. Excludes heavier label types (masks, heatmaps).
+  const labelFieldPaths = useRecoilValue(
+    fieldPaths({
+      space: State.SPACE.SAMPLE,
+      ftype: EMBEDDED_DOCUMENT_FIELD,
+      embeddedDocType: [
+        DETECTION_FIELD,
+        DETECTIONS_FIELD,
+        POLYLINE_FIELD,
+        POLYLINES_FIELD,
+      ],
+    })
+  );
+  const labelFieldsKey = labelFieldPaths.join(",");
 
   const hasGroup = Boolean(sample?.sample?.group?._id);
   const groupId = sample?.sample?.group?._id;
@@ -42,6 +73,7 @@ export const useImageSlicesIfAvailable = (
       setIsLoadingImageSlices(false);
       setImageSlices([]);
       setSliceUrls({});
+      setSliceLabels({});
       return undefined;
     }
 
@@ -52,7 +84,12 @@ export const useImageSlicesIfAvailable = (
         setIsLoadingImageSlices(true);
 
         const fetchFunction = getFetchFunction({ cache: true });
-        const path = `/dataset/${dataset}/groups/${groupId}?fields=filepath&resolve_urls=true&media_type=image`;
+        // Request filepath (for the image URL) plus the 2D label fields so we
+        // can draw the slice's own Detection(s)/Polyline(s) overlays.
+        const fields = ["filepath", ...labelFieldPaths].join(",");
+        const path = `/dataset/${dataset}/groups/${groupId}?fields=${encodeURIComponent(
+          fields
+        )}&resolve_urls=true&media_type=image`;
 
         const response = await fetchFunction("GET", path);
 
@@ -63,11 +100,13 @@ export const useImageSlicesIfAvailable = (
         if (!data.group) {
           setImageSlices([]);
           setSliceUrls({});
+          setSliceLabels({});
           return;
         }
 
         const imageSliceNames: string[] = [];
         const urls: Record<string, string> = {};
+        const labels: Record<string, Native2dLabel[]> = {};
 
         for (const [sliceName, sliceData] of Object.entries(data.group)) {
           const filepath = sliceData.filepath;
@@ -83,15 +122,19 @@ export const useImageSlicesIfAvailable = (
             // Fallback to filepath if URL not in response
             urls[sliceName] = resolveUrl(filepath);
           }
+
+          labels[sliceName] = extractNative2dLabels(sliceData, labelFieldPaths);
         }
 
         setImageSlices(imageSliceNames);
         setSliceUrls(urls);
+        setSliceLabels(labels);
       } catch (error) {
         if (!cancelled) {
           console.error("Failed to fetch image slices:", error);
           setImageSlices([]);
           setSliceUrls({});
+          setSliceLabels({});
         }
       } finally {
         if (!cancelled) {
@@ -105,7 +148,8 @@ export const useImageSlicesIfAvailable = (
     return () => {
       cancelled = true;
     };
-  }, [hasGroup, groupId, dataset]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hasGroup, groupId, dataset, labelFieldsKey]);
 
   const resolveUrlForImageSlice = useCallback(
     (sliceName: string): string | null => {
@@ -114,10 +158,19 @@ export const useImageSlicesIfAvailable = (
     [sliceUrls],
   );
 
+  const emptyLabels = useMemo<Native2dLabel[]>(() => [], []);
+  const resolveLabelsForImageSlice = useCallback(
+    (sliceName: string): Native2dLabel[] => {
+      return sliceLabels[sliceName] ?? emptyLabels;
+    },
+    [sliceLabels, emptyLabels],
+  );
+
   if (!hasGroup) {
     return {
       imageSlices: [],
       resolveUrlForImageSlice: () => null,
+      resolveLabelsForImageSlice: () => emptyLabels,
       isLoadingImageSlices: false,
     };
   }
@@ -125,6 +178,7 @@ export const useImageSlicesIfAvailable = (
   return {
     imageSlices,
     resolveUrlForImageSlice,
+    resolveLabelsForImageSlice,
     isLoadingImageSlices,
   };
 };

--- a/app/packages/looker-3d/src/annotation/useImageSlicesIfAvailable.ts
+++ b/app/packages/looker-3d/src/annotation/useImageSlicesIfAvailable.ts
@@ -124,7 +124,6 @@ export const useImageSlicesIfAvailable = (
     return () => {
       cancelled = true;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hasGroup, groupId, dataset]);
 
   const resolveUrlForImageSlice = useCallback(

--- a/app/packages/looker-3d/src/annotation/useImageSlicesIfAvailable.ts
+++ b/app/packages/looker-3d/src/annotation/useImageSlicesIfAvailable.ts
@@ -1,18 +1,9 @@
 import {
   ModalSample,
-  State,
   datasetId,
-  fieldPaths,
   getSampleSrc as resolveUrl,
 } from "@fiftyone/state";
-import {
-  DETECTIONS_FIELD,
-  DETECTION_FIELD,
-  EMBEDDED_DOCUMENT_FIELD,
-  POLYLINES_FIELD,
-  POLYLINE_FIELD,
-  getFetchFunction,
-} from "@fiftyone/utilities";
+import { getFetchFunction } from "@fiftyone/utilities";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRecoilValue } from "recoil";
 import { extractNative2dLabels } from "./native2d/parse";
@@ -48,22 +39,6 @@ export const useImageSlicesIfAvailable = (
     Record<string, Native2dLabel[]>
   >({});
   const dataset = useRecoilValue(datasetId);
-
-  // Sample-level Detection(s)/Polyline(s) fields — the 2D labels we render on
-  // the camera slices. Excludes heavier label types (masks, heatmaps).
-  const labelFieldPaths = useRecoilValue(
-    fieldPaths({
-      space: State.SPACE.SAMPLE,
-      ftype: EMBEDDED_DOCUMENT_FIELD,
-      embeddedDocType: [
-        DETECTION_FIELD,
-        DETECTIONS_FIELD,
-        POLYLINE_FIELD,
-        POLYLINES_FIELD,
-      ],
-    }),
-  );
-  const labelFieldsKey = labelFieldPaths.join(",");
 
   const hasGroup = Boolean(sample?.sample?.group?._id);
   const groupId = sample?.sample?.group?._id;
@@ -127,22 +102,6 @@ export const useImageSlicesIfAvailable = (
           labels[sliceName] = extractNative2dLabels(sliceData);
         }
 
-        if (process.env.NODE_ENV !== "production") {
-          // eslint-disable-next-line no-console
-          console.debug("[native2d] fetched slices", {
-            schemaDerivedLabelFields: labelFieldPaths,
-            sliceFieldKeys: Object.fromEntries(
-              Object.entries(data.group).map(([k, v]) => [
-                k,
-                Object.keys((v as Record<string, unknown>) ?? {}),
-              ]),
-            ),
-            perSliceLabelCounts: Object.fromEntries(
-              Object.entries(labels).map(([k, v]) => [k, v.length]),
-            ),
-          });
-        }
-
         setImageSlices(imageSliceNames);
         setSliceUrls(urls);
         setSliceLabels(labels);
@@ -166,7 +125,7 @@ export const useImageSlicesIfAvailable = (
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hasGroup, groupId, dataset, labelFieldsKey]);
+  }, [hasGroup, groupId, dataset]);
 
   const resolveUrlForImageSlice = useCallback(
     (sliceName: string): string | null => {

--- a/app/packages/looker-3d/src/annotation/useImageSlicesIfAvailable.ts
+++ b/app/packages/looker-3d/src/annotation/useImageSlicesIfAvailable.ts
@@ -61,7 +61,7 @@ export const useImageSlicesIfAvailable = (
         POLYLINE_FIELD,
         POLYLINES_FIELD,
       ],
-    })
+    }),
   );
   const labelFieldsKey = labelFieldPaths.join(",");
 
@@ -84,12 +84,13 @@ export const useImageSlicesIfAvailable = (
         setIsLoadingImageSlices(true);
 
         const fetchFunction = getFetchFunction({ cache: true });
-        // Request filepath (for the image URL) plus the 2D label fields so we
-        // can draw the slice's own Detection(s)/Polyline(s) overlays.
-        const fields = ["filepath", ...labelFieldPaths].join(",");
-        const path = `/dataset/${dataset}/groups/${groupId}?fields=${encodeURIComponent(
-          fields
-        )}&resolve_urls=true&media_type=image`;
+        // Deliberately unrestricted: `fields=` needs schema-derived paths, and a
+        // label field that lives only on the image slices may be absent from the
+        // group's active-slice schema — which left us requesting nothing but
+        // `filepath` and so finding no labels to draw. Slice docs are small, so
+        // take the whole sample and let the parse pick out label fields by
+        // their `_cls`.
+        const path = `/dataset/${dataset}/groups/${groupId}?resolve_urls=true&media_type=image`;
 
         const response = await fetchFunction("GET", path);
 
@@ -123,7 +124,23 @@ export const useImageSlicesIfAvailable = (
             urls[sliceName] = resolveUrl(filepath);
           }
 
-          labels[sliceName] = extractNative2dLabels(sliceData, labelFieldPaths);
+          labels[sliceName] = extractNative2dLabels(sliceData);
+        }
+
+        if (process.env.NODE_ENV !== "production") {
+          // eslint-disable-next-line no-console
+          console.debug("[native2d] fetched slices", {
+            schemaDerivedLabelFields: labelFieldPaths,
+            sliceFieldKeys: Object.fromEntries(
+              Object.entries(data.group).map(([k, v]) => [
+                k,
+                Object.keys((v as Record<string, unknown>) ?? {}),
+              ]),
+            ),
+            perSliceLabelCounts: Object.fromEntries(
+              Object.entries(labels).map(([k, v]) => [k, v.length]),
+            ),
+          });
         }
 
         setImageSlices(imageSliceNames);

--- a/app/packages/looker-3d/vite.config.ts
+++ b/app/packages/looker-3d/vite.config.ts
@@ -3,7 +3,13 @@ import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import { viteExternalsPlugin } from "vite-plugin-externals";
 
-const isPluginBuild = process.env.STANDALONE !== "true";
+// Vitest sets VITEST; the externals plugin must not apply under test. It
+// rewrites react / react-dom / recoil / @fiftyone/state to `window.*` globals
+// for the plugin bundle, which in a test run resolves to a shim that throws
+// "window is not defined" at import time — silently preventing every test file
+// that imports React or Recoil from loading at all.
+const isTest = process.env.VITEST === "true" || process.env.NODE_ENV === "test";
+const isPluginBuild = !isTest && process.env.STANDALONE !== "true";
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -35,4 +41,8 @@ export default defineConfig({
     exclude: ["react", "react-dom"],
   },
   publicDir: isPluginBuild ? null : "example_data",
+  test: {
+    // Component and hook tests render with React, so they need a DOM.
+    environment: "jsdom",
+  },
 });

--- a/app/packages/looker/src/index.ts
+++ b/app/packages/looker/src/index.ts
@@ -19,6 +19,7 @@ export type {
   ImageOptions,
   KeypointSkeleton,
   LabelData,
+  LabelTagColor,
   Point,
   Sample,
   VideoConfig,


### PR DESCRIPTION
## 🔗 Related Issues

[FOEPD-3965]

## 📋 What changes are proposed in this pull request?

The image slice panels in the 3D annotate view only drew **projected 3D cuboids**. This adds each slice's own stored 2D labels — the image-native `Detection`/`Polyline` labels that live on the camera slice samples.

They're drawn into the **same `OverlaySvg`** as the projected-3D layer, reusing `SvgPolylineProjection` and `resolveVisualProps`. The key difference is that these labels are already in normalized image space, so they scale by the image's natural size (`useImageNaturalSize`) rather than going through frustum projection — `buildPolylinePixelData` is the non-frustum analog of `useProjectedPolyline`. Colors come from `getLabelColor` so they match Explore mode.

`useImageSlicesIfAvailable` gains `resolveLabelsForImageSlice`, and a `native2d/` module handles parsing and geometry.

### Why the labels weren't appearing at all

Worth recording, since the fix is the interesting part of this PR.

The fetch originally restricted the group request with `fields=filepath,<schema-derived label paths>`, where the paths came from `fieldPaths({ space: SAMPLE, embeddedDocType: [Detection, Detections, Polyline, Polylines] })`.

That reads the **active slice's** sample schema — the point-cloud slice. A label field that lives only on the *image* slices isn't necessarily in it, so the path list came back empty, the request asked for `filepath` and nothing else, and there were never any labels in the payload to parse. Two separate filters then keyed off those same absent paths, so even a lucky payload would have been dropped.

The tell was that the image itself displayed: its URL comes from the very same response, so the fetch, group id and slice keys were all fine — only the label fields were missing from it.

Two changes:

1. **The fetch is unrestricted.** Slice documents are small, and the response then actually contains the label fields.
2. **Parsing discovers labels from the payload's own `_cls`** rather than from a schema path list. The response already says what each field is, so `Detections`/`Detection`/`Polylines`/`Polyline` are picked out by tag, skipping `_`-prefixed keys, `filepath` and `id`. The field `path` comes from the actual key, so color-by-field still works.

Sidebar filtering was also relaxed: a label is hidden only if its path *is* a known sidebar label field and is toggled off. Paths the sidebar doesn't know about always draw, rather than being silently dropped.

### Also in here

- The `[native2d]` console diagnostics used to track the above down are removed.
- The schema-derived label-field lookup is dropped from `useImageSlicesIfAvailable`. Once the fetch stopped restricting `fields=`, those paths only fed an effect dependency — so the hook held a recoil subscription and refetched the whole group whenever the dataset's label fields changed, for nothing.
- Carries the `vite.config.ts` test-environment fix, without which this PR's tests wouldn't execute. Same patch as on #8124; identical, so whichever lands first the other merges cleanly.

### Known limitations

- **Display only.** These overlays aren't selectable or hoverable, unlike the projected cuboids.
- **Slice-only fields can't be toggled off**, since they never appear in `activeFields`. That's the trade that makes them visible at all; full sidebar sync would need the sidebar to know about image-slice fields.
- Detections draw a box and label text; masks and heatmaps are deliberately out of scope.

## 🧪 How is this patch tested? If it is not, please explain why.

524 unit tests pass in the package. New:

- **`native2d/parse.test.ts` (17)** — payload-driven `_cls` discovery with no path list, all four label shapes, `$oid` vs plain-string ids, `id` fallback, rejection of labels with no id or a short bounding box, skipping `filepath`/`id`/underscore keys and non-label fields, honouring an explicit path restriction, and that an **empty** restriction falls back to scanning rather than matching nothing — the exact failure mode that left the overlays blank.
- **`native2d/geometry.test.ts` (8)** — normalized-to-pixel scaling, one edge per consecutive pair, the closing edge only when a segment has 3+ points, segment isolation (no bridging edges), skipping empty/non-array segments, and vertex emission.

Those two pure modules are where the logic lives; the rendering components are thin. Manually verified against a grouped dataset with detections on the camera slices: they appear on the slice panels, correctly scaled and colored.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes.

The 3D annotate view's camera slice panels now show each slice's own stored 2D detections and polylines, alongside the projected 3D labels.

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [x] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other

[FOEPD-3965]: https://voxel51.atlassian.net/browse/FOEPD-3965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native 2D annotation overlays to image-slice views.
  * Displays detection boxes and polylines, including labels, colors, filled regions, and closed shapes.
  * Automatically filters annotations based on fields enabled for the current view.
  * Scales annotations accurately to each image’s natural dimensions.

* **Tests**
  * Added coverage for annotation parsing, geometry conversion, image loading, and annotation rendering support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3599
<!-- enterprise-sync-pr:end -->