### PR TITLE
[FOEPD-4324] New MM right sidebar

### DIFF
--- a/app/packages/core/src/components/Modal/Actions/index.tsx
+++ b/app/packages/core/src/components/Modal/Actions/index.tsx
@@ -13,6 +13,7 @@ import Similarity from "../../Actions/Similarity";
 import Tag from "../../Actions/Tag";
 import ToggleSidebar from "../../Actions/ToggleSidebar";
 import { useModalContext } from "../hooks";
+import { MEDIA_TYPE_MULTIMODAL } from "@fiftyone/utilities";
 import GroupVisibility from "./GroupVisibility";
 import HiddenLabels from "./HiddenLabels";
 import ToggleFullscreen from "./ToggleFullscreen";
@@ -78,6 +79,7 @@ export default () => {
   const isActualGroup = useRecoilValue(fos.isGroup);
   const isDynamicGroup = useRecoilValue(fos.isDynamicGroup);
   const isFullScreen = useRecoilValue(fos.fullscreen);
+  const isMultimodal = fos.useIsMediaType(MEDIA_TYPE_MULTIMODAL);
   const mode = useAtomValue(modalMode);
   const isGroup = useMemo(
     () => isActualGroup || isDynamicGroup,
@@ -111,7 +113,9 @@ export default () => {
         <BrowseOperations modal />
         <OperatorPlacements modal place={types.Places.SAMPLES_VIEWER_ACTIONS} />
         <ToggleFullscreen />
-        <ToggleSidebar modal />
+        {/* multimodal owns its own right panel and never mounts the classic
+            sidebar, so there's nothing for this to toggle there */}
+        {!isMultimodal && <ToggleSidebar modal />}
       </Container>
     </Draggable>
   );

--- a/app/packages/core/src/components/Modal/Modal.test.tsx
+++ b/app/packages/core/src/components/Modal/Modal.test.tsx
@@ -2,6 +2,19 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { shouldShowClassicSidebar } from "./utils";
+
+describe("shouldShowClassicSidebar", () => {
+  it("is false for a multimodal viewer, regardless of sidebar visibility", () => {
+    expect(shouldShowClassicSidebar(true, true)).toBe(false);
+    expect(shouldShowClassicSidebar(false, true)).toBe(false);
+  });
+
+  it("follows sidebar visibility for a non-multimodal viewer", () => {
+    expect(shouldShowClassicSidebar(true, false)).toBe(true);
+    expect(shouldShowClassicSidebar(false, false)).toBe(false);
+  });
+});
 
 describe("Modal keyboard shortcuts handler", () => {
   let mockHandlers: {

--- a/app/packages/core/src/components/Modal/Modal.tsx
+++ b/app/packages/core/src/components/Modal/Modal.tsx
@@ -13,7 +13,12 @@ import { ErrorDisplayMarkup, HelpPanel, JSONPanel } from "@fiftyone/components";
 import { selectiveRenderingEventBus } from "@fiftyone/looker";
 import { OPERATOR_PROMPT_AREAS, OperatorPromptArea } from "@fiftyone/operators";
 import * as fos from "@fiftyone/state";
-import { ModalMode, canAnnotate, useModalMode } from "@fiftyone/state";
+import {
+  ModalMode,
+  canAnnotate,
+  useIsMediaType,
+  useModalMode,
+} from "@fiftyone/state";
 import {
   currentModalUniqueIdJotaiAtom,
   jotaiStore,
@@ -42,6 +47,7 @@ import { useAnnotationTracking } from "./Sidebar/Annotate/useAnnotationTracking"
 import { TooltipInfo } from "./TooltipInfo";
 import { useLookerHelpers, useTooltipEventHandler } from "./hooks";
 import { modalContext } from "./modal-context";
+import { shouldShowClassicSidebar } from "./utils";
 
 const ModalWrapper = styled.div`
   position: fixed;
@@ -239,6 +245,11 @@ const Modal = () => {
   );
 
   const isSidebarVisible = useRecoilValue(fos.sidebarVisible(true));
+  const isMultimodal = useIsMediaType(MEDIA_TYPE_MULTIMODAL);
+  const showClassicSidebar = shouldShowClassicSidebar(
+    isSidebarVisible,
+    isMultimodal,
+  );
 
   useKeyBindings(KnownContexts.Modal, [
     {
@@ -347,7 +358,7 @@ const Modal = () => {
               <ModalSpace />
               <ModalStatusBar />
             </SpacesContainer>
-            {isSidebarVisible && <Sidebar />}
+            {showClassicSidebar && <Sidebar />}
             <OperatorPromptArea area={OPERATOR_PROMPT_AREAS.DRAWER_RIGHT} />
 
             {jsonPanel.isOpen && (

--- a/app/packages/core/src/components/Modal/Modal.tsx
+++ b/app/packages/core/src/components/Modal/Modal.tsx
@@ -45,9 +45,12 @@ import { SegmentationToolbar } from "./Sidebar/Annotate/Edit/SegmentationToolbar
 import { useAnnotationStatus } from "./Sidebar/Annotate/Edit/useAnnotationStatus";
 import { useAnnotationTracking } from "./Sidebar/Annotate/useAnnotationTracking";
 import { TooltipInfo } from "./TooltipInfo";
-import { useLookerHelpers, useTooltipEventHandler } from "./hooks";
+import {
+  useLookerHelpers,
+  useShowClassicSidebar,
+  useTooltipEventHandler,
+} from "./hooks";
 import { modalContext } from "./modal-context";
-import { shouldShowClassicSidebar } from "./utils";
 
 const ModalWrapper = styled.div`
   position: fixed;
@@ -244,12 +247,8 @@ const Modal = () => {
     [is3dVisible, modalCloseHandler],
   );
 
-  const isSidebarVisible = useRecoilValue(fos.sidebarVisible(true));
+  const showClassicSidebar = useShowClassicSidebar();
   const isMultimodal = useIsMediaType(MEDIA_TYPE_MULTIMODAL);
-  const showClassicSidebar = shouldShowClassicSidebar(
-    isSidebarVisible,
-    isMultimodal,
-  );
 
   useKeyBindings(KnownContexts.Modal, [
     {
@@ -266,13 +265,19 @@ const Modal = () => {
       label: "Fullscreen",
       description: "Enter/Exit full screen mode",
     },
-    {
-      commandId: KnownCommands.ModalSidebarToggle,
-      sequence: "s",
-      handler: sidebarFn,
-      label: "Sidebar",
-      description: "Show/Hide the sidebar",
-    },
+    // multimodal has no classic sidebar to show/hide, so the shortcut would
+    // silently flip state that mounts nothing
+    ...(isMultimodal
+      ? []
+      : [
+          {
+            commandId: KnownCommands.ModalSidebarToggle,
+            sequence: "s",
+            handler: sidebarFn,
+            label: "Sidebar",
+            description: "Show/Hide the sidebar",
+          },
+        ]),
     {
       commandId: KnownCommands.ModalSelect,
       sequence: "x",

--- a/app/packages/core/src/components/Modal/ModalNavigation.tsx
+++ b/app/packages/core/src/components/Modal/ModalNavigation.tsx
@@ -10,6 +10,7 @@ import styled from "styled-components";
 import useExit from "./Sidebar/Annotate/Edit/useExit";
 import useSave from "./Sidebar/Annotate/Edit/useSave";
 import { createDebouncedNavigator } from "./debouncedNavigator";
+import { useShowClassicSidebar } from "./hooks";
 import {
   KnownCommands,
   KnownContexts,
@@ -63,7 +64,7 @@ const ModalNavigation = ({ closePanels }: { closePanels: () => void }) => {
   );
   const clearUndo = useUndoRedo(KnownContexts.ModalAnnotate).clear;
   const sidebarwidth = useRecoilValue(fos.sidebarWidth(true));
-  const isSidebarVisible = useRecoilValue(fos.sidebarVisible(true));
+  const isSidebarVisible = useShowClassicSidebar();
 
   const countLoadable = useRecoilValueLoadable(
     fos.count({ path: "", extended: true, modal: false }),

--- a/app/packages/core/src/components/Modal/hooks.ts
+++ b/app/packages/core/src/components/Modal/hooks.ts
@@ -1,8 +1,25 @@
 import * as fos from "@fiftyone/state";
-import { useHelpPanel, useJSONPanel } from "@fiftyone/state";
+import { useHelpPanel, useIsMediaType, useJSONPanel } from "@fiftyone/state";
+import { MEDIA_TYPE_MULTIMODAL } from "@fiftyone/utilities";
 import { useCallback, useContext, useRef } from "react";
-import { useRecoilCallback } from "recoil";
+import { useRecoilCallback, useRecoilValue } from "recoil";
 import { modalContext } from "./modal-context";
+import { shouldShowClassicSidebar } from "./utils";
+
+/**
+ * Whether the modal's classic sidebar is actually mounted.
+ *
+ * Anything positioned against the sidebar, or that offers to toggle it, must
+ * read this rather than `sidebarVisible` directly — multimodal suppresses the
+ * sidebar regardless of that flag, so `sidebarVisible` alone would leave
+ * controls that do nothing and layout inset against a panel that isn't there.
+ */
+export const useShowClassicSidebar = () => {
+  const isSidebarVisible = useRecoilValue(fos.sidebarVisible(true));
+  const isMultimodal = useIsMediaType(MEDIA_TYPE_MULTIMODAL);
+
+  return shouldShowClassicSidebar(isSidebarVisible, isMultimodal);
+};
 
 export const useLookerHelpers = () => {
   const jsonPanel = useJSONPanel();

--- a/app/packages/core/src/components/Modal/utils.ts
+++ b/app/packages/core/src/components/Modal/utils.ts
@@ -1,3 +1,11 @@
+// Multimodal viewers use their own right-panel tabs (Inspect/Fields) and
+// don't populate the classic sidebar's projection/aggregation data, so
+// mounting it here would only fire redundant queries.
+export const shouldShowClassicSidebar = (
+  isSidebarVisible: boolean,
+  isMultimodal: boolean,
+): boolean => isSidebarVisible && !isMultimodal;
+
 interface ShortcutItem {
   shortcut: string;
 }

--- a/app/packages/multimodal/src/testing/integration/SourcePlayback.integration.test.tsx
+++ b/app/packages/multimodal/src/testing/integration/SourcePlayback.integration.test.tsx
@@ -55,7 +55,7 @@ vi.mock("../../views/episode/shell/PlaybackShell", () => ({
 vi.mock("../../views/episode/shell/AddTileMenu", () => ({
   default: () => null,
 }));
-vi.mock("../../views/episode/scene/picking/InspectorSidebar", () => ({
+vi.mock("../../views/episode/shell/RightSidebar", () => ({
   default: () => null,
 }));
 vi.mock("../../views/episode/shell/NetworkStatus", () => ({

--- a/app/packages/multimodal/src/views/episode/shell/FieldsSidebar.test.tsx
+++ b/app/packages/multimodal/src/views/episode/shell/FieldsSidebar.test.tsx
@@ -1,0 +1,155 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+interface FakeField {
+  path: string;
+  ftype: string;
+  description?: string;
+  dbField?: string | null;
+}
+
+const { fakeFields, useActiveModalSample, useSampleFields, useTimeZone } =
+  vi.hoisted(() => ({
+    fakeFields: [] as FakeField[],
+    useActiveModalSample: vi.fn(),
+    useSampleFields: vi.fn(),
+    useTimeZone: vi.fn(),
+  }));
+
+vi.mock("@fiftyone/state", () => ({
+  useActiveModalSample,
+  useSampleFields,
+  useTimeZone,
+}));
+
+import FieldsSidebar from "./FieldsSidebar";
+
+function setFields(fields: FakeField[]) {
+  fakeFields.length = 0;
+  fakeFields.push(...fields);
+}
+
+describe("FieldsSidebar", () => {
+  beforeEach(() => {
+    useSampleFields.mockImplementation(() => fakeFields);
+    useTimeZone.mockReturnValue("UTC");
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("shows an empty state when the dataset has no sample fields", () => {
+    setFields([]);
+    useActiveModalSample.mockReturnValue({});
+
+    render(<FieldsSidebar />);
+
+    expect(screen.getByTestId("episode-fields-empty")).toBeTruthy();
+  });
+
+  it("filters out private (underscore-prefixed) schema fields", () => {
+    setFields([
+      { path: "_media_type", ftype: "fiftyone.core.fields.StringField" },
+      { path: "filepath", ftype: "fiftyone.core.fields.StringField" },
+    ]);
+    useActiveModalSample.mockReturnValue({ filepath: "/a/b.mcap" });
+
+    render(<FieldsSidebar />);
+
+    const body = screen.getByTestId("episode-fields-body");
+    expect(body.textContent).toContain("filepath");
+    expect(body.textContent).not.toContain("_media_type");
+  });
+
+  it("renders a plain string field's actual value, not its schema type", () => {
+    setFields([
+      { path: "filepath", ftype: "fiftyone.core.fields.StringField" },
+    ]);
+    useActiveModalSample.mockReturnValue({
+      filepath: "/data/scene-0001.mcap",
+    });
+
+    render(<FieldsSidebar />);
+
+    const body = screen.getByTestId("episode-fields-body");
+    expect(body.textContent).toContain("/data/scene-0001.mcap");
+    expect(body.textContent).not.toContain("StringField");
+  });
+
+  it("resolves `id` against the sample's actual `_id` key", () => {
+    setFields([
+      {
+        path: "id",
+        ftype: "fiftyone.core.fields.ObjectIdField",
+        dbField: "_id",
+      },
+    ]);
+    useActiveModalSample.mockReturnValue({ _id: "abc123" });
+
+    render(<FieldsSidebar />);
+
+    expect(screen.getByTestId("episode-fields-body").textContent).toContain(
+      "abc123",
+    );
+  });
+
+  it("formats a DateTimeField's raw {_cls, datetime} wrapper into a readable date", () => {
+    setFields([
+      { path: "created_at", ftype: "fiftyone.core.fields.DateTimeField" },
+    ]);
+    useActiveModalSample.mockReturnValue({
+      created_at: { _cls: "DateTime", datetime: 1_700_000_000_000 },
+    });
+
+    render(<FieldsSidebar />);
+
+    const value = screen.getByTestId("episode-fields-body").textContent ?? "";
+    expect(value).not.toContain("_cls");
+    expect(value).not.toContain("1700000000000");
+    // formatDateTime renders year-month-day with "-" separators (en-ZA).
+    expect(value).toMatch(/\d{4}-\d{2}-\d{2}/);
+  });
+
+  it("renders an em dash for a field with no value, instead of blank", () => {
+    setFields([
+      { path: "metadata", ftype: "fiftyone.core.fields.EmbeddedDocumentField" },
+    ]);
+    useActiveModalSample.mockReturnValue({});
+
+    render(<FieldsSidebar />);
+
+    expect(screen.getByTestId("episode-fields-body").textContent).toContain(
+      "—",
+    );
+  });
+
+  it("JSON-renders a list field's value", () => {
+    setFields([{ path: "tags", ftype: "fiftyone.core.fields.ListField" }]);
+    useActiveModalSample.mockReturnValue({ tags: ["train", "front-cam"] });
+
+    render(<FieldsSidebar />);
+
+    expect(screen.getByTestId("episode-fields-body").textContent).toContain(
+      '["train","front-cam"]',
+    );
+  });
+
+  it("shows a field's description when present", () => {
+    setFields([
+      {
+        path: "media_type",
+        ftype: "fiftyone.core.fields.StringField",
+        description: "The type of media for the sample.",
+      },
+    ]);
+    useActiveModalSample.mockReturnValue({ media_type: "multimodal" });
+
+    render(<FieldsSidebar />);
+
+    expect(screen.getByTestId("episode-fields-body").textContent).toContain(
+      "The type of media for the sample.",
+    );
+  });
+});

--- a/app/packages/multimodal/src/views/episode/shell/FieldsSidebar.tsx
+++ b/app/packages/multimodal/src/views/episode/shell/FieldsSidebar.tsx
@@ -1,0 +1,128 @@
+import {
+  useActiveModalSample,
+  useSampleFields,
+  useTimeZone,
+} from "@fiftyone/state";
+import { formatPrimitive } from "@fiftyone/utilities";
+import { getNestedField } from "@fiftyone/utilities/src/sample/pointer";
+import { Text, TextColor, TextVariant } from "@voxel51/voodo";
+import React from "react";
+import settingsStyles from "../tiles/Tile.settings.module.css";
+
+/**
+ * The raw sample doc keys some fields by their Mongo `dbField` rather than
+ * their schema path — most commonly `id` (schema path) / `_id` (actual key).
+ * Only the field's own last path segment can differ this way (nested
+ * embedded-document fields don't get renamed at the db level), so swapping
+ * just that segment is enough.
+ */
+const resolveDbPath = (field: {
+  path: string;
+  dbField?: string | null;
+}): string => {
+  if (!field.dbField) {
+    return field.path;
+  }
+  const segments = field.path.split(".");
+  segments[segments.length - 1] = field.dbField;
+  return segments.join(".");
+};
+
+/**
+ * Renders a field's value for display. Dates/datetimes go through the same
+ * formatter as the classic sidebar rather than showing their raw
+ * `{"_cls":"DateTime","datetime":<ms>}` wrapper; arrays/objects (tags, …)
+ * get JSON'd rather than showing "[object Object]"; `null`/`undefined` (no
+ * value set — including fields, like `metadata`, that were never computed
+ * for this sample) render as an em dash so they're distinguishable from a
+ * genuinely empty string value.
+ */
+const formatFieldValue = (
+  value: unknown,
+  ftype: string,
+  timeZone: string,
+): string => {
+  if (value === null || value === undefined) {
+    return "—";
+  }
+  if (typeof value === "string" || typeof value === "number") {
+    const formatted = formatPrimitive({
+      ftype,
+      timeZone,
+      value: value as never,
+    });
+    return formatted === null ? String(value) : String(formatted);
+  }
+  if (typeof value === "boolean") {
+    return value ? "true" : "false";
+  }
+  if (
+    typeof value === "object" &&
+    "datetime" in (value as Record<string, unknown>)
+  ) {
+    const formatted = formatPrimitive({
+      ftype,
+      timeZone,
+      value: value as { datetime: number },
+    });
+    if (formatted !== null) {
+      return String(formatted);
+    }
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+};
+
+/**
+ * "Fields" tab for the MM right sidebar: the current sample's actual field
+ * *values* (not the schema). Field paths/order come from the same
+ * `fields()` selector the classic (now-removed-in-Multimodal) sidebar uses —
+ * that's schema metadata already resolved by the dataset view, so no new
+ * GraphQL query — but each value is read from the active modal sample.
+ */
+const FieldsSidebar: React.FC = () => {
+  const sampleFields = useSampleFields();
+  const activeSample = useActiveModalSample();
+  const timeZone = useTimeZone();
+  const nonPrivateFields = sampleFields.filter(
+    (field) => field && !field.path.startsWith("_"),
+  );
+
+  if (nonPrivateFields.length === 0) {
+    return (
+      <span
+        className={settingsStyles.emptyText}
+        data-testid="episode-fields-empty"
+      >
+        This dataset has no sample fields.
+      </span>
+    );
+  }
+
+  return (
+    <div className={settingsStyles.root} data-testid="episode-fields-body">
+      {nonPrivateFields.map((field) => (
+        <div className={settingsStyles.field} key={field.path}>
+          <Text variant={TextVariant.Xs} color={TextColor.Secondary}>
+            {field.path}
+          </Text>
+          <Text variant={TextVariant.Xs} color={TextColor.Primary}>
+            {formatFieldValue(
+              getNestedField(activeSample, resolveDbPath(field)),
+              field.ftype,
+              timeZone,
+            )}
+          </Text>
+          {field.description ? (
+            <span className={settingsStyles.metaText}>{field.description}</span>
+          ) : null}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default FieldsSidebar;

--- a/app/packages/multimodal/src/views/episode/shell/RightSidebar.module.css
+++ b/app/packages/multimodal/src/views/episode/shell/RightSidebar.module.css
@@ -1,0 +1,26 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+
+/* Tab content (`SidebarPanel`, in both tabs) already pads itself — 12px 16px
+   for its body, matching the left sidebar's root padding — so only the tab
+   list itself needs it here; padding the whole root would double it up for
+   the content. */
+.tabList {
+  padding: 12px 16px 0;
+}
+
+.tabs {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.tabPanel {
+  height: 100%;
+}

--- a/app/packages/multimodal/src/views/episode/shell/RightSidebar.test.tsx
+++ b/app/packages/multimodal/src/views/episode/shell/RightSidebar.test.tsx
@@ -1,0 +1,90 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { useState } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import styles from "./RightSidebar.module.css";
+import RightSidebar from "./RightSidebar";
+
+// Isolates this test to RightSidebar's own wiring (the tab list padding
+// below, and which tab's content mounts by default) — neither sidebar's own
+// content/data plumbing is relevant here and each has its own test coverage.
+vi.mock("../scene/picking/InspectorSidebar", () => ({
+  default: () => <div data-testid="stub-inspector" />,
+}));
+vi.mock("./FieldsSidebar", () => ({
+  default: () => <div data-testid="stub-fields" />,
+}));
+
+// `ToggleSwitch` itself is voodo's, exercised by its own package's tests;
+// stubbed here to a minimal tab-switching shim (clicking a label activates
+// its content) so this test isn't coupled to its internal (HeadlessUI)
+// implementation, while still covering tab selection.
+vi.mock("@voxel51/voodo", () => ({
+  Size: { Sm: "sm" },
+  ToggleSwitchVariant: { Soft: "soft" },
+  HeadingLevel: { H4: "h4" },
+  Heading: ({ children }: { children: ReactNode }) => <h4>{children}</h4>,
+  Divider: () => <hr />,
+  ToggleSwitch: ({
+    tabs,
+    tabListClassName,
+    defaultIndex = 0,
+  }: {
+    tabs: { id: string; data: { label: string; content: ReactNode } }[];
+    tabListClassName?: string;
+    defaultIndex?: number;
+  }) => {
+    const [activeIndex, setActiveIndex] = useState(defaultIndex);
+    return (
+      <div>
+        <div role="tablist" className={tabListClassName}>
+          {tabs.map((tab, index) => (
+            <button
+              key={tab.id}
+              type="button"
+              onClick={() => setActiveIndex(index)}
+            >
+              {tab.data.label}
+            </button>
+          ))}
+        </div>
+        <div>{tabs[activeIndex]?.data.content}</div>
+      </div>
+    );
+  },
+}));
+
+describe("RightSidebar", () => {
+  afterEach(() => cleanup());
+
+  it("renders the Inspect/Fields tab switch", () => {
+    render(<RightSidebar />);
+
+    expect(screen.getByText("Inspect")).toBeTruthy();
+    expect(screen.getByText("Fields")).toBeTruthy();
+  });
+
+  it("pads the tab list to match the left sidebar's edge inset", () => {
+    render(<RightSidebar />);
+
+    // Whatever `styles.tabList` resolves to (its plain source name under
+    // this package's own `classNameStrategy: "non-scoped"` vitest config,
+    // or a hashed name under any other), the rendered tablist must carry it.
+    expect(screen.getByRole("tablist").className).toContain(styles.tabList);
+  });
+
+  it("shows the Inspect tab's content by default", () => {
+    render(<RightSidebar />);
+
+    expect(screen.getByTestId("stub-inspector")).toBeTruthy();
+  });
+
+  it("mounts FieldsSidebar when the Fields tab is selected", () => {
+    render(<RightSidebar />);
+
+    fireEvent.click(screen.getByText("Fields"));
+
+    expect(screen.getByTestId("stub-fields")).toBeTruthy();
+    expect(screen.queryByTestId("stub-inspector")).toBeNull();
+  });
+});

--- a/app/packages/multimodal/src/views/episode/shell/RightSidebar.tsx
+++ b/app/packages/multimodal/src/views/episode/shell/RightSidebar.tsx
@@ -1,0 +1,59 @@
+import { SidebarPanel } from "@fiftyone/tiling";
+import { Size, ToggleSwitch, ToggleSwitchVariant } from "@voxel51/voodo";
+import React from "react";
+import InspectorSidebar from "../scene/picking/InspectorSidebar";
+import FieldsSidebar from "./FieldsSidebar";
+import styles from "./RightSidebar.module.css";
+
+/**
+ * MM right panel: "Inspect" / "Fields" tabs (voodo `ToggleSwitch`).
+ *
+ * A bottom discussion tray (Teams-only, via an OSS extension seam) lands in
+ * a follow-up PR once the Teams-side registration exists.
+ */
+const RightSidebar: React.FC = () => {
+  return (
+    <div className={styles.root}>
+      <div className={styles.tabs}>
+        <ToggleSwitch
+          size={Size.Sm}
+          variant={ToggleSwitchVariant.Soft}
+          tabListClassName={styles.tabList}
+          fullWidth
+          tabs={[
+            {
+              id: "inspect",
+              data: {
+                label: "Inspect",
+                content: (
+                  <div className={styles.tabPanel}>
+                    <InspectorSidebarBody />
+                  </div>
+                ),
+              },
+            },
+            {
+              id: "fields",
+              data: {
+                label: "Fields",
+                content: (
+                  <div className={styles.tabPanel}>
+                    <SidebarPanel title="Fields">
+                      <FieldsSidebar />
+                    </SidebarPanel>
+                  </div>
+                ),
+              },
+            },
+          ]}
+        />
+      </div>
+    </div>
+  );
+};
+
+// `InspectorSidebar` already renders its own `SidebarPanel` shell, so it
+// slots directly into the "Inspect" tab body without a wrapper.
+const InspectorSidebarBody: React.FC = () => <InspectorSidebar />;
+
+export default RightSidebar;

--- a/app/packages/multimodal/src/views/episode/shell/SourcePlayback.test.tsx
+++ b/app/packages/multimodal/src/views/episode/shell/SourcePlayback.test.tsx
@@ -95,7 +95,7 @@ vi.mock("./PlaybackShell", () => {
 });
 
 vi.mock("./AddTileMenu", () => ({ default: () => null }));
-vi.mock("../scene/picking/InspectorSidebar", () => ({
+vi.mock("./RightSidebar", () => ({
   default: () => null,
 }));
 vi.mock("./NetworkStatus", () => ({

--- a/app/packages/multimodal/src/views/episode/shell/SourcePlayback.tsx
+++ b/app/packages/multimodal/src/views/episode/shell/SourcePlayback.tsx
@@ -64,7 +64,7 @@ import { SceneUpdateHistoryProvider } from "../scene/entities/scene-update-histo
 import { SelectionHotkeys } from "../interaction/selection/selected-object";
 import AddTileMenu from "./AddTileMenu";
 import { tileTypesFor, getTileDefinition } from "./tile-catalog";
-import InspectorSidebar from "../scene/picking/InspectorSidebar";
+import RightSidebar from "./RightSidebar";
 import styles from "./ModalRenderer.module.css";
 import { NetworkHealthTracker, NetworkStatusPill } from "./NetworkStatus";
 import { FullHistoryInterestsProvider } from "../playback/full-history-interests";
@@ -493,7 +493,7 @@ export const SourcePlayback: React.FC<SourcePlaybackProps> = ({
                                     />
                                   ) : null
                                 }
-                                rightSidebar={<InspectorSidebar />}
+                                rightSidebar={<RightSidebar />}
                                 sharedImageWebGpuViews
                                 defaultRightOpen={false}
                                 defaultLeftOpen={defaultLeftOpen}

--- a/app/packages/state/src/hooks/index.ts
+++ b/app/packages/state/src/hooks/index.ts
@@ -34,6 +34,7 @@ export * from "./useRenderConfig3d";
 export { default as useReset } from "./useReset";
 export { default as useResetExtendedSelection } from "./useResetExtendedSelection";
 export * from "./useRetryController";
+export { default as useSampleFields } from "./useSampleFields";
 export { default as useSavedViews } from "./useSavedViews";
 export { default as useSchemaSettings } from "./useSchemaSettings";
 export { default as useScreenshot } from "./useScreenshot";

--- a/app/packages/state/src/hooks/useSampleFields.ts
+++ b/app/packages/state/src/hooks/useSampleFields.ts
@@ -1,0 +1,11 @@
+import { useRecoilValue } from "recoil";
+import { fields, State } from "../recoil";
+
+/**
+ * Returns the dataset's sample-space fields (schema metadata resolved by the
+ * active view), sorted by field path.
+ */
+const useSampleFields = () =>
+  useRecoilValue(fields({ space: State.SPACE.SAMPLE }));
+
+export default useSampleFields;

--- a/e2e-pw/src/oss/specs/annotate-multimodal-disabled.spec.ts
+++ b/e2e-pw/src/oss/specs/annotate-multimodal-disabled.spec.ts
@@ -1,4 +1,4 @@
-import { test as base } from "src/oss/fixtures";
+import { test as base, expect } from "src/oss/fixtures";
 import { GridPom } from "src/oss/poms/grid";
 import { ModalPom } from "src/oss/poms/modal";
 import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
@@ -41,21 +41,16 @@ test.beforeEach(async ({ page, fiftyoneLoader }) => {
 });
 
 test.describe.serial("annotate-multimodal-disabled", () => {
-  test("annotate sidebar is disabled for multimodal datasets", async ({
+  test("the classic sidebar's explore/annotate mode switcher is unavailable for multimodal datasets", async ({
     grid,
     modal,
   }) => {
     await grid.openFirstSample();
 
-    // multimodal media renders through its own viewer, not the looker, so
-    // looker load markers never appear; switching modes auto-waits on the
-    // sidebar tab, which is this test's real precondition
-    await modal.sidebar.switchMode("annotate");
-
-    // the annotate sidebar must refuse to load and explain why, rather than
-    // exposing the annotation tools for an unsupported media type
-    await modal.sidebar.assert.hasDisabledMessage(
-      "supported for multimodal datasets",
-    );
+    // Multimodal media renders through its own MM sidebar (Inspect/Fields
+    // tabs) instead of the classic sidebar entirely, so there's no
+    // explore/annotate mode switcher to switch into "annotate" mode with in
+    // the first place — nothing left to disable.
+    await expect(modal.sidebar.locator).toHaveCount(0);
   });
 });

--- a/e2e-pw/src/oss/specs/annotate-multimodal-disabled.spec.ts
+++ b/e2e-pw/src/oss/specs/annotate-multimodal-disabled.spec.ts
@@ -44,6 +44,7 @@ test.describe.serial("annotate-multimodal-disabled", () => {
   test("the classic sidebar's explore/annotate mode switcher is unavailable for multimodal datasets", async ({
     grid,
     modal,
+    page,
   }) => {
     await grid.openFirstSample();
 
@@ -52,5 +53,11 @@ test.describe.serial("annotate-multimodal-disabled", () => {
     // explore/annotate mode switcher to switch into "annotate" mode with in
     // the first place — nothing left to disable.
     await expect(modal.sidebar.locator).toHaveCount(0);
+
+    // ...and no leftover control offering to toggle a sidebar that can never
+    // mount.
+    await expect(
+      page.getByTestId("modal").getByTestId("action-toggle-sidebar"),
+    ).toHaveCount(0);
   });
 });

--- a/e2e-pw/src/oss/specs/mcap-correctness.spec.ts
+++ b/e2e-pw/src/oss/specs/mcap-correctness.spec.ts
@@ -492,7 +492,8 @@ async function openMcapModal(
   sampleIndex = 0,
 ): Promise<void> {
   await grid.openNthSample(sampleIndex);
-  await modal.sidebar.hide();
+  // multimodal never mounts the classic sidebar (it has its own right panel),
+  // so there's nothing to hide and no toggle to hide it with
   await modal.enterFullscreen();
 }
 


### PR DESCRIPTION
## 🔗 Related Issues

[FOEPD-4324]

## 📋 What changes are proposed in this pull request?

Two fixes to the multimodal right sidebar:

- **Padding**: the tab list (Inspect/Fields) ran flush to the sidebar's edges,
  unlike the left sidebar. Added padding matching the left sidebar's root
  padding, applied via `tabListClassName` on the `ToggleSwitch` rather than
  the sidebar root, since the tab content (`SidebarPanel`, used by both tabs)
  already pads itself — padding the root too would have doubled it.
- **Fields tab showed schema, not data**: it rendered each field's `path` and
  `ftype` (e.g. `fiftyone.core.fields.DateTimeField`) instead of the current
  sample's actual value. Now reads the active modal sample and resolves each
  field's real value:
  - Raw `{_cls: "DateTime", datetime: <ms>}` values are formatted through the
    same `formatPrimitive`/`formatDateTime` helpers the classic sidebar uses,
    instead of showing the raw wrapper.
  - `id` (schema path) is resolved against the sample's actual `_id` key via
    each field's `dbField`.
  - Fields with no value (e.g. `metadata`, which isn't computed for this
    media type on this dataset) render as an em dash rather than a blank/`—`
    ambiguity with an empty string.
    
    
<img width="418" height="1337" alt="image" src="https://github.com/user-attachments/assets/f72ed072-5a29-4f57-8f63-c5f23003aaa1" />


## 🧪 How is this patch tested? If it is not, please explain why.

- `McapRightSidebar.test.tsx` (new): tab list renders, padding class is wired
  to `ToggleSwitch`'s `tabListClassName`, Inspect tab mounts by default.
- `McapFieldsSidebar.test.tsx` (new): empty-schema state, private-field
  filtering, plain string values, `id`→`_id` resolution, DateTime formatting,
  em-dash for missing values, JSON rendering of list fields, field
  descriptions.
- `yarn workspace @fiftyone/multimodal run check` (lint + deps + types) and
  `vitest run` pass for the package; pre-existing unrelated failures in this
  local checkout (a `@voxel51/voodo` dev-symlink pulling in a second React
  copy) reproduce identically on unmodified `McapSettingsSidebar.test.tsx`.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No — internal MM sidebar UI polish.

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes

[FOEPD-4324]: https://voxel51.atlassian.net/browse/FOEPD-4324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an MCAP right sidebar with separate **Inspect** and **Fields** tabs.
  * Added field inspection showing public sample fields, formatted values, descriptions, and missing-value indicators.
  * Added scrolling and full-height layout support for sidebar content.
* **Bug Fixes**
  * Prevented the classic sidebar from appearing in multimodal viewers.
* **Tests**
  * Added coverage for sidebar tabs, field rendering, formatting, filtering, and empty states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3670
<!-- enterprise-sync-pr:end -->