### PR TITLE
ci: drop main from the heavy-suite base list

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -97,7 +97,7 @@ jobs:
           heavy=false
           if [ "$run_ci" = "true" ]; then
             case "$BASE_REF" in
-              develop|main|release/*|community) heavy=true ;;
+              develop|release/*|community) heavy=true ;;
             esac
           fi
           echo "run-ci=$run_ci" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Under upstream-first releases nothing merges into `main` — it only fast-forwards to release tags — so no PR ever targets it and the `main` entry in the heavy-suite base list is dead. Removes it; `develop`, `release/*`, and `community` behavior unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request validation to run the full CI suite for changes targeting `develop`, `release/*`, and `community`.
  * Pull requests targeting `main` are no longer included in the heavy CI workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3615
<!-- enterprise-sync-pr:end -->