### PR TITLE
docs(enterprise): document default-credential overwrite and multi-account routing

### DIFF
--- a/docs/source/enterprise/installation.rst
+++ b/docs/source/enterprise/installation.rst
@@ -637,7 +637,7 @@ A managed credential can optionally be restricted to a specific list of bucket(s
     another default credential for the same provider at the same scope
     **replaces** the existing one.
 
-    To use multiple credentials for the same provider — for example, two
+    To use multiple credentials for the same provider and scope — for example, two
     Azure storage accounts, or two AWS accounts — each credential must be
     made bucket-specific by listing its buckets/containers. In particular,
     for Azure the storage account name embedded in the credential is **not**

--- a/docs/source/enterprise/installation.rst
+++ b/docs/source/enterprise/installation.rst
@@ -631,6 +631,18 @@ A managed credential can optionally be restricted to a specific list of bucket(s
     ``s3://my-bucket`` and
     ``https://voxel51.blob.core.windows.net/my-container``.
 
+.. note::
+
+    Only one **default credential** can exist per provider and scope. Adding
+    another default credential for the same provider at the same scope
+    **replaces** the existing one.
+
+    To use multiple credentials for the same provider — for example, two
+    Azure storage accounts, or two AWS accounts — each credential must be
+    made bucket-specific by listing its buckets/containers. In particular,
+    for Azure the storage account name embedded in the credential is **not**
+    used to route requests; provide fully-qualified containers instead, e.g.
+    ``https://account1.blob.core.windows.net/container1``.
 
 Managed credentials are considered unique based on the scope (user, group,
 or global), cloud provider, and the optional bucket(s) they are associated


### PR DESCRIPTION
## Summary

Adds a note to the **Managed cloud credentials** section of the Enterprise installation docs stating that (1) only one default (non-bucket-specific) credential can exist per provider and scope — adding another replaces it — and (2) credentials are not routed by Azure storage account name, so multiple storage accounts require bucket-specific credentials with fully-qualified container URLs.

## Motivation

Porsche (via in-tech) added two Azure credentials for two different storage accounts with the buckets field empty, assuming the account name embedded in each credential would route requests. Instead the second default credential replaced the first, and with group-scoped duplicates only one was used, seemingly at random ([customer thread](https://voxel51.slack.com/archives/C07BJRSHE9J/p1786375168627669), [eng-on-call thread](https://voxel51.slack.com/archives/C05BYM8P01M/p1786384391444949)).

Engineering confirmed this is expected behavior: credentials are unique per (scope, provider, buckets), and account-name routing is not implemented ("we don't auto-route creds based on account name even though you could do that with azure"). The docs implied the uniqueness rule but never stated the replace behavior or the Azure account-name trap. Scoping each credential to its containers resolved the customer issue immediately.

## Implementation plan

- Add a `.. note::` after the existing bucket-specific credentials note in `docs/source/enterprise/installation.rst`, covering the default-credential replace rule and the multi-account (Azure in particular) guidance

## Test plan

- Docs-only change; verified the RST renders correctly (note directive matches surrounding formatting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that only one default managed credential can exist per provider and scope.
  * Explained that adding another default credential replaces the existing one.
  * Documented bucket-specific credential requirements and fully qualified Azure container names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3702
<!-- enterprise-sync-pr:end -->