### PR TITLE
Add a grid poster provider extension seam

### DIFF
--- a/app/packages/multimodal/.dependency-cruiser.cjs
+++ b/app/packages/multimodal/.dependency-cruiser.cjs
@@ -20,8 +20,7 @@ const OBSERVABILITY = `${SRC}observability/`;
 const PORTS = `${SRC}ports/`;
 const QUERY = `${SRC}query/`;
 const RUNTIME = `${SRC}runtime/`;
-const POINT_CLOUD_RUNTIME_LEAVES =
-  `${RUNTIME}point-cloud-(channel-encoding|render-payload)\\.ts$`;
+const POINT_CLOUD_RUNTIME_LEAVES = `${RUNTIME}point-cloud-(channel-encoding|render-payload)\\.ts$`;
 const SCENE_INVENTORY = `${SRC}scene-inventory/`;
 const SCHEMAS = `${SRC}schemas/`;
 const STREAM_SELECTION = `${SRC}stream-selection/`;
@@ -35,7 +34,7 @@ const VIEW_SESSION = `${VIEWS}session/`;
 const VISUALIZATION = `${SRC}visualization/`;
 
 const ENTERPRISE_SHARED_FACADES =
-  `${SRC}(extensions/(timeline|tiles)/(index|runtime)\\.ts$|` +
+  `${SRC}(extensions/(grid-posters|timeline|tiles)/(index|runtime)\\.ts$|` +
   `extensions/mcap-explorer/index\\.ts$|` +
   `query/bytes/index\\.ts$|visualization/index\\.ts$)`;
 const FORMAT_VENDORS =
@@ -219,8 +218,7 @@ module.exports = {
       from: { path: EPISODE_MAP_RENDERING, pathNot: TEST_MODULE },
       to: {
         path: SRC,
-        pathNot:
-          `${EPISODE}map/|${VISUALIZATION}|${IR}|${OBSERVABILITY}|${UTILS}`,
+        pathNot: `${EPISODE}map/|${VISUALIZATION}|${IR}|${OBSERVABILITY}|${UTILS}`,
       },
     },
     {
@@ -268,7 +266,10 @@ module.exports = {
       name: "extensions-import-only-extension-foundations",
       severity: "error",
       from: { path: EXTENSIONS, pathNot: TEST_MODULE },
-      to: { path: SRC, pathNot: `${SRC}(extensions|runtime|ports|ir)/` },
+      to: {
+        path: SRC,
+        pathNot: `${SRC}(extensions|runtime|ports|ir|stream-selection)/`,
+      },
     },
     {
       // Keep the injection namespace a composition root that wires only views,

--- a/app/packages/multimodal/package.json
+++ b/app/packages/multimodal/package.json
@@ -19,6 +19,7 @@
         "./temporal-tags": "./src/temporal-tags/index.ts",
         "./temporal-tags/grid-overlay": "./src/temporal-tags/TemporalTagGridOverlay.tsx",
         "./inject": "./src/inject/index.ts",
+        "./extensions/grid-posters": "./src/extensions/grid-posters/index.ts",
         "./extensions/mcap-explorer": "./src/extensions/mcap-explorer/index.ts",
         "./extensions/timeline": "./src/extensions/timeline/index.ts",
         "./extensions/timeline/runtime": "./src/extensions/timeline/runtime.ts",
@@ -70,6 +71,9 @@
             ],
             "inject": [
                 "src/inject/index.ts"
+            ],
+            "extensions/grid-posters": [
+                "src/extensions/grid-posters/index.ts"
             ],
             "extensions/mcap-explorer": [
                 "src/extensions/mcap-explorer/index.ts"

--- a/app/packages/multimodal/src/extensions/README.md
+++ b/app/packages/multimodal/src/extensions/README.md
@@ -9,3 +9,7 @@ may depend on that host boundary, but never on sibling family implementations.
 The MCAP Explorer extension supplies optional cloud-path resolution. The shared
 Explorer remains HTTP-only until a product entrypoint registers a resolver
 through this boundary.
+
+The grid-poster extension supplies optional precomputed raster posters. The
+shared grid stays on its memory, IndexedDB, and live-preview tiers until a
+product entrypoint registers a provider through this boundary.

--- a/app/packages/multimodal/src/extensions/grid-posters/index.ts
+++ b/app/packages/multimodal/src/extensions/grid-posters/index.ts
@@ -1,0 +1,15 @@
+export {
+  getGridPosterProvider,
+  registerGridPosterProvider,
+  useGridPosterProvider,
+} from "./registry";
+export type {
+  GridPosterCameraPose,
+  GridPosterMediaKind,
+  GridPosterProvider,
+  GridPosterProviderDescriptor,
+  GridPosterProviderMetadata,
+  GridPosterProviderResolveContext,
+  GridPosterProviderSelection,
+  GridPosterProviderSelectionContext,
+} from "./types";

--- a/app/packages/multimodal/src/extensions/grid-posters/index.ts
+++ b/app/packages/multimodal/src/extensions/grid-posters/index.ts
@@ -3,6 +3,7 @@ export {
   registerGridPosterProvider,
   useGridPosterProvider,
 } from "./registry";
+export { filterDefaultStreamEquivalents } from "../../stream-selection";
 export type {
   GridPosterCameraPose,
   GridPosterMediaKind,

--- a/app/packages/multimodal/src/extensions/grid-posters/registry.test.tsx
+++ b/app/packages/multimodal/src/extensions/grid-posters/registry.test.tsx
@@ -1,0 +1,47 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  getGridPosterProvider,
+  registerGridPosterProvider,
+  resetGridPosterProviderForTests,
+  useGridPosterProvider,
+} from "./registry";
+import type { GridPosterProvider } from "./types";
+
+afterEach(() => resetGridPosterProviderForTests());
+
+describe("grid poster provider registry", () => {
+  it("publishes registration changes to mounted consumers", () => {
+    const provider = createProvider("teams:projection");
+    const { result } = renderHook(() => useGridPosterProvider());
+
+    let unregister: () => void = () => undefined;
+    act(() => {
+      unregister = registerGridPosterProvider(provider);
+    });
+    expect(result.current).toBe(provider);
+
+    act(() => unregister());
+    expect(result.current).toBeNull();
+  });
+
+  it("rejects ambiguous and unnamespaced registrations", () => {
+    expect(() =>
+      registerGridPosterProvider(createProvider("projection")),
+    ).toThrow("must be namespaced");
+    registerGridPosterProvider(createProvider("teams:projection"));
+
+    expect(() =>
+      registerGridPosterProvider(createProvider("other:projection")),
+    ).toThrow("already registered");
+    expect(getGridPosterProvider()?.id).toBe("teams:projection");
+  });
+});
+
+function createProvider(id: string): GridPosterProvider {
+  return {
+    id,
+    resolveDescriptor: async () => null,
+  };
+}

--- a/app/packages/multimodal/src/extensions/grid-posters/registry.ts
+++ b/app/packages/multimodal/src/extensions/grid-posters/registry.ts
@@ -1,0 +1,72 @@
+import { useSyncExternalStore } from "react";
+
+import type { GridPosterProvider } from "./types";
+
+interface GridPosterProviderState {
+  readonly listeners: Set<() => void>;
+  provider: GridPosterProvider | null;
+}
+
+const REGISTRY_KEY = Symbol.for(
+  "@fiftyone/multimodal:grid-poster-provider-registry",
+);
+const globalRegistry = globalThis as Record<PropertyKey, unknown>;
+const state = (globalRegistry[REGISTRY_KEY] ??= {
+  listeners: new Set(),
+  provider: null,
+}) as GridPosterProviderState;
+
+/** Registers the optional precomputed-poster provider for this product build. */
+export function registerGridPosterProvider(
+  provider: GridPosterProvider,
+): () => void {
+  if (!provider.id.includes(":")) {
+    throw new Error(
+      `Grid poster provider ids must be namespaced: ${provider.id}`,
+    );
+  }
+  if (state.provider === provider) return () => undefined;
+  if (state.provider) {
+    throw new Error("A grid poster provider is already registered");
+  }
+
+  state.provider = provider;
+  emitChange();
+  let active = true;
+  return () => {
+    if (!active || state.provider !== provider) return;
+    active = false;
+    state.provider = null;
+    emitChange();
+  };
+}
+
+/** Returns the precomputed-poster provider compiled into this product build. */
+export function getGridPosterProvider(): GridPosterProvider | null {
+  return state.provider;
+}
+
+/** React subscription to the current product's optional poster provider. */
+export function useGridPosterProvider(): GridPosterProvider | null {
+  return useSyncExternalStore(
+    subscribe,
+    getGridPosterProvider,
+    getGridPosterProvider,
+  );
+}
+
+/** Test-only reset kept out of the public package barrel. */
+export function resetGridPosterProviderForTests(): void {
+  if (!state.provider) return;
+  state.provider = null;
+  emitChange();
+}
+
+function subscribe(listener: () => void): () => void {
+  state.listeners.add(listener);
+  return () => state.listeners.delete(listener);
+}
+
+function emitChange(): void {
+  for (const listener of state.listeners) listener();
+}

--- a/app/packages/multimodal/src/extensions/grid-posters/types.ts
+++ b/app/packages/multimodal/src/extensions/grid-posters/types.ts
@@ -1,0 +1,65 @@
+/** Media semantics retained with a poster supplied by a product extension. */
+export type GridPosterMediaKind = "image" | "video" | "point-cloud";
+
+/** Minimal camera pose exposed without coupling extensions to a renderer. */
+export interface GridPosterCameraPose {
+  readonly position: readonly [number, number, number];
+  readonly target: readonly [number, number, number];
+}
+
+/** Durable provenance for a poster supplied outside the live preview path. */
+export interface GridPosterProviderMetadata {
+  readonly artifactIdentity: string;
+  readonly id: string;
+  readonly mediaKind: GridPosterMediaKind;
+  readonly policyVersion: string;
+  readonly revision: string | null;
+  readonly variant: string;
+}
+
+/** Product-neutral selection facts exposed by the grid renderer. */
+export interface GridPosterProviderSelectionContext {
+  readonly cameraPose: GridPosterCameraPose | null;
+  readonly posterStartTimeNs: bigint | null;
+  readonly selectedSourceName: string | null;
+}
+
+/** One immutable poster candidate selected by a provider descriptor. */
+export interface GridPosterProviderSelection {
+  readonly byteLength: number;
+  readonly height: number;
+  readonly identity: string;
+  readonly load: (signal: AbortSignal) => Promise<Uint8Array>;
+  readonly mediaKind: GridPosterMediaKind;
+  readonly mimeType: string;
+  readonly policyVersion: string;
+  readonly sourceKind: "image" | "point-cloud";
+  readonly streamId: string | null;
+  readonly streamSourceName: string | null;
+  readonly streamSourceNames: readonly string[];
+  readonly variant: string;
+  readonly width: number;
+}
+
+/** Opaque provider result used to key and select a cold-tier poster. */
+export interface GridPosterProviderDescriptor {
+  readonly cacheRevision: string | null;
+  readonly select: (
+    context: GridPosterProviderSelectionContext,
+  ) => GridPosterProviderSelection | null;
+}
+
+/** Resolve context for a single visible grid sample. */
+export interface GridPosterProviderResolveContext {
+  readonly datasetId: string;
+  readonly sampleId: string;
+}
+
+/** Optional product-edition source for precomputed grid posters. */
+export interface GridPosterProvider {
+  readonly id: string;
+  readonly resolveDescriptor: (
+    context: GridPosterProviderResolveContext,
+    signal: AbortSignal,
+  ) => Promise<GridPosterProviderDescriptor | null>;
+}

--- a/app/packages/multimodal/src/views/episode/grid/GridRenderer.test.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/GridRenderer.test.tsx
@@ -33,6 +33,10 @@ import {
 import classes from "./GridRenderer.module.css";
 import { useGridPreview } from "./use-grid-preview";
 import { useEpisodePreviewSession } from "../../session/use-episode-preview-session";
+import type {
+  GridPosterProviderLookupStatus,
+  ResolvedGridPosterProviderDescriptor,
+} from "./use-grid-poster-provider";
 
 // The grid mounts custom renderers under a RecoilBridge, which is what lets
 // the tile read the embeddings panel's published match for its episode.
@@ -98,6 +102,17 @@ const gridStreamHarness = vi.hoisted(() => ({
   selected: "__auto__",
 }));
 
+const providerHarness = vi.hoisted(() => ({
+  descriptor: {
+    resolved: null as ResolvedGridPosterProviderDescriptor | null,
+    status: "miss" as GridPosterProviderLookupStatus,
+  },
+  poster: {
+    entry: null as GridPosterCacheEntry | null,
+    status: "miss" as GridPosterProviderLookupStatus,
+  },
+}));
+
 interface SnapshotRequest {
   readonly job: {
     readonly cameraPose?: unknown;
@@ -148,6 +163,11 @@ vi.mock("../../session/use-episode-preview-session", () => ({
 
 vi.mock("./use-grid-preview", () => ({
   useGridPreview: vi.fn(() => previewHarness.preview),
+}));
+
+vi.mock("./use-grid-poster-provider", () => ({
+  useGridPosterProviderDescriptor: () => providerHarness.descriptor,
+  useProvidedGridPoster: () => providerHarness.poster,
 }));
 
 vi.mock("./grid-camera-state", () => ({
@@ -255,9 +275,71 @@ afterEach(() => {
   posterCaptureHarness.capture.mockReset();
   sourceHarness.byteSource = null;
   gridStreamHarness.selected = "__auto__";
+  providerHarness.descriptor = { resolved: null, status: "miss" };
+  providerHarness.poster = { entry: null, status: "miss" };
 });
 
 describe("GridRenderer", () => {
+  it("waits for the optional cold tier before opening a source session", () => {
+    sourceHarness.byteSource = {
+      sourceId: "cold-tier-loading",
+      url: "https://example.test/cold-tier-loading.mcap",
+    };
+    providerHarness.descriptor = { resolved: null, status: "loading" };
+
+    render(<GridRenderer ctx={rendererCtx()} />);
+
+    expect(vi.mocked(useEpisodePreviewSession).mock.lastCall?.[2]).toBe(false);
+  });
+
+  it("uses a revision-keyed provided poster without opening the source", () => {
+    sourceHarness.byteSource = {
+      sourceId: "provider-hit",
+      url: "https://example.test/provider-hit.mcap",
+    };
+    const provider = {
+      id: "test:posters",
+      resolveDescriptor: vi.fn(),
+    };
+    const descriptor = {
+      cacheRevision: "source-rev",
+      select: vi.fn(() => null),
+    };
+    providerHarness.descriptor = {
+      resolved: { descriptor, provider },
+      status: "hit",
+    };
+    const providedPoster: GridPosterCacheEntry = {
+      bytes: new Uint8Array([1, 2, 3]),
+      height: 288,
+      mimeType: "image/webp",
+      provider: {
+        artifactIdentity: "artifact",
+        id: provider.id,
+        mediaKind: "image",
+        policyVersion: "image-grid-poster-v1",
+        revision: "source-rev",
+        variant: "frame",
+      },
+      sourceKind: "image",
+      streamId: "camera",
+      streamSourceName: "/camera/front",
+      streamSourceNames: ["/camera/front"],
+      width: 512,
+    };
+    providerHarness.poster = { entry: providedPoster, status: "hit" };
+
+    render(<GridRenderer ctx={rendererCtx()} />);
+
+    expect(vi.mocked(useGridPreview).mock.lastCall?.[0]).toMatchObject({
+      cachedPoster: providedPoster,
+    });
+    expect(
+      vi.mocked(useGridPreview).mock.lastCall?.[0].cacheRequestKey,
+    ).toContain("source-rev");
+    expect(vi.mocked(useEpisodePreviewSession).mock.lastCall?.[2]).toBe(false);
+  });
+
   it("posters at the earliest window the embeddings panel matched", () => {
     renderWithMatches(<GridRenderer ctx={rendererCtx()} />, {
       "1": [

--- a/app/packages/multimodal/src/views/episode/grid/GridRenderer.test.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/GridRenderer.test.tsx
@@ -22,6 +22,7 @@ import {
 } from "../../../visualization/webgpu/webgpu-live-lease";
 import type { ByteSourceDescriptor, EpisodePosterFrame } from "../../../ir";
 import {
+  gridPosterCacheKey,
   pointCloudPoseKey,
   type GridPosterCacheEntry,
 } from "./grid-poster-cache";
@@ -337,7 +338,71 @@ describe("GridRenderer", () => {
     expect(
       vi.mocked(useGridPreview).mock.lastCall?.[0].cacheRequestKey,
     ).toContain("source-rev");
+    expect(
+      vi.mocked(useGridPreview).mock.lastCall?.[0].cacheRequestKey,
+    ).toContain(provider.id);
     expect(vi.mocked(useEpisodePreviewSession).mock.lastCall?.[2]).toBe(false);
+  });
+
+  it("keeps provider misses in the non-provider cache namespace", () => {
+    const source = {
+      sourceId: "provider-miss",
+      url: "https://example.test/provider-miss.mcap",
+    };
+    sourceHarness.byteSource = source;
+
+    render(<GridRenderer ctx={rendererCtx()} />);
+
+    expect(vi.mocked(useGridPreview).mock.lastCall?.[0].cacheRequestKey).toBe(
+      gridPosterCacheKey({
+        datasetId: "dataset-id",
+        mediaField: undefined,
+        selectedSourceName: null,
+        source,
+      }),
+    );
+  });
+
+  it("isolates cache keys for providers with the same revision", () => {
+    const source = {
+      sourceId: "provider-scope",
+      url: "https://example.test/provider-scope.mcap",
+    };
+    sourceHarness.byteSource = source;
+    const descriptor = {
+      cacheRevision: "shared-revision",
+      select: vi.fn(() => null),
+    };
+    const firstProvider = {
+      id: "test:first-provider",
+      resolveDescriptor: vi.fn(),
+    };
+    providerHarness.descriptor = {
+      resolved: { descriptor, provider: firstProvider },
+      status: "hit",
+    };
+    const ctx = rendererCtx();
+    const view = render(<GridRenderer ctx={ctx} />);
+    const firstKey = vi.mocked(useGridPreview).mock.lastCall?.[0]
+      .cacheRequestKey as string;
+
+    const secondProvider = {
+      id: "test:second-provider",
+      resolveDescriptor: vi.fn(),
+    };
+    providerHarness.descriptor = {
+      resolved: { descriptor, provider: secondProvider },
+      status: "hit",
+    };
+    view.rerender(<GridRenderer ctx={ctx} />);
+    const secondKey = vi.mocked(useGridPreview).mock.lastCall?.[0]
+      .cacheRequestKey as string;
+
+    expect(secondKey).not.toBe(firstKey);
+    expect(firstKey).toContain(firstProvider.id);
+    expect(secondKey).toContain(secondProvider.id);
+    expect(firstKey).toContain(descriptor.cacheRevision);
+    expect(secondKey).toContain(descriptor.cacheRevision);
   });
 
   it("posters at the earliest window the embeddings panel matched", () => {
@@ -1015,7 +1080,7 @@ describe("GridRenderer", () => {
 
 function rendererCtx() {
   return {
-    dataset: { name: "dataset" },
+    dataset: { datasetId: "dataset-id", name: "dataset" },
     sample: { sample: { id: "1" } },
   } as never;
 }

--- a/app/packages/multimodal/src/views/episode/grid/GridRenderer.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/GridRenderer.tsx
@@ -109,6 +109,12 @@ export function GridRenderer({
     sampleId,
     visible,
   );
+  const providerCacheScope = providerDescriptor.resolved
+    ? JSON.stringify([
+        providerDescriptor.resolved.provider.id,
+        providerDescriptor.resolved.descriptor.cacheRevision,
+      ])
+    : undefined;
   const providerDescriptorSettled =
     providerDescriptor.status === "hit" || providerDescriptor.status === "miss";
   const cacheKey = useMemo(
@@ -120,8 +126,7 @@ export function GridRenderer({
             mediaPath: ctx.media?.path,
             posterSourceName: firstMatch?.stream,
             posterStartTimeNs: firstMatch?.startNs,
-            providerRevision:
-              providerDescriptor.resolved?.descriptor.cacheRevision,
+            providerRevision: providerCacheScope,
             selectedSourceName,
             source,
           })
@@ -132,7 +137,7 @@ export function GridRenderer({
       ctx.media?.path,
       firstMatch?.startNs,
       firstMatch?.stream,
-      providerDescriptor.resolved?.descriptor.cacheRevision,
+      providerCacheScope,
       providerDescriptorSettled,
       selectedSourceName,
       source,

--- a/app/packages/multimodal/src/views/episode/grid/GridRenderer.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/GridRenderer.tsx
@@ -48,10 +48,11 @@ import {
 } from "./grid-poster-cache";
 import { captureGridPoster } from "./grid-poster-codec";
 import type { PointCloudCameraPose } from "../../../visualization/scene-3d";
+import { useGridPosterCache } from "./use-grid-poster-cache";
 import {
-  useGridPosterCache,
-  type GridPosterCacheLookupStatus,
-} from "./use-grid-poster-cache";
+  useGridPosterProviderDescriptor,
+  useProvidedGridPoster,
+} from "./use-grid-poster-provider";
 
 const IMAGE_FIT = "cover";
 // Trailing debounce for shared-pose and cell-resize re-snapshots: orbiting
@@ -99,15 +100,28 @@ export function GridRenderer({
   // matched window, so both the requested time and preferred stream belong to
   // the poster cache identity.
   const firstMatch = useSampleRendererFirstMatch(ctx);
+  const [cameraPose, setCameraPose] = useGridCameraPose(
+    gridCameraScopeKey,
+    visible,
+  );
+  const providerDescriptor = useGridPosterProviderDescriptor(
+    ctx.dataset.datasetId,
+    sampleId,
+    visible,
+  );
+  const providerDescriptorSettled =
+    providerDescriptor.status === "hit" || providerDescriptor.status === "miss";
   const cacheKey = useMemo(
     () =>
-      source
+      source && providerDescriptorSettled
         ? gridPosterCacheKey({
             datasetId: ctx.dataset.datasetId,
             mediaField: ctx.media?.field,
             mediaPath: ctx.media?.path,
             posterSourceName: firstMatch?.stream,
             posterStartTimeNs: firstMatch?.startNs,
+            providerRevision:
+              providerDescriptor.resolved?.descriptor.cacheRevision,
             selectedSourceName,
             source,
           })
@@ -118,6 +132,8 @@ export function GridRenderer({
       ctx.media?.path,
       firstMatch?.startNs,
       firstMatch?.stream,
+      providerDescriptor.resolved?.descriptor.cacheRevision,
+      providerDescriptorSettled,
       selectedSourceName,
       source,
     ],
@@ -140,23 +156,32 @@ export function GridRenderer({
     if (cachedPoster) getGridPosterCache().touch(cacheKey);
     recordGridPosterDiagnostic(cachedPoster ? "hits" : "misses");
   }, [cacheKey, cacheLookupStatus, cachedPoster]);
-  const [cameraPose, setCameraPose] = useGridCameraPose(
-    gridCameraScopeKey,
-    visible,
-  );
+  const providedPosterLookup = useProvidedGridPoster({
+    cacheKey,
+    cameraPose,
+    enabled: visible && cacheLookupStatus === "miss" && cachedPoster === null,
+    posterStartTimeNs: firstMatch?.startNs ?? null,
+    resolved: providerDescriptor.resolved,
+    selectedSourceName,
+  });
+  const effectivePoster = cachedPoster ?? providedPosterLookup.entry;
   const rootSize = useElementCssSize(rootElement);
   const poseKey = pointCloudPoseKey(cameraPose);
   const freshness = useMemo<GridPosterFreshness | null>(
     () =>
-      cachedPoster && rootSize
-        ? gridPosterFreshness(cachedPoster, rootSize, poseKey)
+      effectivePoster && rootSize
+        ? gridPosterFreshness(effectivePoster, rootSize, poseKey)
         : null,
-    [cachedPoster, poseKey, rootSize],
+    [effectivePoster, poseKey, rootSize],
   );
+  const coldTierLoading =
+    (visible && !providerDescriptorSettled) ||
+    cacheLookupStatus === "loading" ||
+    providedPosterLookup.status === "loading";
   const previewSessionDemand = usePreviewSessionDemand({
     cacheKey,
-    cacheLookupStatus,
-    cachedPoster,
+    cachedPoster: effectivePoster,
+    coldTierLoading,
     freshness,
     hovered,
     sourceId: source?.sourceId ?? null,
@@ -170,7 +195,7 @@ export function GridRenderer({
   );
   const preview = useGridPreview({
     cacheRequestKey: cacheKey,
-    cachedPoster,
+    cachedPoster: effectivePoster,
     enabled: visible,
     hovered,
     onReadResult: gridVideoPlayback.onReadResult,
@@ -477,16 +502,16 @@ function useElementCssSize(
 
 function usePreviewSessionDemand({
   cacheKey,
-  cacheLookupStatus,
   cachedPoster,
+  coldTierLoading,
   freshness,
   hovered,
   sourceId,
   visible,
 }: {
   readonly cacheKey: string | null;
-  readonly cacheLookupStatus: GridPosterCacheLookupStatus;
   readonly cachedPoster: GridPosterCacheEntry | null;
+  readonly coldTierLoading: boolean;
   readonly freshness: GridPosterFreshness | null;
   readonly hovered: boolean;
   readonly sourceId: string | null;
@@ -534,7 +559,7 @@ function usePreviewSessionDemand({
     // already-demanded same-source session stays open across key transitions.
     demanded =
       hovered ||
-      cacheLookupStatus !== "loading" ||
+      !coldTierLoading ||
       (committedDemandRef.current.demanded &&
         committedDemandRef.current.sourceId === sourceId);
   } else if (latched || hovered) {

--- a/app/packages/multimodal/src/views/episode/grid/grid-poster-cache.test.ts
+++ b/app/packages/multimodal/src/views/episode/grid/grid-poster-cache.test.ts
@@ -65,13 +65,20 @@ describe("grid poster cache", () => {
   it("copies admitted bytes and stream metadata", () => {
     const bytes = new Uint8Array([1, 2]);
     const streams = ["/camera"];
+    const provider = providerMetadata();
     const cache = createGridPosterCache({ maxSizeBytes: 1_000 });
-    cache.put("copy", { ...entry(bytes), streamSourceNames: streams });
+    cache.put("copy", {
+      ...entry(bytes),
+      provider,
+      streamSourceNames: streams,
+    });
     bytes[0] = 9;
     streams[0] = "/changed";
+    provider.variant = "changed";
 
     expect(cache.get("copy")).toMatchObject({
       bytes: new Uint8Array([1, 2]),
+      provider: { variant: "frame" },
       streamSourceNames: ["/camera"],
     });
   });
@@ -97,6 +104,9 @@ describe("grid poster cache", () => {
     expect(gridPosterCacheKey({ ...base, posterStartTimeNs: 42n })).not.toBe(
       key,
     );
+    expect(
+      gridPosterCacheKey({ ...base, providerRevision: "revision-a" }),
+    ).not.toBe(key);
     expect(
       gridPosterCacheKey({ ...base, source: source("two", "etag-a") }),
     ).not.toBe(key);
@@ -197,6 +207,46 @@ describe("grid poster cache", () => {
     ).toBe(true);
   });
 
+  it("treats provided quality as static-ready without replacing captured quality", () => {
+    const provided = entry([1], {
+      height: 64,
+      provider: providerMetadata(),
+      sourceKind: "point-cloud",
+      width: 64,
+    });
+    expect(
+      gridPosterFreshness(
+        provided,
+        { height: 512, width: 512 },
+        pointCloudPoseKey(null),
+      ),
+    ).toBe("fresh");
+    expect(
+      gridPosterFreshness(
+        provided,
+        { height: 64, width: 64 },
+        pointCloudPoseKey({ position: [1, 2, 3], target: [0, 0, 0] }),
+      ),
+    ).toBe("stale-pose");
+    expect(
+      shouldReplaceGridPoster(
+        entry([2], { height: 512, width: 512 }),
+        provided,
+      ),
+    ).toBe(false);
+    expect(shouldReplaceGridPoster(provided, entry([2]))).toBe(true);
+    expect(
+      shouldReplaceGridPoster(
+        entry([3], { height: 32, width: 32 }),
+        entry([4], {
+          height: 64,
+          provider: providerMetadata(),
+          width: 64,
+        }),
+      ),
+    ).toBe(false);
+  });
+
   it("uses the fallback and adaptive browser budgets", () => {
     vi.stubGlobal("navigator", {});
     expect(defaultGridPosterCacheBudgetBytes()).toBe(64 * 1024 * 1024);
@@ -228,4 +278,15 @@ function entry(
 
 function source(id: string, etag?: string): ByteSourceDescriptor {
   return { etag, sourceId: id, url: `https://example.test/${id}.mcap` };
+}
+
+function providerMetadata() {
+  return {
+    artifactIdentity: "artifact",
+    id: "test:posters",
+    mediaKind: "image" as const,
+    policyVersion: "image-grid-poster-v1",
+    revision: "revision",
+    variant: "frame",
+  };
 }

--- a/app/packages/multimodal/src/views/episode/grid/grid-poster-cache.ts
+++ b/app/packages/multimodal/src/views/episode/grid/grid-poster-cache.ts
@@ -1,5 +1,6 @@
 import { LRUCache } from "lru-cache";
 
+import type { GridPosterProviderMetadata } from "../../../extensions/grid-posters";
 import type { ByteSourceDescriptor } from "../../../ir";
 import type { PointCloudCameraPose } from "../../../visualization/scene-3d";
 
@@ -9,7 +10,7 @@ const MIN_BUDGET_BYTES = 32 * MIB;
 const MAX_BUDGET_BYTES = 128 * MIB;
 const DEFAULT_MAX_ENTRIES = 2_048;
 const ENTRY_METADATA_BYTES = 256;
-const CACHE_SCHEMA_VERSION = "grid-poster-v2";
+const CACHE_SCHEMA_VERSION = "grid-poster-v3";
 const PREVIEW_SELECTION_POLICY_VERSION = "preview-selection-v1";
 const SNAPSHOT_RENDERER_POLICY_VERSION = "point-cloud-snapshot-v1";
 export const GRID_POSTER_AUTO_SOURCE = "__AUTO__";
@@ -22,6 +23,7 @@ export interface GridPosterCacheEntry {
   readonly height: number;
   readonly mimeType: string;
   readonly pointCloudPoseKey?: string;
+  readonly provider?: GridPosterProviderMetadata;
   readonly sourceKind: GridPosterSourceKind;
   readonly streamId: string | null;
   readonly streamSourceName: string | null;
@@ -40,6 +42,10 @@ export interface GridPosterCacheStats {
   readonly misses: number;
   readonly oversizeRejections: number;
   readonly puts: number;
+  readonly providerArtifactFailures: number;
+  readonly providerArtifactHits: number;
+  readonly providerDescriptorHits: number;
+  readonly providerDescriptorMisses: number;
   readonly replacements: number;
   readonly retainedBytes: number;
   readonly sourceRefreshesHover: number;
@@ -81,6 +87,7 @@ export interface GridPosterKeyParts {
   readonly mediaPath?: string | null | undefined;
   readonly posterSourceName?: string | null | undefined;
   readonly posterStartTimeNs?: bigint | null | undefined;
+  readonly providerRevision?: string | null | undefined;
   readonly selectedSourceName: string | null | undefined;
   readonly source: ByteSourceDescriptor;
 }
@@ -153,6 +160,7 @@ export function gridPosterCacheKey({
   mediaPath,
   posterSourceName,
   posterStartTimeNs,
+  providerRevision,
   selectedSourceName,
   source,
 }: GridPosterKeyParts): GridPosterCacheKey {
@@ -164,6 +172,7 @@ export function gridPosterCacheKey({
     stableMediaFilename(mediaPath ?? source.url),
     source.sizeBytes ?? null,
     source.etag ?? null,
+    providerRevision ?? null,
     selectedSourceName ?? GRID_POSTER_AUTO_SOURCE,
     posterSourceName ?? null,
     posterStartTimeNs?.toString() ?? null,
@@ -202,6 +211,17 @@ export function gridPosterFreshness(
   size: { readonly height: number; readonly width: number },
   poseKey: string,
 ): GridPosterFreshness {
+  if (entry.provider) {
+    if (
+      entry.sourceKind === "point-cloud" &&
+      poseKey !== pointCloudPoseKey(null)
+    ) {
+      return "stale-pose";
+    }
+    // Provider posters are the bounded cold-grid tier. Upsizing one would
+    // open a live preview session and defeat that optimization.
+    return "fresh";
+  }
   if (
     entry.sourceKind === "point-cloud" &&
     entry.pointCloudPoseKey !== poseKey
@@ -219,6 +239,8 @@ export function shouldReplaceGridPoster(
   next: Omit<GridPosterCacheEntry, "bytes">,
 ): boolean {
   if (!current) return true;
+  if (!current.provider && next.provider) return false;
+  if (current.provider && !next.provider) return true;
   if (current.sourceKind !== next.sourceKind) return true;
   if (
     next.sourceKind === "point-cloud" &&
@@ -280,6 +302,10 @@ export function recordGridPosterDiagnostic(
     | "encodesStarted"
     | "hits"
     | "misses"
+    | "providerArtifactFailures"
+    | "providerArtifactHits"
+    | "providerDescriptorHits"
+    | "providerDescriptorMisses"
     | "sourceRefreshesHover"
     | "sourceRefreshesPose"
     | "sourceRefreshesSize"
@@ -302,6 +328,10 @@ function emptyCounters(): MutableStats {
     misses: 0,
     oversizeRejections: 0,
     puts: 0,
+    providerArtifactFailures: 0,
+    providerArtifactHits: 0,
+    providerDescriptorHits: 0,
+    providerDescriptorMisses: 0,
     replacements: 0,
     sourceRefreshesHover: 0,
     sourceRefreshesPose: 0,
@@ -315,6 +345,7 @@ function copyEntry(entry: GridPosterCacheEntry): GridPosterCacheEntry {
   return Object.freeze({
     ...entry,
     bytes: entry.bytes.slice(),
+    provider: entry.provider ? Object.freeze({ ...entry.provider }) : undefined,
     streamSourceNames: Object.freeze([...entry.streamSourceNames]),
   });
 }

--- a/app/packages/multimodal/src/views/episode/grid/grid-poster-persistence.ts
+++ b/app/packages/multimodal/src/views/episode/grid/grid-poster-persistence.ts
@@ -415,7 +415,26 @@ function validEntry(entry: GridPosterCacheEntry): boolean {
     Array.isArray(entry.streamSourceNames) &&
     entry.streamSourceNames.every((name) => typeof name === "string") &&
     (entry.pointCloudPoseKey === undefined ||
-      typeof entry.pointCloudPoseKey === "string")
+      typeof entry.pointCloudPoseKey === "string") &&
+    validProviderMetadata(entry.provider)
+  );
+}
+
+function validProviderMetadata(
+  provider: GridPosterCacheEntry["provider"],
+): boolean {
+  return (
+    provider === undefined ||
+    (typeof provider.artifactIdentity === "string" &&
+      provider.artifactIdentity.length > 0 &&
+      typeof provider.id === "string" &&
+      provider.id.includes(":") &&
+      (provider.mediaKind === "image" ||
+        provider.mediaKind === "video" ||
+        provider.mediaKind === "point-cloud") &&
+      typeof provider.policyVersion === "string" &&
+      (provider.revision === null || typeof provider.revision === "string") &&
+      typeof provider.variant === "string")
   );
 }
 

--- a/app/packages/multimodal/src/views/episode/grid/use-grid-poster-provider.test.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/use-grid-poster-provider.test.tsx
@@ -1,0 +1,206 @@
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  registerGridPosterProvider,
+  type GridPosterProvider,
+  type GridPosterProviderDescriptor,
+} from "../../../extensions/grid-posters";
+import { resetGridPosterProviderForTests } from "../../../extensions/grid-posters/registry";
+import {
+  getGridPosterCache,
+  resetGridPosterCacheForTests,
+  type GridPosterCacheEntry,
+} from "./grid-poster-cache";
+import {
+  resetGridPosterPersistenceForTests,
+  type GridPosterPersistence,
+} from "./grid-poster-persistence";
+import {
+  useGridPosterProviderDescriptor,
+  useProvidedGridPoster,
+} from "./use-grid-poster-provider";
+
+const load = vi.fn<(signal: AbortSignal) => Promise<Uint8Array>>();
+const resolveDescriptor = vi.fn<GridPosterProvider["resolveDescriptor"]>();
+const provider: GridPosterProvider = {
+  id: "test:posters",
+  resolveDescriptor,
+};
+const persistence: GridPosterPersistence = {
+  get: vi.fn(async () => null),
+  put: vi.fn(async () => undefined),
+};
+
+beforeEach(() => {
+  load.mockReset();
+  resolveDescriptor.mockReset();
+  vi.mocked(persistence.get).mockClear();
+  vi.mocked(persistence.put).mockClear();
+  resetGridPosterCacheForTests({ maxSizeBytes: 10_000 });
+  resetGridPosterPersistenceForTests(persistence);
+  resetGridPosterProviderForTests();
+  registerGridPosterProvider(provider);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  resetGridPosterPersistenceForTests();
+  resetGridPosterProviderForTests();
+});
+
+describe("useGridPosterProviderDescriptor", () => {
+  it("settles immediately when this product has no provider", () => {
+    resetGridPosterProviderForTests();
+
+    const { result } = renderHook(() =>
+      useGridPosterProviderDescriptor("dataset", "sample", true),
+    );
+
+    expect(result.current).toEqual({ resolved: null, status: "miss" });
+    expect(resolveDescriptor).not.toHaveBeenCalled();
+  });
+
+  it("resolves provider metadata", async () => {
+    resolveDescriptor.mockResolvedValue(descriptor);
+
+    const { result } = renderHook(() =>
+      useGridPosterProviderDescriptor("dataset", "sample", true),
+    );
+
+    await waitFor(() => expect(result.current.status).toBe("hit"));
+    expect(result.current.resolved).toEqual({ descriptor, provider });
+  });
+
+  it("times out and aborts a stalled descriptor lookup", async () => {
+    vi.useFakeTimers();
+    let signal: AbortSignal | undefined;
+    resolveDescriptor.mockImplementation((_context, value) => {
+      signal = value;
+      return new Promise(() => undefined);
+    });
+    const { result } = renderHook(() =>
+      useGridPosterProviderDescriptor("dataset", "sample", true),
+    );
+
+    await act(() => vi.advanceTimersByTimeAsync(5_000));
+
+    expect(result.current.status).toBe("miss");
+    expect(signal?.aborted).toBe(true);
+  });
+
+  it("aborts the descriptor lookup on unmount", () => {
+    let signal: AbortSignal | undefined;
+    resolveDescriptor.mockImplementation((_context, value) => {
+      signal = value;
+      return new Promise(() => undefined);
+    });
+    const { unmount } = renderHook(() =>
+      useGridPosterProviderDescriptor("dataset", "sample", true),
+    );
+
+    unmount();
+
+    expect(signal?.aborted).toBe(true);
+  });
+});
+
+describe("useProvidedGridPoster", () => {
+  it("rejects an artifact whose byte length does not match", async () => {
+    load.mockResolvedValue(new Uint8Array([1]));
+
+    const { result } = renderPosterHook();
+
+    await waitFor(() => expect(result.current.status).toBe("miss"));
+    expect(getGridPosterCache().peek("cache-key")).toBeNull();
+    expect(persistence.put).not.toHaveBeenCalled();
+  });
+
+  it("retains a better captured poster without persisting the provided one", async () => {
+    const captured = posterEntry({ height: 512, width: 512 });
+    getGridPosterCache().put("cache-key", captured);
+    load.mockResolvedValue(new Uint8Array([1, 2, 3]));
+
+    const { result } = renderPosterHook();
+
+    await waitFor(() => expect(result.current.status).toBe("hit"));
+    expect(result.current.entry).toEqual(captured);
+    expect(getGridPosterCache().peek("cache-key")).toEqual(captured);
+    expect(persistence.put).not.toHaveBeenCalled();
+  });
+
+  it("writes provider provenance to both poster tiers", async () => {
+    load.mockResolvedValue(new Uint8Array([1, 2, 3]));
+
+    const { result } = renderPosterHook();
+
+    await waitFor(() => expect(result.current.status).toBe("hit"));
+    expect(getGridPosterCache().peek("cache-key")).toMatchObject({
+      bytes: new Uint8Array([1, 2, 3]),
+      provider: {
+        artifactIdentity: "artifact",
+        id: "test:posters",
+        revision: "revision",
+      },
+    });
+    expect(persistence.put).toHaveBeenCalledWith(
+      "cache-key",
+      expect.objectContaining({
+        provider: expect.objectContaining({
+          artifactIdentity: "artifact",
+          revision: "revision",
+        }),
+      }),
+    );
+  });
+});
+
+function renderPosterHook() {
+  return renderHook(() =>
+    useProvidedGridPoster({
+      cacheKey: "cache-key",
+      cameraPose: null,
+      enabled: true,
+      posterStartTimeNs: null,
+      resolved,
+      selectedSourceName: null,
+    }),
+  );
+}
+
+const descriptor: GridPosterProviderDescriptor = {
+  cacheRevision: "revision",
+  select: () => ({
+    byteLength: 3,
+    height: 64,
+    identity: "artifact",
+    load,
+    mediaKind: "image",
+    mimeType: "image/webp",
+    policyVersion: "image-grid-poster-v1",
+    sourceKind: "image",
+    streamId: "stream",
+    streamSourceName: "/camera",
+    streamSourceNames: ["/camera"],
+    variant: "frame",
+    width: 64,
+  }),
+};
+const resolved = { descriptor, provider };
+
+function posterEntry(
+  overrides: Partial<GridPosterCacheEntry> = {},
+): GridPosterCacheEntry {
+  return {
+    bytes: new Uint8Array([4, 5, 6]),
+    height: 64,
+    mimeType: "image/webp",
+    sourceKind: "image",
+    streamId: "stream",
+    streamSourceName: "/camera",
+    streamSourceNames: ["/camera"],
+    width: 64,
+    ...overrides,
+  };
+}

--- a/app/packages/multimodal/src/views/episode/grid/use-grid-poster-provider.ts
+++ b/app/packages/multimodal/src/views/episode/grid/use-grid-poster-provider.ts
@@ -1,0 +1,211 @@
+import { useEffect, useMemo, useState } from "react";
+
+import {
+  useGridPosterProvider,
+  type GridPosterProvider,
+  type GridPosterProviderDescriptor,
+} from "../../../extensions/grid-posters";
+import type { PointCloudCameraPose } from "../../../visualization/scene-3d";
+import {
+  getGridPosterCache,
+  recordGridPosterDiagnostic,
+  shouldReplaceGridPoster,
+  type GridPosterCacheEntry,
+} from "./grid-poster-cache";
+import { getGridPosterPersistence } from "./grid-poster-persistence";
+
+export type GridPosterProviderLookupStatus =
+  | "idle"
+  | "loading"
+  | "hit"
+  | "miss";
+
+const GRID_POSTER_PROVIDER_LOOKUP_TIMEOUT_MS = 5_000;
+
+type AbortableLookupOptions<Result> = {
+  readonly onError: () => void;
+  readonly onSuccess: (result: Result) => void;
+  readonly onTimeout: () => void;
+  readonly run: (signal: AbortSignal) => Promise<Result>;
+  readonly timeoutMs: number;
+};
+
+/** Runs a lookup with shared timeout, abort, and stale-result suppression. */
+function runAbortableLookup<Result>({
+  onError,
+  onSuccess,
+  onTimeout,
+  run,
+  timeoutMs,
+}: AbortableLookupOptions<Result>): () => void {
+  const controller = new AbortController();
+  let active = true;
+  const timeout = window.setTimeout(() => {
+    active = false;
+    controller.abort();
+    onTimeout();
+  }, timeoutMs);
+  void run(controller.signal)
+    .then((result) => {
+      if (active) onSuccess(result);
+    })
+    .catch((error: unknown) => {
+      if (!active) return;
+      if (error instanceof Error && error.name === "AbortError") return;
+      onError();
+    })
+    .finally(() => window.clearTimeout(timeout));
+  return () => {
+    active = false;
+    window.clearTimeout(timeout);
+    controller.abort();
+  };
+}
+
+export interface ResolvedGridPosterProviderDescriptor {
+  readonly descriptor: GridPosterProviderDescriptor;
+  readonly provider: GridPosterProvider;
+}
+
+/** Resolves optional precomputed-poster metadata for one visible sample. */
+export function useGridPosterProviderDescriptor(
+  datasetId: string,
+  sampleId: string | undefined,
+  enabled: boolean,
+): {
+  readonly resolved: ResolvedGridPosterProviderDescriptor | null;
+  readonly status: GridPosterProviderLookupStatus;
+} {
+  const provider = useGridPosterProvider();
+  const shouldResolve = enabled && Boolean(sampleId) && provider !== null;
+  const key = shouldResolve ? `${provider.id}:${datasetId}:${sampleId}` : null;
+  const [lookup, setLookup] = useState<{
+    readonly key: string | null;
+    readonly resolved: ResolvedGridPosterProviderDescriptor | null;
+    readonly status: GridPosterProviderLookupStatus;
+  }>({ key: null, resolved: null, status: "idle" });
+
+  useEffect(() => {
+    if (!key || !sampleId || !provider) return undefined;
+    const recordMiss = () => {
+      recordGridPosterDiagnostic("providerDescriptorMisses");
+      setLookup({ key, resolved: null, status: "miss" });
+    };
+    setLookup({ key, resolved: null, status: "loading" });
+    return runAbortableLookup<GridPosterProviderDescriptor | null>({
+      onError: recordMiss,
+      onSuccess: (descriptor) => {
+        recordGridPosterDiagnostic(
+          descriptor ? "providerDescriptorHits" : "providerDescriptorMisses",
+        );
+        setLookup({
+          key,
+          resolved: descriptor ? { descriptor, provider } : null,
+          status: descriptor ? "hit" : "miss",
+        });
+      },
+      onTimeout: recordMiss,
+      run: (signal) =>
+        provider.resolveDescriptor({ datasetId, sampleId }, signal),
+      timeoutMs: GRID_POSTER_PROVIDER_LOOKUP_TIMEOUT_MS,
+    });
+  }, [datasetId, key, provider, sampleId]);
+
+  if (!enabled) return { resolved: null, status: "idle" };
+  if (!provider || !sampleId) return { resolved: null, status: "miss" };
+  if (lookup.key !== key) return { resolved: null, status: "loading" };
+  return lookup;
+}
+
+/** Loads a selected provider artifact into the shared poster cache tiers. */
+export function useProvidedGridPoster({
+  cacheKey,
+  cameraPose,
+  enabled,
+  posterStartTimeNs,
+  resolved,
+  selectedSourceName,
+}: {
+  readonly cacheKey: string | null;
+  readonly cameraPose: PointCloudCameraPose | null;
+  readonly enabled: boolean;
+  readonly posterStartTimeNs: bigint | null;
+  readonly resolved: ResolvedGridPosterProviderDescriptor | null;
+  readonly selectedSourceName: string | null;
+}): {
+  readonly entry: GridPosterCacheEntry | null;
+  readonly status: GridPosterProviderLookupStatus;
+} {
+  const selection = useMemo(
+    () =>
+      resolved?.descriptor.select({
+        cameraPose,
+        posterStartTimeNs,
+        selectedSourceName,
+      }) ?? null,
+    [cameraPose, posterStartTimeNs, resolved, selectedSourceName],
+  );
+  const requestKey =
+    enabled && cacheKey && selection && resolved
+      ? `${resolved.provider.id}:${cacheKey}:${selection.identity}`
+      : null;
+  const [lookup, setLookup] = useState<{
+    readonly entry: GridPosterCacheEntry | null;
+    readonly key: string | null;
+    readonly status: GridPosterProviderLookupStatus;
+  }>({ entry: null, key: null, status: "idle" });
+
+  useEffect(() => {
+    if (!requestKey || !cacheKey || !resolved || !selection) return undefined;
+    const recordMiss = () => {
+      recordGridPosterDiagnostic("providerArtifactFailures");
+      setLookup({ entry: null, key: requestKey, status: "miss" });
+    };
+    setLookup({ entry: null, key: requestKey, status: "loading" });
+    return runAbortableLookup<Uint8Array>({
+      onError: recordMiss,
+      onSuccess: (bytes) => {
+        if (bytes.byteLength !== selection.byteLength) {
+          throw new Error("Grid poster provider byte length mismatch");
+        }
+        const entry: GridPosterCacheEntry = {
+          bytes,
+          height: selection.height,
+          mimeType: selection.mimeType,
+          provider: {
+            artifactIdentity: selection.identity,
+            id: resolved.provider.id,
+            mediaKind: selection.mediaKind,
+            policyVersion: selection.policyVersion,
+            revision: resolved.descriptor.cacheRevision,
+            variant: selection.variant,
+          },
+          sourceKind: selection.sourceKind,
+          streamId: selection.streamId,
+          streamSourceName: selection.streamSourceName,
+          streamSourceNames: selection.streamSourceNames,
+          width: selection.width,
+        };
+        const cache = getGridPosterCache();
+        const current = cache.peek(cacheKey);
+        recordGridPosterDiagnostic("providerArtifactHits");
+        if (!shouldReplaceGridPoster(current, entry)) {
+          setLookup({ entry: current, key: requestKey, status: "hit" });
+          return;
+        }
+        cache.put(cacheKey, entry);
+        void getGridPosterPersistence()
+          .put(cacheKey, entry)
+          .catch(() => recordGridPosterDiagnostic("providerArtifactFailures"));
+        setLookup({ entry, key: requestKey, status: "hit" });
+      },
+      onTimeout: recordMiss,
+      run: selection.load,
+      timeoutMs: GRID_POSTER_PROVIDER_LOOKUP_TIMEOUT_MS,
+    });
+  }, [cacheKey, requestKey, resolved, selection]);
+
+  if (!requestKey) return { entry: null, status: enabled ? "miss" : "idle" };
+  if (lookup.key !== requestKey) return { entry: null, status: "loading" };
+  return lookup;
+}


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

Add an optional grid-poster provider extension for product editions that can serve precomputed raster posters. The shared grid waits for a registered provider before opening a live source session, keeps provider revisions in the durable cache key, and preserves provider provenance across memory and IndexedDB poster tiers.

No provider is registered in OSS, so the existing memory → IndexedDB → live-preview flow is unchanged.

## 🧪 How is this patch tested? If it is not, please explain why.

- `yarn test` on the grid-poster provider registry, provider hooks, poster cache, `GridRenderer`, and its fixture integration: 54 passed
- `yarn workspace @fiftyone/multimodal check`

## High Level Architecture

- `extensions/grid-posters` owns the edition boundary and product-neutral contract.
- The shared grid owns timeout, fallback, cache precedence, and persistence behavior.
- Product code may register one namespaced provider from its edition-specific entrypoint.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

N/A

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3887
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for optional precomputed grid posters from registered providers.
  * Added provider metadata, multiple media types, camera poses, and poster selections.
  * Added responsive provider discovery with timeout and cancellation handling.
  * Improved poster caching, persistence, freshness checks, and diagnostics.

* **Bug Fixes**
  * Prevented unnecessary source-session loading when a valid provider poster is available.
  * Ensured provider revisions and point-cloud camera poses correctly update poster selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->