### PR TITLE
Fix camera tiles rendering blank in the multimodal modal

### DIFF
--- a/app/packages/multimodal/src/components/MultiModalPlayback/MultiModalPlayback.module.css
+++ b/app/packages/multimodal/src/components/MultiModalPlayback/MultiModalPlayback.module.css
@@ -19,14 +19,14 @@
   position: relative;
 }
 
-/* The shared canvas sits below the mosaic DOM. Its tracked views can only
-   show through when the window shell stops painting an opaque card; tile
-   bodies that do not use the shared stage retain their own backgrounds.
-   The doubled class out-specifies the tiling package's equal-specificity
-   card background: webpack orders extracted CSS chunks per build, so an
-   order-decided tie made production builds paint tiles opaque. */
-.sharedViewStage.sharedViewStage :global(.mosaic .mosaic-window) {
-  background: transparent;
+/* The shared canvas sits below the mosaic DOM, so its tracked views can
+   only show through a window shell that paints no opaque card. Set via
+   MosaicGrid's --mosaic-window-bg seam rather than a competing selector:
+   a cross-chunk equal-specificity override is decided by webpack's
+   per-build CSS chunk order, which made production builds paint tiles
+   opaque on an order-decided tie. */
+.sharedViewStage {
+  --mosaic-window-bg: transparent;
 }
 
 /* Width comes from an inline style: the left pane tracks the resizable

--- a/app/packages/multimodal/src/components/MultiModalPlayback/MultiModalPlayback.module.css
+++ b/app/packages/multimodal/src/components/MultiModalPlayback/MultiModalPlayback.module.css
@@ -21,8 +21,11 @@
 
 /* The shared canvas sits below the mosaic DOM. Its tracked views can only
    show through when the window shell stops painting an opaque card; tile
-   bodies that do not use the shared stage retain their own backgrounds. */
-.sharedViewStage :global(.mosaic .mosaic-window) {
+   bodies that do not use the shared stage retain their own backgrounds.
+   The doubled class out-specifies the tiling package's equal-specificity
+   card background: webpack orders extracted CSS chunks per build, so an
+   order-decided tie made production builds paint tiles opaque. */
+.sharedViewStage.sharedViewStage :global(.mosaic .mosaic-window) {
   background: transparent;
 }
 

--- a/app/packages/tiling/src/views/MosaicGrid/MosaicGrid.module.css
+++ b/app/packages/tiling/src/views/MosaicGrid/MosaicGrid.module.css
@@ -32,7 +32,10 @@
   box-shadow: none;
   border-radius: 0;
   border: 1px solid var(--color-content-border-default);
-  background: var(--color-content-bg-card-2);
+  /* Seam for consumers whose tiles sit over an under-canvas stage: they
+     set --mosaic-window-bg (inherited) instead of out-specifying this
+     rule from another chunk, where the winner would be build-order luck */
+  background: var(--mosaic-window-bg, var(--color-content-bg-card-2));
 }
 
 .root :global(.mosaic .mosaic-window-toolbar) {


### PR DESCRIPTION
<!--
Community contributors: target the `community` branch, not `develop`. PRs from
non-members are auto-retargeted to `community`. See CONTRIBUTING.md:
https://github.com/voxel51/fiftyone/blob/develop/CONTRIBUTING.md#community-pull-requests
-->

## 🔗 Related Issues

On some deployments/builds, all camera image tiles in the multimodal modal render as blank panels for every user while  byte fetches succeed and no errors are logged. The frames are actually decoded and painted, but hidden because 2 CSS-module rules target react-mosaic's .mosaic-window with identical specificity (0,3,0).

With equal specificity, the winner is decided by source order — and these rules live in separately emitted CSS chunks whose order is not deterministic across builds. The same commit can produce a working bundle (transparent wins) or a broken one (opaque wins). 

https://github.com/user-attachments/assets/e38c3fe4-8193-4e7b-ad08-194115cb9887



## 📋 What changes are proposed in this pull request?

 Remove the cross-module override entirely and give the property a single owner with an explicit seam:

## 🧪 How is this patch tested? If it is not, please explain why.

- Redeployed ephem now shows images in the modal
<img width="496" height="242" alt="image" src="https://github.com/user-attachments/assets/55264b85-7fcd-4ef7-a80b-96c31a182b2e" />
<img width="1719" height="1199" alt="image" src="https://github.com/user-attachments/assets/14f2b294-22f0-4da3-bf17-5e24c6f14965" />

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved Mosaic Grid background styling to support transparent backgrounds where needed.
  * Added a consistent fallback color for mosaic windows when no custom background is specified.
  * Prevented shared playback views from unintentionally overriding other mosaic window backgrounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3681
<!-- enterprise-sync-pr:end -->