### PR TITLE
fix(skeletonFilter): use helperFunction for null-safe keypoint numeric range filter

### DIFF
--- a/app/packages/state/src/recoil/skeletonFilter.ts
+++ b/app/packages/state/src/recoil/skeletonFilter.ts
@@ -1,9 +1,8 @@
 import { Point } from "@fiftyone/looker";
-import { initial } from "lodash";
 import { selectorFamily } from "recoil";
 import { filters, modalFilters } from "./filters";
 import { BooleanFilter } from "./pathFilters/boolean";
-import { NumericFilter } from "./pathFilters/numeric";
+import { helperFunction, NumericFilter } from "./pathFilters/numeric";
 import { StringFilter } from "./pathFilters/string";
 import { expandPath } from "./schema";
 
@@ -93,10 +92,16 @@ export default selectorFamily<(path: string, value: Point) => boolean, boolean>(
                 }
               }
 
-              const includes =
-                value[key] >= numFilter.range[0] &&
-                value[key] <= numFilter.range[1];
-              const r = numFilter.exclude ? !includes : includes;
+              const r = helperFunction(
+                value[key],
+                numFilter.exclude,
+                numFilter.range[0],
+                numFilter.range[1],
+                numFilter.none,
+                numFilter.inf,
+                numFilter.ninf,
+                numFilter.nan,
+              );
 
               if (!r) {
                 result = false;


### PR DESCRIPTION
When a range-slider thumb rests on a field bound, the FiftyOne App stores `null` for that end of the range — this is intentional, meaning "unbounded on this side." The previous keypoint confidence filter in `skeletonFilter.ts` compared values directly against that range:

```ts
const includes =
  value[key] >= numFilter.range[0] &&
  value[key] <= numFilter.range[1];
```

In JavaScript, `null` coerces to `0` in numeric comparisons. So a stored filter of `[0.2, null]` (min set to 0.2, max left at its upper bound) became `value <= 0`, dropping every keypoint with a positive confidence value. Dragging only the min thumb while leaving the max at the bound showed no keypoints at all — even ones clearly inside the range.

The fix is to delegate to `helperFunction` from `pathFilters/numeric.ts`, which is already used by every other numeric filter in the sidebar and correctly treats a `null` bound as unbounded on that side. This keeps the keypoint path consistent with the rest of the filtering logic.

The unused `import { initial } from "lodash"` (leftover from an earlier refactor) is removed in the same commit.

**Verification**

Tested by extracting `helperFunction` and the old comparison into a standalone Node script that reproduces the bug and confirms the fix:

```
OLD — value >= range[0] && value <= range[1]:
  ❌  confidence=0.3, range=[0.2,null]  → false (null coerced to 0)
  ❌  confidence=0.5, range=[0.2,null]  → false
  ❌  confidence=0.7, range=[0.2,null]  → false

NEW — helperFunction with null-aware bounds:
  ✅  confidence=0.3, range=[0.2,null]  → true
  ✅  confidence=0.5, range=[0.2,null]  → true
  ✅  confidence=0.7, range=[0.2,null]  → true
  ✅  confidence=0.1, range=[0.2,null]  → false  (below min, correctly hidden)
  ✅  null min-bound (max-only slider): 3/3 correct
  ✅  both bounds null (default state): always visible
  ✅  exclude mode with null bound: 2/2 correct

10 passed, 0 failed (with fix)
```

The `helperFunction` itself is covered by `pathFilters/numeric.test.ts` in the existing test suite.

Fixes #8152
