### PR TITLE
fix(app): single-vertex polyline annotation bugs and fully-hideable label attributes

### DIFF
--- a/app/packages/annotation/src/engine/surfaces/lighter/useLighterEngineBridge.ts
+++ b/app/packages/annotation/src/engine/surfaces/lighter/useLighterEngineBridge.ts
@@ -13,6 +13,7 @@
 import type { Scene2D } from "@fiftyone/lighter";
 import {
   DetectionOverlay,
+  PolylineOverlay,
   UNDEFINED_LIGHTER_SCENE_ID,
   useLighter,
   useLighterEventHandler,
@@ -165,6 +166,19 @@ export const useLighterEngineBridge = ({
     (event: { overlayId: string }) => {
       const overlay = (scene as Scene2D).getOverlay(event.overlayId);
 
+      // An emptied polyline has nothing to commit — delete it. The delete
+      // is not a surface write, so the change loop unmounts the overlay.
+      if (
+        overlay instanceof PolylineOverlay &&
+        overlay.getRelativePoints().length === 0
+      ) {
+        surface.deleteLabel(
+          stampFrame({ path: overlay.field, instanceId: overlay.id }, frameOf),
+        );
+        surface.selectHandle(undefined);
+        return;
+      }
+
       // No edit-commit consumer (image / 3D): plain commit, its own undo unit.
       if (!onEditCommit) {
         surface.commit(overlay);
@@ -178,7 +192,7 @@ export const useLighterEngineBridge = ({
       surface.commit(overlay, { undoKey });
       onEditCommit(event.overlayId, overlay?.field ?? "", undoKey);
     },
-    [engine, onEditCommit, scene, surface],
+    [engine, frameOf, onEditCommit, scene, surface],
   );
 
   // Gesture coalescing: drawing a masked detection commits in several steps —

--- a/app/packages/core/src/components/Filters/use-label-attribute-icon.tsx
+++ b/app/packages/core/src/components/Filters/use-label-attribute-icon.tsx
@@ -25,17 +25,14 @@ const Icon = ({
     return null;
   }
 
-  const { attribute, isShown, locked } = toggle;
-  const title = locked
-    ? "At least one attribute must be shown in overlays"
-    : `${isShown ? "Hide" : "Show"} ${attribute} in overlays`;
+  const { attribute, isShown } = toggle;
+  const title = `${isShown ? "Hide" : "Show"} ${attribute} in overlays`;
   const Eye = isShown ? VisibilityIcon : VisibilityOffIcon;
 
   return (
     <button
       aria-label={title}
       data-cy={`shown-attribute-${path}`}
-      disabled={locked}
       onClick={(event) => {
         event.stopPropagation();
         toggle.toggle();
@@ -43,7 +40,7 @@ const Icon = ({
       style={{
         background: "none",
         border: "none",
-        cursor: locked ? "not-allowed" : "pointer",
+        cursor: "pointer",
         display: "inline-flex",
         margin: 0,
         padding: 0,

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useAnnotationContext/createNew.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useAnnotationContext/createNew.ts
@@ -98,11 +98,23 @@ export function createNewLabel(
     const polylineData = data as PolylineLabel;
     const overlay = overlayFactory.create<PolylineOptions, PolylineOverlay>(
       "polyline",
-      { field, id, label: polylineData, selectable: true },
+      // starts empty; points are seeded through the point API below
+      { field, id, label: { ...polylineData, points: [] }, selectable: true },
     );
     // withUndo=true so first-point placement is undoable.
     addOverlay(overlay, true);
     scene?.selectOverlay(id, { ignoreSideEffects: true });
+
+    // The point API dispatches `lighter:keypoint-point-added`, which the
+    // bridge commits to the engine. Points baked into the constructor are
+    // never committed.
+    for (const segment of polylineData.points ?? []) {
+      const segmentIdx = overlay.startNewSegment();
+      for (const point of segment) {
+        overlay.appendPointToSegment(segmentIdx, point);
+      }
+    }
+
     return {
       data: polylineData,
       overlay,

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useDelete.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useDelete.ts
@@ -22,20 +22,28 @@ import useExit from "./useExit";
 
 interface KeypointVertexSelection {
   getSelectedPointIndex(): number | null;
+  getRelativePoints(): [number, number][];
 }
 
-/** True while a specific polyline/keypoint vertex is sub-selected on the canvas. */
+/**
+ * True while a canvas vertex is sub-selected and removing it would leave
+ * geometry behind. Removing the only point removes the label, so Delete
+ * falls through to the whole-label delete.
+ */
 const isVertexSubSelected = (overlay: unknown): boolean => {
+  const selection = overlay as KeypointVertexSelection;
   if (
     !overlay ||
-    typeof (overlay as KeypointVertexSelection).getSelectedPointIndex !==
-      "function"
+    typeof selection.getSelectedPointIndex !== "function" ||
+    typeof selection.getRelativePoints !== "function"
   ) {
     return false;
   }
 
-  const index = (overlay as KeypointVertexSelection).getSelectedPointIndex();
-  return index != null && index >= 0;
+  const index = selection.getSelectedPointIndex();
+  return (
+    index != null && index >= 0 && selection.getRelativePoints().length > 1
+  );
 };
 
 export default function useDelete() {

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/usePolylineMode.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/usePolylineMode.ts
@@ -6,7 +6,9 @@ import {
   PolylineEmptyHitAction,
   PolylineEmptyHitContext,
   PolylineOverlay,
+  UNDEFINED_LIGHTER_SCENE_ID,
   useLighter,
+  useLighterEventBus,
 } from "@fiftyone/lighter";
 import { isPatchesView } from "@fiftyone/state";
 import { POLYLINE } from "@fiftyone/utilities";
@@ -36,6 +38,9 @@ const is2dPolylineSelected = (
  * polyline overlay installs an {@link InteractivePolylineHandler} on it; the
  * handler is torn down on selection change or mode deactivation.
  */
+/** Frame-level field paths (`frames.<field>`) — i.e. video. */
+const FRAMES_PREFIX = "frames.";
+
 const polylineModeActiveAtom = atom<boolean>(false);
 export { polylineModeActiveAtom as _unsafePolylineModeActiveAtom };
 
@@ -141,6 +146,9 @@ export const usePolylineModeInstaller = (): void => {
   const polylineModeActive = useAtomValue(polylineModeActiveAtom);
   const setPolylineModeActive = useSetAtom(polylineModeActiveAtom);
   const { scene } = useLighter();
+  const eventBus = useLighterEventBus(
+    scene?.getEventChannel() ?? UNDEFINED_LIGHTER_SCENE_ID,
+  );
   const { selected, createNew } = useAnnotationContext();
 
   // The handler currently installed via scene.enterInteractiveMode, or null
@@ -253,13 +261,44 @@ export const usePolylineModeInstaller = (): void => {
       id: "interactive-polyline-creation-handler",
       onCreate: (worldPoint) => {
         const rel = scene.absolutePointToRelative(worldPoint);
-        createPolylineRef.current({ origin: [rel.x, rel.y] });
+        const created = createPolylineRef.current({ origin: [rel.x, rel.y] });
+
+        // A drawn shape on video has to announce itself so the video surface can
+        // establish the track — first keyframe plus the auto-extend filler — which
+        // is what makes "draw on one frame, scrub forward, drag the point" work
+        // without extending the track by hand every time. A drawn detection gets
+        // this from the interaction manager's SETTING pointer-up path; the polyline
+        // creation flow (creation handler -> createNew -> polyline handler) has no
+        // equivalent, so without this a drawn polyline never became a track.
+        //
+        // Frame-level fields only: an image polyline is already committed by
+        // `createNew`'s vertex seeding, and re-announcing it would only
+        // re-commit the same label. On video the seeding commit also ran
+        // (frame-stamped), so the bridge's establish commit is a value-equal
+        // no-op — the undo stack drops it — but the establish is still what
+        // stashes the gesture key and hands the draw to the video surface.
+        // Lighter records no undo command of its own here (the annotation engine
+        // holds undo authority while mounted), so this pushes no duplicate.
+        if (created?.path?.startsWith(FRAMES_PREFIX)) {
+          // The video handler reads geometry from the engine anchor, not from
+          // this payload, so a zero rect is enough to satisfy the event shape.
+          const bounds = { x: 0, y: 0, width: 0, height: 0 };
+
+          eventBus.dispatch("lighter:overlay-establish", {
+            id: handler.id,
+            overlayId: created.data._id as string,
+            handler,
+            startBounds: bounds,
+            startPosition: { x: bounds.x, y: bounds.y },
+            bounds,
+          });
+        }
       },
     });
 
     scene.enterInteractiveMode(handler);
     installedHandlerRef.current = handler;
-  }, [exitInstalledHandler, polylineModeActive, scene, selected]);
+  }, [eventBus, exitInstalledHandler, polylineModeActive, scene, selected]);
 
   // Tear down on unmount (e.g., scene swap, modal close).
   useEffect(() => {

--- a/app/packages/lighter/src/interaction/InteractionManager.ts
+++ b/app/packages/lighter/src/interaction/InteractionManager.ts
@@ -81,6 +81,8 @@ function isSelfManagedInteractiveHandler(handler: InteractionHandler): boolean {
 export interface KeypointMutationHandler {
   getSelectedPointIndex(): number | null;
   removePoint(index: number): void;
+  /** Optional: how many points the overlay currently has. */
+  getPointCount?(): number;
 }
 
 function hasKeypointMutation(
@@ -1011,7 +1013,12 @@ export class InteractionManager {
         const handler = this.handlers.find((h) => h.id === selectedId);
         if (handler && hasKeypointMutation(handler)) {
           const idx = handler.getSelectedPointIndex();
-          if (idx !== null && idx >= 0) {
+          // Removing the *last* remaining point would leave a geometry-less
+          // overlay (and, on video, a track that renders nothing but still
+          // exists). Deleting the only vertex IS deleting the label, so leave
+          // the event for the label-delete keybinding to handle.
+          const count = handler.getPointCount?.() ?? Number.POSITIVE_INFINITY;
+          if (idx !== null && idx >= 0 && count > 1) {
             handler.removePoint(idx);
             event.preventDefault();
           }

--- a/app/packages/lighter/src/overlay/KeypointOverlay.ts
+++ b/app/packages/lighter/src/overlay/KeypointOverlay.ts
@@ -949,6 +949,13 @@ export class KeypointOverlay
   }
 
   /**
+   * The number of points currently in this overlay.
+   */
+  getPointCount(): number {
+    return this.#points.length;
+  }
+
+  /**
    * Removes the point at the given index.
    */
   removePoint(index: number): void {

--- a/app/packages/lighter/src/overlay/PolylineOverlay.ts
+++ b/app/packages/lighter/src/overlay/PolylineOverlay.ts
@@ -4,6 +4,7 @@
 
 import {
   EDGE_THRESHOLD,
+  KEYPOINT_SELECTED_RADIUS,
   LABEL_ARCHETYPE_PRIORITY,
   PREVIEW_LINE_OPACITY,
 } from "../constants";
@@ -40,6 +41,9 @@ export interface PolylineOptions {
 }
 
 const DEFAULT_FILL_OPACITY = 0.3;
+
+/** Screen-space gap between a lone vertex's marker and its label text. */
+const SINGLE_POINT_LABEL_GAP = 4;
 
 export type SegmentEndpoint = {
   segmentIdx: number;
@@ -884,6 +888,9 @@ export class PolylineOverlay extends KeypointOverlay {
    * Renders the label text at the centroid of the polyline's points.
    * Anchoring on the centroid reads more clearly for polylines/polygons,
    * where the bounding-box corner can sit far from any actual geometry.
+   *
+   * A lone vertex is its own centroid, so the text anchors above the marker
+   * instead of covering it.
    */
   protected override renderLabelText(
     renderer: Renderer2D,
@@ -904,17 +911,29 @@ export class PolylineOverlay extends KeypointOverlay {
       return;
     }
 
-    const centroid = PolylineOverlay.computeCentroid(ctx.absPoints);
+    const single = ctx.absPoints.length === 1;
+    const scale = renderer.getScale() || 1;
+    const position = single
+      ? {
+          x: ctx.absPoints[0].x,
+          y:
+            ctx.absPoints[0].y -
+            (KEYPOINT_SELECTED_RADIUS + SINGLE_POINT_LABEL_GAP) / scale,
+        }
+      : PolylineOverlay.computeCentroid(ctx.absPoints);
 
     // `drawText` returns the absolute-space background rect; retain it for
     // hover/selection hit-testing.
     this.textBounds = renderer.drawText(
       this.label.label,
-      centroid,
+      position,
       {
         fontColor: "#ffffff",
         backgroundColor: ctx.style.fillStyle || ctx.style.strokeStyle || "#000",
-        anchor: { vertical: "center", horizontal: "center" },
+        anchor: {
+          vertical: single ? "bottom" : "center",
+          horizontal: "center",
+        },
       },
       this.containerId,
     );

--- a/app/packages/looker/src/elements/common/computeTagData.ts
+++ b/app/packages/looker/src/elements/common/computeTagData.ts
@@ -319,7 +319,7 @@ export const computeTagData = ({
   };
 
   const CLASSIFICATION_RENDERER = (
-    path,
+    path: string,
     param: Classification,
   ): TagData | null => {
     const attributes = shownLabelAttributes?.[path];

--- a/app/packages/looker/src/elements/common/computeTagData.ts
+++ b/app/packages/looker/src/elements/common/computeTagData.ts
@@ -318,8 +318,17 @@ export const computeTagData = ({
     },
   };
 
-  const CLASSIFICATION_RENDERER = (path, param: Classification): TagData => {
+  const CLASSIFICATION_RENDERER = (
+    path,
+    param: Classification,
+  ): TagData | null => {
     const attributes = shownLabelAttributes?.[path];
+
+    // every attribute toggled off — hide the tag entirely
+    if (attributes && !attributes.length) {
+      return null;
+    }
+
     const label = attributes
       ? getLabelAttributesText(param, attributes) || "null"
       : (param.label ?? "null");

--- a/app/packages/looker/src/elements/common/computeTagData.ts
+++ b/app/packages/looker/src/elements/common/computeTagData.ts
@@ -324,7 +324,7 @@ export const computeTagData = ({
   ): TagData | null => {
     const attributes = shownLabelAttributes?.[path];
 
-    // every attribute toggled off — hide the tag entirely
+    // all attributes off — no tag
     if (attributes && !attributes.length) {
       return null;
     }

--- a/app/packages/looker/src/overlays/keypoint.ts
+++ b/app/packages/looker/src/overlays/keypoint.ts
@@ -13,7 +13,7 @@ import {
 } from "../state";
 import { distance, distanceFromLineSegment, multiply } from "../util";
 import { CONTAINS, CoordinateOverlay, PointInfo, RegularLabel } from "./base";
-import { resolveLabelSelectionVisuals, t } from "./util";
+import { resolveLabelSelectionVisuals, sizeInImagePixels, t } from "./util";
 import { isHoveringParticularLabelWithInstanceConfig } from "@fiftyone/state/src/jotai";
 
 interface KeypointLabel extends RegularLabel {
@@ -34,7 +34,8 @@ export default class KeypointOverlay<
 
     const result = this.getDistanceAndMaybePoint(state);
 
-    if (result && result[0] <= state.pointRadius) {
+    // distances are image-pixel; convert the draw-space radius to match
+    if (result && result[0] <= sizeInImagePixels(state, state.pointRadius)) {
       return CONTAINS.BORDER;
     }
     return CONTAINS.NONE;
@@ -158,7 +159,7 @@ export default class KeypointOverlay<
         y,
         ...(multiply(dimensions, point) as [number, number]),
       );
-      if (d <= pointRadius * TOLERANCE) {
+      if (d <= sizeInImagePixels(state, pointRadius * TOLERANCE)) {
         distances.push([0, i]);
       } else {
         distances.push([d, i]);

--- a/app/packages/looker/src/overlays/polyline.ts
+++ b/app/packages/looker/src/overlays/polyline.ts
@@ -3,12 +3,13 @@
  */
 
 import { isHoveringParticularLabelWithInstanceConfig } from "@fiftyone/state/src/jotai";
-import { TOLERANCE } from "../constants";
+import { INFO_COLOR, TOLERANCE } from "../constants";
 import { BaseState, Coordinates } from "../state";
 import { distanceFromLineSegment, getRenderedScale } from "../util";
 import { CONTAINS, CoordinateOverlay, PointInfo, RegularLabel } from "./base";
 import {
   getInstanceStrokeStyles,
+  getLabelAttributesText,
   resolveLabelSelectionVisuals,
   t,
 } from "./util";
@@ -24,6 +25,14 @@ export default class PolylineOverlay<
   State extends BaseState,
 > extends CoordinateOverlay<State, PolylineLabel> {
   containsPoint(state: Readonly<State>): CONTAINS {
+    // A lone vertex is hit-tested like a keypoint: the target is the drawn dot's
+    // radius, not a stroke-width tolerance meant for lines. Without this the
+    // clickable area is smaller than the dot you can see, so the label reads as
+    // un-hoverable and un-selectable in Explore.
+    if (this.loneVertexHit(state)) {
+      return CONTAINS.BORDER;
+    }
+
     const tolerance =
       (state.strokeWidth * TOLERANCE) /
       getRenderedScale(
@@ -89,6 +98,77 @@ export default class PolylineOverlay<
         );
       }
     }
+
+    !state.config.thumbnail && this.drawLabelText(ctx, state);
+  }
+
+  /**
+   * Draws the label tag, matching `DetectionOverlay`'s tag styling so polylines
+   * read the same as every other label in Explore (filled box in the label
+   * colour, `INFO_COLOR` text, same padding).
+   *
+   * Anchored at the centroid of the shape's points — a polyline's bounding-box
+   * corner can sit far from any actual geometry — except for a lone vertex,
+   * where the tag is lifted clear of the dot so it doesn't hide it.
+   */
+  private drawLabelText(ctx: CanvasRenderingContext2D, state: Readonly<State>) {
+    const labelText = this.getLabelText(state);
+
+    if (!labelText.length) {
+      return;
+    }
+
+    const points = (this.label.points || []).flat().filter(Boolean);
+
+    if (!points.length) {
+      return;
+    }
+
+    const isLoneVertex = points.length === 1;
+    const anchor: Coordinates = isLoneVertex
+      ? points[0]
+      : [
+          points.reduce((sum, p) => sum + p[0], 0) / points.length,
+          points.reduce((sum, p) => sum + p[1], 0) / points.length,
+        ];
+
+    ctx.beginPath();
+    ctx.fillStyle = this.getColor(state);
+
+    let [ox, oy] = t(state, anchor[0], anchor[1]);
+    // clear the dot for a lone vertex; centre the box on the centroid otherwise
+    oy = isLoneVertex
+      ? oy - state.pointRadius - state.strokeWidth
+      : oy + state.fontSize / 2;
+
+    ctx.moveTo(ox, oy);
+    const { width } = ctx.measureText(labelText);
+    const height = state.fontSize;
+    const bpad = state.textPad * 3 + state.strokeWidth;
+    const btrx = ox + width + bpad;
+    const btry = oy - height - bpad;
+    ctx.lineTo(btrx, oy);
+    ctx.lineTo(btrx, btry);
+    ctx.lineTo(ox, btry);
+    ctx.closePath();
+    ctx.fill();
+
+    ctx.fillStyle = INFO_COLOR;
+    const pad = state.textPad + state.strokeWidth;
+    ctx.fillText(labelText, ox + pad, oy - pad);
+  }
+
+  private getLabelText(state: Readonly<State>): string {
+    const attributes = state.options.shownLabelAttributes?.[this.field];
+
+    return attributes
+      ? getLabelAttributesText(
+          this.label,
+          attributes.filter((name) => name !== "points"),
+        )
+      : this.label.label
+        ? `${this.label.label}`
+        : "";
   }
 
   getMouseDistance(state: Readonly<State>): number {
@@ -99,8 +179,9 @@ export default class PolylineOverlay<
       // No segments to measure against for a lone vertex — measure to the point
       // itself, otherwise a single-vertex polyline can never be hovered.
       if (shape.length === 1) {
-        const [px, py] = t(state, shape[0][0], shape[0][1]);
-        distances.push(Math.hypot(xy[0] - px, xy[1] - py));
+        distances.push(
+          Math.hypot(xy[0] - w * shape[0][0], xy[1] - h * shape[0][1]),
+        );
         continue;
       }
 
@@ -141,6 +222,38 @@ export default class PolylineOverlay<
   }
 
   /**
+   * The cursor's hit against a single-vertex shape, or `null` when it isn't over
+   * one. Mirrors `KeypointOverlay.getDistanceAndMaybePoint`: the radius is
+   * `state.pointRadius * TOLERANCE`, doubled while selected, so the target
+   * always matches the dot actually drawn. Distances are in image-pixel space
+   * (`dimensions`-scaled vs `pixelCoordinates`) — NOT the `t()` draw space, which
+   * is a different coordinate system and silently never matches.
+   */
+  private loneVertexHit(
+    state: Readonly<State>,
+  ): { coordinates: Coordinates; index: number } | null {
+    const radius =
+      (this.isSelected(state) ? state.pointRadius * 2 : state.pointRadius) *
+      TOLERANCE;
+    const [w, h] = state.dimensions;
+    const [x, y] = state.pixelCoordinates;
+    const shapes = this.label.points || [];
+
+    for (let i = 0; i < shapes.length; i++) {
+      if (shapes[i]?.length !== 1) {
+        continue;
+      }
+
+      const [px, py] = shapes[i][0];
+      if (Math.hypot(x - w * px, y - h * py) <= radius) {
+        return { coordinates: shapes[i][0], index: i };
+      }
+    }
+
+    return null;
+  }
+
+  /**
    * Draws a lone vertex as a filled dot, matching how `KeypointOverlay` draws
    * points (same `state.pointRadius`, same selected-size bump) so a
    * single-vertex polyline reads consistently with other point geometry.
@@ -164,6 +277,15 @@ export default class PolylineOverlay<
       Math.PI * 2,
     );
     ctx.fill();
+
+    // Selected dots get the same inner marker keypoints use, so selection is
+    // visible on a shape that has no outline to restyle.
+    if (selected) {
+      ctx.fillStyle = INFO_COLOR;
+      ctx.beginPath();
+      ctx.arc(x, y, state.pointRadius, 0, Math.PI * 2);
+      ctx.fill();
+    }
   }
 
   private strokePath(

--- a/app/packages/looker/src/overlays/polyline.ts
+++ b/app/packages/looker/src/overlays/polyline.ts
@@ -64,6 +64,14 @@ export default class PolylineOverlay<
       });
 
     for (const path of this.label.points || []) {
+      // A single-vertex path has no segment to stroke, but it is still a real
+      // shape the annotator drew — draw the vertex itself so it doesn't vanish
+      // in Explore (it renders in Annotate, where vertices are drawn).
+      if (path.length === 1) {
+        this.drawVertex(ctx, state, path[0], strokeColor, selected);
+        continue;
+      }
+
       if (path.length < 2) {
         continue;
       }
@@ -88,6 +96,14 @@ export default class PolylineOverlay<
     const [w, h] = state.dimensions;
     const xy = state.pixelCoordinates;
     for (const shape of this.label.points || []) {
+      // No segments to measure against for a lone vertex — measure to the point
+      // itself, otherwise a single-vertex polyline can never be hovered.
+      if (shape.length === 1) {
+        const [px, py] = t(state, shape[0][0], shape[0][1]);
+        distances.push(Math.hypot(xy[0] - px, xy[1] - py));
+        continue;
+      }
+
       for (let i = 0; i < shape.length - 1; i++) {
         distances.push(
           distanceFromLineSegment(
@@ -122,6 +138,32 @@ export default class PolylineOverlay<
 
   getPoints(): Coordinates[] {
     return getPolylinePoints([this.label]);
+  }
+
+  /**
+   * Draws a lone vertex as a filled dot, matching how `KeypointOverlay` draws
+   * points (same `state.pointRadius`, same selected-size bump) so a
+   * single-vertex polyline reads consistently with other point geometry.
+   */
+  private drawVertex(
+    ctx: CanvasRenderingContext2D,
+    state: Readonly<State>,
+    point: Coordinates,
+    color: string,
+    selected: boolean,
+  ): void {
+    const [x, y] = t(state, point[0], point[1]);
+
+    ctx.fillStyle = color;
+    ctx.beginPath();
+    ctx.arc(
+      x,
+      y,
+      selected ? state.pointRadius * 2 : state.pointRadius,
+      0,
+      Math.PI * 2,
+    );
+    ctx.fill();
   }
 
   private strokePath(

--- a/app/packages/looker/src/overlays/polyline.ts
+++ b/app/packages/looker/src/overlays/polyline.ts
@@ -144,11 +144,15 @@ export default class PolylineOverlay<
 
     // Match the Annotate placement so a label doesn't jump when toggling modes:
     // horizontally centred on the anchor, and for a lone vertex lifted entirely
-    // above the dot rather than sitting up-and-to-the-right of it. `oy` is the
-    // box's BOTTOM edge (it is drawn upward from there).
+    // above the dot rather than sitting up-and-to-the-right of it (the dot is
+    // drawn at double radius while selected). `oy` is the box's BOTTOM edge (it
+    // is drawn upward from there).
     const ox = ax - boxWidth / 2;
+    const vertexRadius = this.isSelected(state)
+      ? state.pointRadius * 2
+      : state.pointRadius;
     const oy = isLoneVertex
-      ? ay - state.pointRadius - state.strokeWidth
+      ? ay - vertexRadius - state.strokeWidth
       : ay + boxHeight / 2;
 
     ctx.beginPath();

--- a/app/packages/looker/src/overlays/polyline.ts
+++ b/app/packages/looker/src/overlays/polyline.ts
@@ -109,7 +109,9 @@ export default class PolylineOverlay<
    *
    * Anchored at the centroid of the shape's points — a polyline's bounding-box
    * corner can sit far from any actual geometry — except for a lone vertex,
-   * where the tag is lifted clear of the dot so it doesn't hide it.
+   * where the tag is lifted clear of the dot so it doesn't hide it. Placement
+   * mirrors the Annotate surface (centred on the anchor, above the dot) so a
+   * label doesn't shift when toggling between Explore and Annotate.
    */
   private drawLabelText(ctx: CanvasRenderingContext2D, state: Readonly<State>) {
     const labelText = this.getLabelText(state);
@@ -132,24 +134,29 @@ export default class PolylineOverlay<
           points.reduce((sum, p) => sum + p[1], 0) / points.length,
         ];
 
-    ctx.beginPath();
-    ctx.fillStyle = this.getColor(state);
-
-    let [ox, oy] = t(state, anchor[0], anchor[1]);
-    // clear the dot for a lone vertex; centre the box on the centroid otherwise
-    oy = isLoneVertex
-      ? oy - state.pointRadius - state.strokeWidth
-      : oy + state.fontSize / 2;
-
-    ctx.moveTo(ox, oy);
     const { width } = ctx.measureText(labelText);
     const height = state.fontSize;
     const bpad = state.textPad * 3 + state.strokeWidth;
-    const btrx = ox + width + bpad;
-    const btry = oy - height - bpad;
-    ctx.lineTo(btrx, oy);
-    ctx.lineTo(btrx, btry);
-    ctx.lineTo(ox, btry);
+    const boxWidth = width + bpad;
+    const boxHeight = height + bpad;
+
+    const [ax, ay] = t(state, anchor[0], anchor[1]);
+
+    // Match the Annotate placement so a label doesn't jump when toggling modes:
+    // horizontally centred on the anchor, and for a lone vertex lifted entirely
+    // above the dot rather than sitting up-and-to-the-right of it. `oy` is the
+    // box's BOTTOM edge (it is drawn upward from there).
+    const ox = ax - boxWidth / 2;
+    const oy = isLoneVertex
+      ? ay - state.pointRadius - state.strokeWidth
+      : ay + boxHeight / 2;
+
+    ctx.beginPath();
+    ctx.fillStyle = this.getColor(state);
+    ctx.moveTo(ox, oy);
+    ctx.lineTo(ox + boxWidth, oy);
+    ctx.lineTo(ox + boxWidth, oy - boxHeight);
+    ctx.lineTo(ox, oy - boxHeight);
     ctx.closePath();
     ctx.fill();
 

--- a/app/packages/looker/src/overlays/polyline.ts
+++ b/app/packages/looker/src/overlays/polyline.ts
@@ -5,12 +5,13 @@
 import { isHoveringParticularLabelWithInstanceConfig } from "@fiftyone/state/src/jotai";
 import { INFO_COLOR, TOLERANCE } from "../constants";
 import { BaseState, Coordinates } from "../state";
-import { distanceFromLineSegment, getRenderedScale } from "../util";
+import { distanceFromLineSegment } from "../util";
 import { CONTAINS, CoordinateOverlay, PointInfo, RegularLabel } from "./base";
 import {
   getInstanceStrokeStyles,
   getLabelAttributesText,
   resolveLabelSelectionVisuals,
+  sizeInImagePixels,
   t,
 } from "./util";
 
@@ -33,12 +34,7 @@ export default class PolylineOverlay<
       return CONTAINS.BORDER;
     }
 
-    const tolerance =
-      (state.strokeWidth * TOLERANCE) /
-      getRenderedScale(
-        [state.windowBBox[2], state.windowBBox[3]],
-        state.dimensions,
-      );
+    const tolerance = sizeInImagePixels(state, state.strokeWidth * TOLERANCE);
     const minDistance = this.getMouseDistance(state);
     if (minDistance <= tolerance) {
       return CONTAINS.BORDER;
@@ -235,17 +231,18 @@ export default class PolylineOverlay<
   /**
    * The cursor's hit against a single-vertex shape, or `null` when it isn't over
    * one. Mirrors `KeypointOverlay.getDistanceAndMaybePoint`: the radius is
-   * `state.pointRadius * TOLERANCE`, doubled while selected, so the target
-   * always matches the dot actually drawn. Distances are in image-pixel space
-   * (`dimensions`-scaled vs `pixelCoordinates`) — NOT the `t()` draw space, which
-   * is a different coordinate system and silently never matches.
+   * `state.pointRadius * TOLERANCE`, doubled while selected, converted to the
+   * image-pixel space of the distances (`dimensions`-scaled vs
+   * `pixelCoordinates`) so the target always matches the dot actually drawn.
    */
   private loneVertexHit(
     state: Readonly<State>,
   ): { coordinates: Coordinates; index: number } | null {
-    const radius =
+    const radius = sizeInImagePixels(
+      state,
       (this.isSelected(state) ? state.pointRadius * 2 : state.pointRadius) *
-      TOLERANCE;
+        TOLERANCE,
+    );
     const [w, h] = state.dimensions;
     const [x, y] = state.pixelCoordinates;
     const shapes = this.label.points || [];

--- a/app/packages/looker/src/overlays/util.ts
+++ b/app/packages/looker/src/overlays/util.ts
@@ -4,6 +4,7 @@
 
 import { COLOR_BY, REGRESSION, getColor } from "@fiftyone/utilities";
 import colorString from "color-string";
+import { getRenderedScale } from "../util";
 import {
   INFO_COLOR,
   LABEL_SELECTION_GREEN,
@@ -26,6 +27,19 @@ export const t = (state: BaseState, x: number, y: number): Coordinates => {
   const [ctlx, ctly, cw, ch] = state.canvasBBox;
   return [ctlx + cw * x, ctly + ch * y];
 };
+
+/**
+ * Convert a draw-space length (`pointRadius`, `strokeWidth`, …) to image
+ * pixels, the space of `pixelCoordinates`/`dimensions` hit tests. Draw-space
+ * sizes are already zoom-compensated (divided by `scale` in `postProcess`),
+ * so the remaining factor is the window's fit scale.
+ */
+export const sizeInImagePixels = (state: BaseState, length: number): number =>
+  length /
+  getRenderedScale(
+    [state.windowBBox[2], state.windowBBox[3]],
+    state.dimensions,
+  );
 
 const strokeRect = (
   ctx: CanvasRenderingContext2D,

--- a/app/packages/state/src/hooks/useLabelAttributeToggle.ts
+++ b/app/packages/state/src/hooks/useLabelAttributeToggle.ts
@@ -30,12 +30,9 @@ export default function useLabelAttributeToggle(path: string, modal: boolean) {
     return null;
   }
 
-  const isShown = shown.includes(row.attribute);
   return {
     attribute: row.attribute,
-    isShown,
-    // hiding the last shown attribute is not allowed
-    locked: isShown && shown.length === 1,
+    isShown: shown.includes(row.attribute),
     toggle,
   };
 }

--- a/app/packages/state/src/recoil/labelAttributes.test.ts
+++ b/app/packages/state/src/recoil/labelAttributes.test.ts
@@ -15,7 +15,7 @@ describe("toggleShownLabelAttribute", () => {
     );
   });
 
-  it("keeps the last shown attribute", () => {
-    expect(toggleShownLabelAttribute(["label"], "label")).toEqual(["label"]);
+  it("removes the last shown attribute", () => {
+    expect(toggleShownLabelAttribute(["label"], "label")).toEqual([]);
   });
 });

--- a/app/packages/state/src/recoil/labelAttributes.ts
+++ b/app/packages/state/src/recoil/labelAttributes.ts
@@ -68,9 +68,10 @@ const labelAttributeNames = selectorFamily<string[], string>({
 
 /**
  * The attribute names of a label field rendered as text in looker overlays.
- * Attributes no longer present in the schema are silently dropped; when
- * nothing valid remains, the default applies. Setting an empty list is
- * ignored so at least one attribute is always shown.
+ * An explicitly empty list means the user turned every attribute off and
+ * renders no text. Attributes no longer present in the schema are silently
+ * dropped; when a non-empty list loses every valid entry, the default
+ * applies.
  */
 export const shownLabelAttributes = selectorFamily<string[], string>({
   key: "shownLabelAttributes",
@@ -78,8 +79,12 @@ export const shownLabelAttributes = selectorFamily<string[], string>({
     (path) =>
     ({ get }) => {
       const stored = get(shownLabelAttributesMap)[path];
-      if (!stored?.length) {
+      if (!stored) {
         return DEFAULT_SHOWN_LABEL_ATTRIBUTES;
+      }
+
+      if (!stored.length) {
+        return stored;
       }
 
       const valid = new Set(get(labelAttributeNames(path)));
@@ -89,7 +94,7 @@ export const shownLabelAttributes = selectorFamily<string[], string>({
   set:
     (path) =>
     ({ get, set }, value) => {
-      if (value instanceof DefaultValue || !value.length) {
+      if (value instanceof DefaultValue) {
         return;
       }
 
@@ -195,11 +200,7 @@ export const labelAttributeRow = selectorFamily<
 export const toggleShownLabelAttribute = (
   shown: string[],
   attribute: string,
-): string[] => {
-  if (!shown.includes(attribute)) {
-    return [...shown, attribute];
-  }
-
-  const next = shown.filter((name) => name !== attribute);
-  return next.length ? next : shown;
-};
+): string[] =>
+  shown.includes(attribute)
+    ? shown.filter((name) => name !== attribute)
+    : [...shown, attribute];

--- a/app/packages/state/src/recoil/labelAttributes.ts
+++ b/app/packages/state/src/recoil/labelAttributes.ts
@@ -68,10 +68,9 @@ const labelAttributeNames = selectorFamily<string[], string>({
 
 /**
  * The attribute names of a label field rendered as text in looker overlays.
- * An explicitly empty list means the user turned every attribute off and
- * renders no text. Attributes no longer present in the schema are silently
- * dropped; when a non-empty list loses every valid entry, the default
- * applies.
+ * An explicitly empty list renders no text. Attributes no longer present in
+ * the schema are silently dropped; when a non-empty list loses every valid
+ * entry, the default applies.
  */
 export const shownLabelAttributes = selectorFamily<string[], string>({
   key: "shownLabelAttributes",

--- a/app/packages/state/src/recoil/labelAttributes.ts
+++ b/app/packages/state/src/recoil/labelAttributes.ts
@@ -24,8 +24,13 @@ const TAG_OVERLAY_TYPES = new Set(
   [CLASSIFICATION, CLASSIFICATIONS].map((cls) => withPath(LABELS_PATH, cls)),
 );
 
-const BOX_HEADER_TYPES = new Set(
-  [DETECTION, DETECTIONS].map((cls) => withPath(LABELS_PATH, cls)),
+// Label types that render their attributes as overlay text in the modal:
+// detection box headers, and polyline tags (anchored on the shape's centroid,
+// or above the dot for a single-vertex polyline).
+const MODAL_LABEL_TEXT_TYPES = new Set(
+  [DETECTION, DETECTIONS, POLYLINE, POLYLINES].map((cls) =>
+    withPath(LABELS_PATH, cls),
+  ),
 );
 
 const PATCH_LABEL_TYPES = new Set(
@@ -127,8 +132,8 @@ export const resolvedShownLabelAttributes = selector<Record<string, string[]>>({
 /**
  * Whether toggling shown attributes for a label field changes what is
  * rendered in the current context: classification-style tag overlays render
- * everywhere, detection box headers render in the modal, and spatial patch
- * labels render as grid tag overlays in patches views.
+ * everywhere, detection box headers and polyline tags render in the modal, and
+ * spatial patch labels render as grid tag overlays in patches views.
  */
 export const canToggleShownLabelAttributes = selectorFamily<
   boolean,
@@ -148,7 +153,7 @@ export const canToggleShownLabelAttributes = selectorFamily<
       }
 
       if (modal) {
-        return BOX_HEADER_TYPES.has(docType);
+        return MODAL_LABEL_TEXT_TYPES.has(docType);
       }
 
       return PATCH_LABEL_TYPES.has(docType) && get(isPatchesView);

--- a/app/packages/utilities/src/sample/sample.test.ts
+++ b/app/packages/utilities/src/sample/sample.test.ts
@@ -311,6 +311,18 @@ describe("Sample", () => {
       s.setField("detection", makeDet("d1", "cat-revived"));
       expect(s.getResolved("detection")).toEqual(makeDet("d1", "cat-revived"));
     });
+
+    it("notifies a list-label delete even when the parent has no value", () => {
+      const s = new Sample({ schema: detectionsSchema });
+      const changes: unknown[] = [];
+      s.subscribeChanges((c) => changes.push(...c));
+      s.deleteLabel("ground_truth", "d1");
+      expect(changes).toEqual([
+        { path: "ground_truth", labelId: "d1", kind: SampleChangeKind.Delete },
+      ]);
+      // nothing existed, so nothing persists
+      expect(s.getJsonPatch()).toEqual([]);
+    });
   });
 
   describe("getJsonPatch", () => {

--- a/app/packages/utilities/src/sample/sample.ts
+++ b/app/packages/utilities/src/sample/sample.ts
@@ -462,19 +462,19 @@ export class Sample {
       const child = LIST_LABEL_CHILD[type]!;
       const existing = this.getResolved<Record<string, unknown>>(path);
 
-      if (!existing) {
-        return;
+      if (existing) {
+        const prior = Array.isArray(existing[child])
+          ? (existing[child] as LabelData[])
+          : [];
+
+        this.transientData[path] = {
+          ...existing,
+          [child]: prior.filter((l) => l._id !== id),
+        };
       }
 
-      const prior = Array.isArray(existing[child])
-        ? (existing[child] as LabelData[])
-        : [];
-
-      this.transientData[path] = {
-        ...existing,
-        [child]: prior.filter((l) => l._id !== id),
-      };
-
+      // Notify even when nothing was removed — subscribers key off the
+      // announcement, not the data diff.
       this.notify([{ path, labelId: id, kind: SampleChangeKind.Delete }]);
 
       return;

--- a/app/packages/video-annotation/src/hooks/useAutoInterpolate.test.ts
+++ b/app/packages/video-annotation/src/hooks/useAutoInterpolate.test.ts
@@ -258,8 +258,7 @@ describe("useAutoInterpolate (Case C — tail step-hold)", () => {
           closed: false,
           filled: false,
         } as never;
-      if (frame === 2)
-        return { keyframe: false, points: [[[0, 0]]] } as never;
+      if (frame === 2) return { keyframe: false, points: [[[0, 0]]] } as never;
       return null;
     };
 

--- a/app/packages/video-annotation/src/hooks/useAutoInterpolate.test.ts
+++ b/app/packages/video-annotation/src/hooks/useAutoInterpolate.test.ts
@@ -238,12 +238,64 @@ describe("useAutoInterpolate (Case C — tail step-hold)", () => {
     );
   });
 
-  it("does not step-hold a non-detection anchor (no bounding_box)", () => {
-    // A polyline-style track: keyframe present but no bbox to hold forward.
+  it("step-holds a polyline anchor's points forward over filler", () => {
+    // A polyline track's filler is written when the shape is first drawn — one
+    // vertex — so every vertex added to the keyframe afterwards has to be held
+    // forward, exactly as a resized box is. Without this the drawn frame keeps
+    // the full shape and the rest of the track keeps the stale one.
     streamRef.current = { labelsField: "polylines", totalFrames: 3 };
     getLabelImpl.current = ({ frame }: { frame: number }) => {
-      if (frame === 1) return { keyframe: true, points: [[0, 0]] } as never;
-      if (frame === 2) return { keyframe: false, points: [[1, 1]] } as never;
+      if (frame === 1)
+        return {
+          keyframe: true,
+          points: [
+            [
+              [0, 0],
+              [1, 0],
+              [1, 1],
+            ],
+          ],
+          closed: false,
+          filled: false,
+        } as never;
+      if (frame === 2)
+        return { keyframe: false, points: [[[0, 0]]] } as never;
+      return null;
+    };
+
+    renderHook(() => useAutoInterpolate());
+
+    fireKeyframeChanged({
+      trackId: "t1",
+      instanceId: "i1",
+      frame: 1,
+      kind: "set",
+      path: "frames.polylines",
+    });
+
+    expect(updateLabel).toHaveBeenCalledWith(
+      { path: "frames.polylines", instanceId: "i1", frame: 2 },
+      {
+        points: [
+          [
+            [0, 0],
+            [1, 0],
+            [1, 1],
+          ],
+        ],
+        closed: false,
+        filled: false,
+        keyframe: false,
+      },
+    );
+  });
+
+  it("does not step-hold an anchor with no geometry at all", () => {
+    // Neither a bbox nor points — nothing to hold forward.
+    streamRef.current = { labelsField: "polylines", totalFrames: 3 };
+    getLabelImpl.current = ({ frame }: { frame: number }) => {
+      if (frame === 1) return { keyframe: true } as never;
+      if (frame === 2) return { keyframe: false } as never;
       return null;
     };
 

--- a/app/packages/video-annotation/src/hooks/useAutoInterpolate.ts
+++ b/app/packages/video-annotation/src/hooks/useAutoInterpolate.ts
@@ -4,6 +4,7 @@ import {
   useAnnotationEventHandler,
   useSurfaceActions,
 } from "@fiftyone/annotation";
+import type { LabelData } from "@fiftyone/utilities";
 import { useCallback } from "react";
 import { useFrameLabelsStream } from "../streams/frameLabelsStream";
 import { useVideoPropagate } from "./useVideoPropagate";
@@ -139,11 +140,25 @@ export const useAutoInterpolate = (): void => {
           });
           const hasNextKeyframe = keyframeFrames.some((kf) => kf > frame);
 
-          if (
-            anchor &&
-            Array.isArray(anchor.bounding_box) &&
-            !hasNextKeyframe
-          ) {
+          // Whichever geometry the track carries. A polyline's filler has to be
+          // refreshed the same way a box's is: the frames forward of the only
+          // keyframe were filled when the shape was first drawn (one vertex), so
+          // without this every vertex added afterwards would live on the drawn
+          // frame alone and the rest of the track would keep the stale shape.
+          const held: Partial<LabelData> | null = !anchor
+            ? null
+            : Array.isArray(anchor.bounding_box)
+              ? { bounding_box: anchor.bounding_box }
+              : Array.isArray(anchor.points) &&
+                  (anchor.points as unknown[]).length > 0
+                ? {
+                    points: anchor.points,
+                    closed: anchor.closed,
+                    filled: anchor.filled,
+                  }
+                : null;
+
+          if (held && !hasNextKeyframe) {
             const tailFrames = presentFrames.filter((f) => f > frame);
 
             if (tailFrames.length > 0) {
@@ -164,7 +179,7 @@ export const useAutoInterpolate = (): void => {
 
                     actions.updateLabel(
                       { path, instanceId, frame: tailFrame },
-                      { bounding_box: anchor.bounding_box, keyframe: false },
+                      { ...held, keyframe: false },
                     );
                   }
                 },

--- a/app/packages/video-annotation/src/sync/useSyncLighterAnnotation.ts
+++ b/app/packages/video-annotation/src/sync/useSyncLighterAnnotation.ts
@@ -125,8 +125,19 @@ const useRegisterDrawEstablishHandler = ({
 
           clear();
 
-          // boxes only — a fresh draw of another label kind isn't a track
-          if (!Array.isArray(source.bounding_box)) {
+          // Geometry-bearing draws become tracks: a box, or a keypoint /
+          // polyline's `points`. `useKeyframePromotionOnEdit` already treats both
+          // as track geometry when a frame is EDITED, so gating the DRAW on boxes
+          // alone left the two halves disagreeing: editing a polyline promoted a
+          // keyframe, but drawing one never established the track in the first
+          // place — no first keyframe, no auto-extend, no timeline row. A fresh
+          // draw of a non-geometry label kind still isn't a track.
+          const hasTrackGeometry =
+            Array.isArray(source.bounding_box) ||
+            (Array.isArray(source.points) &&
+              (source.points as unknown[]).length > 0);
+
+          if (!hasTrackGeometry) {
             return;
           }
 
@@ -153,7 +164,7 @@ const useRegisterDrawEstablishHandler = ({
           }
 
           // fold the filler into the draw's undo unit (key taken above), on the
-          // field the box was actually drawn on — not the stream's primary,
+          // field the shape was actually drawn on — not the stream's primary,
           // which a draw onto a non-primary active field would miss
           surfaceActions.extendTrack(
             anchor.instanceId,

--- a/e2e-pw/src/oss/poms/grid/index.ts
+++ b/e2e-pw/src/oss/poms/grid/index.ts
@@ -188,6 +188,11 @@ class GridAsserter {
     await expect(tagElement).toHaveText(expectedTagValue);
   }
 
+  async nthSampleHasNoTag(n: number, tagName: string) {
+    const tagElement = this.gridPom.getNthTile(n).getByTestId(`tag-${tagName}`);
+    await expect(tagElement).toBeHidden();
+  }
+
   async isSelectionCountEqualTo(n: number) {
     const action = this.gridPom.actionsRow.gridActionsRow.getByTestId(
       "action-manage-selected",

--- a/e2e-pw/src/oss/poms/modal/annotate-sidebar.ts
+++ b/e2e-pw/src/oss/poms/modal/annotate-sidebar.ts
@@ -238,6 +238,19 @@ class ModalAnnotateSidebarAsserter {
   constructor(private readonly modalAnnotateSidebar: ModalAnnotateSidebarPom) {}
 
   /**
+   * Verify the count shown on the sidebar's Labels group
+   *
+   * @param count The expected number of active labels
+   */
+  async hasActiveLabelsCount(count: number) {
+    await expect(
+      this.modalAnnotateSidebar.locator.getByTestId(
+        "sidebar-group-Labels-field-count",
+      ),
+    ).toHaveText(count.toString());
+  }
+
+  /**
    * Verify that the active labels section is expanded
    */
   async verifyActiveLabelsIsExpanded() {

--- a/e2e-pw/src/oss/poms/modal/index.ts
+++ b/e2e-pw/src/oss/poms/modal/index.ts
@@ -386,11 +386,11 @@ class ModalAsserter {
   constructor(private readonly modalPom: ModalPom) {}
 
   async isClosed() {
-    await expect(this.modalPom.modalContainer).toBeHidden();
+    await expect(this.modalPom.locator).toBeHidden();
   }
 
   async isOpen() {
-    await expect(this.modalPom.modalContainer).toBeVisible();
+    await expect(this.modalPom.locator).toBeVisible();
   }
 
   async verifyModalOpenedSuccessfully() {

--- a/e2e-pw/src/oss/specs/annotate-2d-polyline-single-vertex.spec.ts
+++ b/e2e-pw/src/oss/specs/annotate-2d-polyline-single-vertex.spec.ts
@@ -138,7 +138,11 @@ test("Backspace on the lone vertex deletes the label", async ({
   // clicking the vertex is a point hit — it sub-selects the lone point, the
   // exact state where Backspace previously deferred to vertex removal. The
   // sub-selection is set synchronously in the overlay's pointer handler, so
-  // the keydown that follows always observes it.
+  // the keydown that follows always observes it. Gate the click on the grab
+  // cursor: the hover state is seconds stale by now, and a click that misses
+  // the point hit-test lands in crosshair territory, where polyline mode adds
+  // a vertex — Backspace then removes that vertex instead of the label.
+  await modal.sampleCanvas.move(...VERTEX, "grab");
   await modal.sampleCanvas.click(...VERTEX);
   await page.keyboard.press("Backspace");
 

--- a/e2e-pw/src/oss/specs/annotate-2d-polyline-single-vertex.spec.ts
+++ b/e2e-pw/src/oss/specs/annotate-2d-polyline-single-vertex.spec.ts
@@ -4,18 +4,17 @@
  * Single-vertex polylines in Annotate (FOEPD-4459):
  *   - the seed vertex persists on the first click (previously the label lived
  *     only in the sidebar draft — no engine row, no document write — until a
- *     second vertex landed, so the fresh-context read below found nothing),
+ *     second vertex landed, so the reload read-back below found nothing),
  *   - Backspace with the lone vertex sub-selected deletes the whole label
  *     (previously it deferred to vertex removal and appeared to do nothing).
  *
  * Each test draws on its own sample, so a failed test cannot leak a stray
  * polyline into another.
  */
-import { test as base, type Browser, type Page } from "src/oss/fixtures";
+import { test as base, type Page } from "src/oss/fixtures";
 import { ModalPom } from "src/oss/poms/modal";
 import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
 import type { AbstractFiftyoneLoader } from "src/shared/abstract-loader";
-import { EventUtils } from "src/shared/event-utils";
 import { indexToId } from "src/shared/utils";
 
 const datasetName = getUniqueDatasetNameWithPrefix(
@@ -79,25 +78,22 @@ const openSample = async (
 };
 
 /**
- * Open the persisted sample in an annotate-mode modal in a brand-new browser
- * context (no shared client cache — a true server round-trip) and run
- * `verify` there.
+ * Re-open the sample after the first `openSample`: the annotate-mode choice
+ * persists across navigation, so the modal boots straight into Annotate and
+ * the Explore looker canvas (whose `canvas-loaded` attribute `openSample`
+ * waits on) never mounts — wait on the lighter surface instead.
  */
-const inFreshContext = async (
-  browser: Browser,
+const reopenSample = async (
   fiftyoneLoader: AbstractFiftyoneLoader,
-  verify: (modal: ModalPom) => Promise<void>,
+  page: Page,
+  modal: ModalPom,
+  id: string,
 ) => {
-  const context = await browser.newContext();
-  const freshPage = await context.newPage();
-
-  try {
-    const freshModal = new ModalPom(freshPage, new EventUtils(freshPage));
-    await openSample(fiftyoneLoader, freshPage, freshModal, SAMPLE_IDS.persist);
-    await verify(freshModal);
-  } finally {
-    await context.close();
-  }
+  await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
+    searchParams: new URLSearchParams({ id }),
+  });
+  await modal.waitForLighterReady();
+  await modal.assert.isOpen();
 };
 
 /** Draw the single-vertex polyline and class it `lane`. */
@@ -109,7 +105,6 @@ const drawAndClass = async (modal: ModalPom) => {
 };
 
 test("a single vertex persists on the first click", async ({
-  browser,
   fiftyoneLoader,
   modal,
   page,
@@ -118,17 +113,13 @@ test("a single vertex persists on the first click", async ({
   await drawAndClass(modal);
   await modal.sidebar.annotate.waitForSavesSettled();
 
-  // true round-trip: a brand-new browser context rebuilds the app from the
-  // server, so the one-vertex label reads back (pre-fix there was no engine
-  // row to save, so this read-back found nothing). Re-navigating in the same
-  // page can't be used: the modal reopens straight into Annotate mode, where
-  // the Explore looker canvas that `waitForSampleLoadDomAttribute` keys on
-  // never mounts. See ANNOTATION_E2E_TEST_NOTES.md "persistence pattern".
-  await inFreshContext(browser, fiftyoneLoader, async (freshModal) => {
-    await freshModal.sidebar.annotate.assert.hasActiveLabelsCount(1);
-    await freshModal.sidebar.annotate.selectActiveLabel("lane", 0);
-    await freshModal.sidebar.edit.assert.verifyFieldValue("label", "lane");
-  });
+  // true round-trip: re-navigating reloads the page, so the app rebuilds from
+  // the server and the one-vertex label reads back. Pre-fix there was no
+  // engine row to save, so this reload found nothing.
+  await reopenSample(fiftyoneLoader, page, modal, SAMPLE_IDS.persist);
+  await modal.sidebar.annotate.assert.hasActiveLabelsCount(1);
+  await modal.sidebar.annotate.selectActiveLabel("lane", 0);
+  await modal.sidebar.edit.assert.verifyFieldValue("label", "lane");
 });
 
 test("Backspace on the lone vertex deletes the label", async ({

--- a/e2e-pw/src/oss/specs/annotate-2d-polyline-single-vertex.spec.ts
+++ b/e2e-pw/src/oss/specs/annotate-2d-polyline-single-vertex.spec.ts
@@ -1,0 +1,125 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ *
+ * Single-vertex polylines in Annotate (FOEPD-4459):
+ *   - the seed vertex persists on the first click (previously the label lived
+ *     only in the sidebar draft — no engine row, no document write — until a
+ *     second vertex landed, so the fresh-context read below found nothing),
+ *   - Backspace with the lone vertex sub-selected deletes the whole label
+ *     (previously it deferred to vertex removal and appeared to do nothing).
+ *
+ * Each test draws on its own sample, so a failed test cannot leak a stray
+ * polyline into another.
+ */
+import { test as base, type Page } from "src/oss/fixtures";
+import { ModalPom } from "src/oss/poms/modal";
+import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
+import type { AbstractFiftyoneLoader } from "src/shared/abstract-loader";
+import { indexToId } from "src/shared/utils";
+
+const datasetName = getUniqueDatasetNameWithPrefix(
+  "annotate-2d-polyline-single-vertex",
+);
+
+/** One sample per test, deep-linked by the factory's fixed ids. */
+const SAMPLE_IDS = {
+  persist: indexToId(0),
+  delete: indexToId(1),
+};
+
+/** The single vertex, at the media center. */
+const VERTEX: [number, number] = [0.5, 0.5];
+
+const test = base.extend<{ modal: ModalPom }>({
+  modal: async ({ page, eventUtils }, use) => {
+    await use(new ModalPom(page, eventUtils));
+  },
+});
+
+test.beforeAll(async ({ datasetFactory, foWebServer }) => {
+  await foWebServer.startWebServer();
+  await datasetFactory.createDataset({
+    datasetName,
+    numSamples: Object.keys(SAMPLE_IDS).length,
+    imageOptions: { fillColor: "white", width: 640, height: 480 },
+    schema: {
+      polylines: "Polylines",
+      // the annotate flow stamps an `index` on drawn polylines
+      "polylines.polylines.index": "IntField",
+    },
+    labelSchemas: {
+      polylines: {
+        type: "polylines",
+        classes: ["lane", "curb"],
+        attributes: [],
+        component: "dropdown",
+      },
+    },
+  });
+});
+
+test.afterAll(async ({ foWebServer }) => {
+  await foWebServer.stopWebServer();
+});
+
+/** Open the sample's modal in annotate mode. */
+const openSample = async (
+  fiftyoneLoader: AbstractFiftyoneLoader,
+  page: Page,
+  modal: ModalPom,
+  id: string,
+) => {
+  await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
+    searchParams: new URLSearchParams({ id }),
+  });
+  await modal.waitForSampleLoadDomAttribute();
+  await modal.assert.isOpen();
+  await modal.sidebar.switchMode("annotate");
+};
+
+/** Draw the single-vertex polyline and class it `lane`. */
+const drawAndClass = async (modal: ModalPom) => {
+  await modal.sidebar.annotate.polylineMode();
+  await modal.sampleCanvas.click(...VERTEX);
+  await modal.sidebar.edit.selectFieldChoice("label", "lane");
+  await modal.sidebar.edit.assert.verifyFieldValue("label", "lane");
+};
+
+test("a single vertex persists on the first click", async ({
+  fiftyoneLoader,
+  modal,
+  page,
+}) => {
+  await openSample(fiftyoneLoader, page, modal, SAMPLE_IDS.persist);
+  await drawAndClass(modal);
+  await modal.sidebar.annotate.waitForSavesSettled();
+
+  // true round-trip: re-navigating rebuilds the app from the server, so the
+  // one-vertex label reads back. Pre-fix there was no engine row to save, so
+  // this reload found nothing.
+  await openSample(fiftyoneLoader, page, modal, SAMPLE_IDS.persist);
+  await modal.sidebar.annotate.assert.hasActiveLabelsCount(1);
+  await modal.sidebar.annotate.selectActiveLabel("lane", 0);
+  await modal.sidebar.edit.assert.verifyFieldValue("label", "lane");
+});
+
+test("Backspace on the lone vertex deletes the label", async ({
+  fiftyoneLoader,
+  modal,
+  page,
+}) => {
+  await openSample(fiftyoneLoader, page, modal, SAMPLE_IDS.delete);
+  await drawAndClass(modal);
+  await modal.sidebar.annotate.waitForSavesSettled();
+
+  // clicking the vertex is a point hit — it sub-selects the lone point, the
+  // exact state where Backspace previously deferred to vertex removal. The
+  // sub-selection is set synchronously in the overlay's pointer handler, so
+  // the keydown that follows always observes it.
+  await modal.sampleCanvas.click(...VERTEX);
+  await page.keyboard.press("Backspace");
+
+  await modal.sidebar.annotate.assert.hasActiveLabelsCount(0);
+  // the delete flushes before the test ends
+  await modal.sidebar.annotate.waitForSavesSettled();
+});

--- a/e2e-pw/src/oss/specs/annotate-2d-polyline-single-vertex.spec.ts
+++ b/e2e-pw/src/oss/specs/annotate-2d-polyline-single-vertex.spec.ts
@@ -99,6 +99,10 @@ const reopenSample = async (
 /** Draw the single-vertex polyline and class it `lane`. */
 const drawAndClass = async (modal: ModalPom) => {
   await modal.sidebar.annotate.polylineMode();
+  // the toolbar toggle installs the creation handler via an effect, so gate
+  // the click on its crosshair — with exactly one click, a swallowed click
+  // has no later vertex to self-heal on
+  await modal.sampleCanvas.move(...VERTEX, "crosshair");
   await modal.sampleCanvas.click(...VERTEX);
   await modal.sidebar.edit.selectFieldChoice("label", "lane");
   await modal.sidebar.edit.assert.verifyFieldValue("label", "lane");

--- a/e2e-pw/src/oss/specs/annotate-2d-polyline-single-vertex.spec.ts
+++ b/e2e-pw/src/oss/specs/annotate-2d-polyline-single-vertex.spec.ts
@@ -11,10 +11,11 @@
  * Each test draws on its own sample, so a failed test cannot leak a stray
  * polyline into another.
  */
-import { test as base, type Page } from "src/oss/fixtures";
+import { test as base, type Browser, type Page } from "src/oss/fixtures";
 import { ModalPom } from "src/oss/poms/modal";
 import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
 import type { AbstractFiftyoneLoader } from "src/shared/abstract-loader";
+import { EventUtils } from "src/shared/event-utils";
 import { indexToId } from "src/shared/utils";
 
 const datasetName = getUniqueDatasetNameWithPrefix(
@@ -77,6 +78,28 @@ const openSample = async (
   await modal.sidebar.switchMode("annotate");
 };
 
+/**
+ * Open the persisted sample in an annotate-mode modal in a brand-new browser
+ * context (no shared client cache — a true server round-trip) and run
+ * `verify` there.
+ */
+const inFreshContext = async (
+  browser: Browser,
+  fiftyoneLoader: AbstractFiftyoneLoader,
+  verify: (modal: ModalPom) => Promise<void>,
+) => {
+  const context = await browser.newContext();
+  const freshPage = await context.newPage();
+
+  try {
+    const freshModal = new ModalPom(freshPage, new EventUtils(freshPage));
+    await openSample(fiftyoneLoader, freshPage, freshModal, SAMPLE_IDS.persist);
+    await verify(freshModal);
+  } finally {
+    await context.close();
+  }
+};
+
 /** Draw the single-vertex polyline and class it `lane`. */
 const drawAndClass = async (modal: ModalPom) => {
   await modal.sidebar.annotate.polylineMode();
@@ -86,6 +109,7 @@ const drawAndClass = async (modal: ModalPom) => {
 };
 
 test("a single vertex persists on the first click", async ({
+  browser,
   fiftyoneLoader,
   modal,
   page,
@@ -94,13 +118,17 @@ test("a single vertex persists on the first click", async ({
   await drawAndClass(modal);
   await modal.sidebar.annotate.waitForSavesSettled();
 
-  // true round-trip: re-navigating rebuilds the app from the server, so the
-  // one-vertex label reads back. Pre-fix there was no engine row to save, so
-  // this reload found nothing.
-  await openSample(fiftyoneLoader, page, modal, SAMPLE_IDS.persist);
-  await modal.sidebar.annotate.assert.hasActiveLabelsCount(1);
-  await modal.sidebar.annotate.selectActiveLabel("lane", 0);
-  await modal.sidebar.edit.assert.verifyFieldValue("label", "lane");
+  // true round-trip: a brand-new browser context rebuilds the app from the
+  // server, so the one-vertex label reads back (pre-fix there was no engine
+  // row to save, so this read-back found nothing). Re-navigating in the same
+  // page can't be used: the modal reopens straight into Annotate mode, where
+  // the Explore looker canvas that `waitForSampleLoadDomAttribute` keys on
+  // never mounts. See ANNOTATION_E2E_TEST_NOTES.md "persistence pattern".
+  await inFreshContext(browser, fiftyoneLoader, async (freshModal) => {
+    await freshModal.sidebar.annotate.assert.hasActiveLabelsCount(1);
+    await freshModal.sidebar.annotate.selectActiveLabel("lane", 0);
+    await freshModal.sidebar.edit.assert.verifyFieldValue("label", "lane");
+  });
 });
 
 test("Backspace on the lone vertex deletes the label", async ({

--- a/e2e-pw/src/oss/specs/patch-label-overlays.spec.ts
+++ b/e2e-pw/src/oss/specs/patch-label-overlays.spec.ts
@@ -69,7 +69,7 @@ test("patch tiles show the patch label as a tag bubble", async ({ grid }) => {
   await grid.assert.nthSampleHasTagValue(1, "predictions", "dog");
 });
 
-test("attribute eyes control bubble text; the last shown attribute locks", async ({
+test("attribute eyes control bubble text; all attributes can be hidden", async ({
   grid,
   sidebar,
 }) => {
@@ -80,14 +80,16 @@ test("attribute eyes control bubble text; the last shown attribute locks", async
 
   await sidebar.clickFieldDropdown("predictions");
 
-  // `label` is the only shown attribute by default, so its eye is locked
-  await expect(labelEye).toBeDisabled();
-
   await confidenceEye.click();
   await grid.assert.nthSampleHasTagValue(0, "predictions", "cat, 0.9");
-  await expect(labelEye).toBeEnabled();
 
   await labelEye.click();
   await grid.assert.nthSampleHasTagValue(0, "predictions", "0.9");
-  await expect(confidenceEye).toBeDisabled();
+
+  // hiding the last shown attribute removes the bubble entirely
+  await confidenceEye.click();
+  await grid.assert.nthSampleHasNoTag(0, "predictions");
+
+  await labelEye.click();
+  await grid.assert.nthSampleHasTagValue(0, "predictions", "cat");
 });

--- a/e2e-pw/src/oss/specs/polyline-single-vertex.spec.ts
+++ b/e2e-pw/src/oss/specs/polyline-single-vertex.spec.ts
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ *
+ * Single-vertex polylines in Explore (FOEPD-4459):
+ *   - a lone vertex is drawn as a dot and hit-tested like a keypoint, so
+ *     hovering it opens the polyline tooltip (previously it neither rendered
+ *     nor hit),
+ *   - polyline fields offer per-attribute visibility eyes in the modal
+ *     sidebar (previously gated to detections).
+ */
+import { expect, test as base } from "src/oss/fixtures";
+import { ModalPom } from "src/oss/poms/modal";
+import { SampleCanvasType } from "src/oss/poms/modal/sample-canvas";
+import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
+import { indexToId } from "src/shared/utils";
+
+const datasetName = getUniqueDatasetNameWithPrefix("polyline-single-vertex");
+
+/** The factory's first sample id (index 0), used to deep-link the modal. */
+const id = indexToId(0);
+
+const test = base.extend<{ modal: ModalPom }>({
+  modal: async ({ page, eventUtils }, use) => {
+    await use(new ModalPom(page, eventUtils));
+  },
+});
+
+// A single-vertex polyline at the media center, where container-relative and
+// media-relative coordinates coincide regardless of letterboxing.
+test.beforeAll(async ({ datasetFactory, foWebServer }) => {
+  await foWebServer.startWebServer();
+  await datasetFactory.createDataset({
+    datasetName,
+    imageOptions: { fillColor: "white", width: 640, height: 480 },
+    schema: { polylines: "Polylines" },
+    withSampleData: (_, { createId }) => ({
+      polylines: {
+        _cls: "Polylines",
+        polylines: [
+          {
+            _id: createId(),
+            _cls: "Polyline",
+            label: "dot",
+            points: [[[0.5, 0.5]]],
+            closed: false,
+            filled: false,
+          },
+        ],
+      },
+    }),
+  });
+});
+
+test.afterAll(async ({ foWebServer }) => {
+  await foWebServer.stopWebServer();
+});
+
+test.beforeEach(async ({ fiftyoneLoader, modal, page }) => {
+  await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
+    searchParams: new URLSearchParams({ id }),
+  });
+  await modal.waitForSampleLoadDomAttribute();
+  await modal.assert.isOpen();
+  await modal.sampleCanvas.assert.is(SampleCanvasType.LOOKER);
+});
+
+test("a lone vertex renders and hovers like a keypoint", async ({ modal }) => {
+  // park the cursor away from the vertex, then hover it; the cursor gate
+  // retries until the dot's hit target answers
+  await modal.sampleCanvas.move(0.9, 0.9);
+  await modal.sampleCanvas.move(0.5, 0.5, "pointer");
+
+  await modal.sampleCanvas.tooltip.assert.isVisible();
+  await modal.sampleCanvas.tooltip.assert.hasField("polylines");
+  await modal.sampleCanvas.tooltip.assert.hasAttribute("label", "dot");
+});
+
+test("polyline attributes offer visibility eyes in the modal", async ({
+  modal,
+}) => {
+  await modal.sidebar.clickFieldDropdown("polylines");
+
+  const labelEye = modal.sidebar.locator.getByTestId(
+    "shown-attribute-polylines.polylines.label",
+  );
+  await expect(labelEye).toBeVisible();
+  await expect(labelEye).toBeEnabled();
+});

--- a/e2e-pw/src/shared/dataset-factory/index.ts
+++ b/e2e-pw/src/shared/dataset-factory/index.ts
@@ -42,7 +42,13 @@ interface Helpers {
  * The set of supported FiftyOne label field types.
  * These correspond to embedded document types in the FiftyOne data model.
  */
-type Label = "Classification" | "Classifications" | "Detection" | "Detections";
+type Label =
+  | "Classification"
+  | "Classifications"
+  | "Detection"
+  | "Detections"
+  | "Polyline"
+  | "Polylines";
 
 /**
  * All supported field types for dataset schema definitions.
@@ -80,6 +86,8 @@ const LABEL_TYPES = new Set([
   "Classifications",
   "Detection",
   "Detections",
+  "Polyline",
+  "Polylines",
 ]);
 
 /**
@@ -166,6 +174,24 @@ interface DatasetOptions {
   };
 
   /**
+   * Annotation label schemas keyed by field path. Each is applied with
+   * `dataset.update_label_schema(field, schema)` and the field is added to
+   * `dataset.active_label_schemas`, all inside the single dataset-creation
+   * subprocess — no follow-up SDK calls needed.
+   *
+   * @example
+   * labelSchemas: {
+   *   polylines: {
+   *     type: "polylines",
+   *     classes: ["lane", "curb"],
+   *     attributes: [],
+   *     component: "dropdown",
+   *   },
+   * }
+   */
+  labelSchemas?: { [field: string]: JSONObject };
+
+  /**
    * A factory function that populates a sample with data.
    * Receives an empty `SampleScaffold` and should return a `JSONObject`
    * representing the fully populated sample.
@@ -220,6 +246,7 @@ const createDataset = (() => {
       width: 50,
       height: 50,
     },
+    labelSchemas = {},
     numSamples = 1,
     numbered = false,
     savedViews = {},
@@ -331,6 +358,15 @@ const createDataset = (() => {
         ]
     )
     
+    ${
+      Object.keys(labelSchemas).length
+        ? `label_schemas = json.loads('${JSON.stringify(labelSchemas)}')
+    for field_name, label_schema in label_schemas.items():
+        dataset.update_label_schema(field_name, label_schema)
+    dataset.active_label_schemas = list(label_schemas.keys())`
+        : ""
+    }
+
     ${Object.entries(savedViews)
       .map(([name, view]) => {
         return `dataset.save_view("${name}", ${view})`;


### PR DESCRIPTION
## What changes are proposed in this pull request?

### Single-vertex polyline annotation fixes (FOEPD-4459)

1. **One-vertex polylines are now persisted immediately.** The seed vertex is added through the overlay's point API after the overlay is attached to the scene, so it dispatches `lighter:keypoint-point-added` and the engine bridge commits it exactly like any later vertex (frame-stamped on video). Previously the first vertex was baked into the overlay constructor and committed nothing — the label lived only in the sidebar draft until a second vertex landed.

2. **Deleting a one-vertex polyline now clears the canvas.** Three fixes:
   - Removing a polyline's last vertex is treated as deleting the label. The Delete/Backspace key runs the whole-label delete (with persistence and form exit) when the sub-selected vertex is the overlay's only point, and the engine bridge deletes — rather than commits — a polyline emptied on the canvas (e.g. alt-click on the last vertex), so no degenerate empty-points label is persisted and the stale overlay is unmounted.
   - The lighter `InteractionManager` no longer removes an overlay's last remaining point on Backspace — it leaves the event for the label-delete keybinding, so a geometry-less label (or, on video, a track that renders nothing) can't be left behind.
   - `Sample.deleteLabel` now announces a list-label delete even when the parent field has no resolved value, so deleting a label the sample never materialized still unmounts its canvas overlay instead of silently no-oping.

3. **The label text no longer covers a lone vertex.** A single-vertex polyline's centroid is its vertex, so the centered text box hid the point (and stole its hit target). The text is now anchored just above the point marker.

### Single-vertex polylines in Explore

Previously a one-vertex polyline drawn in Annotate simply vanished when toggling back to Explore (and in grid thumbnails):

- `looker`'s `PolylineOverlay.draw` skipped any path with fewer than 2 points; a lone vertex is now drawn as a filled dot matching `KeypointOverlay` point styling.
- Hit-testing (`containsPoint` / `getMouseDistance`) measured only against segments, so the lone vertex could never be hovered or selected; it is now hit-tested like a keypoint, with the same selected-size bump and `INFO_COLOR` inner marker on selection.
- Polylines now draw their label tag in Explore (they previously drew none), styled like `DetectionOverlay`'s tag and anchored on the shape's centroid — or lifted clear of the dot for a lone vertex — matching the Annotate placement so the label doesn't jump when toggling modes.
- `canToggleShownLabelAttributes` gains Polyline/Polylines in the modal (`BOX_HEADER_TYPES` → `MODAL_LABEL_TEXT_TYPES`), so the attribute eye toggles appear and drive polyline tag text.

### Polyline object tracks on video (FOEPD-4459)

Drawing a polyline on a video frame-level field now establishes an object track like a drawn detection does:

- The polyline creation seam dispatches `lighter:overlay-establish` for frame-level fields — nothing did before, so no first keyframe, no auto-extend, no timeline row. (The bridge's establish commit is a value-equal no-op over the vertex-seed commit, so no spurious undo entry.)
- `useSyncLighterAnnotation`'s draw-establish guard accepts `points` geometry, aligning it with `useKeyframePromotionOnEdit`, which already treats `points` as track geometry on edit.
- `useAutoInterpolate`'s tail step-hold carries a generic `held` geometry (`points`/`closed`/`filled` as well as `bounding_box`), so a multi-vertex polyline keeps its full shape on auto-extended filler frames instead of the one-vertex snapshot from draw time.

### Fully-hideable label attributes

Follow-up to #8114: the eye toggles previously locked the last shown attribute, so overlay text could never be turned off entirely. An explicitly empty selection is now stored and rendered as no overlay text — detection box headers and classification tag overlays disappear — while fields with no customization keep the `label` default.

## Attribution

The Explore-mode and video-track fixes were reconciled in from @ehofesmann's `eric/fix-single-vertex-polyline` (his commits, cherry-picked with authorship preserved); where the two changesets overlapped on the original three bugs, this PR's mechanisms were kept.

## How is this patch tested?

- Unit tests for the new `Sample.deleteLabel` notify behavior, the updated `toggleShownLabelAttribute` semantics, and the generalized auto-interpolate step-hold
- Annotation, lighter, core Annotate, state, looker, video-annotation, and utilities suites pass (912 tests across the touched packages)

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3745
<!-- enterprise-sync-pr:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Polyline annotations now support smoother creation, editing, deletion, and tracking for single-point and empty overlays.
  - Single-point polylines render as selectable dots with labels positioned clearly above their vertices.
  - Label attributes can now be hidden completely, including the final visible attribute.
  - Polyline geometry and styling are preserved when extending video annotations across frames.

- **Bug Fixes**
  - Improved list-label deletion when fields have no existing value.
  - Classification tags are hidden when no attributes are configured.
  - Corrected selection and label cleanup for single-point overlays.
  - Prevented deletion of the final point in a polyline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->