### PR TITLE
Timeline UX: animated drawer chevron, caller-supplied buttons, resizable label column

### DIFF
--- a/app/packages/playback/src/lib/constants.ts
+++ b/app/packages/playback/src/lib/constants.ts
@@ -22,8 +22,12 @@ export const SEEK_BAR_DEBOUNCE = 10;
 // TimelineWithTracks layout
 // ---------------------------------------------------------------------------
 
-/** Width of the label column shared between ruler and tracks (px). */
-export const TIMELINE_LABEL_WIDTH = 140;
+/**
+ * Width of the label column shared between ruler and tracks (px). Doubles as
+ * the *minimum* width when the user drags the column's right edge — the
+ * ceiling is the widest label actually rendered (see `TimelineWithTracks`).
+ */
+export const TIMELINE_LABEL_WIDTH = 180;
 /** Initial open size of the timeline drawer in px. Capped by content height. */
 export const TIMELINE_DEFAULT_DRAWER_SIZE = 220;
 /** Hard ceiling on the timeline drawer height in px (independent of content). */

--- a/app/packages/playback/src/views/TimelineControls/TimelineControls.module.css
+++ b/app/packages/playback/src/views/TimelineControls/TimelineControls.module.css
@@ -6,9 +6,9 @@
   border-bottom: 1px solid var(--color-content-border-default);
 }
 
-/* Suppress focus rings from pointer clicks on the row itself and its children.
-   Keyboard rings still show via :focus-visible so accessibility is preserved. */
-.root:focus:not(:focus-visible),
+/* Suppress focus rings from pointer clicks on the row's children. Keyboard
+   rings still show via :focus-visible so accessibility is preserved. The row
+   itself is no longer a tab stop, so it never rings as a whole. */
 .root :focus:not(:focus-visible) {
   outline: none;
 }
@@ -72,6 +72,39 @@
   background: var(--color-content-border-default);
   flex-shrink: 0;
   margin: 0 6px;
+}
+
+/* Trailing group pinned to the right edge: caller-supplied buttons (behind
+   their own divider) followed by the drawer chevron, which always sits
+   last so its position doesn't shift as buttons come and go. Only
+   `trailingActions` lives here — the time readouts and `extraActions` stay
+   in the left-hand run. */
+.trailing {
+  align-items: center;
+  display: flex;
+  flex-shrink: 0;
+  gap: 2px;
+  margin-left: auto;
+}
+
+/* Caller buttons read as one cluster — slightly wider gap than the transport
+   buttons so they don't merge with the chevron beside them. */
+.trailingActions {
+  align-items: center;
+  display: flex;
+  flex-shrink: 0;
+  gap: 4px;
+}
+
+/* One chevron rotated between states rather than two swapped icons, so the
+   open/closed change animates. voodo's Button wraps its icon in a div —
+   the same handle `.pinButtonActive` uses over in TimelineTrack. */
+.toggle > div {
+  transition: var(--transition-preset-transform);
+}
+
+.toggleExpanded > div {
+  transform: rotate(180deg);
 }
 
 .buffering {

--- a/app/packages/playback/src/views/TimelineControls/TimelineControls.test.tsx
+++ b/app/packages/playback/src/views/TimelineControls/TimelineControls.test.tsx
@@ -161,22 +161,41 @@ describe("TimelineControls", () => {
       expect(screen.getByText("0:00.00 / 0:10.00")).toBeTruthy();
     });
 
-    it("space on the focused controls row toggles playback, not the drawer", async () => {
+    it("space over the controls row toggles playback, not the drawer", async () => {
       const onToggle = vi.fn();
       renderControls({ onToggle });
       const row = screen.getByTestId("timeline-controls-root");
-      row.focus();
       fireEvent.keyDown(row, { key: " " });
       expect(await screen.findByRole("button", { name: "Pause" })).toBeTruthy();
       expect(onToggle).not.toHaveBeenCalled();
     });
 
-    it("enter on the focused controls row still toggles the drawer", () => {
+    it("the controls row is not a tab stop", () => {
       const onToggle = vi.fn();
       renderControls({ onToggle });
       const row = screen.getByTestId("timeline-controls-root");
-      row.focus();
-      fireEvent.keyDown(row, { key: "Enter" });
+      // A focusable row drew a focus ring around the entire bar. Toggling by
+      // keyboard goes through the chevron button instead.
+      expect(row.getAttribute("tabindex")).toBeNull();
+      expect(row.getAttribute("role")).toBeNull();
+    });
+
+    it("exposes the toggle as a real button, so Enter/Space activate it", () => {
+      const onToggle = vi.fn();
+      renderControls({ onToggle });
+      const toggle = screen.getByTestId("timeline-controls-toggle");
+
+      // Keyboard activation is the browser's, not ours: a <button> gets
+      // Enter/Space for free, which is the whole reason the row itself no
+      // longer needs to be a tab stop. jsdom does not implement that
+      // activation behavior (a synthetic Enter keydown fires no click), so
+      // asserting the element type is what actually guards the contract —
+      // swapping in a <div role="button"> would silently lose the keyboard
+      // path. The e2e suite drives the real activation in a browser.
+      expect(toggle.tagName).toBe("BUTTON");
+      expect((toggle as HTMLButtonElement).disabled).toBe(false);
+
+      fireEvent.click(toggle);
       expect(onToggle).toHaveBeenCalledTimes(1);
     });
 
@@ -256,6 +275,113 @@ describe("TimelineControls", () => {
       // extraActions renders far-right, preceded by a second divider.
       const dividers = screen.getAllByTestId("timeline-controls-divider");
       expect(dividers).toHaveLength(2);
+    });
+
+    it("stays inline rather than moving to the right edge", () => {
+      render(
+        <PlaybackProvider duration={10} stepInterval={1 / 30}>
+          <TimelineControls
+            onToggle={vi.fn()}
+            extraActions={<span data-testid="slot">clock</span>}
+          />
+        </PlaybackProvider>,
+      );
+      // Readouts (e.g. the multimodal absolute-timestamp) belong with the
+      // other controls on the left, NOT in the right-edge trailing group.
+      expect(
+        screen.queryByTestId("timeline-controls-trailing-actions"),
+      ).toBeNull();
+      expect(screen.getByTestId("slot")).toBeTruthy();
+    });
+  });
+
+  describe("trailingActions", () => {
+    it("renders slotted content pinned to the right, behind a divider", () => {
+      render(
+        <PlaybackProvider duration={10} stepInterval={1 / 30}>
+          <TimelineControls
+            trailingActions={<button>Trailing Action</button>}
+          />
+        </PlaybackProvider>,
+      );
+      expect(
+        screen.getByRole("button", { name: "Trailing Action" }),
+      ).toBeTruthy();
+      expect(screen.getAllByTestId("timeline-controls-divider")).toHaveLength(
+        2,
+      );
+    });
+
+    it("groups the buttons ahead of the toggle chevron", () => {
+      render(
+        <PlaybackProvider duration={10} stepInterval={1 / 30}>
+          <TimelineControls
+            onToggle={vi.fn()}
+            trailingActions={<button>Trailing Action</button>}
+          />
+        </PlaybackProvider>,
+      );
+
+      const actions = screen.getByTestId("timeline-controls-trailing-actions");
+      const toggle = screen.getByTestId("timeline-controls-toggle");
+      // The chevron always sits last so its position doesn't shift as
+      // callers add or remove actions.
+      expect(
+        actions.compareDocumentPosition(toggle) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy();
+    });
+  });
+
+  describe("drawer toggle chevron", () => {
+    it("renders only when onToggle is provided", () => {
+      renderControls({});
+      expect(screen.queryByTestId("timeline-controls-toggle")).toBeNull();
+
+      cleanup();
+      renderControls({ onToggle: vi.fn() });
+      expect(screen.getByTestId("timeline-controls-toggle")).toBeTruthy();
+    });
+
+    it("reports the collapsed state via aria-expanded and its label", () => {
+      render(
+        <PlaybackProvider duration={10} stepInterval={1 / 30}>
+          <TimelineControls onToggle={vi.fn()} expanded={false} />
+        </PlaybackProvider>,
+      );
+
+      const toggle = screen.getByTestId("timeline-controls-toggle");
+      expect(toggle.getAttribute("aria-expanded")).toBe("false");
+      expect(screen.getByRole("button", { name: "Show tracks" })).toBeTruthy();
+    });
+
+    it("reports the expanded state and rotates the chevron", () => {
+      render(
+        <PlaybackProvider duration={10} stepInterval={1 / 30}>
+          <TimelineControls onToggle={vi.fn()} expanded />
+        </PlaybackProvider>,
+      );
+
+      const toggle = screen.getByTestId("timeline-controls-toggle");
+      expect(toggle.getAttribute("aria-expanded")).toBe("true");
+      expect(screen.getByRole("button", { name: "Hide tracks" })).toBeTruthy();
+      // One rotated icon rather than two swapped ones, so the change animates.
+      expect(toggle.classList.contains(styles.toggleExpanded)).toBe(true);
+    });
+
+    it("fires onToggle exactly once when the chevron is clicked", () => {
+      const onToggle = vi.fn();
+      render(
+        <PlaybackProvider duration={10} stepInterval={1 / 30}>
+          <TimelineControls onToggle={onToggle} />
+        </PlaybackProvider>,
+      );
+
+      fireEvent.click(screen.getByTestId("timeline-controls-toggle"));
+
+      // The row's own handler ignores clicks on buttons, so the chevron's
+      // handler is the only one that runs — no double toggle.
+      expect(onToggle).toHaveBeenCalledOnce();
     });
   });
 });

--- a/app/packages/playback/src/views/TimelineControls/TimelineControls.tsx
+++ b/app/packages/playback/src/views/TimelineControls/TimelineControls.tsx
@@ -38,17 +38,33 @@ export interface TimelineControlsProps {
    */
   extraControls?: ReactNode;
   /**
-   * Optional content rendered far-right, after the playhead time / loop
-   * bounds, preceded by its own divider. Use for trailing actions that read
-   * as a separate group — e.g. the temporal tag-mode button.
+   * Optional content rendered inline after the playhead time / loop bounds,
+   * preceded by its own divider — still part of the left-hand run of
+   * controls. Readouts belong here (the multimodal surface's absolute
+   * timestamp, the temporal tag-mode button). For buttons that should sit
+   * against the right edge instead, use {@link trailingActions}.
    */
   extraActions?: ReactNode;
+  /**
+   * Optional buttons pinned to the right edge of the row, preceded by their
+   * own divider and followed by the drawer chevron. Unlike
+   * {@link extraActions} these never mingle with the time readouts — this is
+   * the bring-your-own-buttons slot.
+   */
+  trailingActions?: ReactNode;
+  /**
+   * Current open state of the surface {@link onToggle} controls. Drives the
+   * trailing chevron's rotation, so it only matters when `onToggle` is set.
+   */
+  expanded?: boolean;
 }
 
 const TimelineControls: React.FC<TimelineControlsProps> = ({
   onToggle,
   extraControls,
   extraActions,
+  trailingActions,
+  expanded = false,
 }) => {
   const isPlaying = useIsPlaying();
   const isPlayPending = useIsPlayPending();
@@ -101,27 +117,17 @@ const TimelineControls: React.FC<TimelineControlsProps> = ({
       }
     : undefined;
 
-  const handleKeyDown = onToggle
-    ? (e: React.KeyboardEvent<HTMLDivElement>) => {
-        // Only respond if focus is on the row itself, not a nested control.
-        if (e.target !== e.currentTarget) return;
-        // Enter only — Space is reserved for the global play/pause
-        // shortcut and must never expand/collapse the tracks drawer.
-        if (e.key === "Enter") {
-          e.preventDefault();
-          onToggle();
-        }
-      }
-    : undefined;
-
   return (
+    // Deliberately not focusable and not `role="button"`. As a tab stop the
+    // row drew a focus ring around the whole bar, which read as everything
+    // lighting up rather than one control being selected. Keyboard access to
+    // the drawer lives on the trailing chevron — a real button, which takes
+    // Enter/Space natively — so nothing is lost by dropping the tab stop.
+    // Click-anywhere-to-toggle still works for pointer users.
     <div
       className={clsx(styles.root, { [styles.clickable]: !!onToggle })}
       data-testid="timeline-controls-root"
       onClick={handleClick}
-      onKeyDown={handleKeyDown}
-      role={onToggle ? "button" : undefined}
-      tabIndex={onToggle ? 0 : undefined}
     >
       <Button
         variant={Variant.Icon}
@@ -170,6 +176,41 @@ const TimelineControls: React.FC<TimelineControlsProps> = ({
           {extraActions}
         </>
       ) : null}
+      {(trailingActions || onToggle) && (
+        <div className={styles.trailing}>
+          {trailingActions ? (
+            <>
+              <span
+                className={styles.divider}
+                data-testid="timeline-controls-divider"
+                aria-hidden
+              />
+              <div
+                className={styles.trailingActions}
+                data-testid="timeline-controls-trailing-actions"
+              >
+                {trailingActions}
+              </div>
+            </>
+          ) : null}
+          {onToggle ? (
+            <Button
+              variant={Variant.Icon}
+              size={Size.Xs}
+              data-testid="timeline-controls-toggle"
+              leadingIcon={IconName.ChevronBottom}
+              aria-label={expanded ? "Hide tracks" : "Show tracks"}
+              aria-expanded={expanded}
+              className={clsx(styles.toggle, {
+                [styles.toggleExpanded]: expanded,
+              })}
+              // The row's own click handler ignores clicks that land on a
+              // button, so the chevron must drive the toggle itself.
+              onClick={onToggle}
+            />
+          ) : null}
+        </div>
+      )}
     </div>
   );
 };

--- a/app/packages/playback/src/views/TimelineHeader/TimelineHeader.tsx
+++ b/app/packages/playback/src/views/TimelineHeader/TimelineHeader.tsx
@@ -18,6 +18,13 @@ export interface TimelineHeaderProps {
    */
   onToggle?: () => void;
   /**
+   * Open state of the surface {@link onToggle} controls, forwarded to
+   * {@link TimelineControls} to orient its trailing chevron. Owned by the
+   * `Drawer` — `TimelineWithTracks` reads it off the `header` render prop's
+   * state rather than tracking a second copy.
+   */
+  expanded?: boolean;
+  /**
    * Overlay rendered on top of the ruler row (position:relative wrapper).
    * Used by TemporalTagRangeOverlay to capture pointer events for range
    * selection — sits only over the ruler, not the controls row above.
@@ -37,6 +44,11 @@ export interface TimelineHeaderProps {
    */
   extraActions?: ReactNode;
   /**
+   * Optional content forwarded to {@link TimelineControls}' `trailingActions`
+   * — buttons pinned to the right edge, just left of the drawer chevron.
+   */
+  trailingActions?: ReactNode;
+  /**
    * Content rendered below the ruler, still inside the always-visible
    * header region. Used by `TimelineWithTracks` to keep pinned tracks
    * on-screen even when the drawer body is collapsed.
@@ -54,17 +66,21 @@ const TimelineHeader: React.FC<TimelineHeaderProps> = ({
   labelWidth,
   zoomRef,
   onToggle,
+  expanded,
   rulerOverlay,
   extraControls,
   extraActions,
+  trailingActions,
   children,
 }) => {
   return (
     <div className={styles.root} data-testid="timeline-header-root">
       <TimelineControls
         onToggle={onToggle}
+        expanded={expanded}
         extraControls={extraControls}
         extraActions={extraActions}
+        trailingActions={trailingActions}
       />
       <TimelineRuler
         labelWidth={labelWidth}

--- a/app/packages/playback/src/views/TimelineTrack/TimelineTrack.module.css
+++ b/app/packages/playback/src/views/TimelineTrack/TimelineTrack.module.css
@@ -75,6 +75,15 @@
   border-top: 1px solid var(--color-content-border-default);
 }
 
+/* The tooltip wrapper stands in for the label text as a flex child, so the
+   text still gets exactly the room it would have unwrapped. */
+.labelTooltip {
+  display: flex;
+  align-items: center;
+  flex: 1;
+  min-width: 0;
+}
+
 .labelText {
   font-size: 0.72rem;
   color: var(--color-content-text-primary);
@@ -94,18 +103,17 @@
 }
 
 .pinButton > div {
-  transition:
-    color 0.1s,
-    transform 0.1s;
+  transition: var(--transition-preset-colors);
 }
 
 .pinButtonActive {
   opacity: 1;
 }
 
+/* Colour alone carries the pinned state. The icon deliberately does NOT
+   rotate — flipping a pin upside-down reads as "broken", not "active". */
 .pinButtonActive > div {
   color: var(--color-brand-primary);
-  transform: rotate(180deg);
 }
 
 .label:hover .pinButton {

--- a/app/packages/playback/src/views/TimelineTrack/TimelineTrack.tsx
+++ b/app/packages/playback/src/views/TimelineTrack/TimelineTrack.tsx
@@ -4,6 +4,7 @@ import {
   useViewStart,
 } from "../../lib/playback/use-playback-state";
 import {
+  Anchor,
   Button,
   ContextMenu,
   IconName,
@@ -13,6 +14,7 @@ import {
   Text,
   TextColor,
   TextVariant,
+  Tooltip,
   Variant,
 } from "@voxel51/voodo";
 import clsx from "clsx";
@@ -255,6 +257,8 @@ const TimelineTrack: React.FC<TimelineTrackProps> = ({
    */
   const justDraggedRef = useRef(false);
 
+  const labelText = label ?? id;
+
   const viewDuration = viewEnd - viewStart;
   // Degenerate view (zero/negative width) — would produce NaN/Infinity
   // CSS values and break layout for every bar/marker below.
@@ -383,8 +387,6 @@ const TimelineTrack: React.FC<TimelineTrackProps> = ({
   const clippedEnd = hasBackground ? Math.min(end, viewEnd) : 0;
   const barVisible = hasBackground && clippedStart < clippedEnd;
 
-  const labelText = label ?? id;
-
   // While moving an interval, point events (e.g. keyframe diamonds) that
   // live inside the dragged bar's *original* span should travel with it.
   // The bar follows the cursor via `dragOverride`; mirror the same offset
@@ -439,6 +441,9 @@ const TimelineTrack: React.FC<TimelineTrackProps> = ({
       {labelWidth > 0 && (
         <div
           className={styles.label}
+          // Marks this as a measurable label column. TimelineWithTracks reads
+          // every mounted column to work out how far the user may widen it.
+          data-track-label-column
           style={{
             width: labelWidth,
             paddingLeft: LABEL_BASE_PADDING_PX + depth * DEPTH_INDENT_PX,
@@ -472,13 +477,28 @@ const TimelineTrack: React.FC<TimelineTrackProps> = ({
           ) : (
             <div className={styles.dot} style={{ background: color }} />
           )}
-          <Text
-            variant={TextVariant.Xs}
-            color={isChild ? TextColor.Secondary : TextColor.Primary}
-            className={styles.labelText}
+          {/* Unconditional: even at the column's maximum width a long enough
+              label still ellipsises, so "is it truncated right now" is the
+              wrong gate — the full text has to stay reachable at every width.
+              Anchored right because the label column hugs the left edge of
+              the viewport; voodo's Tooltip has no collision flipping, so a
+              top-anchored panel is centred on the column and runs off-screen
+              the moment it's wider than twice the column. */}
+          <Tooltip
+            anchor={Anchor.Right}
+            content={labelText}
+            portal
+            wrapperClassName={styles.labelTooltip}
           >
-            {labelText}
-          </Text>
+            <Text
+              variant={TextVariant.Xs}
+              color={isChild ? TextColor.Secondary : TextColor.Primary}
+              className={styles.labelText}
+              data-track-label
+            >
+              {labelText}
+            </Text>
+          </Tooltip>
           {onPinClick && !isChild && (
             <Button
               variant={Variant.Icon}

--- a/app/packages/playback/src/views/TimelineWithTracks/TimelineWithTracks.module.css
+++ b/app/packages/playback/src/views/TimelineWithTracks/TimelineWithTracks.module.css
@@ -42,23 +42,55 @@
   flex-direction: column;
 }
 
-/* Pinned tracks block, rendered into the always-visible header below
-   the ruler. Tracks here are full opacity since they're the user's
-   "promoted" tracks. */
-.pinnedTracks {
-  display: flex;
-  flex-direction: column;
-}
-
-/* Wrapper used only when the drawer is closed: hosts the pinned tracks
-   inside the TimelineHeader's below-ruler slot AND acts as the
-   positioning context for PlayheadLine / LoopOverlays so they anchor
-   over the visible pinned section. */
+/* Hosts the pinned tracks inside the TimelineHeader's below-ruler slot in
+   both drawer states, AND acts as the positioning context for PlayheadLine /
+   LoopOverlays so they anchor over the visible pinned section. Tracks here
+   are full opacity since they're the user's "promoted" tracks. */
 .pinnedOverlayHost {
   position: relative;
   overflow: hidden;
   display: flex;
   flex-direction: column;
+}
+
+/* Drag affordance on the label column's right border, running the full height
+   of whichever surface hosts it. `left` is set inline from the current label
+   width, and the hit area sits entirely *inside* the column via the negative
+   offset — deliberately not straddling the seam. An event starting at time 0
+   renders flush against the lane's left edge, i.e. at exactly this x, so a
+   handle overhanging the lane would swallow clicks on short interval bars.
+   The 6px it does cover is the column's right padding and border, which owns
+   no controls: the pin button's content box ends a pixel short of it.
+   Above the playhead line (z-index 3) so the drag never gets stolen. */
+.labelResizeHandle {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 6px;
+  margin-left: -6px;
+  cursor: col-resize;
+  z-index: 6;
+  /* Keep touch drags from scrolling the tracks area instead of resizing. */
+  touch-action: none;
+}
+
+/* The seam itself only lights up on hover / during a drag, so at rest the
+   column reads as a plain border rather than a second piece of chrome. */
+.labelResizeHandle::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  width: 2px;
+  background: var(--color-brand-primary);
+  opacity: 0;
+  transition: var(--transition-preset-opacity);
+}
+
+.labelResizeHandle:hover::after,
+.labelResizeHandleActive::after {
+  opacity: 1;
 }
 
 /* Unpinned tracks live in the collapsible drawer body. Dimmed so they

--- a/app/packages/playback/src/views/TimelineWithTracks/TimelineWithTracks.tsx
+++ b/app/packages/playback/src/views/TimelineWithTracks/TimelineWithTracks.tsx
@@ -1,6 +1,12 @@
-import { Drawer } from "@voxel51/voodo";
+import { Drawer, useDragDelta } from "@voxel51/voodo";
 import clsx from "clsx";
-import React, { useCallback, useMemo, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { usePlayback } from "../../lib/playback/PlaybackProvider";
 import {
   TIMELINE_DRAWER_MAX_SIZE,
@@ -28,7 +34,12 @@ export interface TimelineWithTracksProps {
    * instead of polling. Omit to leave the attribute off entirely.
    */
   loaded?: boolean;
-  /** @default TIMELINE_LABEL_WIDTH */
+  /**
+   * Width of the label column, and the floor the user may drag it back down
+   * to. The ceiling is the widest label currently rendered, so dragging can
+   * reveal truncated labels but never open dead space beyond them.
+   * @default TIMELINE_LABEL_WIDTH
+   */
   labelWidth?: number;
   /**
    * Initial open size of the drawer (px). Capped by content height.
@@ -67,11 +78,18 @@ export interface TimelineWithTracksProps {
    */
   extraControls?: React.ReactNode;
   /**
-   * Optional content rendered far-right after the playhead time, preceded by a
+   * Optional content rendered inline after the playhead time, preceded by a
    * divider. Forwarded to {@link TimelineHeader}'s `extraActions`; renders in
-   * both the empty-timeline and drawer layouts.
+   * both the empty-timeline and drawer layouts. Readouts belong here — for
+   * right-edge buttons use {@link trailingActions}.
    */
   extraActions?: React.ReactNode;
+  /**
+   * Bring-your-own buttons, pinned to the right edge of the controls row
+   * behind their own divider and followed by the drawer chevron. Renders in
+   * both the empty-timeline and drawer layouts.
+   */
+  trailingActions?: React.ReactNode;
   /**
    * Per-row prop override. Returned partial is merged onto the props
    * passed to each {@link TimelineTrack}.
@@ -85,11 +103,10 @@ export interface TimelineWithTracksProps {
 /**
  * Full timeline composition.
  *
- * When the drawer is **closed**, pinned tracks render in the
- * TimelineHeader's below-ruler slot so they remain visible alongside
- * the controls and ruler. When the drawer is **open**, all tracks —
- * pinned at the top, unpinned below — live in the drawer body and
- * scroll together as one unit.
+ * Pinned tracks always render in the TimelineHeader's below-ruler slot, in
+ * both drawer states — that's what pinning means, and it keeps them off the
+ * drawer's scroll. The drawer body holds only the unpinned tracks, so opening
+ * and closing changes exactly one height and animates cleanly.
  */
 const TimelineWithTracks: React.FC<TimelineWithTracksProps> = ({
   loaded,
@@ -103,6 +120,7 @@ const TimelineWithTracks: React.FC<TimelineWithTracksProps> = ({
   eventMenuItems,
   extraControls,
   extraActions,
+  trailingActions,
   decorateTrack,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -124,7 +142,36 @@ const TimelineWithTracks: React.FC<TimelineWithTracksProps> = ({
     [controlledDrawerOpen, onDrawerOpenChange],
   );
 
-  const labelWidth = tracks.length === 0 ? 0 : requestedLabelWidth;
+  /**
+   * User's dragged label-column width, or `null` while it still sits at the
+   * caller's default. Kept unclamped so a drag past the current ceiling
+   * re-widens on its own once a longer label mounts.
+   */
+  const [draggedLabelWidth, setDraggedLabelWidth] = useState<number | null>(
+    null,
+  );
+  /**
+   * Width the widest *mounted* label needs to render in full — the ceiling
+   * for the drag. Measured from the DOM rather than from the label strings so
+   * it accounts for the real font, the indent, dot and pin button.
+   */
+  const [maxLabelWidth, setMaxLabelWidth] = useState(requestedLabelWidth);
+
+  const clampLabelWidth = useCallback(
+    (width: number) =>
+      Math.round(
+        Math.min(
+          Math.max(width, requestedLabelWidth),
+          Math.max(requestedLabelWidth, maxLabelWidth),
+        ),
+      ),
+    [requestedLabelWidth, maxLabelWidth],
+  );
+
+  const resolvedLabelWidth = clampLabelWidth(
+    draggedLabelWidth ?? requestedLabelWidth,
+  );
+  const labelWidth = tracks.length === 0 ? 0 : resolvedLabelWidth;
 
   // Sub-rows follow their parent's pin state via `parentId` so a partial pin
   // doesn't strand attribute children above unrelated parents — see
@@ -133,6 +180,64 @@ const TimelineWithTracks: React.FC<TimelineWithTracksProps> = ({
     () => partitionTracksByPin(tracks, pinnedIds),
     [tracks, pinnedIds],
   );
+
+  // Widest label across every mounted row. `scrollWidth` reports the full
+  // text width even while it's ellipsised, and the chrome (padding, indent,
+  // dot, pin button, border) is whatever the column holds beyond the text —
+  // a constant as the column resizes, so this never feeds back into itself.
+  //
+  // Both terms must be border-box to match the `width` we set on the column:
+  // `clientWidth` excludes the 1px `border-right`, which left every label a
+  // pixel short of fitting and so permanently ellipsised at maximum width.
+  useLayoutEffect(() => {
+    const host = containerRef.current;
+    if (!host) return;
+
+    let widest = 0;
+    host.querySelectorAll<HTMLElement>("[data-track-label]").forEach((text) => {
+      const column = text.closest<HTMLElement>("[data-track-label-column]");
+      if (!column) return;
+      const chrome =
+        column.getBoundingClientRect().width -
+        text.getBoundingClientRect().width;
+      widest = Math.max(widest, Math.ceil(text.scrollWidth + chrome) + 1);
+    });
+
+    setMaxLabelWidth(Math.max(requestedLabelWidth, widest));
+  }, [tracks, drawerOpen, pinnedIds, requestedLabelWidth]);
+
+  // Width when the current drag began — `useDragDelta` reports the running
+  // delta from pointer-down, not per-move increments.
+  const dragStartWidthRef = useRef(resolvedLabelWidth);
+  const { isDragging, handleProps } = useDragDelta({
+    axis: "horizontal",
+    onDragStart: () => {
+      dragStartWidthRef.current = resolvedLabelWidth;
+    },
+    onDelta: (delta) =>
+      setDraggedLabelWidth(clampLabelWidth(dragStartWidthRef.current + delta)),
+  });
+
+  // Nothing to reveal when every label already fits — hide the affordance
+  // rather than offer a drag that can't move.
+  const canResizeLabels =
+    tracks.length > 0 && maxLabelWidth > requestedLabelWidth;
+
+  const labelResizeHandle = canResizeLabels ? (
+    <div
+      {...handleProps}
+      role="separator"
+      aria-orientation="vertical"
+      aria-label="Resize track label column"
+      data-testid="timeline-label-resize"
+      className={clsx(styles.labelResizeHandle, {
+        [styles.labelResizeHandleActive]: isDragging,
+      })}
+      style={{ left: labelWidth }}
+      // Double-click snaps back to the caller's default width.
+      onDoubleClick={() => setDraggedLabelWidth(null)}
+    />
+  ) : null;
 
   const renderPinnedTrack = (track: Track) => (
     <TimelineTrack
@@ -165,6 +270,7 @@ const TimelineWithTracks: React.FC<TimelineWithTracksProps> = ({
           rulerOverlay={rulerOverlay}
           extraControls={extraControls}
           extraActions={extraActions}
+          trailingActions={trailingActions}
         />
       </div>
     );
@@ -182,35 +288,38 @@ const TimelineWithTracks: React.FC<TimelineWithTracksProps> = ({
         onOpenChange={handleDrawerOpenChange}
         maxSize={maxSize}
         mode="push"
-        header={({ toggle }) => (
+        header={({ open, toggle }) => (
           <TimelineHeader
             labelWidth={labelWidth}
             zoomRef={containerRef}
             onToggle={toggle}
+            expanded={open}
             rulerOverlay={rulerOverlay}
             extraControls={extraControls}
             extraActions={extraActions}
+            trailingActions={trailingActions}
           >
             <div className={styles.pinnedOverlayHost}>
-              {/* Pinned rows live here only while the drawer is closed; when it
-                  opens they move into the body below. Rendering both
-                  unconditionally double-mounts every pinned row under the same
-                  track id, so selecting one hit both. */}
-              {!drawerOpen && pinned.map(renderPinnedTrack)}
+              {/* Pinned rows live here in both drawer states. They used to move
+                  into the body on open, which meant the header shrank in a
+                  single frame while the body animated its height over 200ms —
+                  two heights changing on different clocks, which is what made
+                  the toggle look janky. Keeping them put means only the body
+                  animates, and each row still mounts exactly once. */}
+              {pinned.map(renderPinnedTrack)}
               <LoopOverlays labelWidth={labelWidth} />
               <PlayheadLine labelWidth={labelWidth} />
+              {/* Second handle so the column stays resizable from the pinned
+                  rows when the drawer body is collapsed to nothing. */}
+              {labelResizeHandle}
             </div>
           </TimelineHeader>
         )}
       >
         <div className={styles.tracksOuter}>
           <div className={styles.tracksArea}>
-            {/* When the drawer is open, pinned tracks move into the body
-                so they scroll together with the unpinned section below; the
-                header slot above stops rendering them so each row mounts once. */}
-            <div className={styles.pinnedTracks}>
-              {drawerOpen && pinned.map(renderPinnedTrack)}
-            </div>
+            {/* Unpinned rows only — pinned ones stay in the header above so the
+                drawer's height is the single thing that changes on toggle. */}
             <div>
               {unpinned.map((track) => {
                 const extra = decorateTrack
@@ -237,6 +346,7 @@ const TimelineWithTracks: React.FC<TimelineWithTracksProps> = ({
           </div>
           <LoopOverlays labelWidth={labelWidth} />
           <PlayheadLine labelWidth={labelWidth} />
+          {labelResizeHandle}
         </div>
       </Drawer>
     </div>

--- a/e2e-pw/src/oss/poms/modal/video-annotate.ts
+++ b/e2e-pw/src/oss/poms/modal/video-annotate.ts
@@ -123,26 +123,28 @@ export class VideoAnnotatePom {
   }
 
   /**
-   * Expand the tracks drawer. The playback controls row is the drawer toggle
-   * (`role="button"`); focus it and press Enter so the keypress toggles the
-   * drawer rather than landing on a nested playback button. It toggles, so call
-   * only from the closed default.
+   * The tracks drawer's open/close chevron, at the right end of the playback
+   * controls row. A real `<button>`, so keyboard activation is native — the
+   * controls row itself is deliberately not a tab stop (focusing it used to
+   * ring the whole bar).
+   */
+  private tracksDrawerToggle(): Locator {
+    return this.page
+      .locator('[data-testid="timeline-controls-toggle"]')
+      .first();
+  }
+
+  /**
+   * Expand the tracks drawer via its chevron. It toggles, so call only from
+   * the closed default.
    */
   async openTracksDrawer() {
-    const toggle = this.page
-      .locator('[data-testid="timeline-controls-root"]')
-      .first();
-    await toggle.focus();
-    await toggle.press("Enter");
+    await this.tracksDrawerToggle().click();
   }
 
   /** Collapse the tracks drawer back to the closed default — see {@link openTracksDrawer}. */
   async closeTracksDrawer() {
-    const toggle = this.page
-      .locator('[data-testid="timeline-controls-root"]')
-      .first();
-    await toggle.focus();
-    await toggle.press("Enter");
+    await this.tracksDrawerToggle().click();
   }
 
   /**
@@ -389,8 +391,9 @@ export class VideoAnnotatePom {
    * toolbar action (a 1-second support window starting at the playhead frame).
    */
   async createTemporalDetection() {
-    // target the actual button — the timeline-controls wrapper is also a
-    // role="button" whose accessible name bubbles up "New TD".
+    // target the actual button by element, not by role: the toolbar slot sits
+    // inside the timeline controls row, and pinning the selector to `button`
+    // keeps it unambiguous regardless of what wraps it.
     await this.page.locator('button[aria-label="New TD"]').click();
   }
 


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link.

## 📋 What changes are proposed in this pull request?

UI/UX improvements to `TimelineWithTracks` and the playback controls row. All
of it is contained to `app/packages/playback`; no API or Python changes.

**Drawer chevron.** The controls row now ends in a chevron that shows the
tracks drawer's open/closed state. It's a single `ChevronBottom` rotated 180°
rather than two swapped icons, so the change animates, via voodo's
`--transition-preset-transform` token. Its state is read off `Drawer`'s
`header={({ open, toggle }) => …}` render prop, so the drawer stays the owner
of that state and nothing tracks a second copy.

**Bring-your-own buttons.** New `trailingActions` prop, threaded
`TimelineWithTracks → TimelineHeader → TimelineControls`, rendering as
`divider → your buttons → chevron` pinned to the right edge. The chevron is
always last so its position doesn't shift as callers add or remove buttons.

The pre-existing `extraActions` prop is deliberately left where it was, inline
in the left-hand run — it carries readouts (the multimodal shell's
absolute-timestamp display, the temporal tag-mode button), not right-edge
buttons.

**Label column.** Default width 140 → 180px, and the column's right edge is
now draggable: the floor is the caller's `labelWidth`, the ceiling is the
widest label actually rendered, and double-click resets. The ceiling is
measured from the DOM rather than from the label strings, so it accounts for
the real font, indent, colour dot and pin button.

Track labels now carry a tooltip with the full text, anchored right and
portalled. Anchored right because the label column hugs the viewport's left
edge and voodo's `Tooltip` has no collision flipping — a top-anchored panel
centres on the column and runs off-screen once it's wider than twice the
column.

**Two bugs fixed along the way:**

- The max-width measurement used `clientWidth`, which excludes borders, while
  the column's `width` includes its 1px `border-right` under the global
  `box-sizing: border-box`. Every label ended up exactly one pixel short of
  fitting, so a long one stayed ellipsised even at maximum width. Both terms
  are now border-box `getBoundingClientRect().width`.
- Pinned rows teleported between the header and the drawer body on toggle.
  They previously rendered in both places at once, which double-mounted each
  track id; `caeae5c4c5` fixed that by alternating the two on `drawerOpen`,
  which left the movement behind as a side effect. Pinned rows now render
  once, in the header, in both states — so the header's height is constant
  across a toggle and only the drawer body animates, which also removes the
  jank in the open/close transition.

**Two smaller changes:**

- The pin icon no longer rotates 180° when pinned; colour alone carries the
  state.
- The controls row is no longer a tab stop (it carried `role="button"` +
  `tabIndex={0}`), because the focus ring painted around the entire bar.
  Keyboard access to the drawer now goes through the chevron — a real
  `<button>` that takes Enter/Space natively — and click-anywhere-to-toggle is
  unchanged for pointer users.

## 🧪 How is this patch tested? If it is not, please explain why.

Unit tests added to `TimelineControls.test.tsx` covering the chevron
(renders only with `onToggle`, `aria-expanded` + label in both states, rotation
class, fires exactly once on click) and `trailingActions` (renders behind its
own divider, sits ahead of the chevron), plus a regression test that
`extraActions` stays inline rather than moving to the right edge, and one
asserting the row is not focusable.

`TimelineControls` / `TimelineHeader` / `TemporalTag` are fully green.

Not covered: the tooltip and the drag-to-resize. Every test in
`TimelineTrack.test.tsx` and the track-rendering cases in
`TimelineWithTracks.test.tsx` fail locally for an unrelated environment reason
— a linked `@voxel51/voodo` checkout supplying a second copy of React — so a
new test there couldn't distinguish a real failure from the ambient one. Those
files sit at the same pass/fail counts as before this branch. They pass in CI,
where voodo resolves from the published package.

Manual verification still worth doing on the tooltip placement and the resize
drag.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

The timeline's track drawer now shows an animated open/closed chevron, the
track label column can be dragged wider to reveal long labels (with tooltips
for any that still overflow), and surfaces embedding the timeline can
contribute their own buttons to the right of the controls row.

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3710
<!-- enterprise-sync-pr:end -->