### PR TITLE
Fix the delete re-save loop: fold persisted deltas into the sample source

### DIFF
--- a/app/packages/annotation/src/engine/core/engine.ts
+++ b/app/packages/annotation/src/engine/core/engine.ts
@@ -11,7 +11,7 @@ import type {
   LabelStore,
   StoreSnapshot,
 } from "../store/types";
-import { wholeSampleReset } from "../store/types";
+import { ReconcileOpts, wholeSampleReset } from "../store/types";
 import { registerBridgeLoop } from "../bridge/bridgeLoop";
 import type { AdapterMap, SurfaceBridge } from "../bridge/types";
 import type { EntityId } from "../identity/entityId";
@@ -533,9 +533,12 @@ export class AnnotationEngine {
     }
   }
 
-  reconcilePersisted(results: { sample: string; deltas: JSONDeltas }[]): void {
+  reconcilePersisted(
+    results: { sample: string; deltas: JSONDeltas }[],
+    opts?: ReconcileOpts,
+  ): void {
     for (const { sample, deltas } of results) {
-      this.stores.get(sample)?.reconcilePersisted(deltas);
+      this.stores.get(sample)?.reconcilePersisted(deltas, opts);
     }
   }
 

--- a/app/packages/annotation/src/engine/store/frameStore.ts
+++ b/app/packages/annotation/src/engine/store/frameStore.ts
@@ -40,6 +40,7 @@ import { toSchemaField } from "../identity/framePath";
 import { addressIdOf, indexFromAddressId } from "../identity/ref";
 import type { LabelRef } from "../identity/ref";
 import type {
+  ReconcileOpts,
   ChangeListener,
   DisplayListener,
   LabelChange,
@@ -314,7 +315,7 @@ export class FrameStore implements LabelStore {
    * version bookkeeping stays fresh — this mirrors the sample store's
    * change-only-what-changed reconcile.
    */
-  reconcilePersisted(deltas: JSONDeltas): void {
+  reconcilePersisted(deltas: JSONDeltas, _opts?: ReconcileOpts): void {
     const byFrame = new Map<number, JSONDeltas>();
 
     for (const op of deltas) {

--- a/app/packages/annotation/src/engine/store/sampleLabelStore.ts
+++ b/app/packages/annotation/src/engine/store/sampleLabelStore.ts
@@ -33,7 +33,7 @@ import type {
   LabelStore,
   StoreSnapshot,
 } from "./types";
-import { wholeSampleReset } from "./types";
+import { ReconcileOpts, wholeSampleReset } from "./types";
 
 const CHANGE_KIND: Record<SampleChangeKind, LabelChangeKind> = {
   [SampleChangeKind.Update]: "update",
@@ -203,8 +203,8 @@ export class SampleLabelStore implements LabelStore {
     this.source.captureBaseline();
   }
 
-  reconcilePersisted(deltas: JSONDeltas): void {
-    this.source.reconcilePersisted(deltas);
+  reconcilePersisted(deltas: JSONDeltas, opts?: ReconcileOpts): void {
+    this.source.reconcilePersisted(deltas, opts);
   }
 
   // ---- lifecycle ----

--- a/app/packages/annotation/src/engine/store/types.ts
+++ b/app/packages/annotation/src/engine/store/types.ts
@@ -6,6 +6,17 @@
 
 import type { JSONDeltas, LabelData, LabelType } from "@fiftyone/utilities";
 
+/**
+ * Options threaded from the persist caller down to each store's
+ * reconcile. `sampleRooted` declares that the deltas use sample-rooted
+ * pointers (false for generated/patches views, whose deltas are rooted at
+ * the persisted LABEL) — stores must not rebase their source from
+ * label-rooted paths.
+ */
+export interface ReconcileOpts {
+  sampleRooted?: boolean;
+}
+
 import type { LabelRef } from "../identity/ref";
 
 export type LabelChangeKind = "update" | "delete" | "reset";
@@ -102,7 +113,7 @@ export interface LabelStore {
   // snapshot the pre-persist transient; the trigger calls this before the patch
   // is sent so reconcilePersisted can keep fields edited while it was in flight
   captureBaseline(): void;
-  reconcilePersisted(deltas: JSONDeltas): void;
+  reconcilePersisted(deltas: JSONDeltas, opts?: ReconcileOpts): void;
 
   // lifecycle
   setData(data: Record<string, unknown>): void;

--- a/app/packages/annotation/src/engine/store/videoLabelStore.test.ts
+++ b/app/packages/annotation/src/engine/store/videoLabelStore.test.ts
@@ -228,9 +228,10 @@ describe("VideoLabelStore persistence", () => {
       { op: "add", path: "/events", value: [] },
     ]);
 
-    expect(reconcileSpy).toHaveBeenCalledWith([
-      { op: "add", path: "/frames/1/detections/detections/-", value: {} },
-    ]);
+    expect(reconcileSpy).toHaveBeenCalledWith(
+      [{ op: "add", path: "/frames/1/detections/detections/-", value: {} }],
+      undefined,
+    );
     expect(sampleLevel.reconciled).toEqual([
       { op: "add", path: "/events", value: [] },
     ]);

--- a/app/packages/annotation/src/engine/store/videoLabelStore.ts
+++ b/app/packages/annotation/src/engine/store/videoLabelStore.ts
@@ -32,6 +32,7 @@ import type {
   ChangeListener,
   DisplayListener,
   LabelStore,
+  ReconcileOpts,
   StoreSnapshot,
 } from "./types";
 
@@ -162,7 +163,7 @@ export class VideoLabelStore implements LabelStore {
     this.sampleLevel.captureBaseline();
   }
 
-  reconcilePersisted(deltas: JSONDeltas): void {
+  reconcilePersisted(deltas: JSONDeltas, opts?: ReconcileOpts): void {
     const frameDeltas: JSONDeltas = [];
     const sampleDeltas: JSONDeltas = [];
 
@@ -170,8 +171,8 @@ export class VideoLabelStore implements LabelStore {
       (op.path.startsWith("/frames/") ? frameDeltas : sampleDeltas).push(op);
     }
 
-    this.frames.reconcilePersisted(frameDeltas);
-    this.sampleLevel.reconcilePersisted(sampleDeltas);
+    this.frames.reconcilePersisted(frameDeltas, opts);
+    this.sampleLevel.reconcilePersisted(sampleDeltas, opts);
   }
 
   // ---- lifecycle ----

--- a/app/packages/annotation/src/persistence/usePersistAnnotationDeltas.ts
+++ b/app/packages/annotation/src/persistence/usePersistAnnotationDeltas.ts
@@ -99,7 +99,11 @@ export const usePersistAnnotationDeltas =
         });
 
         if (success && modalId) {
-          engine.reconcilePersisted([{ sample: modalId, deltas }]);
+          // Generated (patches) deltas are LABEL-rooted — the sample
+          // source must not be rebased from them.
+          engine.reconcilePersisted([{ sample: modalId, deltas }], {
+            sampleRooted: false,
+          });
         }
 
         return success;

--- a/app/packages/utilities/src/sample/sample.test.ts
+++ b/app/packages/utilities/src/sample/sample.test.ts
@@ -1305,6 +1305,37 @@ describe("reconcilePersisted source fold (delete re-save loop)", () => {
     expect(JSON.stringify(next)).toContain("c2");
   });
 
+  it("skips the fold when setData replaced source mid-flight", () => {
+    // CodeRabbit case: a fresh fetch landing during the in-flight persist
+    // is strictly better truth than the fold's reconstruction — folding a
+    // stale baseline over it could mask a concurrent writer's newer value.
+    const s = new Sample({
+      schema,
+      data: {
+        classification: { _id: "c1", _cls: "Classification", label: "x" },
+      },
+    });
+
+    s.deleteLabel("classification");
+    s.captureBaseline();
+    const patch = s.getJsonPatch();
+    expect(patch).toEqual([{ op: "remove", path: "/classification" }]);
+
+    // Fresh fetch mid-flight: a concurrent writer set a NEW value.
+    s.setData({
+      classification: { _id: "c9", _cls: "Classification", label: "theirs" },
+    });
+
+    s.reconcilePersisted(patch);
+
+    // The fold must NOT have dropped the freshly fetched value: with the
+    // local tombstone still standing against a source that has the field,
+    // the delete keeps diffing (it will re-persist against fresh truth).
+    expect(s.getJsonPatch()).toEqual([
+      { op: "remove", path: "/classification" },
+    ]);
+  });
+
   it("stops re-emitting a persisted NESTED-path delete", () => {
     // CodeRabbit regression case: transient keys are dot-paths of
     // varying depth — a primitive edit deletes "classification.label",

--- a/app/packages/utilities/src/sample/sample.test.ts
+++ b/app/packages/utilities/src/sample/sample.test.ts
@@ -1243,3 +1243,161 @@ describe("Sample — TemporalDetections", () => {
     );
   });
 });
+
+describe("reconcilePersisted source fold (delete re-save loop)", () => {
+  const schema: Schema = {
+    classification: field("fiftyone.core.labels.Classification"),
+    classifications: field("fiftyone.core.labels.Classifications"),
+  };
+
+  const persistOnce = (s: Sample) => {
+    s.captureBaseline();
+    const patch = s.getJsonPatch();
+    s.reconcilePersisted(patch);
+    return patch;
+  };
+
+  it("stops re-emitting a persisted single-label delete", () => {
+    const s = new Sample({
+      schema,
+      data: {
+        classification: { _id: "c1", _cls: "Classification", label: "x" },
+      },
+    });
+
+    s.deleteLabel("classification");
+    const patch = persistOnce(s);
+    expect(patch).toEqual([{ op: "remove", path: "/classification" }]);
+
+    // The loop: before the fold, this diff re-emitted the same remove
+    // forever (the source still held the label).
+    expect(s.getJsonPatch()).toEqual([]);
+  });
+
+  it("folds an acknowledged delete even when the field was re-added in flight", () => {
+    // CodeRabbit regression case (delete -> persist -> re-add -> reconcile):
+    // the re-add clears the LIVE tombstone before the reconcile runs, but
+    // the server applied the remove — folding from the persist-time
+    // tombstones commits it to source, so the re-add diffs as a fresh add
+    // instead of silently matching the stale source value (data loss).
+    const s = new Sample({
+      schema,
+      data: {
+        classification: { _id: "c1", _cls: "Classification", label: "x" },
+      },
+    });
+
+    s.deleteLabel("classification");
+    s.captureBaseline();
+    const patch = s.getJsonPatch();
+    expect(patch).toEqual([{ op: "remove", path: "/classification" }]);
+
+    // Re-add the SAME value while the persist request is "in flight".
+    const readded = { _id: "c2", _cls: "Classification", label: "x" };
+    s.setField("classification", readded);
+
+    s.reconcilePersisted(patch);
+
+    // The acknowledged remove reached source...
+    const next = s.getJsonPatch();
+    // ...so the re-add must still persist (an add op), never diff away.
+    expect(next.length).toBeGreaterThan(0);
+    expect(JSON.stringify(next)).toContain("c2");
+  });
+
+  it("stops re-emitting a persisted NESTED-path delete", () => {
+    // CodeRabbit regression case: transient keys are dot-paths of
+    // varying depth — a primitive edit deletes "classification.label",
+    // not "classification". The fold must match the tombstone at its
+    // full path or the nested remove re-emits forever.
+    const s = new Sample({
+      schema,
+      data: {
+        classification: { _id: "c1", _cls: "Classification", label: "x" },
+      },
+    });
+
+    s.deleteField("classification.label");
+    const patch = persistOnce(s);
+    expect(patch).toEqual([{ op: "remove", path: "/classification/label" }]);
+
+    expect(s.getJsonPatch()).toEqual([]);
+  });
+
+  it("stops re-emitting a persisted list-label element delete", () => {
+    const s = new Sample({
+      schema,
+      data: {
+        classifications: {
+          _cls: "Classifications",
+          classifications: [
+            { _id: "a", _cls: "Classification", label: "keep" },
+            { _id: "b", _cls: "Classification", label: "drop" },
+          ],
+        },
+      },
+    });
+
+    s.deleteLabel("classifications", "b");
+    const patch = persistOnce(s);
+    expect(patch.length).toBeGreaterThan(0);
+
+    expect(s.getJsonPatch()).toEqual([]);
+  });
+
+  it("keeps an in-flight re-edit diffing after the fold", () => {
+    const s = new Sample({
+      schema,
+      data: {
+        classification: { _id: "c1", _cls: "Classification", label: "x" },
+      },
+    });
+
+    // patch built for label "y"…
+    s.setField("classification", {
+      _id: "c1",
+      _cls: "Classification",
+      label: "y",
+    });
+    s.captureBaseline();
+    const patch = s.getJsonPatch();
+    expect(patch.length).toBeGreaterThan(0);
+
+    // …user edits again while the request is in flight
+    s.setField("classification", {
+      _id: "c1",
+      _cls: "Classification",
+      label: "z",
+    });
+    s.reconcilePersisted(patch);
+
+    // the newer edit must still persist on the next pass
+    const next = s.getJsonPatch();
+    expect(JSON.stringify(next)).toContain("z");
+  });
+
+  it("re-emits a delete tombstoned while the patch was in flight", () => {
+    const s = new Sample({
+      schema,
+      data: {
+        classification: { _id: "c1", _cls: "Classification", label: "x" },
+      },
+    });
+
+    s.setField("classification", {
+      _id: "c1",
+      _cls: "Classification",
+      label: "y",
+    });
+    s.captureBaseline();
+    const patch = s.getJsonPatch();
+
+    // deleted mid-flight: the value write persisted, the delete is newer
+    s.deleteLabel("classification");
+    s.reconcilePersisted(patch);
+
+    expect(s.getJsonPatch()).toEqual([
+      { op: "remove", path: "/classification" },
+    ]);
+  });
+});

--- a/app/packages/utilities/src/sample/sample.test.ts
+++ b/app/packages/utilities/src/sample/sample.test.ts
@@ -1407,6 +1407,33 @@ describe("reconcilePersisted source fold (delete re-save loop)", () => {
     ]);
   });
 
+  it("folds a list append whose list field was absent from source", () => {
+    // CodeRabbit case: /field/<child>/- with the parent missing must
+    // create an ARRAY parent — an object parent would store the "-" as a
+    // literal key and corrupt source.
+    // field present, inner list ABSENT — the discriminating shape: the
+    // diff emits an append op whose array parent must be created
+    const s = new Sample({
+      schema,
+      data: { classifications: { _cls: "Classifications" } },
+    });
+
+    s.updateLabel("classifications", {
+      _id: "a",
+      _cls: "Classification",
+      label: "x",
+    });
+    s.captureBaseline();
+    const patch = s.getJsonPatch();
+    expect(patch.length).toBeGreaterThan(0);
+    s.reconcilePersisted(patch);
+
+    const folded = s.getData().classifications as Record<string, unknown>;
+    expect(Array.isArray(folded?.classifications)).toBe(true);
+    expect((folded.classifications as unknown[]).length).toBe(1);
+    expect(s.getJsonPatch()).toEqual([]);
+  });
+
   it("stops re-emitting a persisted NESTED-path delete", () => {
     // CodeRabbit regression case: transient keys are dot-paths of
     // varying depth — a primitive edit deletes "classification.label",

--- a/app/packages/utilities/src/sample/sample.test.ts
+++ b/app/packages/utilities/src/sample/sample.test.ts
@@ -1298,11 +1298,18 @@ describe("reconcilePersisted source fold (delete re-save loop)", () => {
 
     s.reconcilePersisted(patch);
 
-    // The acknowledged remove reached source...
+    // The acknowledged remove reached source (server-faithful rebase) —
+    // this line alone discriminates the rebase: without it, source still
+    // holds c1.
+    expect(s.getData().classification).toBeUndefined();
+    // ...so the re-add must persist as fresh ADD ops (the diff may emit
+    // the structural granular form), never diff away and never degrade
+    // to replaces against the stale c1 value.
     const next = s.getJsonPatch();
-    // ...so the re-add must still persist (an add op), never diff away.
     expect(next.length).toBeGreaterThan(0);
+    expect(next.every((op) => op.op === "add")).toBe(true);
     expect(JSON.stringify(next)).toContain("c2");
+    expect(JSON.stringify(next)).not.toContain("c1");
   });
 
   it("skips the fold when setData replaced source mid-flight", () => {
@@ -1333,6 +1340,70 @@ describe("reconcilePersisted source fold (delete re-save loop)", () => {
     // the delete keeps diffing (it will re-persist against fresh truth).
     expect(s.getJsonPatch()).toEqual([
       { op: "remove", path: "/classification" },
+    ]);
+  });
+
+  it("mixed delete+edit on one field never resurrects the deleted sub-path", () => {
+    // Review case: [remove /classification/label, replace /classification/conf]
+    // in one patch — the rebase must apply the ops in order, not rewrite
+    // the whole field from a baseline that still contains the label.
+    const s = new Sample({
+      schema,
+      data: {
+        classification: {
+          _id: "c1",
+          _cls: "Classification",
+          label: "x",
+          conf: 1,
+        },
+      },
+    });
+
+    s.deleteField("classification.label");
+    s.setField("classification.conf", 2);
+    s.captureBaseline();
+    const patch = s.getJsonPatch();
+    s.reconcilePersisted(patch);
+
+    const source = s.getData().classification as Record<string, unknown>;
+    expect(source.label).toBeUndefined();
+    expect(source.conf).toBe(2);
+    expect(s.getJsonPatch()).toEqual([]);
+  });
+
+  it("folds an acknowledged nested add whose parent was absent from source", () => {
+    // Review case: withValueAtPath-style folds no-op on a missing
+    // intermediate; the rebase must create object parents like the server.
+    const s = new Sample({ schema, data: {} });
+
+    s.setField("classification.label", "y");
+    s.captureBaseline();
+    const patch = s.getJsonPatch();
+    expect(patch.length).toBeGreaterThan(0);
+    s.reconcilePersisted(patch);
+
+    expect(s.getJsonPatch()).toEqual([]);
+  });
+
+  it("does not rebase from label-rooted (generated) deltas", () => {
+    // Review case: patches views persist LABEL-rooted deltas ("/label" is
+    // the label's own attribute) — rebasing them as sample paths would
+    // clobber a same-named top-level field.
+    const s = new Sample({
+      schema,
+      data: { label: "server-value" },
+    });
+
+    s.setField("label", "pending-edit");
+    s.captureBaseline();
+    s.reconcilePersisted([{ op: "replace", path: "/label", value: "attr" }], {
+      sampleRooted: false,
+    });
+
+    // The pending edit on the top-level field must still diff.
+    expect(s.getData().label).toBe("server-value");
+    expect(s.getJsonPatch()).toEqual([
+      { op: "replace", path: "/label", value: "pending-edit" },
     ]);
   });
 

--- a/app/packages/utilities/src/sample/sample.ts
+++ b/app/packages/utilities/src/sample/sample.ts
@@ -647,13 +647,16 @@ export class Sample {
     // and the next diff resolves against it naturally. Purely
     // source-side: the display projects the transient, so no
     // notification is due.
+    // Compute the release's change set from the PRE-rebase references,
+    // but rebase source BEFORE applying + notifying: a released path's
+    // Reset makes subscribers re-read from source, and they must see the
+    // post-persist value, not the stale pre-rebase one (with no later
+    // event ever correcting it).
+    let changes: SampleChange[] | null = null;
     if (result) {
-      // A released/dropped path has a new (or absent) reference vs.
-      // before; emit a per-path reset so reconcilers re-read just those
-      // from source.
       const before = this.transientData;
       const after = result.transientData;
-      const changes: SampleChange[] = [];
+      changes = [];
       for (const path of new Set([
         ...Object.keys(before),
         ...Object.keys(after),
@@ -662,16 +665,24 @@ export class Sample {
           changes.push({ path, kind: SampleChangeKind.Reset });
         }
       }
-
-      this.transientData = after;
-      this.notify(changes);
     }
 
     const sourceReplaced =
       this.sourceRevision !== this.patchBaselineSourceRevision;
     if (sampleRooted && !sourceReplaced && baseline) {
       this.sourceData = rebaseSource(this.sourceData, deltas);
+    }
+
+    if (result) {
+      this.transientData = result.transientData;
+    }
+    if (sampleRooted && !sourceReplaced && baseline) {
+      // after both the rebase and the release apply, so the sweep sees
+      // the final transient against the final source
       this.gc();
+    }
+    if (changes) {
+      this.notify(changes);
     }
   }
 

--- a/app/packages/utilities/src/sample/sample.ts
+++ b/app/packages/utilities/src/sample/sample.ts
@@ -16,6 +16,7 @@ import {
 } from "./labels";
 import { getNestedField } from "./pointer";
 import { reconcilePersisted } from "./reconcile";
+import { foldPersistedIntoSource } from "./sourceFold";
 
 /**
  * The nature of a {@link SampleChange}: `Update`/`Delete` for in-session edits;
@@ -145,6 +146,7 @@ export class Sample {
    * without it.
    */
   private patchBaseline: Record<string, unknown> | null = null;
+  private patchBaselineDeletes: Set<string> | null = null;
 
   constructor(opts: SampleOptions = {}) {
     if (opts.data) {
@@ -582,6 +584,10 @@ export class Sample {
    */
   captureBaseline(): void {
     this.patchBaseline = { ...this.transientData };
+    // Tombstones as of patch-build time: a re-add during the in-flight
+    // request clears the live tombstone, but the persisted patch still
+    // carries the remove — reconcile must fold from THIS set.
+    this.patchBaselineDeletes = new Set(this.transientDeletes);
   }
 
   /**
@@ -603,6 +609,30 @@ export class Sample {
     // consume the baseline; null it so a stray second reconcile fails safe
     const baseline = this.patchBaseline;
     this.patchBaseline = null;
+    const baselineDeletes = this.patchBaselineDeletes;
+    this.patchBaselineDeletes = null;
+
+    // Fold the persisted fields into source FIRST — deletes otherwise
+    // re-diff against the stale source forever, re-PATCHing the same
+    // remove on every autosave tick and never settling (see
+    // foldPersistedIntoSource). Purely source-side: the display already
+    // projects the transient state, so no change notification is due.
+    const folded = foldPersistedIntoSource(
+      this.sourceData,
+      baselineDeletes,
+      baseline,
+      deltas,
+    );
+    if (folded) {
+      this.sourceData = folded.sourceData;
+      // Release only tombstones the persisted patch actually satisfied
+      // AND that still stand — a tombstone recreated by a post-persist
+      // delete of the re-added value must keep diffing.
+      for (const path of folded.releasedTombstones) {
+        this.transientDeletes.delete(path);
+      }
+    }
+
     const result = reconcilePersisted(
       this.snapshot(),
       deltas,

--- a/app/packages/utilities/src/sample/sample.ts
+++ b/app/packages/utilities/src/sample/sample.ts
@@ -147,6 +147,9 @@ export class Sample {
    */
   private patchBaseline: Record<string, unknown> | null = null;
   private patchBaselineDeletes: Set<string> | null = null;
+  /** Bumped on every wholesale source replacement; see reconcilePersisted. */
+  private sourceRevision = 0;
+  private patchBaselineSourceRevision = 0;
 
   constructor(opts: SampleOptions = {}) {
     if (opts.data) {
@@ -249,6 +252,7 @@ export class Sample {
 
   setData(data: Record<string, unknown>): void {
     this.assertNotDispatching("setData");
+    this.sourceRevision += 1;
     this.sourceData = data;
     this.gc();
     this.notify([{ path: "", kind: SampleChangeKind.Reset }]);
@@ -588,6 +592,7 @@ export class Sample {
     // request clears the live tombstone, but the persisted patch still
     // carries the remove — reconcile must fold from THIS set.
     this.patchBaselineDeletes = new Set(this.transientDeletes);
+    this.patchBaselineSourceRevision = this.sourceRevision;
   }
 
   /**
@@ -617,12 +622,22 @@ export class Sample {
     // remove on every autosave tick and never settling (see
     // foldPersistedIntoSource). Purely source-side: the display already
     // projects the transient state, so no change notification is due.
-    const folded = foldPersistedIntoSource(
-      this.sourceData,
-      baselineDeletes,
-      baseline,
-      deltas,
-    );
+    // A setData() during the in-flight request replaced source with a
+    // FRESH server fetch — strictly better truth than the fold's
+    // reconstruction (the fold exists only because no echo arrives).
+    // Folding a stale baseline over it could mask a concurrent writer's
+    // newer values, so skip; the next diff resolves against the fresh
+    // source naturally.
+    const sourceReplaced =
+      this.sourceRevision !== this.patchBaselineSourceRevision;
+    const folded = sourceReplaced
+      ? null
+      : foldPersistedIntoSource(
+          this.sourceData,
+          baselineDeletes,
+          baseline,
+          deltas,
+        );
     if (folded) {
       this.sourceData = folded.sourceData;
       // Release only tombstones the persisted patch actually satisfied

--- a/app/packages/utilities/src/sample/sample.ts
+++ b/app/packages/utilities/src/sample/sample.ts
@@ -16,7 +16,7 @@ import {
 } from "./labels";
 import { getNestedField } from "./pointer";
 import { reconcilePersisted } from "./reconcile";
-import { foldPersistedIntoSource } from "./sourceFold";
+import { rebaseSource } from "./sourceFold";
 
 /**
  * The nature of a {@link SampleChange}: `Update`/`Delete` for in-session edits;
@@ -146,7 +146,6 @@ export class Sample {
    * without it.
    */
   private patchBaseline: Record<string, unknown> | null = null;
-  private patchBaselineDeletes: Set<string> | null = null;
   /** Bumped on every wholesale source replacement; see reconcilePersisted. */
   private sourceRevision = 0;
   private patchBaselineSourceRevision = 0;
@@ -565,8 +564,10 @@ export class Sample {
     this.assertNotDispatching("clear");
     this.transientData = {};
     this.transientDeletes.clear();
-    // a reset invalidates any captured baseline
+    // a reset invalidates any captured baseline (revision stamp included,
+    // so a stale stamp can never validate a future capture)
     this.patchBaseline = null;
+    this.patchBaselineSourceRevision = this.sourceRevision;
     this.notify([{ path: "", kind: SampleChangeKind.Reset }]);
   }
 
@@ -588,10 +589,6 @@ export class Sample {
    */
   captureBaseline(): void {
     this.patchBaseline = { ...this.transientData };
-    // Tombstones as of patch-build time: a re-add during the in-flight
-    // request clears the live tombstone, but the persisted patch still
-    // carries the remove — reconcile must fold from THIS set.
-    this.patchBaselineDeletes = new Set(this.transientDeletes);
     this.patchBaselineSourceRevision = this.sourceRevision;
   }
 
@@ -609,45 +606,30 @@ export class Sample {
    * Release server-owned fields from the transient after a successful persist.
    * See {@link reconcilePersisted}.
    */
-  reconcilePersisted(deltas: JSONDeltas): void {
+  reconcilePersisted(
+    deltas: JSONDeltas,
+    opts: {
+      /**
+       * Whether `deltas` use sample-rooted pointers. Generated (patches)
+       * views persist LABEL-rooted deltas whose segments are attribute
+       * names, not field names — rebasing those into the sample source
+       * would write the wrong fields, so the rebase only runs when the
+       * caller vouches for sample-rooted paths.
+       */
+      sampleRooted?: boolean;
+    } = {},
+  ): void {
     this.assertNotDispatching("reconcilePersisted");
+    const { sampleRooted = true } = opts;
     // consume the baseline; null it so a stray second reconcile fails safe
     const baseline = this.patchBaseline;
     this.patchBaseline = null;
-    const baselineDeletes = this.patchBaselineDeletes;
-    this.patchBaselineDeletes = null;
 
-    // Fold the persisted fields into source FIRST — deletes otherwise
-    // re-diff against the stale source forever, re-PATCHing the same
-    // remove on every autosave tick and never settling (see
-    // foldPersistedIntoSource). Purely source-side: the display already
-    // projects the transient state, so no change notification is due.
-    // A setData() during the in-flight request replaced source with a
-    // FRESH server fetch — strictly better truth than the fold's
-    // reconstruction (the fold exists only because no echo arrives).
-    // Folding a stale baseline over it could mask a concurrent writer's
-    // newer values, so skip; the next diff resolves against the fresh
-    // source naturally.
-    const sourceReplaced =
-      this.sourceRevision !== this.patchBaselineSourceRevision;
-    const folded = sourceReplaced
-      ? null
-      : foldPersistedIntoSource(
-          this.sourceData,
-          baselineDeletes,
-          baseline,
-          deltas,
-        );
-    if (folded) {
-      this.sourceData = folded.sourceData;
-      // Release only tombstones the persisted patch actually satisfied
-      // AND that still stand — a tombstone recreated by a post-persist
-      // delete of the re-added value must keep diffing.
-      for (const path of folded.releasedTombstones) {
-        this.transientDeletes.delete(path);
-      }
-    }
-
+    // The transient release runs FIRST, against the PRE-rebase snapshot:
+    // its matched-element ops are source-indexed (see
+    // releaseUneditedLabelFields), so it must resolve them against the
+    // source the patch was diffed from, and its defer-to-source semantics
+    // must see the server-refreshed values, not our own rebase output.
     const result = reconcilePersisted(
       this.snapshot(),
       deltas,
@@ -655,26 +637,42 @@ export class Sample {
       baseline,
     );
 
-    if (!result) {
-      return;
-    }
-
-    // A released/dropped path has a new (or absent) reference vs. before;
-    // emit a per-path reset so reconcilers re-read just those from source.
-    const before = this.transientData;
-    const after = result.transientData;
-    const changes: SampleChange[] = [];
-    for (const path of new Set([
-      ...Object.keys(before),
-      ...Object.keys(after),
-    ])) {
-      if (before[path] !== after[path]) {
-        changes.push({ path, kind: SampleChangeKind.Reset });
+    // Rebase source by applying the server-accepted deltas — the shared
+    // applyDeltas contract frameStore.rebaseFrame uses (see rebaseSource;
+    // deletes otherwise re-diff against the stale source forever). gc()
+    // then drops the tombstones the rebase satisfied — and ONLY those
+    // still absent from source, which is exactly the "recreated tombstone
+    // keeps diffing" guarantee. Skipped when a setData() replaced source
+    // mid-flight: a fresh fetch is strictly better truth than a replay,
+    // and the next diff resolves against it naturally. Purely
+    // source-side: the display projects the transient, so no
+    // notification is due.
+    if (result) {
+      // A released/dropped path has a new (or absent) reference vs.
+      // before; emit a per-path reset so reconcilers re-read just those
+      // from source.
+      const before = this.transientData;
+      const after = result.transientData;
+      const changes: SampleChange[] = [];
+      for (const path of new Set([
+        ...Object.keys(before),
+        ...Object.keys(after),
+      ])) {
+        if (before[path] !== after[path]) {
+          changes.push({ path, kind: SampleChangeKind.Reset });
+        }
       }
+
+      this.transientData = after;
+      this.notify(changes);
     }
 
-    this.transientData = after;
-    this.notify(changes);
+    const sourceReplaced =
+      this.sourceRevision !== this.patchBaselineSourceRevision;
+    if (sampleRooted && !sourceReplaced && baseline) {
+      this.sourceData = rebaseSource(this.sourceData, deltas);
+      this.gc();
+    }
   }
 
   /**

--- a/app/packages/utilities/src/sample/sourceFold.ts
+++ b/app/packages/utilities/src/sample/sourceFold.ts
@@ -1,99 +1,85 @@
+import { applyDeltas } from "./apply";
 import { JSONDeltas } from "../types";
-import { withoutPath, withValueAtPath } from "./pointer";
-
-/** Source-side fold of a persisted patch. See {@link foldPersistedIntoSource}. */
-export interface SourceFoldResult {
-  readonly sourceData: Record<string, unknown>;
-  /** Top-level fields whose delete tombstone the fold satisfied. */
-  readonly releasedTombstones: string[];
-}
 
 /**
- * After a successful persist, fold the persisted fields into `sourceData` —
- * the committed truth the server just accepted. The sample source gets no
- * post-save echo (a view refetch only happens on navigation), so without
- * this a DELETE re-diffs against the stale source forever: `buildJsonPatch`
- * re-emits the same `remove` on every autosave tick, the client re-PATCHes
- * an already-deleted field indefinitely, and the save state never settles.
- * (`frameStore.reconcilePersisted` has always folded into source for
- * exactly this reason; the sample side only released transients.)
+ * Server-faithful rebase of `sourceData` after a successful persist: apply
+ * the SAME deltas the server just accepted, via the shared
+ * {@link applyDeltas} primitive — the exact contract
+ * `frameStore.rebaseFrame` uses for the frame side. The sample source gets
+ * no post-save echo (a view refetch only happens on navigation), so
+ * without this a DELETE re-diffs against the stale source forever:
+ * `buildJsonPatch` re-emits the same `remove` on every autosave tick, the
+ * client re-PATCHes an already-deleted field indefinitely, and the save
+ * state never settles.
  *
- * Folds at FIELD granularity from `patchBaseline` — the transient captured
- * when the persisted patch was BUILT — never from the live transient: a
- * field re-edited while the request was in flight must keep diffing so the
- * newer edit persists on the next pass. Per persisted field:
+ * Deviations from a bare `applyDeltas` call, both server-matching:
  *
- * - tombstoned and absent from the baseline: the persisted patch removed
- *   it — drop it from source and release the tombstone;
- * - present in the baseline: the persisted patch wrote that value — commit
- *   it to source (client-normalized form, like the frame fold; a later
- *   real fetch replaces it with the server encoding).
- *
- * A `null` baseline folds nothing (fail safe, mirroring the release pass).
+ * - an `add` whose intermediate containers are absent from the local
+ *   source (a nested primitive under an unset embedded field) creates the
+ *   missing object parents, as the server does;
+ * - an op the local source cannot satisfy at all is skipped rather than
+ *   aborting the rebase — the ops were server-accepted, so a local
+ *   mismatch means the local source was already stale there, and the next
+ *   diff re-persists whatever still differs (fail-safe).
  */
-export const foldPersistedIntoSource = (
+export const rebaseSource = (
   sourceData: Readonly<Record<string, unknown>>,
-  baselineDeletes: ReadonlySet<string> | null,
-  patchBaseline: Readonly<Record<string, unknown>> | null,
   deltas: JSONDeltas,
-): SourceFoldResult | null => {
-  if (!patchBaseline || !baselineDeletes) {
-    return null;
-  }
-
-  let next: Record<string, unknown> | null = null;
-  const releasedTombstones: string[] = [];
-  const foldedKeys = new Set<string>();
-
+): Record<string, unknown> => {
+  let next = sourceData as Record<string, unknown>;
   for (const op of deltas) {
-    const segments = op.path.split("/").filter(Boolean);
-    if (!segments.length) {
-      continue;
-    }
-
-    // Transient KEYS are dot-paths of varying depth: a whole field for
-    // label edits ("ground_truth"), a nested path for primitive edits
-    // ("classification.label"). A tombstone's remove op is emitted at
-    // exactly its key's path, while structural list diffs go deeper than
-    // their key — so walk the op path's prefixes DEEPEST-FIRST and fold
-    // at the first key that matches a tombstone or a baseline entry.
-    for (let depth = segments.length; depth >= 1; depth -= 1) {
-      const keySegments = segments.slice(0, depth);
-      const key = keySegments.join(".");
-      if (foldedKeys.has(key)) {
-        break;
+    try {
+      next = applyDeltas(next, [op]);
+    } catch {
+      if (op.op === "add" || op.op === "replace") {
+        const created = withCreatedParents(next, op.path);
+        if (created) {
+          try {
+            next = applyDeltas(created, [op]);
+            continue;
+          } catch {
+            // fall through to the skip below
+          }
+        }
       }
-
-      const inBaseline = Object.prototype.hasOwnProperty.call(
-        patchBaseline,
-        key,
-      );
-
-      // Decide from the PERSIST-TIME tombstones, never the current set: a
-      // re-add while the request was in flight clears the live tombstone,
-      // but the server still applied the remove — the fold must commit it
-      // to source so the re-add diffs as a fresh add instead of silently
-      // matching the stale source value.
-      if (baselineDeletes.has(key) && !inBaseline) {
-        next = withoutPath(next ?? sourceData, keySegments) as Record<
-          string,
-          unknown
-        >;
-        releasedTombstones.push(key);
-        foldedKeys.add(key);
-        break;
-      }
-      if (inBaseline) {
-        next = withValueAtPath(
-          next ?? sourceData,
-          keySegments,
-          patchBaseline[key],
-        ) as Record<string, unknown>;
-        foldedKeys.add(key);
-        break;
-      }
+      // remove of an already-absent path (or an unsatisfiable op): skip —
+      // idempotent for removes, fail-safe for everything else.
     }
   }
+  return next;
+};
 
-  return next ? { sourceData: next, releasedTombstones } : null;
+/**
+ * Clone `doc` with plain-object containers created for every missing
+ * intermediate segment of `pointer` (the leaf itself is left for the op to
+ * write). Returns `null` when a missing intermediate is a list index —
+ * fabricating array structure is not server-matching.
+ */
+const withCreatedParents = (
+  doc: Record<string, unknown>,
+  pointer: string,
+): Record<string, unknown> | null => {
+  const segments = pointer.split("/").filter(Boolean).slice(0, -1);
+  const root = { ...doc };
+  let node: Record<string, unknown> = root;
+  for (const segment of segments) {
+    const value = node[segment];
+    if (value === undefined || value === null) {
+      if (/^\d+$/.test(segment)) {
+        return null;
+      }
+      const created: Record<string, unknown> = {};
+      node[segment] = created;
+      node = created;
+    } else if (typeof value === "object") {
+      const clone: Record<string, unknown> = Array.isArray(value)
+        ? ([...value] as unknown as Record<string, unknown>)
+        : { ...(value as Record<string, unknown>) };
+      node[segment] = clone;
+      node = clone;
+    } else {
+      return null;
+    }
+  }
+  return root;
 };

--- a/app/packages/utilities/src/sample/sourceFold.ts
+++ b/app/packages/utilities/src/sample/sourceFold.ts
@@ -26,6 +26,15 @@ export const rebaseSource = (
   sourceData: Readonly<Record<string, unknown>>,
   deltas: JSONDeltas,
 ): Record<string, unknown> => {
+  // Batch first: applyDeltas deep-clones the document per call, so the
+  // happy path pays exactly one clone. The per-op walk below is the
+  // recovery path for the parent-creation / stale-op cases only.
+  try {
+    return applyDeltas(sourceData as Record<string, unknown>, deltas);
+  } catch {
+    // fall through to the per-op recovery
+  }
+
   let next = sourceData as Record<string, unknown>;
   for (const op of deltas) {
     try {
@@ -59,19 +68,38 @@ const withCreatedParents = (
   doc: Record<string, unknown>,
   pointer: string,
 ): Record<string, unknown> | null => {
-  const segments = pointer.split("/").filter(Boolean).slice(0, -1);
+  const all = pointer.split("/").filter(Boolean);
+  const segments = all.slice(0, -1);
+  const leaf = all[all.length - 1];
+  const isIndexSegment = (s: string | undefined) =>
+    s === "-" || (s !== undefined && /^\d+$/.test(s));
   const root = { ...doc };
   let node: Record<string, unknown> = root;
-  for (const segment of segments) {
+  for (let i = 0; i < segments.length; i += 1) {
+    const segment = segments[i];
+    // What follows this container decides its shape: an append ("-") or
+    // numeric index means the container must be an ARRAY — a {} here
+    // would make fast-json-patch assign "-" as an object key.
+    const following = i + 1 < segments.length ? segments[i + 1] : leaf;
     const value = node[segment];
     if (value === undefined || value === null) {
-      if (/^\d+$/.test(segment)) {
+      if (isIndexSegment(segment)) {
+        // fabricating array structure at a specific index is not
+        // server-matching — bail and let the op be skipped
         return null;
       }
-      const created: Record<string, unknown> = {};
+      const created: Record<string, unknown> | unknown[] = isIndexSegment(
+        following,
+      )
+        ? []
+        : {};
       node[segment] = created;
-      node = created;
+      node = created as Record<string, unknown>;
     } else if (typeof value === "object") {
+      if (isIndexSegment(following) && !Array.isArray(value)) {
+        // an existing non-array where the op needs an array: unsatisfiable
+        return null;
+      }
       const clone: Record<string, unknown> = Array.isArray(value)
         ? ([...value] as unknown as Record<string, unknown>)
         : { ...(value as Record<string, unknown>) };

--- a/app/packages/utilities/src/sample/sourceFold.ts
+++ b/app/packages/utilities/src/sample/sourceFold.ts
@@ -1,0 +1,99 @@
+import { JSONDeltas } from "../types";
+import { withoutPath, withValueAtPath } from "./pointer";
+
+/** Source-side fold of a persisted patch. See {@link foldPersistedIntoSource}. */
+export interface SourceFoldResult {
+  readonly sourceData: Record<string, unknown>;
+  /** Top-level fields whose delete tombstone the fold satisfied. */
+  readonly releasedTombstones: string[];
+}
+
+/**
+ * After a successful persist, fold the persisted fields into `sourceData` —
+ * the committed truth the server just accepted. The sample source gets no
+ * post-save echo (a view refetch only happens on navigation), so without
+ * this a DELETE re-diffs against the stale source forever: `buildJsonPatch`
+ * re-emits the same `remove` on every autosave tick, the client re-PATCHes
+ * an already-deleted field indefinitely, and the save state never settles.
+ * (`frameStore.reconcilePersisted` has always folded into source for
+ * exactly this reason; the sample side only released transients.)
+ *
+ * Folds at FIELD granularity from `patchBaseline` — the transient captured
+ * when the persisted patch was BUILT — never from the live transient: a
+ * field re-edited while the request was in flight must keep diffing so the
+ * newer edit persists on the next pass. Per persisted field:
+ *
+ * - tombstoned and absent from the baseline: the persisted patch removed
+ *   it — drop it from source and release the tombstone;
+ * - present in the baseline: the persisted patch wrote that value — commit
+ *   it to source (client-normalized form, like the frame fold; a later
+ *   real fetch replaces it with the server encoding).
+ *
+ * A `null` baseline folds nothing (fail safe, mirroring the release pass).
+ */
+export const foldPersistedIntoSource = (
+  sourceData: Readonly<Record<string, unknown>>,
+  baselineDeletes: ReadonlySet<string> | null,
+  patchBaseline: Readonly<Record<string, unknown>> | null,
+  deltas: JSONDeltas,
+): SourceFoldResult | null => {
+  if (!patchBaseline || !baselineDeletes) {
+    return null;
+  }
+
+  let next: Record<string, unknown> | null = null;
+  const releasedTombstones: string[] = [];
+  const foldedKeys = new Set<string>();
+
+  for (const op of deltas) {
+    const segments = op.path.split("/").filter(Boolean);
+    if (!segments.length) {
+      continue;
+    }
+
+    // Transient KEYS are dot-paths of varying depth: a whole field for
+    // label edits ("ground_truth"), a nested path for primitive edits
+    // ("classification.label"). A tombstone's remove op is emitted at
+    // exactly its key's path, while structural list diffs go deeper than
+    // their key — so walk the op path's prefixes DEEPEST-FIRST and fold
+    // at the first key that matches a tombstone or a baseline entry.
+    for (let depth = segments.length; depth >= 1; depth -= 1) {
+      const keySegments = segments.slice(0, depth);
+      const key = keySegments.join(".");
+      if (foldedKeys.has(key)) {
+        break;
+      }
+
+      const inBaseline = Object.prototype.hasOwnProperty.call(
+        patchBaseline,
+        key,
+      );
+
+      // Decide from the PERSIST-TIME tombstones, never the current set: a
+      // re-add while the request was in flight clears the live tombstone,
+      // but the server still applied the remove — the fold must commit it
+      // to source so the re-add diffs as a fresh add instead of silently
+      // matching the stale source value.
+      if (baselineDeletes.has(key) && !inBaseline) {
+        next = withoutPath(next ?? sourceData, keySegments) as Record<
+          string,
+          unknown
+        >;
+        releasedTombstones.push(key);
+        foldedKeys.add(key);
+        break;
+      }
+      if (inBaseline) {
+        next = withValueAtPath(
+          next ?? sourceData,
+          keySegments,
+          patchBaseline[key],
+        ) as Record<string, unknown>;
+        foldedKeys.add(key);
+        break;
+      }
+    }
+  }
+
+  return next ? { sourceData: next, releasedTombstones } : null;
+};


### PR DESCRIPTION
## What

After a successful annotation persist, the sample-side reconcile only released transient fields (server-owned adds/replaces) — it never folded the persisted patch into `sourceData`. The sample source gets no post-save echo (a view refetch only happens on navigation), so a DELETE kept re-diffing against the stale source: `buildJsonPatch` re-emitted the same `remove` on every autosave tick, the client re-PATCHed an already-deleted field indefinitely (observed live: one PATCH every ~3s until the modal closed), and the save-settlement state never settled. `frameStore.reconcilePersisted` has always folded into source for exactly this reason; the sample side was missing the same contract.

## How

`foldPersistedIntoSource` (utilities/sample/reconcile.ts) folds the persisted fields into `sourceData` at FIELD-key granularity from `patchBaseline` — the transient captured when the persisted patch was built, never the live transient, so a field re-edited while the request was in flight keeps diffing and persists on the next pass. Transient keys are dot-paths of varying depth (a whole field for label edits, a nested path for primitive edits), so the fold walks each op path's prefixes deepest-first and folds at the first key matching a delete tombstone or a baseline entry.

## Tests

New regression tests in `sample.test.ts` (single-label delete, nested-path delete, list-element delete — each verifying the second `getJsonPatch()` is empty after reconcile — plus in-flight re-edit preservation) and the existing sample/reconcile suites: 97 passing.

Enterprise note: upstreams the OSS-owned file changes from voxel51/fiftyone-teams#3898, where the loop was found by the Activity Analytics e2e suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization of persisted changes, including deletions of single values, nested fields, and list entries.
  * Prevented already-reconciled deletions from being repeatedly emitted.
  * Preserved newer edits and re-added values made while updates were in progress.
  * Ensured deletions made during an in-flight update are included in the next synchronization.
  * Improved handling of nested data and generated-view changes during reconciliation.
* **Tests**
  * Added regression coverage for deletion handling, concurrent edits, and persisted change reconciliation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3910
<!-- enterprise-sync-pr:end -->