### PR TITLE
Fix shutdown race that dropped in-flight map_samples results

### DIFF
--- a/fiftyone/core/map/process.py
+++ b/fiftyone/core/map/process.py
@@ -40,6 +40,10 @@ R = TypeVar("R")
 U = TypeVar("U")
 
 
+class _BatchDone:
+    """Sentinel a worker enqueues after the last result of a batch."""
+
+
 class ProcessMapper(fomm.LocalMapper):
     """Executes map_samples using multiprocessing."""
 
@@ -87,7 +91,6 @@ class ProcessMapper(fomm.LocalMapper):
             lock = None
 
         queue = multiprocessing.Queue()
-        batch_count = multiprocessing.Value("i", 0)
         sample_count = (
             multiprocessing.Value("i", 0) if progress is not False else None
         )
@@ -115,7 +118,6 @@ class ProcessMapper(fomm.LocalMapper):
                 view_stages,
                 pickle.dumps(iter_fcn),
                 pickle.dumps(map_fcn),
-                batch_count,
                 sample_count,
                 queue,
                 cancel_event,
@@ -142,49 +144,41 @@ class ProcessMapper(fomm.LocalMapper):
 
             sample_errors: List[Tuple[bson.ObjectId, Exception, None]] = []
 
-            # Initialize backoff parameters
-            initial_timeout = 0.1
-            max_timeout = 5.0
-            backoff_factor = 2
-            current_timeout = initial_timeout
+            # Each batch enqueues a _BatchDone sentinel after its last
+            # result. Queue puts from a given worker arrive in order, so
+            # once every sentinel has been received no results can remain
+            # in flight.
+            num_batches_done = 0
 
-            while True:
+            while num_batches_done < num_batches:
                 try:
-                    sample_id, err, result = queue.get(timeout=current_timeout)
-                    # Reset backoff on successful get
-                    current_timeout = initial_timeout
+                    item = queue.get(timeout=1.0)
                 except Empty:
-                    # Apply exponential backoff, but cap at max_timeout
-                    current_timeout = min(
-                        current_timeout * backoff_factor, max_timeout
-                    )
+                    continue
 
-                    # Reset backoff if we've hit too many consecutive timeouts
-                    # This prevents getting stuck with very long timeouts
-                    if current_timeout == max_timeout:
-                        current_timeout = initial_timeout
+                if isinstance(item, _BatchDone):
+                    num_batches_done += 1
+                    continue
 
-                    # Check if done after applying backoff
-                    if batch_count.value >= num_batches:
-                        break
-                else:
-                    # Update progress bar
-                    pb.update()
+                sample_id, err, result = item
 
-                    if err is not None:
-                        # When skipping failures, simply yield the
-                        # sample ID and the error.
-                        if skip_failures:
-                            yield sample_id, err, None
-                        # When NOT skipping failures, aggregate any errors
-                        # to allow for all successfully mapped samples from
-                        # the various workers to be yielded first.
-                        else:
-                            sample_errors.append((sample_id, err, None))
+                # Update progress bar
+                pb.update()
 
+                if err is not None:
+                    # When skipping failures, simply yield the
+                    # sample ID and the error.
+                    if skip_failures:
+                        yield sample_id, err, None
+                    # When NOT skipping failures, aggregate any errors
+                    # to allow for all successfully mapped samples from
+                    # the various workers to be yielded first.
                     else:
-                        # Yield successfully mapped sample
-                        yield sample_id, None, result
+                        sample_errors.append((sample_id, err, None))
+
+                else:
+                    # Yield successfully mapped sample
+                    yield sample_id, None, result
 
             queue.close()
             queue.join_thread()
@@ -201,7 +195,6 @@ def _init_worker(
     view_stages: Any,
     iter_fcn: bytes,
     map_fcn: bytes,
-    batch_count: Optional[multiprocessing.Value],  # type: ignore
     sample_count: Optional[multiprocessing.Value],  # type: ignore
     queue: Optional[multiprocessing.Queue],
     cancel_event: multiprocessing.Event,  # type: ignore
@@ -222,7 +215,6 @@ def _init_worker(
     global process_sample_collection
     global process_iter_fcn
     global process_map_fcn
-    global process_batch_count
     global process_sample_count
     global process_queue
     global process_cancel_event
@@ -245,7 +237,6 @@ def _init_worker(
 
     process_map_fcn = pickle.loads(map_fcn)
     process_iter_fcn = pickle.loads(iter_fcn)
-    process_batch_count = batch_count
     process_sample_count = sample_count
     process_queue = queue
     process_cancel_event = cancel_event
@@ -295,6 +286,4 @@ def _map_batch(args: Tuple[int, int, fomb.SampleBatch]):
                 if pb is not None:
                     pb.update()
     finally:
-        if process_batch_count is not None:
-            with process_batch_count.get_lock():
-                process_batch_count.value += 1
+        process_queue.put(_BatchDone())

--- a/fiftyone/core/map/process.py
+++ b/fiftyone/core/map/process.py
@@ -180,6 +180,13 @@ class ProcessMapper(fomm.LocalMapper):
                     # Yield successfully mapped sample
                     yield sample_id, None, result
 
+            # All sentinels received means the workers are idle; join
+            # them so the context exit's terminate() never overlaps
+            # live worker processes (filelock>=3.30 installs a fork
+            # guard that aborts concurrent os.fork calls)
+            pool.close()
+            pool.join()
+
             queue.close()
             queue.join_thread()
 

--- a/fiftyone/core/map/threading.py
+++ b/fiftyone/core/map/threading.py
@@ -172,30 +172,23 @@ class ThreadMapper(fomm.LocalMapper):
             ) -> Iterator[R]:
                 sample_errors: List[Tuple[bson.ObjectId, Exception, None]] = []
 
-                # Initialize backoff parameters
-                initial_timeout = 0.1
-                max_timeout = 5.0
-                backoff_factor = 2
-                current_timeout = initial_timeout
-
                 while True:
+                    # Check for completion BEFORE reading from the queue.
+                    # Workers enqueue their results before setting their
+                    # done event, so an empty queue observed after all
+                    # events were already set cannot be hiding results.
+                    workers_done = not (
+                        evts := [e for e in evts if not e.is_set()]
+                    )
+
                     try:
-                        sample_id, err, result = q.get(timeout=current_timeout)
-                        # Reset backoff on successful get
-                        current_timeout = initial_timeout
-                    except queue.Empty:
-                        # Apply exponential backoff, but cap at max_timeout
-                        current_timeout = min(
-                            current_timeout * backoff_factor, max_timeout
+                        sample_id, err, result = (
+                            q.get_nowait()
+                            if workers_done
+                            else q.get(timeout=0.1)
                         )
-
-                        # Reset backoff if we've hit too many consecutive
-                        # timeouts This prevents getting stuck with very
-                        # long timeouts
-                        if current_timeout == max_timeout:
-                            current_timeout = initial_timeout
-
-                        if not (evts := [e for e in evts if not e.is_set()]):
+                    except queue.Empty:
+                        if workers_done:
                             break
                     else:
                         # An error was raised in the map_fcn for a sample


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes a shutdown race in both `map_samples` backends that could silently drop results still in flight when the parent decided all workers were done. Observed as a CI flake in a downstream repo: `test_map_fcn_err[skip_failures=False-save=True-process]` failed with `DID NOT RAISE Exception` because the worker's error tuple was dropped ([failing run](https://github.com/voxel51/fiftyone-teams/actions/runs/32621570904/job/97150411657)).

**`ProcessMapper`**: workers `put()` each result on a `multiprocessing.Queue` and then increment a shared `batch_count` when their batch finishes. `multiprocessing.Queue.put` is asynchronous (a feeder thread writes to the pipe later), so the parent could hit a `get()` timeout, see `batch_count == num_batches`, and break while results — including the error to raise when `skip_failures=False` — were still in flight. The shared counter is replaced with a `_BatchDone` sentinel each worker enqueues after its batch's last result; the parent reads until all sentinels are received. Per-worker queue ordering guarantees a sentinel cannot arrive before that worker's results, so nothing can be dropped, and the exponential-backoff polling collapses to a simple `get(timeout=1.0)` loop.

**`ThreadMapper`**: narrower version of the same window — a worker could enqueue a result and set its done event between the parent's `Empty` timeout and its event check. The parent now checks the done events *before* reading and only breaks on an empty queue observed after all events were already set (workers enqueue before setting their event, so that state cannot hide results).

## How is this patch tested?

- `tests/unittests/map/` passes (67 tests)
- The previously flaky parametrization passed 15/15 consecutive local stress runs

## What areas of FiftyOne does this PR affect?

- [ ] `App`: FiftyOne application changes
- [ ] `Build`: Build and test infrastructure changes

- [x] `Core`: Core `fiftyone` Python library changes
- [ ] `Documentation`: FiftyOne documentation changes
- [ ] `Other`

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3912
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process and thread result handling for more reliable worker completion detection.
  * Reduced delays when collecting results from completed workers.
  * Improved queue polling for more consistent batch processing and completion detection.
  * Ensured workers close cleanly after all processing is complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->