### PR TITLE
Use blobless checkouts in full-history CI workflows

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -51,8 +51,9 @@ jobs:
         if: github.ref_type == 'tag'
         uses: actions/checkout@v7
         with:
-          # Fetch full history for rev-parse to work
+          # Full commit graph for rev-parse/merge-base, no historical blobs
           fetch-depth: 0
+          filter: blob:none
       - name: Clone fiftyone for branch builds
         if: github.ref_type == 'branch'
         uses: actions/checkout@v7

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -41,7 +41,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          # Blobless clone: the cherry-pick needs the full commit graph for
+          # the merge-commit parent lookup, but only the blobs it touches.
           fetch-depth: 0
+          filter: blob:none
           token: ${{ secrets.FIFTYONE_GITHUB_TOKEN }}
       - name: Cherry-pick and open PR
         env:

--- a/.github/workflows/community-to-develop.yml
+++ b/.github/workflows/community-to-develop.yml
@@ -36,7 +36,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: community
+          # Full commit graph for the diff and trial merge, blobs on demand
           fetch-depth: 0
+          filter: blob:none
           # Use the bot PAT so the PR triggers CI (GITHUB_TOKEN-authored PRs don't).
           token: ${{ secrets.FIFTYONE_GITHUB_TOKEN }}
           persist-credentials: false

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -26,7 +26,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          # Full commit graph for the ancestry checks, no blobs up front
           fetch-depth: 0
+          filter: blob:none
       - name: Gate release branch PR
         env:
           AUTHOR: ${{ github.event.pull_request.user.login }}

--- a/.github/workflows/sync-develop-to-community.yml
+++ b/.github/workflows/sync-develop-to-community.yml
@@ -29,7 +29,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: develop
+          # Full commit graph for the merge, blobs fetched on demand
           fetch-depth: 0
+          filter: blob:none
           token: ${{ secrets.FIFTYONE_GITHUB_TOKEN }}
 
       - name: Merge develop into community


### PR DESCRIPTION
Every workflow that checks out with `fetch-depth: 0` pays for a multi-minute full-history clone, but none of them need historical file contents — they need the commit graph (ancestry checks, rev-parse, merge-base) plus at most the blobs a merge or diff actually touches, which git lazy-fetches on demand.

This adds `filter: blob:none` to the five full-history checkouts (cherry-pick, release-gate, sync-develop-to-community, community-to-develop, build-docs), matching the pattern version-guard.yml already uses. Checkout drops from minutes to seconds.

Observed today: the cherry-pick workflow spent ~6 minutes in checkout for a one-line cherry-pick.

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3850
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved repository checkout efficiency in automated build, release, and synchronization workflows by avoiding unnecessary historical file downloads.
  * Preserved complete commit history for workflows that require it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->