### PR TITLE
[FOEPD-4319] Selection-scoped legend counts; 2D lasso keeps select mode

### DIFF
--- a/app/packages/embeddings-v2/src/ColorLegend.tsx
+++ b/app/packages/embeddings-v2/src/ColorLegend.tsx
@@ -25,6 +25,7 @@ export function ColorLegend({
   field,
   meta,
   offLabels,
+  scopedCounts,
   onToggle,
   onSolo,
 }: {
@@ -32,6 +33,10 @@ export function ColorLegend({
   meta: ColorMeta;
   /** Classes the field's filter hides; null = filtering unavailable */
   offLabels: ReadonlySet<string> | null;
+  /** Per-class counts for the current selection/scope, aligned with
+   * `meta.classes`; rows then render "scoped / total". Null = no
+   * scope, rows show the run's full counts alone */
+  scopedCounts?: readonly number[] | null;
   onToggle: (label: string) => void;
   onSolo: (label: string) => void;
 }) {
@@ -118,7 +123,9 @@ export function ColorLegend({
                   variant={TextVariant.Md}
                   color={TextColor.Tertiary}
                 >
-                  {cls.count.toLocaleString()}
+                  {scopedCounts
+                    ? `${scopedCounts[index]?.toLocaleString() ?? 0} / ${cls.count.toLocaleString()}`
+                    : cls.count.toLocaleString()}
                 </Text>
               </button>
             );

--- a/app/packages/embeddings-v2/src/PlotView.tsx
+++ b/app/packages/embeddings-v2/src/PlotView.tsx
@@ -50,6 +50,7 @@ import { ContinuousLegend } from "./ContinuousLegend";
 import { categoryHex, MISSING_CATEGORY } from "./colors";
 import { gridFilterPath } from "./filterPath";
 import HoverCard from "./HoverCard";
+import { legendCounts } from "./legendCounts";
 import {
   legendLabels,
   soloLabel,
@@ -183,6 +184,7 @@ export default function PlotView({
   const {
     visibleMask,
     visibleCount,
+    scopeMask,
     error: masksError,
   } = useMasks(
     datasetName,
@@ -246,6 +248,21 @@ export default function PlotView({
     [colorMeta, legendFilter],
   );
 
+  // Focus (selection) wins over scope (view + filters); null means
+  // nothing to scope by, and the legend shows the run's full counts
+  const scopedCounts = useMemo(
+    () =>
+      colorValues?.style === "categorical" && colorMeta?.classes?.length
+        ? legendCounts(
+            colorValues.indices,
+            colorMeta.classes.length,
+            selectedIndices,
+            scopeMask,
+          )
+        : null,
+    [colorValues, colorMeta, selectedIndices, scopeMask],
+  );
+
   // Writes read the filter from a fresh snapshot, not the render-time
   // value — rapid clicks must each transform the latest state, or a
   // click can silently compute from a stale base and drop its
@@ -297,14 +314,16 @@ export default function PlotView({
     [choices, run.pointsField],
   );
 
-  // A completed lasso returns gestures to the camera, so the
-  // selection can be explored immediately without switching modes
+  // A completed 3D lasso returns gestures to the camera — orbiting to
+  // inspect the selection is the natural next step. 2D stays in select
+  // mode so lassos can be redrawn without re-arming the tool
+  // (FOEPD-4319); each new lasso replaces the previous selection
   const handleLasso = (
     indices: number[],
     polygon?: Array<[number, number]> | null,
   ) => {
     handleSelection(indices, polygon);
-    if (indices.length) setMode("explore");
+    if (indices.length && run.dims === 3) setMode("explore");
   };
 
   const chipCount = selectionCount ?? (selectedSamples.size || null);
@@ -468,6 +487,7 @@ export default function PlotView({
             field={colorField}
             meta={colorMeta}
             offLabels={legend?.off ?? null}
+            scopedCounts={scopedCounts}
             onToggle={handleLegendToggle}
             onSolo={handleLegendSolo}
           />

--- a/app/packages/embeddings-v2/src/PlotView.tsx
+++ b/app/packages/embeddings-v2/src/PlotView.tsx
@@ -211,6 +211,7 @@ export default function PlotView({
   );
   const {
     selectedIndices,
+    lassoIndices,
     selectionCount,
     handleSelection,
     handlePointClick,
@@ -249,18 +250,21 @@ export default function PlotView({
   );
 
   // Focus (selection) wins over scope (view + filters); null means
-  // nothing to scope by, and the legend shows the run's full counts
+  // nothing to scope by, and the legend shows the run's full counts.
+  // A lasso's indices live in the bridge, never in fos.selectedSamples,
+  // so they lead and grid checkbox selections are the fallback focus
+  const focusIndices = lassoIndices ?? selectedIndices;
   const scopedCounts = useMemo(
     () =>
       colorValues?.style === "categorical" && colorMeta?.classes?.length
         ? legendCounts(
             colorValues.indices,
             colorMeta.classes.length,
-            selectedIndices,
+            focusIndices,
             scopeMask,
           )
         : null,
-    [colorValues, colorMeta, selectedIndices, scopeMask],
+    [colorValues, colorMeta, focusIndices, scopeMask],
   );
 
   // Writes read the filter from a fresh snapshot, not the render-time

--- a/app/packages/embeddings-v2/src/legendCounts.test.ts
+++ b/app/packages/embeddings-v2/src/legendCounts.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { MISSING_CATEGORY } from "./colors";
+import { legendCounts } from "./legendCounts";
+
+// Points: cat, dog, cat, missing, dog, cat
+const COLUMN = new Uint16Array([0, 1, 0, MISSING_CATEGORY, 1, 0]);
+
+describe("legendCounts", () => {
+  it("returns null when there is no selection and no scope", () => {
+    expect(legendCounts(COLUMN, 2, null, null)).toBeNull();
+    expect(legendCounts(COLUMN, 2, [], null)).toBeNull();
+  });
+
+  it("tallies the selection, ignoring missing values", () => {
+    expect(legendCounts(COLUMN, 2, [0, 1, 3], null)).toEqual([1, 1]);
+  });
+
+  it("prefers the selection over the scope mask", () => {
+    const scope = new Uint8Array([1, 1, 1, 1, 1, 1]);
+    expect(legendCounts(COLUMN, 2, [5], scope)).toEqual([1, 0]);
+  });
+
+  it("tallies the scope mask when nothing is selected", () => {
+    const scope = new Uint8Array([1, 0, 1, 1, 0, 1]);
+    expect(legendCounts(COLUMN, 2, null, scope)).toEqual([3, 0]);
+  });
+
+  it("ignores class indices past a truncated legend's list", () => {
+    // Column knows class 2; the legend only lists top-2
+    const column = new Uint16Array([0, 1, 2]);
+    expect(legendCounts(column, 2, [0, 1, 2], null)).toEqual([1, 1]);
+  });
+
+  it("survives a scope mask shorter than the column", () => {
+    expect(legendCounts(COLUMN, 2, null, new Uint8Array([1, 1]))).toEqual([
+      1, 1,
+    ]);
+  });
+});

--- a/app/packages/embeddings-v2/src/legendCounts.ts
+++ b/app/packages/embeddings-v2/src/legendCounts.ts
@@ -16,15 +16,17 @@ import { MISSING_CATEGORY } from "./colors";
 export function legendCounts(
   column: Uint16Array,
   classCount: number,
-  selectedIndices: readonly number[] | null,
+  // ArrayLike: the lasso keeps its (potentially huge) index list as a
+  // typed array; grid selections arrive as plain arrays
+  selectedIndices: ArrayLike<number> | null,
   scopeMask: Uint8Array | null,
 ): number[] | null {
   if (classCount <= 0) return null;
 
-  if (selectedIndices?.length) {
+  if (selectedIndices && selectedIndices.length) {
     const counts = new Array<number>(classCount).fill(0);
-    for (const index of selectedIndices) {
-      const cls = column[index];
+    for (let i = 0; i < selectedIndices.length; i++) {
+      const cls = column[selectedIndices[i]];
       // Missing values have no legend row; indices past the legend's
       // class list (a truncated top-N legend) have no row either
       if (cls !== undefined && cls !== MISSING_CATEGORY && cls < classCount) {

--- a/app/packages/embeddings-v2/src/legendCounts.ts
+++ b/app/packages/embeddings-v2/src/legendCounts.ts
@@ -1,0 +1,51 @@
+/**
+ * Scope-aware legend counts: a tally of the color column's class
+ * indices over the points the user is focused on — the lasso/grid
+ * selection when one exists, otherwise the view/filter scope. Returns
+ * null when there is nothing to scope by, in which case the legend
+ * shows the run's full counts unannotated.
+ *
+ * The legend's OWN filter is deliberately not part of the scope: a
+ * toggled-off class keeps its count, which is what tells the user what
+ * toggling it back would show. (Callers pass the server-side scope
+ * mask — view stages and sidebar filters — not the combined mask that
+ * includes the color field's local evaluation.)
+ */
+import { MISSING_CATEGORY } from "./colors";
+
+export function legendCounts(
+  column: Uint16Array,
+  classCount: number,
+  selectedIndices: readonly number[] | null,
+  scopeMask: Uint8Array | null,
+): number[] | null {
+  if (classCount <= 0) return null;
+
+  if (selectedIndices?.length) {
+    const counts = new Array<number>(classCount).fill(0);
+    for (const index of selectedIndices) {
+      const cls = column[index];
+      // Missing values have no legend row; indices past the legend's
+      // class list (a truncated top-N legend) have no row either
+      if (cls !== undefined && cls !== MISSING_CATEGORY && cls < classCount) {
+        counts[cls] += 1;
+      }
+    }
+    return counts;
+  }
+
+  if (scopeMask) {
+    const counts = new Array<number>(classCount).fill(0);
+    const length = Math.min(column.length, scopeMask.length);
+    for (let i = 0; i < length; i++) {
+      if (!scopeMask[i]) continue;
+      const cls = column[i];
+      if (cls !== MISSING_CATEGORY && cls < classCount) {
+        counts[cls] += 1;
+      }
+    }
+    return counts;
+  }
+
+  return null;
+}

--- a/app/packages/embeddings-v2/src/useMasks.ts
+++ b/app/packages/embeddings-v2/src/useMasks.ts
@@ -22,6 +22,10 @@ export function useMasks(
 ): {
   visibleMask: Uint8Array | null;
   visibleCount: number | null;
+  /** View stages ∧ sidebar filters only — no `localMask`. Legend
+   * counts scope by this so the color field's own filter never zeroes
+   * the counts of the classes it hides (see legendCounts.ts) */
+  scopeMask: Uint8Array | null;
   error: string | null;
 } {
   const [masks, setMasks] = useState<Masks | null>(null);
@@ -52,18 +56,15 @@ export function useMasks(
 
   // The endpoint early-outs each mask to null when its inputs are empty
   // (no view stages / no filters), so combining only pays when needed
-  const combined = useMemo(() => {
-    const parts = [masks?.visible, masks?.match, localMask].filter(
-      (part): part is Uint8Array => Boolean(part),
-    );
-    if (!parts.length) return null;
-    if (parts.length === 1) return parts[0];
-    const out = new Uint8Array(parts[0].length);
-    for (let i = 0; i < out.length; i++) {
-      out[i] = parts.every((part) => part[i]) ? 1 : 0;
-    }
-    return out;
-  }, [masks, localMask]);
+  const combined = useMemo(
+    () => combineMasks([masks?.visible, masks?.match, localMask]),
+    [masks, localMask],
+  );
+
+  const scopeMask = useMemo(
+    () => combineMasks([masks?.visible, masks?.match]),
+    [masks],
+  );
 
   const visibleMask = useMemo(() => {
     if (!combined || !loadedCount) return null;
@@ -81,5 +82,18 @@ export function useMasks(
     return count;
   }, [combined]);
 
-  return { visibleMask, visibleCount, error };
+  return { visibleMask, visibleCount, scopeMask, error };
+}
+
+function combineMasks(
+  candidates: Array<Uint8Array | null | undefined>,
+): Uint8Array | null {
+  const parts = candidates.filter((part): part is Uint8Array => Boolean(part));
+  if (!parts.length) return null;
+  if (parts.length === 1) return parts[0];
+  const out = new Uint8Array(parts[0].length);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parts.every((part) => part[i]) ? 1 : 0;
+  }
+  return out;
 }

--- a/app/packages/embeddings-v2/src/useSelectionBridge.test.ts
+++ b/app/packages/embeddings-v2/src/useSelectionBridge.test.ts
@@ -74,8 +74,8 @@ describe("useSelectionBridge", () => {
     expect(fetchLassoStage).toHaveBeenCalledWith("ds", "viz", [], { polygon });
   });
 
-  // Focus chrome (legend counts) follows the gesture, not the network:
-  // the lasso's indices surface synchronously, and every clear path
+  // The legend counts follow the gesture, not the network: the
+  // lasso's indices surface synchronously, and every clear path
   // (empty gesture, clearAll) drops them
   it("exposes lasso indices synchronously and clears them", () => {
     vi.mocked(fetchLassoStage)
@@ -270,7 +270,7 @@ describe("useSelectionBridge", () => {
     expect(result.current.selectedIndices).toBeNull();
   });
 
-  it("tracks the lasso's point count for chrome, until cleared", async () => {
+  it("tracks the lasso's point count for display, until cleared", async () => {
     vi.mocked(fetchLassoStage).mockClear().mockResolvedValue({
       _cls: "fiftyone.core.stages.GeoWithin",
       kwargs: {},

--- a/app/packages/embeddings-v2/src/useSelectionBridge.test.ts
+++ b/app/packages/embeddings-v2/src/useSelectionBridge.test.ts
@@ -74,6 +74,30 @@ describe("useSelectionBridge", () => {
     expect(fetchLassoStage).toHaveBeenCalledWith("ds", "viz", [], { polygon });
   });
 
+  // Focus chrome (legend counts) follows the gesture, not the network:
+  // the lasso's indices surface synchronously, and every clear path
+  // (empty gesture, clearAll) drops them
+  it("exposes lasso indices synchronously and clears them", () => {
+    vi.mocked(fetchLassoStage)
+      .mockClear()
+      .mockResolvedValue({ _cls: "s", kwargs: {}, count: 2 });
+    const opts = options();
+    const { result } = renderHook(() => useSelectionBridge(opts));
+
+    expect(result.current.lassoIndices).toBeNull();
+    act(() => result.current.handleSelection([0, 1]));
+    // Available before the stage round trip resolves
+    expect(result.current.lassoIndices).toEqual([0, 1]);
+
+    act(() => result.current.handleSelection([]));
+    expect(result.current.lassoIndices).toBeNull();
+
+    act(() => result.current.handleSelection([1]));
+    expect(result.current.lassoIndices).toEqual([1]);
+    act(() => result.current.clearAll());
+    expect(result.current.lassoIndices).toBeNull();
+  });
+
   it("falls back to indices when no data polygon exists", async () => {
     vi.mocked(fetchLassoStage).mockClear().mockResolvedValue({
       _cls: "fiftyone.core.stages.Select",

--- a/app/packages/embeddings-v2/src/useSelectionBridge.test.ts
+++ b/app/packages/embeddings-v2/src/useSelectionBridge.test.ts
@@ -86,14 +86,15 @@ describe("useSelectionBridge", () => {
 
     expect(result.current.lassoIndices).toBeNull();
     act(() => result.current.handleSelection([0, 1]));
-    // Available before the stage round trip resolves
-    expect(result.current.lassoIndices).toEqual([0, 1]);
+    // Available before the stage round trip resolves; typed array
+    // because a lasso can enclose millions of points
+    expect(Array.from(result.current.lassoIndices ?? [])).toEqual([0, 1]);
 
     act(() => result.current.handleSelection([]));
     expect(result.current.lassoIndices).toBeNull();
 
     act(() => result.current.handleSelection([1]));
-    expect(result.current.lassoIndices).toEqual([1]);
+    expect(Array.from(result.current.lassoIndices ?? [])).toEqual([1]);
     act(() => result.current.clearAll());
     expect(result.current.lassoIndices).toBeNull();
   });

--- a/app/packages/embeddings-v2/src/useSelectionBridge.ts
+++ b/app/packages/embeddings-v2/src/useSelectionBridge.ts
@@ -52,8 +52,10 @@ export function useSelectionBridge({
   selectedIndices: number[] | null;
   /** The live lasso's enclosed wire indices (null = no lasso). Kept
    * client-side for focus-scoped chrome like legend counts; the grid
-   * itself is driven by the server-resolved stage, never these */
-  lassoIndices: number[] | null;
+   * itself is driven by the server-resolved stage, never these. Typed
+   * array on purpose: a lasso can enclose millions of points, and this
+   * is retained until the selection clears */
+  lassoIndices: Uint32Array | null;
   /** Points in the last lasso selection, for chrome (null = none) */
   selectionCount: number | null;
   handleSelection: (
@@ -66,7 +68,7 @@ export function useSelectionBridge({
 } {
   const [error, setError] = useState<string | null>(null);
   const [selectionCount, setSelectionCount] = useState<number | null>(null);
-  const [lassoIndices, setLassoIndices] = useState<number[] | null>(null);
+  const [lassoIndices, setLassoIndices] = useState<Uint32Array | null>(null);
   // Monotonic lasso-request id: a slow older response must not
   // overwrite a newer selection (or resurrect one that was cleared)
   const lassoSeq = useRef(0);
@@ -139,7 +141,7 @@ export function useSelectionBridge({
     }
     // Synchronous, unlike the stage round trip below: focus chrome
     // (legend counts) follows the gesture, not the network
-    setLassoIndices(indices);
+    setLassoIndices(Uint32Array.from(indices));
     const selection = polygon?.length ? { polygon } : { indices };
     fetchLassoStage(datasetName, brainKey, view, selection)
       .then((stage) => {

--- a/app/packages/embeddings-v2/src/useSelectionBridge.ts
+++ b/app/packages/embeddings-v2/src/useSelectionBridge.ts
@@ -51,12 +51,12 @@ export function useSelectionBridge({
 }: SelectionBridgeOptions): {
   selectedIndices: number[] | null;
   /** The live lasso's enclosed wire indices (null = no lasso). Kept
-   * client-side for focus-scoped chrome like legend counts; the grid
-   * itself is driven by the server-resolved stage, never these. Typed
-   * array on purpose: a lasso can enclose millions of points, and this
-   * is retained until the selection clears */
+   * client-side for selection-scoped UI like the legend counts; the
+   * grid itself is driven by the server-resolved stage, never these.
+   * Typed array on purpose: a lasso can enclose millions of points,
+   * and this is retained until the selection clears */
   lassoIndices: Uint32Array | null;
-  /** Points in the last lasso selection, for chrome (null = none) */
+  /** Points in the last lasso selection, for display (null = none) */
   selectionCount: number | null;
   handleSelection: (
     indices: number[],
@@ -139,8 +139,8 @@ export function useSelectionBridge({
       setLassoIndices(null);
       return;
     }
-    // Synchronous, unlike the stage round trip below: focus chrome
-    // (legend counts) follows the gesture, not the network
+    // Synchronous, unlike the stage round trip below: the legend
+    // counts follow the gesture, not the network
     setLassoIndices(Uint32Array.from(indices));
     const selection = polygon?.length ? { polygon } : { indices };
     fetchLassoStage(datasetName, brainKey, view, selection)

--- a/app/packages/embeddings-v2/src/useSelectionBridge.ts
+++ b/app/packages/embeddings-v2/src/useSelectionBridge.ts
@@ -50,6 +50,10 @@ export function useSelectionBridge({
   setSelectedSamples,
 }: SelectionBridgeOptions): {
   selectedIndices: number[] | null;
+  /** The live lasso's enclosed wire indices (null = no lasso). Kept
+   * client-side for focus-scoped chrome like legend counts; the grid
+   * itself is driven by the server-resolved stage, never these */
+  lassoIndices: number[] | null;
   /** Points in the last lasso selection, for chrome (null = none) */
   selectionCount: number | null;
   handleSelection: (
@@ -62,6 +66,7 @@ export function useSelectionBridge({
 } {
   const [error, setError] = useState<string | null>(null);
   const [selectionCount, setSelectionCount] = useState<number | null>(null);
+  const [lassoIndices, setLassoIndices] = useState<number[] | null>(null);
   // Monotonic lasso-request id: a slow older response must not
   // overwrite a newer selection (or resurrect one that was cleared)
   const lassoSeq = useRef(0);
@@ -72,6 +77,7 @@ export function useSelectionBridge({
     resetExtended();
     setSelectedSamples(new Map());
     setSelectionCount(null);
+    setLassoIndices(null);
     setError(null);
     chart.current?.clearSelection();
   }, [resetExtended, setSelectedSamples, chart]);
@@ -128,8 +134,12 @@ export function useSelectionBridge({
     if (!indices.length) {
       resetExtended();
       setSelectionCount(null);
+      setLassoIndices(null);
       return;
     }
+    // Synchronous, unlike the stage round trip below: focus chrome
+    // (legend counts) follows the gesture, not the network
+    setLassoIndices(indices);
     const selection = polygon?.length ? { polygon } : { indices };
     fetchLassoStage(datasetName, brainKey, view, selection)
       .then((stage) => {
@@ -170,6 +180,7 @@ export function useSelectionBridge({
 
   return {
     selectedIndices,
+    lassoIndices,
     selectionCount,
     handleSelection,
     handlePointClick,


### PR DESCRIPTION
> **Stacked on #8209** (the legend/patches filter-path fix) — this PR's base is that branch, so the diff below shows only this work. GitHub will retarget to `develop` when #8209 merges.

## 🔗 Related Issues

- [FOEPD-4319](https://voxel51.atlassian.net/browse/FOEPD-4319)
- Selection-scoped legend counts: recorded as a follow-up on [FOEPD-4404](https://voxel51.atlassian.net/browse/FOEPD-4404)

## 📋 What changes are proposed in this pull request?

Two legend/selection improvements to the Embeddings panel:

- **Selection-scoped legend counts**: legend counts were the full-run class distribution, frozen — they ignored lasso selections, grid selections, and view filters. Legend rows now read "47 / 412" when a focus (lasso or grid selection) or scope (view stages + sidebar filters) exists: an O(n) client-side tally over the color column already in memory, no server work. The legend's own filter is deliberately excluded from the scope, so a toggled-off class keeps its count — that number is what toggling it back would show. The lasso's enclosed indices are now surfaced by the selection bridge (synchronously, so the counts follow the gesture rather than the network) and held as a `Uint32Array` since a lasso can enclose millions of points.
- **Lasso mode (FOEPD-4319)**: a completed 2D lasso stays in select mode so lassos can be redrawn without re-arming the tool; 3D still returns to explore for orbiting, per the ticket. A new lasso replaces the selection (existing behavior, now deliberate).

## 🧪 How is this patch tested? If it is not, please explain why.

- New unit tests for the tally (`legendCounts`): selection precedence over scope, missing-value and truncated-legend handling, mask-length guards.
- New unit test for the bridge: lasso indices surface synchronously and every clear path (empty gesture, Esc/clearAll) drops them.
- Manual verification: lasso → counts scope immediately; clearing restores; grid checkbox selections and sidebar filters scope too; legend toggles never zero their own counts.
- All package gates pass (`vitest`, `check:types`, `check:lint`).

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

Embeddings panel legend counts now reflect the current lasso/grid selection and view filters ("47 / 412"), and a completed 2D lasso stays in select mode so selections can be redrawn immediately.

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other


[FOEPD-4319]: https://voxel51.atlassian.net/browse/FOEPD-4319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOEPD-4404]: https://voxel51.atlassian.net/browse/FOEPD-4404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3717
<!-- enterprise-sync-pr:end -->