### PR TITLE
ci: pin windows ffmpeg to 8.1.2

### DIFF
--- a/.github/actions/setup-ffmpeg/action.yml
+++ b/.github/actions/setup-ffmpeg/action.yml
@@ -10,7 +10,7 @@ runs:
     - name: Install ffmpeg (Windows)
       shell: pwsh
       run: |
-        choco install ffmpeg -y --no-progress --execution-timeout=600
+        choco install ffmpeg -y --version=8.1.2 --no-progress --execution-timeout=600
         # ensure the choco shim dir is on PATH for this and subsequent steps
         "C:\ProgramData\chocolatey\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         $env:PATH = "C:\ProgramData\chocolatey\bin;$env:PATH"


### PR DESCRIPTION
## What changed

Chocolatey began serving **ffmpeg 9.0.0** (gyan.dev build) on 2026-08-04. Under it, eta's `FFmpegVideoWriter` invocation exits immediately, so every video test on the windows runners fails with `BrokenPipeError: [Errno 32] Broken pipe` on the first frame write — both 3.10 and 3.13.

`setup-ffmpeg` installed whatever choco serves, unpinned. This pins the last 8.x (**8.1.2**) so `test-windows` runs are reproducible again.

Any PR that actually runs `test-windows` is currently red (runs that look green skipped it via path filters). Example failing job: https://github.com/voxel51/fiftyone/actions/runs/30940010624/job/92096052297

## Follow-up

The durable fix is ffmpeg 9 compatibility in eta, then dropping the pin.

## Verification

The same one-line pin is on #8127 (`2ee335e21c`), where `test-windows` re-runs against 8.1.2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Windows FFmpeg setup process to use a specific Chocolatey version, improving installation consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3632
<!-- enterprise-sync-pr:end -->