### PR TITLE
embeddings-v2: world-model camera — pan at fit, zoom out past fit

### DIFF
--- a/app/packages/embeddings-v2/src/renderer/cameras/PlanarCamera.test.ts
+++ b/app/packages/embeddings-v2/src/renderer/cameras/PlanarCamera.test.ts
@@ -1,5 +1,7 @@
 // @vitest-environment jsdom
 import { describe, expect, it, vi } from "vitest";
+import { DEFAULT_ZOOM, MARGIN } from "../constants";
+import { fitRect } from "../math";
 import { PlanarCamera } from "./PlanarCamera";
 
 const BOUNDS = {
@@ -53,10 +55,27 @@ describe("PlanarCamera.toDataPolygon", () => {
   });
 });
 
+describe("PlanarCamera default view", () => {
+  // Load and reset land at DEFAULT_ZOOM, not fit: the cloud gets
+  // breathing room around it and pan works immediately
+  it("starts slightly zoomed out of fit", () => {
+    const element = document.createElement("div");
+    const camera = new PlanarCamera(element, vi.fn());
+    camera.setBounds(BOUNDS, 100, 100);
+
+    const home = fitRect(BOUNDS, 100, 100, MARGIN);
+    expect(camera.camera.right - camera.camera.left).toBeCloseTo(
+      (home.x1 - home.x0) / DEFAULT_ZOOM,
+    );
+
+    camera.destroy();
+  });
+});
+
 describe("PlanarCamera pan", () => {
-  // The world model's headline: panning works at the default fit view
+  // The world model's headline: panning works at the default view
   // (the window is smaller than the world), and reset recovers
-  it("pans at the fit view, and reset recenters", () => {
+  it("pans at the default view, and reset recenters", () => {
     const element = document.createElement("div");
     // jsdom has no pointer capture; the pan handlers call it
     element.setPointerCapture = vi.fn();
@@ -92,32 +111,38 @@ describe("PlanarCamera focus", () => {
     (camera.bottom + camera.top) / 2,
   ];
 
+  const expectCentered = (camera: PlanarCamera["camera"]) => {
+    const [cx, cy] = center(camera);
+    expect(cx).toBeCloseTo(5);
+    expect(cy).toBeCloseTo(5);
+  };
+
   // Legend/filter hides move the interesting region; reset must follow
   // it — and forget it again when everything is visible or data changes
   it("reset frames the focus, and setBounds clears it", () => {
     const element = document.createElement("div");
     const camera = new PlanarCamera(element, vi.fn());
     camera.setBounds(BOUNDS, 100, 100);
-    const homeWidth = camera.camera.right - camera.camera.left;
+    const defaultWidth = camera.camera.right - camera.camera.left;
 
     camera.setFocus({ xMin: 7, xMax: 9, yMin: 1, yMax: 3, zMin: 0, zMax: 0 });
     // No immediate movement — focus only steers the next reset
-    expect(center(camera.camera)).toEqual([5, 5]);
+    expectCentered(camera.camera);
 
     camera.reset();
     const [cx, cy] = center(camera.camera);
     expect(cx).toBeCloseTo(8);
     expect(cy).toBeCloseTo(2);
-    expect(camera.camera.right - camera.camera.left).toBeLessThan(homeWidth);
+    expect(camera.camera.right - camera.camera.left).toBeLessThan(defaultWidth);
 
     camera.setFocus(null);
     camera.reset();
-    expect(center(camera.camera)).toEqual([5, 5]);
+    expectCentered(camera.camera);
 
     camera.setFocus({ xMin: 7, xMax: 9, yMin: 1, yMax: 3, zMin: 0, zMax: 0 });
     camera.setBounds(BOUNDS, 100, 100);
     camera.reset();
-    expect(center(camera.camera)).toEqual([5, 5]);
+    expectCentered(camera.camera);
 
     camera.destroy();
   });

--- a/app/packages/embeddings-v2/src/renderer/cameras/PlanarCamera.test.ts
+++ b/app/packages/embeddings-v2/src/renderer/cameras/PlanarCamera.test.ts
@@ -138,6 +138,9 @@ describe("PlanarCamera focus", () => {
     camera.setFocus(null);
     camera.reset();
     expectCentered(camera.camera);
+    // Back to the DEFAULT view, not the fit view — center alone can't
+    // tell those apart
+    expect(camera.camera.right - camera.camera.left).toBeCloseTo(defaultWidth);
 
     camera.setFocus({ xMin: 7, xMax: 9, yMin: 1, yMax: 3, zMin: 0, zMax: 0 });
     camera.setBounds(BOUNDS, 100, 100);

--- a/app/packages/embeddings-v2/src/renderer/cameras/PlanarCamera.test.ts
+++ b/app/packages/embeddings-v2/src/renderer/cameras/PlanarCamera.test.ts
@@ -53,6 +53,39 @@ describe("PlanarCamera.toDataPolygon", () => {
   });
 });
 
+describe("PlanarCamera pan", () => {
+  // The world model's headline: panning works at the default fit view
+  // (the window is smaller than the world), and reset recovers
+  it("pans at the fit view, and reset recenters", () => {
+    const element = document.createElement("div");
+    // jsdom has no pointer capture; the pan handlers call it
+    element.setPointerCapture = vi.fn();
+    const camera = new PlanarCamera(element, vi.fn());
+    camera.setBounds(BOUNDS, 100, 100);
+    camera.setMode("explore");
+
+    const pointer = (type: string, init: Record<string, unknown>) =>
+      element.dispatchEvent(Object.assign(new Event(type), init));
+
+    pointer("pointerdown", {
+      pointerId: 1,
+      button: 0,
+      offsetX: 80,
+      offsetY: 50,
+    });
+    pointer("pointermove", { pointerId: 1, offsetX: 40, offsetY: 50 });
+    pointer("pointerup", { pointerId: 1 });
+
+    const panned = (camera.camera.left + camera.camera.right) / 2;
+    expect(panned).toBeGreaterThan(5);
+
+    camera.reset();
+    expect((camera.camera.left + camera.camera.right) / 2).toBeCloseTo(5);
+
+    camera.destroy();
+  });
+});
+
 describe("PlanarCamera focus", () => {
   const center = (camera: PlanarCamera["camera"]) => [
     (camera.left + camera.right) / 2,

--- a/app/packages/embeddings-v2/src/renderer/cameras/PlanarCamera.ts
+++ b/app/packages/embeddings-v2/src/renderer/cameras/PlanarCamera.ts
@@ -1,5 +1,5 @@
 import { OrthographicCamera } from "three";
-import { MARGIN, MAX_ZOOM, PAN_GIVE } from "../constants";
+import { MARGIN, MAX_ZOOM } from "../constants";
 import {
   clampToHome,
   fitRect,
@@ -165,14 +165,7 @@ export class PlanarCamera implements CameraAdapter {
       event.offsetX,
       event.offsetY,
     );
-    this.rect = zoomRect(
-      this.rect,
-      this.home,
-      focus,
-      factor,
-      MAX_ZOOM,
-      PAN_GIVE,
-    );
+    this.rect = zoomRect(this.rect, this.home, focus, factor, MAX_ZOOM);
     this.apply();
   }
 
@@ -200,7 +193,6 @@ export class PlanarCamera implements CameraAdapter {
       this.home,
       -(event.offsetX - lastX) * perPxX,
       (event.offsetY - lastY) * perPxY,
-      PAN_GIVE,
     );
     this.apply();
   }

--- a/app/packages/embeddings-v2/src/renderer/cameras/PlanarCamera.ts
+++ b/app/packages/embeddings-v2/src/renderer/cameras/PlanarCamera.ts
@@ -1,5 +1,5 @@
 import { OrthographicCamera } from "three";
-import { MARGIN, MAX_ZOOM, MIN_ZOOM } from "../constants";
+import { DEFAULT_ZOOM, MARGIN, MAX_ZOOM, MIN_ZOOM } from "../constants";
 import {
   clampToHome,
   fitRect,
@@ -32,6 +32,8 @@ export class PlanarCamera implements CameraAdapter {
   // The pannable space (see worldRect): every zoom level is a window
   // that must stay inside it
   private world: Rect = this.home;
+  // Where first load and reset land: the view at DEFAULT_ZOOM
+  private defaultView: Rect = this.home;
   private rect: Rect = this.home;
   private width = 1;
   private height = 1;
@@ -91,7 +93,8 @@ export class PlanarCamera implements CameraAdapter {
     this.height = height;
     this.home = fitRect(bounds, width, height, MARGIN);
     this.world = worldRect(this.home, MIN_ZOOM);
-    this.rect = this.home;
+    this.defaultView = worldRect(this.home, DEFAULT_ZOOM);
+    this.rect = this.defaultView;
     this.apply();
   }
 
@@ -110,6 +113,7 @@ export class PlanarCamera implements CameraAdapter {
     const cy = (this.rect.y0 + this.rect.y1) / 2;
     this.home = fitRect(this.bounds, width, height, MARGIN);
     this.world = worldRect(this.home, MIN_ZOOM);
+    this.defaultView = worldRect(this.home, DEFAULT_ZOOM);
     const w = (this.home.x1 - this.home.x0) / k;
     const h = (this.home.y1 - this.home.y0) / k;
     this.rect = clampToHome(
@@ -120,7 +124,7 @@ export class PlanarCamera implements CameraAdapter {
   }
 
   reset(): void {
-    this.rect = this.focus ? this.frameFocus(this.focus) : this.home;
+    this.rect = this.focus ? this.frameFocus(this.focus) : this.defaultView;
     this.apply();
   }
 

--- a/app/packages/embeddings-v2/src/renderer/cameras/PlanarCamera.ts
+++ b/app/packages/embeddings-v2/src/renderer/cameras/PlanarCamera.ts
@@ -1,10 +1,11 @@
 import { OrthographicCamera } from "three";
-import { MARGIN, MAX_ZOOM } from "../constants";
+import { MARGIN, MAX_ZOOM, MIN_ZOOM } from "../constants";
 import {
   clampToHome,
   fitRect,
   panRect,
   pxToData,
+  worldRect,
   zoomOf,
   zoomRect,
   type Rect,
@@ -28,6 +29,9 @@ export class PlanarCamera implements CameraAdapter {
   private bounds: Bounds | null = null;
   private focus: Bounds | null = null;
   private home: Rect = { x0: -1, y0: -1, x1: 1, y1: 1 };
+  // The pannable space (see worldRect): every zoom level is a window
+  // that must stay inside it
+  private world: Rect = this.home;
   private rect: Rect = this.home;
   private width = 1;
   private height = 1;
@@ -86,6 +90,7 @@ export class PlanarCamera implements CameraAdapter {
     this.width = width;
     this.height = height;
     this.home = fitRect(bounds, width, height, MARGIN);
+    this.world = worldRect(this.home, MIN_ZOOM);
     this.rect = this.home;
     this.apply();
   }
@@ -104,11 +109,12 @@ export class PlanarCamera implements CameraAdapter {
     const cx = (this.rect.x0 + this.rect.x1) / 2;
     const cy = (this.rect.y0 + this.rect.y1) / 2;
     this.home = fitRect(this.bounds, width, height, MARGIN);
+    this.world = worldRect(this.home, MIN_ZOOM);
     const w = (this.home.x1 - this.home.x0) / k;
     const h = (this.home.y1 - this.home.y0) / k;
     this.rect = clampToHome(
       { x0: cx - w / 2, x1: cx + w / 2, y0: cy - h / 2, y1: cy + h / 2 },
-      this.home,
+      this.world,
     );
     this.apply();
   }
@@ -133,7 +139,7 @@ export class PlanarCamera implements CameraAdapter {
     const cy = (focus.yMin + focus.yMax) / 2;
     return clampToHome(
       { x0: cx - w / 2, x1: cx + w / 2, y0: cy - h / 2, y1: cy + h / 2 },
-      this.home,
+      this.world,
     );
   }
 
@@ -165,7 +171,14 @@ export class PlanarCamera implements CameraAdapter {
       event.offsetX,
       event.offsetY,
     );
-    this.rect = zoomRect(this.rect, this.home, focus, factor, MAX_ZOOM);
+    this.rect = zoomRect(
+      this.rect,
+      this.home,
+      focus,
+      factor,
+      MAX_ZOOM,
+      this.world,
+    );
     this.apply();
   }
 
@@ -190,7 +203,7 @@ export class PlanarCamera implements CameraAdapter {
     const perPxY = (this.rect.y1 - this.rect.y0) / this.height;
     this.rect = panRect(
       this.rect,
-      this.home,
+      this.world,
       -(event.offsetX - lastX) * perPxX,
       (event.offsetY - lastY) * perPxY,
     );

--- a/app/packages/embeddings-v2/src/renderer/constants.ts
+++ b/app/packages/embeddings-v2/src/renderer/constants.ts
@@ -42,6 +42,14 @@ export const MARGIN = 24;
 /** Max planar zoom-in factor relative to the home view */
 export const MAX_ZOOM = 50;
 
+/** Min planar zoom-out factor relative to the home view: 0.5 = the
+ * data can shrink to half the viewport. This also defines the camera's
+ * world (see worldRect) — the fixed pannable space every zoom level
+ * is a window into — so the default fit view can pan about half a
+ * viewport in each direction, and lassoing around the entire cloud
+ * has breathing room (FOEPD user asks, 08-11) */
+export const MIN_ZOOM = 0.5;
+
 /** Pointer must sit still this long before a hover hit-test runs */
 export const HOVER_DEBOUNCE_MS = 120;
 

--- a/app/packages/embeddings-v2/src/renderer/constants.ts
+++ b/app/packages/embeddings-v2/src/renderer/constants.ts
@@ -42,13 +42,20 @@ export const MARGIN = 24;
 /** Max planar zoom-in factor relative to the home view */
 export const MAX_ZOOM = 50;
 
-/** Min planar zoom-out factor relative to the home view: 0.5 = the
- * data can shrink to half the viewport. This also defines the camera's
- * world (see worldRect) — the fixed pannable space every zoom level
- * is a window into — so the default fit view can pan about half a
- * viewport in each direction, and lassoing around the entire cloud
- * has breathing room (FOEPD user asks, 08-11) */
-export const MIN_ZOOM = 0.5;
+/**
+ * Zoom level of the default view (first load and reset), measured like
+ * the other zoom constants against the fit view (1 = fit). Slightly
+ * out of fit, so the cloud lands with breathing room around it and pan
+ * works immediately. Must stay above MIN_ZOOM.
+ */
+export const DEFAULT_ZOOM = 0.9;
+
+/** Min planar zoom-out factor relative to the fit view. Defines the
+ * camera's world (see worldRect) — the fixed pannable space every zoom
+ * level is a window into — so any view above the floor has pan room,
+ * and lassoing around the entire cloud has breathing room (FOEPD user
+ * asks, 08-11) */
+export const MIN_ZOOM = 0.55;
 
 /** Pointer must sit still this long before a hover hit-test runs */
 export const HOVER_DEBOUNCE_MS = 120;

--- a/app/packages/embeddings-v2/src/renderer/constants.ts
+++ b/app/packages/embeddings-v2/src/renderer/constants.ts
@@ -42,16 +42,6 @@ export const MARGIN = 24;
 /** Max planar zoom-in factor relative to the home view */
 export const MAX_ZOOM = 50;
 
-/** Camera clamp give, as a fraction of the viewport per side: how far
- * the data may sit off-frame. Nonzero so dragging still responds at
- * full zoom-out (FOEPD-4318); pan and zoom clamp against the same
- * inflated bounds, so zooming never yanks an offset view back —
- * only the header's reset recenters. Tuned by feel: high enough that
- * a full-zoom-out drag visibly responds, low enough that a zoomed-in
- * pan can't strand the view in empty space and a give-preserving
- * zoom-out still shows nearly the whole graph */
-export const PAN_GIVE = 0.1;
-
 /** Pointer must sit still this long before a hover hit-test runs */
 export const HOVER_DEBOUNCE_MS = 120;
 

--- a/app/packages/embeddings-v2/src/renderer/math.test.ts
+++ b/app/packages/embeddings-v2/src/renderer/math.test.ts
@@ -8,6 +8,7 @@ import {
   pointInPolygon,
   pxToData,
   selectInPolygon,
+  worldRect,
   zoomOf,
   zoomRect,
   type Rect,
@@ -142,6 +143,34 @@ describe("zoomRect / panRect / clampToHome", () => {
       x1: 2,
       y1: 5,
     });
+  });
+
+  it("builds the world by scaling home about its center", () => {
+    expect(worldRect(home, 0.5)).toEqual({ x0: -5, y0: -5, x1: 15, y1: 15 });
+    expect(worldRect(home, 1)).toEqual(home);
+  });
+
+  // The world model's headline: the fit view is smaller than the
+  // world, so panning works at the default view — up to the world edge
+  it("pans the fit view within the world", () => {
+    const world = worldRect(home, 0.5);
+    expect(panRect(home, world, 3, 0)).toEqual({
+      x0: 3,
+      y0: 0,
+      x1: 13,
+      y1: 10,
+    });
+    expect(panRect(home, world, 100, 0)).toEqual({
+      x0: 5,
+      y0: 0,
+      x1: 15,
+      y1: 10,
+    });
+  });
+
+  it("zooms out past fit to the world, never beyond", () => {
+    const world = worldRect(home, 0.5);
+    expect(zoomRect(home, home, [5, 5], 0.1, 50, world)).toEqual(world);
   });
 });
 

--- a/app/packages/embeddings-v2/src/renderer/math.test.ts
+++ b/app/packages/embeddings-v2/src/renderer/math.test.ts
@@ -172,6 +172,17 @@ describe("zoomRect / panRect / clampToHome", () => {
     const world = worldRect(home, 0.5);
     expect(zoomRect(home, home, [5, 5], 0.1, 50, world)).toEqual(world);
   });
+
+  // Regression: bounds must not move during a zoom — clamping against
+  // home instead of the world yanked a panned view back toward center
+  it("zooming in from a panned fit view stays put", () => {
+    const world = worldRect(home, 0.5);
+    const panned = panRect(home, world, 3, 0);
+    const zoomed = zoomRect(panned, home, [8, 5], 2, 50, world);
+    expect((zoomed.x0 + zoomed.x1) / 2).toBeCloseTo(8);
+    expect((8 - zoomed.x0) / (zoomed.x1 - zoomed.x0)).toBeCloseTo(0.5);
+    expect(zoomOf(zoomed, home)).toBeCloseTo(2);
+  });
 });
 
 describe("pointInPolygon", () => {

--- a/app/packages/embeddings-v2/src/renderer/math.test.ts
+++ b/app/packages/embeddings-v2/src/renderer/math.test.ts
@@ -135,48 +135,6 @@ describe("zoomRect / panRect / clampToHome", () => {
     });
   });
 
-  // Zooming from an overpanned view must not yank the view back to
-  // the data — the give bounds zoom exactly as they bound pan
-  it("zoom preserves an overpanned offset within the give", () => {
-    const offset: Rect = { x0: 3, y0: 0, x1: 13, y1: 10 };
-
-    // Zoom in around (8, 5): focus keeps its relative spot, no slide
-    expect(zoomRect(offset, home, [8, 5], 2, 50, 0.5)).toEqual({
-      x0: 5.5,
-      y0: 2.5,
-      x1: 10.5,
-      y1: 7.5,
-    });
-    // Without give, the strict clamp slides the same zoom back inside
-    expect(zoomRect(offset, home, [8, 5], 2, 50)).toEqual({
-      x0: 5,
-      y0: 2.5,
-      x1: 10,
-      y1: 7.5,
-    });
-  });
-
-  // FOEPD-4318: with no give, panning at full zoom-out is a no-op —
-  // the drag feels dead. Give lets the view slide, bounded so the
-  // data's edge stops at the viewport's center (give 0.5)
-  it("pans at full zoom-out within the give", () => {
-    expect(panRect(home, home, 3, 0)).toEqual(home);
-
-    expect(panRect(home, home, 3, 0, 0.5)).toEqual({
-      x0: 3,
-      y0: 0,
-      x1: 13,
-      y1: 10,
-    });
-    // The give is the cap: a huge delta stops half a viewport out
-    expect(panRect(home, home, 100, 0, 0.5)).toEqual({
-      x0: 5,
-      y0: 0,
-      x1: 15,
-      y1: 10,
-    });
-  });
-
   it("slides an out-of-bounds rect back inside home", () => {
     expect(clampToHome({ x0: -1, y0: 3, x1: 1, y1: 5 }, home)).toEqual({
       x0: 0,

--- a/app/packages/embeddings-v2/src/renderer/math.ts
+++ b/app/packages/embeddings-v2/src/renderer/math.ts
@@ -84,16 +84,18 @@ export function clampToHome(rect: Rect, home: Rect): Rect {
 }
 
 /**
- * The camera's world: the view at minimum zoom, home scaled about its
- * center by 1/minZoom. Every zoom level is a window into this fixed
- * rect and the single camera rule is "the window stays inside the
- * world" — so pan already works at the default fit view (the window is
- * smaller than the world), zooming out grows the window toward the
- * world, and the view is never more lost than reset can recover.
+ * The centered view at `zoom` (<1 = zoomed out): home scaled about its
+ * center by 1/zoom. The camera builds two fixed rects with this. The
+ * world — the view at MIN_ZOOM — is the pannable space, and the single
+ * camera rule is "every window stays inside the world": so any view
+ * above the floor has pan room, zooming out grows the window toward
+ * the world, and the view is never more lost than reset can recover.
+ * The default view — DEFAULT_ZOOM, where load and reset land — is the
+ * same scaling, slightly out of fit.
  */
-export function worldRect(home: Rect, minZoom: number): Rect {
-  const gx = ((home.x1 - home.x0) * (1 / minZoom - 1)) / 2;
-  const gy = ((home.y1 - home.y0) * (1 / minZoom - 1)) / 2;
+export function worldRect(home: Rect, zoom: number): Rect {
+  const gx = ((home.x1 - home.x0) * (1 / zoom - 1)) / 2;
+  const gy = ((home.y1 - home.y0) * (1 / zoom - 1)) / 2;
   return {
     x0: home.x0 - gx,
     x1: home.x1 + gx,

--- a/app/packages/embeddings-v2/src/renderer/math.ts
+++ b/app/packages/embeddings-v2/src/renderer/math.ts
@@ -84,9 +84,29 @@ export function clampToHome(rect: Rect, home: Rect): Rect {
 }
 
 /**
+ * The camera's world: the view at minimum zoom, home scaled about its
+ * center by 1/minZoom. Every zoom level is a window into this fixed
+ * rect and the single camera rule is "the window stays inside the
+ * world" — so pan already works at the default fit view (the window is
+ * smaller than the world), zooming out grows the window toward the
+ * world, and the view is never more lost than reset can recover.
+ */
+export function worldRect(home: Rect, minZoom: number): Rect {
+  const gx = ((home.x1 - home.x0) * (1 / minZoom - 1)) / 2;
+  const gy = ((home.y1 - home.y0) * (1 / minZoom - 1)) / 2;
+  return {
+    x0: home.x0 - gx,
+    x1: home.x1 + gx,
+    y0: home.y0 - gy,
+    y1: home.y1 + gy,
+  };
+}
+
+/**
  * Zoom by `factor` (>1 = in) keeping the data point under `focus`
- * stationary, clamped to [1, maxZoom] relative to home and panned back
- * inside home's bounds.
+ * stationary. The zoom level is measured against `home` (1 = fit),
+ * capped at maxZoom; the floor falls out of `world` — the window can
+ * grow no larger than the world it must stay inside.
  */
 export function zoomRect(
   rect: Rect,
@@ -94,8 +114,10 @@ export function zoomRect(
   focus: [number, number],
   factor: number,
   maxZoom: number,
+  world = home,
 ): Rect {
-  const k = Math.min(Math.max(zoomOf(rect, home) * factor, 1), maxZoom);
+  const minZoom = (home.x1 - home.x0) / (world.x1 - world.x0);
+  const k = Math.min(Math.max(zoomOf(rect, home) * factor, minZoom), maxZoom);
   const w = (home.x1 - home.x0) / k;
   const h = (home.y1 - home.y0) / k;
   const [fx, fy] = focus;
@@ -109,15 +131,21 @@ export function zoomRect(
       y0: fy - ry * h,
       y1: fy + (1 - ry) * h,
     },
-    home,
+    world,
   );
 }
 
-/** Pan by a data-space delta, clamped inside home */
-export function panRect(rect: Rect, home: Rect, dx: number, dy: number): Rect {
+/** Pan by a data-space delta, clamped inside `bounds` (the camera
+ * passes its world, so panning works at any zoom above the floor) */
+export function panRect(
+  rect: Rect,
+  bounds: Rect,
+  dx: number,
+  dy: number,
+): Rect {
   return clampToHome(
     { x0: rect.x0 + dx, x1: rect.x1 + dx, y0: rect.y0 + dy, y1: rect.y1 + dy },
-    home,
+    bounds,
   );
 }
 

--- a/app/packages/embeddings-v2/src/renderer/math.ts
+++ b/app/packages/embeddings-v2/src/renderer/math.ts
@@ -85,11 +85,8 @@ export function clampToHome(rect: Rect, home: Rect): Rect {
 
 /**
  * Zoom by `factor` (>1 = in) keeping the data point under `focus`
- * stationary, clamped to [1, maxZoom] relative to home and slid back
- * inside the pannable bounds. `give` inflates those bounds exactly as
- * in panRect — zooming from an overpanned view must not yank the view
- * back (the give shrinks with the rect, so deep zoom-ins drift toward
- * the data on their own).
+ * stationary, clamped to [1, maxZoom] relative to home and panned back
+ * inside home's bounds.
  */
 export function zoomRect(
   rect: Rect,
@@ -97,7 +94,6 @@ export function zoomRect(
   focus: [number, number],
   factor: number,
   maxZoom: number,
-  give = 0,
 ): Rect {
   const k = Math.min(Math.max(zoomOf(rect, home) * factor, 1), maxZoom);
   const w = (home.x1 - home.x0) / k;
@@ -106,8 +102,6 @@ export function zoomRect(
   // Keep the focus point at the same relative position in the new rect
   const rx = (fx - rect.x0) / (rect.x1 - rect.x0);
   const ry = (fy - rect.y0) / (rect.y1 - rect.y0);
-  const gx = give * w;
-  const gy = give * h;
   return clampToHome(
     {
       x0: fx - rx * w,
@@ -115,31 +109,15 @@ export function zoomRect(
       y0: fy - ry * h,
       y1: fy + (1 - ry) * h,
     },
-    { x0: home.x0 - gx, x1: home.x1 + gx, y0: home.y0 - gy, y1: home.y1 + gy },
+    home,
   );
 }
 
-/**
- * Pan by a data-space delta. `give` loosens the home clamp by that
- * fraction of the viewport per side, so a drag still moves the view
- * when the rect already spans home (fully zoomed out) — without it
- * every delta clamps straight back and the drag feels dead
- * (FOEPD-4318). The data can be pushed at most `give` of a viewport
- * off-frame, never lost. zoomRect honors the same give, so zooming
- * from an offset view stays put; reset is what recenters.
- */
-export function panRect(
-  rect: Rect,
-  home: Rect,
-  dx: number,
-  dy: number,
-  give = 0,
-): Rect {
-  const gx = give * (rect.x1 - rect.x0);
-  const gy = give * (rect.y1 - rect.y0);
+/** Pan by a data-space delta, clamped inside home */
+export function panRect(rect: Rect, home: Rect, dx: number, dy: number): Rect {
   return clampToHome(
     { x0: rect.x0 + dx, x1: rect.x1 + dx, y0: rect.y0 + dy, y1: rect.y1 + dy },
-    { x0: home.x0 - gx, x1: home.x1 + gx, y0: home.y0 - gy, y1: home.y1 + gy },
+    home,
   );
 }
 


### PR DESCRIPTION
## 🔗 Related Issues

Supersedes the pan-give approach from #8220 (FOEPD-4318), which is reverted in this PR's first commit. Also addresses the zoom-out request reported in Slack (lassoing around the entire cloud needs breathing room).

## 📋 What changes are proposed in this pull request?

Replaces the embeddings-v2 planar camera's pan-give clamp with a world model. Two users hit the same wall from different directions — a dead drag at the fit view, and no way to zoom out past fit — and the wall was the design, not the clamp, so #8220's give is reverted rather than tuned further.

The new model: the camera gets a fixed world, defined as the view at `MIN_ZOOM` (0.55) — the home fit scaled about its center. Every zoom level is a window that must stay inside the world. That single rule replaces the give and everything users asked for falls out of it:

- Panning works at the default view, because the window is smaller than the world.
- Zooming out past fit works, growing the window toward the world, so lassoing around the whole cloud has room.
- No bounds inflate during gestures, so zooming from a panned view no longer yanks the camera back to center.
- The view can never get more lost than reset recovers.

The default view (first load and reset) now lands at `DEFAULT_ZOOM` (0.9), slightly out of fit, so the cloud has breathing room immediately.

## 🧪 How is this patch tested? If it is not, please explain why.

- New unit tests: `worldRect` scaling, panning the fit view within the world, the zoom-out floor reconstructing the world exactly, a regression test pinning the give-era snap-back bug (zooming from a panned view must stay put), the camera's pan-at-default-view behavior, and the `DEFAULT_ZOOM` landing contract. 204 tests pass in `embeddings-v2`.
- Manual feel-testing on a 300K-point dataset: pan at fit, zoom out to the floor (centers naturally), zoom in from a panned view (stays anchored), reset from every corner.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

The Embeddings panel's plot camera now supports zooming out slightly past the fitted view and panning from the default view, making it easier to lasso around an entire point cloud.

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved camera zooming and panning for smoother, more predictable navigation.
  * Added clear limits to prevent zooming out or panning beyond the available world.
  * Reset and focus actions now recenter views more reliably and provide tighter framing when appropriate.

* **Tests**
  * Expanded coverage for default zoom, panning, reset behavior, focus framing, and bounded navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3716
<!-- enterprise-sync-pr:end -->