### PR TITLE
Fix multimodal grid preview cadence and framing

### DIFF
--- a/app/packages/core/src/components/Actions/Options/MultimodalGridFitSetting.test.tsx
+++ b/app/packages/core/src/components/Actions/Options/MultimodalGridFitSetting.test.tsx
@@ -1,0 +1,75 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import MultimodalGridFitSetting from "./MultimodalGridFitSetting";
+
+const harness = vi.hoisted(() => ({
+  fit: "cover" as "contain" | "cover",
+  isMultimodal: false,
+  setFit: vi.fn(),
+}));
+
+vi.mock("@fiftyone/state", () => ({
+  isMultimodalDataset: Symbol("isMultimodalDataset"),
+  multimodalGridFit: Symbol("multimodalGridFit"),
+}));
+
+vi.mock("recoil", () => ({
+  useRecoilState: () => [harness.fit, harness.setFit],
+  useRecoilValue: () => harness.isMultimodal,
+}));
+
+vi.mock("@fiftyone/components", () => ({
+  PopoutSectionTitle: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  TabOption: ({
+    active,
+    options,
+  }: {
+    active: string;
+    options: Array<{
+      onClick: () => void;
+      text: string;
+      title: string;
+    }>;
+  }) => (
+    <div data-active={active} data-testid="fit-options">
+      {options.map((option) => (
+        <button
+          key={option.text}
+          onClick={option.onClick}
+          title={option.title}
+          type="button"
+        >
+          {option.text}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+afterEach(() => {
+  harness.fit = "cover";
+  harness.isMultimodal = false;
+  harness.setFit.mockClear();
+});
+
+describe("MultimodalGridFitSetting", () => {
+  it("stays hidden for non-multimodal datasets", () => {
+    render(<MultimodalGridFitSetting />);
+
+    expect(screen.queryByText("Multimodal media fit")).toBeNull();
+  });
+
+  it("defaults to cover and allows contain for multimodal datasets", () => {
+    harness.isMultimodal = true;
+
+    render(<MultimodalGridFitSetting />);
+
+    expect(screen.getByTestId("fit-options").dataset.active).toBe("cover");
+    fireEvent.click(screen.getByRole("button", { name: "contain" }));
+    expect(harness.setFit).toHaveBeenCalledWith("contain");
+  });
+});

--- a/app/packages/core/src/components/Actions/Options/MultimodalGridFitSetting.tsx
+++ b/app/packages/core/src/components/Actions/Options/MultimodalGridFitSetting.tsx
@@ -1,0 +1,32 @@
+import { PopoutSectionTitle, TabOption } from "@fiftyone/components";
+import * as fos from "@fiftyone/state";
+import { useRecoilState, useRecoilValue } from "recoil";
+
+const FIT_OPTIONS = ["cover", "contain"] as const;
+
+/** Cover/Contain control shown only for multimodal grid datasets. */
+export default function MultimodalGridFitSetting() {
+  const isMultimodal = useRecoilValue(fos.isMultimodalDataset);
+  return isMultimodal ? <FitSetting /> : null;
+}
+
+function FitSetting() {
+  const [fit, setFit] = useRecoilState(fos.multimodalGridFit);
+  return (
+    <>
+      <PopoutSectionTitle>Multimodal media fit</PopoutSectionTitle>
+      <TabOption
+        active={fit}
+        options={FIT_OPTIONS.map((value) => ({
+          dataCy: `multimodal-grid-fit-${value}`,
+          onClick: () => setFit(value),
+          text: value,
+          title:
+            value === "cover"
+              ? "Fill square grid tiles; content may be cropped"
+              : "Show the full frame with letterboxing",
+        }))}
+      />
+    </>
+  );
+}

--- a/app/packages/core/src/components/Actions/Options/Options.tsx
+++ b/app/packages/core/src/components/Actions/Options/Options.tsx
@@ -25,6 +25,7 @@ import RadioGroup from "../../Common/RadioGroup";
 import { gridAutosizing, maxGridItemsSizeBytes } from "../../Grid/recoil";
 import { ActionOption } from "../Common";
 import Popout from "../Popout";
+import MultimodalGridFitSetting from "./MultimodalGridFitSetting";
 
 const SortFilterResults = ({ modal }) => {
   const [{ count, asc }, setSortFilterResults] = useRecoilState(
@@ -354,6 +355,7 @@ const Grid = () => {
 
   return (
     <>
+      <MultimodalGridFitSetting />
       <ActionOption
         id="grid-options"
         href={MANAGING_GRID_MEMORY}

--- a/app/packages/multimodal/src/runtime/episode-preview.test.ts
+++ b/app/packages/multimodal/src/runtime/episode-preview.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  EPISODE_PREVIEW_MAX_FPS,
+  EpisodePreviewPlaybackScheduler,
+  episodePreviewPlaybackDelayMs,
+} from "./episode-preview";
+
+const DROID_FRAME_INTERVAL_NS = 70_990_566n;
+const DROID_LAST_FRAME_NS = 7_525_000_000n;
+
+describe("EpisodePreviewPlaybackScheduler", () => {
+  it("fairly caps deterministic 14.2fps input near 12fps at 1x source time", () => {
+    const result = scheduleSourceFrames(
+      sourceFrames(DROID_LAST_FRAME_NS, DROID_FRAME_INTERVAL_NS),
+    );
+    const finalWallTimeMs = result.wallTimesMs.at(-1);
+    const finalSourceTimeNs = result.sourceTimesNs.at(-1);
+    if (finalWallTimeMs === undefined || finalSourceTimeNs === undefined) {
+      throw new Error("expected scheduled DROID frames");
+    }
+    const durationSeconds = finalWallTimeMs / 1_000;
+    const presentedFps = (result.sourceTimesNs.length - 1) / durationSeconds;
+    const sourceProgress =
+      Number(finalSourceTimeNs) / 1_000_000 / finalWallTimeMs;
+
+    expect(presentedFps).toBeGreaterThanOrEqual(10);
+    expect(presentedFps).toBeLessThanOrEqual(EPISODE_PREVIEW_MAX_FPS + 0.01);
+    expect(sourceProgress).toBeGreaterThanOrEqual(0.98);
+    expect(sourceProgress).toBeLessThanOrEqual(1.02);
+    expect(result.skipped).toBeGreaterThan(0);
+    expect(result.skipped).toBeLessThan(result.sourceTimesNs.length);
+  });
+
+  it("presents every lower-rate frame at its recorded cadence", () => {
+    const frames = sourceFrames(2_000_000_000n, 200_000_000n);
+    const result = scheduleSourceFrames(frames);
+
+    expect(result.skipped).toBe(0);
+    expect(result.sourceTimesNs).toEqual(frames);
+    expect(result.wallTimesMs).toEqual(
+      frames.map((frameTimeNs) => Number(frameTimeNs) / 1_000_000),
+    );
+  });
+
+  it("can flush the final source frame before a wrap", () => {
+    const scheduler = new EpisodePreviewPlaybackScheduler();
+    scheduler.reset(0n, 0);
+    let wallTimeMs = 0;
+    let lastDecision: number | null = null;
+    for (let index = 1; index <= 7; index += 1) {
+      const frameTimeNs = BigInt(index) * DROID_FRAME_INTERVAL_NS;
+      lastDecision = scheduler.nextDelayMs(frameTimeNs, wallTimeMs);
+      if (lastDecision !== null) {
+        wallTimeMs += lastDecision;
+        scheduler.markPresented(frameTimeNs, wallTimeMs);
+      }
+    }
+    expect(lastDecision).toBeNull();
+
+    const finalFrameTimeNs = 7n * DROID_FRAME_INTERVAL_NS;
+    const flushDelayMs = scheduler.nextDelayMs(
+      finalFrameTimeNs,
+      wallTimeMs,
+      true,
+    );
+    expect(flushDelayMs).not.toBeNull();
+    wallTimeMs += flushDelayMs ?? 0;
+    scheduler.markPresented(finalFrameTimeNs, wallTimeMs);
+  });
+
+  it("does not reject an isolated sub-cap source interval", () => {
+    expect(episodePreviewPlaybackDelayMs(0n, 70_000_000n, 0)).toBeCloseTo(
+      1_000 / EPISODE_PREVIEW_MAX_FPS,
+    );
+  });
+});
+
+function sourceFrames(lastFrameNs: bigint, intervalNs: bigint): bigint[] {
+  const frames = [0n];
+  for (
+    let frameTimeNs = intervalNs;
+    frameTimeNs < lastFrameNs;
+    frameTimeNs += intervalNs
+  ) {
+    frames.push(frameTimeNs);
+  }
+  frames.push(lastFrameNs);
+  return frames;
+}
+
+function scheduleSourceFrames(frames: readonly bigint[]) {
+  const firstFrame = frames[0];
+  if (firstFrame === undefined) throw new Error("expected source frames");
+  const scheduler = new EpisodePreviewPlaybackScheduler();
+  const sourceTimesNs = [firstFrame];
+  const wallTimesMs = [0];
+  let skipped = 0;
+  let wallTimeMs = 0;
+  scheduler.reset(firstFrame, wallTimeMs);
+
+  for (const frameTimeNs of frames.slice(1)) {
+    const delayMs = scheduler.nextDelayMs(frameTimeNs, wallTimeMs);
+    if (delayMs === null) {
+      skipped += 1;
+      continue;
+    }
+    wallTimeMs += delayMs;
+    scheduler.markPresented(frameTimeNs, wallTimeMs);
+    sourceTimesNs.push(frameTimeNs);
+    wallTimesMs.push(wallTimeMs);
+  }
+
+  return { skipped, sourceTimesNs, wallTimesMs };
+}

--- a/app/packages/multimodal/src/runtime/episode-preview.ts
+++ b/app/packages/multimodal/src/runtime/episode-preview.ts
@@ -3,26 +3,95 @@ export const EPISODE_PREVIEW_MAX_FPS = 12;
 
 const NANOSECONDS_PER_MILLISECOND = 1_000_000;
 const MIN_FRAME_DELAY_MS = 1_000 / EPISODE_PREVIEW_MAX_FPS;
+const SCHEDULER_EPSILON_MS = 1e-6;
 
 /**
- * Returns the wall-clock delay before presenting a preview frame. A `null`
- * result means the frame should be skipped to preserve one-times playback.
+ * Stateful 1x timeline scheduler for a pull-based preview stream.
+ *
+ * Frames normally occupy consecutive 12fps wall-clock slots. When that would
+ * leave playback at least one whole slot behind source time, the stale input
+ * is skipped and the next source frame reuses the slot. This distributes
+ * drops across a faster source instead of rejecting every sub-83ms interval.
+ */
+export class EpisodePreviewPlaybackScheduler {
+  private anchorSourceTimeNs: bigint | undefined;
+  private anchorWallTimeMs: number | undefined;
+  private lastPresentedAtMs: number | undefined;
+
+  reset(frameTimeNs: bigint | undefined, presentedAtMs: number): void {
+    this.anchorSourceTimeNs = frameTimeNs;
+    this.anchorWallTimeMs =
+      frameTimeNs === undefined ? undefined : presentedAtMs;
+    this.lastPresentedAtMs =
+      frameTimeNs === undefined ? undefined : presentedAtMs;
+  }
+
+  /** Returns a delay for a presentation slot, or null when this input is stale. */
+  nextDelayMs(
+    frameTimeNs: bigint | undefined,
+    nowMs: number,
+    force = false,
+  ): number | null {
+    if (
+      frameTimeNs === undefined ||
+      this.anchorSourceTimeNs === undefined ||
+      this.anchorWallTimeMs === undefined ||
+      this.lastPresentedAtMs === undefined
+    ) {
+      return this.lastPresentedAtMs === undefined
+        ? 0
+        : Math.max(0, this.lastPresentedAtMs + MIN_FRAME_DELAY_MS - nowMs);
+    }
+
+    const sourceDueAtMs =
+      this.anchorWallTimeMs +
+      Number(frameTimeNs - this.anchorSourceTimeNs) /
+        NANOSECONDS_PER_MILLISECOND;
+    const targetAtMs = Math.max(
+      sourceDueAtMs,
+      this.lastPresentedAtMs + MIN_FRAME_DELAY_MS,
+      nowMs,
+    );
+    if (
+      !force &&
+      targetAtMs - sourceDueAtMs >= MIN_FRAME_DELAY_MS - SCHEDULER_EPSILON_MS
+    ) {
+      return null;
+    }
+
+    return Math.max(0, targetAtMs - nowMs);
+  }
+
+  /** Commits the actual wall time after the scheduled delay settles. */
+  markPresented(frameTimeNs: bigint | undefined, presentedAtMs: number): void {
+    if (
+      frameTimeNs !== undefined &&
+      (this.anchorSourceTimeNs === undefined ||
+        this.anchorWallTimeMs === undefined)
+    ) {
+      this.anchorSourceTimeNs = frameTimeNs;
+      this.anchorWallTimeMs = presentedAtMs;
+    }
+    this.lastPresentedAtMs = presentedAtMs;
+  }
+}
+
+/**
+ * Returns a one-step wall-clock delay before presenting a preview frame.
+ * Sequence playback must use {@link EpisodePreviewPlaybackScheduler} so
+ * sub-cap source intervals accumulate phase and distribute skips fairly.
  */
 export function episodePreviewPlaybackDelayMs(
   previousFrameTimeNs: bigint | undefined,
   frameTimeNs: bigint | undefined,
   elapsedMs = 0,
-): number | null {
+): number {
   const timelineDelayMs =
     previousFrameTimeNs !== undefined &&
     frameTimeNs !== undefined &&
     frameTimeNs > previousFrameTimeNs
       ? Number(frameTimeNs - previousFrameTimeNs) / NANOSECONDS_PER_MILLISECOND
       : 0;
-
-  if (timelineDelayMs > 0 && timelineDelayMs < MIN_FRAME_DELAY_MS) {
-    return null;
-  }
 
   return Math.max(0, Math.max(MIN_FRAME_DELAY_MS, timelineDelayMs) - elapsedMs);
 }

--- a/app/packages/multimodal/src/testing/integration/GridRenderer.integration.test.tsx
+++ b/app/packages/multimodal/src/testing/integration/GridRenderer.integration.test.tsx
@@ -1,4 +1,5 @@
 import type { SampleRendererProps } from "@fiftyone/plugins";
+import { multimodalGridFit } from "@fiftyone/state";
 import {
   act,
   cleanup,
@@ -8,6 +9,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { RecoilRoot, useSetRecoilState } from "recoil";
 import { createFixtureFormatAdapter } from "../../adapters/fixture";
 import type {
   ByteResources,
@@ -69,8 +71,22 @@ vi.mock("../../views/episode/grid/grid-camera-state", () => ({
 
 vi.mock("../../visualization/media-2d/BitmapImageView", () => ({
   BitmapCanvasHost: () => <div data-testid="fixture-grid-point-cloud" />,
-  BitmapImageView: () => <div data-testid="fixture-grid-cached-image" />,
-  BitmapImageFrameView: () => <div data-testid="fixture-grid-image" />,
+  BitmapImageView: ({
+    bytes,
+    fit,
+  }: {
+    bytes: Uint8Array;
+    fit: "contain" | "cover";
+  }) => (
+    <div
+      data-fit={fit}
+      data-first-byte={bytes[0]}
+      data-testid="fixture-grid-cached-image"
+    />
+  ),
+  BitmapImageFrameView: ({ fit }: { fit: "contain" | "cover" }) => (
+    <div data-fit={fit} data-testid="fixture-grid-image" />
+  ),
 }));
 
 vi.mock("../../visualization/composition", async (importOriginal) => ({
@@ -111,16 +127,9 @@ afterEach(() => {
 
 describe("fixture adapter through the production grid renderer", () => {
   it("loads and renders a fixture preview through the preview-session port", async () => {
-    harness.episodeSource = episodeSource;
-    harness.previewSession =
-      (await createFixtureFormatAdapter().openPreview?.(episodeSource, io)) ??
-      null;
-    if (!harness.previewSession) {
-      throw new Error("Fixture preview session did not open");
-    }
-    const read = vi.spyOn(harness.previewSession, "read");
+    const read = await openFixturePreview();
 
-    render(<GridRenderer ctx={rendererContext()} />);
+    renderGrid();
 
     await waitFor(() => {
       expect(screen.getByTestId("fixture-grid-image")).toBeTruthy();
@@ -132,38 +141,16 @@ describe("fixture adapter through the production grid renderer", () => {
   });
 
   it("hydrates a remounted tile without opening or reading its preview session", async () => {
-    harness.episodeSource = episodeSource;
-    harness.previewSession =
-      (await createFixtureFormatAdapter().openPreview?.(episodeSource, io)) ??
-      null;
-    if (!harness.previewSession) {
-      throw new Error("Fixture preview session did not open");
-    }
-    const read = vi.spyOn(harness.previewSession, "read");
+    const read = await openFixturePreview();
     resetGridPosterCacheForTests({ maxSizeBytes: 10_000 });
-    const key = gridPosterCacheKey({
-      datasetId: "fixture-dataset",
-      mediaField: "recording",
-      selectedSourceName: null,
-      source: harness.byteSource,
-    });
-    getGridPosterCache().put(key, {
-      bytes: new Uint8Array([1, 2, 3]),
-      height: 100,
-      mimeType: "image/webp",
-      sourceKind: "image",
-      streamId: "fixture-camera",
-      streamSourceName: "/fixture/camera",
-      streamSourceNames: ["/fixture/camera"],
-      width: 100,
-    });
+    cacheFixturePoster("cover", [1, 2, 3]);
 
-    const first = render(<GridRenderer ctx={rendererContext()} />);
+    const first = renderGrid();
     await waitFor(() => {
       expect(screen.getByTestId("fixture-grid-cached-image")).toBeTruthy();
     });
     first.unmount();
-    const remounted = render(<GridRenderer ctx={rendererContext()} />);
+    const remounted = renderGrid();
     await waitFor(() => {
       expect(screen.getByTestId("fixture-grid-cached-image")).toBeTruthy();
     });
@@ -187,7 +174,135 @@ describe("fixture adapter through the production grid renderer", () => {
     });
     expect(read).toHaveBeenCalledTimes(1);
   });
+
+  it("reuses fit-specific posters without reopening the preview session", async () => {
+    const read = await openFixturePreview();
+    resetGridPosterCacheForTests({ maxSizeBytes: 10_000 });
+    for (const [fit, firstByte] of [
+      ["cover", 1],
+      ["contain", 2],
+    ] as const) {
+      cacheFixturePoster(fit, [firstByte]);
+    }
+
+    renderGridWithFitControls();
+
+    await expectCachedFit("cover", "1");
+    fireEvent.click(screen.getByRole("button", { name: "use contain" }));
+    await expectCachedFit("contain", "2");
+    fireEvent.click(screen.getByRole("button", { name: "use cover" }));
+    await expectCachedFit("cover", "1");
+
+    expect(read).not.toHaveBeenCalled();
+    expect(harness.sessionEnabled.every((enabled) => enabled === false)).toBe(
+      true,
+    );
+    expect(getGridPosterCache().stats().entryCount).toBe(2);
+  });
+
+  it("retains a loaded frame when an uncached fit is selected", async () => {
+    const read = await openFixturePreview();
+    resetGridPosterCacheForTests({ maxSizeBytes: 10_000 });
+    cacheFixturePoster("cover", [1]);
+
+    renderGridWithFitControls();
+    const poster = await screen.findByTestId("fixture-grid-cached-image");
+    const root = poster.parentElement;
+    if (!root) throw new Error("Expected the grid renderer root");
+
+    fireEvent.pointerEnter(root);
+    await waitFor(() => {
+      expect(read).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId("fixture-grid-image").dataset.fit).toBe(
+        "cover",
+      );
+    });
+    fireEvent.pointerLeave(root);
+    fireEvent.click(screen.getByRole("button", { name: "use contain" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("fixture-grid-image").dataset.fit).toBe(
+        "contain",
+      );
+    });
+    expect(read).toHaveBeenCalledTimes(1);
+  });
 });
+
+function renderGrid() {
+  return render(
+    <RecoilRoot>
+      <GridRenderer ctx={rendererContext()} />
+    </RecoilRoot>,
+  );
+}
+
+function renderGridWithFitControls() {
+  return render(
+    <RecoilRoot>
+      <FitControls />
+      <GridRenderer ctx={rendererContext()} />
+    </RecoilRoot>,
+  );
+}
+
+function FitControls() {
+  const setFit = useSetRecoilState(multimodalGridFit);
+  return (
+    <>
+      <button onClick={() => setFit("contain")} type="button">
+        use contain
+      </button>
+      <button onClick={() => setFit("cover")} type="button">
+        use cover
+      </button>
+    </>
+  );
+}
+
+async function expectCachedFit(fit: "contain" | "cover", firstByte: string) {
+  await waitFor(() => {
+    const image = screen.getByTestId("fixture-grid-cached-image");
+    expect(image.dataset.fit).toBe(fit);
+    expect(image.dataset.firstByte).toBe(firstByte);
+  });
+}
+
+async function openFixturePreview() {
+  harness.episodeSource = episodeSource;
+  harness.previewSession =
+    (await createFixtureFormatAdapter().openPreview?.(episodeSource, io)) ??
+    null;
+  if (!harness.previewSession) {
+    throw new Error("Fixture preview session did not open");
+  }
+  return vi.spyOn(harness.previewSession, "read");
+}
+
+function cacheFixturePoster(
+  fit: "contain" | "cover",
+  bytes: readonly number[],
+) {
+  getGridPosterCache().put(
+    gridPosterCacheKey({
+      datasetId: "fixture-dataset",
+      imageFit: fit,
+      mediaField: "recording",
+      selectedSourceName: null,
+      source: harness.byteSource,
+    }),
+    {
+      bytes: new Uint8Array(bytes),
+      height: 100,
+      mimeType: "image/webp",
+      sourceKind: "image",
+      streamId: "fixture-camera",
+      streamSourceName: "/fixture/camera",
+      streamSourceNames: ["/fixture/camera"],
+      width: 100,
+    },
+  );
+}
 
 function rendererContext(): SampleRendererProps["ctx"] {
   return {

--- a/app/packages/multimodal/src/video/stream-engine.test.ts
+++ b/app/packages/multimodal/src/video/stream-engine.test.ts
@@ -272,7 +272,7 @@ describe("VideoPlaybackManager and VideoStreamEngine", () => {
     lease.release();
   });
 
-  it("closes stale submitted output and never runs an obsolete decode tail", async () => {
+  it("closes stale submitted output for a discontinuous seek", async () => {
     const firstDecode = deferred<VideoFrame>();
     const harness = createHarness({ firstDecode });
     const manager = new VideoPlaybackManager("source", harness.dependencies);
@@ -281,18 +281,72 @@ describe("VideoPlaybackManager and VideoStreamEngine", () => {
     await vi.waitFor(() =>
       expect(harness.decoders[0].decodeCalls).toHaveLength(1),
     );
-    lease.request({ ...accessUnit(2, true), priority: "playing" });
-    lease.request({ ...accessUnit(3, true), priority: "playing" });
+    lease.request({
+      ...accessUnit(1_000_000_000, true),
+      priority: "playing",
+    });
+    lease.request({
+      ...accessUnit(2_000_000_000, true),
+      priority: "playing",
+    });
 
     const stale = fakeVideoFrame();
     firstDecode.resolve(stale.frame);
-    await presented(lease, 3n);
+    await presented(lease, 2_000_000_000n);
 
     expect(stale.close).toHaveBeenCalledOnce();
     expect(harness.decoders[0].decodeCalls.map((call) => call.target)).toEqual([
       1n,
-      3n,
+      2_000_000_000n,
     ]);
+    lease.release();
+  });
+
+  it("keeps publishing while H.264 copies lag continuous forward input", async () => {
+    const copyGates = new Map<bigint, ReturnType<typeof deferred<void>>>();
+    const harness = createHarness({
+      beforeCopy: async (timeNs) => {
+        const gate = deferred<void>();
+        copyGates.set(timeNs, gate);
+        await gate.promise;
+      },
+    });
+    const frameIntervalNs = 70_422_535;
+    const units = Array.from({ length: 10 }, (_, index) =>
+      accessUnit(index * frameIntervalNs, index % 5 === 0),
+    );
+    const manager = new VideoPlaybackManager("source", harness.dependencies);
+    manager.setReader(rangeReader(units));
+    const lease = manager.acquire("/camera");
+    const published: bigint[] = [];
+    let lastPresentedTimeNs: bigint | null = null;
+    const unsubscribe = lease.subscribe(() => {
+      const presentedTimeNs = lease.getSnapshot().presentedTimeNs;
+      if (presentedTimeNs !== null && presentedTimeNs !== lastPresentedTimeNs) {
+        lastPresentedTimeNs = presentedTimeNs;
+        published.push(presentedTimeNs);
+      }
+    });
+
+    lease.request({ ...units[0], priority: "playing" });
+    for (let index = 1; index < units.length; index += 1) {
+      const previousTimeNs = units[index - 1].timeNs;
+      await vi.waitFor(() => expect(copyGates.has(previousTimeNs)).toBe(true));
+      // Models an 83ms grid request arriving before a >83ms bitmap copy. The
+      // producer never pauses, so a burst-only latest-wins test cannot pass it.
+      lease.request({ ...units[index], priority: "playing" });
+      copyGates.get(previousTimeNs)?.resolve();
+    }
+    const lastUnit = units.at(-1);
+    const penultimateUnit = units.at(-2);
+    if (!lastUnit || !penultimateUnit) throw new Error("expected churn units");
+    await vi.waitFor(() => expect(copyGates.has(lastUnit.timeNs)).toBe(true));
+
+    expect(published.length).toBeGreaterThanOrEqual(units.length - 1);
+    expect(published.at(-1)).toBe(penultimateUnit.timeNs);
+
+    copyGates.get(lastUnit.timeNs)?.resolve();
+    unsubscribe();
     lease.release();
   });
 
@@ -356,20 +410,26 @@ describe("VideoPlaybackManager and VideoStreamEngine", () => {
       expect(harness.decoders[0].decodeCalls).toHaveLength(1),
     );
 
-    lease.request({ ...accessUnit(10, true), priority: "playing" });
+    lease.request({
+      ...accessUnit(1_000_000_000, true),
+      priority: "playing",
+    });
     await vi.waitFor(() =>
       expect(harness.decoders[0].decodeCalls).toHaveLength(2),
     );
     gate.resolve();
-    await presented(lease, 10n);
-    lease.request({ ...accessUnit(11), priority: "playing" });
-    await presented(lease, 11n);
-    lease.request({ ...accessUnit(12), priority: "playing" });
-    await presented(lease, 12n);
+    await presented(lease, 1_000_000_000n);
+    lease.request({ ...accessUnit(1_000_000_001), priority: "playing" });
+    await presented(lease, 1_000_000_001n);
+    lease.request({ ...accessUnit(1_000_000_002), priority: "playing" });
+    await presented(lease, 1_000_000_002n);
 
     expect(read).toHaveBeenCalledOnce();
     expect(read).toHaveBeenCalledWith(
-      expect.objectContaining({ endTimeNs: 11n, startTimeNs: 11n }),
+      expect.objectContaining({
+        endTimeNs: 1_000_000_001n,
+        startTimeNs: 1_000_000_001n,
+      }),
     );
     lease.release();
   });
@@ -508,6 +568,7 @@ describe("VideoPlaybackManager and VideoStreamEngine", () => {
 function createHarness(
   options: {
     readonly beforeDecode?: (id: string, targetTimeNs: bigint) => Promise<void>;
+    readonly beforeCopy?: (timeNs: bigint) => Promise<void>;
     readonly decodeGate?: Promise<void>;
     readonly firstDecode?: ReturnType<typeof deferred<VideoFrame>>;
     readonly honorAbort?: boolean;
@@ -518,6 +579,7 @@ function createHarness(
   const presentationSources: Array<{ close: ReturnType<typeof vi.fn> }> = [];
   const dependencies: VideoEngineDependencies = {
     copyPresentation: async (frame, timeNs) => {
+      await options.beforeCopy?.(timeNs);
       frame.close();
       const source = { close: vi.fn(), height: 480, width: 640 };
       presentationSources.push(source);
@@ -561,6 +623,7 @@ class FakeDecoderActor implements VideoDecoderActor {
         id: string,
         targetTimeNs: bigint,
       ) => Promise<void>;
+      readonly beforeCopy?: (timeNs: bigint) => Promise<void>;
       readonly decodeGate?: Promise<void>;
       readonly firstDecode?: ReturnType<typeof deferred<VideoFrame>>;
       readonly honorAbort?: boolean;

--- a/app/packages/multimodal/src/video/stream-engine.ts
+++ b/app/packages/multimodal/src/video/stream-engine.ts
@@ -43,6 +43,7 @@ const INITIAL_SNAPSHOT: VideoStreamSnapshot = {
 /** One source/stream cursor with one serialized decoder actor. */
 export class VideoStreamEngine {
   private activeController: AbortController | null = null;
+  private activeForwardPublicationProtected = false;
   private readonly cache: EncodedAccessUnitCache;
   private closed = false;
   private continuityUncertain = false;
@@ -104,11 +105,13 @@ export class VideoStreamEngine {
       return;
     }
 
+    const retainActiveForwardPublication =
+      this.shouldRetainActiveForwardPublication(intent.timeNs);
     this.requestedTargetTimeNs = intent.timeNs;
     this.requestedPriority = intent.priority;
     this.generation += 1;
     this.latestIntent = intent;
-    if (this.activeController) {
+    if (this.activeController && !retainActiveForwardPublication) {
       this.continuityUncertain = true;
       this.activeController.abort();
     }
@@ -119,6 +122,7 @@ export class VideoStreamEngine {
         this.decoder.cursorTimeNs === null ? "seeking.locating" : "forward",
       targetTimeNs: intent.timeNs,
     });
+    if (retainActiveForwardPublication) return;
     void this.pump();
   }
 
@@ -266,6 +270,7 @@ export class VideoStreamEngine {
         });
       }
 
+      this.activeForwardPublicationProtected = true;
       const decoded = await this.decodeWithOneRecovery(
         units,
         intent,
@@ -273,7 +278,7 @@ export class VideoStreamEngine {
         signal,
       );
       if (directForward) this.observeForwardCadence(cursorTimeNs, units);
-      if (signal.aborted || generation !== this.generation) {
+      if (signal.aborted) {
         decoded.close();
         throw new VideoIntentCancelledError();
       }
@@ -289,25 +294,38 @@ export class VideoStreamEngine {
         decoded.close();
         throw error;
       }
-      if (signal.aborted || generation !== this.generation || this.closed) {
+      if (signal.aborted || this.closed) {
         presentation.releaseOwner();
         throw new VideoIntentCancelledError();
       }
       const previous = this.snapshot
         .presentation as OwnedVideoPresentation | null;
+      const publicationGeneration = this.generation;
       this.snapshot = {
         diagnostic: null,
-        generation,
+        generation: publicationGeneration,
         phase: "forward",
         presentation,
         presentedTimeNs: intent.timeNs,
-        targetTimeNs: intent.timeNs,
+        targetTimeNs: this.requestedTargetTimeNs ?? intent.timeNs,
       };
       this.emit();
       previous?.releaseOwner();
     } finally {
+      this.activeForwardPublicationProtected = false;
       releaseAdmission?.();
     }
+  }
+
+  private shouldRetainActiveForwardPublication(timeNs: bigint): boolean {
+    const previousTargetTimeNs = this.requestedTargetTimeNs;
+    return (
+      this.activeController !== null &&
+      this.activeForwardPublicationProtected &&
+      previousTargetTimeNs !== null &&
+      timeNs > previousTargetTimeNs &&
+      timeNs - previousTargetTimeNs <= MAX_DIRECT_FORWARD_GAP_NS
+    );
   }
 
   private async decodeWithOneRecovery(

--- a/app/packages/multimodal/src/views/episode/grid/GridRenderer.test.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/GridRenderer.test.tsx
@@ -7,7 +7,8 @@ import {
   waitFor,
 } from "@testing-library/react";
 import type { ReactElement } from "react";
-import { RecoilRoot } from "recoil";
+import { RecoilRoot, useSetRecoilState } from "recoil";
+import { multimodalGridFit } from "@fiftyone/state";
 import { publishMcapEmbeddingSelection } from "../../../extensions/timeline";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -22,7 +23,7 @@ import {
 } from "../../../visualization/webgpu/webgpu-live-lease";
 import type { ByteSourceDescriptor, EpisodePosterFrame } from "../../../ir";
 import {
-  gridPosterCacheKey,
+  gridPreviewStateKey,
   pointCloudPoseKey,
   type GridPosterCacheEntry,
 } from "./grid-poster-cache";
@@ -43,6 +44,30 @@ import type {
 // the tile read the embeddings panel's published match for its episode.
 function render(ui: ReactElement) {
   return renderBare(ui, { wrapper: RecoilRoot });
+}
+
+function renderWithGridFit(ui: ReactElement, fit: "contain" | "cover") {
+  return renderBare(
+    <RecoilRoot initializeState={({ set }) => set(multimodalGridFit, fit)}>
+      {ui}
+    </RecoilRoot>,
+  );
+}
+
+let setGridFit: ((fit: "contain" | "cover") => void) | null = null;
+
+function renderWithMutableGridFit(ui: ReactElement) {
+  return renderBare(
+    <RecoilRoot>
+      <GridFitController />
+      {ui}
+    </RecoilRoot>,
+  );
+}
+
+function GridFitController() {
+  setGridFit = useSetRecoilState(multimodalGridFit);
+  return null;
 }
 
 type PublishedWindows = Record<
@@ -74,11 +99,20 @@ const previewHarness = vi.hoisted(() => ({
 }));
 
 const bitmapViewHarness = vi.hoisted(() => ({
+  commitOnFitEffect: false,
   lastProps: null as {
     fit?: string;
     frame: Extract<EpisodePosterFrame, { kind: "image" }>["image"];
     onBitmapRetainedBytesChange?: (retainedBytes: number) => void;
+    onCanvasCommitted?: (
+      canvas: HTMLCanvasElement,
+      size: { readonly height: number; readonly width: number },
+    ) => void;
   } | null,
+}));
+
+const cachedBitmapViewHarness = vi.hoisted(() => ({
+  fit: null as string | null,
 }));
 
 const bitmapHostHarness = vi.hoisted(() => ({
@@ -216,9 +250,11 @@ vi.mock("../../../visualization/media-2d/BitmapImageView", async () => {
       );
     },
     BitmapImageView: (props: {
+      readonly fit?: string;
       readonly onBitmapRetainedBytesChange?: (retainedBytes: number) => void;
     }) => {
-      const { onBitmapRetainedBytesChange } = props;
+      const { fit, onBitmapRetainedBytesChange } = props;
+      cachedBitmapViewHarness.fit = fit ?? null;
       useEffect(() => {
         onBitmapRetainedBytesChange?.(320 * 180 * 4);
       }, [onBitmapRetainedBytesChange]);
@@ -228,13 +264,26 @@ vi.mock("../../../visualization/media-2d/BitmapImageView", async () => {
       readonly fit?: string;
       readonly frame: Extract<EpisodePosterFrame, { kind: "image" }>["image"];
       readonly onBitmapRetainedBytesChange?: (retainedBytes: number) => void;
+      readonly onCanvasCommitted?: (
+        canvas: HTMLCanvasElement,
+        size: { readonly height: number; readonly width: number },
+      ) => void;
     }) => {
       bitmapViewHarness.lastProps = props;
-      const { onBitmapRetainedBytesChange } = props;
+      const { fit, onBitmapRetainedBytesChange, onCanvasCommitted } = props;
       // This effect reports decoded bitmap retention like the real view does.
       useEffect(() => {
         onBitmapRetainedBytesChange?.(640 * 480 * 4);
       }, [onBitmapRetainedBytesChange]);
+      // This effect mirrors the real bitmap view's fit-triggered canvas commit.
+      useEffect(() => {
+        if (bitmapViewHarness.commitOnFitEffect) {
+          onCanvasCommitted?.(document.createElement("canvas"), {
+            height: 100,
+            width: 100,
+          });
+        }
+      }, [fit, onCanvasCommitted]);
       return <div data-testid="bitmap-image-view" />;
     },
   };
@@ -259,7 +308,10 @@ afterEach(() => {
   resetGraphicsRendererRegistryForTests();
   bitmapHostHarness.lastBitmap = null;
   bitmapHostHarness.onCanvasCommitted = null;
+  cachedBitmapViewHarness.fit = null;
+  bitmapViewHarness.commitOnFitEffect = false;
   bitmapViewHarness.lastProps = null;
+  setGridFit = null;
   cameraPoseHarness.pose = null;
   previewHarness.preview.error = null;
   previewHarness.preview.cachedPoster = null;
@@ -354,7 +406,7 @@ describe("GridRenderer", () => {
     render(<GridRenderer ctx={rendererCtx()} />);
 
     expect(vi.mocked(useGridPreview).mock.lastCall?.[0].cacheRequestKey).toBe(
-      gridPosterCacheKey({
+      gridPreviewStateKey({
         datasetId: "dataset-id",
         mediaField: undefined,
         selectedSourceName: null,
@@ -453,6 +505,7 @@ describe("GridRenderer", () => {
     );
 
     expect(screen.getByTestId("bitmap-cached-image-view")).toBeTruthy();
+    expect(cachedBitmapViewHarness.fit).toBe("cover");
     const root = getGridRendererRoot(container);
     expect(root.classList.contains(classes.modalActivationSurface)).toBe(false);
     fireEvent.click(root);
@@ -501,6 +554,40 @@ describe("GridRenderer", () => {
     expect(bitmapViewHarness.lastProps.frame.bytes).toBe(bytes);
     expect(bitmapViewHarness.lastProps?.fit).toBe("cover");
     expect(bitmapViewHarness.lastProps.frame.mimeType).toBe("image/jpeg");
+  });
+
+  it("honors the contain fit setting for multimodal grid frames", () => {
+    previewHarness.preview.frame = imageFrame(new Uint8Array([9]));
+    previewHarness.preview.status = "ready";
+
+    renderWithGridFit(<GridRenderer ctx={rendererCtx()} />, "contain");
+
+    expect(bitmapViewHarness.lastProps?.fit).toBe("contain");
+  });
+
+  it("captures the same frame separately when its fit changes", async () => {
+    sourceHarness.byteSource = {
+      sourceId: "fit-capture",
+      url: "memory://fit-capture",
+    };
+    previewHarness.preview.frame = imageFrame(new Uint8Array([9]));
+    previewHarness.preview.status = "ready";
+    bitmapViewHarness.commitOnFitEffect = true;
+
+    renderWithMutableGridFit(<GridRenderer ctx={rendererCtx()} />);
+    await waitFor(() =>
+      expect(posterCaptureHarness.capture).toHaveBeenCalledTimes(1),
+    );
+    const coverKey = posterCaptureHarness.capture.mock.calls[0]?.[0].key;
+
+    act(() => setGridFit?.("contain"));
+
+    await waitFor(() =>
+      expect(posterCaptureHarness.capture).toHaveBeenCalledTimes(2),
+    );
+    expect(posterCaptureHarness.capture.mock.calls[1]?.[0].key).not.toBe(
+      coverKey,
+    );
   });
 
   it("shows a tiny buffering indicator over the last rendered frame", () => {

--- a/app/packages/multimodal/src/views/episode/grid/GridRenderer.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/GridRenderer.tsx
@@ -1,4 +1,5 @@
 import type { SampleRendererProps } from "@fiftyone/plugins";
+import { multimodalGridFit, type MultimodalGridFit } from "@fiftyone/state";
 import { Size, Spinner } from "@voxel51/voodo";
 import {
   useCallback,
@@ -8,6 +9,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { useRecoilValue } from "recoil";
 import {
   BitmapCanvasHost,
   BitmapImageView,
@@ -41,6 +43,7 @@ import {
   getGridPosterCache,
   gridPosterCacheKey,
   gridPosterFreshness,
+  gridPreviewStateKey,
   pointCloudPoseKey,
   recordGridPosterDiagnostic,
   type GridPosterCacheEntry,
@@ -54,7 +57,6 @@ import {
   useProvidedGridPoster,
 } from "./use-grid-poster-provider";
 
-const IMAGE_FIT = "cover";
 // Trailing debounce for shared-pose and cell-resize re-snapshots: orbiting
 // the one hovered cell staleness-marks every visible point-cloud cell, so
 // the debounce is what coalesces that churn into one serial snapshot burst.
@@ -82,6 +84,7 @@ export function GridRenderer({
   isGridActive = true,
   onRetainedBytesChange,
 }: SampleRendererProps) {
+  const imageFit = useRecoilValue(multimodalGridFit);
   const {
     byteSource: source,
     episodeSource,
@@ -121,10 +124,10 @@ export function GridRenderer({
     : undefined;
   const providerDescriptorSettled =
     providerDescriptor.status === "hit" || providerDescriptor.status === "miss";
-  const cacheKey = useMemo(
+  const previewIdentity = useMemo(
     () =>
       source && providerDescriptorSettled
-        ? gridPosterCacheKey({
+        ? {
             datasetId: ctx.dataset.datasetId,
             mediaField: ctx.media?.field,
             mediaPath: ctx.media?.path,
@@ -133,7 +136,7 @@ export function GridRenderer({
             providerRevision: providerCacheScope,
             selectedSourceName,
             source,
-          })
+          }
         : null,
     [
       ctx.dataset.datasetId,
@@ -146,6 +149,17 @@ export function GridRenderer({
       selectedSourceName,
       source,
     ],
+  );
+  const previewStateKey = useMemo(
+    () => (previewIdentity ? gridPreviewStateKey(previewIdentity) : null),
+    [previewIdentity],
+  );
+  const cacheKey = useMemo(
+    () =>
+      previewIdentity
+        ? gridPosterCacheKey({ ...previewIdentity, imageFit })
+        : null,
+    [imageFit, previewIdentity],
   );
   const { entry: cachedPoster, status: cacheLookupStatus } = useGridPosterCache(
     cacheKey,
@@ -203,7 +217,7 @@ export function GridRenderer({
     previewSessionDemand,
   );
   const preview = useGridPreview({
-    cacheRequestKey: cacheKey,
+    cacheRequestKey: previewStateKey,
     cachedPoster: effectivePoster,
     enabled: visible,
     hovered,
@@ -255,10 +269,10 @@ export function GridRenderer({
     },
     [displayOwner],
   );
-  const capturedTokensRef = useRef(new Set<string>());
-  useEffect(() => {
-    capturedTokensRef.current.clear();
-  }, [cacheKey]);
+  const capturedTokensRef = useRef<{
+    readonly cacheKey: string | null;
+    readonly tokens: Set<string>;
+  }>({ cacheKey: null, tokens: new Set() });
   const handlePosterCanvasCommitted = useCallback(
     (
       capturedSourceKind: "image" | "point-cloud",
@@ -267,6 +281,10 @@ export function GridRenderer({
       snapshotPoseKey?: string,
     ) => {
       if (!cacheKey) return;
+      if (capturedTokensRef.current.cacheKey !== cacheKey) {
+        capturedTokensRef.current = { cacheKey, tokens: new Set() };
+      }
+      const capturedTokens = capturedTokensRef.current.tokens;
       const capturePoseKey =
         capturedSourceKind === "point-cloud" ? snapshotPoseKey : undefined;
       if (capturedSourceKind === "point-cloud" && !capturePoseKey) return;
@@ -276,8 +294,8 @@ export function GridRenderer({
         size.width,
         size.height,
       ]);
-      if (capturedTokensRef.current.has(token)) return;
-      capturedTokensRef.current.add(token);
+      if (capturedTokens.has(token)) return;
+      capturedTokens.add(token);
       captureGridPoster({
         entry: {
           height: size.height,
@@ -337,6 +355,7 @@ export function GridRenderer({
             cameraPose={cameraPose}
             frame={preview.frame}
             hovered={hovered}
+            imageFit={imageFit}
             onCameraPoseChange={setCameraPose}
             onCanvasCommitted={handlePosterCanvasCommitted}
             onSurfaceRetainedBytesChange={handleSurfaceRetainedBytesChange}
@@ -347,7 +366,7 @@ export function GridRenderer({
         <BitmapImageView
           bytes={preview.cachedPoster.bytes}
           className={classes.imagePanel}
-          fit={IMAGE_FIT}
+          fit={imageFit}
           mimeType={preview.cachedPoster.mimeType}
           onBitmapRetainedBytesChange={handleSurfaceRetainedBytesChange}
         />
@@ -658,6 +677,7 @@ function PreviewFrame({
   cameraPose,
   frame,
   hovered,
+  imageFit,
   onCameraPoseChange,
   onCanvasCommitted,
   onSurfaceRetainedBytesChange,
@@ -668,6 +688,7 @@ function PreviewFrame({
   readonly cameraPose: PointCloudCameraPose | null;
   readonly frame: EpisodePosterFrame;
   readonly hovered: boolean;
+  readonly imageFit: MultimodalGridFit;
   readonly onCameraPoseChange: (pose: PointCloudCameraPose | null) => void;
   readonly onCanvasCommitted: (
     sourceKind: "image" | "point-cloud",
@@ -685,6 +706,7 @@ function PreviewFrame({
       cameraPose={cameraPose}
       frame={frame}
       hovered={hovered}
+      imageFit={imageFit}
       onCameraPoseChange={onCameraPoseChange}
       onCanvasCommitted={onCanvasCommitted}
       onSurfaceRetainedBytesChange={onSurfaceRetainedBytesChange}
@@ -692,6 +714,7 @@ function PreviewFrame({
   ) : (
     <ImagePreviewFrame
       frame={frame}
+      imageFit={imageFit}
       onCanvasCommitted={onCanvasCommitted}
       onSurfaceRetainedBytesChange={onSurfaceRetainedBytesChange}
       videoStream={videoStream}
@@ -711,6 +734,7 @@ function PointCloudPreviewFrame({
   cameraPose,
   frame,
   hovered,
+  imageFit,
   onCameraPoseChange,
   onCanvasCommitted,
   onSurfaceRetainedBytesChange,
@@ -720,6 +744,7 @@ function PointCloudPreviewFrame({
   readonly cameraPose: PointCloudCameraPose | null;
   readonly frame: Extract<EpisodePosterFrame, { kind: "point-cloud" }>;
   readonly hovered: boolean;
+  readonly imageFit: MultimodalGridFit;
   readonly onCameraPoseChange: (pose: PointCloudCameraPose | null) => void;
   readonly onCanvasCommitted: (
     sourceKind: "image" | "point-cloud",
@@ -967,7 +992,7 @@ function PointCloudPreviewFrame({
         <BitmapImageView
           bytes={cachedPoster.bytes}
           className={classes.imagePanel}
-          fit={IMAGE_FIT}
+          fit={imageFit}
           mimeType={cachedPoster.mimeType}
           onBitmapRetainedBytesChange={onSurfaceRetainedBytesChange}
         />
@@ -975,7 +1000,7 @@ function PointCloudPreviewFrame({
       <BitmapCanvasHost
         bitmap={snapshot?.bitmap ?? null}
         className={classes.imagePanel}
-        fit={IMAGE_FIT}
+        fit={imageFit}
         onCanvasCommitted={(canvas, size) =>
           onCanvasCommitted("point-cloud", canvas, size, snapshot?.poseKey)
         }
@@ -1004,11 +1029,13 @@ function PointCloudPreviewFrame({
 
 function ImagePreviewFrame({
   frame,
+  imageFit,
   onCanvasCommitted,
   onSurfaceRetainedBytesChange,
   videoStream,
 }: {
   readonly frame: Extract<EpisodePosterFrame, { kind: "image" }>;
+  readonly imageFit: MultimodalGridFit;
   readonly onCanvasCommitted: (
     sourceKind: "image" | "point-cloud",
     canvas: HTMLCanvasElement,
@@ -1022,7 +1049,7 @@ function ImagePreviewFrame({
   return (
     <BitmapImageFrameView
       className={classes.imagePanel}
-      fit={IMAGE_FIT}
+      fit={imageFit}
       frame={frame.image}
       onCanvasCommitted={(canvas, size) =>
         onCanvasCommitted("image", canvas, size)

--- a/app/packages/multimodal/src/views/episode/grid/grid-poster-cache.test.ts
+++ b/app/packages/multimodal/src/views/episode/grid/grid-poster-cache.test.ts
@@ -6,6 +6,7 @@ import {
   defaultGridPosterCacheBudgetBytes,
   gridPosterCacheKey,
   gridPosterFreshness,
+  gridPreviewStateKey,
   pointCloudPoseKey,
   shouldReplaceGridPoster,
   type GridPosterCacheEntry,
@@ -84,13 +85,19 @@ describe("grid poster cache", () => {
   });
 
   it("separates every render-semantic key field", () => {
-    const base = {
+    const previewIdentity = {
       datasetId: "dataset-a",
       mediaField: "recording",
       selectedSourceName: null,
       source: source("one", "etag-a"),
     };
+    const base = { ...previewIdentity, imageFit: "cover" as const };
     const key = gridPosterCacheKey(base);
+    const containKey = gridPosterCacheKey({ ...base, imageFit: "contain" });
+    expect(containKey).not.toBe(key);
+    const stateKey = gridPreviewStateKey(previewIdentity);
+    expect(stateKey).not.toBe(key);
+    expect(stateKey).not.toBe(containKey);
     expect(gridPosterCacheKey({ ...base, datasetId: "dataset-b" })).not.toBe(
       key,
     );
@@ -124,6 +131,7 @@ describe("grid poster cache", () => {
   it("keeps signed access URLs out of persistent poster identity", () => {
     const base = {
       datasetId: "dataset-a",
+      imageFit: "cover" as const,
       mediaField: "recording",
       selectedSourceName: null,
     };

--- a/app/packages/multimodal/src/views/episode/grid/grid-poster-cache.ts
+++ b/app/packages/multimodal/src/views/episode/grid/grid-poster-cache.ts
@@ -1,5 +1,6 @@
 import { LRUCache } from "lru-cache";
 
+import type { MultimodalGridFit } from "@fiftyone/state";
 import type { GridPosterProviderMetadata } from "../../../extensions/grid-posters";
 import type { ByteSourceDescriptor } from "../../../ir";
 import type { PointCloudCameraPose } from "../../../visualization/scene-3d";
@@ -12,6 +13,7 @@ const DEFAULT_MAX_ENTRIES = 2_048;
 const ENTRY_METADATA_BYTES = 256;
 const CACHE_SCHEMA_VERSION = "grid-poster-v3";
 const PREVIEW_SELECTION_POLICY_VERSION = "preview-selection-v1";
+const PREVIEW_STATE_KEY_VERSION = "grid-preview-state-v1";
 const SNAPSHOT_RENDERER_POLICY_VERSION = "point-cloud-snapshot-v1";
 export const GRID_POSTER_AUTO_SOURCE = "__AUTO__";
 
@@ -83,6 +85,7 @@ export interface GridPosterCacheOptions {
 
 export interface GridPosterKeyParts {
   readonly datasetId: string;
+  readonly imageFit: MultimodalGridFit;
   readonly mediaField: string | null | undefined;
   readonly mediaPath?: string | null | undefined;
   readonly posterSourceName?: string | null | undefined;
@@ -154,7 +157,7 @@ export function createGridPosterCache(
   return publicCache;
 }
 
-export function gridPosterCacheKey({
+function gridPreviewIdentityParts({
   datasetId,
   mediaField,
   mediaPath,
@@ -163,8 +166,8 @@ export function gridPosterCacheKey({
   providerRevision,
   selectedSourceName,
   source,
-}: GridPosterKeyParts): GridPosterCacheKey {
-  return serializeGridPosterKey([
+}: Omit<GridPosterKeyParts, "imageFit">): readonly (string | null)[] {
+  return [
     CACHE_SCHEMA_VERSION,
     datasetId,
     mediaField ?? null,
@@ -177,6 +180,27 @@ export function gridPosterCacheKey({
     posterSourceName ?? null,
     posterStartTimeNs?.toString() ?? null,
     PREVIEW_SELECTION_POLICY_VERSION,
+  ];
+}
+
+/** Stable owner identity for live preview state, independent of presentation fit. */
+export function gridPreviewStateKey(
+  parts: Omit<GridPosterKeyParts, "imageFit">,
+): string {
+  return serializeGridPosterKey([
+    ...gridPreviewIdentityParts(parts),
+    PREVIEW_STATE_KEY_VERSION,
+  ]);
+}
+
+/** Persistent identity for a poster whose canvas bytes bake in presentation fit. */
+export function gridPosterCacheKey(
+  parts: GridPosterKeyParts,
+): GridPosterCacheKey {
+  const { imageFit, ...identity } = parts;
+  return serializeGridPosterKey([
+    ...gridPreviewIdentityParts(identity),
+    imageFit,
   ]);
 }
 

--- a/app/packages/multimodal/src/views/episode/grid/use-grid-preview.test.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/use-grid-preview.test.tsx
@@ -444,12 +444,13 @@ describe("useGridPreview", () => {
     act(() => latestState.current?.play());
     await act(async () => {
       await Promise.resolve();
-      await Promise.resolve();
-      await Promise.resolve();
     });
+    expect(onReadResult).toHaveBeenCalledTimes(2);
+
+    await act(() => vi.advanceTimersByTimeAsync(84));
 
     expect(onReadResult).toHaveBeenCalledTimes(4);
-    expect(firstImageByte(latestState.current?.frame ?? null)).toBe(1);
+    expect(firstImageByte(latestState.current?.frame ?? null)).toBe(2);
     act(() => latestState.current?.pause());
   });
 
@@ -579,6 +580,47 @@ describe("useGridPreview", () => {
     await act(() => vi.advanceTimersByTimeAsync(1));
     expect(firstImageByte(latestState.current?.frame ?? null)).toBe(2);
 
+    act(() => latestState.current?.pause());
+  });
+
+  it("flushes the final source frame before wrapping", async () => {
+    vi.useFakeTimers({ toFake: ["clearTimeout", "performance", "setTimeout"] });
+    const latestState = { current: null as GridPreviewState | null };
+    const pending = deferred<EpisodePreviewReadResult>();
+    sessionHarness.session.read.mockResolvedValueOnce(
+      readyResult({ bytes: [0], frameTimeNs: 0n, nextStartTimeNs: 1n }),
+    );
+    for (let frame = 1; frame <= 7; frame += 1) {
+      sessionHarness.session.read.mockResolvedValueOnce(
+        readyResult({
+          bytes: [frame],
+          frameTimeNs: BigInt(frame) * 70_000_000n,
+          nextStartTimeNs: BigInt(frame) * 70_000_000n + 1n,
+        }),
+      );
+    }
+    sessionHarness.session.read
+      .mockResolvedValueOnce(emptyResult(true))
+      .mockReturnValue(pending.promise);
+
+    render(
+      <PreviewHarness
+        id="full-source"
+        onState={(state) => {
+          latestState.current = state;
+        }}
+        source={sourceForId("full-source")}
+      />,
+    );
+    await act(async () => undefined);
+    act(() => latestState.current?.play());
+    await act(() => vi.advanceTimersByTimeAsync(1_000));
+
+    expect(sessionHarness.session.read).toHaveBeenCalledTimes(10);
+    expect(firstImageByte(latestState.current?.frame ?? null)).toBe(7);
+    expect(sessionHarness.session.read.mock.calls[8]?.[0]).toMatchObject({
+      startTimeNs: 490_000_001n,
+    });
     act(() => latestState.current?.pause());
   });
 

--- a/app/packages/multimodal/src/views/episode/grid/use-grid-preview.ts
+++ b/app/packages/multimodal/src/views/episode/grid/use-grid-preview.ts
@@ -6,6 +6,7 @@ import {
 } from "../../../ir";
 import type { EpisodePreviewSession } from "../../../ports";
 import {
+  EpisodePreviewPlaybackScheduler,
   episodePreviewPlaybackDelayMs,
   publishEpisodePreviewBootstrap,
   recordPreviewSourceFacts,
@@ -305,8 +306,33 @@ export function useGridPreview({
     let active = true;
     const controller = new AbortController();
     let bootstrapPublished = false;
-    let previousFrameTimeNs = frameTimeNsRef.current;
-    let presentedAtMs = performance.now();
+    let deferredSkippedFrame: {
+      readonly result: EpisodePreviewReadResult;
+    } | null = null;
+    const playbackScheduler = new EpisodePreviewPlaybackScheduler();
+    playbackScheduler.reset(frameTimeNsRef.current, performance.now());
+
+    const presentResult = async (
+      result: EpisodePreviewReadResult,
+      playbackDelayMs: number,
+    ): Promise<boolean> => {
+      await delayMs(playbackDelayMs, controller.signal);
+      if (!active) return false;
+
+      if (!bootstrapPublished) {
+        publishEpisodePreviewBootstrap(source, result);
+        if (sourceFactsScope) {
+          recordPreviewSourceFacts(source, sourceFactsScope, result);
+        }
+        bootstrapPublished = true;
+      }
+
+      frameTimeNsRef.current = result.frameTimeNs;
+      nextStartTimeNsRef.current = result.nextStartTimeNs;
+      setState((current) => resultPreservingCachedPoster(current, result));
+      playbackScheduler.markPresented(result.frameTimeNs, performance.now());
+      return true;
+    };
 
     const run = async () => {
       try {
@@ -337,11 +363,24 @@ export function useGridPreview({
           notifyReadResult(onReadResultRef.current, result);
 
           if (!result.frame) {
+            if (deferredSkippedFrame) {
+              const deferred = deferredSkippedFrame;
+              const flushDelayMs =
+                playbackScheduler.nextDelayMs(
+                  deferred.result.frameTimeNs,
+                  performance.now(),
+                  true,
+                ) ?? 0;
+              if (!(await presentResult(deferred.result, flushDelayMs))) {
+                break;
+              }
+              deferredSkippedFrame = null;
+            }
             frameTimeNsRef.current = undefined;
             nextStartTimeNsRef.current = undefined;
-            previousFrameTimeNs = undefined;
+            playbackScheduler.reset(undefined, performance.now());
             await delayMs(
-              episodePreviewPlaybackDelayMs(undefined, undefined) ?? 0,
+              episodePreviewPlaybackDelayMs(undefined, undefined),
               controller.signal,
             );
             if (!active) {
@@ -350,34 +389,20 @@ export function useGridPreview({
             continue;
           }
 
-          const playbackDelayMs = episodePreviewPlaybackDelayMs(
-            previousFrameTimeNs,
+          const playbackDelayMs = playbackScheduler.nextDelayMs(
             result.frameTimeNs,
-            performance.now() - presentedAtMs,
+            performance.now(),
           );
           if (playbackDelayMs === null) {
+            deferredSkippedFrame = { result };
             nextStartTimeNsRef.current = result.nextStartTimeNs;
             continue;
           }
 
-          await delayMs(playbackDelayMs, controller.signal);
-          if (!active) {
+          deferredSkippedFrame = null;
+          if (!(await presentResult(result, playbackDelayMs))) {
             break;
           }
-
-          if (!bootstrapPublished) {
-            publishEpisodePreviewBootstrap(source, result);
-            if (sourceFactsScope) {
-              recordPreviewSourceFacts(source, sourceFactsScope, result);
-            }
-            bootstrapPublished = true;
-          }
-
-          frameTimeNsRef.current = result.frameTimeNs;
-          nextStartTimeNsRef.current = result.nextStartTimeNs;
-          setState((current) => resultPreservingCachedPoster(current, result));
-          previousFrameTimeNs = result.frameTimeNs;
-          presentedAtMs = performance.now();
         }
       } catch (caughtError) {
         finishBuffering();

--- a/app/packages/multimodal/src/visualization/media-2d/BitmapImageView.test.tsx
+++ b/app/packages/multimodal/src/visualization/media-2d/BitmapImageView.test.tsx
@@ -678,6 +678,54 @@ describe("BitmapImageFrameView", () => {
     expect(decoder.instances[0].close).toHaveBeenCalledOnce();
   });
 
+  it("commits H.264 presentations while bitmap copies lag continuous rerenders", async () => {
+    stubVideoDecoder();
+    const copies = stubCreateImageBitmap();
+    stubElementSize(100, 50);
+    sharedMockContext();
+    const onCanvasCommitted = vi.fn();
+    const onImageLoaded = vi.fn();
+    const frameIntervalNs = 70_422_535n;
+    const frames = Array.from({ length: 8 }, (_, index) =>
+      index === 0
+        ? videoFrame()
+        : deltaVideoFrame(1_000n + BigInt(index) * frameIntervalNs),
+    );
+
+    const rendered = render(
+      <BitmapImageFrameView
+        frame={frames[0]}
+        onCanvasCommitted={onCanvasCommitted}
+        onImageLoaded={onImageLoaded}
+      />,
+    );
+    for (let index = 1; index < frames.length; index += 1) {
+      await waitFor(() => expect(copies.pendingCount()).toBe(index));
+      rendered.rerender(
+        <BitmapImageFrameView
+          frame={frames[index]}
+          onCanvasCommitted={onCanvasCommitted}
+          onImageLoaded={onImageLoaded}
+        />,
+      );
+      await act(async () => {
+        copies.settle(index - 1, fakeBitmap(640, 480));
+      });
+      await waitFor(() =>
+        expect(onCanvasCommitted).toHaveBeenCalledTimes(index),
+      );
+    }
+
+    await waitFor(() => expect(copies.pendingCount()).toBe(frames.length));
+    expect(onImageLoaded).toHaveBeenCalledTimes(frames.length - 1);
+    await act(async () => {
+      copies.settle(frames.length - 1, fakeBitmap(640, 480));
+    });
+    await waitFor(() =>
+      expect(onCanvasCommitted).toHaveBeenCalledTimes(frames.length),
+    );
+  });
+
   it("waits for a keyframe before bootstrapping a private preview", async () => {
     const decoder = stubVideoDecoder();
     stubElementSize(100, 50);
@@ -956,7 +1004,7 @@ function videoFrame(): EncodedVideoVisualization {
   };
 }
 
-function deltaVideoFrame(): EncodedVideoVisualization {
+function deltaVideoFrame(timestampNs = 2_000n): EncodedVideoVisualization {
   return {
     bytes: Uint8Array.of(0, 0, 1, 0x41),
     codec: "h264",
@@ -964,7 +1012,7 @@ function deltaVideoFrame(): EncodedVideoVisualization {
     h264: { hasFrame: true },
     keyframe: false,
     kind: VISUALIZATION_KIND.ENCODED_VIDEO,
-    timestampNs: 2_000n,
+    timestampNs,
   };
 }
 
@@ -1045,6 +1093,7 @@ function stubCreateImageBitmap() {
 
   return {
     fail: (index: number, error: unknown) => pending[index].reject(error),
+    pendingCount: () => pending.length,
     settle: (index: number, bitmap: ImageBitmap) =>
       pending[index].resolve(bitmap),
   };

--- a/app/packages/multimodal/src/visualization/media-2d/BitmapImageView.test.tsx
+++ b/app/packages/multimodal/src/visualization/media-2d/BitmapImageView.test.tsx
@@ -455,7 +455,7 @@ describe("BitmapImageView", () => {
     expect(onImageLoaded).toHaveBeenCalledWith(200, 200);
   });
 
-  it("bounds rapid frame churn and commits only the latest queued decode", async () => {
+  it("bounds rapid churn while preserving active decode liveness", async () => {
     const decodes = stubCreateImageBitmap();
     stubElementSize(100, 50);
     const context = sharedMockContext();
@@ -481,21 +481,22 @@ describe("BitmapImageView", () => {
       />,
     );
 
-    // createImageBitmap cannot abort the running decode, but intermediate
-    // frames never start and the queue remains one latest request deep.
+    // createImageBitmap cannot abort the running decode. It remains eligible
+    // to commit, while intermediate frames never start and the queue remains
+    // one latest request deep.
     expect(createImageBitmap).toHaveBeenCalledTimes(1);
-    const stale = fakeBitmap(10, 10);
-    decodes.settle(0, stale);
-    await waitFor(() => expect(stale.close).toHaveBeenCalledTimes(1));
-    expect(drawImage).not.toHaveBeenCalled();
+    const active = fakeBitmap(10, 10);
+    decodes.settle(0, active);
+    await waitFor(() => expect(drawImage).toHaveBeenCalledTimes(1));
+    expect(active.close).not.toHaveBeenCalled();
     expect(createImageBitmap).toHaveBeenCalledTimes(2);
 
     const latest = fakeBitmap(30, 30);
     decodes.settle(1, latest);
-    await waitFor(() => expect(drawImage).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(drawImage).toHaveBeenCalledTimes(2));
 
-    expect(drawImage).toHaveBeenCalledTimes(1);
-    expect(drawImage).toHaveBeenCalledWith(
+    expect(drawImage).toHaveBeenCalledTimes(2);
+    expect(drawImage).toHaveBeenLastCalledWith(
       latest,
       expect.anything(),
       expect.anything(),
@@ -503,8 +504,44 @@ describe("BitmapImageView", () => {
       expect.anything(),
     );
     expect(latest.close).not.toHaveBeenCalled();
-    expect(onImageLoaded).toHaveBeenCalledTimes(1);
-    expect(onImageLoaded).toHaveBeenCalledWith(30, 30);
+    expect(onImageLoaded).toHaveBeenCalledTimes(2);
+    expect(onImageLoaded).toHaveBeenLastCalledWith(30, 30);
+  });
+
+  it("keeps committing during continuous slower-than-input churn", async () => {
+    const decodes = stubCreateImageBitmap();
+    stubElementSize(100, 50);
+    const context = sharedMockContext();
+    const drawImage = vi.spyOn(context, "drawImage");
+
+    const { rerender } = render(
+      <BitmapImageView bytes={new Uint8Array([0])} />,
+    );
+
+    for (let frame = 1; frame <= 12; frame += 1) {
+      rerender(<BitmapImageView bytes={new Uint8Array([frame])} />);
+      decodes.settle(frame - 1, fakeBitmap(10, 10));
+      await act(async () => Promise.resolve());
+    }
+
+    // The stream is still producing. Every active decode settled after the
+    // next input arrived, and every one still reached the canvas.
+    expect(drawImage).toHaveBeenCalledTimes(12);
+  });
+
+  it("cancels an in-flight decode when the view unmounts", async () => {
+    const decodes = stubCreateImageBitmap();
+    stubElementSize(100, 50);
+    const context = sharedMockContext();
+    const drawImage = vi.spyOn(context, "drawImage");
+    const { unmount } = render(<BitmapImageView bytes={new Uint8Array([1])} />);
+
+    unmount();
+    const bitmap = fakeBitmap(10, 10);
+    decodes.settle(0, bitmap);
+
+    await waitFor(() => expect(bitmap.close).toHaveBeenCalledTimes(1));
+    expect(drawImage).not.toHaveBeenCalled();
   });
 
   it("closes the previous bitmap on replacement and the last one on unmount", async () => {

--- a/app/packages/multimodal/src/visualization/media-2d/BitmapImageView.tsx
+++ b/app/packages/multimodal/src/visualization/media-2d/BitmapImageView.tsx
@@ -17,9 +17,9 @@
  * Fit math intentionally matches `imageDisplayRect` in `Base2dScene.tsx`
  * (the `ImagePanel` fit semantics) so swapping a cell between this view
  * and a live panel never shifts pixels. Bitmap lifecycle mirrors the
- * discipline in `image-texture-cache.ts`: a superseded decode never
- * commits, and every bitmap is closed exactly once (on replacement, on
- * cancellation, or on unmount).
+ * discipline in `image-texture-cache.ts`: active work stays live through
+ * input churn, pending work coalesces to the latest request, and every bitmap
+ * is closed exactly once (on replacement, cancellation, or unmount).
  */
 import type { CSSProperties } from "react";
 import {
@@ -172,16 +172,37 @@ class LatestEncodedBitmapDecoder {
       source,
     };
     if (this.active) {
-      if (this.pending) this.pending.cancelled = true;
+      if (this.pending) {
+        this.cancel(this.pending);
+      }
       this.pending = request;
     } else {
       this.start(request);
     }
 
     return () => {
-      request.cancelled = true;
-      if (this.pending === request) this.pending = null;
+      if (request.cancelled) return;
+      if (this.active === request) return;
+      if (this.pending === request) {
+        this.pending = null;
+        this.cancel(request);
+      }
     };
+  }
+
+  dispose(): void {
+    if (this.active) {
+      this.cancel(this.active);
+    }
+    if (this.pending) {
+      this.cancel(this.pending);
+      this.pending = null;
+    }
+  }
+
+  private cancel(request: EncodedBitmapDecodeRequest): void {
+    if (request.cancelled) return;
+    request.cancelled = true;
   }
 
   private start(request: EncodedBitmapDecodeRequest): void {
@@ -408,6 +429,9 @@ export function BitmapImageView({
   if (decoderRef.current === null) {
     decoderRef.current = new LatestEncodedBitmapDecoder();
   }
+  useEffect(() => {
+    return () => decoderRef.current?.dispose();
+  }, []);
   const onErrorRef = useLatestRef(onError);
   const onImageLoadedRef = useLatestRef(onImageLoaded);
   const onBitmapRetainedBytesChangeRef = useLatestRef(
@@ -415,9 +439,9 @@ export function BitmapImageView({
   );
 
   // This effect decodes the current bytes and commits the resulting
-  // bitmap. The cleanup flag is the out-of-order guard: only the latest
-  // request may commit — a superseded decode (newer bytes arrived, or
-  // unmount) closes its own bitmap and leaves the previous frame drawn.
+  // bitmap. A running browser decode remains eligible to commit when newer
+  // bytes arrive; the queue still coalesces to one latest pending frame. The
+  // decoder lifecycle effect above cancels both slots on actual unmount.
   useEffect(() => {
     if (!decodeSize) {
       return undefined;

--- a/app/packages/state/src/recoil/grid.test.ts
+++ b/app/packages/state/src/recoil/grid.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("recoil");
+vi.mock("recoil-relay");
+
+import type { TestSelector } from "../../../../__mocks__/recoil";
+import { setMockAtoms } from "../../../../__mocks__/recoil";
+import { multimodalGridFit, type MultimodalGridFit } from "./grid";
+
+type WritableFitSelector = TestSelector<typeof multimodalGridFit> & {
+  set: (value: MultimodalGridFit) => void;
+};
+
+describe("multimodalGridFit", () => {
+  it("defaults invalid persisted values to cover", () => {
+    const fit = multimodalGridFit as unknown as WritableFitSelector;
+    setMockAtoms({
+      datasetId: "grid-fit-default",
+      multimodalGridFitStore: () => "unexpected",
+    });
+
+    expect(fit()).toBe("cover");
+  });
+
+  it("stores the preference independently for each dataset", () => {
+    const fit = multimodalGridFit as unknown as WritableFitSelector;
+    setMockAtoms({
+      datasetId: "grid-fit-first",
+      multimodalGridFitStore: () => "cover",
+    });
+
+    fit.set("contain");
+    expect(fit()).toBe("contain");
+
+    setMockAtoms({ datasetId: "grid-fit-second" });
+    expect(fit()).toBe("cover");
+
+    setMockAtoms({ datasetId: "grid-fit-first" });
+    expect(fit()).toBe("contain");
+  });
+});

--- a/app/packages/state/src/recoil/grid.ts
+++ b/app/packages/state/src/recoil/grid.ts
@@ -6,6 +6,36 @@ import { fieldPath, fields, isNumericField } from "./schema";
 import { datasetId } from "./selectors";
 import { State } from "./types";
 
+/** Presentation fit for media rendered inside square multimodal grid tiles. */
+export type MultimodalGridFit = "contain" | "cover";
+
+const multimodalGridFitStore = atomFamily<string, string>({
+  key: "multimodalGridFitStore",
+  default: "cover",
+  effects: (datasetId) => [
+    getBrowserStorageEffectForKey(`multimodalGridFit-${datasetId}`, {
+      valueClass: "string",
+    }),
+  ],
+});
+
+/** Validated grid fit for the active dataset, defaulting to Cover. */
+export const multimodalGridFit = selector<MultimodalGridFit>({
+  key: "multimodalGridFit",
+  get: ({ get }) => {
+    const value = get(multimodalGridFitStore(get(datasetId) ?? ""));
+    return value === "contain" ? "contain" : "cover";
+  },
+  set: ({ get, reset, set }, value) => {
+    const store = multimodalGridFitStore(get(datasetId) ?? "");
+    if (value instanceof DefaultValue) {
+      reset(store);
+      return;
+    }
+    set(store, value);
+  },
+});
+
 export const gridSortByStore = atomFamily<string, string>({
   key: "gridSortByStore",
   default: null,


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

- Keep bitmap and H.264 decodes live when grid preview frames arrive faster than canvas publication.
- Cap hover playback fairly at 12 fps, keep source time near 1x wall time, and present the final source frame before wrap.
- Add a multimodal-only Cover/Contain display option for square grid tiles, default it to Cover, persist it per dataset, and keep fit-specific posters isolated in the bounded caches.

## 🧪 How is this patch tested? If it is not, please explain why.

- `yarn vitest run` for the nine affected state, core, and multimodal suites: 138 tests passed.
- `yarn check` in `app/packages/multimodal`: lint, dependency boundaries, architecture, bounded reads, and types passed.
- App-wide `yarn typecheck` still reports existing unrelated diagnostics; filtering its output to the changed core and state files reports none.
- Manually verified a representative 14.2 fps H.264 grid hover at 11.9 committed fps with 90/90 presentation-to-canvas coverage, no paint gap over 89 ms, and source time near 1x wall time. A 5 fps control remained at 5 fps.
- Manually verified Cover/Contain thumbnail and hover framing, per-dataset reload persistence, the display-option ordering, and immediate reuse when switching back to an already-cached fit.

## Notes to Reviewer

Best reviewed commit-by-commit: bitmap decoder liveness, fair scheduling, H.264 publication liveness, then the multimodal grid-fit setting and fit-specific poster caching.

A medium-effort independent Claude review found a first-toggle cache miss that could leave the hover preview loading indefinitely. The failure was reproduced in an integration test, fixed by separating fit-independent live preview state from fit-specific poster cache keys, and the follow-up review returned `correct` with no remaining verified issues. A diff-focused desloppify pass then removed stale/dead bookkeeping and tightened the new APIs and tests.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Multimodal grid hover previews now play smoothly at up to 12 fps and offer Cover/Contain framing for square tiles.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3917
<!-- enterprise-sync-pr:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a grid display setting for multimodal datasets with “Cover” and “Contain” options.
  * Fit preferences are saved separately for each dataset.

* **Bug Fixes**
  * Improved episode preview pacing, seeking, and final-frame display.
  * Improved video and image updates during rapid navigation and delayed processing.
  * Prevented background image processing from continuing after leaving a view.
  * Grid poster caching now correctly reflects the selected fit mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
