### PR TITLE
Silently ignore out-of-range lat/lon points in the Map panel

### DIFF
--- a/app/packages/map/src/Map.tsx
+++ b/app/packages/map/src/Map.tsx
@@ -16,6 +16,7 @@ import { useRecoilState, useRecoilValue } from "recoil";
 import useResizeObserver from "use-resize-observer";
 
 import DrawControl from "./Draw";
+import { filterValidSampleLocations } from "./geo";
 import useFetchGeoLocations, {
   SampleLocationMap,
   sampleLocationMapAtom,
@@ -58,7 +59,7 @@ const fitBounds = (
 const createSourceData = (
   sampleLocationMap: SampleLocationMap,
 ): GeoJSON.FeatureCollection<GeoJSON.Point, { id: string }> => {
-  const entries = Object.entries(sampleLocationMap);
+  const entries = Object.entries(filterValidSampleLocations(sampleLocationMap));
   if (entries.length === 0) return null;
 
   return {

--- a/app/packages/map/src/geo.test.ts
+++ b/app/packages/map/src/geo.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { filterValidSampleLocations, isValidCoordinate } from "./geo";
+
+describe("isValidCoordinate", () => {
+  it("accepts coordinates within bounds", () => {
+    expect(isValidCoordinate([-73.968285, 40.785091])).toBe(true);
+    expect(isValidCoordinate([0, 0])).toBe(true);
+  });
+
+  it("accepts boundary values", () => {
+    expect(isValidCoordinate([180, 90])).toBe(true);
+    expect(isValidCoordinate([-180, -90])).toBe(true);
+  });
+
+  it("rejects out-of-range longitude", () => {
+    expect(isValidCoordinate([500, 0])).toBe(false);
+    expect(isValidCoordinate([-181, 0])).toBe(false);
+  });
+
+  it("rejects out-of-range latitude", () => {
+    expect(isValidCoordinate([0, 999])).toBe(false);
+    expect(isValidCoordinate([0, -91])).toBe(false);
+  });
+
+  it("rejects non-finite values", () => {
+    expect(isValidCoordinate([NaN, 0])).toBe(false);
+    expect(isValidCoordinate([0, Infinity])).toBe(false);
+  });
+});
+
+describe("filterValidSampleLocations", () => {
+  it("drops only the samples with invalid coordinates", () => {
+    const input = {
+      valid1: [-73.968285, 40.785091] as [number, number],
+      invalidLng: [500, 0] as [number, number],
+      invalidLat: [0, 999] as [number, number],
+      valid2: [0, 0] as [number, number],
+    };
+
+    expect(filterValidSampleLocations(input)).toEqual({
+      valid1: [-73.968285, 40.785091],
+      valid2: [0, 0],
+    });
+  });
+
+  it("returns an empty object when nothing is valid", () => {
+    const input = { bad: [500, 999] as [number, number] };
+    expect(filterValidSampleLocations(input)).toEqual({});
+  });
+
+  it("returns an empty object for an empty input", () => {
+    expect(filterValidSampleLocations({})).toEqual({});
+  });
+});

--- a/app/packages/map/src/geo.ts
+++ b/app/packages/map/src/geo.ts
@@ -1,0 +1,34 @@
+import type { SampleLocationMap } from "./useFetchGeoLocations";
+
+/**
+ * Whether a [longitude, latitude] pair falls within valid GeoJSON bounds.
+ */
+export const isValidCoordinate = ([lng, lat]: [number, number]): boolean => {
+  return (
+    Number.isFinite(lng) &&
+    Number.isFinite(lat) &&
+    lng >= -180 &&
+    lng <= 180 &&
+    lat >= -90 &&
+    lat <= 90
+  );
+};
+
+/**
+ * Filters out samples whose coordinates fall outside the valid
+ * longitude/latitude bounds. Users may intentionally store out-of-range
+ * values, eg when ingesting raw data for cleaning, so these points are
+ * silently excluded from map rendering rather than raising an error.
+ */
+export const filterValidSampleLocations = (
+  sampleLocationMap: SampleLocationMap,
+): SampleLocationMap => {
+  const result: SampleLocationMap = {};
+  for (const [id, coordinates] of Object.entries(sampleLocationMap)) {
+    if (isValidCoordinate(coordinates)) {
+      result[id] = coordinates;
+    }
+  }
+
+  return result;
+};

--- a/tests/unittests/label_tests.py
+++ b/tests/unittests/label_tests.py
@@ -947,8 +947,10 @@ class ExportMaskTests(unittest.TestCase):
             with self.subTest(case["id"]):
                 with tempfile.TemporaryDirectory() as tmp:
                     src = os.path.join(tmp, "original.png")
-                    dst = src if case["overwrite_path"] else os.path.join(
-                        tmp, "copy.png"
+                    dst = (
+                        src
+                        if case["overwrite_path"]
+                        else os.path.join(tmp, "copy.png")
                     )
                     _write_mask(self._ZEROS, src)
 
@@ -1001,9 +1003,7 @@ class ExportMaskTests(unittest.TestCase):
                         _write_mask(self._ZEROS, mp)
                         outpath = mp
 
-                    det = self._make_detection(
-                        mask=case["mask"], mask_path=mp
-                    )
+                    det = self._make_detection(mask=case["mask"], mask_path=mp)
                     with self.assertRaises(ValueError, msg=case["id"]):
                         det.export_mask(
                             outpath, overwrite_path=case["overwrite_path"]


### PR DESCRIPTION
Fixes #2171

Updated per review: rather than validating lat/lon at data ingest time
(Python), this now filters invalid points out of the Map panel's rendering
logic in the App instead, so users can still intentionally store
out-of-range values (e.g. raw data pending cleanup) — same precedent as
allowing bounding box coordinates outside `[0, 1]`.

## What changed

`app/packages/map/src/geo.ts` (new) adds:
- `isValidCoordinate([lng, lat])`: checks `lng` is in `[-180, 180]` and
  `lat` is in `[-90, 90]`
- `filterValidSampleLocations(sampleLocationMap)`: drops entries with
  invalid coordinates

`Map.tsx`'s `createSourceData()` now filters through
`filterValidSampleLocations` before building the GeoJSON source, so
invalid points are silently excluded from both the map markers and the
`computeBounds()`/`fitBounds()` calls — which is exactly where the
original `Invalid LngLat latitude value: must be between -90 and 90`
crash from mapbox-gl was coming from.

## Testing

- Added `app/packages/map/src/geo.test.ts` (8 unit tests, vitest):
  in-bounds/boundary/out-of-range longitude and latitude, non-finite
  values, and `filterValidSampleLocations` dropping only the bad entries.
  All passing.
- `yarn prettier --check` clean on the changed files.
- Ran the monorepo `tsc --noEmit` typecheck — no errors introduced in
  `packages/map` (the repo has ~1000 pre-existing unrelated errors
  elsewhere that this change doesn't touch).
