### PR TITLE
Fix phantom last frame in video annotation playback

### DIFF
--- a/app/packages/playback/src/lib/playback/PlaybackProvider.test.tsx
+++ b/app/packages/playback/src/lib/playback/PlaybackProvider.test.tsx
@@ -273,11 +273,32 @@ describe("PlaybackProvider engine actions", () => {
       expect(result.current.playhead).toBeCloseTo(1 / 30, 5);
     });
 
-    it("stepForward clamps at duration", () => {
+    it("stepForward clamps at the last frame's start, not duration", () => {
+      // Duration is the last frame's EXCLUSIVE end — resting there would show
+      // a phantom frame past the media. 10s at 1/30 = 300 frames; the last
+      // frame (300) starts at 299/30.
+      const { result } = renderEngine({ duration: 10 });
+      act(() => result.current.api.seek(299 / 30));
+      act(() => result.current.api.stepForward());
+      expect(result.current.playhead).toBeCloseTo(299 / 30, 5);
+    });
+
+    it("stepForward pulls a playhead resting at duration back onto the last frame", () => {
       const { result } = renderEngine({ duration: 10 });
       act(() => result.current.api.seek(10));
       act(() => result.current.api.stepForward());
-      expect(result.current.playhead).toBe(10);
+      expect(result.current.playhead).toBeCloseTo(299 / 30, 5);
+    });
+
+    it("stepForward can enter a partial trailing frame", () => {
+      // 10.02s at 1/30: the final (partial) frame starts at 300/30 = 10.0
+      // and ends at duration. Its start is a valid rest position.
+      const { result } = renderEngine({ duration: 10.02 });
+      act(() => result.current.api.seek(299 / 30));
+      act(() => result.current.api.stepForward());
+      expect(result.current.playhead).toBeCloseTo(300 / 30, 5);
+      act(() => result.current.api.stepForward());
+      expect(result.current.playhead).toBeCloseTo(300 / 30, 5);
     });
 
     it("stepBack subtracts stepInterval", () => {
@@ -740,7 +761,7 @@ describe("PlaybackProvider engine actions", () => {
         }
       });
 
-      it("clamps the target to [0, duration] before snapping", () => {
+      it("clamps the target to the real frame range before snapping", () => {
         const { result } = renderEngine({
           duration: 10,
           snapToFrameOnSettle: true,
@@ -748,8 +769,10 @@ describe("PlaybackProvider engine actions", () => {
         act(() => result.current.api.seekSnapped(-5));
         expect(result.current.playhead).toBe(0);
         act(() => result.current.api.seekSnapped(999));
-        // 10s is already a frame boundary at 1/30 step (300 frames).
-        expect(result.current.playhead).toBeCloseTo(10, 5);
+        // Scrubbing past the end lands on the LAST frame's start (299/30),
+        // not `duration` — 10s is the last frame's exclusive end, one whole
+        // step past its start (a phantom frame with no media behind it).
+        expect(result.current.playhead).toBeCloseTo(299 / 30, 5);
       });
 
       it("crossing frame boundaries during a drag advances the playhead in discrete jumps", () => {

--- a/app/packages/playback/src/lib/playback/use-playback-engine.ts
+++ b/app/packages/playback/src/lib/playback/use-playback-engine.ts
@@ -78,6 +78,26 @@ function displayedFrameStart(time: number, step: number): number {
 }
 
 /**
+ * Start of the LAST displayed frame within `[0, duration)` — the latest
+ * frame-aligned rest position that still lies inside the media. `duration`
+ * itself is that frame's *exclusive* end: a playhead resting there is one
+ * whole step past the last frame's start, so it reads as a frame beyond the
+ * media (no stream has content for it) while being visually identical to the
+ * last frame — a phantom duplicate. Frame-aligned rest paths (step, settle
+ * snap, snapped scrub) cap here; continuous `seek` keeps the full inclusive
+ * `[0, duration]` range.
+ */
+function lastFrameStart(duration: number, step: number): number {
+  if (!(step > 0) || !(duration > 0)) {
+    return duration;
+  }
+
+  // `ceil - 1` (not `floor`) so an exact-multiple duration lands on the
+  // previous boundary; the epsilon absorbs float error in `duration / step`.
+  return Math.max(0, (Math.ceil(duration / step - 1e-6) - 1) * step);
+}
+
+/**
  * Cap on per-tick `dt` (sec) in the engine's wallclock-driven advance.
  * When the main thread is blocked (memory pressure, GC pause, throttled
  * tab) RAF callbacks pile up and the next `timestamp - lastTimestamp`
@@ -633,7 +653,7 @@ export function usePlaybackEngine({
       const snapped = clamp(
         displayedFrameStart(current, step),
         0,
-        store.get(durationAtom),
+        lastFrameStart(store.get(durationAtom), step),
       );
 
       if (Math.abs(snapped - current) < step * 1e-6) {
@@ -691,7 +711,10 @@ export function usePlaybackEngine({
         // Half-step ties round toward +Infinity per JS `Math.round`, so
         // an exact midpoint cursor tips forward — deterministic and
         // imperceptible in practice (sub-frame mouse precision).
-        const snapped = Math.round(clamped / step) * step;
+        const snapped = Math.min(
+          Math.round(clamped / step) * step,
+          lastFrameStart(store.get(durationAtom), step),
+        );
 
         // Early-return when the snap result matches the current playhead —
         // happens on every sub-frame drag delta that stays within the same
@@ -736,14 +759,11 @@ export function usePlaybackEngine({
         if (pendingPlayRef.current) requestOrStartPlayback(next);
       },
       stepForward: () => {
+        const step = store.get(stepIntervalAtom);
         const next = clamp(
-          frameBoundaryStep(
-            store.get(playheadAtom),
-            store.get(stepIntervalAtom),
-            "forward",
-          ),
+          frameBoundaryStep(store.get(playheadAtom), step, "forward"),
           0,
-          store.get(durationAtom),
+          lastFrameStart(store.get(durationAtom), step),
         );
         store.set(playheadAtom, next);
         fireSeekEvent(next, true);

--- a/app/packages/video-annotation/src/hooks/useVideoAnnotationActions.tsx
+++ b/app/packages/video-annotation/src/hooks/useVideoAnnotationActions.tsx
@@ -3,7 +3,8 @@ import { useModalSample } from "@fiftyone/state";
 import { Icon, IconName, Size } from "@voxel51/voodo";
 import { useAtomValue } from "jotai";
 import { useMemo } from "react";
-import { frameAt, usePlayhead } from "@fiftyone/playback";
+import { usePlayhead } from "@fiftyone/playback";
+import { resolveFrameCount } from "../utils/frameCount";
 import { getModalSampleFrameRate } from "../utils/modalSample";
 import {
   labelSchemaData,
@@ -16,6 +17,7 @@ import {
   useSelectionIsInstanceTrack,
   useSelectionIsKeyframeable,
 } from "../state/useVideoInteraction";
+import { useCurrentFrame } from "../state/useCurrentFrame";
 import { useFrameKeyframeState } from "./useFrameKeyframeState";
 import { useVideoSurfaceActions } from "./useVideoSurfaceActions";
 import { AiTrackUpsellButton } from "../components/AiTrackUpsellButton";
@@ -66,6 +68,7 @@ const DiamondIcon = ({ filled }: { filled: boolean }) => (
 export const useVideoAnnotationActions = (): ToolbarActionGroup[] => {
   const actions = useVideoSurfaceActions();
   const playhead = usePlayhead();
+  const playheadFrame = useCurrentFrame();
   const selected = useSelectedTrackIds();
   const modalSample = useModalSample();
 
@@ -145,9 +148,13 @@ export const useVideoAnnotationActions = (): ToolbarActionGroup[] => {
             isDisabled: !canCreateTd,
             onClick: () => {
               if (!canCreateTd || !tdFieldPath || !fps) return;
-              // Default: 1-second window starting at the playhead frame.
-              const startFrame = frameAt(playhead, fps);
-              const endFrame = startFrame + Math.round(fps);
+              // Default: 1-second window starting at the playhead frame,
+              // capped at the video's last frame.
+              const startFrame = playheadFrame;
+              const endFrame = Math.min(
+                startFrame + Math.round(fps),
+                resolveFrameCount(modalSample, fps) ?? Infinity,
+              );
               actions.createTemporalDetection(
                 tdFieldPath,
                 [startFrame, endFrame],
@@ -186,7 +193,7 @@ export const useVideoAnnotationActions = (): ToolbarActionGroup[] => {
                 return;
               }
 
-              actions.splitTrack(selectedIds[0], frameAt(playhead, fps));
+              actions.splitTrack(selectedIds[0], playheadFrame);
             },
           },
           {
@@ -213,7 +220,9 @@ export const useVideoAnnotationActions = (): ToolbarActionGroup[] => {
       fps,
       hasSelection,
       isKeyframeAtPlayhead,
+      modalSample,
       playhead,
+      playheadFrame,
       selectedIds,
       selectionIsInstanceTrack,
       selectionIsKeyframeable,

--- a/app/packages/video-annotation/src/state/useCurrentFrame.test.ts
+++ b/app/packages/video-annotation/src/state/useCurrentFrame.test.ts
@@ -1,0 +1,72 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+// NTSC-style sample: 120 frames at 30000/1001 fps, duration 4.004s. The
+// engine's seek/step clamp is inclusive of `duration`, so the playhead can
+// rest exactly there — the conversion must not report a frame past the last.
+const FPS = 30000 / 1001;
+const TOTAL_FRAMES = 120;
+const DURATION = TOTAL_FRAMES / FPS;
+
+const { source } = vi.hoisted(() => ({
+  source: {
+    playhead: 0,
+    frameRate: undefined as number | undefined,
+    totalFrameCount: undefined as number | undefined,
+  },
+}));
+
+// Keep the real `frameAt` — the clamp under test lives in the interplay
+// between it and the frame count this hook resolves; only the playhead
+// source is stubbed.
+vi.mock("@fiftyone/playback", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@fiftyone/playback")>()),
+  usePlayhead: () => source.playhead,
+}));
+
+vi.mock("@fiftyone/state", () => ({
+  useModalSample: () => ({
+    frameRate: source.frameRate,
+    sample: { metadata: { total_frame_count: source.totalFrameCount } },
+  }),
+}));
+
+import { useCurrentFrame } from "./useCurrentFrame";
+
+describe("useCurrentFrame", () => {
+  it("converts the playhead to a 1-indexed frame", () => {
+    source.playhead = 0;
+    source.frameRate = FPS;
+    source.totalFrameCount = TOTAL_FRAMES;
+
+    const { result } = renderHook(() => useCurrentFrame());
+    expect(result.current).toBe(1);
+  });
+
+  it("clamps a playhead resting at duration to the last real frame", () => {
+    source.playhead = DURATION;
+    source.frameRate = FPS;
+    source.totalFrameCount = TOTAL_FRAMES;
+
+    const { result } = renderHook(() => useCurrentFrame());
+    expect(result.current).toBe(TOTAL_FRAMES);
+  });
+
+  it("stays unclamped when the sample has no frame count", () => {
+    source.playhead = DURATION;
+    source.frameRate = FPS;
+    source.totalFrameCount = undefined;
+
+    const { result } = renderHook(() => useCurrentFrame());
+    expect(result.current).toBe(TOTAL_FRAMES + 1);
+  });
+
+  it("returns -1 without a frame rate", () => {
+    source.playhead = 1;
+    source.frameRate = undefined;
+    source.totalFrameCount = TOTAL_FRAMES;
+
+    const { result } = renderHook(() => useCurrentFrame());
+    expect(result.current).toBe(-1);
+  });
+});

--- a/app/packages/video-annotation/src/state/useCurrentFrame.ts
+++ b/app/packages/video-annotation/src/state/useCurrentFrame.ts
@@ -5,6 +5,7 @@
 import { frameAt, usePlayhead } from "@fiftyone/playback";
 import { useModalSample } from "@fiftyone/state";
 import { useCallback, useRef } from "react";
+import { resolveFrameCount } from "../utils/frameCount";
 import { getModalSampleFrameRate } from "../utils/modalSample";
 
 /**
@@ -18,12 +19,22 @@ import { getModalSampleFrameRate } from "../utils/modalSample";
  * the canvas bridge's `frameOf`, timeline select/hover frame-stamping — must
  * read it from here, converting the playhead seconds to a 1-indexed frame via
  * the shared `frameAt`.
+ *
+ * Clamped to the sample's real frame range: the engine allows the playhead to
+ * rest at exactly `duration` (seek/step clamp inclusively), where an unclamped
+ * conversion yields a nonexistent frame N+1 — no labels resolve there while
+ * the renderer still shows the last frame.
  */
 export const useCurrentFrame = (): number => {
+  const sample = useModalSample();
   const playhead = usePlayhead();
-  const fps = getModalSampleFrameRate(useModalSample());
+  const fps = getModalSampleFrameRate(sample);
 
-  return fps && Number.isFinite(fps) ? frameAt(playhead, fps) : -1;
+  if (!fps || !Number.isFinite(fps)) {
+    return -1;
+  }
+
+  return frameAt(playhead, fps, resolveFrameCount(sample, fps) ?? undefined);
 };
 
 /**

--- a/app/packages/video-annotation/src/state/useCurrentFrame.ts
+++ b/app/packages/video-annotation/src/state/useCurrentFrame.ts
@@ -30,7 +30,7 @@ export const useCurrentFrame = (): number => {
   const playhead = usePlayhead();
   const fps = getModalSampleFrameRate(sample);
 
-  if (!fps || !Number.isFinite(fps)) {
+  if (!fps || !Number.isFinite(fps) || fps <= 0) {
     return -1;
   }
 

--- a/app/packages/video-annotation/src/sync/useTemporalOverlaySync.ts
+++ b/app/packages/video-annotation/src/sync/useTemporalOverlaySync.ts
@@ -14,16 +14,14 @@ import {
   type TemporalOptions,
   useLighterSetupWithPixi,
 } from "@fiftyone/lighter";
-import { useModalSample } from "@fiftyone/state";
 import { isTemporalDetectionsField } from "@fiftyone/utilities";
 import { type MutableRefObject, useEffect, useRef } from "react";
-import { frameAt, usePlayhead } from "@fiftyone/playback";
 import {
   useTemporalDetectionFieldPaths,
   useVisibleLabelSchemas,
 } from "../state/accessors";
+import { useCurrentFrame } from "../state/useCurrentFrame";
 import type { FrameLabelReader } from "../tracks/frameTracks";
-import { getModalSampleFrameRate } from "../utils/modalSample";
 
 /**
  * Minimal scene surface the diff needs — typed against the lighter
@@ -190,18 +188,13 @@ export const useEngineTemporalSample = (): Record<string, unknown> => {
 };
 
 /**
- * Current playhead frame, held in a ref. fps comes from the sample metadata;
- * the ref lets the diff effect seed overlays without re-running per tick.
+ * Current playhead frame, held in a ref. Reads the surface's clamped
+ * frame source ({@link useCurrentFrame}); the ref lets the diff effect
+ * seed overlays without re-running per tick.
  */
 const useCurrentFrameRef = (): MutableRefObject<number | null> => {
-  const modalSample = useModalSample();
-  const playheadSec = usePlayhead();
-  const frameRate = getModalSampleFrameRate(modalSample);
-
-  const currentFrame =
-    frameRate && Number.isFinite(frameRate) && frameRate > 0
-      ? frameAt(playheadSec, frameRate)
-      : null;
+  const frame = useCurrentFrame();
+  const currentFrame = frame > 0 ? frame : null;
 
   const currentFrameRef = useRef(currentFrame);
   currentFrameRef.current = currentFrame;

--- a/app/packages/video-annotation/src/utils/frameCount.test.ts
+++ b/app/packages/video-annotation/src/utils/frameCount.test.ts
@@ -16,6 +16,20 @@ describe("resolveFrameCount", () => {
     expect(resolveFrameCount(sampleWith({ duration: 4 }), 30)).toBe(120);
   });
 
+  it("counts a partial trailing frame in the duration fallback", () => {
+    // 10.01s at 30fps = 300 full frames + a partial 301st starting at 10.0.
+    expect(resolveFrameCount(sampleWith({ duration: 10.01 }), 30)).toBe(301);
+  });
+
+  it("does not mint a frame past the media from float error at an exact multiple", () => {
+    // NTSC: 120 frames at 30000/1001 fps; duration * fps lands at
+    // 120 ± float noise and must resolve to exactly 120, never 121.
+    const fps = 30000 / 1001;
+    expect(resolveFrameCount(sampleWith({ duration: 120 / fps }), fps)).toBe(
+      120,
+    );
+  });
+
   it("ignores a non-positive total_frame_count and uses duration", () => {
     expect(
       resolveFrameCount(sampleWith({ total_frame_count: 0, duration: 2 }), 30),

--- a/app/packages/video-annotation/src/utils/frameCount.ts
+++ b/app/packages/video-annotation/src/utils/frameCount.ts
@@ -27,7 +27,11 @@ export function resolveFrameCount(
     Number.isFinite(duration) &&
     duration > 0
   ) {
-    return Math.max(1, Math.round(duration * frameRate));
+    // Ceiling, not round: a partial trailing frame (duration not an exact
+    // frame multiple) is still a real frame. The epsilon keeps float error
+    // in `duration * frameRate` at an exact multiple from minting a frame
+    // past the media — mirrors the engine's `lastFrameStart` guard.
+    return Math.max(1, Math.ceil(duration * frameRate - 1e-6));
   }
 
   return null;


### PR DESCRIPTION
## 🔗 Related Issues

None

## 📋 What changes are proposed in this pull request?

Fixes a "phantom frame" at the end of videos on the annotation surface.

Root cause: the playback engine allows the playhead to rest at exactly `duration` (seek/step clamp inclusively), and the shared `frameAt` time→frame conversion is only clamped when callers pass a frame count. At `time == duration`, `floor(duration × fps) + 1` yields frame N+1 — a frame that doesn't exist. The frame-clamped bitmap stream kept rendering frame N while label lookups targeted N+1, so the last frame looked unlabeled.

Two-part fix:

1. **Clamp the frame conversion at the surface** — `useCurrentFrame` (the single source of "current frame" for the annotation engine clock) now passes the sample's real frame count into `frameAt`, and the remaining unclamped call sites (temporal overlay sync, the New TD / Split toolbar actions) route through it. The default 1-second TD window is also capped at the last frame.
2. **Cap frame-aligned rest positions in the playback engine** — without this, the playhead had two distinct resting positions that both display frame N (the last frame's start and `duration`, its exclusive end), so stepping to/from the last frame appeared to do nothing. A new `lastFrameStart(duration, step)` helper caps `stepForward`, the settle snap, and `seekSnapped` at the start of the final displayed frame. Continuous `seek` keeps its full `[0, duration]` range.

Note: the resting timestamp on the last frame now reads slightly less than the full duration (e.g. `3.97s` of `4.00s` at 30 fps) — the playhead rests at the *start* of each frame, and `duration` is the last frame's exclusive end.

## 🧪 How is this patch tested? If it is not, please explain why.

- New unit tests for `useCurrentFrame` covering the clamp at the duration boundary with NTSC-style frame rates (30000/1001 fps), the no-frame-count fallback, and the no-fps sentinel.
- New/updated playback engine tests: `stepForward` is a no-op on the last frame, pulls an at-duration playhead back onto the last frame, and can enter a partial trailing frame; `seekSnapped` past the end lands on the last frame's start.
- Full `packages/playback` (457) and `packages/video-annotation` (305) vitest suites pass.
- Manually verified in the app against a fully-labeled video dataset: labels render on the last frame, and frame-stepping at the end no longer shows a duplicated frame.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

Fixed an issue in video annotation where the last frame of a video could appear unlabeled

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playback seeking and forward stepping near media endpoints to stop at the final valid frame.
  * Corrected current-frame calculations, including duration clamping and invalid frame-rate handling.
  * Improved temporal annotation creation, track splitting, and overlay synchronization at video boundaries.
  * Fixed frame counting for partial trailing frames and exact frame-rate durations.
* **Tests**
  * Added coverage for frame conversion, duration limits, partial trailing frames, and seeking beyond media duration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3676
<!-- enterprise-sync-pr:end -->