### PR TITLE
Fix docs build: skip typedoc Reference nodes in gen-docs

### DIFF
--- a/app/gen-docs.js
+++ b/app/gen-docs.js
@@ -714,9 +714,14 @@ class DocFragment {
     return _.has(this.raw, path);
   }
   mapArray(path, override) {
-    return this.get(path, [])
-      .map((raw) => toFragment(raw, override, this))
-      .filter((f) => f.shouldInclude());
+    return (
+      this.get(path, [])
+        // typedoc emits re-exports (`export { default as X } from ...`) as
+        // "Reference" nodes; the target is documented at its source, so skip
+        .filter((raw) => raw.kindString !== "Reference")
+        .map((raw) => toFragment(raw, override, this))
+        .filter((f) => f.shouldInclude())
+    );
   }
   label() {
     return this.get("name");


### PR DESCRIPTION
`Build docs` fails on every PR since #8210, which exports `ViewTarget` through two paths (`export * as types` + a named re-export). typedoc documents the symbol once and emits the second export as a `Reference` node — a bare pointer with no content — which `gen-docs.js` doesn't recognize: `Unknown fragment type: Reference`.

Fix: skip `Reference` nodes. The target is always documented elsewhere in the same output (verified in `docs.json` — rendering it would duplicate the entry). Unknown kinds still throw.

Tested: `app/gen-docs.sh` crashes on `develop` without the fix, completes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)