### PR TITLE
Fix flaky test_date_fields timeout caused by freezegun force-importing lazy modules

### DIFF
--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -19,12 +19,17 @@ from functools import partial
 from unittest.mock import patch
 
 import eta.core.utils as etau
+import freezegun
 import numpy as np
 import pytz
 from bson import ObjectId
 from decorators import drop_datasets, skip_windows
 from freezegun import freeze_time
 from mongoengine import ValidationError
+
+# freezegun scans `sys.modules` attributes when (un)patching time functions,
+# which force-imports lazy modules like `transformers` and can take minutes
+freezegun.configure(extend_ignore_list=["torch", "transformers"])
 
 import fiftyone as fo
 import fiftyone.core.fields as fof


### PR DESCRIPTION
## What changes are proposed in this pull request?

Configures freezegun to ignore `torch` and `transformers` in `tests/unittests/dataset_tests.py`.

`test_date_fields` intermittently hits the 120s `pytest-timeout` limit on Python 3.14 CI legs. The test body itself is fast — the time is spent inside `freeze_time(...).__exit__`: freezegun's `stop()` walks every module in `sys.modules` and `getattr`s their attributes to restore the patched time functions. `transformers` is a `_LazyModule`, so each `getattr` triggers a real import — pulling in the whole model zoo, including `transformers/integrations/bitnet.py`, which runs `@torch.compile` at import time and drags in the full `torch._dynamo`/`torch._inductor` stack. On recent transformers/torch wheels that avalanche can exceed the timeout budget, so the test flakes depending on runner load.

Adding the two packages to freezegun's ignore list skips them during both patch and unpatch, eliminating the forced imports. Neither package needs frozen time in this test.

## How is this patch tested?

`pytest tests/unittests/dataset_tests.py::DatasetTests::test_date_fields` passes locally.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.

### What areas of FiftyOne does this PR affect?

- [x] `Other`: CI test flakiness

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by configuring time-freezing behavior to safely handle machine learning libraries during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3776
<!-- enterprise-sync-pr:end -->