### PR TITLE
ci: release gate and cherry-pick workflow for upstream-first releases

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -20,7 +20,9 @@ on:
       release_branch:
         description: "Target release branch, e.g. release/v1.8.0"
         required: true
-  pull_request:
+  # pull_request_target so fork PRs get the bot token; safe because nothing
+  # here checks out or executes PR-head code — only the already-merged commit.
+  pull_request_target:
     types: [closed, labeled]
     branches:
       - develop

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -37,6 +37,13 @@ jobs:
           PR_NUMBER: ${{ inputs.pr_number }}
           RELEASE_BRANCH: ${{ inputs.release_branch }}
         run: |
+          set -euo pipefail
+
+          if [[ "$RELEASE_BRANCH" != release/* ]]; then
+            echo "::error::Target must be a release/* branch, got '$RELEASE_BRANCH'."
+            exit 1
+          fi
+
           fields=$(gh pr view "$PR_NUMBER" --json state,baseRefName,mergeCommit,title \
             --jq '[.state, .baseRefName, .mergeCommit.oid, .title] | @tsv')
           IFS=$'\t' read -r state base sha title <<< "$fields"

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -1,0 +1,73 @@
+name: Cherry-Pick to Release
+
+# Opens the release-branch PR for a merged develop PR: cherry-picks its merge
+# result with -x (which the release gate verifies) and opens a PR that waits
+# for the 'cherry-pick-approved' label. A conflicting cherry-pick fails the
+# run — resolving it is a human decision, and often the signal that the fix
+# needs the release-only escape hatch instead.
+#
+# PRs opened with GITHUB_TOKEN don't trigger CI; close and reopen the PR to
+# start checks, or dispatch with a bot PAT once one is provisioned.
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Merged develop PR number to cherry-pick"
+        required: true
+      release_branch:
+        description: "Target release branch, e.g. release/v1.8.0"
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  cherry-pick:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.release_branch }}
+          fetch-depth: 0
+      - name: Cherry-pick and open PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          RELEASE_BRANCH: ${{ inputs.release_branch }}
+        run: |
+          fields=$(gh pr view "$PR_NUMBER" --json state,baseRefName,mergeCommit,title \
+            --jq '[.state, .baseRefName, .mergeCommit.oid, .title] | @tsv')
+          IFS=$'\t' read -r state base sha title <<< "$fields"
+
+          if [ "$state" != "MERGED" ] || [ "$base" != "develop" ]; then
+            echo "::error::PR #$PR_NUMBER must be a merged develop PR (state=$state, base=$base)."
+            exit 1
+          fi
+
+          git fetch --quiet origin develop
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          branch="cherry-pick/${RELEASE_BRANCH#release/}/pr-$PR_NUMBER"
+          git checkout -b "$branch"
+
+          mainline=""
+          if [ "$(git rev-list --parents -n 1 "$sha" | wc -w)" -gt 2 ]; then
+            mainline="-m 1"
+          fi
+          if ! git cherry-pick -x $mainline "$sha"; then
+            git cherry-pick --abort
+            echo "::error::Cherry-pick of $sha onto $RELEASE_BRANCH conflicts."
+            echo "Resolve by hand with 'git cherry-pick -x', or consider the"
+            echo "release-only-fix escape hatch if develop has moved on."
+            exit 1
+          fi
+
+          git push origin "$branch"
+          gh pr create \
+            --base "$RELEASE_BRANCH" \
+            --head "$branch" \
+            --title "[$RELEASE_BRANCH] $title" \
+            --body "Cherry-pick of #$PR_NUMBER. Awaiting \`cherry-pick-approved\`."

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -20,9 +20,9 @@ on:
       release_branch:
         description: "Target release branch, e.g. release/v1.8.0"
         required: true
-  # pull_request_target so fork PRs get the bot token; safe because nothing
-  # here checks out or executes PR-head code — only the already-merged commit.
-  pull_request_target:
+  # Fork PRs don't reach develop directly (community-branch flow), so plain
+  # pull_request is enough; the rare exception can use workflow_dispatch.
+  pull_request:
     types: [closed, labeled]
     branches:
       - develop

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -8,8 +8,8 @@ name: Cherry-Pick to Release
 # a human decision, and often the signal that the fix needs the release-only
 # escape hatch instead.
 #
-# PRs opened with GITHUB_TOKEN don't trigger CI; close and reopen the PR to
-# start checks, or dispatch with a bot PAT once one is provisioned.
+# Runs as voxel51-bot (FIFTYONE_GITHUB_TOKEN) so the PRs it opens trigger CI;
+# the default Actions token's PRs would not.
 
 on:
   workflow_dispatch:
@@ -40,9 +40,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ secrets.FIFTYONE_GITHUB_TOKEN }}
       - name: Cherry-pick and open PR
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.FIFTYONE_GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
           RELEASE_BRANCH: ${{ inputs.release_branch || '' }}
@@ -70,8 +71,8 @@ jobs:
           fi
 
           git fetch --quiet origin develop "$RELEASE_BRANCH"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "voxel51-bot"
+          git config user.email "voxel51-bot@users.noreply.github.com"
 
           branch="cherry-pick/${RELEASE_BRANCH#release/}/pr-$PR_NUMBER"
           git checkout -b "$branch" "origin/$RELEASE_BRANCH"

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -1,10 +1,10 @@
 name: Cherry-Pick to Release
 
 # Opens the release-branch PR for a merged develop PR: cherry-picks its merge
-# result with -x (which the release gate verifies) and opens a PR that waits
-# for the 'cherry-pick-approved' label. A conflicting cherry-pick fails the
-# run — resolving it is a human decision, and often the signal that the fix
-# needs the release-only escape hatch instead.
+# result with -x, which the release gate verifies against develop. A
+# conflicting cherry-pick fails the run — resolving it is a human decision,
+# and often the signal that the fix needs the release-only escape hatch
+# instead.
 #
 # PRs opened with GITHUB_TOKEN don't trigger CI; close and reopen the PR to
 # start checks, or dispatch with a bot PAT once one is provisioned.
@@ -70,4 +70,4 @@ jobs:
             --base "$RELEASE_BRANCH" \
             --head "$branch" \
             --title "[$RELEASE_BRANCH] $title" \
-            --body "Cherry-pick of #$PR_NUMBER. Awaiting \`cherry-pick-approved\`."
+            --body "Cherry-pick of #$PR_NUMBER."

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -1,10 +1,12 @@
 name: Cherry-Pick to Release
 
 # Opens the release-branch PR for a merged develop PR: cherry-picks its merge
-# result with -x, which the release gate verifies against develop. A
-# conflicting cherry-pick fails the run — resolving it is a human decision,
-# and often the signal that the fix needs the release-only escape hatch
-# instead.
+# result with -x, which the release gate verifies against develop. Two ways in:
+# dispatch with a PR number + target branch, or label a develop PR
+# 'needs-cherry-pick' and the release PR opens itself when the develop PR
+# merges. Conflicts fail the run and comment on the source PR — resolving is
+# a human decision, and often the signal that the fix needs the release-only
+# escape hatch instead.
 #
 # PRs opened with GITHUB_TOKEN don't trigger CI; close and reopen the PR to
 # start checks, or dispatch with a bot PAT once one is provisioned.
@@ -18,6 +20,10 @@ on:
       release_branch:
         description: "Target release branch, e.g. release/v1.8.0"
         required: true
+  pull_request:
+    types: [closed, labeled]
+    branches:
+      - develop
 
 permissions:
   contents: write
@@ -25,22 +31,32 @@ permissions:
 
 jobs:
   cherry-pick:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
+       contains(github.event.pull_request.labels.*.name, 'needs-cherry-pick'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.release_branch }}
           fetch-depth: 0
       - name: Cherry-pick and open PR
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ inputs.pr_number }}
-          RELEASE_BRANCH: ${{ inputs.release_branch }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
+          RELEASE_BRANCH: ${{ inputs.release_branch || '' }}
         run: |
           set -euo pipefail
 
+          # The labeled flow targets the live release line; there is one at a
+          # time.
+          if [ -z "$RELEASE_BRANCH" ]; then
+            RELEASE_BRANCH=$(gh api "repos/$REPO/branches" --paginate \
+              --jq '.[].name | select(startswith("release/v"))' | sort -V | tail -1)
+          fi
           if [[ "$RELEASE_BRANCH" != release/* ]]; then
-            echo "::error::Target must be a release/* branch, got '$RELEASE_BRANCH'."
+            echo "::error::No release/* branch to target (got '${RELEASE_BRANCH:-none}')."
             exit 1
           fi
 
@@ -53,12 +69,12 @@ jobs:
             exit 1
           fi
 
-          git fetch --quiet origin develop
+          git fetch --quiet origin develop "$RELEASE_BRANCH"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           branch="cherry-pick/${RELEASE_BRANCH#release/}/pr-$PR_NUMBER"
-          git checkout -b "$branch"
+          git checkout -b "$branch" "origin/$RELEASE_BRANCH"
 
           mainline=""
           if [ "$(git rev-list --parents -n 1 "$sha" | wc -w)" -gt 2 ]; then
@@ -66,9 +82,8 @@ jobs:
           fi
           if ! git cherry-pick -x $mainline "$sha"; then
             git cherry-pick --abort
+            gh pr comment "$PR_NUMBER" --body "Cherry-pick to \`$RELEASE_BRANCH\` conflicts — pick it manually with \`git cherry-pick -x\`, or use the \`release-only-fix\` escape hatch if develop has moved on."
             echo "::error::Cherry-pick of $sha onto $RELEASE_BRANCH conflicts."
-            echo "Resolve by hand with 'git cherry-pick -x', or consider the"
-            echo "release-only-fix escape hatch if develop has moved on."
             exit 1
           fi
 

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -3,7 +3,7 @@ name: Cherry-Pick to Release
 # Opens the release-branch PR for a merged develop PR: cherry-picks its merge
 # result with -x, which the release gate verifies against develop. Two ways in:
 # dispatch with a PR number + target branch, or label a develop PR
-# 'needs-cherry-pick' and the release PR opens itself when the develop PR
+# 'cherry-pick-to-release' and the release PR opens itself when the develop PR
 # merges. Conflicts fail the run and comment on the source PR — resolving is
 # a human decision, and often the signal that the fix needs the release-only
 # escape hatch instead.
@@ -32,11 +32,11 @@ permissions:
   pull-requests: write
 
 jobs:
-  cherry-pick:
+  cherry-pick-to-release-branch:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.pull_request.merged == true &&
-       contains(github.event.pull_request.labels.*.name, 'needs-cherry-pick'))
+       contains(github.event.pull_request.labels.*.name, 'cherry-pick-to-release'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -58,8 +58,8 @@ jobs:
             RELEASE_BRANCH=$(gh api "repos/$REPO/branches" --paginate \
               --jq '.[].name | select(startswith("release/v"))' | sort -V | tail -1)
           fi
-          if [[ "$RELEASE_BRANCH" != release/* ]]; then
-            echo "::error::No release/* branch to target (got '${RELEASE_BRANCH:-none}')."
+          if [[ "$RELEASE_BRANCH" != release/v* ]]; then
+            echo "::error::No release/v* branch to target (got '${RELEASE_BRANCH:-none}')."
             exit 1
           fi
 

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -4,14 +4,14 @@ name: Release Gate
 # cherry-pick of commits already on develop, a labeled release-only fix, a
 # version bump, or an automated sync mirror.
 # Everything else originates on develop and arrives here by cherry-pick, so
-# the release branch stays a strict subset of develop and there is never
-# anything to merge back.
+# the release branch stays a strict subset of the default branch
+# and there is never anything to merge back.
 
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled, edited]
     branches:
-      - release/**
+      - release/v**
 
 concurrency:
   group: release-gate-${{ github.event.pull_request.number }}

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -13,6 +13,10 @@ on:
     branches:
       - release/**
 
+concurrency:
+  group: release-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -32,6 +36,8 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
+          set -euo pipefail
+
           has_label() { echo "$LABELS" | grep -q "\"$1\""; }
 
           # Automation the release process already owns: sync mirrors were

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -60,10 +60,16 @@ jobs:
 
           # Everything else must be a cherry-pick of commits already on
           # develop: git cherry-pick -x stamps the source sha, and that sha
-          # must be an ancestor of develop.
+          # must be an ancestor of develop. Merge commits are rejected — they
+          # can carry unvalidated conflict-resolution changes; update
+          # cherry-pick branches by rebase.
           git fetch --quiet origin develop
+          if [ -n "$(git rev-list --merges "$BASE_SHA..$HEAD_SHA")" ]; then
+            echo "::error::Merge commits are not allowed in release PRs; rebase instead."
+            exit 1
+          fi
           bad=0
-          for sha in $(git rev-list --no-merges "$BASE_SHA..$HEAD_SHA"); do
+          for sha in $(git rev-list "$BASE_SHA..$HEAD_SHA"); do
             src=$(git log -1 --format=%B "$sha" \
               | sed -nE 's/^\(cherry picked from commit ([0-9a-f]{40})\)$/\1/p' | tail -1)
             if [ -z "$src" ]; then

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -1,0 +1,102 @@
+name: Release Gate
+
+# Enforces upstream-first on release branches: a PR into release/* must be an
+# approved cherry-pick of commits already on develop, an approved release-only
+# fix that justifies why develop doesn't need it, a version bump, or an
+# automated sync mirror. Everything else originates on develop and arrives
+# here by cherry-pick, so the release branch stays a strict subset of develop
+# and there is never anything to merge back.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled, edited]
+    branches:
+      - release/**
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  release-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Gate release branch PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+          HEAD_REF: ${{ github.head_ref }}
+          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+          BODY: ${{ github.event.pull_request.body }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          APPROVERS: ${{ vars.RELEASE_GATE_APPROVERS }}
+        run: |
+          has_label() { echo "$LABELS" | grep -q "\"$1\""; }
+
+          # Automation the release process already owns: sync mirrors were
+          # gated on the upstream side, version bumps are guarded by the
+          # version-guard workflow.
+          if [ "$AUTHOR" = "voxel51-bot" ] && [[ "$HEAD_REF" == oss-sync/* ]]; then
+            echo "Sync mirror PR; gated upstream. OK."
+            exit 0
+          fi
+          if has_label "version-bump"; then
+            echo "Version bump PR. OK."
+            exit 0
+          fi
+
+          if ! has_label "cherry-pick-approved"; then
+            echo "::error::PRs into release/* need the 'cherry-pick-approved' label."
+            echo "Release branches take only approved cherry-picks of develop commits"
+            echo "(regression, critical bug, or security fix). Land the change on"
+            echo "develop first, then use the 'Cherry-Pick to Release' workflow."
+            exit 1
+          fi
+
+          # The label only counts if a release approver applied it.
+          # RELEASE_GATE_APPROVERS is a comma-separated list of GitHub logins
+          # (repo or org variable); unset means label presence alone gates.
+          if [ -n "$APPROVERS" ]; then
+            actor=$(gh api "repos/$REPO/issues/$PR_NUMBER/events" --paginate --jq \
+              '[.[] | select(.event == "labeled" and .label.name == "cherry-pick-approved")] | last | .actor.login')
+            if ! echo ",$APPROVERS," | grep -qi ",$actor,"; then
+              echo "::error::'cherry-pick-approved' was applied by '$actor', who is not in RELEASE_GATE_APPROVERS."
+              exit 1
+            fi
+          fi
+
+          if has_label "release-only-fix"; then
+            if echo "$BODY" | grep -qi "not needed on develop because"; then
+              echo "Approved release-only fix with justification. OK."
+              exit 0
+            fi
+            echo "::error::A release-only fix must explain itself: add"
+            echo "'Not needed on develop because ...' to the PR body."
+            exit 1
+          fi
+
+          # Every commit must be a cherry-pick of a commit already on develop:
+          # git cherry-pick -x stamps the source sha, and that sha must be an
+          # ancestor of develop.
+          git fetch --quiet origin develop
+          bad=0
+          for sha in $(git rev-list --no-merges "$BASE_SHA..$HEAD_SHA"); do
+            src=$(git log -1 --format=%B "$sha" \
+              | sed -nE 's/^\(cherry picked from commit ([0-9a-f]{40})\)$/\1/p' | tail -1)
+            if [ -z "$src" ]; then
+              echo "::error::$sha has no '(cherry picked from commit ...)' trailer."
+              echo "Cherry-pick with -x, or use the 'Cherry-Pick to Release' workflow."
+              bad=1
+            elif ! git merge-base --is-ancestor "$src" origin/develop 2>/dev/null; then
+              echo "::error::$sha claims source $src, which is not on develop."
+              bad=1
+            fi
+          done
+          [ "$bad" -eq 0 ] || exit 1
+          echo "Approved cherry-pick of develop commits. OK."

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -1,8 +1,8 @@
 name: Release Gate
 
 # Enforces upstream-first on release branches: a PR into release/* must be a
-# cherry-pick of commits already on develop, a release-only fix that says why
-# develop doesn't need it, a version bump, or an automated sync mirror.
+# cherry-pick of commits already on develop, a labeled release-only fix, a
+# version bump, or an automated sync mirror.
 # Everything else originates on develop and arrives here by cherry-pick, so
 # the release branch stays a strict subset of develop and there is never
 # anything to merge back.
@@ -32,7 +32,6 @@ jobs:
           AUTHOR: ${{ github.event.pull_request.user.login }}
           HEAD_REF: ${{ github.head_ref }}
           LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
-          BODY: ${{ github.event.pull_request.body }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
@@ -53,16 +52,10 @@ jobs:
           fi
 
           # The escape hatch: a fix that applies only to the release branch.
-          # The label is the deliberate act; the body must say why develop
-          # doesn't need the change.
+          # The label is the deliberate act.
           if has_label "release-only-fix"; then
-            if echo "$BODY" | grep -qi "not needed on develop because"; then
-              echo "Release-only fix with justification. OK."
-              exit 0
-            fi
-            echo "::error::A release-only fix must explain itself: add"
-            echo "'Not needed on develop because ...' to the PR body."
-            exit 1
+            echo "Release-only fix. OK."
+            exit 0
           fi
 
           # Everything else must be a cherry-pick of commits already on
@@ -77,7 +70,7 @@ jobs:
               echo "::error::$sha has no '(cherry picked from commit ...)' trailer."
               echo "Land the change on develop first, then cherry-pick with -x or the"
               echo "'Cherry-Pick to Release' workflow. If the fix truly applies only to"
-              echo "this release branch, add the 'release-only-fix' label and justify it."
+              echo "this release branch, add the 'release-only-fix' label."
               bad=1
             elif ! git merge-base --is-ancestor "$src" origin/develop 2>/dev/null; then
               echo "::error::$sha claims source $src, which is not on develop."

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -1,11 +1,11 @@
 name: Release Gate
 
-# Enforces upstream-first on release branches: a PR into release/* must be an
-# approved cherry-pick of commits already on develop, an approved release-only
-# fix that justifies why develop doesn't need it, a version bump, or an
-# automated sync mirror. Everything else originates on develop and arrives
-# here by cherry-pick, so the release branch stays a strict subset of develop
-# and there is never anything to merge back.
+# Enforces upstream-first on release branches: a PR into release/* must be a
+# cherry-pick of commits already on develop, a release-only fix that says why
+# develop doesn't need it, a version bump, or an automated sync mirror.
+# Everything else originates on develop and arrives here by cherry-pick, so
+# the release branch stays a strict subset of develop and there is never
+# anything to merge back.
 
 on:
   pull_request:
@@ -15,7 +15,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   release-gate:
@@ -26,16 +25,12 @@ jobs:
           fetch-depth: 0
       - name: Gate release branch PR
         env:
-          GH_TOKEN: ${{ github.token }}
           AUTHOR: ${{ github.event.pull_request.user.login }}
           HEAD_REF: ${{ github.head_ref }}
           LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
           BODY: ${{ github.event.pull_request.body }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
-          APPROVERS: ${{ vars.RELEASE_GATE_APPROVERS }}
         run: |
           has_label() { echo "$LABELS" | grep -q "\"$1\""; }
 
@@ -51,29 +46,12 @@ jobs:
             exit 0
           fi
 
-          if ! has_label "cherry-pick-approved"; then
-            echo "::error::PRs into release/* need the 'cherry-pick-approved' label."
-            echo "Release branches take only approved cherry-picks of develop commits"
-            echo "(regression, critical bug, or security fix). Land the change on"
-            echo "develop first, then use the 'Cherry-Pick to Release' workflow."
-            exit 1
-          fi
-
-          # The label only counts if a release approver applied it.
-          # RELEASE_GATE_APPROVERS is a comma-separated list of GitHub logins
-          # (repo or org variable); unset means label presence alone gates.
-          if [ -n "$APPROVERS" ]; then
-            actor=$(gh api "repos/$REPO/issues/$PR_NUMBER/events" --paginate --jq \
-              '[.[] | select(.event == "labeled" and .label.name == "cherry-pick-approved")] | last | .actor.login')
-            if ! echo ",$APPROVERS," | grep -qi ",$actor,"; then
-              echo "::error::'cherry-pick-approved' was applied by '$actor', who is not in RELEASE_GATE_APPROVERS."
-              exit 1
-            fi
-          fi
-
+          # The escape hatch: a fix that applies only to the release branch.
+          # The label is the deliberate act; the body must say why develop
+          # doesn't need the change.
           if has_label "release-only-fix"; then
             if echo "$BODY" | grep -qi "not needed on develop because"; then
-              echo "Approved release-only fix with justification. OK."
+              echo "Release-only fix with justification. OK."
               exit 0
             fi
             echo "::error::A release-only fix must explain itself: add"
@@ -81,9 +59,9 @@ jobs:
             exit 1
           fi
 
-          # Every commit must be a cherry-pick of a commit already on develop:
-          # git cherry-pick -x stamps the source sha, and that sha must be an
-          # ancestor of develop.
+          # Everything else must be a cherry-pick of commits already on
+          # develop: git cherry-pick -x stamps the source sha, and that sha
+          # must be an ancestor of develop.
           git fetch --quiet origin develop
           bad=0
           for sha in $(git rev-list --no-merges "$BASE_SHA..$HEAD_SHA"); do
@@ -91,7 +69,9 @@ jobs:
               | sed -nE 's/^\(cherry picked from commit ([0-9a-f]{40})\)$/\1/p' | tail -1)
             if [ -z "$src" ]; then
               echo "::error::$sha has no '(cherry picked from commit ...)' trailer."
-              echo "Cherry-pick with -x, or use the 'Cherry-Pick to Release' workflow."
+              echo "Land the change on develop first, then cherry-pick with -x or the"
+              echo "'Cherry-Pick to Release' workflow. If the fix truly applies only to"
+              echo "this release branch, add the 'release-only-fix' label and justify it."
               bad=1
             elif ! git merge-base --is-ancestor "$src" origin/develop 2>/dev/null; then
               echo "::error::$sha claims source $src, which is not on develop."
@@ -99,4 +79,4 @@ jobs:
             fi
           done
           [ "$bad" -eq 0 ] || exit 1
-          echo "Approved cherry-pick of develop commits. OK."
+          echo "Cherry-picks of develop commits. OK."


### PR DESCRIPTION
Release branches move to upstream-first: nothing originates on `release/*` — changes land on `develop` and arrive on the release line as cherry-picks, so the release branch stays a strict subset of develop and there is never anything to merge back.

Two workflows, both inert until a `release/v*` branch exists:

**`release-gate.yml`** — required-check candidate for PRs into `release/*`. Fully mechanical; passes only:
- cherry-picks: every commit carries a `(cherry picked from commit <sha>)` trailer whose sha is an ancestor of `develop` — no label needed, the invariant proves itself
- release-only fixes: the `release-only-fix` label — the one intentional escape hatch
- version bumps (`version-bump` label — content already enforced by version-guard)
- automated sync PRs, which were gated upstream

**`cherry-pick.yml`** — two ways in: label a develop PR `needs-cherry-pick` and the release PR opens itself when the develop PR merges (targets the live release line), or `workflow_dispatch` with a PR number + target branch. Cherry-picks the merge result with `-x`. Conflicts fail the run and comment on the source PR — a conflicting cherry-pick is a human decision.

Follow-ups before the next release cut (not in this PR):
- add `release-gate` as a required check on the `release/v*` ruleset (with `do_not_enforce_on_create` so branch cuts aren't blocked)
- dry-run against a scratch `release/vtest` branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated workflow to select or validate a release branch, apply approved changes, and open a release pull request.
  * Added manual and label-based options for initiating release updates.
  * Added automated validation for pull requests targeting release branches.

* **Bug Fixes**
  * Prevents invalid, unauthorized, or improperly prepared changes from being merged into release branches.
  * Reports cherry-pick conflicts so they can be resolved before release integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Labels (`release-only-fix`, `needs-cherry-pick`) already exist in both repos.

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3613
<!-- enterprise-sync-pr:end -->