### PR TITLE
Migrate EndSession to strawberry SchemaExtension

### DIFF
--- a/fiftyone/server/extensions.py
+++ b/fiftyone/server/extensions.py
@@ -8,12 +8,12 @@ FiftyOne Server extensions
 import traceback
 
 from graphql import GraphQLError
-from strawberry.extensions import Extension
-from strawberry.utils.await_maybe import AwaitableOrValue
+from strawberry.extensions import SchemaExtension
 
 
-class EndSession(Extension):
-    async def on_request_end(self) -> AwaitableOrValue[None]:
+class EndSession(SchemaExtension):
+    async def on_operation(self):
+        yield
         result = self.execution_context.result
         if getattr(result, "errors", None):
             result.errors = [


### PR DESCRIPTION
## What changes are proposed in this pull request?

Migrates `fiftyone/server/extensions.py` off strawberry-graphql's legacy `Extension` base class to `SchemaExtension`, rewriting the removed `on_request_end` hook as a generator-style `on_operation` hook (post-`yield` code runs at operation end, preserving the existing behavior of attaching stack traces to GraphQL errors).

The legacy `Extension` alias and hook API were removed from strawberry-graphql after our current ceiling (`<0.317`), which is what makes the Renovate bump in #8299 crash the server at startup (`ImportError: cannot import name 'Extension' from 'strawberry.extensions'`).

## How is this patch tested? If it is not, please explain why.

Verified against both ends of the range in isolated venvs: strawberry-graphql 0.316.0 (current pin) and 0.324.0 (proposed bump). In both, a schema using `EndSession` attaches `extensions.stack` to errors and preserves message/path/source, and error-free queries pass through untouched. The existing `tests/isolated/service_tests.py::test_server` exercises server startup in CI.

## What areas of FiftyOne does this PR affect?

- [ ] `App`
- [ ] `Build`
- [x] `Core`: `fiftyone` Python server code
- [ ] `Documentation`

## Notes

- Compatible with the currently pinned strawberry range, so this can merge independently of and ahead of any version bump.
- Once merged, #8299's `strawberry-graphql>=0.324.0,<0.325.0` bump needs a merge of `develop` into its branch to pick this up.
- Remaining strawberry migration debt (not in this PR): `strawberry.scalar()` class-passing in `fiftyone/server/scalars.py` emits deprecation warnings on 0.324.

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3864
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-of-operation session handling.
  * Preserved existing post-operation error transformation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->