### PR TITLE
Disable npm major updates in Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -50,6 +50,11 @@
             "matchManagers": ["npm"],
             "matchDepNames": ["minimatch", "brace-expansion"],
             "enabled": false
+        },
+        {
+            "matchManagers": ["npm"],
+            "matchUpdateTypes": ["major"],
+            "enabled": false
         }
     ],
     "vulnerabilityAlerts": {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds a Renovate package rule disabling major npm updates:

```json
{
    "matchManagers": ["npm"],
    "matchUpdateTypes": ["major"],
    "enabled": false
}
```

## How is this patch tested? If it is not, please explain why.

Config-only change; JSON validated locally. Renovate picks it up on its next weekly run.

## What areas of FiftyOne does this PR affect?

- [ ] `App`
- [ ] `Build`
- [ ] `Core`
- [ ] `Documentation`
- [x] `Other`: CI/dependency automation

## Notes

- The grouped "app-dependencies (major)" PR (#8300) bundles ~70 major bumps (React 19, MUI 9, Relay 21, eslint 10, ...) into one unreviewable PR. Major upgrades of that size are deliberate migration projects and will be done as dedicated PRs instead.
- Renovate should auto-close #8300 on its next run once this merges.
- Minor/patch npm rollups and the Python group are unaffected.
- Security-fix PRs still fire for majors via `vulnerabilityAlerts.enabled: true`.
- Downstream repos with the same Renovate config should apply the same rule.

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3862
<!-- enterprise-sync-pr:end -->