### PR TITLE
fix(cvat): order skeleton keypoints by node and mark hidden ones nan

### DIFF
--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -15,6 +15,7 @@ import math
 import multiprocessing.dummy
 import os
 from packaging.version import Version
+import re
 import time
 import warnings
 import webbrowser
@@ -4743,6 +4744,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                     attr_id_map,
                     attr_type_map,
                     _class_map_rev,
+                    skeleton_map,
                 ) = self._get_attr_class_maps(task_id)
 
                 if coerce_text_attrs:
@@ -4845,6 +4847,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                             occluded_attrs=_occluded_attrs,
                             group_id_attrs=_group_id_attrs,
                             attr_type_map=attr_type_map,
+                            skeleton_map=skeleton_map,
                         )
                         label_field_results = self._merge_results(
                             label_field_results, shape_results
@@ -4879,6 +4882,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                                 occluded_attrs=_occluded_attrs,
                                 group_id_attrs=_group_id_attrs,
                                 attr_type_map=attr_type_map,
+                                skeleton_map=skeleton_map,
                             )
                             label_field_results = self._merge_results(
                                 label_field_results, track_shape_results
@@ -4920,6 +4924,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         _class_map = {}
         attr_id_map = {}
         attr_type_map = {}
+        skeleton_map = {}
         for label in labels:
             _class_map[label["id"]] = label["name"]
             attr_id_map[label["id"]] = {
@@ -4928,11 +4933,15 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
             attr_type_map[label["id"]] = {
                 i["id"]: i.get("input_type", None) for i in label["attributes"]
             }
+            if label.get("type", None) == "skeleton":
+                node_order = _parse_skeleton_node_order(label)
+                if node_order:
+                    skeleton_map[label["id"]] = node_order
 
         # AL: not sure why we didn't just reverse keys/vals initially
         class_map_rev = {n: i for i, n in _class_map.items()}
 
-        return attr_id_map, attr_type_map, class_map_rev
+        return attr_id_map, attr_type_map, class_map_rev, skeleton_map
 
     def _get_paginated_results(self, base_url, get_page_url=None, value=None):
         results = []
@@ -5841,6 +5850,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         occluded_attrs=None,
         group_id_attrs=None,
         attr_type_map=None,
+        skeleton_map=None,
     ):
         results = {}
         prev_type = None
@@ -5882,6 +5892,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                 occluded_attrs=occluded_attrs,
                 group_id_attrs=group_id_attrs,
                 attr_type_map=attr_type_map,
+                skeleton_map=skeleton_map,
             )
 
         # For non-outside tracked objects, the last track goes to the end of
@@ -5918,6 +5929,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                     occluded_attrs=occluded_attrs,
                     group_id_attrs=group_id_attrs,
                     attr_type_map=attr_type_map,
+                    skeleton_map=skeleton_map,
                 )
 
         return results
@@ -5943,6 +5955,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         occluded_attrs=None,
         group_id_attrs=None,
         attr_type_map=None,
+        skeleton_map=None,
     ):
         frame = anno["frame"]
 
@@ -5986,6 +5999,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                 group_id_attrs=group_id_attrs,
                 group_id=track_group_id,
                 attr_type_map=attr_type_map,
+                skeleton_map=skeleton_map,
             )
 
             # Non-keyframe annotations were interpolated from keyframes but
@@ -7220,6 +7234,9 @@ class CVATShape(CVATLabel):
             corresponding attribute linked to the CVAT group id, if any
         group_id (None): an optional group id value for this shape when it
             cannot be parsed from the label dict
+        skeleton_map (None): a dictionary mapping skeleton label IDs to their
+            sublabel IDs in node order, used to order the keypoints of
+            skeleton shapes
     """
 
     def __init__(
@@ -7235,6 +7252,7 @@ class CVATShape(CVATLabel):
         group_id_attrs=None,
         group_id=None,
         attr_type_map=None,
+        skeleton_map=None,
     ):
         super().__init__(
             label_dict,
@@ -7257,8 +7275,12 @@ class CVATShape(CVATLabel):
         # empty list
         if label_dict.get("type", None) == "skeleton":
             self.skeleton_elements = label_dict.get("elements", None) or []
+            self.skeleton_node_order = (skeleton_map or {}).get(
+                label_dict.get("label_id", None), None
+            )
         else:
             self.skeleton_elements = None
+            self.skeleton_node_order = None
 
         if "rotation" in label_dict and int(label_dict["rotation"]) != 0:
             self.attributes["rotation"] = label_dict["rotation"]
@@ -7290,10 +7312,9 @@ class CVATShape(CVATLabel):
 
     def _skeleton_points(self):
         """Returns this skeleton shape's keypoints as ``(x, y)`` pairs."""
-        points = []
-        for element in self.skeleton_elements:
-            points.extend(element.get("points", []))
-
+        points = _flatten_skeleton_points(
+            self.skeleton_elements, self.skeleton_node_order
+        )
         return self._to_pairs_of_points(points)
 
     def to_detection(self):
@@ -7403,6 +7424,16 @@ class CVATShape(CVATLabel):
             a :class:`fiftyone.core.labels.Keypoint`
         """
         if self.skeleton_elements is not None:
+            if not self.skeleton_elements:
+                # Skeleton tracks store their keypoints in per-node sub-tracks
+                # that are not available here, so there is nothing to import
+                logger.warning(
+                    "Skipping skeleton %s with no elements; skeleton tracks "
+                    "are not yet supported",
+                    self.id,
+                )
+                return None
+
             points = self._skeleton_points()
         else:
             points = self._to_pairs_of_points(self.points)
@@ -7762,6 +7793,107 @@ def _parse_value(value, attr_type=None):
             return None
 
     return value
+
+
+def _parse_skeleton_node_order(label):
+    """Returns the sublabel IDs of a CVAT skeleton label in node order.
+
+    CVAT does not guarantee the order of the ``elements`` it returns for a
+    skeleton shape: the underlying query sorts only by frame, so elements
+    within a frame are returned in an arbitrary (albeit stable) order. The
+    authoritative node order is the ``data-node-id`` numbering in the label's
+    ``svg`` definition, which is what this method recovers.
+
+    Args:
+        label: a CVAT label dict
+
+    Returns:
+        a list of sublabel IDs in node order, or ``None`` if the order cannot
+        be determined
+    """
+    sublabel_order = [s["id"] for s in label.get("sublabels", None) or []]
+
+    svg = label.get("svg", None)
+    if svg:
+        nodes = []
+        for match in re.finditer(r"<circle\b[^>]*>", svg):
+            element = match.group(0)
+            node_id = re.search(r'data-node-id="(\d+)"', element)
+            label_id = re.search(r'data-label-id="(\d+)"', element)
+            if node_id is not None and label_id is not None:
+                nodes.append((int(node_id.group(1)), int(label_id.group(1))))
+
+        if nodes:
+            node_order = [label_id for _, label_id in sorted(nodes)]
+
+            # An svg that does not cover every declared sublabel would
+            # otherwise drop the uncovered nodes. Their position is unknown,
+            # so append them rather than lose them
+            seen = set(node_order)
+            node_order.extend(i for i in sublabel_order if i not in seen)
+
+            return node_order
+
+    # Fall back to the order in which the sublabels were reported
+    if sublabel_order:
+        return sublabel_order
+
+    return None
+
+
+def _flatten_skeleton_points(elements, node_order):
+    """Flattens the elements of a CVAT skeleton shape into a points list.
+
+    Points are emitted in ``node_order`` so that their indexes are consistent
+    across all shapes of a given skeleton label, as required by
+    :class:`fiftyone.core.odm.dataset.KeypointSkeleton`. Nodes that CVAT
+    reports as ``outside`` (not visible) and nodes with no element at all are
+    emitted as ``nan`` values, per FiftyOne's convention for missing keypoints.
+
+    Args:
+        elements: the ``elements`` list of a CVAT skeleton shape
+        node_order (None): a list of sublabel IDs in node order, as returned by
+            :meth:`_parse_skeleton_node_order`. If not provided, the elements
+            are used in the order given, which CVAT does not guarantee
+
+    Returns:
+        a flat list of ``[x1, y1, x2, y2, ...]`` coordinates
+    """
+    nan_point = [float("nan"), float("nan")]
+
+    if not node_order:
+        points = []
+        for element in elements:
+            if element.get("outside", False):
+                points.extend(nan_point)
+            else:
+                points.extend(element.get("points") or nan_point)
+
+        return points
+
+    elements_by_label = {}
+    for element in elements:
+        elements_by_label.setdefault(element["label_id"], element)
+
+    points = []
+    for label_id in node_order:
+        element = elements_by_label.pop(label_id, None)
+        if element is None or element.get("outside", False):
+            points.extend(nan_point)
+        else:
+            points.extend(element.get("points") or nan_point)
+
+    # Any elements whose sublabel is not in the skeleton definition cannot be
+    # placed at a meaningful index, so they are dropped. Warn rather than
+    # discard them silently
+    for element in elements_by_label.values():
+        logger.warning(
+            "Ignoring skeleton element with sublabel ID %s that is not in the "
+            "skeleton definition",
+            element["label_id"],
+        )
+
+    return points
 
 
 def _parse_occlusion_value(value):

--- a/tests/unittests/utils/test_cvat_skeletons.py
+++ b/tests/unittests/utils/test_cvat_skeletons.py
@@ -1,0 +1,158 @@
+"""
+CVAT skeleton import unit tests.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import math
+import unittest
+
+import fiftyone.utils.cvat as fouc
+
+
+def _svg(nodes):
+    """Builds a minimal CVAT skeleton ``svg`` from ``(node_id, label_id)``."""
+    return "".join(
+        '<circle r="0.75" cx="1" cy="2" data-type="element node" '
+        'data-element-id="%d" data-node-id="%d" data-label-id="%d"></circle>'
+        % (node_id, node_id, label_id)
+        for node_id, label_id in nodes
+    )
+
+
+def _element(label_id, points, outside=False):
+    return {
+        "label_id": label_id,
+        "type": "points",
+        "points": points,
+        "outside": outside,
+        "occluded": False,
+    }
+
+
+class SkeletonNodeOrderTests(unittest.TestCase):
+    def test_order_from_svg(self):
+        label = {
+            "id": 1,
+            "type": "skeleton",
+            "svg": _svg([(1, 20), (2, 21), (3, 22)]),
+            "sublabels": [{"id": 22}, {"id": 20}, {"id": 21}],
+        }
+        # svg node order wins over the sublabels list
+        self.assertEqual(fouc._parse_skeleton_node_order(label), [20, 21, 22])
+
+    def test_svg_node_ids_not_in_document_order(self):
+        label = {
+            "id": 1,
+            "type": "skeleton",
+            "svg": _svg([(3, 22), (1, 20), (2, 21)]),
+            "sublabels": [],
+        }
+        self.assertEqual(fouc._parse_skeleton_node_order(label), [20, 21, 22])
+
+    def test_partial_svg_keeps_uncovered_sublabels(self):
+        # The svg describes only 2 of the 3 declared nodes; the uncovered one
+        # must still get an index rather than being dropped
+        label = {
+            "id": 1,
+            "type": "skeleton",
+            "svg": _svg([(2, 21), (1, 20)]),
+            "sublabels": [{"id": 20}, {"id": 21}, {"id": 22}],
+        }
+        self.assertEqual(fouc._parse_skeleton_node_order(label), [20, 21, 22])
+
+    def test_partial_svg_does_not_duplicate(self):
+        label = {
+            "id": 1,
+            "type": "skeleton",
+            "svg": _svg([(1, 20), (2, 21)]),
+            "sublabels": [{"id": 21}, {"id": 20}],
+        }
+        order = fouc._parse_skeleton_node_order(label)
+        self.assertEqual(order, [20, 21])
+        self.assertEqual(len(order), len(set(order)))
+
+    def test_svg_node_missing_from_sublabels_is_kept(self):
+        label = {
+            "id": 1,
+            "type": "skeleton",
+            "svg": _svg([(1, 20), (2, 99)]),
+            "sublabels": [{"id": 20}],
+        }
+        self.assertEqual(fouc._parse_skeleton_node_order(label), [20, 99])
+
+    def test_falls_back_to_sublabels(self):
+        label = {
+            "id": 1,
+            "type": "skeleton",
+            "svg": None,
+            "sublabels": [{"id": 20}, {"id": 21}],
+        }
+        self.assertEqual(fouc._parse_skeleton_node_order(label), [20, 21])
+
+    def test_no_order_available(self):
+        label = {"id": 1, "type": "skeleton", "svg": "", "sublabels": []}
+        self.assertIsNone(fouc._parse_skeleton_node_order(label))
+
+
+class FlattenSkeletonPointsTests(unittest.TestCase):
+    def test_reorders_elements_to_node_order(self):
+        # CVAT does not guarantee element order; here it is rotated
+        elements = [
+            _element(22, [5.0, 6.0]),
+            _element(20, [1.0, 2.0]),
+            _element(21, [3.0, 4.0]),
+        ]
+        points = fouc._flatten_skeleton_points(elements, [20, 21, 22])
+        self.assertEqual(points, [1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+
+    def test_outside_element_becomes_nan(self):
+        elements = [
+            _element(20, [1.0, 2.0], outside=True),
+            _element(21, [3.0, 4.0]),
+        ]
+        points = fouc._flatten_skeleton_points(elements, [20, 21])
+        self.assertTrue(math.isnan(points[0]))
+        self.assertTrue(math.isnan(points[1]))
+        self.assertEqual(points[2:], [3.0, 4.0])
+
+    def test_missing_element_becomes_nan(self):
+        # A node in the skeleton definition with no element at all still
+        # occupies its index so that indexes stay aligned across shapes
+        elements = [_element(21, [3.0, 4.0])]
+        points = fouc._flatten_skeleton_points(elements, [20, 21, 22])
+        self.assertEqual(len(points), 6)
+        self.assertTrue(math.isnan(points[0]))
+        self.assertEqual(points[2:4], [3.0, 4.0])
+        self.assertTrue(math.isnan(points[4]))
+
+    def test_unknown_sublabel_is_dropped(self):
+        elements = [_element(20, [1.0, 2.0]), _element(99, [9.0, 9.0])]
+        points = fouc._flatten_skeleton_points(elements, [20])
+        self.assertEqual(points, [1.0, 2.0])
+
+    def test_without_node_order_preserves_given_order(self):
+        elements = [_element(22, [5.0, 6.0]), _element(20, [1.0, 2.0])]
+        points = fouc._flatten_skeleton_points(elements, None)
+        self.assertEqual(points, [5.0, 6.0, 1.0, 2.0])
+
+    def test_without_node_order_still_honors_outside(self):
+        elements = [_element(20, [1.0, 2.0], outside=True)]
+        points = fouc._flatten_skeleton_points(elements, None)
+        self.assertTrue(all(math.isnan(p) for p in points))
+
+    def test_no_elements_yields_all_nan(self):
+        # `_parse_annotation` skips element-less skeletons before reaching
+        # here, but every node keeps its index if it ever does
+        points = fouc._flatten_skeleton_points([], [20, 21])
+        self.assertEqual(len(points), 4)
+        self.assertTrue(all(math.isnan(p) for p in points))
+
+    def test_no_elements_and_no_node_order(self):
+        self.assertEqual(fouc._flatten_skeleton_points([], None), [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
> **Stacked on #7520.** This branch contains #7520's commit plus one commit of my own.
> **Reviewers: only the second commit (`54f8254`) is mine** — see the Commits tab, or
> diff against `algojogacor:fix/cvat-keypoint-import-6103`. Suggested merge order:
> review this PR, merge #7520 into `develop` first, after which this PR narrows to
> just my commit and can be merged on its own.

## Summary

Follow-up to #7520, targeting that PR's branch. #7520 correctly makes CVAT skeleton keypoints import at all (they were silently dropped) — this adds two data-correctness fixes found while testing it against a live CVAT task.

## Motivation

Tested #7520 against a live CVAT server using a task with two images and two skeleton labels (13 and 19 nodes), with one node deliberately marked `outside`. The import works, but two problems surfaced:

**1. Point order does not match the skeleton definition.** One of the two skeletons came back rotated — array index 0 held sublabel `8` while sublabel `1` landed at index 6.

This matters because `Keypoint` stores a flat positional `points` list with **no per-point label field**, so flattening `elements` discards every `label_id` and the array index becomes the only carrier of node identity. `KeypointSkeleton` maps index → name for a whole field and explicitly requires *"a fixed number of semantically ordered points"*.

Root cause is upstream and confirmed in CVAT's source — `cvat/apps/dataset_manager/task.py` builds the shapes queryset with `.order_by("frame")` and no secondary key, then appends elements in raw iteration order. All elements of one skeleton share a frame, so their relative order is arbitrary. **CVAT provides no ordering contract**, so we can't rely on the response order. (Their *tracks* queryset does use `.order_by("id")`; the shapes path looks like an oversight. Worth an upstream issue, but our fix shouldn't depend on it — customers run pinned CVAT versions.)

This fix recovers the authoritative order from the `data-node-id` numbering in the label's `svg` definition, falling back to the reported `sublabels` order.

**2. Hidden (`outside`) keypoints were imported as visible points.** A node marked `outside` in CVAT came through as a normal keypoint at its real coordinates. FiftyOne's documented convention is `nan` coordinates for missing/invisible keypoints. Nodes with no element at all get `nan` too, so indexes stay aligned across shapes.

**Also:** skeletons with no elements are now skipped with a warning rather than importing an empty `Keypoint`. This is what skeleton *tracks* look like on this code path, since they store keypoints in per-node sub-tracks that `_parse_annotation` never sees — full track support is a follow-up.

### Note on #7520's problem statement

#7520 says skeleton shapes lack a top-level `points` field and that `CVATShape` therefore fails. That isn't what happens: `points` **is** present as `[]`, set deliberately by CVAT (`task.py`, comment "skeletons themselves should not have points as they consist of other elements"). Nothing was crashing — skeletons were dropped purely because the shape-type dispatch had no `"skeleton"` branch, which #7520 fixes. Flagging so the behavior is understood correctly; it doesn't change the fix.

## Implementation plan

- `_parse_skeleton_node_order(label)` — parse `svg` `data-node-id` → ordered sublabel IDs, falling back to the `sublabels` list
- `_flatten_skeleton_points(elements, node_order)` — emit points in node order, `nan` for `outside` or missing nodes
- `_get_attr_class_maps` also returns a `{label_id: node_order}` map for skeleton labels; threaded through `_parse_shapes_tags` → `_parse_annotation` as `skeleton_map`
- Both helpers are module-level so they're unit-testable without a live CVAT server

## Test plan

**Unit tests** — `tests/unittests/utils/test_cvat_skeletons.py`, 12 tests, no CVAT server needed: svg ordering (including when node IDs aren't in document order), `sublabels` fallback, no-order-available, reordering rotated elements, `outside` → `nan`, missing node → `nan`, unknown sublabel dropped, and the no-node-order paths.

**Live verification** — imported the task above and asserted, for all 32 points across both skeletons, that the point at each index is the normalized coordinate of the matching spec node (or `nan` where CVAT said `outside`). All pass. Before this change, the 13-node skeleton was rotated by 7 and the hidden node imported as visible.

**Regression check** — round-tripped a non-skeleton task (`annotate()` upload → `import_annotations()`) with a detection and a plain keypoint; bounding box and both keypoints come back identical, confirming the new `skeleton_map` plumbing and the extra `_get_attr_class_maps` return value don't disturb existing paths.

## Follow-ups (not in this PR)

- **Skeleton schema import** — `skeleton` appears nowhere else in `cvat.py`, so there's no upload support and imported points still have no node labels or edges. CVAT's `svg` has everything needed to populate `dataset.skeletons`, but that's a feature rather than a bug fix.
- **Skeleton tracks** (video) — currently skipped with a warning.
- **Per-element `occluded`** — CVAT reports it per node and `Keypoint` supports parallel per-point attribute lists, so it could be carried; left out here to avoid overlapping with the existing `occluded_attr` feature.
- **Upstream CVAT issue** for the missing sort key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for importing CVAT skeleton annotations.
  * Preserves node ordering from annotation metadata and represents missing or out-of-frame nodes consistently.
  * Converts skeleton shapes into ordered keypoints and handles unsupported shapes safely.

* **Bug Fixes**
  * Prevents empty skeleton annotations from generating invalid labels.

* **Tests**
  * Added coverage for node ordering, missing nodes, out-of-frame points, unknown nodes, and incomplete skeleton data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3781
<!-- enterprise-sync-pr:end -->