### PR TITLE
Align grouped direct PCDs in the world frame

### DIFF
--- a/app/packages/looker-3d/src/annotation/CreateCuboidRenderer.test.tsx
+++ b/app/packages/looker-3d/src/annotation/CreateCuboidRenderer.test.tsx
@@ -29,6 +29,7 @@ const mocks = vi.hoisted(() => ({
   setEditingToNewCuboid: vi.fn(),
   setTransformMode: vi.fn(),
   useEmptyCanvasInteraction: vi.fn(),
+  directPcdWorldTransformsBySampleId: {} as Record<string, unknown>,
 }));
 
 vi.mock("@fiftyone/annotation", () => ({
@@ -39,6 +40,10 @@ vi.mock("@fiftyone/annotation", () => ({
     },
   }),
   useSceneSampleId: () => "scene-sample",
+}));
+
+vi.mock("@fiftyone/state", () => ({
+  useStableSceneSample3d: () => ({ sample: { _id: "scene-sample" } }),
 }));
 
 vi.mock("@fiftyone/utilities", () => ({
@@ -54,6 +59,13 @@ vi.mock("recoil", () => ({
 
 vi.mock("../hooks/use-empty-canvas-interaction", () => ({
   useEmptyCanvasInteraction: mocks.useEmptyCanvasInteraction,
+}));
+
+vi.mock("../fo3d/context", () => ({
+  useFo3dContext: () => ({
+    directPcdWorldTransformsBySampleId:
+      mocks.directPcdWorldTransformsBySampleId,
+  }),
 }));
 
 // The renderer reads live scene point clouds (via useThree under the hood) to
@@ -115,6 +127,7 @@ describe("CreateCuboidRenderer", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.directPcdWorldTransformsBySampleId = {};
     creationStateValue = INITIAL_CREATION_STATE;
 
     (useRecoilState as Mock).mockImplementation((atom) => {
@@ -233,5 +246,36 @@ describe("CreateCuboidRenderer", () => {
     expect(mocks.setTransformMode).toHaveBeenCalledWith("scale");
     // Create mode exits after a cuboid is placed; press C to start another.
     expect(setIsCreatingCuboid).toHaveBeenCalledWith(false);
+  });
+
+  it("stores a world-created cuboid in the target PCD native frame", () => {
+    creationStateValue = STEP_TWO_CREATION_STATE;
+    mocks.directPcdWorldTransformsBySampleId = {
+      "scene-sample": {
+        translation: [10, 0, 0],
+        quaternion: [0, 0, 0, 1],
+        source_frame: "lidar_top",
+        target_frame: "world",
+      },
+    };
+
+    render(<CreateCuboidRenderer />);
+    triggerCommitClick();
+
+    expect(mocks.createCuboid).toHaveBeenCalledWith(
+      "new-cuboid-id",
+      expect.objectContaining({
+        location: [-9.5, 0.5, 0],
+        dimensions: [1, 1, 1],
+        quaternion: [0, 0, 1, 0],
+      }),
+      "ground_truth",
+      "vehicle",
+    );
+    expect(mocks.setEditingToNewCuboid).toHaveBeenCalledWith(
+      "new-cuboid-id",
+      expect.objectContaining({ location: [-9.5, 0.5, 0] }),
+      "vehicle",
+    );
   });
 });

--- a/app/packages/looker-3d/src/annotation/CreateCuboidRenderer.tsx
+++ b/app/packages/looker-3d/src/annotation/CreateCuboidRenderer.tsx
@@ -1,9 +1,12 @@
 import { useAnnotationEventBus } from "@fiftyone/annotation";
+import * as fos from "@fiftyone/state";
 import { objectId } from "@fiftyone/utilities";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 import * as THREE from "three";
 import { useEmptyCanvasInteraction } from "../hooks/use-empty-canvas-interaction";
+import { useFo3dContext } from "../fo3d/context";
+import { transformCuboidToNativeFrame } from "../fo3d/direct-pcd-world-alignment";
 import { useScenePointClouds } from "../hooks/use-scene-point-clouds";
 import { useSelect3DLabelForAnnotation } from "../hooks/useSelect3DLabelForAnnotation";
 import type { CuboidCreationState } from "../types";
@@ -45,6 +48,8 @@ export const CreateCuboidRenderer = ({
   ignoreEffects = false,
 }: CreateCuboidRendererProps) => {
   const currentActiveField = useRecoilValue(currentActiveAnnotationField3dAtom);
+  const sceneSampleId = fos.useStableSceneSample3d()?.sample?._id;
+  const { directPcdWorldTransformsBySampleId } = useFo3dContext();
   const [isCreatingCuboid, setIsCreatingCuboid] =
     useRecoilState(isCreatingCuboidAtom);
   const selectForAnnotation = useSelect3DLabelForAnnotation();
@@ -188,11 +193,17 @@ export const CreateCuboidRenderer = ({
 
         const labelClass = getDefaultLabel(currentActiveField, workingDoc);
 
-        const transformData: CuboidTransformData = {
+        const worldTransformData: CuboidTransformData = {
           location: roundTuple(fittedCuboid.location),
           dimensions: roundTuple(fittedCuboid.dimensions),
           quaternion: roundTuple(previewCuboid.quaternion),
         };
+        const nativeToWorld = sceneSampleId
+          ? directPcdWorldTransformsBySampleId[sceneSampleId]
+          : undefined;
+        const transformData = nativeToWorld
+          ? transformCuboidToNativeFrame(worldTransformData, nativeToWorld)
+          : worldTransformData;
 
         createCuboid(labelId, transformData, currentActiveField, labelClass);
 
@@ -234,6 +245,8 @@ export const CreateCuboidRenderer = ({
       setTransformMode,
       resetCuboidCreation,
       workingDoc,
+      sceneSampleId,
+      directPcdWorldTransformsBySampleId,
     ],
   );
 

--- a/app/packages/looker-3d/src/annotation/usePointCloudCrop.ts
+++ b/app/packages/looker-3d/src/annotation/usePointCloudCrop.ts
@@ -36,7 +36,12 @@ export const usePointCloudCrop = ({
   enabled = true,
 }: UsePointCloudCropOptions = {}) => {
   const mode = fos.useModalMode();
-  const { pluginSettings, pointCloudSettings, upVector } = useFo3dContext();
+  const {
+    directPcdWorldTransformsBySampleId,
+    pluginSettings,
+    pointCloudSettings,
+    upVector,
+  } = useFo3dContext();
   const selectedLabel = useCurrentSelected3dAnnotationLabel();
   const hoveredLabel = useHoveredLabel3d();
   const selectedLabels = useRecoilValue(fos.selectedLabelMap);
@@ -131,6 +136,7 @@ export const usePointCloudCrop = ({
         renderModel: cropRenderModel,
         labelId: raycastResult.intersectedLabelId,
         margin,
+        directPcdWorldTransformsBySampleId,
         source: "raycast-hover",
         useLegacyCoordinates,
         visibleWorldHeightAtCenter: raycastResult.visibleWorldHeightAtPoint,
@@ -161,6 +167,7 @@ export const usePointCloudCrop = ({
       renderModel: cropRenderModel,
       selectedLabelId: selectedCuboidId,
       margin,
+      directPcdWorldTransformsBySampleId,
       useLegacyCoordinates,
     });
   }, [
@@ -176,6 +183,7 @@ export const usePointCloudCrop = ({
     raycastResult.visibleWorldHeightAtPoint,
     raycastResult.worldPosition,
     cropRenderModel,
+    directPcdWorldTransformsBySampleId,
     selectedCuboidId,
     upVector,
     useLegacyCoordinates,

--- a/app/packages/looker-3d/src/fo3d/MediaTypeFo3d.tsx
+++ b/app/packages/looker-3d/src/fo3d/MediaTypeFo3d.tsx
@@ -129,6 +129,7 @@ export const MediaTypeFo3dComponent = () => {
   const loadingManager = useMemo(() => new LoadingManager(), []);
 
   const {
+    directPcdWorldTransformsBySampleId,
     foScene,
     isLoading: isParsingFo3d,
     loadError,
@@ -186,6 +187,7 @@ export const MediaTypeFo3dComponent = () => {
       loadingManager,
       cameraLifecycleState,
       isSceneReady,
+      directPcdWorldTransformsBySampleId,
     });
 
   const { shouldRenderMultiPanelView, currentRenderPath } = useFo3dPanelRouting(

--- a/app/packages/looker-3d/src/fo3d/context.tsx
+++ b/app/packages/looker-3d/src/fo3d/context.tsx
@@ -3,6 +3,7 @@ import type { Box3, LoadingManager, Vector3 } from "three";
 import { DEFAULT_SELECTED_CUBOID_CROP_MARGIN } from "../constants";
 import type { Looker3dSettings } from "../settings";
 import { HoverMetadata } from "../types";
+import type { DirectPcdWorldTransforms } from "./direct-pcd-world-alignment";
 import {
   FO3D_CAMERA_LIFECYCLE,
   type Fo3dCameraLifecycleState,
@@ -32,6 +33,7 @@ interface Fo3dContextT {
   setPointCloudSettings: Dispatch<SetStateAction<Fo3dPointCloudSettings>>;
   hoverMetadata: HoverMetadata | null;
   setHoverMetadata: Dispatch<SetStateAction<HoverMetadata | null>>;
+  directPcdWorldTransformsBySampleId: DirectPcdWorldTransforms;
 }
 
 const noop = () => {
@@ -60,6 +62,7 @@ const defaultContext: Fo3dContextT = {
   setPointCloudSettings: noop,
   hoverMetadata: null,
   setHoverMetadata: noop,
+  directPcdWorldTransformsBySampleId: {},
 };
 
 export const Fo3dSceneContext = createContext<Fo3dContextT>(defaultContext);

--- a/app/packages/looker-3d/src/fo3d/direct-pcd-world-alignment.test.ts
+++ b/app/packages/looker-3d/src/fo3d/direct-pcd-world-alignment.test.ts
@@ -1,0 +1,132 @@
+import { Euler, Quaternion, Vector3 } from "three";
+import { describe, expect, it } from "vitest";
+import type { GroupStaticTransformResponse } from "../frustum/types";
+import {
+  resolveDirectPcdWorldAlignment,
+  transformCuboidToNativeFrame,
+} from "./direct-pcd-world-alignment";
+
+describe("resolveDirectPcdWorldAlignment", () => {
+  it("preserves identity behavior when no transforms are configured", () => {
+    expect(
+      resolveDirectPcdWorldAlignment(
+        response(false, {
+          lidar_top: { staticTransform: null },
+        }),
+        ["lidar_top"],
+      ),
+    ).toEqual({
+      transformsBySlice: {},
+      unresolvedSlices: [],
+    });
+  });
+
+  it("accepts only each requested native frame resolved to world", () => {
+    const alignment = resolveDirectPcdWorldAlignment(
+      response(true, {
+        lidar_left: {
+          staticTransform: {
+            translation: [-2, 0, 0],
+            quaternion: [0, 0, 0, 2],
+            source_frame: "lidar_left",
+            target_frame: "world",
+          },
+        },
+        lidar_right: {
+          staticTransform: {
+            translation: [2, 0, 0],
+            quaternion: [0, 0, 0, 1],
+            source_frame: "lidar_right",
+            target_frame: "world",
+          },
+        },
+      }),
+      ["lidar_left", "lidar_right"],
+    );
+
+    expect(alignment.unresolvedSlices).toEqual([]);
+    expect(alignment.transformsBySlice.lidar_left).toEqual({
+      translation: [-2, 0, 0],
+      quaternion: [0, 0, 0, 1],
+      source_frame: "lidar_left",
+      target_frame: "world",
+    });
+  });
+
+  it("rejects missing, ambiguous, or wrong-target results", () => {
+    const alignment = resolveDirectPcdWorldAlignment(
+      response(true, {
+        ambiguous: { staticTransform: null },
+        failed: { error: "multiple paths" },
+        wrong_target: {
+          staticTransform: {
+            translation: [0, 0, 0],
+            quaternion: [0, 0, 0, 1],
+            source_frame: "wrong_target",
+            target_frame: "ego",
+          },
+        },
+      }),
+      ["ambiguous", "failed", "missing", "wrong_target"],
+    );
+
+    expect(alignment.transformsBySlice).toEqual({});
+    expect(alignment.unresolvedSlices).toEqual([
+      "ambiguous",
+      "failed",
+      "missing",
+      "wrong_target",
+    ]);
+  });
+});
+
+describe("transformCuboidToNativeFrame", () => {
+  it("inverse-transforms center and orientation while preserving dimensions", () => {
+    const frameQuaternion = new Quaternion().setFromEuler(
+      new Euler(0, 0, Math.PI / 2),
+    );
+    const nativeQuaternion = new Quaternion().setFromEuler(
+      new Euler(Math.PI / 3, 0, 0),
+    );
+    const nativeLocation = new Vector3(1, 2, 3);
+    const translation = new Vector3(10, -4, 2);
+    const worldLocation = nativeLocation
+      .clone()
+      .applyQuaternion(frameQuaternion)
+      .add(translation);
+    const worldQuaternion = frameQuaternion.clone().multiply(nativeQuaternion);
+
+    const native = transformCuboidToNativeFrame(
+      {
+        location: worldLocation.toArray(),
+        dimensions: [4, 5, 6],
+        quaternion: worldQuaternion.toArray(),
+      },
+      {
+        translation: translation.toArray(),
+        quaternion: frameQuaternion.toArray(),
+        source_frame: "lidar_top",
+        target_frame: "world",
+      },
+    );
+
+    expect(native.location).toEqual(expectCloseToTuple([1, 2, 3]));
+    expect(native.dimensions).toEqual([4, 5, 6]);
+    expect(native.quaternion).toEqual(
+      expectCloseToTuple(nativeQuaternion.toArray()),
+    );
+  });
+});
+
+const response = (
+  hasStaticTransforms: boolean,
+  results: GroupStaticTransformResponse["results"],
+): GroupStaticTransformResponse => ({
+  group_id: "group-id",
+  has_static_transforms: hasStaticTransforms,
+  target_frame: "world",
+  results,
+});
+
+const expectCloseToTuple = (values: readonly number[]) =>
+  values.map((value) => expect.closeTo(value, 10));

--- a/app/packages/looker-3d/src/fo3d/direct-pcd-world-alignment.test.ts
+++ b/app/packages/looker-3d/src/fo3d/direct-pcd-world-alignment.test.ts
@@ -4,6 +4,7 @@ import type { GroupStaticTransformResponse } from "../frustum/types";
 import {
   resolveDirectPcdWorldAlignment,
   transformCuboidToNativeFrame,
+  transformCuboidToWorldFrame,
 } from "./direct-pcd-world-alignment";
 
 describe("resolveDirectPcdWorldAlignment", () => {
@@ -114,6 +115,34 @@ describe("transformCuboidToNativeFrame", () => {
     expect(native.dimensions).toEqual([4, 5, 6]);
     expect(native.quaternion).toEqual(
       expectCloseToTuple(nativeQuaternion.toArray()),
+    );
+  });
+
+  it("round-trips a native cuboid through its world display frame", () => {
+    const native = {
+      location: [1, 2, 3] as [number, number, number],
+      dimensions: [4, 5, 6] as [number, number, number],
+      rotation: [Math.PI / 3, 0, 0] as [number, number, number],
+    };
+    const nativeToWorld = {
+      translation: [10, -4, 2] as [number, number, number],
+      quaternion: new Quaternion()
+        .setFromEuler(new Euler(0, 0, Math.PI / 2))
+        .toArray(),
+      source_frame: "lidar_top",
+      target_frame: "world",
+    };
+
+    const world = transformCuboidToWorldFrame(native, nativeToWorld);
+    const roundTrip = transformCuboidToNativeFrame(world, nativeToWorld);
+
+    expect(world.location).toEqual(expectCloseToTuple([8, -3, 5]));
+    expect(roundTrip.location).toEqual(expectCloseToTuple(native.location));
+    expect(roundTrip.dimensions).toEqual(native.dimensions);
+    expect(roundTrip.quaternion).toEqual(
+      expectCloseToTuple(
+        new Quaternion().setFromEuler(new Euler(...native.rotation)).toArray(),
+      ),
     );
   });
 });

--- a/app/packages/looker-3d/src/fo3d/direct-pcd-world-alignment.ts
+++ b/app/packages/looker-3d/src/fo3d/direct-pcd-world-alignment.ts
@@ -1,0 +1,129 @@
+import { Euler, Quaternion, Vector3 } from "three";
+import type { CuboidTransformData } from "../annotation/types";
+import type {
+  GroupStaticTransformResponse,
+  StaticTransform,
+} from "../frustum/types";
+
+/** The fixed display target for grouped direct PCD alignment. */
+export const WORLD_FRAME = "world";
+
+/** Static transforms keyed by either native slice or sample ID. */
+export type DirectPcdWorldTransforms = Readonly<
+  Record<string, StaticTransform>
+>;
+
+interface DirectPcdWorldAlignment {
+  readonly transformsBySlice: DirectPcdWorldTransforms;
+  readonly unresolvedSlices: readonly string[];
+}
+
+const isFiniteTuple = (value: unknown, length: number): value is number[] =>
+  Array.isArray(value) &&
+  value.length === length &&
+  value.every((item) => typeof item === "number" && Number.isFinite(item));
+
+const normalizeStaticTransform = (
+  value: unknown,
+  sourceFrame: string,
+): StaticTransform | null => {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const transform = value as Partial<StaticTransform>;
+  if (
+    transform.source_frame !== sourceFrame ||
+    transform.target_frame !== WORLD_FRAME ||
+    !isFiniteTuple(transform.translation, 3) ||
+    !isFiniteTuple(transform.quaternion, 4)
+  ) {
+    return null;
+  }
+
+  const quaternion = new Quaternion(...transform.quaternion);
+  if (!Number.isFinite(quaternion.lengthSq()) || quaternion.lengthSq() === 0) {
+    return null;
+  }
+  quaternion.normalize();
+
+  return {
+    source_frame: sourceFrame,
+    target_frame: WORLD_FRAME,
+    translation: [...transform.translation] as StaticTransform["translation"],
+    quaternion: quaternion.toArray() as StaticTransform["quaternion"],
+  };
+};
+
+/**
+ * Validates the group transform response for the requested native PCD frames.
+ */
+export const resolveDirectPcdWorldAlignment = (
+  response: GroupStaticTransformResponse,
+  sliceNames: readonly string[],
+): DirectPcdWorldAlignment => {
+  if (!response.has_static_transforms) {
+    return {
+      transformsBySlice: {},
+      unresolvedSlices: [],
+    };
+  }
+
+  const transformsBySlice: Record<string, StaticTransform> = {};
+  const unresolvedSlices: string[] = [];
+
+  for (const sliceName of sliceNames) {
+    const result = response.results[sliceName];
+    const transform =
+      result && "staticTransform" in result
+        ? normalizeStaticTransform(result.staticTransform, sliceName)
+        : null;
+
+    if (transform) {
+      transformsBySlice[sliceName] = transform;
+    } else {
+      unresolvedSlices.push(sliceName);
+    }
+  }
+
+  return {
+    transformsBySlice,
+    unresolvedSlices,
+  };
+};
+
+/**
+ * Converts a cuboid manipulated in the aligned world display back into the
+ * writable PCD slice's native sensor frame.
+ */
+export const transformCuboidToNativeFrame = (
+  cuboid: CuboidTransformData,
+  nativeToWorld: StaticTransform,
+): CuboidTransformData => {
+  const frameQuaternion = new Quaternion(
+    ...nativeToWorld.quaternion,
+  ).normalize();
+  const worldToNativeQuaternion = frameQuaternion.clone().invert();
+  const nativeLocation = new Vector3(...cuboid.location)
+    .sub(new Vector3(...nativeToWorld.translation))
+    .applyQuaternion(worldToNativeQuaternion);
+
+  const worldQuaternion = cuboid.quaternion
+    ? new Quaternion(...cuboid.quaternion)
+    : new Quaternion().setFromEuler(
+        new Euler(...(cuboid.rotation ?? [0, 0, 0])),
+      );
+  const nativeQuaternion = worldToNativeQuaternion
+    .clone()
+    .multiply(worldQuaternion)
+    .normalize();
+  const nativeEuler = new Euler().setFromQuaternion(nativeQuaternion);
+
+  return {
+    ...cuboid,
+    location: nativeLocation.toArray() as CuboidTransformData["location"],
+    dimensions: [...cuboid.dimensions] as CuboidTransformData["dimensions"],
+    rotation: [nativeEuler.x, nativeEuler.y, nativeEuler.z],
+    quaternion: nativeQuaternion.toArray() as CuboidTransformData["quaternion"],
+  };
+};

--- a/app/packages/looker-3d/src/fo3d/direct-pcd-world-alignment.ts
+++ b/app/packages/looker-3d/src/fo3d/direct-pcd-world-alignment.ts
@@ -92,6 +92,39 @@ export const resolveDirectPcdWorldAlignment = (
   };
 };
 
+const getCuboidQuaternion = (cuboid: CuboidTransformData) =>
+  cuboid.quaternion
+    ? new Quaternion(...cuboid.quaternion)
+    : new Quaternion().setFromEuler(
+        new Euler(...(cuboid.rotation ?? [0, 0, 0])),
+      );
+
+/** Converts a sensor-local cuboid into the aligned world display frame. */
+export const transformCuboidToWorldFrame = (
+  cuboid: CuboidTransformData,
+  nativeToWorld: StaticTransform,
+): CuboidTransformData => {
+  const frameQuaternion = new Quaternion(
+    ...nativeToWorld.quaternion,
+  ).normalize();
+  const worldLocation = new Vector3(...cuboid.location)
+    .applyQuaternion(frameQuaternion)
+    .add(new Vector3(...nativeToWorld.translation));
+  const worldQuaternion = frameQuaternion
+    .clone()
+    .multiply(getCuboidQuaternion(cuboid))
+    .normalize();
+  const worldEuler = new Euler().setFromQuaternion(worldQuaternion);
+
+  return {
+    ...cuboid,
+    location: worldLocation.toArray() as CuboidTransformData["location"],
+    dimensions: [...cuboid.dimensions] as CuboidTransformData["dimensions"],
+    rotation: [worldEuler.x, worldEuler.y, worldEuler.z],
+    quaternion: worldQuaternion.toArray() as CuboidTransformData["quaternion"],
+  };
+};
+
 /**
  * Converts a cuboid manipulated in the aligned world display back into the
  * writable PCD slice's native sensor frame.
@@ -108,11 +141,7 @@ export const transformCuboidToNativeFrame = (
     .sub(new Vector3(...nativeToWorld.translation))
     .applyQuaternion(worldToNativeQuaternion);
 
-  const worldQuaternion = cuboid.quaternion
-    ? new Quaternion(...cuboid.quaternion)
-    : new Quaternion().setFromEuler(
-        new Euler(...(cuboid.rotation ?? [0, 0, 0])),
-      );
+  const worldQuaternion = getCuboidQuaternion(cuboid);
   const nativeQuaternion = worldToNativeQuaternion
     .clone()
     .multiply(worldQuaternion)

--- a/app/packages/looker-3d/src/fo3d/synthetic-scene.test.ts
+++ b/app/packages/looker-3d/src/fo3d/synthetic-scene.test.ts
@@ -121,6 +121,42 @@ describe("buildSyntheticSceneForDirect3dSamples", () => {
     ]);
   });
 
+  it("places grouped PCD nodes in their resolved world frames", () => {
+    const sampleMap = {
+      lidar_left: buildModalSample("/tmp/group/left.pcd"),
+      lidar_right: buildModalSample("/tmp/group/right.pcd"),
+    };
+
+    const scene = buildSyntheticSceneForDirect3dSamples({
+      sample: sampleMap.lidar_left,
+      mediaField: "filepath",
+      sampleMap,
+      worldTransformsBySlice: {
+        lidar_left: {
+          translation: [-3, 0, 0],
+          quaternion: [0, 0, 0, 1],
+        },
+        lidar_right: {
+          translation: [3, 0, 0],
+          quaternion: [0, 0, Math.SQRT1_2, Math.SQRT1_2],
+        },
+      },
+    });
+
+    expect(scene.children).toEqual([
+      expect.objectContaining({
+        name: "lidar_left",
+        position: [-3, 0, 0],
+        quaternion: [0, 0, 0, 1],
+      }),
+      expect.objectContaining({
+        name: "lidar_right",
+        position: [3, 0, 0],
+        quaternion: [0, 0, Math.SQRT1_2, Math.SQRT1_2],
+      }),
+    ]);
+  });
+
   it("returns null for unsupported direct assets", () => {
     const scene = buildSyntheticSceneForDirect3dSamples({
       sample: buildModalSample("/tmp/lidar/frame.obj"),

--- a/app/packages/looker-3d/src/fo3d/synthetic-scene.ts
+++ b/app/packages/looker-3d/src/fo3d/synthetic-scene.ts
@@ -5,6 +5,7 @@ import {
   isWrappableDirect3dSamplePath,
 } from "@fiftyone/utilities";
 import type { FiftyoneSceneRawJson, FoSceneRawNode } from "../utils";
+import type { DirectPcdWorldTransforms } from "./direct-pcd-world-alignment";
 import { DEFAULT_SPLAT_OPACITY, DEFAULT_SPLAT_TINT } from "./splat/settings";
 import { getMediaPathForFo3dSample } from "./utils";
 
@@ -155,10 +156,12 @@ const buildSyntheticNode = ({
   sample,
   slice,
   mediaField,
+  worldTransformsBySlice,
 }: {
   sample: ModalSample;
   slice: string;
   mediaField: string;
+  worldTransformsBySlice?: DirectPcdWorldTransforms;
 }): FiftyoneSceneRawJson | null => {
   const mediaPath =
     getMediaPathForFo3dSample(sample, mediaField) ?? sample.sample.filepath;
@@ -175,6 +178,15 @@ const buildSyntheticNode = ({
     defaultMaterial: nodeConfig.defaultMaterial,
     ...EMPTY_SCENE_NODE_PROPS,
   };
+
+  const worldTransform =
+    nodeConfig.nodeType === "PointCloud"
+      ? worldTransformsBySlice?.[slice]
+      : undefined;
+  if (worldTransform) {
+    node.position = [...worldTransform.translation];
+    node.quaternion = [...worldTransform.quaternion];
+  }
 
   // Each loader expects the source path on a node-type-specific media field.
   node[nodeConfig.mediaFieldName] = mediaPath;
@@ -201,10 +213,12 @@ export const buildSyntheticSceneNodesForDirect3dSamples = ({
   sample,
   mediaField,
   sampleMap,
+  worldTransformsBySlice,
 }: {
   sample: ModalSample;
   mediaField: string;
   sampleMap?: SliceToSampleMap;
+  worldTransformsBySlice?: DirectPcdWorldTransforms;
 }): FiftyoneSceneRawJson[] => {
   const sceneSamples =
     sampleMap && Object.keys(sampleMap).length > 0
@@ -217,6 +231,7 @@ export const buildSyntheticSceneNodesForDirect3dSamples = ({
         sample: currentSample,
         slice,
         mediaField,
+        worldTransformsBySlice,
       }),
     )
     .filter((node): node is FiftyoneSceneRawJson => Boolean(node));
@@ -230,15 +245,18 @@ export const buildSyntheticSceneForDirect3dSamples = ({
   sample,
   mediaField,
   sampleMap,
+  worldTransformsBySlice,
 }: {
   sample: ModalSample;
   mediaField: string;
   sampleMap?: SliceToSampleMap;
+  worldTransformsBySlice?: DirectPcdWorldTransforms;
 }): FiftyoneSceneRawJson | null => {
   const children = buildSyntheticSceneNodesForDirect3dSamples({
     sample,
     mediaField,
     sampleMap,
+    worldTransformsBySlice,
   });
 
   if (!children.length) {

--- a/app/packages/looker-3d/src/frustum/types.ts
+++ b/app/packages/looker-3d/src/frustum/types.ts
@@ -79,6 +79,10 @@ export interface FrustumGeometry {
  */
 export interface GroupStaticTransformResponse {
   group_id: string;
+  /** Whether any dataset- or sample-level static transforms are configured. */
+  has_static_transforms: boolean;
+  /** Resolution target returned by the endpoint. */
+  target_frame: string;
   results: {
     [sliceName: string]:
       | { staticTransform: StaticTransform | null }

--- a/app/packages/looker-3d/src/hooks/use-fo3d-scene-context-state.ts
+++ b/app/packages/looker-3d/src/hooks/use-fo3d-scene-context-state.ts
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import type { Box3, LoadingManager } from "three";
 import type { Fo3dCameraLifecycleState } from "../fo3d/camera-lifecycle";
+import type { DirectPcdWorldTransforms } from "../fo3d/direct-pcd-world-alignment";
 import { FoScene } from "../fo3d/render-types";
 import type { Looker3dSettings } from "../settings";
 import type { HoverMetadata } from "../types";
@@ -18,6 +19,7 @@ interface UseFo3dSceneContextStateArgs {
   loadingManager: LoadingManager | null;
   cameraLifecycleState: Fo3dCameraLifecycleState;
   isSceneReady: boolean;
+  directPcdWorldTransformsBySampleId: DirectPcdWorldTransforms;
 }
 
 /**
@@ -33,6 +35,7 @@ export const useFo3dSceneContextState = ({
   loadingManager,
   cameraLifecycleState,
   isSceneReady,
+  directPcdWorldTransformsBySampleId,
 }: UseFo3dSceneContextStateArgs) => {
   const [upVector, setUpVectorVal] = useFo3dUpVector(
     foScene,
@@ -73,6 +76,7 @@ export const useFo3dSceneContextState = ({
       hoverMetadata,
       setHoverMetadata,
       pluginSettings: settings ?? null,
+      directPcdWorldTransformsBySampleId,
     }),
     [
       cameraLifecycleState,
@@ -93,6 +97,7 @@ export const useFo3dSceneContextState = ({
       hoverMetadata,
       setHoverMetadata,
       settings,
+      directPcdWorldTransformsBySampleId,
     ],
   );
 

--- a/app/packages/looker-3d/src/hooks/use-fo3d.test.ts
+++ b/app/packages/looker-3d/src/hooks/use-fo3d.test.ts
@@ -27,6 +27,11 @@ const mockState = vi.hoisted(() => ({
   getRootAssetCount: vi.fn(
     (scene: FiftyoneSceneRawJson | null) => scene?.children?.length ?? 0,
   ),
+  directPcdAlignment: {
+    error: null as Error | null,
+    isLoading: false,
+    transformsBySlice: {},
+  },
 }));
 
 vi.mock("@fiftyone/state", () => ({
@@ -64,6 +69,10 @@ vi.mock("./use-fo3d-fetcher", () => ({
 vi.mock("./use-fo3d-scene-parser", () => ({
   buildFoScene: mockState.buildFoScene,
   getRootAssetCount: mockState.getRootAssetCount,
+}));
+
+vi.mock("./use-grouped-direct-pcd-world-transforms", () => ({
+  useGroupedDirectPcdWorldTransforms: () => mockState.directPcdAlignment,
 }));
 
 const DEFAULT_MATERIAL = {
@@ -159,6 +168,11 @@ describe("useFo3d", () => {
     mockState.getSampleSrc.mockClear();
     mockState.buildFoScene.mockClear();
     mockState.getRootAssetCount.mockClear();
+    mockState.directPcdAlignment = {
+      error: null,
+      isLoading: false,
+      transformsBySlice: {},
+    };
   });
 
   afterEach(() => {
@@ -194,6 +208,87 @@ describe("useFo3d", () => {
       "mesh",
       "pcd",
     ]);
+  });
+
+  it("places grouped PCD slices in world and exposes label parent transforms", async () => {
+    const leftSample = buildModalSample("left-id", "/tmp/group/left.pcd");
+    const rightSample = buildModalSample("right-id", "/tmp/group/right.pcd");
+
+    mockState.isGroup = true;
+    mockState.group3dState.activeSlices = ["lidar_left", "lidar_right"];
+    mockState.group3dState.activeDirectSlices = ["lidar_left", "lidar_right"];
+    mockState.group3dState.activeSampleMap = {
+      lidar_left: leftSample,
+      lidar_right: rightSample,
+    };
+    mockState.group3dState.allSampleMap =
+      mockState.group3dState.activeSampleMap;
+    mockState.directPcdAlignment = {
+      error: null,
+      isLoading: false,
+      transformsBySlice: {
+        lidar_left: {
+          translation: [-5, 0, 0],
+          quaternion: [0, 0, 0, 1],
+          source_frame: "lidar_left",
+          target_frame: "world",
+        },
+        lidar_right: {
+          translation: [5, 0, 0],
+          quaternion: [0, 0, 0, 1],
+          source_frame: "lidar_right",
+          target_frame: "world",
+        },
+      },
+    };
+
+    const { result } = renderHook(() => useFo3d(leftSample));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const content = getLastNonNullFo3dContent();
+    expect(
+      Object.fromEntries(
+        content.children.map((child) => [child.name, child.position]),
+      ),
+    ).toEqual({
+      lidar_left: [-5, 0, 0],
+      lidar_right: [5, 0, 0],
+    });
+    expect(result.current.directPcdWorldTransformsBySampleId).toEqual({
+      "left-id": mockState.directPcdAlignment.transformsBySlice.lidar_left,
+      "right-id": mockState.directPcdAlignment.transformsBySlice.lidar_right,
+    });
+  });
+
+  it("does not render grouped PCDs when configured world alignment fails", async () => {
+    const pcdSample = buildModalSample("pcd-id", "/tmp/group/lidar.pcd");
+
+    mockState.isGroup = true;
+    mockState.group3dState.activeSlices = ["lidar_top"];
+    mockState.group3dState.activeDirectSlices = ["lidar_top"];
+    mockState.group3dState.activeSampleMap = { lidar_top: pcdSample };
+    mockState.group3dState.allSampleMap =
+      mockState.group3dState.activeSampleMap;
+    mockState.directPcdAlignment = {
+      error: new Error("Unable to align grouped PCD slice to world: lidar_top"),
+      isLoading: false,
+      transformsBySlice: {},
+    };
+
+    const { result } = renderHook(() => useFo3d(pcdSample));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.foScene).toBeNull();
+    expect(result.current.loadError?.message).toContain(
+      "Unable to align grouped PCD slice to world: lidar_top",
+    );
+    expect(getLastNonNullFo3dContent()).toBeUndefined();
   });
 
   it("appends active direct 3d slices onto the active fo3d scene root", async () => {

--- a/app/packages/looker-3d/src/hooks/use-fo3d.ts
+++ b/app/packages/looker-3d/src/hooks/use-fo3d.ts
@@ -1,11 +1,13 @@
 import * as fos from "@fiftyone/state";
 import {
+  getSamplePathExtension,
   isFo3dSamplePath,
   isWrappableDirect3dSamplePath,
 } from "@fiftyone/utilities";
 import { useEffect, useMemo, useState } from "react";
 import { useRecoilValue } from "recoil";
 import type { FoScene } from "../fo3d/render-types";
+import type { DirectPcdWorldTransforms } from "../fo3d/direct-pcd-world-alignment";
 import {
   buildSyntheticSceneForDirect3dSamples,
   buildSyntheticSceneNodesForDirect3dSamples,
@@ -13,6 +15,7 @@ import {
 import { getFo3dRoot, getMediaPathForFo3dSample } from "../fo3d/utils";
 import type { FiftyoneSceneRawJson } from "../utils";
 import useFo3dFetcher from "./use-fo3d-fetcher";
+import { useGroupedDirectPcdWorldTransforms } from "./use-grouped-direct-pcd-world-transforms";
 import { buildFoScene, getRootAssetCount } from "./use-fo3d-scene-parser";
 
 import { getResolvedUrlForFo3dAsset } from "../fo3d/utils";
@@ -109,6 +112,7 @@ export const appendDirect3dSamplesToScene = ({
 };
 
 type UseFo3dReturnType = {
+  directPcdWorldTransformsBySampleId: DirectPcdWorldTransforms;
   foScene: FoScene | null;
   isLoading: boolean;
   loadError: Error | null;
@@ -180,6 +184,47 @@ export const useFo3d = (sample: fos.ModalSample): UseFo3dReturnType => {
     isGroup,
     group3dState.realFo3dSlices,
   ]);
+  const groupedDirectPcdSampleMap = useMemo(() => {
+    if (!groupedDirectSampleMap) {
+      return {};
+    }
+
+    return Object.fromEntries(
+      Object.entries(groupedDirectSampleMap).filter(([, currentSample]) => {
+        const path =
+          getMediaPathForFo3dSample(currentSample, mediaField) ??
+          currentSample.sample.filepath;
+        return getSamplePathExtension(path)?.toLowerCase() === ".pcd";
+      }),
+    );
+  }, [groupedDirectSampleMap, mediaField]);
+  const directPcdSliceNames = useMemo(
+    () => Object.keys(groupedDirectPcdSampleMap),
+    [groupedDirectPcdSampleMap],
+  );
+  const directPcdAlignment = useGroupedDirectPcdWorldTransforms({
+    enabled:
+      isGroup &&
+      !group3dState.activeFo3dSlice &&
+      directPcdSliceNames.length > 0,
+    sampleId: sample.sample._id ?? null,
+    sliceNames: directPcdSliceNames,
+  });
+  const directPcdWorldTransformsBySampleId = useMemo(() => {
+    const transforms: Record<string, DirectPcdWorldTransforms[string]> = {};
+
+    for (const [slice, currentSample] of Object.entries(
+      groupedDirectPcdSampleMap,
+    )) {
+      const transform = directPcdAlignment.transformsBySlice[slice];
+      const sampleId = currentSample.sample._id;
+      if (transform && sampleId) {
+        transforms[sampleId] = transform;
+      }
+    }
+
+    return transforms;
+  }, [directPcdAlignment.transformsBySlice, groupedDirectPcdSampleMap]);
   const syntheticRawData = useMemo(() => {
     if (group3dState.activeFo3dSlice || !isWrappableDirectAsset) {
       return null;
@@ -194,6 +239,7 @@ export const useFo3d = (sample: fos.ModalSample): UseFo3dReturnType => {
       sample,
       mediaField,
       sampleMap: groupedSampleMap,
+      worldTransformsBySlice: directPcdAlignment.transformsBySlice,
     });
   }, [
     group3dState.activeFo3dSlice,
@@ -204,6 +250,7 @@ export const useFo3d = (sample: fos.ModalSample): UseFo3dReturnType => {
     groupedDirectSampleMap,
     mediaField,
     sample,
+    directPcdAlignment.transformsBySlice,
   ]);
 
   // This effect fetches fo3d data for the active sample and guards stale updates.
@@ -213,6 +260,20 @@ export const useFo3d = (sample: fos.ModalSample): UseFo3dReturnType => {
     setIsLoading(true);
     setLoadError(null);
     setRawData(null);
+
+    if (directPcdAlignment.isLoading) {
+      return () => {
+        isActive = false;
+      };
+    }
+
+    if (directPcdAlignment.error) {
+      setLoadError(directPcdAlignment.error);
+      setIsLoading(false);
+      return () => {
+        isActive = false;
+      };
+    }
 
     if (isRealFo3dScene) {
       fetchFo3d(url, fo3dPath)
@@ -269,6 +330,8 @@ export const useFo3d = (sample: fos.ModalSample): UseFo3dReturnType => {
     };
   }, [
     fetchFo3d,
+    directPcdAlignment.error,
+    directPcdAlignment.isLoading,
     fo3dPath,
     filepath,
     groupedDirectSampleMap,
@@ -304,6 +367,7 @@ export const useFo3d = (sample: fos.ModalSample): UseFo3dReturnType => {
 
   if (isLoading) {
     return {
+      directPcdWorldTransformsBySampleId: {},
       foScene: null,
       isLoading: true,
       loadError: null,
@@ -313,6 +377,7 @@ export const useFo3d = (sample: fos.ModalSample): UseFo3dReturnType => {
   }
 
   return {
+    directPcdWorldTransformsBySampleId,
     foScene,
     isLoading: false,
     loadError,

--- a/app/packages/looker-3d/src/hooks/use-grouped-direct-pcd-world-transforms.ts
+++ b/app/packages/looker-3d/src/hooks/use-grouped-direct-pcd-world-transforms.ts
@@ -1,0 +1,144 @@
+import * as fos from "@fiftyone/state";
+import { getFetchFunction } from "@fiftyone/utilities";
+import { useEffect, useMemo, useState } from "react";
+import {
+  resolveDirectPcdWorldAlignment,
+  WORLD_FRAME,
+  type DirectPcdWorldTransforms,
+} from "../fo3d/direct-pcd-world-alignment";
+import type { GroupStaticTransformResponse } from "../frustum/types";
+
+interface AlignmentState {
+  readonly error: Error | null;
+  readonly isLoading: boolean;
+  readonly key: string | null;
+  readonly transformsBySlice: DirectPcdWorldTransforms;
+}
+
+const EMPTY_RESULT = {
+  error: null,
+  isLoading: false,
+  transformsBySlice: {},
+} as const;
+
+const EMPTY_STATE: AlignmentState = {
+  ...EMPTY_RESULT,
+  key: null,
+};
+
+/**
+ * Resolves active grouped direct-PCD native frames into the existing world
+ * target. An explicit target disables the endpoint's best-target fallback.
+ */
+export const useGroupedDirectPcdWorldTransforms = ({
+  enabled,
+  sampleId,
+  sliceNames,
+}: {
+  enabled: boolean;
+  sampleId: string | null;
+  sliceNames: readonly string[];
+}) => {
+  const datasetId = fos.useCurrentDatasetId();
+  const slicesKey = useMemo(
+    () => [...sliceNames].sort().join("\0"),
+    [sliceNames],
+  );
+  const requestKey =
+    enabled && datasetId && sampleId && slicesKey
+      ? `${datasetId}\0${sampleId}\0${slicesKey}`
+      : null;
+  const [state, setState] = useState<AlignmentState>(EMPTY_STATE);
+
+  // This effect resolves one world transform request and ignores stale group
+  // navigation responses.
+  useEffect(() => {
+    if (!requestKey || !datasetId || !sampleId) {
+      setState(EMPTY_STATE);
+      return undefined;
+    }
+
+    let cancelled = false;
+    const requestedSlices = slicesKey.split("\0");
+    setState({
+      error: null,
+      isLoading: true,
+      key: requestKey,
+      transformsBySlice: {},
+    });
+
+    const query = new URLSearchParams({
+      slices: requestedSlices.join(","),
+      target_frame: WORLD_FRAME,
+    });
+    const fetch = getFetchFunction({ cache: true });
+
+    void fetch<void, GroupStaticTransformResponse>(
+      "GET",
+      `/dataset/${encodeURIComponent(datasetId)}/sample/${encodeURIComponent(
+        sampleId,
+      )}/group/static_transforms?${query.toString()}`,
+    )
+      .then((response) => {
+        if (cancelled) {
+          return;
+        }
+
+        const alignment = resolveDirectPcdWorldAlignment(
+          response,
+          requestedSlices,
+        );
+        const error = alignment.unresolvedSlices.length
+          ? new Error(
+              `Unable to align grouped PCD slice${
+                alignment.unresolvedSlices.length === 1 ? "" : "s"
+              } to world: ${alignment.unresolvedSlices.join(", ")}`,
+            )
+          : null;
+
+        setState({
+          error,
+          isLoading: false,
+          key: requestKey,
+          transformsBySlice: alignment.transformsBySlice,
+        });
+      })
+      .catch((reason) => {
+        if (cancelled) {
+          return;
+        }
+
+        const message =
+          reason instanceof Error ? reason.message : String(reason);
+        setState({
+          error: new Error(
+            `Failed to resolve grouped PCD world transforms: ${message}`,
+          ),
+          isLoading: false,
+          key: requestKey,
+          transformsBySlice: {},
+        });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [datasetId, requestKey, sampleId, slicesKey]);
+
+  if (!requestKey) {
+    return EMPTY_RESULT;
+  }
+
+  if (state.key !== requestKey) {
+    return {
+      ...EMPTY_RESULT,
+      isLoading: true,
+    };
+  }
+
+  return {
+    error: state.error,
+    isLoading: state.isLoading,
+    transformsBySlice: state.transformsBySlice,
+  };
+};

--- a/app/packages/looker-3d/src/labels/cuboid.tsx
+++ b/app/packages/looker-3d/src/labels/cuboid.tsx
@@ -284,6 +284,8 @@ export interface CuboidProps extends OverlayProps {
   enableFaceResize?: boolean;
   enableHeadingEdit?: boolean;
   hoverSource?: HoveredLabelSource;
+  /** Rotation contributed by display-only ancestors outside this cuboid. */
+  parentWorldQuaternion?: THREE.Vector4Tuple;
   showOrientation?: boolean;
 }
 
@@ -405,6 +407,7 @@ export const Cuboid = ({
   enableFaceResize = false,
   enableHeadingEdit = false,
   hoverSource = PANEL_ID_MAIN,
+  parentWorldQuaternion,
   showOrientation = false,
 }: CuboidProps) => {
   useHoverState();
@@ -595,6 +598,26 @@ export const Cuboid = ({
     useLegacyCoordinates,
   });
 
+  const parentQuaternion = useMemo(
+    () =>
+      parentWorldQuaternion
+        ? new THREE.Quaternion(...parentWorldQuaternion).normalize()
+        : new THREE.Quaternion(),
+    [parentWorldQuaternion],
+  );
+  const worldOrientationQuaternion = useMemo(
+    () => parentQuaternion.clone().multiply(orientationQuaternion).normalize(),
+    [orientationQuaternion, parentQuaternion],
+  );
+  const parentLocalUpVector = useMemo(() => {
+    const effectiveUp =
+      upVector && upVector.lengthSq() > 0
+        ? upVector.clone().normalize()
+        : new THREE.Vector3(0, 0, 1);
+
+    return effectiveUp.applyQuaternion(parentQuaternion.clone().invert());
+  }, [parentQuaternion, upVector]);
+
   // Set while a face button in the "Edit heading/up vector" sidebar section
   // is hovered — previews the ghost arrow/face highlight below.
   const headingUpPreview = useHeadingUpPreview();
@@ -605,15 +628,11 @@ export const Cuboid = ({
   // hovered (and vice versa), since the sidebar hover only ever carries one
   // face at a time.
   const currentUpFace = useMemo(() => {
-    const effectiveUp =
-      upVector && upVector.lengthSq() > 0
-        ? upVector.clone().normalize()
-        : new THREE.Vector3(0, 0, 1);
-    const localUp = effectiveUp
+    const localUp = parentLocalUpVector
       .clone()
       .applyQuaternion(orientationQuaternion.clone().invert());
     return getCuboidResizeFaceFromNormal(localUp) ?? "+z";
-  }, [upVector, orientationQuaternion]);
+  }, [orientationQuaternion, parentLocalUpVector]);
 
   // Full candidate orientation for the hovered heading/up combination, so the
   // axes tripod can preview the resulting frame before committing — alongside
@@ -639,7 +658,7 @@ export const Cuboid = ({
       quaternion: orientationQuaternion,
       headingFace: nextHeadingFace,
       upFace: nextUpFace,
-      upVector,
+      upVector: parentLocalUpVector,
     });
   }, [
     isHeadingUpPreviewActive,
@@ -647,7 +666,7 @@ export const Cuboid = ({
     currentUpFace,
     effectiveDimensions,
     orientationQuaternion,
-    upVector,
+    parentLocalUpVector,
   ]);
 
   const headingUpPreviewQuaternion = useMemo(
@@ -714,7 +733,7 @@ export const Cuboid = ({
     enabled: canEditHeading,
     dimensions: displayDimensions,
     orientation: orientationQuaternion,
-    upVector,
+    upVector: parentLocalUpVector,
     contentRef,
     panelElementRef,
     onDragStart: handleHeadingDragStart,
@@ -821,7 +840,10 @@ export const Cuboid = ({
       }
 
       const orientation = orientationQuaternion.clone().normalize();
-      const faceWorldNormal = getCuboidResizeFaceWorldNormal(face, orientation);
+      const faceWorldNormal = getCuboidResizeFaceWorldNormal(
+        face,
+        worldOrientationQuaternion,
+      );
       const cameraDirection = camera.getWorldDirection(new THREE.Vector3());
       const cameraUp = new THREE.Vector3(0, 1, 0)
         .applyQuaternion(camera.quaternion)
@@ -869,6 +891,7 @@ export const Cuboid = ({
       orientationQuaternion,
       setHoveredResizeFace,
       setIsCurrentlyTransforming,
+      worldOrientationQuaternion,
     ],
   );
 
@@ -1101,7 +1124,7 @@ export const Cuboid = ({
       ? getCuboidFaceDepthEdges(
           hoveredResizeFace,
           displayDimensions,
-          orientationQuaternion,
+          worldOrientationQuaternion,
           camera,
         )
       : null;

--- a/app/packages/looker-3d/src/labels/index.tsx
+++ b/app/packages/looker-3d/src/labels/index.tsx
@@ -19,6 +19,7 @@ import { folder, useControls } from "leva";
 import { get as _get } from "lodash";
 import { useCallback, useEffect, useMemo } from "react";
 import { useRecoilValue } from "recoil";
+import { Euler, Quaternion, type Vector3Tuple, type Vector4Tuple } from "three";
 import { useIsWorkingInitialized, useRenderModel } from "../annotation/store";
 import type {
   ReconciledDetection3D,
@@ -51,6 +52,16 @@ import { WorkingStoreManager } from "./WorkingStoreManager";
 // color (e.g. coloring metadata is missing/non-string). Newly created labels
 // take their color from getLabelColor instead.
 const DEFAULT_OVERLAY_COLOR = "#ffffff";
+const NATIVE_CUBOID_BATCH = Symbol("native-cuboid-batch");
+
+const composeParentWorldQuaternion = (
+  nativeToWorldQuaternion: Vector4Tuple | undefined,
+  overlayRotation: Vector3Tuple,
+): Vector4Tuple =>
+  new Quaternion(...(nativeToWorldQuaternion ?? [0, 0, 0, 1]))
+    .multiply(new Quaternion().setFromEuler(new Euler(...overlayRotation)))
+    .normalize()
+    .toArray();
 
 export interface ThreeDLabelsProps {
   sampleMap: Parameters<typeof load3dOverlays>[0];
@@ -366,6 +377,8 @@ export const ThreeDLabels = ({
   const cuboidOverlays = useMemo(
     () =>
       standaloneDetections.map((overlay) => {
+        const worldTransform =
+          directPcdWorldTransformsBySampleId[overlay.sampleId];
         const cuboid = (
           <DragGate3D
             dragThresholdPx={DRAG_GATE_THRESHOLD_PX}
@@ -389,11 +402,13 @@ export const ThreeDLabels = ({
               enableHeadingEdit
               hoverSource={hoverSource}
               showOrientation={showCuboidOrientation}
+              parentWorldQuaternion={composeParentWorldQuaternion(
+                worldTransform?.quaternion,
+                overlayRotation,
+              )}
             />
           </DragGate3D>
         );
-        const worldTransform =
-          directPcdWorldTransformsBySampleId[overlay.sampleId];
         const key = `cuboid-${overlay.ui.isNew ? "new-" : ""}${
           overlay.data._id
         }-${overlay.sampleId}`;
@@ -438,19 +453,26 @@ export const ThreeDLabels = ({
     : labelAlpha;
 
   const cuboidInstances = useMemo(() => {
-    const batches = new Map<string, ReconciledDetection3D[]>();
+    const batches = new Map<
+      string | typeof NATIVE_CUBOID_BATCH,
+      ReconciledDetection3D[]
+    >();
 
     for (const detection of instancedDetections) {
       const batchKey = directPcdWorldTransformsBySampleId[detection.sampleId]
         ? detection.sampleId
-        : "";
+        : NATIVE_CUBOID_BATCH;
       const batch = batches.get(batchKey) ?? [];
       batch.push(detection);
       batches.set(batchKey, batch);
     }
 
-    return [...batches.entries()].map(([sampleId, detections]) => {
-      const worldTransform = directPcdWorldTransformsBySampleId[sampleId];
+    return [...batches.entries()].map(([batchKey, detections]) => {
+      const isNativeBatch = batchKey === NATIVE_CUBOID_BATCH;
+      const sampleId = isNativeBatch ? null : batchKey;
+      const worldTransform = sampleId
+        ? directPcdWorldTransformsBySampleId[sampleId]
+        : undefined;
       const instances = (
         <mesh rotation={overlayRotation}>
           <CuboidInstances

--- a/app/packages/looker-3d/src/labels/index.tsx
+++ b/app/packages/looker-3d/src/labels/index.tsx
@@ -35,6 +35,7 @@ import {
 import { usePathFilter, useSelect3DLabelForAnnotation } from "../hooks";
 import { type Looker3dSettings, defaultPluginSettings } from "../settings";
 import { useThreeDLabelState } from "../state";
+import { useFo3dContext } from "../fo3d/context";
 import { isDetection3dOverlay, isPolyline3dOverlay } from "../types";
 import type { Archetype3d, PanelId } from "../types";
 import { toEulerFromDegreesArray } from "../utils";
@@ -69,6 +70,7 @@ export const ThreeDLabels = ({
   unfocusedLabelOpacity,
 }: ThreeDLabelsProps) => {
   const mode = fos.useModalMode();
+  const { directPcdWorldTransformsBySampleId } = useFo3dContext();
   const schema = useRecoilValue(fieldSchema({ space: fos.State.SPACE.SAMPLE }));
   const annotationSchemas = useAtomValue(activeLabelSchemas);
   const { coloring, selectedLabelTags, customizeColorSetting, labelTagColors } =
@@ -364,11 +366,8 @@ export const ThreeDLabels = ({
   const cuboidOverlays = useMemo(
     () =>
       standaloneDetections.map((overlay) => {
-        return (
+        const cuboid = (
           <DragGate3D
-            key={`cuboid-${overlay.ui.isNew ? "new-" : ""}${
-              overlay.data._id
-            }-${overlay.sampleId}`}
             dragThresholdPx={DRAG_GATE_THRESHOLD_PX}
             onClick={(e) => handleSelect(overlay, ANNOTATION_CUBOID, e)}
           >
@@ -393,6 +392,24 @@ export const ThreeDLabels = ({
             />
           </DragGate3D>
         );
+        const worldTransform =
+          directPcdWorldTransformsBySampleId[overlay.sampleId];
+        const key = `cuboid-${overlay.ui.isNew ? "new-" : ""}${
+          overlay.data._id
+        }-${overlay.sampleId}`;
+        const content = <mesh rotation={overlayRotation}>{cuboid}</mesh>;
+
+        return worldTransform ? (
+          <group
+            key={key}
+            position={worldTransform.translation}
+            quaternion={worldTransform.quaternion}
+          >
+            {content}
+          </group>
+        ) : (
+          <group key={key}>{content}</group>
+        );
       }),
     [
       standaloneDetections,
@@ -405,6 +422,7 @@ export const ThreeDLabels = ({
       settings,
       getOverlayColor,
       showCuboidOrientation,
+      directPcdWorldTransformsBySampleId,
     ],
   );
 
@@ -419,20 +437,60 @@ export const ThreeDLabels = ({
     ? (effectiveUnfocusedLabelOpacity ?? labelAlpha)
     : labelAlpha;
 
-  const cuboidInstances =
-    instancedDetections.length > 0 ? (
-      <CuboidInstances
-        detections={instancedDetections}
-        getColor={getOverlayColor}
-        opacity={instancedOpacity}
-        lineWidth={cuboidLineWidth}
-        useLegacyCoordinates={settings.useLegacyCoordinates}
-        overlayRotationFallback={overlayRotation}
-        hoverSource={hoverSource}
-        showOrientation={showCuboidOrientation}
-        onClick={(label, e) => handleSelect(label, ANNOTATION_CUBOID, e)}
-      />
-    ) : null;
+  const cuboidInstances = useMemo(() => {
+    const batches = new Map<string, ReconciledDetection3D[]>();
+
+    for (const detection of instancedDetections) {
+      const batchKey = directPcdWorldTransformsBySampleId[detection.sampleId]
+        ? detection.sampleId
+        : "";
+      const batch = batches.get(batchKey) ?? [];
+      batch.push(detection);
+      batches.set(batchKey, batch);
+    }
+
+    return [...batches.entries()].map(([sampleId, detections]) => {
+      const worldTransform = directPcdWorldTransformsBySampleId[sampleId];
+      const instances = (
+        <mesh rotation={overlayRotation}>
+          <CuboidInstances
+            detections={detections}
+            getColor={getOverlayColor}
+            opacity={instancedOpacity}
+            lineWidth={cuboidLineWidth}
+            useLegacyCoordinates={settings.useLegacyCoordinates}
+            overlayRotationFallback={overlayRotation}
+            hoverSource={hoverSource}
+            showOrientation={showCuboidOrientation}
+            onClick={(label, e) => handleSelect(label, ANNOTATION_CUBOID, e)}
+          />
+        </mesh>
+      );
+
+      return worldTransform ? (
+        <group
+          key={sampleId}
+          position={worldTransform.translation}
+          quaternion={worldTransform.quaternion}
+        >
+          {instances}
+        </group>
+      ) : (
+        <group key="native">{instances}</group>
+      );
+    });
+  }, [
+    cuboidLineWidth,
+    directPcdWorldTransformsBySampleId,
+    getOverlayColor,
+    handleSelect,
+    hoverSource,
+    instancedDetections,
+    instancedOpacity,
+    overlayRotation,
+    settings.useLegacyCoordinates,
+    showCuboidOrientation,
+  ]);
 
   // Polylines render model -> JSX
   const polylineOverlays = useMemo(() => {
@@ -490,10 +548,8 @@ export const ThreeDLabels = ({
   return (
     <group>
       {workingStoreManager}
-      <mesh rotation={overlayRotation}>
-        {cuboidOverlays}
-        {cuboidInstances}
-      </mesh>
+      {cuboidOverlays}
+      {cuboidInstances}
       {polylineOverlays}
     </group>
   );

--- a/app/packages/looker-3d/src/utils/point-cloud-crop.test.ts
+++ b/app/packages/looker-3d/src/utils/point-cloud-crop.test.ts
@@ -38,6 +38,9 @@ const buildDetection = (
     ui: { selected: false },
   }) as ReconciledDetection3D;
 
+const expectCloseToTuple = (values: readonly number[]) =>
+  values.map((value) => expect.closeTo(value, 10));
+
 describe("point-cloud crop", () => {
   it("creates a crop from a selected cuboid", () => {
     const crop = getSelectedCuboidPointCloudCrop({
@@ -46,6 +49,44 @@ describe("point-cloud crop", () => {
     });
 
     expect(crop?.labelId).toBe("detection-1");
+  });
+
+  it("aligns a native selected-cuboid crop with its displayed PCD", () => {
+    const frameQuaternion = new Quaternion().setFromAxisAngle(
+      new Vector3(0, 0, 1),
+      Math.PI / 2,
+    );
+    const crop = getSelectedCuboidPointCloudCrop({
+      renderModel: {
+        detections: [
+          buildDetection({ location: [1, 0, 0], dimensions: [4, 2, 2] }),
+        ],
+        polylines: [],
+      },
+      selectedLabelId: "detection-1",
+      margin: 0,
+      directPcdWorldTransformsBySampleId: {
+        "sample-1": {
+          translation: [10, 0, 0],
+          quaternion: [
+            frameQuaternion.x,
+            frameQuaternion.y,
+            frameQuaternion.z,
+            frameQuaternion.w,
+          ],
+          source_frame: "lidar_top",
+          target_frame: "world",
+        },
+      },
+    });
+
+    expect(crop?.center.toArray()).toEqual(expectCloseToTuple([10, 1, 0]));
+    expect(isPointInsidePointCloudCrop(new Vector3(10, 2.9, 0), crop!)).toBe(
+      true,
+    );
+    expect(isPointInsidePointCloudCrop(new Vector3(11.1, 1, 0), crop!)).toBe(
+      false,
+    );
   });
 
   it("selects an explore cuboid that exists in the render model", () => {
@@ -279,7 +320,6 @@ describe("point-cloud crop", () => {
     });
     const workingDoc: WorkingDoc = {
       labelsById: { [detection.data._id]: detection },
-      deletedIds: new Set(),
     };
     const transient: TransientStore = {
       cuboids: {

--- a/app/packages/looker-3d/src/utils/point-cloud-crop.ts
+++ b/app/packages/looker-3d/src/utils/point-cloud-crop.ts
@@ -8,6 +8,11 @@ import {
   DEFAULT_SELECTED_CUBOID_CROP_MARGIN,
   POINT_CLOUD_CROP_BOUNDS_EPSILON,
 } from "../constants";
+import {
+  transformCuboidToWorldFrame,
+  type DirectPcdWorldTransforms,
+} from "../fo3d/direct-pcd-world-alignment";
+import type { StaticTransform } from "../frustum/types";
 
 export interface PointCloudCrop {
   labelId: string;
@@ -26,6 +31,10 @@ interface CreatePointCloudCropOptions {
   visibleWorldHeightAtCenter?: number | null;
 }
 
+interface CreateCuboidPointCloudCropOptions extends CreatePointCloudCropOptions {
+  nativeToWorld?: StaticTransform;
+}
+
 interface CreatePointCloudCropFromPointOptions extends CreatePointCloudCropOptions {
   labelId?: string;
   upVector?: THREE.Vector3 | null;
@@ -33,6 +42,7 @@ interface CreatePointCloudCropFromPointOptions extends CreatePointCloudCropOptio
 }
 
 interface RenderModelPointCloudCropOptions extends CreatePointCloudCropOptions {
+  directPcdWorldTransformsBySampleId?: DirectPcdWorldTransforms;
   renderModel: RenderModel;
 }
 
@@ -108,10 +118,11 @@ export const createPointCloudCropFromCuboidTransform = (
   cuboid: CuboidTransformData,
   {
     margin,
+    nativeToWorld,
     source,
     useLegacyCoordinates = false,
     visibleWorldHeightAtCenter,
-  }: CreatePointCloudCropOptions = {},
+  }: CreateCuboidPointCloudCropOptions = {},
 ): PointCloudCrop | null => {
   if (
     !isFiniteNumberTuple(cuboid.location, 3) ||
@@ -135,9 +146,22 @@ export const createPointCloudCropFromCuboidTransform = (
     center.y -= size.y / 2;
   }
 
+  const displayCuboid = nativeToWorld
+    ? transformCuboidToWorldFrame(
+        {
+          ...cuboid,
+          location: center.toArray(),
+        },
+        nativeToWorld,
+      )
+    : cuboid;
+  if (nativeToWorld) {
+    center.set(...displayCuboid.location);
+  }
+
   const resolvedMargin = resolveCropMargin(margin);
   const halfSize = size.multiplyScalar(0.5).addScalar(resolvedMargin);
-  const quaternion = getCuboidQuaternion(cuboid);
+  const quaternion = getCuboidQuaternion(displayCuboid);
   const boxToWorld = new THREE.Matrix4().compose(
     center,
     quaternion,
@@ -159,7 +183,7 @@ export const createPointCloudCropFromCuboidTransform = (
 
 export const createPointCloudCropFromDetection = (
   detection: ReconciledDetection3D,
-  options: CreatePointCloudCropOptions = {},
+  options: CreateCuboidPointCloudCropOptions = {},
 ) => {
   return createPointCloudCropFromCuboidTransform(
     detection.data._id,
@@ -222,12 +246,14 @@ export const getSelectedCuboidPointCloudCrop = ({
   renderModel,
   selectedLabelId,
   margin,
+  directPcdWorldTransformsBySampleId,
   useLegacyCoordinates = false,
 }: SelectedPointCloudCropOptions): PointCloudCrop | null => {
   return getCuboidPointCloudCrop({
     renderModel,
     labelId: selectedLabelId,
     margin,
+    directPcdWorldTransformsBySampleId,
     source: "selection",
     useLegacyCoordinates,
   });
@@ -258,6 +284,7 @@ export const getCuboidPointCloudCrop = ({
   renderModel,
   labelId,
   margin,
+  directPcdWorldTransformsBySampleId,
   source,
   useLegacyCoordinates = false,
   visibleWorldHeightAtCenter,
@@ -276,6 +303,7 @@ export const getCuboidPointCloudCrop = ({
 
   return createPointCloudCropFromDetection(detection, {
     margin,
+    nativeToWorld: directPcdWorldTransformsBySampleId?.[detection.sampleId],
     source,
     useLegacyCoordinates,
     visibleWorldHeightAtCenter,

--- a/e2e-pw/src/oss/specs/grouped-direct-pcd-world-alignment.spec.ts
+++ b/e2e-pw/src/oss/specs/grouped-direct-pcd-world-alignment.spec.ts
@@ -1,0 +1,291 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Jimp } from "jimp";
+import { expect, Locator, test as base } from "src/oss/fixtures";
+import type { AnnotateSDK } from "src/oss/fixtures/annotate-sdk";
+import { GridPom } from "src/oss/poms/grid";
+import { ModalPom } from "src/oss/poms/modal";
+import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
+import type { AbstractFiftyoneLoader } from "src/shared/abstract-loader";
+
+const datasetName = getUniqueDatasetNameWithPrefix(
+  "grouped-direct-pcd-world-alignment",
+);
+const leftPcdPath = `/tmp/${datasetName}-lidar-left.pcd`;
+const rightPcdPath = `/tmp/${datasetName}-lidar-right.pcd`;
+const TEMP_FILE_PATHS = [leftPcdPath, rightPcdPath];
+
+const test = base.extend<{ grid: GridPom; modal: ModalPom }>({
+  grid: async ({ page, eventUtils }, use) => {
+    await use(new GridPom(page, eventUtils));
+  },
+  modal: async ({ page, eventUtils }, use) => {
+    await use(new ModalPom(page, eventUtils));
+  },
+});
+
+type PersistedCuboid = {
+  dimensions: number[];
+  label: string;
+  location: number[];
+  rotation: number[];
+};
+
+const seedDataset = async (
+  fiftyoneLoader: AbstractFiftyoneLoader,
+  annotateSDK: AnnotateSDK,
+) => {
+  await fiftyoneLoader.executePythonCode(`
+import fiftyone as fo
+import fiftyone.core.media as fom
+from fiftyone.core.camera import StaticTransform
+
+if fo.dataset_exists("${datasetName}"):
+    fo.delete_dataset("${datasetName}")
+
+dataset = fo.Dataset("${datasetName}")
+dataset.add_group_field("group", default="lidar_left")
+dataset._doc.group_media_types = {
+    "lidar_left": fom.POINT_CLOUD,
+    "lidar_right": fom.POINT_CLOUD,
+}
+dataset.static_transforms = {
+    "lidar_left::ego": StaticTransform(
+        translation=[-8.0, 0.0, 0.0],
+        quaternion=[0.0, 0.0, 0.7071067811865476, 0.7071067811865476],
+        source_frame="lidar_left",
+        target_frame="ego",
+    ),
+    "ego::world": StaticTransform(
+        translation=[0.0, 0.0, 0.0],
+        quaternion=[0.0, 0.0, 0.0, 1.0],
+        source_frame="ego",
+        target_frame="world",
+    ),
+    "lidar_right::world": StaticTransform(
+        translation=[8.0, 0.0, 0.0],
+        quaternion=[0.0, 0.0, 0.0, 1.0],
+        source_frame="lidar_right",
+        target_frame="world",
+    ),
+}
+
+group = fo.Group()
+left = fo.Sample(
+    filepath="${leftPcdPath}",
+    media_type="point-cloud",
+    group=group.element("lidar_left"),
+    detections=fo.Detections(
+        detections=[
+            fo.Detection(
+                label="seeded-left",
+                location=[1.5, 1.5, 1.5],
+                dimensions=[2.0, 2.0, 2.0],
+                rotation=[0.0, 0.0, 0.0],
+            )
+        ]
+    ),
+)
+right = fo.Sample(
+    filepath="${rightPcdPath}",
+    media_type="point-cloud",
+    group=group.element("lidar_right"),
+)
+dataset.add_samples([left, right])
+dataset.persistent = True
+  `);
+
+  await annotateSDK.updateLabelSchema(datasetName, "detections", {
+    type: "detections",
+    classes: ["seeded-left", "world-created"],
+    attributes: [],
+    component: "dropdown",
+  });
+  await annotateSDK.addFieldToActiveLabelSchema(datasetName, "detections");
+};
+
+const readLeftCuboids = async (
+  fiftyoneLoader: AbstractFiftyoneLoader,
+): Promise<PersistedCuboid[]> => {
+  const resultFile = path.join(
+    os.tmpdir(),
+    `grouped-world-cuboids-${datasetName}.json`,
+  );
+
+  await fiftyoneLoader.executePythonCode(`
+import json
+import fiftyone as fo
+
+dataset = fo.load_dataset("${datasetName}")
+sample = dataset.select_group_slices("lidar_left").first()
+cuboids = []
+for detection in sample.detections.detections:
+    cuboids.append({
+        "label": detection.label,
+        "location": list(detection.location),
+        "dimensions": list(detection.dimensions),
+        "rotation": list(detection.rotation),
+    })
+
+with open("${resultFile}", "w") as f:
+    json.dump(cuboids, f)
+  `);
+
+  const result = JSON.parse(
+    fs.readFileSync(resultFile, "utf-8"),
+  ) as PersistedCuboid[];
+  fs.rmSync(resultFile, { force: true });
+  return result;
+};
+
+const countOuterBandPixels = async (canvas: Locator) => {
+  const screenshot = await canvas.screenshot();
+  const image = await Jimp.read(screenshot);
+  const { data, width, height } = image.bitmap;
+
+  const countBand = (minXFraction: number, maxXFraction: number) => {
+    const minX = Math.floor(width * minXFraction);
+    const maxX = Math.floor(width * maxXFraction);
+    const minY = Math.floor(height * 0.15);
+    const maxY = Math.floor(height * 0.85);
+    let count = 0;
+
+    for (let y = minY; y < maxY; y++) {
+      for (let x = minX; x < maxX; x++) {
+        const offset = (y * width + x) * 4;
+        if (
+          data[offset + 3] > 0 &&
+          data[offset] + data[offset + 1] + data[offset + 2] > 45
+        ) {
+          count++;
+        }
+      }
+    }
+
+    return count;
+  };
+
+  return {
+    left: countBand(0.08, 0.42),
+    right: countBand(0.58, 0.92),
+  };
+};
+
+test.beforeAll(
+  async ({ annotateSDK, fiftyoneLoader, foWebServer, mediaFactory }) => {
+    await foWebServer.startWebServer();
+    mediaFactory.createPcd({
+      outputPath: leftPcdPath,
+      shape: "cube",
+      numPoints: 216,
+    });
+    mediaFactory.createPcd({
+      outputPath: rightPcdPath,
+      shape: "cube",
+      numPoints: 216,
+    });
+    await seedDataset(fiftyoneLoader, annotateSDK);
+  },
+);
+
+test.afterAll(async ({ fiftyoneLoader, foWebServer }) => {
+  try {
+    await fiftyoneLoader.executePythonCode(`
+import fiftyone as fo
+
+if fo.dataset_exists("${datasetName}"):
+    fo.delete_dataset("${datasetName}")
+    `);
+  } catch (error) {
+    void error;
+  }
+
+  try {
+    await foWebServer.stopWebServer();
+  } catch (error) {
+    void error;
+  }
+
+  for (const filePath of TEMP_FILE_PATHS) {
+    fs.rmSync(filePath, { force: true });
+  }
+});
+
+test("aligns grouped direct PCDs in world and writes cuboids back to the native slice", async ({
+  fiftyoneLoader,
+  grid,
+  modal,
+  page,
+}) => {
+  await fiftyoneLoader.waitUntilGridVisible(page, datasetName);
+  await page.evaluate(() =>
+    window.localStorage.setItem("fo-3d-annotation-tips-dismissed", "true"),
+  );
+
+  await grid.openFirstSample();
+  await modal.waitForSampleLoadDomAttribute(true);
+  await modal.looker3dControls.waitForAllAssetsLoaded();
+  await modal.toggleLooker3dSlice("lidar_right");
+  await modal.looker3dControls.waitForAllAssetsLoaded();
+  await modal.looker3dControls.setTopView();
+  await modal.looker3dControls.toggleGridHelper();
+
+  await expect
+    .poll(
+      async () => {
+        const visiblePixels = await countOuterBandPixels(
+          modal.annotate3d.canvas,
+        );
+        return Math.min(visiblePixels.left, visiblePixels.right);
+      },
+      { timeout: 10_000 },
+    )
+    .toBeGreaterThan(30);
+
+  await modal.sidebar.switchMode("annotate");
+  await modal.sidebar.annotate.selectAnnotationSlice("lidar_left");
+  await modal.sidebar.annotate.assert.verifySelectedAnnotationSlice(
+    "lidar_left",
+  );
+  await modal.annotate3d.waitForSurface();
+  await modal.annotate3d.enterCuboidMode();
+  await modal.looker3dControls.setTopView();
+  await modal.annotate3d.toggleCreateCuboid();
+  await modal.annotate3d.drawCuboid([
+    [0.42, 0.42],
+    [0.58, 0.42],
+    [0.58, 0.58],
+  ]);
+  await modal.sidebar.edit.selectFieldChoice("label", "world-created");
+  await modal.sidebar.annotate.waitForSavesSettled();
+
+  let createdCuboid: PersistedCuboid | undefined;
+  await expect
+    .poll(
+      async () => {
+        const cuboids = await readLeftCuboids(fiftyoneLoader);
+        createdCuboid = cuboids.find(
+          (cuboid) => cuboid.label === "world-created",
+        );
+        return createdCuboid;
+      },
+      { timeout: 20_000 },
+    )
+    .toBeTruthy();
+
+  expect(createdCuboid).toBeDefined();
+  expect(Math.hypot(...createdCuboid!.location.slice(0, 2))).toBeGreaterThan(4);
+  expect(Math.abs(createdCuboid!.rotation[2])).toBeCloseTo(Math.PI / 2, 1);
+  expect(createdCuboid!.dimensions.every((value) => value > 0)).toBe(true);
+
+  const persistedX = createdCuboid!.location[0].toFixed(2);
+  await modal.close();
+  await grid.openFirstSample();
+  await modal.sidebar.switchMode("annotate");
+  await modal.sidebar.annotate.selectAnnotationSlice("lidar_left");
+  await modal.annotate3d.waitForSurface();
+  await modal.annotate3d.assert.labelListed("world-created");
+  await modal.annotate3d.selectLabel("world-created");
+  await expect(modal.annotate3d.geometryField("x")).toHaveValue(persistedX);
+});

--- a/e2e-pw/src/oss/specs/grouped-direct-pcd-world-alignment.spec.ts
+++ b/e2e-pw/src/oss/specs/grouped-direct-pcd-world-alignment.spec.ts
@@ -12,8 +12,8 @@ import type { AbstractFiftyoneLoader } from "src/shared/abstract-loader";
 const datasetName = getUniqueDatasetNameWithPrefix(
   "grouped-direct-pcd-world-alignment",
 );
-const leftPcdPath = `/tmp/${datasetName}-lidar-left.pcd`;
-const rightPcdPath = `/tmp/${datasetName}-lidar-right.pcd`;
+const leftPcdPath = path.join(os.tmpdir(), `${datasetName}-lidar-left.pcd`);
+const rightPcdPath = path.join(os.tmpdir(), `${datasetName}-lidar-right.pcd`);
 const TEMP_FILE_PATHS = [leftPcdPath, rightPcdPath];
 
 const test = base.extend<{ grid: GridPom; modal: ModalPom }>({
@@ -73,7 +73,7 @@ dataset.static_transforms = {
 
 group = fo.Group()
 left = fo.Sample(
-    filepath="${leftPcdPath}",
+    filepath=${JSON.stringify(leftPcdPath)},
     media_type="point-cloud",
     group=group.element("lidar_left"),
     detections=fo.Detections(
@@ -88,7 +88,7 @@ left = fo.Sample(
     ),
 )
 right = fo.Sample(
-    filepath="${rightPcdPath}",
+    filepath=${JSON.stringify(rightPcdPath)},
     media_type="point-cloud",
     group=group.element("lidar_right"),
 )
@@ -128,7 +128,7 @@ for detection in sample.detections.detections:
         "rotation": list(detection.rotation),
     })
 
-with open("${resultFile}", "w") as f:
+with open(${JSON.stringify(resultFile)}, "w") as f:
     json.dump(cuboids, f)
   `);
 
@@ -279,7 +279,7 @@ test("aligns grouped direct PCDs in world and writes cuboids back to the native 
   expect(Math.abs(createdCuboid!.rotation[2])).toBeCloseTo(Math.PI / 2, 1);
   expect(createdCuboid!.dimensions.every((value) => value > 0)).toBe(true);
 
-  const persistedX = createdCuboid!.location[0].toFixed(2);
+  const persistedX = createdCuboid!.location[0];
   await modal.close();
   await grid.openFirstSample();
   await modal.sidebar.switchMode("annotate");
@@ -287,5 +287,9 @@ test("aligns grouped direct PCDs in world and writes cuboids back to the native 
   await modal.annotate3d.waitForSurface();
   await modal.annotate3d.assert.labelListed("world-created");
   await modal.annotate3d.selectLabel("world-created");
-  await expect(modal.annotate3d.geometryField("x")).toHaveValue(persistedX);
+  await expect
+    .poll(async () =>
+      Number(await modal.annotate3d.geometryField("x").inputValue()),
+    )
+    .toBeCloseTo(persistedX, 2);
 });

--- a/e2e-pw/src/oss/specs/grouped-direct-pcd-world-alignment.spec.ts
+++ b/e2e-pw/src/oss/specs/grouped-direct-pcd-world-alignment.spec.ts
@@ -275,8 +275,9 @@ test("aligns grouped direct PCDs in world and writes cuboids back to the native 
     .toBeTruthy();
 
   expect(createdCuboid).toBeDefined();
-  expect(Math.hypot(...createdCuboid!.location.slice(0, 2))).toBeGreaterThan(4);
-  expect(Math.abs(createdCuboid!.rotation[2])).toBeCloseTo(Math.PI / 2, 1);
+  expect(createdCuboid!.location[0]).toBeCloseTo(2, 1);
+  expect(createdCuboid!.location[1]).toBeCloseTo(-23.15, 1);
+  expect(createdCuboid!.rotation[2]).toBeCloseTo(Math.PI / 2, 1);
   expect(createdCuboid!.dimensions.every((value) => value > 0)).toBe(true);
 
   const persistedX = createdCuboid!.location[0];

--- a/fiftyone/server/routes/camera.py
+++ b/fiftyone/server/routes/camera.py
@@ -419,6 +419,25 @@ def _has_successful_static_transform(results: dict) -> bool:
     return False
 
 
+def _has_group_static_transform_configuration(
+    dataset, group_id: str, slices: List[str]
+) -> bool:
+    """Checks whether static transforms are configured for a group request."""
+    if dataset.static_transforms:
+        return True
+
+    for slice_name in slices:
+        slice_sample, error = _get_slice_sample(dataset, group_id, slice_name)
+        if error:
+            continue
+
+        for _, value in slice_sample.iter_fields():
+            if next(_iter_static_transform_values(value), None) is not None:
+                return True
+
+    return False
+
+
 def _collect_static_transforms(
     dataset,
     group_id: str,
@@ -575,6 +594,9 @@ class GroupStaticTransforms(HTTPEndpoint):
         results = _collect_static_transforms(
             dataset, group_id, slices, source_frame, target_frame, chain_via
         )
+        has_static_transforms = _has_group_static_transform_configuration(
+            dataset, group_id, slices
+        )
 
         # If no successful transforms found and target_frame was defaulted,
         # try to find the best available target
@@ -607,6 +629,7 @@ class GroupStaticTransforms(HTTPEndpoint):
         return utils.json.JSONResponse(
             {
                 "group_id": group_id,
+                "has_static_transforms": has_static_transforms,
                 "target_frame": target_frame,
                 "results": results,
             }

--- a/fiftyone/server/routes/camera.py
+++ b/fiftyone/server/routes/camera.py
@@ -419,18 +419,12 @@ def _has_successful_static_transform(results: dict) -> bool:
     return False
 
 
-def _has_group_static_transform_configuration(
-    dataset, group_id: str, slices: List[str]
-) -> bool:
+def _has_group_static_transform_configuration(dataset, group_samples) -> bool:
     """Checks whether static transforms are configured for a group request."""
     if dataset.static_transforms:
         return True
 
-    for slice_name in slices:
-        slice_sample, error = _get_slice_sample(dataset, group_id, slice_name)
-        if error:
-            continue
-
+    for slice_sample in group_samples.values():
         for _, value in slice_sample.iter_fields():
             if next(_iter_static_transform_values(value), None) is not None:
                 return True
@@ -440,7 +434,7 @@ def _has_group_static_transform_configuration(
 
 def _collect_static_transforms(
     dataset,
-    group_id: str,
+    group_samples,
     slices: List[str],
     source_frame: str,
     target_frame: str,
@@ -450,7 +444,7 @@ def _collect_static_transforms(
 
     Args:
         dataset: The FiftyOne dataset
-        group_id: The group ID to fetch transforms for
+        group_samples: Dict mapping slice names to samples in the group
         slices: List of slice names to collect transforms from
         source_frame: The source coordinate frame
         target_frame: The target coordinate frame
@@ -462,9 +456,11 @@ def _collect_static_transforms(
     """
     results = {}
     for slice_name in slices:
-        slice_sample, error = _get_slice_sample(dataset, group_id, slice_name)
-        if error:
-            results[slice_name] = error
+        slice_sample = group_samples.get(slice_name)
+        if slice_sample is None:
+            results[slice_name] = {
+                "error": f"Slice '{slice_name}' not found in group"
+            }
             continue
 
         try:
@@ -482,7 +478,11 @@ def _collect_static_transforms(
             results[slice_name] = {"staticTransform": None}
         else:
             results[slice_name] = {
-                "staticTransform": utils.json.serialize(transform)
+                "staticTransform": _serialize_static_transform(
+                    transform,
+                    fallback_source_frame=slice_name,
+                    fallback_target_frame=target_frame,
+                )
             }
 
     return results
@@ -591,11 +591,17 @@ class GroupStaticTransforms(HTTPEndpoint):
             chain_via,
         )
 
+        group_samples = dataset.get_group(group_id)
         results = _collect_static_transforms(
-            dataset, group_id, slices, source_frame, target_frame, chain_via
+            dataset,
+            group_samples,
+            slices,
+            source_frame,
+            target_frame,
+            chain_via,
         )
         has_static_transforms = _has_group_static_transform_configuration(
-            dataset, group_id, slices
+            dataset, group_samples
         )
 
         # If no successful transforms found and target_frame was defaulted,
@@ -619,7 +625,7 @@ class GroupStaticTransforms(HTTPEndpoint):
                     # Re-collect results with new target_frame
                     results = _collect_static_transforms(
                         dataset,
-                        group_id,
+                        group_samples,
                         slices,
                         source_frame,
                         target_frame,

--- a/tests/unittests/server/routes/test_camera.py
+++ b/tests/unittests/server/routes/test_camera.py
@@ -670,7 +670,6 @@ class TestGroupStaticTransformsRoute:
         self,
         group_static_transforms_endpoint,
         mock_group_request,
-        grouped_dataset,
     ):
         """Tests retrieving static transforms for all slices in a group."""
         request = mock_group_request()
@@ -701,7 +700,8 @@ class TestGroupStaticTransformsRoute:
         grouped_dataset,
     ):
         """Tests the identity-compatible no-configuration signal."""
-        for sample in grouped_dataset:
+        group_id = grouped_dataset.first().group.id
+        for sample in grouped_dataset.get_group(group_id).values():
             if sample.has_field("static_transform"):
                 del sample["static_transform"]
                 sample.save()
@@ -713,6 +713,47 @@ class TestGroupStaticTransformsRoute:
         data = json.loads(response.body)
         assert data["has_static_transforms"] is False
         assert data["results"]["lidar"]["staticTransform"] is None
+
+    @pytest.mark.asyncio
+    async def test_get_group_static_transforms_detects_configuration_on_other_slice(
+        self,
+        group_static_transforms_endpoint,
+        mock_group_request,
+    ):
+        """Tests that configuration detection covers the entire group."""
+        request = mock_group_request(query_params={"slices": "lidar"})
+        response = await group_static_transforms_endpoint.get(request)
+
+        assert response.status_code == 200
+        data = json.loads(response.body)
+        assert data["has_static_transforms"] is True
+        assert data["results"]["lidar"]["staticTransform"] is None
+
+    @pytest.mark.asyncio
+    async def test_get_group_static_transforms_normalizes_implicit_world_target(
+        self,
+        group_static_transforms_endpoint,
+        mock_group_request,
+        grouped_dataset,
+    ):
+        """Tests that an omitted transform target serializes as world."""
+        lidar_sample = grouped_dataset.select_group_slices("lidar").first()
+        lidar_sample["static_transform"] = StaticTransform(
+            translation=[2.0, 0.0, 0.0],
+            quaternion=[0.0, 0.0, 0.0, 1.0],
+            source_frame="lidar",
+        )
+        lidar_sample.save()
+
+        request = mock_group_request(query_params={"slices": "lidar"})
+        response = await group_static_transforms_endpoint.get(request)
+
+        assert response.status_code == 200
+        data = json.loads(response.body)
+        transform = data["results"]["lidar"]["staticTransform"]
+        assert transform["source_frame"] == "lidar"
+        assert transform["target_frame"] == "world"
+        assert transform["translation"] == [2.0, 0.0, 0.0]
 
     @pytest.mark.asyncio
     async def test_get_group_static_transforms_specific_slices(

--- a/tests/unittests/server/routes/test_camera.py
+++ b/tests/unittests/server/routes/test_camera.py
@@ -679,6 +679,7 @@ class TestGroupStaticTransformsRoute:
         assert response.status_code == 200
         data = json.loads(response.body)
         assert "group_id" in data
+        assert data["has_static_transforms"] is True
         assert "results" in data
 
         # Should have results for all 3 slices
@@ -690,6 +691,27 @@ class TestGroupStaticTransformsRoute:
         # left and right have staticTransform, lidar doesn't
         assert "staticTransform" in data["results"]["left"]
         assert "staticTransform" in data["results"]["right"]
+        assert data["results"]["lidar"]["staticTransform"] is None
+
+    @pytest.mark.asyncio
+    async def test_get_group_static_transforms_reports_no_configuration(
+        self,
+        group_static_transforms_endpoint,
+        mock_group_request,
+        grouped_dataset,
+    ):
+        """Tests the identity-compatible no-configuration signal."""
+        for sample in grouped_dataset:
+            if sample.has_field("static_transform"):
+                del sample["static_transform"]
+                sample.save()
+
+        request = mock_group_request(query_params={"slices": "lidar"})
+        response = await group_static_transforms_endpoint.get(request)
+
+        assert response.status_code == 200
+        data = json.loads(response.body)
+        assert data["has_static_transforms"] is False
         assert data["results"]["lidar"]["staticTransform"] is None
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

Align grouped direct PCD slices and their 3D cuboids in the existing world frame when static transforms are configured. Cuboid creation and edits stay in the aligned display, then save back into the selected slice native sensor frame. Configured slices that cannot resolve to world now show a load error instead of rendering at identity.

## 🧪 How is this patch tested? If it is not, please explain why.

- `./node_modules/.bin/vitest run packages/looker-3d/src/fo3d/direct-pcd-world-alignment.test.ts packages/looker-3d/src/utils/point-cloud-crop.test.ts packages/looker-3d/src/annotation/cuboid-face-resize.test.ts packages/looker-3d/src/annotation/cuboid-heading-relabel.test.ts packages/looker-3d/src/annotation/CreateCuboidRenderer.test.tsx packages/looker-3d/src/fo3d/synthetic-scene.test.ts packages/looker-3d/src/hooks/use-fo3d.test.ts --coverage.enabled=false` — 222 tests passed
- `python -m pytest tests/unittests/server/routes/test_camera.py -q` — 38 tests passed
- `src/oss/specs/grouped-direct-pcd-world-alignment.spec.ts`, exact title run once and with `--repeat-each=3` — 1/1 and 3/3 passed
- Existing cuboid form persistence and undo/redo Playwright coverage — passed
- `yarn lint` in `e2e-pw` — passed
- Live grouped-PCD smoke test — verified two offset sensor-local clouds align in world and cuboid edits round-trip to native coordinates

## Notes to Reviewer

This is best reviewed commit-by-commit. The product change is limited to grouped direct PCD assets, static transforms, and the existing cuboid annotation path.

## High Level Architecture

- The grouped transform route resolves each slice native frame to the explicit `world` target and reports whether spatial configuration exists anywhere in the group.
- Direct PCD scene nodes and cuboid labels share the resolved parent transform. Unresolved configured slices fail through the existing scene load error.
- Cuboid interaction stays in world display coordinates. Creation and persistence inverse-transform center and orientation into the writable slice native frame.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Grouped direct PCD slices and their 3D cuboids now display in a shared world frame when static transforms are configured. Cuboid annotations continue to save in the selected slice native sensor frame.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3872
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added world-frame alignment for grouped point-cloud scenes.
  - Cuboids now render, create, edit, and crop correctly across transformed point-cloud slices.
  - Preserved cuboid orientation and dimensions while applying scene transforms.
  - Added clearer handling for unavailable or invalid alignment data.

- **Bug Fixes**
  - Improved persistence and restoration of world-aligned cuboid geometry across sessions.

- **Tests**
  - Added unit, integration, and end-to-end coverage for transformed scenes, cuboids, cropping, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->