### PR TITLE
fix(app): restore zero-warning eslint on develop

### DIFF
--- a/app/.recoil-allowlist.txt
+++ b/app/.recoil-allowlist.txt
@@ -370,7 +370,9 @@ packages/spaces/src/components/Workspaces/WorkspaceEditor.tsx
 packages/spaces/src/components/Workspaces/Workspace.tsx
 packages/spaces/src/hooks.ts
 packages/spaces/src/state.ts
+packages/state/src/accessors/coloring.ts
 packages/state/src/accessors/dataset.ts
+packages/state/src/accessors/fields.ts
 packages/state/src/accessors/modal/3d.ts
 packages/state/src/accessors/modal/dynamicGroups.ts
 packages/state/src/accessors/modal/index.ts

--- a/app/packages/looker-3d/src/annotation/native2d/parse.ts
+++ b/app/packages/looker-3d/src/annotation/native2d/parse.ts
@@ -20,8 +20,11 @@ const oid = (value: unknown): string | undefined => {
   return undefined;
 };
 
+const str = (value: unknown): string | undefined =>
+  typeof value === "string" ? value : undefined;
+
 const detectionFrom = (
-  raw: Record<string, any>,
+  raw: Record<string, unknown>,
   path: string,
 ): Native2dLabel | null => {
   const _id = oid(raw?._id) ?? oid(raw?.id);
@@ -31,13 +34,13 @@ const detectionFrom = (
     _id,
     _cls: "Detection",
     path,
-    label: raw.label,
+    label: str(raw.label),
     boundingBox: [bbox[0], bbox[1], bbox[2], bbox[3]],
   };
 };
 
 const polylineFrom = (
-  raw: Record<string, any>,
+  raw: Record<string, unknown>,
   path: string,
 ): Native2dLabel | null => {
   const _id = oid(raw?._id) ?? oid(raw?.id);
@@ -46,10 +49,10 @@ const polylineFrom = (
     _id,
     _cls: "Polyline",
     path,
-    label: raw.label,
+    label: str(raw.label),
     points: raw.points as [number, number][][],
-    closed: raw.closed,
-    filled: raw.filled,
+    closed: typeof raw.closed === "boolean" ? raw.closed : undefined,
+    filled: typeof raw.filled === "boolean" ? raw.filled : undefined,
   };
 };
 
@@ -68,7 +71,7 @@ const polylineFrom = (
  *   omitted every top-level field is considered.
  */
 export const extractNative2dLabels = (
-  sliceData: Record<string, any> | undefined | null,
+  sliceData: Record<string, unknown> | undefined | null,
   labelPaths?: string[],
 ): Native2dLabel[] => {
   if (!sliceData) return [];
@@ -84,30 +87,31 @@ export const extractNative2dLabels = (
     const value = sliceData[path];
     if (!value || typeof value !== "object") continue;
 
-    switch (value._cls) {
+    const field = value as Record<string, unknown>;
+    switch (field._cls) {
       case DETECTIONS:
-        if (Array.isArray(value.detections)) {
-          for (const d of value.detections) {
+        if (Array.isArray(field.detections)) {
+          for (const d of field.detections) {
             const label = detectionFrom(d, path);
             if (label) out.push(label);
           }
         }
         break;
       case DETECTION: {
-        const label = detectionFrom(value, path);
+        const label = detectionFrom(field, path);
         if (label) out.push(label);
         break;
       }
       case POLYLINES:
-        if (Array.isArray(value.polylines)) {
-          for (const p of value.polylines) {
+        if (Array.isArray(field.polylines)) {
+          for (const p of field.polylines) {
             const label = polylineFrom(p, path);
             if (label) out.push(label);
           }
         }
         break;
       case POLYLINE: {
-        const label = polylineFrom(value, path);
+        const label = polylineFrom(field, path);
         if (label) out.push(label);
         break;
       }

--- a/app/packages/looker-3d/src/annotation/native2d/useImageNaturalSize.test.ts
+++ b/app/packages/looker-3d/src/annotation/native2d/useImageNaturalSize.test.ts
@@ -77,7 +77,7 @@ describe("useImageNaturalSize", () => {
   });
 
   it("warns and leaves size unset on a failed load", () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const { result } = renderHook(() => useImageNaturalSize("broken.jpg"));
 
     act(() => {

--- a/app/packages/looker-3d/src/annotation/native2d/useNative2dLabelColor.ts
+++ b/app/packages/looker-3d/src/annotation/native2d/useNative2dLabelColor.ts
@@ -5,7 +5,6 @@ import {
 } from "@fiftyone/looker";
 import * as fos from "@fiftyone/state";
 import { useCallback } from "react";
-import { useRecoilValue } from "recoil";
 import type { Native2dLabel } from "./types";
 
 /**
@@ -14,8 +13,8 @@ import type { Native2dLabel } from "./types";
  * in Explore mode.
  */
 export const useNative2dLabelColor = (): ((label: Native2dLabel) => string) => {
-  const coloring = useRecoilValue(fos.coloring);
-  const colorScheme = useRecoilValue(fos.colorScheme);
+  const coloring = fos.useColoring();
+  const colorScheme = fos.useColorScheme();
 
   return useCallback(
     (label: Native2dLabel): string =>

--- a/app/packages/looker-3d/src/annotation/native2d/useVisibleNative2dLabels.ts
+++ b/app/packages/looker-3d/src/annotation/native2d/useVisibleNative2dLabels.ts
@@ -1,6 +1,5 @@
 import * as fos from "@fiftyone/state";
 import { useMemo } from "react";
-import { useRecoilValue } from "recoil";
 import type { Native2dLabel } from "./types";
 
 /**
@@ -15,10 +14,10 @@ import type { Native2dLabel } from "./types";
 export const useVisibleNative2dLabels = (
   labels: Native2dLabel[],
 ): Native2dLabel[] => {
-  const activeFields = useRecoilValue(fos.activeFields({ modal: true }));
-  const knownLabelFields = useRecoilValue(
-    fos.labelFields({ space: fos.State.SPACE.SAMPLE }),
-  );
+  const activeFields = fos.useActiveFields({ modal: true });
+  const knownLabelFields = fos.useLabelFields({
+    space: fos.State.SPACE.SAMPLE,
+  });
 
   return useMemo(() => {
     const active = new Set(activeFields);

--- a/app/packages/looker-3d/src/fo3d/mesh/MirisStream.tsx
+++ b/app/packages/looker-3d/src/fo3d/mesh/MirisStream.tsx
@@ -1,6 +1,5 @@
-import { dataset } from "@fiftyone/state";
+import { useCurrentDataset } from "@fiftyone/state";
 import { useEffect, useState } from "react";
-import { useRecoilValue } from "recoil";
 import type { Group, Quaternion, Vector3 } from "three";
 import type { MirisStreamAsset } from "../render-types";
 
@@ -33,7 +32,7 @@ export const MirisStream = ({
   scale: Vector3;
   children?: React.ReactNode;
 }) => {
-  const ds = useRecoilValue(dataset as never) as {
+  const ds = useCurrentDataset() as {
     info?: Record<string, unknown>;
   } | null;
   const rawDatasetViewerKey = ds?.info?.["miris_viewer_key"];

--- a/app/packages/looker-3d/src/labels/CuboidInstances.tsx
+++ b/app/packages/looker-3d/src/labels/CuboidInstances.tsx
@@ -556,7 +556,7 @@ export const CuboidInstances = ({
         onClick={handleClick}
       />
       {outlineGeometry && (
-        // @ts-ignore — registered via ./shared/registerLineElements
+        // @ts-expect-error — registered via ./shared/registerLineElements
         <lineSegments2
           geometry={outlineGeometry}
           material={outlineMaterial}
@@ -572,7 +572,7 @@ export const CuboidInstances = ({
         />
       )}
       {shaftGeometry && (
-        // @ts-ignore — registered via ./shared/registerLineElements
+        // @ts-expect-error — registered via ./shared/registerLineElements
         <lineSegments2
           geometry={shaftGeometry}
           material={shaftMaterial}
@@ -583,7 +583,7 @@ export const CuboidInstances = ({
         />
       )}
       {axesGeometry && (
-        // @ts-ignore — registered via ./shared/registerLineElements
+        // @ts-expect-error — registered via ./shared/registerLineElements
         <lineSegments2
           geometry={axesGeometry}
           material={axesMaterial}

--- a/app/packages/looker-3d/src/labels/shared/hooks.ts
+++ b/app/packages/looker-3d/src/labels/shared/hooks.ts
@@ -71,7 +71,7 @@ export const useHoverState = (): HoverState => {
 const useMeshTooltipProps = () => {
   const onPointerOver = useRecoilCallback(
     ({ snapshot, set }) =>
-      (label: any, e?: ThreeEvent<PointerEvent>) => {
+      (label: OverlayLabel, e?: ThreeEvent<PointerEvent>) => {
         const selectedLabel = snapshot
           .getLoadable(selectedLabelForAnnotationAtom)
           .getValue();
@@ -111,7 +111,7 @@ const useMeshTooltipProps = () => {
 
   const onPointerOut = useRecoilCallback(
     ({ snapshot, set }) =>
-      (label: any) => {
+      (label: OverlayLabel) => {
         const isTooltipLocked = snapshot
           .getLoadable(fos.isTooltipLocked)
           .getValue();
@@ -143,7 +143,7 @@ const useMeshTooltipProps = () => {
 
   const onPointerMove = useRecoilCallback(
     ({ snapshot, set }) =>
-      (label: any, e: ThreeEvent<PointerEvent>) => {
+      (label: OverlayLabel, e: ThreeEvent<PointerEvent>) => {
         const selectedLabel = snapshot
           .getLoadable(selectedLabelForAnnotationAtom)
           .getValue();
@@ -213,7 +213,7 @@ export const useEventHandlers = (): InstancedEventHandlers => {
   // handler runs first so it is never coupled to annotation state.
   return {
     onPointerOver: useCallback(
-      (label: any, e?: ThreeEvent<PointerEvent>) => {
+      (label: OverlayLabel, e?: ThreeEvent<PointerEvent>) => {
         _onPointerOver(label, e);
 
         if (!isAnnotateMode) {
@@ -232,7 +232,7 @@ export const useEventHandlers = (): InstancedEventHandlers => {
       [isAnnotateMode, engine, sample, _onPointerOver],
     ),
     onPointerOut: useCallback(
-      (label: any) => {
+      (label: OverlayLabel) => {
         _onPointerOut(label);
 
         if (!isAnnotateMode) {

--- a/app/packages/looker-3d/src/labels/shared/useDisplayCuboidTransform.test.ts
+++ b/app/packages/looker-3d/src/labels/shared/useDisplayCuboidTransform.test.ts
@@ -1,13 +1,11 @@
 import { renderHook } from "@testing-library/react";
-import React from "react";
-import { RecoilRoot } from "recoil";
 import * as THREE from "three";
 import { describe, expect, it, vi } from "vitest";
-import { transformModeAtom } from "../../state";
 import { useDisplayCuboidTransform } from "./useDisplayCuboidTransform";
 
-const { useTransientCuboidMock } = vi.hoisted(() => ({
+const { useTransientCuboidMock, useTransformModeMock } = vi.hoisted(() => ({
   useTransientCuboidMock: vi.fn(),
+  useTransformModeMock: vi.fn(),
 }));
 
 vi.mock("../../annotation/store", () => ({
@@ -16,30 +14,18 @@ vi.mock("../../annotation/store", () => ({
 
 // The state barrel reaches `@fiftyone/state` and its Relay fragments, which
 // need the Relay Babel transform that vitest doesn't run — importing it threw at
-// load time, so this file never executed. Stand in a real atom (the test drives
-// it through RecoilRoot) without pulling the barrel in.
-vi.mock("../../state", async () => {
-  const { atom } = await import("recoil");
-  return {
-    transformModeAtom: atom({
-      key: "test-transformMode",
-      default: "scale",
-    }),
-  };
-});
+// load time, so this file never executed. Stand in the accessor hook without
+// pulling the barrel in.
+vi.mock("../../state", () => ({
+  useTransformMode: useTransformModeMock,
+}));
 
 function renderWithMode(
   transformMode: "scale" | "rotate" | "translate",
   args: Parameters<typeof useDisplayCuboidTransform>[0],
 ) {
-  const wrapper = ({ children }: { children?: React.ReactNode }) =>
-    // `children` goes in the props object: RecoilRootProps requires it, and the
-    // third-argument form doesn't satisfy that overload.
-    React.createElement(RecoilRoot, {
-      initializeState: ({ set }) => set(transformModeAtom, transformMode),
-      children,
-    });
-  return renderHook(() => useDisplayCuboidTransform(args), { wrapper });
+  useTransformModeMock.mockReturnValue(transformMode);
+  return renderHook(() => useDisplayCuboidTransform(args));
 }
 
 describe("useDisplayCuboidTransform", () => {

--- a/app/packages/looker-3d/src/labels/shared/useDisplayCuboidTransform.ts
+++ b/app/packages/looker-3d/src/labels/shared/useDisplayCuboidTransform.ts
@@ -1,10 +1,9 @@
 import { useMemo } from "react";
-import { useRecoilValue } from "recoil";
 import * as THREE from "three";
 import { getCuboidResizeQuaternion } from "../../annotation/cuboid-face-resize";
 import { useTransientCuboid } from "../../annotation/store";
 import type { LabelId } from "../../annotation/store/types";
-import { transformModeAtom } from "../../state";
+import { useTransformMode } from "../../state";
 
 export interface UseDisplayCuboidTransformArgs {
   labelId: LabelId;
@@ -49,7 +48,7 @@ export function useDisplayCuboidTransform({
   useLegacyCoordinates,
 }: UseDisplayCuboidTransformArgs): UseDisplayCuboidTransformResult {
   const transientState = useTransientCuboid(labelId);
-  const transformMode = useRecoilValue(transformModeAtom);
+  const transformMode = useTransformMode();
 
   // Compute display dimensions: apply transient delta if present
   const displayDimensions = useMemo(() => {

--- a/app/packages/looker-3d/src/labels/shared/useHeadingDrag.test.ts
+++ b/app/packages/looker-3d/src/labels/shared/useHeadingDrag.test.ts
@@ -36,10 +36,26 @@ const mocks = vi.hoisted(() => ({
   pickSpy: vi.fn(),
 }));
 
-vi.mock("../../state", () => ({
-  hoveredHeadingTargetFaceAtom: mocks.atoms.hoveredHeadingTargetFaceAtom,
-  isCurrentlyTransformingAtom: mocks.atoms.isCurrentlyTransformingAtom,
-}));
+vi.mock("../../state", async () => {
+  // resolves to the mocked recoil below, so the accessor hooks share its
+  // reactive stand-in and the `mocks.setAtom` spy
+  const { useRecoilValue, useSetRecoilState } =
+    (await import("recoil")) as unknown as {
+      useRecoilValue: (atom: symbol) => unknown;
+      useSetRecoilState: (atom: symbol) => (value: unknown) => void;
+    };
+
+  return {
+    hoveredHeadingTargetFaceAtom: mocks.atoms.hoveredHeadingTargetFaceAtom,
+    isCurrentlyTransformingAtom: mocks.atoms.isCurrentlyTransformingAtom,
+    useHoveredHeadingTargetFace: () =>
+      useRecoilValue(mocks.atoms.hoveredHeadingTargetFaceAtom),
+    useSetHoveredHeadingTargetFace: () =>
+      useSetRecoilState(mocks.atoms.hoveredHeadingTargetFaceAtom),
+    useSetIsCurrentlyTransforming: () =>
+      useSetRecoilState(mocks.atoms.isCurrentlyTransformingAtom),
+  };
+});
 
 // A minimally reactive recoil stand-in: writes notify subscribers so consumers
 // re-render and re-read, which is what makes the shared target-face atom

--- a/app/packages/looker-3d/src/labels/shared/useHeadingDrag.ts
+++ b/app/packages/looker-3d/src/labels/shared/useHeadingDrag.ts
@@ -7,13 +7,13 @@ import {
   type MutableRefObject,
   type RefObject,
 } from "react";
-import { useRecoilValue, useSetRecoilState } from "recoil";
 import * as THREE from "three";
 import type { CuboidResizeFace } from "../../annotation/cuboid-face-resize";
 import { computeCuboidHeadingRelabel } from "../../annotation/cuboid-heading-relabel";
 import {
-  hoveredHeadingTargetFaceAtom,
-  isCurrentlyTransformingAtom,
+  useHoveredHeadingTargetFace,
+  useSetHoveredHeadingTargetFace,
+  useSetIsCurrentlyTransforming,
 } from "../../state";
 import type { HoveredLabelSource } from "../../types";
 import { toNDC, toNDCForElement } from "../../utils";
@@ -118,11 +118,9 @@ export function useHeadingDrag({
   suppressNextClickRef,
 }: UseHeadingDragOptions): UseHeadingDragResult {
   const { camera, gl } = useThree();
-  const setIsCurrentlyTransforming = useSetRecoilState(
-    isCurrentlyTransformingAtom,
-  );
-  const targetFaceState = useRecoilValue(hoveredHeadingTargetFaceAtom);
-  const setTargetFaceState = useSetRecoilState(hoveredHeadingTargetFaceAtom);
+  const setIsCurrentlyTransforming = useSetIsCurrentlyTransforming();
+  const targetFaceState = useHoveredHeadingTargetFace();
+  const setTargetFaceState = useSetHoveredHeadingTargetFace();
 
   const [isHovered, setIsHovered] = useState(false);
   const [isDragging, setIsDragging] = useState(false);

--- a/app/packages/looker-3d/src/state/accessors.ts
+++ b/app/packages/looker-3d/src/state/accessors.ts
@@ -12,6 +12,7 @@ import {
   fo3dPerformanceStatsAtom,
   headingUpEditorHoverAtom,
   headingUpPreviewAtom,
+  hoveredHeadingTargetFaceAtom,
   hoveredLabelAtom,
   isActivelySegmentingSelector,
   isCreatingCuboidAtom,
@@ -111,6 +112,29 @@ export const useSetFo3dPerformanceStats = () => {
  */
 export const useIsCurrentlyTransforming = () => {
   return useRecoilValue(isCurrentlyTransformingAtom);
+};
+
+export const useSetIsCurrentlyTransforming = () => {
+  return useSetRecoilState(isCurrentlyTransformingAtom);
+};
+
+/**
+ * The active transform gizmo mode (translate/rotate/scale).
+ */
+export const useTransformMode = () => {
+  return useRecoilValue(transformModeAtom);
+};
+
+/**
+ * The candidate face during a heading drag, shared across panels so the
+ * highlight shows wherever the label is drawn.
+ */
+export const useHoveredHeadingTargetFace = () => {
+  return useRecoilValue(hoveredHeadingTargetFaceAtom);
+};
+
+export const useSetHoveredHeadingTargetFace = () => {
+  return useSetRecoilState(hoveredHeadingTargetFaceAtom);
 };
 
 /**

--- a/app/packages/state/src/accessors/coloring.ts
+++ b/app/packages/state/src/accessors/coloring.ts
@@ -1,0 +1,13 @@
+import { useRecoilValue } from "recoil";
+import { coloring, colorScheme } from "../recoil";
+
+/**
+ * The resolved coloring configuration (color-by mode, pool, seed) used to
+ * color labels.
+ */
+export const useColoring = () => useRecoilValue(coloring);
+
+/**
+ * The session color scheme (per-field customizations, label tag colors).
+ */
+export const useColorScheme = () => useRecoilValue(colorScheme);

--- a/app/packages/state/src/accessors/fields.ts
+++ b/app/packages/state/src/accessors/fields.ts
@@ -1,0 +1,14 @@
+import { useRecoilValue } from "recoil";
+import { activeFields, labelFields, State } from "../recoil";
+
+/**
+ * The field paths currently toggled visible in the sidebar.
+ */
+export const useActiveFields = (params: { modal: boolean }) =>
+  useRecoilValue(activeFields(params));
+
+/**
+ * The label field paths in the dataset schema.
+ */
+export const useLabelFields = (params: { space?: State.SPACE } = {}) =>
+  useRecoilValue(labelFields(params));

--- a/app/packages/state/src/accessors/index.ts
+++ b/app/packages/state/src/accessors/index.ts
@@ -1,3 +1,5 @@
+export * from "./coloring";
 export * from "./dataset";
+export * from "./fields";
 export * from "./modal";
 export * from "./sidebar";


### PR DESCRIPTION
## What

Restores zero-warning eslint on `develop`. Every open PR currently fails the `lint / eslint` job with 19 warnings in `looker-3d` files it doesn't touch.

How it happened: the zero-warning gate landed on `develop` while #8114's green lint check was already recorded; the check never re-ran against the new base, so the merge brought the warnings in. Lint only runs on PRs, so `develop` went red silently.

## Changes

**Recoil freeze (6 warnings)** — accessor hooks instead of direct `recoil` imports, per the freeze policy:
- looker-3d `state/accessors.ts`: `useTransformMode`, `useSetIsCurrentlyTransforming`, `useHoveredHeadingTargetFace` / `useSetHoveredHeadingTargetFace`
- `@fiftyone/state`: `useColoring`, `useColorScheme` (`accessors/coloring.ts`), `useActiveFields`, `useLabelFields` (`accessors/fields.ts`) — the two new files are the only allowlist additions, and they are the accessor layer itself
- `MirisStream` uses the existing `fos.useCurrentDataset()` instead of `useRecoilValue(dataset as never)`
- `useDisplayCuboidTransform.test` mocks the accessor hook and drops `RecoilRoot` (also removes the `react/no-children-prop` warning)

**Types (9 warnings)** — `parse.ts` takes `Record<string, unknown>` with narrowing (`label`/`closed`/`filled` behavior preserved); `hooks.ts` pointer handlers take `OverlayLabel` instead of `any`.

**Comments (4 warnings)** — `@ts-ignore` → `@ts-expect-error` on the three `lineSegments2` JSX sites (runtime-registered via `extend()`, no type declarations); a no-op test mock returns `undefined` instead of an empty body.

## Verification

- CI's exact lint invocation (`yarn eslint $ESLINT_PACKAGES`): 0 problems
- `yarn format:check`: clean
- Both touched test files pass (10/10)
- `yarn typecheck` error count identical to `develop` baseline (pre-existing, not a PR gate)

## Follow-ups (not in this PR)

- Run lint on `develop` pushes so a red trunk is visible immediately
- Require checks to be current against the base at merge time (stale-approval gap)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added accessors for coloring, color schemes, active fields, label fields, transform modes, and hovered heading targets.
* **Bug Fixes**
  * Improved annotation label parsing while preserving valid polyline properties.
* **Refactor**
  * Updated 3D annotation, label, and viewer components to use unified state handling.
* **Tests**
  * Simplified transform-mode test setup and clarified failed-image-load test behavior.
* **Type Safety**
  * Improved handling of serialized data and pointer events with explicit types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3688
<!-- enterprise-sync-pr:end -->