### PR TITLE
Improve the multimodal Fields sidebar

### DIFF
--- a/app/packages/multimodal/src/views/episode/shell/FieldsSidebar.module.css
+++ b/app/packages/multimodal/src/views/episode/shell/FieldsSidebar.module.css
@@ -1,0 +1,125 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-width: 0;
+}
+
+.searchBar {
+  flex: 0 0 auto;
+}
+
+.searchInput {
+  min-width: 0;
+  width: 100%;
+}
+
+.fieldList {
+  border-top: 1px solid var(--color-border);
+  display: flex;
+  flex-direction: column;
+}
+
+.fieldNode {
+  border-bottom: 1px solid var(--color-border);
+  min-width: 0;
+}
+
+.fieldRow {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+  padding: 9px 0;
+}
+
+.fieldLabel {
+  color: var(--color-content-text-muted);
+  font-size: 11px;
+  line-height: 1.25;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.fieldValue {
+  color: var(--color-content-text);
+  font-size: 12px;
+  line-height: 1.4;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.mutedValue,
+.groupSummary,
+.description,
+.emptyText {
+  color: var(--color-content-text-muted);
+}
+
+.description,
+.emptyText {
+  font-size: 11px;
+  line-height: 1.25;
+}
+
+.groupHeader {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+  display: flex;
+  gap: 8px;
+  list-style: none;
+  min-width: 0;
+  padding: 9px 0;
+  text-align: left;
+  width: 100%;
+}
+
+.groupHeader::-webkit-details-marker {
+  display: none;
+}
+
+.groupHeader:focus-visible {
+  outline: 1px solid var(--color-content-border-focus);
+  outline-offset: 2px;
+}
+
+.chevron {
+  border-right: 1.5px solid var(--color-content-text-muted);
+  border-top: 1.5px solid var(--color-content-text-muted);
+  flex: 0 0 auto;
+  height: 5px;
+  transform: rotate(45deg);
+  transition: transform 120ms ease;
+  width: 5px;
+}
+
+.fieldNode[open] > .groupHeader .chevron {
+  transform: rotate(135deg);
+}
+
+.groupSummary {
+  flex: 0 0 auto;
+  font-size: 10px;
+  line-height: 1.2;
+  margin-left: auto;
+  white-space: nowrap;
+}
+
+.children {
+  border-left: 1px solid var(--color-border);
+  margin: 0 0 8px 3px;
+  padding-left: 10px;
+}
+
+.children > .description {
+  display: block;
+  padding: 0 0 9px;
+}
+
+.children > .fieldNode:last-child {
+  border-bottom: 0;
+}

--- a/app/packages/multimodal/src/views/episode/shell/FieldsSidebar.test.tsx
+++ b/app/packages/multimodal/src/views/episode/shell/FieldsSidebar.test.tsx
@@ -1,9 +1,18 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  Experimental_CssVarsProvider as CssVarsProvider,
+  experimental_extendTheme as extendMuiTheme,
+} from "@mui/material";
+import { cleanup, render, screen } from "@testing-library/react";
 import type { ReactElement } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+// `JSONViewer` (used for non-empty object/array fields) reads the color
+// scheme via MUI's `useColorScheme`, which throws outside a
+// `CssVarsProvider` — the real app supplies one at its root
+// (`ThemeProvider`), but this unit test renders `FieldsSidebar` standalone.
+const muiTestTheme = extendMuiTheme();
 function renderFieldsSidebar(ui: ReactElement) {
-  return render(ui);
+  return render(<CssVarsProvider theme={muiTestTheme}>{ui}</CssVarsProvider>);
 }
 
 interface FakeField {
@@ -80,56 +89,6 @@ describe("FieldsSidebar", () => {
     expect(body.textContent).not.toContain("_media_type");
   });
 
-  it("filters out multimodal projection grain fields independently of field visibility", () => {
-    setFields([
-      { path: "events", ftype: "fiftyone.core.fields.EmbeddedDocumentField" },
-      {
-        path: "events.drive_events.event",
-        ftype: "fiftyone.core.fields.StringField",
-      },
-      {
-        path: "labels.camera_labels.label",
-        ftype: "fiftyone.core.fields.StringField",
-      },
-      {
-        path: "summaries.episode_summary.duration",
-        ftype: "fiftyone.core.fields.FloatField",
-      },
-      {
-        path: "signals.imu.angular_velocity",
-        ftype: "fiftyone.core.fields.FloatField",
-      },
-      {
-        path: "metadata",
-        ftype: "fiftyone.core.fields.EmbeddedDocumentField",
-      },
-      {
-        path: "metadata.labels",
-        ftype: "fiftyone.core.fields.StringField",
-      },
-      {
-        path: "event_count",
-        ftype: "fiftyone.core.fields.IntField",
-      },
-    ]);
-    useActiveModalSample.mockReturnValue({
-      event_count: 4,
-      metadata: { labels: "release" },
-    });
-
-    renderFieldsSidebar(<FieldsSidebar />);
-    fireEvent.click(screen.getByText("metadata"));
-
-    const body = screen.getByTestId("episode-fields-body");
-    expect(body.textContent).not.toContain("events");
-    expect(body.textContent).not.toContain("camera_labels");
-    expect(body.textContent).not.toContain("episode_summary");
-    expect(body.textContent).not.toContain("angular_velocity");
-    expect(body.textContent).toContain("labels");
-    expect(body.textContent).toContain("release");
-    expect(body.textContent).toContain("event_count");
-  });
-
   it("renders a plain string field's actual value, not its schema type", () => {
     setFields([
       { path: "filepath", ftype: "fiftyone.core.fields.StringField" },
@@ -192,12 +151,14 @@ describe("FieldsSidebar", () => {
     );
   });
 
-  it("renders a non-empty primitive list field inline", () => {
+  it("renders a non-empty list field's value through the JSON tree viewer", () => {
     setFields([{ path: "tags", ftype: "fiftyone.core.fields.ListField" }]);
     useActiveModalSample.mockReturnValue({ tags: ["train", "front-cam"] });
 
     renderFieldsSidebar(<FieldsSidebar />);
 
+    // `JsonViewer` renders each entry as separate key/value nodes rather
+    // than one flat stringified block, so assert on the values individually.
     const body = screen.getByTestId("episode-fields-body");
     expect(body.textContent).toContain("train");
     expect(body.textContent).toContain("front-cam");
@@ -249,87 +210,5 @@ describe("FieldsSidebar", () => {
     expect(screen.getByTestId("episode-fields-body").textContent).toContain(
       "The type of media for the sample.",
     );
-  });
-
-  it("shows metadata once as a collapsible field group", () => {
-    setFields([
-      {
-        path: "metadata",
-        ftype: "fiftyone.core.fields.EmbeddedDocumentField",
-      },
-      {
-        path: "metadata.mime_type",
-        ftype: "fiftyone.core.fields.StringField",
-      },
-    ]);
-    useActiveModalSample.mockReturnValue({
-      metadata: {
-        _cls: "MultimodalMetadata",
-        mime_type: "application/octet-stream",
-        source_format: "mcap",
-      },
-    });
-
-    renderFieldsSidebar(<FieldsSidebar />);
-
-    const metadata = screen.getByText("metadata").closest("details");
-    expect(metadata?.hasAttribute("open")).toBe(false);
-
-    fireEvent.click(screen.getByText("metadata"));
-
-    expect(metadata?.hasAttribute("open")).toBe(true);
-    expect(screen.getByText("mime_type")).toBeTruthy();
-    expect(screen.getByText("source_format")).toBeTruthy();
-    expect(screen.queryByText("_cls")).toBeNull();
-  });
-
-  it("searches nested field paths and primitive values", () => {
-    setFields([
-      { path: "filepath", ftype: "fiftyone.core.fields.StringField" },
-      {
-        path: "metadata",
-        ftype: "fiftyone.core.fields.EmbeddedDocumentField",
-      },
-      {
-        path: "metadata.mime_type",
-        ftype: "fiftyone.core.fields.StringField",
-      },
-      { path: "scene_name", ftype: "fiftyone.core.fields.StringField" },
-      { path: "tags", ftype: "fiftyone.core.fields.ListField" },
-    ]);
-    useActiveModalSample.mockReturnValue({
-      filepath: "/a/b.mcap",
-      metadata: { mime_type: "application/octet-stream" },
-      scene_name: "Warehouse A",
-      tags: ["train", "front-cam"],
-    });
-
-    renderFieldsSidebar(<FieldsSidebar />);
-    fireEvent.change(screen.getByLabelText("Search fields"), {
-      target: { value: "mime" },
-    });
-
-    expect(screen.getByText("metadata")).toBeTruthy();
-    expect(screen.getByText("mime_type")).toBeTruthy();
-    expect(screen.queryByText("filepath")).toBeNull();
-    expect(screen.queryByText("scene_name")).toBeNull();
-    expect(screen.queryByText("tags")).toBeNull();
-
-    fireEvent.change(screen.getByLabelText("Search fields"), {
-      target: { value: "warehouse" },
-    });
-    expect(screen.getByText("scene_name")).toBeTruthy();
-    expect(screen.queryByText("metadata")).toBeNull();
-
-    fireEvent.change(screen.getByLabelText("Search fields"), {
-      target: { value: "train" },
-    });
-    expect(screen.getByText("tags")).toBeTruthy();
-    expect(screen.queryByText("scene_name")).toBeNull();
-
-    fireEvent.change(screen.getByLabelText("Search fields"), {
-      target: { value: "nothing" },
-    });
-    expect(screen.getByText('No fields match "nothing"')).toBeTruthy();
   });
 });

--- a/app/packages/multimodal/src/views/episode/shell/FieldsSidebar.test.tsx
+++ b/app/packages/multimodal/src/views/episode/shell/FieldsSidebar.test.tsx
@@ -89,6 +89,50 @@ describe("FieldsSidebar", () => {
     expect(body.textContent).not.toContain("_media_type");
   });
 
+  it("filters out multimodal projection grain fields independently of field visibility", () => {
+    setFields([
+      { path: "events", ftype: "fiftyone.core.fields.EmbeddedDocumentField" },
+      {
+        path: "events.drive_events.event",
+        ftype: "fiftyone.core.fields.StringField",
+      },
+      {
+        path: "labels.camera_labels.label",
+        ftype: "fiftyone.core.fields.StringField",
+      },
+      {
+        path: "summaries.episode_summary.duration",
+        ftype: "fiftyone.core.fields.FloatField",
+      },
+      {
+        path: "signals.imu.angular_velocity",
+        ftype: "fiftyone.core.fields.FloatField",
+      },
+      {
+        path: "metadata.labels",
+        ftype: "fiftyone.core.fields.StringField",
+      },
+      {
+        path: "event_count",
+        ftype: "fiftyone.core.fields.IntField",
+      },
+    ]);
+    useActiveModalSample.mockReturnValue({
+      event_count: 4,
+      metadata: { labels: "release" },
+    });
+
+    renderFieldsSidebar(<FieldsSidebar />);
+
+    const body = screen.getByTestId("episode-fields-body");
+    expect(body.textContent).not.toContain("events");
+    expect(body.textContent).not.toContain("camera_labels");
+    expect(body.textContent).not.toContain("episode_summary");
+    expect(body.textContent).not.toContain("angular_velocity");
+    expect(body.textContent).toContain("metadata.labels");
+    expect(body.textContent).toContain("event_count");
+  });
+
   it("renders a plain string field's actual value, not its schema type", () => {
     setFields([
       { path: "filepath", ftype: "fiftyone.core.fields.StringField" },

--- a/app/packages/multimodal/src/views/episode/shell/FieldsSidebar.test.tsx
+++ b/app/packages/multimodal/src/views/episode/shell/FieldsSidebar.test.tsx
@@ -1,18 +1,9 @@
-import {
-  Experimental_CssVarsProvider as CssVarsProvider,
-  experimental_extendTheme as extendMuiTheme,
-} from "@mui/material";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { ReactElement } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-// `JSONViewer` (used for non-empty object/array fields) reads the color
-// scheme via MUI's `useColorScheme`, which throws outside a
-// `CssVarsProvider` — the real app supplies one at its root
-// (`ThemeProvider`), but this unit test renders `FieldsSidebar` standalone.
-const muiTestTheme = extendMuiTheme();
 function renderFieldsSidebar(ui: ReactElement) {
-  return render(<CssVarsProvider theme={muiTestTheme}>{ui}</CssVarsProvider>);
+  return render(ui);
 }
 
 interface FakeField {
@@ -109,6 +100,10 @@ describe("FieldsSidebar", () => {
         ftype: "fiftyone.core.fields.FloatField",
       },
       {
+        path: "metadata",
+        ftype: "fiftyone.core.fields.EmbeddedDocumentField",
+      },
+      {
         path: "metadata.labels",
         ftype: "fiftyone.core.fields.StringField",
       },
@@ -123,13 +118,15 @@ describe("FieldsSidebar", () => {
     });
 
     renderFieldsSidebar(<FieldsSidebar />);
+    fireEvent.click(screen.getByText("metadata"));
 
     const body = screen.getByTestId("episode-fields-body");
     expect(body.textContent).not.toContain("events");
     expect(body.textContent).not.toContain("camera_labels");
     expect(body.textContent).not.toContain("episode_summary");
     expect(body.textContent).not.toContain("angular_velocity");
-    expect(body.textContent).toContain("metadata.labels");
+    expect(body.textContent).toContain("labels");
+    expect(body.textContent).toContain("release");
     expect(body.textContent).toContain("event_count");
   });
 
@@ -195,14 +192,12 @@ describe("FieldsSidebar", () => {
     );
   });
 
-  it("renders a non-empty list field's value through the JSON tree viewer", () => {
+  it("renders a non-empty primitive list field inline", () => {
     setFields([{ path: "tags", ftype: "fiftyone.core.fields.ListField" }]);
     useActiveModalSample.mockReturnValue({ tags: ["train", "front-cam"] });
 
     renderFieldsSidebar(<FieldsSidebar />);
 
-    // `JsonViewer` renders each entry as separate key/value nodes rather
-    // than one flat stringified block, so assert on the values individually.
     const body = screen.getByTestId("episode-fields-body");
     expect(body.textContent).toContain("train");
     expect(body.textContent).toContain("front-cam");
@@ -254,5 +249,87 @@ describe("FieldsSidebar", () => {
     expect(screen.getByTestId("episode-fields-body").textContent).toContain(
       "The type of media for the sample.",
     );
+  });
+
+  it("shows metadata once as a collapsible field group", () => {
+    setFields([
+      {
+        path: "metadata",
+        ftype: "fiftyone.core.fields.EmbeddedDocumentField",
+      },
+      {
+        path: "metadata.mime_type",
+        ftype: "fiftyone.core.fields.StringField",
+      },
+    ]);
+    useActiveModalSample.mockReturnValue({
+      metadata: {
+        _cls: "MultimodalMetadata",
+        mime_type: "application/octet-stream",
+        source_format: "mcap",
+      },
+    });
+
+    renderFieldsSidebar(<FieldsSidebar />);
+
+    const metadata = screen.getByText("metadata").closest("details");
+    expect(metadata?.hasAttribute("open")).toBe(false);
+
+    fireEvent.click(screen.getByText("metadata"));
+
+    expect(metadata?.hasAttribute("open")).toBe(true);
+    expect(screen.getByText("mime_type")).toBeTruthy();
+    expect(screen.getByText("source_format")).toBeTruthy();
+    expect(screen.queryByText("_cls")).toBeNull();
+  });
+
+  it("searches nested field paths and primitive values", () => {
+    setFields([
+      { path: "filepath", ftype: "fiftyone.core.fields.StringField" },
+      {
+        path: "metadata",
+        ftype: "fiftyone.core.fields.EmbeddedDocumentField",
+      },
+      {
+        path: "metadata.mime_type",
+        ftype: "fiftyone.core.fields.StringField",
+      },
+      { path: "scene_name", ftype: "fiftyone.core.fields.StringField" },
+      { path: "tags", ftype: "fiftyone.core.fields.ListField" },
+    ]);
+    useActiveModalSample.mockReturnValue({
+      filepath: "/a/b.mcap",
+      metadata: { mime_type: "application/octet-stream" },
+      scene_name: "Warehouse A",
+      tags: ["train", "front-cam"],
+    });
+
+    renderFieldsSidebar(<FieldsSidebar />);
+    fireEvent.change(screen.getByLabelText("Search fields"), {
+      target: { value: "mime" },
+    });
+
+    expect(screen.getByText("metadata")).toBeTruthy();
+    expect(screen.getByText("mime_type")).toBeTruthy();
+    expect(screen.queryByText("filepath")).toBeNull();
+    expect(screen.queryByText("scene_name")).toBeNull();
+    expect(screen.queryByText("tags")).toBeNull();
+
+    fireEvent.change(screen.getByLabelText("Search fields"), {
+      target: { value: "warehouse" },
+    });
+    expect(screen.getByText("scene_name")).toBeTruthy();
+    expect(screen.queryByText("metadata")).toBeNull();
+
+    fireEvent.change(screen.getByLabelText("Search fields"), {
+      target: { value: "train" },
+    });
+    expect(screen.getByText("tags")).toBeTruthy();
+    expect(screen.queryByText("scene_name")).toBeNull();
+
+    fireEvent.change(screen.getByLabelText("Search fields"), {
+      target: { value: "nothing" },
+    });
+    expect(screen.getByText('No fields match "nothing"')).toBeTruthy();
   });
 });

--- a/app/packages/multimodal/src/views/episode/shell/FieldsSidebar.tsx
+++ b/app/packages/multimodal/src/views/episode/shell/FieldsSidebar.tsx
@@ -1,16 +1,19 @@
-import JSONViewer from "@fiftyone/components/src/components/JSONViewer";
 import {
   fieldVisibilityStage,
   useActiveModalSample,
   useSampleFields,
   useTimeZone,
 } from "@fiftyone/state";
-import { formatPrimitive } from "@fiftyone/utilities";
+import {
+  DATE_TIME_FIELD,
+  formatPrimitive,
+  type Field,
+} from "@fiftyone/utilities";
 import { getNestedField } from "@fiftyone/utilities/src/sample/pointer";
-import { Text, TextColor, TextVariant } from "@voxel51/voodo";
-import React from "react";
+import { Input, InputType, Size } from "@voxel51/voodo";
+import React, { useMemo, useState } from "react";
 import { useRecoilValue } from "recoil";
-import settingsStyles from "../tiles/Tile.settings.module.css";
+import styles from "./FieldsSidebar.module.css";
 
 // Release-only workaround: `sampleFields` currently merges the Mongo schema
 // with multimodal projection fields. Until FOEPD-4553 exposes the Mongo schema
@@ -23,8 +26,34 @@ const MULTIMODAL_PROJECTION_GRAINS = new Set([
   "signals",
 ]);
 
+type SidebarField = Pick<Field, "dbField" | "description" | "ftype" | "path">;
+
+interface FieldNode {
+  readonly children: readonly FieldNode[];
+  readonly field: SidebarField;
+  readonly value: unknown;
+}
+
 const isMultimodalProjectionField = (path: string): boolean =>
   MULTIMODAL_PROJECTION_GRAINS.has(path.split(".", 1)[0]);
+
+const hasPrivatePathSegment = (path: string): boolean =>
+  path.split(".").some((segment) => segment.startsWith("_"));
+
+const isHiddenPath = (
+  path: string,
+  hiddenPaths: ReadonlySet<string>,
+): boolean => {
+  for (const hiddenPath of hiddenPaths) {
+    if (path === hiddenPath || path.startsWith(`${hiddenPath}.`)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const fieldName = (field: SidebarField): string =>
+  field.path.split(".").at(-1) ?? field.path;
 
 /**
  * The raw sample doc keys some fields by their Mongo `dbField` rather than
@@ -33,10 +62,7 @@ const isMultimodalProjectionField = (path: string): boolean =>
  * embedded-document fields don't get renamed at the db level), so swapping
  * just that segment is enough.
  */
-const resolveDbPath = (field: {
-  path: string;
-  dbField?: string | null;
-}): string => {
+const resolveDbPath = (field: SidebarField): string => {
   if (!field.dbField) {
     return field.path;
   }
@@ -45,28 +71,111 @@ const resolveDbPath = (field: {
   return segments.join(".");
 };
 
-/**
- * A formatted field value, tagged with how it should render: `muted` for
- * "nothing here" placeholders (no value set, or an empty list/dict), `json`
- * for multi-key objects/arrays that need a real (searchable, collapsible)
- * tree view to be readable, and `text` for everything else.
- */
+const isDateWrapper = (value: unknown): value is { datetime: number } =>
+  value !== null &&
+  typeof value === "object" &&
+  typeof (value as Record<string, unknown>).datetime === "number";
+
+const displayObject = (value: unknown): Record<string, unknown> | undefined => {
+  if (
+    value === null ||
+    typeof value !== "object" ||
+    Array.isArray(value) ||
+    isDateWrapper(value)
+  ) {
+    return undefined;
+  }
+  return value as Record<string, unknown>;
+};
+
+const inferRuntimeFieldType = (value: unknown): string =>
+  isDateWrapper(value) ? DATE_TIME_FIELD : "";
+
+const buildValueNode = (
+  field: SidebarField,
+  value: unknown,
+  fieldsByPath: ReadonlyMap<string, SidebarField>,
+  hiddenPaths: ReadonlySet<string>,
+): FieldNode => {
+  const objectValue = displayObject(value);
+  const children = objectValue
+    ? Object.entries(objectValue).flatMap(([name, childValue]) => {
+        const path = `${field.path}.${name}`;
+        if (name.startsWith("_") || isHiddenPath(path, hiddenPaths)) {
+          return [];
+        }
+        const childField = fieldsByPath.get(path) ?? {
+          dbField: null,
+          description: null,
+          ftype: inferRuntimeFieldType(childValue),
+          path,
+        };
+        return [
+          buildValueNode(childField, childValue, fieldsByPath, hiddenPaths),
+        ];
+      })
+    : [];
+  return {
+    children,
+    field,
+    value,
+  };
+};
+
+const buildFieldTree = (
+  sampleFields: readonly SidebarField[],
+  sample: Record<string, unknown> | undefined,
+  hiddenPaths: ReadonlySet<string>,
+): readonly FieldNode[] => {
+  const fieldsByPath = new Map<string, SidebarField>();
+  for (const field of sampleFields) {
+    if (field) {
+      fieldsByPath.set(field.path, field);
+    }
+  }
+
+  return sampleFields
+    .filter(
+      (field) =>
+        field &&
+        !field.path.includes(".") &&
+        !hasPrivatePathSegment(field.path) &&
+        !isMultimodalProjectionField(field.path) &&
+        !isHiddenPath(field.path, hiddenPaths),
+    )
+    .map((field) =>
+      buildValueNode(
+        field,
+        getNestedField(sample, resolveDbPath(field)),
+        fieldsByPath,
+        hiddenPaths,
+      ),
+    )
+    .sort((left, right) => left.field.path.localeCompare(right.field.path));
+};
+
 type FormattedFieldValue =
-  | { kind: "muted"; text: string }
-  | { kind: "json"; value: object }
+  | { kind: "muted" | "summary"; text: string }
   | { kind: "text"; text: string };
 
-/**
- * Formats a field's value for display. Dates/datetimes go through the same
- * formatter as the classic sidebar rather than showing their raw
- * `{"_cls":"DateTime","datetime":<ms>}` wrapper; non-empty arrays/objects
- * (metadata, …) render through `JSONViewer` (search + collapsible tree)
- * rather than a flat stringified dump, since these can be arbitrarily large
- * and deeply nested; empty arrays/objects (e.g. `tags: []`) and
- * `null`/`undefined` (no value set — including fields, like `metadata`,
- * that were never computed for this sample) render as muted placeholders
- * rather than literal "[]"/"{}" text.
- */
+const itemCount = (count: number, singular: string): string =>
+  `${count} ${singular}${count === 1 ? "" : "s"}`;
+
+const visibleObjectKeyCount = (value: Record<string, unknown>): number =>
+  Object.keys(value).filter((key) => !key.startsWith("_")).length;
+
+const collectionSummary = (
+  value: unknown,
+  fallbackFieldCount: number,
+): string => {
+  const objectValue = displayObject(value);
+  return itemCount(
+    objectValue ? visibleObjectKeyCount(objectValue) : fallbackFieldCount,
+    "field",
+  );
+};
+
+/** Formats primitive and compact-list values for the one-column inspector. */
 const formatFieldValue = (
   value: unknown,
   ftype: string,
@@ -89,98 +198,217 @@ const formatFieldValue = (
   if (typeof value === "boolean") {
     return { kind: "text", text: value ? "true" : "false" };
   }
-  if (
-    typeof value === "object" &&
-    "datetime" in (value as Record<string, unknown>)
-  ) {
-    const formatted = formatPrimitive({
-      ftype,
-      timeZone,
-      value: value as { datetime: number },
-    });
+  if (isDateWrapper(value)) {
+    const formatted = formatPrimitive({ ftype, timeZone, value });
     if (formatted !== null) {
       return { kind: "text", text: String(formatted) };
     }
   }
-  const isEmptyCollection = Array.isArray(value)
-    ? value.length === 0
-    : Object.keys(value as Record<string, unknown>).length === 0;
-  if (isEmptyCollection) {
-    return { kind: "muted", text: "None" };
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return { kind: "muted", text: "None" };
+    }
+    if (
+      value.every(
+        (item) =>
+          item === null ||
+          typeof item === "string" ||
+          typeof item === "number" ||
+          typeof item === "boolean",
+      )
+    ) {
+      return {
+        kind: "text",
+        text: value.map((item) => String(item)).join(", "),
+      };
+    }
+    return { kind: "summary", text: itemCount(value.length, "item") };
   }
-  return { kind: "json", value: value as object };
+  const objectValue = displayObject(value);
+  if (objectValue) {
+    const count = visibleObjectKeyCount(objectValue);
+    return count === 0
+      ? { kind: "muted", text: "None" }
+      : { kind: "summary", text: itemCount(count, "field") };
+  }
+  return { kind: "text", text: String(value) };
 };
 
-/**
- * "Fields" tab for the MM right sidebar: the current sample's actual field
- * *values* (not the schema). Field paths/order come from the same
- * `fields()` selector the classic (now-removed-in-Multimodal) sidebar uses —
- * that's schema metadata already resolved by the dataset view, so no new
- * GraphQL query — but each value is read from the active modal sample.
- */
+const searchablePrimitiveValue = (
+  node: FieldNode,
+  timeZone: string,
+): string | undefined => {
+  const primitiveList =
+    Array.isArray(node.value) &&
+    node.value.every(
+      (item) =>
+        item === null ||
+        typeof item === "string" ||
+        typeof item === "number" ||
+        typeof item === "boolean",
+    );
+  if (
+    typeof node.value !== "string" &&
+    typeof node.value !== "number" &&
+    typeof node.value !== "boolean" &&
+    !isDateWrapper(node.value) &&
+    !primitiveList
+  ) {
+    return undefined;
+  }
+  return formatFieldValue(node.value, node.field.ftype, timeZone).text;
+};
+
+const filterFieldTree = (
+  nodes: readonly FieldNode[],
+  query: string,
+  timeZone: string,
+): readonly FieldNode[] => {
+  if (!query) {
+    return nodes;
+  }
+
+  const results: FieldNode[] = [];
+  for (const node of nodes) {
+    const primitiveValue = searchablePrimitiveValue(node, timeZone);
+    const matches =
+      node.field.path.toLocaleLowerCase().includes(query) ||
+      node.field.description?.toLocaleLowerCase().includes(query) ||
+      primitiveValue?.toLocaleLowerCase().includes(query);
+    if (matches) {
+      results.push(node);
+      continue;
+    }
+    const children = filterFieldTree(node.children, query, timeZone);
+    if (children.length > 0) {
+      results.push({ ...node, children });
+    }
+  }
+  return results;
+};
+
+const FieldNodeRow: React.FC<{
+  readonly forceExpanded: boolean;
+  readonly node: FieldNode;
+  readonly timeZone: string;
+}> = ({ forceExpanded, node, timeZone }) => {
+  const path = node.field.path;
+  const name = fieldName(node.field);
+  const expandable = node.children.length > 0;
+
+  if (expandable) {
+    return (
+      <details className={styles.fieldNode} open={forceExpanded || undefined}>
+        <summary
+          className={styles.groupHeader}
+          onClick={(event) => {
+            if (forceExpanded) {
+              event.preventDefault();
+            }
+          }}
+          title={path}
+        >
+          <span aria-hidden="true" className={styles.chevron} />
+          <span className={styles.fieldLabel}>{name}</span>
+          <span className={styles.groupSummary}>
+            {collectionSummary(node.value, node.children.length)}
+          </span>
+        </summary>
+        <div className={styles.children}>
+          {node.field.description ? (
+            <span className={styles.description}>{node.field.description}</span>
+          ) : null}
+          {node.children.map((child) => (
+            <FieldNodeRow
+              forceExpanded={forceExpanded}
+              key={child.field.path}
+              node={child}
+              timeZone={timeZone}
+            />
+          ))}
+        </div>
+      </details>
+    );
+  }
+
+  const formatted = formatFieldValue(node.value, node.field.ftype, timeZone);
+  return (
+    <div className={styles.fieldNode} title={path}>
+      <div className={styles.fieldRow}>
+        <span className={styles.fieldLabel}>{name}</span>
+        <span
+          className={`${styles.fieldValue} ${
+            formatted.kind === "text" ? "" : styles.mutedValue
+          }`}
+        >
+          {formatted.text}
+        </span>
+        {node.field.description ? (
+          <span className={styles.description}>{node.field.description}</span>
+        ) : null}
+      </div>
+    </div>
+  );
+};
+
+/** Current sample values, searchable and grouped by their schema hierarchy. */
 const FieldsSidebar: React.FC = () => {
   const sampleFields = useSampleFields();
   const activeSample = useActiveModalSample();
   const timeZone = useTimeZone();
   const fvStage = useRecoilValue(fieldVisibilityStage);
-  const hiddenPaths = new Set(fvStage?.kwargs?.field_names ?? []);
-  const nonPrivateFields = sampleFields.filter(
-    (field) =>
-      field &&
-      !field.path.startsWith("_") &&
-      !isMultimodalProjectionField(field.path) &&
-      !hiddenPaths.has(field.path),
+  const [search, setSearch] = useState("");
+  const hiddenPaths = useMemo(
+    () => new Set<string>(fvStage?.kwargs?.field_names ?? []),
+    [fvStage?.kwargs?.field_names],
+  );
+  const fieldTree = useMemo(
+    () => buildFieldTree(sampleFields, activeSample, hiddenPaths),
+    [activeSample, hiddenPaths, sampleFields],
+  );
+  const normalizedSearch = search.trim().toLocaleLowerCase();
+  const visibleTree = useMemo(
+    () => filterFieldTree(fieldTree, normalizedSearch, timeZone),
+    [fieldTree, normalizedSearch, timeZone],
   );
 
-  if (nonPrivateFields.length === 0) {
+  if (fieldTree.length === 0) {
     return (
-      <span
-        className={settingsStyles.emptyText}
-        data-testid="episode-fields-empty"
-      >
+      <span className={styles.emptyText} data-testid="episode-fields-empty">
         This dataset has no sample fields.
       </span>
     );
   }
 
   return (
-    <div className={settingsStyles.root} data-testid="episode-fields-body">
-      {nonPrivateFields.map((field) => {
-        const formatted = formatFieldValue(
-          getNestedField(activeSample, resolveDbPath(field)),
-          field.ftype,
-          timeZone,
-        );
-        return (
-          <div className={settingsStyles.field} key={field.path}>
-            <Text variant={TextVariant.Xs} color={TextColor.Secondary}>
-              {field.path}
-            </Text>
-            {formatted.kind === "json" ? (
-              <JSONViewer
-                value={formatted.value as never}
-                containerProps={{ className: settingsStyles.jsonViewer }}
-              />
-            ) : (
-              <Text
-                variant={TextVariant.Xs}
-                color={
-                  formatted.kind === "muted"
-                    ? TextColor.Secondary
-                    : TextColor.Primary
-                }
-              >
-                {formatted.text}
-              </Text>
-            )}
-            {field.description ? (
-              <span className={settingsStyles.metaText}>
-                {field.description}
-              </span>
-            ) : null}
-          </div>
-        );
-      })}
+    <div className={styles.root} data-testid="episode-fields-body">
+      <div className={styles.searchBar}>
+        <Input
+          aria-label="Search fields"
+          className={styles.searchInput}
+          onChange={(event) => setSearch(event.target.value)}
+          placeholder="Search fields"
+          size={Size.Sm}
+          type={InputType.Search}
+          value={search}
+        />
+      </div>
+      {visibleTree.length > 0 ? (
+        <div className={styles.fieldList}>
+          {visibleTree.map((node) => (
+            <FieldNodeRow
+              forceExpanded={normalizedSearch.length > 0}
+              key={node.field.path}
+              node={node}
+              timeZone={timeZone}
+            />
+          ))}
+        </div>
+      ) : (
+        <span className={styles.emptyText}>
+          No fields match &quot;{search}&quot;
+        </span>
+      )}
     </div>
   );
 };

--- a/app/packages/multimodal/src/views/episode/shell/FieldsSidebar.tsx
+++ b/app/packages/multimodal/src/views/episode/shell/FieldsSidebar.tsx
@@ -12,6 +12,20 @@ import React from "react";
 import { useRecoilValue } from "recoil";
 import settingsStyles from "../tiles/Tile.settings.module.css";
 
+// Release-only workaround: `sampleFields` currently merges the Mongo schema
+// with multimodal projection fields. Until FOEPD-4553 exposes the Mongo schema
+// separately, keep paths rooted in multimodal projection grains out of this
+// sample-document view.
+const MULTIMODAL_PROJECTION_GRAINS = new Set([
+  "events",
+  "labels",
+  "summaries",
+  "signals",
+]);
+
+const isMultimodalProjectionField = (path: string): boolean =>
+  MULTIMODAL_PROJECTION_GRAINS.has(path.split(".", 1)[0]);
+
 /**
  * The raw sample doc keys some fields by their Mongo `dbField` rather than
  * their schema path — most commonly `id` (schema path) / `_id` (actual key).
@@ -112,7 +126,10 @@ const FieldsSidebar: React.FC = () => {
   const hiddenPaths = new Set(fvStage?.kwargs?.field_names ?? []);
   const nonPrivateFields = sampleFields.filter(
     (field) =>
-      field && !field.path.startsWith("_") && !hiddenPaths.has(field.path),
+      field &&
+      !field.path.startsWith("_") &&
+      !isMultimodalProjectionField(field.path) &&
+      !hiddenPaths.has(field.path),
   );
 
   if (nonPrivateFields.length === 0) {


### PR DESCRIPTION
## 🔗 Related Issues

[FOEPD-4553](https://voxel51.atlassian.net/browse/FOEPD-4553)

## 📋 What changes are proposed in this pull request?

Hide multimodal projection-grain schema entries from the modal Fields tab until the server exposes Mongo-only sample fields. Replace the flat value dump with searchable, collapsible sample fields so nested metadata stays compact and primitive values are easier to find.

## 🧪 How is this patch tested? If it is not, please explain why.

- `yarn vitest run packages/multimodal/src/views/episode/shell/FieldsSidebar.test.tsx --no-coverage`
- `yarn workspace @fiftyone/multimodal check:lint`
- `yarn workspace @fiftyone/multimodal check:types`
- `yarn prettier --check packages/multimodal/src/views/episode/shell/FieldsSidebar.tsx packages/multimodal/src/views/episode/shell/FieldsSidebar.test.tsx packages/multimodal/src/views/episode/shell/FieldsSidebar.module.css`

Manual verification:

1. Open a multimodal sample modal and select Fields.
2. Confirm Mongo sample fields appear while the events, labels, summaries, and signals multimodal projection grains do not.
3. Search by field path or primitive value and expand nested metadata.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

The multimodal Fields sidebar now hides projection-only fields and provides searchable, collapsible sample metadata.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other

[FOEPD-4553]: https://voxel51.atlassian.net/browse/FOEPD-4553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Redesigned the episode fields sidebar with a structured, nested field view.
  - Added search across field paths and values, with matching groups expanded automatically.
  - Added expandable sections, field descriptions, collection summaries, and inline primitive lists.
  - Improved formatting for dates, nested objects, and metadata.

- **Bug Fixes**
  - Hidden, private, and unsupported projection fields are no longer displayed.
  - Improved handling of empty and filtered field states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3831
<!-- enterprise-sync-pr:end -->