### PR TITLE
[FOEPD-4318] Embeddings 2D pan responds at full zoom-out

### DIFF
--- a/app/packages/embeddings-v2/src/renderer/cameras/PlanarCamera.ts
+++ b/app/packages/embeddings-v2/src/renderer/cameras/PlanarCamera.ts
@@ -165,7 +165,14 @@ export class PlanarCamera implements CameraAdapter {
       event.offsetX,
       event.offsetY,
     );
-    this.rect = zoomRect(this.rect, this.home, focus, factor, MAX_ZOOM);
+    this.rect = zoomRect(
+      this.rect,
+      this.home,
+      focus,
+      factor,
+      MAX_ZOOM,
+      PAN_GIVE,
+    );
     this.apply();
   }
 

--- a/app/packages/embeddings-v2/src/renderer/cameras/PlanarCamera.ts
+++ b/app/packages/embeddings-v2/src/renderer/cameras/PlanarCamera.ts
@@ -1,5 +1,5 @@
 import { OrthographicCamera } from "three";
-import { MARGIN, MAX_ZOOM } from "../constants";
+import { MARGIN, MAX_ZOOM, PAN_GIVE } from "../constants";
 import {
   clampToHome,
   fitRect,
@@ -193,6 +193,7 @@ export class PlanarCamera implements CameraAdapter {
       this.home,
       -(event.offsetX - lastX) * perPxX,
       (event.offsetY - lastY) * perPxY,
+      PAN_GIVE,
     );
     this.apply();
   }

--- a/app/packages/embeddings-v2/src/renderer/constants.ts
+++ b/app/packages/embeddings-v2/src/renderer/constants.ts
@@ -42,6 +42,12 @@ export const MARGIN = 24;
 /** Max planar zoom-in factor relative to the home view */
 export const MAX_ZOOM = 50;
 
+/** Pan clamp give, as a fraction of the viewport per side: how far the
+ * data may be pushed off-frame by panning. Nonzero so dragging still
+ * responds at full zoom-out (FOEPD-4318); 0.5 = the data's edge can
+ * reach the viewport's center, no further */
+export const PAN_GIVE = 0.5;
+
 /** Pointer must sit still this long before a hover hit-test runs */
 export const HOVER_DEBOUNCE_MS = 120;
 

--- a/app/packages/embeddings-v2/src/renderer/constants.ts
+++ b/app/packages/embeddings-v2/src/renderer/constants.ts
@@ -46,8 +46,10 @@ export const MAX_ZOOM = 50;
  * the data may sit off-frame. Nonzero so dragging still responds at
  * full zoom-out (FOEPD-4318); pan and zoom clamp against the same
  * inflated bounds, so zooming never yanks an offset view back —
- * only the header's reset recenters */
-export const PAN_GIVE = 1 / 3;
+ * only the header's reset recenters. Tuned by feel: high enough that
+ * a full-zoom-out drag visibly responds, low enough that a zoomed-in
+ * pan can't strand the view in empty space */
+export const PAN_GIVE = 0.2;
 
 /** Pointer must sit still this long before a hover hit-test runs */
 export const HOVER_DEBOUNCE_MS = 120;

--- a/app/packages/embeddings-v2/src/renderer/constants.ts
+++ b/app/packages/embeddings-v2/src/renderer/constants.ts
@@ -42,11 +42,12 @@ export const MARGIN = 24;
 /** Max planar zoom-in factor relative to the home view */
 export const MAX_ZOOM = 50;
 
-/** Pan clamp give, as a fraction of the viewport per side: how far the
- * data may be pushed off-frame by panning. Nonzero so dragging still
- * responds at full zoom-out (FOEPD-4318); 0.5 = the data's edge can
- * reach the viewport's center, no further */
-export const PAN_GIVE = 0.5;
+/** Camera clamp give, as a fraction of the viewport per side: how far
+ * the data may sit off-frame. Nonzero so dragging still responds at
+ * full zoom-out (FOEPD-4318); pan and zoom clamp against the same
+ * inflated bounds, so zooming never yanks an offset view back —
+ * only the header's reset recenters */
+export const PAN_GIVE = 1 / 3;
 
 /** Pointer must sit still this long before a hover hit-test runs */
 export const HOVER_DEBOUNCE_MS = 120;

--- a/app/packages/embeddings-v2/src/renderer/constants.ts
+++ b/app/packages/embeddings-v2/src/renderer/constants.ts
@@ -48,8 +48,9 @@ export const MAX_ZOOM = 50;
  * inflated bounds, so zooming never yanks an offset view back —
  * only the header's reset recenters. Tuned by feel: high enough that
  * a full-zoom-out drag visibly responds, low enough that a zoomed-in
- * pan can't strand the view in empty space */
-export const PAN_GIVE = 0.2;
+ * pan can't strand the view in empty space and a give-preserving
+ * zoom-out still shows nearly the whole graph */
+export const PAN_GIVE = 0.1;
 
 /** Pointer must sit still this long before a hover hit-test runs */
 export const HOVER_DEBOUNCE_MS = 120;

--- a/app/packages/embeddings-v2/src/renderer/math.test.ts
+++ b/app/packages/embeddings-v2/src/renderer/math.test.ts
@@ -135,6 +135,27 @@ describe("zoomRect / panRect / clampToHome", () => {
     });
   });
 
+  // Zooming from an overpanned view must not yank the view back to
+  // the data — the give bounds zoom exactly as they bound pan
+  it("zoom preserves an overpanned offset within the give", () => {
+    const offset: Rect = { x0: 3, y0: 0, x1: 13, y1: 10 };
+
+    // Zoom in around (8, 5): focus keeps its relative spot, no slide
+    expect(zoomRect(offset, home, [8, 5], 2, 50, 0.5)).toEqual({
+      x0: 5.5,
+      y0: 2.5,
+      x1: 10.5,
+      y1: 7.5,
+    });
+    // Without give, the strict clamp slides the same zoom back inside
+    expect(zoomRect(offset, home, [8, 5], 2, 50)).toEqual({
+      x0: 5,
+      y0: 2.5,
+      x1: 10,
+      y1: 7.5,
+    });
+  });
+
   // FOEPD-4318: with no give, panning at full zoom-out is a no-op —
   // the drag feels dead. Give lets the view slide, bounded so the
   // data's edge stops at the viewport's center (give 0.5)

--- a/app/packages/embeddings-v2/src/renderer/math.test.ts
+++ b/app/packages/embeddings-v2/src/renderer/math.test.ts
@@ -135,6 +135,27 @@ describe("zoomRect / panRect / clampToHome", () => {
     });
   });
 
+  // FOEPD-4318: with no give, panning at full zoom-out is a no-op —
+  // the drag feels dead. Give lets the view slide, bounded so the
+  // data's edge stops at the viewport's center (give 0.5)
+  it("pans at full zoom-out within the give", () => {
+    expect(panRect(home, home, 3, 0)).toEqual(home);
+
+    expect(panRect(home, home, 3, 0, 0.5)).toEqual({
+      x0: 3,
+      y0: 0,
+      x1: 13,
+      y1: 10,
+    });
+    // The give is the cap: a huge delta stops half a viewport out
+    expect(panRect(home, home, 100, 0, 0.5)).toEqual({
+      x0: 5,
+      y0: 0,
+      x1: 15,
+      y1: 10,
+    });
+  });
+
   it("slides an out-of-bounds rect back inside home", () => {
     expect(clampToHome({ x0: -1, y0: 3, x1: 1, y1: 5 }, home)).toEqual({
       x0: 0,

--- a/app/packages/embeddings-v2/src/renderer/math.ts
+++ b/app/packages/embeddings-v2/src/renderer/math.ts
@@ -113,11 +113,27 @@ export function zoomRect(
   );
 }
 
-/** Pan by a data-space delta, clamped inside home */
-export function panRect(rect: Rect, home: Rect, dx: number, dy: number): Rect {
+/**
+ * Pan by a data-space delta. `give` loosens the home clamp by that
+ * fraction of the viewport per side, so a drag still moves the view
+ * when the rect already spans home (fully zoomed out) — without it
+ * every delta clamps straight back and the drag feels dead
+ * (FOEPD-4318). The data can be pushed at most `give` of a viewport
+ * off-frame, never lost; zoom and reset keep the strict clamp, so any
+ * zoom action recovers the overpan.
+ */
+export function panRect(
+  rect: Rect,
+  home: Rect,
+  dx: number,
+  dy: number,
+  give = 0,
+): Rect {
+  const gx = give * (rect.x1 - rect.x0);
+  const gy = give * (rect.y1 - rect.y0);
   return clampToHome(
     { x0: rect.x0 + dx, x1: rect.x1 + dx, y0: rect.y0 + dy, y1: rect.y1 + dy },
-    home,
+    { x0: home.x0 - gx, x1: home.x1 + gx, y0: home.y0 - gy, y1: home.y1 + gy },
   );
 }
 

--- a/app/packages/embeddings-v2/src/renderer/math.ts
+++ b/app/packages/embeddings-v2/src/renderer/math.ts
@@ -85,8 +85,11 @@ export function clampToHome(rect: Rect, home: Rect): Rect {
 
 /**
  * Zoom by `factor` (>1 = in) keeping the data point under `focus`
- * stationary, clamped to [1, maxZoom] relative to home and panned back
- * inside home's bounds.
+ * stationary, clamped to [1, maxZoom] relative to home and slid back
+ * inside the pannable bounds. `give` inflates those bounds exactly as
+ * in panRect — zooming from an overpanned view must not yank the view
+ * back (the give shrinks with the rect, so deep zoom-ins drift toward
+ * the data on their own).
  */
 export function zoomRect(
   rect: Rect,
@@ -94,6 +97,7 @@ export function zoomRect(
   focus: [number, number],
   factor: number,
   maxZoom: number,
+  give = 0,
 ): Rect {
   const k = Math.min(Math.max(zoomOf(rect, home) * factor, 1), maxZoom);
   const w = (home.x1 - home.x0) / k;
@@ -102,6 +106,8 @@ export function zoomRect(
   // Keep the focus point at the same relative position in the new rect
   const rx = (fx - rect.x0) / (rect.x1 - rect.x0);
   const ry = (fy - rect.y0) / (rect.y1 - rect.y0);
+  const gx = give * w;
+  const gy = give * h;
   return clampToHome(
     {
       x0: fx - rx * w,
@@ -109,7 +115,7 @@ export function zoomRect(
       y0: fy - ry * h,
       y1: fy + (1 - ry) * h,
     },
-    home,
+    { x0: home.x0 - gx, x1: home.x1 + gx, y0: home.y0 - gy, y1: home.y1 + gy },
   );
 }
 
@@ -119,8 +125,8 @@ export function zoomRect(
  * when the rect already spans home (fully zoomed out) — without it
  * every delta clamps straight back and the drag feels dead
  * (FOEPD-4318). The data can be pushed at most `give` of a viewport
- * off-frame, never lost; zoom and reset keep the strict clamp, so any
- * zoom action recovers the overpan.
+ * off-frame, never lost. zoomRect honors the same give, so zooming
+ * from an offset view stays put; reset is what recenters.
  */
 export function panRect(
   rect: Rect,


### PR DESCRIPTION
## 🔗 Related Issues

- [FOEPD-4318](https://voxel51.atlassian.net/browse/FOEPD-4318)

## 📋 What changes are proposed in this pull request?

In the Embeddings panel's 2D plot, drag-to-pan did nothing at full zoom-out: `panRect` clamped the viewport fully inside the data bounds, and at full zoom-out — where the viewport equals the bounds — every pan delta clamped straight back to zero, so the drag felt dead.

The pan clamp now has give (`PAN_GIVE`, 10% of the viewport per side, tuned by feel): dragging always moves the view, and the data can be pushed at most that fraction off-frame, never lost. Zoom honors the same give — zooming from an offset view stays anchored under the cursor instead of yanking the view back — while the header's reset keeps the strict clamp and recenters.

## 🧪 How is this patch tested? If it is not, please explain why.

- New unit tests pin the pan give (responds at full zoom-out, capped at the give) and that zoom preserves an overpanned offset within the give while the strict clamp slides it back.
- Manual feel-testing at three give values (0.5 → 1/3 → 0.1); 0.1 keeps the graph essentially whole through zoom-out-from-an-edge.
- All package gates pass (`vitest`, `check:types`, `check:lint`).

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

Fixed drag-to-pan doing nothing in the Embeddings panel's 2D plot when fully zoomed out.

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other


[FOEPD-4318]: https://voxel51.atlassian.net/browse/FOEPD-4318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Camera zooming and panning now allow a small, controlled amount of movement beyond the normal frame boundaries.
  * Zoom and pan behavior remains strictly bounded by default, with the additional allowance applied where supported.

* **Bug Fixes**
  * Improved camera navigation near frame edges to prevent overly restrictive clamping during zooming and dragging.

* **Tests**
  * Added coverage for bounded over-panning and zooming behavior, including default strict clamping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3706
<!-- enterprise-sync-pr:end -->