### PR TITLE
fix: contains(all=True) no longer errors on missing field paths

### DIFF
--- a/fiftyone/core/expressions.py
+++ b/fiftyone/core/expressions.py
@@ -2426,7 +2426,7 @@ class ViewExpression(object):
         if not isinstance(values, ViewExpression):
             values = ViewExpression(values)
 
-        return values.is_subset(self)
+        return values.is_subset(self.if_null([]))
 
     def is_subset(self, values):
         """Checks whether this expression's contents, which must resolve to an

--- a/tests/unittests/view_tests.py
+++ b/tests/unittests/view_tests.py
@@ -639,6 +639,49 @@ class ViewExpressionTests(unittest.TestCase):
             self.assertTrue(my_int < bounds[0] or my_int > bounds[1])
 
     @drop_datasets
+    def test_contains_all_missing_field(self):
+        # https://github.com/voxel51/fiftyone/issues/3560
+        dataset = fo.Dataset()
+
+        dataset.add_samples(
+            [
+                fo.Sample(
+                    filepath="filepath1.jpg",
+                    predictions=fo.Detections(
+                        detections=[
+                            fo.Detection(label="cat"),
+                            fo.Detection(label="dog"),
+                        ]
+                    ),
+                ),
+                fo.Sample(filepath="filepath2.jpg"),
+                fo.Sample(
+                    filepath="filepath3.jpg",
+                    predictions=fo.Detections(
+                        detections=[fo.Detection(label="cat")]
+                    ),
+                ),
+            ]
+        )
+
+        # samples whose `predictions.detections.label` path is missing
+        # cannot contain anything
+        view = dataset.match(
+            F("predictions.detections.label").contains(
+                ["cat", "dog"], all=True
+            )
+        )
+        self.assertEqual(len(view), 1)
+
+        view = dataset.match(
+            F("predictions.detections.label").contains(["cat", "fox"])
+        )
+        self.assertEqual(len(view), 2)
+
+        view = dataset.match(F("tags").contains(["a", "b"], all=True))
+        self.assertEqual(len(view), 0)
+
+    @drop_datasets
     def test_arithmetic(self):
         dataset = fo.Dataset()
 


### PR DESCRIPTION
## Problem

`ViewExpression.contains(values, all=True)` builds a bare `$setIsSubset`, which raises `OperationFailure: All operands of $setIsSubset must be arrays` on MongoDB 6+ whenever the field expression resolves to null or is missing for a sample (#3560). One such sample poisoned the whole aggregation — every user of the view got an error, regardless of their own samples.

The any-match path and the scalar path already guard against this (`length()` wraps `$size` in `$ifNull`; the scalar branch uses `{"$in": [values, {"$ifNull": [self, []]}]}`); only the `all=True` branch was unguarded.

## Fix

One line:

```python
return values.is_subset(self.if_null([]))
```

Samples whose field path is missing/null now simply don't match, consistent with the other two branches. This also unifies behavior across server versions: older MongoDBs silently returned `false` for the same query.

## Testing

New test in `tests/unittests/view_tests.py::ViewExpressionTests::test_contains_all_missing_field` using deep label paths (the shape from #3560) plus a top-level list field:

- fails before this change (`pymongo.errors.OperationFailure`) and passes after, verified against a real mongod 8.3.7 via `FIFTYONE_DATABASE_URI`
- full `ViewExpressionTests` + `ViewFieldTests`: 10 passed

Semantics checked against raw documents: existing arrays unchanged (incl. duplicates/empty), stored-null and absent both now yield `False`, genuinely wrong-typed fields still raise as before.

🧪 How is this patch tested? — see above; also confirmed the only internal `all=True` caller (`collections.py` tag filtering) now tolerates label docs with missing tags instead of erroring.

---

Prepared with AI assistance under my review; reproduction, semantics matrix, and tests were verified locally against a real MongoDB server.
