### PR TITLE
Cherry-pick #8179 (pin choco ffmpeg) into release/v1.20.1

### DIFF
--- a/.github/actions/setup-ffmpeg/action.yml
+++ b/.github/actions/setup-ffmpeg/action.yml
@@ -10,7 +10,7 @@ runs:
     - name: Install ffmpeg (Windows)
       shell: pwsh
       run: |
-        choco install ffmpeg -y --no-progress --execution-timeout=600
+        choco install ffmpeg -y --version=8.1.2 --no-progress --execution-timeout=600
         # ensure the choco shim dir is on PATH for this and subsequent steps
         "C:\ProgramData\chocolatey\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         $env:PATH = "C:\ProgramData\chocolatey\bin;$env:PATH"


### PR DESCRIPTION
Cherry-pick of #8179. Windows CI on the 1.20 line fails in video tests because choco now installs ffmpeg 9; this pins the known-good version. CI-only change — fixes the red test-windows checks on #8182.

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3646
<!-- enterprise-sync-pr:end -->