### PR TITLE
e2e: patch label bubbles and attribute eye toggles in patches views

### DIFF
--- a/e2e-pw/src/oss/poms/sidebar.ts
+++ b/e2e-pw/src/oss/poms/sidebar.ts
@@ -85,6 +85,15 @@ export class SidebarPom {
     return selector.click();
   }
 
+  /**
+   * The eye button on an attribute's filter row controlling whether the
+   * attribute renders in label overlays. Visible after expanding the parent
+   * field's dropdown.
+   */
+  shownAttributeToggle(path: string) {
+    return this.sidebar.getByTestId(`shown-attribute-${path}`);
+  }
+
   async waitForElement(dataCy: string) {
     const selector = this.sidebar.getByTestId(dataCy);
     await selector.waitFor();

--- a/e2e-pw/src/oss/specs/patch-label-overlays.spec.ts
+++ b/e2e-pw/src/oss/specs/patch-label-overlays.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ *
+ * Patch label overlays (FOEPD-4259) and toggleable label attributes
+ * (FOEPD-4260) in grid patches views. Each patch tile shows its label as a
+ * tag bubble; the sidebar's per-attribute eye icons control which attributes
+ * render in the bubble, and the last shown attribute locks so at least one
+ * always renders.
+ */
+import { test as base, expect } from "src/oss/fixtures";
+import { GridPom } from "src/oss/poms/grid";
+import { SidebarPom } from "src/oss/poms/sidebar";
+import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
+
+const datasetName = getUniqueDatasetNameWithPrefix("patch-label-overlays");
+
+const test = base.extend<{ grid: GridPom; sidebar: SidebarPom }>({
+  grid: async ({ page, eventUtils }, use) => {
+    await use(new GridPom(page, eventUtils));
+  },
+  sidebar: async ({ page }, use) => {
+    await use(new SidebarPom(page));
+  },
+});
+
+test.beforeAll(async ({ datasetFactory, foWebServer }) => {
+  await foWebServer.startWebServer();
+  await datasetFactory.createDataset({
+    datasetName,
+    numSamples: 3,
+    schema: {
+      predictions: "Detections",
+    },
+    withSampleData: (_, { createId }) => ({
+      predictions: {
+        detections: [
+          {
+            _id: createId(),
+            label: "cat",
+            confidence: 0.9,
+            bounding_box: [0.1, 0.1, 0.2, 0.2],
+          },
+          {
+            _id: createId(),
+            label: "dog",
+            confidence: 0.4,
+            bounding_box: [0.3, 0.3, 0.2, 0.2],
+          },
+        ],
+      },
+    }),
+    savedViews: { patches: "dataset.to_patches('predictions')" },
+  });
+});
+
+test.afterAll(async ({ foWebServer }) => {
+  await foWebServer.stopWebServer();
+});
+
+test.beforeEach(async ({ fiftyoneLoader, page }) => {
+  await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
+    searchParams: new URLSearchParams({ view: "patches" }),
+  });
+});
+
+test("patch tiles show the patch label as a tag bubble", async ({ grid }) => {
+  await grid.assert.isTileCountEqualTo(6);
+  await grid.assert.nthSampleHasTagValue(0, "predictions", "cat");
+  await grid.assert.nthSampleHasTagValue(1, "predictions", "dog");
+});
+
+test("attribute eyes control bubble text; the last shown attribute locks", async ({
+  grid,
+  page,
+  sidebar,
+}) => {
+  const labelEye = page.getByTestId(
+    "shown-attribute-predictions.detections.label",
+  );
+  const confidenceEye = page.getByTestId(
+    "shown-attribute-predictions.detections.confidence",
+  );
+
+  await sidebar.clickFieldDropdown("predictions");
+
+  // `label` is the only shown attribute by default, so its eye is locked
+  await expect(labelEye).toBeDisabled();
+
+  await confidenceEye.click();
+  await grid.assert.nthSampleHasTagValue(0, "predictions", "cat, 0.9");
+  await expect(labelEye).toBeEnabled();
+
+  await labelEye.click();
+  await grid.assert.nthSampleHasTagValue(0, "predictions", "0.9");
+  await expect(confidenceEye).toBeDisabled();
+});

--- a/e2e-pw/src/oss/specs/patch-label-overlays.spec.ts
+++ b/e2e-pw/src/oss/specs/patch-label-overlays.spec.ts
@@ -73,10 +73,10 @@ test("attribute eyes control bubble text; the last shown attribute locks", async
   grid,
   sidebar,
 }) => {
-  const labelEye = sidebar.shownAttributeToggle("predictions.detections.label");
-  const confidenceEye = sidebar.shownAttributeToggle(
-    "predictions.detections.confidence",
-  );
+  // patch samples flatten `Detections` to a single `Detection`, so attribute
+  // paths are `predictions.<attr>`
+  const labelEye = sidebar.shownAttributeToggle("predictions.label");
+  const confidenceEye = sidebar.shownAttributeToggle("predictions.confidence");
 
   await sidebar.clickFieldDropdown("predictions");
 

--- a/e2e-pw/src/oss/specs/patch-label-overlays.spec.ts
+++ b/e2e-pw/src/oss/specs/patch-label-overlays.spec.ts
@@ -71,14 +71,11 @@ test("patch tiles show the patch label as a tag bubble", async ({ grid }) => {
 
 test("attribute eyes control bubble text; the last shown attribute locks", async ({
   grid,
-  page,
   sidebar,
 }) => {
-  const labelEye = page.getByTestId(
-    "shown-attribute-predictions.detections.label",
-  );
-  const confidenceEye = page.getByTestId(
-    "shown-attribute-predictions.detections.confidence",
+  const labelEye = sidebar.shownAttributeToggle("predictions.detections.label");
+  const confidenceEye = sidebar.shownAttributeToggle(
+    "predictions.detections.confidence",
   );
 
   await sidebar.clickFieldDropdown("predictions");


### PR DESCRIPTION
## What changes

Follow-up e2e coverage for the patch label overlays and toggleable label attributes shipped in #8114 (FOEPD-4259 / FOEPD-4260), which merged without e2e specs.

`patch-label-overlays.spec.ts` builds a 3-sample detections dataset (`cat` 0.9 / `dog` 0.4) with a saved `to_patches('predictions')` view and locks down:

- **Patch label bubbles**: in the patches view, tiles render `tag-predictions` bubbles with exactly the patch's label text
- **Attribute eye toggles**: the `label` eye starts locked as the sole shown attribute; showing `confidence` renders the comma-separated `cat, 0.9` bubble and unlocks `label`; hiding `label` leaves `0.9` and locks the `confidence` eye

All waits are auto-retrying DOM assertions — no timeouts. As a new spec it goes through CI burn-in.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for patch label overlays.
  * Verified patch tiles display label and confidence bubbles.
  * Verified sidebar attribute toggles update bubble text and prevent hiding the last visible attribute.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3690
<!-- enterprise-sync-pr:end -->