### PR TITLE
Fix load_annotations silently losing existing labels

### DIFF
--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -1254,6 +1254,7 @@ def _prompt_field(
     if not new_field:
         return None
 
+    fo_label_type = None
     if label_type != "scalar":
         fo_label_type = _LABEL_TYPES_MAP[label_type]
 
@@ -1478,6 +1479,7 @@ def _merge_labels(
         _label_field = label_field
 
     fo_label_type = _LABEL_TYPES_MAP[label_type]
+    list_field = None
     if issubclass(fo_label_type, fol._HasLabelList):
         is_list = True
         list_field = fo_label_type._LABEL_LIST_FIELD
@@ -1664,6 +1666,7 @@ def _merge_labels(
                     labels = [image_label]
 
                 # Merge labels that existed before and after annotation
+                merged_keys = set()
                 for label in labels:
                     label_id = label.id
                     if is_clips_view:
@@ -1688,8 +1691,10 @@ def _merge_labels(
                             allow_spatial_edits=allow_spatial_edits,
                             only_keyframes=only_keyframes,
                         )
+                        merged_keys.add(key)
 
-                # Add new labels to label list fields
+                # Add new labels to label list fields, plus any merge IDs
+                # that never matched a physically present label
                 if is_list and allow_additions:
                     for label_id, anno_label in image_annos.items():
                         if is_clips_view:
@@ -1701,7 +1706,10 @@ def _merge_labels(
                         else:
                             key = (sample_id, label_id)
 
-                        if key not in new_ids:
+                        is_stale_merge_id = (
+                            key in merge_ids and key not in merged_keys
+                        )
+                        if key not in new_ids and not is_stale_merge_id:
                             continue
 
                         labels.append(anno_label)

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -6212,6 +6212,9 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
 
             return
 
+        if label.id in results:
+            label.id = str(ObjectId())
+
         results[label.id] = label
 
     def _parse_arg(self, arg, config_arg):

--- a/tests/unittests/utils/test_cvat_duplicate_shapes.py
+++ b/tests/unittests/utils/test_cvat_duplicate_shapes.py
@@ -1,0 +1,40 @@
+"""
+Tests for `fiftyone.utils.cvat.CVATAnnotationAPI._add_label_to_results()`.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import unittest
+
+from bson import ObjectId
+
+import fiftyone.core.labels as fol
+import fiftyone.utils.cvat as fouc
+
+
+class DuplicateLabelIdTests(unittest.TestCase):
+    def test_duplicate_label_id_is_regenerated(self):
+        shared_id = str(ObjectId())
+        det1 = fol.Detection(label="car", bounding_box=[0, 0, 0.1, 0.1])
+        det1.id = shared_id
+        det2 = fol.Detection(label="car", bounding_box=[0.2, 0.2, 0.1, 0.1])
+        det2.id = shared_id
+
+        results = {}
+        fouc.CVATAnnotationAPI._add_label_to_results(
+            None, results, "detections", det1
+        )
+        fouc.CVATAnnotationAPI._add_label_to_results(
+            None, results, "detections", det2
+        )
+
+        self.assertEqual(len(results), 2)
+        ids = set(results.keys())
+        self.assertTrue(all(ObjectId.is_valid(_id) for _id in ids))
+        self.assertEqual(len(ids), 2)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## 🔗 Related Issues

No related issues. Reported by Joy on Discord.

## 📋 What changes are proposed in this pull request?

Fixes two annotation import bugs:

1. `load_annotations()` could fail to restore labels that were deleted outside the annotation workflow because stale `id_map` entries marked them as existing. Unmatched labels are now added back.

2. CVAT shapes with the same `label_id`, commonly caused by copy/paste, could overwrite each other during parsing. Duplicate IDs are now regenerated before the labels are merged.

These fixes apply to the shared annotation merge path used by all annotation backends. The PR also silences two pre-existing pylint false positives by initializing `fo_label_type` and `list_field` to `None`.

## 🧪 How is this patch tested? If it is not, please explain why.

Manually verified with live round-trip tests against `app.cvat.ai`:

* Deleted a synced label locally and confirmed the next sync restores it.
* Copied a CVAT shape with the same `label_id` and confirmed both shapes are imported with unique IDs.

The fixes were tested on and off against the same CVAT tasks. No automated tests are included.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

* [x] No. You can skip the rest of this section.
* [ ] Yes. Give a description of this change to be included in the release notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

* [ ] App: FiftyOne application changes
* [ ] Build: Build and test infrastructure changes
* [x] Core: Core `fiftyone` Python library changes
* [ ] Documentation: FiftyOne documentation changes
* [ ] Other



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved annotation loading for list-based label fields, preventing stale or unmatched labels from being reintroduced.
  * Prevented identifier collisions when importing non-segmentation labels, ensuring imported results remain distinct and reliable.
  * Improved consistency and stability across annotation workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3897
<!-- enterprise-sync-pr:end -->