### PR TITLE
fix(ci): no-op all-tests mirrors must not wait on each other

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -298,12 +298,43 @@ jobs:
                   per_page: 100,
                 },
               );
-              const live = runs.filter(
+              const candidates = runs.filter(
                 (r) =>
                   r.workflow_id === self.workflow_id &&
                   r.id !== context.runId &&
                   r.status !== 'completed',
               );
+              // A fellow no-op mirror is not testing this SHA. Without this
+              // check, concurrent no-op runs (an event burst on one commit)
+              // wait on each other until the deadline and conclude red. A run
+              // counts as a mirror only when its gate passed and every suite
+              // job it spawned was skipped; anything ambiguous (gate still
+              // running, jobs not yet listed) stays blocking.
+              const SUITE = /^(build|lint|test|test-windows|e2e)\b/;
+              const live = [];
+              for (const r of candidates) {
+                const jobs = await github.paginate(
+                  github.rest.actions.listJobsForWorkflowRun,
+                  {
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    run_id: r.id,
+                    per_page: 100,
+                  },
+                );
+                const gate = jobs.find((j) => j.name === 'modified-files');
+                const suite = jobs.filter((j) => SUITE.test(j.name));
+                const isMirror =
+                  gate?.status === 'completed' &&
+                  gate?.conclusion === 'success' &&
+                  suite.length > 0 &&
+                  suite.every(
+                    (j) => j.status === 'completed' && j.conclusion === 'skipped',
+                  );
+                if (!isMirror) {
+                  live.push(r);
+                }
+              }
               const finished = new Set(
                 runs
                   .filter((r) => r.status === 'completed' && r.conclusion !== 'cancelled')


### PR DESCRIPTION
## What

The `all-tests` no-op mirror (`pr.yml`) refuses to report a verdict while another Pull Request run is live on the SHA. When several *no-op* runs are in flight on the same commit — e.g. a burst of bot-driven `pull_request` events — each counts the others as live, so they all wait on each other until the 90-minute deadline and conclude **failed**, turning a green suite red.

Hit today on #8167: three concurrent no-op runs deadlocked while the real suite had been green for 20 minutes; unstuck by cancelling two by hand.

## Fix

Classify a live run before blocking on it. A run whose `modified-files` gate passed and whose every suite job (`build` / `lint` / `test` / `test-windows` / `e2e`) completed as skipped is a fellow mirror — it can never produce a verdict, so it no longer counts as live. Anything ambiguous (gate still running, suite jobs not yet listed) keeps blocking, preserving the original safety property: never mirror while a run that might be testing the SHA is in flight.

## Validation

- YAML parses; embedded script passes `node --check`.
- Replayed today's deadlock state against the new predicate: the three no-op runs classify as mirrors (gate `success`, all suite jobs `skipped`), the real run 30841742403 classifies as blocking while in flight.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of concurrent workflow runs when mirroring verdicts.
  * Runs now remain blocking unless their gate succeeds and all spawned suite jobs are explicitly skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3623
<!-- enterprise-sync-pr:end -->