### PR TITLE
Bootstrap DB connection when dereferencing dataset document references

### DIFF
--- a/fiftyone/core/odm/dataset.py
+++ b/fiftyone/core/odm/dataset.py
@@ -42,7 +42,7 @@ from .database import (
 )
 from .document import Document
 from .embedded_document import EmbeddedDocument
-from .runs import RunDocument
+from .runs import RunDocument, RunReferencesField
 from .utils import create_field
 from .views import SavedViewDocument
 from .workspace import WorkspaceDocument
@@ -947,10 +947,10 @@ class DatasetDocument(Document):
     frame_fields = EmbeddedDocumentListField(SampleFieldDocument)
     saved_views = ListField(ReferenceField(SavedViewDocument))
     workspaces = ListField(ReferenceField(WorkspaceDocument))
-    annotation_runs = DictField(ReferenceField(RunDocument))
-    brain_methods = DictField(ReferenceField(RunDocument))
-    evaluations = DictField(ReferenceField(RunDocument))
-    runs = DictField(ReferenceField(RunDocument))
+    annotation_runs = RunReferencesField(ReferenceField(RunDocument))
+    brain_methods = RunReferencesField(ReferenceField(RunDocument))
+    evaluations = RunReferencesField(ReferenceField(RunDocument))
+    runs = RunReferencesField(ReferenceField(RunDocument))
     active_label_schemas = ListField(StringField())
     label_schemas = DictField()
     frame_label_schemas = DictField()

--- a/fiftyone/core/odm/dataset.py
+++ b/fiftyone/core/odm/dataset.py
@@ -33,6 +33,7 @@ from fiftyone.core.fields import (
 )
 
 from .database import (
+    ensure_connection,
     patch_annotation_runs,
     patch_brain_runs,
     patch_evaluations,
@@ -42,7 +43,7 @@ from .database import (
 )
 from .document import Document
 from .embedded_document import EmbeddedDocument
-from .runs import RunDocument, RunReferencesField
+from .runs import RunDocument
 from .utils import create_field
 from .views import SavedViewDocument
 from .workspace import WorkspaceDocument
@@ -906,6 +907,35 @@ def _update_path(p, path, new_path):
     return new_path + p[len(path) :]
 
 
+class _ConnectedReferencesMixin:
+    """Mixin for reference-holding fields that establishes the database
+    connection before dereferencing.
+
+    References are dereferenced lazily upon first access, which may occur in
+    a process without an established connection (e.g. a cold process in API
+    mode, or a worker that disconnected), so the access cannot rely on
+    another SDK call having connected first.
+    """
+
+    def __get__(self, instance, owner):
+        if instance is not None:
+            ensure_connection()
+
+        return super().__get__(instance, owner)
+
+
+class _ConnectedReferencesDictField(_ConnectedReferencesMixin, DictField):
+    """Dict field of document references that establishes the database
+    connection before dereferencing.
+    """
+
+
+class _ConnectedReferencesListField(_ConnectedReferencesMixin, ListField):
+    """List field of document references that establishes the database
+    connection before dereferencing.
+    """
+
+
 class DatasetDocument(Document):
     """Backing document for datasets."""
 
@@ -945,12 +975,18 @@ class DatasetDocument(Document):
     static_transforms = DictField(EmbeddedDocumentField(StaticTransform))
     sample_fields = EmbeddedDocumentListField(SampleFieldDocument)
     frame_fields = EmbeddedDocumentListField(SampleFieldDocument)
-    saved_views = ListField(ReferenceField(SavedViewDocument))
-    workspaces = ListField(ReferenceField(WorkspaceDocument))
-    annotation_runs = RunReferencesField(ReferenceField(RunDocument))
-    brain_methods = RunReferencesField(ReferenceField(RunDocument))
-    evaluations = RunReferencesField(ReferenceField(RunDocument))
-    runs = RunReferencesField(ReferenceField(RunDocument))
+    saved_views = _ConnectedReferencesListField(
+        ReferenceField(SavedViewDocument)
+    )
+    workspaces = _ConnectedReferencesListField(
+        ReferenceField(WorkspaceDocument)
+    )
+    annotation_runs = _ConnectedReferencesDictField(
+        ReferenceField(RunDocument)
+    )
+    brain_methods = _ConnectedReferencesDictField(ReferenceField(RunDocument))
+    evaluations = _ConnectedReferencesDictField(ReferenceField(RunDocument))
+    runs = _ConnectedReferencesDictField(ReferenceField(RunDocument))
     active_label_schemas = ListField(StringField())
     label_schemas = DictField()
     frame_label_schemas = DictField()

--- a/fiftyone/core/odm/runs.py
+++ b/fiftyone/core/odm/runs.py
@@ -5,6 +5,7 @@ Dataset run documents.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from mongoengine import FileField
 
 from fiftyone.core.fields import (
@@ -15,7 +16,25 @@ from fiftyone.core.fields import (
     StringField,
 )
 
+from .database import ensure_connection
 from .document import Document
+
+
+class RunReferencesField(DictField):
+    """Dict field of run references that establishes the database connection
+    before dereferencing.
+
+    Run references on a dataset document are dereferenced lazily upon first
+    access, which may occur in a process without an established connection
+    (e.g. a cold process in API mode, or a worker that disconnected), so the
+    access cannot rely on another SDK call having connected first.
+    """
+
+    def __get__(self, instance, owner):
+        if instance is not None:
+            ensure_connection()
+
+        return super().__get__(instance, owner)
 
 
 class RunDocument(Document):

--- a/fiftyone/core/odm/runs.py
+++ b/fiftyone/core/odm/runs.py
@@ -16,25 +16,7 @@ from fiftyone.core.fields import (
     StringField,
 )
 
-from .database import ensure_connection
 from .document import Document
-
-
-class RunReferencesField(DictField):
-    """Dict field of run references that establishes the database connection
-    before dereferencing.
-
-    Run references on a dataset document are dereferenced lazily upon first
-    access, which may occur in a process without an established connection
-    (e.g. a cold process in API mode, or a worker that disconnected), so the
-    access cannot rely on another SDK call having connected first.
-    """
-
-    def __get__(self, instance, owner):
-        if instance is not None:
-            ensure_connection()
-
-        return super().__get__(instance, owner)
 
 
 class RunDocument(Document):

--- a/tests/unittests/run_tests.py
+++ b/tests/unittests/run_tests.py
@@ -192,60 +192,75 @@ class RunTests(unittest.TestCase):
         self.assertTrue(run_info1.timestamp < run_info2.timestamp)
 
 
-class RunConnectionBootstrapTests(unittest.TestCase):
-    """Accessing a dataset document's run references must bootstrap the DB
-    connection before dereferencing — a runs access may occur in a process
-    without an established connection (e.g. a cold process in API mode, or a
-    worker that disconnected), and mongoengine's dereference machinery does
-    not establish the default connection on its own.
+class ReferenceConnectionBootstrapTests(unittest.TestCase):
+    """Accessing a dataset document's references (runs, saved views,
+    workspaces) must bootstrap the DB connection before dereferencing — the
+    access may occur in a process without an established connection (e.g. a
+    cold process in API mode, or a worker that disconnected), and
+    mongoengine's dereference machinery does not establish the default
+    connection on its own.
     """
 
-    def test_run_references_field_bootstraps_connection_first(self):
-        from mongoengine.base import ComplexBaseField
+    @classmethod
+    def _field_classes(cls):
+        import fiftyone.core.fields as fof
+        import fiftyone.core.odm.dataset as food
 
-        import fiftyone.core.odm.runs as foor
-
-        manager = mock.Mock()
-        field = foor.RunReferencesField()
-
-        with (
-            mock.patch.object(
-                foor, "ensure_connection", manager.ensure_connection
-            ),
-            mock.patch.object(ComplexBaseField, "__get__", manager.super_get),
-        ):
-            foor.RunReferencesField.__get__(field, object(), object)
-
-        calls = [name for name, _, _ in manager.mock_calls]
-        self.assertIn("super_get", calls)
-        self.assertEqual(
-            calls[0],
-            "ensure_connection",
-            f"connection must be established before dereferencing; got {calls}",
+        return (
+            (food._ConnectedReferencesDictField, fof.DictField),
+            (food._ConnectedReferencesListField, fof.ListField),
         )
 
-    def test_run_references_field_skips_class_access(self):
-        from mongoengine.base import ComplexBaseField
-
-        import fiftyone.core.odm.runs as foor
-
-        manager = mock.Mock()
-        field = foor.RunReferencesField()
-
-        with (
-            mock.patch.object(
-                foor, "ensure_connection", manager.ensure_connection
-            ),
-            mock.patch.object(ComplexBaseField, "__get__", manager.super_get),
-        ):
-            foor.RunReferencesField.__get__(field, None, object)
-
-        calls = [name for name, _, _ in manager.mock_calls]
-        self.assertNotIn("ensure_connection", calls)
-
-    def test_dataset_run_fields_use_connected_field(self):
+    def test_connected_fields_bootstrap_connection_first(self):
         import fiftyone.core.odm.dataset as food
-        import fiftyone.core.odm.runs as foor
+
+        for field_cls, base_cls in self._field_classes():
+            manager = mock.Mock()
+            field = field_cls()
+
+            with (
+                mock.patch.object(
+                    food, "ensure_connection", manager.ensure_connection
+                ),
+                mock.patch.object(
+                    base_cls, "__get__", manager.super_get, create=True
+                ),
+            ):
+                field_cls.__get__(field, object(), object)
+
+            calls = [name for name, _, _ in manager.mock_calls]
+            self.assertIn("super_get", calls)
+            self.assertEqual(
+                calls[0],
+                "ensure_connection",
+                f"connection must be established before dereferencing; got {calls}",
+            )
+
+    def test_connected_fields_skip_class_access(self):
+        import fiftyone.core.odm.dataset as food
+
+        for field_cls, base_cls in self._field_classes():
+            manager = mock.Mock()
+            field = field_cls()
+
+            with (
+                mock.patch.object(
+                    food, "ensure_connection", manager.ensure_connection
+                ),
+                mock.patch.object(
+                    base_cls, "__get__", manager.super_get, create=True
+                ),
+            ):
+                field_cls.__get__(field, None, object)
+
+            calls = [name for name, _, _ in manager.mock_calls]
+            self.assertNotIn("ensure_connection", calls)
+
+    def test_dataset_reference_fields_use_connected_fields(self):
+        import fiftyone.core.odm.dataset as food
+
+        # pylint: disable=no-member
+        fields = food.DatasetDocument._fields
 
         for name in (
             "annotation_runs",
@@ -254,16 +269,30 @@ class RunConnectionBootstrapTests(unittest.TestCase):
             "runs",
         ):
             self.assertIsInstance(
-                # pylint: disable=no-member
-                food.DatasetDocument._fields[name],
-                foor.RunReferencesField,
-                name,
+                fields[name], food._ConnectedReferencesDictField, name
             )
+
+        for name in ("saved_views", "workspaces"):
+            self.assertIsInstance(
+                fields[name], food._ConnectedReferencesListField, name
+            )
+
+    def _disconnect(self):
+        """Simulates a worker teardown (fiftyone.core.map.process,
+        fiftyone.utils.torch).
+        """
+        import fiftyone.core.odm.database as fodb
+        import fiftyone.factory.repo_factory as forf
+
+        fodb._disconnect()
+
+        # The repo factory caches the client, which is now closed; reset it
+        # so that test cleanup can reconnect
+        forf._db = None
+        forf.RepositoryFactory.repos.clear()
 
     @drop_datasets
     def test_run_access_after_disconnect(self):
-        import fiftyone.core.odm.database as food
-
         dataset = fo.Dataset()
 
         config = dataset.init_run(foo="bar")
@@ -275,14 +304,34 @@ class RunConnectionBootstrapTests(unittest.TestCase):
         # Reset the in-memory doc so the run references are raw DBRefs again
         dataset.reload()
 
-        # Simulates a worker teardown (fiftyone.core.map.process,
-        # fiftyone.utils.torch)
-        food._disconnect()
+        self._disconnect()
 
         self.assertListEqual(dataset.list_runs(), ["test"])
 
         results = dataset.load_run_results("test", cache=False)
         self.assertEqual(results.spam, "eggs")
+
+    @drop_datasets
+    def test_saved_view_access_after_disconnect(self):
+        dataset = fo.Dataset()
+        dataset.save_view("test", dataset.limit(1))
+
+        dataset.reload()
+        self._disconnect()
+
+        self.assertListEqual(dataset.list_saved_views(), ["test"])
+        dataset.load_saved_view("test")
+
+    @drop_datasets
+    def test_workspace_access_after_disconnect(self):
+        dataset = fo.Dataset()
+        dataset.save_workspace("test", fo.Space())
+
+        dataset.reload()
+        self._disconnect()
+
+        self.assertListEqual(dataset.list_workspaces(), ["test"])
+        dataset.load_workspace("test")
 
 
 if __name__ == "__main__":

--- a/tests/unittests/run_tests.py
+++ b/tests/unittests/run_tests.py
@@ -206,6 +206,7 @@ class ReferenceConnectionBootstrapTests(unittest.TestCase):
         import fiftyone.core.fields as fof
         import fiftyone.core.odm.dataset as food
 
+        # pylint: disable=no-member
         return (
             (food._ConnectedReferencesDictField, fof.DictField),
             (food._ConnectedReferencesListField, fof.ListField),
@@ -307,6 +308,10 @@ class ReferenceConnectionBootstrapTests(unittest.TestCase):
         self._disconnect()
 
         self.assertListEqual(dataset.list_runs(), ["test"])
+
+        # Disconnect again so that loading results also starts cold
+        dataset.reload()
+        self._disconnect()
 
         results = dataset.load_run_results("test", cache=False)
         self.assertEqual(results.spam, "eggs")

--- a/tests/unittests/run_tests.py
+++ b/tests/unittests/run_tests.py
@@ -5,7 +5,9 @@ FiftyOne run-related unit tests.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import unittest
+from unittest import mock
 
 import fiftyone as fo
 
@@ -188,6 +190,99 @@ class RunTests(unittest.TestCase):
         run_info2 = dataset2.get_run_info("test")
 
         self.assertTrue(run_info1.timestamp < run_info2.timestamp)
+
+
+class RunConnectionBootstrapTests(unittest.TestCase):
+    """Accessing a dataset document's run references must bootstrap the DB
+    connection before dereferencing — a runs access may occur in a process
+    without an established connection (e.g. a cold process in API mode, or a
+    worker that disconnected), and mongoengine's dereference machinery does
+    not establish the default connection on its own.
+    """
+
+    def test_run_references_field_bootstraps_connection_first(self):
+        from mongoengine.base import ComplexBaseField
+
+        import fiftyone.core.odm.runs as foor
+
+        manager = mock.Mock()
+        field = foor.RunReferencesField()
+
+        with (
+            mock.patch.object(
+                foor, "ensure_connection", manager.ensure_connection
+            ),
+            mock.patch.object(ComplexBaseField, "__get__", manager.super_get),
+        ):
+            foor.RunReferencesField.__get__(field, object(), object)
+
+        calls = [name for name, _, _ in manager.mock_calls]
+        self.assertIn("super_get", calls)
+        self.assertEqual(
+            calls[0],
+            "ensure_connection",
+            f"connection must be established before dereferencing; got {calls}",
+        )
+
+    def test_run_references_field_skips_class_access(self):
+        from mongoengine.base import ComplexBaseField
+
+        import fiftyone.core.odm.runs as foor
+
+        manager = mock.Mock()
+        field = foor.RunReferencesField()
+
+        with (
+            mock.patch.object(
+                foor, "ensure_connection", manager.ensure_connection
+            ),
+            mock.patch.object(ComplexBaseField, "__get__", manager.super_get),
+        ):
+            foor.RunReferencesField.__get__(field, None, object)
+
+        calls = [name for name, _, _ in manager.mock_calls]
+        self.assertNotIn("ensure_connection", calls)
+
+    def test_dataset_run_fields_use_connected_field(self):
+        import fiftyone.core.odm.dataset as food
+        import fiftyone.core.odm.runs as foor
+
+        for name in (
+            "annotation_runs",
+            "brain_methods",
+            "evaluations",
+            "runs",
+        ):
+            self.assertIsInstance(
+                # pylint: disable=no-member
+                food.DatasetDocument._fields[name],
+                foor.RunReferencesField,
+                name,
+            )
+
+    @drop_datasets
+    def test_run_access_after_disconnect(self):
+        import fiftyone.core.odm.database as food
+
+        dataset = fo.Dataset()
+
+        config = dataset.init_run(foo="bar")
+        dataset.register_run("test", config)
+
+        results = dataset.init_run_results("test", spam="eggs")
+        dataset.save_run_results("test", results, cache=False)
+
+        # Reset the in-memory doc so the run references are raw DBRefs again
+        dataset.reload()
+
+        # Simulates a worker teardown (fiftyone.core.map.process,
+        # fiftyone.utils.torch)
+        food._disconnect()
+
+        self.assertListEqual(dataset.list_runs(), ["test"])
+
+        results = dataset.load_run_results("test", cache=False)
+        self.assertEqual(results.spam, "eggs")
 
 
 if __name__ == "__main__":

--- a/tests/unittests/run_tests.py
+++ b/tests/unittests/run_tests.py
@@ -279,18 +279,20 @@ class ReferenceConnectionBootstrapTests(unittest.TestCase):
             )
 
     def _disconnect(self):
-        """Simulates a worker teardown (fiftyone.core.map.process,
-        fiftyone.utils.torch).
+        """Puts the process in the state a cold or freshly-forked worker sees
+        (fiftyone.core.map.process, fiftyone.utils.torch): mongoengine's
+        connection registry is empty and FiftyOne will reconnect lazily.
+
+        Unlike ``fiftyone.core.odm.database._disconnect()``, this does not
+        close the pymongo client, so handles held by other tests sharing this
+        process (e.g. package-scoped fixtures) keep working.
         """
+        import mongoengine
+
         import fiftyone.core.odm.database as fodb
-        import fiftyone.factory.repo_factory as forf
 
-        fodb._disconnect()
-
-        # The repo factory caches the client, which is now closed; reset it
-        # so that test cleanup can reconnect
-        forf._db = None
-        forf.RepositoryFactory.repos.clear()
+        mongoengine.disconnect_all()
+        fodb._client = None
 
     @drop_datasets
     def test_run_access_after_disconnect(self):


### PR DESCRIPTION
## What changes are proposed in this pull request?

Loading runs (e.g. `dataset.load_brain_results()`), saved views, or workspaces could fail with

```
mongoengine.connection.ConnectionFailure: You have not defined a default connection
```

The references on a dataset document (`annotation_runs`, `brain_methods`, `evaluations`, `runs`, `saved_views`, `workspaces` — the only reference-holding fields in the ODM) are dereferenced lazily upon first attribute access, and that access may occur in a process without an established mongoengine connection — a cold process in API mode, or a worker process that tore down its connection via `_disconnect()` (as `fiftyone.core.map.process` and `fiftyone.utils.torch` do), which calls `mongoengine.disconnect_all()`.

This PR gives those fields `DictField`/`ListField` subclasses (via a shared mixin) that call `ensure_connection()` before dereferencing, mirroring the ontology fix in #8140.

## How is this patch tested?

New `ReferenceConnectionBootstrapTests` in `tests/unittests/run_tests.py`:
- mock-based tests asserting the fields bootstrap the connection before dereferencing (and skip class-level access, so imports cannot trigger a connection)
- regression tests that save a run's results / a saved view / a workspace, reload the dataset doc, call `_disconnect()`, then load them back — each reproduces the exact `ConnectionFailure` without the fix and passes with it

`run_tests.py`, `odm_tests.py`, `view_tests.py`, and `dataset_tests.py` all pass.

## What areas of FiftyOne does this PR affect?

- [x] `Core`: Core `fiftyone` Python library

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3843
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when accessing dataset references after a database connection is interrupted.
  * Automatically re-establishes the connection before loading saved views, workspaces, runs, evaluations, annotation runs, and related records.

* **Tests**
  * Added coverage for connection recovery and reference access in disconnected scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->