### PR TITLE
Don't select existing labels on click while a draw tool is active

### DIFF
--- a/app/packages/lighter/src/interaction/InteractionManager.ts
+++ b/app/packages/lighter/src/interaction/InteractionManager.ts
@@ -296,11 +296,8 @@ export class InteractionManager {
   }
 
   /**
-   * Whether a label-creation tool is active: detection (bbox) mode, or a
-   * segmentation painting tool. While drawing, unselected overlays under the
-   * cursor are treated as empty canvas so a new label can be started anywhere;
-   * labels are only selectable via the Select tool. The Merge tool is excluded
-   * because it picks its sources by selecting overlays.
+   * While a creation tool is active, unselected overlays are treated as empty
+   * canvas. Merge is excluded because it picks sources by selecting overlays.
    */
   private isDrawModeActive(): boolean {
     if (detectionModeBridge.isActive()) {
@@ -388,10 +385,8 @@ export class InteractionManager {
         TypeGuards.isSelectable(handler) &&
         !this.selectionManager.isSelected(handler.id);
 
-      // While a draw tool is active, an unselected overlay under the cursor
-      // never claims the click — the click starts a new label instead, so
-      // dense scenes stay drawable. The selected overlay still wins the hit
-      // test, keeping drag/resize of the label being edited intact.
+      // While drawing, unselected overlays never claim the click; the
+      // selected overlay still wins the hit test so drag/resize works
       const drawOverOverlay = isUnselectedOverlay && this.isDrawModeActive();
 
       if (isUnselectedOverlay && !drawOverOverlay) {
@@ -498,8 +493,7 @@ export class InteractionManager {
       return;
     }
 
-    // While a draw tool is active, unselected overlays don't claim clicks, so
-    // don't advertise selection with a 'pointer' — show the mode cursor.
+    // unselected overlays aren't clickable while drawing — show the mode cursor
     const isUnselectedOverlay =
       TypeGuards.isSelectable(handler) && !handler.isSelected?.();
 

--- a/app/packages/lighter/src/interaction/InteractionManager.ts
+++ b/app/packages/lighter/src/interaction/InteractionManager.ts
@@ -312,6 +312,16 @@ export class InteractionManager {
     return tool !== SegmentationTool.Select && tool !== SegmentationTool.Merge;
   }
 
+  /** While drawing, an unselected overlay never claims the pointer. */
+  private isDrawingOverUnselected(handler?: InteractionHandler): boolean {
+    return (
+      !!handler &&
+      TypeGuards.isSelectable(handler) &&
+      !this.selectionManager.isSelected(handler.id) &&
+      this.isDrawModeActive()
+    );
+  }
+
   private setupEventListeners(): void {
     this.canvas.addEventListener("pointerdown", this.handlePointerDown);
     this.canvas.addEventListener("pointermove", this.handlePointerMove);
@@ -385,9 +395,8 @@ export class InteractionManager {
         TypeGuards.isSelectable(handler) &&
         !this.selectionManager.isSelected(handler.id);
 
-      // While drawing, unselected overlays never claim the click; the
-      // selected overlay still wins the hit test so drag/resize works
-      const drawOverOverlay = isUnselectedOverlay && this.isDrawModeActive();
+      // the selected overlay still wins the hit test so drag/resize works
+      const drawOverOverlay = this.isDrawingOverUnselected(handler);
 
       if (isUnselectedOverlay && !drawOverOverlay) {
         this.selectionManager.select(handler!.id);
@@ -1353,7 +1362,10 @@ export class InteractionManager {
     // Hover target is pre-resolved by the caller (single hit-test per
     // pointermove). `undefined` means either nothing under the cursor or a
     // drag is active and hover should be cleared.
-    const handler = resolvedHandler;
+    // no hover highlight while drawing over an unselected overlay
+    const handler = this.isDrawingOverUnselected(resolvedHandler)
+      ? undefined
+      : resolvedHandler;
     const interactingHandler = this.findInteractingHandler();
 
     // If we are dragging, we should unhover the previous one

--- a/app/packages/lighter/src/interaction/InteractionManager.ts
+++ b/app/packages/lighter/src/interaction/InteractionManager.ts
@@ -295,6 +295,26 @@ export class InteractionManager {
     return this.currentModifiers.shiftKey;
   }
 
+  /**
+   * Whether a label-creation tool is active: detection (bbox) mode, or a
+   * segmentation painting tool. While drawing, unselected overlays under the
+   * cursor are treated as empty canvas so a new label can be started anywhere;
+   * labels are only selectable via the Select tool. The Merge tool is excluded
+   * because it picks its sources by selecting overlays.
+   */
+  private isDrawModeActive(): boolean {
+    if (detectionModeBridge.isActive()) {
+      return true;
+    }
+
+    if (!segmentationModeBridge.isActive()) {
+      return false;
+    }
+
+    const tool = segmentationModeBridge.getActiveTool();
+    return tool !== SegmentationTool.Select && tool !== SegmentationTool.Merge;
+  }
+
   private setupEventListeners(): void {
     this.canvas.addEventListener("pointerdown", this.handlePointerDown);
     this.canvas.addEventListener("pointermove", this.handlePointerMove);
@@ -368,7 +388,13 @@ export class InteractionManager {
         TypeGuards.isSelectable(handler) &&
         !this.selectionManager.isSelected(handler.id);
 
-      if (isUnselectedOverlay) {
+      // While a draw tool is active, an unselected overlay under the cursor
+      // never claims the click — the click starts a new label instead, so
+      // dense scenes stay drawable. The selected overlay still wins the hit
+      // test, keeping drag/resize of the label being edited intact.
+      const drawOverOverlay = isUnselectedOverlay && this.isDrawModeActive();
+
+      if (isUnselectedOverlay && !drawOverOverlay) {
         this.selectionManager.select(handler!.id);
 
         // Select an overlay before issuing any edits. The cursor at this point
@@ -381,13 +407,12 @@ export class InteractionManager {
 
       // Detection mode: defer overlay creation until we confirm this is a drag.
       // If the user releases without dragging (a click), exit detection mode.
-      // Clicking on an existing overlay selects it normally instead.
       if (detectionModeBridge.isActive() || segmentationModeBridge.isActive()) {
         const isSelectInSegmentation =
           segmentationModeBridge.isActive() &&
           segmentationModeBridge.getActiveTool() === SegmentationTool.Select;
 
-        if (isNonOverlay && !isSelectInSegmentation) {
+        if ((isNonOverlay || drawOverOverlay) && !isSelectInSegmentation) {
           this.renderer.disableZoomPan();
 
           this.pendingAction = {
@@ -473,12 +498,19 @@ export class InteractionManager {
       return;
     }
 
-    if (TypeGuards.isSelectable(handler) && !handler.isSelected?.()) {
+    // While a draw tool is active, unselected overlays don't claim clicks, so
+    // don't advertise selection with a 'pointer' — show the mode cursor.
+    const isUnselectedOverlay =
+      TypeGuards.isSelectable(handler) && !handler.isSelected?.();
+
+    if (isUnselectedOverlay && !this.isDrawModeActive()) {
       this.canvas.style.cursor = "pointer";
     } else if (segmentationModeBridge.isActive()) {
       this.canvas.style.cursor = buildBrushCursor(
         segmentationModeBridge.getToolState(scale)!,
       );
+    } else if (isUnselectedOverlay && detectionModeBridge.isActive()) {
+      this.canvas.style.cursor = "crosshair";
     } else if (TypeGuards.isInteractionHandler(handler) && handler.getCursor) {
       this.canvas.style.cursor = handler.getCursor(
         worldPoint,

--- a/e2e-pw/src/oss/specs/annotate-action-switching.spec.ts
+++ b/e2e-pw/src/oss/specs/annotate-action-switching.spec.ts
@@ -183,7 +183,7 @@ test.describe.serial("action switching", () => {
     await modal.sidebar.annotate.assert.classificationIsActive(false);
   });
 
-  test("clicking overlay in detection mode shows pointer cursor", async ({
+  test("detection mode shows crosshair cursor over existing overlays", async ({
     modal,
   }) => {
     await modal.assert.isOpen();
@@ -196,7 +196,8 @@ test.describe.serial("action switching", () => {
     // Move to empty space — should show crosshair
     await modal.sampleCanvas.move(0.09, 0.09, "crosshair");
 
-    // Move over an existing detection — should show pointer
-    await modal.sampleCanvas.move(0.5, 0.5, "pointer");
+    // Existing overlays don't claim clicks while a draw tool is active, so
+    // the cursor stays a crosshair over them too
+    await modal.sampleCanvas.move(0.5, 0.5, "crosshair");
   });
 });

--- a/e2e-pw/src/oss/specs/annotate-action-switching.spec.ts
+++ b/e2e-pw/src/oss/specs/annotate-action-switching.spec.ts
@@ -196,8 +196,7 @@ test.describe.serial("action switching", () => {
     // Move to empty space — should show crosshair
     await modal.sampleCanvas.move(0.09, 0.09, "crosshair");
 
-    // Existing overlays don't claim clicks while a draw tool is active, so
-    // the cursor stays a crosshair over them too
+    // overlays don't claim clicks while drawing — crosshair over them too
     await modal.sampleCanvas.move(0.5, 0.5, "crosshair");
   });
 });

--- a/e2e-pw/src/oss/specs/annotate-canvas-actions.spec.ts
+++ b/e2e-pw/src/oss/specs/annotate-canvas-actions.spec.ts
@@ -126,7 +126,7 @@ test.describe.serial("canvas interactions and action state", () => {
     await modal.sidebar.annotate.assert.selectIsActive();
   });
 
-  test("clicking an existing detection overlay in detection mode selects it", async ({
+  test("clicking an existing detection overlay in detection mode does not select it", async ({
     modal,
   }) => {
     await modal.assert.isOpen();
@@ -140,19 +140,16 @@ test.describe.serial("canvas interactions and action state", () => {
     await modal.sidebar.annotate.detectionMode("Detections");
     await modal.sidebar.annotate.assert.detectionModeIsActive();
 
-    // Click on the existing detection at (0.4-0.6, 0.4-0.6)
-    await modal.sampleCanvas.move(0.5, 0.5, "pointer");
+    // The existing detection at (0.4-0.6, 0.4-0.6) doesn't claim the pointer
+    // while a draw tool is active — the cursor stays a crosshair over it
+    await modal.sampleCanvas.move(0.5, 0.5, "crosshair");
     await modal.sampleCanvas.down();
     await modal.sampleCanvas.up();
 
-    // detection mode should remain active (it's a detection being edited)
-    await modal.sidebar.annotate.assert.detectionModeIsActive();
-
-    // The label list should be hidden (edit form is showing)
-    const labelListHeader = modal.sidebar.locator.getByText("Edit", {
-      exact: true,
-    });
-    await expect(labelListHeader).toBeHidden();
+    // click-to-quit applies over overlays like empty canvas: detection mode
+    // deactivates and Select reactivates, without selecting the label
+    await modal.sidebar.annotate.assert.detectionModeIsActive(false);
+    await modal.sidebar.annotate.assert.selectIsActive();
   });
 
   test("clicking an existing detection overlay activates detection mode", async ({

--- a/e2e-pw/src/oss/specs/annotate-canvas-actions.spec.ts
+++ b/e2e-pw/src/oss/specs/annotate-canvas-actions.spec.ts
@@ -150,6 +150,12 @@ test.describe.serial("canvas interactions and action state", () => {
     // deactivates and Select reactivates, without selecting the label
     await modal.sidebar.annotate.assert.detectionModeIsActive(false);
     await modal.sidebar.annotate.assert.selectIsActive();
+
+    // the label list header is still showing — the click didn't open the
+    // detection for editing (the list unmounts while a label is being edited)
+    await expect(
+      modal.sidebar.locator.getByText("Edit", { exact: true }),
+    ).toBeVisible();
   });
 
   test("clicking an existing detection overlay activates detection mode", async ({

--- a/e2e-pw/src/oss/specs/annotate-canvas-actions.spec.ts
+++ b/e2e-pw/src/oss/specs/annotate-canvas-actions.spec.ts
@@ -140,19 +140,16 @@ test.describe.serial("canvas interactions and action state", () => {
     await modal.sidebar.annotate.detectionMode("Detections");
     await modal.sidebar.annotate.assert.detectionModeIsActive();
 
-    // The existing detection at (0.4-0.6, 0.4-0.6) doesn't claim the pointer
-    // while a draw tool is active — the cursor stays a crosshair over it
+    // the existing detection at (0.4-0.6, 0.4-0.6) doesn't claim the click
     await modal.sampleCanvas.move(0.5, 0.5, "crosshair");
     await modal.sampleCanvas.down();
     await modal.sampleCanvas.up();
 
-    // click-to-quit applies over overlays like empty canvas: detection mode
-    // deactivates and Select reactivates, without selecting the label
+    // click-to-quit applies over overlays like empty canvas
     await modal.sidebar.annotate.assert.detectionModeIsActive(false);
     await modal.sidebar.annotate.assert.selectIsActive();
 
-    // the label list header is still showing — the click didn't open the
-    // detection for editing (the list unmounts while a label is being edited)
+    // the "Edit" header belongs to the label list, which unmounts while editing
     await expect(
       modal.sidebar.locator.getByText("Edit", { exact: true }),
     ).toBeVisible();

--- a/e2e-pw/src/oss/specs/detection-mode.spec.ts
+++ b/e2e-pw/src/oss/specs/detection-mode.spec.ts
@@ -143,17 +143,14 @@ test.describe.serial("detection mode", () => {
     await modal.sampleCanvas.up();
     await modal.sampleCanvas.assert.hasCursor("nwse-resize");
 
-    // Unselected detection #1 doesn't claim the pointer while drawing: the
-    // cursor stays a crosshair over it, and dragging inside it draws
-    // detection #3 instead of selecting or moving #1
+    // Unselected #1 doesn't claim the pointer: dragging inside it draws #3
     await modal.sampleCanvas.move(0.3, 0.3, "crosshair");
     await modal.sampleCanvas.down();
     await modal.sampleCanvas.move(0.5, 0.5);
     await modal.sampleCanvas.up();
     await modal.sampleCanvas.assert.hasCursor("nwse-resize");
 
-    // The drag created detection #3 rather than selecting or moving #1:
-    // after click-to-quit the label list shows all three detections
+    // Quit, then the label list shows all three (#3 was created, #1 untouched)
     await modal.sampleCanvas.move(0.1, 0.1);
     await modal.sampleCanvas.down();
     await modal.sampleCanvas.up();

--- a/e2e-pw/src/oss/specs/detection-mode.spec.ts
+++ b/e2e-pw/src/oss/specs/detection-mode.spec.ts
@@ -151,6 +151,14 @@ test.describe.serial("detection mode", () => {
     await modal.sampleCanvas.move(0.5, 0.5);
     await modal.sampleCanvas.up();
     await modal.sampleCanvas.assert.hasCursor("nwse-resize");
+
+    // The drag created detection #3 rather than selecting or moving #1:
+    // after click-to-quit the label list shows all three detections
+    await modal.sampleCanvas.move(0.1, 0.1);
+    await modal.sampleCanvas.down();
+    await modal.sampleCanvas.up();
+    await modal.sidebar.annotate.assert.detectionModeIsActive(false);
+    await modal.sidebar.annotate.assert.hasActiveLabelsCount(3);
   });
 
   test("draw multiple detections", async ({ modal }) => {

--- a/e2e-pw/src/oss/specs/detection-mode.spec.ts
+++ b/e2e-pw/src/oss/specs/detection-mode.spec.ts
@@ -124,6 +124,35 @@ test.describe.serial("detection mode", () => {
     );
   });
 
+  test("draw over an existing detection", async ({ modal }) => {
+    // Activate detection mode
+    await modal.sidebar.annotate.detectionMode("Detections");
+    await modal.sidebar.annotate.assert.detectionModeIsActive();
+
+    // Draw detection #1
+    await modal.sampleCanvas.move(0.2, 0.2, "crosshair");
+    await modal.sampleCanvas.down();
+    await modal.sampleCanvas.move(0.6, 0.6);
+    await modal.sampleCanvas.up();
+    await modal.sampleCanvas.assert.hasCursor("nwse-resize");
+
+    // Draw detection #2 in empty space so #1 becomes unselected
+    await modal.sampleCanvas.move(0.7, 0.7, "crosshair");
+    await modal.sampleCanvas.down();
+    await modal.sampleCanvas.move(0.9, 0.9);
+    await modal.sampleCanvas.up();
+    await modal.sampleCanvas.assert.hasCursor("nwse-resize");
+
+    // Unselected detection #1 doesn't claim the pointer while drawing: the
+    // cursor stays a crosshair over it, and dragging inside it draws
+    // detection #3 instead of selecting or moving #1
+    await modal.sampleCanvas.move(0.3, 0.3, "crosshair");
+    await modal.sampleCanvas.down();
+    await modal.sampleCanvas.move(0.5, 0.5);
+    await modal.sampleCanvas.up();
+    await modal.sampleCanvas.assert.hasCursor("nwse-resize");
+  });
+
   test("draw multiple detections", async ({ modal }) => {
     // Activate detection mode
     await modal.sidebar.annotate.detectionMode("Detections");


### PR DESCRIPTION
## What changes are proposed in this pull request?

Resolves [FOEPD-4568](https://voxel51.atlassian.net/browse/FOEPD-4568)

While a draw tool is active in Annotate mode (detection bbox, or a segmentation painting tool), clicking the canvas no longer selects an existing label under the cursor — unselected overlays behave like empty canvas, so dense or fully-labeled scenes stay drawable. Labels are selectable via the **Select** tool (and **Merge**, which picks its sources by selection).

Consequences of that rule:

- The *selected* overlay still wins the hit test, so drag/resize of the label being edited is unchanged.
- Hovering an unselected overlay shows the mode cursor (crosshair/brush) instead of `pointer`, and no longer hover-highlights it.
- A plain click (no drag) over an unselected label click-to-quits, like empty canvas.

## How is this patch tested?

New and updated e2e specs (`detection-mode`, `annotate-canvas-actions`, `annotate-action-switching`): drawing inside an unselected detection creates a new label and leaves the existing one untouched, a click over an unselected overlay quits draw mode without opening the label, and the cursor stays a crosshair over unselected overlays.

## Release Notes

### What areas of FiftyOne does this PR affect?

- [ ] `fiftyone.core`
- [x] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for FiftyOne users.

In Annotate mode, drawing tools (bounding box, segmentation brush/pen) no longer select existing labels on click — clicks always start a new label, so overlapping and dense scenes can be annotated. Labels are selectable via the Select tool.

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3877
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved detection and segmentation drawing interactions over existing unselected overlays.
  * Users can create new labels directly over unselected detections without selecting or moving them.
  * Selected overlays remain available for editing.
  * Draw-mode cursors clearly indicate when new annotations can be created.

* **Bug Fixes**
  * Corrected cursor behavior over existing detection overlays.
  * Prevented unselected overlays from blocking new detection creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


[FOEPD-4568]: https://voxel51.atlassian.net/browse/FOEPD-4568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ