### PR TITLE
Remove Vite-only episode grid diagnostics

### DIFF
--- a/app/packages/multimodal/src/views/episode/grid/GridRenderer.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/GridRenderer.tsx
@@ -190,13 +190,6 @@ export function GridRenderer({
     visible,
     setHovered,
   );
-  const gridPosterDisplay = import.meta.env.DEV
-    ? preview.cachedPoster && !preview.frame
-      ? "cache"
-      : preview.frame
-        ? "source"
-        : "empty"
-    : undefined;
   const [surfaceRetention, setSurfaceRetention] = useState<{
     readonly bytes: number;
     readonly owner: EpisodePosterFrame | GridPosterCacheEntry;
@@ -284,7 +277,6 @@ export function GridRenderer({
   return (
     <div
       className={rootClassName}
-      data-grid-poster-display={gridPosterDisplay}
       onClick={gridActivationHandler}
       onContextMenu={gridActivationHandler}
       onPointerEnter={playbackIntent.enter}

--- a/app/packages/multimodal/src/views/episode/grid/grid-poster-cache.ts
+++ b/app/packages/multimodal/src/views/episode/grid/grid-poster-cache.ts
@@ -307,22 +307,3 @@ function normalizePositiveInteger(value: number, fallback: number): number {
 function serializeGridPosterKey(parts: readonly (string | null)[]): string {
   return JSON.stringify(parts);
 }
-
-if (import.meta.env.DEV && typeof window !== "undefined") {
-  Object.defineProperty(
-    window as Window & {
-      __FIFTYONE_GRID_POSTER_CACHE__?: {
-        clear(): void;
-        stats(): GridPosterCacheStats;
-      };
-    },
-    "__FIFTYONE_GRID_POSTER_CACHE__",
-    {
-      configurable: true,
-      value: {
-        clear: clearGridPosterCache,
-        stats: () => getGridPosterCache().stats(),
-      },
-    },
-  );
-}

--- a/app/packages/multimodal/src/visualization/media-2d/BitmapImageView.test.tsx
+++ b/app/packages/multimodal/src/visualization/media-2d/BitmapImageView.test.tsx
@@ -764,7 +764,7 @@ describe("BitmapCanvasHost", () => {
     });
   });
 
-  it("reports a commit callback failure in development without failing display", () => {
+  it("reports a commit callback failure without failing display", () => {
     stubElementSize(100, 50);
     const context = sharedMockContext();
     const drawImage = vi.spyOn(context, "drawImage");

--- a/app/packages/multimodal/src/visualization/media-2d/BitmapImageView.tsx
+++ b/app/packages/multimodal/src/visualization/media-2d/BitmapImageView.tsx
@@ -314,12 +314,10 @@ function useBitmapCanvas(
       onCanvasCommittedRef.current?.(canvas, { height, width });
     } catch (error) {
       // Poster capture is optional optimization work and cannot fail display.
-      if (import.meta.env.DEV) {
-        console.warn(
-          "onCanvasCommitted threw; display draw is unaffected",
-          error,
-        );
-      }
+      console.warn(
+        "onCanvasCommitted threw; display draw is unaffected",
+        error,
+      );
     }
   }, [onCanvasCommittedRef, trackCssSize]);
 


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

Remove unused episode-grid diagnostics that depend on `import.meta.env.DEV`. The Vite-only check throws when `@fiftyone/multimodal` is bundled by Next.js because `import.meta.env` is undefined.

This removes the unused grid source attribute and global cache debug hook. Poster-capture failures remain non-fatal and now report without a bundler-specific environment check.

## 🧪 How is this patch tested? If it is not, please explain why.

- `yarn vitest run --no-coverage packages/multimodal/src/views/episode/grid/grid-poster-cache.test.ts packages/multimodal/src/views/episode/grid/GridRenderer.test.tsx packages/multimodal/src/visualization/media-2d/BitmapImageView.test.tsx packages/multimodal/src/testing/integration/GridRenderer.integration.test.tsx`
- `yarn workspace @fiftyone/multimodal check:types`
- `yarn prettier --check` on the four changed files
- Loaded an MCAP dataset in Enterprise and confirmed custom grid thumbnails render without renderer failover

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

N/A

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image rendering reliability when canvas completion callbacks encounter errors.
  * Rendering and preview behavior remain unchanged in normal use.

* **Refactor**
  * Removed development-only grid display diagnostics and cache inspection hooks.
  * Simplified internal rendering and media-view behavior without changing the end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3765
<!-- enterprise-sync-pr:end -->