### PR TITLE
Pin a temporal tag on creation, and offer the dataset's tags in the dropdown

### DIFF
--- a/app/packages/multimodal/src/views/episode/playback/use-temporal-tags.test.ts
+++ b/app/packages/multimodal/src/views/episode/playback/use-temporal-tags.test.ts
@@ -34,7 +34,9 @@ const colorForTag = vi.hoisted(() => vi.fn(() => "#123456"));
 
 vi.mock("@fiftyone/state", () => ({
   useActiveTemporalTagFilterValues: () => [],
+  useSyncTemporalTagResults: () => undefined,
   useTemporalTagColor: () => colorForTag,
+  useTemporalTagValues: () => [],
 }));
 
 vi.mock("../../../temporal-tags", () => ({

--- a/app/packages/multimodal/src/views/episode/playback/use-temporal-tags.ts
+++ b/app/packages/multimodal/src/views/episode/playback/use-temporal-tags.ts
@@ -6,7 +6,9 @@ import type {
 } from "@fiftyone/playback";
 import {
   useActiveTemporalTagFilterValues,
+  useSyncTemporalTagResults,
   useTemporalTagColor,
+  useTemporalTagValues,
 } from "@fiftyone/state";
 import { useCallback, useMemo } from "react";
 import { useSampleRendererTemporalTags } from "../../../temporal-tags";
@@ -22,6 +24,8 @@ const temporalTagTrackId = (label: string): string =>
 
 export interface TemporalTagsResult {
   tracks: Track[];
+  /** Every tag label in the dataset, for the creation popup's dropdown. */
+  existingTags: string[];
   onTagCreate: (tag: TemporalTagCreatePayload) => Promise<void>;
   onTagUpdate: (tag: TemporalTagUpdatePayload) => Promise<void>;
   onTagDelete: (event: { data?: unknown }) => Promise<void>;
@@ -103,7 +107,14 @@ export function useTemporalTags(
     }));
   }, [temporalTags, colorForTag]);
 
-  return { tracks, onTagCreate, onTagUpdate, onTagDelete };
+  // The dropdown offers the whole dataset's vocabulary, not just this
+  // sample's tags — otherwise the first tag on any sample has nothing to pick
+  // from and every label has to be retyped. The sidebar filter loads the same
+  // atom; loading here too covers the modal being opened without it.
+  useSyncTemporalTagResults();
+  const existingTags = useTemporalTagValues();
+
+  return { tracks, existingTags, onTagCreate, onTagUpdate, onTagDelete };
 }
 
 /**

--- a/app/packages/multimodal/src/views/episode/shell/ModalRenderer.tsx
+++ b/app/packages/multimodal/src/views/episode/shell/ModalRenderer.tsx
@@ -35,6 +35,7 @@ const ModalRenderer: React.FC<SampleRendererProps> = ({ ctx }) => {
   const datasetId = ctx.dataset.datasetId;
   const {
     tracks: tagTracks,
+    existingTags,
     onTagCreate,
     onTagUpdate,
     onTagDelete,
@@ -82,6 +83,7 @@ const ModalRenderer: React.FC<SampleRendererProps> = ({ ctx }) => {
             initialSeekTimeNs={firstMatch?.startNs ?? null}
             layoutScopeKey={datasetId}
             cameraPreferenceField={ctx.media.field}
+            existingTags={existingTags}
             onTagCreate={onTagCreate}
             onTagUpdate={onTagUpdate}
             onTagDelete={onTagDelete}

--- a/app/packages/multimodal/src/views/episode/shell/PlaybackShell.tsx
+++ b/app/packages/multimodal/src/views/episode/shell/PlaybackShell.tsx
@@ -186,6 +186,8 @@ export interface PlaybackShellProps {
    * the temporal-tag workflow is enabled in the timeline (button, `T`
    * hotkey, Shift+drag).
    */
+  /** Dataset-wide tag labels for the creation popup's dropdown. */
+  existingTags?: TemporalTagTimelineProps["existingTags"];
   onTagCreate?: TemporalTagTimelineProps["onTagCreate"];
   onTagUpdate?: TemporalTagTimelineProps["onTagUpdate"];
   /** Callback that deletes an existing temporal tag by its backend id. */
@@ -272,6 +274,7 @@ const PlaybackShell: React.FC<PlaybackShellProps> = ({
   mainOverlay,
   leftSidebarWidth,
   onLeftSidebarWidthChange,
+  existingTags,
   onTagCreate,
   onTagUpdate,
   onTagDelete,
@@ -323,6 +326,7 @@ const PlaybackShell: React.FC<PlaybackShellProps> = ({
               mainOverlay={mainOverlay}
               leftSidebarWidth={leftSidebarWidth}
               onLeftSidebarWidthChange={onLeftSidebarWidthChange}
+              existingTags={existingTags}
               onTagCreate={onTagCreate}
               onTagUpdate={onTagUpdate}
               onTagDelete={onTagDelete}
@@ -364,6 +368,8 @@ interface LayoutProps {
   mainOverlay?: ReactNode;
   leftSidebarWidth?: number;
   onLeftSidebarWidthChange?: (px: number) => void;
+  /** Dataset-wide tag labels for the creation popup's dropdown. */
+  existingTags?: PlaybackShellProps["existingTags"];
   onTagCreate?: PlaybackShellProps["onTagCreate"];
   onTagUpdate?: PlaybackShellProps["onTagUpdate"];
   onTagDelete?: PlaybackShellProps["onTagDelete"];
@@ -394,6 +400,7 @@ function Layout({
   mainOverlay,
   leftSidebarWidth,
   onLeftSidebarWidthChange,
+  existingTags,
   onTagCreate,
   onTagUpdate,
   onTagDelete,
@@ -614,6 +621,7 @@ function Layout({
         decorateTrack={decorateTrack}
         readouts={timelineReadouts}
         extraActions={timelineExtraActions}
+        existingTags={existingTags}
         onTagCreate={onTagCreate}
         onTagUpdate={onTagUpdate}
         eventMenuItems={

--- a/app/packages/multimodal/src/views/episode/shell/SourcePlayback.tsx
+++ b/app/packages/multimodal/src/views/episode/shell/SourcePlayback.tsx
@@ -132,6 +132,8 @@ export interface SourcePlaybackProps {
   readonly layoutScopeKey?: string;
   /** Host selected a new sample whose media descriptor is still resolving. */
   readonly navigationPending?: boolean;
+  /** Dataset-wide tag labels for the creation popup's dropdown. */
+  readonly existingTags?: TemporalTagTimelineProps["existingTags"];
   readonly onTagCreate?: TemporalTagTimelineProps["onTagCreate"];
   readonly onTagUpdate?: TemporalTagTimelineProps["onTagUpdate"];
   readonly onTagDelete?: NonNullable<
@@ -161,6 +163,7 @@ export const SourcePlayback: React.FC<SourcePlaybackProps> = ({
   initialSeekTimeNs,
   layoutScopeKey,
   navigationPending = false,
+  existingTags,
   onTagCreate,
   onTagUpdate,
   onTagDelete,
@@ -630,6 +633,7 @@ export const SourcePlayback: React.FC<SourcePlaybackProps> = ({
                                 onLeftSidebarWidthChange={
                                   onLeftSidebarWidthChange
                                 }
+                                existingTags={existingTags}
                                 onTagCreate={onTagCreate}
                                 onTagUpdate={onTagUpdate}
                                 onTimelineDrawerOpenChange={

--- a/app/packages/playback/src/views/TemporalTag/TemporalTagTimeline.tsx
+++ b/app/packages/playback/src/views/TemporalTag/TemporalTagTimeline.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from "react";
 import { TIMELINE_LABEL_WIDTH } from "../../lib/constants";
-import { useTracks } from "../../lib/tracks/TrackProvider";
+import { useTracks, useTrackPinning } from "../../lib/tracks/TrackProvider";
 import { TemporalTagProvider } from "./TemporalTagContext";
 import type {
   TemporalTagCreatePayload,
@@ -14,11 +14,22 @@ import TimelineWithTracks from "../TimelineWithTracks/TimelineWithTracks";
 import type { TimelineWithTracksProps } from "../TimelineWithTracks/TimelineWithTracks";
 import type { TrackEventMenuItem } from "../TimelineTrack/TimelineTrack";
 
+/** Track-id prefix for a temporal-tag group; the host builds the same ids. */
+const TEMPORAL_TAG_TRACK_PREFIX = "temporal-tag::";
+
 export interface TemporalTagTimelineProps extends TimelineWithTracksProps {
   onTagCreate?: (tag: TemporalTagCreatePayload) => Promise<void>;
   /** When provided, adds an "Edit tag" context-menu action that opens the
    *  popup pre-filled to mutate that tag's time range / label. */
   onTagUpdate?: (tag: TemporalTagUpdatePayload) => Promise<void>;
+  /**
+   * Tag labels offered by the "add to existing tag" dropdown. Hosts pass the
+   * whole dataset's labels; without it the dropdown can only offer what the
+   * current sample already carries, which is nothing on the first tag of a
+   * dataset. Merged with the labels on the timeline, so a tag created in this
+   * session is selectable before the host's list refreshes.
+   */
+  existingTags?: readonly string[];
 }
 
 /**
@@ -32,6 +43,7 @@ export interface TemporalTagTimelineProps extends TimelineWithTracksProps {
 const TemporalTagTimeline: React.FC<TemporalTagTimelineProps> = ({
   onTagCreate,
   onTagUpdate,
+  existingTags: hostTags,
   labelWidth: requestedLabelWidth = TIMELINE_LABEL_WIDTH,
   rulerOverlay,
   extraActions,
@@ -39,22 +51,37 @@ const TemporalTagTimeline: React.FC<TemporalTagTimelineProps> = ({
   ...timelineProps
 }) => {
   const tracks = useTracks();
+  const { setPinned } = useTrackPinning();
   const { state, actions } = useTemporalTagMode();
 
   // Mirror TimelineWithTracks's own labelWidth logic so the overlay aligns.
   const labelWidth = tracks.length === 0 ? 0 : requestedLabelWidth;
 
-  const existingTags = useMemo(
-    () =>
-      tracks
-        .filter((t) => t.id.startsWith("temporal-tag::"))
-        .map((t) => t.label),
-    [tracks],
-  );
+  const existingTags = useMemo(() => {
+    const onTimeline = tracks
+      .filter((t) => t.id.startsWith(TEMPORAL_TAG_TRACK_PREFIX))
+      .map((t) => t.label);
+    // Host list first: it is the dataset-wide vocabulary, and the timeline
+    // only contributes labels it hasn't caught up with yet.
+    return Array.from(new Set([...(hostTags ?? []), ...onTimeline]));
+  }, [tracks, hostTags]);
+
+  // Pin the tag's track on creation so a new tag is visible without the user
+  // hunting for it in the drawer. The track for a brand-new label does not
+  // exist until the write round-trips, but pinning is by id and the timeline
+  // renders only pinned tracks that exist, so pinning ahead is safe.
+  const handleTagCreate = useMemo(() => {
+    if (!onTagCreate) return undefined;
+    return async (tag: TemporalTagCreatePayload) => {
+      await onTagCreate(tag);
+      setPinned(`${TEMPORAL_TAG_TRACK_PREFIX}${tag.tag}`, true);
+    };
+  }, [onTagCreate, setPinned]);
+
   const tagContextValue = {
     state,
     actions,
-    onTagCreate,
+    onTagCreate: handleTagCreate,
     onTagUpdate,
     existingTags,
   };

--- a/app/packages/state/src/recoil/temporalTags.test.tsx
+++ b/app/packages/state/src/recoil/temporalTags.test.tsx
@@ -7,7 +7,12 @@ import {
   waitFor,
 } from "@testing-library/react";
 import React from "react";
-import { RecoilRoot, useRecoilValue, useSetRecoilState } from "recoil";
+import {
+  RecoilRoot,
+  useRecoilValue,
+  useSetRecoilState,
+  type RecoilState,
+} from "recoil";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const fetchMock = vi.fn();
@@ -38,9 +43,25 @@ vi.mock("./selectors", async () => {
     }),
   };
 });
+vi.mock("./modal", async () => {
+  const { atom } = await vi.importActual<typeof import("recoil")>("recoil");
+  return {
+    isModalActive: atom<boolean>({
+      key: "test_isModalActive",
+      default: false,
+    }),
+  };
+});
 
 import { filters as filtersAtom } from "./filters";
+import { isModalActive } from "./modal";
 import { datasetId as datasetIdAtom } from "./selectors";
+
+// The real `isModalActive` is a read-only selector; the mock above swaps it
+// for a plain atom so the test can drive it, but the import still carries
+// the selector's type — a targeted cast at this one declaration site is
+// simpler than re-typing the mock.
+const isModalActiveAtom = isModalActive as unknown as RecoilState<boolean>;
 import {
   fetchTemporalTagResults,
   temporalTagResults,
@@ -186,5 +207,51 @@ describe("useSyncTemporalTagResults", () => {
     await waitFor(() =>
       expect(screen.getByTestId("probe").textContent).toContain('"results":[]'),
     );
+  });
+
+  it("ignores a stale response from an earlier overlapping load", async () => {
+    // The mount effect starts a fetch that stays pending while the modal
+    // opens and closes, which starts a second, independent fetch. The second
+    // resolves first with fresh results; the first resolving afterwards must
+    // not clobber them with what it fetched before the modal round-trip.
+    let resolveFirst: (value: {
+      response: { counts: Record<string, number> };
+    }) => void;
+    fetchMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFirst = resolve;
+        }),
+    );
+    fetchMock.mockResolvedValueOnce({ response: { counts: { fresh: 1 } } });
+
+    let setModalActive: ((value: boolean) => void) | undefined;
+    function ModalControl() {
+      setModalActive = useSetRecoilState(isModalActiveAtom);
+      return null;
+    }
+
+    render(
+      <RecoilRoot>
+        <Harness />
+        <ModalControl />
+      </RecoilRoot>,
+    );
+
+    act(() => setModalActive?.(true));
+    act(() => setModalActive?.(false));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("probe").textContent).toContain("fresh"),
+    );
+
+    resolveFirst({ response: { counts: { stale: 1 } } });
+
+    // Give the stale promise a turn to resolve and (incorrectly) apply.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(screen.getByTestId("probe").textContent).toContain("fresh");
+    expect(screen.getByTestId("probe").textContent).not.toContain("stale");
   });
 });

--- a/app/packages/state/src/recoil/temporalTags.ts
+++ b/app/packages/state/src/recoil/temporalTags.ts
@@ -82,11 +82,23 @@ export const useSyncTemporalTagResults = (): void => {
   const modalActive = useRecoilValue(isModalActive);
   const wasModalActive = useRef(modalActive);
 
+  // Shared across both call sites below (mount/dataset-change and
+  // modal-close), which can overlap: the dataset-change effect can still be
+  // in flight when the modal closes and re-triggers `load`. A `cancelled`
+  // flag scoped to a single call can't see a *later* call — only this
+  // counter, bumped by every call, can tell an in-flight response that it is
+  // no longer the latest one and let it drop its result instead of
+  // clobbering fresher data.
+  const requestGenerationRef = useRef(0);
+
   const load = useCallback(() => {
+    const generation = ++requestGenerationRef.current;
+    const isStale = () => requestGenerationRef.current !== generation;
+
     if (!currentDatasetId) {
       // No active dataset — clear any stale results from a prior one.
       setResults({ results: [], count: null });
-      return undefined;
+      return;
     }
 
     // Clear the prior dataset's results immediately — otherwise
@@ -94,22 +106,17 @@ export const useSyncTemporalTagResults = (): void => {
     // until this fetch resolves.
     setResults({ results: [], count: null });
 
-    let cancelled = false;
     fetchTemporalTagResults(currentDatasetId)
       .then((results) => {
-        if (!cancelled) {
+        if (!isStale()) {
           setResults(results);
         }
       })
       .catch(() => {
-        if (!cancelled) {
+        if (!isStale()) {
           setResults({ results: [], count: null });
         }
       });
-
-    return () => {
-      cancelled = true;
-    };
     // `setResults` is a stable Recoil setter.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentDatasetId]);
@@ -122,7 +129,7 @@ export const useSyncTemporalTagResults = (): void => {
   useEffect(() => {
     const closed = wasModalActive.current && !modalActive;
     wasModalActive.current = modalActive;
-    return closed ? load() : undefined;
+    if (closed) load();
   }, [modalActive, load]);
 };
 

--- a/app/packages/state/src/recoil/temporalTags.ts
+++ b/app/packages/state/src/recoil/temporalTags.ts
@@ -128,6 +128,21 @@ export const useTemporalTagsFieldActive = (): boolean =>
   useRecoilValue(activeField({ modal: false, path: TEMPORAL_TAGS_FIELD }));
 
 /**
+ * Every temporal-tag value defined on the current dataset. Populated by
+ * {@link useSyncTemporalTagResults}; empty until that has run, so callers
+ * that need it should call the sync hook too.
+ */
+export const useTemporalTagValues = (): string[] => {
+  const { results } = useRecoilValue(temporalTagResults);
+  return useMemo(() => {
+    const values = results
+      .map(({ value }) => value)
+      .filter((value): value is string => !!value);
+    return values.length ? values : NO_VALUES;
+  }, [results]);
+};
+
+/**
  * Tag values the grid is currently filtering *for* via the temporal-tags
  * filter — inclusive selections only (empty when the filter is unset or set to
  * exclude). Used to auto-pin the matching timeline tracks when a sample is


### PR DESCRIPTION
Two fixes to temporal tagging in the episode modal.

### A new tag is now pinned

Creating a tag left it unpinned, so it went straight into the collapsed tracks drawer and looked like nothing had happened.

`TrackProvider` already supports auto-pinning, but every surface passes `autoPinNewTracks={false}` on purpose — tracks arrive in async batches and would otherwise each pin themselves as the batches land. So rather than flip that flag, `TemporalTagTimeline` now pins the one track it knows was just created, after `onTagCreate` resolves.

Pinning is by id, and the timeline renders only pinned tracks that exist, so pinning before the write round-trips is safe — the same thing `useFilteredTemporalTagPinnedIds` already relies on.

### The dropdown offers the dataset's tags, not the sample's

The "add to existing tag" dropdown was derived from the tracks on screen:

```ts
tracks.filter((t) => t.id.startsWith("temporal-tag::")).map((t) => t.label)
```

Those are the *current sample's* tags. On any sample that has none yet the dropdown was empty, so every label had to be retyped and tag vocabularies drifted apart across samples.

It now offers the whole dataset's tag values, merged with the on-timeline labels so a tag created this session stays selectable before the refetch lands. The values come from the `temporalTagResults` atom the grid's sidebar filter already populates — previously that filter was its only loader, so in the modal it was usually empty; the modal now loads it too.

The Recoil read sits behind a new `useTemporalTagValues` hook in `@fiftyone/state`, matching the existing `useActiveTemporalTagFilterValues` pattern, which keeps `@fiftyone/playback` free of a `state` dependency. The labels reach the timeline as an optional `existingTags` prop along the same path `onTagCreate` / `onTagUpdate` / `onTagDelete` already take.

### Testing

`tsc` clean for `playback`, `multimodal`, and `state`; unit tests pass. Not yet confirmed against a running app — the pin in particular is worth a manual check.

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3939
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Temporal tag creation now offers the full dataset-wide tag vocabulary, including tags not currently visible on the timeline.
  * Newly created temporal tags are automatically pinned and immediately visible on the timeline.

* **Bug Fixes**
  * Prevented duplicate tag options in the creation dropdown.
  * Improved temporal tag loading so stale results from overlapping requests cannot replace newer data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->