### PR TITLE
fix(app): handle null range bounds in keypoint numeric filters

### DIFF
--- a/app/packages/state/src/recoil/skeletonFilter.ts
+++ b/app/packages/state/src/recoil/skeletonFilter.ts
@@ -2,7 +2,7 @@ import { Point } from "@fiftyone/looker";
 import { selectorFamily } from "recoil";
 import { filters, modalFilters } from "./filters";
 import { BooleanFilter } from "./pathFilters/boolean";
-import { NumericFilter } from "./pathFilters/numeric";
+import { helperFunction, NumericFilter } from "./pathFilters/numeric";
 import { StringFilter } from "./pathFilters/string";
 import { expandPath } from "./schema";
 
@@ -92,10 +92,19 @@ export default selectorFamily<(path: string, value: Point) => boolean, boolean>(
                 }
               }
 
-              const includes =
-                value[key] >= numFilter.range[0] &&
-                value[key] <= numFilter.range[1];
-              const r = numFilter.exclude ? !includes : includes;
+              // a null bound means that end is unbounded, and the range may be
+              // absent entirely when both ends sit on the field bounds
+              const [start, end] = numFilter.range ?? [null, null];
+              const r = helperFunction(
+                value[key],
+                numFilter.exclude,
+                start,
+                end,
+                numFilter.none,
+                numFilter.inf,
+                numFilter.ninf,
+                numFilter.nan,
+              );
 
               if (!r) {
                 result = false;


### PR DESCRIPTION
# PR draft — voxel51/fiftyone (base branch: `community`)

**Title:** fix(app): handle null range bounds in keypoint numeric filters

## What changes

Fixes #8152.

Per-point numeric filtering for `Keypoint`/`Keypoints` list attributes (e.g.
`confidence`) compared values directly against the stored filter range:

```ts
value >= numFilter.range[0] && value <= numFilter.range[1]
```

The range slider intentionally stores `null` for a thumb resting on a field
bound (meaning "unbounded on this side"). In JavaScript `null` coerces to `0`,
so a range like `[0.2, null]` became `value <= 0` and hid every point with
positive confidence.

This change routes keypoint per-point numeric filtering through the same
`helperFunction` in `pathFilters/numeric.ts` that regular numeric filters
(e.g. detection `confidence`) already use, which handles null bounds,
none/nan/inf/ninf toggles, and exclude semantics. It also guards against
`numFilter.range` being absent entirely — the filter setter deletes `range`
when both ends are null, which would previously have thrown.

## How to reproduce / verify

Repro script from #8152: create a dataset with one `Keypoints` sample with
per-point `confidence: [0.1, 0.3, 0.5, 0.7]`, open the modal, and drag the
confidence **min** thumb to ~0.2 while leaving **max** on the upper bound.

- Before: no keypoints drawn.
- After: points with confidence 0.3, 0.5, 0.7 remain, matching the behavior
  of detection confidence filters.

## Tests

`helperFunction`'s null-bound behavior is already covered by
`app/packages/state/src/recoil/pathFilters/numeric.test.ts` ("handles start or
end"). The full `packages/state` suite passes (350 tests, 30 files).

A direct unit test of `skeletonFilter` isn't possible with the current recoil
mock harness (`getCallback` is unimplemented in `app/__mocks__/recoil.ts`);
happy to add one if that lands.