### PR TITLE
fix(app): scale keypoint hit radius for large images

### DIFF
--- a/app/packages/looker/src/overlays/keypoint.ts
+++ b/app/packages/looker/src/overlays/keypoint.ts
@@ -11,7 +11,12 @@ import {
   NONFINITE,
   Point,
 } from "../state";
-import { distance, distanceFromLineSegment, multiply } from "../util";
+import {
+  distance,
+  distanceFromLineSegment,
+  getRenderedScale,
+  multiply,
+} from "../util";
 import { CONTAINS, CoordinateOverlay, PointInfo, RegularLabel } from "./base";
 import { resolveLabelSelectionVisuals, t } from "./util";
 import { isHoveringParticularLabelWithInstanceConfig } from "@fiftyone/state/src/jotai";
@@ -34,7 +39,7 @@ export default class KeypointOverlay<
 
     const result = this.getDistanceAndMaybePoint(state);
 
-    if (result && result[0] <= state.pointRadius) {
+    if (result && result[0] <= this.getHitRadius(state)) {
       return CONTAINS.BORDER;
     }
     return CONTAINS.NONE;
@@ -133,16 +138,33 @@ export default class KeypointOverlay<
     return getKeypointPoints([this.label]);
   }
 
+  /**
+   * Hit radius in image-pixel space. `pointRadius` is sized for canvas/window
+   * coords (constant on-screen size); divide by the media fit scale so large
+   * images keep hover/click targets matching the drawn dots.
+   */
+  private getHitRadius(state: Readonly<State>): number {
+    const pointRadius = this.isSelected(state)
+      ? state.pointRadius * 2
+      : state.pointRadius;
+    return (
+      pointRadius /
+      getRenderedScale(
+        [state.windowBBox[2], state.windowBBox[3]],
+        state.dimensions,
+      )
+    );
+  }
+
   private getDistanceAndMaybePoint(
     state: Readonly<State>,
   ): [number, number | null] | null {
     const distances: [number, number][] = [];
-    let {
+    const {
       dimensions,
-      pointRadius,
       pixelCoordinates: [x, y],
     } = state;
-    pointRadius = this.isSelected(state) ? pointRadius * 2 : pointRadius;
+    const hitRadius = this.getHitRadius(state);
 
     const skeleton = getSkeleton(this.field, state);
     const points = this.getFilteredPoints(state, skeleton);
@@ -158,7 +180,7 @@ export default class KeypointOverlay<
         y,
         ...(multiply(dimensions, point) as [number, number]),
       );
-      if (d <= pointRadius * TOLERANCE) {
+      if (d <= hitRadius * TOLERANCE) {
         distances.push([0, i]);
       } else {
         distances.push([d, i]);


### PR DESCRIPTION
## 🔗 Related Issues

Fixes #8154

## 📋 What changes are proposed in this pull request?

Keypoint hover/click hit-testing mixed coordinate spaces: mouse distance was computed in **image pixels**, but the threshold used `state.pointRadius` (canvas/window units sized for on-screen drawing). On large images fitted into a smaller viewport, that made hit targets much smaller than the drawn dots.

This PR adds `getHitRadius()` which converts `pointRadius` into image-pixel space by dividing by `getRenderedScale(windowBBox, dimensions)` — the same approach polyline overlays already use for stroke hit tolerance. `containsPoint` and `getDistanceAndMaybePoint` now use that scaled radius (including the selected `2×` visual size).

## 🧪 How is this patch tested? If it is not, please explain why.

Manual App verification with a 5000×5000 image + skeleton (see repro code in issue):

1. Open sample without zooming.
2. Hover each keypoint — tooltip / hover highlight engages over the full drawn dot, not only the center.
3. Click / select points without needing extreme zoom.
4. Spot-check a small image still behaves normally; zoom in/out on the large image keeps hit area aligned with visible dots.

Unit tests for looker overlay hit geometry were not present; happy to add a focused test around `getHitRadius` / scale conversion if maintainers want that in this PR.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

Fixed App keypoint hover and click targeting on large images so hit areas match the on-screen drawn points.

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other
