### PR TITLE
release: bump develop to 1.22.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ Installs FiftyOne.
 import os
 from setuptools import setup, find_packages
 
-VERSION = "1.21.0"
+VERSION = "1.22.0"
 
 
 def get_version():


### PR DESCRIPTION
Advances `develop` to the next dev version following the 1.21.0 / 2.24.0 release-branch cut. The `oss-sync/bump-versions-1.22.0` companion is pre-pushed with the downstream version advance.

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3729
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version from 1.21.0 to 1.22.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->