### PR TITLE
Annotation: plumb attributionSampleId (grid anchor) through the persist path

### DIFF
--- a/app/packages/annotation/src/hooks/usePatchSample.test.ts
+++ b/app/packages/annotation/src/hooks/usePatchSample.test.ts
@@ -58,6 +58,17 @@ describe("usePatchSampleWith", () => {
     );
   });
 
+  it("forwards attributionSampleId so grouped-modal ops credit the anchor", async () => {
+    const args = makeArgs();
+    const { result } = renderHook(() => usePatchSampleWith(args));
+
+    await result.current(DELTAS, { attributionSampleId: "anchor-1" });
+
+    expect(doPatchSample).toHaveBeenCalledWith(
+      expect.objectContaining({ attributionSampleId: "anchor-1" }),
+    );
+  });
+
   it("passes all constructor args through to doPatchSample", async () => {
     const args = makeArgs({
       isGenerated: true,

--- a/app/packages/annotation/src/hooks/usePatchSample.ts
+++ b/app/packages/annotation/src/hooks/usePatchSample.ts
@@ -39,7 +39,7 @@ export const usePatchSampleWith = ({
   generatedDatasetName,
 }: Omit<
   DoPatchSampleArgs,
-  "sampleDeltas" | "labelId" | "labelPath" | "opType"
+  "sampleDeltas" | "labelId" | "labelPath" | "opType" | "attributionSampleId"
 >) => {
   return useCallback(
     (

--- a/app/packages/annotation/src/hooks/usePatchSample.ts
+++ b/app/packages/annotation/src/hooks/usePatchSample.ts
@@ -16,6 +16,8 @@ type PatchOptions = {
   labelId?: string;
   labelPath?: string;
   opType?: OpType;
+  /** See DoPatchSampleArgs.attributionSampleId (grouped-modal anchor). */
+  attributionSampleId?: string;
 };
 
 /**
@@ -55,6 +57,7 @@ export const usePatchSampleWith = ({
         labelId: patchOptions?.labelId,
         labelPath: patchOptions?.labelPath,
         opType: patchOptions?.opType,
+        attributionSampleId: patchOptions?.attributionSampleId,
       });
     },
     [

--- a/app/packages/annotation/src/persistence/usePersistAnnotationDeltas.ts
+++ b/app/packages/annotation/src/persistence/usePersistAnnotationDeltas.ts
@@ -151,6 +151,7 @@ export const usePersistAnnotationDeltas =
 
       return success;
     }, [
+      anchorSampleId,
       engine,
       eventBus,
       isGenerated,

--- a/app/packages/annotation/src/persistence/usePersistAnnotationDeltas.ts
+++ b/app/packages/annotation/src/persistence/usePersistAnnotationDeltas.ts
@@ -1,5 +1,6 @@
 import {
   isGeneratedView,
+  nullableModalSampleId,
   useCurrentDatasetId,
   useModalSample,
   useRefreshSample,
@@ -55,6 +56,12 @@ export const usePersistAnnotationDeltas =
     // hang the modal on "Pixelating…". Until the 3D group query settles it reads
     // `undefined`, which matches `sceneId` below so the 3D branch stays inert.
     const modalId = useModalSample()?.sample?._id;
+    // The task's unit of work: the GRID anchor sample id, stable across
+    // group-slice and 3D-pin changes. Non-generated label ops attribute
+    // to it so grouped-modal edits (the second camera, the pinned 3D
+    // scene) reach the submit delta and the trail under the same key the
+    // subtask, the delta peek, and the tracker focus already use.
+    const anchorSampleId = useRecoilValue(nullableModalSampleId) ?? undefined;
     const sceneId = useThreeDSceneSampleId();
     const threeDScene = useStableInteraction3dSample();
     const patch3d = usePatchSampleWith({
@@ -128,7 +135,9 @@ export const usePersistAnnotationDeltas =
       for (const entry of patches) {
         const patch = entry.sample === sceneId ? patch3d : patchSelected;
 
-        const ok = await patch(entry.deltas);
+        const ok = await patch(entry.deltas, {
+          attributionSampleId: anchorSampleId,
+        });
 
         if (ok) {
           // release server-owned fields (e.g. masks) the backend now owns, so

--- a/app/packages/annotation/src/util/labelPersistence.ts
+++ b/app/packages/annotation/src/util/labelPersistence.ts
@@ -20,6 +20,17 @@ export type DoPatchSampleArgs = {
   labelId?: string;
   labelPath?: string;
   opType?: OpType;
+  /**
+   * The sample id that label-op ATTRIBUTION should use when it differs
+   * from the persisted document: a grouped modal persists edits against
+   * the slice document that owns them (the second camera, the pinned 3D
+   * scene), while the modal's unit of work is the GRID anchor sample.
+   * The unified persist loop passes the anchor here for every
+   * non-generated patch; consumers that credit label work (e.g.
+   * annotation-activity integrations downstream) attribute by this id
+   * rather than the persisted document's.
+   */
+  attributionSampleId?: string;
 };
 
 /**

--- a/app/packages/annotation/src/util/labelPersistence.ts
+++ b/app/packages/annotation/src/util/labelPersistence.ts
@@ -64,6 +64,8 @@ export interface PatchPersistedInfo {
   labelId?: string;
   labelPath?: string;
   opType?: OpType;
+  /** See DoPatchSampleArgs.attributionSampleId (grouped-modal anchor). */
+  attributionSampleId?: string;
 }
 
 type PatchPersistedListener = (
@@ -91,6 +93,7 @@ export const doPatchSample = async ({
   labelId,
   labelPath,
   opType,
+  attributionSampleId,
 }: DoPatchSampleArgs): Promise<boolean> => {
   // The annotation endpoint implements a CRDT via a version token
   const versionToken = getVersionToken();
@@ -188,6 +191,7 @@ export const doPatchSample = async ({
       labelId,
       labelPath,
       opType,
+      attributionSampleId,
     };
     for (const listener of patchListeners) {
       try {


### PR DESCRIPTION
## What

A grouped modal persists edits against the slice document that owns them (the second camera, the pinned 3D scene), while the modal's unit of work is the GRID anchor sample. Consumers that credit label work by sample — e.g. annotation-activity integrations downstream — need the anchor, not the persisted document id: without it, non-anchor-slice work attributes to a document no workspace tracks.

## How

- `DoPatchSampleArgs` gains an optional, documented `attributionSampleId`.
- `usePatchSample` forwards it.
- The unified persist loop (`usePersistAnnotationDeltas`) passes the modal anchor (`nullableModalSampleId` — stable across slice and 3D-pin changes) for every non-generated patch; generated views keep their source-sample attribution.

A no-op for flat datasets and for consumers that ignore the field.

## Tests

`usePatchSample.test.ts` covers the forward (8 passing); hooks + persistence suites all green (49 passing).

Enterprise note: upstreams the OSS-owned file changes from voxel51/fiftyone-teams#3859 (where the field feeds the activity label-op announce), keeping the enterprise sync clean.

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3902
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved grouped-modal annotation updates by correctly associating changes with their anchor sample.
  * Preserved attribution information when saving non-generated annotation changes.

* **Tests**
  * Added coverage verifying attribution details are forwarded correctly during grouped-modal operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->