### PR TITLE
fix(playback): import ChevronBottomIcon for the timeline drawer toggle

### DIFF
--- a/app/packages/playback/src/views/TimelineControls/TimelineControls.tsx
+++ b/app/packages/playback/src/views/TimelineControls/TimelineControls.tsx
@@ -20,6 +20,7 @@ import {
   Variant,
 } from "@voxel51/voodo";
 import {
+  ChevronBottomIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
   PauseIcon,
@@ -222,7 +223,7 @@ const TimelineControls: React.FC<TimelineControlsProps> = ({
               variant={Variant.Icon}
               size={Size.Xs}
               data-testid="timeline-controls-toggle"
-              leadingIcon={IconName.ChevronBottom}
+              leadingIcon={ChevronBottomIcon}
               aria-label={expanded ? "Hide tracks" : "Show tracks"}
               aria-expanded={expanded}
               className={clsx(styles.toggle, {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes a runtime `ReferenceError: IconName is not defined` in `TimelineControls`, introduced by a semantic merge conflict when #8204 merged: the branch used `IconName` from `@voxel51/voodo`, while develop had moved to stable icon components (`stableIcons`). The merge converted two of the three usages and dropped the `IconName` import, leaving the drawer toggle chevron referencing an undefined identifier.

Rendering `TimelineControls` with an `onToggle` prop (the timeline tracks drawer toggle) crashes, which currently fails 20 `test / test-app` tests on every PR merge ref (first surfaced on #8104).

## How is this patch tested?

Ran the 5 previously failing test files locally: `TimelineControls`, `TimelineHeader`, `TimelineWithTracks`, `PlaybackShell`, `use-temporal-tags` — 5 files, 82 tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the timeline toggle button icon for a more consistent visual appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3712
<!-- enterprise-sync-pr:end -->