### PR TITLE
release: bump version to 1.20.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ Installs FiftyOne.
 import os
 from setuptools import setup, find_packages
 
-VERSION = "1.20.0"
+VERSION = "1.20.1"
 
 
 def get_version():


### PR DESCRIPTION
Version bump for the 1.20.1 patch release (embeddings panel fix, #8181).

FOE companion `oss-sync/bump-versions-1.20.1` is pre-pushed with Enterprise versions (2.23.1 / OSS 1.20.1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version to **1.20.1**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->