### PR TITLE
Add Qwen3.8-27B to model zoo

### DIFF
--- a/fiftyone/utils/qwen3_8.py
+++ b/fiftyone/utils/qwen3_8.py
@@ -1,0 +1,437 @@
+"""
+`Qwen3.8 <https://huggingface.co/Qwen/Qwen3.8-27B>`_ wrapper for the FiftyOne
+Model Zoo.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import json
+import logging
+import re
+from typing import Any, List, Optional, Sequence, Tuple, Union
+
+import numpy as np
+
+import fiftyone.core.labels as fol
+import fiftyone.core.utils as fou
+import fiftyone.utils.torch as fout
+import fiftyone.zoo.models as fozm
+
+fou.ensure_torch()
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+def _ensure_qwen3_8() -> None:
+    # Qwen3.8 reports model_type "qwen3_5"
+    fou.ensure_package("transformers>=5.8.0")
+    fou.ensure_package("accelerate")
+
+
+transformers = fou.lazy_import("transformers", callback=_ensure_qwen3_8)
+
+from PIL import Image as PILImage
+
+# Anything fout.to_rgb_pil accepts
+ImageLike = Union[str, np.ndarray, torch.Tensor, PILImage.Image]
+
+DEFAULT_QWEN3_8_MODEL = "Qwen/Qwen3.8-27B"
+
+_BBOX_FORMAT_INSTRUCTION = (
+    "Report bbox coordinates in JSON format as a list of "
+    '{"label": "<class>", "bbox_2d": [x1, y1, x2, y2]} objects, '
+    "where coordinates are normalized to 0-1000 with x first."
+)
+DEFAULT_DETECTION_PROMPT = (
+    "Detect all objects in this image. " + _BBOX_FORMAT_INSTRUCTION
+)
+
+# Thinking mode is on by default and the generation prompt opens the
+# reasoning block, so generated text starts inside it and carries only the
+# closing tag. The reasoning holds candidate boxes that were never
+# committed, so only text after </think> is an answer.
+_THINK_OPEN = "<think>"
+_THINK_CLOSE = "</think>"
+_THINK_BLOCK = re.compile(
+    r"%s.*?%s" % (re.escape(_THINK_OPEN), re.escape(_THINK_CLOSE)),
+    flags=re.DOTALL,
+)
+
+# Generations are decoded with special tokens retained so the reasoning
+# boundary stays visible, which leaves the turn terminator on the answer
+_TURN_ENDS = ("<|im_end|>", "<|endoftext|>")
+
+VALID_REASONING_EFFORTS = ("low", "medium", "xhigh")
+
+
+class Qwen38OutputProcessor(fout.OutputProcessor):
+    """Output processor for Qwen3.8 detection models.
+
+    Strips the model's reasoning block, then parses JSON bounding boxes into
+    :class:`fiftyone.core.labels.Detections` instances.
+    """
+
+    def __call__(
+        self,
+        output: Sequence[str],
+        frame_size: Tuple[int, int],
+        confidence_thresh: Optional[float] = None,
+        **kwargs: Any,
+    ) -> List[fol.Detections]:
+        """Processes model output into detections.
+
+        Args:
+            output: a list of raw generated strings, decoded with special
+                tokens retained so the reasoning block is visible
+            frame_size: a ``(width, height)`` tuple
+            confidence_thresh: optional confidence threshold (unused for VLM)
+            **kwargs: additional keyword arguments
+
+        Returns:
+            a list of :class:`fiftyone.core.labels.Detections` instances
+        """
+        results = []
+        for raw_output in output:
+            answer = self._extract_answer(raw_output)
+            detections = self._parse_detections(answer, frame_size)
+            results.append(fol.Detections(detections=detections))
+        return results
+
+    @staticmethod
+    def _extract_answer(raw_output: Optional[str]) -> str:
+        """Return the committed answer, or ``""`` when the model never
+        closed its reasoning block.
+
+        The generation prompt opens the reasoning block, so generated text
+        begins inside it and a missing ``</think>`` means the token budget
+        ran out mid-reasoning. That yields no labels: the reasoning
+        rehearses candidate boxes that were never committed.
+        """
+        text = raw_output or ""
+
+        if _THINK_CLOSE not in text:
+            return ""
+
+        # Keep only what follows the final closed reasoning block
+        answer = _THINK_BLOCK.sub("", text).split(_THINK_CLOSE)[-1]
+        return Qwen38OutputProcessor._strip_turn_ends(answer)
+
+    @staticmethod
+    def _strip_turn_ends(text: str) -> str:
+        for marker in _TURN_ENDS:
+            text = text.split(marker)[0]
+        return text.strip()
+
+    def _parse_detections(
+        self, raw_output: str, frame_size: Tuple[int, int]
+    ) -> List[fol.Detection]:
+        """Parse an answer payload into Detection objects."""
+        detections = []
+
+        json_str = raw_output.strip()
+
+        if not json_str or json_str.lower() in (
+            "there are none.",
+            "none",
+            "no objects detected",
+            "[]",
+        ):
+            return detections
+
+        try:
+            # Model wraps JSON output in markdown code blocks
+            if json_str.startswith("```json"):
+                json_str = json_str[7:]
+            if json_str.startswith("```"):
+                json_str = json_str[3:]
+            if json_str.endswith("```"):
+                json_str = json_str[:-3]
+            json_str = json_str.strip()
+
+            if not (json_str.startswith("[") or json_str.startswith("{")):
+                return detections
+
+            parsed = json.loads(json_str)
+            if not isinstance(parsed, list):
+                parsed = [parsed]
+
+        except (json.JSONDecodeError, ValueError) as e:
+            logger.debug("Could not parse model output: %s", e)
+            return detections
+
+        for obj in parsed:
+            if not isinstance(obj, dict):
+                continue
+
+            label = obj.get("label", "object")
+            bbox = obj.get("bbox_2d")
+
+            if not isinstance(bbox, (list, tuple)) or len(bbox) != 4:
+                continue
+
+            try:
+                x1, y1, x2, y2 = (float(v) for v in bbox)
+            except (TypeError, ValueError, OverflowError):
+                continue
+
+            # JSON permits NaN and Infinity literals; NaN also passes the
+            # positive-area check below
+            if not all(np.isfinite(v) for v in (x1, y1, x2, y2)):
+                continue
+
+            # Qwen3.8 reports bbox_2d on a 0-1000 normalized scale with x
+            # first; convert to 0-1
+            x1 = float(np.clip(x1 / 1000.0, 0.0, 1.0))
+            y1 = float(np.clip(y1 / 1000.0, 0.0, 1.0))
+            x2 = float(np.clip(x2 / 1000.0, 0.0, 1.0))
+            y2 = float(np.clip(y2 / 1000.0, 0.0, 1.0))
+
+            w = x2 - x1
+            h = y2 - y1
+
+            if w <= 0 or h <= 0:
+                continue
+
+            detections.append(
+                fol.Detection(
+                    label=str(label),
+                    bounding_box=[x1, y1, w, h],
+                )
+            )
+
+        return detections
+
+
+class Qwen38ModelConfig(fout.TorchImageModelConfig, fozm.HasZooModel):
+    """Configuration for running a :class:`Qwen38Model`.
+
+    Args:
+        name_or_path ("Qwen/Qwen3.8-27B"): the HuggingFace model path
+        prompt (None): the detection prompt; if None, uses default
+        classes (None): list of classes to detect; if provided, added to
+            prompt
+        max_new_tokens (4096): maximum tokens to generate. The model reasons
+            before answering, so the budget covers both the reasoning block
+            and the answer
+        reasoning_effort ("low"): how long the model reasons before
+            answering, one of ``"low"``, ``"medium"`` or ``"xhigh"``. The
+            chat template turns this into a system instruction rather than a
+            hard limit. The model's own default is ``"xhigh"``; detection
+            needs no extended deliberation, and brief reasoning leaves more
+            of ``max_new_tokens`` for the answer
+        load_in_4bit (True): whether to load the language model with 4-bit
+            NF4 quantization on GPU; the vision encoder stays bf16. The full
+            bf16 weights are 55.6 GB. Set to False to load bf16 on hardware
+            that can hold it
+    """
+
+    def __init__(self, d: dict) -> None:
+        d = self.init(d)
+        super().__init__(d)
+
+        self.name_or_path = self.parse_string(
+            d, "name_or_path", default=DEFAULT_QWEN3_8_MODEL
+        )
+        self.prompt = self.parse_string(d, "prompt", default=None)
+        self.classes = self.parse_array(d, "classes", default=None)
+        self.max_new_tokens = self.parse_int(d, "max_new_tokens", default=4096)
+        if self.max_new_tokens <= 0:
+            raise ValueError(
+                "max_new_tokens must be positive; got %s" % self.max_new_tokens
+            )
+        self.reasoning_effort = self.parse_string(
+            d, "reasoning_effort", default="low"
+        )
+        if self.reasoning_effort not in VALID_REASONING_EFFORTS:
+            raise ValueError(
+                "reasoning_effort must be one of %s; got %r"
+                % (", ".join(VALID_REASONING_EFFORTS), self.reasoning_effort)
+            )
+        self.load_in_4bit = self.parse_bool(d, "load_in_4bit", default=True)
+
+        # Detection is the only mode, so the processor is not optional
+        if self.output_processor is None and self.output_processor_cls is None:
+            self.output_processor_cls = Qwen38OutputProcessor
+
+        self.raw_inputs = True
+
+
+class Qwen38Model(fout.TorchImageModel):
+    """Wrapper for running inference with Qwen3.8 models.
+
+    Qwen3.8 is a vision-language model that detects objects by emitting
+    bounding box coordinates via 2D grounding. It reasons before answering,
+    and the wrapper returns only the committed answer.
+
+    Detection example::
+
+        import fiftyone as fo
+        import fiftyone.zoo as foz
+
+        dataset = foz.load_zoo_dataset(
+            "quickstart", max_samples=5, shuffle=True, seed=51
+        )
+
+        model = foz.load_zoo_model("qwen3.8-27b-torch")
+
+        dataset.apply_model(model, label_field="qwen_detections")
+
+        session = fo.launch_app(dataset)
+
+    Detect specific classes::
+
+        model = foz.load_zoo_model(
+            "qwen3.8-27b-torch",
+            classes=["person", "car", "dog"],
+        )
+
+    Args:
+        config: a :class:`Qwen38ModelConfig`
+    """
+
+    def __init__(self, config: "Qwen38ModelConfig") -> None:
+        self._processor = None
+        super().__init__(config)
+
+    def _download_model(self, config: "Qwen38ModelConfig") -> None:
+        pass
+
+    def _load_model(self, config: "Qwen38ModelConfig") -> torch.nn.Module:
+        # Checked before transformers is resolved, so an invalid
+        # configuration does not first pull in the library
+        if config.load_in_4bit and not self._using_gpu:
+            raise ValueError(
+                "load_in_4bit=True requires a GPU; set it to False to "
+                "load the 55.6 GB bfloat16 weights"
+            )
+
+        model_cls = transformers.AutoModelForMultimodalLM
+
+        kwargs = {"dtype": torch.bfloat16}
+
+        if self._using_gpu and config.load_in_4bit:
+            # Only the 4-bit path needs bitsandbytes; the model is 55.6 GB
+            # at bf16
+            fou.ensure_package("bitsandbytes")
+
+            # bitsandbytes dispatches through accelerate, so quantized loads
+            # always use a device map. The vision tower stays bf16: its
+            # forward casts pixels to its own weight dtype, which 4-bit
+            # packing stores as uint8. Skip entries are fully qualified
+            # module paths.
+            kwargs["quantization_config"] = transformers.BitsAndBytesConfig(
+                load_in_4bit=True,
+                bnb_4bit_quant_type="nf4",
+                bnb_4bit_compute_dtype=torch.bfloat16,
+                bnb_4bit_use_double_quant=True,
+                llm_int8_skip_modules=["model.visual"],
+            )
+            kwargs["device_map"] = (
+                "auto" if config.device is None else {"": config.device}
+            )
+        elif self._using_gpu:
+            kwargs["device_map"] = "auto" if config.device is None else None
+
+        model = model_cls.from_pretrained(config.name_or_path, **kwargs)
+
+        if kwargs.get("device_map") is None and self._using_gpu:
+            model = model.to(self._device)
+        model.eval()
+
+        self._processor = transformers.AutoProcessor.from_pretrained(
+            config.name_or_path
+        )
+
+        return model
+
+    def _get_prompt(self) -> str:
+        if self.config.prompt is not None:
+            return self.config.prompt
+
+        if self.config.classes is not None:
+            classes_str = ", ".join(self.config.classes)
+            return (
+                f"Detect all instances of: {classes_str}. "
+                + _BBOX_FORMAT_INSTRUCTION
+            )
+
+        return DEFAULT_DETECTION_PROMPT
+
+    def _forward_pass(self, imgs: Sequence[Any]) -> List[str]:
+        prompt = self._get_prompt()
+        results = []
+
+        for img in imgs:
+            img = self._prepare_image(img)
+
+            messages = [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image", "image": img},
+                        {"type": "text", "text": prompt},
+                    ],
+                }
+            ]
+
+            inputs = self._processor.apply_chat_template(
+                messages,
+                tokenize=True,
+                add_generation_prompt=True,
+                return_dict=True,
+                return_tensors="pt",
+                reasoning_effort=self.config.reasoning_effort,
+            )
+            inputs = inputs.to(self._model.device)
+
+            generated_ids = self._model.generate(
+                **inputs,
+                max_new_tokens=self.config.max_new_tokens,
+                do_sample=False,
+            )
+
+            generated_ids_trimmed = [
+                out_ids[len(in_ids) :]
+                for in_ids, out_ids in zip(inputs["input_ids"], generated_ids)
+            ]
+
+            # Special tokens are retained so the output processor can see the
+            # reasoning block boundaries
+            text = self._processor.batch_decode(
+                generated_ids_trimmed,
+                skip_special_tokens=False,
+                clean_up_tokenization_spaces=False,
+            )[0]
+
+            results.append(text)
+
+        return results
+
+    def _prepare_image(self, img: ImageLike) -> PILImage.Image:
+        """Converts image-like input to an RGB PIL image for the processor.
+
+        ``fout.to_rgb_pil`` expects channel-last layout and reads float
+        arrays as 0-1, wrapping anything above it, so tensors are converted
+        and channel-first or 0-255 float input is normalized first.
+        """
+        if isinstance(img, torch.Tensor):
+            img = img.detach().cpu().numpy()
+
+        if isinstance(img, np.ndarray):
+            # Transpose CHW to HWC when the first dim is channels and the
+            # last cannot be
+            if (
+                img.ndim == 3
+                and img.shape[0] in (1, 3, 4)
+                and img.shape[2] not in (1, 3, 4)
+            ):
+                img = np.transpose(img, (1, 2, 0))
+
+            if np.issubdtype(img.dtype, np.floating):
+                scale = 255.0 if img.max() <= 1.0 else 1.0
+                img = np.clip(img * scale, 0, 255).astype(np.uint8)
+
+        return fout.to_rgb_pil(img)

--- a/fiftyone/utils/qwen3_8.py
+++ b/fiftyone/utils/qwen3_8.py
@@ -10,7 +10,6 @@ Model Zoo.
 import json
 import logging
 import re
-from typing import Any, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 
@@ -25,7 +24,7 @@ import torch
 logger = logging.getLogger(__name__)
 
 
-def _ensure_qwen3_8() -> None:
+def _ensure_qwen3_8():
     # Qwen3.8 reports model_type "qwen3_5"
     fou.ensure_package("transformers>=5.8.0")
     fou.ensure_package("accelerate")
@@ -34,9 +33,6 @@ def _ensure_qwen3_8() -> None:
 transformers = fou.lazy_import("transformers", callback=_ensure_qwen3_8)
 
 from PIL import Image as PILImage
-
-# Anything fout.to_rgb_pil accepts
-ImageLike = Union[str, np.ndarray, torch.Tensor, PILImage.Image]
 
 DEFAULT_QWEN3_8_MODEL = "Qwen/Qwen3.8-27B"
 
@@ -76,11 +72,11 @@ class Qwen38OutputProcessor(fout.OutputProcessor):
 
     def __call__(
         self,
-        output: Sequence[str],
-        frame_size: Tuple[int, int],
-        confidence_thresh: Optional[float] = None,
-        **kwargs: Any,
-    ) -> List[fol.Detections]:
+        output,
+        frame_size,
+        confidence_thresh=None,
+        **kwargs,
+    ):
         """Processes model output into detections.
 
         Args:
@@ -101,7 +97,7 @@ class Qwen38OutputProcessor(fout.OutputProcessor):
         return results
 
     @staticmethod
-    def _extract_answer(raw_output: Optional[str]) -> str:
+    def _extract_answer(raw_output):
         """Return the committed answer, or ``""`` when the model never
         closed its reasoning block.
 
@@ -120,14 +116,12 @@ class Qwen38OutputProcessor(fout.OutputProcessor):
         return Qwen38OutputProcessor._strip_turn_ends(answer)
 
     @staticmethod
-    def _strip_turn_ends(text: str) -> str:
+    def _strip_turn_ends(text):
         for marker in _TURN_ENDS:
             text = text.split(marker)[0]
         return text.strip()
 
-    def _parse_detections(
-        self, raw_output: str, frame_size: Tuple[int, int]
-    ) -> List[fol.Detection]:
+    def _parse_detections(self, raw_output, frame_size):
         """Parse an answer payload into Detection objects."""
         detections = []
 
@@ -228,7 +222,7 @@ class Qwen38ModelConfig(fout.TorchImageModelConfig, fozm.HasZooModel):
             that can hold it
     """
 
-    def __init__(self, d: dict) -> None:
+    def __init__(self, d):
         d = self.init(d)
         super().__init__(d)
 
@@ -292,14 +286,14 @@ class Qwen38Model(fout.TorchImageModel):
         config: a :class:`Qwen38ModelConfig`
     """
 
-    def __init__(self, config: "Qwen38ModelConfig") -> None:
+    def __init__(self, config):
         self._processor = None
         super().__init__(config)
 
-    def _download_model(self, config: "Qwen38ModelConfig") -> None:
+    def _download_model(self, config):
         pass
 
-    def _load_model(self, config: "Qwen38ModelConfig") -> torch.nn.Module:
+    def _load_model(self, config):
         # Checked before transformers is resolved, so an invalid
         # configuration does not first pull in the library
         if config.load_in_4bit and not self._using_gpu:
@@ -347,7 +341,7 @@ class Qwen38Model(fout.TorchImageModel):
 
         return model
 
-    def _get_prompt(self) -> str:
+    def _get_prompt(self):
         if self.config.prompt is not None:
             return self.config.prompt
 
@@ -360,7 +354,7 @@ class Qwen38Model(fout.TorchImageModel):
 
         return DEFAULT_DETECTION_PROMPT
 
-    def _forward_pass(self, imgs: Sequence[Any]) -> List[str]:
+    def _forward_pass(self, imgs):
         prompt = self._get_prompt()
         results = []
 
@@ -410,7 +404,7 @@ class Qwen38Model(fout.TorchImageModel):
 
         return results
 
-    def _prepare_image(self, img: ImageLike) -> PILImage.Image:
+    def _prepare_image(self, img):
         """Converts image-like input to an RGB PIL image for the processor.
 
         ``fout.to_rgb_pil`` expects channel-last layout and reads float

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -12442,6 +12442,41 @@
                 }
             ],
             "date_added": "2026-07-14 12:00:00"
+        },
+        {
+            "base_name": "qwen3.8-27b-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "Hybrid-attention 27B vision-language model for object detection via 2D grounding",
+            "source": "https://huggingface.co/Qwen/Qwen3.8-27B",
+            "author": "Qwen Team, Alibaba",
+            "license": "Apache 2.0",
+            "size_bytes": 55600000000,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.qwen3_8.Qwen38Model",
+                "config": {
+                    "name_or_path": "Qwen/Qwen3.8-27B",
+                    "output_processor_cls": "fiftyone.utils.qwen3_8.Qwen38OutputProcessor"
+                }
+            },
+            "requirements": {
+                "packages": [
+                    "torch",
+                    "torchvision",
+                    "transformers>=5.8.0",
+                    "accelerate",
+                    "bitsandbytes"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["detection", "vlm", "torch", "transformer", "zero-shot"],
+            "training_data": [],
+            "date_added": "2026-08-14 12:00:00"
         }
     ]
 }

--- a/tests/unittests/utils/test_qwen3_8.py
+++ b/tests/unittests/utils/test_qwen3_8.py
@@ -1,0 +1,416 @@
+"""
+Tests for fiftyone/utils/qwen3_8.py output processor and parsing.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+from typing import Tuple
+
+import numpy as np
+import pytest
+import torch
+from PIL import Image as PILImage
+
+import fiftyone.core.labels as fol
+from fiftyone.utils.qwen3_8 import (
+    DEFAULT_DETECTION_PROMPT,
+    ImageLike,
+    Qwen38Model,
+    Qwen38ModelConfig,
+    Qwen38OutputProcessor,
+)
+
+# Thinking mode is on by default and the generation prompt opens the <think>
+# block, so generated text begins inside the reasoning and carries only the
+# closing tag. The reasoning rehearses a candidate box that differs from the
+# committed answer, and the turn terminator survives decoding.
+FULL_TRANSCRIPT = (
+    "The user wants all objects. A candidate is "
+    '[{"label": "cat", "bbox_2d": [0, 0, 500, 500]}] but looking closer '
+    "it is a bear near the bottom.</think>"
+    '[{"label": "bear", "bbox_2d": [0, 100, 1000, 1000]}]<|im_end|>'
+)
+
+TRUNCATED_TRANSCRIPT = (
+    "Let me identify the objects. I see a cat at "
+    '[{"label": "cat", "bbox_2d": [100, 100, 400, 400]}] and also'
+)
+
+# The model fences its answer, and the fence is followed by the terminator
+FENCED_TRANSCRIPT = (
+    "Considering the scene.</think>\n"
+    '```json\n[\n\t{"label": "bird", "bbox_2d": [10, 20, 30, 40]}\n]\n```'
+    "<|im_end|>"
+)
+
+
+class TestQwen38AnswerExtraction:
+    """Test extraction of the committed answer past the reasoning block"""
+
+    def test_answer_wins_over_reasoning(self) -> None:
+        """Only the committed answer is parsed, not the rehearsed candidate"""
+        processor = Qwen38OutputProcessor()
+        detections = processor._parse_detections(
+            processor._extract_answer(FULL_TRANSCRIPT), (1000, 1000)
+        )
+
+        assert len(detections) == 1
+        assert detections[0].label == "bear"
+        bbox = detections[0].bounding_box
+        assert bbox[0] == pytest.approx(0.0)
+        assert bbox[1] == pytest.approx(0.1)
+        assert bbox[2] == pytest.approx(1.0)
+        assert bbox[3] == pytest.approx(0.9)
+
+    def test_truncated_reasoning_yields_empty(self) -> None:
+        """A generation that exhausted its budget mid-reasoning commits
+        nothing, even though the reasoning contains parseable JSON"""
+        processor = Qwen38OutputProcessor()
+        answer = processor._extract_answer(TRUNCATED_TRANSCRIPT)
+
+        assert answer == ""
+        assert processor._parse_detections(answer, (1000, 1000)) == []
+
+    def test_turn_terminator_stripped(self) -> None:
+        """The terminator survives decoding with special tokens retained,
+        and must not reach the JSON parser"""
+        processor = Qwen38OutputProcessor()
+        answer = processor._extract_answer(FULL_TRANSCRIPT)
+
+        assert "<|im_end|>" not in answer
+        assert answer.endswith("]")
+
+    def test_fenced_answer_with_terminator(self) -> None:
+        """A fenced answer followed by the terminator still parses; the
+        trailing fence is only stripped once the terminator is gone"""
+        processor = Qwen38OutputProcessor()
+        detections = processor._parse_detections(
+            processor._extract_answer(FENCED_TRANSCRIPT), (1000, 1000)
+        )
+
+        assert len(detections) == 1
+        assert detections[0].label == "bird"
+
+    def test_multiple_reasoning_blocks(self) -> None:
+        """Every closed reasoning block is stripped, not just the first"""
+        processor = Qwen38OutputProcessor()
+        raw = (
+            "first pass</think>"
+            "<think>second pass, candidate "
+            '[{"label": "cat", "bbox_2d": [0, 0, 10, 10]}]</think>'
+            '[{"label": "dog", "bbox_2d": [0, 0, 500, 500]}]'
+        )
+        detections = processor._parse_detections(
+            processor._extract_answer(raw), (1000, 1000)
+        )
+
+        assert len(detections) == 1
+        assert detections[0].label == "dog"
+
+    def test_unclosed_reasoning_yields_empty(self) -> None:
+        """Text with no closing tag never left the reasoning block, even
+        when it carries no opening tag either"""
+        processor = Qwen38OutputProcessor()
+        raw = '[{"label": "cat", "bbox_2d": [100, 200, 400, 600]}]'
+
+        assert processor._extract_answer(raw) == ""
+
+    def test_empty_output(self) -> None:
+        processor = Qwen38OutputProcessor()
+
+        assert processor._extract_answer("") == ""
+        assert processor._extract_answer(None) == ""
+
+    def test_reasoning_closed_with_empty_answer(self) -> None:
+        """Closed reasoning followed by nothing commits no labels"""
+        processor = Qwen38OutputProcessor()
+        raw = (
+            '[{"label": "cat", "bbox_2d": [0, 0, 500, 500]}]</think><|im_end|>'
+        )
+
+        assert processor._extract_answer(raw) == ""
+
+
+class TestQwen38DetectionParsing:
+    """Test parsing of bbox JSON into detections"""
+
+    def test_parse_multiple_detections(self) -> None:
+        processor = Qwen38OutputProcessor()
+        raw = (
+            '[{"label": "cat", "bbox_2d": [0, 0, 500, 500]}, '
+            '{"label": "dog", "bbox_2d": [500, 500, 1000, 1000]}]'
+        )
+        detections = processor._parse_detections(raw, (1000, 1000))
+
+        assert len(detections) == 2
+        assert [d.label for d in detections] == ["cat", "dog"]
+
+    def test_parse_single_object_json(self) -> None:
+        processor = Qwen38OutputProcessor()
+        raw = '{"label": "cat", "bbox_2d": [0, 0, 500, 500]}'
+
+        assert len(processor._parse_detections(raw, (1000, 1000))) == 1
+
+    @pytest.mark.parametrize(
+        "raw", ["", "none", "There are none.", "no objects detected", "[]"]
+    )
+    def test_parse_empty_responses(self, raw: str) -> None:
+        processor = Qwen38OutputProcessor()
+
+        assert processor._parse_detections(raw, (1000, 1000)) == []
+
+    def test_parse_invalid_json(self) -> None:
+        processor = Qwen38OutputProcessor()
+
+        assert processor._parse_detections("[{broken", (1000, 1000)) == []
+
+    def test_parse_missing_bbox(self) -> None:
+        processor = Qwen38OutputProcessor()
+        raw = '[{"label": "cat"}]'
+
+        assert processor._parse_detections(raw, (1000, 1000)) == []
+
+    @pytest.mark.parametrize(
+        "bbox", ["[0, 0, 500]", '"0,0,500,500"', "null", "{}", "5"]
+    )
+    def test_parse_malformed_bbox(self, bbox: str) -> None:
+        """A bbox that is not a four-element sequence is skipped"""
+        processor = Qwen38OutputProcessor()
+        raw = '[{"label": "cat", "bbox_2d": %s}]' % bbox
+
+        assert processor._parse_detections(raw, (1000, 1000)) == []
+
+    def test_parse_non_numeric_bbox_elements(self) -> None:
+        processor = Qwen38OutputProcessor()
+        raw = '[{"label": "cat", "bbox_2d": ["a", "b", "c", "d"]}]'
+
+        assert processor._parse_detections(raw, (1000, 1000)) == []
+
+    @pytest.mark.parametrize("literal", ["NaN", "Infinity", "-Infinity"])
+    def test_parse_non_finite_coordinates(self, literal: str) -> None:
+        """JSON permits NaN and Infinity literals; NaN also passes the
+        positive-area check, so it must be rejected explicitly"""
+        processor = Qwen38OutputProcessor()
+        raw = '[{"label": "cat", "bbox_2d": [0, 0, 500, %s]}]' % literal
+
+        assert processor._parse_detections(raw, (1000, 1000)) == []
+
+    def test_clamp_out_of_range(self) -> None:
+        processor = Qwen38OutputProcessor()
+        raw = '[{"label": "cat", "bbox_2d": [-100, -100, 1500, 1500]}]'
+        detections = processor._parse_detections(raw, (1000, 1000))
+
+        assert detections[0].bounding_box == [0.0, 0.0, 1.0, 1.0]
+
+    def test_skip_inverted_bbox(self) -> None:
+        processor = Qwen38OutputProcessor()
+        raw = '[{"label": "cat", "bbox_2d": [500, 500, 100, 100]}]'
+
+        assert processor._parse_detections(raw, (1000, 1000)) == []
+
+    def test_standard_conversion(self) -> None:
+        """bbox_2d is a 0-1000 scale with x first"""
+        processor = Qwen38OutputProcessor()
+        raw = '[{"label": "cat", "bbox_2d": [100, 200, 300, 600]}]'
+        bbox = processor._parse_detections(raw, (1000, 1000))[0].bounding_box
+
+        assert bbox[0] == pytest.approx(0.1)
+        assert bbox[1] == pytest.approx(0.2)
+        assert bbox[2] == pytest.approx(0.2)
+        assert bbox[3] == pytest.approx(0.4)
+
+
+class TestQwen38OutputProcessorCall:
+    """Test the batch entry point"""
+
+    def test_process_batch(self) -> None:
+        processor = Qwen38OutputProcessor()
+        output = [
+            FULL_TRANSCRIPT,
+            TRUNCATED_TRANSCRIPT,
+            'done.</think>[{"label": "car", "bbox_2d": [0, 0, 100, 100]}]',
+        ]
+        results = processor(output, (1000, 1000))
+
+        assert len(results) == 3
+        assert all(isinstance(r, fol.Detections) for r in results)
+        assert [len(r.detections) for r in results] == [1, 0, 1]
+
+
+class TestQwen38ModelConfig:
+    """Test config parsing and validation"""
+
+    def test_default_config(self) -> None:
+        config = Qwen38ModelConfig({})
+
+        assert config.name_or_path == "Qwen/Qwen3.8-27B"
+        assert config.max_new_tokens == 4096
+        assert config.reasoning_effort == "low"
+        assert config.load_in_4bit is True
+        assert config.raw_inputs is True
+
+    def test_custom_config(self) -> None:
+        config = Qwen38ModelConfig(
+            {
+                "classes": ["person", "car"],
+                "max_new_tokens": 512,
+                "reasoning_effort": "xhigh",
+                "load_in_4bit": False,
+            }
+        )
+
+        assert config.classes == ["person", "car"]
+        assert config.max_new_tokens == 512
+        assert config.reasoning_effort == "xhigh"
+        assert config.load_in_4bit is False
+
+    @pytest.mark.parametrize("effort", ["high", "none", "XHIGH", ""])
+    def test_rejects_unsupported_reasoning_effort(self, effort: str) -> None:
+        """The chat template raises on anything outside xhigh/medium/low,
+        so the config rejects it before a generation is attempted"""
+        with pytest.raises(ValueError, match="reasoning_effort"):
+            Qwen38ModelConfig({"reasoning_effort": effort})
+
+
+class TestQwen38PrepareImage:
+    """Test image normalization to PIL, which needs no model"""
+
+    def _prepare(self, img: ImageLike) -> PILImage.Image:
+        return Qwen38Model._prepare_image(None, img)
+
+    def test_channel_first_array_is_transposed(self) -> None:
+        """fout.to_rgb_pil rejects a (C, H, W) array outright"""
+        img = np.zeros((3, 40, 60), dtype=np.uint8)
+
+        assert self._prepare(img).size == (60, 40)
+
+    def test_channel_first_tensor_is_transposed(self) -> None:
+        img = torch.zeros(3, 40, 60, dtype=torch.uint8)
+
+        assert self._prepare(img).size == (60, 40)
+
+    def test_channel_last_array_is_left_alone(self) -> None:
+        img = np.zeros((40, 60, 3), dtype=np.uint8)
+
+        assert self._prepare(img).size == (60, 40)
+
+    def test_ambiguous_square_channel_count_is_left_alone(self) -> None:
+        """A (3, 224, 3) array is channel-last; transposing would corrupt it"""
+        img = np.zeros((3, 224, 3), dtype=np.uint8)
+
+        assert self._prepare(img).size == (224, 3)
+
+    def test_unit_float_array_is_scaled(self) -> None:
+        img = np.full((8, 8, 3), 0.5, dtype=np.float32)
+        out = np.asarray(self._prepare(img))
+
+        assert out.dtype == np.uint8
+        assert out.max() == 127
+
+    @pytest.mark.parametrize(
+        "value,expected", [(200.0, 200), (255.0, 255), (300.0, 255)]
+    )
+    def test_wide_float_array_is_clipped(
+        self, value: float, expected: int
+    ) -> None:
+        """A 0-255 float array is clipped, not wrapped"""
+        img = np.full((8, 8, 3), value, dtype=np.float32)
+        out = np.asarray(self._prepare(img))
+
+        assert out.dtype == np.uint8
+        assert out.max() == expected
+
+    @pytest.mark.parametrize(
+        "value,expected", [(0.5, 127), (200.0, 200), (300.0, 255)]
+    )
+    def test_float_tensor_is_scaled_and_clipped(
+        self, value: float, expected: int
+    ) -> None:
+        """A float tensor takes the same 0-1 versus 0-255 handling as an
+        array; to_rgb_pil would wrap anything above 1.0"""
+        img = torch.full((3, 8, 8), value, dtype=torch.float32)
+        out = np.asarray(self._prepare(img))
+
+        assert out.dtype == np.uint8
+        assert out.max() == expected
+
+    def test_singleton_channel_is_widened_to_rgb(self) -> None:
+        """The processor takes RGB, so a single channel is widened"""
+        img = np.zeros((8, 8, 1), dtype=np.uint8)
+        out = self._prepare(img)
+
+        assert out.mode == "RGB"
+        assert out.size == (8, 8)
+
+    def test_pil_image_is_preserved(self) -> None:
+        img = PILImage.new("RGB", (12, 9), color=(10, 20, 30))
+        out = self._prepare(img)
+
+        assert out.mode == "RGB"
+        assert out.size == (12, 9)
+        assert np.array_equal(np.asarray(out), np.asarray(img))
+
+
+class TestQwen38Prompt:
+    """Test prompt selection, which needs no model"""
+
+    def _prompt(self, d: dict) -> str:
+        model = Qwen38Model.__new__(Qwen38Model)
+        model.config = Qwen38ModelConfig(d)
+        return Qwen38Model._get_prompt(model)
+
+    def test_default_prompt(self) -> None:
+        assert self._prompt({}) == DEFAULT_DETECTION_PROMPT
+
+    def test_classes_are_named_in_the_prompt(self) -> None:
+        prompt = self._prompt({"classes": ["person", "car", "dog"]})
+
+        assert "person, car, dog" in prompt
+        assert "bbox_2d" in prompt
+
+    def test_explicit_prompt_wins_over_classes(self) -> None:
+        prompt = self._prompt(
+            {"prompt": "Find the cats.", "classes": ["person"]}
+        )
+
+        assert prompt == "Find the cats."
+
+
+class TestQwen38FrameSizeIndependence:
+    """bbox_2d is normalized, so detections do not depend on frame size"""
+
+    @pytest.mark.parametrize(
+        "frame_size", [(1000, 1000), (640, 480), (1920, 1080), (100, 800)]
+    )
+    def test_non_square_frames_give_the_same_box(
+        self, frame_size: Tuple[int, int]
+    ) -> None:
+        processor = Qwen38OutputProcessor()
+        raw = '[{"label": "cat", "bbox_2d": [100, 200, 300, 600]}]'
+        bbox = processor._parse_detections(raw, frame_size)[0].bounding_box
+
+        assert bbox[0] == pytest.approx(0.1)
+        assert bbox[1] == pytest.approx(0.2)
+        assert bbox[2] == pytest.approx(0.2)
+        assert bbox[3] == pytest.approx(0.4)
+
+
+class TestQwen38LoadGuards:
+    """Configuration combinations rejected before the model is loaded"""
+
+    @pytest.mark.parametrize("value", [0, -1, -4096])
+    def test_rejects_non_positive_max_new_tokens(self, value: int) -> None:
+        with pytest.raises(ValueError, match="max_new_tokens"):
+            Qwen38ModelConfig({"max_new_tokens": value})
+
+    def test_four_bit_without_gpu_is_rejected(self) -> None:
+        """Without a GPU both load branches are skipped, which would load
+        the 55.6 GB bfloat16 weights instead of quantizing"""
+        model = Qwen38Model.__new__(Qwen38Model)
+        model._using_gpu = False
+        config = Qwen38ModelConfig({"load_in_4bit": True})
+
+        with pytest.raises(ValueError, match="requires a GPU"):
+            Qwen38Model._load_model(model, config)

--- a/tests/unittests/utils/test_qwen3_8.py
+++ b/tests/unittests/utils/test_qwen3_8.py
@@ -6,8 +6,6 @@ Tests for fiftyone/utils/qwen3_8.py output processor and parsing.
 |
 """
 
-from typing import Tuple
-
 import numpy as np
 import pytest
 import torch
@@ -16,7 +14,6 @@ from PIL import Image as PILImage
 import fiftyone.core.labels as fol
 from fiftyone.utils.qwen3_8 import (
     DEFAULT_DETECTION_PROMPT,
-    ImageLike,
     Qwen38Model,
     Qwen38ModelConfig,
     Qwen38OutputProcessor,
@@ -49,7 +46,7 @@ FENCED_TRANSCRIPT = (
 class TestQwen38AnswerExtraction:
     """Test extraction of the committed answer past the reasoning block"""
 
-    def test_answer_wins_over_reasoning(self) -> None:
+    def test_answer_wins_over_reasoning(self):
         """Only the committed answer is parsed, not the rehearsed candidate"""
         processor = Qwen38OutputProcessor()
         detections = processor._parse_detections(
@@ -64,7 +61,7 @@ class TestQwen38AnswerExtraction:
         assert bbox[2] == pytest.approx(1.0)
         assert bbox[3] == pytest.approx(0.9)
 
-    def test_truncated_reasoning_yields_empty(self) -> None:
+    def test_truncated_reasoning_yields_empty(self):
         """A generation that exhausted its budget mid-reasoning commits
         nothing, even though the reasoning contains parseable JSON"""
         processor = Qwen38OutputProcessor()
@@ -73,7 +70,7 @@ class TestQwen38AnswerExtraction:
         assert answer == ""
         assert processor._parse_detections(answer, (1000, 1000)) == []
 
-    def test_turn_terminator_stripped(self) -> None:
+    def test_turn_terminator_stripped(self):
         """The terminator survives decoding with special tokens retained,
         and must not reach the JSON parser"""
         processor = Qwen38OutputProcessor()
@@ -82,7 +79,7 @@ class TestQwen38AnswerExtraction:
         assert "<|im_end|>" not in answer
         assert answer.endswith("]")
 
-    def test_fenced_answer_with_terminator(self) -> None:
+    def test_fenced_answer_with_terminator(self):
         """A fenced answer followed by the terminator still parses; the
         trailing fence is only stripped once the terminator is gone"""
         processor = Qwen38OutputProcessor()
@@ -93,7 +90,7 @@ class TestQwen38AnswerExtraction:
         assert len(detections) == 1
         assert detections[0].label == "bird"
 
-    def test_multiple_reasoning_blocks(self) -> None:
+    def test_multiple_reasoning_blocks(self):
         """Every closed reasoning block is stripped, not just the first"""
         processor = Qwen38OutputProcessor()
         raw = (
@@ -109,7 +106,7 @@ class TestQwen38AnswerExtraction:
         assert len(detections) == 1
         assert detections[0].label == "dog"
 
-    def test_unclosed_reasoning_yields_empty(self) -> None:
+    def test_unclosed_reasoning_yields_empty(self):
         """Text with no closing tag never left the reasoning block, even
         when it carries no opening tag either"""
         processor = Qwen38OutputProcessor()
@@ -117,13 +114,13 @@ class TestQwen38AnswerExtraction:
 
         assert processor._extract_answer(raw) == ""
 
-    def test_empty_output(self) -> None:
+    def test_empty_output(self):
         processor = Qwen38OutputProcessor()
 
         assert processor._extract_answer("") == ""
         assert processor._extract_answer(None) == ""
 
-    def test_reasoning_closed_with_empty_answer(self) -> None:
+    def test_reasoning_closed_with_empty_answer(self):
         """Closed reasoning followed by nothing commits no labels"""
         processor = Qwen38OutputProcessor()
         raw = (
@@ -136,7 +133,7 @@ class TestQwen38AnswerExtraction:
 class TestQwen38DetectionParsing:
     """Test parsing of bbox JSON into detections"""
 
-    def test_parse_multiple_detections(self) -> None:
+    def test_parse_multiple_detections(self):
         processor = Qwen38OutputProcessor()
         raw = (
             '[{"label": "cat", "bbox_2d": [0, 0, 500, 500]}, '
@@ -147,7 +144,7 @@ class TestQwen38DetectionParsing:
         assert len(detections) == 2
         assert [d.label for d in detections] == ["cat", "dog"]
 
-    def test_parse_single_object_json(self) -> None:
+    def test_parse_single_object_json(self):
         processor = Qwen38OutputProcessor()
         raw = '{"label": "cat", "bbox_2d": [0, 0, 500, 500]}'
 
@@ -156,17 +153,17 @@ class TestQwen38DetectionParsing:
     @pytest.mark.parametrize(
         "raw", ["", "none", "There are none.", "no objects detected", "[]"]
     )
-    def test_parse_empty_responses(self, raw: str) -> None:
+    def test_parse_empty_responses(self, raw):
         processor = Qwen38OutputProcessor()
 
         assert processor._parse_detections(raw, (1000, 1000)) == []
 
-    def test_parse_invalid_json(self) -> None:
+    def test_parse_invalid_json(self):
         processor = Qwen38OutputProcessor()
 
         assert processor._parse_detections("[{broken", (1000, 1000)) == []
 
-    def test_parse_missing_bbox(self) -> None:
+    def test_parse_missing_bbox(self):
         processor = Qwen38OutputProcessor()
         raw = '[{"label": "cat"}]'
 
@@ -175,21 +172,21 @@ class TestQwen38DetectionParsing:
     @pytest.mark.parametrize(
         "bbox", ["[0, 0, 500]", '"0,0,500,500"', "null", "{}", "5"]
     )
-    def test_parse_malformed_bbox(self, bbox: str) -> None:
+    def test_parse_malformed_bbox(self, bbox):
         """A bbox that is not a four-element sequence is skipped"""
         processor = Qwen38OutputProcessor()
         raw = '[{"label": "cat", "bbox_2d": %s}]' % bbox
 
         assert processor._parse_detections(raw, (1000, 1000)) == []
 
-    def test_parse_non_numeric_bbox_elements(self) -> None:
+    def test_parse_non_numeric_bbox_elements(self):
         processor = Qwen38OutputProcessor()
         raw = '[{"label": "cat", "bbox_2d": ["a", "b", "c", "d"]}]'
 
         assert processor._parse_detections(raw, (1000, 1000)) == []
 
     @pytest.mark.parametrize("literal", ["NaN", "Infinity", "-Infinity"])
-    def test_parse_non_finite_coordinates(self, literal: str) -> None:
+    def test_parse_non_finite_coordinates(self, literal):
         """JSON permits NaN and Infinity literals; NaN also passes the
         positive-area check, so it must be rejected explicitly"""
         processor = Qwen38OutputProcessor()
@@ -197,20 +194,20 @@ class TestQwen38DetectionParsing:
 
         assert processor._parse_detections(raw, (1000, 1000)) == []
 
-    def test_clamp_out_of_range(self) -> None:
+    def test_clamp_out_of_range(self):
         processor = Qwen38OutputProcessor()
         raw = '[{"label": "cat", "bbox_2d": [-100, -100, 1500, 1500]}]'
         detections = processor._parse_detections(raw, (1000, 1000))
 
         assert detections[0].bounding_box == [0.0, 0.0, 1.0, 1.0]
 
-    def test_skip_inverted_bbox(self) -> None:
+    def test_skip_inverted_bbox(self):
         processor = Qwen38OutputProcessor()
         raw = '[{"label": "cat", "bbox_2d": [500, 500, 100, 100]}]'
 
         assert processor._parse_detections(raw, (1000, 1000)) == []
 
-    def test_standard_conversion(self) -> None:
+    def test_standard_conversion(self):
         """bbox_2d is a 0-1000 scale with x first"""
         processor = Qwen38OutputProcessor()
         raw = '[{"label": "cat", "bbox_2d": [100, 200, 300, 600]}]'
@@ -225,7 +222,7 @@ class TestQwen38DetectionParsing:
 class TestQwen38OutputProcessorCall:
     """Test the batch entry point"""
 
-    def test_process_batch(self) -> None:
+    def test_process_batch(self):
         processor = Qwen38OutputProcessor()
         output = [
             FULL_TRANSCRIPT,
@@ -242,7 +239,7 @@ class TestQwen38OutputProcessorCall:
 class TestQwen38ModelConfig:
     """Test config parsing and validation"""
 
-    def test_default_config(self) -> None:
+    def test_default_config(self):
         config = Qwen38ModelConfig({})
 
         assert config.name_or_path == "Qwen/Qwen3.8-27B"
@@ -251,7 +248,7 @@ class TestQwen38ModelConfig:
         assert config.load_in_4bit is True
         assert config.raw_inputs is True
 
-    def test_custom_config(self) -> None:
+    def test_custom_config(self):
         config = Qwen38ModelConfig(
             {
                 "classes": ["person", "car"],
@@ -267,7 +264,7 @@ class TestQwen38ModelConfig:
         assert config.load_in_4bit is False
 
     @pytest.mark.parametrize("effort", ["high", "none", "XHIGH", ""])
-    def test_rejects_unsupported_reasoning_effort(self, effort: str) -> None:
+    def test_rejects_unsupported_reasoning_effort(self, effort):
         """The chat template raises on anything outside xhigh/medium/low,
         so the config rejects it before a generation is attempted"""
         with pytest.raises(ValueError, match="reasoning_effort"):
@@ -277,32 +274,32 @@ class TestQwen38ModelConfig:
 class TestQwen38PrepareImage:
     """Test image normalization to PIL, which needs no model"""
 
-    def _prepare(self, img: ImageLike) -> PILImage.Image:
+    def _prepare(self, img):
         return Qwen38Model._prepare_image(None, img)
 
-    def test_channel_first_array_is_transposed(self) -> None:
+    def test_channel_first_array_is_transposed(self):
         """fout.to_rgb_pil rejects a (C, H, W) array outright"""
         img = np.zeros((3, 40, 60), dtype=np.uint8)
 
         assert self._prepare(img).size == (60, 40)
 
-    def test_channel_first_tensor_is_transposed(self) -> None:
+    def test_channel_first_tensor_is_transposed(self):
         img = torch.zeros(3, 40, 60, dtype=torch.uint8)
 
         assert self._prepare(img).size == (60, 40)
 
-    def test_channel_last_array_is_left_alone(self) -> None:
+    def test_channel_last_array_is_left_alone(self):
         img = np.zeros((40, 60, 3), dtype=np.uint8)
 
         assert self._prepare(img).size == (60, 40)
 
-    def test_ambiguous_square_channel_count_is_left_alone(self) -> None:
+    def test_ambiguous_square_channel_count_is_left_alone(self):
         """A (3, 224, 3) array is channel-last; transposing would corrupt it"""
         img = np.zeros((3, 224, 3), dtype=np.uint8)
 
         assert self._prepare(img).size == (224, 3)
 
-    def test_unit_float_array_is_scaled(self) -> None:
+    def test_unit_float_array_is_scaled(self):
         img = np.full((8, 8, 3), 0.5, dtype=np.float32)
         out = np.asarray(self._prepare(img))
 
@@ -312,9 +309,7 @@ class TestQwen38PrepareImage:
     @pytest.mark.parametrize(
         "value,expected", [(200.0, 200), (255.0, 255), (300.0, 255)]
     )
-    def test_wide_float_array_is_clipped(
-        self, value: float, expected: int
-    ) -> None:
+    def test_wide_float_array_is_clipped(self, value, expected):
         """A 0-255 float array is clipped, not wrapped"""
         img = np.full((8, 8, 3), value, dtype=np.float32)
         out = np.asarray(self._prepare(img))
@@ -325,9 +320,7 @@ class TestQwen38PrepareImage:
     @pytest.mark.parametrize(
         "value,expected", [(0.5, 127), (200.0, 200), (300.0, 255)]
     )
-    def test_float_tensor_is_scaled_and_clipped(
-        self, value: float, expected: int
-    ) -> None:
+    def test_float_tensor_is_scaled_and_clipped(self, value, expected):
         """A float tensor takes the same 0-1 versus 0-255 handling as an
         array; to_rgb_pil would wrap anything above 1.0"""
         img = torch.full((3, 8, 8), value, dtype=torch.float32)
@@ -336,7 +329,7 @@ class TestQwen38PrepareImage:
         assert out.dtype == np.uint8
         assert out.max() == expected
 
-    def test_singleton_channel_is_widened_to_rgb(self) -> None:
+    def test_singleton_channel_is_widened_to_rgb(self):
         """The processor takes RGB, so a single channel is widened"""
         img = np.zeros((8, 8, 1), dtype=np.uint8)
         out = self._prepare(img)
@@ -344,7 +337,7 @@ class TestQwen38PrepareImage:
         assert out.mode == "RGB"
         assert out.size == (8, 8)
 
-    def test_pil_image_is_preserved(self) -> None:
+    def test_pil_image_is_preserved(self):
         img = PILImage.new("RGB", (12, 9), color=(10, 20, 30))
         out = self._prepare(img)
 
@@ -356,21 +349,21 @@ class TestQwen38PrepareImage:
 class TestQwen38Prompt:
     """Test prompt selection, which needs no model"""
 
-    def _prompt(self, d: dict) -> str:
+    def _prompt(self, d):
         model = Qwen38Model.__new__(Qwen38Model)
         model.config = Qwen38ModelConfig(d)
         return Qwen38Model._get_prompt(model)
 
-    def test_default_prompt(self) -> None:
+    def test_default_prompt(self):
         assert self._prompt({}) == DEFAULT_DETECTION_PROMPT
 
-    def test_classes_are_named_in_the_prompt(self) -> None:
+    def test_classes_are_named_in_the_prompt(self):
         prompt = self._prompt({"classes": ["person", "car", "dog"]})
 
         assert "person, car, dog" in prompt
         assert "bbox_2d" in prompt
 
-    def test_explicit_prompt_wins_over_classes(self) -> None:
+    def test_explicit_prompt_wins_over_classes(self):
         prompt = self._prompt(
             {"prompt": "Find the cats.", "classes": ["person"]}
         )
@@ -384,9 +377,7 @@ class TestQwen38FrameSizeIndependence:
     @pytest.mark.parametrize(
         "frame_size", [(1000, 1000), (640, 480), (1920, 1080), (100, 800)]
     )
-    def test_non_square_frames_give_the_same_box(
-        self, frame_size: Tuple[int, int]
-    ) -> None:
+    def test_non_square_frames_give_the_same_box(self, frame_size):
         processor = Qwen38OutputProcessor()
         raw = '[{"label": "cat", "bbox_2d": [100, 200, 300, 600]}]'
         bbox = processor._parse_detections(raw, frame_size)[0].bounding_box
@@ -401,11 +392,11 @@ class TestQwen38LoadGuards:
     """Configuration combinations rejected before the model is loaded"""
 
     @pytest.mark.parametrize("value", [0, -1, -4096])
-    def test_rejects_non_positive_max_new_tokens(self, value: int) -> None:
+    def test_rejects_non_positive_max_new_tokens(self, value):
         with pytest.raises(ValueError, match="max_new_tokens"):
             Qwen38ModelConfig({"max_new_tokens": value})
 
-    def test_four_bit_without_gpu_is_rejected(self) -> None:
+    def test_four_bit_without_gpu_is_rejected(self):
         """Without a GPU both load branches are skipped, which would load
         the 55.6 GB bfloat16 weights instead of quantizing"""
         model = Qwen38Model.__new__(Qwen38Model)


### PR DESCRIPTION
Adds `qwen3.8-27b-torch` to the model zoo.

[Qwen3.8-27B](https://huggingface.co/Qwen/Qwen3.8-27B) is a 27.8B vision-language model under Apache 2.0 with a 262,144-token context. It reports `model_type` `qwen3_5` and loads through `AutoModelForMultimodalLM` as `Qwen3_5ForConditionalGeneration`, which transformers has supported since 5.8.

## Implementation

`Qwen38Model` runs 2D grounding and returns `Detections`. The wrapper defaults to 4-bit NF4 on GPU, keeping `model.visual` in bf16, since the bf16 checkpoint is 55.6 GB. `load_in_4bit=False` loads bf16 on hardware that can hold it.

Thinking mode is on by default and the generation prompt opens the reasoning block, so generated text begins inside it. `Qwen38OutputProcessor` returns only the text following `</think>`; a generation that exhausts its budget mid-reasoning yields no labels rather than parsing rehearsed candidates.

`reasoning_effort` accepts `low`, `medium` and `xhigh`. The chat template raises on any other value, so the config validates it before a generation is attempted. The default is `low`, which leaves more of `max_new_tokens` for the answer.

## Usage

```python
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart", max_samples=5)

model = foz.load_zoo_model("qwen3.8-27b-torch")
dataset.apply_model(model, label_field="qwen38")

session = fo.launch_app(dataset)
```

Restrict to specific classes:

```python
model = foz.load_zoo_model(
    "qwen3.8-27b-torch", classes=["person", "car", "dog"]
)
```

## Verification

Run on an RTX 6000 Ada against `quickstart`:

- 15.6 GB VRAM under NF4, load in 47 s
- 18 detections across 5 samples, with labels including alpaca, carrot, horse, fence, train, sign, zebra, person and bench

Parity against direct `transformers` inference, same images, prompt, `reasoning_effort` and `max_new_tokens`, greedy decoding: the generated text is byte-identical and the parsed detections match on all three images tested (6, 6 and 1 boxes).

`tests/unittests/utils/test_qwen3_8.py` covers answer extraction, bbox parsing including non-finite and malformed coordinates, the 0-1000 coordinate convention and its independence from frame size, image normalization, prompt selection, and `reasoning_effort` validation. 60 tests.

The Gated DeltaNet fast path (`flash-linear-attention`, `causal-conv1d`) is not required; transformers falls back to its torch implementation when those are absent.

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3795
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Qwen3.8-27B vision-language object detection.
  * Supports configurable prompts, detection classes, reasoning effort, token limits, and optional 4-bit loading.
  * Converts model responses into validated, normalized bounding-box detections.
  * Handles floating-point image preprocessing and robust response cleanup.

* **Tests**
  * Added comprehensive coverage for detection parsing, configuration validation, image conversion, truncation handling, and normalized coordinates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
