### PR TITLE
docs: release notes for 1.20.1 / 2.23.1

### DIFF
--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -21,7 +21,7 @@ FiftyOne 1.20.1
 
 App
 ^^^
-- Fixed the Embeddings panel crashing when opened
+- Fixed a crash that occurred when opening the Embeddings panel
   `#8181 <https://github.com/voxel51/fiftyone/pull/8181>`_
 
 FiftyOne Enterprise 2.23.0

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -3,6 +3,26 @@ FiftyOne Release Notes
 
 .. default-role:: code
 
+FiftyOne Enterprise 2.23.1
+--------------------------
+*Released August 5, 2026*
+
+Includes all updates from :ref:`FiftyOne 1.20.1 <release-notes-v1.20.1>`, plus:
+
+- Fixed a bug that prevented users with the Labeler role from submitting
+  annotation tasks
+
+.. _release-notes-v1.20.1:
+
+FiftyOne 1.20.1
+---------------
+*Released August 5, 2026*
+
+App
+^^^
+- Fixed the Embeddings panel crashing when opened
+  `#8181 <https://github.com/voxel51/fiftyone/pull/8181>`_
+
 FiftyOne Enterprise 2.23.0
 --------------------------
 *Released July 31, 2026*

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -11,6 +11,7 @@ Includes all updates from :ref:`FiftyOne 1.20.1 <release-notes-v1.20.1>`, plus:
 
 - Fixed a bug that prevented users with the Labeler role from submitting
   annotation tasks
+- Fixed an error when deleting brain runs from the Embeddings panel
 
 .. _release-notes-v1.20.1:
 


### PR DESCRIPTION
Release notes for the 1.20.1 / 2.23.1 patch release (Embeddings panel fix, Labeler task submission fix). Will be cherry-picked to release/v1.20.1 before tagging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue preventing Labeler-role users from submitting annotation tasks.
  - Fixed errors when deleting brain runs from the Embeddings panel.
  - Fixed a crash that could occur when opening the Embeddings panel.
- **Documentation**
  - Added release notes for FiftyOne Enterprise 2.23.1 and FiftyOne 1.20.1 (released August 5, 2026).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3637
<!-- enterprise-sync-pr:end -->