### PR TITLE
Load docs homepage banner dynamically from CDN

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -28,16 +28,24 @@ FiftyOne
 
 .. raw:: html
 
-  <div class="responsive-banner">
-    <a href="https://voxel51.com/whitepapers/state-of-physical-ai-2026?utm_source=docs&utm_medium=referral&utm_campaign=SoVPAI_Launch&utm_content=docs_banner" target="_blank" aria-label="2026 State of Visual and Physical AI">
-      <video class="banner-mobile" autoplay loop muted playsinline aria-hidden="true">
-        <source src="https://cdn.voxel51.com/banner/StateOfVisualPhysicalAI-A_1200x200.webm" type="video/webm">
-      </video>
-      <video class="banner-desktop" autoplay loop muted playsinline aria-hidden="true">
-        <source src="https://cdn.voxel51.com/banner/StateOfVisualPhysicalAI-A_2400x400.webm" type="video/webm">
-      </video>
-    </a>
-  </div>
+  <div id="banner" class="responsive-banner" style="display:none"></div>
+  <script src="https://cdn.voxel51.com/banner_config.js"></script>
+  <script>
+    (function(){
+      if(typeof defined_banner_config==="undefined")return;
+      var c=defined_banner_config;
+      if(!c.url||!c.video_mobile||!c.video_desktop||c.url.indexOf("https://")!==0)return;
+      var b=document.getElementById("banner"),a=document.createElement("a");
+      a.href=c.url;a.target="_blank";a.rel="noopener";a.setAttribute("aria-label",c.description);
+      ["banner-mobile","banner-desktop"].forEach(function(cls){
+        var v=document.createElement("video"),s=document.createElement("source");
+        v.className=cls;v.autoplay=v.loop=v.muted=v.playsInline=true;
+        s.src=c["video_"+cls.split("-")[1]];s.type="video/webm";
+        v.appendChild(s);a.appendChild(v);
+      });
+      b.appendChild(a);b.style.display="";
+    })();
+  </script>
 
 .. raw:: html
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -40,6 +40,7 @@ FiftyOne
       ["banner-mobile","banner-desktop"].forEach(function(cls){
         var v=document.createElement("video"),s=document.createElement("source");
         v.className=cls;v.autoplay=v.loop=v.muted=v.playsInline=true;
+        v.setAttribute("muted","");v.setAttribute("aria-hidden","true");
         s.src=c["video_"+cls.split("-")[1]];s.type="video/webm";
         v.appendChild(s);a.appendChild(v);
       });


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Replace hardcoded banner HTML with a dynamic config loaded from CDN
- Banner URL, description, and videos are now controlled via `banner_config.js` on CDN, no code push needed to update.
- Banner gracefully hides if the config script fails to load

## How is this patch tested? If it is not, please explain why.

Built in local

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3893
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced the landing-page banner with configurable content.
  * Added responsive mobile and desktop video banners with autoplay and linking.
  * Banner displays only when valid configuration is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->