### PR TITLE
Hide field-visibility-restricted fields from MM Fields sidebar

### DIFF
--- a/app/packages/multimodal/src/views/episode/shell/FieldsSidebar.test.tsx
+++ b/app/packages/multimodal/src/views/episode/shell/FieldsSidebar.test.tsx
@@ -22,18 +22,29 @@ interface FakeField {
   dbField?: string | null;
 }
 
-const { fakeFields, useActiveModalSample, useSampleFields, useTimeZone } =
-  vi.hoisted(() => ({
-    fakeFields: [] as FakeField[],
-    useActiveModalSample: vi.fn(),
-    useSampleFields: vi.fn(),
-    useTimeZone: vi.fn(),
-  }));
-
-vi.mock("@fiftyone/state", () => ({
+const {
+  fakeFields,
+  fieldVisibilityStageValue,
   useActiveModalSample,
   useSampleFields,
   useTimeZone,
+} = vi.hoisted(() => ({
+  fakeFields: [] as FakeField[],
+  fieldVisibilityStageValue: { current: null as unknown },
+  useActiveModalSample: vi.fn(),
+  useSampleFields: vi.fn(),
+  useTimeZone: vi.fn(),
+}));
+
+vi.mock("@fiftyone/state", () => ({
+  fieldVisibilityStage: "fieldVisibilityStage",
+  useActiveModalSample,
+  useSampleFields,
+  useTimeZone,
+}));
+
+vi.mock("recoil", () => ({
+  useRecoilValue: () => fieldVisibilityStageValue.current,
 }));
 
 import FieldsSidebar from "./FieldsSidebar";
@@ -47,6 +58,7 @@ describe("FieldsSidebar", () => {
   beforeEach(() => {
     useSampleFields.mockImplementation(() => fakeFields);
     useTimeZone.mockReturnValue("UTC");
+    fieldVisibilityStageValue.current = null;
   });
 
   afterEach(() => {
@@ -161,6 +173,26 @@ describe("FieldsSidebar", () => {
     expect(screen.getByTestId("episode-fields-body").textContent).toContain(
       "None",
     );
+  });
+
+  it("filters out fields hidden by the field visibility stage", () => {
+    setFields([
+      { path: "filepath", ftype: "fiftyone.core.fields.StringField" },
+      { path: "secret_field", ftype: "fiftyone.core.fields.StringField" },
+    ]);
+    useActiveModalSample.mockReturnValue({
+      filepath: "/a/b.mcap",
+      secret_field: "hidden",
+    });
+    fieldVisibilityStageValue.current = {
+      kwargs: { field_names: ["secret_field"] },
+    };
+
+    render(<FieldsSidebar />);
+
+    const body = screen.getByTestId("episode-fields-body");
+    expect(body.textContent).toContain("filepath");
+    expect(body.textContent).not.toContain("secret_field");
   });
 
   it("shows a field's description when present", () => {

--- a/app/packages/multimodal/src/views/episode/shell/FieldsSidebar.tsx
+++ b/app/packages/multimodal/src/views/episode/shell/FieldsSidebar.tsx
@@ -1,5 +1,6 @@
 import JSONViewer from "@fiftyone/components/src/components/JSONViewer";
 import {
+  fieldVisibilityStage,
   useActiveModalSample,
   useSampleFields,
   useTimeZone,
@@ -8,6 +9,7 @@ import { formatPrimitive } from "@fiftyone/utilities";
 import { getNestedField } from "@fiftyone/utilities/src/sample/pointer";
 import { Text, TextColor, TextVariant } from "@voxel51/voodo";
 import React from "react";
+import { useRecoilValue } from "recoil";
 import settingsStyles from "../tiles/Tile.settings.module.css";
 
 /**
@@ -106,8 +108,11 @@ const FieldsSidebar: React.FC = () => {
   const sampleFields = useSampleFields();
   const activeSample = useActiveModalSample();
   const timeZone = useTimeZone();
+  const fvStage = useRecoilValue(fieldVisibilityStage);
+  const hiddenPaths = new Set(fvStage?.kwargs?.field_names ?? []);
   const nonPrivateFields = sampleFields.filter(
-    (field) => field && !field.path.startsWith("_"),
+    (field) =>
+      field && !field.path.startsWith("_") && !hiddenPaths.has(field.path),
   );
 
   if (nonPrivateFields.length === 0) {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Follow-up to #8199. The MM right sidebar's new Fields tab (`FieldsSidebar.tsx`) lists every path returned by `useSampleFields()`, which reflects the current view's schema but has no notion of the (client-side-only) Field Visibility stage. As a result, fields an admin has hidden via Field Visibility were still showing up in the MM viewer's Fields tab.

The classic sidebar already handles this: `useSchemaSettings.ts` reads `fieldVisibilityStage.kwargs.field_names` and subtracts those paths before building its field list (see also `excludedPathsState` in `schemaSettings.atoms.ts`). This PR applies the same filter in `FieldsSidebar.tsx` — alongside the existing private-field (`_`-prefixed) filtering — so hidden fields don't leak into the MM viewer.

## 🧪 How is this patch tested?

- Added a `FieldsSidebar.test.tsx` case mocking `fieldVisibilityStage` and asserting a field named in `kwargs.field_names` is excluded while others still render.
- `yarn workspace @fiftyone/multimodal run check:lint` passes; `vitest run` passes (10/10) for `FieldsSidebar.test.tsx`.
- Pre-existing unrelated `check:types` failures (missing `hyparquet`/`@xyflow/react` type declarations in other files) reproduce identically on unmodified `develop`.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] Yes — fixes a bug where Field Visibility-restricted fields were visible in the MM (multimodal) viewer's Fields tab.

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3807
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the episode fields sidebar to hide fields excluded by visibility settings.
  * Private fields continue to remain hidden.
  * Ensured visible fields are still displayed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->