### PR TITLE
fix(server): only exclude exact paths and their children from grid pagination payloads

### DIFF
--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -414,7 +414,12 @@ def _project_pagination_paths(
 
     selected_fields = ["_group"]  # store dynamic group values
     for path in schema:
-        if any(path.startswith(exclude) for exclude in excluded):
+        # exclude the field and its children, but not sibling fields that
+        # share a name prefix (e.g. `clip` must not exclude `clip-pred`)
+        if any(
+            path == exclude or path.startswith(exclude + ".")
+            for exclude in excluded
+        ):
             continue
 
         selected_fields.append(path)

--- a/tests/unittests/server_view_tests.py
+++ b/tests/unittests/server_view_tests.py
@@ -9,6 +9,8 @@ FiftyOne Server view tests.
 import math
 import unittest
 
+import numpy as np
+
 import fiftyone as fo
 import fiftyone.core.dataset as fod
 import fiftyone.core.labels as fol
@@ -260,6 +262,30 @@ class ServerViewTests(unittest.TestCase):
         }
         view = fosv.get_view("test", filters=filters)
         self.assertEqual(len(view), 0)
+
+    @drop_datasets
+    def test_pagination_data_excludes_exact_paths(self):
+        dataset = fo.Dataset("test")
+        dataset.add_sample(
+            fo.Sample(
+                filepath="image.png",
+                clip=np.array([1.0, 2.0]),
+                **{"clip-pred-test": fo.Classification(label="cat")},
+            )
+        )
+
+        view = fosv.get_view("test", pagination_data=True)
+        (sample,) = list(
+            foo.aggregate(
+                foo.get_db_conn()[view._dataset._sample_collection_name],
+                view._pipeline(),
+            )
+        )
+
+        # the vector field is excluded; a sibling field sharing its name
+        # prefix is not
+        self.assertNotIn("clip", sample)
+        self.assertIn("clip-pred-test", sample)
 
     @drop_datasets
     def test_extended_frame_sample(self):


### PR DESCRIPTION
## What

Grid pagination payloads exclude `DictField`/`VectorField` values (`_project_pagination_paths` in `fiftyone/server/view.py`), but the exclusion used a raw string-prefix match:

```python
if any(path.startswith(exclude) for exclude in excluded):
```

A vector field named `clip` therefore also excluded any sibling field sharing the name prefix — e.g. a `clip-pred-test` `Classification` never reached the App's grid samples, so its labels could not render even when toggled on in the sidebar (the schema still lists the field, so the checkbox appears to do nothing).

The match is now exact-path-or-child:

```python
if any(
    path == exclude or path.startswith(exclude + ".")
    for exclude in excluded
):
```

## Testing

- New unit test: a `clip` vector field is excluded from the pagination projection while its `clip-pred-test` sibling survives
- `tests/unittests/server_view_tests.py` passes (19 tests)
- Verified against a real dataset that grid samples now include the prefix-sibling classification and still exclude all vector/dict fields


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pagination field selection so only the matched field and its descendants are excluded.
  * Preserved access to distinct sibling fields with similar names, such as `clip-pred-test`.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3653
<!-- enterprise-sync-pr:end -->