### PR TITLE
Skip multimodal metadata reads during grid pagination (perf)

### DIFF
--- a/fiftyone/server/metadata.py
+++ b/fiftyone/server/metadata.py
@@ -60,6 +60,7 @@ async def get_metadata(
     url_cache: t.Dict[str, str],
     *,
     additional_media_fields: t.Optional[t.Tuple] = None,
+    skip_metadata_read: bool = False,
 ):
     """Gets the metadata for the given local media file.
 
@@ -70,6 +71,8 @@ async def get_metadata(
         additional_media_fields: pre-computed result of
             ``_get_additional_media_fields(collection)``. If None, will be
             computed (expensive — prefer passing it in).
+        skip_metadata_read (False): whether to return placeholder metadata
+            without reading the media
 
     Returns:
         metadata dict
@@ -77,11 +80,11 @@ async def get_metadata(
     filepath = sample["filepath"]
     metadata = sample.get("metadata", None)
 
-    (
-        opm_field,
-        detections_fields,
-        additional_fields,
-    ) = additional_media_fields if additional_media_fields is not None else _get_additional_media_fields(collection)
+    (opm_field, detections_fields, additional_fields,) = (
+        additional_media_fields
+        if additional_media_fields is not None
+        else _get_additional_media_fields(collection)
+    )
 
     filepath_result, filepath_source, urls = _create_media_urls(
         collection,
@@ -94,6 +97,9 @@ async def get_metadata(
     )
     if filepath_result is not None:
         filepath = filepath_result
+
+    if skip_metadata_read:
+        return dict(urls=urls, aspect_ratio=1)
 
     is_video = media_type == fom.VIDEO
 

--- a/fiftyone/server/samples.py
+++ b/fiftyone/server/samples.py
@@ -194,6 +194,7 @@ async def _create_sample_item(
         metadata_cache,
         url_cache,
         additional_media_fields=additional_media_fields,
+        skip_metadata_read=(pagination_data and media_type == fom.MULTIMODAL),
     )
 
     if cls == VideoSample:

--- a/tests/unittests/server_samples_tests.py
+++ b/tests/unittests/server_samples_tests.py
@@ -7,17 +7,101 @@ FiftyOne Server samples tests.
 """
 
 import unittest
+from unittest.mock import AsyncMock, Mock, patch
 
 import fiftyone as fo
-from fiftyone.server.samples import get_samples_pipeline
+import fiftyone.core.media as fom
+from fiftyone.server.samples import (
+    UnknownSample,
+    _create_sample_item,
+    get_samples_pipeline,
+)
 
 from decorators import drop_async_dataset
-
 
 F = fo.ViewField
 
 
 class ServerSamplesTests(unittest.IsolatedAsyncioTestCase):
+    async def test_multimodal_grid_skips_metadata_read(self):
+        collection = Mock(media_type=fom.MULTIMODAL)
+        sample = {"_id": "sample-id", "filepath": "scene.mcap"}
+        urls = [{"field": "filepath", "url": "media-url"}]
+
+        with patch(
+            "fiftyone.server.metadata._create_media_urls",
+            return_value=("scene.mcap", urls[0]["url"], urls),
+        ) as create_urls, patch(
+            "fiftyone.server.metadata.read_metadata",
+            new=AsyncMock(side_effect=AssertionError("unexpected read")),
+        ) as read_metadata:
+            node = await _create_sample_item(
+                collection,
+                sample,
+                {},
+                {},
+                pagination_data=True,
+                additional_media_fields=(None, None, []),
+            )
+
+        create_urls.assert_called_once()
+        read_metadata.assert_not_awaited()
+        self.assertIsInstance(node, UnknownSample)
+        self.assertEqual(node.id, "sample-id")
+        self.assertEqual(node.aspect_ratio, 1)
+        self.assertEqual(node.urls[0].field, "filepath")
+        self.assertEqual(node.urls[0].url, urls[0]["url"])
+
+    async def test_multimodal_modal_reads_metadata(self):
+        collection = Mock(media_type=fom.MULTIMODAL)
+        sample = {"_id": "sample-id", "filepath": "scene.mcap"}
+        urls = [{"field": "filepath", "url": "media-url"}]
+
+        with patch(
+            "fiftyone.server.metadata._create_media_urls",
+            return_value=("scene.mcap", urls[0]["url"], urls),
+        ), patch(
+            "fiftyone.server.metadata.read_metadata",
+            new=AsyncMock(return_value={"aspect_ratio": 2}),
+        ) as read_metadata:
+            node = await _create_sample_item(
+                collection,
+                sample,
+                {},
+                {},
+                pagination_data=False,
+                additional_media_fields=(None, None, []),
+            )
+
+        read_metadata.assert_awaited_once()
+        self.assertEqual(node.id, "sample-id-modal")
+        self.assertEqual(node.aspect_ratio, 2)
+        self.assertEqual(node.urls[0].url, urls[0]["url"])
+
+    async def test_unknown_grid_reads_metadata(self):
+        collection = Mock(media_type=fom.UNKNOWN)
+        sample = {"_id": "sample-id", "filepath": "scene.bin"}
+
+        with patch(
+            "fiftyone.server.metadata._create_media_urls",
+            return_value=("scene.bin", "media-url", []),
+        ), patch(
+            "fiftyone.server.metadata.read_metadata",
+            new=AsyncMock(return_value={"aspect_ratio": 3}),
+        ) as read_metadata:
+            node = await _create_sample_item(
+                collection,
+                sample,
+                {},
+                {},
+                pagination_data=True,
+                additional_media_fields=(None, None, []),
+            )
+
+        read_metadata.assert_awaited_once()
+        self.assertIsInstance(node, UnknownSample)
+        self.assertEqual(node.aspect_ratio, 3)
+
     @drop_async_dataset
     async def test_limited_frames_lookup(self, dataset: fo.Dataset):
         video = _add_video_sample(dataset)


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

Skip metadata reads for multimodal grid items after building their media URLs. Multimodal grid nodes use placeholder aspect ratios, so probing MCAP, BAG, or RRD media as images cannot produce useful dimensions and can add per-sample latency. Modal requests and non-multimodal media keep their existing metadata behavior.

## 🧪 How is this patch tested? If it is not, please explain why.

- `python -m pytest tests/unittests/server_samples_tests.py -q`
- `pre-commit run --from-ref origin/main --to-ref HEAD`
- `python -m compileall -q fiftyone/server/metadata.py fiftyone/server/samples.py tests/unittests/server_samples_tests.py`

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

N/A

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
  - Improved multimodal grid loading by skipping unnecessary metadata reads during pagination.
  - Grid views now load faster while still providing media URLs and default aspect-ratio information.

- **Bug Fixes**
  - Metadata continues to load correctly for modal views and samples with unknown media types.

- **Tests**
  - Added coverage for metadata behavior across multimodal, modal, grid, and unknown-media views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3905
<!-- enterprise-sync-pr:end -->