### PR TITLE
docs: release notes for FiftyOne Enterprise 2.24.1

### DIFF
--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -7,8 +7,6 @@ FiftyOne Enterprise 2.24.1
 --------------------------
 *Released August 21, 2026*
 
-Includes all updates from :ref:`FiftyOne 1.21.0 <release-notes-v1.21.0>`, plus:
-
 - Fixed a bug that prevented embeddings and similarity search on camera
   streams using ROS image schemas
 - Multimodal stream discovery is now cached, so the embeddings form opens

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -3,6 +3,26 @@ FiftyOne Release Notes
 
 .. default-role:: code
 
+FiftyOne Enterprise 2.24.1
+--------------------------
+*Released August 20, 2026*
+
+Includes all updates from :ref:`FiftyOne 1.21.1 <release-notes-v1.21.1>`, plus:
+
+- Fixed a bug where camera streams using ROS `Image` and `CompressedImage`
+  schemas were not recognized as embeddable, preventing embeddings and
+  similarity search on those streams
+- Multimodal stream discovery is now cached and parallelized, so the
+  embeddings form opens much faster on large datasets
+
+.. _release-notes-v1.21.1:
+
+FiftyOne 1.21.1
+---------------
+*Released August 20, 2026*
+
+.. TODO: add entries once the 1.21.1 cherry-picks are finalized
+
 FiftyOne Enterprise 2.24.0
 --------------------------
 *Released August 19, 2026*

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -7,21 +7,13 @@ FiftyOne Enterprise 2.24.1
 --------------------------
 *Released August 20, 2026*
 
-Includes all updates from :ref:`FiftyOne 1.21.1 <release-notes-v1.21.1>`, plus:
+Includes all updates from :ref:`FiftyOne 1.21.0 <release-notes-v1.21.0>`, plus:
 
 - Fixed a bug where camera streams using ROS `Image` and `CompressedImage`
   schemas were not recognized as embeddable, preventing embeddings and
   similarity search on those streams
 - Multimodal stream discovery is now cached and parallelized, so the
   embeddings form opens much faster on large datasets
-
-.. _release-notes-v1.21.1:
-
-FiftyOne 1.21.1
----------------
-*Released August 20, 2026*
-
-.. TODO: add entries once the 1.21.1 cherry-picks are finalized
 
 FiftyOne Enterprise 2.24.0
 --------------------------

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -5,15 +5,14 @@ FiftyOne Release Notes
 
 FiftyOne Enterprise 2.24.1
 --------------------------
-*Released August 20, 2026*
+*Released August 21, 2026*
 
 Includes all updates from :ref:`FiftyOne 1.21.0 <release-notes-v1.21.0>`, plus:
 
-- Fixed a bug where camera streams using ROS `Image` and `CompressedImage`
-  schemas were not recognized as embeddable, preventing embeddings and
-  similarity search on those streams
-- Multimodal stream discovery is now cached and parallelized, so the
-  embeddings form opens much faster on large datasets
+- Fixed a bug that prevented embeddings and similarity search on camera
+  streams using ROS image schemas
+- Multimodal stream discovery is now cached, so the embeddings form opens
+  much faster
 
 FiftyOne Enterprise 2.24.0
 --------------------------


### PR DESCRIPTION
Draft notes for the 2.24.1 / 1.21.1 patch. The OSS 1.21.1 section is a placeholder until the cherry-pick set is final — will update when fiftyone-teams#3853 and the decoders PR land.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added release notes for FiftyOne Enterprise 2.24.1, released August 21, 2026.
  * Documented fixes for embeddings and similarity search on ROS image-schema camera streams.
  * Documented improved performance when discovering multimodal streams for the embeddings form through caching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3866
<!-- enterprise-sync-pr:end -->