### PR TITLE
embeddings-v2: hover feel, explore cursor, and run-card meta polish

### DIFF
--- a/app/packages/embeddings-v2/src/FacetCell.tsx
+++ b/app/packages/embeddings-v2/src/FacetCell.tsx
@@ -67,6 +67,9 @@ export interface FacetCellProps {
   /** Shared hover state; the card shows only when the hovered point is a
    * member of this cell */
   hover: HoverContent | null;
+  /** The live hovered hit — rings the point instantly, ahead of the card's
+   * dwell. Optional so extension-rendered cells opt in when ready. */
+  hoverHit?: HoverHit | null;
 }
 
 export default function FacetCell({
@@ -90,6 +93,7 @@ export default function FacetCell({
   hoverAction,
   registerChart,
   hover,
+  hoverHit = null,
 }: FacetCellProps) {
   const sceneRef = useRef<HTMLDivElement>(null);
   const setChart = useCallback(
@@ -99,6 +103,8 @@ export default function FacetCell({
 
   const label = [rowLabel, colLabel].filter((v) => v !== null).join(" · ");
   const showHover = hover != null && visible[hover.hit.index] === 1;
+  // Same membership rule as the card: a point rings only in its own cell
+  const showRing = hoverHit != null && visible[hoverHit.index] === 1;
 
   return (
     <div className="emb-facet-cell">
@@ -131,6 +137,12 @@ export default function FacetCell({
           onError={onError}
           onHover={onHover}
         />
+        {showRing && hoverHit && (
+          <span
+            className="emb-hover-ring"
+            style={{ left: hoverHit.x, top: hoverHit.y }}
+          />
+        )}
         {showHover && (
           <HoverCard
             content={hover}

--- a/app/packages/embeddings-v2/src/PlotView.tsx
+++ b/app/packages/embeddings-v2/src/PlotView.tsx
@@ -116,6 +116,7 @@ export default function PlotView({
     handleBackgroundClick,
     clearAll,
     hover,
+    hoverHit,
     handleHover,
     keepHover,
     features,
@@ -193,6 +194,7 @@ export default function PlotView({
         onHover: handleHover,
         onKeepHover: keepHover,
         hover,
+        hoverHit,
         hoverAction,
         registerChart,
       }
@@ -369,6 +371,7 @@ export default function PlotView({
                 hoverAction={shared.hoverAction}
                 registerChart={shared.registerChart}
                 hover={shared.hover}
+                hoverHit={shared.hoverHit}
               />
             </div>
           ))}

--- a/app/packages/embeddings-v2/src/RunCard.tsx
+++ b/app/packages/embeddings-v2/src/RunCard.tsx
@@ -20,7 +20,7 @@ import {
   TextColor,
   TextVariant,
 } from "@voxel51/voodo";
-import { Fragment, type CSSProperties, type ReactNode } from "react";
+import { type CSSProperties, type ReactNode } from "react";
 import "./panel.css";
 
 export interface RunCardStatus {
@@ -129,12 +129,14 @@ export function RunCard({
       {meta && meta.length > 0 && (
         <div className="emb-run-card-meta">
           {meta.map((item, index) => (
-            <Fragment key={index}>
+            // The dot travels with its segment: a narrow card wraps
+            // between segments, never inside one
+            <span className="emb-run-card-meta-item" key={index}>
               {index > 0 && <span className="emb-run-card-meta-dot" />}
               <Text variant={TextVariant.Md} color={TextColor.Tertiary}>
                 {item}
               </Text>
-            </Fragment>
+            </span>
           ))}
         </div>
       )}

--- a/app/packages/embeddings-v2/src/RunsList.test.tsx
+++ b/app/packages/embeddings-v2/src/RunsList.test.tsx
@@ -56,7 +56,7 @@ describe("RunsList", () => {
           run("viz_model", { timestamp: "2026-08-11T18:00:00Z" }),
           run("viz_precomputed", { model: null }),
         ]}
-        error={null}
+        actionError={null}
         onOpen={vi.fn()}
         onDelete={vi.fn()}
       />,

--- a/app/packages/embeddings-v2/src/RunsList.test.tsx
+++ b/app/packages/embeddings-v2/src/RunsList.test.tsx
@@ -47,6 +47,26 @@ describe("RunsList", () => {
     expect(screen.getByText("ground_truth patches")).toBeDefined();
   });
 
+  // The card spec: source segment "model (METHOD)" with a precomputed
+  // fallback, and a fixed-format "last updated MM/DD/YYYY"
+  it("describes each run's embeddings source and freshness", () => {
+    render(
+      <RunsList
+        runs={[
+          run("viz_model", { timestamp: "2026-08-11T18:00:00Z" }),
+          run("viz_precomputed", { model: null }),
+        ]}
+        error={null}
+        onOpen={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("clip-vit-base32-torch (UMAP)")).toBeDefined();
+    expect(screen.getByText("pre-computed embeddings (UMAP)")).toBeDefined();
+    expect(screen.getByText("last updated 08/11/2026")).toBeDefined();
+  });
+
   // Runs with 3D points are listed and open in the 2D plot; guards
   // against filtering them out of the list
   it("lists 3D runs and opens runs on click", () => {

--- a/app/packages/embeddings-v2/src/RunsList.tsx
+++ b/app/packages/embeddings-v2/src/RunsList.tsx
@@ -35,10 +35,28 @@ import type { VisualizationRun } from "./protocol";
 import { RunCard } from "./RunCard";
 import { UpsellBanner } from "./UpsellBanner";
 
+// MM/DD/YYYY per the card spec — a fixed format, not the viewer locale
 const formatTimestamp = (timestamp: string | null): string | null => {
   if (!timestamp) return null;
   const date = new Date(timestamp);
-  return Number.isNaN(date.getTime()) ? null : date.toLocaleDateString();
+  return Number.isNaN(date.getTime())
+    ? null
+    : date.toLocaleDateString("en-US", {
+        month: "2-digit",
+        day: "2-digit",
+        year: "numeric",
+      });
+};
+
+/** "clip-vit-base32-torch (UMAP)", or the precomputed fallback */
+const embeddingsSource = (run: VisualizationRun): string => {
+  const source = run.model ?? "pre-computed embeddings";
+  return run.method ? `${source} (${run.method.toUpperCase()})` : source;
+};
+
+const lastUpdated = (timestamp: string | null): string | null => {
+  const formatted = formatTimestamp(timestamp);
+  return formatted ? `last updated ${formatted}` : null;
 };
 
 export default function RunsList({
@@ -227,13 +245,13 @@ export default function RunsList({
                 }
                 meta={[
                   run.error,
-                  run.method,
                   // Same brain key semantics, very different plots —
                   // which granularity a run embeds must be readable
-                  // from the card
+                  // from the card. (The point count joins this segment
+                  // once runs record it.)
                   run.patchesField ? `${run.patchesField} patches` : "samples",
-                  run.model,
-                  formatTimestamp(run.timestamp),
+                  embeddingsSource(run),
+                  lastUpdated(run.timestamp),
                 ].filter((item): item is string => Boolean(item))}
                 onClick={
                   run.ready && !run.error

--- a/app/packages/embeddings-v2/src/extensions.ts
+++ b/app/packages/embeddings-v2/src/extensions.ts
@@ -168,6 +168,8 @@ export interface SharedPlotProps {
   onHover: (hit: HoverHit | null) => void;
   onKeepHover: () => void;
   hover: HoverContent | null;
+  /** The live hovered hit, before the card's dwell — anchors the ring. */
+  hoverHit: HoverHit | null;
   hoverAction: HoverAction | null;
   registerChart: (key: string, handle: EmbeddingsViewHandle | null) => void;
 }

--- a/app/packages/embeddings-v2/src/panel.css
+++ b/app/packages/embeddings-v2/src/panel.css
@@ -89,9 +89,26 @@
 
 .emb-run-card-meta {
   display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.25rem 0.625rem;
+  min-width: 0;
+}
+
+/* Segments wrap as units; only a segment longer than the whole card
+   ellipsizes */
+.emb-run-card-meta-item {
+  display: inline-flex;
   align-items: center;
   gap: 0.625rem;
+  max-width: 100%;
   min-width: 0;
+  white-space: nowrap;
+}
+
+.emb-run-card-meta-item > :last-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .emb-run-card-meta-dot {

--- a/app/packages/embeddings-v2/src/panel.css
+++ b/app/packages/embeddings-v2/src/panel.css
@@ -854,6 +854,21 @@
 
 /* --- Hover card --------------------------------------------------------- */
 
+/* Ring marking the hovered point itself — the card floats offset from
+   the cursor, so without it the subject of the card is ambiguous in a
+   dense cloud. Renders immediately on hover (the card waits for its
+   thumbnail to load). */
+.emb-hover-ring {
+  position: absolute;
+  z-index: 2;
+  width: 14px; /* rings the 6px point with breathing room */
+  height: 14px;
+  border: 2px solid var(--emb-fg);
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+}
+
 .emb-hover-card {
   position: absolute;
   z-index: 3;

--- a/app/packages/embeddings-v2/src/renderer/cameras/PlanarCamera.test.ts
+++ b/app/packages/embeddings-v2/src/renderer/cameras/PlanarCamera.test.ts
@@ -180,6 +180,13 @@ describe("PlanarCamera cursor", () => {
     pointer("pointerup", { pointerId: 1 });
     expect(element.style.cursor).toBe("grab");
 
+    // A cancelled drag (e.g. the browser reclaims the pointer) must
+    // release the cursor through the same path
+    pointer("pointerdown", { pointerId: 2, button: 0, offsetX: 50 });
+    expect(element.style.cursor).toBe("grabbing");
+    pointer("pointercancel", { pointerId: 2 });
+    expect(element.style.cursor).toBe("grab");
+
     camera.destroy();
   });
 });

--- a/app/packages/embeddings-v2/src/renderer/cameras/PlanarCamera.test.ts
+++ b/app/packages/embeddings-v2/src/renderer/cameras/PlanarCamera.test.ts
@@ -150,3 +150,36 @@ describe("PlanarCamera focus", () => {
     camera.destroy();
   });
 });
+
+describe("PlanarCamera cursor", () => {
+  // A drag shows the closed hand, then gives back the resting cursor,
+  // which the chart owns (crosshair in select, grab in explore)
+  it("borrows the cursor for the duration of a drag", () => {
+    const element = document.createElement("div");
+    // jsdom has no pointer capture; the pan handlers call it
+    element.setPointerCapture = vi.fn();
+    const camera = new PlanarCamera(element, vi.fn());
+    camera.setBounds(BOUNDS, 100, 100);
+    camera.setMode("explore");
+    element.style.cursor = "grab";
+
+    const pointer = (type: string, init: Record<string, unknown>) =>
+      element.dispatchEvent(Object.assign(new Event(type), init));
+
+    pointer("pointerdown", {
+      pointerId: 1,
+      button: 0,
+      offsetX: 50,
+      offsetY: 50,
+    });
+    expect(element.style.cursor).toBe("grabbing");
+
+    pointer("pointermove", { pointerId: 1, offsetX: 60, offsetY: 50 });
+    expect(element.style.cursor).toBe("grabbing");
+
+    pointer("pointerup", { pointerId: 1 });
+    expect(element.style.cursor).toBe("grab");
+
+    camera.destroy();
+  });
+});

--- a/app/packages/embeddings-v2/src/renderer/cameras/PlanarCamera.test.ts
+++ b/app/packages/embeddings-v2/src/renderer/cameras/PlanarCamera.test.ts
@@ -177,6 +177,18 @@ describe("PlanarCamera cursor", () => {
     pointer("pointermove", { pointerId: 1, offsetX: 60, offsetY: 50 });
     expect(element.style.cursor).toBe("grabbing");
 
+    // A second pointer mid-pan must not steal the pan: no second
+    // capture, and its release must not give the cursor back early
+    pointer("pointerdown", {
+      pointerId: 2,
+      button: 0,
+      offsetX: 60,
+      offsetY: 50,
+    });
+    expect(element.setPointerCapture).toHaveBeenCalledTimes(1);
+    pointer("pointerup", { pointerId: 2 });
+    expect(element.style.cursor).toBe("grabbing");
+
     pointer("pointerup", { pointerId: 1 });
     expect(element.style.cursor).toBe("grab");
 
@@ -188,5 +200,58 @@ describe("PlanarCamera cursor", () => {
     expect(element.style.cursor).toBe("grab");
 
     camera.destroy();
+  });
+
+  // The chart may re-own the cursor mid-pan (a mode change from another
+  // pointer): release must keep that newer value, not restore the
+  // pre-pan cursor over it
+  it("does not restore a pre-pan cursor over a mid-pan rewrite", () => {
+    const element = document.createElement("div");
+    element.setPointerCapture = vi.fn();
+    const camera = new PlanarCamera(element, vi.fn());
+    camera.setBounds(BOUNDS, 100, 100);
+    camera.setMode("explore");
+    element.style.cursor = "grab";
+
+    const pointer = (type: string, init: Record<string, unknown>) =>
+      element.dispatchEvent(Object.assign(new Event(type), init));
+
+    pointer("pointerdown", {
+      pointerId: 1,
+      button: 0,
+      offsetX: 50,
+      offsetY: 50,
+    });
+    expect(element.style.cursor).toBe("grabbing");
+    // What EmbeddingsChart.applyCursor does on a mid-pan mode change
+    element.style.cursor = "crosshair";
+    pointer("pointerup", { pointerId: 1 });
+    expect(element.style.cursor).toBe("crosshair");
+
+    camera.destroy();
+  });
+
+  // The container outlives the camera (adapter swaps): teardown during
+  // a pan must give the cursor back, not strand "grabbing"
+  it("restores the cursor when destroyed mid-pan", () => {
+    const element = document.createElement("div");
+    element.setPointerCapture = vi.fn();
+    const camera = new PlanarCamera(element, vi.fn());
+    camera.setBounds(BOUNDS, 100, 100);
+    camera.setMode("explore");
+    element.style.cursor = "grab";
+
+    element.dispatchEvent(
+      Object.assign(new Event("pointerdown"), {
+        pointerId: 1,
+        button: 0,
+        offsetX: 50,
+        offsetY: 50,
+      }),
+    );
+    expect(element.style.cursor).toBe("grabbing");
+
+    camera.destroy();
+    expect(element.style.cursor).toBe("grab");
   });
 });

--- a/app/packages/embeddings-v2/src/renderer/cameras/PlanarCamera.ts
+++ b/app/packages/embeddings-v2/src/renderer/cameras/PlanarCamera.ts
@@ -150,6 +150,9 @@ export class PlanarCamera implements CameraAdapter {
   }
 
   destroy(): void {
+    // The container outlives the camera (adapter swaps, chart teardown):
+    // a pan cut short by teardown must still give the cursor back
+    if (this.panPointer !== null) this.endPan();
     this.listeners.abort();
   }
 
@@ -223,7 +226,19 @@ export class PlanarCamera implements CameraAdapter {
 
   private handlePanEnd(event: PointerEvent): void {
     if (this.panPointer !== event.pointerId) return;
+    this.endPan();
+  }
+
+  /**
+   * Release the pan and give the cursor back — but only when the
+   * borrowed "grabbing" is still in place: if the chart re-owned the
+   * cursor mid-pan (a mode change), its value is newer than the one
+   * remembered at pan start.
+   */
+  private endPan(): void {
     this.panPointer = null;
-    this.element.style.cursor = this.cursorBefore;
+    if (this.element.style.cursor === "grabbing") {
+      this.element.style.cursor = this.cursorBefore;
+    }
   }
 }

--- a/app/packages/embeddings-v2/src/renderer/cameras/PlanarCamera.ts
+++ b/app/packages/embeddings-v2/src/renderer/cameras/PlanarCamera.ts
@@ -39,6 +39,8 @@ export class PlanarCamera implements CameraAdapter {
   private height = 1;
   private panPointer: number | null = null;
   private panLast: [number, number] = [0, 0];
+  // The chart owns the resting cursor; a drag only borrows it
+  private cursorBefore = "";
   private mode: InteractionMode = "select";
 
   constructor(element: HTMLElement, onChange: () => void) {
@@ -194,6 +196,8 @@ export class PlanarCamera implements CameraAdapter {
     event.preventDefault();
     this.panPointer = event.pointerId;
     this.panLast = [event.offsetX, event.offsetY];
+    this.cursorBefore = this.element.style.cursor;
+    this.element.style.cursor = "grabbing";
     this.element.setPointerCapture(event.pointerId);
   }
 
@@ -217,5 +221,6 @@ export class PlanarCamera implements CameraAdapter {
   private handlePanEnd(event: PointerEvent): void {
     if (this.panPointer !== event.pointerId) return;
     this.panPointer = null;
+    this.element.style.cursor = this.cursorBefore;
   }
 }

--- a/app/packages/embeddings-v2/src/renderer/cameras/PlanarCamera.ts
+++ b/app/packages/embeddings-v2/src/renderer/cameras/PlanarCamera.ts
@@ -189,6 +189,9 @@ export class PlanarCamera implements CameraAdapter {
   }
 
   private handlePanStart(event: PointerEvent): void {
+    // One pan at a time: a second pointer would overwrite the borrowed
+    // cursor and orphan the first pointer's restore
+    if (this.panPointer !== null) return;
     const pan =
       event.button === 1 ||
       (event.button === 0 && (event.shiftKey || this.mode === "explore"));

--- a/app/packages/embeddings-v2/src/renderer/constants.ts
+++ b/app/packages/embeddings-v2/src/renderer/constants.ts
@@ -57,10 +57,10 @@ export const DEFAULT_ZOOM = 0.9;
  * asks, 08-11) */
 export const MIN_ZOOM = 0.55;
 
-/** Pointer must sit still this long before a hover hit-test runs.
- * Short enough to feel live while gliding; it still gates the host's
- * per-hit sample-media fetches. */
-export const HOVER_DEBOUNCE_MS = 50;
+/** While the pointer moves, hover hit-tests run at most this often —
+ * a cost bound on the linear-scan pick at large point counts, and the
+ * cadence at which the host's card can change subjects. */
+export const HOVER_INTERVAL_MS = 50;
 
 /** Hover pick radius around the cursor, CSS px. Comfortably past the
  * point's own 6px footprint, so hover engages on approach rather than

--- a/app/packages/embeddings-v2/src/renderer/constants.ts
+++ b/app/packages/embeddings-v2/src/renderer/constants.ts
@@ -57,11 +57,15 @@ export const DEFAULT_ZOOM = 0.9;
  * asks, 08-11) */
 export const MIN_ZOOM = 0.55;
 
-/** Pointer must sit still this long before a hover hit-test runs */
-export const HOVER_DEBOUNCE_MS = 120;
+/** Pointer must sit still this long before a hover hit-test runs.
+ * Short enough to feel live while gliding; it still gates the host's
+ * per-hit sample-media fetches. */
+export const HOVER_DEBOUNCE_MS = 50;
 
-/** Hover pick radius around the cursor, CSS px */
-export const HOVER_RADIUS_PX = 8;
+/** Hover pick radius around the cursor, CSS px. Comfortably past the
+ * point's own 6px footprint, so hover engages on approach rather than
+ * only once the cursor covers the point. */
+export const HOVER_RADIUS_PX = 14;
 
 /** A press+release that travels no farther than this is a click, CSS px */
 export const CLICK_SLOP_PX = 4;

--- a/app/packages/embeddings-v2/src/renderer/interaction/HoverPicker.test.ts
+++ b/app/packages/embeddings-v2/src/renderer/interaction/HoverPicker.test.ts
@@ -157,6 +157,27 @@ describe("HoverPicker", () => {
     expect(onHover).toHaveBeenLastCalledWith(moved);
   });
 
+  // A drag moves the pointer without updating the remembered position
+  // (drag moves are filtered), so a post-drag wheel zoom used to
+  // hit-test the PRE-drag coordinate and ring the wrong point
+  it("forgets the pointer position when a drag starts", () => {
+    fire(container, "pointermove", { offsetX: 5, offsetY: 6 });
+    vi.advanceTimersByTime(HOVER_INTERVAL_MS);
+    expect(onHover).toHaveBeenLastCalledWith(HIT);
+
+    fire(container, "pointerdown", {});
+    fire(container, "pointerup", {});
+    pick.mockClear();
+    picker.viewChanged();
+    vi.advanceTimersByTime(HOVER_INTERVAL_MS);
+    expect(pick).not.toHaveBeenCalled();
+
+    // The next real movement re-seeds hovering
+    fire(container, "pointermove", { offsetX: 7, offsetY: 8 });
+    vi.advanceTimersByTime(HOVER_INTERVAL_MS);
+    expect(pick).toHaveBeenCalledExactlyOnceWith(7, 8);
+  });
+
   it("forgets the pointer position on reset (new data)", () => {
     fire(container, "pointermove", { offsetX: 5, offsetY: 6 });
     picker.reset();

--- a/app/packages/embeddings-v2/src/renderer/interaction/HoverPicker.test.ts
+++ b/app/packages/embeddings-v2/src/renderer/interaction/HoverPicker.test.ts
@@ -8,7 +8,7 @@ import {
   type Mock,
   vi,
 } from "vitest";
-import { HOVER_DEBOUNCE_MS } from "../constants";
+import { HOVER_INTERVAL_MS } from "../constants";
 import type { HoverHit } from "../types";
 import { HoverPicker } from "./HoverPicker";
 
@@ -57,47 +57,78 @@ describe("HoverPicker", () => {
     vi.useRealTimers();
   });
 
-  it("hit-tests only after the pointer settles", () => {
+  it("hit-tests at most once per interval, with the latest pointer", () => {
     fire(container, "pointermove", { offsetX: 5, offsetY: 6 });
+    fire(container, "pointermove", { offsetX: 7, offsetY: 8 });
     expect(pick).not.toHaveBeenCalled();
 
-    vi.advanceTimersByTime(HOVER_DEBOUNCE_MS);
-    expect(pick).toHaveBeenCalledExactlyOnceWith(5, 6);
+    vi.advanceTimersByTime(HOVER_INTERVAL_MS);
+    expect(pick).toHaveBeenCalledExactlyOnceWith(7, 8);
     expect(onHover).toHaveBeenCalledExactlyOnceWith(HIT);
   });
 
-  it("hides a shown hit the moment the pointer moves again", () => {
+  // The flicker bug: hand jitter over one point used to tear the hover
+  // down and remount it — the host must hear nothing at all
+  it("stays silent while the pointer jitters over the same point", () => {
     fire(container, "pointermove", { offsetX: 5, offsetY: 6 });
-    vi.advanceTimersByTime(HOVER_DEBOUNCE_MS);
-    expect(onHover).toHaveBeenLastCalledWith(HIT);
+    vi.advanceTimersByTime(HOVER_INTERVAL_MS);
+    expect(onHover).toHaveBeenCalledExactlyOnceWith(HIT);
 
-    fire(container, "pointermove", { offsetX: 7, offsetY: 8 });
+    fire(container, "pointermove", { offsetX: 6, offsetY: 6 });
+    vi.advanceTimersByTime(HOVER_INTERVAL_MS);
+    fire(container, "pointermove", { offsetX: 5, offsetY: 7 });
+    vi.advanceTimersByTime(HOVER_INTERVAL_MS);
+
+    expect(pick).toHaveBeenCalledTimes(3);
+    expect(onHover).toHaveBeenCalledTimes(1);
+  });
+
+  it("moves between points without a null in between", () => {
+    fire(container, "pointermove", { offsetX: 5, offsetY: 6 });
+    vi.advanceTimersByTime(HOVER_INTERVAL_MS);
+
+    const other: HoverHit = { index: 4, id: "def", label: "dog", x: 40, y: 41 };
+    pick.mockReturnValue(other);
+    fire(container, "pointermove", { offsetX: 40, offsetY: 41 });
+    vi.advanceTimersByTime(HOVER_INTERVAL_MS);
+
+    expect(onHover).toHaveBeenCalledTimes(2);
+    expect(onHover).toHaveBeenLastCalledWith(other);
+  });
+
+  it("clears once the pointer tests empty space", () => {
+    fire(container, "pointermove", { offsetX: 5, offsetY: 6 });
+    vi.advanceTimersByTime(HOVER_INTERVAL_MS);
+
+    pick.mockReturnValue(null);
+    fire(container, "pointermove", { offsetX: 90, offsetY: 90 });
+    vi.advanceTimersByTime(HOVER_INTERVAL_MS);
     expect(onHover).toHaveBeenLastCalledWith(null);
   });
 
   it("stays quiet when nothing is hit", () => {
     pick.mockReturnValue(null);
     fire(container, "pointermove", {});
-    vi.advanceTimersByTime(HOVER_DEBOUNCE_MS);
+    vi.advanceTimersByTime(HOVER_INTERVAL_MS);
     expect(onHover).not.toHaveBeenCalled();
   });
 
   it("ignores movement while buttons are down (camera drags)", () => {
     fire(container, "pointermove", { offsetX: 5, offsetY: 6, buttons: 1 });
-    vi.advanceTimersByTime(HOVER_DEBOUNCE_MS);
+    vi.advanceTimersByTime(HOVER_INTERVAL_MS);
     expect(pick).not.toHaveBeenCalled();
   });
 
   it("ignores movement while another interaction owns the pointer", () => {
     blocked = true;
     fire(container, "pointermove", {});
-    vi.advanceTimersByTime(HOVER_DEBOUNCE_MS);
+    vi.advanceTimersByTime(HOVER_INTERVAL_MS);
     expect(pick).not.toHaveBeenCalled();
   });
 
   it("clears on pointerdown and on pointerleave", () => {
     fire(container, "pointermove", { offsetX: 5, offsetY: 6 });
-    vi.advanceTimersByTime(HOVER_DEBOUNCE_MS);
+    vi.advanceTimersByTime(HOVER_INTERVAL_MS);
     expect(onHover).toHaveBeenLastCalledWith(HIT);
 
     fire(container, "pointerdown", {});
@@ -105,28 +136,31 @@ describe("HoverPicker", () => {
 
     fire(container, "pointerup", {});
     fire(container, "pointermove", { offsetX: 5, offsetY: 6 });
-    vi.advanceTimersByTime(HOVER_DEBOUNCE_MS);
+    vi.advanceTimersByTime(HOVER_INTERVAL_MS);
     expect(onHover).toHaveBeenLastCalledWith(HIT);
 
     fire(container, "pointerleave", {});
     expect(onHover).toHaveBeenLastCalledWith(null);
   });
 
-  it("re-tests after the view changes under a still pointer", () => {
+  // A wheel zoom moves the point under a still pointer: the same index
+  // at new screen coords must re-fire so the host re-anchors its ring
+  it("re-anchors when the camera moves under a still pointer", () => {
     fire(container, "pointermove", { offsetX: 5, offsetY: 6 });
-    vi.advanceTimersByTime(HOVER_DEBOUNCE_MS);
-    expect(pick).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(HOVER_INTERVAL_MS);
+    expect(onHover).toHaveBeenLastCalledWith(HIT);
 
-    // A wheel zoom: same pointer position, new projection
+    const moved = { ...HIT, x: 20, y: 24 };
+    pick.mockReturnValue(moved);
     picker.viewChanged();
-    vi.advanceTimersByTime(HOVER_DEBOUNCE_MS);
-    expect(pick).toHaveBeenCalledTimes(2);
+    vi.advanceTimersByTime(HOVER_INTERVAL_MS);
+    expect(onHover).toHaveBeenLastCalledWith(moved);
   });
 
   it("forgets the pointer position on reset (new data)", () => {
     fire(container, "pointermove", { offsetX: 5, offsetY: 6 });
     picker.reset();
-    vi.advanceTimersByTime(HOVER_DEBOUNCE_MS);
+    vi.advanceTimersByTime(HOVER_INTERVAL_MS);
     expect(pick).not.toHaveBeenCalled();
   });
 });

--- a/app/packages/embeddings-v2/src/renderer/interaction/HoverPicker.ts
+++ b/app/packages/embeddings-v2/src/renderer/interaction/HoverPicker.ts
@@ -24,7 +24,8 @@ export class HoverPicker {
   private readonly callbacks: HoverCallbacks;
   private readonly listeners = new AbortController();
   private handle: number | null = null;
-  /** Last idle pointer position (CSS px); null once the pointer leaves */
+  /** Last idle pointer position (CSS px); null once the pointer leaves
+   * or a drag starts (drag moves are filtered, so it would go stale) */
   private pointer: [number, number] | null = null;
   /** The hit the host is currently showing, for change detection */
   private shown: HoverHit | null = null;
@@ -37,6 +38,11 @@ export class HoverPicker {
       "pointerdown",
       () => {
         this.buttonsDown = true;
+        // Drag moves never update the position (the buttons filter
+        // below), so from here it describes where the pointer WAS — a
+        // post-drag viewChanged() must not hit-test the pre-drag spot.
+        // The next idle move re-seeds it.
+        this.pointer = null;
         this.clear();
       },
       { capture: true, signal },

--- a/app/packages/embeddings-v2/src/renderer/interaction/HoverPicker.ts
+++ b/app/packages/embeddings-v2/src/renderer/interaction/HoverPicker.ts
@@ -1,4 +1,4 @@
-import { HOVER_DEBOUNCE_MS } from "../constants";
+import { HOVER_INTERVAL_MS } from "../constants";
 import type { HoverHit } from "../types";
 
 interface HoverCallbacks {
@@ -11,12 +11,14 @@ interface HoverCallbacks {
 }
 
 /**
- * Debounced hover: any movement hides the current hit immediately; the
- * hit-test runs only after the pointer sits still for HOVER_DEBOUNCE_MS.
- * Camera drags never trigger it (buttons are tracked in capture phase so
- * this stays true even when other handlers stopPropagation), and camera
- * changes without pointer movement — wheel zooms — re-test after
- * settling via viewChanged().
+ * Throttled hover: while the pointer moves, hit-tests run at most once
+ * per HOVER_INTERVAL_MS, and the callback fires only when the result
+ * CHANGES — a new point, a miss after a hit, or the same point under a
+ * moved camera. Jitter over one point is silence, so the host's card
+ * never flickers. Camera drags never trigger it (buttons are tracked
+ * in capture phase so this stays true even when other handlers
+ * stopPropagation), and camera changes without pointer movement —
+ * wheel zooms — re-test via viewChanged().
  */
 export class HoverPicker {
   private readonly callbacks: HoverCallbacks;
@@ -24,7 +26,8 @@ export class HoverPicker {
   private handle: number | null = null;
   /** Last idle pointer position (CSS px); null once the pointer leaves */
   private pointer: [number, number] | null = null;
-  private hitShown = false;
+  /** The hit the host is currently showing, for change detection */
+  private shown: HoverHit | null = null;
   private buttonsDown = false;
 
   constructor(container: HTMLElement, callbacks: HoverCallbacks) {
@@ -83,20 +86,20 @@ export class HoverPicker {
     this.listeners.abort();
   }
 
-  /** Hide any current hit now, hit-test once the pointer settles */
+  /** Throttle: an already-pending test picks up the latest pointer */
   private schedule(): void {
-    this.clear();
-    if (!this.pointer) return;
+    if (this.handle !== null || !this.pointer) return;
     this.handle = window.setTimeout(() => {
       this.handle = null;
       this.hitTest();
-    }, HOVER_DEBOUNCE_MS);
+    }, HOVER_INTERVAL_MS);
   }
 
+  /** Interactions (drag, leave, new data) drop the hover instantly */
   private clear(): void {
     this.cancel();
-    if (this.hitShown) {
-      this.hitShown = false;
+    if (this.shown) {
+      this.shown = null;
       this.callbacks.onHover(null);
     }
   }
@@ -111,8 +114,25 @@ export class HoverPicker {
   private hitTest(): void {
     if (!this.pointer || this.callbacks.isBlocked()) return;
     const hit = this.callbacks.pick(this.pointer[0], this.pointer[1]);
-    if (!hit) return;
-    this.hitShown = true;
+    if (!hit) {
+      if (this.shown) {
+        this.shown = null;
+        this.callbacks.onHover(null);
+      }
+      return;
+    }
+    // Same point at the same projected spot: nothing changed for the
+    // host, so stay silent (a re-fire would remount the hover card).
+    // A moved camera changes x/y, which must re-fire to re-anchor.
+    if (
+      this.shown &&
+      this.shown.index === hit.index &&
+      this.shown.x === hit.x &&
+      this.shown.y === hit.y
+    ) {
+      return;
+    }
+    this.shown = hit;
     this.callbacks.onHover(hit);
   }
 }

--- a/app/packages/embeddings-v2/src/useHoverInfo.test.ts
+++ b/app/packages/embeddings-v2/src/useHoverInfo.test.ts
@@ -64,6 +64,7 @@ describe("useHoverInfo", () => {
   it("drops info that resolves after the pointer moved on", async () => {
     let release!: (value: SampleInfo) => void;
     vi.mocked(fetchSampleInfo)
+      .mockClear()
       .mockImplementationOnce(
         () => new Promise<SampleInfo>((res) => (release = res)),
       )
@@ -72,13 +73,39 @@ describe("useHoverInfo", () => {
       useHoverInfo("ds", "viz", null, mediaUrl),
     );
 
+    // Dwell out on point 1 so its fetch is genuinely in flight
     act(() => result.current.handleHover(hit(1)));
+    await waitFor(() => expect(fetchSampleInfo).toHaveBeenCalledTimes(1));
     act(() => result.current.handleHover(hit(2)));
     await waitFor(() => expect(result.current.hover).not.toBeNull());
 
     act(() => release(info(1)));
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(result.current.hover?.hit.index).toBe(2);
+  });
+
+  // The dense-cloud contract: gliding across points is free — only the
+  // point the pointer rests on gets fetched and carded
+  it("fetches nothing for points crossed without dwelling", async () => {
+    vi.mocked(fetchSampleInfo).mockClear().mockResolvedValue(info(3));
+    const { result } = renderHook(() =>
+      useHoverInfo("ds", "viz", null, mediaUrl),
+    );
+
+    act(() => result.current.handleHover(hit(1)));
+    act(() => result.current.handleHover(hit(2)));
+    act(() => result.current.handleHover(hit(3)));
+    // The ring saw every point instantly, the card none of them
+    expect(result.current.hoverHit?.index).toBe(3);
+    expect(result.current.hover).toBeNull();
+
+    await waitFor(() => expect(result.current.hover).not.toBeNull());
+    expect(fetchSampleInfo).toHaveBeenCalledExactlyOnceWith(
+      "ds",
+      "viz",
+      3,
+      null,
+    );
   });
 
   it("clears on hover-out", async () => {
@@ -133,9 +160,38 @@ describe("useHoverInfo", () => {
   // run — the stale response used to land because only the index matched
   it("drops an in-flight response that resolves after a run change", async () => {
     let resolveInfo: (value: ReturnType<typeof info>) => void = () => undefined;
-    vi.mocked(fetchSampleInfo).mockImplementationOnce(
-      () => new Promise((resolve) => (resolveInfo = resolve)),
+    vi.mocked(fetchSampleInfo)
+      .mockClear()
+      .mockImplementationOnce(
+        () => new Promise((resolve) => (resolveInfo = resolve)),
+      );
+    const { result, rerender } = renderHook(
+      ({ brainKey }: { brainKey: string }) =>
+        useHoverInfo("ds", brainKey, null, mediaUrl),
+      { initialProps: { brainKey: "viz" } },
     );
+
+    // Dwell out so the old run's fetch is genuinely in flight
+    act(() => result.current.handleHover(hit(1)));
+    await waitFor(() => expect(fetchSampleInfo).toHaveBeenCalledTimes(1));
+    rerender({ brainKey: "viz2" });
+    // Same index, new run: hover the new run's point 1 with a pending
+    // fetch, then let the OLD run's response arrive
+    vi.mocked(fetchSampleInfo).mockImplementationOnce(
+      () => new Promise(() => undefined),
+    );
+    act(() => result.current.handleHover(hit(1)));
+    await waitFor(() => expect(fetchSampleInfo).toHaveBeenCalledTimes(2));
+    await act(async () => {
+      resolveInfo(info(1));
+    });
+    expect(result.current.hover).toBeNull();
+  });
+
+  // A run switch mid-dwell: the pending timer and request key belong
+  // to the old run and must die with it — no stale card, no fetch
+  it("cancels a pending dwell when the run changes", async () => {
+    vi.mocked(fetchSampleInfo).mockClear().mockResolvedValue(info(1));
     const { result, rerender } = renderHook(
       ({ brainKey }: { brainKey: string }) =>
         useHoverInfo("ds", brainKey, null, mediaUrl),
@@ -144,15 +200,9 @@ describe("useHoverInfo", () => {
 
     act(() => result.current.handleHover(hit(1)));
     rerender({ brainKey: "viz2" });
-    // Same index, new run: hover the new run's point 1 with a pending
-    // fetch, then let the OLD run's response arrive
-    vi.mocked(fetchSampleInfo).mockImplementationOnce(
-      () => new Promise(() => undefined),
-    );
-    act(() => result.current.handleHover(hit(1)));
-    await act(async () => {
-      resolveInfo(info(1));
-    });
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    expect(fetchSampleInfo).not.toHaveBeenCalled();
     expect(result.current.hover).toBeNull();
   });
 

--- a/app/packages/embeddings-v2/src/useHoverInfo.test.ts
+++ b/app/packages/embeddings-v2/src/useHoverInfo.test.ts
@@ -156,6 +156,58 @@ describe("useHoverInfo", () => {
     expect(result.current.hover).not.toBeNull();
   });
 
+  // A camera move re-anchors the same point at new coords: a response
+  // requested at the OLD position must not paint the card there (same
+  // dataset/run/field/index — only the seq token can tell them apart)
+  it("drops a response that resolves after the point re-anchors", async () => {
+    let release!: (value: SampleInfo) => void;
+    // The fallback is a persistent implementation, NOT a queued once: a
+    // queued fallback this test never consumes would leak into the next
+    // test's fetch queue
+    vi.mocked(fetchSampleInfo)
+      .mockClear()
+      .mockImplementation(() => new Promise<SampleInfo>(() => undefined))
+      .mockImplementationOnce(
+        () => new Promise<SampleInfo>((res) => (release = res)),
+      );
+    const { result } = renderHook(() =>
+      useHoverInfo("ds", "viz", null, mediaUrl),
+    );
+
+    // Dwell out on point 1 so its fetch is genuinely in flight
+    act(() => result.current.handleHover(hit(1)));
+    await waitFor(() => expect(fetchSampleInfo).toHaveBeenCalledTimes(1));
+    // Same index, new projected position (wheel zoom under a still pointer)
+    act(() => result.current.handleHover({ ...hit(1), x: 30, y: 40 }));
+    await act(async () => release(info(1)));
+    expect(result.current.hover).toBeNull();
+  });
+
+  // Keyboard-driven color-by changes can land under a stationary
+  // pointer: the card (whose value line shows the field) must drop, the
+  // ring must stay, and the old field's in-flight response must die
+  it("invalidates the card when the color field changes", async () => {
+    let release!: (value: SampleInfo) => void;
+    vi.mocked(fetchSampleInfo)
+      .mockClear()
+      .mockImplementationOnce(
+        () => new Promise<SampleInfo>((res) => (release = res)),
+      );
+    const { result, rerender } = renderHook(
+      ({ field }: { field: string | null }) =>
+        useHoverInfo("ds", "viz", field, mediaUrl),
+      { initialProps: { field: "label" as string | null } },
+    );
+
+    act(() => result.current.handleHover(hit(1)));
+    await waitFor(() => expect(fetchSampleInfo).toHaveBeenCalledTimes(1));
+    rerender({ field: "other" });
+    await act(async () => release(info(1)));
+
+    expect(result.current.hover).toBeNull();
+    expect(result.current.hoverHit?.index).toBe(1);
+  });
+
   // The guard must be the FULL request identity: same index, previous
   // run — the stale response used to land because only the index matched
   it("drops an in-flight response that resolves after a run change", async () => {

--- a/app/packages/embeddings-v2/src/useHoverInfo.ts
+++ b/app/packages/embeddings-v2/src/useHoverInfo.ts
@@ -53,7 +53,11 @@ export function useHoverInfo(
       clearTimer.current = null;
     }
   }, []);
-  const hoverKeyRef = useRef<string | null>(null);
+  // Invalidation token for card work: bumped on every hover transition
+  // (a new point, a miss, the SAME point re-anchored by a camera move)
+  // and on run/field changes, so an older dwell or in-flight response
+  // can never paint the card — not even at a stale position
+  const hoverSeq = useRef(0);
   const dwellRef = useRef<number | null>(null);
   const infoCache = useRef(new Map<string, SampleInfo>());
 
@@ -65,15 +69,26 @@ export function useHoverInfo(
   }, []);
 
   // A new run reorders the wire, invalidating cached indices — and any
-  // in-flight dwell or fetch, whose key would still match hoverKeyRef
+  // in-flight dwell or fetch
   useEffect(() => {
     infoCache.current.clear();
+    hoverSeq.current++;
     cancelDwell();
     cancelClear();
-    hoverKeyRef.current = null;
     setHover(null);
     setHoverHit(null);
   }, [datasetName, brainKey]);
+
+  // The card's value line describes the color-by field: a field change
+  // under a stationary pointer (keyboard-driven — a mouse trip to the
+  // menu leaves the plot and clears the hover first) must drop the card
+  // and any in-flight fetch for the old field. The ring (hoverHit) is
+  // field-independent and stays; the next transition rebuilds the card.
+  useEffect(() => {
+    hoverSeq.current++;
+    cancelDwell();
+    setHover(null);
+  }, [colorField, cancelDwell]);
 
   useEffect(
     () => () => {
@@ -84,12 +99,13 @@ export function useHoverInfo(
   );
 
   const handleHover = (hit: HoverHit | null) => {
-    // Every transition restarts the dwell; jitter over one point never
-    // reaches here (the picker only reports changes)
+    // Every transition restarts the dwell and invalidates the previous
+    // card work; jitter over one point never reaches here (the picker
+    // only reports changes)
+    const seq = ++hoverSeq.current;
     cancelDwell();
     setHoverHit(hit);
     if (!hit || !datasetName || !brainKey) {
-      hoverKeyRef.current = null;
       // Grace-delay the clear so the pointer can reach the card's actions
       cancelClear();
       clearTimer.current = setTimeout(() => setHover(null), CLEAR_GRACE_MS);
@@ -97,13 +113,15 @@ export function useHoverInfo(
     }
 
     cancelClear();
-    // The FULL request identity: a response for the same index but a
-    // previous dataset/run/field must not land on the current hover
+    // The CACHE identity: dataset/run/field/index. The apply guard is
+    // the seq token, not this key — a camera move re-anchors the same
+    // point under the same key, and the old response's card must not
+    // paint at the old position
     const key = `${datasetName}::${brainKey}::${colorField ?? ""}::${hit.index}`;
-    hoverKeyRef.current = key;
     const apply = (info: SampleInfo) => {
-      // The pointer (or the run) may have moved on while this resolved
-      if (hoverKeyRef.current !== key) return;
+      // The pointer, the camera, the run, or the field may have moved
+      // on while this resolved
+      if (hoverSeq.current !== seq) return;
 
       let value: HoverContent["value"] = null;
       if (info.value !== null && info.value !== undefined) {

--- a/app/packages/embeddings-v2/src/useHoverInfo.ts
+++ b/app/packages/embeddings-v2/src/useHoverInfo.ts
@@ -4,6 +4,14 @@ import { fetchSampleInfo, type SampleInfo } from "./protocol";
 import type { HoverHit } from "./renderer";
 
 /**
+ * A hit must survive this long before the card commits to it. The ring
+ * (hoverHit) tracks instantly; fetching and showing a card for every
+ * point crossed while gliding over a dense cloud would hammer the
+ * network and flicker the card.
+ */
+const CARD_DWELL_MS = 125;
+
+/**
  * Hover -> lazy sample info, cached per run/field/index. `mediaUrl`
  * maps a server media path to a browser URL (the App's getSampleSrc)
  * — injected because URL resolution is deployment-specific.
@@ -17,19 +25,23 @@ export function useHoverInfo(
   mediaUrl: (media: string) => string,
   pointSwatch?: (index: number) => string | null,
   /** Builds hover content SYNCHRONOUSLY from data the client already holds,
-   * skipping the sample-info fetch. A run whose media is expensive to fetch
+   * skipping the sample-info fetch — and the card dwell, which exists to
+   * protect the network path. A run whose media is expensive to fetch
    * and decode (an extension-owned run reading its own storage) shows cheap
    * per-point detail instead of an image. Returns null to fall through to
    * the normal fetch path. */
   localDetail?: (hit: HoverHit) => HoverContent | null,
 ): {
   hover: HoverContent | null;
+  /** The live hit, before the card's dwell — anchors the hover ring */
+  hoverHit: HoverHit | null;
   handleHover: (hit: HoverHit | null) => void;
   /** Cancels a pending clear — call when the pointer enters the hover card,
    * so moving from the point onto the card's actions doesn't dismiss it */
   keepHover: () => void;
 } {
   const [hover, setHover] = useState<HoverContent | null>(null);
+  const [hoverHit, setHoverHit] = useState<HoverHit | null>(null);
   // The card doesn't vanish the instant the pointer leaves a point: a short
   // grace lets the pointer cross the gap onto the card to click an action
   const clearTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -41,17 +53,41 @@ export function useHoverInfo(
       clearTimer.current = null;
     }
   }, []);
-  useEffect(() => () => cancelClear(), []);
   const hoverKeyRef = useRef<string | null>(null);
+  const dwellRef = useRef<number | null>(null);
   const infoCache = useRef(new Map<string, SampleInfo>());
 
-  // A new run reorders the wire, invalidating cached indices
+  const cancelDwell = useCallback(() => {
+    if (dwellRef.current !== null) {
+      window.clearTimeout(dwellRef.current);
+      dwellRef.current = null;
+    }
+  }, []);
+
+  // A new run reorders the wire, invalidating cached indices — and any
+  // in-flight dwell or fetch, whose key would still match hoverKeyRef
   useEffect(() => {
     infoCache.current.clear();
+    cancelDwell();
+    cancelClear();
+    hoverKeyRef.current = null;
     setHover(null);
+    setHoverHit(null);
   }, [datasetName, brainKey]);
 
+  useEffect(
+    () => () => {
+      cancelDwell();
+      cancelClear();
+    },
+    [],
+  );
+
   const handleHover = (hit: HoverHit | null) => {
+    // Every transition restarts the dwell; jitter over one point never
+    // reaches here (the picker only reports changes)
+    cancelDwell();
+    setHoverHit(hit);
     if (!hit || !datasetName || !brainKey) {
       hoverKeyRef.current = null;
       // Grace-delay the clear so the pointer can reach the card's actions
@@ -89,27 +125,33 @@ export function useHoverInfo(
       });
     };
 
-    // Client-side detail wins: no request, no media decode
+    // Client-side detail wins: no request, no media decode — and no dwell,
+    // which only exists to protect the fetch path
     const local = localDetail?.(hit);
     if (local) {
       setHover(local);
       return;
     }
 
-    const cached = infoCache.current.get(key);
-    if (cached) {
-      apply(cached);
-      return;
-    }
-    fetchSampleInfo(datasetName, brainKey, hit.index, colorField)
-      .then((info) => {
-        infoCache.current.set(key, info);
-        apply(info);
-      })
-      .catch(() => undefined);
+    // The old card describes the old point
+    setHover(null);
+    dwellRef.current = window.setTimeout(() => {
+      dwellRef.current = null;
+      const cached = infoCache.current.get(key);
+      if (cached) {
+        apply(cached);
+        return;
+      }
+      fetchSampleInfo(datasetName, brainKey, hit.index, colorField)
+        .then((info) => {
+          infoCache.current.set(key, info);
+          apply(info);
+        })
+        .catch(() => undefined);
+    }, CARD_DWELL_MS);
   };
 
-  return { hover, handleHover, keepHover: cancelClear };
+  return { hover, hoverHit, handleHover, keepHover: cancelClear };
 }
 
 /** How long the card survives the pointer leaving a point. */

--- a/app/packages/embeddings-v2/src/useRunPlotData.ts
+++ b/app/packages/embeddings-v2/src/useRunPlotData.ts
@@ -128,6 +128,8 @@ export interface RunPlotData {
 
   // Hover
   hover: ReturnType<typeof useHoverInfo>["hover"];
+  /** The live hit, before the card's dwell — anchors the hover ring */
+  hoverHit: ReturnType<typeof useHoverInfo>["hoverHit"];
   handleHover: ReturnType<typeof useHoverInfo>["handleHover"];
   keepHover: () => void;
 
@@ -514,7 +516,7 @@ export function useRunPlotData(
       : categoryCss(palette, valueIndex);
   };
 
-  const { hover, handleHover, keepHover } = useHoverInfo(
+  const { hover, hoverHit, handleHover, keepHover } = useHoverInfo(
     datasetName,
     brainKey,
     colorField,
@@ -786,6 +788,7 @@ export function useRunPlotData(
     handleBackgroundClick,
     clearAll,
     hover,
+    hoverHit,
     handleHover,
     keepHover,
     features,


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link (Jira: FOEPD-4405, FOEPD-4406, FOEPD-4435). Supersedes #8228.

## 📋 What changes are proposed in this pull request?

Rebuild of #8228 on top of the panel seam (#8178), which restructured PlotView and the hover path while that PR was in review. Same content, re-expressed against the new architecture:

- **FOEPD-4405** — grabbing cursor during camera drags
- **FOEPD-4406** — hover rebuilt: an instant ring on the hovered point (14px pick radius, transition-only picker callbacks), with the info card committing only after a 125ms dwell, so gliding across a dense cloud neither flickers the card nor hammers the sample-info route
- **FOEPD-4435** — run-card meta line (`<field> patches · <model> (<method>) · last updated <date>`)

How this composes with #8178's hover features (the part worth reviewing closely):

- `localDetail` stays synchronous — extension-owned runs skip both the fetch and the dwell
- the 260ms leave-grace and `keepHover` are preserved; note that crossing another point on the way to the card clears it immediately (the dwell treats a new point as a new subject). On dense plots this makes card actions hard to reach — flagged here as an open product question rather than decided
- `hoverHit` threads through `useRunPlotData` → `SharedPlotProps` → `FacetCell`; the `FacetCell` prop is optional, so extension-rendered cells compile unchanged and can adopt the ring when ready
- the ring renders per-cell under the same membership gate as the card

Carried over from #8228 review: the `run.timestamp` question (whether "last updated" populates for all runs) is still open — the meta segment drops silently when the timestamp is null.

## 🧪 How is this patch tested? If it is not, please explain why.

- The package suite (286 tests) passes, including the union of this PR's hover tests and #8178's — both sets' pinned behaviors hold unmodified (dwell gating, run-switch invalidation, synchronous `localDetail`, `keepHover` grace)
- Manual: ring tracks instantly while the card waits out its dwell; no sample-info requests while gliding; the card survives pointer travel across empty space and stays while hovered; grabbing cursor during drags; run-card meta line renders

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

Embeddings panel polish: hovered points are highlighted with a ring and the info card no longer flickers while moving across dense plots, camera drags show a grabbing cursor, and run cards show their source, model, and last-updated details.

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a visible ring highlighting the currently hovered point on embedding plots.
  * Improved hover interactions with smoother tracking, a larger hit area, and delayed detail cards to reduce unnecessary loading.
  * Added clearer run metadata, including method, model or precomputed status, update date, and granularity.

* **Bug Fixes**
  * Preserved and restored the chart cursor correctly during panning.
  * Improved metadata wrapping so separated items remain readable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3751
<!-- enterprise-sync-pr:end -->