### PR TITLE
Improve MCAP sample navigation performance

### DIFF
--- a/app/packages/multimodal/src/runtime/react/source-bootstrap.ts
+++ b/app/packages/multimodal/src/runtime/react/source-bootstrap.ts
@@ -1,0 +1,39 @@
+import { useCallback, useEffect, useSyncExternalStore } from "react";
+
+import type { ByteSourceDescriptor } from "../../ir";
+import {
+  getSourceBootstrap,
+  getSourceBootstrapSnapshot,
+  subscribeSourceBootstrap,
+  type SourceBootstrap,
+} from "../source-bootstrap-cache";
+
+const EMPTY_SOURCE_BOOTSTRAP = (): null => null;
+const NOOP_UNSUBSCRIBE = () => undefined;
+
+/** React view of the grid-to-modal bootstrap facts for one byte source. */
+export function useSourceBootstrap(
+  source: ByteSourceDescriptor | null,
+): SourceBootstrap | null {
+  const subscribe = useCallback(
+    (listener: () => void) =>
+      source ? subscribeSourceBootstrap(source, listener) : NOOP_UNSUBSCRIBE,
+    [source],
+  );
+  const getSnapshot = useCallback(
+    () => (source ? getSourceBootstrapSnapshot(source) : null),
+    [source],
+  );
+  const bootstrap = useSyncExternalStore(
+    subscribe,
+    getSnapshot,
+    EMPTY_SOURCE_BOOTSTRAP,
+  );
+
+  // This effect makes the opened modal source recent in the bounded cache.
+  useEffect(() => {
+    if (source && bootstrap) getSourceBootstrap(source);
+  }, [bootstrap, source]);
+
+  return bootstrap;
+}

--- a/app/packages/multimodal/src/runtime/source-bootstrap-cache.test.ts
+++ b/app/packages/multimodal/src/runtime/source-bootstrap-cache.test.ts
@@ -5,10 +5,12 @@ import type {
   EpisodePosterFrame,
   TimeWindow,
 } from "../ir";
+import { getEpisodeTimeRange } from "./episode-time-range-registry";
 import {
   getSourceBootstrap,
   getSourceBootstrapSnapshot,
   peekSourceBootstrap,
+  publishEpisodePreviewBootstrap,
   publishSourceBootstrap,
   resetSourceBootstrapCacheForTests,
   subscribeSourceBootstrap,
@@ -41,15 +43,15 @@ describe("source bootstrap cache", () => {
     const first = createSource("source-0");
     publishSourceBootstrap(first, { manifest: createManifest("first") });
 
-    for (let index = 1; index <= 32; index++) {
+    for (let index = 1; index <= 64; index++) {
       publishSourceBootstrap(createSource(`source-${index}`), {
         manifest: createManifest(`topic-${index}`),
       });
     }
 
     expect(getSourceBootstrap(first)).toBeNull();
-    expect(getSourceBootstrap(createSource("source-32"))?.manifest).toEqual(
-      createManifest("topic-32"),
+    expect(getSourceBootstrap(createSource("source-64"))?.manifest).toEqual(
+      createManifest("topic-64"),
     );
   });
 
@@ -63,7 +65,7 @@ describe("source bootstrap cache", () => {
       notified++;
     });
 
-    for (let index = 1; index <= 32; index++) {
+    for (let index = 1; index <= 64; index++) {
       publishSourceBootstrap(createSource(`source-${index}`), {
         manifest: createManifest(`topic-${index}`),
       });
@@ -90,6 +92,73 @@ describe("source bootstrap cache", () => {
 
     expect(peekSourceBootstrap(source)).toEqual({
       poster: replacementPoster,
+    });
+  });
+
+  it("publishes the timeline-derived range into the bootstrap cache", () => {
+    resetSourceBootstrapCacheForTests();
+    const source = createSource("timeline-range");
+    const timeline = {
+      endNs: 30n,
+      startNs: 10n,
+      timeDomainId: "recording",
+    } as const;
+
+    publishEpisodePreviewBootstrap(source, {
+      bootstrapTimeline: timeline,
+      frame: null,
+      status: "ready",
+      streamId: null,
+      streamSourceName: null,
+      streamSourceNames: [],
+    });
+
+    expect(peekSourceBootstrap(source)?.timeRange).toEqual({
+      endNs: 30n,
+      startNs: 10n,
+    });
+    expect(peekSourceBootstrap(source)?.timeline).toBe(timeline);
+    expect(peekSourceBootstrap(source)?.previewReadComplete).toBe(true);
+    expect(getEpisodeTimeRange(source.sourceId)).toEqual({
+      endNs: 30n,
+      startNs: 10n,
+    });
+  });
+
+  it("retains a bounded marker for a completed posterless preview", () => {
+    resetSourceBootstrapCacheForTests();
+    const source = createSource("posterless");
+
+    publishEpisodePreviewBootstrap(source, {
+      frame: null,
+      status: "empty",
+      streamId: null,
+      streamSourceName: null,
+      streamSourceNames: [],
+    });
+
+    expect(peekSourceBootstrap(source)).toEqual({
+      previewReadComplete: true,
+    });
+  });
+
+  it("publishes the explicit preview range when no timeline is available", () => {
+    resetSourceBootstrapCacheForTests();
+    const source = createSource("explicit-preview-range");
+    const timeRange = createTimeRange();
+
+    publishEpisodePreviewBootstrap(source, {
+      bootstrapTimeRange: timeRange,
+      frame: null,
+      status: "ready",
+      streamId: null,
+      streamSourceName: null,
+      streamSourceNames: [],
+    });
+
+    expect(peekSourceBootstrap(source)).toEqual({
+      previewReadComplete: true,
+      timeRange,
     });
   });
 

--- a/app/packages/multimodal/src/runtime/source-bootstrap-cache.ts
+++ b/app/packages/multimodal/src/runtime/source-bootstrap-cache.ts
@@ -2,13 +2,18 @@ import type {
   ByteSourceDescriptor,
   EpisodeManifest,
   EpisodePosterFrame,
+  EpisodePreviewReadResult,
   EpisodeTimeline,
   TimeWindow,
 } from "../ir";
 import { byteSourceAccessKey } from "../query/bytes";
+import { publishEpisodeTimeRange } from "./episode-time-range-registry";
 
-/** Keep enough nearby grid samples for first-open and short navigation runs. */
-const MAX_SOURCE_ENTRIES = 32;
+/**
+ * Keep a full grid viewport plus virtualization overscan for first-open and
+ * short navigation runs. Poster bytes retain their independent hard ceiling.
+ */
+const MAX_SOURCE_ENTRIES = 64;
 /** Poster data is bounded independently because point-cloud previews can be large. */
 const MAX_POSTER_BYTES = 32 * 1024 * 1024;
 
@@ -17,6 +22,8 @@ export interface SourceBootstrap {
   readonly manifest?: EpisodeManifest;
   readonly poster?: EpisodePosterFrame;
   readonly posterStreamId?: string;
+  /** A lightweight preview read completed, even if it found no poster. */
+  readonly previewReadComplete?: boolean;
   readonly timeline?: EpisodeTimeline;
   readonly timeRange?: TimeWindow;
 }
@@ -55,10 +62,13 @@ export function publishSourceBootstrap(
   const manifest = bootstrap.manifest ?? current?.manifest;
   const timeline = bootstrap.timeline ?? current?.timeline;
   const timeRange = bootstrap.timeRange ?? current?.timeRange;
+  const previewReadComplete =
+    bootstrap.previewReadComplete ?? current?.previewReadComplete;
   const next: CacheEntry = {
     ...(manifest ? { manifest } : {}),
     ...(poster ? { poster } : {}),
     ...(posterStreamId ? { posterStreamId } : {}),
+    ...(previewReadComplete ? { previewReadComplete } : {}),
     ...(timeRange ? { timeRange } : {}),
     ...(timeline ? { timeline } : {}),
     posterBytes: retainedBinaryBytes(poster ?? null),
@@ -74,6 +84,32 @@ export function publishSourceBootstrap(
       notifySourceListeners(evictedKey);
     }
   }
+}
+
+/** Publishes every reusable fact learned by one lightweight preview read. */
+export function publishEpisodePreviewBootstrap(
+  source: ByteSourceDescriptor,
+  result: EpisodePreviewReadResult,
+): void {
+  const timeRange = result.bootstrapTimeline
+    ? {
+        endNs: result.bootstrapTimeline.endNs,
+        startNs: result.bootstrapTimeline.startNs,
+      }
+    : result.bootstrapTimeRange;
+  publishSourceBootstrap(source, {
+    ...(result.bootstrapManifest ? { manifest: result.bootstrapManifest } : {}),
+    ...(result.bootstrapTimeline ? { timeline: result.bootstrapTimeline } : {}),
+    ...(timeRange ? { timeRange } : {}),
+    ...(result.frame
+      ? {
+          poster: result.frame,
+          ...(result.streamId ? { posterStreamId: result.streamId } : {}),
+        }
+      : {}),
+    previewReadComplete: true,
+  });
+  if (timeRange) publishEpisodeTimeRange(source.sourceId, timeRange);
 }
 
 /** Returns the current source bootstrap without changing its LRU position. */
@@ -132,6 +168,9 @@ function copyEntry(entry: CacheEntry | undefined): SourceBootstrap | null {
     ...(entry.manifest ? { manifest: entry.manifest } : {}),
     ...(entry.poster ? { poster: entry.poster } : {}),
     ...(entry.posterStreamId ? { posterStreamId: entry.posterStreamId } : {}),
+    ...(entry.previewReadComplete
+      ? { previewReadComplete: entry.previewReadComplete }
+      : {}),
     ...(entry.timeRange ? { timeRange: entry.timeRange } : {}),
     ...(entry.timeline ? { timeline: entry.timeline } : {}),
   };

--- a/app/packages/multimodal/src/views/episode/grid/use-grid-preview.ts
+++ b/app/packages/multimodal/src/views/episode/grid/use-grid-preview.ts
@@ -7,8 +7,7 @@ import {
 import type { EpisodePreviewSession } from "../../../ports";
 import {
   episodePreviewPlaybackDelayMs,
-  publishEpisodeTimeRange,
-  publishSourceBootstrap,
+  publishEpisodePreviewBootstrap,
 } from "../../../runtime";
 import { errorMessage } from "../status/error-message";
 import type { GridPosterCacheEntry } from "./grid-poster-cache";
@@ -230,7 +229,7 @@ export function useGridPreview({
       .then((result) => {
         if (active) {
           notifyReadResult(onReadResultRef.current, result);
-          publishGridBootstrap(source, result);
+          publishEpisodePreviewBootstrap(source, result);
           loadedRequestRef.current = {
             posterStartTimeNs,
             source,
@@ -351,7 +350,7 @@ export function useGridPreview({
           }
 
           if (!bootstrapPublished) {
-            publishGridBootstrap(source, result);
+            publishEpisodePreviewBootstrap(source, result);
             bootstrapPublished = true;
           }
 
@@ -490,43 +489,6 @@ function useGridPreviewBufferingIndicator() {
   );
 
   return { finish, start, visible };
-}
-
-function publishGridBootstrap(
-  source: ByteSourceDescriptor,
-  result: EpisodePreviewReadResult,
-): void {
-  if (
-    !result.bootstrapManifest &&
-    !result.bootstrapTimeline &&
-    !result.bootstrapTimeRange &&
-    !result.frame
-  ) {
-    return;
-  }
-
-  publishSourceBootstrap(source, {
-    ...(result.bootstrapManifest ? { manifest: result.bootstrapManifest } : {}),
-    ...(result.bootstrapTimeline ? { timeline: result.bootstrapTimeline } : {}),
-    ...(result.bootstrapTimeRange
-      ? { timeRange: result.bootstrapTimeRange }
-      : {}),
-    ...(result.frame
-      ? {
-          poster: result.frame,
-          ...(result.streamId ? { posterStreamId: result.streamId } : {}),
-        }
-      : {}),
-  });
-  const timeRange = result.bootstrapTimeline
-    ? {
-        endNs: result.bootstrapTimeline.endNs,
-        startNs: result.bootstrapTimeline.startNs,
-      }
-    : result.bootstrapTimeRange;
-  if (timeRange) {
-    publishEpisodeTimeRange(source.sourceId, timeRange);
-  }
 }
 
 function snapshotFromResult(

--- a/app/packages/multimodal/src/views/episode/image/ImageTile.tsx
+++ b/app/packages/multimodal/src/views/episode/image/ImageTile.tsx
@@ -3,12 +3,14 @@ import {
   useSetTileTitle,
   useTileDuplicator,
   useTileId,
+  useTiling,
 } from "@fiftyone/tiling";
 import { useIsPlaying } from "@fiftyone/playback";
 import { useStore } from "jotai";
 import React, {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -23,6 +25,7 @@ import { useSceneSourcesByType } from "../../../scene-inventory/react";
 import { VISUALIZATION_KIND } from "../../../visualization";
 import { ImagePanel } from "../../../visualization/media-2d/ImagePanel";
 import { VideoPanel } from "../../../visualization/media-2d/VideoPanel";
+import { BitmapImageFrameView } from "../../../visualization/media-2d/BitmapImageView";
 import GpuImageAnnotationLayer from "../../../visualization/media-2d/GpuImageAnnotationLayer";
 import { GpuImageAnnotationPicker } from "../../../visualization/media-2d/GpuImageAnnotationPicker";
 import { imageTextureCacheKey } from "../../../visualization/media-2d/image-texture-cache";
@@ -88,6 +91,8 @@ import {
   getRectifiedDisplayIssue,
 } from "./image-camera-status";
 import { projectionStreamsForHover } from "./hover-projection-streams";
+import { useSourcePoster } from "./source-poster-context";
+import { shouldPresentDestinationPoster } from "./destination-poster";
 
 const IMAGE_FIT = "contain";
 const EMPTY_PROJECTION_STREAMS: readonly string[] = [];
@@ -95,6 +100,7 @@ const EMPTY_PROJECTION_STREAMS: readonly string[] = [];
 /** Renders one image stream with labels, projections, and camera controls. */
 const ImageTile: React.FC<EpisodeTileProps> = ({ initialSourceId }) => {
   const tileId = useTileId();
+  const { expandedTileId } = useTiling();
   const isPlaying = useIsPlaying();
   const [imageDims, setImageDims] = useState<{
     width: number;
@@ -105,9 +111,11 @@ const ImageTile: React.FC<EpisodeTileProps> = ({ initialSourceId }) => {
     sourceKey: string;
     stream: string;
   } | null>(null);
+  const [committedPosterKey, setCommittedPosterKey] = useState("");
   const projectionPickerRef =
     useRef<GpuPointCloudProjectionPickerHandle | null>(null);
   const sharedHover = useHoverEcho();
+  const sourcePoster = useSourcePoster();
   const images = useSceneSourcesByType(SCENE_SOURCE_TYPE.IMAGE);
   const sourceIdentity = useSidebarSourceIdentity();
   const preferredImageTileStream = usePreferredImageTileStream();
@@ -217,6 +225,17 @@ const ImageTile: React.FC<EpisodeTileProps> = ({ initialSourceId }) => {
   const playbackFrame = useStreamContentFrame<CameraVisualization>(stream);
   const frame = playbackFrame?.frame ?? null;
   const sourceKey = useDataStream()?.sourceKey ?? "";
+  const previousDataStreamSourceKeyRef = useRef(sourceKey);
+  // This layout effect clears the transition latch when the provider unbinds
+  // the outgoing stream, so rapid A -> B -> A navigation can present A's
+  // poster again even when B never committed a frame.
+  useLayoutEffect(() => {
+    if (previousDataStreamSourceKeyRef.current === sourceKey) return;
+    previousDataStreamSourceKeyRef.current = sourceKey;
+    setCommittedImage(null);
+    setCommittedPosterKey("");
+    setImageDims(null);
+  }, [sourceKey]);
   // Shared texture key per (recording, stream, frame). The 3D tile's
   // frustum image planes form the same key, so both surfaces share one
   // decode and one GPU texture for the same camera frame.
@@ -234,6 +253,13 @@ const ImageTile: React.FC<EpisodeTileProps> = ({ initialSourceId }) => {
     committedImage.stream === stream
       ? committedImage.contentTimeNs
       : null;
+  const updateImageDimensions = useCallback((width: number, height: number) => {
+    setImageDims((previous) =>
+      previous?.width === width && previous.height === height
+        ? previous
+        : { width, height },
+    );
+  }, []);
   const handleImageLoaded = useCallback(
     (width: number, height: number) => {
       if (requestedImageContentTimeNs !== null) {
@@ -243,14 +269,41 @@ const ImageTile: React.FC<EpisodeTileProps> = ({ initialSourceId }) => {
           stream,
         });
       }
-      setImageDims((previous) =>
-        previous?.width === width && previous?.height === height
-          ? previous
-          : { width, height },
-      );
+      updateImageDimensions(width, height);
     },
-    [requestedImageContentTimeNs, sourceKey, stream],
+    [requestedImageContentTimeNs, sourceKey, stream, updateImageDimensions],
   );
+  const destinationPoster =
+    sourcePoster &&
+    shouldPresentDestinationPoster({
+      committedSourceKey: committedImage?.sourceKey ?? null,
+      committedStream: committedImage?.stream ?? null,
+      dataStreamSourceKey: sourceKey,
+      posterSourceKey: sourcePoster.sourceKey,
+      posterStreamId: sourcePoster.streamId,
+      stream,
+    })
+      ? sourcePoster.frame
+      : null;
+  // This layout effect registers only a visible tile whose stream can consume
+  // the poster, allowing the shell to keep its fallback overlay otherwise.
+  useLayoutEffect(() => {
+    const isVisible = expandedTileId === null || expandedTileId === tileId;
+    if (!isVisible || !tileId || !sourcePoster || !destinationPoster) {
+      return undefined;
+    }
+    return sourcePoster.registerConsumer(tileId);
+  }, [destinationPoster, expandedTileId, sourcePoster, tileId]);
+  const posterSessionKey = useMemo(
+    () => `${sourcePoster?.sourceKey ?? ""}\n${stream}`,
+    [sourcePoster?.sourceKey, stream],
+  );
+  const destinationPosterKey = destinationPoster ? posterSessionKey : null;
+  const handleDestinationPosterLoaded = useCallback(() => {
+    // Poster decode is only a display-ready edge. Real stream frames remain
+    // authoritative for calibration, annotations, and projection geometry.
+    if (destinationPosterKey) setCommittedPosterKey(destinationPosterKey);
+  }, [destinationPosterKey]);
   const selectedImageSource =
     images.find((source) => source.id === stream) ?? null;
   const annotationStreams = useMemo(
@@ -863,7 +916,7 @@ const ImageTile: React.FC<EpisodeTileProps> = ({ initialSourceId }) => {
 
   return (
     <>
-      {frame && playbackFrame ? (
+      {(frame && playbackFrame) || destinationPoster ? (
         <div
           className={styles.imageStack}
           {...hoverProps}
@@ -874,9 +927,33 @@ const ImageTile: React.FC<EpisodeTileProps> = ({ initialSourceId }) => {
           ref={imagePanZoom.surfaceRef}
           style={imagePanZoom.surfaceStyle}
         >
-          {frame.kind === "encoded-video" ? (
-            frame.codec === "h264" ? (
-              <VideoPanel
+          {frame && playbackFrame ? (
+            frame.kind === "encoded-video" ? (
+              frame.codec === "h264" ? (
+                <VideoPanel
+                  canvasSurface="modal-image"
+                  className={styles.panel}
+                  fit={IMAGE_FIT}
+                  frame={frame}
+                  notices={imageNotices}
+                  onImageLoaded={handleImageLoaded}
+                  onResetView={imagePanZoom.resetView}
+                  priority={isPlaying ? "playing" : "visible"}
+                  sceneChildren={panelSceneChildren}
+                  stream={stream}
+                  targetTimeNs={playbackFrame.contentTimeNs}
+                  textureMesh={
+                    rectifiedViewActive ? rectifiedDisplay?.textureMesh : null
+                  }
+                  viewTransform={imagePanZoom.viewTransform}
+                />
+              ) : (
+                <div className={styles.panel} role="alert">
+                  Video codec {frame.codec} is unsupported
+                </div>
+              )
+            ) : (
+              <ImagePanel
                 canvasSurface="modal-image"
                 className={styles.panel}
                 fit={IMAGE_FIT}
@@ -884,37 +961,33 @@ const ImageTile: React.FC<EpisodeTileProps> = ({ initialSourceId }) => {
                 notices={imageNotices}
                 onImageLoaded={handleImageLoaded}
                 onResetView={imagePanZoom.resetView}
-                priority={isPlaying ? "playing" : "visible"}
                 sceneChildren={panelSceneChildren}
-                stream={stream}
-                targetTimeNs={playbackFrame.contentTimeNs}
                 textureMesh={
                   rectifiedViewActive ? rectifiedDisplay?.textureMesh : null
                 }
+                textureKey={textureKey}
                 viewTransform={imagePanZoom.viewTransform}
               />
-            ) : (
-              <div className={styles.panel} role="alert">
-                Video codec {frame.codec} is unsupported
-              </div>
             )
-          ) : (
-            <ImagePanel
-              canvasSurface="modal-image"
-              className={styles.panel}
-              fit={IMAGE_FIT}
-              frame={frame}
-              notices={imageNotices}
-              onImageLoaded={handleImageLoaded}
-              onResetView={imagePanZoom.resetView}
-              sceneChildren={panelSceneChildren}
-              textureMesh={
-                rectifiedViewActive ? rectifiedDisplay?.textureMesh : null
+          ) : null}
+          {destinationPoster ? (
+            <div
+              className={styles.destinationPoster}
+              data-episode-destination-poster=""
+              data-episode-destination-poster-ready={
+                committedPosterKey === destinationPosterKey || undefined
               }
-              textureKey={textureKey}
-              viewTransform={imagePanZoom.viewTransform}
-            />
-          )}
+              data-testid="episode-destination-poster"
+            >
+              <BitmapImageFrameView
+                className={styles.panel}
+                fit={IMAGE_FIT}
+                frame={destinationPoster}
+                onImageLoaded={handleDestinationPosterLoaded}
+                videoSessionKey={posterSessionKey}
+              />
+            </div>
+          ) : null}
           {activeDepthHover ? (
             <DepthHoverOverlay
               {...activeDepthHover}

--- a/app/packages/multimodal/src/views/episode/image/destination-poster.test.ts
+++ b/app/packages/multimodal/src/views/episode/image/destination-poster.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldPresentDestinationPoster } from "./destination-poster";
+
+describe("shouldPresentDestinationPoster", () => {
+  const base = {
+    committedSourceKey: null,
+    committedStream: null,
+    dataStreamSourceKey: "source-a",
+    posterSourceKey: "source-a",
+    posterStreamId: "/camera/front",
+    stream: "/camera/front",
+  } as const;
+
+  it("presents the destination poster before the data stream is bound", () => {
+    expect(
+      shouldPresentDestinationPoster({
+        ...base,
+        dataStreamSourceKey: "",
+      }),
+    ).toBe(true);
+  });
+
+  it("never re-presents the poster after the first destination frame commits", () => {
+    expect(
+      shouldPresentDestinationPoster({
+        ...base,
+        committedSourceKey: "source-a",
+        committedStream: "/camera/front",
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects a poster for another visible source or stream", () => {
+    expect(
+      shouldPresentDestinationPoster({
+        ...base,
+        dataStreamSourceKey: "source-b",
+      }),
+    ).toBe(false);
+    expect(
+      shouldPresentDestinationPoster({
+        ...base,
+        stream: "/camera/rear",
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects a poster without a resolved stream identity", () => {
+    expect(
+      shouldPresentDestinationPoster({ ...base, posterStreamId: null }),
+    ).toBe(false);
+  });
+
+  it("presents the poster when only part of the prior frame identity matches", () => {
+    expect(
+      shouldPresentDestinationPoster({
+        ...base,
+        committedSourceKey: "source-previous",
+        committedStream: "/camera/front",
+      }),
+    ).toBe(true);
+    expect(
+      shouldPresentDestinationPoster({
+        ...base,
+        committedSourceKey: "source-a",
+        committedStream: "/camera/rear",
+      }),
+    ).toBe(true);
+  });
+});

--- a/app/packages/multimodal/src/views/episode/image/destination-poster.ts
+++ b/app/packages/multimodal/src/views/episode/image/destination-poster.ts
@@ -1,0 +1,28 @@
+export interface DestinationPosterIdentity {
+  readonly committedSourceKey: string | null;
+  readonly committedStream: string | null;
+  readonly dataStreamSourceKey: string;
+  readonly posterSourceKey: string;
+  readonly posterStreamId: string | null;
+  readonly stream: string;
+}
+
+/**
+ * Shows a source-authenticated bootstrap poster until this tile commits its
+ * first real frame for the destination source and stream.
+ */
+export function shouldPresentDestinationPoster({
+  committedSourceKey,
+  committedStream,
+  dataStreamSourceKey,
+  posterSourceKey,
+  posterStreamId,
+  stream,
+}: DestinationPosterIdentity): boolean {
+  if (posterStreamId !== stream) return false;
+  if (dataStreamSourceKey && dataStreamSourceKey !== posterSourceKey) {
+    return false;
+  }
+
+  return committedSourceKey !== posterSourceKey || committedStream !== stream;
+}

--- a/app/packages/multimodal/src/views/episode/image/source-poster-context.tsx
+++ b/app/packages/multimodal/src/views/episode/image/source-poster-context.tsx
@@ -1,0 +1,37 @@
+import { createContext, useContext, type ReactNode } from "react";
+
+import type { EpisodePosterFrame } from "../../../ir";
+
+type SourcePosterImage = Extract<
+  EpisodePosterFrame,
+  { readonly kind: "image" }
+>;
+
+export interface SourcePosterValue {
+  readonly frame: SourcePosterImage["image"];
+  readonly registerConsumer: (consumerId: string) => () => void;
+  readonly sourceKey: string;
+  readonly streamId: string | null;
+}
+
+const SourcePosterContext = createContext<SourcePosterValue | null>(null);
+
+/** Supplies a source-authenticated grid poster to destination modal tiles. */
+export function SourcePosterProvider({
+  children,
+  value,
+}: {
+  readonly children: ReactNode;
+  readonly value: SourcePosterValue | null;
+}) {
+  return (
+    <SourcePosterContext.Provider value={value}>
+      {children}
+    </SourcePosterContext.Provider>
+  );
+}
+
+/** Returns the current source's destination poster, when the grid captured one. */
+export function useSourcePoster(): SourcePosterValue | null {
+  return useContext(SourcePosterContext);
+}

--- a/app/packages/multimodal/src/views/episode/playback/AdjacentSamplePrewarm.test.tsx
+++ b/app/packages/multimodal/src/views/episode/playback/AdjacentSamplePrewarm.test.tsx
@@ -7,6 +7,7 @@ import { AdjacentSamplePrewarm } from "./AdjacentSamplePrewarm";
 const prewarmHarness = vi.hoisted(() => ({
   buffering: false,
   episodeSource: { episodeId: "next" },
+  episodeSourceFromByteSource: vi.fn(),
   isPlayPending: false,
   neighbor: { sample: { _id: "next" } },
   openEpisodePreviewSession: vi.fn(),
@@ -46,7 +47,7 @@ vi.mock("../../../runtime", () => ({
 
 vi.mock("../../session/episode-source", () => ({
   episodeByteSourceFromSample: () => prewarmHarness.source,
-  episodeSourceFromByteSource: () => prewarmHarness.episodeSource,
+  episodeSourceFromByteSource: prewarmHarness.episodeSourceFromByteSource,
   sampleDescriptorFromSample: () => ({
     mediaType: "group",
     path: "next.mcap",
@@ -62,6 +63,10 @@ describe("AdjacentSamplePrewarm", () => {
     });
     prewarmHarness.buffering = false;
     prewarmHarness.isPlayPending = false;
+    prewarmHarness.episodeSourceFromByteSource.mockReset();
+    prewarmHarness.episodeSourceFromByteSource.mockReturnValue(
+      prewarmHarness.episodeSource,
+    );
     prewarmHarness.openEpisodePreviewSession.mockReset();
     prewarmHarness.peekSourceBootstrap.mockReset();
     prewarmHarness.prewarmEpisodeSource.mockReset();
@@ -133,6 +138,89 @@ describe("AdjacentSamplePrewarm", () => {
       prewarmHarness.publishEpisodePreviewBootstrap.mock.invocationCallOrder[0],
     ).toBeLessThan(
       prewarmHarness.prewarmEpisodeSource.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("passes preview-derived hints to the byte prewarm", async () => {
+    const manifest = { streams: [] } as const;
+    const timeline = {
+      endNs: 30n,
+      startNs: 10n,
+      timeDomainId: "recording",
+    } as const;
+    const result = {
+      bootstrapManifest: manifest,
+      bootstrapTimeline: timeline,
+      frame: {
+        image: {
+          bytes: new Uint8Array([1, 2, 3]),
+          kind: "encoded-image",
+          mimeType: "image/jpeg",
+        },
+        kind: "image",
+      },
+      status: "ready",
+      streamId: "/camera/front",
+      streamSourceName: "/camera/front",
+      streamSourceNames: ["/camera/front"],
+    } as const;
+    let cachedHints: {
+      manifest: typeof manifest;
+      timeline: typeof timeline;
+    } | null = null;
+    prewarmHarness.peekSourceBootstrap.mockImplementation(() =>
+      cachedHints
+        ? { manifest: cachedHints.manifest, poster: result.frame }
+        : null,
+    );
+    prewarmHarness.episodeSourceFromByteSource.mockImplementation(() => ({
+      ...prewarmHarness.episodeSource,
+      ...(cachedHints
+        ? {
+            manifestHint: cachedHints.manifest,
+            playbackHint: cachedHints.timeline,
+          }
+        : {}),
+    }));
+    prewarmHarness.publishEpisodePreviewBootstrap.mockImplementation(() => {
+      cachedHints = { manifest, timeline };
+    });
+    prewarmHarness.previewRead.mockResolvedValue(result);
+    prewarmHarness.openEpisodePreviewSession.mockResolvedValue({
+      dispose: prewarmHarness.previewDispose,
+      read: prewarmHarness.previewRead,
+    });
+    prewarmHarness.prewarmEpisodeSource.mockResolvedValue(true);
+
+    render(
+      <EpisodeSourceReadyProvider ready>
+        <AdjacentSamplePrewarm
+          ctx={
+            {
+              dataset: { mediaType: "group" },
+              media: { field: "mcap" },
+              sample: { sample: { _id: "current-with-hints" } },
+            } as never
+          }
+        />
+      </EpisodeSourceReadyProvider>,
+    );
+
+    await act(async () => vi.runAllTimersAsync());
+
+    expect(prewarmHarness.episodeSourceFromByteSource).toHaveBeenCalledTimes(2);
+    expect(prewarmHarness.openEpisodePreviewSession).toHaveBeenCalledWith(
+      expect.anything(),
+      prewarmHarness.episodeSource,
+      expect.anything(),
+    );
+    expect(prewarmHarness.prewarmEpisodeSource).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        manifestHint: manifest,
+        playbackHint: timeline,
+      }),
+      expect.any(AbortSignal),
     );
   });
 

--- a/app/packages/multimodal/src/views/episode/playback/AdjacentSamplePrewarm.test.tsx
+++ b/app/packages/multimodal/src/views/episode/playback/AdjacentSamplePrewarm.test.tsx
@@ -1,0 +1,397 @@
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { EpisodeSourceReadyProvider } from "./source-ready-context";
+import { AdjacentSamplePrewarm } from "./AdjacentSamplePrewarm";
+
+const prewarmHarness = vi.hoisted(() => ({
+  buffering: false,
+  episodeSource: { episodeId: "next" },
+  isPlayPending: false,
+  neighbor: { sample: { _id: "next" } },
+  openEpisodePreviewSession: vi.fn(),
+  peekSourceBootstrap: vi.fn(),
+  prewarmEpisodeSource: vi.fn(),
+  previewDispose: vi.fn(),
+  previewRead: vi.fn(),
+  publishEpisodePreviewBootstrap: vi.fn(),
+  publishSourceBootstrap: vi.fn(),
+  source: { sourceId: "next", url: "memory://next.mcap" },
+  sourceAccessKey: "next-access-key-0",
+  sourceAccessKeyCounter: 0,
+}));
+
+vi.mock("@fiftyone/playback/runtime", () => ({
+  getIsBuffering: () => prewarmHarness.buffering,
+  getIsPlayPending: () => prewarmHarness.isPlayPending,
+  useIsBuffering: () => prewarmHarness.buffering,
+  useIsPlayPending: () => prewarmHarness.isPlayPending,
+  usePlaybackStore: () => ({ get: () => ({ limited: false }) }),
+}));
+
+vi.mock("@fiftyone/state", () => ({
+  modalNavigation: {
+    get: () => ({ peek: vi.fn(async () => prewarmHarness.neighbor) }),
+  },
+}));
+
+vi.mock("../../../runtime", () => ({
+  episodeSourceAccessKey: () => prewarmHarness.sourceAccessKey,
+  openEpisodePreviewSession: prewarmHarness.openEpisodePreviewSession,
+  peekSourceBootstrap: prewarmHarness.peekSourceBootstrap,
+  prewarmEpisodeSource: prewarmHarness.prewarmEpisodeSource,
+  publishEpisodePreviewBootstrap: prewarmHarness.publishEpisodePreviewBootstrap,
+  publishSourceBootstrap: prewarmHarness.publishSourceBootstrap,
+}));
+
+vi.mock("../../session/episode-source", () => ({
+  episodeByteSourceFromSample: () => prewarmHarness.source,
+  episodeSourceFromByteSource: () => prewarmHarness.episodeSource,
+  sampleDescriptorFromSample: () => ({
+    mediaType: "group",
+    path: "next.mcap",
+  }),
+}));
+
+describe("AdjacentSamplePrewarm", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal("requestIdleCallback", (callback: () => void) => {
+      callback();
+      return 1;
+    });
+    prewarmHarness.buffering = false;
+    prewarmHarness.isPlayPending = false;
+    prewarmHarness.openEpisodePreviewSession.mockReset();
+    prewarmHarness.peekSourceBootstrap.mockReset();
+    prewarmHarness.prewarmEpisodeSource.mockReset();
+    prewarmHarness.previewDispose.mockReset();
+    prewarmHarness.previewRead.mockReset();
+    prewarmHarness.publishEpisodePreviewBootstrap.mockReset();
+    prewarmHarness.publishSourceBootstrap.mockReset();
+    prewarmHarness.sourceAccessKey = `next-access-key-${++prewarmHarness.sourceAccessKeyCounter}`;
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("publishes an adjacent poster before the heavier byte prewarm", async () => {
+    const result = {
+      frame: {
+        image: {
+          bytes: new Uint8Array([1, 2, 3]),
+          kind: "encoded-image",
+          mimeType: "image/jpeg",
+        },
+        kind: "image",
+      },
+      status: "ready",
+      streamId: "/camera/front",
+      streamSourceName: "/camera/front",
+      streamSourceNames: ["/camera/front"],
+    } as const;
+    prewarmHarness.peekSourceBootstrap
+      .mockReturnValueOnce(null)
+      .mockReturnValue({ manifest: {}, poster: result.frame });
+    prewarmHarness.previewRead.mockResolvedValue(result);
+    prewarmHarness.openEpisodePreviewSession.mockResolvedValue({
+      dispose: prewarmHarness.previewDispose,
+      read: prewarmHarness.previewRead,
+    });
+    prewarmHarness.prewarmEpisodeSource.mockResolvedValue(true);
+
+    render(
+      <EpisodeSourceReadyProvider ready>
+        <AdjacentSamplePrewarm
+          ctx={
+            {
+              dataset: { mediaType: "group" },
+              media: { field: "mcap" },
+              sample: { sample: { _id: "current" } },
+            } as never
+          }
+        />
+      </EpisodeSourceReadyProvider>,
+    );
+
+    await act(async () => vi.runAllTimersAsync());
+
+    expect(prewarmHarness.previewRead).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({ priority: "idle" }),
+    );
+    expect(prewarmHarness.publishEpisodePreviewBootstrap).toHaveBeenCalledWith(
+      prewarmHarness.source,
+      result,
+    );
+    expect(prewarmHarness.previewDispose).toHaveBeenCalledOnce();
+    expect(prewarmHarness.prewarmEpisodeSource).toHaveBeenCalledOnce();
+    expect(
+      prewarmHarness.publishEpisodePreviewBootstrap.mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      prewarmHarness.prewarmEpisodeSource.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("does no speculative work before the current source is ready", async () => {
+    render(
+      <EpisodeSourceReadyProvider ready={false}>
+        <AdjacentSamplePrewarm
+          ctx={
+            {
+              dataset: { mediaType: "group" },
+              media: { field: "mcap" },
+              sample: { sample: { _id: "not-ready" } },
+            } as never
+          }
+        />
+      </EpisodeSourceReadyProvider>,
+    );
+
+    await act(async () => vi.runAllTimersAsync());
+
+    expect(prewarmHarness.openEpisodePreviewSession).not.toHaveBeenCalled();
+    expect(prewarmHarness.prewarmEpisodeSource).not.toHaveBeenCalled();
+  });
+
+  it.each(["buffering", "isPlayPending"] as const)(
+    "does no speculative work while playback is %s",
+    async (gate) => {
+      prewarmHarness[gate] = true;
+
+      render(
+        <EpisodeSourceReadyProvider ready>
+          <AdjacentSamplePrewarm
+            ctx={
+              {
+                dataset: { mediaType: "group" },
+                media: { field: "mcap" },
+                sample: { sample: { _id: `current-${gate}` } },
+              } as never
+            }
+          />
+        </EpisodeSourceReadyProvider>,
+      );
+
+      await act(async () => vi.runAllTimersAsync());
+
+      expect(prewarmHarness.openEpisodePreviewSession).not.toHaveBeenCalled();
+      expect(prewarmHarness.prewarmEpisodeSource).not.toHaveBeenCalled();
+    },
+  );
+
+  it("backs off after foreground playback releases the link", async () => {
+    prewarmHarness.buffering = true;
+    prewarmHarness.peekSourceBootstrap.mockReturnValue({
+      previewReadComplete: true,
+    });
+    prewarmHarness.prewarmEpisodeSource.mockResolvedValue(true);
+    const ctx = {
+      dataset: { mediaType: "group" },
+      media: { field: "mcap" },
+      sample: { sample: { _id: "foreground-gate" } },
+    } as never;
+    const view = render(
+      <EpisodeSourceReadyProvider ready>
+        <AdjacentSamplePrewarm ctx={ctx} />
+      </EpisodeSourceReadyProvider>,
+    );
+
+    prewarmHarness.buffering = false;
+    view.rerender(
+      <EpisodeSourceReadyProvider ready>
+        <AdjacentSamplePrewarm ctx={ctx} />
+      </EpisodeSourceReadyProvider>,
+    );
+
+    await act(async () => vi.advanceTimersByTimeAsync(4_999));
+    expect(prewarmHarness.prewarmEpisodeSource).not.toHaveBeenCalled();
+
+    await act(async () => vi.advanceTimersByTimeAsync(1));
+    expect(prewarmHarness.prewarmEpisodeSource).toHaveBeenCalledOnce();
+  });
+
+  it("recaptures an evicted poster without repeating the byte prewarm", async () => {
+    const result = {
+      bootstrapManifest: { streams: [] },
+      frame: {
+        image: {
+          bytes: new Uint8Array([1, 2, 3]),
+          kind: "encoded-image",
+          mimeType: "image/jpeg",
+        },
+        kind: "image",
+      },
+      status: "ready",
+      streamId: "/camera/front",
+      streamSourceName: "/camera/front",
+      streamSourceNames: ["/camera/front"],
+    } as const;
+    const cachedBootstrap = {
+      manifest: result.bootstrapManifest,
+      poster: result.frame,
+    };
+    prewarmHarness.peekSourceBootstrap.mockReturnValue(cachedBootstrap);
+    prewarmHarness.prewarmEpisodeSource.mockResolvedValue(true);
+
+    const first = render(
+      <EpisodeSourceReadyProvider ready>
+        <AdjacentSamplePrewarm
+          ctx={
+            {
+              dataset: { mediaType: "group" },
+              media: { field: "mcap" },
+              sample: { sample: { _id: "current-a" } },
+            } as never
+          }
+        />
+      </EpisodeSourceReadyProvider>,
+    );
+    await act(async () => vi.runAllTimersAsync());
+    expect(prewarmHarness.prewarmEpisodeSource).toHaveBeenCalledOnce();
+    expect(prewarmHarness.openEpisodePreviewSession).not.toHaveBeenCalled();
+
+    first.unmount();
+    prewarmHarness.peekSourceBootstrap
+      .mockReset()
+      .mockReturnValueOnce(null)
+      .mockReturnValue(cachedBootstrap);
+    prewarmHarness.previewRead.mockResolvedValue(result);
+    prewarmHarness.openEpisodePreviewSession.mockResolvedValue({
+      dispose: prewarmHarness.previewDispose,
+      read: prewarmHarness.previewRead,
+    });
+
+    render(
+      <EpisodeSourceReadyProvider ready>
+        <AdjacentSamplePrewarm
+          ctx={
+            {
+              dataset: { mediaType: "group" },
+              media: { field: "mcap" },
+              sample: { sample: { _id: "current-b" } },
+            } as never
+          }
+        />
+      </EpisodeSourceReadyProvider>,
+    );
+    await act(async () => vi.runAllTimersAsync());
+
+    expect(prewarmHarness.publishEpisodePreviewBootstrap).toHaveBeenCalledWith(
+      prewarmHarness.source,
+      result,
+    );
+    expect(prewarmHarness.prewarmEpisodeSource).toHaveBeenCalledOnce();
+  });
+
+  it("does not repeat a completed posterless preview while its marker is cached", async () => {
+    const result = {
+      frame: null,
+      status: "empty",
+      streamId: null,
+      streamSourceName: null,
+      streamSourceNames: [],
+    } as const;
+    prewarmHarness.peekSourceBootstrap.mockReturnValue(null);
+    prewarmHarness.publishEpisodePreviewBootstrap.mockImplementation(() => {
+      prewarmHarness.peekSourceBootstrap.mockReturnValue({
+        previewReadComplete: true,
+      });
+    });
+    prewarmHarness.previewRead.mockResolvedValue(result);
+    prewarmHarness.openEpisodePreviewSession.mockResolvedValue({
+      dispose: prewarmHarness.previewDispose,
+      read: prewarmHarness.previewRead,
+    });
+    prewarmHarness.prewarmEpisodeSource.mockResolvedValue(true);
+
+    const first = render(
+      <EpisodeSourceReadyProvider ready>
+        <AdjacentSamplePrewarm
+          ctx={
+            {
+              dataset: { mediaType: "group" },
+              media: { field: "mcap" },
+              sample: { sample: { _id: "posterless-a" } },
+            } as never
+          }
+        />
+      </EpisodeSourceReadyProvider>,
+    );
+    await act(async () => vi.runAllTimersAsync());
+    expect(prewarmHarness.openEpisodePreviewSession).toHaveBeenCalledOnce();
+
+    first.unmount();
+    prewarmHarness.peekSourceBootstrap.mockReturnValue({
+      previewReadComplete: true,
+    });
+    render(
+      <EpisodeSourceReadyProvider ready>
+        <AdjacentSamplePrewarm
+          ctx={
+            {
+              dataset: { mediaType: "group" },
+              media: { field: "mcap" },
+              sample: { sample: { _id: "posterless-b" } },
+            } as never
+          }
+        />
+      </EpisodeSourceReadyProvider>,
+    );
+    await act(async () => vi.runAllTimersAsync());
+
+    expect(prewarmHarness.openEpisodePreviewSession).toHaveBeenCalledOnce();
+  });
+
+  it("does not repeatedly open an unsupported preview session", async () => {
+    prewarmHarness.peekSourceBootstrap.mockReturnValue(null);
+    prewarmHarness.publishSourceBootstrap.mockImplementation(() => {
+      prewarmHarness.peekSourceBootstrap.mockReturnValue({
+        previewReadComplete: true,
+      });
+    });
+    prewarmHarness.openEpisodePreviewSession.mockResolvedValue(null);
+    prewarmHarness.prewarmEpisodeSource.mockResolvedValue(true);
+
+    const first = render(
+      <EpisodeSourceReadyProvider ready>
+        <AdjacentSamplePrewarm
+          ctx={
+            {
+              dataset: { mediaType: "group" },
+              media: { field: "mcap" },
+              sample: { sample: { _id: "unsupported-a" } },
+            } as never
+          }
+        />
+      </EpisodeSourceReadyProvider>,
+    );
+    await act(async () => vi.runAllTimersAsync());
+
+    expect(prewarmHarness.publishSourceBootstrap).toHaveBeenCalledWith(
+      prewarmHarness.source,
+      { previewReadComplete: true },
+    );
+    first.unmount();
+
+    render(
+      <EpisodeSourceReadyProvider ready>
+        <AdjacentSamplePrewarm
+          ctx={
+            {
+              dataset: { mediaType: "group" },
+              media: { field: "mcap" },
+              sample: { sample: { _id: "unsupported-b" } },
+            } as never
+          }
+        />
+      </EpisodeSourceReadyProvider>,
+    );
+    await act(async () => vi.runAllTimersAsync());
+
+    expect(prewarmHarness.openEpisodePreviewSession).toHaveBeenCalledOnce();
+  });
+});

--- a/app/packages/multimodal/src/views/episode/playback/AdjacentSamplePrewarm.tsx
+++ b/app/packages/multimodal/src/views/episode/playback/AdjacentSamplePrewarm.tsx
@@ -151,11 +151,11 @@ export function AdjacentSamplePrewarm({
             mediaField,
             mediaType,
           );
-          const episodeSource = episodeSourceFromByteSource(source);
           if (needsPreview) {
+            const previewSource = episodeSourceFromByteSource(source);
             const preview = await openEpisodePreviewSession(
               sampleDescriptor,
-              episodeSource,
+              previewSource,
               { signal: abort.signal },
             );
             try {
@@ -190,9 +190,10 @@ export function AdjacentSamplePrewarm({
             continue;
           }
 
+          const prewarmSource = episodeSourceFromByteSource(source);
           const prewarmed = await prewarmEpisodeSource(
             sampleDescriptor,
-            episodeSource,
+            prewarmSource,
             abort.signal,
           );
           if (prewarmed && !abort.signal.aborted) {

--- a/app/packages/multimodal/src/views/episode/playback/AdjacentSamplePrewarm.tsx
+++ b/app/packages/multimodal/src/views/episode/playback/AdjacentSamplePrewarm.tsx
@@ -3,21 +3,34 @@ import type {
   SampleRendererSampleLike,
 } from "@fiftyone/plugins";
 // The view-free runtime entry avoids loading playback view Relay fragments.
-import { usePlaybackStore } from "@fiftyone/playback/runtime";
-import { getIsBuffering, getIsPlayPending } from "@fiftyone/playback/runtime";
+import {
+  getIsBuffering,
+  getIsPlayPending,
+  useIsBuffering,
+  useIsPlayPending,
+  usePlaybackStore,
+} from "@fiftyone/playback/runtime";
 import type { PlaybackStore } from "@fiftyone/playback/runtime";
 import { modalNavigation } from "@fiftyone/state";
-import { useEffect } from "react";
-import { episodeSourceAccessKey, prewarmEpisodeSource } from "../../../runtime";
+import { useEffect, useRef } from "react";
+import {
+  episodeSourceAccessKey,
+  openEpisodePreviewSession,
+  peekSourceBootstrap,
+  prewarmEpisodeSource,
+  publishEpisodePreviewBootstrap,
+  publishSourceBootstrap,
+} from "../../../runtime";
 import {
   episodeByteSourceFromSample,
   episodeSourceFromByteSource,
   sampleDescriptorFromSample,
 } from "../../session/episode-source";
 import { getNetworkHealth } from "./network-health";
+import { useEpisodeSourceReady } from "./source-ready-context";
 
-/** Settle time for the current sample before spending idle bandwidth. */
-const PREWARM_START_DELAY_MS = 3_000;
+/** Yield one task after the real current-source ready edge. */
+const PREWARM_START_DELAY_MS = 0;
 
 /** Re-check cadence while playback or the network needs the link. */
 const PREWARM_RETRY_DELAY_MS = 5_000;
@@ -32,11 +45,11 @@ const prewarmedSourceKeys = new Set<string>();
 
 /**
  * Non-visual worker that prewarms the adjacent samples' startup bytes at
- * idle: after a settle delay (and only while playback is not waiting on
- * data and the network is not limited), it peeks the modal's neighbors,
- * builds their episode sources, and warms the shared persistent byte cache
- * so the hop's cold reads skip the network. Mount inside the playback
- * shell — it reads the shell's store for the buffering and health gates.
+ * idle: after the current source's real ready edge (and only while playback
+ * is not waiting on data and the network is not limited), it captures the
+ * next samples' manifest/poster before warming the shared persistent byte
+ * cache. Mount inside the playback shell — it reads the shell's store for
+ * the buffering and health gates.
  */
 export function AdjacentSamplePrewarm({
   ctx,
@@ -44,15 +57,35 @@ export function AdjacentSamplePrewarm({
   readonly ctx: SampleRendererProps["ctx"];
 }) {
   const store = usePlaybackStore();
+  const sourceReady = useEpisodeSourceReady();
+  // These subscriptions abort an in-flight speculative read as soon as
+  // foreground playback needs the link; shouldYieldLink gates pass boundaries.
+  const isBuffering = useIsBuffering();
+  const isPlayPending = useIsPlayPending();
+  const retryAfterForegroundGateRef = useRef(false);
   const mediaField = ctx.media.field;
   const mediaType = ctx.dataset.mediaType;
   const currentSample = ctx.sample.sample as { _id?: string; id?: string };
   const sampleId = currentSample._id ?? currentSample.id;
 
   // This effect schedules the advisory prewarm pass for the mounted
-  // source's neighbors: browser-idle callback after a settle delay,
+  // source's neighbors: browser-idle callback after the real ready edge,
   // re-scheduled while the link is needed elsewhere, aborted on unmount.
   useEffect(() => {
+    if (!sourceReady) {
+      retryAfterForegroundGateRef.current = false;
+      return undefined;
+    }
+    if (isBuffering || isPlayPending) {
+      retryAfterForegroundGateRef.current = true;
+      return undefined;
+    }
+
+    const startDelayMs = retryAfterForegroundGateRef.current
+      ? PREWARM_RETRY_DELAY_MS
+      : PREWARM_START_DELAY_MS;
+    retryAfterForegroundGateRef.current = false;
+
     const abort = new AbortController();
     let timer: ReturnType<typeof setTimeout> | null = null;
     let disposed = false;
@@ -104,13 +137,62 @@ export function AdjacentSamplePrewarm({
           }
 
           const sourceKey = episodeSourceAccessKey(source);
-          if (prewarmedSourceKeys.has(sourceKey)) {
+          const bootstrap = peekSourceBootstrap(source);
+          const needsPreview =
+            bootstrap?.previewReadComplete !== true &&
+            (!bootstrap?.manifest || !bootstrap.poster);
+          const sourceAlreadyPrewarmed = prewarmedSourceKeys.has(sourceKey);
+          if (!needsPreview && sourceAlreadyPrewarmed) {
+            continue;
+          }
+
+          const sampleDescriptor = sampleDescriptorFromSample(
+            neighborSample,
+            mediaField,
+            mediaType,
+          );
+          const episodeSource = episodeSourceFromByteSource(source);
+          if (needsPreview) {
+            const preview = await openEpisodePreviewSession(
+              sampleDescriptor,
+              episodeSource,
+              { signal: abort.signal },
+            );
+            try {
+              const result = await preview?.read(
+                {},
+                { priority: "idle", signal: abort.signal },
+              );
+              if (result && !abort.signal.aborted) {
+                publishEpisodePreviewBootstrap(source, result);
+              } else if (!abort.signal.aborted) {
+                // Some adapters cannot open a lightweight preview. Remember
+                // that outcome in the bounded LRU so every idle pass does not
+                // retry the same unsupported operation.
+                publishSourceBootstrap(source, { previewReadComplete: true });
+              }
+            } finally {
+              preview?.dispose();
+            }
+          }
+
+          if (disposed || abort.signal.aborted) {
+            return;
+          }
+          if (shouldYieldLink(store)) {
+            schedule(PREWARM_RETRY_DELAY_MS);
+            return;
+          }
+
+          // Preview facts have their own bounded LRU and may need recapturing
+          // after eviction even when the persistent startup bytes are warm.
+          if (sourceAlreadyPrewarmed) {
             continue;
           }
 
           const prewarmed = await prewarmEpisodeSource(
-            sampleDescriptorFromSample(neighborSample, mediaField, mediaType),
-            episodeSourceFromByteSource(source),
+            sampleDescriptor,
+            episodeSource,
             abort.signal,
           );
           if (prewarmed && !abort.signal.aborted) {
@@ -122,7 +204,7 @@ export function AdjacentSamplePrewarm({
       }
     };
 
-    schedule(PREWARM_START_DELAY_MS);
+    schedule(startDelayMs);
 
     return () => {
       disposed = true;
@@ -131,7 +213,15 @@ export function AdjacentSamplePrewarm({
       }
       abort.abort();
     };
-  }, [store, mediaField, mediaType, sampleId]);
+  }, [
+    store,
+    mediaField,
+    mediaType,
+    sampleId,
+    sourceReady,
+    isBuffering,
+    isPlayPending,
+  ]);
 
   return null;
 }

--- a/app/packages/multimodal/src/views/episode/playback/source-ready-context.tsx
+++ b/app/packages/multimodal/src/views/episode/playback/source-ready-context.tsx
@@ -1,0 +1,23 @@
+import { createContext, useContext, type ReactNode } from "react";
+
+const EpisodeSourceReadyContext = createContext(false);
+
+/** Publishes the current source's real playhead-ready edge to idle workers. */
+export function EpisodeSourceReadyProvider({
+  children,
+  ready,
+}: {
+  readonly children: ReactNode;
+  readonly ready: boolean;
+}) {
+  return (
+    <EpisodeSourceReadyContext.Provider value={ready}>
+      {children}
+    </EpisodeSourceReadyContext.Provider>
+  );
+}
+
+/** True only after the current source has committed real playhead data. */
+export function useEpisodeSourceReady(): boolean {
+  return useContext(EpisodeSourceReadyContext);
+}

--- a/app/packages/multimodal/src/views/episode/shell/ModalRenderer.module.css
+++ b/app/packages/multimodal/src/views/episode/shell/ModalRenderer.module.css
@@ -49,6 +49,20 @@
   :global(img) {
   visibility: visible;
 }
+
+/* A grid-captured poster belongs to the incoming source, so it is safe to
+   paint inside its destination tile while outgoing media remains hidden. */
+.playbackRoot[data-episode-source-transitioning="true"]
+  :global([data-episode-destination-poster])
+  :global(canvas),
+.playbackRoot[data-episode-source-transitioning="true"]
+  :global([data-episode-destination-poster])
+  :global(img),
+.playbackRoot[data-episode-source-transitioning="true"]
+  :global([data-episode-destination-poster])
+  :global(video) {
+  visibility: visible;
+}
 /* stylelint-enable selector-pseudo-class-no-unknown */
 
 .preparing {

--- a/app/packages/multimodal/src/views/episode/shell/SourcePlayback.test.tsx
+++ b/app/packages/multimodal/src/views/episode/shell/SourcePlayback.test.tsx
@@ -1,18 +1,45 @@
 import { PlaybackProvider } from "@fiftyone/playback";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   BYTE_SOURCE_READ_PROFILE,
   type ByteSourceDescriptor,
 } from "../../../query/bytes";
 import type { EpisodeSession } from "../../../ports";
-import type { EpisodeRecordingFacts, StreamDescriptor } from "../../../ir";
+import {
+  SCENE_SOURCE_METADATA,
+  SCENE_SOURCE_TYPE,
+  type EpisodeManifest,
+  type EpisodePosterFrame,
+  type EpisodeRecordingFacts,
+  type StreamDescriptor,
+} from "../../../ir";
+import {
+  peekSourceBootstrap,
+  publishSourceBootstrap,
+  resetSourceBootstrapCacheForTests,
+} from "../../../runtime";
+import { useSourcePoster } from "../image/source-poster-context";
+import { TILE_TYPE } from "../tiles/tile-types";
 import { SourcePlayback } from "./SourcePlayback";
 
 const playbackHarness = vi.hoisted(() => {
   const harness = {
     nextShellId: 0,
+    posterConsumerEnabled: true,
     sceneInventory: {
       error: null as string | null,
       sources: [] as Array<{ id: string; label: string; type: string }>,
@@ -22,24 +49,26 @@ const playbackHarness = vi.hoisted(() => {
     },
     shellMounts: 0,
     shellUnmounts: 0,
-    useModalLayout: vi.fn(() => ({
+    modalLayoutResult: {
       defaultLeftOpen: true,
       defaultLeftSidebarWidth: undefined,
       initialExpandedTileId: null,
-      initialLayout: undefined,
-      initialTiles: {},
+      initialLayout: undefined as unknown,
+      initialTiles: {} as Record<string, unknown>,
       onLeftOpenChange: vi.fn(),
       onLeftSidebarWidthChange: vi.fn(),
       onSceneUpAxisChange: vi.fn(),
       onTimelineSamplingRateChange: vi.fn(),
       sceneUpAxis: "z",
       timelineSamplingRateHz: 30,
-    })),
+    },
+    useModalLayout: vi.fn(),
     useSceneInventoryState: vi.fn(),
   };
   harness.useSceneInventoryState.mockImplementation(
     () => harness.sceneInventory,
   );
+  harness.useModalLayout.mockImplementation(() => harness.modalLayoutResult);
   return harness;
 });
 
@@ -50,12 +79,14 @@ vi.mock("./PlaybackShell", () => {
     leftSidebar,
     mainOverlay,
     sceneSources,
+    initialTiles,
   }: {
     readonly children?: ReactNode;
     readonly fileName: string;
     readonly leftSidebar?: ReactNode;
     readonly mainOverlay?: ReactNode;
     readonly sceneSources?: readonly { id: string }[];
+    readonly initialTiles?: Readonly<Record<string, unknown>>;
   }) => {
     const instanceIdRef = useRef<number | null>(null);
     if (instanceIdRef.current === null) {
@@ -78,6 +109,11 @@ vi.mock("./PlaybackShell", () => {
           <span data-testid="shell-sources">
             {sceneSources?.map((source) => source.id).join(",") ?? ""}
           </span>
+          <span data-testid="shell-initial-tiles">
+            {Object.keys(initialTiles ?? {})
+              .sort()
+              .join(",")}
+          </span>
           <button
             data-testid="shell-state"
             onClick={() => setShellState((value) => value + 1)}
@@ -93,6 +129,10 @@ vi.mock("./PlaybackShell", () => {
   };
   return { default: MockPlaybackShell };
 });
+
+vi.mock("../../../visualization/media-2d/BitmapImageView", () => ({
+  BitmapImageFrameView: () => <span data-testid="mock-poster-frame" />,
+}));
 
 vi.mock("./AddTileMenu", () => ({ default: () => null }));
 vi.mock("./RightSidebar", () => ({
@@ -132,14 +172,27 @@ vi.mock("./Streams", () => ({
   }: {
     onPlayheadDataReady?: () => void;
     source: ByteSourceDescriptor | null;
-  }) => (
-    <>
-      <span data-testid="stream-source">{source?.sourceId ?? "none"}</span>
-      <button data-testid="stream-ready" onClick={onPlayheadDataReady}>
-        ready
-      </button>
-    </>
-  ),
+  }) => {
+    const sourcePoster = useSourcePoster();
+    const posterConsumerEnabled = playbackHarness.posterConsumerEnabled;
+    useLayoutEffect(() => {
+      if (!posterConsumerEnabled || !sourcePoster?.streamId) return undefined;
+      return sourcePoster.registerConsumer("mock-image-tile");
+    }, [posterConsumerEnabled, sourcePoster]);
+    return (
+      <>
+        <span data-testid="stream-source">{source?.sourceId ?? "none"}</span>
+        <span data-testid="stream-source-poster">
+          {sourcePoster
+            ? `${sourcePoster.streamId}:${sourcePoster.frame.kind}`
+            : "none"}
+        </span>
+        <button data-testid="stream-ready" onClick={onPlayheadDataReady}>
+          ready
+        </button>
+      </>
+    );
+  },
 }));
 vi.mock("../playback/TimestampReadout", () => ({ default: () => null }));
 vi.mock("../layout/use-modal-layout", () => ({
@@ -152,6 +205,7 @@ vi.mock("../stream-discovery/use-scene-inventory", () => ({
 
 describe("SourcePlayback", () => {
   beforeEach(() => {
+    resetSourceBootstrapCacheForTests();
     playbackHarness.sceneInventory = {
       error: null,
       sources: [],
@@ -160,9 +214,26 @@ describe("SourcePlayback", () => {
       streamCount: 3,
     };
     playbackHarness.nextShellId = 0;
+    playbackHarness.posterConsumerEnabled = true;
     playbackHarness.shellMounts = 0;
     playbackHarness.shellUnmounts = 0;
-    playbackHarness.useModalLayout.mockClear();
+    playbackHarness.modalLayoutResult = {
+      defaultLeftOpen: true,
+      defaultLeftSidebarWidth: undefined,
+      initialExpandedTileId: null,
+      initialLayout: undefined,
+      initialTiles: {},
+      onLeftOpenChange: vi.fn(),
+      onLeftSidebarWidthChange: vi.fn(),
+      onSceneUpAxisChange: vi.fn(),
+      onTimelineSamplingRateChange: vi.fn(),
+      sceneUpAxis: "z",
+      timelineSamplingRateHz: 30,
+    };
+    playbackHarness.useModalLayout.mockReset();
+    playbackHarness.useModalLayout.mockImplementation(
+      () => playbackHarness.modalLayoutResult,
+    );
     playbackHarness.useSceneInventoryState.mockClear();
   });
 
@@ -227,19 +298,295 @@ describe("SourcePlayback", () => {
     );
   });
 
-  it("retains recording facts with their source inventory during navigation", () => {
+  it("builds the destination shell and poster from a buffered grid bootstrap", () => {
+    const source = createSource("grid-buffered");
+    const manifest = bootstrapManifest("/camera/front");
+    const poster = bootstrapPoster();
+    publishSourceBootstrap(source, {
+      manifest,
+      poster,
+      posterStreamId: "/camera/front",
+    });
+    playbackHarness.sceneInventory = {
+      error: null,
+      sources: [],
+      status: "loading",
+      streams: [],
+      streamCount: 0,
+    };
+
+    render(
+      <SourcePlayback
+        session={null}
+        fileName="grid-buffered.mcap"
+        source={source}
+      />,
+    );
+
+    expect(screen.queryByTestId("episode-preparing-scaffold")).toBeNull();
+    expect(screen.getByTestId("playback-shell")).toBeTruthy();
+    expect(screen.getByTestId("shell-sources").textContent).toBe(
+      "/camera/front",
+    );
+    expect(screen.getByTestId("stream-source").textContent).toBe("none");
+    expect(screen.getByTestId("stream-source-poster").textContent).toBe(
+      "/camera/front:encoded-image",
+    );
+    expect(screen.queryByTestId("episode-poster-overlay")).toBeNull();
+
+    act(() => {
+      // The cache retains 64 sources; these 65 publishes evict the destination.
+      for (let index = 0; index <= 64; index++) {
+        publishSourceBootstrap(createSource(`grid-overscan-${index}`), {
+          manifest: bootstrapManifest(`/camera/${index}`),
+        });
+      }
+    });
+    expect(peekSourceBootstrap(source)).toBeNull();
+    expect(screen.getByTestId("shell-sources").textContent).toBe(
+      "/camera/front",
+    );
+    expect(screen.getByTestId("stream-source-poster").textContent).toBe("none");
+  });
+
+  it("does not build an empty shell from unclassified bootstrap streams", () => {
+    const source = createSource("unclassified-bootstrap");
+    const manifest = bootstrapManifest("/unknown");
+    publishSourceBootstrap(source, {
+      manifest: {
+        ...manifest,
+        streams: manifest.streams.map((stream) => ({
+          ...stream,
+          metadata: {},
+        })),
+      },
+    });
+    playbackHarness.sceneInventory = {
+      error: null,
+      sources: [],
+      status: "loading",
+      streams: [],
+      streamCount: 0,
+    };
+
+    render(
+      <SourcePlayback
+        session={null}
+        fileName="unclassified-bootstrap.mcap"
+        source={source}
+      />,
+    );
+
+    expect(screen.getByTestId("episode-preparing-scaffold")).toBeTruthy();
+    expect(screen.queryByTestId("playback-shell")).toBeNull();
+  });
+
+  it("keeps the fallback overlay when no tile can consume the poster", () => {
+    const source = createSource("poster-without-image-tile");
+    playbackHarness.posterConsumerEnabled = false;
+    publishSourceBootstrap(source, {
+      manifest: bootstrapManifest("/camera/front"),
+      poster: bootstrapPoster(),
+      posterStreamId: "/camera/front",
+    });
+    playbackHarness.sceneInventory = {
+      error: null,
+      sources: [],
+      status: "loading",
+      streams: [],
+      streamCount: 0,
+    };
+
+    render(
+      <SourcePlayback
+        session={null}
+        fileName="poster-without-image-tile.mcap"
+        source={source}
+      />,
+    );
+
+    expect(screen.getByTestId("episode-poster-overlay")).toBeTruthy();
+  });
+
+  it("reseeds only with authoritative capabilities and timeline mode", () => {
+    const source = createSource("capability-bootstrap");
+    const nextSource = createSource("capability-next");
+    const session = {
+      activate: vi.fn(),
+      numericSeries: {},
+    } as unknown as EpisodeSession;
+    publishSourceBootstrap(source, {
+      manifest: bootstrapManifest("/camera/front"),
+      poster: bootstrapPoster(),
+      posterStreamId: "/camera/front",
+    });
+    playbackHarness.modalLayoutResult = {
+      ...playbackHarness.modalLayoutResult,
+      initialLayout: "image-1",
+      initialTiles: {
+        "image-1": { render: () => null, title: "Image" },
+      },
+    };
+    playbackHarness.sceneInventory = {
+      error: null,
+      sources: [],
+      status: "loading",
+      streams: [],
+      streamCount: 0,
+    };
+
+    const view = render(
+      <SourcePlayback
+        session={session}
+        fileName="capability-bootstrap.mcap"
+        source={source}
+      />,
+    );
+    const bootstrapShellId = screen
+      .getByTestId("playback-shell")
+      .getAttribute("data-instance-id");
+    expect(screen.getByTestId("shell-initial-tiles").textContent).toBe(
+      "image-1",
+    );
+
+    playbackHarness.modalLayoutResult = {
+      ...playbackHarness.modalLayoutResult,
+      initialLayout: {
+        direction: "row",
+        first: "image-1",
+        second: "plot-1",
+      },
+      initialTiles: {
+        "image-1": { render: () => null, title: "Image" },
+        "plot-1": { render: () => null, title: "Plot" },
+      },
+    };
+    playbackHarness.sceneInventory = readyInventory("/camera/front");
+    view.rerender(
+      <SourcePlayback
+        session={session}
+        fileName="capability-bootstrap.mcap"
+        source={source}
+      />,
+    );
+
+    const authoritativeShellId = screen
+      .getByTestId("playback-shell")
+      .getAttribute("data-instance-id");
+    expect(authoritativeShellId).not.toBe(bootstrapShellId);
+    expect(screen.getByTestId("shell-initial-tiles").textContent).toBe(
+      "image-1,plot-1",
+    );
+    expect(playbackHarness.useModalLayout).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        availableTileTypes: expect.arrayContaining([TILE_TYPE.PLOT]),
+      }),
+    );
+
+    const nextManifest = bootstrapManifest("/camera/front");
+    const nextSequenceManifest = {
+      ...nextManifest,
+      streams: nextManifest.streams.map((stream) => ({
+        ...stream,
+        metadata: {
+          ...stream.metadata,
+          "mcap.channel_metadata.timeline_fps": "10",
+          "mcap.channel_metadata.timeline_mode": "sequence",
+        },
+      })),
+    };
+    publishSourceBootstrap(nextSource, {
+      manifest: nextSequenceManifest,
+      poster: bootstrapPoster(),
+      posterStreamId: "/camera/front",
+    });
+    playbackHarness.sceneInventory = {
+      error: null,
+      sources: [],
+      status: "loading",
+      streams: [],
+      streamCount: 0,
+    };
+    view.rerender(
+      <SourcePlayback
+        session={session}
+        fileName="capability-next.mcap"
+        source={nextSource}
+      />,
+    );
+    expect(
+      screen.getByTestId("playback-shell").getAttribute("data-instance-id"),
+    ).toBe(authoritativeShellId);
+    expect(screen.getByTestId("shell-initial-tiles").textContent).toBe(
+      "image-1,plot-1",
+    );
+
+    playbackHarness.sceneInventory = readyInventory(
+      "/camera/front",
+      nextSequenceManifest.streams,
+    );
+    view.rerender(
+      <SourcePlayback
+        session={session}
+        fileName="capability-next.mcap"
+        source={nextSource}
+      />,
+    );
+    expect(
+      screen.getByTestId("playback-shell").getAttribute("data-instance-id"),
+    ).not.toBe(authoritativeShellId);
+    expect(screen.getByTestId("shell-initial-tiles").textContent).toBe(
+      "image-1,plot-1",
+    );
+    expect(playbackHarness.useModalLayout).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        availableTileTypes: expect.arrayContaining([TILE_TYPE.PLOT]),
+      }),
+    );
+  });
+
+  it("keeps the initial poster overlay when its stream is unknown", () => {
+    const source = createSource("grid-poster-without-stream");
+    publishSourceBootstrap(source, {
+      manifest: bootstrapManifest("/camera/front"),
+      poster: bootstrapPoster(),
+    });
+    playbackHarness.sceneInventory = {
+      error: null,
+      sources: [],
+      status: "loading",
+      streams: [],
+      streamCount: 0,
+    };
+
+    render(
+      <SourcePlayback
+        session={null}
+        fileName="grid-poster-without-stream.mcap"
+        source={source}
+      />,
+    );
+
+    expect(screen.queryByTestId("episode-preparing-scaffold")).toBeNull();
+    expect(screen.getByTestId("playback-shell")).toBeTruthy();
+    expect(screen.getByTestId("episode-poster-overlay")).toBeTruthy();
+  });
+
+  it("never applies retained recording facts to a different source", () => {
     const firstSource = createSource("sample-a");
     const secondSource = createSource("sample-b");
-    const firstSession = sessionWithRecordingFacts({
+    const firstRecordingFacts = {
       format: "mcap",
       sizeBytes: "100",
       topicCount: 1,
-    });
-    const secondSession = sessionWithRecordingFacts({
+    } as const;
+    const secondRecordingFacts = {
       format: "mcap",
       sizeBytes: "200",
       topicCount: 2,
-    });
+    } as const;
+    const firstSession = sessionWithRecordingFacts(firstRecordingFacts);
+    const secondSession = sessionWithRecordingFacts(secondRecordingFacts);
     playbackHarness.sceneInventory = readyInventory("/camera/a");
 
     const view = render(
@@ -267,8 +614,19 @@ describe("SourcePlayback", () => {
         source={secondSource}
       />,
     );
+    expect(screen.queryByTestId("settings-recording-facts")).toBeNull();
+    expect(screen.getByTestId("episode-preparing-scaffold")).toBeTruthy();
+
+    act(() => {
+      publishSourceBootstrap(secondSource, {
+        manifest: {
+          ...bootstrapManifest("/camera/b"),
+          recordingFacts: secondRecordingFacts,
+        },
+      });
+    });
     expect(screen.getByTestId("settings-recording-facts").textContent).toBe(
-      "1:100",
+      "2:200",
     );
 
     playbackHarness.sceneInventory = readyInventory("/camera/b");
@@ -331,6 +689,11 @@ describe("SourcePlayback", () => {
       streams: [],
       streamCount: 0,
     };
+    publishSourceBootstrap(secondSource, {
+      manifest: bootstrapManifest("/camera/b"),
+      poster: bootstrapPoster(),
+      posterStreamId: "/camera/b",
+    });
     rerender(
       <SourcePlayback
         session={session}
@@ -346,8 +709,11 @@ describe("SourcePlayback", () => {
     expect(screen.getByTestId("shell-file-name").textContent).toBe(
       "sample-b.mcap",
     );
-    expect(screen.getByTestId("shell-sources").textContent).toBe("/camera/a");
+    expect(screen.getByTestId("shell-sources").textContent).toBe("/camera/b");
     expect(screen.getByTestId("stream-source").textContent).toBe("none");
+    expect(screen.getByTestId("stream-source-poster").textContent).toBe(
+      "/camera/b:encoded-image",
+    );
     expect(screen.queryByTestId("episode-preparing-scaffold")).toBeNull();
     expect(screen.queryByTestId("episode-poster-overlay")).toBeNull();
 
@@ -423,6 +789,11 @@ describe("SourcePlayback", () => {
       streams: [],
       streamCount: 0,
     };
+    publishSourceBootstrap(firstSource, {
+      manifest: bootstrapManifest("/camera/a"),
+      poster: bootstrapPoster(),
+      posterStreamId: "/camera/a",
+    });
     rerender(
       <SourcePlayback
         session={session}
@@ -545,6 +916,39 @@ function timelineModeStream(
     },
     sourceName: "/topic",
     timeRange: { endNs: 1n, startNs: 0n },
+  };
+}
+
+function bootstrapManifest(streamId: string): EpisodeManifest {
+  const timeRange = { endNs: 20n, startNs: 10n };
+  return {
+    episodeId: "grid-buffered",
+    streams: [
+      {
+        id: streamId,
+        kind: "image",
+        metadata: {
+          [SCENE_SOURCE_METADATA.SOURCE_NAME]: streamId,
+          [SCENE_SOURCE_METADATA.TYPE]: SCENE_SOURCE_TYPE.IMAGE,
+        },
+        payload: { encoding: "jpeg" },
+        sourceName: streamId,
+        timeRange,
+      },
+    ],
+    timeDomain: { id: "recording", kind: "timestamp" },
+    timeRange,
+  };
+}
+
+function bootstrapPoster(): EpisodePosterFrame {
+  return {
+    image: {
+      bytes: new Uint8Array([1, 2, 3]),
+      kind: "encoded-image",
+      mimeType: "image/jpeg",
+    },
+    kind: "image",
   };
 }
 

--- a/app/packages/multimodal/src/views/episode/shell/SourcePlayback.tsx
+++ b/app/packages/multimodal/src/views/episode/shell/SourcePlayback.tsx
@@ -22,11 +22,15 @@ import type {
   StreamDescriptor,
 } from "../../../ir";
 import type { SceneSource } from "../../../scene-inventory";
+import { sceneSourcesFromStreamDescriptors } from "../../../stream-selection/scene-sources";
+import { episodeSourceAccessKey } from "../../../runtime/episode-resources";
+import { EpisodePlaybackStoreProvider } from "../../../runtime/react/playback-store-context";
+import { useSourceBootstrap } from "../../../runtime/react/source-bootstrap";
+import { createScheduledSourceReadBudgetAccount } from "../../../runtime/scheduled-read-budget-account";
 import {
-  createScheduledSourceReadBudgetAccount,
-  episodeSourceAccessKey,
-} from "../../../runtime";
-import { EpisodePlaybackStoreProvider } from "../../../runtime/react";
+  sourceBootstrapKey,
+  type SourceBootstrap,
+} from "../../../runtime/source-bootstrap-cache";
 import { releaseRetainedImageTextures } from "../../../visualization/media-2d/image-texture-cache";
 import {
   releaseGpuImageAnnotationResources,
@@ -38,7 +42,6 @@ import {
 } from "../../../visualization/composition/gpu-point-cloud-projection-resources";
 import { releaseGpuPointCloudColormapTextures } from "../../../visualization/scene-3d/gpu/gpu-point-cloud-colormap-texture";
 import { BitmapImageFrameView } from "../../../visualization/media-2d/BitmapImageView";
-import { getSourceBootstrap, sourceBootstrapKey } from "../../../runtime";
 import type { EpisodeSession, EpisodeTerminology } from "../../../ports";
 import { Scene3dViewStateProvider } from "../scene/camera/scene-3d-view-state-context";
 import { Scene3dViewSettingsProvider } from "../spatial/view-settings-context";
@@ -83,6 +86,11 @@ import {
 import { resolveTimelineMode } from "../playback/timeline-mode";
 import { useSceneInventoryState } from "../stream-discovery/use-scene-inventory";
 import { TransformTopologyProvider } from "../transforms/transform-topology-context";
+import {
+  SourcePosterProvider,
+  type SourcePosterValue,
+} from "../image/source-poster-context";
+import { EpisodeSourceReadyProvider } from "../playback/source-ready-context";
 
 const EMPTY_MANUAL_TILE_TITLES: Record<string, string> = {};
 
@@ -98,7 +106,7 @@ interface ReadyInventory {
 }
 
 type PosterImage = Extract<
-  NonNullable<ReturnType<typeof getSourceBootstrap>>["poster"],
+  NonNullable<SourceBootstrap["poster"]>,
   { kind: "image" }
 >;
 
@@ -209,19 +217,52 @@ export const SourcePlayback: React.FC<SourcePlaybackProps> = ({
     const account = session?.boundedRead?.openAccount();
     return account ? createScheduledSourceReadBudgetAccount(account) : null;
   }, [session]);
-  const previousSourceKeyRef = useRef(sourceKey);
-  const hasNavigatedRef = useRef(false);
-  if (navigationPending || previousSourceKeyRef.current !== sourceKey) {
-    previousSourceKeyRef.current = sourceKey;
-    hasNavigatedRef.current = true;
-  }
-  const isModalNavigation = hasNavigatedRef.current;
-  const bootstrap = useMemo(
-    () => (source ? getSourceBootstrap(source) : null),
-    [source],
-  );
+  const bootstrap = useSourceBootstrap(source);
   const poster: PosterImage | undefined =
     bootstrap?.poster?.kind === "image" ? bootstrap.poster : undefined;
+  const posterStreamId = bootstrap?.posterStreamId ?? null;
+  const posterIdentityKey =
+    poster && posterStreamId
+      ? JSON.stringify([sourceAccessKey, posterStreamId])
+      : null;
+  const [posterConsumerIdentities, setPosterConsumerIdentities] = useState<
+    ReadonlyMap<string, string>
+  >(() => new Map());
+  const registerPosterConsumer = useCallback(
+    (consumerId: string) => {
+      if (!posterIdentityKey) return () => undefined;
+      setPosterConsumerIdentities((current) => {
+        if (current.get(consumerId) === posterIdentityKey) return current;
+        const next = new Map(current);
+        next.set(consumerId, posterIdentityKey);
+        return next;
+      });
+      return () => {
+        setPosterConsumerIdentities((current) => {
+          if (current.get(consumerId) !== posterIdentityKey) return current;
+          const next = new Map(current);
+          next.delete(consumerId);
+          return next;
+        });
+      };
+    },
+    [posterIdentityKey],
+  );
+  const hasDestinationPosterConsumer = posterIdentityKey
+    ? [...posterConsumerIdentities.values()].includes(posterIdentityKey)
+    : false;
+  const sourcePoster = useMemo(
+    () =>
+      poster
+        ? {
+            frame: poster.image,
+            registerConsumer: registerPosterConsumer,
+            sourceKey: sourceAccessKey,
+            streamId: posterStreamId,
+          }
+        : null,
+    [poster, posterStreamId, registerPosterConsumer, sourceAccessKey],
+  );
   const [presentedSourceKey, setPresentedSourceKey] = useState("");
   const handlePlayheadDataReady = useCallback(
     () => setPresentedSourceKey(sourceKey),
@@ -253,14 +294,47 @@ export const SourcePlayback: React.FC<SourcePlaybackProps> = ({
       streams,
     ],
   );
-  const retainedInventoryRef = useRef<ReadyInventory | null>(null);
-  // This layout effect retains the last inventory that produced a usable shell.
+  const bootstrapInventory = useMemo<ReadyInventory | null>(() => {
+    const manifest = bootstrap?.manifest;
+    if (!manifest) return null;
+    const sources = sceneSourcesFromStreamDescriptors(manifest.streams);
+    if (sources.length === 0) return null;
+    return {
+      hasNumericSeries: false,
+      hasRawRecords: false,
+      hasTransformTopology: false,
+      recordingFacts: manifest.recordingFacts,
+      sources,
+      streamCount: manifest.streams.length,
+      streams: manifest.streams,
+    };
+  }, [bootstrap?.manifest]);
+  const [retainedInventoryState, setRetainedInventoryState] = useState<{
+    readonly inventory: ReadyInventory;
+    readonly sourceKey: string;
+  } | null>(null);
+  // Retain the current source's destination inventory before the bounded grid
+  // bootstrap cache can evict it while the full session is still opening.
   useLayoutEffect(() => {
-    if (readyInventory) {
-      retainedInventoryRef.current = readyInventory;
+    const retainableInventory = readyInventory ?? bootstrapInventory;
+    if (retainableInventory) {
+      setRetainedInventoryState((current) =>
+        current?.inventory === retainableInventory &&
+        current.sourceKey === sourceKey
+          ? current
+          : { inventory: retainableInventory, sourceKey },
+      );
     }
-  }, [readyInventory]);
-  const shellInventory = readyInventory ?? retainedInventoryRef.current;
+  }, [bootstrapInventory, readyInventory, sourceKey]);
+  // A fully buffered grid tile already knows the destination manifest. Prefer
+  // that source-authenticated inventory over the outgoing shell so modal open
+  // and adjacent navigation can lay out the destination before session open.
+  const retainedInventory =
+    retainedInventoryState?.sourceKey === sourceKey
+      ? retainedInventoryState.inventory
+      : null;
+  const shellInventory =
+    readyInventory ?? bootstrapInventory ?? retainedInventory;
   const shellSources = shellInventory?.sources ?? sources;
   const shellStreams = shellInventory?.streams ?? streams;
   const timelineMode = useMemo(
@@ -278,6 +352,25 @@ export const SourcePlayback: React.FC<SourcePlaybackProps> = ({
       : timelineMode.kind === "absolute"
         ? `absolute:${timelineMode.epochAnchorMs}`
         : "duration";
+  const [
+    retainedAuthoritativeTimelineModeKey,
+    setAuthoritativeTimelineModeKey,
+  ] = useState<string | null>(null);
+  const authoritativeTimelineModeKey = readyInventory
+    ? timelineModeKey
+    : retainedAuthoritativeTimelineModeKey;
+  // This layout effect records the last authoritative timeline mode. A
+  // bootstrap manifest can seed the first-pixel shell but cannot describe
+  // session capabilities such as plots, raw records, and transforms. After
+  // authoritative inventory commits, hold its timeline key through adjacent
+  // transitions. A different destination mode may remount only after its
+  // capabilities are authoritative, so capability-gated tiles are not pruned.
+  useLayoutEffect(() => {
+    if (readyInventory) setAuthoritativeTimelineModeKey(timelineModeKey);
+  }, [readyInventory, timelineModeKey]);
+  const playbackShellKey = authoritativeTimelineModeKey
+    ? `authoritative:${authoritativeTimelineModeKey}`
+    : `bootstrap:${sourceKey}:${timelineModeKey}`;
   const availableTileTypes = useMemo(
     () =>
       tileTypesFor({
@@ -380,6 +473,8 @@ export const SourcePlayback: React.FC<SourcePlaybackProps> = ({
       <PlaybackSessionStateProviders
         cameraViewStateScopeKey={cameraViewStateScopeKey}
         sources={shellSources}
+        sourcePoster={sourcePoster}
+        sourceReady={!transitioning}
         transformTopologyCapability={
           readyInventory ? (session?.transformTopology ?? null) : null
         }
@@ -426,7 +521,7 @@ export const SourcePlayback: React.FC<SourcePlaybackProps> = ({
                               onChange={onImageAspectRatioChange}
                             >
                               <PlaybackShell
-                                key={timelineModeKey}
+                                key={playbackShellKey}
                                 fileName={fileName}
                                 decorateTrack={decorateTrack}
                                 headerCaption={headerCaption}
@@ -483,8 +578,8 @@ export const SourcePlayback: React.FC<SourcePlaybackProps> = ({
                                       error={status === "error"}
                                       text={transitionMessage}
                                     />
-                                  ) : !isModalNavigation &&
-                                    presentedSourceKey !== sourceKey ? (
+                                  ) : presentedSourceKey !== sourceKey &&
+                                    !hasDestinationPosterConsumer ? (
                                     <PosterOverlay
                                       fileName={fileName}
                                       poster={poster}
@@ -553,6 +648,8 @@ const PlaybackSessionStateProviders: React.FC<{
   readonly cameraViewStateScopeKey?: string;
   readonly children: React.ReactNode;
   readonly sources: readonly SceneSource[];
+  readonly sourcePoster: SourcePosterValue | null;
+  readonly sourceReady: boolean;
   readonly transformTopologyCapability: NonNullable<
     EpisodeSession["transformTopology"]
   > | null;
@@ -562,35 +659,41 @@ const PlaybackSessionStateProviders: React.FC<{
   cameraViewStateScopeKey,
   children,
   sources,
+  sourcePoster,
+  sourceReady,
   transformTopologyCapability,
   transformTopologySourceKey,
   viewportScopeKey,
 }) => (
-  <FullHistoryInterestsProvider>
-    <Scene3dViewStateProvider scopeKey={cameraViewStateScopeKey}>
-      <SidebarPreferencesProvider
-        scopeKey={cameraViewStateScopeKey}
-        sources={sources}
-      >
-        <Scene3dViewpointProvider>
-          <SceneFramesProvider>
-            <SceneNoticesProvider>
-              <TileSettingsProvider>
-                <MapViewportScopeProvider scopeKey={viewportScopeKey}>
-                  <TransformTopologyProvider
-                    capability={transformTopologyCapability}
-                    sourceKey={transformTopologySourceKey}
-                  >
-                    {children}
-                  </TransformTopologyProvider>
-                </MapViewportScopeProvider>
-              </TileSettingsProvider>
-            </SceneNoticesProvider>
-          </SceneFramesProvider>
-        </Scene3dViewpointProvider>
-      </SidebarPreferencesProvider>
-    </Scene3dViewStateProvider>
-  </FullHistoryInterestsProvider>
+  <SourcePosterProvider value={sourcePoster}>
+    <EpisodeSourceReadyProvider ready={sourceReady}>
+      <FullHistoryInterestsProvider>
+        <Scene3dViewStateProvider scopeKey={cameraViewStateScopeKey}>
+          <SidebarPreferencesProvider
+            scopeKey={cameraViewStateScopeKey}
+            sources={sources}
+          >
+            <Scene3dViewpointProvider>
+              <SceneFramesProvider>
+                <SceneNoticesProvider>
+                  <TileSettingsProvider>
+                    <MapViewportScopeProvider scopeKey={viewportScopeKey}>
+                      <TransformTopologyProvider
+                        capability={transformTopologyCapability}
+                        sourceKey={transformTopologySourceKey}
+                      >
+                        {children}
+                      </TransformTopologyProvider>
+                    </MapViewportScopeProvider>
+                  </TileSettingsProvider>
+                </SceneNoticesProvider>
+              </SceneFramesProvider>
+            </Scene3dViewpointProvider>
+          </SidebarPreferencesProvider>
+        </Scene3dViewStateProvider>
+      </FullHistoryInterestsProvider>
+    </EpisodeSourceReadyProvider>
+  </SourcePosterProvider>
 );
 
 function ExtensionRuntimeBoundary({

--- a/app/packages/multimodal/src/views/episode/tiles/Tile.module.css
+++ b/app/packages/multimodal/src/views/episode/tiles/Tile.module.css
@@ -12,6 +12,15 @@
   width: 100%;
 }
 
+.destinationPoster {
+  height: 100%;
+  inset: 0;
+  pointer-events: none;
+  position: absolute;
+  width: 100%;
+  z-index: 1;
+}
+
 /* Generic positioned wrapper so the status badge can anchor to any
    tile body (lidar, future panels) the way .imageStack anchors the
    camera overlay. */
@@ -50,7 +59,7 @@
   position: absolute;
   right: 8px;
   top: 8px;
-  z-index: 1;
+  z-index: 2;
 }
 
 .statusBadgeError {


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

Reuse grid preview manifests and posters when an MCAP modal opens or changes samples, so the destination shell can render before the full session is ready. Adjacent samples capture bounded bootstrap data at idle, yielding immediately whenever foreground playback needs the link.

Destination posters are source-authenticated and render inside the matching image tile until its first real frame commits. Authoritative capabilities and timeline modes reseed the shell only when needed, preserving layout state across ordinary hops without pruning capability-gated tiles during a transition.

The transition contexts are installed through the existing playback-session provider boundary. This deliberately leaves the main `PlaybackShell` prop block nearly untouched, giving downstream distributions a cleaner extension seam and reducing sync conflicts.

## 🧪 How is this patch tested? If it is not, please explain why.

- Added and updated unit coverage for bootstrap eviction/subscriptions, preview-derived prewarm hints, poster identity, unsupported previews, foreground retry backoff, shell retention, rapid navigation, and authoritative capability/timeline reseeding
- `yarn test packages/multimodal/src/views/episode/grid packages/multimodal/src/views/episode/image packages/multimodal/src/views/episode/shell packages/multimodal/src/views/episode/playback packages/multimodal/src/runtime --run` (72 files, 715 tests)
- `yarn workspace @fiftyone/multimodal check`
- Manually verified authenticated MCAP sample navigation in the live Next.js app, including rapid back/forward hops and destination-poster dismissal

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

MCAP sample navigation now reuses cached preview data to show the destination viewer sooner and preserve the viewer shell across adjacent samples.

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3784
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added poster previews during transitions between episode sources, keeping destination imagery visible until playback is ready.
  - Improved playback startup by preloading adjacent samples and reusing available preview data.
  - Preserved playback capabilities and metadata more consistently across source and timeline changes.

- **Bug Fixes**
  - Reduced visual flicker and stale-image display during source transitions.
  - Improved handling of posterless, unsupported, and partially loaded previews.
  - Increased retained preview capacity for smoother navigation across episodes.
  - Improved retry behavior when playback is buffering or pending.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->