### PR TITLE
bump @voxel51/voodo to 0.2.0

### DIFF
--- a/app/.yarnrc.yml
+++ b/app/.yarnrc.yml
@@ -57,7 +57,7 @@ catalog:
   "@vitejs/plugin-react": ^6.0.4
   "@vitest/coverage-v8": ^4.1.10
   "@vitest/ui": ^4.1.10
-  "@voxel51/voodo": ^0.1.0
+  "@voxel51/voodo": ^0.2.0
   babel-plugin-relay: ^14.1.0
   buffer: ^6.0.3
   colormap: ^2.3.2

--- a/app/package.json
+++ b/app/package.json
@@ -84,7 +84,7 @@
     "resolutions": {
         "@types/mapbox-gl": "2.7.21",
         "@types/react": "18.3.12",
-        "@voxel51/voodo": "^0.1.0",
+        "@voxel51/voodo": "^0.2.0",
         "brace-expansion": "^5.0.6",
         "minimatch": "9.0.7",
         "prettier": "~3.8.4",

--- a/app/packages/multimodal/src/extensions/tiles/registry.test.tsx
+++ b/app/packages/multimodal/src/extensions/tiles/registry.test.tsx
@@ -1,4 +1,4 @@
-import { IconName } from "@voxel51/voodo";
+import { JSONIcon } from "@voxel51/voodo";
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -9,7 +9,7 @@ import {
 import type { EpisodeTileExtension } from "./types";
 
 const extension: EpisodeTileExtension = {
-  icon: IconName.JSON,
+  icon: JSONIcon,
   id: "test:events",
   isAvailable: () => true,
   order: 10,

--- a/app/packages/multimodal/src/extensions/tiles/types.ts
+++ b/app/packages/multimodal/src/extensions/tiles/types.ts
@@ -1,4 +1,4 @@
-import type { IconName } from "@voxel51/voodo";
+import type { IconProps } from "@voxel51/voodo";
 import type React from "react";
 
 /** Namespaced identity required for a build-time tile contribution. */
@@ -21,7 +21,7 @@ export interface EpisodeTileProps {
 
 /** One tile kind contributed by code included in the current build. */
 export interface EpisodeTileExtension {
-  readonly icon: IconName;
+  readonly icon: React.ComponentType<IconProps>;
   readonly id: EpisodeTileExtensionId;
   readonly isAvailable: (facts: EpisodeTileAvailability) => boolean;
   readonly order: number;

--- a/app/packages/multimodal/src/views/episode/settings/modal/SettingsSidebar.test.tsx
+++ b/app/packages/multimodal/src/views/episode/settings/modal/SettingsSidebar.test.tsx
@@ -1,3 +1,4 @@
+import { GridViewIcon } from "@voxel51/voodo";
 import {
   act,
   cleanup,
@@ -119,19 +120,19 @@ const TileRegistryFixture: React.FC = () => {
   React.useEffect(() => {
     const cleanups = [
       registerTile({
-        icon: null,
+        icon: GridViewIcon,
         Tile: () => null,
         type: TILE_TYPE.IMAGE,
         typeLabel: "Image",
       }),
       registerTile({
-        icon: null,
+        icon: GridViewIcon,
         Tile: () => null,
         type: TILE_TYPE.MAP,
         typeLabel: "Map",
       }),
       registerTile({
-        icon: null,
+        icon: GridViewIcon,
         Tile: () => null,
         type: TILE_TYPE.RAW,
         typeLabel: "Message",

--- a/app/packages/multimodal/src/views/episode/shell/AddTileMenu.test.tsx
+++ b/app/packages/multimodal/src/views/episode/shell/AddTileMenu.test.tsx
@@ -1,6 +1,6 @@
 import { TilingProvider, useTiling } from "@fiftyone/tiling";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { Button, Dropdown, IconName } from "@voxel51/voodo";
+import { Button, Dropdown, JSONIcon } from "@voxel51/voodo";
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -181,7 +181,7 @@ describe("tileTypesFor", () => {
 
   it("orders and filters build-time tile contributions with the built-ins", () => {
     registerEpisodeTileExtension({
-      icon: IconName.JSON,
+      icon: JSONIcon,
       id: "test:events",
       isAvailable: ({ sourceTypes }) => sourceTypes.includes("event"),
       order: 45,

--- a/app/packages/multimodal/src/views/episode/shell/AddTileMenu.tsx
+++ b/app/packages/multimodal/src/views/episode/shell/AddTileMenu.tsx
@@ -24,7 +24,7 @@ const AddTileMenu: React.FC<{
           <MenuIconTextItem
             key={type}
             data-testid={`episode-add-tile-${type === TILE_TYPE.RAW ? "message" : type}`}
-            icon={definition.icon}
+            icon={<definition.icon />}
             text={definition.typeLabel}
             onClick={() => {
               addTile(

--- a/app/packages/multimodal/src/views/episode/shell/tile-catalog.ts
+++ b/app/packages/multimodal/src/views/episode/shell/tile-catalog.ts
@@ -6,6 +6,7 @@ import {
   JSONIcon,
   LogsIcon,
   PolylineIcon,
+  VolumeUpIcon,
   WorkspacesIcon,
 } from "@voxel51/voodo";
 import {
@@ -50,7 +51,7 @@ const THREE_D_SOURCE_TYPES = new Set<string>([
 /** Built-in tile catalog in explicit product order. */
 const BUILT_IN_TILE_BY_TYPE: Record<BuiltInTileType, TileDefinition> = {
   [TILE_TYPE.AUDIO]: {
-    icon: IconName.VolumeUp,
+    icon: VolumeUpIcon,
     isAvailable: ({ sourceTypes }) =>
       sourceTypes.includes(SCENE_SOURCE_TYPE.AUDIO),
     order: 15,

--- a/app/packages/multimodal/src/views/episode/shell/tile-catalog.ts
+++ b/app/packages/multimodal/src/views/episode/shell/tile-catalog.ts
@@ -1,4 +1,13 @@
-import { IconName } from "@voxel51/voodo";
+import {
+  EmbeddingsIcon,
+  GridViewIcon,
+  type IconProps,
+  InsightsIcon,
+  JSONIcon,
+  LogsIcon,
+  PolylineIcon,
+  WorkspacesIcon,
+} from "@voxel51/voodo";
 import {
   getEpisodeTileExtension,
   getEpisodeTileExtensions,
@@ -24,7 +33,7 @@ export type { EpisodeTileProps, TileType } from "../tiles/tile-types";
 export type { EpisodeTileAvailability } from "../../../extensions/tiles/types";
 
 interface TileDefinition {
-  readonly icon: IconName;
+  readonly icon: React.ComponentType<IconProps>;
   readonly isAvailable: (facts: EpisodeTileAvailability) => boolean;
   readonly order: number;
   readonly Tile: React.ComponentType<EpisodeTileProps>;
@@ -49,7 +58,7 @@ const BUILT_IN_TILE_BY_TYPE: Record<BuiltInTileType, TileDefinition> = {
     typeLabel: "Audio",
   },
   [TILE_TYPE.IMAGE]: {
-    icon: IconName.GridView,
+    icon: GridViewIcon,
     isAvailable: ({ sourceTypes }) =>
       sourceTypes.includes(SCENE_SOURCE_TYPE.IMAGE),
     order: 10,
@@ -57,7 +66,7 @@ const BUILT_IN_TILE_BY_TYPE: Record<BuiltInTileType, TileDefinition> = {
     typeLabel: "Image",
   },
   [TILE_TYPE.LOG]: {
-    icon: IconName.Logs,
+    icon: LogsIcon,
     isAvailable: ({ sourceTypes }) =>
       sourceTypes.includes(SCENE_SOURCE_TYPE.LOG),
     order: 40,
@@ -65,7 +74,7 @@ const BUILT_IN_TILE_BY_TYPE: Record<BuiltInTileType, TileDefinition> = {
     typeLabel: "Logs",
   },
   [TILE_TYPE.MAP]: {
-    icon: IconName.Polyline,
+    icon: PolylineIcon,
     isAvailable: ({ sourceTypes }) =>
       sourceTypes.includes(SCENE_SOURCE_TYPE.LOCATION),
     order: 30,
@@ -73,7 +82,7 @@ const BUILT_IN_TILE_BY_TYPE: Record<BuiltInTileType, TileDefinition> = {
     typeLabel: "Map",
   },
   [TILE_TYPE.THREE_D]: {
-    icon: IconName.Embeddings,
+    icon: EmbeddingsIcon,
     isAvailable: ({ sourceTypes }) =>
       sourceTypes.some((sourceType) => THREE_D_SOURCE_TYPES.has(sourceType)),
     order: 20,
@@ -81,21 +90,21 @@ const BUILT_IN_TILE_BY_TYPE: Record<BuiltInTileType, TileDefinition> = {
     typeLabel: "3D",
   },
   [TILE_TYPE.PLOT]: {
-    icon: IconName.Insights,
+    icon: InsightsIcon,
     isAvailable: ({ hasNumericSeries }) => hasNumericSeries,
     order: 50,
     Tile: PlotTile,
     typeLabel: "Plot",
   },
   [TILE_TYPE.TRANSFORMS]: {
-    icon: IconName.Workspaces,
+    icon: WorkspacesIcon,
     isAvailable: ({ hasTransformTopology }) => hasTransformTopology,
     order: 55,
     Tile: TransformGraphTile,
     typeLabel: "Transforms",
   },
   [TILE_TYPE.RAW]: {
-    icon: IconName.JSON,
+    icon: JSONIcon,
     isAvailable: ({ hasRawRecords }) => hasRawRecords,
     order: 60,
     Tile: RawMessageTile,
@@ -117,7 +126,7 @@ function isBuiltInTileType(type: string): type is BuiltInTileType {
  * a build with more tile kinds).
  */
 export function getTileDefinition(type: string): {
-  icon: IconName;
+  icon: React.ComponentType<IconProps>;
   order: number;
   typeLabel: string;
   Tile: React.ComponentType<EpisodeTileProps>;

--- a/app/packages/multimodal/src/views/episode/tiles/use-open-raw-message-tile.test.tsx
+++ b/app/packages/multimodal/src/views/episode/tiles/use-open-raw-message-tile.test.tsx
@@ -13,7 +13,7 @@ import {
 } from "@testing-library/react";
 import { useAtomValue, useSetAtom } from "jotai";
 import React, { useEffect } from "react";
-import { IconName } from "@voxel51/voodo";
+import { JSONIcon } from "@voxel51/voodo";
 import { afterEach, describe, expect, it } from "vitest";
 import { rawTileStreamAtom, type RawTileStreams } from "./raw-message-binding";
 import { TILE_TYPE } from "./tile-types";
@@ -32,7 +32,7 @@ const Probe: React.FC<{ readonly seedStreams?: RawTileStreams }> = ({
   useEffect(
     () =>
       registerTile({
-        icon: IconName.JSON,
+        icon: JSONIcon,
         Tile: () => null,
         type: TILE_TYPE.RAW,
         typeLabel: "Message",

--- a/app/packages/tiling/src/lib/TilingProvider.test.tsx
+++ b/app/packages/tiling/src/lib/TilingProvider.test.tsx
@@ -1,3 +1,4 @@
+import { GridViewIcon } from "@voxel51/voodo";
 import {
   act,
   cleanup,
@@ -834,7 +835,7 @@ function RegisterCameraKind() {
       registerTile({
         type: "camera",
         typeLabel: "Camera",
-        icon: null,
+        icon: GridViewIcon,
         Tile: KindTile,
       }),
     [registerTile],
@@ -850,7 +851,7 @@ function RegisterLidarKind() {
       registerTile({
         type: "lidar",
         typeLabel: "Lidar",
-        icon: null,
+        icon: GridViewIcon,
         Tile: KindTile,
       }),
     [registerTile],

--- a/app/packages/tiling/src/lib/types.ts
+++ b/app/packages/tiling/src/lib/types.ts
@@ -1,4 +1,4 @@
-import type { IconName } from "@voxel51/voodo";
+import type { IconProps } from "@voxel51/voodo";
 import type { ComponentType, ReactNode } from "react";
 import type { MosaicNode } from "react-mosaic-component";
 
@@ -9,7 +9,8 @@ import type { MosaicNode } from "react-mosaic-component";
 export interface RegisteredTile {
   type: string;
   typeLabel: string;
-  icon: IconName | ReactNode;
+  /** Icon component for the menu entry, e.g. `GridViewIcon`. */
+  icon: ComponentType<IconProps>;
   Tile: ComponentType;
 }
 

--- a/app/packages/tiling/src/lib/use-tile-registry.test.tsx
+++ b/app/packages/tiling/src/lib/use-tile-registry.test.tsx
@@ -1,5 +1,5 @@
 import { act, cleanup, renderHook } from "@testing-library/react";
-import { IconName } from "@voxel51/voodo";
+import { GridViewIcon } from "@voxel51/voodo";
 import { Provider as JotaiProvider, createStore } from "jotai";
 import React from "react";
 import { afterEach, describe, expect, it } from "vitest";
@@ -28,7 +28,7 @@ const makeEntry = (
 ): RegisteredTile => ({
   type,
   typeLabel,
-  icon: IconName.GridView,
+  icon: GridViewIcon,
   Tile: DummyTile,
 });
 

--- a/app/packages/tiling/src/lib/use-tile-state.test.tsx
+++ b/app/packages/tiling/src/lib/use-tile-state.test.tsx
@@ -1,5 +1,5 @@
 import { act, cleanup, renderHook } from "@testing-library/react";
-import { IconName } from "@voxel51/voodo";
+import { GridViewIcon } from "@voxel51/voodo";
 import { Provider as JotaiProvider, createStore } from "jotai";
 import React from "react";
 import { afterEach, describe, expect, it } from "vitest";
@@ -48,7 +48,7 @@ const DummyTile: React.FC = () => null;
 const makeEntry = (type: string): RegisteredTile => ({
   type,
   typeLabel: type.charAt(0).toUpperCase() + type.slice(1),
-  icon: IconName.GridView,
+  icon: GridViewIcon,
   Tile: DummyTile,
 });
 

--- a/app/packages/tiling/src/views/AddTileMenu/DefaultAddTileMenuItems.tsx
+++ b/app/packages/tiling/src/views/AddTileMenu/DefaultAddTileMenuItems.tsx
@@ -21,7 +21,7 @@ export const DefaultAddTileMenuItems: React.FC = () => {
         return (
           <MenuIconTextItem
             key={entry.type}
-            icon={entry.icon}
+            icon={<entry.icon />}
             text={entry.typeLabel}
             onClick={() => {
               addTile(

--- a/app/packages/tiling/src/views/MosaicGrid/MosaicGrid.test.tsx
+++ b/app/packages/tiling/src/views/MosaicGrid/MosaicGrid.test.tsx
@@ -1,3 +1,4 @@
+import { GridViewIcon } from "@voxel51/voodo";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -26,13 +27,13 @@ const RegisterTileKinds: React.FC = () => {
     const cleanupCamera = registerTile({
       type: "cam",
       typeLabel: "Camera",
-      icon: null,
+      icon: GridViewIcon,
       Tile: CameraTile,
     });
     const cleanupLidar = registerTile({
       type: "lidar",
       typeLabel: "Lidar",
-      icon: null,
+      icon: GridViewIcon,
       Tile: LidarTile,
     });
     return () => {

--- a/app/packages/tiling/src/views/MosaicGrid/MosaicGrid.tsx
+++ b/app/packages/tiling/src/views/MosaicGrid/MosaicGrid.tsx
@@ -1,9 +1,13 @@
 import {
+  CloseIcon,
+  ContentCopyIcon,
   ContextMenu,
-  IconName,
+  EditIcon,
+  FullscreenIcon,
   MenuIconTextItem,
   MenuSectionTitle,
   MenuSeparator,
+  RemoveIcon,
 } from "@voxel51/voodo";
 import clsx from "clsx";
 import React, {
@@ -148,7 +152,7 @@ const TileWindow: React.FC<TileWindowProps> = ({
   const contextMenu = (
     <>
       <MenuIconTextItem
-        icon={IconName.Edit}
+        icon={<EditIcon />}
         text="Rename"
         onClick={() => setRenameRequest((current) => current + 1)}
       />
@@ -169,7 +173,7 @@ const TileWindow: React.FC<TileWindowProps> = ({
       )}
       {onDuplicate && (
         <MenuIconTextItem
-          icon={IconName.ContentCopy}
+          icon={<ContentCopyIcon />}
           text="Duplicate"
           onClick={onDuplicate}
         />
@@ -184,7 +188,7 @@ const TileWindow: React.FC<TileWindowProps> = ({
               <MenuIconTextItem
                 key={entry.type}
                 disabled={isCurrent}
-                icon={entry.icon}
+                icon={<entry.icon />}
                 text={entry.typeLabel}
                 onClick={
                   isCurrent ? undefined : () => onChangeType?.(entry.type)
@@ -196,21 +200,21 @@ const TileWindow: React.FC<TileWindowProps> = ({
         </>
       ) : null}
       <MenuIconTextItem
-        icon={isFullscreen ? <FullscreenExitIcon /> : IconName.Fullscreen}
+        icon={isFullscreen ? <FullscreenExitIcon /> : <FullscreenIcon />}
         text={fullscreenLabel}
         onClick={onFullscreen}
       />
       <MenuSeparator />
       {onCloseOthers && (
         <MenuIconTextItem
-          icon={IconName.Remove}
+          icon={<RemoveIcon />}
           text="Close others"
           onClick={onCloseOthers}
         />
       )}
       <MenuIconTextItem
         destructive
-        icon={IconName.Close}
+        icon={<CloseIcon />}
         text="Close"
         onClick={onClose}
       />

--- a/app/packages/tiling/src/views/TilingHeader/TilingHeader.stories.tsx
+++ b/app/packages/tiling/src/views/TilingHeader/TilingHeader.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { IconName } from "@voxel51/voodo";
+import { EmbeddingsIcon, GridViewIcon, LogsIcon } from "@voxel51/voodo";
 import { useEffect, useState } from "react";
 import { TilingProvider } from "../../lib/TilingProvider";
 import { useTileRegistry } from "../../lib/use-tile-registry";
@@ -34,19 +34,19 @@ function RegisterTiles() {
       registerTile({
         type: "camera",
         typeLabel: "Camera",
-        icon: IconName.GridView,
+        icon: GridViewIcon,
         Tile: DummyTile,
       }),
       registerTile({
         type: "lidar",
         typeLabel: "Lidar",
-        icon: IconName.Embeddings,
+        icon: EmbeddingsIcon,
         Tile: DummyTile,
       }),
       registerTile({
         type: "graph",
         typeLabel: "Graph",
-        icon: IconName.Logs,
+        icon: LogsIcon,
         Tile: DummyTile,
       }),
     ];

--- a/app/packages/tiling/src/views/TilingHeader/TilingHeader.test.tsx
+++ b/app/packages/tiling/src/views/TilingHeader/TilingHeader.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { IconName, MenuTextItem } from "@voxel51/voodo";
+import { EmbeddingsIcon, GridViewIcon, MenuTextItem } from "@voxel51/voodo";
 import React, { useEffect } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -136,13 +136,13 @@ describe("TilingHeader", () => {
             {
               type: "camera",
               typeLabel: "Camera",
-              icon: IconName.GridView,
+              icon: GridViewIcon,
               Tile: CameraTile,
             },
             {
               type: "lidar",
               typeLabel: "Lidar",
-              icon: IconName.Embeddings,
+              icon: EmbeddingsIcon,
               Tile: LidarTile,
             },
           ]}
@@ -165,7 +165,7 @@ describe("TilingHeader", () => {
             {
               type: "camera",
               typeLabel: "Camera",
-              icon: IconName.GridView,
+              icon: GridViewIcon,
               Tile: CameraTile,
             },
           ]}
@@ -191,7 +191,7 @@ describe("TilingHeader", () => {
             {
               type: "camera",
               typeLabel: "Camera",
-              icon: IconName.GridView,
+              icon: GridViewIcon,
               Tile: CameraTile,
             },
           ]}

--- a/app/packages/tiling/src/views/TilingHeader/TilingHeader.tsx
+++ b/app/packages/tiling/src/views/TilingHeader/TilingHeader.tsx
@@ -2,13 +2,15 @@ import {
   Button,
   Dropdown,
   DropdownAnchor,
-  IconName,
+  GridViewIcon,
   MenuIconTextItem,
   MenuSeparator,
+  RefreshIcon,
   Size,
   Text,
   TextColor,
   TextVariant,
+  UndoIcon,
   Variant,
 } from "@voxel51/voodo";
 import clsx from "clsx";
@@ -29,8 +31,7 @@ export interface TilingHeaderCaptionContext {
 }
 
 export type TilingHeaderCaption =
-  | ReactNode
-  | ((context: TilingHeaderCaptionContext) => ReactNode);
+  ReactNode | ((context: TilingHeaderCaptionContext) => ReactNode);
 
 export interface TilingHeaderProps {
   fileName: string;
@@ -80,12 +81,12 @@ const TilingHeader: React.FC<TilingHeaderProps> = ({
       {addTileMenu ?? <DefaultAddTileMenuItems />}
       <MenuSeparator />
       <MenuIconTextItem
-        icon={IconName.Refresh}
+        icon={<RefreshIcon />}
         text="Auto Layout"
         onClick={autoLayout}
       />
       <MenuIconTextItem
-        icon={IconName.Undo}
+        icon={<UndoIcon />}
         text="Reset Layout"
         onClick={resetLayout}
       />
@@ -123,7 +124,7 @@ const TilingHeader: React.FC<TilingHeaderProps> = ({
                   variant={Variant.Secondary}
                   size={Size.Xs}
                   data-testid="tiling-header-add-tile"
-                  leadingIcon={IconName.GridView}
+                  leadingIcon={GridViewIcon}
                   aria-label="Layout"
                   title="Layout"
                 >

--- a/app/packages/tiling/src/views/TilingHeader/TilingHeader.tsx
+++ b/app/packages/tiling/src/views/TilingHeader/TilingHeader.tsx
@@ -31,7 +31,8 @@ export interface TilingHeaderCaptionContext {
 }
 
 export type TilingHeaderCaption =
-  ReactNode | ((context: TilingHeaderCaptionContext) => ReactNode);
+  | ReactNode
+  | ((context: TilingHeaderCaptionContext) => ReactNode);
 
 export interface TilingHeaderProps {
   fileName: string;

--- a/app/packages/tiling/src/views/TilingZeroState/TilingZeroState.test.tsx
+++ b/app/packages/tiling/src/views/TilingZeroState/TilingZeroState.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { MenuTextItem } from "@voxel51/voodo";
+import { GridViewIcon, MenuTextItem } from "@voxel51/voodo";
 import React, { useEffect } from "react";
 import { afterEach, describe, expect, it } from "vitest";
 import { TilingProvider, useTiling } from "../../lib/TilingProvider";
@@ -15,7 +15,7 @@ function RegisterCameraKind() {
       registerTile({
         type: "camera",
         typeLabel: "Camera",
-        icon: null,
+        icon: GridViewIcon,
         Tile: CameraTile,
       }),
     [registerTile],

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -7133,9 +7133,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@voxel51/voodo@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "@voxel51/voodo@npm:0.1.0"
+"@voxel51/voodo@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@voxel51/voodo@npm:0.2.0"
   dependencies:
     "@dnd-kit/core": "npm:^6.3.1"
     "@dnd-kit/sortable": "npm:^10.0.0"
@@ -7144,6 +7144,7 @@ __metadata:
     "@headlessui/react": "npm:^2.2.9"
     "@tanstack/react-virtual": "npm:^3.13.24"
     clsx: "npm:^2.1.1"
+    date-fns-tz: "npm:^3.2.0"
     lodash.debounce: "npm:^4.0.8"
     react-datepicker: "npm:^9.1.0"
     tailwind-merge: "npm:^3.4.0"
@@ -7151,7 +7152,7 @@ __metadata:
     react: ^18.0.0
     react-dom: ^18.0.0
     react-is: ^18.0.0
-  checksum: 10/fb6f49778b5ad74527b110bbd5a091c24c22dd795f6b3307ed518cbb72426d83cf9511e7f393e63d6b6827db4060085aec5de14f2af7445ef27e6d5770154bc9
+  checksum: 10/6428e7098a96daee1032677670d0ace6e84e5a051126a7b313954633ee10379e64d1161b5135a9efbdae981c3bd2cacca7e812fc065661f391dd6545bbc5d393
   languageName: node
   linkType: hard
 
@@ -9275,6 +9276,15 @@ __metadata:
     es-errors: "npm:^1.3.0"
     is-data-view: "npm:^1.0.1"
   checksum: 10/96f34f151bf02affb7b9f98762fb7aca1dd5f4553cb57b80bce750ca609c15d33ca659568ef1d422f7e35680736cbccb893a3d4b012760c758c1446bbdc4c6db
+  languageName: node
+  linkType: hard
+
+"date-fns-tz@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "date-fns-tz@npm:3.2.0"
+  peerDependencies:
+    date-fns: ^3.0.0 || ^4.0.0
+  checksum: 10/8ab4745f00b40381220f0a7a2ec16e217cb629d4018a19047264d289dd260322baa23e19b3ed63c7e553f9ad34bea9dea105391132930a3e141e9a0a53e54af2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

Bumps `@voxel51/voodo` from `0.1.0` to `0.2.0`.

Two declarations have to move together:

- `app/.yarnrc.yml` — the catalog entry, which feeds the ten workspaces that declare `"@voxel51/voodo": "catalog:"` (tiling, core, components, app, state, multimodal, playback, video-annotation, embeddings-v2, similarity-search).
- `app/package.json` — the `resolutions` override. This one is decisive: it force-pins every consumer regardless of the catalog, so bumping only the catalog would leave the tree on 0.1.0.

`packages/annotation` declares `"*"` and follows whatever resolves, so it needs no edit.

## Lockfile

`yarn install` resolves `@voxel51/voodo@npm:0.2.0` and adds `date-fns-tz@npm:3.2.0`, a new transitive dependency of voodo 0.2.0.

## Call-site migration (merged from #8331)

The bump alone is not shippable: voodo 0.2.0 replaced the `Icon`/`IconName`
map with per-icon components, and `MenuIconTextItem`'s `icon` prop went from
`IconName | ReactNode` to plain `ReactNode`. `IconName` values are strings and
every string is a valid `ReactNode`, so call sites kept compiling and started
rendering the icon's *name* as text — "Add Tile" showed the word "Workspaces"
in the icon slot.

#8331 is merged in here, so this PR now carries both halves:

- `RegisteredTile.icon` and the episode tile catalog/extension types hold an
  icon component (`ComponentType<IconProps>`) instead of an `IconName`.
- Menu call sites render it: `icon={<entry.icon />}`; direct uses become
  `<EditIcon />`, `<CloseIcon />`, `<VolumeUpIcon />`, etc.

`leadingIcon={IconName.X}` on `Button` is deliberately left alone — `Button`
accepts `IconInput` and renders those correctly, and 0.2.0 still ships
`IconName` as an explicit legacy bridge.

## Verification

The peer-dependency warnings emitted during install (react/xstate,
three/@miris-inc, multimodal/spaces) are pre-existing and unrelated.

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3894
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Standardized icons across tile catalogs, tile menus, layout controls, and context menus for a more consistent interface.
  * Tile registrations now use reusable icon components, improving how icons are displayed throughout the tiling experience.
* **Chores**
  * Updated the Voodo package version used by the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
