### PR TITLE
Proposal: bootstrap mongoengine's default connection on demand

### DIFF
--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -491,6 +491,50 @@ def ensure_connection():
     _connect()
 
 
+def _install_connection_bootstrap():
+    """Wraps ``mongoengine.connection.get_connection`` so that mongoengine's
+    default connection is established on demand.
+
+    FiftyOne's connection setup is lazy: entry points in FiftyOne code funnel
+    through :func:`ensure_connection`, which connects on first use and
+    reconnects after a teardown. But operations that mongoengine performs
+    natively — queryset access, lazy dereference of reference fields, GridFS
+    reads — resolve the connection registry directly and would otherwise
+    raise ``You have not defined a default connection`` in a process that
+    has not (or no longer has) an established connection, e.g. a cold
+    process in API mode or a forked worker after ``_disconnect()``.
+
+    ``get_connection`` is the choke point that every such operation resolves
+    at call time, and the spot where the error above is raised.
+    """
+    default_alias = mongoengine.connection.DEFAULT_CONNECTION_NAME
+    original = mongoengine.connection.get_connection
+
+    if getattr(original, "_fiftyone_bootstrap", False):
+        return
+
+    def get_connection(alias=default_alias, reconnect=False):
+        if (
+            alias == default_alias
+            and alias not in mongoengine.connection._connection_settings
+        ):
+            ensure_connection()
+
+        return original(alias=alias, reconnect=reconnect)
+
+    get_connection._fiftyone_bootstrap = True
+    mongoengine.connection.get_connection = get_connection
+
+    # The one mongoengine module that holds a direct reference rather than
+    # resolving via ``mongoengine.connection`` at call time
+    from mongoengine import mongodb_support
+
+    mongodb_support.get_connection = get_connection
+
+
+_install_connection_bootstrap()
+
+
 def get_db_client():
     """Returns a database client.
 

--- a/tests/unittests/odm_tests.py
+++ b/tests/unittests/odm_tests.py
@@ -200,18 +200,20 @@ class ConnectionBootstrapTests(unittest.TestCase):
     """
 
     def _disconnect(self):
-        """Simulates a worker teardown (fiftyone.core.map.process,
-        fiftyone.utils.torch) or a cold process.
+        """Puts the process in the state a cold or freshly-forked worker sees
+        (fiftyone.core.map.process, fiftyone.utils.torch): mongoengine's
+        connection registry is empty and FiftyOne will reconnect lazily.
+
+        Unlike ``fiftyone.core.odm.database._disconnect()``, this does not
+        close the pymongo client, so handles held by other tests sharing this
+        process (e.g. package-scoped fixtures) keep working.
         """
+        import mongoengine
+
         import fiftyone.core.odm.database as fodb
-        import fiftyone.factory.repo_factory as forf
 
-        fodb._disconnect()
-
-        # The repo factory caches the client, which is now closed; reset it
-        # so that test cleanup can reconnect
-        forf._db = None
-        forf.RepositoryFactory.repos.clear()
+        mongoengine.disconnect_all()
+        fodb._client = None
 
     def test_wrapper_is_installed(self):
         import mongoengine

--- a/tests/unittests/odm_tests.py
+++ b/tests/unittests/odm_tests.py
@@ -188,3 +188,97 @@ class GetIndexedValuesTests(unittest.TestCase):
 
         finally:
             dataset.delete()
+
+
+class ConnectionBootstrapTests(unittest.TestCase):
+    """Operations that mongoengine performs natively (querysets, lazy
+    dereference of reference fields, GridFS reads) resolve the connection
+    registry directly rather than passing through FiftyOne's lazy
+    ``ensure_connection()`` checkpoints. The ``get_connection`` wrapper
+    installed by ``fiftyone.core.odm.database`` must bootstrap the default
+    connection for them.
+    """
+
+    def _disconnect(self):
+        """Simulates a worker teardown (fiftyone.core.map.process,
+        fiftyone.utils.torch) or a cold process.
+        """
+        import fiftyone.core.odm.database as fodb
+        import fiftyone.factory.repo_factory as forf
+
+        fodb._disconnect()
+
+        # The repo factory caches the client, which is now closed; reset it
+        # so that test cleanup can reconnect
+        forf._db = None
+        forf.RepositoryFactory.repos.clear()
+
+    def test_wrapper_is_installed(self):
+        import mongoengine
+        from mongoengine import mongodb_support
+
+        self.assertTrue(
+            getattr(
+                mongoengine.connection.get_connection,
+                "_fiftyone_bootstrap",
+                False,
+            )
+        )
+        self.assertIs(
+            mongodb_support.get_connection,
+            mongoengine.connection.get_connection,
+        )
+
+    def test_bootstraps_default_connection(self):
+        import mongoengine
+
+        self._disconnect()
+
+        conn = mongoengine.connection.get_connection()
+        self.assertIsNotNone(conn)
+
+    def test_non_default_alias_still_raises(self):
+        import mongoengine
+        from mongoengine.connection import ConnectionFailure
+
+        with self.assertRaises(ConnectionFailure):
+            mongoengine.connection.get_connection("no-such-alias")
+
+    def test_queryset_after_disconnect(self):
+        self._disconnect()
+
+        # A direct queryset is the first DB access after teardown
+        # pylint: disable-next=no-member
+        foo.DatasetDocument.objects.first()
+
+    def test_dereference_after_disconnect(self):
+        dataset = fo.Dataset()
+
+        try:
+            config = dataset.init_run(foo="bar")
+            dataset.register_run("test", config)
+
+            results = dataset.init_run_results("test", spam="eggs")
+            dataset.save_run_results("test", results, cache=False)
+
+            # Reset the in-memory doc so the run references are raw DBRefs
+            dataset.reload()
+
+            self._disconnect()
+
+            # Dereferencing run references + reading GridFS results are the
+            # first DB accesses after teardown
+            self.assertListEqual(dataset.list_runs(), ["test"])
+
+            dataset.reload()
+            self._disconnect()
+
+            results = dataset.load_run_results("test", cache=False)
+            self.assertEqual(results.spam, "eggs")
+        finally:
+            dataset.delete()
+
+
+if __name__ == "__main__":
+    fo.config.show_progress_bars = False
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What changes are proposed in this pull request?

**Proposal / RFC** — closes out the `ConnectionFailure: You have not defined a default connection` bug class structurally, rather than one access path at a time.

FiftyOne's connection setup is lazy: every DB entry point in FiftyOne code funnels through `ensure_connection()`, which connects on first use and reconnects after a teardown. But operations that mongoengine performs *natively* — `.objects` querysets, lazy dereference of `ReferenceField`s, GridFS reads — resolve mongoengine's connection registry directly, skipping every FiftyOne checkpoint. In a process without an established connection (a cold process in API mode, or a forked worker after `_disconnect()` — which `fiftyone.core.map.process` and `fiftyone.utils.torch.worker_init` call by design), whichever feature touches such a path first crashes. #8140 fixed the queryset variant for ontologies; #8263 fixes the dereference variant for dataset references; an audit found more latent cases (e.g. `delete_ontology(force=True)` queries `DatasetDocument.objects` directly and only works today because `load_ontology()` happens to bootstrap first).

This PR wraps `mongoengine.connection.get_connection` once, at `odm/database.py` import time: if the default alias is unregistered, call `ensure_connection()` first, then delegate. Why this is the right choke point:

- mongoengine's dereference/GridFS modules from-import `get_db`, but `get_db` resolves `get_connection` as a module global at call time, so one wrapper reaches every path (the one direct-reference holder, `mongodb_support`, is rebound explicitly)
- it is the exact function that raises the error
- `mongoengine.disconnect()` clears `_connection_settings`, so the guard detects both never-connected and torn-down states
- zero steady-state cost (a dict-membership check), recursion-safe (`mongoengine.connect()` registers the alias before its internal `get_connection` call), and non-default aliases keep stock behavior including the stock error

Relationship to #8263: complementary. This hook alone also fixes that reproduction; the connected field/manager classes remain as declaration-site documentation and defense in depth.

## How is this patch tested?

New `ConnectionBootstrapTests` in `tests/unittests/odm_tests.py`: wrapper installation (both patch points), bootstrap from an empty registry, direct queryset and run-dereference + GridFS access after `_disconnect()`, and non-default-alias passthrough. All fail without the hook except the passthrough. `odm_tests.py`, `run_tests.py`, `view_tests.py`, and `dataset_tests.py` all pass.

## What areas of FiftyOne does this PR affect?

- [x] `Core`: Core `fiftyone` Python library