### PR TITLE
Label-op patch classification + persisted-patch listener seam

### DIFF
--- a/app/packages/annotation/src/util/labelPersistence.ts
+++ b/app/packages/annotation/src/util/labelPersistence.ts
@@ -51,10 +51,13 @@ export interface PatchPersistedInfo {
   postSample: unknown;
   isGenerated: boolean;
   labelId?: string;
-  opType?: string;
+  labelPath?: string;
+  opType?: OpType;
 }
 
-type PatchPersistedListener = (info: PatchPersistedInfo) => void;
+type PatchPersistedListener = (
+  info: PatchPersistedInfo,
+) => void | Promise<void>;
 
 const patchListeners = new Set<PatchPersistedListener>();
 
@@ -172,11 +175,16 @@ export const doPatchSample = async ({
       postSample,
       isGenerated: Boolean(isGenerated),
       labelId,
+      labelPath,
       opType,
     };
     for (const listener of patchListeners) {
       try {
-        listener(info);
+        // Async listeners are not awaited — persistence never blocks on
+        // observers — but their rejections must not surface as unhandled.
+        Promise.resolve(listener(info)).catch((err) => {
+          console.debug("patch listener failed", err);
+        });
       } catch (err) {
         console.debug("patch listener failed", err);
       }

--- a/app/packages/annotation/src/util/labelPersistence.ts
+++ b/app/packages/annotation/src/util/labelPersistence.ts
@@ -38,6 +38,34 @@ export type DoPatchSampleArgs = {
  * @param labelPath Path to the label field (if applicable)
  * @param opType Operation type (mutate/delete)
  */
+/**
+ * Observers of persisted sample patches. A listener receives the patch
+ * exactly as it landed: the deltas, the pre-patch sample, the server's
+ * post-patch sample, and the field-level metadata when the caller used
+ * that fast path. Registered by downstream consumers (e.g. activity
+ * analytics); failures never interfere with persistence.
+ */
+export interface PatchPersistedInfo {
+  deltas: JSONDeltas;
+  preSample: unknown;
+  postSample: unknown;
+  isGenerated: boolean;
+  labelId?: string;
+  opType?: string;
+}
+
+type PatchPersistedListener = (info: PatchPersistedInfo) => void;
+
+const patchListeners = new Set<PatchPersistedListener>();
+
+/** Returns an unsubscribe function. */
+export const addPatchPersistedListener = (
+  listener: PatchPersistedListener,
+): (() => void) => {
+  patchListeners.add(listener);
+  return () => patchListeners.delete(listener);
+};
+
 export const doPatchSample = async ({
   sample,
   datasetId,
@@ -58,6 +86,10 @@ export const doPatchSample = async ({
   }
 
   let caughtErr: Error;
+  // The server's post-patch sample, for the persisted-patch listeners: a
+  // new single-label field can arrive as ops whose values carry no label
+  // id, so only the post state can say what was created.
+  let postSample: unknown = null;
 
   if (sampleDeltas.length > 0) {
     try {
@@ -97,6 +129,7 @@ export const doPatchSample = async ({
       if (updatedSample) {
         // transform response data to match the graphql sample format
         const cleanedSample = transformSampleData(updatedSample);
+        postSample = cleanedSample;
         if (isSampleIsh(cleanedSample)) {
           refreshSample(cleanedSample as Sample);
         } else {
@@ -130,6 +163,24 @@ export const doPatchSample = async ({
   // raise HTTP errors to the caller
   if (caughtErr) {
     throw caughtErr;
+  }
+
+  if (sampleDeltas.length > 0) {
+    const info: PatchPersistedInfo = {
+      deltas: sampleDeltas,
+      preSample: sample,
+      postSample,
+      isGenerated: Boolean(isGenerated),
+      labelId,
+      opType,
+    };
+    for (const listener of patchListeners) {
+      try {
+        listener(info);
+      } catch (err) {
+        console.debug("patch listener failed", err);
+      }
+    }
   }
 
   return true;

--- a/app/packages/utilities/src/sample/index.ts
+++ b/app/packages/utilities/src/sample/index.ts
@@ -10,14 +10,15 @@ export type { LabelData } from "./labels";
 // by per-frame video labels and temporal detections.
 export { idAlignedListDelta } from "./diff";
 export type { IdAlignedDeltaSpec } from "./diff";
+// Per-label classification of persisted JSON patches (Activity Analytics
+// label-op capture; see the activity-analytics KB, time-tracking-events.md).
+export { classifyLabelOps, isEmptyLabelOps } from "./labelOps";
+export type { LabelOpsSummary } from "./labelOps";
 // Apply JSON-Patch deltas to a document (server-faithful re-baseline primitive).
 export { applyDeltas } from "./apply";
 // Sample's canonical value-equality (collapses DateTime shapes); reused by
 // reconcilers to decide whether a change is a no-op echo of Sample's truth.
 export { equalsNormalized } from "./normalize";
-// Per-label classification of persisted RFC-6902 patches.
-export { classifyLabelOps, isEmptyLabelOps } from "./labelOps";
-export type { ClassifyLabelOpsArgs, LabelOpsSummary } from "./labelOps";
 export { Sample, SampleChangeKind } from "./sample";
 export type {
   SampleChange,

--- a/app/packages/utilities/src/sample/index.ts
+++ b/app/packages/utilities/src/sample/index.ts
@@ -14,9 +14,10 @@ export type { IdAlignedDeltaSpec } from "./diff";
 export { applyDeltas } from "./apply";
 // Sample's canonical value-equality (collapses DateTime shapes); reused by
 // reconcilers to decide whether a change is a no-op echo of Sample's truth.
-export { classifyLabelOps, isEmptyLabelOps } from "./labelOps";
-export type { LabelOpsSummary } from "./labelOps";
 export { equalsNormalized } from "./normalize";
+// Per-label classification of persisted RFC-6902 patches.
+export { classifyLabelOps, isEmptyLabelOps } from "./labelOps";
+export type { ClassifyLabelOpsArgs, LabelOpsSummary } from "./labelOps";
 export { Sample, SampleChangeKind } from "./sample";
 export type {
   SampleChange,

--- a/app/packages/utilities/src/sample/index.ts
+++ b/app/packages/utilities/src/sample/index.ts
@@ -14,6 +14,8 @@ export type { IdAlignedDeltaSpec } from "./diff";
 export { applyDeltas } from "./apply";
 // Sample's canonical value-equality (collapses DateTime shapes); reused by
 // reconcilers to decide whether a change is a no-op echo of Sample's truth.
+export { classifyLabelOps, isEmptyLabelOps } from "./labelOps";
+export type { LabelOpsSummary } from "./labelOps";
 export { equalsNormalized } from "./normalize";
 export { Sample, SampleChangeKind } from "./sample";
 export type {

--- a/app/packages/utilities/src/sample/labelOps.test.ts
+++ b/app/packages/utilities/src/sample/labelOps.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { classifyLabelOps } from "./labelOps";
+import { classifyLabelOps, isEmptyLabelOps } from "./labelOps";
 import type { JSONDeltas } from "../types";
 
 const sample = {
@@ -185,45 +185,51 @@ describe("classifyLabelOps", () => {
   });
 });
 
-it("attributes sequential removes through the index shift", () => {
-  // RFC-6902 applies ops in order: removing index 1 twice deletes the
-  // ORIGINAL n2 then n3 (which shifted into slot 1).
-  const pre = {
-    ground_truth: {
-      detections: [{ _id: "n1" }, { _id: "n2" }, { _id: "n3" }],
-    },
-  };
-  const ops = classifyLabelOps({
-    deltas: [
-      { op: "remove", path: "/ground_truth/detections/1" },
-      { op: "remove", path: "/ground_truth/detections/1" },
-    ],
-    preSample: pre,
-  });
-  expect(ops.deleted.sort()).toEqual(["n2", "n3"]);
-  expect(ops.added).toEqual([]);
-  expect(ops.modified).toEqual([]);
-});
-
-it("attributes labels nested under video frames", () => {
-  const pre = {
-    frames: {
-      "1": {
-        detections: { detections: [{ _id: "f1" }, { _id: "f2" }] },
+describe("sequential index replay", () => {
+  it("attributes sequential removes through the index shift", () => {
+    // RFC-6902 applies ops in order: removing index 1 twice deletes the
+    // ORIGINAL n2 then n3 (which shifted into slot 1).
+    const pre = {
+      ground_truth: {
+        detections: [{ _id: "n1" }, { _id: "n2" }, { _id: "n3" }],
       },
-    },
-  };
-  const ops = classifyLabelOps({
-    deltas: [
-      { op: "remove", path: "/frames/1/detections/detections/0" },
-      { op: "replace", path: "/frames/1/detections/detections/0/label" },
-    ],
-    preSample: pre,
+    };
+    const ops = classifyLabelOps({
+      deltas: [
+        { op: "remove", path: "/ground_truth/detections/1" },
+        { op: "remove", path: "/ground_truth/detections/1" },
+      ],
+      preSample: pre,
+    });
+    expect(ops.deleted.sort()).toEqual(["n2", "n3"]);
+    expect(ops.added).toEqual([]);
+    expect(ops.modified).toEqual([]);
   });
-  // Sequential shift: the remove takes f1; the replace then edits f2
-  // (which shifted into slot 0).
-  expect(ops.deleted).toEqual(["f1"]);
-  expect(ops.modified).toEqual(["f2"]);
+
+  it("attributes labels nested under video frames", () => {
+    const pre = {
+      frames: {
+        "1": {
+          detections: { detections: [{ _id: "f1" }, { _id: "f2" }] },
+        },
+      },
+    };
+    const ops = classifyLabelOps({
+      deltas: [
+        { op: "remove", path: "/frames/1/detections/detections/0" },
+        {
+          op: "replace",
+          path: "/frames/1/detections/detections/0/label",
+          value: "bus",
+        },
+      ],
+      preSample: pre,
+    });
+    // Sequential shift: the remove takes f1; the replace then edits f2
+    // (which shifted into slot 0).
+    expect(ops.deleted).toEqual(["f1"]);
+    expect(ops.modified).toEqual(["f2"]);
+  });
 });
 
 describe("whole-field ops (FOEPD-4344)", () => {
@@ -520,5 +526,67 @@ describe("video temporal labels identify by instance (FOEPD-4344 follow-up)", ()
     expect([...ops.modified].sort()).toEqual(["f1", "f2"]);
     expect(ops.instanceOf.f1).toBe("aaaa000011112222aaaa0001");
     expect(ops.instanceOf.f2).toBe("aaaa000011112222aaaa0001");
+  });
+
+  it("attributes a whole-frame-field replace to the frame's field", () => {
+    const pre = {
+      _id: "smp",
+      frames: [
+        null,
+        { weather: { _id: "w1", label: "sunny", instance: inst } },
+      ],
+    };
+    const ops = classifyLabelOps({
+      deltas: [
+        {
+          op: "replace",
+          path: "/frames/1/weather",
+          value: { _id: "w1", label: "rain", instance: inst },
+        },
+      ] as JSONDeltas,
+      preSample: pre,
+    });
+    expect(ops.modified).toEqual(["w1"]);
+    expect(ops.fieldOf.w1).toBe("weather");
+    expect(ops.instanceOf.w1).toBe("aaaa000011112222aaaa0001");
+  });
+});
+
+describe("isEmptyLabelOps", () => {
+  it("is true when no operations were classified", () => {
+    expect(
+      isEmptyLabelOps(classifyLabelOps({ deltas: [], preSample: sample })),
+    ).toBe(true);
+    expect(
+      isEmptyLabelOps({
+        added: [],
+        deleted: [],
+        modified: [],
+        fieldOf: {},
+        instanceOf: {},
+      }),
+    ).toBe(true);
+  });
+
+  it("is false when any operation set is populated", () => {
+    expect(
+      isEmptyLabelOps({
+        added: [],
+        deleted: ["n1"],
+        modified: [],
+        fieldOf: { n1: "ground_truth" },
+        instanceOf: {},
+      }),
+    ).toBe(false);
+    expect(
+      isEmptyLabelOps(
+        classifyLabelOps({
+          deltas: [
+            { op: "remove", path: "/ground_truth/detections/0" },
+          ] as JSONDeltas,
+          preSample: sample,
+        }),
+      ),
+    ).toBe(false);
   });
 });

--- a/app/packages/utilities/src/sample/labelOps.test.ts
+++ b/app/packages/utilities/src/sample/labelOps.test.ts
@@ -552,6 +552,132 @@ describe("video temporal labels identify by instance (FOEPD-4344 follow-up)", ()
   });
 });
 
+describe("generated-view fast path (label-rooted deltas)", () => {
+  // Patches views emit deltas rooted at the LABEL — no field prefix — and
+  // route persistence via {labelId, labelPath}. The patch sample carries
+  // the label under its field, so the id is present in the pre state even
+  // though no op path can locate its container.
+  const patchSample = {
+    _id: "patch1",
+    _sample_id: "smp1",
+    ground_truth: {
+      _id: "p1",
+      _cls: "Detection",
+      label: "car",
+      bounding_box: [0.1, 0.2, 0.3, 0.4],
+    },
+  };
+
+  it("classifies an edit of a pre-existing label as a modify, not an add", () => {
+    const ops = classifyLabelOps({
+      deltas: [
+        { op: "replace", path: "/label", value: "truck" },
+        { op: "replace", path: "/bounding_box/3", value: 0.5 },
+      ] as JSONDeltas,
+      preSample: patchSample,
+      labelId: "p1",
+      labelPath: "ground_truth.detections",
+      opType: "mutate",
+    });
+    expect(ops.modified).toEqual(["p1"]);
+    expect(ops.added).toEqual([]);
+  });
+
+  it("attributes the label to the labelPath field, not the op path head", () => {
+    const ops = classifyLabelOps({
+      deltas: [{ op: "replace", path: "/label", value: "truck" }] as JSONDeltas,
+      preSample: patchSample,
+      labelId: "p1",
+      labelPath: "ground_truth.detections",
+      opType: "mutate",
+    });
+    expect(ops.fieldOf.p1).toBe("ground_truth");
+  });
+});
+
+describe("frame paths resolve by frame_number (modal frames array)", () => {
+  // The modal sample carries frames as a positional array — often only the
+  // head frame — while deltas address frames by frame NUMBER.
+  it("resolves a frame remove when the frame is not at its positional index", () => {
+    const pre = {
+      _id: "smp",
+      frames: [{ frame_number: 3, dets: { detections: [{ _id: "f9" }] } }],
+    };
+    const ops = classifyLabelOps({
+      deltas: [{ op: "remove", path: "/frames/3/dets/detections/0" }],
+      preSample: pre,
+    });
+    expect(ops.deleted).toEqual(["f9"]);
+  });
+
+  it("attributes edits to the numbered frame, not the array position", () => {
+    const pre = {
+      _id: "smp",
+      frames: [
+        { frame_number: 1, dets: { detections: [{ _id: "a1" }] } },
+        { frame_number: 2, dets: { detections: [{ _id: "b1" }] } },
+      ],
+    };
+    const ops = classifyLabelOps({
+      deltas: [
+        {
+          op: "replace",
+          path: "/frames/2/dets/detections/0/label",
+          value: "bus",
+        },
+      ] as JSONDeltas,
+      preSample: pre,
+    });
+    // positional frames[2] is out of range; frame_number 2 is index 1
+    expect(ops.modified).toEqual(["b1"]);
+    expect(ops.added).toEqual([]);
+  });
+});
+
+describe("numeric attribute indices on single-label fields", () => {
+  it("classifies a bbox drag on a plain Detection field as one modify", () => {
+    const pre = {
+      _id: "smp",
+      gt_det: {
+        _id: "d1",
+        _cls: "Detection",
+        label: "car",
+        bounding_box: [0.1, 0.2, 0.3, 0.4],
+      },
+    };
+    const ops = classifyLabelOps({
+      deltas: [
+        { op: "replace", path: "/gt_det/bounding_box/3", value: 0.5 },
+        { op: "replace", path: "/gt_det/bounding_box/2", value: 0.6 },
+      ] as JSONDeltas,
+      preSample: pre,
+    });
+    expect(ops.modified).toEqual(["d1"]);
+    expect(ops.added).toEqual([]);
+    expect(ops.fieldOf.d1).toBe("gt_det");
+  });
+
+  it("classifies attribute-array edits on a frame single-label field", () => {
+    const pre = {
+      _id: "smp",
+      frames: [
+        {
+          frame_number: 1,
+          gt_det: { _id: "fd1", bounding_box: [0.1, 0.2, 0.3, 0.4] },
+        },
+      ],
+    };
+    const ops = classifyLabelOps({
+      deltas: [
+        { op: "replace", path: "/frames/1/gt_det/bounding_box/0", value: 0.9 },
+      ] as JSONDeltas,
+      preSample: pre,
+    });
+    expect(ops.modified).toEqual(["fd1"]);
+    expect(ops.fieldOf.fd1).toBe("gt_det");
+  });
+});
+
 describe("isEmptyLabelOps", () => {
   it("is true when no operations were classified", () => {
     expect(

--- a/app/packages/utilities/src/sample/labelOps.test.ts
+++ b/app/packages/utilities/src/sample/labelOps.test.ts
@@ -1,0 +1,524 @@
+import { describe, expect, it } from "vitest";
+import { classifyLabelOps } from "./labelOps";
+import type { JSONDeltas } from "../types";
+
+const sample = {
+  _id: "smp1",
+  ground_truth: {
+    detections: [
+      { _id: "n1", label: "car" },
+      { _id: "n2", label: "car" },
+      { _id: "n3", label: "bus" },
+      { _id: "n4", label: "bike" },
+      { _id: "n5", label: "car" },
+    ],
+  },
+  weather: { classification: { _id: "w1", label: "sunny" } },
+};
+
+describe("classifyLabelOps", () => {
+  it("groups multiple deep ops on one label as a single modify", () => {
+    const deltas = [
+      {
+        op: "replace",
+        path: "/ground_truth/detections/0/bounding_box/3",
+        value: 1,
+      },
+      {
+        op: "replace",
+        path: "/ground_truth/detections/0/bounding_box/2",
+        value: 2,
+      },
+      {
+        op: "replace",
+        path: "/ground_truth/detections/0/bounding_box/1",
+        value: 3,
+      },
+    ] as JSONDeltas;
+    expect(classifyLabelOps({ deltas, preSample: sample })).toEqual(
+      expect.objectContaining({
+        added: [],
+        deleted: [],
+        modified: ["n1"],
+      }),
+    );
+  });
+
+  it("classifies element removes as deletes with pre-patch ids", () => {
+    const deltas = [
+      { op: "remove", path: "/ground_truth/detections/4" },
+    ] as JSONDeltas;
+    expect(classifyLabelOps({ deltas, preSample: sample })).toEqual(
+      expect.objectContaining({
+        added: [],
+        deleted: ["n5"],
+        modified: [],
+      }),
+    );
+  });
+
+  it("classifies element adds from the op value, including appends", () => {
+    const deltas = [
+      { op: "add", path: "/ground_truth/detections/-", value: { _id: "n9" } },
+      { op: "add", path: "/ground_truth/detections/5", value: { _id: "n8" } },
+    ] as JSONDeltas;
+    expect(classifyLabelOps({ deltas, preSample: sample })).toEqual(
+      expect.objectContaining({
+        added: ["n9", "n8"],
+        deleted: [],
+        modified: [],
+      }),
+    );
+  });
+
+  it("handles mixed patches and dedupes per label", () => {
+    const deltas = [
+      { op: "add", path: "/ground_truth/detections/-", value: { _id: "n9" } },
+      {
+        op: "replace",
+        path: "/ground_truth/detections/1/label",
+        value: "truck",
+      },
+      {
+        op: "replace",
+        path: "/ground_truth/detections/1/confidence",
+        value: 0.9,
+      },
+      { op: "remove", path: "/ground_truth/detections/2" },
+    ] as JSONDeltas;
+    expect(classifyLabelOps({ deltas, preSample: sample })).toEqual(
+      expect.objectContaining({
+        added: ["n9"],
+        deleted: ["n3"],
+        modified: ["n2"],
+      }),
+    );
+  });
+
+  it("treats single-label fields as elements", () => {
+    const deltas = [
+      { op: "replace", path: "/weather/classification/label", value: "rain" },
+    ] as JSONDeltas;
+    expect(classifyLabelOps({ deltas, preSample: sample })).toEqual(
+      expect.objectContaining({
+        added: [],
+        deleted: [],
+        modified: ["w1"],
+      }),
+    );
+  });
+
+  it("uses the field-level fast path when labelId is supplied", () => {
+    expect(
+      classifyLabelOps({
+        deltas: [
+          { op: "remove", path: "/ground_truth/detections/0" },
+        ] as JSONDeltas,
+        preSample: sample,
+        labelId: "n1",
+        opType: "delete",
+      }),
+    ).toEqual(
+      expect.objectContaining({ added: [], deleted: ["n1"], modified: [] }),
+    );
+
+    expect(
+      classifyLabelOps({
+        deltas: [
+          {
+            op: "add",
+            path: "/ground_truth/detections/-",
+            value: { _id: "n9" },
+          },
+        ] as JSONDeltas,
+        preSample: sample,
+        labelId: "n9",
+        opType: "mutate",
+      }),
+    ).toEqual(
+      expect.objectContaining({ added: ["n9"], deleted: [], modified: [] }),
+    );
+
+    expect(
+      classifyLabelOps({
+        deltas: [
+          {
+            op: "replace",
+            path: "/ground_truth/detections/0/label",
+            value: "x",
+          },
+        ] as JSONDeltas,
+        preSample: sample,
+        labelId: "n1",
+        opType: "mutate",
+      }),
+    ).toEqual(
+      expect.objectContaining({ added: [], deleted: [], modified: ["n1"] }),
+    );
+  });
+
+  it("skips labels whose ids cannot be resolved", () => {
+    const deltas = [
+      { op: "remove", path: "/ground_truth/detections/99" },
+      {
+        op: "add",
+        path: "/ground_truth/detections/-",
+        value: { label: "no-id" },
+      },
+    ] as JSONDeltas;
+    expect(classifyLabelOps({ deltas, preSample: sample })).toEqual(
+      expect.objectContaining({
+        added: [],
+        deleted: [],
+        modified: [],
+      }),
+    );
+  });
+
+  it("records the owning field per label", () => {
+    const deltas = [
+      { op: "replace", path: "/ground_truth/detections/0/label", value: "x" },
+      { op: "remove", path: "/ground_truth/detections/4" },
+    ] as JSONDeltas;
+    const ops = classifyLabelOps({ deltas, preSample: sample });
+    expect(ops.fieldOf).toEqual({ n1: "ground_truth", n5: "ground_truth" });
+  });
+});
+
+it("attributes sequential removes through the index shift", () => {
+  // RFC-6902 applies ops in order: removing index 1 twice deletes the
+  // ORIGINAL n2 then n3 (which shifted into slot 1).
+  const pre = {
+    ground_truth: {
+      detections: [{ _id: "n1" }, { _id: "n2" }, { _id: "n3" }],
+    },
+  };
+  const ops = classifyLabelOps({
+    deltas: [
+      { op: "remove", path: "/ground_truth/detections/1" },
+      { op: "remove", path: "/ground_truth/detections/1" },
+    ],
+    preSample: pre,
+  });
+  expect(ops.deleted.sort()).toEqual(["n2", "n3"]);
+  expect(ops.added).toEqual([]);
+  expect(ops.modified).toEqual([]);
+});
+
+it("attributes labels nested under video frames", () => {
+  const pre = {
+    frames: {
+      "1": {
+        detections: { detections: [{ _id: "f1" }, { _id: "f2" }] },
+      },
+    },
+  };
+  const ops = classifyLabelOps({
+    deltas: [
+      { op: "remove", path: "/frames/1/detections/detections/0" },
+      { op: "replace", path: "/frames/1/detections/detections/0/label" },
+    ],
+    preSample: pre,
+  });
+  // Sequential shift: the remove takes f1; the replace then edits f2
+  // (which shifted into slot 0).
+  expect(ops.deleted).toEqual(["f1"]);
+  expect(ops.modified).toEqual(["f2"]);
+});
+
+describe("whole-field ops (FOEPD-4344)", () => {
+  it("counts a whole-field classification add via the container value", () => {
+    const ops = classifyLabelOps({
+      deltas: [
+        {
+          op: "add",
+          path: "/my_tags",
+          value: { classifications: [{ _id: "c1", label: "cat" }] },
+        },
+      ] as JSONDeltas,
+      preSample: { _id: "smp1" },
+    });
+    expect(ops.added).toEqual(["c1"]);
+    expect(ops.deleted).toEqual([]);
+    expect(ops.fieldOf.c1).toBe("my_tags");
+  });
+
+  it("counts a replace of an empty single-label field as an add", () => {
+    const ops = classifyLabelOps({
+      deltas: [
+        {
+          op: "replace",
+          path: "/weather2",
+          value: { _id: "c2", label: "rainy" },
+        },
+      ] as JSONDeltas,
+      preSample: { _id: "smp1", weather2: null },
+    });
+    expect(ops.added).toEqual(["c2"]);
+    expect(ops.modified).toEqual([]);
+  });
+
+  it("counts a same-id whole-field replace as a modify", () => {
+    const ops = classifyLabelOps({
+      deltas: [
+        {
+          op: "replace",
+          path: "/weather",
+          value: { classification: { _id: "w1", label: "cloudy" } },
+        },
+      ] as JSONDeltas,
+      preSample: sample,
+    });
+    expect(ops.modified).toEqual(["w1"]);
+    expect(ops.added).toEqual([]);
+    expect(ops.deleted).toEqual([]);
+  });
+
+  it("diffs a whole-field replace that swaps the label", () => {
+    const ops = classifyLabelOps({
+      deltas: [
+        {
+          op: "replace",
+          path: "/weather",
+          value: { classification: { _id: "w9", label: "hail" } },
+        },
+      ] as JSONDeltas,
+      preSample: sample,
+    });
+    expect(ops.added).toEqual(["w9"]);
+    expect(ops.deleted).toEqual(["w1"]);
+  });
+
+  it("counts every contained label on a whole-field remove", () => {
+    const ops = classifyLabelOps({
+      deltas: [{ op: "remove", path: "/ground_truth" }] as JSONDeltas,
+      preSample: sample,
+    });
+    expect([...ops.deleted].sort()).toEqual(["n1", "n2", "n3", "n4", "n5"]);
+  });
+
+  it("treats a same-patch remove+add of one label as a move, not a delete", () => {
+    const ops = classifyLabelOps({
+      deltas: [
+        { op: "remove", path: "/ground_truth/detections/0" },
+        {
+          op: "add",
+          path: "/my_field/detections/-",
+          value: { _id: "n1", label: "car" },
+        },
+      ] as JSONDeltas,
+      preSample: sample,
+    });
+    expect(ops.added).toEqual(["n1"]);
+    expect(ops.deleted).toEqual([]);
+  });
+
+  it("fast path: whole-field set of an absent label counts as added", () => {
+    const ops = classifyLabelOps({
+      deltas: [
+        {
+          op: "replace",
+          path: "/new_tag",
+          value: { _id: "c7", label: "dog" },
+        },
+      ] as JSONDeltas,
+      preSample: { _id: "smp1" },
+      labelId: "c7",
+      opType: "mutate",
+    });
+    expect(ops.added).toEqual(["c7"]);
+    expect(ops.modified).toEqual([]);
+  });
+
+  it("fast path: whole-field set of a pre-existing label stays a modify", () => {
+    const ops = classifyLabelOps({
+      deltas: [
+        {
+          op: "replace",
+          path: "/weather",
+          value: { classification: { _id: "w1", label: "fog" } },
+        },
+      ] as JSONDeltas,
+      preSample: sample,
+      labelId: "w1",
+      opType: "mutate",
+    });
+    expect(ops.modified).toEqual(["w1"]);
+    expect(ops.added).toEqual([]);
+  });
+});
+
+describe("skeleton adds resolved from the post state (FOEPD-4344)", () => {
+  it("classifies a skeleton add + per-property sets as one added label", () => {
+    // The engine emits a NEW classification as an id-less skeleton add
+    // followed by property sets — no single op carries the label id.
+    const ops = classifyLabelOps({
+      deltas: [
+        { op: "add", path: "/lanny_tag", value: { _cls: "Classification" } },
+        { op: "replace", path: "/lanny_tag/label", value: "cat" },
+        { op: "replace", path: "/lanny_tag/confidence", value: 0.9 },
+      ] as JSONDeltas,
+      preSample: { _id: "smp1" },
+      postSample: {
+        _id: "smp1",
+        lanny_tag: { _id: "c9", _cls: "Classification", label: "cat" },
+      },
+    });
+    expect(ops.added).toEqual(["c9"]);
+    expect(ops.modified).toEqual([]);
+  });
+
+  it("classifies deep sets on a pre-existing label as modified, not added", () => {
+    const ops = classifyLabelOps({
+      deltas: [
+        { op: "replace", path: "/weather/classification/label", value: "fog" },
+      ] as JSONDeltas,
+      preSample: sample,
+      postSample: sample,
+    });
+    expect(ops.modified).toEqual(["w1"]);
+    expect(ops.added).toEqual([]);
+  });
+
+  it("resolves a whole-field replace via the post state when the op value is a skeleton", () => {
+    const ops = classifyLabelOps({
+      deltas: [
+        { op: "replace", path: "/new_tag", value: { _cls: "Classification" } },
+      ] as JSONDeltas,
+      preSample: { _id: "smp1", new_tag: null },
+      postSample: {
+        _id: "smp1",
+        new_tag: { _id: "c10", _cls: "Classification", label: "dog" },
+      },
+    });
+    expect(ops.added).toEqual(["c10"]);
+  });
+});
+
+describe("per-property add shape (FOEPD-4344, captured from the wire)", () => {
+  it("classifies four per-property adds as ONE added label via the post state", () => {
+    // The exact payload the app sends for a fresh classification tag —
+    // no single op touches the element path, and no op value carries a
+    // resolvable label object.
+    const ops = classifyLabelOps({
+      deltas: [
+        { op: "add", path: "/lanny_tag/_cls", value: "Classification" },
+        {
+          op: "add",
+          path: "/lanny_tag/_id",
+          value: "6a75fda06f51230f8949c0f0",
+        },
+        { op: "add", path: "/lanny_tag/is_fun", value: false },
+        { op: "add", path: "/lanny_tag/label", value: "a" },
+      ] as JSONDeltas,
+      preSample: { _id: "smp", lanny_tag: null },
+      postSample: {
+        _id: "smp",
+        lanny_tag: {
+          _id: { $oid: "6a75fda06f51230f8949c0f0" },
+          _cls: "Classification",
+          label: "a",
+          is_fun: false,
+        },
+      },
+    });
+    expect(ops.added).toEqual(["6a75fda06f51230f8949c0f0"]);
+    expect(ops.modified).toEqual([]);
+    expect(ops.fieldOf["6a75fda06f51230f8949c0f0"]).toBe("lanny_tag");
+  });
+});
+
+describe("video temporal labels identify by instance (FOEPD-4344 follow-up)", () => {
+  const inst = { _id: { $oid: "aaaa000011112222aaaa0001" }, _cls: "Instance" };
+  const frameDet = (id: string, frame: number) => ({
+    op: "add",
+    path: `/frames/${frame}/dets/detections/-`,
+    value: { _id: id, label: "car", instance: inst },
+  });
+
+  it("keeps per-frame label ids and maps each to the shared instance", () => {
+    const ops = classifyLabelOps({
+      deltas: [
+        frameDet("f1", 1),
+        frameDet("f2", 2),
+        frameDet("f3", 3),
+      ] as JSONDeltas,
+      preSample: { _id: "smp", frames: [] },
+    });
+    expect([...ops.added].sort()).toEqual(["f1", "f2", "f3"]);
+    expect(ops.instanceOf).toEqual({
+      f1: "aaaa000011112222aaaa0001",
+      f2: "aaaa000011112222aaaa0001",
+      f3: "aaaa000011112222aaaa0001",
+    });
+    expect(ops.fieldOf.f1).toBe("dets");
+  });
+
+  it("falls back to field+index identity for tracking-style labels", () => {
+    const ops = classifyLabelOps({
+      deltas: [
+        {
+          op: "add",
+          path: "/frames/1/dets/detections/-",
+          value: { _id: "f1", label: "car", index: 7 },
+        },
+        {
+          op: "add",
+          path: "/frames/2/dets/detections/-",
+          value: { _id: "f2", label: "car", index: 7 },
+        },
+      ] as JSONDeltas,
+      preSample: { _id: "smp", frames: [] },
+    });
+    expect(ops.instanceOf).toEqual({ f1: "dets#track7", f2: "dets#track7" });
+  });
+
+  it("maps no instance when a frame label has no tracking identity", () => {
+    const ops = classifyLabelOps({
+      deltas: [
+        {
+          op: "add",
+          path: "/frames/1/dets/detections/-",
+          value: { _id: "f1", label: "car" },
+        },
+        {
+          op: "add",
+          path: "/frames/2/dets/detections/-",
+          value: { _id: "f2", label: "car" },
+        },
+      ] as JSONDeltas,
+      preSample: { _id: "smp", frames: [] },
+    });
+    expect([...ops.added].sort()).toEqual(["f1", "f2"]);
+    expect(ops.instanceOf).toEqual({});
+  });
+
+  it("edits of one instance across frames map both frame ids to it", () => {
+    const pre = {
+      _id: "smp",
+      frames: [
+        null,
+        { dets: { detections: [{ _id: "f1", label: "car", instance: inst }] } },
+        { dets: { detections: [{ _id: "f2", label: "car", instance: inst }] } },
+      ],
+    };
+    const ops = classifyLabelOps({
+      deltas: [
+        {
+          op: "replace",
+          path: "/frames/1/dets/detections/0/label",
+          value: "bus",
+        },
+        {
+          op: "replace",
+          path: "/frames/2/dets/detections/0/label",
+          value: "bus",
+        },
+      ] as JSONDeltas,
+      preSample: pre,
+    });
+    expect([...ops.modified].sort()).toEqual(["f1", "f2"]);
+    expect(ops.instanceOf.f1).toBe("aaaa000011112222aaaa0001");
+    expect(ops.instanceOf.f2).toBe("aaaa000011112222aaaa0001");
+  });
+});

--- a/app/packages/utilities/src/sample/labelOps.ts
+++ b/app/packages/utilities/src/sample/labelOps.ts
@@ -160,8 +160,8 @@ export interface ClassifyLabelOpsArgs {
   postSample?: unknown;
   /** Field-level fast path: the single label the patch targets. */
   labelId?: string;
-  /** Field-level fast path: "mutate" | "delete". */
-  opType?: string;
+  /** Field-level fast path: only "delete" changes classification. */
+  opType?: "mutate" | "delete" | "add";
 }
 
 /**
@@ -229,7 +229,12 @@ export const classifyLabelOps = ({
     const element = elementSegments(segments);
     const exactlyElement = element.length === segments.length;
     const last = element[element.length - 1];
-    const isListElement = element.length > 1 && isElementSegment(last);
+    // A bare /frames/<n> is the frame CONTAINER, not a label list element:
+    // resolving it as one would fabricate the frame document's id. Let the
+    // whole-field branches collect the labels it contains instead.
+    const isWholeFrame = element.length === 2 && element[0] === "frames";
+    const isListElement =
+      element.length > 1 && isElementSegment(last) && !isWholeFrame;
     const ids = isListElement ? idsFor(element.slice(0, -1)) : null;
     const index =
       last === "-" ? (ids ? ids.length : -1) : Number.parseInt(last, 10);
@@ -266,7 +271,7 @@ export const classifyLabelOps = ({
     } else if (delta.op === "remove" && exactlyElement) {
       // Deleted label(s): the SHIFTED array state names a list element; a
       // whole-field remove names every label still in the pre-patch field.
-      let opIds = shifted
+      const opIds = shifted
         ? [shifted]
         : isListElement
           ? []
@@ -286,21 +291,26 @@ export const classifyLabelOps = ({
       // (a classification "set" on a pre-existing null field lands here).
       // The op value may be a skeleton without ids — the post-patch
       // sample is the fallback source for what now lives in the field.
-      const preIds = new Set(collectLabelIds(getAtPath(preSample, element)));
-      let postIds = collectLabelIds((delta as { value?: unknown }).value);
+      const preNode = getAtPath(preSample, element);
+      const preIds = new Set(collectLabelIds(preNode));
+      let postNode: unknown = (delta as { value?: unknown }).value;
+      let postIds = collectLabelIds(postNode);
       if (!postIds.length) {
-        postIds = collectLabelIds(getAtPath(postSample, element));
+        postNode = getAtPath(postSample, element);
+        postIds = collectLabelIds(postNode);
       }
       for (const id of postIds) {
         if (preIds.has(id)) modified.add(id);
         else added.add(id);
-        fieldOf[id] = element[0];
+        fieldOf[id] = opField;
+        noteInstance(id, postNode);
       }
       const postSet = new Set(postIds);
       for (const id of preIds) {
         if (!postSet.has(id)) {
           deleted.add(id);
-          fieldOf[id] = element[0];
+          fieldOf[id] = opField;
+          noteInstance(id, preNode);
         }
       }
     } else {

--- a/app/packages/utilities/src/sample/labelOps.ts
+++ b/app/packages/utilities/src/sample/labelOps.ts
@@ -1,0 +1,384 @@
+/**
+ * Classify a persisted JSON Patch into per-label operations.
+ *
+ * Every label save (add / edit / delete, autosave included) flows through
+ * `doPatchSample` as RFC-6902 deltas against the sample document, e.g.:
+ *
+ *   {op: "replace", path: "/ground_truth/detections/0/bounding_box/3"}  edit
+ *   {op: "remove",  path: "/ground_truth/detections/4"}                 delete
+ *   {op: "add",     path: "/ground_truth/detections/-", value: {...}}   add
+ *
+ * This module turns one such patch into `{added, deleted, modified}` label-id
+ * sets for Activity Analytics (the submit-time label delta + the per-label
+ * activity trail — see the activity-analytics KB, `time-tracking-events.md`).
+ *
+ * Classification is per LABEL ELEMENT, not per op: a bbox drag emits several
+ * `replace` ops on one detection and must count as ONE modified label. The
+ * element boundary is the prefix through the first numeric (or `-`) path
+ * segment for list labels, or the field itself for single-label fields.
+ *
+ * Unresolvable label ids are skipped — an undercount is acceptable for
+ * analytics; a fabricated id is not.
+ */
+
+import type { JSONDeltas } from "../types";
+import { getAtPath } from "./pointer";
+
+export interface LabelOpsSummary {
+  added: string[];
+  deleted: string[];
+  modified: string[];
+  /** Sample field each label lives in (e.g. "ground_truth"), by label id. */
+  fieldOf: Record<string, string>;
+  /**
+   * Instance identity by label id, where one exists (video temporal
+   * labels): the shared ``instance`` id, else ``field#track<index>`` for
+   * tracking-style labels. Consumers count/dedupe by
+   * ``instanceOf[id] ?? id`` so one temporal detection materialized
+   * across N frames reads as ONE label, while events keep the true
+   * per-frame label id (FOEPD-4344 follow-up).
+   */
+  instanceOf: Record<string, string>;
+}
+
+/** True when the summary carries no operations. */
+export const isEmptyLabelOps = (ops: LabelOpsSummary): boolean =>
+  ops.added.length === 0 &&
+  ops.deleted.length === 0 &&
+  ops.modified.length === 0;
+
+const NUMERIC = /^\d+$/;
+
+const isElementSegment = (segment: string): boolean =>
+  segment === "-" || NUMERIC.test(segment);
+
+/** Path segments for a JSON pointer ("/a/b/0" → ["a", "b", "0"]). */
+const segmentsOf = (pointer: string): string[] =>
+  pointer
+    .split("/")
+    .slice(1)
+    .filter((segment) => segment.length > 0);
+
+/**
+ * The label-element prefix of a delta path: through the first numeric
+ * segment for list labels, else the bare field for single-label fields.
+ */
+const elementSegments = (segments: string[]): string[] => {
+  for (let i = 0; i < segments.length; i++) {
+    if (isElementSegment(segments[i])) {
+      // Video paths nest the label under a frame: /frames/<n>/<field>/…
+      // — the frame index is an INTERMEDIATE segment, not the label
+      // element. Continue to the next numeric segment (list label) or
+      // the frame's field (single-label).
+      if (i === 1 && segments[0] === "frames") {
+        for (let j = i + 1; j < segments.length; j++) {
+          if (isElementSegment(segments[j])) {
+            return segments.slice(0, j + 1);
+          }
+        }
+        return segments.slice(0, Math.min(3, segments.length));
+      }
+      return segments.slice(0, i + 1);
+    }
+  }
+  return segments.slice(0, 1);
+};
+
+const labelIdOf = (candidate: unknown): string | null => {
+  if (candidate && typeof candidate === "object") {
+    const record = candidate as Record<string, unknown>;
+    const id = record._id ?? record.id;
+    if (typeof id === "string" && id) return id;
+    // Extended-JSON object ids ({$oid: "..."}) survive some transforms.
+    if (id && typeof id === "object") {
+      const oid = (id as Record<string, unknown>).$oid;
+      if (typeof oid === "string" && oid) return oid;
+    }
+  }
+  return null;
+};
+
+/**
+ * Instance-level identity for a VIDEO frame label (FOEPD-4344 follow-up).
+ *
+ * A temporal detection is one logical label materialized as one document
+ * per frame — a single gesture adds dozens of per-frame ids. Managers
+ * read "labels" at the INSTANCE level, so frame labels identify by their
+ * shared ``instance`` id (or, for older tracking-style labels, by
+ * ``field + index``) and every per-frame op on the same instance folds
+ * into one added/deleted/modified entry. Frame labels with neither
+ * tracking field keep their per-frame id (each frame genuinely is its
+ * own label then).
+ */
+const frameLabelIdentity = (
+  node: unknown,
+  field: string | undefined,
+): string | null => {
+  if (!node || typeof node !== "object") return null;
+  const record = node as Record<string, unknown>;
+  const instanceId = labelIdOf(record.instance);
+  if (instanceId) return instanceId;
+  if (typeof record.index === "number" && field) {
+    return `${field}#track${record.index}`;
+  }
+  return null;
+};
+
+/**
+ * Every label id in a whole-field value: the label itself, or the labels
+ * inside a container field (`{classifications: [...]}`, `{detections:
+ * [...]}`). Whole-field ops carry these shapes — a classification set from
+ * the annotate sidebar arrives as one add/replace of the field, and
+ * resolving only the top object's id (which containers don't have) made
+ * those saves invisible (FOEPD-4344).
+ */
+const collectLabelIds = (node: unknown, depth = 2): string[] => {
+  const direct = labelIdOf(node);
+  if (direct) return [direct];
+  if (depth <= 0 || !node || typeof node !== "object") return [];
+  const out: string[] = [];
+  const children = Array.isArray(node)
+    ? node
+    : Object.values(node as Record<string, unknown>);
+  for (const child of children) {
+    if (!child || typeof child !== "object") continue;
+    const id = labelIdOf(child);
+    if (id) {
+      out.push(id);
+    } else if (Array.isArray(child)) {
+      out.push(...collectLabelIds(child, depth - 1));
+    }
+  }
+  return out;
+};
+
+export interface ClassifyLabelOpsArgs {
+  deltas: JSONDeltas;
+  /** The sample BEFORE the patch (source for deleted/modified ids). */
+  preSample: unknown;
+  /** The sample AFTER the patch (source for added ids). */
+  postSample?: unknown;
+  /** Field-level fast path: the single label the patch targets. */
+  labelId?: string;
+  /** Field-level fast path: "mutate" | "delete". */
+  opType?: string;
+}
+
+/**
+ * Classifies one persisted patch into deduped per-label operation sets.
+ */
+export const classifyLabelOps = ({
+  deltas,
+  preSample,
+  postSample,
+  labelId,
+  opType,
+}: ClassifyLabelOpsArgs): LabelOpsSummary => {
+  const added = new Set<string>();
+  const deleted = new Set<string>();
+  const modified = new Set<string>();
+  const fieldOf: Record<string, string> = {};
+  const instanceOf: Record<string, string> = {};
+
+  // Field-level updates name their label outright — trust that.
+  if (labelId) {
+    if (opType === "delete") {
+      deleted.add(labelId);
+    } else if (
+      deltas.some(
+        (delta) =>
+          delta.op === "add" &&
+          isElementTail(segmentsOf(delta.path)) &&
+          labelIdOf((delta as { value?: unknown }).value) === labelId,
+      ) ||
+      !fastPathPreExisting(deltas, preSample, labelId)
+    ) {
+      // Explicit list add, or the label is absent from the pre-patch
+      // sample: a whole-field set of a new classification arrives as one
+      // add/replace of the field and must count as ADDED, not modified
+      // (FOEPD-4344).
+      added.add(labelId);
+    } else {
+      modified.add(labelId);
+    }
+    const field = deltas.length ? segmentsOf(deltas[0].path)[0] : undefined;
+    if (field) fieldOf[labelId] = field;
+    return toSummary(added, deleted, modified, fieldOf, instanceOf);
+  }
+
+  // RFC-6902 ops apply SEQUENTIALLY: `remove /f/detections/1` twice
+  // deletes the pre-patch elements at index 1 THEN 2 (indices shift as
+  // each op lands). Resolving every op against the untouched preSample
+  // would attribute the second remove to the first element again, so
+  // each touched array's id list is replayed op by op.
+  const arrayIds = new Map<string, (string | null)[]>();
+  const idsFor = (prefix: string[]): (string | null)[] | null => {
+    const key = prefix.join("/");
+    const cached = arrayIds.get(key);
+    if (cached) return cached;
+    const node = getAtPath(preSample, prefix);
+    if (!Array.isArray(node)) return null;
+    const ids = node.map((entry) => labelIdOf(entry));
+    arrayIds.set(key, ids);
+    return ids;
+  };
+
+  for (const delta of deltas) {
+    const segments = segmentsOf(delta.path);
+    if (segments.length === 0) continue;
+    const element = elementSegments(segments);
+    const exactlyElement = element.length === segments.length;
+    const last = element[element.length - 1];
+    const isListElement = element.length > 1 && isElementSegment(last);
+    const ids = isListElement ? idsFor(element.slice(0, -1)) : null;
+    const index =
+      last === "-" ? (ids ? ids.length : -1) : Number.parseInt(last, 10);
+    const shifted = ids && index >= 0 && index < ids.length ? ids[index] : null;
+    // Video frame paths: attribute ops to the label FIELD (element[2] in
+    // /frames/<n>/<field>/…), not the literal "frames" container, and
+    // prefer the instance identity over the per-frame document id.
+    const isFrame = element[0] === "frames" && element.length >= 3;
+    const opField = isFrame ? element[2] : element[0];
+    const noteInstance = (id: string | null, node: unknown) => {
+      if (!id || !isFrame) return;
+      const identity = frameLabelIdentity(node, opField);
+      if (identity) instanceOf[id] = identity;
+    };
+
+    if (delta.op === "add" && exactlyElement) {
+      // New label(s): ids ride in the op's own value — directly for a list
+      // element, inside the container for a whole-field add (a
+      // classification set from the sidebar arrives as one field-level op).
+      const value = (delta as { value?: unknown }).value;
+      let opIds = collectLabelIds(value);
+      if (!opIds.length) {
+        const resolved = resolveId(postSample, element);
+        if (resolved) opIds = [resolved];
+      }
+      if (opIds.length === 1) {
+        noteInstance(opIds[0], value ?? getAtPath(postSample, element));
+      }
+      for (const id of opIds) {
+        added.add(id);
+        fieldOf[id] = opField;
+      }
+      if (ids && index >= 0) ids.splice(index, 0, opIds[0] ?? null);
+    } else if (delta.op === "remove" && exactlyElement) {
+      // Deleted label(s): the SHIFTED array state names a list element; a
+      // whole-field remove names every label still in the pre-patch field.
+      let opIds = shifted
+        ? [shifted]
+        : isListElement
+          ? []
+          : collectLabelIds(getAtPath(preSample, element));
+      if (opIds.length === 1) {
+        noteInstance(opIds[0], getAtPath(preSample, element));
+      }
+      for (const id of opIds) {
+        deleted.add(id);
+        fieldOf[id] = opField;
+      }
+      if (ids && index >= 0 && index < ids.length) ids.splice(index, 1);
+    } else if (delta.op === "replace" && exactlyElement && !isListElement) {
+      // Whole-field replace: an add when the field was empty, a delete
+      // when it is being cleared, and modified/moved labels otherwise —
+      // diff the pre and post label-id sets rather than guessing
+      // (a classification "set" on a pre-existing null field lands here).
+      // The op value may be a skeleton without ids — the post-patch
+      // sample is the fallback source for what now lives in the field.
+      const preIds = new Set(collectLabelIds(getAtPath(preSample, element)));
+      let postIds = collectLabelIds((delta as { value?: unknown }).value);
+      if (!postIds.length) {
+        postIds = collectLabelIds(getAtPath(postSample, element));
+      }
+      for (const id of postIds) {
+        if (preIds.has(id)) modified.add(id);
+        else added.add(id);
+        fieldOf[id] = element[0];
+      }
+      const postSet = new Set(postIds);
+      for (const id of preIds) {
+        if (!postSet.has(id)) {
+          deleted.add(id);
+          fieldOf[id] = element[0];
+        }
+      }
+    } else {
+      // Anything deeper (or replace at the element) edits a label; the
+      // shifted state resolves it, else the samples. A label absent from
+      // the PRE state that the POST state resolves was created by this
+      // patch (a skeleton add + per-property sets never carries the id
+      // in any single op) — that is an ADD, not an edit (FOEPD-4344).
+      const preId = shifted ?? resolveId(preSample, element);
+      const id = preId ?? resolveId(postSample, element);
+      if (id) {
+        noteInstance(
+          id,
+          getAtPath(preSample, element) ?? getAtPath(postSample, element),
+        );
+        if (preId) {
+          modified.add(id);
+        } else {
+          added.add(id);
+        }
+        fieldOf[id] = opField;
+      }
+    }
+  }
+
+  return toSummary(added, deleted, modified, fieldOf, instanceOf);
+};
+
+const isElementTail = (segments: string[]): boolean =>
+  segments.length > 0 && isElementSegment(segments[segments.length - 1]);
+
+/** Whether the fast path's label already exists in the pre-patch sample. */
+const fastPathPreExisting = (
+  deltas: JSONDeltas,
+  preSample: unknown,
+  labelId: string,
+): boolean => {
+  if (!deltas.length) return true; // no path to check — assume edit
+  const element = elementSegments(segmentsOf(deltas[0].path));
+  const container =
+    element.length > 1 && isElementSegment(element[element.length - 1])
+      ? element.slice(0, -1)
+      : element;
+  return collectLabelIds(getAtPath(preSample, container)).includes(labelId);
+};
+
+const resolveId = (sample: unknown, element: string[]): string | null => {
+  if (!sample) return null;
+  const node = getAtPath(sample, element);
+  const direct = labelIdOf(node);
+  if (direct) return direct;
+  // Single-label fields sometimes nest the label one level down
+  // (e.g. {classification: {...}}); accept an only-child with an id.
+  if (node && typeof node === "object" && !Array.isArray(node)) {
+    const values = Object.values(node as Record<string, unknown>);
+    for (const value of values) {
+      const id = labelIdOf(value);
+      if (id) return id;
+    }
+  }
+  return null;
+};
+
+const toSummary = (
+  added: Set<string>,
+  deleted: Set<string>,
+  modified: Set<string>,
+  fieldOf: Record<string, string>,
+  instanceOf: Record<string, string> = {},
+): LabelOpsSummary => ({
+  added: [...added],
+  // A label both added and removed by ONE patch was moved (e.g. re-homed
+  // from its staging field on first save) — it survives the patch, so
+  // reporting the remove would poison the session netting into "add then
+  // delete = no work" (FOEPD-4344).
+  deleted: [...deleted].filter((id) => !added.has(id)),
+  // A label added or deleted in the same patch is not ALSO modified.
+  modified: [...modified].filter((id) => !added.has(id) && !deleted.has(id)),
+  fieldOf,
+  instanceOf,
+});

--- a/app/packages/utilities/src/sample/labelOps.ts
+++ b/app/packages/utilities/src/sample/labelOps.ts
@@ -84,6 +84,33 @@ const elementSegments = (segments: string[]): string[] => {
   return segments.slice(0, 1);
 };
 
+/**
+ * Resolve a path against a sample document. Frame deltas address frames by
+ * frame NUMBER (`/frames/<n>/…`), but the modal sample carries `frames` as a
+ * positional array — often holding only the head frame — so a plain pointer
+ * walk reads the wrong frame (or none). Dereference the frame by its
+ * `frame_number` when frames is an array; positional and map-keyed shapes
+ * fall through to the plain walk.
+ */
+const getAtSamplePath = (root: unknown, segments: string[]): unknown => {
+  if (segments.length >= 2 && segments[0] === "frames" && root) {
+    const frames = (root as Record<string, unknown>).frames;
+    if (Array.isArray(frames)) {
+      const frameNumber = Number.parseInt(segments[1], 10);
+      const frame = frames.find(
+        (candidate) =>
+          candidate &&
+          typeof candidate === "object" &&
+          (candidate as Record<string, unknown>).frame_number === frameNumber,
+      );
+      if (frame !== undefined) {
+        return getAtPath(frame, segments.slice(2));
+      }
+    }
+  }
+  return getAtPath(root, segments);
+};
+
 const labelIdOf = (candidate: unknown): string | null => {
   if (candidate && typeof candidate === "object") {
     const record = candidate as Record<string, unknown>;
@@ -152,6 +179,26 @@ const collectLabelIds = (node: unknown, depth = 2): string[] => {
   return out;
 };
 
+/**
+ * Bounded search for a label id anywhere in a sample document. Generated
+ * (patches) views emit deltas rooted at the LABEL — no field prefix — so the
+ * fast path cannot locate the label's container from an op path; presence of
+ * the id anywhere in the pre-patch document is what distinguishes an edit
+ * from a creation there.
+ */
+const containsLabelId = (
+  node: unknown,
+  labelId: string,
+  depth = 8,
+): boolean => {
+  if (depth < 0 || !node || typeof node !== "object") return false;
+  if (labelIdOf(node) === labelId) return true;
+  const children = Array.isArray(node)
+    ? node
+    : Object.values(node as Record<string, unknown>);
+  return children.some((child) => containsLabelId(child, labelId, depth - 1));
+};
+
 export interface ClassifyLabelOpsArgs {
   deltas: JSONDeltas;
   /** The sample BEFORE the patch (source for deleted/modified ids). */
@@ -160,6 +207,12 @@ export interface ClassifyLabelOpsArgs {
   postSample?: unknown;
   /** Field-level fast path: the single label the patch targets. */
   labelId?: string;
+  /**
+   * Field-level fast path: dotted path to the label's field (e.g.
+   * `ground_truth.detections`). Authoritative for field attribution when
+   * the deltas are label-rooted (generated views).
+   */
+  labelPath?: string;
   /** Field-level fast path: only "delete" changes classification. */
   opType?: "mutate" | "delete" | "add";
 }
@@ -172,6 +225,7 @@ export const classifyLabelOps = ({
   preSample,
   postSample,
   labelId,
+  labelPath,
   opType,
 }: ClassifyLabelOpsArgs): LabelOpsSummary => {
   const added = new Set<string>();
@@ -201,7 +255,12 @@ export const classifyLabelOps = ({
     } else {
       modified.add(labelId);
     }
-    const field = deltas.length ? segmentsOf(deltas[0].path)[0] : undefined;
+    // labelPath is authoritative: generated views root their deltas at the
+    // LABEL, so the op path's head segment is a label attribute ("label",
+    // "bounding_box"), not a sample field.
+    const field = labelPath
+      ? fieldOfLabelPath(labelPath)
+      : fieldOfDeltaPath(deltas);
     if (field) fieldOf[labelId] = field;
     return toSummary(added, deleted, modified, fieldOf, instanceOf);
   }
@@ -216,7 +275,7 @@ export const classifyLabelOps = ({
     const key = prefix.join("/");
     const cached = arrayIds.get(key);
     if (cached) return cached;
-    const node = getAtPath(preSample, prefix);
+    const node = getAtSamplePath(preSample, prefix);
     if (!Array.isArray(node)) return null;
     const ids = node.map((entry) => labelIdOf(entry));
     arrayIds.set(key, ids);
@@ -226,9 +285,30 @@ export const classifyLabelOps = ({
   for (const delta of deltas) {
     const segments = segmentsOf(delta.path);
     if (segments.length === 0) continue;
-    const element = elementSegments(segments);
+    let element = elementSegments(segments);
+    let last = element[element.length - 1];
+    // A numeric segment is only a list-label boundary when the container it
+    // indexes is a list of LABELS. On a single-label field a numeric index
+    // addresses an attribute array (`/gt_det/bounding_box/3` — a bbox drag),
+    // and the element is the owning field itself; treating the coordinate as
+    // a list entry silently drops the edit.
+    if (element.length > 1 && NUMERIC.test(last)) {
+      const container =
+        getAtSamplePath(preSample, element.slice(0, -1)) ??
+        getAtSamplePath(postSample, element.slice(0, -1));
+      if (
+        Array.isArray(container) &&
+        container.length > 0 &&
+        !container.some((entry) => labelIdOf(entry))
+      ) {
+        element =
+          element[0] === "frames"
+            ? element.slice(0, Math.min(3, element.length))
+            : element.slice(0, 1);
+        last = element[element.length - 1];
+      }
+    }
     const exactlyElement = element.length === segments.length;
-    const last = element[element.length - 1];
     // A bare /frames/<n> is the frame CONTAINER, not a label list element:
     // resolving it as one would fabricate the frame document's id. Let the
     // whole-field branches collect the labels it contains instead.
@@ -261,7 +341,7 @@ export const classifyLabelOps = ({
         if (resolved) opIds = [resolved];
       }
       if (opIds.length === 1) {
-        noteInstance(opIds[0], value ?? getAtPath(postSample, element));
+        noteInstance(opIds[0], value ?? getAtSamplePath(postSample, element));
       }
       for (const id of opIds) {
         added.add(id);
@@ -275,9 +355,9 @@ export const classifyLabelOps = ({
         ? [shifted]
         : isListElement
           ? []
-          : collectLabelIds(getAtPath(preSample, element));
+          : collectLabelIds(getAtSamplePath(preSample, element));
       if (opIds.length === 1) {
-        noteInstance(opIds[0], getAtPath(preSample, element));
+        noteInstance(opIds[0], getAtSamplePath(preSample, element));
       }
       for (const id of opIds) {
         deleted.add(id);
@@ -291,12 +371,12 @@ export const classifyLabelOps = ({
       // (a classification "set" on a pre-existing null field lands here).
       // The op value may be a skeleton without ids — the post-patch
       // sample is the fallback source for what now lives in the field.
-      const preNode = getAtPath(preSample, element);
+      const preNode = getAtSamplePath(preSample, element);
       const preIds = new Set(collectLabelIds(preNode));
       let postNode: unknown = (delta as { value?: unknown }).value;
       let postIds = collectLabelIds(postNode);
       if (!postIds.length) {
-        postNode = getAtPath(postSample, element);
+        postNode = getAtSamplePath(postSample, element);
         postIds = collectLabelIds(postNode);
       }
       for (const id of postIds) {
@@ -324,7 +404,8 @@ export const classifyLabelOps = ({
       if (id) {
         noteInstance(
           id,
-          getAtPath(preSample, element) ?? getAtPath(postSample, element),
+          getAtSamplePath(preSample, element) ??
+            getAtSamplePath(postSample, element),
         );
         if (preId) {
           modified.add(id);
@@ -342,6 +423,21 @@ export const classifyLabelOps = ({
 const isElementTail = (segments: string[]): boolean =>
   segments.length > 0 && isElementSegment(segments[segments.length - 1]);
 
+/** The sample field of a dotted label path ("frames.dets.detections" → "dets"). */
+const fieldOfLabelPath = (labelPath: string): string | undefined => {
+  const segments = labelPath.split(".");
+  return segments[0] === "frames" ? segments[1] : segments[0];
+};
+
+/** The frame-aware sample field of the patch's first delta path. */
+const fieldOfDeltaPath = (deltas: JSONDeltas): string | undefined => {
+  if (!deltas.length) return undefined;
+  const element = elementSegments(segmentsOf(deltas[0].path));
+  return element[0] === "frames" && element.length >= 3
+    ? element[2]
+    : element[0];
+};
+
 /** Whether the fast path's label already exists in the pre-patch sample. */
 const fastPathPreExisting = (
   deltas: JSONDeltas,
@@ -354,12 +450,18 @@ const fastPathPreExisting = (
     element.length > 1 && isElementSegment(element[element.length - 1])
       ? element.slice(0, -1)
       : element;
-  return collectLabelIds(getAtPath(preSample, container)).includes(labelId);
+  return (
+    collectLabelIds(getAtSamplePath(preSample, container)).includes(labelId) ||
+    // Label-rooted deltas (generated views) name no container the sample
+    // can resolve — the label pre-exists if its id appears anywhere in the
+    // pre-patch document.
+    containsLabelId(preSample, labelId)
+  );
 };
 
 const resolveId = (sample: unknown, element: string[]): string | null => {
   if (!sample) return null;
-  const node = getAtPath(sample, element);
+  const node = getAtSamplePath(sample, element);
   const direct = labelIdOf(node);
   if (direct) return direct;
   // Single-label fields sometimes nest the label one level down


### PR DESCRIPTION
Upstreams two pieces the FiftyOne Teams app currently carries as local divergence, so the trees stay aligned:

- **`classifyLabelOps`** (`@fiftyone/utilities`): classifies a persisted RFC-6902 sample patch into per-label `added`/`deleted`/`modified` id sets — element-level grouping (a bbox drag is one modify), sequential index replay for list removes, whole-field container values, post-state resolution for id-less skeleton adds, and instance identity for video temporal labels (`instanceOf` map). Fully covered by the ported test suite (26 tests, including wire shapes captured from real sessions).
- **A persisted-patch observer seam** in `doPatchSample`: listeners receive the landed deltas plus the pre/post sample states. Downstream consumers (e.g. Teams' activity analytics) subscribe via `addPatchPersistedListener`; listener failures never interfere with persistence.

No behavioral change for existing code paths — the seam only notifies after a successful patch, and nothing in OSS subscribes yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added utilities to classify label changes as additions, deletions, or modifications.
  * Added support for tracking persisted patch details, including before-and-after sample states.
  * Exposed label-operation classification helpers for broader use.
  * Added notifications for successfully persisted, non-empty label changes.

* **Tests**
  * Added comprehensive coverage for nested labels, indexed updates, video frames, skeletons, and complex patch scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3691
<!-- enterprise-sync-pr:end -->