### PR TITLE
Fix mutable field access on temporary samples

### DIFF
--- a/fiftyone/core/document.py
+++ b/fiftyone/core/document.py
@@ -8,6 +8,7 @@ Base classes for objects that are backed by database documents.
 from copy import deepcopy
 
 from bson import ObjectId
+from mongoengine.base import BaseDict, BaseList
 
 import eta.core.serial as etas
 import eta.core.utils as etau
@@ -166,6 +167,10 @@ class _Document(object):
 
         if isinstance(value, ObjectId):
             value = str(value)
+        elif isinstance(value, (BaseDict, BaseList)):
+            # MongoEngine only weakly references a mutable value's backing
+            # document, so retain it while callers hold the value
+            value._fiftyone_document = self
 
         return value
 

--- a/tests/unittests/sample_tests.py
+++ b/tests/unittests/sample_tests.py
@@ -6,9 +6,11 @@ FiftyOne sample-related unit tests.
 |
 """
 
+import gc
 import os
 import tempfile
 import unittest
+import weakref
 
 from bson import Binary, ObjectId, SON
 import numpy as np
@@ -570,6 +572,26 @@ class SampleCollectionTests(unittest.TestCase):
         self.assertIsInstance(dataset.last(), fo.Sample)
         self.assertIsInstance(dataset.view().first(), fos.SampleView)
         self.assertIsInstance(dataset.view().last(), fos.SampleView)
+
+    @drop_datasets
+    def test_mutate_field_on_temporary_sample(self):
+        dataset = fo.Dataset()
+        dataset.add_sample(fo.Sample("test.png"))
+
+        dataset.first()["tags"].append("tag")
+
+        sample = dataset.first()
+        self.assertEqual(sample.tags, ["tag"])
+
+        tags = sample.tags
+        sample_ref = weakref.ref(sample)
+        del sample
+        gc.collect()
+        self.assertIsNotNone(sample_ref())
+
+        del tags
+        gc.collect()
+        self.assertIsNone(sample_ref())
 
 
 class VideoSampleTests(unittest.TestCase):


### PR DESCRIPTION
## 🔗 Related Issues

Fixes #2738

## 📋 What changes are proposed in this pull request?

MongoEngine mutable field values keep only a weak reference to their backing ODM document. When a Sample is used as a temporary expression, the document can therefore be collected before append or item assignment marks the field as changed, raising ReferenceError.

This change retains the FiftyOne document wrapper for the lifetime of returned BaseList and BaseDict values. It preserves MongoEngine change tracking while allowing the wrapper and its backing document to be garbage-collected once callers release the mutable value. A regression test covers the reported chained tags append and verifies both retention and collection behavior.

## 🧪 How is this patch tested? If it is not, please explain why.

- All 37 tests in tests/unittests/sample_tests.py pass
- Black 22.3.0 leaves both changed files unchanged
- Pylint reports no new errors; the only unfiltered error is also present on the community baseline
- Manual CPU test verifies BaseList and BaseDict mutations survive save and reload

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Mutable list and dictionary sample fields can now be changed through temporary Sample expressions without a weak-reference error.

### What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [x] Core: Core fiftyone Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other