### PR TITLE
Lock overlays to the presented frame during scrubs

### DIFF
--- a/app/packages/playback/index.ts
+++ b/app/packages/playback/index.ts
@@ -53,6 +53,7 @@ export {
   useDuration,
   useIsPlaying,
   usePlayhead,
+  usePresentedTime,
   useViewEnd,
   useViewStart,
 } from "./src/lib/playback/use-playback-state";

--- a/app/packages/playback/src/lib/playback/atoms.ts
+++ b/app/packages/playback/src/lib/playback/atoms.ts
@@ -86,6 +86,18 @@ export const inspectionMarkerAtom = atom<PlaybackInspectionMarker | null>(
  */
 export const currentTimeAtom = atom(0);
 
+/**
+ * The media time (seconds) of the frame actually on glass, published by the
+ * tile that painted it — a `requestVideoFrameCallback` for an html `<video>`,
+ * the just-drawn bitmap's frame for decoded tiles. Null when nothing has
+ * presented (no media, no vfc support), and consumers fall back to the
+ * playhead. Overlay clocks read this so labels track the picture rather than
+ * the requested scrub position, which the picture can trail without bound.
+ */
+export const presentedTimeAtom = atom<number | null>(null) as PrimitiveAtom<
+  number | null
+>;
+
 export const isPlayingAtom = atom(false);
 
 /**

--- a/app/packages/playback/src/lib/playback/store-access.ts
+++ b/app/packages/playback/src/lib/playback/store-access.ts
@@ -28,6 +28,7 @@ import {
   bufferingStreamsAtom,
   currentTimeAtom,
   hoverTimeAtom,
+  presentedTimeAtom,
   inspectionMarkerAtom,
   isBufferingAtom,
   isPlayPendingAtom,
@@ -119,6 +120,28 @@ export function subscribeHoverTime(
   callback: () => void,
 ): () => void {
   return store.sub(hoverTimeAtom, callback);
+}
+
+/** Non-reactive read of the presented media time, in seconds (or null). */
+export function getPresentedTime(store: PlaybackStore): number | null {
+  return store.get(presentedTimeAtom);
+}
+
+/**
+ * Publishes the media time of the frame a tile just put on glass (null when
+ * its media unmounts or stops presenting). Tile-owned, like hover: the vfc
+ * callback for an html `<video>`, the paint effect for decoded bitmaps.
+ */
+export function setPresentedTime(store: PlaybackStore, timeSec: number | null) {
+  store.set(presentedTimeAtom, timeSec);
+}
+
+/** Subscribes to presented-time changes; returns an unsubscribe. */
+export function subscribePresentedTime(
+  store: PlaybackStore,
+  callback: () => void,
+): () => void {
+  return store.sub(presentedTimeAtom, callback);
 }
 
 /** Publishes or moves one owner's persistent visual inspection marker. */

--- a/app/packages/playback/src/lib/playback/use-playback-state.ts
+++ b/app/packages/playback/src/lib/playback/use-playback-state.ts
@@ -25,6 +25,7 @@ import {
   currentTimeAtom,
   durationAtom,
   hoverTimeAtom,
+  presentedTimeAtom,
   inspectionMarkerAtom,
   isBufferingAtom,
   isPlayPendingAtom,
@@ -75,6 +76,16 @@ export function useInspectionMarker(): PlaybackInspectionMarker | null {
 export function useCurrentTime(): number {
   const store = usePlaybackStore();
   return useAtomValue(currentTimeAtom, { store });
+}
+
+/**
+ * Media time of the frame actually on glass (null when nothing has
+ * presented). Overlay clocks read this so labels track the picture through
+ * a scrub instead of the requested position the picture may trail.
+ */
+export function usePresentedTime(): number | null {
+  const store = usePlaybackStore();
+  return useAtomValue(presentedTimeAtom, { store });
 }
 
 export function useIsPlaying(): boolean {

--- a/app/packages/playback/src/lib/playback/use-video-stream.ts
+++ b/app/packages/playback/src/lib/playback/use-video-stream.ts
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState, type RefObject } from "react";
 import type { PlaybackStream } from "./types";
 import { usePlayback } from "./PlaybackProvider";
+import { usePlaybackStore } from "./playback-store-context";
+import { setPresentedTime } from "./store-access";
 
 /**
  * Maximum drift (sec) between the engine's target time and the video's
@@ -171,6 +173,7 @@ export function usePresentedMediaTime(
   enabled = true,
 ): RefObject<number | null> {
   const ref = useRef<number | null>(null);
+  const store = usePlaybackStore();
 
   useEffect(() => {
     if (!enabled) {
@@ -206,6 +209,10 @@ export function usePresentedMediaTime(
       }
 
       ref.current = metadata.mediaTime;
+      // The presented-frame authority: this fires when a frame reaches the
+      // compositor, so overlay clocks tracking it follow the picture through
+      // a scrub instead of the requested time the browser's async seek trails
+      setPresentedTime(store, metadata.mediaTime);
       handle = rvfc.call(v, onFrame);
     };
     handle = rvfc.call(v, onFrame);
@@ -217,8 +224,9 @@ export function usePresentedMediaTime(
       }
 
       ref.current = null;
+      setPresentedTime(store, null);
     };
-  }, [videoRef, enabled]);
+  }, [videoRef, enabled, store]);
 
   return ref;
 }

--- a/app/packages/video-annotation/src/components/ImaVidLighterTile.tsx
+++ b/app/packages/video-annotation/src/components/ImaVidLighterTile.tsx
@@ -1,5 +1,11 @@
-import React, { useEffect, useRef, useState } from "react";
-import { useStream } from "@fiftyone/playback";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import {
+  setPresentedTime,
+  usePlaybackStore,
+  useStream,
+} from "@fiftyone/playback";
+import { useModalSample } from "@fiftyone/state";
+import { getModalSampleFrameRate } from "../utils/modalSample";
 import { useLighterTileScene } from "../hooks/useLighterTileScene";
 import { useVideoAnnotationSyncBundle } from "../hooks/useVideoAnnotationSyncBundle";
 import { IMAVID_STREAM_ID } from "../utils/ids";
@@ -22,6 +28,7 @@ interface ImageDimensions {
 function usePaintFrameToCanvas(
   frame: ImaVidImageFrame | undefined,
   canvasRef: React.RefObject<HTMLCanvasElement | null>,
+  onPainted: (frameNumber: number | null) => void,
 ): ImageDimensions | null {
   const [dims, setDims] = useState<ImageDimensions | null>(null);
 
@@ -37,6 +44,7 @@ function usePaintFrameToCanvas(
     if (!frame) {
       const ctx = canvasEl.getContext("2d");
       ctx?.clearRect(0, 0, canvasEl.width, canvasEl.height);
+      onPainted(null);
       return;
     }
 
@@ -67,10 +75,14 @@ function usePaintFrameToCanvas(
     ctx.drawImage(frame.bitmap, 0, 0);
     ctx.imageSmoothingEnabled = priorImageSmoothing;
 
+    // The frame is on glass as of this draw — the presented-frame authority
+    // for decoded tiles, the vfc callback's analogue
+    onPainted(frame.frameNumber);
+
     if (dims === null || dims.w !== w || dims.h !== h) {
       setDims({ w, h });
     }
-  }, [frame, dims, canvasRef]);
+  }, [frame, dims, canvasRef, onPainted]);
 
   return dims;
 }
@@ -93,7 +105,26 @@ export const ImaVidLighterTile: React.FC = () => {
   // only changes when the frame actually changes.
   const frame = useStream<ImaVidImageFrame>(sourceId);
 
-  const imageDims = usePaintFrameToCanvas(frame, frameCanvasRef);
+  // The presented-frame authority for decoded tiles: publish the media time
+  // of the bitmap the moment it is drawn, so overlay clocks track the
+  // picture through a scrub instead of the requested playhead
+  const store = usePlaybackStore();
+  const sample = useModalSample();
+  const fps = getModalSampleFrameRate(sample);
+  const onPainted = useCallback(
+    (frameNumber: number | null) => {
+      setPresentedTime(
+        store,
+        frameNumber == null || !fps || fps <= 0
+          ? null
+          : (frameNumber - 1) / fps,
+      );
+    },
+    [store, fps],
+  );
+  useEffect(() => () => setPresentedTime(store, null), [store]);
+
+  const imageDims = usePaintFrameToCanvas(frame, frameCanvasRef, onPainted);
 
   // Scene lifecycle: once-per-mount scene; `dims` from the decoded bitmap.
   const { scene, canonicalMediaReady } = useLighterTileScene({

--- a/app/packages/video-annotation/src/state/useCurrentFrame.test.ts
+++ b/app/packages/video-annotation/src/state/useCurrentFrame.test.ts
@@ -11,6 +11,7 @@ const DURATION = TOTAL_FRAMES / FPS;
 const { source } = vi.hoisted(() => ({
   source: {
     playhead: 0,
+    presented: null as number | null,
     frameRate: undefined as number | undefined,
     totalFrameCount: undefined as number | undefined,
   },
@@ -22,6 +23,7 @@ const { source } = vi.hoisted(() => ({
 vi.mock("@fiftyone/playback", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@fiftyone/playback")>()),
   usePlayhead: () => source.playhead,
+  usePresentedTime: () => source.presented,
 }));
 
 vi.mock("@fiftyone/state", () => ({
@@ -36,6 +38,7 @@ import { useCurrentFrame } from "./useCurrentFrame";
 describe("useCurrentFrame", () => {
   it("converts the playhead to a 1-indexed frame", () => {
     source.playhead = 0;
+    source.presented = null;
     source.frameRate = FPS;
     source.totalFrameCount = TOTAL_FRAMES;
 
@@ -68,5 +71,29 @@ describe("useCurrentFrame", () => {
 
     const { result } = renderHook(() => useCurrentFrame());
     expect(result.current).toBe(-1);
+  });
+});
+
+describe("useCurrentFrame presented-frame authority", () => {
+  it("prefers the presented time over the playhead", () => {
+    // Mid-scrub shape: the user requested ~frame 90, but the tile has only
+    // presented frame 30 — overlays must track the picture
+    source.playhead = 3;
+    source.presented = 1;
+    source.frameRate = FPS;
+    source.totalFrameCount = TOTAL_FRAMES;
+
+    const { result } = renderHook(() => useCurrentFrame());
+    expect(result.current).toBe(30);
+  });
+
+  it("falls back to the playhead when nothing has presented", () => {
+    source.playhead = 1;
+    source.presented = null;
+    source.frameRate = FPS;
+    source.totalFrameCount = TOTAL_FRAMES;
+
+    const { result } = renderHook(() => useCurrentFrame());
+    expect(result.current).toBe(30);
   });
 });

--- a/app/packages/video-annotation/src/state/useCurrentFrame.ts
+++ b/app/packages/video-annotation/src/state/useCurrentFrame.ts
@@ -2,7 +2,7 @@
  * Copyright 2017-2026, Voxel51, Inc.
  */
 
-import { frameAt, usePlayhead } from "@fiftyone/playback";
+import { frameAt, usePlayhead, usePresentedTime } from "@fiftyone/playback";
 import { useModalSample } from "@fiftyone/state";
 import { useCallback, useRef } from "react";
 import { resolveFrameCount } from "../utils/frameCount";
@@ -28,13 +28,22 @@ import { getModalSampleFrameRate } from "../utils/modalSample";
 export const useCurrentFrame = (): number => {
   const sample = useModalSample();
   const playhead = usePlayhead();
+  const presented = usePresentedTime();
   const fps = getModalSampleFrameRate(sample);
 
   if (!fps || !Number.isFinite(fps) || fps <= 0) {
     return -1;
   }
 
-  return frameAt(playhead, fps, resolveFrameCount(sample, fps) ?? undefined);
+  // The frame actually on glass, when the tile publishes one — during a
+  // scrub the picture can trail the requested playhead without bound
+  // (browser seek pipeline, chunk fetch + decode), and every consumer of
+  // "current frame" — overlay clock, TD gates, gesture frame-stamping —
+  // should track what the user sees. The playhead is the fallback for
+  // tiles that never present (no media, no vfc support).
+  const time = presented ?? playhead;
+
+  return frameAt(time, fps, resolveFrameCount(sample, fps) ?? undefined);
 };
 
 /**

--- a/e2e-pw/src/oss/specs/annotate-video-presented-frame.spec.ts
+++ b/e2e-pw/src/oss/specs/annotate-video-presented-frame.spec.ts
@@ -1,0 +1,162 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ *
+ * Presented-frame lock: `useCurrentFrame` — the single source of "current
+ * frame" for the engine clock and the temporal-detection sidebar gates —
+ * follows the frame actually on glass (the ImaVid tile publishes the painted
+ * bitmap's time into `presentedTimeAtom`), falling back to the playhead.
+ * The sidebar's in-support TD listing is the frame-derived UI this exercises.
+ *
+ * Guards the two regressions the presented-frame preference can introduce:
+ *
+ *  - an off-by-one in the tile's publisher (`(frameNumber - 1) / fps`): every
+ *    frame-derived consumer would shift by one frame, so the TD boundary
+ *    frames (approach [1,6] / pass [7,13] / depart [14,20]) would gate the
+ *    sidebar one frame early. Exact single-frame steps across the 6→7
+ *    boundary catch it in both directions.
+ *  - stale presented time across a sample switch: if the tile failed to clear
+ *    the atom (or republish the new sample's paint), paging to the next video
+ *    would keep frame-derived UI on the PREVIOUS sample's late frame instead
+ *    of the fresh sample's frame 1.
+ */
+import { expect, test as base } from "src/oss/fixtures";
+import { GridPom } from "src/oss/poms/grid";
+import { ModalPom } from "src/oss/poms/modal";
+import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
+import type { AbstractFiftyoneLoader } from "src/shared/abstract-loader";
+import type { Page } from "src/oss/fixtures";
+
+const datasetName = getUniqueDatasetNameWithPrefix(
+  "annotate-video-presented-frame",
+);
+const sample0Id = "000000000000000000000000";
+const clip0 = `/tmp/${datasetName}-0.webm`;
+const clip1 = `/tmp/${datasetName}-1.webm`;
+
+const test = base.extend<{ grid: GridPom; modal: ModalPom }>({
+  grid: async ({ page, eventUtils }, use) => use(new GridPom(page, eventUtils)),
+  modal: async ({ page, eventUtils }, use) =>
+    use(new ModalPom(page, eventUtils)),
+});
+
+test.beforeAll(async ({ foWebServer, mediaFactory, videoAnnotateSDK }) => {
+  await foWebServer.startWebServer();
+  await mediaFactory.createVideo({
+    outputPath: clip0,
+    duration: 2,
+    width: 64,
+    height: 64,
+    frameRate: 10,
+    color: "#3050a0",
+  });
+  await mediaFactory.createVideo({
+    outputPath: clip1,
+    duration: 2,
+    width: 64,
+    height: 64,
+    frameRate: 10,
+    color: "#a05030",
+  });
+  // 20 frames per clip -> demo TDs approach [1,6], pass [7,13], depart [14,20].
+  // Both tests are read-only navigation, so a single seed serves the file.
+  await videoAnnotateSDK.seed({ datasetName, videoPaths: [clip0, clip1] });
+});
+
+test.afterAll(async ({ foWebServer }) => {
+  await foWebServer.stopWebServer();
+});
+
+const openAnnotateSurface = async (modal: ModalPom) => {
+  await modal.assert.isOpen();
+  await modal.sidebar.switchMode("annotate");
+  await modal.videoAnnotate.waitForSurface();
+};
+
+const openAnnotateDeepLink = async (
+  fiftyoneLoader: AbstractFiftyoneLoader,
+  modal: ModalPom,
+  page: Page,
+) => {
+  await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
+    searchParams: new URLSearchParams({ id: sample0Id }),
+  });
+  await openAnnotateSurface(modal);
+};
+
+const stepForward = async (modal: ModalPom, n: number) => {
+  for (let i = 0; i < n; i++) {
+    await modal.videoAnnotate.stepForward();
+  }
+};
+
+test.describe.serial("video annotation presented-frame lock", () => {
+  test("TD sidebar gates track exact frame steps and a ruler seek", async ({
+    fiftyoneLoader,
+    modal,
+    page,
+  }) => {
+    await openAnnotateDeepLink(fiftyoneLoader, modal, page);
+    const va = modal.videoAnnotate;
+
+    // frame 1: only "approach" [1,6] is in support
+    await va.assert.labelListed("approach");
+    await va.assert.labelListed("pass", false);
+    await va.assert.labelListed("depart", false);
+
+    // six exact steps -> frame 7, the first "pass" frame. The positive poll
+    // ("pass" appears) is the signal the steps landed; only then is the
+    // negative ("approach" gone) meaningful.
+    await stepForward(modal, 6);
+    await va.assert.labelListed("pass");
+    await va.assert.labelListed("approach", false);
+
+    // one step back -> frame 6, the LAST "approach" frame. A one-frame-late
+    // publisher would still present frame 7 here and keep "pass" listed.
+    await va.stepBack();
+    await va.assert.labelListed("approach");
+    await va.assert.labelListed("pass", false);
+
+    // a real ruler-click scrub into the "depart" third [14,20] — the seek
+    // path where the picture trails the requested playhead
+    await va.seekToRulerFraction(0.9);
+    await va.assert.labelListed("depart");
+    await va.assert.labelListed("pass", false);
+    await va.assert.labelListed("approach", false);
+  });
+
+  test("paging to the next sample presents ITS frame 1, not a stale late frame", async ({
+    fiftyoneLoader,
+    grid,
+    modal,
+    page,
+  }) => {
+    // open from the grid so the modal carries the sample sequence
+    await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
+      withGrid: true,
+    });
+    await grid.openFirstSample();
+    await openAnnotateSurface(modal);
+    const va = modal.videoAnnotate;
+
+    // scrub sample 0 deep into its "depart" third [14,20]
+    await stepForward(modal, 13);
+    await va.assert.labelListed("depart");
+    const firstSampleTds = new Set(await va.temporalTrackIds());
+
+    // page to the next video sample (ArrowRight = ModalNextSample); its TD
+    // ids are distinct, so all-new ids prove the surface switched samples
+    await page.keyboard.press("ArrowRight");
+    await expect
+      .poll(async () => {
+        const ids = await va.temporalTrackIds();
+        return ids.length === 3 && ids.every((t) => !firstSampleTds.has(t));
+      })
+      .toBe(true);
+    await va.waitForSurface();
+
+    // the fresh sample presents from ITS frame 1 — a stale presented time
+    // from sample 0 would keep the sidebar gated to the depart third
+    await va.assert.labelListed("approach");
+    await va.assert.labelListed("depart", false);
+  });
+});


### PR DESCRIPTION
## What

Scrubbing the new timeline player lets overlays (and the frame counter) run ahead of the picture: they key off the **requested** playhead, while the picture keys off something gated — the browser's async seek pipeline for `html` decoding, the barrier-gated bitmap commit for `extract`/`fetch`. Under load the two diverge without bound, so labels visibly slip off the frame on glass.

## How

One new atom, two publishers, one consumer swap — covering every decode strategy:

- **`presentedTimeAtom`** (`@fiftyone/playback`): the media time of the frame actually on glass, `null` when nothing has presented. Read via `usePresentedTime()`; written via `setPresentedTime` in store-access, mirroring the hover-time pattern.
- **html publisher**: the existing `requestVideoFrameCallback` loop in `usePresentedMediaTime` now also stamps `metadata.mediaTime` into the atom — rVFC fires exactly when a frame reaches the compositor, so this is presentation truth, not `currentTime` bookkeeping. The loop is already mounted on the annotate video surface via `useVfcClockSource`, playing or paused.
- **extract/fetch publisher**: the ImaVid tile stamps the painted bitmap's frame time as part of the same effect that draws it (`(frameNumber - 1) / fps`), and clears it on unmount.
- **consumer**: `useCurrentFrame` — the single source of "current frame" for the engine clock, temporal-detection gates, and gesture frame-stamping — prefers the presented time and falls back to the playhead for surfaces that never present (no media, no rVFC support).

The playhead remains the authority for everything that should track the *request* (scrubber thumb, seek targets); only frame-derived consumers follow the picture.

## Tests

- `useCurrentFrame`: presented-time-wins and playhead-fallback cases added.
- Full `packages/playback` + `packages/video-annotation` vitest suites pass (73 files / 864 tests).