### PR TITLE
Collapse the timeline label gutter when no labels are visible

### DIFF
--- a/app/packages/playback/src/views/TemporalTag/TemporalTagTimeline.tsx
+++ b/app/packages/playback/src/views/TemporalTag/TemporalTagTimeline.tsx
@@ -54,9 +54,6 @@ const TemporalTagTimeline: React.FC<TemporalTagTimelineProps> = ({
   const { setPinned } = useTrackPinning();
   const { state, actions } = useTemporalTagMode();
 
-  // Mirror TimelineWithTracks's own labelWidth logic so the overlay aligns.
-  const labelWidth = tracks.length === 0 ? 0 : requestedLabelWidth;
-
   const existingTags = useMemo(() => {
     const onTimeline = tracks
       .filter((t) => t.id.startsWith(TEMPORAL_TAG_TRACK_PREFIX))
@@ -116,13 +113,19 @@ const TemporalTagTimeline: React.FC<TemporalTagTimelineProps> = ({
         labelWidth={requestedLabelWidth}
         // Compose caller-provided slot content with the tag UI instead of
         // replacing it — hosts inject their own controls (e.g. a timestamp
-        // readout) through the same slots.
-        rulerOverlay={
+        // readout) through the same slots. Resolved against
+        // TimelineWithTracks's *effective* label width (a render prop,
+        // since that width can collapse to 0 independently of
+        // `requestedLabelWidth` — see that prop's doc) so the overlay's own
+        // offset math never drifts from where the gutter actually renders.
+        rulerOverlay={(effectiveLabelWidth: number) => (
           <>
-            {rulerOverlay}
-            <TemporalTagRangeOverlay labelWidth={labelWidth} />
+            {typeof rulerOverlay === "function"
+              ? rulerOverlay(effectiveLabelWidth)
+              : rulerOverlay}
+            <TemporalTagRangeOverlay labelWidth={effectiveLabelWidth} />
           </>
-        }
+        )}
         extraActions={
           <>
             {extraActions}

--- a/app/packages/playback/src/views/TimelineWithTracks/TimelineWithTracks.test.tsx
+++ b/app/packages/playback/src/views/TimelineWithTracks/TimelineWithTracks.test.tsx
@@ -23,19 +23,32 @@ interface RenderOpts {
   pinnedIds?: string[];
   duration?: number;
   labelWidth?: number;
+  drawerOpen?: boolean;
 }
 
 function renderTimeline(opts: RenderOpts = {}) {
-  const { tracks = [], pinnedIds = [], duration = 10, labelWidth } = opts;
+  const {
+    tracks = [],
+    pinnedIds = [],
+    duration = 10,
+    labelWidth,
+    drawerOpen,
+  } = opts;
 
   return render(
     <PlaybackProvider duration={duration} stepInterval={1 / 30}>
       <TrackProvider tracks={tracks} initialPinnedIds={pinnedIds}>
-        <TimelineWithTracks labelWidth={labelWidth} />
+        <TimelineWithTracks labelWidth={labelWidth} drawerOpen={drawerOpen} />
       </TrackProvider>
     </PlaybackProvider>,
   );
 }
+
+/** Every mounted label column, i.e. the left gutter `labelWidth` controls. */
+const labelColumns = (container: HTMLElement) =>
+  Array.from(
+    container.querySelectorAll<HTMLElement>("[data-track-label-column]"),
+  );
 
 describe("TimelineWithTracks", () => {
   beforeEach(() => {
@@ -65,14 +78,16 @@ describe("TimelineWithTracks", () => {
     // those undefined rows used to throw and take the tree down — which is how
     // deleting the last track broke the annotation surface.
     it("survives every track being removed", () => {
-      const { rerender } = render(
+      const { container, rerender } = render(
         <PlaybackProvider duration={10} stepInterval={1 / 30}>
           <TrackProvider tracks={[TRACK_A, TRACK_B]} initialPinnedIds={[]}>
             <TimelineWithTracks />
           </TrackProvider>
         </PlaybackProvider>,
       );
-      expect(screen.getAllByText("Track A").length).toBeGreaterThan(0);
+      expect(
+        container.querySelectorAll("[data-track-id]").length,
+      ).toBeGreaterThan(0);
 
       expect(() =>
         rerender(
@@ -84,11 +99,11 @@ describe("TimelineWithTracks", () => {
         ),
       ).not.toThrow();
 
-      expect(screen.queryByText("Track A")).toBeNull();
+      expect(container.querySelectorAll("[data-track-id]")).toHaveLength(0);
     });
 
     it("survives the list shrinking to a single track", () => {
-      const { rerender } = render(
+      const { container, rerender } = render(
         <PlaybackProvider duration={10} stepInterval={1 / 30}>
           <TrackProvider tracks={[TRACK_A, TRACK_B]} initialPinnedIds={[]}>
             <TimelineWithTracks />
@@ -106,7 +121,7 @@ describe("TimelineWithTracks", () => {
         ),
       ).not.toThrow();
 
-      expect(screen.getAllByText("Track B").length).toBeGreaterThan(0);
+      expect(container.querySelectorAll("[data-track-id]")).toHaveLength(1);
     });
   });
 
@@ -152,6 +167,63 @@ describe("TimelineWithTracks", () => {
       const { container } = renderTimeline({ tracks: [] });
       // No track label elements in the empty state
       expect(container.querySelectorAll("[class*=label]")).toHaveLength(0);
+    });
+
+    // The gutter is only worth its width when a label is actually on screen.
+    // Collapsed drawer with nothing pinned shows no labels, so reserving the
+    // column just pushed the ruler and every event bar to the right for
+    // nothing — which is the left-side padding this branch removes.
+    it("collapses the gutter when the drawer is shut and nothing is pinned", () => {
+      const { container } = renderTimeline({
+        tracks: [TRACK_A, TRACK_B],
+        pinnedIds: [],
+        drawerOpen: false,
+      });
+
+      expect(labelColumns(container)).toHaveLength(0);
+    });
+
+    it("keeps the gutter when a track is pinned and the drawer is shut", () => {
+      const { container } = renderTimeline({
+        tracks: [TRACK_A, TRACK_B],
+        pinnedIds: ["track-a"],
+        drawerOpen: false,
+        labelWidth: 120,
+      });
+
+      const columns = labelColumns(container);
+      expect(columns.length).toBeGreaterThan(0);
+      for (const column of columns) {
+        expect(column.style.width).toBe("120px");
+      }
+    });
+
+    it("keeps the gutter when the drawer is open and nothing is pinned", () => {
+      const { container } = renderTimeline({
+        tracks: [TRACK_A, TRACK_B],
+        pinnedIds: [],
+        drawerOpen: true,
+        labelWidth: 120,
+      });
+
+      const columns = labelColumns(container);
+      expect(columns.length).toBeGreaterThan(0);
+      for (const column of columns) {
+        expect(column.style.width).toBe("120px");
+      }
+    });
+
+    it("collapses the gutter when the last pinned track is unpinned", () => {
+      const { container } = renderTimeline({
+        tracks: [TRACK_A],
+        pinnedIds: ["track-a"],
+        drawerOpen: false,
+      });
+      expect(labelColumns(container).length).toBeGreaterThan(0);
+
+      fireEvent.click(screen.getByTestId("timeline-track-pin-track-a"));
+
+      expect(labelColumns(container)).toHaveLength(0);
     });
   });
 });

--- a/app/packages/playback/src/views/TimelineWithTracks/TimelineWithTracks.tsx
+++ b/app/packages/playback/src/views/TimelineWithTracks/TimelineWithTracks.tsx
@@ -246,7 +246,6 @@ const TimelineWithTracks: React.FC<TimelineWithTracksProps> = ({
   const resolvedLabelWidth = clampLabelWidth(
     draggedLabelWidth ?? requestedLabelWidth,
   );
-  const labelWidth = tracks.length === 0 ? 0 : resolvedLabelWidth;
 
   // Sub-rows follow their parent's pin state via `parentId` so a partial pin
   // doesn't strand attribute children above unrelated parents — see
@@ -255,6 +254,11 @@ const TimelineWithTracks: React.FC<TimelineWithTracksProps> = ({
     () => partitionTracksByPin(tracks, pinnedIds),
     [tracks, pinnedIds],
   );
+
+  const labelWidth =
+    pinned.length > 0 || (drawerOpen && tracks.length > 0)
+      ? resolvedLabelWidth
+      : 0;
 
   /**
    * Index range the virtualizer currently has mounted, as a `start:end` key.

--- a/app/packages/playback/src/views/TimelineWithTracks/TimelineWithTracks.tsx
+++ b/app/packages/playback/src/views/TimelineWithTracks/TimelineWithTracks.tsx
@@ -82,8 +82,15 @@ export interface TimelineWithTracksProps {
   drawerOpen?: boolean;
   /** Called when the tracks drawer requests an open-state change. */
   onDrawerOpenChange?: (open: boolean) => void;
-  /** Overlay rendered on top of the ruler row in each TimelineHeader. */
-  rulerOverlay?: React.ReactNode;
+  /**
+   * Overlay rendered on top of the ruler row in each TimelineHeader. Accepts
+   * a render function instead of a plain node when the overlay's own layout
+   * math needs the *effective* label width — the gutter can collapse to `0`
+   * (see `labelWidth` below) independently of the requested width, and a
+   * caller computing its own copy of that logic can drift out of sync with
+   * it (as `TemporalTagRangeOverlay` once did).
+   */
+  rulerOverlay?: React.ReactNode | ((labelWidth: number) => React.ReactNode);
   /**
    * Custom context-menu items added to every track's events. Per-row overrides
    * can still be supplied via {@link decorateTrack}. See
@@ -259,6 +266,13 @@ const TimelineWithTracks: React.FC<TimelineWithTracksProps> = ({
     pinned.length > 0 || (drawerOpen && tracks.length > 0)
       ? resolvedLabelWidth
       : 0;
+
+  // Resolve a render-prop `rulerOverlay` against the *effective* width above
+  // rather than `requestedLabelWidth` — see the prop doc.
+  const resolvedRulerOverlay =
+    typeof rulerOverlay === "function"
+      ? rulerOverlay(labelWidth)
+      : rulerOverlay;
 
   /**
    * Index range the virtualizer currently has mounted, as a `start:end` key.
@@ -536,7 +550,7 @@ const TimelineWithTracks: React.FC<TimelineWithTracksProps> = ({
         <TimelineHeader
           labelWidth={labelWidth}
           zoomRef={containerRef}
-          rulerOverlay={rulerOverlay}
+          rulerOverlay={resolvedRulerOverlay}
           extraControls={extraControls}
           readouts={readouts}
           extraActions={extraActions}
@@ -564,7 +578,7 @@ const TimelineWithTracks: React.FC<TimelineWithTracksProps> = ({
             zoomRef={containerRef}
             onToggle={toggle}
             expanded={open}
-            rulerOverlay={rulerOverlay}
+            rulerOverlay={resolvedRulerOverlay}
             extraControls={extraControls}
             readouts={readouts}
             extraActions={extraActions}


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link.

## 📋 What changes are proposed in this pull request?

`TimelineWithTracks` reserved the track-label column whenever the timeline had
any tracks at all:

```ts
const labelWidth = tracks.length === 0 ? 0 : resolvedLabelWidth;
```

But labels only actually render inside that column — `TimelineTrack` mounts its
label element solely when `labelWidth > 0`. With the drawer collapsed and
nothing pinned, there is no label on screen, so the reserved column was empty
space that still pushed the ruler, the playhead, the loop overlays and every
event bar to the right.

This narrows the condition to the states where a label is genuinely visible —
something is pinned (pinned rows live in the header in both drawer states), or
the drawer is open with tracks in it:

```ts
const labelWidth =
  pinned.length > 0 || (drawerOpen && tracks.length > 0)
    ? resolvedLabelWidth
    : 0;
```

The gutter now appears and disappears with the labels it exists for, and the
collapsed timeline uses its full width. The computation moves below
`partitionTracksByPin` since it now depends on `pinned`; the empty-timeline
behaviour is unchanged (no tracks still means no gutter).

## 🧪 How is this patch tested? If it is not, please explain why.

Four new cases in the existing `label width` block of
`TimelineWithTracks.test.tsx`, asserting on `[data-track-label-column]` — the
element `TimelineTrack` only mounts when `labelWidth > 0`, so it reads the
gutter directly:

- drawer shut, nothing pinned → no gutter
- a track pinned, drawer shut → gutter at the requested width
- drawer open, nothing pinned → gutter at the requested width
- unpinning the last pinned track via its pin button → gutter collapses

The two "collapses" cases fail against the previous `labelWidth` expression and
pass with this one, so they are pinned to the change rather than to incidental
DOM.

Two existing tests needed their assertions updated. `survives every track being
removed` and `survives the list shrinking to a single track` both render with
the drawer closed and nothing pinned, then asserted on track label *text* —
which no longer renders in that state, by design. Both tests are about the
virtualizer not crashing when the list shrinks, so they now assert on
`[data-track-id]` rows instead of label text: same intent, no longer coupled to
whether the gutter happens to be showing.

`TimelineWithTracks`, `TimelineTrack` and `TemporalTag` suites are green
(111 tests).

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

N/A

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeline gutter behavior when the drawer is open or tracks are pinned.
  * Ensured the gutter collapses correctly when no tracks require it.
  * Fixed temporal tag overlays so they align with the visible timeline label width.
* **Tests**
  * Added coverage for gutter retention, collapse behavior, and unpinning the final pinned track.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3957
<!-- enterprise-sync-pr:end -->