### PR TITLE
Downgrade googleapis-common-protos alongside protobuf in test_incompatible_protobuf

### DIFF
--- a/tests/isolated/protobuf_test.py
+++ b/tests/isolated/protobuf_test.py
@@ -39,8 +39,14 @@ def _current_version(package):
 def test_incompatible_protobuf():
     original_version = _current_version("protobuf")
 
+    # googleapis-common-protos>=1.75.2 generates its pb2 files with a protoc
+    # that requires protobuf>=6.33.5 at import time, so it must be downgraded
+    # in lockstep to isolate the incompatibility to protobuf itself
+    original_protos_version = _current_version("googleapis-common-protos")
+
     try:
         _pip_install("protobuf==4.25.9")
+        _pip_install("googleapis-common-protos==1.75.1")
 
         env = os.environ.copy()
         env.pop("VFF_MULTIMODAL", None)
@@ -61,3 +67,10 @@ def test_incompatible_protobuf():
             _pip_uninstall("protobuf")
         else:
             _pip_install(f"protobuf=={original_version}")
+
+        if original_protos_version is None:
+            _pip_uninstall("googleapis-common-protos")
+        else:
+            _pip_install(
+                f"googleapis-common-protos=={original_protos_version}"
+            )


### PR DESCRIPTION
## What

Pins `googleapis-common-protos==1.75.1` inside `test_incompatible_protobuf`'s protobuf-downgrade window, and restores the original version afterward, mirroring the existing protobuf handling.

## Why

`googleapis-common-protos 1.75.2` (released 2026-08-25) regenerated its pb2 files with a newer protoc: `google/rpc/error_details_pb2.py` now does `from google.protobuf import runtime_version`, which requires `protobuf>=6.33.5`. The test deliberately installs `protobuf==4.25.9`, so any import chain that reaches `google.api_core`/`google.rpc` under the downgraded protobuf now dies with `ImportError: cannot import name 'runtime_version'` instead of exercising fiftyone's graceful handling.

OSS CI currently passes because `import fiftyone` here never reaches `google.api_core`, but CI environments already resolve `googleapis-common-protos 1.75.2` from PyPI, so this test is one transitive-dependency change away from failing. Downstream repos whose import chains do reach `google.api_core` hit this today. Downgrading the protos package in lockstep keeps the test focused on the incompatibility it actually targets: protobuf itself.

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3916
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved protobuf compatibility testing by covering a specific dependency version combination.
  - Test setup now records the existing environment and restores it after execution, reducing side effects between test runs.
  - Added cleanup handling for environments where the dependency was not previously installed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->