### PR TITLE
Let grid render while operators initialize

### DIFF
--- a/app/packages/app/src/Sync.tsx
+++ b/app/packages/app/src/Sync.tsx
@@ -49,7 +49,7 @@ export const SessionContext = React.createContext<Session>(SESSION_DEFAULT);
 
 const Plugins = ({ children }: { children: React.ReactNode }) => {
   const plugins = usePlugins();
-  if (plugins.isLoading) return <Loading>Pixelating...</Loading>;
+  if (plugins.isLoadingPlugins) return <Loading>Pixelating...</Loading>;
   return <>{children}</>;
 };
 

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useLoadSchemas.test.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useLoadSchemas.test.ts
@@ -1,0 +1,73 @@
+import { act, renderHook } from "@testing-library/react";
+import { useEffect } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  available: false,
+  closeSchemaManager: vi.fn(),
+  execute: vi.fn(),
+  result: null,
+  setActive: vi.fn(),
+  setActivePathsOrder: vi.fn(),
+  setData: vi.fn(),
+}));
+
+vi.mock("@fiftyone/operators", () => ({
+  useOperatorAvailability: vi.fn(() => mocks.available),
+  useOperatorExecutor: vi.fn(() => ({
+    execute: mocks.execute,
+    result: mocks.result,
+  })),
+}));
+
+vi.mock("jotai", () => ({
+  useSetAtom: vi.fn((atom) => {
+    if (atom === "activeLabelSchemas") return mocks.setActive;
+    if (atom === "activePathsOrder") return mocks.setActivePathsOrder;
+    return mocks.setData;
+  }),
+}));
+
+vi.mock("./SchemaManager/hooks", () => ({
+  useSchemaManagerModal: vi.fn(() => ({
+    closeSchemaManager: mocks.closeSchemaManager,
+  })),
+}));
+
+vi.mock("./state", () => ({
+  activeLabelSchemas: "activeLabelSchemas",
+  activePathsOrder: "activePathsOrder",
+  labelSchemasData: "labelSchemasData",
+}));
+
+import useLoadSchemas from "./useLoadSchemas";
+
+describe("useLoadSchemas operator readiness", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.available = false;
+    mocks.result = null;
+  });
+
+  it("retries schema loading when the operator registers", () => {
+    const { rerender } = renderHook(() => {
+      const loadSchemas = useLoadSchemas();
+      useEffect(() => {
+        loadSchemas();
+      }, [loadSchemas]);
+    });
+
+    expect(mocks.execute).not.toHaveBeenCalled();
+    expect(mocks.closeSchemaManager).not.toHaveBeenCalled();
+    expect(mocks.setActivePathsOrder).not.toHaveBeenCalled();
+
+    act(() => {
+      mocks.available = true;
+      rerender();
+    });
+
+    expect(mocks.setActivePathsOrder).toHaveBeenCalledWith(null);
+    expect(mocks.closeSchemaManager).toHaveBeenCalledTimes(1);
+    expect(mocks.execute).toHaveBeenCalledWith({});
+  });
+});

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/useLoadSchemas.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/useLoadSchemas.ts
@@ -1,4 +1,7 @@
-import { useOperatorExecutor } from "@fiftyone/operators";
+import {
+  useOperatorAvailability,
+  useOperatorExecutor,
+} from "@fiftyone/operators";
 import { useSetAtom } from "jotai";
 import { useCallback, useEffect, useRef } from "react";
 import { useSchemaManagerModal } from "./SchemaManager/hooks";
@@ -13,6 +16,7 @@ export default function useLoadSchemas() {
   const setActive = useSetAtom(activeLabelSchemas);
   const setActivePathsOrder = useSetAtom(activePathsOrder);
   const { closeSchemaManager } = useSchemaManagerModal();
+  const operatorAvailable = useOperatorAvailability("get_label_schemas");
   const get = useOperatorExecutor("get_label_schemas");
 
   useEffect(() => {
@@ -34,10 +38,14 @@ export default function useLoadSchemas() {
   // Refetch without pre-clearing the schema atoms: the `get.result`
   // effect above swaps them atomically once the response lands, so
   // consumers (`useLabels`, `useFormAnchor`'s `labelMap` lookup) never
-  // see a transient null mid-refetch.
+  // see a transient null mid-refetch. Operator availability is a dependency
+  // so callers whose effects depend on this callback retry once definitions
+  // register instead of retaining an executor that resolved too early.
   return useCallback(() => {
+    if (!operatorAvailable) return;
+
     setActivePathsOrder(null);
     closeSchemaManager();
     executeRef.current({});
-  }, [setActivePathsOrder, closeSchemaManager]);
+  }, [operatorAvailable, setActivePathsOrder, closeSchemaManager]);
 }

--- a/app/packages/core/src/components/SchemaManagerOutlet.test.tsx
+++ b/app/packages/core/src/components/SchemaManagerOutlet.test.tsx
@@ -1,0 +1,69 @@
+import { cleanup, render } from "@testing-library/react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  available: false,
+  ensureSchemasLoaded: vi.fn(),
+  registerContextManager: vi.fn(),
+}));
+
+vi.mock("@fiftyone/annotation", () => ({
+  useRegisterAnnotationContextManager: mocks.registerContextManager,
+}));
+
+vi.mock("@fiftyone/operators", () => ({
+  useOperatorAvailability: vi.fn(() => mocks.available),
+}));
+
+vi.mock("../url/useSchemaManagerUrl", () => ({
+  useSchemaManagerUrl: vi.fn(),
+}));
+
+vi.mock("./Modal/Sidebar/Annotate/SchemaManager", () => ({
+  default: () => React.createElement("div", null, "schema-manager"),
+}));
+
+vi.mock("./Modal/Sidebar/Annotate/SchemaManager/hooks", () => ({
+  useSchemaManagerModal: vi.fn(() => ({ schemaManagerDisplayed: false })),
+}));
+
+vi.mock("./Modal/Sidebar/Annotate/SchemaManagementProvider", () => ({
+  default: () => React.createElement("div", null, "schema-provider"),
+}));
+
+vi.mock("./Modal/Sidebar/Annotate/useAnnotationContextManager", () => ({
+  useAnnotationContextManager: vi.fn(() => ({})),
+}));
+
+vi.mock("./Modal/Sidebar/Annotate/useCanManageSchema", () => ({
+  default: vi.fn(() => true),
+}));
+
+vi.mock("./Modal/Sidebar/Annotate/useEnsureSchemasLoaded", () => ({
+  useEnsureSchemasLoaded: mocks.ensureSchemasLoaded,
+}));
+
+import SchemaManagerOutlet from "./SchemaManagerOutlet";
+
+describe("SchemaManagerOutlet operator readiness", () => {
+  afterEach(cleanup);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.available = false;
+  });
+
+  it("waits for its operator without delaying context registration", () => {
+    const { rerender } = render(<SchemaManagerOutlet />);
+
+    expect(mocks.ensureSchemasLoaded).toHaveBeenCalledWith(false);
+    expect(mocks.registerContextManager).toHaveBeenCalledTimes(1);
+
+    mocks.available = true;
+    rerender(<SchemaManagerOutlet />);
+
+    expect(mocks.ensureSchemasLoaded).toHaveBeenCalledWith(true);
+    expect(mocks.registerContextManager).toHaveBeenCalledTimes(2);
+  });
+});

--- a/app/packages/core/src/components/SchemaManagerOutlet.tsx
+++ b/app/packages/core/src/components/SchemaManagerOutlet.tsx
@@ -10,11 +10,13 @@
  *   4. `useEnsureSchemasLoaded()` — one-shot dataset-level fetch so the modal
  *      renders populated when opened from the grid.
  *
- * All gated on `canManageSchema`. Mount once per app — `DatasetPage.tsx` in
- * OSS, the samples page in teams-app — inside the Recoil/Jotai-aware tree.
+ * Operator-backed schema loading/UI is gated on `canManageSchema` and operator
+ * availability. Mount once per app — `DatasetPage.tsx` in OSS, the samples
+ * page in teams-app — inside the Recoil/Jotai-aware tree.
  */
 
 import { useRegisterAnnotationContextManager } from "@fiftyone/annotation";
+import { useOperatorAvailability } from "@fiftyone/operators";
 import { useSchemaManagerUrl } from "../url/useSchemaManagerUrl";
 import SchemaManager from "./Modal/Sidebar/Annotate/SchemaManager";
 import { useSchemaManagerModal } from "./Modal/Sidebar/Annotate/SchemaManager/hooks";
@@ -25,17 +27,18 @@ import { useEnsureSchemasLoaded } from "./Modal/Sidebar/Annotate/useEnsureSchema
 
 const SchemaManagerOutlet = () => {
   const canManage = useCanManageSchema();
+  const operatorAvailable = useOperatorAvailability("get_label_schemas");
   const { schemaManagerDisplayed } = useSchemaManagerModal();
-  // Run unconditionally so effect cleanups stay stable across permission
-  // flips; both hooks are no-ops when `canManage` is false.
+  // Run unconditionally so effect cleanups stay stable across readiness
+  // flips. Schema loading remains disabled until its operator is available.
   useSchemaManagerUrl();
-  useEnsureSchemasLoaded(canManage);
+  useEnsureSchemasLoaded(canManage && operatorAvailable);
   // The context-manager implementation registers app-level (not gated on
   // `canManage` — enter/exit must work regardless, and programmatic entry
   // via the `annotate` operator can precede the modal mounting).
   useRegisterAnnotationContextManager(useAnnotationContextManager());
 
-  if (!canManage) return null;
+  if (!canManage || !operatorAvailable) return null;
 
   return (
     <>

--- a/app/packages/operators/src/hooks.test.ts
+++ b/app/packages/operators/src/hooks.test.ts
@@ -1,0 +1,70 @@
+import { renderHook } from "@testing-library/react";
+import { useRecoilValue } from "recoil";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveOperatorURI } from "./operators";
+
+vi.mock("@fiftyone/state", () => ({}));
+
+vi.mock("@fiftyone/plugins", () => ({
+  pluginsLoaderAtom: "pluginsLoaderAtom",
+}));
+
+vi.mock("recoil", () => ({
+  useRecoilState: vi.fn(),
+  useRecoilValue: vi.fn(),
+  useSetRecoilState: vi.fn(),
+}));
+
+vi.mock("./operators", () => ({
+  ExecutionContext: vi.fn(),
+  fetchRemotePlacements: vi.fn(),
+  listLocalAndRemoteOperators: vi.fn(),
+  resolveLocalPlacements: vi.fn(),
+  resolveOperatorURI: vi.fn(),
+}));
+
+vi.mock("./state", () => ({
+  activePanelsEventCountAtom: "activePanelsEventCountAtom",
+  availableOperators: "availableOperators",
+  operatorPlacementsAtom: "operatorPlacementsAtom",
+  operatorThrottledContext: "operatorThrottledContext",
+  operatorsInitializedAtom: "operatorsInitializedAtom",
+  useCurrentSample: vi.fn(),
+}));
+
+import { useFirstExistingUri, useOperatorAvailability } from "./hooks";
+
+describe("operator availability hooks", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(resolveOperatorURI).mockImplementation((uri) =>
+      uri.startsWith("@") ? uri : `@voxel51/operators/${uri}`,
+    );
+  });
+
+  it("resolves bare URIs and reacts when definitions register", () => {
+    vi.mocked(useRecoilValue).mockReturnValue([]);
+    const uris = ["missing", "list_workspaces"];
+    const { result, rerender } = renderHook(() => ({
+      available: useOperatorAvailability("list_workspaces"),
+      first: useFirstExistingUri(uris),
+    }));
+
+    expect(result.current.available).toBe(false);
+    expect(result.current.first).toEqual({
+      firstExistingUri: undefined,
+      exists: false,
+    });
+
+    vi.mocked(useRecoilValue).mockReturnValue([
+      { value: "@voxel51/operators/list_workspaces" },
+    ]);
+    rerender();
+
+    expect(result.current.available).toBe(true);
+    expect(result.current.first).toEqual({
+      firstExistingUri: "list_workspaces",
+      exists: true,
+    });
+  });
+});

--- a/app/packages/operators/src/hooks.ts
+++ b/app/packages/operators/src/hooks.ts
@@ -7,12 +7,13 @@ import { RESOLVE_PLACEMENTS_TTL } from "./constants";
 import {
   ExecutionContext,
   fetchRemotePlacements,
-  listLocalAndRemoteOperators,
+  resolveOperatorURI,
   resolveLocalPlacements,
   type RawContext,
 } from "./operators";
 import {
   activePanelsEventCountAtom,
+  availableOperators,
   operatorPlacementsAtom,
   operatorThrottledContext,
   operatorsInitializedAtom,
@@ -171,13 +172,20 @@ export function useActivePanelEventsCount(id: string) {
   return { count, increment, decrement };
 }
 
+/** Reactively returns the first registered operator URI from a list. */
 export function useFirstExistingUri(uris: string[]) {
-  const availableOperators = useMemo(() => listLocalAndRemoteOperators(), []);
-  return useMemo(() => {
-    const existingUri = uris.find((uri) =>
-      availableOperators.allOperators.some((op) => op.uri === uri),
-    );
-    const exists = Boolean(existingUri);
-    return { firstExistingUri: existingUri, exists };
-  }, [availableOperators, uris]);
+  const operators = useRecoilValue(availableOperators);
+  const existingUri = uris.find((uri) => {
+    const resolvedUri = resolveOperatorURI(uri);
+    return operators.some((operator) => operator.value === resolvedUri);
+  });
+  return { firstExistingUri: existingUri, exists: Boolean(existingUri) };
+}
+
+/**
+ * Reactively reports whether an operator URI is registered. This checks
+ * registry presence only; callers remain responsible for permission checks.
+ */
+export function useOperatorAvailability(uri: string) {
+  return useFirstExistingUri([uri]).exists;
 }

--- a/app/packages/operators/src/index.ts
+++ b/app/packages/operators/src/index.ts
@@ -1,5 +1,5 @@
 export { OPERATOR_PROMPT_AREAS, RiskLevel } from "./constants";
-export { useFirstExistingUri } from "./hooks";
+export { useFirstExistingUri, useOperatorAvailability } from "./hooks";
 export { useOperators, useRefreshOperators } from "./loader";
 export { default as OperatorBrowser } from "./OperatorBrowser";
 export { default as OperatorCore } from "./OperatorCore";

--- a/app/packages/operators/src/loader.test.tsx
+++ b/app/packages/operators/src/loader.test.tsx
@@ -1,0 +1,123 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  datasetName: "dataset-one",
+  executeOperatorsForEvent: vi.fn(),
+  initialized: false,
+  loadOperatorsFromServer: vi.fn(),
+  registerBuiltInOperators: vi.fn(),
+  registerPanel: vi.fn(),
+  setInitialized: vi.fn(),
+  setRefreshCount: vi.fn(),
+}));
+
+vi.mock("@fiftyone/state", () => ({
+  datasetName: "datasetName",
+}));
+
+vi.mock("@fiftyone/utilities", () => ({
+  isPrimitiveString: (value: unknown) => typeof value === "string",
+}));
+
+vi.mock("recoil", () => ({
+  useRecoilValue: vi.fn(() => mocks.datasetName),
+  useSetRecoilState: vi.fn((atom) =>
+    atom === "availableOperatorsRefreshCount"
+      ? mocks.setRefreshCount
+      : mocks.setInitialized,
+  ),
+}));
+
+vi.mock("./built-in-operators", () => ({
+  registerBuiltInOperators: mocks.registerBuiltInOperators,
+}));
+
+vi.mock("./hooks", () => ({
+  useOperatorPlacementsResolver: vi.fn(() => ({
+    initialized: mocks.initialized,
+  })),
+}));
+
+vi.mock("./operators", () => ({
+  executeOperatorsForEvent: mocks.executeOperatorsForEvent,
+  loadOperatorsFromServer: mocks.loadOperatorsFromServer,
+}));
+
+vi.mock("./Panel/register", () => ({
+  default: mocks.registerPanel,
+}));
+
+vi.mock("./state", () => ({
+  availableOperatorsRefreshCount: "availableOperatorsRefreshCount",
+  operatorsInitializedAtom: "operatorsInitializedAtom",
+}));
+
+import { useOperators } from "./loader";
+
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((onResolve) => {
+    resolve = onResolve;
+  });
+  return { promise, resolve };
+};
+
+describe("useOperators lifecycle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.datasetName = "dataset-one";
+    mocks.initialized = false;
+  });
+
+  it("publishes definitions before placements and does not await startup execution", async () => {
+    const definitions = deferred<Array<{ panel_name: string }>>();
+    const startupExecution = deferred<void>();
+    mocks.loadOperatorsFromServer.mockReturnValueOnce(definitions.promise);
+    mocks.executeOperatorsForEvent.mockReturnValue(startupExecution.promise);
+
+    const { result, rerender } = renderHook(() => useOperators(false));
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.ready).toBe(false);
+    expect(mocks.executeOperatorsForEvent).not.toHaveBeenCalled();
+
+    await act(async () => {
+      definitions.resolve([{ panel_name: "panel" }]);
+      await definitions.promise;
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.ready).toBe(false);
+    expect(mocks.registerPanel).toHaveBeenCalledWith({ panel_name: "panel" });
+    expect(mocks.executeOperatorsForEvent).toHaveBeenCalledWith(
+      "onDatasetOpen",
+    );
+    expect(mocks.executeOperatorsForEvent).toHaveBeenCalledWith("onStartup");
+    expect(mocks.setInitialized).toHaveBeenCalledWith(true);
+
+    mocks.initialized = true;
+    rerender();
+    expect(result.current.ready).toBe(true);
+
+    mocks.loadOperatorsFromServer.mockResolvedValueOnce([]);
+    mocks.datasetName = "dataset-two";
+    rerender();
+    await waitFor(() =>
+      expect(mocks.loadOperatorsFromServer).toHaveBeenCalledWith("dataset-two"),
+    );
+    await waitFor(() =>
+      expect(mocks.executeOperatorsForEvent).toHaveBeenCalledTimes(3),
+    );
+    expect(
+      mocks.executeOperatorsForEvent.mock.calls.filter(
+        ([event]) => event === "onStartup",
+      ),
+    ).toHaveLength(1);
+    expect(
+      mocks.executeOperatorsForEvent.mock.calls.filter(
+        ([event]) => event === "onDatasetOpen",
+      ),
+    ).toHaveLength(2);
+  });
+});

--- a/app/packages/plugins/src/index.test.tsx
+++ b/app/packages/plugins/src/index.test.tsx
@@ -1,0 +1,128 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  operatorState: {
+    hasError: false,
+    isLoading: true,
+    ready: false,
+  },
+  pluginState: "ready" as "error" | "loading" | "ready",
+}));
+
+vi.mock("recoil", () => ({
+  atom: vi.fn((value) => value),
+  useRecoilState: vi.fn(() => [mocks.pluginState, vi.fn()]),
+  useRecoilValue: vi.fn(() => "dataset"),
+}));
+
+vi.mock("@fiftyone/operators", () => ({
+  useOperators: vi.fn(() => mocks.operatorState),
+}));
+
+vi.mock("@fiftyone/state", () => ({
+  datasetName: "datasetName",
+  useNotification: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("@fiftyone/utilities", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@fiftyone/utilities")>()),
+  getFetchFunction: vi.fn(() => vi.fn(() => new Promise(() => undefined))),
+  getFetchParameters: vi.fn(() => ({ pathPrefix: "" })),
+  getFetchPathPrefix: vi.fn(() => ""),
+}));
+
+vi.mock("./registry", () => ({
+  usingRegistry: vi.fn(() => ({
+    getScript: vi.fn(),
+    registerPluginDefinition: vi.fn(),
+    registerScript: vi.fn(),
+  })),
+}));
+
+vi.mock("./externalize", () => ({}));
+
+import { usePlugins } from ".";
+
+function GridBoundary() {
+  const plugins = usePlugins();
+  if (plugins.isLoadingPlugins) return <div>Pixelating</div>;
+  return (
+    <div>
+      <span>Grid</span>
+      <span>
+        {plugins.isLoading ? "operators-loading" : "operators-loaded"}
+      </span>
+      <span>{plugins.ready ? "ready" : "not-ready"}</span>
+      <span>{plugins.hasError ? "operator-error" : "no-error"}</span>
+    </div>
+  );
+}
+
+describe("usePlugins readiness boundaries", () => {
+  afterEach(cleanup);
+
+  beforeEach(() => {
+    mocks.pluginState = "ready";
+    mocks.operatorState = {
+      hasError: false,
+      isLoading: true,
+      ready: false,
+    };
+  });
+
+  it("mounts grid children while operator definitions are pending", () => {
+    const { rerender } = render(<GridBoundary />);
+
+    expect(screen.getByText("Grid")).toBeTruthy();
+    expect(screen.getByText("operators-loading")).toBeTruthy();
+
+    mocks.operatorState = {
+      hasError: false,
+      isLoading: false,
+      ready: true,
+    };
+    rerender(<GridBoundary />);
+
+    expect(screen.getByText("operators-loaded")).toBeTruthy();
+    expect(screen.getByText("ready")).toBeTruthy();
+  });
+
+  it("keeps placement readiness and operator errors local to consumers", () => {
+    mocks.operatorState = {
+      hasError: false,
+      isLoading: false,
+      ready: false,
+    };
+    const { rerender } = render(<GridBoundary />);
+
+    expect(screen.getByText("Grid")).toBeTruthy();
+    expect(screen.getByText("operators-loaded")).toBeTruthy();
+    expect(screen.getByText("not-ready")).toBeTruthy();
+
+    mocks.operatorState = {
+      hasError: true,
+      isLoading: false,
+      ready: false,
+    };
+    rerender(<GridBoundary />);
+
+    expect(screen.getByText("Grid")).toBeTruthy();
+    expect(screen.getByText("operator-error")).toBeTruthy();
+  });
+
+  it("continues to gate children on plugin metadata and bundles", () => {
+    mocks.pluginState = "loading";
+    mocks.operatorState = {
+      hasError: false,
+      isLoading: false,
+      ready: true,
+    };
+
+    render(<GridBoundary />);
+
+    expect(screen.getByText("Pixelating")).toBeTruthy();
+    expect(screen.queryByText("Grid")).toBeNull();
+  });
+});

--- a/app/packages/plugins/src/index.ts
+++ b/app/packages/plugins/src/index.ts
@@ -146,6 +146,10 @@ export function usePlugins() {
   }, [setState]);
 
   return {
+    // Plugin metadata and JavaScript bundles must register before rendering
+    // surfaces that select plugin-provided components, such as grid renderers.
+    // Operator definitions can initialize behind those surfaces.
+    isLoadingPlugins: state === "loading",
     isLoading: state === "loading" || operatorIsLoading,
     hasError: state === "error" || operatorHasError,
     ready: state === "ready" && operatorsReady,

--- a/app/packages/spaces/src/components/Workspaces/hooks.test.ts
+++ b/app/packages/spaces/src/components/Workspaces/hooks.test.ts
@@ -1,0 +1,63 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  available: false,
+  executeOperator: vi.fn(),
+  resetState: vi.fn(),
+  setState: vi.fn(),
+}));
+
+vi.mock("@fiftyone/operators", () => ({
+  executeOperator: mocks.executeOperator,
+  useOperatorAvailability: vi.fn(() => mocks.available),
+}));
+
+vi.mock("@fiftyone/state", () => ({
+  datasetName: "datasetName",
+}));
+
+vi.mock("@fiftyone/utilities", () => ({
+  toSlug: (value: string) => value.toLowerCase(),
+}));
+
+vi.mock("recoil", () => ({
+  useRecoilState: vi.fn(() => [
+    { dataset: "dataset", initialized: false, workspaces: [] },
+    mocks.setState,
+  ]),
+  useRecoilValue: vi.fn(() => "dataset"),
+  useResetRecoilState: vi.fn(() => mocks.resetState),
+}));
+
+vi.mock("../../state", () => ({
+  savedWorkspacesAtom: "savedWorkspacesAtom",
+}));
+
+import { useWorkspaces } from "./hooks";
+
+describe("useWorkspaces operator readiness", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.available = false;
+  });
+
+  it("waits locally for list_workspaces to become available", () => {
+    const { result, rerender } = renderHook(() => useWorkspaces());
+
+    expect(result.current.canInitialize).toBe(false);
+    act(() => result.current.listWorkspace());
+    expect(mocks.executeOperator).not.toHaveBeenCalled();
+
+    mocks.available = true;
+    rerender();
+    expect(result.current.canInitialize).toBe(true);
+
+    act(() => result.current.listWorkspace());
+    expect(mocks.executeOperator).toHaveBeenCalledWith(
+      "@voxel51/operators/list_workspaces",
+      {},
+      expect.objectContaining({ skipOutput: true }),
+    );
+  });
+});

--- a/app/packages/spaces/src/components/Workspaces/hooks.ts
+++ b/app/packages/spaces/src/components/Workspaces/hooks.ts
@@ -1,21 +1,22 @@
-import { executeOperator } from "@fiftyone/operators";
+import { executeOperator, useOperatorAvailability } from "@fiftyone/operators";
 import { datasetName } from "@fiftyone/state";
 import { toSlug } from "@fiftyone/utilities";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRecoilState, useRecoilValue, useResetRecoilState } from "recoil";
 import { savedWorkspacesAtom, Workspace } from "../../state";
 import { LIST_WORKSPACES_OPERATOR, LOAD_WORKSPACE_OPERATOR } from "./constants";
-import { operatorsInitializedAtom } from "@fiftyone/operators/src/state";
 
 export function useWorkspaces() {
   const [state, setState] = useRecoilState(savedWorkspacesAtom);
   const resetState = useResetRecoilState(savedWorkspacesAtom);
   const [listWorkspaceExecuting, setListWorkspaceExecuting] = useState(false);
   const currentDataset = useRecoilValue(datasetName);
-  const operatorsInitialized = useRecoilValue(operatorsInitializedAtom);
+  const listWorkspacesAvailable = useOperatorAvailability(
+    LIST_WORKSPACES_OPERATOR,
+  );
 
   const listWorkspace = useCallback(() => {
-    if (listWorkspaceExecuting || !operatorsInitialized) return;
+    if (listWorkspaceExecuting || !listWorkspacesAvailable) return;
     setListWorkspaceExecuting(true);
     executeOperator(
       LIST_WORKSPACES_OPERATOR,
@@ -41,7 +42,12 @@ export function useWorkspaces() {
         skipOutput: true,
       },
     );
-  }, [listWorkspaceExecuting, setState, currentDataset, operatorsInitialized]);
+  }, [
+    listWorkspaceExecuting,
+    setState,
+    currentDataset,
+    listWorkspacesAvailable,
+  ]);
 
   const loadWorkspace = useCallback((name: string) => {
     executeOperator(LOAD_WORKSPACE_OPERATOR, { name }, { skipOutput: true });
@@ -64,6 +70,6 @@ export function useWorkspaces() {
     listWorkspace,
     reset: resetState,
     existingSlugs,
-    canInitialize: operatorsInitialized,
+    canInitialize: listWorkspacesAvailable,
   };
 }


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

Separate plugin bundle readiness from operator readiness so dataset grids can mount and start loading samples while operator definitions initialize. Plugin metadata and JavaScript bundles still gate rendering so plugin-provided renderers register first.

Operator-backed mount-time consumers now wait for the specific operator they need, and operator URI discovery reacts when definitions register or refresh.

**In local benchmarks: first pagination was 1500% (16x) faster, and meaningful paint was 1300% (14x) faster.** 

Before:
```
/plugins + JS bundles complete
        ↓
/operators completes
        ├──→ grid mounts and paginateSamplesQuery starts
        ├──→ workspaces, schema manager, panels, palette become usable
        └──→ placements/startup continue and eventually finish
```

Now:
```
/plugins + JS bundles complete
        ├──→ grid mounts and paginateSamplesQuery starts
        └──→ /operators continues
                    ↓
             definitions register
                    ├──→ workspaces, schema manager, panels, palette become usable
                    └──→ placements/startup continue and eventually finish
```

## 🧪 How is this patch tested? If it is not, please explain why.
- 10 focused and adjacent Vitest files: 63 tests passed
- Controlled A/B with a deterministic 3-second operator-definition delay: first grid/pagination started at about 0.19/0.20 seconds with this patch instead of about 3.28 seconds
- Operator-definition failure still painted the grid; a plugin-bundle delay continued to gate it
- Enterprise four-service smoke: the grid painted six tiles, loaded 100 samples, and preserved workspace availability
- Repository-wide typecheck still reports 1,127 pre-existing diagnostics; none are on added tests or changed lines
 
## 📝 Release Notes
### Is this a user-facing change that should be mentioned in the release notes?

Yes.

Dataset grids can begin loading while operators initialize, reducing time to first content on operator-heavy setups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added reactive operator availability tracking.
  - Workspace and schema features now activate only when required operators are ready.
  - Plugin loading status now distinguishes plugin assets from operator initialization.

- **Bug Fixes**
  - Prevented premature workspace and schema loading when required operators are unavailable.
  - Improved loading-state handling during plugin initialization.

- **Tests**
  - Added coverage for operator readiness, plugin loading, schema management, workspace listing, and operator lifecycle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3892
<!-- enterprise-sync-pr:end -->