### PR TITLE
Cache compressed MCAP grid posters across tile remounts

### DIFF
--- a/app/packages/multimodal/src/testing/integration/GridRenderer.integration.test.tsx
+++ b/app/packages/multimodal/src/testing/integration/GridRenderer.integration.test.tsx
@@ -1,5 +1,6 @@
 import type { SampleRendererProps } from "@fiftyone/plugins";
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -179,8 +180,11 @@ describe("fixture adapter through the production grid renderer", () => {
       {},
       expect.objectContaining({ priority: "current" }),
     );
-    fireEvent.pointerLeave(remounted.container.firstElementChild as Element);
-    fireEvent.pointerEnter(remounted.container.firstElementChild as Element);
+    await act(async () => {
+      fireEvent.pointerLeave(remounted.container.firstElementChild as Element);
+      fireEvent.pointerEnter(remounted.container.firstElementChild as Element);
+      await Promise.resolve();
+    });
     expect(read).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/packages/multimodal/src/testing/integration/GridRenderer.integration.test.tsx
+++ b/app/packages/multimodal/src/testing/integration/GridRenderer.integration.test.tsx
@@ -1,5 +1,11 @@
 import type { SampleRendererProps } from "@fiftyone/plugins";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createFixtureFormatAdapter } from "../../adapters/fixture";
 import type {
@@ -8,6 +14,11 @@ import type {
   EpisodeSource,
 } from "../../ports";
 import { GridRenderer } from "../../views/episode";
+import {
+  getGridPosterCache,
+  gridPosterCacheKey,
+  resetGridPosterCacheForTests,
+} from "../../views/episode/grid/grid-poster-cache";
 
 const harness = vi.hoisted(() => ({
   byteSource: {
@@ -18,6 +29,7 @@ const harness = vi.hoisted(() => ({
   episodeSource: null as EpisodeSource | null,
   previewSession: null as EpisodePreviewSession | null,
   registerStreams: vi.fn(),
+  sessionEnabled: [] as boolean[],
 }));
 
 vi.mock("../../views/session/use-stable-episode-source", () => ({
@@ -28,11 +40,20 @@ vi.mock("../../views/session/use-stable-episode-source", () => ({
 }));
 
 vi.mock("../../views/session/use-episode-preview-session", () => ({
-  useEpisodePreviewSession: () => ({
-    error: null,
-    session: harness.previewSession,
-    status: "ready",
-  }),
+  useEpisodePreviewSession: (
+    _sample: unknown,
+    _source: unknown,
+    enabled: boolean,
+  ) => {
+    harness.sessionEnabled.push(enabled);
+    return enabled
+      ? {
+          error: null,
+          session: harness.previewSession,
+          status: "ready",
+        }
+      : { error: null, session: null, status: "idle" };
+  },
 }));
 
 vi.mock("../../views/episode/grid/grid-stream-state", () => ({
@@ -47,6 +68,7 @@ vi.mock("../../views/episode/grid/grid-camera-state", () => ({
 
 vi.mock("../../visualization/media-2d/BitmapImageView", () => ({
   BitmapCanvasHost: () => <div data-testid="fixture-grid-point-cloud" />,
+  BitmapImageView: () => <div data-testid="fixture-grid-cached-image" />,
   BitmapImageFrameView: () => <div data-testid="fixture-grid-image" />,
 }));
 
@@ -82,6 +104,8 @@ afterEach(() => {
   harness.episodeSource = null;
   harness.cameraSetter.mockReset();
   harness.registerStreams.mockReset();
+  harness.sessionEnabled.length = 0;
+  resetGridPosterCacheForTests();
 });
 
 describe("fixture adapter through the production grid renderer", () => {
@@ -104,6 +128,60 @@ describe("fixture adapter through the production grid renderer", () => {
       {},
       expect.objectContaining({ priority: "idle" }),
     );
+  });
+
+  it("hydrates a remounted tile without opening or reading its preview session", async () => {
+    harness.episodeSource = episodeSource;
+    harness.previewSession =
+      (await createFixtureFormatAdapter().openPreview?.(episodeSource, io)) ??
+      null;
+    if (!harness.previewSession) {
+      throw new Error("Fixture preview session did not open");
+    }
+    const read = vi.spyOn(harness.previewSession, "read");
+    resetGridPosterCacheForTests({ maxSizeBytes: 10_000 });
+    const key = gridPosterCacheKey({
+      datasetId: "fixture-dataset",
+      mediaField: "recording",
+      selectedSourceName: null,
+      source: harness.byteSource,
+    });
+    getGridPosterCache().put(key, {
+      bytes: new Uint8Array([1, 2, 3]),
+      height: 100,
+      mimeType: "image/webp",
+      sourceKind: "image",
+      streamId: "fixture-camera",
+      streamSourceName: "/fixture/camera",
+      streamSourceNames: ["/fixture/camera"],
+      width: 100,
+    });
+
+    const first = render(<GridRenderer ctx={rendererContext()} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("fixture-grid-cached-image")).toBeTruthy();
+    });
+    first.unmount();
+    const remounted = render(<GridRenderer ctx={rendererContext()} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("fixture-grid-cached-image")).toBeTruthy();
+    });
+
+    expect(read).not.toHaveBeenCalled();
+    expect(harness.sessionEnabled.every((enabled) => enabled === false)).toBe(
+      true,
+    );
+    expect(getGridPosterCache().stats().hits).toBe(2);
+
+    fireEvent.pointerEnter(remounted.container.firstElementChild as Element);
+    await waitFor(() => expect(read).toHaveBeenCalledTimes(1));
+    expect(read).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({ priority: "current" }),
+    );
+    fireEvent.pointerLeave(remounted.container.firstElementChild as Element);
+    fireEvent.pointerEnter(remounted.container.firstElementChild as Element);
+    expect(read).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/app/packages/multimodal/src/views/episode/grid/GridRenderer.test.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/GridRenderer.test.tsx
@@ -304,6 +304,7 @@ describe("GridRenderer", () => {
     expect(root.classList.contains(classes.modalActivationSurface)).toBe(false);
     fireEvent.click(root);
     expect(parentClick).not.toHaveBeenCalled();
+    expect(posterCaptureHarness.capture).not.toHaveBeenCalled();
   });
 
   it("explains when the recording cannot be found", () => {

--- a/app/packages/multimodal/src/views/episode/grid/GridRenderer.test.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/GridRenderer.test.tsx
@@ -20,7 +20,11 @@ import {
   gridLiveLeaseStats,
   resetGridLiveLeasesForTests,
 } from "../../../visualization/webgpu/webgpu-live-lease";
-import type { EpisodePosterFrame } from "../../../ir";
+import type { ByteSourceDescriptor, EpisodePosterFrame } from "../../../ir";
+import {
+  pointCloudPoseKey,
+  type GridPosterCacheEntry,
+} from "./grid-poster-cache";
 import {
   GridRenderer,
   HOVER_INTENT_DELAY_MS,
@@ -49,6 +53,7 @@ function renderWithMatches(ui: ReactElement, byEpisode: PublishedWindows) {
 
 const previewHarness = vi.hoisted(() => ({
   preview: {
+    cachedPoster: null as GridPosterCacheEntry | null,
     error: null as string | null,
     frame: null as EpisodePosterFrame | null,
     hasPreviewStreams: false,
@@ -56,6 +61,7 @@ const previewHarness = vi.hoisted(() => ({
     pause: vi.fn(),
     play: vi.fn(),
     streamId: null as string | null,
+    streamSourceName: null as string | null,
     streamSourceNames: [] as readonly string[],
     status: "idle",
   },
@@ -71,6 +77,20 @@ const bitmapViewHarness = vi.hoisted(() => ({
 
 const bitmapHostHarness = vi.hoisted(() => ({
   lastBitmap: null as ImageBitmap | null,
+  onCanvasCommitted: null as
+    | ((
+        canvas: HTMLCanvasElement,
+        size: { readonly height: number; readonly width: number },
+      ) => void)
+    | null,
+}));
+
+const posterCaptureHarness = vi.hoisted(() => ({
+  capture: vi.fn(),
+}));
+
+const sourceHarness = vi.hoisted(() => ({
+  byteSource: null as ByteSourceDescriptor | null,
 }));
 
 interface SnapshotRequest {
@@ -104,9 +124,13 @@ function getGridRendererRoot(container: HTMLElement): HTMLElement {
 
 vi.mock("../../session/use-stable-episode-source", () => ({
   useStableEpisodeSource: vi.fn(() => ({
-    byteSource: null,
+    byteSource: sourceHarness.byteSource,
     episodeSource: null,
   })),
+}));
+
+vi.mock("./grid-poster-codec", () => ({
+  captureGridPoster: posterCaptureHarness.capture,
 }));
 
 vi.mock("../../session/use-episode-preview-session", () => ({
@@ -146,14 +170,33 @@ vi.mock("./grid-stream-state", () => ({
 vi.mock("../../../visualization/media-2d/BitmapImageView", async () => {
   const { useEffect } = await import("react");
   return {
-    BitmapCanvasHost: ({ bitmap }: { readonly bitmap: ImageBitmap | null }) => {
+    BitmapCanvasHost: ({
+      bitmap,
+      onCanvasCommitted,
+    }: {
+      readonly bitmap: ImageBitmap | null;
+      readonly onCanvasCommitted?: (
+        canvas: HTMLCanvasElement,
+        size: { readonly height: number; readonly width: number },
+      ) => void;
+    }) => {
       bitmapHostHarness.lastBitmap = bitmap;
+      bitmapHostHarness.onCanvasCommitted = onCanvasCommitted ?? null;
       return (
         <div
           data-committed={bitmap ? "true" : "false"}
           data-testid="bitmap-canvas-host"
         />
       );
+    },
+    BitmapImageView: (props: {
+      readonly onBitmapRetainedBytesChange?: (retainedBytes: number) => void;
+    }) => {
+      const { onBitmapRetainedBytesChange } = props;
+      useEffect(() => {
+        onBitmapRetainedBytesChange?.(320 * 180 * 4);
+      }, [onBitmapRetainedBytesChange]);
+      return <div data-testid="bitmap-cached-image-view" />;
     },
     BitmapImageFrameView: (props: {
       readonly fit?: string;
@@ -189,18 +232,23 @@ afterEach(() => {
   resetGridLiveLeasesForTests();
   resetWebGpuDeviceRegistryForTests();
   bitmapHostHarness.lastBitmap = null;
+  bitmapHostHarness.onCanvasCommitted = null;
   bitmapViewHarness.lastProps = null;
   cameraPoseHarness.pose = null;
   previewHarness.preview.error = null;
+  previewHarness.preview.cachedPoster = null;
   previewHarness.preview.frame = null;
   previewHarness.preview.hasPreviewStreams = false;
   previewHarness.preview.isBuffering = false;
   previewHarness.preview.status = "idle";
   previewHarness.preview.streamId = null;
+  previewHarness.preview.streamSourceName = null;
   previewHarness.preview.streamSourceNames = [];
   previewHarness.preview.pause.mockClear();
   previewHarness.preview.play.mockClear();
   snapshotHarness.requests.length = 0;
+  posterCaptureHarness.capture.mockReset();
+  sourceHarness.byteSource = null;
 });
 
 describe("GridRenderer", () => {
@@ -229,6 +277,33 @@ describe("GridRenderer", () => {
       posterStartTimeNs: null,
       posterSourceName: null,
     });
+  });
+
+  it("renders a cached point-cloud poster with point-cloud activation semantics", () => {
+    previewHarness.preview.cachedPoster = {
+      bytes: new Uint8Array([1, 2, 3]),
+      height: 180,
+      mimeType: "image/webp",
+      pointCloudPoseKey: "pose",
+      sourceKind: "point-cloud",
+      streamId: "point-cloud",
+      streamSourceName: "/lidar",
+      streamSourceNames: ["/lidar"],
+      width: 320,
+    };
+    previewHarness.preview.status = "ready";
+    const parentClick = vi.fn();
+    const { container } = render(
+      <div onClick={parentClick}>
+        <GridRenderer ctx={rendererCtx()} />
+      </div>,
+    );
+
+    expect(screen.getByTestId("bitmap-cached-image-view")).toBeTruthy();
+    const root = getGridRendererRoot(container);
+    expect(root.classList.contains(classes.modalActivationSurface)).toBe(false);
+    fireEvent.click(root);
+    expect(parentClick).not.toHaveBeenCalled();
   });
 
   it("explains when the recording cannot be found", () => {
@@ -438,6 +513,45 @@ describe("GridRenderer", () => {
     expect(
       screen.getByTestId("bitmap-canvas-host").getAttribute("data-committed"),
     ).toBe("true");
+  });
+
+  it("tags a point-cloud poster with the pose that rendered its snapshot", async () => {
+    const renderedPose = {
+      position: [1, 2, 3] as [number, number, number],
+      target: [0, 0, 0] as [number, number, number],
+    };
+    const laterPose = {
+      position: [4, 5, 6] as [number, number, number],
+      target: [0, 0, 0] as [number, number, number],
+    };
+    sourceHarness.byteSource = {
+      sourceId: "pose-provenance",
+      url: "memory://pose-provenance",
+    };
+    cameraPoseHarness.pose = renderedPose;
+    previewHarness.preview.frame = pointCloudFrame();
+    previewHarness.preview.status = "ready";
+
+    const { rerender } = render(<GridRenderer ctx={rendererCtx()} />);
+    expect(snapshotHarness.requests[0]?.job.cameraPose).toBe(renderedPose);
+    await act(async () => {
+      snapshotHarness.requests[0]?.resolve(fakeSnapshotBitmap());
+    });
+
+    cameraPoseHarness.pose = laterPose;
+    rerender(<GridRenderer ctx={rendererCtx()} />);
+    bitmapHostHarness.onCanvasCommitted?.(document.createElement("canvas"), {
+      height: 180,
+      width: 320,
+    });
+
+    expect(posterCaptureHarness.capture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entry: expect.objectContaining({
+          pointCloudPoseKey: pointCloudPoseKey(renderedPose),
+        }),
+      }),
+    );
   });
 
   it("never goes live when the hover ends before the intent delay", () => {

--- a/app/packages/multimodal/src/views/episode/grid/GridRenderer.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/GridRenderer.tsx
@@ -122,11 +122,17 @@ export function GridRenderer({
   }>({ entry: null, key: null });
   if (cachedPosterRef.current.key !== cacheKey) {
     cachedPosterRef.current = {
-      entry: cacheKey ? getGridPosterCache().get(cacheKey) : null,
+      entry: cacheKey ? getGridPosterCache().peek(cacheKey) : null,
       key: cacheKey,
     };
   }
   const cachedPoster = cachedPosterRef.current.entry;
+  const recordedCacheLookupKeyRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!cacheKey || recordedCacheLookupKeyRef.current === cacheKey) return;
+    recordedCacheLookupKeyRef.current = cacheKey;
+    recordGridPosterDiagnostic(cachedPoster ? "hits" : "misses");
+  }, [cacheKey, cachedPoster]);
   const [cameraPose, setCameraPose] = useGridCameraPose(
     gridCameraScopeKey,
     visible,

--- a/app/packages/multimodal/src/views/episode/grid/GridRenderer.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/GridRenderer.tsx
@@ -10,7 +10,9 @@ import {
 } from "react";
 import {
   BitmapCanvasHost,
+  BitmapImageView,
   BitmapImageFrameView,
+  type BitmapDrawSize,
 } from "../../../visualization/media-2d/BitmapImageView";
 import type { EpisodePosterFrame, EpisodePreviewReadResult } from "../../../ir";
 import { retainedBinaryBytes } from "../../../runtime";
@@ -35,6 +37,17 @@ import { useGridCameraPose } from "./grid-camera-state";
 import { cameraScopeKey } from "../shell/camera-scope";
 import { useSampleRendererFirstMatch } from "../../../extensions/timeline";
 import { useGridPreview, type GridPreviewStatus } from "./use-grid-preview";
+import {
+  getGridPosterCache,
+  gridPosterCacheKey,
+  gridPosterFreshness,
+  pointCloudPoseKey,
+  recordGridPosterDiagnostic,
+  type GridPosterCacheEntry,
+  type GridPosterFreshness,
+} from "./grid-poster-cache";
+import { captureGridPoster } from "./grid-poster-codec";
+import type { PointCloudCameraPose } from "../../../visualization/scene-3d";
 
 const IMAGE_FIT = "cover";
 // Trailing debounce for shared-pose and cell-resize re-snapshots: orbiting
@@ -76,17 +89,73 @@ export function GridRenderer({
     return sample._id ?? sample.id;
   }, [ctx.sample.sample]);
   const [selectedStream] = useGridSelectedStream(ctx.dataset.name);
+  const selectedSourceName =
+    selectedStream === GRID_STREAM_AUTO ? null : selectedStream;
+  // A lasso/search in the embeddings panel posters this tile at its earliest
+  // matched window, so both the requested time and preferred stream belong to
+  // the poster cache identity.
+  const firstMatch = useSampleRendererFirstMatch(ctx);
+  const cacheKey = useMemo(
+    () =>
+      source
+        ? gridPosterCacheKey({
+            datasetId: ctx.dataset.datasetId,
+            mediaField: ctx.media?.field,
+            posterSourceName: firstMatch?.stream,
+            posterStartTimeNs: firstMatch?.startNs,
+            selectedSourceName,
+            source,
+          })
+        : null,
+    [
+      ctx.dataset.datasetId,
+      ctx.media?.field,
+      firstMatch?.startNs,
+      firstMatch?.stream,
+      selectedSourceName,
+      source,
+    ],
+  );
+  const cachedPosterRef = useRef<{
+    readonly entry: GridPosterCacheEntry | null;
+    readonly key: string | null;
+  }>({ entry: null, key: null });
+  if (cachedPosterRef.current.key !== cacheKey) {
+    cachedPosterRef.current = {
+      entry: cacheKey ? getGridPosterCache().get(cacheKey) : null,
+      key: cacheKey,
+    };
+  }
+  const cachedPoster = cachedPosterRef.current.entry;
+  const [cameraPose, setCameraPose] = useGridCameraPose(
+    gridCameraScopeKey,
+    visible,
+  );
+  const rootSize = useElementCssSize(rootElement);
+  const poseKey = pointCloudPoseKey(cameraPose);
+  const freshness = useMemo<GridPosterFreshness | null>(
+    () =>
+      cachedPoster && rootSize
+        ? gridPosterFreshness(cachedPoster, rootSize, poseKey)
+        : null,
+    [cachedPoster, poseKey, rootSize],
+  );
+  const previewSessionDemand = usePreviewSessionDemand({
+    cacheKey,
+    cachedPoster,
+    freshness,
+    hovered,
+    visible,
+  });
   const gridVideoPlayback = useGridVideoPlayback(source?.sourceId ?? null);
   const previewSession = useEpisodePreviewSession(
     sampleDescriptorFromContext(ctx),
     episodeSource,
-    visible,
+    previewSessionDemand,
   );
-  // A lasso/search in the embeddings panel posters this tile at its earliest
-  // matched window, so the still frame is the match rather than the recording
-  // start. Null whenever nothing matched this episode.
-  const firstMatch = useSampleRendererFirstMatch(ctx);
   const preview = useGridPreview({
+    cacheRequestKey: cacheKey,
+    cachedPoster,
     enabled: visible,
     hovered,
     onReadResult: gridVideoPlayback.onReadResult,
@@ -95,13 +164,13 @@ export function GridRenderer({
     previewSession: previewSession.session,
     previewSessionError: previewSession.error,
     previewSessionStatus: previewSession.status,
-    selectedSourceName:
-      selectedStream === GRID_STREAM_AUTO ? null : selectedStream,
+    selectedSourceName,
     source,
   });
   const registerStreams = useRegisterGridStreams();
   const stableStreams = useStableGridStreams(preview.streamSourceNames);
-  const blocksGridActivation = preview.frame?.kind === "point-cloud";
+  const sourceKind = preview.frame?.kind ?? preview.cachedPoster?.sourceKind;
+  const blocksGridActivation = sourceKind === "point-cloud";
   const gridActivationHandler = blocksGridActivation
     ? stopGridActivationPropagation
     : undefined;
@@ -116,22 +185,70 @@ export function GridRenderer({
   );
   const [surfaceRetention, setSurfaceRetention] = useState<{
     readonly bytes: number;
-    readonly frame: EpisodePosterFrame;
+    readonly owner: EpisodePosterFrame | GridPosterCacheEntry;
   } | null>(null);
+  const displayOwner = preview.frame ?? preview.cachedPoster;
   const surfaceRetainedBytes =
-    surfaceRetention?.frame === preview.frame ? surfaceRetention.bytes : 0;
+    surfaceRetention && surfaceRetention.owner === displayOwner
+      ? surfaceRetention.bytes
+      : 0;
   const handleSurfaceRetainedBytesChange = useCallback(
     (bytes: number) => {
-      const frame = preview.frame;
-      if (frame) {
+      const owner = displayOwner;
+      if (owner) {
         setSurfaceRetention((current) =>
-          current?.frame === frame && current.bytes === bytes
+          current?.owner === owner && current.bytes === bytes
             ? current
-            : { bytes, frame },
+            : { bytes, owner },
         );
       }
     },
-    [preview.frame],
+    [displayOwner],
+  );
+  const capturedTokensRef = useRef(new Set<string>());
+  useEffect(() => {
+    capturedTokensRef.current.clear();
+  }, [cacheKey]);
+  const handlePosterCanvasCommitted = useCallback(
+    (
+      sourceKind: "image" | "point-cloud",
+      canvas: HTMLCanvasElement,
+      size: BitmapDrawSize,
+      snapshotPoseKey?: string,
+    ) => {
+      if (!cacheKey) return;
+      const capturePoseKey =
+        sourceKind === "point-cloud" ? snapshotPoseKey : undefined;
+      if (sourceKind === "point-cloud" && !capturePoseKey) return;
+      const token = JSON.stringify([
+        sourceKind,
+        capturePoseKey ?? null,
+        size.width,
+        size.height,
+      ]);
+      if (capturedTokensRef.current.has(token)) return;
+      capturedTokensRef.current.add(token);
+      captureGridPoster({
+        entry: {
+          height: size.height,
+          mimeType: "image/webp",
+          ...(capturePoseKey ? { pointCloudPoseKey: capturePoseKey } : {}),
+          sourceKind,
+          streamId: preview.streamId,
+          streamSourceName: preview.streamSourceName,
+          streamSourceNames: preview.streamSourceNames,
+          width: size.width,
+        },
+        key: cacheKey,
+        source: canvas,
+      });
+    },
+    [
+      cacheKey,
+      preview.streamId,
+      preview.streamSourceName,
+      preview.streamSourceNames,
+    ],
   );
 
   // This effect keeps the grid cache's retained-byte estimate current.
@@ -166,12 +283,24 @@ export function GridRenderer({
             // dimensions when the source or selected stream changes.
             key={`${source?.sourceId ?? ""}:${preview.streamId ?? ""}`}
             active={visible}
-            cameraScopeKey={gridCameraScopeKey}
+            cachedPoster={preview.cachedPoster}
+            cameraPose={cameraPose}
             frame={preview.frame}
+            hovered={hovered}
+            onCameraPoseChange={setCameraPose}
+            onCanvasCommitted={handlePosterCanvasCommitted}
             onSurfaceRetainedBytesChange={handleSurfaceRetainedBytesChange}
             videoStream={preview.streamId}
           />
         </VideoPlaybackManagerProvider>
+      ) : preview.cachedPoster ? (
+        <BitmapImageView
+          bytes={preview.cachedPoster.bytes}
+          className={classes.imagePanel}
+          fit={IMAGE_FIT}
+          mimeType={preview.cachedPoster.mimeType}
+          onBitmapRetainedBytesChange={handleSurfaceRetainedBytesChange}
+        />
       ) : (
         <PreviewStatus
           error={preview.error}
@@ -301,6 +430,85 @@ function useGridRendererVisibility(
   return gridActive && intersecting;
 }
 
+function useElementCssSize(
+  element: HTMLDivElement | null,
+): BitmapDrawSize | null {
+  const [size, setSize] = useState<BitmapDrawSize | null>(null);
+  useEffect(() => {
+    if (!element) {
+      setSize(null);
+      return undefined;
+    }
+    const update = () => {
+      const rect = element.getBoundingClientRect();
+      const next = {
+        height: Math.max(1, Math.round(rect.height)),
+        width: Math.max(1, Math.round(rect.width)),
+      };
+      setSize((current) =>
+        current?.height === next.height && current.width === next.width
+          ? current
+          : next,
+      );
+    };
+    update();
+    if (typeof ResizeObserver === "undefined") return undefined;
+    const observer = new ResizeObserver(update);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [element]);
+  return size;
+}
+
+function usePreviewSessionDemand({
+  cacheKey,
+  cachedPoster,
+  freshness,
+  hovered,
+  visible,
+}: {
+  readonly cacheKey: string | null;
+  readonly cachedPoster: GridPosterCacheEntry | null;
+  readonly freshness: GridPosterFreshness | null;
+  readonly hovered: boolean;
+  readonly visible: boolean;
+}): boolean {
+  const [latched, setLatched] = useState(false);
+  const diagnosticRef = useRef<string | null>(null);
+  useEffect(() => {
+    setLatched(false);
+    diagnosticRef.current = null;
+  }, [cacheKey, visible]);
+  useEffect(() => {
+    if (visible && hovered && cachedPoster) {
+      setLatched(true);
+      recordGridPosterDiagnostic("sourceRefreshesHover");
+    }
+  }, [cachedPoster, hovered, visible]);
+  useEffect(() => {
+    if (!visible || !cachedPoster || !freshness) return;
+    const diagnosticKey = `${cacheKey}:${freshness}`;
+    if (diagnosticRef.current === diagnosticKey) return;
+    diagnosticRef.current = diagnosticKey;
+    if (freshness === "fresh") {
+      recordGridPosterDiagnostic("staticHitsAvoidedSessionOpen");
+    } else {
+      recordGridPosterDiagnostic("staleHits");
+      recordGridPosterDiagnostic(
+        freshness === "stale-pose"
+          ? "sourceRefreshesPose"
+          : "sourceRefreshesSize",
+      );
+    }
+  }, [cacheKey, cachedPoster, freshness, visible]);
+
+  if (!visible) return false;
+  if (!cachedPoster) return true;
+  if (latched || hovered) return true;
+  if (freshness === null) return false;
+  return freshness !== "fresh";
+}
+
 function usePlaybackHoverIntent(
   pause: () => void,
   play: () => void,
@@ -368,27 +576,45 @@ function useStableGridStreams(streams: readonly string[]) {
 
 function PreviewFrame({
   active,
-  cameraScopeKey,
+  cachedPoster,
+  cameraPose,
   frame,
+  hovered,
+  onCameraPoseChange,
+  onCanvasCommitted,
   onSurfaceRetainedBytesChange,
   videoStream,
 }: {
   readonly active: boolean;
-  readonly cameraScopeKey: string;
+  readonly cachedPoster: GridPosterCacheEntry | null;
+  readonly cameraPose: PointCloudCameraPose | null;
   readonly frame: EpisodePosterFrame;
+  readonly hovered: boolean;
+  readonly onCameraPoseChange: (pose: PointCloudCameraPose | null) => void;
+  readonly onCanvasCommitted: (
+    sourceKind: "image" | "point-cloud",
+    canvas: HTMLCanvasElement,
+    size: BitmapDrawSize,
+    snapshotPoseKey?: string,
+  ) => void;
   readonly onSurfaceRetainedBytesChange: (bytes: number) => void;
   readonly videoStream: string | null;
 }) {
   return frame.kind === "point-cloud" ? (
     <PointCloudPreviewFrame
       active={active}
-      cameraScopeKey={cameraScopeKey}
+      cachedPoster={cachedPoster}
+      cameraPose={cameraPose}
       frame={frame}
+      hovered={hovered}
+      onCameraPoseChange={onCameraPoseChange}
+      onCanvasCommitted={onCanvasCommitted}
       onSurfaceRetainedBytesChange={onSurfaceRetainedBytesChange}
     />
   ) : (
     <ImagePreviewFrame
       frame={frame}
+      onCanvasCommitted={onCanvasCommitted}
       onSurfaceRetainedBytesChange={onSurfaceRetainedBytesChange}
       videoStream={videoStream}
     />
@@ -403,18 +629,30 @@ function PreviewFrame({
  */
 function PointCloudPreviewFrame({
   active,
-  cameraScopeKey,
+  cachedPoster,
+  cameraPose,
   frame,
+  hovered,
+  onCameraPoseChange,
+  onCanvasCommitted,
   onSurfaceRetainedBytesChange,
 }: {
   readonly active: boolean;
-  readonly cameraScopeKey: string;
+  readonly cachedPoster: GridPosterCacheEntry | null;
+  readonly cameraPose: PointCloudCameraPose | null;
   readonly frame: Extract<EpisodePosterFrame, { kind: "point-cloud" }>;
+  readonly hovered: boolean;
+  readonly onCameraPoseChange: (pose: PointCloudCameraPose | null) => void;
+  readonly onCanvasCommitted: (
+    sourceKind: "image" | "point-cloud",
+    canvas: HTMLCanvasElement,
+    size: BitmapDrawSize,
+    snapshotPoseKey?: string,
+  ) => void;
   readonly onSurfaceRetainedBytesChange: (bytes: number) => void;
 }) {
   // Only active/visible cells subscribe to the shared pose. Hidden cached
   // roots keep their last bitmap and catch up lazily when reattached.
-  const [cameraPose, setCameraPose] = useGridCameraPose(cameraScopeKey, active);
   // Two-step live gate: `wantsLive` flips once the pointer has dwelled
   // past the intent delay; `live` flips only once the lease pool grants
   // this cell one of its capped live-renderer slots.
@@ -424,7 +662,10 @@ function PointCloudPreviewFrame({
   // StrictMode's double-invoked effects.
   const holderId = useId();
   const intentTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const [snapshot, setSnapshot] = useState<ImageBitmap | null>(null);
+  const [snapshot, setSnapshot] = useState<{
+    readonly bitmap: ImageBitmap;
+    readonly poseKey: string;
+  } | null>(null);
   const rootRef = useRef<HTMLDivElement | null>(null);
   const inFlightRef = useRef<AbortController | null>(null);
   const layers = useMemo(
@@ -458,8 +699,10 @@ function PointCloudPreviewFrame({
     // of rescaling. A null pose auto-fits exactly like the live panel, so
     // hover swaps don't jump.
     const rect = root.getBoundingClientRect();
+    const snapshotPose = cameraPoseRef.current;
+    const snapshotPoseKey = pointCloudPoseKey(snapshotPose);
     void renderPointCloudSnapshot({
-      cameraPose: cameraPoseRef.current,
+      cameraPose: snapshotPose,
       height: rect.height,
       layers: layersRef.current,
       signal: controller.signal,
@@ -476,7 +719,7 @@ function PointCloudPreviewFrame({
       }
 
       // The host adopts the bitmap and closes the one it replaces.
-      setSnapshot(bitmap);
+      setSnapshot({ bitmap, poseKey: snapshotPoseKey });
       onSurfaceRetainedBytesChange(bitmap.width * bitmap.height * 4);
     });
   }, [onSurfaceRetainedBytesChange]);
@@ -487,6 +730,22 @@ function PointCloudPreviewFrame({
       intentTimerRef.current = null;
     }
   }, []);
+
+  // A cached point-cloud poster can receive hover before the real frame
+  // arrives. Derive live intent from the parent hover state so mounting the
+  // point-cloud surface under an already-stationary pointer still upgrades.
+  useEffect(() => {
+    cancelHoverIntent();
+    if (!active || !hovered) {
+      setWantsLive(false);
+      return undefined;
+    }
+    intentTimerRef.current = setTimeout(() => {
+      intentTimerRef.current = null;
+      setWantsLive(true);
+    }, HOVER_INTENT_DELAY_MS);
+    return cancelHoverIntent;
+  }, [active, cancelHoverIntent, hovered]);
 
   // This effect holds this cell's live-renderer lease while the hover
   // intent stands: acquire on wants-live, release in the cleanup
@@ -623,33 +882,26 @@ function PointCloudPreviewFrame({
     : `${classes.imagePanel} ${classes.pointCloud}`;
 
   return (
-    <div
-      className={pointCloudClassName}
-      onPointerEnter={() => {
-        // Arm the hover-intent timer; only a dwell past the delay asks
-        // the pool for a live-renderer lease.
-        cancelHoverIntent();
-        if (!active) {
-          return;
-        }
-        intentTimerRef.current = setTimeout(() => {
-          intentTimerRef.current = null;
-          setWantsLive(true);
-        }, HOVER_INTENT_DELAY_MS);
-      }}
-      onPointerLeave={() => {
-        // Back to rest: a pending intent is simply cancelled; if the cell
-        // went live, dropping wantsLive releases the lease and unmounts
-        // the panel (the lease effect's cleanup), and the snapshot is
-        // refreshed at the pose the user left the shared camera in.
-        cancelHoverIntent();
-        setWantsLive(false);
-      }}
-      ref={rootRef}
-    >
+    <div className={pointCloudClassName} ref={rootRef}>
       {/* The snapshot host stays mounted UNDERNEATH the live panel while
           hovered so unhovering never flashes an empty cell. */}
-      <BitmapCanvasHost bitmap={snapshot} fit={IMAGE_FIT} />
+      {!snapshot && cachedPoster ? (
+        <BitmapImageView
+          bytes={cachedPoster.bytes}
+          className={classes.imagePanel}
+          fit={IMAGE_FIT}
+          mimeType={cachedPoster.mimeType}
+          onBitmapRetainedBytesChange={onSurfaceRetainedBytesChange}
+        />
+      ) : null}
+      <BitmapCanvasHost
+        bitmap={snapshot?.bitmap ?? null}
+        className={classes.imagePanel}
+        fit={IMAGE_FIT}
+        onCanvasCommitted={(canvas, size) =>
+          onCanvasCommitted("point-cloud", canvas, size, snapshot?.poseKey)
+        }
+      />
       {live ? (
         // Hover comes alive — but only with one of the pool's capped
         // live-renderer leases; denied/stolen cells stay on the snapshot.
@@ -658,7 +910,7 @@ function PointCloudPreviewFrame({
           canvasSurface="grid-preview"
           className={classes.imagePanel}
           layers={layers}
-          onCameraPoseChange={setCameraPose}
+          onCameraPoseChange={onCameraPoseChange}
           showControls={false}
           showGizmo={false}
           showHud={false}
@@ -674,10 +926,16 @@ function PointCloudPreviewFrame({
 
 function ImagePreviewFrame({
   frame,
+  onCanvasCommitted,
   onSurfaceRetainedBytesChange,
   videoStream,
 }: {
   readonly frame: Extract<EpisodePosterFrame, { kind: "image" }>;
+  readonly onCanvasCommitted: (
+    sourceKind: "image" | "point-cloud",
+    canvas: HTMLCanvasElement,
+    size: BitmapDrawSize,
+  ) => void;
   readonly onSurfaceRetainedBytesChange: (bytes: number) => void;
   readonly videoStream: string | null;
 }) {
@@ -688,6 +946,9 @@ function ImagePreviewFrame({
       className={classes.imagePanel}
       fit={IMAGE_FIT}
       frame={frame.image}
+      onCanvasCommitted={(canvas, size) =>
+        onCanvasCommitted("image", canvas, size)
+      }
       onBitmapRetainedBytesChange={onSurfaceRetainedBytesChange}
       videoSessionKey={videoStream ?? undefined}
     />

--- a/app/packages/multimodal/src/views/episode/grid/GridRenderer.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/GridRenderer.tsx
@@ -189,8 +189,12 @@ export function GridRenderer({
     visible,
     setHovered,
   );
-  const gridPosterDiagnostics = import.meta.env.DEV
-    ? JSON.stringify(getGridPosterCache().stats())
+  const gridPosterDisplay = import.meta.env.DEV
+    ? preview.cachedPoster && !preview.frame
+      ? "cache"
+      : preview.frame
+        ? "source"
+        : "empty"
     : undefined;
   const [surfaceRetention, setSurfaceRetention] = useState<{
     readonly bytes: number;
@@ -279,14 +283,7 @@ export function GridRenderer({
   return (
     <div
       className={rootClassName}
-      data-grid-poster-cache-stats={gridPosterDiagnostics}
-      data-grid-poster-display={
-        preview.cachedPoster && !preview.frame
-          ? "cache"
-          : preview.frame
-            ? "source"
-            : "empty"
-      }
+      data-grid-poster-display={gridPosterDisplay}
       onClick={gridActivationHandler}
       onContextMenu={gridActivationHandler}
       onPointerEnter={playbackIntent.enter}

--- a/app/packages/multimodal/src/views/episode/grid/GridRenderer.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/GridRenderer.tsx
@@ -131,6 +131,7 @@ export function GridRenderer({
   useEffect(() => {
     if (!cacheKey || recordedCacheLookupKeyRef.current === cacheKey) return;
     recordedCacheLookupKeyRef.current = cacheKey;
+    if (cachedPoster) getGridPosterCache().touch(cacheKey);
     recordGridPosterDiagnostic(cachedPoster ? "hits" : "misses");
   }, [cacheKey, cachedPoster]);
   const [cameraPose, setCameraPose] = useGridCameraPose(
@@ -224,17 +225,17 @@ export function GridRenderer({
   }, [cacheKey]);
   const handlePosterCanvasCommitted = useCallback(
     (
-      sourceKind: "image" | "point-cloud",
+      capturedSourceKind: "image" | "point-cloud",
       canvas: HTMLCanvasElement,
       size: BitmapDrawSize,
       snapshotPoseKey?: string,
     ) => {
       if (!cacheKey) return;
       const capturePoseKey =
-        sourceKind === "point-cloud" ? snapshotPoseKey : undefined;
-      if (sourceKind === "point-cloud" && !capturePoseKey) return;
+        capturedSourceKind === "point-cloud" ? snapshotPoseKey : undefined;
+      if (capturedSourceKind === "point-cloud" && !capturePoseKey) return;
       const token = JSON.stringify([
-        sourceKind,
+        capturedSourceKind,
         capturePoseKey ?? null,
         size.width,
         size.height,
@@ -246,7 +247,7 @@ export function GridRenderer({
           height: size.height,
           mimeType: "image/webp",
           ...(capturePoseKey ? { pointCloudPoseKey: capturePoseKey } : {}),
-          sourceKind,
+          sourceKind: capturedSourceKind,
           streamId: preview.streamId,
           streamSourceName: preview.streamSourceName,
           streamSourceNames: preview.streamSourceNames,

--- a/app/packages/multimodal/src/views/episode/grid/GridRenderer.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/GridRenderer.tsx
@@ -183,6 +183,9 @@ export function GridRenderer({
     visible,
     setHovered,
   );
+  const gridPosterDiagnostics = import.meta.env.DEV
+    ? JSON.stringify(getGridPosterCache().stats())
+    : undefined;
   const [surfaceRetention, setSurfaceRetention] = useState<{
     readonly bytes: number;
     readonly owner: EpisodePosterFrame | GridPosterCacheEntry;
@@ -270,6 +273,14 @@ export function GridRenderer({
   return (
     <div
       className={rootClassName}
+      data-grid-poster-cache-stats={gridPosterDiagnostics}
+      data-grid-poster-display={
+        preview.cachedPoster && !preview.frame
+          ? "cache"
+          : preview.frame
+            ? "source"
+            : "empty"
+      }
       onClick={gridActivationHandler}
       onContextMenu={gridActivationHandler}
       onPointerEnter={playbackIntent.enter}

--- a/app/packages/multimodal/src/views/episode/grid/grid-poster-cache.test.ts
+++ b/app/packages/multimodal/src/views/episode/grid/grid-poster-cache.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { ByteSourceDescriptor } from "../../../ir";
+import {
+  createGridPosterCache,
+  defaultGridPosterCacheBudgetBytes,
+  gridPosterCacheKey,
+  gridPosterFreshness,
+  pointCloudPoseKey,
+  shouldReplaceGridPoster,
+  type GridPosterCacheEntry,
+} from "./grid-poster-cache";
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("grid poster cache", () => {
+  it("promotes hits and evicts by exact compressed byte accounting", () => {
+    const cache = createGridPosterCache({ maxSizeBytes: 256 * 3 + 5 });
+    cache.put("a", entry([1, 2]));
+    cache.put("b", entry([3, 4]));
+    expect(cache.get("a")?.bytes[0]).toBe(1);
+    cache.put("c", entry([5, 6]));
+
+    expect(cache.peek("a")).not.toBeNull();
+    expect(cache.peek("b")).toBeNull();
+    expect(cache.peek("c")).not.toBeNull();
+    expect(cache.stats()).toMatchObject({
+      entryCount: 2,
+      evictions: 1,
+      hits: 1,
+      retainedBytes: 516,
+    });
+  });
+
+  it("replaces entries, rejects oversize values, and enforces the entry cap", () => {
+    const cache = createGridPosterCache({ maxEntries: 2, maxSizeBytes: 1_000 });
+    expect(cache.put("too-big", entry(new Array(745).fill(1)))).toBe(false);
+    cache.put("a", entry([1]));
+    cache.put("a", entry([2, 3]));
+    cache.put("b", entry([4]));
+    cache.put("c", entry([5]));
+
+    expect(cache.peek("a")).toBeNull();
+    expect(cache.stats()).toMatchObject({
+      entryCount: 2,
+      oversizeRejections: 1,
+      puts: 4,
+      replacements: 1,
+    });
+  });
+
+  it("copies admitted bytes and stream metadata", () => {
+    const bytes = new Uint8Array([1, 2]);
+    const streams = ["/camera"];
+    const cache = createGridPosterCache({ maxSizeBytes: 1_000 });
+    cache.put("copy", { ...entry(bytes), streamSourceNames: streams });
+    bytes[0] = 9;
+    streams[0] = "/changed";
+
+    expect(cache.get("copy")).toMatchObject({
+      bytes: new Uint8Array([1, 2]),
+      streamSourceNames: ["/camera"],
+    });
+  });
+
+  it("separates every render-semantic key field", () => {
+    const base = {
+      datasetId: "dataset-a",
+      mediaField: "recording",
+      selectedSourceName: null,
+      source: source("one", "etag-a"),
+    };
+    const key = gridPosterCacheKey(base);
+    expect(gridPosterCacheKey({ ...base, datasetId: "dataset-b" })).not.toBe(
+      key,
+    );
+    expect(gridPosterCacheKey({ ...base, mediaField: "other" })).not.toBe(key);
+    expect(
+      gridPosterCacheKey({ ...base, selectedSourceName: "/camera" }),
+    ).not.toBe(key);
+    expect(
+      gridPosterCacheKey({ ...base, source: source("two", "etag-a") }),
+    ).not.toBe(key);
+    expect(
+      gridPosterCacheKey({ ...base, source: source("one", "etag-b") }),
+    ).not.toBe(key);
+  });
+
+  it("classifies size and complete point-cloud pose freshness without key variants", () => {
+    const poseA = pointCloudPoseKey({ position: [1, 2, 3], target: [0, 0, 0] });
+    const poseB = pointCloudPoseKey({ position: [1, 2, 4], target: [0, 0, 0] });
+    const poster = entry([1], {
+      height: 100,
+      pointCloudPoseKey: poseA,
+      sourceKind: "point-cloud",
+      width: 200,
+    });
+    expect(
+      gridPosterFreshness(poster, { height: 100, width: 200 }, poseA),
+    ).toBe("fresh");
+    expect(
+      gridPosterFreshness(poster, { height: 101, width: 200 }, poseA),
+    ).toBe("stale-size");
+    expect(
+      gridPosterFreshness(poster, { height: 100, width: 200 }, poseB),
+    ).toBe("stale-pose");
+    expect(
+      shouldReplaceGridPoster(poster, {
+        ...poster,
+        bytes: new Uint8Array([2]),
+        pointCloudPoseKey: poseB,
+      }),
+    ).toBe(true);
+    expect(
+      shouldReplaceGridPoster(
+        entry([1], { height: 200, width: 300 }),
+        entry([2]),
+      ),
+    ).toBe(false);
+  });
+
+  it("uses the fallback and adaptive browser budgets", () => {
+    vi.stubGlobal("navigator", {});
+    expect(defaultGridPosterCacheBudgetBytes()).toBe(64 * 1024 * 1024);
+    vi.stubGlobal("navigator", { deviceMemory: 4 });
+    expect(defaultGridPosterCacheBudgetBytes()).toBe(64 * 1024 * 1024);
+    vi.stubGlobal("navigator", { deviceMemory: 16 });
+    expect(defaultGridPosterCacheBudgetBytes()).toBe(128 * 1024 * 1024);
+    vi.stubGlobal("navigator", { deviceMemory: 1 });
+    expect(defaultGridPosterCacheBudgetBytes()).toBe(32 * 1024 * 1024);
+  });
+});
+
+function entry(
+  bytes: readonly number[] | Uint8Array,
+  overrides: Partial<GridPosterCacheEntry> = {},
+): GridPosterCacheEntry {
+  return {
+    bytes: bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes),
+    height: 20,
+    mimeType: "image/webp",
+    sourceKind: "image",
+    streamId: "stream-id",
+    streamSourceName: "/camera",
+    streamSourceNames: ["/camera"],
+    width: 30,
+    ...overrides,
+  };
+}
+
+function source(id: string, etag?: string): ByteSourceDescriptor {
+  return { etag, sourceId: id, url: `https://example.test/${id}.mcap` };
+}

--- a/app/packages/multimodal/src/views/episode/grid/grid-poster-cache.test.ts
+++ b/app/packages/multimodal/src/views/episode/grid/grid-poster-cache.test.ts
@@ -106,9 +106,14 @@ describe("grid poster cache", () => {
     ).toBe("stale-pose");
     expect(
       shouldReplaceGridPoster(poster, {
-        ...poster,
-        bytes: new Uint8Array([2]),
+        height: poster.height,
+        mimeType: poster.mimeType,
         pointCloudPoseKey: poseB,
+        sourceKind: poster.sourceKind,
+        streamId: poster.streamId,
+        streamSourceName: poster.streamSourceName,
+        streamSourceNames: poster.streamSourceNames,
+        width: poster.width,
       }),
     ).toBe(true);
     expect(

--- a/app/packages/multimodal/src/views/episode/grid/grid-poster-cache.test.ts
+++ b/app/packages/multimodal/src/views/episode/grid/grid-poster-cache.test.ts
@@ -79,6 +79,12 @@ describe("grid poster cache", () => {
       gridPosterCacheKey({ ...base, selectedSourceName: "/camera" }),
     ).not.toBe(key);
     expect(
+      gridPosterCacheKey({ ...base, posterSourceName: "/camera/match" }),
+    ).not.toBe(key);
+    expect(gridPosterCacheKey({ ...base, posterStartTimeNs: 42n })).not.toBe(
+      key,
+    );
+    expect(
       gridPosterCacheKey({ ...base, source: source("two", "etag-a") }),
     ).not.toBe(key);
     expect(
@@ -122,6 +128,15 @@ describe("grid poster cache", () => {
         entry([2]),
       ),
     ).toBe(false);
+    expect(
+      shouldReplaceGridPoster(
+        entry([1], { sourceKind: "image" }),
+        entry([2], {
+          pointCloudPoseKey: poseA,
+          sourceKind: "point-cloud",
+        }),
+      ),
+    ).toBe(true);
   });
 
   it("uses the fallback and adaptive browser budgets", () => {

--- a/app/packages/multimodal/src/views/episode/grid/grid-poster-cache.test.ts
+++ b/app/packages/multimodal/src/views/episode/grid/grid-poster-cache.test.ts
@@ -32,6 +32,19 @@ describe("grid poster cache", () => {
     });
   });
 
+  it("touches recency without changing hit diagnostics", () => {
+    const cache = createGridPosterCache({ maxEntries: 2, maxSizeBytes: 1_000 });
+    cache.put("a", entry([1]));
+    cache.put("b", entry([2]));
+
+    expect(cache.touch("a")?.bytes[0]).toBe(1);
+    cache.put("c", entry([3]));
+
+    expect(cache.peek("a")).not.toBeNull();
+    expect(cache.peek("b")).toBeNull();
+    expect(cache.stats()).toMatchObject({ hits: 0, misses: 0 });
+  });
+
   it("replaces entries, rejects oversize values, and enforces the entry cap", () => {
     const cache = createGridPosterCache({ maxEntries: 2, maxSizeBytes: 1_000 });
     expect(cache.put("too-big", entry(new Array(745).fill(1)))).toBe(false);

--- a/app/packages/multimodal/src/views/episode/grid/grid-poster-cache.ts
+++ b/app/packages/multimodal/src/views/episode/grid/grid-poster-cache.ts
@@ -115,11 +115,11 @@ export function createGridPosterCache(
       return cache.peek(key) ?? null;
     },
     put(key, entry) {
-      const immutableEntry = copyEntry(entry);
-      if (entrySizeBytes(immutableEntry) > maxSizeBytes) {
+      if (entrySizeBytes(entry) > maxSizeBytes) {
         counters.oversizeRejections += 1;
         return false;
       }
+      const immutableEntry = copyEntry(entry);
       const replacing = cache.has(key);
       cache.set(key, immutableEntry);
       counters.puts += 1;
@@ -189,6 +189,7 @@ export function shouldReplaceGridPoster(
   next: Omit<GridPosterCacheEntry, "bytes">,
 ): boolean {
   if (!current) return true;
+  if (current.sourceKind !== next.sourceKind) return true;
   if (
     next.sourceKind === "point-cloud" &&
     current.pointCloudPoseKey !== next.pointCloudPoseKey
@@ -246,6 +247,8 @@ export function recordGridPosterDiagnostic(
     | "encodesCompleted"
     | "encodesFailed"
     | "encodesStarted"
+    | "hits"
+    | "misses"
     | "sourceRefreshesHover"
     | "sourceRefreshesPose"
     | "sourceRefreshesSize"

--- a/app/packages/multimodal/src/views/episode/grid/grid-poster-cache.ts
+++ b/app/packages/multimodal/src/views/episode/grid/grid-poster-cache.ts
@@ -186,7 +186,7 @@ export function gridPosterFreshness(
 
 export function shouldReplaceGridPoster(
   current: GridPosterCacheEntry | null,
-  next: GridPosterCacheEntry,
+  next: Omit<GridPosterCacheEntry, "bytes">,
 ): boolean {
   if (!current) return true;
   if (
@@ -195,7 +195,11 @@ export function shouldReplaceGridPoster(
   ) {
     return true;
   }
-  return next.width >= current.width && next.height >= current.height;
+  return (
+    next.width >= current.width &&
+    next.height >= current.height &&
+    (next.width > current.width || next.height > current.height)
+  );
 }
 
 export function defaultGridPosterCacheBudgetBytes(): number {

--- a/app/packages/multimodal/src/views/episode/grid/grid-poster-cache.ts
+++ b/app/packages/multimodal/src/views/episode/grid/grid-poster-cache.ts
@@ -1,0 +1,310 @@
+import { LRUCache } from "lru-cache";
+
+import type { ByteSourceDescriptor } from "../../../ir";
+import { episodeSourceAccessKey } from "../../../runtime";
+import type { PointCloudCameraPose } from "../../../visualization/scene-3d";
+
+const MIB = 1024 * 1024;
+const DEFAULT_FALLBACK_BYTES = 64 * MIB;
+const MIN_BUDGET_BYTES = 32 * MIB;
+const MAX_BUDGET_BYTES = 128 * MIB;
+const DEFAULT_MAX_ENTRIES = 2_048;
+const ENTRY_METADATA_BYTES = 256;
+const CACHE_SCHEMA_VERSION = "grid-poster-v1";
+const PREVIEW_SELECTION_POLICY_VERSION = "preview-selection-v1";
+const SNAPSHOT_RENDERER_POLICY_VERSION = "point-cloud-snapshot-v1";
+export const GRID_POSTER_AUTO_SOURCE = "__AUTO__";
+
+export type GridPosterCacheKey = string;
+export type GridPosterSourceKind = "image" | "point-cloud";
+
+export interface GridPosterCacheEntry {
+  readonly bytes: Uint8Array;
+  readonly height: number;
+  readonly mimeType: string;
+  readonly pointCloudPoseKey?: string;
+  readonly sourceKind: GridPosterSourceKind;
+  readonly streamId: string | null;
+  readonly streamSourceName: string | null;
+  readonly streamSourceNames: readonly string[];
+  readonly width: number;
+}
+
+export interface GridPosterCacheStats {
+  readonly encodesCoalesced: number;
+  readonly encodesCompleted: number;
+  readonly encodesFailed: number;
+  readonly encodesStarted: number;
+  readonly entryCount: number;
+  readonly evictions: number;
+  readonly hits: number;
+  readonly misses: number;
+  readonly oversizeRejections: number;
+  readonly puts: number;
+  readonly replacements: number;
+  readonly retainedBytes: number;
+  readonly sourceRefreshesHover: number;
+  readonly sourceRefreshesPose: number;
+  readonly sourceRefreshesSize: number;
+  readonly staleHits: number;
+  readonly staticHitsAvoidedSessionOpen: number;
+}
+
+type MutableStats = {
+  -readonly [Key in Exclude<
+    keyof GridPosterCacheStats,
+    "entryCount" | "retainedBytes"
+  >]: GridPosterCacheStats[Key];
+};
+
+export interface GridPosterCache {
+  clear(): void;
+  get(key: GridPosterCacheKey): GridPosterCacheEntry | null;
+  peek(key: GridPosterCacheKey): GridPosterCacheEntry | null;
+  put(key: GridPosterCacheKey, entry: GridPosterCacheEntry): boolean;
+  stats(): GridPosterCacheStats;
+}
+
+export interface GridPosterCacheOptions {
+  readonly maxEntries?: number;
+  readonly maxSizeBytes: number;
+}
+
+export interface GridPosterKeyParts {
+  readonly datasetId: string;
+  readonly mediaField: string | null | undefined;
+  readonly selectedSourceName: string | null | undefined;
+  readonly source: ByteSourceDescriptor;
+}
+
+export type GridPosterFreshness = "fresh" | "stale-pose" | "stale-size";
+
+export function createGridPosterCache(
+  options: GridPosterCacheOptions,
+): GridPosterCache {
+  const maxSizeBytes = normalizePositiveInteger(options.maxSizeBytes, 1);
+  const maxEntries = normalizePositiveInteger(
+    options.maxEntries ?? DEFAULT_MAX_ENTRIES,
+    1,
+  );
+  const counters: MutableStats = emptyCounters();
+  const cache = new LRUCache<GridPosterCacheKey, GridPosterCacheEntry>({
+    dispose: (_value, _key, reason) => {
+      if (reason === "evict") counters.evictions += 1;
+    },
+    max: maxEntries,
+    maxSize: maxSizeBytes,
+    sizeCalculation: entrySizeBytes,
+  });
+
+  const publicCache: GridPosterCache & {
+    __increment(name: keyof MutableStats): void;
+  } = {
+    clear() {
+      cache.clear();
+    },
+    get(key) {
+      const entry = cache.get(key) ?? null;
+      if (entry) counters.hits += 1;
+      else counters.misses += 1;
+      return entry;
+    },
+    peek(key) {
+      return cache.peek(key) ?? null;
+    },
+    put(key, entry) {
+      const immutableEntry = copyEntry(entry);
+      if (entrySizeBytes(immutableEntry) > maxSizeBytes) {
+        counters.oversizeRejections += 1;
+        return false;
+      }
+      const replacing = cache.has(key);
+      cache.set(key, immutableEntry);
+      counters.puts += 1;
+      if (replacing) counters.replacements += 1;
+      return true;
+    },
+    stats() {
+      return {
+        ...counters,
+        entryCount: cache.size,
+        retainedBytes: cache.calculatedSize,
+      };
+    },
+    __increment(name) {
+      counters[name] += 1;
+    },
+  };
+  return publicCache;
+}
+
+export function gridPosterCacheKey({
+  datasetId,
+  mediaField,
+  selectedSourceName,
+  source,
+}: GridPosterKeyParts): GridPosterCacheKey {
+  return serializeGridPosterKey([
+    CACHE_SCHEMA_VERSION,
+    datasetId,
+    mediaField ?? null,
+    episodeSourceAccessKey(source),
+    selectedSourceName ?? GRID_POSTER_AUTO_SOURCE,
+    PREVIEW_SELECTION_POLICY_VERSION,
+  ]);
+}
+
+export function pointCloudPoseKey(pose: PointCloudCameraPose | null): string {
+  return serializeGridPosterKey([
+    SNAPSHOT_RENDERER_POLICY_VERSION,
+    pose ? JSON.stringify([pose.position, pose.target]) : "AUTO_FIT",
+  ]);
+}
+
+export function gridPosterFreshness(
+  entry: GridPosterCacheEntry,
+  size: { readonly height: number; readonly width: number },
+  poseKey: string,
+): GridPosterFreshness {
+  if (
+    entry.sourceKind === "point-cloud" &&
+    entry.pointCloudPoseKey !== poseKey
+  ) {
+    return "stale-pose";
+  }
+  if (entry.width < size.width || entry.height < size.height) {
+    return "stale-size";
+  }
+  return "fresh";
+}
+
+export function shouldReplaceGridPoster(
+  current: GridPosterCacheEntry | null,
+  next: GridPosterCacheEntry,
+): boolean {
+  if (!current) return true;
+  if (
+    next.sourceKind === "point-cloud" &&
+    current.pointCloudPoseKey !== next.pointCloudPoseKey
+  ) {
+    return true;
+  }
+  return next.width >= current.width && next.height >= current.height;
+}
+
+export function defaultGridPosterCacheBudgetBytes(): number {
+  if (typeof navigator === "undefined") return DEFAULT_FALLBACK_BYTES;
+  const memory = (navigator as Navigator & { readonly deviceMemory?: number })
+    .deviceMemory;
+  if (!Number.isFinite(memory) || !memory || memory <= 0) {
+    return DEFAULT_FALLBACK_BYTES;
+  }
+  return Math.round(
+    Math.min(
+      MAX_BUDGET_BYTES,
+      Math.max(MIN_BUDGET_BYTES, (memory / 8) * MAX_BUDGET_BYTES),
+    ),
+  );
+}
+
+let singleton = createGridPosterCache({
+  maxEntries: DEFAULT_MAX_ENTRIES,
+  maxSizeBytes: defaultGridPosterCacheBudgetBytes(),
+});
+
+export function getGridPosterCache(): GridPosterCache {
+  return singleton;
+}
+
+export function clearGridPosterCache(): void {
+  singleton.clear();
+}
+
+export function resetGridPosterCacheForTests(options?: GridPosterCacheOptions) {
+  singleton = createGridPosterCache(
+    options ?? {
+      maxEntries: DEFAULT_MAX_ENTRIES,
+      maxSizeBytes: defaultGridPosterCacheBudgetBytes(),
+    },
+  );
+}
+
+export function recordGridPosterDiagnostic(
+  name: keyof Pick<
+    MutableStats,
+    | "encodesCoalesced"
+    | "encodesCompleted"
+    | "encodesFailed"
+    | "encodesStarted"
+    | "sourceRefreshesHover"
+    | "sourceRefreshesPose"
+    | "sourceRefreshesSize"
+    | "staleHits"
+    | "staticHitsAvoidedSessionOpen"
+  >,
+): void {
+  // The production singleton owns page-session diagnostics alongside entries.
+  const cache = singleton as GridPosterCache & {
+    __increment?: (name: keyof MutableStats) => void;
+  };
+  cache.__increment?.(name);
+}
+
+function emptyCounters(): MutableStats {
+  return {
+    encodesCoalesced: 0,
+    encodesCompleted: 0,
+    encodesFailed: 0,
+    encodesStarted: 0,
+    evictions: 0,
+    hits: 0,
+    misses: 0,
+    oversizeRejections: 0,
+    puts: 0,
+    replacements: 0,
+    sourceRefreshesHover: 0,
+    sourceRefreshesPose: 0,
+    sourceRefreshesSize: 0,
+    staleHits: 0,
+    staticHitsAvoidedSessionOpen: 0,
+  };
+}
+
+function copyEntry(entry: GridPosterCacheEntry): GridPosterCacheEntry {
+  return Object.freeze({
+    ...entry,
+    bytes: entry.bytes.slice(),
+    streamSourceNames: Object.freeze([...entry.streamSourceNames]),
+  });
+}
+
+function entrySizeBytes(entry: GridPosterCacheEntry): number {
+  return entry.bytes.byteLength + ENTRY_METADATA_BYTES;
+}
+
+function normalizePositiveInteger(value: number, fallback: number): number {
+  return Number.isFinite(value) && value >= 1 ? Math.floor(value) : fallback;
+}
+
+function serializeGridPosterKey(parts: readonly (string | null)[]): string {
+  return JSON.stringify(parts);
+}
+
+if (import.meta.env.DEV && typeof window !== "undefined") {
+  Object.defineProperty(
+    window as Window & {
+      __FIFTYONE_GRID_POSTER_CACHE__?: {
+        clear(): void;
+        stats(): GridPosterCacheStats;
+      };
+    },
+    "__FIFTYONE_GRID_POSTER_CACHE__",
+    {
+      configurable: true,
+      value: {
+        clear: clearGridPosterCache,
+        stats: () => getGridPosterCache().stats(),
+      },
+    },
+  );
+}

--- a/app/packages/multimodal/src/views/episode/grid/grid-poster-cache.ts
+++ b/app/packages/multimodal/src/views/episode/grid/grid-poster-cache.ts
@@ -1,7 +1,7 @@
 import { LRUCache } from "lru-cache";
 
 import type { ByteSourceDescriptor } from "../../../ir";
-import { episodeSourceAccessKey } from "../../../runtime";
+import { episodeSourceAccessKey } from "../../../runtime/episode-resources";
 import type { PointCloudCameraPose } from "../../../visualization/scene-3d";
 
 const MIB = 1024 * 1024;
@@ -63,6 +63,12 @@ export interface GridPosterCache {
   peek(key: GridPosterCacheKey): GridPosterCacheEntry | null;
   put(key: GridPosterCacheKey, entry: GridPosterCacheEntry): boolean;
   stats(): GridPosterCacheStats;
+  /** Promotes an entry without changing hit/miss diagnostics. */
+  touch(key: GridPosterCacheKey): GridPosterCacheEntry | null;
+}
+
+interface GridPosterCacheInternals {
+  __increment(name: keyof MutableStats): void;
 }
 
 export interface GridPosterCacheOptions {
@@ -83,7 +89,7 @@ export type GridPosterFreshness = "fresh" | "stale-pose" | "stale-size";
 
 export function createGridPosterCache(
   options: GridPosterCacheOptions,
-): GridPosterCache {
+): GridPosterCache & GridPosterCacheInternals {
   const maxSizeBytes = normalizePositiveInteger(options.maxSizeBytes, 1);
   const maxEntries = normalizePositiveInteger(
     options.maxEntries ?? DEFAULT_MAX_ENTRIES,
@@ -99,9 +105,7 @@ export function createGridPosterCache(
     sizeCalculation: entrySizeBytes,
   });
 
-  const publicCache: GridPosterCache & {
-    __increment(name: keyof MutableStats): void;
-  } = {
+  const publicCache: GridPosterCache & GridPosterCacheInternals = {
     clear() {
       cache.clear();
     },
@@ -132,6 +136,9 @@ export function createGridPosterCache(
         entryCount: cache.size,
         retainedBytes: cache.calculatedSize,
       };
+    },
+    touch(key) {
+      return cache.get(key) ?? null;
     },
     __increment(name) {
       counters[name] += 1;
@@ -218,10 +225,11 @@ export function defaultGridPosterCacheBudgetBytes(): number {
   );
 }
 
-let singleton = createGridPosterCache({
-  maxEntries: DEFAULT_MAX_ENTRIES,
-  maxSizeBytes: defaultGridPosterCacheBudgetBytes(),
-});
+let singleton: GridPosterCache & GridPosterCacheInternals =
+  createGridPosterCache({
+    maxEntries: DEFAULT_MAX_ENTRIES,
+    maxSizeBytes: defaultGridPosterCacheBudgetBytes(),
+  });
 
 export function getGridPosterCache(): GridPosterCache {
   return singleton;
@@ -257,10 +265,7 @@ export function recordGridPosterDiagnostic(
   >,
 ): void {
   // The production singleton owns page-session diagnostics alongside entries.
-  const cache = singleton as GridPosterCache & {
-    __increment?: (name: keyof MutableStats) => void;
-  };
-  cache.__increment?.(name);
+  singleton.__increment(name);
 }
 
 function emptyCounters(): MutableStats {

--- a/app/packages/multimodal/src/views/episode/grid/grid-poster-cache.ts
+++ b/app/packages/multimodal/src/views/episode/grid/grid-poster-cache.ts
@@ -73,6 +73,8 @@ export interface GridPosterCacheOptions {
 export interface GridPosterKeyParts {
   readonly datasetId: string;
   readonly mediaField: string | null | undefined;
+  readonly posterSourceName?: string | null | undefined;
+  readonly posterStartTimeNs?: bigint | null | undefined;
   readonly selectedSourceName: string | null | undefined;
   readonly source: ByteSourceDescriptor;
 }
@@ -141,6 +143,8 @@ export function createGridPosterCache(
 export function gridPosterCacheKey({
   datasetId,
   mediaField,
+  posterSourceName,
+  posterStartTimeNs,
   selectedSourceName,
   source,
 }: GridPosterKeyParts): GridPosterCacheKey {
@@ -150,6 +154,8 @@ export function gridPosterCacheKey({
     mediaField ?? null,
     episodeSourceAccessKey(source),
     selectedSourceName ?? GRID_POSTER_AUTO_SOURCE,
+    posterSourceName ?? null,
+    posterStartTimeNs?.toString() ?? null,
     PREVIEW_SELECTION_POLICY_VERSION,
   ]);
 }

--- a/app/packages/multimodal/src/views/episode/grid/grid-poster-codec.test.ts
+++ b/app/packages/multimodal/src/views/episode/grid/grid-poster-codec.test.ts
@@ -68,6 +68,82 @@ describe("grid poster codec", () => {
     expect(maximum).toBe(1);
   });
 
+  it("drops the oldest queued capture when the pending queue is full", async () => {
+    resetGridPosterCacheForTests({ maxSizeBytes: 10_000 });
+    const releases: Array<(blob: Blob) => void> = [];
+    const canvases: OffscreenCanvas[] = [];
+    const encode = vi.fn(
+      () => new Promise<Blob>((resolve) => releases.push(resolve)),
+    );
+    const encoder = createGridPosterEncoder({
+      cloneCanvas: () => {
+        const canvas = ownedCanvas();
+        canvases.push(canvas);
+        return canvas;
+      },
+      concurrency: 1,
+      encode,
+      maxPendingCaptures: 2,
+    });
+
+    encoder.capture(capture("active"));
+    encoder.capture(capture("dropped"));
+    encoder.capture(capture("queued-a"));
+    encoder.capture(capture("queued-b"));
+
+    expect(canvases[1]).toMatchObject({ height: 0, width: 0 });
+    releases.shift()?.(encodedBlob([1], "image/webp"));
+    await vi.waitFor(() => expect(encode).toHaveBeenCalledTimes(2));
+    releases.shift()?.(encodedBlob([2], "image/webp"));
+    await vi.waitFor(() => expect(encode).toHaveBeenCalledTimes(3));
+    releases.shift()?.(encodedBlob([3], "image/webp"));
+    await vi.waitFor(() =>
+      expect(getGridPosterCache().peek("queued-b")).not.toBeNull(),
+    );
+
+    expect(getGridPosterCache().peek("dropped")).toBeNull();
+  });
+
+  it("does not commit an encode that completes after reset", async () => {
+    resetGridPosterCacheForTests({ maxSizeBytes: 10_000 });
+    const canvas = ownedCanvas();
+    let resolveEncode: ((blob: Blob) => void) | undefined;
+    const encoder = createGridPosterEncoder({
+      cloneCanvas: () => canvas,
+      concurrency: 1,
+      encode: () =>
+        new Promise<Blob>((resolve) => {
+          resolveEncode = resolve;
+        }),
+    });
+
+    encoder.capture(capture("reset"));
+    encoder.reset();
+    resolveEncode?.(encodedBlob([1], "image/webp"));
+    await vi.waitFor(() =>
+      expect(canvas).toMatchObject({ height: 0, width: 0 }),
+    );
+
+    expect(getGridPosterCache().peek("reset")).toBeNull();
+    expect(getGridPosterCache().stats().encodesCompleted).toBe(0);
+  });
+
+  it("records a completed encode only when the cache accepts it", async () => {
+    resetGridPosterCacheForTests({ maxSizeBytes: 257 });
+    const encoder = createGridPosterEncoder({
+      cloneCanvas: () => ownedCanvas(),
+      encode: vi.fn().mockResolvedValue(encodedBlob([1, 2], "image/webp")),
+    });
+
+    encoder.capture(capture("oversize"));
+    await vi.waitFor(() =>
+      expect(getGridPosterCache().stats().oversizeRejections).toBe(1),
+    );
+
+    expect(getGridPosterCache().stats().encodesCompleted).toBe(0);
+    expect(getGridPosterCache().peek("oversize")).toBeNull();
+  });
+
   it("treats encoder failures as cache misses", async () => {
     resetGridPosterCacheForTests({ maxSizeBytes: 10_000 });
     const encoder = createGridPosterEncoder({

--- a/app/packages/multimodal/src/views/episode/grid/grid-poster-codec.test.ts
+++ b/app/packages/multimodal/src/views/episode/grid/grid-poster-codec.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  getGridPosterCache,
+  resetGridPosterCacheForTests,
+} from "./grid-poster-cache";
+import { createGridPosterEncoder } from "./grid-poster-codec";
+
+afterEach(() => resetGridPosterCacheForTests());
+
+describe("grid poster codec", () => {
+  it("encodes WebP and falls back to PNG when the browser rejects it", async () => {
+    resetGridPosterCacheForTests({ maxSizeBytes: 10_000 });
+    const encode = vi
+      .fn()
+      .mockResolvedValueOnce(encodedBlob([], "image/webp"))
+      .mockResolvedValueOnce(encodedBlob([7, 8], "image/png"));
+    const encoder = createGridPosterEncoder({
+      cloneCanvas: () => ownedCanvas(),
+      concurrency: 1,
+      encode,
+    });
+    encoder.capture(capture("fallback"));
+    await vi.waitFor(() =>
+      expect(getGridPosterCache().peek("fallback")).not.toBeNull(),
+    );
+
+    expect(encode).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      "image/webp",
+      0.8,
+    );
+    expect(encode).toHaveBeenNthCalledWith(2, expect.anything(), "image/png");
+    expect(getGridPosterCache().peek("fallback")).toMatchObject({
+      bytes: new Uint8Array([7, 8]),
+      mimeType: "image/png",
+    });
+  });
+
+  it("bounds concurrency and coalesces the latest pending job per key", async () => {
+    resetGridPosterCacheForTests({ maxSizeBytes: 10_000 });
+    const releases: Array<(blob: Blob) => void> = [];
+    let active = 0;
+    let maximum = 0;
+    const encode = vi.fn(async () => {
+      active += 1;
+      maximum = Math.max(maximum, active);
+      const blob = await new Promise<Blob>((resolve) => releases.push(resolve));
+      active -= 1;
+      return blob;
+    });
+    const encoder = createGridPosterEncoder({
+      cloneCanvas: () => ownedCanvas(),
+      concurrency: 1,
+      encode,
+    });
+    encoder.capture(capture("a", 10));
+    encoder.capture(capture("b", 20));
+    encoder.capture(capture("b", 30));
+    expect(encode).toHaveBeenCalledTimes(1);
+    releases.shift()?.(encodedBlob([1], "image/webp"));
+    await vi.waitFor(() => expect(encode).toHaveBeenCalledTimes(2));
+    releases.shift()?.(encodedBlob([2], "image/webp"));
+    await vi.waitFor(() =>
+      expect(getGridPosterCache().peek("b")?.width).toBe(30),
+    );
+    expect(maximum).toBe(1);
+  });
+
+  it("treats encoder failures as cache misses", async () => {
+    resetGridPosterCacheForTests({ maxSizeBytes: 10_000 });
+    const encoder = createGridPosterEncoder({
+      cloneCanvas: () => ownedCanvas(),
+      encode: vi.fn().mockRejectedValue(new Error("encode failed")),
+    });
+    encoder.capture(capture("failed"));
+    await vi.waitFor(() =>
+      expect(getGridPosterCache().stats().encodesFailed).toBe(1),
+    );
+    expect(getGridPosterCache().peek("failed")).toBeNull();
+  });
+});
+
+function capture(key: string, width = 10) {
+  return {
+    entry: {
+      height: 10,
+      mimeType: "image/webp",
+      sourceKind: "image" as const,
+      streamId: "stream-id",
+      streamSourceName: "/camera",
+      streamSourceNames: ["/camera"],
+      width,
+    },
+    key,
+    source: {} as HTMLCanvasElement,
+  };
+}
+
+function ownedCanvas(): OffscreenCanvas {
+  return { height: 10, width: 10 } as OffscreenCanvas;
+}
+
+function encodedBlob(bytes: readonly number[], type: string): Blob {
+  const value = new Uint8Array(bytes);
+  return {
+    arrayBuffer: async () => value.buffer,
+    size: value.byteLength,
+    type,
+  } as Blob;
+}

--- a/app/packages/multimodal/src/views/episode/grid/grid-poster-codec.test.ts
+++ b/app/packages/multimodal/src/views/episode/grid/grid-poster-codec.test.ts
@@ -80,6 +80,22 @@ describe("grid poster codec", () => {
     );
     expect(getGridPosterCache().peek("failed")).toBeNull();
   });
+
+  it("skips encoding when the cached poster is already large enough", () => {
+    resetGridPosterCacheForTests({ maxSizeBytes: 10_000 });
+    getGridPosterCache().put("current", {
+      ...capture("current", 30).entry,
+      bytes: new Uint8Array([1]),
+    });
+    const cloneCanvas = vi.fn(() => ownedCanvas());
+    const encode = vi.fn();
+    const encoder = createGridPosterEncoder({ cloneCanvas, encode });
+
+    encoder.capture(capture("current", 30));
+
+    expect(cloneCanvas).not.toHaveBeenCalled();
+    expect(encode).not.toHaveBeenCalled();
+  });
 });
 
 function capture(key: string, width = 10) {

--- a/app/packages/multimodal/src/views/episode/grid/grid-poster-codec.ts
+++ b/app/packages/multimodal/src/views/episode/grid/grid-poster-codec.ts
@@ -55,6 +55,10 @@ export function createGridPosterEncoder(
       const job = pending.get(key);
       if (!job) continue;
       pending.delete(key);
+      if (!shouldReplaceGridPoster(getGridPosterCache().peek(key), job.entry)) {
+        releaseCanvas(job.canvas);
+        continue;
+      }
       active += 1;
       const jobGeneration = generation;
       recordGridPosterDiagnostic("encodesStarted");
@@ -81,6 +85,14 @@ export function createGridPosterEncoder(
   return {
     capture(capture) {
       try {
+        if (
+          !shouldReplaceGridPoster(
+            getGridPosterCache().peek(capture.key),
+            capture.entry,
+          )
+        ) {
+          return;
+        }
         const job = { ...capture, canvas: cloneCanvas(capture.source) };
         const previous = pending.get(capture.key);
         if (previous) {

--- a/app/packages/multimodal/src/views/episode/grid/grid-poster-codec.ts
+++ b/app/packages/multimodal/src/views/episode/grid/grid-poster-codec.ts
@@ -1,0 +1,175 @@
+import {
+  getGridPosterCache,
+  recordGridPosterDiagnostic,
+  shouldReplaceGridPoster,
+  type GridPosterCacheEntry,
+  type GridPosterCacheKey,
+} from "./grid-poster-cache";
+
+const WEBP_MIME_TYPE = "image/webp";
+const PNG_MIME_TYPE = "image/png";
+const WEBP_QUALITY = 0.8;
+
+type OwnedCanvas = HTMLCanvasElement | OffscreenCanvas;
+
+export interface GridPosterCapture {
+  readonly entry: Omit<GridPosterCacheEntry, "bytes">;
+  readonly key: GridPosterCacheKey;
+  readonly source: HTMLCanvasElement;
+}
+
+export interface GridPosterEncoderOptions {
+  readonly cloneCanvas?: (source: HTMLCanvasElement) => OwnedCanvas;
+  readonly concurrency?: number;
+  readonly encode?: (
+    canvas: OwnedCanvas,
+    mimeType: string,
+    quality?: number,
+  ) => Promise<Blob | null>;
+}
+
+interface EncodeJob extends Omit<GridPosterCapture, "source"> {
+  readonly canvas: OwnedCanvas;
+}
+
+export interface GridPosterEncoder {
+  capture(capture: GridPosterCapture): void;
+  reset(): void;
+}
+
+export function createGridPosterEncoder(
+  options: GridPosterEncoderOptions = {},
+): GridPosterEncoder {
+  const concurrency = Math.max(1, Math.floor(options.concurrency ?? 2));
+  const cloneCanvas = options.cloneCanvas ?? cloneDisplayCanvas;
+  const encode = options.encode ?? encodeCanvas;
+  const pending = new Map<GridPosterCacheKey, EncodeJob>();
+  const order: GridPosterCacheKey[] = [];
+  let active = 0;
+  let generation = 0;
+
+  const pump = () => {
+    while (active < concurrency && order.length > 0) {
+      const key = order.shift();
+      if (!key) continue;
+      const job = pending.get(key);
+      if (!job) continue;
+      pending.delete(key);
+      active += 1;
+      const jobGeneration = generation;
+      recordGridPosterDiagnostic("encodesStarted");
+      void encodeJob(job, encode)
+        .then((entry) => {
+          if (!entry || jobGeneration !== generation) return;
+          const cache = getGridPosterCache();
+          if (shouldReplaceGridPoster(cache.peek(job.key), entry)) {
+            cache.put(job.key, entry);
+          }
+          recordGridPosterDiagnostic("encodesCompleted");
+        })
+        .catch(() => {
+          recordGridPosterDiagnostic("encodesFailed");
+        })
+        .finally(() => {
+          releaseCanvas(job.canvas);
+          active -= 1;
+          pump();
+        });
+    }
+  };
+
+  return {
+    capture(capture) {
+      try {
+        const job = { ...capture, canvas: cloneCanvas(capture.source) };
+        const previous = pending.get(capture.key);
+        if (previous) {
+          releaseCanvas(previous.canvas);
+          recordGridPosterDiagnostic("encodesCoalesced");
+        } else {
+          order.push(capture.key);
+        }
+        pending.set(capture.key, job);
+        pump();
+      } catch {
+        recordGridPosterDiagnostic("encodesFailed");
+      }
+    },
+    reset() {
+      generation += 1;
+      for (const job of pending.values()) releaseCanvas(job.canvas);
+      pending.clear();
+      order.length = 0;
+    },
+  };
+}
+
+let singleton = createGridPosterEncoder();
+
+export function captureGridPoster(capture: GridPosterCapture): void {
+  singleton.capture(capture);
+}
+
+export function resetGridPosterEncoderForTests(
+  options?: GridPosterEncoderOptions,
+): void {
+  singleton.reset();
+  singleton = createGridPosterEncoder(options);
+}
+
+async function encodeJob(
+  job: EncodeJob,
+  encode: NonNullable<GridPosterEncoderOptions["encode"]>,
+): Promise<GridPosterCacheEntry | null> {
+  let blob = await encode(job.canvas, WEBP_MIME_TYPE, WEBP_QUALITY);
+  if (!validBlob(blob, WEBP_MIME_TYPE)) {
+    blob = await encode(job.canvas, PNG_MIME_TYPE);
+  }
+  if (!validBlob(blob, PNG_MIME_TYPE) && !validBlob(blob, WEBP_MIME_TYPE)) {
+    throw new Error("Grid poster encoding returned no supported image");
+  }
+  return {
+    ...job.entry,
+    bytes: new Uint8Array(await blob.arrayBuffer()),
+    mimeType: blob.type,
+  };
+}
+
+function validBlob(blob: Blob | null, mimeType: string): blob is Blob {
+  return blob !== null && blob.size > 0 && blob.type === mimeType;
+}
+
+function cloneDisplayCanvas(source: HTMLCanvasElement): OwnedCanvas {
+  const width = Math.max(1, source.width);
+  const height = Math.max(1, source.height);
+  if (typeof OffscreenCanvas !== "undefined") {
+    const clone = new OffscreenCanvas(width, height);
+    const context = clone.getContext("2d");
+    if (!context) throw new Error("Unable to clone grid poster canvas");
+    context.drawImage(source, 0, 0);
+    return clone;
+  }
+  const clone = document.createElement("canvas");
+  clone.width = width;
+  clone.height = height;
+  const context = clone.getContext("2d");
+  if (!context) throw new Error("Unable to clone grid poster canvas");
+  context.drawImage(source, 0, 0);
+  return clone;
+}
+
+async function encodeCanvas(
+  canvas: OwnedCanvas,
+  mimeType: string,
+  quality?: number,
+): Promise<Blob | null> {
+  if (canvas instanceof HTMLCanvasElement) {
+    return new Promise((resolve) => canvas.toBlob(resolve, mimeType, quality));
+  }
+  return canvas.convertToBlob({ quality, type: mimeType });
+}
+
+function releaseCanvas(canvas: OwnedCanvas): void {
+  canvas.width = 0;
+  canvas.height = 0;
+}

--- a/app/packages/multimodal/src/views/episode/grid/grid-poster-codec.ts
+++ b/app/packages/multimodal/src/views/episode/grid/grid-poster-codec.ts
@@ -9,6 +9,7 @@ import {
 const WEBP_MIME_TYPE = "image/webp";
 const PNG_MIME_TYPE = "image/png";
 const WEBP_QUALITY = 0.8;
+const DEFAULT_MAX_PENDING_CAPTURES = 16;
 
 type OwnedCanvas = HTMLCanvasElement | OffscreenCanvas;
 
@@ -26,6 +27,7 @@ export interface GridPosterEncoderOptions {
     mimeType: string,
     quality?: number,
   ) => Promise<Blob | null>;
+  readonly maxPendingCaptures?: number;
 }
 
 interface EncodeJob extends Omit<GridPosterCapture, "source"> {
@@ -43,6 +45,10 @@ export function createGridPosterEncoder(
   const concurrency = Math.max(1, Math.floor(options.concurrency ?? 2));
   const cloneCanvas = options.cloneCanvas ?? cloneDisplayCanvas;
   const encode = options.encode ?? encodeCanvas;
+  const maxPendingCaptures = Math.max(
+    1,
+    Math.floor(options.maxPendingCaptures ?? DEFAULT_MAX_PENDING_CAPTURES),
+  );
   const pending = new Map<GridPosterCacheKey, EncodeJob>();
   const order: GridPosterCacheKey[] = [];
   let active = 0;
@@ -66,10 +72,12 @@ export function createGridPosterEncoder(
         .then((entry) => {
           if (!entry || jobGeneration !== generation) return;
           const cache = getGridPosterCache();
-          if (shouldReplaceGridPoster(cache.peek(job.key), entry)) {
-            cache.put(job.key, entry);
+          if (
+            shouldReplaceGridPoster(cache.peek(job.key), entry) &&
+            cache.put(job.key, entry)
+          ) {
+            recordGridPosterDiagnostic("encodesCompleted");
           }
-          recordGridPosterDiagnostic("encodesCompleted");
         })
         .catch(() => {
           recordGridPosterDiagnostic("encodesFailed");
@@ -102,6 +110,14 @@ export function createGridPosterEncoder(
           order.push(capture.key);
         }
         pending.set(capture.key, job);
+        while (order.length > maxPendingCaptures) {
+          const droppedKey = order.shift();
+          if (!droppedKey) break;
+          const droppedJob = pending.get(droppedKey);
+          if (!droppedJob) continue;
+          pending.delete(droppedKey);
+          releaseCanvas(droppedJob.canvas);
+        }
         pump();
       } catch {
         recordGridPosterDiagnostic("encodesFailed");

--- a/app/packages/multimodal/src/views/episode/grid/grid-poster-codec.ts
+++ b/app/packages/multimodal/src/views/episode/grid/grid-poster-codec.ts
@@ -42,12 +42,16 @@ export interface GridPosterEncoder {
 export function createGridPosterEncoder(
   options: GridPosterEncoderOptions = {},
 ): GridPosterEncoder {
-  const concurrency = Math.max(1, Math.floor(options.concurrency ?? 2));
+  const normalizeLimit = (value: number | undefined, fallback: number) =>
+    typeof value === "number" && Number.isFinite(value)
+      ? Math.max(1, Math.floor(value))
+      : fallback;
+  const concurrency = normalizeLimit(options.concurrency, 2);
   const cloneCanvas = options.cloneCanvas ?? cloneDisplayCanvas;
   const encode = options.encode ?? encodeCanvas;
-  const maxPendingCaptures = Math.max(
-    1,
-    Math.floor(options.maxPendingCaptures ?? DEFAULT_MAX_PENDING_CAPTURES),
+  const maxPendingCaptures = normalizeLimit(
+    options.maxPendingCaptures,
+    DEFAULT_MAX_PENDING_CAPTURES,
   );
   const pending = new Map<GridPosterCacheKey, EncodeJob>();
   const order: GridPosterCacheKey[] = [];

--- a/app/packages/multimodal/src/views/episode/grid/use-grid-preview.test.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/use-grid-preview.test.tsx
@@ -18,6 +18,7 @@ import {
   useGridPreview,
   type GridPreviewState,
 } from "./use-grid-preview";
+import type { GridPosterCacheEntry } from "./grid-poster-cache";
 
 const sessionHarness = vi.hoisted(() => ({
   session: {
@@ -36,6 +37,42 @@ afterEach(() => {
 describe("useGridPreview", () => {
   beforeEach(() => {
     sessionHarness.session.read.mockReset();
+  });
+
+  it("seeds a cached poster synchronously and never reads without session demand", () => {
+    const latest = { current: null as GridPreviewState | null };
+    const source = sourceForId("cached");
+    const { rerender } = render(
+      <PreviewHarness
+        cacheRequestKey="cached-key"
+        cachedPoster={cachedPoster()}
+        id="cached"
+        onState={(state) => {
+          latest.current = state;
+        }}
+        previewSession={null}
+        source={source}
+      />,
+    );
+
+    expect(latest.current?.cachedPoster?.bytes[0]).toBe(7);
+    expect(latest.current?.status).toBe("ready");
+    expect(sessionHarness.session.read).not.toHaveBeenCalled();
+
+    rerender(
+      <PreviewHarness
+        cacheRequestKey="other-key"
+        cachedPoster={null}
+        id="cached"
+        onState={(state) => {
+          latest.current = state;
+        }}
+        previewSession={null}
+        source={sourceForId("other")}
+      />,
+    );
+    expect(latest.current?.cachedPoster).toBeNull();
+    expect(latest.current?.status).toBe("loading");
   });
 
   it("loads an initial preview through the preview session", async () => {
@@ -775,6 +812,8 @@ describe("useGridPreview", () => {
 });
 
 function PreviewHarness({
+  cacheRequestKey,
+  cachedPoster,
   enabled,
   hovered,
   id,
@@ -782,9 +821,12 @@ function PreviewHarness({
   onState,
   posterStartTimeNs,
   posterSourceName,
+  previewSession,
   selectedSourceName,
   source,
 }: {
+  readonly cacheRequestKey?: string | null;
+  readonly cachedPoster?: GridPosterCacheEntry | null;
   readonly enabled?: boolean;
   readonly hovered?: boolean;
   readonly id: string;
@@ -792,17 +834,23 @@ function PreviewHarness({
   readonly onState?: (state: GridPreviewState) => void;
   readonly posterStartTimeNs?: bigint | null;
   readonly posterSourceName?: string | null;
+  readonly previewSession?: EpisodePreviewSession | null;
   readonly selectedSourceName?: string | null;
   readonly source: ByteSourceDescriptor | null;
 }) {
   const state = useGridPreview({
+    cacheRequestKey,
+    cachedPoster,
     enabled,
     hovered,
     onReadResult,
     posterStartTimeNs,
     posterSourceName,
-    previewSession: sessionHarness.session as EpisodePreviewSession,
-    previewSessionStatus: "ready",
+    previewSession:
+      previewSession === undefined
+        ? (sessionHarness.session as EpisodePreviewSession)
+        : previewSession,
+    previewSessionStatus: previewSession === null ? "idle" : "ready",
     selectedSourceName,
     source,
   });
@@ -858,6 +906,19 @@ function emptyResult(hasPreviewStreams: boolean): EpisodePreviewReadResult {
     streamSourceName: hasPreviewStreams ? "/camera/front" : null,
     streamSourceNames: hasPreviewStreams ? ["/camera/front"] : [],
     status: "empty",
+  };
+}
+
+function cachedPoster(): GridPosterCacheEntry {
+  return {
+    bytes: new Uint8Array([7, 8]),
+    height: 100,
+    mimeType: "image/webp",
+    sourceKind: "image",
+    streamId: "cached-stream",
+    streamSourceName: "/camera/cached",
+    streamSourceNames: ["/camera/cached"],
+    width: 100,
   };
 }
 

--- a/app/packages/multimodal/src/views/episode/grid/use-grid-preview.test.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/use-grid-preview.test.tsx
@@ -75,6 +75,66 @@ describe("useGridPreview", () => {
     expect(latest.current?.status).toBe("loading");
   });
 
+  it("preserves a cached poster when the preview session fails", async () => {
+    const latest = { current: null as GridPreviewState | null };
+    render(
+      <PreviewHarness
+        cacheRequestKey="cached-error"
+        cachedPoster={cachedPoster()}
+        id="cached-error"
+        onState={(state) => {
+          latest.current = state;
+        }}
+        previewSession={null}
+        previewSessionStatus="error"
+        source={sourceForId("cached-error")}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(latest.current?.error).toBe("Episode preview failed to open"),
+    );
+    expect(latest.current?.cachedPoster?.bytes[0]).toBe(7);
+    expect(latest.current?.status).toBe("ready");
+  });
+
+  it("does not reset a live preview when same-key poster identity changes", async () => {
+    sessionHarness.session.read.mockResolvedValue(
+      readyResult({ bytes: [1, 2, 3] }),
+    );
+    const source = sourceForId("same-key-poster");
+    const { rerender } = render(
+      <PreviewHarness
+        cacheRequestKey="same-key"
+        cachedPoster={cachedPoster()}
+        id="same-key-poster"
+        source={source}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("preview-same-key-poster").textContent).toBe(
+        "ready:1:frame:",
+      ),
+    );
+
+    rerender(
+      <PreviewHarness
+        cacheRequestKey="same-key"
+        cachedPoster={{ ...cachedPoster(), bytes: new Uint8Array([9]) }}
+        id="same-key-poster"
+        source={source}
+      />,
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(sessionHarness.session.read).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("preview-same-key-poster").textContent).toBe(
+      "ready:1:frame:",
+    );
+  });
+
   it("loads an initial preview through the preview session", async () => {
     sessionHarness.session.read.mockResolvedValueOnce(
       readyResult({ bytes: [1, 2, 3], nextStartTimeNs: 5n }),
@@ -822,6 +882,7 @@ function PreviewHarness({
   posterStartTimeNs,
   posterSourceName,
   previewSession,
+  previewSessionStatus,
   selectedSourceName,
   source,
 }: {
@@ -835,6 +896,12 @@ function PreviewHarness({
   readonly posterStartTimeNs?: bigint | null;
   readonly posterSourceName?: string | null;
   readonly previewSession?: EpisodePreviewSession | null;
+  readonly previewSessionStatus?:
+    | "error"
+    | "idle"
+    | "loading"
+    | "ready"
+    | "unavailable";
   readonly selectedSourceName?: string | null;
   readonly source: ByteSourceDescriptor | null;
 }) {
@@ -850,7 +917,8 @@ function PreviewHarness({
       previewSession === undefined
         ? (sessionHarness.session as EpisodePreviewSession)
         : previewSession,
-    previewSessionStatus: previewSession === null ? "idle" : "ready",
+    previewSessionStatus:
+      previewSessionStatus ?? (previewSession === null ? "idle" : "ready"),
     selectedSourceName,
     source,
   });

--- a/app/packages/multimodal/src/views/episode/grid/use-grid-preview.ts
+++ b/app/packages/multimodal/src/views/episode/grid/use-grid-preview.ts
@@ -11,6 +11,7 @@ import {
   publishSourceBootstrap,
 } from "../../../runtime";
 import { errorMessage } from "../status/error-message";
+import type { GridPosterCacheEntry } from "./grid-poster-cache";
 
 /** Status values used by the format-neutral episode grid preview. */
 export type GridPreviewStatus =
@@ -23,10 +24,12 @@ export type GridPreviewStatus =
 
 /** Render state for one lightweight episode preview. */
 export interface GridPreviewSnapshot {
+  readonly cachedPoster: GridPosterCacheEntry | null;
   readonly error: string | null;
   readonly frame: EpisodePosterFrame | null;
   readonly hasPreviewStreams: boolean;
   readonly streamId: string | null;
+  readonly streamSourceName: string | null;
   readonly streamSourceNames: readonly string[];
   readonly status: GridPreviewStatus;
 }
@@ -44,6 +47,8 @@ export interface GridPreviewState extends GridPreviewSnapshot {
  * Options for rendering one lightweight episode stream preview in the grid.
  */
 export interface UseGridPreviewOptions {
+  readonly cacheRequestKey?: string | null;
+  readonly cachedPoster?: GridPosterCacheEntry | null;
   readonly enabled?: boolean;
   /** Whether this tile is the user's current interactive target. */
   readonly hovered?: boolean;
@@ -71,10 +76,12 @@ export interface UseGridPreviewOptions {
 export const GRID_BUFFERING_DELAY_MS = 150;
 
 const IDLE_PREVIEW_STATE: GridPreviewSnapshot = {
+  cachedPoster: null,
   error: null,
   frame: null,
   hasPreviewStreams: false,
   streamId: null,
+  streamSourceName: null,
   streamSourceNames: [],
   status: "idle",
 } as const;
@@ -85,6 +92,8 @@ const IDLE_PREVIEW_STATE: GridPreviewSnapshot = {
  * advance playback from the last rendered frame.
  */
 export function useGridPreview({
+  cacheRequestKey = null,
+  cachedPoster = null,
   enabled = true,
   hovered = false,
   onReadResult,
@@ -96,7 +105,10 @@ export function useGridPreview({
   selectedSourceName,
   source,
 }: UseGridPreviewOptions): GridPreviewState {
-  const [state, setState] = useState<GridPreviewSnapshot>(IDLE_PREVIEW_STATE);
+  const [state, setState] = useState<GridPreviewSnapshot>(() =>
+    seededSnapshot(source, cachedPoster),
+  );
+  const [stateOwnerKey, setStateOwnerKey] = useState(cacheRequestKey);
   const [playing, setPlaying] = useState(false);
   // Bumped whenever the still-frame load below commits a fresh result
   // (a poster move included) — the hover loop depends on it so a poster
@@ -146,19 +158,15 @@ export function useGridPreview({
     nextStartTimeNsRef.current = undefined;
     finishBuffering();
     setPlaying(false);
-    setState(
-      source
-        ? {
-            error: null,
-            frame: null,
-            hasPreviewStreams: false,
-            streamId: null,
-            streamSourceNames: [],
-            status: "loading",
-          }
-        : IDLE_PREVIEW_STATE,
-    );
-  }, [finishBuffering, selectedSourceName, source]);
+    setStateOwnerKey(cacheRequestKey);
+    setState(seededSnapshot(source, cachedPoster));
+  }, [
+    cacheRequestKey,
+    cachedPoster,
+    finishBuffering,
+    selectedSourceName,
+    source,
+  ]);
 
   // This effect surfaces adapter failures and unsupported preview providers
   // without exposing format details to the grid.
@@ -166,30 +174,27 @@ export function useGridPreview({
     if (!source || previewSessionStatus === "idle") return;
     if (previewSessionStatus === "loading") {
       setState((current) =>
-        current.frame ? current : { ...current, status: "loading" },
+        current.frame || current.cachedPoster
+          ? current
+          : { ...current, status: "loading" },
       );
       return;
     }
     if (previewSessionStatus === "unavailable") {
-      setState({
-        error: null,
-        frame: null,
-        hasPreviewStreams: false,
-        streamId: null,
-        streamSourceNames: [],
-        status: "unavailable",
-      });
+      setState((current) =>
+        current.cachedPoster
+          ? current
+          : { ...IDLE_PREVIEW_STATE, status: "unavailable" },
+      );
       return;
     }
     if (previewSessionStatus === "error") {
-      setState({
+      setState((current) => ({
+        ...(current.cachedPoster
+          ? current
+          : { ...IDLE_PREVIEW_STATE, status: "error" as const }),
         error: previewSessionError ?? "Episode preview failed to open",
-        frame: null,
-        hasPreviewStreams: false,
-        streamId: null,
-        streamSourceNames: [],
-        status: "error",
-      });
+      }));
     }
   }, [previewSessionError, previewSessionStatus, source]);
 
@@ -242,7 +247,10 @@ export function useGridPreview({
           };
           frameTimeNsRef.current = result.frameTimeNs;
           nextStartTimeNsRef.current = result.nextStartTimeNs;
-          setState(snapshotFromResult(result));
+          setState((current) => ({
+            ...snapshotFromResult(result),
+            cachedPoster: current.cachedPoster,
+          }));
           setLoadGeneration((g) => g + 1);
         }
       })
@@ -251,14 +259,12 @@ export function useGridPreview({
           return;
         }
 
-        setState({
+        setState((current) => ({
+          ...(current.cachedPoster
+            ? current
+            : { ...IDLE_PREVIEW_STATE, status: "error" as const }),
           error: errorMessage(caughtError),
-          frame: null,
-          hasPreviewStreams: false,
-          streamId: null,
-          streamSourceNames: [],
-          status: "error",
-        });
+        }));
       })
       .finally(() => {
         if (active) {
@@ -365,7 +371,10 @@ export function useGridPreview({
 
           frameTimeNsRef.current = result.frameTimeNs;
           nextStartTimeNsRef.current = result.nextStartTimeNs;
-          setState(snapshotFromResult(result));
+          setState((current) => ({
+            ...snapshotFromResult(result),
+            cachedPoster: current.cachedPoster,
+          }));
           previousFrameTimeNs = result.frameTimeNs;
           presentedAtMs = performance.now();
         }
@@ -400,7 +409,31 @@ export function useGridPreview({
     state.status,
   ]);
 
-  return { ...state, isBuffering, pause, play };
+  const visibleState =
+    stateOwnerKey === cacheRequestKey
+      ? state
+      : seededSnapshot(source, cachedPoster);
+  return { ...visibleState, isBuffering, pause, play };
+}
+
+function seededSnapshot(
+  source: ByteSourceDescriptor | null,
+  cachedPoster: GridPosterCacheEntry | null,
+): GridPreviewSnapshot {
+  if (!source) return IDLE_PREVIEW_STATE;
+  if (!cachedPoster) {
+    return { ...IDLE_PREVIEW_STATE, status: "loading" };
+  }
+  return {
+    cachedPoster,
+    error: null,
+    frame: null,
+    hasPreviewStreams: cachedPoster.streamSourceNames.length > 0,
+    streamId: cachedPoster.streamId,
+    streamSourceName: cachedPoster.streamSourceName,
+    streamSourceNames: cachedPoster.streamSourceNames,
+    status: "ready",
+  };
 }
 
 function notifyReadResult(
@@ -509,10 +542,12 @@ function snapshotFromResult(
         }
       : frame;
   return {
+    cachedPoster: null,
     error: null,
     frame: timestampedFrame,
     hasPreviewStreams: result.streamSourceNames.length > 0,
     streamId: result.streamId,
+    streamSourceName: result.streamSourceName,
     streamSourceNames: result.streamSourceNames,
     status: result.status,
   };

--- a/app/packages/multimodal/src/views/episode/grid/use-grid-preview.ts
+++ b/app/packages/multimodal/src/views/episode/grid/use-grid-preview.ts
@@ -48,6 +48,7 @@ export interface GridPreviewState extends GridPreviewSnapshot {
  */
 export interface UseGridPreviewOptions {
   readonly cacheRequestKey?: string | null;
+  /** Snapshot for `cacheRequestKey`; keep its identity stable while the key is unchanged. */
   readonly cachedPoster?: GridPosterCacheEntry | null;
   readonly enabled?: boolean;
   /** Whether this tile is the user's current interactive target. */
@@ -110,6 +111,8 @@ export function useGridPreview({
   );
   const [stateOwnerKey, setStateOwnerKey] = useState(cacheRequestKey);
   const [playing, setPlaying] = useState(false);
+  const cachedPosterRef = useRef(cachedPoster);
+  cachedPosterRef.current = cachedPoster;
   // Bumped whenever the still-frame load below commits a fresh result
   // (a poster move included) — the hover loop depends on it so a poster
   // moving out from under an in-progress loop tears the stale loop down
@@ -159,14 +162,8 @@ export function useGridPreview({
     finishBuffering();
     setPlaying(false);
     setStateOwnerKey(cacheRequestKey);
-    setState(seededSnapshot(source, cachedPoster));
-  }, [
-    cacheRequestKey,
-    cachedPoster,
-    finishBuffering,
-    selectedSourceName,
-    source,
-  ]);
+    setState(seededSnapshot(source, cachedPosterRef.current));
+  }, [cacheRequestKey, finishBuffering, selectedSourceName, source]);
 
   // This effect surfaces adapter failures and unsupported preview providers
   // without exposing format details to the grid.
@@ -181,18 +178,12 @@ export function useGridPreview({
       return;
     }
     if (previewSessionStatus === "unavailable") {
-      setState((current) =>
-        current.cachedPoster
-          ? current
-          : { ...IDLE_PREVIEW_STATE, status: "unavailable" },
-      );
+      setState((current) => preservingCachedPoster(current, "unavailable"));
       return;
     }
     if (previewSessionStatus === "error") {
       setState((current) => ({
-        ...(current.cachedPoster
-          ? current
-          : { ...IDLE_PREVIEW_STATE, status: "error" as const }),
+        ...preservingCachedPoster(current, "error"),
         error: previewSessionError ?? "Episode preview failed to open",
       }));
     }
@@ -247,10 +238,7 @@ export function useGridPreview({
           };
           frameTimeNsRef.current = result.frameTimeNs;
           nextStartTimeNsRef.current = result.nextStartTimeNs;
-          setState((current) => ({
-            ...snapshotFromResult(result),
-            cachedPoster: current.cachedPoster,
-          }));
+          setState((current) => resultPreservingCachedPoster(current, result));
           setLoadGeneration((g) => g + 1);
         }
       })
@@ -260,9 +248,7 @@ export function useGridPreview({
         }
 
         setState((current) => ({
-          ...(current.cachedPoster
-            ? current
-            : { ...IDLE_PREVIEW_STATE, status: "error" as const }),
+          ...preservingCachedPoster(current, "error"),
           error: errorMessage(caughtError),
         }));
       })
@@ -371,10 +357,7 @@ export function useGridPreview({
 
           frameTimeNsRef.current = result.frameTimeNs;
           nextStartTimeNsRef.current = result.nextStartTimeNs;
-          setState((current) => ({
-            ...snapshotFromResult(result),
-            cachedPoster: current.cachedPoster,
-          }));
+          setState((current) => resultPreservingCachedPoster(current, result));
           previousFrameTimeNs = result.frameTimeNs;
           presentedAtMs = performance.now();
         }
@@ -433,6 +416,25 @@ function seededSnapshot(
     streamSourceName: cachedPoster.streamSourceName,
     streamSourceNames: cachedPoster.streamSourceNames,
     status: "ready",
+  };
+}
+
+function preservingCachedPoster(
+  current: GridPreviewSnapshot,
+  fallbackStatus: GridPreviewStatus,
+): GridPreviewSnapshot {
+  return current.cachedPoster
+    ? current
+    : { ...IDLE_PREVIEW_STATE, status: fallbackStatus };
+}
+
+function resultPreservingCachedPoster(
+  current: GridPreviewSnapshot,
+  result: EpisodePreviewReadResult,
+): GridPreviewSnapshot {
+  return {
+    ...snapshotFromResult(result),
+    cachedPoster: current.cachedPoster,
   };
 }
 

--- a/app/packages/multimodal/src/visualization/media-2d/BitmapImageView.test.tsx
+++ b/app/packages/multimodal/src/visualization/media-2d/BitmapImageView.test.tsx
@@ -742,8 +742,14 @@ describe("BitmapCanvasHost", () => {
     const context = sharedMockContext();
     const drawImage = vi.spyOn(context, "drawImage");
     const bitmap = fakeBitmap(100, 50);
+    const onCanvasCommitted = vi.fn();
 
-    const { container } = render(<BitmapCanvasHost bitmap={bitmap} />);
+    const { container } = render(
+      <BitmapCanvasHost
+        bitmap={bitmap}
+        onCanvasCommitted={onCanvasCommitted}
+      />,
+    );
 
     // Snapshots are rendered at the cell's CSS pixel size, so cover fit
     // degenerates to an exact 1:1 blit — no crop, no stretch.
@@ -752,6 +758,10 @@ describe("BitmapCanvasHost", () => {
     const canvas = container.querySelector("canvas");
     expect(canvas?.width).toBe(100);
     expect(canvas?.height).toBe(50);
+    expect(onCanvasCommitted).toHaveBeenCalledWith(canvas, {
+      height: 50,
+      width: 100,
+    });
   });
 
   it("closes the replaced bitmap on swap and the committed one on unmount", () => {

--- a/app/packages/multimodal/src/visualization/media-2d/BitmapImageView.test.tsx
+++ b/app/packages/multimodal/src/visualization/media-2d/BitmapImageView.test.tsx
@@ -764,6 +764,33 @@ describe("BitmapCanvasHost", () => {
     });
   });
 
+  it("reports a commit callback failure in development without failing display", () => {
+    stubElementSize(100, 50);
+    const context = sharedMockContext();
+    const drawImage = vi.spyOn(context, "drawImage");
+    const warning = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    const error = new Error("capture failed");
+
+    expect(() =>
+      render(
+        <BitmapCanvasHost
+          bitmap={fakeBitmap(100, 50)}
+          onCanvasCommitted={() => {
+            throw error;
+          }}
+        />,
+      ),
+    ).not.toThrow();
+
+    expect(drawImage).toHaveBeenCalledTimes(1);
+    expect(warning).toHaveBeenCalledWith(
+      "onCanvasCommitted threw; display draw is unaffected",
+      error,
+    );
+  });
+
   it("closes the replaced bitmap on swap and the committed one on unmount", () => {
     stubElementSize(100, 50);
     const first = fakeBitmap(10, 10);

--- a/app/packages/multimodal/src/visualization/media-2d/BitmapImageView.tsx
+++ b/app/packages/multimodal/src/visualization/media-2d/BitmapImageView.tsx
@@ -259,8 +259,7 @@ function useBitmapCanvas(
   const bitmapRef = useRef<CanvasDrawable | null>(null);
   const fitRef = useRef(fit);
   fitRef.current = fit;
-  const onCanvasCommittedRef = useRef(onCanvasCommitted);
-  onCanvasCommittedRef.current = onCanvasCommitted;
+  const onCanvasCommittedRef = useLatestRef(onCanvasCommitted);
 
   const draw = useCallback(() => {
     const canvas = canvasRef.current;
@@ -313,10 +312,16 @@ function useBitmapCanvas(
     context.drawImage(bitmap, rect.x, rect.y, rect.width, rect.height);
     try {
       onCanvasCommittedRef.current?.(canvas, { height, width });
-    } catch {
+    } catch (error) {
       // Poster capture is optional optimization work and cannot fail display.
+      if (import.meta.env.DEV) {
+        console.warn(
+          "onCanvasCommitted threw; display draw is unaffected",
+          error,
+        );
+      }
     }
-  }, [trackCssSize]);
+  }, [onCanvasCommittedRef, trackCssSize]);
 
   const commit = useCallback(
     (bitmap: CanvasDrawable | null) => {

--- a/app/packages/multimodal/src/visualization/media-2d/BitmapImageView.tsx
+++ b/app/packages/multimodal/src/visualization/media-2d/BitmapImageView.tsx
@@ -86,6 +86,15 @@ export interface BitmapImageViewProps {
    * decode — the contract annotation overlays position themselves by.
    */
   readonly onImageLoaded?: (width: number, height: number) => void;
+  /**
+   * Reports every successful display draw, including unchanged-bitmap redraws.
+   * Consumers must deduplicate and treat the canvas as read-only: resizing or
+   * drawing into it can synchronously trigger another display draw.
+   */
+  readonly onCanvasCommitted?: (
+    canvas: HTMLCanvasElement,
+    size: BitmapDrawSize,
+  ) => void;
   readonly style?: CSSProperties;
 }
 
@@ -97,6 +106,11 @@ export interface BitmapCanvasHostProps {
   readonly bitmap: ImageBitmap | null;
   readonly className?: string;
   readonly fit?: "contain" | "cover";
+  /** See `BitmapImageViewProps.onCanvasCommitted`. */
+  readonly onCanvasCommitted?: (
+    canvas: HTMLCanvasElement,
+    size: BitmapDrawSize,
+  ) => void;
   readonly role?: string;
   readonly style?: CSSProperties;
 }
@@ -115,6 +129,11 @@ export interface BitmapImageFrameViewProps {
   readonly onError?: (error: unknown) => void;
   readonly onBitmapRetainedBytesChange?: (retainedBytes: number) => void;
   readonly onImageLoaded?: (width: number, height: number) => void;
+  /** See `BitmapImageViewProps.onCanvasCommitted`. */
+  readonly onCanvasCommitted?: (
+    canvas: HTMLCanvasElement,
+    size: BitmapDrawSize,
+  ) => void;
   readonly style?: CSSProperties;
   /** Stable source/stream owner key for encoded-video decoder cleanup. */
   readonly videoSessionKey?: string;
@@ -227,7 +246,11 @@ export function bitmapDrawRect(
  * close-on-unmount), sizes the backing store to CSS pixels, and redraws
  * on layout or fit changes.
  */
-function useBitmapCanvas(fit: "contain" | "cover", trackCssSize = false) {
+function useBitmapCanvas(
+  fit: "contain" | "cover",
+  trackCssSize = false,
+  onCanvasCommitted?: BitmapImageViewProps["onCanvasCommitted"],
+) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const [cssSize, setCssSize] = useState<BitmapDrawSize | null>(null);
   // The committed bitmap — stays drawn until the NEXT commit lands, so
@@ -236,6 +259,8 @@ function useBitmapCanvas(fit: "contain" | "cover", trackCssSize = false) {
   const bitmapRef = useRef<CanvasDrawable | null>(null);
   const fitRef = useRef(fit);
   fitRef.current = fit;
+  const onCanvasCommittedRef = useRef(onCanvasCommitted);
+  onCanvasCommittedRef.current = onCanvasCommitted;
 
   const draw = useCallback(() => {
     const canvas = canvasRef.current;
@@ -286,6 +311,11 @@ function useBitmapCanvas(fit: "contain" | "cover", trackCssSize = false) {
     // frame's aspect never linger.
     context.clearRect(0, 0, width, height);
     context.drawImage(bitmap, rect.x, rect.y, rect.width, rect.height);
+    try {
+      onCanvasCommittedRef.current?.(canvas, { height, width });
+    } catch {
+      // Poster capture is optional optimization work and cannot fail display.
+    }
   }, [trackCssSize]);
 
   const commit = useCallback(
@@ -360,11 +390,16 @@ export function BitmapImageView({
   fit = "cover",
   mimeType,
   onBitmapRetainedBytesChange,
+  onCanvasCommitted,
   onError,
   onImageLoaded,
   style,
 }: BitmapImageViewProps) {
-  const { canvasRef, commit, cssSize } = useBitmapCanvas(fit, true);
+  const { canvasRef, commit, cssSize } = useBitmapCanvas(
+    fit,
+    true,
+    onCanvasCommitted,
+  );
   const decodeSize = useDebouncedBitmapDecodeSize(cssSize);
   const decoderRef = useRef<LatestEncodedBitmapDecoder | null>(null);
   if (decoderRef.current === null) {
@@ -436,6 +471,7 @@ export function BitmapImageFrameView({
   fit = "cover",
   frame,
   onBitmapRetainedBytesChange,
+  onCanvasCommitted,
   onError,
   onImageLoaded,
   style,
@@ -449,6 +485,7 @@ export function BitmapImageFrameView({
         fit={fit}
         onError={onError}
         onBitmapRetainedBytesChange={onBitmapRetainedBytesChange}
+        onCanvasCommitted={onCanvasCommitted}
         onImageLoaded={onImageLoaded}
         style={style}
         videoSessionKey={videoSessionKey}
@@ -463,6 +500,7 @@ export function BitmapImageFrameView({
       frame={frame}
       onError={onError}
       onBitmapRetainedBytesChange={onBitmapRetainedBytesChange}
+      onCanvasCommitted={onCanvasCommitted}
       onImageLoaded={onImageLoaded}
       style={style}
     />
@@ -474,6 +512,7 @@ export function BitmapImageFrameView({
       mimeType={frame.mimeType}
       onError={onError}
       onBitmapRetainedBytesChange={onBitmapRetainedBytesChange}
+      onCanvasCommitted={onCanvasCommitted}
       onImageLoaded={onImageLoaded}
       style={style}
     />
@@ -486,13 +525,14 @@ function BitmapEncodedVideoView({
   fit = "cover",
   onError,
   onBitmapRetainedBytesChange,
+  onCanvasCommitted,
   onImageLoaded,
   style,
   videoSessionKey,
 }: Omit<BitmapImageFrameViewProps, "frame"> & {
   readonly frame: EncodedVideoVisualization;
 }) {
-  const { canvasRef, commit } = useBitmapCanvas(fit);
+  const { canvasRef, commit } = useBitmapCanvas(fit, false, onCanvasCommitted);
   const onErrorRef = useLatestRef(onError);
   const onImageLoadedRef = useLatestRef(onImageLoaded);
   const onBitmapRetainedBytesChangeRef = useLatestRef(
@@ -675,12 +715,17 @@ function BitmapRawImageView({
   frame,
   onError,
   onBitmapRetainedBytesChange,
+  onCanvasCommitted,
   onImageLoaded,
   style,
 }: Omit<BitmapImageFrameViewProps, "frame"> & {
   readonly frame: RawImageVisualization;
 }) {
-  const { canvasRef, commit, cssSize } = useBitmapCanvas(fit, true);
+  const { canvasRef, commit, cssSize } = useBitmapCanvas(
+    fit,
+    true,
+    onCanvasCommitted,
+  );
   const previewSize = useDebouncedBitmapDecodeSize(cssSize);
   const onErrorRef = useLatestRef(onError);
   const onImageLoadedRef = useLatestRef(onImageLoaded);
@@ -988,10 +1033,11 @@ export function BitmapCanvasHost({
   bitmap,
   className,
   fit = "cover",
+  onCanvasCommitted,
   role = "img",
   style,
 }: BitmapCanvasHostProps) {
-  const { canvasRef, commit } = useBitmapCanvas(fit);
+  const { canvasRef, commit } = useBitmapCanvas(fit, false, onCanvasCommitted);
 
   // This layout effect adopts the incoming bitmap before paint: the
   // replaced bitmap is closed exactly once and the swap draws in the same


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

Add a page-session, byte-bounded LRU for tile-sized compressed MCAP posters. Grid tiles hydrate from a fresh cached poster after a virtualization remount, while hover playback and stale size, pose, stream, or match-poster state still use the normal preview session.

Poster encoding is asynchronous, bounded, and coalesced. The cache accounts for encoded bytes plus entry overhead and preserves image, raw-image, video, and point-cloud display semantics.

## 🧪 How is this patch tested? If it is not, please explain why.

- `yarn vitest run --coverage.enabled=false packages/multimodal/src/views/episode/grid/grid-poster-cache.test.ts packages/multimodal/src/views/episode/grid/grid-poster-codec.test.ts packages/multimodal/src/views/episode/grid/use-grid-preview.test.tsx packages/multimodal/src/views/episode/grid/GridRenderer.test.tsx packages/multimodal/src/testing/integration/GridRenderer.integration.test.tsx packages/multimodal/src/visualization/media-2d/BitmapImageView.test.tsx` (90 tests)
- `yarn workspace @fiftyone/multimodal check`
- Manual 800-sample MCAP grid pass: scrolled far enough to unmount hundreds of tiles, then returned to the top. The returning viewport recorded 46 cache hits with misses unchanged at 324 and 24 preview-session opens avoided. Hover playback still refreshed from the source, with no browser errors.

## Notes to Reviewer

Best reviewed commit-by-commit. The two `probe:` commits contain development-only cache diagnostics and can be dropped together.

## High Level Architecture

- Cache keys cover dataset, media field, source access identity, selected stream, and match-poster time/preferred stream.
- A two-worker encoder clones committed tile canvases, coalesces pending work per key, and stores WebP with PNG fallback.
- Tiles synchronously seed from the cache; size and point-cloud pose freshness decide whether a preview session must reopen.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

MCAP grid thumbnails now reappear immediately from a bounded in-memory poster cache when scrolling back through a dataset.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3747
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added poster caching for grid previews, enabling recently viewed image and point-cloud tiles to reappear instantly.
  - Reduced unnecessary preview-session activity when cached content is available.
  - Added automatic poster updates after image and point-cloud previews render.
  - Improved point-cloud previews by preserving camera position across cached snapshots and remounts.
  - Added efficient poster encoding with WebP support and PNG fallback.

- **Bug Fixes**
  - Improved preview loading behavior when cached content, source data, or viewing state changes.
  - Prevented stale cached posters from replacing newer preview content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->