### PR TITLE
ci: anchor docs publish to release tags, not main

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -58,6 +58,8 @@ jobs:
         uses: actions/checkout@v7
       - name: Get Branch Name
         id: get_branch
+        env:
+          RO_FOT_FG_PAT: ${{ secrets.RO_FOT_FG_PAT }}
         run: |
           if [[ "${{ github.ref_type }}" == "tag" ]]; then
             TAG_SHA=$(git rev-parse ${{ github.ref }})
@@ -65,12 +67,16 @@ jobs:
               docs-publish|v*)
                 # Published docs must match the latest released product: the
                 # tag must be the newest final release tag, or sit on top of
-                # it (a docs/v* line carrying doc cherry-picks).
-                # branch_name=main refers to fiftyone-teams/eta checkouts
-                # below, not this repo.
+                # it (a docs/v* line carrying doc cherry-picks). Enterprise
+                # docs content builds from the latest teams-v* release tag;
+                # branch_name=main is only the eta clone ref below (eta's
+                # current branch, not a release pointer).
                 LATEST=$(git tag -l 'v*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
                 if git merge-base --is-ancestor "$(git rev-parse ${LATEST}^{commit})" "${TAG_SHA}"; then
                   echo "branch_name=main" >> "${GITHUB_OUTPUT}"
+                  TEAMS_TAG=$(git ls-remote --tags "https://x-access-token:${RO_FOT_FG_PAT}@github.com/voxel51/fiftyone-teams.git" 'refs/tags/teams-v*' \
+                    | awk -F/ '{print $NF}' | grep -E '^teams-v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
+                  echo "teams_ref=${TEAMS_TAG}" >> "${GITHUB_OUTPUT}"
                 else
                   echo "docs publish only from the latest release (${LATEST}) or a docs/v* line on it"
                   exit 1
@@ -103,7 +109,7 @@ jobs:
           repository: voxel51/fiftyone-teams
           path: fiftyone-teams
           token: ${{ secrets.RO_FOT_FG_PAT }}
-          ref: ${{ steps.get_branch.outputs.branch_name }}
+          ref: ${{ steps.get_branch.outputs.teams_ref || steps.get_branch.outputs.branch_name }}
       - name: Set up Python 3.13
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -20,7 +20,6 @@ on:
   pull_request:
     branches:
       - develop
-      - main
       - release/*
     paths:
       - .github/workflows/build-docs.yml
@@ -64,11 +63,16 @@ jobs:
             TAG_SHA=$(git rev-parse ${{ github.ref }})
             case "${{ github.ref_name }}" in
               docs-publish|v*)
-                MAIN_SHA=$(git rev-parse origin/main)
-                if [[ "${MAIN_SHA}" == "${TAG_SHA}" ]]; then
+                # Published docs must match the latest released product: the
+                # tag must be the newest final release tag, or sit on top of
+                # it (a docs/v* line carrying doc cherry-picks).
+                # branch_name=main refers to fiftyone-teams/eta checkouts
+                # below, not this repo.
+                LATEST=$(git tag -l 'v*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
+                if git merge-base --is-ancestor "$(git rev-parse ${LATEST}^{commit})" "${TAG_SHA}"; then
                   echo "branch_name=main" >> "${GITHUB_OUTPUT}"
                 else
-                  echo "docs-publish should only be performed on 'main'"
+                  echo "docs publish only from the latest release (${LATEST}) or a docs/v* line on it"
                   exit 1
                 fi
                 ;;


### PR DESCRIPTION
Docs publishing is the last automation reading this repo's `main`. The guard asserted the `docs-publish`/`v*` tag SHA equals `main`'s tip — true only while releases merge into main. Under upstream-first releases nothing merges into main, so every release-tag push would fail the guard and public docs would silently stop updating.

New guard, same guarantee (published docs always match the latest released product):
- the pushed tag must be the newest final `v*` release tag, or a descendant of it (a `docs/v*` line carrying doc cherry-picks)
- an older patch tag can't clobber docs for a newer release
- rc tags fail the guard exactly as they do today

The fiftyone-teams docs checkout resolves the latest final `teams-v*` tag instead of teams `main`, so no repo's `main` is a release pointer anywhere in the docs pipeline. eta keeps `main` — that's its current development branch, not a release pointer. Also drops the dead `main` entry from the `pull_request` trigger list.

With this, no `main` has release consumers: no merges, no fast-forwards, frozen. Docs patches tag the `docs/v*` head directly instead of fast-forwarding main (release runbook updated separately).

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3614
<!-- enterprise-sync-pr:end -->