### PR TITLE
Move annotation instructions into a status bar help tooltip

### DIFF
--- a/app/packages/core/src/components/Modal/ModalStatusBar.test.tsx
+++ b/app/packages/core/src/components/Modal/ModalStatusBar.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useEffect } from "react";
+import { ThemeProvider } from "styled-components";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  ModalStatusBar,
+  StatusContent,
+  StatusHelp,
+  useModalStatusBar,
+} from "./ModalStatusBar";
+
+const theme = {
+  text: {
+    primary: "#fff",
+    secondary: "#aaa",
+  },
+};
+
+const helpContent = (
+  <StatusHelp
+    title="Polyline"
+    entries={[{ gesture: "Alt + click", description: "Delete a point" }]}
+  />
+);
+
+const Registrar = ({ content }: { content: StatusContent }) => {
+  const { setContent } = useModalStatusBar();
+
+  useEffect(() => {
+    setContent(content);
+    return () => setContent(null);
+  }, [content, setContent]);
+
+  return null;
+};
+
+const renderBar = (content: StatusContent) =>
+  render(
+    <ThemeProvider theme={theme}>
+      <Registrar content={content} />
+      <ModalStatusBar />
+    </ThemeProvider>,
+  );
+
+describe("ModalStatusBar", () => {
+  // unmounting also clears the registered content, so each case starts empty
+  afterEach(cleanup);
+
+  it("renders nothing when no content is registered", () => {
+    renderBar(null);
+
+    expect(screen.queryByTestId("modal-status-bar")).toBeNull();
+  });
+
+  it("renders nothing when content carries neither status nor help", () => {
+    renderBar({});
+
+    expect(screen.queryByTestId("modal-status-bar")).toBeNull();
+  });
+
+  it("omits the help affordance when content has no help", () => {
+    renderBar({ status: <span>3 vertices</span> });
+
+    expect(screen.getByText("3 vertices")).toBeTruthy();
+    expect(screen.queryByLabelText("Show instructions")).toBeNull();
+  });
+
+  it("shows the help affordance with no inline status", () => {
+    renderBar({ help: helpContent });
+
+    expect(screen.getByLabelText("Show instructions")).toBeTruthy();
+  });
+
+  it("keeps instructions hidden until the affordance is hovered", async () => {
+    renderBar({ status: <span>3 vertices</span>, help: helpContent });
+
+    expect(screen.queryByText("Alt + click")).toBeNull();
+
+    await userEvent.hover(screen.getByLabelText("Show instructions"));
+
+    expect(screen.getByText("Polyline")).toBeTruthy();
+    expect(screen.getByText("Alt + click")).toBeTruthy();
+    expect(screen.getByText("Delete a point")).toBeTruthy();
+  });
+});

--- a/app/packages/core/src/components/Modal/ModalStatusBar.test.tsx
+++ b/app/packages/core/src/components/Modal/ModalStatusBar.test.tsx
@@ -4,7 +4,6 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useEffect } from "react";
-import { ThemeProvider } from "styled-components";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   ModalStatusBar,
@@ -12,13 +11,6 @@ import {
   StatusHelp,
   useModalStatusBar,
 } from "./ModalStatusBar";
-
-const theme = {
-  text: {
-    primary: "#fff",
-    secondary: "#aaa",
-  },
-};
 
 const helpContent = (
   <StatusHelp
@@ -40,10 +32,10 @@ const Registrar = ({ content }: { content: StatusContent }) => {
 
 const renderBar = (content: StatusContent) =>
   render(
-    <ThemeProvider theme={theme}>
+    <>
       <Registrar content={content} />
       <ModalStatusBar />
-    </ThemeProvider>,
+    </>,
   );
 
 describe("ModalStatusBar", () => {

--- a/app/packages/core/src/components/Modal/ModalStatusBar.tsx
+++ b/app/packages/core/src/components/Modal/ModalStatusBar.tsx
@@ -1,46 +1,95 @@
 import {
-  Align,
+  Anchor,
+  Icon,
+  IconName,
   Orientation,
+  Size,
   Spacing,
   Stack,
   Text,
   TextColor,
   TextVariant,
+  Tooltip,
 } from "@voxel51/voodo";
 import { atom, PrimitiveAtom, useAtomValue, useSetAtom } from "jotai";
-import { ReactElement, ReactNode, useMemo } from "react";
+import { Fragment, ReactElement, useMemo } from "react";
 import styled from "styled-components";
 
-export type StatusContent = ReactElement | null;
+export type StatusContent = {
+  /**
+   * Live state the user cannot read anywhere else — a vertex count, inference
+   * progress, an error. Keep it to a few words: instructions belong in `help`,
+   * not here, so the bar stays clear of the panel tabs to its left.
+   */
+  status?: ReactElement;
+  /** Instructions for the active mode, revealed by the help affordance. */
+  help?: ReactElement;
+} | null;
 
 const initialContent: StatusContent = null;
 const statusContentAtom: PrimitiveAtom<StatusContent> = atom(initialContent);
 
+// Matches the panel tab strip the bar sits over (`StyledPanel` subtracts the
+// same height), so bar content is centered in that strip.
+const TAB_STRIP_HEIGHT = "28px";
+
+// Anchored to the right edge only — with no `left`, the box shrink-wraps its
+// content and grows leftward, so it cannot reach the tabs at the left of the
+// strip. `position: absolute` keeps it out of the flex flow so it never
+// shrinks the sample canvas.
 const Container = styled.div`
   position: absolute;
   top: 0;
-  left: 50%;
-  transform: translateX(-50%);
+  right: 0;
+  max-width: 100%;
+  height: ${TAB_STRIP_HEIGHT};
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+  padding: 0 8px;
   z-index: 1502;
   pointer-events: none;
   user-select: none;
   white-space: nowrap;
 `;
 
-const IconWrap = styled.span`
+// Truncates rather than growing left indefinitely; anything at risk of being
+// cut short (a long error message) should also be in `help`.
+const Status = styled.div`
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+// Wraps the tooltip rather than the trigger itself: `Tooltip` renders its own
+// wrapper element around children, so it — not the trigger — is the flex item.
+// Only this slot takes pointer events; the rest of the bar lets clicks fall
+// through to the tab strip and canvas beneath it.
+const HelpSlot = styled.div`
+  flex: none;
   display: inline-flex;
   align-items: center;
-  color: ${({ theme }) => theme.text.secondary};
+  pointer-events: auto;
+`;
 
-  & > svg {
-    font-size: 18px;
+const HelpTrigger = styled.span`
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  cursor: help;
+  opacity: 0.7;
+  transition: opacity 0.15s ease;
+
+  &:hover {
+    opacity: 1;
   }
 `;
 
 /**
- * Floating status / hint display at the top of the modal sample pane.
- * Renders whatever was registered via {@link useModalStatusBar}'s
- * `setContent`. Hidden when no content is registered.
+ * Status / hint display at the top right of the modal sample pane. Renders
+ * whatever was registered via {@link useModalStatusBar}'s `setContent`, and
+ * nothing at all when no content is registered.
  *
  * The bar is mode-agnostic; mode-specific registrar components call
  * `setContent` based on their own state.
@@ -48,12 +97,37 @@ const IconWrap = styled.span`
 export const ModalStatusBar = () => {
   const content = useAtomValue(statusContentAtom);
   if (!content) return null;
-  return <Container data-cy="modal-status-bar">{content}</Container>;
+  if (!content.status && !content.help) return null;
+
+  return (
+    <Container data-cy="modal-status-bar">
+      {content.status && <Status>{content.status}</Status>}
+      {content.help && (
+        <HelpSlot>
+          <Tooltip content={content.help} anchor={Anchor.Bottom} portal>
+            <HelpTrigger
+              data-cy="modal-status-bar-help"
+              aria-label="Show instructions"
+            >
+              <Icon
+                name={IconName.Info}
+                size={Size.Sm}
+                color={TextColor.Secondary}
+              />
+              <Text variant={TextVariant.Sm} color={TextColor.Secondary}>
+                Help
+              </Text>
+            </HelpTrigger>
+          </Tooltip>
+        </HelpSlot>
+      )}
+    </Container>
+  );
 };
 
 /**
- * Hook for mode-specific status registrars. Call `setContent(<XStatus />)`
- * when the mode becomes active, `setContent(null)` when it leaves.
+ * Hook for mode-specific status registrars. Call `setContent(...)` when the
+ * mode becomes active, `setContent(null)` when it leaves.
  *
  * Last-writer-wins; rely on conditional mounting so at most one writer is
  * mounted at a time and React's commit ordering (cleanup before next mount)
@@ -64,25 +138,51 @@ export const useModalStatusBar = () => {
   return useMemo(() => ({ setContent }), [setContent]);
 };
 
+export type StatusHelpEntry = {
+  /** The gesture or key, e.g. `"Alt + click"`. */
+  gesture: string;
+  /** What that gesture does. */
+  description: string;
+};
+
+const HelpEntries = styled.div`
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 6px 12px;
+  align-items: baseline;
+  /* inside the tooltip panel's own 500px cap, with room for the longer
+     multi-sentence descriptions */
+  max-width: 440px;
+  white-space: normal;
+`;
+
 /**
- * Common "icon + label" content for mode status bars.
+ * Common help content for mode status bars: the mode's name over a
+ * gesture/description table, for the {@link StatusContent} `help` slot.
  */
-export const StatusItem = ({
-  icon,
-  label,
+export const StatusHelp = ({
+  title,
+  entries,
 }: {
-  icon: ReactNode;
-  label: ReactNode;
+  title: string;
+  entries: StatusHelpEntry[];
 }) => (
-  <Stack
-    orientation={Orientation.Row}
-    align={Align.Center}
-    spacing={Spacing.Sm}
-  >
-    <IconWrap>{icon}</IconWrap>
-    <Text variant={TextVariant.Md} color={TextColor.Secondary}>
-      {label}
+  <Stack orientation={Orientation.Column} spacing={Spacing.Sm}>
+    <Text variant={TextVariant.Label} color={TextColor.Primary}>
+      {title}
     </Text>
+    <HelpEntries>
+      {entries.map(({ gesture, description }) => (
+        <Fragment key={gesture}>
+          <Text variant={TextVariant.Sm} color={TextColor.Primary}>
+            {gesture}
+          </Text>
+          <Text variant={TextVariant.Sm} color={TextColor.Secondary}>
+            {description}
+          </Text>
+        </Fragment>
+      ))}
+    </HelpEntries>
   </Stack>
 );
 

--- a/app/packages/core/src/components/Modal/ModalStatusBar.tsx
+++ b/app/packages/core/src/components/Modal/ModalStatusBar.tsx
@@ -17,9 +17,9 @@ import styled from "styled-components";
 
 export type StatusContent = {
   /**
-   * Live state the user cannot read anywhere else — a vertex count, inference
-   * progress, an error. Keep it to a few words: instructions belong in `help`,
-   * not here, so the bar stays clear of the panel tabs to its left.
+   * Live state the user cannot read anywhere else — inference progress, a
+   * chosen merge target, an error. Keep it to a few words: instructions belong
+   * in `help`, not here, so the bar stays clear of the panel tabs to its left.
    */
   status?: ReactElement;
   /** Instructions for the active mode, revealed by the help affordance. */

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/annotationStatusContent.test.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/annotationStatusContent.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { aiSegmentationStatus } from "./annotationStatusContent";
+
+const renderHelp = (help: React.ReactElement | undefined) => {
+  expect(help).toBeTruthy();
+  render(help as React.ReactElement);
+};
+
+describe("aiSegmentationStatus", () => {
+  afterEach(cleanup);
+
+  it("keeps the gesture table when an error carries a message", () => {
+    const content = aiSegmentationStatus({
+      status: "error",
+      progress: null,
+      error: { kind: "encoder_failure", message: "out of memory" },
+    });
+
+    renderHelp(content?.help);
+
+    expect(screen.getByText("out of memory")).toBeTruthy();
+    expect(screen.getByText("AI segmentation")).toBeTruthy();
+    expect(screen.getByText("Shift + click")).toBeTruthy();
+  });
+
+  it("still offers help when an error carries no message", () => {
+    const content = aiSegmentationStatus({
+      status: "error",
+      progress: null,
+      error: { kind: "unsupported", message: "" },
+    });
+
+    renderHelp(content?.help);
+
+    expect(screen.getByText("AI segmentation")).toBeTruthy();
+  });
+
+  it("offers help while inference is running", () => {
+    const content = aiSegmentationStatus({
+      status: "inferring",
+      progress: null,
+      error: null,
+    });
+
+    renderHelp(content?.help);
+
+    expect(screen.getByText("AI segmentation")).toBeTruthy();
+  });
+});

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/annotationStatusContent.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/annotationStatusContent.tsx
@@ -130,12 +130,7 @@ const POLYLINE_PROGRESS_HELP: StatusHelpEntry[] = [
   },
 ];
 
-export const polylineProgressStatus = (vertexCount: number): StatusContent => ({
-  status: (
-    <StatusText>
-      {`${vertexCount} ${vertexCount === 1 ? "vertex" : "vertices"}`}
-    </StatusText>
-  ),
+export const polylineProgressStatus = (): StatusContent => ({
   help: <StatusHelp title="Polyline" entries={POLYLINE_PROGRESS_HELP} />,
 });
 

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/annotationStatusContent.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/annotationStatusContent.tsx
@@ -1,8 +1,4 @@
-import { DetectionIcon } from "@fiftyone/components";
 import ErrorOutline from "@mui/icons-material/ErrorOutline";
-import Brush from "@mui/icons-material/Brush";
-import CallMerge from "@mui/icons-material/CallMerge";
-import Timeline from "@mui/icons-material/Timeline";
 import {
   Align,
   Orientation,
@@ -15,7 +11,11 @@ import {
   TextVariant,
 } from "@voxel51/voodo";
 import { ReactElement } from "react";
-import { StatusItem } from "../../../ModalStatusBar";
+import {
+  StatusContent,
+  StatusHelp,
+  StatusHelpEntry,
+} from "../../../ModalStatusBar";
 import {
   InferenceError,
   InferenceProgress,
@@ -23,86 +23,145 @@ import {
 } from "@fiftyone/annotation/src/agents";
 import { ProviderErrorKind } from "@fiftyone/annotation";
 
-const DETECTION_2D_STATUS_LABEL = "Click and drag to create a bounding box";
-const DETECTION_3D_STATUS_LABEL =
-  "Press C to toggle cuboid creation · T/R/S for translate/rotate/scale · Shift + hover to crop";
-
-export const DetectionStatus = ({
-  isCuboid = false,
+const StatusText = ({
+  children,
+  color = TextColor.Secondary,
 }: {
-  isCuboid?: boolean;
+  children: string;
+  color?: TextColor;
 }): ReactElement => (
-  <StatusItem
-    icon={<DetectionIcon />}
-    label={isCuboid ? DETECTION_3D_STATUS_LABEL : DETECTION_2D_STATUS_LABEL}
-  />
+  <Text variant={TextVariant.Sm} color={color}>
+    {children}
+  </Text>
 );
 
-export const BrushStatus = (): ReactElement => (
-  <StatusItem
-    icon={<Brush fontSize="small" />}
-    label="Paint to create a mask"
-  />
-);
+const DETECTION_2D_HELP: StatusHelpEntry[] = [
+  { gesture: "Click and drag", description: "Draw a new bounding box" },
+  {
+    gesture: "Right click",
+    description: "Stop editing this box; again to leave the tool",
+  },
+];
 
-export const PenStatus = (): ReactElement => (
-  <StatusItem
-    icon={<Timeline fontSize="small" />}
-    label="Draw freeform to create a filled mask"
-  />
-);
+const DETECTION_3D_HELP: StatusHelpEntry[] = [
+  { gesture: "C", description: "Toggle cuboid creation on and off" },
+  {
+    gesture: "Three clicks",
+    description: "Set the first corner, then the orientation, then the width",
+  },
+  {
+    gesture: "T / R / S",
+    description: "Translate, rotate, or scale the selection",
+  },
+  {
+    gesture: "Shift + hover",
+    description: "Crop the side panels to the point under the cursor",
+  },
+  // Right click is reserved for camera panning in 3D, so Escape is the only
+  // cancel/exit gesture here.
+  {
+    gesture: "Escape",
+    description: "Cancel the cuboid you are creating, or exit edit mode",
+  },
+];
 
-export const PolylineEntryStatus = (): ReactElement => (
-  <StatusItem
-    icon={<Timeline fontSize="small" />}
-    label="Click to start a new polyline"
-  />
-);
+export const detectionStatus = (isCuboid = false): StatusContent => ({
+  help: isCuboid ? (
+    <StatusHelp title="Cuboid" entries={DETECTION_3D_HELP} />
+  ) : (
+    <StatusHelp title="Bounding box" entries={DETECTION_2D_HELP} />
+  ),
+});
 
-export const PolylineProgressStatus = ({
-  vertexCount,
-}: {
-  vertexCount: number;
-}): ReactElement => {
-  const instructions = [
-    `${vertexCount} ${vertexCount === 1 ? "vertex" : "vertices"}`,
-    "Click to add a point",
-    "Ctrl + click to swap segment endpoints",
-    "Shift + click to start a new segment",
-    "Alt + click to delete a point",
-    "Right click to exit",
-  ];
+const BRUSH_HELP: StatusHelpEntry[] = [
+  { gesture: "Click and drag", description: "Paint a mask" },
+  {
+    gesture: "Right click",
+    description: "Stop editing this mask; again to leave the tool",
+  },
+];
 
-  return (
-    <Stack orientation={Orientation.Row} spacing={Spacing.Md}>
-      {instructions.map((text, idx) => (
-        <>
-          <Text color={TextColor.Secondary}>{text}</Text>
-          {idx < instructions.length - 1 && <Separator />}
-        </>
-      ))}
-    </Stack>
-  );
-};
+export const brushStatus = (): StatusContent => ({
+  help: <StatusHelp title="Brush" entries={BRUSH_HELP} />,
+});
 
-export const MergeInitialStatus = (): ReactElement => (
-  <StatusItem
-    icon={<CallMerge fontSize="small" />}
-    label={
-      <>
-        Click the <strong>primary</strong> polygon first · its properties will
-        be kept
-      </>
-    }
-  />
-);
+const PEN_HELP: StatusHelpEntry[] = [
+  {
+    gesture: "Click or drag",
+    description:
+      "Click to place a series of connected points, or drag to draw a continuous shape",
+  },
+  {
+    gesture: "Right click",
+    description: "Commit the shape you are drawing",
+  },
+  {
+    gesture: "Right click again",
+    description: "Stop editing this mask, then leave the tool",
+  },
+];
 
-export const MergeTargetSetStatus = (): ReactElement => (
-  <StatusItem
-    icon={<CallMerge fontSize="small" />}
-    label="Primary set · click a polygon to merge into it"
-  />
-);
+export const penStatus = (): StatusContent => ({
+  help: <StatusHelp title="Pen" entries={PEN_HELP} />,
+});
+
+const POLYLINE_ENTRY_HELP: StatusHelpEntry[] = [
+  { gesture: "Click", description: "Place the first vertex of a new polyline" },
+  { gesture: "Right click", description: "Leave polyline mode" },
+];
+
+export const polylineEntryStatus = (): StatusContent => ({
+  help: <StatusHelp title="Polyline" entries={POLYLINE_ENTRY_HELP} />,
+});
+
+const POLYLINE_PROGRESS_HELP: StatusHelpEntry[] = [
+  { gesture: "Click", description: "Add a point to the current segment" },
+  { gesture: "Drag a point", description: "Move that vertex" },
+  { gesture: "Click an edge", description: "Insert a vertex on that edge" },
+  {
+    gesture: "Ctrl + click",
+    description: "Extend from the other end of the current segment",
+  },
+  { gesture: "Shift + click", description: "Start a new, separate segment" },
+  { gesture: "Alt + click", description: "Delete the point you clicked" },
+  {
+    gesture: "Right click",
+    description: "Finish this polyline; again to leave polyline mode",
+  },
+];
+
+export const polylineProgressStatus = (vertexCount: number): StatusContent => ({
+  status: (
+    <StatusText>
+      {`${vertexCount} ${vertexCount === 1 ? "vertex" : "vertices"}`}
+    </StatusText>
+  ),
+  help: <StatusHelp title="Polyline" entries={POLYLINE_PROGRESS_HELP} />,
+});
+
+const MERGE_HELP: StatusHelpEntry[] = [
+  {
+    gesture: "First click",
+    description: "Pick the primary mask — its properties are kept",
+  },
+  {
+    gesture: "Second click",
+    description:
+      "Merge that mask into the primary; the source label is removed",
+  },
+  { gesture: "Right click", description: "Clear the primary and leave merge" },
+];
+
+const mergeHelp = <StatusHelp title="Merge masks" entries={MERGE_HELP} />;
+
+export const mergeInitialStatus = (): StatusContent => ({
+  help: mergeHelp,
+});
+
+export const mergeTargetSetStatus = (): StatusContent => ({
+  status: <StatusText>Primary set</StatusText>,
+  help: mergeHelp,
+});
 
 const STATUS_LABELS: Record<InferenceStatus, string> = {
   idle: "No inference running",
@@ -140,15 +199,6 @@ const formatProgressLabel = (
   return `${base} (${pct}%)`;
 };
 
-const formatErrorLabel = (error: InferenceError): string => {
-  if (!error) {
-    return STATUS_LABELS.error;
-  }
-
-  const prefix = ERROR_KIND_LABELS[error.kind] ?? STATUS_LABELS.error;
-  return error.message ? `${prefix}: ${error.message}` : prefix;
-};
-
 const AIInferringStatus = ({
   status,
   progress,
@@ -161,10 +211,8 @@ const AIInferringStatus = ({
     align={Align.Center}
     spacing={Spacing.Sm}
   >
-    <Spinner size={Size.Md} color={TextColor.Secondary} />
-    <Text variant={TextVariant.Md} color={TextColor.Secondary}>
-      {formatProgressLabel(status, progress)}
-    </Text>
+    <Spinner size={Size.Sm} color={TextColor.Secondary} />
+    <StatusText>{formatProgressLabel(status, progress)}</StatusText>
   </Stack>
 );
 
@@ -175,16 +223,10 @@ const AIErrorStatus = ({ error }: { error: InferenceError }): ReactElement => (
     spacing={Spacing.Sm}
   >
     <ErrorOutline fontSize="small" color="error" />
-    <Text variant={TextVariant.Md} color={TextColor.Destructive}>
-      {formatErrorLabel(error)}
-    </Text>
+    <StatusText color={TextColor.Destructive}>
+      {error ? ERROR_KIND_LABELS[error.kind] : STATUS_LABELS.error}
+    </StatusText>
   </Stack>
-);
-
-const AIFirstClickStatus = (): ReactElement => (
-  <Text variant={TextVariant.Md} color={TextColor.Secondary}>
-    Click on an object to segment it
-  </Text>
 );
 
 const Marker = ({ color, label }: { color: TextColor; label: string }) => (
@@ -193,73 +235,98 @@ const Marker = ({ color, label }: { color: TextColor; label: string }) => (
     align={Align.Center}
     spacing={Spacing.Xs}
   >
-    <Text variant={TextVariant.Md} color={color}>
+    <Text variant={TextVariant.Sm} color={color}>
       ●
     </Text>
-    <Text variant={TextVariant.Md} color={TextColor.Secondary}>
+    <Text variant={TextVariant.Sm} color={TextColor.Secondary}>
       {label}
     </Text>
   </Stack>
 );
 
-const Separator = () => (
-  <Text variant={TextVariant.Md} color={TextColor.Tertiary}>
-    ·
-  </Text>
-);
+const AI_SEGMENTATION_HELP: StatusHelpEntry[] = [
+  {
+    gesture: "Click",
+    description:
+      "Add a point prompt. Clicking an empty region adds a positive point, which includes the region in the resulting mask. Clicking on an existing masked region adds a negative point, which removes the region from the resulting mask",
+  },
+  {
+    gesture: "Shift + click",
+    description: "Invert positive/negative for that click",
+  },
+  { gesture: "Click a marker", description: "Remove that prompt point" },
+  {
+    gesture: "Right click",
+    description: "Commit the mask and start a new one",
+  },
+  {
+    gesture: "Right click again",
+    description: "Deselect the mask, then leave the tool",
+  },
+];
 
-const AIPromptStatus = (): ReactElement => (
-  <Stack
-    orientation={Orientation.Row}
-    align={Align.Center}
-    spacing={Spacing.Md}
-  >
-    <Marker color={TextColor.Success} label="Positive prompt" />
-    <Marker color={TextColor.Destructive} label="Negative prompt" />
-    <Separator />
-    <Text variant={TextVariant.Md} color={TextColor.Secondary}>
-      Hold shift to invert positive/negative selection
-    </Text>
-    <Separator />
-    <Text variant={TextVariant.Md} color={TextColor.Secondary}>
-      Click marker to remove
-    </Text>
+const aiSegmentationHelp = (
+  <Stack orientation={Orientation.Column} spacing={Spacing.Sm}>
+    <StatusHelp title="AI segmentation" entries={AI_SEGMENTATION_HELP} />
+    <Stack
+      orientation={Orientation.Row}
+      align={Align.Center}
+      spacing={Spacing.Md}
+    >
+      <Marker color={TextColor.Success} label="Positive prompt" />
+      <Marker color={TextColor.Destructive} label="Negative prompt" />
+    </Stack>
   </Stack>
 );
 
+// The message is only ever shown here: the inline status carries the short
+// error kind so it cannot crowd the panel tabs.
+const aiErrorHelp = (error: InferenceError): ReactElement | undefined => {
+  if (!error || !error.message) return undefined;
+
+  return (
+    <Stack orientation={Orientation.Column} spacing={Spacing.Sm}>
+      <Text variant={TextVariant.Label} color={TextColor.Primary}>
+        {ERROR_KIND_LABELS[error.kind] ?? STATUS_LABELS.error}
+      </Text>
+      <Text variant={TextVariant.Sm} color={TextColor.Secondary}>
+        {error.message}
+      </Text>
+    </Stack>
+  );
+};
+
 /**
- * Single status-bar component for the AI segmentation tool.
+ * Status content for the AI segmentation tool.
  *
- * Picks the right sub-state based on inference status, download progress,
- * terminal error, and whether the user has placed any prompt points:
- *
- * - `"error"`            → {@link AIErrorStatus} with a readable message
- * - active inference     → {@link AIInferringStatus} with progress %
- * - no prompt points yet → {@link AIFirstClickStatus}
- * - prompt points placed → {@link AIPromptStatus}
+ * Only machine state goes inline — download progress, a short error kind — so
+ * the gesture table stays behind the help affordance in every state. The help
+ * content is deliberately identical across idle and inference states: the
+ * gestures do not change, and swapping it would make the affordance flicker
+ * while the model works.
  */
-export const AISegmentationStatus = ({
+export const aiSegmentationStatus = ({
   status,
   progress,
   error,
-  hasPoints,
 }: {
   status: InferenceStatus;
   progress: InferenceProgress;
   error: InferenceError;
-  hasPoints: boolean;
-}): ReactElement => {
+}): StatusContent => {
   if (status === "error") {
-    return <AIErrorStatus error={error} />;
+    return {
+      status: <AIErrorStatus error={error} />,
+      help: aiErrorHelp(error),
+    };
   }
 
   if (isActiveStatus(status)) {
-    return <AIInferringStatus status={status} progress={progress} />;
+    return {
+      status: <AIInferringStatus status={status} progress={progress} />,
+      help: aiSegmentationHelp,
+    };
   }
 
-  if (!hasPoints) {
-    return <AIFirstClickStatus />;
-  }
-
-  return <AIPromptStatus />;
+  return { help: aiSegmentationHelp };
 };

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/annotationStatusContent.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/annotationStatusContent.tsx
@@ -275,18 +275,22 @@ const aiSegmentationHelp = (
 );
 
 // The message is only ever shown here: the inline status carries the short
-// error kind so it cannot crowd the panel tabs.
-const aiErrorHelp = (error: InferenceError): ReactElement | undefined => {
-  if (!error || !error.message) return undefined;
+// error kind so it cannot crowd the panel tabs. The gestures still work while
+// an error is up, so they stay below the detail rather than being replaced.
+const aiErrorHelp = (error: InferenceError): ReactElement => {
+  if (!error || !error.message) return aiSegmentationHelp;
 
   return (
-    <Stack orientation={Orientation.Column} spacing={Spacing.Sm}>
-      <Text variant={TextVariant.Label} color={TextColor.Primary}>
-        {ERROR_KIND_LABELS[error.kind] ?? STATUS_LABELS.error}
-      </Text>
-      <Text variant={TextVariant.Sm} color={TextColor.Secondary}>
-        {error.message}
-      </Text>
+    <Stack orientation={Orientation.Column} spacing={Spacing.Md}>
+      <Stack orientation={Orientation.Column} spacing={Spacing.Sm}>
+        <Text variant={TextVariant.Label} color={TextColor.Primary}>
+          {ERROR_KIND_LABELS[error.kind] ?? STATUS_LABELS.error}
+        </Text>
+        <Text variant={TextVariant.Sm} color={TextColor.Secondary}>
+          {error.message}
+        </Text>
+      </Stack>
+      {aiSegmentationHelp}
     </Stack>
   );
 };
@@ -295,10 +299,10 @@ const aiErrorHelp = (error: InferenceError): ReactElement | undefined => {
  * Status content for the AI segmentation tool.
  *
  * Only machine state goes inline — download progress, a short error kind — so
- * the gesture table stays behind the help affordance in every state. The help
- * content is deliberately identical across idle and inference states: the
- * gestures do not change, and swapping it would make the affordance flicker
- * while the model works.
+ * the gesture table stays behind the help affordance in every state. It is
+ * deliberately the same table throughout: the gestures never change, and
+ * swapping it would make the affordance flicker while the model works. An
+ * error adds its detail above that table instead of replacing it.
  */
 export const aiSegmentationStatus = ({
   status,

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useAnnotationStatus.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useAnnotationStatus.tsx
@@ -1,7 +1,4 @@
-import {
-  useInferenceStatus,
-  useToolsContext,
-} from "@fiftyone/annotation/src/agents";
+import { useInferenceStatus } from "@fiftyone/annotation/src/agents";
 import { ANNOTATION_CUBOID } from "@fiftyone/looker-3d/src/constants";
 import { useCurrent3dAnnotationMode } from "@fiftyone/looker-3d/src/state/accessors";
 import type { PolylineAnnotationLabel } from "@fiftyone/state";
@@ -9,14 +6,14 @@ import { useAtomValue } from "jotai";
 import { useEffect, useMemo } from "react";
 import { StatusContent, useModalStatusBar } from "../../../ModalStatusBar";
 import {
-  AISegmentationStatus,
-  BrushStatus,
-  DetectionStatus,
-  MergeInitialStatus,
-  MergeTargetSetStatus,
-  PenStatus,
-  PolylineEntryStatus,
-  PolylineProgressStatus,
+  aiSegmentationStatus,
+  brushStatus,
+  detectionStatus,
+  mergeInitialStatus,
+  mergeTargetSetStatus,
+  penStatus,
+  polylineEntryStatus,
+  polylineProgressStatus,
 } from "./annotationStatusContent";
 import { useAnnotationContext } from "./useAnnotationContext";
 import { _unsafeDetectionModeActiveAtom } from "./useDetectionMode";
@@ -56,51 +53,41 @@ export const useAnnotationStatus = () => {
     progress: inferenceProgress,
     error: inferenceError,
   } = useInferenceStatus();
-  const { positivePoints, negativePoints } = useToolsContext();
   const { selected } = useAnnotationContext();
   const polylineData = (selected?.data ?? null) as
     | PolylineAnnotationLabel["data"]
     | null;
 
   const vertexCount = countVertices(polylineData?.points);
-  const hasAiPoints =
-    (positivePoints?.length ?? 0) + (negativePoints?.length ?? 0) > 0;
   const cuboidModeActive = current3dAnnotationMode === ANNOTATION_CUBOID;
 
   const content = useMemo<StatusContent>(() => {
-    if (cuboidModeActive) return <DetectionStatus isCuboid />;
+    if (cuboidModeActive) return detectionStatus(true);
 
-    if (detectionModeActive) return <DetectionStatus />;
+    if (detectionModeActive) return detectionStatus();
 
     if (segmentationModeActive) {
       switch (tool) {
         case SegmentationTool.Brush:
-          return <BrushStatus />;
+          return brushStatus();
         case SegmentationTool.Pen:
-          return <PenStatus />;
+          return penStatus();
         case SegmentationTool.AI:
-          return (
-            <AISegmentationStatus
-              status={inferenceStatus}
-              progress={inferenceProgress}
-              error={inferenceError}
-              hasPoints={hasAiPoints}
-            />
-          );
+          return aiSegmentationStatus({
+            status: inferenceStatus,
+            progress: inferenceProgress,
+            error: inferenceError,
+          });
         case SegmentationTool.Merge:
-          return mergeTargetId ? (
-            <MergeTargetSetStatus />
-          ) : (
-            <MergeInitialStatus />
-          );
+          return mergeTargetId ? mergeTargetSetStatus() : mergeInitialStatus();
         default:
           return null;
       }
     }
 
     if (polylineModeActive) {
-      if (vertexCount === 0) return <PolylineEntryStatus />;
-      return <PolylineProgressStatus vertexCount={vertexCount} />;
+      if (vertexCount === 0) return polylineEntryStatus();
+      return polylineProgressStatus(vertexCount);
     }
 
     return null;
@@ -114,7 +101,6 @@ export const useAnnotationStatus = () => {
     inferenceStatus,
     inferenceProgress,
     inferenceError,
-    hasAiPoints,
     vertexCount,
   ]);
 

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useAnnotationStatus.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/useAnnotationStatus.tsx
@@ -87,7 +87,7 @@ export const useAnnotationStatus = () => {
 
     if (polylineModeActive) {
       if (vertexCount === 0) return polylineEntryStatus();
-      return polylineProgressStatus(vertexCount);
+      return polylineProgressStatus();
     }
 
     return null;


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link. Supersedes #7640, which took a different approach to the same problem.

## 📋 What changes are proposed in this pull request?

The modal status bar centered its hint text at the top of the sample pane, so long instructions ran over the panel tabs on the left and were clipped at the pane edge. #7640 tried to fix this by giving the bar its own row, but that pulled it into the flex flow and shrank the looker canvas (914x620 -> 914x592), breaking canvas screenshot specs.

This takes the opposite approach: stop rendering instructions inline at all.

-   `StatusContent` is now `{ status?, help? }`. `status` is for live state only — inference progress, a chosen merge target, a short error kind. All instructional text moved into `help`, revealed by an `ⓘ Help` affordance. For most modes the bar is now just the affordance.
-   The bar stays an absolute overlay, so canvas dimensions are untouched, and is now anchored to the right edge only (`top: 0; right: 0`, no `left`). With no left edge the box shrink-wraps its content and grows leftward, so it has no geometry near the tabs — clipping is prevented structurally rather than by keeping strings short.
-   `pointer-events` are off for the whole bar except the help affordance, so tab and canvas clicks still fall through.
-   Each tooltip shows the mode name over a gesture/description table, since the bar no longer says which mode is active.

Instruction text was rewritten against the actual handlers, which corrected several inaccuracies in the existing strings:

-   Right click does not exit polyline mode in one step — it clears the selection and stays in the mode; a second right click exits. It also does not close the polyline.
-   In AI segmentation, right click with points placed **commits** the mask and re-arms a fresh session. This was undocumented, and it is the primary way to finish a mask.
-   A plain click in AI segmentation is not unconditionally positive: clicking inside the current mask adds a negative point.
-   "Shift + hover to crop" (3D) also triggers on Cmd and Alt, and the crop applies to the side panels only.
-   The merge tool operates on mask detections, not polygons, as its status text claimed.
-   Cuboid mode has no right-click exit at all — right click is reserved for camera panning in 3D — so its exit row documents Escape instead.

## 🧪 How is this patch tested? If it is not, please explain why.

-   New `ModalStatusBar.test.tsx` (5 cases): renders nothing when empty or when content has neither slot, omits the affordance when there is no help, renders with no inline status, and keeps instructions hidden until the affordance is hovered.
-   `packages/core/src/components/Modal` suite passes (425 tests).
-   Scoped typecheck clean on all changed files.
-   Canvas screenshot specs are unaffected by design: the bar takes no layout space and sits over the tab strip, above the canvas region those specs capture.
-   Verified live in a browser.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Annotation instructions have moved from the status bar into a hover tooltip, so hints no longer overlap the panel tabs, and the instructions themselves are more complete and accurate.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned the modal status bar with separate status information and contextual Help guidance.
  * Added gesture-based help tables for annotation tools, including detection, brush, pen, polyline, merge, and AI segmentation.
  * AI segmentation now shows inference progress inline, with guidance and error details available through Help.

* **Bug Fixes**
  * Improved readability with right-aligned, truncated status content and more compact progress indicators.

* **Tests**
  * Added coverage for status bar states, Help interactions, and AI segmentation guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3826
<!-- enterprise-sync-pr:end -->