### PR TITLE
refactor(core): lift the saved-views dropdown into its own component

### DIFF
--- a/app/packages/core/src/components/Sidebar/ViewSelection/SavedViewsSelection.tsx
+++ b/app/packages/core/src/components/Sidebar/ViewSelection/SavedViewsSelection.tsx
@@ -1,0 +1,75 @@
+import { Selection, type DatasetViewOption } from "@fiftyone/components";
+import { AddIcon, Box, LastOption, TextContainer } from "./styledComponents";
+
+export interface SavedViewsSelectionProps {
+  /** View options to list, already filtered by the search term. */
+  items: DatasetViewOption[];
+  selected: DatasetViewOption | null;
+  onSelect: (item: DatasetViewOption) => void;
+  onClear: () => void;
+  onEdit: (item: DatasetViewOption) => void;
+  /** Opens the create-view dialog from the pinned last option. */
+  onCreate: () => void;
+  search: { value: string; onSearch: (term: string) => void };
+  /** The viewer may not create or edit saved views. */
+  disabled: boolean;
+  /** Tooltip explaining ``disabled``. */
+  disabledMsg?: string;
+  /** There is nothing to save — the create option stays inert. */
+  isEmptyView: boolean;
+}
+
+/**
+ * The saved-views dropdown itself: the ``Selection`` list plus its pinned
+ * "Save current filters as view" option.
+ *
+ * Split out of ``ViewSelection`` so the surrounding component keeps only
+ * data-loading and URL/selection syncing, and so a caller can wrap the
+ * control without re-indenting it.
+ */
+export default function SavedViewsSelection({
+  items,
+  selected,
+  onSelect,
+  onClear,
+  onEdit,
+  onCreate,
+  search,
+  disabled,
+  disabledMsg,
+  isEmptyView,
+}: SavedViewsSelectionProps) {
+  const createDisabled = isEmptyView || disabled;
+
+  return (
+    <Selection
+      readonly={disabled}
+      id="saved-views"
+      selected={selected}
+      setSelected={onSelect}
+      onClear={onClear}
+      items={items}
+      onEdit={onEdit}
+      search={{
+        value: search.value,
+        placeholder: "Search views...",
+        onSearch: search.onSearch,
+      }}
+      lastFixedOption={
+        <LastOption
+          data-cy={"saved-views-create-new"}
+          onClick={() => !createDisabled && onCreate()}
+          disabled={createDisabled}
+          title={disabledMsg}
+        >
+          <Box style={{ width: "12%" }}>
+            <AddIcon fontSize="small" disabled={createDisabled} />
+          </Box>
+          <TextContainer disabled={createDisabled}>
+            Save current filters as view
+          </TextContainer>
+        </LastOption>
+      }
+    />
+  );
+}

--- a/app/packages/core/src/components/Sidebar/ViewSelection/index.tsx
+++ b/app/packages/core/src/components/Sidebar/ViewSelection/index.tsx
@@ -1,5 +1,4 @@
 import { useTrackEvent } from "@fiftyone/analytics";
-import { Selection } from "@fiftyone/components";
 import { default as useRefetchableSavedViews } from "../../../hooks/useRefetchableSavedViews";
 import * as fos from "@fiftyone/state";
 import { Suspense, useEffect, useMemo } from "react";
@@ -11,8 +10,9 @@ import {
   useSetRecoilState,
 } from "recoil";
 import { shouldToggleBookMarkIconOnSelector } from "../../Grid/Actions/SaveFilters";
+import SavedViewsSelection from "./SavedViewsSelection";
 import ViewDialog, { viewDialogContent } from "./ViewDialog";
-import { AddIcon, Box, LastOption, TextContainer } from "./styledComponents";
+import { Box } from "./styledComponents";
 
 export const viewSearchTerm = atom<string>({
   key: "viewSearchTerm",
@@ -208,11 +208,10 @@ export default function ViewSelection() {
             );
           }}
         />
-        <Selection
-          readonly={disabled}
-          id="saved-views"
+        <SavedViewsSelection
+          items={searchData}
           selected={selected}
-          setSelected={(item: fos.DatasetViewOption) => {
+          onSelect={(item: fos.DatasetViewOption) => {
             setSelected(item);
             setViewName(item.slug);
             trackEvent("select_saved_view");
@@ -221,7 +220,6 @@ export default function ViewSelection() {
             setSelected(fos.DEFAULT_SELECTED);
             resetView();
           }}
-          items={searchData}
           onEdit={(item) => {
             setEditView({
               color: item.color || "",
@@ -231,28 +229,16 @@ export default function ViewSelection() {
             });
             setIsOpen(true);
           }}
+          onCreate={() => setIsOpen(true)}
           search={{
             value: viewSearch,
-            placeholder: "Search views...",
             onSearch: (term: string) => {
               setViewSearch(term);
             },
           }}
-          lastFixedOption={
-            <LastOption
-              data-cy={"saved-views-create-new"}
-              onClick={() => !disabled && !isEmptyView && setIsOpen(true)}
-              disabled={isEmptyView || disabled}
-              title={disabledMsg}
-            >
-              <Box style={{ width: "12%" }}>
-                <AddIcon fontSize="small" disabled={isEmptyView || disabled} />
-              </Box>
-              <TextContainer disabled={isEmptyView || disabled}>
-                Save current filters as view
-              </TextContainer>
-            </LastOption>
-          }
+          disabled={disabled}
+          disabledMsg={disabledMsg}
+          isEmptyView={isEmptyView}
         />
       </Box>
     </Suspense>


### PR DESCRIPTION
### What

Extracts the `<Selection>` block at the bottom of `ViewSelection` into a new `SavedViewsSelection` component, behind an explicit prop interface. `ViewSelection` keeps the data loading and URL/selection syncing and drops to a single call.

### Why

`ViewSelection` currently does two unrelated jobs, and the rendering half is ~70 lines of JSX wedged under ~150 lines of state and effects. Splitting them makes each readable on its own, and makes the dropdown wrappable/reusable without re-indenting the whole control.

Full motivation: reduce FOE sync code divergence and conflicts

### Behavior

None intended. The same props reach `Selection`, the same `data-cy` hooks are emitted (`saved-views-create-new`, and everything `Selection` derives from `id="saved-views"`), and the create option keeps its `isEmptyView || disabled` gate — now computed once as `createDisabled` instead of being spelled out three times.

### Checks

- `tsc` on `packages/core`: same pre-existing errors in `ViewSelection/index.tsx` (the `DatasetViewOption` cast mismatches), none added; the new file is clean.
- Prettier clean.
- The saved-views e2e POM selectors are untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a searchable saved-view selector with options to select, clear, edit, and create views.
  * Added a pinned “Create view” option with support for disabled states and explanatory tooltips.
  * Preserved saved-view search and selection behavior in the sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3654
<!-- enterprise-sync-pr:end -->