### PR TITLE
Keep the MCAP sample navigation shell stable

### DIFF
--- a/app/packages/multimodal/src/views/episode/image/ImageTile.tsx
+++ b/app/packages/multimodal/src/views/episode/image/ImageTile.tsx
@@ -3,7 +3,6 @@ import {
   useSetTileTitle,
   useTileDuplicator,
   useTileId,
-  useTiling,
 } from "@fiftyone/tiling";
 import { useIsPlaying } from "@fiftyone/playback";
 import { useStore } from "jotai";
@@ -100,7 +99,6 @@ const EMPTY_PROJECTION_STREAMS: readonly string[] = [];
 /** Renders one image stream with labels, projections, and camera controls. */
 const ImageTile: React.FC<EpisodeTileProps> = ({ initialSourceId }) => {
   const tileId = useTileId();
-  const { expandedTileId } = useTiling();
   const isPlaying = useIsPlaying();
   const [imageDims, setImageDims] = useState<{
     width: number;
@@ -285,15 +283,6 @@ const ImageTile: React.FC<EpisodeTileProps> = ({ initialSourceId }) => {
     })
       ? sourcePoster.frame
       : null;
-  // This layout effect registers only a visible tile whose stream can consume
-  // the poster, allowing the shell to keep its fallback overlay otherwise.
-  useLayoutEffect(() => {
-    const isVisible = expandedTileId === null || expandedTileId === tileId;
-    if (!isVisible || !tileId || !sourcePoster || !destinationPoster) {
-      return undefined;
-    }
-    return sourcePoster.registerConsumer(tileId);
-  }, [destinationPoster, expandedTileId, sourcePoster, tileId]);
   const posterSessionKey = useMemo(
     () => `${sourcePoster?.sourceKey ?? ""}\n${stream}`,
     [sourcePoster?.sourceKey, stream],

--- a/app/packages/multimodal/src/views/episode/image/source-poster-context.tsx
+++ b/app/packages/multimodal/src/views/episode/image/source-poster-context.tsx
@@ -9,7 +9,6 @@ type SourcePosterImage = Extract<
 
 export interface SourcePosterValue {
   readonly frame: SourcePosterImage["image"];
-  readonly registerConsumer: (consumerId: string) => () => void;
   readonly sourceKey: string;
   readonly streamId: string | null;
 }

--- a/app/packages/multimodal/src/views/episode/shell/ModalRenderer.module.css
+++ b/app/packages/multimodal/src/views/episode/shell/ModalRenderer.module.css
@@ -23,6 +23,12 @@
   font-size: 11px;
 }
 
+.transitionStatus {
+  color: var(--color-content-text-muted);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
 .playbackRoot {
   height: 100%;
   position: relative;
@@ -38,16 +44,6 @@
 .playbackRoot[data-episode-source-transitioning="true"] :global(img),
 .playbackRoot[data-episode-source-transitioning="true"] :global(video) {
   visibility: hidden;
-}
-
-/* Grid entry intentionally carries its target poster through this interval. */
-.playbackRoot[data-episode-source-transitioning="true"]
-  .posterOverlay
-  :global(canvas),
-.playbackRoot[data-episode-source-transitioning="true"]
-  .posterOverlay
-  :global(img) {
-  visibility: visible;
 }
 
 /* A grid-captured poster belongs to the incoming source, so it is safe to
@@ -170,18 +166,8 @@
   top: 30px;
 }
 
-.posterOverlay {
-  display: grid;
-  grid-template-columns: minmax(280px, 2fr) minmax(160px, 1fr);
-  inset: 6px;
-  pointer-events: none;
-  position: absolute;
-  z-index: 5;
-}
-
 @media (max-width: 760px) {
-  .preparingTiles,
-  .posterOverlay {
+  .preparingTiles {
     grid-template-columns: 1fr;
   }
 

--- a/app/packages/multimodal/src/views/episode/shell/SourcePlayback.test.tsx
+++ b/app/packages/multimodal/src/views/episode/shell/SourcePlayback.test.tsx
@@ -6,13 +6,7 @@ import {
   render,
   screen,
 } from "@testing-library/react";
-import {
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-  type ReactNode,
-} from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   BYTE_SOURCE_READ_PROFILE,
@@ -39,7 +33,6 @@ import { SourcePlayback } from "./SourcePlayback";
 const playbackHarness = vi.hoisted(() => {
   const harness = {
     nextShellId: 0,
-    posterConsumerEnabled: true,
     sceneInventory: {
       error: null as string | null,
       sources: [] as Array<{ id: string; label: string; type: string }>,
@@ -76,6 +69,7 @@ vi.mock("./PlaybackShell", () => {
   const MockPlaybackShell = ({
     children,
     fileName,
+    headerActions,
     leftSidebar,
     mainOverlay,
     sceneSources,
@@ -83,6 +77,7 @@ vi.mock("./PlaybackShell", () => {
   }: {
     readonly children?: ReactNode;
     readonly fileName: string;
+    readonly headerActions?: ReactNode;
     readonly leftSidebar?: ReactNode;
     readonly mainOverlay?: ReactNode;
     readonly sceneSources?: readonly { id: string }[];
@@ -114,6 +109,7 @@ vi.mock("./PlaybackShell", () => {
               .sort()
               .join(",")}
           </span>
+          <div data-testid="shell-header-actions">{headerActions}</div>
           <button
             data-testid="shell-state"
             onClick={() => setShellState((value) => value + 1)}
@@ -174,11 +170,6 @@ vi.mock("./Streams", () => ({
     source: ByteSourceDescriptor | null;
   }) => {
     const sourcePoster = useSourcePoster();
-    const posterConsumerEnabled = playbackHarness.posterConsumerEnabled;
-    useLayoutEffect(() => {
-      if (!posterConsumerEnabled || !sourcePoster?.streamId) return undefined;
-      return sourcePoster.registerConsumer("mock-image-tile");
-    }, [posterConsumerEnabled, sourcePoster]);
     return (
       <>
         <span data-testid="stream-source">{source?.sourceId ?? "none"}</span>
@@ -214,7 +205,6 @@ describe("SourcePlayback", () => {
       streamCount: 3,
     };
     playbackHarness.nextShellId = 0;
-    playbackHarness.posterConsumerEnabled = true;
     playbackHarness.shellMounts = 0;
     playbackHarness.shellUnmounts = 0;
     playbackHarness.modalLayoutResult = {
@@ -237,7 +227,10 @@ describe("SourcePlayback", () => {
     playbackHarness.useSceneInventoryState.mockClear();
   });
 
-  afterEach(() => cleanup());
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
 
   it("treats unsupported recordings as opened files with no previewable streams", () => {
     const session = {
@@ -349,6 +342,89 @@ describe("SourcePlayback", () => {
     expect(screen.getByTestId("stream-source-poster").textContent).toBe("none");
   });
 
+  it("keeps a bootstrap-only shell mounted while an unwarmed destination opens", () => {
+    const firstSource = createSource("bootstrap-a");
+    const secondSource = createSource("bootstrap-b");
+    publishSourceBootstrap(firstSource, {
+      manifest: bootstrapManifest("/camera/a"),
+      poster: bootstrapPoster(),
+      posterStreamId: "/camera/a",
+    });
+    playbackHarness.sceneInventory = {
+      error: null,
+      sources: [],
+      status: "loading",
+      streams: [],
+      streamCount: 0,
+    };
+
+    const view = render(
+      <SourcePlayback
+        session={null}
+        fileName="bootstrap-a.mcap"
+        source={firstSource}
+      />,
+    );
+    const shellInstance = screen
+      .getByTestId("playback-shell")
+      .getAttribute("data-instance-id");
+    fireEvent.click(screen.getByTestId("shell-state"));
+
+    view.rerender(
+      <SourcePlayback
+        session={null}
+        fileName="bootstrap-b.mcap"
+        source={secondSource}
+      />,
+    );
+
+    expect(screen.queryByTestId("episode-preparing-scaffold")).toBeNull();
+    expect(
+      screen.getByTestId("playback-shell").getAttribute("data-instance-id"),
+    ).toBe(shellInstance);
+    expect(screen.getByTestId("shell-state").textContent).toBe("1");
+    expect(screen.getByTestId("shell-file-name").textContent).toBe(
+      "bootstrap-b.mcap",
+    );
+    expect(screen.getByTestId("shell-sources").textContent).toBe("/camera/a");
+    expect(screen.getByTestId("stream-source").textContent).toBe("none");
+    expect(screen.getByTestId("stream-source-poster").textContent).toBe("none");
+
+    act(() => {
+      publishSourceBootstrap(secondSource, {
+        manifest: bootstrapManifest("/camera/b"),
+      });
+    });
+    expect(screen.getByTestId("shell-sources").textContent).toBe("/camera/b");
+    expect(
+      screen.getByTestId("playback-shell").getAttribute("data-instance-id"),
+    ).toBe(shellInstance);
+  });
+
+  it("shows compact transition feedback only after the loading delay", () => {
+    vi.useFakeTimers();
+    playbackHarness.sceneInventory = readyInventory("/camera");
+
+    render(
+      <SourcePlayback
+        session={{ activate: vi.fn() } as unknown as EpisodeSession}
+        fileName="sample.mcap"
+        source={createSource("sample")}
+      />,
+    );
+
+    expect(screen.queryByTestId("episode-transition-status")).toBeNull();
+    act(() => vi.advanceTimersByTime(199));
+    expect(screen.queryByTestId("episode-transition-status")).toBeNull();
+    act(() => vi.advanceTimersByTime(1));
+    expect(screen.getByTestId("episode-transition-status").textContent).toBe(
+      "Loading sample…",
+    );
+
+    fireEvent.click(screen.getByTestId("stream-ready"));
+    expect(screen.queryByTestId("episode-transition-status")).toBeNull();
+  });
+
   it("does not build an empty shell from unclassified bootstrap streams", () => {
     const source = createSource("unclassified-bootstrap");
     const manifest = bootstrapManifest("/unknown");
@@ -381,9 +457,8 @@ describe("SourcePlayback", () => {
     expect(screen.queryByTestId("playback-shell")).toBeNull();
   });
 
-  it("keeps the fallback overlay when no tile can consume the poster", () => {
+  it("never promotes an unconsumed poster into a global overlay", () => {
     const source = createSource("poster-without-image-tile");
-    playbackHarness.posterConsumerEnabled = false;
     publishSourceBootstrap(source, {
       manifest: bootstrapManifest("/camera/front"),
       poster: bootstrapPoster(),
@@ -405,7 +480,10 @@ describe("SourcePlayback", () => {
       />,
     );
 
-    expect(screen.getByTestId("episode-poster-overlay")).toBeTruthy();
+    expect(screen.queryByTestId("episode-poster-overlay")).toBeNull();
+    expect(screen.getByTestId("stream-source-poster").textContent).toBe(
+      "/camera/front:encoded-image",
+    );
   });
 
   it("reseeds only with authoritative capabilities and timeline mode", () => {
@@ -545,7 +623,7 @@ describe("SourcePlayback", () => {
     );
   });
 
-  it("keeps the initial poster overlay when its stream is unknown", () => {
+  it("keeps an unidentified poster out of the global viewport", () => {
     const source = createSource("grid-poster-without-stream");
     publishSourceBootstrap(source, {
       manifest: bootstrapManifest("/camera/front"),
@@ -569,7 +647,10 @@ describe("SourcePlayback", () => {
 
     expect(screen.queryByTestId("episode-preparing-scaffold")).toBeNull();
     expect(screen.getByTestId("playback-shell")).toBeTruthy();
-    expect(screen.getByTestId("episode-poster-overlay")).toBeTruthy();
+    expect(screen.queryByTestId("episode-poster-overlay")).toBeNull();
+    expect(screen.getByTestId("stream-source-poster").textContent).toBe(
+      "null:encoded-image",
+    );
   });
 
   it("never applies retained recording facts to a different source", () => {
@@ -599,6 +680,9 @@ describe("SourcePlayback", () => {
     expect(screen.getByTestId("settings-recording-facts").textContent).toBe(
       "1:100",
     );
+    const shellInstance = screen
+      .getByTestId("playback-shell")
+      .getAttribute("data-instance-id");
 
     playbackHarness.sceneInventory = {
       error: null,
@@ -614,8 +698,14 @@ describe("SourcePlayback", () => {
         source={secondSource}
       />,
     );
-    expect(screen.queryByTestId("settings-recording-facts")).toBeNull();
-    expect(screen.getByTestId("episode-preparing-scaffold")).toBeTruthy();
+    expect(screen.getByTestId("settings-recording-facts").textContent).toBe(
+      "none",
+    );
+    expect(screen.queryByTestId("episode-preparing-scaffold")).toBeNull();
+    expect(screen.getByTestId("shell-sources").textContent).toBe("/camera/a");
+    expect(
+      screen.getByTestId("playback-shell").getAttribute("data-instance-id"),
+    ).toBe(shellInstance);
 
     act(() => {
       publishSourceBootstrap(secondSource, {
@@ -628,6 +718,9 @@ describe("SourcePlayback", () => {
     expect(screen.getByTestId("settings-recording-facts").textContent).toBe(
       "2:200",
     );
+    expect(
+      screen.getByTestId("playback-shell").getAttribute("data-instance-id"),
+    ).toBe(shellInstance);
 
     playbackHarness.sceneInventory = readyInventory("/camera/b");
     view.rerender(

--- a/app/packages/multimodal/src/views/episode/shell/SourcePlayback.tsx
+++ b/app/packages/multimodal/src/views/episode/shell/SourcePlayback.tsx
@@ -93,6 +93,7 @@ import {
 import { EpisodeSourceReadyProvider } from "../playback/source-ready-context";
 
 const EMPTY_MANUAL_TILE_TITLES: Record<string, string> = {};
+const TRANSITION_STATUS_DELAY_MS = 200;
 
 interface ReadyInventory {
   readonly hasNumericSeries: boolean;
@@ -221,47 +222,16 @@ export const SourcePlayback: React.FC<SourcePlaybackProps> = ({
   const poster: PosterImage | undefined =
     bootstrap?.poster?.kind === "image" ? bootstrap.poster : undefined;
   const posterStreamId = bootstrap?.posterStreamId ?? null;
-  const posterIdentityKey =
-    poster && posterStreamId
-      ? JSON.stringify([sourceAccessKey, posterStreamId])
-      : null;
-  const [posterConsumerIdentities, setPosterConsumerIdentities] = useState<
-    ReadonlyMap<string, string>
-  >(() => new Map());
-  const registerPosterConsumer = useCallback(
-    (consumerId: string) => {
-      if (!posterIdentityKey) return () => undefined;
-      setPosterConsumerIdentities((current) => {
-        if (current.get(consumerId) === posterIdentityKey) return current;
-        const next = new Map(current);
-        next.set(consumerId, posterIdentityKey);
-        return next;
-      });
-      return () => {
-        setPosterConsumerIdentities((current) => {
-          if (current.get(consumerId) !== posterIdentityKey) return current;
-          const next = new Map(current);
-          next.delete(consumerId);
-          return next;
-        });
-      };
-    },
-    [posterIdentityKey],
-  );
-  const hasDestinationPosterConsumer = posterIdentityKey
-    ? [...posterConsumerIdentities.values()].includes(posterIdentityKey)
-    : false;
-  const sourcePoster = useMemo(
+  const sourcePoster = useMemo<SourcePosterValue | null>(
     () =>
       poster
         ? {
             frame: poster.image,
-            registerConsumer: registerPosterConsumer,
             sourceKey: sourceAccessKey,
             streamId: posterStreamId,
           }
         : null,
-    [poster, posterStreamId, registerPosterConsumer, sourceAccessKey],
+    [poster, posterStreamId, sourceAccessKey],
   );
   const [presentedSourceKey, setPresentedSourceKey] = useState("");
   const handlePlayheadDataReady = useCallback(
@@ -333,11 +303,24 @@ export const SourcePlayback: React.FC<SourcePlaybackProps> = ({
     retainedInventoryState?.sourceKey === sourceKey
       ? retainedInventoryState.inventory
       : null;
-  const shellInventory =
+  const destinationInventory =
     readyInventory ?? bootstrapInventory ?? retainedInventory;
+  const [retainedShellInventory, setRetainedShellInventory] =
+    useState<ReadyInventory | null>(null);
+  // Keep the mounted shell's presentation topology while a destination that
+  // lacks bootstrap facts opens. Playback and source-specific metadata remain
+  // gated on destinationInventory below, so this cannot expose outgoing data.
+  useLayoutEffect(() => {
+    if (destinationInventory) {
+      setRetainedShellInventory((current) =>
+        current === destinationInventory ? current : destinationInventory,
+      );
+    }
+  }, [destinationInventory]);
+  const shellInventory = destinationInventory ?? retainedShellInventory;
   const shellSources = shellInventory?.sources ?? sources;
   const shellStreams = shellInventory?.streams ?? streams;
-  const timelineMode = useMemo(
+  const resolvedTimelineMode = useMemo(
     () => resolveTimelineMode(shellStreams),
     [shellStreams],
   );
@@ -346,19 +329,15 @@ export const SourcePlayback: React.FC<SourcePlaybackProps> = ({
   // forces a remount — and a fresh provider/store — whenever navigating to a
   // source resolves a different timeline mode, instead of silently retaining
   // the previous mode's stale presentation.
-  const timelineModeKey =
-    timelineMode.kind === "sequence"
-      ? `sequence:${timelineMode.fps}`
-      : timelineMode.kind === "absolute"
-        ? `absolute:${timelineMode.epochAnchorMs}`
-        : "duration";
-  const [
-    retainedAuthoritativeTimelineModeKey,
-    setAuthoritativeTimelineModeKey,
-  ] = useState<string | null>(null);
-  const authoritativeTimelineModeKey = readyInventory
-    ? timelineModeKey
-    : retainedAuthoritativeTimelineModeKey;
+  const resolvedTimelineModeKey = timelineModeKey(resolvedTimelineMode);
+  const initialShellTimelineModeRef = useRef<ReturnType<
+    typeof resolveTimelineMode
+  > | null>(null);
+  if (initialShellTimelineModeRef.current === null && shellInventory) {
+    initialShellTimelineModeRef.current = resolvedTimelineMode;
+  }
+  const [retainedAuthoritativeTimelineMode, setAuthoritativeTimelineMode] =
+    useState<ReturnType<typeof resolveTimelineMode> | null>(null);
   // This layout effect records the last authoritative timeline mode. A
   // bootstrap manifest can seed the first-pixel shell but cannot describe
   // session capabilities such as plots, raw records, and transforms. After
@@ -366,11 +345,27 @@ export const SourcePlayback: React.FC<SourcePlaybackProps> = ({
   // transitions. A different destination mode may remount only after its
   // capabilities are authoritative, so capability-gated tiles are not pruned.
   useLayoutEffect(() => {
-    if (readyInventory) setAuthoritativeTimelineModeKey(timelineModeKey);
-  }, [readyInventory, timelineModeKey]);
-  const playbackShellKey = authoritativeTimelineModeKey
-    ? `authoritative:${authoritativeTimelineModeKey}`
-    : `bootstrap:${sourceKey}:${timelineModeKey}`;
+    if (!readyInventory) return;
+    setAuthoritativeTimelineMode((current) =>
+      current && timelineModeKey(current) === resolvedTimelineModeKey
+        ? current
+        : resolvedTimelineMode,
+    );
+  }, [readyInventory, resolvedTimelineMode, resolvedTimelineModeKey]);
+  const playbackTimelineMode = readyInventory
+    ? resolvedTimelineMode
+    : (retainedAuthoritativeTimelineMode ??
+      initialShellTimelineModeRef.current ??
+      resolvedTimelineMode);
+  // The first authoritative inventory gets one chance to reseed capability-
+  // gated tiles that a bootstrap manifest cannot describe. After that, keep
+  // the shell mounted across source changes unless an authoritative timeline
+  // mode proves incompatible with the current PlaybackProvider.
+  const playbackShellKey = `${
+    readyInventory || retainedAuthoritativeTimelineMode
+      ? "authoritative"
+      : "bootstrap"
+  }:${timelineModeKey(playbackTimelineMode)}`;
   const availableTileTypes = useMemo(
     () =>
       tileTypesFor({
@@ -454,9 +449,7 @@ export const SourcePlayback: React.FC<SourcePlaybackProps> = ({
   const transitionMessage =
     status === "error"
       ? `Failed to read recording: ${error ?? "Unknown error"}`
-      : status === "ready" && sources.length === 0
-        ? `No previewable streams in this recording (${streamCount.toLocaleString()} streams found)`
-        : "Preparing viewer";
+      : `No previewable streams in this recording (${streamCount.toLocaleString()} streams found)`;
   const hasTerminalTransition =
     status === "error" || (status === "ready" && sources.length === 0);
   const transitioning =
@@ -526,14 +519,19 @@ export const SourcePlayback: React.FC<SourcePlaybackProps> = ({
                                 decorateTrack={decorateTrack}
                                 headerCaption={headerCaption}
                                 headerActions={
-                                  <HeaderActions actions={headerActions} />
+                                  <HeaderActions
+                                    actions={headerActions}
+                                    loading={
+                                      transitioning && !hasTerminalTransition
+                                    }
+                                  />
                                 }
                                 addTileMenu={
                                   <AddTileMenu tileTypes={availableTileTypes} />
                                 }
                                 timelineExtraActions={<TimestampReadout />}
                                 sceneSources={shellSources}
-                                mode={timelineMode}
+                                mode={playbackTimelineMode}
                                 deselectFocusedTileOnRepeatSelect={false}
                                 initialTiles={initialTiles}
                                 initialManualTileTitles={
@@ -563,10 +561,14 @@ export const SourcePlayback: React.FC<SourcePlaybackProps> = ({
                                       onTimelineSamplingRateChange
                                     }
                                     recordingFacts={
-                                      shellInventory?.recordingFacts
+                                      destinationInventory?.recordingFacts
                                     }
-                                    streams={shellStreams}
-                                    terminology={shellInventory?.terminology}
+                                    streams={
+                                      destinationInventory?.streams ?? []
+                                    }
+                                    terminology={
+                                      destinationInventory?.terminology
+                                    }
                                     timelineSamplingRateHz={
                                       timelineSamplingRateHz
                                     }
@@ -577,15 +579,6 @@ export const SourcePlayback: React.FC<SourcePlaybackProps> = ({
                                     <PlaybackState
                                       error={status === "error"}
                                       text={transitionMessage}
-                                    />
-                                  ) : presentedSourceKey !== sourceKey &&
-                                    !hasDestinationPosterConsumer ? (
-                                    <PosterOverlay
-                                      fileName={fileName}
-                                      poster={poster}
-                                      posterStream={bootstrap?.posterStreamId}
-                                      sourceKey={sourceAccessKey}
-                                      statusText={transitionMessage}
                                     />
                                   ) : null
                                 }
@@ -725,13 +718,46 @@ function SourceResourceBoundary() {
   return null;
 }
 
-function HeaderActions({ actions }: { readonly actions?: React.ReactNode }) {
+function HeaderActions({
+  actions,
+  loading,
+}: {
+  readonly actions?: React.ReactNode;
+  readonly loading: boolean;
+}) {
   return (
     <>
+      <DelayedTransitionStatus active={loading} />
       <NetworkStatusPill />
       {actions}
     </>
   );
+}
+
+function DelayedTransitionStatus({ active }: { readonly active: boolean }) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (!active) {
+      setVisible(false);
+      return undefined;
+    }
+    const timer = setTimeout(
+      () => setVisible(true),
+      TRANSITION_STATUS_DELAY_MS,
+    );
+    return () => clearTimeout(timer);
+  }, [active]);
+
+  return active && visible ? (
+    <span
+      className={styles.transitionStatus}
+      data-testid="episode-transition-status"
+      role="status"
+    >
+      Loading sample…
+    </span>
+  ) : null;
 }
 
 function PlaybackState({
@@ -791,45 +817,14 @@ function PreparingPlayback({
   );
 }
 
-function PosterOverlay({
-  fileName,
-  poster,
-  posterStream,
-  sourceKey,
-  statusText,
-}: {
-  readonly fileName: string;
-  readonly poster?: PosterImage;
-  readonly posterStream?: string;
-  readonly sourceKey: string;
-  readonly statusText?: string;
-}) {
-  return (
-    <div
-      aria-label={`Preview of ${fileName}`}
-      className={styles.posterOverlay}
-      data-testid="episode-poster-overlay"
-    >
-      <PosterCard
-        poster={poster}
-        posterStream={posterStream}
-        sourceKey={sourceKey}
-        statusText={statusText}
-      />
-    </div>
-  );
-}
-
 function PosterCard({
   poster,
   posterStream,
   sourceKey,
-  statusText,
 }: {
   readonly poster?: PosterImage;
   readonly posterStream?: string;
   readonly sourceKey: string;
-  readonly statusText?: string;
 }) {
   return (
     <div className={styles.posterCard}>
@@ -845,10 +840,18 @@ function PosterCard({
       )}
       <div className={styles.posterCaption}>
         <span>{posterStream ?? "Primary preview"}</span>
-        <span>{statusText ?? (poster ? "Preview" : "Preparing")}</span>
+        <span>{poster ? "Preview" : "Preparing"}</span>
       </div>
     </div>
   );
+}
+
+function timelineModeKey(mode: ReturnType<typeof resolveTimelineMode>): string {
+  return mode.kind === "sequence"
+    ? `sequence:${mode.fps}`
+    : mode.kind === "absolute"
+      ? `absolute:${mode.epochAnchorMs}`
+      : "duration";
 }
 
 // Deliberately just the file size: stream/stream/label counts used to render

--- a/app/packages/multimodal/src/views/episode/shell/SourcePlayback.tsx
+++ b/app/packages/multimodal/src/views/episode/shell/SourcePlayback.tsx
@@ -737,6 +737,7 @@ function HeaderActions({
 function DelayedTransitionStatus({ active }: { readonly active: boolean }) {
   const [visible, setVisible] = useState(false);
 
+  // This effect delays transition copy so fast sample swaps stay quiet.
   useEffect(() => {
     if (!active) {
       setVisible(false);


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

MCAP sample navigation now keeps the mounted playback shell in place while an unwarmed destination opens. Matching cached posters render only inside their image tile, and a compact loading label appears after 200 ms instead of replacing the viewer with a full-size preparing scaffold.

The shell still remounts when an authoritative destination timeline mode changes. Source-specific playback and settings stay gated to the destination.

## 🧪 How is this patch tested? If it is not, please explain why.

- `yarn workspace @fiftyone/multimodal check`
- `yarn test SourcePlayback.test.tsx SourcePlayback.integration.test.tsx PlaybackShell.test.tsx use-modal-layout.test.tsx destination-poster.test.ts --run` (89 tests)

The regression tests cover an unwarmed destination, shell instance and local-state preservation, delayed transition feedback, destination-only metadata, poster identity, and authoritative timeline-mode reseeding.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

MCAP sample navigation now keeps the viewer shell stable while the next sample loads.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3794
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved source transitions by preserving the existing playback shell while content loads.
  * Added delayed loading feedback in header actions.
  * Poster cards now display clear “Preview” or “Preparing” labels.
  * Settings now reflect the selected destination more accurately.

* **Bug Fixes**
  * Improved playback remounting when timeline modes change.
  * Prevented recording details from persisting incorrectly during source transitions.
  * Improved poster behavior so posters remain within the playback stream instead of appearing as overlays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->