### PR TITLE
FOEPD-4588: hide audio controls on silent recordings and fail worklet loads gracefully

### DIFF
--- a/app/packages/multimodal/src/audio/audio-stream-engine.ts
+++ b/app/packages/multimodal/src/audio/audio-stream-engine.ts
@@ -13,7 +13,6 @@
 // timeline with no way to notice.
 // ---------------------------------------------------------------------------
 
-import workletUrl from "./audio-stream-processor.worklet?worker&url";
 import {
   AudioRingBuffer,
   allocateAudioRing,
@@ -119,6 +118,37 @@ declare global {
 // in the render thread.
 // ---------------------------------------------------------------------------
 
+/**
+ * Resolved on first use rather than imported at module scope.
+ *
+ * `?worker&url` is a bundler contract, not a language feature. A bundler
+ * that does not implement it evaluates the worklet inside the app bundle
+ * instead of emitting a separate module asset, and the worklet then throws
+ * `AudioWorkletProcessor is not defined` — a global that only exists on the
+ * render thread. As a static import that happened during module evaluation,
+ * before any caller existed to catch it, so a shell that mis-bundles the
+ * worklet lost the whole episode modal rather than just its audio.
+ *
+ * Deferring it moves that failure inside `acquireAudioContext`, where it
+ * surfaces as a rejected `ready` and the existing handler in
+ * `use-audio-stream-playback.ts` degrades it to an audio-only error.
+ *
+ * The promise is memoized so concurrent sources share one fetch, but cleared
+ * on rejection: this is a chunk load, so a transient network failure must not
+ * poison every later attempt.
+ */
+let workletUrlPromise: Promise<string> | undefined;
+
+function resolveWorkletUrl(): Promise<string> {
+  workletUrlPromise ??= import("./audio-stream-processor.worklet?worker&url")
+    .then((module) => module.default)
+    .catch((error: unknown) => {
+      workletUrlPromise = undefined;
+      throw error;
+    });
+  return workletUrlPromise;
+}
+
 interface ContextLease {
   readonly audioContext: AudioContext;
   release(): Promise<void>;
@@ -142,7 +172,9 @@ async function acquireAudioContext(sampleRate: number): Promise<ContextLease> {
       // Registered once per context, not once per engine: `addModule` is
       // idempotent but re-awaiting it per source serialises engine startup
       // behind a fetch that has already happened.
-      ready: audioContext.audioWorklet.addModule(workletUrl),
+      ready: resolveWorkletUrl().then((url) =>
+        audioContext.audioWorklet.addModule(url),
+      ),
       leases: 0,
     };
     SHARED_CONTEXTS.set(sampleRate, shared);

--- a/app/packages/multimodal/src/views/episode/audio/RegisterMcapAudioStreams.test.tsx
+++ b/app/packages/multimodal/src/views/episode/audio/RegisterMcapAudioStreams.test.tsx
@@ -12,16 +12,21 @@ const mocks = vi.hoisted(() => ({
   }>,
   /** Every `enabled` value `useMcapAudioStream` has been called with. */
   enabledCalls: [] as boolean[],
+  /** Every `(sourceId, label)` pair the registrar mounted a stream for. */
+  streamCalls: [] as Array<{ sourceId: string; label: string }>,
+  registerAudioTrack: vi.fn(() => vi.fn()),
+  setAudioAvailable: vi.fn(),
 }));
 
 vi.mock("@fiftyone/playback", () => ({
   useAudio: () => ({
     masterMuted: mocks.masterMuted,
     tracks: [{ id: "audio-1", muted: mocks.trackMuted }],
+    registerAudioTrack: mocks.registerAudioTrack,
   }),
   useIsPlaying: () => mocks.isPlaying,
   usePlaybackStore: () => ({}),
-  setAudioAvailable: vi.fn(),
+  setAudioAvailable: mocks.setAudioAvailable,
 }));
 
 vi.mock("../../../scene-inventory/react", () => ({
@@ -37,8 +42,12 @@ vi.mock("../../../audio/audio-source-registry", () => ({
 // Here it is a probe: all this test cares about is whether the registrar
 // asked it to run.
 vi.mock("./use-mcap-audio-stream", () => ({
-  useMcapAudioStream: (_sourceId: string, options: { enabled: boolean }) => {
+  useMcapAudioStream: (
+    sourceId: string,
+    options: { enabled: boolean; label: string },
+  ) => {
     mocks.enabledCalls.push(options.enabled);
+    mocks.streamCalls.push({ sourceId, label: options.label });
     return { status: "idle", hasAudio: false };
   },
 }));
@@ -57,6 +66,10 @@ describe("RegisterMcapAudioStreams demand gating", () => {
     mocks.isPlaying = false;
     mocks.requested = false;
     mocks.enabledCalls.length = 0;
+    mocks.streamCalls.length = 0;
+    mocks.sources = [{ id: "audio-1", label: "Front mic" }];
+    mocks.registerAudioTrack.mockClear();
+    mocks.setAudioAvailable.mockClear();
   });
 
   afterEach(cleanup);
@@ -123,5 +136,88 @@ describe("RegisterMcapAudioStreams demand gating", () => {
     mocks.isPlaying = true;
     render(<RegisterMcapAudioStreams />);
     expect(lastEnabled()).toBe(false);
+  });
+});
+
+/**
+ * Presence, as distinct from the demand gating above: whether this recording
+ * advertises audio at all. Every test in that suite runs with a non-empty
+ * source list, so the empty case — by far the common one, since most
+ * recordings carry no audio — went uncovered.
+ *
+ * It reached production as a synthetic "Audio (stub)" track that the
+ * registrar mounted whenever a scene had no real audio source, which also
+ * pushed `setAudioAvailable(store, "available")`. That single call was what
+ * put master volume and the Mixed dropdown on datasets with no audio topics
+ * at all (nuscenes, among others). These tests pin the invariant that
+ * replaced it: no sources means no audio surface, full stop.
+ */
+describe("RegisterMcapAudioStreams presence", () => {
+  beforeEach(() => {
+    mocks.masterMuted = true;
+    mocks.trackMuted = false;
+    mocks.isPlaying = false;
+    mocks.requested = false;
+    mocks.enabledCalls.length = 0;
+    mocks.streamCalls.length = 0;
+    mocks.sources = [{ id: "audio-1", label: "Front mic" }];
+    mocks.registerAudioTrack.mockClear();
+    mocks.setAudioAvailable.mockClear();
+  });
+
+  afterEach(cleanup);
+
+  it("registers no audio track for a recording with no audio sources", () => {
+    mocks.sources = [];
+    render(<RegisterMcapAudioStreams />);
+    expect(mocks.registerAudioTrack).not.toHaveBeenCalled();
+  });
+
+  // The specific regression: availability is what the volume control and the
+  // Mixed dropdown gate on, so anything that marks a silent recording
+  // "available" puts controls on screen that can never do anything.
+  it("never marks audio available when there are no audio sources", () => {
+    mocks.sources = [];
+    render(<RegisterMcapAudioStreams />);
+    expect(mocks.setAudioAvailable).not.toHaveBeenCalled();
+  });
+
+  it("starts no audio stream when there are no audio sources", () => {
+    mocks.sources = [];
+    render(<RegisterMcapAudioStreams />);
+    expect(mocks.streamCalls).toEqual([]);
+  });
+
+  // The registrar mounts beside every scene, including shells rendered
+  // without a `SceneInventoryProvider`. No inventory must read as "no audio"
+  // rather than taking the shell down.
+  it("renders without crashing when there is no scene inventory", () => {
+    mocks.sources = [];
+    expect(() => render(<RegisterMcapAudioStreams />)).not.toThrow();
+  });
+
+  it("mounts one stream per real audio source, passing each label through", () => {
+    mocks.sources = [
+      { id: "audio-1", label: "Front mic" },
+      { id: "audio-2", label: "Cabin mic" },
+    ];
+    render(<RegisterMcapAudioStreams />);
+    expect(mocks.streamCalls).toEqual([
+      { sourceId: "audio-1", label: "Front mic" },
+      { sourceId: "audio-2", label: "Cabin mic" },
+    ]);
+  });
+
+  // Labels matter beyond cosmetics: without one the mixer row and tile header
+  // fall back to the raw stream id ("0", "1").
+  it("stops advertising audio when a sample with sources is replaced by one without", () => {
+    const { rerender } = render(<RegisterMcapAudioStreams />);
+    expect(mocks.streamCalls).toHaveLength(1);
+
+    mocks.sources = [];
+    mocks.streamCalls.length = 0;
+    rerender(<RegisterMcapAudioStreams />);
+    expect(mocks.streamCalls).toEqual([]);
+    expect(mocks.registerAudioTrack).not.toHaveBeenCalled();
   });
 });

--- a/app/packages/multimodal/src/views/episode/audio/RegisterMcapAudioStreams.tsx
+++ b/app/packages/multimodal/src/views/episode/audio/RegisterMcapAudioStreams.tsx
@@ -1,9 +1,4 @@
-import {
-  useAudio,
-  useIsPlaying,
-  usePlaybackStore,
-  setAudioAvailable,
-} from "@fiftyone/playback";
+import { useAudio, useIsPlaying } from "@fiftyone/playback";
 import React, { useEffect, useState } from "react";
 
 import {
@@ -84,33 +79,6 @@ const AudioSourceRegistrar: React.FC<{
 };
 
 /**
- * TEMPORARY stub: when a scene has no real audio scene source yet (no
- * decoder support for the file's encoding, e.g. JSON-encoded
- * `foxglove.RawAudio`), register one synthetic placeholder track anyway so
- * the master volume control, the Mixed dropdown, and the main-timeline
- * audio row are all reachable/testable in a real browser before the real
- * decode path is debugged. Remove once every real audio source classifies
- * and decodes correctly end to end.
- */
-const StubAudioTrack: React.FC = () => {
-  const store = usePlaybackStore();
-  const { registerAudioTrack } = useAudio();
-  useEffect(() => {
-    setAudioAvailable(store, "available");
-    const unregister = registerAudioTrack({
-      id: "audio-stub",
-      label: "Audio (stub)",
-      kind: "native-element",
-    });
-    return () => {
-      unregister();
-      setAudioAvailable(store, "unavailable");
-    };
-  }, [store, registerAudioTrack]);
-  return null;
-};
-
-/**
  * Ambient audio registrar for the MCAP scene viewer — mirrors
  * `video-annotation`'s `RegisterTimelineAudio`, which mounts unconditionally
  * alongside the video so native audio plays/mixes regardless of which tile
@@ -133,17 +101,13 @@ const RegisterMcapAudioStreams: React.FC = () => {
   const sources = useOptionalSceneSourcesByType(SCENE_SOURCE_TYPE.AUDIO);
   return (
     <>
-      {sources.length === 0 ? (
-        <StubAudioTrack />
-      ) : (
-        sources.map((source) => (
-          <AudioSourceRegistrar
-            key={source.id}
-            label={source.label}
-            sourceId={source.id}
-          />
-        ))
-      )}
+      {sources.map((source) => (
+        <AudioSourceRegistrar
+          key={source.id}
+          label={source.label}
+          sourceId={source.id}
+        />
+      ))}
     </>
   );
 };


### PR DESCRIPTION
## 🔗 Related Issues

Jira: [FOEPD-4588](https://voxel51.atlassian.net/browse/FOEPD-4588) — *Replace the audio worklet bundling bandaid*

Also picks up the two UI nits Sashank raised alongside the prod crash report.

## 📋 What changes are proposed in this pull request?

Follow-up to the audio PR, covering the UI nits and the non-graceful failure. Two independent changes:

**1. Stop advertising audio on recordings that have none** (`RegisterMcapAudioStreams.tsx`)

`RegisterMcapAudioStreams` mounted a synthetic `StubAudioTrack` whenever a scene had no real audio source. It registered a track labelled `"Audio (stub)"` **and** called `setAudioAvailable(store, "available")`. That availability push was the only thing in `multimodal` marking audio as present, so master volume and the Mixed dropdown appeared on every recording with no audio topics — nuscenes among them.

One deletion fixes both nits. `VolumeControl` and `MixedAudioDropdown` already render nothing when no integration has published availability, so they now correctly disappear. The stub was explicitly marked `TEMPORARY`, standing in for a decode path that has since been working unaided; removing it exposed no other caller.

**2. Resolve the audio worklet URL lazily** (`audio-stream-engine.ts`) — FOEPD-4588

`?worker&url` is a bundler contract, not a language feature. A bundler that does not implement it evaluates the worklet inside the app bundle, where `AudioWorkletProcessor` does not exist. As a **static** import that throw landed during module evaluation — before any caller existed to catch it — which is why a bundling problem took down the entire episode modal and blanked the visual tiles instead of just costing the scene its audio.

Deferring the import moves the failure inside `acquireAudioContext`, where it surfaces as a rejected `ready` and the **existing** handler in `use-audio-stream-playback.ts` degrades it to an audio-only error. The promise is memoized so concurrent sources share one fetch, and cleared on rejection so a transient chunk-load failure cannot poison later attempts.

**On the packaging boundary itself:** this deliberately does *not* replace the bandaid. `@fiftyone/multimodal` is a source-only package (`main: ./src/index.ts`), so the host bundler compiles its TypeScript directly and any bundler-specific contract leaks into every consumer. There is no shared native contract to migrate to — Vite and Webpack both recognise `new Worker(new URL(..., import.meta.url))` (which is why the MCAP workers never broke in Enterprise) but neither treats `audioWorklet.addModule()` as a boundary. Ahead-of-time bundling into a committed generated artifact was evaluated and consciously deferred: two known consumers, both handled, versus a generated file that can silently drift. Reasoning is recorded on the ticket. The Enterprise webpack rule (`fiftyone-teams` `e3564ba24d`) stays as the supported path and needs no change.

## 🧪 How is this patch tested? If it is not, please explain why.

**New tests** — a `presence` suite in `RegisterMcapAudioStreams.test.tsx` (6 tests). The existing suite covered demand gating well but ran every case with a non-empty source list, so the empty case — by far the common one — went untested. That is how the stub survived. New cases: no track registered, `setAudioAvailable` never called, no stream started, no crash without a scene inventory, one stream per real source with labels passed through, and the has-audio → none sample transition.

These were verified to actually catch the bug, not merely pass: temporarily restoring `StubAudioTrack` fails exactly three of them and they pass again once it is removed.

**Bundler verification** — unit tests do not exercise real bundling, and this changes a static import to a dynamic one, so both shells were checked directly:

- *Vite (real OSS `yarn build`)*: emits a 105-byte URL stub feeding a 3KB self-contained worklet with the ring buffer inlined. `registerProcessor` appears only in that asset, never in the app bundle.
- *Webpack*: harness using Next 15.5.21's bundled webpack with the Enterprise rule and loader verbatim, comparing static vs dynamic imports. Both emit the same content-hashed asset (identical hash `e8cc66b3888347dc8cbc`), dependency inlined, `registerProcessor` absent from the app bundle. Content-hashing intact, so cache invalidation is preserved.

**Suites** — 660 tests passing across 50 files (`multimodal` audio + episode audio, `playback`). `multimodal` typecheck, lint, and deps clean. Prettier clean.

**Not covered** — no e2e run for the Enterprise path; the webpack result above is from an isolated harness rather than a full Teams build. Worth an ephemeral deploy before merge, per Sashank's point about testing big features there first.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

Volume and audio mixer controls no longer appear on recordings that contain no audio. Audio that fails to initialise now degrades to an audio-only error instead of leaving the episode modal blank.

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other


[FOEPD-4588]: https://voxel51.atlassian.net/browse/FOEPD-4588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved audio setup reliability by retrying worklet loading after temporary failures.
  - Recordings without audio sources no longer create misleading audio tracks or advertise audio availability.
  - Audio streams now start and stop correctly as available sources change.

- **Tests**
  - Added coverage for recordings with and without audio sources, labeled stream registration, and stream cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3936
<!-- enterprise-sync-pr:end -->