### PR TITLE
Replace the all-tests mirror with a no-op run alias

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -251,9 +251,13 @@ jobs:
     # `all-tests` would shadow the real verdict (vacuous green on a SHA whose
     # suite failed, or a misleading link on one that passed). Under the alias,
     # the SHA's latest `all-tests` is always the run that actually tested it.
+    # Built from the event payload (the gate's run-ci logic), not `needs`: a
+    # needs-based name resolves only when the job starts, so a run cancelled
+    # while queued (an edit burst, the next no-op displacing this one) would
+    # publish the raw expression string as its check name.
     name: >-
-      ${{ (needs.modified-files.result == 'success' &&
-      needs.modified-files.outputs.run-ci != 'true')
+      ${{ (github.event.action == 'edited' &&
+      github.event.changes.base == null)
       && 'all-tests (no-op edit)' || 'all-tests' }}
     runs-on: ubuntu-latest
     needs: [modified-files, build, lint, test, e2e]

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,14 +10,19 @@ on:
     types: [opened, synchronize, reopened, ready_for_review, edited]
 
 concurrency:
-  # A PR title/body edit is a no-op run (run-ci=false). It gets its own group:
+  # A PR title/body edit is a no-op run (run-ci=false). It gets its own
+  # *per-run* group, for two reasons. Separate from `ci`:
   # `cancel-in-progress: false` can't protect a *queued* real run — GitHub
   # allows only one queued run per group — so a shared group lets an edit
-  # displace the suite run before it starts.
+  # displace the suite run before it starts. Per-run rather than a shared
+  # `noop` group: a run cancelled while queued publishes its jobs' raw,
+  # unevaluated `name` expressions as check names, and since edits don't
+  # change the head SHA, that artifact stays visible on the PR. No-op runs
+  # cost seconds — an edit burst just runs them all.
   group: >-
     ${{ github.workflow }}-${{ github.ref }}-${{
     (github.event.action == 'edited' && github.event.changes.base == null)
-    && 'noop' || 'ci' }}
+    && format('noop-{0}', github.run_id) || 'ci' }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -245,22 +245,25 @@ jobs:
             -F body=@new-body.md
 
   all-tests:
+    # A no-op run (title/body edit, run-ci=false) publishes its aggregate
+    # under an alias. Branch protection and the PR UI read only the latest
+    # check run per name — and skipped counts as passing — so a no-op run's
+    # `all-tests` would shadow the real verdict (vacuous green on a SHA whose
+    # suite failed, or a misleading link on one that passed). Under the alias,
+    # the SHA's latest `all-tests` is always the run that actually tested it.
+    name: >-
+      ${{ (needs.modified-files.result == 'success' &&
+      needs.modified-files.outputs.run-ci != 'true')
+      && 'all-tests (no-op edit)' || 'all-tests' }}
     runs-on: ubuntu-latest
     needs: [modified-files, build, lint, test, e2e]
     # not `always()`: a concurrency-cancelled run (an edit displaced by the
     # next edit) must conclude cancelled, not turn the failed gate into a
     # red `all-tests` on a SHA it never tested.
     if: ${{ !cancelled() }}
-    permissions:
-      # the mirror lists the SHA's workflow runs to find the run testing it;
-      # implicit on public repos, required on private fiftyone-teams
-      actions: read
-      # the mirror reads the SHA's all-tests check runs for the verdict
-      checks: read
     env:
-      # A run that skipped the suite (a no-op body edit, or a failed gate)
-      # must not aggregate its skipped needs into a vacuous green that
-      # becomes the latest `all-tests` for a SHA whose real suite failed.
+      # skips the draft and aggregate steps — a no-op run tested nothing,
+      # so it has nothing to aggregate under its alias
       NO_OP: >-
         ${{ needs.modified-files.result == 'success' &&
         needs.modified-files.outputs.run-ci != 'true' }}
@@ -268,126 +271,11 @@ jobs:
       - name: Fail when the CI gate did not complete
         if: needs.modified-files.result != 'success'
         run: exit 1
-      - name: Mirror the last real all-tests result
+      - name: Point at the run testing this SHA
         if: env.NO_OP == 'true'
-        uses: actions/github-script@v9
-        with:
-          script: |
-            // A no-op edit usually lands while the run actually testing this
-            // SHA is still in flight. Its all-tests check run doesn't exist
-            // until its needs finish, so watch this workflow's *runs* on the
-            // SHA instead: stay pending while one is live, then mirror its
-            // verdict. Completed check runs only count as a verdict when
-            // their workflow run finished uncancelled — a run displaced by
-            // concurrency reds its always() gate without testing anything.
-            const sha = context.payload.pull_request.head.sha;
-            const { data: self } = await github.rest.actions.getWorkflowRun({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: context.runId,
-            });
-            const deadline = Date.now() + 90 * 60 * 1000;
-            let emptyPolls = 0;
-            for (;;) {
-              const runs = await github.paginate(
-                github.rest.actions.listWorkflowRunsForRepo,
-                {
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  head_sha: sha,
-                  per_page: 100,
-                },
-              );
-              const candidates = runs.filter(
-                (r) =>
-                  r.workflow_id === self.workflow_id &&
-                  r.id !== context.runId &&
-                  r.status !== 'completed',
-              );
-              // A fellow no-op mirror is not testing this SHA. Without this
-              // check, concurrent no-op runs (an event burst on one commit)
-              // wait on each other until the deadline and conclude red. A run
-              // counts as a mirror only when its gate passed and every suite
-              // job it spawned was skipped; anything ambiguous (gate still
-              // running, jobs not yet listed) stays blocking.
-              const SUITE = /^(build|lint|test|test-windows|e2e)\b/;
-              const live = [];
-              for (const r of candidates) {
-                const jobs = await github.paginate(
-                  github.rest.actions.listJobsForWorkflowRun,
-                  {
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    run_id: r.id,
-                    per_page: 100,
-                  },
-                );
-                const gate = jobs.find((j) => j.name === 'modified-files');
-                const suite = jobs.filter((j) => SUITE.test(j.name));
-                const isMirror =
-                  gate?.status === 'completed' &&
-                  gate?.conclusion === 'success' &&
-                  suite.length > 0 &&
-                  suite.every(
-                    (j) => j.status === 'completed' && j.conclusion === 'skipped',
-                  );
-                if (!isMirror) {
-                  live.push(r);
-                }
-              }
-              const finished = new Set(
-                runs
-                  .filter((r) => r.status === 'completed' && r.conclusion !== 'cancelled')
-                  .map((r) => `/runs/${r.id}/`),
-              );
-              const { data } = await github.rest.checks.listForRef({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                ref: sha,
-                check_name: 'all-tests',
-                // `latest` (the default) returns only the newest run per name —
-                // this job's own in_progress run — hiding the completed verdict.
-                filter: 'all',
-                per_page: 100,
-              });
-              const prior = data.check_runs
-                .filter(
-                  (c) =>
-                    c.status === 'completed' &&
-                    (c.conclusion === 'success' || c.conclusion === 'failure') &&
-                    [...finished].some((p) => (c.details_url ?? '').includes(p)),
-                )
-                .sort((a, b) => new Date(b.started_at) - new Date(a.started_at))[0];
-              // Never mirror while another suite run is in flight — a stale
-              // completed verdict (e.g. a draft-era run, or the attempt a
-              // rerun is replacing) must not shadow the run testing this SHA.
-              if (live.length === 0 && prior) {
-                if (prior.conclusion === 'success') {
-                  core.info(`Mirroring the real all-tests result: success — ${prior.details_url}`);
-                } else {
-                  core.setFailed(`Mirroring the real all-tests result: failure — see ${prior.details_url}`);
-                }
-                return;
-              }
-              if (live.length > 0) {
-                emptyPolls = 0;
-                if (Date.now() >= deadline) {
-                  core.setFailed(`Still waiting on ${live[0].html_url} after 90 minutes — re-run this job once it completes.`);
-                  return;
-                }
-                core.info(`Waiting on the run testing this SHA: ${live.map((r) => r.html_url).join(', ')}`);
-              } else {
-                // Nothing is testing the SHA and no verdict exists (e.g.
-                // every real run was cancelled). Give races a short grace,
-                // then defer to a human rather than inventing a verdict.
-                if (++emptyPolls >= 3) {
-                  core.setFailed('No run is testing this SHA and no completed all-tests verdict exists — re-run the Pull Request workflow.');
-                  return;
-                }
-                core.info('No verdict and no live run for this SHA yet — waiting.');
-              }
-              await new Promise((resolve) => setTimeout(resolve, 2 * 60 * 1000));
-            }
+        run: >-
+          echo "Title/body edit — no code ran here. The verdict is the
+          \`all-tests\` check from the run that tested this SHA."
       - name: Fail when a draft deferred the e2e suite
         # A draft run must not publish a successful merge-authoritative
         # aggregate for a SHA whose e2e never ran; it goes green after


### PR DESCRIPTION
### What

Replaces the `all-tests` mirror step with a dynamic job name: a no-op run (PR title/body edit, `run-ci=false`) publishes its aggregate check as **`all-tests (no-op edit)`** instead of re-publishing the real verdict under the required name. Two supporting changes shaken out by live testing on this PR:

- The alias is computed from the event payload (`edited` without a base change — the same condition the gate and the concurrency group use), since a `needs`-based expression can't resolve if the job never starts.
- No-op runs get a **per-run** concurrency group instead of a shared `noop` group. A run cancelled while its aggregate job is still waiting on `needs` publishes the job's raw, unevaluated `${{ }}` name expression as the check name — and since edits don't change the head SHA, that artifact stays visible on the PR. No-op runs cost seconds, so an edit burst just runs them all; the aliased checks supersede each other by name.

### Why

Branch protection and the PR checks UI read only the **latest** check run per name. The mirror existed so a no-op run wouldn't shadow the real `all-tests` with a vacuous green (a skipped required job counts as passing) — but its side effect was that the red ✗ `all-tests` on a failing PR linked to the near-instant mirror job, not the run that actually failed. With the alias, the SHA's latest `all-tests` is always the run that tested it, so the link is always correct — and the 120-line mirror/polling script (plus its `actions: read` / `checks: read` job permissions) is deleted.

### Preserved semantics

- A failed `modified-files` gate on a real run still concludes a red `all-tests`
- Draft-deferred-e2e and aggregate steps unchanged, still skipped on no-op runs via `NO_OP`
- The CI comment plumbing never sees the alias — it only runs when `run-ci == 'true'`
- No-op runs no longer wait on an in-flight suite run — the real run's own pending `all-tests` already blocks merge

### Known residual

A run cancelled mid-flight on the same SHA (e.g. a draft run displaced by ready-for-review) leaves one raw-named cancelled check for its never-started aggregate job. This artifact class already exists today for displaced runs' never-started matrix jobs (see the raw `Test Python ${{ matrix.python }}...` checks on recent PRs); the alternative — reporting the verdict as a commit status — was rejected because fork PRs run with a read-only token and could never satisfy the required check.

### Test plan (verified live on this PR)

- [x] Real runs publish `all-tests` normally
- [x] A body edit publishes `all-tests (no-op edit)` and `all-tests` still links to the run testing the SHA
- [x] A rapid multi-edit burst (the case that broke two earlier iterations of this PR) settles with every no-op run green and no raw-named check on the head SHA
