### PR TITLE
Scope the tile split-action hover to the split control, not the whole header

### DIFF
--- a/app/packages/tiling/src/views/Tile/Tile.module.css
+++ b/app/packages/tiling/src/views/Tile/Tile.module.css
@@ -57,32 +57,49 @@
 }
 
 /* Split affordance: at rest a single direction-neutral glyph advertises
-   the action; hovering the header (or focusing into it) swaps it for
-   the real split-right / split-down pair. */
+   the action; hovering the split group itself (or focusing into it)
+   swaps it for the real split-right / split-down pair. Scoped to this
+   group rather than the whole header so drifting across the title bar
+   doesn't fire the swap.
+
+   Hint and pair share one grid cell so the group's width is the max of
+   the two. That keeps the group from collapsing out from under the
+   cursor the instant the hint hides — a collapse would drop :hover and
+   oscillate. */
+.splitGroup {
+  align-items: center;
+  display: grid;
+  grid-template-areas: "split";
+  justify-items: end;
+}
+
 .splitHint {
   color: var(--color-content-text-muted);
+  grid-area: split;
   pointer-events: none;
 }
 
-.header:hover .splitHint,
-.header:focus-within .splitHint {
-  display: none;
+/* visibility (not display) so the hidden hint still reserves its width. */
+.splitGroup:hover .splitHint,
+.splitGroup:focus-within .splitHint {
+  visibility: hidden;
 }
 
 /* Collapsed via max-width + overflow (not display) so the buttons stay
-   keyboard-focusable at rest — tabbing into one triggers the header's
+   keyboard-focusable at rest — tabbing into one triggers the group's
    :focus-within and expands the pair. */
 .splitActions {
   align-items: center;
   display: flex;
   gap: 1px;
+  grid-area: split;
   max-width: 0;
   overflow: hidden;
   transition: max-width 120ms ease;
 }
 
-.header:hover .splitActions,
-.header:focus-within .splitActions {
+.splitGroup:hover .splitActions,
+.splitGroup:focus-within .splitActions {
   max-width: 64px;
 }
 

--- a/app/packages/tiling/src/views/Tile/Tile.tsx
+++ b/app/packages/tiling/src/views/Tile/Tile.tsx
@@ -49,8 +49,9 @@ export interface TileHeaderProps {
  * (the toolbar is the drag source — the entire header becomes the drag
  * handle). The split actions rest as ONE direction-neutral glyph (so the
  * affordance is always advertised) and resolve into the split-right /
- * split-down pair on header hover or keyboard focus; fullscreen and
- * close stay persistent.
+ * split-down pair when the pointer is over that glyph specifically (or
+ * on keyboard focus into the pair) — not on any hover of the header;
+ * fullscreen and close stay persistent.
  */
 export const TileHeader: React.FC<TileHeaderProps> = ({
   title,
@@ -181,7 +182,7 @@ export const TileHeader: React.FC<TileHeaderProps> = ({
       )}
       <div className={styles.actions}>
         {(onSplitRight || onSplitDown) && (
-          <>
+          <div className={styles.splitGroup}>
             {/* Decorative stand-in, never interactive: by the time a
                 pointer could click it, hover has already swapped in the
                 real buttons. A Button (focus-skipped) keeps its box
@@ -219,7 +220,7 @@ export const TileHeader: React.FC<TileHeaderProps> = ({
                 />
               )}
             </div>
-          </>
+          </div>
         )}
         <Button
           variant={Variant.Borderless}


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

The tile header's split affordance rests as a single direction-neutral glyph and
expands into the split-right / split-down pair on interaction. That expansion was
keyed on `.header:hover`, so it fired whenever the pointer touched **anywhere** on
the header — dragging a tile, double-clicking the title to rename, or just moving
the cursor across the bar all triggered the swap. The animation read as noise
attached to the whole header rather than as an affordance belonging to the split
control.

This scopes the trigger to the split control itself: the hint and the split pair
are now wrapped in a `.splitGroup`, and `:hover` / `:focus-within` are keyed on
that group instead of the header.

The naive version of this change self-destructs, which is worth calling out for
review. The hint previously hid via `display: none`. Once the hover target is the
group rather than the header, removing the hint from flow collapses the group to
~0 width the instant it hides — the cursor is then outside the element it is
supposedly hovering, `:hover` drops, the hint returns, and the whole thing
oscillates. Two changes avoid that:

- The hint and the split pair share a single CSS-grid cell
  (`grid-template-areas: "split"`), so the group's width is always
  `max(hint, pair)` and never collapses mid-transition.
- The hint hides with `visibility: hidden` rather than `display: none`, so it
  keeps reserving its width while invisible.

No behavior changes for keyboard users: the pair is still collapsed via
`max-width` + `overflow` rather than `display`, so both buttons stay in the tab
order at rest and tabbing into either one triggers `:focus-within` on the group
and expands the pair.

## 🧪 How is this patch tested? If it is not, please explain why.

Manually, in the MCAP multimodal modal:

- Moving the pointer across the tile header (title, empty space, fullscreen and
  close buttons) no longer expands the split pair.
- Hovering the split glyph expands the pair; moving off collapses it. No flicker
  or oscillation at the boundary, which was the specific failure mode the grid-cell
  overlay is there to prevent.
- Tabbing into the split buttons expands the pair with the pointer nowhere near
  the header; both buttons remain reachable and activate correctly.
- Dragging a tile by its header no longer animates the split control mid-drag.

No automated tests added. `Tile.test.tsx` asserts the presence/absence of the
split hint and the split buttons, which this change preserves — it does not
assert hover state, and jsdom does not evaluate CSS `:hover` / `:focus-within`
against a stylesheet, so the actual regression here isn't reachable from a unit
test. Verifying it properly would need a browser-driven test, which the tiling
package doesn't currently have.

Note for anyone reproducing locally: `packages/tiling`'s Vitest suites may fail on
your machine with `Cannot read properties of null (reading 'useContext')` if you
have `app/node_modules/@voxel51/voodo` symlinked to a local `design-system`
checkout — that pulls a second React into the module graph. It is a local dev-link
artifact, not a repo or CI problem, and it reproduces on `develop` without this
change.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

N/A — interaction polish within the existing multimodal tiling UI; no new
capability or changed workflow.

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved split-action controls so they expand only when the split control is hovered or focused.
  * Preserved the control group’s width while hiding contextual hints, reducing unwanted header interactions.
  * Improved keyboard focus behavior for split actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3686
<!-- enterprise-sync-pr:end -->
