### PR TITLE
Fix stale selection state on multimodal grid shift-select

### DIFF
--- a/app/packages/core/src/components/Grid/GridCustomRendererItem.test.tsx
+++ b/app/packages/core/src/components/Grid/GridCustomRendererItem.test.tsx
@@ -493,6 +493,129 @@ describe("GridCustomRendererItem", () => {
     host.remove();
   });
 
+  it("shows selected on attach when isSampleSelected reports selected, without requiring hover", async () => {
+    const Renderer = () => <div data-testid="renderer">preview</div>;
+    const isSampleSelected = vi.fn(() => true);
+    const looker = new GridCustomRendererItem({
+      pluginName: "pdf-renderer",
+      Renderer,
+      RecoilBridge: TestBridge,
+      ctx: BASE_CTX as any,
+      symbol: BASE_SYMBOL,
+      isSampleSelected,
+    });
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+
+    looker.attach(host, [200, 120], 12);
+
+    await waitFor(() => {
+      expect(getSelectControl(host)?.getAttribute("title")).toBe("Selected");
+    });
+    expect(isSampleSelected).toHaveBeenCalledWith("sample-id");
+
+    looker.destroy();
+    host.remove();
+  });
+
+  it("reconciles a stale local selected flag against the true selection state on reattach from the cache", async () => {
+    // Regression test for the multimodal-grid shift-select bug: an item that
+    // scrolls offscreen stays alive in the grid's cache and stops receiving
+    // updateOptions() calls (those only reach currently shown rows), so its
+    // local `selected` flag can go stale relative to the real selection.
+    // Reattaching (e.g. scrolling back into view) must reconcile against the
+    // live source of truth instead of repainting the stale value.
+    const Renderer = () => <div data-testid="renderer">preview</div>;
+    let currentlySelected = false;
+    const isSampleSelected = vi.fn(() => currentlySelected);
+    const looker = new GridCustomRendererItem({
+      pluginName: "pdf-renderer",
+      Renderer,
+      RecoilBridge: TestBridge,
+      ctx: BASE_CTX as any,
+      symbol: BASE_SYMBOL,
+      isSampleSelected,
+    });
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+
+    looker.attach(host, [200, 120], 12);
+    await waitFor(() => {
+      expect(host.querySelector("[data-testid='renderer']")).toBeTruthy();
+    });
+    expect(getSelectControl(host)).toBeNull();
+
+    // Item scrolls offscreen (but stays cached, not destroyed) and gets
+    // selected for real while hidden — no updateOptions() call reaches it.
+    looker.detach();
+    currentlySelected = true;
+
+    // Item scrolls back into view: the cache reattaches the same instance.
+    looker.attach(host, [200, 120], 12);
+
+    await waitFor(() => {
+      expect(getSelectControl(host)?.getAttribute("title")).toBe("Selected");
+    });
+
+    looker.destroy();
+    host.remove();
+  });
+
+  it("reconciles a stale locally-selected flag back to unselected on reattach", async () => {
+    const Renderer = () => <div data-testid="renderer">preview</div>;
+    let currentlySelected = true;
+    const isSampleSelected = vi.fn(() => currentlySelected);
+    const looker = new GridCustomRendererItem({
+      pluginName: "pdf-renderer",
+      Renderer,
+      RecoilBridge: TestBridge,
+      ctx: BASE_CTX as any,
+      symbol: BASE_SYMBOL,
+      isSampleSelected,
+    });
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+
+    looker.attach(host, [200, 120], 12);
+    await waitFor(() => {
+      expect(getSelectControl(host)?.getAttribute("title")).toBe("Selected");
+    });
+
+    looker.detach();
+    currentlySelected = false;
+    looker.attach(host, [200, 120], 12);
+
+    await waitFor(() => {
+      expect(getSelectControl(host)).toBeNull();
+    });
+
+    looker.destroy();
+    host.remove();
+  });
+
+  it("does not reconcile selection on attach when isSampleSelected is not provided", async () => {
+    const Renderer = () => <div data-testid="renderer">preview</div>;
+    const looker = new GridCustomRendererItem({
+      pluginName: "pdf-renderer",
+      Renderer,
+      RecoilBridge: TestBridge,
+      ctx: BASE_CTX as any,
+      symbol: BASE_SYMBOL,
+    });
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+
+    looker.attach(host, [200, 120], 12);
+
+    await waitFor(() => {
+      expect(host.querySelector("[data-testid='renderer']")).toBeTruthy();
+    });
+    expect(getSelectControl(host)).toBeNull();
+
+    looker.destroy();
+    host.remove();
+  });
+
   it("survives a destroy() from inside a React effect cleanup", async () => {
     // How the grid actually destroys items: the looker cache evicts during a
     // render, so destroy() lands in an effect cleanup while React is mid-commit

--- a/app/packages/core/src/components/Grid/GridCustomRendererItem.tsx
+++ b/app/packages/core/src/components/Grid/GridCustomRendererItem.tsx
@@ -509,6 +509,17 @@ export class GridCustomRendererItem {
     // stopped receiving updateOptions() calls (those only reach currently
     // shown rows), so its local `selected` flag can be stale relative to the
     // real selectedSamples atom.
+    //
+    // Known trade-off: the selection click handler applies its toggle to
+    // `this.selected` optimistically, before the Recoil write it dispatches
+    // has actually committed (that round-trip is async). If this exact
+    // instance were detached and reattached inside that narrow window, this
+    // reconciliation would read the not-yet-committed snapshot and revert the
+    // optimistic toggle. In practice a reattach is driven by scroll/relayout,
+    // which cannot happen inside the same microtask window as the click, so
+    // this hasn't been observed — flagging for future readers rather than
+    // guarding against it, since a guard would have to reintroduce the same
+    // staleness this reconciliation exists to fix.
     if (this.config.isSampleSelected) {
       this.selected = this.config.isSampleSelected(this.getSampleId());
     }

--- a/app/packages/core/src/components/Grid/GridCustomRendererItem.tsx
+++ b/app/packages/core/src/components/Grid/GridCustomRendererItem.tsx
@@ -23,6 +23,13 @@ type GridCustomRendererItemConfig = {
   ctx: SampleRendererRenderContext;
   clickBehavior?: SampleRendererGridClickBehavior;
   symbol: ID;
+  /**
+   * Synchronous lookup against the true `selectedSamples` source of truth,
+   * used to reconcile this item's local `selected` flag when it's reattached
+   * from the cache (`attach()`), since offscreen cached items don't receive
+   * `updateOptions()` calls while hidden.
+   */
+  isSampleSelected?: (sampleId: string) => boolean;
 };
 
 /** Dimensions as [width, height] in pixels. */
@@ -400,10 +407,14 @@ export class GridCustomRendererItem {
     );
   }
 
+  private getSampleId(): string {
+    const sample = this.config.ctx.sample?.sample;
+    return sample?._id ?? sample?.["id"] ?? this.config.symbol.description;
+  }
+
   private getSelectionPayload(event: React.MouseEvent<HTMLButtonElement>) {
     const sample = this.config.ctx.sample?.sample;
-    const sampleId =
-      sample?._id ?? sample?.["id"] ?? this.config.symbol.description;
+    const sampleId = this.getSampleId();
 
     return buildThumbnailSelectionDetail({
       id: sampleId,
@@ -491,6 +502,15 @@ export class GridCustomRendererItem {
     if (this.hostElement.parentElement !== resolvedElement) {
       // Replace all children of the target element with the host element.
       resolvedElement.replaceChildren(this.hostElement);
+    }
+
+    // Reconcile against the true selection state on (re)attach: while this
+    // item was scrolled offscreen it stayed alive in the grid's cache but
+    // stopped receiving updateOptions() calls (those only reach currently
+    // shown rows), so its local `selected` flag can be stale relative to the
+    // real selectedSamples atom.
+    if (this.config.isSampleSelected) {
+      this.selected = this.config.isSampleSelected(this.getSampleId());
     }
 
     this.renderPluginRenderer();

--- a/app/packages/core/src/components/Grid/useGridCustomRendererItem.test.tsx
+++ b/app/packages/core/src/components/Grid/useGridCustomRendererItem.test.tsx
@@ -1,8 +1,12 @@
-import { renderHook } from "@testing-library/react";
+import { renderHook, waitFor } from "@testing-library/react";
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GridCustomRendererItem } from "./GridCustomRendererItem";
 import { useGridCustomRendererItem } from "./useGridCustomRendererItem";
+
+// Mutated per-test to control what the mocked `useRecoilCallback`-derived
+// selection lookup reports, without depending on a real Recoil store.
+let currentSelectedSampleIds = new Set<string>();
 
 const {
   createSampleRendererRenderContext,
@@ -51,9 +55,11 @@ vi.mock("@fiftyone/plugins", () => ({
 vi.mock("@fiftyone/state", () => ({
   isGridCustomRendererFailOpen: (...args: unknown[]) =>
     isGridCustomRendererFailOpen(...args),
+  selectedSamples: "SELECTED_SAMPLES_ATOM",
   useCurrentDataset: (...args: unknown[]) => useCurrentDataset(...args),
   useGridCustomRendererFailover: (...args: unknown[]) =>
     useGridCustomRendererFailover(...args),
+  useModalActive: () => false,
   useSampleSchema: (...args: unknown[]) => useSampleSchema(...args),
   useSelectedMediaFieldGrid: (...args: unknown[]) =>
     useSelectedMediaFieldGrid(...args),
@@ -63,11 +69,27 @@ vi.mock("@fiftyone/analytics", () => ({
   useTrackEvent: () => trackEvent,
 }));
 
+// GridTagBubbles reaches for looker/schema hooks this test's minimal
+// @fiftyone/state mock doesn't provide; it's irrelevant to selection wiring.
+vi.mock("./GridTagBubbles", () => ({
+  default: () => null,
+}));
+
 vi.mock("recoil", () => ({
   useRecoilBridgeAcrossReactRoots_UNSTABLE: vi.fn(
     () =>
       ({ children }: React.PropsWithChildren) => <>{children}</>,
   ),
+  useRecoilCallback: (
+    fn: (args: { snapshot: unknown }) => (...args: unknown[]) => unknown,
+  ) =>
+    fn({
+      snapshot: {
+        getLoadable: () => ({
+          getValue: () => currentSelectedSampleIds,
+        }),
+      },
+    }),
 }));
 
 const Renderer = ({ ctx }: { ctx: { media: { url: string | null } } }) => (
@@ -109,6 +131,7 @@ const sampleResult = {
 describe("useGridCustomRendererItem", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    currentSelectedSampleIds = new Set<string>();
     useCurrentDataset.mockReturnValue(mockDataset);
     useGridCustomRendererFailover.mockReturnValue({
       dismissBanner: vi.fn(),
@@ -147,6 +170,31 @@ describe("useGridCustomRendererItem", () => {
     expect(looker).toBeInstanceOf(GridCustomRendererItem);
     expect(createDefaultLooker.current).not.toHaveBeenCalled();
     expect(trackEvent).toHaveBeenCalledWith("grid_custom_renderer_used");
+  });
+
+  it("wires a synchronous selection lookup into the created item that reflects selectedSamples", async () => {
+    currentSelectedSampleIds = new Set(["sample-id"]);
+    const createDefaultLooker = { current: vi.fn() } as any;
+    const { result } = renderHook(() =>
+      useGridCustomRendererItem(createDefaultLooker),
+    );
+
+    const looker = result.current.createItem(
+      sampleResult,
+      { description: "sample-id" } as any,
+      12,
+    ) as GridCustomRendererItem;
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+
+    looker.attach(host, [200, 120], 12);
+
+    await waitFor(() => {
+      expect(host.querySelector("[title='Selected']")).toBeTruthy();
+    });
+
+    looker.destroy();
+    host.remove();
   });
 
   it("stays on the default path when no sample renderer matches", () => {

--- a/app/packages/core/src/components/Grid/useGridCustomRendererItem.ts
+++ b/app/packages/core/src/components/Grid/useGridCustomRendererItem.ts
@@ -12,7 +12,10 @@ import type { ID } from "@fiftyone/spotlight";
 import * as fos from "@fiftyone/state";
 import type React from "react";
 import { useCallback, useMemo, useRef } from "react";
-import { useRecoilBridgeAcrossReactRoots_UNSTABLE } from "recoil";
+import {
+  useRecoilBridgeAcrossReactRoots_UNSTABLE,
+  useRecoilCallback,
+} from "recoil";
 import { GridCustomRendererItem } from "./GridCustomRendererItem";
 
 type GridSampleResult = SampleRendererSampleLike;
@@ -37,6 +40,18 @@ export function useGridCustomRendererItem(
 
   const RecoilBridge = useRecoilBridgeAcrossReactRoots_UNSTABLE();
   const hasTrackedRendererUsageRef = useRef(false);
+
+  // Synchronous, non-hook lookup so a GridCustomRendererItem instance can
+  // reconcile its local `selected` flag against the true source of truth when
+  // it's reattached from the cache (e.g. after scrolling out of and back into
+  // the shown viewport) instead of trusting a value it hasn't been updated
+  // with while offscreen.
+  const isSampleSelected = useRecoilCallback(
+    ({ snapshot }) =>
+      (sampleId: string) =>
+        snapshot.getLoadable(fos.selectedSamples).getValue().has(sampleId),
+    [],
+  );
 
   const getResolvedRenderer = useCallback(
     (result: GridSampleResult) => {
@@ -117,6 +132,7 @@ export function useGridCustomRendererItem(
             RecoilBridge as React.ComponentType<React.PropsWithChildren>,
           ctx: resolvedRenderer.ctx,
           symbol: id,
+          isSampleSelected,
         }) as unknown as fos.Lookers;
 
         // Track coarse-grained adoption once per active grid instance (rather
@@ -135,7 +151,13 @@ export function useGridCustomRendererItem(
         return createDefaultItem(result, id, fontSize);
       }
     },
-    [createDefaultItem, getResolvedRenderer, RecoilBridge, trackEvent],
+    [
+      createDefaultItem,
+      getResolvedRenderer,
+      RecoilBridge,
+      trackEvent,
+      isSampleSelected,
+    ],
   );
 
   return { createItem };


### PR DESCRIPTION
## 🔗 Related Issues

bug/mmGridShiftSelect

## 📋 What changes are proposed in this pull request?

Fixes a shift-select bug that only reproduces in multimodal grids: shift-clicking a range of samples (e.g. 0-80) then scrolling back to the top shows the first sample as unselected, even though it's actually selected — clicking it toggles it *off* and reveals the rest of the range really was selected the whole time.

Root cause: `GridCustomRendererItem` (the tile renderer used for multimodal grid items) keeps a private, imperative `selected` boolean that's only kept in sync via `updateOptions()`. That call is only pushed to rows the grid's virtualization currently considers "shown" — items that have scrolled offscreen but are still alive in the looker cache never receive it. When such an item is later reattached (scrolled back into view), it repainted from its stale local flag instead of the real `selectedSamples` Recoil state, so it visually showed unselected while actually being selected in the source of truth. Clicking it then hit the "already selected → deselect" branch, producing the reported symptom.

Fix: thread a synchronous `isSampleSelected(sampleId)` lookup (backed by `useRecoilCallback` + `snapshot.getLoadable(selectedSamples)`) into `GridCustomRendererItem`, and reconcile its local `selected` flag against that source of truth at the top of `attach()`, before repainting. This is additive/optional wiring (`isSampleSelected` is an optional config field) so it can't affect the non-multimodal grid path, which doesn't use this renderer.

### Known limitations / follow-up (surfaced in review)

- **Narrow optimistic-toggle race**: the selection click handler flips `this.selected` optimistically before the Recoil write it dispatches has actually committed (that round-trip is async, via `useRecoilCallback`/`snapshot.getPromise`). If the same tile instance were detached and reattached inside that microtask-scoped window, the new `attach()` reconciliation would read the not-yet-committed value and revert the just-made toggle. This requires a scroll-driven reattach to land inside a single-click's microtask window, which isn't reachable via real scrolling — documented in a code comment rather than guarded against, since a guard would have to reintroduce the staleness this PR fixes.
- **Scoped fix, not a root-cause fix**: the actual gap — `spotlight`'s `Section`/`Row` `updateItems()` only pushes updates to currently-"shown" rows, leaving hidden-but-cached items stale — is only patched here for `GridCustomRendererItem` (multimodal). Any other stateful Looker type that stays cached offscreen with option state that changes while hidden could be exposed to the same class of bug. Fixing that generally would mean changing the shared `spotlight` virtualization contract, which is a larger, riskier change than this bug's scope; flagging as a candidate for separate follow-up work.

## 🧪 How is this patch tested? If it is not, please explain why.

- Added regression tests in `GridCustomRendererItem.test.tsx` covering:
  - selection control renders as selected on attach when `isSampleSelected` reports true, without requiring hover
  - a stale local `selected=false` is corrected to selected on reattach after the sample becomes selected while offscreen (the exact bug scenario)
  - the symmetric case: a stale local `selected=true` is corrected back to unselected on reattach
  - backward compatibility: `attach()` doesn't throw and leaves `selected` untouched when `isSampleSelected` isn't provided
- Added a test in `useGridCustomRendererItem.test.tsx` verifying the hook wires a synchronous selection lookup reflecting `selectedSamples` into the constructed item.
- Ran the full `Grid` test suite locally (28/28 passing) and `yarn typecheck` (no new errors introduced).
- Manually verified in the app: shift-click select a range of multimodal samples, scroll to the top, confirm the first sample shows as selected and toggling it deselects (rather than the reverse).

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

Fixed a bug where shift-clicking to select a range of samples in a multimodal grid could show the first sample in the range as unselected until clicked, at which point it (incorrectly) toggled off instead of on.

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3780
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved grid item selection synchronization with the current application state.
  * Selection indicators now update correctly when sample selections change.
  * Ensured selection information remains accurate when grid items are attached, detached, reattached, or rendered.
  * Prevented stale selection states from appearing when grid items are reused.
  * Preserved existing behavior for grid items without selection-state information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->