### PR TITLE
Show view-incompatible similarity indexes as disabled

### DIFF
--- a/app/packages/similarity-search/src/components/NewSearch/NewSearch.tsx
+++ b/app/packages/similarity-search/src/components/NewSearch/NewSearch.tsx
@@ -17,15 +17,16 @@ import {
   TextColor,
   TextVariant,
   Toggle,
+  Tooltip,
   Orientation,
   Spacing,
   Variant,
 } from "@voxel51/voodo";
 import { FileUploadOutlined } from "../../mui";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { OperatorExecutionButton } from "@fiftyone/operators";
 import {
-  BrainKeyConfig,
+  AnnotatedBrainKeyConfig,
   CloneConfig,
   QueryType,
   ViewTarget,
@@ -51,7 +52,7 @@ import {
 } from "../styled";
 
 type NewSearchProps = {
-  brainKeys: BrainKeyConfig[];
+  brainKeys: AnnotatedBrainKeyConfig[];
   cloneConfig?: CloneConfig | null;
   isPatchesView?: boolean;
   isReadOnly?: boolean;
@@ -69,6 +70,40 @@ export default function NewSearch({
 }: NewSearchProps) {
   const form = useNewSearchForm(brainKeys, cloneConfig, onSubmitted);
   const [uploadError, setUploadError] = useState<string | null>(null);
+
+  // All indexes are listed; ones that can't be used in the current view
+  // are grayed out with a tooltip and rejected by handleBrainKeyChange
+  const brainKeyOptions = useMemo(
+    () =>
+      brainKeys.map((bk) => {
+        const label =
+          bk.key + (bk.patches_field ? ` (patches: ${bk.patches_field})` : "");
+        return {
+          id: bk.key,
+          data: {
+            label,
+            content: bk.compatible ? undefined : (
+              <Tooltip content={bk.incompatibleReason}>
+                <span style={{ opacity: 0.5, cursor: "not-allowed" }}>
+                  {label}
+                </span>
+              </Tooltip>
+            ),
+          },
+        };
+      }),
+    [brainKeys],
+  );
+
+  const handleBrainKeyChange = useCallback(
+    (value: string | string[] | null) => {
+      const key = (value as string) ?? "";
+      const config = brainKeys.find((bk) => bk.key === key);
+      if (config && !config.compatible) return;
+      form.setBrainKey(key);
+    },
+    [brainKeys, form.setBrainKey],
+  );
 
   // Guard against setting state after unmount — `fileToBase64` resolves
   // asynchronously and the user can navigate away mid-read.
@@ -105,9 +140,9 @@ export default function NewSearch({
           control={
             <Select
               exclusive
-              options={form.brainKeyOptions}
+              options={brainKeyOptions}
               value={form.brainKey}
-              onChange={(value) => form.setBrainKey((value as string) ?? "")}
+              onChange={handleBrainKeyChange}
             />
           }
         />

--- a/app/packages/similarity-search/src/components/SimilarityIndex/SimilarityIndex.tsx
+++ b/app/packages/similarity-search/src/components/SimilarityIndex/SimilarityIndex.tsx
@@ -18,11 +18,11 @@ import {
   Variant,
 } from "@voxel51/voodo";
 import { useCallback, useMemo, useState } from "react";
-import { BrainKeyConfig } from "../../types";
+import { AnnotatedBrainKeyConfig } from "../../types";
 import SimilaritySearchCTA from "../SimilaritySearchCTA";
 
 type SimilarityIndexProps = {
-  brainKeys: BrainKeyConfig[];
+  brainKeys: AnnotatedBrainKeyConfig[];
   onBack: () => void;
 };
 
@@ -41,66 +41,78 @@ export default function SimilarityIndex({
   }, []);
   const listItems = useMemo(
     () =>
-      brainKeys.map((bk) => ({
-        id: bk.key,
-        data: {
-          primaryContent: (
-            <Stack orientation={Orientation.Column} spacing={Spacing.Xs}>
-              <span style={{ fontWeight: "bold" }}>{bk.key}</span>
-              {bk.model && (
-                <Text variant={TextVariant.Md} color={TextColor.Secondary}>
-                  Model: {bk.model}
-                </Text>
-              )}
-              {bk.backend && (
-                <Text variant={TextVariant.Md} color={TextColor.Secondary}>
-                  Backend: {bk.backend}
-                </Text>
-              )}
-              {bk.metric && (
-                <Text variant={TextVariant.Md} color={TextColor.Secondary}>
-                  Metric: {bk.metric}
-                </Text>
-              )}
-              {bk.identifiers?.map((id) => (
-                <Text
-                  key={id.label}
-                  variant={TextVariant.Md}
-                  color={TextColor.Secondary}
-                >
-                  {id.label}: {id.value}
-                </Text>
-              ))}
-              <Stack
-                orientation={Orientation.Row}
-                spacing={Spacing.Xs}
-                align={Align.Center}
+      brainKeys.map((bk) => {
+        const details = (
+          <Stack orientation={Orientation.Column} spacing={Spacing.Xs}>
+            <span style={{ fontWeight: "bold" }}>{bk.key}</span>
+            {bk.model && (
+              <Text variant={TextVariant.Md} color={TextColor.Secondary}>
+                Model: {bk.model}
+              </Text>
+            )}
+            {bk.backend && (
+              <Text variant={TextVariant.Md} color={TextColor.Secondary}>
+                Backend: {bk.backend}
+              </Text>
+            )}
+            {bk.metric && (
+              <Text variant={TextVariant.Md} color={TextColor.Secondary}>
+                Metric: {bk.metric}
+              </Text>
+            )}
+            {bk.identifiers?.map((id) => (
+              <Text
+                key={id.label}
+                variant={TextVariant.Md}
+                color={TextColor.Secondary}
               >
-                <Text variant={TextVariant.Md} color={TextColor.Secondary}>
-                  Supports text queries?
-                </Text>
-                <Icon
-                  name={bk.supports_prompts ? IconName.Check : IconName.Close}
-                  size={Size.Sm}
-                  color={
-                    bk.supports_prompts ? IconColor.Success : IconColor.Error
-                  }
-                />
-              </Stack>
-              {bk.embeddings_field && (
-                <Text variant={TextVariant.Md} color={TextColor.Secondary}>
-                  Embeddings field: {bk.embeddings_field}
-                </Text>
-              )}
-              {bk.patches_field && (
-                <Text variant={TextVariant.Md} color={TextColor.Muted}>
-                  Patches field: {bk.patches_field}
-                </Text>
-              )}
+                {id.label}: {id.value}
+              </Text>
+            ))}
+            <Stack
+              orientation={Orientation.Row}
+              spacing={Spacing.Xs}
+              align={Align.Center}
+            >
+              <Text variant={TextVariant.Md} color={TextColor.Secondary}>
+                Supports text queries?
+              </Text>
+              <Icon
+                name={bk.supports_prompts ? IconName.Check : IconName.Close}
+                size={Size.Sm}
+                color={
+                  bk.supports_prompts ? IconColor.Success : IconColor.Error
+                }
+              />
             </Stack>
-          ),
-        },
-      })),
+            {bk.embeddings_field && (
+              <Text variant={TextVariant.Md} color={TextColor.Secondary}>
+                Embeddings field: {bk.embeddings_field}
+              </Text>
+            )}
+            {bk.patches_field && (
+              <Text variant={TextVariant.Md} color={TextColor.Muted}>
+                Patches field: {bk.patches_field}
+              </Text>
+            )}
+          </Stack>
+        );
+        return {
+          id: bk.key,
+          data: {
+            // Indexes that can't be used in the current view are shown
+            // grayed out with an explanatory tooltip
+            style: bk.compatible ? undefined : { opacity: 0.5 },
+            primaryContent: bk.compatible ? (
+              details
+            ) : (
+              <Tooltip content={bk.incompatibleReason}>
+                <div>{details}</div>
+              </Tooltip>
+            ),
+          },
+        };
+      }),
     [brainKeys],
   );
 

--- a/app/packages/similarity-search/src/hooks/useNewSearchForm.ts
+++ b/app/packages/similarity-search/src/hooks/useNewSearchForm.ts
@@ -1,6 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
 import { useViewTargets } from "@fiftyone/operators";
-import { BrainKeyConfig, CloneConfig, QueryType, ViewTarget } from "../types";
+import {
+  AnnotatedBrainKeyConfig,
+  CloneConfig,
+  QueryType,
+  ViewTarget,
+} from "../types";
 import { UploadedImage } from "../utils";
 import { useSearchSelection } from "./useSearchSelection";
 import { useSearchSubmission } from "./useSearchSubmission";
@@ -12,7 +17,7 @@ import { useSearchSubmission } from "./useSearchSubmission";
  * useSearchSubmission (params building + submit handlers).
  */
 export const useNewSearchForm = (
-  brainKeys: BrainKeyConfig[],
+  brainKeys: AnnotatedBrainKeyConfig[],
   cloneConfig: CloneConfig | null | undefined,
   onSubmitted: () => void,
 ) => {
@@ -25,17 +30,28 @@ export const useNewSearchForm = (
     hasView,
   } = useSearchSelection();
 
-  const firstTextKey = useMemo(
-    () => brainKeys.find((bk) => bk.supports_prompts),
+  // Incompatible keys are rendered (grayed out) but never selectable
+  const compatibleKeys = useMemo(
+    () => brainKeys.filter((bk) => bk.compatible),
     [brainKeys],
   );
 
+  const firstTextKey = useMemo(
+    () => compatibleKeys.find((bk) => bk.supports_prompts),
+    [compatibleKeys],
+  );
+
   const defaultBrainKey = useMemo(() => {
-    if (cloneConfig?.brain_key) return cloneConfig.brain_key;
-    if (hasSamplesSelected) return brainKeys[0]?.key ?? "";
+    if (
+      cloneConfig?.brain_key &&
+      compatibleKeys.some((bk) => bk.key === cloneConfig.brain_key)
+    ) {
+      return cloneConfig.brain_key;
+    }
+    if (hasSamplesSelected) return compatibleKeys[0]?.key ?? "";
     if (firstTextKey) return firstTextKey.key;
-    return brainKeys[0]?.key ?? "";
-  }, [cloneConfig, hasSamplesSelected, firstTextKey, brainKeys]);
+    return compatibleKeys[0]?.key ?? "";
+  }, [cloneConfig, hasSamplesSelected, firstTextKey, compatibleKeys]);
 
   const defaultQueryType = useMemo((): QueryType => {
     if (cloneConfig?.query_type) return cloneConfig.query_type;
@@ -66,7 +82,7 @@ export const useNewSearchForm = (
 
   // ─── Derived config ─────────────────────────────────────────────
 
-  const selectedConfig = brainKeys.find((bk) => bk.key === brainKey);
+  const selectedConfig = compatibleKeys.find((bk) => bk.key === brainKey);
   const supportsPrompts = selectedConfig?.supports_prompts ?? false;
   const supportsLeast = selectedConfig?.supports_least_similarity ?? false;
   const supportsUpload =
@@ -76,10 +92,12 @@ export const useNewSearchForm = (
   // ─── Auto-correct effects ───────────────────────────────────────
 
   useEffect(() => {
-    if (!brainKey && brainKeys.length > 0) {
-      setBrainKey(brainKeys[0].key);
+    // Also covers a selected key becoming incompatible when the view
+    // changes (samples ↔ patches) while the form is open
+    if (!compatibleKeys.some((bk) => bk.key === brainKey)) {
+      setBrainKey(compatibleKeys[0]?.key ?? "");
     }
-  }, [brainKey, brainKeys]);
+  }, [brainKey, compatibleKeys]);
 
   useEffect(() => {
     if (!supportsPrompts && queryType === QueryType.Text) {
@@ -138,16 +156,6 @@ export const useNewSearchForm = (
     onSubmitted,
   });
 
-  // ─── Brain key options ──────────────────────────────────────────
-
-  const brainKeyOptions = brainKeys.map((bk) => ({
-    id: bk.key,
-    data: {
-      label:
-        bk.key + (bk.patches_field ? ` (patches: ${bk.patches_field})` : ""),
-    },
-  }));
-
   return {
     // form state
     brainKey,
@@ -183,7 +191,6 @@ export const useNewSearchForm = (
     kError,
     canSubmit,
     submitting,
-    brainKeyOptions,
     executionParams,
 
     // handlers

--- a/app/packages/similarity-search/src/hooks/useNewSearchForm.ts
+++ b/app/packages/similarity-search/src/hooks/useNewSearchForm.ts
@@ -82,7 +82,16 @@ export const useNewSearchForm = (
 
   // ─── Derived config ─────────────────────────────────────────────
 
-  const selectedConfig = compatibleKeys.find((bk) => bk.key === brainKey);
+  // Derived during render rather than via the auto-correct effect so
+  // the frame where a view change invalidates the selected key never
+  // exposes an undefined config (which would flip queryType off Text)
+  const effectiveBrainKey = compatibleKeys.some((bk) => bk.key === brainKey)
+    ? brainKey
+    : (compatibleKeys[0]?.key ?? "");
+
+  const selectedConfig = compatibleKeys.find(
+    (bk) => bk.key === effectiveBrainKey,
+  );
   const supportsPrompts = selectedConfig?.supports_prompts ?? false;
   const supportsLeast = selectedConfig?.supports_least_similarity ?? false;
   const supportsUpload =
@@ -92,12 +101,13 @@ export const useNewSearchForm = (
   // ─── Auto-correct effects ───────────────────────────────────────
 
   useEffect(() => {
-    // Also covers a selected key becoming incompatible when the view
-    // changes (samples ↔ patches) while the form is open
-    if (!compatibleKeys.some((bk) => bk.key === brainKey)) {
-      setBrainKey(compatibleKeys[0]?.key ?? "");
+    // Sync state to the render-derived effective key (covers a
+    // selected key becoming incompatible when the view changes while
+    // the form is open)
+    if (brainKey !== effectiveBrainKey) {
+      setBrainKey(effectiveBrainKey);
     }
-  }, [brainKey, compatibleKeys]);
+  }, [brainKey, effectiveBrainKey]);
 
   useEffect(() => {
     if (!supportsPrompts && queryType === QueryType.Text) {
@@ -138,7 +148,7 @@ export const useNewSearchForm = (
     canSubmit,
     submitting,
   } = useSearchSubmission({
-    brainKey,
+    brainKey: effectiveBrainKey,
     queryType,
     textQuery,
     queryIds,
@@ -158,7 +168,7 @@ export const useNewSearchForm = (
 
   return {
     // form state
-    brainKey,
+    brainKey: effectiveBrainKey,
     setBrainKey,
     queryType,
     setQueryType,

--- a/app/packages/similarity-search/src/hooks/useSimilarityPanel.ts
+++ b/app/packages/similarity-search/src/hooks/useSimilarityPanel.ts
@@ -67,7 +67,7 @@ const useDerivedPanelState = (props: SimilaritySearchViewProps) => {
   // annotated as incompatible so components can gray them out with an
   // explanatory tooltip instead of hiding them.
   const brainKeys = useMemo((): AnnotatedBrainKeyConfig[] => {
-    return allBrainKeys.map((bk) => {
+    const annotated = allBrainKeys.map((bk): AnnotatedBrainKeyConfig => {
       const compatible = isPatchesView
         ? bk.patches_field === patchesField
         : !bk.patches_field;
@@ -82,6 +82,12 @@ const useDerivedPanelState = (props: SimilaritySearchViewProps) => {
           : "Cannot use a dataset index in the current view",
       };
     });
+    // Usable indexes first; disabled ones sink to the bottom of the
+    // index page list and the new-search dropdown
+    return [
+      ...annotated.filter((bk) => bk.compatible),
+      ...annotated.filter((bk) => !bk.compatible),
+    ];
   }, [allBrainKeys, isPatchesView, patchesField]);
 
   // Filter runs to only those whose brain_key is usable in this view

--- a/app/packages/similarity-search/src/hooks/useSimilarityPanel.ts
+++ b/app/packages/similarity-search/src/hooks/useSimilarityPanel.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRecoilValue } from "recoil";
 import * as fos from "@fiftyone/state";
 import {
+  AnnotatedBrainKeyConfig,
   CloneConfig,
   RunStatus,
   SimilaritySearchViewProps,
@@ -61,16 +62,31 @@ const useDerivedPanelState = (props: SimilaritySearchViewProps) => {
     )?.[1] as string | undefined;
   }, [isPatchesView, viewStages]);
 
-  const brainKeys = useMemo(() => {
-    if (isPatchesView) {
-      return allBrainKeys.filter((bk) => bk.patches_field === patchesField);
-    }
-    return allBrainKeys.filter((bk) => !bk.patches_field);
+  // All brain keys are shown in the UI; ones that can't be used in the
+  // current view (patch index in a sample view, and vice versa) are
+  // annotated as incompatible so components can gray them out with an
+  // explanatory tooltip instead of hiding them.
+  const brainKeys = useMemo((): AnnotatedBrainKeyConfig[] => {
+    return allBrainKeys.map((bk) => {
+      const compatible = isPatchesView
+        ? bk.patches_field === patchesField
+        : !bk.patches_field;
+      if (compatible) {
+        return { ...bk, compatible: true };
+      }
+      return {
+        ...bk,
+        compatible: false,
+        incompatibleReason: bk.patches_field
+          ? "Cannot use a patch index in the current view"
+          : "Cannot use a dataset index in the current view",
+      };
+    });
   }, [allBrainKeys, isPatchesView, patchesField]);
 
-  // Filter runs to only those whose brain_key is in the effective set
+  // Filter runs to only those whose brain_key is usable in this view
   const effectiveBrainKeySet = useMemo(
-    () => new Set(brainKeys.map((bk) => bk.key)),
+    () => new Set(brainKeys.filter((bk) => bk.compatible).map((bk) => bk.key)),
     [brainKeys],
   );
   const runs = useMemo(

--- a/app/packages/similarity-search/src/types/index.ts
+++ b/app/packages/similarity-search/src/types/index.ts
@@ -35,6 +35,16 @@ export type BrainKeyConfig = {
 };
 
 /**
+ * A brain key annotated with whether it can be used in the current
+ * view. Incompatible keys are still shown in the UI (grayed out) with
+ * `incompatibleReason` as hover text.
+ */
+export type AnnotatedBrainKeyConfig = BrainKeyConfig & {
+  compatible: boolean;
+  incompatibleReason?: string;
+};
+
+/**
  * Data model for a similarity search run.
  */
 export type SimilarityRun = {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Product direction change for the similarity search panel: instead of hiding similarity indexes that don't match the current view, show them **grayed out with an explanatory tooltip** — in both the similarity index page and the new-search index dropdown.

- A patch index shown in a sample view (and a patch view on a different patches field) is disabled with hover text "Cannot use a patch index in the current view"
- A dataset index shown in a patch view is disabled with hover text "Cannot use a dataset index in the current view"

## How is this patch implemented?

- `useSimilarityPanel`: brain keys are no longer filtered by view compatibility; each key is annotated with `compatible: boolean` and an `incompatibleReason` (new `AnnotatedBrainKeyConfig` type). The runs list remains filtered to runs on compatible indexes.
- Similarity index page: incompatible entries render at 50% opacity wrapped in a tooltip.
- New Search dropdown: the voodo `Select` has no per-option `disabled` support, so incompatible options get grayed, tooltip-wrapped `content` and the change handler rejects selecting them.
- `useNewSearchForm`: default selection, clone defaults, and the auto-correct effect only ever pick compatible keys; if the view changes while the form is open and the selected index becomes incompatible, selection resets to a compatible one.

Side effects (consistent with the product intent):
- The onboarding CTA now only appears when the dataset has no indexes at all (previously, having only an off-view index hid the whole panel behind the CTA)
- The "New Search" button enables whenever any index exists; the form then shows the disabled options with their tooltips

## How is this patch tested?

- All 33 existing unit tests in the package pass
- `tsc --noEmit` on the package reports the exact same error set as `main` (no new errors; the package has pre-existing voodo/mui type drift, plus a pre-existing missing local `ViewTarget` import on `main` being fixed separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Displays all available similarity indexes with compatibility status.
  * Shows explanatory tooltips when an index cannot be used.
  * Prevents incompatible indexes from being selected or used.
  * Automatically resets selections when compatibility changes.
  * Continues displaying index metadata and capability indicators.
  * Prioritizes compatible indexes in available results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3945
<!-- enterprise-sync-pr:end -->