### PR TITLE
ci: treat 'main' as a synced base in enterprise-sync (unblocks all PRs)

### DIFF
--- a/.github/workflows/enterprise-sync.yml
+++ b/.github/workflows/enterprise-sync.yml
@@ -31,6 +31,7 @@ jobs:
       !endsWith(github.event.pull_request.user.login, '[bot]') &&
       (github.event.action != 'edited' || github.event.changes.base) &&
       (
+        github.event.pull_request.base.ref == 'main' ||
         github.event.pull_request.base.ref == 'develop' ||
         startsWith(github.event.pull_request.base.ref, 'release/') ||
         github.event.changes.base
@@ -51,7 +52,8 @@ jobs:
             const base = pr.base.ref;
 
             // Bases mirrored into Enterprise.
-            const isSyncBase = (b) => b === 'develop' || b.startsWith('release/');
+            const isSyncBase = (b) =>
+              b === 'main' || b === 'develop' || b.startsWith('release/');
 
             // Retarget away from a synced base: close the orphaned mirror.
             if (action === 'edited' && context.payload.changes.base) {


### PR DESCRIPTION
## What

`develop` was renamed to `main` today (PRs merged into develop as late as 18:30Z; everything since targets main). The enterprise-sync job's base gate still matches only `develop`/`release/*`, so it SKIPS on every main-based PR - and since `enterprise / ci` is a required context that only this job reports, **every open PR in the repo is stuck at 'Expected - Waiting for status to be reported'** (currently #8329-#8335).

## How

Add `main` to the job's base gate and to `isSyncBase`, keeping `develop` and `release/*` matching unchanged.

## Merging this

This PR is itself stuck behind the same required context (chicken-and-egg), so it needs an **admin bypass-merge**. After it lands, existing PRs re-report on their next synchronize event (a push or Update branch click).

The fiftyone-teams side of the sync (the `oss-pr-sync` receiver and any develop-hardcoded mapping) may need the same rename treatment - flagging for whoever drove the rename.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Enterprise synchronization workflow handling for the `main` branch.
  * Pull-request filtering and dispatch logic now consistently support `main` as an Enterprise-synchronized base.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3904
<!-- enterprise-sync-pr:end -->