### PR TITLE
[FOEPD-4402] Fix embeddings plot double click selection 

### DIFF
--- a/app/packages/embeddings-v2/src/legendFilter.test.ts
+++ b/app/packages/embeddings-v2/src/legendFilter.test.ts
@@ -130,25 +130,31 @@ describe("legendLabels", () => {
 });
 
 describe("soloLabel", () => {
-  it("writes the exclusion of every other class", () => {
+  it("writes an inclusion filter naming only the isolated class", () => {
+    // Exclusion could only name the OTHER known classes, leaving
+    // unlisted values (missing, or past the top-N cap) visible
     expect(soloLabel(null, LABELS, "dog")).toEqual({
-      values: ["cat", "bird"],
-      exclude: true,
+      values: ["dog"],
+      exclude: false,
     });
-  });
-
-  // Identical toggle states must produce identical filters no matter
-  // the click path — otherwise the same legend state renders
-  // differently (sidebar mode, grey/unlisted points) by history
-  it("is exactly equivalent to single-clicking every other class off", () => {
-    const viaSolo = soloLabel(null, LABELS, "dog");
-    let viaToggles = toggleLabel(null, LABELS, "cat");
-    viaToggles = toggleLabel(viaToggles, LABELS, "bird");
-    expect(viaSolo).toEqual(viaToggles);
   });
 
   it("restores all classes when the lone visible class is solo'd again", () => {
     const solo = soloLabel(null, LABELS, "dog");
     expect(soloLabel(solo, LABELS, "dog")).toBeNull();
+  });
+
+  it("recognizes an inclusion filter reached by other means as already solo'd", () => {
+    expect(
+      soloLabel({ values: ["dog"], exclude: false }, LABELS, "dog"),
+    ).toBeNull();
+  });
+
+  it("drops any prior filter's foreign values and extra properties", () => {
+    const filter = { values: ["zebra"], exclude: true, isMatching: true };
+    expect(soloLabel(filter, LABELS, "dog")).toEqual({
+      values: ["dog"],
+      exclude: false,
+    });
   });
 });

--- a/app/packages/embeddings-v2/src/legendFilter.test.ts
+++ b/app/packages/embeddings-v2/src/legendFilter.test.ts
@@ -46,24 +46,35 @@ describe("toggleLabel", () => {
     expect(toggleLabel(once, LABELS, "dog")).toBeNull();
   });
 
-  // Representation is a pure function of the toggle set: an inclusion
-  // filter (e.g. hand-written in the sidebar) converts to the
-  // equivalent exclusion on the first legend click
-  it("converts inclusion filters to exclusion", () => {
-    const included = { values: ["cat"], exclude: false };
-    expect(toggleLabel(included, LABELS, "dog")).toEqual({
-      values: ["bird"],
-      exclude: true,
+  // The clicks after a double click must go on editing its inclusion —
+  // rewriting it as an exclusion is what un-isolated the solo'd class
+  it("keeps editing an inclusion filter as an inclusion", () => {
+    const solo = soloLabel(null, LABELS, "dog");
+    const two = toggleLabel(solo, LABELS, "cat");
+    expect(two).toEqual({ values: ["cat", "dog"], exclude: false });
+    expect(toggleLabel(two, LABELS, "cat")).toEqual({
+      values: ["dog"],
+      exclude: false,
     });
   });
 
-  it("collapses to no filter when every class is back on", () => {
+  it("clears the filter when the last shown class is clicked off", () => {
+    // An empty inclusion reads as no filter at all, so it can't be
+    // written — and an exclusion here would undo the solo
+    const solo = soloLabel(null, LABELS, "dog");
+    expect(toggleLabel(solo, LABELS, "dog")).toBeNull();
+  });
+
+  it("collapses to no filter when an exclusion turns every class back on", () => {
     expect(
       toggleLabel({ values: ["cat"], exclude: true }, LABELS, "cat"),
     ).toBeNull();
+  });
+
+  it("stays an inclusion when it grows to every class", () => {
     expect(
       toggleLabel({ values: ["cat", "dog"], exclude: false }, LABELS, "bird"),
-    ).toBeNull();
+    ).toEqual({ values: LABELS, exclude: false });
   });
 
   it("allows toggling every class off", () => {
@@ -86,13 +97,11 @@ describe("toggleLabel", () => {
     });
   });
 
-  it("drops an inclusion filter's foreign values", () => {
-    // Inclusion of an unlisted value cannot survive in exclusion form —
-    // carrying "zebra" into the exclusion list would invert its meaning
+  it("preserves included sidebar values outside the legend's class list", () => {
     const filter = { values: ["zebra"], exclude: false };
     expect(toggleLabel(filter, LABELS, "cat")).toEqual({
-      values: ["dog", "bird"],
-      exclude: true,
+      values: ["cat", "zebra"],
+      exclude: false,
     });
   });
 

--- a/app/packages/embeddings-v2/src/legendFilter.ts
+++ b/app/packages/embeddings-v2/src/legendFilter.ts
@@ -1,26 +1,20 @@
 /**
  * Legend click semantics as pure transforms over the App's sidebar
- * filter for the color-by field. The legend keeps no selection state of
- * its own: which classes are "on" derives from that filter, and a click
- * maps the current filter to the next one — so sidebar edits and legend
- * clicks can never disagree. `null` stands for "no filter" (every class
- * on) in both directions.
+ * filter for the color-by field. Which classes are "on" derives from
+ * that filter, not legend state, so sidebar edits and legend clicks can
+ * never disagree. `null` means no filter (every class on).
  *
- * The legend writes EXCLUSION filters, always. The filter is a pure
- * function of the toggle set — identical toggle states produce
- * identical filters no matter the click path, so the sidebar can never
- * flip between "omit" and "show" for the same legend state, and a solo
- * (double-click) is exactly equivalent to single-clicking every other
- * class off. Consequences accepted with that choice: points with no
- * value in the field, and a capped field's unlisted (>top-N) classes,
- * are never hidden by legend clicks — exclusion can't name them.
+ * toggleLabel (single click) writes EXCLUSION: hide a few known
+ * classes, keep everyone else — including values the legend doesn't
+ * know about — visible.
  *
- * Other rules:
- * - Excluded values outside the legend's class list (sidebar entries
- *   for uncapped classes) ride along untouched; an inclusion filter's
- *   foreign values cannot be expressed in exclusion form and are
- *   dropped on the first legend click.
- * - A filter that turns every class back on collapses to `null`.
+ * soloLabel (double click) writes INCLUSION: exclusion can't isolate
+ * one class, since values outside the legend's list (missing, or past
+ * the top-N cap) would stay visible. Solo also drops any prior filter's
+ * foreign values/extra properties; toggle carries them forward where
+ * representable.
+ *
+ * A filter that turns every class back on collapses to `null`.
  */
 import type { ColorMeta } from "./protocol";
 
@@ -88,9 +82,9 @@ export function toggleLabel(
   return build(filter, on, labels);
 }
 
-/** Double click: isolate one class — a bulk toggle, writing the exact
- * filter that single-clicking every other class off would. On the lone
- * visible class, restore all (the escape hatch) */
+/** Double click: isolate one class via inclusion — exclusion could only
+ * name the OTHER known classes, leaving unlisted values visible. On the
+ * lone visible class, restore all (the escape hatch) */
 export function soloLabel(
   filter: CategoricalFilter | null,
   labels: readonly string[],
@@ -98,7 +92,7 @@ export function soloLabel(
 ): CategoricalFilter | null {
   const on = onLabels(filter, labels);
   if (on.size === 1 && on.has(label)) return null;
-  return build(filter, new Set([label]), labels);
+  return { values: [label], exclude: false };
 }
 
 function build(

--- a/app/packages/embeddings-v2/src/legendFilter.ts
+++ b/app/packages/embeddings-v2/src/legendFilter.ts
@@ -4,15 +4,16 @@
  * that filter, not legend state, so sidebar edits and legend clicks can
  * never disagree. `null` means no filter (every class on).
  *
- * toggleLabel (single click) writes EXCLUSION: hide a few known
- * classes, keep everyone else — including values the legend doesn't
- * know about — visible.
- *
  * soloLabel (double click) writes INCLUSION: exclusion can't isolate
  * one class, since values outside the legend's list (missing, or past
  * the top-N cap) would stay visible. Solo also drops any prior filter's
- * foreign values/extra properties; toggle carries them forward where
- * representable.
+ * foreign values/extra properties.
+ *
+ * toggleLabel (single click) keeps whichever form the filter is already
+ * in, so the clicks after a solo go on editing its inclusion instead of
+ * undoing it. With no filter to follow it writes EXCLUSION: hide a few
+ * known classes, keep everyone else — including values the legend
+ * doesn't know about — visible.
  *
  * A filter that turns every class back on collapses to `null`.
  */
@@ -101,16 +102,18 @@ function build(
   labels: readonly string[],
 ): CategoricalFilter | null {
   const known = new Set(labels);
-  // Only exclusions can carry foreign values forward — an inclusion
-  // filter's foreign values would invert meaning in exclusion form
-  const foreign =
-    base?.exclude === true
-      ? (base.values ?? []).filter(
-          (value) => !(typeof value === "string" && known.has(value)),
-        )
-      : [];
-  const off = labels.filter((label) => !on.has(label));
-  if (!off.length && !foreign.length) return null;
+  // The form follows the filter being edited: the inclusion a solo left
+  // behind goes on naming what is shown, everything else names what is
+  // hidden. Foreign values ride along in either form — their meaning
+  // only inverts if the form changes under them
+  const include = Boolean(base?.values) && base?.exclude !== true;
+  const foreign = (base?.values ?? []).filter(
+    (value) => !(typeof value === "string" && known.has(value)),
+  );
+  const values = labels.filter((label) =>
+    include ? on.has(label) : !on.has(label),
+  );
+  if (!values.length && !foreign.length) return null;
 
-  return { ...base, values: [...off, ...foreign], exclude: true };
+  return { ...base, values: [...values, ...foreign], exclude: !include };
 }


### PR DESCRIPTION
<!--
Community contributors: target the `community` branch, not `develop`. PRs from
non-members are auto-retargeted to `community`. See CONTRIBUTING.md:
https://github.com/voxel51/fiftyone/blob/develop/CONTRIBUTING.md#community-pull-requests
-->

## 🔗 Related Issues

- fix double clicking on legend item not filtering to just the selected value

## 📋 What changes are proposed in this pull request?

- use an inclusion filter to isolate a legend value

## 🧪 How is this patch tested? If it is not, please explain why.

- tested locally

https://github.com/user-attachments/assets/1e16730c-dad5-4198-b619-5cc9e33b5606



## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Double-clicking a legend label now isolates it with an inclusion filter.
  - Repeatedly isolating the same label clears the filter.
  - Legend toggles preserve the current filter mode while editing included labels.
  - Existing equivalent filters are recognized correctly.

- **Bug Fixes**
  - Clearing the last included label now removes the filter.
  - Unknown, capped, and unrelated values are handled without affecting the selected label.
  - Solo filters now discard unrelated values and properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3672
<!-- enterprise-sync-pr:end -->