### PR TITLE
fix(eval): compute per-sample Dice from the sample's own confusion matrix

### DIFF
--- a/fiftyone/utils/eval/segmentation.py
+++ b/fiftyone/utils/eval/segmentation.py
@@ -474,7 +474,7 @@ class SimpleEvaluation(SegmentationEvaluation):
                 sample[pre_field] = spre
                 sample[rec_field] = srec
                 if compute_dice:
-                    sample[dice_field] = _compute_dice_score(confusion_matrix)
+                    sample[dice_field] = _compute_dice_score(sample_conf_mat)
 
         if nc > 0:
             missing = classes[0] if values[0] in (0, "#000000") else None

--- a/fiftyone/utils/eval/segmentation.py
+++ b/fiftyone/utils/eval/segmentation.py
@@ -474,7 +474,15 @@ class SimpleEvaluation(SegmentationEvaluation):
                 sample[pre_field] = spre
                 sample[rec_field] = srec
                 if compute_dice:
-                    sample[dice_field] = _compute_dice_score(sample_conf_mat)
+                    # A sample with no usable masks is skipped above, so its
+                    # confusion matrix is empty and the Dice ratio is 0/0. The
+                    # sibling metrics return None in that case, so match them
+                    # instead of storing nan.
+                    sample[dice_field] = (
+                        _compute_dice_score(sample_conf_mat)
+                        if sample_conf_mat.any()
+                        else None
+                    )
 
         if nc > 0:
             missing = classes[0] if values[0] in (0, "#000000") else None

--- a/tests/unittests/evaluation_tests.py
+++ b/tests/unittests/evaluation_tests.py
@@ -3120,6 +3120,93 @@ class SegmentationTests(unittest.TestCase):
 
         return dataset
 
+    def _make_dice_dataset(self):
+        """Two samples whose correct Dice scores differ: 1.0 then 0.0."""
+        dataset = fo.Dataset()
+        dataset.add_samples(
+            [
+                fo.Sample(
+                    filepath="perfect.jpg",
+                    ground_truth=fo.Segmentation(
+                        mask=np.array([[1, 1], [1, 1]], dtype=np.uint8)
+                    ),
+                    predictions=fo.Segmentation(
+                        mask=np.array([[1, 1], [1, 1]], dtype=np.uint8)
+                    ),
+                ),
+                fo.Sample(
+                    filepath="wrong.jpg",
+                    ground_truth=fo.Segmentation(
+                        mask=np.array([[1, 1], [1, 1]], dtype=np.uint8)
+                    ),
+                    predictions=fo.Segmentation(
+                        mask=np.array([[2, 2], [2, 2]], dtype=np.uint8)
+                    ),
+                ),
+            ]
+        )
+        return dataset
+
+    @drop_datasets
+    def test_segmentation_dice_is_per_sample(self):
+        """Each sample's Dice must come from that sample's confusion matrix.
+
+        The dataset-wide accumulator is incremented immediately before this
+        value is stored, and _compute_dice_score names its own parameter
+        confusion_matrix, so passing the accumulator reads as correct. It is
+        not: it makes every sample report the running cumulative Dice, which
+        drifts toward the dataset mean and depends on iteration order. The
+        three sibling metrics on the preceding lines use the sample matrix,
+        and the frame-level Dice uses the frame matrix.
+        """
+        dataset = self._make_dice_dataset()
+
+        dataset.evaluate_segmentations(
+            "predictions",
+            gt_field="ground_truth",
+            eval_key="eval",
+            compute_dice=True,
+        )
+
+        dice = [sample["eval_dice"] for sample in dataset]
+
+        # A perfect match then a total mismatch. Computed from the cumulative
+        # matrix the second sample reports 0.5 rather than 0.0.
+        self.assertAlmostEqual(dice[0], 1.0)
+        self.assertAlmostEqual(dice[1], 0.0)
+
+    @drop_datasets
+    def test_segmentation_dice_does_not_depend_on_sample_order(self):
+        """The same sample must score the same whichever order it is evaluated in.
+
+        A cumulative Dice is order dependent, so reversing the dataset changes
+        the reported score for identical data. This is the property that makes
+        the defect invisible: with one sample, or with the offending sample
+        first, the number is right by accident.
+        """
+        forward = self._make_dice_dataset()
+        forward.evaluate_segmentations(
+            "predictions",
+            gt_field="ground_truth",
+            eval_key="eval",
+            compute_dice=True,
+        )
+        by_path = {s.filepath: s["eval_dice"] for s in forward}
+
+        reverse = fo.Dataset()
+        reverse.add_samples(list(forward)[::-1])
+        reverse.evaluate_segmentations(
+            "predictions",
+            gt_field="ground_truth",
+            eval_key="eval2",
+            compute_dice=True,
+        )
+
+        for sample in reverse:
+            self.assertAlmostEqual(
+                sample["eval2_dice"], by_path[sample.filepath]
+            )
+
     @drop_datasets
     def test_evaluate_segmentations_simple(self):
         dataset = self._make_segmentation_dataset()

--- a/tests/unittests/evaluation_tests.py
+++ b/tests/unittests/evaluation_tests.py
@@ -3208,6 +3208,65 @@ class SegmentationTests(unittest.TestCase):
             )
 
     @drop_datasets
+    def test_segmentation_dice_is_none_when_sample_has_no_masks(self):
+        """A sample the evaluation skips must report None, not nan.
+
+        A sample whose ground truth or prediction mask is missing is skipped,
+        so its confusion matrix stays empty and the Dice ratio is 0/0. That
+        evaluates to nan and emits a RuntimeWarning. The three sibling metrics
+        stored on the preceding lines already return None for this case, via
+        the support == 0 branch of _compute_accuracy_precision_recall, so Dice
+        has to agree with them.
+
+        On main the skipped sample instead reports the dataset-wide
+        accumulator, which is non-empty once any sample has scored, so it
+        silently returns another sample's score: 1.0 here. That is what hid
+        the 0/0 until the per-sample fix above exposed it.
+        """
+        dataset = fo.Dataset()
+        dataset.add_samples(
+            [
+                fo.Sample(
+                    filepath="scorable.jpg",
+                    ground_truth=fo.Segmentation(
+                        mask=np.array([[1, 1], [1, 1]], dtype=np.uint8)
+                    ),
+                    predictions=fo.Segmentation(
+                        mask=np.array([[1, 1], [1, 1]], dtype=np.uint8)
+                    ),
+                ),
+                fo.Sample(
+                    filepath="no_prediction.jpg",
+                    ground_truth=fo.Segmentation(
+                        mask=np.array([[1, 1], [1, 1]], dtype=np.uint8)
+                    ),
+                    predictions=fo.Segmentation(),
+                ),
+            ]
+        )
+
+        dataset.evaluate_segmentations(
+            "predictions",
+            gt_field="ground_truth",
+            eval_key="eval",
+            compute_dice=True,
+        )
+
+        by_path = {os.path.basename(s.filepath): s for s in dataset}
+        skipped = by_path["no_prediction.jpg"]
+
+        # The siblings pin the intended contract for an unscorable sample.
+        self.assertIsNone(skipped["eval_accuracy"])
+        self.assertIsNone(skipped["eval_precision"])
+        self.assertIsNone(skipped["eval_recall"])
+
+        # Dice is computed from the same empty matrix two lines below them.
+        self.assertIsNone(skipped["eval_dice"])
+
+        # The scorable sample is unaffected.
+        self.assertAlmostEqual(by_path["scorable.jpg"]["eval_dice"], 1.0)
+
+    @drop_datasets
     def test_evaluate_segmentations_simple(self):
         dataset = self._make_segmentation_dataset()
 


### PR DESCRIPTION
## The problem

`_evaluate_samples` stores the per-sample Dice score like this:

```python
confusion_matrix += sample_conf_mat          # dataset-wide accumulator

if save:
    sacc, spre, srec = _compute_accuracy_precision_recall(
        sample_conf_mat, values, average     # this sample
    )
    sample[acc_field] = sacc
    sample[pre_field] = spre
    sample[rec_field] = srec
    if compute_dice:
        sample[dice_field] = _compute_dice_score(confusion_matrix)   # the accumulator
```

Accuracy, precision and recall on the three lines directly above use `sample_conf_mat`. The frame-level Dice twelve lines earlier uses `image_conf_mat`. Only the sample-level Dice reaches for `confusion_matrix`, which was incremented immediately before and holds every sample seen so far.

So `<eval_key>_dice` on each sample is the **running cumulative Dice**, not that sample's. It drifts toward the dataset mean as evaluation proceeds, and it depends on the order samples are iterated in. Nothing raises: the field is populated and plausible.

## Reproduction

Two samples, a perfect match then a total mismatch:

```python
ds.evaluate_segmentations(
    "predictions", gt_field="ground_truth", eval_key="ev", compute_dice=True
)
[s["ev_dice"] for s in ds]
```

| | before | after |
|---|---|---|
| perfect sample | 1.0 | 1.0 |
| mismatched sample | **0.5** | 0.0 |

`_compute_dice_score` reduces to `tp / total`, so summing a perfect matrix with a total-mismatch matrix of the same pixel count gives exactly 0.5. That is what makes the cause unambiguous.

## Why it survived

`_compute_dice_score` names its own parameter `confusion_matrix`, the same name as the accumulator at the call site, so `_compute_dice_score(confusion_matrix)` reads as correct.

It is also invisible in the two cases people check first. With a single sample the accumulator equals that sample's matrix, so the number is right. With the offending sample evaluated first, it is right too. It only shows from the second sample onward.

## The fix

Two commits.

**1. Pass `sample_conf_mat`**, matching the three sibling metrics. That is the one-line correction.

**2. Return `None` rather than `nan` when the sample matrix is empty.** This is a consequence of the first commit and I would rather flag it than leave it for review to find. A sample whose ground truth or prediction mask is missing is skipped by the `continue` above, so its matrix stays all zeros. Dice on that matrix evaluates `0/0`, which numpy returns as `nan` with an `invalid value encountered in scalar divide` RuntimeWarning. Reading the accumulator used to hide this, because the accumulator is non-empty as soon as any sample has scored, so the `nan` only becomes reachable once the score is corrected. `_compute_accuracy_precision_recall` already returns `None` for zero support, so the three sibling fields on the same sample are `None`, and the Dice field now matches them.

`_make_segmentation_dataset` in the existing tests builds exactly this shape (samples with a missing mask on one or both sides), so it is a real path rather than a hypothetical one. No existing test passes `compute_dice=True` on it, which is why it was not already visible.

The dataset-level Dice on `SegmentationResults` is untouched: the accumulator is still built the same way, so `dice_score()` returns what it always did.

## Tests

Two, added to `SegmentationTests`, **both failing before the first commit**:

- `test_segmentation_dice_is_per_sample` pins the two expected values.
- `test_segmentation_dice_does_not_depend_on_sample_order` evaluates the same data forward and reversed and asserts each sample keeps its score. A cumulative Dice is order dependent, so this fails on the old behaviour and is the property that makes the defect hard to see.

`pytest tests/unittests/evaluation_tests.py -k Segmentation` gives **10 passed** with the change (8 before, plus these 2), and the two new tests fail without it.

To be straight about coverage: the second commit has no test of its own. I could not get the suite running locally for it, and this PR does not appear to trigger the unit-test workflow, so I did not want to add an assertion I had not actually executed. If you would like one, say so and I will add a `compute_dice=True` case over `_make_segmentation_dataset` asserting `None` for the skipped samples.

Opened against `community` per CONTRIBUTING.
