### PR TITLE
Fix docs build: remove unused top-level ViewTarget re-export

### DIFF
--- a/app/packages/operators/src/index.ts
+++ b/app/packages/operators/src/index.ts
@@ -40,4 +40,3 @@ export {
   ViewTargetSelector,
   type ViewTargetMeta,
 } from "./ViewTargets";
-export { ViewTarget } from "./types";


### PR DESCRIPTION
`Build docs` fails on every PR since #8210: it re-exported `ViewTarget` from the operators package index, but the enum is already exported via the `types` namespace, and typedoc emits the duplicate export path as a `Reference` node — which `gen-docs.js` doesn't recognize (`Unknown fragment type: Reference`).

No code imports `ViewTarget` top-level (checked OSS and Enterprise: similarity-search deep-imports `@fiftyone/operators/src/types`, internal code imports `./types`), so the re-export is unused and safe to remove. Supersedes #8238 by fixing the export structure instead of the docs generator.

Tested: `app/gen-docs.sh` completes locally with unmodified `gen-docs.js`; the typedoc JSON contains zero `Reference` nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the `ViewTarget` export from the operators package’s public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3750
<!-- enterprise-sync-pr:end -->