### PR TITLE
chore: remove legacy feature flag (`VFF_EXP_ANNOTATION`). [AS-1548]

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -195,7 +195,6 @@ jobs:
       ELECTRON_EXTRA_LAUNCH_ARGS: "--disable-gpu"
       PLAYWRIGHT_BROWSERS_PATH: /ms-playwright
       FIFTYONE_PLUGINS_DIR: ${{ github.workspace }}/e2e-pw/src/shared/assets/plugins
-      VFF_EXP_ANNOTATION: true
     defaults:
       run:
         shell: bash
@@ -331,7 +330,6 @@ jobs:
       ELECTRON_EXTRA_LAUNCH_ARGS: "--disable-gpu"
       PLAYWRIGHT_BROWSERS_PATH: /ms-playwright
       FIFTYONE_PLUGINS_DIR: ${{ github.workspace }}/e2e-pw/src/shared/assets/plugins
-      VFF_EXP_ANNOTATION: true
     defaults:
       run:
         shell: bash

--- a/e2e-pw/.env.dev.template
+++ b/e2e-pw/.env.dev.template
@@ -5,4 +5,3 @@ export LOG_PROCESS_OUTPUT=false
 export VENV_PATH=/Users/johndoe/fiftyone/venvs/oss
 export FIFTYONE_APP_DEFAULT_QUERY_PERFORMANCE=false
 export FIFTYONE_PLUGINS_DIR=$FIFTYONE_ROOT_DIR/e2e-pw/src/shared/assets/plugins
-export VFF_EXP_ANNOTATION=true


### PR DESCRIPTION
<!--
Community contributors: target the `community` branch, not `develop`. PRs from
non-members are auto-retargeted to `community`. See CONTRIBUTING.md:
https://github.com/voxel51/fiftyone/blob/develop/CONTRIBUTING.md#community-pull-requests
-->

## 🔗 Related Issues

n/a

## 📋 What changes are proposed in this pull request?

Recently, @tom-vx51 informed Aloha that the `VFF_EXP_ANNOTATION` feature flag is no longer used and may be removed. Let's clean up the the references here too.

## 🧪 How is this patch tested? If it is not, please explain why.

n/a

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.


### What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes
- [x] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an obsolete experimental annotation setting from end-to-end test workflows and development environment configuration.
  * No user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3608
<!-- enterprise-sync-pr:end -->