### PR TITLE
Fix MCAP sidebar scroll and inspector layout nitpicks

### DIFF
--- a/app/packages/multimodal/src/adapters/mcap/react/McapInspectorSidebar.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapInspectorSidebar.tsx
@@ -39,7 +39,10 @@ const McapInspectorSidebar: React.FC = () => {
           inspect it. Esc clears the selection.
         </span>
       ) : (
-        <div className={settingsStyles.root} data-testid="mcap-inspector-body">
+        <div
+          className={`${settingsStyles.root} ${settingsStyles.inspectorBody}`}
+          data-testid="mcap-inspector-body"
+        >
           {selected.kind === "scene-annotation" ? (
             <SceneObjectFields selected={selected} />
           ) : (
@@ -103,11 +106,15 @@ function ImageObjectFields({
       <Field label="Object" value={selected.label ?? selected.primitiveKind} />
       <Field label="Kind" value={selected.primitiveKind} />
       <Field label="Topic" value={selected.topic} />
-      <div className={settingsStyles.field}>
+      <div
+        className={`${settingsStyles.field} ${settingsStyles.growField}`}
+      >
         <Text variant={TextVariant.Xs} color={TextColor.Secondary}>
           Geometry
         </Text>
-        <pre className={settingsStyles.metaText} style={preStyle}>
+        <pre
+          className={`${settingsStyles.metaText} ${settingsStyles.growPre}`}
+        >
           {safeJson(selected.data)}
         </pre>
       </div>
@@ -133,14 +140,6 @@ function Field({
     </div>
   );
 }
-
-const preStyle: React.CSSProperties = {
-  margin: 0,
-  maxHeight: 240,
-  overflow: "auto",
-  whiteSpace: "pre-wrap",
-  wordBreak: "break-word",
-};
 
 function safeJson(value: unknown): string {
   try {

--- a/app/packages/multimodal/src/adapters/mcap/react/McapInspectorSidebar.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapInspectorSidebar.tsx
@@ -106,15 +106,11 @@ function ImageObjectFields({
       <Field label="Object" value={selected.label ?? selected.primitiveKind} />
       <Field label="Kind" value={selected.primitiveKind} />
       <Field label="Topic" value={selected.topic} />
-      <div
-        className={`${settingsStyles.field} ${settingsStyles.growField}`}
-      >
+      <div className={`${settingsStyles.field} ${settingsStyles.growField}`}>
         <Text variant={TextVariant.Xs} color={TextColor.Secondary}>
           Geometry
         </Text>
-        <pre
-          className={`${settingsStyles.metaText} ${settingsStyles.growPre}`}
-        >
+        <pre className={`${settingsStyles.metaText} ${settingsStyles.growPre}`}>
           {safeJson(selected.data)}
         </pre>
       </div>

--- a/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.module.css
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.module.css
@@ -7,8 +7,33 @@
 .sidebarRoot {
   display: flex;
   flex-direction: column;
-  min-height: 100%;
+  height: 100%;
+  min-height: 0;
   padding: 12px 16px;
+}
+
+.toggleSwitchRoot {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.tabPanelGroup {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+}
+
+/* Fills the active tab panel (rendered by ToggleSwitch) so tab content
+   can opt into its own internal scroll region instead of the outer
+   sidebar scrolling as one unit. */
+.tabPanelGroup > * {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
 }
 
 .stickyTabList {
@@ -88,10 +113,21 @@
   gap: 8px;
 }
 
+.topicsTabContent {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
 .topicGroups {
   display: flex;
+  flex: 1;
   flex-direction: column;
   gap: 12px;
+  margin-right: -8px;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 8px;
 }
 
 .topicSearchInput {
@@ -99,19 +135,8 @@
   width: 100%;
 }
 
-.stickyTopicSearch {
-  isolation: isolate;
-  position: sticky;
-  top: 52px;
-  z-index: 1;
-}
-
-.stickyTopicSearch::before {
-  background: var(--color-content-bg-background);
-  content: "";
-  inset: -8px 0;
-  position: absolute;
-  z-index: -1;
+.topicSearchBar {
+  flex: 0 0 auto;
 }
 
 .statsDisclosure {

--- a/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.module.css
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.module.css
@@ -124,7 +124,6 @@
   flex: 1;
   flex-direction: column;
   gap: 12px;
-  margin-right: -8px;
   min-height: 0;
   overflow-y: auto;
   padding-right: 8px;

--- a/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapSettingsSidebar.tsx
@@ -157,11 +157,13 @@ const McapSettingsSidebar: React.FC<{
     <div className={styles.sidebarRoot}>
       <ToggleSwitch
         key={hasPanelTab ? "with-panel" : "scene-only"}
+        className={styles.toggleSwitchRoot}
         defaultIndex={defaultIndex}
         fullWidth
         onChange={handleTabChange}
         size={Size.Sm}
         tabListClassName={styles.stickyTabList}
+        tabPanelClassName={styles.tabPanelGroup}
         tabs={tabs}
       />
     </div>

--- a/app/packages/multimodal/src/adapters/mcap/react/McapTile.settings.module.css
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapTile.settings.module.css
@@ -10,6 +10,25 @@
   gap: 6px;
 }
 
+.inspectorBody {
+  flex: 1;
+  min-height: 0;
+}
+
+.growField {
+  flex: 1;
+  min-height: 0;
+}
+
+.growPre {
+  flex: 1;
+  margin: 0;
+  min-height: 120px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
 .recommendButton {
   align-self: flex-start;
   background: transparent;

--- a/app/packages/multimodal/src/adapters/mcap/react/McapTile.settings.module.css
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapTile.settings.module.css
@@ -25,8 +25,8 @@
   margin: 0;
   min-height: 120px;
   overflow: auto;
+  overflow-wrap: anywhere;
   white-space: pre-wrap;
-  word-break: break-word;
 }
 
 .recommendButton {

--- a/app/packages/multimodal/src/adapters/mcap/react/McapTopicsSettings.tsx
+++ b/app/packages/multimodal/src/adapters/mcap/react/McapTopicsSettings.tsx
@@ -75,13 +75,15 @@ const McapTopicsSettings: React.FC<{
   );
 
   return (
-    <div className={`${styles.root} ${styles.tabContent}`}>
+    <div
+      className={`${styles.root} ${styles.tabContent} ${styles.topicsTabContent}`}
+    >
       {rows.length === 0 ? (
         <span className={styles.topicEmpty}>No topics found</span>
       ) : (
         <>
           {showSearch ? (
-            <div className={styles.stickyTopicSearch}>
+            <div className={styles.topicSearchBar}>
               <Input
                 aria-label="Search topics"
                 className={styles.topicSearchInput}


### PR DESCRIPTION
<!--
Community contributors: target the `community` branch, not `develop`. PRs from
non-members are auto-retargeted to `community`. See CONTRIBUTING.md:
https://github.com/voxel51/fiftyone/blob/develop/CONTRIBUTING.md#community-pull-requests
-->

## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

Fixes two layout bugs in the MCAP viewer's settings sidebars:

- **Left sidebar, Topics tab**: scrolling the topic list scrolled the entire
  sidebar as one unit, dragging the tab bar and search box along with it.
  `McapSettingsSidebar` and `McapTopicsSettings` now build a proper
  fixed-height flex chain from the sidebar root down through `ToggleSwitch`'s
  active tab panel, so only the topic list (`.topicGroups`) scrolls
  internally — the tab bar and search box stay put. The search box no longer
  needs the `position: sticky` workaround it previously relied on. Also added
  a small right-side gutter so the scrollbar doesn't sit flush against the
  row content.
- **Right sidebar, object inspector**: `mcap-inspector-body` didn't fill its
  container, and the "Geometry" JSON blob for inspected image objects was
  capped at a fixed `max-height: 240px` regardless of how much room was
  actually available. The inspector body now flexes to fill the sidebar
  panel, and the Geometry `<pre>` grows to consume the remaining space (with
  a sensible `min-height: 120px` floor) instead of using a fixed cap.

No behavioral/data changes — this is CSS/layout only.

AFTER:
<img width="1824" height="1312" alt="screenshot-2026-08-06_11-37-49" src="https://github.com/user-attachments/assets/0f7a20f0-e402-4ad0-854a-41e9a3dc4ab5" />


BEFORE:
<img width="1828" height="1271" alt="screenshot-2026-08-06_11-39-08" src="https://github.com/user-attachments/assets/563b81fb-ab2c-48e6-aa32-8d0e365fa810" />

## 🧪 How is this patch tested? If it is not, please explain why.

Manually verified in the running app:
- Left sidebar Topics tab: scrolled a topic list long enough to overflow and
  confirmed the tab bar and search box stay fixed while only the list
  scrolls, with a small gutter between the row content and the scrollbar.
- Right sidebar inspector: selected scene and image objects and confirmed
  the inspector body fills the available height and the Geometry JSON panel
  grows/shrinks with the sidebar instead of clipping at a fixed height.

No existing unit tests cover pixel-level scroll/flex layout, so this was
verified visually rather than via `McapSettingsSidebar.test.tsx` /
`McapInspectorSidebar.test.tsx` (which still pass unmodified).

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCAP inspector layout and scrolling behavior.
  * Topic groups now scroll correctly within their tab without affecting surrounding controls.
  * Enhanced handling of long, preformatted inspector content with wrapping and flexible sizing.
  * Improved vertical sizing and alignment for settings toggles and tab panels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3675
<!-- enterprise-sync-pr:end -->