### PR TITLE
[release] Cherry-pick #8183: release notes for 1.20.1 / 2.23.1

### DIFF
--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -3,6 +3,27 @@ FiftyOne Release Notes
 
 .. default-role:: code
 
+FiftyOne Enterprise 2.23.1
+--------------------------
+*Released August 5, 2026*
+
+Includes all updates from :ref:`FiftyOne 1.20.1 <release-notes-v1.20.1>`, plus:
+
+- Fixed a bug that prevented users with the Labeler role from submitting
+  annotation tasks
+- Fixed an error when deleting brain runs from the Embeddings panel
+
+.. _release-notes-v1.20.1:
+
+FiftyOne 1.20.1
+---------------
+*Released August 5, 2026*
+
+App
+^^^
+- Fixed a crash that occurred when opening the Embeddings panel
+  `#8181 <https://github.com/voxel51/fiftyone/pull/8181>`_
+
 FiftyOne Enterprise 2.23.0
 --------------------------
 *Released July 31, 2026*


### PR DESCRIPTION
Cherry-pick of #8183. Docs-only — release notes must be on the release branch before the final tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue preventing Labeler annotation tasks from being submitted.
  * Fixed deletion failures for Embeddings panel brain runs.
  * Resolved a crash in the Embeddings panel.

* **Documentation**
  * Added release notes for FiftyOne Enterprise 2.23.1 and FiftyOne 1.20.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3649
<!-- enterprise-sync-pr:end -->