### PR TITLE
Prevent MCAP video flicker during 3D label playback

### DIFF
--- a/app/packages/multimodal/src/visualization/composition/CameraFrustumSceneLayer.tsx
+++ b/app/packages/multimodal/src/visualization/composition/CameraFrustumSceneLayer.tsx
@@ -37,6 +37,7 @@ import {
   isScenePrimarySelection,
   useSceneHoverLifecycle,
 } from "../scene-3d/use-scene-object-interaction";
+import { createScreenSpaceLineRaycast } from "../scene-3d/screen-space-line-raycast";
 
 // Camera frustum wireframes are purely presentational — depth is not data,
 // which is also why frustums never participate in camera-fit bounds.
@@ -117,6 +118,11 @@ export const CameraFrustumSceneLayer = memo(function CameraFrustumSceneLayer({
   const axisGeometry = useMemo(
     () => createCameraAxisMarkerGeometry(imagePlaneDepthM),
     [imagePlaneDepthM],
+  );
+  const viewportHeightPx = useThree((state) => state.size.height);
+  const lineRaycast = useMemo(
+    () => createScreenSpaceLineRaycast(viewportHeightPx),
+    [viewportHeightPx],
   );
   const pickingEnabled = useScenePicking();
   const [hovered, setHovered] = useState(false);
@@ -274,6 +280,8 @@ export const CameraFrustumSceneLayer = memo(function CameraFrustumSceneLayer({
   const imageMap = activeImageHandle
     ? (activeImageHandle.texture as never)
     : null;
+  // The same bundled-three mismatch applies to Object3D.raycast's signature.
+  const fiberLineRaycast = lineRaycast as never;
   if (!geometry) {
     return null;
   }
@@ -309,7 +317,7 @@ export const CameraFrustumSceneLayer = memo(function CameraFrustumSceneLayer({
       }
       userData={interactive ? POINT_PICK_BLOCKING_USER_DATA : undefined}
     >
-      <lineSegments frustumCulled={false}>
+      <lineSegments frustumCulled={false} raycast={fiberLineRaycast}>
         <primitive attach="geometry" object={geometry} />
         {selected ? (
           <lineDashedMaterial
@@ -331,7 +339,7 @@ export const CameraFrustumSceneLayer = memo(function CameraFrustumSceneLayer({
           />
         )}
       </lineSegments>
-      <lineSegments frustumCulled={false}>
+      <lineSegments frustumCulled={false} raycast={fiberLineRaycast}>
         <primitive attach="geometry" object={axisGeometry} />
         <lineBasicMaterial
           linewidth={CAMERA_FRUSTUM_AXIS_LINE_WIDTH}

--- a/app/packages/multimodal/src/visualization/media-2d/use-video-texture.test.tsx
+++ b/app/packages/multimodal/src/visualization/media-2d/use-video-texture.test.tsx
@@ -65,6 +65,35 @@ describe("useVideoTexture", () => {
     expect(onLoaded).toHaveBeenLastCalledWith(result.current);
   });
 
+  it("recreates the renderer texture when frame dimensions change", async () => {
+    const textureDispose = vi.spyOn(THREE.Texture.prototype, "dispose");
+    const firstRelease = vi.fn();
+    const secondRelease = vi.fn();
+    const first = presentation(1n, firstRelease);
+    const second = presentation(
+      2n,
+      secondRelease,
+      document.createElement("canvas"),
+      1280,
+      720,
+    );
+    const { result, rerender } = renderHook(
+      ({ value }: { readonly value: VideoPresentation }) =>
+        useVideoTexture(value),
+      { initialProps: { value: first } },
+    );
+    await waitFor(() => expect(result.current).not.toBeNull());
+    const firstTexture = result.current?.texture;
+
+    rerender({ value: second });
+    await waitFor(() => expect(result.current?.texture).not.toBe(firstTexture));
+    expect(result.current?.imageWidth).toBe(1280);
+    expect(result.current?.imageHeight).toBe(720);
+    expect(textureDispose).toHaveBeenCalledOnce();
+    expect(firstRelease).toHaveBeenCalledOnce();
+    expect(secondRelease).not.toHaveBeenCalled();
+  });
+
   it("disposes the stable texture and current lease on unmount", async () => {
     const textureDispose = vi.spyOn(THREE.Texture.prototype, "dispose");
     const release = vi.fn();
@@ -83,18 +112,22 @@ function presentation(
   timeNs: bigint,
   release: () => void,
   source = document.createElement("canvas"),
+  width = 640,
+  height = 480,
 ): VideoPresentation {
+  source.width = width;
+  source.height = height;
   return {
     acquire: () => ({
-      height: 480,
+      height,
       release,
       source,
       timeNs,
-      width: 640,
+      width,
     }),
-    height: 480,
+    height,
     live: true,
     timeNs,
-    width: 640,
+    width,
   };
 }

--- a/app/packages/multimodal/src/visualization/media-2d/use-video-texture.test.tsx
+++ b/app/packages/multimodal/src/visualization/media-2d/use-video-texture.test.tsx
@@ -1,24 +1,17 @@
 import { cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import * as THREE from "three";
 
 import type { VideoPresentation } from "../../video/types";
-import {
-  useVideoTexture,
-  VIDEO_TEXTURE_RETIRE_FALLBACK_MS,
-} from "./use-video-texture";
+import { useVideoTexture } from "./use-video-texture";
 
 afterEach(() => {
   cleanup();
-  vi.useRealTimers();
   vi.restoreAllMocks();
 });
 
 describe("useVideoTexture", () => {
-  it("clears a disposed presentation handle and releases its lease", async () => {
-    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
-      callback(0);
-      return 1;
-    });
+  it("clears the handle and releases its lease without a presentation", async () => {
     const release = vi.fn();
     const presentation: VideoPresentation = {
       acquire: () => ({
@@ -45,15 +38,14 @@ describe("useVideoTexture", () => {
     expect(release).toHaveBeenCalledOnce();
   });
 
-  it("replaces the renderer texture and retires the prior lease", async () => {
-    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
-      callback(0);
-      return 1;
-    });
+  it("reuses the renderer texture and retires only the prior lease", async () => {
+    const textureDispose = vi.spyOn(THREE.Texture.prototype, "dispose");
     const firstRelease = vi.fn();
     const secondRelease = vi.fn();
-    const first = presentation(1n, firstRelease);
-    const second = presentation(2n, secondRelease);
+    const firstSource = document.createElement("canvas");
+    const secondSource = document.createElement("canvas");
+    const first = presentation(1n, firstRelease, firstSource);
+    const second = presentation(2n, secondRelease, secondSource);
     const onLoaded = vi.fn();
     const { result, rerender } = renderHook(
       ({ value }: { readonly value: VideoPresentation }) =>
@@ -65,38 +57,38 @@ describe("useVideoTexture", () => {
 
     rerender({ value: second });
     await waitFor(() => expect(result.current).not.toBe(firstHandle));
+    expect(result.current?.texture).toBe(firstHandle?.texture);
+    expect(result.current?.texture.image).toBe(secondSource);
+    expect(textureDispose).not.toHaveBeenCalled();
     expect(firstRelease).toHaveBeenCalledOnce();
     expect(secondRelease).not.toHaveBeenCalled();
     expect(onLoaded).toHaveBeenLastCalledWith(result.current);
   });
 
-  it("retires through the timeout when animation frames are paused", async () => {
-    vi.useFakeTimers();
-    vi.spyOn(window, "requestAnimationFrame").mockImplementation(() => 1);
+  it("disposes the stable texture and current lease on unmount", async () => {
+    const textureDispose = vi.spyOn(THREE.Texture.prototype, "dispose");
     const release = vi.fn();
-    const { rerender } = renderHook(
-      ({ value }: { readonly value: VideoPresentation | null }) =>
-        useVideoTexture(value),
-      {
-        initialProps: {
-          value: presentation(1n, release) as VideoPresentation | null,
-        },
-      },
-    );
+    const current = presentation(1n, release);
+    const { result, unmount } = renderHook(() => useVideoTexture(current));
+    await waitFor(() => expect(result.current).not.toBeNull());
 
-    rerender({ value: null });
-    expect(release).not.toHaveBeenCalled();
-    await vi.advanceTimersByTimeAsync(VIDEO_TEXTURE_RETIRE_FALLBACK_MS);
+    unmount();
+
+    expect(textureDispose).toHaveBeenCalledOnce();
     expect(release).toHaveBeenCalledOnce();
   });
 });
 
-function presentation(timeNs: bigint, release: () => void): VideoPresentation {
+function presentation(
+  timeNs: bigint,
+  release: () => void,
+  source = document.createElement("canvas"),
+): VideoPresentation {
   return {
     acquire: () => ({
       height: 480,
       release,
-      source: document.createElement("canvas"),
+      source,
       timeNs,
       width: 640,
     }),

--- a/app/packages/multimodal/src/visualization/media-2d/use-video-texture.test.tsx
+++ b/app/packages/multimodal/src/visualization/media-2d/use-video-texture.test.tsx
@@ -65,6 +65,41 @@ describe("useVideoTexture", () => {
     expect(onLoaded).toHaveBeenLastCalledWith(result.current);
   });
 
+  it("makes handle disposal lease-generation aware", async () => {
+    const textureDispose = vi.spyOn(THREE.Texture.prototype, "dispose");
+    const firstRelease = vi.fn();
+    const secondRelease = vi.fn();
+    const thirdRelease = vi.fn();
+    const first = presentation(1n, firstRelease);
+    const second = presentation(2n, secondRelease);
+    const third = presentation(3n, thirdRelease);
+    const { result, rerender } = renderHook(
+      ({ value }: { readonly value: VideoPresentation }) =>
+        useVideoTexture(value),
+      { initialProps: { value: first } },
+    );
+    await waitFor(() => expect(result.current).not.toBeNull());
+    const firstHandle = result.current;
+
+    rerender({ value: second });
+    await waitFor(() => expect(result.current).not.toBe(firstHandle));
+    const secondHandle = result.current;
+    firstHandle?.dispose();
+
+    expect(textureDispose).not.toHaveBeenCalled();
+    expect(secondRelease).not.toHaveBeenCalled();
+
+    secondHandle?.dispose();
+    expect(textureDispose).toHaveBeenCalledOnce();
+    expect(secondRelease).toHaveBeenCalledOnce();
+
+    rerender({ value: third });
+    await waitFor(() =>
+      expect(result.current?.texture).not.toBe(secondHandle?.texture),
+    );
+    expect(thirdRelease).not.toHaveBeenCalled();
+  });
+
   it("recreates the renderer texture when frame dimensions change", async () => {
     const textureDispose = vi.spyOn(THREE.Texture.prototype, "dispose");
     const firstRelease = vi.fn();

--- a/app/packages/multimodal/src/visualization/media-2d/use-video-texture.ts
+++ b/app/packages/multimodal/src/visualization/media-2d/use-video-texture.ts
@@ -1,16 +1,19 @@
 import { useEffect, useRef, useState } from "react";
 import * as THREE from "three";
 
-import type { VideoPresentation } from "../../video/types";
+import type {
+  VideoPresentation,
+  VideoPresentationLease,
+} from "../../video/types";
 import type { ImageTextureHandle } from "./Base2dScene";
 
 interface HeldVideoTexture {
-  readonly handle: ImageTextureHandle;
+  currentLease: VideoPresentationLease | null;
+  disposed: boolean;
+  readonly texture: THREE.Texture;
 }
 
-export const VIDEO_TEXTURE_RETIRE_FALLBACK_MS = 250;
-
-/** Gives one renderer its own texture while sharing the copied presentation. */
+/** Gives one renderer a stable texture while sharing each copied presentation. */
 export function useVideoTexture(
   presentation: VideoPresentation | null,
   onLoaded?: (handle: ImageTextureHandle) => void,
@@ -20,66 +23,63 @@ export function useVideoTexture(
   const onLoadedRef = useRef(onLoaded);
   onLoadedRef.current = onLoaded;
 
+  // This effect updates the source of one renderer-owned texture and releases
+  // the presentation that it replaces.
   useEffect(() => {
-    if (!presentation) return undefined;
-    const lease = presentation.acquire();
-    if (!lease) return undefined;
-    const texture = new THREE.Texture(lease.source as TexImageSource);
-    texture.colorSpace = THREE.SRGBColorSpace;
-    texture.generateMipmaps = false;
-    texture.magFilter = THREE.LinearFilter;
-    texture.minFilter = THREE.LinearFilter;
-    texture.needsUpdate = true;
-    let disposed = false;
-    const next: HeldVideoTexture = {
-      handle: {
-        aspectRatio: lease.width / Math.max(1, lease.height),
-        dispose: () => {
-          if (disposed) return;
-          disposed = true;
-          texture.dispose();
-          lease.release();
-        },
-        imageHeight: lease.height,
-        imageWidth: lease.width,
-        retainWhenUnused: false,
-        texture,
-      },
-    };
-    const previous = heldRef.current;
-    heldRef.current = next;
-    setHandle(next.handle);
-    onLoadedRef.current?.(next.handle);
-    if (previous) retireVideoTexture(previous);
-
-    return () => {
-      if (heldRef.current !== next) return;
+    if (!presentation) {
+      disposeHeldVideoTexture(heldRef.current);
       heldRef.current = null;
-      setHandle((current) => (current === next.handle ? null : current));
-      retireVideoTexture(next);
+      setHandle(null);
+      return;
+    }
+    const lease = presentation.acquire();
+    if (!lease) return;
+    let held = heldRef.current;
+    if (!held) {
+      const texture = new THREE.Texture();
+      texture.colorSpace = THREE.SRGBColorSpace;
+      texture.generateMipmaps = false;
+      texture.magFilter = THREE.LinearFilter;
+      texture.minFilter = THREE.LinearFilter;
+      held = { currentLease: null, disposed: false, texture };
+      heldRef.current = held;
+    }
+    const previousLease = held.currentLease;
+    held.currentLease = lease;
+    held.texture.image = lease.source as TexImageSource;
+    // Reusing the texture keeps materials and WebGPU resources stable. The
+    // handle identity still changes so the demand-rendered scene invalidates.
+    held.texture.needsUpdate = true;
+    previousLease?.release();
+    const owned = held;
+    const next: ImageTextureHandle = {
+      aspectRatio: lease.width / Math.max(1, lease.height),
+      dispose: () => disposeHeldVideoTexture(owned),
+      imageHeight: lease.height,
+      imageWidth: lease.width,
+      retainWhenUnused: false,
+      texture: held.texture,
     };
+    setHandle(next);
+    onLoadedRef.current?.(next);
   }, [presentation]);
+
+  // This effect releases the stable texture and final presentation on unmount.
+  useEffect(
+    () => () => {
+      disposeHeldVideoTexture(heldRef.current);
+      heldRef.current = null;
+    },
+    [],
+  );
 
   return handle;
 }
 
-function retireVideoTexture(texture: HeldVideoTexture): void {
-  if (
-    typeof window === "undefined" ||
-    typeof window.requestAnimationFrame !== "function"
-  ) {
-    texture.handle.dispose();
-    return;
-  }
-  let disposed = false;
-  const dispose = () => {
-    if (disposed) return;
-    disposed = true;
-    window.clearTimeout(timeout);
-    texture.handle.dispose();
-  };
-  const timeout = window.setTimeout(dispose, VIDEO_TEXTURE_RETIRE_FALLBACK_MS);
-  window.requestAnimationFrame(() => {
-    window.requestAnimationFrame(dispose);
-  });
+function disposeHeldVideoTexture(held: HeldVideoTexture | null): void {
+  if (!held || held.disposed) return;
+  held.disposed = true;
+  held.texture.dispose();
+  held.currentLease?.release();
+  held.currentLease = null;
 }

--- a/app/packages/multimodal/src/visualization/media-2d/use-video-texture.ts
+++ b/app/packages/multimodal/src/visualization/media-2d/use-video-texture.ts
@@ -63,7 +63,13 @@ export function useVideoTexture(
     const owned = held;
     const next: ImageTextureHandle = {
       aspectRatio: lease.width / Math.max(1, lease.height),
-      dispose: () => disposeHeldVideoTexture(owned),
+      dispose: () => {
+        if (owned.currentLease !== lease) return;
+        disposeHeldVideoTexture(owned);
+        if (heldRef.current === owned) {
+          heldRef.current = null;
+        }
+      },
       imageHeight: lease.height,
       imageWidth: lease.width,
       retainWhenUnused: false,

--- a/app/packages/multimodal/src/visualization/media-2d/use-video-texture.ts
+++ b/app/packages/multimodal/src/visualization/media-2d/use-video-texture.ts
@@ -35,6 +35,15 @@ export function useVideoTexture(
     const lease = presentation.acquire();
     if (!lease) return;
     let held = heldRef.current;
+    if (
+      held?.currentLease &&
+      (held.currentLease.width !== lease.width ||
+        held.currentLease.height !== lease.height)
+    ) {
+      disposeHeldVideoTexture(held);
+      heldRef.current = null;
+      held = null;
+    }
     if (!held) {
       const texture = new THREE.Texture();
       texture.colorSpace = THREE.SRGBColorSpace;

--- a/app/packages/multimodal/src/visualization/scene-3d/scene-annotation-meshes.tsx
+++ b/app/packages/multimodal/src/visualization/scene-3d/scene-annotation-meshes.tsx
@@ -25,6 +25,7 @@ import {
   modelAssetForPrimitive,
 } from "./scene-models";
 import { useSceneEmphasis } from "./scene-emphasis";
+import { createScreenSpaceLineRaycast } from "./screen-space-line-raycast";
 import { scenePoseObjectTransform } from "./transforms";
 import type { SceneIndexedGeometryRenderData } from "./types";
 import {
@@ -231,6 +232,11 @@ export function SceneLineMesh({ line }: { readonly line: SceneLinePrimitive }) {
   const emphasis = useSceneEmphasis();
   const emphasized = emphasis !== "none";
   const invalidate = useThree((state) => state.invalidate);
+  const viewportHeightPx = useThree((state) => state.size.height);
+  const lineRaycast = useMemo(
+    () => createScreenSpaceLineRaycast(viewportHeightPx),
+    [viewportHeightPx],
+  );
   const renderData = useMemo(() => createSceneLineRenderData(line), [line]);
 
   useEffect(() => {
@@ -249,10 +255,12 @@ export function SceneLineMesh({ line }: { readonly line: SceneLinePrimitive }) {
     SCENE_LINE_OPACITY,
     emphasized,
   );
+  // Fiber and the app resolve distinct bundled-three raycast signatures.
+  const fiberLineRaycast = lineRaycast as never;
 
   return (
     <group position={transform.position} quaternion={transform.quaternion}>
-      <lineSegments frustumCulled={false}>
+      <lineSegments frustumCulled={false} raycast={fiberLineRaycast}>
         <primitive attach="geometry" object={renderData.geometry} />
         {emphasis === "selected" ? (
           <lineDashedMaterial

--- a/app/packages/multimodal/src/visualization/scene-3d/screen-space-line-raycast.test.ts
+++ b/app/packages/multimodal/src/visualization/scene-3d/screen-space-line-raycast.test.ts
@@ -1,0 +1,61 @@
+import * as THREE from "three";
+import { describe, expect, it } from "vitest";
+
+import { createScreenSpaceLineRaycast } from "./screen-space-line-raycast";
+
+const VIEWPORT_HEIGHT_PX = 1000;
+
+describe("createScreenSpaceLineRaycast", () => {
+  it("keeps a two-pixel perspective tolerance across distance", () => {
+    for (const distance of [10, 40]) {
+      const camera = new THREE.PerspectiveCamera(90, 1, 0.1, 1000);
+      camera.position.set(0, 0, distance);
+      camera.lookAt(0, 0, 0);
+      camera.updateMatrixWorld(true);
+      const line = pickableLine();
+
+      expect(intersectionsAtPixelOffset(line, camera, 1)).toHaveLength(1);
+      expect(intersectionsAtPixelOffset(line, camera, 4)).toHaveLength(0);
+    }
+  });
+
+  it("keeps the tolerance in screen space for an orthographic view", () => {
+    const camera = new THREE.OrthographicCamera(-5, 5, 5, -5, 0.1, 1000);
+    camera.zoom = 2;
+    camera.position.set(0, 0, 10);
+    camera.lookAt(0, 0, 0);
+    camera.updateProjectionMatrix();
+    camera.updateMatrixWorld(true);
+    const line = pickableLine();
+
+    expect(intersectionsAtPixelOffset(line, camera, 1)).toHaveLength(1);
+    expect(intersectionsAtPixelOffset(line, camera, 4)).toHaveLength(0);
+  });
+});
+
+function pickableLine(): THREE.LineSegments {
+  const geometry = new THREE.BufferGeometry().setFromPoints([
+    new THREE.Vector3(-1, 0, 0),
+    new THREE.Vector3(1, 0, 0),
+  ]);
+  const line = new THREE.LineSegments(geometry);
+  line.raycast = createScreenSpaceLineRaycast(VIEWPORT_HEIGHT_PX);
+  line.updateMatrixWorld(true);
+  return line;
+}
+
+function intersectionsAtPixelOffset(
+  line: THREE.LineSegments,
+  camera: THREE.Camera,
+  offsetPx: number,
+): THREE.Intersection[] {
+  const raycaster = new THREE.Raycaster();
+  raycaster.params.Line.threshold = 0.75;
+  raycaster.setFromCamera(
+    new THREE.Vector2(0, (offsetPx / VIEWPORT_HEIGHT_PX) * 2),
+    camera,
+  );
+  const intersections = raycaster.intersectObject(line);
+  expect(raycaster.params.Line.threshold).toBe(0.75);
+  return intersections;
+}

--- a/app/packages/multimodal/src/visualization/scene-3d/screen-space-line-raycast.ts
+++ b/app/packages/multimodal/src/visualization/scene-3d/screen-space-line-raycast.ts
@@ -1,0 +1,43 @@
+import * as THREE from "three";
+
+import { pointPickWorldThreshold } from "./point-picking";
+
+/** Interactive 3D line tolerance in CSS pixels. */
+const SCREEN_SPACE_LINE_PICK_RADIUS_PX = 2;
+
+type LineRaycast = (
+  this: THREE.LineSegments,
+  raycaster: THREE.Raycaster,
+  intersects: THREE.Intersection[],
+) => void;
+
+const lineSegmentsRaycast = THREE.LineSegments.prototype.raycast;
+
+/** Keeps line picking approximately constant in screen space across zoom. */
+export function createScreenSpaceLineRaycast(
+  viewportHeightPx: number,
+): LineRaycast {
+  const worldPosition = new THREE.Vector3();
+
+  return function raycast(raycaster, intersects) {
+    const camera = raycaster.camera;
+    if (!camera || viewportHeightPx <= 0) {
+      lineSegmentsRaycast.call(this, raycaster, intersects);
+      return;
+    }
+
+    const previousThreshold = raycaster.params.Line.threshold;
+    this.getWorldPosition(worldPosition);
+    raycaster.params.Line.threshold = pointPickWorldThreshold({
+      camera,
+      pickRadiusPx: SCREEN_SPACE_LINE_PICK_RADIUS_PX,
+      referenceDistance: raycaster.ray.origin.distanceTo(worldPosition),
+      viewportHeightPx,
+    });
+    try {
+      lineSegmentsRaycast.call(this, raycaster, intersects);
+    } finally {
+      raycaster.params.Line.threshold = previousThreshold;
+    }
+  };
+}


### PR DESCRIPTION
## 🔗 Related Issues

[FOEPD-4578](https://voxel51.atlassian.net/browse/FOEPD-4578)

## 📋 What changes are proposed in this pull request?

Reuse one renderer-owned texture per video tile and update its image source for each presentation. This removes per-frame WebGPU texture allocation and retirement that can race uploads and stall camera tiles under 3D label load.

Also replace the Three.js default one-world-unit line-picking threshold with an approximately two-CSS-pixel screen-space threshold for camera frustums, camera axes, and 3D annotation lines. This keeps camera and keypoint tooltips close to visible geometry across zoom levels.

## 🧪 How is this patch tested? If it is not, please explain why.

- `yarn vitest run --no-coverage packages/multimodal/src/video packages/multimodal/src/visualization/media-2d/use-video-texture.test.tsx packages/multimodal/src/visualization/media-2d/VideoPanel.test.tsx`
- `yarn vitest run --no-coverage packages/multimodal/src/visualization/scene-3d packages/multimodal/src/visualization/composition/CameraFrustumSceneLayer.test.ts`
- `yarn workspace @fiftyone/multimodal check`
- Manually played an MCAP sample with four H.264 camera streams and all eight 3D label streams enabled. Video frames advanced with the 3D pose and the browser reported no WebGPU texture-copy errors.
- Manually verified that camera-frustum and keypoint/skeleton tooltips activate only near their visible line geometry.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

MCAP video tiles no longer flicker or stall during playback when 3D labels are enabled. Camera and 3D-label line tooltips now activate only near the visible geometry.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other

[FOEPD-4578]: https://voxel51.atlassian.net/browse/FOEPD-4578?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3907
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved video texture reuse for smoother media updates and more efficient rendering.
  * Reduced unnecessary texture replacement when only the video source changes.

* **Bug Fixes**
  * Improved cleanup when video content is removed or components are unmounted.
  * Ensured textures and associated media resources are released reliably.
  * Improved handling when video dimensions change.
  * Improved selection accuracy for camera frustums, axes, and scene line annotations across different viewport and camera configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->