### PR TITLE
Label-op classification: generated views, frame-number resolution, attribute indices

### DIFF
--- a/app/packages/utilities/src/sample/labelOps.test.ts
+++ b/app/packages/utilities/src/sample/labelOps.test.ts
@@ -552,6 +552,132 @@ describe("video temporal labels identify by instance (FOEPD-4344 follow-up)", ()
   });
 });
 
+describe("generated-view fast path (label-rooted deltas)", () => {
+  // Patches views emit deltas rooted at the LABEL — no field prefix — and
+  // route persistence via {labelId, labelPath}. The patch sample carries
+  // the label under its field, so the id is present in the pre state even
+  // though no op path can locate its container.
+  const patchSample = {
+    _id: "patch1",
+    _sample_id: "smp1",
+    ground_truth: {
+      _id: "p1",
+      _cls: "Detection",
+      label: "car",
+      bounding_box: [0.1, 0.2, 0.3, 0.4],
+    },
+  };
+
+  it("classifies an edit of a pre-existing label as a modify, not an add", () => {
+    const ops = classifyLabelOps({
+      deltas: [
+        { op: "replace", path: "/label", value: "truck" },
+        { op: "replace", path: "/bounding_box/3", value: 0.5 },
+      ] as JSONDeltas,
+      preSample: patchSample,
+      labelId: "p1",
+      labelPath: "ground_truth.detections",
+      opType: "mutate",
+    });
+    expect(ops.modified).toEqual(["p1"]);
+    expect(ops.added).toEqual([]);
+  });
+
+  it("attributes the label to the labelPath field, not the op path head", () => {
+    const ops = classifyLabelOps({
+      deltas: [{ op: "replace", path: "/label", value: "truck" }] as JSONDeltas,
+      preSample: patchSample,
+      labelId: "p1",
+      labelPath: "ground_truth.detections",
+      opType: "mutate",
+    });
+    expect(ops.fieldOf.p1).toBe("ground_truth");
+  });
+});
+
+describe("frame paths resolve by frame_number (modal frames array)", () => {
+  // The modal sample carries frames as a positional array — often only the
+  // head frame — while deltas address frames by frame NUMBER.
+  it("resolves a frame remove when the frame is not at its positional index", () => {
+    const pre = {
+      _id: "smp",
+      frames: [{ frame_number: 3, dets: { detections: [{ _id: "f9" }] } }],
+    };
+    const ops = classifyLabelOps({
+      deltas: [{ op: "remove", path: "/frames/3/dets/detections/0" }],
+      preSample: pre,
+    });
+    expect(ops.deleted).toEqual(["f9"]);
+  });
+
+  it("attributes edits to the numbered frame, not the array position", () => {
+    const pre = {
+      _id: "smp",
+      frames: [
+        { frame_number: 1, dets: { detections: [{ _id: "a1" }] } },
+        { frame_number: 2, dets: { detections: [{ _id: "b1" }] } },
+      ],
+    };
+    const ops = classifyLabelOps({
+      deltas: [
+        {
+          op: "replace",
+          path: "/frames/2/dets/detections/0/label",
+          value: "bus",
+        },
+      ] as JSONDeltas,
+      preSample: pre,
+    });
+    // positional frames[2] is out of range; frame_number 2 is index 1
+    expect(ops.modified).toEqual(["b1"]);
+    expect(ops.added).toEqual([]);
+  });
+});
+
+describe("numeric attribute indices on single-label fields", () => {
+  it("classifies a bbox drag on a plain Detection field as one modify", () => {
+    const pre = {
+      _id: "smp",
+      gt_det: {
+        _id: "d1",
+        _cls: "Detection",
+        label: "car",
+        bounding_box: [0.1, 0.2, 0.3, 0.4],
+      },
+    };
+    const ops = classifyLabelOps({
+      deltas: [
+        { op: "replace", path: "/gt_det/bounding_box/3", value: 0.5 },
+        { op: "replace", path: "/gt_det/bounding_box/2", value: 0.6 },
+      ] as JSONDeltas,
+      preSample: pre,
+    });
+    expect(ops.modified).toEqual(["d1"]);
+    expect(ops.added).toEqual([]);
+    expect(ops.fieldOf.d1).toBe("gt_det");
+  });
+
+  it("classifies attribute-array edits on a frame single-label field", () => {
+    const pre = {
+      _id: "smp",
+      frames: [
+        {
+          frame_number: 1,
+          gt_det: { _id: "fd1", bounding_box: [0.1, 0.2, 0.3, 0.4] },
+        },
+      ],
+    };
+    const ops = classifyLabelOps({
+      deltas: [
+        { op: "replace", path: "/frames/1/gt_det/bounding_box/0", value: 0.9 },
+      ] as JSONDeltas,
+      preSample: pre,
+    });
+    expect(ops.modified).toEqual(["fd1"]);
+    expect(ops.fieldOf.fd1).toBe("gt_det");
+  });
+});
+
 describe("isEmptyLabelOps", () => {
   it("is true when no operations were classified", () => {
     expect(

--- a/app/packages/utilities/src/sample/labelOps.ts
+++ b/app/packages/utilities/src/sample/labelOps.ts
@@ -84,6 +84,33 @@ const elementSegments = (segments: string[]): string[] => {
   return segments.slice(0, 1);
 };
 
+/**
+ * Resolve a path against a sample document. Frame deltas address frames by
+ * frame NUMBER (`/frames/<n>/…`), but the modal sample carries `frames` as a
+ * positional array — often holding only the head frame — so a plain pointer
+ * walk reads the wrong frame (or none). Dereference the frame by its
+ * `frame_number` when frames is an array; positional and map-keyed shapes
+ * fall through to the plain walk.
+ */
+const getAtSamplePath = (root: unknown, segments: string[]): unknown => {
+  if (segments.length >= 2 && segments[0] === "frames" && root) {
+    const frames = (root as Record<string, unknown>).frames;
+    if (Array.isArray(frames)) {
+      const frameNumber = Number.parseInt(segments[1], 10);
+      const frame = frames.find(
+        (candidate) =>
+          candidate &&
+          typeof candidate === "object" &&
+          (candidate as Record<string, unknown>).frame_number === frameNumber,
+      );
+      if (frame !== undefined) {
+        return getAtPath(frame, segments.slice(2));
+      }
+    }
+  }
+  return getAtPath(root, segments);
+};
+
 const labelIdOf = (candidate: unknown): string | null => {
   if (candidate && typeof candidate === "object") {
     const record = candidate as Record<string, unknown>;
@@ -152,6 +179,26 @@ const collectLabelIds = (node: unknown, depth = 2): string[] => {
   return out;
 };
 
+/**
+ * Bounded search for a label id anywhere in a sample document. Generated
+ * (patches) views emit deltas rooted at the LABEL — no field prefix — so the
+ * fast path cannot locate the label's container from an op path; presence of
+ * the id anywhere in the pre-patch document is what distinguishes an edit
+ * from a creation there.
+ */
+const containsLabelId = (
+  node: unknown,
+  labelId: string,
+  depth = 8,
+): boolean => {
+  if (depth < 0 || !node || typeof node !== "object") return false;
+  if (labelIdOf(node) === labelId) return true;
+  const children = Array.isArray(node)
+    ? node
+    : Object.values(node as Record<string, unknown>);
+  return children.some((child) => containsLabelId(child, labelId, depth - 1));
+};
+
 export interface ClassifyLabelOpsArgs {
   deltas: JSONDeltas;
   /** The sample BEFORE the patch (source for deleted/modified ids). */
@@ -160,6 +207,12 @@ export interface ClassifyLabelOpsArgs {
   postSample?: unknown;
   /** Field-level fast path: the single label the patch targets. */
   labelId?: string;
+  /**
+   * Field-level fast path: dotted path to the label's field (e.g.
+   * `ground_truth.detections`). Authoritative for field attribution when
+   * the deltas are label-rooted (generated views).
+   */
+  labelPath?: string;
   /** Field-level fast path: only "delete" changes classification. */
   opType?: "mutate" | "delete" | "add";
 }
@@ -172,6 +225,7 @@ export const classifyLabelOps = ({
   preSample,
   postSample,
   labelId,
+  labelPath,
   opType,
 }: ClassifyLabelOpsArgs): LabelOpsSummary => {
   const added = new Set<string>();
@@ -201,7 +255,12 @@ export const classifyLabelOps = ({
     } else {
       modified.add(labelId);
     }
-    const field = deltas.length ? segmentsOf(deltas[0].path)[0] : undefined;
+    // labelPath is authoritative: generated views root their deltas at the
+    // LABEL, so the op path's head segment is a label attribute ("label",
+    // "bounding_box"), not a sample field.
+    const field = labelPath
+      ? fieldOfLabelPath(labelPath)
+      : fieldOfDeltaPath(deltas);
     if (field) fieldOf[labelId] = field;
     return toSummary(added, deleted, modified, fieldOf, instanceOf);
   }
@@ -216,7 +275,7 @@ export const classifyLabelOps = ({
     const key = prefix.join("/");
     const cached = arrayIds.get(key);
     if (cached) return cached;
-    const node = getAtPath(preSample, prefix);
+    const node = getAtSamplePath(preSample, prefix);
     if (!Array.isArray(node)) return null;
     const ids = node.map((entry) => labelIdOf(entry));
     arrayIds.set(key, ids);
@@ -226,9 +285,30 @@ export const classifyLabelOps = ({
   for (const delta of deltas) {
     const segments = segmentsOf(delta.path);
     if (segments.length === 0) continue;
-    const element = elementSegments(segments);
+    let element = elementSegments(segments);
+    let last = element[element.length - 1];
+    // A numeric segment is only a list-label boundary when the container it
+    // indexes is a list of LABELS. On a single-label field a numeric index
+    // addresses an attribute array (`/gt_det/bounding_box/3` — a bbox drag),
+    // and the element is the owning field itself; treating the coordinate as
+    // a list entry silently drops the edit.
+    if (element.length > 1 && NUMERIC.test(last)) {
+      const container =
+        getAtSamplePath(preSample, element.slice(0, -1)) ??
+        getAtSamplePath(postSample, element.slice(0, -1));
+      if (
+        Array.isArray(container) &&
+        container.length > 0 &&
+        !container.some((entry) => labelIdOf(entry))
+      ) {
+        element =
+          element[0] === "frames"
+            ? element.slice(0, Math.min(3, element.length))
+            : element.slice(0, 1);
+        last = element[element.length - 1];
+      }
+    }
     const exactlyElement = element.length === segments.length;
-    const last = element[element.length - 1];
     // A bare /frames/<n> is the frame CONTAINER, not a label list element:
     // resolving it as one would fabricate the frame document's id. Let the
     // whole-field branches collect the labels it contains instead.
@@ -261,7 +341,7 @@ export const classifyLabelOps = ({
         if (resolved) opIds = [resolved];
       }
       if (opIds.length === 1) {
-        noteInstance(opIds[0], value ?? getAtPath(postSample, element));
+        noteInstance(opIds[0], value ?? getAtSamplePath(postSample, element));
       }
       for (const id of opIds) {
         added.add(id);
@@ -275,9 +355,9 @@ export const classifyLabelOps = ({
         ? [shifted]
         : isListElement
           ? []
-          : collectLabelIds(getAtPath(preSample, element));
+          : collectLabelIds(getAtSamplePath(preSample, element));
       if (opIds.length === 1) {
-        noteInstance(opIds[0], getAtPath(preSample, element));
+        noteInstance(opIds[0], getAtSamplePath(preSample, element));
       }
       for (const id of opIds) {
         deleted.add(id);
@@ -291,12 +371,12 @@ export const classifyLabelOps = ({
       // (a classification "set" on a pre-existing null field lands here).
       // The op value may be a skeleton without ids — the post-patch
       // sample is the fallback source for what now lives in the field.
-      const preNode = getAtPath(preSample, element);
+      const preNode = getAtSamplePath(preSample, element);
       const preIds = new Set(collectLabelIds(preNode));
       let postNode: unknown = (delta as { value?: unknown }).value;
       let postIds = collectLabelIds(postNode);
       if (!postIds.length) {
-        postNode = getAtPath(postSample, element);
+        postNode = getAtSamplePath(postSample, element);
         postIds = collectLabelIds(postNode);
       }
       for (const id of postIds) {
@@ -324,7 +404,8 @@ export const classifyLabelOps = ({
       if (id) {
         noteInstance(
           id,
-          getAtPath(preSample, element) ?? getAtPath(postSample, element),
+          getAtSamplePath(preSample, element) ??
+            getAtSamplePath(postSample, element),
         );
         if (preId) {
           modified.add(id);
@@ -342,6 +423,21 @@ export const classifyLabelOps = ({
 const isElementTail = (segments: string[]): boolean =>
   segments.length > 0 && isElementSegment(segments[segments.length - 1]);
 
+/** The sample field of a dotted label path ("frames.dets.detections" → "dets"). */
+const fieldOfLabelPath = (labelPath: string): string | undefined => {
+  const segments = labelPath.split(".");
+  return segments[0] === "frames" ? segments[1] : segments[0];
+};
+
+/** The frame-aware sample field of the patch's first delta path. */
+const fieldOfDeltaPath = (deltas: JSONDeltas): string | undefined => {
+  if (!deltas.length) return undefined;
+  const element = elementSegments(segmentsOf(deltas[0].path));
+  return element[0] === "frames" && element.length >= 3
+    ? element[2]
+    : element[0];
+};
+
 /** Whether the fast path's label already exists in the pre-patch sample. */
 const fastPathPreExisting = (
   deltas: JSONDeltas,
@@ -354,12 +450,18 @@ const fastPathPreExisting = (
     element.length > 1 && isElementSegment(element[element.length - 1])
       ? element.slice(0, -1)
       : element;
-  return collectLabelIds(getAtPath(preSample, container)).includes(labelId);
+  return (
+    collectLabelIds(getAtSamplePath(preSample, container)).includes(labelId) ||
+    // Label-rooted deltas (generated views) name no container the sample
+    // can resolve — the label pre-exists if its id appears anywhere in the
+    // pre-patch document.
+    containsLabelId(preSample, labelId)
+  );
 };
 
 const resolveId = (sample: unknown, element: string[]): string | null => {
   if (!sample) return null;
-  const node = getAtPath(sample, element);
+  const node = getAtSamplePath(sample, element);
   const direct = labelIdOf(node);
   if (direct) return direct;
   // Single-label fields sometimes nest the label one level down


### PR DESCRIPTION
Stacked on #8206. Fixes the three highest-impact classification gaps surfaced in review, each with red-green test coverage (the six new tests fail against the previous classifier; 35/35 pass with the fixes).

**Generated (patches) views classified every save as ADDED.** Patches views emit deltas rooted at the label — `replace /label`, `replace /bounding_box/3` — so `fastPathPreExisting` resolved a container from a path that names a label attribute, found nothing in the pre-patch document, and marked the label added on every autosave tick. Pre-existence now falls back to a bounded search for the label id anywhere in the pre-patch document, and field attribution uses a new optional `labelPath` argument (the `{labelId, labelPath}` metadata generated-view persistence already carries) instead of fabricating a field from the op path head.

**Frame paths resolved positionally against the modal frames array.** Deltas address frames by frame number (`/frames/2/…`) but the modal sample carries `frames` as a positional array, typically holding only the head frame — so frame-label edits and deletes resolved to the wrong frame or were silently dropped. All sample lookups now go through `getAtSamplePath`, which dereferences `/frames/<n>` by the frame document's `frame_number` when `frames` is an array, falling back to the plain pointer walk for positional and map-keyed shapes.

**Numeric attribute indices on single-label fields dropped the edit.** A bbox drag on a plain `Detection` field emits `replace /gt_det/bounding_box/3`; the first numeric segment was misread as a list-element boundary, and resolving coordinates as labels yielded nothing. A numeric boundary now only counts as a list element when the container it indexes actually holds labels; otherwise the element collapses to the owning field and the ops classify as one modify of that label.

No API breaks: `labelPath` is optional and existing call sites are unchanged.