### PR TITLE
Require fiftyone-brain 0.24

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ setup(
         "scikit-image<1",
         "scipy<2",
         # internal packages
-        "fiftyone-brain>=0.23.0,<0.24",
+        "fiftyone-brain>=0.24.0,<0.25",
         "fiftyone-db>=0.4,<2.0",
         "voxel51-eta>=0.17,<0.18",
     ],


### PR DESCRIPTION
Bumps the `fiftyone-brain` pin to `>=0.24.0,<0.25` for the brain 0.24.0 release (voxel51/fiftyone-brain#308), which carries Python 3.13/3.14 support (voxel51/fiftyone-brain#307), incremental embeddings visualization updates, and a fix for unpickling incremental embeddings across differing Python versions (voxel51/fiftyone-brain#304).

Draft until `fiftyone-brain 0.24.0` is published to PyPI — the `>=0.24.0` floor cannot resolve before then.

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3715
<!-- enterprise-sync-pr:end -->