### PR TITLE
docs: release notes for FiftyOne Enterprise 2.24.1

### DIFF
--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -3,6 +3,15 @@ FiftyOne Release Notes
 
 .. default-role:: code
 
+FiftyOne Enterprise 2.24.1
+--------------------------
+*Released August 21, 2026*
+
+- Fixed a bug that prevented embeddings and similarity search on camera
+  streams using ROS image schemas
+- Multimodal stream discovery is now cached, so the embeddings form opens
+  much faster
+
 FiftyOne Enterprise 2.24.0
 --------------------------
 *Released August 19, 2026*


### PR DESCRIPTION
Cherry-pick of #8312 onto the docs-publish line (Enterprise-only release — no OSS release branch to carry the notes). Publishes via the docs-patch flow at release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)