### PR TITLE
Guard browser storage access so a broken profile cannot crash the modal

### DIFF
--- a/app/packages/core/src/components/Modal/Modal.tsx
+++ b/app/packages/core/src/components/Modal/Modal.tsx
@@ -1,3 +1,4 @@
+import { useTrackEvent } from "@fiftyone/analytics";
 import {
   useAutoSave,
   useRegisterAnnotationEventHandlers,
@@ -44,7 +45,7 @@ import { Sidebar } from "./Sidebar";
 import { SegmentationToolbar } from "./Sidebar/Annotate/Edit/SegmentationToolbar";
 import { useAnnotationStatus } from "./Sidebar/Annotate/Edit/useAnnotationStatus";
 import { useAnnotationTracking } from "./Sidebar/Annotate/useAnnotationTracking";
-import { TooltipInfo } from "./TooltipInfo";
+import { TooltipInfoBoundary } from "./TooltipInfoBoundary";
 import {
   useLookerHelpers,
   useShowClassicSidebar,
@@ -153,6 +154,22 @@ const Modal = () => {
   );
 
   const { jsonPanel, helpPanel } = useLookerHelpers();
+
+  const trackEvent = useTrackEvent();
+  const trackBoundaryError = useCallback(
+    (error: Error) => {
+      // same event the @fiftyone/components ErrorBoundary emits, so errors
+      // caught by these raw boundaries still reach analytics
+      trackEvent("uncaught_app_error", {
+        error: error?.message || error?.name || error,
+        stack: error?.stack,
+        messages: (error as Error & { errors?: Error[] })?.errors?.map(
+          (e) => e.message,
+        ),
+      });
+    },
+    [trackEvent],
+  );
 
   const modalCloseHandler = useRecoilCallback(
     ({ snapshot, set }) =>
@@ -350,6 +367,7 @@ const Modal = () => {
             place and resets on navigation like the main boundary. */}
         <ReactErrorBoundary
           FallbackComponent={ModalErrorFallback}
+          onError={trackBoundaryError}
           resetKeys={[modalSelector?.id, modalSelector?.groupId]}
         >
           <Actions />
@@ -359,15 +377,15 @@ const Modal = () => {
             <AnnotationHandlerRegistration />
           </Suspense>
         )}
-        <ReactErrorBoundary
+        <TooltipInfoBoundary
           FallbackComponent={ModalErrorFallback}
+          onError={trackBoundaryError}
           resetKeys={[modalSelector?.id, modalSelector?.groupId]}
-        >
-          <TooltipInfo />
-        </ReactErrorBoundary>
+        />
         <ModalContainer data-cy="modal-content" style={{ ...screenParams }}>
           <ReactErrorBoundary
             FallbackComponent={ModalErrorFallback}
+            onError={trackBoundaryError}
             resetKeys={[modalSelector?.id, modalSelector?.groupId]}
           >
             <OperatorPromptArea area={OPERATOR_PROMPT_AREAS.DRAWER_LEFT} />

--- a/app/packages/core/src/components/Modal/Modal.tsx
+++ b/app/packages/core/src/components/Modal/Modal.tsx
@@ -344,13 +344,27 @@ const Modal = () => {
         onClick={onClickModalWrapper}
         data-cy="modal"
       >
-        <Actions />
+        {/* Overlay chrome gets its own boundary: a render throw here (e.g. a
+            failing browser-storage read behind a cosmetic preference) must
+            not unmount the modal itself. Shows the error in the overlay's
+            place and resets on navigation like the main boundary. */}
+        <ReactErrorBoundary
+          FallbackComponent={ModalErrorFallback}
+          resetKeys={[modalSelector?.id, modalSelector?.groupId]}
+        >
+          <Actions />
+        </ReactErrorBoundary>
         {isAnnotationEnabled && (
           <Suspense>
             <AnnotationHandlerRegistration />
           </Suspense>
         )}
-        <TooltipInfo />
+        <ReactErrorBoundary
+          FallbackComponent={ModalErrorFallback}
+          resetKeys={[modalSelector?.id, modalSelector?.groupId]}
+        >
+          <TooltipInfo />
+        </ReactErrorBoundary>
         <ModalContainer data-cy="modal-content" style={{ ...screenParams }}>
           <ReactErrorBoundary
             FallbackComponent={ModalErrorFallback}

--- a/app/packages/core/src/components/Modal/Modal.tsx
+++ b/app/packages/core/src/components/Modal/Modal.tsx
@@ -159,13 +159,16 @@ const Modal = () => {
   const trackBoundaryError = useCallback(
     (error: Error) => {
       // same event the @fiftyone/components ErrorBoundary emits, so errors
-      // caught by these raw boundaries still reach analytics
+      // caught by these raw boundaries still reach analytics. Nested errors
+      // (e.g. AggregateError) can hold arbitrary values, so guard against
+      // throwing while reporting the original throw
+      const nested = (error as Error & { errors?: unknown })?.errors;
       trackEvent("uncaught_app_error", {
         error: error?.message || error?.name || error,
         stack: error?.stack,
-        messages: (error as Error & { errors?: Error[] })?.errors?.map(
-          (e) => e.message,
-        ),
+        messages: Array.isArray(nested)
+          ? nested.map((e) => (e instanceof Error ? e.message : String(e)))
+          : undefined,
       });
     },
     [trackEvent],

--- a/app/packages/core/src/components/Modal/TooltipInfoBoundary.test.tsx
+++ b/app/packages/core/src/components/Modal/TooltipInfoBoundary.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, cleanup, render, screen } from "@testing-library/react";
+import React from "react";
+import { FallbackProps } from "react-error-boundary";
+import { RecoilRoot, useSetRecoilState } from "recoil";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Provide just the @fiftyone/state surface the boundary imports.
+vi.mock("@fiftyone/state", async () => {
+  const { atom } = await vi.importActual<typeof import("recoil")>("recoil");
+  return {
+    tooltipDetail: atom<{ field: string; label?: { id?: string } } | null>({
+      key: "test_tooltipDetail",
+      default: null,
+    }),
+  };
+});
+
+// Stub the real tooltip (heavy dependency tree) with one that renders the
+// current detail and throws for a designated field, so the tests can drive
+// the boundary through error and recovery.
+vi.mock("./TooltipInfo", async () => {
+  const fos = await import("@fiftyone/state");
+  const { useRecoilValue } = await import("recoil");
+  return {
+    TooltipInfo: () => {
+      const detail = useRecoilValue(fos.tooltipDetail);
+      if (detail?.field === "explodes") {
+        throw new Error("tooltip render failure");
+      }
+      return <div data-testid="tooltip">{detail?.field ?? "empty"}</div>;
+    },
+  };
+});
+
+import * as fos from "@fiftyone/state";
+import {
+  TooltipInfoBoundary,
+  tooltipDetailIdentity,
+} from "./TooltipInfoBoundary";
+
+const Fallback = ({ error }: FallbackProps) => (
+  <div data-testid="fallback">{(error as Error).message}</div>
+);
+
+type Detail = { field: string; label?: { id?: string } } | null;
+
+let setDetail: (detail: Detail) => void;
+
+const CaptureSetter = () => {
+  setDetail = useSetRecoilState(
+    fos.tooltipDetail as import("recoil").RecoilState<Detail>,
+  );
+  return null;
+};
+
+const renderBoundary = (onError = vi.fn()) => {
+  render(
+    <RecoilRoot>
+      <CaptureSetter />
+      <TooltipInfoBoundary
+        FallbackComponent={Fallback}
+        onError={onError}
+        resetKeys={["sample-1"]}
+      />
+    </RecoilRoot>,
+  );
+  return onError;
+};
+
+describe("TooltipInfoBoundary", () => {
+  // React logs boundary-caught errors to the console and re-dispatches them
+  // on window; silence both to keep test output clean
+  const swallowWindowError = (e: ErrorEvent) => e.preventDefault();
+
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    window.addEventListener("error", swallowWindowError);
+  });
+
+  afterEach(() => {
+    window.removeEventListener("error", swallowWindowError);
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("renders the tooltip and reports the error when it throws", () => {
+    const onError = renderBoundary();
+    expect(screen.getByTestId("tooltip").textContent).toBe("empty");
+
+    act(() => setDetail({ field: "explodes", label: { id: "a" } }));
+
+    expect(screen.getByTestId("fallback").textContent).toBe(
+      "tooltip render failure",
+    );
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  it("recovers and renders detail B after detail A throws", () => {
+    renderBoundary();
+
+    act(() => setDetail({ field: "explodes", label: { id: "a" } }));
+    expect(screen.getByTestId("fallback")).toBeTruthy();
+
+    act(() => setDetail({ field: "confidence", label: { id: "b" } }));
+
+    expect(screen.queryByTestId("fallback")).toBeNull();
+    expect(screen.getByTestId("tooltip").textContent).toBe("confidence");
+  });
+});
+
+describe("tooltipDetailIdentity", () => {
+  it("prefers the canonical label id and falls back to field", () => {
+    expect(
+      tooltipDetailIdentity({ label: { _id: "x", id: "y" }, field: "f" }),
+    ).toBe("x");
+    expect(tooltipDetailIdentity({ label: { id: "y" }, field: "f" })).toBe("y");
+    expect(tooltipDetailIdentity({ field: "f" })).toBe("f");
+    expect(tooltipDetailIdentity(null)).toBeUndefined();
+  });
+});

--- a/app/packages/core/src/components/Modal/TooltipInfoBoundary.tsx
+++ b/app/packages/core/src/components/Modal/TooltipInfoBoundary.tsx
@@ -1,0 +1,45 @@
+import * as fos from "@fiftyone/state";
+import { ComponentType } from "react";
+import {
+  FallbackProps,
+  ErrorBoundary as ReactErrorBoundary,
+} from "react-error-boundary";
+import { useRecoilValue } from "recoil";
+import { TooltipInfo } from "./TooltipInfo";
+
+/**
+ * Identity of the overlay a tooltip detail describes. Stable across pointer
+ * moves over the same label, so an errored boundary retries only when the
+ * user hovers something else.
+ */
+export const tooltipDetailIdentity = (
+  detail: { label?: { _id?: string; id?: string }; field?: string } | null,
+) => detail?.label?._id ?? detail?.label?.id ?? detail?.field;
+
+/**
+ * Error boundary for the floating tooltip. Subscribes to the tooltip detail
+ * here rather than in Modal so hover updates do not rerender the whole modal,
+ * and folds the hovered overlay's identity into resetKeys: Modal does not
+ * otherwise subscribe to tooltip state, so without this a throw on one label
+ * would leave the fallback up until sample navigation.
+ */
+export const TooltipInfoBoundary = ({
+  FallbackComponent,
+  onError,
+  resetKeys,
+}: {
+  FallbackComponent: ComponentType<FallbackProps>;
+  onError: (error: Error, info: { componentStack: string }) => void;
+  resetKeys: unknown[];
+}) => {
+  const detail = useRecoilValue(fos.tooltipDetail);
+  return (
+    <ReactErrorBoundary
+      FallbackComponent={FallbackComponent}
+      onError={onError}
+      resetKeys={[...resetKeys, tooltipDetailIdentity(detail)]}
+    >
+      <TooltipInfo />
+    </ReactErrorBoundary>
+  );
+};

--- a/app/packages/state/src/hooks/useBrowserStorage.test.ts
+++ b/app/packages/state/src/hooks/useBrowserStorage.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useBrowserStorage } from "./useBrowserStorage";
 
 // Utility wrapper for cleaner access
@@ -191,5 +191,69 @@ describe("useBrowserStorage", () => {
       expect(result.current.value).toBe(51);
       expect(localStorage.getItem("test-key")).toBe("51");
     });
+  });
+});
+
+describe("storage failures", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("falls back to the initial value when reads throw", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("NS_ERROR_FAILURE");
+    });
+
+    const { result } = renderHook(() => useTestableState("broken", "default"));
+
+    expect(result.current.value).toBe("default");
+  });
+
+  it("keeps in-memory state when writes throw", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("NS_ERROR_FAILURE");
+    });
+
+    const { result } = renderHook(() => useTestableState("broken", "default"));
+
+    act(() => {
+      result.current.setState("next");
+    });
+
+    expect(result.current.value).toBe("next");
+  });
+
+  it("falls back to the initial value on corrupt stored JSON", () => {
+    localStorage.setItem("corrupt", "{not json");
+
+    const { result } = renderHook(() => useTestableState("corrupt", "default"));
+
+    expect(result.current.value).toBe("default");
+  });
+
+  it("works in-memory when the storage accessor itself throws", () => {
+    const original = Object.getOwnPropertyDescriptor(window, "localStorage");
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      get() {
+        throw new Error("NS_ERROR_FAILURE");
+      },
+    });
+
+    try {
+      const { result } = renderHook(() => useTestableState("gone", "default"));
+
+      expect(result.current.value).toBe("default");
+
+      act(() => {
+        result.current.setState("next");
+      });
+
+      expect(result.current.value).toBe("next");
+    } finally {
+      if (original) {
+        Object.defineProperty(window, "localStorage", original);
+      }
+    }
   });
 });

--- a/app/packages/state/src/hooks/useBrowserStorage.ts
+++ b/app/packages/state/src/hooks/useBrowserStorage.ts
@@ -1,5 +1,18 @@
 import { useCallback, useState } from "react";
 
+// Browser storage can be entirely unavailable: Firefox surfaces profile-level
+// storage failures as NS_ERROR_FAILURE thrown from the `window.localStorage`
+// accessor itself or from any read/write, and blocked site data raises
+// SecurityError. This hook backs cosmetic preferences, so storage failures
+// degrade to plain in-memory state instead of throwing mid-render.
+const resolveStorage = (useSessionStorage: boolean): Storage | null => {
+  try {
+    return useSessionStorage ? window.sessionStorage : window.localStorage;
+  } catch {
+    return null;
+  }
+};
+
 // riffed from https://usehooks.com/useLocalStorage/
 export const useBrowserStorage = <T = string>(
   key: string,
@@ -10,25 +23,19 @@ export const useBrowserStorage = <T = string>(
     stringify: (value: T) => string;
   },
 ) => {
-  const storage = useSessionStorage
-    ? window.sessionStorage
-    : window.localStorage;
+  const storage = resolveStorage(useSessionStorage);
 
   // Pass initial state function to useState so logic is only executed once
   const [storedValue, setStoredValue] = useState<T>(() => {
-    const item = storage.getItem(key);
+    try {
+      const item = storage?.getItem(key);
 
-    if (item) {
-      // Workaround for existing "undefined" values in storage
-      if (item === "undefined") {
-        return initialValue instanceof Function ? initialValue() : initialValue;
+      // "undefined" guards existing values written by an older stringify bug
+      if (item && item !== "undefined") {
+        return parseFn ? parseFn.parse(item) : JSON.parse(item);
       }
-
-      if (parseFn) {
-        return parseFn.parse(item);
-      }
-
-      return JSON.parse(item);
+    } catch {
+      // Unreadable or corrupt storage — fall through to the initial value.
     }
 
     return initialValue instanceof Function ? initialValue() : initialValue;
@@ -49,15 +56,19 @@ export const useBrowserStorage = <T = string>(
         setStoredValue(value);
       }
 
-      // Handle undefined values by removing from storage
-      if (valueToStore === undefined) {
-        storage.removeItem(key);
-      } else if (parseFn) {
-        // Let the custom parser handle other values
-        storage.setItem(key, parseFn.stringify(valueToStore));
-      } else {
-        // For JSON.stringify, handle other values
-        storage.setItem(key, JSON.stringify(valueToStore));
+      try {
+        // Handle undefined values by removing from storage
+        if (valueToStore === undefined) {
+          storage?.removeItem(key);
+        } else if (parseFn) {
+          // Let the custom parser handle other values
+          storage?.setItem(key, parseFn.stringify(valueToStore));
+        } else {
+          // For JSON.stringify, handle other values
+          storage?.setItem(key, JSON.stringify(valueToStore));
+        }
+      } catch {
+        // Write failed — the in-memory state above is already updated.
       }
     },
     [key, storage, parseFn],


### PR DESCRIPTION
## Problem

`useBrowserStorage` performs three unguarded browser-storage operations: resolving `window.localStorage` / `window.sessionStorage`, reading + `JSON.parse`-ing in its `useState` initializer, and writing in its setter. Firefox surfaces profile-level storage failures as `NS_ERROR_FAILURE` thrown from any of these -- including the `window.localStorage` property access itself -- and blocked site data raises `SecurityError`.

Because the modal's action bar calls this hook during render, a browser with broken storage throws mid-render, the modal error boundary tears the whole modal down, and the user is dropped back to the grid. Observed in the wild on Firefox (clearing site data un-breaks it). The hook has ~15 call sites across core, looker-3d, operators, multimodal, auto-labeling, and similarity-search, so every one is a latent crash of the same shape -- all to back cosmetic preferences.

## Fix

**`useBrowserStorage.ts`** -- degrade to plain in-memory state on any storage failure:
- `resolveStorage()` wraps the `window.(local|session)Storage` accessor itself (it can throw before any read); failure yields `null` and the hook runs memory-only.
- The `useState` initializer wraps read + parse (corrupt stored JSON included), falling back to `initialValue`.
- The setter wraps `setItem`/`removeItem`; on failure the in-memory state is already updated, so the feature keeps working for the session.

**`Modal.tsx`** -- containment for whatever slips through: `<Actions />` and `<TooltipInfo />` each get their own `ReactErrorBoundary` reusing the modal's `ModalErrorFallback`, with the same `resetKeys` as the main content boundary. A render throw in overlay chrome now shows the error (with its reset control) in the overlay's place instead of unmounting the whole modal, and resets on navigation. Surfacing the error rather than hiding it is deliberate -- a visible error is debuggable; a silently missing action bar is the next unreproducible report. The components are guarded in place rather than moved inside `ModalContainer`'s boundary so the overlay positioning context and DOM order stay unchanged.

## Testing

- `useBrowserStorage.test.ts`: 4 new failure-injection tests (reads throw, writes throw, corrupt stored JSON, and the storage *accessor itself* throwing -- the Firefox failure mode); 16/16 green including the pre-existing cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved modal stability by isolating failures in actions and information overlays, preventing unexpected modal closures.
  - Improved tooltip recovery when displayed details change or encounter an error.
  - Improved browser storage resilience when storage is unavailable, unreadable, corrupted, or cannot be written.
  - Settings and other stored values now safely fall back to defaults while continuing to work during the current session.
- **Tests**
  - Added coverage for modal error recovery, tooltip behavior, and storage failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3931
<!-- enterprise-sync-pr:end -->