### PR TITLE
Settle synchronized multimodal streams authoritatively

### DIFF
--- a/app/packages/multimodal/src/adapters/mcap/contracts/index.ts
+++ b/app/packages/multimodal/src/adapters/mcap/contracts/index.ts
@@ -827,6 +827,8 @@ export interface McapTimelineRange {
 export interface McapReadSynchronizedMessagesRequest {
   /** Active point-cloud color source requested per MCAP topic. */
   readonly pointCloudColorByByTopic?: Readonly<Record<string, string>>;
+  /** Topics eligible for one cost-selected early delivery. */
+  readonly earlyDeliveryTopics?: readonly string[];
   /**
    * Playback timeline time around which per-topic messages are selected.
    */
@@ -889,6 +891,14 @@ export type McapResourceReadPriority =
 export interface McapResourceReadOptions {
   readonly priority?: McapResourceReadPriority;
   readonly signal?: AbortSignal;
+}
+
+/** Options for one synchronized current-frame read. */
+export interface McapSynchronizedMessagesReadOptions extends McapResourceReadOptions {
+  /** Receives at most one topic-complete window before the union settles. */
+  readonly onSynchronizedProgress?: (
+    window: McapSynchronizedMessageWindow,
+  ) => void;
 }
 
 /**
@@ -1180,7 +1190,7 @@ export interface McapResourceClient {
    */
   readSynchronizedMessages(
     request: McapReadSynchronizedMessagesRequest,
-    options?: McapResourceReadOptions,
+    options?: McapSynchronizedMessagesReadOptions,
   ): Promise<McapSynchronizedMessageWindow>;
 
   /**

--- a/app/packages/multimodal/src/adapters/mcap/contracts/index.ts
+++ b/app/packages/multimodal/src/adapters/mcap/contracts/index.ts
@@ -827,6 +827,8 @@ export interface McapTimelineRange {
 export interface McapReadSynchronizedMessagesRequest {
   /** Active point-cloud color source requested per MCAP topic. */
   readonly pointCloudColorByByTopic?: Readonly<Record<string, string>>;
+  /** Topics eligible for the first independently useful settlement. */
+  readonly firstUsefulSettlementTopics?: readonly string[];
   /** Stable presentation order for current-tick priority settlements. */
   readonly settlementPriorityTopics?: readonly string[];
   /**

--- a/app/packages/multimodal/src/adapters/mcap/contracts/index.ts
+++ b/app/packages/multimodal/src/adapters/mcap/contracts/index.ts
@@ -827,8 +827,8 @@ export interface McapTimelineRange {
 export interface McapReadSynchronizedMessagesRequest {
   /** Active point-cloud color source requested per MCAP topic. */
   readonly pointCloudColorByByTopic?: Readonly<Record<string, string>>;
-  /** Topics eligible for one cost-selected early delivery. */
-  readonly earlyDeliveryTopics?: readonly string[];
+  /** Topics eligible for one cost-selected first settlement. */
+  readonly settlementPriorityTopics?: readonly string[];
   /**
    * Playback timeline time around which per-topic messages are selected.
    */
@@ -893,11 +893,19 @@ export interface McapResourceReadOptions {
   readonly signal?: AbortSignal;
 }
 
+/** One authoritative topic result from a synchronized union read. */
+export interface McapSynchronizedTopicSettlement {
+  /** The only topic whose ownership is settled by this window. */
+  readonly topic: string;
+  /** Authoritative payload, empty result, or diagnostics for `topic`. */
+  readonly window: McapSynchronizedMessageWindow;
+}
+
 /** Options for one synchronized current-frame read. */
 export interface McapSynchronizedMessagesReadOptions extends McapResourceReadOptions {
-  /** Receives at most one topic-complete window before the union settles. */
-  readonly onSynchronizedProgress?: (
-    window: McapSynchronizedMessageWindow,
+  /** Receives ordered, authoritative per-topic ownership settlements. */
+  readonly onTopicSettlement?: (
+    settlement: McapSynchronizedTopicSettlement,
   ) => void;
 }
 

--- a/app/packages/multimodal/src/adapters/mcap/contracts/index.ts
+++ b/app/packages/multimodal/src/adapters/mcap/contracts/index.ts
@@ -827,7 +827,7 @@ export interface McapTimelineRange {
 export interface McapReadSynchronizedMessagesRequest {
   /** Active point-cloud color source requested per MCAP topic. */
   readonly pointCloudColorByByTopic?: Readonly<Record<string, string>>;
-  /** Topics eligible for one cost-selected first settlement. */
+  /** Stable presentation order for current-tick priority settlements. */
   readonly settlementPriorityTopics?: readonly string[];
   /**
    * Playback timeline time around which per-topic messages are selected.

--- a/app/packages/multimodal/src/adapters/mcap/contracts/index.ts
+++ b/app/packages/multimodal/src/adapters/mcap/contracts/index.ts
@@ -907,6 +907,10 @@ export interface McapSynchronizedMessagesReadOptions extends McapResourceReadOpt
   readonly onTopicSettlement?: (
     settlement: McapSynchronizedTopicSettlement,
   ) => void;
+  /** Receives one ordered worker delivery group of authoritative settlements. */
+  readonly onTopicSettlements?: (
+    settlements: readonly McapSynchronizedTopicSettlement[],
+  ) => void;
 }
 
 /**

--- a/app/packages/multimodal/src/adapters/mcap/format-adapter.ts
+++ b/app/packages/multimodal/src/adapters/mcap/format-adapter.ts
@@ -893,6 +893,7 @@ class McapEpisodeSession implements EpisodeSession {
   private returnedBatches = 0;
   private budgetAllowance?: ReadWorkBudget;
   private budgetLedger?: SourceReadBudgetLedger;
+  private readonly streamIdsBySourceName: ReadonlyMap<string, string>;
   private readonly sourceNamesById: ReadonlyMap<string, string>;
 
   constructor(
@@ -920,6 +921,14 @@ class McapEpisodeSession implements EpisodeSession {
     this.sourceNamesById = new Map(
       manifest.streams.map((stream) => [stream.id, stream.sourceName]),
     );
+    const streamIdsBySourceName = new Map<string, string>();
+    for (const stream of manifest.streams) {
+      // Preserve the former Array.find behavior for duplicate source names.
+      if (!streamIdsBySourceName.has(stream.sourceName)) {
+        streamIdsBySourceName.set(stream.sourceName, stream.id);
+      }
+    }
+    this.streamIdsBySourceName = streamIdsBySourceName;
     this.boundedRead = {
       openAccount: (allowance) => this.openBoundedReadAccount(allowance),
     };
@@ -1567,10 +1576,7 @@ class McapEpisodeSession implements EpisodeSession {
   }
 
   private streamIdFor(sourceName: string): string {
-    return (
-      this.manifest.streams.find((stream) => stream.sourceName === sourceName)
-        ?.id ?? sourceName
-    );
+    return this.streamIdsBySourceName.get(sourceName) ?? sourceName;
   }
 
   private toMcapSyncPolicies(

--- a/app/packages/multimodal/src/adapters/mcap/format-adapter.ts
+++ b/app/packages/multimodal/src/adapters/mcap/format-adapter.ts
@@ -1244,6 +1244,15 @@ class McapEpisodeSession implements EpisodeSession {
               ),
             },
             {
+              onTopicSettlements: request.onStreamSettlements
+                ? (settlements) =>
+                    request.onStreamSettlements?.(
+                      settlements.map(({ topic, window }) => ({
+                        stream: this.streamIdFor(topic),
+                        window: this.fromMcapWindow(window),
+                      })),
+                    )
+                : undefined,
               onTopicSettlement: request.onStreamSettlement
                 ? ({ topic, window }) =>
                     request.onStreamSettlement?.({

--- a/app/packages/multimodal/src/adapters/mcap/format-adapter.ts
+++ b/app/packages/multimodal/src/adapters/mcap/format-adapter.ts
@@ -1230,6 +1230,10 @@ class McapEpisodeSession implements EpisodeSession {
               defaultStreamPolicy: toMcapSyncPolicy(
                 request.defaultStreamPolicy,
               ),
+              firstUsefulSettlementTopics:
+                request.firstUsefulSettlementStreams?.map((stream) =>
+                  this.sourceNameFor(stream),
+                ),
               pointCloudColorByByTopic: this.toMcapPointCloudColorBy(
                 request.pointCloudColorBy,
               ),

--- a/app/packages/multimodal/src/adapters/mcap/format-adapter.ts
+++ b/app/packages/multimodal/src/adapters/mcap/format-adapter.ts
@@ -1230,6 +1230,9 @@ class McapEpisodeSession implements EpisodeSession {
               defaultStreamPolicy: toMcapSyncPolicy(
                 request.defaultStreamPolicy,
               ),
+              earlyDeliveryTopics: request.earlyDeliveryStreams?.map((stream) =>
+                this.sourceNameFor(stream),
+              ),
               pointCloudColorByByTopic: this.toMcapPointCloudColorBy(
                 request.pointCloudColorBy,
               ),
@@ -1240,7 +1243,13 @@ class McapEpisodeSession implements EpisodeSession {
                 this.sourceNameFor(stream),
               ),
             },
-            { signal: request.signal },
+            {
+              onSynchronizedProgress: request.onProgress
+                ? (progress) =>
+                    request.onProgress?.(this.fromMcapWindow(progress))
+                : undefined,
+              signal: request.signal,
+            },
           );
           return this.fromMcapWindow(window);
         } catch (error) {

--- a/app/packages/multimodal/src/adapters/mcap/format-adapter.ts
+++ b/app/packages/multimodal/src/adapters/mcap/format-adapter.ts
@@ -1230,11 +1230,11 @@ class McapEpisodeSession implements EpisodeSession {
               defaultStreamPolicy: toMcapSyncPolicy(
                 request.defaultStreamPolicy,
               ),
-              earlyDeliveryTopics: request.earlyDeliveryStreams?.map((stream) =>
-                this.sourceNameFor(stream),
-              ),
               pointCloudColorByByTopic: this.toMcapPointCloudColorBy(
                 request.pointCloudColorBy,
+              ),
+              settlementPriorityTopics: request.settlementPriorityStreams?.map(
+                (stream) => this.sourceNameFor(stream),
               ),
               source: this.source,
               streamPolicies: this.toMcapSyncPolicies(request.streamPolicies),
@@ -1244,9 +1244,12 @@ class McapEpisodeSession implements EpisodeSession {
               ),
             },
             {
-              onSynchronizedProgress: request.onProgress
-                ? (progress) =>
-                    request.onProgress?.(this.fromMcapWindow(progress))
+              onTopicSettlement: request.onStreamSettlement
+                ? ({ topic, window }) =>
+                    request.onStreamSettlement?.({
+                      stream: this.streamIdFor(topic),
+                      window: this.fromMcapWindow(window),
+                    })
                 : undefined,
               signal: request.signal,
             },

--- a/app/packages/multimodal/src/adapters/mcap/resource-client/inline-client.synchronized-messages.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/resource-client/inline-client.synchronized-messages.test.ts
@@ -431,7 +431,7 @@ describe("MCAP synchronized messages", () => {
     });
   });
 
-  it("reuses an indexed decoded record before chunk materialization", async () => {
+  it("reuses an indexed decoded record with a per-request signal", async () => {
     const indexed = createIndexedMessageTime("/topic", 7, 90n, 900n);
     const readIndexedMessageTimes = vi.fn(async function* () {
       yield indexed;
@@ -460,7 +460,8 @@ describe("MCAP synchronized messages", () => {
       }) => ({ kind: "retained" as const, ...identity }),
     );
 
-    const [window] = await client.readSynchronizedMessageBatchWithReuse(
+    const controller = new AbortController();
+    const window = await client.readSynchronizedMessagesWithReuse(
       {
         defaultStreamPolicy: {
           mode: PlaybackSyncMode.NEAREST,
@@ -469,10 +470,12 @@ describe("MCAP synchronized messages", () => {
         },
         pointCloudColorByByTopic: { "/topic": "intensity" },
         source: createMcapSourceDescriptor(),
-        timeNs: [100n],
+        timeNs: 100n,
         topics: ["/topic"],
       },
       reuse,
+      undefined,
+      { signal: controller.signal },
     );
 
     expect(window.messages[0]).toMatchObject({

--- a/app/packages/multimodal/src/adapters/mcap/resource-client/inline-client.synchronized-messages.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/resource-client/inline-client.synchronized-messages.test.ts
@@ -114,6 +114,66 @@ describe("MCAP synchronized messages", () => {
     ]);
   });
 
+  it.each([
+    ["forward", ["/camera", "/lidar"]],
+    ["reverse", ["/lidar", "/camera"]],
+  ] as const)(
+    "settles every topic from one union read independent of %s request order",
+    async (_direction, topics) => {
+      const messages = [
+        createMessage(new Uint8Array(100), {
+          channelId: 7,
+          logTime: 100n,
+          publishTime: 101n,
+        }),
+        createMessage(new Uint8Array(10), {
+          channelId: 8,
+          logTime: 100n,
+          publishTime: 101n,
+        }),
+      ];
+      const readMessages = vi.fn(async function* () {
+        for (const message of messages) yield message;
+      });
+      const client = createInlineMcapResourceClient({
+        byteClient: { readBytes: vi.fn() },
+        decodeClient: createTestDecodeClient(),
+        readerFactory: vi.fn(async () =>
+          createReader({
+            channelsById: new Map([
+              [7, createChannel({ id: 7, topic: "/camera" })],
+              [8, createChannel({ id: 8, topic: "/lidar" })],
+            ]),
+            readMessages,
+          }),
+        ),
+      });
+      const settlements: string[] = [];
+
+      const window = await client.readSynchronizedMessages(
+        {
+          settlementPriorityTopics: ["/camera", "/lidar"],
+          source: createMcapSourceDescriptor(),
+          timeNs: 100n,
+          topics,
+        },
+        {
+          onTopicSettlement: ({ topic, window: settledWindow }) => {
+            settlements.push(topic);
+            expect(Object.keys(settledWindow.messagesByTopic)).toEqual([topic]);
+          },
+        },
+      );
+
+      expect(settlements).toEqual(["/lidar", "/camera"]);
+      expect(Object.keys(window.messagesByTopic).sort()).toEqual([
+        "/camera",
+        "/lidar",
+      ]);
+      expect(readMessages).toHaveBeenCalledOnce();
+    },
+  );
+
   it("contains payload decode failures to their topic and preserves shared decode work", async () => {
     const source = createMcapSourceDescriptor();
     const messages = [

--- a/app/packages/multimodal/src/adapters/mcap/resource-client/inline-client.synchronized-messages.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/resource-client/inline-client.synchronized-messages.test.ts
@@ -165,7 +165,7 @@ describe("MCAP synchronized messages", () => {
         },
       );
 
-      expect(settlements).toEqual(["/lidar", "/camera"]);
+      expect(settlements).toEqual(["/camera", "/lidar"]);
       expect(Object.keys(window.messagesByTopic).sort()).toEqual([
         "/camera",
         "/lidar",

--- a/app/packages/multimodal/src/adapters/mcap/resource-client/inline-client.ts
+++ b/app/packages/multimodal/src/adapters/mcap/resource-client/inline-client.ts
@@ -116,6 +116,7 @@ export interface McapSynchronizedMessageReuseClient extends McapResourceClient {
         McapDecodedMessage | ReusedMessage
       >,
     ) => void,
+    readOptions?: McapResourceReadOptions,
   ): Promise<
     readonly McapSynchronizedMessageWindowWithMessages<
       McapDecodedMessage | ReusedMessage
@@ -134,6 +135,7 @@ export interface McapSynchronizedMessageReuseClient extends McapResourceClient {
         McapDecodedMessage | ReusedMessage
       >,
     ) => void,
+    readOptions?: McapResourceReadOptions,
   ): Promise<
     McapSynchronizedMessageWindowWithMessages<
       McapDecodedMessage | ReusedMessage
@@ -542,25 +544,28 @@ export function createInlineMcapResourceClient(
       request,
       reuseIndexedMessage,
       onWindowProgress,
+      readOptions,
     ) {
       if (request.timeNs.length === 0) {
         return [];
       }
 
       const timeline = resolveMcapTimelineStrategy(request.activeTimeline);
-      const reader = await readerStore.get(request.source);
       const sourceKey = byteSourceAccessKey(request.source);
+      const signal = readOptions?.signal;
 
-      return readMcapSynchronizedMessageBatch({
-        decodeClient,
-        predecessorStore: predecessorStoreForSource(sourceKey),
-        reader,
-        readSignal: options.readSignal,
-        onWindowProgress,
-        request,
-        reuseIndexedMessage,
-        timeline,
-      });
+      return withRequestReader(request.source, signal, (reader) =>
+        readMcapSynchronizedMessageBatch({
+          decodeClient,
+          predecessorStore: predecessorStoreForSource(sourceKey),
+          reader,
+          readSignal: signal ? { current: signal } : options.readSignal,
+          onWindowProgress,
+          request,
+          reuseIndexedMessage,
+          timeline,
+        }),
+      );
     },
 
     async readSynchronizedMessages(
@@ -599,11 +604,13 @@ export function createInlineMcapResourceClient(
       request,
       reuseIndexedMessage,
       onWindowProgress,
+      readOptions,
     ) {
       const windows = await client.readSynchronizedMessageBatchWithReuse(
         { ...request, timeNs: [request.timeNs] },
         reuseIndexedMessage,
         onWindowProgress,
+        readOptions,
       );
       const window = windows[0];
       if (!window) {

--- a/app/packages/multimodal/src/adapters/mcap/resource-client/inline-client.ts
+++ b/app/packages/multimodal/src/adapters/mcap/resource-client/inline-client.ts
@@ -78,6 +78,7 @@ import {
   type McapReadTimelineRangeRequest,
   type McapResourceClient,
   type McapResourceReadOptions,
+  type McapSynchronizedMessagesReadOptions,
   type McapSynchronizedMessageWindow,
   type McapTimelineRange,
   type McapTopicNumericFields,
@@ -110,6 +111,11 @@ export interface McapSynchronizedMessageReuseClient extends McapResourceClient {
   >(
     request: McapReadSynchronizedMessageBatchRequest,
     reuseIndexedMessage?: McapIndexedMessageReuse<ReusedMessage>,
+    onWindowProgress?: (
+      window: McapSynchronizedMessageWindowWithMessages<
+        McapDecodedMessage | ReusedMessage
+      >,
+    ) => void,
   ): Promise<
     readonly McapSynchronizedMessageWindowWithMessages<
       McapDecodedMessage | ReusedMessage
@@ -123,6 +129,11 @@ export interface McapSynchronizedMessageReuseClient extends McapResourceClient {
   >(
     request: McapReadSynchronizedMessagesRequest,
     reuseIndexedMessage?: McapIndexedMessageReuse<ReusedMessage>,
+    onWindowProgress?: (
+      window: McapSynchronizedMessageWindowWithMessages<
+        McapDecodedMessage | ReusedMessage
+      >,
+    ) => void,
   ): Promise<
     McapSynchronizedMessageWindowWithMessages<
       McapDecodedMessage | ReusedMessage
@@ -527,7 +538,11 @@ export function createInlineMcapResourceClient(
       );
     },
 
-    async readSynchronizedMessageBatchWithReuse(request, reuseIndexedMessage) {
+    async readSynchronizedMessageBatchWithReuse(
+      request,
+      reuseIndexedMessage,
+      onWindowProgress,
+    ) {
       if (request.timeNs.length === 0) {
         return [];
       }
@@ -541,6 +556,7 @@ export function createInlineMcapResourceClient(
         predecessorStore: predecessorStoreForSource(sourceKey),
         reader,
         readSignal: options.readSignal,
+        onWindowProgress,
         request,
         reuseIndexedMessage,
         timeline,
@@ -549,21 +565,45 @@ export function createInlineMcapResourceClient(
 
     async readSynchronizedMessages(
       request: McapReadSynchronizedMessagesRequest,
-      readOptions?: McapResourceReadOptions,
+      readOptions?: McapSynchronizedMessagesReadOptions,
     ): Promise<McapSynchronizedMessageWindow> {
-      const windows = await client.readSynchronizedMessageBatch(
-        { ...request, timeNs: [request.timeNs] },
-        readOptions,
+      if (!readOptions?.signal) {
+        return client.readSynchronizedMessagesWithReuse(
+          request,
+          undefined,
+          readOptions?.onSynchronizedProgress,
+        );
+      }
+      const timeline = resolveMcapTimelineStrategy(request.activeTimeline);
+      const sourceKey = byteSourceAccessKey(request.source);
+      const windows = await withRequestReader(
+        request.source,
+        readOptions.signal,
+        (reader) =>
+          readMcapSynchronizedMessageBatch({
+            decodeClient,
+            predecessorStore: predecessorStoreForSource(sourceKey),
+            reader,
+            readSignal: { current: readOptions.signal ?? null },
+            onWindowProgress: readOptions.onSynchronizedProgress,
+            request: { ...request, timeNs: [request.timeNs] },
+            timeline,
+          }),
       );
       const window = windows[0];
       if (!window) throw new Error("Expected synchronized MCAP window");
       return window;
     },
 
-    async readSynchronizedMessagesWithReuse(request, reuseIndexedMessage) {
+    async readSynchronizedMessagesWithReuse(
+      request,
+      reuseIndexedMessage,
+      onWindowProgress,
+    ) {
       const windows = await client.readSynchronizedMessageBatchWithReuse(
         { ...request, timeNs: [request.timeNs] },
         reuseIndexedMessage,
+        onWindowProgress,
       );
       const window = windows[0];
       if (!window) {

--- a/app/packages/multimodal/src/adapters/mcap/resource-client/inline-client.ts
+++ b/app/packages/multimodal/src/adapters/mcap/resource-client/inline-client.ts
@@ -574,11 +574,23 @@ export function createInlineMcapResourceClient(
       request: McapReadSynchronizedMessagesRequest,
       readOptions?: McapSynchronizedMessagesReadOptions,
     ): Promise<McapSynchronizedMessageWindow> {
+      const onTopicSettlement = readOptions
+        ? (
+            settlement: Parameters<
+              NonNullable<
+                McapSynchronizedMessagesReadOptions["onTopicSettlement"]
+              >
+            >[0],
+          ) => {
+            readOptions.onTopicSettlements?.([settlement]);
+            readOptions.onTopicSettlement?.(settlement);
+          }
+        : undefined;
       if (!readOptions?.signal) {
         return client.readSynchronizedMessagesWithReuse(
           request,
           undefined,
-          readOptions?.onTopicSettlement,
+          onTopicSettlement,
         );
       }
       const timeline = resolveMcapTimelineStrategy(request.activeTimeline);
@@ -592,7 +604,7 @@ export function createInlineMcapResourceClient(
             predecessorStore: predecessorStoreForSource(sourceKey),
             reader,
             readSignal: { current: readOptions.signal ?? null },
-            onTopicSettlement: readOptions.onTopicSettlement,
+            onTopicSettlement,
             request: { ...request, timeNs: [request.timeNs] },
             timeline,
           }),

--- a/app/packages/multimodal/src/adapters/mcap/resource-client/inline-client.ts
+++ b/app/packages/multimodal/src/adapters/mcap/resource-client/inline-client.ts
@@ -111,11 +111,12 @@ export interface McapSynchronizedMessageReuseClient extends McapResourceClient {
   >(
     request: McapReadSynchronizedMessageBatchRequest,
     reuseIndexedMessage?: McapIndexedMessageReuse<ReusedMessage>,
-    onWindowProgress?: (
-      window: McapSynchronizedMessageWindowWithMessages<
+    onTopicSettlement?: (settlement: {
+      readonly topic: string;
+      readonly window: McapSynchronizedMessageWindowWithMessages<
         McapDecodedMessage | ReusedMessage
-      >,
-    ) => void,
+      >;
+    }) => void,
     readOptions?: McapResourceReadOptions,
   ): Promise<
     readonly McapSynchronizedMessageWindowWithMessages<
@@ -130,11 +131,12 @@ export interface McapSynchronizedMessageReuseClient extends McapResourceClient {
   >(
     request: McapReadSynchronizedMessagesRequest,
     reuseIndexedMessage?: McapIndexedMessageReuse<ReusedMessage>,
-    onWindowProgress?: (
-      window: McapSynchronizedMessageWindowWithMessages<
+    onTopicSettlement?: (settlement: {
+      readonly topic: string;
+      readonly window: McapSynchronizedMessageWindowWithMessages<
         McapDecodedMessage | ReusedMessage
-      >,
-    ) => void,
+      >;
+    }) => void,
     readOptions?: McapResourceReadOptions,
   ): Promise<
     McapSynchronizedMessageWindowWithMessages<
@@ -543,7 +545,7 @@ export function createInlineMcapResourceClient(
     async readSynchronizedMessageBatchWithReuse(
       request,
       reuseIndexedMessage,
-      onWindowProgress,
+      onTopicSettlement,
       readOptions,
     ) {
       if (request.timeNs.length === 0) {
@@ -560,7 +562,7 @@ export function createInlineMcapResourceClient(
           predecessorStore: predecessorStoreForSource(sourceKey),
           reader,
           readSignal: signal ? { current: signal } : options.readSignal,
-          onWindowProgress,
+          onTopicSettlement,
           request,
           reuseIndexedMessage,
           timeline,
@@ -576,7 +578,7 @@ export function createInlineMcapResourceClient(
         return client.readSynchronizedMessagesWithReuse(
           request,
           undefined,
-          readOptions?.onSynchronizedProgress,
+          readOptions?.onTopicSettlement,
         );
       }
       const timeline = resolveMcapTimelineStrategy(request.activeTimeline);
@@ -590,7 +592,7 @@ export function createInlineMcapResourceClient(
             predecessorStore: predecessorStoreForSource(sourceKey),
             reader,
             readSignal: { current: readOptions.signal ?? null },
-            onWindowProgress: readOptions.onSynchronizedProgress,
+            onTopicSettlement: readOptions.onTopicSettlement,
             request: { ...request, timeNs: [request.timeNs] },
             timeline,
           }),
@@ -603,13 +605,13 @@ export function createInlineMcapResourceClient(
     async readSynchronizedMessagesWithReuse(
       request,
       reuseIndexedMessage,
-      onWindowProgress,
+      onTopicSettlement,
       readOptions,
     ) {
       const windows = await client.readSynchronizedMessageBatchWithReuse(
         { ...request, timeNs: [request.timeNs] },
         reuseIndexedMessage,
-        onWindowProgress,
+        onTopicSettlement,
         readOptions,
       );
       const window = windows[0];

--- a/app/packages/multimodal/src/adapters/mcap/resource-client/non-indexed-mcap.integration.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/resource-client/non-indexed-mcap.integration.test.ts
@@ -52,22 +52,22 @@ describe("non-indexed MCAP production contract", () => {
       },
       registry: createMcapDecoderRegistry(),
     });
-    const progress: string[][] = [];
+    const settlements: string[][] = [];
     const windows = await readMcapSynchronizedMessageBatch({
       decodeClient,
-      onWindowProgress: (window) => {
-        progress.push(Object.keys(window.messagesByTopic));
+      onTopicSettlement: ({ window }) => {
+        settlements.push(Object.keys(window.messagesByTopic));
       },
       reader,
       request: {
-        earlyDeliveryTopics: ["/pose"],
+        settlementPriorityTopics: ["/pose"],
         source,
         timeNs: [2_000_000_000n],
         topics: ["/pose"],
       },
       timeline,
     });
-    expect(progress).toEqual([["/pose"]]);
+    expect(settlements).toEqual([["/pose"]]);
     expect(windows[0]?.messagesByTopic["/pose"]?.[0]?.timelineTimeNs).toBe(0n);
 
     const transforms = await readMcapFrameTransformWindow({

--- a/app/packages/multimodal/src/adapters/mcap/resource-client/non-indexed-mcap.integration.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/resource-client/non-indexed-mcap.integration.test.ts
@@ -52,16 +52,22 @@ describe("non-indexed MCAP production contract", () => {
       },
       registry: createMcapDecoderRegistry(),
     });
+    const progress: string[][] = [];
     const windows = await readMcapSynchronizedMessageBatch({
       decodeClient,
+      onWindowProgress: (window) => {
+        progress.push(Object.keys(window.messagesByTopic));
+      },
       reader,
       request: {
+        earlyDeliveryTopics: ["/pose"],
         source,
         timeNs: [2_000_000_000n],
         topics: ["/pose"],
       },
       timeline,
     });
+    expect(progress).toEqual([["/pose"]]);
     expect(windows[0]?.messagesByTopic["/pose"]?.[0]?.timelineTimeNs).toBe(0n);
 
     const transforms = await readMcapFrameTransformWindow({

--- a/app/packages/multimodal/src/adapters/mcap/resource-client/operations/read-synchronized-message-batch.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/resource-client/operations/read-synchronized-message-batch.test.ts
@@ -4,7 +4,7 @@ import {
   INDEXED_RECORD_ID_OPTION_PART_COUNT,
   mintIndexedRecordIdentity,
   parseIndexedRecordIdentity,
-  selectEarlyDeliveryTopic,
+  selectFirstSettlementTopic,
 } from "./read-synchronized-message-batch";
 
 describe("indexed record identity", () => {
@@ -46,7 +46,7 @@ describe("indexed record identity", () => {
   });
 });
 
-describe("early synchronized delivery", () => {
+describe("synchronized settlement order", () => {
   it.each([
     [
       "forward",
@@ -72,9 +72,9 @@ describe("early synchronized delivery", () => {
         readonly { readonly bytes: number }[],
       ])[] = selectedByTopic;
       await expect(
-        selectEarlyDeliveryTopic({
-          earlyDeliveryTopics: ["/large", "/small"],
+        selectFirstSettlementTopic({
           estimateCandidateBytes: (candidate) => candidate.bytes,
+          settlementPriorityTopics: ["/large", "/small"],
           selectedByTopic: candidates,
         }),
       ).resolves.toBe("/small");

--- a/app/packages/multimodal/src/adapters/mcap/resource-client/operations/read-synchronized-message-batch.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/resource-client/operations/read-synchronized-message-batch.test.ts
@@ -4,6 +4,7 @@ import {
   INDEXED_RECORD_ID_OPTION_PART_COUNT,
   mintIndexedRecordIdentity,
   parseIndexedRecordIdentity,
+  selectEarlyDeliveryTopic,
 } from "./read-synchronized-message-batch";
 
 describe("indexed record identity", () => {
@@ -43,4 +44,40 @@ describe("indexed record identity", () => {
       ),
     ).toThrow("cannot contain NUL bytes");
   });
+});
+
+describe("early synchronized delivery", () => {
+  it.each([
+    [
+      "forward",
+      [
+        ["/large", [{ bytes: 100 }]],
+        ["/small", [{ bytes: 10 }]],
+        ["/support", [{ bytes: 1 }]],
+      ],
+    ],
+    [
+      "reverse",
+      [
+        ["/support", [{ bytes: 1 }]],
+        ["/small", [{ bytes: 10 }]],
+        ["/large", [{ bytes: 100 }]],
+      ],
+    ],
+  ] as const)(
+    "selects the cheapest eligible surface for %s request order",
+    async (_direction, selectedByTopic) => {
+      const candidates: readonly (readonly [
+        string,
+        readonly { readonly bytes: number }[],
+      ])[] = selectedByTopic;
+      await expect(
+        selectEarlyDeliveryTopic({
+          earlyDeliveryTopics: ["/large", "/small"],
+          estimateCandidateBytes: (candidate) => candidate.bytes,
+          selectedByTopic: candidates,
+        }),
+      ).resolves.toBe("/small");
+    },
+  );
 });

--- a/app/packages/multimodal/src/adapters/mcap/resource-client/operations/read-synchronized-message-batch.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/resource-client/operations/read-synchronized-message-batch.test.ts
@@ -4,7 +4,6 @@ import {
   INDEXED_RECORD_ID_OPTION_PART_COUNT,
   mintIndexedRecordIdentity,
   parseIndexedRecordIdentity,
-  selectFirstSettlementTopic,
   selectSettlementTopics,
 } from "./read-synchronized-message-batch";
 
@@ -66,26 +65,18 @@ describe("synchronized settlement order", () => {
       ],
     ],
   ] as const)(
-    "selects the cheapest eligible surface for %s request order",
-    async (_direction, selectedByTopic) => {
+    "preserves explicit presentation priority for %s candidate order",
+    (_direction, selectedByTopic) => {
       const candidates: readonly (readonly [
         string,
         readonly { readonly bytes: number }[],
       ])[] = selectedByTopic;
-      await expect(
-        selectFirstSettlementTopic({
-          estimateCandidateBytes: (candidate) => candidate.bytes,
-          settlementPriorityTopics: ["/large", "/small"],
-          selectedByTopic: candidates,
-        }),
-      ).resolves.toBe("/small");
-      await expect(
+      expect(
         selectSettlementTopics({
-          estimateCandidateBytes: (candidate) => candidate.bytes,
-          settlementPriorityTopics: ["/large", "/small"],
+          settlementPriorityTopics: ["/small", "/large"],
           selectedByTopic: candidates,
         }),
-      ).resolves.toEqual(["/small", "/large"]);
+      ).toEqual(["/small", "/large"]);
     },
   );
 });

--- a/app/packages/multimodal/src/adapters/mcap/resource-client/operations/read-synchronized-message-batch.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/resource-client/operations/read-synchronized-message-batch.test.ts
@@ -5,6 +5,7 @@ import {
   mintIndexedRecordIdentity,
   parseIndexedRecordIdentity,
   selectFirstSettlementTopic,
+  selectSettlementTopics,
 } from "./read-synchronized-message-batch";
 
 describe("indexed record identity", () => {
@@ -78,6 +79,13 @@ describe("synchronized settlement order", () => {
           selectedByTopic: candidates,
         }),
       ).resolves.toBe("/small");
+      await expect(
+        selectSettlementTopics({
+          estimateCandidateBytes: (candidate) => candidate.bytes,
+          settlementPriorityTopics: ["/large", "/small"],
+          selectedByTopic: candidates,
+        }),
+      ).resolves.toEqual(["/small", "/large"]);
     },
   );
 });

--- a/app/packages/multimodal/src/adapters/mcap/resource-client/operations/read-synchronized-message-batch.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/resource-client/operations/read-synchronized-message-batch.test.ts
@@ -66,17 +66,25 @@ describe("synchronized settlement order", () => {
     ],
   ] as const)(
     "preserves explicit presentation priority for %s candidate order",
-    (_direction, selectedByTopic) => {
+    async (_direction, selectedByTopic) => {
       const candidates: readonly (readonly [
         string,
         readonly { readonly bytes: number }[],
       ])[] = selectedByTopic;
-      expect(
+      await expect(
         selectSettlementTopics({
           settlementPriorityTopics: ["/small", "/large"],
           selectedByTopic: candidates,
         }),
-      ).toEqual(["/small", "/large"]);
+      ).resolves.toEqual(["/small", "/large"]);
+      await expect(
+        selectSettlementTopics({
+          estimateCandidateBytes: (candidate) => candidate.bytes,
+          firstUsefulSettlementTopics: ["/large", "/small"],
+          settlementPriorityTopics: ["/large", "/small"],
+          selectedByTopic: candidates,
+        }),
+      ).resolves.toEqual(["/small", "/large"]);
     },
   );
 });

--- a/app/packages/multimodal/src/adapters/mcap/resource-client/operations/read-synchronized-message-batch.ts
+++ b/app/packages/multimodal/src/adapters/mcap/resource-client/operations/read-synchronized-message-batch.ts
@@ -279,20 +279,6 @@ export async function readMcapSynchronizedMessageBatch<
           timeline,
         }),
       settlementPriorityTopics: request.settlementPriorityTopics,
-      estimateCandidateBytes: async (candidate) => {
-        const identity = indexedCandidateReuseIdentity({
-          candidate,
-          pointCloudColorBy:
-            request.pointCloudColorByByTopic?.[candidate.topic],
-          timeline,
-        });
-        if (reusedIndexedMessages.has(identity.recordId)) return 0;
-        const materialized = await selectedRawCandidates;
-        return (
-          materialized?.get(candidate)?.message.data.byteLength ??
-          Number.MAX_SAFE_INTEGER
-        );
-      },
       // Selected candidates name their chunks exactly, so the byte layer can
       // pipeline those chunk fetches while decoding walks them serially.
       onCandidatesSelected: (selected) => {
@@ -354,7 +340,6 @@ export async function readMcapSynchronizedMessageBatch<
         timeline,
       }),
     settlementPriorityTopics: request.settlementPriorityTopics,
-    estimateCandidateBytes: (candidate) => candidate.message.data.byteLength,
     onTopicSettlement,
     selectTieBreaker: compareRawCandidateTieBreaker,
     timeline,
@@ -564,7 +549,6 @@ async function decodeWindowsFromCandidates<
   candidates,
   decodeCandidate,
   settlementPriorityTopics,
-  estimateCandidateBytes,
   onCandidatesSelected,
   onTopicSettlement,
   selectTieBreaker,
@@ -576,9 +560,6 @@ async function decodeWindowsFromCandidates<
   readonly candidates: ReadonlyMap<string, readonly Candidate[]>;
   readonly decodeCandidate: (candidate: Candidate) => Promise<Message>;
   readonly settlementPriorityTopics?: readonly string[];
-  readonly estimateCandidateBytes?: (
-    candidate: Candidate,
-  ) => number | Promise<number>;
   readonly onCandidatesSelected?: (selected: readonly Candidate[]) => void;
   readonly onTopicSettlement?: (settlement: {
     readonly topic: string;
@@ -647,7 +628,6 @@ async function decodeWindowsFromCandidates<
       > = {};
       const messages: Message[] = [];
       const settlementTopics = await selectSettlementTopics({
-        estimateCandidateBytes,
         settlementPriorityTopics,
         selectedByTopic,
       });
@@ -789,64 +769,22 @@ async function decodeWindowsFromCandidates<
   );
 }
 
-export async function selectFirstSettlementTopic<Candidate>({
-  estimateCandidateBytes,
+/** Preserves the caller's stable presentation order ahead of stragglers. */
+export function selectSettlementTopics<Candidate>({
   settlementPriorityTopics,
   selectedByTopic,
 }: {
-  readonly estimateCandidateBytes?: (
-    candidate: Candidate,
-  ) => number | Promise<number>;
   readonly settlementPriorityTopics?: readonly string[];
   readonly selectedByTopic: readonly (readonly [
     string,
     readonly Candidate[],
   ])[];
-}): Promise<string | undefined> {
-  return (
-    await selectSettlementTopics({
-      estimateCandidateBytes,
-      settlementPriorityTopics,
-      selectedByTopic,
-    })
-  )[0];
-}
-
-/** Orders every priority topic ahead of non-blocking settlement work. */
-export async function selectSettlementTopics<Candidate>({
-  estimateCandidateBytes,
-  settlementPriorityTopics,
-  selectedByTopic,
-}: {
-  readonly estimateCandidateBytes?: (
-    candidate: Candidate,
-  ) => number | Promise<number>;
-  readonly settlementPriorityTopics?: readonly string[];
-  readonly selectedByTopic: readonly (readonly [
-    string,
-    readonly Candidate[],
-  ])[];
-}): Promise<readonly string[]> {
+}): readonly string[] {
   if (!settlementPriorityTopics?.length) return [];
-  const eligible = new Set(settlementPriorityTopics);
-  const costs = await Promise.all(
-    selectedByTopic
-      .filter(([topic]) => eligible.has(topic))
-      .map(async ([topic, selected]) => ({
-        cost: estimateCandidateBytes
-          ? (await Promise.all(selected.map(estimateCandidateBytes))).reduce(
-              (total, bytes) => total + bytes,
-              0,
-            )
-          : 0,
-        topic,
-      })),
+  const selectedTopics = new Set(selectedByTopic.map(([topic]) => topic));
+  return [...new Set(settlementPriorityTopics)].filter((topic) =>
+    selectedTopics.has(topic),
   );
-  costs.sort(
-    (left, right) =>
-      left.cost - right.cost || left.topic.localeCompare(right.topic),
-  );
-  return costs.map(({ topic }) => topic);
 }
 
 async function collectIndexedCandidates({

--- a/app/packages/multimodal/src/adapters/mcap/resource-client/operations/read-synchronized-message-batch.ts
+++ b/app/packages/multimodal/src/adapters/mcap/resource-client/operations/read-synchronized-message-batch.ts
@@ -168,6 +168,7 @@ export async function readMcapSynchronizedMessageBatch<
   readSignal,
   request,
   reuseIndexedMessage,
+  onWindowProgress,
   timeline,
 }: {
   readonly decodeClient: DecodeClient;
@@ -176,6 +177,11 @@ export async function readMcapSynchronizedMessageBatch<
   readonly readSignal?: { readonly current: AbortSignal | null };
   readonly request: McapReadSynchronizedMessageBatchRequest;
   readonly reuseIndexedMessage?: McapIndexedMessageReuse<ReusedMessage>;
+  readonly onWindowProgress?: (
+    window: McapSynchronizedMessageWindowWithMessages<
+      McapDecodedMessage | ReusedMessage
+    >,
+  ) => void;
   readonly timeline: McapTimelineStrategy;
 }): Promise<
   readonly McapSynchronizedMessageWindowWithMessages<
@@ -271,6 +277,21 @@ export async function readMcapSynchronizedMessageBatch<
           source: request.source,
           timeline,
         }),
+      earlyDeliveryTopics: request.earlyDeliveryTopics,
+      estimateCandidateBytes: async (candidate) => {
+        const identity = indexedCandidateReuseIdentity({
+          candidate,
+          pointCloudColorBy:
+            request.pointCloudColorByByTopic?.[candidate.topic],
+          timeline,
+        });
+        if (reusedIndexedMessages.has(identity.recordId)) return 0;
+        const materialized = await selectedRawCandidates;
+        return (
+          materialized?.get(candidate)?.message.data.byteLength ??
+          Number.MAX_SAFE_INTEGER
+        );
+      },
       // Selected candidates name their chunks exactly, so the byte layer can
       // pipeline those chunk fetches while decoding walks them serially.
       onCandidatesSelected: (selected) => {
@@ -296,6 +317,7 @@ export async function readMcapSynchronizedMessageBatch<
           });
         }
       },
+      onWindowProgress,
       selectTieBreaker: compareIndexedCandidateTieBreaker,
       timeline,
       topics: request.topics,
@@ -330,6 +352,9 @@ export async function readMcapSynchronizedMessageBatch<
         source: request.source,
         timeline,
       }),
+    earlyDeliveryTopics: request.earlyDeliveryTopics,
+    estimateCandidateBytes: (candidate) => candidate.message.data.byteLength,
+    onWindowProgress,
     selectTieBreaker: compareRawCandidateTieBreaker,
     timeline,
     topics: request.topics,
@@ -537,7 +562,10 @@ async function decodeWindowsFromCandidates<
 >({
   candidates,
   decodeCandidate,
+  earlyDeliveryTopics,
+  estimateCandidateBytes,
   onCandidatesSelected,
+  onWindowProgress,
   selectTieBreaker,
   throwIfAborted,
   timeline,
@@ -546,7 +574,14 @@ async function decodeWindowsFromCandidates<
 }: {
   readonly candidates: ReadonlyMap<string, readonly Candidate[]>;
   readonly decodeCandidate: (candidate: Candidate) => Promise<Message>;
+  readonly earlyDeliveryTopics?: readonly string[];
+  readonly estimateCandidateBytes?: (
+    candidate: Candidate,
+  ) => number | Promise<number>;
   readonly onCandidatesSelected?: (selected: readonly Candidate[]) => void;
+  readonly onWindowProgress?: (
+    window: McapSynchronizedMessageWindowWithMessages<Message>,
+  ) => void;
   readonly selectTieBreaker: (left: Candidate, right: Candidate) => number;
   readonly throwIfAborted?: () => void;
   readonly timeline: McapTimelineStrategy;
@@ -609,8 +644,23 @@ async function decodeWindowsFromCandidates<
         readonly McapTopicDecodeDiagnostic[]
       > = {};
       const messages: Message[] = [];
+      const earlyDeliveryTopic = await selectEarlyDeliveryTopic({
+        earlyDeliveryTopics,
+        estimateCandidateBytes,
+        selectedByTopic,
+      });
+      const decodeOrder = earlyDeliveryTopic
+        ? [
+            ...selectedByTopic.filter(
+              ([topic]) => topic === earlyDeliveryTopic,
+            ),
+            ...selectedByTopic.filter(
+              ([topic]) => topic !== earlyDeliveryTopic,
+            ),
+          ]
+        : selectedByTopic;
 
-      for (const [topic, selected] of selectedByTopic) {
+      for (const [topic, selected] of decodeOrder) {
         throwIfAborted?.();
         const settled: readonly McapSettledTopicDecode<Message>[] =
           await Promise.all(
@@ -676,6 +726,18 @@ async function decodeWindowsFromCandidates<
           .map((result) => result.decoded);
         messagesByTopic[topic] = decoded;
         messages.push(...decoded);
+
+        if (topic === earlyDeliveryTopic && decoded.length > 0) {
+          onWindowProgress?.({
+            activeTimeline: timeline.id,
+            endTimeNs: streamPolicies[topic].endTimeNs,
+            messages: decoded,
+            messagesByTopic: { [topic]: decoded },
+            startTimeNs: streamPolicies[topic].startTimeNs ?? 0n,
+            streamPolicies: { [topic]: streamPolicies[topic] },
+            timeNs,
+          });
+        }
       }
 
       messages.sort((left, right) => {
@@ -706,6 +768,40 @@ async function decodeWindowsFromCandidates<
       };
     }),
   );
+}
+
+export async function selectEarlyDeliveryTopic<Candidate>({
+  earlyDeliveryTopics,
+  estimateCandidateBytes,
+  selectedByTopic,
+}: {
+  readonly earlyDeliveryTopics?: readonly string[];
+  readonly estimateCandidateBytes?: (
+    candidate: Candidate,
+  ) => number | Promise<number>;
+  readonly selectedByTopic: readonly (readonly [
+    string,
+    readonly Candidate[],
+  ])[];
+}): Promise<string | undefined> {
+  if (!estimateCandidateBytes || !earlyDeliveryTopics?.length) return undefined;
+  const eligible = new Set(earlyDeliveryTopics);
+  const costs = await Promise.all(
+    selectedByTopic
+      .filter(([topic, selected]) => eligible.has(topic) && selected.length > 0)
+      .map(async ([topic, selected]) => ({
+        cost: (await Promise.all(selected.map(estimateCandidateBytes))).reduce(
+          (total, bytes) => total + bytes,
+          0,
+        ),
+        topic,
+      })),
+  );
+  costs.sort(
+    (left, right) =>
+      left.cost - right.cost || left.topic.localeCompare(right.topic),
+  );
+  return costs[0]?.topic;
 }
 
 async function collectIndexedCandidates({

--- a/app/packages/multimodal/src/adapters/mcap/resource-client/operations/read-synchronized-message-batch.ts
+++ b/app/packages/multimodal/src/adapters/mcap/resource-client/operations/read-synchronized-message-batch.ts
@@ -168,7 +168,7 @@ export async function readMcapSynchronizedMessageBatch<
   readSignal,
   request,
   reuseIndexedMessage,
-  onWindowProgress,
+  onTopicSettlement,
   timeline,
 }: {
   readonly decodeClient: DecodeClient;
@@ -177,11 +177,12 @@ export async function readMcapSynchronizedMessageBatch<
   readonly readSignal?: { readonly current: AbortSignal | null };
   readonly request: McapReadSynchronizedMessageBatchRequest;
   readonly reuseIndexedMessage?: McapIndexedMessageReuse<ReusedMessage>;
-  readonly onWindowProgress?: (
-    window: McapSynchronizedMessageWindowWithMessages<
+  readonly onTopicSettlement?: (settlement: {
+    readonly topic: string;
+    readonly window: McapSynchronizedMessageWindowWithMessages<
       McapDecodedMessage | ReusedMessage
-    >,
-  ) => void;
+    >;
+  }) => void;
   readonly timeline: McapTimelineStrategy;
 }): Promise<
   readonly McapSynchronizedMessageWindowWithMessages<
@@ -277,7 +278,7 @@ export async function readMcapSynchronizedMessageBatch<
           source: request.source,
           timeline,
         }),
-      earlyDeliveryTopics: request.earlyDeliveryTopics,
+      settlementPriorityTopics: request.settlementPriorityTopics,
       estimateCandidateBytes: async (candidate) => {
         const identity = indexedCandidateReuseIdentity({
           candidate,
@@ -317,7 +318,7 @@ export async function readMcapSynchronizedMessageBatch<
           });
         }
       },
-      onWindowProgress,
+      onTopicSettlement,
       selectTieBreaker: compareIndexedCandidateTieBreaker,
       timeline,
       topics: request.topics,
@@ -352,9 +353,9 @@ export async function readMcapSynchronizedMessageBatch<
         source: request.source,
         timeline,
       }),
-    earlyDeliveryTopics: request.earlyDeliveryTopics,
+    settlementPriorityTopics: request.settlementPriorityTopics,
     estimateCandidateBytes: (candidate) => candidate.message.data.byteLength,
-    onWindowProgress,
+    onTopicSettlement,
     selectTieBreaker: compareRawCandidateTieBreaker,
     timeline,
     topics: request.topics,
@@ -562,10 +563,10 @@ async function decodeWindowsFromCandidates<
 >({
   candidates,
   decodeCandidate,
-  earlyDeliveryTopics,
+  settlementPriorityTopics,
   estimateCandidateBytes,
   onCandidatesSelected,
-  onWindowProgress,
+  onTopicSettlement,
   selectTieBreaker,
   throwIfAborted,
   timeline,
@@ -574,14 +575,15 @@ async function decodeWindowsFromCandidates<
 }: {
   readonly candidates: ReadonlyMap<string, readonly Candidate[]>;
   readonly decodeCandidate: (candidate: Candidate) => Promise<Message>;
-  readonly earlyDeliveryTopics?: readonly string[];
+  readonly settlementPriorityTopics?: readonly string[];
   readonly estimateCandidateBytes?: (
     candidate: Candidate,
   ) => number | Promise<number>;
   readonly onCandidatesSelected?: (selected: readonly Candidate[]) => void;
-  readonly onWindowProgress?: (
-    window: McapSynchronizedMessageWindowWithMessages<Message>,
-  ) => void;
+  readonly onTopicSettlement?: (settlement: {
+    readonly topic: string;
+    readonly window: McapSynchronizedMessageWindowWithMessages<Message>;
+  }) => void;
   readonly selectTieBreaker: (left: Candidate, right: Candidate) => number;
   readonly throwIfAborted?: () => void;
   readonly timeline: McapTimelineStrategy;
@@ -644,18 +646,18 @@ async function decodeWindowsFromCandidates<
         readonly McapTopicDecodeDiagnostic[]
       > = {};
       const messages: Message[] = [];
-      const earlyDeliveryTopic = await selectEarlyDeliveryTopic({
-        earlyDeliveryTopics,
+      const firstSettlementTopic = await selectFirstSettlementTopic({
         estimateCandidateBytes,
+        settlementPriorityTopics,
         selectedByTopic,
       });
-      const decodeOrder = earlyDeliveryTopic
+      const decodeOrder = firstSettlementTopic
         ? [
             ...selectedByTopic.filter(
-              ([topic]) => topic === earlyDeliveryTopic,
+              ([topic]) => topic === firstSettlementTopic,
             ),
             ...selectedByTopic.filter(
-              ([topic]) => topic !== earlyDeliveryTopic,
+              ([topic]) => topic !== firstSettlementTopic,
             ),
           ]
         : selectedByTopic;
@@ -712,6 +714,19 @@ async function decodeWindowsFromCandidates<
               ),
             ).values(),
           ];
+          onTopicSettlement?.({
+            topic,
+            window: {
+              activeTimeline: timeline.id,
+              decodeErrorsByTopic: { [topic]: decodeErrorsByTopic[topic] },
+              endTimeNs: streamPolicies[topic].endTimeNs,
+              messages: [],
+              messagesByTopic: { [topic]: [] },
+              startTimeNs: streamPolicies[topic].startTimeNs ?? 0n,
+              streamPolicies: { [topic]: streamPolicies[topic] },
+              timeNs,
+            },
+          });
           continue;
         }
         const decoded = settled
@@ -727,8 +742,9 @@ async function decodeWindowsFromCandidates<
         messagesByTopic[topic] = decoded;
         messages.push(...decoded);
 
-        if (topic === earlyDeliveryTopic && decoded.length > 0) {
-          onWindowProgress?.({
+        onTopicSettlement?.({
+          topic,
+          window: {
             activeTimeline: timeline.id,
             endTimeNs: streamPolicies[topic].endTimeNs,
             messages: decoded,
@@ -736,8 +752,8 @@ async function decodeWindowsFromCandidates<
             startTimeNs: streamPolicies[topic].startTimeNs ?? 0n,
             streamPolicies: { [topic]: streamPolicies[topic] },
             timeNs,
-          });
-        }
+          },
+        });
       }
 
       messages.sort((left, right) => {
@@ -770,22 +786,24 @@ async function decodeWindowsFromCandidates<
   );
 }
 
-export async function selectEarlyDeliveryTopic<Candidate>({
-  earlyDeliveryTopics,
+export async function selectFirstSettlementTopic<Candidate>({
   estimateCandidateBytes,
+  settlementPriorityTopics,
   selectedByTopic,
 }: {
-  readonly earlyDeliveryTopics?: readonly string[];
   readonly estimateCandidateBytes?: (
     candidate: Candidate,
   ) => number | Promise<number>;
+  readonly settlementPriorityTopics?: readonly string[];
   readonly selectedByTopic: readonly (readonly [
     string,
     readonly Candidate[],
   ])[];
 }): Promise<string | undefined> {
-  if (!estimateCandidateBytes || !earlyDeliveryTopics?.length) return undefined;
-  const eligible = new Set(earlyDeliveryTopics);
+  if (!estimateCandidateBytes || !settlementPriorityTopics?.length) {
+    return undefined;
+  }
+  const eligible = new Set(settlementPriorityTopics);
   const costs = await Promise.all(
     selectedByTopic
       .filter(([topic, selected]) => eligible.has(topic) && selected.length > 0)

--- a/app/packages/multimodal/src/adapters/mcap/resource-client/operations/read-synchronized-message-batch.ts
+++ b/app/packages/multimodal/src/adapters/mcap/resource-client/operations/read-synchronized-message-batch.ts
@@ -279,6 +279,21 @@ export async function readMcapSynchronizedMessageBatch<
           timeline,
         }),
       settlementPriorityTopics: request.settlementPriorityTopics,
+      firstUsefulSettlementTopics: request.firstUsefulSettlementTopics,
+      estimateCandidateBytes: async (candidate) => {
+        const identity = indexedCandidateReuseIdentity({
+          candidate,
+          pointCloudColorBy:
+            request.pointCloudColorByByTopic?.[candidate.topic],
+          timeline,
+        });
+        if (reusedIndexedMessages.has(identity.recordId)) return 0;
+        const materialized = await selectedRawCandidates;
+        return (
+          materialized?.get(candidate)?.message.data.byteLength ??
+          Number.MAX_SAFE_INTEGER
+        );
+      },
       // Selected candidates name their chunks exactly, so the byte layer can
       // pipeline those chunk fetches while decoding walks them serially.
       onCandidatesSelected: (selected) => {
@@ -340,6 +355,8 @@ export async function readMcapSynchronizedMessageBatch<
         timeline,
       }),
     settlementPriorityTopics: request.settlementPriorityTopics,
+    firstUsefulSettlementTopics: request.firstUsefulSettlementTopics,
+    estimateCandidateBytes: (candidate) => candidate.message.data.byteLength,
     onTopicSettlement,
     selectTieBreaker: compareRawCandidateTieBreaker,
     timeline,
@@ -548,7 +565,9 @@ async function decodeWindowsFromCandidates<
 >({
   candidates,
   decodeCandidate,
+  firstUsefulSettlementTopics,
   settlementPriorityTopics,
+  estimateCandidateBytes,
   onCandidatesSelected,
   onTopicSettlement,
   selectTieBreaker,
@@ -559,7 +578,11 @@ async function decodeWindowsFromCandidates<
 }: {
   readonly candidates: ReadonlyMap<string, readonly Candidate[]>;
   readonly decodeCandidate: (candidate: Candidate) => Promise<Message>;
+  readonly firstUsefulSettlementTopics?: readonly string[];
   readonly settlementPriorityTopics?: readonly string[];
+  readonly estimateCandidateBytes?: (
+    candidate: Candidate,
+  ) => number | Promise<number>;
   readonly onCandidatesSelected?: (selected: readonly Candidate[]) => void;
   readonly onTopicSettlement?: (settlement: {
     readonly topic: string;
@@ -628,6 +651,8 @@ async function decodeWindowsFromCandidates<
       > = {};
       const messages: Message[] = [];
       const settlementTopics = await selectSettlementTopics({
+        estimateCandidateBytes,
+        firstUsefulSettlementTopics,
         settlementPriorityTopics,
         selectedByTopic,
       });
@@ -770,21 +795,55 @@ async function decodeWindowsFromCandidates<
 }
 
 /** Preserves the caller's stable presentation order ahead of stragglers. */
-export function selectSettlementTopics<Candidate>({
+export async function selectSettlementTopics<Candidate>({
+  estimateCandidateBytes,
+  firstUsefulSettlementTopics,
   settlementPriorityTopics,
   selectedByTopic,
 }: {
+  readonly estimateCandidateBytes?: (
+    candidate: Candidate,
+  ) => number | Promise<number>;
+  readonly firstUsefulSettlementTopics?: readonly string[];
   readonly settlementPriorityTopics?: readonly string[];
   readonly selectedByTopic: readonly (readonly [
     string,
     readonly Candidate[],
   ])[];
-}): readonly string[] {
+}): Promise<readonly string[]> {
   if (!settlementPriorityTopics?.length) return [];
   const selectedTopics = new Set(selectedByTopic.map(([topic]) => topic));
-  return [...new Set(settlementPriorityTopics)].filter((topic) =>
+  const explicitOrder = [...new Set(settlementPriorityTopics)].filter((topic) =>
     selectedTopics.has(topic),
   );
+  if (!estimateCandidateBytes || !firstUsefulSettlementTopics?.length) {
+    return explicitOrder;
+  }
+
+  const selectedByTopicMap = new Map(selectedByTopic);
+  const firstUsefulSet = new Set(firstUsefulSettlementTopics);
+  const firstUsefulOrder = explicitOrder.filter((topic) =>
+    firstUsefulSet.has(topic),
+  );
+  if (firstUsefulOrder.length === 0) return explicitOrder;
+  const costs = await Promise.all(
+    firstUsefulOrder.map(async (topic) => ({
+      cost: (
+        await Promise.all(
+          (selectedByTopicMap.get(topic) ?? []).map(estimateCandidateBytes),
+        )
+      ).reduce((total, bytes) => total + bytes, 0),
+      topic,
+    })),
+  );
+  costs.sort(
+    (left, right) =>
+      left.cost - right.cost || left.topic.localeCompare(right.topic),
+  );
+  const firstTopic = costs[0]?.topic;
+  return firstTopic
+    ? [firstTopic, ...explicitOrder.filter((topic) => topic !== firstTopic)]
+    : explicitOrder;
 }
 
 async function collectIndexedCandidates({

--- a/app/packages/multimodal/src/adapters/mcap/resource-client/operations/read-synchronized-message-batch.ts
+++ b/app/packages/multimodal/src/adapters/mcap/resource-client/operations/read-synchronized-message-batch.ts
@@ -646,18 +646,21 @@ async function decodeWindowsFromCandidates<
         readonly McapTopicDecodeDiagnostic[]
       > = {};
       const messages: Message[] = [];
-      const firstSettlementTopic = await selectFirstSettlementTopic({
+      const settlementTopics = await selectSettlementTopics({
         estimateCandidateBytes,
         settlementPriorityTopics,
         selectedByTopic,
       });
-      const decodeOrder = firstSettlementTopic
+      const settlementTopicSet = new Set(settlementTopics);
+      const selectedByTopicMap = new Map(selectedByTopic);
+      const decodeOrder = settlementTopics.length
         ? [
+            ...settlementTopics.flatMap((topic) => {
+              const selected = selectedByTopicMap.get(topic);
+              return selected ? ([[topic, selected]] as const) : [];
+            }),
             ...selectedByTopic.filter(
-              ([topic]) => topic === firstSettlementTopic,
-            ),
-            ...selectedByTopic.filter(
-              ([topic]) => topic !== firstSettlementTopic,
+              ([topic]) => !settlementTopicSet.has(topic),
             ),
           ]
         : selectedByTopic;
@@ -800,18 +803,42 @@ export async function selectFirstSettlementTopic<Candidate>({
     readonly Candidate[],
   ])[];
 }): Promise<string | undefined> {
-  if (!estimateCandidateBytes || !settlementPriorityTopics?.length) {
-    return undefined;
-  }
+  return (
+    await selectSettlementTopics({
+      estimateCandidateBytes,
+      settlementPriorityTopics,
+      selectedByTopic,
+    })
+  )[0];
+}
+
+/** Orders every priority topic ahead of non-blocking settlement work. */
+export async function selectSettlementTopics<Candidate>({
+  estimateCandidateBytes,
+  settlementPriorityTopics,
+  selectedByTopic,
+}: {
+  readonly estimateCandidateBytes?: (
+    candidate: Candidate,
+  ) => number | Promise<number>;
+  readonly settlementPriorityTopics?: readonly string[];
+  readonly selectedByTopic: readonly (readonly [
+    string,
+    readonly Candidate[],
+  ])[];
+}): Promise<readonly string[]> {
+  if (!settlementPriorityTopics?.length) return [];
   const eligible = new Set(settlementPriorityTopics);
   const costs = await Promise.all(
     selectedByTopic
-      .filter(([topic, selected]) => eligible.has(topic) && selected.length > 0)
+      .filter(([topic]) => eligible.has(topic))
       .map(async ([topic, selected]) => ({
-        cost: (await Promise.all(selected.map(estimateCandidateBytes))).reduce(
-          (total, bytes) => total + bytes,
-          0,
-        ),
+        cost: estimateCandidateBytes
+          ? (await Promise.all(selected.map(estimateCandidateBytes))).reduce(
+              (total, bytes) => total + bytes,
+              0,
+            )
+          : 0,
         topic,
       })),
   );
@@ -819,7 +846,7 @@ export async function selectFirstSettlementTopic<Candidate>({
     (left, right) =>
       left.cost - right.cost || left.topic.localeCompare(right.topic),
   );
-  return costs[0]?.topic;
+  return costs.map(({ topic }) => topic);
 }
 
 async function collectIndexedCandidates({

--- a/app/packages/multimodal/src/adapters/mcap/worker-host/worker-client.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker-host/worker-client.test.ts
@@ -376,36 +376,60 @@ describe("worker-backed MCAP resource client", () => {
       type: "readSynchronizedMessages",
     });
 
-    const settlement = createSynchronizedWindow(15n);
+    const cameraSettlement = createSynchronizedWindow(15n);
+    const lidarSettlement = createSynchronizedWindow(15n);
+    worker.respond({
+      done: false,
+      id: 1,
+      items: [
+        {
+          kind: "topic-settlement",
+          topic: "/camera",
+          window: cameraSettlement,
+        },
+        {
+          kind: "topic-settlement",
+          topic: "/lidar",
+          window: lidarSettlement,
+        },
+      ],
+      ok: true,
+      stream: true,
+    });
+    await vi.waitFor(() => {
+      expect(onTopicSettlement).toHaveBeenCalledTimes(2);
+    });
+    expect(onTopicSettlement.mock.calls).toEqual([
+      [{ topic: "/camera", window: cameraSettlement }],
+      [{ topic: "/lidar", window: lidarSettlement }],
+    ]);
+    expect(onTopicSettlements).toHaveBeenCalledOnce();
+    expect(onTopicSettlements).toHaveBeenCalledWith([
+      { topic: "/camera", window: cameraSettlement },
+      { topic: "/lidar", window: lidarSettlement },
+    ]);
+    expect(settled).toBe(false);
+
     worker.respond({
       done: false,
       id: 1,
       item: {
         kind: "topic-settlement",
         topic: "/camera",
-        window: settlement,
+        window: createSynchronizedWindow(15n),
       },
       ok: true,
       stream: true,
     });
-    await vi.waitFor(() => {
-      expect(onTopicSettlement).toHaveBeenCalledOnce();
-    });
-    expect(onTopicSettlement).toHaveBeenCalledWith({
-      topic: "/camera",
-      window: settlement,
-    });
-    expect(onTopicSettlements).toHaveBeenCalledWith([
-      { topic: "/camera", window: settlement },
-    ]);
-    expect(settled).toBe(false);
 
     const complete = createSynchronizedWindow(15n);
     respondSynchronizedTerminal(worker, 1, complete);
     await expect(current).resolves.toEqual({
       ...complete,
-      messagesByTopic: { "/camera": [] },
+      messagesByTopic: { "/camera": [], "/lidar": [] },
     });
+    expect(onTopicSettlement).toHaveBeenCalledTimes(2);
+    expect(onTopicSettlements).toHaveBeenCalledOnce();
     expect(settled).toBe(true);
   });
 

--- a/app/packages/multimodal/src/adapters/mcap/worker-host/worker-client.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker-host/worker-client.test.ts
@@ -354,6 +354,7 @@ describe("worker-backed MCAP resource client", () => {
   it("streams authoritative topic settlements before the terminal union", async () => {
     const { client, workers } = createClientHarness();
     const onTopicSettlement = vi.fn();
+    const onTopicSettlements = vi.fn();
     let settled = false;
     const current = client
       .readSynchronizedMessages(
@@ -363,7 +364,7 @@ describe("worker-backed MCAP resource client", () => {
           timeNs: 15n,
           topics: ["/camera", "/lidar"],
         },
-        { onTopicSettlement },
+        { onTopicSettlement, onTopicSettlements },
       )
       .finally(() => {
         settled = true;
@@ -394,6 +395,9 @@ describe("worker-backed MCAP resource client", () => {
       topic: "/camera",
       window: settlement,
     });
+    expect(onTopicSettlements).toHaveBeenCalledWith([
+      { topic: "/camera", window: settlement },
+    ]);
     expect(settled).toBe(false);
 
     const complete = createSynchronizedWindow(15n);

--- a/app/packages/multimodal/src/adapters/mcap/worker-host/worker-client.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker-host/worker-client.test.ts
@@ -6,6 +6,7 @@ import {
   MCAP_PLAYBACK_WORKER_PRIORITY,
   type McapPlaybackWorkerRequest,
   type McapPlaybackWorkerResponse,
+  type McapPlaybackWorkerSynchronizedWindow,
 } from "../worker/playback-worker-types";
 import { createWorkerMcapResourceClient } from "./worker-client";
 import { dehydrateMcapFrameTransformSet } from "../transforms/wire";
@@ -339,7 +340,7 @@ describe("worker-backed MCAP resource client", () => {
     });
 
     const currentWindow = createSynchronizedWindow(15n);
-    workers[1].respond({ id: 1, ok: true, result: currentWindow });
+    respondSynchronizedTerminal(workers[1], 1, currentWindow);
     await expect(current).resolves.toEqual(currentWindow);
 
     workers[0].respond({
@@ -350,19 +351,19 @@ describe("worker-backed MCAP resource client", () => {
     await expect(transforms).resolves.toEqual({ samples: [] });
   });
 
-  it("publishes one synchronized surface without settling the union", async () => {
+  it("streams authoritative topic settlements before the terminal union", async () => {
     const { client, workers } = createClientHarness();
-    const onSynchronizedProgress = vi.fn();
+    const onTopicSettlement = vi.fn();
     let settled = false;
     const current = client
       .readSynchronizedMessages(
         {
-          earlyDeliveryTopics: ["/camera", "/lidar"],
+          settlementPriorityTopics: ["/camera", "/lidar"],
           source: createSource("source:1"),
           timeNs: 15n,
           topics: ["/camera", "/lidar"],
         },
-        { onSynchronizedProgress },
+        { onTopicSettlement },
       )
       .finally(() => {
         settled = true;
@@ -370,26 +371,37 @@ describe("worker-backed MCAP resource client", () => {
     const worker = workers[0];
 
     expect(worker.messages[1]).toMatchObject({
-      payload: { earlyDeliveryTopics: ["/camera", "/lidar"] },
+      payload: { settlementPriorityTopics: ["/camera", "/lidar"] },
       type: "readSynchronizedMessages",
     });
 
-    const progress = createSynchronizedWindow(15n);
+    const settlement = createSynchronizedWindow(15n);
     worker.respond({
+      done: false,
       id: 1,
+      item: {
+        kind: "topic-settlement",
+        topic: "/camera",
+        window: settlement,
+      },
       ok: true,
-      progress: true,
-      result: progress,
+      stream: true,
     });
-    await Promise.resolve();
-
-    expect(onSynchronizedProgress).toHaveBeenCalledOnce();
-    expect(onSynchronizedProgress).toHaveBeenCalledWith(progress);
+    await vi.waitFor(() => {
+      expect(onTopicSettlement).toHaveBeenCalledOnce();
+    });
+    expect(onTopicSettlement).toHaveBeenCalledWith({
+      topic: "/camera",
+      window: settlement,
+    });
     expect(settled).toBe(false);
 
     const complete = createSynchronizedWindow(15n);
-    worker.respond({ id: 1, ok: true, result: complete });
-    await expect(current).resolves.toEqual(complete);
+    respondSynchronizedTerminal(worker, 1, complete);
+    await expect(current).resolves.toEqual({
+      ...complete,
+      messagesByTopic: { "/camera": [] },
+    });
     expect(settled).toBe(true);
   });
 
@@ -562,11 +574,11 @@ describe("worker-backed MCAP resource client", () => {
       timelineTimeNs: decoded.timelineTimeNs,
       topic: decoded.topic,
     };
-    interactiveWorker.respond({
-      id: 1,
-      ok: true,
-      result: createSynchronizedWindowWithMessage(reference),
-    });
+    respondSynchronizedTerminal(
+      interactiveWorker,
+      1,
+      createSynchronizedWindowWithMessage(reference),
+    );
 
     await expect(scrub).resolves.toMatchObject({ messages: [decoded] });
     expect((await scrub).messages[0]).toBe(playbackWindow?.messages[0]);
@@ -870,7 +882,7 @@ describe("worker-backed MCAP resource client", () => {
     });
 
     const currentWindow = createSynchronizedWindow(1n);
-    workers[1].respond({ id: 1, ok: true, result: currentWindow });
+    respondSynchronizedTerminal(workers[1], 1, currentWindow);
     await expect(current).resolves.toEqual(currentWindow);
 
     workers[0].respond({ id: 1, ok: true, result: [] });
@@ -920,7 +932,7 @@ describe("worker-backed MCAP resource client", () => {
     ]);
 
     const currentWindow = createSynchronizedWindow(1n);
-    workers[1].respond({ id: 1, ok: true, result: currentWindow });
+    respondSynchronizedTerminal(workers[1], 1, currentWindow);
     await expect(current).resolves.toEqual(currentWindow);
 
     workers[0].respond({ id: 1, ok: true, result: [] });
@@ -957,7 +969,7 @@ describe("worker-backed MCAP resource client", () => {
     ]);
 
     const window = createSynchronizedWindow(2n);
-    worker.respond({ id: 2, ok: true, result: window });
+    respondSynchronizedTerminal(worker, 2, window);
     await expect(latest).resolves.toEqual(window);
   });
 
@@ -1508,6 +1520,21 @@ function createTopic(topic: string) {
     },
     streamId: topic,
   });
+}
+
+function respondSynchronizedTerminal(
+  worker: MockWorker,
+  id: number,
+  window: McapPlaybackWorkerSynchronizedWindow,
+) {
+  worker.respond({
+    done: false,
+    id,
+    item: { kind: "terminal", window },
+    ok: true,
+    stream: true,
+  });
+  worker.respond({ done: true, id, ok: true, stream: true });
 }
 
 class MockWorker {

--- a/app/packages/multimodal/src/adapters/mcap/worker-host/worker-client.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker-host/worker-client.test.ts
@@ -350,6 +350,49 @@ describe("worker-backed MCAP resource client", () => {
     await expect(transforms).resolves.toEqual({ samples: [] });
   });
 
+  it("publishes one synchronized surface without settling the union", async () => {
+    const { client, workers } = createClientHarness();
+    const onSynchronizedProgress = vi.fn();
+    let settled = false;
+    const current = client
+      .readSynchronizedMessages(
+        {
+          earlyDeliveryTopics: ["/camera", "/lidar"],
+          source: createSource("source:1"),
+          timeNs: 15n,
+          topics: ["/camera", "/lidar"],
+        },
+        { onSynchronizedProgress },
+      )
+      .finally(() => {
+        settled = true;
+      });
+    const worker = workers[0];
+
+    expect(worker.messages[1]).toMatchObject({
+      payload: { earlyDeliveryTopics: ["/camera", "/lidar"] },
+      type: "readSynchronizedMessages",
+    });
+
+    const progress = createSynchronizedWindow(15n);
+    worker.respond({
+      id: 1,
+      ok: true,
+      progress: true,
+      result: progress,
+    });
+    await Promise.resolve();
+
+    expect(onSynchronizedProgress).toHaveBeenCalledOnce();
+    expect(onSynchronizedProgress).toHaveBeenCalledWith(progress);
+    expect(settled).toBe(false);
+
+    const complete = createSynchronizedWindow(15n);
+    worker.respond({ id: 1, ok: true, result: complete });
+    await expect(current).resolves.toEqual(complete);
+    expect(settled).toBe(true);
+  });
+
   it("cancels placement transforms superseded by a newer playhead", async () => {
     const { client, workers } = createClientHarness();
     const source = createSource("source:1");

--- a/app/packages/multimodal/src/adapters/mcap/worker-host/worker-client.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker-host/worker-client.ts
@@ -413,31 +413,39 @@ class WorkerMcapResourceClient implements McapResourceClient {
     } catch (error) {
       return Promise.reject(error);
     }
-    return this.request(
-      "readSynchronizedMessages",
-      request,
-      undefined,
-      options?.signal,
-      lease.recordIds,
-      options?.onSynchronizedProgress
-        ? (progress) => {
-            const hydrated = hydrateSynchronizedWindows(
-              [progress],
-              lease,
-              this.decodedRecords,
-            )[0];
-            if (hydrated) options.onSynchronizedProgress?.(hydrated);
-          }
-        : undefined,
-    )
-      .then(
-        (window) =>
-          hydrateSynchronizedWindows([window], lease, this.decodedRecords)[0],
-      )
-      .then((window) => {
-        if (!window) throw new Error("Expected synchronized MCAP window");
-        return window;
-      })
+    const read = async () => {
+      const settlements = new Map<string, McapSynchronizedMessageWindow>();
+      let terminal: McapSynchronizedMessageWindow | undefined;
+      for await (const item of this.streamRequest(
+        "readSynchronizedMessages",
+        request,
+        undefined,
+        options?.signal,
+        lease.recordIds,
+      )) {
+        const window = hydrateSynchronizedWindows(
+          [item.window],
+          lease,
+          this.decodedRecords,
+        )[0];
+        if (!window) throw new Error("Expected synchronized MCAP stream item");
+        if (item.kind === "topic-settlement") {
+          if (settlements.has(item.topic)) continue;
+          settlements.set(item.topic, window);
+          options?.onTopicSettlement?.({ topic: item.topic, window });
+        } else {
+          terminal = window;
+        }
+      }
+      if (!terminal)
+        throw new Error("Expected synchronized MCAP terminal window");
+      return mergeSynchronizedTopicSettlements(
+        request.topics,
+        settlements,
+        terminal,
+      );
+    };
+    return read()
       .catch((error) => {
         if (error instanceof RetainedDecodedRecordProtocolError) {
           this.decodedRecords.clear();
@@ -492,9 +500,6 @@ class WorkerMcapResourceClient implements McapResourceClient {
     priority?: McapPlaybackWorkerPriority,
     signal?: AbortSignal,
     retainedDecodedRecordIds?: readonly string[],
-    onProgress?: (
-      result: McapPlaybackWorkerResultByType["readSynchronizedMessages"],
-    ) => void,
   ): Promise<McapPlaybackWorkerResultByType[Type]> {
     if (this.disposed) {
       return Promise.reject(new Error("MCAP worker client is disposed"));
@@ -517,12 +522,17 @@ class WorkerMcapResourceClient implements McapResourceClient {
       type,
     });
     if (supersessionKeys.length > 0) {
-      const cancelledIds = lane.transport.cancelPending((pending) =>
+      const overlaps = (pending: {
+        readonly supersessionKeys: readonly string[];
+      }) =>
         haveMcapSupersessionKeyOverlap(
           pending.supersessionKeys,
           supersessionKeys,
-        ),
-      );
+        );
+      const cancelledIds = [
+        ...lane.transport.cancelPending(overlaps),
+        ...lane.transport.cancelPendingStreams(overlaps),
+      ];
       this.postCancelRequests(lane, cancelledIds);
       // A burst of obsolete presentation work is also a seek/scrub signal.
       // Give the byte link back to the newest foreground frame immediately;
@@ -538,7 +548,6 @@ class WorkerMcapResourceClient implements McapResourceClient {
       supersessionKeys,
       signal,
       retainedDecodedRecordIds,
-      onProgress,
     );
   }
 
@@ -547,6 +556,7 @@ class WorkerMcapResourceClient implements McapResourceClient {
     payload: McapPlaybackWorkerRequestPayloadByType[Type],
     priority?: McapPlaybackWorkerPriority,
     signal?: AbortSignal,
+    retainedDecodedRecordIds?: readonly string[],
   ): AsyncGenerator<McapPlaybackWorkerStreamItemByType[Type], void, void> {
     if (this.disposed) {
       throw new Error("MCAP worker client is disposed");
@@ -557,6 +567,28 @@ class WorkerMcapResourceClient implements McapResourceClient {
     const sourceKey = byteSourceAccessKey(payload.source);
     this.ensureActiveSource(sourceKey);
     const lane = this.laneForPriority(effectivePriority);
+    const supersessionKeys = mcapForegroundSupersessionKeys({
+      generation: this.foregroundGeneration,
+      payload,
+      priority: effectivePriority,
+      sourceKey,
+      type,
+    });
+    if (supersessionKeys.length > 0) {
+      const overlaps = (pending: {
+        readonly supersessionKeys: readonly string[];
+      }) =>
+        haveMcapSupersessionKeyOverlap(
+          pending.supersessionKeys,
+          supersessionKeys,
+        );
+      const cancelledIds = [
+        ...lane.transport.cancelPending(overlaps),
+        ...lane.transport.cancelPendingStreams(overlaps),
+      ];
+      this.postCancelRequests(lane, cancelledIds);
+      if (cancelledIds.length > 0) this.cancelIdleReads();
+    }
     try {
       yield* lane.transport.stream(
         this.workerForLane(lane, sourceKey),
@@ -565,6 +597,8 @@ class WorkerMcapResourceClient implements McapResourceClient {
         payload,
         effectivePriority,
         signal,
+        retainedDecodedRecordIds,
+        supersessionKeys,
       );
     } finally {
       this.maybeReleaseBulkLane(lane);
@@ -738,6 +772,30 @@ function hydrateSynchronizedWindows(
       ]),
     ),
   }));
+}
+
+function mergeSynchronizedTopicSettlements(
+  topics: readonly string[],
+  settlements: ReadonlyMap<string, McapSynchronizedMessageWindow>,
+  terminal: McapSynchronizedMessageWindow,
+): McapSynchronizedMessageWindow {
+  const messagesByTopic: Record<string, readonly McapDecodedMessage[]> = {
+    ...terminal.messagesByTopic,
+  };
+  for (const topic of topics) {
+    const settlement = settlements.get(topic);
+    if (settlement) {
+      messagesByTopic[topic] = settlement.messagesByTopic[topic] ?? [];
+    }
+  }
+  const messages = Object.values(messagesByTopic)
+    .flat()
+    .sort((left, right) => {
+      if (left.timelineTimeNs < right.timelineTimeNs) return -1;
+      if (left.timelineTimeNs > right.timelineTimeNs) return 1;
+      return left.topic.localeCompare(right.topic);
+    });
+  return { ...terminal, messages, messagesByTopic };
 }
 
 function resourcePriorityToWorkerPriority(

--- a/app/packages/multimodal/src/adapters/mcap/worker-host/worker-client.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker-host/worker-client.ts
@@ -60,6 +60,7 @@ import type {
   McapTransformTopologyResult,
   McapResourceClient,
   McapSynchronizedMessageWindow,
+  McapSynchronizedTopicSettlement,
   McapTimelineRange,
   McapTopicNumericFields,
   McapTopicTimeBounds,
@@ -416,25 +417,37 @@ class WorkerMcapResourceClient implements McapResourceClient {
     const read = async () => {
       const settlements = new Map<string, McapSynchronizedMessageWindow>();
       let terminal: McapSynchronizedMessageWindow | undefined;
-      for await (const item of this.streamRequest(
+      for await (const items of this.streamRequest(
         "readSynchronizedMessages",
         request,
         undefined,
         options?.signal,
         lease.recordIds,
+        true,
       )) {
-        const window = hydrateSynchronizedWindows(
-          [item.window],
-          lease,
-          this.decodedRecords,
-        )[0];
-        if (!window) throw new Error("Expected synchronized MCAP stream item");
-        if (item.kind === "topic-settlement") {
-          if (settlements.has(item.topic)) continue;
-          settlements.set(item.topic, window);
-          options?.onTopicSettlement?.({ topic: item.topic, window });
-        } else {
-          terminal = window;
+        const deliverySettlements: McapSynchronizedTopicSettlement[] = [];
+        for (const item of items) {
+          const window = hydrateSynchronizedWindows(
+            [item.window],
+            lease,
+            this.decodedRecords,
+          )[0];
+          if (!window)
+            throw new Error("Expected synchronized MCAP stream item");
+          if (item.kind === "topic-settlement") {
+            if (settlements.has(item.topic)) continue;
+            const settlement = { topic: item.topic, window };
+            settlements.set(item.topic, window);
+            deliverySettlements.push(settlement);
+          } else {
+            terminal = window;
+          }
+        }
+        if (deliverySettlements.length > 0) {
+          options?.onTopicSettlements?.(deliverySettlements);
+          for (const settlement of deliverySettlements) {
+            options?.onTopicSettlement?.(settlement);
+          }
         }
       }
       if (!terminal)
@@ -551,13 +564,39 @@ class WorkerMcapResourceClient implements McapResourceClient {
     );
   }
 
+  private streamRequest<Type extends McapPlaybackWorkerStreamType>(
+    type: Type,
+    payload: McapPlaybackWorkerRequestPayloadByType[Type],
+    priority?: McapPlaybackWorkerPriority,
+    signal?: AbortSignal,
+    retainedDecodedRecordIds?: readonly string[],
+    yieldResponseBatches?: false,
+  ): AsyncGenerator<McapPlaybackWorkerStreamItemByType[Type], void, void>;
+  private streamRequest<Type extends McapPlaybackWorkerStreamType>(
+    type: Type,
+    payload: McapPlaybackWorkerRequestPayloadByType[Type],
+    priority: McapPlaybackWorkerPriority | undefined,
+    signal: AbortSignal | undefined,
+    retainedDecodedRecordIds: readonly string[] | undefined,
+    yieldResponseBatches: true,
+  ): AsyncGenerator<
+    readonly McapPlaybackWorkerStreamItemByType[Type][],
+    void,
+    void
+  >;
   private async *streamRequest<Type extends McapPlaybackWorkerStreamType>(
     type: Type,
     payload: McapPlaybackWorkerRequestPayloadByType[Type],
     priority?: McapPlaybackWorkerPriority,
     signal?: AbortSignal,
     retainedDecodedRecordIds?: readonly string[],
-  ): AsyncGenerator<McapPlaybackWorkerStreamItemByType[Type], void, void> {
+    yieldResponseBatches = false,
+  ): AsyncGenerator<
+    | McapPlaybackWorkerStreamItemByType[Type]
+    | readonly McapPlaybackWorkerStreamItemByType[Type][],
+    void,
+    void
+  > {
     if (this.disposed) {
       throw new Error("MCAP worker client is disposed");
     }
@@ -590,16 +629,30 @@ class WorkerMcapResourceClient implements McapResourceClient {
       if (cancelledIds.length > 0) this.cancelIdleReads();
     }
     try {
-      yield* lane.transport.stream(
-        this.workerForLane(lane, sourceKey),
-        sourceKey,
-        type,
-        payload,
-        effectivePriority,
-        signal,
-        retainedDecodedRecordIds,
-        supersessionKeys,
-      );
+      if (yieldResponseBatches) {
+        yield* lane.transport.stream(
+          this.workerForLane(lane, sourceKey),
+          sourceKey,
+          type,
+          payload,
+          effectivePriority,
+          signal,
+          retainedDecodedRecordIds,
+          supersessionKeys,
+          true,
+        );
+      } else {
+        yield* lane.transport.stream(
+          this.workerForLane(lane, sourceKey),
+          sourceKey,
+          type,
+          payload,
+          effectivePriority,
+          signal,
+          retainedDecodedRecordIds,
+          supersessionKeys,
+        );
+      }
     } finally {
       this.maybeReleaseBulkLane(lane);
     }

--- a/app/packages/multimodal/src/adapters/mcap/worker-host/worker-client.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker-host/worker-client.ts
@@ -52,6 +52,7 @@ import type {
   McapReadSynchronizedMessagesRequest,
   McapRecordingInventory,
   McapResourceReadOptions,
+  McapSynchronizedMessagesReadOptions,
   McapReadTopicsRequest,
   McapReadTopicTimeBoundsRequest,
   McapReadTimelineRangeRequest,
@@ -404,7 +405,7 @@ class WorkerMcapResourceClient implements McapResourceClient {
 
   readSynchronizedMessages(
     request: McapReadSynchronizedMessagesRequest,
-    options?: McapResourceReadOptions,
+    options?: McapSynchronizedMessagesReadOptions,
   ): Promise<McapSynchronizedMessageWindow> {
     let lease: DecodedRecordLease;
     try {
@@ -418,6 +419,16 @@ class WorkerMcapResourceClient implements McapResourceClient {
       undefined,
       options?.signal,
       lease.recordIds,
+      options?.onSynchronizedProgress
+        ? (progress) => {
+            const hydrated = hydrateSynchronizedWindows(
+              [progress],
+              lease,
+              this.decodedRecords,
+            )[0];
+            if (hydrated) options.onSynchronizedProgress?.(hydrated);
+          }
+        : undefined,
     )
       .then(
         (window) =>
@@ -481,6 +492,9 @@ class WorkerMcapResourceClient implements McapResourceClient {
     priority?: McapPlaybackWorkerPriority,
     signal?: AbortSignal,
     retainedDecodedRecordIds?: readonly string[],
+    onProgress?: (
+      result: McapPlaybackWorkerResultByType["readSynchronizedMessages"],
+    ) => void,
   ): Promise<McapPlaybackWorkerResultByType[Type]> {
     if (this.disposed) {
       return Promise.reject(new Error("MCAP worker client is disposed"));
@@ -524,6 +538,7 @@ class WorkerMcapResourceClient implements McapResourceClient {
       supersessionKeys,
       signal,
       retainedDecodedRecordIds,
+      onProgress,
     );
   }
 

--- a/app/packages/multimodal/src/adapters/mcap/worker/playback-worker-rpc.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/playback-worker-rpc.test.ts
@@ -6,6 +6,7 @@ import {
 } from "./playback-worker-types";
 import {
   mcapPlaybackWorkerOperation,
+  runMcapPlaybackWorkerStreamRequest,
   runMcapPlaybackWorkerUnaryRequest,
 } from "./playback-worker-rpc";
 import type { McapPlaybackWorkerResourceClient } from "./worker-resource-client";
@@ -13,6 +14,28 @@ import type { McapPlaybackWorkerResourceClient } from "./worker-resource-client"
 const source = { sourceId: "fixture", url: "memory://fixture" };
 
 describe("exact-message playback worker RPC", () => {
+  it("preserves an undefined synchronized stream rejection", async () => {
+    const client = {
+      readSynchronizedMessages: vi.fn(() => Promise.reject(undefined)),
+    } as unknown as McapPlaybackWorkerResourceClient;
+    const request: McapPlaybackWorkerRpcRequest<"readSynchronizedMessages"> = {
+      id: 1,
+      payload: { source, timeNs: 1n, topics: ["/camera"] },
+      priority: MCAP_PLAYBACK_WORKER_PRIORITY.CURRENT_FRAME,
+      sourceKey: "source-key",
+      type: "readSynchronizedMessages",
+    };
+    let rejected = false;
+
+    try {
+      await runMcapPlaybackWorkerStreamRequest(client, request).next();
+    } catch (error) {
+      rejected = true;
+      expect(error).toBeUndefined();
+    }
+    expect(rejected).toBe(true);
+  });
+
   it("dispatches index and exact-record reads on the interactive lane", async () => {
     const indexResult = {
       entries: [{ cursor: "cursor-2", logTimeNs: 2n }],

--- a/app/packages/multimodal/src/adapters/mcap/worker/playback-worker-rpc.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/playback-worker-rpc.ts
@@ -145,6 +145,9 @@ export function isMcapPlaybackWorkerStreamRequest(
 export function runMcapPlaybackWorkerUnaryRequest(
   client: McapPlaybackWorkerResourceClient,
   message: McapPlaybackWorkerRpcRequest<McapPlaybackWorkerUnaryType>,
+  onSynchronizedProgress?: (
+    window: McapPlaybackWorkerResultByType["readSynchronizedMessages"],
+  ) => void,
 ): Promise<McapPlaybackWorkerResultByType[McapPlaybackWorkerUnaryType]> {
   switch (message.type) {
     case "enumerateNumericFields":
@@ -194,7 +197,10 @@ export function runMcapPlaybackWorkerUnaryRequest(
     case "readSynchronizedMessageBatch":
       return client.readSynchronizedMessageBatch(message.payload);
     case "readSynchronizedMessages":
-      return client.readSynchronizedMessages(message.payload);
+      return client.readSynchronizedMessages(
+        message.payload,
+        onSynchronizedProgress,
+      );
     case "readTimelineRange":
       return client.readTimelineRange(message.payload);
     case "readTransformTopology":

--- a/app/packages/multimodal/src/adapters/mcap/worker/playback-worker-rpc.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/playback-worker-rpc.ts
@@ -11,6 +11,7 @@ import {
 import { dehydrateMcapFrameTransformSet } from "../transforms/wire";
 import type { McapResourceClient } from "../contracts/index";
 import type { McapPlaybackWorkerResourceClient } from "./worker-resource-client";
+import type { McapPlaybackWorkerSynchronizedWindow } from "./playback-worker-types";
 
 /**
  * Worker operation descriptor for one unary MCAP RPC.
@@ -100,7 +101,7 @@ export const MCAP_PLAYBACK_WORKER_OPERATIONS: McapPlaybackWorkerOperationMap = {
     priority: MCAP_PLAYBACK_WORKER_PRIORITY.PLAYBACK_BATCH,
   },
   readSynchronizedMessages: {
-    kind: "unary",
+    kind: "stream",
     priority: MCAP_PLAYBACK_WORKER_PRIORITY.CURRENT_FRAME,
   },
   readTimelineRange: {
@@ -145,9 +146,6 @@ export function isMcapPlaybackWorkerStreamRequest(
 export function runMcapPlaybackWorkerUnaryRequest(
   client: McapPlaybackWorkerResourceClient,
   message: McapPlaybackWorkerRpcRequest<McapPlaybackWorkerUnaryType>,
-  onSynchronizedProgress?: (
-    window: McapPlaybackWorkerResultByType["readSynchronizedMessages"],
-  ) => void,
 ): Promise<McapPlaybackWorkerResultByType[McapPlaybackWorkerUnaryType]> {
   switch (message.type) {
     case "enumerateNumericFields":
@@ -196,10 +194,6 @@ export function runMcapPlaybackWorkerUnaryRequest(
       return client.readMessageIndexWindow(message.payload);
     case "readSynchronizedMessageBatch":
       return client.readSynchronizedMessageBatch(message.payload);
-    case "readSynchronizedMessages":
-      return client.readSynchronizedMessages(message.payload, {
-        onSynchronizedProgress,
-      });
     case "readTimelineRange":
       return client.readTimelineRange(message.payload);
     case "readTransformTopology":
@@ -220,7 +214,8 @@ export function runMcapPlaybackWorkerUnaryRequest(
  * Streams results for one streaming MCAP worker request.
  */
 export async function* runMcapPlaybackWorkerStreamRequest(
-  client: Pick<McapResourceClient, "readDecodedMessages">,
+  client: Pick<McapResourceClient, "readDecodedMessages"> &
+    Pick<McapPlaybackWorkerResourceClient, "readSynchronizedMessages">,
   message: McapPlaybackWorkerRpcRequest<McapPlaybackWorkerStreamType>,
 ): AsyncGenerator<
   McapPlaybackWorkerStreamItemByType[McapPlaybackWorkerStreamType],
@@ -231,5 +226,85 @@ export async function* runMcapPlaybackWorkerStreamRequest(
     case "readDecodedMessages":
       yield* client.readDecodedMessages(message.payload);
       return;
+    case "readSynchronizedMessages":
+      yield* streamSynchronizedMessages(client, message.payload);
+      return;
   }
+}
+
+async function* streamSynchronizedMessages(
+  client: Pick<McapPlaybackWorkerResourceClient, "readSynchronizedMessages">,
+  request: McapPlaybackWorkerRpcRequest<"readSynchronizedMessages">["payload"],
+): AsyncGenerator<
+  McapPlaybackWorkerStreamItemByType["readSynchronizedMessages"],
+  void,
+  void
+> {
+  const queued: McapPlaybackWorkerStreamItemByType["readSynchronizedMessages"][] =
+    [];
+  const settledTopics = new Set<string>();
+  let complete = false;
+  let failure: unknown;
+  let terminal: McapPlaybackWorkerSynchronizedWindow | undefined;
+  let wake: (() => void) | undefined;
+  const notify = () => {
+    const resolve = wake;
+    wake = undefined;
+    resolve?.();
+  };
+
+  void client
+    .readSynchronizedMessages(request, {
+      onTopicSettlement: ({ topic, window }) => {
+        if (settledTopics.has(topic)) return;
+        settledTopics.add(topic);
+        queued.push({ kind: "topic-settlement", topic, window });
+        notify();
+      },
+    })
+    .then(
+      (window) => {
+        terminal = withoutSettledTopicPayloads(window, settledTopics);
+        complete = true;
+        notify();
+      },
+      (error) => {
+        failure = error;
+        complete = true;
+        notify();
+      },
+    );
+
+  while (!complete || queued.length > 0) {
+    if (queued.length === 0) {
+      await new Promise<void>((resolve) => {
+        if (complete || queued.length > 0) resolve();
+        else wake = resolve;
+      });
+    }
+    while (queued.length > 0) {
+      const item = queued.shift();
+      if (item) yield item;
+    }
+  }
+  if (failure !== undefined) throw failure;
+  if (!terminal) throw new Error("Expected synchronized MCAP terminal window");
+  yield { kind: "terminal", window: terminal };
+}
+
+function withoutSettledTopicPayloads(
+  window: McapPlaybackWorkerSynchronizedWindow,
+  settledTopics: ReadonlySet<string>,
+): McapPlaybackWorkerSynchronizedWindow {
+  return {
+    ...window,
+    messages: window.messages.filter(
+      (message) => !settledTopics.has(message.topic),
+    ),
+    messagesByTopic: Object.fromEntries(
+      Object.entries(window.messagesByTopic).filter(
+        ([topic]) => !settledTopics.has(topic),
+      ),
+    ),
+  };
 }

--- a/app/packages/multimodal/src/adapters/mcap/worker/playback-worker-rpc.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/playback-worker-rpc.ts
@@ -242,10 +242,8 @@ async function* streamSynchronizedMessages(
 > {
   const queued: McapPlaybackWorkerStreamItemByType["readSynchronizedMessages"][] =
     [];
-  const settledTopics = new Set<string>();
   let complete = false;
   let failure: unknown;
-  let terminal: McapPlaybackWorkerSynchronizedWindow | undefined;
   let wake: (() => void) | undefined;
   const notify = () => {
     const resolve = wake;
@@ -253,27 +251,20 @@ async function* streamSynchronizedMessages(
     resolve?.();
   };
 
-  void client
-    .readSynchronizedMessages(request, {
-      onTopicSettlement: ({ topic, window }) => {
-        if (settledTopics.has(topic)) return;
-        settledTopics.add(topic);
-        queued.push({ kind: "topic-settlement", topic, window });
-        notify();
-      },
-    })
-    .then(
-      (window) => {
-        terminal = withoutSettledTopicPayloads(window, settledTopics);
-        complete = true;
-        notify();
-      },
-      (error) => {
-        failure = error;
-        complete = true;
-        notify();
-      },
-    );
+  void runMcapPlaybackWorkerSynchronizedRequest(client, request, (item) => {
+    queued.push(item);
+    notify();
+  }).then(
+    () => {
+      complete = true;
+      notify();
+    },
+    (error) => {
+      failure = error;
+      complete = true;
+      notify();
+    },
+  );
 
   while (!complete || queued.length > 0) {
     if (queued.length === 0) {
@@ -288,8 +279,34 @@ async function* streamSynchronizedMessages(
     }
   }
   if (failure !== undefined) throw failure;
-  if (!terminal) throw new Error("Expected synchronized MCAP terminal window");
-  yield { kind: "terminal", window: terminal };
+}
+
+/**
+ * Pushes synchronized stream items directly from their decode boundary.
+ *
+ * The worker uses this callback form so an authoritative settlement can cross
+ * the worker boundary before the decoder resumes with the next topic. The
+ * async-generator adapter above remains available to ordinary stream callers.
+ */
+export async function runMcapPlaybackWorkerSynchronizedRequest(
+  client: Pick<McapPlaybackWorkerResourceClient, "readSynchronizedMessages">,
+  request: McapPlaybackWorkerRpcRequest<"readSynchronizedMessages">["payload"],
+  onItem: (
+    item: McapPlaybackWorkerStreamItemByType["readSynchronizedMessages"],
+  ) => void,
+): Promise<void> {
+  const settledTopics = new Set<string>();
+  const window = await client.readSynchronizedMessages(request, {
+    onTopicSettlement: ({ topic, window }) => {
+      if (settledTopics.has(topic)) return;
+      settledTopics.add(topic);
+      onItem({ kind: "topic-settlement", topic, window });
+    },
+  });
+  onItem({
+    kind: "terminal",
+    window: withoutSettledTopicPayloads(window, settledTopics),
+  });
 }
 
 function withoutSettledTopicPayloads(

--- a/app/packages/multimodal/src/adapters/mcap/worker/playback-worker-rpc.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/playback-worker-rpc.ts
@@ -197,10 +197,9 @@ export function runMcapPlaybackWorkerUnaryRequest(
     case "readSynchronizedMessageBatch":
       return client.readSynchronizedMessageBatch(message.payload);
     case "readSynchronizedMessages":
-      return client.readSynchronizedMessages(
-        message.payload,
+      return client.readSynchronizedMessages(message.payload, {
         onSynchronizedProgress,
-      );
+      });
     case "readTimelineRange":
       return client.readTimelineRange(message.payload);
     case "readTransformTopology":

--- a/app/packages/multimodal/src/adapters/mcap/worker/playback-worker-rpc.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/playback-worker-rpc.ts
@@ -243,6 +243,7 @@ async function* streamSynchronizedMessages(
   const queued: McapPlaybackWorkerStreamItemByType["readSynchronizedMessages"][] =
     [];
   let complete = false;
+  let failed = false;
   let failure: unknown;
   let wake: (() => void) | undefined;
   const notify = () => {
@@ -260,6 +261,7 @@ async function* streamSynchronizedMessages(
       notify();
     },
     (error) => {
+      failed = true;
       failure = error;
       complete = true;
       notify();
@@ -278,7 +280,7 @@ async function* streamSynchronizedMessages(
       if (item) yield item;
     }
   }
-  if (failure !== undefined) throw failure;
+  if (failed) throw failure;
 }
 
 /**

--- a/app/packages/multimodal/src/adapters/mcap/worker/playback-worker-stream-batch.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/playback-worker-stream-batch.test.ts
@@ -15,6 +15,15 @@ describe("MCAP worker stream batching", () => {
     expect(estimateMcapStreamItemBytes(message())).toBe(256);
   });
 
+  it("falls back safely when an unknown decoded output is nullish", () => {
+    expect(
+      estimateMcapStreamItemBytes({ decoded: { output: undefined } }),
+    ).toBe(256);
+    expect(estimateMcapStreamItemBytes({ decoded: { output: null } })).toBe(
+      256,
+    );
+  });
+
   it("flushes before an item would cross the byte cap", () => {
     expect(
       wouldOverflowMcapStreamBatch({

--- a/app/packages/multimodal/src/adapters/mcap/worker/playback-worker-stream-batch.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/playback-worker-stream-batch.ts
@@ -38,7 +38,9 @@ function isMcapDecodedMessage(item: unknown): item is McapDecodedMessage {
     "decoded" in item &&
     typeof item.decoded === "object" &&
     item.decoded !== null &&
-    "output" in item.decoded
+    "output" in item.decoded &&
+    typeof item.decoded.output === "object" &&
+    item.decoded.output !== null
   );
 }
 

--- a/app/packages/multimodal/src/adapters/mcap/worker/playback-worker-stream-batch.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/playback-worker-stream-batch.ts
@@ -1,4 +1,5 @@
 import type { McapDecodedMessage } from "../contracts/index";
+import { messagesFromMcapWorkerResult } from "./worker-result-traversal";
 
 /** Maximum plain decoded records delivered in one worker message. */
 export const MCAP_STREAM_BATCH_MAX_ITEMS = 64;
@@ -13,11 +14,31 @@ const MIN_STREAM_ITEM_ESTIMATED_BYTES = 256;
  * payload size covers generic log records; decoder hints cover outputs that
  * expand materially during decoding.
  */
-export function estimateMcapStreamItemBytes(item: McapDecodedMessage): number {
+export function estimateMcapStreamItemBytes(item: unknown): number {
+  const messages = messagesFromMcapWorkerResult(item, isMcapDecodedMessage);
+  if (messages.length === 0) return MIN_STREAM_ITEM_ESTIMATED_BYTES;
   return Math.max(
     MIN_STREAM_ITEM_ESTIMATED_BYTES,
-    item.encodedPayloadBytes ?? 0,
-    item.decoded.output.resourceHints?.sizeBytes ?? 0,
+    messages.reduce(
+      (total, message) =>
+        total +
+        Math.max(
+          message.encodedPayloadBytes ?? 0,
+          message.decoded.output.resourceHints?.sizeBytes ?? 0,
+        ),
+      0,
+    ),
+  );
+}
+
+function isMcapDecodedMessage(item: unknown): item is McapDecodedMessage {
+  return (
+    typeof item === "object" &&
+    item !== null &&
+    "decoded" in item &&
+    typeof item.decoded === "object" &&
+    item.decoded !== null &&
+    "output" in item.decoded
   );
 }
 

--- a/app/packages/multimodal/src/adapters/mcap/worker/playback-worker-supersession.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/playback-worker-supersession.ts
@@ -1,7 +1,7 @@
 import type {
   McapPlaybackWorkerPriority,
   McapPlaybackWorkerRequestPayloadByType,
-  McapPlaybackWorkerUnaryType,
+  McapPlaybackWorkerRpcType,
 } from "./playback-worker-types";
 import { MCAP_PLAYBACK_WORKER_PRIORITY } from "./playback-worker-types";
 
@@ -14,7 +14,7 @@ const SUPERSESSION_KEY_SEPARATOR = "\0";
  * Playback runway and unrelated RPCs deliberately return no keys.
  */
 export function mcapForegroundSupersessionKeys<
-  Type extends McapPlaybackWorkerUnaryType,
+  Type extends McapPlaybackWorkerRpcType,
 >({
   generation,
   payload,

--- a/app/packages/multimodal/src/adapters/mcap/worker/playback-worker-transport.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/playback-worker-transport.test.ts
@@ -382,6 +382,42 @@ describe("MCAP playback worker transport", () => {
     });
     await expect(done).resolves.toEqual({ done: true, value: undefined });
   });
+
+  it("preserves a worker response batch when requested by the owner", async () => {
+    const worker = createWorker();
+    const transport = new McapPlaybackWorkerTransport(() => true);
+    const stream = transport.stream(
+      worker,
+      "source:1",
+      "readDecodedMessages",
+      { source: createSource(), topics: ["/diagnostics"] },
+      undefined,
+      undefined,
+      undefined,
+      [],
+      true,
+    );
+    const items = [createDecodedMessage(1n), createDecodedMessage(2n)];
+    const next = stream.next();
+
+    transport.handleResponse({
+      done: false,
+      id: 1,
+      items,
+      ok: true,
+      stream: true,
+    });
+
+    await expect(next).resolves.toEqual({ done: false, value: items });
+    const done = stream.next();
+    transport.handleResponse({
+      done: true,
+      id: 1,
+      ok: true,
+      stream: true,
+    });
+    await expect(done).resolves.toEqual({ done: true, value: undefined });
+  });
 });
 
 function createWorker(): Worker {

--- a/app/packages/multimodal/src/adapters/mcap/worker/playback-worker-transport.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/playback-worker-transport.test.ts
@@ -322,7 +322,7 @@ describe("MCAP playback worker transport", () => {
     expect(transport.isIdle()).toBe(true);
   });
 
-  it("finishes inactive streams instead of leaving readers pending", async () => {
+  it("cancels inactive streams instead of leaving readers pending", async () => {
     const worker = createWorker();
     const transport = new McapPlaybackWorkerTransport(() => false);
     const stream = transport.stream(worker, "source:1", "readDecodedMessages", {
@@ -339,10 +339,8 @@ describe("MCAP playback worker transport", () => {
       stream: true,
     });
 
-    await expect(next).resolves.toEqual({
-      done: true,
-      value: undefined,
-    });
+    await expect(next).rejects.toThrow(EPISODE_READ_CANCELLED_MESSAGE);
+    expect(transport.isIdle()).toBe(true);
   });
 
   it("yields batched worker stream items in order", async () => {

--- a/app/packages/multimodal/src/adapters/mcap/worker/playback-worker-transport.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/playback-worker-transport.ts
@@ -23,9 +23,6 @@ type PendingRequest<
 > = {
   cancelled?: boolean;
   readonly cleanup?: () => void;
-  readonly onProgress?: (
-    result: McapPlaybackWorkerResultByType["readSynchronizedMessages"],
-  ) => void;
   readonly reject: (error: Error) => void;
   readonly resolve: (result: McapPlaybackWorkerResultByType[Type]) => void;
   readonly sourceKey: string;
@@ -38,6 +35,8 @@ type PendingStream = {
   readonly rejectors: Array<(error: Error) => void>;
   readonly resolvers: Array<(result: IteratorResult<unknown, void>) => void>;
   readonly sourceKey: string;
+  readonly supersessionKeys: readonly string[];
+  readonly type: McapPlaybackWorkerStreamType;
   readonly values: unknown[];
   done: boolean;
   error?: Error;
@@ -68,9 +67,6 @@ export class McapPlaybackWorkerTransport {
     supersessionKeys: readonly string[] = [],
     signal?: AbortSignal,
     retainedDecodedRecordIds?: readonly string[],
-    onProgress?: (
-      result: McapPlaybackWorkerResultByType["readSynchronizedMessages"],
-    ) => void,
   ): Promise<McapPlaybackWorkerResultByType[Type]> {
     const id = this.nextRequestId++;
     const message = createRpcRequest(
@@ -118,7 +114,6 @@ export class McapPlaybackWorkerTransport {
               cleanup: () => signal.removeEventListener("abort", cancel),
             }
           : {}),
-        ...(onProgress ? { onProgress } : {}),
         reject,
         resolve: resolve as PendingRequest["resolve"],
         sourceKey,
@@ -178,8 +173,26 @@ export class McapPlaybackWorkerTransport {
    * no response, so local settlement is what keeps consumers from hanging.
    */
   cancelStreams(): number[] {
+    return this.cancelPendingStreams(() => true);
+  }
+
+  /** Cancels matching pending streams while preserving unrelated lanes. */
+  cancelPendingStreams(
+    filter: (pending: {
+      readonly supersessionKeys: readonly string[];
+      readonly type: McapPlaybackWorkerStreamType;
+    }) => boolean,
+  ): number[] {
     const cancelledIds: number[] = [];
     for (const [id, stream] of [...this.streams]) {
+      if (
+        !filter({
+          supersessionKeys: stream.supersessionKeys,
+          type: stream.type,
+        })
+      ) {
+        continue;
+      }
       this.failStream(id, stream, new EpisodeReadCancelledError());
       cancelledIds.push(id);
     }
@@ -197,9 +210,18 @@ export class McapPlaybackWorkerTransport {
     payload: McapPlaybackWorkerRequestPayloadByType[Type],
     priority?: McapPlaybackWorkerPriority,
     signal?: AbortSignal,
+    retainedDecodedRecordIds?: readonly string[],
+    supersessionKeys: readonly string[] = [],
   ): AsyncGenerator<McapPlaybackWorkerStreamItemByType[Type], void, void> {
     const id = this.nextRequestId++;
-    const message = createRpcRequest(id, sourceKey, type, payload, priority);
+    const message = createRpcRequest(
+      id,
+      sourceKey,
+      type,
+      payload,
+      priority,
+      retainedDecodedRecordIds,
+    );
     const cancel = () => {
       const pending = this.streams.get(id);
       if (!pending) return;
@@ -221,6 +243,8 @@ export class McapPlaybackWorkerTransport {
       rejectors: [],
       resolvers: [],
       sourceKey,
+      supersessionKeys,
+      type,
       values: [],
     };
 
@@ -263,17 +287,12 @@ export class McapPlaybackWorkerTransport {
       this.onTransport?.(response.transport);
     }
 
-    const pending = this.pending.get(response.id);
-    if (pending && response.ok && "progress" in response) {
-      pending.onProgress?.(response.result);
-      return;
-    }
-
     if (response.ok && "stream" in response) {
       this.handleStreamResponse(response);
       return;
     }
 
+    const pending = this.pending.get(response.id);
     if (pending) {
       // A response can arrive after the client has moved to another source.
       // It still owns this request id, so settle and remove it instead of

--- a/app/packages/multimodal/src/adapters/mcap/worker/playback-worker-transport.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/playback-worker-transport.ts
@@ -399,9 +399,10 @@ export class McapPlaybackWorkerTransport {
       return;
     }
     if (!this.isActiveSource(stream.sourceKey)) {
-      // Stale stream success has no active consumer anymore. Finish it so any
-      // awaiting iterator observes completion and the stream entry is released.
-      this.finishStream(response.id, stream);
+      // A synchronized stream without its terminal is incomplete. Surface a
+      // stale-source completion through the ordinary cancellation path so an
+      // owner never mistakes it for a protocol failure or retries it.
+      this.failStream(response.id, stream, new EpisodeReadCancelledError());
       return;
     }
 

--- a/app/packages/multimodal/src/adapters/mcap/worker/playback-worker-transport.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/playback-worker-transport.ts
@@ -38,6 +38,7 @@ type PendingStream = {
   readonly supersessionKeys: readonly string[];
   readonly type: McapPlaybackWorkerStreamType;
   readonly values: unknown[];
+  readonly yieldResponseBatches: boolean;
   done: boolean;
   error?: Error;
 };
@@ -203,6 +204,32 @@ export class McapPlaybackWorkerTransport {
   /**
    * Sends one streaming worker RPC and yields incremental response payloads.
    */
+  stream<Type extends McapPlaybackWorkerStreamType>(
+    worker: Worker,
+    sourceKey: string,
+    type: Type,
+    payload: McapPlaybackWorkerRequestPayloadByType[Type],
+    priority?: McapPlaybackWorkerPriority,
+    signal?: AbortSignal,
+    retainedDecodedRecordIds?: readonly string[],
+    supersessionKeys?: readonly string[],
+    yieldResponseBatches?: false,
+  ): AsyncGenerator<McapPlaybackWorkerStreamItemByType[Type], void, void>;
+  stream<Type extends McapPlaybackWorkerStreamType>(
+    worker: Worker,
+    sourceKey: string,
+    type: Type,
+    payload: McapPlaybackWorkerRequestPayloadByType[Type],
+    priority: McapPlaybackWorkerPriority | undefined,
+    signal: AbortSignal | undefined,
+    retainedDecodedRecordIds: readonly string[] | undefined,
+    supersessionKeys: readonly string[],
+    yieldResponseBatches: true,
+  ): AsyncGenerator<
+    readonly McapPlaybackWorkerStreamItemByType[Type][],
+    void,
+    void
+  >;
   async *stream<Type extends McapPlaybackWorkerStreamType>(
     worker: Worker,
     sourceKey: string,
@@ -212,7 +239,13 @@ export class McapPlaybackWorkerTransport {
     signal?: AbortSignal,
     retainedDecodedRecordIds?: readonly string[],
     supersessionKeys: readonly string[] = [],
-  ): AsyncGenerator<McapPlaybackWorkerStreamItemByType[Type], void, void> {
+    yieldResponseBatches = false,
+  ): AsyncGenerator<
+    | McapPlaybackWorkerStreamItemByType[Type]
+    | readonly McapPlaybackWorkerStreamItemByType[Type][],
+    void,
+    void
+  > {
     const id = this.nextRequestId++;
     const message = createRpcRequest(
       id,
@@ -246,6 +279,7 @@ export class McapPlaybackWorkerTransport {
       supersessionKeys,
       type,
       values: [],
+      yieldResponseBatches,
     };
 
     signal?.addEventListener("abort", cancel, { once: true });
@@ -375,8 +409,12 @@ export class McapPlaybackWorkerTransport {
       this.finishStream(response.id, stream);
     } else {
       const items = "items" in response ? response.items : [response.item];
-      for (const item of items) {
-        pushStreamValue(stream, item);
+      if (stream.yieldResponseBatches) {
+        pushStreamValue(stream, items);
+      } else {
+        for (const item of items) {
+          pushStreamValue(stream, item);
+        }
       }
     }
   }

--- a/app/packages/multimodal/src/adapters/mcap/worker/playback-worker-transport.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/playback-worker-transport.ts
@@ -23,6 +23,9 @@ type PendingRequest<
 > = {
   cancelled?: boolean;
   readonly cleanup?: () => void;
+  readonly onProgress?: (
+    result: McapPlaybackWorkerResultByType["readSynchronizedMessages"],
+  ) => void;
   readonly reject: (error: Error) => void;
   readonly resolve: (result: McapPlaybackWorkerResultByType[Type]) => void;
   readonly sourceKey: string;
@@ -65,6 +68,9 @@ export class McapPlaybackWorkerTransport {
     supersessionKeys: readonly string[] = [],
     signal?: AbortSignal,
     retainedDecodedRecordIds?: readonly string[],
+    onProgress?: (
+      result: McapPlaybackWorkerResultByType["readSynchronizedMessages"],
+    ) => void,
   ): Promise<McapPlaybackWorkerResultByType[Type]> {
     const id = this.nextRequestId++;
     const message = createRpcRequest(
@@ -112,6 +118,7 @@ export class McapPlaybackWorkerTransport {
               cleanup: () => signal.removeEventListener("abort", cancel),
             }
           : {}),
+        ...(onProgress ? { onProgress } : {}),
         reject,
         resolve: resolve as PendingRequest["resolve"],
         sourceKey,
@@ -256,12 +263,17 @@ export class McapPlaybackWorkerTransport {
       this.onTransport?.(response.transport);
     }
 
+    const pending = this.pending.get(response.id);
+    if (pending && response.ok && "progress" in response) {
+      pending.onProgress?.(response.result);
+      return;
+    }
+
     if (response.ok && "stream" in response) {
       this.handleStreamResponse(response);
       return;
     }
 
-    const pending = this.pending.get(response.id);
     if (pending) {
       // A response can arrive after the client has moved to another source.
       // It still owns this request id, so settle and remove it instead of

--- a/app/packages/multimodal/src/adapters/mcap/worker/playback-worker-types.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/playback-worker-types.ts
@@ -229,6 +229,14 @@ export type McapPlaybackWorkerUnaryResponse = {
   readonly transport?: McapTransportSnapshot;
 };
 
+/** One early topic result for a still-running synchronized union read. */
+export type McapPlaybackWorkerProgressResponse = {
+  readonly id: number;
+  readonly ok: true;
+  readonly progress: true;
+  readonly result: McapPlaybackWorkerResultByType["readSynchronizedMessages"];
+};
+
 /**
  * Incremental or terminal success response for one streaming worker RPC.
  */
@@ -283,6 +291,7 @@ export type McapPlaybackWorkerTransportResponse = {
  */
 export type McapPlaybackWorkerResponse =
   | McapPlaybackWorkerUnaryResponse
+  | McapPlaybackWorkerProgressResponse
   | McapPlaybackWorkerStreamResponse
   | McapPlaybackWorkerErrorResponse
   | McapPlaybackWorkerTransportResponse;

--- a/app/packages/multimodal/src/adapters/mcap/worker/playback-worker-types.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/playback-worker-types.ts
@@ -130,6 +130,19 @@ export type McapPlaybackWorkerSynchronizedMessage =
 export type McapPlaybackWorkerSynchronizedWindow =
   McapSynchronizedMessageWindowWithMessages<McapPlaybackWorkerSynchronizedMessage>;
 
+/** Ordered ownership events for one synchronized current-frame union read. */
+export type McapPlaybackWorkerSynchronizedStreamItem =
+  | {
+      readonly kind: "topic-settlement";
+      readonly topic: string;
+      readonly window: McapPlaybackWorkerSynchronizedWindow;
+    }
+  | {
+      /** Contains only payloads for topics not already emitted above. */
+      readonly kind: "terminal";
+      readonly window: McapPlaybackWorkerSynchronizedWindow;
+    };
+
 /**
  * Unary result payloads returned by worker RPC calls.
  */
@@ -145,7 +158,6 @@ export type McapPlaybackWorkerResultByType = {
   readonly readRawMessageAtCursor: McapRawMessageRecordResult;
   readonly readRawMessageRecord: McapRawMessageRecordResult;
   readonly readSynchronizedMessageBatch: readonly McapPlaybackWorkerSynchronizedWindow[];
-  readonly readSynchronizedMessages: McapPlaybackWorkerSynchronizedWindow;
   readonly readTimelineRange: McapTimelineRange;
   readonly readTransformTopology: McapTransformTopologyResult;
   readonly readTopics: McapRecordingInventory;
@@ -157,6 +169,7 @@ export type McapPlaybackWorkerResultByType = {
  */
 export type McapPlaybackWorkerStreamItemByType = {
   readonly readDecodedMessages: McapDecodedMessage;
+  readonly readSynchronizedMessages: McapPlaybackWorkerSynchronizedStreamItem;
 };
 
 /**
@@ -229,14 +242,6 @@ export type McapPlaybackWorkerUnaryResponse = {
   readonly transport?: McapTransportSnapshot;
 };
 
-/** One early topic result for a still-running synchronized union read. */
-export type McapPlaybackWorkerProgressResponse = {
-  readonly id: number;
-  readonly ok: true;
-  readonly progress: true;
-  readonly result: McapPlaybackWorkerResultByType["readSynchronizedMessages"];
-};
-
 /**
  * Incremental or terminal success response for one streaming worker RPC.
  */
@@ -291,7 +296,6 @@ export type McapPlaybackWorkerTransportResponse = {
  */
 export type McapPlaybackWorkerResponse =
   | McapPlaybackWorkerUnaryResponse
-  | McapPlaybackWorkerProgressResponse
   | McapPlaybackWorkerStreamResponse
   | McapPlaybackWorkerErrorResponse
   | McapPlaybackWorkerTransportResponse;

--- a/app/packages/multimodal/src/adapters/mcap/worker/playback-worker.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/playback-worker.test.ts
@@ -149,7 +149,7 @@ describe("MCAP playback worker lifecycle", () => {
     ).toBe(false);
   });
 
-  it("delivers the complete blocking prefix in one transferable batch", async () => {
+  it("delivers the first useful settlement before the remaining blocking group", async () => {
     const cameraBytes = new Uint8Array([1, 2, 3]);
     const lidarBytes = new Uint8Array([4, 5, 6]);
     const diagnosticBytes = new Uint8Array([7, 8, 9]);
@@ -187,7 +187,7 @@ describe("MCAP playback worker lifecycle", () => {
     } as McapPlaybackWorkerRequest);
 
     await vi.waitFor(() => {
-      expect(workerScope.postMessage).toHaveBeenCalledTimes(3);
+      expect(workerScope.postMessage).toHaveBeenCalledTimes(4);
     });
     expect(workerScope.postMessage.mock.calls[0]).toEqual([
       expect.objectContaining({
@@ -196,15 +196,22 @@ describe("MCAP playback worker lifecycle", () => {
             kind: "topic-settlement",
             topic: "/camera",
           }),
+        ],
+      }),
+      expect.arrayContaining([cameraBytes.buffer]),
+    ]);
+    expect(workerScope.postMessage.mock.calls[1]).toEqual([
+      expect.objectContaining({
+        items: [
           expect.objectContaining({
             kind: "topic-settlement",
             topic: "/lidar",
           }),
         ],
       }),
-      expect.arrayContaining([cameraBytes.buffer, lidarBytes.buffer]),
+      expect.arrayContaining([lidarBytes.buffer]),
     ]);
-    expect(workerScope.postMessage.mock.calls[1]).toEqual([
+    expect(workerScope.postMessage.mock.calls[2]).toEqual([
       expect.objectContaining({
         items: [
           expect.objectContaining({

--- a/app/packages/multimodal/src/adapters/mcap/worker/playback-worker.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/playback-worker.test.ts
@@ -6,17 +6,23 @@ import {
 
 type WorkerClientMock = {
   readonly dispose: Mock;
+  readonly readSynchronizedMessages: Mock;
   readonly readTopics: Mock;
 };
 
 const workerResourceClientMock = vi.hoisted(() => ({
   clients: [] as WorkerClientMock[],
+  synchronizedResult: null as unknown,
 }));
 
 vi.mock("./worker-resource-client", () => ({
   createWorkerResourceClient: vi.fn(() => {
     const client: WorkerClientMock = {
       dispose: vi.fn(),
+      readSynchronizedMessages: vi.fn(async (_request, onProgress) => {
+        onProgress?.(workerResourceClientMock.synchronizedResult);
+        return workerResourceClientMock.synchronizedResult;
+      }),
       readTopics: vi.fn(async () => ({
         recordingFacts: { format: "mcap" },
         streams: [],
@@ -38,6 +44,7 @@ describe("MCAP playback worker lifecycle", () => {
     vi.unstubAllGlobals();
     vi.resetModules();
     workerResourceClientMock.clients.length = 0;
+    workerResourceClientMock.synchronizedResult = null;
   });
 
   it("releases active and parked source clients while keeping the worker alive", async () => {
@@ -69,7 +76,84 @@ describe("MCAP playback worker lifecycle", () => {
     expect(workerResourceClientMock.clients).toHaveLength(5);
     expect(workerResourceClientMock.clients[4]).not.toBe(parked);
   });
+
+  it("clones progress without detaching the terminal union", async () => {
+    const bytes = new Uint8Array([1, 2, 3]);
+    workerResourceClientMock.synchronizedResult = synchronizedWindow(bytes);
+    const workerScope: WorkerScopeMock = {
+      close: vi.fn(),
+      onmessage: null,
+      postMessage: vi.fn((response, transferables?: Transferable[]) => {
+        structuredClone(response, { transfer: transferables ?? [] });
+      }),
+    };
+    vi.stubGlobal("self", workerScope);
+    await import("./playback-worker");
+
+    dispatch(workerScope, {
+      id: 1,
+      payload: {
+        earlyDeliveryTopics: ["/camera"],
+        source: { sizeBytes: "1024", sourceId: "source:1", url: "mcap://1" },
+        timeNs: 1n,
+        topics: ["/camera", "/lidar"],
+      },
+      priority: MCAP_PLAYBACK_WORKER_PRIORITY.CURRENT_FRAME,
+      sourceKey: "source:1",
+      type: "readSynchronizedMessages",
+    } as McapPlaybackWorkerRequest);
+
+    await vi.waitFor(() => {
+      expect(workerScope.postMessage).toHaveBeenCalledTimes(2);
+    });
+    expect(workerScope.postMessage.mock.calls[0]).toEqual([
+      expect.objectContaining({ ok: true, progress: true }),
+      [],
+    ]);
+    expect(workerScope.postMessage.mock.calls[1]?.[0]).toEqual(
+      expect.objectContaining({ id: 1, ok: true }),
+    );
+    expect(workerScope.postMessage.mock.calls[1]?.[0]).not.toHaveProperty(
+      "progress",
+    );
+    expect(workerScope.postMessage.mock.calls[1]?.[1]).toHaveLength(1);
+    expect(
+      workerScope.postMessage.mock.calls.some(
+        ([response]) => response.ok === false,
+      ),
+    ).toBe(false);
+  });
 });
+
+function synchronizedWindow(bytes: Uint8Array) {
+  const message = {
+    activeTimeline: "log" as const,
+    channelId: 1,
+    decoded: {
+      decoderId: "decoder",
+      decoderVersion: "1",
+      output: {
+        attributes: {},
+        resourceHints: { transferables: [bytes.buffer] },
+      },
+      payload: { encoding: "protobuf" },
+    },
+    logTimeNs: 1n,
+    publishTimeNs: 1n,
+    sequence: 1,
+    timelineTimeNs: 1n,
+    topic: "/camera",
+  };
+  return {
+    activeTimeline: "log" as const,
+    endTimeNs: 1n,
+    messages: [message],
+    messagesByTopic: { "/camera": [message] },
+    startTimeNs: 1n,
+    streamPolicies: {},
+    timeNs: 1n,
+  };
+}
 
 async function readTopics(
   workerScope: WorkerScopeMock,

--- a/app/packages/multimodal/src/adapters/mcap/worker/playback-worker.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/playback-worker.test.ts
@@ -12,6 +12,10 @@ type WorkerClientMock = {
 
 const workerResourceClientMock = vi.hoisted(() => ({
   clients: [] as WorkerClientMock[],
+  synchronizedSettlements: [] as Array<{
+    readonly topic: string;
+    readonly window: unknown;
+  }>,
   synchronizedResult: null as unknown,
 }));
 
@@ -20,10 +24,18 @@ vi.mock("./worker-resource-client", () => ({
     const client: WorkerClientMock = {
       dispose: vi.fn(),
       readSynchronizedMessages: vi.fn(async (_request, options) => {
-        options?.onTopicSettlement?.({
-          topic: "/camera",
-          window: workerResourceClientMock.synchronizedResult,
-        });
+        const settlements = workerResourceClientMock.synchronizedSettlements
+          .length
+          ? workerResourceClientMock.synchronizedSettlements
+          : [
+              {
+                topic: "/camera",
+                window: workerResourceClientMock.synchronizedResult,
+              },
+            ];
+        for (const settlement of settlements) {
+          options?.onTopicSettlement?.(settlement);
+        }
         return workerResourceClientMock.synchronizedResult;
       }),
       readTopics: vi.fn(async () => ({
@@ -47,6 +59,7 @@ describe("MCAP playback worker lifecycle", () => {
     vi.unstubAllGlobals();
     vi.resetModules();
     workerResourceClientMock.clients.length = 0;
+    workerResourceClientMock.synchronizedSettlements.length = 0;
     workerResourceClientMock.synchronizedResult = null;
   });
 
@@ -111,7 +124,7 @@ describe("MCAP playback worker lifecycle", () => {
     });
     expect(workerScope.postMessage.mock.calls[0]).toEqual([
       expect.objectContaining({
-        item: expect.objectContaining({ kind: "topic-settlement" }),
+        items: [expect.objectContaining({ kind: "topic-settlement" })],
         ok: true,
         stream: true,
       }),
@@ -134,6 +147,60 @@ describe("MCAP playback worker lifecycle", () => {
         ([response]) => response.ok === false,
       ),
     ).toBe(false);
+  });
+
+  it("delivers the complete blocking prefix in one transferable batch", async () => {
+    const cameraBytes = new Uint8Array([1, 2, 3]);
+    const lidarBytes = new Uint8Array([4, 5, 6]);
+    const camera = synchronizedWindow(cameraBytes, "/camera");
+    const lidar = synchronizedWindow(lidarBytes, "/lidar");
+    workerResourceClientMock.synchronizedSettlements.push(
+      { topic: "/camera", window: camera },
+      { topic: "/lidar", window: lidar },
+    );
+    workerResourceClientMock.synchronizedResult = synchronizedWindow(
+      new Uint8Array([]),
+      "/terminal",
+    );
+    const workerScope: WorkerScopeMock = {
+      close: vi.fn(),
+      onmessage: null,
+      postMessage: vi.fn(),
+    };
+    vi.stubGlobal("self", workerScope);
+    await import("./playback-worker");
+
+    dispatch(workerScope, {
+      id: 1,
+      payload: {
+        settlementPriorityTopics: ["/camera", "/lidar"],
+        source: { sizeBytes: "1024", sourceId: "source:1", url: "mcap://1" },
+        timeNs: 1n,
+        topics: ["/camera", "/lidar", "/terminal"],
+      },
+      priority: MCAP_PLAYBACK_WORKER_PRIORITY.CURRENT_FRAME,
+      sourceKey: "source:1",
+      type: "readSynchronizedMessages",
+    } as McapPlaybackWorkerRequest);
+
+    await vi.waitFor(() => {
+      expect(workerScope.postMessage).toHaveBeenCalledTimes(3);
+    });
+    expect(workerScope.postMessage.mock.calls[0]).toEqual([
+      expect.objectContaining({
+        items: [
+          expect.objectContaining({
+            kind: "topic-settlement",
+            topic: "/camera",
+          }),
+          expect.objectContaining({
+            kind: "topic-settlement",
+            topic: "/lidar",
+          }),
+        ],
+      }),
+      expect.arrayContaining([cameraBytes.buffer, lidarBytes.buffer]),
+    ]);
   });
 
   it("keeps the terminal event payload-free after topic settlement", async () => {
@@ -179,7 +246,7 @@ describe("MCAP playback worker lifecycle", () => {
   });
 });
 
-function synchronizedWindow(bytes: Uint8Array) {
+function synchronizedWindow(bytes: Uint8Array, topic = "/camera") {
   const message = {
     activeTimeline: "log" as const,
     channelId: 1,
@@ -196,13 +263,13 @@ function synchronizedWindow(bytes: Uint8Array) {
     publishTimeNs: 1n,
     sequence: 1,
     timelineTimeNs: 1n,
-    topic: "/camera",
+    topic,
   };
   return {
     activeTimeline: "log" as const,
     endTimeNs: 1n,
     messages: [message],
-    messagesByTopic: { "/camera": [message] },
+    messagesByTopic: { [topic]: [message] },
     startTimeNs: 1n,
     streamPolicies: {},
     timeNs: 1n,

--- a/app/packages/multimodal/src/adapters/mcap/worker/playback-worker.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/playback-worker.test.ts
@@ -152,11 +152,14 @@ describe("MCAP playback worker lifecycle", () => {
   it("delivers the complete blocking prefix in one transferable batch", async () => {
     const cameraBytes = new Uint8Array([1, 2, 3]);
     const lidarBytes = new Uint8Array([4, 5, 6]);
+    const diagnosticBytes = new Uint8Array([7, 8, 9]);
     const camera = synchronizedWindow(cameraBytes, "/camera");
     const lidar = synchronizedWindow(lidarBytes, "/lidar");
+    const diagnostics = synchronizedWindow(diagnosticBytes, "/diagnostics");
     workerResourceClientMock.synchronizedSettlements.push(
       { topic: "/camera", window: camera },
       { topic: "/lidar", window: lidar },
+      { topic: "/diagnostics", window: diagnostics },
     );
     workerResourceClientMock.synchronizedResult = synchronizedWindow(
       new Uint8Array([]),
@@ -200,6 +203,18 @@ describe("MCAP playback worker lifecycle", () => {
         ],
       }),
       expect.arrayContaining([cameraBytes.buffer, lidarBytes.buffer]),
+    ]);
+    expect(workerScope.postMessage.mock.calls[1]).toEqual([
+      expect.objectContaining({
+        items: [
+          expect.objectContaining({
+            kind: "topic-settlement",
+            topic: "/diagnostics",
+          }),
+          expect.objectContaining({ kind: "terminal" }),
+        ],
+      }),
+      expect.arrayContaining([diagnosticBytes.buffer]),
     ]);
   });
 

--- a/app/packages/multimodal/src/adapters/mcap/worker/playback-worker.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/playback-worker.test.ts
@@ -11,6 +11,7 @@ type WorkerClientMock = {
 };
 
 const workerResourceClientMock = vi.hoisted(() => ({
+  afterTopicSettlement: undefined as ((topic: string) => void) | undefined,
   clients: [] as WorkerClientMock[],
   synchronizedSettlements: [] as Array<{
     readonly topic: string;
@@ -35,6 +36,7 @@ vi.mock("./worker-resource-client", () => ({
             ];
         for (const settlement of settlements) {
           options?.onTopicSettlement?.(settlement);
+          workerResourceClientMock.afterTopicSettlement?.(settlement.topic);
         }
         return workerResourceClientMock.synchronizedResult;
       }),
@@ -59,6 +61,7 @@ describe("MCAP playback worker lifecycle", () => {
     vi.unstubAllGlobals();
     vi.resetModules();
     workerResourceClientMock.clients.length = 0;
+    workerResourceClientMock.afterTopicSettlement = undefined;
     workerResourceClientMock.synchronizedSettlements.length = 0;
     workerResourceClientMock.synchronizedResult = null;
   });
@@ -172,6 +175,10 @@ describe("MCAP playback worker lifecycle", () => {
     };
     vi.stubGlobal("self", workerScope);
     await import("./playback-worker");
+    const postCountsAfterSettlement: number[] = [];
+    workerResourceClientMock.afterTopicSettlement = () => {
+      postCountsAfterSettlement.push(workerScope.postMessage.mock.calls.length);
+    };
 
     dispatch(workerScope, {
       id: 1,
@@ -223,6 +230,7 @@ describe("MCAP playback worker lifecycle", () => {
       }),
       expect.arrayContaining([diagnosticBytes.buffer]),
     ]);
+    expect(postCountsAfterSettlement).toEqual([1, 2, 2]);
   });
 
   it("keeps the terminal event payload-free after topic settlement", async () => {

--- a/app/packages/multimodal/src/adapters/mcap/worker/playback-worker.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/playback-worker.test.ts
@@ -19,8 +19,10 @@ vi.mock("./worker-resource-client", () => ({
   createWorkerResourceClient: vi.fn(() => {
     const client: WorkerClientMock = {
       dispose: vi.fn(),
-      readSynchronizedMessages: vi.fn(async (_request, onProgress) => {
-        onProgress?.(workerResourceClientMock.synchronizedResult);
+      readSynchronizedMessages: vi.fn(async (_request, options) => {
+        options?.onSynchronizedProgress?.(
+          workerResourceClientMock.synchronizedResult,
+        );
         return workerResourceClientMock.synchronizedResult;
       }),
       readTopics: vi.fn(async () => ({
@@ -117,6 +119,46 @@ describe("MCAP playback worker lifecycle", () => {
       "progress",
     );
     expect(workerScope.postMessage.mock.calls[1]?.[1]).toHaveLength(1);
+    expect(
+      workerScope.postMessage.mock.calls.some(
+        ([response]) => response.ok === false,
+      ),
+    ).toBe(false);
+  });
+
+  it("returns the terminal union when progress delivery fails", async () => {
+    workerResourceClientMock.synchronizedResult = synchronizedWindow(
+      new Uint8Array([1, 2, 3]),
+    );
+    const workerScope: WorkerScopeMock = {
+      close: vi.fn(),
+      onmessage: null,
+      postMessage: vi.fn((response) => {
+        if (response.progress) throw new DOMException("clone failed");
+      }),
+    };
+    vi.stubGlobal("self", workerScope);
+    await import("./playback-worker");
+
+    dispatch(workerScope, {
+      id: 1,
+      payload: {
+        earlyDeliveryTopics: ["/camera"],
+        source: { sizeBytes: "1024", sourceId: "source:1", url: "mcap://1" },
+        timeNs: 1n,
+        topics: ["/camera", "/lidar"],
+      },
+      priority: MCAP_PLAYBACK_WORKER_PRIORITY.CURRENT_FRAME,
+      sourceKey: "source:1",
+      type: "readSynchronizedMessages",
+    } as McapPlaybackWorkerRequest);
+
+    await vi.waitFor(() => {
+      expect(workerScope.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 1, ok: true }),
+        expect.any(Array),
+      );
+    });
     expect(
       workerScope.postMessage.mock.calls.some(
         ([response]) => response.ok === false,

--- a/app/packages/multimodal/src/adapters/mcap/worker/playback-worker.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/playback-worker.test.ts
@@ -20,9 +20,10 @@ vi.mock("./worker-resource-client", () => ({
     const client: WorkerClientMock = {
       dispose: vi.fn(),
       readSynchronizedMessages: vi.fn(async (_request, options) => {
-        options?.onSynchronizedProgress?.(
-          workerResourceClientMock.synchronizedResult,
-        );
+        options?.onTopicSettlement?.({
+          topic: "/camera",
+          window: workerResourceClientMock.synchronizedResult,
+        });
         return workerResourceClientMock.synchronizedResult;
       }),
       readTopics: vi.fn(async () => ({
@@ -79,7 +80,7 @@ describe("MCAP playback worker lifecycle", () => {
     expect(workerResourceClientMock.clients[4]).not.toBe(parked);
   });
 
-  it("clones progress without detaching the terminal union", async () => {
+  it("transfers settled payloads once and omits them from the terminal item", async () => {
     const bytes = new Uint8Array([1, 2, 3]);
     workerResourceClientMock.synchronizedResult = synchronizedWindow(bytes);
     const workerScope: WorkerScopeMock = {
@@ -95,7 +96,7 @@ describe("MCAP playback worker lifecycle", () => {
     dispatch(workerScope, {
       id: 1,
       payload: {
-        earlyDeliveryTopics: ["/camera"],
+        settlementPriorityTopics: ["/camera"],
         source: { sizeBytes: "1024", sourceId: "source:1", url: "mcap://1" },
         timeNs: 1n,
         topics: ["/camera", "/lidar"],
@@ -106,19 +107,28 @@ describe("MCAP playback worker lifecycle", () => {
     } as McapPlaybackWorkerRequest);
 
     await vi.waitFor(() => {
-      expect(workerScope.postMessage).toHaveBeenCalledTimes(2);
+      expect(workerScope.postMessage).toHaveBeenCalledTimes(3);
     });
     expect(workerScope.postMessage.mock.calls[0]).toEqual([
-      expect.objectContaining({ ok: true, progress: true }),
-      [],
+      expect.objectContaining({
+        item: expect.objectContaining({ kind: "topic-settlement" }),
+        ok: true,
+        stream: true,
+      }),
+      expect.any(Array),
     ]);
+    expect(workerScope.postMessage.mock.calls[0]?.[1]).toHaveLength(1);
     expect(workerScope.postMessage.mock.calls[1]?.[0]).toEqual(
-      expect.objectContaining({ id: 1, ok: true }),
+      expect.objectContaining({
+        items: [expect.objectContaining({ kind: "terminal" })],
+        ok: true,
+        stream: true,
+      }),
     );
-    expect(workerScope.postMessage.mock.calls[1]?.[0]).not.toHaveProperty(
-      "progress",
+    expect(workerScope.postMessage.mock.calls[1]?.[1]).toEqual([]);
+    expect(workerScope.postMessage.mock.calls[2]?.[0]).toEqual(
+      expect.objectContaining({ done: true, ok: true, stream: true }),
     );
-    expect(workerScope.postMessage.mock.calls[1]?.[1]).toHaveLength(1);
     expect(
       workerScope.postMessage.mock.calls.some(
         ([response]) => response.ok === false,
@@ -126,16 +136,14 @@ describe("MCAP playback worker lifecycle", () => {
     ).toBe(false);
   });
 
-  it("returns the terminal union when progress delivery fails", async () => {
+  it("keeps the terminal event payload-free after topic settlement", async () => {
     workerResourceClientMock.synchronizedResult = synchronizedWindow(
       new Uint8Array([1, 2, 3]),
     );
     const workerScope: WorkerScopeMock = {
       close: vi.fn(),
       onmessage: null,
-      postMessage: vi.fn((response) => {
-        if (response.progress) throw new DOMException("clone failed");
-      }),
+      postMessage: vi.fn(),
     };
     vi.stubGlobal("self", workerScope);
     await import("./playback-worker");
@@ -143,7 +151,7 @@ describe("MCAP playback worker lifecycle", () => {
     dispatch(workerScope, {
       id: 1,
       payload: {
-        earlyDeliveryTopics: ["/camera"],
+        settlementPriorityTopics: ["/camera"],
         source: { sizeBytes: "1024", sourceId: "source:1", url: "mcap://1" },
         timeNs: 1n,
         topics: ["/camera", "/lidar"],
@@ -154,11 +162,15 @@ describe("MCAP playback worker lifecycle", () => {
     } as McapPlaybackWorkerRequest);
 
     await vi.waitFor(() => {
-      expect(workerScope.postMessage).toHaveBeenCalledWith(
-        expect.objectContaining({ id: 1, ok: true }),
-        expect.any(Array),
-      );
+      expect(workerScope.postMessage).toHaveBeenCalledTimes(3);
     });
+    const terminalItems = workerScope.postMessage.mock.calls[1]?.[0].items;
+    expect(terminalItems).toEqual([
+      expect.objectContaining({
+        kind: "terminal",
+        window: expect.objectContaining({ messages: [], messagesByTopic: {} }),
+      }),
+    ]);
     expect(
       workerScope.postMessage.mock.calls.some(
         ([response]) => response.ok === false,

--- a/app/packages/multimodal/src/adapters/mcap/worker/playback-worker.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/playback-worker.ts
@@ -190,12 +190,40 @@ async function streamRequest(
   let batch: McapPlaybackWorkerStreamItemByType[McapPlaybackWorkerStreamType][] =
     [];
   let batchBytes = 0;
+  const pendingPriorityTopics =
+    message.type === "readSynchronizedMessages"
+      ? new Set(
+          (message.payload.settlementPriorityTopics ?? []).filter((topic) =>
+            message.payload.topics.includes(topic),
+          ),
+        )
+      : null;
+  let holdingPrioritySettlements = (pendingPriorityTopics?.size ?? 0) > 0;
 
   for await (const item of runMcapPlaybackWorkerStreamRequest(mcap, message)) {
     throwIfWorkerRequestCancelled(signal);
     const transferables = transferablesForMcapResult(item);
-    // Transferable buffers must keep their per-item ownership boundary. Plain
-    // decoded records can share one postMessage to reduce main-thread churn.
+    // The complete blocking prefix is one delivery boundary. Its ordered
+    // per-topic items still hydrate independently on the host, while one
+    // postMessage lets the playback store publish readiness in one browser
+    // turn and transfers every payload exactly once.
+    if (holdingPrioritySettlements) {
+      batch.push(item);
+      batchBytes += estimateMcapStreamItemBytes(item);
+      if (isSynchronizedTopicSettlement(item)) {
+        pendingPriorityTopics?.delete(item.topic);
+      }
+      if ((pendingPriorityTopics?.size ?? 0) === 0) {
+        postStreamBatch(message.id, batch);
+        batch = [];
+        batchBytes = 0;
+        holdingPrioritySettlements = false;
+      }
+      continue;
+    }
+    // Outside the explicit priority boundary, transferable buffers keep their
+    // per-item ownership boundary. Plain decoded records can share one
+    // postMessage to reduce main-thread churn.
     if (transferables.length > 0) {
       postStreamBatch(message.id, batch);
       batch = [];
@@ -249,6 +277,20 @@ async function streamRequest(
     stream: true,
     transport: transportMeter.snapshot(),
   });
+}
+
+function isSynchronizedTopicSettlement(
+  item: McapPlaybackWorkerStreamItemByType[McapPlaybackWorkerStreamType],
+): item is Extract<
+  McapPlaybackWorkerStreamItemByType["readSynchronizedMessages"],
+  { readonly kind: "topic-settlement" }
+> {
+  return (
+    typeof item === "object" &&
+    item !== null &&
+    "kind" in item &&
+    item.kind === "topic-settlement"
+  );
 }
 
 function throwIfWorkerRequestCancelled(signal: AbortSignal): void {

--- a/app/packages/multimodal/src/adapters/mcap/worker/playback-worker.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/playback-worker.ts
@@ -139,7 +139,30 @@ async function runAndRespond(
       return;
     }
 
-    const result = await runMcapPlaybackWorkerUnaryRequest(mcap, message);
+    let postedProgress = false;
+    const result = await runMcapPlaybackWorkerUnaryRequest(
+      mcap,
+      message,
+      message.type === "readSynchronizedMessages" &&
+        message.payload.earlyDeliveryTopics?.length
+        ? (progress) => {
+            if (postedProgress) return;
+            throwIfWorkerRequestCancelled(context.signal);
+            postedProgress = true;
+            // Clone the single early surface so the worker retains ownership
+            // of every buffer until the complete union transfers normally.
+            postResponse(
+              {
+                id: message.id,
+                ok: true,
+                progress: true,
+                result: progress,
+              },
+              [],
+            );
+          }
+        : undefined,
+    );
     if (
       context.signal.aborted &&
       message.type === "readBoundedMessages" &&

--- a/app/packages/multimodal/src/adapters/mcap/worker/playback-worker.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/playback-worker.ts
@@ -151,15 +151,20 @@ async function runAndRespond(
             postedProgress = true;
             // Clone the single early surface so the worker retains ownership
             // of every buffer until the complete union transfers normally.
-            postResponse(
-              {
-                id: message.id,
-                ok: true,
-                progress: true,
-                result: progress,
-              },
-              [],
-            );
+            try {
+              postResponse(
+                {
+                  id: message.id,
+                  ok: true,
+                  progress: true,
+                  result: progress,
+                },
+                [],
+              );
+            } catch {
+              // Progress is best effort; the terminal union remains
+              // authoritative when an intermediate clone cannot be posted.
+            }
           }
         : undefined,
     );

--- a/app/packages/multimodal/src/adapters/mcap/worker/playback-worker.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/playback-worker.ts
@@ -199,6 +199,7 @@ async function streamRequest(
         )
       : null;
   let holdingPrioritySettlements = (pendingPriorityTopics?.size ?? 0) > 0;
+  let deliveredFirstPrioritySettlement = false;
 
   for await (const item of runMcapPlaybackWorkerStreamRequest(mcap, message)) {
     throwIfWorkerRequestCancelled(signal);
@@ -208,6 +209,22 @@ async function streamRequest(
     // postMessage lets the playback store publish readiness in one browser
     // turn and transfers every payload exactly once.
     if (holdingPrioritySettlements) {
+      if (
+        !deliveredFirstPrioritySettlement &&
+        isSynchronizedTopicSettlement(item) &&
+        pendingPriorityTopics?.has(item.topic)
+      ) {
+        // The first presentation-priority surface is useful independently of
+        // the remaining blocking group. Transfer it as soon as it is decoded;
+        // the rest of the prefix still shares one readiness boundary.
+        postStreamBatch(message.id, [item]);
+        pendingPriorityTopics.delete(item.topic);
+        deliveredFirstPrioritySettlement = true;
+        if (pendingPriorityTopics.size === 0) {
+          holdingPrioritySettlements = false;
+        }
+        continue;
+      }
       batch.push(item);
       batchBytes += estimateMcapStreamItemBytes(item);
       if (isSynchronizedTopicSettlement(item)) {

--- a/app/packages/multimodal/src/adapters/mcap/worker/playback-worker.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/playback-worker.ts
@@ -221,6 +221,15 @@ async function streamRequest(
       }
       continue;
     }
+    // A synchronized current-tick read has one more ownership boundary after
+    // the blocking prefix: unresolved stragglers plus the payload-free
+    // terminal. Keep that remainder together even when it owns transferable
+    // buffers, so the host can accept it in one store turn without copying.
+    if (message.type === "readSynchronizedMessages") {
+      batch.push(item);
+      batchBytes += estimateMcapStreamItemBytes(item);
+      continue;
+    }
     // Outside the explicit priority boundary, transferable buffers keep their
     // per-item ownership boundary. Plain decoded records can share one
     // postMessage to reduce main-thread churn.

--- a/app/packages/multimodal/src/adapters/mcap/worker/playback-worker.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/playback-worker.ts
@@ -191,6 +191,13 @@ async function streamRequest(
   let batch: McapPlaybackWorkerStreamItemByType[McapPlaybackWorkerStreamType][] =
     [];
   let batchBytes = 0;
+  let batchTransferables: Transferable[] = [];
+  const flushBatch = (): void => {
+    postStreamBatch(message.id, batch, batchTransferables);
+    batch = [];
+    batchBytes = 0;
+    batchTransferables = [];
+  };
   const pendingPriorityTopics =
     message.type === "readSynchronizedMessages"
       ? new Set(
@@ -220,7 +227,7 @@ async function streamRequest(
         // The first presentation-priority surface is useful independently of
         // the remaining blocking group. Transfer it as soon as it is decoded;
         // the rest of the prefix still shares one readiness boundary.
-        postStreamBatch(message.id, [item]);
+        postStreamBatch(message.id, [item], transferables);
         pendingPriorityTopics.delete(item.topic);
         deliveredFirstPrioritySettlement = true;
         if (pendingPriorityTopics.size === 0) {
@@ -230,13 +237,12 @@ async function streamRequest(
       }
       batch.push(item);
       batchBytes += estimateMcapStreamItemBytes(item);
+      batchTransferables.push(...transferables);
       if (isSynchronizedTopicSettlement(item)) {
         pendingPriorityTopics?.delete(item.topic);
       }
       if ((pendingPriorityTopics?.size ?? 0) === 0) {
-        postStreamBatch(message.id, batch);
-        batch = [];
-        batchBytes = 0;
+        flushBatch();
         holdingPrioritySettlements = false;
       }
       return;
@@ -248,15 +254,14 @@ async function streamRequest(
     if (message.type === "readSynchronizedMessages") {
       batch.push(item);
       batchBytes += estimateMcapStreamItemBytes(item);
+      batchTransferables.push(...transferables);
       return;
     }
     // Outside the explicit priority boundary, transferable buffers keep their
     // per-item ownership boundary. Plain decoded records can share one
     // postMessage to reduce main-thread churn.
     if (transferables.length > 0) {
-      postStreamBatch(message.id, batch);
-      batch = [];
-      batchBytes = 0;
+      flushBatch();
       postResponse(
         {
           done: false,
@@ -278,9 +283,7 @@ async function streamRequest(
         nextItemBytes: itemBytes,
       })
     ) {
-      postStreamBatch(message.id, batch);
-      batch = [];
-      batchBytes = 0;
+      flushBatch();
     }
 
     batch.push(item);
@@ -291,9 +294,7 @@ async function streamRequest(
         batchItems: batch.length,
       })
     ) {
-      postStreamBatch(message.id, batch);
-      batch = [];
-      batchBytes = 0;
+      flushBatch();
     }
   };
 
@@ -312,7 +313,7 @@ async function streamRequest(
     }
   }
   throwIfWorkerRequestCancelled(signal);
-  postStreamBatch(message.id, batch);
+  flushBatch();
 
   postResponse({
     done: true,
@@ -346,18 +347,22 @@ function throwIfWorkerRequestCancelled(signal: AbortSignal): void {
 function postStreamBatch(
   id: number,
   items: readonly McapPlaybackWorkerStreamItemByType[McapPlaybackWorkerStreamType][],
+  transferables?: readonly Transferable[],
 ) {
   if (items.length === 0) {
     return;
   }
 
-  postResponse({
-    done: false,
-    id,
-    items,
-    ok: true,
-    stream: true,
-  });
+  postResponse(
+    {
+      done: false,
+      id,
+      items,
+      ok: true,
+      stream: true,
+    },
+    transferables,
+  );
 }
 
 // Adjacent-sample navigation flips between a small set of sources; a parked
@@ -433,7 +438,7 @@ function maybePostTransportProgress() {
 
 function postResponse(
   response: McapPlaybackWorkerResponse,
-  transferables = transferablesForResponse(response),
+  transferables: readonly Transferable[] = transferablesForResponse(response),
 ) {
   workerScope.postMessage(response, transferables);
 }

--- a/app/packages/multimodal/src/adapters/mcap/worker/playback-worker.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/playback-worker.ts
@@ -4,6 +4,7 @@ import { EPISODE_READ_CANCELLED_MESSAGE } from "../../../ports";
 import {
   isMcapPlaybackWorkerStreamRequest,
   runMcapPlaybackWorkerStreamRequest,
+  runMcapPlaybackWorkerSynchronizedRequest,
   runMcapPlaybackWorkerUnaryRequest,
 } from "./playback-worker-rpc";
 import {
@@ -201,7 +202,9 @@ async function streamRequest(
   let holdingPrioritySettlements = (pendingPriorityTopics?.size ?? 0) > 0;
   let deliveredFirstPrioritySettlement = false;
 
-  for await (const item of runMcapPlaybackWorkerStreamRequest(mcap, message)) {
+  const acceptItem = (
+    item: McapPlaybackWorkerStreamItemByType[McapPlaybackWorkerStreamType],
+  ): void => {
     throwIfWorkerRequestCancelled(signal);
     const transferables = transferablesForMcapResult(item);
     // The complete blocking prefix is one delivery boundary. Its ordered
@@ -223,7 +226,7 @@ async function streamRequest(
         if (pendingPriorityTopics.size === 0) {
           holdingPrioritySettlements = false;
         }
-        continue;
+        return;
       }
       batch.push(item);
       batchBytes += estimateMcapStreamItemBytes(item);
@@ -236,7 +239,7 @@ async function streamRequest(
         batchBytes = 0;
         holdingPrioritySettlements = false;
       }
-      continue;
+      return;
     }
     // A synchronized current-tick read has one more ownership boundary after
     // the blocking prefix: unresolved stragglers plus the payload-free
@@ -245,7 +248,7 @@ async function streamRequest(
     if (message.type === "readSynchronizedMessages") {
       batch.push(item);
       batchBytes += estimateMcapStreamItemBytes(item);
-      continue;
+      return;
     }
     // Outside the explicit priority boundary, transferable buffers keep their
     // per-item ownership boundary. Plain decoded records can share one
@@ -264,7 +267,7 @@ async function streamRequest(
         },
         transferables,
       );
-      continue;
+      return;
     }
 
     const itemBytes = estimateMcapStreamItemBytes(item);
@@ -291,6 +294,21 @@ async function streamRequest(
       postStreamBatch(message.id, batch);
       batch = [];
       batchBytes = 0;
+    }
+  };
+
+  if (message.type === "readSynchronizedMessages") {
+    await runMcapPlaybackWorkerSynchronizedRequest(
+      mcap,
+      message.payload,
+      acceptItem,
+    );
+  } else {
+    for await (const item of runMcapPlaybackWorkerStreamRequest(
+      mcap,
+      message,
+    )) {
+      acceptItem(item);
     }
   }
   throwIfWorkerRequestCancelled(signal);

--- a/app/packages/multimodal/src/adapters/mcap/worker/playback-worker.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/playback-worker.ts
@@ -139,35 +139,7 @@ async function runAndRespond(
       return;
     }
 
-    let postedProgress = false;
-    const result = await runMcapPlaybackWorkerUnaryRequest(
-      mcap,
-      message,
-      message.type === "readSynchronizedMessages" &&
-        message.payload.earlyDeliveryTopics?.length
-        ? (progress) => {
-            if (postedProgress) return;
-            throwIfWorkerRequestCancelled(context.signal);
-            postedProgress = true;
-            // Clone the single early surface so the worker retains ownership
-            // of every buffer until the complete union transfers normally.
-            try {
-              postResponse(
-                {
-                  id: message.id,
-                  ok: true,
-                  progress: true,
-                  result: progress,
-                },
-                [],
-              );
-            } catch {
-              // Progress is best effort; the terminal union remains
-              // authoritative when an intermediate clone cannot be posted.
-            }
-          }
-        : undefined,
-    );
+    const result = await runMcapPlaybackWorkerUnaryRequest(mcap, message);
     if (
       context.signal.aborted &&
       message.type === "readBoundedMessages" &&

--- a/app/packages/multimodal/src/adapters/mcap/worker/worker-resource-client.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/worker-resource-client.ts
@@ -121,13 +121,11 @@ export function createWorkerResourceClient({
         reuseRetainedDecodedMessage,
       ),
     readSynchronizedMessages: (request, options) => {
-      if (options?.signal) {
-        return client.readSynchronizedMessages(request, options);
-      }
       return client.readSynchronizedMessagesWithReuse(
         request,
         reuseRetainedDecodedMessage,
         options?.onSynchronizedProgress,
+        options,
       );
     },
   };

--- a/app/packages/multimodal/src/adapters/mcap/worker/worker-resource-client.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/worker-resource-client.ts
@@ -13,6 +13,7 @@ import type {
   McapReadSynchronizedMessageBatchRequest,
   McapReadSynchronizedMessagesRequest,
   McapResourceClient,
+  McapSynchronizedMessagesReadOptions,
 } from "../contracts/index";
 import type {
   McapPlaybackWorkerFetchParameters,
@@ -29,6 +30,9 @@ export type McapPlaybackWorkerResourceClient = Omit<
   ): Promise<readonly McapPlaybackWorkerSynchronizedWindow[]>;
   readSynchronizedMessages(
     request: McapReadSynchronizedMessagesRequest,
+    optionsOrProgress?:
+      | McapSynchronizedMessagesReadOptions
+      | ((window: McapPlaybackWorkerSynchronizedWindow) => void),
   ): Promise<McapPlaybackWorkerSynchronizedWindow>;
 };
 
@@ -109,11 +113,19 @@ export function createWorkerResourceClient({
         request,
         reuseRetainedDecodedMessage,
       ),
-    readSynchronizedMessages: (request) =>
-      client.readSynchronizedMessagesWithReuse(
+    readSynchronizedMessages: (request, optionsOrProgress) => {
+      if (
+        optionsOrProgress !== undefined &&
+        typeof optionsOrProgress !== "function"
+      ) {
+        return client.readSynchronizedMessages(request, optionsOrProgress);
+      }
+      return client.readSynchronizedMessagesWithReuse(
         request,
         reuseRetainedDecodedMessage,
-      ),
+        optionsOrProgress,
+      );
+    },
   };
 }
 

--- a/app/packages/multimodal/src/adapters/mcap/worker/worker-resource-client.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/worker-resource-client.ts
@@ -23,7 +23,7 @@ import type {
 
 type McapPlaybackWorkerSynchronizedMessagesReadOptions = Omit<
   McapSynchronizedMessagesReadOptions,
-  "onTopicSettlement"
+  "onTopicSettlement" | "onTopicSettlements"
 > & {
   readonly onTopicSettlement?: (settlement: {
     readonly topic: string;

--- a/app/packages/multimodal/src/adapters/mcap/worker/worker-resource-client.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/worker-resource-client.ts
@@ -23,11 +23,12 @@ import type {
 
 type McapPlaybackWorkerSynchronizedMessagesReadOptions = Omit<
   McapSynchronizedMessagesReadOptions,
-  "onSynchronizedProgress"
+  "onTopicSettlement"
 > & {
-  readonly onSynchronizedProgress?: (
-    window: McapPlaybackWorkerSynchronizedWindow,
-  ) => void;
+  readonly onTopicSettlement?: (settlement: {
+    readonly topic: string;
+    readonly window: McapPlaybackWorkerSynchronizedWindow;
+  }) => void;
 };
 
 export type McapPlaybackWorkerResourceClient = Omit<
@@ -124,7 +125,7 @@ export function createWorkerResourceClient({
       return client.readSynchronizedMessagesWithReuse(
         request,
         reuseRetainedDecodedMessage,
-        options?.onSynchronizedProgress,
+        options?.onTopicSettlement,
         options,
       );
     },

--- a/app/packages/multimodal/src/adapters/mcap/worker/worker-resource-client.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/worker-resource-client.ts
@@ -21,6 +21,15 @@ import type {
   McapRetainedDecodedMessageReference,
 } from "./playback-worker-types";
 
+type McapPlaybackWorkerSynchronizedMessagesReadOptions = Omit<
+  McapSynchronizedMessagesReadOptions,
+  "onSynchronizedProgress"
+> & {
+  readonly onSynchronizedProgress?: (
+    window: McapPlaybackWorkerSynchronizedWindow,
+  ) => void;
+};
+
 export type McapPlaybackWorkerResourceClient = Omit<
   McapResourceClient,
   "readSynchronizedMessageBatch" | "readSynchronizedMessages"
@@ -30,9 +39,7 @@ export type McapPlaybackWorkerResourceClient = Omit<
   ): Promise<readonly McapPlaybackWorkerSynchronizedWindow[]>;
   readSynchronizedMessages(
     request: McapReadSynchronizedMessagesRequest,
-    optionsOrProgress?:
-      | McapSynchronizedMessagesReadOptions
-      | ((window: McapPlaybackWorkerSynchronizedWindow) => void),
+    options?: McapPlaybackWorkerSynchronizedMessagesReadOptions,
   ): Promise<McapPlaybackWorkerSynchronizedWindow>;
 };
 
@@ -113,17 +120,14 @@ export function createWorkerResourceClient({
         request,
         reuseRetainedDecodedMessage,
       ),
-    readSynchronizedMessages: (request, optionsOrProgress) => {
-      if (
-        optionsOrProgress !== undefined &&
-        typeof optionsOrProgress !== "function"
-      ) {
-        return client.readSynchronizedMessages(request, optionsOrProgress);
+    readSynchronizedMessages: (request, options) => {
+      if (options?.signal) {
+        return client.readSynchronizedMessages(request, options);
       }
       return client.readSynchronizedMessagesWithReuse(
         request,
         reuseRetainedDecodedMessage,
-        optionsOrProgress,
+        options?.onSynchronizedProgress,
       );
     },
   };

--- a/app/packages/multimodal/src/adapters/mcap/worker/worker-result-traversal.ts
+++ b/app/packages/multimodal/src/adapters/mcap/worker/worker-result-traversal.ts
@@ -16,6 +16,10 @@ export function messagesFromMcapWorkerResult<Message>(
       messagesFromMcapWorkerResult(item, isMessage),
     );
   }
+  const window = recordFromUnknown(result)?.window;
+  if (window !== undefined) {
+    return messagesFromMcapWorkerResult(window, isMessage);
+  }
   return [];
 }
 

--- a/app/packages/multimodal/src/ports/session.ts
+++ b/app/packages/multimodal/src/ports/session.ts
@@ -284,7 +284,11 @@ export interface SynchronizedPlaybackReadRequest {
   readonly defaultStreamPolicy?: StreamSyncPolicy;
   /** Streams eligible for the first independently useful settlement. */
   readonly firstUsefulSettlementStreams?: readonly StreamId[];
-  /** Receives ordered, authoritative per-stream ownership settlements. */
+  /**
+   * Receives ordered, authoritative per-stream ownership settlements.
+   * Adapters may also report the same settlement through
+   * `onStreamSettlements`, so consumers registering both must be idempotent.
+   */
   readonly onStreamSettlement?: (
     settlement: SynchronizedStreamSettlement,
   ) => void;
@@ -292,6 +296,7 @@ export interface SynchronizedPlaybackReadRequest {
    * Receives one ordered transport delivery group. Every member remains an
    * independent authoritative stream settlement; the group lets consumers
    * publish simultaneously available presentation surfaces in one store turn.
+   * Members may also be reported through `onStreamSettlement` when registered.
    */
   readonly onStreamSettlements?: (
     settlements: readonly SynchronizedStreamSettlement[],

--- a/app/packages/multimodal/src/ports/session.ts
+++ b/app/packages/multimodal/src/ports/session.ts
@@ -282,6 +282,8 @@ export interface SynchronizedStreamSettlement {
 /** One synchronized playback read around a single presentation time. */
 export interface SynchronizedPlaybackReadRequest {
   readonly defaultStreamPolicy?: StreamSyncPolicy;
+  /** Streams eligible for the first independently useful settlement. */
+  readonly firstUsefulSettlementStreams?: readonly StreamId[];
   /** Receives ordered, authoritative per-stream ownership settlements. */
   readonly onStreamSettlement?: (
     settlement: SynchronizedStreamSettlement,

--- a/app/packages/multimodal/src/ports/session.ts
+++ b/app/packages/multimodal/src/ports/session.ts
@@ -286,6 +286,14 @@ export interface SynchronizedPlaybackReadRequest {
   readonly onStreamSettlement?: (
     settlement: SynchronizedStreamSettlement,
   ) => void;
+  /**
+   * Receives one ordered transport delivery group. Every member remains an
+   * independent authoritative stream settlement; the group lets consumers
+   * publish simultaneously available presentation surfaces in one store turn.
+   */
+  readonly onStreamSettlements?: (
+    settlements: readonly SynchronizedStreamSettlement[],
+  ) => void;
   /** Active point-cloud color source requested per stream. */
   readonly pointCloudColorBy?: Readonly<Record<StreamId, string>>;
   /** Stable presentation order for streams that gate current-tick readiness. */

--- a/app/packages/multimodal/src/ports/session.ts
+++ b/app/packages/multimodal/src/ports/session.ts
@@ -274,6 +274,10 @@ export interface TransformPlacementReadResult {
 /** One synchronized playback read around a single presentation time. */
 export interface SynchronizedPlaybackReadRequest {
   readonly defaultStreamPolicy?: StreamSyncPolicy;
+  /** Active surfaces eligible for one cost-selected early delivery. */
+  readonly earlyDeliveryStreams?: readonly StreamId[];
+  /** Receives at most one usable surface while the shared read continues. */
+  readonly onProgress?: (window: SynchronizedFrameWindow) => void;
   /** Active point-cloud color source requested per stream. */
   readonly pointCloudColorBy?: Readonly<Record<StreamId, string>>;
   readonly streamPolicies?: StreamSyncPolicies;

--- a/app/packages/multimodal/src/ports/session.ts
+++ b/app/packages/multimodal/src/ports/session.ts
@@ -271,15 +271,25 @@ export interface TransformPlacementReadResult {
   readonly samples: readonly TransformSample[];
 }
 
+/** One authoritative stream result within a synchronized presentation read. */
+export interface SynchronizedStreamSettlement {
+  /** The only stream whose ownership is settled by this window. */
+  readonly stream: StreamId;
+  /** Authoritative payload, empty result, or diagnostics for `stream`. */
+  readonly window: SynchronizedFrameWindow;
+}
+
 /** One synchronized playback read around a single presentation time. */
 export interface SynchronizedPlaybackReadRequest {
   readonly defaultStreamPolicy?: StreamSyncPolicy;
-  /** Active surfaces eligible for one cost-selected early delivery. */
-  readonly earlyDeliveryStreams?: readonly StreamId[];
-  /** Receives at most one usable surface while the shared read continues. */
-  readonly onProgress?: (window: SynchronizedFrameWindow) => void;
+  /** Receives ordered, authoritative per-stream ownership settlements. */
+  readonly onStreamSettlement?: (
+    settlement: SynchronizedStreamSettlement,
+  ) => void;
   /** Active point-cloud color source requested per stream. */
   readonly pointCloudColorBy?: Readonly<Record<StreamId, string>>;
+  /** Streams eligible for cost-based first settlement. */
+  readonly settlementPriorityStreams?: readonly StreamId[];
   readonly streamPolicies?: StreamSyncPolicies;
   readonly streams: readonly StreamId[];
   readonly signal?: AbortSignal;

--- a/app/packages/multimodal/src/ports/session.ts
+++ b/app/packages/multimodal/src/ports/session.ts
@@ -288,7 +288,7 @@ export interface SynchronizedPlaybackReadRequest {
   ) => void;
   /** Active point-cloud color source requested per stream. */
   readonly pointCloudColorBy?: Readonly<Record<StreamId, string>>;
-  /** Streams eligible for cost-based first settlement. */
+  /** Stable presentation order for streams that gate current-tick readiness. */
   readonly settlementPriorityStreams?: readonly StreamId[];
   readonly streamPolicies?: StreamSyncPolicies;
   readonly streams: readonly StreamId[];

--- a/app/packages/multimodal/src/query/cache-utils.test.ts
+++ b/app/packages/multimodal/src/query/cache-utils.test.ts
@@ -44,4 +44,25 @@ describe("decodedOutputSizeBytes", () => {
       } as DecodedOutput),
     ).toBe(256);
   });
+
+  it("deduplicates shared binary stores without a declared size", () => {
+    const buffer = new ArrayBuffer(256);
+    expect(
+      decodedOutputSizeBytes({
+        resourceHints: { transferables: [buffer] },
+        visualization: { bytes: new Uint8Array(buffer) },
+      } as unknown as DecodedOutput),
+    ).toBe(256);
+  });
+
+  it("does not recount hinted binary metadata", () => {
+    const buffer = new ArrayBuffer(256);
+    expect(
+      decodedOutputSizeBytes({
+        attributes: { bytes: new Uint8Array(buffer) },
+        resourceHints: { sizeBytes: 1, transferables: [buffer] },
+        timing: { bytes: new Uint8Array(buffer) },
+      } as unknown as DecodedOutput),
+    ).toBe(256);
+  });
 });

--- a/app/packages/multimodal/src/query/cache-utils.test.ts
+++ b/app/packages/multimodal/src/query/cache-utils.test.ts
@@ -14,7 +14,7 @@ describe("decodedOutputSizeBytes", () => {
     ).toBe(139);
   });
 
-  it("falls back to structural sizing and saturates oversized totals", () => {
+  it("falls back to structural sizing and clamps oversized totals", () => {
     expect(decodedOutputSizeBytes({ attributes: { x: 1 } })).toBe(8);
     expect(
       decodedOutputSizeBytes({
@@ -27,5 +27,21 @@ describe("decodedOutputSizeBytes", () => {
         timing: { decodeMs: 1 },
       } as DecodedOutput),
     ).toBe(Number.MAX_SAFE_INTEGER);
+  });
+
+  it("counts each retained binary backing store once", () => {
+    const buffer = new ArrayBuffer(256);
+    expect(
+      decodedOutputSizeBytes({
+        resourceHints: {
+          sizeBytes: 1,
+          transferables: [buffer],
+        },
+        visualization: {
+          bytes: new Uint8Array(buffer, 0, 16),
+          kind: "encoded-image",
+        },
+      } as DecodedOutput),
+    ).toBe(256);
   });
 });

--- a/app/packages/multimodal/src/query/cache-utils.ts
+++ b/app/packages/multimodal/src/query/cache-utils.ts
@@ -116,44 +116,59 @@ function estimateFieldSize(
   return ESTIMATED_UNKNOWN_FIELD_SIZE_BYTES;
 }
 
-function measuredBackingStoreBytes(
-  value: unknown,
-  visited = new WeakSet<object>(),
-): number {
-  if (value === undefined || value === null) return 0;
-  if (value instanceof ArrayBuffer) {
-    if (visited.has(value)) return 0;
-    visited.add(value);
-    return value.byteLength;
-  }
-  if (ArrayBuffer.isView(value)) {
-    if (visited.has(value.buffer)) return 0;
-    visited.add(value.buffer);
-    return value.byteLength;
-  }
-  if (typeof value !== "object" || visited.has(value)) return 0;
-  visited.add(value);
-  return Object.values(value).reduce(
-    (size, item) => size + measuredBackingStoreBytes(item, visited),
-    0,
-  );
-}
-
 /** Estimates one decoded output for every cache and retention byte ledger. */
 export function decodedOutputSizeBytes(output: DecodedOutput): number {
-  const hintedBytes = output.resourceHints?.sizeBytes;
+  const hint = output.resourceHints?.sizeBytes;
+  const hintedBytes =
+    typeof hint === "number" && Number.isSafeInteger(hint) && hint >= 0
+      ? hint
+      : undefined;
+  // A decoder hint is not a retained-size contract. Count each underlying
+  // binary store once even when visualization data and transfer hints expose
+  // the same buffer through multiple views.
+  const binaryBytes = estimateUniqueBinaryBytes(output);
+  const payloadBytes = Math.max(hintedBytes ?? 0, binaryBytes);
+  const auxiliaryBytes =
+    estimateFieldSize(output.attributes) + estimateFieldSize(output.timing);
   const bytes =
-    hintedBytes === undefined
+    hint === undefined
       ? estimateFieldSize(output)
-      : Number.isSafeInteger(hintedBytes) && hintedBytes >= 0
-        ? Math.min(
-            Number.MAX_SAFE_INTEGER,
-            hintedBytes +
-              estimateFieldSize(output.attributes) +
-              estimateFieldSize(output.timing),
-          )
-        : measuredBackingStoreBytes(output);
-  return Number.isSafeInteger(bytes) && bytes > 0 ? bytes : 0;
+      : hintedBytes === undefined
+        ? binaryBytes
+        : payloadBytes > 0
+          ? payloadBytes + auxiliaryBytes
+          : 0;
+  if (Number.isNaN(bytes) || bytes <= 0) return 0;
+  return Math.min(Number.MAX_SAFE_INTEGER, Math.ceil(bytes));
+}
+
+function estimateUniqueBinaryBytes(value: unknown): number {
+  const buffers = new Set<ArrayBufferLike>();
+  const visited = new WeakSet<object>();
+  const visit = (candidate: unknown): number => {
+    if (candidate instanceof ArrayBuffer) {
+      if (buffers.has(candidate)) return 0;
+      buffers.add(candidate);
+      return candidate.byteLength;
+    }
+    if (ArrayBuffer.isView(candidate)) {
+      const buffer = candidate.buffer;
+      if (buffers.has(buffer)) return 0;
+      buffers.add(buffer);
+      return buffer.byteLength;
+    }
+    if (!candidate || typeof candidate !== "object") return 0;
+    if (visited.has(candidate)) return 0;
+    visited.add(candidate);
+    if (Array.isArray(candidate)) {
+      return candidate.reduce((bytes, item) => bytes + visit(item), 0);
+    }
+    return Object.values(candidate).reduce(
+      (bytes, item) => bytes + visit(item),
+      0,
+    );
+  };
+  return visit(value);
 }
 
 function normalizeCacheSizeBytes(value: number, minimum: number): number {

--- a/app/packages/multimodal/src/query/cache-utils.ts
+++ b/app/packages/multimodal/src/query/cache-utils.ts
@@ -68,7 +68,7 @@ export function serializeCacheKey(parts: readonly (string | null)[]): string {
 /**
  * Estimates nested decoded payload size for cache eviction.
  */
-function estimateFieldSize(
+function estimateStructuralFieldSize(
   value: unknown,
   visited = new WeakSet<object>(),
 ): number {
@@ -76,10 +76,10 @@ function estimateFieldSize(
     return 0;
   }
   if (value instanceof ArrayBuffer) {
-    return value.byteLength;
+    return 0;
   }
   if (ArrayBuffer.isView(value)) {
-    return value.byteLength;
+    return 0;
   }
   if (typeof value === "string") {
     // Cache sizing is an eviction heuristic, not exact encoded-byte accounting.
@@ -102,13 +102,13 @@ function estimateFieldSize(
   }
   if (Array.isArray(value)) {
     return value.reduce(
-      (size, item) => size + estimateFieldSize(item, visited),
+      (size, item) => size + estimateStructuralFieldSize(item, visited),
       0,
     );
   }
   if (typeof value === "object") {
     return Object.values(value).reduce(
-      (size, item) => size + estimateFieldSize(item, visited),
+      (size, item) => size + estimateStructuralFieldSize(item, visited),
       0,
     );
   }
@@ -129,12 +129,13 @@ export function decodedOutputSizeBytes(output: DecodedOutput): number {
   const binaryBytes = estimateUniqueBinaryBytes(output);
   const payloadBytes = Math.max(hintedBytes ?? 0, binaryBytes);
   const auxiliaryBytes =
-    estimateFieldSize(output.attributes) + estimateFieldSize(output.timing);
+    estimateStructuralFieldSize(output.attributes) +
+    estimateStructuralFieldSize(output.timing);
   const bytes =
     hint === undefined
-      ? estimateFieldSize(output)
+      ? estimateStructuralFieldSize(output) + binaryBytes
       : hintedBytes === undefined
-        ? binaryBytes
+        ? binaryBytes + auxiliaryBytes
         : payloadBytes > 0
           ? payloadBytes + auxiliaryBytes
           : 0;

--- a/app/packages/multimodal/src/runtime/episode-stream-cache.test.ts
+++ b/app/packages/multimodal/src/runtime/episode-stream-cache.test.ts
@@ -375,6 +375,32 @@ describe("EpisodeStreamCache", () => {
     ]);
   });
 
+  it("accepts a new source timeline after reset", () => {
+    const first = createTimelineIndex(
+      { endNs: 2_000_000_000n, startNs: 0n },
+      1,
+    );
+    const second = createTimelineIndex(
+      { endNs: 12_000_000_000n, startNs: 10_000_000_000n },
+      1,
+    );
+    const cache = new EpisodeStreamCache();
+    cache.configureTimeline(first);
+    cache.set(0n, MESSAGE);
+
+    cache.reset();
+    cache.set(10_000_000_000n, {
+      ...MESSAGE,
+      timestampNs: 10_000_000_000n,
+    });
+
+    expect(cache.has(0n)).toBe(false);
+    expect(cache.has(10_000_000_000n)).toBe(true);
+    expect(cache.cachedTickIndexRanges(second)).toEqual([
+      { endIndex: 0, startIndex: 0 },
+    ]);
+  });
+
   it("bounds metadata-only placements and canonicalizes repeated payloads", () => {
     const shared = { ...MESSAGE, recordId: "shared" };
     const cache = new EpisodeStreamCache(3);

--- a/app/packages/multimodal/src/runtime/episode-stream-cache.ts
+++ b/app/packages/multimodal/src/runtime/episode-stream-cache.ts
@@ -453,6 +453,12 @@ export class EpisodeStreamCache {
     this.bumpRevision();
   }
 
+  /** Clears entries and releases timeline identity at a source boundary. */
+  reset(): void {
+    this.clear();
+    this.coverage = null;
+  }
+
   private retainEntry(entry: CacheEntry): void {
     this._placementBytes += entry.placementBytes;
     if (!entry.msg) return;

--- a/app/packages/multimodal/src/runtime/read-policy.test.ts
+++ b/app/packages/multimodal/src/runtime/read-policy.test.ts
@@ -132,6 +132,66 @@ describe("session read policy", () => {
     });
   });
 
+  it("settles generic current reads in explicit priority order", async () => {
+    const streamIds = ["camera", "lidar"];
+    const read = vi.fn(async function* (readRequest: ReadRequest) {
+      const stream = readRequest.streams[0];
+      if (!stream) return;
+      yield {
+        frames: [
+          {
+            output: { resourceHints: { transferables: [] } },
+            streamId: stream,
+            timestampNs: 5n,
+          },
+        ],
+        stream,
+      };
+    });
+    const base = sessionWithBatches([]);
+    const session: EpisodeSession = {
+      ...base,
+      manifest: {
+        ...base.manifest,
+        streams: streamIds.map((id) => ({
+          id,
+          kind: "unknown" as const,
+          payload: { encoding: "fixture" },
+          sourceName: `/${id}`,
+          timeRange: request.window,
+        })),
+      },
+      read,
+    };
+    const deliveryGroups: string[][] = [];
+    const singularDeliveries: string[] = [];
+
+    const windows = await readSynchronizedPlaybackBatchFallback(
+      session,
+      { streams: streamIds, timeNs: [5n] },
+      {},
+      {
+        onStreamSettlement: ({ stream }) => singularDeliveries.push(stream),
+        onStreamSettlements: (settlements) =>
+          deliveryGroups.push(settlements.map(({ stream }) => stream)),
+        settlementPriorityStreams: ["lidar", "camera", "lidar", "absent"],
+      },
+    );
+
+    expect(read.mock.calls.map(([readRequest]) => readRequest.streams)).toEqual(
+      [["lidar"], ["camera"]],
+    );
+    expect(deliveryGroups).toEqual([["lidar"], ["camera"]]);
+    expect(singularDeliveries).toEqual(["lidar", "camera"]);
+    expect(windows[0]).toMatchObject({
+      framesByStream: {
+        camera: [expect.objectContaining({ timestampNs: 5n })],
+        lidar: [expect.objectContaining({ timestampNs: 5n })],
+      },
+      timeNs: 5n,
+    });
+  });
+
   it("returns the correct latest predecessor at the generic boundary", async () => {
     const frames = Array.from(
       { length: GENERIC_PLAYBACK_FALLBACK_MAX_MESSAGES_PER_STREAM },

--- a/app/packages/multimodal/src/runtime/read-policy.test.ts
+++ b/app/packages/multimodal/src/runtime/read-policy.test.ts
@@ -192,6 +192,22 @@ describe("session read policy", () => {
     });
   });
 
+  it("does not emit single-tick settlements for a multi-tick batch", async () => {
+    const onStreamSettlement = vi.fn();
+    const onStreamSettlements = vi.fn();
+
+    const windows = await readSynchronizedPlaybackBatchFallback(
+      longHistorySession([1n, 2n]),
+      { streams: ["stream"], timeNs: [1n, 2n] },
+      {},
+      { onStreamSettlement, onStreamSettlements },
+    );
+
+    expect(windows).toHaveLength(2);
+    expect(onStreamSettlement).not.toHaveBeenCalled();
+    expect(onStreamSettlements).not.toHaveBeenCalled();
+  });
+
   it("returns the correct latest predecessor at the generic boundary", async () => {
     const frames = Array.from(
       { length: GENERIC_PLAYBACK_FALLBACK_MAX_MESSAGES_PER_STREAM },

--- a/app/packages/multimodal/src/runtime/read-policy.ts
+++ b/app/packages/multimodal/src/runtime/read-policy.ts
@@ -227,8 +227,11 @@ export async function readSynchronizedPlaybackBatchFallback(
     session,
     signal: options.signal,
     onStreamComplete:
-      settlementOptions.onStreamSettlement ||
-      settlementOptions.onStreamSettlements
+      (settlementOptions.onStreamSettlement ||
+        settlementOptions.onStreamSettlements) &&
+      // Per-stream settlements describe one tick. Batched multi-tick reads
+      // have no single authoritative window to report.
+      request.timeNs.length === 1
         ? (stream, streamBatches) => {
             const window = resolved[0];
             if (!window) return;

--- a/app/packages/multimodal/src/runtime/read-policy.ts
+++ b/app/packages/multimodal/src/runtime/read-policy.ts
@@ -181,6 +181,7 @@ export async function readSynchronizedPlaybackFallback(
     { priority: "current", signal: request.signal },
     {
       onStreamSettlement: request.onStreamSettlement,
+      onStreamSettlements: request.onStreamSettlements,
       settlementPriorityStreams: request.settlementPriorityStreams,
     },
   );
@@ -194,6 +195,7 @@ export async function readSynchronizedPlaybackBatchFallback(
   options: SynchronizedPlaybackReadOptions = {},
   settlementOptions: {
     readonly onStreamSettlement?: SynchronizedPlaybackReadRequest["onStreamSettlement"];
+    readonly onStreamSettlements?: SynchronizedPlaybackReadRequest["onStreamSettlements"];
     readonly settlementPriorityStreams?: readonly string[];
   } = {},
 ): Promise<readonly SynchronizedFrameWindow[]> {
@@ -224,32 +226,36 @@ export async function readSynchronizedPlaybackBatchFallback(
     priority: options.priority,
     session,
     signal: options.signal,
-    onStreamComplete: settlementOptions.onStreamSettlement
-      ? (stream, streamBatches) => {
-          const window = resolved[0];
-          if (!window) return;
-          const policy = window.streamPolicies[stream];
-          settlementOptions.onStreamSettlement?.({
-            stream,
-            window: selectPlaybackWindow(
-              collectFramesByStream(streamBatches, [stream]),
-              [stream],
-              sourceNames,
-              {
-                endNs: policy.endNs,
-                startNs: readStartForPolicy(
-                  session.manifest.timeRange.startNs,
-                  streamsById,
-                  stream,
-                  policy,
-                ),
-                streamPolicies: { [stream]: policy },
-                timeNs: window.timeNs,
-              },
-            ),
-          });
-        }
-      : undefined,
+    onStreamComplete:
+      settlementOptions.onStreamSettlement ||
+      settlementOptions.onStreamSettlements
+        ? (stream, streamBatches) => {
+            const window = resolved[0];
+            if (!window) return;
+            const policy = window.streamPolicies[stream];
+            const settlement = {
+              stream,
+              window: selectPlaybackWindow(
+                collectFramesByStream(streamBatches, [stream]),
+                [stream],
+                sourceNames,
+                {
+                  endNs: policy.endNs,
+                  startNs: readStartForPolicy(
+                    session.manifest.timeRange.startNs,
+                    streamsById,
+                    stream,
+                    policy,
+                  ),
+                  streamPolicies: { [stream]: policy },
+                  timeNs: window.timeNs,
+                },
+              ),
+            };
+            settlementOptions.onStreamSettlements?.([settlement]);
+            settlementOptions.onStreamSettlement?.(settlement);
+          }
+        : undefined,
     streams: readStreams,
     windowForStream: (stream) => ({
       endNs: maxBigInt(resolved.map((window) => window.endNs)),

--- a/app/packages/multimodal/src/runtime/read-policy.ts
+++ b/app/packages/multimodal/src/runtime/read-policy.ts
@@ -179,6 +179,10 @@ export async function readSynchronizedPlaybackFallback(
     session,
     { ...request, timeNs: [request.timeNs] },
     { priority: "current", signal: request.signal },
+    {
+      onStreamSettlement: request.onStreamSettlement,
+      settlementPriorityStreams: request.settlementPriorityStreams,
+    },
   );
   return windows[0] ?? emptyPlaybackWindow(request.timeNs);
 }
@@ -188,6 +192,10 @@ export async function readSynchronizedPlaybackBatchFallback(
   session: EpisodeSession,
   request: SynchronizedPlaybackBatchReadRequest,
   options: SynchronizedPlaybackReadOptions = {},
+  settlementOptions: {
+    readonly onStreamSettlement?: SynchronizedPlaybackReadRequest["onStreamSettlement"];
+    readonly settlementPriorityStreams?: readonly string[];
+  } = {},
 ): Promise<readonly SynchronizedFrameWindow[]> {
   if (request.timeNs.length === 0) return [];
   if (request.streams.length === 0) {
@@ -203,13 +211,46 @@ export async function readSynchronizedPlaybackBatchFallback(
       timeNs,
     }),
   );
+  const sourceNames = new Map(
+    session.manifest.streams.map((stream) => [stream.id, stream.sourceName]),
+  );
+  const readStreams = prioritizedStreams(
+    request.streams,
+    settlementOptions.settlementPriorityStreams,
+  );
   const batches = await readCompleteBoundedStreams({
     maxMessagesPerStream: GENERIC_PLAYBACK_FALLBACK_MAX_MESSAGES_PER_STREAM,
     operation: "generic-playback-fallback",
     priority: options.priority,
     session,
     signal: options.signal,
-    streams: request.streams,
+    onStreamComplete: settlementOptions.onStreamSettlement
+      ? (stream, streamBatches) => {
+          const window = resolved[0];
+          if (!window) return;
+          const policy = window.streamPolicies[stream];
+          settlementOptions.onStreamSettlement?.({
+            stream,
+            window: selectPlaybackWindow(
+              collectFramesByStream(streamBatches, [stream]),
+              [stream],
+              sourceNames,
+              {
+                endNs: policy.endNs,
+                startNs: readStartForPolicy(
+                  session.manifest.timeRange.startNs,
+                  streamsById,
+                  stream,
+                  policy,
+                ),
+                streamPolicies: { [stream]: policy },
+                timeNs: window.timeNs,
+              },
+            ),
+          });
+        }
+      : undefined,
+    streams: readStreams,
     windowForStream: (stream) => ({
       endNs: maxBigInt(resolved.map((window) => window.endNs)),
       startNs: minBigInt(
@@ -225,9 +266,6 @@ export async function readSynchronizedPlaybackBatchFallback(
     }),
   });
   const framesByStream = collectFramesByStream(batches, request.streams);
-  const sourceNames = new Map(
-    session.manifest.streams.map((stream) => [stream.id, stream.sourceName]),
-  );
   return resolved.map((window) =>
     selectPlaybackWindow(framesByStream, request.streams, sourceNames, window),
   );
@@ -236,6 +274,7 @@ export async function readSynchronizedPlaybackBatchFallback(
 async function readCompleteBoundedStreams({
   maxMessagesPerStream,
   operation,
+  onStreamComplete,
   priority,
   session,
   signal,
@@ -244,6 +283,10 @@ async function readCompleteBoundedStreams({
 }: {
   readonly maxMessagesPerStream: number;
   readonly operation: string;
+  readonly onStreamComplete?: (
+    stream: string,
+    batches: readonly FrameBatch[],
+  ) => void;
   readonly priority: ReadRequest["priority"];
   readonly session: EpisodeSession;
   readonly signal?: AbortSignal;
@@ -254,6 +297,7 @@ async function readCompleteBoundedStreams({
   for (const stream of streams) {
     throwIfAborted(signal);
     let messageCount = 0;
+    const streamBatches: FrameBatch[] = [];
     for await (const batch of session.read({
       // The extra message is a completeness probe. It is never published.
       limit: maxMessagesPerStream + 1,
@@ -275,10 +319,27 @@ async function readCompleteBoundedStreams({
         }
         admitted.push(frame);
       }
-      if (admitted.length > 0) batches.push({ frames: admitted, stream });
+      if (admitted.length > 0) {
+        const admittedBatch = { frames: admitted, stream };
+        batches.push(admittedBatch);
+        streamBatches.push(admittedBatch);
+      }
     }
+    onStreamComplete?.(stream, streamBatches);
   }
   return batches;
+}
+
+function prioritizedStreams(
+  streams: readonly string[],
+  priorityStreams: readonly string[] | undefined,
+): string[] {
+  if (!priorityStreams?.length) return [...streams];
+  const eligible = new Set(priorityStreams);
+  return [
+    ...streams.filter((stream) => eligible.has(stream)),
+    ...streams.filter((stream) => !eligible.has(stream)),
+  ];
 }
 
 interface ResolvedPlaybackWindow {

--- a/app/packages/multimodal/src/runtime/read-policy.ts
+++ b/app/packages/multimodal/src/runtime/read-policy.ts
@@ -341,11 +341,12 @@ function prioritizedStreams(
   priorityStreams: readonly string[] | undefined,
 ): string[] {
   if (!priorityStreams?.length) return [...streams];
-  const eligible = new Set(priorityStreams);
-  return [
-    ...streams.filter((stream) => eligible.has(stream)),
-    ...streams.filter((stream) => !eligible.has(stream)),
-  ];
+  const requested = new Set(streams);
+  const priority = [...new Set(priorityStreams)].filter((stream) =>
+    requested.has(stream),
+  );
+  const prioritized = new Set(priority);
+  return [...priority, ...streams.filter((stream) => !prioritized.has(stream))];
 }
 
 interface ResolvedPlaybackWindow {

--- a/app/packages/multimodal/src/views/episode/playback/data-stream-prefetch.test.ts
+++ b/app/packages/multimodal/src/views/episode/playback/data-stream-prefetch.test.ts
@@ -219,7 +219,9 @@ describe("data stream prefetcher", () => {
     expect(harness.prefetcher.fetchCurrentFrame(0n, [IMAGE], [IMAGE])).toBe(
       true,
     );
-    harness.store.set(playheadAtom, 0.5);
+    const movedTick = harness.index.tickAt(1);
+    if (movedTick === undefined) throw new Error("expected a second tick");
+    harness.store.set(playheadAtom, harness.index.nsToSec(movedTick));
     expect(publishProgress).toBeTypeOf("function");
     if (!publishProgress) throw new Error("expected progress callback");
     publishProgress(windowAt(0n, [frame(IMAGE, 0n)]));
@@ -445,9 +447,11 @@ function createHarness({
   const fetchState = createDataStreamFetchState();
   const lastFrames = new Map<string, StreamPlaybackFrame<unknown>>();
   const rebalanceDecodedCaches = vi.fn();
+  const index = createTimelineIndex({ endNs: 1_000_000_000n, startNs: 0n }, 2);
   const harness = {
     caches,
     fetchState,
+    index,
     lastFrames,
     prefetcher: undefined as unknown as ReturnType<
       typeof createDataStreamPrefetcher
@@ -459,8 +463,7 @@ function createHarness({
   harness.prefetcher = createDataStreamPrefetcher({
     caches,
     fetchState,
-    getIndex: () =>
-      createTimelineIndex({ endNs: 1_000_000_000n, startNs: 0n }, 2),
+    getIndex: () => index,
     getSourceEpoch: () => harness.sourceEpoch,
     getStreamPolicies: () => ({}) as StreamSyncPolicies,
     isStreamTimeAvailable,

--- a/app/packages/multimodal/src/views/episode/playback/data-stream-prefetch.test.ts
+++ b/app/packages/multimodal/src/views/episode/playback/data-stream-prefetch.test.ts
@@ -183,7 +183,9 @@ describe("data stream prefetcher", () => {
     harness.caches.get(LIDAR)?.subscribe();
 
     expect(
-      harness.prefetcher.fetchCurrentFrame(0n, [IMAGE, LIDAR], [IMAGE, LIDAR]),
+      harness.prefetcher.fetchCurrentFrame(0n, [IMAGE, LIDAR], {
+        settlementPriorityStreams: [IMAGE, LIDAR],
+      }),
     ).toBe(true);
     expect(publishSettlement).toBeTypeOf("function");
     if (!publishSettlement) throw new Error("expected settlement callback");
@@ -227,7 +229,9 @@ describe("data stream prefetcher", () => {
     harness.caches.get(LIDAR)?.subscribe();
 
     expect(
-      harness.prefetcher.fetchCurrentFrame(0n, [IMAGE, LIDAR], [IMAGE, LIDAR]),
+      harness.prefetcher.fetchCurrentFrame(0n, [IMAGE, LIDAR], {
+        settlementPriorityStreams: [IMAGE, LIDAR],
+      }),
     ).toBe(true);
     expect(publishSettlements).toBeTypeOf("function");
     publishSettlements?.([
@@ -261,12 +265,10 @@ describe("data stream prefetcher", () => {
     harness.caches.get(LIDAR)?.subscribe();
 
     expect(
-      harness.prefetcher.fetchCurrentFrame(
-        0n,
-        [IMAGE, LIDAR],
-        [IMAGE, LIDAR],
-        [IMAGE],
-      ),
+      harness.prefetcher.fetchCurrentFrame(0n, [IMAGE, LIDAR], {
+        firstUsefulSettlementStreams: [IMAGE],
+        settlementPriorityStreams: [IMAGE, LIDAR],
+      }),
     ).toBe(true);
     publishSettlements?.([
       { stream: IMAGE, window: windowAt(0n, [frame(IMAGE, 0n)]) },
@@ -285,6 +287,38 @@ describe("data stream prefetcher", () => {
     expect(getStreamValue(harness.store, LIDAR)).not.toBeNull();
   });
 
+  it("releases later priority presentation after empty first-useful results", async () => {
+    const terminal = deferred<SynchronizedFrameWindow>();
+    let publishSettlements:
+      | ((settlements: readonly SynchronizedStreamSettlement[]) => void)
+      | undefined;
+    const harness = createHarness({
+      readSynchronized: vi.fn((request) => {
+        publishSettlements = request.onStreamSettlements;
+        return terminal.promise;
+      }),
+    });
+    harness.caches.get(IMAGE)?.subscribe();
+    harness.caches.get(LIDAR)?.subscribe();
+
+    expect(
+      harness.prefetcher.fetchCurrentFrame(0n, [IMAGE, LIDAR], {
+        firstUsefulSettlementStreams: [IMAGE],
+        settlementPriorityStreams: [IMAGE, LIDAR],
+      }),
+    ).toBe(true);
+    publishSettlements?.([{ stream: IMAGE, window: windowAt(0n, []) }]);
+    expect(getStreamValue(harness.store, IMAGE)).toBeNull();
+
+    publishSettlements?.([
+      { stream: LIDAR, window: windowAt(0n, [frame(LIDAR, 0n)]) },
+    ]);
+    expect(getStreamValue(harness.store, LIDAR)).not.toBeNull();
+
+    terminal.resolve(windowAt(0n, []));
+    await settle();
+  });
+
   it("does not preview a current-frame result after the playhead moves", async () => {
     const terminal = deferred<SynchronizedFrameWindow>();
     let publishSettlement:
@@ -298,9 +332,11 @@ describe("data stream prefetcher", () => {
     });
     harness.caches.get(IMAGE)?.subscribe();
 
-    expect(harness.prefetcher.fetchCurrentFrame(0n, [IMAGE], [IMAGE])).toBe(
-      true,
-    );
+    expect(
+      harness.prefetcher.fetchCurrentFrame(0n, [IMAGE], {
+        settlementPriorityStreams: [IMAGE],
+      }),
+    ).toBe(true);
     const movedTick = harness.index.tickAt(1);
     if (movedTick === undefined) throw new Error("expected a second tick");
     harness.store.set(playheadAtom, harness.index.nsToSec(movedTick));
@@ -372,12 +408,10 @@ describe("data stream prefetcher", () => {
     harness.caches.get(LIDAR)?.subscribe();
 
     expect(
-      harness.prefetcher.fetchCurrentFrame(
-        0n,
-        [IMAGE, LIDAR],
-        [IMAGE, LIDAR],
-        [IMAGE],
-      ),
+      harness.prefetcher.fetchCurrentFrame(0n, [IMAGE, LIDAR], {
+        firstUsefulSettlementStreams: [IMAGE],
+        settlementPriorityStreams: [IMAGE, LIDAR],
+      }),
     ).toBe(true);
     const image = frame(IMAGE, 0n);
     const lidar = frame(LIDAR, 0n);

--- a/app/packages/multimodal/src/views/episode/playback/data-stream-prefetch.test.ts
+++ b/app/packages/multimodal/src/views/episode/playback/data-stream-prefetch.test.ts
@@ -212,6 +212,40 @@ describe("data stream prefetcher", () => {
     expect(harness.rebalanceDecodedCaches).toHaveBeenCalledOnce();
   });
 
+  it("publishes one authoritative settlement delivery group in one store turn", async () => {
+    const terminal = deferred<SynchronizedFrameWindow>();
+    let publishSettlements:
+      | ((settlements: readonly SynchronizedStreamSettlement[]) => void)
+      | undefined;
+    const harness = createHarness({
+      readSynchronized: vi.fn((request) => {
+        publishSettlements = request.onStreamSettlements;
+        return terminal.promise;
+      }),
+    });
+    harness.caches.get(IMAGE)?.subscribe();
+    harness.caches.get(LIDAR)?.subscribe();
+
+    expect(
+      harness.prefetcher.fetchCurrentFrame(0n, [IMAGE, LIDAR], [IMAGE, LIDAR]),
+    ).toBe(true);
+    expect(publishSettlements).toBeTypeOf("function");
+    publishSettlements?.([
+      { stream: IMAGE, window: windowAt(0n, [frame(IMAGE, 0n)]) },
+      { stream: LIDAR, window: windowAt(0n, [frame(LIDAR, 0n)]) },
+    ]);
+
+    expect(getStreamValue(harness.store, IMAGE)).not.toBeNull();
+    expect(getStreamValue(harness.store, LIDAR)).not.toBeNull();
+    expect(harness.prefetcher.isStreamPending("0", IMAGE)).toBe(false);
+    expect(harness.prefetcher.isStreamPending("0", LIDAR)).toBe(false);
+    expect(harness.publishStreamStatuses).toHaveBeenCalledOnce();
+    expect(harness.publishStreamStatuses).toHaveBeenCalledWith([IMAGE, LIDAR]);
+
+    terminal.resolve(windowAt(0n, []));
+    await settle();
+  });
+
   it("does not preview a current-frame result after the playhead moves", async () => {
     const terminal = deferred<SynchronizedFrameWindow>();
     let publishSettlement:

--- a/app/packages/multimodal/src/views/episode/playback/data-stream-prefetch.test.ts
+++ b/app/packages/multimodal/src/views/episode/playback/data-stream-prefetch.test.ts
@@ -15,6 +15,7 @@ import type {
 import {
   EpisodeReadCancelledError,
   type PlaybackReadCapability,
+  type SynchronizedStreamSettlement,
 } from "../../../ports";
 import { VISUALIZATION_KIND } from "../../../visualization";
 import { createTimelineIndex, EpisodeStreamCache } from "../../../runtime";
@@ -167,14 +168,14 @@ describe("data stream prefetcher", () => {
     expect(harness.caches.get(IMAGE)?.has(0n)).toBe(false);
   });
 
-  it("publishes one preview without releasing union ownership", async () => {
+  it("caches and releases only each authoritatively settled stream", async () => {
     const terminal = deferred<SynchronizedFrameWindow>();
-    let publishProgress:
-      | ((window: SynchronizedFrameWindow) => void)
+    let publishSettlement:
+      | ((settlement: SynchronizedStreamSettlement) => void)
       | undefined;
     const harness = createHarness({
       readSynchronized: vi.fn((request) => {
-        publishProgress = request.onProgress;
+        publishSettlement = request.onStreamSettlement;
         return terminal.promise;
       }),
     });
@@ -184,20 +185,24 @@ describe("data stream prefetcher", () => {
     expect(
       harness.prefetcher.fetchCurrentFrame(0n, [IMAGE, LIDAR], [IMAGE, LIDAR]),
     ).toBe(true);
-    expect(publishProgress).toBeTypeOf("function");
-    if (!publishProgress) throw new Error("expected progress callback");
-    publishProgress(windowAt(0n, [frame(IMAGE, 0n)]));
+    expect(publishSettlement).toBeTypeOf("function");
+    if (!publishSettlement) throw new Error("expected settlement callback");
+    const settledImage = frame(IMAGE, 0n);
+    publishSettlement({
+      stream: IMAGE,
+      window: windowAt(0n, [settledImage]),
+    });
 
     expect(getStreamValue(harness.store, IMAGE)).not.toBeNull();
     expect(getStreamValue(harness.store, LIDAR)).toBeNull();
-    expect(harness.caches.get(IMAGE)?.has(0n)).toBe(false);
-    expect(harness.prefetcher.isStreamPending("0", IMAGE)).toBe(true);
+    expect(harness.caches.get(IMAGE)?.get(0n)).toBe(settledImage);
+    expect(harness.prefetcher.isStreamPending("0", IMAGE)).toBe(false);
     expect(harness.prefetcher.isStreamPending("0", LIDAR)).toBe(true);
 
     terminal.resolve(windowAt(0n, [frame(IMAGE, 0n), frame(LIDAR, 0n)]));
     await settle();
 
-    expect(harness.caches.get(IMAGE)?.has(0n)).toBe(true);
+    expect(harness.caches.get(IMAGE)?.get(0n)).toBe(settledImage);
     expect(harness.caches.get(LIDAR)?.has(0n)).toBe(true);
     expect(harness.prefetcher.isStreamPending("0", IMAGE)).toBe(false);
     expect(harness.prefetcher.isStreamPending("0", LIDAR)).toBe(false);
@@ -205,12 +210,12 @@ describe("data stream prefetcher", () => {
 
   it("does not preview a current-frame result after the playhead moves", async () => {
     const terminal = deferred<SynchronizedFrameWindow>();
-    let publishProgress:
-      | ((window: SynchronizedFrameWindow) => void)
+    let publishSettlement:
+      | ((settlement: SynchronizedStreamSettlement) => void)
       | undefined;
     const harness = createHarness({
       readSynchronized: vi.fn((request) => {
-        publishProgress = request.onProgress;
+        publishSettlement = request.onStreamSettlement;
         return terminal.promise;
       }),
     });
@@ -222,14 +227,87 @@ describe("data stream prefetcher", () => {
     const movedTick = harness.index.tickAt(1);
     if (movedTick === undefined) throw new Error("expected a second tick");
     harness.store.set(playheadAtom, harness.index.nsToSec(movedTick));
-    expect(publishProgress).toBeTypeOf("function");
-    if (!publishProgress) throw new Error("expected progress callback");
-    publishProgress(windowAt(0n, [frame(IMAGE, 0n)]));
+    expect(publishSettlement).toBeTypeOf("function");
+    if (!publishSettlement) throw new Error("expected settlement callback");
+    publishSettlement({
+      stream: IMAGE,
+      window: windowAt(0n, [frame(IMAGE, 0n)]),
+    });
     expect(getStreamValue(harness.store, IMAGE)).toBeNull();
 
     terminal.resolve(windowAt(0n, [frame(IMAGE, 0n)]));
     await settle();
     expect(getStreamValue(harness.store, IMAGE)).toBeNull();
+  });
+
+  it("retries only a topic that failed after a sibling settled", async () => {
+    let attempt = 0;
+    const readSynchronized = vi.fn<PlaybackReadCapability["readSynchronized"]>(
+      async (request) => {
+        attempt += 1;
+        if (attempt === 1) {
+          request.onStreamSettlement?.({
+            stream: LIDAR,
+            window: windowAt(request.timeNs, [frame(LIDAR, request.timeNs)]),
+          });
+          request.onStreamSettlement?.({
+            stream: IMAGE,
+            window: windowAt(request.timeNs, [], [IMAGE]),
+          });
+        } else {
+          request.onStreamSettlement?.({
+            stream: IMAGE,
+            window: windowAt(request.timeNs, [frame(IMAGE, request.timeNs)]),
+          });
+        }
+        return windowAt(request.timeNs, []);
+      },
+    );
+    const harness = createHarness({ readSynchronized });
+    harness.caches.get(IMAGE)?.subscribe();
+    harness.caches.get(LIDAR)?.subscribe();
+
+    expect(harness.prefetcher.fetchCurrentFrame(0n, [IMAGE, LIDAR])).toBe(true);
+    await settle();
+    expect(harness.caches.get(LIDAR)?.has(0n)).toBe(true);
+    expect(harness.caches.get(IMAGE)?.has(0n)).toBe(false);
+    expect(harness.fetchState.failureStreaks.get(IMAGE)).toBe(1);
+
+    expect(harness.prefetcher.fetchCurrentFrame(0n, [IMAGE, LIDAR])).toBe(true);
+    await settle();
+    expect(readSynchronized.mock.calls[1]?.[0].streams).toEqual([IMAGE]);
+    expect(harness.caches.get(IMAGE)?.has(0n)).toBe(true);
+    expect(harness.fetchState.failureStreaks.has(IMAGE)).toBe(false);
+  });
+
+  it("keeps a partial settlement authoritative when the union is cancelled", async () => {
+    const terminal = deferred<SynchronizedFrameWindow>();
+    let publishSettlement:
+      | ((settlement: SynchronizedStreamSettlement) => void)
+      | undefined;
+    const harness = createHarness({
+      readSynchronized: vi.fn((request) => {
+        publishSettlement = request.onStreamSettlement;
+        return terminal.promise;
+      }),
+    });
+    harness.caches.get(IMAGE)?.subscribe();
+    harness.caches.get(LIDAR)?.subscribe();
+
+    expect(harness.prefetcher.fetchCurrentFrame(0n, [IMAGE, LIDAR])).toBe(true);
+    const image = frame(IMAGE, 0n);
+    publishSettlement?.({
+      stream: IMAGE,
+      window: windowAt(0n, [image]),
+    });
+    terminal.reject(new EpisodeReadCancelledError());
+    await settle();
+
+    expect(harness.caches.get(IMAGE)?.get(0n)).toBe(image);
+    expect(harness.caches.get(LIDAR)?.has(0n)).toBe(false);
+    expect(harness.prefetcher.isStreamPending("0", IMAGE)).toBe(false);
+    expect(harness.prefetcher.isStreamPending("0", LIDAR)).toBe(false);
+    expect(harness.fetchState.failureStreaks).toEqual(new Map());
   });
 
   it("returns late loop-continuation reads to ordinary cache ownership", async () => {

--- a/app/packages/multimodal/src/views/episode/playback/data-stream-prefetch.test.ts
+++ b/app/packages/multimodal/src/views/episode/playback/data-stream-prefetch.test.ts
@@ -359,29 +359,39 @@ describe("data stream prefetcher", () => {
 
   it("keeps a partial settlement authoritative when the union is cancelled", async () => {
     const terminal = deferred<SynchronizedFrameWindow>();
-    let publishSettlement:
-      | ((settlement: SynchronizedStreamSettlement) => void)
+    let publishSettlements:
+      | ((settlements: readonly SynchronizedStreamSettlement[]) => void)
       | undefined;
     const harness = createHarness({
       readSynchronized: vi.fn((request) => {
-        publishSettlement = request.onStreamSettlement;
+        publishSettlements = request.onStreamSettlements;
         return terminal.promise;
       }),
     });
     harness.caches.get(IMAGE)?.subscribe();
     harness.caches.get(LIDAR)?.subscribe();
 
-    expect(harness.prefetcher.fetchCurrentFrame(0n, [IMAGE, LIDAR])).toBe(true);
+    expect(
+      harness.prefetcher.fetchCurrentFrame(
+        0n,
+        [IMAGE, LIDAR],
+        [IMAGE, LIDAR],
+        [IMAGE],
+      ),
+    ).toBe(true);
     const image = frame(IMAGE, 0n);
-    publishSettlement?.({
-      stream: IMAGE,
-      window: windowAt(0n, [image]),
-    });
+    const lidar = frame(LIDAR, 0n);
+    publishSettlements?.([{ stream: IMAGE, window: windowAt(0n, [image]) }]);
+    publishSettlements?.([{ stream: LIDAR, window: windowAt(0n, [lidar]) }]);
+    expect(getStreamValue(harness.store, LIDAR)).toBeNull();
+
+    harness.prefetcher.cancel();
     terminal.reject(new EpisodeReadCancelledError());
     await settle();
 
     expect(harness.caches.get(IMAGE)?.get(0n)).toBe(image);
-    expect(harness.caches.get(LIDAR)?.has(0n)).toBe(false);
+    expect(harness.caches.get(LIDAR)?.get(0n)).toBe(lidar);
+    expect(getStreamValue(harness.store, LIDAR)).not.toBeNull();
     expect(harness.prefetcher.isStreamPending("0", IMAGE)).toBe(false);
     expect(harness.prefetcher.isStreamPending("0", LIDAR)).toBe(false);
     expect(harness.fetchState.failureStreaks).toEqual(new Map());

--- a/app/packages/multimodal/src/views/episode/playback/data-stream-prefetch.test.ts
+++ b/app/packages/multimodal/src/views/episode/playback/data-stream-prefetch.test.ts
@@ -198,6 +198,8 @@ describe("data stream prefetcher", () => {
     expect(harness.caches.get(IMAGE)?.get(0n)).toBe(settledImage);
     expect(harness.prefetcher.isStreamPending("0", IMAGE)).toBe(false);
     expect(harness.prefetcher.isStreamPending("0", LIDAR)).toBe(true);
+    expect(harness.publishStreamStatuses).toHaveBeenLastCalledWith([IMAGE]);
+    expect(harness.rebalanceDecodedCaches).not.toHaveBeenCalled();
 
     terminal.resolve(windowAt(0n, [frame(IMAGE, 0n), frame(LIDAR, 0n)]));
     await settle();
@@ -206,6 +208,8 @@ describe("data stream prefetcher", () => {
     expect(harness.caches.get(LIDAR)?.has(0n)).toBe(true);
     expect(harness.prefetcher.isStreamPending("0", IMAGE)).toBe(false);
     expect(harness.prefetcher.isStreamPending("0", LIDAR)).toBe(false);
+    expect(harness.publishStreamStatuses).toHaveBeenLastCalledWith([LIDAR]);
+    expect(harness.rebalanceDecodedCaches).toHaveBeenCalledOnce();
   });
 
   it("does not preview a current-frame result after the playhead moves", async () => {
@@ -525,6 +529,7 @@ function createHarness({
   const fetchState = createDataStreamFetchState();
   const lastFrames = new Map<string, StreamPlaybackFrame<unknown>>();
   const rebalanceDecodedCaches = vi.fn();
+  const publishStreamStatuses = vi.fn();
   const index = createTimelineIndex({ endNs: 1_000_000_000n, startNs: 0n }, 2);
   const harness = {
     caches,
@@ -534,6 +539,7 @@ function createHarness({
     prefetcher: undefined as unknown as ReturnType<
       typeof createDataStreamPrefetcher
     >,
+    publishStreamStatuses,
     rebalanceDecodedCaches,
     sourceEpoch: 0,
     store,
@@ -550,7 +556,7 @@ function createHarness({
       readSynchronized,
       readSynchronizedBatch,
     },
-    publishStreamStatuses: vi.fn(),
+    publishStreamStatuses,
     rebalanceDecodedCaches,
     shouldAdmitBatch,
     store,

--- a/app/packages/multimodal/src/views/episode/playback/data-stream-prefetch.test.ts
+++ b/app/packages/multimodal/src/views/episode/playback/data-stream-prefetch.test.ts
@@ -167,6 +167,69 @@ describe("data stream prefetcher", () => {
     expect(harness.caches.get(IMAGE)?.has(0n)).toBe(false);
   });
 
+  it("publishes one preview without releasing union ownership", async () => {
+    const terminal = deferred<SynchronizedFrameWindow>();
+    let publishProgress:
+      | ((window: SynchronizedFrameWindow) => void)
+      | undefined;
+    const harness = createHarness({
+      readSynchronized: vi.fn((request) => {
+        publishProgress = request.onProgress;
+        return terminal.promise;
+      }),
+    });
+    harness.caches.get(IMAGE)?.subscribe();
+    harness.caches.get(LIDAR)?.subscribe();
+
+    expect(
+      harness.prefetcher.fetchCurrentFrame(0n, [IMAGE, LIDAR], [IMAGE, LIDAR]),
+    ).toBe(true);
+    expect(publishProgress).toBeTypeOf("function");
+    if (!publishProgress) throw new Error("expected progress callback");
+    publishProgress(windowAt(0n, [frame(IMAGE, 0n)]));
+
+    expect(getStreamValue(harness.store, IMAGE)).not.toBeNull();
+    expect(getStreamValue(harness.store, LIDAR)).toBeNull();
+    expect(harness.caches.get(IMAGE)?.has(0n)).toBe(false);
+    expect(harness.prefetcher.isStreamPending("0", IMAGE)).toBe(true);
+    expect(harness.prefetcher.isStreamPending("0", LIDAR)).toBe(true);
+
+    terminal.resolve(windowAt(0n, [frame(IMAGE, 0n), frame(LIDAR, 0n)]));
+    await settle();
+
+    expect(harness.caches.get(IMAGE)?.has(0n)).toBe(true);
+    expect(harness.caches.get(LIDAR)?.has(0n)).toBe(true);
+    expect(harness.prefetcher.isStreamPending("0", IMAGE)).toBe(false);
+    expect(harness.prefetcher.isStreamPending("0", LIDAR)).toBe(false);
+  });
+
+  it("does not preview a current-frame result after the playhead moves", async () => {
+    const terminal = deferred<SynchronizedFrameWindow>();
+    let publishProgress:
+      | ((window: SynchronizedFrameWindow) => void)
+      | undefined;
+    const harness = createHarness({
+      readSynchronized: vi.fn((request) => {
+        publishProgress = request.onProgress;
+        return terminal.promise;
+      }),
+    });
+    harness.caches.get(IMAGE)?.subscribe();
+
+    expect(harness.prefetcher.fetchCurrentFrame(0n, [IMAGE], [IMAGE])).toBe(
+      true,
+    );
+    harness.store.set(playheadAtom, 0.5);
+    expect(publishProgress).toBeTypeOf("function");
+    if (!publishProgress) throw new Error("expected progress callback");
+    publishProgress(windowAt(0n, [frame(IMAGE, 0n)]));
+    expect(getStreamValue(harness.store, IMAGE)).toBeNull();
+
+    terminal.resolve(windowAt(0n, [frame(IMAGE, 0n)]));
+    await settle();
+    expect(getStreamValue(harness.store, IMAGE)).toBeNull();
+  });
+
   it("returns late loop-continuation reads to ordinary cache ownership", async () => {
     const lateRead = deferred<readonly SynchronizedFrameWindow[]>();
     const harness = createHarness({

--- a/app/packages/multimodal/src/views/episode/playback/data-stream-prefetch.test.ts
+++ b/app/packages/multimodal/src/views/episode/playback/data-stream-prefetch.test.ts
@@ -246,6 +246,45 @@ describe("data stream prefetcher", () => {
     await settle();
   });
 
+  it("settles remaining blocking ownership before terminal presentation", async () => {
+    const terminal = deferred<SynchronizedFrameWindow>();
+    let publishSettlements:
+      | ((settlements: readonly SynchronizedStreamSettlement[]) => void)
+      | undefined;
+    const harness = createHarness({
+      readSynchronized: vi.fn((request) => {
+        publishSettlements = request.onStreamSettlements;
+        return terminal.promise;
+      }),
+    });
+    harness.caches.get(IMAGE)?.subscribe();
+    harness.caches.get(LIDAR)?.subscribe();
+
+    expect(
+      harness.prefetcher.fetchCurrentFrame(
+        0n,
+        [IMAGE, LIDAR],
+        [IMAGE, LIDAR],
+        [IMAGE],
+      ),
+    ).toBe(true);
+    publishSettlements?.([
+      { stream: IMAGE, window: windowAt(0n, [frame(IMAGE, 0n)]) },
+    ]);
+    publishSettlements?.([
+      { stream: LIDAR, window: windowAt(0n, [frame(LIDAR, 0n)]) },
+    ]);
+
+    expect(harness.caches.get(LIDAR)?.has(0n)).toBe(true);
+    expect(harness.prefetcher.isStreamPending("0", LIDAR)).toBe(false);
+    expect(getStreamValue(harness.store, IMAGE)).not.toBeNull();
+    expect(getStreamValue(harness.store, LIDAR)).toBeNull();
+
+    terminal.resolve(windowAt(0n, []));
+    await settle();
+    expect(getStreamValue(harness.store, LIDAR)).not.toBeNull();
+  });
+
   it("does not preview a current-frame result after the playhead moves", async () => {
     const terminal = deferred<SynchronizedFrameWindow>();
     let publishSettlement:

--- a/app/packages/multimodal/src/views/episode/playback/data-stream-prefetch.ts
+++ b/app/packages/multimodal/src/views/episode/playback/data-stream-prefetch.ts
@@ -93,6 +93,7 @@ export interface DataStreamPrefetcher {
     tick: bigint,
     activeStreams: string[],
     settlementPriorityStreams?: readonly string[],
+    firstUsefulSettlementStreams?: readonly string[],
   ): boolean;
   isStreamPending(tickKey: string, stream: string): boolean;
 }
@@ -354,6 +355,7 @@ export function createDataStreamPrefetcher({
     tick,
     activeStreams,
     settlementPriorityStreams,
+    firstUsefulSettlementStreams,
   ) => {
     if (activeStreams.length === 0) return false;
 
@@ -372,6 +374,13 @@ export function createDataStreamPrefetcher({
       filteredSettlementPriorityStreams?.length
         ? filteredSettlementPriorityStreams
         : undefined;
+    const firstUsefulSettlementStreamsToFetch =
+      firstUsefulSettlementStreams?.filter((stream) =>
+        streamsToFetchSet.has(stream),
+      ) ?? [];
+    const settlementPriorityStreamSet = new Set(
+      settlementPriorityStreamsToFetch ?? [],
+    );
     const unsettledStreams = new Set(streamsToFetch);
     let deliveredCurrentFrame = false;
 
@@ -426,6 +435,7 @@ export function createDataStreamPrefetcher({
     const controller = createReadController();
     void playback
       .readSynchronized({
+        firstUsefulSettlementStreams: firstUsefulSettlementStreamsToFetch,
         onStreamSettlement: (settlement) => acceptSettlements([settlement]),
         onStreamSettlements: acceptSettlements,
         pointCloudColorBy: getPointCloudColorBy(),
@@ -515,6 +525,7 @@ export interface DataStreamSchedulerOptions {
   readonly getBackgroundLookaheadSeconds: () => number;
   readonly getByteTimeline: () => readonly ByteTimelinePoint[] | null;
   readonly getBlockingStreams: () => ReadonlySet<string>;
+  readonly getFirstUsefulSettlementStreams?: () => string[];
   readonly getIndex: () => TimelineIndex | null;
   readonly getLastSeekAtMs: () => number | null;
   readonly getSettlementPriorityStreams?: () => string[];
@@ -676,7 +687,12 @@ export class DataStreamScheduler {
         options.caches.get(stream)?.has(currentTick),
       )
     ) {
-      options.prefetcher.fetchCurrentFrame(currentTick, activeBlockingStreams);
+      options.prefetcher.fetchCurrentFrame(
+        currentTick,
+        activeBlockingStreams,
+        options.getSettlementPriorityStreams?.() ?? activeBlockingStreams,
+        options.getFirstUsefulSettlementStreams?.(),
+      );
       // Keep the cadence alive while this read is pending. A cancellation
       // clears pending ownership asynchronously, so stopping here would leave
       // no later pass to retry the uncovered current frame.
@@ -732,6 +748,7 @@ export class DataStreamScheduler {
         tick,
         activeStreams,
         options.getSettlementPriorityStreams?.() ?? activeBlockingStreams,
+        options.getFirstUsefulSettlementStreams?.(),
       );
     }
     fillMissingStartupBufferFrom({

--- a/app/packages/multimodal/src/views/episode/playback/data-stream-prefetch.ts
+++ b/app/packages/multimodal/src/views/episode/playback/data-stream-prefetch.ts
@@ -487,6 +487,7 @@ export interface DataStreamSchedulerOptions {
   readonly getBlockingStreams: () => ReadonlySet<string>;
   readonly getIndex: () => TimelineIndex | null;
   readonly getLastSeekAtMs: () => number | null;
+  readonly getSettlementPriorityStreams?: () => string[];
   readonly hasDeferredBatchAdmission: () => boolean;
   readonly isSourceAvailable: () => boolean;
   readonly lastFrames: Map<string, StreamPlaybackFrame<unknown>>;
@@ -700,7 +701,7 @@ export class DataStreamScheduler {
       options.prefetcher.fetchCurrentFrame(
         tick,
         activeStreams,
-        activeBlockingStreams,
+        options.getSettlementPriorityStreams?.() ?? activeBlockingStreams,
       );
     }
     fillMissingStartupBufferFrom({

--- a/app/packages/multimodal/src/views/episode/playback/data-stream-prefetch.ts
+++ b/app/packages/multimodal/src/views/episode/playback/data-stream-prefetch.ts
@@ -392,7 +392,6 @@ export function createDataStreamPrefetcher({
     const publishCurrentTickStreams = (streams: readonly string[]): void => {
       if (
         streams.length === 0 ||
-        controller.signal.aborted ||
         getSourceEpoch() !== sourceEpoch ||
         getIndex()?.nearestTick(getPlayhead(store)) !== tick
       ) {

--- a/app/packages/multimodal/src/views/episode/playback/data-stream-prefetch.ts
+++ b/app/packages/multimodal/src/views/episode/playback/data-stream-prefetch.ts
@@ -12,7 +12,10 @@ import {
 } from "@fiftyone/playback";
 
 import type { ByteTimelinePoint, StreamSyncPolicies } from "../../../ir";
-import type { PlaybackReadCapability } from "../../../ports";
+import type {
+  PlaybackReadCapability,
+  SynchronizedStreamSettlement,
+} from "../../../ports";
 import { isEpisodeReadCancelledError } from "../../../ports";
 import { type EpisodeStreamCache, type TimelineIndex } from "../../../runtime";
 import { monotonicNowMs } from "../../../utils/monotonic-time";
@@ -220,11 +223,13 @@ export function createDataStreamPrefetcher({
 
   const deliverWindows = ({
     rebalance = true,
+    pushCurrentTick = true,
     sourceEpoch,
     streams,
     windows,
   }: {
     readonly rebalance?: boolean;
+    readonly pushCurrentTick?: boolean;
     readonly sourceEpoch: number;
     readonly streams: readonly string[];
     readonly windows: Parameters<typeof decodeFailuresByStream>[0];
@@ -256,9 +261,8 @@ export function createDataStreamPrefetcher({
       );
     }
     if (rebalance) rebalanceDecodedCaches();
-    const currentIndex = getIndex();
-    const currentTick = currentIndex?.nearestTick(getPlayhead(store));
-    if (currentTick !== undefined) {
+    const currentTick = getIndex()?.nearestTick(getPlayhead(store));
+    if (pushCurrentTick && currentTick !== undefined) {
       pushTickToStore(
         activeFetchedStreams,
         currentTick,
@@ -371,33 +375,59 @@ export function createDataStreamPrefetcher({
     const unsettledStreams = new Set(streamsToFetch);
     let deliveredCurrentFrame = false;
 
+    const acceptSettlements = (
+      settlements: readonly SynchronizedStreamSettlement[],
+    ): void => {
+      const accepted: SynchronizedStreamSettlement[] = [];
+      for (const settlement of settlements) {
+        const { stream, window } = settlement;
+        if (
+          controller.signal.aborted ||
+          getSourceEpoch() !== sourceEpoch ||
+          window.timeNs !== tick ||
+          getIndex()?.nearestTick(getPlayhead(store)) !== tick ||
+          !unsettledStreams.has(stream)
+        ) {
+          continue;
+        }
+        unsettledStreams.delete(stream);
+        accepted.push(settlement);
+      }
+      if (accepted.length === 0) return;
+
+      const acceptedStreams: string[] = [];
+      for (const { stream, window } of accepted) {
+        acceptedStreams.push(stream);
+        deliveredCurrentFrame =
+          deliverWindows({
+            pushCurrentTick: false,
+            rebalance: false,
+            sourceEpoch,
+            streams: [stream],
+            windows: [window],
+          }) || deliveredCurrentFrame;
+      }
+
+      const currentTick = getIndex()?.nearestTick(getPlayhead(store));
+      if (currentTick === tick) {
+        pushTickToStore(
+          activeStreamsInCaches(caches, acceptedStreams),
+          tick,
+          caches,
+          lastFrames,
+          store,
+          fetchState.failedStreams,
+        );
+      }
+      finishFetch(sourceEpoch, [tickKey], acceptedStreams);
+    };
+
     markStreamsPending([tickKey], streamsToFetch);
     const controller = createReadController();
     void playback
       .readSynchronized({
-        onStreamSettlement: ({ stream, window }) => {
-          if (
-            controller.signal.aborted ||
-            getSourceEpoch() !== sourceEpoch ||
-            window.timeNs !== tick ||
-            getIndex()?.nearestTick(getPlayhead(store)) !== tick ||
-            !unsettledStreams.has(stream)
-          ) {
-            return;
-          }
-          unsettledStreams.delete(stream);
-          try {
-            deliveredCurrentFrame =
-              deliverWindows({
-                rebalance: false,
-                sourceEpoch,
-                streams: [stream],
-                windows: [window],
-              }) || deliveredCurrentFrame;
-          } finally {
-            finishFetch(sourceEpoch, [tickKey], [stream]);
-          }
-        },
+        onStreamSettlement: (settlement) => acceptSettlements([settlement]),
+        onStreamSettlements: acceptSettlements,
         pointCloudColorBy: getPointCloudColorBy(),
         settlementPriorityStreams: settlementPriorityStreamsToFetch,
         streamPolicies: getStreamPolicies(),

--- a/app/packages/multimodal/src/views/episode/playback/data-stream-prefetch.ts
+++ b/app/packages/multimodal/src/views/episode/playback/data-stream-prefetch.ts
@@ -57,6 +57,12 @@ export interface DataStreamFetchState {
   readonly pendingStreamsByTick: Map<string, Set<string>>;
 }
 
+/** Presentation ordering for one synchronized current-tick acquisition. */
+interface CurrentFrameFetchOptions {
+  readonly firstUsefulSettlementStreams?: readonly string[];
+  readonly settlementPriorityStreams?: readonly string[];
+}
+
 /** Creates isolated request bookkeeping for an episode data stream. */
 export function createDataStreamFetchState(): DataStreamFetchState {
   return {
@@ -92,8 +98,7 @@ export interface DataStreamPrefetcher {
   fetchCurrentFrame(
     tick: bigint,
     activeStreams: string[],
-    settlementPriorityStreams?: readonly string[],
-    firstUsefulSettlementStreams?: readonly string[],
+    options?: CurrentFrameFetchOptions,
   ): boolean;
   isStreamPending(tickKey: string, stream: string): boolean;
 }
@@ -354,10 +359,11 @@ export function createDataStreamPrefetcher({
   const fetchCurrentFrame: DataStreamPrefetcher["fetchCurrentFrame"] = (
     tick,
     activeStreams,
-    settlementPriorityStreams,
-    firstUsefulSettlementStreams,
+    options = {},
   ) => {
     if (activeStreams.length === 0) return false;
+
+    const { firstUsefulSettlementStreams, settlementPriorityStreams } = options;
 
     const sourceEpoch = getSourceEpoch();
     const tickKey = tick.toString();
@@ -384,8 +390,14 @@ export function createDataStreamPrefetcher({
     const firstUsefulSettlementStreamSet = new Set(
       firstUsefulSettlementStreamsToFetch,
     );
+    const unsettledFirstUsefulStreams = new Set(
+      firstUsefulSettlementStreamsToFetch,
+    );
     const deferredPresentationStreams = new Set<string>();
     let publishedFirstUsefulSettlement = false;
+    // If every preferred surface is an authoritative gap, the next priority
+    // stream becomes the fallback useful paint instead of waiting on terminal.
+    let publishPriorityAfterEmptyFirstUseful = false;
     const unsettledStreams = new Set(streamsToFetch);
     let deliveredCurrentFrame = false;
 
@@ -435,6 +447,7 @@ export function createDataStreamPrefetcher({
       const acceptedStreams: string[] = [];
       for (const { stream, window } of accepted) {
         acceptedStreams.push(stream);
+        unsettledFirstUsefulStreams.delete(stream);
         deliveredCurrentFrame =
           deliverWindows({
             pushCurrentTick: false,
@@ -450,10 +463,17 @@ export function createDataStreamPrefetcher({
           firstUsefulSettlementStreamSet.has(stream) &&
           (window.framesByStream[stream]?.length ?? 0) > 0,
       );
+      const exhaustedEmptyFirstUseful =
+        unsettledFirstUsefulStreams.size === 0 &&
+        !publishedFirstUsefulSettlement &&
+        !includesPresentFirstUsefulSettlement;
       const includesNonPrioritySettlement = acceptedStreams.some(
         (stream) => !settlementPriorityStreamSet.has(stream),
       );
-      if (firstUsefulSettlementStreamSet.size === 0) {
+      if (
+        firstUsefulSettlementStreamSet.size === 0 ||
+        publishPriorityAfterEmptyFirstUseful
+      ) {
         publishCurrentTickStreams(acceptedStreams);
       } else if (
         !publishedFirstUsefulSettlement &&
@@ -465,7 +485,13 @@ export function createDataStreamPrefetcher({
         for (const stream of acceptedStreams) {
           deferredPresentationStreams.add(stream);
         }
-        if (includesNonPrioritySettlement) flushDeferredPresentation();
+        if (exhaustedEmptyFirstUseful) {
+          publishPriorityAfterEmptyFirstUseful = true;
+          publishedFirstUsefulSettlement = true;
+        }
+        if (includesNonPrioritySettlement || exhaustedEmptyFirstUseful) {
+          flushDeferredPresentation();
+        }
       }
       finishFetch(sourceEpoch, [tickKey], acceptedStreams);
     };
@@ -729,12 +755,12 @@ export class DataStreamScheduler {
         options.caches.get(stream)?.has(currentTick),
       )
     ) {
-      options.prefetcher.fetchCurrentFrame(
-        currentTick,
-        activeBlockingStreams,
-        options.getSettlementPriorityStreams?.() ?? activeBlockingStreams,
-        options.getFirstUsefulSettlementStreams?.(),
-      );
+      options.prefetcher.fetchCurrentFrame(currentTick, activeBlockingStreams, {
+        firstUsefulSettlementStreams:
+          options.getFirstUsefulSettlementStreams?.(),
+        settlementPriorityStreams:
+          options.getSettlementPriorityStreams?.() ?? activeBlockingStreams,
+      });
       // Keep the cadence alive while this read is pending. A cancellation
       // clears pending ownership asynchronously, so stopping here would leave
       // no later pass to retry the uncovered current frame.
@@ -786,12 +812,12 @@ export class DataStreamScheduler {
         options.store,
         options.failedStreams,
       );
-      options.prefetcher.fetchCurrentFrame(
-        tick,
-        activeStreams,
-        options.getSettlementPriorityStreams?.() ?? activeBlockingStreams,
-        options.getFirstUsefulSettlementStreams?.(),
-      );
+      options.prefetcher.fetchCurrentFrame(tick, activeStreams, {
+        firstUsefulSettlementStreams:
+          options.getFirstUsefulSettlementStreams?.(),
+        settlementPriorityStreams:
+          options.getSettlementPriorityStreams?.() ?? activeBlockingStreams,
+      });
     }
     fillMissingStartupBufferFrom({
       activeStreams: startupStreams,
@@ -864,7 +890,13 @@ export class DataStreamScheduler {
         const activeStreams = options.getActiveStreams();
         const tick = index.nearestTick(startSec);
         if (tick !== undefined) {
-          options.prefetcher.fetchCurrentFrame(tick, activeStreams);
+          options.prefetcher.fetchCurrentFrame(tick, activeStreams, {
+            firstUsefulSettlementStreams:
+              options.getFirstUsefulSettlementStreams?.(),
+            settlementPriorityStreams:
+              options.getSettlementPriorityStreams?.() ??
+              options.getActiveBlockingStreams(),
+          });
         }
         for (
           let batch = 0;

--- a/app/packages/multimodal/src/views/episode/playback/data-stream-prefetch.ts
+++ b/app/packages/multimodal/src/views/episode/playback/data-stream-prefetch.ts
@@ -5,7 +5,6 @@ import {
   getLoopEnd,
   getLoopStart,
   getPlayhead,
-  setStreamValue,
   subscribeCurrentTime,
   subscribeIsPlayPending,
   type PlaybackStore,
@@ -90,7 +89,7 @@ export interface DataStreamPrefetcher {
   fetchCurrentFrame(
     tick: bigint,
     activeStreams: string[],
-    earlyDeliveryStreams?: readonly string[],
+    settlementPriorityStreams?: readonly string[],
   ): boolean;
   isStreamPending(tickKey: string, stream: string): boolean;
 }
@@ -232,6 +231,7 @@ export function createDataStreamPrefetcher({
   }): void => {
     if (getSourceEpoch() !== sourceEpoch) return;
     const decodeFailures = decodeFailuresByStream(windows);
+    const streamSet = new Set(streams);
     handleFetchSuccess(streams.filter((stream) => !decodeFailures.has(stream)));
 
     const activeFetchedStreams = activeStreamsInCaches(caches, streams);
@@ -248,6 +248,7 @@ export function createDataStreamPrefetcher({
       );
     }
     for (const [stream, failure] of decodeFailures) {
+      if (!streamSet.has(stream)) continue;
       handleFetchFailure(
         new Error(failure.messages.join("; ")),
         failure.ticks,
@@ -278,35 +279,6 @@ export function createDataStreamPrefetcher({
     if (getSourceEpoch() !== sourceEpoch) return;
     if (isEpisodeReadCancelledError(error)) return;
     handleFetchFailure(error, ticks, streams);
-  };
-
-  const deliverProgressWindow = ({
-    sourceEpoch,
-    streams,
-    window,
-  }: {
-    readonly sourceEpoch: number;
-    readonly streams: readonly string[];
-    readonly window: Parameters<typeof decodeFailuresByStream>[0][number];
-  }): void => {
-    if (getSourceEpoch() !== sourceEpoch) return;
-    for (const stream of activeStreamsInCaches(caches, streams)) {
-      if (!isStreamTimeAvailable(stream, window.timeNs)) continue;
-      const message = window.framesByStream[stream]?.[0];
-      const visualization = message?.output.visualization;
-      if (!message || visualization == null) continue;
-      const frame: StreamPlaybackFrame<unknown> = {
-        ageNs:
-          window.timeNs >= message.timestampNs
-            ? window.timeNs - message.timestampNs
-            : 0n,
-        contentTimeNs: message.timestampNs,
-        frame: visualization,
-        requestedTimeNs: window.timeNs,
-      };
-      lastFrames.set(stream, frame);
-      setStreamValue(store, stream, frame);
-    }
   };
 
   const fetchBatch: DataStreamPrefetcher["fetchBatch"] = (
@@ -377,7 +349,7 @@ export function createDataStreamPrefetcher({
   const fetchCurrentFrame: DataStreamPrefetcher["fetchCurrentFrame"] = (
     tick,
     activeStreams,
-    earlyDeliveryStreams,
+    settlementPriorityStreams,
   ) => {
     if (activeStreams.length === 0) return false;
 
@@ -389,60 +361,65 @@ export function createDataStreamPrefetcher({
     );
     if (streamsToFetch.length === 0) return false;
     const streamsToFetchSet = new Set(streamsToFetch);
-    const filteredEarlyDeliveryStreams = earlyDeliveryStreams?.filter(
+    const filteredSettlementPriorityStreams = settlementPriorityStreams?.filter(
       (stream) => streamsToFetchSet.has(stream),
     );
-    const earlyDeliveryStreamsToFetch = filteredEarlyDeliveryStreams?.length
-      ? filteredEarlyDeliveryStreams
-      : undefined;
+    const settlementPriorityStreamsToFetch =
+      filteredSettlementPriorityStreams?.length
+        ? filteredSettlementPriorityStreams
+        : undefined;
+    const unsettledStreams = new Set(streamsToFetch);
 
     markStreamsPending([tickKey], streamsToFetch);
     const controller = createReadController();
     void playback
       .readSynchronized({
-        earlyDeliveryStreams: earlyDeliveryStreamsToFetch,
-        onProgress: (window) => {
+        onStreamSettlement: ({ stream, window }) => {
           if (
             controller.signal.aborted ||
             getSourceEpoch() !== sourceEpoch ||
             window.timeNs !== tick ||
-            getIndex()?.nearestTick(getPlayhead(store)) !== tick
+            getIndex()?.nearestTick(getPlayhead(store)) !== tick ||
+            !unsettledStreams.has(stream)
           ) {
             return;
           }
-          const progressedStreams = Object.keys(window.framesByStream).filter(
-            (stream) => streamsToFetchSet.has(stream),
-          );
-          if (progressedStreams.length === 0) return;
-          deliverProgressWindow({
-            sourceEpoch,
-            streams: progressedStreams,
-            window,
-          });
-          // The full union retains pending and readiness ownership. The store
-          // update can paint this surface without publishing an intermediate
-          // lifecycle state that remounts other consumers.
+          unsettledStreams.delete(stream);
+          try {
+            deliverWindows({
+              activeStreams,
+              sourceEpoch,
+              streams: [stream],
+              windows: [window],
+            });
+          } finally {
+            finishFetch(sourceEpoch, [tickKey], [stream]);
+          }
         },
         pointCloudColorBy: getPointCloudColorBy(),
+        settlementPriorityStreams: settlementPriorityStreamsToFetch,
         streamPolicies: getStreamPolicies(),
         streams: streamsToFetch,
         signal: controller.signal,
         timeNs: tick,
       })
       .then((window) => {
+        const terminalStreams = [...unsettledStreams];
+        if (terminalStreams.length === 0) return;
         deliverWindows({
           activeStreams,
           sourceEpoch,
-          streams: streamsToFetch,
+          streams: terminalStreams,
           windows: [window],
         });
       })
       .catch((error) =>
-        handleRejectedFetch(error, sourceEpoch, [tick], streamsToFetch),
+        handleRejectedFetch(error, sourceEpoch, [tick], [...unsettledStreams]),
       )
       .finally(() => {
         activeControllers.delete(controller);
-        finishFetch(sourceEpoch, [tickKey], streamsToFetch);
+        finishFetch(sourceEpoch, [tickKey], [...unsettledStreams]);
+        unsettledStreams.clear();
       });
 
     return true;

--- a/app/packages/multimodal/src/views/episode/playback/data-stream-prefetch.ts
+++ b/app/packages/multimodal/src/views/episode/playback/data-stream-prefetch.ts
@@ -127,7 +127,7 @@ export function createDataStreamPrefetcher({
     PlaybackReadCapability,
     "readSynchronized" | "readSynchronizedBatch"
   >;
-  readonly publishStreamStatuses: () => void;
+  readonly publishStreamStatuses: (updatedStreams?: readonly string[]) => void;
   readonly rebalanceDecodedCaches: () => void;
   /**
    * Admission boundary for speculative batch work. Returning false leaves the
@@ -215,27 +215,27 @@ export function createDataStreamPrefetcher({
   ): void => {
     if (getSourceEpoch() !== sourceEpoch) return;
     clearStreamsPending(tickKeys, streams);
-    publishStreamStatuses();
+    publishStreamStatuses(streams);
   };
 
   const deliverWindows = ({
-    activeStreams,
+    rebalance = true,
     sourceEpoch,
     streams,
     windows,
   }: {
-    readonly activeStreams: readonly string[];
+    readonly rebalance?: boolean;
     readonly sourceEpoch: number;
     readonly streams: readonly string[];
     readonly windows: Parameters<typeof decodeFailuresByStream>[0];
-  }): void => {
-    if (getSourceEpoch() !== sourceEpoch) return;
+  }): boolean => {
+    if (getSourceEpoch() !== sourceEpoch) return false;
     const decodeFailures = decodeFailuresByStream(windows);
     const streamSet = new Set(streams);
     handleFetchSuccess(streams.filter((stream) => !decodeFailures.has(stream)));
 
     const activeFetchedStreams = activeStreamsInCaches(caches, streams);
-    if (activeFetchedStreams.length === 0) return;
+    if (activeFetchedStreams.length === 0) return false;
 
     for (const window of windows) {
       distributeWindowToCaches(
@@ -255,12 +255,12 @@ export function createDataStreamPrefetcher({
         [stream],
       );
     }
-    rebalanceDecodedCaches();
+    if (rebalance) rebalanceDecodedCaches();
     const currentIndex = getIndex();
     const currentTick = currentIndex?.nearestTick(getPlayhead(store));
     if (currentTick !== undefined) {
       pushTickToStore(
-        activeStreamsInCaches(caches, activeStreams),
+        activeFetchedStreams,
         currentTick,
         caches,
         lastFrames,
@@ -268,6 +268,7 @@ export function createDataStreamPrefetcher({
         fetchState.failedStreams,
       );
     }
+    return true;
   };
 
   const handleRejectedFetch = (
@@ -324,7 +325,6 @@ export function createDataStreamPrefetcher({
       )
       .then((windows) => {
         deliverWindows({
-          activeStreams,
           sourceEpoch,
           streams: streamsToFetch,
           windows,
@@ -369,6 +369,7 @@ export function createDataStreamPrefetcher({
         ? filteredSettlementPriorityStreams
         : undefined;
     const unsettledStreams = new Set(streamsToFetch);
+    let deliveredCurrentFrame = false;
 
     markStreamsPending([tickKey], streamsToFetch);
     const controller = createReadController();
@@ -386,12 +387,13 @@ export function createDataStreamPrefetcher({
           }
           unsettledStreams.delete(stream);
           try {
-            deliverWindows({
-              activeStreams,
-              sourceEpoch,
-              streams: [stream],
-              windows: [window],
-            });
+            deliveredCurrentFrame =
+              deliverWindows({
+                rebalance: false,
+                sourceEpoch,
+                streams: [stream],
+                windows: [window],
+              }) || deliveredCurrentFrame;
           } finally {
             finishFetch(sourceEpoch, [tickKey], [stream]);
           }
@@ -406,18 +408,22 @@ export function createDataStreamPrefetcher({
       .then((window) => {
         const terminalStreams = [...unsettledStreams];
         if (terminalStreams.length === 0) return;
-        deliverWindows({
-          activeStreams,
-          sourceEpoch,
-          streams: terminalStreams,
-          windows: [window],
-        });
+        deliveredCurrentFrame =
+          deliverWindows({
+            rebalance: false,
+            sourceEpoch,
+            streams: terminalStreams,
+            windows: [window],
+          }) || deliveredCurrentFrame;
       })
       .catch((error) =>
         handleRejectedFetch(error, sourceEpoch, [tick], [...unsettledStreams]),
       )
       .finally(() => {
         activeControllers.delete(controller);
+        if (deliveredCurrentFrame && getSourceEpoch() === sourceEpoch) {
+          rebalanceDecodedCaches();
+        }
         finishFetch(sourceEpoch, [tickKey], [...unsettledStreams]);
         unsettledStreams.clear();
       });

--- a/app/packages/multimodal/src/views/episode/playback/data-stream-prefetch.ts
+++ b/app/packages/multimodal/src/views/episode/playback/data-stream-prefetch.ts
@@ -5,6 +5,7 @@ import {
   getLoopEnd,
   getLoopStart,
   getPlayhead,
+  setStreamValue,
   subscribeCurrentTime,
   subscribeIsPlayPending,
   type PlaybackStore,
@@ -86,7 +87,11 @@ export interface DataStreamPrefetcher {
     activeStreams: string[],
     operation: DataOperation,
   ): boolean;
-  fetchCurrentFrame(tick: bigint, activeStreams: string[]): boolean;
+  fetchCurrentFrame(
+    tick: bigint,
+    activeStreams: string[],
+    earlyDeliveryStreams?: readonly string[],
+  ): boolean;
   isStreamPending(tickKey: string, stream: string): boolean;
 }
 
@@ -275,6 +280,35 @@ export function createDataStreamPrefetcher({
     handleFetchFailure(error, ticks, streams);
   };
 
+  const deliverProgressWindow = ({
+    sourceEpoch,
+    streams,
+    window,
+  }: {
+    readonly sourceEpoch: number;
+    readonly streams: readonly string[];
+    readonly window: Parameters<typeof decodeFailuresByStream>[0][number];
+  }): void => {
+    if (getSourceEpoch() !== sourceEpoch) return;
+    for (const stream of activeStreamsInCaches(caches, streams)) {
+      if (!isStreamTimeAvailable(stream, window.timeNs)) continue;
+      const message = window.framesByStream[stream]?.[0];
+      const visualization = message?.output.visualization;
+      if (!message || visualization == null) continue;
+      const frame: StreamPlaybackFrame<unknown> = {
+        ageNs:
+          window.timeNs >= message.timestampNs
+            ? window.timeNs - message.timestampNs
+            : 0n,
+        contentTimeNs: message.timestampNs,
+        frame: visualization,
+        requestedTimeNs: window.timeNs,
+      };
+      lastFrames.set(stream, frame);
+      setStreamValue(store, stream, frame);
+    }
+  };
+
   const fetchBatch: DataStreamPrefetcher["fetchBatch"] = (
     ticks,
     activeStreams,
@@ -343,6 +377,7 @@ export function createDataStreamPrefetcher({
   const fetchCurrentFrame: DataStreamPrefetcher["fetchCurrentFrame"] = (
     tick,
     activeStreams,
+    earlyDeliveryStreams,
   ) => {
     if (activeStreams.length === 0) return false;
 
@@ -358,6 +393,31 @@ export function createDataStreamPrefetcher({
     const controller = createReadController();
     void playback
       .readSynchronized({
+        earlyDeliveryStreams: earlyDeliveryStreams?.filter((stream) =>
+          streamsToFetch.includes(stream),
+        ),
+        onProgress: (window) => {
+          if (
+            controller.signal.aborted ||
+            getSourceEpoch() !== sourceEpoch ||
+            window.timeNs !== tick ||
+            getIndex()?.nearestTick(getPlayhead(store)) !== tick
+          ) {
+            return;
+          }
+          const progressedStreams = Object.keys(window.framesByStream).filter(
+            (stream) => streamsToFetch.includes(stream),
+          );
+          if (progressedStreams.length === 0) return;
+          deliverProgressWindow({
+            sourceEpoch,
+            streams: progressedStreams,
+            window,
+          });
+          // The full union retains pending and readiness ownership. The store
+          // update can paint this surface without publishing an intermediate
+          // lifecycle state that remounts other consumers.
+        },
         pointCloudColorBy: getPointCloudColorBy(),
         streamPolicies: getStreamPolicies(),
         streams: streamsToFetch,
@@ -637,11 +697,7 @@ export class DataStreamScheduler {
     const activeBlockingStreams = activeStreams.filter((stream) =>
       blockingSet.has(stream),
     );
-    const overlayStreams =
-      activeBlockingStreams.length > 0
-        ? activeStreams.filter((stream) => !blockingSet.has(stream))
-        : [];
-    const heavyStreams =
+    const startupStreams =
       activeBlockingStreams.length > 0 ? activeBlockingStreams : activeStreams;
     const tick = index.nearestTick(timeSec);
     if (tick !== undefined) {
@@ -653,15 +709,16 @@ export class DataStreamScheduler {
         options.store,
         options.failedStreams,
       );
-      options.prefetcher.fetchCurrentFrame(tick, heavyStreams);
-      if (overlayStreams.length > 0) {
-        options.prefetcher.fetchCurrentFrame(tick, overlayStreams);
-      }
+      options.prefetcher.fetchCurrentFrame(
+        tick,
+        activeStreams,
+        activeBlockingStreams,
+      );
     }
     fillMissingStartupBufferFrom({
-      activeStreams: heavyStreams,
+      activeStreams: startupStreams,
       collectMissingTicks: (startSec, endSec, maxTicks) =>
-        this.collectStartupTicks(startSec, endSec, maxTicks, heavyStreams),
+        this.collectStartupTicks(startSec, endSec, maxTicks, startupStreams),
       fetchBatch: options.prefetcher.fetchBatch,
       policy: options.policy,
       timeSec,

--- a/app/packages/multimodal/src/views/episode/playback/data-stream-prefetch.ts
+++ b/app/packages/multimodal/src/views/episode/playback/data-stream-prefetch.ts
@@ -388,14 +388,19 @@ export function createDataStreamPrefetcher({
         !caches.get(stream)?.has(tick) && !isStreamPending(tickKey, stream),
     );
     if (streamsToFetch.length === 0) return false;
+    const streamsToFetchSet = new Set(streamsToFetch);
+    const filteredEarlyDeliveryStreams = earlyDeliveryStreams?.filter(
+      (stream) => streamsToFetchSet.has(stream),
+    );
+    const earlyDeliveryStreamsToFetch = filteredEarlyDeliveryStreams?.length
+      ? filteredEarlyDeliveryStreams
+      : undefined;
 
     markStreamsPending([tickKey], streamsToFetch);
     const controller = createReadController();
     void playback
       .readSynchronized({
-        earlyDeliveryStreams: earlyDeliveryStreams?.filter((stream) =>
-          streamsToFetch.includes(stream),
-        ),
+        earlyDeliveryStreams: earlyDeliveryStreamsToFetch,
         onProgress: (window) => {
           if (
             controller.signal.aborted ||
@@ -406,7 +411,7 @@ export function createDataStreamPrefetcher({
             return;
           }
           const progressedStreams = Object.keys(window.framesByStream).filter(
-            (stream) => streamsToFetch.includes(stream),
+            (stream) => streamsToFetchSet.has(stream),
           );
           if (progressedStreams.length === 0) return;
           deliverProgressWindow({

--- a/app/packages/multimodal/src/views/episode/playback/data-stream-prefetch.ts
+++ b/app/packages/multimodal/src/views/episode/playback/data-stream-prefetch.ts
@@ -381,8 +381,37 @@ export function createDataStreamPrefetcher({
     const settlementPriorityStreamSet = new Set(
       settlementPriorityStreamsToFetch ?? [],
     );
+    const firstUsefulSettlementStreamSet = new Set(
+      firstUsefulSettlementStreamsToFetch,
+    );
+    const deferredPresentationStreams = new Set<string>();
+    let publishedFirstUsefulSettlement = false;
     const unsettledStreams = new Set(streamsToFetch);
     let deliveredCurrentFrame = false;
+
+    const publishCurrentTickStreams = (streams: readonly string[]): void => {
+      if (
+        streams.length === 0 ||
+        controller.signal.aborted ||
+        getSourceEpoch() !== sourceEpoch ||
+        getIndex()?.nearestTick(getPlayhead(store)) !== tick
+      ) {
+        return;
+      }
+      pushTickToStore(
+        activeStreamsInCaches(caches, streams),
+        tick,
+        caches,
+        lastFrames,
+        store,
+        fetchState.failedStreams,
+      );
+    };
+    const flushDeferredPresentation = (): void => {
+      const streams = [...deferredPresentationStreams];
+      deferredPresentationStreams.clear();
+      publishCurrentTickStreams(streams);
+    };
 
     const acceptSettlements = (
       settlements: readonly SynchronizedStreamSettlement[],
@@ -417,16 +446,27 @@ export function createDataStreamPrefetcher({
           }) || deliveredCurrentFrame;
       }
 
-      const currentTick = getIndex()?.nearestTick(getPlayhead(store));
-      if (currentTick === tick) {
-        pushTickToStore(
-          activeStreamsInCaches(caches, acceptedStreams),
-          tick,
-          caches,
-          lastFrames,
-          store,
-          fetchState.failedStreams,
-        );
+      const includesPresentFirstUsefulSettlement = accepted.some(
+        ({ stream, window }) =>
+          firstUsefulSettlementStreamSet.has(stream) &&
+          (window.framesByStream[stream]?.length ?? 0) > 0,
+      );
+      const includesNonPrioritySettlement = acceptedStreams.some(
+        (stream) => !settlementPriorityStreamSet.has(stream),
+      );
+      if (firstUsefulSettlementStreamSet.size === 0) {
+        publishCurrentTickStreams(acceptedStreams);
+      } else if (
+        !publishedFirstUsefulSettlement &&
+        includesPresentFirstUsefulSettlement
+      ) {
+        publishedFirstUsefulSettlement = true;
+        publishCurrentTickStreams(acceptedStreams);
+      } else {
+        for (const stream of acceptedStreams) {
+          deferredPresentationStreams.add(stream);
+        }
+        if (includesNonPrioritySettlement) flushDeferredPresentation();
       }
       finishFetch(sourceEpoch, [tickKey], acceptedStreams);
     };
@@ -447,14 +487,16 @@ export function createDataStreamPrefetcher({
       })
       .then((window) => {
         const terminalStreams = [...unsettledStreams];
-        if (terminalStreams.length === 0) return;
-        deliveredCurrentFrame =
-          deliverWindows({
-            rebalance: false,
-            sourceEpoch,
-            streams: terminalStreams,
-            windows: [window],
-          }) || deliveredCurrentFrame;
+        if (terminalStreams.length > 0) {
+          deliveredCurrentFrame =
+            deliverWindows({
+              rebalance: false,
+              sourceEpoch,
+              streams: terminalStreams,
+              windows: [window],
+            }) || deliveredCurrentFrame;
+        }
+        flushDeferredPresentation();
       })
       .catch((error) =>
         handleRejectedFetch(error, sourceEpoch, [tick], [...unsettledStreams]),
@@ -464,6 +506,7 @@ export function createDataStreamPrefetcher({
         if (deliveredCurrentFrame && getSourceEpoch() === sourceEpoch) {
           rebalanceDecodedCaches();
         }
+        flushDeferredPresentation();
         finishFetch(sourceEpoch, [tickKey], [...unsettledStreams]);
         unsettledStreams.clear();
       });

--- a/app/packages/multimodal/src/views/episode/playback/data-stream-scheduler.test.ts
+++ b/app/packages/multimodal/src/views/episode/playback/data-stream-scheduler.test.ts
@@ -577,13 +577,19 @@ function createSchedulerHarness({
   const unsubscribeStream = vi.fn();
   const cancelIdle = vi.fn();
   const activeStreams = [...configuredActiveStreams];
+  const getActiveBlockingStreams = () => {
+    const blockingStreams = activeStreams.filter((stream) =>
+      configuredBlockingStreams.includes(stream),
+    );
+    return blockingStreams.length > 0 ? blockingStreams : [...activeStreams];
+  };
   let registeredStream: PlaybackStream | null = null;
   const scheduler = new DataStreamScheduler({
     caches,
     cancelIdle,
     computeBufferedRanges: () => [[0, 10]],
     failedStreams: new Set(),
-    getActiveBlockingStreams: () => [...activeStreams],
+    getActiveBlockingStreams,
     getActiveStreams: () => [...activeStreams],
     getBackgroundLookaheadSeconds: () => 2,
     getByteTimeline: () => byteTimeline,

--- a/app/packages/multimodal/src/views/episode/playback/data-stream-scheduler.test.ts
+++ b/app/packages/multimodal/src/views/episode/playback/data-stream-scheduler.test.ts
@@ -68,6 +68,7 @@ describe("DataStreamScheduler", () => {
     const harness = createSchedulerHarness({
       activeStreams: streams,
       blockingStreams: ["/camera/left", "/lidar"],
+      settlementPriorityStreams: ["/lidar", "/camera/left"],
     });
 
     harness.scheduler.prefetchLookaheadFrom(0);
@@ -76,7 +77,7 @@ describe("DataStreamScheduler", () => {
     expect(harness.prefetcher.fetchCurrentFrame).toHaveBeenCalledWith(
       0n,
       streams,
-      ["/camera/left", "/lidar"],
+      ["/lidar", "/camera/left"],
     );
   });
 
@@ -538,6 +539,8 @@ function createSchedulerHarness({
   deferredBatchAdmission = false,
   fillCache = true,
   policy = {},
+  settlementPriorityStreams:
+    configuredSettlementPriorityStreams = configuredBlockingStreams,
 }: {
   readonly activeStreams?: string[];
   readonly blockingStreams?: readonly string[];
@@ -545,6 +548,7 @@ function createSchedulerHarness({
   readonly deferredBatchAdmission?: boolean;
   readonly fillCache?: boolean;
   readonly policy?: Partial<PlaybackPolicy>;
+  readonly settlementPriorityStreams?: readonly string[];
 } = {}) {
   const index = createTimelineIndex({
     endNs: 10_000_000_000n,
@@ -596,6 +600,9 @@ function createSchedulerHarness({
     getBlockingStreams: () => new Set(configuredBlockingStreams),
     getIndex: () => index,
     getLastSeekAtMs: () => null,
+    getSettlementPriorityStreams: () => [
+      ...configuredSettlementPriorityStreams,
+    ],
     hasDeferredBatchAdmission: () => deferredBatchAdmission,
     isSourceAvailable: () => true,
     lastFrames: new Map(),

--- a/app/packages/multimodal/src/views/episode/playback/data-stream-scheduler.test.ts
+++ b/app/packages/multimodal/src/views/episode/playback/data-stream-scheduler.test.ts
@@ -78,6 +78,7 @@ describe("DataStreamScheduler", () => {
       0n,
       streams,
       ["/lidar", "/camera/left"],
+      undefined,
     );
   });
 
@@ -93,6 +94,7 @@ describe("DataStreamScheduler", () => {
       0n,
       ["/camera/left", "/camera/right"],
       ["/camera/left", "/camera/right"],
+      undefined,
     );
   });
 
@@ -470,6 +472,8 @@ describe("DataStreamScheduler", () => {
     expect(harness.prefetcher.fetchCurrentFrame).toHaveBeenCalledWith(
       0n,
       streams,
+      streams,
+      undefined,
     );
     expect(harness.prefetcher.fetchBatch).not.toHaveBeenCalled();
   });

--- a/app/packages/multimodal/src/views/episode/playback/data-stream-scheduler.test.ts
+++ b/app/packages/multimodal/src/views/episode/playback/data-stream-scheduler.test.ts
@@ -63,10 +63,11 @@ beforeEach(() => {
 });
 
 describe("DataStreamScheduler", () => {
-  it("admits one atomic current-frame read across image and 3D streams", () => {
+  it("admits one stable union across active current-tick demand", () => {
     const streams = ["/camera/left", "/lidar", "/camera/right"];
     const harness = createSchedulerHarness({
       activeStreams: streams,
+      blockingStreams: ["/camera/left", "/lidar"],
     });
 
     harness.scheduler.prefetchLookaheadFrom(0);
@@ -75,10 +76,11 @@ describe("DataStreamScheduler", () => {
     expect(harness.prefetcher.fetchCurrentFrame).toHaveBeenCalledWith(
       0n,
       streams,
+      ["/camera/left", "/lidar"],
     );
   });
 
-  it("keeps current-frame reads atomic when no image split applies", () => {
+  it("keeps the presentation read atomic without overlay demand", () => {
     const harness = createSchedulerHarness({
       activeStreams: ["/camera/left", "/camera/right"],
     });
@@ -86,10 +88,11 @@ describe("DataStreamScheduler", () => {
     harness.scheduler.prefetchLookaheadFrom(0);
 
     expect(harness.prefetcher.fetchCurrentFrame).toHaveBeenCalledOnce();
-    expect(harness.prefetcher.fetchCurrentFrame).toHaveBeenCalledWith(0n, [
-      "/camera/left",
-      "/camera/right",
-    ]);
+    expect(harness.prefetcher.fetchCurrentFrame).toHaveBeenCalledWith(
+      0n,
+      ["/camera/left", "/camera/right"],
+      ["/camera/left", "/camera/right"],
+    );
   });
 
   it("keeps playback prefetch batches atomic across all active streams", () => {
@@ -524,6 +527,7 @@ describe("DataStreamScheduler", () => {
 
 function createSchedulerHarness({
   activeStreams: configuredActiveStreams = ["/camera"],
+  blockingStreams: configuredBlockingStreams = configuredActiveStreams,
   byteTimeline = [
     {
       cumulativeCompressedBytes: 1_024,
@@ -536,6 +540,7 @@ function createSchedulerHarness({
   policy = {},
 }: {
   readonly activeStreams?: string[];
+  readonly blockingStreams?: readonly string[];
   readonly byteTimeline?: readonly ByteTimelinePoint[];
   readonly deferredBatchAdmission?: boolean;
   readonly fillCache?: boolean;
@@ -582,7 +587,7 @@ function createSchedulerHarness({
     getActiveStreams: () => [...activeStreams],
     getBackgroundLookaheadSeconds: () => 2,
     getByteTimeline: () => byteTimeline,
-    getBlockingStreams: () => new Set(activeStreams),
+    getBlockingStreams: () => new Set(configuredBlockingStreams),
     getIndex: () => index,
     getLastSeekAtMs: () => null,
     hasDeferredBatchAdmission: () => deferredBatchAdmission,

--- a/app/packages/multimodal/src/views/episode/playback/data-stream-scheduler.test.ts
+++ b/app/packages/multimodal/src/views/episode/playback/data-stream-scheduler.test.ts
@@ -77,8 +77,10 @@ describe("DataStreamScheduler", () => {
     expect(harness.prefetcher.fetchCurrentFrame).toHaveBeenCalledWith(
       0n,
       streams,
-      ["/lidar", "/camera/left"],
-      undefined,
+      {
+        firstUsefulSettlementStreams: [],
+        settlementPriorityStreams: ["/lidar", "/camera/left"],
+      },
     );
   });
 
@@ -93,8 +95,10 @@ describe("DataStreamScheduler", () => {
     expect(harness.prefetcher.fetchCurrentFrame).toHaveBeenCalledWith(
       0n,
       ["/camera/left", "/camera/right"],
-      ["/camera/left", "/camera/right"],
-      undefined,
+      {
+        firstUsefulSettlementStreams: [],
+        settlementPriorityStreams: ["/camera/left", "/camera/right"],
+      },
     );
   });
 
@@ -102,6 +106,7 @@ describe("DataStreamScheduler", () => {
     const streams = ["/camera/left", "/lidar", "/camera/right"];
     const harness = createSchedulerHarness({
       activeStreams: streams,
+      firstUsefulSettlementStreams: ["/camera/left"],
     });
     const cleanup = harness.register();
 
@@ -110,6 +115,10 @@ describe("DataStreamScheduler", () => {
     expect(harness.prefetcher.fetchCurrentFrame).toHaveBeenCalledWith(
       0n,
       streams,
+      {
+        firstUsefulSettlementStreams: ["/camera/left"],
+        settlementPriorityStreams: streams,
+      },
     );
     expect(harness.prefetcher.fetchBatch).toHaveBeenCalledWith(
       expect.any(Array),
@@ -472,8 +481,10 @@ describe("DataStreamScheduler", () => {
     expect(harness.prefetcher.fetchCurrentFrame).toHaveBeenCalledWith(
       0n,
       streams,
-      streams,
-      undefined,
+      {
+        firstUsefulSettlementStreams: [],
+        settlementPriorityStreams: streams,
+      },
     );
     expect(harness.prefetcher.fetchBatch).not.toHaveBeenCalled();
   });
@@ -542,6 +553,7 @@ function createSchedulerHarness({
   ],
   deferredBatchAdmission = false,
   fillCache = true,
+  firstUsefulSettlementStreams = [],
   policy = {},
   settlementPriorityStreams:
     configuredSettlementPriorityStreams = configuredBlockingStreams,
@@ -551,6 +563,7 @@ function createSchedulerHarness({
   readonly byteTimeline?: readonly ByteTimelinePoint[];
   readonly deferredBatchAdmission?: boolean;
   readonly fillCache?: boolean;
+  readonly firstUsefulSettlementStreams?: readonly string[];
   readonly policy?: Partial<PlaybackPolicy>;
   readonly settlementPriorityStreams?: readonly string[];
 } = {}) {
@@ -601,6 +614,7 @@ function createSchedulerHarness({
     getActiveStreams: () => [...activeStreams],
     getBackgroundLookaheadSeconds: () => 2,
     getByteTimeline: () => byteTimeline,
+    getFirstUsefulSettlementStreams: () => [...firstUsefulSettlementStreams],
     getBlockingStreams: () => new Set(configuredBlockingStreams),
     getIndex: () => index,
     getLastSeekAtMs: () => null,

--- a/app/packages/multimodal/src/views/episode/playback/stream-status-state.test.ts
+++ b/app/packages/multimodal/src/views/episode/playback/stream-status-state.test.ts
@@ -88,6 +88,49 @@ describe("publishDataStreamStatuses", () => {
     expect(getIsBuffering(store)).toBe(false);
     expect(onPlayheadDataReady).toHaveBeenCalledOnce();
   });
+  it("limits non-blocking settlements to their own stream state", () => {
+    const store = createStore() as PlaybackStore;
+    const camera = new EpisodeStreamCache();
+    const lidar = new EpisodeStreamCache();
+    camera.set(0n, frame(CAMERA));
+    const common = {
+      activeBlockingStreams: [CAMERA],
+      activeStreams: [CAMERA, LIDAR],
+      caches: new Map([
+        [CAMERA, camera],
+        [LIDAR, lidar],
+      ]),
+      failedStreams: new Set<string>(),
+      index: createTimelineIndex({
+        endNs: 1_000_000_000n,
+        startNs: 0n,
+      }),
+      onPlayheadDataReady: vi.fn(),
+      policy: derivePlaybackPolicy(DEFAULT_PLAYBACK_POLICY),
+      publishBufferedRangesNow: vi.fn(),
+      pushCurrentTick: vi.fn(),
+      resolveStartupCushion: () => ({
+        cushionSeconds: 0.5,
+        estimatedWaitSeconds: 0,
+      }),
+      scheduleBufferedRangesPublish: vi.fn(),
+      schedulePausedIdleWarmup: vi.fn(),
+      staleWarningStreams: new Set<string>(),
+      store,
+      streamNames: new Map<string, string>(),
+    } as const;
+
+    publishDataStreamStatuses(common);
+    vi.clearAllMocks();
+    lidar.set(0n, frame(LIDAR));
+    publishDataStreamStatuses({ ...common, updatedStreams: [LIDAR] });
+
+    expect(getStreamStatus(store, LIDAR)).toBe("ready");
+    expect(common.onPlayheadDataReady).not.toHaveBeenCalled();
+    expect(common.publishBufferedRangesNow).not.toHaveBeenCalled();
+    expect(common.scheduleBufferedRangesPublish).not.toHaveBeenCalled();
+    expect(common.schedulePausedIdleWarmup).not.toHaveBeenCalled();
+  });
 });
 
 function frame(streamId: string): DecodedFrame {

--- a/app/packages/multimodal/src/views/episode/playback/stream-status-state.test.ts
+++ b/app/packages/multimodal/src/views/episode/playback/stream-status-state.test.ts
@@ -81,7 +81,7 @@ describe("publishDataStreamStatuses", () => {
 
     setIsBuffering(store, true);
     lidar.set(0n, null);
-    publishDataStreamStatuses(common);
+    publishDataStreamStatuses({ ...common, updatedStreams: [LIDAR] });
     expect(getStreamStatus(store, LIDAR)).toBe("gap");
     expect(getBufferingDetail(store)).toBeNull();
     expect(getBufferingStreams(store)).toEqual([]);

--- a/app/packages/multimodal/src/views/episode/playback/stream-status-state.ts
+++ b/app/packages/multimodal/src/views/episode/playback/stream-status-state.ts
@@ -298,6 +298,7 @@ export function publishDataStreamStatuses({
   staleWarningStreams,
   store,
   streamNames,
+  updatedStreams,
 }: {
   readonly activeBlockingStreams: readonly string[];
   readonly activeStreams: readonly string[];
@@ -317,13 +318,20 @@ export function publishDataStreamStatuses({
   readonly staleWarningStreams: ReadonlySet<string>;
   readonly store: PlaybackStore;
   readonly streamNames: ReadonlyMap<string, string>;
+  /** Streams whose cache ownership changed, or all streams when omitted. */
+  readonly updatedStreams?: readonly string[];
 }): void {
+  const activeStreamSet = new Set(activeStreams);
   const blockingStreamSet = new Set(activeBlockingStreams);
   const coveredBlockingStreams = new Set<string>();
   const tick = index?.nearestTick(getPlayhead(store)) ?? null;
   let blockingCovered = 0;
 
-  for (const stream of activeStreams) {
+  const streamsToPublish =
+    updatedStreams === undefined
+      ? activeStreams
+      : updatedStreams.filter((stream) => activeStreamSet.has(stream));
+  for (const stream of streamsToPublish) {
     const cache = caches.get(stream);
     let status: StreamStatus;
     let staleAgeNs: bigint | null = null;
@@ -331,10 +339,6 @@ export function publishDataStreamStatuses({
     if (tick === null || !cache?.has(tick)) {
       status = failedStreams.has(stream) ? "failed" : "loading";
     } else {
-      if (blockingStreamSet.has(stream)) {
-        blockingCovered += 1;
-        coveredBlockingStreams.add(stream);
-      }
       if (failedStreams.has(stream)) {
         status = "failed";
       } else {
@@ -364,6 +368,24 @@ export function publishDataStreamStatuses({
     }
     if (getStreamStatus(store, stream) !== status) {
       setStreamStatus(store, stream, status);
+    }
+  }
+
+  // Non-blocking settlements still publish their own status and visible frame,
+  // but cannot change buffering or startup readiness. Avoid making every topic
+  // settlement rescan and republish the aggregate playback state.
+  if (
+    updatedStreams !== undefined &&
+    !updatedStreams.some((stream) => blockingStreamSet.has(stream))
+  ) {
+    return;
+  }
+
+  if (tick !== null) {
+    for (const stream of activeBlockingStreams) {
+      if (!caches.get(stream)?.has(tick)) continue;
+      blockingCovered += 1;
+      coveredBlockingStreams.add(stream);
     }
   }
 

--- a/app/packages/multimodal/src/views/episode/playback/use-register-data-stream.test.tsx
+++ b/app/packages/multimodal/src/views/episode/playback/use-register-data-stream.test.tsx
@@ -118,16 +118,17 @@ interface ResourceClient {
   readSynchronizedMessages(
     request: {
       readonly activeTimeline?: "log";
-      readonly earlyDeliveryTopics?: readonly string[];
+      readonly settlementPriorityTopics?: readonly string[];
       readonly source: ByteSourceDescriptor;
       readonly streamPolicies?: StreamSyncPolicies;
       readonly timeNs: bigint;
       readonly topics: readonly string[];
     },
     options?: {
-      readonly onSynchronizedProgress?: (
-        window: SynchronizedMessageWindow,
-      ) => void;
+      readonly onTopicSettlement?: (settlement: {
+        readonly topic: string;
+        readonly window: SynchronizedMessageWindow;
+      }) => void;
       readonly signal?: AbortSignal;
     },
   ): Promise<SynchronizedMessageWindow>;
@@ -1325,8 +1326,11 @@ describe("stream status + buffering feedback", () => {
     const storeCapture = capturePlaybackStore();
     let dataStream: DataStream | null = null;
     const sourceARead = deferred<SynchronizedMessageWindow>();
-    let sourceAProgress:
-      | ((window: SynchronizedMessageWindow) => void)
+    let sourceASettlement:
+      | ((settlement: {
+          readonly topic: string;
+          readonly window: SynchronizedMessageWindow;
+        }) => void)
       | undefined;
     const readSynchronizedMessages = vi.fn(
       (
@@ -1334,7 +1338,7 @@ describe("stream status + buffering feedback", () => {
         options?: Parameters<ResourceClient["readSynchronizedMessages"]>[1],
       ) => {
         if (request.source.sourceId === sourceA.sourceId) {
-          sourceAProgress = options?.onSynchronizedProgress;
+          sourceASettlement = options?.onTopicSettlement;
           return sourceARead.promise;
         }
         return new Promise<SynchronizedMessageWindow>(() => undefined);
@@ -1372,7 +1376,10 @@ describe("stream status + buffering feedback", () => {
     });
     rerender(<Harness {...props} source={null} />);
     await act(async () => {
-      sourceAProgress?.(createMultiStreamWindow(0n, [STREAM]));
+      sourceASettlement?.({
+        topic: STREAM,
+        window: createMultiStreamWindow(0n, [STREAM]),
+      });
       sourceARead.resolve(
         createWindow({
           timeNs: 0n,
@@ -1440,13 +1447,16 @@ describe("stream status + buffering feedback", () => {
     });
   });
 
-  it("publishes one early surface before final blocking readiness", async () => {
+  it("becomes blocking-ready before a non-blocking settlement", async () => {
     const current = deferred<SynchronizedMessageWindow>();
     const source = createSource("atomic-current-delivery");
     const storeCapture = capturePlaybackStore();
     const onPlayheadDataReady = vi.fn();
-    let publishProgress:
-      | ((window: SynchronizedMessageWindow) => void)
+    let publishSettlement:
+      | ((settlement: {
+          readonly topic: string;
+          readonly window: SynchronizedMessageWindow;
+        }) => void)
       | undefined;
     const client = createClient({
       readSynchronizedMessageBatch: vi.fn(
@@ -1458,7 +1468,7 @@ describe("stream status + buffering feedback", () => {
           _request: Parameters<ResourceClient["readSynchronizedMessages"]>[0],
           options?: Parameters<ResourceClient["readSynchronizedMessages"]>[1],
         ) => {
-          publishProgress = options?.onSynchronizedProgress;
+          publishSettlement = options?.onTopicSettlement;
           return current.promise;
         },
       ),
@@ -1484,11 +1494,11 @@ describe("stream status + buffering feedback", () => {
     });
     expect(client.readSynchronizedMessages).toHaveBeenCalledWith(
       expect.objectContaining({
-        earlyDeliveryTopics: [STREAM, LIDAR_STREAM],
+        settlementPriorityTopics: [STREAM, LIDAR_STREAM],
         topics: [STREAM, LIDAR_STREAM, MAP_STREAM],
       }),
       expect.objectContaining({
-        onSynchronizedProgress: expect.any(Function),
+        onTopicSettlement: expect.any(Function),
       }),
     );
     expect(getStreamValue(store, STREAM)).toBeNull();
@@ -1497,7 +1507,10 @@ describe("stream status + buffering feedback", () => {
     expect(onPlayheadDataReady).not.toHaveBeenCalled();
 
     await act(async () => {
-      publishProgress?.(createMultiStreamWindow(0n, [STREAM]));
+      publishSettlement?.({
+        topic: STREAM,
+        window: createMultiStreamWindow(0n, [STREAM]),
+      });
     });
     await waitFor(() => {
       expect(getStreamValue(store, STREAM)).not.toBeNull();
@@ -1505,6 +1518,18 @@ describe("stream status + buffering feedback", () => {
     expect(getStreamValue(store, LIDAR_STREAM)).toBeNull();
     expect(getStreamValue(store, MAP_STREAM)).toBeNull();
     expect(onPlayheadDataReady).not.toHaveBeenCalled();
+
+    await act(async () => {
+      publishSettlement?.({
+        topic: LIDAR_STREAM,
+        window: createMultiStreamWindow(0n, [LIDAR_STREAM]),
+      });
+    });
+    await waitFor(() => {
+      expect(getStreamValue(store, LIDAR_STREAM)).not.toBeNull();
+      expect(onPlayheadDataReady).toHaveBeenCalled();
+    });
+    expect(getStreamValue(store, MAP_STREAM)).toBeNull();
 
     await act(async () => {
       current.resolve(
@@ -3372,15 +3397,20 @@ function useTestSession(
                       await client.readSynchronizedMessages(
                         {
                           activeTimeline: "log",
-                          earlyDeliveryTopics: request.earlyDeliveryStreams,
+                          settlementPriorityTopics:
+                            request.settlementPriorityStreams,
                           source,
                           streamPolicies: request.streamPolicies,
                           timeNs: request.timeNs,
                           topics: request.streams,
                         },
                         {
-                          onSynchronizedProgress: request.onProgress
-                            ? (window) => request.onProgress?.(toWindow(window))
+                          onTopicSettlement: request.onStreamSettlement
+                            ? ({ topic, window }) =>
+                                request.onStreamSettlement?.({
+                                  stream: topic,
+                                  window: toWindow(window),
+                                })
                             : undefined,
                           signal: request.signal,
                         },

--- a/app/packages/multimodal/src/views/episode/playback/use-register-data-stream.test.tsx
+++ b/app/packages/multimodal/src/views/episode/playback/use-register-data-stream.test.tsx
@@ -115,13 +115,22 @@ interface ResourceClient {
     },
     options?: { readonly priority?: "bulk" | "current" | "idle" | "playback" },
   ): Promise<readonly SynchronizedMessageWindow[]>;
-  readSynchronizedMessages(request: {
-    readonly activeTimeline?: "log";
-    readonly source: ByteSourceDescriptor;
-    readonly streamPolicies?: StreamSyncPolicies;
-    readonly timeNs: bigint;
-    readonly topics: readonly string[];
-  }): Promise<SynchronizedMessageWindow>;
+  readSynchronizedMessages(
+    request: {
+      readonly activeTimeline?: "log";
+      readonly earlyDeliveryTopics?: readonly string[];
+      readonly source: ByteSourceDescriptor;
+      readonly streamPolicies?: StreamSyncPolicies;
+      readonly timeNs: bigint;
+      readonly topics: readonly string[];
+    },
+    options?: {
+      readonly onSynchronizedProgress?: (
+        window: SynchronizedMessageWindow,
+      ) => void;
+      readonly signal?: AbortSignal;
+    },
+  ): Promise<SynchronizedMessageWindow>;
   readTimelineRange(request: {
     readonly activeTimeline?: "log";
     readonly source: ByteSourceDescriptor;
@@ -894,8 +903,10 @@ describe("useRegisterDataStream", () => {
     const storeCapture = capturePlaybackStore();
     const cancelRunway = vi.fn();
     const readSynchronizedMessageBatch = vi.fn(async () => []);
-    const readSynchronizedMessages = vi.fn(async (request) =>
-      createEmptyWindow(request.timeNs),
+    const readSynchronizedMessages = vi.fn(
+      async (
+        request: Parameters<ResourceClient["readSynchronizedMessages"]>[0],
+      ) => createEmptyWindow(request.timeNs),
     );
     const client = createClient({
       cancelRunwayReads: cancelRunway,
@@ -1096,18 +1107,17 @@ describe("stream status + buffering feedback", () => {
     expect(firstBatch?.[1]?.priority).toBe("playback");
 
     await waitFor(() => {
-      expect(client.readSynchronizedMessages).toHaveBeenCalled();
+      expect(client.readSynchronizedMessages).toHaveBeenCalledOnce();
     });
-    const firstCurrentFrame = vi.mocked(client.readSynchronizedMessages).mock
-      .calls[0]?.[0];
-    expect(firstCurrentFrame?.topics).toEqual([
+    const currentFrames = vi.mocked(client.readSynchronizedMessages).mock.calls;
+    expect(currentFrames[0]?.[0].topics).toEqual([
       LIDAR_STREAM,
       RADAR_STREAM,
       STREAM,
     ]);
   });
 
-  it("queues blocking current-frame data before non-blocking map overlays", async () => {
+  it("keeps startup blocking while current-tick demand is one union", async () => {
     const source = createSource("source");
     const storeCapture = capturePlaybackStore();
     const client = createClient({
@@ -1131,11 +1141,371 @@ describe("stream status + buffering feedback", () => {
     );
 
     await waitFor(() => {
-      expect(client.readSynchronizedMessages).toHaveBeenCalledTimes(2);
+      expect(client.readSynchronizedMessages).toHaveBeenCalledOnce();
+      expect(client.readSynchronizedMessageBatch).toHaveBeenCalled();
     });
-    const calls = vi.mocked(client.readSynchronizedMessages).mock.calls;
-    expect(calls[0]?.[0].topics).toEqual([STREAM]);
-    expect(calls[1]?.[0].topics).toEqual([MAP_STREAM]);
+    const currentCalls = vi.mocked(client.readSynchronizedMessages).mock.calls;
+    expect(currentCalls[0]?.[0].topics).toEqual([MAP_STREAM, STREAM]);
+    expect(
+      vi.mocked(client.readSynchronizedMessageBatch).mock.calls[0]?.[0].topics,
+    ).toEqual([STREAM]);
+  });
+
+  it.each([
+    ["forward", [STREAM, LIDAR_STREAM, MAP_STREAM]],
+    ["reverse", [MAP_STREAM, LIDAR_STREAM, STREAM]],
+  ] as const)(
+    "derives one stable current-tick union for a %s subscription batch",
+    async (_direction, subscriptionOrder) => {
+      const allStreams = [STREAM, LIDAR_STREAM, MAP_STREAM] as const;
+      const source = createSource(`subscription-${_direction}`);
+      const storeCapture = capturePlaybackStore();
+      let dataStream: DataStream | null = null;
+      const readSynchronizedMessages = vi.fn(
+        (_request: Parameters<ResourceClient["readSynchronizedMessages"]>[0]) =>
+          new Promise<SynchronizedMessageWindow>(() => undefined),
+      );
+      const client = createClient({
+        readSynchronizedMessageBatch: vi.fn(async () => []),
+        readSynchronizedMessages,
+        readTimelineRange: vi.fn(async () => createTimelineRange()),
+      });
+
+      render(
+        <Harness
+          allStreams={allStreams}
+          blockingStreams={[STREAM, LIDAR_STREAM]}
+          client={client}
+          onDataStream={(next) => {
+            dataStream = next;
+          }}
+          onStore={storeCapture.onStore}
+          source={source}
+          subscribe={false}
+        />,
+        { wrapper: TestProviders },
+      );
+
+      await waitFor(() => {
+        expect(dataStream?.getTimelineIndex()).not.toBeNull();
+      });
+      const currentDataStream = dataStream as DataStream | null;
+      if (!currentDataStream) throw new Error("data stream was not registered");
+
+      act(() => {
+        for (const stream of subscriptionOrder) {
+          currentDataStream.subscribeToStream(stream);
+        }
+      });
+
+      await waitFor(() => {
+        expect(readSynchronizedMessages).toHaveBeenCalledOnce();
+      });
+      expect(readSynchronizedMessages.mock.calls[0]?.[0].topics).toEqual([
+        STREAM,
+        LIDAR_STREAM,
+        MAP_STREAM,
+      ]);
+    },
+  );
+
+  it("reflushes idempotently and reads only genuinely late demand", async () => {
+    const allStreams = [STREAM, LIDAR_STREAM, MAP_STREAM] as const;
+    const source = createSource("subscription-delta");
+    const storeCapture = capturePlaybackStore();
+    let dataStream: DataStream | null = null;
+    const readSynchronizedMessages = vi.fn(
+      (_request: Parameters<ResourceClient["readSynchronizedMessages"]>[0]) =>
+        new Promise<SynchronizedMessageWindow>(() => undefined),
+    );
+    const client = createClient({
+      readSynchronizedMessageBatch: vi.fn(async () => []),
+      readSynchronizedMessages,
+      readTimelineRange: vi.fn(async () => createTimelineRange()),
+    });
+
+    render(
+      <Harness
+        allStreams={allStreams}
+        blockingStreams={allStreams}
+        client={client}
+        onDataStream={(next) => {
+          dataStream = next;
+        }}
+        onStore={storeCapture.onStore}
+        source={source}
+        subscribe={false}
+      />,
+      { wrapper: TestProviders },
+    );
+
+    await waitFor(() => {
+      expect(dataStream?.getTimelineIndex()).not.toBeNull();
+    });
+    const currentDataStream = dataStream as DataStream | null;
+    if (!currentDataStream) throw new Error("data stream was not registered");
+
+    act(() => {
+      currentDataStream.subscribeToStream(STREAM);
+      currentDataStream.subscribeToStream(LIDAR_STREAM);
+    });
+    await waitFor(() => {
+      expect(readSynchronizedMessages).toHaveBeenCalledOnce();
+    });
+    expect(readSynchronizedMessages.mock.calls[0]?.[0].topics).toEqual([
+      STREAM,
+      LIDAR_STREAM,
+    ]);
+
+    act(() => {
+      currentDataStream.subscribeToStream(STREAM);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(readSynchronizedMessages).toHaveBeenCalledOnce();
+
+    act(() => {
+      currentDataStream.subscribeToStream(MAP_STREAM);
+    });
+    await waitFor(() => {
+      expect(readSynchronizedMessages).toHaveBeenCalledTimes(2);
+    });
+    expect(readSynchronizedMessages.mock.calls[1]?.[0].topics).toEqual([
+      MAP_STREAM,
+    ]);
+  });
+
+  it("retries live demand when the timeline index becomes ready", async () => {
+    const timeline = deferred<TimelineRange>();
+    const source = createSource("index-ready-flush");
+    const storeCapture = capturePlaybackStore();
+    const readSynchronizedMessages = vi.fn(async (request) =>
+      createEmptyWindow(request.timeNs),
+    );
+    const client = createClient({
+      readSynchronizedMessageBatch: vi.fn(async () => []),
+      readSynchronizedMessages,
+      readTimelineRange: vi.fn(() => timeline.promise),
+    });
+
+    render(
+      <Harness
+        client={client}
+        onStore={storeCapture.onStore}
+        source={source}
+      />,
+      { wrapper: TestProviders },
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(readSynchronizedMessages).not.toHaveBeenCalled();
+
+    await act(async () => {
+      timeline.resolve(createTimelineRange());
+      await timeline.promise;
+    });
+
+    await waitFor(() => {
+      expect(readSynchronizedMessages).toHaveBeenCalledOnce();
+    });
+    expect(readSynchronizedMessages.mock.calls[0]?.[0]).toMatchObject({
+      source,
+      topics: [STREAM],
+    });
+  });
+
+  it("rejects old current-tick delivery after a rapid source commit", async () => {
+    const sourceA = createSource("queued-source-a");
+    const sourceB = createSource("queued-source-b");
+    const storeCapture = capturePlaybackStore();
+    let dataStream: DataStream | null = null;
+    const sourceARead = deferred<SynchronizedMessageWindow>();
+    let sourceAProgress:
+      | ((window: SynchronizedMessageWindow) => void)
+      | undefined;
+    const readSynchronizedMessages = vi.fn((request, options) => {
+      if (request.source.sourceId === sourceA.sourceId) {
+        sourceAProgress = options?.onSynchronizedProgress;
+        return sourceARead.promise;
+      }
+      return new Promise<SynchronizedMessageWindow>(() => undefined);
+    });
+    const client = createClient({
+      readSynchronizedMessageBatch: vi.fn(async () => []),
+      readSynchronizedMessages,
+      readTimelineRange: vi.fn(async () => createTimelineRange()),
+    });
+    const props = {
+      client,
+      onDataStream: (next: DataStream | null) => {
+        dataStream = next;
+      },
+      onStore: storeCapture.onStore,
+      subscribe: false,
+    } as const;
+
+    const { rerender } = render(<Harness {...props} source={sourceA} />, {
+      wrapper: TestProviders,
+    });
+    await waitFor(() => {
+      expect(dataStream?.getTimelineIndex()).not.toBeNull();
+    });
+    const sourceADataStream = dataStream as DataStream | null;
+    if (!sourceADataStream) throw new Error("data stream was not registered");
+    readSynchronizedMessages.mockClear();
+
+    act(() => {
+      sourceADataStream.subscribeToStream(STREAM);
+    });
+    await waitFor(() => {
+      expect(readSynchronizedMessages).toHaveBeenCalledOnce();
+    });
+    rerender(<Harness {...props} source={null} />);
+    await act(async () => {
+      sourceAProgress?.(createMultiStreamWindow(0n, [STREAM]));
+      sourceARead.resolve(
+        createWindow({
+          timeNs: 0n,
+          visualization: {
+            bytes: new Uint8Array([1]),
+            kind: VISUALIZATION_KIND.ENCODED_IMAGE,
+          },
+        }),
+      );
+      await Promise.resolve();
+    });
+    expect(getStreamValue(storeCapture.store(), STREAM)).toBeNull();
+
+    rerender(<Harness {...props} source={sourceB} />);
+    await waitFor(() => {
+      expect(readSynchronizedMessages).toHaveBeenCalledTimes(2);
+    });
+    expect(readSynchronizedMessages.mock.calls[1]?.[0].source).toEqual(sourceB);
+  });
+
+  it("publishes first surface and blocking readiness atomically before startup continuation", async () => {
+    const presentation = deferred<SynchronizedMessageWindow>();
+    const source = createSource("blocking-first-surface-delivery");
+    const storeCapture = capturePlaybackStore();
+    const onPlayheadDataReady = vi.fn();
+    const client = createClient({
+      readSynchronizedMessageBatch: vi.fn(
+        () =>
+          new Promise<readonly SynchronizedMessageWindow[]>(() => undefined),
+      ),
+      readSynchronizedMessages: vi.fn(() => presentation.promise),
+      readTimelineRange: vi.fn(async () => createTimelineRange()),
+    });
+
+    render(
+      <Harness
+        allStreams={[STREAM, LIDAR_STREAM]}
+        blockingStreams={[STREAM, LIDAR_STREAM]}
+        client={client}
+        onPlayheadDataReady={onPlayheadDataReady}
+        onStore={storeCapture.onStore}
+        source={source}
+        subscribedStreams={[STREAM, LIDAR_STREAM]}
+      />,
+      { wrapper: TestProviders },
+    );
+    const store = storeCapture.store();
+
+    await waitFor(() => {
+      expect(client.readSynchronizedMessages).toHaveBeenCalledOnce();
+      expect(client.readSynchronizedMessageBatch).toHaveBeenCalledOnce();
+    });
+    expect(getStreamValue(store, STREAM)).toBeNull();
+    expect(getStreamValue(store, LIDAR_STREAM)).toBeNull();
+    expect(onPlayheadDataReady).not.toHaveBeenCalled();
+
+    await act(async () => {
+      presentation.resolve(createMultiStreamWindow(0n, [STREAM, LIDAR_STREAM]));
+      await presentation.promise;
+    });
+    await waitFor(() => {
+      expect(getStreamValue(store, STREAM)).not.toBeNull();
+      expect(getStreamValue(store, LIDAR_STREAM)).not.toBeNull();
+      expect(onPlayheadDataReady).toHaveBeenCalled();
+    });
+  });
+
+  it("publishes one early surface before final blocking readiness", async () => {
+    const current = deferred<SynchronizedMessageWindow>();
+    const source = createSource("atomic-current-delivery");
+    const storeCapture = capturePlaybackStore();
+    const onPlayheadDataReady = vi.fn();
+    let publishProgress:
+      | ((window: SynchronizedMessageWindow) => void)
+      | undefined;
+    const client = createClient({
+      readSynchronizedMessageBatch: vi.fn(
+        () =>
+          new Promise<readonly SynchronizedMessageWindow[]>(() => undefined),
+      ),
+      readSynchronizedMessages: vi.fn((_request, options) => {
+        publishProgress = options?.onSynchronizedProgress;
+        return current.promise;
+      }),
+      readTimelineRange: vi.fn(async () => createTimelineRange()),
+    });
+
+    render(
+      <Harness
+        allStreams={[STREAM, LIDAR_STREAM, MAP_STREAM]}
+        blockingStreams={[STREAM, LIDAR_STREAM]}
+        client={client}
+        onPlayheadDataReady={onPlayheadDataReady}
+        onStore={storeCapture.onStore}
+        source={source}
+        subscribedStreams={[STREAM, LIDAR_STREAM, MAP_STREAM]}
+      />,
+      { wrapper: TestProviders },
+    );
+    const store = storeCapture.store();
+
+    await waitFor(() => {
+      expect(client.readSynchronizedMessages).toHaveBeenCalledOnce();
+    });
+    expect(client.readSynchronizedMessages).toHaveBeenCalledWith(
+      expect.objectContaining({
+        earlyDeliveryTopics: [STREAM, LIDAR_STREAM],
+        topics: [STREAM, LIDAR_STREAM, MAP_STREAM],
+      }),
+      expect.objectContaining({
+        onSynchronizedProgress: expect.any(Function),
+      }),
+    );
+    expect(getStreamValue(store, STREAM)).toBeNull();
+    expect(getStreamValue(store, LIDAR_STREAM)).toBeNull();
+    expect(getStreamValue(store, MAP_STREAM)).toBeNull();
+    expect(onPlayheadDataReady).not.toHaveBeenCalled();
+
+    await act(async () => {
+      publishProgress?.(createMultiStreamWindow(0n, [STREAM]));
+    });
+    await waitFor(() => {
+      expect(getStreamValue(store, STREAM)).not.toBeNull();
+    });
+    expect(getStreamValue(store, LIDAR_STREAM)).toBeNull();
+    expect(getStreamValue(store, MAP_STREAM)).toBeNull();
+    expect(onPlayheadDataReady).not.toHaveBeenCalled();
+
+    await act(async () => {
+      current.resolve(
+        createMultiStreamWindow(0n, [STREAM, LIDAR_STREAM, MAP_STREAM]),
+      );
+      await current.promise;
+    });
+    await waitFor(() => {
+      expect(getStreamValue(store, STREAM)).not.toBeNull();
+      expect(getStreamValue(store, LIDAR_STREAM)).not.toBeNull();
+      expect(getStreamValue(store, MAP_STREAM)).not.toBeNull();
+      expect(onPlayheadDataReady).toHaveBeenCalled();
+    });
   });
 
   it("does not queue idle background lookahead while startup data is still in flight", async () => {
@@ -2791,6 +3161,7 @@ function Harness({
   blockingStreams = DEFAULT_TEST_STREAMS,
   client,
   initialSeekTimeNs,
+  onPlayheadDataReady,
   onStore,
   onApi,
   onDataStream,
@@ -2806,6 +3177,7 @@ function Harness({
   readonly blockingStreams?: readonly string[];
   readonly client: ResourceClient;
   readonly initialSeekTimeNs?: bigint | null;
+  readonly onPlayheadDataReady?: () => void;
   readonly onStore: (store: PlaybackStore) => void;
   readonly onApi?: (api: ReturnType<typeof usePlayback>) => void;
   readonly onDataStream?: (dataStream: DataStream | null) => void;
@@ -2835,6 +3207,7 @@ function Harness({
     blockingStreams,
     endBoundedStreams: [],
     initialSeekTimeNs,
+    onPlayheadDataReady,
     session,
     source,
     staleWarningStreams,
@@ -2984,13 +3357,22 @@ function useTestSession(
                     })),
                   readSynchronized: async (request) =>
                     toWindow(
-                      await client.readSynchronizedMessages({
-                        activeTimeline: "log",
-                        source,
-                        streamPolicies: request.streamPolicies,
-                        timeNs: request.timeNs,
-                        topics: request.streams,
-                      }),
+                      await client.readSynchronizedMessages(
+                        {
+                          activeTimeline: "log",
+                          earlyDeliveryTopics: request.earlyDeliveryStreams,
+                          source,
+                          streamPolicies: request.streamPolicies,
+                          timeNs: request.timeNs,
+                          topics: request.streams,
+                        },
+                        {
+                          onSynchronizedProgress: request.onProgress
+                            ? (window) => request.onProgress?.(toWindow(window))
+                            : undefined,
+                          signal: request.signal,
+                        },
+                      ),
                     ),
                   readSynchronizedBatch: async (request, options) =>
                     (
@@ -3146,6 +3528,33 @@ function createEmptyWindow(timeNs: bigint): SynchronizedMessageWindow {
     endTimeNs: timeNs,
     messages: [],
     messagesByTopic: {},
+    startTimeNs: timeNs,
+    streamPolicies: {},
+    timeNs,
+  };
+}
+
+function createMultiStreamWindow(
+  timeNs: bigint,
+  streams: readonly string[],
+): SynchronizedMessageWindow {
+  const messages = streams.map((stream) =>
+    createDecodedMessage({
+      stream,
+      timeNs,
+      visualization: {
+        bytes: new Uint8Array([1]),
+        kind: VISUALIZATION_KIND.ENCODED_IMAGE,
+      },
+    }),
+  );
+  return {
+    activeTimeline: "log",
+    endTimeNs: timeNs,
+    messages,
+    messagesByTopic: Object.fromEntries(
+      messages.map((message) => [message.topic, [message]]),
+    ),
     startTimeNs: timeNs,
     streamPolicies: {},
     timeNs,

--- a/app/packages/multimodal/src/views/episode/playback/use-register-data-stream.test.tsx
+++ b/app/packages/multimodal/src/views/episode/playback/use-register-data-stream.test.tsx
@@ -129,6 +129,12 @@ interface ResourceClient {
         readonly topic: string;
         readonly window: SynchronizedMessageWindow;
       }) => void;
+      readonly onTopicSettlements?: (
+        settlements: readonly {
+          readonly topic: string;
+          readonly window: SynchronizedMessageWindow;
+        }[],
+      ) => void;
       readonly signal?: AbortSignal;
     },
   ): Promise<SynchronizedMessageWindow>;
@@ -1262,7 +1268,7 @@ describe("stream status + buffering feedback", () => {
       currentDataStream.subscribeToStream(STREAM);
     });
     await act(async () => {
-      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
     });
     expect(readSynchronizedMessages).toHaveBeenCalledOnce();
 
@@ -1452,11 +1458,13 @@ describe("stream status + buffering feedback", () => {
     const source = createSource("atomic-current-delivery");
     const storeCapture = capturePlaybackStore();
     const onPlayheadDataReady = vi.fn();
-    let publishSettlement:
-      | ((settlement: {
-          readonly topic: string;
-          readonly window: SynchronizedMessageWindow;
-        }) => void)
+    let publishSettlements:
+      | ((
+          settlements: readonly {
+            readonly topic: string;
+            readonly window: SynchronizedMessageWindow;
+          }[],
+        ) => void)
       | undefined;
     const client = createClient({
       readSynchronizedMessageBatch: vi.fn(
@@ -1468,7 +1476,7 @@ describe("stream status + buffering feedback", () => {
           _request: Parameters<ResourceClient["readSynchronizedMessages"]>[0],
           options?: Parameters<ResourceClient["readSynchronizedMessages"]>[1],
         ) => {
-          publishSettlement = options?.onTopicSettlement;
+          publishSettlements = options?.onTopicSettlements;
           return current.promise;
         },
       ),
@@ -1498,7 +1506,7 @@ describe("stream status + buffering feedback", () => {
         topics: [STREAM, LIDAR_STREAM, MAP_STREAM],
       }),
       expect.objectContaining({
-        onTopicSettlement: expect.any(Function),
+        onTopicSettlements: expect.any(Function),
       }),
     );
     expect(getStreamValue(store, STREAM)).toBeNull();
@@ -1507,25 +1515,19 @@ describe("stream status + buffering feedback", () => {
     expect(onPlayheadDataReady).not.toHaveBeenCalled();
 
     await act(async () => {
-      publishSettlement?.({
-        topic: STREAM,
-        window: createMultiStreamWindow(0n, [STREAM]),
-      });
+      publishSettlements?.([
+        {
+          topic: STREAM,
+          window: createMultiStreamWindow(0n, [STREAM]),
+        },
+        {
+          topic: LIDAR_STREAM,
+          window: createMultiStreamWindow(0n, [LIDAR_STREAM]),
+        },
+      ]);
     });
     await waitFor(() => {
       expect(getStreamValue(store, STREAM)).not.toBeNull();
-    });
-    expect(getStreamValue(store, LIDAR_STREAM)).toBeNull();
-    expect(getStreamValue(store, MAP_STREAM)).toBeNull();
-    expect(onPlayheadDataReady).not.toHaveBeenCalled();
-
-    await act(async () => {
-      publishSettlement?.({
-        topic: LIDAR_STREAM,
-        window: createMultiStreamWindow(0n, [LIDAR_STREAM]),
-      });
-    });
-    await waitFor(() => {
       expect(getStreamValue(store, LIDAR_STREAM)).not.toBeNull();
       expect(onPlayheadDataReady).toHaveBeenCalled();
     });
@@ -3405,6 +3407,15 @@ function useTestSession(
                           topics: request.streams,
                         },
                         {
+                          onTopicSettlements: request.onStreamSettlements
+                            ? (settlements) =>
+                                request.onStreamSettlements?.(
+                                  settlements.map(({ topic, window }) => ({
+                                    stream: topic,
+                                    window: toWindow(window),
+                                  })),
+                                )
+                            : undefined,
                           onTopicSettlement: request.onStreamSettlement
                             ? ({ topic, window }) =>
                                 request.onStreamSettlement?.({

--- a/app/packages/multimodal/src/views/episode/playback/use-register-data-stream.test.tsx
+++ b/app/packages/multimodal/src/views/episode/playback/use-register-data-stream.test.tsx
@@ -1326,13 +1326,18 @@ describe("stream status + buffering feedback", () => {
     let sourceAProgress:
       | ((window: SynchronizedMessageWindow) => void)
       | undefined;
-    const readSynchronizedMessages = vi.fn((request, options) => {
-      if (request.source.sourceId === sourceA.sourceId) {
-        sourceAProgress = options?.onSynchronizedProgress;
-        return sourceARead.promise;
-      }
-      return new Promise<SynchronizedMessageWindow>(() => undefined);
-    });
+    const readSynchronizedMessages = vi.fn(
+      (
+        request: Parameters<ResourceClient["readSynchronizedMessages"]>[0],
+        options?: Parameters<ResourceClient["readSynchronizedMessages"]>[1],
+      ) => {
+        if (request.source.sourceId === sourceA.sourceId) {
+          sourceAProgress = options?.onSynchronizedProgress;
+          return sourceARead.promise;
+        }
+        return new Promise<SynchronizedMessageWindow>(() => undefined);
+      },
+    );
     const client = createClient({
       readSynchronizedMessageBatch: vi.fn(async () => []),
       readSynchronizedMessages,
@@ -1446,10 +1451,15 @@ describe("stream status + buffering feedback", () => {
         () =>
           new Promise<readonly SynchronizedMessageWindow[]>(() => undefined),
       ),
-      readSynchronizedMessages: vi.fn((_request, options) => {
-        publishProgress = options?.onSynchronizedProgress;
-        return current.promise;
-      }),
+      readSynchronizedMessages: vi.fn(
+        (
+          _request: Parameters<ResourceClient["readSynchronizedMessages"]>[0],
+          options?: Parameters<ResourceClient["readSynchronizedMessages"]>[1],
+        ) => {
+          publishProgress = options?.onSynchronizedProgress;
+          return current.promise;
+        },
+      ),
       readTimelineRange: vi.fn(async () => createTimelineRange()),
     });
 

--- a/app/packages/multimodal/src/views/episode/playback/use-register-data-stream.test.tsx
+++ b/app/packages/multimodal/src/views/episode/playback/use-register-data-stream.test.tsx
@@ -1280,8 +1280,10 @@ describe("stream status + buffering feedback", () => {
     const timeline = deferred<TimelineRange>();
     const source = createSource("index-ready-flush");
     const storeCapture = capturePlaybackStore();
-    const readSynchronizedMessages = vi.fn(async (request) =>
-      createEmptyWindow(request.timeNs),
+    const readSynchronizedMessages = vi.fn(
+      async (
+        request: Parameters<ResourceClient["readSynchronizedMessages"]>[0],
+      ) => createEmptyWindow(request.timeNs),
     );
     const client = createClient({
       readSynchronizedMessageBatch: vi.fn(async () => []),

--- a/app/packages/multimodal/src/views/episode/playback/use-register-data-stream.ts
+++ b/app/packages/multimodal/src/views/episode/playback/use-register-data-stream.ts
@@ -303,7 +303,6 @@ export function useRegisterDataStream({
   // The passive source effect below still owns the actual cache/session reset.
   useLayoutEffect(() => {
     sourceEpochRef.current += 1;
-    currentTickFlushScheduleEpochRef.current = null;
   }, [playback, source, timelineSamplingRateHz]);
 
   // Hold the most recent `allStreams` / `streamPolicies` in refs so the
@@ -543,7 +542,6 @@ export function useRegisterDataStream({
     streamStartTimesNsRef.current.clear();
     streamEndTimesNsRef.current.clear();
     autoSeekSourceEpochRef.current = null;
-    autoSeekScheduleEpochRef.current = null;
     deferredBatchAdmissionRef.current = false;
     lastSeekAtMsRef.current = null;
     startupCushionPlanner.resetPendingPlan();

--- a/app/packages/multimodal/src/views/episode/playback/use-register-data-stream.ts
+++ b/app/packages/multimodal/src/views/episode/playback/use-register-data-stream.ts
@@ -148,6 +148,8 @@ export interface UseDataStreamOptions {
   session: EpisodeSession | null;
   /** Called whenever every blocking stream covers the current playhead. */
   onPlayheadDataReady?: () => void;
+  /** Streams eligible for the first independently useful settlement. */
+  firstUsefulSettlementStreams?: readonly string[];
   /** Stable presentation-first order for authoritative current-tick delivery. */
   settlementPriorityStreams?: readonly string[];
   source: ByteSourceDescriptor | null;
@@ -177,6 +179,7 @@ export function useRegisterDataStream({
   blockingStreams,
   endBoundedStreams,
   initialSeekTimeNs,
+  firstUsefulSettlementStreams = [],
   session,
   onPlayheadDataReady,
   settlementPriorityStreams = blockingStreams,
@@ -315,6 +318,7 @@ export function useRegisterDataStream({
   const blockingStreamsRef = useRef<ReadonlySet<string>>(
     new Set(blockingStreams),
   );
+  const firstUsefulSettlementStreamsRef = useRef(firstUsefulSettlementStreams);
   const settlementPriorityStreamsRef = useRef(settlementPriorityStreams);
   const endBoundedStreamsRef = useRef<ReadonlySet<string>>(
     new Set(endBoundedStreams),
@@ -333,6 +337,9 @@ export function useRegisterDataStream({
   useEffect(() => {
     blockingStreamsRef.current = new Set(blockingStreams);
   }, [blockingStreams]);
+  useEffect(() => {
+    firstUsefulSettlementStreamsRef.current = firstUsefulSettlementStreams;
+  }, [firstUsefulSettlementStreams]);
   useEffect(() => {
     settlementPriorityStreamsRef.current = settlementPriorityStreams;
   }, [settlementPriorityStreams]);
@@ -379,6 +386,12 @@ export function useRegisterDataStream({
     );
     return prioritized.length > 0 ? prioritized : activeBlockingStreams;
   }, [getActiveBlockingStreams]);
+  const getActiveFirstUsefulSettlementStreams = useCallback((): string[] => {
+    const activeStreams = new Set(getActiveStreams());
+    return firstUsefulSettlementStreamsRef.current.filter((stream) =>
+      activeStreams.has(stream),
+    );
+  }, [getActiveStreams]);
 
   const clearPausedIdleWarmupTimer = useCallback(() => {
     if (pausedIdleWarmupTimerRef.current === null) return;
@@ -846,6 +859,8 @@ export function useRegisterDataStream({
                 ? byteTimelineRef.current
                 : null,
             getBlockingStreams: () => blockingStreamsRef.current,
+            getFirstUsefulSettlementStreams:
+              getActiveFirstUsefulSettlementStreams,
             getIndex: () => indexRef.current,
             getLastSeekAtMs: () => lastSeekAtMsRef.current,
             getSettlementPriorityStreams: getActiveSettlementPriorityStreams,
@@ -864,6 +879,7 @@ export function useRegisterDataStream({
       computeBufferedRanges,
       fetchState,
       getActiveBlockingStreams,
+      getActiveFirstUsefulSettlementStreams,
       getActiveStreams,
       getActiveSettlementPriorityStreams,
       prefetcher,

--- a/app/packages/multimodal/src/views/episode/playback/use-register-data-stream.ts
+++ b/app/packages/multimodal/src/views/episode/playback/use-register-data-stream.ts
@@ -148,6 +148,8 @@ export interface UseDataStreamOptions {
   session: EpisodeSession | null;
   /** Called whenever every blocking stream covers the current playhead. */
   onPlayheadDataReady?: () => void;
+  /** Stable presentation-first order for authoritative current-tick delivery. */
+  settlementPriorityStreams?: readonly string[];
   source: ByteSourceDescriptor | null;
   allStreams: readonly string[];
   staleWarningStreams: readonly string[];
@@ -177,6 +179,7 @@ export function useRegisterDataStream({
   initialSeekTimeNs,
   session,
   onPlayheadDataReady,
+  settlementPriorityStreams = blockingStreams,
   source,
   allStreams,
   staleWarningStreams,
@@ -312,6 +315,7 @@ export function useRegisterDataStream({
   const blockingStreamsRef = useRef<ReadonlySet<string>>(
     new Set(blockingStreams),
   );
+  const settlementPriorityStreamsRef = useRef(settlementPriorityStreams);
   const endBoundedStreamsRef = useRef<ReadonlySet<string>>(
     new Set(endBoundedStreams),
   );
@@ -329,6 +333,9 @@ export function useRegisterDataStream({
   useEffect(() => {
     blockingStreamsRef.current = new Set(blockingStreams);
   }, [blockingStreams]);
+  useEffect(() => {
+    settlementPriorityStreamsRef.current = settlementPriorityStreams;
+  }, [settlementPriorityStreams]);
   // This effect keeps the readiness callback current without rebuilding streams.
   useEffect(() => {
     onPlayheadDataReadyRef.current = onPlayheadDataReady;
@@ -364,6 +371,14 @@ export function useRegisterDataStream({
     );
     return blockingStreams.length > 0 ? blockingStreams : activeStreams;
   }, [getActiveStreams]);
+  const getActiveSettlementPriorityStreams = useCallback((): string[] => {
+    const activeBlockingStreams = getActiveBlockingStreams();
+    const activeBlockingSet = new Set(activeBlockingStreams);
+    const prioritized = settlementPriorityStreamsRef.current.filter((stream) =>
+      activeBlockingSet.has(stream),
+    );
+    return prioritized.length > 0 ? prioritized : activeBlockingStreams;
+  }, [getActiveBlockingStreams]);
 
   const clearPausedIdleWarmupTimer = useCallback(() => {
     if (pausedIdleWarmupTimerRef.current === null) return;
@@ -833,6 +848,7 @@ export function useRegisterDataStream({
             getBlockingStreams: () => blockingStreamsRef.current,
             getIndex: () => indexRef.current,
             getLastSeekAtMs: () => lastSeekAtMsRef.current,
+            getSettlementPriorityStreams: getActiveSettlementPriorityStreams,
             hasDeferredBatchAdmission: () => deferredBatchAdmissionRef.current,
             isSourceAvailable: () => source !== null,
             lastFrames: lastFrameRef.current,
@@ -849,6 +865,7 @@ export function useRegisterDataStream({
       fetchState,
       getActiveBlockingStreams,
       getActiveStreams,
+      getActiveSettlementPriorityStreams,
       prefetcher,
       playbackPolicy,
       publishStreamStatuses,

--- a/app/packages/multimodal/src/views/episode/playback/use-register-data-stream.ts
+++ b/app/packages/multimodal/src/views/episode/playback/use-register-data-stream.ts
@@ -12,6 +12,7 @@ import {
 } from "@fiftyone/playback";
 import { seekEventAtom } from "@fiftyone/playback/runtime";
 import {
+  type MutableRefObject,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -97,6 +98,22 @@ const REMOTE_SEEK_FETCH_DEBOUNCE_MS = 150;
 const LOCAL_STARTUP_BUFFER_SECONDS = 0.1;
 
 const noop = (): void => undefined;
+
+function scheduleOncePerEpoch(
+  scheduleEpochRef: MutableRefObject<number | null>,
+  sourceEpochRef: MutableRefObject<number>,
+  work: () => void,
+): void {
+  const currentEpoch = sourceEpochRef.current;
+  if (scheduleEpochRef.current === currentEpoch) return;
+  scheduleEpochRef.current = currentEpoch;
+  void Promise.resolve().then(() => {
+    if (scheduleEpochRef.current === currentEpoch) {
+      scheduleEpochRef.current = null;
+    }
+    if (sourceEpochRef.current === currentEpoch) work();
+  });
+}
 
 /** Treats cancellation against an already-disposed session as complete. */
 export function cancelIdleReads(
@@ -272,6 +289,7 @@ export function useRegisterDataStream({
   >(new Map());
   const autoSeekSourceEpochRef = useRef<number | null>(null);
   const autoSeekScheduleEpochRef = useRef<number | null>(null);
+  const currentTickFlushScheduleEpochRef = useRef<number | null>(null);
   const deferredBatchAdmissionRef = useRef(false);
   const lastSeekAtMsRef = useRef<number | null>(null);
   const [startupCushionPlanner] = useState(() => new StartupCushionPlanner());
@@ -279,6 +297,15 @@ export function useRegisterDataStream({
   const byteTimelineRef = useRef<readonly ByteTimelinePoint[] | null>(null);
   const sourceEpochRef = useRef(0);
   indexRef.current = index;
+
+  // Advance the source epoch at commit time, before any subscription microtask
+  // can flush against a playback instance that the new render has replaced.
+  // The passive source effect below still owns the actual cache/session reset.
+  useLayoutEffect(() => {
+    sourceEpochRef.current += 1;
+    currentTickFlushScheduleEpochRef.current = null;
+  }, [playback, source, timelineSamplingRateHz]);
+
   // Hold the most recent `allStreams` / `streamPolicies` in refs so the
   // stable callbacks below read fresh values without listing them as
   // deps (which would invalidate the registered stream every render).
@@ -480,17 +507,11 @@ export function useRegisterDataStream({
   // auto-seek checks lets the target consider the complete visible set instead
   // of committing to whichever short-skew stream subscribes first.
   const scheduleAutoSeekToFirstData = useCallback(() => {
-    const currentEpoch = sourceEpochRef.current;
-    if (autoSeekScheduleEpochRef.current === currentEpoch) return;
-    autoSeekScheduleEpochRef.current = currentEpoch;
-    void Promise.resolve().then(() => {
-      if (autoSeekScheduleEpochRef.current === currentEpoch) {
-        autoSeekScheduleEpochRef.current = null;
-      }
-      if (sourceEpochRef.current === currentEpoch) {
-        maybeAutoSeekToFirstData();
-      }
-    });
+    scheduleOncePerEpoch(
+      autoSeekScheduleEpochRef,
+      sourceEpochRef,
+      maybeAutoSeekToFirstData,
+    );
   }, [maybeAutoSeekToFirstData]);
 
   // This effect ensures a cache exists for every known stream.
@@ -513,7 +534,6 @@ export function useRegisterDataStream({
   // combine a new timeline with old ticks or stale frames while the async range
   // load is in flight.
   useEffect(() => {
-    sourceEpochRef.current += 1;
     const sourceEpoch = sourceEpochRef.current;
     setIndex(null);
     byteTimelineRef.current = null;
@@ -534,7 +554,7 @@ export function useRegisterDataStream({
     cancelIdleReads(session);
     for (const cache of streamCachesRef.current.values()) {
       cache.resize(playbackPolicy.streamCacheMaxEntries);
-      cache.clear();
+      cache.reset();
     }
     for (const stream of streamCachesRef.current.keys()) {
       setStreamValue(store, stream, null);
@@ -908,6 +928,15 @@ export function useRegisterDataStream({
     [scheduler],
   );
 
+  // Stream subscriptions mount as one React effect batch. Defer acquisition
+  // until that batch settles, then derive the complete visible demand from
+  // the live caches instead of preserving subscription order as read order.
+  const scheduleCurrentTickFlush = useCallback(() => {
+    scheduleOncePerEpoch(currentTickFlushScheduleEpochRef, sourceEpochRef, () =>
+      prefetchLookaheadFrom(getPlayhead(store)),
+    );
+  }, [prefetchLookaheadFrom, store]);
+
   // This effect registers the engine stream and proactive lookahead subscription.
   useEffect(() => {
     return scheduler?.register(registerStream, subscribeStream);
@@ -941,12 +970,11 @@ export function useRegisterDataStream({
     });
   }, [rebalanceDecodedCaches, session, startupCushionPlanner, store]);
 
-  // This effect kicks off lookahead so the buffer fills before play or seek.
-  // (May be a no-op if no tile has subscribed yet — subscribeToStream also
-  // triggers this for the same reason.)
+  // Timeline readiness is a flush trigger: an earlier subscription flush may
+  // have observed no index, so derive the live demand again once it exists.
   useEffect(() => {
-    if (index) prefetchLookaheadFrom(getPlayhead(store));
-  }, [index, prefetchLookaheadFrom, store]);
+    if (index) scheduleCurrentTickFlush();
+  }, [index, scheduleCurrentTickFlush]);
 
   // Expose subscribeToStream via the playback store so tiles can subscribe
   // without a React context hierarchy constraint. The first subscription for
@@ -970,7 +998,7 @@ export function useRegisterDataStream({
       }
       const cleanup = cache.subscribe();
       scheduleAutoSeekToFirstData();
-      prefetchLookaheadFrom(getPlayhead(store));
+      scheduleCurrentTickFlush();
       return () => {
         cleanup();
         if (colorBy) {
@@ -1006,10 +1034,9 @@ export function useRegisterDataStream({
     },
     [
       getActiveStreams,
-      prefetchLookaheadFrom,
       scheduleAutoSeekToFirstData,
+      scheduleCurrentTickFlush,
       session,
-      store,
     ],
   );
 

--- a/app/packages/multimodal/src/views/episode/playback/use-register-data-stream.ts
+++ b/app/packages/multimodal/src/views/episode/playback/use-register-data-stream.ts
@@ -553,8 +553,8 @@ export function useRegisterDataStream({
     // speculative idle work as well so the old cadence stops consuming I/O.
     cancelIdleReads(session);
     for (const cache of streamCachesRef.current.values()) {
-      cache.resize(playbackPolicy.streamCacheMaxEntries);
       cache.reset();
+      cache.resize(playbackPolicy.streamCacheMaxEntries);
     }
     for (const stream of streamCachesRef.current.keys()) {
       setStreamValue(store, stream, null);

--- a/app/packages/multimodal/src/views/episode/playback/use-register-data-stream.ts
+++ b/app/packages/multimodal/src/views/episode/playback/use-register-data-stream.ts
@@ -705,43 +705,47 @@ export function useRegisterDataStream({
     startupCushionPlanner.resetPendingPlan();
   }, [isPlaying, startupCushionPlanner]);
 
-  const publishStreamStatuses = useCallback(() => {
-    publishDataStreamStatuses({
-      activeBlockingStreams: getActiveBlockingStreams(),
-      activeStreams: getActiveStreams(),
-      caches: streamCachesRef.current,
-      failedStreams: fetchState.failedStreams,
-      index: indexRef.current,
-      onPlayheadDataReady: onPlayheadDataReadyRef.current,
-      policy: playbackPolicy,
+  const publishStreamStatuses = useCallback(
+    (updatedStreams?: readonly string[]) => {
+      publishDataStreamStatuses({
+        activeBlockingStreams: getActiveBlockingStreams(),
+        activeStreams: getActiveStreams(),
+        caches: streamCachesRef.current,
+        failedStreams: fetchState.failedStreams,
+        index: indexRef.current,
+        onPlayheadDataReady: onPlayheadDataReadyRef.current,
+        policy: playbackPolicy,
+        publishBufferedRangesNow,
+        pushCurrentTick: (activeStreams, tick) =>
+          pushTickToStore(
+            [...activeStreams],
+            tick,
+            streamCachesRef.current,
+            lastFrameRef.current,
+            store,
+            fetchState.failedStreams,
+          ),
+        resolveStartupCushion,
+        scheduleBufferedRangesPublish,
+        schedulePausedIdleWarmup: (delayMs) =>
+          schedulePausedIdleWarmupRef.current?.(delayMs),
+        staleWarningStreams: staleWarningStreamsRef.current,
+        streamNames: streamNamesRef.current,
+        store,
+        updatedStreams,
+      });
+    },
+    [
+      fetchState,
+      getActiveBlockingStreams,
+      getActiveStreams,
       publishBufferedRangesNow,
-      pushCurrentTick: (activeStreams, tick) =>
-        pushTickToStore(
-          [...activeStreams],
-          tick,
-          streamCachesRef.current,
-          lastFrameRef.current,
-          store,
-          fetchState.failedStreams,
-        ),
+      playbackPolicy,
       resolveStartupCushion,
       scheduleBufferedRangesPublish,
-      schedulePausedIdleWarmup: (delayMs) =>
-        schedulePausedIdleWarmupRef.current?.(delayMs),
-      staleWarningStreams: staleWarningStreamsRef.current,
-      streamNames: streamNamesRef.current,
       store,
-    });
-  }, [
-    fetchState,
-    getActiveBlockingStreams,
-    getActiveStreams,
-    publishBufferedRangesNow,
-    playbackPolicy,
-    resolveStartupCushion,
-    scheduleBufferedRangesPublish,
-    store,
-  ]);
+    ],
+  );
 
   const rebalanceDecodedCaches = useCallback(() => {
     backgroundLookaheadSecondsRef.current = applyDecodedCachePolicy({

--- a/app/packages/multimodal/src/views/episode/shell/ModalRenderer.module.css
+++ b/app/packages/multimodal/src/views/episode/shell/ModalRenderer.module.css
@@ -25,7 +25,10 @@
 
 .transitionStatus {
   color: var(--color-content-text-muted);
-  font-size: 11px;
+  font-size: 0.75rem;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 

--- a/app/packages/multimodal/src/views/episode/shell/SourcePlayback.test.tsx
+++ b/app/packages/multimodal/src/views/episode/shell/SourcePlayback.test.tsx
@@ -28,7 +28,7 @@ import {
 } from "../../../runtime";
 import { useSourcePoster } from "../image/source-poster-context";
 import { TILE_TYPE } from "../tiles/tile-types";
-import { SourcePlayback } from "./SourcePlayback";
+import { SourcePlayback, TRANSITION_STATUS_DELAY_MS } from "./SourcePlayback";
 
 const playbackHarness = vi.hoisted(() => {
   const harness = {
@@ -414,7 +414,7 @@ describe("SourcePlayback", () => {
     );
 
     expect(screen.queryByTestId("episode-transition-status")).toBeNull();
-    act(() => vi.advanceTimersByTime(199));
+    act(() => vi.advanceTimersByTime(TRANSITION_STATUS_DELAY_MS - 1));
     expect(screen.queryByTestId("episode-transition-status")).toBeNull();
     act(() => vi.advanceTimersByTime(1));
     expect(screen.getByTestId("episode-transition-status").textContent).toBe(

--- a/app/packages/multimodal/src/views/episode/shell/SourcePlayback.tsx
+++ b/app/packages/multimodal/src/views/episode/shell/SourcePlayback.tsx
@@ -93,7 +93,7 @@ import {
 import { EpisodeSourceReadyProvider } from "../playback/source-ready-context";
 
 const EMPTY_MANUAL_TILE_TITLES: Record<string, string> = {};
-const TRANSITION_STATUS_DELAY_MS = 200;
+export const TRANSITION_STATUS_DELAY_MS = 200;
 
 interface ReadyInventory {
   readonly hasNumericSeries: boolean;

--- a/app/packages/multimodal/src/views/episode/shell/Streams.tsx
+++ b/app/packages/multimodal/src/views/episode/shell/Streams.tsx
@@ -131,6 +131,21 @@ export function Streams({
         .map((s) => s.id),
     [sources],
   );
+  const settlementPriorityStreams = useMemo(
+    () => [
+      ...sources
+        .filter((source) => source.type === SCENE_SOURCE_TYPE.IMAGE)
+        .map((source) => source.id),
+      ...blockingStreams.filter(
+        (stream) =>
+          !sources.some(
+            (source) =>
+              source.id === stream && source.type === SCENE_SOURCE_TYPE.IMAGE,
+          ),
+      ),
+    ],
+    [blockingStreams, sources],
+  );
   const poseStreams = useMemo(
     () =>
       requestedPoseHistoryStreams.filter((stream) =>
@@ -169,6 +184,7 @@ export function Streams({
     endBoundedStreams,
     initialSeekTimeNs,
     onPlayheadDataReady,
+    settlementPriorityStreams,
     session,
     source,
     allStreams,

--- a/app/packages/multimodal/src/views/episode/shell/Streams.tsx
+++ b/app/packages/multimodal/src/views/episode/shell/Streams.tsx
@@ -131,11 +131,16 @@ export function Streams({
         .map((s) => s.id),
     [sources],
   );
-  const settlementPriorityStreams = useMemo(
-    () => [
-      ...sources
+  const firstUsefulSettlementStreams = useMemo(
+    () =>
+      sources
         .filter((source) => source.type === SCENE_SOURCE_TYPE.IMAGE)
         .map((source) => source.id),
+    [sources],
+  );
+  const settlementPriorityStreams = useMemo(
+    () => [
+      ...firstUsefulSettlementStreams,
       ...blockingStreams.filter(
         (stream) =>
           !sources.some(
@@ -144,7 +149,7 @@ export function Streams({
           ),
       ),
     ],
-    [blockingStreams, sources],
+    [blockingStreams, firstUsefulSettlementStreams, sources],
   );
   const poseStreams = useMemo(
     () =>
@@ -182,6 +187,7 @@ export function Streams({
   useRegisterDataStream({
     blockingStreams,
     endBoundedStreams,
+    firstUsefulSettlementStreams,
     initialSeekTimeNs,
     onPlayheadDataReady,
     settlementPriorityStreams,


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

Replace the early visual-only progress path with ordered per-stream settlements for synchronized current-frame reads. Each accepted settlement owns cache insertion, per-stream pending cleanup, visible status, and blocking readiness. The terminal response resolves only the remaining streams and reports aggregate failures.

The read still uses one subscription-order-independent union acquisition and transfers each decoded payload once. Source-epoch and playhead guards, cancellation, unresolved-topic retries, retained-message reuse, warmup, lookahead, and separate native acquisition planes remain intact.

This PR also keeps the multimodal shell mounted through MCAP sample transitions and delays loading feedback so fast transitions stay quiet.

## 🧪 How is this patch tested? If it is not, please explain why.

- `yarn check` in `app/packages/multimodal`
- 208 focused Vitest cases across MCAP acquisition, worker RPC and transport, cache, scheduler, stream status, and subscription hooks
- Tiny MCAP E2E: `keeps paused stepping, raw values, logs, and image pixels synchronized`
- FiftyOne source-development smoke
- A/B testing

## Notes to Reviewer

Best reviewed commit-by-commit. The acquisition union is an optimization; each stream settlement is the ownership unit. The last functional commits cover stale-source cancellation, generic non-MCAP fallback ordering, retained-buffer accounting, and literal-`undefined` streaming rejection.

## High Level Architecture

- The worker streaming RPC yields ordered settlement groups and transfers each decoded payload once. The terminal event contains only unresolved-topic and aggregate diagnostic state.
- The prefetch path validates source epoch and tick, caches each accepted stream, clears only that stream pending state, and updates blocking readiness immediately.
- Cancellation preserves accepted settlements. Partial failures retry only unresolved streams, while one coalesced current-frame union remains the acquisition boundary.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Multimodal MCAP navigation now delivers synchronized streams as they become available while preserving one shared current-frame read.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3801
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Synchronized playback now delivers per-stream results progressively.
  - Added configurable stream prioritization and first-useful-result handling.
  - Playback status updates can target only changed streams.
  - Source transitions preserve the playback shell with clearer loading feedback.

- **Bug Fixes**
  - Improved cancellation and replacement of outdated playback requests.
  - Fixed cache resets when switching timelines or sources.
  - Improved binary-size accounting for cached decoded data.
  - Improved handling of streamed playback responses and settlement windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->