### PR TITLE
Document new FiftyOne Agent features and permissions

### DIFF
--- a/docs/source/enterprise/agent.rst
+++ b/docs/source/enterprise/agent.rst
@@ -256,6 +256,16 @@ attached.
    :alt: fiftyone-agent-screenshot
    :align: center
 
+If you select one or more samples in the grid first, an additional icon lets
+you attach their images directly, so you can ask the Agent about specific
+samples without describing or searching for them in words. Up to 20 samples
+can be attached at once; if more are selected, only the first 20 are
+attached.
+
+.. image:: https://cdn.voxel51.com/voxel-agent/enterprise/agent_attach_samples.webp
+   :alt: fiftyone-agent-attach-samples
+   :align: center
+
 .. _enterprise-agent-workspace:
 
 Returning to a previous view

--- a/docs/source/enterprise/agent.rst
+++ b/docs/source/enterprise/agent.rst
@@ -6,7 +6,7 @@ FiftyOne Agent
 .. default-role:: code
 
 .. customavailablein::
-    :enterprise_version: 2.19.0
+    :enterprise_version: 2.25.0
 
 The FiftyOne Agent is an AI-powered assistant built into the
 :ref:`FiftyOne Enterprise App <enterprise-app>`. It lets you work with your

--- a/docs/source/enterprise/agent.rst
+++ b/docs/source/enterprise/agent.rst
@@ -33,6 +33,14 @@ _____
    :alt: fiftyone-agent-button-location
    :align: center
 
+.. note::
+
+    The FiftyOne Agent now ships as a built-in feature of the FiftyOne
+    Enterprise App rather than a separately installed plugin. If you
+    installed an earlier standalone version of the Agent plugin, you can
+    remove it once your deployment is upgraded. The built-in version
+    replaces it entirely.
+
 .. _enterprise-agent-providers:
 
 Configuring model providers
@@ -60,7 +68,6 @@ To add a provider, fill in the following fields:
   correct routing when the model name alone is ambiguous
 - **Extra headers** (optional): static key-value HTTP headers sent with every
   request (e.g. ``User-Agent``, project tokens required by your gateway)
-- **Default**: mark this provider as the default
 
 .. image:: https://cdn.voxel51.com/voxel-agent/enterprise/provider_more_details.webp
    :alt: fiftyone-agent-provider-details
@@ -68,11 +75,43 @@ To add a provider, fill in the following fields:
 
 You can click **Test connection** to verify your credentials before saving.
 
+To choose which model new users start with, use the **Default model** picker
+at the top of the Connections list.
+
+.. image:: https://cdn.voxel51.com/voxel-agent/enterprise/agent_default_model.webp
+   :alt: fiftyone-agent-default-model
+   :align: center
+
 .. note::
 
     Need help configuring a provider? Contact your Customer Success
     representative, or see :ref:`Secrets <enterprise-secrets>` for how to
     store API keys securely in your deployment.
+
+.. _enterprise-agent-permissions:
+
+Permissions
+___________
+
+Any user who can view a dataset can chat with the Agent and ask it to take
+action on that dataset. A few capabilities require additional permissions:
+
+- **Managing connections** (adding, editing, or removing a model provider,
+  or changing the default model) requires the Admin role.
+- **Generating and testing plugins** with the Agent requires the Admin role.
+
+.. image:: https://cdn.voxel51.com/fiftyone-internal-skills/develop_plugin.webp
+   :alt: fiftyone-agent-develop-plugin
+   :align: center
+
+- **Generating and executing SDK code** with the Agent requires a role with
+  API key access enabled. See :ref:`Roles and permissions
+  <enterprise-roles>` for which roles support this by default and how to
+  change it.
+
+.. image:: https://cdn.voxel51.com/fiftyone-internal-skills/write_code.webp
+   :alt: fiftyone-agent-write-code
+   :align: center
 
 .. _enterprise-agent-custom-gateway:
 
@@ -145,6 +184,26 @@ useful for enforcing per-user quotas or audit logging.
     Admins are responsible for ensuring that the configured endpoint's data
     handling and retention align with their organization's privacy policy.
 
+.. _enterprise-agent-instructions:
+
+Custom instructions
+____________________
+
+You can give the Agent standing instructions that are automatically included
+in every conversation, at three scopes:
+
+- **Organization**: written by an admin, applied to every conversation for
+  every user in the deployment
+- **User**: personal instructions that apply only to your own conversations
+- **Dataset**: shared instructions that apply to every conversation involving
+  a specific dataset, for everyone with access to it
+
+.. image:: https://cdn.voxel51.com/voxel-agent/enterprise/agent_instructions.webp
+   :alt: fiftyone-agent-instructions
+   :align: center
+
+Configure instructions from the Agent's settings panel.
+
 .. _enterprise-agent-using:
 
 Using the agent
@@ -174,6 +233,74 @@ To return to a previous conversation, click **History**.
 
 .. image:: https://cdn.voxel51.com/voxel-agent/enterprise/conversation_history.webp
    :alt: fiftyone-agent-conversation-history
+   :align: center
+
+.. _enterprise-agent-screenshot:
+
+Asking about the current App state
+___________________________________
+
+Click the screenshot icon next to the attach icon in the message box to
+capture what's currently on screen and attach it to your next message.
+
+.. image:: https://cdn.voxel51.com/voxel-agent/enterprise/agent_screenshot_location.webp
+   :alt: fiftyone-agent-screenshot-location
+   :align: center
+
+This lets you ask the Agent about exactly what you're looking at, such as a
+specific sample, a plot, or a 3D scene, without describing it in words. Your
+browser will prompt you to choose what to share before the screenshot is
+attached.
+
+.. image:: https://cdn.voxel51.com/voxel-agent/enterprise/agent_screenshot.webp
+   :alt: fiftyone-agent-screenshot
+   :align: center
+
+.. _enterprise-agent-workspace:
+
+Returning to a previous view
+_____________________________
+
+Whenever the Agent changes what you're looking at, such as applying a
+filter, loading a view, or running an operator, that step gets a
+**Load Workspace** button. Click it any time, even after navigating away, to
+instantly restore the App to that exact state.
+
+.. image:: https://cdn.voxel51.com/voxel-agent/enterprise/agent_load_workspace_location.webp
+   :alt: fiftyone-agent-load-workspace-location
+   :align: center
+
+.. _enterprise-agent-delegated-ops:
+
+Tracking delegated operations
+______________________________
+
+When the Agent runs a long-running task as a :ref:`delegated operation
+<enterprise-delegated-operations>`, it appears in a tray showing how many are
+queued, running, completed, and failed, so you can keep chatting while it
+runs in the background.
+
+.. image:: https://cdn.voxel51.com/voxel-agent/enterprise/agent_delegated_ops.webp
+   :alt: fiftyone-agent-delegated-ops
+   :align: center
+
+Click a job in the tray to see its own progress and details.
+
+.. image:: https://cdn.voxel51.com/voxel-agent/enterprise/agent_delegated_ops_detail.webp
+   :alt: fiftyone-agent-delegated-ops-detail
+   :align: center
+
+.. _enterprise-agent-usage:
+
+Usage
+_____
+
+The Agent's settings panel includes a Usage tab showing your own token and
+request counts for the current period. Admins additionally see usage totals
+for the entire organization.
+
+.. image:: https://cdn.voxel51.com/voxel-agent/enterprise/agent_usage.webp
+   :alt: fiftyone-agent-usage
    :align: center
 
 .. _enterprise-agent-skills:

--- a/docs/source/enterprise/agent.rst
+++ b/docs/source/enterprise/agent.rst
@@ -84,9 +84,9 @@ at the top of the Connections list.
 
 .. note::
 
-    Need help configuring a provider? Contact your Customer Success
-    representative, or see :ref:`Secrets <enterprise-secrets>` for how to
-    store API keys securely in your deployment.
+    API keys are automatically stored securely using FiftyOne
+    Enterprise's :ref:`Secrets <enterprise-secrets>` infrastructure. No
+    manual secret configuration is required.
 
 .. _enterprise-agent-permissions:
 

--- a/docs/source/workflows/curation_post.rst
+++ b/docs/source/workflows/curation_post.rst
@@ -6,15 +6,13 @@ Curation: Post-Annotation
 Labels are rarely perfect on the first pass. After annotation, use FiftyOne to
 verify label quality and prepare your dataset for training: find likely
 :ref:`annotation mistakes <brain-label-mistakes>`, review labels as
-:ref:`object patches <object-patches-views>`, :ref:`filter and slice
-<app-filtering>` your dataset in the App, and audit samples with the
-FiftyOne Enterprise Data Quality 🚀 panel.
+:ref:`object patches <object-patches-views>`, and :ref:`filter and slice
+<app-filtering>` your dataset in the App.
 
 .. toctree::
    :maxdepth: 1
    :hidden:
 
-   Data Quality 🚀 <../enterprise/data_quality>
    Finding classification mistakes <../tutorials/classification_mistakes.ipynb>
    Finding detection mistakes <../tutorials/detection_mistakes.ipynb>
    Removing duplicate objects <../recipes/remove_duplicate_annos.ipynb>

--- a/docs/source/workflows/curation_pre.rst
+++ b/docs/source/workflows/curation_pre.rst
@@ -9,8 +9,9 @@ workflows include :ref:`visualizing embeddings <brain-embeddings-visualization>`
 to explore the structure of your dataset, :ref:`similarity search
 <brain-similarity>` (including :ref:`natural language queries
 <brain-similarity-text>`), scoring samples by :ref:`uniqueness
-<brain-image-uniqueness>`, and pruning :ref:`near-duplicate
-<brain-near-duplicates>` samples.
+<brain-image-uniqueness>`, pruning :ref:`near-duplicate
+<brain-near-duplicates>` samples, and auditing your raw data with the
+FiftyOne Enterprise Data Quality 🚀 panel.
 
 In the FiftyOne App, the :ref:`Embeddings panel <app-embeddings-panel>` and
 :ref:`similarity search <app-similarity-search-panel>` make these workflows
@@ -21,6 +22,7 @@ subsets you discover into named slices of your dataset.
    :maxdepth: 1
    :hidden:
 
+   Data Quality 🚀 <../enterprise/data_quality>
    Similarity Search <../user_guide/similarity>
    Using image embeddings <../tutorials/image_embeddings.ipynb>
    Dimensionality reduction <../tutorials/dimension_reduction.ipynb>


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link.

## 📋 What changes are proposed in this pull request?

Updates the FiftyOne Agent docs to match the latest features:

* Documents Agent as a built-in Enterprise feature.
* Adds Agent permissions and API key access details.
* Adds custom instructions, App state, Load Workspace, operations, and Usage docs.
* Documents the new Default model picker.
* Moves Data Quality from Post-Annotation to Pre-Annotation.

## 🧪 How is this patch tested?

* Docs build locally without errors.
* Verified the updated pages render correctly.
* Deploy in Dev Environment, [here](https://docs.dev.voxel51.com/)

## 📝 Release Notes

* [ ] No
* [x] Yes

The FiftyOne Agent now ships as a built-in Enterprise App feature instead of a separate plugin. It supports custom instructions at the organization, user, and dataset level, can answer questions about the current App state using a screenshot, tracks delegated operations in a dedicated tray, lets you restore previous views with Load Workspace, Plugin Generation tools, Write Python SDK Tools, and includes a Usage tab to track token usage.

### What areas of FiftyOne does this PR affect?

* [ ] App
* [ ] Build
* [ ] Core
* [x] Documentation
* [ ] Other

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3946
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Enterprise Agent documentation for version 2.25.0 and built-in Enterprise App availability.
  * Replaced the legacy standalone plugin guidance with current setup information, including provider configuration and permissions.
  * Added guidance for custom instructions, workspace restoration, delegated operations, usage tracking, screenshots, and sample attachments.
  * Updated pre-annotation curation guidance to include Data Quality auditing.
  * Removed outdated Data Quality panel references from post-annotation workflow documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->