### PR TITLE
fix(app): resolve uuid to a single advisory-clean version

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -78,6 +78,7 @@
         "minimatch": "9.0.7",
         "prettier": "~3.8.4",
         "protobufjs": "^7.6.4",
-        "three-stdlib": "^2.36.1"
+        "three-stdlib": "^2.36.1",
+        "uuid": "^14.0.0"
     }
 }

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -19894,15 +19894,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^9.0.0, uuid@npm:^9.0.1":
-  version: 9.0.1
-  resolution: "uuid@npm:9.0.1"
-  bin:
-    uuid: dist/bin/uuid
-  checksum: 10/9d0b6adb72b736e36f2b1b53da0d559125ba3e39d913b6072f6f033e0c87835b414f0836b45bcfaf2bdf698f92297fea1c3cc19b0b258bc182c9c43cc0fab9f2
-  languageName: node
-  linkType: hard
-
 "uvu@npm:^0.5.0":
   version: 0.5.6
   resolution: "uvu@npm:0.5.6"


### PR DESCRIPTION
GHSA-w5hq-g745-h8pq (missing buffer bounds check in `v3`/`v5`/`v6` when `buf` is provided) affects `uuid` < 11.1.1. Its withdrawn duplicate (GHSA-qmq6-f8pr-cx5x) still flags anything < 14.0.0 in some scanner databases.

The app already ships uuid 14.0.0 (via `@fiftyone/auto-labeling`); the remaining consumers (`@react-three/drei`, `react-mosaic-component`, `@storybook/addon-actions`) declare `^9` ranges and use only named exports, which are unchanged across these majors.

This adds a blanket `"uuid": "^14.0.0"` resolution so the lockfile carries a single, advisory-clean copy (9.0.1 is removed).

Lock-only change; no source edits.

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3607
<!-- enterprise-sync-pr:end -->