### PR TITLE
Stop Renovate from widening version ranges

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,7 +4,6 @@
     "dependencyDashboard": false,
     "baseBranches": ["develop"],
     "gitAuthor": "voxel51-bot <bot@voxel51.com>",
-    "rangeStrategy": "widen",
     "schedule": ["* * * * 3"],
     "labels": ["dependencies"],
     "enabledManagers": [
@@ -42,6 +41,16 @@
             "matchManagers": ["npm"],
             "groupName": "app-dependencies",
             "addLabels": ["app"]
+        },
+        {
+            "matchManagers": ["github-actions"],
+            "matchDepNames": ["python"],
+            "enabled": false
+        },
+        {
+            "matchManagers": ["npm"],
+            "matchDepNames": ["minimatch", "brace-expansion"],
+            "enabled": false
         }
     ],
     "vulnerabilityAlerts": {


### PR DESCRIPTION
Renovate's `rangeStrategy: widen` produced union ranges like `"leva": "^0.9.36 || ^0.10.0"` in #8231 — the resolver installs the new version regardless, so the old half of the range asserts compatibility nobody verified. It also widened `python-version` to `"3.13 || 3.14"` in #8186, which resolves to 3.14 and breaks jobs built for 3.13.

Changes:
- Drop `rangeStrategy: widen` — the default replaces ranges explicitly (`^0.9.36` → `^0.10.0`)
- Exclude `python-version` from the github-actions manager; Python upgrades need coordinated workflow changes and should be deliberate PRs
- Exclude `minimatch` and `brace-expansion` from npm updates; minimatch is pinned to work with the brace-expansion v5 security override, and the stock `9.0.9` bump in #8231 undid that wiring (`TypeError: brace_expansion_1.default is not a function` in the lint and build jobs)

After this merges, Renovate rewrites the open #8231 branch on its next run with clean replacement ranges. #8186 was hand-corrected and won't be rewritten.

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3727
<!-- enterprise-sync-pr:end -->