### PR TITLE
Docs: update dependencies to the latest version

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -6,8 +6,8 @@ torchvision
 typing_extensions==4.16.0
 
 # precommit requirements
-pre-commit==4.6.1
-pylint==4.0.6
+pre-commit==4.6.2
+pylint==4.0.7
 jupyter-client==8.9.1
 
 # docs requirements
@@ -17,7 +17,7 @@ autodocsumm==0.2.15
 # Using latest compatible version from 0.22.x series
 docutils==0.22.4
 pypandoc>=1.17
-sphinx-markdown-builder==0.6.10
+sphinx-markdown-builder==0.6.11
 huggingface_hub>=1.17.0
 requests>=2.34.2
 ipykernel==7.3.0
@@ -28,7 +28,7 @@ jsx-lexer==2.0.1
 libsass==0.23.0
 myst-parser==5.1.0
 nbsphinx==0.9.8
-pydata-sphinx-theme==0.20.0
+pydata-sphinx-theme==0.21.0
 sphinx-autobuild==2025.8.25
 sphinx-tabs==3.5.0
 sphinx-design==0.7.0
@@ -36,7 +36,7 @@ Sphinx==9.1.0
 sphinx-copybutton==0.5.2
 sphinxcontrib-jquery==4.1
 sphinx-pushfeedback==0.1.8
-sphinx-docsearch==0.3.0
+sphinx-docsearch==0.3.1
 sphinx-remove-toctrees==1.0.0.post1
-sphinx-autoapi==3.8.0
+sphinx-autoapi==3.8.1
 sphinx-sitemap==2.9.0


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link.

## 📋 What changes are proposed in this pull request?

Updates docs dependencies to their latest compatible versions. Sphinx and docutils stay unchanged for compatibility.

## 🧪 How is this patch tested?

* Docs build locally without errors.

## 📝 Release Notes

* [x] No
* [ ] Yes

### What areas of FiftyOne does this PR affect?

* [ ] App
* [ ] Build
* [ ] Core
* [x] Documentation
* [ ] Other

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3941
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation tooling and code-quality tool versions.
  * No user-facing features or functionality were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->