### PR TITLE
feat(app): [2/2] stream multimodal audio through a shared-memory ring buffer

### DIFF
--- a/app/packages/multimodal/src/audio/audio-stream-engine.ts
+++ b/app/packages/multimodal/src/audio/audio-stream-engine.ts
@@ -58,6 +58,8 @@ export interface AudioStreamEngine {
   readonly sampleRate: number;
   /** Frames the ring can accept right now. */
   availableWrite(): number;
+  /** Frames queued and not yet emitted — how much runway the render thread has. */
+  bufferedFrames(): number;
   /**
    * Queues interleaved PCM starting at `offsetFrames`. Returns frames
    * accepted, which is short whenever the ring is nearly full — the caller
@@ -153,6 +155,7 @@ export async function createAudioStreamEngine(
     channels,
     sampleRate,
     availableWrite: () => ring.availableWrite(),
+    bufferedFrames: () => ring.availableRead(),
     push: (interleaved, offsetFrames = 0) =>
       ring.write(interleaved, offsetFrames),
     seek: () => {

--- a/app/packages/multimodal/src/audio/audio-stream-engine.ts
+++ b/app/packages/multimodal/src/audio/audio-stream-engine.ts
@@ -1,0 +1,174 @@
+// ---------------------------------------------------------------------------
+// Main-thread half of streaming audio playback.
+//
+// Owns the transport only: the `AudioContext`, the worklet node, and the
+// ring the render thread drains. It knows nothing about MCAP, Foxglove, or
+// where samples come from — a caller pushes interleaved PCM and this makes
+// it audible. That keeps `src/audio/` container-neutral, the same property
+// `use-audio-playback.ts` documents.
+//
+// Backpressure is the caller's job, and deliberately so: `push()` reports
+// how many frames it accepted, and the producer retains the rest. A ring
+// that silently dropped the overflow would desynchronize audio from the
+// timeline with no way to notice.
+// ---------------------------------------------------------------------------
+
+import workletUrl from "./audio-stream-processor.worklet?worker&url";
+import {
+  AudioRingBuffer,
+  allocateAudioRing,
+  canUseSharedRingBuffer,
+} from "./ring-buffer";
+
+/**
+ * How much audio the ring holds. Large enough that a slow windowed read
+ * cannot starve the render thread, small enough that a seek discards little
+ * work: at 48 kHz stereo this is ~1.5MB.
+ */
+const DEFAULT_BUFFER_SECONDS = 4;
+
+/** Thrown when the page cannot back a ring with shared memory. */
+export class SharedAudioUnavailableError extends Error {
+  constructor() {
+    super(
+      "Streaming audio requires a cross-origin-isolated page (SharedArrayBuffer)",
+    );
+    this.name = "SharedAudioUnavailableError";
+  }
+}
+
+export interface AudioStreamEngineOptions {
+  readonly channels: number;
+  /**
+   * The source's sample rate. The `AudioContext` is created at exactly this
+   * rate so the worklet can pass samples through untouched — a context at a
+   * different rate would need resampling on the render thread, and playing
+   * 44.1kHz material through a 48kHz graph without it shifts pitch.
+   */
+  readonly sampleRate: number;
+  readonly bufferSeconds?: number;
+  /** Notified when the ring runs dry and when it refills. */
+  readonly onStarvationChange?: (starved: boolean) => void;
+}
+
+export interface AudioStreamEngine {
+  readonly node: AudioWorkletNode;
+  readonly audioContext: AudioContext;
+  readonly channels: number;
+  readonly sampleRate: number;
+  /** Frames the ring can accept right now. */
+  availableWrite(): number;
+  /**
+   * Queues interleaved PCM starting at `offsetFrames`. Returns frames
+   * accepted, which is short whenever the ring is nearly full — the caller
+   * keeps the remainder and pushes again once the render thread drains.
+   */
+  push(interleaved: Float32Array, offsetFrames?: number): number;
+  /**
+   * Discards audio queued before this call. Frames pushed afterwards are
+   * treated as the new position, so the caller need not wait for the render
+   * thread to acknowledge before queueing them.
+   */
+  seek(): void;
+  /** Marks the current position's audio complete, so silence is not a fault. */
+  markEnded(): void;
+  /** Seconds of real audio emitted since the last `seek()`. The audio clock. */
+  playedSeconds(): number;
+  /** Frames of silence emitted because the ring ran dry. Diagnostics. */
+  underrunFrames(): number;
+  dispose(): Promise<void>;
+}
+
+/**
+ * Test seam mirroring `__FO_TEST_SAM2_WORKER_FACTORY`: jsdom has no
+ * `AudioWorklet`, so tests substitute the whole transport rather than
+ * leaving this path uncovered.
+ */
+declare global {
+  // eslint-disable-next-line no-var
+  var __FO_TEST_AUDIO_ENGINE_FACTORY:
+    | ((options: AudioStreamEngineOptions) => Promise<AudioStreamEngine>)
+    | undefined;
+}
+
+export async function createAudioStreamEngine(
+  options: AudioStreamEngineOptions,
+): Promise<AudioStreamEngine> {
+  const testFactory = globalThis.__FO_TEST_AUDIO_ENGINE_FACTORY;
+  if (testFactory) return testFactory(options);
+
+  const {
+    channels,
+    sampleRate,
+    bufferSeconds = DEFAULT_BUFFER_SECONDS,
+    onStarvationChange,
+  } = options;
+
+  if (!canUseSharedRingBuffer()) {
+    // Callers fall back to the buffered `AudioBuffer` path. Failing loudly
+    // here beats constructing a ring the render thread cannot see, which
+    // would present as unexplained silence.
+    throw new SharedAudioUnavailableError();
+  }
+  if (!Number.isFinite(sampleRate) || sampleRate <= 0) {
+    throw new RangeError(`Invalid audio sample rate: ${sampleRate}`);
+  }
+
+  const audioContext = new AudioContext({ sampleRate });
+  let disposed = false;
+
+  try {
+    await audioContext.audioWorklet.addModule(workletUrl);
+  } catch (error) {
+    void audioContext.close().catch(() => undefined);
+    throw error;
+  }
+
+  const layout = allocateAudioRing(
+    Math.max(2, Math.ceil(bufferSeconds * sampleRate)),
+    channels,
+  );
+  const ring = new AudioRingBuffer(layout);
+
+  const node = new AudioWorkletNode(audioContext, "fo-audio-stream", {
+    numberOfInputs: 0,
+    numberOfOutputs: 1,
+    // Must match the ring: the processor silences any output channel the
+    // ring does not cover.
+    outputChannelCount: [channels],
+    processorOptions: { layout },
+  });
+
+  if (onStarvationChange) {
+    node.port.onmessage = (event: MessageEvent) => {
+      const type = (event.data as { type?: string } | null)?.type;
+      if (type === "starved") onStarvationChange(true);
+      else if (type === "recovered") onStarvationChange(false);
+    };
+  }
+
+  return {
+    node,
+    audioContext,
+    channels,
+    sampleRate,
+    availableWrite: () => ring.availableWrite(),
+    push: (interleaved, offsetFrames = 0) =>
+      ring.write(interleaved, offsetFrames),
+    seek: () => {
+      ring.requestFlush();
+    },
+    markEnded: () => ring.markEnded(),
+    playedSeconds: () => ring.framesPlayed() / sampleRate,
+    underrunFrames: () => ring.underrunFrames(),
+    dispose: async () => {
+      if (disposed) return;
+      disposed = true;
+      node.port.onmessage = null;
+      node.disconnect();
+      // Browsers cap concurrent AudioContexts per page; leaking them
+      // eventually makes construction fail, presenting as silence.
+      await audioContext.close().catch(() => undefined);
+    },
+  };
+}

--- a/app/packages/multimodal/src/audio/audio-stream-processor.worklet.test.ts
+++ b/app/packages/multimodal/src/audio/audio-stream-processor.worklet.test.ts
@@ -1,0 +1,192 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { AudioRingBuffer } from "./ring-buffer";
+
+// `AudioWorkletProcessor` and `registerProcessor` exist only in
+// `AudioWorkletGlobalScope`. Stub them before importing the worklet so the
+// real-time `process()` logic can be driven directly — otherwise the only
+// way to cover it would be an e2e run with real audio hardware.
+const posted: unknown[] = [];
+
+class FakeAudioWorkletProcessor {
+  readonly port = {
+    postMessage: (message: unknown) => posted.push(message),
+  } as unknown as MessagePort;
+}
+
+type Processor = {
+  process(inputs: Float32Array[][], outputs: Float32Array[][]): boolean;
+};
+
+let ProcessorCtor: new (options?: unknown) => Processor;
+let AUDIO_STREAM_PROCESSOR: string;
+
+beforeAll(async () => {
+  vi.stubGlobal("AudioWorkletProcessor", FakeAudioWorkletProcessor);
+  vi.stubGlobal(
+    "registerProcessor",
+    (_name: string, ctor: new (options?: unknown) => Processor) => {
+      ProcessorCtor = ctor;
+    },
+  );
+  const mod = await import("./audio-stream-processor.worklet");
+  AUDIO_STREAM_PROCESSOR = mod.AUDIO_STREAM_PROCESSOR;
+});
+
+const CAPACITY = 512;
+
+function harness(channels = 2) {
+  const layout = {
+    buffer: new SharedArrayBuffer(
+      8 * 4 + CAPACITY * channels * Float32Array.BYTES_PER_ELEMENT,
+    ),
+    capacityFrames: CAPACITY,
+    channels,
+  };
+  posted.length = 0;
+  return {
+    producer: new AudioRingBuffer(layout),
+    processor: new ProcessorCtor({ processorOptions: { layout } }),
+    outputs: (quantum = 128) => [
+      Array.from({ length: channels }, () => new Float32Array(quantum)),
+    ],
+  };
+}
+
+/** Interleaved constant-per-channel frames, value = base + channel. */
+function frames(count: number, channels: number, base: number): Float32Array {
+  const out = new Float32Array(count * channels);
+  for (let f = 0; f < count; f++) {
+    for (let c = 0; c < channels; c++) out[f * channels + c] = base + c;
+  }
+  return out;
+}
+
+describe("audio stream worklet", () => {
+  it("registers under the name the main thread constructs", () => {
+    expect(AUDIO_STREAM_PROCESSOR).toBe("fo-audio-stream");
+    expect(ProcessorCtor).toBeTypeOf("function");
+  });
+
+  it("refuses to construct without a ring layout rather than silently emitting silence", () => {
+    expect(() => new ProcessorCtor({ processorOptions: {} })).toThrow(
+      /ring buffer layout/,
+    );
+  });
+
+  it("de-interleaves buffered audio onto the output bus", () => {
+    const { producer, processor, outputs } = harness(2);
+    producer.write(frames(128, 2, 10));
+
+    const out = outputs(128);
+    expect(processor.process([], out)).toBe(true);
+    expect(out[0][0][0]).toBe(10);
+    expect(out[0][1][0]).toBe(11);
+    expect(out[0][0][127]).toBe(10);
+  });
+
+  it("keeps the media clock on real frames only, so it is not inflated by starvation", () => {
+    const { producer, processor, outputs } = harness(2);
+    producer.write(frames(64, 2, 1));
+
+    processor.process([], outputs(128));
+    // 64 real frames delivered, 64 of silence.
+    expect(producer.framesPlayed()).toBe(64);
+    expect(producer.underrunFrames()).toBe(64);
+  });
+
+  it("zero-fills the shortfall instead of repeating the previous quantum", () => {
+    const { producer, processor, outputs } = harness(1);
+    producer.write(frames(200, 1, 5));
+
+    const first = outputs(128);
+    processor.process([], first);
+    expect(first[0][0][127]).toBe(5);
+
+    // Only 72 frames remain for a 128-frame quantum.
+    const second = outputs(128);
+    processor.process([], second);
+    expect(second[0][0][71]).toBe(5);
+    expect(second[0][0][72]).toBe(0);
+    expect(second[0][0][127]).toBe(0);
+  });
+
+  it("reports starvation once, not once per quantum", () => {
+    const { processor, outputs } = harness(1);
+    processor.process([], outputs());
+    processor.process([], outputs());
+    processor.process([], outputs());
+    expect(
+      posted.filter((m) => (m as { type: string }).type === "starved"),
+    ).toHaveLength(1);
+  });
+
+  it("reports recovery when data arrives again", () => {
+    const { producer, processor, outputs } = harness(1);
+    processor.process([], outputs());
+    expect(posted).toEqual([{ type: "starved" }]);
+
+    producer.write(frames(128, 1, 3));
+    processor.process([], outputs());
+    expect(posted).toEqual([{ type: "starved" }, { type: "recovered" }]);
+  });
+
+  it("does not count end-of-stream silence as an underrun", () => {
+    const { producer, processor, outputs } = harness(1);
+    producer.markEnded();
+
+    processor.process([], outputs());
+    processor.process([], outputs());
+    expect(producer.underrunFrames()).toBe(0);
+    expect(posted).toHaveLength(0);
+  });
+
+  it("drops stale audio on the quantum after a seek", () => {
+    const { producer, processor, outputs } = harness(1);
+    producer.write(frames(256, 1, 7)); // audio from the old position
+
+    const generation = producer.requestFlush();
+    producer.write(frames(128, 1, 9)); // audio for the new position
+
+    const out = outputs(128);
+    processor.process([], out);
+    // The pre-seek samples never reach the bus.
+    expect(out[0][0][0]).toBe(9);
+    expect(producer.flushAcknowledged(generation)).toBe(true);
+  });
+
+  it("restarts the clock after a seek so position is not cumulative", () => {
+    const { producer, processor, outputs } = harness(1);
+    producer.write(frames(128, 1, 1));
+    processor.process([], outputs());
+    expect(producer.framesPlayed()).toBe(128);
+
+    producer.requestFlush();
+    producer.write(frames(128, 1, 2));
+    processor.process([], outputs());
+    expect(producer.framesPlayed()).toBe(128);
+  });
+
+  it("stays alive at end of stream so a later seek can refill the same node", () => {
+    const { producer, processor, outputs } = harness(1);
+    producer.markEnded();
+    expect(processor.process([], outputs())).toBe(true);
+    expect(processor.process([], outputs())).toBe(true);
+  });
+
+  it("tolerates a bus with no channels rather than throwing on the render thread", () => {
+    const { processor } = harness(2);
+    expect(processor.process([], [[]])).toBe(true);
+    expect(processor.process([], [])).toBe(true);
+  });
+
+  it("keeps remaining channels time-aligned when the bus is narrower than the ring", () => {
+    const { producer, processor } = harness(2);
+    producer.write(frames(4, 2, 100));
+    // Mono bus against a stereo ring: channel 1 is dropped, but its samples
+    // are still consumed so channel 0 does not smear across frames.
+    const out = [[new Float32Array(4)]];
+    processor.process([], out);
+    expect(Array.from(out[0][0])).toEqual([100, 100, 100, 100]);
+    expect(producer.availableRead()).toBe(0);
+  });
+});

--- a/app/packages/multimodal/src/audio/audio-stream-processor.worklet.ts
+++ b/app/packages/multimodal/src/audio/audio-stream-processor.worklet.ts
@@ -55,9 +55,14 @@ class AudioStreamProcessorImpl extends AudioWorkletProcessor {
   private readonly channelScratch: (Float32Array | undefined)[];
   private starved = false;
 
-  constructor(options?: { processorOptions?: AudioStreamProcessorOptions }) {
+  // `unknown` rather than the option shape: `registerProcessor` hands the
+  // constructor whatever the main thread put in `processorOptions`, so the
+  // narrowing belongs here rather than in a signature the host cannot honor.
+  constructor(options?: unknown) {
     super();
-    const layout = options?.processorOptions?.layout;
+    const layout = (
+      options as { processorOptions?: AudioStreamProcessorOptions } | undefined
+    )?.processorOptions?.layout;
     if (!layout) {
       throw new Error("AudioStreamProcessor requires a ring buffer layout");
     }

--- a/app/packages/multimodal/src/audio/audio-stream-processor.worklet.ts
+++ b/app/packages/multimodal/src/audio/audio-stream-processor.worklet.ts
@@ -1,0 +1,133 @@
+// ---------------------------------------------------------------------------
+// The consumer half of the streaming audio path: an `AudioWorkletProcessor`
+// that pulls interleaved PCM out of the shared ring and writes it to the
+// output bus.
+//
+// This runs on the audio render thread under a hard real-time deadline —
+// roughly 2.7ms of wall clock per 128-frame quantum at 48 kHz. Everything
+// here is allocation-free and lock-free for that reason: no `await`, no
+// `postMessage` on the hot path, no array/object construction inside
+// `process()`. Missing the deadline is an audible glitch, not a slow frame.
+//
+// It shares `ring-buffer.ts` with the producer rather than reimplementing
+// the cursor arithmetic, so the two halves cannot drift apart. That module
+// touches `globalThis` only inside a function, which matters because
+// `AudioWorkletGlobalScope` has no `window` or DOM.
+// ---------------------------------------------------------------------------
+
+import { AudioRingBuffer, type AudioRingBufferLayout } from "./ring-buffer";
+
+/** Sent to the main thread when playback state changes materially. */
+export type AudioStreamProcessorEvent =
+  | { readonly type: "starved" }
+  | { readonly type: "recovered" }
+  | { readonly type: "ended" };
+
+interface AudioStreamProcessorOptions {
+  readonly layout: AudioRingBufferLayout;
+}
+
+declare abstract class AudioWorkletProcessor {
+  readonly port: MessagePort;
+  constructor(options?: unknown);
+  abstract process(
+    inputs: Float32Array[][],
+    outputs: Float32Array[][],
+    parameters: Record<string, Float32Array>,
+  ): boolean;
+}
+
+declare function registerProcessor(
+  name: string,
+  ctor: new (options?: unknown) => AudioWorkletProcessor,
+): void;
+
+export const AUDIO_STREAM_PROCESSOR = "fo-audio-stream";
+
+class AudioStreamProcessorImpl extends AudioWorkletProcessor {
+  private readonly ring: AudioRingBuffer;
+  /**
+   * Scratch array of output channel views, allocated once. `process()`
+   * receives a fresh `outputs` structure each quantum but the channel
+   * `Float32Array`s are reused by the host, so this only ever re-points
+   * existing references — no per-quantum allocation.
+   */
+  private readonly channelScratch: (Float32Array | undefined)[];
+  private starved = false;
+
+  constructor(options?: { processorOptions?: AudioStreamProcessorOptions }) {
+    super();
+    const layout = options?.processorOptions?.layout;
+    if (!layout) {
+      throw new Error("AudioStreamProcessor requires a ring buffer layout");
+    }
+    this.ring = new AudioRingBuffer(layout);
+    this.channelScratch = new Array<Float32Array | undefined>(
+      this.ring.channels,
+    );
+  }
+
+  process(_inputs: Float32Array[][], outputs: Float32Array[][]): boolean {
+    const output = outputs[0];
+    if (!output || output.length === 0) return true;
+
+    const quantum = output[0]?.length ?? 0;
+    if (quantum === 0) return true;
+
+    // A seek invalidates everything queued. Doing this before the read means
+    // the very next quantum is already the new position, rather than
+    // draining audio from where the viewer used to be.
+    if (this.ring.applyPendingFlush()) {
+      this.starved = false;
+    }
+
+    // The ring's channel count is authoritative: the node is constructed
+    // with `outputChannelCount` matching it. If the host still hands us a
+    // different bus (a channel-count change mid-graph), only fill what both
+    // sides have and silence the rest rather than reading out of bounds.
+    // Holes are intentional and `read()` skips them: if the bus is narrower
+    // than the ring, those channels are dropped but their samples are still
+    // consumed, so the remaining channels stay time-aligned.
+    for (let channel = 0; channel < this.ring.channels; channel++) {
+      this.channelScratch[channel] = output[channel];
+    }
+
+    const delivered = this.ring.read(this.channelScratch, quantum);
+
+    if (delivered < quantum) {
+      // Zero the tail. `Float32Array#fill` is a single memset, cheap enough
+      // for the render thread; leaving stale samples would repeat the last
+      // buffer as a buzz.
+      for (let channel = 0; channel < output.length; channel++) {
+        output[channel]?.fill(0, delivered);
+      }
+      const missing = quantum - delivered;
+      // End of stream is silence too, but it is not a fault — do not count
+      // it as an underrun or the diagnostics would climb forever on a
+      // finished track.
+      if (!this.ring.hasEnded()) {
+        this.ring.recordUnderrun(missing);
+        if (!this.starved) {
+          this.starved = true;
+          this.port.postMessage({ type: "starved" });
+        }
+      }
+    } else if (this.starved) {
+      this.starved = false;
+      this.port.postMessage({ type: "recovered" });
+    }
+
+    // Silence does not move the media clock: when data arrives the track
+    // resumes from where it stopped, so only real frames count. This is what
+    // makes `framesPlayed` a trustworthy position source where
+    // `currentTime` is not — that keeps advancing through starvation.
+    if (delivered > 0) this.ring.advancePlayed(delivered);
+
+    // Stay alive even at end of stream: a seek can refill this same node,
+    // and returning false would tear the processor down permanently. The
+    // main thread disconnects the node when the track goes away.
+    return true;
+  }
+}
+
+registerProcessor(AUDIO_STREAM_PROCESSOR, AudioStreamProcessorImpl);

--- a/app/packages/multimodal/src/audio/audio-stream-pump.test.ts
+++ b/app/packages/multimodal/src/audio/audio-stream-pump.test.ts
@@ -1,0 +1,323 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createAudioStreamPump,
+  type AudioWindowReader,
+} from "./audio-stream-pump";
+import type { PcmAudioData } from "./types";
+
+const SAMPLE_RATE = 100; // small, so window math is readable
+const CHANNELS = 1;
+
+/**
+ * Records what the pump pushes. `capacity` is in frames; `push` honors it
+ * and reports short writes so backpressure is exercised for real rather
+ * than assumed away by an infinite sink.
+ */
+function fakeEngine(capacity = 1_000_000) {
+  const pushed: number[] = [];
+  let seeks = 0;
+  let ended = 0;
+  let room = capacity;
+  return {
+    pushed,
+    get seeks() {
+      return seeks;
+    },
+    get ended() {
+      return ended;
+    },
+    setRoom(frames: number) {
+      room = frames;
+    },
+    sampleRate: SAMPLE_RATE,
+    channels: CHANNELS,
+    availableWrite: () => room,
+    push: (interleaved: Float32Array, offsetFrames = 0) => {
+      const total = Math.floor(interleaved.length / CHANNELS);
+      const accepted = Math.max(0, Math.min(total - offsetFrames, room));
+      for (let f = 0; f < accepted; f++) {
+        pushed.push(interleaved[(offsetFrames + f) * CHANNELS]);
+      }
+      room -= accepted;
+      return accepted;
+    },
+    seek: () => {
+      seeks += 1;
+    },
+    markEnded: () => {
+      ended += 1;
+    },
+  };
+}
+
+/** Window whose every sample equals its start second, for provenance. */
+function windowOf(startSec: number, frames: number): PcmAudioData {
+  return {
+    samples: new Float32Array(frames).fill(startSec),
+    sampleRate: SAMPLE_RATE,
+    channels: CHANNELS,
+  };
+}
+
+/** Runs scheduled callbacks eagerly so tests need no real timers. */
+function immediateScheduler() {
+  const queue: (() => void)[] = [];
+  return {
+    schedule: (fn: () => void) => queue.push(fn),
+    async flush(rounds = 20) {
+      for (let i = 0; i < rounds && queue.length > 0; i++) {
+        const next = queue.shift();
+        next?.();
+        await Promise.resolve();
+      }
+    },
+  };
+}
+
+const settle = () => new Promise((r) => setTimeout(r, 0));
+
+describe("audio stream pump", () => {
+  it("reads consecutive windows and pushes them in order", async () => {
+    const engine = fakeEngine();
+    const scheduler = immediateScheduler();
+    const read: AudioWindowReader = vi.fn(async (startSec) =>
+      windowOf(startSec, SAMPLE_RATE),
+    );
+
+    const pump = createAudioStreamPump({
+      engine,
+      read,
+      durationSec: 3,
+      windowSeconds: 1,
+      schedule: scheduler.schedule,
+    });
+    pump.start(0);
+    await settle();
+
+    // Windows starting at 0, 1, 2 — each 100 frames tagged with its start.
+    expect(engine.pushed.length).toBe(300);
+    expect(engine.pushed[0]).toBe(0);
+    expect(engine.pushed[100]).toBe(1);
+    expect(engine.pushed[200]).toBe(2);
+    expect(engine.ended).toBeGreaterThan(0);
+  });
+
+  it("does not read past the media duration", async () => {
+    const engine = fakeEngine();
+    const reads: Array<[number, number]> = [];
+    const read: AudioWindowReader = async (startSec, endSec) => {
+      reads.push([startSec, endSec]);
+      return windowOf(startSec, Math.round((endSec - startSec) * SAMPLE_RATE));
+    };
+
+    const pump = createAudioStreamPump({
+      engine,
+      read,
+      durationSec: 2.5,
+      windowSeconds: 1,
+      schedule: immediateScheduler().schedule,
+    });
+    pump.start(0);
+    await settle();
+
+    expect(reads).toEqual([
+      [0, 1],
+      [1, 2],
+      [2, 2.5],
+    ]);
+    expect(pump.ended()).toBe(true);
+  });
+
+  it("retains the remainder of a short push instead of dropping samples", async () => {
+    const engine = fakeEngine(150); // room for 1.5 windows
+    const scheduler = immediateScheduler();
+    const read: AudioWindowReader = async (startSec) =>
+      windowOf(startSec, SAMPLE_RATE);
+
+    const pump = createAudioStreamPump({
+      engine,
+      read,
+      durationSec: 3,
+      windowSeconds: 1,
+      schedule: scheduler.schedule,
+    });
+    pump.start(0);
+    await settle();
+
+    expect(engine.pushed.length).toBe(150);
+    // Drain and let the pump resume; the retained 50 frames land next.
+    engine.setRoom(1000);
+    await scheduler.flush();
+    await settle();
+
+    expect(engine.pushed.length).toBeGreaterThan(150);
+    // Frame 150 is the second half of the window that started at 1 — the
+    // retained remainder, not a re-read of window 0.
+    expect(engine.pushed[150]).toBe(1);
+  });
+
+  it("discards a read that resolves after a seek", async () => {
+    const engine = fakeEngine();
+    // Definite-assignment: TS cannot see the assignment inside the executor
+    // below, so a `| null` union would narrow to `null` at the call site.
+    let release!: (value: PcmAudioData) => void;
+    const read: AudioWindowReader = (startSec) =>
+      startSec === 0
+        ? new Promise<PcmAudioData>((resolve) => {
+            release = resolve;
+          })
+        : Promise.resolve(windowOf(startSec, SAMPLE_RATE));
+
+    const pump = createAudioStreamPump({
+      engine,
+      read,
+      durationSec: 10,
+      windowSeconds: 1,
+      schedule: immediateScheduler().schedule,
+    });
+    pump.start(0);
+    await settle();
+    expect(engine.pushed).toHaveLength(0);
+
+    pump.seek(5);
+    await settle();
+
+    // The stale window resolves only now; its samples must not be queued.
+    release(windowOf(0, SAMPLE_RATE));
+    await settle();
+
+    expect(engine.seeks).toBe(1);
+    expect(engine.pushed.every((v) => v >= 5)).toBe(true);
+    expect(engine.pushed).not.toHaveLength(0);
+  });
+
+  it("aborts the in-flight read on seek", async () => {
+    const engine = fakeEngine();
+    const signals: AbortSignal[] = [];
+    const read: AudioWindowReader = (startSec, _endSec, signal) => {
+      signals.push(signal);
+      return startSec === 0
+        ? new Promise<PcmAudioData>(() => undefined)
+        : Promise.resolve(windowOf(startSec, SAMPLE_RATE));
+    };
+
+    const pump = createAudioStreamPump({
+      engine,
+      read,
+      durationSec: 10,
+      windowSeconds: 1,
+      schedule: immediateScheduler().schedule,
+    });
+    pump.start(0);
+    await settle();
+    expect(signals[0].aborted).toBe(false);
+
+    pump.seek(4);
+    expect(signals[0].aborted).toBe(true);
+  });
+
+  it("restarts from the seek target rather than the old cursor", async () => {
+    const engine = fakeEngine();
+    const read: AudioWindowReader = async (startSec) =>
+      windowOf(startSec, SAMPLE_RATE);
+
+    const pump = createAudioStreamPump({
+      engine,
+      read,
+      durationSec: 10,
+      windowSeconds: 1,
+      schedule: immediateScheduler().schedule,
+    });
+    pump.start(0);
+    await settle();
+    const before = engine.pushed.length;
+
+    pump.seek(7);
+    await settle();
+
+    expect(engine.pushed[before]).toBe(7);
+  });
+
+  it("clears end-of-stream when seeking backwards out of it", async () => {
+    const engine = fakeEngine();
+    const read: AudioWindowReader = async (startSec) =>
+      windowOf(startSec, SAMPLE_RATE);
+
+    const pump = createAudioStreamPump({
+      engine,
+      read,
+      durationSec: 2,
+      windowSeconds: 1,
+      schedule: immediateScheduler().schedule,
+    });
+    pump.start(0);
+    await settle();
+    expect(pump.ended()).toBe(true);
+
+    pump.seek(0);
+    await settle();
+    // Reached the end again after replaying, but it did resume.
+    expect(engine.pushed.length).toBeGreaterThan(200);
+  });
+
+  it("treats an empty read as end of stream rather than looping forever", async () => {
+    const engine = fakeEngine();
+    const read: AudioWindowReader = vi.fn(async () => null);
+
+    const pump = createAudioStreamPump({
+      engine,
+      read,
+      durationSec: 100,
+      windowSeconds: 1,
+      schedule: immediateScheduler().schedule,
+    });
+    pump.start(0);
+    await settle();
+
+    expect(read).toHaveBeenCalledTimes(1);
+    expect(pump.ended()).toBe(true);
+    expect(engine.ended).toBeGreaterThan(0);
+  });
+
+  it("surfaces a reader failure and stops instead of spinning", async () => {
+    const engine = fakeEngine();
+    const onError = vi.fn();
+    const read: AudioWindowReader = async () => {
+      throw new Error("read blew up");
+    };
+
+    const pump = createAudioStreamPump({
+      engine,
+      read,
+      durationSec: 10,
+      windowSeconds: 1,
+      schedule: immediateScheduler().schedule,
+      onError,
+    });
+    pump.start(0);
+    await settle();
+
+    expect(onError).toHaveBeenCalledOnce();
+    expect(pump.ended()).toBe(true);
+  });
+
+  it("stops reading once stopped", async () => {
+    const engine = fakeEngine();
+    const read = vi.fn<AudioWindowReader>(async (startSec) =>
+      windowOf(startSec, SAMPLE_RATE),
+    );
+
+    const pump = createAudioStreamPump({
+      engine,
+      read,
+      durationSec: 100,
+      windowSeconds: 1,
+      schedule: immediateScheduler().schedule,
+    });
+    pump.stop();
+    pump.start(0);
+    await settle();
+
+    expect(read).not.toHaveBeenCalled();
+  });
+});

--- a/app/packages/multimodal/src/audio/audio-stream-pump.test.ts
+++ b/app/packages/multimodal/src/audio/audio-stream-pump.test.ts
@@ -18,6 +18,10 @@ function fakeEngine(capacity = 1_000_000) {
   let seeks = 0;
   let ended = 0;
   let room = capacity;
+  // Frames written but not yet "rendered". The pump backs off on this, so a
+  // fake that always reported 0 would make it retry at the floor delay and
+  // hide any regression in the backoff.
+  let buffered = 0;
   return {
     pushed,
     get seeks() {
@@ -29,6 +33,11 @@ function fakeEngine(capacity = 1_000_000) {
     setRoom(frames: number) {
       room = frames;
     },
+    /** Simulates the render thread consuming `frames`. */
+    drain(frames: number) {
+      buffered = Math.max(0, buffered - frames);
+    },
+    bufferedFrames: () => buffered,
     sampleRate: SAMPLE_RATE,
     channels: CHANNELS,
     availableWrite: () => room,
@@ -39,10 +48,12 @@ function fakeEngine(capacity = 1_000_000) {
         pushed.push(interleaved[(offsetFrames + f) * CHANNELS]);
       }
       room -= accepted;
+      buffered += accepted;
       return accepted;
     },
     seek: () => {
       seeks += 1;
+      buffered = 0;
     },
     markEnded: () => {
       ended += 1;

--- a/app/packages/multimodal/src/audio/audio-stream-pump.ts
+++ b/app/packages/multimodal/src/audio/audio-stream-pump.ts
@@ -27,7 +27,13 @@ export type AudioWindowReader = (
 export interface AudioStreamPumpOptions {
   readonly engine: Pick<
     AudioStreamEngine,
-    "push" | "availableWrite" | "seek" | "markEnded" | "sampleRate" | "channels"
+    | "push"
+    | "availableWrite"
+    | "bufferedFrames"
+    | "seek"
+    | "markEnded"
+    | "sampleRate"
+    | "channels"
   >;
   readonly read: AudioWindowReader;
   /** Total media duration; the pump stops reading past it. */
@@ -96,16 +102,19 @@ export function createAudioStreamPump({
     return false;
   };
 
-  /** Wait proportional to what is buffered, so the loop idles when full. */
+  /**
+   * Back off in proportion to the runway the render thread still has. This
+   * must key off buffered audio, not free space: those are inverses, and
+   * using free space would sleep longest exactly when the ring is empty and
+   * about to underrun.
+   */
   const waitAndResume = () => {
     if (stopped) return;
-    const bufferedFrames = Math.max(0, engine.availableWrite());
-    // Re-check after roughly half the remaining headroom has drained; floor
-    // keeps a nearly-full ring from spinning.
-    const delayMs = Math.max(
-      20,
-      Math.min(500, (bufferedFrames / sampleRate) * 500),
-    );
+    const bufferedSec = Math.max(0, engine.bufferedFrames()) / sampleRate;
+    // Re-check after roughly half the runway is gone. The floor keeps a
+    // still-full ring from spinning; the ceiling bounds seek latency when
+    // the ring is full and waiting on the render thread's flush ack.
+    const delayMs = Math.max(5, Math.min(250, bufferedSec * 500));
     schedule(() => void pumpLoop(), delayMs);
   };
 

--- a/app/packages/multimodal/src/audio/audio-stream-pump.ts
+++ b/app/packages/multimodal/src/audio/audio-stream-pump.ts
@@ -1,0 +1,194 @@
+// ---------------------------------------------------------------------------
+// Producer loop: keeps the ring fed from windowed reads.
+//
+// Container-neutral by construction — it drives an injected
+// `AudioWindowReader`, so the MCAP paging lives in the view layer and a
+// .wav fetch or a test double works here unchanged.
+//
+// The loop is demand-driven rather than a timer poll: it reads the next
+// window only when the ring has room, then waits for the render thread to
+// drain roughly half the buffer before looking again. A fixed-interval poll
+// would either spin needlessly on a full ring or starve a fast one.
+// ---------------------------------------------------------------------------
+
+import type { AudioStreamEngine } from "./audio-stream-engine";
+import type { PcmAudioData } from "./types";
+
+/**
+ * Reads interleaved PCM covering `[startSec, endSec)`. Returns `null` when
+ * the range holds no audio, which ends the stream.
+ */
+export type AudioWindowReader = (
+  startSec: number,
+  endSec: number,
+  signal: AbortSignal,
+) => Promise<PcmAudioData | null>;
+
+export interface AudioStreamPumpOptions {
+  readonly engine: Pick<
+    AudioStreamEngine,
+    "push" | "availableWrite" | "seek" | "markEnded" | "sampleRate" | "channels"
+  >;
+  readonly read: AudioWindowReader;
+  /** Total media duration; the pump stops reading past it. */
+  readonly durationSec: number;
+  /** Span of one read. Smaller means finer seek granularity, more reads. */
+  readonly windowSeconds?: number;
+  /** Injected for tests; defaults to `setTimeout`. */
+  readonly schedule?: (fn: () => void, delayMs: number) => void;
+  readonly onError?: (error: unknown) => void;
+}
+
+export interface AudioStreamPump {
+  /** Begins filling from `fromSec`. Idempotent. */
+  start(fromSec: number): void;
+  /** Repositions: discards queued audio and refills from `toSec`. */
+  seek(toSec: number): void;
+  /** True once the reader has reported the end of the media. */
+  ended(): boolean;
+  stop(): void;
+}
+
+const DEFAULT_WINDOW_SECONDS = 1;
+
+export function createAudioStreamPump({
+  engine,
+  read,
+  durationSec,
+  windowSeconds = DEFAULT_WINDOW_SECONDS,
+  schedule = (fn, delayMs) => {
+    setTimeout(fn, delayMs);
+  },
+  onError,
+}: AudioStreamPumpOptions): AudioStreamPump {
+  const { sampleRate, channels } = engine;
+
+  let controller: AbortController | null = null;
+  let running = false;
+  let stopped = false;
+  let atEnd = false;
+  /** Next media second to read from. */
+  let cursorSec = 0;
+  /**
+   * Frames read but not yet accepted by the ring. A short `push` must not
+   * drop the remainder or audio would silently lose a slice.
+   */
+  let pending: Float32Array | null = null;
+  let pendingOffsetFrames = 0;
+  /**
+   * Incremented on every seek. An in-flight read that resolves after a seek
+   * belongs to the old position and is discarded by comparing this — the
+   * abort signal alone is not enough, because a reader may resolve normally
+   * before it observes the abort.
+   */
+  let generation = 0;
+
+  const drainPending = (): boolean => {
+    if (!pending) return true;
+    const accepted = engine.push(pending, pendingOffsetFrames);
+    pendingOffsetFrames += accepted;
+    const total = Math.floor(pending.length / channels);
+    if (pendingOffsetFrames >= total) {
+      pending = null;
+      pendingOffsetFrames = 0;
+      return true;
+    }
+    return false;
+  };
+
+  /** Wait proportional to what is buffered, so the loop idles when full. */
+  const waitAndResume = () => {
+    if (stopped) return;
+    const bufferedFrames = Math.max(0, engine.availableWrite());
+    // Re-check after roughly half the remaining headroom has drained; floor
+    // keeps a nearly-full ring from spinning.
+    const delayMs = Math.max(
+      20,
+      Math.min(500, (bufferedFrames / sampleRate) * 500),
+    );
+    schedule(() => void pumpLoop(), delayMs);
+  };
+
+  async function pumpLoop(): Promise<void> {
+    if (stopped || running) return;
+    running = true;
+    const myGeneration = generation;
+
+    try {
+      while (!stopped && generation === myGeneration) {
+        if (!drainPending()) {
+          waitAndResume();
+          return;
+        }
+        if (atEnd || cursorSec >= durationSec) {
+          engine.markEnded();
+          return;
+        }
+        // Only read when there is somewhere to put the result; otherwise a
+        // full window would sit in `pending` holding memory for nothing.
+        if (engine.availableWrite() < sampleRate * windowSeconds * 0.25) {
+          waitAndResume();
+          return;
+        }
+
+        const startSec = cursorSec;
+        const endSec = Math.min(durationSec, startSec + windowSeconds);
+        controller = new AbortController();
+        const result = await read(startSec, endSec, controller.signal);
+
+        // A seek landed while this read was in flight: its samples are for
+        // the position the viewer left.
+        if (stopped || generation !== myGeneration) return;
+
+        if (!result || result.samples.length === 0) {
+          atEnd = true;
+          engine.markEnded();
+          return;
+        }
+
+        pending = result.samples;
+        pendingOffsetFrames = 0;
+        cursorSec = endSec;
+        if (endSec >= durationSec) atEnd = true;
+      }
+    } catch (error) {
+      if (!stopped && generation === myGeneration) {
+        atEnd = true;
+        onError?.(error);
+      }
+    } finally {
+      running = false;
+    }
+  }
+
+  return {
+    start(fromSec: number) {
+      if (stopped) return;
+      cursorSec = Math.max(0, fromSec);
+      atEnd = false;
+      void pumpLoop();
+    },
+    seek(toSec: number) {
+      if (stopped) return;
+      generation += 1;
+      controller?.abort();
+      controller = null;
+      pending = null;
+      pendingOffsetFrames = 0;
+      atEnd = false;
+      cursorSec = Math.max(0, toSec);
+      // Order matters: the engine records the flush boundary now, so frames
+      // pushed by the restarted loop survive it.
+      engine.seek();
+      running = false;
+      void pumpLoop();
+    },
+    ended: () => atEnd,
+    stop() {
+      stopped = true;
+      controller?.abort();
+      controller = null;
+      pending = null;
+    },
+  };
+}

--- a/app/packages/multimodal/src/audio/incremental-peaks.test.ts
+++ b/app/packages/multimodal/src/audio/incremental-peaks.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { createIncrementalPeaks } from "./incremental-peaks";
+import { buildChannelPeakPyramids } from "./peak-pyramid";
+
+const SAMPLE_RATE = 8000;
+
+/** Deterministic waveform; no Math.random so failures reproduce. */
+function signal(frames: number, channels: number): Float32Array {
+  const out = new Float32Array(frames * channels);
+  for (let f = 0; f < frames; f++) {
+    for (let c = 0; c < channels; c++) {
+      out[f * channels + c] = Math.sin((f * (c + 1)) / 37) * 0.8;
+    }
+  }
+  return out;
+}
+
+describe("incremental peaks", () => {
+  it("matches the one-shot build when fed in windows", () => {
+    const channels = 2;
+    const frames = 5000;
+    const all = signal(frames, channels);
+
+    const acc = createIncrementalPeaks({
+      channels,
+      sampleRate: SAMPLE_RATE,
+      totalFrames: frames,
+    });
+    // Deliberately not a multiple of samplesPerPeak (256), so windows
+    // straddle bucket boundaries — the case most likely to smear.
+    const windowFrames = 333;
+    for (let start = 0; start < frames; start += windowFrames) {
+      const end = Math.min(frames, start + windowFrames);
+      acc.add(all.subarray(start * channels, end * channels), start);
+    }
+
+    const incremental = acc.pyramids();
+    const oneShot = buildChannelPeakPyramids(all, {
+      channels,
+      sampleRate: SAMPLE_RATE,
+    });
+
+    expect(incremental).toHaveLength(oneShot.length);
+    for (let c = 0; c < oneShot.length; c++) {
+      expect(Array.from(incremental[c].levels[0].min)).toEqual(
+        Array.from(oneShot[c].levels[0].min),
+      );
+      expect(Array.from(incremental[c].levels[0].max)).toEqual(
+        Array.from(oneShot[c].levels[0].max),
+      );
+    }
+  });
+
+  it("distinguishes an unread bucket from a silent one", () => {
+    const acc = createIncrementalPeaks({
+      channels: 1,
+      sampleRate: SAMPLE_RATE,
+      totalFrames: 2560, // 10 buckets
+    });
+    expect(acc.hasData()).toBe(false);
+    expect(acc.coverage()).toBe(0);
+
+    acc.add(new Float32Array(256), 0); // genuinely silent, but read
+    expect(acc.hasData()).toBe(true);
+    expect(acc.coverage()).toBeCloseTo(0.1);
+  });
+
+  it("does not widen peaks when a region is replayed after a seek", () => {
+    const channels = 1;
+    const frames = 1024;
+    const all = signal(frames, channels);
+
+    const acc = createIncrementalPeaks({
+      channels,
+      sampleRate: SAMPLE_RATE,
+      totalFrames: frames,
+    });
+    acc.add(all, 0);
+    const first = Array.from(acc.pyramids()[0].levels[0].max);
+
+    // Same audio again, as a seek back would produce.
+    acc.add(all, 0);
+    expect(Array.from(acc.pyramids()[0].levels[0].max)).toEqual(first);
+  });
+
+  it("fills only the region visited when playback starts mid-track", () => {
+    const acc = createIncrementalPeaks({
+      channels: 1,
+      sampleRate: SAMPLE_RATE,
+      totalFrames: 2560, // 10 buckets
+    });
+    acc.add(new Float32Array(512).fill(0.5), 1280); // buckets 5 and 6
+    expect(acc.coverage()).toBeCloseTo(0.2);
+    const level0 = acc.pyramids()[0].levels[0];
+    expect(level0.max[5]).toBeCloseTo(0.5);
+    expect(level0.max[0]).toBe(0); // never read
+  });
+
+  it("reduces coarser levels down to a single bucket", () => {
+    const acc = createIncrementalPeaks({
+      channels: 1,
+      sampleRate: SAMPLE_RATE,
+      totalFrames: 256 * 8,
+    });
+    acc.add(signal(256 * 8, 1), 0);
+    const levels = acc.pyramids()[0].levels;
+    expect(levels[0].min).toHaveLength(8);
+    expect(levels.at(-1)?.min).toHaveLength(1);
+  });
+});

--- a/app/packages/multimodal/src/audio/incremental-peaks.ts
+++ b/app/packages/multimodal/src/audio/incremental-peaks.ts
@@ -1,0 +1,134 @@
+// ---------------------------------------------------------------------------
+// Waveform peaks for audio that is never fully in memory.
+//
+// `buildChannelPeakPyramids` needs the whole track at once, which is exactly
+// what streaming exists to avoid. Peaks are a min/max fold, though, so they
+// can be accumulated window by window and the samples discarded immediately
+// after — the pyramid is the only thing retained.
+//
+// The size difference is the point: an hour of 48kHz stereo is ~1.4GB of
+// float samples, but only ~5MB of LOD-0 peaks at 256 samples per peak.
+//
+// Buckets not yet visited stay empty rather than reading as silence, so the
+// viewer can render "not loaded" differently from "quiet". A track played
+// straight through fills left to right; seeking fills the visited regions.
+// ---------------------------------------------------------------------------
+
+import {
+  DEFAULT_SAMPLES_PER_PEAK,
+  type PeakLevel,
+  type PeakPyramid,
+} from "./peak-pyramid";
+
+export interface IncrementalPeakOptions {
+  readonly channels: number;
+  readonly sampleRate: number;
+  readonly totalFrames: number;
+  readonly samplesPerPeak?: number;
+}
+
+export interface IncrementalPeakAccumulator {
+  /**
+   * Folds one window of interleaved PCM in at `startFrame`. Safe to call
+   * out of order and to overlap previously written ranges — a re-read after
+   * a seek overwrites rather than blends, so repeated playback of a region
+   * cannot inflate its peaks.
+   */
+  add(interleaved: Float32Array, startFrame: number): void;
+  /** True once any bucket has data — gates showing a waveform at all. */
+  hasData(): boolean;
+  /** Fraction of buckets filled, for a progress affordance. */
+  coverage(): number;
+  /** Snapshot with coarser levels reduced from LOD 0. */
+  pyramids(): readonly PeakPyramid[];
+}
+
+/** Coarser levels, each halving the peak count, down to a single bucket. */
+function reduceLevels(base: PeakLevel): PeakLevel[] {
+  const levels: PeakLevel[] = [base];
+  let current = base;
+  while (current.min.length > 1) {
+    const count = Math.ceil(current.min.length / 2);
+    const min = new Float32Array(count);
+    const max = new Float32Array(count);
+    for (let i = 0; i < count; i++) {
+      const a = i * 2;
+      const b = Math.min(a + 1, current.min.length - 1);
+      min[i] = Math.min(current.min[a], current.min[b]);
+      max[i] = Math.max(current.max[a], current.max[b]);
+    }
+    current = { min, max };
+    levels.push(current);
+  }
+  return levels;
+}
+
+export function createIncrementalPeaks({
+  channels,
+  sampleRate,
+  totalFrames,
+  samplesPerPeak = DEFAULT_SAMPLES_PER_PEAK,
+}: IncrementalPeakOptions): IncrementalPeakAccumulator {
+  const channelCount = Math.max(1, channels);
+  const peakCount = Math.max(1, Math.ceil(totalFrames / samplesPerPeak));
+
+  // One min/max pair per bucket per channel, allocated once.
+  const mins = Array.from(
+    { length: channelCount },
+    () => new Float32Array(peakCount),
+  );
+  const maxs = Array.from(
+    { length: channelCount },
+    () => new Float32Array(peakCount),
+  );
+  // Tracked separately from the values: a bucket whose true peaks are 0 is
+  // silence, which is not the same as a bucket never read.
+  const filled = new Uint8Array(peakCount);
+  let filledCount = 0;
+
+  return {
+    add(interleaved, startFrame) {
+      const frames = Math.floor(interleaved.length / channelCount);
+      if (frames <= 0) return;
+
+      let bucket = Math.floor(startFrame / samplesPerPeak);
+      let frame = 0;
+      while (frame < frames && bucket < peakCount) {
+        // Fold only up to this bucket's boundary, so a window that starts
+        // mid-bucket does not smear into the next one.
+        const bucketEndFrame = (bucket + 1) * samplesPerPeak - startFrame;
+        const stop = Math.min(frames, bucketEndFrame);
+
+        // A re-read overwrites: seed from the first frame rather than the
+        // stored value, or replaying a region would widen its peaks forever.
+        const fresh = filled[bucket] === 0;
+        for (let channel = 0; channel < channelCount; channel++) {
+          let lo = fresh ? Number.POSITIVE_INFINITY : mins[channel][bucket];
+          let hi = fresh ? Number.NEGATIVE_INFINITY : maxs[channel][bucket];
+          for (let f = frame; f < stop; f++) {
+            const value = interleaved[f * channelCount + channel] ?? 0;
+            if (value < lo) lo = value;
+            if (value > hi) hi = value;
+          }
+          if (Number.isFinite(lo)) mins[channel][bucket] = lo;
+          if (Number.isFinite(hi)) maxs[channel][bucket] = hi;
+        }
+        if (fresh && stop > frame) {
+          filled[bucket] = 1;
+          filledCount += 1;
+        }
+        frame = stop;
+        bucket += 1;
+      }
+    },
+    hasData: () => filledCount > 0,
+    coverage: () => filledCount / peakCount,
+    pyramids() {
+      return mins.map((min, channel) => ({
+        levels: reduceLevels({ min, max: maxs[channel] }),
+        samplesPerPeak,
+        sampleRate,
+      }));
+    },
+  };
+}

--- a/app/packages/multimodal/src/audio/index.ts
+++ b/app/packages/multimodal/src/audio/index.ts
@@ -4,6 +4,14 @@
  * tomorrow) only implement an `AudioLoader`.
  */
 export { useAudioPlayback } from "./use-audio-playback";
+export { useAudioStreamPlayback } from "./use-audio-stream-playback";
+export type {
+  AudioStreamSource,
+  UseAudioStreamPlaybackOptions,
+  UseAudioStreamPlaybackResult,
+} from "./use-audio-stream-playback";
+export { canUseSharedRingBuffer } from "./ring-buffer";
+export type { AudioWindowReader } from "./audio-stream-pump";
 export type {
   AudioPlaybackStatus,
   UseAudioPlaybackOptions,

--- a/app/packages/multimodal/src/audio/ring-buffer.test.ts
+++ b/app/packages/multimodal/src/audio/ring-buffer.test.ts
@@ -1,0 +1,360 @@
+import { describe, expect, it } from "vitest";
+import {
+  AudioRingBuffer,
+  allocateAudioRing,
+  canUseSharedRingBuffer,
+} from "./ring-buffer";
+
+/** Interleaved ramp: frame f, channel c -> f * channels + c. */
+function ramp(frames: number, channels: number, from = 0): Float32Array {
+  const out = new Float32Array(frames * channels);
+  for (let f = 0; f < frames; f++) {
+    for (let c = 0; c < channels; c++) {
+      out[f * channels + c] = (from + f) * channels + c;
+    }
+  }
+  return out;
+}
+
+function planar(frames: number, channels: number): Float32Array[] {
+  return Array.from({ length: channels }, () => new Float32Array(frames));
+}
+
+function ring(capacityFrames: number, channels: number): AudioRingBuffer {
+  return new AudioRingBuffer(allocateAudioRing(capacityFrames, channels));
+}
+
+describe("allocateAudioRing", () => {
+  it("rejects degenerate geometry rather than allocating an unusable ring", () => {
+    expect(() => allocateAudioRing(1, 2)).toThrow(RangeError);
+    expect(() => allocateAudioRing(8.5, 2)).toThrow(RangeError);
+    expect(() => allocateAudioRing(8, 0)).toThrow(RangeError);
+  });
+
+  it("sizes the allocation for control block plus interleaved samples", () => {
+    const { buffer } = allocateAudioRing(64, 2);
+    // 8 control ints + 64 frames * 2 channels * 4 bytes.
+    expect(buffer.byteLength).toBe(8 * 4 + 64 * 2 * 4);
+  });
+
+  it("uses shared memory only when the page is cross-origin isolated", () => {
+    const { buffer } = allocateAudioRing(8, 1);
+    expect(buffer instanceof SharedArrayBuffer).toBe(canUseSharedRingBuffer());
+  });
+});
+
+describe("AudioRingBuffer", () => {
+  it("starts empty, with one frame reserved to disambiguate full from empty", () => {
+    const rb = ring(16, 2);
+    expect(rb.availableRead()).toBe(0);
+    expect(rb.availableWrite()).toBe(15);
+  });
+
+  it("round-trips interleaved frames as de-interleaved planar output", () => {
+    const rb = ring(16, 2);
+    expect(rb.write(ramp(4, 2))).toBe(4);
+    expect(rb.availableRead()).toBe(4);
+
+    const out = planar(4, 2);
+    expect(rb.read(out, 4)).toBe(4);
+    // frame f, channel c == f * 2 + c
+    expect(Array.from(out[0])).toEqual([0, 2, 4, 6]);
+    expect(Array.from(out[1])).toEqual([1, 3, 5, 7]);
+    expect(rb.availableRead()).toBe(0);
+  });
+
+  it("writes only what fits and reports the short count", () => {
+    const rb = ring(8, 1); // 7 usable
+    expect(rb.write(ramp(10, 1))).toBe(7);
+    expect(rb.availableWrite()).toBe(0);
+    expect(rb.write(ramp(1, 1))).toBe(0);
+  });
+
+  it("resumes a partial write from offsetFrames without duplicating samples", () => {
+    const rb = ring(8, 1); // 7 usable
+    const source = ramp(10, 1);
+    const first = rb.write(source);
+    expect(first).toBe(7);
+
+    const out = planar(7, 1);
+    rb.read(out, 7);
+    expect(Array.from(out[0])).toEqual([0, 1, 2, 3, 4, 5, 6]);
+
+    // The producer retains the remainder and continues where it stopped.
+    expect(rb.write(source, first)).toBe(3);
+    const rest = planar(3, 1);
+    rb.read(rest, 3);
+    expect(Array.from(rest[0])).toEqual([7, 8, 9]);
+  });
+
+  it("wraps correctly when a write straddles the physical end of the ring", () => {
+    const rb = ring(8, 2); // 7 usable frames
+    // Advance the cursors so the next write must wrap.
+    rb.write(ramp(5, 2));
+    rb.read(planar(5, 2), 5);
+    expect(rb.availableRead()).toBe(0);
+
+    // 6 frames from write index 5, capacity 8 -> 3 then wrap 3.
+    expect(rb.write(ramp(6, 2, 100))).toBe(6);
+    const out = planar(6, 2);
+    expect(rb.read(out, 6)).toBe(6);
+    expect(Array.from(out[0])).toEqual([200, 202, 204, 206, 208, 210]);
+    expect(Array.from(out[1])).toEqual([201, 203, 205, 207, 209, 211]);
+  });
+
+  it("survives many wrap cycles without drifting the cursors", () => {
+    const rb = ring(8, 1); // 7 usable
+    let expected = 0;
+    for (let cycle = 0; cycle < 50; cycle++) {
+      expect(rb.write(ramp(5, 1, expected))).toBe(5);
+      const out = planar(5, 1);
+      expect(rb.read(out, 5)).toBe(5);
+      expect(Array.from(out[0])).toEqual([
+        expected,
+        expected + 1,
+        expected + 2,
+        expected + 3,
+        expected + 4,
+      ]);
+      expected += 5;
+    }
+    expect(rb.availableRead()).toBe(0);
+    expect(rb.availableWrite()).toBe(7);
+  });
+
+  it("reads only what is available, leaving the caller to zero-fill", () => {
+    const rb = ring(16, 1);
+    rb.write(ramp(3, 1));
+    const out = planar(8, 1);
+    expect(rb.read(out, 8)).toBe(3);
+    // Untouched tail stays zero — the consumer treats it as an underrun.
+    expect(Array.from(out[0].subarray(3))).toEqual([0, 0, 0, 0, 0]);
+  });
+
+  it("reports an empty read rather than throwing when fully drained", () => {
+    const rb = ring(16, 2);
+    expect(rb.read(planar(4, 2), 4)).toBe(0);
+  });
+});
+
+describe("seek flush", () => {
+  it("discards buffered audio only once the consumer acknowledges", () => {
+    const rb = ring(16, 1);
+    rb.write(ramp(8, 1));
+    expect(rb.availableRead()).toBe(8);
+
+    const generation = rb.requestFlush();
+    // The producer must not assume the stale audio is gone yet: the render
+    // thread may be mid-callback.
+    expect(rb.flushAcknowledged(generation)).toBe(false);
+    expect(rb.availableRead()).toBe(8);
+
+    expect(rb.applyPendingFlush()).toBe(true);
+    expect(rb.flushAcknowledged(generation)).toBe(true);
+    expect(rb.availableRead()).toBe(0);
+  });
+
+  it("is a no-op for the consumer when no flush is pending", () => {
+    const rb = ring(16, 1);
+    rb.write(ramp(4, 1));
+    expect(rb.applyPendingFlush()).toBe(false);
+    expect(rb.availableRead()).toBe(4);
+  });
+
+  it("resets the audio clock and underrun tally, so post-seek timing is not offset", () => {
+    const rb = ring(16, 1);
+    rb.write(ramp(4, 1));
+    rb.read(planar(4, 1), 4);
+    rb.advancePlayed(4);
+    rb.recordUnderrun(2);
+    expect(rb.framesPlayed()).toBe(4);
+    expect(rb.underrunFrames()).toBe(2);
+
+    rb.requestFlush();
+    rb.applyPendingFlush();
+    expect(rb.framesPlayed()).toBe(0);
+    expect(rb.underrunFrames()).toBe(0);
+  });
+
+  it("frees the whole ring for the new position after a flush", () => {
+    const rb = ring(8, 1); // 7 usable
+    rb.write(ramp(7, 1));
+    expect(rb.availableWrite()).toBe(0);
+
+    rb.requestFlush();
+    rb.applyPendingFlush();
+    expect(rb.availableWrite()).toBe(7);
+    expect(rb.write(ramp(7, 1, 900))).toBe(7);
+    const out = planar(7, 1);
+    rb.read(out, 7);
+    expect(out[0][0]).toBe(900);
+  });
+
+  it("keeps audio queued after the flush request, discarding only what preceded it", () => {
+    // Regression: an earlier version jumped READ to the live WRITE cursor,
+    // which ate the post-seek frames too whenever the producer queued them
+    // before the render thread acknowledged. The seek then played silence
+    // until the following read landed.
+    const rb = ring(64, 1);
+    rb.write(ramp(16, 1, 100)); // audio for the position being left
+
+    rb.requestFlush();
+    rb.write(ramp(8, 1, 900)); // audio for the position seeked to
+
+    expect(rb.applyPendingFlush()).toBe(true);
+    expect(rb.availableRead()).toBe(8);
+    const out = planar(8, 1);
+    rb.read(out, 8);
+    expect(Array.from(out[0])).toEqual([
+      900, 901, 902, 903, 904, 905, 906, 907,
+    ]);
+  });
+
+  it("honors the most recent boundary when seeks arrive faster than the render thread", () => {
+    const rb = ring(64, 1);
+    rb.write(ramp(8, 1, 100));
+    rb.requestFlush();
+    rb.write(ramp(8, 1, 200));
+    rb.requestFlush();
+    rb.write(ramp(4, 1, 300));
+
+    rb.applyPendingFlush();
+    expect(rb.availableRead()).toBe(4);
+    const out = planar(4, 1);
+    rb.read(out, 4);
+    expect(Array.from(out[0])).toEqual([300, 301, 302, 303]);
+  });
+
+  it("clears the ended flag so a seek out of end-of-stream resumes", () => {
+    const rb = ring(16, 1);
+    rb.markEnded();
+    expect(rb.hasEnded()).toBe(true);
+    rb.requestFlush();
+    expect(rb.hasEnded()).toBe(false);
+  });
+
+  it("acknowledges the latest generation when seeks arrive back to back", () => {
+    const rb = ring(16, 1);
+    rb.write(ramp(4, 1));
+    rb.requestFlush();
+    const second = rb.requestFlush();
+    // One consumer pass collapses both: it jumps to the current write cursor.
+    expect(rb.applyPendingFlush()).toBe(true);
+    expect(rb.flushAcknowledged(second)).toBe(true);
+    expect(rb.availableRead()).toBe(0);
+  });
+});
+
+describe("clock and diagnostics", () => {
+  it("counts frames played, not context time, so starvation is visible", () => {
+    const rb = ring(16, 1);
+    rb.advancePlayed(128);
+    rb.advancePlayed(128);
+    expect(rb.framesPlayed()).toBe(256);
+  });
+
+  it("tracks end-of-stream separately from starvation", () => {
+    const rb = ring(16, 1);
+    expect(rb.hasEnded()).toBe(false);
+    rb.markEnded();
+    expect(rb.hasEnded()).toBe(true);
+  });
+});
+
+describe("producer/consumer interleaving", () => {
+  it("preserves sample order under randomized partial writes and reads", () => {
+    const rb = ring(32, 2);
+    const total = 500;
+    const source = ramp(total, 2);
+
+    let written = 0;
+    let readBack = 0;
+    const seen: number[] = [];
+    // Deterministic pseudo-random sizes: a fixed LCG keeps the failure
+    // reproducible, which `Math.random()` would not.
+    let seed = 12345;
+    const nextSize = (max: number) => {
+      seed = (seed * 1103515245 + 12345) % 2147483648;
+      return 1 + (seed % max);
+    };
+
+    let guard = 0;
+    while (readBack < total && guard++ < 100000) {
+      if (written < total) {
+        written += rb.write(source.subarray(written * 2), 0);
+      }
+      const want = Math.min(nextSize(9), total - readBack);
+      const out = planar(want, 2);
+      const got = rb.read(out, want);
+      for (let f = 0; f < got; f++) {
+        seen.push(out[0][f], out[1][f]);
+      }
+      readBack += got;
+    }
+
+    expect(readBack).toBe(total);
+    expect(seen).toEqual(Array.from(source));
+  });
+});
+
+describe("shared memory topology", () => {
+  // The allocator gates on `crossOriginIsolated`, which is undefined under
+  // the test runner, so these build the layout by hand. Production runs
+  // exactly this shape: two `AudioRingBuffer` views — the producer on the
+  // main thread, the consumer on the audio render thread — over one
+  // `SharedArrayBuffer`. Every test above shares a single instance between
+  // both roles and so cannot catch a field accidentally held in JS state
+  // instead of the shared control block.
+  const sharedLayout = (capacityFrames: number, channels: number) => ({
+    buffer: new SharedArrayBuffer(
+      8 * 4 + capacityFrames * channels * Float32Array.BYTES_PER_ELEMENT,
+    ),
+    capacityFrames,
+    channels,
+  });
+
+  it("carries samples between two independent views of one buffer", () => {
+    const layout = sharedLayout(16, 2);
+    const producer = new AudioRingBuffer(layout);
+    const consumer = new AudioRingBuffer(layout);
+
+    expect(producer.write(ramp(5, 2))).toBe(5);
+    // The consumer was never told; it reads the shared cursor.
+    expect(consumer.availableRead()).toBe(5);
+
+    const out = planar(5, 2);
+    expect(consumer.read(out, 5)).toBe(5);
+    expect(Array.from(out[0])).toEqual([0, 2, 4, 6, 8]);
+
+    // ...and the producer sees the space the consumer freed.
+    expect(producer.availableWrite()).toBe(15);
+  });
+
+  it("propagates a seek flush from producer to consumer and back", () => {
+    const layout = sharedLayout(16, 1);
+    const producer = new AudioRingBuffer(layout);
+    const consumer = new AudioRingBuffer(layout);
+
+    producer.write(ramp(8, 1));
+    const generation = producer.requestFlush();
+    expect(producer.flushAcknowledged(generation)).toBe(false);
+
+    expect(consumer.applyPendingFlush()).toBe(true);
+    expect(producer.flushAcknowledged(generation)).toBe(true);
+    expect(producer.availableWrite()).toBe(15);
+  });
+
+  it("publishes the audio clock and end-of-stream across views", () => {
+    const layout = sharedLayout(16, 1);
+    const producer = new AudioRingBuffer(layout);
+    const consumer = new AudioRingBuffer(layout);
+
+    consumer.advancePlayed(480);
+    consumer.recordUnderrun(128);
+    expect(producer.framesPlayed()).toBe(480);
+    expect(producer.underrunFrames()).toBe(128);
+
+    producer.markEnded();
+    expect(consumer.hasEnded()).toBe(true);
+  });
+});

--- a/app/packages/multimodal/src/audio/ring-buffer.ts
+++ b/app/packages/multimodal/src/audio/ring-buffer.ts
@@ -1,0 +1,296 @@
+// ---------------------------------------------------------------------------
+// Lock-free SPSC ring buffer for streaming PCM into an AudioWorklet.
+//
+// One producer (the main thread, filling from paged MCAP reads) and one
+// consumer (the audio render thread) share one `SharedArrayBuffer`. No
+// locks: the render thread runs under a hard real-time deadline and must
+// never block, so coordination is two atomic cursors that only ever move
+// forward, each written by exactly one side.
+//
+// Layout, one allocation:
+//
+//   [ control: Int32Array(CONTROL_SLOTS) ][ data: Float32Array(capacity * ch) ]
+//
+// `write` is only ever stored by the producer and `read` only by the
+// consumer, so neither needs a compare-and-swap — an `Atomics.store` with
+// the matching `Atomics.load` on the other side is enough to publish the
+// samples that precede it.
+//
+// Capacity is one frame short of usable: `write === read` has to mean empty,
+// so a full buffer is `write + 1 === read` (mod capacity). Sizing accounts
+// for this.
+// ---------------------------------------------------------------------------
+
+/** Cursor and telemetry slots, in `Int32Array` units. */
+const CONTROL = Object.freeze({
+  /** Next frame index the producer will write. Producer-owned. */
+  WRITE: 0,
+  /** Next frame index the consumer will read. Consumer-owned. */
+  READ: 1,
+  /**
+   * Bumped by the producer to discard everything currently buffered (seek).
+   * The consumer observes the change, jumps `READ` to `WRITE`, and echoes
+   * the value into `GENERATION_ACK` so the producer knows the stale audio
+   * is gone rather than merely requested gone.
+   */
+  GENERATION: 2,
+  /** Last generation the consumer has acted on. Consumer-owned. */
+  GENERATION_ACK: 3,
+  /**
+   * Frames the consumer has emitted since the last flush. Drives the audio
+   * clock: this is the only honest answer to "what is the DAC playing",
+   * because `AudioContext.currentTime` advances even while the worklet is
+   * starved and emitting silence.
+   */
+  FRAMES_PLAYED: 4,
+  /** Frames of silence emitted because the buffer ran dry. Diagnostics. */
+  UNDERRUN_FRAMES: 5,
+  /**
+   * Set by the producer once no more data is coming for this generation, so
+   * the consumer can distinguish "end of stream" from "starved".
+   */
+  ENDED: 6,
+  /**
+   * Write cursor at the instant of the last flush request — the boundary
+   * between audio for the position the viewer left and audio for the one
+   * they seeked to. The consumer jumps `READ` here rather than to the live
+   * `WRITE`, so post-seek frames the producer has already queued survive.
+   */
+  FLUSH_TO: 7,
+});
+
+const CONTROL_SLOTS = 8;
+const CONTROL_BYTES = CONTROL_SLOTS * Int32Array.BYTES_PER_ELEMENT;
+
+/** True when this context can back a ring with shared memory. */
+export function canUseSharedRingBuffer(): boolean {
+  return (
+    typeof SharedArrayBuffer !== "undefined" &&
+    typeof Atomics !== "undefined" &&
+    typeof globalThis.crossOriginIsolated !== "undefined" &&
+    globalThis.crossOriginIsolated === true
+  );
+}
+
+export interface AudioRingBufferLayout {
+  readonly buffer: SharedArrayBuffer | ArrayBuffer;
+  readonly capacityFrames: number;
+  readonly channels: number;
+}
+
+/**
+ * Allocates the backing store for a ring holding `capacityFrames` frames of
+ * `channels`-channel interleaved float samples.
+ *
+ * Falls back to a plain `ArrayBuffer` when the page is not cross-origin
+ * isolated (notebook/Colab embeds skip COOP/COEP, and Safari does not
+ * implement `COEP: credentialless`). That buffer cannot be shared with the
+ * render thread, so the caller must use the port-transfer transport
+ * instead — `canUseSharedRingBuffer()` is the check that decides.
+ */
+export function allocateAudioRing(
+  capacityFrames: number,
+  channels: number,
+): AudioRingBufferLayout {
+  if (!Number.isInteger(capacityFrames) || capacityFrames < 2) {
+    throw new RangeError(`capacityFrames must be an integer >= 2`);
+  }
+  if (!Number.isInteger(channels) || channels < 1) {
+    throw new RangeError(`channels must be a positive integer`);
+  }
+  const bytes =
+    CONTROL_BYTES + capacityFrames * channels * Float32Array.BYTES_PER_ELEMENT;
+  const buffer = canUseSharedRingBuffer()
+    ? new SharedArrayBuffer(bytes)
+    : new ArrayBuffer(bytes);
+  return { buffer, capacityFrames, channels };
+}
+
+/**
+ * Typed views over a ring allocation. Both threads construct one of these
+ * over the same buffer; it holds no state of its own.
+ */
+export class AudioRingBuffer {
+  private readonly control: Int32Array;
+  private readonly data: Float32Array;
+  readonly capacityFrames: number;
+  readonly channels: number;
+
+  constructor({ buffer, capacityFrames, channels }: AudioRingBufferLayout) {
+    this.control = new Int32Array(buffer, 0, CONTROL_SLOTS);
+    this.data = new Float32Array(
+      buffer,
+      CONTROL_BYTES,
+      capacityFrames * channels,
+    );
+    this.capacityFrames = capacityFrames;
+    this.channels = channels;
+  }
+
+  /** Frames available to read. */
+  availableRead(): number {
+    const write = Atomics.load(this.control, CONTROL.WRITE);
+    const read = Atomics.load(this.control, CONTROL.READ);
+    return write >= read ? write - read : write + this.capacityFrames - read;
+  }
+
+  /** Frames the producer may write before the ring is full. */
+  availableWrite(): number {
+    // One frame is reserved so a full ring is distinguishable from an empty
+    // one; see the header.
+    return this.capacityFrames - 1 - this.availableRead();
+  }
+
+  /**
+   * Producer: copies as many frames of `interleaved` as fit, starting at
+   * `offsetFrames`. Returns the number of frames actually written, which is
+   * short of the request whenever the ring is nearly full — the caller
+   * retains the remainder and retries after the consumer drains.
+   */
+  write(interleaved: Float32Array, offsetFrames = 0): number {
+    const { channels, capacityFrames } = this;
+    const requested = Math.max(
+      0,
+      Math.floor(interleaved.length / channels) - offsetFrames,
+    );
+    const writable = Math.min(requested, this.availableWrite());
+    if (writable === 0) return 0;
+
+    const write = Atomics.load(this.control, CONTROL.WRITE);
+    // At most two copies: up to the physical end of the ring, then the
+    // wrapped remainder.
+    const firstFrames = Math.min(writable, capacityFrames - write);
+    this.data.set(
+      interleaved.subarray(
+        offsetFrames * channels,
+        (offsetFrames + firstFrames) * channels,
+      ),
+      write * channels,
+    );
+    const remaining = writable - firstFrames;
+    if (remaining > 0) {
+      this.data.set(
+        interleaved.subarray(
+          (offsetFrames + firstFrames) * channels,
+          (offsetFrames + writable) * channels,
+        ),
+        0,
+      );
+    }
+    // Publishes the sample copies above: the consumer's `Atomics.load` of
+    // WRITE synchronizes-with this store, so it cannot observe the new
+    // cursor without also observing the data.
+    Atomics.store(
+      this.control,
+      CONTROL.WRITE,
+      (write + writable) % capacityFrames,
+    );
+    return writable;
+  }
+
+  /**
+   * Consumer: fills `planar` (one `Float32Array` per channel) with up to
+   * `frames` frames, de-interleaving as it goes. Returns frames delivered;
+   * the caller zero-fills the rest and counts it as an underrun.
+   */
+  read(planar: readonly (Float32Array | undefined)[], frames: number): number {
+    const { channels, capacityFrames } = this;
+    const readable = Math.min(frames, this.availableRead());
+    if (readable === 0) return 0;
+
+    const read = Atomics.load(this.control, CONTROL.READ);
+    for (let frame = 0; frame < readable; frame++) {
+      const src = ((read + frame) % capacityFrames) * channels;
+      for (let channel = 0; channel < channels; channel++) {
+        const out = planar[channel];
+        if (out) out[frame] = this.data[src + channel] ?? 0;
+      }
+    }
+    Atomics.store(
+      this.control,
+      CONTROL.READ,
+      (read + readable) % capacityFrames,
+    );
+    return readable;
+  }
+
+  /**
+   * Producer: discards audio queued before this call. Used on seek, where
+   * every sample already buffered belongs to the position the viewer just
+   * left. Frames written *after* this call are for the new position and are
+   * preserved, so the producer does not have to wait for the acknowledgement
+   * before queueing them.
+   *
+   * The consumer performs the actual cursor move, because moving READ from
+   * this side would race a read already in flight on the render thread.
+   */
+  requestFlush(): number {
+    Atomics.store(this.control, CONTROL.ENDED, 0);
+    // Order matters: the boundary must be visible before the generation that
+    // advertises it, or the consumer could act on a stale `FLUSH_TO`.
+    Atomics.store(
+      this.control,
+      CONTROL.FLUSH_TO,
+      Atomics.load(this.control, CONTROL.WRITE),
+    );
+    return Atomics.add(this.control, CONTROL.GENERATION, 1) + 1;
+  }
+
+  /** Producer: true once the consumer has dropped the flushed audio. */
+  flushAcknowledged(generation: number): boolean {
+    return Atomics.load(this.control, CONTROL.GENERATION_ACK) >= generation;
+  }
+
+  /**
+   * Consumer: drops buffered audio if the producer asked for a flush.
+   * Returns true when a flush happened, so the caller can reset its own
+   * position bookkeeping.
+   */
+  applyPendingFlush(): boolean {
+    const generation = Atomics.load(this.control, CONTROL.GENERATION);
+    if (generation === Atomics.load(this.control, CONTROL.GENERATION_ACK)) {
+      return false;
+    }
+    // Not `WRITE`: the producer may already have queued audio for the new
+    // position, and jumping to the live write cursor would throw that away
+    // too, leaving the seek silent until the next read landed.
+    Atomics.store(
+      this.control,
+      CONTROL.READ,
+      Atomics.load(this.control, CONTROL.FLUSH_TO),
+    );
+    Atomics.store(this.control, CONTROL.FRAMES_PLAYED, 0);
+    Atomics.store(this.control, CONTROL.UNDERRUN_FRAMES, 0);
+    Atomics.store(this.control, CONTROL.GENERATION_ACK, generation);
+    return true;
+  }
+
+  /** Consumer: records frames emitted to the output. */
+  advancePlayed(frames: number): void {
+    Atomics.add(this.control, CONTROL.FRAMES_PLAYED, frames);
+  }
+
+  /** Consumer: records frames of silence emitted because the ring was dry. */
+  recordUnderrun(frames: number): void {
+    Atomics.add(this.control, CONTROL.UNDERRUN_FRAMES, frames);
+  }
+
+  /** Frames emitted since the last flush. The audio clock. */
+  framesPlayed(): number {
+    return Atomics.load(this.control, CONTROL.FRAMES_PLAYED);
+  }
+
+  underrunFrames(): number {
+    return Atomics.load(this.control, CONTROL.UNDERRUN_FRAMES);
+  }
+
+  /** Producer: marks the current generation complete. */
+  markEnded(): void {
+    Atomics.store(this.control, CONTROL.ENDED, 1);
+  }
+
+  /** Consumer: true when the producer will send nothing further. */
+  hasEnded(): boolean {
+    return Atomics.load(this.control, CONTROL.ENDED) === 1;
+  }
+}

--- a/app/packages/multimodal/src/audio/streaming-integration.test.ts
+++ b/app/packages/multimodal/src/audio/streaming-integration.test.ts
@@ -1,0 +1,272 @@
+// End-to-end through the real pieces: the pump produces, the ring carries,
+// the worklet processor consumes. Only the window reader and the render
+// thread's clock are faked — everything between them is production code.
+//
+// The unit tests cover each half against a stub of the other, which cannot
+// catch a disagreement about the contract between them (a frame/sample
+// confusion, or a flush boundary each side interprets differently). This
+// drives audio all the way to the output bus and checks the samples.
+
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { AudioRingBuffer } from "./ring-buffer";
+import {
+  createAudioStreamPump,
+  type AudioWindowReader,
+} from "./audio-stream-pump";
+import type { PcmAudioData } from "./types";
+
+class FakeAudioWorkletProcessor {
+  readonly port = { postMessage: () => undefined } as unknown as MessagePort;
+}
+
+type Processor = {
+  process(inputs: Float32Array[][], outputs: Float32Array[][]): boolean;
+};
+
+let ProcessorCtor: new (options?: unknown) => Processor;
+
+beforeAll(async () => {
+  vi.stubGlobal("AudioWorkletProcessor", FakeAudioWorkletProcessor);
+  vi.stubGlobal(
+    "registerProcessor",
+    (_n: string, ctor: new (options?: unknown) => Processor) => {
+      ProcessorCtor = ctor;
+    },
+  );
+  await import("./audio-stream-processor.worklet");
+});
+
+const SAMPLE_RATE = 1000;
+const CHANNELS = 1;
+const QUANTUM = 128;
+
+/**
+ * The engine surface the pump needs, backed by a real ring and a real
+ * processor. `createAudioStreamEngine` itself is skipped only because jsdom
+ * has no `AudioContext`/`AudioWorklet`; the ring and processor are real.
+ */
+function rig(capacityFrames = 4096) {
+  const layout = {
+    buffer: new SharedArrayBuffer(
+      8 * 4 + capacityFrames * CHANNELS * Float32Array.BYTES_PER_ELEMENT,
+    ),
+    capacityFrames,
+    channels: CHANNELS,
+  };
+  const ring = new AudioRingBuffer(layout);
+  const processor = new ProcessorCtor({ processorOptions: { layout } });
+
+  const engine = {
+    sampleRate: SAMPLE_RATE,
+    channels: CHANNELS,
+    availableWrite: () => ring.availableWrite(),
+    bufferedFrames: () => ring.availableRead(),
+    push: (pcm: Float32Array, offsetFrames = 0) =>
+      ring.write(pcm, offsetFrames),
+    seek: () => {
+      ring.requestFlush();
+    },
+    markEnded: () => ring.markEnded(),
+  };
+
+  /** Pulls `quanta` render quanta and returns every sample emitted. */
+  const render = (quanta: number): number[] => {
+    const out: number[] = [];
+    for (let q = 0; q < quanta; q++) {
+      const bus = [[new Float32Array(QUANTUM)]];
+      processor.process([], bus[0] ? bus : [[]]);
+      out.push(...Array.from(bus[0][0]));
+    }
+    return out;
+  };
+
+  return { ring, engine, render };
+}
+
+/**
+ * Window whose samples count up globally, so order is verifiable. Values
+ * start at 1: sample 0 would be indistinguishable from the silence the
+ * worklet emits when starved, making every assertion below ambiguous.
+ */
+const countingReader =
+  (frames: number): AudioWindowReader =>
+  async (startSec) => {
+    const base = Math.round(startSec * SAMPLE_RATE);
+    const samples = new Float32Array(frames);
+    for (let i = 0; i < frames; i++) samples[i] = base + i + 1;
+    return { samples, sampleRate: SAMPLE_RATE, channels: CHANNELS };
+  };
+
+const settle = () => new Promise((r) => setTimeout(r, 0));
+const immediate = () => {
+  const queue: (() => void)[] = [];
+  return {
+    schedule: (fn: () => void) => queue.push(fn),
+    async drain(rounds = 200) {
+      for (let i = 0; i < rounds && queue.length; i++) {
+        queue.shift()?.();
+        await Promise.resolve();
+      }
+    },
+  };
+};
+
+describe("streaming audio end to end", () => {
+  it("delivers windowed reads to the output bus in order", async () => {
+    const { engine, render } = rig();
+    const pump = createAudioStreamPump({
+      engine,
+      read: countingReader(SAMPLE_RATE),
+      durationSec: 2,
+      windowSeconds: 1,
+      schedule: immediate().schedule,
+    });
+
+    pump.start(0);
+    await settle();
+
+    // 2000 frames produced; pull 16 quanta (2048 frames) to drain them.
+    const emitted = render(16);
+    const audible = emitted.slice(0, 2000);
+    expect(audible).toEqual(Array.from({ length: 2000 }, (_, i) => i + 1));
+    // Past the end the bus is silent, not repeating the last buffer.
+    expect(emitted.slice(2000).every((v) => v === 0)).toBe(true);
+  });
+
+  it("keeps the media clock equal to the audio actually emitted", async () => {
+    const { ring, engine, render } = rig();
+    const pump = createAudioStreamPump({
+      engine,
+      read: countingReader(SAMPLE_RATE),
+      durationSec: 1,
+      windowSeconds: 1,
+      schedule: immediate().schedule,
+    });
+
+    pump.start(0);
+    await settle();
+    render(4); // 512 frames
+
+    expect(ring.framesPlayed()).toBe(512);
+    expect(ring.underrunFrames()).toBe(0);
+  });
+
+  it("loses no samples when the ring is smaller than the media", async () => {
+    // Ring holds 512 frames; the source is 4000. Every sample must still
+    // arrive exactly once, in order, across repeated drain/refill cycles.
+    const { engine, render } = rig(512);
+    const scheduler = immediate();
+    const pump = createAudioStreamPump({
+      engine,
+      read: countingReader(SAMPLE_RATE),
+      durationSec: 4,
+      windowSeconds: 1,
+      schedule: scheduler.schedule,
+    });
+
+    pump.start(0);
+    const collected: number[] = [];
+    for (let round = 0; round < 60; round++) {
+      await settle();
+      await scheduler.drain(5);
+      collected.push(...render(2));
+    }
+
+    // 0 is silence, never a sample value — see `countingReader`.
+    const audible = collected.filter((v) => v !== 0);
+    const expected = Array.from({ length: 4000 }, (_, i) => i + 1);
+    expect(audible).toEqual(expected);
+  });
+
+  it("plays the new position after a seek, never the audio left behind", async () => {
+    const { engine, render } = rig();
+    const scheduler = immediate();
+    const pump = createAudioStreamPump({
+      engine,
+      read: countingReader(SAMPLE_RATE),
+      durationSec: 100,
+      windowSeconds: 1,
+      schedule: scheduler.schedule,
+    });
+
+    pump.start(0);
+    await settle();
+
+    pump.seek(50);
+    await settle();
+    // The ring is still full of pre-seek audio, and the producer cannot
+    // refill until the render thread acknowledges the flush. That ack
+    // happens inside `process()`, so a quantum has to run first — this is
+    // the real post-seek sequence, not a test artifact.
+    render(1);
+    await scheduler.drain();
+    await settle();
+
+    const emitted = render(4).filter((v) => v !== 0);
+    expect(emitted.length).toBeGreaterThan(0);
+    expect(Math.min(...emitted)).toBeGreaterThan(50 * SAMPLE_RATE);
+  });
+
+  it("restarts the clock at the seek target so position is not cumulative", async () => {
+    const { ring, engine, render } = rig();
+    const pump = createAudioStreamPump({
+      engine,
+      read: countingReader(SAMPLE_RATE),
+      durationSec: 100,
+      windowSeconds: 1,
+      schedule: immediate().schedule,
+    });
+
+    pump.start(0);
+    await settle();
+    render(2);
+    expect(ring.framesPlayed()).toBe(256);
+
+    pump.seek(10);
+    await settle();
+    render(2);
+    // Not 512: the clock restarts at the seek target. The first of these two
+    // quanta consumes the flush, so only the second carries audio.
+    expect(ring.framesPlayed()).toBeLessThanOrEqual(256);
+    expect(ring.framesPlayed()).toBeGreaterThan(0);
+  });
+
+  it("emits silence without counting underruns once the media ends", async () => {
+    const { ring, engine, render } = rig();
+    const pump = createAudioStreamPump({
+      engine,
+      read: countingReader(100),
+      durationSec: 0.1,
+      windowSeconds: 1,
+      schedule: immediate().schedule,
+    });
+
+    pump.start(0);
+    await settle();
+
+    render(8); // far past the 100 available frames
+    expect(ring.hasEnded()).toBe(true);
+    expect(ring.underrunFrames()).toBe(0);
+    expect(ring.framesPlayed()).toBe(100);
+  });
+
+  it("counts underruns when the producer is too slow, not when it is done", async () => {
+    const { ring, engine, render } = rig();
+    // Reader never resolves: the pump is starved, not finished.
+    const pump = createAudioStreamPump({
+      engine,
+      read: () => new Promise<PcmAudioData>(() => undefined),
+      durationSec: 100,
+      windowSeconds: 1,
+      schedule: immediate().schedule,
+    });
+
+    pump.start(0);
+    await settle();
+    render(2);
+
+    expect(ring.hasEnded()).toBe(false);
+    expect(ring.underrunFrames()).toBe(2 * QUANTUM);
+    expect(ring.framesPlayed()).toBe(0);
+  });
+});

--- a/app/packages/multimodal/src/audio/use-audio-stream-playback.ts
+++ b/app/packages/multimodal/src/audio/use-audio-stream-playback.ts
@@ -1,0 +1,354 @@
+// ---------------------------------------------------------------------------
+// Streaming counterpart to `useAudioPlayback`.
+//
+// Same public result, different transport: instead of decoding the source
+// up front into one `AudioBuffer`, this keeps a bounded ring fed from
+// windowed reads and lets an `AudioWorklet` drain it. Memory is a function
+// of the ring, not the recording, so an hour-long track costs the same as a
+// ten-second one.
+//
+// It is a sibling rather than a branch inside `useAudioPlayback` because
+// the two transports share almost no machinery: there is no `AudioBuffer`,
+// no one-shot source node, and the clock comes from the worklet instead of
+// `AudioContext.currentTime`. Both hooks are called unconditionally by the
+// caller with one of them passed `null`, which keeps the rules of hooks
+// satisfied without a conditional call.
+//
+// Returns `available: false` when streaming cannot run here — off
+// cross-origin isolation there is no `SharedArrayBuffer`, and the caller
+// falls back to `useAudioPlayback`.
+//
+// `playback: false` consumers (the tile, which only draws a waveform) still
+// stream: they run the same read loop so peaks fill in, but push into a
+// discard sink instead of an audio graph. Gating the whole hook on
+// `playback` would leave those consumers stuck reporting "no audio".
+// ---------------------------------------------------------------------------
+
+import {
+  registerAudioTrack as registerAudioTrackImpl,
+  getEffectiveTrackVolume,
+  getPlayhead,
+  isMasterMuteAtSessionDefault,
+  setMasterMuted,
+  usePlayback,
+  usePlaybackStore,
+  useEffectiveTrackVolume,
+  useIsPlaying,
+  useSeekEvent,
+  type AudioSourceKind,
+  type PlaybackStream,
+} from "@fiftyone/playback";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  createAudioStreamEngine,
+  SharedAudioUnavailableError,
+  type AudioStreamEngine,
+} from "./audio-stream-engine";
+import {
+  createAudioStreamPump,
+  type AudioStreamPump,
+  type AudioWindowReader,
+} from "./audio-stream-pump";
+import {
+  createIncrementalPeaks,
+  type IncrementalPeakAccumulator,
+} from "./incremental-peaks";
+import { canUseSharedRingBuffer } from "./ring-buffer";
+import type { AudioMetadata } from "./types";
+import type {
+  AudioPlaybackStatus,
+  UseAudioPlaybackResult,
+} from "./use-audio-playback";
+import { audioProbe } from "./probe";
+
+/**
+ * Stand-in for the engine when a consumer wants the waveform but no sound.
+ * It accepts everything immediately, so the pump reads straight through the
+ * source folding peaks as it goes, and no `AudioContext` is created.
+ */
+function createDiscardSink(sampleRate: number, channels: number) {
+  return {
+    sampleRate,
+    channels,
+    availableWrite: () => Number.MAX_SAFE_INTEGER,
+    bufferedFrames: () => 0,
+    push: (interleaved: Float32Array, offsetFrames = 0) =>
+      Math.max(0, Math.floor(interleaved.length / channels) - offsetFrames),
+    seek: () => undefined,
+    markEnded: () => undefined,
+  };
+}
+
+/** Re-anchor the pump when the engine clock drifts past this. */
+const DRIFT_TOLERANCE_S = 0.25;
+/** How often the waveform snapshot is refreshed while filling. */
+const PEAK_REFRESH_MS = 400;
+
+/** Everything the transport needs to describe a streamable source. */
+export interface AudioStreamSource {
+  readonly sampleRate: number;
+  readonly channels: number;
+  readonly durationSec: number;
+  readonly read: AudioWindowReader;
+  readonly metadata?: AudioMetadata;
+}
+
+export interface UseAudioStreamPlaybackOptions {
+  readonly trackId: string;
+  readonly label?: string;
+  readonly kind?: AudioSourceKind;
+  /** `null` disables this hook entirely, for the buffered fallback. */
+  readonly source: AudioStreamSource | null;
+  readonly playback?: boolean;
+}
+
+export interface UseAudioStreamPlaybackResult extends UseAudioPlaybackResult {
+  /**
+   * False when this transport cannot run — no shared memory, or the engine
+   * failed to start. The caller uses the buffered path instead.
+   */
+  readonly available: boolean;
+}
+
+export function useAudioStreamPlayback({
+  trackId,
+  label,
+  kind = "pcm",
+  source,
+  playback = true,
+}: UseAudioStreamPlaybackOptions): UseAudioStreamPlaybackResult {
+  const { registerStream, subscribeStream } = usePlayback();
+  const store = usePlaybackStore();
+  const isPlaying = useIsPlaying();
+  const seekEvent = useSeekEvent();
+
+  // Constant for the page lifetime, so this never flips mid-session and
+  // leaves half a graph behind.
+  const supported = useMemo(() => canUseSharedRingBuffer(), []);
+
+  const [status, setStatus] = useState<AudioPlaybackStatus>("idle");
+  const [available, setAvailable] = useState(supported);
+  const [waveformPeaks, setWaveformPeaks] =
+    useState<UseAudioPlaybackResult["waveformPeaks"]>(null);
+
+  const engineRef = useRef<AudioStreamEngine | null>(null);
+  const pumpRef = useRef<AudioStreamPump | null>(null);
+  const peaksRef = useRef<IncrementalPeakAccumulator | null>(null);
+  const gainRef = useRef<GainNode | null>(null);
+  /** Media position the current ring generation started from. */
+  const anchorSecRef = useRef(0);
+
+  // Not gated on `playback`: a waveform-only consumer still streams, it
+  // just has no audio graph behind it.
+  const active = Boolean(source) && supported;
+
+  // Build the transport. Keyed on the source identity so a new track tears
+  // the old graph down rather than feeding two sources into one ring.
+  useEffect(() => {
+    if (!active || !source) {
+      setStatus("idle");
+      return undefined;
+    }
+
+    let cancelled = false;
+    setStatus("loading");
+    setWaveformPeaks(null);
+
+    const accumulator = createIncrementalPeaks({
+      channels: source.channels,
+      sampleRate: source.sampleRate,
+      totalFrames: Math.max(
+        1,
+        Math.round(source.durationSec * source.sampleRate),
+      ),
+    });
+    peaksRef.current = accumulator;
+
+    void (async () => {
+      try {
+        // Only an audible consumer builds a graph; browsers cap concurrent
+        // AudioContexts per page, and one per waveform tile would exhaust
+        // that budget for tracks nobody is listening to.
+        const sink = playback
+          ? await createAudioStreamEngine({
+              channels: source.channels,
+              sampleRate: source.sampleRate,
+            })
+          : createDiscardSink(source.sampleRate, source.channels);
+        if (cancelled) {
+          if ("dispose" in sink) void sink.dispose();
+          return;
+        }
+        if ("dispose" in sink) {
+          engineRef.current = sink;
+          const gain = sink.audioContext.createGain();
+          gain.gain.value = getEffectiveTrackVolume(store, trackId);
+          sink.node.connect(gain);
+          gain.connect(sink.audioContext.destination);
+          gainRef.current = gain;
+        }
+
+        // Peaks are folded from the same windows playback consumes, so the
+        // waveform costs no extra reads.
+        const read: AudioWindowReader = async (startSec, endSec, signal) => {
+          const window = await source.read(startSec, endSec, signal);
+          if (window) {
+            accumulator.add(
+              window.samples,
+              Math.round(startSec * source.sampleRate),
+            );
+          }
+          return window;
+        };
+
+        pumpRef.current = createAudioStreamPump({
+          engine: sink,
+          read,
+          durationSec: source.durationSec,
+          onError: () => setStatus("error"),
+        });
+
+        anchorSecRef.current = getPlayhead(store);
+        pumpRef.current.start(anchorSecRef.current);
+        audioProbe("stream-engine-ready", {
+          trackId,
+          playback,
+          channels: source.channels,
+          sampleRate: source.sampleRate,
+        });
+        setStatus("ready");
+      } catch (error) {
+        if (cancelled) return;
+        // No shared memory here: report unavailable so the caller falls back
+        // rather than presenting an audio track that is silently mute.
+        if (error instanceof SharedAudioUnavailableError) {
+          setAvailable(false);
+          setStatus("idle");
+        } else {
+          setStatus("error");
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      pumpRef.current?.stop();
+      pumpRef.current = null;
+      gainRef.current?.disconnect();
+      gainRef.current = null;
+      peaksRef.current = null;
+      const engine = engineRef.current;
+      engineRef.current = null;
+      void engine?.dispose();
+    };
+  }, [active, playback, source, store, trackId]);
+
+  // Waveform snapshots while the pyramid fills. Polled rather than pushed:
+  // the accumulator is written from the read path, and re-rendering on every
+  // window would thrash the canvas for no visible gain.
+  useEffect(() => {
+    if (status !== "ready") return undefined;
+    const timer = setInterval(() => {
+      const accumulator = peaksRef.current;
+      if (accumulator?.hasData()) setWaveformPeaks(accumulator.pyramids());
+    }, PEAK_REFRESH_MS);
+    return () => clearInterval(timer);
+  }, [status]);
+
+  // Mixer roster. Registered whenever this transport owns the track, so a
+  // source that fails to stream still appears rather than vanishing.
+  useEffect(() => {
+    // Roster membership is about audible tracks; a waveform-only instance
+    // would otherwise register a duplicate mixer row for the same source.
+    if (!active || !playback || !trackId) return undefined;
+    return registerAudioTrackImpl(store, {
+      id: trackId,
+      kind,
+      label: label ?? trackId,
+    });
+  }, [active, playback, store, trackId, label, kind]);
+
+  const seekTo = useCallback((timeSec: number) => {
+    anchorSecRef.current = timeSec;
+    pumpRef.current?.seek(timeSec);
+  }, []);
+
+  // Engine registration. `bufferState` is honest here, unlike the buffered
+  // transport's constant "ready": a streaming track really can be waiting.
+  useEffect(() => {
+    if (!active || !playback || status !== "ready") return undefined;
+    const stream: PlaybackStream = {
+      id: trackId,
+      blocking: false,
+      bufferState: () =>
+        (engineRef.current?.bufferedFrames() ?? 0) > 0 ? "ready" : "loading",
+      onCommit: (time) => {
+        const engine = engineRef.current;
+        if (!engine) return;
+        // The worklet's frame count is the only trustworthy position: it
+        // stops advancing during starvation, where `currentTime` does not.
+        const actual = anchorSecRef.current + engine.playedSeconds();
+        if (Math.abs(actual - time) > DRIFT_TOLERANCE_S) seekTo(time);
+      },
+    };
+    const unregister = registerStream(stream);
+    const unsubscribe = subscribeStream(trackId);
+    return () => {
+      unsubscribe();
+      unregister();
+    };
+  }, [
+    active,
+    playback,
+    status,
+    registerStream,
+    subscribeStream,
+    trackId,
+    seekTo,
+  ]);
+
+  // Transport. Web Audio has no per-node pause, so the context is suspended
+  // and resumed — this keeps the ring intact, which is the whole advantage
+  // over tearing down a source node.
+  useEffect(() => {
+    if (!active || !playback || status !== "ready") return undefined;
+    const engine = engineRef.current;
+    if (!engine) return undefined;
+
+    if (isPlaying) {
+      if (isMasterMuteAtSessionDefault()) setMasterMuted(store, false);
+      // Play is the user gesture browsers wait for before a context may
+      // produce sound.
+      void engine.audioContext.resume();
+    } else {
+      void engine.audioContext.suspend();
+    }
+    return undefined;
+  }, [active, playback, status, isPlaying, store]);
+
+  // Discontinuous jumps: scrub, step, loop wrap.
+  useEffect(() => {
+    if (!active || status !== "ready" || !seekEvent) return undefined;
+    seekTo(seekEvent.time);
+    return undefined;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [seekEvent?.seq]);
+
+  const effectiveVolume = useEffectiveTrackVolume(trackId);
+  useEffect(() => {
+    const gain = gainRef.current;
+    if (gain) gain.gain.value = effectiveVolume;
+  }, [effectiveVolume]);
+
+  return useMemo(
+    () => ({
+      available,
+      channels: source?.channels ?? 0,
+      hasAudio: Boolean(source) && status !== "idle",
+      metadata: source?.metadata ?? null,
+      status,
+      waveformPeaks,
+    }),
+    [available, source, status, waveformPeaks],
+  );
+}

--- a/app/packages/multimodal/src/audio/worklet-url.d.ts
+++ b/app/packages/multimodal/src/audio/worklet-url.d.ts
@@ -1,0 +1,13 @@
+/**
+ * Vite's `?worker&url` suffix: transpiles and bundles the target as a
+ * separate module-format entry and yields its URL, which is what
+ * `AudioWorklet.addModule()` needs. A plain `new URL(…, import.meta.url)`
+ * would hand the raw `.ts` to the browser untranspiled.
+ *
+ * `multimodal` has no `vite-env.d.ts`, so the ambient declaration lives
+ * here rather than pulling all of `vite/client` into this package.
+ */
+declare module "*?worker&url" {
+  const url: string;
+  export default url;
+}

--- a/app/packages/multimodal/src/views/episode/audio/use-mcap-audio-stream.ts
+++ b/app/packages/multimodal/src/views/episode/audio/use-mcap-audio-stream.ts
@@ -19,9 +19,12 @@
 // make full-buffer decode too slow or memory-heavy.
 // ---------------------------------------------------------------------------
 
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   useAudioPlayback,
+  useAudioStreamPlayback,
+  type AudioStreamSource,
+  type AudioWindowReader,
   type AudioLoadResult,
   type AudioMetadata,
   type PcmAudioData,
@@ -30,6 +33,8 @@ import {
   pcmToFloat32,
 } from "../../../audio";
 import { VISUALIZATION_KIND } from "../../../ir/index";
+import { canUseSharedRingBuffer } from "../../../audio";
+import type { DecodedFrame } from "../../../ir";
 import { monotonicNowMs } from "../../../utils/monotonic-time";
 import { useDataStream } from "../playback/data-stream-context";
 import {
@@ -43,12 +48,124 @@ import {
 // zero frames. Always a finite budget, computed per call.
 const ONE_SHOT_READ_TIMEOUT_MS = 60_000;
 
+/**
+ * One window is orders of magnitude smaller than the whole recording, so
+ * these bounds are tight — a window that cannot be read inside them is a
+ * starved ring, and failing fast lets the pump retry rather than block.
+ */
+function windowBudget() {
+  return {
+    deadlineMs: monotonicNowMs() + 15_000,
+    maxMessages: 20_000,
+    maxObservedPayloadBytes: 64 * 1024 * 1024,
+  } as const;
+}
+
+/**
+ * Length of the discovery read. The engine needs the real sample rate and
+ * channel count before it can build a context, and only the decoded audio
+ * knows them — `foxglove.CompressedAudio` carries neither in its manifest.
+ */
+const PROBE_SECONDS = 0.5;
+
 function oneShotBudget() {
   return {
     deadlineMs: monotonicNowMs() + ONE_SHOT_READ_TIMEOUT_MS,
     maxMessages: 100_000,
     maxObservedPayloadBytes: 256 * 1024 * 1024,
   } as const;
+}
+
+/**
+ * Folds one read's frames into a single interleaved PCM block. Shared by
+ * both transports: the buffered path calls it once over the whole
+ * recording, the streaming path once per window, and neither should have
+ * its own copy of the RawAudio/CompressedAudio handling.
+ */
+async function framesToPcm(
+  frames: readonly DecodedFrame[],
+  signal?: AbortSignal,
+): Promise<AudioLoadResult> {
+  const rawChunks: Array<PcmAudioData & { timestampNs: bigint }> = [];
+  const compressedChunks: CompressedAudioChunk[] = [];
+  let encodedBytes = 0;
+  let format: string | undefined;
+
+  for (const frame of frames) {
+    const visualization = frame.output.visualization;
+    if (visualization?.kind === VISUALIZATION_KIND.RAW_AUDIO) {
+      rawChunks.push({
+        channels: visualization.channels,
+        sampleRate: visualization.sampleRate,
+        samples: pcmToFloat32(visualization.samples),
+        timestampNs: frame.timestampNs,
+      });
+      // `??=` would latch an empty string forever (it is not nullish),
+      // so only accept a non-empty format.
+      format ||= String(frame.output.attributes?.format ?? "");
+      encodedBytes += Number(frame.output.attributes?.byteLength ?? 0);
+    } else if (visualization?.kind === VISUALIZATION_KIND.COMPRESSED_AUDIO) {
+      compressedChunks.push({
+        bytes: visualization.bytes,
+        format: visualization.format,
+        timestampNs: frame.timestampNs,
+      });
+      format ||= visualization.format;
+      encodedBytes += visualization.bytes.byteLength;
+    }
+  }
+
+  // Count the source messages, not the intermediate buffers: the
+  // compressed branch below pushes its single decoded block into
+  // `rawChunks`, so reading their lengths after that point would
+  // double-count.
+  const sourceChunkCount = rawChunks.length + compressedChunks.length;
+
+  // Compressed chunks decode to the same interleaved float layout the
+  // raw branch produces, so everything downstream is codec-agnostic.
+  if (rawChunks.length === 0 && compressedChunks.length > 0) {
+    const decoded = await decodeCompressedAudio(compressedChunks, signal);
+    if (signal?.aborted) return { ok: false, reason: "empty" };
+    if (!decoded) {
+      // A codec this browser cannot decode is not a broken recording.
+      return {
+        ok: false,
+        reason: "unsupported",
+        detail: compressedChunks[0]?.format,
+      };
+    }
+    rawChunks.push({
+      ...decoded,
+      timestampNs: compressedChunks[0].timestampNs,
+    });
+  }
+
+  if (rawChunks.length === 0) {
+    return { ok: false, reason: "empty" };
+  }
+
+  rawChunks.sort((a, b) => (a.timestampNs < b.timestampNs ? -1 : 1));
+  const data = concatPcmChunks(rawChunks);
+  if (!data) {
+    // Non-uniform sample rate/channel count across chunks — see
+    // `concatPcmChunks`. Report it rather than emit corrupt audio.
+    return {
+      ok: false,
+      reason: "error",
+      detail: "audio format changes mid-stream",
+    };
+  }
+
+  const metadata: AudioMetadata = {
+    byteLength: encodedBytes || undefined,
+    channels: data.channels,
+    chunkCount: sourceChunkCount,
+    durationSec:
+      data.samples.length / Math.max(1, data.channels) / data.sampleRate,
+    format: format || undefined,
+    sampleRate: data.sampleRate,
+  };
+  return { ok: true, data, metadata };
 }
 
 export type { UseAudioPlaybackResult as UseMcapAudioStreamResult };
@@ -94,97 +211,129 @@ export function useMcapAudioStream(
       });
       if (!result || signal?.aborted) return { ok: false, reason: "empty" };
 
-      const rawChunks: Array<PcmAudioData & { timestampNs: bigint }> = [];
-      const compressedChunks: CompressedAudioChunk[] = [];
-      let encodedBytes = 0;
-      let format: string | undefined;
-
-      for (const frame of result.frames) {
-        const visualization = frame.output.visualization;
-        if (visualization?.kind === VISUALIZATION_KIND.RAW_AUDIO) {
-          rawChunks.push({
-            channels: visualization.channels,
-            sampleRate: visualization.sampleRate,
-            samples: pcmToFloat32(visualization.samples),
-            timestampNs: frame.timestampNs,
-          });
-          // `??=` would latch an empty string forever (it is not nullish),
-          // so only accept a non-empty format.
-          format ||= String(frame.output.attributes?.format ?? "");
-          encodedBytes += Number(frame.output.attributes?.byteLength ?? 0);
-        } else if (
-          visualization?.kind === VISUALIZATION_KIND.COMPRESSED_AUDIO
-        ) {
-          compressedChunks.push({
-            bytes: visualization.bytes,
-            format: visualization.format,
-            timestampNs: frame.timestampNs,
-          });
-          format ||= visualization.format;
-          encodedBytes += visualization.bytes.byteLength;
-        }
-      }
-
-      // Count the source messages, not the intermediate buffers: the
-      // compressed branch below pushes its single decoded block into
-      // `rawChunks`, so reading their lengths after that point would
-      // double-count.
-      const sourceChunkCount = rawChunks.length + compressedChunks.length;
-
-      // Compressed chunks decode to the same interleaved float layout the
-      // raw branch produces, so everything downstream is codec-agnostic.
-      if (rawChunks.length === 0 && compressedChunks.length > 0) {
-        const decoded = await decodeCompressedAudio(compressedChunks, signal);
-        if (signal?.aborted) return { ok: false, reason: "empty" };
-        if (!decoded) {
-          // A codec this browser cannot decode is not a broken recording.
-          return {
-            ok: false,
-            reason: "unsupported",
-            detail: compressedChunks[0]?.format,
-          };
-        }
-        rawChunks.push({
-          ...decoded,
-          timestampNs: compressedChunks[0].timestampNs,
-        });
-      }
-
-      if (rawChunks.length === 0) {
-        return { ok: false, reason: "empty" };
-      }
-
-      rawChunks.sort((a, b) => (a.timestampNs < b.timestampNs ? -1 : 1));
-      const data = concatPcmChunks(rawChunks);
-      if (!data) {
-        // Non-uniform sample rate/channel count across chunks — see
-        // `concatPcmChunks`. Report it rather than emit corrupt audio.
-        return {
-          ok: false,
-          reason: "error",
-          detail: "audio format changes mid-stream",
-        };
-      }
-
-      const metadata: AudioMetadata = {
-        byteLength: encodedBytes || undefined,
-        channels: data.channels,
-        chunkCount: sourceChunkCount,
-        durationSec:
-          data.samples.length / Math.max(1, data.channels) / data.sampleRate,
-        format: format || undefined,
-        sampleRate: data.sampleRate,
-      };
-      return { ok: true, data, metadata };
+      return framesToPcm(result.frames, signal);
     },
     [getTimelineIndex, readStreamFrames, streamId],
   );
 
-  return useAudioPlayback({
+  // Reads one window of the recording. Time is expressed relative to the
+  // timeline origin, which is what the pump and the playhead both use.
+  const readWindowDetailed = useCallback(
+    async (
+      startSec: number,
+      endSec: number,
+      signal: AbortSignal,
+    ): Promise<AudioLoadResult> => {
+      if (!readStreamFrames || !getTimelineIndex) {
+        return { ok: false, reason: "empty" };
+      }
+      const timeline = getTimelineIndex();
+      if (!timeline) return { ok: false, reason: "empty" };
+
+      const result = await readStreamFrames({
+        budget: windowBudget(),
+        startTimeNs: timeline.secToNs(startSec),
+        endTimeNs: timeline.secToNs(endSec),
+        stream: streamId,
+        signal,
+      });
+      if (!result || signal.aborted) return { ok: false, reason: "empty" };
+
+      return framesToPcm(result.frames, signal);
+    },
+    [getTimelineIndex, readStreamFrames, streamId],
+  );
+
+  // The pump only wants PCM; the probe below also wants the metadata the
+  // same decode already produced, hence the two layers.
+  const readWindow = useCallback<AudioWindowReader>(
+    async (startSec, endSec, signal) => {
+      const decoded = await readWindowDetailed(startSec, endSec, signal);
+      return decoded.ok ? decoded.data : null;
+    },
+    [readWindowDetailed],
+  );
+
+  // Discover the stream's real geometry before building an audio graph for
+  // it. Only decoded audio knows the sample rate and channel count, so this
+  // reads a short head window rather than trusting the manifest.
+  const [streamSource, setStreamSource] = useState<AudioStreamSource | null>(
+    null,
+  );
+  useEffect(() => {
+    if (!streamId || !canUseSharedRingBuffer() || !getTimelineIndex) {
+      setStreamSource(null);
+      return undefined;
+    }
+    let cancelled = false;
+    const controller = new AbortController();
+
+    void (async () => {
+      const timeline = getTimelineIndex();
+      if (!timeline) return;
+      const probed = await readWindowDetailed(
+        0,
+        PROBE_SECONDS,
+        controller.signal,
+      );
+      if (cancelled) return;
+      if (
+        !probed.ok ||
+        probed.data.sampleRate <= 0 ||
+        probed.data.channels <= 0
+      ) {
+        // Nothing decodable at the head: let the buffered path report why,
+        // including "unsupported codec", which it distinguishes properly.
+        setStreamSource(null);
+        return;
+      }
+      setStreamSource({
+        channels: probed.data.channels,
+        durationSec: timeline.durationSec,
+        read: readWindow,
+        sampleRate: probed.data.sampleRate,
+        // Byte and chunk counts describe the probe window only, so they are
+        // dropped rather than reported as totals for the whole recording.
+        metadata: {
+          channels: probed.data.channels,
+          codecLabel: probed.metadata?.codecLabel,
+          durationSec: timeline.durationSec,
+          format: probed.metadata?.format,
+          sampleRate: probed.data.sampleRate,
+        },
+      });
+    })();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [getTimelineIndex, readWindow, readWindowDetailed, streamId]);
+
+  // Both transports are called unconditionally with one of them disabled —
+  // a conditional hook call would break the rules of hooks, and the choice
+  // can flip once at runtime when streaming turns out to be unavailable.
+  const streaming = useAudioStreamPlayback({
     kind: "pcm",
     label,
-    load: useMemo(() => (streamId ? load : null), [load, streamId]),
+    playback,
+    source: streamSource,
+    trackId: streamId,
+  });
+  const streamingActive = Boolean(streamSource) && streaming.available;
+
+  const buffered = useAudioPlayback({
+    kind: "pcm",
+    label,
+    // Disabled while streaming owns the track: two transports decoding the
+    // same source would build two audio graphs and double the signal.
+    load: useMemo(
+      () => (streamId && !streamingActive ? load : null),
+      [load, streamId, streamingActive],
+    ),
     playback,
     trackId: streamId,
   });
+
+  return streamingActive ? streaming : buffered;
 }


### PR DESCRIPTION
> [!NOTE]
> **Stack 2/2.** This PR targets `feat/mmAudio` (#8274), so the diff below is *only* the
> streaming work — 4 commits / 14 files. It will retarget to `develop` automatically once
> #8274 merges.
>
> Review #8274 first.

## 🔗 Related Issues

Stacked on #8274 (container-agnostic multi-track audio playback).

## 📋 What changes are proposed in this pull request?

Replaces the up-front full-recording audio decode with real streaming.

**The problem.** #8274 decodes each audio source in one pass: a single `readStreamFrames`
over the whole recording, concatenated into one `Float32Array`, copied into one
`AudioBuffer`. Both modules label this a "SIMPLIFICATION" in their headers and say to
revisit it. An hour of 48 kHz stereo is ~1.4 GB of float samples — that does not degrade on
long recordings, it fails. The same assumption had already surfaced one layer down, where
waveform peaks overflowed WebGPU's `maxTextureDimension2D` past ~44 seconds of audio.

**The approach.** A fixed ~4-second ring buffer in shared memory. A producer on the main
thread reads one-second windows and writes into the ring; an `AudioWorklet` on the audio
render thread drains it. Memory is a function of the ring, not the recording, so an hour
costs the same as ten seconds.

No adapter changes were needed: `readStreamFrames` already took arbitrary
`startTimeNs`/`endTimeNs` with a budget and bottomed out in
`session.read({ window, streams, priority })` — a real ranged read against MCAP's chunk
index. The full-extent read was a consumer choice, not a limitation of the layer.

### New modules (`app/packages/multimodal/src/audio/`)

| File | Role |
|------|------|
| `ring-buffer.ts` | Lock-free SPSC ring over one `SharedArrayBuffer`. Each side owns exactly one cursor, so no CAS is needed and the audio thread never blocks. |
| `audio-stream-processor.worklet.ts` | The consumer, on the audio render thread. Allocation-free and lock-free — it has ~2.7 ms per 128-frame callback, and missing that deadline is an audible glitch. |
| `audio-stream-engine.ts` | Owns the `AudioContext` and worklet node. Transport only, no MCAP knowledge, keeping `src/audio/` container-neutral. |
| `audio-stream-pump.ts` | Producer loop. Reads only when the ring has room, then backs off proportionally to the runway left. Takes an **injected reader**, so MCAP paging stays in the view layer. |
| `incremental-peaks.ts` | Waveform peaks accumulated window by window. |
| `use-audio-stream-playback.ts` | React hook: transport, roster, volume, drift correction. |

### Decisions worth reviewing

**The clock counts frames actually emitted, not `AudioContext.currentTime`.** `currentTime`
keeps advancing while the worklet is starved and emitting silence, so using it for drift
correction would slide the media position every time the ring ran dry.

**A seek records the write cursor as a flush boundary** rather than discarding to the live
cursor. Flushing to `WRITE` also ate post-seek frames the producer had already queued,
leaving the seek silent until the next read landed.

**Waveforms survive because peaks are a min/max fold.** `incremental-peaks.ts` accumulates
them per window and discards the samples immediately — ~5 MB of peaks instead of ~1.4 GB of
samples for an hour of stereo. A test asserts the incremental result is identical to the
one-shot `buildChannelPeakPyramids`, including windows straddling bucket boundaries.

**Both transports are kept, deliberately.** Streaming needs `SharedArrayBuffer`, so it is
unavailable in notebook/Colab embeds (`app.py` skips COOP/COEP there on purpose, since
`COOP: same-origin` would break the iframe) and in Safari (no `COEP: credentialless`). The
buffered path stays as the fallback, selected by `canUseSharedRingBuffer()`.
`use-mcap-audio-stream.ts` calls **both hooks unconditionally** with one disabled — a
conditional hook call would break the rules of hooks, and the choice can flip at runtime.
The old path becomes deletable once a port-transfer transport exists for those contexts.

### Threads

**No new Web Worker.** The `AudioWorklet` runs on the browser's audio render thread, one per
`AudioContext` — a real-time thread, not a worker.

⚠️ That means **one render thread per audible track**, and Chrome caps `AudioContext`s per
page at ~6; past that, construction fails as unexplained silence rather than an error. This
is **pre-existing** — the buffered path also does `new AudioContext()` per track
(`use-audio-playback.ts:253`) — and this PR slightly improves it, since waveform-only tiles
now create no context at all. The real fix is one shared context with a node per track
feeding a mixer; not done here.

## 🧪 How is this patch tested? If it is not, please explain why.

**91 tests** across `audio/` and `views/episode/audio/`, plus the package's `check:lint`,
`check:types`, `check:architecture`, `check:deps`, and `check:bounded-reads`.

- `ring-buffer.test.ts` — wraparound, backpressure, seek-flush semantics, and the real
  two-views-over-one-`SharedArrayBuffer` topology (not one instance playing both roles).
- `audio-stream-processor.worklet.test.ts` — drives `process()` directly with stubbed
  worklet globals, covering starvation, end-of-stream, and mid-quantum seeks.
- `audio-stream-pump.test.ts` — short-push retention, seek-during-read, reader failure.
- `streaming-integration.test.ts` — the real pump, ring, and worklet together; asserts all
  4000 samples arrive exactly once in order through a ring one-eighth the size of the media.
- `incremental-peaks.test.ts` — equivalence with the one-shot pyramid build.

**Three bugs were found by testing rather than review**, which is the main argument for the
coverage above:

1. Seek discarded the new position's audio along with the old (flush boundary).
2. The pump's backoff was inverted — it keyed off free space rather than buffered audio, so
   it slept longest exactly when the ring was empty. Only the end-to-end test caught this;
   each half looked correct against a stub of the other.
3. From live use: `AudioTile` requests `playback: false` for a waveform, and gating the
   streaming hook on `playback` left it reporting "No audio decoded from this source" while
   audio played.

**Not covered:** no browser-audio e2e — the worklet is exercised by calling `process()`
directly, so nothing here verifies real audio hardware.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

Audio in the multimodal viewer now streams instead of decoding the entire recording before
playback, so long recordings start quickly and no longer scale memory with their length.

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audio playback support for MCAP raw and compressed audio streams.
  * Added interactive audio tiles with per-track waveforms, seeking, mute controls, and timeline integration.
  * Added master and per-track volume controls through a mixer popover.
  * Added support for streaming playback, waveform visualization, audio settings, and unsupported-format states.
  * Added audio source detection and classification across supported message formats.
* **Bug Fixes**
  * Audio-only recordings now load and become playable without blocking readiness.
* **Tests**
  * Added comprehensive coverage for audio decoding, playback, visualization, controls, and end-to-end scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
