### PR TITLE
Persist multimodal source facts across reloads

### DIFF
--- a/app/packages/multimodal/package.json
+++ b/app/packages/multimodal/package.json
@@ -151,6 +151,7 @@
         "@types/three": "^0.182.0",
         "babel-plugin-relay": "catalog:",
         "concurrently": "^7.2.1",
+        "fake-indexeddb": "^6.2.5",
         "react": "catalog:",
         "react-dom": "catalog:",
         "react-error-boundary": "catalog:",

--- a/app/packages/multimodal/src/adapters/mcap/reader.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/reader.test.ts
@@ -514,6 +514,7 @@ describe("MCAP indexed message times", () => {
   });
 
   it("uses byte client stat when descriptor size is missing", async () => {
+    const controller = new AbortController();
     const byteClient: ByteClient = {
       readBytes: vi.fn(),
       stat: vi.fn(async (source) => ({
@@ -527,13 +528,17 @@ describe("MCAP indexed message times", () => {
         url: "mcap-source://sample",
       },
       byteClient,
+      { readSignal: { current: controller.signal } },
     );
 
     await expect(readable.size()).resolves.toBe(128n);
-    expect(byteClient.stat).toHaveBeenCalledWith({
-      sourceId: "source:1",
-      url: "mcap-source://sample",
-    });
+    expect(byteClient.stat).toHaveBeenCalledWith(
+      {
+        sourceId: "source:1",
+        url: "mcap-source://sample",
+      },
+      controller.signal,
+    );
     expect(byteClient.readBytes).not.toHaveBeenCalled();
   });
 
@@ -558,7 +563,7 @@ describe("MCAP indexed message times", () => {
     const readable = new ByteClientReadable(source, byteClient);
 
     await expect(readable.size()).resolves.toBe(128n);
-    expect(byteClient.stat).toHaveBeenCalledWith(source);
+    expect(byteClient.stat).toHaveBeenCalledWith(source, undefined);
     expect(byteClient.readBytes).toHaveBeenCalledWith({
       range: { length: 1n, offset: 0n },
       source,

--- a/app/packages/multimodal/src/adapters/mcap/reader/byte-readable.ts
+++ b/app/packages/multimodal/src/adapters/mcap/reader/byte-readable.ts
@@ -153,7 +153,7 @@ export class ByteClientReadable implements McapTypes.IReadable {
 
     // Prefer cheap transport metadata before doing a tiny ranged GET; many
     // object stores allow range reads but block HEAD, so both paths are needed.
-    const statSource = await this.byteClient.stat?.(this.source);
+    const statSource = await this.byteClient.stat?.(this.source, signal);
     if (signal?.aborted) throw createAbortError("MCAP read aborted");
     if (statSource) {
       this.updateSource(statSource);

--- a/app/packages/multimodal/src/ports/adapter.ts
+++ b/app/packages/multimodal/src/ports/adapter.ts
@@ -23,12 +23,23 @@ export interface AssetResolver {
   ): Promise<ByteSourceDescriptor>;
 }
 
+/** Format-neutral source facts resolved before an adapter opens. */
+export interface EpisodeSourceHints {
+  readonly adapterId: string;
+  readonly manifestHint?: EpisodeManifest;
+  readonly playbackHint?: EpisodeTimeline;
+}
+
 /** Format-neutral source supplied to an adapter. */
 export interface EpisodeSource {
   readonly assets: AssetResolver;
   readonly episodeId: string;
   readonly manifestHint?: EpisodeManifest;
   readonly playbackHint?: EpisodeTimeline;
+  /** Resolves one durable hint bundle without replacing this source object. */
+  resolveHints?(
+    options?: EpisodeOpenOptions,
+  ): Promise<EpisodeSourceHints | null>;
 }
 
 /** Lightweight sample facts available before a heavy adapter chunk loads. */

--- a/app/packages/multimodal/src/query/bytes/cached-byte-client.ts
+++ b/app/packages/multimodal/src/query/bytes/cached-byte-client.ts
@@ -436,8 +436,8 @@ export function createCachedByteClient(
       return planByteCacheFillRequest(request, resolveBlockSizeBytes(request));
     },
 
-    async stat(source) {
-      return reader.stat?.(source);
+    async stat(source, signal) {
+      return reader.stat?.(source, signal);
     },
 
     async readBytes(request) {

--- a/app/packages/multimodal/src/query/bytes/default-byte-client.ts
+++ b/app/packages/multimodal/src/query/bytes/default-byte-client.ts
@@ -11,10 +11,10 @@ export function createDefaultByteClient(): ByteClient {
   const httpClient = createHttpByteClient();
 
   return {
-    async stat(source) {
+    async stat(source, signal) {
       return source.localFile
-        ? fileClient.stat?.(source)
-        : httpClient.stat?.(source);
+        ? fileClient.stat?.(source, signal)
+        : httpClient.stat?.(source, signal);
     },
 
     async readBytes(request) {

--- a/app/packages/multimodal/src/query/bytes/http-byte-client.ts
+++ b/app/packages/multimodal/src/query/bytes/http-byte-client.ts
@@ -25,10 +25,15 @@ export function createHttpByteClient(
   fetchFunction?: AbortableFetchFunction,
 ): ByteClient {
   return {
-    async stat(source) {
+    async stat(source, signal) {
+      if (signal?.aborted) {
+        throw createAbortError(HTTP_BYTE_READ_ABORT_MESSAGE);
+      }
       const fetchBytes: AbortableFetchFunction =
         fetchFunction ?? getFetchFunctionExtended();
       const controller = new AbortController();
+      const onExternalAbort = () => controller.abort();
+      signal?.addEventListener("abort", onExternalAbort, { once: true });
 
       try {
         const { headers } = await withHttpByteReadTimeout(
@@ -59,9 +64,14 @@ export function createHttpByteClient(
             : {}),
         };
       } catch {
+        if (signal?.aborted) {
+          throw createAbortError(HTTP_BYTE_READ_ABORT_MESSAGE);
+        }
         // HEAD is only an optimization; object stores and CORS policies often
         // block it even when ranged GETs are allowed.
         return undefined;
+      } finally {
+        signal?.removeEventListener("abort", onExternalAbort);
       }
     },
 

--- a/app/packages/multimodal/src/query/bytes/local-file-byte-client.test.ts
+++ b/app/packages/multimodal/src/query/bytes/local-file-byte-client.test.ts
@@ -22,6 +22,16 @@ describe("createLocalFileByteClient", () => {
     });
   });
 
+  it("honors an already-aborted stat signal", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const client = createLocalFileByteClient();
+
+    await expect(
+      client.stat?.(createSource(createFile([1])), controller.signal),
+    ).rejects.toMatchObject({ name: "AbortError" });
+  });
+
   it("reads the exact requested byte range", async () => {
     const file = createFile([1, 2, 3, 4]);
     const source = createSource(file);

--- a/app/packages/multimodal/src/query/bytes/local-file-byte-client.ts
+++ b/app/packages/multimodal/src/query/bytes/local-file-byte-client.ts
@@ -15,7 +15,8 @@ const FILE_BYTE_READ_ABORT_MESSAGE = "File byte-range read aborted";
  */
 export function createLocalFileByteClient(): ByteClient {
   return {
-    async stat(source) {
+    async stat(source, signal) {
+      throwIfAborted(signal, FILE_BYTE_READ_ABORT_MESSAGE);
       return source.localFile
         ? withFileSize(source, source.localFile)
         : undefined;

--- a/app/packages/multimodal/src/query/bytes/types.ts
+++ b/app/packages/multimodal/src/query/bytes/types.ts
@@ -121,6 +121,7 @@ export interface ByteClient {
    */
   stat?(
     source: ByteSourceDescriptor,
+    signal?: AbortSignal,
   ): Promise<ByteSourceDescriptor | undefined>;
 
   /**

--- a/app/packages/multimodal/src/query/query.test.ts
+++ b/app/packages/multimodal/src/query/query.test.ts
@@ -73,6 +73,33 @@ describe("multimodal query clients", () => {
     });
   });
 
+  it("aborts an in-flight HTTP HEAD probe with its caller", async () => {
+    let transportSignal: AbortSignal | undefined;
+    const client = createHttpByteClient(async (config) => {
+      transportSignal = config.signal;
+      if (config.signal?.aborted) {
+        throw new Error("transport aborted");
+      }
+      return new Promise((_resolve, reject) => {
+        config.signal?.addEventListener(
+          "abort",
+          () => reject(new Error("transport aborted")),
+          { once: true },
+        );
+      });
+    });
+    const controller = new AbortController();
+    const pending = client.stat?.(
+      { sourceId: "source:1", url: "bytes://source/default" },
+      controller.signal,
+    );
+
+    controller.abort();
+
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    expect(transportSignal?.aborted).toBe(true);
+  });
+
   it("captures normalized ETag validators from HEAD and ranged responses", async () => {
     const { extendedFetch } = createFetchMock(
       {

--- a/app/packages/multimodal/src/runtime/episode-resources.test.ts
+++ b/app/packages/multimodal/src/runtime/episode-resources.test.ts
@@ -1,7 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { EpisodeSource } from "../ports";
-import { openEpisodePreviewSession } from "./episode-resources";
+import type { EpisodeManifest } from "../ir";
+import type { EpisodeSource, EpisodeSourceHints } from "../ports";
+import {
+  openEpisodePreviewSession,
+  openEpisodeSession,
+} from "./episode-resources";
 
 const resourceHarness = vi.hoisted(() => ({
   byteResources: { read: vi.fn() },
@@ -49,6 +53,74 @@ describe("episode resources", () => {
       { signal: controller.signal },
     );
   });
+
+  it("loads the adapter and durable hints concurrently, then opens once", async () => {
+    let finishAdapter!: (adapter: {
+      id: string;
+      open: ReturnType<typeof vi.fn>;
+    }) => void;
+    let finishHints!: (hints: EpisodeSourceHints) => void;
+    const open = vi.fn().mockResolvedValue({ dispose: vi.fn() });
+    resourceHarness.loadFormatAdapter.mockImplementation(
+      () =>
+        new Promise<{ id: string; open: ReturnType<typeof vi.fn> }>(
+          (resolve) => {
+            finishAdapter = resolve;
+          },
+        ),
+    );
+    const resolveHints = vi.fn(
+      () =>
+        new Promise<EpisodeSourceHints>((resolve) => {
+          finishHints = resolve;
+        }),
+    );
+    const source = { ...createSource(), resolveHints };
+
+    const pending = openEpisodeSession(
+      { mediaType: "multimodal", path: "sample.mcap" },
+      source,
+    );
+
+    expect(resourceHarness.loadFormatAdapter).toHaveBeenCalledTimes(1);
+    expect(resolveHints).toHaveBeenCalledTimes(1);
+    finishAdapter({ id: "mcap", open });
+    finishHints({
+      adapterId: "mcap",
+      manifestHint: createManifest("sample-a"),
+    });
+    await pending;
+
+    expect(open).toHaveBeenCalledTimes(1);
+    expect(open).toHaveBeenCalledWith(
+      expect.objectContaining({
+        episodeId: "sample-a",
+        manifestHint: createManifest("sample-a"),
+      }),
+      resourceHarness.byteResources,
+      undefined,
+    );
+    expect(open.mock.calls[0]?.[0]).not.toHaveProperty("resolveHints");
+  });
+
+  it("discards hint bundles produced for a different adapter", async () => {
+    const open = vi.fn().mockResolvedValue({ dispose: vi.fn() });
+    resourceHarness.loadFormatAdapter.mockResolvedValue({ id: "mcap", open });
+    const source = {
+      ...createSource(),
+      resolveHints: vi.fn(async () => ({
+        adapterId: "fixture",
+        manifestHint: createManifest("wrong-adapter"),
+      })),
+    };
+
+    await openEpisodeSession(
+      { mediaType: "multimodal", path: "sample.mcap" },
+      source,
+    );
+
+    expect(open.mock.calls[0]?.[0]).not.toHaveProperty("manifestHint");
+  });
 });
 
 function createSource(): EpisodeSource {
@@ -58,5 +130,14 @@ function createSource(): EpisodeSource {
       resolve: vi.fn(),
     },
     episodeId: "sample-a",
+  };
+}
+
+function createManifest(episodeId: string): EpisodeManifest {
+  return {
+    episodeId,
+    streams: [],
+    timeDomain: { id: "log", kind: "timestamp" },
+    timeRange: { endNs: 1n, startNs: 0n },
   };
 }

--- a/app/packages/multimodal/src/runtime/episode-resources.ts
+++ b/app/packages/multimodal/src/runtime/episode-resources.ts
@@ -22,11 +22,31 @@ export async function openEpisodeSession(
   source: EpisodeSource,
   options?: EpisodeOpenOptions,
 ): Promise<EpisodeSession> {
-  const adapter = await loadFormatAdapter(sample, options);
+  const adapterPromise = loadFormatAdapter(sample, options);
+  const hintsPromise = source.resolveHints
+    ? source.resolveHints(options).catch((error: unknown) => {
+        if (options?.signal?.aborted) throw error;
+        return null;
+      })
+    : Promise.resolve(null);
+  const [adapter, hints] = await Promise.all([adapterPromise, hintsPromise]);
   if (!adapter) {
     throw new Error("No episode adapter recognized this sample");
   }
-  return adapter.open(source, episodeByteResources, options);
+  const { resolveHints: _resolveHints, ...baseSource } = source;
+  const resolvedSource =
+    hints?.adapterId === adapter.id
+      ? {
+          ...baseSource,
+          ...((source.manifestHint ?? hints.manifestHint)
+            ? { manifestHint: source.manifestHint ?? hints.manifestHint }
+            : {}),
+          ...((source.playbackHint ?? hints.playbackHint)
+            ? { playbackHint: source.playbackHint ?? hints.playbackHint }
+            : {}),
+        }
+      : baseSource;
+  return adapter.open(resolvedSource, episodeByteResources, options);
 }
 
 /** Detects an adapter and opens its lightweight preview when supported. */

--- a/app/packages/multimodal/src/runtime/index.ts
+++ b/app/packages/multimodal/src/runtime/index.ts
@@ -36,6 +36,10 @@ export * from "./temporal-policy";
 export * from "./data-stream";
 /** Public bounded grid-to-modal source bootstrap handoff. */
 export * from "./source-bootstrap-cache";
+/** Public durable source-facts identity, persistence, and orchestration. */
+export * from "./source-facts";
+export * from "./source-facts-persistence";
+export * from "./source-facts-service";
 /** Public episode time-range handoff used across grid and modal shells. */
 export {
   getEpisodeTimeRange,

--- a/app/packages/multimodal/src/runtime/persistence/indexeddb.test.ts
+++ b/app/packages/multimodal/src/runtime/persistence/indexeddb.test.ts
@@ -1,0 +1,124 @@
+import { IDBFactory } from "fake-indexeddb";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createIndexedDbConnection,
+  requestResult,
+  transactionDone,
+} from "./indexeddb";
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("IndexedDB runtime persistence", () => {
+  it("retries unavailable factories and memoizes a successful open", async () => {
+    let factory: IDBFactory | null = null;
+    const resolveFactory = vi.fn(() => factory);
+    const upgrade = vi.fn((database: IDBDatabase) => {
+      database.createObjectStore("entries");
+    });
+    const connection = createIndexedDbConnection({
+      name: "retryable",
+      resolveFactory,
+      upgrade,
+      version: 1,
+    });
+
+    await expect(connection.open()).resolves.toBeNull();
+    factory = new IDBFactory();
+    const first = connection.open();
+    const second = connection.open();
+
+    expect(second).toBe(first);
+    await expect(first).resolves.not.toBeNull();
+    expect(resolveFactory).toHaveBeenCalledTimes(2);
+    expect(upgrade).toHaveBeenCalledOnce();
+  });
+
+  it("resolves the default factory lazily and reopens after invalidation", async () => {
+    const upgrade = vi.fn((database: IDBDatabase) => {
+      database.createObjectStore("entries");
+    });
+    const connection = createIndexedDbConnection({
+      name: "lazy-global",
+      upgrade,
+      version: 1,
+    });
+    vi.stubGlobal("indexedDB", new IDBFactory());
+
+    const first = await connection.open();
+    if (!first) throw new Error("Expected IndexedDB to open");
+    first.onversionchange?.(
+      new Event("versionchange") as IDBVersionChangeEvent,
+    );
+    const second = await connection.open();
+
+    expect(second).not.toBeNull();
+    expect(second).not.toBe(first);
+    expect(upgrade).toHaveBeenCalledOnce();
+  });
+
+  it("reopens after the browser closes a connection", async () => {
+    const factory = new IDBFactory();
+    const connection = createIndexedDbConnection({
+      name: "browser-close",
+      resolveFactory: () => factory,
+      upgrade: (database) => database.createObjectStore("entries"),
+      version: 1,
+    });
+
+    const first = await connection.open();
+    if (!first) throw new Error("Expected IndexedDB to open");
+    first.close();
+    first.onclose?.(new Event("close"));
+    const second = await connection.open();
+
+    expect(second).not.toBeNull();
+    expect(second).not.toBe(first);
+  });
+
+  it("degrades synchronous open failures to retryable misses", async () => {
+    const open = vi.fn(() => {
+      throw new Error("storage disabled");
+    });
+    const connection = createIndexedDbConnection({
+      name: "throwing-open",
+      resolveFactory: () => ({ open }) as unknown as IDBFactory,
+      upgrade: vi.fn(),
+      version: 1,
+    });
+
+    await expect(connection.open()).resolves.toBeNull();
+    await expect(connection.open()).resolves.toBeNull();
+    expect(open).toHaveBeenCalledTimes(2);
+  });
+
+  it("adapts successful and failed requests and transactions", async () => {
+    const factory = new IDBFactory();
+    const connection = createIndexedDbConnection({
+      name: "adapters",
+      resolveFactory: () => factory,
+      upgrade: (database) => database.createObjectStore("entries"),
+      version: 1,
+    });
+    const database = await connection.open();
+    if (!database) throw new Error("Expected IndexedDB to open");
+
+    const write = database.transaction("entries", "readwrite");
+    const written = transactionDone(write);
+    write.objectStore("entries").add("first", "key");
+    await written;
+
+    const read = database.transaction("entries", "readonly");
+    const readDone = transactionDone(read);
+    await expect(
+      requestResult<string>(read.objectStore("entries").get("key")),
+    ).resolves.toBe("first");
+    await expect(readDone).resolves.toBeUndefined();
+
+    const duplicate = database.transaction("entries", "readwrite");
+    const duplicateDone = transactionDone(duplicate);
+    await expect(
+      requestResult(duplicate.objectStore("entries").add("second", "key")),
+    ).rejects.toBeTruthy();
+    await expect(duplicateDone).rejects.toBeTruthy();
+  });
+});

--- a/app/packages/multimodal/src/runtime/persistence/indexeddb.ts
+++ b/app/packages/multimodal/src/runtime/persistence/indexeddb.ts
@@ -1,0 +1,103 @@
+/** Lazy, best-effort connection to one IndexedDB database. */
+export interface IndexedDbConnection {
+  open(): Promise<IDBDatabase | null>;
+}
+
+/** Domain-owned database definition consumed by the shared lifecycle layer. */
+export interface IndexedDbConnectionOptions {
+  readonly name: string;
+  /** Resolved for every open attempt. Defaults to `globalThis.indexedDB`. */
+  readonly resolveFactory?: () => IDBFactory | null | undefined;
+  readonly upgrade: (database: IDBDatabase) => void;
+  readonly version: number;
+}
+
+/**
+ * Creates a retryable IndexedDB connection. Unsupported, blocked, or failed
+ * opens resolve to `null`; close and version-change events invalidate the
+ * memoized connection so a later operation can try again.
+ */
+export function createIndexedDbConnection(
+  options: IndexedDbConnectionOptions,
+): IndexedDbConnection {
+  const resolveFactory =
+    options.resolveFactory ??
+    (() =>
+      (globalThis as typeof globalThis & { indexedDB?: IDBFactory }).indexedDB);
+  let databasePromise: Promise<IDBDatabase | null> | null = null;
+
+  return {
+    open() {
+      if (databasePromise) return databasePromise;
+      const invalidate = () => {
+        if (databasePromise === current) databasePromise = null;
+      };
+      const current = openDatabase(resolveFactory(), options, invalidate).then(
+        (database) => {
+          if (!database) invalidate();
+          return database;
+        },
+      );
+      databasePromise = current;
+      return current;
+    },
+  };
+}
+
+/** Resolves one IndexedDB request or rejects with its storage error. */
+export function requestResult<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () =>
+      reject(request.error ?? new Error("IndexedDB storage request failed"));
+  });
+}
+
+/** Resolves when one IndexedDB transaction commits successfully. */
+export function transactionDone(transaction: IDBTransaction): Promise<void> {
+  return new Promise((resolve, reject) => {
+    transaction.oncomplete = () => resolve();
+    transaction.onabort = () =>
+      reject(transaction.error ?? new Error("IndexedDB transaction aborted"));
+    transaction.onerror = () =>
+      reject(transaction.error ?? new Error("IndexedDB transaction failed"));
+  });
+}
+
+function openDatabase(
+  factory: IDBFactory | null | undefined,
+  options: IndexedDbConnectionOptions,
+  invalidate: () => void,
+): Promise<IDBDatabase | null> {
+  if (!factory) return Promise.resolve(null);
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (database: IDBDatabase | null) => {
+      if (settled) {
+        database?.close();
+        return;
+      }
+      settled = true;
+      resolve(database);
+    };
+    let request: IDBOpenDBRequest;
+    try {
+      request = factory.open(options.name, options.version);
+    } catch {
+      finish(null);
+      return;
+    }
+    request.onupgradeneeded = () => options.upgrade(request.result);
+    request.onsuccess = () => {
+      const database = request.result;
+      database.onclose = invalidate;
+      database.onversionchange = () => {
+        database.close();
+        invalidate();
+      };
+      finish(database);
+    };
+    request.onerror = () => finish(null);
+    request.onblocked = () => finish(null);
+  });
+}

--- a/app/packages/multimodal/src/runtime/source-bootstrap-cache.test.ts
+++ b/app/packages/multimodal/src/runtime/source-bootstrap-cache.test.ts
@@ -11,6 +11,7 @@ import {
   getSourceBootstrapSnapshot,
   getSourceSessionHints,
   peekSourceBootstrap,
+  publishCurrentSourceFacts,
   publishDurableSourceFacts,
   publishEpisodePreviewBootstrap,
   publishSourceBootstrap,
@@ -208,6 +209,25 @@ describe("source bootstrap cache", () => {
 
     expect(peekSourceBootstrap(source)).toEqual({ timeRange });
     expect(getSourceSessionHints(source, "mcap")).toBeNull();
+  });
+
+  it("replaces validated durable hints with authoritative current facts", () => {
+    resetSourceBootstrapCacheForTests();
+    const source = createSource("authoritative-current");
+    const durableManifest = createManifest("durable", "log");
+    const currentManifest = createManifest("current", "log");
+    publishDurableSourceFacts(source, {
+      adapterId: "mcap",
+      facts: { manifest: durableManifest },
+      trust: "validated",
+    });
+
+    publishCurrentSourceFacts(source, { manifest: currentManifest });
+
+    expect(getSourceSessionHints(source, "mcap")).toEqual({
+      manifestHint: currentManifest,
+    });
+    expect(peekSourceBootstrap(source)?.manifest).toBe(currentManifest);
   });
 
   it("uses validated durable hints only for their adapter", () => {

--- a/app/packages/multimodal/src/runtime/source-bootstrap-cache.test.ts
+++ b/app/packages/multimodal/src/runtime/source-bootstrap-cache.test.ts
@@ -14,6 +14,7 @@ import {
   publishDurableSourceFacts,
   publishEpisodePreviewBootstrap,
   publishSourceBootstrap,
+  retractDurableSourceFacts,
   resetSourceBootstrapCacheForTests,
   subscribeSourceBootstrap,
 } from "./source-bootstrap-cache";
@@ -263,6 +264,24 @@ describe("source bootstrap cache", () => {
     });
 
     expect(getEpisodeTimeRange(source.sourceId)).toBeNull();
+  });
+
+  it("retracts only the durable lane produced by the expected disk read", () => {
+    resetSourceBootstrapCacheForTests();
+    const source = createSource("retracted-durable");
+    const revision = {};
+    publishDurableSourceFacts(source, {
+      adapterId: "mcap",
+      facts: { manifest: createManifest("stale") },
+      revision,
+      trust: "provisional",
+    });
+
+    retractDurableSourceFacts(source, {});
+    expect(peekSourceBootstrap(source)?.manifest).toBeDefined();
+
+    retractDurableSourceFacts(source, revision);
+    expect(peekSourceBootstrap(source)).toBeNull();
   });
 });
 

--- a/app/packages/multimodal/src/runtime/source-bootstrap-cache.test.ts
+++ b/app/packages/multimodal/src/runtime/source-bootstrap-cache.test.ts
@@ -9,7 +9,9 @@ import { getEpisodeTimeRange } from "./episode-time-range-registry";
 import {
   getSourceBootstrap,
   getSourceBootstrapSnapshot,
+  getSourceSessionHints,
   peekSourceBootstrap,
+  publishDurableSourceFacts,
   publishEpisodePreviewBootstrap,
   publishSourceBootstrap,
   resetSourceBootstrapCacheForTests,
@@ -174,6 +176,94 @@ describe("source bootstrap cache", () => {
     ).toEqual(createManifest("initial"));
     expect(peekSourceBootstrap(replacement)).toBeNull();
   });
+
+  it("shows provisional durable facts to the UI but never to the adapter", () => {
+    resetSourceBootstrapCacheForTests();
+    const source = createSource("provisional");
+    const manifest = createManifest("/camera");
+
+    publishDurableSourceFacts(source, {
+      adapterId: "mcap",
+      facts: { manifest },
+      trust: "provisional",
+    });
+    publishSourceBootstrap(source, { poster: createPoster([1]) });
+
+    expect(peekSourceBootstrap(source)?.manifest).toBe(manifest);
+    expect(getSourceSessionHints(source, "mcap")).toBeNull();
+  });
+
+  it("drops the provisional lane when a partial live fact is published", () => {
+    resetSourceBootstrapCacheForTests();
+    const source = createSource("partial-current");
+    const timeRange = createTimeRange();
+    publishDurableSourceFacts(source, {
+      adapterId: "mcap",
+      facts: { manifest: createManifest("stale") },
+      trust: "provisional",
+    });
+
+    publishSourceBootstrap(source, { timeRange });
+
+    expect(peekSourceBootstrap(source)).toEqual({ timeRange });
+    expect(getSourceSessionHints(source, "mcap")).toBeNull();
+  });
+
+  it("uses validated durable hints only for their adapter", () => {
+    resetSourceBootstrapCacheForTests();
+    const source = createSource("validated");
+    const manifest = createManifest("/camera", "log");
+    const timeline = {
+      endNs: 30n,
+      startNs: 10n,
+      timeDomainId: "log",
+    } as const;
+    publishDurableSourceFacts(source, {
+      adapterId: "mcap",
+      facts: { manifest, timeline },
+      trust: "validated",
+    });
+
+    expect(getSourceSessionHints(source, "mcap")).toEqual({
+      manifestHint: manifest,
+      playbackHint: timeline,
+    });
+    expect(getSourceSessionHints(source, "fixture")).toBeNull();
+  });
+
+  it("never treats a non-log MCAP timeline as a playback hint", () => {
+    resetSourceBootstrapCacheForTests();
+    const source = createSource("publish-time");
+    const manifest = createManifest("/camera", "publish");
+    publishDurableSourceFacts(source, {
+      adapterId: "mcap",
+      facts: {
+        manifest,
+        timeline: {
+          endNs: 20n,
+          startNs: 10n,
+          timeDomainId: "publish",
+        },
+      },
+      trust: "validated",
+    });
+
+    expect(getSourceSessionHints(source, "mcap")).toEqual({
+      manifestHint: manifest,
+    });
+  });
+
+  it("does not publish durable hydration into the grid time-range registry", () => {
+    resetSourceBootstrapCacheForTests();
+    const source = createSource("durable-grid-range");
+    publishDurableSourceFacts(source, {
+      adapterId: "mcap",
+      facts: { timeRange: createTimeRange() },
+      trust: "provisional",
+    });
+
+    expect(getEpisodeTimeRange(source.sourceId)).toBeNull();
+  });
 });
 
 function createTimeRange(): TimeWindow {
@@ -184,7 +274,10 @@ function createSource(sourceId: string, etag?: string): ByteSourceDescriptor {
   return { sourceId, url: `memory://${sourceId}.mcap`, etag };
 }
 
-function createManifest(streamId: string): EpisodeManifest {
+function createManifest(
+  streamId: string,
+  timeDomainId = "recording",
+): EpisodeManifest {
   return {
     episodeId: "episode",
     streams: [
@@ -196,7 +289,7 @@ function createManifest(streamId: string): EpisodeManifest {
         timeRange: createTimeRange(),
       },
     ],
-    timeDomain: { id: "recording", kind: "timestamp" },
+    timeDomain: { id: timeDomainId, kind: "timestamp" },
     timeRange: createTimeRange(),
   };
 }

--- a/app/packages/multimodal/src/runtime/source-bootstrap-cache.ts
+++ b/app/packages/multimodal/src/runtime/source-bootstrap-cache.ts
@@ -43,6 +43,8 @@ export interface SourceSessionHints {
 interface DurableFactLane {
   readonly adapterId: string;
   readonly facts: SourceFactsPayload;
+  /** Opaque identity of the disk entry that produced this lane. */
+  readonly revision?: object;
   readonly trust: Exclude<SourceFactsTrust, "current">;
 }
 
@@ -134,6 +136,28 @@ export function publishDurableSourceFacts(
     ...(current ?? { posterBytes: 0 }),
     durableFacts: { ...lane, facts: normalized },
   });
+}
+
+/** Removes durable UI facts only when they still belong to one disk read. */
+export function retractDurableSourceFacts(
+  source: ByteSourceDescriptor,
+  revision: object,
+): void {
+  const key = sourceBootstrapKey(source);
+  const entry = entries.get(key);
+  if (!entry || entry.durableFacts?.revision !== revision) return;
+  removeEntry(key);
+  const { durableFacts: _durableFacts, ...retained } = entry;
+  if (
+    retained.currentFacts ||
+    retained.poster ||
+    retained.posterStreamId ||
+    retained.previewReadComplete
+  ) {
+    storeEntry(key, retained);
+  } else {
+    notifySourceListeners(key);
+  }
 }
 
 /** Publishes every reusable fact learned by one lightweight preview read. */

--- a/app/packages/multimodal/src/runtime/source-bootstrap-cache.ts
+++ b/app/packages/multimodal/src/runtime/source-bootstrap-cache.ts
@@ -229,12 +229,8 @@ export function getSourceSessionHints(
   };
 }
 
-/** Returns a stable cache snapshot suitable for `useSyncExternalStore`. */
-export function getSourceBootstrapSnapshot(
-  source: ByteSourceDescriptor,
-): SourceBootstrap | null {
-  return copyEntry(entries.get(sourceBootstrapKey(source)));
-}
+/** Stable cache snapshot reader suitable for `useSyncExternalStore`. */
+export const getSourceBootstrapSnapshot = peekSourceBootstrap;
 
 /** Subscribes to one source's bootstrap publishes. */
 export function subscribeSourceBootstrap(

--- a/app/packages/multimodal/src/runtime/source-bootstrap-cache.ts
+++ b/app/packages/multimodal/src/runtime/source-bootstrap-cache.ts
@@ -8,6 +8,12 @@ import type {
 } from "../ir";
 import { byteSourceAccessKey } from "../query/bytes";
 import { publishEpisodeTimeRange } from "./episode-time-range-registry";
+import {
+  normalizeSourceFactsPayload,
+  SOURCE_FACTS_MCAP_ADAPTER_ID,
+  type SourceFactsPayload,
+  type SourceFactsTrust,
+} from "./source-facts";
 
 /**
  * Keep a full grid viewport plus virtualization overscan for first-open and
@@ -28,62 +34,106 @@ export interface SourceBootstrap {
   readonly timeRange?: TimeWindow;
 }
 
-type CacheEntry = SourceBootstrap & {
+/** Trusted adapter inputs projected separately from the bootstrap UI. */
+export interface SourceSessionHints {
+  readonly manifestHint?: EpisodeManifest;
+  readonly playbackHint?: EpisodeTimeline;
+}
+
+interface DurableFactLane {
+  readonly adapterId: string;
+  readonly facts: SourceFactsPayload;
+  readonly trust: Exclude<SourceFactsTrust, "current">;
+}
+
+interface CacheEntry {
+  readonly currentFacts?: SourceFactsPayload;
+  readonly durableFacts?: DurableFactLane;
+  readonly poster?: EpisodePosterFrame;
   readonly posterBytes: number;
-};
+  readonly posterStreamId?: string;
+  readonly previewReadComplete?: boolean;
+}
 
 const entries = new Map<string, CacheEntry>();
+const snapshots = new WeakMap<CacheEntry, SourceBootstrap>();
 let retainedPosterBytes = 0;
 const listenersBySource = new Map<string, Set<() => void>>();
 
 function notifySourceListeners(key: string): void {
-  for (const listener of listenersBySource.get(key) ?? []) {
-    listener();
-  }
+  for (const listener of listenersBySource.get(key) ?? []) listener();
 }
 
-/** Publishes cloneable source facts learned by a lightweight grid. */
+/** Publishes cloneable current-page source facts or poster state. */
 export function publishSourceBootstrap(
   source: ByteSourceDescriptor,
   bootstrap: SourceBootstrap,
 ): void {
   const key = sourceBootstrapKey(source);
-  const current = entries.get(key);
-  if (current) {
-    retainedPosterBytes -= current.posterBytes;
-    entries.delete(key);
-  }
-
+  const current = removeEntry(key);
   const replacesPoster = bootstrap.poster !== undefined;
   const poster = bootstrap.poster ?? current?.poster;
   const posterStreamId =
     bootstrap.posterStreamId ??
     (replacesPoster ? undefined : current?.posterStreamId);
-  const manifest = bootstrap.manifest ?? current?.manifest;
-  const timeline = bootstrap.timeline ?? current?.timeline;
-  const timeRange = bootstrap.timeRange ?? current?.timeRange;
-  const previewReadComplete =
-    bootstrap.previewReadComplete ?? current?.previewReadComplete;
+  const hasFacts =
+    bootstrap.manifest !== undefined ||
+    bootstrap.timeline !== undefined ||
+    bootstrap.timeRange !== undefined;
+  const currentFacts = hasFacts
+    ? (normalizeSourceFactsPayload({
+        ...current?.currentFacts,
+        ...(bootstrap.manifest ? { manifest: bootstrap.manifest } : {}),
+        ...(bootstrap.timeline ? { timeline: bootstrap.timeline } : {}),
+        ...(bootstrap.timeRange ? { timeRange: bootstrap.timeRange } : {}),
+      }) ?? undefined)
+    : current?.currentFacts;
   const next: CacheEntry = {
-    ...(manifest ? { manifest } : {}),
+    ...(currentFacts ? { currentFacts } : {}),
+    // Any live fact publication is authoritative for this access path. Drop
+    // the durable lane rather than field-merging provisional data into trust.
+    ...(!hasFacts && current?.durableFacts
+      ? { durableFacts: current.durableFacts }
+      : {}),
     ...(poster ? { poster } : {}),
     ...(posterStreamId ? { posterStreamId } : {}),
-    ...(previewReadComplete ? { previewReadComplete } : {}),
-    ...(timeRange ? { timeRange } : {}),
-    ...(timeline ? { timeline } : {}),
+    ...((bootstrap.previewReadComplete ?? current?.previewReadComplete)
+      ? { previewReadComplete: true }
+      : {}),
     posterBytes: retainedBinaryBytes(poster ?? null),
   };
-  entries.set(key, next);
-  retainedPosterBytes += next.posterBytes;
-  const evicted = evictBootstrapEntries();
-  notifySourceListeners(key);
-  // An eviction is a change too: a subscriber holding the evicted source's
-  // snapshot must re-read (and see null), not keep rendering stale facts
-  for (const evictedKey of evicted) {
-    if (evictedKey !== key) {
-      notifySourceListeners(evictedKey);
-    }
-  }
+  storeEntry(key, next);
+}
+
+/** Replaces all durable facts with one authoritative current-page payload. */
+export function publishCurrentSourceFacts(
+  source: ByteSourceDescriptor,
+  facts: SourceFactsPayload,
+): void {
+  const normalized = normalizeSourceFactsPayload(facts);
+  if (!normalized) return;
+  const key = sourceBootstrapKey(source);
+  const current = removeEntry(key);
+  storeEntry(key, {
+    ...(current ?? { posterBytes: 0 }),
+    currentFacts: normalized,
+    durableFacts: undefined,
+  });
+}
+
+/** Publishes one wholesale durable lane without affecting grid range state. */
+export function publishDurableSourceFacts(
+  source: ByteSourceDescriptor,
+  lane: DurableFactLane,
+): void {
+  const normalized = normalizeSourceFactsPayload(lane.facts);
+  if (!normalized) return;
+  const key = sourceBootstrapKey(source);
+  const current = removeEntry(key);
+  storeEntry(key, {
+    ...(current ?? { posterBytes: 0 }),
+    durableFacts: { ...lane, facts: normalized },
+  });
 }
 
 /** Publishes every reusable fact learned by one lightweight preview read. */
@@ -112,35 +162,57 @@ export function publishEpisodePreviewBootstrap(
   if (timeRange) publishEpisodeTimeRange(source.sourceId, timeRange);
 }
 
-/** Returns the current source bootstrap without changing its LRU position. */
+/** Returns the UI bootstrap projection without changing its LRU position. */
 export function peekSourceBootstrap(
   source: ByteSourceDescriptor,
 ): SourceBootstrap | null {
   return copyEntry(entries.get(sourceBootstrapKey(source)));
 }
 
-/** Returns the current source bootstrap and promotes it as recently used. */
+/** Returns the UI bootstrap projection and promotes it as recently used. */
 export function getSourceBootstrap(
   source: ByteSourceDescriptor,
 ): SourceBootstrap | null {
   const key = sourceBootstrapKey(source);
   const entry = entries.get(key);
   if (!entry) return null;
-
   entries.delete(key);
   entries.set(key, entry);
   return copyEntry(entry);
+}
+
+/** Returns only current or content-validated facts eligible for adapter use. */
+export function getSourceSessionHints(
+  source: ByteSourceDescriptor,
+  adapterId: string,
+): SourceSessionHints | null {
+  const entry = entries.get(sourceBootstrapKey(source));
+  if (!entry) return null;
+  const durable =
+    entry.durableFacts?.trust === "validated" &&
+    entry.durableFacts.adapterId === adapterId
+      ? entry.durableFacts.facts
+      : undefined;
+  const manifest = entry.currentFacts?.manifest ?? durable?.manifest;
+  const timeline = entry.currentFacts?.timeline ?? durable?.timeline;
+  const playbackHint = validPlaybackHint(adapterId, manifest, timeline)
+    ? timeline
+    : undefined;
+  if (!manifest && !playbackHint) return null;
+  return {
+    ...(manifest ? { manifestHint: manifest } : {}),
+    ...(playbackHint ? { playbackHint } : {}),
+  };
 }
 
 /** Returns a stable cache snapshot suitable for `useSyncExternalStore`. */
 export function getSourceBootstrapSnapshot(
   source: ByteSourceDescriptor,
 ): SourceBootstrap | null {
-  return entries.get(sourceBootstrapKey(source)) ?? null;
+  return copyEntry(entries.get(sourceBootstrapKey(source)));
 }
 
-/** Subscribes to one source's bootstrap publishes, for
- * `useSyncExternalStore` alongside {@link getSourceBootstrapSnapshot}. */
+/** Subscribes to one source's bootstrap publishes. */
 export function subscribeSourceBootstrap(
   source: ByteSourceDescriptor,
   listener: () => void,
@@ -151,38 +223,92 @@ export function subscribeSourceBootstrap(
   listenersBySource.set(key, listeners);
   return () => {
     listeners.delete(listener);
-    if (listeners.size === 0) {
-      listenersBySource.delete(key);
-    }
+    if (listeners.size === 0) listenersBySource.delete(key);
   };
 }
 
-/** Cache identity for source facts, including transport validators. */
+/** Cache identity for current-page source facts, including access validators. */
 export function sourceBootstrapKey(source: ByteSourceDescriptor): string {
   return JSON.stringify([byteSourceAccessKey(source), source.etag ?? null]);
-}
-
-function copyEntry(entry: CacheEntry | undefined): SourceBootstrap | null {
-  if (!entry) return null;
-  return {
-    ...(entry.manifest ? { manifest: entry.manifest } : {}),
-    ...(entry.poster ? { poster: entry.poster } : {}),
-    ...(entry.posterStreamId ? { posterStreamId: entry.posterStreamId } : {}),
-    ...(entry.previewReadComplete
-      ? { previewReadComplete: entry.previewReadComplete }
-      : {}),
-    ...(entry.timeRange ? { timeRange: entry.timeRange } : {}),
-    ...(entry.timeline ? { timeline: entry.timeline } : {}),
-  };
 }
 
 /** Clears every source bootstrap between tests. */
 export function resetSourceBootstrapCacheForTests(): void {
   entries.clear();
   retainedPosterBytes = 0;
-  for (const key of listenersBySource.keys()) {
-    notifySourceListeners(key);
+  for (const key of listenersBySource.keys()) notifySourceListeners(key);
+}
+
+/** Counts unique retained binary allocations in an arbitrary poster graph. */
+export function retainedBinaryBytes(value: unknown): number {
+  const buffers = new Set<ArrayBufferLike>();
+  collectArrayBuffers(value, buffers, new Set<object>());
+  let total = 0;
+  for (const buffer of buffers) total += buffer.byteLength;
+  return total;
+}
+
+function removeEntry(key: string): CacheEntry | undefined {
+  const current = entries.get(key);
+  if (!current) return undefined;
+  entries.delete(key);
+  retainedPosterBytes -= current.posterBytes;
+  return current;
+}
+
+function storeEntry(key: string, entry: CacheEntry): void {
+  entries.set(key, entry);
+  retainedPosterBytes += entry.posterBytes;
+  const evicted = evictBootstrapEntries();
+  notifySourceListeners(key);
+  for (const evictedKey of evicted) {
+    if (evictedKey !== key) notifySourceListeners(evictedKey);
   }
+}
+
+function copyEntry(entry: CacheEntry | undefined): SourceBootstrap | null {
+  if (!entry) return null;
+  const retained = snapshots.get(entry);
+  if (retained) return retained;
+  const facts = uiFacts(entry);
+  const snapshot = {
+    ...(facts?.manifest ? { manifest: facts.manifest } : {}),
+    ...(entry.poster ? { poster: entry.poster } : {}),
+    ...(entry.posterStreamId ? { posterStreamId: entry.posterStreamId } : {}),
+    ...(entry.previewReadComplete ? { previewReadComplete: true } : {}),
+    ...(facts?.timeRange ? { timeRange: facts.timeRange } : {}),
+    ...(facts?.timeline ? { timeline: facts.timeline } : {}),
+  };
+  snapshots.set(entry, snapshot);
+  return snapshot;
+}
+
+function uiFacts(entry: CacheEntry): SourceFactsPayload | null {
+  const current = entry.currentFacts;
+  const durable = entry.durableFacts?.facts;
+  if (!current && !durable) return null;
+  const manifest = current?.manifest ?? durable?.manifest;
+  const timeline = current?.timeline ?? durable?.timeline;
+  const timeRange = current?.timeRange ?? durable?.timeRange;
+  return {
+    ...(manifest ? { manifest } : {}),
+    ...(timeline ? { timeline } : {}),
+    ...(timeRange ? { timeRange } : {}),
+  };
+}
+
+function validPlaybackHint(
+  adapterId: string,
+  manifest: EpisodeManifest | undefined,
+  timeline: EpisodeTimeline | undefined,
+): timeline is EpisodeTimeline {
+  if (!timeline) return false;
+  if (manifest && manifest.timeDomain.id !== timeline.timeDomainId)
+    return false;
+  return (
+    adapterId !== SOURCE_FACTS_MCAP_ADAPTER_ID ||
+    timeline.timeDomainId === "log"
+  );
 }
 
 function evictBootstrapEntries(): string[] {
@@ -202,15 +328,6 @@ function evictBootstrapEntries(): string[] {
   return evicted;
 }
 
-/** Counts unique retained binary allocations in an arbitrary poster graph. */
-export function retainedBinaryBytes(value: unknown): number {
-  const buffers = new Set<ArrayBufferLike>();
-  collectArrayBuffers(value, buffers, new Set<object>());
-  let total = 0;
-  for (const buffer of buffers) total += buffer.byteLength;
-  return total;
-}
-
 function collectArrayBuffers(
   value: unknown,
   buffers: Set<ArrayBufferLike>,
@@ -221,7 +338,6 @@ function collectArrayBuffers(
     return;
   }
   if (!value || typeof value !== "object" || visited.has(value)) return;
-
   visited.add(value);
   for (const child of Object.values(value)) {
     collectArrayBuffers(child, buffers, visited);

--- a/app/packages/multimodal/src/runtime/source-facts-codec.ts
+++ b/app/packages/multimodal/src/runtime/source-facts-codec.ts
@@ -21,6 +21,7 @@ import {
 
 const BIGINT_TAG = "__fiftyone_source_facts_bigint_v1__";
 const DECIMAL_INTEGER = /^\d+$/;
+const SIGNED_DECIMAL_INTEGER = /^-?\d+$/;
 const STREAM_KINDS = new Set<string>(Object.values(STREAM_KIND));
 const TIME_DOMAIN_KINDS = new Set(["duration", "sequence", "timestamp"]);
 const READ_PROFILES = new Set<string>(Object.values(BYTE_SOURCE_READ_PROFILE));
@@ -63,7 +64,10 @@ export function decodeStoredSourceFacts(
   if (typeof value !== "string") return null;
   try {
     const parsed: unknown = JSON.parse(value, (_key, child: unknown) => {
-      if (!recordWithKeys(child, [BIGINT_TAG])) return child;
+      if (!isRecord(child) || !(BIGINT_TAG in child)) return child;
+      if (!hasOnlyKeys(child, [BIGINT_TAG])) {
+        throw new Error("Invalid source-facts bigint");
+      }
       const encoded = child[BIGINT_TAG];
       if (typeof encoded !== "string" || !/^-?\d+$/.test(encoded)) {
         throw new Error("Invalid source-facts bigint");
@@ -620,5 +624,8 @@ function optionalByteSize(value: unknown): boolean {
 }
 
 function optionalDecimal(value: unknown): boolean {
-  return value === undefined || byteSize(value);
+  return (
+    value === undefined ||
+    (typeof value === "string" && SIGNED_DECIMAL_INTEGER.test(value))
+  );
 }

--- a/app/packages/multimodal/src/runtime/source-facts-codec.ts
+++ b/app/packages/multimodal/src/runtime/source-facts-codec.ts
@@ -1,0 +1,636 @@
+import type {
+  EpisodeManifest,
+  EpisodeRecordingFacts,
+  EpisodeTimeline,
+  StreamCalibration,
+  StreamDescriptor,
+  TimeDomain,
+  TimeWindow,
+  TransformTopology,
+} from "../ir";
+import {
+  SOURCE_FACTS_SCHEMA_VERSION,
+  type SourceFactsIdentity,
+  type SourceFactsPayload,
+  type SourceFactsScope,
+  type SourceFactsValidator,
+  type StoredSourceFactsV1,
+} from "./source-facts";
+
+const BIGINT_TAG = "__fiftyone_source_facts_bigint_v1__";
+const DECIMAL_INTEGER = /^\d+$/;
+const STREAM_KINDS = new Set([
+  "camera-calibration",
+  "grid",
+  "image",
+  "image-annotations",
+  "location",
+  "log",
+  "point-cloud",
+  "pose",
+  "scalar",
+  "scene-update",
+  "transform",
+  "unknown",
+  "video",
+]);
+const TIME_DOMAIN_KINDS = new Set(["duration", "sequence", "timestamp"]);
+const READ_PROFILES = new Set(["local", "remote"]);
+const MESSAGE_INDEX_STATUSES = new Set([
+  "absent",
+  "complete",
+  "partial",
+  "unknown",
+]);
+
+/** JSON-safe durable envelope and its exact UTF-8 size. */
+export interface EncodedSourceFacts {
+  readonly byteLength: number;
+  readonly value: string;
+}
+
+/** Encodes validated facts with lossless decimal bigint markers. */
+export function encodeStoredSourceFacts(
+  entry: StoredSourceFactsV1,
+): EncodedSourceFacts | null {
+  if (!validStoredSourceFacts(entry)) return null;
+  try {
+    const value = JSON.stringify(entry, (_key, child: unknown) => {
+      if (typeof child === "bigint") return { [BIGINT_TAG]: child.toString() };
+      if (ArrayBuffer.isView(child) || child instanceof ArrayBuffer) {
+        throw new Error("Source facts cannot contain binary payloads");
+      }
+      return child;
+    });
+    return { byteLength: new TextEncoder().encode(value).byteLength, value };
+  } catch {
+    return null;
+  }
+}
+
+/** Decodes and runtime-validates one untrusted durable envelope. */
+export function decodeStoredSourceFacts(
+  value: unknown,
+): StoredSourceFactsV1 | null {
+  if (typeof value !== "string") return null;
+  try {
+    const parsed: unknown = JSON.parse(value, (_key, child: unknown) => {
+      if (!recordWithKeys(child, [BIGINT_TAG])) return child;
+      const encoded = child[BIGINT_TAG];
+      if (typeof encoded !== "string" || !/^-?\d+$/.test(encoded)) {
+        throw new Error("Invalid source-facts bigint");
+      }
+      return BigInt(encoded);
+    });
+    return validStoredSourceFacts(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Runtime validator for all fields persisted by the V1 codec. */
+export function validStoredSourceFacts(
+  value: unknown,
+): value is StoredSourceFactsV1 {
+  if (
+    !recordWithKeys(value, [
+      "adapterId",
+      "createdAt",
+      "facts",
+      "identity",
+      "scope",
+      "validator",
+      "version",
+    ]) ||
+    value.version !== SOURCE_FACTS_SCHEMA_VERSION ||
+    !nonEmptyString(value.adapterId) ||
+    !nonNegativeInteger(value.createdAt) ||
+    !validIdentity(value.identity) ||
+    !validScope(value.scope) ||
+    (value.validator !== undefined && !validValidator(value.validator)) ||
+    !validFacts(value.facts)
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function validIdentity(value: unknown): value is SourceFactsIdentity {
+  return (
+    recordWithKeys(value, ["canonicalLocator", "sourceId"]) &&
+    nonEmptyString(value.canonicalLocator) &&
+    nonEmptyString(value.sourceId)
+  );
+}
+
+function validScope(value: unknown): value is SourceFactsScope {
+  return (
+    recordWithKeys(value, ["cachePartition", "datasetId", "mediaField"]) &&
+    nonEmptyString(value.cachePartition) &&
+    nonEmptyString(value.datasetId) &&
+    (value.mediaField === null || nonEmptyString(value.mediaField))
+  );
+}
+
+function validValidator(value: unknown): value is SourceFactsValidator {
+  if (!isRecord(value)) return false;
+  if (value.kind === "etag") {
+    return (
+      hasOnlyKeys(value, ["kind", "etag", "sizeBytes"]) &&
+      nonEmptyString(value.etag) &&
+      optionalByteSize(value.sizeBytes)
+    );
+  }
+  if (value.kind === "local-file") {
+    return (
+      hasOnlyKeys(value, ["kind", "lastModified", "name", "sizeBytes"]) &&
+      nonNegativeInteger(value.lastModified) &&
+      nonEmptyString(value.name) &&
+      byteSize(value.sizeBytes)
+    );
+  }
+  return false;
+}
+
+function validFacts(value: unknown): value is SourceFactsPayload {
+  if (
+    !recordWithKeys(value, ["manifest", "timeline", "timeRange"]) ||
+    (value.manifest !== undefined && !validManifest(value.manifest)) ||
+    (value.timeline !== undefined && !validTimeline(value.timeline)) ||
+    (value.timeRange !== undefined && !validTimeRange(value.timeRange)) ||
+    (!value.manifest && !value.timeline && !value.timeRange)
+  ) {
+    return false;
+  }
+  const manifest = value.manifest as EpisodeManifest | undefined;
+  const timeline = value.timeline as EpisodeTimeline | undefined;
+  const timeRange = value.timeRange as TimeWindow | undefined;
+  if (
+    manifest &&
+    timeline &&
+    manifest.timeDomain.id !== timeline.timeDomainId
+  ) {
+    return false;
+  }
+  return !timeline || !timeRange || sameRange(timeline, timeRange);
+}
+
+function validManifest(value: unknown): value is EpisodeManifest {
+  if (
+    !recordWithKeys(value, [
+      "calibrations",
+      "episodeId",
+      "metadata",
+      "recordingFacts",
+      "streams",
+      "timeDomain",
+      "timeRange",
+      "transformTopology",
+    ]) ||
+    !nonEmptyString(value.episodeId) ||
+    !Array.isArray(value.streams) ||
+    !validTimeDomain(value.timeDomain) ||
+    !validTimeRange(value.timeRange) ||
+    !optionalStringRecord(value.metadata) ||
+    (value.recordingFacts !== undefined &&
+      !validRecordingFacts(value.recordingFacts)) ||
+    (value.calibrations !== undefined &&
+      (!Array.isArray(value.calibrations) ||
+        !value.calibrations.every(validCalibration))) ||
+    (value.transformTopology !== undefined &&
+      !validTransformTopology(value.transformTopology))
+  ) {
+    return false;
+  }
+  const range = value.timeRange as TimeWindow;
+  const streamIds = new Set<string>();
+  for (const candidate of value.streams) {
+    if (!validStream(candidate, range) || streamIds.has(candidate.id)) {
+      return false;
+    }
+    streamIds.add(candidate.id);
+  }
+  const calibrationIds = new Set<string>();
+  for (const candidate of value.calibrations ?? []) {
+    if (calibrationIds.has(candidate.streamId)) return false;
+    calibrationIds.add(candidate.streamId);
+  }
+  return true;
+}
+
+function validStream(
+  value: unknown,
+  manifestRange: TimeWindow,
+): value is StreamDescriptor {
+  return (
+    recordWithKeys(value, [
+      "approxRateHz",
+      "coordinateFrameId",
+      "count",
+      "id",
+      "kind",
+      "metadata",
+      "payload",
+      "sourceName",
+      "timeRange",
+    ]) &&
+    nonEmptyString(value.id) &&
+    nonEmptyString(value.sourceName) &&
+    typeof value.kind === "string" &&
+    STREAM_KINDS.has(value.kind) &&
+    optionalFiniteNonNegative(value.approxRateHz) &&
+    optionalNonNegativeInteger(value.count) &&
+    optionalString(value.coordinateFrameId) &&
+    optionalStringRecord(value.metadata) &&
+    validPayload(value.payload) &&
+    validTimeRange(value.timeRange) &&
+    rangeContains(manifestRange, value.timeRange)
+  );
+}
+
+function validPayload(value: unknown): boolean {
+  return (
+    recordWithKeys(value, ["encoding", "schema", "schemaEncoding"]) &&
+    nonEmptyString(value.encoding) &&
+    optionalString(value.schema) &&
+    optionalString(value.schemaEncoding)
+  );
+}
+
+function validTimeDomain(value: unknown): value is TimeDomain {
+  return (
+    recordWithKeys(value, ["id", "kind", "originNs"]) &&
+    nonEmptyString(value.id) &&
+    typeof value.kind === "string" &&
+    TIME_DOMAIN_KINDS.has(value.kind) &&
+    (value.originNs === undefined || typeof value.originNs === "bigint")
+  );
+}
+
+function validTimeRange(value: unknown): value is TimeWindow {
+  return recordWithKeys(value, ["endNs", "startNs"]) && validRangeFields(value);
+}
+
+function validRangeFields(value: Record<string, unknown>): value is Record<
+  string,
+  unknown
+> & {
+  readonly endNs: bigint;
+  readonly startNs: bigint;
+} {
+  return (
+    typeof value.startNs === "bigint" &&
+    typeof value.endNs === "bigint" &&
+    value.endNs >= value.startNs
+  );
+}
+
+function validTimeline(value: unknown): value is EpisodeTimeline {
+  if (
+    !recordWithKeys(value, [
+      "byteTimeline",
+      "endNs",
+      "startNs",
+      "timeDomainId",
+    ]) ||
+    !validRangeFields(value) ||
+    !nonEmptyString(value.timeDomainId) ||
+    (value.byteTimeline !== undefined && !Array.isArray(value.byteTimeline))
+  ) {
+    return false;
+  }
+  let previousEnd: bigint | undefined;
+  let previousOffset: bigint | undefined;
+  let previousBytes: number | undefined;
+  for (const point of value.byteTimeline ?? []) {
+    if (
+      !recordWithKeys(point, [
+        "cumulativeCompressedBytes",
+        "endTimeNs",
+        "startOffsetBytes",
+      ]) ||
+      !finiteNonNegative(point.cumulativeCompressedBytes) ||
+      typeof point.endTimeNs !== "bigint" ||
+      typeof point.startOffsetBytes !== "bigint" ||
+      point.startOffsetBytes < 0n ||
+      point.endTimeNs < value.startNs ||
+      point.endTimeNs > value.endNs ||
+      (previousEnd !== undefined && point.endTimeNs < previousEnd) ||
+      (previousOffset !== undefined &&
+        point.startOffsetBytes < previousOffset) ||
+      (previousBytes !== undefined &&
+        point.cumulativeCompressedBytes < previousBytes)
+    ) {
+      return false;
+    }
+    previousEnd = point.endTimeNs;
+    previousOffset = point.startOffsetBytes;
+    previousBytes = point.cumulativeCompressedBytes;
+  }
+  return true;
+}
+
+function validCalibration(value: unknown): value is StreamCalibration {
+  if (
+    !recordWithKeys(value, ["calibration", "streamId"]) ||
+    !nonEmptyString(value.streamId) ||
+    !isRecord(value.calibration)
+  ) {
+    return false;
+  }
+  const calibration = value.calibration;
+  return (
+    recordWithKeys(calibration, [
+      "binningX",
+      "binningY",
+      "coordinateFrameId",
+      "D",
+      "distortionModel",
+      "height",
+      "K",
+      "kind",
+      "P",
+      "R",
+      "roi",
+      "timestampNs",
+      "width",
+    ]) &&
+    calibration.kind === "camera-calibration" &&
+    positiveInteger(calibration.width) &&
+    positiveInteger(calibration.height) &&
+    finiteNumberArray(calibration.K, 9) &&
+    optionalFiniteNumberArray(calibration.R, 9) &&
+    optionalFiniteNumberArray(calibration.P, 12) &&
+    optionalFiniteNumberArray(calibration.D) &&
+    optionalNonNegativeInteger(calibration.binningX) &&
+    optionalNonNegativeInteger(calibration.binningY) &&
+    optionalString(calibration.coordinateFrameId) &&
+    optionalString(calibration.distortionModel) &&
+    (calibration.timestampNs === undefined ||
+      typeof calibration.timestampNs === "bigint") &&
+    (calibration.roi === undefined || validCalibrationRoi(calibration.roi))
+  );
+}
+
+function validCalibrationRoi(value: unknown): boolean {
+  return (
+    recordWithKeys(value, [
+      "doRectify",
+      "height",
+      "width",
+      "xOffset",
+      "yOffset",
+    ]) &&
+    typeof value.doRectify === "boolean" &&
+    nonNegativeInteger(value.height) &&
+    nonNegativeInteger(value.width) &&
+    nonNegativeInteger(value.xOffset) &&
+    nonNegativeInteger(value.yOffset)
+  );
+}
+
+function validTransformTopology(value: unknown): value is TransformTopology {
+  if (!recordWithKeys(value, ["edges"]) || !Array.isArray(value.edges)) {
+    return false;
+  }
+  const identities = new Set<string>();
+  for (const edge of value.edges) {
+    if (
+      !recordWithKeys(edge, [
+        "childFrameId",
+        "parentFrameId",
+        "sourceStreamId",
+      ]) ||
+      !nonEmptyString(edge.childFrameId) ||
+      !nonEmptyString(edge.parentFrameId) ||
+      !optionalString(edge.sourceStreamId)
+    ) {
+      return false;
+    }
+    const identity = `${edge.parentFrameId}\0${edge.childFrameId}\0${
+      edge.sourceStreamId ?? ""
+    }`;
+    if (identities.has(identity)) return false;
+    identities.add(identity);
+  }
+  return true;
+}
+
+function validRecordingFacts(value: unknown): value is EpisodeRecordingFacts {
+  return (
+    recordWithKeys(value, [
+      "applicationSupport",
+      "channelCount",
+      "durationNs",
+      "endTimeNs",
+      "format",
+      "mcap",
+      "messageCount",
+      "readProfile",
+      "schemaCount",
+      "schemaCoverage",
+      "sizeBytes",
+      "startTimeNs",
+      "topicCount",
+    ]) &&
+    nonEmptyString(value.format) &&
+    optionalNonNegativeInteger(value.channelCount) &&
+    optionalDecimal(value.durationNs) &&
+    optionalDecimal(value.endTimeNs) &&
+    optionalDecimal(value.messageCount) &&
+    optionalDecimal(value.sizeBytes) &&
+    optionalDecimal(value.startTimeNs) &&
+    optionalNonNegativeInteger(value.schemaCount) &&
+    optionalNonNegativeInteger(value.topicCount) &&
+    (value.readProfile === undefined ||
+      (typeof value.readProfile === "string" &&
+        READ_PROFILES.has(value.readProfile))) &&
+    (value.applicationSupport === undefined ||
+      validApplicationSupport(value.applicationSupport)) &&
+    (value.schemaCoverage === undefined ||
+      validSchemaCoverage(value.schemaCoverage)) &&
+    (value.mcap === undefined || validMcapFacts(value.mcap))
+  );
+}
+
+function validApplicationSupport(value: unknown): boolean {
+  return (
+    recordWithKeys(value, [
+      "inspectableStreamCount",
+      "renderableStreamCount",
+      "unavailableStreamCount",
+    ]) &&
+    nonNegativeInteger(value.inspectableStreamCount) &&
+    nonNegativeInteger(value.renderableStreamCount) &&
+    nonNegativeInteger(value.unavailableStreamCount)
+  );
+}
+
+function validSchemaCoverage(value: unknown): boolean {
+  return (
+    recordWithKeys(value, [
+      "embeddedSchemaChannelCount",
+      "missingSchemaChannelCount",
+    ]) &&
+    nonNegativeInteger(value.embeddedSchemaChannelCount) &&
+    nonNegativeInteger(value.missingSchemaChannelCount)
+  );
+}
+
+function validMcapFacts(value: unknown): boolean {
+  return (
+    recordWithKeys(value, [
+      "attachmentCount",
+      "attachments",
+      "chunkCount",
+      "compression",
+      "compressionRatio",
+      "library",
+      "medianChannelsPerChunk",
+      "medianChunkSizeBytes",
+      "medianChunkSpanNs",
+      "messageIndexStatus",
+      "metadataRecordCount",
+      "metadataRecordNames",
+      "profile",
+    ]) &&
+    optionalNonNegativeInteger(value.attachmentCount) &&
+    optionalNonNegativeInteger(value.chunkCount) &&
+    optionalFiniteNonNegative(value.compressionRatio) &&
+    optionalString(value.library) &&
+    optionalFiniteNonNegative(value.medianChannelsPerChunk) &&
+    optionalDecimal(value.medianChunkSizeBytes) &&
+    optionalDecimal(value.medianChunkSpanNs) &&
+    optionalNonNegativeInteger(value.metadataRecordCount) &&
+    optionalString(value.profile) &&
+    (value.messageIndexStatus === undefined ||
+      (typeof value.messageIndexStatus === "string" &&
+        MESSAGE_INDEX_STATUSES.has(value.messageIndexStatus))) &&
+    (value.metadataRecordNames === undefined ||
+      stringArray(value.metadataRecordNames)) &&
+    (value.attachments === undefined ||
+      (Array.isArray(value.attachments) &&
+        value.attachments.every(validAttachment))) &&
+    (value.compression === undefined ||
+      (Array.isArray(value.compression) &&
+        value.compression.every(validCompression)))
+  );
+}
+
+function validAttachment(value: unknown): boolean {
+  return (
+    recordWithKeys(value, ["dataSizeBytes", "mediaType", "name"]) &&
+    byteSize(value.dataSizeBytes) &&
+    typeof value.mediaType === "string" &&
+    nonEmptyString(value.name)
+  );
+}
+
+function validCompression(value: unknown): boolean {
+  return (
+    recordWithKeys(value, [
+      "chunkCount",
+      "codec",
+      "compressedBytes",
+      "uncompressedBytes",
+    ]) &&
+    nonNegativeInteger(value.chunkCount) &&
+    typeof value.codec === "string" &&
+    byteSize(value.compressedBytes) &&
+    byteSize(value.uncompressedBytes)
+  );
+}
+
+function sameRange(left: TimeWindow, right: TimeWindow): boolean {
+  return left.startNs === right.startNs && left.endNs === right.endNs;
+}
+
+function rangeContains(parent: TimeWindow, child: unknown): boolean {
+  const range = child as TimeWindow;
+  return range.startNs >= parent.startNs && range.endNs <= parent.endNs;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function recordWithKeys(
+  value: unknown,
+  keys: readonly string[],
+): value is Record<string, unknown> {
+  return isRecord(value) && hasOnlyKeys(value, keys);
+}
+
+function hasOnlyKeys(
+  value: Record<string, unknown>,
+  keys: readonly string[],
+): boolean {
+  const allowed = new Set(keys);
+  return Object.keys(value).every((key) => allowed.has(key));
+}
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function optionalString(value: unknown): boolean {
+  return value === undefined || typeof value === "string";
+}
+
+function optionalStringRecord(value: unknown): boolean {
+  return (
+    value === undefined ||
+    (isRecord(value) &&
+      Object.values(value).every((child) => typeof child === "string"))
+  );
+}
+
+function stringArray(value: unknown): boolean {
+  return (
+    Array.isArray(value) && value.every((child) => typeof child === "string")
+  );
+}
+
+function nonNegativeInteger(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) >= 0;
+}
+
+function positiveInteger(value: unknown): boolean {
+  return Number.isSafeInteger(value) && (value as number) > 0;
+}
+
+function optionalNonNegativeInteger(value: unknown): boolean {
+  return value === undefined || nonNegativeInteger(value);
+}
+
+function finiteNonNegative(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+function optionalFiniteNonNegative(value: unknown): boolean {
+  return value === undefined || finiteNonNegative(value);
+}
+
+function finiteNumberArray(value: unknown, length?: number): boolean {
+  return (
+    Array.isArray(value) &&
+    (length === undefined || value.length === length) &&
+    value.every((child) => typeof child === "number" && Number.isFinite(child))
+  );
+}
+
+function optionalFiniteNumberArray(value: unknown, length?: number): boolean {
+  return value === undefined || finiteNumberArray(value, length);
+}
+
+function byteSize(value: unknown): value is string {
+  return typeof value === "string" && DECIMAL_INTEGER.test(value);
+}
+
+function optionalByteSize(value: unknown): boolean {
+  return value === undefined || byteSize(value);
+}
+
+function optionalDecimal(value: unknown): boolean {
+  return value === undefined || byteSize(value);
+}

--- a/app/packages/multimodal/src/runtime/source-facts-codec.ts
+++ b/app/packages/multimodal/src/runtime/source-facts-codec.ts
@@ -1,12 +1,14 @@
-import type {
-  EpisodeManifest,
-  EpisodeRecordingFacts,
-  EpisodeTimeline,
-  StreamCalibration,
-  StreamDescriptor,
-  TimeDomain,
-  TimeWindow,
-  TransformTopology,
+import {
+  BYTE_SOURCE_READ_PROFILE,
+  STREAM_KIND,
+  type EpisodeManifest,
+  type EpisodeRecordingFacts,
+  type EpisodeTimeline,
+  type StreamCalibration,
+  type StreamDescriptor,
+  type TimeDomain,
+  type TimeWindow,
+  type TransformTopology,
 } from "../ir";
 import {
   SOURCE_FACTS_SCHEMA_VERSION,
@@ -19,23 +21,9 @@ import {
 
 const BIGINT_TAG = "__fiftyone_source_facts_bigint_v1__";
 const DECIMAL_INTEGER = /^\d+$/;
-const STREAM_KINDS = new Set([
-  "camera-calibration",
-  "grid",
-  "image",
-  "image-annotations",
-  "location",
-  "log",
-  "point-cloud",
-  "pose",
-  "scalar",
-  "scene-update",
-  "transform",
-  "unknown",
-  "video",
-]);
+const STREAM_KINDS = new Set<string>(Object.values(STREAM_KIND));
 const TIME_DOMAIN_KINDS = new Set(["duration", "sequence", "timestamp"]);
-const READ_PROFILES = new Set(["local", "remote"]);
+const READ_PROFILES = new Set<string>(Object.values(BYTE_SOURCE_READ_PROFILE));
 const MESSAGE_INDEX_STATUSES = new Set([
   "absent",
   "complete",

--- a/app/packages/multimodal/src/runtime/source-facts-persistence.test.ts
+++ b/app/packages/multimodal/src/runtime/source-facts-persistence.test.ts
@@ -4,6 +4,7 @@ import {
   SOURCE_FACTS_SCHEMA_VERSION,
   type StoredSourceFactsV1,
 } from "./source-facts";
+import { requestResult, transactionDone } from "./persistence/indexeddb";
 import {
   createIndexedDbSourceFactsPersistence,
   selectSourceFactsEvictions,
@@ -111,19 +112,4 @@ async function storeCounts(factory: IDBFactory): Promise<{
   await completed;
   database.close();
   return { entries, recency };
-}
-
-function requestResult<T>(request: IDBRequest<T>): Promise<T> {
-  return new Promise((resolve, reject) => {
-    request.onsuccess = () => resolve(request.result);
-    request.onerror = () => reject(request.error);
-  });
-}
-
-function transactionDone(transaction: IDBTransaction): Promise<void> {
-  return new Promise((resolve, reject) => {
-    transaction.oncomplete = () => resolve();
-    transaction.onabort = () => reject(transaction.error);
-    transaction.onerror = () => reject(transaction.error);
-  });
 }

--- a/app/packages/multimodal/src/runtime/source-facts-persistence.test.ts
+++ b/app/packages/multimodal/src/runtime/source-facts-persistence.test.ts
@@ -1,7 +1,13 @@
-import { describe, expect, it } from "vitest";
+import { IDBFactory } from "fake-indexeddb";
+import { describe, expect, it, vi } from "vitest";
+import {
+  SOURCE_FACTS_SCHEMA_VERSION,
+  type StoredSourceFactsV1,
+} from "./source-facts";
 import {
   createIndexedDbSourceFactsPersistence,
   selectSourceFactsEvictions,
+  SOURCE_FACTS_DATABASE_NAME,
 } from "./source-facts-persistence";
 
 describe("source facts persistence", () => {
@@ -13,6 +19,41 @@ describe("source facts persistence", () => {
     await expect(persistence.get("missing")).resolves.toBeNull();
     await expect(persistence.delete("missing")).resolves.toBeUndefined();
     await expect(persistence.clear()).resolves.toBeUndefined();
+  });
+
+  it("resolves the default IndexedDB factory when storage first opens", async () => {
+    const persistence = createIndexedDbSourceFactsPersistence();
+    const factory = new IDBFactory();
+    vi.stubGlobal("indexedDB", factory);
+    try {
+      const entry = storedEntry(1);
+
+      await expect(persistence.put("source", entry)).resolves.toMatchObject({
+        stored: true,
+      });
+      await expect(persistence.get("source")).resolves.toEqual(entry);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("conditionally deletes entries and recency in one IndexedDB transaction", async () => {
+    const factory = new IDBFactory();
+    const persistence = createIndexedDbSourceFactsPersistence({ factory });
+    const entry = storedEntry(10);
+    await persistence.put("source", entry);
+
+    await persistence.delete("source", 9);
+    await expect(storeCounts(factory)).resolves.toEqual({
+      entries: 1,
+      recency: 1,
+    });
+
+    await persistence.delete("source", entry.createdAt);
+    await expect(storeCounts(factory)).resolves.toEqual({
+      entries: 0,
+      recency: 0,
+    });
   });
 
   it("evicts oldest entries under count and byte budgets", () => {
@@ -38,3 +79,51 @@ describe("source facts persistence", () => {
     expect(selectSourceFactsEvictions(replaced, 2, 100)).toEqual(["other"]);
   });
 });
+
+function storedEntry(createdAt: number): StoredSourceFactsV1 {
+  return {
+    adapterId: "mcap",
+    createdAt,
+    facts: { timeRange: { endNs: 1n, startNs: 0n } },
+    identity: { canonicalLocator: "/run.mcap", sourceId: "sample" },
+    scope: {
+      cachePartition: "partition",
+      datasetId: "dataset",
+      mediaField: "filepath",
+    },
+    version: SOURCE_FACTS_SCHEMA_VERSION,
+  };
+}
+
+async function storeCounts(factory: IDBFactory): Promise<{
+  readonly entries: number;
+  readonly recency: number;
+}> {
+  const database = await requestResult(
+    factory.open(SOURCE_FACTS_DATABASE_NAME),
+  );
+  const transaction = database.transaction(["entries", "recency"], "readonly");
+  const completed = transactionDone(transaction);
+  const [entries, recency] = await Promise.all([
+    requestResult(transaction.objectStore("entries").count()),
+    requestResult(transaction.objectStore("recency").count()),
+  ]);
+  await completed;
+  database.close();
+  return { entries, recency };
+}
+
+function requestResult<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+function transactionDone(transaction: IDBTransaction): Promise<void> {
+  return new Promise((resolve, reject) => {
+    transaction.oncomplete = () => resolve();
+    transaction.onabort = () => reject(transaction.error);
+    transaction.onerror = () => reject(transaction.error);
+  });
+}

--- a/app/packages/multimodal/src/runtime/source-facts-persistence.test.ts
+++ b/app/packages/multimodal/src/runtime/source-facts-persistence.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  createIndexedDbSourceFactsPersistence,
+  selectSourceFactsEvictions,
+} from "./source-facts-persistence";
+
+describe("source facts persistence", () => {
+  it("degrades unsupported IndexedDB to a miss", async () => {
+    const persistence = createIndexedDbSourceFactsPersistence({
+      factory: null,
+    });
+
+    await expect(persistence.get("missing")).resolves.toBeNull();
+    await expect(persistence.delete("missing")).resolves.toBeUndefined();
+    await expect(persistence.clear()).resolves.toBeUndefined();
+  });
+
+  it("evicts oldest entries under count and byte budgets", () => {
+    const recency = [
+      { byteLength: 40, key: "oldest", lastAccessedAt: 1 },
+      { byteLength: 40, key: "middle", lastAccessedAt: 2 },
+      { byteLength: 40, key: "newest", lastAccessedAt: 3 },
+    ];
+
+    expect(selectSourceFactsEvictions(recency, 2, 1_000)).toEqual(["oldest"]);
+    expect(selectSourceFactsEvictions(recency, 10, 50)).toEqual([
+      "oldest",
+      "middle",
+    ]);
+  });
+
+  it("accounts for replacement metadata once per logical key", () => {
+    const replaced = [
+      { byteLength: 90, key: "same", lastAccessedAt: 2 },
+      { byteLength: 20, key: "other", lastAccessedAt: 1 },
+    ];
+
+    expect(selectSourceFactsEvictions(replaced, 2, 100)).toEqual(["other"]);
+  });
+});

--- a/app/packages/multimodal/src/runtime/source-facts-persistence.ts
+++ b/app/packages/multimodal/src/runtime/source-facts-persistence.ts
@@ -1,0 +1,420 @@
+import {
+  decodeStoredSourceFacts,
+  encodeStoredSourceFacts,
+} from "./source-facts-codec";
+import type { StoredSourceFactsV1 } from "./source-facts";
+
+const MIB = 1024 * 1024;
+/** IndexedDB database owned by the multimodal runtime source-facts tier. */
+export const SOURCE_FACTS_DATABASE_NAME = "fiftyone-multimodal-source-facts";
+const DATABASE_VERSION = 1;
+const ENTRY_STORE = "entries";
+const RECENCY_STORE = "recency";
+const RECENCY_INDEX = "last-accessed";
+const STORED_ENVELOPE_VERSION = 1;
+
+/** Hard ceiling on durable source-facts entries. */
+export const SOURCE_FACTS_MAX_ENTRIES = 512;
+/** Hard ceiling on aggregate encoded source-facts bytes. */
+export const SOURCE_FACTS_MAX_TOTAL_BYTES = 32 * MIB;
+/** Hard ceiling on one encoded source-facts entry. */
+export const SOURCE_FACTS_MAX_ENTRY_BYTES = 2 * MIB;
+
+interface StoredSourceFactsEnvelope {
+  readonly encoded: string;
+  readonly version: typeof STORED_ENVELOPE_VERSION;
+}
+
+/** Recency metadata retained separately from the larger facts payload. */
+export interface StoredSourceFactsRecency {
+  readonly byteLength: number;
+  readonly key: string;
+  readonly lastAccessedAt: number;
+}
+
+/** Best-effort durable repository for validated source-facts values. */
+export interface SourceFactsPersistence {
+  clear(): Promise<void>;
+  delete(key: string): Promise<void>;
+  get(key: string): Promise<StoredSourceFactsV1 | null>;
+  put(key: string, entry: StoredSourceFactsV1): Promise<SourceFactsWriteResult>;
+}
+
+/** Observable outcome of one best-effort durable write. */
+export interface SourceFactsWriteResult {
+  readonly byteLength?: number;
+  readonly stored: boolean;
+}
+
+/** Testable options for constructing an IndexedDB repository. */
+export interface SourceFactsPersistenceOptions {
+  readonly factory?: IDBFactory | null;
+  readonly maxEntries?: number;
+  readonly maxEntryBytes?: number;
+  readonly maxTotalBytes?: number;
+}
+
+/**
+ * Creates the reload-surviving source-facts repository. Storage denial,
+ * lifecycle failures, corrupt values, and quota pressure all degrade to a
+ * miss; none of these operations is allowed to become a product error.
+ */
+export function createIndexedDbSourceFactsPersistence(
+  options: SourceFactsPersistenceOptions = {},
+): SourceFactsPersistence {
+  const factory =
+    options.factory === undefined
+      ? (globalThis as typeof globalThis & { indexedDB?: IDBFactory }).indexedDB
+      : options.factory;
+  const maxEntries = options.maxEntries ?? SOURCE_FACTS_MAX_ENTRIES;
+  const maxEntryBytes = options.maxEntryBytes ?? SOURCE_FACTS_MAX_ENTRY_BYTES;
+  const maxTotalBytes = options.maxTotalBytes ?? SOURCE_FACTS_MAX_TOTAL_BYTES;
+  let databasePromise: Promise<IDBDatabase | null> | null = null;
+  const pendingReads = new Map<string, Promise<StoredSourceFactsV1 | null>>();
+  let mutationChain = Promise.resolve();
+
+  const open = (): Promise<IDBDatabase | null> => {
+    if (databasePromise) return databasePromise;
+    const invalidate = () => {
+      if (databasePromise === current) databasePromise = null;
+    };
+    const current = openDatabase(factory, invalidate).then((database) => {
+      if (!database) invalidate();
+      return database;
+    });
+    databasePromise = current;
+    return current;
+  };
+
+  const enqueueMutation = (operation: () => Promise<void>): Promise<void> => {
+    const pending = mutationChain.catch(() => undefined).then(operation);
+    mutationChain = pending.catch(() => undefined);
+    return pending;
+  };
+
+  const read = async (key: string): Promise<StoredSourceFactsV1 | null> => {
+    const database = await open();
+    if (!database) return null;
+    try {
+      const envelope = await readEnvelope(database, key);
+      if (!validEnvelope(envelope)) {
+        if (envelope) {
+          void enqueueMutation(() => deleteEntry(database, key)).catch(
+            () => undefined,
+          );
+        }
+        return null;
+      }
+      const entry = decodeStoredSourceFacts(envelope.encoded);
+      if (!entry) {
+        void enqueueMutation(() => deleteEntry(database, key)).catch(
+          () => undefined,
+        );
+        return null;
+      }
+      // Advisory recency must never delay delivery of a visible hit.
+      void touchEntry(database, key, envelope.encoded, Date.now());
+      return entry;
+    } catch {
+      return null;
+    }
+  };
+
+  return {
+    async clear() {
+      const database = await open();
+      if (!database) return;
+      await enqueueMutation(() => clearEntries(database)).catch(
+        () => undefined,
+      );
+    },
+
+    async delete(key) {
+      const database = await open();
+      if (!database) return;
+      await enqueueMutation(() => deleteEntry(database, key)).catch(
+        () => undefined,
+      );
+    },
+
+    get(key) {
+      let pending = pendingReads.get(key);
+      if (!pending) {
+        pending = read(key).finally(() => pendingReads.delete(key));
+        pendingReads.set(key, pending);
+      }
+      return pending;
+    },
+
+    async put(key, entry) {
+      const encoded = encodeStoredSourceFacts(entry);
+      if (!encoded || encoded.byteLength > maxEntryBytes) {
+        return { stored: false };
+      }
+      const database = await open();
+      if (!database) return { stored: false };
+      try {
+        await enqueueMutation(async () => {
+          await writeEntry(database, key, encoded, Date.now());
+          await enforceBudget(database, maxEntries, maxTotalBytes);
+        });
+        return { byteLength: encoded.byteLength, stored: true };
+      } catch {
+        return { stored: false };
+      }
+    },
+  };
+}
+
+let singleton: SourceFactsPersistence = createIndexedDbSourceFactsPersistence();
+
+/** Returns the process-local durable source-facts repository. */
+export function getSourceFactsPersistence(): SourceFactsPersistence {
+  return singleton;
+}
+
+/** Replaces the durable repository for deterministic tests. */
+export function resetSourceFactsPersistenceForTests(
+  persistence?: SourceFactsPersistence,
+): void {
+  singleton = persistence ?? createIndexedDbSourceFactsPersistence();
+}
+
+/** Selects oldest entries until both configured budgets are satisfied. */
+export function selectSourceFactsEvictions(
+  recency: readonly StoredSourceFactsRecency[],
+  maxEntries: number,
+  maxTotalBytes: number,
+): readonly string[] {
+  const ordered = recency
+    .filter(validRecency)
+    .slice()
+    .sort(
+      (left, right) =>
+        left.lastAccessedAt - right.lastAccessedAt ||
+        left.key.localeCompare(right.key),
+    );
+  let entryCount = ordered.length;
+  let totalBytes = ordered.reduce(
+    (total, entry) => total + entry.byteLength,
+    0,
+  );
+  const evictions: string[] = [];
+  for (const entry of ordered) {
+    if (entryCount <= maxEntries && totalBytes <= maxTotalBytes) break;
+    evictions.push(entry.key);
+    entryCount--;
+    totalBytes -= entry.byteLength;
+  }
+  return evictions;
+}
+
+function openDatabase(
+  factory: IDBFactory | null | undefined,
+  onClose: () => void,
+): Promise<IDBDatabase | null> {
+  if (!factory) return Promise.resolve(null);
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (database: IDBDatabase | null) => {
+      if (settled) {
+        database?.close();
+        return;
+      }
+      settled = true;
+      resolve(database);
+    };
+    let request: IDBOpenDBRequest;
+    try {
+      request = factory.open(SOURCE_FACTS_DATABASE_NAME, DATABASE_VERSION);
+    } catch {
+      finish(null);
+      return;
+    }
+    request.onupgradeneeded = () => {
+      const database = request.result;
+      if (!database.objectStoreNames.contains(ENTRY_STORE)) {
+        database.createObjectStore(ENTRY_STORE);
+      }
+      if (!database.objectStoreNames.contains(RECENCY_STORE)) {
+        const store = database.createObjectStore(RECENCY_STORE, {
+          keyPath: "key",
+        });
+        store.createIndex(RECENCY_INDEX, "lastAccessedAt");
+      }
+    };
+    request.onsuccess = () => {
+      const database = request.result;
+      database.onclose = onClose;
+      database.onversionchange = () => {
+        database.close();
+        onClose();
+      };
+      finish(database);
+    };
+    request.onerror = () => finish(null);
+    request.onblocked = () => finish(null);
+  });
+}
+
+async function readEnvelope(
+  database: IDBDatabase,
+  key: string,
+): Promise<unknown> {
+  const transaction = database.transaction(ENTRY_STORE, "readonly");
+  const value = await requestResult<unknown>(
+    transaction.objectStore(ENTRY_STORE).get(key),
+  );
+  await transactionDone(transaction);
+  return value;
+}
+
+async function writeEntry(
+  database: IDBDatabase,
+  key: string,
+  encoded: { readonly byteLength: number; readonly value: string },
+  lastAccessedAt: number,
+): Promise<void> {
+  const transaction = database.transaction(
+    [ENTRY_STORE, RECENCY_STORE],
+    "readwrite",
+  );
+  transaction.objectStore(ENTRY_STORE).put(
+    {
+      encoded: encoded.value,
+      version: STORED_ENVELOPE_VERSION,
+    } satisfies StoredSourceFactsEnvelope,
+    key,
+  );
+  transaction.objectStore(RECENCY_STORE).put({
+    byteLength: encoded.byteLength,
+    key,
+    lastAccessedAt,
+  } satisfies StoredSourceFactsRecency);
+  await transactionDone(transaction);
+}
+
+async function touchEntry(
+  database: IDBDatabase,
+  key: string,
+  encoded: string,
+  lastAccessedAt: number,
+): Promise<void> {
+  try {
+    const transaction = database.transaction(RECENCY_STORE, "readwrite");
+    const store = transaction.objectStore(RECENCY_STORE);
+    const current = await requestResult<unknown>(store.get(key));
+    if (validRecency(current)) {
+      store.put({
+        ...current,
+        lastAccessedAt,
+      } satisfies StoredSourceFactsRecency);
+    } else {
+      store.put({
+        byteLength: new TextEncoder().encode(encoded).byteLength,
+        key,
+        lastAccessedAt,
+      } satisfies StoredSourceFactsRecency);
+    }
+    await transactionDone(transaction);
+  } catch {
+    // Recency is advisory; a valid entry remains a hit if this update fails.
+  }
+}
+
+async function deleteEntry(database: IDBDatabase, key: string): Promise<void> {
+  const transaction = database.transaction(
+    [ENTRY_STORE, RECENCY_STORE],
+    "readwrite",
+  );
+  transaction.objectStore(ENTRY_STORE).delete(key);
+  transaction.objectStore(RECENCY_STORE).delete(key);
+  await transactionDone(transaction);
+}
+
+async function clearEntries(database: IDBDatabase): Promise<void> {
+  const transaction = database.transaction(
+    [ENTRY_STORE, RECENCY_STORE],
+    "readwrite",
+  );
+  transaction.objectStore(ENTRY_STORE).clear();
+  transaction.objectStore(RECENCY_STORE).clear();
+  await transactionDone(transaction);
+}
+
+async function enforceBudget(
+  database: IDBDatabase,
+  maxEntries: number,
+  maxTotalBytes: number,
+): Promise<void> {
+  const read = database.transaction(RECENCY_STORE, "readonly");
+  const recency = await requestResult<unknown[]>(
+    read.objectStore(RECENCY_STORE).getAll(),
+  );
+  await transactionDone(read);
+  const invalidKeys = recency.flatMap((entry) =>
+    !validRecency(entry) && isRecord(entry) && typeof entry.key === "string"
+      ? [entry.key]
+      : [],
+  );
+  const valid = recency.filter(validRecency);
+  const evictions = [
+    ...new Set([
+      ...invalidKeys,
+      ...selectSourceFactsEvictions(valid, maxEntries, maxTotalBytes),
+    ]),
+  ];
+  if (evictions.length === 0) return;
+  const write = database.transaction([ENTRY_STORE, RECENCY_STORE], "readwrite");
+  const entries = write.objectStore(ENTRY_STORE);
+  const access = write.objectStore(RECENCY_STORE);
+  for (const key of evictions) {
+    entries.delete(key);
+    access.delete(key);
+  }
+  await transactionDone(write);
+}
+
+function validEnvelope(value: unknown): value is StoredSourceFactsEnvelope {
+  return (
+    isRecord(value) &&
+    Object.keys(value).every((key) => key === "encoded" || key === "version") &&
+    value.version === STORED_ENVELOPE_VERSION &&
+    typeof value.encoded === "string"
+  );
+}
+
+function validRecency(value: unknown): value is StoredSourceFactsRecency {
+  return (
+    isRecord(value) &&
+    typeof value.key === "string" &&
+    Number.isSafeInteger(value.byteLength) &&
+    (value.byteLength as number) >= 0 &&
+    typeof value.lastAccessedAt === "number" &&
+    Number.isFinite(value.lastAccessedAt)
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function requestResult<T>(request: IDBRequest): Promise<T> {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result as T);
+    request.onerror = () =>
+      reject(request.error ?? new Error("Source-facts storage request failed"));
+  });
+}
+
+function transactionDone(transaction: IDBTransaction): Promise<void> {
+  return new Promise((resolve, reject) => {
+    transaction.oncomplete = () => resolve();
+    transaction.onabort = () =>
+      reject(
+        transaction.error ?? new Error("Source-facts transaction aborted"),
+      );
+    transaction.onerror = () =>
+      reject(transaction.error ?? new Error("Source-facts transaction failed"));
+  });
+}

--- a/app/packages/multimodal/src/runtime/source-facts-persistence.ts
+++ b/app/packages/multimodal/src/runtime/source-facts-persistence.ts
@@ -35,7 +35,7 @@ export interface StoredSourceFactsRecency {
 /** Best-effort durable repository for validated source-facts values. */
 export interface SourceFactsPersistence {
   clear(): Promise<void>;
-  delete(key: string): Promise<void>;
+  delete(key: string, expectedCreatedAt?: number): Promise<void>;
   get(key: string): Promise<StoredSourceFactsV1 | null>;
   put(key: string, entry: StoredSourceFactsV1): Promise<SourceFactsWriteResult>;
 }
@@ -129,12 +129,12 @@ export function createIndexedDbSourceFactsPersistence(
       );
     },
 
-    async delete(key) {
+    async delete(key, expectedCreatedAt) {
       const database = await open();
       if (!database) return;
-      await enqueueMutation(() => deleteEntry(database, key)).catch(
-        () => undefined,
-      );
+      await enqueueMutation(() =>
+        deleteEntry(database, key, expectedCreatedAt),
+      ).catch(() => undefined);
     },
 
     get(key) {
@@ -322,12 +322,27 @@ async function touchEntry(
   }
 }
 
-async function deleteEntry(database: IDBDatabase, key: string): Promise<void> {
+async function deleteEntry(
+  database: IDBDatabase,
+  key: string,
+  expectedCreatedAt?: number,
+): Promise<void> {
   const transaction = database.transaction(
     [ENTRY_STORE, RECENCY_STORE],
     "readwrite",
   );
-  transaction.objectStore(ENTRY_STORE).delete(key);
+  const entries = transaction.objectStore(ENTRY_STORE);
+  if (expectedCreatedAt !== undefined) {
+    const envelope = await requestResult<unknown>(entries.get(key));
+    const current = validEnvelope(envelope)
+      ? decodeStoredSourceFacts(envelope.encoded)
+      : null;
+    if (current?.createdAt !== expectedCreatedAt) {
+      await transactionDone(transaction);
+      return;
+    }
+  }
+  entries.delete(key);
   transaction.objectStore(RECENCY_STORE).delete(key);
   await transactionDone(transaction);
 }

--- a/app/packages/multimodal/src/runtime/source-facts-persistence.ts
+++ b/app/packages/multimodal/src/runtime/source-facts-persistence.ts
@@ -62,7 +62,7 @@ export interface SourceFactsPersistenceOptions {
 export function createIndexedDbSourceFactsPersistence(
   options: SourceFactsPersistenceOptions = {},
 ): SourceFactsPersistence {
-  const factory =
+  const resolveFactory = (): IDBFactory | null | undefined =>
     options.factory === undefined
       ? (globalThis as typeof globalThis & { indexedDB?: IDBFactory }).indexedDB
       : options.factory;
@@ -78,10 +78,12 @@ export function createIndexedDbSourceFactsPersistence(
     const invalidate = () => {
       if (databasePromise === current) databasePromise = null;
     };
-    const current = openDatabase(factory, invalidate).then((database) => {
-      if (!database) invalidate();
-      return database;
-    });
+    const current = openDatabase(resolveFactory(), invalidate).then(
+      (database) => {
+        if (!database) invalidate();
+        return database;
+      },
+    );
     databasePromise = current;
     return current;
   };

--- a/app/packages/multimodal/src/runtime/source-facts-persistence.ts
+++ b/app/packages/multimodal/src/runtime/source-facts-persistence.ts
@@ -3,6 +3,11 @@ import {
   encodeStoredSourceFacts,
 } from "./source-facts-codec";
 import type { StoredSourceFactsV1 } from "./source-facts";
+import {
+  createIndexedDbConnection,
+  requestResult,
+  transactionDone,
+} from "./persistence/indexeddb";
 
 const MIB = 1024 * 1024;
 /** IndexedDB database owned by the multimodal runtime source-facts tier. */
@@ -62,31 +67,19 @@ export interface SourceFactsPersistenceOptions {
 export function createIndexedDbSourceFactsPersistence(
   options: SourceFactsPersistenceOptions = {},
 ): SourceFactsPersistence {
-  const resolveFactory = (): IDBFactory | null | undefined =>
-    options.factory === undefined
-      ? (globalThis as typeof globalThis & { indexedDB?: IDBFactory }).indexedDB
-      : options.factory;
   const maxEntries = options.maxEntries ?? SOURCE_FACTS_MAX_ENTRIES;
   const maxEntryBytes = options.maxEntryBytes ?? SOURCE_FACTS_MAX_ENTRY_BYTES;
   const maxTotalBytes = options.maxTotalBytes ?? SOURCE_FACTS_MAX_TOTAL_BYTES;
-  let databasePromise: Promise<IDBDatabase | null> | null = null;
+  const connection = createIndexedDbConnection({
+    name: SOURCE_FACTS_DATABASE_NAME,
+    ...(options.factory !== undefined
+      ? { resolveFactory: () => options.factory }
+      : {}),
+    upgrade: upgradeSourceFactsDatabase,
+    version: DATABASE_VERSION,
+  });
   const pendingReads = new Map<string, Promise<StoredSourceFactsV1 | null>>();
   let mutationChain = Promise.resolve();
-
-  const open = (): Promise<IDBDatabase | null> => {
-    if (databasePromise) return databasePromise;
-    const invalidate = () => {
-      if (databasePromise === current) databasePromise = null;
-    };
-    const current = openDatabase(resolveFactory(), invalidate).then(
-      (database) => {
-        if (!database) invalidate();
-        return database;
-      },
-    );
-    databasePromise = current;
-    return current;
-  };
 
   const enqueueMutation = (operation: () => Promise<void>): Promise<void> => {
     const pending = mutationChain.catch(() => undefined).then(operation);
@@ -95,7 +88,7 @@ export function createIndexedDbSourceFactsPersistence(
   };
 
   const read = async (key: string): Promise<StoredSourceFactsV1 | null> => {
-    const database = await open();
+    const database = await connection.open();
     if (!database) return null;
     try {
       const envelope = await readEnvelope(database, key);
@@ -124,7 +117,7 @@ export function createIndexedDbSourceFactsPersistence(
 
   return {
     async clear() {
-      const database = await open();
+      const database = await connection.open();
       if (!database) return;
       await enqueueMutation(() => clearEntries(database)).catch(
         () => undefined,
@@ -132,7 +125,7 @@ export function createIndexedDbSourceFactsPersistence(
     },
 
     async delete(key, expectedCreatedAt) {
-      const database = await open();
+      const database = await connection.open();
       if (!database) return;
       await enqueueMutation(() =>
         deleteEntry(database, key, expectedCreatedAt),
@@ -153,7 +146,7 @@ export function createIndexedDbSourceFactsPersistence(
       if (!encoded || encoded.byteLength > maxEntryBytes) {
         return { stored: false };
       }
-      const database = await open();
+      const database = await connection.open();
       if (!database) return { stored: false };
       try {
         await enqueueMutation(async () => {
@@ -211,52 +204,16 @@ export function selectSourceFactsEvictions(
   return evictions;
 }
 
-function openDatabase(
-  factory: IDBFactory | null | undefined,
-  onClose: () => void,
-): Promise<IDBDatabase | null> {
-  if (!factory) return Promise.resolve(null);
-  return new Promise((resolve) => {
-    let settled = false;
-    const finish = (database: IDBDatabase | null) => {
-      if (settled) {
-        database?.close();
-        return;
-      }
-      settled = true;
-      resolve(database);
-    };
-    let request: IDBOpenDBRequest;
-    try {
-      request = factory.open(SOURCE_FACTS_DATABASE_NAME, DATABASE_VERSION);
-    } catch {
-      finish(null);
-      return;
-    }
-    request.onupgradeneeded = () => {
-      const database = request.result;
-      if (!database.objectStoreNames.contains(ENTRY_STORE)) {
-        database.createObjectStore(ENTRY_STORE);
-      }
-      if (!database.objectStoreNames.contains(RECENCY_STORE)) {
-        const store = database.createObjectStore(RECENCY_STORE, {
-          keyPath: "key",
-        });
-        store.createIndex(RECENCY_INDEX, "lastAccessedAt");
-      }
-    };
-    request.onsuccess = () => {
-      const database = request.result;
-      database.onclose = onClose;
-      database.onversionchange = () => {
-        database.close();
-        onClose();
-      };
-      finish(database);
-    };
-    request.onerror = () => finish(null);
-    request.onblocked = () => finish(null);
-  });
+function upgradeSourceFactsDatabase(database: IDBDatabase): void {
+  if (!database.objectStoreNames.contains(ENTRY_STORE)) {
+    database.createObjectStore(ENTRY_STORE);
+  }
+  if (!database.objectStoreNames.contains(RECENCY_STORE)) {
+    const store = database.createObjectStore(RECENCY_STORE, {
+      keyPath: "key",
+    });
+    store.createIndex(RECENCY_INDEX, "lastAccessedAt");
+  }
 }
 
 async function readEnvelope(
@@ -414,24 +371,4 @@ function validRecency(value: unknown): value is StoredSourceFactsRecency {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
-}
-
-function requestResult<T>(request: IDBRequest): Promise<T> {
-  return new Promise((resolve, reject) => {
-    request.onsuccess = () => resolve(request.result as T);
-    request.onerror = () =>
-      reject(request.error ?? new Error("Source-facts storage request failed"));
-  });
-}
-
-function transactionDone(transaction: IDBTransaction): Promise<void> {
-  return new Promise((resolve, reject) => {
-    transaction.oncomplete = () => resolve();
-    transaction.onabort = () =>
-      reject(
-        transaction.error ?? new Error("Source-facts transaction aborted"),
-      );
-    transaction.onerror = () =>
-      reject(transaction.error ?? new Error("Source-facts transaction failed"));
-  });
 }

--- a/app/packages/multimodal/src/runtime/source-facts-service.test.ts
+++ b/app/packages/multimodal/src/runtime/source-facts-service.test.ts
@@ -23,8 +23,9 @@ import {
 
 const byteClientHarness = vi.hoisted(() => ({ stat: vi.fn() }));
 
-vi.mock("../query/bytes", async (importOriginal) => {
-  const original = await importOriginal<typeof import("../query/bytes")>();
+vi.mock("../query/bytes/default-byte-client", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("../query/bytes/default-byte-client")>();
   return {
     ...original,
     createDefaultByteClient: () => ({
@@ -300,6 +301,45 @@ describe("source facts service", () => {
     await Promise.resolve();
 
     expect(persistence.put).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not let a late preview replace an authoritative session write", async () => {
+    let resolveStat!: (source: ByteSourceDescriptor) => void;
+    byteClientHarness.stat.mockImplementation(
+      () =>
+        new Promise<ByteSourceDescriptor>((resolve) => {
+          resolveStat = resolve;
+        }),
+    );
+    const source = createSource();
+    recordSessionSourceFacts(source, SCOPE, {
+      dispose: vi.fn(),
+      manifest: manifest(),
+      playback: { timeline: timeline() },
+      read: vi.fn(),
+    } as unknown as EpisodeSession);
+
+    recordPreviewSourceFacts(source, SCOPE, {
+      bootstrapManifest: { ...manifest(), streams: [] },
+      frame: null,
+      status: "ready",
+      streamId: null,
+      streamSourceName: null,
+      streamSourceNames: [],
+    });
+    resolveStat({ ...source, etag: "abc", sizeBytes: "100" });
+
+    await vi.waitFor(() => expect(persistence.put).toHaveBeenCalledTimes(1));
+    expect(persistence.put).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        facts: expect.objectContaining({
+          manifest: manifest(),
+          timeline: timeline(),
+        }),
+        validator: { etag: "abc", kind: "etag", sizeBytes: "100" },
+      }),
+    );
   });
 
   it("records unavailable persistence as an invisible write failure", async () => {

--- a/app/packages/multimodal/src/runtime/source-facts-service.test.ts
+++ b/app/packages/multimodal/src/runtime/source-facts-service.test.ts
@@ -1,0 +1,353 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  ByteSourceDescriptor,
+  EpisodeManifest,
+  EpisodeTimeline,
+} from "../ir";
+import type { EpisodeSession } from "../ports";
+import {
+  getSourceSessionHints,
+  peekSourceBootstrap,
+  resetSourceBootstrapCacheForTests,
+} from "./source-bootstrap-cache";
+import {
+  SOURCE_FACTS_SCHEMA_VERSION,
+  sourceFactsIdentity,
+  type SourceFactsScope,
+  type StoredSourceFactsV1,
+} from "./source-facts";
+import {
+  resetSourceFactsPersistenceForTests,
+  type SourceFactsPersistence,
+} from "./source-facts-persistence";
+
+const byteClientHarness = vi.hoisted(() => ({ stat: vi.fn() }));
+
+vi.mock("../query/bytes", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../query/bytes")>();
+  return {
+    ...original,
+    createDefaultByteClient: () => ({
+      readBytes: vi.fn(),
+      stat: byteClientHarness.stat,
+    }),
+  };
+});
+
+import {
+  getSourceFactsDiagnostics,
+  recordPreviewSourceFacts,
+  recordSessionSourceFacts,
+  resetSourceFactsServiceForTests,
+  resolveSourceFactsHints,
+} from "./source-facts-service";
+
+const SCOPE: SourceFactsScope = {
+  cachePartition: "partition",
+  datasetId: "dataset",
+  mediaField: "filepath",
+};
+
+describe("source facts service", () => {
+  let persistence: SourceFactsPersistence;
+
+  beforeEach(() => {
+    byteClientHarness.stat.mockReset();
+    resetSourceBootstrapCacheForTests();
+    resetSourceFactsServiceForTests();
+    persistence = {
+      clear: vi.fn(async () => undefined),
+      delete: vi.fn(async () => undefined),
+      get: vi.fn(async () => null),
+      put: vi.fn(async () => ({ byteLength: 100, stored: true })),
+    };
+    resetSourceFactsPersistenceForTests(persistence);
+  });
+
+  it("hydrates matching ETag facts as trusted adapter hints", async () => {
+    const source = createSource({ etag: "abc", sizeBytes: "100" });
+    vi.mocked(persistence.get).mockResolvedValue(entry(source));
+
+    await expect(
+      resolveSourceFactsHints(source, SCOPE, "mcap"),
+    ).resolves.toEqual({
+      adapterId: "mcap",
+      manifestHint: manifest(),
+      playbackHint: timeline(),
+    });
+  });
+
+  it("hydrates a matching local-file signature without transport work", async () => {
+    const file = new File([new Uint8Array(10)], "run.mcap", {
+      lastModified: 42,
+    });
+    const source = createSource({
+      localFile: file,
+      sourceId: "local-run",
+      url: "local-file:run.mcap:10:42",
+    });
+    vi.mocked(persistence.get).mockResolvedValue({
+      ...entry(source),
+      validator: {
+        kind: "local-file",
+        lastModified: 42,
+        name: "run.mcap",
+        sizeBytes: "10",
+      },
+    });
+
+    await expect(
+      resolveSourceFactsHints(source, SCOPE, "mcap"),
+    ).resolves.toEqual({
+      adapterId: "mcap",
+      manifestHint: manifest(),
+      playbackHint: timeline(),
+    });
+    expect(byteClientHarness.stat).not.toHaveBeenCalled();
+  });
+
+  it("hydrates unknown remote validators for UI only", async () => {
+    const source = createSource();
+    vi.mocked(persistence.get).mockResolvedValue(entry(source));
+    byteClientHarness.stat.mockResolvedValue(undefined);
+
+    await expect(
+      resolveSourceFactsHints(source, SCOPE, "mcap"),
+    ).resolves.toBeNull();
+
+    expect(peekSourceBootstrap(source)?.manifest).toEqual(manifest());
+    expect(getSourceSessionHints(source, "mcap")).toBeNull();
+  });
+
+  it("continues cold when IndexedDB exceeds the local lookup deadline", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.mocked(persistence.get).mockReturnValue(new Promise(() => undefined));
+      const pending = resolveSourceFactsHints(createSource(), SCOPE, "mcap");
+
+      await vi.advanceTimersByTimeAsync(50);
+
+      await expect(pending).resolves.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("deletes stale validators and wrong-adapter entries", async () => {
+    const source = createSource({ etag: "new", sizeBytes: "100" });
+    vi.mocked(persistence.get).mockResolvedValue(entry(source, "old"));
+
+    await expect(
+      resolveSourceFactsHints(source, SCOPE, "mcap"),
+    ).resolves.toBeNull();
+    expect(persistence.delete).toHaveBeenCalledTimes(1);
+
+    vi.mocked(persistence.get).mockResolvedValue({
+      ...entry(source, "new"),
+      adapterId: "fixture",
+    });
+    await expect(
+      resolveSourceFactsHints(source, SCOPE, "mcap"),
+    ).resolves.toBeNull();
+    expect(persistence.delete).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not upgrade provisional facts after navigation aborts validation", async () => {
+    const source = createSource();
+    vi.mocked(persistence.get).mockResolvedValue(entry(source));
+    let finishStat!: (value: ByteSourceDescriptor) => void;
+    byteClientHarness.stat.mockImplementation(
+      () =>
+        new Promise<ByteSourceDescriptor>((resolve) => {
+          finishStat = resolve;
+        }),
+    );
+    const controller = new AbortController();
+
+    await resolveSourceFactsHints(source, SCOPE, "mcap", {
+      signal: controller.signal,
+    });
+    controller.abort();
+    finishStat({ ...source, etag: "abc", sizeBytes: "100" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(getSourceSessionHints(source, "mcap")).toBeNull();
+  });
+
+  it("persists preview and direct-session facts off their ready paths", async () => {
+    const source = createSource({ etag: "abc", sizeBytes: "100" });
+    recordPreviewSourceFacts(source, SCOPE, {
+      bootstrapManifest: manifest(),
+      bootstrapTimeline: timeline(),
+      frame: null,
+      status: "ready",
+      streamId: null,
+      streamSourceName: null,
+      streamSourceNames: [],
+    });
+    await vi.waitFor(() => expect(persistence.put).toHaveBeenCalledTimes(1));
+
+    recordSessionSourceFacts(source, SCOPE, {
+      dispose: vi.fn(),
+      manifest: manifest(),
+      playback: { timeline: timeline() },
+      read: vi.fn(),
+    } as unknown as EpisodeSession);
+    await vi.waitFor(() => expect(persistence.put).toHaveBeenCalledTimes(2));
+
+    expect(persistence.put).toHaveBeenLastCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        adapterId: "mcap",
+        facts: expect.objectContaining({
+          manifest: manifest(),
+          timeline: timeline(),
+        }),
+        validator: { etag: "abc", kind: "etag", sizeBytes: "100" },
+      }),
+    );
+  });
+
+  it("never issues remote validator probes from grid preview writes", async () => {
+    const source = createSource();
+    recordPreviewSourceFacts(source, SCOPE, {
+      bootstrapManifest: manifest(),
+      bootstrapTimeline: timeline(),
+      frame: null,
+      status: "ready",
+      streamId: null,
+      streamSourceName: null,
+      streamSourceNames: [],
+    });
+
+    await vi.waitFor(() => expect(persistence.put).toHaveBeenCalledTimes(1));
+
+    expect(byteClientHarness.stat).not.toHaveBeenCalled();
+    expect(persistence.put).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.not.objectContaining({ validator: expect.anything() }),
+    );
+  });
+
+  it("allows demanded session writes to acquire a remote validator", async () => {
+    const source = createSource();
+    byteClientHarness.stat.mockResolvedValue({
+      ...source,
+      etag: "abc",
+      sizeBytes: "100",
+    });
+
+    recordSessionSourceFacts(source, SCOPE, {
+      dispose: vi.fn(),
+      manifest: manifest(),
+      playback: { timeline: timeline() },
+      read: vi.fn(),
+    } as unknown as EpisodeSession);
+
+    await vi.waitFor(() => expect(persistence.put).toHaveBeenCalledTimes(1));
+
+    expect(byteClientHarness.stat).toHaveBeenCalledWith(source);
+    expect(persistence.put).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        validator: { etag: "abc", kind: "etag", sizeBytes: "100" },
+      }),
+    );
+  });
+
+  it("coalesces identical same-key write bursts", async () => {
+    let finishWrite!: () => void;
+    vi.mocked(persistence.put).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          finishWrite = () => resolve({ byteLength: 100, stored: true });
+        }),
+    );
+    const source = createSource({ etag: "abc" });
+    const result = {
+      bootstrapManifest: manifest(),
+      bootstrapTimeline: timeline(),
+      frame: null,
+      status: "ready" as const,
+      streamId: null,
+      streamSourceName: null,
+      streamSourceNames: [],
+    };
+
+    recordPreviewSourceFacts(source, SCOPE, result);
+    recordPreviewSourceFacts(source, SCOPE, result);
+    await vi.waitFor(() => expect(persistence.put).toHaveBeenCalledTimes(1));
+    finishWrite();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(persistence.put).toHaveBeenCalledTimes(1);
+  });
+
+  it("records unavailable persistence as an invisible write failure", async () => {
+    vi.mocked(persistence.put).mockResolvedValue({ stored: false });
+    recordPreviewSourceFacts(createSource({ etag: "abc" }), SCOPE, {
+      bootstrapManifest: manifest(),
+      bootstrapTimeline: timeline(),
+      frame: null,
+      status: "ready",
+      streamId: null,
+      streamSourceName: null,
+      streamSourceNames: [],
+    });
+
+    await vi.waitFor(() =>
+      expect(getSourceFactsDiagnostics().writesFailed).toBe(1),
+    );
+
+    expect(getSourceFactsDiagnostics()).toMatchObject({
+      encodedBytesWritten: 0,
+      writesCompleted: 0,
+      writesStarted: 1,
+    });
+  });
+});
+
+function createSource(
+  fields: Partial<ByteSourceDescriptor> = {},
+): ByteSourceDescriptor {
+  return {
+    sourceId: "sample-a",
+    url: "https://app.example/media?filepath=%2Fdata%2Frun.mcap",
+    ...fields,
+  };
+}
+
+function entry(
+  source: ByteSourceDescriptor,
+  etag = "abc",
+): StoredSourceFactsV1 {
+  return {
+    adapterId: "mcap",
+    createdAt: 1,
+    facts: {
+      manifest: manifest(),
+      timeline: timeline(),
+      timeRange: { endNs: 20n, startNs: 10n },
+    },
+    identity: sourceFactsIdentity(source),
+    scope: SCOPE,
+    validator: { etag, kind: "etag", sizeBytes: "100" },
+    version: SOURCE_FACTS_SCHEMA_VERSION,
+  };
+}
+
+function manifest(): EpisodeManifest {
+  return {
+    episodeId: "sample-a",
+    recordingFacts: { format: "mcap" },
+    streams: [],
+    timeDomain: { id: "log", kind: "timestamp" },
+    timeRange: { endNs: 20n, startNs: 10n },
+  };
+}
+
+function timeline(): EpisodeTimeline {
+  return { endNs: 20n, startNs: 10n, timeDomainId: "log" };
+}

--- a/app/packages/multimodal/src/runtime/source-facts-service.test.ts
+++ b/app/packages/multimodal/src/runtime/source-facts-service.test.ts
@@ -175,6 +175,23 @@ describe("source facts service", () => {
     expect(getSourceSessionHints(source, "mcap")).toBeNull();
   });
 
+  it("retracts provisional UI facts when background validation proves them stale", async () => {
+    const source = createSource();
+    vi.mocked(persistence.get).mockResolvedValue(entry(source));
+    byteClientHarness.stat.mockResolvedValue({
+      ...source,
+      etag: "different",
+      sizeBytes: "100",
+    });
+
+    await resolveSourceFactsHints(source, SCOPE, "mcap");
+    await vi.waitFor(() =>
+      expect(persistence.delete).toHaveBeenCalledWith(expect.any(String), 1),
+    );
+
+    expect(peekSourceBootstrap(source)).toBeNull();
+  });
+
   it("persists preview and direct-session facts off their ready paths", async () => {
     const source = createSource({ etag: "abc", sizeBytes: "100" });
     recordPreviewSourceFacts(source, SCOPE, {

--- a/app/packages/multimodal/src/runtime/source-facts-service.ts
+++ b/app/packages/multimodal/src/runtime/source-facts-service.ts
@@ -4,7 +4,7 @@ import type {
   EpisodeSession,
   EpisodeSourceHints,
 } from "../ports";
-import { createDefaultByteClient } from "../query/bytes";
+import { createDefaultByteClient } from "../query/bytes/default-byte-client";
 import {
   getSourceSessionHints,
   publishCurrentSourceFacts,
@@ -256,6 +256,13 @@ function recordSourceFacts(
     if (
       (current.active && sameWriteFacts(current.active, normalizedRequest)) ||
       (current.latest && sameWriteFacts(current.latest, normalizedRequest))
+    ) {
+      return;
+    }
+    if (
+      !normalizedRequest.resolveRemoteValidator &&
+      (current.active?.resolveRemoteValidator ||
+        current.latest?.resolveRemoteValidator)
     ) {
       return;
     }

--- a/app/packages/multimodal/src/runtime/source-facts-service.ts
+++ b/app/packages/multimodal/src/runtime/source-facts-service.ts
@@ -9,6 +9,7 @@ import {
   getSourceSessionHints,
   publishCurrentSourceFacts,
   publishDurableSourceFacts,
+  retractDurableSourceFacts,
 } from "./source-bootstrap-cache";
 import {
   normalizeSourceFactsPayload,
@@ -118,24 +119,25 @@ export async function resolveSourceFactsHints(
     !sameScope(result.scope, scope)
   ) {
     recordLookup("invalid", durationMs);
-    void getSourceFactsPersistence().delete(key);
+    void getSourceFactsPersistence().delete(key, result.createdAt);
     return null;
   }
   if (result.adapterId !== adapterId) {
     recordLookup("stale", durationMs);
-    void getSourceFactsPersistence().delete(key);
+    void getSourceFactsPersistence().delete(key, result.createdAt);
     return null;
   }
 
   const validation = validateSourceFactsContent(result.validator, source);
   if (validation === "stale") {
     recordLookup("stale", durationMs);
-    void getSourceFactsPersistence().delete(key);
+    void getSourceFactsPersistence().delete(key, result.createdAt);
     return null;
   }
   publishDurableSourceFacts(source, {
     adapterId,
     facts: result.facts,
+    revision: result,
     trust: validation,
   });
   recordLookup(
@@ -340,13 +342,15 @@ async function validateRemoteFactsInBackground({
   totalValidationDurationMs += nowMs() - startedAt;
   const validation = validateSourceFactsContent(entry.validator, resolved);
   if (validation === "stale") {
-    await getSourceFactsPersistence().delete(key);
+    retractDurableSourceFacts(source, entry);
+    await getSourceFactsPersistence().delete(key, entry.createdAt);
     return;
   }
   if (validation !== "validated" || signal?.aborted) return;
   publishDurableSourceFacts(source, {
     adapterId: entry.adapterId,
     facts: entry.facts,
+    revision: entry,
     trust: "validated",
   });
 }

--- a/app/packages/multimodal/src/runtime/source-facts-service.ts
+++ b/app/packages/multimodal/src/runtime/source-facts-service.ts
@@ -1,0 +1,437 @@
+import type { ByteSourceDescriptor, EpisodePreviewReadResult } from "../ir";
+import type {
+  EpisodeOpenOptions,
+  EpisodeSession,
+  EpisodeSourceHints,
+} from "../ports";
+import { createDefaultByteClient } from "../query/bytes";
+import {
+  getSourceSessionHints,
+  publishCurrentSourceFacts,
+  publishDurableSourceFacts,
+} from "./source-bootstrap-cache";
+import {
+  normalizeSourceFactsPayload,
+  SOURCE_FACTS_LOOKUP_DEADLINE_MS,
+  SOURCE_FACTS_MCAP_ADAPTER_ID,
+  SOURCE_FACTS_SCHEMA_VERSION,
+  sourceFactsIdentity,
+  sourceFactsKey,
+  sourceFactsValidatorFromSource,
+  validateSourceFactsContent,
+  type SourceFactsIdentity,
+  type SourceFactsPayload,
+  type SourceFactsScope,
+  type StoredSourceFactsV1,
+} from "./source-facts";
+import {
+  getSourceFactsPersistence,
+  type SourceFactsPersistence,
+} from "./source-facts-persistence";
+
+/** Aggregate result names recorded without source identifiers or paths. */
+export type SourceFactsLookupResult =
+  | "memory-current"
+  | "disk-validated"
+  | "disk-provisional"
+  | "miss"
+  | "stale"
+  | "invalid"
+  | "timeout"
+  | "unavailable";
+
+/** Page-lifetime aggregate source-facts diagnostics. */
+export interface SourceFactsDiagnostics {
+  readonly encodedBytesWritten: number;
+  readonly lookupDurationMs: number;
+  readonly lookups: Readonly<Record<SourceFactsLookupResult, number>>;
+  readonly validationDurationMs: number;
+  readonly validations: number;
+  readonly writesCompleted: number;
+  readonly writesFailed: number;
+  readonly writesStarted: number;
+}
+
+interface RecordSourceFactsRequest {
+  readonly adapterId: string;
+  readonly facts: SourceFactsPayload;
+  readonly resolveRemoteValidator: boolean;
+  readonly scope: SourceFactsScope;
+  readonly source: ByteSourceDescriptor;
+}
+
+interface PendingWrite {
+  active: RecordSourceFactsRequest | null;
+  latest: RecordSourceFactsRequest | null;
+  promise: Promise<void>;
+}
+
+const byteClient = createDefaultByteClient();
+const pendingWrites = new Map<string, PendingWrite>();
+const lookupCounts = createLookupCounts();
+let totalLookupDurationMs = 0;
+let totalValidationDurationMs = 0;
+let validations = 0;
+let encodedBytesWritten = 0;
+let writesCompleted = 0;
+let writesFailed = 0;
+let writesStarted = 0;
+
+/**
+ * Resolves one trusted hint bundle while publishing logical disk hits to the
+ * UI lane. Remote ETag discovery continues only as abortable background
+ * enrichment and never extends this open beyond the local lookup deadline.
+ */
+export async function resolveSourceFactsHints(
+  source: ByteSourceDescriptor,
+  scope: SourceFactsScope,
+  adapterId: string,
+  options: EpisodeOpenOptions = {},
+): Promise<EpisodeSourceHints | null> {
+  const memory = getSourceSessionHints(source, adapterId);
+  if (memory) {
+    recordLookup("memory-current", 0);
+    return { adapterId, ...memory };
+  }
+  if (options.signal?.aborted) return null;
+
+  const identity = sourceFactsIdentity(source);
+  const key = sourceFactsKey(scope, identity);
+  const startedAt = nowMs();
+  const result = await withLookupDeadline(
+    getSourceFactsPersistence().get(key),
+    options.signal,
+    SOURCE_FACTS_LOOKUP_DEADLINE_MS,
+  );
+  const durationMs = nowMs() - startedAt;
+  if (result === LOOKUP_TIMEOUT) {
+    recordLookup("timeout", durationMs);
+    return null;
+  }
+  if (result === LOOKUP_ABORTED || options.signal?.aborted) return null;
+  if (!result) {
+    recordLookup("miss", durationMs);
+    return null;
+  }
+  if (
+    !sameIdentity(result.identity, identity) ||
+    !sameScope(result.scope, scope)
+  ) {
+    recordLookup("invalid", durationMs);
+    void getSourceFactsPersistence().delete(key);
+    return null;
+  }
+  if (result.adapterId !== adapterId) {
+    recordLookup("stale", durationMs);
+    void getSourceFactsPersistence().delete(key);
+    return null;
+  }
+
+  const validation = validateSourceFactsContent(result.validator, source);
+  if (validation === "stale") {
+    recordLookup("stale", durationMs);
+    void getSourceFactsPersistence().delete(key);
+    return null;
+  }
+  publishDurableSourceFacts(source, {
+    adapterId,
+    facts: result.facts,
+    trust: validation,
+  });
+  recordLookup(
+    validation === "validated" ? "disk-validated" : "disk-provisional",
+    durationMs,
+  );
+
+  if (validation === "provisional" && !source.localFile && !source.etag) {
+    void validateRemoteFactsInBackground({
+      entry: result,
+      key,
+      signal: options.signal,
+      source,
+    });
+  }
+  const hints = getSourceSessionHints(source, adapterId);
+  return hints ? { adapterId, ...hints } : null;
+}
+
+/** Records immutable metadata produced by a successful lightweight preview. */
+export function recordPreviewSourceFacts(
+  source: ByteSourceDescriptor,
+  scope: SourceFactsScope,
+  result: EpisodePreviewReadResult,
+): void {
+  const facts = normalizeSourceFactsPayload({
+    ...(result.bootstrapManifest ? { manifest: result.bootstrapManifest } : {}),
+    ...(result.bootstrapTimeline ? { timeline: result.bootstrapTimeline } : {}),
+    ...(result.bootstrapTimeRange
+      ? { timeRange: result.bootstrapTimeRange }
+      : {}),
+  });
+  if (!facts) return;
+  recordSourceFacts(
+    {
+      adapterId: SOURCE_FACTS_MCAP_ADAPTER_ID,
+      facts,
+      resolveRemoteValidator: false,
+      scope,
+      source,
+    },
+    false,
+  );
+}
+
+/** Records immutable metadata after an authoritative full session opens. */
+export function recordSessionSourceFacts(
+  source: ByteSourceDescriptor,
+  scope: SourceFactsScope,
+  session: EpisodeSession,
+): void {
+  const facts = normalizeSourceFactsPayload({
+    manifest: session.manifest,
+    ...(session.playback?.timeline
+      ? { timeline: session.playback.timeline }
+      : {}),
+    timeRange: session.manifest.timeRange,
+  });
+  if (!facts) return;
+  recordSourceFacts({
+    adapterId: SOURCE_FACTS_MCAP_ADAPTER_ID,
+    facts,
+    resolveRemoteValidator: true,
+    scope,
+    source,
+  });
+}
+
+/** Clears every durable source-facts entry, for account-boundary changes. */
+export function clearSourceFacts(): Promise<void> {
+  return getSourceFactsPersistence().clear();
+}
+
+/** Returns aggregate page diagnostics without source identity. */
+export function getSourceFactsDiagnostics(): SourceFactsDiagnostics {
+  return {
+    encodedBytesWritten,
+    lookupDurationMs: totalLookupDurationMs,
+    lookups: { ...lookupCounts },
+    validationDurationMs: totalValidationDurationMs,
+    validations,
+    writesCompleted,
+    writesFailed,
+    writesStarted,
+  };
+}
+
+/** Resets aggregate diagnostics and queued jobs between tests. */
+export function resetSourceFactsServiceForTests(): void {
+  pendingWrites.clear();
+  Object.assign(lookupCounts, createLookupCounts());
+  totalLookupDurationMs = 0;
+  totalValidationDurationMs = 0;
+  validations = 0;
+  encodedBytesWritten = 0;
+  writesCompleted = 0;
+  writesFailed = 0;
+  writesStarted = 0;
+}
+
+function recordSourceFacts(
+  request: RecordSourceFactsRequest,
+  publishCurrent = true,
+): void {
+  if (request.adapterId !== SOURCE_FACTS_MCAP_ADAPTER_ID) return;
+  const facts = normalizeSourceFactsPayload(request.facts);
+  if (!facts) return;
+  if (publishCurrent) publishCurrentSourceFacts(request.source, facts);
+  const normalizedRequest = { ...request, facts };
+  const key = sourceFactsKey(
+    normalizedRequest.scope,
+    sourceFactsIdentity(normalizedRequest.source),
+  );
+  const current = pendingWrites.get(key);
+  if (current) {
+    if (
+      (current.active && sameWriteFacts(current.active, normalizedRequest)) ||
+      (current.latest && sameWriteFacts(current.latest, normalizedRequest))
+    ) {
+      return;
+    }
+    current.latest = normalizedRequest;
+    return;
+  }
+  const job = {} as PendingWrite;
+  job.active = null;
+  job.latest = normalizedRequest;
+  job.promise = runWriteQueue(key, job).finally(() => {
+    if (pendingWrites.get(key) === job) pendingWrites.delete(key);
+  });
+  pendingWrites.set(key, job);
+}
+
+async function runWriteQueue(key: string, job: PendingWrite): Promise<void> {
+  while (job.latest) {
+    const request = job.latest;
+    job.latest = null;
+    job.active = request;
+    writesStarted++;
+    try {
+      const result = await persistSourceFacts(
+        key,
+        request,
+        getSourceFactsPersistence(),
+      );
+      if (result.stored) {
+        writesCompleted++;
+        encodedBytesWritten += result.byteLength ?? 0;
+      } else {
+        writesFailed++;
+      }
+    } catch {
+      writesFailed++;
+    }
+    job.active = null;
+  }
+}
+
+async function persistSourceFacts(
+  key: string,
+  request: RecordSourceFactsRequest,
+  persistence: SourceFactsPersistence,
+) {
+  let source = request.source;
+  let validator = sourceFactsValidatorFromSource(source);
+  if (!validator && !source.localFile && request.resolveRemoteValidator) {
+    source = (await byteClient.stat?.(source)) ?? source;
+    validator = sourceFactsValidatorFromSource(source);
+  }
+  const entry: StoredSourceFactsV1 = {
+    adapterId: request.adapterId,
+    createdAt: Date.now(),
+    facts: request.facts,
+    identity: sourceFactsIdentity(request.source),
+    scope: request.scope,
+    ...(validator ? { validator } : {}),
+    version: SOURCE_FACTS_SCHEMA_VERSION,
+  };
+  return persistence.put(key, entry);
+}
+
+async function validateRemoteFactsInBackground({
+  entry,
+  key,
+  signal,
+  source,
+}: {
+  readonly entry: StoredSourceFactsV1;
+  readonly key: string;
+  readonly signal?: AbortSignal;
+  readonly source: ByteSourceDescriptor;
+}): Promise<void> {
+  const startedAt = nowMs();
+  let resolved: ByteSourceDescriptor | undefined;
+  try {
+    resolved = await byteClient.stat?.(source, signal);
+  } catch {
+    return;
+  }
+  if (!resolved || signal?.aborted) return;
+  validations++;
+  totalValidationDurationMs += nowMs() - startedAt;
+  const validation = validateSourceFactsContent(entry.validator, resolved);
+  if (validation === "stale") {
+    await getSourceFactsPersistence().delete(key);
+    return;
+  }
+  if (validation !== "validated" || signal?.aborted) return;
+  publishDurableSourceFacts(source, {
+    adapterId: entry.adapterId,
+    facts: entry.facts,
+    trust: "validated",
+  });
+}
+
+const LOOKUP_TIMEOUT = Symbol("source-facts-timeout");
+const LOOKUP_ABORTED = Symbol("source-facts-aborted");
+
+function withLookupDeadline<T>(
+  promise: Promise<T>,
+  signal: AbortSignal | undefined,
+  deadlineMs: number,
+): Promise<T | typeof LOOKUP_TIMEOUT | typeof LOOKUP_ABORTED> {
+  if (signal?.aborted) return Promise.resolve(LOOKUP_ABORTED);
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (
+      value: T | typeof LOOKUP_TIMEOUT | typeof LOOKUP_ABORTED,
+    ) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+      resolve(value);
+    };
+    const onAbort = () => finish(LOOKUP_ABORTED);
+    const timer = setTimeout(() => finish(LOOKUP_TIMEOUT), deadlineMs);
+    signal?.addEventListener("abort", onAbort, { once: true });
+    promise.then(finish, () => finish(null as T));
+  });
+}
+
+function sameIdentity(
+  left: SourceFactsIdentity,
+  right: SourceFactsIdentity,
+): boolean {
+  return (
+    left.sourceId === right.sourceId &&
+    left.canonicalLocator === right.canonicalLocator
+  );
+}
+
+function sameScope(left: SourceFactsScope, right: SourceFactsScope): boolean {
+  return (
+    left.cachePartition === right.cachePartition &&
+    left.datasetId === right.datasetId &&
+    left.mediaField === right.mediaField
+  );
+}
+
+function sameWriteFacts(
+  left: RecordSourceFactsRequest,
+  right: RecordSourceFactsRequest,
+): boolean {
+  return (
+    left.adapterId === right.adapterId &&
+    left.resolveRemoteValidator === right.resolveRemoteValidator &&
+    left.source === right.source &&
+    left.facts.manifest === right.facts.manifest &&
+    left.facts.timeline === right.facts.timeline &&
+    left.facts.timeRange?.startNs === right.facts.timeRange?.startNs &&
+    left.facts.timeRange?.endNs === right.facts.timeRange?.endNs
+  );
+}
+
+function recordLookup(
+  result: SourceFactsLookupResult,
+  durationMs: number,
+): void {
+  lookupCounts[result]++;
+  totalLookupDurationMs += durationMs;
+}
+
+function createLookupCounts(): Record<SourceFactsLookupResult, number> {
+  return {
+    "disk-provisional": 0,
+    "disk-validated": 0,
+    invalid: 0,
+    "memory-current": 0,
+    miss: 0,
+    stale: 0,
+    timeout: 0,
+    unavailable: 0,
+  };
+}
+
+function nowMs(): number {
+  return globalThis.performance?.now?.() ?? Date.now();
+}

--- a/app/packages/multimodal/src/runtime/source-facts.test.ts
+++ b/app/packages/multimodal/src/runtime/source-facts.test.ts
@@ -70,6 +70,19 @@ describe("source facts identity", () => {
     expect(locator).toBe("https://example.com/a/b/run.mcap");
     expect(locator).not.toMatch(/bearer|secret|signature|private|fragment/);
   });
+
+  it("removes credentials from URL-shaped source ids at the facts boundary", () => {
+    const identity = sourceFactsIdentity({
+      sourceId:
+        "remote-url:https://bearer:secret@example.com/run.mcap?signature=private#fragment",
+      url: "https://example.com/run.mcap?signature=private",
+    });
+
+    expect(identity.sourceId).toBe("remote-url:https://example.com/run.mcap");
+    expect(JSON.stringify(identity)).not.toMatch(
+      /bearer|secret|signature|private|fragment/,
+    );
+  });
 });
 
 describe("source facts codec", () => {

--- a/app/packages/multimodal/src/runtime/source-facts.test.ts
+++ b/app/packages/multimodal/src/runtime/source-facts.test.ts
@@ -105,6 +105,23 @@ describe("source facts codec", () => {
     ).toEqual(entry);
   });
 
+  it("round-trips empty metadata and signed recording timestamps", () => {
+    const entry = storedEntry({
+      manifest: {
+        ...manifest(),
+        metadata: {},
+        recordingFacts: {
+          format: "mcap",
+          startTimeNs: "-1",
+        },
+      },
+    });
+
+    expect(
+      decodeStoredSourceFacts(encodeStoredSourceFacts(entry)?.value),
+    ).toEqual(entry);
+  });
+
   it("rejects malformed versions, ranges, domains, duplicates, and empty facts", () => {
     const encoded = encodeStoredSourceFacts(storedEntry());
     if (!encoded) throw new Error("Expected a valid source-facts fixture");
@@ -143,11 +160,19 @@ describe("source facts codec", () => {
 });
 
 describe("source facts validators", () => {
-  it("validates matching ETags and rejects ETag or size changes", () => {
+  it("validates strong ETags, keeps weak matches provisional, and rejects changes", () => {
     const validator = { kind: "etag", etag: "abc", sizeBytes: "100" } as const;
     expect(
       validateSourceFactsContent(validator, {
         etag: 'W/"abc"',
+        sizeBytes: "100",
+        sourceId: "sample-a",
+        url: "/run.mcap",
+      }),
+    ).toBe("provisional");
+    expect(
+      validateSourceFactsContent(validator, {
+        etag: '"abc"',
         sizeBytes: "100",
         sourceId: "sample-a",
         url: "/run.mcap",

--- a/app/packages/multimodal/src/runtime/source-facts.test.ts
+++ b/app/packages/multimodal/src/runtime/source-facts.test.ts
@@ -1,0 +1,314 @@
+import { describe, expect, it } from "vitest";
+import type {
+  ByteSourceDescriptor,
+  EpisodeManifest,
+  EpisodeTimeline,
+} from "../ir";
+import {
+  decodeStoredSourceFacts,
+  encodeStoredSourceFacts,
+} from "./source-facts-codec";
+import {
+  canonicalSourceFactsLocator,
+  SOURCE_FACTS_SCHEMA_VERSION,
+  sourceFactsIdentity,
+  sourceFactsKey,
+  validateSourceFactsContent,
+  type SourceFactsScope,
+  type StoredSourceFactsV1,
+} from "./source-facts";
+
+const SCOPE: SourceFactsScope = {
+  cachePartition: "partition-a",
+  datasetId: "dataset-a",
+  mediaField: "filepath",
+};
+
+describe("source facts identity", () => {
+  it("survives signed media URL rotation without retaining credentials", () => {
+    const first = sourceFactsIdentity({
+      sourceId: "sample-a",
+      url: "https://app.example/media?filepath=%2Fdata%2Frun.mcap&token=secret-a",
+    });
+    const second = sourceFactsIdentity({
+      sourceId: "sample-a",
+      url: "https://app.example/media?token=secret-b&filepath=%2Fdata%2Frun.mcap",
+    });
+
+    expect(sourceFactsKey(SCOPE, first)).toBe(sourceFactsKey(SCOPE, second));
+    expect(first.canonicalLocator).toBe("/data/run.mcap");
+    expect(JSON.stringify(first)).not.toContain("secret");
+  });
+
+  it("keeps full paths and every security/dataset scope dimension distinct", () => {
+    const identity = sourceFactsIdentity(source("/first/run.mcap"));
+    expect(sourceFactsKey(SCOPE, identity)).not.toBe(
+      sourceFactsKey(SCOPE, {
+        ...identity,
+        canonicalLocator: "/second/run.mcap",
+      }),
+    );
+    for (const scope of [
+      { ...SCOPE, cachePartition: "partition-b" },
+      { ...SCOPE, datasetId: "dataset-b" },
+      { ...SCOPE, mediaField: "alternate" },
+    ]) {
+      expect(sourceFactsKey(scope, identity)).not.toBe(
+        sourceFactsKey(SCOPE, identity),
+      );
+    }
+    expect(
+      sourceFactsKey(SCOPE, { ...identity, sourceId: "sample-b" }),
+    ).not.toBe(sourceFactsKey(SCOPE, identity));
+  });
+
+  it("removes URL userinfo, query, fragment, and normalizes separators", () => {
+    const locator = canonicalSourceFactsLocator(
+      "https://bearer:secret@example.com/a\\b/run.mcap?signature=private#fragment",
+    );
+
+    expect(locator).toBe("https://example.com/a/b/run.mcap");
+    expect(locator).not.toMatch(/bearer|secret|signature|private|fragment/);
+  });
+});
+
+describe("source facts codec", () => {
+  it("round-trips manifest, calibration, topology, and timeline bigints", () => {
+    const entry = storedEntry();
+    const encoded = encodeStoredSourceFacts(entry);
+
+    expect(encoded).not.toBeNull();
+    expect(encoded?.value).not.toContain("poster");
+    expect(decodeStoredSourceFacts(encoded?.value)).toEqual(entry);
+  });
+
+  it("round-trips an empty stream inventory", () => {
+    const entry = storedEntry({
+      manifest: { ...manifest(), calibrations: undefined, streams: [] },
+    });
+
+    expect(
+      decodeStoredSourceFacts(encodeStoredSourceFacts(entry)?.value),
+    ).toEqual(entry);
+  });
+
+  it("rejects malformed versions, ranges, domains, duplicates, and empty facts", () => {
+    const encoded = encodeStoredSourceFacts(storedEntry());
+    if (!encoded) throw new Error("Expected a valid source-facts fixture");
+    expect(
+      decodeStoredSourceFacts(
+        encoded.value.replace('"version":1', '"version":2'),
+      ),
+    ).toBeNull();
+    expect(
+      encodeStoredSourceFacts(
+        storedEntry({ timeRange: { endNs: 1n, startNs: 2n } }),
+      ),
+    ).toBeNull();
+    expect(
+      encodeStoredSourceFacts(
+        storedEntry({
+          manifest: {
+            ...manifest(),
+            streams: [manifest().streams[0], manifest().streams[0]],
+          },
+        }),
+      ),
+    ).toBeNull();
+    expect(
+      encodeStoredSourceFacts(
+        storedEntry({ timeline: { ...timeline(), timeDomainId: "publish" } }),
+      ),
+    ).toBeNull();
+    expect(
+      encodeStoredSourceFacts({
+        ...storedEntry(),
+        facts: {},
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("source facts validators", () => {
+  it("validates matching ETags and rejects ETag or size changes", () => {
+    const validator = { kind: "etag", etag: "abc", sizeBytes: "100" } as const;
+    expect(
+      validateSourceFactsContent(validator, {
+        etag: 'W/"abc"',
+        sizeBytes: "100",
+        sourceId: "sample-a",
+        url: "/run.mcap",
+      }),
+    ).toBe("validated");
+    expect(
+      validateSourceFactsContent(validator, {
+        etag: "different",
+        sizeBytes: "100",
+        sourceId: "sample-a",
+        url: "/run.mcap",
+      }),
+    ).toBe("stale");
+    expect(
+      validateSourceFactsContent(validator, {
+        sizeBytes: "101",
+        sourceId: "sample-a",
+        url: "/run.mcap",
+      }),
+    ).toBe("stale");
+  });
+
+  it("requires the complete local-file signature", () => {
+    const file = new File([new Uint8Array(10)], "run.mcap", {
+      lastModified: 42,
+    });
+    const sourceWithFile: ByteSourceDescriptor = {
+      localFile: file,
+      sourceId: "local",
+      url: "local-file:run.mcap",
+    };
+    expect(
+      validateSourceFactsContent(
+        {
+          kind: "local-file",
+          lastModified: 42,
+          name: "run.mcap",
+          sizeBytes: "10",
+        },
+        sourceWithFile,
+      ),
+    ).toBe("validated");
+    expect(
+      validateSourceFactsContent(
+        {
+          kind: "local-file",
+          lastModified: 41,
+          name: "run.mcap",
+          sizeBytes: "10",
+        },
+        sourceWithFile,
+      ),
+    ).toBe("stale");
+  });
+});
+
+function storedEntry(
+  facts: Partial<StoredSourceFactsV1["facts"]> = {},
+): StoredSourceFactsV1 {
+  return {
+    adapterId: "mcap",
+    createdAt: 1_725_000_000_000,
+    facts: {
+      manifest: manifest(),
+      timeline: timeline(),
+      timeRange: { endNs: 20n, startNs: 10n },
+      ...facts,
+    },
+    identity: {
+      canonicalLocator: "/data/run.mcap",
+      sourceId: "sample-a",
+    },
+    scope: SCOPE,
+    validator: { etag: "abc", kind: "etag", sizeBytes: "100" },
+    version: SOURCE_FACTS_SCHEMA_VERSION,
+  };
+}
+
+function manifest(): EpisodeManifest {
+  return {
+    calibrations: [
+      {
+        calibration: {
+          D: [0.1, 0.2],
+          K: [1, 0, 2, 0, 1, 3, 0, 0, 1],
+          P: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0],
+          R: [1, 0, 0, 0, 1, 0, 0, 0, 1],
+          height: 480,
+          kind: "camera-calibration",
+          roi: {
+            doRectify: false,
+            height: 480,
+            width: 640,
+            xOffset: 0,
+            yOffset: 0,
+          },
+          timestampNs: 10n,
+          width: 640,
+        },
+        streamId: "camera-info",
+      },
+    ],
+    episodeId: "sample-a",
+    metadata: { profile: "test" },
+    recordingFacts: {
+      applicationSupport: {
+        inspectableStreamCount: 1,
+        renderableStreamCount: 1,
+        unavailableStreamCount: 0,
+      },
+      format: "mcap",
+      mcap: {
+        attachments: [
+          { dataSizeBytes: "4", mediaType: "text/plain", name: "note" },
+        ],
+        compression: [
+          {
+            chunkCount: 1,
+            codec: "zstd",
+            compressedBytes: "50",
+            uncompressedBytes: "100",
+          },
+        ],
+        messageIndexStatus: "complete",
+      },
+      messageCount: "1",
+      sizeBytes: "100",
+    },
+    streams: [
+      {
+        id: "camera",
+        kind: "image",
+        metadata: { "mcap.topic": "/camera" },
+        payload: {
+          encoding: "jpeg",
+          schema: "sensor_msgs/CompressedImage",
+          schemaEncoding: "ros2msg",
+        },
+        sourceName: "/camera",
+        timeRange: { endNs: 20n, startNs: 10n },
+      },
+    ],
+    timeDomain: { id: "log", kind: "timestamp", originNs: 10n },
+    timeRange: { endNs: 20n, startNs: 10n },
+    transformTopology: {
+      edges: [
+        {
+          childFrameId: "camera",
+          parentFrameId: "vehicle",
+          sourceStreamId: "tf-static",
+        },
+      ],
+    },
+  };
+}
+
+function timeline(): EpisodeTimeline {
+  return {
+    byteTimeline: [
+      {
+        cumulativeCompressedBytes: 50,
+        endTimeNs: 20n,
+        startOffsetBytes: 0n,
+      },
+    ],
+    endNs: 20n,
+    startNs: 10n,
+    timeDomainId: "log",
+  };
+}
+
+function source(path: string): ByteSourceDescriptor {
+  return {
+    sourceId: "sample-a",
+    url: `https://app.example/media?filepath=${encodeURIComponent(path)}`,
+  };
+}

--- a/app/packages/multimodal/src/runtime/source-facts.ts
+++ b/app/packages/multimodal/src/runtime/source-facts.ts
@@ -1,0 +1,220 @@
+import type {
+  ByteSourceDescriptor,
+  EpisodeManifest,
+  EpisodeTimeline,
+  TimeWindow,
+} from "../ir";
+
+/** Current source-facts storage schema. Incompatible changes invalidate V1. */
+export const SOURCE_FACTS_SCHEMA_VERSION = 1 as const;
+
+/** OSS origin-local namespace. Authenticated compositions must supply another partition. */
+export const OSS_SOURCE_FACTS_CACHE_PARTITION = "fiftyone-oss-origin";
+
+/** Adapter whose immutable facts V1 understands and persists. */
+export const SOURCE_FACTS_MCAP_ADAPTER_ID = "mcap";
+
+/** Maximum time a local durable lookup may add to source opening. */
+export const SOURCE_FACTS_LOOKUP_DEADLINE_MS = 50;
+
+/** Provenance attached to source facts retained in memory. */
+export type SourceFactsTrust = "current" | "validated" | "provisional";
+
+/** Security and dataset boundary for one durable source-facts key. */
+export interface SourceFactsScope {
+  readonly cachePartition: string;
+  readonly datasetId: string;
+  readonly mediaField: string | null;
+}
+
+/** Credential-free logical identity for one recording. */
+export interface SourceFactsIdentity {
+  readonly canonicalLocator: string;
+  readonly sourceId: string;
+}
+
+/** Content evidence retained with immutable source facts. */
+export type SourceFactsValidator =
+  | {
+      readonly kind: "etag";
+      readonly etag: string;
+      readonly sizeBytes?: string;
+    }
+  | {
+      readonly kind: "local-file";
+      readonly lastModified: number;
+      readonly name: string;
+      readonly sizeBytes: string;
+    };
+
+/** Immutable metadata learned while inspecting an episode source. */
+export interface SourceFactsPayload {
+  readonly manifest?: EpisodeManifest;
+  readonly timeRange?: TimeWindow;
+  readonly timeline?: EpisodeTimeline;
+}
+
+/** Validated in-memory representation of one V1 durable entry. */
+export interface StoredSourceFactsV1 {
+  readonly adapterId: string;
+  readonly createdAt: number;
+  readonly facts: SourceFactsPayload;
+  readonly identity: SourceFactsIdentity;
+  readonly scope: SourceFactsScope;
+  readonly validator?: SourceFactsValidator;
+  readonly version: typeof SOURCE_FACTS_SCHEMA_VERSION;
+}
+
+/** Outcome of comparing persisted content evidence with the active source. */
+export type SourceFactsValidationResult = "validated" | "provisional" | "stale";
+
+/** Creates the credential-free durable identity for a byte source. */
+export function sourceFactsIdentity(
+  source: ByteSourceDescriptor,
+): SourceFactsIdentity {
+  return {
+    canonicalLocator: canonicalSourceFactsLocator(source.url),
+    sourceId: source.sourceId,
+  };
+}
+
+/** Creates the durable logical key used by IndexedDB. */
+export function sourceFactsKey(
+  scope: SourceFactsScope,
+  identity: SourceFactsIdentity,
+): string {
+  return JSON.stringify([
+    SOURCE_FACTS_SCHEMA_VERSION,
+    scope.cachePartition,
+    scope.datasetId,
+    scope.mediaField,
+    identity.sourceId,
+    identity.canonicalLocator,
+  ]);
+}
+
+/**
+ * Returns a stable full-path locator without query credentials. FiftyOne's
+ * media proxy carries the backing path in `filepath`; all other URLs retain
+ * their scheme/host/path identity while dropping query and fragment data.
+ */
+export function canonicalSourceFactsLocator(sourceUrl: string): string {
+  const parsed = parseUrl(sourceUrl);
+  const proxiedPath = parsed?.searchParams.get("filepath");
+  return normalizeCredentialFreeLocator(proxiedPath || sourceUrl);
+}
+
+/** Returns content evidence already available on the active descriptor. */
+export function sourceFactsValidatorFromSource(
+  source: ByteSourceDescriptor,
+): SourceFactsValidator | undefined {
+  const file = source.localFile;
+  if (file) {
+    return {
+      kind: "local-file",
+      lastModified: file.lastModified,
+      name: file.name,
+      sizeBytes: String(file.size),
+    };
+  }
+  const etag = normalizedEtag(source.etag);
+  return etag
+    ? {
+        kind: "etag",
+        etag,
+        ...(source.sizeBytes ? { sizeBytes: source.sizeBytes } : {}),
+      }
+    : undefined;
+}
+
+/** Classifies persisted evidence against the active descriptor. */
+export function validateSourceFactsContent(
+  stored: SourceFactsValidator | undefined,
+  source: ByteSourceDescriptor,
+): SourceFactsValidationResult {
+  const current = sourceFactsValidatorFromSource(source);
+  if (current?.kind === "local-file") {
+    return stored?.kind === "local-file" &&
+      stored.lastModified === current.lastModified &&
+      stored.name === current.name &&
+      stored.sizeBytes === current.sizeBytes
+      ? "validated"
+      : "stale";
+  }
+  if (stored?.kind === "local-file") return "stale";
+
+  if (
+    source.sizeBytes &&
+    stored?.sizeBytes &&
+    source.sizeBytes !== stored.sizeBytes
+  ) {
+    return "stale";
+  }
+  if (current?.kind === "etag" && stored?.kind === "etag") {
+    return current.etag === normalizedEtag(stored.etag) ? "validated" : "stale";
+  }
+  return "provisional";
+}
+
+/**
+ * Normalizes scheduling facts before they enter memory or storage. Timeline
+ * bounds are authoritative; a manifest range is the final fallback.
+ */
+export function normalizeSourceFactsPayload(
+  facts: SourceFactsPayload,
+): SourceFactsPayload | null {
+  const timeRange = facts.timeline
+    ? { endNs: facts.timeline.endNs, startNs: facts.timeline.startNs }
+    : (facts.timeRange ?? facts.manifest?.timeRange);
+  if (!facts.manifest && !facts.timeline && !timeRange) return null;
+  return {
+    ...(facts.manifest ? { manifest: facts.manifest } : {}),
+    ...(facts.timeline ? { timeline: facts.timeline } : {}),
+    ...(timeRange ? { timeRange } : {}),
+  };
+}
+
+function normalizeCredentialFreeLocator(locator: string): string {
+  const value = locator.trim().replaceAll("\\", "/");
+  const parsed = parseUrl(value);
+  if (parsed && hasExplicitScheme(value)) {
+    parsed.username = "";
+    parsed.password = "";
+    parsed.search = "";
+    parsed.hash = "";
+    parsed.pathname = normalizePath(parsed.pathname);
+    return parsed.toString();
+  }
+  const withoutCredentials = value.split(/[?#]/, 1)[0];
+  return normalizePath(withoutCredentials);
+}
+
+function normalizePath(path: string): string {
+  const leadingSlash = path.startsWith("/");
+  const normalized = path.replace(/\/{2,}/g, "/");
+  return leadingSlash && !normalized.startsWith("/")
+    ? `/${normalized}`
+    : normalized;
+}
+
+function parseUrl(value: string): URL | null {
+  try {
+    return new URL(value, "http://fiftyone.invalid");
+  } catch {
+    return null;
+  }
+}
+
+function hasExplicitScheme(value: string): boolean {
+  return /^[a-z][a-z\d+.-]*:/i.test(value);
+}
+
+function normalizedEtag(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim().replace(/^W\//i, "");
+  const unquoted =
+    trimmed.startsWith('"') && trimmed.endsWith('"') && trimmed.length >= 2
+      ? trimmed.slice(1, -1)
+      : trimmed;
+  return unquoted || undefined;
+}

--- a/app/packages/multimodal/src/runtime/source-facts.ts
+++ b/app/packages/multimodal/src/runtime/source-facts.ts
@@ -151,7 +151,13 @@ export function validateSourceFactsContent(
     return "stale";
   }
   if (current?.kind === "etag" && stored?.kind === "etag") {
-    return current.etag === normalizedEtag(stored.etag) ? "validated" : "stale";
+    const storedEtag = normalizedEtag(stored.etag);
+    if (!storedEtag || etagValue(current.etag) !== etagValue(storedEtag)) {
+      return "stale";
+    }
+    return isWeakEtag(current.etag) || isWeakEtag(storedEtag)
+      ? "provisional"
+      : "validated";
   }
   return "provisional";
 }
@@ -219,10 +225,20 @@ function hasExplicitScheme(value: string): boolean {
 
 function normalizedEtag(value: string | undefined): string | undefined {
   if (!value) return undefined;
-  const trimmed = value.trim().replace(/^W\//i, "");
+  const trimmed = value.trim();
+  const weak = isWeakEtag(trimmed);
+  const opaque = weak ? trimmed.slice(2).trim() : trimmed;
   const unquoted =
-    trimmed.startsWith('"') && trimmed.endsWith('"') && trimmed.length >= 2
-      ? trimmed.slice(1, -1)
-      : trimmed;
-  return unquoted || undefined;
+    opaque.startsWith('"') && opaque.endsWith('"') && opaque.length >= 2
+      ? opaque.slice(1, -1)
+      : opaque;
+  return unquoted ? `${weak ? "W/" : ""}${unquoted}` : undefined;
+}
+
+function isWeakEtag(value: string): boolean {
+  return /^W\//i.test(value);
+}
+
+function etagValue(value: string): string {
+  return isWeakEtag(value) ? value.slice(2) : value;
 }

--- a/app/packages/multimodal/src/runtime/source-facts.ts
+++ b/app/packages/multimodal/src/runtime/source-facts.ts
@@ -74,7 +74,7 @@ export function sourceFactsIdentity(
 ): SourceFactsIdentity {
   return {
     canonicalLocator: canonicalSourceFactsLocator(source.url),
-    sourceId: source.sourceId,
+    sourceId: credentialFreeSourceFactsSourceId(source.sourceId),
   };
 }
 
@@ -187,6 +187,14 @@ function normalizeCredentialFreeLocator(locator: string): string {
   }
   const withoutCredentials = value.split(/[?#]/, 1)[0];
   return normalizePath(withoutCredentials);
+}
+
+function credentialFreeSourceFactsSourceId(sourceId: string): string {
+  const embeddedUrl = /[a-z][a-z\d+.-]*:\/\//i.exec(sourceId);
+  if (!embeddedUrl || embeddedUrl.index === undefined) return sourceId;
+  return `${sourceId.slice(0, embeddedUrl.index)}${normalizeCredentialFreeLocator(
+    sourceId.slice(embeddedUrl.index),
+  )}`;
 }
 
 function normalizePath(path: string): string {

--- a/app/packages/multimodal/src/views/episode/grid/GridRenderer.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/GridRenderer.tsx
@@ -81,7 +81,11 @@ export function GridRenderer({
   isGridActive = true,
   onRetainedBytesChange,
 }: SampleRendererProps) {
-  const { byteSource: source, episodeSource } = useStableEpisodeSource(ctx);
+  const {
+    byteSource: source,
+    episodeSource,
+    sourceFactsScope,
+  } = useStableEpisodeSource(ctx);
   const gridCameraScopeKey =
     cameraScopeKey(ctx.dataset.datasetId, ctx.media?.field) ??
     ctx.dataset.datasetId;
@@ -181,6 +185,7 @@ export function GridRenderer({
     previewSessionStatus: previewSession.status,
     selectedSourceName,
     source,
+    sourceFactsScope,
   });
   const registerStreams = useRegisterGridStreams();
   const stableStreams = useStableGridStreams(preview.streamSourceNames);

--- a/app/packages/multimodal/src/views/episode/grid/grid-poster-persistence.test.ts
+++ b/app/packages/multimodal/src/views/episode/grid/grid-poster-persistence.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment node
+
+import { IDBFactory } from "fake-indexeddb";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  requestResult,
+  transactionDone,
+} from "../../../runtime/persistence/indexeddb";
+import type { GridPosterCacheEntry } from "./grid-poster-cache";
+import {
+  createIndexedDbGridPosterPersistence,
+  GRID_POSTER_DATABASE_NAME,
+} from "./grid-poster-persistence";
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("grid poster persistence", () => {
+  it("round-trips encoded posters through IndexedDB", async () => {
+    const persistence = createIndexedDbGridPosterPersistence({
+      factory: new IDBFactory(),
+    });
+    const entry = poster([1, 2, 3]);
+
+    await persistence.put("poster", entry);
+
+    await expect(persistence.get("poster")).resolves.toEqual(entry);
+  });
+
+  it("evicts the oldest poster under the configured entry budget", async () => {
+    const now = vi.spyOn(Date, "now");
+    now.mockReturnValue(3).mockReturnValueOnce(1).mockReturnValueOnce(2);
+    const persistence = createIndexedDbGridPosterPersistence({
+      factory: new IDBFactory(),
+      maxEntries: 1,
+      maxSizeBytes: 1_000,
+    });
+    const newest = poster([2]);
+
+    await persistence.put("a-oldest", poster([1]));
+    await persistence.put("b-newest", newest);
+
+    await expect(persistence.get("a-oldest")).resolves.toBeNull();
+    await expect(persistence.get("b-newest")).resolves.toEqual(newest);
+  });
+
+  it("evicts the oldest poster under the configured byte budget", async () => {
+    const now = vi.spyOn(Date, "now");
+    now.mockReturnValue(3).mockReturnValueOnce(1).mockReturnValueOnce(2);
+    const persistence = createIndexedDbGridPosterPersistence({
+      factory: new IDBFactory(),
+      maxEntries: 10,
+      maxSizeBytes: 2,
+    });
+    const newest = poster([3]);
+
+    await persistence.put("a-oldest", poster([1, 2]));
+    await persistence.put("b-newest", newest);
+
+    await expect(persistence.get("a-oldest")).resolves.toBeNull();
+    await expect(persistence.get("b-newest")).resolves.toEqual(newest);
+  });
+
+  it("accounts for replacement bytes without evicting valid posters", async () => {
+    const factory = new IDBFactory();
+    const persistence = createIndexedDbGridPosterPersistence({
+      factory,
+      maxEntries: 2,
+      maxSizeBytes: 3,
+    });
+    const replacement = poster([4]);
+    const second = poster([5, 6]);
+
+    await persistence.put("replacement", poster([1, 2, 3]));
+    await persistence.put("replacement", replacement);
+    await persistence.put("second", second);
+
+    await expect(persistence.get("replacement")).resolves.toEqual(replacement);
+    await expect(persistence.get("second")).resolves.toEqual(second);
+  });
+
+  it("deletes a corrupt poster discovered during a read", async () => {
+    const factory = new IDBFactory();
+    const persistence = createIndexedDbGridPosterPersistence({ factory });
+    await persistence.put("seed", poster([1]));
+    const database = await requestResult<IDBDatabase>(
+      factory.open(GRID_POSTER_DATABASE_NAME),
+    );
+    const corruptWrite = database.transaction("entries", "readwrite");
+    const corruptWritten = transactionDone(corruptWrite);
+    corruptWrite.objectStore("entries").put(
+      {
+        bytes: new Blob(),
+        version: 1,
+      },
+      "corrupt",
+    );
+    await corruptWritten;
+
+    await expect(persistence.get("corrupt")).resolves.toBeNull();
+    const check = database.transaction("entries", "readonly");
+    const checked = transactionDone(check);
+    await expect(
+      requestResult(check.objectStore("entries").get("corrupt")),
+    ).resolves.toBeUndefined();
+    await checked;
+    database.close();
+  });
+});
+
+function poster(bytes: readonly number[]): GridPosterCacheEntry {
+  return {
+    bytes: new Uint8Array(bytes),
+    height: 10,
+    mimeType: "image/webp",
+    sourceKind: "image",
+    streamId: "camera",
+    streamSourceName: "/camera",
+    streamSourceNames: ["/camera"],
+    width: 10,
+  };
+}

--- a/app/packages/multimodal/src/views/episode/grid/grid-poster-persistence.ts
+++ b/app/packages/multimodal/src/views/episode/grid/grid-poster-persistence.ts
@@ -2,9 +2,14 @@ import type {
   GridPosterCacheEntry,
   GridPosterCacheKey,
 } from "./grid-poster-cache";
+import {
+  createIndexedDbConnection,
+  requestResult,
+  transactionDone,
+} from "../../../runtime/persistence/indexeddb";
 
 const MIB = 1024 * 1024;
-const DATABASE_NAME = "fiftyone-multimodal-grid-posters";
+export const GRID_POSTER_DATABASE_NAME = "fiftyone-multimodal-grid-posters";
 const DATABASE_VERSION = 1;
 const ENTRY_STORE = "entries";
 const RECENCY_STORE = "recency";
@@ -37,36 +42,41 @@ export interface GridPosterPersistence {
   put(key: GridPosterCacheKey, entry: GridPosterCacheEntry): Promise<void>;
 }
 
+/** Testable limits and factory for the grid-poster repository. */
+export interface GridPosterPersistenceOptions {
+  readonly factory?: IDBFactory | null;
+  readonly maxEntries?: number;
+  readonly maxSizeBytes?: number;
+}
+
 /**
  * Creates the reload-surviving grid-poster tier. Every operation is
  * best-effort: storage denial, quota pressure, corruption, and unsupported
  * runtimes all degrade to a miss without affecting preview rendering.
  */
-function createIndexedDbGridPosterPersistence(): GridPosterPersistence {
-  let databasePromise: Promise<IDBDatabase | null> | null = null;
+export function createIndexedDbGridPosterPersistence(
+  options: GridPosterPersistenceOptions = {},
+): GridPosterPersistence {
+  const maxEntries = options.maxEntries ?? DEFAULT_MAX_ENTRIES;
+  const maxSizeBytes = options.maxSizeBytes ?? DEFAULT_MAX_SIZE_BYTES;
+  const connection = createIndexedDbConnection({
+    name: GRID_POSTER_DATABASE_NAME,
+    ...(options.factory !== undefined
+      ? { resolveFactory: () => options.factory }
+      : {}),
+    upgrade: upgradeGridPosterDatabase,
+    version: DATABASE_VERSION,
+  });
   const pendingReads = new Map<
     GridPosterCacheKey,
     Promise<GridPosterCacheEntry | null>
   >();
   let evictionChain = Promise.resolve();
 
-  const open = () => {
-    if (databasePromise) return databasePromise;
-    const invalidate = () => {
-      if (databasePromise === current) databasePromise = null;
-    };
-    const current = openDatabase(invalidate).then((database) => {
-      if (!database) invalidate();
-      return database;
-    });
-    databasePromise = current;
-    return current;
-  };
-
   const read = async (
     key: GridPosterCacheKey,
   ): Promise<GridPosterCacheEntry | null> => {
-    const database = await open();
+    const database = await connection.open();
     if (!database) return null;
     try {
       const stored = await readStoredEntry(database, key);
@@ -94,19 +104,16 @@ function createIndexedDbGridPosterPersistence(): GridPosterPersistence {
     },
 
     async put(key, entry) {
-      if (
-        !validEntry(entry) ||
-        entry.bytes.byteLength > DEFAULT_MAX_SIZE_BYTES
-      ) {
+      if (!validEntry(entry) || entry.bytes.byteLength > maxSizeBytes) {
         return;
       }
-      const database = await open();
+      const database = await connection.open();
       if (!database) return;
       try {
         const totals = await writeStoredEntry(database, key, entry, Date.now());
         if (
-          totals.entryCount <= DEFAULT_MAX_ENTRIES &&
-          totals.sizeBytes <= DEFAULT_MAX_SIZE_BYTES
+          totals.entryCount <= maxEntries &&
+          totals.sizeBytes <= maxSizeBytes
         ) {
           return;
         }
@@ -114,13 +121,7 @@ function createIndexedDbGridPosterPersistence(): GridPosterPersistence {
         // race totals or run several cursor sweeps at once.
         evictionChain = evictionChain
           .catch(() => undefined)
-          .then(() =>
-            enforceBudget(
-              database,
-              DEFAULT_MAX_ENTRIES,
-              DEFAULT_MAX_SIZE_BYTES,
-            ),
-          );
+          .then(() => enforceBudget(database, maxEntries, maxSizeBytes));
         await evictionChain;
       } catch {
         // The memory tier has already accepted the poster. Persistence is an
@@ -142,55 +143,19 @@ export function resetGridPosterPersistenceForTests(
   singleton = persistence ?? createIndexedDbGridPosterPersistence();
 }
 
-function openDatabase(onClose: () => void): Promise<IDBDatabase | null> {
-  const factory = (globalThis as typeof globalThis & { indexedDB?: IDBFactory })
-    .indexedDB;
-  if (!factory) return Promise.resolve(null);
-
-  return new Promise((resolve) => {
-    let settled = false;
-    const finish = (database: IDBDatabase | null) => {
-      if (settled) {
-        database?.close();
-        return;
-      }
-      settled = true;
-      resolve(database);
-    };
-    let request: IDBOpenDBRequest;
-    try {
-      request = factory.open(DATABASE_NAME, DATABASE_VERSION);
-    } catch {
-      finish(null);
-      return;
-    }
-    request.onupgradeneeded = () => {
-      const database = request.result;
-      if (!database.objectStoreNames.contains(ENTRY_STORE)) {
-        database.createObjectStore(ENTRY_STORE);
-      }
-      if (!database.objectStoreNames.contains(RECENCY_STORE)) {
-        const store = database.createObjectStore(RECENCY_STORE, {
-          keyPath: "key",
-        });
-        store.createIndex(RECENCY_INDEX, "lastAccessedAt");
-      }
-      if (!database.objectStoreNames.contains(STATE_STORE)) {
-        database.createObjectStore(STATE_STORE);
-      }
-    };
-    request.onsuccess = () => {
-      const database = request.result;
-      database.onclose = onClose;
-      database.onversionchange = () => {
-        database.close();
-        onClose();
-      };
-      finish(database);
-    };
-    request.onerror = () => finish(null);
-    request.onblocked = () => finish(null);
-  });
+function upgradeGridPosterDatabase(database: IDBDatabase): void {
+  if (!database.objectStoreNames.contains(ENTRY_STORE)) {
+    database.createObjectStore(ENTRY_STORE);
+  }
+  if (!database.objectStoreNames.contains(RECENCY_STORE)) {
+    const store = database.createObjectStore(RECENCY_STORE, {
+      keyPath: "key",
+    });
+    store.createIndex(RECENCY_INDEX, "lastAccessedAt");
+  }
+  if (!database.objectStoreNames.contains(STATE_STORE)) {
+    database.createObjectStore(STATE_STORE);
+  }
 }
 
 async function readStoredEntry(
@@ -430,22 +395,4 @@ function normalizeTotals(
     entryCount: Math.max(0, Math.floor(totals?.entryCount ?? 0)),
     sizeBytes: Math.max(0, Math.floor(totals?.sizeBytes ?? 0)),
   };
-}
-
-function requestResult<T>(request: IDBRequest): Promise<T> {
-  return new Promise((resolve, reject) => {
-    request.onsuccess = () => resolve(request.result as T);
-    request.onerror = () =>
-      reject(request.error ?? new Error("Grid poster storage request failed"));
-  });
-}
-
-function transactionDone(transaction: IDBTransaction): Promise<void> {
-  return new Promise((resolve, reject) => {
-    transaction.oncomplete = () => resolve();
-    transaction.onabort = () =>
-      reject(transaction.error ?? new Error("Grid poster transaction aborted"));
-    transaction.onerror = () =>
-      reject(transaction.error ?? new Error("Grid poster transaction failed"));
-  });
 }

--- a/app/packages/multimodal/src/views/episode/grid/use-grid-preview.ts
+++ b/app/packages/multimodal/src/views/episode/grid/use-grid-preview.ts
@@ -8,6 +8,8 @@ import type { EpisodePreviewSession } from "../../../ports";
 import {
   episodePreviewPlaybackDelayMs,
   publishEpisodePreviewBootstrap,
+  recordPreviewSourceFacts,
+  type SourceFactsScope,
 } from "../../../runtime";
 import { errorMessage } from "../status/error-message";
 import type { GridPosterCacheEntry } from "./grid-poster-cache";
@@ -70,6 +72,7 @@ export interface UseGridPreviewOptions {
     | "unavailable";
   readonly selectedSourceName?: string | null;
   readonly source: ByteSourceDescriptor | null;
+  readonly sourceFactsScope?: SourceFactsScope;
 }
 
 /** Suppresses buffering chrome for ordinary fast grid frame reads. */
@@ -104,6 +107,7 @@ export function useGridPreview({
   previewSessionStatus = "idle",
   selectedSourceName,
   source,
+  sourceFactsScope,
 }: UseGridPreviewOptions): GridPreviewState {
   const [state, setState] = useState<GridPreviewSnapshot>(() =>
     seededSnapshot(source, cachedPoster),
@@ -238,6 +242,9 @@ export function useGridPreview({
         if (active) {
           notifyReadResult(onReadResultRef.current, result);
           publishEpisodePreviewBootstrap(source, result);
+          if (sourceFactsScope) {
+            recordPreviewSourceFacts(source, sourceFactsScope, result);
+          }
           loadedRequestRef.current = {
             posterStartTimeNs,
             source,
@@ -277,6 +284,7 @@ export function useGridPreview({
     posterStartTimeNs,
     previewSession,
     source,
+    sourceFactsScope,
   ]);
 
   // This effect runs the hover playback loop: while playing, it keeps
@@ -359,6 +367,9 @@ export function useGridPreview({
 
           if (!bootstrapPublished) {
             publishEpisodePreviewBootstrap(source, result);
+            if (sourceFactsScope) {
+              recordPreviewSourceFacts(source, sourceFactsScope, result);
+            }
             bootstrapPublished = true;
           }
 
@@ -395,6 +406,7 @@ export function useGridPreview({
     playing,
     previewSession,
     source,
+    sourceFactsScope,
     startBuffering,
     state.status,
   ]);

--- a/app/packages/multimodal/src/views/episode/shell/ModalRenderer.tsx
+++ b/app/packages/multimodal/src/views/episode/shell/ModalRenderer.tsx
@@ -23,7 +23,11 @@ import { useTimeRange } from "../playback/use-time-range";
  * source-oriented host shared with the ad hoc episode panel.
  */
 const ModalRenderer: React.FC<SampleRendererProps> = ({ ctx }) => {
-  const { byteSource: source, episodeSource } = useStableEpisodeSource(ctx);
+  const {
+    byteSource: source,
+    episodeSource,
+    sourceFactsScope,
+  } = useStableEpisodeSource(ctx);
   const sampleDescriptor = sampleDescriptorFromContext(ctx);
   const sessionState = useEpisodeSession(sampleDescriptor, episodeSource);
   const timeRange = useTimeRange(sessionState.session);
@@ -87,6 +91,7 @@ const ModalRenderer: React.FC<SampleRendererProps> = ({ ctx }) => {
             session={sessionState.session}
             sessionError={sessionState.error}
             source={source}
+            sourceFactsScope={sourceFactsScope}
             tracks={tracks}
           >
             {runtime}

--- a/app/packages/multimodal/src/views/episode/shell/SourcePlayback.test.tsx
+++ b/app/packages/multimodal/src/views/episode/shell/SourcePlayback.test.tsx
@@ -65,6 +65,12 @@ const playbackHarness = vi.hoisted(() => {
   return harness;
 });
 
+const sourceFactsHarness = vi.hoisted(() => ({
+  recordSessionSourceFacts: vi.fn(),
+}));
+
+vi.mock("../../../runtime/source-facts-service", () => sourceFactsHarness);
+
 vi.mock("./PlaybackShell", () => {
   const MockPlaybackShell = ({
     children,
@@ -225,6 +231,7 @@ describe("SourcePlayback", () => {
       () => playbackHarness.modalLayoutResult,
     );
     playbackHarness.useSceneInventoryState.mockClear();
+    sourceFactsHarness.recordSessionSourceFacts.mockReset();
   });
 
   afterEach(() => {
@@ -289,6 +296,49 @@ describe("SourcePlayback", () => {
     expect(screen.getByTestId("settings-stream-term").textContent).toBe(
       "topics",
     );
+  });
+
+  it("does not record a prior session under the next source", () => {
+    const firstSource = createSource("source-a");
+    const nextSource = createSource("source-b");
+    const scope = {
+      cachePartition: "partition",
+      datasetId: "dataset",
+      mediaField: "filepath",
+    } as const;
+    const session = {
+      activate: vi.fn(),
+      manifest: {
+        ...bootstrapManifest("/camera"),
+        episodeId: firstSource.sourceId,
+      },
+    } as unknown as EpisodeSession;
+    playbackHarness.sceneInventory = readyInventory("/camera");
+    const view = render(
+      <SourcePlayback
+        fileName="source-a.mcap"
+        session={session}
+        source={firstSource}
+        sourceFactsScope={scope}
+      />,
+    );
+    expect(sourceFactsHarness.recordSessionSourceFacts).toHaveBeenCalledWith(
+      firstSource,
+      scope,
+      session,
+    );
+    sourceFactsHarness.recordSessionSourceFacts.mockClear();
+
+    view.rerender(
+      <SourcePlayback
+        fileName="source-b.mcap"
+        session={session}
+        source={nextSource}
+        sourceFactsScope={scope}
+      />,
+    );
+
+    expect(sourceFactsHarness.recordSessionSourceFacts).not.toHaveBeenCalled();
   });
 
   it("builds the destination shell and poster from a buffered grid bootstrap", () => {

--- a/app/packages/multimodal/src/views/episode/shell/SourcePlayback.tsx
+++ b/app/packages/multimodal/src/views/episode/shell/SourcePlayback.tsx
@@ -205,7 +205,12 @@ export const SourcePlayback: React.FC<SourcePlaybackProps> = ({
 
   // This effect records authoritative session metadata off the ready path.
   useEffect(() => {
-    if (session && source && sourceFactsScope) {
+    if (
+      session &&
+      source &&
+      sourceFactsScope &&
+      session.manifest.episodeId === source.sourceId
+    ) {
       recordSessionSourceFacts(source, sourceFactsScope, session);
     }
   }, [session, source, sourceFactsScope]);

--- a/app/packages/multimodal/src/views/episode/shell/SourcePlayback.tsx
+++ b/app/packages/multimodal/src/views/episode/shell/SourcePlayback.tsx
@@ -24,6 +24,8 @@ import type {
 import type { SceneSource } from "../../../scene-inventory";
 import { sceneSourcesFromStreamDescriptors } from "../../../stream-selection/scene-sources";
 import { episodeSourceAccessKey } from "../../../runtime/episode-resources";
+import { recordSessionSourceFacts } from "../../../runtime/source-facts-service";
+import type { SourceFactsScope } from "../../../runtime/source-facts";
 import { EpisodePlaybackStoreProvider } from "../../../runtime/react/playback-store-context";
 import { useSourceBootstrap } from "../../../runtime/react/source-bootstrap";
 import { createScheduledSourceReadBudgetAccount } from "../../../runtime/scheduled-read-budget-account";
@@ -138,6 +140,7 @@ export interface SourcePlaybackProps {
   /** Optional maximum expanded track-body height. */
   readonly timelineDrawerMaxSize?: number;
   readonly source: ByteSourceDescriptor | null;
+  readonly sourceFactsScope?: SourceFactsScope;
   readonly tracks?: readonly Track[];
 }
 
@@ -164,6 +167,7 @@ export const SourcePlayback: React.FC<SourcePlaybackProps> = ({
   session,
   sessionError = null,
   source,
+  sourceFactsScope,
   tracks,
 }) => {
   const imageAspectRatiosRef = useRef<Record<string, number>>({});
@@ -198,6 +202,13 @@ export const SourcePlayback: React.FC<SourcePlaybackProps> = ({
       releaseRetainedImageTextures();
     };
   }, []);
+
+  // This effect records authoritative session metadata off the ready path.
+  useEffect(() => {
+    if (session && source && sourceFactsScope) {
+      recordSessionSourceFacts(source, sourceFactsScope, session);
+    }
+  }, [session, source, sourceFactsScope]);
 
   const { status, error, sources, streams, streamCount } =
     useSceneInventoryState({

--- a/app/packages/multimodal/src/views/mcap-explorer/McapExplorerPanel.test.tsx
+++ b/app/packages/multimodal/src/views/mcap-explorer/McapExplorerPanel.test.tsx
@@ -77,8 +77,7 @@ describe("McapExplorerPanel", () => {
     });
     expect(viewerHarness.lastPlaybackProps?.source).toEqual({
       readProfile: BYTE_SOURCE_READ_PROFILE.REMOTE,
-      sourceId:
-        "remote-url:https://example.com/path/recording.mcap?signature=1",
+      sourceId: "remote-url:https://example.com/path/recording.mcap",
       url: "https://example.com/path/recording.mcap?signature=1",
     });
     expect(screen.queryByText("Drag & drop an MCAP file")).toBeNull();

--- a/app/packages/multimodal/src/views/mcap-explorer/McapExplorerPanel.test.tsx
+++ b/app/packages/multimodal/src/views/mcap-explorer/McapExplorerPanel.test.tsx
@@ -77,7 +77,8 @@ describe("McapExplorerPanel", () => {
     });
     expect(viewerHarness.lastPlaybackProps?.source).toEqual({
       readProfile: BYTE_SOURCE_READ_PROFILE.REMOTE,
-      sourceId: "remote-url:https://example.com/path/recording.mcap",
+      sourceId:
+        "remote-url:https://example.com/path/recording.mcap?signature=1",
       url: "https://example.com/path/recording.mcap?signature=1",
     });
     expect(screen.queryByText("Drag & drop an MCAP file")).toBeNull();

--- a/app/packages/multimodal/src/views/mcap-explorer/McapExplorerPanel.tsx
+++ b/app/packages/multimodal/src/views/mcap-explorer/McapExplorerPanel.tsx
@@ -14,6 +14,10 @@ import {
 import React, { useCallback, useMemo, useRef, useState } from "react";
 import { hasMcapCloudSourceResolver } from "../../extensions/mcap-explorer";
 import type { ByteSourceDescriptor } from "../../ir/index";
+import {
+  OSS_SOURCE_FACTS_CACHE_PARTITION,
+  type SourceFactsScope,
+} from "../../runtime";
 import { diagnosticMessage } from "../../utils/errors";
 import { episodeSourceFromByteSource } from "../session/episode-source";
 import { useEpisodeSession } from "../session/use-episode-session";
@@ -35,6 +39,12 @@ type ViewerError = {
   readonly target: "file" | "url";
 };
 
+const EXPLORER_SOURCE_FACTS_SCOPE: SourceFactsScope = {
+  cachePartition: OSS_SOURCE_FACTS_CACHE_PARTITION,
+  datasetId: "mcap-explorer",
+  mediaField: null,
+};
+
 const McapExplorerPanel: React.FC = () => {
   const [active, setActive] = useState<ActiveAnyMcapSource | null>(null);
   const [dragging, setDragging] = useState(false);
@@ -44,7 +54,13 @@ const McapExplorerPanel: React.FC = () => {
   const dragDepthRef = useRef(0);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const episodeSource = useMemo(
-    () => (active ? episodeSourceFromByteSource(active.source) : null),
+    () =>
+      active
+        ? episodeSourceFromByteSource(
+            active.source,
+            EXPLORER_SOURCE_FACTS_SCOPE,
+          )
+        : null,
     [active],
   );
   const sessionState = useEpisodeSession(
@@ -209,6 +225,7 @@ const McapExplorerPanel: React.FC = () => {
             session={sessionState.session}
             sessionError={sessionState.error}
             source={active.source}
+            sourceFactsScope={EXPLORER_SOURCE_FACTS_SCOPE}
           />
         </div>
       ) : (

--- a/app/packages/multimodal/src/views/mcap-explorer/McapExplorerPanel.tsx
+++ b/app/packages/multimodal/src/views/mcap-explorer/McapExplorerPanel.tsx
@@ -17,7 +17,7 @@ import type { ByteSourceDescriptor } from "../../ir/index";
 import {
   OSS_SOURCE_FACTS_CACHE_PARTITION,
   type SourceFactsScope,
-} from "../../runtime";
+} from "../../runtime/source-facts";
 import { diagnosticMessage } from "../../utils/errors";
 import { episodeSourceFromByteSource } from "../session/episode-source";
 import { useEpisodeSession } from "../session/use-episode-session";

--- a/app/packages/multimodal/src/views/mcap-explorer/source-descriptors.test.ts
+++ b/app/packages/multimodal/src/views/mcap-explorer/source-descriptors.test.ts
@@ -46,7 +46,8 @@ describe("any MCAP source descriptors", () => {
       fileName: "drive.mcap",
       source: {
         readProfile: BYTE_SOURCE_READ_PROFILE.REMOTE,
-        sourceId: "remote-url:https://example.com/recordings/drive.mcap",
+        sourceId:
+          "remote-url:https://example.com/recordings/drive.mcap?signature=1",
         url: "https://example.com/recordings/drive.mcap?signature=1",
       },
     });

--- a/app/packages/multimodal/src/views/mcap-explorer/source-descriptors.test.ts
+++ b/app/packages/multimodal/src/views/mcap-explorer/source-descriptors.test.ts
@@ -46,8 +46,7 @@ describe("any MCAP source descriptors", () => {
       fileName: "drive.mcap",
       source: {
         readProfile: BYTE_SOURCE_READ_PROFILE.REMOTE,
-        sourceId:
-          "remote-url:https://example.com/recordings/drive.mcap?signature=1",
+        sourceId: "remote-url:https://example.com/recordings/drive.mcap",
         url: "https://example.com/recordings/drive.mcap?signature=1",
       },
     });

--- a/app/packages/multimodal/src/views/mcap-explorer/source-descriptors.ts
+++ b/app/packages/multimodal/src/views/mcap-explorer/source-descriptors.ts
@@ -94,20 +94,12 @@ function createResolvedRemoteMcapSourceDescriptor(
     fileName: sourceDisplayName(sourceIdentity) ?? "remote.mcap",
     source: {
       readProfile: BYTE_SOURCE_READ_PROFILE.REMOTE,
-      sourceId: `remote-url:${credentialFreeSourceIdentity(sourceIdentity)}`,
+      // Byte caches need the complete access identity. Source-facts storage
+      // applies its credential-free identity at its own boundary.
+      sourceId: `remote-url:${sourceIdentity}`,
       url: href,
     },
   };
-}
-
-function credentialFreeSourceIdentity(value: string): string {
-  if (!/^https?:\/\//i.test(value)) return value.split(/[?#]/, 1)[0];
-  const url = new URL(value);
-  url.username = "";
-  url.password = "";
-  url.search = "";
-  url.hash = "";
-  return url.toString();
 }
 
 function parseHttpUrl(

--- a/app/packages/multimodal/src/views/mcap-explorer/source-descriptors.ts
+++ b/app/packages/multimodal/src/views/mcap-explorer/source-descriptors.ts
@@ -94,10 +94,20 @@ function createResolvedRemoteMcapSourceDescriptor(
     fileName: sourceDisplayName(sourceIdentity) ?? "remote.mcap",
     source: {
       readProfile: BYTE_SOURCE_READ_PROFILE.REMOTE,
-      sourceId: `remote-url:${sourceIdentity}`,
+      sourceId: `remote-url:${credentialFreeSourceIdentity(sourceIdentity)}`,
       url: href,
     },
   };
+}
+
+function credentialFreeSourceIdentity(value: string): string {
+  if (!/^https?:\/\//i.test(value)) return value.split(/[?#]/, 1)[0];
+  const url = new URL(value);
+  url.username = "";
+  url.password = "";
+  url.search = "";
+  url.hash = "";
+  return url.toString();
 }
 
 function parseHttpUrl(

--- a/app/packages/multimodal/src/views/session/episode-source.ts
+++ b/app/packages/multimodal/src/views/session/episode-source.ts
@@ -7,7 +7,12 @@ import { getSampleSrc } from "@fiftyone/state";
 
 import { BYTE_SOURCE_READ_PROFILE, type ByteSourceDescriptor } from "../../ir";
 import type { EpisodeSource, SampleDescriptor } from "../../ports";
-import { getSourceBootstrap } from "../../runtime";
+import {
+  getSourceSessionHints,
+  resolveSourceFactsHints,
+  SOURCE_FACTS_MCAP_ADAPTER_ID,
+  type SourceFactsScope,
+} from "../../runtime";
 
 /** Builds the format-neutral sample facts used by lazy adapter detection. */
 export function sampleDescriptorFromContext(
@@ -48,8 +53,9 @@ export function episodeByteSourceFromSample(
 /** Wraps one physical recording in the multi-asset episode port. */
 export function episodeSourceFromByteSource(
   source: ByteSourceDescriptor,
+  sourceFactsScope?: SourceFactsScope,
 ): EpisodeSource {
-  const bootstrap = getSourceBootstrap(source);
+  const hints = getSourceSessionHints(source, SOURCE_FACTS_MCAP_ADAPTER_ID);
   return {
     assets: {
       list: async () => [
@@ -66,8 +72,19 @@ export function episodeSourceFromByteSource(
       },
     },
     episodeId: source.sourceId,
-    ...(bootstrap?.manifest ? { manifestHint: bootstrap.manifest } : {}),
-    ...(bootstrap?.timeline ? { playbackHint: bootstrap.timeline } : {}),
+    ...(hints?.manifestHint ? { manifestHint: hints.manifestHint } : {}),
+    ...(hints?.playbackHint ? { playbackHint: hints.playbackHint } : {}),
+    ...(sourceFactsScope
+      ? {
+          resolveHints: (options) =>
+            resolveSourceFactsHints(
+              source,
+              sourceFactsScope,
+              SOURCE_FACTS_MCAP_ADAPTER_ID,
+              options,
+            ),
+        }
+      : {}),
   };
 }
 

--- a/app/packages/multimodal/src/views/session/use-stable-episode-source.ts
+++ b/app/packages/multimodal/src/views/session/use-stable-episode-source.ts
@@ -3,7 +3,11 @@ import { useMemo, useRef } from "react";
 
 import type { ByteSourceDescriptor } from "../../ir";
 import type { EpisodeSource } from "../../ports";
-import { episodeSourceAccessKey } from "../../runtime";
+import {
+  episodeSourceAccessKey,
+  OSS_SOURCE_FACTS_CACHE_PARTITION,
+  type SourceFactsScope,
+} from "../../runtime";
 import {
   episodeByteSourceFromContext,
   episodeSourceFromByteSource,
@@ -13,8 +17,19 @@ import {
 export function useStableEpisodeSource(ctx: SampleRendererProps["ctx"]): {
   readonly byteSource: ByteSourceDescriptor | null;
   readonly episodeSource: EpisodeSource | null;
+  readonly sourceFactsScope: SourceFactsScope;
 } {
   const next = episodeByteSourceFromContext(ctx);
+  const datasetId = ctx.dataset.datasetId;
+  const mediaField = ctx.media?.field ?? null;
+  const sourceFactsScope = useMemo(
+    () => ({
+      cachePartition: OSS_SOURCE_FACTS_CACHE_PARTITION,
+      datasetId,
+      mediaField,
+    }),
+    [datasetId, mediaField],
+  );
   const sourceKey = next ? episodeSourceAccessKey(next) : "";
   const ref = useRef<{
     readonly byteSource: ByteSourceDescriptor | null;
@@ -26,8 +41,11 @@ export function useStableEpisodeSource(ctx: SampleRendererProps["ctx"]): {
   }
   const byteSource = ref.current.byteSource;
   const episodeSource = useMemo(
-    () => (byteSource ? episodeSourceFromByteSource(byteSource) : null),
-    [byteSource],
+    () =>
+      byteSource
+        ? episodeSourceFromByteSource(byteSource, sourceFactsScope)
+        : null,
+    [byteSource, sourceFactsScope],
   );
-  return { byteSource, episodeSource };
+  return { byteSource, episodeSource, sourceFactsScope };
 }

--- a/app/packages/multimodal/src/views/session/use-stable-episode-source.ts
+++ b/app/packages/multimodal/src/views/session/use-stable-episode-source.ts
@@ -3,11 +3,11 @@ import { useMemo, useRef } from "react";
 
 import type { ByteSourceDescriptor } from "../../ir";
 import type { EpisodeSource } from "../../ports";
+import { episodeSourceAccessKey } from "../../runtime/episode-resources";
 import {
-  episodeSourceAccessKey,
   OSS_SOURCE_FACTS_CACHE_PARTITION,
   type SourceFactsScope,
-} from "../../runtime";
+} from "../../runtime/source-facts";
 import {
   episodeByteSourceFromContext,
   episodeSourceFromByteSource,

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2181,6 +2181,7 @@ __metadata:
     colormap: "catalog:"
     concurrently: "npm:^7.2.1"
     date-fns: "npm:^4.1.0"
+    fake-indexeddb: "npm:^6.2.5"
     hyparquet: "npm:^1.26.2"
     jotai: "catalog:"
     lru-cache: "catalog:"
@@ -10712,6 +10713,13 @@ __metadata:
   version: 3.0.2
   resolution: "extend@npm:3.0.2"
   checksum: 10/59e89e2dc798ec0f54b36d82f32a27d5f6472c53974f61ca098db5d4648430b725387b53449a34df38fd0392045434426b012f302b3cc049a6500ccf82877e4e
+  languageName: node
+  linkType: hard
+
+"fake-indexeddb@npm:^6.2.5":
+  version: 6.2.5
+  resolution: "fake-indexeddb@npm:6.2.5"
+  checksum: 10/a0b6a81413a8dd40d3ae31d6158ffa8a3d113981b11644e206874847c454d5a1519a9fe2b6008d8f66d5630ba96b3da43789a20b6462a0e7cadc008caea15ae8
   languageName: node
   linkType: hard
 

--- a/e2e-pw/src/oss/poms/multimodal/episode.ts
+++ b/e2e-pw/src/oss/poms/multimodal/episode.ts
@@ -69,6 +69,21 @@ export class EpisodePom {
     ).toBeHidden();
   }
 
+  /** Verifies useful episode topology is visible before source reads recover. */
+  async expectWarmBootstrapShell(
+    fileName: string,
+    tileTitles: readonly string[],
+  ): Promise<void> {
+    await expect(this.shell).toBeVisible({ timeout: READY_TIMEOUT });
+    await expect(this.scope.getByText(fileName, { exact: true })).toBeVisible({
+      timeout: READY_TIMEOUT,
+    });
+    await this.expectTileTitles(tileTitles);
+    await expect(
+      byDataTestId(this.scope, "episode-preparing-scaffold"),
+    ).toBeHidden();
+  }
+
   async navigateDatasetSample(
     direction: "forward" | "backward",
     fileName: string,

--- a/e2e-pw/src/oss/specs/mcap-correctness.spec.ts
+++ b/e2e-pw/src/oss/specs/mcap-correctness.spec.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import type { ConsoleMessage } from "@playwright/test";
+import type { ConsoleMessage, Page } from "@playwright/test";
 import { test as base, expect, Locator } from "src/oss/fixtures";
 import { GridPom } from "src/oss/poms/grid";
 import { McapExplorerPom } from "src/oss/poms/multimodal/mcap-explorer";
@@ -20,6 +20,7 @@ const alternateMediaDatasetName = getUniqueDatasetNameWithPrefix(
 const fixtureDir = path.join(os.tmpdir(), datasetName);
 const originalMultimodalFlag = process.env.VFF_MULTIMODAL;
 const RENDERER_ERROR_PATTERN = /(?:webgpu|webgl|graphics renderer|gpu device)/i;
+const SOURCE_FACTS_DATABASE_NAME = "fiftyone-multimodal-source-facts";
 const { long, sidebar, tinyA, tinyB, unsupported } = MCAP_FIXTURE_CONTRACT;
 const fixturePaths = {
   episodeA: path.join(fixtureDir, tinyA.fileName),
@@ -276,6 +277,39 @@ for dataset_name in ["${datasetName}", "${alternateMediaDatasetName}"]:
     await modal.episode.expectPlayhead(
       "2024-01-01 00:00:00.000 / 2024-01-01 00:00:02.000",
     );
+    await modal.episode.expectNoViewerError();
+  });
+
+  test("restores the episode shell from source facts after reload and reopen", async ({
+    grid,
+    modal,
+    page,
+  }) => {
+    await openMcapModal(grid, modal, sampleIndex.episodeA);
+    await modal.episode.waitForReady(tinyA.fileName);
+    await expect
+      .poll(() => sourceFactsEntryCount(page), { timeout: 10_000 })
+      .toBeGreaterThan(0);
+
+    await modal.close();
+    await page.evaluate(async () => {
+      await Promise.all((await caches.keys()).map((key) => caches.delete(key)));
+    });
+    await page.reload();
+    await expect(grid.locator).toBeVisible({ timeout: 30_000 });
+
+    const sourceUrl = new RegExp(tinyA.fileName.replace(/\./g, "\\."));
+    await page.route(sourceUrl, (route) => route.abort("failed"));
+    await openMcapModal(grid, modal, sampleIndex.episodeA);
+    await modal.episode.expectWarmBootstrapShell(tinyA.fileName, [
+      "camera/front",
+      "points",
+    ]);
+
+    await modal.close();
+    await page.unroute(sourceUrl);
+    await openMcapModal(grid, modal, sampleIndex.episodeA);
+    await modal.episode.waitForReady(tinyA.fileName);
     await modal.episode.expectNoViewerError();
   });
 
@@ -920,6 +954,30 @@ async function openMcapModal(
   // multimodal never mounts the classic sidebar (it has its own right panel),
   // so there's nothing to hide and no toggle to hide it with
   await modal.enterFullscreen();
+}
+
+async function sourceFactsEntryCount(page: Page): Promise<number> {
+  return page.evaluate(async (databaseName) => {
+    const databases = await indexedDB.databases();
+    if (!databases.some((database) => database.name === databaseName)) return 0;
+    return new Promise<number>((resolve) => {
+      const request = indexedDB.open(databaseName);
+      request.onerror = () => resolve(0);
+      request.onsuccess = () => {
+        const database = request.result;
+        if (!database.objectStoreNames.contains("entries")) {
+          database.close();
+          resolve(0);
+          return;
+        }
+        const transaction = database.transaction("entries", "readonly");
+        const count = transaction.objectStore("entries").count();
+        count.onerror = () => resolve(0);
+        count.onsuccess = () => resolve(count.result);
+        transaction.oncomplete = () => database.close();
+      };
+    });
+  }, SOURCE_FACTS_DATABASE_NAME);
 }
 
 async function setRepresentativeSidebarPreferences(

--- a/e2e-pw/src/oss/specs/patch-label-overlays.spec.ts
+++ b/e2e-pw/src/oss/specs/patch-label-overlays.spec.ts
@@ -7,7 +7,7 @@
  * render in the bubble, and the last shown attribute locks so at least one
  * always renders.
  */
-import { test as base, expect } from "src/oss/fixtures";
+import { test as base } from "src/oss/fixtures";
 import { GridPom } from "src/oss/poms/grid";
 import { SidebarPom } from "src/oss/poms/sidebar";
 import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

Persist immutable MCAP manifest, timeline, and time-range facts in a bounded IndexedDB cache. Warm modal reopens can restore the episode shell after a page reload, while only content-validated entries are allowed to skip authoritative adapter inspection.

The cache uses credential-free logical media identity, keeps provisional and validated facts separate, writes from both previews and full sessions, and fails open on storage, validation, timeout, or quota errors.

## 🧪 How is this patch tested? If it is not, please explain why.

- `yarn workspace @fiftyone/multimodal check`
- `yarn vitest run --no-coverage packages/multimodal/src` — 3,246 passed, 2 skipped
- `yarn lint` in `e2e-pw`
- `fo-e2e run --grep "restores the episode shell from source facts after reload and reopen" src/oss/specs/mcap-correctness.spec.ts -- --repeat-each=3` — 3/3 passed
- Opened a remote MCAP sample in the modal, reloaded the app, reopened the sample, and verified the warm shell and final frame.

## Notes to Reviewer

Best reviewed commit-by-commit:

- Source-facts model, codec, IndexedDB repository, and budget enforcement
- Provenance-aware bootstrap hydration and one-shot adapter hints
- Preview/modal integration, cancellation handling, and reload E2E coverage

## High Level Architecture

The runtime owns a separate IndexedDB database containing metadata only. The in-memory bootstrap cache keeps current-page facts separate from durable provisional or validated facts. The modal resolves local facts alongside adapter loading; provisional facts may hydrate the shell, but only current or validator-matched facts reach the adapter as hints.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Multimodal MCAP episodes now restore cached stream and timeline metadata across page reloads, reducing warm modal reopen time.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3858
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added durable source-facts caching to speed episode previews and session startup.
  * Episodes can reuse validated manifest and playback hints across reloads.
  * Added scoped source-facts support for MCAP Explorer datasets.
  * Added public APIs for source hints, persistence, diagnostics, and cache management.
  * Added bounded browser storage with automatic cleanup of older or oversized entries.

* **Bug Fixes**
  * Improved cancellation handling for metadata and network requests.
  * Improved fallback behavior when cached or remote source information is unavailable.

* **Tests**
  * Added coverage for persistence, validation, cancellation, fallback loading, and warm bootstrap behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->