### PR TITLE
deps: require voxel51-eta 0.17

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ setup(
         # internal packages
         "fiftyone-brain>=0.23.0,<0.24",
         "fiftyone-db>=0.4,<2.0",
-        "voxel51-eta>=0.16.0,<0.17",
+        "voxel51-eta>=0.17,<0.18",
     ],
     include_package_data=True,
     classifiers=[


### PR DESCRIPTION
Bumps the eta requirement to `>=0.17,<0.18`. eta 0.17.0 ships the native paramiko SFTP client (voxel51/eta#718 + voxel51/eta#720), which removes the unmaintained pysftp dependency and its `paramiko<4` constraint, unblocking paramiko CVE remediation.

Merge after voxel51-eta 0.17.0 is published to PyPI — the pin is unsatisfiable until then, so CI will be red on the install step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the supported `voxel51-eta` dependency version range to the latest compatible release series.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3628
<!-- enterprise-sync-pr:end -->