### PR TITLE
Add Muse Glimmer 30B to the model zoo

### DIFF
--- a/fiftyone/utils/muse_glimmer.py
+++ b/fiftyone/utils/muse_glimmer.py
@@ -1,0 +1,401 @@
+"""
+`Muse Glimmer <https://huggingface.co/meta-models/Muse-Glimmer-30B>`_
+wrapper for the FiftyOne Model Zoo.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import json
+import logging
+import re
+
+import numpy as np
+
+import fiftyone.core.labels as fol
+import fiftyone.core.utils as fou
+import fiftyone.utils.torch as fout
+import fiftyone.zoo.models as fozm
+
+fou.ensure_torch()
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+def _ensure_muse_glimmer():
+    fou.ensure_package("transformers>=5.15.0")
+    fou.ensure_package("accelerate")
+    # 4-bit NF4 loading; the model is 59.6 GB at bf16
+    fou.ensure_package("bitsandbytes")
+
+
+transformers = fou.lazy_import("transformers", callback=_ensure_muse_glimmer)
+
+from PIL import Image as PILImage
+
+DEFAULT_MUSE_GLIMMER_MODEL = "meta-models/Muse-Glimmer-30B"
+_BBOX_FORMAT_INSTRUCTION = (
+    "Report bbox coordinates in JSON format as a list of "
+    '{"label": "<class>", "bbox_2d": [x1, y1, x2, y2]} objects, '
+    "where coordinates are normalized to 0-1000 with x first."
+)
+DEFAULT_DETECTION_PROMPT = (
+    "Detect all objects in this image. " + _BBOX_FORMAT_INSTRUCTION
+)
+
+# Muse Glimmer emits reasoning on a `to=self` channel closed by `<|eom|>`
+# before answering on a `to=user` channel closed by `<|eot|>`. Only the
+# `to=user` channel is a committed answer; the reasoning channel rehearses
+# candidate outputs that must never be parsed as labels.
+_CHANNEL_START = "<|start|>"
+_CHANNEL_MESSAGE = "<|message|>"
+_CHANNEL_ENDS = ("<|eot|>", "<|eom|>", "<|end|>")
+_ANSWER_HEADER = re.compile(r"\s*assistant\s+to=user\s*$")
+_REASONING_HEADER = re.compile(r"\bto=self\b")
+
+
+class MuseGlimmerOutputProcessor(fout.OutputProcessor):
+    """Output processor for Muse Glimmer detection models.
+
+    Extracts the model's answer channel from its channelized output,
+    then parses JSON bounding boxes into
+    :class:`fiftyone.core.labels.Detections` instances.
+    """
+
+    def __call__(self, output, frame_size, confidence_thresh=None, **kwargs):
+        """Processes model output into detections.
+
+        Args:
+            output: a list of raw generated strings, decoded with special
+                tokens retained so channel boundaries are visible
+            frame_size: a ``(width, height)`` tuple
+            confidence_thresh: optional confidence threshold (unused for VLM)
+            **kwargs: additional keyword arguments
+
+        Returns:
+            a list of :class:`fiftyone.core.labels.Detections` instances
+        """
+        results = []
+        for raw_output in output:
+            answer = self._extract_answer(raw_output)
+            detections = self._parse_detections(answer, frame_size)
+            results.append(fol.Detections(detections=detections))
+        return results
+
+    def _extract_answer(self, raw_output):
+        """Return the ``to=user`` answer channel, or ``""`` when the model
+        never reached one.
+
+        The generation prompt opens the assistant turn, so the first
+        generated channel may arrive without its leading ``<|start|>``;
+        the text is normalized before splitting. A generation that
+        truncates inside the reasoning channel yields no answer channel,
+        and must yield no labels: the reasoning rehearses candidate
+        boxes that were never committed.
+        """
+        text = raw_output or ""
+
+        if _CHANNEL_MESSAGE not in text:
+            # No channel structure at all: only safe to treat as an answer
+            # when there is also no evidence of a reasoning channel
+            if _REASONING_HEADER.search(text) is None:
+                return self._strip_end_markers(text)
+            return ""
+
+        if not text.lstrip().startswith(_CHANNEL_START):
+            # Re-attach the header the generation prompt opened
+            text = _CHANNEL_START + "assistant" + text
+
+        answer = ""
+        for segment in text.split(_CHANNEL_START):
+            if _CHANNEL_MESSAGE not in segment:
+                continue
+            header, _, body = segment.partition(_CHANNEL_MESSAGE)
+            if _ANSWER_HEADER.search(header) is None:
+                continue
+            answer = self._strip_end_markers(body)
+
+        return answer
+
+    @staticmethod
+    def _strip_end_markers(text):
+        for marker in _CHANNEL_ENDS:
+            text = text.split(marker)[0]
+        return text.strip()
+
+    def _parse_detections(self, raw_output, frame_size):
+        """Parse an answer-channel payload into Detection objects."""
+        detections = []
+
+        json_str = raw_output.strip()
+
+        if not json_str or json_str.lower() in (
+            "there are none.",
+            "none",
+            "no objects detected",
+            "[]",
+        ):
+            return detections
+
+        try:
+            # Model wraps JSON output in markdown code blocks
+            if json_str.startswith("```json"):
+                json_str = json_str[7:]
+            if json_str.startswith("```"):
+                json_str = json_str[3:]
+            if json_str.endswith("```"):
+                json_str = json_str[:-3]
+            json_str = json_str.strip()
+
+            if not (json_str.startswith("[") or json_str.startswith("{")):
+                return detections
+
+            parsed = json.loads(json_str)
+            if not isinstance(parsed, list):
+                parsed = [parsed]
+
+        except (json.JSONDecodeError, ValueError) as e:
+            logger.debug("Could not parse model output: %s", e)
+            return detections
+
+        for obj in parsed:
+            if not isinstance(obj, dict):
+                continue
+
+            label = obj.get("label", "object")
+            bbox = obj.get("bbox_2d")
+
+            if not isinstance(bbox, (list, tuple)) or len(bbox) != 4:
+                continue
+
+            try:
+                x1, y1, x2, y2 = (float(v) for v in bbox)
+            except (TypeError, ValueError, OverflowError):
+                continue
+
+            # JSON permits NaN and Infinity literals; NaN also passes the
+            # positive-area check below
+            if not all(np.isfinite(v) for v in (x1, y1, x2, y2)):
+                continue
+            # Muse Glimmer reports bbox_2d on a 0-1000 normalized scale
+            # with x first; convert to 0-1
+            x1 = float(np.clip(x1 / 1000.0, 0.0, 1.0))
+            y1 = float(np.clip(y1 / 1000.0, 0.0, 1.0))
+            x2 = float(np.clip(x2 / 1000.0, 0.0, 1.0))
+            y2 = float(np.clip(y2 / 1000.0, 0.0, 1.0))
+
+            w = x2 - x1
+            h = y2 - y1
+
+            if w <= 0 or h <= 0:
+                continue
+
+            detections.append(
+                fol.Detection(
+                    label=str(label),
+                    bounding_box=[x1, y1, w, h],
+                )
+            )
+
+        return detections
+
+
+class MuseGlimmerModelConfig(fout.TorchImageModelConfig, fozm.HasZooModel):
+    """Configuration for running a :class:`MuseGlimmerModel`.
+
+    Args:
+        name_or_path ("meta-models/Muse-Glimmer-30B"): the HuggingFace
+            model path
+        prompt (None): the detection prompt; if None, uses default
+        classes (None): list of classes to detect; if provided, added to
+            prompt
+        max_new_tokens (4096): maximum tokens to generate. The model
+            reasons before answering and the reasoning cannot be disabled,
+            so the budget covers both channels
+        load_in_4bit (True): whether to load the language model with
+            4-bit NF4 quantization on GPU; the vision encoder stays
+            bf16. The full bf16 weights are 59.6 GB; 4-bit loading fits
+            24 GB cards. Set to False to load bf16 on hardware that can
+            hold it
+    """
+
+    def __init__(self, d):
+        d = self.init(d)
+        super().__init__(d)
+
+        self.name_or_path = self.parse_string(
+            d, "name_or_path", default=DEFAULT_MUSE_GLIMMER_MODEL
+        )
+        self.prompt = self.parse_string(d, "prompt", default=None)
+        self.classes = self.parse_array(d, "classes", default=None)
+        self.max_new_tokens = self.parse_int(d, "max_new_tokens", default=4096)
+        self.load_in_4bit = self.parse_bool(d, "load_in_4bit", default=True)
+
+        self.raw_inputs = True
+
+
+class MuseGlimmerModel(fout.TorchImageModel):
+    """Wrapper for running inference with Muse Glimmer models.
+
+    Muse Glimmer is an agentic vision-language model that detects objects
+    by emitting bounding box coordinates via 2D grounding.
+
+    Detection example::
+
+        import fiftyone as fo
+        import fiftyone.zoo as foz
+
+        dataset = foz.load_zoo_dataset(
+            "quickstart", max_samples=5, shuffle=True, seed=51
+        )
+
+        model = foz.load_zoo_model("muse-glimmer-30b-torch")
+
+        dataset.apply_model(model, label_field="glimmer_detections")
+
+        session = fo.launch_app(dataset)
+
+    Detect specific classes::
+
+        model = foz.load_zoo_model(
+            "muse-glimmer-30b-torch",
+            classes=["person", "car", "dog"],
+        )
+
+    Args:
+        config: a :class:`MuseGlimmerModelConfig`
+    """
+
+    def __init__(self, config):
+        self._processor = None
+        super().__init__(config)
+
+    def _download_model(self, config):
+        pass
+
+    def _load_model(self, config):
+        model_cls = transformers.AutoModelForMultimodalLM
+
+        kwargs = {"torch_dtype": torch.bfloat16}
+
+        if self._using_gpu and config.load_in_4bit:
+            # bitsandbytes dispatches through accelerate, so quantized
+            # loads always use a device map. The vision tower stays bf16:
+            # its forward casts pixels to its own weight dtype, which 4-bit
+            # packing stores as uint8. The skip entry must be the fully
+            # qualified module path from the model root
+            kwargs["quantization_config"] = transformers.BitsAndBytesConfig(
+                load_in_4bit=True,
+                bnb_4bit_quant_type="nf4",
+                bnb_4bit_compute_dtype=torch.bfloat16,
+                bnb_4bit_use_double_quant=True,
+                llm_int8_skip_modules=["model.vision_tower"],
+            )
+            kwargs["device_map"] = (
+                "auto" if config.device is None else {"": config.device}
+            )
+        elif self._using_gpu:
+            kwargs["device_map"] = "auto" if config.device is None else None
+
+        model = model_cls.from_pretrained(config.name_or_path, **kwargs)
+
+        if kwargs.get("device_map") is None and self._using_gpu:
+            model = model.to(self._device)
+        model.eval()
+
+        self._processor = transformers.AutoProcessor.from_pretrained(
+            config.name_or_path
+        )
+
+        return model
+
+    def _get_prompt(self):
+        if self.config.prompt is not None:
+            return self.config.prompt
+
+        if self.config.classes is not None:
+            classes_str = ", ".join(self.config.classes)
+            return (
+                f"Detect all instances of: {classes_str}. "
+                + _BBOX_FORMAT_INSTRUCTION
+            )
+
+        return DEFAULT_DETECTION_PROMPT
+
+    def _forward_pass(self, imgs):
+        prompt = self._get_prompt()
+        results = []
+
+        for img in imgs:
+            img = self._prepare_image(img)
+
+            messages = [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image", "image": img},
+                        {"type": "text", "text": prompt},
+                    ],
+                }
+            ]
+
+            inputs = self._processor.apply_chat_template(
+                messages,
+                tokenize=True,
+                add_generation_prompt=True,
+                return_dict=True,
+                return_tensors="pt",
+            )
+            inputs = inputs.to(self._model.device)
+
+            generated_ids = self._model.generate(
+                **inputs,
+                max_new_tokens=self.config.max_new_tokens,
+                do_sample=False,
+            )
+
+            generated_ids_trimmed = [
+                out_ids[len(in_ids) :]
+                for in_ids, out_ids in zip(inputs["input_ids"], generated_ids)
+            ]
+
+            # Special tokens are retained so the output processor can see
+            # the channel boundaries separating reasoning from the answer
+            text = self._processor.batch_decode(
+                generated_ids_trimmed,
+                skip_special_tokens=False,
+                clean_up_tokenization_spaces=False,
+            )[0]
+
+            results.append(text)
+
+        return results
+
+    def _prepare_image(self, img):
+        """Convert image to PIL format for processor."""
+        if isinstance(img, torch.Tensor):
+            img = img.cpu().numpy()
+            # Transpose CHW to HWC if first dim is channels and last dim is not
+            if (
+                img.ndim == 3
+                and img.shape[0] in (1, 3, 4)
+                and img.shape[2] not in (1, 3, 4)
+            ):
+                img = np.transpose(img, (1, 2, 0))
+
+        if isinstance(img, np.ndarray) and np.issubdtype(
+            img.dtype, np.floating
+        ):
+            if img.max() <= 1.0:
+                img = img * 255.0
+            img = np.clip(img, 0, 255).astype(np.uint8)
+
+        if isinstance(img, np.ndarray):
+            # Pillow maps grayscale to 2D arrays; collapse a singleton channel
+            if img.ndim == 3 and img.shape[2] == 1:
+                img = img[:, :, 0]
+            img = PILImage.fromarray(img)
+
+        return img

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -12442,6 +12442,41 @@
                 }
             ],
             "date_added": "2026-07-14 12:00:00"
+        },
+        {
+            "base_name": "muse-glimmer-30b-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "Agentic 30B vision-language model for object detection via 2D grounding",
+            "source": "https://huggingface.co/meta-models/Muse-Glimmer-30B",
+            "author": "Meta",
+            "license": "Apache 2.0",
+            "size_bytes": 59600000000,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.muse_glimmer.MuseGlimmerModel",
+                "config": {
+                    "name_or_path": "meta-models/Muse-Glimmer-30B",
+                    "output_processor_cls": "fiftyone.utils.muse_glimmer.MuseGlimmerOutputProcessor"
+                }
+            },
+            "requirements": {
+                "packages": [
+                    "torch",
+                    "torchvision",
+                    "transformers>=5.15.0",
+                    "accelerate",
+                    "bitsandbytes"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["detection", "vlm", "torch", "transformer", "zero-shot"],
+            "training_data": [],
+            "date_added": "2026-08-10 12:00:00"
         }
     ]
 }

--- a/tests/unittests/utils/test_muse_glimmer.py
+++ b/tests/unittests/utils/test_muse_glimmer.py
@@ -1,0 +1,317 @@
+"""
+Tests for fiftyone/utils/muse_glimmer.py output processor and parsing.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import pytest
+
+import fiftyone.core.labels as fol
+from fiftyone.utils.muse_glimmer import (
+    MuseGlimmerModelConfig,
+    MuseGlimmerOutputProcessor,
+)
+
+# The generation prompt opens the assistant turn, so generated text begins
+# mid-header on the reasoning channel. The reasoning rehearses a candidate
+# box that differs from the committed answer.
+FULL_TRANSCRIPT = (
+    " to=self<|message|>The user wants all objects. I can see a bear in "
+    'the lower region. A candidate is [{"label": "cat", "bbox_2d": '
+    "[0, 0, 500, 500]}] but looking closer it is a bear near the bottom."
+    "<|eom|><|start|>assistant to=user<|message|>"
+    '[{"label": "bear", "bbox_2d": [0, 100, 1000, 1000]}]<|eot|>'
+)
+
+TRUNCATED_TRANSCRIPT = (
+    " to=self<|message|>Let me identify the objects. I see a cat at "
+    '[{"label": "cat", "bbox_2d": [100, 100, 400, 400]}] and also'
+)
+
+
+class TestMuseGlimmerAnswerExtraction:
+    """Test extraction of the to=user answer channel"""
+
+    def test_answer_channel_wins_over_reasoning(self):
+        """Only the committed answer is parsed, not the rehearsed candidate"""
+        processor = MuseGlimmerOutputProcessor()
+        detections = processor._parse_detections(
+            processor._extract_answer(FULL_TRANSCRIPT), (1000, 1000)
+        )
+
+        assert len(detections) == 1
+        assert detections[0].label == "bear"
+        bbox = detections[0].bounding_box
+        assert bbox[0] == pytest.approx(0.0)
+        assert bbox[1] == pytest.approx(0.1)
+        assert bbox[2] == pytest.approx(1.0)
+        assert bbox[3] == pytest.approx(0.9)
+
+    def test_truncated_reasoning_yields_empty(self):
+        """A generation that never reached the answer channel commits
+        nothing, even though the reasoning contains parseable JSON"""
+        processor = MuseGlimmerOutputProcessor()
+        answer = processor._extract_answer(TRUNCATED_TRANSCRIPT)
+
+        assert answer == ""
+        detections = processor._parse_detections(answer, (1000, 1000))
+        assert len(detections) == 0
+
+    def test_answer_with_leading_start_marker(self):
+        """A transcript whose first channel carries its own header parses"""
+        processor = MuseGlimmerOutputProcessor()
+        raw = (
+            "<|start|>assistant to=self<|message|>Thinking.<|eom|>"
+            "<|start|>assistant to=user<|message|>"
+            '[{"label": "dog", "bbox_2d": [0, 0, 500, 500]}]<|eot|>'
+        )
+        answer = processor._extract_answer(raw)
+        detections = processor._parse_detections(answer, (1000, 1000))
+
+        assert len(detections) == 1
+        assert detections[0].label == "dog"
+
+    def test_plain_json_without_channels(self):
+        """Output with no channel structure is treated as the answer"""
+        processor = MuseGlimmerOutputProcessor()
+        raw = '[{"label": "cat", "bbox_2d": [100, 200, 400, 600]}]'
+        answer = processor._extract_answer(raw)
+        detections = processor._parse_detections(answer, (1000, 1000))
+
+        assert len(detections) == 1
+        assert detections[0].label == "cat"
+
+    def test_reasoning_mention_without_markers_yields_empty(self):
+        """Text referencing to=self without channel markers is not
+        mistaken for an answer"""
+        processor = MuseGlimmerOutputProcessor()
+        raw = " to=self reasoning that never opened a message channel"
+        answer = processor._extract_answer(raw)
+
+        assert answer == ""
+
+    def test_markdown_fenced_answer_channel(self):
+        """Markdown fences inside the answer channel are stripped"""
+        processor = MuseGlimmerOutputProcessor()
+        raw = (
+            " to=self<|message|>Reasoning.<|eom|>"
+            "<|start|>assistant to=user<|message|>```json\n"
+            '[{"label": "bird", "bbox_2d": [100, 100, 300, 300]}]\n'
+            "```<|eot|>"
+        )
+        answer = processor._extract_answer(raw)
+        detections = processor._parse_detections(answer, (1000, 1000))
+
+        assert len(detections) == 1
+        assert detections[0].label == "bird"
+
+    def test_last_answer_channel_wins(self):
+        """When multiple to=user channels appear, the last is committed"""
+        processor = MuseGlimmerOutputProcessor()
+        raw = (
+            " to=user<|message|>"
+            '[{"label": "cat", "bbox_2d": [0, 0, 100, 100]}]<|eot|>'
+            "<|start|>assistant to=user<|message|>"
+            '[{"label": "dog", "bbox_2d": [0, 0, 500, 500]}]<|eot|>'
+        )
+        answer = processor._extract_answer(raw)
+        detections = processor._parse_detections(answer, (1000, 1000))
+
+        assert len(detections) == 1
+        assert detections[0].label == "dog"
+
+    def test_empty_output(self):
+        processor = MuseGlimmerOutputProcessor()
+        assert processor._extract_answer("") == ""
+        assert processor._extract_answer(None) == ""
+
+    def test_unterminated_answer_channel(self):
+        """An answer channel that truncated before <|eot|> still parses
+        when its JSON is complete"""
+        processor = MuseGlimmerOutputProcessor()
+        raw = (
+            " to=self<|message|>Reasoning.<|eom|>"
+            "<|start|>assistant to=user<|message|>"
+            '[{"label": "cat", "bbox_2d": [0, 0, 500, 500]}]'
+        )
+        answer = processor._extract_answer(raw)
+        detections = processor._parse_detections(answer, (1000, 1000))
+
+        assert len(detections) == 1
+
+
+class TestMuseGlimmerDetectionParsing:
+    """Test bbox parsing of the answer payload"""
+
+    def test_parse_multiple_detections(self):
+        processor = MuseGlimmerOutputProcessor()
+        raw = """[
+            {"label": "cat", "bbox_2d": [0, 0, 500, 500]},
+            {"label": "dog", "bbox_2d": [500, 500, 1000, 1000]}
+        ]"""
+        detections = processor._parse_detections(raw, (1000, 1000))
+
+        assert len(detections) == 2
+        assert detections[0].label == "cat"
+        assert detections[1].label == "dog"
+
+    def test_parse_single_object_json(self):
+        processor = MuseGlimmerOutputProcessor()
+        raw = '{"label": "dog", "bbox_2d": [100, 200, 400, 600]}'
+        detections = processor._parse_detections(raw, (1000, 1000))
+
+        assert len(detections) == 1
+        assert detections[0].label == "dog"
+
+    def test_parse_empty_responses(self):
+        processor = MuseGlimmerOutputProcessor()
+
+        for raw in (
+            "",
+            "[]",
+            "none",
+            "None",
+            "there are none.",
+            "no objects detected",
+        ):
+            detections = processor._parse_detections(raw, (1000, 1000))
+            assert len(detections) == 0, f"Expected empty for: {raw}"
+
+    def test_parse_invalid_json(self):
+        processor = MuseGlimmerOutputProcessor()
+        detections = processor._parse_detections(
+            "this is not json at all", (1000, 1000)
+        )
+
+        assert len(detections) == 0
+
+    def test_parse_missing_bbox(self):
+        processor = MuseGlimmerOutputProcessor()
+        detections = processor._parse_detections(
+            '[{"label": "cat"}]', (1000, 1000)
+        )
+
+        assert len(detections) == 0
+
+    def test_parse_invalid_bbox_length(self):
+        processor = MuseGlimmerOutputProcessor()
+        detections = processor._parse_detections(
+            '[{"label": "cat", "bbox_2d": [100, 200, 300]}]', (1000, 1000)
+        )
+
+        assert len(detections) == 0
+
+    def test_parse_non_sequence_bbox(self):
+        processor = MuseGlimmerOutputProcessor()
+
+        for raw in (
+            '[{"label": "cat", "bbox_2d": 500}]',
+            '[{"label": "cat", "bbox_2d": "0, 0, 500, 500"}]',
+            '[{"label": "cat", "bbox_2d": {"x1": 0, "y1": 0}}]',
+        ):
+            detections = processor._parse_detections(raw, (1000, 1000))
+            assert len(detections) == 0, f"Expected empty for: {raw}"
+
+    def test_parse_non_numeric_bbox_elements(self):
+        processor = MuseGlimmerOutputProcessor()
+        raw = '[{"label": "cat", "bbox_2d": ["100", null, 300, 400]}]'
+        detections = processor._parse_detections(raw, (1000, 1000))
+
+        assert len(detections) == 0
+
+    def test_parse_non_finite_coordinates(self):
+        processor = MuseGlimmerOutputProcessor()
+
+        big_int = "9" * 400
+        for raw in (
+            '[{"label": "cat", "bbox_2d": [NaN, 0, 500, 500]}]',
+            '[{"label": "cat", "bbox_2d": [0, Infinity, 500, 500]}]',
+            '[{"label": "cat", "bbox_2d": [0, -Infinity, 500, 500]}]',
+            f'[{{"label": "cat", "bbox_2d": [{big_int}, 0, 500, 500]}}]',
+        ):
+            detections = processor._parse_detections(raw, (1000, 1000))
+            assert len(detections) == 0, f"Expected empty for: {raw[:60]}"
+
+    def test_clamp_out_of_range(self):
+        processor = MuseGlimmerOutputProcessor()
+        raw = '[{"label": "cat", "bbox_2d": [-100, -100, 1100, 1100]}]'
+        detections = processor._parse_detections(raw, (1000, 1000))
+
+        assert len(detections) == 1
+        assert detections[0].bounding_box == [0.0, 0.0, 1.0, 1.0]
+
+    def test_skip_zero_size_after_clamp(self):
+        processor = MuseGlimmerOutputProcessor()
+        raw = '[{"label": "cat", "bbox_2d": [1100, 1100, 1200, 1200]}]'
+        detections = processor._parse_detections(raw, (1000, 1000))
+
+        assert len(detections) == 0
+
+    def test_skip_inverted_bbox(self):
+        processor = MuseGlimmerOutputProcessor()
+        raw = '[{"label": "cat", "bbox_2d": [500, 500, 100, 100]}]'
+        detections = processor._parse_detections(raw, (1000, 1000))
+
+        assert len(detections) == 0
+
+    def test_standard_conversion(self):
+        processor = MuseGlimmerOutputProcessor()
+        raw = '[{"label": "cat", "bbox_2d": [100, 200, 300, 400]}]'
+        detections = processor._parse_detections(raw, (1000, 1000))
+
+        bbox = detections[0].bounding_box
+        assert bbox[0] == pytest.approx(0.1)
+        assert bbox[1] == pytest.approx(0.2)
+        assert bbox[2] == pytest.approx(0.2)
+        assert bbox[3] == pytest.approx(0.2)
+
+
+class TestMuseGlimmerOutputProcessorCall:
+    """Test the __call__ method end to end on channelized outputs"""
+
+    def test_process_batch(self):
+        processor = MuseGlimmerOutputProcessor()
+        outputs = [
+            FULL_TRANSCRIPT,
+            TRUNCATED_TRANSCRIPT,
+            " to=self<|message|>Empty scene.<|eom|>"
+            "<|start|>assistant to=user<|message|>[]<|eot|>",
+        ]
+
+        results = processor(outputs, (1000, 1000))
+
+        assert len(results) == 3
+        assert all(isinstance(r, fol.Detections) for r in results)
+        assert len(results[0].detections) == 1
+        assert results[0].detections[0].label == "bear"
+        assert len(results[1].detections) == 0
+        assert len(results[2].detections) == 0
+
+
+class TestMuseGlimmerModelConfig:
+    """Test MuseGlimmerModelConfig"""
+
+    def test_default_config(self):
+        config = MuseGlimmerModelConfig({})
+
+        assert config.name_or_path == "meta-models/Muse-Glimmer-30B"
+        assert config.prompt is None
+        assert config.classes is None
+        assert config.max_new_tokens == 4096
+        assert config.load_in_4bit is True
+        assert config.raw_inputs is True
+
+    def test_custom_config(self):
+        config = MuseGlimmerModelConfig(
+            {
+                "classes": ["person", "car"],
+                "max_new_tokens": 2048,
+                "load_in_4bit": False,
+            }
+        )
+
+        assert config.classes == ["person", "car"]
+        assert config.max_new_tokens == 2048
+        assert config.load_in_4bit is False


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

Adds `muse-glimmer-30b-torch` ([meta-models/Muse-Glimmer-30B](https://huggingface.co/meta-models/Muse-Glimmer-30B), Apache 2.0) to the torch model zoo for zero-shot object detection via 2D grounding, with a `fiftyone/utils/muse_glimmer.py` wrapper following the Qwen3-VL pattern.

- The model emits reasoning on a `to=self` channel before answering on a `to=user` channel. The output processor parses only the answer channel; a generation that truncates before it yields an empty result.
- Detections are `{"label", "bbox_2d"}` JSON on a 0-1000 scale, converted to relative `[x, y, w, h]`.
- The language model loads with 4-bit NF4 quantization by default, fitting 24 GB cards; the vision tower remains bf16 because its forward casts pixels to its own weight dtype. `load_in_4bit=False` loads full bf16 (59.6 GB).

## 🧪 How is this patch tested? If it is not, please explain why.

- `tests/unittests/utils/test_muse_glimmer.py`: 22 tests covering answer-channel extraction, truncation handling, bbox parsing and clamping, and config defaults. No GPU or model download required.
- Live on an RTX 6000 Ada: NF4 load in 51 s at 18.7 GB VRAM; a COCO validation image produced 30 detections with correct geometry under greedy decoding. The captured transcript confirms the channel structure and box format the parser targets.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] Yes. Give a description of this change to be included in the release notes for FiftyOne users.

Added `muse-glimmer-30b-torch` (Muse Glimmer 30B) to the model zoo for zero-shot object detection via 2D grounding.

### What areas of FiftyOne does this PR affect?

- [x] Core: Core `fiftyone` Python library changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Muse Glimmer model support to the FiftyOne Model Zoo.
  - Supports configurable prompts, class lists, image generation, channel-aware decoding, and optional 4-bit quantization.
  - Converts valid model responses into FiftyOne detections while filtering invalid or incomplete results.

- **Tests**
  - Added coverage for response parsing, bounding-box validation, batch processing, and custom model configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3699
<!-- enterprise-sync-pr:end -->