### PR TITLE
Improve transform analysis and graph navigation

### DIFF
--- a/app/packages/multimodal/package.json
+++ b/app/packages/multimodal/package.json
@@ -128,6 +128,7 @@
         "@react-three/drei": "9.105.4",
         "@react-three/fiber": "catalog:",
         "@voxel51/voodo": "catalog:",
+        "@xyflow/react": "^12.4.4",
         "buffer": "catalog:",
         "colormap": "catalog:",
         "date-fns": "^4.1.0",

--- a/app/packages/multimodal/src/adapters/mcap/format-adapter.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/format-adapter.test.ts
@@ -313,6 +313,16 @@ describe("MCAP format adapter", () => {
             sourceName: "/tf",
             sourceStreamId: "/tf",
           },
+          {
+            childFrameId: "base_link",
+            firstObservedTimeNs: 150n,
+            kind: "static" as const,
+            lastObservedTimeNs: 160n,
+            occurrenceCount: 4,
+            parentFrameId: "map",
+            sourceName: "/tf",
+            sourceStreamId: "/tf",
+          },
         ],
         frameUses: [
           {
@@ -342,6 +352,17 @@ describe("MCAP format adapter", () => {
         stopReason: "source-exhausted" as const,
         usage: topologyUsage,
       });
+    vi.mocked(client.readFrameTransformBootstrap).mockResolvedValue({
+      samples: [
+        {
+          childFrameId: "base_link",
+          parentFrameId: "map",
+          rotation: new Quaternion(),
+          sourceName: "/tf",
+          translation: new Vector3(),
+        },
+      ],
+    });
     const session = await createMcapFormatAdapter({
       createClient: () => client,
     }).open(source, io);
@@ -366,6 +387,17 @@ describe("MCAP format adapter", () => {
         { priority: "bulk", signal: undefined },
       );
       expect(result?.edges[0]?.sourceStreamId).toBe("tf");
+      expect(result?.edges).toContainEqual(
+        expect.objectContaining({
+          childFrameId: "base_link",
+          firstObservedTimeNs: 1n,
+          kind: "static",
+          lastObservedTimeNs: 160n,
+          occurrenceCount: 4,
+          parentFrameId: "map",
+          sourceStreamId: "tf",
+        }),
+      );
       expect(result?.continuation).toBe(continuation);
 
       const resumed = await session.transformTopology?.scan({
@@ -379,22 +411,23 @@ describe("MCAP format adapter", () => {
       );
       expect(resumed?.frameUses).toEqual([
         {
-          frameId: "camera",
-          sourceName: "/camera",
-          streamId: "/camera",
-        },
-        {
           frameId: "lidar",
           sourceName: "/points",
           streamId: "points",
         },
+        {
+          frameId: "camera",
+          sourceName: "/camera",
+          streamId: "/camera",
+        },
       ]);
+      expect(client.readFrameTransformBootstrap).toHaveBeenCalledOnce();
     } finally {
       session.dispose();
     }
   });
 
-  it("charges failed topology grants conservatively", async () => {
+  it("authorizes each explicit topology grant independently", async () => {
     const client = createClient();
     vi.mocked(client.readTopics).mockResolvedValue(
       recordingInventory([
@@ -410,10 +443,10 @@ describe("MCAP format adapter", () => {
       throw new Error("transform decode failed");
     });
     const allowance = {
-      maxMessages: 10,
-      maxSourceBytes: 1_000,
-      maxUncompressedBytes: 2_000,
-      maxWallTimeMs: 100,
+      maxMessages: 40,
+      maxSourceBytes: 4_000,
+      maxUncompressedBytes: 8_000,
+      maxWallTimeMs: 400,
     };
     const session = await createMcapFormatAdapter({
       boundedSourceAllowance: allowance,
@@ -426,7 +459,116 @@ describe("MCAP format adapter", () => {
 
       await expect(
         session.transformTopology?.scan({ budget: allowance }),
-      ).resolves.toMatchObject({ stopReason: "account-exhausted" });
+      ).rejects.toThrow("transform decode failed");
+      expect(client.readTransformTopology).toHaveBeenCalledTimes(2);
+      expect(client.readFrameTransformBootstrap).toHaveBeenCalledTimes(2);
+      expect(client.readTransformTopology).toHaveBeenCalledWith(
+        expect.objectContaining({
+          absoluteBudget: allowance,
+          budget: allowance,
+        }),
+        expect.anything(),
+      );
+      expect(session.boundedRead?.openAccount(allowance).remaining()).toEqual({
+        maxMessages: 40,
+        maxSourceBytes: 4_000,
+        maxUncompressedBytes: 8_000,
+        maxWallTimeMs: 400,
+      });
+    } finally {
+      session.dispose();
+    }
+  });
+
+  it("allows explicit topology grants after general bounded reads exhaust", async () => {
+    const client = createClient();
+    vi.mocked(client.readTopics).mockResolvedValue(
+      recordingInventory([
+        create(StreamInventorySchema, {
+          displayName: "/tf",
+          metadata: { "mcap.topic": "/tf" },
+          payload: { encoding: "ros2", schema: "tf2_msgs/msg/TFMessage" },
+          streamId: "tf",
+        }),
+        create(StreamInventorySchema, {
+          displayName: "/camera",
+          metadata: { "mcap.topic": "/camera" },
+          payload: { encoding: "ros2", schema: "sensor_msgs/msg/Image" },
+          streamId: "camera",
+        }),
+      ]),
+    );
+    vi.mocked(client.readBoundedMessages).mockResolvedValue({
+      coverageByTopic: new Map(),
+      messages: [],
+      stopReason: "source-exhausted",
+      usage: {
+        chunksOpened: 4,
+        decompressedBytes: 128 * 1024 * 1024,
+        decompressionCacheHits: 0,
+        elapsedMs: 2_000,
+        logicalSourceBytes: 64 * 1024 * 1024,
+        logicalUncompressedBytes: 128 * 1024 * 1024,
+        messagesDecoded: 40_000,
+        transferredBytes: 64 * 1024 * 1024,
+      },
+    });
+    client.readTransformTopology = vi.fn(async () => ({
+      coverageByTopic: new Map(),
+      edges: [],
+      frameUses: [],
+      stopReason: "source-exhausted" as const,
+      usage: {
+        chunksOpened: 1,
+        decompressedBytes: 32 * 1024 * 1024,
+        decompressionCacheHits: 0,
+        elapsedMs: 500,
+        logicalSourceBytes: 16 * 1024 * 1024,
+        logicalUncompressedBytes: 32 * 1024 * 1024,
+        messagesDecoded: 10_000,
+        transferredBytes: 16 * 1024 * 1024,
+      },
+    }));
+    const allowance = {
+      maxMessages: 40_000,
+      maxSourceBytes: 64 * 1024 * 1024,
+      maxUncompressedBytes: 128 * 1024 * 1024,
+      maxWallTimeMs: 2_000,
+    };
+    const session = await createMcapFormatAdapter({
+      boundedSourceAllowance: allowance,
+      createClient: () => client,
+    }).open(source, io);
+    try {
+      const account = session.boundedRead?.openAccount(allowance);
+      await account?.createJob().read({
+        budget: {
+          maxMessages: 40_000,
+          maxSourceBytes: 64 * 1024 * 1024,
+          maxUncompressedBytes: 128 * 1024 * 1024,
+          maxWallTimeMs: 2_000,
+        },
+        streams: ["camera"],
+        window: { endNs: 2n, startNs: 1n },
+      });
+      expect(account?.remaining()).toEqual({
+        maxMessages: 0,
+        maxSourceBytes: 0,
+        maxUncompressedBytes: 0,
+        maxWallTimeMs: 0,
+      });
+
+      await expect(
+        session.transformTopology?.scan({
+          budget: {
+            maxMessages: 10_000,
+            maxSourceBytes: 16 * 1024 * 1024,
+            maxUncompressedBytes: 32 * 1024 * 1024,
+            maxWallTimeMs: 500,
+          },
+        }),
+      ).resolves.toMatchObject({ stopReason: "source-exhausted" });
+      expect(client.readFrameTransformBootstrap).toHaveBeenCalledOnce();
       expect(client.readTransformTopology).toHaveBeenCalledOnce();
     } finally {
       session.dispose();

--- a/app/packages/multimodal/src/adapters/mcap/format-adapter.ts
+++ b/app/packages/multimodal/src/adapters/mcap/format-adapter.ts
@@ -17,7 +17,6 @@ import {
   type SynchronizedFrameWindow,
   type TransformSample,
   type EpisodeTransformTopologyEdgeObservation,
-  type EpisodeTransformTopologyFrameUse,
 } from "../../ir";
 import {
   EpisodeReadCancelledError,
@@ -894,7 +893,6 @@ class McapEpisodeSession implements EpisodeSession {
   private returnedBatches = 0;
   private budgetAllowance?: ReadWorkBudget;
   private budgetLedger?: SourceReadBudgetLedger;
-  private topologyFrameUses?: readonly EpisodeTransformTopologyFrameUse[];
   private readonly sourceNamesById: ReadonlyMap<string, string>;
 
   constructor(
@@ -1387,7 +1385,7 @@ class McapEpisodeSession implements EpisodeSession {
           ...edge,
           sourceStreamId: this.streamIdFor(edge.sourceStreamId),
         })),
-        frameUses: this.topologyFrameUses ?? [],
+        frameUses: [],
         sampledAtNs,
       };
     } catch (error) {
@@ -1400,32 +1398,10 @@ class McapEpisodeSession implements EpisodeSession {
   ): Promise<TransformTopologyScanResult> {
     this.ensureOpen();
     throwIfAborted(request.signal);
-    // Opening is idempotent and shares the same cumulative ledger as every
-    // other background consumer for this source.
-    this.openBoundedReadAccount();
-    const ledger = this.budgetLedger;
-    const absoluteBudget = this.budgetAllowance;
-    if (!ledger || !absoluteBudget) {
-      throw new Error("MCAP source read budget account is not open");
-    }
-    const reservation = ledger.reserve(
-      request.budget,
-      this.boundedPolicy.maxChunksPerGrant,
-    );
-    if (!reservation) {
-      return {
-        ...(request.continuation ? { continuation: request.continuation } : {}),
-        coverageByStream: new Map(),
-        edges: [],
-        frameUses: this.topologyFrameUses ?? [],
-        stopReason: "account-exhausted",
-        usage: emptyReadWorkUsage(),
-      };
-    }
-
-    let completedUsage: ReadWorkUsage | undefined;
-    let reservationSettled = false;
     try {
+      const bootstrapEdges = request.continuation
+        ? []
+        : await this.readTransformTopologyBootstrap(request.signal);
       const readTransformTopology = this.client.readTransformTopology;
       if (!readTransformTopology) {
         throw new Error("MCAP transform topology reads are unavailable");
@@ -1433,10 +1409,10 @@ class McapEpisodeSession implements EpisodeSession {
       const result = await readTransformTopology.call(
         this.client,
         {
-          absoluteBudget,
+          absoluteBudget: request.budget,
           absoluteMaxChunks: this.boundedPolicy.maxChunksPerGrant,
           activeTimeline: MCAP_ACTIVE_TIMELINE.LOG,
-          budget: reservation.budget,
+          budget: request.budget,
           continuation: request.continuation,
           endTimeNs: this.manifest.timeRange.endNs,
           frameUseTopics: this.manifest.streams
@@ -1444,26 +1420,22 @@ class McapEpisodeSession implements EpisodeSession {
               DATA_BEARING_TOPOLOGY_STREAM_KINDS.has(stream.kind),
             )
             .map((stream) => stream.sourceName),
-          maxChunks: reservation.maxPhysicalUnits,
+          maxChunks: this.boundedPolicy.maxChunksPerGrant,
           source: this.source,
           startTimeNs: this.manifest.timeRange.startNs,
         },
         { priority: "bulk", signal: request.signal },
       );
-      completedUsage = result.usage;
       this.ensureOpen();
       throwIfAborted(request.signal);
-      reservationSettled = true;
-      reservation.commit(result.usage, result.usage.chunksOpened, {
-        exact: true,
-      });
-      this.topologyFrameUses = mergeTransformTopologyFrameUses(
-        this.topologyFrameUses ?? [],
-        result.frameUses.map((use) => ({
-          ...use,
-          streamId: this.streamIdFor(use.streamId),
-        })),
-      );
+      const frameUses = result.frameUses.map((use) => ({
+        ...use,
+        streamId: this.streamIdFor(use.streamId),
+      }));
+      const scannedEdges = result.edges.map((edge) => ({
+        ...edge,
+        sourceStreamId: this.streamIdFor(edge.sourceStreamId),
+      }));
       return {
         ...(result.continuation ? { continuation: result.continuation } : {}),
         coverageByStream: new Map(
@@ -1472,11 +1444,8 @@ class McapEpisodeSession implements EpisodeSession {
             windows,
           ]),
         ),
-        edges: result.edges.map((edge) => ({
-          ...edge,
-          sourceStreamId: this.streamIdFor(edge.sourceStreamId),
-        })),
-        frameUses: this.topologyFrameUses ?? [],
+        edges: mergeTransformTopologyEdges(bootstrapEdges, scannedEdges),
+        frameUses,
         stopReason: result.stopReason,
         ...(result.unavailableByTopic
           ? {
@@ -1495,19 +1464,30 @@ class McapEpisodeSession implements EpisodeSession {
         isMcapBoundedReadCancelledError(error) ||
         isEpisodeReadCancelledError(error) ||
         request.signal?.aborted === true;
-      if (!reservationSettled) {
-        const usage = cancelled
-          ? boundedCancellationUsage(error, completedUsage)
-          : emptyReadWorkUsage();
-        reservationSettled = true;
-        reservation.commit(usage, usage.chunksOpened, {
-          // A thrown read cannot prove that no physical work occurred. Keep
-          // the reservation conservative so retries cannot reset the account.
-          exact: false,
-        });
-      }
       if (cancelled) throw new EpisodeReadCancelledError();
       throw error;
+    }
+  }
+
+  private async readTransformTopologyBootstrap(
+    signal: AbortSignal | undefined,
+  ): Promise<readonly EpisodeTransformTopologyEdgeObservation[]> {
+    try {
+      const result = await this.client.readFrameTransformBootstrap(
+        { source: this.source },
+        { signal },
+      );
+      this.ensureOpen();
+      throwIfAborted(signal);
+      return topologyEdgesFromTransformSamples(
+        result.samples,
+        this.manifest.timeRange.startNs,
+      ).map((edge) => ({
+        ...edge,
+        sourceStreamId: this.streamIdFor(edge.sourceStreamId),
+      }));
+    } catch (error) {
+      throw this.normalizeReadError(error);
     }
   }
 
@@ -1656,26 +1636,56 @@ function transformTopologyObservationKey(
   ].join("\0");
 }
 
-function mergeTransformTopologyFrameUses(
-  left: readonly EpisodeTransformTopologyFrameUse[],
-  right: readonly EpisodeTransformTopologyFrameUse[],
-): readonly EpisodeTransformTopologyFrameUse[] {
-  const uses = new Map<string, EpisodeTransformTopologyFrameUse>();
-  for (const use of [...left, ...right]) {
-    uses.set(transformTopologyFrameUseKey(use), use);
+/** Bootstrap comes first so scanned counts win while timestamps are merged. */
+function mergeTransformTopologyEdges(
+  bootstrap: readonly EpisodeTransformTopologyEdgeObservation[],
+  scanned: readonly EpisodeTransformTopologyEdgeObservation[],
+): readonly EpisodeTransformTopologyEdgeObservation[] {
+  const edges = new Map<string, EpisodeTransformTopologyEdgeObservation>();
+  for (const edge of [...bootstrap, ...scanned]) {
+    const key = transformTopologyObservationKey(edge);
+    const current = edges.get(key);
+    edges.set(
+      key,
+      current
+        ? {
+            ...edge,
+            firstObservedTimeNs: earliestDefined(
+              current.firstObservedTimeNs,
+              edge.firstObservedTimeNs,
+            ),
+            lastObservedTimeNs: latestDefined(
+              current.lastObservedTimeNs,
+              edge.lastObservedTimeNs,
+            ),
+          }
+        : edge,
+    );
   }
-  return [...uses.values()].sort((first, second) =>
+  return [...edges.values()].sort((first, second) =>
     compareFrameIds(
-      transformTopologyFrameUseKey(first),
-      transformTopologyFrameUseKey(second),
+      transformTopologyObservationKey(first),
+      transformTopologyObservationKey(second),
     ),
   );
 }
 
-function transformTopologyFrameUseKey(
-  use: EpisodeTransformTopologyFrameUse,
-): string {
-  return `${use.frameId}\0${use.streamId}`;
+function earliestDefined(
+  left: bigint | undefined,
+  right: bigint | undefined,
+): bigint | undefined {
+  if (left === undefined) return right;
+  if (right === undefined) return left;
+  return left < right ? left : right;
+}
+
+function latestDefined(
+  left: bigint | undefined,
+  right: bigint | undefined,
+): bigint | undefined {
+  if (left === undefined) return right;
+  if (right === undefined) return left;
+  return left > right ? left : right;
 }
 
 function sameReadWorkBudget(

--- a/app/packages/multimodal/src/runtime/transform-topology-layout.ts
+++ b/app/packages/multimodal/src/runtime/transform-topology-layout.ts
@@ -12,25 +12,18 @@ interface TransformTopologyLayoutNode {
   readonly y: number;
 }
 
-interface TransformTopologyLayoutEdge {
-  readonly edgeId: string;
-  readonly source: readonly [number, number];
-  readonly target: readonly [number, number];
-}
-
 interface TransformTopologyLayout {
   readonly bounds: {
     readonly height: number;
     readonly width: number;
   };
-  readonly edges: readonly TransformTopologyLayoutEdge[];
   readonly nodes: readonly TransformTopologyLayoutNode[];
 }
 
-const NODE_WIDTH = 176;
-const NODE_HEIGHT = 44;
-const COLUMN_GAP = 96;
-const ROW_GAP = 24;
+const NODE_WIDTH = 196;
+const NODE_HEIGHT = 58;
+const COLUMN_GAP = 100;
+const ROW_GAP = 28;
 const COMPONENT_GAP = 88;
 const PADDING = 32;
 
@@ -80,33 +73,13 @@ export function layoutTransformTopology(
     }
     componentTop += componentHeight + COMPONENT_GAP;
   }
-  const nodeByFrame = new Map(nodes.map((node) => [node.frameId, node]));
-  const edges = analysis.edges.flatMap((edge) => {
-    const parent = nodeByFrame.get(edge.parentFrameId);
-    const child = nodeByFrame.get(edge.childFrameId);
-    if (!parent || !child) return [];
-    const forward = child.x >= parent.x;
-    return [
-      {
-        edgeId: edge.id,
-        source: [
-          parent.x + (forward ? parent.width : 0),
-          parent.y + parent.height / 2,
-        ] as const,
-        target: [
-          child.x + (forward ? 0 : child.width),
-          child.y + child.height / 2,
-        ] as const,
-      },
-    ];
-  });
   let width = 1;
   let height = 1;
   for (const node of nodes) {
     width = Math.max(width, node.x + node.width + PADDING);
     height = Math.max(height, node.y + node.height + PADDING);
   }
-  return { bounds: { height, width }, edges, nodes };
+  return { bounds: { height, width }, nodes };
 }
 
 function componentLevels(

--- a/app/packages/multimodal/src/runtime/transform-topology-layout.ts
+++ b/app/packages/multimodal/src/runtime/transform-topology-layout.ts
@@ -13,10 +13,6 @@ interface TransformTopologyLayoutNode {
 }
 
 interface TransformTopologyLayout {
-  readonly bounds: {
-    readonly height: number;
-    readonly width: number;
-  };
   readonly nodes: readonly TransformTopologyLayoutNode[];
 }
 
@@ -73,13 +69,7 @@ export function layoutTransformTopology(
     }
     componentTop += componentHeight + COMPONENT_GAP;
   }
-  let width = 1;
-  let height = 1;
-  for (const node of nodes) {
-    width = Math.max(width, node.x + node.width + PADDING);
-    height = Math.max(height, node.y + node.height + PADDING);
-  }
-  return { bounds: { height, width }, nodes };
+  return { nodes };
 }
 
 function componentLevels(

--- a/app/packages/multimodal/src/runtime/transform-topology.test.ts
+++ b/app/packages/multimodal/src/runtime/transform-topology.test.ts
@@ -199,7 +199,6 @@ describe("transform topology layout", () => {
     const layout = layoutTransformTopology(analyzeTransformTopology([], []));
 
     expect(layout.nodes).toEqual([]);
-    expect(layout.edges).toEqual([]);
     expect(layout.bounds.width).toBeGreaterThan(0);
     expect(layout.bounds.height).toBeGreaterThan(0);
     expect(Number.isFinite(layout.bounds.width)).toBe(true);
@@ -221,7 +220,6 @@ describe("transform topology layout", () => {
       "b",
       "c",
     ]);
-    expect(first.edges).toHaveLength(3);
     expect(first.bounds.width).toBeGreaterThan(0);
     expect(first.bounds.height).toBeGreaterThan(0);
   });

--- a/app/packages/multimodal/src/runtime/transform-topology.test.ts
+++ b/app/packages/multimodal/src/runtime/transform-topology.test.ts
@@ -195,14 +195,10 @@ describe("transform topology model", () => {
 });
 
 describe("transform topology layout", () => {
-  it("returns finite bounds for empty evidence", () => {
+  it("returns no nodes for empty evidence", () => {
     const layout = layoutTransformTopology(analyzeTransformTopology([], []));
 
     expect(layout.nodes).toEqual([]);
-    expect(layout.bounds.width).toBeGreaterThan(0);
-    expect(layout.bounds.height).toBeGreaterThan(0);
-    expect(Number.isFinite(layout.bounds.width)).toBe(true);
-    expect(Number.isFinite(layout.bounds.height)).toBe(true);
   });
 
   it("is deterministic and cycle-safe", () => {
@@ -220,7 +216,5 @@ describe("transform topology layout", () => {
       "b",
       "c",
     ]);
-    expect(first.bounds.width).toBeGreaterThan(0);
-    expect(first.bounds.height).toBeGreaterThan(0);
   });
 });

--- a/app/packages/multimodal/src/runtime/transform-topology.test.ts
+++ b/app/packages/multimodal/src/runtime/transform-topology.test.ts
@@ -111,6 +111,25 @@ describe("transform topology model", () => {
       "a-leaf",
     ]);
     expect(analysis.components[0]?.dataBearingFrameCount).toBe(1);
+    expect(
+      analysis.issues.find((issue) => issue.kind === "disconnected-components"),
+    ).toMatchObject({ severity: "warning" });
+  });
+
+  it("warns when transform-only components are disconnected", () => {
+    const analysis = analyzeTransformTopology(
+      [observation("map", "oxts"), observation("odom", "base_link")],
+      [],
+    );
+
+    expect(analysis.issues).toEqual([
+      expect.objectContaining({
+        affectedFrameIds: ["base_link", "map", "odom", "oxts"],
+        kind: "disconnected-components",
+        severity: "warning",
+        title: "Transform graph is disconnected",
+      }),
+    ]);
   });
 
   it("reports data-bearing streams split across disconnected components", () => {
@@ -122,6 +141,9 @@ describe("transform topology model", () => {
     expect(
       analysis.issues.find((issue) => issue.kind === "disconnected-data"),
     ).toMatchObject({ severity: "error" });
+    expect(
+      analysis.issues.some((issue) => issue.kind === "disconnected-components"),
+    ).toBe(false);
   });
 
   it("retains cycles and conflicting relationships as actionable issues", () => {

--- a/app/packages/multimodal/src/runtime/transform-topology.ts
+++ b/app/packages/multimodal/src/runtime/transform-topology.ts
@@ -39,6 +39,7 @@ export interface TransformTopologyFrame {
 
 type TransformTopologyIssueKind =
   | "cycle"
+  | "disconnected-components"
   | "disconnected-data"
   | "frame-name-mismatch"
   | "multiple-parents"
@@ -399,6 +400,17 @@ function diagnoseTopology({
       kind: "disconnected-data",
       severity: "error",
       title: "Renderable streams are disconnected",
+    });
+  } else if (components.length > 1) {
+    issues.push({
+      affectedFrameIds: components
+        .flatMap((component) => component.frameIds)
+        .sort(compareFrameIds),
+      detail: `${components.length} disconnected transform components were observed. A connecting relationship may be missing or may not have been observed.`,
+      id: "disconnected-components",
+      kind: "disconnected-components",
+      severity: "warning",
+      title: "Transform graph is disconnected",
     });
   }
 

--- a/app/packages/multimodal/src/views/episode/transforms/TransformGraphCanvas.module.css
+++ b/app/packages/multimodal/src/views/episode/transforms/TransformGraphCanvas.module.css
@@ -1,0 +1,118 @@
+.graphToolbar {
+  border-bottom: 1px solid var(--color-content-border-default);
+  flex: none;
+  min-height: 44px;
+  padding: var(--spacing-xs) var(--spacing-sm);
+}
+
+.toolbarSearch {
+  min-width: 0;
+}
+
+.searchField {
+  max-width: 260px;
+  min-width: 160px;
+}
+
+.canvas {
+  background: var(--color-content-bg-background);
+  flex: 1;
+  min-height: 180px;
+  overflow: hidden;
+  position: relative;
+  touch-action: none;
+}
+
+.canvas :global(.react-flow) {
+  background: var(--color-content-bg-background);
+}
+
+.canvas :global(.react-flow__pane) {
+  cursor: grab;
+}
+
+.canvas :global(.react-flow__pane.dragging) {
+  cursor: grabbing;
+}
+
+.canvas :global(.react-flow__node:focus),
+.canvas :global(.react-flow__node:focus-visible) {
+  outline: none;
+}
+
+.canvas :global(.react-flow__node-transform-component) {
+  pointer-events: none;
+}
+
+.canvas :global(.react-flow__node-transform-frame) {
+  cursor: pointer;
+}
+
+.canvas :global(.react-flow__node-transform-frame:hover) .flowNodeCard,
+.canvas :global(.react-flow__node-transform-frame:focus-visible) .flowNodeCard {
+  border-color: var(--color-content-border-focus);
+}
+
+.canvas
+  :global(.react-flow__edge:focus-visible)
+  :global(.react-flow__edge-path) {
+  stroke: var(--color-content-border-focus) !important;
+  stroke-width: 2.5 !important;
+}
+
+.flowComponent {
+  border-style: dashed;
+  box-sizing: border-box;
+  height: 100%;
+  pointer-events: none;
+  position: relative;
+  width: 100%;
+}
+
+.flowNodeCard {
+  box-sizing: border-box;
+  height: 100%;
+  overflow: hidden;
+  width: 100%;
+}
+
+.flowNodeContent,
+.flowNodeText {
+  min-width: 0;
+  width: 100%;
+}
+
+.flowNodeLabel,
+.flowNodeMeta {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.flowHandle {
+  background: var(--color-content-icon-default) !important;
+  border: 2px solid var(--color-content-bg-card-2) !important;
+  height: 8px !important;
+  min-height: 8px;
+  min-width: 8px;
+  pointer-events: none !important;
+  width: 8px !important;
+}
+
+.flowLoopHandle {
+  opacity: 0;
+}
+
+.filtered {
+  opacity: 0.11;
+  pointer-events: none;
+}
+
+@container (max-width: 430px) {
+  .toolbarSearch,
+  .searchField {
+    max-width: none;
+    width: 100%;
+  }
+}

--- a/app/packages/multimodal/src/views/episode/transforms/TransformGraphCanvas.tsx
+++ b/app/packages/multimodal/src/views/episode/transforms/TransformGraphCanvas.tsx
@@ -1,0 +1,639 @@
+import {
+  Button,
+  FormField,
+  IconName,
+  Input,
+  InputType,
+  Size,
+  Text,
+  TextColor,
+  TextVariant,
+  Variant,
+} from "@voxel51/voodo";
+import {
+  Background,
+  BackgroundVariant,
+  Handle,
+  MarkerType,
+  Position,
+  ReactFlow,
+  ReactFlowProvider,
+  type Edge,
+  type EdgeChange,
+  type Node,
+  type NodeChange,
+  type NodeProps,
+  useReactFlow,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
+import type {
+  TransformTopologyAnalysis,
+  TransformTopologySource,
+} from "../../../runtime";
+import type { layoutTransformTopology } from "../../../runtime/transform-topology-layout";
+import styles from "./TransformGraphTile.module.css";
+
+export type TransformGraphSelection =
+  | { readonly id: string; readonly kind: "edge" }
+  | { readonly id: string; readonly kind: "frame" };
+
+interface TransformGraphCanvasProps {
+  readonly analysis: TransformTopologyAnalysis;
+  readonly layout: ReturnType<typeof layoutTransformTopology>;
+  readonly matchingFrameIds: ReadonlySet<string>;
+  readonly onQueryChange: (query: string) => void;
+  readonly onSelect: (selection: TransformGraphSelection) => void;
+  readonly query: string;
+  readonly queryActive: boolean;
+  readonly selection: TransformGraphSelection | null;
+}
+
+interface FrameNodeData extends Record<string, unknown> {
+  readonly dataBearing: boolean;
+  readonly frameId: string;
+  readonly isolated: boolean;
+  readonly sourceSummary: string;
+  readonly title: string;
+}
+
+interface ComponentNodeData extends Record<string, unknown> {
+  readonly label: string;
+}
+
+type FrameFlowNode = Node<FrameNodeData, "transform-frame">;
+type ComponentFlowNode = Node<ComponentNodeData, "transform-component">;
+type TransformFlowNode = ComponentFlowNode | FrameFlowNode;
+type TransformFlowEdge = Edge<Record<string, never>, "default">;
+
+interface ComponentRect {
+  readonly flowId: string;
+  readonly height: number;
+  readonly id: string;
+  readonly label: string;
+  readonly width: number;
+  readonly x: number;
+  readonly y: number;
+}
+
+const MIN_ZOOM = 0.02;
+const MAX_ZOOM = 2.5;
+const FIT_OPTIONS = { maxZoom: 1.25, padding: 0.08 } as const;
+const NODE_TYPES = {
+  "transform-component": TransformComponentNode,
+  "transform-frame": TransformFrameNode,
+} as const;
+
+/** Read-only React Flow host for the observed transform topology. */
+export function TransformGraphCanvas(props: TransformGraphCanvasProps) {
+  return (
+    <ReactFlowProvider>
+      <TransformGraphCanvasContent {...props} />
+    </ReactFlowProvider>
+  );
+}
+
+function TransformGraphCanvasContent({
+  analysis,
+  layout,
+  matchingFrameIds,
+  onQueryChange,
+  onSelect,
+  query,
+  queryActive,
+  selection,
+}: TransformGraphCanvasProps) {
+  const canvasRef = useRef<HTMLDivElement>(null);
+  const { fitView, zoomIn, zoomOut } = useReactFlow<
+    TransformFlowNode,
+    TransformFlowEdge
+  >();
+  const connectedFrameIds = useMemo(
+    () =>
+      new Set(
+        analysis.edges.flatMap((edge) => [
+          edge.parentFrameId,
+          edge.childFrameId,
+        ]),
+      ),
+    [analysis.edges],
+  );
+  const frameById = useMemo(
+    () => new Map(analysis.frames.map((frame) => [frame.id, frame])),
+    [analysis.frames],
+  );
+  const componentRects = useMemo(
+    () => componentBounds(analysis, layout.nodes),
+    [analysis, layout.nodes],
+  );
+  const componentByFrame = useMemo(() => {
+    const result = new Map<string, ComponentRect>();
+    const rectById = new Map(
+      componentRects.map((component) => [component.id, component]),
+    );
+    for (const component of analysis.components) {
+      const rect = rectById.get(component.id);
+      if (!rect) continue;
+      for (const frameId of component.frameIds) result.set(frameId, rect);
+    }
+    return result;
+  }, [analysis.components, componentRects]);
+  const nodes = useMemo<TransformFlowNode[]>(() => {
+    const showComponents = componentRects.length > 0;
+    const groups: ComponentFlowNode[] = showComponents
+      ? componentRects.map((component) => {
+          const label = componentRects.length > 1 ? component.label : "";
+          return {
+            ariaLabel: label || "Transform component",
+            ariaRole: "group",
+            connectable: false,
+            data: { label },
+            draggable: false,
+            focusable: false,
+            height: component.height,
+            id: component.flowId,
+            position: { x: component.x, y: component.y },
+            selectable: false,
+            style: { height: component.height, width: component.width },
+            type: "transform-component",
+            width: component.width,
+            zIndex: 0,
+          };
+        })
+      : [];
+    const frames: FrameFlowNode[] = layout.nodes.map((node) => {
+      const frame = frameById.get(node.frameId);
+      const component = componentByFrame.get(node.frameId);
+      const matched = !queryActive || matchingFrameIds.has(node.frameId);
+      const isolated = !connectedFrameIds.has(node.frameId);
+      const selected =
+        selection?.kind === "frame" && selection.id === node.frameId;
+      return {
+        ariaLabel: `Frame ${node.frameId}`,
+        ariaRole: "button",
+        className: matched ? undefined : styles.filtered,
+        connectable: false,
+        data: {
+          dataBearing: frame?.dataBearing ?? false,
+          frameId: node.frameId,
+          isolated,
+          sourceSummary: shortTransformSourceSummary(
+            frame?.transformSources ?? [],
+          ),
+          title: `${node.frameId} — ${fullTransformSourceSummary(frame?.transformSources ?? [])}`,
+        },
+        domAttributes: {
+          "data-isolated": isolated ? "true" : undefined,
+        } as React.HTMLAttributes<HTMLDivElement>,
+        draggable: false,
+        focusable: matched,
+        handles: frameHandles(node.width, node.height),
+        height: node.height,
+        id: frameNodeId(node.frameId),
+        ...(showComponents && component
+          ? {
+              parentId: component.flowId,
+              position: {
+                x: node.x - component.x,
+                y: node.y - component.y,
+              },
+            }
+          : { position: { x: node.x, y: node.y } }),
+        selectable: matched,
+        selected,
+        style: { height: node.height, width: node.width },
+        type: "transform-frame",
+        width: node.width,
+        zIndex: 2,
+      };
+    });
+    return [...groups, ...frames];
+  }, [
+    componentByFrame,
+    componentRects,
+    connectedFrameIds,
+    frameById,
+    layout.nodes,
+    matchingFrameIds,
+    queryActive,
+    selection,
+  ]);
+  const nodePositionByFrame = useMemo(
+    () => new Map(layout.nodes.map((node) => [node.frameId, node])),
+    [layout.nodes],
+  );
+  const edges = useMemo<TransformFlowEdge[]>(
+    () =>
+      analysis.edges.map((edge) => {
+        const matched =
+          !queryActive ||
+          matchingFrameIds.has(edge.parentFrameId) ||
+          matchingFrameIds.has(edge.childFrameId);
+        const selected = selection?.kind === "edge" && selection.id === edge.id;
+        const stroke = edgeStroke(edge.kind, selected);
+        const source = nodePositionByFrame.get(edge.parentFrameId);
+        const target = nodePositionByFrame.get(edge.childFrameId);
+        const selfEdge = edge.parentFrameId === edge.childFrameId;
+        const reverse = Boolean(source && target && target.x < source.x);
+        return {
+          ariaLabel: `Transform edge ${edge.parentFrameId} to ${edge.childFrameId}`,
+          ariaRole: "button",
+          className: matched ? undefined : styles.filtered,
+          focusable: matched,
+          id: edge.id,
+          interactionWidth: matched ? 16 : 0,
+          markerEnd: {
+            color: edgeMarkerColor(edge.kind, selected),
+            type: MarkerType.ArrowClosed,
+          },
+          selectable: matched,
+          selected,
+          source: frameNodeId(edge.parentFrameId),
+          sourceHandle: selfEdge
+            ? "source-top"
+            : reverse
+              ? "source-left"
+              : "source-right",
+          style: {
+            filter: selected ? `drop-shadow(0 0 4px ${stroke})` : undefined,
+            opacity: matched ? 1 : 0.11,
+            stroke,
+            strokeDasharray: edge.kind === "static" ? "5 4" : undefined,
+            strokeWidth: selected ? 3 : edge.kind === "mixed" ? 2.2 : 1.6,
+          },
+          target: frameNodeId(edge.childFrameId),
+          targetHandle: selfEdge
+            ? "target-top"
+            : reverse
+              ? "target-right"
+              : "target-left",
+          type: "default",
+          zIndex: 1,
+        };
+      }),
+    [
+      analysis.edges,
+      matchingFrameIds,
+      nodePositionByFrame,
+      queryActive,
+      selection,
+    ],
+  );
+  const fit = useCallback(() => {
+    void fitView(FIT_OPTIONS);
+  }, [fitView]);
+  const frameIdByNodeId = useMemo(
+    () =>
+      new Map(
+        nodes.flatMap((node) =>
+          node.type === "transform-frame"
+            ? [[node.id, node.data.frameId] as const]
+            : [],
+        ),
+      ),
+    [nodes],
+  );
+  const handleNodeChanges = useCallback(
+    (changes: NodeChange<TransformFlowNode>[]) => {
+      for (const change of changes) {
+        if (change.type !== "select" || !change.selected) continue;
+        const frameId = frameIdByNodeId.get(change.id);
+        if (frameId) onSelect({ id: frameId, kind: "frame" });
+      }
+    },
+    [frameIdByNodeId, onSelect],
+  );
+  const handleEdgeChanges = useCallback(
+    (changes: EdgeChange<TransformFlowEdge>[]) => {
+      for (const change of changes) {
+        if (change.type === "select" && change.selected) {
+          onSelect({ id: change.id, kind: "edge" });
+        }
+      }
+    },
+    [onSelect],
+  );
+
+  // This effect keeps every component fitted after layout or tile-size changes.
+  useEffect(() => {
+    fit();
+    const element = canvasRef.current;
+    if (!element || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(fit);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [fit, layout]);
+
+  return (
+    <>
+      <div
+        aria-label="Transform graph controls"
+        className={styles.graphToolbar}
+      >
+        <FormField
+          className={styles.searchField}
+          control={
+            <Input
+              aria-label="Filter transform frames"
+              icon={IconName.Search}
+              onChange={(event) => onQueryChange(event.target.value)}
+              placeholder="Frame name"
+              size={Size.Sm}
+              type={InputType.Search}
+              value={query}
+            />
+          }
+        />
+        {queryActive ? (
+          <Text color={TextColor.Secondary} variant={TextVariant.Xs}>
+            {matchingFrameIds.size} of {analysis.frames.length}
+          </Text>
+        ) : null}
+        <div className={styles.canvasControls}>
+          <Button
+            aria-label="Zoom out"
+            borderless
+            leadingIcon={IconName.Remove}
+            onClick={() => void zoomOut({ duration: 120 })}
+            size={Size.Xs}
+            variant={Variant.Icon}
+          />
+          <Button
+            aria-label="Zoom in"
+            borderless
+            leadingIcon={IconName.Add}
+            onClick={() => void zoomIn({ duration: 120 })}
+            size={Size.Xs}
+            variant={Variant.Icon}
+          />
+          <Button
+            aria-label="Fit transform graph"
+            borderless
+            leadingIcon={IconName.Fullscreen}
+            onClick={fit}
+            size={Size.Xs}
+            title="Fit"
+            variant={Variant.Icon}
+          />
+        </div>
+      </div>
+      <div
+        className={styles.canvas}
+        data-testid="transform-topology-canvas"
+        ref={canvasRef}
+      >
+        <ReactFlow<TransformFlowNode, TransformFlowEdge>
+          aria-label="Static transform topology"
+          colorMode="dark"
+          deleteKeyCode={null}
+          edges={edges}
+          edgesFocusable
+          edgesReconnectable={false}
+          elementsSelectable
+          fitView
+          fitViewOptions={FIT_OPTIONS}
+          maxZoom={MAX_ZOOM}
+          minZoom={MIN_ZOOM}
+          nodes={nodes}
+          nodesConnectable={false}
+          nodesDraggable={false}
+          nodesFocusable
+          nodeTypes={NODE_TYPES}
+          onEdgesChange={handleEdgeChanges}
+          onEdgeClick={(_, edge) => onSelect({ id: edge.id, kind: "edge" })}
+          onInit={fit}
+          onNodesChange={handleNodeChanges}
+          onNodeClick={(_, node) => {
+            if (node.type === "transform-frame") {
+              onSelect({ id: node.data.frameId, kind: "frame" });
+            }
+          }}
+          panOnDrag
+          proOptions={{ hideAttribution: true }}
+          zoomOnDoubleClick={false}
+        >
+          <Background
+            color="var(--color-content-text-muted, #8d929d)"
+            gap={18}
+            size={1}
+            variant={BackgroundVariant.Dots}
+          />
+        </ReactFlow>
+      </div>
+    </>
+  );
+}
+
+function TransformFrameNode({ data, selected }: NodeProps<FrameFlowNode>) {
+  return (
+    <div
+      className={`${styles.flowNodeCard} ${data.dataBearing ? styles.flowDataNode : ""} ${data.isolated ? styles.flowIsolatedNode : ""} ${selected ? styles.flowSelectedNode : ""}`}
+      title={data.title}
+    >
+      <Handle
+        className={styles.flowHandle}
+        id="target-left"
+        isConnectable={false}
+        position={Position.Left}
+        type="target"
+      />
+      <Handle
+        className={styles.flowHandle}
+        id="source-left"
+        isConnectable={false}
+        position={Position.Left}
+        type="source"
+      />
+      <Handle
+        className={`${styles.flowHandle} ${styles.flowLoopHandle}`}
+        id="source-top"
+        isConnectable={false}
+        position={Position.Top}
+        style={{ left: "38%" }}
+        type="source"
+      />
+      <Handle
+        className={`${styles.flowHandle} ${styles.flowLoopHandle}`}
+        id="target-top"
+        isConnectable={false}
+        position={Position.Top}
+        style={{ left: "62%" }}
+        type="target"
+      />
+      <span aria-hidden="true" className={styles.flowNodeGlyph}>
+        TF
+      </span>
+      <span className={styles.flowNodeText}>
+        <span className={styles.flowNodeKind}>Frame</span>
+        <span className={styles.flowNodeLabel}>{data.frameId}</span>
+        <span className={styles.flowNodeMeta}>{data.sourceSummary}</span>
+      </span>
+      <Handle
+        className={styles.flowHandle}
+        id="target-right"
+        isConnectable={false}
+        position={Position.Right}
+        type="target"
+      />
+      <Handle
+        className={styles.flowHandle}
+        id="source-right"
+        isConnectable={false}
+        position={Position.Right}
+        type="source"
+      />
+    </div>
+  );
+}
+
+function TransformComponentNode({ data }: NodeProps<ComponentFlowNode>) {
+  return (
+    <div className={styles.flowComponent}>
+      {data.label ? (
+        <span className={styles.flowComponentLabel}>{data.label}</span>
+      ) : null}
+    </div>
+  );
+}
+
+function componentBounds(
+  analysis: TransformTopologyAnalysis,
+  nodes: TransformGraphCanvasProps["layout"]["nodes"],
+): readonly ComponentRect[] {
+  const nodeByFrame = new Map(nodes.map((node) => [node.frameId, node]));
+  return analysis.components.flatMap((component, index) => {
+    const componentNodes = component.frameIds.flatMap((frameId) => {
+      const node = nodeByFrame.get(frameId);
+      return node ? [node] : [];
+    });
+    if (componentNodes.length === 0) return [];
+    const x = Math.min(...componentNodes.map((node) => node.x)) - 16;
+    const y = Math.min(...componentNodes.map((node) => node.y)) - 36;
+    const right = Math.max(
+      ...componentNodes.map((node) => node.x + node.width),
+    );
+    const bottom = Math.max(
+      ...componentNodes.map((node) => node.y + node.height),
+    );
+    return [
+      {
+        flowId: `transform-component-${index}`,
+        height: bottom - y + 16,
+        id: component.id,
+        label: `Component ${index + 1}`,
+        width: right - x + 16,
+        x,
+        y,
+      },
+    ];
+  });
+}
+
+function frameNodeId(frameId: string): string {
+  return `transform-frame:${frameId}`;
+}
+
+function frameHandles(
+  width: number,
+  height: number,
+): NonNullable<FrameFlowNode["handles"]> {
+  const handleSize = 8;
+  const y = height / 2 - handleSize / 2;
+  return [
+    {
+      height: handleSize,
+      id: "target-left",
+      position: Position.Left,
+      type: "target",
+      width: handleSize,
+      x: -handleSize / 2,
+      y,
+    },
+    {
+      height: handleSize,
+      id: "source-left",
+      position: Position.Left,
+      type: "source",
+      width: handleSize,
+      x: -handleSize / 2,
+      y,
+    },
+    {
+      height: handleSize,
+      id: "target-right",
+      position: Position.Right,
+      type: "target",
+      width: handleSize,
+      x: width - handleSize / 2,
+      y,
+    },
+    {
+      height: handleSize,
+      id: "source-right",
+      position: Position.Right,
+      type: "source",
+      width: handleSize,
+      x: width - handleSize / 2,
+      y,
+    },
+    {
+      height: handleSize,
+      id: "source-top",
+      position: Position.Top,
+      type: "source",
+      width: handleSize,
+      x: width * 0.38 - handleSize / 2,
+      y: -handleSize / 2,
+    },
+    {
+      height: handleSize,
+      id: "target-top",
+      position: Position.Top,
+      type: "target",
+      width: handleSize,
+      x: width * 0.62 - handleSize / 2,
+      y: -handleSize / 2,
+    },
+  ];
+}
+
+function edgeStroke(
+  kind: "mixed" | "static" | "temporal",
+  selected: boolean,
+): string {
+  if (selected || kind === "mixed") {
+    return "var(--color-voxel-secondary, #ff8d00)";
+  }
+  if (kind === "temporal") return "var(--fo-palette-info-main, #4ca3ff)";
+  return "var(--color-content-text-muted, #8d929d)";
+}
+
+function edgeMarkerColor(
+  kind: "mixed" | "static" | "temporal",
+  selected: boolean,
+): string {
+  if (selected || kind === "mixed") return "#ff8d00";
+  return kind === "temporal" ? "#4ca3ff" : "#8d929d";
+}
+
+function shortTransformSourceSummary(
+  sources: readonly TransformTopologySource[],
+): string {
+  if (sources.length === 0) return "transform source unknown";
+  const visible = sources
+    .slice(0, 2)
+    .map((source) => source.sourceName.replace(/^\/+/, ""));
+  const suffix =
+    sources.length > visible.length ? ` +${sources.length - 2}` : "";
+  const summary = `${visible.join(" + ")}${suffix}`;
+  return summary.length <= 28 ? summary : `${summary.slice(0, 25)}…`;
+}
+
+function fullTransformSourceSummary(
+  sources: readonly TransformTopologySource[],
+): string {
+  if (sources.length === 0) return "no transform source observed";
+  return sources
+    .map((source) => `${source.sourceName} (${source.kind})`)
+    .join(", ");
+}

--- a/app/packages/multimodal/src/views/episode/transforms/TransformGraphCanvas.tsx
+++ b/app/packages/multimodal/src/views/episode/transforms/TransformGraphCanvas.tsx
@@ -1,10 +1,23 @@
 import {
+  Align,
+  BorderColor,
+  BrandColor,
   Button,
+  Card,
+  CardBackground,
+  borderColorClass,
   FormField,
+  getColorCssVar,
+  Icon,
+  IconColor,
   IconName,
   Input,
   InputType,
+  Justify,
+  Orientation,
   Size,
+  Spacing,
+  Stack,
   Text,
   TextColor,
   TextVariant,
@@ -33,7 +46,7 @@ import type {
   TransformTopologySource,
 } from "../../../runtime";
 import type { layoutTransformTopology } from "../../../runtime/transform-topology-layout";
-import styles from "./TransformGraphTile.module.css";
+import styles from "./TransformGraphCanvas.module.css";
 
 export type TransformGraphSelection =
   | { readonly id: string; readonly kind: "edge" }
@@ -80,6 +93,10 @@ interface ComponentRect {
 const MIN_ZOOM = 0.02;
 const MAX_ZOOM = 2.5;
 const FIT_OPTIONS = { maxZoom: 1.25, padding: 0.08 } as const;
+const ACTIVE_EDGE_COLOR = `var(${getColorCssVar(BrandColor.Primary)})`;
+const GRID_DOT_COLOR = `var(${getColorCssVar(IconColor.Muted)})`;
+const STATIC_EDGE_COLOR = `var(${getColorCssVar(IconColor.Muted)})`;
+const TEMPORAL_EDGE_COLOR = `var(${getColorCssVar(IconColor.Info)})`;
 const NODE_TYPES = {
   "transform-component": TransformComponentNode,
   "transform-frame": TransformFrameNode,
@@ -245,7 +262,7 @@ function TransformGraphCanvasContent({
           id: edge.id,
           interactionWidth: matched ? 16 : 0,
           markerEnd: {
-            color: edgeMarkerColor(edge.kind, selected),
+            color: "context-stroke",
             type: MarkerType.ArrowClosed,
           },
           selectable: matched,
@@ -257,7 +274,6 @@ function TransformGraphCanvasContent({
               ? "source-left"
               : "source-right",
           style: {
-            filter: selected ? `drop-shadow(0 0 4px ${stroke})` : undefined,
             opacity: matched ? 1 : 0.11,
             stroke,
             strokeDasharray: edge.kind === "static" ? "5 4" : undefined,
@@ -329,30 +345,46 @@ function TransformGraphCanvasContent({
 
   return (
     <>
-      <div
+      <Stack
+        align={Align.Center}
         aria-label="Transform graph controls"
         className={styles.graphToolbar}
+        justify={Justify.Between}
+        orientation={Orientation.Row}
+        spacing={Spacing.Sm}
       >
-        <FormField
-          className={styles.searchField}
-          control={
-            <Input
-              aria-label="Filter transform frames"
-              icon={IconName.Search}
-              onChange={(event) => onQueryChange(event.target.value)}
-              placeholder="Frame name"
-              size={Size.Sm}
-              type={InputType.Search}
-              value={query}
-            />
-          }
-        />
-        {queryActive ? (
-          <Text color={TextColor.Secondary} variant={TextVariant.Xs}>
-            {matchingFrameIds.size} of {analysis.frames.length}
-          </Text>
-        ) : null}
-        <div className={styles.canvasControls}>
+        <Stack
+          align={Align.Center}
+          className={styles.toolbarSearch}
+          orientation={Orientation.Row}
+          spacing={Spacing.Sm}
+        >
+          <FormField
+            className={styles.searchField}
+            control={
+              <Input
+                aria-label="Filter transform frames"
+                icon={IconName.Search}
+                onChange={(event) => onQueryChange(event.target.value)}
+                placeholder="Frame name"
+                size={Size.Sm}
+                type={InputType.Search}
+                value={query}
+              />
+            }
+            spacing={Spacing.None}
+          />
+          {queryActive ? (
+            <Text color={TextColor.Secondary} variant={TextVariant.Xs}>
+              {matchingFrameIds.size} of {analysis.frames.length}
+            </Text>
+          ) : null}
+        </Stack>
+        <Stack
+          align={Align.Center}
+          orientation={Orientation.Row}
+          spacing={Spacing.Xs}
+        >
           <Button
             aria-label="Zoom out"
             borderless
@@ -378,8 +410,8 @@ function TransformGraphCanvasContent({
             title="Fit"
             variant={Variant.Icon}
           />
-        </div>
-      </div>
+        </Stack>
+      </Stack>
       <div
         className={styles.canvas}
         data-testid="transform-topology-canvas"
@@ -409,7 +441,7 @@ function TransformGraphCanvasContent({
           zoomOnDoubleClick={false}
         >
           <Background
-            color="var(--color-content-text-muted, #8d929d)"
+            color={GRID_DOT_COLOR}
             gap={18}
             size={1}
             variant={BackgroundVariant.Dots}
@@ -421,9 +453,26 @@ function TransformGraphCanvasContent({
 }
 
 function TransformFrameNode({ data, selected }: NodeProps<FrameFlowNode>) {
+  const borderColor = selected
+    ? BorderColor.Active
+    : data.isolated
+      ? BorderColor.Error
+      : data.dataBearing
+        ? BorderColor.Strong
+        : BorderColor.Default;
+  const iconColor = selected
+    ? BrandColor.Accent
+    : data.isolated
+      ? IconColor.Destructive
+      : data.dataBearing
+        ? IconColor.Info
+        : IconColor.Muted;
   return (
-    <div
-      className={`${styles.flowNodeCard} ${data.dataBearing ? styles.flowDataNode : ""} ${data.isolated ? styles.flowIsolatedNode : ""} ${selected ? styles.flowSelectedNode : ""}`}
+    <Card
+      background={selected ? CardBackground.Elevated : CardBackground.Secondary}
+      className={`${styles.flowNodeCard} ${borderColorClass(borderColor)}`}
+      compact
+      outlined
       title={data.title}
     >
       <Handle
@@ -456,14 +505,38 @@ function TransformFrameNode({ data, selected }: NodeProps<FrameFlowNode>) {
         style={{ left: "62%" }}
         type="target"
       />
-      <span aria-hidden="true" className={styles.flowNodeGlyph}>
-        TF
-      </span>
-      <span className={styles.flowNodeText}>
-        <span className={styles.flowNodeKind}>Frame</span>
-        <span className={styles.flowNodeLabel}>{data.frameId}</span>
-        <span className={styles.flowNodeMeta}>{data.sourceSummary}</span>
-      </span>
+      <Stack
+        align={Align.Center}
+        className={styles.flowNodeContent}
+        orientation={Orientation.Row}
+        spacing={Spacing.Sm}
+      >
+        <Icon
+          color={iconColor}
+          name={data.dataBearing ? IconName.Database : IconName.Waypoints}
+          size={Size.Md}
+        />
+        <Stack
+          className={styles.flowNodeText}
+          orientation={Orientation.Column}
+          spacing={Spacing.None}
+        >
+          <Text
+            className={styles.flowNodeLabel}
+            color={TextColor.Primary}
+            variant={TextVariant.Xs}
+          >
+            {data.frameId}
+          </Text>
+          <Text
+            className={styles.flowNodeMeta}
+            color={TextColor.Muted}
+            variant={TextVariant.Xxs}
+          >
+            {data.sourceSummary}
+          </Text>
+        </Stack>
+      </Stack>
       <Handle
         className={styles.flowHandle}
         id="target-right"
@@ -478,17 +551,24 @@ function TransformFrameNode({ data, selected }: NodeProps<FrameFlowNode>) {
         position={Position.Right}
         type="source"
       />
-    </div>
+    </Card>
   );
 }
 
 function TransformComponentNode({ data }: NodeProps<ComponentFlowNode>) {
   return (
-    <div className={styles.flowComponent}>
+    <Card
+      background={CardBackground.Primary}
+      className={styles.flowComponent}
+      compact
+      outlined
+    >
       {data.label ? (
-        <span className={styles.flowComponentLabel}>{data.label}</span>
+        <Text color={TextColor.Secondary} variant={TextVariant.Label}>
+          {data.label}
+        </Text>
       ) : null}
-    </div>
+    </Card>
   );
 }
 
@@ -597,19 +677,8 @@ function edgeStroke(
   kind: "mixed" | "static" | "temporal",
   selected: boolean,
 ): string {
-  if (selected || kind === "mixed") {
-    return "var(--color-voxel-secondary, #ff8d00)";
-  }
-  if (kind === "temporal") return "var(--fo-palette-info-main, #4ca3ff)";
-  return "var(--color-content-text-muted, #8d929d)";
-}
-
-function edgeMarkerColor(
-  kind: "mixed" | "static" | "temporal",
-  selected: boolean,
-): string {
-  if (selected || kind === "mixed") return "#ff8d00";
-  return kind === "temporal" ? "#4ca3ff" : "#8d929d";
+  if (selected || kind === "mixed") return ACTIVE_EDGE_COLOR;
+  return kind === "temporal" ? TEMPORAL_EDGE_COLOR : STATIC_EDGE_COLOR;
 }
 
 function shortTransformSourceSummary(

--- a/app/packages/multimodal/src/views/episode/transforms/TransformGraphCanvas.tsx
+++ b/app/packages/multimodal/src/views/episode/transforms/TransformGraphCanvas.tsx
@@ -23,6 +23,7 @@ import {
   type Node,
   type NodeChange,
   type NodeProps,
+  useNodesInitialized,
   useReactFlow,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
@@ -104,6 +105,7 @@ function TransformGraphCanvasContent({
   selection,
 }: TransformGraphCanvasProps) {
   const canvasRef = useRef<HTMLDivElement>(null);
+  const nodesInitialized = useNodesInitialized();
   const { fitView, zoomIn, zoomOut } = useReactFlow<
     TransformFlowNode,
     TransformFlowEdge
@@ -316,13 +318,14 @@ function TransformGraphCanvasContent({
 
   // This effect keeps every component fitted after layout or tile-size changes.
   useEffect(() => {
+    if (!nodesInitialized) return;
     fit();
     const element = canvasRef.current;
     if (!element || typeof ResizeObserver === "undefined") return;
     const observer = new ResizeObserver(fit);
     observer.observe(element);
     return () => observer.disconnect();
-  }, [fit, layout]);
+  }, [fit, layout, nodesInitialized]);
 
   return (
     <>
@@ -400,14 +403,7 @@ function TransformGraphCanvasContent({
           nodesFocusable
           nodeTypes={NODE_TYPES}
           onEdgesChange={handleEdgeChanges}
-          onEdgeClick={(_, edge) => onSelect({ id: edge.id, kind: "edge" })}
-          onInit={fit}
           onNodesChange={handleNodeChanges}
-          onNodeClick={(_, node) => {
-            if (node.type === "transform-frame") {
-              onSelect({ id: node.data.frameId, kind: "frame" });
-            }
-          }}
           panOnDrag
           proOptions={{ hideAttribution: true }}
           zoomOnDoubleClick={false}

--- a/app/packages/multimodal/src/views/episode/transforms/TransformGraphTile.module.css
+++ b/app/packages/multimodal/src/views/episode/transforms/TransformGraphTile.module.css
@@ -12,7 +12,7 @@
 
 .summary {
   align-items: center;
-  border-bottom: 1px solid var(--color-content-border-default, #383835);
+  border-bottom: 1px solid var(--color-content-border-default);
   display: flex;
   flex: none;
   gap: 16px;
@@ -35,7 +35,7 @@
 }
 
 .metric {
-  border-right: 1px solid var(--color-content-border-default, #383835);
+  border-right: 1px solid var(--color-content-border-default);
   display: flex;
   flex-direction: column;
   gap: 2px;
@@ -51,11 +51,11 @@
   align-items: center;
   background: color-mix(
     in srgb,
-    var(--fo-palette-warning-main, #b58105) 12%,
+    var(--color-content-text-warning) 12%,
     transparent
   );
   border-bottom: 1px solid
-    color-mix(in srgb, var(--fo-palette-warning-main, #b58105) 35%, transparent);
+    color-mix(in srgb, var(--color-content-text-warning) 35%, transparent);
   display: flex;
   flex: none;
   gap: 12px;
@@ -85,229 +85,15 @@
   min-width: 0;
 }
 
-.graphToolbar {
-  align-items: center;
-  border-bottom: 1px solid var(--color-content-border-default, #383835);
-  display: flex;
-  flex: none;
-  gap: 10px;
-  min-height: 44px;
-  padding: 6px 10px;
-}
-
-.searchField {
-  margin: 0;
-  max-width: 260px;
-  min-width: 160px;
-}
-
-.canvas {
-  background: var(--fo-palette-background-level1, #0b0d10);
-  flex: 1;
-  min-height: 180px;
-  overflow: hidden;
-  position: relative;
-  touch-action: none;
-}
-
-.canvas :global(.react-flow) {
-  background: var(--fo-palette-background-level1, #0b0d10);
-}
-
-.canvas :global(.react-flow__pane) {
-  cursor: grab;
-}
-
-.canvas :global(.react-flow__pane.dragging) {
-  cursor: grabbing;
-}
-
-.canvas :global(.react-flow__node) {
-  font-family: inherit;
-}
-
-.canvas :global(.react-flow__node:focus),
-.canvas :global(.react-flow__node:focus-visible) {
-  outline: none;
-}
-
-.canvas :global(.react-flow__node-transform-component) {
-  pointer-events: none;
-}
-
-.canvas :global(.react-flow__node-transform-frame:hover) .flowNodeCard,
-.canvas :global(.react-flow__node-transform-frame:focus-visible) .flowNodeCard {
-  border-color: var(--color-content-border-focus, #7ca9ff);
-  box-shadow: 0 0 0 1px var(--color-content-border-focus, #7ca9ff);
-}
-
-.canvas
-  :global(.react-flow__edge:focus-visible)
-  :global(.react-flow__edge-path) {
-  filter: drop-shadow(0 0 3px var(--color-content-border-focus, #7ca9ff));
-  stroke: var(--color-content-border-focus, #7ca9ff) !important;
-  stroke-width: 2.5 !important;
-}
-
-.canvasControls {
-  align-items: center;
-  display: flex;
-  gap: 2px;
-  margin-left: auto;
-}
-
-.flowComponent {
-  background: color-mix(
-    in srgb,
-    var(--fo-palette-background-level2, #15171b) 72%,
-    transparent
-  );
-  border: 1px dashed var(--color-content-border-default, #383835);
-  border-radius: 12px;
-  box-sizing: border-box;
-  height: 100%;
-  pointer-events: none;
-  position: relative;
-  width: 100%;
-}
-
-.flowComponentLabel {
-  color: var(--color-content-text-secondary);
-  font-size: 10px;
-  font-weight: 600;
-  left: 12px;
-  letter-spacing: 0.02em;
-  position: absolute;
-  text-transform: uppercase;
-  top: 9px;
-}
-
-.flowNodeCard {
-  align-items: center;
-  background: var(--fo-palette-background-level2, #15171b);
-  border: 1px solid var(--color-content-border-default, #383835);
-  border-radius: 9px;
-  box-shadow: 0 5px 14px rgb(0 0 0 / 20%);
-  box-sizing: border-box;
-  color: var(--color-content-text-primary, #f1f2f4);
-  cursor: pointer;
-  display: flex;
-  gap: 9px;
-  height: 100%;
-  padding: 7px 10px;
-  transition:
-    border-color 100ms ease,
-    box-shadow 100ms ease;
-  width: 100%;
-}
-
-.flowDataNode {
-  background: color-mix(
-    in srgb,
-    var(--fo-palette-info-main, #4ca3ff) 11%,
-    var(--fo-palette-background-level2, #15171b)
-  );
-  border-color: var(--fo-palette-info-main, #4ca3ff);
-}
-
-.flowIsolatedNode {
-  border-color: var(--fo-palette-error-main, #ff665d);
-}
-
-.flowSelectedNode {
-  background: color-mix(
-    in srgb,
-    var(--color-voxel-secondary, #ff8d00) 18%,
-    var(--fo-palette-background-level2, #15171b)
-  );
-  border-color: var(--color-voxel-secondary, #ff8d00);
-  box-shadow: 0 0 0 2px
-    color-mix(in srgb, var(--color-voxel-secondary, #ff8d00) 55%, transparent);
-}
-
-.flowNodeGlyph {
-  align-items: center;
-  background: color-mix(
-    in srgb,
-    var(--color-content-text-primary, #f1f2f4) 7%,
-    transparent
-  );
-  border-radius: 7px;
-  color: var(--color-content-text-secondary);
-  display: flex;
-  flex: none;
-  font-size: 9px;
-  font-weight: 700;
-  height: 30px;
-  justify-content: center;
-  letter-spacing: 0.04em;
-  width: 30px;
-}
-
-.flowNodeText {
-  display: flex;
-  flex: 1;
-  flex-direction: column;
-  min-width: 0;
-}
-
-.flowNodeKind {
-  color: var(--color-content-text-muted, #8d929d);
-  font-size: 8px;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  line-height: 1.1;
-  text-transform: uppercase;
-}
-
-.flowNodeLabel {
-  color: var(--color-content-text-primary, #f1f2f4);
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  font-size: 11px;
-  font-weight: 600;
-  line-height: 1.35;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.flowNodeMeta {
-  color: var(--color-content-text-muted, #8d929d);
-  font-size: 9px;
-  line-height: 1.2;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.flowHandle {
-  background: var(--color-content-text-secondary, #b3b6bd) !important;
-  border: 2px solid var(--fo-palette-background-level2, #15171b) !important;
-  height: 8px !important;
-  min-height: 8px;
-  min-width: 8px;
-  pointer-events: none !important;
-  width: 8px !important;
-}
-
-.flowLoopHandle {
-  opacity: 0;
-}
-
-.filtered {
-  opacity: 0.11;
-  pointer-events: none;
-}
-
 .details {
-  background: var(--fo-palette-background-level1, #0b0d10);
-  border-left: 1px solid var(--color-content-border-default, #383835);
+  background: var(--color-content-bg-background);
+  border-left: 1px solid var(--color-content-border-default);
   min-height: 0;
   overflow: auto;
 }
 
 .detailSection {
-  border-bottom: 1px solid var(--color-content-border-default, #383835);
+  border-bottom: 1px solid var(--color-content-border-default);
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -360,10 +146,10 @@
 .issue {
   background: color-mix(
     in srgb,
-    var(--fo-palette-background-level2, #15171b) 90%,
+    var(--color-content-bg-card-2) 90%,
     transparent
   );
-  border: 1px solid var(--color-content-border-default, #383835);
+  border: 1px solid var(--color-content-border-default);
   border-radius: 6px;
   color: inherit;
   cursor: pointer;
@@ -376,7 +162,7 @@
 
 .issue:hover,
 .issue:focus-visible {
-  border-color: var(--color-content-border-focus, #7ca9ff);
+  border-color: var(--color-content-border-focus);
   outline: none;
 }
 
@@ -391,7 +177,7 @@
 
 .errorDot,
 .warningDot {
-  background: var(--fo-palette-error-main, #ff665d);
+  background: var(--color-content-text-destructive);
   border-radius: 50%;
   flex: none;
   height: 7px;
@@ -399,7 +185,7 @@
 }
 
 .warningDot {
-  background: var(--fo-palette-warning-main, #e3ad22);
+  background: var(--color-content-text-warning);
 }
 
 .issueDetail,
@@ -410,7 +196,7 @@
 }
 
 .suggestion {
-  color: var(--fo-palette-warning-main, #e3ad22);
+  color: var(--color-content-text-warning);
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 }
 
@@ -447,7 +233,7 @@
 
   .details {
     border-left: 0;
-    border-top: 1px solid var(--color-content-border-default, #383835);
+    border-top: 1px solid var(--color-content-border-default);
   }
 }
 
@@ -462,10 +248,5 @@
   .metric {
     min-width: 0;
     padding-right: 5px;
-  }
-
-  .searchField {
-    max-width: none;
-    width: 100%;
   }
 }

--- a/app/packages/multimodal/src/views/episode/transforms/TransformGraphTile.module.css
+++ b/app/packages/multimodal/src/views/episode/transforms/TransformGraphTile.module.css
@@ -102,15 +102,7 @@
 }
 
 .canvas {
-  background:
-    radial-gradient(
-        circle at 1px 1px,
-        color-mix(in srgb, var(--color-content-text-muted) 14%, transparent) 1px,
-        transparent 1.2px
-      )
-      0 0 / 18px 18px,
-    var(--fo-palette-background-level1, #0b0d10);
-  cursor: grab;
+  background: var(--fo-palette-background-level1, #0b0d10);
   flex: 1;
   min-height: 180px;
   overflow: hidden;
@@ -118,8 +110,43 @@
   touch-action: none;
 }
 
-.canvas:active {
+.canvas :global(.react-flow) {
+  background: var(--fo-palette-background-level1, #0b0d10);
+}
+
+.canvas :global(.react-flow__pane) {
+  cursor: grab;
+}
+
+.canvas :global(.react-flow__pane.dragging) {
   cursor: grabbing;
+}
+
+.canvas :global(.react-flow__node) {
+  font-family: inherit;
+}
+
+.canvas :global(.react-flow__node:focus),
+.canvas :global(.react-flow__node:focus-visible) {
+  outline: none;
+}
+
+.canvas :global(.react-flow__node-transform-component) {
+  pointer-events: none;
+}
+
+.canvas :global(.react-flow__node-transform-frame:hover) .flowNodeCard,
+.canvas :global(.react-flow__node-transform-frame:focus-visible) .flowNodeCard {
+  border-color: var(--color-content-border-focus, #7ca9ff);
+  box-shadow: 0 0 0 1px var(--color-content-border-focus, #7ca9ff);
+}
+
+.canvas
+  :global(.react-flow__edge:focus-visible)
+  :global(.react-flow__edge-path) {
+  filter: drop-shadow(0 0 3px var(--color-content-border-focus, #7ca9ff));
+  stroke: var(--color-content-border-focus, #7ca9ff) !important;
+  stroke-width: 2.5 !important;
 }
 
 .canvasControls {
@@ -129,137 +156,142 @@
   margin-left: auto;
 }
 
-.svg {
-  height: 100%;
-  inset: 0;
-  overflow: visible;
-  pointer-events: none;
-  position: absolute;
-  width: 100%;
-}
-
-.svg g[role="button"],
-.edgeHitTarget {
-  pointer-events: auto;
-}
-
-.componentBox {
-  fill: color-mix(
+.flowComponent {
+  background: color-mix(
     in srgb,
     var(--fo-palette-background-level2, #15171b) 72%,
     transparent
   );
-  stroke: var(--color-content-border-default, #383835);
-  stroke-dasharray: 3 4;
+  border: 1px dashed var(--color-content-border-default, #383835);
+  border-radius: 12px;
+  box-sizing: border-box;
+  height: 100%;
+  pointer-events: none;
+  position: relative;
+  width: 100%;
 }
 
-.componentLabel {
-  fill: var(--color-content-text-secondary);
+.flowComponentLabel {
+  color: var(--color-content-text-secondary);
   font-size: 10px;
   font-weight: 600;
+  left: 12px;
   letter-spacing: 0.02em;
+  position: absolute;
   text-transform: uppercase;
+  top: 9px;
 }
 
-.edge {
-  fill: none;
-  stroke: var(--color-content-text-muted, #8d929d);
-  stroke-width: 1.6;
-}
-
-.edgeGroup {
-  outline: none;
-}
-
-.edgeGroup:focus-visible .edge {
-  filter: drop-shadow(0 0 3px var(--color-content-border-focus, #7ca9ff));
-  stroke: var(--color-content-border-focus, #7ca9ff);
-  stroke-width: 2.5;
-}
-
-.edge_static {
-  stroke-dasharray: 5 4;
-}
-
-.edge_temporal {
-  stroke: var(--fo-palette-info-main, #4ca3ff);
-}
-
-.edge_mixed {
-  stroke: var(--color-voxel-secondary, #ff8d00);
-  stroke-width: 2.2;
-}
-
-.selectedEdge {
-  filter: drop-shadow(0 0 4px var(--color-voxel-secondary, #ff8d00));
-  stroke: var(--color-voxel-secondary, #ff8d00);
-  stroke-width: 3;
-}
-
-.arrowHead {
-  fill: var(--color-content-text-secondary, #b3b6bd);
-}
-
-.edgeHitTarget {
+.flowNodeCard {
+  align-items: center;
+  background: var(--fo-palette-background-level2, #15171b);
+  border: 1px solid var(--color-content-border-default, #383835);
+  border-radius: 9px;
+  box-shadow: 0 5px 14px rgb(0 0 0 / 20%);
+  box-sizing: border-box;
+  color: var(--color-content-text-primary, #f1f2f4);
   cursor: pointer;
-  fill: none;
-  stroke: transparent;
-  stroke-width: 14;
+  display: flex;
+  gap: 9px;
+  height: 100%;
+  padding: 7px 10px;
+  transition:
+    border-color 100ms ease,
+    box-shadow 100ms ease;
+  width: 100%;
 }
 
-.node {
-  cursor: pointer;
-  outline: none;
-  pointer-events: auto;
-}
-
-.nodeBox {
-  fill: var(--fo-palette-background-level2, #15171b);
-  stroke: var(--color-content-border-default, #383835);
-  stroke-width: 1;
-}
-
-.node:hover .nodeBox,
-.node:focus-visible .nodeBox {
-  stroke: var(--color-content-border-focus, #7ca9ff);
-  stroke-width: 2;
-}
-
-.dataNode {
-  fill: color-mix(
+.flowDataNode {
+  background: color-mix(
     in srgb,
     var(--fo-palette-info-main, #4ca3ff) 11%,
     var(--fo-palette-background-level2, #15171b)
   );
-  stroke: var(--fo-palette-info-main, #4ca3ff);
+  border-color: var(--fo-palette-info-main, #4ca3ff);
 }
 
-.isolatedNode {
-  stroke: var(--fo-palette-error-main, #ff665d);
+.flowIsolatedNode {
+  border-color: var(--fo-palette-error-main, #ff665d);
 }
 
-.selectedNode {
-  fill: color-mix(
+.flowSelectedNode {
+  background: color-mix(
     in srgb,
     var(--color-voxel-secondary, #ff8d00) 18%,
     var(--fo-palette-background-level2, #15171b)
   );
-  stroke: var(--color-voxel-secondary, #ff8d00);
-  stroke-width: 2.5;
+  border-color: var(--color-voxel-secondary, #ff8d00);
+  box-shadow: 0 0 0 2px
+    color-mix(in srgb, var(--color-voxel-secondary, #ff8d00) 55%, transparent);
 }
 
-.nodeLabel {
-  fill: var(--color-content-text-primary, #f1f2f4);
+.flowNodeGlyph {
+  align-items: center;
+  background: color-mix(
+    in srgb,
+    var(--color-content-text-primary, #f1f2f4) 7%,
+    transparent
+  );
+  border-radius: 7px;
+  color: var(--color-content-text-secondary);
+  display: flex;
+  flex: none;
+  font-size: 9px;
+  font-weight: 700;
+  height: 30px;
+  justify-content: center;
+  letter-spacing: 0.04em;
+  width: 30px;
+}
+
+.flowNodeText {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.flowNodeKind {
+  color: var(--color-content-text-muted, #8d929d);
+  font-size: 8px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  line-height: 1.1;
+  text-transform: uppercase;
+}
+
+.flowNodeLabel {
+  color: var(--color-content-text-primary, #f1f2f4);
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   font-size: 11px;
   font-weight: 600;
-  pointer-events: none;
+  line-height: 1.35;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.nodeMeta {
-  fill: var(--color-content-text-muted, #8d929d);
-  font-size: 10px;
-  pointer-events: none;
+.flowNodeMeta {
+  color: var(--color-content-text-muted, #8d929d);
+  font-size: 9px;
+  line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.flowHandle {
+  background: var(--color-content-text-secondary, #b3b6bd) !important;
+  border: 2px solid var(--fo-palette-background-level2, #15171b) !important;
+  height: 8px !important;
+  min-height: 8px;
+  min-width: 8px;
+  pointer-events: none !important;
+  width: 8px !important;
+}
+
+.flowLoopHandle {
+  opacity: 0;
 }
 
 .filtered {

--- a/app/packages/multimodal/src/views/episode/transforms/TransformGraphTile.module.css
+++ b/app/packages/multimodal/src/views/episode/transforms/TransformGraphTile.module.css
@@ -124,21 +124,9 @@
 
 .canvasControls {
   align-items: center;
-  background: color-mix(
-    in srgb,
-    var(--fo-palette-background-level2, #15171b) 92%,
-    transparent
-  );
-  border: 1px solid var(--color-content-border-default, #383835);
-  border-radius: 7px;
-  box-shadow: 0 4px 14px rgb(0 0 0 / 24%);
   display: flex;
   gap: 2px;
-  padding: 3px;
-  position: absolute;
-  right: 10px;
-  top: 10px;
-  z-index: 2;
+  margin-left: auto;
 }
 
 .svg {
@@ -177,6 +165,16 @@
   fill: none;
   stroke: var(--color-content-text-muted, #8d929d);
   stroke-width: 1.6;
+}
+
+.edgeGroup {
+  outline: none;
+}
+
+.edgeGroup:focus-visible .edge {
+  filter: drop-shadow(0 0 3px var(--color-content-border-focus, #7ca9ff));
+  stroke: var(--color-content-border-focus, #7ca9ff);
+  stroke-width: 2.5;
 }
 
 .edge_static {
@@ -236,7 +234,7 @@
   stroke: var(--fo-palette-info-main, #4ca3ff);
 }
 
-.issueNode {
+.isolatedNode {
   stroke: var(--fo-palette-error-main, #ff665d);
 }
 
@@ -315,13 +313,6 @@
   display: flex;
   flex-wrap: wrap;
   gap: 5px;
-}
-
-.sampleNote {
-  color: var(--color-content-text-muted);
-  font-size: 10px;
-  line-height: 1.35;
-  margin-top: 3px;
 }
 
 .healthy {
@@ -444,10 +435,5 @@
   .searchField {
     max-width: none;
     width: 100%;
-  }
-
-  .canvasControls {
-    right: 6px;
-    top: 6px;
   }
 }

--- a/app/packages/multimodal/src/views/episode/transforms/TransformGraphTile.test.tsx
+++ b/app/packages/multimodal/src/views/episode/transforms/TransformGraphTile.test.tsx
@@ -11,11 +11,11 @@ import type { TransformTopologyScanState } from "./transform-topology-context";
 import TransformGraphTile from "./TransformGraphTile";
 
 const mocks = vi.hoisted(() => ({
-  canSample: true,
+  analyzeMore: vi.fn(),
+  canAnalyzeMore: true,
   capability: true,
   readPlaybackTimeNs: vi.fn<() => bigint | undefined>(),
   retry: vi.fn(),
-  sampleCurrentTime: vi.fn(),
   setTileTitle: vi.fn(),
   state: {} as TransformTopologyScanState,
 }));
@@ -36,20 +36,20 @@ vi.mock("./transform-topology-context", async (importOriginal) => {
     useTransformTopologyCapability: () => mocks.capability,
     useTransformTopologyScan: () => ({
       ...mocks.state,
-      canSample: mocks.canSample,
+      analyzeMore: mocks.analyzeMore,
+      canAnalyzeMore: mocks.canAnalyzeMore,
       retry: mocks.retry,
-      sampleCurrentTime: mocks.sampleCurrentTime,
     }),
   };
 });
 
 beforeEach(() => {
-  mocks.canSample = true;
+  mocks.analyzeMore.mockReset();
+  mocks.canAnalyzeMore = true;
   mocks.capability = true;
   mocks.readPlaybackTimeNs.mockReset();
   mocks.readPlaybackTimeNs.mockReturnValue(123n);
   mocks.retry.mockReset();
-  mocks.sampleCurrentTime.mockReset();
   mocks.setTileTitle.mockReset();
   mocks.state = partialState();
 });
@@ -69,9 +69,7 @@ describe("TransformGraphTile", () => {
     );
     expect(screen.getByText("2 issues")).toBeTruthy();
     expect(screen.queryByText("Partial", { exact: true })).toBeNull();
-    expect(
-      screen.getByText(/Data spans 2 disconnected components/),
-    ).toBeTruthy();
+    expect(screen.getByText("3 disconnected components")).toBeTruthy();
     expect(
       screen.getByText("Renderable streams are disconnected"),
     ).toBeTruthy();
@@ -81,16 +79,63 @@ describe("TransformGraphTile", () => {
     ).toBeTruthy();
     expect(screen.getByText("Partial analysis")).toBeTruthy();
     expect(screen.queryByText(/108 messages/)).toBeNull();
+    expect(mocks.readPlaybackTimeNs).not.toHaveBeenCalled();
 
-    fireEvent.click(
-      screen.getByRole("button", { name: "Sample current time" }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: "Analyze more" }));
     expect(mocks.readPlaybackTimeNs).toHaveBeenCalledOnce();
-    expect(mocks.sampleCurrentTime).toHaveBeenCalledWith(123n);
+    expect(mocks.analyzeMore).toHaveBeenCalledWith(123n);
+    expect(
+      screen.queryByRole("button", { name: "Continue analysis" }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Add current time" }),
+    ).toBeNull();
   });
 
   it("filters frames and exposes accessible frame and edge selection details", () => {
     render(<TransformGraphTile />);
+
+    const toolbar = screen.getByLabelText("Transform graph controls");
+    expect(
+      within(toolbar).getByRole("searchbox", {
+        name: "Filter transform frames",
+      }),
+    ).toBeTruthy();
+    expect(
+      within(toolbar).getByRole("button", { name: "Zoom out" }),
+    ).toBeTruthy();
+    expect(
+      within(toolbar).getByRole("button", { name: "Zoom in" }),
+    ).toBeTruthy();
+    expect(
+      within(toolbar)
+        .getByRole("button", { name: "Fit transform graph" })
+        .getAttribute("title"),
+    ).toBe("Fit");
+    expect(
+      within(toolbar).queryByRole("button", {
+        name: "Reset transform graph view",
+      }),
+    ).toBeNull();
+    expect(
+      within(screen.getByTestId("transform-topology-canvas")).queryByRole(
+        "button",
+        { name: "Zoom in" },
+      ),
+    ).toBeNull();
+    expect(
+      screen
+        .getByRole("button", { name: "Frame lucid_cam/front_center" })
+        .getAttribute("data-isolated"),
+    ).toBe("true");
+    fireEvent.click(
+      screen.getByRole("button", { name: "Frame lucid_cam/front_center" }),
+    );
+    expect(
+      within(screen.getByTestId("transform-selection-details")).queryByText(
+        "None observed",
+      ),
+    ).toBeNull();
 
     fireEvent.change(
       screen.getByRole("searchbox", { name: "Filter transform frames" }),
@@ -99,7 +144,11 @@ describe("TransformGraphTile", () => {
       },
     );
     expect(screen.getByText("1 of 6")).toBeTruthy();
-    expect(screen.queryByRole("button", { name: "Frame map" })).toBeNull();
+    expect(
+      screen
+        .getByRole("button", { name: "Frame map" })
+        .getAttribute("tabindex"),
+    ).toBe("-1");
 
     fireEvent.change(
       screen.getByRole("searchbox", { name: "Filter transform frames" }),
@@ -117,7 +166,8 @@ describe("TransformGraphTile", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Frame map" }));
     const frameDetails = screen.getByTestId("transform-selection-details");
-    expect(within(frameDetails).getByText("/oxts/odometry")).toBeTruthy();
+    expect(within(frameDetails).queryByText("Renderable streams")).toBeNull();
+    expect(within(frameDetails).queryByText("/oxts/odometry")).toBeNull();
     expect(within(frameDetails).getByText("Static · /tf_static")).toBeTruthy();
     expect(
       within(frameDetails).getByText("Component").parentElement?.textContent,
@@ -134,13 +184,13 @@ describe("TransformGraphTile", () => {
   });
 
   it("renders loading, empty, error, and unavailable states honestly", () => {
-    mocks.state = { ...emptyState(), loading: true };
+    mocks.state = { ...emptyState(), loading: true, operation: "scan" };
     const { rerender } = render(<TransformGraphTile />);
     expect(screen.getByText("Reading transforms")).toBeTruthy();
 
     mocks.state = {
       ...emptyState(),
-      partial: true,
+      status: "partial",
       stopReason: "oversized-source-unit",
       unavailableSpanCount: 4_489,
     };
@@ -148,20 +198,18 @@ describe("TransformGraphTile", () => {
     expect(screen.getByText("More data needed")).toBeTruthy();
     expect(
       screen.getByText(
-        "We scanned a tiny bit of your episode but looks like we need to sample more transform data to build this view",
+        "The initial bounded scan did not find enough transform data. Analyze more to continue the scan and include the current time.",
       ),
     ).toBeTruthy();
     expect(screen.queryByText(/4,489/)).toBeNull();
     expect(
-      screen.queryByRole("button", { name: "Continue analysis" }),
+      screen.queryByRole("button", { name: "Add current time" }),
     ).toBeNull();
-    fireEvent.click(
-      screen.getByRole("button", { name: "Sample current time" }),
-    );
-    expect(mocks.sampleCurrentTime).toHaveBeenCalledWith(123n);
+    fireEvent.click(screen.getByRole("button", { name: "Analyze more" }));
+    expect(mocks.analyzeMore).toHaveBeenCalledWith(123n);
 
-    mocks.canSample = false;
-    mocks.state = { ...emptyState(), complete: true };
+    mocks.canAnalyzeMore = false;
+    mocks.state = { ...emptyState(), status: "complete" };
     rerender(<TransformGraphTile />);
     expect(screen.getByText("No transform topology observed")).toBeTruthy();
 
@@ -183,46 +231,87 @@ describe("TransformGraphTile", () => {
   it("marks fully covered healthy topology complete", () => {
     mocks.state = {
       ...emptyState(),
-      complete: true,
       edges: [edge("map", "base_link", "static", "/tf_static")],
       frameUses: [{ frameId: "map", sourceName: "/odom", streamId: "odom" }],
+      status: "complete",
       stopReason: "source-exhausted",
     };
     render(<TransformGraphTile />);
 
-    expect(screen.getByText("Complete")).toBeTruthy();
+    expect(screen.getByText("Transform scan complete")).toBeTruthy();
     expect(screen.getByText("Connected")).toBeTruthy();
     expect(screen.getByText("No structural issues observed")).toBeTruthy();
+    expect(screen.queryByText("Component 1")).toBeNull();
     expect(screen.queryByTestId("transform-topology-partial")).toBeNull();
   });
 
-  it("labels an explicitly sampled graph without exposing read details", () => {
+  it("warns when the observed transform graph has multiple components", () => {
+    mocks.state = {
+      ...emptyState(),
+      edges: [
+        edge("map", "oxts", "static", "/tf_static"),
+        edge("odom", "base_link", "temporal", "/tf"),
+      ],
+      status: "complete",
+      stopReason: "source-exhausted",
+    };
+    render(<TransformGraphTile />);
+
+    expect(screen.getByText("1 issue")).toBeTruthy();
+    expect(screen.queryByText("Connected")).toBeNull();
+    expect(screen.getByText("Transform graph is disconnected")).toBeTruthy();
+    expect(screen.getByText("2 disconnected components")).toBeTruthy();
+    expect(screen.getByText("Component 1")).toBeTruthy();
+    expect(screen.getByText("Component 2")).toBeTruthy();
+    expect(screen.queryByText(/data frames?/i)).toBeNull();
+    expect(
+      screen
+        .getByRole("button", { name: "Frame map" })
+        .getAttribute("data-isolated"),
+    ).toBeNull();
+    expect(
+      screen
+        .getByRole("button", { name: "Frame base_link" })
+        .getAttribute("data-isolated"),
+    ).toBeNull();
+    expect(
+      screen.getByText(/2 disconnected transform components were observed/),
+    ).toBeTruthy();
+    expect(screen.queryByText("No structural issues observed")).toBeNull();
+  });
+
+  it("keeps one partial-analysis label after adding time evidence", () => {
     mocks.state = {
       ...emptyState(),
       edges: [edge("map", "base_link", "temporal", "/tf")],
-      partial: true,
-      sampled: true,
-      stopReason: "oversized-source-unit",
+      sampledTimesNs: [123n],
+      status: "partial",
+      stopReason: "account-exhausted",
       unavailableSpanCount: 4_489,
       usage: { ...usage(), chunksOpened: 32, messagesDecoded: 99_999 },
     };
     render(<TransformGraphTile />);
 
     expect(screen.queryByText("Sampled", { exact: true })).toBeNull();
-    expect(screen.getByText("Sampled analysis")).toBeTruthy();
+    expect(screen.queryByText("Sampled analysis")).toBeNull();
+    expect(screen.getByText("Partial analysis")).toBeTruthy();
+    expect(screen.queryByText(/budget limit reached/i)).toBeNull();
     expect(screen.queryByText(/99,999|4,489|oversized/i)).toBeNull();
-    fireEvent.click(
-      screen.getByRole("button", { name: "Sample current time" }),
-    );
-    expect(mocks.sampleCurrentTime).toHaveBeenCalledWith(123n);
+    fireEvent.click(screen.getByRole("button", { name: "Analyze more" }));
+    expect(mocks.analyzeMore).toHaveBeenCalledWith(123n);
   });
 
-  it("keeps the current-time action visible and disabled while sampling", () => {
-    mocks.state = { ...partialState(), loading: true };
+  it("keeps the combined action visible and disabled while analyzing", () => {
+    mocks.state = {
+      ...partialState(),
+      loading: true,
+      operation: "analyze",
+    };
     render(<TransformGraphTile />);
 
-    const button = screen.getByRole("button", { name: "Sampling…" });
+    const button = screen.getByRole("button", { name: "Analyzing…" });
     expect((button as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.getByText("Partial analysis")).toBeTruthy();
   });
 });
 
@@ -244,7 +333,7 @@ function partialState(): TransformTopologyScanState {
         streamId: "camera",
       },
     ],
-    partial: true,
+    status: "partial",
     stopReason: "budget-exhausted",
     usage: { ...usage(), chunksOpened: 2, messagesDecoded: 108 },
   };
@@ -252,13 +341,16 @@ function partialState(): TransformTopologyScanState {
 
 function emptyState(): TransformTopologyScanState {
   return {
-    complete: false,
+    continuation: undefined,
     edges: [],
     error: null,
     frameUses: [],
     loading: false,
-    partial: false,
-    sampled: false,
+    operation: undefined,
+    sampledTimesNs: [],
+    scanCanProgress: true,
+    status: "idle",
+    stopReason: undefined,
     unavailableSpanCount: 0,
     usage: usage(),
   };

--- a/app/packages/multimodal/src/views/episode/transforms/TransformGraphTile.test.tsx
+++ b/app/packages/multimodal/src/views/episode/transforms/TransformGraphTile.test.tsx
@@ -14,7 +14,7 @@ const mocks = vi.hoisted(() => ({
   analyzeMore: vi.fn(),
   canAnalyzeMore: true,
   capability: true,
-  readPlaybackTimeNs: vi.fn<() => bigint | undefined>(),
+  playbackTimeNs: 123n as bigint | undefined,
   retry: vi.fn(),
   setTileTitle: vi.fn(),
   state: {} as TransformTopologyScanState,
@@ -25,7 +25,7 @@ vi.mock("@fiftyone/tiling", () => ({
 }));
 
 vi.mock("../playback/use-playback-time-ns", () => ({
-  useReadPlaybackTimeNs: () => mocks.readPlaybackTimeNs,
+  usePlaybackTimeNs: () => mocks.playbackTimeNs,
 }));
 
 vi.mock("./transform-topology-context", async (importOriginal) => {
@@ -47,8 +47,7 @@ beforeEach(() => {
   mocks.analyzeMore.mockReset();
   mocks.canAnalyzeMore = true;
   mocks.capability = true;
-  mocks.readPlaybackTimeNs.mockReset();
-  mocks.readPlaybackTimeNs.mockReturnValue(123n);
+  mocks.playbackTimeNs = 123n;
   mocks.retry.mockReset();
   mocks.setTileTitle.mockReset();
   mocks.state = partialState();
@@ -79,10 +78,9 @@ describe("TransformGraphTile", () => {
     ).toBeTruthy();
     expect(screen.getByText("Partial analysis")).toBeTruthy();
     expect(screen.queryByText(/108 messages/)).toBeNull();
-    expect(mocks.readPlaybackTimeNs).not.toHaveBeenCalled();
+    expect(mocks.analyzeMore).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole("button", { name: "Analyze more" }));
-    expect(mocks.readPlaybackTimeNs).toHaveBeenCalledOnce();
     expect(mocks.analyzeMore).toHaveBeenCalledWith(123n);
     expect(
       screen.queryByRole("button", { name: "Continue analysis" }),
@@ -360,6 +358,7 @@ function emptyState(): TransformTopologyScanState {
     frameUses: [],
     loading: false,
     operation: undefined,
+    sampledRequestTimesNs: [],
     sampledTimesNs: [],
     scanCanProgress: true,
     status: "idle",

--- a/app/packages/multimodal/src/views/episode/transforms/TransformGraphTile.test.tsx
+++ b/app/packages/multimodal/src/views/episode/transforms/TransformGraphTile.test.tsx
@@ -148,7 +148,7 @@ describe("TransformGraphTile", () => {
       screen
         .getByRole("button", { name: "Frame map" })
         .getAttribute("tabindex"),
-    ).toBe("-1");
+    ).toBeNull();
 
     fireEvent.change(
       screen.getByRole("searchbox", { name: "Filter transform frames" }),
@@ -161,10 +161,14 @@ describe("TransformGraphTile", () => {
       { target: { value: "" } },
     );
     expect(
-      screen.getByRole("group", { name: "Static transform topology" }),
+      screen.getByRole("application", {
+        name: "Static transform topology",
+      }),
     ).toBeTruthy();
 
-    fireEvent.click(screen.getByRole("button", { name: "Frame map" }));
+    const mapFrame = screen.getByRole("button", { name: "Frame map" });
+    expect(mapFrame.tagName).toBe("DIV");
+    fireEvent.keyDown(mapFrame, { key: "Enter" });
     const frameDetails = screen.getByTestId("transform-selection-details");
     expect(within(frameDetails).queryByText("Renderable streams")).toBeNull();
     expect(within(frameDetails).queryByText("/oxts/odometry")).toBeNull();
@@ -173,9 +177,15 @@ describe("TransformGraphTile", () => {
       within(frameDetails).getByText("Component").parentElement?.textContent,
     ).toBe("Component1");
 
-    fireEvent.click(
-      screen.getByRole("button", { name: "Transform edge map to base_link" }),
-    );
+    const mapEdge = screen.getByRole("button", {
+      name: "Transform edge map to base_link",
+    });
+    expect(
+      mapEdge
+        .querySelector(".react-flow__edge-path")
+        ?.getAttribute("marker-end"),
+    ).not.toContain("var(");
+    fireEvent.keyDown(mapEdge, { key: " " });
     const edgeDetails = screen.getByTestId("transform-selection-details");
     expect(within(edgeDetails).getByText("Parent")).toBeTruthy();
     expect(within(edgeDetails).getByText("base_link")).toBeTruthy();
@@ -242,6 +252,9 @@ describe("TransformGraphTile", () => {
     expect(screen.getByText("Connected")).toBeTruthy();
     expect(screen.getByText("No structural issues observed")).toBeTruthy();
     expect(screen.queryByText("Component 1")).toBeNull();
+    expect(
+      screen.getByRole("group", { name: "Transform component" }),
+    ).toBeTruthy();
     expect(screen.queryByTestId("transform-topology-partial")).toBeNull();
   });
 

--- a/app/packages/multimodal/src/views/episode/transforms/TransformGraphTile.tsx
+++ b/app/packages/multimodal/src/views/episode/transforms/TransformGraphTile.tsx
@@ -14,7 +14,7 @@ import {
 } from "@voxel51/voodo";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import type { EpisodeTileProps } from "../tiles/tile-types";
-import { useReadPlaybackTimeNs } from "../playback/use-playback-time-ns";
+import { usePlaybackTimeNs } from "../playback/use-playback-time-ns";
 import {
   analyzeTransformTopology,
   type TransformTopologyAnalysis,
@@ -40,14 +40,14 @@ type Selection = TransformGraphSelection;
 const TransformGraphTile: React.FC<EpisodeTileProps> = () => {
   const setTileTitle = useSetTileTitle();
   const capability = useTransformTopologyCapability();
-  const scan = useTransformTopologyScan();
-  const readPlaybackTimeNs = useReadPlaybackTimeNs();
+  const playbackTimeNs = usePlaybackTimeNs();
+  const scan = useTransformTopologyScan(playbackTimeNs);
   const requestAnalyzeMore = scan.analyzeMore;
   const [query, setQuery] = useState("");
   const [selection, setSelection] = useState<Selection | null>(null);
   const analyzeMore = useCallback(() => {
-    requestAnalyzeMore(readPlaybackTimeNs());
-  }, [readPlaybackTimeNs, requestAnalyzeMore]);
+    requestAnalyzeMore(playbackTimeNs);
+  }, [playbackTimeNs, requestAnalyzeMore]);
 
   // This effect keeps the surrounding tile header aligned with this view.
   useEffect(() => {

--- a/app/packages/multimodal/src/views/episode/transforms/TransformGraphTile.tsx
+++ b/app/packages/multimodal/src/views/episode/transforms/TransformGraphTile.tsx
@@ -3,10 +3,7 @@ import {
   BackgroundColor,
   Button,
   EmptyState,
-  FormField,
   IconName,
-  Input,
-  InputType,
   Pill,
   Size,
   Spinner,
@@ -15,20 +12,12 @@ import {
   TextVariant,
   Variant,
 } from "@voxel51/voodo";
-import React, {
-  useCallback,
-  useEffect,
-  useId,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import type { EpisodeTileProps } from "../tiles/tile-types";
 import { useReadPlaybackTimeNs } from "../playback/use-playback-time-ns";
 import {
   analyzeTransformTopology,
   type TransformTopologyAnalysis,
-  type TransformTopologyComponent,
   type TransformTopologyEdge,
   type TransformTopologyFrame,
   type TransformTopologyIssue,
@@ -39,21 +28,13 @@ import {
   useTransformTopologyCapability,
   useTransformTopologyScan,
 } from "./transform-topology-context";
+import {
+  TransformGraphCanvas,
+  type TransformGraphSelection,
+} from "./TransformGraphCanvas";
 import styles from "./TransformGraphTile.module.css";
 
-type Selection =
-  | { readonly id: string; readonly kind: "edge" }
-  | { readonly id: string; readonly kind: "frame" };
-
-interface Viewport {
-  readonly scale: number;
-  readonly x: number;
-  readonly y: number;
-}
-
-const MIN_SCALE = 0.25;
-const MAX_SCALE = 2.5;
-const GRAPH_INSET = 28;
+type Selection = TransformGraphSelection;
 
 /** Static, demand-driven transform topology diagnostic tile. */
 const TransformGraphTile: React.FC<EpisodeTileProps> = () => {
@@ -191,7 +172,7 @@ const TransformGraphTile: React.FC<EpisodeTileProps> = () => {
       <CoverageNotice onAnalyzeMore={analyzeMore} scan={scan} />
       <div className={styles.workspace}>
         <section className={styles.graphColumn} aria-label="Transform graph">
-          <TopologyCanvas
+          <TransformGraphCanvas
             analysis={analysis}
             layout={layout}
             matchingFrameIds={matchingFrameIds}
@@ -348,347 +329,6 @@ function CoverageNotice({
         ) : null}
       </div>
     </div>
-  );
-}
-
-function TopologyCanvas({
-  analysis,
-  layout,
-  matchingFrameIds,
-  onQueryChange,
-  onSelect,
-  query,
-  queryActive,
-  selection,
-}: {
-  readonly analysis: TransformTopologyAnalysis;
-  readonly layout: ReturnType<typeof layoutTransformTopology>;
-  readonly matchingFrameIds: ReadonlySet<string>;
-  readonly onQueryChange: (query: string) => void;
-  readonly onSelect: (selection: Selection) => void;
-  readonly query: string;
-  readonly queryActive: boolean;
-  readonly selection: Selection | null;
-}) {
-  const arrowMarkerId = `transform-topology-arrow-${useId().replaceAll(":", "")}`;
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [viewport, setViewport] = useState<Viewport>({ scale: 1, x: 0, y: 0 });
-  const dragRef = useRef<{
-    readonly pointerId: number;
-    readonly startX: number;
-    readonly startY: number;
-    readonly viewport: Viewport;
-  } | null>(null);
-  const edgeById = useMemo(
-    () => new Map(analysis.edges.map((edge) => [edge.id, edge])),
-    [analysis.edges],
-  );
-  const frameById = useMemo(
-    () => new Map(analysis.frames.map((frame) => [frame.id, frame])),
-    [analysis.frames],
-  );
-  const connectedFrameIds = useMemo(
-    () =>
-      new Set(
-        analysis.edges.flatMap((edge) => [
-          edge.parentFrameId,
-          edge.childFrameId,
-        ]),
-      ),
-    [analysis.edges],
-  );
-  const componentRects = useMemo(
-    () => componentBounds(analysis.components, layout.nodes),
-    [analysis.components, layout.nodes],
-  );
-
-  const fit = useCallback(() => {
-    const element = containerRef.current;
-    if (
-      !element ||
-      element.clientWidth <= 0 ||
-      element.clientHeight <= 0 ||
-      componentRects.length === 0
-    ) {
-      return;
-    }
-    const left = Math.min(...componentRects.map((component) => component.x));
-    const top = Math.min(...componentRects.map((component) => component.y));
-    const right = Math.max(
-      ...componentRects.map((component) => component.x + component.width),
-    );
-    const bottom = Math.max(
-      ...componentRects.map((component) => component.y + component.height),
-    );
-    const width = right - left;
-    const height = bottom - top;
-    // Fit may go below the manual zoom floor so every component stays visible.
-    const scale = Math.min(
-      Math.max(1, element.clientWidth - GRAPH_INSET * 2) / width,
-      Math.max(1, element.clientHeight - GRAPH_INSET * 2) / height,
-      MAX_SCALE,
-    );
-    setViewport({
-      scale,
-      x: (element.clientWidth - width * scale) / 2 - left * scale,
-      y: (element.clientHeight - height * scale) / 2 - top * scale,
-    });
-  }, [componentRects]);
-
-  // This effect fits the graph initially and after its tile changes size.
-  useEffect(() => {
-    fit();
-    const element = containerRef.current;
-    if (!element || typeof ResizeObserver === "undefined") return;
-    const observer = new ResizeObserver(fit);
-    observer.observe(element);
-    return () => observer.disconnect();
-  }, [fit]);
-
-  const zoom = useCallback((factor: number) => {
-    const element = containerRef.current;
-    if (!element) return;
-    setViewport((current) => {
-      const scale = clamp(current.scale * factor, MIN_SCALE, MAX_SCALE);
-      const centerX = element.clientWidth / 2;
-      const centerY = element.clientHeight / 2;
-      const ratio = scale / current.scale;
-      return {
-        scale,
-        x: centerX - (centerX - current.x) * ratio,
-        y: centerY - (centerY - current.y) * ratio,
-      };
-    });
-  }, []);
-
-  // This effect routes non-passive wheel input into centered graph zoom.
-  useEffect(() => {
-    const element = containerRef.current;
-    if (!element) return;
-    const handleWheel = (event: WheelEvent) => {
-      event.preventDefault();
-      zoom(event.deltaY < 0 ? 1.12 : 1 / 1.12);
-    };
-    element.addEventListener("wheel", handleWheel, { passive: false });
-    return () => element.removeEventListener("wheel", handleWheel);
-  }, [zoom]);
-
-  return (
-    <>
-      <div
-        aria-label="Transform graph controls"
-        className={styles.graphToolbar}
-      >
-        <FormField
-          className={styles.searchField}
-          control={
-            <Input
-              aria-label="Filter transform frames"
-              icon={IconName.Search}
-              onChange={(event) => onQueryChange(event.target.value)}
-              placeholder="Frame name"
-              size={Size.Sm}
-              type={InputType.Search}
-              value={query}
-            />
-          }
-        />
-        {queryActive ? (
-          <Text color={TextColor.Secondary} variant={TextVariant.Xs}>
-            {matchingFrameIds.size} of {analysis.frames.length}
-          </Text>
-        ) : null}
-        <div className={styles.canvasControls}>
-          <Button
-            aria-label="Zoom out"
-            borderless
-            leadingIcon={IconName.Remove}
-            onClick={() => zoom(1 / 1.2)}
-            size={Size.Xs}
-            variant={Variant.Icon}
-          />
-          <Button
-            aria-label="Zoom in"
-            borderless
-            leadingIcon={IconName.Add}
-            onClick={() => zoom(1.2)}
-            size={Size.Xs}
-            variant={Variant.Icon}
-          />
-          <Button
-            aria-label="Fit transform graph"
-            borderless
-            leadingIcon={IconName.Fullscreen}
-            onClick={fit}
-            size={Size.Xs}
-            title="Fit"
-            variant={Variant.Icon}
-          />
-        </div>
-      </div>
-      <div
-        className={styles.canvas}
-        data-testid="transform-topology-canvas"
-        onPointerDown={(event) => {
-          if (event.button !== 0 || event.target !== event.currentTarget)
-            return;
-          event.currentTarget.setPointerCapture(event.pointerId);
-          dragRef.current = {
-            pointerId: event.pointerId,
-            startX: event.clientX,
-            startY: event.clientY,
-            viewport,
-          };
-        }}
-        onPointerMove={(event) => {
-          const drag = dragRef.current;
-          if (!drag || drag.pointerId !== event.pointerId) return;
-          setViewport({
-            ...drag.viewport,
-            x: drag.viewport.x + event.clientX - drag.startX,
-            y: drag.viewport.y + event.clientY - drag.startY,
-          });
-        }}
-        onPointerUp={(event) => {
-          if (dragRef.current?.pointerId === event.pointerId)
-            dragRef.current = null;
-        }}
-        onPointerCancel={(event) => {
-          if (dragRef.current?.pointerId === event.pointerId)
-            dragRef.current = null;
-        }}
-        onLostPointerCapture={(event) => {
-          if (dragRef.current?.pointerId === event.pointerId)
-            dragRef.current = null;
-        }}
-        ref={containerRef}
-      >
-        <svg
-          aria-label="Static transform topology"
-          className={styles.svg}
-          role="group"
-        >
-          <defs>
-            <marker
-              id={arrowMarkerId}
-              markerHeight="7"
-              markerUnits="strokeWidth"
-              markerWidth="7"
-              orient="auto"
-              refX="6"
-              refY="3.5"
-            >
-              <path className={styles.arrowHead} d="M 0 0 L 7 3.5 L 0 7 z" />
-            </marker>
-          </defs>
-          <g
-            transform={`translate(${viewport.x} ${viewport.y}) scale(${viewport.scale})`}
-          >
-            {componentRects.map((component, index) => (
-              <g key={component.id}>
-                <rect
-                  className={styles.componentBox}
-                  height={component.height}
-                  rx="12"
-                  width={component.width}
-                  x={component.x}
-                  y={component.y}
-                />
-                {componentRects.length > 1 ? (
-                  <text
-                    className={styles.componentLabel}
-                    x={component.x + 12}
-                    y={component.y + 19}
-                  >
-                    {`Component ${index + 1}`}
-                  </text>
-                ) : null}
-              </g>
-            ))}
-            {layout.edges.map((layoutEdge) => {
-              const edge = edgeById.get(layoutEdge.edgeId);
-              if (!edge) return null;
-              const matched =
-                !queryActive ||
-                matchingFrameIds.has(edge.parentFrameId) ||
-                matchingFrameIds.has(edge.childFrameId);
-              const selected =
-                selection?.kind === "edge" && selection.id === edge.id;
-              const path = edgePath(layoutEdge.source, layoutEdge.target);
-              const edgeVariant = styles[`edge_${edge.kind}`] ?? "";
-              // These are independent buttons, so each match stays tabbable.
-              return (
-                <g
-                  aria-label={`Transform edge ${edge.parentFrameId} to ${edge.childFrameId}`}
-                  className={`${styles.edgeGroup} ${!matched ? styles.filtered : ""}`}
-                  key={edge.id}
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    onSelect({ id: edge.id, kind: "edge" });
-                  }}
-                  onKeyDown={(event) => {
-                    if (event.key !== "Enter" && event.key !== " ") return;
-                    event.preventDefault();
-                    onSelect({ id: edge.id, kind: "edge" });
-                  }}
-                  role="button"
-                  tabIndex={matched ? 0 : -1}
-                >
-                  <path
-                    className={`${styles.edge} ${edgeVariant} ${selected ? styles.selectedEdge : ""}`}
-                    d={path}
-                    markerEnd={`url(#${arrowMarkerId})`}
-                  />
-                  <path className={styles.edgeHitTarget} d={path} />
-                </g>
-              );
-            })}
-            {layout.nodes.map((node) => {
-              const frame = frameById.get(node.frameId);
-              if (!frame) return null;
-              const matched = !queryActive || matchingFrameIds.has(frame.id);
-              const selected =
-                selection?.kind === "frame" && selection.id === frame.id;
-              const isolated = !connectedFrameIds.has(frame.id);
-              return (
-                <g
-                  aria-label={`Frame ${frame.id}`}
-                  className={`${styles.node} ${!matched ? styles.filtered : ""}`}
-                  data-isolated={isolated || undefined}
-                  key={frame.id}
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    onSelect({ id: frame.id, kind: "frame" });
-                  }}
-                  onKeyDown={(event) => {
-                    if (event.key !== "Enter" && event.key !== " ") return;
-                    event.preventDefault();
-                    onSelect({ id: frame.id, kind: "frame" });
-                  }}
-                  role="button"
-                  tabIndex={matched ? 0 : -1}
-                  transform={`translate(${node.x} ${node.y})`}
-                >
-                  <rect
-                    className={`${styles.nodeBox} ${frame.dataBearing ? styles.dataNode : ""} ${isolated ? styles.isolatedNode : ""} ${selected ? styles.selectedNode : ""}`}
-                    height={node.height}
-                    rx="7"
-                    width={node.width}
-                  />
-                  <title>{`${frame.id} — ${fullTransformSourceSummary(frame.transformSources)}`}</title>
-                  <text className={styles.nodeLabel} x="12" y="18">
-                    {shortFrameLabel(frame.id)}
-                  </text>
-                  <text className={styles.nodeMeta} x="12" y="34">
-                    {shortTransformSourceSummary(frame.transformSources)}
-                  </text>
-                </g>
-              );
-            })}
-          </g>
-        </svg>
-      </div>
-    </>
   );
 }
 
@@ -900,81 +540,6 @@ function TileState({
   );
 }
 
-function componentBounds(
-  components: readonly TransformTopologyComponent[],
-  nodes: readonly {
-    readonly frameId: string;
-    readonly height: number;
-    readonly width: number;
-    readonly x: number;
-    readonly y: number;
-  }[],
-) {
-  const nodeByFrame = new Map(nodes.map((node) => [node.frameId, node]));
-  return components.flatMap((component) => {
-    const componentNodes = component.frameIds.flatMap((frameId) => {
-      const node = nodeByFrame.get(frameId);
-      return node ? [node] : [];
-    });
-    if (componentNodes.length === 0) return [];
-    const x = Math.min(...componentNodes.map((node) => node.x)) - 12;
-    const topInset = components.length > 1 ? 32 : 12;
-    const y = Math.min(...componentNodes.map((node) => node.y)) - topInset;
-    const right = Math.max(
-      ...componentNodes.map((node) => node.x + node.width),
-    );
-    const bottom = Math.max(
-      ...componentNodes.map((node) => node.y + node.height),
-    );
-    return [
-      {
-        dataBearingFrameCount: component.dataBearingFrameCount,
-        frameCount: component.frameIds.length,
-        height: bottom - y + 12,
-        id: component.id,
-        width: right - x + 12,
-        x,
-        y,
-      },
-    ];
-  });
-}
-
-function edgePath(
-  source: readonly [number, number],
-  target: readonly [number, number],
-): string {
-  const bend = Math.max(36, Math.abs(target[0] - source[0]) * 0.45);
-  const direction = target[0] >= source[0] ? 1 : -1;
-  return `M ${source[0]} ${source[1]} C ${source[0] + bend * direction} ${source[1]}, ${target[0] - bend * direction} ${target[1]}, ${target[0]} ${target[1]}`;
-}
-
-function shortFrameLabel(frameId: string): string {
-  return frameId.length <= 24 ? frameId : `${frameId.slice(0, 21)}…`;
-}
-
-function shortTransformSourceSummary(
-  sources: readonly TransformTopologySource[],
-): string {
-  if (sources.length === 0) return "transform source unknown";
-  const visible = sources
-    .slice(0, 2)
-    .map((source) => source.sourceName.replace(/^\/+/, ""));
-  const suffix =
-    sources.length > visible.length ? ` +${sources.length - 2}` : "";
-  const summary = `${visible.join(" + ")}${suffix}`;
-  return summary.length <= 28 ? summary : `${summary.slice(0, 25)}…`;
-}
-
-function fullTransformSourceSummary(
-  sources: readonly TransformTopologySource[],
-): string {
-  if (sources.length === 0) return "no transform source observed";
-  return sources
-    .map((source) => `${source.sourceName} (${source.kind})`)
-    .join(", ");
-}
-
 function transformSourceColor(
   kind: TransformTopologySource["kind"],
 ): TextColor {
@@ -989,10 +554,6 @@ function formatNanoseconds(value: bigint): string {
 
 function capitalize(value: string): string {
   return `${value.charAt(0).toUpperCase()}${value.slice(1)}`;
-}
-
-function clamp(value: number, min: number, max: number): number {
-  return Math.max(min, Math.min(max, value));
 }
 
 export default TransformGraphTile;

--- a/app/packages/multimodal/src/views/episode/transforms/TransformGraphTile.tsx
+++ b/app/packages/multimodal/src/views/episode/transforms/TransformGraphTile.tsx
@@ -53,7 +53,6 @@ interface Viewport {
 
 const MIN_SCALE = 0.25;
 const MAX_SCALE = 2.5;
-const MIN_READABLE_FIT_SCALE = 0.65;
 const GRAPH_INSET = 28;
 
 /** Static, demand-driven transform topology diagnostic tile. */
@@ -62,13 +61,12 @@ const TransformGraphTile: React.FC<EpisodeTileProps> = () => {
   const capability = useTransformTopologyCapability();
   const scan = useTransformTopologyScan();
   const readPlaybackTimeNs = useReadPlaybackTimeNs();
-  const requestCurrentTimeSample = scan.sampleCurrentTime;
+  const requestAnalyzeMore = scan.analyzeMore;
   const [query, setQuery] = useState("");
   const [selection, setSelection] = useState<Selection | null>(null);
-  const sampleCurrentTime = useCallback(() => {
-    const timeNs = readPlaybackTimeNs();
-    if (timeNs !== undefined) requestCurrentTimeSample(timeNs);
-  }, [readPlaybackTimeNs, requestCurrentTimeSample]);
+  const analyzeMore = useCallback(() => {
+    requestAnalyzeMore(readPlaybackTimeNs());
+  }, [readPlaybackTimeNs, requestAnalyzeMore]);
 
   // This effect keeps the surrounding tile header aligned with this view.
   useEffect(() => {
@@ -110,7 +108,12 @@ const TransformGraphTile: React.FC<EpisodeTileProps> = () => {
       </TileState>
     );
   }
-  if (scan.loading && analysis.frames.length === 0 && !scan.error) {
+  if (
+    scan.loading &&
+    scan.operation === "scan" &&
+    analysis.frames.length === 0 &&
+    !scan.error
+  ) {
     return (
       <TileState status="Reading transforms">
         <Spinner size={Size.Lg} />
@@ -136,9 +139,10 @@ const TransformGraphTile: React.FC<EpisodeTileProps> = () => {
       </TileState>
     );
   }
-  if (!scan.loading && analysis.frames.length === 0) {
-    const emptyAnalysisIsPartial = !scan.complete;
-    const emptyTitle = scan.sampled
+  if (analysis.frames.length === 0) {
+    const emptyAnalysisIsPartial = scan.status !== "complete" || scan.loading;
+    const hasTimeSamples = scan.sampledTimesNs.length > 0;
+    const emptyTitle = hasTimeSamples
       ? "No transform sample found"
       : "More data needed";
     return (
@@ -146,9 +150,9 @@ const TransformGraphTile: React.FC<EpisodeTileProps> = () => {
         <EmptyState
           description={
             emptyAnalysisIsPartial
-              ? scan.sampled
+              ? hasTimeSamples
                 ? "The targeted read did not return a usable transform graph."
-                : "We scanned a tiny bit of your episode but looks like we need to sample more transform data to build this view"
+                : "The initial bounded scan did not find enough transform data. Analyze more to continue the scan and include the current time."
               : "The complete analysis contained no frame-transform relationships or renderable frame IDs."
           }
           icon={emptyAnalysisIsPartial ? IconName.Warning : IconName.Workspaces}
@@ -158,16 +162,24 @@ const TransformGraphTile: React.FC<EpisodeTileProps> = () => {
               : "No transform topology observed"
           }
         />
-        {!scan.error && scan.canSample ? (
-          <Button
-            disabled={scan.loading}
-            leadingIcon={scan.loading ? IconName.Spinner : IconName.Refresh}
-            onClick={sampleCurrentTime}
-            size={Size.Sm}
-            variant={Variant.Secondary}
-          >
-            {scan.loading ? "Sampling…" : "Sample current time"}
-          </Button>
+        {!scan.error ? (
+          <div className={styles.coverageActions}>
+            {scan.canAnalyzeMore ? (
+              <Button
+                disabled={scan.loading}
+                leadingIcon={
+                  scan.operation === "analyze"
+                    ? IconName.Spinner
+                    : IconName.Refresh
+                }
+                onClick={analyzeMore}
+                size={Size.Sm}
+                variant={Variant.Secondary}
+              >
+                {scan.operation === "analyze" ? "Analyzing…" : "Analyze more"}
+              </Button>
+            ) : null}
+          </div>
         ) : null}
       </TileState>
     );
@@ -176,35 +188,16 @@ const TransformGraphTile: React.FC<EpisodeTileProps> = () => {
   return (
     <div className={styles.root} data-testid="transform-graph-tile">
       <SummaryHeader analysis={analysis} scan={scan} />
-      <CoverageNotice onSampleCurrentTime={sampleCurrentTime} scan={scan} />
+      <CoverageNotice onAnalyzeMore={analyzeMore} scan={scan} />
       <div className={styles.workspace}>
         <section className={styles.graphColumn} aria-label="Transform graph">
-          <div className={styles.graphToolbar}>
-            <FormField
-              className={styles.searchField}
-              control={
-                <Input
-                  aria-label="Filter transform frames"
-                  icon={IconName.Search}
-                  onChange={(event) => setQuery(event.target.value)}
-                  placeholder="Frame name"
-                  size={Size.Sm}
-                  type={InputType.Search}
-                  value={query}
-                />
-              }
-            />
-            {normalizedQuery ? (
-              <Text color={TextColor.Secondary} variant={TextVariant.Xs}>
-                {matchingFrameIds.size} of {analysis.frames.length}
-              </Text>
-            ) : null}
-          </div>
           <TopologyCanvas
             analysis={analysis}
             layout={layout}
             matchingFrameIds={matchingFrameIds}
+            onQueryChange={setQuery}
             onSelect={setSelection}
+            query={query}
             queryActive={normalizedQuery.length > 0}
             selection={selection}
           />
@@ -226,9 +219,11 @@ function SummaryHeader({
   readonly scan: ReturnType<typeof useTransformTopologyScan>;
 }) {
   const hasErrors = analysis.issues.some((issue) => issue.severity === "error");
-  const dataBearingComponents = analysis.components.filter(
-    (component) => component.dataBearingFrameCount > 0,
-  ).length;
+  const hasWarnings = analysis.issues.some(
+    (issue) => issue.severity === "warning",
+  );
+  const issueCount = analysis.issues.length;
+  const componentCount = analysis.summary.componentCount;
   return (
     <header className={styles.summary}>
       <div className={styles.summaryMetrics}>
@@ -239,25 +234,32 @@ function SummaryHeader({
         <SummaryMetric label="Frames" value={analysis.summary.frameCount} />
         <SummaryMetric label="Edges" value={analysis.summary.edgeCount} />
         <SummaryMetric
-          emphasis={hasErrors}
           label="Health"
-          value={hasErrors ? `${analysis.issues.length} issues` : "Connected"}
+          severity={hasErrors ? "error" : hasWarnings ? "warning" : undefined}
+          value={
+            issueCount === 0
+              ? "Connected"
+              : `${issueCount} ${issueCount === 1 ? "issue" : "issues"}`
+          }
         />
       </div>
       <div className={styles.summaryStatus}>
-        {dataBearingComponents > 1 ? (
-          <Text color={TextColor.Destructive} variant={TextVariant.Xs}>
-            Data spans {dataBearingComponents} disconnected components
+        {componentCount > 1 ? (
+          <Text
+            color={hasErrors ? TextColor.Destructive : TextColor.Warning}
+            variant={TextVariant.Xs}
+          >
+            {componentCount} disconnected components
           </Text>
         ) : null}
-        {scan.complete ? (
+        {scan.status === "complete" ? (
           <Pill
             backgroundColor={BackgroundColor.Secondary}
             color={TextColor.Primary}
             isStatus
             size={Size.Xs}
           >
-            Complete
+            Transform scan complete
           </Pill>
         ) : null}
       </div>
@@ -266,12 +268,12 @@ function SummaryHeader({
 }
 
 function SummaryMetric({
-  emphasis = false,
   label,
+  severity,
   value,
 }: {
-  readonly emphasis?: boolean;
   readonly label: string;
+  readonly severity?: TransformTopologyIssue["severity"];
   readonly value: number | string;
 }) {
   return (
@@ -280,7 +282,13 @@ function SummaryMetric({
         {label}
       </Text>
       <Text
-        color={emphasis ? TextColor.Destructive : TextColor.Primary}
+        color={
+          severity === "error"
+            ? TextColor.Destructive
+            : severity === "warning"
+              ? TextColor.Warning
+              : TextColor.Primary
+        }
         variant={TextVariant.Sm}
       >
         {value}
@@ -290,18 +298,16 @@ function SummaryMetric({
 }
 
 function CoverageNotice({
-  onSampleCurrentTime,
+  onAnalyzeMore,
   scan,
 }: {
-  readonly onSampleCurrentTime: () => void;
+  readonly onAnalyzeMore: () => void;
   readonly scan: ReturnType<typeof useTransformTopologyScan>;
 }) {
-  if (scan.complete && !scan.error) return null;
+  if (scan.status === "complete" && !scan.error && !scan.loading) return null;
   const coverageSummary = scan.error
     ? "Analysis interrupted"
-    : scan.sampled
-      ? "Sampled analysis"
-      : "Partial analysis";
+    : "Partial analysis";
   return (
     <div
       className={styles.coverageNotice}
@@ -327,15 +333,17 @@ function CoverageNotice({
             Retry
           </Button>
         ) : null}
-        {!scan.error && scan.canSample ? (
+        {!scan.error && scan.canAnalyzeMore ? (
           <Button
             disabled={scan.loading}
-            leadingIcon={scan.loading ? IconName.Spinner : IconName.Refresh}
-            onClick={onSampleCurrentTime}
+            leadingIcon={
+              scan.operation === "analyze" ? IconName.Spinner : IconName.Refresh
+            }
+            onClick={onAnalyzeMore}
             size={Size.Xs}
             variant={Variant.Secondary}
           >
-            {scan.loading ? "Sampling…" : "Sample current time"}
+            {scan.operation === "analyze" ? "Analyzing…" : "Analyze more"}
           </Button>
         ) : null}
       </div>
@@ -347,14 +355,18 @@ function TopologyCanvas({
   analysis,
   layout,
   matchingFrameIds,
+  onQueryChange,
   onSelect,
+  query,
   queryActive,
   selection,
 }: {
   readonly analysis: TransformTopologyAnalysis;
   readonly layout: ReturnType<typeof layoutTransformTopology>;
   readonly matchingFrameIds: ReadonlySet<string>;
+  readonly onQueryChange: (query: string) => void;
   readonly onSelect: (selection: Selection) => void;
+  readonly query: string;
   readonly queryActive: boolean;
   readonly selection: Selection | null;
 }) {
@@ -375,17 +387,16 @@ function TopologyCanvas({
     () => new Map(analysis.frames.map((frame) => [frame.id, frame])),
     [analysis.frames],
   );
-  const issuesByFrame = useMemo(() => {
-    const map = new Map<string, TransformTopologyIssue[]>();
-    for (const issue of analysis.issues) {
-      for (const frameId of issue.affectedFrameIds) {
-        const issues = map.get(frameId) ?? [];
-        issues.push(issue);
-        map.set(frameId, issues);
-      }
-    }
-    return map;
-  }, [analysis.issues]);
+  const connectedFrameIds = useMemo(
+    () =>
+      new Set(
+        analysis.edges.flatMap((edge) => [
+          edge.parentFrameId,
+          edge.childFrameId,
+        ]),
+      ),
+    [analysis.edges],
+  );
   const componentRects = useMemo(
     () => componentBounds(analysis.components, layout.nodes),
     [analysis.components, layout.nodes],
@@ -393,37 +404,36 @@ function TopologyCanvas({
 
   const fit = useCallback(() => {
     const element = containerRef.current;
-    if (!element) return;
-    const fittedScale = Math.min(
-      (element.clientWidth - GRAPH_INSET * 2) / layout.bounds.width,
-      (element.clientHeight - GRAPH_INSET * 2) / layout.bounds.height,
+    if (
+      !element ||
+      element.clientWidth <= 0 ||
+      element.clientHeight <= 0 ||
+      componentRects.length === 0
+    ) {
+      return;
+    }
+    const left = Math.min(...componentRects.map((component) => component.x));
+    const top = Math.min(...componentRects.map((component) => component.y));
+    const right = Math.max(
+      ...componentRects.map((component) => component.x + component.width),
     );
-    const scale = clamp(fittedScale, MIN_READABLE_FIT_SCALE, MAX_SCALE);
-    const largestComponent = [...componentRects].sort(
-      (left, right) =>
-        right.frameCount - left.frameCount ||
-        right.dataBearingFrameCount - left.dataBearingFrameCount ||
-        left.id.localeCompare(right.id),
-    )[0];
-    const focusBounds =
-      fittedScale < MIN_READABLE_FIT_SCALE && largestComponent
-        ? largestComponent
-        : {
-            height: layout.bounds.height,
-            width: layout.bounds.width,
-            x: 0,
-            y: 0,
-          };
+    const bottom = Math.max(
+      ...componentRects.map((component) => component.y + component.height),
+    );
+    const width = right - left;
+    const height = bottom - top;
+    // Fit may go below the manual zoom floor so every component stays visible.
+    const scale = Math.min(
+      Math.max(1, element.clientWidth - GRAPH_INSET * 2) / width,
+      Math.max(1, element.clientHeight - GRAPH_INSET * 2) / height,
+      MAX_SCALE,
+    );
     setViewport({
       scale,
-      x:
-        (element.clientWidth - focusBounds.width * scale) / 2 -
-        focusBounds.x * scale,
-      y:
-        (element.clientHeight - focusBounds.height * scale) / 2 -
-        focusBounds.y * scale,
+      x: (element.clientWidth - width * scale) / 2 - left * scale,
+      y: (element.clientHeight - height * scale) / 2 - top * scale,
     });
-  }, [componentRects, layout.bounds.height, layout.bounds.width]);
+  }, [componentRects]);
 
   // This effect fits the graph initially and after its tile changes size.
   useEffect(() => {
@@ -451,6 +461,7 @@ function TopologyCanvas({
     });
   }, []);
 
+  // This effect routes non-passive wheel input into centered graph zoom.
   useEffect(() => {
     const element = containerRef.current;
     if (!element) return;
@@ -463,201 +474,221 @@ function TopologyCanvas({
   }, [zoom]);
 
   return (
-    <div
-      className={styles.canvas}
-      data-testid="transform-topology-canvas"
-      onPointerDown={(event) => {
-        if (event.button !== 0 || event.target !== event.currentTarget) return;
-        event.currentTarget.setPointerCapture(event.pointerId);
-        dragRef.current = {
-          pointerId: event.pointerId,
-          startX: event.clientX,
-          startY: event.clientY,
-          viewport,
-        };
-      }}
-      onPointerMove={(event) => {
-        const drag = dragRef.current;
-        if (!drag || drag.pointerId !== event.pointerId) return;
-        setViewport({
-          ...drag.viewport,
-          x: drag.viewport.x + event.clientX - drag.startX,
-          y: drag.viewport.y + event.clientY - drag.startY,
-        });
-      }}
-      onPointerUp={(event) => {
-        if (dragRef.current?.pointerId === event.pointerId)
-          dragRef.current = null;
-      }}
-      onPointerCancel={(event) => {
-        if (dragRef.current?.pointerId === event.pointerId)
-          dragRef.current = null;
-      }}
-      onLostPointerCapture={(event) => {
-        if (dragRef.current?.pointerId === event.pointerId)
-          dragRef.current = null;
-      }}
-      ref={containerRef}
-    >
-      <div className={styles.canvasControls}>
-        <Button
-          aria-label="Zoom out"
-          borderless
-          leadingIcon={IconName.Remove}
-          onClick={() => zoom(1 / 1.2)}
-          size={Size.Xs}
-          variant={Variant.Icon}
-        />
-        <Button
-          aria-label="Zoom in"
-          borderless
-          leadingIcon={IconName.Add}
-          onClick={() => zoom(1.2)}
-          size={Size.Xs}
-          variant={Variant.Icon}
-        />
-        <Button
-          aria-label="Fit transform graph"
-          borderless
-          leadingIcon={IconName.Fullscreen}
-          onClick={fit}
-          size={Size.Xs}
-          title="Fit at a readable scale"
-          variant={Variant.Icon}
-        />
-        <Button
-          aria-label="Reset transform graph view"
-          borderless
-          leadingIcon={IconName.Undo}
-          onClick={() => setViewport({ scale: 1, x: 0, y: 0 })}
-          size={Size.Xs}
-          title="Reset graph view"
-          variant={Variant.Icon}
-        />
-      </div>
-      <svg
-        aria-label="Static transform topology"
-        className={styles.svg}
-        role="group"
+    <>
+      <div
+        aria-label="Transform graph controls"
+        className={styles.graphToolbar}
       >
-        <defs>
-          <marker
-            id={arrowMarkerId}
-            markerHeight="7"
-            markerUnits="strokeWidth"
-            markerWidth="7"
-            orient="auto"
-            refX="6"
-            refY="3.5"
-          >
-            <path className={styles.arrowHead} d="M 0 0 L 7 3.5 L 0 7 z" />
-          </marker>
-        </defs>
-        <g
-          transform={`translate(${viewport.x} ${viewport.y}) scale(${viewport.scale})`}
+        <FormField
+          className={styles.searchField}
+          control={
+            <Input
+              aria-label="Filter transform frames"
+              icon={IconName.Search}
+              onChange={(event) => onQueryChange(event.target.value)}
+              placeholder="Frame name"
+              size={Size.Sm}
+              type={InputType.Search}
+              value={query}
+            />
+          }
+        />
+        {queryActive ? (
+          <Text color={TextColor.Secondary} variant={TextVariant.Xs}>
+            {matchingFrameIds.size} of {analysis.frames.length}
+          </Text>
+        ) : null}
+        <div className={styles.canvasControls}>
+          <Button
+            aria-label="Zoom out"
+            borderless
+            leadingIcon={IconName.Remove}
+            onClick={() => zoom(1 / 1.2)}
+            size={Size.Xs}
+            variant={Variant.Icon}
+          />
+          <Button
+            aria-label="Zoom in"
+            borderless
+            leadingIcon={IconName.Add}
+            onClick={() => zoom(1.2)}
+            size={Size.Xs}
+            variant={Variant.Icon}
+          />
+          <Button
+            aria-label="Fit transform graph"
+            borderless
+            leadingIcon={IconName.Fullscreen}
+            onClick={fit}
+            size={Size.Xs}
+            title="Fit"
+            variant={Variant.Icon}
+          />
+        </div>
+      </div>
+      <div
+        className={styles.canvas}
+        data-testid="transform-topology-canvas"
+        onPointerDown={(event) => {
+          if (event.button !== 0 || event.target !== event.currentTarget)
+            return;
+          event.currentTarget.setPointerCapture(event.pointerId);
+          dragRef.current = {
+            pointerId: event.pointerId,
+            startX: event.clientX,
+            startY: event.clientY,
+            viewport,
+          };
+        }}
+        onPointerMove={(event) => {
+          const drag = dragRef.current;
+          if (!drag || drag.pointerId !== event.pointerId) return;
+          setViewport({
+            ...drag.viewport,
+            x: drag.viewport.x + event.clientX - drag.startX,
+            y: drag.viewport.y + event.clientY - drag.startY,
+          });
+        }}
+        onPointerUp={(event) => {
+          if (dragRef.current?.pointerId === event.pointerId)
+            dragRef.current = null;
+        }}
+        onPointerCancel={(event) => {
+          if (dragRef.current?.pointerId === event.pointerId)
+            dragRef.current = null;
+        }}
+        onLostPointerCapture={(event) => {
+          if (dragRef.current?.pointerId === event.pointerId)
+            dragRef.current = null;
+        }}
+        ref={containerRef}
+      >
+        <svg
+          aria-label="Static transform topology"
+          className={styles.svg}
+          role="group"
         >
-          {componentRects.map((component, index) => (
-            <g key={component.id}>
-              <rect
-                className={styles.componentBox}
-                height={component.height}
-                rx="12"
-                width={component.width}
-                x={component.x}
-                y={component.y}
-              />
-              <text
-                className={styles.componentLabel}
-                x={component.x + 12}
-                y={component.y + 19}
-              >
-                {`Component ${index + 1} · ${component.dataBearingFrameCount} data frame${component.dataBearingFrameCount === 1 ? "" : "s"}`}
-              </text>
-            </g>
-          ))}
-          {layout.edges.map((layoutEdge) => {
-            const edge = edgeById.get(layoutEdge.edgeId);
-            if (!edge) return null;
-            const matched =
-              !queryActive ||
-              matchingFrameIds.has(edge.parentFrameId) ||
-              matchingFrameIds.has(edge.childFrameId);
-            const selected =
-              selection?.kind === "edge" && selection.id === edge.id;
-            const path = edgePath(layoutEdge.source, layoutEdge.target);
-            const edgeVariant = styles[`edge_${edge.kind}`] ?? "";
-            return (
-              <g
-                aria-label={`Transform edge ${edge.parentFrameId} to ${edge.childFrameId}`}
-                aria-hidden={!matched || undefined}
-                className={!matched ? styles.filtered : undefined}
-                key={edge.id}
-                onClick={(event) => {
-                  event.stopPropagation();
-                  onSelect({ id: edge.id, kind: "edge" });
-                }}
-                onKeyDown={(event) => {
-                  if (event.key !== "Enter" && event.key !== " ") return;
-                  event.preventDefault();
-                  onSelect({ id: edge.id, kind: "edge" });
-                }}
-                role="button"
-                tabIndex={matched ? 0 : -1}
-              >
-                <path
-                  className={`${styles.edge} ${edgeVariant} ${selected ? styles.selectedEdge : ""}`}
-                  d={path}
-                  markerEnd={`url(#${arrowMarkerId})`}
-                />
-                <path className={styles.edgeHitTarget} d={path} />
-              </g>
-            );
-          })}
-          {layout.nodes.map((node) => {
-            const frame = frameById.get(node.frameId);
-            if (!frame) return null;
-            const matched = !queryActive || matchingFrameIds.has(frame.id);
-            const selected =
-              selection?.kind === "frame" && selection.id === frame.id;
-            const frameIssues = issuesByFrame.get(frame.id) ?? [];
-            return (
-              <g
-                aria-label={`Frame ${frame.id}`}
-                aria-hidden={!matched || undefined}
-                className={`${styles.node} ${!matched ? styles.filtered : ""}`}
-                key={frame.id}
-                onClick={(event) => {
-                  event.stopPropagation();
-                  onSelect({ id: frame.id, kind: "frame" });
-                }}
-                onKeyDown={(event) => {
-                  if (event.key !== "Enter" && event.key !== " ") return;
-                  event.preventDefault();
-                  onSelect({ id: frame.id, kind: "frame" });
-                }}
-                role="button"
-                tabIndex={matched ? 0 : -1}
-                transform={`translate(${node.x} ${node.y})`}
-              >
+          <defs>
+            <marker
+              id={arrowMarkerId}
+              markerHeight="7"
+              markerUnits="strokeWidth"
+              markerWidth="7"
+              orient="auto"
+              refX="6"
+              refY="3.5"
+            >
+              <path className={styles.arrowHead} d="M 0 0 L 7 3.5 L 0 7 z" />
+            </marker>
+          </defs>
+          <g
+            transform={`translate(${viewport.x} ${viewport.y}) scale(${viewport.scale})`}
+          >
+            {componentRects.map((component, index) => (
+              <g key={component.id}>
                 <rect
-                  className={`${styles.nodeBox} ${frame.dataBearing ? styles.dataNode : ""} ${frameIssues.length > 0 ? styles.issueNode : ""} ${selected ? styles.selectedNode : ""}`}
-                  height={node.height}
-                  rx="7"
-                  width={node.width}
+                  className={styles.componentBox}
+                  height={component.height}
+                  rx="12"
+                  width={component.width}
+                  x={component.x}
+                  y={component.y}
                 />
-                <title>{`${frame.id} — ${fullTransformSourceSummary(frame.transformSources)}`}</title>
-                <text className={styles.nodeLabel} x="12" y="18">
-                  {shortFrameLabel(frame.id)}
-                </text>
-                <text className={styles.nodeMeta} x="12" y="34">
-                  {shortTransformSourceSummary(frame.transformSources)}
-                </text>
+                {componentRects.length > 1 ? (
+                  <text
+                    className={styles.componentLabel}
+                    x={component.x + 12}
+                    y={component.y + 19}
+                  >
+                    {`Component ${index + 1}`}
+                  </text>
+                ) : null}
               </g>
-            );
-          })}
-        </g>
-      </svg>
-    </div>
+            ))}
+            {layout.edges.map((layoutEdge) => {
+              const edge = edgeById.get(layoutEdge.edgeId);
+              if (!edge) return null;
+              const matched =
+                !queryActive ||
+                matchingFrameIds.has(edge.parentFrameId) ||
+                matchingFrameIds.has(edge.childFrameId);
+              const selected =
+                selection?.kind === "edge" && selection.id === edge.id;
+              const path = edgePath(layoutEdge.source, layoutEdge.target);
+              const edgeVariant = styles[`edge_${edge.kind}`] ?? "";
+              // These are independent buttons, so each match stays tabbable.
+              return (
+                <g
+                  aria-label={`Transform edge ${edge.parentFrameId} to ${edge.childFrameId}`}
+                  className={`${styles.edgeGroup} ${!matched ? styles.filtered : ""}`}
+                  key={edge.id}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onSelect({ id: edge.id, kind: "edge" });
+                  }}
+                  onKeyDown={(event) => {
+                    if (event.key !== "Enter" && event.key !== " ") return;
+                    event.preventDefault();
+                    onSelect({ id: edge.id, kind: "edge" });
+                  }}
+                  role="button"
+                  tabIndex={matched ? 0 : -1}
+                >
+                  <path
+                    className={`${styles.edge} ${edgeVariant} ${selected ? styles.selectedEdge : ""}`}
+                    d={path}
+                    markerEnd={`url(#${arrowMarkerId})`}
+                  />
+                  <path className={styles.edgeHitTarget} d={path} />
+                </g>
+              );
+            })}
+            {layout.nodes.map((node) => {
+              const frame = frameById.get(node.frameId);
+              if (!frame) return null;
+              const matched = !queryActive || matchingFrameIds.has(frame.id);
+              const selected =
+                selection?.kind === "frame" && selection.id === frame.id;
+              const isolated = !connectedFrameIds.has(frame.id);
+              return (
+                <g
+                  aria-label={`Frame ${frame.id}`}
+                  className={`${styles.node} ${!matched ? styles.filtered : ""}`}
+                  data-isolated={isolated || undefined}
+                  key={frame.id}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onSelect({ id: frame.id, kind: "frame" });
+                  }}
+                  onKeyDown={(event) => {
+                    if (event.key !== "Enter" && event.key !== " ") return;
+                    event.preventDefault();
+                    onSelect({ id: frame.id, kind: "frame" });
+                  }}
+                  role="button"
+                  tabIndex={matched ? 0 : -1}
+                  transform={`translate(${node.x} ${node.y})`}
+                >
+                  <rect
+                    className={`${styles.nodeBox} ${frame.dataBearing ? styles.dataNode : ""} ${isolated ? styles.isolatedNode : ""} ${selected ? styles.selectedNode : ""}`}
+                    height={node.height}
+                    rx="7"
+                    width={node.width}
+                  />
+                  <title>{`${frame.id} — ${fullTransformSourceSummary(frame.transformSources)}`}</title>
+                  <text className={styles.nodeLabel} x="12" y="18">
+                    {shortFrameLabel(frame.id)}
+                  </text>
+                  <text className={styles.nodeMeta} x="12" y="34">
+                    {shortTransformSourceSummary(frame.transformSources)}
+                  </text>
+                </g>
+              );
+            })}
+          </g>
+        </svg>
+      </div>
+    </>
   );
 }
 
@@ -681,7 +712,7 @@ function SelectionDetails({
       <section className={styles.detailSection}>
         <SectionTitle>Selection</SectionTitle>
         <Text color={TextColor.Secondary} variant={TextVariant.Xs}>
-          Select a frame or edge for provenance and stream usage.
+          Select a frame or edge for details.
         </Text>
       </section>
     );
@@ -719,11 +750,11 @@ function FrameDetails({
         label="Relationships"
         value={relatedEdges.length.toLocaleString()}
       />
-      <div className={styles.detailRow}>
-        <dt>Transform sources</dt>
-        <dd className={styles.sourcePills}>
-          {frame.transformSources.length > 0 ? (
-            frame.transformSources.map((source) => (
+      {frame.transformSources.length > 0 ? (
+        <div className={styles.detailRow}>
+          <dt>Transform sources</dt>
+          <dd className={styles.sourcePills}>
+            {frame.transformSources.map((source) => (
               <Pill
                 backgroundColor={BackgroundColor.Secondary}
                 color={transformSourceColor(source.kind)}
@@ -733,26 +764,8 @@ function FrameDetails({
               >
                 {`${capitalize(source.kind)} · ${source.sourceName}`}
               </Pill>
-            ))
-          ) : (
-            <Text color={TextColor.Secondary} variant={TextVariant.Xs}>
-              None observed
-            </Text>
-          )}
-        </dd>
-      </div>
-      <Detail
-        label="Renderable streams"
-        value={
-          frame.sourceNames.length > 0
-            ? frame.sourceNames.join(", ")
-            : "None observed"
-        }
-      />
-      {frame.dataBearing ? (
-        <div className={styles.sampleNote}>
-          Stream frame IDs are sampled only from messages admitted by the
-          bounded topology slices.
+            ))}
+          </dd>
         </div>
       ) : null}
     </dl>
@@ -905,7 +918,8 @@ function componentBounds(
     });
     if (componentNodes.length === 0) return [];
     const x = Math.min(...componentNodes.map((node) => node.x)) - 12;
-    const y = Math.min(...componentNodes.map((node) => node.y)) - 32;
+    const topInset = components.length > 1 ? 32 : 12;
+    const y = Math.min(...componentNodes.map((node) => node.y)) - topInset;
     const right = Math.max(
       ...componentNodes.map((node) => node.x + node.width),
     );

--- a/app/packages/multimodal/src/views/episode/transforms/transform-topology-context.test.tsx
+++ b/app/packages/multimodal/src/views/episode/transforms/transform-topology-context.test.tsx
@@ -13,12 +13,11 @@ import type {
   TransformTopologyScanResult,
 } from "../../../ports";
 import {
+  MAX_STORES_PER_CAPABILITY,
   TRANSFORM_TOPOLOGY_GRANT_BUDGET,
   TransformTopologyProvider,
   useTransformTopologyScan,
 } from "./transform-topology-context";
-
-const MAX_STORES_PER_CAPABILITY = 8;
 
 afterEach(cleanup);
 
@@ -211,6 +210,7 @@ describe("TransformTopologyProvider", () => {
 
     await waitFor(() => expect(sample).toHaveBeenCalledOnce());
     expect(scan).toHaveBeenCalledOnce();
+    expect(screen.getByTestId("can-analyze").textContent).toBe("no");
     expect(screen.getByTestId("edges").textContent).toBe(
       "map>base_link:static:/tf_static:1",
     );
@@ -336,7 +336,7 @@ describe("TransformTopologyProvider", () => {
 });
 
 function Probe() {
-  const state = useTransformTopologyScan();
+  const state = useTransformTopologyScan(5n);
   return (
     <div>
       <span data-testid="status">

--- a/app/packages/multimodal/src/views/episode/transforms/transform-topology-context.test.tsx
+++ b/app/packages/multimodal/src/views/episode/transforms/transform-topology-context.test.tsx
@@ -18,6 +18,8 @@ import {
   useTransformTopologyScan,
 } from "./transform-topology-context";
 
+const MAX_STORES_PER_CAPABILITY = 8;
+
 afterEach(cleanup);
 
 describe("TransformTopologyProvider", () => {
@@ -35,7 +37,7 @@ describe("TransformTopologyProvider", () => {
     expect(capability.scan).not.toHaveBeenCalled();
   });
 
-  it("starts exactly one modest grant and never auto-continues", async () => {
+  it("starts one bounded grant and waits for explicit continuation", async () => {
     const continuation = { cursor: 1 } as ReadContinuation;
     const capability = createCapability(
       vi.fn(async () =>
@@ -45,21 +47,69 @@ describe("TransformTopologyProvider", () => {
 
     renderHarness(capability);
 
-    await waitFor(() => expect(capability.scan).toHaveBeenCalledOnce());
+    expect((await screen.findByTestId("status")).textContent).toBe("partial");
+    expect(capability.scan).toHaveBeenCalledOnce();
     expect(capability.scan).toHaveBeenCalledWith({
       budget: TRANSFORM_TOPOLOGY_GRANT_BUDGET,
-      continuation: undefined,
       signal: expect.any(AbortSignal),
     });
-    expect(await screen.findByText("partial")).toBeTruthy();
     await act(async () => Promise.resolve());
     expect(capability.scan).toHaveBeenCalledOnce();
   });
 
-  it("merges only new current-time evidence into partial scan topology", async () => {
-    let completedScanSignal: AbortSignal | undefined;
-    const scan = vi.fn<TransformTopologyCapability["scan"]>(async (request) => {
-      completedScanSignal = request.signal;
+  it("authorizes another bounded grant after the initial account is exhausted", async () => {
+    const continuation = { cursor: 1 } as ReadContinuation;
+    const nextContinuation = { cursor: 2 } as ReadContinuation;
+    const scan = vi
+      .fn<TransformTopologyCapability["scan"]>()
+      .mockResolvedValueOnce(
+        result({ continuation, stopReason: "account-exhausted" }),
+      )
+      .mockResolvedValueOnce(
+        result({
+          continuation: nextContinuation,
+          edges: [edge("map", "base_link", "temporal", "/tf")],
+          stopReason: "budget-exhausted",
+          usage: usage(1),
+        }),
+      );
+    renderHarness({ scan });
+    await screen.findByText("partial");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "analyze without time" }),
+    );
+
+    await waitFor(() => expect(scan).toHaveBeenCalledTimes(2));
+    expect(screen.getByTestId("edges").textContent).toBe(
+      "map>base_link:temporal:/tf:1",
+    );
+    expect(screen.getByTestId("can-analyze").textContent).toBe("yes");
+  });
+
+  it("stops scan advancement after an explicit grant makes no progress", async () => {
+    const continuation = { cursor: 1 } as ReadContinuation;
+    const scan = vi.fn<TransformTopologyCapability["scan"]>(async () =>
+      result({ continuation, stopReason: "account-exhausted" }),
+    );
+    renderHarness({ scan });
+    await screen.findByText("partial");
+    expect(screen.getByTestId("can-analyze").textContent).toBe("yes");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "analyze without time" }),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("can-analyze").textContent).toBe("no"),
+    );
+    expect(scan).toHaveBeenCalledTimes(2);
+  });
+
+  it("continues before sampling and never repeats the same time sample", async () => {
+    const operations: string[] = [];
+    const scan = vi.fn<TransformTopologyCapability["scan"]>(async () => {
+      operations.push("scan");
       return result({
         continuation: { cursor: 1 } as ReadContinuation,
         edges: [edge("map", "base_link", "temporal", "/tf", 7)],
@@ -68,83 +118,205 @@ describe("TransformTopologyProvider", () => {
       });
     });
     const sample = vi.fn<NonNullable<TransformTopologyCapability["sample"]>>(
-      async (request) => ({
-        edges: [
-          edge("map", "base_link", "temporal", "/tf"),
-          edge("map", "base_link", "static", "/tf_static"),
-          edge("base_link", "lidar", "temporal", "/tf"),
-        ],
-        frameUses: [frameUse("lidar", "points")],
-        sampledAtNs: request.timeNs,
-      }),
+      async (request) => {
+        operations.push("sample");
+        return {
+          edges: [
+            edge("map", "base_link", "temporal", "/tf"),
+            edge("map", "base_link", "static", "/tf_static"),
+            edge("base_link", "lidar", "temporal", "/tf"),
+          ],
+          frameUses: [frameUse("lidar", "points")],
+          sampledAtNs: request.timeNs,
+        };
+      },
     );
 
     renderHarness({ sample, scan });
     await screen.findByText("partial");
-    expect(sample).not.toHaveBeenCalled();
-    expect(scan).toHaveBeenCalledOnce();
-
-    fireEvent.click(screen.getByRole("button", { name: "sample at 5" }));
+    fireEvent.click(screen.getByRole("button", { name: "analyze at 5" }));
 
     await waitFor(() =>
       expect(screen.getByTestId("edges").textContent).toBe(
-        "map>base_link:temporal:/tf:7,map>base_link:static:/tf_static:1,base_link>lidar:temporal:/tf:1",
+        "map>base_link:temporal:/tf:14,map>base_link:static:/tf_static:1,base_link>lidar:temporal:/tf:1",
       ),
     );
-    expect(screen.getByText("partial")).toBeTruthy();
-    expect(completedScanSignal?.aborted).toBe(false);
-    expect(sample).toHaveBeenCalledWith({
-      signal: expect.any(AbortSignal),
-      timeNs: 5n,
-    });
-    expect(scan).toHaveBeenCalledOnce();
+    expect(screen.getByTestId("status").textContent).toBe("partial");
+    expect(screen.getByTestId("sampled-times").textContent).toBe("5");
     expect(screen.getByTestId("frame-uses").textContent).toBe(
       "lidar:points,map:odom",
     );
+    expect(operations).toEqual(["scan", "scan", "sample"]);
 
-    fireEvent.click(screen.getByRole("button", { name: "sample at 9" }));
-    await waitFor(() =>
-      expect(screen.getByTestId("sample-loading").textContent).toBe("idle"),
-    );
-    expect(sample).toHaveBeenCalledTimes(2);
-    expect(screen.getByTestId("edges").textContent).toBe(
-      "map>base_link:temporal:/tf:7,map>base_link:static:/tf_static:1,base_link>lidar:temporal:/tf:1",
+    fireEvent.click(screen.getByRole("button", { name: "analyze at 5" }));
+    await waitFor(() => expect(scan).toHaveBeenCalledTimes(3));
+    expect(sample).toHaveBeenCalledOnce();
+    expect(screen.getByTestId("edges").textContent).toContain(
+      "map>base_link:temporal:/tf:21",
     );
   });
 
-  it("keeps earlier point-in-time topology when sampling again", async () => {
+  it("resumes the stored continuation and accumulates only scan usage", async () => {
+    const continuation = { cursor: 1 } as ReadContinuation;
+    const scan = vi
+      .fn<TransformTopologyCapability["scan"]>()
+      .mockResolvedValueOnce(
+        result({
+          continuation,
+          edges: [edge("map", "base_link", "temporal", "/tf", 4)],
+          stopReason: "budget-exhausted",
+          usage: usage(2),
+        }),
+      )
+      .mockResolvedValueOnce(
+        result({
+          edges: [edge("map", "base_link", "temporal", "/tf", 6)],
+          stopReason: "source-exhausted",
+          usage: usage(3),
+        }),
+      );
+
+    renderHarness({ scan });
+    await screen.findByText("partial");
+    fireEvent.click(
+      screen.getByRole("button", { name: "analyze without time" }),
+    );
+
+    expect(await screen.findByText("complete:5")).toBeTruthy();
+    expect(screen.getByTestId("edges").textContent).toBe(
+      "map>base_link:temporal:/tf:10",
+    );
+    expect(scan).toHaveBeenLastCalledWith({
+      budget: TRANSFORM_TOPOLOGY_GRANT_BUDGET,
+      continuation,
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it("samples when no continuation is available", async () => {
     const scan = vi.fn<TransformTopologyCapability["scan"]>(async () =>
       result({ stopReason: "oversized-source-unit" }),
     );
     const sample = vi.fn<NonNullable<TransformTopologyCapability["sample"]>>(
       async (request) => ({
-        edges:
-          request.timeNs === 5n
-            ? [edge("map", "base_link", "temporal", "/tf")]
-            : [edge("world", "camera", "static", "/tf_static")],
-        frameUses:
-          request.timeNs === 5n ? [] : [frameUse("camera", "front-camera")],
+        edges: [edge("map", "base_link", "static", "/tf_static")],
+        frameUses: [],
         sampledAtNs: request.timeNs,
       }),
     );
-
     renderHarness({ sample, scan });
     await screen.findByText("partial");
-    fireEvent.click(screen.getByRole("button", { name: "sample at 5" }));
 
-    expect(await screen.findByText("sampled")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "analyze at 5" }));
+
+    await waitFor(() => expect(sample).toHaveBeenCalledOnce());
+    expect(scan).toHaveBeenCalledOnce();
     expect(screen.getByTestId("edges").textContent).toBe(
-      "map>base_link:temporal:/tf:1",
+      "map>base_link:static:/tf_static:1",
     );
+  });
 
-    fireEvent.click(screen.getByRole("button", { name: "sample at 9" }));
-    await waitFor(() =>
-      expect(screen.getByTestId("edges").textContent).toBe(
-        "map>base_link:temporal:/tf:1,world>camera:static:/tf_static:1",
+  it("reuses completed grants and evidence across panel remounts", async () => {
+    const continuation = { cursor: 1 } as ReadContinuation;
+    const capability = createCapability(
+      vi.fn(async () =>
+        result({
+          continuation,
+          edges: [edge("map", "base_link", "static", "/tf_static")],
+          stopReason: "budget-exhausted",
+        }),
       ),
     );
-    expect(screen.getByTestId("frame-uses").textContent).toBe(
-      "camera:front-camera",
+    const first = renderHarness(capability);
+    await screen.findByText("partial");
+    first.unmount();
+
+    renderHarness(capability);
+
+    expect(await screen.findByText("partial")).toBeTruthy();
+    expect(screen.getByTestId("edges").textContent).toBe(
+      "map>base_link:static:/tf_static:1",
+    );
+    expect(capability.scan).toHaveBeenCalledOnce();
+  });
+
+  it("lets an in-flight bounded grant finish while the panel is unmounted", async () => {
+    let resolveScan: ((value: TransformTopologyScanResult) => void) | undefined;
+    const scan = vi.fn<TransformTopologyCapability["scan"]>(
+      () =>
+        new Promise((resolve) => {
+          resolveScan = resolve;
+        }),
+    );
+    const capability = { scan };
+    const first = renderHarness(capability);
+    await waitFor(() => expect(scan).toHaveBeenCalledOnce());
+    first.unmount();
+
+    await act(async () => {
+      resolveScan?.(
+        result({
+          continuation: { cursor: 1 } as ReadContinuation,
+          stopReason: "budget-exhausted",
+        }),
+      );
+    });
+    renderHarness(capability);
+
+    expect(await screen.findByText("partial")).toBeTruthy();
+    expect(scan).toHaveBeenCalledOnce();
+  });
+
+  it("keeps different sources isolated within one session", async () => {
+    const scan = vi.fn<TransformTopologyCapability["scan"]>(async () =>
+      result({ stopReason: "source-exhausted" }),
+    );
+    const capability = { scan };
+    const view = renderHarness(capability, "recording-a");
+    await screen.findByText("complete:0");
+
+    view.rerender(
+      <TransformTopologyProvider
+        capability={capability}
+        sourceKey="recording-b"
+      >
+        <Probe />
+      </TransformTopologyProvider>,
+    );
+
+    await waitFor(() => expect(scan).toHaveBeenCalledTimes(2));
+  });
+
+  it("bounds retained source stores per session", async () => {
+    const scan = vi.fn<TransformTopologyCapability["scan"]>(async () =>
+      result({ stopReason: "source-exhausted" }),
+    );
+    const capability = { scan };
+    const view = renderHarness(capability, "recording-0");
+    await waitFor(() => expect(scan).toHaveBeenCalledTimes(1));
+
+    for (let index = 1; index <= MAX_STORES_PER_CAPABILITY; index += 1) {
+      view.rerender(
+        <TransformTopologyProvider
+          capability={capability}
+          sourceKey={`recording-${index}`}
+        >
+          <Probe />
+        </TransformTopologyProvider>,
+      );
+      await waitFor(() => expect(scan).toHaveBeenCalledTimes(index + 1));
+    }
+
+    view.rerender(
+      <TransformTopologyProvider
+        capability={capability}
+        sourceKey="recording-0"
+      >
+        <Probe />
+      </TransformTopologyProvider>,
+    );
+    await waitFor(() =>
+      expect(scan).toHaveBeenCalledTimes(MAX_STORES_PER_CAPABILITY + 2),
     );
   });
 
@@ -161,52 +333,16 @@ describe("TransformTopologyProvider", () => {
 
     expect(await screen.findByText("partial")).toBeTruthy();
   });
-
-  it("cancels an in-flight grant when the source changes", async () => {
-    let firstSignal: AbortSignal | undefined;
-    const scan = vi.fn<TransformTopologyCapability["scan"]>((request) => {
-      firstSignal ??= request.signal;
-      return new Promise(() => undefined);
-    });
-    const capability: TransformTopologyCapability = { scan };
-    const { rerender } = render(
-      <TransformTopologyProvider
-        capability={capability}
-        sourceKey="recording-a"
-      >
-        <Probe />
-      </TransformTopologyProvider>,
-    );
-    await waitFor(() => expect(scan).toHaveBeenCalledOnce());
-
-    rerender(
-      <TransformTopologyProvider
-        capability={capability}
-        sourceKey="recording-b"
-      >
-        <Probe />
-      </TransformTopologyProvider>,
-    );
-
-    await waitFor(() => expect(scan).toHaveBeenCalledTimes(2));
-    expect(firstSignal?.aborted).toBe(true);
-  });
 });
 
 function Probe() {
   const state = useTransformTopologyScan();
   return (
     <div>
-      <span>
-        {state.sampled
-          ? "sampled"
-          : state.complete
-            ? `complete:${state.usage.messagesDecoded}`
-            : state.partial
-              ? "partial"
-              : state.loading
-                ? "loading"
-                : "idle"}
+      <span data-testid="status">
+        {state.status === "complete"
+          ? `complete:${state.usage.messagesDecoded}`
+          : state.status}
       </span>
       <span data-testid="frame-uses">
         {state.frameUses
@@ -221,22 +357,28 @@ function Probe() {
           )
           .join(",")}
       </span>
-      <span data-testid="sample-loading">
-        {state.loading ? "loading" : "idle"}
+      <span data-testid="sampled-times">
+        {state.sampledTimesNs.map(String).join(",")}
       </span>
-      <button onClick={() => state.sampleCurrentTime(5n)} type="button">
-        sample at 5
+      <span data-testid="can-analyze">
+        {state.canAnalyzeMore ? "yes" : "no"}
+      </span>
+      <button onClick={() => state.analyzeMore(undefined)} type="button">
+        analyze without time
       </button>
-      <button onClick={() => state.sampleCurrentTime(9n)} type="button">
-        sample at 9
+      <button onClick={() => state.analyzeMore(5n)} type="button">
+        analyze at 5
       </button>
     </div>
   );
 }
 
-function renderHarness(capability: TransformTopologyCapability) {
+function renderHarness(
+  capability: TransformTopologyCapability,
+  sourceKey = "recording-a",
+) {
   return render(
-    <TransformTopologyProvider capability={capability} sourceKey="recording-a">
+    <TransformTopologyProvider capability={capability} sourceKey={sourceKey}>
       <Probe />
     </TransformTopologyProvider>,
   );
@@ -284,7 +426,7 @@ function edge(
   } as const;
 }
 
-function usage() {
+function usage(messagesDecoded = 0) {
   return {
     chunksOpened: 0,
     decompressedBytes: 0,
@@ -292,7 +434,7 @@ function usage() {
     elapsedMs: 0,
     logicalSourceBytes: 0,
     logicalUncompressedBytes: 0,
-    messagesDecoded: 0,
+    messagesDecoded,
     transferredBytes: 0,
   };
 }

--- a/app/packages/multimodal/src/views/episode/transforms/transform-topology-context.tsx
+++ b/app/packages/multimodal/src/views/episode/transforms/transform-topology-context.tsx
@@ -1,11 +1,9 @@
 import React, {
   createContext,
-  useCallback,
   useContext,
   useEffect,
   useMemo,
-  useRef,
-  useState,
+  useSyncExternalStore,
 } from "react";
 import type {
   EpisodeTransformTopologyEdgeObservation,
@@ -16,13 +14,16 @@ import type {
   ReadContinuation,
   ReadWorkUsage,
   TransformTopologyCapability,
+  TransformTopologySampleResult,
+  TransformTopologyScanResult,
 } from "../../../ports";
 import { emptyReadWorkUsage } from "../../../ports/read-work-usage";
 import { errorMessage } from "../../../utils/errors";
 
 const MIB = 1024 * 1024;
+const MAX_STORES_PER_CAPABILITY = 8;
 
-/** One user-authorized topology grant. Continuations are never automatic. */
+/** One bounded topology grant. Continuations are never automatic. */
 export const TRANSFORM_TOPOLOGY_GRANT_BUDGET = {
   maxMessages: 10_000,
   maxSourceBytes: 16 * MIB,
@@ -30,26 +31,94 @@ export const TRANSFORM_TOPOLOGY_GRANT_BUDGET = {
   maxWallTimeMs: 500,
 } as const;
 
-interface TransformTopologySource {
-  readonly capability: TransformTopologyCapability | null;
-  readonly sourceKey: string | null;
+export type TransformTopologyScanStatus =
+  | "complete"
+  | "error"
+  | "idle"
+  | "partial"
+  | "running";
+
+type TransformTopologyOperation = "analyze" | "scan";
+
+/** Persistent source-scoped evidence and recording-scan coverage. */
+export interface TransformTopologyScanState {
+  readonly continuation: ReadContinuation | undefined;
+  readonly edges: readonly EpisodeTransformTopologyEdgeObservation[];
+  readonly error: string | null;
+  readonly frameUses: readonly EpisodeTransformTopologyFrameUse[];
+  readonly loading: boolean;
+  readonly operation: TransformTopologyOperation | undefined;
+  readonly sampledTimesNs: readonly bigint[];
+  readonly scanCanProgress: boolean;
+  readonly status: TransformTopologyScanStatus;
+  readonly stopReason: BudgetedReadStopReason | undefined;
+  readonly unavailableSpanCount: number;
+  readonly usage: ReadWorkUsage;
 }
 
-const TransformTopologyContext = createContext<TransformTopologySource>({
-  capability: null,
-  sourceKey: null,
-});
+interface TransformTopologyScanController extends TransformTopologyScanState {
+  readonly analyzeMore: (timeNs: bigint | undefined) => void;
+  readonly canAnalyzeMore: boolean;
+  readonly retry: () => void;
+}
 
-/** Makes a source-bound topology capability available to episode tiles. */
+interface TransformTopologyStore {
+  readonly analyzeMore: (timeNs: bigint | undefined) => void;
+  readonly capability: TransformTopologyCapability | null;
+  readonly dispose: () => void;
+  readonly getSnapshot: () => TransformTopologyScanState;
+  readonly retry: () => void;
+  readonly start: () => void;
+  readonly subscribe: (listener: () => void) => () => void;
+}
+
+interface TransformTopologySource {
+  readonly store: TransformTopologyStore;
+}
+
+const INITIAL_STATE: TransformTopologyScanState = {
+  continuation: undefined,
+  edges: [],
+  error: null,
+  frameUses: [],
+  loading: false,
+  operation: undefined,
+  sampledTimesNs: [],
+  scanCanProgress: true,
+  status: "idle",
+  stopReason: undefined,
+  unavailableSpanCount: 0,
+  usage: emptyReadWorkUsage(),
+};
+
+const UNAVAILABLE_STORE = createUnavailableStore();
+const TransformTopologyContext = createContext<TransformTopologySource>({
+  store: UNAVAILABLE_STORE,
+});
+// Store ownership deliberately sits outside React so an authorized bounded
+// grant can finish and retain evidence while its tile is unmounted.
+const STORES_BY_CAPABILITY = new WeakMap<
+  TransformTopologyCapability,
+  Map<string, TransformTopologyStore>
+>();
+const STORE_MOUNT_COUNTS = new WeakMap<TransformTopologyStore, number>();
+
+/** Makes one session/source-scoped topology controller available to tiles. */
 export const TransformTopologyProvider: React.FC<{
   readonly capability: TransformTopologyCapability | null;
   readonly children: React.ReactNode;
   readonly sourceKey: string | null;
 }> = ({ capability, children, sourceKey }) => {
-  const value = useMemo(
-    () => ({ capability, sourceKey }),
+  const store = useMemo(
+    () => topologyStoreFor(capability, sourceKey),
     [capability, sourceKey],
   );
+  // This effect commits store recency and mount ownership after render.
+  useEffect(
+    () => retainTopologyStore(capability, sourceKey, store),
+    [capability, sourceKey, store],
+  );
+  const value = useMemo(() => ({ store }), [store]);
   return (
     <TransformTopologyContext.Provider value={value}>
       {children}
@@ -59,234 +128,410 @@ export const TransformTopologyProvider: React.FC<{
 
 /** Capability presence without authorizing any source read. */
 export function useTransformTopologyCapability(): boolean {
-  return useContext(TransformTopologyContext).capability !== null;
+  return useContext(TransformTopologyContext).store.capability !== null;
 }
 
-/** Observable state for one demand-driven topology analysis. */
-export interface TransformTopologyScanState {
-  readonly complete: boolean;
-  readonly continuation?: ReadContinuation;
-  readonly edges: readonly EpisodeTransformTopologyEdgeObservation[];
-  readonly error: string | null;
-  readonly frameUses: readonly EpisodeTransformTopologyFrameUse[];
-  readonly loading: boolean;
-  readonly partial: boolean;
-  readonly sampled: boolean;
-  readonly stopReason?: BudgetedReadStopReason;
-  readonly unavailableSpanCount: number;
-  readonly usage: ReadWorkUsage;
-}
-
-interface TransformTopologyScanController extends TransformTopologyScanState {
-  readonly canSample: boolean;
-  readonly retry: () => void;
-  readonly sampleCurrentTime: (timeNs: bigint) => void;
-}
-
-interface TransformTopologyEvidence {
-  readonly edges: readonly EpisodeTransformTopologyEdgeObservation[];
-  readonly frameUses: readonly EpisodeTransformTopologyFrameUse[];
-}
-
-const INITIAL_STATE: TransformTopologyScanState = {
-  complete: false,
-  edges: [],
-  error: null,
-  frameUses: [],
-  loading: false,
-  partial: false,
-  sampled: false,
-  unavailableSpanCount: 0,
-  usage: emptyReadWorkUsage(),
-};
-
-const EMPTY_EVIDENCE: TransformTopologyEvidence = {
-  edges: [],
-  frameUses: [],
-};
-
-/** Demand-driven scan state owned by a mounted Transforms tile. */
+/** Demand-driven view of persistent topology analysis for this session/source. */
 export function useTransformTopologyScan(): TransformTopologyScanController {
-  const { capability, sourceKey } = useContext(TransformTopologyContext);
-  const [state, setState] = useState<TransformTopologyScanState>(INITIAL_STATE);
-  const stateRef = useRef(state);
-  const requestRef = useRef(0);
-  const controllerRef = useRef<AbortController | null>(null);
-  const scanEvidenceRef = useRef<TransformTopologyEvidence>(EMPTY_EVIDENCE);
-
-  useEffect(() => {
-    stateRef.current = state;
-  }, [state]);
-
-  const run = useCallback(() => {
-    if (!capability || !sourceKey) return;
-    scanEvidenceRef.current = EMPTY_EVIDENCE;
-    controllerRef.current?.abort();
-    const controller = new AbortController();
-    controllerRef.current = controller;
-    const requestId = ++requestRef.current;
-    setState({
-      ...INITIAL_STATE,
-      error: null,
-      loading: true,
-    });
-    void capability
-      .scan({
-        budget: TRANSFORM_TOPOLOGY_GRANT_BUDGET,
-        continuation: undefined,
-        signal: controller.signal,
-      })
-      .then((result) => {
-        if (controller.signal.aborted || requestRef.current !== requestId) {
-          return;
-        }
-        if (controllerRef.current === controller) {
-          controllerRef.current = null;
-        }
-        const unavailableSpanCount = result.unavailableByStream
-          ? [...result.unavailableByStream.values()].reduce(
-              (count, windows) => count + windows.length,
-              0,
-            )
-          : 0;
-        const complete =
-          result.stopReason === "source-exhausted" &&
-          result.continuation === undefined &&
-          unavailableSpanCount === 0;
-        scanEvidenceRef.current = {
-          edges: result.edges,
-          frameUses: result.frameUses,
-        };
-        setState({
-          complete,
-          continuation: result.continuation,
-          edges: result.edges,
-          error: null,
-          frameUses: result.frameUses,
-          loading: false,
-          partial: !complete,
-          sampled: false,
-          stopReason: result.stopReason,
-          unavailableSpanCount,
-          usage: result.usage,
-        });
-      })
-      .catch((error: unknown) => {
-        if (controller.signal.aborted || requestRef.current !== requestId) {
-          return;
-        }
-        if (controllerRef.current === controller) {
-          controllerRef.current = null;
-        }
-        setState((current) => ({
-          ...current,
-          error: errorMessage(error),
-          loading: false,
-        }));
-      });
-  }, [capability, sourceKey]);
-
-  const runSample = useCallback(
-    (timeNs: bigint) => {
-      if (!capability?.sample || !sourceKey) return;
-      controllerRef.current?.abort();
-      const controller = new AbortController();
-      controllerRef.current = controller;
-      const requestId = ++requestRef.current;
-      setState((current) => ({ ...current, error: null, loading: true }));
-      void capability
-        .sample({ signal: controller.signal, timeNs })
-        .then((result) => {
-          if (controller.signal.aborted || requestRef.current !== requestId) {
-            return;
-          }
-          if (controllerRef.current === controller) {
-            controllerRef.current = null;
-          }
-          const hasScanTopology = hasTopology(scanEvidenceRef.current);
-          setState((current) => ({
-            ...current,
-            continuation: hasScanTopology ? current.continuation : undefined,
-            edges: mergeSampleEdges(current.edges, result.edges),
-            error: null,
-            frameUses: mergeFrameUses(current.frameUses, result.frameUses),
-            loading: false,
-            partial: true,
-            sampled: !hasScanTopology,
-          }));
-        })
-        .catch((error: unknown) => {
-          if (controller.signal.aborted || requestRef.current !== requestId) {
-            return;
-          }
-          if (controllerRef.current === controller) {
-            controllerRef.current = null;
-          }
-          setState((current) => ({
-            ...current,
-            error: errorMessage(error),
-            loading: false,
-          }));
-        });
-    },
-    [capability, sourceKey],
+  const { store } = useContext(TransformTopologyContext);
+  const state = useSyncExternalStore(
+    store.subscribe,
+    store.getSnapshot,
+    store.getSnapshot,
   );
-
-  // Mounting the tile authorizes exactly one bounded grant for this source.
-  useEffect(() => {
-    scanEvidenceRef.current = EMPTY_EVIDENCE;
-    setState(INITIAL_STATE);
-    if (capability && sourceKey) run();
-    return () => {
-      requestRef.current += 1;
-      controllerRef.current?.abort();
-      controllerRef.current = null;
-    };
-  }, [capability, run, sourceKey]);
-
-  const sampleCurrentTime = useCallback(
-    (timeNs: bigint) => {
-      const current = stateRef.current;
-      if (canSampleFrom(capability, current) && !current.loading) {
-        runSample(timeNs);
-      }
-    },
-    [capability, runSample],
-  );
-  const retry = useCallback(() => run(), [run]);
-
+  // This effect authorizes the source's one initial bounded scan on demand.
+  useEffect(() => store.start(), [store]);
+  const continuationAvailable =
+    state.continuation !== undefined && state.scanCanProgress;
+  const sampleAvailable =
+    store.capability?.sample !== undefined && state.status === "partial";
   return {
     ...state,
-    canSample: canSampleFrom(capability, state),
-    retry,
-    sampleCurrentTime,
+    analyzeMore: store.analyzeMore,
+    canAnalyzeMore:
+      state.operation === "analyze" ||
+      (state.error === null && (continuationAvailable || sampleAvailable)),
+    retry: store.retry,
   };
 }
 
-function canSampleFrom(
+function topologyStoreFor(
   capability: TransformTopologyCapability | null,
-  state: TransformTopologyScanState,
-): boolean {
-  return capability?.sample !== undefined && state.partial;
+  sourceKey: string | null,
+): TransformTopologyStore {
+  if (!capability || !sourceKey) return UNAVAILABLE_STORE;
+  // Synchronous registration lets remounts share one store before effects run.
+  // It starts no I/O; recency, retention, and eviction happen after commit.
+  const stores = STORES_BY_CAPABILITY.get(capability) ?? new Map();
+  STORES_BY_CAPABILITY.set(capability, stores);
+  const existing = stores.get(sourceKey);
+  if (existing) return existing;
+  const store = createTransformTopologyStore(capability);
+  stores.set(sourceKey, store);
+  return store;
 }
 
-function hasTopology(evidence: TransformTopologyEvidence): boolean {
-  return evidence.edges.length > 0 || evidence.frameUses.length > 0;
+function retainTopologyStore(
+  capability: TransformTopologyCapability | null,
+  sourceKey: string | null,
+  store: TransformTopologyStore,
+): (() => void) | undefined {
+  if (!capability || !sourceKey || store === UNAVAILABLE_STORE) return;
+  const stores = STORES_BY_CAPABILITY.get(capability);
+  if (!stores || stores.get(sourceKey) !== store) return;
+  STORE_MOUNT_COUNTS.set(store, (STORE_MOUNT_COUNTS.get(store) ?? 0) + 1);
+  stores.delete(sourceKey);
+  stores.set(sourceKey, store);
+  evictInactiveTopologyStores(stores);
+  return () => {
+    const mounts = Math.max(0, (STORE_MOUNT_COUNTS.get(store) ?? 1) - 1);
+    STORE_MOUNT_COUNTS.set(store, mounts);
+    evictInactiveTopologyStores(stores);
+  };
 }
 
-/** Adds only topology identities not already represented by scan or samples. */
+function evictInactiveTopologyStores(
+  stores: Map<string, TransformTopologyStore>,
+): void {
+  while (stores.size > MAX_STORES_PER_CAPABILITY) {
+    const oldestInactive = [...stores].find(
+      ([, store]) => (STORE_MOUNT_COUNTS.get(store) ?? 0) === 0,
+    );
+    if (!oldestInactive) return;
+    const [sourceKey, store] = oldestInactive;
+    store.dispose();
+    stores.delete(sourceKey);
+  }
+}
+
+function createTransformTopologyStore(
+  capability: TransformTopologyCapability,
+): TransformTopologyStore {
+  let snapshot = INITIAL_STATE;
+  let started = false;
+  let requestId = 0;
+  let activeController: AbortController | null = null;
+  let scanEdges: readonly EpisodeTransformTopologyEdgeObservation[] = [];
+  let scanFrameUses: readonly EpisodeTransformTopologyFrameUse[] = [];
+  let retryPlan: AnalyzePlan | null = null;
+  const samplesByTime = new Map<bigint, TransformTopologySampleResult>();
+  const sampledRequestTimes = new Set<bigint>();
+  const listeners = new Set<() => void>();
+
+  const publish = (next: TransformTopologyScanState) => {
+    snapshot = next;
+    for (const listener of listeners) listener();
+  };
+  const publishEvidence = (patch: Partial<TransformTopologyScanState>) => {
+    const evidence = visibleEvidence(scanEdges, scanFrameUses, samplesByTime);
+    publish({ ...snapshot, ...patch, ...evidence });
+  };
+
+  const applyScanResult = (
+    result: TransformTopologyScanResult,
+    patch: Partial<TransformTopologyScanState>,
+  ) => {
+    scanEdges = mergeScanEdges(scanEdges, result.edges);
+    scanFrameUses = mergeFrameUses(scanFrameUses, result.frameUses);
+    const unavailableSpanCount =
+      snapshot.unavailableSpanCount + countUnavailableSpans(result);
+    const complete =
+      result.stopReason === "source-exhausted" &&
+      result.continuation === undefined &&
+      unavailableSpanCount === 0;
+    publishEvidence({
+      continuation: result.continuation,
+      status: complete ? "complete" : "partial",
+      stopReason: result.stopReason,
+      unavailableSpanCount,
+      usage: addUsage(snapshot.usage, result.usage),
+      ...patch,
+    });
+  };
+
+  const runScan = async (continuation: ReadContinuation | undefined) => {
+    if (snapshot.loading) return;
+    retryPlan = null;
+    const activeRequest = ++requestId;
+    const controller = new AbortController();
+    activeController = controller;
+    publish({
+      ...snapshot,
+      error: null,
+      loading: true,
+      operation: "scan",
+      status: hasTopology(snapshot) ? snapshot.status : "running",
+    });
+    try {
+      const result = await capability.scan({
+        budget: TRANSFORM_TOPOLOGY_GRANT_BUDGET,
+        ...(continuation ? { continuation } : {}),
+        signal: controller.signal,
+      });
+      if (requestId !== activeRequest) return;
+      applyScanResult(result, {
+        error: null,
+        loading: false,
+        operation: undefined,
+      });
+    } catch (error: unknown) {
+      if (requestId !== activeRequest) return;
+      publish({
+        ...snapshot,
+        error: errorMessage(error),
+        loading: false,
+        operation: undefined,
+        status: hasTopology(snapshot) ? "partial" : "error",
+      });
+    } finally {
+      if (activeController === controller) activeController = null;
+    }
+  };
+
+  const runAnalyzePlan = async (plan: AnalyzePlan) => {
+    if (snapshot.loading || !hasAnalyzeWork(plan)) return;
+    retryPlan = null;
+    const activeRequest = ++requestId;
+    const controller = new AbortController();
+    activeController = controller;
+    publish({
+      ...snapshot,
+      error: null,
+      loading: true,
+      operation: "analyze",
+    });
+    const failures: string[] = [];
+    const failedPlan: MutableAnalyzePlan = {};
+
+    try {
+      if (plan.continuation !== undefined) {
+        try {
+          const result = await capability.scan({
+            budget: TRANSFORM_TOPOLOGY_GRANT_BUDGET,
+            continuation: plan.continuation,
+            signal: controller.signal,
+          });
+          if (requestId !== activeRequest) return;
+          // Only an explicit follow-up may prove the scan is stalled. An
+          // exhausted initial account must still allow one Analyze more grant.
+          applyScanResult(result, {
+            error: null,
+            loading: true,
+            operation: "analyze",
+            scanCanProgress: scanResultMadeProgress(result),
+          });
+        } catch (error: unknown) {
+          failures.push(errorMessage(error));
+          failedPlan.continuation = plan.continuation;
+        }
+      }
+
+      if (plan.sampleTimeNs !== undefined && capability.sample) {
+        try {
+          const result = await capability.sample({
+            signal: controller.signal,
+            timeNs: plan.sampleTimeNs,
+          });
+          if (requestId !== activeRequest) return;
+          samplesByTime.set(result.sampledAtNs, result);
+          sampledRequestTimes.add(plan.sampleTimeNs);
+          publishEvidence({
+            error: failures[0] ?? null,
+            loading: true,
+            operation: "analyze",
+          });
+        } catch (error: unknown) {
+          failures.push(errorMessage(error));
+          failedPlan.sampleTimeNs = plan.sampleTimeNs;
+        }
+      }
+
+      if (requestId !== activeRequest) return;
+      retryPlan = hasAnalyzeWork(failedPlan) ? failedPlan : null;
+      publishEvidence({
+        error: failures.length > 0 ? failures.join("; ") : null,
+        loading: false,
+        operation: undefined,
+      });
+    } finally {
+      if (activeController === controller) activeController = null;
+    }
+  };
+
+  const analyzeMore = (timeNs: bigint | undefined) => {
+    const continuation =
+      snapshot.continuation !== undefined && snapshot.scanCanProgress
+        ? snapshot.continuation
+        : undefined;
+    const sampleTimeNs =
+      timeNs !== undefined &&
+      capability.sample !== undefined &&
+      !sampledRequestTimes.has(timeNs)
+        ? timeNs
+        : undefined;
+    void runAnalyzePlan({
+      ...(continuation ? { continuation } : {}),
+      ...(sampleTimeNs !== undefined ? { sampleTimeNs } : {}),
+    });
+  };
+  const retry = () => {
+    if (retryPlan) {
+      void runAnalyzePlan(retryPlan);
+      return;
+    }
+    void runScan(snapshot.continuation);
+  };
+  const start = () => {
+    if (started) return;
+    started = true;
+    void runScan(undefined);
+  };
+
+  return {
+    analyzeMore,
+    capability,
+    dispose: () => {
+      requestId += 1;
+      activeController?.abort();
+      activeController = null;
+      listeners.clear();
+    },
+    getSnapshot: () => snapshot,
+    retry,
+    start,
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+  };
+}
+
+function createUnavailableStore(): TransformTopologyStore {
+  return {
+    analyzeMore: () => undefined,
+    capability: null,
+    dispose: () => undefined,
+    getSnapshot: () => INITIAL_STATE,
+    retry: () => undefined,
+    start: () => undefined,
+    subscribe: () => () => undefined,
+  };
+}
+
+interface AnalyzePlan {
+  readonly continuation?: ReadContinuation;
+  readonly sampleTimeNs?: bigint;
+}
+
+interface MutableAnalyzePlan {
+  continuation?: ReadContinuation;
+  sampleTimeNs?: bigint;
+}
+
+function hasAnalyzeWork(plan: AnalyzePlan): boolean {
+  return plan.continuation !== undefined || plan.sampleTimeNs !== undefined;
+}
+
+function scanResultMadeProgress(result: TransformTopologyScanResult): boolean {
+  return (
+    result.continuation === undefined ||
+    result.edges.length > 0 ||
+    result.frameUses.length > 0 ||
+    result.usage.chunksOpened > 0 ||
+    result.usage.logicalSourceBytes > 0 ||
+    result.usage.logicalUncompressedBytes > 0 ||
+    result.usage.messagesDecoded > 0 ||
+    [...result.coverageByStream.values()].some(
+      (windows) => windows.length > 0,
+    ) ||
+    (result.unavailableByStream !== undefined &&
+      [...result.unavailableByStream.values()].some(
+        (windows) => windows.length > 0,
+      ))
+  );
+}
+
+function visibleEvidence(
+  scanEdges: readonly EpisodeTransformTopologyEdgeObservation[],
+  scanFrameUses: readonly EpisodeTransformTopologyFrameUse[],
+  samplesByTime: ReadonlyMap<bigint, TransformTopologySampleResult>,
+): Pick<TransformTopologyScanState, "edges" | "frameUses" | "sampledTimesNs"> {
+  let edges = scanEdges;
+  let frameUses = scanFrameUses;
+  const samples = [...samplesByTime].sort(([left], [right]) =>
+    left < right ? -1 : left > right ? 1 : 0,
+  );
+  for (const [, sample] of samples) {
+    edges = mergeSampleEdges(edges, sample.edges);
+    frameUses = mergeFrameUses(frameUses, sample.frameUses);
+  }
+  return {
+    edges,
+    frameUses,
+    sampledTimesNs: samples.map(([timeNs]) => timeNs),
+  };
+}
+
+/** Adds non-overlapping continuation observations to aggregate scan evidence. */
+function mergeScanEdges(
+  left: readonly EpisodeTransformTopologyEdgeObservation[],
+  right: readonly EpisodeTransformTopologyEdgeObservation[],
+): readonly EpisodeTransformTopologyEdgeObservation[] {
+  const edges = new Map(
+    left.map((edge) => [transformObservationIdentity(edge), edge]),
+  );
+  for (const edge of right) {
+    const identity = transformObservationIdentity(edge);
+    const current = edges.get(identity);
+    edges.set(
+      identity,
+      current
+        ? {
+            ...current,
+            firstObservedTimeNs: minDefined(
+              current.firstObservedTimeNs,
+              edge.firstObservedTimeNs,
+            ),
+            lastObservedTimeNs: maxDefined(
+              current.lastObservedTimeNs,
+              edge.lastObservedTimeNs,
+            ),
+            occurrenceCount: current.occurrenceCount + edge.occurrenceCount,
+          }
+        : edge,
+    );
+  }
+  return [...edges.values()];
+}
+
+/** Adds sampled identities without inflating recording-scan occurrence counts. */
 function mergeSampleEdges(
   left: readonly EpisodeTransformTopologyEdgeObservation[],
   right: readonly EpisodeTransformTopologyEdgeObservation[],
 ): readonly EpisodeTransformTopologyEdgeObservation[] {
-  const seen = new Set(left.map(transformObservationIdentity));
-  const additions = right.filter((edge) => {
+  const edges = new Map(
+    left.map((edge) => [transformObservationIdentity(edge), edge]),
+  );
+  for (const edge of right) {
     const identity = transformObservationIdentity(edge);
-    if (seen.has(identity)) return false;
-    seen.add(identity);
-    return true;
-  });
-  return additions.length > 0 ? [...left, ...additions] : left;
+    const current = edges.get(identity);
+    if (!current) {
+      edges.set(identity, edge);
+      continue;
+    }
+    edges.set(identity, {
+      ...current,
+      firstObservedTimeNs: minDefined(
+        current.firstObservedTimeNs,
+        edge.firstObservedTimeNs,
+      ),
+      lastObservedTimeNs: maxDefined(
+        current.lastObservedTimeNs,
+        edge.lastObservedTimeNs,
+      ),
+    });
+  }
+  return [...edges.values()];
 }
 
 function transformObservationIdentity(
@@ -314,4 +559,58 @@ function mergeFrameUses(
     const rightKey = `${rightUse.frameId}\0${rightUse.streamId}`;
     return leftKey < rightKey ? -1 : leftKey > rightKey ? 1 : 0;
   });
+}
+
+function countUnavailableSpans(result: {
+  readonly unavailableByStream?: ReadonlyMap<
+    string,
+    readonly { readonly endNs: bigint; readonly startNs: bigint }[]
+  >;
+}): number {
+  return result.unavailableByStream
+    ? [...result.unavailableByStream.values()].reduce(
+        (count, windows) => count + windows.length,
+        0,
+      )
+    : 0;
+}
+
+function addUsage(left: ReadWorkUsage, right: ReadWorkUsage): ReadWorkUsage {
+  return {
+    chunksOpened: left.chunksOpened + right.chunksOpened,
+    decompressedBytes: left.decompressedBytes + right.decompressedBytes,
+    decompressionCacheHits:
+      left.decompressionCacheHits + right.decompressionCacheHits,
+    elapsedMs: left.elapsedMs + right.elapsedMs,
+    logicalSourceBytes: left.logicalSourceBytes + right.logicalSourceBytes,
+    logicalUncompressedBytes:
+      left.logicalUncompressedBytes + right.logicalUncompressedBytes,
+    messagesDecoded: left.messagesDecoded + right.messagesDecoded,
+    transferredBytes: left.transferredBytes + right.transferredBytes,
+  };
+}
+
+function minDefined(
+  left: bigint | undefined,
+  right: bigint | undefined,
+): bigint | undefined {
+  if (left === undefined) return right;
+  if (right === undefined) return left;
+  return left < right ? left : right;
+}
+
+function maxDefined(
+  left: bigint | undefined,
+  right: bigint | undefined,
+): bigint | undefined {
+  if (left === undefined) return right;
+  if (right === undefined) return left;
+  return left > right ? left : right;
+}
+
+function hasTopology(evidence: {
+  readonly edges: readonly unknown[];
+  readonly frameUses: readonly unknown[];
+}): boolean {
+  return evidence.edges.length > 0 || evidence.frameUses.length > 0;
 }

--- a/app/packages/multimodal/src/views/episode/transforms/transform-topology-context.tsx
+++ b/app/packages/multimodal/src/views/episode/transforms/transform-topology-context.tsx
@@ -21,7 +21,7 @@ import { emptyReadWorkUsage } from "../../../ports/read-work-usage";
 import { errorMessage } from "../../../utils/errors";
 
 const MIB = 1024 * 1024;
-const MAX_STORES_PER_CAPABILITY = 8;
+export const MAX_STORES_PER_CAPABILITY = 8;
 
 /** One bounded topology grant. Continuations are never automatic. */
 export const TRANSFORM_TOPOLOGY_GRANT_BUDGET = {
@@ -48,6 +48,7 @@ export interface TransformTopologyScanState {
   readonly frameUses: readonly EpisodeTransformTopologyFrameUse[];
   readonly loading: boolean;
   readonly operation: TransformTopologyOperation | undefined;
+  readonly sampledRequestTimesNs: readonly bigint[];
   readonly sampledTimesNs: readonly bigint[];
   readonly scanCanProgress: boolean;
   readonly status: TransformTopologyScanStatus;
@@ -83,6 +84,7 @@ const INITIAL_STATE: TransformTopologyScanState = {
   frameUses: [],
   loading: false,
   operation: undefined,
+  sampledRequestTimesNs: [],
   sampledTimesNs: [],
   scanCanProgress: true,
   status: "idle",
@@ -132,7 +134,9 @@ export function useTransformTopologyCapability(): boolean {
 }
 
 /** Demand-driven view of persistent topology analysis for this session/source. */
-export function useTransformTopologyScan(): TransformTopologyScanController {
+export function useTransformTopologyScan(
+  sampleTimeNs?: bigint,
+): TransformTopologyScanController {
   const { store } = useContext(TransformTopologyContext);
   const state = useSyncExternalStore(
     store.subscribe,
@@ -144,7 +148,10 @@ export function useTransformTopologyScan(): TransformTopologyScanController {
   const continuationAvailable =
     state.continuation !== undefined && state.scanCanProgress;
   const sampleAvailable =
-    store.capability?.sample !== undefined && state.status === "partial";
+    sampleTimeNs !== undefined &&
+    store.capability?.sample !== undefined &&
+    state.status === "partial" &&
+    !state.sampledRequestTimesNs.includes(sampleTimeNs);
   return {
     ...state,
     analyzeMore: store.analyzeMore,
@@ -339,6 +346,7 @@ function createTransformTopologyStore(
             error: failures[0] ?? null,
             loading: true,
             operation: "analyze",
+            sampledRequestTimesNs: [...sampledRequestTimes],
           });
         } catch (error: unknown) {
           failures.push(errorMessage(error));

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2174,6 +2174,7 @@ __metadata:
     "@types/react": "catalog:"
     "@types/three": "npm:^0.182.0"
     "@voxel51/voodo": "catalog:"
+    "@xyflow/react": "npm:^12.4.4"
     babel-plugin-relay: "catalog:"
     buffer: "catalog:"
     colormap: "catalog:"
@@ -5808,6 +5809,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/d3-drag@npm:^3.0.7":
+  version: 3.0.7
+  resolution: "@types/d3-drag@npm:3.0.7"
+  dependencies:
+    "@types/d3-selection": "npm:*"
+  checksum: 10/93aba299c3a8d41ee326c5304ab694ceea135ed115c3b2ccab727a5d9bfc935f7f36d3fc416c013010eb755ac536c52adfcb15c195f241dc61f62650cc95088e
+  languageName: node
+  linkType: hard
+
 "@types/d3-ease@npm:^3.0.0":
   version: 3.0.2
   resolution: "@types/d3-ease@npm:3.0.2"
@@ -5815,7 +5825,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/d3-interpolate@npm:^3.0.1":
+"@types/d3-interpolate@npm:*, @types/d3-interpolate@npm:^3.0.1, @types/d3-interpolate@npm:^3.0.4":
   version: 3.0.4
   resolution: "@types/d3-interpolate@npm:3.0.4"
   dependencies:
@@ -5840,6 +5850,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/d3-selection@npm:*, @types/d3-selection@npm:^3.0.10":
+  version: 3.0.11
+  resolution: "@types/d3-selection@npm:3.0.11"
+  checksum: 10/2d2d993b9e9553d066566cb22916c632e5911090db99e247bd8c32855a344e6b7c25b674f3c27956c367a6b3b1214b09931ce854788c3be2072003e01f2c75d7
+  languageName: node
+  linkType: hard
+
 "@types/d3-shape@npm:^3.1.0":
   version: 3.1.6
   resolution: "@types/d3-shape@npm:3.1.6"
@@ -5860,6 +5877,25 @@ __metadata:
   version: 3.0.2
   resolution: "@types/d3-timer@npm:3.0.2"
   checksum: 10/1643eebfa5f4ae3eb00b556bbc509444d88078208ec2589ddd8e4a24f230dd4cf2301e9365947e70b1bee33f63aaefab84cd907822aae812b9bc4871b98ab0e1
+  languageName: node
+  linkType: hard
+
+"@types/d3-transition@npm:^3.0.8":
+  version: 3.0.9
+  resolution: "@types/d3-transition@npm:3.0.9"
+  dependencies:
+    "@types/d3-selection": "npm:*"
+  checksum: 10/dad647c485440f176117e8a45f31aee9427d8d4dfa174eaa2f01e702641db53ad0f752a144b20987c7189723c4f0afe0bf0f16d95b2a91aa28937eee4339c161
+  languageName: node
+  linkType: hard
+
+"@types/d3-zoom@npm:^3.0.8":
+  version: 3.0.8
+  resolution: "@types/d3-zoom@npm:3.0.8"
+  dependencies:
+    "@types/d3-interpolate": "npm:*"
+    "@types/d3-selection": "npm:*"
+  checksum: 10/cc6ba975cf4f55f94933413954d81b87feb1ee8b8cee8f2202cf526f218dcb3ba240cbeb04ed80522416201c4a7394b37de3eb695d840a36d190dfb2d3e62cb5
   languageName: node
   linkType: hard
 
@@ -7161,6 +7197,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@xyflow/react@npm:^12.4.4":
+  version: 12.11.2
+  resolution: "@xyflow/react@npm:12.11.2"
+  dependencies:
+    "@xyflow/system": "npm:0.0.79"
+    classcat: "npm:^5.0.3"
+    zustand: "npm:^4.4.0"
+  peerDependencies:
+    "@types/react": ">=17"
+    "@types/react-dom": ">=17"
+    react: ">=17"
+    react-dom: ">=17"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10/d3db2220dc7f6ba001aaa5646dd3e91eac82e7d278101ce9305ff8fad7f68711747a237ceff16b6dbc7d2be5b2dd8c0229a66805aa422495c18fd91c4b7f694b
+  languageName: node
+  linkType: hard
+
+"@xyflow/system@npm:0.0.79":
+  version: 0.0.79
+  resolution: "@xyflow/system@npm:0.0.79"
+  dependencies:
+    "@types/d3-drag": "npm:^3.0.7"
+    "@types/d3-interpolate": "npm:^3.0.4"
+    "@types/d3-selection": "npm:^3.0.10"
+    "@types/d3-transition": "npm:^3.0.8"
+    "@types/d3-zoom": "npm:^3.0.8"
+    d3-drag: "npm:^3.0.0"
+    d3-interpolate: "npm:^3.0.1"
+    d3-selection: "npm:^3.0.0"
+    d3-zoom: "npm:^3.0.0"
+  checksum: 10/08685f07135e48f3a4f1f4a6d90faef8a928d2d106a13d43520aaaa00dbd309d6b852379a09b52e40f3e2fd3b9c7e5a7ec2e066e36085e4af4ae97ef5b8fe0ec
+  languageName: node
+  linkType: hard
+
 "abab@npm:^2.0.6":
   version: 2.0.6
   resolution: "abab@npm:2.0.6"
@@ -8219,6 +8293,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"classcat@npm:^5.0.3":
+  version: 5.0.5
+  resolution: "classcat@npm:5.0.5"
+  checksum: 10/19bdeb99b8923b47f9df978b6ef2c5a4cc3bcaa8fb6be16244e31fad619b291b366429747331903ac2ea27560ffd6066d14089a99c95535ce0f1e897525fa63d
+  languageName: node
+  linkType: hard
+
 "classnames@npm:2.3.1":
   version: 2.3.1
   resolution: "classnames@npm:2.3.1"
@@ -8893,7 +8974,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-ease@npm:^3.0.1":
+"d3-dispatch@npm:1 - 3":
+  version: 3.0.1
+  resolution: "d3-dispatch@npm:3.0.1"
+  checksum: 10/2b82f41bf4ef88c2f9033dfe32815b67e2ef1c5754a74137a74c7d44d6f0d6ecfa934ac56ed8afe358f6c1f06462e8aa42ca0a388397b5b77a42721570e80487
+  languageName: node
+  linkType: hard
+
+"d3-drag@npm:2 - 3, d3-drag@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "d3-drag@npm:3.0.0"
+  dependencies:
+    d3-dispatch: "npm:1 - 3"
+    d3-selection: "npm:3"
+  checksum: 10/80bc689935e5a46ee92b2d7f71e1c792279382affed9fbcf46034bff3ff7d3f50cf61a874da4bdf331037292b9e7dca5c6401a605d4bb699fdcb4e0c87e176ec
+  languageName: node
+  linkType: hard
+
+"d3-ease@npm:1 - 3, d3-ease@npm:^3.0.1":
   version: 3.0.1
   resolution: "d3-ease@npm:3.0.1"
   checksum: 10/985d46e868494e9e6806fedd20bad712a50dcf98f357bf604a843a9f6bc17714a657c83dd762f183173dcde983a3570fa679b2bc40017d40b24163cdc4167796
@@ -8960,7 +9058,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-interpolate@npm:1.2.0 - 3, d3-interpolate@npm:^3.0.1":
+"d3-interpolate@npm:1 - 3, d3-interpolate@npm:1.2.0 - 3, d3-interpolate@npm:^3.0.1":
   version: 3.0.1
   resolution: "d3-interpolate@npm:3.0.1"
   dependencies:
@@ -9000,6 +9098,13 @@ __metadata:
     d3-time: "npm:2.1.1 - 3"
     d3-time-format: "npm:2 - 4"
   checksum: 10/e2dc4243586eae2a0fdf91de1df1a90d51dfacb295933f0ca7e9184c31203b01436bef69906ad40f1100173a5e6197ae753cb7b8a1a8fcfda43194ea9cad6493
+  languageName: node
+  linkType: hard
+
+"d3-selection@npm:2 - 3, d3-selection@npm:3, d3-selection@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "d3-selection@npm:3.0.0"
+  checksum: 10/0e5acfd305b31628b7be5009ba7303d84bb34817a88ed4dde9c8bd9c23528573fc5272f89fc04e5be03d2cbf5441a248d7274aaf55a8ef3dad46e16333d72298
   languageName: node
   linkType: hard
 
@@ -9062,10 +9167,38 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-timer@npm:^3.0.1":
+"d3-timer@npm:1 - 3, d3-timer@npm:^3.0.1":
   version: 3.0.1
   resolution: "d3-timer@npm:3.0.1"
   checksum: 10/004128602bb187948d72c7dc153f0f063f38ac7a584171de0b45e3a841ad2e17f1e40ad396a4af9cce5551b6ab4a838d5246d23492553843d9da4a4050a911e2
+  languageName: node
+  linkType: hard
+
+"d3-transition@npm:2 - 3":
+  version: 3.0.1
+  resolution: "d3-transition@npm:3.0.1"
+  dependencies:
+    d3-color: "npm:1 - 3"
+    d3-dispatch: "npm:1 - 3"
+    d3-ease: "npm:1 - 3"
+    d3-interpolate: "npm:1 - 3"
+    d3-timer: "npm:1 - 3"
+  peerDependencies:
+    d3-selection: 2 - 3
+  checksum: 10/02571636acb82f5532117928a87fe25de68f088c38ab4a8b16e495f0f2d08a3fd2937eaebdefdfcf7f1461545524927d2632d795839b88d2e4c71e387aaaffac
+  languageName: node
+  linkType: hard
+
+"d3-zoom@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "d3-zoom@npm:3.0.0"
+  dependencies:
+    d3-dispatch: "npm:1 - 3"
+    d3-drag: "npm:2 - 3"
+    d3-interpolate: "npm:1 - 3"
+    d3-selection: "npm:2 - 3"
+    d3-transition: "npm:2 - 3"
+  checksum: 10/0e6e5c14e33c4ecdff311a900dd037dea407734f2dd2818988ed6eae342c1799e8605824523678bd404f81e37824cc588f62dbde46912444c89acc7888036c6b
   languageName: node
   linkType: hard
 
@@ -20321,7 +20454,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zustand@npm:^4.3.2, zustand@npm:~4.5.2":
+"zustand@npm:^4.3.2, zustand@npm:^4.4.0, zustand@npm:~4.5.2":
   version: 4.5.7
   resolution: "zustand@npm:4.5.7"
   dependencies:


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

Make transform analysis consistent across panel lifecycles and large recordings.

- Keep scan coverage, continuations, and sampled-time evidence scoped to the recording and available after panel remounts.
- Replace the separate continuation and sampling actions with **Analyze more**. Each click grants one bounded continuation step and samples the current playback time when useful, without treating the cumulative background budget as terminal.
- Report disconnected transform components as warnings or errors instead of healthy topology.
- Replace the hand-built SVG canvas with read-only React Flow frame cards and component groups. Search, keyboard selection, pan, zoom, and **Fit** remain in the tile.

## 🧪 How is this patch tested? If it is not, please explain why.

- Unit tests

Manual check:

1. Open an MCAP recording with more than one transform component and add the Transforms panel.
2. Confirm the component count matches the graph labels, disconnected topology is reported, **Fit** includes every component, and only isolated frames use red borders.
3. Confirm frame cards and edges support mouse and keyboard selection, then pan and zoom the read-only canvas.
4. Click **Analyze more** repeatedly. Confirm each click can advance scan coverage, an unchanged playback time is sampled only once, and the panel stays on **Partial analysis** until the scan completes or stops making progress.

## Notes to Reviewer

- `transform-topology-context.tsx` owns source-scoped evidence and the scan-then-sample lifecycle.
- `format-adapter.ts` supplies one independently bounded topology grant per request and merges the static bootstrap into the first scan result.
- `TransformGraphCanvas.tsx` maps pure topology analysis and deterministic layout into controlled React Flow nodes and edges.

## High Level Architecture

The MCAP adapter returns one bounded result per scan request and keeps no cumulative topology state. A source-scoped controller merges scan evidence with explicit time samples, preserves the continuation across panel remounts, and exposes one action to the tile. Analysis and layout remain pure; React Flow only renders and navigates their output.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Transform graphs now preserve analysis across panel remounts, flag disconnected components, and use one **Analyze more** action to extend scan coverage and sample the current playback time. The graph uses card-style nodes with consistent keyboard selection, pan, zoom, and fit behavior.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added demand-driven transform analysis with “Analyze more,” continuation scans, retry support, and time-based sampling.
  * Added an interactive transform graph with search, zoom, fit, selection, and drag controls.
  * Added clearer warnings for disconnected components and isolated frames.
* **Improvements**
  * Analysis results now persist across navigation and combine evidence from multiple scans and samples.
  * Improved support for static and temporal transform relationships.
  * Updated loading, partial, empty, unavailable, and error states with clearer feedback.
  * Improved accessibility, graph layout, and visual styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3718
<!-- enterprise-sync-pr:end -->
