### PR TITLE
fix(app): handle null range bounds in keypoint point filters

### DIFF
--- a/app/packages/state/src/recoil/skeletonFilter.ts
+++ b/app/packages/state/src/recoil/skeletonFilter.ts
@@ -2,7 +2,7 @@ import { Point } from "@fiftyone/looker";
 import { selectorFamily } from "recoil";
 import { filters, modalFilters } from "./filters";
 import { BooleanFilter } from "./pathFilters/boolean";
-import { NumericFilter } from "./pathFilters/numeric";
+import { helperFunction, NumericFilter } from "./pathFilters/numeric";
 import { StringFilter } from "./pathFilters/string";
 import { expandPath } from "./schema";
 
@@ -92,10 +92,13 @@ export default selectorFamily<(path: string, value: Point) => boolean, boolean>(
                 }
               }
 
-              const includes =
-                value[key] >= numFilter.range[0] &&
-                value[key] <= numFilter.range[1];
-              const r = numFilter.exclude ? !includes : includes;
+              const [start, end] = numFilter.range ?? [null, null];
+              const r = helperFunction(
+                value[key] as number,
+                numFilter.exclude,
+                start,
+                end,
+              );
 
               if (!r) {
                 result = false;


### PR DESCRIPTION
## 🔗 Related Issues

Fixes #8152

## 📋 What changes are proposed in this pull request?

Keypoint per-point numeric filters (e.g. `confidence`) ignored null range ends. The sidebar range slider stores `null` when a thumb is on a field bound, meaning “no constraint on that side.” `skeletonFilter` used raw `>=` / `<=` against `range[0]` / `range[1]`, so `null` coerced to `0` in JS and incorrectly rejected valid points (e.g. `[0.2, null]` → `value <= 0`).

This PR reuses the existing `helperFunction` from `pathFilters/numeric.ts` in `skeletonFilter` so keypoint point filters treat null bounds the same way as other numeric sidebar filters.

## 🧪 How is this patch tested? If it is not, please explain why.

Manual App verification:

1. Dataset with one `Keypoints` label, point confidences `[0.1, 0.3, 0.5, 0.7]`.
2. Filter `keypoints.confidence`: min ≈ `0.2`, max left at bound → **3 points** visible (`0.3`, `0.5`, `0.7`).
3. Filter max ≈ `0.4`, min at bound → **2 points** visible (`0.1`, `0.3`).
4. Confirmed both ends set to concrete values still works.

Unit tests for `skeletonFilter` were not present; happy to add a focused test around null-bound range checks if maintainers want that in this PR.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

Fixed App filtering of keypoint list attributes (such as `confidence`) when only one end of the range slider is constrained, so points are no longer incorrectly hidden.

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other
