### PR TITLE
Add extension point for mcap explorer url

### DIFF
--- a/app/packages/multimodal/.dependency-cruiser.cjs
+++ b/app/packages/multimodal/.dependency-cruiser.cjs
@@ -36,6 +36,7 @@ const VISUALIZATION = `${SRC}visualization/`;
 
 const ENTERPRISE_SHARED_FACADES =
   `${SRC}(extensions/(timeline|tiles)/(index|runtime)\\.ts$|` +
+  `extensions/mcap-explorer/index\\.ts$|` +
   `query/bytes/index\\.ts$|visualization/index\\.ts$)`;
 const FORMAT_VENDORS =
   "(^|/)node_modules/(@mcap|@foxglove|hyparquet|mp4box)(/|$)|" +

--- a/app/packages/multimodal/package.json
+++ b/app/packages/multimodal/package.json
@@ -19,6 +19,7 @@
         "./temporal-tags": "./src/temporal-tags/index.ts",
         "./temporal-tags/grid-overlay": "./src/temporal-tags/TemporalTagGridOverlay.tsx",
         "./inject": "./src/inject/index.ts",
+        "./extensions/mcap-explorer": "./src/extensions/mcap-explorer/index.ts",
         "./extensions/timeline": "./src/extensions/timeline/index.ts",
         "./extensions/timeline/runtime": "./src/extensions/timeline/runtime.ts",
         "./extensions/tiles": "./src/extensions/tiles/index.ts",
@@ -69,6 +70,9 @@
             ],
             "inject": [
                 "src/inject/index.ts"
+            ],
+            "extensions/mcap-explorer": [
+                "src/extensions/mcap-explorer/index.ts"
             ],
             "extensions/timeline": [
                 "src/extensions/timeline/index.ts"

--- a/app/packages/multimodal/src/extensions/README.md
+++ b/app/packages/multimodal/src/extensions/README.md
@@ -6,6 +6,6 @@ teaching that surface about the feature's internals.
 Shared registry and data-plane contracts live under `host/`. Extension families
 may depend on that host boundary, but never on sibling family implementations.
 
-The MCAP Explorer extension supplies edition-specific cloud-path resolution.
-The shared Explorer remains HTTP-only until a product entrypoint registers a
-resolver through this boundary.
+The MCAP Explorer extension supplies optional cloud-path resolution. The shared
+Explorer remains HTTP-only until a product entrypoint registers a resolver
+through this boundary.

--- a/app/packages/multimodal/src/extensions/README.md
+++ b/app/packages/multimodal/src/extensions/README.md
@@ -5,3 +5,7 @@ teaching that surface about the feature's internals.
 
 Shared registry and data-plane contracts live under `host/`. Extension families
 may depend on that host boundary, but never on sibling family implementations.
+
+The MCAP Explorer extension supplies edition-specific cloud-path resolution.
+The shared Explorer remains HTTP-only until a product entrypoint registers a
+resolver through this boundary.

--- a/app/packages/multimodal/src/extensions/mcap-explorer/index.ts
+++ b/app/packages/multimodal/src/extensions/mcap-explorer/index.ts
@@ -1,0 +1,6 @@
+export {
+  getMcapCloudSourceResolver,
+  hasMcapCloudSourceResolver,
+  registerMcapCloudSourceResolver,
+  type McapCloudSourceResolver,
+} from "./registry";

--- a/app/packages/multimodal/src/extensions/mcap-explorer/registry.ts
+++ b/app/packages/multimodal/src/extensions/mcap-explorer/registry.ts
@@ -1,0 +1,42 @@
+/** Resolves a raw cloud-storage path into a browser-readable URL. */
+export type McapCloudSourceResolver = (cloudPath: string) => Promise<string>;
+
+interface McapCloudSourceResolverState {
+  resolver: McapCloudSourceResolver | null;
+}
+
+const REGISTRY_KEY = Symbol.for(
+  "@fiftyone/multimodal:mcap-cloud-source-resolver",
+);
+const globalRegistry = globalThis as Record<PropertyKey, unknown>;
+const state = (globalRegistry[REGISTRY_KEY] ??= {
+  resolver: null,
+}) as McapCloudSourceResolverState;
+
+/** Registers the edition-specific resolver for raw cloud-storage paths. */
+export function registerMcapCloudSourceResolver(
+  resolver: McapCloudSourceResolver,
+): () => void {
+  if (state.resolver === resolver) return () => undefined;
+  if (state.resolver) {
+    throw new Error("An MCAP cloud-source resolver is already registered");
+  }
+
+  state.resolver = resolver;
+  let active = true;
+  return () => {
+    if (!active || state.resolver !== resolver) return;
+    active = false;
+    state.resolver = null;
+  };
+}
+
+/** Returns the resolver contributed by the current product edition. */
+export function getMcapCloudSourceResolver(): McapCloudSourceResolver | null {
+  return state.resolver;
+}
+
+/** Whether the current product edition supports raw cloud-storage paths. */
+export function hasMcapCloudSourceResolver(): boolean {
+  return state.resolver !== null;
+}

--- a/app/packages/multimodal/src/views/mcap-explorer/McapExplorerPanel.test.tsx
+++ b/app/packages/multimodal/src/views/mcap-explorer/McapExplorerPanel.test.tsx
@@ -1,5 +1,12 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { registerMcapCloudSourceResolver } from "../../extensions/mcap-explorer";
 import { BYTE_SOURCE_READ_PROFILE } from "../../query/bytes/index";
 import type { SourcePlaybackProps } from "../episode/index";
 import McapExplorerPanel from "./McapExplorerPanel";
@@ -53,7 +60,7 @@ describe("McapExplorerPanel", () => {
     expect(screen.queryByTestId("mcap-source-playback")).toBeNull();
   });
 
-  it("opens a direct HTTP(S) MCAP URL", () => {
+  it("opens a direct HTTP(S) MCAP URL", async () => {
     render(<McapExplorerPanel />);
 
     fireEvent.change(screen.getByLabelText("Remote MCAP URL"), {
@@ -63,9 +70,11 @@ describe("McapExplorerPanel", () => {
     });
     fireEvent.click(screen.getByRole("button", { name: "Open URL" }));
 
-    expect(screen.getByTestId("mcap-source-file-name").textContent).toBe(
-      "recording.mcap",
-    );
+    await waitFor(() => {
+      expect(screen.getByTestId("mcap-source-file-name").textContent).toBe(
+        "recording.mcap",
+      );
+    });
     expect(viewerHarness.lastPlaybackProps?.source).toEqual({
       readProfile: BYTE_SOURCE_READ_PROFILE.REMOTE,
       sourceId:
@@ -150,13 +159,14 @@ describe("McapExplorerPanel", () => {
     );
   });
 
-  it("unmounts the active source and restores the picker", () => {
+  it("unmounts the active source and restores the picker", async () => {
     render(<McapExplorerPanel />);
 
     fireEvent.change(screen.getByLabelText("Remote MCAP URL"), {
       target: { value: "https://example.com/run.mcap" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Open URL" }));
+    await screen.findByTestId("mcap-source-playback");
     fireEvent.click(screen.getByRole("button", { name: "Unmount recording" }));
 
     expect(screen.getByText("Drag & drop an MCAP file")).toBeTruthy();
@@ -196,7 +206,39 @@ describe("McapExplorerPanel", () => {
     );
   });
 
-  it("shows invalid URL and file errors", () => {
+  it("opens an Enterprise cloud path through its registered resolver", async () => {
+    const resolver = vi.fn(
+      async () => "https://signed.example.com/recording.mcap?token=secret",
+    );
+    const unregister = registerMcapCloudSourceResolver(resolver);
+
+    try {
+      render(<McapExplorerPanel />);
+
+      expect(
+        screen.getByText(
+          "HTTP(S), s3://, gs://, and configured Enterprise cloud paths.",
+        ),
+      ).toBeTruthy();
+      fireEvent.change(screen.getByLabelText("Remote MCAP URL"), {
+        target: { value: "s3://bucket/run.mcap" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: "Open URL" }));
+
+      await waitFor(() => {
+        expect(viewerHarness.lastPlaybackProps?.source).toEqual({
+          readProfile: BYTE_SOURCE_READ_PROFILE.REMOTE,
+          sourceId: "remote-url:s3://bucket/run.mcap",
+          url: "https://signed.example.com/recording.mcap?token=secret",
+        });
+      });
+      expect(resolver).toHaveBeenCalledWith("s3://bucket/run.mcap");
+    } finally {
+      unregister();
+    }
+  });
+
+  it("shows invalid URL and file errors", async () => {
     render(<McapExplorerPanel />);
 
     fireEvent.change(screen.getByLabelText("Remote MCAP URL"), {
@@ -204,7 +246,7 @@ describe("McapExplorerPanel", () => {
     });
     fireEvent.click(screen.getByRole("button", { name: "Open URL" }));
     expect(
-      screen.getByText("Only HTTP(S) MCAP URLs are supported"),
+      await screen.findByText("Only HTTP(S) MCAP URLs are supported"),
     ).toBeTruthy();
 
     fireEvent.change(screen.getByTestId("local-mcap-input"), {

--- a/app/packages/multimodal/src/views/mcap-explorer/McapExplorerPanel.test.tsx
+++ b/app/packages/multimodal/src/views/mcap-explorer/McapExplorerPanel.test.tsx
@@ -206,7 +206,7 @@ describe("McapExplorerPanel", () => {
     );
   });
 
-  it("opens an Enterprise cloud path through its registered resolver", async () => {
+  it("opens a cloud path through its registered resolver", async () => {
     const resolver = vi.fn(
       async () => "https://signed.example.com/recording.mcap?token=secret",
     );
@@ -216,9 +216,7 @@ describe("McapExplorerPanel", () => {
       render(<McapExplorerPanel />);
 
       expect(
-        screen.getByText(
-          "HTTP(S), s3://, gs://, and configured Enterprise cloud paths.",
-        ),
+        screen.getByText("HTTP(S) and configured cloud paths."),
       ).toBeTruthy();
       fireEvent.change(screen.getByLabelText("Remote MCAP URL"), {
         target: { value: "s3://bucket/run.mcap" },

--- a/app/packages/multimodal/src/views/mcap-explorer/McapExplorerPanel.tsx
+++ b/app/packages/multimodal/src/views/mcap-explorer/McapExplorerPanel.tsx
@@ -316,7 +316,7 @@ const McapExplorerPanel: React.FC = () => {
               color={TextColor.Secondary}
             >
               {supportsCloudPaths
-                ? "HTTP(S), s3://, gs://, and configured Enterprise cloud paths."
+                ? "HTTP(S) and configured cloud paths."
                 : "HTTP(S) sources must support CORS and byte-range reads."}
             </Text>
           )}

--- a/app/packages/multimodal/src/views/mcap-explorer/McapExplorerPanel.tsx
+++ b/app/packages/multimodal/src/views/mcap-explorer/McapExplorerPanel.tsx
@@ -12,6 +12,7 @@ import {
   Variant,
 } from "@voxel51/voodo";
 import React, { useCallback, useMemo, useRef, useState } from "react";
+import { hasMcapCloudSourceResolver } from "../../extensions/mcap-explorer";
 import type { ByteSourceDescriptor } from "../../ir/index";
 import { diagnosticMessage } from "../../utils/errors";
 import { episodeSourceFromByteSource } from "../session/episode-source";
@@ -19,7 +20,7 @@ import { useEpisodeSession } from "../session/use-episode-session";
 import { SourcePlayback } from "../episode/index";
 import {
   createLocalMcapSourceDescriptor,
-  createRemoteMcapSourceDescriptor,
+  resolveRemoteMcapSourceDescriptor,
 } from "./source-descriptors";
 import styles from "./McapExplorerPanel.module.css";
 
@@ -38,6 +39,7 @@ const McapExplorerPanel: React.FC = () => {
   const [active, setActive] = useState<ActiveAnyMcapSource | null>(null);
   const [dragging, setDragging] = useState(false);
   const [error, setError] = useState<ViewerError | null>(null);
+  const [openingUrl, setOpeningUrl] = useState(false);
   const [urlInput, setUrlInput] = useState("");
   const dragDepthRef = useRef(0);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -78,9 +80,11 @@ const McapExplorerPanel: React.FC = () => {
     }
   }, []);
 
-  const openUrl = useCallback(() => {
+  const openUrl = useCallback(async () => {
+    setOpeningUrl(true);
+    setError(null);
     try {
-      const descriptor = createRemoteMcapSourceDescriptor(urlInput);
+      const descriptor = await resolveRemoteMcapSourceDescriptor(urlInput);
       setActive({
         fileName: descriptor.fileName,
         kind: "url",
@@ -92,8 +96,12 @@ const McapExplorerPanel: React.FC = () => {
         message: diagnosticMessage(caught, "Could not open MCAP"),
         target: "url",
       });
+    } finally {
+      setOpeningUrl(false);
     }
   }, [urlInput]);
+
+  const supportsCloudPaths = hasMcapCloudSourceResolver();
 
   const handleDragEnter = useCallback(
     (event: React.DragEvent) => {
@@ -272,23 +280,28 @@ const McapExplorerPanel: React.FC = () => {
               aria-label="Remote MCAP URL"
               error={error?.target === "url"}
               icon={IconName.ExternalLink}
+              disabled={openingUrl}
               onChange={(event) => {
                 setUrlInput(event.target.value);
                 if (error?.target === "url") {
                   setError(null);
                 }
               }}
-              placeholder="https://example.com/recording.mcap"
+              placeholder={
+                supportsCloudPaths
+                  ? "https://example.com/recording.mcap or s3://bucket/recording.mcap"
+                  : "https://example.com/recording.mcap"
+              }
               size={Size.Sm}
-              type={InputType.Url}
+              type={InputType.Text}
               value={urlInput}
             />
             <Button
-              disabled={urlInput.trim().length === 0}
+              disabled={openingUrl || urlInput.trim().length === 0}
               size={Size.Sm}
               type="submit"
             >
-              Open URL
+              {openingUrl ? "Opening..." : "Open URL"}
             </Button>
           </form>
 
@@ -302,7 +315,9 @@ const McapExplorerPanel: React.FC = () => {
               variant={TextVariant.Xs}
               color={TextColor.Secondary}
             >
-              HTTP(S) sources must support CORS and byte-range reads.
+              {supportsCloudPaths
+                ? "HTTP(S), s3://, gs://, and configured Enterprise cloud paths."
+                : "HTTP(S) sources must support CORS and byte-range reads."}
             </Text>
           )}
         </div>

--- a/app/packages/multimodal/src/views/mcap-explorer/README.md
+++ b/app/packages/multimodal/src/views/mcap-explorer/README.md
@@ -6,3 +6,8 @@ remote MCAP recording and presenting it as an episode.
 The format name describes the product surface, not an implementation boundary.
 The explorer validates user input and composes neutral episode capabilities; it
 does not parse MCAP, consume generated schemas, or import adapter internals.
+
+HTTP(S) sources are supported by the shared product surface. Enterprise also
+registers a cloud-source resolver through its injection entrypoint, allowing
+raw storage paths such as `s3://` and `gs://` to be exchanged for signed URLs
+by the server before browser byte reads begin.

--- a/app/packages/multimodal/src/views/mcap-explorer/README.md
+++ b/app/packages/multimodal/src/views/mcap-explorer/README.md
@@ -7,7 +7,6 @@ The format name describes the product surface, not an implementation boundary.
 The explorer validates user input and composes neutral episode capabilities; it
 does not parse MCAP, consume generated schemas, or import adapter internals.
 
-HTTP(S) sources are supported by the shared product surface. Enterprise also
-registers a cloud-source resolver through its injection entrypoint, allowing
-raw storage paths such as `s3://` and `gs://` to be exchanged for signed URLs
-by the server before browser byte reads begin.
+HTTP(S) sources are supported by the shared product surface. Product
+entrypoints may register a cloud-source resolver that exchanges configured
+storage paths for browser-readable URLs before byte reads begin.

--- a/app/packages/multimodal/src/views/mcap-explorer/source-descriptors.test.ts
+++ b/app/packages/multimodal/src/views/mcap-explorer/source-descriptors.test.ts
@@ -1,9 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { registerMcapCloudSourceResolver } from "../../extensions/mcap-explorer";
 import { BYTE_SOURCE_READ_PROFILE } from "../../query/bytes";
 import {
   createLocalMcapSourceDescriptor,
   createRemoteMcapSourceDescriptor,
   isMcapFile,
+  resolveRemoteMcapSourceDescriptor,
 } from "./source-descriptors";
 
 describe("any MCAP source descriptors", () => {
@@ -58,5 +60,68 @@ describe("any MCAP source descriptors", () => {
     expect(() => createRemoteMcapSourceDescriptor("not a url")).toThrow(
       "Enter a valid HTTP(S) URL",
     );
+  });
+
+  it("keeps cloud paths Enterprise-only when no resolver is registered", async () => {
+    await expect(
+      resolveRemoteMcapSourceDescriptor("s3://bucket/file.mcap"),
+    ).rejects.toThrow("Only HTTP(S) MCAP URLs are supported");
+  });
+
+  it("resolves a cloud path without putting its signed URL in the source id", async () => {
+    const resolver = vi.fn(
+      async () => "https://signed.example.com/file.mcap?token=secret",
+    );
+    const unregister = registerMcapCloudSourceResolver(resolver);
+
+    try {
+      await expect(
+        resolveRemoteMcapSourceDescriptor(" gs://bucket/runs/drive.mcap "),
+      ).resolves.toEqual({
+        fileName: "drive.mcap",
+        source: {
+          readProfile: BYTE_SOURCE_READ_PROFILE.REMOTE,
+          sourceId: "remote-url:gs://bucket/runs/drive.mcap",
+          url: "https://signed.example.com/file.mcap?token=secret",
+        },
+      });
+      expect(resolver).toHaveBeenCalledWith("gs://bucket/runs/drive.mcap");
+    } finally {
+      unregister();
+    }
+  });
+
+  it("preserves dot segments that may be literal cloud object keys", async () => {
+    const resolver = vi.fn(
+      async () => "https://signed.example.com/file.mcap?token=secret",
+    );
+    const unregister = registerMcapCloudSourceResolver(resolver);
+
+    try {
+      const descriptor = await resolveRemoteMcapSourceDescriptor(
+        " s3://bucket/runs/../drive.mcap ",
+      );
+
+      expect(resolver).toHaveBeenCalledWith("s3://bucket/runs/../drive.mcap");
+      expect(descriptor.source.sourceId).toBe(
+        "remote-url:s3://bucket/runs/../drive.mcap",
+      );
+    } finally {
+      unregister();
+    }
+  });
+
+  it("rejects a non-HTTP response from the cloud resolver", async () => {
+    const unregister = registerMcapCloudSourceResolver(
+      async () => "s3://bucket/still-raw.mcap",
+    );
+
+    try {
+      await expect(
+        resolveRemoteMcapSourceDescriptor("s3://bucket/file.mcap"),
+      ).rejects.toThrow("server did not return a valid signed MCAP URL");
+    } finally {
+      unregister();
+    }
   });
 });

--- a/app/packages/multimodal/src/views/mcap-explorer/source-descriptors.test.ts
+++ b/app/packages/multimodal/src/views/mcap-explorer/source-descriptors.test.ts
@@ -62,7 +62,7 @@ describe("any MCAP source descriptors", () => {
     );
   });
 
-  it("keeps cloud paths Enterprise-only when no resolver is registered", async () => {
+  it("rejects cloud paths when no resolver is registered", async () => {
     await expect(
       resolveRemoteMcapSourceDescriptor("s3://bucket/file.mcap"),
     ).rejects.toThrow("Only HTTP(S) MCAP URLs are supported");

--- a/app/packages/multimodal/src/views/mcap-explorer/source-descriptors.ts
+++ b/app/packages/multimodal/src/views/mcap-explorer/source-descriptors.ts
@@ -45,8 +45,8 @@ export function createRemoteMcapSourceDescriptor(
 /**
  * Resolves user input into a browser-readable MCAP source.
  *
- * HTTP(S) URLs pass through. Other ``scheme://`` paths require an
- * edition-provided cloud resolver, which is registered only by Enterprise.
+ * HTTP(S) URLs pass through. Other ``scheme://`` paths require a
+ * product-provided cloud resolver.
  */
 export async function resolveRemoteMcapSourceDescriptor(
   value: string,

--- a/app/packages/multimodal/src/views/mcap-explorer/source-descriptors.ts
+++ b/app/packages/multimodal/src/views/mcap-explorer/source-descriptors.ts
@@ -1,4 +1,5 @@
 import { BYTE_SOURCE_READ_PROFILE, type ByteSourceDescriptor } from "../../ir";
+import { getMcapCloudSourceResolver } from "../../extensions/mcap-explorer";
 import { sourceDisplayName } from "../episode";
 
 export interface AnyMcapSourceDescriptor {
@@ -29,31 +30,93 @@ export function createLocalMcapSourceDescriptor(
 export function createRemoteMcapSourceDescriptor(
   value: string,
 ): AnyMcapSourceDescriptor {
-  const trimmed = value.trim();
-  if (!trimmed) {
+  if (!value.trim()) {
     throw new Error("Enter an HTTP(S) MCAP URL");
   }
 
-  let url: URL;
-  try {
-    url = new URL(trimmed);
-  } catch {
-    throw new Error("Enter a valid HTTP(S) URL");
+  const href = parseHttpUrl(
+    value,
+    "Enter a valid HTTP(S) URL",
+    "Only HTTP(S) MCAP URLs are supported",
+  );
+  return createResolvedRemoteMcapSourceDescriptor(href, href);
+}
+
+/**
+ * Resolves user input into a browser-readable MCAP source.
+ *
+ * HTTP(S) URLs pass through. Other ``scheme://`` paths require an
+ * edition-provided cloud resolver, which is registered only by Enterprise.
+ */
+export async function resolveRemoteMcapSourceDescriptor(
+  value: string,
+): Promise<AnyMcapSourceDescriptor> {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error("Enter an HTTP(S) MCAP URL or cloud path");
   }
 
-  if (url.protocol !== "http:" && url.protocol !== "https:") {
+  let sourceUrl: URL;
+  try {
+    sourceUrl = new URL(trimmed);
+  } catch {
+    throw new Error("Enter a valid HTTP(S) URL or cloud path");
+  }
+
+  if (sourceUrl.protocol === "http:" || sourceUrl.protocol === "https:") {
+    return createRemoteMcapSourceDescriptor(sourceUrl.toString());
+  }
+
+  if (!/^[a-z][a-z\d+.-]*:\/\//i.test(trimmed)) {
+    throw new Error("Enter a valid HTTP(S) URL or cloud path");
+  }
+
+  const resolveCloudSource = getMcapCloudSourceResolver();
+  if (!resolveCloudSource) {
     throw new Error("Only HTTP(S) MCAP URLs are supported");
   }
 
-  const href = url.toString();
+  const cloudPath = trimmed;
+  const signedUrl = await resolveCloudSource(cloudPath);
+  const href = parseHttpUrl(
+    signedUrl,
+    "The server did not return a valid signed MCAP URL",
+  );
+
+  return createResolvedRemoteMcapSourceDescriptor(cloudPath, href);
+}
+
+function createResolvedRemoteMcapSourceDescriptor(
+  sourceIdentity: string,
+  href: string,
+): AnyMcapSourceDescriptor {
   return {
-    fileName: sourceDisplayName(href) ?? "remote.mcap",
+    fileName: sourceDisplayName(sourceIdentity) ?? "remote.mcap",
     source: {
       readProfile: BYTE_SOURCE_READ_PROFILE.REMOTE,
-      sourceId: `remote-url:${href}`,
+      sourceId: `remote-url:${sourceIdentity}`,
       url: href,
     },
   };
+}
+
+function parseHttpUrl(
+  value: string,
+  invalidMessage: string,
+  unsupportedProtocolMessage = invalidMessage,
+): string {
+  let url: URL;
+  try {
+    url = new URL(value.trim());
+  } catch {
+    throw new Error(invalidMessage);
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error(unsupportedProtocolMessage);
+  }
+
+  return url.toString();
 }
 
 export function isMcapFile(file: File): boolean {


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

Adds an optional product extension point for resolving configured storage paths before MCAP byte reads. The default behavior remains HTTP(S)-only; registered products can supply browser-readable URLs without forking the Explorer UI.

## 🧪 How is this patch tested? If it is not, please explain why.

- `yarn vitest run packages/multimodal/src/views/mcap-explorer/McapExplorerPanel.test.tsx packages/multimodal/src/views/mcap-explorer/source-descriptors.test.ts --no-coverage` (17 tests)
- `yarn workspace @fiftyone/multimodal check`
- CodeRabbit review of the substantive feature diff (0 findings)

## Notes to Reviewer

The shared `extensions/mcap-explorer` package owns only the optional resolver contract and lifecycle. Product-specific network behavior stays outside the shared Explorer.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

N/A

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3713
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional support for opening MCAP files from cloud storage paths.
  * Cloud paths can be resolved into browser-accessible URLs through a registered resolver.
  * Preserved original source identities while using resolved URLs for playback.
  * Added loading and error states while remote sources are opening.
  * URL input now accepts cloud paths and displays clearer help text.

* **Documentation**
  * Documented supported HTTP(S) sources and optional cloud-path resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->