### PR TITLE
[TEAMS-2523] support ToPatches for grouped datasets

### DIFF
--- a/app/packages/state/src/hooks/resolveActiveGroupSliceForView.test.ts
+++ b/app/packages/state/src/hooks/resolveActiveGroupSliceForView.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+vi.mock("recoil");
+vi.mock("recoil-relay");
+
+import type { Snapshot } from "recoil";
+import { getValue, setMockAtoms } from "../../../../__mocks__/recoil";
+import type { State } from "../recoil";
+import resolveActiveGroupSliceForView from "./resolveActiveGroupSliceForView";
+
+const SELECT_GROUP_SLICES = "fiftyone.core.stages.SelectGroupSlices";
+
+const LIMIT: State.Stage = {
+  _cls: "fiftyone.core.stages.Limit",
+  kwargs: [["limit", 3]],
+};
+
+const snapshot = {
+  getPromise: async (atom) => getValue(atom),
+} as unknown as Snapshot;
+
+describe("resolveActiveGroupSliceForView", () => {
+  it("selects the active slice for grouped views", async () => {
+    setMockAtoms({
+      isGroup: true,
+      groupSlice: "left",
+      _view__setter: [LIMIT],
+    });
+
+    const { slice, updater } = await resolveActiveGroupSliceForView(snapshot);
+    expect(slice).toBeNull();
+    expect(updater([LIMIT])).toEqual([
+      LIMIT,
+      {
+        _cls: SELECT_GROUP_SLICES,
+        kwargs: [
+          ["slices", "left"],
+          ["media_type", null],
+          ["flat", true],
+        ],
+      },
+    ]);
+  });
+
+  it("makes no change when the view has a SelectGroupSlices stage", async () => {
+    const stage: State.Stage = {
+      _cls: SELECT_GROUP_SLICES,
+      kwargs: [["slices", "left"]],
+    };
+    setMockAtoms({
+      isGroup: true,
+      groupSlice: "left",
+      _view__setter: [stage],
+    });
+
+    const { slice, updater } = await resolveActiveGroupSliceForView(snapshot);
+    expect(slice).toBe("left");
+    expect(updater([stage])).toEqual([stage]);
+  });
+
+  it("makes no change for non-grouped datasets", async () => {
+    setMockAtoms({
+      isGroup: false,
+      groupSlice: null,
+      _view__setter: [LIMIT],
+    });
+
+    const { slice, updater } = await resolveActiveGroupSliceForView(snapshot);
+    expect(slice).toBeNull();
+    expect(updater([LIMIT])).toEqual([LIMIT]);
+  });
+});

--- a/app/packages/state/src/hooks/resolveActiveGroupSliceForView.ts
+++ b/app/packages/state/src/hooks/resolveActiveGroupSliceForView.ts
@@ -1,0 +1,44 @@
+import type { Snapshot } from "recoil";
+import { groupSlice, isGroup, view } from "../recoil";
+import type { State } from "../recoil";
+
+const SELECT_GROUP_SLICES = "fiftyone.core.stages.SelectGroupSlices";
+
+/**
+ * Conversion stages (e.g. ToPatches) require a flattened collection, so
+ * grouped views without a SelectGroupSlices stage have one appended for the
+ * active slice. Otherwise the view and form slice are unchanged
+ */
+export default async function resolveActiveGroupSliceForView(
+  snapshot: Snapshot,
+): Promise<{
+  slice: string | null;
+  updater: (stages: State.Stage[]) => State.Stage[];
+}> {
+  const slice = await snapshot.getPromise(groupSlice);
+  const group = await snapshot.getPromise(isGroup);
+  const stages = await snapshot.getPromise(view);
+
+  if (
+    !group ||
+    !slice ||
+    stages?.some(({ _cls }) => _cls === SELECT_GROUP_SLICES)
+  ) {
+    return { slice, updater: (v) => v };
+  }
+
+  return {
+    slice: null,
+    updater: (v) => [
+      ...v,
+      {
+        _cls: SELECT_GROUP_SLICES,
+        kwargs: [
+          ["slices", slice],
+          ["media_type", null],
+          ["flat", true],
+        ],
+      },
+    ],
+  };
+}

--- a/app/packages/state/src/hooks/useToEvaluationPatches.ts
+++ b/app/packages/state/src/hooks/useToEvaluationPatches.ts
@@ -3,18 +3,20 @@ import { useRecoilCallback } from "recoil";
 import {
   extendedStages,
   filters,
-  groupSlice,
   patching,
   selectedSamples,
   view,
   viewStateForm_INTERNAL,
 } from "../recoil";
+import resolveActiveGroupSliceForView from "./resolveActiveGroupSliceForView";
 
 export default function useToEvaluationPatches() {
   return useRecoilCallback(
     ({ set, snapshot }) =>
       async (evaluation) => {
         set(patching, true);
+        const { slice, updater } =
+          await resolveActiveGroupSliceForView(snapshot);
         set(viewStateForm_INTERNAL, {
           addStages: [
             {
@@ -25,14 +27,14 @@ export default function useToEvaluationPatches() {
               ],
             },
           ],
-          slice: await snapshot.getPromise(groupSlice),
+          slice,
           filters: await snapshot.getPromise(filters),
           extended: await snapshot.getPromise(extendedStages),
           sampleIds: Array.from(
             (await snapshot.getPromise(selectedSamples)).keys(),
           ),
         });
-        set(view, (v) => v);
+        set(view, updater);
         const unsubscribe = subscribe((_, { reset, set }) => {
           reset(viewStateForm_INTERNAL);
           set(patching, false);

--- a/app/packages/state/src/hooks/useToPatches.ts
+++ b/app/packages/state/src/hooks/useToPatches.ts
@@ -4,18 +4,20 @@ import {
   _activeFields,
   extendedStages,
   filters,
-  groupSlice,
   patching,
   selectedSamples,
   view,
   viewStateForm_INTERNAL,
 } from "../recoil";
+import resolveActiveGroupSliceForView from "./resolveActiveGroupSliceForView";
 
 export default function useToPatches() {
   return useRecoilCallback(
     ({ set, snapshot }) =>
       async (field) => {
         set(patching, true);
+        const { slice, updater } =
+          await resolveActiveGroupSliceForView(snapshot);
         set(viewStateForm_INTERNAL, {
           addStages: [
             {
@@ -26,14 +28,14 @@ export default function useToPatches() {
               ],
             },
           ],
-          slice: await snapshot.getPromise(groupSlice),
+          slice,
           filters: await snapshot.getPromise(filters),
           extended: await snapshot.getPromise(extendedStages),
           sampleIds: Array.from(
             (await snapshot.getPromise(selectedSamples)).keys(),
           ),
         });
-        set(view, (v) => v);
+        set(view, updater);
 
         const unsubscribe = subscribe((_, { reset, set, get }) => {
           reset(viewStateForm_INTERNAL);


### PR DESCRIPTION
<!--
Community contributors: target the `community` branch, not `develop`. PRs from
non-members are auto-retargeted to `community`. See CONTRIBUTING.md:
https://github.com/voxel51/fiftyone/blob/develop/CONTRIBUTING.md#community-pull-requests
-->

## 🔗 Related Issues

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->

## 📋 What changes are proposed in this pull request?

Automatically select the active slice for grouped datasets for ToPatches if no SelectGroupSlice already applied

## 🧪 How is this patch tested? If it is not, please explain why.

- add tests
- 

https://github.com/user-attachments/assets/54057bcf-b3f8-400a-acb6-f5ba8f46363a



## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed grouped views so active group selections are correctly applied when generating updates.
  * Prevented active group selections from being lost when view stages are processed.
  * Preserved existing group-selection stages without adding duplicates.
  * Ensured non-grouped views continue to behave unchanged.

* **Tests**
  * Added coverage for grouped views with and without existing group-selection stages, as well as non-grouped views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3757
<!-- enterprise-sync-pr:end -->