### PR TITLE
Add synchronized LeRobot episode viewer

### DIFF
--- a/app/packages/multimodal/src/adapters/fixture/fixture-state-action.test.ts
+++ b/app/packages/multimodal/src/adapters/fixture/fixture-state-action.test.ts
@@ -1,0 +1,7 @@
+import { defineStateActionCapabilityContractTests } from "../../testing/state-action-contract";
+import { createFixtureStateActionProvider } from "./fixture-state-action";
+
+defineStateActionCapabilityContractTests({
+  createSession: async (scenario) => createFixtureStateActionProvider(scenario),
+  name: "fixture",
+});

--- a/app/packages/multimodal/src/adapters/fixture/fixture-state-action.ts
+++ b/app/packages/multimodal/src/adapters/fixture/fixture-state-action.ts
@@ -14,7 +14,11 @@ const NS_PER_SECOND = 1_000_000_000;
 /** One declared state/action feature with its per-row stored values. */
 export interface StateActionScenarioFeature {
   readonly dtype: string;
-  readonly names?: readonly string[] | null;
+  /** Flat list, or a source-format-specific shape such as an axis dict. */
+  readonly names?:
+    | readonly string[]
+    | Readonly<Record<string, readonly string[]>>
+    | null;
   /** Per-row raw values, nested exactly as stored; scalars allowed. */
   readonly rows: readonly unknown[];
   readonly shape: readonly number[];
@@ -233,12 +237,12 @@ function featureSchema(
   return {
     dimensions: Array.from(
       { length: elementCount(feature.shape) },
-      (_, index) => ({
-        index,
-        ...(feature.names?.[index] !== undefined
-          ? { name: feature.names[index] }
-          : {}),
-      }),
+      (_, index) => {
+        const name = Array.isArray(feature.names)
+          ? feature.names[index]
+          : undefined;
+        return { index, ...(name !== undefined ? { name } : {}) };
+      },
     ),
     dtype: feature.dtype,
     featureName,

--- a/app/packages/multimodal/src/adapters/fixture/fixture-state-action.ts
+++ b/app/packages/multimodal/src/adapters/fixture/fixture-state-action.ts
@@ -328,7 +328,7 @@ function timingProfileOf(timesNs: readonly bigint[]): StateActionTimingProfile {
 }
 
 /** Flattens nested stored values in row-major source order. */
-export function flattenStateActionValues(value: unknown): readonly unknown[] {
+function flattenStateActionValues(value: unknown): readonly unknown[] {
   if (Array.isArray(value)) {
     return value.flatMap((entry) => flattenStateActionValues(entry));
   }

--- a/app/packages/multimodal/src/adapters/fixture/fixture-state-action.ts
+++ b/app/packages/multimodal/src/adapters/fixture/fixture-state-action.ts
@@ -1,0 +1,328 @@
+import type { RawRecordIndexWindow } from "../../ir";
+import {
+  EpisodeExactCursorError,
+  EpisodeReadCancelledError,
+  type StateActionCapability,
+  type StateActionFeatureSchema,
+  type StateActionRow,
+  type StateActionSchema,
+} from "../../ports";
+import { throwIfAborted } from "../../utils/cancellation";
+
+const NS_PER_SECOND = 1_000_000_000;
+
+/** One declared state/action feature with its per-row stored values. */
+export interface StateActionScenarioFeature {
+  readonly dtype: string;
+  readonly names?: readonly string[] | null;
+  /** Per-row raw values, nested exactly as stored; scalars allowed. */
+  readonly rows: readonly unknown[];
+  readonly shape: readonly number[];
+}
+
+/** Deterministic dataset description shared by state/action test harnesses. */
+export interface StateActionScenario {
+  readonly action?: StateActionScenarioFeature;
+  /** Declared episode end in seconds; defaults to the last row timestamp. */
+  readonly declaredEndSeconds?: number;
+  /** Episode-declared task labels, independent of the tasks asset. */
+  readonly episodeTasks?: readonly string[];
+  /** Simulated slab-fill latency so abort and dedupe behavior is observable. */
+  readonly fillLatencyMs?: number;
+  readonly state?: StateActionScenarioFeature;
+  /** Per-row task indexes; defaults to zero for every row. */
+  readonly taskIndexes?: readonly number[];
+  /** Tasks metadata mapping; undefined means the tasks asset is absent. */
+  readonly taskLabelsByIndex?: Readonly<Record<number, string>>;
+  readonly timestampsSeconds: readonly number[];
+}
+
+/** In-memory reference provider used by the capability contract tests. */
+export interface FixtureStateActionProvider {
+  readonly capability: StateActionCapability;
+  readonly declaredEndNs: bigint;
+  dispose(): void;
+  /** Count of simulated physical data reads issued so far. */
+  physicalReads(): number;
+}
+
+interface FilledRow {
+  readonly action?: readonly unknown[];
+  readonly featureErrors?: StateActionRow["featureErrors"];
+  readonly state?: readonly unknown[];
+  readonly taskIndex: number;
+}
+
+/**
+ * Reference implementation of the state/action capability over an in-memory
+ * scenario. It mirrors the production semantics — latest-row-at-or-before
+ * time resolution, one deduplicated fill, index-only windows, typed cursor
+ * rejection — without any real source format.
+ */
+export function createFixtureStateActionProvider(
+  scenario: StateActionScenario,
+): FixtureStateActionProvider {
+  const timesNs = scenario.timestampsSeconds.map(secondsToNs);
+  const rowCount = timesNs.length;
+  const declaredEndNs =
+    scenario.declaredEndSeconds !== undefined
+      ? secondsToNs(scenario.declaredEndSeconds)
+      : (timesNs.at(-1) ?? 0n);
+  const schema: StateActionSchema = {
+    ...(scenario.action
+      ? { action: featureSchema("action", scenario.action) }
+      : {}),
+    rowCount,
+    ...(scenario.state
+      ? { state: featureSchema("observation.state", scenario.state) }
+      : {}),
+  };
+
+  let disposed = false;
+  let reads = 0;
+  let fill: Promise<readonly FilledRow[]> | null = null;
+
+  const ensureOpen = () => {
+    if (disposed) throw new EpisodeReadCancelledError();
+  };
+  const ensureFill = () => {
+    if (!fill) {
+      const started = (async () => {
+        reads += 1;
+        if (scenario.fillLatencyMs) await delay(scenario.fillLatencyMs);
+        ensureOpen();
+        return buildFilledRows(scenario, rowCount);
+      })();
+      fill = started;
+      void started.catch(() => {
+        if (fill === started) fill = null;
+      });
+    }
+    return fill;
+  };
+  const rowAt = async (
+    offset: number,
+    signal?: AbortSignal,
+  ): Promise<StateActionRow> => {
+    const filled = await waitForSharedFill(ensureFill(), signal);
+    throwIfAborted(signal);
+    ensureOpen();
+    const row = filled[offset];
+    return {
+      ...(row.action ? { action: [...row.action] } : {}),
+      cursor: `row:${offset}`,
+      ...(row.featureErrors ? { featureErrors: row.featureErrors } : {}),
+      frameIndex: offset,
+      ...(row.state ? { state: [...row.state] } : {}),
+      task: {
+        index: row.taskIndex,
+        ...(taskLabel(scenario, row.taskIndex) !== undefined
+          ? { label: taskLabel(scenario, row.taskIndex) }
+          : {}),
+      },
+      timestampNs: timesNs[offset],
+    };
+  };
+
+  return {
+    capability: {
+      schema,
+      async readAtCursor(request) {
+        ensureOpen();
+        throwIfAborted(request.signal);
+        return rowAt(parseCursor(request.cursor, rowCount), request.signal);
+      },
+      async readAtTime(request) {
+        ensureOpen();
+        throwIfAborted(request.signal);
+        if (request.timestampNs > declaredEndNs) return null;
+        const offset = offsetAtOrBefore(timesNs, request.timestampNs);
+        return offset === null ? null : rowAt(offset, request.signal);
+      },
+      async readIndexWindow(request) {
+        ensureOpen();
+        throwIfAborted(request.signal);
+        const selected =
+          request.anchorCursor !== undefined
+            ? parseCursor(request.anchorCursor, rowCount)
+            : (offsetAtOrBefore(timesNs, request.anchorTimestampNs) ?? 0);
+        const start = Math.max(0, selected - Math.max(0, request.before));
+        const end = Math.min(
+          rowCount,
+          selected + Math.max(0, request.after) + 1,
+        );
+        const window: RawRecordIndexWindow = {
+          entries: timesNs.slice(start, end).map((timestampNs, index) => ({
+            cursor: `row:${start + index}`,
+            timestampNs,
+          })),
+          hasNext: end < rowCount,
+          hasPrevious: start > 0,
+          selectedCursor: `row:${selected}`,
+        };
+        return window;
+      },
+    },
+    declaredEndNs,
+    dispose() {
+      disposed = true;
+      fill = null;
+    },
+    physicalReads: () => reads,
+  };
+}
+
+/** Flattens nested stored values in row-major source order. */
+export function flattenStateActionValues(value: unknown): readonly unknown[] {
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => flattenStateActionValues(entry));
+  }
+  return [value];
+}
+
+function buildFilledRows(
+  scenario: StateActionScenario,
+  rowCount: number,
+): readonly FilledRow[] {
+  return Array.from({ length: rowCount }, (_, offset) => {
+    const state = scenario.state
+      ? flattenStateActionValues(scenario.state.rows[offset])
+      : undefined;
+    const action = scenario.action
+      ? flattenStateActionValues(scenario.action.rows[offset])
+      : undefined;
+    const stateError =
+      scenario.state && state
+        ? shapeMismatch("observation.state", scenario.state, state.length)
+        : undefined;
+    const actionError =
+      scenario.action && action
+        ? shapeMismatch("action", scenario.action, action.length)
+        : undefined;
+    return {
+      ...(action ? { action } : {}),
+      ...(stateError || actionError
+        ? {
+            featureErrors: {
+              ...(actionError ? { action: actionError } : {}),
+              ...(stateError ? { state: stateError } : {}),
+            },
+          }
+        : {}),
+      ...(state ? { state } : {}),
+      taskIndex: scenario.taskIndexes?.[offset] ?? 0,
+    };
+  });
+}
+
+function shapeMismatch(
+  featureName: string,
+  feature: StateActionScenarioFeature,
+  count: number,
+): string | undefined {
+  const expected = elementCount(feature.shape);
+  return count === expected
+    ? undefined
+    : `'${featureName}' row has ${count} values but declares shape [${feature.shape.join(",")}]`;
+}
+
+function featureSchema(
+  featureName: string,
+  feature: StateActionScenarioFeature,
+): StateActionFeatureSchema {
+  return {
+    dimensions: Array.from(
+      { length: elementCount(feature.shape) },
+      (_, index) => ({
+        index,
+        ...(feature.names?.[index] !== undefined
+          ? { name: feature.names[index] }
+          : {}),
+      }),
+    ),
+    dtype: feature.dtype,
+    featureName,
+    shape: feature.shape,
+  };
+}
+
+function elementCount(shape: readonly number[]): number {
+  return Math.max(
+    1,
+    shape.reduce((product, value) => product * value, 1),
+  );
+}
+
+function taskLabel(
+  scenario: StateActionScenario,
+  index: number,
+): string | undefined {
+  return (
+    scenario.taskLabelsByIndex?.[index] ??
+    (scenario.episodeTasks?.length === 1 ? scenario.episodeTasks[0] : undefined)
+  );
+}
+
+function parseCursor(cursor: string, rowCount: number): number {
+  const match = /^row:(\d+)$/.exec(cursor);
+  const value = match ? Number(match[1]) : Number.NaN;
+  if (!Number.isSafeInteger(value) || value < 0 || value >= rowCount) {
+    throw new EpisodeExactCursorError(
+      "Unknown state/action row cursor for this source",
+    );
+  }
+  return value;
+}
+
+function offsetAtOrBefore(
+  timesNs: readonly bigint[],
+  timestampNs: bigint,
+): number | null {
+  if (!timesNs.length || timestampNs < timesNs[0]) return null;
+  let low = 0;
+  let high = timesNs.length;
+  while (low < high) {
+    const middle = (low + high) >>> 1;
+    if (timesNs[middle] <= timestampNs) low = middle + 1;
+    else high = middle;
+  }
+  return Math.max(0, low - 1);
+}
+
+function secondsToNs(seconds: number): bigint {
+  return BigInt(Math.round(seconds * NS_PER_SECOND));
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function waitForSharedFill<T>(
+  promise: Promise<T>,
+  signal?: AbortSignal,
+): Promise<T> {
+  if (!signal) return promise;
+  throwIfAborted(signal);
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      cleanup();
+      try {
+        throwIfAborted(signal);
+      } catch (error) {
+        reject(error);
+      }
+    };
+    const cleanup = () => signal.removeEventListener("abort", onAbort);
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => {
+        cleanup();
+        resolve(value);
+      },
+      (error) => {
+        cleanup();
+        reject(error);
+      },
+    );
+  });
+}

--- a/app/packages/multimodal/src/adapters/fixture/fixture-state-action.ts
+++ b/app/packages/multimodal/src/adapters/fixture/fixture-state-action.ts
@@ -3,9 +3,14 @@ import {
   EpisodeExactCursorError,
   EpisodeReadCancelledError,
   type StateActionCapability,
+  type StateActionDimensionExtreme,
+  type StateActionEpisodeProfile,
+  type StateActionFeatureProfile,
   type StateActionFeatureSchema,
   type StateActionRow,
   type StateActionSchema,
+  type StateActionTimingGap,
+  type StateActionTimingProfile,
 } from "../../ports";
 import { throwIfAborted } from "../../utils/cancellation";
 
@@ -143,6 +148,14 @@ export function createFixtureStateActionProvider(
         const offset = offsetAtOrBefore(timesNs, request.timestampNs);
         return offset === null ? null : rowAt(offset, request.signal);
       },
+      async readEpisodeProfile(options) {
+        ensureOpen();
+        throwIfAborted(options?.signal);
+        const filled = await waitForSharedFill(ensureFill(), options?.signal);
+        throwIfAborted(options?.signal);
+        ensureOpen();
+        return buildEpisodeProfile(filled, timesNs, schema);
+      },
       async readIndexWindow(request) {
         ensureOpen();
         throwIfAborted(request.signal);
@@ -173,6 +186,144 @@ export function createFixtureStateActionProvider(
       fill = null;
     },
     physicalReads: () => reads,
+  };
+}
+
+/** Largest-first gap samples kept on a timing profile. */
+const TIMING_GAP_CAP = 8;
+
+function buildEpisodeProfile(
+  rows: readonly FilledRow[],
+  timesNs: readonly bigint[],
+  schema: StateActionSchema,
+): StateActionEpisodeProfile {
+  const state = schema.state
+    ? aggregateFeature(
+        rows.map((row) => row.state),
+        timesNs,
+        schema.state.dimensions.length,
+      )
+    : undefined;
+  const action = schema.action
+    ? aggregateFeature(
+        rows.map((row) => row.action),
+        timesNs,
+        schema.action.dimensions.length,
+      )
+    : undefined;
+  const trackingError =
+    schema.state &&
+    schema.action &&
+    schema.state.dimensions.length === schema.action.dimensions.length
+      ? trackingErrorOf(rows, schema.state.dimensions.length)
+      : undefined;
+  return {
+    ...(action ? { action } : {}),
+    rowCount: timesNs.length,
+    ...(state ? { state } : {}),
+    timing: timingProfileOf(timesNs),
+    ...(trackingError ? { trackingError } : {}),
+  };
+}
+
+function aggregateFeature(
+  perRowValues: readonly (readonly unknown[] | undefined)[],
+  timesNs: readonly bigint[],
+  dimensionCount: number,
+): StateActionFeatureProfile {
+  const min: (StateActionDimensionExtreme | null)[] = Array.from(
+    { length: dimensionCount },
+    () => null,
+  );
+  const max: (StateActionDimensionExtreme | null)[] = Array.from(
+    { length: dimensionCount },
+    () => null,
+  );
+  const sums = new Array<number>(dimensionCount).fill(0);
+  const counts = new Array<number>(dimensionCount).fill(0);
+  perRowValues.forEach((values, frameIndex) => {
+    if (!values) return;
+    for (let index = 0; index < dimensionCount; index += 1) {
+      const value = values[index];
+      if (typeof value !== "number" || !Number.isFinite(value)) continue;
+      sums[index] += value;
+      counts[index] += 1;
+      const timestampNs = timesNs[frameIndex];
+      const currentMin = min[index];
+      if (currentMin === null || value < currentMin.value) {
+        min[index] = { frameIndex, timestampNs, value };
+      }
+      const currentMax = max[index];
+      if (currentMax === null || value > currentMax.value) {
+        max[index] = { frameIndex, timestampNs, value };
+      }
+    }
+  });
+  return {
+    max,
+    mean: counts.map((count, index) =>
+      count > 0 ? sums[index] / count : null,
+    ),
+    min,
+    // The fixture models no declared statistics, so declared bounds never
+    // exist to count against.
+    outOfRangeCounts: null,
+  };
+}
+
+function trackingErrorOf(
+  rows: readonly FilledRow[],
+  dimensionCount: number,
+): readonly (number | null)[] {
+  const sums = new Array<number>(dimensionCount).fill(0);
+  const counts = new Array<number>(dimensionCount).fill(0);
+  for (const row of rows) {
+    if (!row.state || !row.action) continue;
+    for (let index = 0; index < dimensionCount; index += 1) {
+      const state = row.state[index];
+      const action = row.action[index];
+      if (
+        typeof state !== "number" ||
+        !Number.isFinite(state) ||
+        typeof action !== "number" ||
+        !Number.isFinite(action)
+      ) {
+        continue;
+      }
+      sums[index] += Math.abs(action - state);
+      counts[index] += 1;
+    }
+  }
+  return counts.map((count, index) => (count > 0 ? sums[index] / count : null));
+}
+
+function timingProfileOf(timesNs: readonly bigint[]): StateActionTimingProfile {
+  if (timesNs.length < 2) {
+    return { gapCount: 0, gaps: [], medianIntervalNs: 0n };
+  }
+  const intervals = timesNs.slice(1).map((timeNs, index) => ({
+    beforeFrameIndex: index,
+    durationNs: timeNs - timesNs[index],
+    timestampNs: timeNs,
+  }));
+  const sorted = intervals
+    .map((interval) => interval.durationNs)
+    .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+  const medianIntervalNs =
+    (sorted[(sorted.length - 1) >> 1] + sorted[sorted.length >> 1]) / 2n;
+  const gaps: StateActionTimingGap[] = intervals
+    .filter(
+      (interval) =>
+        medianIntervalNs > 0n &&
+        interval.durationNs * 2n > medianIntervalNs * 3n,
+    )
+    .sort((a, b) =>
+      a.durationNs < b.durationNs ? 1 : a.durationNs > b.durationNs ? -1 : 0,
+    );
+  return {
+    gapCount: gaps.length,
+    gaps: gaps.slice(0, TIMING_GAP_CAP),
+    medianIntervalNs,
   };
 }
 

--- a/app/packages/multimodal/src/adapters/fixture/index.ts
+++ b/app/packages/multimodal/src/adapters/fixture/index.ts
@@ -1,3 +1,10 @@
 /** Public deterministic format adapter for contract and performance tests. */
 export { createFixtureFormatAdapter } from "./fixture-adapter";
 export type { FixtureAdapterOptions } from "./fixture-adapter";
+/** Reference state/action provider for the capability contract tests. */
+export { createFixtureStateActionProvider } from "./fixture-state-action";
+export type {
+  FixtureStateActionProvider,
+  StateActionScenario,
+  StateActionScenarioFeature,
+} from "./fixture-state-action";

--- a/app/packages/multimodal/src/adapters/lerobot/descriptor.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/descriptor.ts
@@ -13,7 +13,13 @@ export const leRobotAdapterDescriptor: AdapterDescriptor = {
   detect: detectLeRobotSample,
   id: "lerobot-v3",
   load: async () => {
-    const { createLeRobotFormatAdapter } = await import("./format-adapter");
+    // The LeRobot tile extension registers as a side effect of this lazy
+    // load, so it exists before any session can expose hasStateAction and
+    // never enters the initial bundle for non-LeRobot sessions.
+    const [{ createLeRobotFormatAdapter }] = await Promise.all([
+      import("./format-adapter"),
+      import("../../views/episode/state-action/register-state-action-tile"),
+    ]);
     return createLeRobotFormatAdapter();
   },
 };

--- a/app/packages/multimodal/src/adapters/lerobot/descriptor.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/descriptor.ts
@@ -2,19 +2,16 @@ import type { AdapterDescriptor, SampleDescriptor } from "../../ports";
 
 /** Returns whether lightweight sample facts identify a LeRobot episode. */
 export function detectLeRobotSample(sample: SampleDescriptor): boolean {
-  if (sample.mediaType === "application/x-lerobot") return true;
-  const path = sample.path ?? "";
   return (
-    /^lerobot:/i.test(path) ||
-    /(?:^|\/)meta\/info\.json(?:$|[?#])/i.test(path) ||
-    /\.lerobot\.json(?:$|[?#])/i.test(path)
+    sample.mediaType === "multimodal" &&
+    sample.mediaReference?.kind === "lerobot-episode"
   );
 }
 
 /** Tiny descriptor that keeps Parquet and MP4 parsing behind `load()`. */
 export const leRobotAdapterDescriptor: AdapterDescriptor = {
   detect: detectLeRobotSample,
-  id: "lerobot",
+  id: "lerobot-v3",
   load: async () => {
     const { createLeRobotFormatAdapter } = await import("./format-adapter");
     return createLeRobotFormatAdapter();

--- a/app/packages/multimodal/src/adapters/lerobot/descriptor.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/descriptor.ts
@@ -8,18 +8,16 @@ export function detectLeRobotSample(sample: SampleDescriptor): boolean {
   );
 }
 
-/** Tiny descriptor that keeps Parquet and MP4 parsing behind `load()`. */
+/**
+ * Tiny descriptor that keeps Parquet and MP4 parsing behind `load()`.
+ * Format-specific view extensions ride the same lazy load, but the
+ * injection root composes them in — the adapter layer stays view-free.
+ */
 export const leRobotAdapterDescriptor: AdapterDescriptor = {
   detect: detectLeRobotSample,
   id: "lerobot-v3",
   load: async () => {
-    // The LeRobot tile extension registers as a side effect of this lazy
-    // load, so it exists before any session can expose hasStateAction and
-    // never enters the initial bundle for non-LeRobot sessions.
-    const [{ createLeRobotFormatAdapter }] = await Promise.all([
-      import("./format-adapter"),
-      import("../../views/episode/state-action/register-state-action-tile"),
-    ]);
+    const { createLeRobotFormatAdapter } = await import("./format-adapter");
     return createLeRobotFormatAdapter();
   },
 };

--- a/app/packages/multimodal/src/adapters/lerobot/format-adapter.test.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/format-adapter.test.ts
@@ -610,6 +610,7 @@ describe("LeRobot format adapter", () => {
     if (!preview) throw new Error("LeRobot preview session is unavailable");
     try {
       const first = await preview.read({
+        decodeLookaheadNs: 250_000_000n,
         sourceName: "observation.images.test",
       });
       expect(first).toMatchObject({
@@ -630,6 +631,13 @@ describe("LeRobot format adapter", () => {
           "observation.images.test",
         ],
       });
+      expect(
+        first.videoDecodeRunway?.map((frame) =>
+          frame.kind === "image" && frame.image.kind === "encoded-video"
+            ? frame.image.timestampNs
+            : null,
+        ),
+      ).toEqual([0n, 500_000_000n]);
       await expect(
         preview.read({
           sourceName: "observation.images.test",

--- a/app/packages/multimodal/src/adapters/lerobot/format-adapter.test.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/format-adapter.test.ts
@@ -28,6 +28,7 @@ const info = {
     },
     "action.gripper": { dtype: "float32", shape: [1] },
     language_instruction: { dtype: "string", shape: [1] },
+    task_progress: { dtype: "float32", shape: [1] },
     "observation.state": {
       dtype: "float32",
       names: ["joint_a", "joint_b"],
@@ -189,6 +190,7 @@ const dataRows = [
     "observation.images.embedded": Uint8Array.of(0xff, 0xd8, 0xff, 0xd9),
     "observation.state": [3, 4],
     task_index: 0n,
+    task_progress: [0.1],
     timestamp: 0,
     success: false,
   },
@@ -202,6 +204,7 @@ const dataRows = [
     "observation.images.embedded": Uint8Array.of(0xff, 0xd8, 0xff, 0xd9),
     "observation.state": [7, 8],
     task_index: 0n,
+    task_progress: [0.5],
     timestamp: 0.033333335,
     success: true,
   },
@@ -215,6 +218,7 @@ const dataRows = [
     "observation.images.embedded": Uint8Array.of(0xff, 0xd8, 0xff, 0xd9),
     "observation.state": [11, 12],
     task_index: 0n,
+    task_progress: [1],
     timestamp: 0.06666667,
     success: true,
   },
@@ -339,6 +343,10 @@ describe("LeRobot format adapter", () => {
         "stream.category": "custom",
         "stream.inspectable": "true",
       });
+      expect(byName.get("task_progress")?.metadata).toMatchObject({
+        "stream.category": "custom",
+        "stream.inspectable": "true",
+      });
       expect(byName.get("observation.images.embedded")).toMatchObject({
         count: 3,
         kind: "image",
@@ -355,7 +363,7 @@ describe("LeRobot format adapter", () => {
       expect(byName.get("observation.images.test")).not.toHaveProperty("count");
       expect(session.manifest.recordingFacts).toMatchObject({
         applicationSupport: {
-          inspectableStreamCount: 4,
+          inspectableStreamCount: 5,
           renderableStreamCount: 2,
           unavailableStreamCount: 1,
         },
@@ -364,7 +372,7 @@ describe("LeRobot format adapter", () => {
         lerobot: {
           codebaseVersion: "v3.0",
           episodeIndex: "0",
-          featureCount: 8,
+          featureCount: 9,
           fps: 30,
           logicalRowCount: 3,
           mediaFeatureCount: 2,

--- a/app/packages/multimodal/src/adapters/lerobot/format-adapter.test.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/format-adapter.test.ts
@@ -423,6 +423,144 @@ describe("LeRobot format adapter", () => {
     }
   });
 
+  it("reuses an MP4 GOP prefix and reads only its missing tail", async () => {
+    const readBytes = vi.fn<ByteResources["readBytes"]>((request) =>
+      io.readBytes(request),
+    );
+    const session = await createLeRobotFormatAdapter({
+      readParquetObjects,
+    }).open(source, { readBytes });
+    const readVideo = (endNs: bigint) =>
+      collectBatches(
+        session.read({
+          streams: ["lerobot:observation.images.test"],
+          window: { endNs, startNs: 0n },
+        }),
+      );
+    try {
+      await readVideo(0n);
+      const firstReads = readBytes.mock.calls
+        .map(([request]) => request)
+        .filter((request) => request.source.sourceId === "video");
+      const firstSpan = firstReads.at(-1)?.range;
+      if (!firstSpan) throw new Error("Expected an MP4 sample span read");
+
+      await readVideo(500_000_000n);
+      const extendedReads = readBytes.mock.calls
+        .map(([request]) => request)
+        .filter((request) => request.source.sourceId === "video");
+      expect(extendedReads).toHaveLength(firstReads.length + 1);
+      const tail = extendedReads.at(-1)?.range;
+      expect(tail?.offset).toBe(firstSpan.offset + firstSpan.length);
+
+      await readVideo(500_000_000n);
+      expect(
+        readBytes.mock.calls
+          .map(([request]) => request)
+          .filter((request) => request.source.sourceId === "video"),
+      ).toHaveLength(extendedReads.length);
+    } finally {
+      session.dispose();
+    }
+  });
+
+  it("reads synchronized camera batches concurrently", async () => {
+    const secondFeature = "observation.images.second";
+    const dualInfo = {
+      ...info,
+      features: {
+        ...info.features,
+        [secondFeature]: info.features["observation.images.test"],
+      },
+    };
+    const dualInfoBytes = new TextEncoder().encode(JSON.stringify(dualInfo));
+    const firstVideoAsset = assets.find((asset) => asset.id === "video");
+    if (!firstVideoAsset) throw new Error("Missing test video asset");
+    const dualAssets = [
+      ...assets.map((asset) =>
+        asset.id === "info"
+          ? {
+              ...asset,
+              metadata: { sizeBytes: dualInfoBytes.byteLength.toString() },
+            }
+          : asset,
+      ),
+      {
+        ...firstVideoAsset,
+        featureName: secondFeature,
+        id: "video-second",
+        metadata: {
+          ...firstVideoAsset.metadata,
+          stream: secondFeature,
+        },
+      },
+    ];
+    let activeVideoReads = 0;
+    let maxActiveVideoReads = 0;
+    const dualSource: EpisodeSource = {
+      assets: {
+        list: async () => dualAssets,
+        resolve: async (assetId) => {
+          const asset = dualAssets.find(
+            (candidate) => candidate.id === assetId,
+          );
+          if (!asset) throw new Error(`Unknown dual-camera asset ${assetId}`);
+          return {
+            sizeBytes: asset.metadata?.sizeBytes,
+            sourceId: asset.id,
+            url: `memory://${asset.id}`,
+          };
+        },
+      },
+      episodeId: "episode-0",
+    };
+    const dualIo: ByteResources = {
+      readBytes: async (request) => {
+        const isVideo = request.source.sourceId.startsWith("video");
+        if (isVideo) {
+          activeVideoReads += 1;
+          maxActiveVideoReads = Math.max(maxActiveVideoReads, activeVideoReads);
+          await Promise.resolve();
+        }
+        try {
+          const start = Number(request.range.offset);
+          const end = start + Number(request.range.length);
+          const bytes =
+            request.source.sourceId === "info"
+              ? dualInfoBytes.slice(start, end)
+              : isVideo
+                ? tinyMp4Bytes.slice(start, end)
+                : new Uint8Array(Number(request.range.length));
+          return { bytes, range: request.range, source: request.source };
+        } finally {
+          if (isVideo) activeVideoReads -= 1;
+        }
+      },
+    };
+    const session = await createLeRobotFormatAdapter({
+      readParquetObjects,
+    }).open(dualSource, dualIo);
+    try {
+      const streams = [
+        "lerobot:observation.images.test",
+        `lerobot:${secondFeature}`,
+      ];
+      const windows = await session.playback?.readSynchronizedBatch({
+        streams,
+        timeNs: [0n, 500_000_000n],
+      });
+
+      expect(maxActiveVideoReads).toBeGreaterThanOrEqual(2);
+      expect(windows).toHaveLength(2);
+      expect(windows?.[0].framesByStream[streams[0]]).toHaveLength(1);
+      expect(windows?.[0].framesByStream[streams[1]]).toHaveLength(1);
+      expect(windows?.[1].framesByStream[streams[0]]).toHaveLength(1);
+      expect(windows?.[1].framesByStream[streams[1]]).toHaveLength(1);
+    } finally {
+      session.dispose();
+    }
+  });
+
   it("reads embedded images and exact bounded raw rows", async () => {
     const session = await createLeRobotFormatAdapter({
       readParquetObjects,

--- a/app/packages/multimodal/src/adapters/lerobot/format-adapter.test.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/format-adapter.test.ts
@@ -100,6 +100,8 @@ const tinyAv1Mp4Bytes = new Uint8Array(
     "base64",
   ),
 );
+const EPISODE_ROW_START = 100;
+const EPISODE_ROW_END = 101;
 const assets: readonly AssetDescriptor[] = [
   {
     id: "info",
@@ -115,9 +117,9 @@ const assets: readonly AssetDescriptor[] = [
     role: "episode-metadata",
     selector: {
       coordinateSystem: "parquet-file-row",
-      end: 1,
+      end: EPISODE_ROW_END,
       kind: "row-interval",
-      start: 0,
+      start: EPISODE_ROW_START,
     },
   },
   {
@@ -263,7 +265,13 @@ const readParquetObjects = vi.fn(
     rowEnd?: number;
     rowStart?: number;
   }) => {
-    if (!options.columns && options.file.byteLength !== 2) return [episodeRow];
+    if (
+      !options.columns &&
+      options.rowStart === EPISODE_ROW_START &&
+      options.rowEnd === EPISODE_ROW_END
+    ) {
+      return [episodeRow];
+    }
     return dataRows.slice(
       options.rowStart ?? 0,
       options.rowEnd ?? dataRows.length,

--- a/app/packages/multimodal/src/adapters/lerobot/format-adapter.test.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/format-adapter.test.ts
@@ -635,6 +635,50 @@ describe("LeRobot format adapter", () => {
       preview.dispose();
     }
   });
+
+  it("keeps an MP4 boundary keyframe after nanosecond normalization", async () => {
+    const boundaryAssets = assets.map((asset) =>
+      asset.id === "video"
+        ? {
+            ...asset,
+            selector: {
+              fromTimestamp: Number.EPSILON,
+              kind: "video-timestamp-interval" as const,
+              toTimestamp: 1,
+            },
+          }
+        : asset,
+    );
+    const boundarySource: EpisodeSource = {
+      ...source,
+      assets: {
+        ...source.assets,
+        list: async () => boundaryAssets,
+      },
+    };
+    const preview = await createLeRobotFormatAdapter({
+      readParquetObjects,
+    }).openPreview?.(boundarySource, io);
+    if (!preview) throw new Error("LeRobot preview session is unavailable");
+    try {
+      const result = await preview.read({
+        sourceName: "observation.images.test",
+      });
+      expect(result).toMatchObject({
+        frame: {
+          image: {
+            keyframe: true,
+            timestampNs: 0n,
+          },
+          kind: "image",
+        },
+        frameTimeNs: 0n,
+        status: "ready",
+      });
+    } finally {
+      preview.dispose();
+    }
+  });
 });
 
 const realRoot = process.env.LEROBOT_DATASET_PATH;

--- a/app/packages/multimodal/src/adapters/lerobot/format-adapter.test.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/format-adapter.test.ts
@@ -561,7 +561,7 @@ describe("LeRobot format adapter", () => {
     }
   });
 
-  it("reads embedded images and exact bounded raw rows", async () => {
+  it("reads embedded images and exact bounded raw feature records", async () => {
     const session = await createLeRobotFormatAdapter({
       readParquetObjects,
     }).open(source, io);
@@ -581,6 +581,25 @@ describe("LeRobot format adapter", () => {
         rowStart: 0,
       });
 
+      await expect(session.rawRecords?.listRawRecordStreams()).resolves.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            sourceName: "Episode rows",
+            streamId: "lerobot:rows",
+          }),
+          expect.objectContaining({
+            schemaName: "float32[2]",
+            sourceName: "action",
+            streamId: "lerobot:action",
+          }),
+          expect.objectContaining({
+            schemaName: "float32[2]",
+            sourceName: "observation.state",
+            streamId: "lerobot:observation.state",
+          }),
+        ]),
+      );
+
       await expect(
         session.rawRecords?.readRawRecordAtCursor?.({
           cursor: "row:1",
@@ -594,7 +613,30 @@ describe("LeRobot format adapter", () => {
         status: "ok",
         timestampNs: 33_333_335n,
       });
+      await expect(
+        session.rawRecords?.readRawRecordAtCursor?.({
+          cursor: "row:1",
+          includeFullJson: true,
+          stream: "lerobot:action",
+        }),
+      ).resolves.toMatchObject({
+        cursor: "row:1",
+        fullJson: expect.stringContaining('"action.joint_a": 5'),
+        root: {
+          entries: [
+            ["action.joint_a", { value: "5", valueType: "number" }],
+            ["action.joint_b", { value: "6", valueType: "number" }],
+          ],
+        },
+        schemaName: "float32[2]",
+        sequence: 1,
+        sourceName: "action",
+        status: "ok",
+        streamId: "lerobot:action",
+        timestampNs: 33_333_335n,
+      });
       expect(readParquetObjects.mock.lastCall?.[0]).toMatchObject({
+        columns: ["timestamp", "frame_index", "action"],
         rowEnd: 2,
         rowStart: 1,
       });

--- a/app/packages/multimodal/src/adapters/lerobot/format-adapter.test.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/format-adapter.test.ts
@@ -77,6 +77,26 @@ const tinyMp4Bytes = new Uint8Array(
     "base64",
   ),
 );
+const tinyAv1Mp4Bytes = new Uint8Array(
+  Buffer.from(
+    [
+      "AAAAIGZ0eXBpc29tAAACAGlzb21hdjAxaXNvMm1wNDEAAAMebW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAA+gAAQAA",
+      "AQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "AgAAAkl0cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAA+gAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAB",
+      "AAAAAAAAAAAAAAAAAABAAAAAAEAAAABAAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAAPoAAAAAAABAAAAAAHBbWRpYQAAACB",
+      "tZGhkAAAAAAAAAAAAAAAAAABAAAAAQABVxAAAAAAALWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABWaWRlb0hhbmRsZXIAAAAB",
+      "bG1pbmYAAAAUdm1oZAAAAAEAAAAAAAAAAAAAACRkaW5mAAAAHGRyZWYAAAAAAAAAAQAAAAx1cmwgAAAAAQAAASxzdGJsAAAArHN0c",
+      "2QAAAAAAAAAAQAAAJxhdjAxAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAEAAQABIAAAASAAAAAAAAAABF0xhdmM2Mi4xMS4xMDAg",
+      "bGlic3Z0YXYxAAAAAAAAAAAAGP//AAAAGGF2MUOBAAwACgoAAAACr/+AXwAIAAAACmZpZWwBAAAAABBwYXNwAAAAAQAAAAEAAAAU",
+      "YnRydAAAAAAAAAGoAAABqAAAABhzdHRzAAAAAAAAAAEAAAACAAAgAAAAABRzdHNzAAAAAAAAAAEAAAABAAAAHHN0c2MAAAAAAAAA",
+      "AQAAAAEAAAACAAAAAQAAABxzdHN6AAAAAAAAAAAAAAACAAAAIwAAABIAAAAUc3RjbwAAAAAAAAABAAADTgAAAGF1ZHRhAAAAWW1l",
+      "dGEAAAAAAAAAIWhkbHIAAAAAAAAAAG1kaXJhcHBsAAAAAAAAAAAAAAAALGlsc3QAAAAkqXRvbwAAABxkYXRhAAAAAQAAAABMYXZm",
+      "NjIuMy4xMDAAAAAIZnJlZQAAAD1tZGF0CgoAAAACr/+JXyAIMhUQAMGCCyxRQgAACJQNlzHvMaZyCPgyEDACBAkkkiOQAAACAAA",
+      "AnFA=",
+    ].join(""),
+    "base64",
+  ),
+);
 const assets: readonly AssetDescriptor[] = [
   {
     id: "info",
@@ -658,6 +678,8 @@ describe("LeRobot format adapter", () => {
       expect(first).toMatchObject({
         frameTimeNs: 0n,
         nativeVideo: {
+          codec: "h264",
+          codecString: expect.stringMatching(/^avc1\./),
           endTimeSeconds: 1,
           source: {
             sourceId: "video",
@@ -688,6 +710,95 @@ describe("LeRobot format adapter", () => {
       ).resolves.toMatchObject({
         frameTimeNs: 500_000_000n,
         status: "ready",
+      });
+    } finally {
+      preview.dispose();
+    }
+  });
+
+  it("exposes AV1 video as a native-only grid preview", async () => {
+    const av1InfoBytes = new TextEncoder().encode(
+      JSON.stringify({
+        ...info,
+        features: {
+          ...info.features,
+          "observation.images.test": {
+            ...info.features["observation.images.test"],
+            info: { "video.codec": "av1", "video.fps": 2 },
+          },
+        },
+      }),
+    );
+    const av1Assets = assets.map((asset) => {
+      if (asset.id === "info") {
+        return {
+          ...asset,
+          metadata: { sizeBytes: av1InfoBytes.byteLength.toString() },
+        };
+      }
+      if (asset.id === "video") {
+        return {
+          ...asset,
+          metadata: {
+            ...asset.metadata,
+            sizeBytes: tinyAv1Mp4Bytes.byteLength.toString(),
+          },
+        };
+      }
+      return asset;
+    });
+    const av1Source: EpisodeSource = {
+      ...source,
+      assets: {
+        list: async () => av1Assets,
+        resolve: async (assetId) => ({
+          ...descriptor(assetId),
+          sizeBytes: av1Assets.find((asset) => asset.id === assetId)?.metadata
+            ?.sizeBytes,
+        }),
+      },
+    };
+    const av1Io: ByteResources = {
+      readBytes: async (request) => {
+        const start = Number(request.range.offset);
+        const end = start + Number(request.range.length);
+        if (request.source.sourceId === "video") {
+          return {
+            bytes: tinyAv1Mp4Bytes.slice(start, end),
+            range: request.range,
+            source: request.source,
+          };
+        }
+        if (request.source.sourceId !== "info") return io.readBytes(request);
+        return {
+          bytes: av1InfoBytes.slice(start, end),
+          range: request.range,
+          source: request.source,
+        };
+      },
+    };
+    const preview = await createLeRobotFormatAdapter({
+      readParquetObjects,
+    }).openPreview?.(av1Source, av1Io);
+    if (!preview) throw new Error("LeRobot preview session is unavailable");
+    try {
+      await expect(
+        preview.read({ sourceName: "observation.images.test" }),
+      ).resolves.toMatchObject({
+        frame: null,
+        nativeVideo: {
+          codec: "av1",
+          codecString: expect.stringMatching(/^av01\./),
+          endTimeSeconds: 1,
+          source: { sourceId: "video", url: "memory://video" },
+          startTimeSeconds: 0,
+        },
+        status: "ready",
+        streamSourceName: "observation.images.test",
+        streamSourceNames: [
+          "observation.images.embedded",
+          "observation.images.test",
+        ],
       });
     } finally {
       preview.dispose();

--- a/app/packages/multimodal/src/adapters/lerobot/format-adapter.test.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/format-adapter.test.ts
@@ -716,7 +716,7 @@ describe("LeRobot format adapter", () => {
     }
   });
 
-  it("exposes AV1 video as a native-only grid preview", async () => {
+  it("keeps AV1 grid previews native while demuxing modal access units", async () => {
     const av1InfoBytes = new TextEncoder().encode(
       JSON.stringify({
         ...info,
@@ -777,9 +777,10 @@ describe("LeRobot format adapter", () => {
         };
       },
     };
-    const preview = await createLeRobotFormatAdapter({
+    const adapter = createLeRobotFormatAdapter({
       readParquetObjects,
-    }).openPreview?.(av1Source, av1Io);
+    });
+    const preview = await adapter.openPreview?.(av1Source, av1Io);
     if (!preview) throw new Error("LeRobot preview session is unavailable");
     try {
       await expect(
@@ -802,6 +803,35 @@ describe("LeRobot format adapter", () => {
       });
     } finally {
       preview.dispose();
+    }
+
+    const session = await adapter.open(av1Source, av1Io);
+    try {
+      expect(
+        session.manifest.streams.find(
+          (stream) => stream.id === "lerobot:observation.images.test",
+        )?.metadata,
+      ).toMatchObject({ "stream.decode_status": "decodable" });
+      const batches = await collectBatches(
+        session.read({
+          streams: ["lerobot:observation.images.test"],
+          window: session.manifest.timeRange,
+        }),
+      );
+      expect(batches[0].frames[0].output.visualization).toMatchObject({
+        codec: "av1",
+        format: expect.stringMatching(/^av01\./),
+        keyframe: true,
+        kind: "encoded-video",
+      });
+      expect(batches[0].frames[0].output.visualization).not.toHaveProperty(
+        "h264",
+      );
+      expect(
+        batches[0].frames[0].output.resourceHints?.sizeBytes,
+      ).toBeGreaterThan(0);
+    } finally {
+      session.dispose();
     }
   });
 

--- a/app/packages/multimodal/src/adapters/lerobot/format-adapter.test.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/format-adapter.test.ts
@@ -273,7 +273,6 @@ describe("LeRobot format adapter", () => {
         mediaReference: {
           kind: "lerobot-episode",
           key: "source:17",
-          version: "1",
         },
       }),
     ).toBe(true);
@@ -283,7 +282,6 @@ describe("LeRobot format adapter", () => {
         mediaReference: {
           kind: "lerobot-episode",
           key: "source:17",
-          version: "1",
         },
       }),
     ).toBe(false);

--- a/app/packages/multimodal/src/adapters/lerobot/format-adapter.test.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/format-adapter.test.ts
@@ -614,6 +614,14 @@ describe("LeRobot format adapter", () => {
       });
       expect(first).toMatchObject({
         frameTimeNs: 0n,
+        nativeVideo: {
+          endTimeSeconds: 1,
+          source: {
+            sourceId: "video",
+            url: "memory://video",
+          },
+          startTimeSeconds: 0,
+        },
         nextStartTimeNs: 500_000_000n,
         status: "ready",
         streamSourceName: "observation.images.test",

--- a/app/packages/multimodal/src/adapters/lerobot/format-adapter.test.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/format-adapter.test.ts
@@ -31,10 +31,15 @@ const info = {
       names: ["joint_a", "joint_b"],
       shape: [2],
     },
+    success: { dtype: "bool", shape: [1] },
     "observation.images.test": {
       dtype: "video",
       info: { "video.codec": "h264", "video.fps": 2 },
       shape: [16, 16, 3],
+    },
+    "observation.images.embedded": {
+      dtype: "image",
+      shape: [1, 1, 3],
     },
     timestamp: { dtype: "float32", shape: [1] },
   },
@@ -77,21 +82,48 @@ const assets: readonly AssetDescriptor[] = [
     id: "info",
     mediaType: "application/json",
     metadata: { sizeBytes: infoBytes.byteLength.toString() },
-    role: "metadata",
+    role: "dataset-info",
+    selector: { kind: "whole-file" },
   },
   {
     id: "episodes",
     mediaType: "application/vnd.apache.parquet",
     metadata: { sizeBytes: "1" },
-    role: "episode-index",
+    role: "episode-metadata",
+    selector: {
+      coordinateSystem: "parquet-file-row",
+      end: 1,
+      kind: "row-interval",
+      start: 0,
+    },
   },
   {
     id: "data",
     mediaType: "application/vnd.apache.parquet",
-    metadata: { chunkIndex: "0", fileIndex: "0", sizeBytes: "1" },
-    role: "data",
+    metadata: { chunkIndex: "0", fileIndex: "0", sizeBytes: "2" },
+    role: "tabular-frame-data",
+    selector: {
+      coordinateSystem: "parquet-file-row",
+      end: 3,
+      kind: "row-interval",
+      start: 0,
+    },
   },
   {
+    featureName: "observation.images.embedded",
+    id: "images",
+    mediaType: "application/vnd.apache.parquet",
+    metadata: { sizeBytes: "2" },
+    role: "image-payload",
+    selector: {
+      coordinateSystem: "parquet-file-row",
+      end: 3,
+      kind: "row-interval",
+      start: 0,
+    },
+  },
+  {
+    featureName: "observation.images.test",
     id: "video",
     mediaType: "video/mp4",
     metadata: {
@@ -100,7 +132,12 @@ const assets: readonly AssetDescriptor[] = [
       sizeBytes: tinyMp4Bytes.byteLength.toString(),
       stream: "observation.images.test",
     },
-    role: "video",
+    role: "video-stream",
+    selector: {
+      fromTimestamp: 0,
+      kind: "video-timestamp-interval",
+      toTimestamp: 1,
+    },
   },
 ];
 
@@ -122,21 +159,36 @@ const episodeRow = {
 const dataRows = [
   {
     action: [1, 2],
+    episode_index: 0n,
     frame_index: 0n,
+    index: 0n,
+    "observation.images.embedded": Uint8Array.of(0xff, 0xd8, 0xff, 0xd9),
     "observation.state": [3, 4],
+    task_index: 0n,
     timestamp: 0,
+    success: false,
   },
   {
     action: [5, 6],
+    episode_index: 0n,
     frame_index: 1n,
+    index: 1n,
+    "observation.images.embedded": Uint8Array.of(0xff, 0xd8, 0xff, 0xd9),
     "observation.state": [7, 8],
+    task_index: 0n,
     timestamp: 0.033333335,
+    success: true,
   },
   {
     action: [9, 10],
+    episode_index: 0n,
     frame_index: 2n,
+    index: 2n,
+    "observation.images.embedded": Uint8Array.of(0xff, 0xd8, 0xff, 0xd9),
     "observation.state": [11, 12],
+    task_index: 0n,
     timestamp: 0.06666667,
+    success: true,
   },
 ];
 
@@ -172,8 +224,19 @@ function descriptor(assetId: string): ByteSourceDescriptor {
   };
 }
 
-const readParquetObjects = vi.fn(async (options: { columns?: string[] }) =>
-  options.columns ? dataRows : [episodeRow],
+const readParquetObjects = vi.fn(
+  async (options: {
+    columns?: string[];
+    file: { byteLength: number };
+    rowEnd?: number;
+    rowStart?: number;
+  }) => {
+    if (!options.columns && options.file.byteLength !== 2) return [episodeRow];
+    return dataRows.slice(
+      options.rowStart ?? 0,
+      options.rowEnd ?? dataRows.length,
+    );
+  },
 );
 
 defineEpisodeSessionContractTests({
@@ -187,19 +250,27 @@ describe("LeRobot format adapter", () => {
     expect(
       detectLeRobotSample({
         mediaType: "multimodal",
-        path: "/robot/run/meta/info.json",
+        mediaReference: {
+          kind: "lerobot-episode",
+          key: "source:17",
+          version: "1",
+        },
       }),
     ).toBe(true);
     expect(
       detectLeRobotSample({
         mediaType: "application/x-lerobot",
-        path: "/robot/run",
+        mediaReference: {
+          kind: "lerobot-episode",
+          key: "source:17",
+          version: "1",
+        },
       }),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       detectLeRobotSample({
         mediaType: "multimodal",
-        path: "/robot/run/data.parquet",
+        path: "/robot/run/meta/info.json",
       }),
     ).toBe(false);
   });
@@ -248,7 +319,31 @@ describe("LeRobot format adapter", () => {
         stream: "lerobot:action",
         window: session.manifest.timeRange,
       });
-      expect(readParquetObjects).toHaveBeenCalledTimes(2);
+      expect(readParquetObjects).toHaveBeenCalledTimes(3);
+    } finally {
+      session.dispose();
+    }
+  });
+
+  it("projects boolean scalar values as plottable zero/one samples", async () => {
+    const session = await createLeRobotFormatAdapter({
+      readParquetObjects,
+    }).open(source, io);
+    try {
+      await expect(
+        session.numericSeries?.readNumericSeries({
+          fields: ["success"],
+          stream: "lerobot:success",
+          window: session.manifest.timeRange,
+        }),
+      ).resolves.toMatchObject({
+        fields: [
+          {
+            path: "success",
+            values: Float64Array.from([0, 1, 1]),
+          },
+        ],
+      });
     } finally {
       session.dispose();
     }
@@ -280,44 +375,27 @@ describe("LeRobot format adapter", () => {
     session.dispose();
   });
 
-  it("activates a session on read and cancels the previous session", async () => {
-    let releaseFirstRead = (_rows: Record<string, unknown>[]): void => {
-      throw new Error("First data read did not start");
-    };
-    let dataReadCount = 0;
-    const controlledReadParquet = vi.fn(
-      async (options: { columns?: string[] }) => {
-        if (!options.columns) return [episodeRow];
-        dataReadCount += 1;
-        if (dataReadCount > 1) return dataRows;
-        return new Promise<Record<string, unknown>[]>((resolve) => {
-          releaseFirstRead = resolve;
-        });
-      },
-    );
-    const adapter = createLeRobotFormatAdapter({
-      readParquetObjects: controlledReadParquet,
-    });
+  it("keeps concurrent episode sessions independently readable", async () => {
+    const adapter = createLeRobotFormatAdapter({ readParquetObjects });
     const firstSession = await adapter.open(source, io);
     const secondSession = await adapter.open(source, io);
-    const firstRead = collectBatches(
-      firstSession.read({
-        streams: ["lerobot:action"],
-        window: firstSession.manifest.timeRange,
-      }),
-    );
-    const secondRead = collectBatches(
-      secondSession.read({
-        streams: ["lerobot:action"],
-        window: secondSession.manifest.timeRange,
-      }),
-    );
-
-    await expect(secondRead).resolves.toHaveLength(1);
-    releaseFirstRead(dataRows);
-    await expect(firstRead).rejects.toSatisfy(isEpisodeReadCancelledError);
-    firstSession.dispose();
-    secondSession.dispose();
+    try {
+      const request = (session: EpisodeSession) =>
+        collectBatches(
+          session.read({
+            streams: ["lerobot:action"],
+            window: session.manifest.timeRange,
+          }),
+        );
+      await expect(
+        Promise.all([request(firstSession), request(secondSession)]),
+      ).resolves.toEqual([expect.any(Array), expect.any(Array)]);
+      firstSession.dispose();
+      await expect(request(secondSession)).resolves.toHaveLength(1);
+    } finally {
+      firstSession.dispose();
+      secondSession.dispose();
+    }
   });
 
   it("demuxes an in-memory MP4 fixture into encoded video IR", async () => {
@@ -344,17 +422,94 @@ describe("LeRobot format adapter", () => {
       session.dispose();
     }
   });
+
+  it("reads embedded images and exact bounded raw rows", async () => {
+    const session = await createLeRobotFormatAdapter({
+      readParquetObjects,
+    }).open(source, io);
+    try {
+      const batches = await collectBatches(
+        session.read({
+          streams: ["lerobot:observation.images.embedded"],
+          window: { endNs: 0n, startNs: 0n },
+        }),
+      );
+      expect(batches[0].frames[0].output.visualization).toMatchObject({
+        kind: "encoded-image",
+        mimeType: "image/jpeg",
+      });
+      expect(readParquetObjects.mock.lastCall?.[0]).toMatchObject({
+        rowEnd: 1,
+        rowStart: 0,
+      });
+
+      await expect(
+        session.rawRecords?.readRawRecordAtCursor?.({
+          cursor: "row:1",
+          includeFullJson: true,
+          stream: "lerobot:rows",
+        }),
+      ).resolves.toMatchObject({
+        cursor: "row:1",
+        fullJson: expect.stringContaining('"frame_index": "1"'),
+        sequence: 1,
+        status: "ok",
+        timestampNs: 33_333_335n,
+      });
+      expect(readParquetObjects.mock.lastCall?.[0]).toMatchObject({
+        rowEnd: 2,
+        rowStart: 1,
+      });
+    } finally {
+      session.dispose();
+    }
+  });
+
+  it("previews one deterministic camera frame at a time", async () => {
+    const preview = await createLeRobotFormatAdapter({
+      readParquetObjects,
+    }).openPreview?.(source, io);
+    if (!preview) throw new Error("LeRobot preview session is unavailable");
+    try {
+      const first = await preview.read({
+        sourceName: "observation.images.test",
+      });
+      expect(first).toMatchObject({
+        frameTimeNs: 0n,
+        nextStartTimeNs: 500_000_000n,
+        status: "ready",
+        streamSourceName: "observation.images.test",
+        streamSourceNames: [
+          "observation.images.embedded",
+          "observation.images.test",
+        ],
+      });
+      await expect(
+        preview.read({
+          sourceName: "observation.images.test",
+          startTimeNs: first.nextStartTimeNs,
+        }),
+      ).resolves.toMatchObject({
+        frameTimeNs: 500_000_000n,
+        status: "ready",
+      });
+    } finally {
+      preview.dispose();
+    }
+  });
 });
 
 const realRoot = process.env.LEROBOT_DATASET_PATH;
 
 describe.runIf(Boolean(realRoot))("LeRobot real-file walking slice", () => {
-  it("reads Parquet signals and demuxes an AV1 MP4 GOP through the port", async () => {
+  it("reads the so-2crw Parquet slice and range-demuxes both H.264 cameras", async () => {
     if (!realRoot) throw new Error("LEROBOT_DATASET_PATH is required");
     const real = await realSource(realRoot);
-    let session: EpisodeSession | undefined;
+    const session = await createLeRobotFormatAdapter().open(
+      real.source,
+      real.io,
+    );
     try {
-      session = await createLeRobotFormatAdapter().open(real.source, real.io);
       expect(session.manifest.metadata?.["lerobot.codebaseVersion"]).toBe(
         "v3.0",
       );
@@ -364,8 +519,8 @@ describe.runIf(Boolean(realRoot))("LeRobot real-file walking slice", () => {
         expect.arrayContaining([
           "action",
           "observation.state",
-          "observation.images.overhead",
-          "observation.images.wrist",
+          "observation.images.camera1",
+          "observation.images.camera2",
         ]),
       );
 
@@ -375,33 +530,37 @@ describe.runIf(Boolean(realRoot))("LeRobot real-file walking slice", () => {
           window: { endNs: 100_000_000n, startNs: 0n },
         }),
       );
-      expect(signalBatches[0].frames).toHaveLength(3);
+      expect(signalBatches[0].frames.length).toBeGreaterThanOrEqual(3);
       expect(signalBatches[0].frames[0].output.scalars).toHaveLength(6);
 
       const videoBatches = await collectBatches(
         session.read({
           priority: "current",
-          streams: ["lerobot:observation.images.overhead"],
+          streams: ["lerobot:observation.images.camera1"],
           window: { endNs: 200_000_000n, startNs: 0n },
         }),
       );
       expect(videoBatches[0].frames.length).toBeGreaterThanOrEqual(6);
       expect(videoBatches[0].frames[0].output.visualization).toMatchObject({
-        codec: "av1",
+        codec: "h264",
         kind: "encoded-video",
         keyframe: true,
       });
       expect(
         videoBatches[0].frames[0].output.resourceHints?.sizeBytes,
       ).toBeGreaterThan(0);
+      const stats = session.stats?.();
+      if (!stats) throw new Error("LeRobot session stats are unavailable");
+      expect(stats.transferredBytes).toBeLessThan(real.camera1SizeBytes);
     } finally {
-      session?.dispose();
+      session.dispose();
       await real.close();
     }
   }, 30_000);
 });
 
 async function realSource(root: string): Promise<{
+  camera1SizeBytes: number;
   close(): Promise<void>;
   io: ByteResources;
   source: EpisodeSource;
@@ -410,11 +569,14 @@ async function realSource(root: string): Promise<{
     data: join(root, "data/chunk-000/file-000.parquet"),
     episodes: join(root, "meta/episodes/chunk-000/file-000.parquet"),
     info: join(root, "meta/info.json"),
-    overhead: join(
+    camera1: join(
       root,
-      "videos/observation.images.overhead/chunk-000/file-000.mp4",
+      "videos/observation.images.camera1/chunk-000/file-000.mp4",
     ),
-    wrist: join(root, "videos/observation.images.wrist/chunk-000/file-000.mp4"),
+    camera2: join(
+      root,
+      "videos/observation.images.camera2/chunk-000/file-000.mp4",
+    ),
   } as const;
   const entries = await Promise.all(
     Object.entries(paths).map(
@@ -431,13 +593,20 @@ async function realSource(root: string): Promise<{
       id: "info",
       mediaType: "application/json",
       metadata: { sizeBytes: requiredValue(sizeById, "info") },
-      role: "metadata",
+      role: "dataset-info",
+      selector: { kind: "whole-file" },
     },
     {
       id: "episodes",
       mediaType: "application/vnd.apache.parquet",
       metadata: { sizeBytes: requiredValue(sizeById, "episodes") },
-      role: "episode-index",
+      role: "episode-metadata",
+      selector: {
+        coordinateSystem: "parquet-file-row",
+        end: 1,
+        kind: "row-interval",
+        start: 0,
+      },
     },
     {
       id: "data",
@@ -447,17 +616,23 @@ async function realSource(root: string): Promise<{
         fileIndex: "0",
         sizeBytes: requiredValue(sizeById, "data"),
       },
-      role: "data",
+      role: "tabular-frame-data",
+      selector: {
+        coordinateSystem: "parquet-file-row",
+        end: 426,
+        kind: "row-interval",
+        start: 0,
+      },
     },
     videoAsset(
-      "overhead",
-      "observation.images.overhead",
-      requiredValue(sizeById, "overhead"),
+      "camera1",
+      "observation.images.camera1",
+      requiredValue(sizeById, "camera1"),
     ),
     videoAsset(
-      "wrist",
-      "observation.images.wrist",
-      requiredValue(sizeById, "wrist"),
+      "camera2",
+      "observation.images.camera2",
+      requiredValue(sizeById, "camera2"),
     ),
   ];
   const resolve = async (id: string): Promise<ByteSourceDescriptor> => {
@@ -467,6 +642,7 @@ async function realSource(root: string): Promise<{
     return { sizeBytes, sourceId: id, url: path };
   };
   return {
+    camera1SizeBytes: Number(requiredValue(sizeById, "camera1")),
     close: async () => {
       await Promise.all(
         [...filesById.values()].map(async (file) => (await file).close()),
@@ -514,6 +690,7 @@ function videoAsset(
   sizeBytes: string,
 ): AssetDescriptor {
   return {
+    featureName: stream,
     id,
     mediaType: "video/mp4",
     metadata: {
@@ -522,6 +699,11 @@ function videoAsset(
       sizeBytes,
       stream,
     },
-    role: "video",
+    role: "video-stream",
+    selector: {
+      fromTimestamp: 0,
+      kind: "video-timestamp-interval",
+      toTimestamp: 14.2,
+    },
   };
 }

--- a/app/packages/multimodal/src/adapters/lerobot/format-adapter.test.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/format-adapter.test.ts
@@ -293,6 +293,66 @@ describe("LeRobot format adapter", () => {
     ).toBe(false);
   });
 
+  it("publishes canonical catalog and recording facts even with a stale hint", async () => {
+    const staleSource: EpisodeSource = {
+      ...source,
+      manifestHint: {
+        episodeId: "stale",
+        streams: [],
+        timeDomain: { id: "stale", kind: "duration" },
+        timeRange: { endNs: 0n, startNs: 0n },
+      },
+    };
+    const session = await createLeRobotFormatAdapter({
+      readParquetObjects,
+    }).open(staleSource, io);
+    try {
+      const byName = new Map(
+        session.manifest.streams.map((stream) => [stream.sourceName, stream]),
+      );
+      expect(byName.get("observation.state")?.metadata).toMatchObject({
+        "stream.category": "observations",
+        "stream.count_noun": "samples",
+        "stream.inspectable": "true",
+      });
+      expect(byName.get("action")?.metadata).toMatchObject({
+        "stream.category": "actions",
+        "stream.inspectable": "true",
+      });
+      expect(byName.get("observation.images.embedded")).toMatchObject({
+        count: 3,
+        kind: "image",
+        metadata: {
+          "stream.category": "observations",
+          "stream.count_noun": "frames",
+          "stream.inspectable": "false",
+        },
+      });
+      expect(byName.get("observation.images.test")).toMatchObject({
+        kind: "video",
+        metadata: { "stream.inspectable": "false" },
+      });
+      expect(byName.get("observation.images.test")).not.toHaveProperty("count");
+      expect(session.manifest.recordingFacts).toMatchObject({
+        durationNs: "1000000000",
+        format: "lerobot",
+        lerobot: {
+          codebaseVersion: "v3.0",
+          episodeIndex: "0",
+          featureCount: 6,
+          fps: 30,
+          logicalRowCount: 3,
+          mediaFeatureCount: 2,
+          robotType: "test-arm",
+          videoCodecs: ["h264"],
+        },
+        messageCount: "3",
+      });
+    } finally {
+      session.dispose();
+    }
+  });
+
   it("exposes named vector values through the numeric capability", async () => {
     readParquetObjects.mockClear();
     const session = await createLeRobotFormatAdapter({

--- a/app/packages/multimodal/src/adapters/lerobot/format-adapter.test.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/format-adapter.test.ts
@@ -26,6 +26,8 @@ const info = {
       names: ["joint_a", "joint_b"],
       shape: [2],
     },
+    "action.gripper": { dtype: "float32", shape: [1] },
+    language_instruction: { dtype: "string", shape: [1] },
     "observation.state": {
       dtype: "float32",
       names: ["joint_a", "joint_b"],
@@ -179,9 +181,11 @@ const episodeRow = {
 const dataRows = [
   {
     action: [1, 2],
+    "action.gripper": [0.1],
     episode_index: 0n,
     frame_index: 0n,
     index: 0n,
+    language_instruction: "reach for the cube",
     "observation.images.embedded": Uint8Array.of(0xff, 0xd8, 0xff, 0xd9),
     "observation.state": [3, 4],
     task_index: 0n,
@@ -190,9 +194,11 @@ const dataRows = [
   },
   {
     action: [5, 6],
+    "action.gripper": [0.2],
     episode_index: 0n,
     frame_index: 1n,
     index: 1n,
+    language_instruction: "reach for the cube",
     "observation.images.embedded": Uint8Array.of(0xff, 0xd8, 0xff, 0xd9),
     "observation.state": [7, 8],
     task_index: 0n,
@@ -201,9 +207,11 @@ const dataRows = [
   },
   {
     action: [9, 10],
+    "action.gripper": [0.3],
     episode_index: 0n,
     frame_index: 2n,
     index: 2n,
+    language_instruction: "reach for the cube",
     "observation.images.embedded": Uint8Array.of(0xff, 0xd8, 0xff, 0xd9),
     "observation.state": [11, 12],
     task_index: 0n,
@@ -319,6 +327,18 @@ describe("LeRobot format adapter", () => {
         "stream.category": "actions",
         "stream.inspectable": "true",
       });
+      expect(byName.get("action.gripper")?.metadata).toMatchObject({
+        "stream.category": "actions",
+        "stream.inspectable": "true",
+      });
+      expect(byName.get("language_instruction")?.metadata).toMatchObject({
+        "stream.category": "instructions",
+        "stream.inspectable": "false",
+      });
+      expect(byName.get("success")?.metadata).toMatchObject({
+        "stream.category": "custom",
+        "stream.inspectable": "true",
+      });
       expect(byName.get("observation.images.embedded")).toMatchObject({
         count: 3,
         kind: "image",
@@ -334,20 +354,27 @@ describe("LeRobot format adapter", () => {
       });
       expect(byName.get("observation.images.test")).not.toHaveProperty("count");
       expect(session.manifest.recordingFacts).toMatchObject({
+        applicationSupport: {
+          inspectableStreamCount: 4,
+          renderableStreamCount: 2,
+          unavailableStreamCount: 1,
+        },
         durationNs: "1000000000",
         format: "lerobot",
         lerobot: {
           codebaseVersion: "v3.0",
           episodeIndex: "0",
-          featureCount: 6,
+          featureCount: 8,
           fps: 30,
           logicalRowCount: 3,
           mediaFeatureCount: 2,
           robotType: "test-arm",
           videoCodecs: ["h264"],
         },
-        messageCount: "3",
       });
+      expect(session.manifest.recordingFacts).not.toHaveProperty(
+        "messageCount",
+      );
     } finally {
       session.dispose();
     }

--- a/app/packages/multimodal/src/adapters/lerobot/format-adapter.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/format-adapter.ts
@@ -30,6 +30,7 @@ import {
   type TimeWindow,
 } from "../../ir";
 import {
+  EpisodeExactCursorError,
   EpisodeReadCancelledError,
   type AssetDescriptor,
   type ByteResources,
@@ -47,6 +48,10 @@ import {
   type ReadRequest,
   type SynchronizedPlaybackBatchReadRequest,
   type SynchronizedPlaybackReadOptions,
+  type StateActionCapability,
+  type StateActionFeatureSchema,
+  type StateActionRow,
+  type StateActionSchema,
   type SynchronizedPlaybackReadRequest,
   type SourceStats,
 } from "../../ports";
@@ -69,8 +74,11 @@ const INFO_ROLE = "dataset-info";
 const EPISODE_METADATA_ROLE = "episode-metadata";
 const DATA_ROLE = "tabular-frame-data";
 const IMAGE_ROLE = "image-payload";
+const TASKS_ROLE = "tasks-metadata";
 const VIDEO_ROLE = "video-stream";
 const RAW_STREAM_ID = "lerobot:rows";
+const STATE_FEATURE_NAME = "observation.state";
+const ACTION_FEATURE_NAME = "action";
 const NS_PER_SECOND = 1_000_000_000;
 const MP4_INDEX_CHUNK_BYTES = 1024 * 1024;
 const MAX_VIDEO_SPAN_CACHE_BYTES = 64 * 1024 * 1024;
@@ -87,9 +95,23 @@ type ParquetReader = (
   options: ParquetReaderOptions,
 ) => Promise<Record<string, unknown>[]>;
 
+/** Byte ceilings that switch the state/action slab to bounded block reads. */
+export interface StateActionSlabLimits {
+  /** Rows-per-block read budget once the whole slab exceeds the ceiling. */
+  readonly blockBytes: number;
+  /** Largest estimated slab decoded as one physical read. */
+  readonly maxSingleSlabBytes: number;
+}
+
+const DEFAULT_STATE_ACTION_SLAB_LIMITS: StateActionSlabLimits = {
+  blockBytes: 8 * 1024 * 1024,
+  maxSingleSlabBytes: 32 * 1024 * 1024,
+};
+
 /** Test seams for the browser-native LeRobot readers. */
 export interface CreateLeRobotFormatAdapterOptions {
   readonly readParquetObjects?: ParquetReader;
+  readonly stateActionSlabLimits?: StateActionSlabLimits;
 }
 
 interface LeRobotFeature {
@@ -187,6 +209,8 @@ export function createLeRobotFormatAdapter(
   options: CreateLeRobotFormatAdapterOptions = {},
 ): FormatAdapter {
   const readObjects = options.readParquetObjects ?? parquetReadObjects;
+  const stateActionSlabLimits =
+    options.stateActionSlabLimits ?? DEFAULT_STATE_ACTION_SLAB_LIMITS;
   const open = async (
     source: EpisodeSource,
     io: ByteResources,
@@ -229,6 +253,7 @@ export function createLeRobotFormatAdapter(
       io,
       readObjects,
       source,
+      stateActionSlabLimits,
     });
   };
 
@@ -359,11 +384,18 @@ class LeRobotEpisodeSession implements EpisodeSession {
   readonly playback: PlaybackReadCapability;
   readonly rawRecords: RawRecordCapability;
   readonly scalarFeatures: ReadonlyMap<string, LeRobotFeature>;
+  readonly stateAction?: StateActionCapability;
   readonly videoBindings: ReadonlyMap<string, VideoBinding>;
   private readonly rowCache = new Map<
     string,
     Promise<readonly Record<string, unknown>[]>
   >();
+  private readonly stateActionBlocks = new Map<
+    number,
+    Promise<readonly Record<string, unknown>[]>
+  >();
+  private stateActionTasks: Promise<ReadonlyMap<number, string> | null> | null =
+    null;
   private readonly videoIndexCache = new Map<string, Promise<VideoIndex>>();
   private readonly videoSpanCache = new Map<string, VideoSpanCacheEntry>();
   private decodedFrames = 0;
@@ -382,6 +414,7 @@ class LeRobotEpisodeSession implements EpisodeSession {
       readonly io: ByteResources;
       readonly readObjects: ParquetReader;
       readonly source: EpisodeSource;
+      readonly stateActionSlabLimits: StateActionSlabLimits;
     },
   ) {
     this.info = state.info;
@@ -462,6 +495,7 @@ class LeRobotEpisodeSession implements EpisodeSession {
       readNumericSeries: async (request) => this.readNumericSeries(request),
     };
     this.rawRecords = this.createRawRecordCapability();
+    this.stateAction = this.createStateActionCapability();
     this.playback = this.createPlaybackCapability();
   }
 
@@ -483,6 +517,8 @@ class LeRobotEpisodeSession implements EpisodeSession {
     this.disposed = true;
     this.generation += 1;
     this.rowCache.clear();
+    this.stateActionBlocks.clear();
+    this.stateActionTasks = null;
     this.videoIndexCache.clear();
     this.videoSpanCache.clear();
   }
@@ -1144,6 +1180,192 @@ class LeRobotEpisodeSession implements EpisodeSession {
         return result;
       },
     };
+  }
+
+  private createStateActionCapability(): StateActionCapability | undefined {
+    const stateFeature = this.scalarFeatures.get(
+      streamIdForFeature(STATE_FEATURE_NAME),
+    );
+    const actionFeature = this.scalarFeatures.get(
+      streamIdForFeature(ACTION_FEATURE_NAME),
+    );
+    if (!stateFeature && !actionFeature) return undefined;
+    const rows = this.state.episodeRows.rows;
+    const config: StateActionReadConfig = {
+      action: actionFeature,
+      blockRows: stateActionBlockRowCount(
+        rows.length,
+        [stateFeature, actionFeature].filter(
+          (feature): feature is LeRobotFeature => feature !== undefined,
+        ),
+        this.state.stateActionSlabLimits,
+      ),
+      columns: [
+        "timestamp",
+        "frame_index",
+        "task_index",
+        ...(stateFeature ? [STATE_FEATURE_NAME] : []),
+        ...(actionFeature ? [ACTION_FEATURE_NAME] : []),
+      ],
+      state: stateFeature,
+    };
+    const schema: StateActionSchema = {
+      ...(actionFeature
+        ? {
+            action: stateActionFeatureSchema(
+              ACTION_FEATURE_NAME,
+              actionFeature,
+            ),
+          }
+        : {}),
+      rowCount: rows.length,
+      ...(stateFeature
+        ? { state: stateActionFeatureSchema(STATE_FEATURE_NAME, stateFeature) }
+        : {}),
+    };
+    return {
+      schema,
+      readAtCursor: async (request) => {
+        this.ensureOpen();
+        throwIfAborted(request.signal);
+        return this.readStateActionRow(
+          parseStateActionCursor(request.cursor, rows.length),
+          config,
+          request.signal,
+        );
+      },
+      readAtTime: async (request) => {
+        this.ensureOpen();
+        throwIfAborted(request.signal);
+        if (request.timestampNs > this.manifest.timeRange.endNs) return null;
+        const offset = rowAtOrBefore(rows, request.timestampNs);
+        return offset === null
+          ? null
+          : this.readStateActionRow(offset, config, request.signal);
+      },
+      readIndexWindow: async (request) => {
+        this.ensureOpen();
+        throwIfAborted(request.signal);
+        const selected =
+          request.anchorCursor !== undefined
+            ? parseStateActionCursor(request.anchorCursor, rows.length)
+            : (rowAtOrBefore(rows, request.anchorTimestampNs) ?? 0);
+        const start = Math.max(0, selected - Math.max(0, request.before));
+        const end = Math.min(
+          rows.length,
+          selected + Math.max(0, request.after) + 1,
+        );
+        return {
+          entries: rows.slice(start, end).map((row) => ({
+            cursor: rawCursor(row.rowOffset),
+            timestampNs: row.localTimeNs,
+          })),
+          hasNext: end < rows.length,
+          hasPrevious: start > 0,
+          selectedCursor: rawCursor(selected),
+        };
+      },
+    };
+  }
+
+  private async readStateActionRow(
+    offset: number,
+    config: StateActionReadConfig,
+    signal?: AbortSignal,
+  ): Promise<StateActionRow> {
+    const blockIndex = Math.floor(offset / config.blockRows);
+    const [block, taskLabels] = await Promise.all([
+      waitForSharedRead(this.stateActionBlock(blockIndex, config), signal),
+      waitForSharedRead(this.stateActionTaskLabels(), signal),
+    ]);
+    throwIfAborted(signal);
+    this.ensureOpen();
+    const timeline = this.state.episodeRows.rows[offset];
+    const row = block[offset - blockIndex * config.blockRows];
+    if (!row || !timeline) {
+      throw new Error("LeRobot state/action row is unavailable");
+    }
+    const state = config.state
+      ? stateActionVector(STATE_FEATURE_NAME, config.state, row)
+      : undefined;
+    const action = config.action
+      ? stateActionVector(ACTION_FEATURE_NAME, config.action, row)
+      : undefined;
+    const taskIndex = optionalInteger(row.task_index);
+    const label =
+      taskIndex !== null
+        ? (taskLabels?.get(taskIndex) ??
+          singleEpisodeTask(this.state.episodeRows.episode))
+        : undefined;
+    return {
+      ...(action?.values ? { action: action.values } : {}),
+      cursor: rawCursor(offset),
+      ...(state?.error || action?.error
+        ? {
+            featureErrors: {
+              ...(action?.error ? { action: action.error } : {}),
+              ...(state?.error ? { state: state.error } : {}),
+            },
+          }
+        : {}),
+      frameIndex: timeline.frameIndex,
+      ...(state?.values ? { state: state.values } : {}),
+      ...(taskIndex !== null
+        ? {
+            task: {
+              index: taskIndex,
+              ...(label !== undefined ? { label } : {}),
+            },
+          }
+        : {}),
+      timestampNs: timeline.localTimeNs,
+    };
+  }
+
+  private stateActionBlock(blockIndex: number, config: StateActionReadConfig) {
+    let cached = this.stateActionBlocks.get(blockIndex);
+    if (!cached) {
+      const rowCount = this.state.episodeRows.rows.length;
+      const start = blockIndex * config.blockRows;
+      // The shared block fill is deliberately unbound from caller signals so
+      // an aborted trigger cannot poison the session-lifetime cache.
+      cached = readSelectedParquetRows(
+        this.state.source,
+        this.state.io,
+        this.state.episodeRows.dataAsset,
+        this.state.readObjects,
+        [...config.columns],
+        undefined,
+        start,
+        Math.min(rowCount, start + config.blockRows),
+      );
+      this.stateActionBlocks.set(blockIndex, cached);
+      void cached.catch(() => {
+        if (this.stateActionBlocks.get(blockIndex) === cached) {
+          this.stateActionBlocks.delete(blockIndex);
+        }
+      });
+    }
+    return cached;
+  }
+
+  private stateActionTaskLabels() {
+    if (!this.stateActionTasks) {
+      const asset = this.state.assets.find(
+        (candidate) => candidate.role === TASKS_ROLE,
+      );
+      // Task labels are a fallback ladder rung; a missing or unreadable
+      // tasks asset must never block state/action inspection.
+      this.stateActionTasks = asset
+        ? readTaskLabels(
+            this.state.source,
+            this.state.io,
+            asset,
+            this.state.readObjects,
+          ).catch(() => null)
+        : Promise.resolve(null);
+    }
+    return this.stateActionTasks;
   }
 
   private ensureReadable(
@@ -2141,6 +2363,125 @@ function parseRawCursor(cursor: string, rowCount: number) {
     throw new Error("Invalid LeRobot raw-record cursor");
   }
   return value;
+}
+
+interface StateActionReadConfig {
+  readonly action?: LeRobotFeature;
+  readonly blockRows: number;
+  readonly columns: readonly string[];
+  readonly state?: LeRobotFeature;
+}
+
+function stateActionFeatureSchema(
+  featureName: string,
+  feature: LeRobotFeature,
+): StateActionFeatureSchema {
+  const count = Math.max(1, numericElementCount(feature.shape));
+  return {
+    dimensions: Array.from({ length: count }, (_, index) => {
+      const name = feature.names?.[index];
+      return { index, ...(typeof name === "string" ? { name } : {}) };
+    }),
+    dtype: feature.dtype,
+    featureName,
+    shape: feature.shape ?? [],
+  };
+}
+
+function stateActionVector(
+  featureName: string,
+  feature: LeRobotFeature,
+  row: Record<string, unknown>,
+): { readonly error?: string; readonly values?: readonly unknown[] } {
+  if (!(featureName in row) || row[featureName] === undefined) {
+    return { error: `'${featureName}' column is missing from this row` };
+  }
+  const values = flattenStateActionSource(row[featureName]);
+  const expected = Math.max(1, numericElementCount(feature.shape));
+  if (values.length === expected) return { values };
+  return {
+    error: `'${featureName}' row has ${values.length} values but declares shape [${(
+      feature.shape ?? []
+    ).join(",")}]`,
+    values,
+  };
+}
+
+function flattenStateActionSource(value: unknown): readonly unknown[] {
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => flattenStateActionSource(entry));
+  }
+  if (ArrayBuffer.isView(value) && !(value instanceof DataView)) {
+    return [...(value as unknown as Iterable<unknown>)];
+  }
+  return [value];
+}
+
+function stateActionBlockRowCount(
+  rowCount: number,
+  features: readonly LeRobotFeature[],
+  limits: StateActionSlabLimits,
+): number {
+  const rowBytes = features.reduce(
+    (total, feature) =>
+      total +
+      Math.max(1, numericElementCount(feature.shape)) *
+        stateActionDtypeBytes(feature.dtype),
+    24,
+  );
+  if (rowBytes * rowCount <= limits.maxSingleSlabBytes) {
+    return Math.max(1, rowCount);
+  }
+  return Math.max(1, Math.floor(limits.blockBytes / rowBytes));
+}
+
+function stateActionDtypeBytes(dtype: string): number {
+  if (/64/.test(dtype)) return 8;
+  if (/32/.test(dtype)) return 4;
+  if (/16/.test(dtype)) return 2;
+  if (/^(?:bool|int8|uint8)/.test(dtype)) return 1;
+  return 8;
+}
+
+function parseStateActionCursor(cursor: string, rowCount: number): number {
+  try {
+    return parseRawCursor(cursor, rowCount);
+  } catch {
+    throw new EpisodeExactCursorError(
+      "Unknown LeRobot state/action row cursor for this episode",
+    );
+  }
+}
+
+function singleEpisodeTask(
+  episode: Record<string, unknown>,
+): string | undefined {
+  const tasks = episode.tasks;
+  return Array.isArray(tasks) &&
+    tasks.length === 1 &&
+    typeof tasks[0] === "string"
+    ? tasks[0]
+    : undefined;
+}
+
+async function readTaskLabels(
+  source: EpisodeSource,
+  io: ByteResources,
+  asset: AssetDescriptor,
+  readObjects: ParquetReader,
+): Promise<ReadonlyMap<number, string>> {
+  const rows = await readObjects({
+    columns: ["task_index", "task"],
+    file: asyncBufferForSource(asset, source, io),
+  });
+  const labels = new Map<number, string>();
+  for (const row of rows) {
+    const index = optionalInteger(row.task_index);
+    if (index !== null && typeof row.task === "string") {
+      labels.set(index, row.task);
+    }
+  }
+  return labels;
 }
 
 function rowAtOrBefore(rows: readonly TimelineRow[], timestampNs: bigint) {

--- a/app/packages/multimodal/src/adapters/lerobot/format-adapter.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/format-adapter.ts
@@ -106,6 +106,19 @@ interface LeRobotInfo {
   readonly robot_type?: string;
 }
 
+type LeRobotRawStreamBinding = {
+  readonly schemaName: string;
+  readonly sourceName: string;
+  readonly streamId: string;
+} & (
+  | { readonly kind: "row" }
+  | {
+      readonly feature: LeRobotFeature;
+      readonly featureName: string;
+      readonly kind: "feature";
+    }
+);
+
 interface TimelineRow {
   readonly frameIndex: number;
   readonly localTimeNs: bigint;
@@ -991,8 +1004,37 @@ class LeRobotEpisodeSession implements EpisodeSession {
 
   private createRawRecordCapability(): RawRecordCapability {
     const rows = this.state.episodeRows.rows;
+    const streamBindings: readonly LeRobotRawStreamBinding[] = [
+      {
+        kind: "row",
+        schemaName: "LeRobotDataset v3 row",
+        sourceName: "Episode rows",
+        streamId: RAW_STREAM_ID,
+      },
+      ...[...this.scalarFeatures.entries()].map(([streamId, feature]) => {
+        const featureName = featureNameForStream(streamId);
+        return {
+          feature,
+          featureName,
+          kind: "feature" as const,
+          schemaName: `${feature.dtype}${shapeSuffix(feature.shape)}`,
+          sourceName: featureName,
+          streamId,
+        };
+      }),
+    ];
+    const requireStream = (stream: string) => {
+      const binding = streamBindings.find(
+        (candidate) => candidate.streamId === stream,
+      );
+      if (!binding) {
+        throw new Error(`Unknown LeRobot raw-record stream '${stream}'`);
+      }
+      return binding;
+    };
     const readAt = async (
       rowOffset: number,
+      binding: LeRobotRawStreamBinding,
       options: {
         readonly includeFullJson?: boolean;
         readonly prune?: RawRecordPruneBudgets;
@@ -1004,31 +1046,43 @@ class LeRobotEpisodeSession implements EpisodeSession {
         this.state.io,
         this.state.episodeRows.dataAsset,
         this.state.readObjects,
-        undefined,
+        binding.kind === "feature"
+          ? ["timestamp", "frame_index", binding.featureName]
+          : undefined,
         options.signal,
         rowOffset,
         rowOffset + 1,
       );
       const row = selected[0];
       const timeline = rows[rowOffset];
-      if (!row || !timeline) return emptyRawRecord(this.manifest.timeRange);
-      const pruned = pruneRawRecord(row, options.prune);
+      if (!row || !timeline) {
+        return emptyRawRecord(this.manifest.timeRange, binding);
+      }
+      const record =
+        binding.kind === "feature"
+          ? scalarRawRecord(
+              binding.featureName,
+              binding.feature,
+              row[binding.featureName],
+            )
+          : row;
+      const pruned = pruneRawRecord(record, options.prune);
       const next = rows[rowOffset + 1]?.localTimeNs;
       return {
         cursor: rawCursor(rowOffset),
         encoding: "parquet",
         ...(options.includeFullJson
-          ? { fullJson: boundedJson(row, options.prune) }
+          ? { fullJson: boundedJson(record, options.prune) }
           : {}),
         root: pruned.root,
-        schemaName: "LeRobotDataset v3 row",
+        schemaName: binding.schemaName,
         sequence: timeline.frameIndex,
-        sourceName: "Episode rows",
+        sourceName: binding.sourceName,
         sourceTimestamps: {
           lerobot: secondsToNs(timeline.sourceTimeSeconds),
         },
         status: "ok",
-        streamId: RAW_STREAM_ID,
+        streamId: binding.streamId,
         timestampNs: timeline.localTimeNs,
         truncated: pruned.truncated,
         validFromNs: timeline.localTimeNs,
@@ -1042,30 +1096,32 @@ class LeRobotEpisodeSession implements EpisodeSession {
     return {
       listRawRecordStreams: async ({ signal } = {}) => {
         throwIfAborted(signal);
-        return [
-          {
-            encoding: "parquet",
-            sampleCount: rows.length,
-            schemaName: "LeRobotDataset v3 row",
-            sourceName: "Episode rows",
-            streamId: RAW_STREAM_ID,
-            supportsExactBrowsing: true,
-          },
-        ];
+        return streamBindings.map((binding) => ({
+          encoding: "parquet",
+          sampleCount: rows.length,
+          schemaName: binding.schemaName,
+          sourceName: binding.sourceName,
+          streamId: binding.streamId,
+          supportsExactBrowsing: true,
+        }));
       },
       readRawRecord: async (request) => {
-        requireRawStream(request.stream);
+        const binding = requireStream(request.stream);
         const offset = rowAtOrBefore(rows, request.timestampNs);
         return offset === null
-          ? emptyRawRecord(this.manifest.timeRange)
-          : readAt(offset, request);
+          ? emptyRawRecord(this.manifest.timeRange, binding)
+          : readAt(offset, binding, request);
       },
       readRawRecordAtCursor: async (request) => {
-        requireRawStream(request.stream);
-        return readAt(parseRawCursor(request.cursor, rows.length), request);
+        const binding = requireStream(request.stream);
+        return readAt(
+          parseRawCursor(request.cursor, rows.length),
+          binding,
+          request,
+        );
       },
       readRawRecordIndexWindow: async (request) => {
-        requireRawStream(request.stream);
+        requireStream(request.stream);
         throwIfAborted(request.signal);
         const selected =
           request.anchorCursor !== undefined
@@ -2087,12 +2143,6 @@ function parseRawCursor(cursor: string, rowCount: number) {
   return value;
 }
 
-function requireRawStream(stream: string) {
-  if (stream !== RAW_STREAM_ID) {
-    throw new Error(`Unknown LeRobot raw-record stream '${stream}'`);
-  }
-}
-
 function rowAtOrBefore(rows: readonly TimelineRow[], timestampNs: bigint) {
   if (!rows.length) return null;
   if (timestampNs < rows[0].localTimeNs) return null;
@@ -2106,16 +2156,33 @@ function rowAtOrBefore(rows: readonly TimelineRow[], timestampNs: bigint) {
   return Math.max(0, low - 1);
 }
 
-function emptyRawRecord(timeRange: TimeWindow): RawRecordResult {
+function emptyRawRecord(
+  timeRange: TimeWindow,
+  binding: LeRobotRawStreamBinding,
+): RawRecordResult {
   return {
     encoding: "parquet",
-    schemaName: "LeRobotDataset v3 row",
-    sourceName: "Episode rows",
+    schemaName: binding.schemaName,
+    sourceName: binding.sourceName,
     status: "empty",
-    streamId: RAW_STREAM_ID,
+    streamId: binding.streamId,
     validFromNs: timeRange.startNs,
     validUntilNs: timeRange.endNs,
   };
+}
+
+function scalarRawRecord(
+  featureName: string,
+  feature: LeRobotFeature,
+  value: unknown,
+): Record<string, unknown> {
+  const values = Array.isArray(value) ? value.flat(Infinity) : [value];
+  return Object.fromEntries(
+    scalarFieldNames(featureName, feature).map((field, index) => [
+      field,
+      values[index],
+    ]),
+  );
 }
 
 interface PruneState {

--- a/app/packages/multimodal/src/adapters/lerobot/format-adapter.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/format-adapter.ts
@@ -17,6 +17,7 @@ import {
   type DecodedOutput,
   type EncodedVideoVisualization,
   type EpisodeManifest,
+  type EpisodePreviewNativeVideo,
   type EpisodePosterFrame,
   type EpisodePreviewReadResult,
   type RawObjectNode,
@@ -283,6 +284,10 @@ class LeRobotEpisodePreviewSession implements EpisodePreviewSession {
       frames = batch.frames;
       break;
     }
+    const nativeVideo = await this.session.resolveNativePreviewVideo(
+      selected.id,
+      options.signal,
+    );
     this.ensureOpen();
     throwIfAborted(options.signal);
     const initialized = this.initializedStreams.has(selected.id);
@@ -304,6 +309,7 @@ class LeRobotEpisodePreviewSession implements EpisodePreviewSession {
       bootstrapTimeRange: this.session.manifest.timeRange,
       frame,
       frameTimeNs: decoded?.timestampNs,
+      ...(nativeVideo ? { nativeVideo } : {}),
       nextStartTimeNs:
         nextStartTimeNs !== undefined &&
         nextStartTimeNs <= selected.timeRange.endNs
@@ -493,6 +499,23 @@ class LeRobotEpisodeSession implements EpisodeSession {
       readRequests: this.readRequests,
       returnedBatches: this.returnedBatches,
       transferredBytes: this.transferredBytes,
+    };
+  }
+
+  async resolveNativePreviewVideo(
+    streamId: string,
+    signal?: AbortSignal,
+  ): Promise<EpisodePreviewNativeVideo | undefined> {
+    const binding = this.videoBindings.get(streamId);
+    if (!binding) return undefined;
+    const source = await this.state.source.assets.resolve(binding.asset.id, {
+      signal,
+    });
+    throwIfAborted(signal);
+    return {
+      endTimeSeconds: binding.toSeconds,
+      source,
+      startTimeSeconds: binding.fromSeconds,
     };
   }
 

--- a/app/packages/multimodal/src/adapters/lerobot/format-adapter.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/format-adapter.ts
@@ -76,8 +76,10 @@ import {
 } from "../../ports/playback-policy";
 import { throwIfAborted } from "../../utils/cancellation";
 import {
-  maxBigInt as maxOfBigInts,
-  minBigInt as minOfBigInts,
+  maxBigInt,
+  maxBigIntPair,
+  minBigInt,
+  minBigIntPair,
 } from "../../utils/bigint";
 import { nsDeltaToSeconds } from "../../utils/nanoseconds";
 
@@ -329,7 +331,7 @@ class LeRobotEpisodePreviewSession implements EpisodePreviewSession {
       1 / (selected.approxRateHz ?? this.session.info.fps),
     );
     const readDurationNs = request.decodeLookaheadNs
-      ? maxOfBigInts([
+      ? maxBigInt([
           frameDurationNs,
           request.decodeLookaheadNs + frameDurationNs,
         ])
@@ -341,7 +343,10 @@ class LeRobotEpisodePreviewSession implements EpisodePreviewSession {
         signal: options.signal,
         streams: [selected.id],
         window: {
-          endNs: minBigInt(selected.timeRange.endNs, startNs + readDurationNs),
+          endNs: minBigIntPair(
+            selected.timeRange.endNs,
+            startNs + readDurationNs,
+          ),
           startNs,
         },
       })) {
@@ -824,8 +829,8 @@ class LeRobotEpisodeSession implements EpisodeSession {
             signal: options.signal,
             streams: [stream],
             window: {
-              endNs: maxOfBigInts(windows.map((window) => window.endNs)),
-              startNs: minOfBigInts(windows.map((window) => window.startNs)),
+              endNs: maxBigInt(windows.map((window) => window.endNs)),
+              startNs: minBigInt(windows.map((window) => window.startNs)),
             },
           })) {
             streamBatches.push(batch);
@@ -2345,7 +2350,10 @@ function episodeTimeRange(
       ? Math.max(end, selector.toTimestamp - selector.fromTimestamp)
       : end;
   }, 0);
-  return { endNs: maxBigInt(rowEnd, secondsToNs(videoEnd)), startNs: 0n };
+  return {
+    endNs: maxBigIntPair(rowEnd, secondsToNs(videoEnd)),
+    startNs: 0n,
+  };
 }
 
 function requireSingleRole(
@@ -2723,14 +2731,6 @@ function exactArrayBuffer(bytes: Uint8Array): ArrayBuffer {
   ) as ArrayBuffer;
 }
 
-function maxBigInt(left: bigint, right: bigint) {
-  return left > right ? left : right;
-}
-
-function minBigInt(left: bigint, right: bigint) {
-  return left < right ? left : right;
-}
-
 function rawCursor(rowOffset: number) {
   return `row:${rowOffset}`;
 }
@@ -2857,8 +2857,11 @@ function createStateActionAggregator(
   const declaredBound = (index: number) => {
     const low = declared?.min?.[index];
     const high = declared?.max?.[index];
-    return Number.isFinite(low) && Number.isFinite(high)
-      ? { high: high as number, low: low as number }
+    return typeof low === "number" &&
+      Number.isFinite(low) &&
+      typeof high === "number" &&
+      Number.isFinite(high)
+      ? { high, low }
       : null;
   };
   const bounds = Array.from({ length: dimensionCount }, (_, index) =>

--- a/app/packages/multimodal/src/adapters/lerobot/format-adapter.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/format-adapter.ts
@@ -2411,13 +2411,19 @@ function stateActionFeatureSchema(
   feature: LeRobotFeature,
 ): StateActionFeatureSchema {
   const count = Math.max(1, numericElementCount(feature.shape));
+  const fieldPaths = scalarFieldNames(featureName, feature);
   return {
     dimensions: Array.from({ length: count }, (_, index) => {
       const name = feature.names?.[index];
-      return { index, ...(typeof name === "string" ? { name } : {}) };
+      return {
+        index,
+        ...(typeof name === "string" ? { name } : {}),
+        ...(fieldPaths[index] ? { numericFieldPath: fieldPaths[index] } : {}),
+      };
     }),
     dtype: feature.dtype,
     featureName,
+    numericStreamId: streamIdForFeature(featureName),
     shape: feature.shape ?? [],
   };
 }

--- a/app/packages/multimodal/src/adapters/lerobot/format-adapter.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/format-adapter.ts
@@ -1,13 +1,29 @@
 import { parquetReadObjects, type AsyncBuffer } from "hyparquet";
-import { createFile, MP4BoxBuffer, type Sample, type Track } from "mp4box";
+import {
+  createFile,
+  MP4BoxBuffer,
+  type ISOFile,
+  type Sample,
+  type Track,
+} from "mp4box";
 
 import {
+  SCENE_SOURCE_METADATA,
+  SCENE_SOURCE_TYPE,
   STREAM_KIND,
+  STREAM_METADATA,
   VISUALIZATION_KIND,
   type DecodedFrame,
   type DecodedOutput,
   type EncodedVideoVisualization,
   type EpisodeManifest,
+  type EpisodePosterFrame,
+  type EpisodePreviewReadResult,
+  type RawObjectNode,
+  type RawRecordIndexWindow,
+  type RawRecordPruneBudgets,
+  type RawRecordResult,
+  type RawValueNode,
   type StreamDescriptor,
   type TimeWindow,
 } from "../../ir";
@@ -15,23 +31,30 @@ import {
   EpisodeReadCancelledError,
   type AssetDescriptor,
   type ByteResources,
+  type EpisodeOpenOptions,
+  type EpisodePreviewReadOptions,
+  type EpisodePreviewReadRequest,
+  type EpisodePreviewSession,
   type EpisodeSession,
   type EpisodeSource,
   type FormatAdapter,
   type FrameBatch,
   type NumericSeriesCapability,
+  type RawRecordCapability,
   type ReadRequest,
   type SourceStats,
 } from "../../ports";
-import { nsDeltaToSeconds } from "../../utils/nanoseconds";
 import { throwIfAborted } from "../../utils/cancellation";
-import { toError } from "../../utils/errors";
+import { nsDeltaToSeconds } from "../../utils/nanoseconds";
 
-const INFO_ROLE = "metadata";
-const EPISODE_INDEX_ROLE = "episode-index";
-const DATA_ROLE = "data";
-const VIDEO_ROLE = "video";
+const INFO_ROLE = "dataset-info";
+const EPISODE_METADATA_ROLE = "episode-metadata";
+const DATA_ROLE = "tabular-frame-data";
+const IMAGE_ROLE = "image-payload";
+const VIDEO_ROLE = "video-stream";
+const RAW_STREAM_ID = "lerobot:rows";
 const NS_PER_SECOND = 1_000_000_000;
+const MP4_INDEX_CHUNK_BYTES = 1024 * 1024;
 
 interface ParquetReaderOptions {
   readonly columns?: string[];
@@ -44,7 +67,7 @@ type ParquetReader = (
   options: ParquetReaderOptions,
 ) => Promise<Record<string, unknown>[]>;
 
-/** Test seam for the browser-native Parquet reader. */
+/** Test seams for the browser-native LeRobot readers. */
 export interface CreateLeRobotFormatAdapterOptions {
   readonly readParquetObjects?: ParquetReader;
 }
@@ -63,76 +86,221 @@ interface LeRobotInfo {
   readonly robot_type?: string;
 }
 
+interface TimelineRow {
+  readonly frameIndex: number;
+  readonly localTimeNs: bigint;
+  readonly rowOffset: number;
+  readonly sourceTimeSeconds: number;
+}
+
 interface EpisodeRows {
   readonly dataAsset: AssetDescriptor;
-  readonly end: number;
   readonly episode: Record<string, unknown>;
-  readonly start: number;
+  readonly originSeconds: number;
+  readonly rows: readonly TimelineRow[];
 }
 
 interface VideoBinding {
   readonly asset: AssetDescriptor;
+  readonly feature: LeRobotFeature;
   readonly fromSeconds: number;
   readonly streamId: string;
   readonly toSeconds: number;
 }
 
-interface DemuxedVideo {
+interface ImageBinding {
+  readonly asset: AssetDescriptor;
+  readonly feature: LeRobotFeature;
+  readonly streamId: string;
+}
+
+interface VideoIndex {
+  readonly compositionOffsetSeconds: number;
+  readonly file: ISOFile;
   readonly samples: readonly Sample[];
   readonly track: Track;
 }
 
-/** Creates the Parquet + MP4 LeRobot implementation of the episode port. */
+interface AvcConfiguration {
+  readonly lengthSizeMinusOne?: number;
+  readonly PPS?: readonly { readonly data?: ArrayLike<number> }[];
+  readonly SPS?: readonly { readonly data?: ArrayLike<number> }[];
+}
+
+interface Mp4SampleDescription {
+  readonly avcC?: AvcConfiguration;
+}
+
+/** Creates the Parquet + range-addressed MP4 LeRobot v3 episode adapter. */
 export function createLeRobotFormatAdapter(
   options: CreateLeRobotFormatAdapterOptions = {},
 ): FormatAdapter {
   const readObjects = options.readParquetObjects ?? parquetReadObjects;
-  let activeSession: LeRobotEpisodeSession | null = null;
+  const open = async (
+    source: EpisodeSource,
+    io: ByteResources,
+    openOptions?: EpisodeOpenOptions,
+  ) => {
+    throwIfAborted(openOptions?.signal);
+    const assets = await source.assets.list(openOptions);
+    const infoAsset = requireSingleRole(assets, INFO_ROLE);
+    const episodeAsset = requireSingleRole(assets, EPISODE_METADATA_ROLE);
+    const dataAsset = requireSingleRole(assets, DATA_ROLE);
+    const [info, episodeRows] = await Promise.all([
+      readInfo(source, io, infoAsset, openOptions?.signal),
+      readSelectedParquetRows(
+        source,
+        io,
+        episodeAsset,
+        readObjects,
+        undefined,
+        openOptions?.signal,
+      ),
+    ]);
+    if (episodeRows.length !== 1) {
+      throw new Error(
+        "LeRobot episode metadata selector must resolve exactly one row",
+      );
+    }
+    const episode = await readEpisodeRows(
+      source,
+      io,
+      dataAsset,
+      episodeRows[0],
+      readObjects,
+      openOptions?.signal,
+    );
+    throwIfAborted(openOptions?.signal);
+    return new LeRobotEpisodeSession({
+      assets,
+      episodeRows: episode,
+      info,
+      io,
+      readObjects,
+      source,
+    });
+  };
 
   return {
-    id: "lerobot",
-    async open(source, io) {
-      const assets = await source.assets.list();
-      const infoAsset = requireSingleRole(assets, INFO_ROLE);
-      const episodeIndexAsset = requireSingleRole(assets, EPISODE_INDEX_ROLE);
-      const [info, episodeRows] = await Promise.all([
-        readInfo(source, io, infoAsset),
-        readEpisodeRows(source, io, assets, episodeIndexAsset, readObjects),
-      ]);
-      const session = new LeRobotEpisodeSession({
-        assets,
-        episodeRows,
-        info,
-        io,
-        onActivate: () => {
-          if (activeSession && activeSession !== session) {
-            activeSession.deactivate();
-          }
-          activeSession = session;
-        },
-        readObjects,
-        source,
-      });
-      return session;
+    id: "lerobot-v3",
+    open,
+    async openPreview(source, io, openOptions) {
+      return new LeRobotEpisodePreviewSession(
+        await open(source, io, openOptions),
+      );
     },
   };
 }
 
+class LeRobotEpisodePreviewSession implements EpisodePreviewSession {
+  private readonly initializedStreams = new Set<string>();
+  private disposed = false;
+
+  constructor(private readonly session: LeRobotEpisodeSession) {}
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.session.dispose();
+  }
+
+  async read(
+    request: EpisodePreviewReadRequest = {},
+    options: EpisodePreviewReadOptions = {},
+  ): Promise<EpisodePreviewReadResult> {
+    this.ensureOpen();
+    throwIfAborted(options.signal);
+    const previewStreams = this.session.manifest.streams
+      .filter(isRenderableCameraStream)
+      .sort(comparePreviewStreams);
+    const selected = request.sourceName
+      ? previewStreams.find(
+          (stream) => stream.sourceName === request.sourceName,
+        )
+      : previewStreams[0];
+    const streamSourceNames = previewStreams.map((stream) => stream.sourceName);
+    if (!selected) {
+      return {
+        frame: null,
+        streamId: null,
+        streamSourceName: null,
+        streamSourceNames,
+        status: previewStreams.length ? "empty" : "unavailable",
+      };
+    }
+
+    const startNs = request.startTimeNs ?? selected.timeRange.startNs;
+    const frameDurationNs = secondsToNs(
+      1 / (selected.approxRateHz ?? this.session.info.fps),
+    );
+    let frames: readonly DecodedFrame[] = [];
+    for await (const batch of this.session.read({
+      priority: options.priority,
+      signal: options.signal,
+      streams: [selected.id],
+      window: {
+        endNs: minBigInt(selected.timeRange.endNs, startNs + frameDurationNs),
+        startNs,
+      },
+    })) {
+      frames = batch.frames;
+      break;
+    }
+    this.ensureOpen();
+    throwIfAborted(options.signal);
+    const initialized = this.initializedStreams.has(selected.id);
+    const decoded = initialized
+      ? firstFrameAtOrAfter(frames, startNs)
+      : frames[0];
+    if (decoded) this.initializedStreams.add(selected.id);
+    const frame = decoded ? posterFrame(decoded) : null;
+    const nextStartTimeNs = decoded
+      ? decoded.timestampNs + frameDurationNs
+      : undefined;
+    return {
+      bootstrapManifest: this.session.manifest,
+      bootstrapTimeline: {
+        endNs: this.session.manifest.timeRange.endNs,
+        startNs: this.session.manifest.timeRange.startNs,
+        timeDomainId: this.session.manifest.timeDomain.id,
+      },
+      bootstrapTimeRange: this.session.manifest.timeRange,
+      frame,
+      frameTimeNs: decoded?.timestampNs,
+      nextStartTimeNs:
+        nextStartTimeNs !== undefined &&
+        nextStartTimeNs <= selected.timeRange.endNs
+          ? nextStartTimeNs
+          : undefined,
+      streamId: selected.id,
+      streamSourceName: selected.sourceName,
+      streamSourceNames,
+      status: frame ? "ready" : "empty",
+    };
+  }
+
+  private ensureOpen() {
+    if (this.disposed) throw new EpisodeReadCancelledError();
+  }
+}
+
 class LeRobotEpisodeSession implements EpisodeSession {
+  readonly imageBindings: ReadonlyMap<string, ImageBinding>;
+  readonly info: LeRobotInfo;
   readonly manifest: EpisodeManifest;
   readonly numericSeries: NumericSeriesCapability;
-  private readonly dataBuffer: AsyncBuffer;
-  private readonly scalarFeatures: ReadonlyMap<string, LeRobotFeature>;
-  private readonly scalarRowsCache = new Map<
+  readonly rawRecords: RawRecordCapability;
+  readonly scalarFeatures: ReadonlyMap<string, LeRobotFeature>;
+  readonly videoBindings: ReadonlyMap<string, VideoBinding>;
+  private readonly rowCache = new Map<
     string,
-    Promise<Record<string, unknown>[]>
+    Promise<readonly Record<string, unknown>[]>
   >();
-  private readonly videoBindings: ReadonlyMap<string, VideoBinding>;
-  private readonly videoCache = new Map<string, Promise<DemuxedVideo>>();
+  private readonly videoIndexCache = new Map<string, Promise<VideoIndex>>();
+  private decodedFrames = 0;
   private disposed = false;
   private generation = 0;
   private idleGeneration = 0;
-  private decodedFrames = 0;
   private readRequests = 0;
   private returnedBatches = 0;
   private transferredBytes = 0;
@@ -143,68 +311,92 @@ class LeRobotEpisodeSession implements EpisodeSession {
       readonly episodeRows: EpisodeRows;
       readonly info: LeRobotInfo;
       readonly io: ByteResources;
-      readonly onActivate: () => void;
       readonly readObjects: ParquetReader;
       readonly source: EpisodeSource;
     },
   ) {
-    const duration = episodeDuration(state.episodeRows.episode, state.info.fps);
-    const timeRange = {
-      endNs: secondsToNs(duration.end),
-      startNs: secondsToNs(duration.start),
-    };
+    this.info = state.info;
     const scalarFeatures = new Map<string, LeRobotFeature>();
     const videoBindings = new Map<string, VideoBinding>();
+    const imageBindings = new Map<string, ImageBinding>();
+    const timeRange = episodeTimeRange(state.episodeRows, state.assets);
     const streams = Object.entries(state.info.features).flatMap(
       ([name, feature]): StreamDescriptor[] => {
         const streamId = streamIdForFeature(name);
         if (feature.dtype === "video") {
-          const binding = resolveVideoBinding(
-            state.assets,
-            state.episodeRows.episode,
-            name,
+          const asset = findFeatureAsset(state.assets, VIDEO_ROLE, name);
+          const selector = asset?.selector;
+          if (
+            !asset ||
+            !selector ||
+            selector.kind !== "video-timestamp-interval"
+          ) {
+            return [unsupportedStream(name, feature, timeRange)];
+          }
+          const binding = {
+            asset,
+            feature,
+            fromSeconds: selector.fromTimestamp,
             streamId,
-          );
-          if (!binding) return [];
+            toSeconds: selector.toTimestamp,
+          };
           videoBindings.set(streamId, binding);
-          return [videoStream(name, feature, binding, timeRange)];
+          return [
+            videoStream(name, feature, binding, timeRange, state.info.fps),
+          ];
         }
-        if (!isScalarFeature(name, feature)) return [];
-        scalarFeatures.set(streamId, feature);
-        return [scalarStream(name, feature, timeRange)];
+        if (feature.dtype === "image") {
+          const asset = findFeatureAsset(state.assets, IMAGE_ROLE, name);
+          if (!asset) return [unsupportedStream(name, feature, timeRange)];
+          imageBindings.set(streamId, { asset, feature, streamId });
+          return [imageStream(name, feature, timeRange, state.info.fps)];
+        }
+        if (isNumericFeature(name, feature)) {
+          scalarFeatures.set(streamId, feature);
+          return [
+            scalarStream(
+              name,
+              feature,
+              timeRange,
+              state.info.fps,
+              state.episodeRows.rows.length,
+            ),
+          ];
+        }
+        return isStandardField(name)
+          ? []
+          : [unsupportedStream(name, feature, timeRange)];
       },
     );
     this.scalarFeatures = scalarFeatures;
     this.videoBindings = videoBindings;
+    this.imageBindings = imageBindings;
     this.manifest = state.source.manifestHint ?? {
       episodeId: state.source.episodeId,
       metadata: {
         "lerobot.codebaseVersion": state.info.codebase_version ?? "unknown",
-        "lerobot.episodeIndex": episodeIndex(state.source).toString(),
+        "lerobot.episodeIndex": integer(
+          state.episodeRows.episode.episode_index,
+          "episode_index",
+        ).toString(),
+        "lerobot.fps": state.info.fps.toString(),
         "lerobot.robotType": state.info.robot_type ?? "unknown",
+        "lerobot.tasks": JSON.stringify(state.episodeRows.episode.tasks ?? []),
       },
       streams,
       timeDomain: { id: "episode", kind: "duration", originNs: 0n },
       timeRange,
     };
-    this.dataBuffer = asyncBufferForSource(
-      state.episodeRows.dataAsset,
-      state.source,
-      state.io,
-      (bytes) => {
-        this.transferredBytes += bytes;
-      },
-    );
     this.numericSeries = {
-      enumerateNumericFields: async (streams) =>
-        this.enumerateNumericFields(streams),
+      enumerateNumericFields: async (requested) =>
+        this.enumerateNumericFields(requested),
       readNumericSeries: async (request) => this.readNumericSeries(request),
     };
+    this.rawRecords = this.createRawRecordCapability();
   }
 
   activate(): void {
     this.ensureOpen();
-    this.state.onActivate();
   }
 
   cancelIdle(): void {
@@ -213,16 +405,15 @@ class LeRobotEpisodeSession implements EpisodeSession {
   }
 
   deactivate(): void {
-    if (this.disposed) return;
-    this.generation += 1;
+    if (!this.disposed) this.generation += 1;
   }
 
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
     this.generation += 1;
-    this.scalarRowsCache.clear();
-    this.videoCache.clear();
+    this.rowCache.clear();
+    this.videoIndexCache.clear();
   }
 
   async *read(request: ReadRequest): AsyncIterable<FrameBatch> {
@@ -232,46 +423,25 @@ class LeRobotEpisodeSession implements EpisodeSession {
     const idleGeneration = this.idleGeneration;
     const priority = request.priority ?? "playback";
     this.readRequests += 1;
-
-    const scalarStreams = request.streams.filter((stream) =>
-      this.scalarFeatures.has(stream),
-    );
-    if (scalarStreams.length > 0) {
-      const rows = await this.readScalarRows(scalarStreams);
-      this.ensureReadable(generation, idleGeneration, priority, request.signal);
-      for (const stream of scalarStreams) {
-        const featureName = featureNameForStream(stream);
-        const feature = this.scalarFeatures.get(stream);
-        if (!feature) continue;
-        const frames = rows
-          .map((row) => scalarFrame(stream, featureName, feature, row))
-          .filter(
-            (frame): frame is DecodedFrame =>
-              frame !== null && inWindow(frame.timestampNs, request.window),
-          );
-        if (frames.length === 0) continue;
-        this.recordBatch(frames.length);
-        yield { frames, stream };
-      }
-    }
-
     for (const stream of request.streams) {
-      const binding = this.videoBindings.get(stream);
-      if (!binding) continue;
-      const video = await this.readVideo(binding);
+      const scalar = this.scalarFeatures.get(stream);
+      const image = this.imageBindings.get(stream);
+      const video = this.videoBindings.get(stream);
+      const frames = scalar
+        ? await this.readScalarFrames(stream, scalar, request)
+        : image
+          ? await this.readImageFrames(stream, image, request)
+          : video
+            ? await this.readVideoFrames(stream, video, request)
+            : [];
       this.ensureReadable(generation, idleGeneration, priority, request.signal);
-      const frames = video.samples
-        .filter((sample) =>
-          videoSampleInWindow(binding, video.track, sample, request.window),
-        )
-        .map((sample) => videoFrame(stream, binding, video.track, sample))
-        .filter(
-          (frame): frame is DecodedFrame =>
-            frame !== null && inWindow(frame.timestampNs, request.window),
-        );
-      if (frames.length === 0) continue;
-      this.recordBatch(frames.length);
-      yield { frames, stream };
+      if (!frames.length) continue;
+      const limited =
+        request.limit && request.limit > 0
+          ? frames.slice(0, request.limit)
+          : frames;
+      this.recordBatch(limited.length);
+      yield { frames: limited, stream };
     }
   }
 
@@ -285,33 +455,149 @@ class LeRobotEpisodeSession implements EpisodeSession {
     };
   }
 
-  private async readScalarRows(
-    streams: readonly string[],
-  ): Promise<Record<string, unknown>[]> {
-    const featureNames = [...new Set(streams.map(featureNameForStream))].sort();
-    const key = featureNames.join("\n");
-    const cached = this.scalarRowsCache.get(key);
-    if (cached) return cached;
-    const promise = this.state.readObjects({
-      columns: ["timestamp", "frame_index", ...featureNames],
-      file: this.dataBuffer,
-      rowEnd: this.state.episodeRows.end,
-      rowStart: this.state.episodeRows.start,
-    });
-    this.scalarRowsCache.set(key, promise);
-    try {
-      return await promise;
-    } catch (error) {
-      this.scalarRowsCache.delete(key);
-      throw error;
-    }
+  private async readScalarFrames(
+    streamId: string,
+    feature: LeRobotFeature,
+    request: ReadRequest,
+  ) {
+    const featureName = featureNameForStream(streamId);
+    const range = rowRangeForWindow(
+      this.state.episodeRows.rows,
+      request.window,
+    );
+    if (!range) return [];
+    const rows = await this.readRows(
+      ["timestamp", "frame_index", featureName],
+      request.signal,
+      this.state.episodeRows.dataAsset,
+      range,
+    );
+    return rows
+      .map((row) =>
+        scalarFrame(
+          streamId,
+          featureName,
+          feature,
+          row,
+          this.state.episodeRows.originSeconds,
+        ),
+      )
+      .filter(
+        (frame): frame is DecodedFrame =>
+          frame !== null && inWindow(frame.timestampNs, request.window),
+      );
   }
 
-  private async readVideo(binding: VideoBinding): Promise<DemuxedVideo> {
-    const cached = this.videoCache.get(binding.asset.id);
-    if (cached) return cached;
-    const promise = (async () => {
-      const buffer = asyncBufferForSource(
+  private async readImageFrames(
+    streamId: string,
+    binding: ImageBinding,
+    request: ReadRequest,
+  ) {
+    const featureName = featureNameForStream(streamId);
+    const range = rowRangeForWindow(
+      this.state.episodeRows.rows,
+      request.window,
+    );
+    if (!range) return [];
+    const rows = await this.readRows(
+      ["timestamp", "frame_index", featureName],
+      request.signal,
+      binding.asset,
+      range,
+    );
+    return rows
+      .map((row) =>
+        imageFrame(
+          streamId,
+          featureName,
+          row,
+          this.state.episodeRows.originSeconds,
+        ),
+      )
+      .filter(
+        (frame): frame is DecodedFrame =>
+          frame !== null && inWindow(frame.timestampNs, request.window),
+      );
+  }
+
+  private async readVideoFrames(
+    streamId: string,
+    binding: VideoBinding,
+    request: ReadRequest,
+  ) {
+    if (codecFamily(videoCodec(binding.feature)) !== "h264") return [];
+    const index = await this.readVideoIndex(binding, request.signal);
+    const samples = selectVideoSamples(index, binding, request.window);
+    if (!samples.length) return [];
+    const bytes = await readSampleSpan(
+      binding.asset,
+      samples,
+      this.state.source,
+      this.state.io,
+      request.signal,
+    );
+    this.transferredBytes += bytes.byteLength;
+    const avc = (samples[0].description as Mp4SampleDescription).avcC;
+    const lengthSize = (avc?.lengthSizeMinusOne ?? 3) + 1;
+    const parameterSets = avcParameterSets(avc);
+    return samples
+      .map((sample) => {
+        const offset = sample.offset - samples[0].offset;
+        return videoFrame(
+          streamId,
+          binding,
+          index,
+          sample,
+          mp4SampleToAnnexB(
+            bytes.subarray(offset, offset + sample.size),
+            lengthSize,
+          ),
+          parameterSets,
+        );
+      })
+      .filter((frame): frame is DecodedFrame => frame !== null);
+  }
+
+  private async readRows(
+    columns: readonly string[],
+    signal?: AbortSignal,
+    asset = this.state.episodeRows.dataAsset,
+    range?: { readonly end: number; readonly start: number },
+  ) {
+    const key = `${asset.id}\n${range?.start ?? "all"}:${
+      range?.end ?? "all"
+    }\n${[...columns].sort().join("\n")}`;
+    let cached = this.rowCache.get(key);
+    if (!cached) {
+      cached = readSelectedParquetRows(
+        this.state.source,
+        this.state.io,
+        asset,
+        this.state.readObjects,
+        [...columns],
+        undefined,
+        range?.start,
+        range?.end,
+      );
+      if (this.rowCache.size >= 32) {
+        const oldest = this.rowCache.keys().next().value;
+        if (oldest !== undefined) this.rowCache.delete(oldest);
+      }
+      this.rowCache.set(key, cached);
+      void cached.catch(() => {
+        if (this.rowCache.get(key) === cached) this.rowCache.delete(key);
+      });
+    }
+    throwIfAborted(signal);
+    const rows = await cached;
+    throwIfAborted(signal);
+    return rows;
+  }
+
+  private async readVideoIndex(binding: VideoBinding, signal?: AbortSignal) {
+    let cached = this.videoIndexCache.get(binding.asset.id);
+    if (!cached) {
+      cached = parseVideoIndex(
         binding.asset,
         this.state.source,
         this.state.io,
@@ -319,21 +605,20 @@ class LeRobotEpisodeSession implements EpisodeSession {
           this.transferredBytes += bytes;
         },
       );
-      const bytes = new Uint8Array(await buffer.slice(0, buffer.byteLength));
-      return demuxVideo(bytes);
-    })();
-    this.videoCache.set(binding.asset.id, promise);
-    try {
-      return await promise;
-    } catch (error) {
-      this.videoCache.delete(binding.asset.id);
-      throw error;
+      this.videoIndexCache.set(binding.asset.id, cached);
+      void cached.catch(() => {
+        if (this.videoIndexCache.get(binding.asset.id) === cached) {
+          this.videoIndexCache.delete(binding.asset.id);
+        }
+      });
     }
+    throwIfAborted(signal);
+    const index = await cached;
+    throwIfAborted(signal);
+    return index;
   }
 
-  private enumerateNumericFields(
-    streams: readonly string[] | undefined,
-  ): ReturnType<NumericSeriesCapability["enumerateNumericFields"]> {
+  private enumerateNumericFields(streams: readonly string[] | undefined) {
     const requested = streams ? new Set(streams) : null;
     return Promise.resolve(
       [...this.scalarFeatures.entries()]
@@ -352,26 +637,66 @@ class LeRobotEpisodeSession implements EpisodeSession {
 
   private async readNumericSeries(
     request: Parameters<NumericSeriesCapability["readNumericSeries"]>[0],
-  ): ReturnType<NumericSeriesCapability["readNumericSeries"]> {
-    const frames: DecodedFrame[] = [];
-    for await (const batch of this.read({
-      streams: [request.stream],
-      window: request.window,
-    })) {
-      frames.push(...batch.frames);
+  ) {
+    throwIfAborted(request.signal);
+    const feature = this.scalarFeatures.get(request.stream);
+    if (!feature) {
+      throw new Error(`Unknown LeRobot numeric stream '${request.stream}'`);
     }
+    const featureName = featureNameForStream(request.stream);
+    const range = rowRangeForWindow(
+      this.state.episodeRows.rows,
+      request.window,
+    );
+    if (!range) {
+      return {
+        baseTimeNs: this.manifest.timeRange.startNs,
+        fields: request.fields.map((path) => ({
+          path,
+          timesSec: new Float64Array(),
+          values: new Float64Array(),
+        })),
+        sampleCount: 0,
+        streamId: request.stream,
+        truncated: false,
+      };
+    }
+    const rows = await this.readRows(
+      ["timestamp", "frame_index", featureName],
+      request.signal,
+      this.state.episodeRows.dataAsset,
+      range,
+    );
+    const frames = rows
+      .map((row) =>
+        scalarFrame(
+          request.stream,
+          featureName,
+          feature,
+          row,
+          this.state.episodeRows.originSeconds,
+        ),
+      )
+      .filter(
+        (frame): frame is DecodedFrame =>
+          frame !== null && inWindow(frame.timestampNs, request.window),
+      );
+    const selected = sampledIndexes(
+      frames.length,
+      request.maxPointsPerField,
+    ).map((index) => frames[index]);
     const baseTimeNs = this.manifest.timeRange.startNs;
     return {
       baseTimeNs,
       fields: request.fields.map((path) => ({
         path,
         timesSec: Float64Array.from(
-          frames.map((frame) =>
+          selected.map((frame) =>
             nsDeltaToSeconds(frame.timestampNs - baseTimeNs),
           ),
         ),
         values: Float64Array.from(
-          frames.map(
+          selected.map(
             (frame) =>
               frame.output.scalars?.find((scalar) => scalar.field === path)
                 ?.value ?? Number.NaN,
@@ -380,7 +705,108 @@ class LeRobotEpisodeSession implements EpisodeSession {
       })),
       sampleCount: frames.length,
       streamId: request.stream,
-      truncated: false,
+      truncated: selected.length < frames.length,
+    };
+  }
+
+  private createRawRecordCapability(): RawRecordCapability {
+    const rows = this.state.episodeRows.rows;
+    const readAt = async (
+      rowOffset: number,
+      options: {
+        readonly includeFullJson?: boolean;
+        readonly prune?: RawRecordPruneBudgets;
+        readonly signal?: AbortSignal;
+      },
+    ): Promise<RawRecordResult> => {
+      const selected = await readSelectedParquetRows(
+        this.state.source,
+        this.state.io,
+        this.state.episodeRows.dataAsset,
+        this.state.readObjects,
+        undefined,
+        options.signal,
+        rowOffset,
+        rowOffset + 1,
+      );
+      const row = selected[0];
+      const timeline = rows[rowOffset];
+      if (!row || !timeline) return emptyRawRecord(this.manifest.timeRange);
+      const pruned = pruneRawRecord(row, options.prune);
+      const next = rows[rowOffset + 1]?.localTimeNs;
+      return {
+        cursor: rawCursor(rowOffset),
+        encoding: "parquet",
+        ...(options.includeFullJson
+          ? { fullJson: boundedJson(row, options.prune) }
+          : {}),
+        root: pruned.root,
+        schemaName: "LeRobotDataset v3 row",
+        sequence: timeline.frameIndex,
+        sourceName: "Episode rows",
+        sourceTimestamps: {
+          lerobot: secondsToNs(timeline.sourceTimeSeconds),
+        },
+        status: "ok",
+        streamId: RAW_STREAM_ID,
+        timestampNs: timeline.localTimeNs,
+        truncated: pruned.truncated,
+        validFromNs: timeline.localTimeNs,
+        validUntilNs:
+          next !== undefined && next > timeline.localTimeNs
+            ? next - 1n
+            : this.manifest.timeRange.endNs,
+      };
+    };
+
+    return {
+      listRawRecordStreams: async ({ signal } = {}) => {
+        throwIfAborted(signal);
+        return [
+          {
+            encoding: "parquet",
+            sampleCount: rows.length,
+            schemaName: "LeRobotDataset v3 row",
+            sourceName: "Episode rows",
+            streamId: RAW_STREAM_ID,
+            supportsExactBrowsing: true,
+          },
+        ];
+      },
+      readRawRecord: async (request) => {
+        requireRawStream(request.stream);
+        const offset = rowAtOrBefore(rows, request.timestampNs);
+        return offset === null
+          ? emptyRawRecord(this.manifest.timeRange)
+          : readAt(offset, request);
+      },
+      readRawRecordAtCursor: async (request) => {
+        requireRawStream(request.stream);
+        return readAt(parseRawCursor(request.cursor, rows.length), request);
+      },
+      readRawRecordIndexWindow: async (request) => {
+        requireRawStream(request.stream);
+        throwIfAborted(request.signal);
+        const selected =
+          request.anchorCursor !== undefined
+            ? parseRawCursor(request.anchorCursor, rows.length)
+            : (rowAtOrBefore(rows, request.anchorTimestampNs) ?? 0);
+        const start = Math.max(0, selected - Math.max(0, request.before));
+        const end = Math.min(
+          rows.length,
+          selected + Math.max(0, request.after) + 1,
+        );
+        const result: RawRecordIndexWindow = {
+          entries: rows.slice(start, end).map((row) => ({
+            cursor: rawCursor(row.rowOffset),
+            timestampNs: row.localTimeNs,
+          })),
+          hasNext: end < rows.length,
+          hasPrevious: start > 0,
+          selectedCursor: rawCursor(selected),
+        };
+        return result;
+      },
     };
   }
 
@@ -388,8 +814,8 @@ class LeRobotEpisodeSession implements EpisodeSession {
     generation: number,
     idleGeneration: number,
     priority: ReadRequest["priority"],
-    signal: AbortSignal | undefined,
-  ): void {
+    signal?: AbortSignal,
+  ) {
     this.ensureOpen();
     throwIfAborted(signal);
     if (generation !== this.generation) throw new EpisodeReadCancelledError();
@@ -401,11 +827,11 @@ class LeRobotEpisodeSession implements EpisodeSession {
     }
   }
 
-  private ensureOpen(): void {
+  private ensureOpen() {
     if (this.disposed) throw new EpisodeReadCancelledError();
   }
 
-  private recordBatch(frameCount: number): void {
+  private recordBatch(frameCount: number) {
     this.decodedFrames += frameCount;
     this.returnedBatches += 1;
   }
@@ -415,12 +841,25 @@ async function readInfo(
   source: EpisodeSource,
   io: ByteResources,
   asset: AssetDescriptor,
+  signal?: AbortSignal,
 ): Promise<LeRobotInfo> {
-  const buffer = asyncBufferForSource(asset, source, io);
+  const buffer = asyncBufferForSource(asset, source, io, signal);
   const bytes = new Uint8Array(await buffer.slice(0, buffer.byteLength));
+  throwIfAborted(signal);
   const value = JSON.parse(new TextDecoder().decode(bytes)) as LeRobotInfo;
   if (!value.features || !Number.isFinite(value.fps) || value.fps <= 0) {
     throw new Error("Invalid LeRobot meta/info.json");
+  }
+  const version = value.codebase_version?.trim();
+  const match = version?.match(
+    /^v?(\d+)(?:\.\d+){0,2}(?:[-+][0-9A-Za-z.-]+)?$/i,
+  );
+  if (!match || Number(match[1]) !== 3) {
+    throw new Error(
+      `This viewer supports LeRobotDataset format v3.x; the source declares '${
+        version ?? "missing"
+      }'`,
+    );
   }
   return value;
 }
@@ -428,44 +867,120 @@ async function readInfo(
 async function readEpisodeRows(
   source: EpisodeSource,
   io: ByteResources,
-  assets: readonly AssetDescriptor[],
-  indexAsset: AssetDescriptor,
+  dataAsset: AssetDescriptor,
+  episode: Record<string, unknown>,
   readObjects: ParquetReader,
+  signal?: AbortSignal,
 ): Promise<EpisodeRows> {
-  const index = episodeIndex(source);
-  const rows = await readObjects({
-    file: asyncBufferForSource(indexAsset, source, io),
+  const interval = requireRowInterval(dataAsset);
+  const rows = await readSelectedParquetRows(
+    source,
+    io,
+    dataAsset,
+    readObjects,
+    ["timestamp", "frame_index", "episode_index", "index", "task_index"],
+    signal,
+  );
+  const expectedLength = integer(episode.length, "length");
+  if (
+    rows.length !== expectedLength ||
+    interval.end - interval.start !== expectedLength
+  ) {
+    throw new Error("LeRobot selected data rows do not match episode length");
+  }
+  const expectedEpisode = integer(episode.episode_index, "episode_index");
+  const expectedGlobalStart = integer(
+    episode.dataset_from_index,
+    "dataset_from_index",
+  );
+  const sourceTimes = rows.map((row, rowOffset) => {
+    const timestamp = number(row.timestamp, "timestamp");
+    if (integer(row.episode_index, "episode_index") !== expectedEpisode) {
+      throw new Error(
+        "LeRobot data selector contains rows from another episode",
+      );
+    }
+    if (integer(row.index, "index") !== expectedGlobalStart + rowOffset) {
+      throw new Error("LeRobot global index must be contiguous");
+    }
+    if (integer(row.task_index, "task_index") < 0) {
+      throw new Error("LeRobot task_index must be nonnegative");
+    }
+    return {
+      frameIndex: integer(row.frame_index, "frame_index"),
+      rowOffset,
+      sourceTimeSeconds: timestamp,
+    };
   });
-  const episode = rows.find(
-    (row) => integer(row.episode_index, "episode_index") === index,
-  );
-  if (!episode) throw new Error(`LeRobot episode ${index} was not found`);
-  const chunkIndex = integer(episode["data/chunk_index"], "data/chunk_index");
-  const fileIndex = integer(episode["data/file_index"], "data/file_index");
-  const dataAsset = requireIndexedAsset(
-    assets,
-    DATA_ROLE,
-    chunkIndex,
-    fileIndex,
-  );
+  const originSeconds = sourceTimes[0]?.sourceTimeSeconds ?? 0;
+  const timeline = sourceTimes.map((row) => ({
+    ...row,
+    localTimeNs: secondsToNs(row.sourceTimeSeconds - originSeconds),
+  }));
+  for (let index = 0; index < timeline.length; index += 1) {
+    if (timeline[index].frameIndex !== index) {
+      throw new Error(
+        "LeRobot frame_index must be contiguous within an episode",
+      );
+    }
+    if (
+      index > 0 &&
+      timeline[index].localTimeNs < timeline[index - 1].localTimeNs
+    ) {
+      throw new Error("LeRobot row timestamps must be monotonic");
+    }
+  }
   return {
     dataAsset,
-    end: integer(episode.dataset_to_index, "dataset_to_index"),
     episode,
-    start: integer(episode.dataset_from_index, "dataset_from_index"),
+    originSeconds,
+    rows: timeline,
   };
+}
+
+async function readSelectedParquetRows(
+  source: EpisodeSource,
+  io: ByteResources,
+  asset: AssetDescriptor,
+  readObjects: ParquetReader,
+  columns?: string[],
+  signal?: AbortSignal,
+  relativeStart?: number,
+  relativeEnd?: number,
+): Promise<Record<string, unknown>[]> {
+  const interval = requireRowInterval(asset);
+  const rowStart = interval.start + (relativeStart ?? 0);
+  const rowEnd =
+    relativeEnd === undefined ? interval.end : interval.start + relativeEnd;
+  if (
+    rowStart < interval.start ||
+    rowEnd > interval.end ||
+    rowStart >= rowEnd
+  ) {
+    throw new Error("LeRobot row request exceeds the resolved selector");
+  }
+  throwIfAborted(signal);
+  const rows = await readObjects({
+    ...(columns ? { columns } : {}),
+    file: asyncBufferForSource(asset, source, io, signal),
+    rowEnd,
+    rowStart,
+  });
+  throwIfAborted(signal);
+  return rows;
 }
 
 function asyncBufferForSource(
   asset: AssetDescriptor,
   source: EpisodeSource,
   io: ByteResources,
+  signal?: AbortSignal,
   onBytes?: (bytes: number) => void,
 ): AsyncBuffer {
   let resolved: ReturnType<EpisodeSource["assets"]["resolve"]> | undefined;
-  const resolve = () => (resolved ??= source.assets.resolve(asset.id));
-  const sizeText = asset.metadata?.sizeBytes;
-  const byteLength = safeByteLength(sizeText);
+  const resolve = () =>
+    (resolved ??= source.assets.resolve(asset.id, { signal }));
+  const byteLength = safeByteLength(asset.metadata?.sizeBytes);
   if (byteLength === null) {
     throw new Error(
       `LeRobot asset '${asset.id}' is missing metadata.sizeBytes`,
@@ -477,172 +992,243 @@ function asyncBufferForSource(
       if (start < 0 || end < start || end > byteLength) {
         throw new RangeError(`Invalid byte range ${start}:${end}`);
       }
-      const descriptor = await resolve();
+      throwIfAborted(signal);
       const result = await io.readBytes({
         range: { length: BigInt(end - start), offset: BigInt(start) },
-        source: descriptor,
+        signal,
+        source: await resolve(),
       });
+      throwIfAborted(signal);
       onBytes?.(result.bytes.byteLength);
-      return result.bytes.buffer.slice(
-        result.bytes.byteOffset,
-        result.bytes.byteOffset + result.bytes.byteLength,
-      ) as ArrayBuffer;
+      return exactArrayBuffer(result.bytes);
     },
   };
 }
 
-function safeByteLength(value: string | undefined): number | null {
-  if (!value || !/^\d+$/.test(value)) return null;
-  const size = Number(value);
-  return Number.isSafeInteger(size) && size >= 0 ? size : null;
-}
-
-function requireSingleRole(
-  assets: readonly AssetDescriptor[],
-  role: string,
-): AssetDescriptor {
-  const matches = assets.filter((asset) => asset.role === role);
-  if (matches.length !== 1) {
-    throw new Error(`LeRobot source requires exactly one '${role}' asset`);
-  }
-  return matches[0];
-}
-
-function requireIndexedAsset(
-  assets: readonly AssetDescriptor[],
-  role: string,
-  chunkIndex: number,
-  fileIndex: number,
-): AssetDescriptor {
-  const matches = assets.filter(
-    (asset) =>
-      asset.role === role &&
-      integerMetadata(asset, "chunkIndex") === chunkIndex &&
-      integerMetadata(asset, "fileIndex") === fileIndex,
-  );
-  if (matches.length !== 1) {
-    throw new Error(
-      `LeRobot source requires '${role}' asset ${chunkIndex}/${fileIndex}`,
+async function parseVideoIndex(
+  asset: AssetDescriptor,
+  source: EpisodeSource,
+  io: ByteResources,
+  onBytes: (bytes: number) => void,
+): Promise<VideoIndex> {
+  const byteLength = safeByteLength(asset.metadata?.sizeBytes);
+  if (byteLength === null) throw new Error("LeRobot video asset has no size");
+  const file = createFile(false);
+  let track: Track | null = null;
+  let failure: Error | null = null;
+  file.onError = (message) => {
+    failure = new Error(`LeRobot MP4 index parse failed: ${message}`);
+  };
+  file.onReady = (info) => {
+    track = info.videoTracks[0] ?? null;
+  };
+  const descriptor = await source.assets.resolve(asset.id);
+  let offset = 0;
+  while (!track && !failure && offset < byteLength) {
+    const end = Math.min(byteLength, offset + MP4_INDEX_CHUNK_BYTES);
+    const result = await io.readBytes({
+      range: { length: BigInt(end - offset), offset: BigInt(offset) },
+      source: descriptor,
+    });
+    onBytes(result.bytes.byteLength);
+    const next = file.appendBuffer(
+      MP4BoxBuffer.fromArrayBuffer(exactArrayBuffer(result.bytes), offset),
+      end === byteLength,
     );
+    offset = Number.isSafeInteger(next) && next > offset ? next : end;
   }
-  return matches[0];
+  if (failure) throw failure;
+  const videoTrack = track as Track | null;
+  if (!videoTrack)
+    throw new Error("LeRobot video asset has no readable video track");
+  const samples = file.getTrackSamplesInfo(videoTrack.id);
+  if (!samples.length) throw new Error("LeRobot video track has no samples");
+  const compositionOffsetSeconds = Math.min(
+    ...samples.map((sample) => sample.cts / videoTrack.timescale),
+  );
+  return { compositionOffsetSeconds, file, samples, track: videoTrack };
 }
 
-function integerMetadata(asset: AssetDescriptor, key: string): number | null {
-  const value = asset.metadata?.[key];
-  if (!value || !/^\d+$/.test(value)) return null;
-  const parsed = Number(value);
-  return Number.isSafeInteger(parsed) ? parsed : null;
+function selectVideoSamples(
+  index: VideoIndex,
+  binding: VideoBinding,
+  window: TimeWindow,
+): readonly Sample[] {
+  const indexed = index.samples.map((sample, decodeIndex) => ({
+    decodeIndex,
+    presentationSeconds: videoPresentationSeconds(index, sample),
+    sample,
+  }));
+  const selectedInterval = indexed.filter(
+    ({ presentationSeconds }) =>
+      presentationSeconds >= binding.fromSeconds &&
+      presentationSeconds < binding.toSeconds,
+  );
+  const startSeconds = binding.fromSeconds + nsToSeconds(window.startNs);
+  const endSeconds = binding.fromSeconds + nsToSeconds(window.endNs);
+  const requested = selectedInterval.filter(
+    ({ presentationSeconds }) =>
+      presentationSeconds >= startSeconds && presentationSeconds <= endSeconds,
+  );
+  if (!requested.length) return [];
+  const firstDecode = Math.min(...requested.map((entry) => entry.decodeIndex));
+  const lastDecode = Math.max(...requested.map((entry) => entry.decodeIndex));
+  let startDecode = firstDecode;
+  for (const entry of indexed) {
+    if (entry.decodeIndex > firstDecode) break;
+    if (entry.sample.is_sync) startDecode = entry.decodeIndex;
+  }
+  return index.samples.slice(startDecode, lastDecode + 1);
 }
 
-function resolveVideoBinding(
-  assets: readonly AssetDescriptor[],
-  episode: Record<string, unknown>,
-  featureName: string,
+async function readSampleSpan(
+  asset: AssetDescriptor,
+  samples: readonly Sample[],
+  source: EpisodeSource,
+  io: ByteResources,
+  signal?: AbortSignal,
+) {
+  const start = samples[0].offset;
+  const end = Math.max(...samples.map((sample) => sample.offset + sample.size));
+  const result = await io.readBytes({
+    range: { length: BigInt(end - start), offset: BigInt(start) },
+    signal,
+    source: await source.assets.resolve(asset.id, { signal }),
+  });
+  throwIfAborted(signal);
+  return result.bytes;
+}
+
+function videoFrame(
   streamId: string,
-): VideoBinding | null {
-  const prefix = `videos/${featureName}/`;
-  const chunk = optionalInteger(episode[`${prefix}chunk_index`]);
-  const file = optionalInteger(episode[`${prefix}file_index`]);
-  const fromSeconds = optionalNumber(episode[`${prefix}from_timestamp`]);
-  const toSeconds = optionalNumber(episode[`${prefix}to_timestamp`]);
+  binding: VideoBinding,
+  index: VideoIndex,
+  sample: Sample,
+  bytes: Uint8Array,
+  parameterSets: { readonly pps?: Uint8Array; readonly sps?: Uint8Array },
+): DecodedFrame | null {
+  if (index.track.timescale <= 0) return null;
+  const presentationSeconds = videoPresentationSeconds(index, sample);
   if (
-    chunk === null ||
-    file === null ||
-    fromSeconds === null ||
-    toSeconds === null
+    presentationSeconds < binding.fromSeconds ||
+    presentationSeconds >= binding.toSeconds
   ) {
     return null;
   }
-  const asset = assets.find(
-    (candidate) =>
-      candidate.role === VIDEO_ROLE &&
-      candidate.metadata?.stream === featureName &&
-      integerMetadata(candidate, "chunkIndex") === chunk &&
-      integerMetadata(candidate, "fileIndex") === file,
+  const timestampNs = secondsToNs(presentationSeconds - binding.fromSeconds);
+  const decodeTimestampNs = secondsToNs(
+    sample.dts / index.track.timescale - binding.fromSeconds,
   );
-  return asset ? { asset, fromSeconds, streamId, toSeconds } : null;
+  const visualization = encodedVideo(
+    index.track.codec,
+    bytes,
+    sample.is_sync,
+    timestampNs,
+    decodeTimestampNs,
+    parameterSets,
+  );
+  const output: DecodedOutput = {
+    resourceHints: {
+      sizeBytes: bytes.byteLength,
+      transferables: [bytes.buffer],
+    },
+    timing: { timeRange: { startNs: timestampNs } },
+    visualization,
+  };
+  return {
+    output,
+    sequence: sample.number,
+    sourceTimestamps: {
+      lerobotShard: secondsToNs(presentationSeconds),
+    },
+    streamId,
+    timestampNs,
+  };
 }
 
-function episodeIndex(source: EpisodeSource): number {
-  const hinted = source.manifestHint?.metadata?.["lerobot.episodeIndex"];
-  const candidate = hinted ?? source.episodeId.match(/(?:^|[^\d])(\d+)$/)?.[1];
-  if (!candidate || !/^\d+$/.test(candidate)) {
-    throw new Error(
-      "LeRobot source needs a numeric episodeId or lerobot.episodeIndex hint",
-    );
+function encodedVideo(
+  codecString: string,
+  bytes: Uint8Array,
+  keyframe: boolean,
+  timestampNs: bigint,
+  decodeTimestampNs: bigint,
+  parameterSets: { readonly pps?: Uint8Array; readonly sps?: Uint8Array },
+): EncodedVideoVisualization {
+  const codec = codecFamily(codecString);
+  if (codec === "h264") {
+    return {
+      bytes,
+      codec,
+      decodeTimestampNs,
+      format: codecString,
+      h264: {
+        codecString,
+        hasFrame: true,
+        ...(keyframe && parameterSets.pps ? { pps: parameterSets.pps } : {}),
+        ...(keyframe && parameterSets.sps ? { sps: parameterSets.sps } : {}),
+      },
+      keyframe,
+      kind: VISUALIZATION_KIND.ENCODED_VIDEO,
+      timestampNs,
+    };
   }
-  const index = Number(candidate);
-  if (!Number.isSafeInteger(index))
-    throw new Error("Invalid LeRobot episode index");
-  return index;
-}
-
-function episodeDuration(
-  episode: Record<string, unknown>,
-  fps: number,
-): { start: number; end: number } {
-  const min = firstNumber(episode["stats/timestamp/min"]) ?? 0;
-  const max =
-    firstNumber(episode["stats/timestamp/max"]) ??
-    Math.max(0, (integer(episode.length, "length") - 1) / fps);
-  return { end: Math.max(min, max), start: min };
-}
-
-function scalarStream(
-  name: string,
-  feature: LeRobotFeature,
-  timeRange: TimeWindow,
-): StreamDescriptor {
+  if (codec === "unknown") {
+    throw new Error(`Unsupported LeRobot video codec '${codecString}'`);
+  }
   return {
-    approxRateHz: undefined,
-    id: streamIdForFeature(name),
-    kind: STREAM_KIND.SCALAR,
-    metadata: {
-      "lerobot.dtype": feature.dtype,
-      "lerobot.names": JSON.stringify(feature.names ?? []),
-      "lerobot.shape": JSON.stringify(feature.shape ?? []),
-    },
-    payload: {
-      encoding: "parquet",
-      schema: `${feature.dtype}${shapeSuffix(feature.shape)}`,
-    },
-    sourceName: name,
-    timeRange,
+    bytes,
+    codec,
+    decodeTimestampNs,
+    format: codecString,
+    keyframe,
+    kind: VISUALIZATION_KIND.ENCODED_VIDEO,
+    timestampNs,
   };
 }
 
-function videoStream(
-  name: string,
-  feature: LeRobotFeature,
-  binding: VideoBinding,
-  timeRange: TimeWindow,
-): StreamDescriptor {
-  const codec = stringValue(feature.info?.["video.codec"]) ?? "unknown";
-  return {
-    approxRateHz: optionalNumber(feature.info?.["video.fps"]) ?? undefined,
-    id: binding.streamId,
-    kind: STREAM_KIND.VIDEO,
-    metadata: {
-      "lerobot.assetId": binding.asset.id,
-      "lerobot.codec": codec,
-    },
-    payload: { encoding: "mp4", schema: codec },
-    sourceName: name,
-    timeRange,
-  };
+function videoPresentationSeconds(index: VideoIndex, sample: Sample) {
+  return sample.cts / index.track.timescale - index.compositionOffsetSeconds;
 }
 
-function isScalarFeature(name: string, feature: LeRobotFeature): boolean {
-  return (
-    ![
-      "timestamp",
-      "frame_index",
-      "episode_index",
-      "index",
-      "task_index",
-    ].includes(name) && /^(?:bool|float|int|uint)/.test(feature.dtype)
-  );
+function mp4SampleToAnnexB(bytes: Uint8Array, lengthSize: number): Uint8Array {
+  const units: Uint8Array[] = [];
+  let offset = 0;
+  let total = 0;
+  while (offset + lengthSize <= bytes.byteLength) {
+    let length = 0;
+    for (let index = 0; index < lengthSize; index += 1) {
+      length = length * 256 + bytes[offset + index];
+    }
+    offset += lengthSize;
+    if (length <= 0 || offset + length > bytes.byteLength) {
+      throw new Error("Malformed H.264 sample in LeRobot MP4 asset");
+    }
+    const unit = bytes.subarray(offset, offset + length);
+    units.push(unit);
+    total += 4 + unit.byteLength;
+    offset += length;
+  }
+  if (offset !== bytes.byteLength || !units.length) {
+    throw new Error("Malformed H.264 access unit in LeRobot MP4 asset");
+  }
+  const output = new Uint8Array(total);
+  offset = 0;
+  for (const unit of units) {
+    output.set([0, 0, 0, 1], offset);
+    offset += 4;
+    output.set(unit, offset);
+    offset += unit.byteLength;
+  }
+  return output;
+}
+
+function avcParameterSets(avc: AvcConfiguration | undefined) {
+  const bytes = (value: ArrayLike<number> | undefined) =>
+    value ? Uint8Array.from(value) : undefined;
+  return {
+    pps: bytes(avc?.PPS?.[0]?.data),
+    sps: bytes(avc?.SPS?.[0]?.data),
+  };
 }
 
 function scalarFrame(
@@ -650,10 +1236,11 @@ function scalarFrame(
   featureName: string,
   feature: LeRobotFeature,
   row: Record<string, unknown>,
+  originSeconds: number,
 ): DecodedFrame | null {
   const seconds = optionalNumber(row.timestamp);
   if (seconds === null) return null;
-  const timestampNs = secondsToNs(seconds);
+  const timestampNs = secondsToNs(seconds - originSeconds);
   const values = numericValues(row[featureName]);
   const names = scalarFieldNames(featureName, feature);
   const scalars = values.flatMap((value, index) =>
@@ -667,169 +1254,273 @@ function scalarFrame(
         ]
       : [],
   );
-  const output: DecodedOutput = {
-    attributes: {
-      frameIndex: optionalBigInt(row.frame_index),
-    },
-    resourceHints: { transferables: [] },
-    scalars,
-    timing: { timeRange: { startNs: timestampNs } },
-  };
   return {
-    output,
+    output: {
+      attributes: { frameIndex: optionalBigInt(row.frame_index) },
+      resourceHints: { transferables: [] },
+      scalars,
+      timing: { timeRange: { startNs: timestampNs } },
+    },
     sequence: optionalInteger(row.frame_index) ?? undefined,
-    sourceTimestamps: { lerobot: timestampNs },
+    sourceTimestamps: { lerobot: secondsToNs(seconds) },
     streamId,
     timestampNs,
   };
 }
 
-function videoFrame(
+function imageFrame(
   streamId: string,
-  binding: VideoBinding,
-  track: Track,
-  sample: Sample,
+  featureName: string,
+  row: Record<string, unknown>,
+  originSeconds: number,
 ): DecodedFrame | null {
-  if (!sample.data || track.timescale <= 0) return null;
-  const shardSeconds = sample.cts / track.timescale;
-  if (shardSeconds < binding.fromSeconds || shardSeconds >= binding.toSeconds) {
-    return null;
-  }
-  const timestampNs = secondsToNs(shardSeconds - binding.fromSeconds);
-  const bytes = new Uint8Array(sample.data);
-  const visualization = encodedVideo(
-    track.codec,
-    bytes,
-    sample.is_sync,
-    timestampNs,
-  );
-  const output: DecodedOutput = {
-    resourceHints: {
-      sizeBytes: bytes.byteLength,
-      transferables: [bytes.buffer],
-    },
-    timing: { timeRange: { startNs: timestampNs } },
-    visualization,
-  };
+  const seconds = optionalNumber(row.timestamp);
+  const sourceBytes = imageBytes(row[featureName]);
+  if (seconds === null || !sourceBytes) return null;
+  const bytes = Uint8Array.from(sourceBytes);
+  const timestampNs = secondsToNs(seconds - originSeconds);
   return {
-    output,
-    sequence: sample.number,
-    sourceTimestamps: { lerobotShard: secondsToNs(shardSeconds) },
+    output: {
+      attributes: { frameIndex: optionalBigInt(row.frame_index) },
+      resourceHints: {
+        sizeBytes: bytes.byteLength,
+        transferables: [bytes.buffer],
+      },
+      timing: { timeRange: { startNs: timestampNs } },
+      visualization: {
+        bytes,
+        kind: VISUALIZATION_KIND.ENCODED_IMAGE,
+        mimeType: sniffImageMimeType(bytes),
+      },
+    },
+    sequence: optionalInteger(row.frame_index) ?? undefined,
+    sourceTimestamps: { lerobot: secondsToNs(seconds) },
     streamId,
     timestampNs,
   };
 }
 
-function videoSampleInWindow(
-  binding: VideoBinding,
-  track: Track,
-  sample: Sample,
-  window: TimeWindow,
-): boolean {
-  if (!sample.data || track.timescale <= 0) return false;
-  const shardSeconds = sample.cts / track.timescale;
-  if (shardSeconds < binding.fromSeconds || shardSeconds >= binding.toSeconds) {
-    return false;
-  }
-  return inWindow(secondsToNs(shardSeconds - binding.fromSeconds), window);
-}
-
-function encodedVideo(
-  codecString: string,
-  bytes: Uint8Array,
-  keyframe: boolean,
-  timestampNs: bigint,
-): EncodedVideoVisualization {
-  const codec = codecFamily(codecString);
-  if (codec === "h264") {
-    return {
-      bytes,
-      codec,
-      format: codecString,
-      h264: { codecString, hasFrame: true },
-      keyframe,
-      kind: VISUALIZATION_KIND.ENCODED_VIDEO,
-      timestampNs,
-    };
-  }
+function scalarStream(
+  name: string,
+  feature: LeRobotFeature,
+  timeRange: TimeWindow,
+  fps: number,
+  count: number,
+): StreamDescriptor {
   return {
-    bytes,
-    codec,
-    format: codecString,
-    keyframe,
-    kind: VISUALIZATION_KIND.ENCODED_VIDEO,
-    timestampNs,
+    approxRateHz: fps,
+    count,
+    id: streamIdForFeature(name),
+    kind: STREAM_KIND.SCALAR,
+    metadata: streamMetadata(feature.dtype, feature.dtype, "decodable"),
+    payload: {
+      encoding: "parquet",
+      schema: `${feature.dtype}${shapeSuffix(feature.shape)}`,
+    },
+    sourceName: name,
+    timeRange,
   };
 }
 
-function codecFamily(codec: string): "av1" | "h264" | "h265" | "vp9" {
-  const normalized = codec.toLowerCase();
-  if (/^(?:av01|av1)/.test(normalized)) return "av1";
-  if (/^(?:hvc1|hev1|h265|hevc)/.test(normalized)) return "h265";
-  if (/^(?:vp09|vp9)/.test(normalized)) return "vp9";
-  if (/^(?:avc1|avc3|h264)/.test(normalized)) return "h264";
-  throw new Error(`Unsupported LeRobot video codec '${codec}'`);
-}
-
-function demuxVideo(bytes: Uint8Array): Promise<DemuxedVideo> {
-  return new Promise((resolve, reject) => {
-    const file = createFile(true);
-    let track: Track | undefined;
-    const samples: Sample[] = [];
-    let settled = false;
-    const fail = (error: unknown) => {
-      if (settled) return;
-      settled = true;
-      reject(toError(error));
-    };
-    file.onError = (error) => fail(new Error(`MP4 demux failed: ${error}`));
-    file.onReady = (info) => {
-      track = info.videoTracks[0];
-      if (!track) {
-        fail(new Error("LeRobot video asset has no video track"));
-        return;
-      }
-      file.setExtractionOptions(track.id, undefined, {
-        nbSamples: Math.max(1, track.nb_samples),
-      });
-      file.start();
-    };
-    file.onSamples = (_id, _user, next) => {
-      if (settled || !track) return;
-      for (const sample of next) samples.push(sample);
-      if (samples.length >= track.nb_samples) {
-        settled = true;
-        file.stop();
-        resolve({ samples, track });
-      }
-    };
-    try {
-      const data = bytes.buffer.slice(
-        bytes.byteOffset,
-        bytes.byteOffset + bytes.byteLength,
-      );
-      file.appendBuffer(MP4BoxBuffer.fromArrayBuffer(data, 0), true);
-      file.flush();
-      queueMicrotask(() => {
-        if (settled) return;
-        if (!track) {
-          fail(new Error("LeRobot video asset has no readable video track"));
-          return;
-        }
-        settled = true;
-        file.stop();
-        resolve({ samples, track });
-      });
-    } catch (error) {
-      fail(error);
-    }
-  });
-}
-
-function scalarFieldNames(
-  featureName: string,
+function imageStream(
+  name: string,
   feature: LeRobotFeature,
-): readonly string[] {
+  timeRange: TimeWindow,
+  fps: number,
+): StreamDescriptor {
+  return {
+    approxRateHz: fps,
+    id: streamIdForFeature(name),
+    kind: STREAM_KIND.IMAGE,
+    metadata: {
+      ...streamMetadata("parquet-image", feature.dtype, "decodable"),
+      [SCENE_SOURCE_METADATA.SOURCE_NAME]: name,
+      [SCENE_SOURCE_METADATA.TYPE]: SCENE_SOURCE_TYPE.IMAGE,
+    },
+    payload: { encoding: "parquet-image", schema: feature.dtype },
+    sourceName: name,
+    timeRange,
+  };
+}
+
+function videoStream(
+  name: string,
+  feature: LeRobotFeature,
+  binding: VideoBinding,
+  timeRange: TimeWindow,
+  fps: number,
+): StreamDescriptor {
+  const codec = videoCodec(feature);
+  const supported = codecFamily(codec) === "h264";
+  return {
+    approxRateHz: optionalNumber(feature.info?.["video.fps"]) ?? fps,
+    id: binding.streamId,
+    kind: STREAM_KIND.VIDEO,
+    metadata: {
+      ...streamMetadata(
+        "mp4",
+        codec,
+        supported ? "decodable" : "unsupported-encoding",
+      ),
+      [SCENE_SOURCE_METADATA.SOURCE_NAME]: name,
+      [SCENE_SOURCE_METADATA.TYPE]: SCENE_SOURCE_TYPE.IMAGE,
+      "lerobot.assetId": binding.asset.id,
+      "lerobot.codec": codec,
+    },
+    payload: { encoding: "mp4", schema: codec },
+    sourceName: name,
+    timeRange,
+  };
+}
+
+function unsupportedStream(
+  name: string,
+  feature: LeRobotFeature,
+  timeRange: TimeWindow,
+): StreamDescriptor {
+  return {
+    id: streamIdForFeature(name),
+    kind: STREAM_KIND.UNKNOWN,
+    metadata: streamMetadata(
+      feature.dtype,
+      feature.dtype,
+      "unsupported-encoding",
+    ),
+    payload: { encoding: feature.dtype, schema: shapeSuffix(feature.shape) },
+    sourceName: name,
+    timeRange,
+  };
+}
+
+function streamMetadata(
+  encoding: string,
+  schema: string,
+  status: "decodable" | "unsupported-encoding",
+) {
+  return {
+    [STREAM_METADATA.DECODE_STATUS]: status,
+    [STREAM_METADATA.ENCODING]: encoding,
+    [STREAM_METADATA.SCHEMA_NAME]: schema,
+  };
+}
+
+function episodeTimeRange(
+  episodeRows: EpisodeRows,
+  assets: readonly AssetDescriptor[],
+): TimeWindow {
+  const rowEnd = episodeRows.rows.at(-1)?.localTimeNs ?? 0n;
+  const videoEnd = assets.reduce((end, asset) => {
+    const selector = asset.selector;
+    return selector?.kind === "video-timestamp-interval"
+      ? Math.max(end, selector.toTimestamp - selector.fromTimestamp)
+      : end;
+  }, 0);
+  return { endNs: maxBigInt(rowEnd, secondsToNs(videoEnd)), startNs: 0n };
+}
+
+function requireSingleRole(
+  assets: readonly AssetDescriptor[],
+  role: string,
+): AssetDescriptor {
+  const matches = assets.filter((asset) => asset.role === role);
+  if (matches.length !== 1) {
+    throw new Error(`LeRobot source requires exactly one '${role}' asset`);
+  }
+  return matches[0];
+}
+
+function findFeatureAsset(
+  assets: readonly AssetDescriptor[],
+  role: string,
+  featureName: string,
+) {
+  return assets.find(
+    (asset) => asset.role === role && asset.featureName === featureName,
+  );
+}
+
+function requireRowInterval(asset: AssetDescriptor) {
+  const selector = asset.selector;
+  if (
+    selector?.kind !== "row-interval" ||
+    selector.coordinateSystem !== "parquet-file-row" ||
+    !Number.isSafeInteger(selector.start) ||
+    !Number.isSafeInteger(selector.end) ||
+    selector.start < 0 ||
+    selector.start >= selector.end
+  ) {
+    throw new Error(
+      `LeRobot asset '${asset.id}' needs a valid parquet-file-row selector`,
+    );
+  }
+  return selector;
+}
+
+function isRenderableCameraStream(stream: StreamDescriptor) {
+  return (
+    stream.metadata?.[SCENE_SOURCE_METADATA.TYPE] === SCENE_SOURCE_TYPE.IMAGE &&
+    stream.metadata?.[STREAM_METADATA.DECODE_STATUS] === "decodable"
+  );
+}
+
+function comparePreviewStreams(
+  left: StreamDescriptor,
+  right: StreamDescriptor,
+) {
+  const preference = (stream: StreamDescriptor) =>
+    /(?:^|[._/-])(primary|front)(?:$|[._/-])/i.test(stream.sourceName) ? 0 : 1;
+  return (
+    preference(left) - preference(right) ||
+    left.sourceName.localeCompare(right.sourceName)
+  );
+}
+
+function posterFrame(frame: DecodedFrame): EpisodePosterFrame | null {
+  const visualization = frame.output.visualization;
+  if (
+    visualization?.kind === VISUALIZATION_KIND.ENCODED_IMAGE ||
+    visualization?.kind === VISUALIZATION_KIND.RAW_IMAGE ||
+    visualization?.kind === VISUALIZATION_KIND.ENCODED_VIDEO
+  ) {
+    return { image: visualization, kind: "image" };
+  }
+  return null;
+}
+
+function firstFrameAtOrAfter(
+  frames: readonly DecodedFrame[],
+  timestampNs: bigint,
+) {
+  return (
+    frames
+      .filter((frame) => frame.timestampNs >= timestampNs)
+      .sort((left, right) =>
+        left.timestampNs < right.timestampNs
+          ? -1
+          : left.timestampNs > right.timestampNs
+            ? 1
+            : 0,
+      )[0] ?? frames[0]
+  );
+}
+
+function isNumericFeature(name: string, feature: LeRobotFeature) {
+  return (
+    !isStandardField(name) && /^(?:bool|float|int|uint)/.test(feature.dtype)
+  );
+}
+
+function isStandardField(name: string) {
+  return [
+    "timestamp",
+    "frame_index",
+    "episode_index",
+    "index",
+    "task_index",
+  ].includes(name);
+}
+
+function scalarFieldNames(featureName: string, feature: LeRobotFeature) {
   const count = Math.max(1, numericElementCount(feature.shape));
   return Array.from({ length: count }, (_, index) => {
     const name = feature.names?.[index];
@@ -841,43 +1532,131 @@ function scalarFieldNames(
   });
 }
 
-function numericElementCount(shape: readonly number[] | undefined): number {
+function numericElementCount(shape: readonly number[] | undefined) {
   return (shape ?? []).reduce((product, value) => product * value, 1);
 }
 
 function numericValues(value: unknown): readonly number[] {
+  if (typeof value === "boolean") return [value ? 1 : 0];
   if (typeof value === "number") return [value];
   if (!Array.isArray(value)) return [];
   return value
     .flat(Infinity)
-    .filter((entry): entry is number => typeof entry === "number");
+    .map((entry) =>
+      typeof entry === "boolean" ? (entry ? 1 : 0) : optionalNumber(entry),
+    )
+    .filter((entry): entry is number => entry !== null);
 }
 
-function streamIdForFeature(feature: string): string {
+function imageBytes(value: unknown): Uint8Array | null {
+  if (value instanceof Uint8Array) return value;
+  if (value instanceof ArrayBuffer) return new Uint8Array(value);
+  if (value && typeof value === "object" && "bytes" in value) {
+    return imageBytes((value as { readonly bytes?: unknown }).bytes);
+  }
+  return null;
+}
+
+function sniffImageMimeType(bytes: Uint8Array) {
+  if (bytes[0] === 0xff && bytes[1] === 0xd8) return "image/jpeg";
+  if (
+    bytes[0] === 0x89 &&
+    bytes[1] === 0x50 &&
+    bytes[2] === 0x4e &&
+    bytes[3] === 0x47
+  ) {
+    return "image/png";
+  }
+  if (
+    String.fromCharCode(...bytes.subarray(0, 4)) === "RIFF" &&
+    String.fromCharCode(...bytes.subarray(8, 12)) === "WEBP"
+  ) {
+    return "image/webp";
+  }
+  return undefined;
+}
+
+function videoCodec(feature: LeRobotFeature) {
+  return stringValue(feature.info?.["video.codec"]) ?? "unknown";
+}
+
+function codecFamily(
+  codec: string,
+): "av1" | "h264" | "h265" | "unknown" | "vp9" {
+  const normalized = codec.toLowerCase();
+  if (/^(?:av01|av1)/.test(normalized)) return "av1";
+  if (/^(?:hvc1|hev1|h265|hevc)/.test(normalized)) return "h265";
+  if (/^(?:vp09|vp9)/.test(normalized)) return "vp9";
+  if (/^(?:avc1|avc3|h264)/.test(normalized)) return "h264";
+  return "unknown";
+}
+
+function streamIdForFeature(feature: string) {
   return `lerobot:${feature}`;
 }
 
-function featureNameForStream(stream: string): string {
+function featureNameForStream(stream: string) {
   return stream.startsWith("lerobot:")
     ? stream.slice("lerobot:".length)
     : stream;
 }
 
-function shapeSuffix(shape: readonly number[] | undefined): string {
-  return shape && shape.length > 0 ? `[${shape.join(",")}]` : "";
+function shapeSuffix(shape: readonly number[] | undefined) {
+  return shape?.length ? `[${shape.join(",")}]` : "";
 }
 
-function inWindow(timestampNs: bigint, window: TimeWindow): boolean {
+function sampledIndexes(length: number, maxPoints: number | undefined) {
+  if (!maxPoints || maxPoints <= 0 || length <= maxPoints) {
+    return Array.from({ length }, (_, index) => index);
+  }
+  if (maxPoints === 1) return [0];
+  return Array.from({ length: maxPoints }, (_, index) =>
+    Math.round((index * (length - 1)) / (maxPoints - 1)),
+  );
+}
+
+function inWindow(timestampNs: bigint, window: TimeWindow) {
   return timestampNs >= window.startNs && timestampNs <= window.endNs;
 }
 
-function secondsToNs(seconds: number): bigint {
+function rowRangeForWindow(
+  rows: readonly TimelineRow[],
+  window: TimeWindow,
+): { readonly end: number; readonly start: number } | null {
+  let low = 0;
+  let high = rows.length;
+  while (low < high) {
+    const middle = (low + high) >>> 1;
+    if (rows[middle].localTimeNs < window.startNs) low = middle + 1;
+    else high = middle;
+  }
+  const start = low;
+  high = rows.length;
+  while (low < high) {
+    const middle = (low + high) >>> 1;
+    if (rows[middle].localTimeNs <= window.endNs) low = middle + 1;
+    else high = middle;
+  }
+  return start < low ? { end: low, start } : null;
+}
+
+function secondsToNs(seconds: number) {
   if (!Number.isFinite(seconds)) throw new Error("Invalid LeRobot timestamp");
   return BigInt(Math.round(seconds * NS_PER_SECOND));
 }
 
-function integer(value: unknown, field: string): number {
+function nsToSeconds(timestampNs: bigint) {
+  return Number(timestampNs) / NS_PER_SECOND;
+}
+
+function integer(value: unknown, field: string) {
   const parsed = optionalInteger(value);
+  if (parsed === null) throw new Error(`Invalid LeRobot ${field}`);
+  return parsed;
+}
+
+function number(value: unknown, field: string) {
+  const parsed = optionalNumber(value);
   if (parsed === null) throw new Error(`Invalid LeRobot ${field}`);
   return parsed;
 }
@@ -900,15 +1679,219 @@ function optionalBigInt(value: unknown): bigint | null {
 }
 
 function optionalNumber(value: unknown): number | null {
+  if (typeof value === "bigint") {
+    const parsed = Number(value);
+    return Number.isSafeInteger(parsed) ? parsed : null;
+  }
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
-function firstNumber(value: unknown): number | null {
-  return Array.isArray(value)
-    ? optionalNumber(value[0])
-    : optionalNumber(value);
+function stringValue(value: unknown) {
+  return typeof value === "string" && value.length ? value : null;
 }
 
-function stringValue(value: unknown): string | null {
-  return typeof value === "string" && value.length > 0 ? value : null;
+function safeByteLength(value: string | undefined) {
+  if (!value || !/^\d+$/.test(value)) return null;
+  const size = Number(value);
+  return Number.isSafeInteger(size) && size >= 0 ? size : null;
+}
+
+function exactArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  return bytes.buffer.slice(
+    bytes.byteOffset,
+    bytes.byteOffset + bytes.byteLength,
+  ) as ArrayBuffer;
+}
+
+function maxBigInt(left: bigint, right: bigint) {
+  return left > right ? left : right;
+}
+
+function minBigInt(left: bigint, right: bigint) {
+  return left < right ? left : right;
+}
+
+function rawCursor(rowOffset: number) {
+  return `row:${rowOffset}`;
+}
+
+function parseRawCursor(cursor: string, rowCount: number) {
+  const match = /^row:(\d+)$/.exec(cursor);
+  const value = match ? Number(match[1]) : Number.NaN;
+  if (!Number.isSafeInteger(value) || value < 0 || value >= rowCount) {
+    throw new Error("Invalid LeRobot raw-record cursor");
+  }
+  return value;
+}
+
+function requireRawStream(stream: string) {
+  if (stream !== RAW_STREAM_ID) {
+    throw new Error(`Unknown LeRobot raw-record stream '${stream}'`);
+  }
+}
+
+function rowAtOrBefore(rows: readonly TimelineRow[], timestampNs: bigint) {
+  if (!rows.length) return null;
+  if (timestampNs < rows[0].localTimeNs) return null;
+  let low = 0;
+  let high = rows.length;
+  while (low < high) {
+    const middle = (low + high) >>> 1;
+    if (rows[middle].localTimeNs <= timestampNs) low = middle + 1;
+    else high = middle;
+  }
+  return Math.max(0, low - 1);
+}
+
+function emptyRawRecord(timeRange: TimeWindow): RawRecordResult {
+  return {
+    encoding: "parquet",
+    schemaName: "LeRobotDataset v3 row",
+    sourceName: "Episode rows",
+    status: "empty",
+    streamId: RAW_STREAM_ID,
+    validFromNs: timeRange.startNs,
+    validUntilNs: timeRange.endNs,
+  };
+}
+
+interface PruneState {
+  readonly budgets: Required<RawRecordPruneBudgets>;
+  nodes: number;
+  truncated: boolean;
+}
+
+function pruneRawRecord(
+  record: Record<string, unknown>,
+  requested: RawRecordPruneBudgets = {},
+) {
+  const state: PruneState = {
+    budgets: {
+      maxArrayLength: requested.maxArrayLength ?? 64,
+      maxDepth: requested.maxDepth ?? 6,
+      maxStringLength: requested.maxStringLength ?? 1_000,
+      maxTotalNodes: requested.maxTotalNodes ?? 2_000,
+    },
+    nodes: 0,
+    truncated: false,
+  };
+  const root = pruneObject(record, 0, state);
+  return { root, truncated: state.truncated };
+}
+
+function pruneValue(
+  value: unknown,
+  depth: number,
+  state: PruneState,
+): RawValueNode {
+  if (state.nodes >= state.budgets.maxTotalNodes) {
+    state.truncated = true;
+    return { kind: "truncated", reason: "nodes" };
+  }
+  state.nodes += 1;
+  if (depth > state.budgets.maxDepth) {
+    state.truncated = true;
+    return { kind: "truncated", reason: "depth" };
+  }
+  const bytes = imageBytes(value);
+  if (bytes) {
+    return {
+      byteLength: bytes.byteLength,
+      kind: "bytes",
+      preview: [...bytes.subarray(0, 16)]
+        .map((byte) => byte.toString(16).padStart(2, "0"))
+        .join(" "),
+    };
+  }
+  if (Array.isArray(value)) {
+    const count = Math.min(value.length, state.budgets.maxArrayLength);
+    if (count < value.length) state.truncated = true;
+    return {
+      items: value
+        .slice(0, count)
+        .map((item) => pruneValue(item, depth + 1, state)),
+      kind: "array",
+      totalLength: value.length,
+    };
+  }
+  if (value && typeof value === "object") {
+    return pruneObject(value as Record<string, unknown>, depth, state);
+  }
+  if (typeof value === "string") {
+    const truncated = value.length > state.budgets.maxStringLength;
+    if (truncated) state.truncated = true;
+    return {
+      kind: "scalar",
+      truncated,
+      value: value.slice(0, state.budgets.maxStringLength),
+      valueType: "string",
+    };
+  }
+  const valueType =
+    value === null
+      ? "null"
+      : value === undefined
+        ? "undefined"
+        : typeof value === "bigint"
+          ? "bigint"
+          : typeof value === "boolean"
+            ? "boolean"
+            : "number";
+  return { kind: "scalar", value: String(value), valueType };
+}
+
+function pruneObject(
+  record: Record<string, unknown>,
+  depth: number,
+  state: PruneState,
+): RawObjectNode {
+  const entries: (readonly [string, RawValueNode])[] = [];
+  const sourceEntries = Object.entries(record);
+  for (const [key, value] of sourceEntries) {
+    if (state.nodes >= state.budgets.maxTotalNodes) {
+      state.truncated = true;
+      break;
+    }
+    entries.push([key, pruneValue(value, depth + 1, state)]);
+  }
+  return {
+    ...(entries.length < sourceEntries.length
+      ? { droppedEntries: sourceEntries.length - entries.length }
+      : {}),
+    entries,
+    kind: "object",
+  };
+}
+
+function boundedJson(
+  value: Record<string, unknown>,
+  prune: RawRecordPruneBudgets | undefined,
+) {
+  return JSON.stringify(
+    rawNodeToJson(pruneRawRecord(value, prune).root),
+    null,
+    2,
+  );
+}
+
+function rawNodeToJson(node: RawValueNode): unknown {
+  switch (node.kind) {
+    case "scalar":
+      if (node.valueType === "number") return Number(node.value);
+      if (node.valueType === "boolean") return node.value === "true";
+      if (node.valueType === "null" || node.valueType === "undefined") {
+        return null;
+      }
+      return node.truncated ? `${node.value}…` : node.value;
+    case "bytes":
+      return `<${node.byteLength} bytes: ${node.preview}>`;
+    case "array":
+      return node.items.map(rawNodeToJson);
+    case "object":
+      return Object.fromEntries(
+        node.entries.map(([key, value]) => [key, rawNodeToJson(value)]),
+      );
+    case "truncated":
+      return "…";
+  }
 }

--- a/app/packages/multimodal/src/adapters/lerobot/format-adapter.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/format-adapter.ts
@@ -315,7 +315,7 @@ class LeRobotEpisodePreviewSession implements EpisodePreviewSession {
         ])
       : frameDurationNs;
     let frames: readonly DecodedFrame[] = [];
-    if (isSharedDecoderCameraStream(selected)) {
+    if (isGridFrameDecoderCameraStream(selected)) {
       for await (const batch of this.session.read({
         priority: options.priority,
         signal: options.signal,
@@ -657,8 +657,15 @@ class LeRobotEpisodeSession implements EpisodeSession {
     binding: VideoBinding,
     request: ReadRequest,
   ) {
-    if (codecFamily(videoCodec(binding.feature)) !== "h264") return [];
+    const declaredCodec = codecFamily(videoCodec(binding.feature));
+    if (declaredCodec !== "h264" && declaredCodec !== "av1") return [];
     const index = await this.readVideoIndex(binding, request.signal);
+    const containerCodec = codecFamily(index.track.codec);
+    if (containerCodec !== declaredCodec) {
+      throw new Error(
+        `LeRobot video codec mismatch: manifest '${videoCodec(binding.feature)}', MP4 '${index.track.codec}'`,
+      );
+    }
     const samples = selectVideoSamples(index, binding, request.window);
     if (!samples.length) return [];
     const bytes = await this.readSampleSpan(
@@ -666,7 +673,10 @@ class LeRobotEpisodeSession implements EpisodeSession {
       samples,
       request.signal,
     );
-    const avc = (samples[0].description as Mp4SampleDescription).avcC;
+    const avc =
+      declaredCodec === "h264"
+        ? (samples[0].description as Mp4SampleDescription).avcC
+        : undefined;
     const lengthSize = (avc?.lengthSizeMinusOne ?? 3) + 1;
     const parameterSets = avcParameterSets(avc);
     return samples
@@ -677,10 +687,12 @@ class LeRobotEpisodeSession implements EpisodeSession {
           binding,
           index,
           sample,
-          mp4SampleToAnnexB(
-            bytes.subarray(offset, offset + sample.size),
-            lengthSize,
-          ),
+          declaredCodec === "h264"
+            ? mp4SampleToAnnexB(
+                bytes.subarray(offset, offset + sample.size),
+                lengthSize,
+              )
+            : bytes.slice(offset, offset + sample.size),
           parameterSets,
         );
       })
@@ -1610,9 +1622,13 @@ async function parseVideoIndex(
     throw new Error("LeRobot video asset has no readable video track");
   const samples = file.getTrackSamplesInfo(videoTrack.id);
   if (!samples.length) throw new Error("LeRobot video track has no samples");
-  const compositionOffsetSeconds = Math.min(
-    ...samples.map((sample) => sample.cts / videoTrack.timescale),
-  );
+  let compositionOffsetSeconds = Number.POSITIVE_INFINITY;
+  for (const sample of samples) {
+    compositionOffsetSeconds = Math.min(
+      compositionOffsetSeconds,
+      sample.cts / videoTrack.timescale,
+    );
+  }
   const presentationSamples = samples
     .map((sample, decodeIndex) => ({
       decodeIndex,
@@ -2001,7 +2017,8 @@ function videoStream(
   fps: number,
 ): StreamDescriptor {
   const codec = videoCodec(feature);
-  const supported = codecFamily(codec) === "h264";
+  const family = codecFamily(codec);
+  const supported = family === "h264" || family === "av1";
   return {
     approxRateHz: optionalNumber(feature.info?.["video.fps"]) ?? fps,
     id: binding.streamId,
@@ -2106,20 +2123,22 @@ function requireRowInterval(asset: AssetDescriptor) {
   return selector;
 }
 
-function isSharedDecoderCameraStream(stream: StreamDescriptor) {
+function isGridFrameDecoderCameraStream(stream: StreamDescriptor) {
   return (
     stream.metadata?.[SCENE_SOURCE_METADATA.TYPE] === SCENE_SOURCE_TYPE.IMAGE &&
-    stream.metadata?.[STREAM_METADATA.DECODE_STATUS] === "decodable"
+    stream.metadata?.[STREAM_METADATA.DECODE_STATUS] === "decodable" &&
+    (stream.kind !== STREAM_KIND.VIDEO ||
+      codecFamily(stream.metadata?.["lerobot.codec"] ?? "") === "h264")
   );
 }
 
 /**
- * Grid previews may use a browser-native video even before its codec is
- * implemented by the shared synchronized decoder. Keep that capability local
- * to preview selection so modal inventories remain truthful.
+ * The AV1 grid path deliberately stays browser-native even though the shared
+ * synchronized decoder supports AV1 in the modal. Keep that policy local to
+ * previews so grid reads do not start a redundant WebCodecs pipeline.
  */
 function isPreviewableCameraStream(stream: StreamDescriptor) {
-  if (isSharedDecoderCameraStream(stream)) return true;
+  if (isGridFrameDecoderCameraStream(stream)) return true;
   return (
     stream.kind === STREAM_KIND.VIDEO &&
     stream.metadata?.[SCENE_SOURCE_METADATA.TYPE] === SCENE_SOURCE_TYPE.IMAGE &&

--- a/app/packages/multimodal/src/adapters/lerobot/format-adapter.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/format-adapter.ts
@@ -49,11 +49,16 @@ import {
   type SynchronizedPlaybackBatchReadRequest,
   type SynchronizedPlaybackReadOptions,
   type StateActionCapability,
+  type StateActionDimensionExtreme,
+  type StateActionEpisodeProfile,
+  type StateActionFeatureProfile,
   type StateActionFeatureSchema,
   type StateActionFeatureStats,
   type StateActionRow,
   type StateActionSchema,
   type StateActionStats,
+  type StateActionTimingGap,
+  type StateActionTimingProfile,
   type SynchronizedPlaybackReadRequest,
   type SourceStats,
 } from "../../ports";
@@ -407,6 +412,7 @@ class LeRobotEpisodeSession implements EpisodeSession {
     number,
     Promise<readonly Record<string, unknown>[]>
   >();
+  private stateActionProfile: Promise<StateActionEpisodeProfile> | null = null;
   private stateActionStats: Promise<StateActionStats | null> | null = null;
   private stateActionTasks: Promise<ReadonlyMap<number, string> | null> | null =
     null;
@@ -532,6 +538,7 @@ class LeRobotEpisodeSession implements EpisodeSession {
     this.generation += 1;
     this.rowCache.clear();
     this.stateActionBlocks.clear();
+    this.stateActionProfile = null;
     this.stateActionStats = null;
     this.stateActionTasks = null;
     this.videoIndexCache.clear();
@@ -1288,6 +1295,17 @@ class LeRobotEpisodeSession implements EpisodeSession {
         this.ensureOpen();
         return stats;
       },
+      readEpisodeProfile: async (options) => {
+        this.ensureOpen();
+        throwIfAborted(options?.signal);
+        const profile = await waitForSharedRead(
+          this.stateActionProfileFill(config, schema),
+          options?.signal,
+        );
+        throwIfAborted(options?.signal);
+        this.ensureOpen();
+        return profile;
+      },
       readIndexWindow: async (request) => {
         this.ensureOpen();
         throwIfAborted(request.signal);
@@ -1415,6 +1433,98 @@ class LeRobotEpisodeSession implements EpisodeSession {
         : Promise.resolve(null);
     }
     return this.stateActionStats;
+  }
+
+  private stateActionProfileFill(
+    config: StateActionReadConfig,
+    schema: StateActionSchema,
+  ) {
+    if (!this.stateActionProfile) {
+      // The shared profile fill is deliberately unbound from caller signals
+      // so an aborted trigger cannot poison the session-lifetime cache.
+      const started = this.computeStateActionProfile(config, schema);
+      this.stateActionProfile = started;
+      void started.catch(() => {
+        if (this.stateActionProfile === started) {
+          this.stateActionProfile = null;
+        }
+      });
+    }
+    return this.stateActionProfile;
+  }
+
+  private async computeStateActionProfile(
+    config: StateActionReadConfig,
+    schema: StateActionSchema,
+  ): Promise<StateActionEpisodeProfile> {
+    const rows = this.state.episodeRows.rows;
+    // Declared statistics only bound the out-of-range counts; their
+    // absence must never block the episode-computed profile.
+    const declared = await this.stateActionStatsFill(
+      config.state,
+      config.action,
+    );
+    const state = schema.state
+      ? createStateActionAggregator(
+          schema.state.dimensions.length,
+          declared?.state,
+        )
+      : null;
+    const action = schema.action
+      ? createStateActionAggregator(
+          schema.action.dimensions.length,
+          declared?.action,
+        )
+      : null;
+    const tracking =
+      schema.state &&
+      schema.action &&
+      schema.state.dimensions.length === schema.action.dimensions.length
+        ? createStateActionTrackingAggregator(schema.state.dimensions.length)
+        : null;
+    const blockCount = Math.ceil(rows.length / config.blockRows);
+    for (let blockIndex = 0; blockIndex < blockCount; blockIndex += 1) {
+      const block = await this.stateActionBlock(blockIndex, config);
+      this.ensureOpen();
+      for (let inBlock = 0; inBlock < block.length; inBlock += 1) {
+        const timeline = rows[blockIndex * config.blockRows + inBlock];
+        if (!timeline) continue;
+        const raw = block[inBlock];
+        const stateValues =
+          config.state && raw[STATE_FEATURE_NAME] !== undefined
+            ? flattenStateActionSource(raw[STATE_FEATURE_NAME])
+            : undefined;
+        const actionValues =
+          config.action && raw[ACTION_FEATURE_NAME] !== undefined
+            ? flattenStateActionSource(raw[ACTION_FEATURE_NAME])
+            : undefined;
+        if (stateValues) {
+          state?.accumulate(
+            stateValues,
+            timeline.frameIndex,
+            timeline.localTimeNs,
+          );
+        }
+        if (actionValues) {
+          action?.accumulate(
+            actionValues,
+            timeline.frameIndex,
+            timeline.localTimeNs,
+          );
+        }
+        if (stateValues && actionValues) {
+          tracking?.accumulate(stateValues, actionValues);
+        }
+      }
+    }
+    const trackingError = tracking?.finish();
+    return {
+      ...(action ? { action: action.finish() } : {}),
+      rowCount: rows.length,
+      ...(state ? { state: state.finish() } : {}),
+      timing: stateActionTimingProfile(rows),
+      ...(trackingError ? { trackingError } : {}),
+    };
   }
 
   private stateActionTaskLabels() {
@@ -2609,6 +2719,149 @@ function stateActionDtypeBytes(dtype: string): number {
   if (/16/.test(dtype)) return 2;
   if (/^(?:bool|int8|uint8)/.test(dtype)) return 1;
   return 8;
+}
+
+/** Largest-first gap samples kept on a timing profile. */
+const STATE_ACTION_TIMING_GAP_CAP = 8;
+
+function createStateActionAggregator(
+  dimensionCount: number,
+  declared: StateActionFeatureStats | undefined,
+): {
+  accumulate(
+    values: readonly unknown[],
+    frameIndex: number,
+    timestampNs: bigint,
+  ): void;
+  finish(): StateActionFeatureProfile;
+} {
+  const min: (StateActionDimensionExtreme | null)[] = Array.from(
+    { length: dimensionCount },
+    () => null,
+  );
+  const max: (StateActionDimensionExtreme | null)[] = Array.from(
+    { length: dimensionCount },
+    () => null,
+  );
+  const sums = new Array<number>(dimensionCount).fill(0);
+  const counts = new Array<number>(dimensionCount).fill(0);
+  const outOfRange = declared
+    ? new Array<number>(dimensionCount).fill(0)
+    : null;
+  const declaredBound = (index: number) => {
+    const low = declared?.min?.[index];
+    const high = declared?.max?.[index];
+    return Number.isFinite(low) && Number.isFinite(high)
+      ? { high: high as number, low: low as number }
+      : null;
+  };
+  const bounds = Array.from({ length: dimensionCount }, (_, index) =>
+    declaredBound(index),
+  );
+  return {
+    accumulate(values, frameIndex, timestampNs) {
+      for (let index = 0; index < dimensionCount; index += 1) {
+        const value = values[index];
+        if (typeof value !== "number" || !Number.isFinite(value)) continue;
+        sums[index] += value;
+        counts[index] += 1;
+        const currentMin = min[index];
+        if (currentMin === null || value < currentMin.value) {
+          min[index] = { frameIndex, timestampNs, value };
+        }
+        const currentMax = max[index];
+        if (currentMax === null || value > currentMax.value) {
+          max[index] = { frameIndex, timestampNs, value };
+        }
+        const bound = bounds[index];
+        if (outOfRange && bound && (value < bound.low || value > bound.high)) {
+          outOfRange[index] += 1;
+        }
+      }
+    },
+    finish() {
+      return {
+        max,
+        mean: counts.map((count, index) =>
+          count > 0 ? sums[index] / count : null,
+        ),
+        min,
+        outOfRangeCounts: outOfRange
+          ? outOfRange.map((count, index) =>
+              bounds[index] !== null ? count : null,
+            )
+          : null,
+      };
+    },
+  };
+}
+
+function createStateActionTrackingAggregator(dimensionCount: number): {
+  accumulate(state: readonly unknown[], action: readonly unknown[]): void;
+  finish(): readonly (number | null)[];
+} {
+  const sums = new Array<number>(dimensionCount).fill(0);
+  const counts = new Array<number>(dimensionCount).fill(0);
+  return {
+    accumulate(state, action) {
+      for (let index = 0; index < dimensionCount; index += 1) {
+        const stateValue = state[index];
+        const actionValue = action[index];
+        if (
+          typeof stateValue !== "number" ||
+          !Number.isFinite(stateValue) ||
+          typeof actionValue !== "number" ||
+          !Number.isFinite(actionValue)
+        ) {
+          continue;
+        }
+        sums[index] += Math.abs(actionValue - stateValue);
+        counts[index] += 1;
+      }
+    },
+    finish() {
+      return counts.map((count, index) =>
+        count > 0 ? sums[index] / count : null,
+      );
+    },
+  };
+}
+
+/**
+ * Recorded-cadence facts from the already-loaded timeline rows: median
+ * inter-row interval plus the intervals exceeding 1.5× that median, so a
+ * single dropped frame at a steady rate registers while jitter does not.
+ */
+function stateActionTimingProfile(
+  rows: readonly TimelineRow[],
+): StateActionTimingProfile {
+  if (rows.length < 2) {
+    return { gapCount: 0, gaps: [], medianIntervalNs: 0n };
+  }
+  const intervals = rows.slice(1).map((row, index) => ({
+    beforeFrameIndex: rows[index].frameIndex,
+    durationNs: row.localTimeNs - rows[index].localTimeNs,
+    timestampNs: row.localTimeNs,
+  }));
+  const sorted = intervals
+    .map((interval) => interval.durationNs)
+    .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+  const medianIntervalNs =
+    (sorted[(sorted.length - 1) >> 1] + sorted[sorted.length >> 1]) / 2n;
+  const gaps: StateActionTimingGap[] = intervals
+    .filter(
+      (interval) =>
+        medianIntervalNs > 0n &&
+        interval.durationNs * 2n > medianIntervalNs * 3n,
+    )
+    .sort((a, b) =>
+      a.durationNs < b.durationNs ? 1 : a.durationNs > b.durationNs ? -1 : 0,
+    );
+  return {
+    gapCount: gaps.length,
+    gaps: gaps.slice(0, STATE_ACTION_TIMING_GAP_CAP),
+    medianIntervalNs,
+  };
 }
 
 function parseStateActionCursor(cursor: string, rowCount: number): number {

--- a/app/packages/multimodal/src/adapters/lerobot/format-adapter.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/format-adapter.ts
@@ -1010,31 +1010,32 @@ class LeRobotEpisodeSession implements EpisodeSession {
         (frame): frame is DecodedFrame =>
           frame !== null && inWindow(frame.timestampNs, request.window),
       );
-    const selected = sampledIndexes(
-      frames.length,
-      request.maxPointsPerField,
-    ).map((index) => frames[index]);
     const baseTimeNs = this.manifest.timeRange.startNs;
+    const timesSec = frames.map((frame) =>
+      nsDeltaToSeconds(frame.timestampNs - baseTimeNs),
+    );
+    let truncated = false;
     return {
       baseTimeNs,
-      fields: request.fields.map((path) => ({
-        path,
-        timesSec: Float64Array.from(
-          selected.map((frame) =>
-            nsDeltaToSeconds(frame.timestampNs - baseTimeNs),
-          ),
-        ),
-        values: Float64Array.from(
-          selected.map(
-            (frame) =>
-              frame.output.scalars?.find((scalar) => scalar.field === path)
-                ?.value ?? Number.NaN,
-          ),
-        ),
-      })),
+      // Decimation is per field: each signal keeps its own extremes, so a
+      // budgeted read never aliases one field's spikes away to fit another.
+      fields: request.fields.map((path) => {
+        const values = frames.map(
+          (frame) =>
+            frame.output.scalars?.find((scalar) => scalar.field === path)
+              ?.value ?? Number.NaN,
+        );
+        const picked = minMaxSampledIndexes(values, request.maxPointsPerField);
+        truncated ||= picked.length < values.length;
+        return {
+          path,
+          timesSec: Float64Array.from(picked.map((index) => timesSec[index])),
+          values: Float64Array.from(picked.map((index) => values[index])),
+        };
+      }),
       sampleCount: frames.length,
       streamId: request.stream,
-      truncated: selected.length < frames.length,
+      truncated,
     };
   }
 
@@ -2246,14 +2247,47 @@ function shapeSuffix(shape: readonly number[] | undefined) {
   return shape?.length ? `[${shape.join(",")}]` : "";
 }
 
-function sampledIndexes(length: number, maxPoints: number | undefined) {
+/**
+ * Peak-preserving decimation: every bucket keeps its extreme samples in
+ * time order, so a budgeted series never aliases spikes away the way a
+ * uniform stride does. An all-gap bucket keeps one sample so decoded gap
+ * markers stay visible.
+ */
+function minMaxSampledIndexes(
+  values: readonly number[],
+  maxPoints: number | undefined,
+): readonly number[] {
+  const length = values.length;
   if (!maxPoints || maxPoints <= 0 || length <= maxPoints) {
     return Array.from({ length }, (_, index) => index);
   }
   if (maxPoints === 1) return [0];
-  return Array.from({ length: maxPoints }, (_, index) =>
-    Math.round((index * (length - 1)) / (maxPoints - 1)),
-  );
+  const buckets = Math.max(1, Math.floor(maxPoints / 2));
+  const picked: number[] = [];
+  for (let bucket = 0; bucket < buckets; bucket += 1) {
+    const start = Math.floor((bucket * length) / buckets);
+    const end = Math.max(
+      start + 1,
+      Math.floor(((bucket + 1) * length) / buckets),
+    );
+    let minIndex = -1;
+    let maxIndex = -1;
+    for (let index = start; index < end && index < length; index += 1) {
+      const value = values[index];
+      if (!Number.isFinite(value)) continue;
+      if (minIndex < 0 || value < values[minIndex]) minIndex = index;
+      if (maxIndex < 0 || value > values[maxIndex]) maxIndex = index;
+    }
+    if (minIndex < 0) {
+      picked.push(start);
+      continue;
+    }
+    const first = Math.min(minIndex, maxIndex);
+    const second = Math.max(minIndex, maxIndex);
+    picked.push(first);
+    if (second !== first) picked.push(second);
+  }
+  return picked;
 }
 
 function inWindow(timestampNs: bigint, window: TimeWindow) {

--- a/app/packages/multimodal/src/adapters/lerobot/format-adapter.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/format-adapter.ts
@@ -25,6 +25,7 @@ import {
   type RawRecordResult,
   type RawValueNode,
   type StreamDescriptor,
+  type SynchronizedFrameWindow,
   type TimeWindow,
 } from "../../ir";
 import {
@@ -40,11 +41,27 @@ import {
   type FormatAdapter,
   type FrameBatch,
   type NumericSeriesCapability,
+  type PlaybackReadCapability,
   type RawRecordCapability,
   type ReadRequest,
+  type SynchronizedPlaybackBatchReadRequest,
+  type SynchronizedPlaybackReadOptions,
+  type SynchronizedPlaybackReadRequest,
   type SourceStats,
 } from "../../ports";
+import {
+  emptyPlaybackWindow,
+  prioritizedStreams,
+  resolvePlaybackWindow,
+  selectPlaybackWindow,
+  streamTimeBoundsFromManifest,
+  type ResolvedPlaybackWindow,
+} from "../../stream-selection/playback";
 import { throwIfAborted } from "../../utils/cancellation";
+import {
+  maxBigInt as maxOfBigInts,
+  minBigInt as minOfBigInts,
+} from "../../utils/bigint";
 import { nsDeltaToSeconds } from "../../utils/nanoseconds";
 
 const INFO_ROLE = "dataset-info";
@@ -55,6 +72,8 @@ const VIDEO_ROLE = "video-stream";
 const RAW_STREAM_ID = "lerobot:rows";
 const NS_PER_SECOND = 1_000_000_000;
 const MP4_INDEX_CHUNK_BYTES = 1024 * 1024;
+const MAX_VIDEO_SPAN_CACHE_BYTES = 64 * 1024 * 1024;
+const MAX_VIDEO_SPAN_CACHE_ENTRIES = 16;
 
 interface ParquetReaderOptions {
   readonly columns?: string[];
@@ -117,8 +136,26 @@ interface ImageBinding {
 interface VideoIndex {
   readonly compositionOffsetSeconds: number;
   readonly file: ISOFile;
+  readonly presentationSamples: readonly IndexedVideoSample[];
   readonly samples: readonly Sample[];
   readonly track: Track;
+}
+
+interface IndexedVideoSample {
+  readonly decodeIndex: number;
+  readonly presentationSeconds: number;
+  readonly sample: Sample;
+}
+
+interface CachedVideoSpan {
+  readonly bytes: Uint8Array;
+  readonly end: number;
+}
+
+interface VideoSpanCacheEntry {
+  bytes: number;
+  readonly promise: Promise<CachedVideoSpan>;
+  span: CachedVideoSpan | null;
 }
 
 interface AvcConfiguration {
@@ -289,6 +326,7 @@ class LeRobotEpisodeSession implements EpisodeSession {
   readonly info: LeRobotInfo;
   readonly manifest: EpisodeManifest;
   readonly numericSeries: NumericSeriesCapability;
+  readonly playback: PlaybackReadCapability;
   readonly rawRecords: RawRecordCapability;
   readonly scalarFeatures: ReadonlyMap<string, LeRobotFeature>;
   readonly videoBindings: ReadonlyMap<string, VideoBinding>;
@@ -297,6 +335,7 @@ class LeRobotEpisodeSession implements EpisodeSession {
     Promise<readonly Record<string, unknown>[]>
   >();
   private readonly videoIndexCache = new Map<string, Promise<VideoIndex>>();
+  private readonly videoSpanCache = new Map<string, VideoSpanCacheEntry>();
   private decodedFrames = 0;
   private disposed = false;
   private generation = 0;
@@ -393,6 +432,7 @@ class LeRobotEpisodeSession implements EpisodeSession {
       readNumericSeries: async (request) => this.readNumericSeries(request),
     };
     this.rawRecords = this.createRawRecordCapability();
+    this.playback = this.createPlaybackCapability();
   }
 
   activate(): void {
@@ -414,6 +454,7 @@ class LeRobotEpisodeSession implements EpisodeSession {
     this.generation += 1;
     this.rowCache.clear();
     this.videoIndexCache.clear();
+    this.videoSpanCache.clear();
   }
 
   async *read(request: ReadRequest): AsyncIterable<FrameBatch> {
@@ -529,14 +570,11 @@ class LeRobotEpisodeSession implements EpisodeSession {
     const index = await this.readVideoIndex(binding, request.signal);
     const samples = selectVideoSamples(index, binding, request.window);
     if (!samples.length) return [];
-    const bytes = await readSampleSpan(
+    const bytes = await this.readSampleSpan(
       binding.asset,
       samples,
-      this.state.source,
-      this.state.io,
       request.signal,
     );
-    this.transferredBytes += bytes.byteLength;
     const avc = (samples[0].description as Mp4SampleDescription).avcC;
     const lengthSize = (avc?.lengthSizeMinusOne ?? 3) + 1;
     const parameterSets = avcParameterSets(avc);
@@ -556,6 +594,214 @@ class LeRobotEpisodeSession implements EpisodeSession {
         );
       })
       .filter((frame): frame is DecodedFrame => frame !== null);
+  }
+
+  private createPlaybackCapability(): PlaybackReadCapability {
+    const streamsById = new Map(
+      this.manifest.streams.map((stream) => [stream.id, stream]),
+    );
+    const sourceNames = new Map(
+      this.manifest.streams.map((stream) => [stream.id, stream.sourceName]),
+    );
+    const readBatch = (
+      request: SynchronizedPlaybackBatchReadRequest,
+      options?: SynchronizedPlaybackReadOptions,
+    ) => this.readPlaybackBatch(request, streamsById, sourceNames, options);
+    return {
+      timeline: {
+        endNs: this.manifest.timeRange.endNs,
+        startNs: this.manifest.timeRange.startNs,
+        timeDomainId: this.manifest.timeDomain.id,
+      },
+      readStreamTimeBounds: async (streams) => {
+        this.ensureOpen();
+        return streamTimeBoundsFromManifest(this.manifest, streams);
+      },
+      readSynchronized: async (request) => {
+        const windows = await readBatch(
+          { ...request, timeNs: [request.timeNs] },
+          { priority: "current", signal: request.signal },
+        );
+        const window = windows[0] ?? emptyPlaybackWindow(request.timeNs);
+        this.publishPlaybackSettlements(request, window);
+        return window;
+      },
+      readSynchronizedBatch: readBatch,
+    };
+  }
+
+  private async readPlaybackBatch(
+    request: SynchronizedPlaybackBatchReadRequest,
+    streamsById: ReadonlyMap<string, StreamDescriptor>,
+    sourceNames: ReadonlyMap<string, string>,
+    options: SynchronizedPlaybackReadOptions = {},
+  ): Promise<readonly SynchronizedFrameWindow[]> {
+    this.ensureOpen();
+    throwIfAborted(options.signal);
+    if (request.timeNs.length === 0) return [];
+    if (request.streams.length === 0) {
+      return request.timeNs.map(emptyPlaybackWindow);
+    }
+    const streams = [...new Set(request.streams)];
+    const resolved = request.timeNs.map((timeNs) =>
+      resolvePlaybackWindow(this.manifest.timeRange.startNs, streamsById, {
+        ...request,
+        streams,
+        timeNs,
+      }),
+    );
+    const batches = (
+      await Promise.all(
+        streams.map(async (stream) => {
+          const windows = resolved.map((window) =>
+            this.playbackReadWindow(stream, streamsById, window),
+          );
+          const streamBatches: FrameBatch[] = [];
+          for await (const batch of this.read({
+            priority: options.priority,
+            signal: options.signal,
+            streams: [stream],
+            window: {
+              endNs: maxOfBigInts(windows.map((window) => window.endNs)),
+              startNs: minOfBigInts(windows.map((window) => window.startNs)),
+            },
+          })) {
+            streamBatches.push(batch);
+          }
+          return streamBatches;
+        }),
+      )
+    ).flat();
+    throwIfAborted(options.signal);
+    const framesByStream = collectLeRobotFramesByStream(batches, streams);
+    return resolved.map((window) =>
+      selectPlaybackWindow(framesByStream, streams, sourceNames, window),
+    );
+  }
+
+  private playbackReadWindow(
+    streamId: string,
+    streamsById: ReadonlyMap<string, StreamDescriptor>,
+    window: ResolvedPlaybackWindow,
+  ): TimeWindow {
+    const policy = window.streamPolicies[streamId];
+    const stream = streamsById.get(streamId);
+    const streamStartNs =
+      stream?.timeRange.startNs ?? this.manifest.timeRange.startNs;
+    const rateHz =
+      stream?.approxRateHz && stream.approxRateHz > 0
+        ? stream.approxRateHz
+        : this.info.fps;
+    const frameStepNs = BigInt(Math.ceil(NS_PER_SECOND / rateHz));
+    const predecessorStartNs =
+      window.timeNs - frameStepNs * BigInt(policy.limit);
+    return {
+      endNs: policy.endNs,
+      startNs:
+        policy.startNs ??
+        (predecessorStartNs > streamStartNs
+          ? predecessorStartNs
+          : streamStartNs),
+    };
+  }
+
+  private publishPlaybackSettlements(
+    request: SynchronizedPlaybackReadRequest,
+    window: SynchronizedFrameWindow,
+  ): void {
+    if (!request.onStreamSettlement && !request.onStreamSettlements) return;
+    const settlements = prioritizedStreams(
+      request.streams,
+      request.settlementPriorityStreams,
+    ).map((stream) => ({
+      stream,
+      window: {
+        ...window,
+        frames: window.framesByStream[stream] ?? [],
+        framesByStream: {
+          [stream]: window.framesByStream[stream] ?? [],
+        },
+        streamPolicies: { [stream]: window.streamPolicies[stream] },
+      },
+    }));
+    request.onStreamSettlements?.(settlements);
+    for (const settlement of settlements) {
+      request.onStreamSettlement?.(settlement);
+    }
+  }
+
+  private async readSampleSpan(
+    asset: AssetDescriptor,
+    samples: readonly Sample[],
+    signal?: AbortSignal,
+  ): Promise<Uint8Array> {
+    const start = samples[0].offset;
+    const end = Math.max(
+      ...samples.map((sample) => sample.offset + sample.size),
+    );
+    const key = `${asset.id}:${start}`;
+    const previous = this.videoSpanCache.get(key);
+    if (previous) {
+      this.videoSpanCache.delete(key);
+      this.videoSpanCache.set(key, previous);
+      if (previous.span && previous.span.end >= end) {
+        return previous.span.bytes.subarray(0, end - start);
+      }
+    }
+    const promise = (async (): Promise<CachedVideoSpan> => {
+      const cached = await previous?.promise;
+      if (cached && cached.end >= end) return cached;
+      const readStart = cached?.end ?? start;
+      const result = await this.state.io.readBytes({
+        range: {
+          length: BigInt(end - readStart),
+          offset: BigInt(readStart),
+        },
+        source: await this.state.source.assets.resolve(asset.id),
+      });
+      this.transferredBytes += result.bytes.byteLength;
+      const bytes = new Uint8Array(
+        (cached?.bytes.byteLength ?? 0) + result.bytes.byteLength,
+      );
+      if (cached) bytes.set(cached.bytes);
+      bytes.set(result.bytes, cached?.bytes.byteLength ?? 0);
+      return { bytes, end: readStart + result.bytes.byteLength };
+    })();
+    const entry: VideoSpanCacheEntry = { bytes: 0, promise, span: null };
+    this.videoSpanCache.set(key, entry);
+    void promise.then(
+      (span) => {
+        entry.bytes = span.bytes.byteLength;
+        entry.span = span;
+        this.evictVideoSpans();
+      },
+      () => {
+        if (this.videoSpanCache.get(key) === entry) {
+          this.videoSpanCache.delete(key);
+        }
+      },
+    );
+    const span = await waitForSharedRead(promise, signal);
+    throwIfAborted(signal);
+    return span.bytes.subarray(0, end - start);
+  }
+
+  private evictVideoSpans(): void {
+    let retainedBytes = [...this.videoSpanCache.values()].reduce(
+      (total, entry) => total + entry.bytes,
+      0,
+    );
+    while (
+      this.videoSpanCache.size > MAX_VIDEO_SPAN_CACHE_ENTRIES ||
+      retainedBytes > MAX_VIDEO_SPAN_CACHE_BYTES
+    ) {
+      const oldest = this.videoSpanCache.entries().next().value as
+        | readonly [string, VideoSpanCacheEntry]
+        | undefined;
+      if (!oldest) return;
+      this.videoSpanCache.delete(oldest[0]);
+      retainedBytes -= oldest[1].bytes;
+    }
   }
 
   private async readRows(
@@ -1046,7 +1292,25 @@ async function parseVideoIndex(
   const compositionOffsetSeconds = Math.min(
     ...samples.map((sample) => sample.cts / videoTrack.timescale),
   );
-  return { compositionOffsetSeconds, file, samples, track: videoTrack };
+  const presentationSamples = samples
+    .map((sample, decodeIndex) => ({
+      decodeIndex,
+      presentationSeconds:
+        sample.cts / videoTrack.timescale - compositionOffsetSeconds,
+      sample,
+    }))
+    .sort((left, right) =>
+      left.presentationSeconds !== right.presentationSeconds
+        ? left.presentationSeconds - right.presentationSeconds
+        : left.decodeIndex - right.decodeIndex,
+    );
+  return {
+    compositionOffsetSeconds,
+    file,
+    presentationSamples,
+    samples,
+    track: videoTrack,
+  };
 }
 
 function selectVideoSamples(
@@ -1054,49 +1318,34 @@ function selectVideoSamples(
   binding: VideoBinding,
   window: TimeWindow,
 ): readonly Sample[] {
-  const indexed = index.samples.map((sample, decodeIndex) => ({
-    decodeIndex,
-    presentationSeconds: videoPresentationSeconds(index, sample),
-    sample,
-  }));
-  const selectedInterval = indexed.filter(
-    ({ presentationSeconds }) =>
-      presentationSeconds >= binding.fromSeconds &&
-      presentationSeconds < binding.toSeconds,
+  const startSeconds = Math.max(
+    binding.fromSeconds,
+    binding.fromSeconds + nsToSeconds(window.startNs),
   );
-  const startSeconds = binding.fromSeconds + nsToSeconds(window.startNs);
-  const endSeconds = binding.fromSeconds + nsToSeconds(window.endNs);
-  const requested = selectedInterval.filter(
-    ({ presentationSeconds }) =>
-      presentationSeconds >= startSeconds && presentationSeconds <= endSeconds,
+  const endSeconds = Math.min(
+    binding.toSeconds,
+    binding.fromSeconds + nsToSeconds(window.endNs),
   );
+  const startIndex = lowerBoundPresentation(
+    index.presentationSamples,
+    startSeconds,
+  );
+  const endIndex = upperBoundPresentation(
+    index.presentationSamples,
+    endSeconds,
+  );
+  const requested = index.presentationSamples.slice(startIndex, endIndex);
   if (!requested.length) return [];
   const firstDecode = Math.min(...requested.map((entry) => entry.decodeIndex));
   const lastDecode = Math.max(...requested.map((entry) => entry.decodeIndex));
   let startDecode = firstDecode;
-  for (const entry of indexed) {
-    if (entry.decodeIndex > firstDecode) break;
-    if (entry.sample.is_sync) startDecode = entry.decodeIndex;
+  for (let decodeIndex = firstDecode; decodeIndex >= 0; decodeIndex -= 1) {
+    if (index.samples[decodeIndex].is_sync) {
+      startDecode = decodeIndex;
+      break;
+    }
   }
   return index.samples.slice(startDecode, lastDecode + 1);
-}
-
-async function readSampleSpan(
-  asset: AssetDescriptor,
-  samples: readonly Sample[],
-  source: EpisodeSource,
-  io: ByteResources,
-  signal?: AbortSignal,
-) {
-  const start = samples[0].offset;
-  const end = Math.max(...samples.map((sample) => sample.offset + sample.size));
-  const result = await io.readBytes({
-    range: { length: BigInt(end - start), offset: BigInt(start) },
-    signal,
-    source: await source.assets.resolve(asset.id, { signal }),
-  });
-  throwIfAborted(signal);
-  return result.bytes;
 }
 
 function videoFrame(
@@ -1188,6 +1437,83 @@ function encodedVideo(
 
 function videoPresentationSeconds(index: VideoIndex, sample: Sample) {
   return sample.cts / index.track.timescale - index.compositionOffsetSeconds;
+}
+
+function lowerBoundPresentation(
+  samples: readonly IndexedVideoSample[],
+  timeSeconds: number,
+): number {
+  let low = 0;
+  let high = samples.length;
+  while (low < high) {
+    const middle = (low + high) >>> 1;
+    if (samples[middle].presentationSeconds < timeSeconds) low = middle + 1;
+    else high = middle;
+  }
+  return low;
+}
+
+function upperBoundPresentation(
+  samples: readonly IndexedVideoSample[],
+  timeSeconds: number,
+): number {
+  let low = 0;
+  let high = samples.length;
+  while (low < high) {
+    const middle = (low + high) >>> 1;
+    if (samples[middle].presentationSeconds <= timeSeconds) low = middle + 1;
+    else high = middle;
+  }
+  return low;
+}
+
+function waitForSharedRead<T>(
+  promise: Promise<T>,
+  signal?: AbortSignal,
+): Promise<T> {
+  if (!signal) return promise;
+  throwIfAborted(signal);
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      cleanup();
+      try {
+        throwIfAborted(signal);
+      } catch (error) {
+        reject(error);
+      }
+    };
+    const cleanup = () => signal.removeEventListener("abort", onAbort);
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => {
+        cleanup();
+        resolve(value);
+      },
+      (error) => {
+        cleanup();
+        reject(error);
+      },
+    );
+  });
+}
+
+function collectLeRobotFramesByStream(
+  batches: readonly FrameBatch[],
+  streams: readonly string[],
+): ReadonlyMap<string, readonly DecodedFrame[]> {
+  const requested = new Set(streams);
+  const framesByStream = new Map<string, DecodedFrame[]>(
+    streams.map((stream) => [stream, []]),
+  );
+  for (const batch of batches) {
+    if (!requested.has(batch.stream)) continue;
+    const frames = framesByStream.get(batch.stream);
+    if (!frames) continue;
+    for (const frame of batch.frames) {
+      if (frame.streamId === batch.stream) frames.push(frame);
+    }
+  }
+  return framesByStream;
 }
 
 function mp4SampleToAnnexB(bytes: Uint8Array, lengthSize: number): Uint8Array {

--- a/app/packages/multimodal/src/adapters/lerobot/format-adapter.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/format-adapter.ts
@@ -2157,7 +2157,7 @@ function scalarStream(
     id: streamIdForFeature(name),
     kind: STREAM_KIND.SCALAR,
     metadata: streamMetadata(feature.dtype, feature.dtype, "decodable", {
-      [STREAM_METADATA.CATEGORY]: leRobotCategory(name),
+      [STREAM_METADATA.CATEGORY]: leRobotCategory(name, feature.dtype),
       [STREAM_METADATA.COUNT_NOUN]: STREAM_COUNT_NOUN.SAMPLES,
       [STREAM_METADATA.INSPECTABLE]: "true",
     }),
@@ -2184,7 +2184,7 @@ function imageStream(
     kind: STREAM_KIND.IMAGE,
     metadata: {
       ...streamMetadata("parquet-image", feature.dtype, "decodable"),
-      [STREAM_METADATA.CATEGORY]: leRobotCategory(name),
+      [STREAM_METADATA.CATEGORY]: leRobotCategory(name, feature.dtype),
       [STREAM_METADATA.COUNT_NOUN]: STREAM_COUNT_NOUN.FRAMES,
       [STREAM_METADATA.INSPECTABLE]: "false",
       [SCENE_SOURCE_METADATA.SOURCE_NAME]: name,
@@ -2216,7 +2216,7 @@ function videoStream(
         codec,
         supported ? "decodable" : "unsupported-encoding",
       ),
-      [STREAM_METADATA.CATEGORY]: leRobotCategory(name),
+      [STREAM_METADATA.CATEGORY]: leRobotCategory(name, feature.dtype),
       [STREAM_METADATA.INSPECTABLE]: "false",
       [SCENE_SOURCE_METADATA.SOURCE_NAME]: name,
       [SCENE_SOURCE_METADATA.TYPE]: SCENE_SOURCE_TYPE.IMAGE,
@@ -2242,7 +2242,7 @@ function unsupportedStream(
       feature.dtype,
       "unsupported-encoding",
       {
-        [STREAM_METADATA.CATEGORY]: leRobotCategory(name),
+        [STREAM_METADATA.CATEGORY]: leRobotCategory(name, feature.dtype),
         [STREAM_METADATA.INSPECTABLE]: "false",
       },
     ),
@@ -2266,7 +2266,7 @@ function streamMetadata(
   };
 }
 
-function leRobotCategory(name: string): StreamCategory {
+function leRobotCategory(name: string, dtype: string): StreamCategory {
   if (name === "action" || name.startsWith("action.")) {
     return STREAM_CATEGORY.ACTIONS;
   }
@@ -2274,6 +2274,7 @@ function leRobotCategory(name: string): StreamCategory {
     return STREAM_CATEGORY.OBSERVATIONS;
   }
   if (
+    dtype === "string" &&
     /(?:^|[._/])(instruction|language|task|prompt|text)(?:[._/]|$)/i.test(name)
   ) {
     return STREAM_CATEGORY.INSTRUCTIONS;

--- a/app/packages/multimodal/src/adapters/lerobot/format-adapter.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/format-adapter.ts
@@ -50,8 +50,10 @@ import {
   type SynchronizedPlaybackReadOptions,
   type StateActionCapability,
   type StateActionFeatureSchema,
+  type StateActionFeatureStats,
   type StateActionRow,
   type StateActionSchema,
+  type StateActionStats,
   type SynchronizedPlaybackReadRequest,
   type SourceStats,
 } from "../../ports";
@@ -75,6 +77,7 @@ const EPISODE_METADATA_ROLE = "episode-metadata";
 const DATA_ROLE = "tabular-frame-data";
 const IMAGE_ROLE = "image-payload";
 const TASKS_ROLE = "tasks-metadata";
+const STATISTICS_ROLE = "dataset-statistics";
 const VIDEO_ROLE = "video-stream";
 const RAW_STREAM_ID = "lerobot:rows";
 const STATE_FEATURE_NAME = "observation.state";
@@ -404,6 +407,7 @@ class LeRobotEpisodeSession implements EpisodeSession {
     number,
     Promise<readonly Record<string, unknown>[]>
   >();
+  private stateActionStats: Promise<StateActionStats | null> | null = null;
   private stateActionTasks: Promise<ReadonlyMap<number, string> | null> | null =
     null;
   private readonly videoIndexCache = new Map<string, Promise<VideoIndex>>();
@@ -528,6 +532,7 @@ class LeRobotEpisodeSession implements EpisodeSession {
     this.generation += 1;
     this.rowCache.clear();
     this.stateActionBlocks.clear();
+    this.stateActionStats = null;
     this.stateActionTasks = null;
     this.videoIndexCache.clear();
     this.videoSpanCache.clear();
@@ -1272,6 +1277,17 @@ class LeRobotEpisodeSession implements EpisodeSession {
           ? null
           : this.readStateActionRow(offset, config, request.signal);
       },
+      readDimensionStats: async (options) => {
+        this.ensureOpen();
+        throwIfAborted(options?.signal);
+        const stats = await waitForSharedRead(
+          this.stateActionStatsFill(stateFeature, actionFeature),
+          options?.signal,
+        );
+        throwIfAborted(options?.signal);
+        this.ensureOpen();
+        return stats;
+      },
       readIndexWindow: async (request) => {
         this.ensureOpen();
         throwIfAborted(request.signal);
@@ -1376,6 +1392,29 @@ class LeRobotEpisodeSession implements EpisodeSession {
       });
     }
     return cached;
+  }
+
+  private stateActionStatsFill(
+    stateFeature: LeRobotFeature | undefined,
+    actionFeature: LeRobotFeature | undefined,
+  ) {
+    if (!this.stateActionStats) {
+      const asset = this.state.assets.find(
+        (candidate) => candidate.role === STATISTICS_ROLE,
+      );
+      // Statistics are reference context; a missing or unreadable stats
+      // asset must never block row inspection.
+      this.stateActionStats = asset
+        ? readStateActionStats(
+            this.state.source,
+            this.state.io,
+            asset,
+            stateFeature,
+            actionFeature,
+          ).catch(() => null)
+        : Promise.resolve(null);
+    }
+    return this.stateActionStats;
   }
 
   private stateActionTaskLabels() {
@@ -2611,6 +2650,84 @@ async function readTaskLabels(
     }
   }
   return labels;
+}
+
+const STATE_ACTION_STAT_KEYS = [
+  "max",
+  "mean",
+  "min",
+  "q01",
+  "q50",
+  "q99",
+  "std",
+] as const;
+
+/**
+ * Reads the source-declared `meta/stats.json` and keeps only the stat
+ * vectors that flatten to exactly one finite number per declared
+ * dimension; anything else is omitted rather than realigned.
+ */
+async function readStateActionStats(
+  source: EpisodeSource,
+  io: ByteResources,
+  asset: AssetDescriptor,
+  stateFeature: LeRobotFeature | undefined,
+  actionFeature: LeRobotFeature | undefined,
+): Promise<StateActionStats | null> {
+  const buffer = asyncBufferForSource(asset, source, io);
+  const bytes = new Uint8Array(await buffer.slice(0, buffer.byteLength));
+  const parsed = JSON.parse(new TextDecoder().decode(bytes)) as Record<
+    string,
+    unknown
+  >;
+  const state = stateFeature
+    ? statsForFeature(parsed[STATE_FEATURE_NAME], stateFeature)
+    : undefined;
+  const action = actionFeature
+    ? statsForFeature(parsed[ACTION_FEATURE_NAME], actionFeature)
+    : undefined;
+  if (!state && !action) return null;
+  const sampleCount = statsSampleCount(
+    parsed[STATE_FEATURE_NAME] ?? parsed[ACTION_FEATURE_NAME],
+  );
+  return {
+    ...(action ? { action } : {}),
+    ...(sampleCount !== undefined ? { sampleCount } : {}),
+    ...(state ? { state } : {}),
+  };
+}
+
+function statsSampleCount(entry: unknown): number | undefined {
+  if (!entry || typeof entry !== "object") return undefined;
+  const flattened = flattenStateActionSource(
+    (entry as Record<string, unknown>).count,
+  );
+  const count = flattened[0];
+  return typeof count === "number" && Number.isFinite(count) && count > 0
+    ? count
+    : undefined;
+}
+
+function statsForFeature(
+  entry: unknown,
+  feature: LeRobotFeature,
+): StateActionFeatureStats | undefined {
+  if (!entry || typeof entry !== "object") return undefined;
+  const count = Math.max(1, numericElementCount(feature.shape));
+  const record = entry as Record<string, unknown>;
+  const stats: Record<string, readonly number[]> = {};
+  for (const key of STATE_ACTION_STAT_KEYS) {
+    const values = flattenStateActionSource(record[key]);
+    if (
+      values.length === count &&
+      values.every((value) => typeof value === "number")
+    ) {
+      stats[key] = values as readonly number[];
+    }
+  }
+  return Object.keys(stats).length > 0
+    ? (stats as StateActionFeatureStats)
+    : undefined;
 }
 
 function rowAtOrBefore(rows: readonly TimelineRow[], timestampNs: bigint) {

--- a/app/packages/multimodal/src/adapters/lerobot/format-adapter.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/format-adapter.ts
@@ -114,10 +114,18 @@ export interface CreateLeRobotFormatAdapterOptions {
   readonly stateActionSlabLimits?: StateActionSlabLimits;
 }
 
+/**
+ * Declared dimension names as LeRobot writes them: a flat list, a nested
+ * per-axis list, or a dict of axis lists (DROID-style `{"axes": [...]}`).
+ */
+type LeRobotFeatureNames =
+  | readonly (string | null | readonly string[])[]
+  | Readonly<Record<string, unknown>>;
+
 interface LeRobotFeature {
   readonly dtype: string;
   readonly info?: Readonly<Record<string, unknown>>;
-  readonly names?: readonly string[] | null;
+  readonly names?: LeRobotFeatureNames | null;
   readonly shape?: readonly number[];
 }
 
@@ -2204,15 +2212,56 @@ function isStandardField(name: string) {
 }
 
 function scalarFieldNames(featureName: string, feature: LeRobotFeature) {
-  const count = Math.max(1, numericElementCount(feature.shape));
-  return Array.from({ length: count }, (_, index) => {
-    const name = feature.names?.[index];
+  const names = featureDimensionNames(feature);
+  return names.map((name, index) => {
     return name
       ? `${featureName}.${name}`
-      : count === 1
+      : names.length === 1
         ? featureName
         : `${featureName}[${index}]`;
   });
+}
+
+/**
+ * Declared per-dimension names in row-major order. A flat list stays
+ * positional (a shorter list leaves trailing dimensions unnamed); nested
+ * lists and axis dicts are used only when they flatten to exactly one
+ * string per dimension, never realigned by guesswork.
+ */
+function featureDimensionNames(
+  feature: LeRobotFeature,
+): readonly (string | undefined)[] {
+  const count = Math.max(1, numericElementCount(feature.shape));
+  const names = feature.names;
+  if (
+    Array.isArray(names) &&
+    names.every((entry) => typeof entry === "string" || entry === null)
+  ) {
+    return Array.from({ length: count }, (_, index) => {
+      const name = names[index];
+      return typeof name === "string" ? name : undefined;
+    });
+  }
+  const flattened = flattenDeclaredNames(names);
+  if (
+    flattened.length === count &&
+    flattened.every((name) => typeof name === "string")
+  ) {
+    return flattened;
+  }
+  return Array.from({ length: count }, () => undefined);
+}
+
+function flattenDeclaredNames(names: unknown): readonly (string | undefined)[] {
+  if (Array.isArray(names)) {
+    return names.flatMap((entry) =>
+      typeof entry === "string" ? [entry] : flattenDeclaredNames(entry),
+    );
+  }
+  if (names && typeof names === "object") {
+    return Object.values(names).flatMap((value) => flattenDeclaredNames(value));
+  }
+  return [];
 }
 
 function numericElementCount(shape: readonly number[] | undefined) {
@@ -2451,11 +2500,10 @@ function stateActionFeatureSchema(
   featureName: string,
   feature: LeRobotFeature,
 ): StateActionFeatureSchema {
-  const count = Math.max(1, numericElementCount(feature.shape));
+  const names = featureDimensionNames(feature);
   const fieldPaths = scalarFieldNames(featureName, feature);
   return {
-    dimensions: Array.from({ length: count }, (_, index) => {
-      const name = feature.names?.[index];
+    dimensions: names.map((name, index) => {
       return {
         index,
         ...(typeof name === "string" ? { name } : {}),

--- a/app/packages/multimodal/src/adapters/lerobot/format-adapter.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/format-adapter.ts
@@ -401,6 +401,7 @@ class LeRobotEpisodeSession implements EpisodeSession {
   readonly numericSeries: NumericSeriesCapability;
   readonly playback: PlaybackReadCapability;
   readonly rawRecords: RawRecordCapability;
+  readonly rawStreamBindings: readonly LeRobotRawStreamBinding[];
   readonly scalarFeatures: ReadonlyMap<string, LeRobotFeature>;
   readonly stateAction?: StateActionCapability;
   readonly videoBindings: ReadonlyMap<string, VideoBinding>;
@@ -471,7 +472,15 @@ class LeRobotEpisodeSession implements EpisodeSession {
           const asset = findFeatureAsset(state.assets, IMAGE_ROLE, name);
           if (!asset) return [unsupportedStream(name, feature, timeRange)];
           imageBindings.set(streamId, { asset, feature, streamId });
-          return [imageStream(name, feature, timeRange, state.info.fps)];
+          return [
+            imageStream(
+              name,
+              feature,
+              timeRange,
+              state.info.fps,
+              state.episodeRows.rows.length,
+            ),
+          ];
         }
         if (isNumericFeature(name, feature)) {
           scalarFeatures.set(streamId, feature);
@@ -493,7 +502,23 @@ class LeRobotEpisodeSession implements EpisodeSession {
     this.scalarFeatures = scalarFeatures;
     this.videoBindings = videoBindings;
     this.imageBindings = imageBindings;
-    this.manifest = state.source.manifestHint ?? {
+    this.rawStreamBindings = [
+      {
+        kind: "row",
+        schemaName: "LeRobotDataset v3 row",
+        sourceName: "Episode rows",
+        streamId: RAW_STREAM_ID,
+      },
+      ...[...scalarFeatures.entries()].map(([streamId, feature]) => ({
+        feature,
+        featureName: featureNameForStream(streamId),
+        kind: "feature" as const,
+        schemaName: `${feature.dtype}${shapeSuffix(feature.shape)}`,
+        sourceName: featureNameForStream(streamId),
+        streamId,
+      })),
+    ];
+    this.manifest = {
       episodeId: state.source.episodeId,
       metadata: {
         "lerobot.codebaseVersion": state.info.codebase_version ?? "unknown",
@@ -505,6 +530,16 @@ class LeRobotEpisodeSession implements EpisodeSession {
         "lerobot.robotType": state.info.robot_type ?? "unknown",
         "lerobot.tasks": JSON.stringify(state.episodeRows.episode.tasks ?? []),
       },
+      recordingFacts: leRobotRecordingFacts({
+        episode: state.episodeRows.episode,
+        fps: state.info.fps,
+        streams,
+        features: state.info.features,
+        rowCount: state.episodeRows.rows.length,
+        codebaseVersion: state.info.codebase_version,
+        robotType: state.info.robot_type,
+        timeRange,
+      }),
       streams,
       timeDomain: { id: "episode", kind: "duration", originNs: 0n },
       timeRange,
@@ -1081,25 +1116,7 @@ class LeRobotEpisodeSession implements EpisodeSession {
 
   private createRawRecordCapability(): RawRecordCapability {
     const rows = this.state.episodeRows.rows;
-    const streamBindings: readonly LeRobotRawStreamBinding[] = [
-      {
-        kind: "row",
-        schemaName: "LeRobotDataset v3 row",
-        sourceName: "Episode rows",
-        streamId: RAW_STREAM_ID,
-      },
-      ...[...this.scalarFeatures.entries()].map(([streamId, feature]) => {
-        const featureName = featureNameForStream(streamId);
-        return {
-          feature,
-          featureName,
-          kind: "feature" as const,
-          schemaName: `${feature.dtype}${shapeSuffix(feature.shape)}`,
-          sourceName: featureName,
-          streamId,
-        };
-      }),
-    ];
+    const streamBindings = this.rawStreamBindings;
     const requireStream = (stream: string) => {
       const binding = streamBindings.find(
         (candidate) => candidate.streamId === stream,
@@ -2135,7 +2152,11 @@ function scalarStream(
     count,
     id: streamIdForFeature(name),
     kind: STREAM_KIND.SCALAR,
-    metadata: streamMetadata(feature.dtype, feature.dtype, "decodable"),
+    metadata: streamMetadata(feature.dtype, feature.dtype, "decodable", {
+      [STREAM_METADATA.CATEGORY]: leRobotCategory(name),
+      [STREAM_METADATA.COUNT_NOUN]: "samples",
+      [STREAM_METADATA.INSPECTABLE]: "true",
+    }),
     payload: {
       encoding: "parquet",
       schema: `${feature.dtype}${shapeSuffix(feature.shape)}`,
@@ -2150,13 +2171,18 @@ function imageStream(
   feature: LeRobotFeature,
   timeRange: TimeWindow,
   fps: number,
+  count: number,
 ): StreamDescriptor {
   return {
     approxRateHz: fps,
+    count,
     id: streamIdForFeature(name),
     kind: STREAM_KIND.IMAGE,
     metadata: {
       ...streamMetadata("parquet-image", feature.dtype, "decodable"),
+      [STREAM_METADATA.CATEGORY]: leRobotCategory(name),
+      [STREAM_METADATA.COUNT_NOUN]: "frames",
+      [STREAM_METADATA.INSPECTABLE]: "false",
       [SCENE_SOURCE_METADATA.SOURCE_NAME]: name,
       [SCENE_SOURCE_METADATA.TYPE]: SCENE_SOURCE_TYPE.IMAGE,
     },
@@ -2186,6 +2212,8 @@ function videoStream(
         codec,
         supported ? "decodable" : "unsupported-encoding",
       ),
+      [STREAM_METADATA.CATEGORY]: leRobotCategory(name),
+      [STREAM_METADATA.INSPECTABLE]: "false",
       [SCENE_SOURCE_METADATA.SOURCE_NAME]: name,
       [SCENE_SOURCE_METADATA.TYPE]: SCENE_SOURCE_TYPE.IMAGE,
       "lerobot.assetId": binding.asset.id,
@@ -2209,6 +2237,10 @@ function unsupportedStream(
       feature.dtype,
       feature.dtype,
       "unsupported-encoding",
+      {
+        [STREAM_METADATA.CATEGORY]: leRobotCategory(name),
+        [STREAM_METADATA.INSPECTABLE]: "false",
+      },
     ),
     payload: { encoding: feature.dtype, schema: shapeSuffix(feature.shape) },
     sourceName: name,
@@ -2220,11 +2252,99 @@ function streamMetadata(
   encoding: string,
   schema: string,
   status: "decodable" | "unsupported-encoding",
+  additional: Readonly<Record<string, string>> = {},
 ) {
   return {
+    ...additional,
     [STREAM_METADATA.DECODE_STATUS]: status,
     [STREAM_METADATA.ENCODING]: encoding,
     [STREAM_METADATA.SCHEMA_NAME]: schema,
+  };
+}
+
+function leRobotCategory(name: string): string {
+  if (name === "action" || name.startsWith("action.")) return "actions";
+  if (name.startsWith("observation.")) return "observations";
+  if (
+    /(?:^|[._/])(instruction|language|task|prompt|text)(?:[._/]|$)/i.test(name)
+  ) {
+    return "instructions";
+  }
+  return "custom";
+}
+
+function leRobotRecordingFacts({
+  codebaseVersion,
+  episode,
+  features,
+  fps,
+  robotType,
+  rowCount,
+  streams,
+  timeRange,
+}: {
+  readonly codebaseVersion?: string;
+  readonly episode: Record<string, unknown>;
+  readonly features: Readonly<Record<string, LeRobotFeature>>;
+  readonly fps: number;
+  readonly robotType?: string;
+  readonly rowCount: number;
+  readonly streams: readonly StreamDescriptor[];
+  readonly timeRange: TimeWindow;
+}) {
+  const tasks = Array.isArray(episode.tasks)
+    ? episode.tasks.filter((task): task is string => typeof task === "string")
+    : [];
+  const codecs = [
+    ...new Set(
+      Object.values(features)
+        .filter((feature) => feature.dtype === "video")
+        .map(videoCodec)
+        .filter((codec) => codec !== "unknown"),
+    ),
+  ];
+  const mediaFeatureCount = Object.values(features).filter(
+    (feature) => feature.dtype === "image" || feature.dtype === "video",
+  ).length;
+  let inspectableStreamCount = 0;
+  let renderableStreamCount = 0;
+  let unavailableStreamCount = 0;
+  for (const stream of streams) {
+    if (stream.kind !== STREAM_KIND.UNKNOWN) {
+      renderableStreamCount++;
+    } else if (stream.metadata?.[STREAM_METADATA.INSPECTABLE] === "true") {
+      inspectableStreamCount++;
+    } else {
+      unavailableStreamCount++;
+    }
+  }
+  return {
+    applicationSupport: {
+      inspectableStreamCount,
+      renderableStreamCount,
+      unavailableStreamCount,
+    },
+    durationNs: (timeRange.endNs - timeRange.startNs).toString(),
+    format: "lerobot",
+    lerobot: {
+      ...(codebaseVersion ? { codebaseVersion } : {}),
+      ...(integer(episode.episode_index, "episode_index") >= 0n
+        ? {
+            episodeIndex: integer(
+              episode.episode_index,
+              "episode_index",
+            ).toString(),
+          }
+        : {}),
+      featureCount: Object.keys(features).length,
+      fps,
+      logicalRowCount: rowCount,
+      mediaFeatureCount,
+      ...(robotType ? { robotType } : {}),
+      ...(tasks.length ? { taskLabels: tasks } : {}),
+      ...(codecs.length ? { videoCodecs: codecs } : {}),
+    },
+    messageCount: rowCount.toString(),
   };
 }
 

--- a/app/packages/multimodal/src/adapters/lerobot/format-adapter.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/format-adapter.ts
@@ -286,7 +286,7 @@ class LeRobotEpisodePreviewSession implements EpisodePreviewSession {
     this.ensureOpen();
     throwIfAborted(options.signal);
     const previewStreams = this.session.manifest.streams
-      .filter(isRenderableCameraStream)
+      .filter(isPreviewableCameraStream)
       .sort(comparePreviewStreams);
     const selected = request.sourceName
       ? previewStreams.find(
@@ -315,17 +315,19 @@ class LeRobotEpisodePreviewSession implements EpisodePreviewSession {
         ])
       : frameDurationNs;
     let frames: readonly DecodedFrame[] = [];
-    for await (const batch of this.session.read({
-      priority: options.priority,
-      signal: options.signal,
-      streams: [selected.id],
-      window: {
-        endNs: minBigInt(selected.timeRange.endNs, startNs + readDurationNs),
-        startNs,
-      },
-    })) {
-      frames = batch.frames;
-      break;
+    if (isSharedDecoderCameraStream(selected)) {
+      for await (const batch of this.session.read({
+        priority: options.priority,
+        signal: options.signal,
+        streams: [selected.id],
+        window: {
+          endNs: minBigInt(selected.timeRange.endNs, startNs + readDurationNs),
+          startNs,
+        },
+      })) {
+        frames = batch.frames;
+        break;
+      }
     }
     const nativeVideo = await this.session.resolveNativePreviewVideo(
       selected.id,
@@ -366,7 +368,7 @@ class LeRobotEpisodePreviewSession implements EpisodePreviewSession {
       streamId: selected.id,
       streamSourceName: selected.sourceName,
       streamSourceNames,
-      status: frame ? "ready" : "empty",
+      status: frame || nativeVideo ? "ready" : "empty",
       ...(videoDecodeRunway?.length ? { videoDecodeRunway } : {}),
     };
   }
@@ -568,11 +570,17 @@ class LeRobotEpisodeSession implements EpisodeSession {
   ): Promise<EpisodePreviewNativeVideo | undefined> {
     const binding = this.videoBindings.get(streamId);
     if (!binding) return undefined;
+    const index = await this.readVideoIndex(binding, signal);
+    const codecString = index.track.codec;
+    const codec = codecFamily(codecString);
+    if (codec === "unknown") return undefined;
     const source = await this.state.source.assets.resolve(binding.asset.id, {
       signal,
     });
     throwIfAborted(signal);
     return {
+      codec,
+      codecString,
       endTimeSeconds: binding.toSeconds,
       source,
       startTimeSeconds: binding.fromSeconds,
@@ -2098,10 +2106,24 @@ function requireRowInterval(asset: AssetDescriptor) {
   return selector;
 }
 
-function isRenderableCameraStream(stream: StreamDescriptor) {
+function isSharedDecoderCameraStream(stream: StreamDescriptor) {
   return (
     stream.metadata?.[SCENE_SOURCE_METADATA.TYPE] === SCENE_SOURCE_TYPE.IMAGE &&
     stream.metadata?.[STREAM_METADATA.DECODE_STATUS] === "decodable"
+  );
+}
+
+/**
+ * Grid previews may use a browser-native video even before its codec is
+ * implemented by the shared synchronized decoder. Keep that capability local
+ * to preview selection so modal inventories remain truthful.
+ */
+function isPreviewableCameraStream(stream: StreamDescriptor) {
+  if (isSharedDecoderCameraStream(stream)) return true;
+  return (
+    stream.kind === STREAM_KIND.VIDEO &&
+    stream.metadata?.[SCENE_SOURCE_METADATA.TYPE] === SCENE_SOURCE_TYPE.IMAGE &&
+    codecFamily(stream.metadata?.["lerobot.codec"] ?? "") === "av1"
   );
 }
 

--- a/app/packages/multimodal/src/adapters/lerobot/format-adapter.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/format-adapter.ts
@@ -56,7 +56,7 @@ import {
   selectPlaybackWindow,
   streamTimeBoundsFromManifest,
   type ResolvedPlaybackWindow,
-} from "../../stream-selection/playback";
+} from "../../ports/playback-policy";
 import { throwIfAborted } from "../../utils/cancellation";
 import {
   maxBigInt as maxOfBigInts,

--- a/app/packages/multimodal/src/adapters/lerobot/format-adapter.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/format-adapter.ts
@@ -10,9 +10,12 @@ import {
 import {
   SCENE_SOURCE_METADATA,
   SCENE_SOURCE_TYPE,
+  STREAM_CATEGORY,
+  STREAM_COUNT_NOUN,
   STREAM_KIND,
   STREAM_METADATA,
   VISUALIZATION_KIND,
+  recordingSupportFactsFromStreams,
   type DecodedFrame,
   type DecodedOutput,
   type EncodedVideoVisualization,
@@ -26,6 +29,7 @@ import {
   type RawRecordResult,
   type RawValueNode,
   type StreamDescriptor,
+  type StreamCategory,
   type SynchronizedFrameWindow,
   type TimeWindow,
 } from "../../ir";
@@ -2154,7 +2158,7 @@ function scalarStream(
     kind: STREAM_KIND.SCALAR,
     metadata: streamMetadata(feature.dtype, feature.dtype, "decodable", {
       [STREAM_METADATA.CATEGORY]: leRobotCategory(name),
-      [STREAM_METADATA.COUNT_NOUN]: "samples",
+      [STREAM_METADATA.COUNT_NOUN]: STREAM_COUNT_NOUN.SAMPLES,
       [STREAM_METADATA.INSPECTABLE]: "true",
     }),
     payload: {
@@ -2181,7 +2185,7 @@ function imageStream(
     metadata: {
       ...streamMetadata("parquet-image", feature.dtype, "decodable"),
       [STREAM_METADATA.CATEGORY]: leRobotCategory(name),
-      [STREAM_METADATA.COUNT_NOUN]: "frames",
+      [STREAM_METADATA.COUNT_NOUN]: STREAM_COUNT_NOUN.FRAMES,
       [STREAM_METADATA.INSPECTABLE]: "false",
       [SCENE_SOURCE_METADATA.SOURCE_NAME]: name,
       [SCENE_SOURCE_METADATA.TYPE]: SCENE_SOURCE_TYPE.IMAGE,
@@ -2262,15 +2266,19 @@ function streamMetadata(
   };
 }
 
-function leRobotCategory(name: string): string {
-  if (name === "action" || name.startsWith("action.")) return "actions";
-  if (name.startsWith("observation.")) return "observations";
+function leRobotCategory(name: string): StreamCategory {
+  if (name === "action" || name.startsWith("action.")) {
+    return STREAM_CATEGORY.ACTIONS;
+  }
+  if (name.startsWith("observation.")) {
+    return STREAM_CATEGORY.OBSERVATIONS;
+  }
   if (
     /(?:^|[._/])(instruction|language|task|prompt|text)(?:[._/]|$)/i.test(name)
   ) {
-    return "instructions";
+    return STREAM_CATEGORY.INSTRUCTIONS;
   }
-  return "custom";
+  return STREAM_CATEGORY.CUSTOM;
 }
 
 function leRobotRecordingFacts({
@@ -2306,36 +2314,14 @@ function leRobotRecordingFacts({
   const mediaFeatureCount = Object.values(features).filter(
     (feature) => feature.dtype === "image" || feature.dtype === "video",
   ).length;
-  let inspectableStreamCount = 0;
-  let renderableStreamCount = 0;
-  let unavailableStreamCount = 0;
-  for (const stream of streams) {
-    if (stream.kind !== STREAM_KIND.UNKNOWN) {
-      renderableStreamCount++;
-    } else if (stream.metadata?.[STREAM_METADATA.INSPECTABLE] === "true") {
-      inspectableStreamCount++;
-    } else {
-      unavailableStreamCount++;
-    }
-  }
+  const episodeIndex = integer(episode.episode_index, "episode_index");
   return {
-    applicationSupport: {
-      inspectableStreamCount,
-      renderableStreamCount,
-      unavailableStreamCount,
-    },
+    applicationSupport: recordingSupportFactsFromStreams(streams),
     durationNs: (timeRange.endNs - timeRange.startNs).toString(),
     format: "lerobot",
     lerobot: {
       ...(codebaseVersion ? { codebaseVersion } : {}),
-      ...(integer(episode.episode_index, "episode_index") >= 0n
-        ? {
-            episodeIndex: integer(
-              episode.episode_index,
-              "episode_index",
-            ).toString(),
-          }
-        : {}),
+      ...(episodeIndex >= 0n ? { episodeIndex: episodeIndex.toString() } : {}),
       featureCount: Object.keys(features).length,
       fps,
       logicalRowCount: rowCount,
@@ -2344,7 +2330,6 @@ function leRobotRecordingFacts({
       ...(tasks.length ? { taskLabels: tasks } : {}),
       ...(codecs.length ? { videoCodecs: codecs } : {}),
     },
-    messageCount: rowCount.toString(),
   };
 }
 

--- a/app/packages/multimodal/src/adapters/lerobot/format-adapter.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/format-adapter.ts
@@ -1358,13 +1358,16 @@ function videoFrame(
 ): DecodedFrame | null {
   if (index.track.timescale <= 0) return null;
   const presentationSeconds = videoPresentationSeconds(index, sample);
-  if (
-    presentationSeconds < binding.fromSeconds ||
-    presentationSeconds >= binding.toSeconds
-  ) {
+  // MP4 timestamps and v3 selectors can represent the same frame boundary
+  // with slightly different floats. Compare them in the IR's nanosecond
+  // domain so the opening keyframe is not mistaken for out-of-episode preroll.
+  const timestampNs = secondsToNs(presentationSeconds - binding.fromSeconds);
+  const episodeDurationNs = secondsToNs(
+    binding.toSeconds - binding.fromSeconds,
+  );
+  if (timestampNs < 0n || timestampNs >= episodeDurationNs) {
     return null;
   }
-  const timestampNs = secondsToNs(presentationSeconds - binding.fromSeconds);
   const decodeTimestampNs = secondsToNs(
     sample.dts / index.track.timescale - binding.fromSeconds,
   );

--- a/app/packages/multimodal/src/adapters/lerobot/format-adapter.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/format-adapter.ts
@@ -231,7 +231,6 @@ export function createLeRobotFormatAdapter(
 }
 
 class LeRobotEpisodePreviewSession implements EpisodePreviewSession {
-  private readonly initializedStreams = new Set<string>();
   private disposed = false;
 
   constructor(private readonly session: LeRobotEpisodeSession) {}
@@ -271,13 +270,19 @@ class LeRobotEpisodePreviewSession implements EpisodePreviewSession {
     const frameDurationNs = secondsToNs(
       1 / (selected.approxRateHz ?? this.session.info.fps),
     );
+    const readDurationNs = request.decodeLookaheadNs
+      ? maxOfBigInts([
+          frameDurationNs,
+          request.decodeLookaheadNs + frameDurationNs,
+        ])
+      : frameDurationNs;
     let frames: readonly DecodedFrame[] = [];
     for await (const batch of this.session.read({
       priority: options.priority,
       signal: options.signal,
       streams: [selected.id],
       window: {
-        endNs: minBigInt(selected.timeRange.endNs, startNs + frameDurationNs),
+        endNs: minBigInt(selected.timeRange.endNs, startNs + readDurationNs),
         startNs,
       },
     })) {
@@ -290,12 +295,17 @@ class LeRobotEpisodePreviewSession implements EpisodePreviewSession {
     );
     this.ensureOpen();
     throwIfAborted(options.signal);
-    const initialized = this.initializedStreams.has(selected.id);
-    const decoded = initialized
-      ? firstFrameAtOrAfter(frames, startNs)
-      : frames[0];
-    if (decoded) this.initializedStreams.add(selected.id);
+    const decoded = firstFrameAtOrAfter(frames, startNs);
     const frame = decoded ? posterFrame(decoded) : null;
+    const videoDecodeRunway = request.decodeLookaheadNs
+      ? frames.flatMap((candidate) => {
+          const poster = posterFrame(candidate);
+          return poster?.kind === "image" &&
+            poster.image.kind === "encoded-video"
+            ? [poster]
+            : [];
+        })
+      : undefined;
     const nextStartTimeNs = decoded
       ? decoded.timestampNs + frameDurationNs
       : undefined;
@@ -319,6 +329,7 @@ class LeRobotEpisodePreviewSession implements EpisodePreviewSession {
       streamSourceName: selected.sourceName,
       streamSourceNames,
       status: frame ? "ready" : "empty",
+      ...(videoDecodeRunway?.length ? { videoDecodeRunway } : {}),
     };
   }
 

--- a/app/packages/multimodal/src/adapters/lerobot/mp4box.d.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/mp4box.d.ts
@@ -3,9 +3,13 @@ declare module "mp4box" {
   export interface Sample {
     cts: number;
     data?: Uint8Array;
+    description: unknown;
+    dts: number;
     duration: number;
     is_sync: boolean;
     number: number;
+    offset: number;
+    size: number;
     timescale: number;
   }
 
@@ -25,6 +29,7 @@ declare module "mp4box" {
   export interface ISOFile {
     appendBuffer(data: MP4BoxBuffer, last?: boolean): number;
     flush(): void;
+    getTrackSamplesInfo(id: number): Sample[];
     onError?: (error: string) => void;
     onReady?: (info: Movie) => void;
     onSamples?: (id: number, user: unknown, samples: Sample[]) => void;

--- a/app/packages/multimodal/src/adapters/lerobot/state-action.test.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/state-action.test.ts
@@ -275,6 +275,56 @@ describe("LeRobot state/action provider", () => {
     }
   });
 
+  it("reads DROID-style axis-dict dimension names", async () => {
+    const built = buildStateActionSource({
+      action: {
+        dtype: "float32",
+        names: { axes: ["joint_0", "joint_1", "gripper"] },
+        rows: [[1, 2, 3]],
+        shape: [3],
+      },
+      state: {
+        dtype: "float32",
+        // A dict that does not flatten to one name per dimension yields
+        // stable indices, never a guessed alignment.
+        names: { axes: ["a", "b"] },
+        rows: [[4, 5, 6]],
+        shape: [3],
+      },
+      timestampsSeconds: [0],
+    });
+    const session = await createLeRobotFormatAdapter({
+      readParquetObjects: built.reader,
+    }).open(built.source, built.io);
+    try {
+      const schema = session.stateAction?.schema;
+      expect(
+        schema?.action?.dimensions.map((dimension) => dimension.name),
+      ).toEqual(["joint_0", "joint_1", "gripper"]);
+      expect(
+        schema?.action?.dimensions.map(
+          (dimension) => dimension.numericFieldPath,
+        ),
+      ).toEqual(["action.joint_0", "action.joint_1", "action.gripper"]);
+      expect(
+        schema?.state?.dimensions.map((dimension) => dimension.name),
+      ).toEqual([undefined, undefined, undefined]);
+      await expect(
+        session.numericSeries?.enumerateNumericFields(["lerobot:action"]),
+      ).resolves.toMatchObject([
+        {
+          fields: [
+            { path: "action.joint_0" },
+            { path: "action.joint_1" },
+            { path: "action.gripper" },
+          ],
+        },
+      ]);
+    } finally {
+      session.dispose();
+    }
+  });
+
   it("binds dimensions to the numeric-series stream for add-to-plot", async () => {
     const built = buildStateActionSource(BASIC_SCENARIO);
     const session = await createLeRobotFormatAdapter({

--- a/app/packages/multimodal/src/adapters/lerobot/state-action.test.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/state-action.test.ts
@@ -19,6 +19,8 @@ interface BuildOptions {
   readonly intervalStart?: number;
   /** Makes every tasks-metadata read reject. */
   readonly failTasksRead?: boolean;
+  /** Serves this object as the meta/stats.json asset when present. */
+  readonly statistics?: Readonly<Record<string, unknown>>;
 }
 
 interface ParquetReadOptions {
@@ -71,6 +73,9 @@ function buildStateActionSource(
     robot_type: "test-arm",
   };
   const infoBytes = new TextEncoder().encode(JSON.stringify(info));
+  const statsBytes = build.statistics
+    ? new TextEncoder().encode(JSON.stringify(build.statistics))
+    : null;
   const episodeRow = {
     dataset_from_index: 0n,
     dataset_to_index: BigInt(rowCount),
@@ -136,6 +141,17 @@ function buildStateActionSource(
           },
         ]
       : []),
+    ...(statsBytes
+      ? [
+          {
+            id: "stats",
+            mediaType: "application/json",
+            metadata: { sizeBytes: statsBytes.byteLength.toString() },
+            role: "dataset-statistics",
+            selector: { kind: "whole-file" } as const,
+          },
+        ]
+      : []),
   ];
   let slabReads = 0;
   const reader = vi.fn(async (options: ParquetReadOptions) => {
@@ -167,14 +183,18 @@ function buildStateActionSource(
     },
     episodeId: "episode-0",
   };
+  let statsAssetReads = 0;
   const io: ByteResources = {
     readBytes: async ({ range, source: byteSource }) => {
       const start = Number(range.offset);
       const end = start + Number(range.length);
+      if (byteSource.sourceId === "stats") statsAssetReads += 1;
       const bytes =
         byteSource.sourceId === "info"
           ? infoBytes.slice(start, end)
-          : new Uint8Array(Number(range.length));
+          : byteSource.sourceId === "stats" && statsBytes
+            ? statsBytes.slice(start, end)
+            : new Uint8Array(Number(range.length));
       return { bytes, range, source: byteSource };
     },
   };
@@ -183,6 +203,7 @@ function buildStateActionSource(
     physicalReads: () => slabReads,
     reader,
     source,
+    statsReads: () => statsAssetReads,
   };
 }
 
@@ -320,6 +341,55 @@ describe("LeRobot state/action provider", () => {
           ],
         },
       ]);
+    } finally {
+      session.dispose();
+    }
+  });
+
+  it("reads declared per-dimension statistics lazily and caches them", async () => {
+    const built = buildStateActionSource(BASIC_SCENARIO, {
+      statistics: {
+        action: {
+          max: [5, 6],
+          mean: [3, 4],
+          min: [1, 2],
+          std: [0.5, 0.6],
+        },
+        "observation.state": {
+          // Wrong length: this stat vector must be omitted, not realigned.
+          max: [9],
+          min: [-9, -8],
+        },
+      },
+    });
+    const session = await createLeRobotFormatAdapter({
+      readParquetObjects: built.reader,
+    }).open(built.source, built.io);
+    try {
+      const stats = await session.stateAction?.readDimensionStats?.();
+      expect(stats?.action).toEqual({
+        max: [5, 6],
+        mean: [3, 4],
+        min: [1, 2],
+        std: [0.5, 0.6],
+      });
+      expect(stats?.state).toEqual({ min: [-9, -8] });
+      await session.stateAction?.readDimensionStats?.();
+      expect(built.statsReads()).toBe(1);
+    } finally {
+      session.dispose();
+    }
+  });
+
+  it("resolves null statistics when the source ships none", async () => {
+    const built = buildStateActionSource(BASIC_SCENARIO);
+    const session = await createLeRobotFormatAdapter({
+      readParquetObjects: built.reader,
+    }).open(built.source, built.io);
+    try {
+      await expect(
+        session.stateAction?.readDimensionStats?.(),
+      ).resolves.toBeNull();
     } finally {
       session.dispose();
     }

--- a/app/packages/multimodal/src/adapters/lerobot/state-action.test.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/state-action.test.ts
@@ -503,6 +503,63 @@ describe("LeRobot state/action provider", () => {
     }
   });
 
+  it("counts out-of-declared-range rows in the episode profile", async () => {
+    const built = buildStateActionSource(BASIC_SCENARIO, {
+      statistics: {
+        // Deliberately tighter than the data: rows 0 and 2 fall outside
+        // dimension 0's declared bounds while dimension 1 stays inside.
+        action: { max: [4, 6], min: [2, 2] },
+        // Min without max: no usable bounds, so counts stay null rather
+        // than pretending a one-sided range was checked.
+        "observation.state": { min: [-9, -8] },
+      },
+    });
+    const session = await createLeRobotFormatAdapter({
+      readParquetObjects: built.reader,
+    }).open(built.source, built.io);
+    try {
+      const profile = await session.stateAction?.readEpisodeProfile?.();
+      expect(profile?.action?.outOfRangeCounts).toEqual([2, 0]);
+      expect(profile?.state?.outOfRangeCounts).toEqual([null, null]);
+      // The profile shares the cached statistics read with the stats API.
+      await session.stateAction?.readDimensionStats?.();
+      expect(built.statsReads()).toBe(1);
+    } finally {
+      session.dispose();
+    }
+  });
+
+  it("profiles across bounded blocks with one cached scan", async () => {
+    const built = buildStateActionSource(BASIC_SCENARIO);
+    const session = await createLeRobotFormatAdapter({
+      readParquetObjects: built.reader,
+      // rowBytes = 40 (see the degradation test): the profile scan must
+      // walk two blocks and later reads must reuse them.
+      stateActionSlabLimits: { blockBytes: 90, maxSingleSlabBytes: 100 },
+    }).open(built.source, built.io);
+    try {
+      const profile = await session.stateAction?.readEpisodeProfile?.();
+      expect(built.physicalReads()).toBe(2);
+      expect(profile?.state?.min[0]).toMatchObject({
+        frameIndex: 0,
+        value: 0.1,
+      });
+      expect(profile?.state?.max[0]).toMatchObject({
+        frameIndex: 2,
+        value: 2.1,
+      });
+      expect(profile?.trackingError?.[0]).toBeCloseTo(
+        (Math.abs(1 - 0.1) + Math.abs(3 - 1.1) + Math.abs(5 - 2.1)) / 3,
+      );
+      await session.stateAction?.readEpisodeProfile?.();
+      const row = await session.stateAction?.readAtCursor({ cursor: "row:1" });
+      expect(row?.state).toEqual([1.1, 1.2]);
+      expect(built.physicalReads()).toBe(2);
+    } finally {
+      session.dispose();
+    }
+  });
+
   it("degrades to bounded block reads when the slab exceeds its ceiling", async () => {
     const built = buildStateActionSource(BASIC_SCENARIO);
     const session = await createLeRobotFormatAdapter({

--- a/app/packages/multimodal/src/adapters/lerobot/state-action.test.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/state-action.test.ts
@@ -275,6 +275,30 @@ describe("LeRobot state/action provider", () => {
     }
   });
 
+  it("binds dimensions to the numeric-series stream for add-to-plot", async () => {
+    const built = buildStateActionSource(BASIC_SCENARIO);
+    const session = await createLeRobotFormatAdapter({
+      readParquetObjects: built.reader,
+    }).open(built.source, built.io);
+    try {
+      const schema = session.stateAction?.schema;
+      expect(schema?.state?.numericStreamId).toBe("lerobot:observation.state");
+      expect(
+        schema?.state?.dimensions.map(
+          (dimension) => dimension.numericFieldPath,
+        ),
+      ).toEqual(["observation.state.shoulder", "observation.state.elbow"]);
+      expect(schema?.action?.numericStreamId).toBe("lerobot:action");
+      expect(
+        schema?.action?.dimensions.map(
+          (dimension) => dimension.numericFieldPath,
+        ),
+      ).toEqual(["action[0]", "action[1]"]);
+    } finally {
+      session.dispose();
+    }
+  });
+
   it("omits the capability when neither canonical feature is declared", async () => {
     const built = buildStateActionSource({
       timestampsSeconds: [0, 0.05],

--- a/app/packages/multimodal/src/adapters/lerobot/state-action.test.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/state-action.test.ts
@@ -1,0 +1,355 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ByteSourceDescriptor } from "../../ir";
+import type {
+  AssetDescriptor,
+  ByteResources,
+  EpisodeSource,
+} from "../../ports";
+import type { StateActionScenario } from "../fixture/fixture-state-action";
+import { defineStateActionCapabilityContractTests } from "../../testing/state-action-contract";
+import { createLeRobotFormatAdapter } from "./format-adapter";
+
+interface BuildOptions {
+  /** Absolute Parquet row where the episode's data interval begins. */
+  readonly intervalStart?: number;
+  /** Makes every tasks-metadata read reject. */
+  readonly failTasksRead?: boolean;
+}
+
+interface ParquetReadOptions {
+  columns?: string[];
+  file: { byteLength: number };
+  rowEnd?: number;
+  rowStart?: number;
+}
+
+const EPISODES_BYTE_LENGTH = 1;
+const DATA_BYTE_LENGTH = 2;
+const TASKS_BYTE_LENGTH = 3;
+
+function isSlabRead(options: ParquetReadOptions): boolean {
+  return Boolean(
+    options.columns?.includes("frame_index") &&
+    options.columns.includes("task_index") &&
+    !options.columns.includes("episode_index"),
+  );
+}
+
+function buildStateActionSource(
+  scenario: StateActionScenario,
+  build: BuildOptions = {},
+) {
+  const rowCount = scenario.timestampsSeconds.length;
+  const intervalStart = build.intervalStart ?? 0;
+  const features: Record<string, unknown> = {
+    success: { dtype: "bool", shape: [1] },
+    timestamp: { dtype: "float32", shape: [1] },
+  };
+  if (scenario.state) {
+    features["observation.state"] = {
+      dtype: scenario.state.dtype,
+      ...(scenario.state.names ? { names: scenario.state.names } : {}),
+      shape: scenario.state.shape,
+    };
+  }
+  if (scenario.action) {
+    features.action = {
+      dtype: scenario.action.dtype,
+      ...(scenario.action.names ? { names: scenario.action.names } : {}),
+      shape: scenario.action.shape,
+    };
+  }
+  const info = {
+    codebase_version: "v3.0",
+    features,
+    fps: 30,
+    robot_type: "test-arm",
+  };
+  const infoBytes = new TextEncoder().encode(JSON.stringify(info));
+  const episodeRow = {
+    dataset_from_index: 0n,
+    dataset_to_index: BigInt(rowCount),
+    episode_index: 0n,
+    length: BigInt(rowCount),
+    tasks: scenario.episodeTasks ? [...scenario.episodeTasks] : [],
+  };
+  const dataRows = scenario.timestampsSeconds.map((timestamp, offset) => ({
+    ...(scenario.action ? { action: scenario.action.rows[offset] } : {}),
+    episode_index: 0n,
+    frame_index: BigInt(offset),
+    index: BigInt(offset),
+    ...(scenario.state
+      ? { "observation.state": scenario.state.rows[offset] }
+      : {}),
+    success: true,
+    task_index: BigInt(scenario.taskIndexes?.[offset] ?? 0),
+    timestamp,
+  }));
+  const taskRows = Object.entries(scenario.taskLabelsByIndex ?? {}).map(
+    ([index, task]) => ({ task, task_index: BigInt(index) }),
+  );
+  const assets: AssetDescriptor[] = [
+    {
+      id: "info",
+      mediaType: "application/json",
+      metadata: { sizeBytes: infoBytes.byteLength.toString() },
+      role: "dataset-info",
+      selector: { kind: "whole-file" },
+    },
+    {
+      id: "episodes",
+      mediaType: "application/vnd.apache.parquet",
+      metadata: { sizeBytes: EPISODES_BYTE_LENGTH.toString() },
+      role: "episode-metadata",
+      selector: {
+        coordinateSystem: "parquet-file-row",
+        end: 1,
+        kind: "row-interval",
+        start: 0,
+      },
+    },
+    {
+      id: "data",
+      mediaType: "application/vnd.apache.parquet",
+      metadata: { sizeBytes: DATA_BYTE_LENGTH.toString() },
+      role: "tabular-frame-data",
+      selector: {
+        coordinateSystem: "parquet-file-row",
+        end: intervalStart + rowCount,
+        kind: "row-interval",
+        start: intervalStart,
+      },
+    },
+    ...(scenario.taskLabelsByIndex
+      ? [
+          {
+            id: "tasks",
+            mediaType: "application/vnd.apache.parquet",
+            metadata: { sizeBytes: TASKS_BYTE_LENGTH.toString() },
+            role: "tasks-metadata",
+            selector: { kind: "whole-file" } as const,
+          },
+        ]
+      : []),
+  ];
+  let slabReads = 0;
+  const reader = vi.fn(async (options: ParquetReadOptions) => {
+    if (options.file.byteLength === TASKS_BYTE_LENGTH) {
+      if (build.failTasksRead) {
+        throw new Error("tasks metadata is unreadable");
+      }
+      return taskRows;
+    }
+    if (options.file.byteLength === EPISODES_BYTE_LENGTH) {
+      return [episodeRow];
+    }
+    if (isSlabRead(options)) {
+      slabReads += 1;
+      if (scenario.fillLatencyMs) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, scenario.fillLatencyMs),
+        );
+      }
+    }
+    const start = (options.rowStart ?? intervalStart) - intervalStart;
+    const end = (options.rowEnd ?? intervalStart + rowCount) - intervalStart;
+    return dataRows.slice(start, end);
+  });
+  const source: EpisodeSource = {
+    assets: {
+      list: async () => assets,
+      resolve: async (assetId) => descriptor(assets, assetId),
+    },
+    episodeId: "episode-0",
+  };
+  const io: ByteResources = {
+    readBytes: async ({ range, source: byteSource }) => {
+      const start = Number(range.offset);
+      const end = start + Number(range.length);
+      const bytes =
+        byteSource.sourceId === "info"
+          ? infoBytes.slice(start, end)
+          : new Uint8Array(Number(range.length));
+      return { bytes, range, source: byteSource };
+    },
+  };
+  return {
+    io,
+    physicalReads: () => slabReads,
+    reader,
+    source,
+  };
+}
+
+function descriptor(
+  assets: readonly AssetDescriptor[],
+  assetId: string,
+): ByteSourceDescriptor {
+  const asset = assets.find((candidate) => candidate.id === assetId);
+  if (!asset) throw new Error(`Unknown test asset ${assetId}`);
+  return {
+    sizeBytes: asset.metadata?.sizeBytes,
+    sourceId: asset.id,
+    url: `memory://${asset.id}`,
+  };
+}
+
+defineStateActionCapabilityContractTests({
+  createSession: async (scenario) => {
+    const built = buildStateActionSource(scenario);
+    const session = await createLeRobotFormatAdapter({
+      readParquetObjects: built.reader,
+    }).open(built.source, built.io);
+    if (!session.stateAction) {
+      throw new Error("LeRobot session did not expose the capability");
+    }
+    return {
+      capability: session.stateAction,
+      declaredEndNs: session.manifest.timeRange.endNs,
+      dispose: () => session.dispose(),
+      physicalReads: built.physicalReads,
+    };
+  },
+  name: "lerobot",
+});
+
+const BASIC_SCENARIO: StateActionScenario = {
+  action: {
+    dtype: "float32",
+    rows: [
+      [1, 2],
+      [3, 4],
+      [5, 6],
+    ],
+    shape: [2],
+  },
+  state: {
+    dtype: "float32",
+    names: ["shoulder", "elbow"],
+    rows: [
+      [0.1, 0.2],
+      [1.1, 1.2],
+      [2.1, 2.2],
+    ],
+    shape: [2],
+  },
+  timestampsSeconds: [0, 0.05, 0.1],
+};
+
+describe("LeRobot state/action provider", () => {
+  it("omits the capability when neither canonical feature is declared", async () => {
+    const built = buildStateActionSource({
+      timestampsSeconds: [0, 0.05],
+    });
+    const session = await createLeRobotFormatAdapter({
+      readParquetObjects: built.reader,
+    }).open(built.source, built.io);
+    try {
+      expect(session.stateAction).toBeUndefined();
+    } finally {
+      session.dispose();
+    }
+  });
+
+  it("fills one slab selecting only the declared columns over the episode interval", async () => {
+    const built = buildStateActionSource(BASIC_SCENARIO);
+    const session = await createLeRobotFormatAdapter({
+      readParquetObjects: built.reader,
+    }).open(built.source, built.io);
+    try {
+      await session.stateAction?.readAtTime({ timestampNs: 0n });
+      const slabCall = built.reader.mock.calls.find(([options]) =>
+        isSlabRead(options),
+      );
+      expect(slabCall?.[0]).toMatchObject({
+        columns: [
+          "timestamp",
+          "frame_index",
+          "task_index",
+          "observation.state",
+          "action",
+        ],
+        rowEnd: 3,
+        rowStart: 0,
+      });
+      for (const [options] of built.reader.mock.calls) {
+        expect(options.columns ?? []).not.toContain(
+          "observation.images.embedded",
+        );
+      }
+    } finally {
+      session.dispose();
+    }
+  });
+
+  it("translates the slab to absolute rows for an offset episode interval", async () => {
+    const built = buildStateActionSource(BASIC_SCENARIO, { intervalStart: 10 });
+    const session = await createLeRobotFormatAdapter({
+      readParquetObjects: built.reader,
+    }).open(built.source, built.io);
+    try {
+      const row = await session.stateAction?.readAtTime({ timestampNs: 0n });
+      expect(row?.state).toEqual([0.1, 0.2]);
+      const slabCall = built.reader.mock.calls.find(([options]) =>
+        isSlabRead(options),
+      );
+      expect(slabCall?.[0]).toMatchObject({ rowEnd: 13, rowStart: 10 });
+    } finally {
+      session.dispose();
+    }
+  });
+
+  it("keeps rows readable when the tasks asset cannot be read", async () => {
+    const built = buildStateActionSource(
+      {
+        ...BASIC_SCENARIO,
+        episodeTasks: ["pick up the block"],
+        taskIndexes: [0, 0, 1],
+        taskLabelsByIndex: { 0: "unused", 1: "unused" },
+      },
+      { failTasksRead: true },
+    );
+    const session = await createLeRobotFormatAdapter({
+      readParquetObjects: built.reader,
+    }).open(built.source, built.io);
+    try {
+      const row = await session.stateAction?.readAtCursor({ cursor: "row:2" });
+      expect(row?.state).toEqual([2.1, 2.2]);
+      expect(row?.task).toEqual({ index: 1, label: "pick up the block" });
+    } finally {
+      session.dispose();
+    }
+  });
+
+  it("degrades to bounded block reads when the slab exceeds its ceiling", async () => {
+    const built = buildStateActionSource(BASIC_SCENARIO);
+    const session = await createLeRobotFormatAdapter({
+      readParquetObjects: built.reader,
+      // rowBytes = 24 + 2×4 + 2×4 = 40; three rows exceed 100 bytes, and a
+      // 90-byte block budget admits two rows per physical read.
+      stateActionSlabLimits: { blockBytes: 90, maxSingleSlabBytes: 100 },
+    }).open(built.source, built.io);
+    try {
+      const first = await session.stateAction?.readAtCursor({
+        cursor: "row:0",
+      });
+      expect(first?.state).toEqual([0.1, 0.2]);
+      expect(built.physicalReads()).toBe(1);
+      const last = await session.stateAction?.readAtCursor({ cursor: "row:2" });
+      expect(last?.state).toEqual([2.1, 2.2]);
+      expect(built.physicalReads()).toBe(2);
+      const slabCalls = built.reader.mock.calls
+        .filter(([options]) => isSlabRead(options))
+        .map(([options]) => [options.rowStart, options.rowEnd]);
+      expect(slabCalls).toEqual([
+        [0, 2],
+        [2, 3],
+      ]);
+      await session.stateAction?.readAtCursor({ cursor: "row:1" });
+      expect(built.physicalReads()).toBe(2);
+    } finally {
+      session.dispose();
+    }
+  });
+});

--- a/app/packages/multimodal/src/adapters/lerobot/state-action.test.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/state-action.test.ts
@@ -242,6 +242,39 @@ const BASIC_SCENARIO: StateActionScenario = {
 };
 
 describe("LeRobot state/action provider", () => {
+  it("preserves signal peaks under a numeric decimation budget", async () => {
+    const values = [0, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0];
+    const built = buildStateActionSource({
+      action: {
+        dtype: "float32",
+        rows: values.map((value) => [value]),
+        shape: [1],
+      },
+      timestampsSeconds: values.map((_, index) => index / 30),
+    });
+    const session = await createLeRobotFormatAdapter({
+      readParquetObjects: built.reader,
+    }).open(built.source, built.io);
+    try {
+      const series = await session.numericSeries?.readNumericSeries({
+        fields: ["action"],
+        maxPointsPerField: 6,
+        stream: "lerobot:action",
+        window: session.manifest.timeRange,
+      });
+      const field = series?.fields[0];
+      expect(field?.values.length).toBeLessThanOrEqual(6);
+      // A uniform stride would alias the lone spike away; per-bucket
+      // min/max decimation must keep it.
+      expect([...(field?.values ?? [])]).toContain(100);
+      expect(series?.truncated).toBe(true);
+      const times = [...(field?.timesSec ?? [])];
+      expect([...times].sort((left, right) => left - right)).toEqual(times);
+    } finally {
+      session.dispose();
+    }
+  });
+
   it("omits the capability when neither canonical feature is declared", async () => {
     const built = buildStateActionSource({
       timestampsSeconds: [0, 0.05],

--- a/app/packages/multimodal/src/adapters/lerobot/state-action.test.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/state-action.test.ts
@@ -486,7 +486,7 @@ async function openRealEpisode(root: string): Promise<{
   };
   const buffer = (id: string): AsyncBuffer => ({
     byteLength: sizes.get(id) ?? 0,
-    async slice(start, end) {
+    async slice(start: number, end?: number) {
       const bytes = await readFileRange(
         id,
         start,

--- a/app/packages/multimodal/src/adapters/lerobot/state-action.test.ts
+++ b/app/packages/multimodal/src/adapters/lerobot/state-action.test.ts
@@ -1,3 +1,7 @@
+import { open, stat } from "node:fs/promises";
+import { join } from "node:path";
+
+import { parquetReadObjects, type AsyncBuffer } from "hyparquet";
 import { describe, expect, it, vi } from "vitest";
 
 import type { ByteSourceDescriptor } from "../../ir";
@@ -353,3 +357,277 @@ describe("LeRobot state/action provider", () => {
     }
   });
 });
+
+const realRoot = process.env.LEROBOT_DATASET_PATH;
+
+describe.runIf(Boolean(realRoot))(
+  "LeRobot real-corpus state/action parity",
+  () => {
+    it("matches direct Parquet values row for row and walks every cursor", async () => {
+      if (!realRoot) throw new Error("LEROBOT_DATASET_PATH is required");
+      const real = await openRealEpisode(realRoot);
+      const session = await createLeRobotFormatAdapter().open(
+        real.source,
+        real.io,
+      );
+      const capability = session.stateAction;
+      try {
+        if (!capability) {
+          throw new Error("real LeRobot session did not expose the capability");
+        }
+        expect(capability.schema.rowCount).toBe(real.episodeLength);
+        expect(
+          capability.schema.state?.dimensions.map(
+            (dimension) => dimension.name,
+          ),
+        ).toEqual(real.stateNames);
+        expect(
+          capability.schema.action?.dimensions.map(
+            (dimension) => dimension.name,
+          ),
+        ).toEqual(real.actionNames);
+
+        // Ten deterministic pseudo-random rows compared against an
+        // independent selected-column Parquet read of the same interval.
+        const sampled = Array.from(
+          { length: 10 },
+          (_, index) => (17 + index * 41) % real.episodeLength,
+        );
+        for (const offset of sampled) {
+          const row = await capability.readAtCursor({
+            cursor: `row:${offset}`,
+          });
+          const reference = real.referenceRows[offset];
+          expect(row.frameIndex).toBe(offset);
+          expect(row.featureErrors).toBeUndefined();
+          expect(row.state).toEqual(
+            flattenDeep(reference["observation.state"]),
+          );
+          expect(row.action).toEqual(flattenDeep(reference.action));
+          const taskIndex = Number(reference.task_index);
+          expect(row.task?.index).toBe(taskIndex);
+          expect(row.task?.label).toBe(real.taskLabels.get(taskIndex));
+          const atTime = await capability.readAtTime({
+            timestampNs: row.timestampNs,
+          });
+          expect(atTime?.cursor).toBe(row.cursor);
+        }
+
+        // Walking the first rows through bounded windows visits every
+        // cursor exactly once with non-decreasing timestamps.
+        const walkCount = Math.min(60, real.episodeLength);
+        const first = await capability.readIndexWindow({
+          after: 0,
+          anchorTimestampNs: 0n,
+          before: 1,
+        });
+        expect(first.hasPrevious).toBe(false);
+        let cursor = first.selectedCursor;
+        let lastTimestampNs = -1n;
+        const visited = new Set<string>();
+        for (let index = 0; index < walkCount; index += 1) {
+          visited.add(cursor);
+          const window = await capability.readIndexWindow({
+            after: 1,
+            anchorCursor: cursor,
+            before: 0,
+          });
+          expect(window.selectedCursor).toBe(cursor);
+          expect(window.entries[0].timestampNs >= lastTimestampNs).toBe(true);
+          lastTimestampNs = window.entries[0].timestampNs;
+          const next = window.entries[1];
+          if (!next) break;
+          cursor = next.cursor;
+        }
+        expect(visited.size).toBe(walkCount);
+      } finally {
+        session.dispose();
+        await real.close();
+      }
+    }, 30_000);
+  },
+);
+
+async function openRealEpisode(root: string): Promise<{
+  actionNames: readonly (string | undefined)[];
+  close(): Promise<void>;
+  episodeLength: number;
+  io: ByteResources;
+  referenceRows: readonly Record<string, unknown>[];
+  source: EpisodeSource;
+  stateNames: readonly (string | undefined)[];
+  taskLabels: ReadonlyMap<number, string>;
+}> {
+  const paths = new Map([
+    ["data", join(root, "data/chunk-000/file-000.parquet")],
+    ["episodes", join(root, "meta/episodes/chunk-000/file-000.parquet")],
+    ["info", join(root, "meta/info.json")],
+    ["tasks", join(root, "meta/tasks.parquet")],
+  ]);
+  const sizes = new Map(
+    await Promise.all(
+      [...paths.entries()].map(
+        async ([id, path]) => [id, (await stat(path)).size] as const,
+      ),
+    ),
+  );
+  const files = new Map<string, ReturnType<typeof open>>();
+  const readFileRange = async (id: string, offset: number, length: number) => {
+    const path = paths.get(id);
+    if (!path) throw new Error(`Unknown real asset ${id}`);
+    let file = files.get(id);
+    if (!file) {
+      file = open(path, "r");
+      files.set(id, file);
+    }
+    const bytes = new Uint8Array(length);
+    const { bytesRead } = await (await file).read(bytes, 0, length, offset);
+    return bytes.subarray(0, bytesRead);
+  };
+  const buffer = (id: string): AsyncBuffer => ({
+    byteLength: sizes.get(id) ?? 0,
+    async slice(start, end) {
+      const bytes = await readFileRange(
+        id,
+        start,
+        (end ?? sizes.get(id) ?? 0) - start,
+      );
+      return bytes.buffer.slice(
+        bytes.byteOffset,
+        bytes.byteOffset + bytes.byteLength,
+      ) as ArrayBuffer;
+    },
+  });
+
+  const infoBytes = await readFileRange("info", 0, sizes.get("info") ?? 0);
+  const info = JSON.parse(new TextDecoder().decode(infoBytes)) as {
+    features: Record<
+      string,
+      { names?: readonly string[] | null; shape?: readonly number[] }
+    >;
+  };
+  const [episodeRow] = await parquetReadObjects({
+    file: buffer("episodes"),
+    rowEnd: 1,
+    rowStart: 0,
+  });
+  const episodeLength = Number(episodeRow.length);
+  const referenceRows = await parquetReadObjects({
+    columns: [
+      "timestamp",
+      "frame_index",
+      "task_index",
+      "observation.state",
+      "action",
+    ],
+    file: buffer("data"),
+    rowEnd: episodeLength,
+    rowStart: 0,
+  });
+  const taskRows = await parquetReadObjects({
+    columns: ["task_index", "task"],
+    file: buffer("tasks"),
+  });
+  const taskLabels = new Map(
+    taskRows.map((row) => [Number(row.task_index), String(row.task)]),
+  );
+
+  const assets: readonly AssetDescriptor[] = [
+    {
+      id: "info",
+      mediaType: "application/json",
+      metadata: { sizeBytes: String(sizes.get("info")) },
+      role: "dataset-info",
+      selector: { kind: "whole-file" },
+    },
+    {
+      id: "episodes",
+      mediaType: "application/vnd.apache.parquet",
+      metadata: { sizeBytes: String(sizes.get("episodes")) },
+      role: "episode-metadata",
+      selector: {
+        coordinateSystem: "parquet-file-row",
+        end: 1,
+        kind: "row-interval",
+        start: 0,
+      },
+    },
+    {
+      id: "data",
+      mediaType: "application/vnd.apache.parquet",
+      metadata: { sizeBytes: String(sizes.get("data")) },
+      role: "tabular-frame-data",
+      selector: {
+        coordinateSystem: "parquet-file-row",
+        end: episodeLength,
+        kind: "row-interval",
+        start: 0,
+      },
+    },
+    {
+      id: "tasks",
+      mediaType: "application/vnd.apache.parquet",
+      metadata: { sizeBytes: String(sizes.get("tasks")) },
+      role: "tasks-metadata",
+      selector: { kind: "whole-file" },
+    },
+  ];
+  return {
+    actionNames: dimensionNames(info.features.action),
+    close: async () => {
+      await Promise.all(
+        [...files.values()].map(async (file) => (await file).close()),
+      );
+      files.clear();
+    },
+    episodeLength,
+    io: {
+      async readBytes({ range, source: byteSource }) {
+        const bytes = await readFileRange(
+          byteSource.sourceId,
+          Number(range.offset),
+          Number(range.length),
+        );
+        return { bytes, range, source: byteSource };
+      },
+    },
+    referenceRows,
+    source: {
+      assets: {
+        list: async () => assets,
+        resolve: async (assetId) => ({
+          sizeBytes: String(sizes.get(assetId)),
+          sourceId: assetId,
+          url: paths.get(assetId) ?? assetId,
+        }),
+      },
+      episodeId: "episode-0",
+    },
+    stateNames: dimensionNames(info.features["observation.state"]),
+    taskLabels,
+  };
+}
+
+function dimensionNames(feature: {
+  names?: readonly string[] | null;
+  shape?: readonly number[];
+}): readonly (string | undefined)[] {
+  const count = Math.max(
+    1,
+    (feature.shape ?? []).reduce((product, value) => product * value, 1),
+  );
+  return Array.from({ length: count }, (_, index) => {
+    const name = feature.names?.[index];
+    return typeof name === "string" ? name : undefined;
+  });
+}
+
+function flattenDeep(value: unknown): readonly unknown[] {
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => flattenDeep(entry));
+  }
+  if (ArrayBuffer.isView(value) && !(value instanceof DataView)) {
+    return [...(value as unknown as Iterable<unknown>)];
+  }
+  return [value];
+}

--- a/app/packages/multimodal/src/adapters/mcap/format-adapter.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/format-adapter.test.ts
@@ -100,6 +100,7 @@ describe("MCAP format adapter", () => {
           }),
           create(StreamInventorySchema, {
             metadata: {
+              "mcap.exact_browsing": "true",
               "mcap.topic": "/opaque",
               [STREAM_METADATA.DECODE_STATUS]: "schema-unavailable",
             },
@@ -123,9 +124,9 @@ describe("MCAP format adapter", () => {
 
     expect(manifest.recordingFacts).toEqual({
       applicationSupport: {
-        inspectableStreamCount: 1,
+        inspectableStreamCount: 2,
         renderableStreamCount: 1,
-        unavailableStreamCount: 1,
+        unavailableStreamCount: 0,
       },
       channelCount: 3,
       durationNs: "30000000000",
@@ -155,7 +156,7 @@ describe("MCAP format adapter", () => {
         expect.objectContaining({
           id: "3",
           metadata: expect.objectContaining({
-            [STREAM_METADATA.INSPECTABLE]: "false",
+            [STREAM_METADATA.INSPECTABLE]: "true",
           }),
         }),
       ]),

--- a/app/packages/multimodal/src/adapters/mcap/format-adapter.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/format-adapter.test.ts
@@ -81,6 +81,7 @@ describe("MCAP format adapter", () => {
           create(StreamInventorySchema, {
             metadata: {
               "mcap.topic": "/camera",
+              [SCENE_SOURCE_METADATA.TYPE]: "image",
               [STREAM_METADATA.DECODE_STATUS]: "decodable",
             },
             payload: {

--- a/app/packages/multimodal/src/adapters/mcap/format-adapter.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/format-adapter.test.ts
@@ -79,7 +79,10 @@ describe("MCAP format adapter", () => {
       recordingInventory(
         [
           create(StreamInventorySchema, {
-            metadata: { "mcap.topic": "/camera" },
+            metadata: {
+              "mcap.topic": "/camera",
+              [STREAM_METADATA.DECODE_STATUS]: "decodable",
+            },
             payload: {
               encoding: "cdr",
               schema: "sensor_msgs/msg/Image",
@@ -134,6 +137,28 @@ describe("MCAP format adapter", () => {
       startTimeNs: "10000000000",
       topicCount: 3,
     });
+    expect(manifest.streams).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "1",
+          metadata: expect.objectContaining({
+            [STREAM_METADATA.INSPECTABLE]: "true",
+          }),
+        }),
+        expect.objectContaining({
+          id: "2",
+          metadata: expect.objectContaining({
+            [STREAM_METADATA.INSPECTABLE]: "true",
+          }),
+        }),
+        expect.objectContaining({
+          id: "3",
+          metadata: expect.objectContaining({
+            [STREAM_METADATA.INSPECTABLE]: "false",
+          }),
+        }),
+      ]),
+    );
   });
 
   it("preserves source size discovered while reading inventory", () => {

--- a/app/packages/multimodal/src/adapters/mcap/format-adapter.ts
+++ b/app/packages/multimodal/src/adapters/mcap/format-adapter.ts
@@ -3,10 +3,10 @@ import {
   STREAM_METADATA,
   STREAM_SYNC_MODE,
   STREAM_KIND,
+  recordingSupportFactsFromStreams,
   type ByteSourceDescriptor,
   type DecodedFrame,
   type EpisodeManifest,
-  type EpisodeRecordingSupportFacts,
   type EpisodePreviewReadResult,
   type StreamDescriptor,
   type StreamKind,
@@ -737,7 +737,7 @@ export function createMcapManifest(
     episodeId,
     recordingFacts: {
       ...inventory.recordingFacts,
-      applicationSupport: recordingSupportFacts(streams),
+      applicationSupport: recordingSupportFactsFromStreams(streams),
       durationNs: (range.endTimeNs - range.startTimeNs).toString(),
       endTimeNs: range.endTimeNs.toString(),
       ...(source?.readProfile ? { readProfile: source.readProfile } : {}),
@@ -749,30 +749,6 @@ export function createMcapManifest(
     streams,
     timeDomain: { id: MCAP_ACTIVE_TIMELINE.LOG, kind: "timestamp" },
     timeRange,
-  };
-}
-
-function recordingSupportFacts(
-  streams: readonly StreamDescriptor[],
-): EpisodeRecordingSupportFacts {
-  let inspectableStreamCount = 0;
-  let renderableStreamCount = 0;
-  let unavailableStreamCount = 0;
-  for (const stream of streams) {
-    if (stream.kind !== STREAM_KIND.UNKNOWN) {
-      renderableStreamCount++;
-    } else if (
-      stream.metadata?.[STREAM_METADATA.DECODE_STATUS] === "decodable"
-    ) {
-      inspectableStreamCount++;
-    } else {
-      unavailableStreamCount++;
-    }
-  }
-  return {
-    inspectableStreamCount,
-    renderableStreamCount,
-    unavailableStreamCount,
   };
 }
 

--- a/app/packages/multimodal/src/adapters/mcap/format-adapter.ts
+++ b/app/packages/multimodal/src/adapters/mcap/format-adapter.ts
@@ -716,7 +716,8 @@ export function createMcapManifest(
       metadata: {
         ...topic.metadata,
         [STREAM_METADATA.INSPECTABLE]:
-          topic.metadata[STREAM_METADATA.DECODE_STATUS] === "decodable"
+          topic.metadata[STREAM_METADATA.DECODE_STATUS] === "decodable" ||
+          topic.metadata["mcap.exact_browsing"] === "true"
             ? "true"
             : "false",
         ...(calibrationSourceName

--- a/app/packages/multimodal/src/adapters/mcap/format-adapter.ts
+++ b/app/packages/multimodal/src/adapters/mcap/format-adapter.ts
@@ -712,6 +712,10 @@ export function createMcapManifest(
       kind: streamKindForPayload(topic.payload),
       metadata: {
         ...topic.metadata,
+        [STREAM_METADATA.INSPECTABLE]:
+          topic.metadata[STREAM_METADATA.DECODE_STATUS] === "decodable"
+            ? "true"
+            : "false",
         ...(calibrationSourceName
           ? {
               [SCENE_SOURCE_METADATA.CALIBRATION_STREAM_ID]:

--- a/app/packages/multimodal/src/adapters/mcap/synchronization/policy-parity.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/synchronization/policy-parity.test.ts
@@ -99,6 +99,35 @@ describe("generic and MCAP synchronization parity", () => {
     });
   });
 
+  it("sorts strict duplicate timestamps before limiting them", async () => {
+    const frames = [frame(TIME_NS, 2), frame(TIME_NS, 0), frame(TIME_NS, 1)];
+    const runtimeWindow = (
+      await readSynchronizedPlaybackBatchFallback(session(frames), {
+        streamPolicies: {
+          [STREAM]: { limit: 2, mode: STREAM_SYNC_MODE.STRICT },
+        },
+        streams: [STREAM],
+        timeNs: [TIME_NS],
+      })
+    )[0];
+    const bounds = createWindowBounds({
+      streamPolicies: {
+        [STREAM]: { limit: 2, mode: PlaybackSyncMode.STRICT },
+      },
+      timeNs: TIME_NS,
+      topics: [STREAM],
+    }).streamPolicies[STREAM];
+    const mcapSelected = selectCandidatesForTopic(
+      [message(TIME_NS, 2), message(TIME_NS, 0), message(TIME_NS, 1)],
+      TIME_NS,
+      bounds,
+      (left, right) => left.sequence - right.sequence,
+    );
+
+    expect(runtimeWindow.frames.map((item) => item.sequence)).toEqual([0, 1]);
+    expect(mcapSelected.map((item) => item.sequence)).toEqual([0, 1]);
+  });
+
   it.each([
     {
       mcap: { limit: 0 },

--- a/app/packages/multimodal/src/adapters/mcap/synchronization/policy.ts
+++ b/app/packages/multimodal/src/adapters/mcap/synchronization/policy.ts
@@ -171,8 +171,8 @@ export function selectCandidatesForTopic<Candidate extends SyncCandidate>(
     case PlaybackSyncMode.STRICT:
       return inWindow
         .filter((candidate) => candidate.timelineTimeNs === timeNs)
-        .slice(0, policy.limit)
-        .sort(compareByTime);
+        .sort(compareByTime)
+        .slice(0, policy.limit);
     case PlaybackSyncMode.LATEST:
       return inWindow
         .filter((candidate) => candidate.timelineTimeNs <= timeNs)

--- a/app/packages/multimodal/src/extensions/tiles/types.ts
+++ b/app/packages/multimodal/src/extensions/tiles/types.ts
@@ -8,6 +8,7 @@ export type EpisodeTileExtensionId = `${string}:${string}`;
 export interface EpisodeTileAvailability {
   readonly hasNumericSeries: boolean;
   readonly hasRawRecords: boolean;
+  readonly hasStateAction: boolean;
   readonly hasTransformTopology: boolean;
   readonly sourceTypes: readonly string[];
 }

--- a/app/packages/multimodal/src/index.ts
+++ b/app/packages/multimodal/src/index.ts
@@ -17,6 +17,7 @@ export type {
   DecodedTiming,
   DecodedVisualization,
   CameraVisualization,
+  EncodedAv1VideoVisualization,
   EncodedH264VideoVisualization,
   EncodedImageVisualization,
   EncodedVideoVisualization,

--- a/app/packages/multimodal/src/inject/index.test.ts
+++ b/app/packages/multimodal/src/inject/index.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getEpisodeTileExtension } from "../extensions/tiles/registry";
+import {
+  getFormatAdapterDescriptors,
+  resetFormatAdapterRegistryForTests,
+} from "../runtime/adapter-registry";
+
+vi.mock("@fiftyone/plugins", () => ({
+  PluginComponentType: { Panel: "Panel", SampleRenderer: "SampleRenderer" },
+  registerComponent: vi.fn(),
+  SAMPLE_RENDERER_GRID_SLOT: { HEADER_AFTER_RESOURCE_COUNT: "slot" },
+}));
+
+afterEach(() => resetFormatAdapterRegistryForTests());
+
+describe("injection root composition", () => {
+  // Deliberately heavy: load() pulls the real format adapter and the whole
+  // tile chunk, which under full-suite transform contention outlives the
+  // default timeout.
+  it(
+    "registers the LeRobot tile extension with the format's lazy load",
+    {
+      timeout: 30_000,
+    },
+    async () => {
+      await import("./index");
+
+      const descriptor = getFormatAdapterDescriptors().find(
+        (candidate) => candidate.id === "lerobot-v3",
+      );
+      expect(descriptor).toBeDefined();
+      // The composed descriptor stays lazy: registering it loads nothing.
+      expect(getEpisodeTileExtension("lerobot:state-action")).toBeNull();
+
+      const adapter = await descriptor?.load();
+      expect(adapter).toBeDefined();
+      // The tile extension exists as soon as load() resolves — before any
+      // opened session can expose hasStateAction to the catalog.
+      expect(getEpisodeTileExtension("lerobot:state-action")).not.toBeNull();
+    },
+  );
+});

--- a/app/packages/multimodal/src/inject/index.ts
+++ b/app/packages/multimodal/src/inject/index.ts
@@ -1,6 +1,8 @@
+import { leRobotAdapterDescriptor } from "../adapters/lerobot/descriptor";
 import { mcapAdapterDescriptor } from "../adapters/mcap/descriptor";
 import { registerFormatAdapter } from "../runtime/adapter-registry";
 import { registerEpisodeViews } from "../views/entry";
 
+registerFormatAdapter(leRobotAdapterDescriptor);
 registerFormatAdapter(mcapAdapterDescriptor);
 registerEpisodeViews();

--- a/app/packages/multimodal/src/inject/index.ts
+++ b/app/packages/multimodal/src/inject/index.ts
@@ -1,8 +1,25 @@
 import { leRobotAdapterDescriptor } from "../adapters/lerobot/descriptor";
 import { mcapAdapterDescriptor } from "../adapters/mcap/descriptor";
 import { registerFormatAdapter } from "../runtime/adapter-registry";
-import { registerEpisodeViews } from "../views/entry";
+import {
+  loadLeRobotViewExtensions,
+  registerEpisodeViews,
+} from "../views/entry";
 
-registerFormatAdapter(leRobotAdapterDescriptor);
+// Format-specific view extensions are composed onto the adapter's lazy
+// load here, in the injection root: the adapter layer stays view-free,
+// while the extension still registers before `load()` resolves — so it
+// exists before any session can expose `hasStateAction` — and stays out
+// of the initial bundle for non-LeRobot sessions.
+registerFormatAdapter({
+  ...leRobotAdapterDescriptor,
+  load: async (options) => {
+    const [adapter] = await Promise.all([
+      leRobotAdapterDescriptor.load(options),
+      loadLeRobotViewExtensions(),
+    ]);
+    return adapter;
+  },
+});
 registerFormatAdapter(mcapAdapterDescriptor);
 registerEpisodeViews();

--- a/app/packages/multimodal/src/ir/frames.ts
+++ b/app/packages/multimodal/src/ir/frames.ts
@@ -39,6 +39,8 @@ interface BaseEncodedVideoVisualization {
   readonly kind: typeof VISUALIZATION_KIND.ENCODED_VIDEO;
   readonly bytes: Uint8Array;
   readonly coordinateFrameId?: string;
+  /** Decode-order timestamp when it differs from presentation order. */
+  readonly decodeTimestampNs?: bigint;
   readonly format: string;
   readonly keyframe?: boolean;
   readonly timestampNs?: bigint;

--- a/app/packages/multimodal/src/ir/frames.ts
+++ b/app/packages/multimodal/src/ir/frames.ts
@@ -59,6 +59,12 @@ export interface EncodedH264VideoVisualization extends BaseEncodedVideoVisualiza
   };
 }
 
+/** AV1 temporal unit carried directly from an ISO BMFF sample. */
+export interface EncodedAv1VideoVisualization extends BaseEncodedVideoVisualization {
+  readonly codec: "av1";
+  readonly h264?: never;
+}
+
 /**
  * Encoded video access unit decoded from one record. The contract lets source
  * streams be classified as image-family streams while keeping codec metadata
@@ -66,8 +72,9 @@ export interface EncodedH264VideoVisualization extends BaseEncodedVideoVisualiza
  */
 export type EncodedVideoVisualization =
   | EncodedH264VideoVisualization
+  | EncodedAv1VideoVisualization
   | (BaseEncodedVideoVisualization & {
-      readonly codec: "av1" | "h265" | "vp9";
+      readonly codec: "h265" | "vp9";
       readonly h264?: never;
     });
 

--- a/app/packages/multimodal/src/ir/manifest.ts
+++ b/app/packages/multimodal/src/ir/manifest.ts
@@ -56,8 +56,11 @@ export const SCENE_SOURCE_METADATA = Object.freeze({
 
 /** Well-known adapter-normalized metadata keys used by generic inventories. */
 export const STREAM_METADATA = Object.freeze({
+  CATEGORY: "stream.category",
+  COUNT_NOUN: "stream.count_noun",
   DECODE_STATUS: "stream.decode_status",
   ENCODING: "stream.encoding",
+  INSPECTABLE: "stream.inspectable",
   SCHEMA_NAME: "stream.schema_name",
 } as const);
 
@@ -160,6 +163,19 @@ export interface McapRecordingFacts {
   readonly profile?: string;
 }
 
+/** LeRobot-specific facts resolved from its selected episode metadata. */
+export interface LeRobotRecordingFacts {
+  readonly codebaseVersion?: string;
+  readonly episodeIndex?: string;
+  readonly featureCount?: number;
+  readonly fps?: number;
+  readonly logicalRowCount?: number;
+  readonly mediaFeatureCount?: number;
+  readonly robotType?: string;
+  readonly taskLabels?: readonly string[];
+  readonly videoCodecs?: readonly string[];
+}
+
 /** Immutable episode-wide recording facts safe to clone across workers. */
 export interface EpisodeRecordingFacts {
   readonly applicationSupport?: EpisodeRecordingSupportFacts;
@@ -167,6 +183,7 @@ export interface EpisodeRecordingFacts {
   readonly durationNs?: string;
   readonly endTimeNs?: string;
   readonly format: string;
+  readonly lerobot?: LeRobotRecordingFacts;
   readonly mcap?: McapRecordingFacts;
   readonly messageCount?: string;
   readonly readProfile?: ByteSourceReadProfile;

--- a/app/packages/multimodal/src/ir/manifest.ts
+++ b/app/packages/multimodal/src/ir/manifest.ts
@@ -29,6 +29,34 @@ export const STREAM_KIND = Object.freeze({
 /** Closed union of renderer-level stream families. */
 export type StreamKind = (typeof STREAM_KIND)[keyof typeof STREAM_KIND];
 
+/** Shared catalog categories that adapters may assign to streams. */
+export const STREAM_CATEGORY = Object.freeze({
+  ACTIONS: "actions",
+  ANNOTATIONS_PLANNING: "annotations-planning",
+  CUSTOM: "custom",
+  DIAGNOSTICS: "diagnostics",
+  INSTRUCTIONS: "instructions",
+  OBSERVATIONS: "observations",
+  SENSORS: "sensors",
+  TELEMETRY: "telemetry",
+  TRANSFORMS_POSES: "transforms-poses",
+} as const);
+
+/** Closed union of shared stream-catalog categories. */
+export type StreamCategory =
+  (typeof STREAM_CATEGORY)[keyof typeof STREAM_CATEGORY];
+
+/** Shared plural nouns for exact per-stream record counts. */
+export const STREAM_COUNT_NOUN = Object.freeze({
+  FRAMES: "frames",
+  MESSAGES: "messages",
+  SAMPLES: "samples",
+} as const);
+
+/** Closed union of shared stream-count nouns. */
+export type StreamCountNoun =
+  (typeof STREAM_COUNT_NOUN)[keyof typeof STREAM_COUNT_NOUN];
+
 /** Semantic source families consumed by the shared scene views. */
 export const SCENE_SOURCE_TYPE = Object.freeze({
   AUDIO: "audio",
@@ -46,6 +74,8 @@ export const SCENE_SOURCE_TYPE = Object.freeze({
 /** Closed union of semantic source families understood by scene views. */
 export type SceneSourceType =
   (typeof SCENE_SOURCE_TYPE)[keyof typeof SCENE_SOURCE_TYPE];
+
+const SCENE_SOURCE_TYPES = new Set<string>(Object.values(SCENE_SOURCE_TYPE));
 
 /** Well-known renderer-neutral scene-source metadata keys. */
 export const SCENE_SOURCE_METADATA = Object.freeze({
@@ -192,6 +222,34 @@ export interface EpisodeRecordingFacts {
   readonly sizeBytes?: string;
   readonly startTimeNs?: string;
   readonly topicCount?: number;
+}
+
+/** Classifies streams into mutually exclusive scene, inspection, or unavailable totals. */
+export function recordingSupportFactsFromStreams(
+  streams: readonly StreamDescriptor[],
+): EpisodeRecordingSupportFacts {
+  let inspectableStreamCount = 0;
+  let renderableStreamCount = 0;
+  let unavailableStreamCount = 0;
+  for (const stream of streams) {
+    const sceneSourceType = stream.metadata?.[SCENE_SOURCE_METADATA.TYPE];
+    if (
+      (sceneSourceType !== undefined &&
+        SCENE_SOURCE_TYPES.has(sceneSourceType)) ||
+      stream.kind === STREAM_KIND.TRANSFORM
+    ) {
+      renderableStreamCount++;
+    } else if (stream.metadata?.[STREAM_METADATA.INSPECTABLE] === "true") {
+      inspectableStreamCount++;
+    } else {
+      unavailableStreamCount++;
+    }
+  }
+  return {
+    inspectableStreamCount,
+    renderableStreamCount,
+    unavailableStreamCount,
+  };
 }
 
 /** Cloneable inventory returned when an episode session opens. */

--- a/app/packages/multimodal/src/ir/preview.ts
+++ b/app/packages/multimodal/src/ir/preview.ts
@@ -1,3 +1,4 @@
+import type { ByteSourceDescriptor } from "./bytes";
 import type { CameraVisualization, PointCloudVisualization } from "./frames";
 import type { EpisodeManifest, StreamId } from "./manifest";
 import type { EpisodeTimeline } from "./playback";
@@ -17,6 +18,13 @@ export type EpisodePosterFrame =
 /** Adapter-produced outcome for one lightweight episode preview read. */
 export type EpisodePreviewReadStatus = "empty" | "ready" | "unavailable";
 
+/** Browser-native video source scoped to one half-open episode interval. */
+export interface EpisodePreviewNativeVideo {
+  readonly endTimeSeconds: number;
+  readonly source: ByteSourceDescriptor;
+  readonly startTimeSeconds: number;
+}
+
 /** Cloneable result handed from a format preview provider to the grid. */
 export interface EpisodePreviewReadResult {
   /** Manifest learned while opening the source, normally only on first read. */
@@ -27,6 +35,8 @@ export interface EpisodePreviewReadResult {
   readonly bootstrapTimeRange?: TimeWindow;
   readonly frame: EpisodePosterFrame | null;
   readonly frameTimeNs?: bigint;
+  /** Optional native-video path used only by lightweight grid playback. */
+  readonly nativeVideo?: EpisodePreviewNativeVideo;
   readonly nextStartTimeNs?: bigint;
   /** Selected stream identity in this episode, if one was resolved. */
   readonly streamId: StreamId | null;

--- a/app/packages/multimodal/src/ir/preview.ts
+++ b/app/packages/multimodal/src/ir/preview.ts
@@ -1,5 +1,9 @@
 import type { ByteSourceDescriptor } from "./bytes";
-import type { CameraVisualization, PointCloudVisualization } from "./frames";
+import type {
+  CameraVisualization,
+  EncodedVideoVisualization,
+  PointCloudVisualization,
+} from "./frames";
 import type { EpisodeManifest, StreamId } from "./manifest";
 import type { EpisodeTimeline } from "./playback";
 import type { TimeWindow } from "./time";
@@ -20,6 +24,10 @@ export type EpisodePreviewReadStatus = "empty" | "ready" | "unavailable";
 
 /** Browser-native video source scoped to one half-open episode interval. */
 export interface EpisodePreviewNativeVideo {
+  /** Browser codec family used for runtime native-playback capability checks. */
+  readonly codec: EncodedVideoVisualization["codec"];
+  /** Container-qualified codec string used by `canPlayType()`. */
+  readonly codecString: string;
   readonly endTimeSeconds: number;
   readonly source: ByteSourceDescriptor;
   readonly startTimeSeconds: number;

--- a/app/packages/multimodal/src/ir/preview.ts
+++ b/app/packages/multimodal/src/ir/preview.ts
@@ -45,4 +45,6 @@ export interface EpisodePreviewReadResult {
   /** Previewable source names suitable for dataset-scoped selection. */
   readonly streamSourceNames: readonly string[];
   readonly status: EpisodePreviewReadStatus;
+  /** Decode-order access units retained alongside an encoded-video poster. */
+  readonly videoDecodeRunway?: readonly EpisodePosterFrame[];
 }

--- a/app/packages/multimodal/src/ports/adapter.ts
+++ b/app/packages/multimodal/src/ports/adapter.ts
@@ -10,11 +10,30 @@ import type { ByteResources, EpisodeSession, ReadPriority } from "./session";
 
 /** One stable asset exposed by an episode resolver. */
 export interface AssetDescriptor {
+  readonly featureName?: string;
   readonly id: string;
   readonly mediaType?: string;
   readonly metadata?: Readonly<Record<string, string>>;
   readonly role: string;
+  readonly selector?: AssetSelectorDescriptor;
 }
+
+/** Closed, browser-safe selector vocabulary returned by media manifests. */
+export type AssetSelectorDescriptor =
+  | { readonly kind: "whole-file" }
+  | {
+      readonly coordinateSystem:
+        | "lerobot-v3-global-dataset-row"
+        | "parquet-file-row";
+      readonly end: number;
+      readonly kind: "row-interval";
+      readonly start: number;
+    }
+  | {
+      readonly fromTimestamp: number;
+      readonly kind: "video-timestamp-interval";
+      readonly toTimestamp: number;
+    };
 
 /** Resolves one or more physical assets that make up an episode. */
 export interface AssetResolver {

--- a/app/packages/multimodal/src/ports/adapter.ts
+++ b/app/packages/multimodal/src/ports/adapter.ts
@@ -89,6 +89,8 @@ export interface AdapterDescriptor {
 
 /** One lightweight poster request made before a full episode session opens. */
 export interface EpisodePreviewReadRequest {
+  /** Forward access-unit coverage needed to decode the requested video frame. */
+  readonly decodeLookaheadNs?: bigint;
   /** Stable, human-facing source name used for cross-episode selection. */
   readonly sourceName?: string | null;
   readonly startTimeNs?: bigint;

--- a/app/packages/multimodal/src/ports/errors.test.ts
+++ b/app/packages/multimodal/src/ports/errors.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  EpisodeReadCancelledError,
+  EpisodeReadUnsupportedError,
   EPISODE_READ_CANCELLED_MESSAGE,
   isEpisodeReadCancelledError,
 } from "./errors";
@@ -26,4 +28,37 @@ describe("isEpisodeReadCancelledError", () => {
       ),
     ).toBe(false);
   });
+
+  it("constructs typed errors when the host freezes the base Error name", () => {
+    const cancelled = withReadonlyErrorName(
+      () => new EpisodeReadCancelledError(),
+    );
+    const unsupported = withReadonlyErrorName(
+      () => new EpisodeReadUnsupportedError("seek", "unsupported"),
+    );
+
+    expect(cancelled).toMatchObject({
+      message: EPISODE_READ_CANCELLED_MESSAGE,
+      name: "EpisodeReadCancelledError",
+    });
+    expect(unsupported).toMatchObject({
+      message: "unsupported",
+      name: "EpisodeReadUnsupportedError",
+      operation: "seek",
+    });
+  });
 });
+
+function withReadonlyErrorName<T>(construct: () => T): T {
+  const descriptor = Object.getOwnPropertyDescriptor(Error.prototype, "name");
+  if (!descriptor) throw new Error("Error.prototype.name is unavailable");
+  Object.defineProperty(Error.prototype, "name", {
+    ...descriptor,
+    writable: false,
+  });
+  try {
+    return construct();
+  } finally {
+    Object.defineProperty(Error.prototype, "name", descriptor);
+  }
+}

--- a/app/packages/multimodal/src/ports/errors.ts
+++ b/app/packages/multimodal/src/ports/errors.ts
@@ -49,6 +49,35 @@ export class EpisodeReadUnsupportedError extends Error {
   }
 }
 
+/** Stable code for an unknown or stale-epoch exact-row cursor. */
+export const EPISODE_EXACT_CURSOR_INVALID_CODE = "episode-exact-cursor-invalid";
+
+/**
+ * Typed rejection for an exact-row read whose cursor is unknown or belongs to
+ * another source epoch. Raised instead of silently substituting a nearby row.
+ */
+export class EpisodeExactCursorError extends Error {
+  readonly code = EPISODE_EXACT_CURSOR_INVALID_CODE;
+
+  constructor(message: string) {
+    super(message);
+    setErrorName(this, "EpisodeExactCursorError");
+  }
+}
+
+/** Returns whether an error represents an unknown or stale exact-row cursor. */
+export function isEpisodeExactCursorError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const candidate = error as {
+    readonly code?: unknown;
+    readonly name?: unknown;
+  };
+  return (
+    candidate.name === "EpisodeExactCursorError" ||
+    candidate.code === EPISODE_EXACT_CURSOR_INVALID_CODE
+  );
+}
+
 /** Defines an own name even when the host freezes Error.prototype. */
 function setErrorName(error: Error, name: string): void {
   Object.defineProperty(error, "name", { configurable: true, value: name });

--- a/app/packages/multimodal/src/ports/errors.ts
+++ b/app/packages/multimodal/src/ports/errors.ts
@@ -10,7 +10,7 @@ export class EpisodeReadCancelledError extends Error {
 
   constructor() {
     super(EPISODE_READ_CANCELLED_MESSAGE);
-    this.name = "EpisodeReadCancelledError";
+    setErrorName(this, "EpisodeReadCancelledError");
   }
 }
 
@@ -45,6 +45,11 @@ export class EpisodeReadUnsupportedError extends Error {
     message: string,
   ) {
     super(message);
-    this.name = "EpisodeReadUnsupportedError";
+    setErrorName(this, "EpisodeReadUnsupportedError");
   }
+}
+
+/** Defines an own name even when the host freezes Error.prototype. */
+function setErrorName(error: Error, name: string): void {
+  Object.defineProperty(error, "name", { configurable: true, value: name });
 }

--- a/app/packages/multimodal/src/ports/index.ts
+++ b/app/packages/multimodal/src/ports/index.ts
@@ -6,3 +6,5 @@ export * from "./errors";
 export * from "./numeric-series";
 /** Public episode-session data-plane contracts. */
 export * from "./session";
+/** Exact single-row state/action inspection contract. */
+export * from "./state-action";

--- a/app/packages/multimodal/src/ports/playback-policy.test.ts
+++ b/app/packages/multimodal/src/ports/playback-policy.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { prioritizedStreams } from "./playback-policy";
+
+describe("prioritizedStreams", () => {
+  it("deduplicates requested streams without changing their order", () => {
+    expect(
+      prioritizedStreams(["camera", "state", "camera"], undefined),
+    ).toEqual(["camera", "state"]);
+  });
+
+  it("prioritizes requested streams once and preserves the remaining order", () => {
+    expect(
+      prioritizedStreams(
+        ["camera", "state", "camera", "audio"],
+        ["audio", "camera", "audio", "missing"],
+      ),
+    ).toEqual(["audio", "camera", "state"]);
+  });
+});

--- a/app/packages/multimodal/src/ports/playback-policy.ts
+++ b/app/packages/multimodal/src/ports/playback-policy.ts
@@ -239,7 +239,7 @@ function selectFrames(
         .slice(0, policy.limit)
         .sort(chronological);
     case STREAM_SYNC_MODE.STRICT:
-      return inWindow.slice(0, policy.limit).sort(chronological);
+      return [...inWindow].sort(chronological).slice(0, policy.limit);
     case STREAM_SYNC_MODE.LATEST:
       return [...inWindow]
         .filter((frame) => frame.timestampNs <= timeNs)

--- a/app/packages/multimodal/src/ports/playback-policy.ts
+++ b/app/packages/multimodal/src/ports/playback-policy.ts
@@ -9,7 +9,6 @@ import {
   type StreamSyncPolicy,
   type SynchronizedFrameWindow,
 } from "../ir";
-import { maxBigInt, minBigInt } from "../utils/bigint";
 
 /** Default symmetric tolerance for nearest-frame presentation. */
 export const DEFAULT_EPISODE_SYNC_TOLERANCE_NS = 50_000_000n;
@@ -293,4 +292,14 @@ function absBigInt(value: bigint): bigint {
 
 function clampStartTime(value: bigint): bigint {
   return value < 0n ? 0n : value;
+}
+
+function maxBigInt(values: readonly bigint[]): bigint {
+  if (values.length === 0) throw new Error("Expected at least one time value");
+  return values.reduce((maximum, value) => (value > maximum ? value : maximum));
+}
+
+function minBigInt(values: readonly bigint[]): bigint {
+  if (values.length === 0) throw new Error("Expected at least one time value");
+  return values.reduce((minimum, value) => (value < minimum ? value : minimum));
 }

--- a/app/packages/multimodal/src/ports/playback-policy.ts
+++ b/app/packages/multimodal/src/ports/playback-policy.ts
@@ -15,6 +15,7 @@ export const DEFAULT_EPISODE_SYNC_TOLERANCE_NS = 50_000_000n;
 
 const DEFAULT_STREAM_SYNC_LIMIT = 1;
 
+/** Read bounds and per-stream policies resolved for one playhead target. */
 export interface ResolvedPlaybackWindow {
   readonly endNs: bigint;
   readonly startNs: bigint;
@@ -22,6 +23,7 @@ export interface ResolvedPlaybackWindow {
   readonly timeNs: bigint;
 }
 
+/** Format-neutral request used to derive a synchronized playback window. */
 export interface PlaybackWindowRequest {
   readonly defaultStreamPolicy?: StreamSyncPolicy;
   readonly streamPolicies?: StreamSyncPolicies;
@@ -29,6 +31,7 @@ export interface PlaybackWindowRequest {
   readonly timeNs: bigint;
 }
 
+/** Places requested priority streams first without duplicating stream ids. */
 export function prioritizedStreams(
   streams: readonly string[],
   priorityStreams: readonly string[] | undefined,
@@ -42,6 +45,7 @@ export function prioritizedStreams(
   return [...priority, ...streams.filter((stream) => !prioritized.has(stream))];
 }
 
+/** Resolves one read window from manifest bounds and stream sync policies. */
 export function resolvePlaybackWindow(
   manifestStartNs: bigint,
   streamsById: ReadonlyMap<string, StreamDescriptor>,
@@ -81,6 +85,7 @@ export function resolvePlaybackWindow(
   };
 }
 
+/** Selects and orders the frames that satisfy a resolved playback window. */
 export function selectPlaybackWindow(
   candidatesByStream: ReadonlyMap<string, readonly DecodedFrame[]>,
   streams: readonly string[],
@@ -109,6 +114,7 @@ export function selectPlaybackWindow(
   };
 }
 
+/** Reads manifest time bounds for the requested streams in request order. */
 export function streamTimeBoundsFromManifest(
   manifest: EpisodeManifest,
   streams: readonly string[],
@@ -124,6 +130,7 @@ export function streamTimeBoundsFromManifest(
   });
 }
 
+/** Resolves an explicit or manifest-derived read start for one stream. */
 export function readStartForPolicy(
   manifestStartNs: bigint,
   streamsById: ReadonlyMap<string, StreamDescriptor>,
@@ -134,6 +141,7 @@ export function readStartForPolicy(
   return streamsById.get(streamId)?.timeRange.startNs ?? manifestStartNs;
 }
 
+/** Creates a synchronized window with no selected frames. */
 export function emptyPlaybackWindow(timeNs: bigint): SynchronizedFrameWindow {
   return {
     endNs: timeNs,

--- a/app/packages/multimodal/src/ports/playback-policy.ts
+++ b/app/packages/multimodal/src/ports/playback-policy.ts
@@ -36,13 +36,16 @@ export function prioritizedStreams(
   streams: readonly string[],
   priorityStreams: readonly string[] | undefined,
 ): string[] {
-  if (!priorityStreams?.length) return [...streams];
   const requested = new Set(streams);
+  if (!priorityStreams?.length) return [...requested];
   const priority = [...new Set(priorityStreams)].filter((stream) =>
     requested.has(stream),
   );
   const prioritized = new Set(priority);
-  return [...priority, ...streams.filter((stream) => !prioritized.has(stream))];
+  return [
+    ...priority,
+    ...[...requested].filter((stream) => !prioritized.has(stream)),
+  ];
 }
 
 /** Resolves one read window from manifest bounds and stream sync policies. */

--- a/app/packages/multimodal/src/ports/session.ts
+++ b/app/packages/multimodal/src/ports/session.ts
@@ -24,6 +24,7 @@ import type {
   EpisodeTransformTopologyEdgeObservation,
   EpisodeTransformTopologyFrameUse,
 } from "../ir";
+import type { StateActionCapability } from "./state-action";
 
 /** Four proven scheduling lanes exposed by every episode session. */
 export type ReadPriority = "bulk" | "current" | "idle" | "playback";
@@ -491,6 +492,7 @@ export interface EpisodeSession {
   readonly playback?: PlaybackReadCapability;
   readonly pointCloudProjection?: PointCloudProjectionCapability;
   readonly rawRecords?: RawRecordCapability;
+  readonly stateAction?: StateActionCapability;
   readonly synchronizedRead?: SynchronizedReadAcceleration;
   readonly terminology?: EpisodeTerminology;
   readonly transformRead?: TransformReadAcceleration;

--- a/app/packages/multimodal/src/ports/state-action.ts
+++ b/app/packages/multimodal/src/ports/state-action.ts
@@ -13,9 +13,13 @@ export interface StateActionFeatureSchema {
   readonly dimensions: readonly {
     readonly index: number;
     readonly name?: string;
+    /** Numeric-series field path plotting this dimension, when served. */
+    readonly numericFieldPath?: string;
   }[];
   readonly dtype: string;
   readonly featureName: string;
+  /** Numeric-series stream serving this feature's dimensions, when any. */
+  readonly numericStreamId?: string;
   readonly shape: readonly number[];
 }
 

--- a/app/packages/multimodal/src/ports/state-action.ts
+++ b/app/packages/multimodal/src/ports/state-action.ts
@@ -54,6 +54,25 @@ export interface StateActionRow {
   readonly timestampNs: bigint;
 }
 
+/** Source-declared per-dimension statistics for one feature, row-major. */
+export interface StateActionFeatureStats {
+  readonly max?: readonly number[];
+  readonly mean?: readonly number[];
+  readonly min?: readonly number[];
+  readonly q01?: readonly number[];
+  readonly q50?: readonly number[];
+  readonly q99?: readonly number[];
+  readonly std?: readonly number[];
+}
+
+/** Source-declared dataset statistics for the canonical features. */
+export interface StateActionStats {
+  readonly action?: StateActionFeatureStats;
+  /** Dataset-wide frame count the statistics were computed over. */
+  readonly sampleCount?: number;
+  readonly state?: StateActionFeatureStats;
+}
+
 /**
  * Optional semantic capability for exact single-row state/action inspection.
  *
@@ -84,4 +103,12 @@ export interface StateActionCapability {
       readonly signal?: AbortSignal;
     },
   ): Promise<RawRecordIndexWindow>;
+  /**
+   * Source-declared per-dimension statistics, read lazily and cached for
+   * the session. Resolves null when the source ships none; a missing or
+   * unreadable statistics asset never blocks row inspection.
+   */
+  readDimensionStats?(options?: {
+    readonly signal?: AbortSignal;
+  }): Promise<StateActionStats | null>;
 }

--- a/app/packages/multimodal/src/ports/state-action.ts
+++ b/app/packages/multimodal/src/ports/state-action.ts
@@ -73,6 +73,70 @@ export interface StateActionStats {
   readonly state?: StateActionFeatureStats;
 }
 
+/** One episode extreme: the exact row where a dimension attains a value. */
+export interface StateActionDimensionExtreme {
+  readonly frameIndex: number;
+  readonly timestampNs: bigint;
+  readonly value: number;
+}
+
+/**
+ * Episode-computed per-dimension aggregates for one feature, row-major.
+ * Only finite numeric values aggregate; a dimension with none is null.
+ */
+export interface StateActionFeatureProfile {
+  readonly max: readonly (StateActionDimensionExtreme | null)[];
+  readonly mean: readonly (number | null)[];
+  readonly min: readonly (StateActionDimensionExtreme | null)[];
+  /**
+   * Rows whose value falls outside the source-declared [min, max]; null
+   * for a dimension without declared bounds, or entirely when the source
+   * declares no statistics.
+   */
+  readonly outOfRangeCounts: readonly (number | null)[] | null;
+}
+
+/** One irregular inter-row interval in the episode's recorded timeline. */
+export interface StateActionTimingGap {
+  /** Frame index of the last row before the gap. */
+  readonly beforeFrameIndex: number;
+  readonly durationNs: bigint;
+  /** Timestamp of the first row after the gap — the natural seek target. */
+  readonly timestampNs: bigint;
+}
+
+/**
+ * Recorded-cadence facts for the episode. A gap is an inter-row interval
+ * exceeding 1.5× the median interval, so a single dropped frame at a
+ * steady rate registers while ordinary jitter does not.
+ */
+export interface StateActionTimingProfile {
+  readonly gapCount: number;
+  /** Largest-first sample of the gaps, capped for transport. */
+  readonly gaps: readonly StateActionTimingGap[];
+  /** Median inter-row interval; 0n with fewer than two rows. */
+  readonly medianIntervalNs: bigint;
+}
+
+/**
+ * Episode-computed profile over every row: per-dimension extremes and
+ * means, recorded-timing health, and index-wise action-vs-state tracking
+ * error. Everything here derives from this episode's rows — never from
+ * dataset-declared statistics, which only bound the out-of-range counts.
+ */
+export interface StateActionEpisodeProfile {
+  readonly action?: StateActionFeatureProfile;
+  readonly rowCount: number;
+  readonly state?: StateActionFeatureProfile;
+  readonly timing: StateActionTimingProfile;
+  /**
+   * Mean |action − state| per dimension, present only when both features
+   * declare the same dimension count; a null entry had no row where both
+   * values were finite.
+   */
+  readonly trackingError?: readonly (number | null)[];
+}
+
 /**
  * Optional semantic capability for exact single-row state/action inspection.
  *
@@ -111,4 +175,12 @@ export interface StateActionCapability {
   readDimensionStats?(options?: {
     readonly signal?: AbortSignal;
   }): Promise<StateActionStats | null>;
+  /**
+   * Episode-computed profile over every row, read lazily and cached for
+   * the session. The scan shares the row-read caches, so profiling never
+   * rereads data a row inspection already paid for.
+   */
+  readEpisodeProfile?(options?: {
+    readonly signal?: AbortSignal;
+  }): Promise<StateActionEpisodeProfile>;
 }

--- a/app/packages/multimodal/src/ports/state-action.ts
+++ b/app/packages/multimodal/src/ports/state-action.ts
@@ -1,0 +1,83 @@
+import type {
+  RawRecordCursor,
+  RawRecordIndexWindow,
+  RawRecordIndexWindowRequest,
+} from "../ir";
+
+/**
+ * Declared identity of one state/action feature vector. Dimension order and
+ * names come verbatim from source metadata; consumers must not reorder them
+ * or invent semantic names for unnamed dimensions.
+ */
+export interface StateActionFeatureSchema {
+  readonly dimensions: readonly {
+    readonly index: number;
+    readonly name?: string;
+  }[];
+  readonly dtype: string;
+  readonly featureName: string;
+  readonly shape: readonly number[];
+}
+
+/** Session-known state/action shape facts; derivable without any value read. */
+export interface StateActionSchema {
+  readonly action?: StateActionFeatureSchema;
+  readonly rowCount: number;
+  readonly state?: StateActionFeatureSchema;
+}
+
+/**
+ * One exact source row. Both feature vectors come from the same logical row,
+ * identified by a cursor in the same opaque, source-epoch-scoped domain the
+ * raw-record capability uses. Values are raw parsed source values — never
+ * float-coerced, padded, or truncated; a shape disagreement is reported
+ * through `featureErrors` while the readable values are preserved.
+ */
+export interface StateActionRow {
+  readonly action?: readonly unknown[];
+  readonly cursor: RawRecordCursor;
+  /** Feature-scoped read faults; values are never silently padded to hide one. */
+  readonly featureErrors?: {
+    readonly action?: string;
+    readonly state?: string;
+  };
+  readonly frameIndex: number;
+  readonly state?: readonly unknown[];
+  readonly task?: {
+    readonly index: number;
+    readonly label?: string;
+  };
+  readonly timestampNs: bigint;
+}
+
+/**
+ * Optional semantic capability for exact single-row state/action inspection.
+ *
+ * `schema` is a plain property because it derives from already-loaded episode
+ * metadata; no I/O and no promise. Time reads use latest-row-at-or-before
+ * semantics inside the episode's declared time range and return `null` before
+ * the first row or outside the range. Cursor reads never consult the playback
+ * clock; an unknown or stale cursor is a typed error, never a silent
+ * nearest-row substitution.
+ */
+export interface StateActionCapability {
+  /** Derived from already-loaded episode metadata; no I/O, no promise. */
+  readonly schema: StateActionSchema;
+  readAtTime(request: {
+    /** Paused inspection stays responsive; playback following stays idle. */
+    readonly intent?: "background" | "paused-inspection";
+    readonly signal?: AbortSignal;
+    readonly timestampNs: bigint;
+  }): Promise<StateActionRow | null>;
+  /** Reads one exact row without consulting the playback clock. */
+  readAtCursor(request: {
+    readonly cursor: RawRecordCursor;
+    readonly signal?: AbortSignal;
+  }): Promise<StateActionRow>;
+  /** Bounded index-only window; the anchor union is exclusive by contract. */
+  readIndexWindow(
+    request: RawRecordIndexWindowRequest & {
+      readonly signal?: AbortSignal;
+    },
+  ): Promise<RawRecordIndexWindow>;
+}

--- a/app/packages/multimodal/src/runtime/demand-bridge.ts
+++ b/app/packages/multimodal/src/runtime/demand-bridge.ts
@@ -28,6 +28,15 @@ export interface DemandHandlers {
 /** Default stand-down after a failed demand read. */
 export const DEMAND_FAILURE_BACKOFF_MS = 5_000;
 
+/** Shared retry delay while playback traffic leaves idle demand starved. */
+export const DEMAND_DEFERRED_RETRY_MS = 2_000;
+
+/** Shared retry delay while the episode timeline is still registering. */
+export const DEMAND_TIMELINE_RETRY_MS = 250;
+
+/** Shared playhead throttle for exact-record demand bridges. */
+export const EXACT_RECORD_PLAYHEAD_THROTTLE_MS = 300;
+
 /** Refcounted demand registry shared by source-scoped runtime providers. */
 export interface DemandRegistry<THandlers extends DemandHandlers> {
   readonly handlersRef: MutableRef<THandlers | null>;

--- a/app/packages/multimodal/src/runtime/react/demand-context.tsx
+++ b/app/packages/multimodal/src/runtime/react/demand-context.tsx
@@ -60,6 +60,12 @@ export interface DemandContextProviderFactory<
     Value,
     Handlers
   >;
+  /** Nullable accessor for surfaces that may render without the provider. */
+  readonly useOptionalDemandContext: () => DemandContextController<
+    InventoryState,
+    Value,
+    Handlers
+  > | null;
 }
 
 /** Creates the shared state, registry, inventory, and reset provider scaffold. */
@@ -150,7 +156,9 @@ export function createDemandContextProvider<
     return value;
   };
 
-  return { Provider, useDemandContext };
+  const useOptionalDemandContext = () => useContext(Context);
+
+  return { Provider, useDemandContext, useOptionalDemandContext };
 }
 
 /** Clears provider-owned publications after its bridge leaves the tree. */

--- a/app/packages/multimodal/src/runtime/read-policy.ts
+++ b/app/packages/multimodal/src/runtime/read-policy.ts
@@ -22,11 +22,11 @@ import {
   resolvePlaybackWindow,
   selectPlaybackWindow,
   streamTimeBoundsFromManifest,
-} from "../stream-selection/playback";
+} from "../ports/playback-policy";
 import { maxBigInt, minBigInt } from "../utils/bigint";
 import { throwIfAborted } from "../utils/cancellation";
 
-export { DEFAULT_EPISODE_SYNC_TOLERANCE_NS } from "../stream-selection/playback";
+export { DEFAULT_EPISODE_SYNC_TOLERANCE_NS } from "../ports/playback-policy";
 
 /** Complete decoded messages admitted per stream for one generic playback batch. */
 export const GENERIC_PLAYBACK_FALLBACK_MAX_MESSAGES_PER_STREAM = 1_024;

--- a/app/packages/multimodal/src/runtime/read-policy.ts
+++ b/app/packages/multimodal/src/runtime/read-policy.ts
@@ -1,12 +1,6 @@
 import {
   STREAM_KIND,
-  STREAM_SYNC_MODE,
   type DecodedFrame,
-  type EpisodeManifest,
-  type ResolvedStreamSyncPolicy,
-  type StreamDescriptor,
-  type StreamSyncMode,
-  type StreamSyncPolicy,
   type SynchronizedFrameWindow,
   type TransformSample,
 } from "../ir";
@@ -21,13 +15,18 @@ import type {
   TransformReadAcceleration,
 } from "../ports";
 import { EpisodeReadUnsupportedError } from "../ports";
+import {
+  emptyPlaybackWindow,
+  prioritizedStreams,
+  readStartForPolicy,
+  resolvePlaybackWindow,
+  selectPlaybackWindow,
+  streamTimeBoundsFromManifest,
+} from "../stream-selection/playback";
 import { maxBigInt, minBigInt } from "../utils/bigint";
 import { throwIfAborted } from "../utils/cancellation";
 
-/** Default symmetric tolerance for nearest-frame presentation. */
-export const DEFAULT_EPISODE_SYNC_TOLERANCE_NS = 50_000_000n;
-
-const DEFAULT_STREAM_SYNC_LIMIT = 1;
+export { DEFAULT_EPISODE_SYNC_TOLERANCE_NS } from "../stream-selection/playback";
 
 /** Complete decoded messages admitted per stream for one generic playback batch. */
 export const GENERIC_PLAYBACK_FALLBACK_MAX_MESSAGES_PER_STREAM = 1_024;
@@ -339,189 +338,6 @@ async function readCompleteBoundedStreams({
   return batches;
 }
 
-function prioritizedStreams(
-  streams: readonly string[],
-  priorityStreams: readonly string[] | undefined,
-): string[] {
-  if (!priorityStreams?.length) return [...streams];
-  const requested = new Set(streams);
-  const priority = [...new Set(priorityStreams)].filter((stream) =>
-    requested.has(stream),
-  );
-  const prioritized = new Set(priority);
-  return [...priority, ...streams.filter((stream) => !prioritized.has(stream))];
-}
-
-interface ResolvedPlaybackWindow {
-  readonly endNs: bigint;
-  readonly startNs: bigint;
-  readonly streamPolicies: Readonly<Record<string, ResolvedStreamSyncPolicy>>;
-  readonly timeNs: bigint;
-}
-
-function resolvePlaybackWindow(
-  manifestStartNs: bigint,
-  streamsById: ReadonlyMap<string, StreamDescriptor>,
-  request: SynchronizedPlaybackReadRequest,
-): ResolvedPlaybackWindow {
-  const streamPolicies = Object.fromEntries(
-    request.streams.map((stream) => [
-      stream,
-      resolveStreamSyncPolicy(
-        request.timeNs,
-        request.streamPolicies?.[stream] ?? request.defaultStreamPolicy,
-        stream,
-      ),
-    ]),
-  );
-  const policies = Object.values(streamPolicies);
-  return {
-    endNs:
-      policies.length > 0
-        ? maxBigInt(policies.map((policy) => policy.endNs))
-        : request.timeNs,
-    startNs:
-      policies.length > 0
-        ? minBigInt(
-            request.streams.map((stream) =>
-              readStartForPolicy(
-                manifestStartNs,
-                streamsById,
-                stream,
-                streamPolicies[stream],
-              ),
-            ),
-          )
-        : request.timeNs,
-    streamPolicies,
-    timeNs: request.timeNs,
-  };
-}
-
-function resolveStreamSyncPolicy(
-  timeNs: bigint,
-  policy: StreamSyncPolicy | undefined,
-  stream: string,
-): ResolvedStreamSyncPolicy {
-  const mode = policy?.mode ?? STREAM_SYNC_MODE.LATEST;
-  const limit = policy?.limit ?? DEFAULT_STREAM_SYNC_LIMIT;
-  if (!Number.isFinite(limit) || !Number.isInteger(limit) || limit < 1) {
-    throw new Error(
-      `Episode sync policy for ${stream} must request a positive integer frame limit`,
-    );
-  }
-
-  switch (mode) {
-    case STREAM_SYNC_MODE.NEAREST: {
-      const toleranceBeforeNs =
-        policy?.toleranceBeforeNs ?? DEFAULT_EPISODE_SYNC_TOLERANCE_NS;
-      const toleranceAfterNs =
-        policy?.toleranceAfterNs ?? DEFAULT_EPISODE_SYNC_TOLERANCE_NS;
-      assertNonNegativeTolerance(
-        stream,
-        "toleranceBeforeNs",
-        toleranceBeforeNs,
-      );
-      assertNonNegativeTolerance(stream, "toleranceAfterNs", toleranceAfterNs);
-      return {
-        endNs: timeNs + toleranceAfterNs,
-        limit,
-        mode,
-        startNs: clampStartTime(timeNs - toleranceBeforeNs),
-      };
-    }
-    case STREAM_SYNC_MODE.STRICT:
-      assertUnsupportedTolerance(stream, mode, "toleranceBeforeNs", policy);
-      assertUnsupportedTolerance(stream, mode, "toleranceAfterNs", policy);
-      return { endNs: timeNs, limit, mode, startNs: timeNs };
-    case STREAM_SYNC_MODE.LATEST: {
-      assertUnsupportedTolerance(stream, mode, "toleranceAfterNs", policy);
-      const toleranceBeforeNs = policy?.toleranceBeforeNs;
-      if (toleranceBeforeNs === undefined) {
-        return { endNs: timeNs, limit, mode };
-      }
-      assertNonNegativeTolerance(
-        stream,
-        "toleranceBeforeNs",
-        toleranceBeforeNs,
-      );
-      return {
-        endNs: timeNs,
-        limit,
-        mode,
-        startNs: clampStartTime(timeNs - toleranceBeforeNs),
-      };
-    }
-  }
-}
-
-function selectPlaybackWindow(
-  candidatesByStream: ReadonlyMap<string, readonly DecodedFrame[]>,
-  streams: readonly string[],
-  sourceNames: ReadonlyMap<string, string>,
-  window: ResolvedPlaybackWindow,
-): SynchronizedFrameWindow {
-  const framesByStream: Record<string, readonly DecodedFrame[]> = {};
-  const frames: DecodedFrame[] = [];
-  for (const stream of streams) {
-    const selected = selectFrames(
-      candidatesByStream.get(stream) ?? [],
-      window.timeNs,
-      window.streamPolicies[stream],
-    );
-    framesByStream[stream] = selected;
-    frames.push(...selected);
-  }
-  frames.sort((left, right) => compareFrames(sourceNames, left, right));
-  return {
-    endNs: window.endNs,
-    frames,
-    framesByStream,
-    startNs: window.startNs,
-    streamPolicies: window.streamPolicies,
-    timeNs: window.timeNs,
-  };
-}
-
-function selectFrames(
-  candidates: readonly DecodedFrame[],
-  timeNs: bigint,
-  policy: ResolvedStreamSyncPolicy,
-): readonly DecodedFrame[] {
-  const inWindow = candidates.filter(
-    (frame) =>
-      (policy.startNs === undefined || frame.timestampNs >= policy.startNs) &&
-      frame.timestampNs <= policy.endNs,
-  );
-  const chronological = (left: DecodedFrame, right: DecodedFrame) =>
-    compareFramesByTime(left, right);
-
-  switch (policy.mode) {
-    case STREAM_SYNC_MODE.NEAREST:
-      return [...inWindow]
-        .sort((left, right) => {
-          const distance =
-            absBigInt(left.timestampNs - timeNs) -
-            absBigInt(right.timestampNs - timeNs);
-          return distance < 0n
-            ? -1
-            : distance > 0n
-              ? 1
-              : chronological(left, right);
-        })
-        .slice(0, policy.limit)
-        .sort(chronological);
-    case STREAM_SYNC_MODE.STRICT:
-      return inWindow.slice(0, policy.limit).sort(chronological);
-    case STREAM_SYNC_MODE.LATEST:
-      return [...inWindow]
-        .filter((frame) => frame.timestampNs <= timeNs)
-        .sort((left, right) => chronological(right, left))
-        .slice(0, policy.limit)
-        .sort(chronological);
-  }
-}
-
 function collectFramesByStream(
   batches: readonly FrameBatch[],
   streams: readonly string[],
@@ -542,42 +358,6 @@ function collectFramesByStream(
   return collected;
 }
 
-function streamTimeBoundsFromManifest(
-  manifest: EpisodeManifest,
-  streams: readonly string[],
-) {
-  const byId = new Map(manifest.streams.map((stream) => [stream.id, stream]));
-  return streams.map((streamId) => {
-    const stream = byId.get(streamId);
-    return {
-      firstTimestampNs: stream?.timeRange.startNs ?? null,
-      lastTimestampNs: stream?.timeRange.endNs ?? null,
-      streamId,
-    };
-  });
-}
-
-function readStartForPolicy(
-  manifestStartNs: bigint,
-  streamsById: ReadonlyMap<string, StreamDescriptor>,
-  streamId: string,
-  policy: ResolvedStreamSyncPolicy,
-): bigint {
-  if (policy.startNs !== undefined) return policy.startNs;
-  return streamsById.get(streamId)?.timeRange.startNs ?? manifestStartNs;
-}
-
-function emptyPlaybackWindow(timeNs: bigint): SynchronizedFrameWindow {
-  return {
-    endNs: timeNs,
-    frames: [],
-    framesByStream: {},
-    startNs: timeNs,
-    streamPolicies: {},
-    timeNs,
-  };
-}
-
 function compareTransforms(
   left: TransformSample,
   right: TransformSample,
@@ -587,55 +367,9 @@ function compareTransforms(
   return leftTimeNs < rightTimeNs ? -1 : leftTimeNs > rightTimeNs ? 1 : 0;
 }
 
-function compareFrames(
-  sourceNames: ReadonlyMap<string, string>,
-  left: DecodedFrame,
-  right: DecodedFrame,
-): number {
-  const timeOrder = compareFramesByTime(left, right);
-  if (timeOrder !== 0) return timeOrder;
-  return (sourceNames.get(left.streamId) ?? left.streamId).localeCompare(
-    sourceNames.get(right.streamId) ?? right.streamId,
-  );
-}
-
 function compareFramesByTime(left: DecodedFrame, right: DecodedFrame): number {
   if (left.timestampNs !== right.timestampNs) {
     return left.timestampNs < right.timestampNs ? -1 : 1;
   }
   return (left.sequence ?? 0) - (right.sequence ?? 0);
-}
-
-function assertNonNegativeTolerance(
-  stream: string,
-  field: "toleranceAfterNs" | "toleranceBeforeNs",
-  value: bigint,
-): void {
-  if (value < 0n) {
-    throw new Error(
-      `Episode sync policy ${field} for ${stream} cannot be negative`,
-    );
-  }
-}
-
-function assertUnsupportedTolerance(
-  stream: string,
-  mode: StreamSyncMode,
-  field: "toleranceAfterNs" | "toleranceBeforeNs",
-  policy: StreamSyncPolicy | undefined,
-): void {
-  const value = policy?.[field];
-  if (value !== undefined && value !== 0n) {
-    throw new Error(
-      `Episode sync policy ${field} for ${stream} is not valid for ${mode}`,
-    );
-  }
-}
-
-function absBigInt(value: bigint): bigint {
-  return value < 0n ? -value : value;
-}
-
-function clampStartTime(value: bigint): bigint {
-  return value < 0n ? 0n : value;
 }

--- a/app/packages/multimodal/src/runtime/source-bootstrap-cache.test.ts
+++ b/app/packages/multimodal/src/runtime/source-bootstrap-cache.test.ts
@@ -230,6 +230,44 @@ describe("source bootstrap cache", () => {
     expect(peekSourceBootstrap(source)?.manifest).toBe(currentManifest);
   });
 
+  it("retains canonical LeRobot catalog and recording facts in current hints", () => {
+    resetSourceBootstrapCacheForTests();
+    const source = createSource("lerobot-current");
+    const base = createManifest("lerobot:action", "episode");
+    const manifest: EpisodeManifest = {
+      ...base,
+      recordingFacts: {
+        durationNs: "1000000000",
+        format: "lerobot",
+        lerobot: {
+          codebaseVersion: "v3.0",
+          episodeIndex: "4",
+          featureCount: 8,
+          fps: 30,
+          logicalRowCount: 30,
+          mediaFeatureCount: 2,
+          robotType: "so101",
+          taskLabels: ["pick up cube"],
+          videoCodecs: ["h264"],
+        },
+      },
+      streams: base.streams.map((stream) => ({
+        ...stream,
+        metadata: {
+          "stream.category": "actions",
+          "stream.count_noun": "samples",
+          "stream.inspectable": "true",
+        },
+      })),
+    };
+
+    publishSourceBootstrap(source, { manifest });
+
+    expect(getSourceSessionHints(source, "lerobot-v3")).toEqual({
+      manifestHint: manifest,
+    });
+  });
+
   it("uses validated durable hints only for their adapter", () => {
     resetSourceBootstrapCacheForTests();
     const source = createSource("validated");

--- a/app/packages/multimodal/src/runtime/source-facts-codec.ts
+++ b/app/packages/multimodal/src/runtime/source-facts-codec.ts
@@ -416,6 +416,7 @@ function validRecordingFacts(value: unknown): value is EpisodeRecordingFacts {
       "durationNs",
       "endTimeNs",
       "format",
+      "lerobot",
       "mcap",
       "messageCount",
       "readProfile",
@@ -441,7 +442,33 @@ function validRecordingFacts(value: unknown): value is EpisodeRecordingFacts {
       validApplicationSupport(value.applicationSupport)) &&
     (value.schemaCoverage === undefined ||
       validSchemaCoverage(value.schemaCoverage)) &&
+    (value.lerobot === undefined || validLeRobotFacts(value.lerobot)) &&
     (value.mcap === undefined || validMcapFacts(value.mcap))
+  );
+}
+
+function validLeRobotFacts(value: unknown): boolean {
+  return (
+    recordWithKeys(value, [
+      "codebaseVersion",
+      "episodeIndex",
+      "featureCount",
+      "fps",
+      "logicalRowCount",
+      "mediaFeatureCount",
+      "robotType",
+      "taskLabels",
+      "videoCodecs",
+    ]) &&
+    optionalString(value.codebaseVersion) &&
+    optionalDecimal(value.episodeIndex) &&
+    optionalNonNegativeInteger(value.featureCount) &&
+    optionalFiniteNonNegative(value.fps) &&
+    optionalNonNegativeInteger(value.logicalRowCount) &&
+    optionalNonNegativeInteger(value.mediaFeatureCount) &&
+    optionalString(value.robotType) &&
+    optionalStringArray(value.taskLabels) &&
+    optionalStringArray(value.videoCodecs)
   );
 }
 
@@ -575,6 +602,10 @@ function optionalStringRecord(value: unknown): boolean {
     (isRecord(value) &&
       Object.values(value).every((child) => typeof child === "string"))
   );
+}
+
+function optionalStringArray(value: unknown): boolean {
+  return value === undefined || stringArray(value);
 }
 
 function stringArray(value: unknown): boolean {

--- a/app/packages/multimodal/src/runtime/source-facts.test.ts
+++ b/app/packages/multimodal/src/runtime/source-facts.test.ts
@@ -122,6 +122,34 @@ describe("source facts codec", () => {
     ).toEqual(entry);
   });
 
+  it("round-trips typed LeRobot recording details", () => {
+    const entry = storedEntry({
+      manifest: {
+        ...manifest(),
+        recordingFacts: {
+          durationNs: "1000000000",
+          format: "lerobot",
+          lerobot: {
+            codebaseVersion: "v3.0",
+            episodeIndex: "12",
+            featureCount: 8,
+            fps: 30,
+            logicalRowCount: 30,
+            mediaFeatureCount: 2,
+            robotType: "so101",
+            taskLabels: ["pick up cube"],
+            videoCodecs: ["h264"],
+          },
+          messageCount: "30",
+        },
+      },
+    });
+
+    expect(
+      decodeStoredSourceFacts(encodeStoredSourceFacts(entry)?.value),
+    ).toEqual(entry);
+  });
+
   it("rejects malformed versions, ranges, domains, duplicates, and empty facts", () => {
     const encoded = encodeStoredSourceFacts(storedEntry());
     if (!encoded) throw new Error("Expected a valid source-facts fixture");

--- a/app/packages/multimodal/src/runtime/source-facts.test.ts
+++ b/app/packages/multimodal/src/runtime/source-facts.test.ts
@@ -140,7 +140,6 @@ describe("source facts codec", () => {
             taskLabels: ["pick up cube"],
             videoCodecs: ["h264"],
           },
-          messageCount: "30",
         },
       },
     });

--- a/app/packages/multimodal/src/stream-selection/index.ts
+++ b/app/packages/multimodal/src/stream-selection/index.ts
@@ -1,2 +1,3 @@
+export * from "./playback";
 export * from "./scene-sources";
 export * from "./stream-selection";

--- a/app/packages/multimodal/src/stream-selection/index.ts
+++ b/app/packages/multimodal/src/stream-selection/index.ts
@@ -1,3 +1,2 @@
-export * from "./playback";
 export * from "./scene-sources";
 export * from "./stream-selection";

--- a/app/packages/multimodal/src/stream-selection/playback.ts
+++ b/app/packages/multimodal/src/stream-selection/playback.ts
@@ -1,0 +1,296 @@
+import {
+  STREAM_SYNC_MODE,
+  type DecodedFrame,
+  type EpisodeManifest,
+  type ResolvedStreamSyncPolicy,
+  type StreamDescriptor,
+  type StreamSyncMode,
+  type StreamSyncPolicies,
+  type StreamSyncPolicy,
+  type SynchronizedFrameWindow,
+} from "../ir";
+import { maxBigInt, minBigInt } from "../utils/bigint";
+
+/** Default symmetric tolerance for nearest-frame presentation. */
+export const DEFAULT_EPISODE_SYNC_TOLERANCE_NS = 50_000_000n;
+
+const DEFAULT_STREAM_SYNC_LIMIT = 1;
+
+export interface ResolvedPlaybackWindow {
+  readonly endNs: bigint;
+  readonly startNs: bigint;
+  readonly streamPolicies: Readonly<Record<string, ResolvedStreamSyncPolicy>>;
+  readonly timeNs: bigint;
+}
+
+export interface PlaybackWindowRequest {
+  readonly defaultStreamPolicy?: StreamSyncPolicy;
+  readonly streamPolicies?: StreamSyncPolicies;
+  readonly streams: readonly string[];
+  readonly timeNs: bigint;
+}
+
+export function prioritizedStreams(
+  streams: readonly string[],
+  priorityStreams: readonly string[] | undefined,
+): string[] {
+  if (!priorityStreams?.length) return [...streams];
+  const requested = new Set(streams);
+  const priority = [...new Set(priorityStreams)].filter((stream) =>
+    requested.has(stream),
+  );
+  const prioritized = new Set(priority);
+  return [...priority, ...streams.filter((stream) => !prioritized.has(stream))];
+}
+
+export function resolvePlaybackWindow(
+  manifestStartNs: bigint,
+  streamsById: ReadonlyMap<string, StreamDescriptor>,
+  request: PlaybackWindowRequest,
+): ResolvedPlaybackWindow {
+  const streamPolicies = Object.fromEntries(
+    request.streams.map((stream) => [
+      stream,
+      resolveStreamSyncPolicy(
+        request.timeNs,
+        request.streamPolicies?.[stream] ?? request.defaultStreamPolicy,
+        stream,
+      ),
+    ]),
+  );
+  const policies = Object.values(streamPolicies);
+  return {
+    endNs:
+      policies.length > 0
+        ? maxBigInt(policies.map((policy) => policy.endNs))
+        : request.timeNs,
+    startNs:
+      policies.length > 0
+        ? minBigInt(
+            request.streams.map((stream) =>
+              readStartForPolicy(
+                manifestStartNs,
+                streamsById,
+                stream,
+                streamPolicies[stream],
+              ),
+            ),
+          )
+        : request.timeNs,
+    streamPolicies,
+    timeNs: request.timeNs,
+  };
+}
+
+export function selectPlaybackWindow(
+  candidatesByStream: ReadonlyMap<string, readonly DecodedFrame[]>,
+  streams: readonly string[],
+  sourceNames: ReadonlyMap<string, string>,
+  window: ResolvedPlaybackWindow,
+): SynchronizedFrameWindow {
+  const framesByStream: Record<string, readonly DecodedFrame[]> = {};
+  const frames: DecodedFrame[] = [];
+  for (const stream of streams) {
+    const selected = selectFrames(
+      candidatesByStream.get(stream) ?? [],
+      window.timeNs,
+      window.streamPolicies[stream],
+    );
+    framesByStream[stream] = selected;
+    frames.push(...selected);
+  }
+  frames.sort((left, right) => compareFrames(sourceNames, left, right));
+  return {
+    endNs: window.endNs,
+    frames,
+    framesByStream,
+    startNs: window.startNs,
+    streamPolicies: window.streamPolicies,
+    timeNs: window.timeNs,
+  };
+}
+
+export function streamTimeBoundsFromManifest(
+  manifest: EpisodeManifest,
+  streams: readonly string[],
+) {
+  const byId = new Map(manifest.streams.map((stream) => [stream.id, stream]));
+  return streams.map((streamId) => {
+    const stream = byId.get(streamId);
+    return {
+      firstTimestampNs: stream?.timeRange.startNs ?? null,
+      lastTimestampNs: stream?.timeRange.endNs ?? null,
+      streamId,
+    };
+  });
+}
+
+export function readStartForPolicy(
+  manifestStartNs: bigint,
+  streamsById: ReadonlyMap<string, StreamDescriptor>,
+  streamId: string,
+  policy: ResolvedStreamSyncPolicy,
+): bigint {
+  if (policy.startNs !== undefined) return policy.startNs;
+  return streamsById.get(streamId)?.timeRange.startNs ?? manifestStartNs;
+}
+
+export function emptyPlaybackWindow(timeNs: bigint): SynchronizedFrameWindow {
+  return {
+    endNs: timeNs,
+    frames: [],
+    framesByStream: {},
+    startNs: timeNs,
+    streamPolicies: {},
+    timeNs,
+  };
+}
+
+function resolveStreamSyncPolicy(
+  timeNs: bigint,
+  policy: StreamSyncPolicy | undefined,
+  stream: string,
+): ResolvedStreamSyncPolicy {
+  const mode = policy?.mode ?? STREAM_SYNC_MODE.LATEST;
+  const limit = policy?.limit ?? DEFAULT_STREAM_SYNC_LIMIT;
+  if (!Number.isFinite(limit) || !Number.isInteger(limit) || limit < 1) {
+    throw new Error(
+      `Episode sync policy for ${stream} must request a positive integer frame limit`,
+    );
+  }
+
+  switch (mode) {
+    case STREAM_SYNC_MODE.NEAREST: {
+      const toleranceBeforeNs =
+        policy?.toleranceBeforeNs ?? DEFAULT_EPISODE_SYNC_TOLERANCE_NS;
+      const toleranceAfterNs =
+        policy?.toleranceAfterNs ?? DEFAULT_EPISODE_SYNC_TOLERANCE_NS;
+      assertNonNegativeTolerance(
+        stream,
+        "toleranceBeforeNs",
+        toleranceBeforeNs,
+      );
+      assertNonNegativeTolerance(stream, "toleranceAfterNs", toleranceAfterNs);
+      return {
+        endNs: timeNs + toleranceAfterNs,
+        limit,
+        mode,
+        startNs: clampStartTime(timeNs - toleranceBeforeNs),
+      };
+    }
+    case STREAM_SYNC_MODE.STRICT:
+      assertUnsupportedTolerance(stream, mode, "toleranceBeforeNs", policy);
+      assertUnsupportedTolerance(stream, mode, "toleranceAfterNs", policy);
+      return { endNs: timeNs, limit, mode, startNs: timeNs };
+    case STREAM_SYNC_MODE.LATEST: {
+      assertUnsupportedTolerance(stream, mode, "toleranceAfterNs", policy);
+      const toleranceBeforeNs = policy?.toleranceBeforeNs;
+      if (toleranceBeforeNs === undefined) {
+        return { endNs: timeNs, limit, mode };
+      }
+      assertNonNegativeTolerance(
+        stream,
+        "toleranceBeforeNs",
+        toleranceBeforeNs,
+      );
+      return {
+        endNs: timeNs,
+        limit,
+        mode,
+        startNs: clampStartTime(timeNs - toleranceBeforeNs),
+      };
+    }
+  }
+}
+
+function selectFrames(
+  candidates: readonly DecodedFrame[],
+  timeNs: bigint,
+  policy: ResolvedStreamSyncPolicy,
+): readonly DecodedFrame[] {
+  const inWindow = candidates.filter(
+    (frame) =>
+      (policy.startNs === undefined || frame.timestampNs >= policy.startNs) &&
+      frame.timestampNs <= policy.endNs,
+  );
+  const chronological = (left: DecodedFrame, right: DecodedFrame) =>
+    compareFramesByTime(left, right);
+
+  switch (policy.mode) {
+    case STREAM_SYNC_MODE.NEAREST:
+      return [...inWindow]
+        .sort((left, right) => {
+          const distance =
+            absBigInt(left.timestampNs - timeNs) -
+            absBigInt(right.timestampNs - timeNs);
+          return distance < 0n
+            ? -1
+            : distance > 0n
+              ? 1
+              : chronological(left, right);
+        })
+        .slice(0, policy.limit)
+        .sort(chronological);
+    case STREAM_SYNC_MODE.STRICT:
+      return inWindow.slice(0, policy.limit).sort(chronological);
+    case STREAM_SYNC_MODE.LATEST:
+      return [...inWindow]
+        .filter((frame) => frame.timestampNs <= timeNs)
+        .sort((left, right) => chronological(right, left))
+        .slice(0, policy.limit)
+        .sort(chronological);
+  }
+}
+
+function compareFrames(
+  sourceNames: ReadonlyMap<string, string>,
+  left: DecodedFrame,
+  right: DecodedFrame,
+): number {
+  const timeOrder = compareFramesByTime(left, right);
+  if (timeOrder !== 0) return timeOrder;
+  return (sourceNames.get(left.streamId) ?? left.streamId).localeCompare(
+    sourceNames.get(right.streamId) ?? right.streamId,
+  );
+}
+
+function compareFramesByTime(left: DecodedFrame, right: DecodedFrame): number {
+  if (left.timestampNs !== right.timestampNs) {
+    return left.timestampNs < right.timestampNs ? -1 : 1;
+  }
+  return (left.sequence ?? 0) - (right.sequence ?? 0);
+}
+
+function assertNonNegativeTolerance(
+  stream: string,
+  field: "toleranceAfterNs" | "toleranceBeforeNs",
+  value: bigint,
+): void {
+  if (value < 0n) {
+    throw new Error(
+      `Episode sync policy ${field} for ${stream} cannot be negative`,
+    );
+  }
+}
+
+function assertUnsupportedTolerance(
+  stream: string,
+  mode: StreamSyncMode,
+  field: "toleranceAfterNs" | "toleranceBeforeNs",
+  policy: StreamSyncPolicy | undefined,
+): void {
+  const value = policy?.[field];
+  if (value !== undefined && value !== 0n) {
+    throw new Error(
+      `Episode sync policy ${field} for ${stream} is not valid for ${mode}`,
+    );
+  }
+}
+
+function absBigInt(value: bigint): bigint {
+  return value < 0n ? -value : value;
+}
+
+function clampStartTime(value: bigint): bigint {
+  return value < 0n ? 0n : value;
+}

--- a/app/packages/multimodal/src/testing/integration/GridRenderer.integration.test.tsx
+++ b/app/packages/multimodal/src/testing/integration/GridRenderer.integration.test.tsx
@@ -22,6 +22,7 @@ import {
   gridPosterCacheKey,
   resetGridPosterCacheForTests,
 } from "../../views/episode/grid/grid-poster-cache";
+import { H264_REORDERED_DECODE_LOOKAHEAD_NS } from "../../video/stream-engine";
 
 const harness = vi.hoisted(() => ({
   byteSource: {
@@ -135,7 +136,7 @@ describe("fixture adapter through the production grid renderer", () => {
       expect(screen.getByTestId("fixture-grid-image")).toBeTruthy();
     });
     expect(read).toHaveBeenCalledWith(
-      {},
+      { decodeLookaheadNs: H264_REORDERED_DECODE_LOOKAHEAD_NS },
       expect.objectContaining({ priority: "idle" }),
     );
   });
@@ -164,7 +165,7 @@ describe("fixture adapter through the production grid renderer", () => {
     fireEvent.pointerEnter(remounted.container.firstElementChild as Element);
     await waitFor(() => expect(read).toHaveBeenCalledTimes(1));
     expect(read).toHaveBeenCalledWith(
-      {},
+      { decodeLookaheadNs: H264_REORDERED_DECODE_LOOKAHEAD_NS },
       expect.objectContaining({ priority: "current" }),
     );
     await act(async () => {

--- a/app/packages/multimodal/src/testing/integration/GridRenderer.integration.test.tsx
+++ b/app/packages/multimodal/src/testing/integration/GridRenderer.integration.test.tsx
@@ -22,7 +22,7 @@ import {
   gridPosterCacheKey,
   resetGridPosterCacheForTests,
 } from "../../views/episode/grid/grid-poster-cache";
-import { H264_REORDERED_DECODE_LOOKAHEAD_NS } from "../../video/stream-engine";
+import { REORDERED_VIDEO_DECODE_LOOKAHEAD_NS } from "../../video/stream-engine";
 
 const harness = vi.hoisted(() => ({
   byteSource: {
@@ -136,7 +136,7 @@ describe("fixture adapter through the production grid renderer", () => {
       expect(screen.getByTestId("fixture-grid-image")).toBeTruthy();
     });
     expect(read).toHaveBeenCalledWith(
-      { decodeLookaheadNs: H264_REORDERED_DECODE_LOOKAHEAD_NS },
+      { decodeLookaheadNs: REORDERED_VIDEO_DECODE_LOOKAHEAD_NS },
       expect.objectContaining({ priority: "idle" }),
     );
   });
@@ -165,7 +165,7 @@ describe("fixture adapter through the production grid renderer", () => {
     fireEvent.pointerEnter(remounted.container.firstElementChild as Element);
     await waitFor(() => expect(read).toHaveBeenCalledTimes(1));
     expect(read).toHaveBeenCalledWith(
-      { decodeLookaheadNs: H264_REORDERED_DECODE_LOOKAHEAD_NS },
+      { decodeLookaheadNs: REORDERED_VIDEO_DECODE_LOOKAHEAD_NS },
       expect.objectContaining({ priority: "current" }),
     );
     await act(async () => {

--- a/app/packages/multimodal/src/testing/state-action-contract.ts
+++ b/app/packages/multimodal/src/testing/state-action-contract.ts
@@ -1,0 +1,457 @@
+import { describe, expect, it } from "vitest";
+
+import type { RawRecordIndexWindowRequest } from "../ir";
+import type { StateActionScenario } from "../adapters/fixture/fixture-state-action";
+import type { StateActionCapability } from "../ports";
+import {
+  isEpisodeExactCursorError,
+  isEpisodeReadCancelledError,
+} from "../ports";
+
+/** One opened provider under contract test. */
+export interface StateActionContractSession {
+  readonly capability: StateActionCapability;
+  /** End of the episode's declared time range in the provider's domain. */
+  readonly declaredEndNs: bigint;
+  dispose(): void;
+  /** Physical data-asset reads issued by the capability, excluding tasks. */
+  physicalReads?(): number;
+}
+
+/** Factory used to run the shared state/action capability contract. */
+export interface StateActionContractHarness {
+  createSession(
+    scenario: StateActionScenario,
+  ): Promise<StateActionContractSession>;
+  readonly name: string;
+}
+
+const CANONICAL_SCENARIO: StateActionScenario = {
+  action: {
+    dtype: "float32",
+    rows: [
+      [
+        [0, 1],
+        [2, 3],
+      ],
+      [
+        [10, 11],
+        [12, 13],
+      ],
+      [
+        [20, 21],
+        [22, 23],
+      ],
+      [
+        [30, 31],
+        [32, 33],
+      ],
+      [
+        [40, 41],
+        [42, 43],
+      ],
+    ],
+    shape: [2, 2],
+  },
+  episodeTasks: ["fold the towel", "stack the cube"],
+  state: {
+    dtype: "float32",
+    names: ["shoulder", "elbow"],
+    rows: [
+      [0.1, 0.2, 0.3],
+      [1.1, Number.NaN, 1.3],
+      [2.1, 2.2, Number.POSITIVE_INFINITY],
+      [3.1, 3.2, null],
+      [4.1, 4.2, 4.3],
+    ],
+    shape: [3],
+  },
+  taskIndexes: [0, 0, 1, 1, 7],
+  taskLabelsByIndex: { 0: "fold the towel", 1: "stack the cube" },
+  timestampsSeconds: [0, 0.05, 0.1, 0.15, 0.2],
+};
+
+// The anchor union is exclusive at the type level; an ambiguous request is
+// not constructible.
+// @ts-expect-error two anchors must not be accepted together
+const AMBIGUOUS_ANCHOR: RawRecordIndexWindowRequest = {
+  after: 1,
+  anchorCursor: "row:0",
+  anchorTimestampNs: 0n,
+  before: 1,
+};
+void AMBIGUOUS_ANCHOR;
+
+/** Defines the reusable behavioral contract every state/action provider must pass. */
+export function defineStateActionCapabilityContractTests({
+  createSession,
+  name,
+}: StateActionContractHarness): void {
+  const withSession = async (
+    scenario: StateActionScenario,
+    run: (session: StateActionContractSession) => Promise<void>,
+  ) => {
+    const session = await createSession(scenario);
+    try {
+      await run(session);
+    } finally {
+      session.dispose();
+    }
+  };
+  const allEntries = async (
+    session: StateActionContractSession,
+    rowCount: number,
+  ) => {
+    const window = await session.capability.readIndexWindow({
+      after: 0,
+      anchorTimestampNs: session.declaredEndNs,
+      before: rowCount,
+    });
+    return window.entries;
+  };
+
+  describe(`${name} state/action capability contract`, () => {
+    it("derives the schema without any value read", async () => {
+      await withSession(CANONICAL_SCENARIO, async ({ capability }) => {
+        const { schema } = capability;
+        expect(schema.rowCount).toBe(5);
+        expect(schema.state).toMatchObject({
+          dtype: "float32",
+          featureName: "observation.state",
+          shape: [3],
+        });
+        expect(schema.state?.dimensions).toEqual([
+          { index: 0, name: "shoulder" },
+          { index: 1, name: "elbow" },
+          { index: 2 },
+        ]);
+        expect(schema.action).toMatchObject({
+          dtype: "float32",
+          featureName: "action",
+          shape: [2, 2],
+        });
+        expect(schema.action?.dimensions).toEqual([
+          { index: 0 },
+          { index: 1 },
+          { index: 2 },
+          { index: 3 },
+        ]);
+      });
+    });
+
+    it("returns state and action from the same selected row and cursor", async () => {
+      await withSession(CANONICAL_SCENARIO, async (session) => {
+        const entries = await allEntries(session, 5);
+        const row = await session.capability.readAtTime({
+          timestampNs: entries[1].timestampNs,
+        });
+        expect(row).not.toBeNull();
+        expect(row?.cursor).toBe(entries[1].cursor);
+        expect(row?.frameIndex).toBe(1);
+        expect(row?.timestampNs).toBe(entries[1].timestampNs);
+        expect(row?.state).toEqual([1.1, Number.NaN, 1.3]);
+        expect(row?.action).toEqual([10, 11, 12, 13]);
+        const exact = await session.capability.readAtCursor({
+          cursor: entries[1].cursor,
+        });
+        expect(exact.cursor).toBe(entries[1].cursor);
+        expect(exact.state).toEqual(row?.state);
+        expect(exact.action).toEqual(row?.action);
+      });
+    });
+
+    it("resolves time with latest-row-at-or-before semantics", async () => {
+      await withSession(CANONICAL_SCENARIO, async (session) => {
+        const entries = await allEntries(session, 5);
+        const exact = await session.capability.readAtTime({
+          timestampNs: entries[2].timestampNs,
+        });
+        expect(exact?.cursor).toBe(entries[2].cursor);
+        const between = await session.capability.readAtTime({
+          timestampNs: (entries[1].timestampNs + entries[2].timestampNs) / 2n,
+        });
+        expect(between?.cursor).toBe(entries[1].cursor);
+        await expect(
+          session.capability.readAtTime({
+            timestampNs: entries[0].timestampNs - 1n,
+          }),
+        ).resolves.toBeNull();
+        const atEnd = await session.capability.readAtTime({
+          timestampNs: session.declaredEndNs,
+        });
+        expect(atEnd?.cursor).toBe(entries[4].cursor);
+        await expect(
+          session.capability.readAtTime({
+            timestampNs: session.declaredEndNs + 1n,
+          }),
+        ).resolves.toBeNull();
+      });
+    });
+
+    it("keeps cursor reads independent of interleaved time reads", async () => {
+      await withSession(CANONICAL_SCENARIO, async (session) => {
+        const entries = await allEntries(session, 5);
+        const first = await session.capability.readAtCursor({
+          cursor: entries[1].cursor,
+        });
+        await session.capability.readAtTime({
+          timestampNs: entries[4].timestampNs,
+        });
+        const second = await session.capability.readAtCursor({
+          cursor: entries[1].cursor,
+        });
+        expect(second).toEqual(first);
+      });
+    });
+
+    it("walks every cursor exactly once through bounded index windows", async () => {
+      await withSession(CANONICAL_SCENARIO, async (session) => {
+        const start = await session.capability.readIndexWindow({
+          after: 0,
+          anchorTimestampNs: 0n,
+          before: 5,
+        });
+        expect(start.hasPrevious).toBe(false);
+        let cursor = start.entries[0].cursor;
+        const visited: string[] = [];
+        for (;;) {
+          visited.push(cursor);
+          const window = await session.capability.readIndexWindow({
+            after: 1,
+            anchorCursor: cursor,
+            before: 0,
+          });
+          expect(window.selectedCursor).toBe(cursor);
+          expect(window.entries[0].cursor).toBe(cursor);
+          const next = window.entries[1];
+          if (!next) {
+            expect(window.hasNext).toBe(false);
+            break;
+          }
+          cursor = next.cursor;
+        }
+        expect(visited).toHaveLength(5);
+        expect(new Set(visited).size).toBe(5);
+      });
+    });
+
+    it("shares one physical fill and never rereads after it", async () => {
+      await withSession(CANONICAL_SCENARIO, async (session) => {
+        if (!session.physicalReads) return;
+        const entries = await allEntries(session, 5);
+        expect(session.physicalReads()).toBe(0);
+        await Promise.all([
+          session.capability.readAtTime({
+            timestampNs: entries[0].timestampNs,
+          }),
+          session.capability.readAtTime({
+            timestampNs: entries[3].timestampNs,
+          }),
+        ]);
+        expect(session.physicalReads()).toBe(1);
+        await session.capability.readAtCursor({ cursor: entries[2].cursor });
+        await session.capability.readAtTime({
+          timestampNs: entries[4].timestampNs,
+        });
+        await session.capability.readIndexWindow({
+          after: 2,
+          anchorCursor: entries[2].cursor,
+          before: 2,
+        });
+        expect(session.physicalReads()).toBe(1);
+      });
+    });
+
+    it("rejects an aborted read without poisoning the shared fill", async () => {
+      await withSession(
+        { ...CANONICAL_SCENARIO, fillLatencyMs: 20 },
+        async (session) => {
+          const entries = await allEntries(session, 5);
+          const controller = new AbortController();
+          const aborted = session.capability.readAtTime({
+            signal: controller.signal,
+            timestampNs: entries[1].timestampNs,
+          });
+          controller.abort();
+          await expect(aborted).rejects.toSatisfy(isEpisodeReadCancelledError);
+          const row = await session.capability.readAtTime({
+            timestampNs: entries[1].timestampNs,
+          });
+          expect(row?.state).toEqual([1.1, Number.NaN, 1.3]);
+          if (session.physicalReads) {
+            expect(session.physicalReads()).toBe(1);
+          }
+        },
+      );
+    });
+
+    it("preserves booleans and integers without float coercion", async () => {
+      await withSession(
+        {
+          action: {
+            dtype: "int64",
+            rows: [
+              [1n, -2n],
+              [3n, 4n],
+            ],
+            shape: [2],
+          },
+          state: {
+            dtype: "bool",
+            rows: [
+              [true, false],
+              [false, true],
+            ],
+            shape: [2],
+          },
+          timestampsSeconds: [0, 0.1],
+        },
+        async (session) => {
+          const entries = await allEntries(session, 2);
+          const row = await session.capability.readAtCursor({
+            cursor: entries[0].cursor,
+          });
+          expect(row.state).toEqual([true, false]);
+          expect(row.state?.every((value) => typeof value === "boolean")).toBe(
+            true,
+          );
+          expect(row.action).toEqual([1n, -2n]);
+          expect(row.action?.every((value) => typeof value === "bigint")).toBe(
+            true,
+          );
+        },
+      );
+    });
+
+    it("omits an undeclared feature instead of inventing values", async () => {
+      await withSession(
+        {
+          action: {
+            dtype: "float32",
+            rows: [[1, 2]],
+            shape: [2],
+          },
+          timestampsSeconds: [0],
+        },
+        async (session) => {
+          expect(session.capability.schema.state).toBeUndefined();
+          expect(session.capability.schema.action).toBeDefined();
+          const entries = await allEntries(session, 1);
+          const row = await session.capability.readAtCursor({
+            cursor: entries[0].cursor,
+          });
+          expect(row.state).toBeUndefined();
+          expect(row.action).toEqual([1, 2]);
+          expect(row.featureErrors).toBeUndefined();
+        },
+      );
+    });
+
+    it("reports a shape mismatch without padding or truncating values", async () => {
+      await withSession(
+        {
+          state: {
+            dtype: "float32",
+            rows: [
+              [1, 2, 3],
+              [4, 5],
+            ],
+            shape: [3],
+          },
+          timestampsSeconds: [0, 0.1],
+        },
+        async (session) => {
+          const entries = await allEntries(session, 2);
+          const healthy = await session.capability.readAtCursor({
+            cursor: entries[0].cursor,
+          });
+          expect(healthy.state).toEqual([1, 2, 3]);
+          expect(healthy.featureErrors).toBeUndefined();
+          const malformed = await session.capability.readAtCursor({
+            cursor: entries[1].cursor,
+          });
+          expect(malformed.state).toEqual([4, 5]);
+          expect(malformed.featureErrors?.state).toBeTruthy();
+        },
+      );
+    });
+
+    it("resolves tasks through the ladder without blocking on any rung", async () => {
+      await withSession(CANONICAL_SCENARIO, async (session) => {
+        const entries = await allEntries(session, 5);
+        const mapped = await session.capability.readAtCursor({
+          cursor: entries[0].cursor,
+        });
+        expect(mapped.task).toEqual({ index: 0, label: "fold the towel" });
+        const secondTask = await session.capability.readAtCursor({
+          cursor: entries[2].cursor,
+        });
+        expect(secondTask.task).toEqual({ index: 1, label: "stack the cube" });
+        const unknown = await session.capability.readAtCursor({
+          cursor: entries[4].cursor,
+        });
+        expect(unknown.task).toEqual({ index: 7 });
+      });
+      await withSession(
+        {
+          episodeTasks: ["only task"],
+          state: { dtype: "float32", rows: [[1]], shape: [1] },
+          taskIndexes: [3],
+          timestampsSeconds: [0],
+        },
+        async (session) => {
+          const entries = await allEntries(session, 1);
+          const row = await session.capability.readAtCursor({
+            cursor: entries[0].cursor,
+          });
+          expect(row.task).toEqual({ index: 3, label: "only task" });
+        },
+      );
+      await withSession(
+        {
+          episodeTasks: ["one", "two"],
+          state: { dtype: "float32", rows: [[1]], shape: [1] },
+          taskIndexes: [5],
+          timestampsSeconds: [0],
+        },
+        async (session) => {
+          const entries = await allEntries(session, 1);
+          const row = await session.capability.readAtCursor({
+            cursor: entries[0].cursor,
+          });
+          expect(row.task).toEqual({ index: 5 });
+        },
+      );
+    });
+
+    it("rejects unknown or foreign cursors with a typed error", async () => {
+      await withSession(CANONICAL_SCENARIO, async ({ capability }) => {
+        await expect(
+          capability.readAtCursor({ cursor: "row:99" }),
+        ).rejects.toSatisfy(isEpisodeExactCursorError);
+        await expect(
+          capability.readAtCursor({ cursor: "bogus" }),
+        ).rejects.toSatisfy(isEpisodeExactCursorError);
+        await expect(
+          capability.readIndexWindow({
+            after: 1,
+            anchorCursor: "row:99",
+            before: 1,
+          }),
+        ).rejects.toSatisfy(isEpisodeExactCursorError);
+      });
+    });
+
+    it("cancels reads after disposal", async () => {
+      const session = await createSession(CANONICAL_SCENARIO);
+      const entries = await allEntries(session, 5);
+      session.dispose();
+      await expect(
+        session.capability.readAtTime({ timestampNs: entries[0].timestampNs }),
+      ).rejects.toSatisfy(isEpisodeReadCancelledError);
+      await expect(
+        session.capability.readAtCursor({ cursor: entries[0].cursor }),
+      ).rejects.toSatisfy(isEpisodeReadCancelledError);
+    });
+  });
+}

--- a/app/packages/multimodal/src/testing/state-action-contract.ts
+++ b/app/packages/multimodal/src/testing/state-action-contract.ts
@@ -432,6 +432,99 @@ export function defineStateActionCapabilityContractTests({
       );
     });
 
+    it("profiles the episode from its own rows, skipping non-finite values", async () => {
+      await withSession(CANONICAL_SCENARIO, async ({ capability }) => {
+        expect(capability.readEpisodeProfile).toBeDefined();
+        const profile = await capability.readEpisodeProfile?.();
+        expect(profile?.rowCount).toBe(5);
+        // Extremes carry the exact row that attains them.
+        expect(profile?.state?.min[0]).toMatchObject({
+          frameIndex: 0,
+          value: 0.1,
+        });
+        expect(profile?.state?.max[0]).toMatchObject({
+          frameIndex: 4,
+          value: 4.1,
+        });
+        expect(profile?.state?.mean[0]).toBeCloseTo(2.1);
+        // Dimension 1 skips its NaN row; dimension 2 skips Infinity and null.
+        expect(profile?.state?.mean[1]).toBeCloseTo(
+          (0.2 + 2.2 + 3.2 + 4.2) / 4,
+        );
+        expect(profile?.state?.min[2]).toMatchObject({
+          frameIndex: 0,
+          value: 0.3,
+        });
+        expect(profile?.state?.max[2]).toMatchObject({
+          frameIndex: 4,
+          value: 4.3,
+        });
+        // Without declared statistics there are no bounds to count against.
+        expect(profile?.state?.outOfRangeCounts).toBeNull();
+        // Dimension counts differ (3 vs 4): no index-wise tracking error.
+        expect(profile?.trackingError).toBeUndefined();
+        // A perfectly regular 20 Hz cadence has no gaps.
+        expect(profile?.timing.medianIntervalNs).toBe(50_000_000n);
+        expect(profile?.timing.gapCount).toBe(0);
+        expect(profile?.timing.gaps).toEqual([]);
+      });
+    });
+
+    it("computes tracking error and timing gaps over matching features", async () => {
+      await withSession(
+        {
+          action: {
+            dtype: "float32",
+            rows: [
+              [1, 10],
+              [2, 20],
+              [4, 30],
+              [3, 34],
+            ],
+            shape: [2],
+          },
+          state: {
+            dtype: "float32",
+            names: ["a", "b"],
+            rows: [
+              [0, 10],
+              [1, 22],
+              [2, 27],
+              [3, 30],
+            ],
+            shape: [2],
+          },
+          timestampsSeconds: [0, 0.1, 0.2, 0.5],
+        },
+        async ({ capability }) => {
+          const profile = await capability.readEpisodeProfile?.();
+          expect(profile?.trackingError?.[0]).toBeCloseTo(1);
+          expect(profile?.trackingError?.[1]).toBeCloseTo(2.25);
+          // Intervals 100ms, 100ms, 300ms: the 300ms one exceeds 1.5× the
+          // 100ms median and seeks to the row where data resumes.
+          expect(profile?.timing.medianIntervalNs).toBe(100_000_000n);
+          expect(profile?.timing.gapCount).toBe(1);
+          expect(profile?.timing.gaps[0]).toEqual({
+            beforeFrameIndex: 2,
+            durationNs: 300_000_000n,
+            timestampNs: 500_000_000n,
+          });
+        },
+      );
+    });
+
+    it("reuses the profiled scan instead of rereading data", async () => {
+      await withSession(CANONICAL_SCENARIO, async (session) => {
+        const first = await session.capability.readEpisodeProfile?.();
+        const readsAfterFirst = session.physicalReads?.();
+        const second = await session.capability.readEpisodeProfile?.();
+        expect(second).toEqual(first);
+        if (session.physicalReads) {
+          expect(session.physicalReads()).toBe(readsAfterFirst);
+        }
+      });
+    });
+
     it("rejects unknown or foreign cursors with a typed error", async () => {
       await withSession(CANONICAL_SCENARIO, async ({ capability }) => {
         await expect(

--- a/app/packages/multimodal/src/testing/state-action-contract.ts
+++ b/app/packages/multimodal/src/testing/state-action-contract.ts
@@ -120,22 +120,30 @@ export function defineStateActionCapabilityContractTests({
           featureName: "observation.state",
           shape: [3],
         });
-        expect(schema.state?.dimensions).toEqual([
+        // Providers may add optional plot bindings; order and names are
+        // the contract.
+        expect(schema.state?.dimensions).toMatchObject([
           { index: 0, name: "shoulder" },
           { index: 1, name: "elbow" },
           { index: 2 },
         ]);
+        expect(schema.state?.dimensions[2]?.name).toBeUndefined();
         expect(schema.action).toMatchObject({
           dtype: "float32",
           featureName: "action",
           shape: [2, 2],
         });
-        expect(schema.action?.dimensions).toEqual([
+        expect(schema.action?.dimensions).toMatchObject([
           { index: 0 },
           { index: 1 },
           { index: 2 },
           { index: 3 },
         ]);
+        expect(
+          schema.action?.dimensions.every(
+            (dimension) => dimension.name === undefined,
+          ),
+        ).toBe(true);
       });
     });
 

--- a/app/packages/multimodal/src/utils/cancellation.test.ts
+++ b/app/packages/multimodal/src/utils/cancellation.test.ts
@@ -37,6 +37,37 @@ describe("cancellation identity", () => {
     epochOnly.cleanup();
   });
 
+  it("propagates epoch cancellation through a linked request", () => {
+    const epoch = new AbortController();
+    const request = new AbortController();
+    const linked = linkAbortSignals(epoch.signal, request.signal);
+
+    epoch.abort();
+
+    expect(linked.signal.aborted).toBe(true);
+    linked.cleanup();
+  });
+
+  it("links already-aborted epochs and requests as aborted", () => {
+    const abortedEpoch = new AbortController();
+    abortedEpoch.abort();
+    const fromEpoch = linkAbortSignals(
+      abortedEpoch.signal,
+      new AbortController().signal,
+    );
+    expect(fromEpoch.signal.aborted).toBe(true);
+    fromEpoch.cleanup();
+
+    const abortedRequest = new AbortController();
+    abortedRequest.abort();
+    const fromRequest = linkAbortSignals(
+      new AbortController().signal,
+      abortedRequest.signal,
+    );
+    expect(fromRequest.signal.aborted).toBe(true);
+    fromRequest.cleanup();
+  });
+
   it("accepts absent and active signals without throwing", () => {
     expect(() => throwIfAborted(undefined)).not.toThrow();
     expect(() => throwIfAborted(null)).not.toThrow();

--- a/app/packages/multimodal/src/utils/cancellation.test.ts
+++ b/app/packages/multimodal/src/utils/cancellation.test.ts
@@ -4,6 +4,7 @@ import {
   ABORT_ERROR_NAME,
   createAbortError,
   DEFAULT_ABORT_ERROR_MESSAGE,
+  linkAbortSignals,
   throwIfAborted,
 } from "./cancellation";
 
@@ -19,6 +20,21 @@ describe("cancellation identity", () => {
     expect(first.stack).toContain("createAbortError");
     expect(second).not.toBe(first);
     expect(second.message).toBe("Indexed read aborted");
+  });
+
+  it("links an epoch with optional request cancellation", () => {
+    const epoch = new AbortController();
+    const request = new AbortController();
+    const linked = linkAbortSignals(epoch.signal, request.signal);
+
+    expect(linked.signal.aborted).toBe(false);
+    request.abort();
+    expect(linked.signal.aborted).toBe(true);
+    linked.cleanup();
+
+    const epochOnly = linkAbortSignals(epoch.signal);
+    expect(epochOnly.signal).toBe(epoch.signal);
+    epochOnly.cleanup();
   });
 
   it("accepts absent and active signals without throwing", () => {

--- a/app/packages/multimodal/src/utils/cancellation.ts
+++ b/app/packages/multimodal/src/utils/cancellation.ts
@@ -20,3 +20,29 @@ export function throwIfAborted(
     throw createAbortError(message);
   }
 }
+
+/** Links an epoch signal with one optional request signal. */
+export function linkAbortSignals(
+  epochSignal: AbortSignal,
+  requestSignal?: AbortSignal,
+): { readonly cleanup: () => void; readonly signal: AbortSignal } {
+  if (!requestSignal) {
+    return { cleanup: () => undefined, signal: epochSignal };
+  }
+
+  const controller = new AbortController();
+  const abort = () => controller.abort();
+  if (epochSignal.aborted || requestSignal.aborted) {
+    controller.abort();
+  } else {
+    epochSignal.addEventListener("abort", abort, { once: true });
+    requestSignal.addEventListener("abort", abort, { once: true });
+  }
+  return {
+    cleanup: () => {
+      epochSignal.removeEventListener("abort", abort);
+      requestSignal.removeEventListener("abort", abort);
+    },
+    signal: controller.signal,
+  };
+}

--- a/app/packages/multimodal/src/video/gop-index.ts
+++ b/app/packages/multimodal/src/video/gop-index.ts
@@ -1,4 +1,4 @@
-import type { H264AccessUnit } from "./types";
+import type { EncodedVideoAccessUnit } from "./types";
 
 export const VIDEO_ENCODED_ACCESS_UNIT_BYTE_CAP = 128 * 1024 * 1024;
 const VIDEO_GOP_INDEX_KEYFRAME_CAP = 8_192;
@@ -22,9 +22,9 @@ export class VideoGopIndex {
 
   constructor(private readonly keyframeCap = VIDEO_GOP_INDEX_KEYFRAME_CAP) {}
 
-  observe(unit: H264AccessUnit): void {
+  observe(unit: EncodedVideoAccessUnit): void {
     if (!unit.frame.keyframe) return;
-    const signature = h264ConfigSignature(unit);
+    const signature = videoConfigSignature(unit);
     const insertionIndex = lowerBoundKeyframe(this.keyframes, unit.timeNs);
     if (this.keyframes[insertionIndex]?.timeNs === unit.timeNs) return;
     const inserted: KeyframeEntry = {
@@ -51,7 +51,7 @@ export class VideoGopIndex {
   recordReadCoverage(
     startTimeNs: bigint,
     endTimeNs: bigint,
-    units: readonly H264AccessUnit[],
+    units: readonly EncodedVideoAccessUnit[],
   ): void {
     mergeRange(this.readCoverage, { endTimeNs, startTimeNs });
     for (const unit of units) this.observe(unit);
@@ -130,7 +130,7 @@ export class VideoGopIndex {
 /** Byte-budgeted encoded access-unit LRU. No live VideoFrames are retained. */
 export class EncodedAccessUnitCache {
   private bytes = 0;
-  private readonly entries = new Map<bigint, H264AccessUnit>();
+  private readonly entries = new Map<bigint, EncodedVideoAccessUnit>();
   private readonly sortedTimes: bigint[] = [];
 
   constructor(
@@ -146,13 +146,13 @@ export class EncodedAccessUnitCache {
     return this.entries.has(timeNs);
   }
 
-  get(timeNs: bigint): H264AccessUnit | undefined {
+  get(timeNs: bigint): EncodedVideoAccessUnit | undefined {
     const unit = this.entries.get(timeNs);
     if (unit) this.touch(timeNs, unit);
     return unit;
   }
 
-  put(unit: H264AccessUnit): void {
+  put(unit: EncodedVideoAccessUnit): void {
     const previous = this.entries.get(unit.timeNs);
     if (previous) {
       this.bytes -= previous.frame.bytes.byteLength;
@@ -173,7 +173,7 @@ export class EncodedAccessUnitCache {
     this.bytes += unit.frame.bytes.byteLength;
     while (this.bytes > this.byteCap) {
       const oldest = this.entries.entries().next().value as
-        | readonly [bigint, H264AccessUnit]
+        | readonly [bigint, EncodedVideoAccessUnit]
         | undefined;
       if (!oldest) break;
       this.entries.delete(oldest[0]);
@@ -183,12 +183,12 @@ export class EncodedAccessUnitCache {
     }
   }
 
-  putAll(units: readonly H264AccessUnit[]): void {
+  putAll(units: readonly EncodedVideoAccessUnit[]): void {
     for (const unit of units) this.put(unit);
   }
 
-  range(startTimeNs: bigint, endTimeNs: bigint): H264AccessUnit[] {
-    const units: H264AccessUnit[] = [];
+  range(startTimeNs: bigint, endTimeNs: bigint): EncodedVideoAccessUnit[] {
+    const units: EncodedVideoAccessUnit[] = [];
     const touchedTimes: bigint[] = [];
     let index = lowerBoundTime(this.sortedTimes, startTimeNs);
     while (index < this.sortedTimes.length) {
@@ -209,7 +209,10 @@ export class EncodedAccessUnitCache {
     return units;
   }
 
-  rangeByDecodeTime(startTimeNs: bigint, endTimeNs: bigint): H264AccessUnit[] {
+  rangeByDecodeTime(
+    startTimeNs: bigint,
+    endTimeNs: bigint,
+  ): EncodedVideoAccessUnit[] {
     const units = [...this.entries.values()]
       .filter((unit) => {
         const decodeTimeNs = unit.frame.decodeTimestampNs ?? unit.timeNs;
@@ -233,21 +236,22 @@ export class EncodedAccessUnitCache {
     if (this.sortedTimes[index] === timeNs) this.sortedTimes.splice(index, 1);
   }
 
-  private touch(timeNs: bigint, unit: H264AccessUnit): void {
+  private touch(timeNs: bigint, unit: EncodedVideoAccessUnit): void {
     this.entries.delete(timeNs);
     this.entries.set(timeNs, unit);
   }
 }
 
 export function uniqueSortedAccessUnits(
-  units: readonly H264AccessUnit[],
-): H264AccessUnit[] {
-  const byTime = new Map<bigint, H264AccessUnit>();
+  units: readonly EncodedVideoAccessUnit[],
+): EncodedVideoAccessUnit[] {
+  const byTime = new Map<bigint, EncodedVideoAccessUnit>();
   for (const unit of units) byTime.set(unit.timeNs, unit);
   return [...byTime.values()].sort(compareUnitTime);
 }
 
-function h264ConfigSignature(unit: H264AccessUnit): string {
+function videoConfigSignature(unit: EncodedVideoAccessUnit): string {
+  if (unit.frame.codec !== "h264") return unit.frame.format;
   const { codecString = "", pps, sps } = unit.frame.h264;
   return `${codecString}:${encodeBytes(sps)}:${encodeBytes(pps)}`;
 }
@@ -262,13 +266,16 @@ function encodeBytes(bytes: Uint8Array | undefined): string {
   return encoded;
 }
 
-function compareUnitTime(left: H264AccessUnit, right: H264AccessUnit): number {
+function compareUnitTime(
+  left: EncodedVideoAccessUnit,
+  right: EncodedVideoAccessUnit,
+): number {
   return left.timeNs < right.timeNs ? -1 : left.timeNs > right.timeNs ? 1 : 0;
 }
 
 function compareUnitDecodeTime(
-  left: H264AccessUnit,
-  right: H264AccessUnit,
+  left: EncodedVideoAccessUnit,
+  right: EncodedVideoAccessUnit,
 ): number {
   const leftTimeNs = left.frame.decodeTimestampNs ?? left.timeNs;
   const rightTimeNs = right.frame.decodeTimestampNs ?? right.timeNs;

--- a/app/packages/multimodal/src/video/gop-index.ts
+++ b/app/packages/multimodal/src/video/gop-index.ts
@@ -273,7 +273,8 @@ function compareUnitTime(
   return left.timeNs < right.timeNs ? -1 : left.timeNs > right.timeNs ? 1 : 0;
 }
 
-function compareUnitDecodeTime(
+/** Orders access units by decode time, then presentation time. */
+export function compareUnitDecodeTime(
   left: EncodedVideoAccessUnit,
   right: EncodedVideoAccessUnit,
 ): number {

--- a/app/packages/multimodal/src/video/gop-index.ts
+++ b/app/packages/multimodal/src/video/gop-index.ts
@@ -146,6 +146,12 @@ export class EncodedAccessUnitCache {
     return this.entries.has(timeNs);
   }
 
+  get(timeNs: bigint): H264AccessUnit | undefined {
+    const unit = this.entries.get(timeNs);
+    if (unit) this.touch(timeNs, unit);
+    return unit;
+  }
+
   put(unit: H264AccessUnit): void {
     const previous = this.entries.get(unit.timeNs);
     if (previous) {
@@ -198,10 +204,19 @@ export class EncodedAccessUnitCache {
     // Refresh recency without disturbing timestamp order.
     for (const timeNs of touchedTimes) {
       const unit = this.entries.get(timeNs);
-      if (!unit) continue;
-      this.entries.delete(timeNs);
-      this.entries.set(timeNs, unit);
+      if (unit) this.touch(timeNs, unit);
     }
+    return units;
+  }
+
+  rangeByDecodeTime(startTimeNs: bigint, endTimeNs: bigint): H264AccessUnit[] {
+    const units = [...this.entries.values()]
+      .filter((unit) => {
+        const decodeTimeNs = unit.frame.decodeTimestampNs ?? unit.timeNs;
+        return decodeTimeNs >= startTimeNs && decodeTimeNs <= endTimeNs;
+      })
+      .sort(compareUnitDecodeTime);
+    for (const unit of units) this.touch(unit.timeNs, unit);
     return units;
   }
 
@@ -216,6 +231,11 @@ export class EncodedAccessUnitCache {
   private removeSortedTime(timeNs: bigint): void {
     const index = lowerBoundTime(this.sortedTimes, timeNs);
     if (this.sortedTimes[index] === timeNs) this.sortedTimes.splice(index, 1);
+  }
+
+  private touch(timeNs: bigint, unit: H264AccessUnit): void {
+    this.entries.delete(timeNs);
+    this.entries.set(timeNs, unit);
   }
 }
 
@@ -244,6 +264,19 @@ function encodeBytes(bytes: Uint8Array | undefined): string {
 
 function compareUnitTime(left: H264AccessUnit, right: H264AccessUnit): number {
   return left.timeNs < right.timeNs ? -1 : left.timeNs > right.timeNs ? 1 : 0;
+}
+
+function compareUnitDecodeTime(
+  left: H264AccessUnit,
+  right: H264AccessUnit,
+): number {
+  const leftTimeNs = left.frame.decodeTimestampNs ?? left.timeNs;
+  const rightTimeNs = right.frame.decodeTimestampNs ?? right.timeNs;
+  return leftTimeNs < rightTimeNs
+    ? -1
+    : leftTimeNs > rightTimeNs
+      ? 1
+      : compareUnitTime(left, right);
 }
 
 function lowerBoundKeyframe(

--- a/app/packages/multimodal/src/video/playback-manager.ts
+++ b/app/packages/multimodal/src/video/playback-manager.ts
@@ -7,7 +7,7 @@ import type {
   VideoPlaybackIntent,
   VideoStreamSnapshot,
 } from "./types";
-import { WebCodecsH264Decoder } from "./webcodecs-decoder";
+import { WebCodecsVideoDecoder } from "./webcodecs-decoder";
 
 interface RegisteredEngine {
   readonly engine: VideoStreamEngine;
@@ -30,7 +30,7 @@ export interface VideoPlaybackManagerStats {
 
 const DEFAULT_DEPENDENCIES: VideoEngineDependencies = {
   copyPresentation: copyVideoFramePresentation,
-  createDecoder: () => new WebCodecsH264Decoder(),
+  createDecoder: () => new WebCodecsVideoDecoder(),
   nowMs: () => performance.now(),
 };
 

--- a/app/packages/multimodal/src/video/presentation.ts
+++ b/app/packages/multimodal/src/video/presentation.ts
@@ -26,7 +26,7 @@ export async function copyVideoFramePresentation(
       canvas.height = height;
       const context = canvas.getContext("2d");
       if (!context) {
-        throw new Error("Unable to allocate an H.264 presentation canvas");
+        throw new Error("Unable to allocate a video presentation canvas");
       }
       context.drawImage(frame, 0, 0, width, height);
       source = canvas;

--- a/app/packages/multimodal/src/video/push-reader.test.ts
+++ b/app/packages/multimodal/src/video/push-reader.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { EncodedH264VideoVisualization } from "../ir";
 import { VISUALIZATION_KIND } from "../ir";
@@ -13,6 +13,10 @@ const budget = {
 };
 
 describe("PushVideoAccessUnitReader", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("returns a complete retained keyframe-to-target span", async () => {
     const reader = new PushVideoAccessUnitReader();
     reader.push("camera", unit(0, true));
@@ -72,7 +76,7 @@ describe("PushVideoAccessUnitReader", () => {
     ).rejects.toBeInstanceOf(VideoIntentCancelledError);
   });
 
-  it("waits for future pushed coverage inside the read deadline", async () => {
+  it("waits for future pushed coverage", async () => {
     const reader = new PushVideoAccessUnitReader();
     reader.push("camera", unit(0, true));
     let settled = false;
@@ -98,6 +102,48 @@ describe("PushVideoAccessUnitReader", () => {
     await expect(read).resolves.toMatchObject({
       complete: true,
       units: [unit(0, true), unit(1), unit(2)],
+    });
+  });
+
+  it("returns an incomplete read when its deadline expires", async () => {
+    vi.useFakeTimers();
+    const reader = new PushVideoAccessUnitReader();
+    reader.push("camera", unit(0, true));
+    const read = reader.read({
+      budget: { ...budget, deadlineMs: performance.now() + 10 },
+      endTimeNs: 2n,
+      signal: new AbortController().signal,
+      startTimeNs: 0n,
+      stream: "camera",
+    });
+
+    await vi.advanceTimersByTimeAsync(11);
+
+    await expect(read).resolves.toMatchObject({
+      complete: false,
+      stopReason: "push-history",
+      units: [unit(0, true)],
+    });
+  });
+
+  it("returns retained history when the producer becomes quiescent", async () => {
+    vi.useFakeTimers();
+    const reader = new PushVideoAccessUnitReader();
+    reader.push("camera", unit(0, true));
+    const read = reader.read({
+      budget,
+      endTimeNs: 2n,
+      signal: new AbortController().signal,
+      startTimeNs: 0n,
+      stream: "camera",
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await expect(read).resolves.toMatchObject({
+      complete: false,
+      stopReason: "push-history",
+      units: [unit(0, true)],
     });
   });
 

--- a/app/packages/multimodal/src/video/push-reader.test.ts
+++ b/app/packages/multimodal/src/video/push-reader.test.ts
@@ -7,7 +7,7 @@ import type { H264AccessUnit } from "./types";
 import { VideoIntentCancelledError } from "./types";
 
 const budget = {
-  deadlineMs: Number.POSITIVE_INFINITY,
+  maxWallTimeMs: Number.POSITIVE_INFINITY,
   maxMessages: 100,
   maxObservedPayloadBytes: 1_024,
 };
@@ -110,7 +110,7 @@ describe("PushVideoAccessUnitReader", () => {
     const reader = new PushVideoAccessUnitReader();
     reader.push("camera", unit(0, true));
     const read = reader.read({
-      budget: { ...budget, deadlineMs: performance.now() + 10 },
+      budget: { ...budget, maxWallTimeMs: 10 },
       endTimeNs: 2n,
       signal: new AbortController().signal,
       startTimeNs: 0n,
@@ -119,6 +119,35 @@ describe("PushVideoAccessUnitReader", () => {
 
     await vi.advanceTimersByTimeAsync(11);
 
+    await expect(read).resolves.toMatchObject({
+      complete: false,
+      stopReason: "push-history",
+      units: [unit(0, true)],
+    });
+  });
+
+  it("does not restart one stream's quiescence window for another stream", async () => {
+    vi.useFakeTimers();
+    const reader = new PushVideoAccessUnitReader();
+    reader.push("camera-a", unit(0, true));
+    let settled = false;
+    const read = reader
+      .read({
+        budget,
+        endTimeNs: 2n,
+        signal: new AbortController().signal,
+        startTimeNs: 0n,
+        stream: "camera-a",
+      })
+      .finally(() => {
+        settled = true;
+      });
+
+    await vi.advanceTimersByTimeAsync(50);
+    reader.push("camera-b", unit(0, true));
+    await vi.advanceTimersByTimeAsync(51);
+
+    expect(settled).toBe(true);
     await expect(read).resolves.toMatchObject({
       complete: false,
       stopReason: "push-history",

--- a/app/packages/multimodal/src/video/push-reader.test.ts
+++ b/app/packages/multimodal/src/video/push-reader.test.ts
@@ -72,6 +72,52 @@ describe("PushVideoAccessUnitReader", () => {
     ).rejects.toBeInstanceOf(VideoIntentCancelledError);
   });
 
+  it("waits for future pushed coverage inside the read deadline", async () => {
+    const reader = new PushVideoAccessUnitReader();
+    reader.push("camera", unit(0, true));
+    let settled = false;
+    const read = reader
+      .read({
+        budget,
+        endTimeNs: 2n,
+        signal: new AbortController().signal,
+        startTimeNs: 0n,
+        stream: "camera",
+      })
+      .finally(() => {
+        settled = true;
+      });
+
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    reader.push("camera", unit(1));
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    reader.push("camera", unit(2));
+
+    await expect(read).resolves.toMatchObject({
+      complete: true,
+      units: [unit(0, true), unit(1), unit(2)],
+    });
+  });
+
+  it("cancels a read waiting for future pushed coverage", async () => {
+    const reader = new PushVideoAccessUnitReader();
+    const controller = new AbortController();
+    reader.push("camera", unit(0, true));
+    const read = reader.read({
+      budget,
+      endTimeNs: 2n,
+      signal: controller.signal,
+      startTimeNs: 0n,
+      stream: "camera",
+    });
+
+    controller.abort();
+
+    await expect(read).rejects.toBeInstanceOf(VideoIntentCancelledError);
+  });
+
   it("reports whether a retained keyframe can bootstrap a target", () => {
     const reader = new PushVideoAccessUnitReader();
     reader.push("camera", unit(2));

--- a/app/packages/multimodal/src/video/push-reader.ts
+++ b/app/packages/multimodal/src/video/push-reader.ts
@@ -37,6 +37,7 @@ export class PushVideoAccessUnitReader implements VideoAccessUnitReader {
   private bytes = 0;
   private readonly insertionOrder: InsertionReference[] = [];
   private nextToken = 0;
+  private readonly pushListeners = new Set<() => void>();
   private readonly streams = new Map<string, StreamHistory>();
   private units = 0;
 
@@ -107,6 +108,7 @@ export class PushVideoAccessUnitReader implements VideoAccessUnitReader {
     this.insertionOrder.push({ stream, timeNs: unit.timeNs, token });
     this.bytes += unit.frame.bytes.byteLength;
     this.evictToBudget();
+    this.notifyPushListeners();
   }
 
   async read({
@@ -118,12 +120,57 @@ export class PushVideoAccessUnitReader implements VideoAccessUnitReader {
   }: Parameters<
     VideoAccessUnitReader["read"]
   >[0]): Promise<VideoAccessUnitReadResult> {
-    if (signal.aborted) throw new VideoIntentCancelledError();
+    for (;;) {
+      if (signal.aborted) throw new VideoIntentCancelledError();
+      const retained = this.readRetained(
+        stream,
+        startTimeNs,
+        endTimeNs,
+        budget.maxMessages,
+        budget.maxObservedPayloadBytes,
+      );
+      if (
+        retained.complete ||
+        retained.stopReason === "push-budget" ||
+        !retained.canGrowToComplete ||
+        playbackNowMs() >= budget.deadlineMs
+      ) {
+        return retained.result;
+      }
+      await this.waitForPush(signal, budget.deadlineMs);
+    }
+  }
+
+  clear(): void {
+    this.bytes = 0;
+    this.insertionOrder.length = 0;
+    this.streams.clear();
+    this.units = 0;
+    this.notifyPushListeners();
+  }
+
+  private readRetained(
+    stream: string,
+    startTimeNs: bigint,
+    endTimeNs: bigint,
+    maxMessages: number,
+    maxObservedPayloadBytes: number,
+  ): {
+    readonly canGrowToComplete: boolean;
+    readonly complete: boolean;
+    readonly result: VideoAccessUnitReadResult;
+    readonly stopReason?: "push-budget" | "push-history";
+  } {
     const history = this.streams.get(stream);
     const retainedStart = history?.sortedTimes[0];
     const retainedEnd = history?.sortedTimes.at(-1);
     if (!history || retainedStart === undefined || retainedEnd === undefined) {
-      return { complete: false, stopReason: "push-history", units: [] };
+      return {
+        canGrowToComplete: false,
+        complete: false,
+        result: { complete: false, stopReason: "push-history", units: [] },
+        stopReason: "push-history",
+      };
     }
 
     const units: H264AccessUnit[] = [];
@@ -131,17 +178,13 @@ export class PushVideoAccessUnitReader implements VideoAccessUnitReader {
     let budgetStopped = false;
     let index = lowerBound(history.sortedTimes, startTimeNs);
     while (index < history.sortedTimes.length) {
-      if (signal.aborted) throw new VideoIntentCancelledError();
       const timeNs = history.sortedTimes[index];
       if (timeNs > endTimeNs) break;
       const unit = history.entries.get(timeNs)?.unit;
       index += 1;
       if (!unit) continue;
       const nextBytes = observedBytes + unit.frame.bytes.byteLength;
-      if (
-        units.length >= budget.maxMessages ||
-        nextBytes > budget.maxObservedPayloadBytes
-      ) {
+      if (units.length >= maxMessages || nextBytes > maxObservedPayloadBytes) {
         budgetStopped = true;
         break;
       }
@@ -152,20 +195,49 @@ export class PushVideoAccessUnitReader implements VideoAccessUnitReader {
       !budgetStopped &&
       startTimeNs >= retainedStart &&
       endTimeNs <= retainedEnd;
+    const stopReason = budgetStopped ? "push-budget" : "push-history";
     return {
+      canGrowToComplete:
+        !budgetStopped &&
+        startTimeNs >= retainedStart &&
+        endTimeNs > retainedEnd,
       complete,
-      ...(complete
-        ? {}
-        : { stopReason: budgetStopped ? "push-budget" : "push-history" }),
-      units,
+      result: {
+        complete,
+        ...(complete ? {} : { stopReason }),
+        units,
+      },
+      ...(complete ? {} : { stopReason }),
     };
   }
 
-  clear(): void {
-    this.bytes = 0;
-    this.insertionOrder.length = 0;
-    this.streams.clear();
-    this.units = 0;
+  private waitForPush(signal: AbortSignal, deadlineMs: number): Promise<void> {
+    if (signal.aborted) return Promise.reject(new VideoIntentCancelledError());
+    return new Promise<void>((resolve, reject) => {
+      let timer: ReturnType<typeof setTimeout> | null = null;
+      const finish = () => {
+        cleanup();
+        resolve();
+      };
+      const cancel = () => {
+        cleanup();
+        reject(new VideoIntentCancelledError());
+      };
+      const cleanup = () => {
+        this.pushListeners.delete(finish);
+        signal.removeEventListener("abort", cancel);
+        if (timer !== null) clearTimeout(timer);
+      };
+      this.pushListeners.add(finish);
+      signal.addEventListener("abort", cancel, { once: true });
+      if (Number.isFinite(deadlineMs)) {
+        timer = setTimeout(finish, Math.max(0, deadlineMs - playbackNowMs()));
+      }
+    });
+  }
+
+  private notifyPushListeners(): void {
+    for (const listener of [...this.pushListeners]) listener();
   }
 
   private evictToBudget(): void {
@@ -185,6 +257,10 @@ export class PushVideoAccessUnitReader implements VideoAccessUnitReader {
       if (history.entries.size === 0) this.streams.delete(reference.stream);
     }
   }
+}
+
+function playbackNowMs(): number {
+  return globalThis.performance?.now() ?? Date.now();
 }
 
 function lowerBound(times: readonly bigint[], timeNs: bigint): number {

--- a/app/packages/multimodal/src/video/push-reader.ts
+++ b/app/packages/multimodal/src/video/push-reader.ts
@@ -1,6 +1,6 @@
 import { VIDEO_ENCODED_ACCESS_UNIT_BYTE_CAP } from "./gop-index";
 import type {
-  H264AccessUnit,
+  EncodedVideoAccessUnit,
   VideoAccessUnitReader,
   VideoAccessUnitReadResult,
 } from "./types";
@@ -10,7 +10,7 @@ const PUSH_VIDEO_ACCESS_UNIT_CAP = 4_096;
 
 interface StoredAccessUnit {
   readonly token: number;
-  readonly unit: H264AccessUnit;
+  readonly unit: EncodedVideoAccessUnit;
 }
 
 interface StreamHistory {
@@ -79,7 +79,7 @@ export class PushVideoAccessUnitReader implements VideoAccessUnitReader {
     return false;
   }
 
-  push(stream: string, unit: H264AccessUnit): void {
+  push(stream: string, unit: EncodedVideoAccessUnit): void {
     let history = this.streams.get(stream);
     if (!history) {
       history = { entries: new Map(), sortedTimes: [] };
@@ -173,7 +173,7 @@ export class PushVideoAccessUnitReader implements VideoAccessUnitReader {
       };
     }
 
-    const units: H264AccessUnit[] = [];
+    const units: EncodedVideoAccessUnit[] = [];
     let observedBytes = 0;
     let budgetStopped = false;
     let index = lowerBound(history.sortedTimes, startTimeNs);

--- a/app/packages/multimodal/src/video/push-reader.ts
+++ b/app/packages/multimodal/src/video/push-reader.ts
@@ -7,6 +7,9 @@ import type {
 import { VideoIntentCancelledError } from "./types";
 
 const PUSH_VIDEO_ACCESS_UNIT_CAP = 4_096;
+// Push-only sources have no EOF marker. One video-frame-scale quiet period
+// closes an incomplete runway instead of spending the engine's full deadline.
+const PUSH_VIDEO_QUIESCENCE_MS = 100;
 
 interface StoredAccessUnit {
   readonly token: number;
@@ -137,7 +140,11 @@ export class PushVideoAccessUnitReader implements VideoAccessUnitReader {
       ) {
         return retained.result;
       }
-      await this.waitForPush(signal, budget.deadlineMs);
+      const pushed = await this.waitForPush(
+        signal,
+        Math.min(budget.deadlineMs, playbackNowMs() + PUSH_VIDEO_QUIESCENCE_MS),
+      );
+      if (!pushed) return retained.result;
     }
   }
 
@@ -211,13 +218,20 @@ export class PushVideoAccessUnitReader implements VideoAccessUnitReader {
     };
   }
 
-  private waitForPush(signal: AbortSignal, deadlineMs: number): Promise<void> {
+  private waitForPush(
+    signal: AbortSignal,
+    deadlineMs: number,
+  ): Promise<boolean> {
     if (signal.aborted) return Promise.reject(new VideoIntentCancelledError());
-    return new Promise<void>((resolve, reject) => {
+    return new Promise<boolean>((resolve, reject) => {
       let timer: ReturnType<typeof setTimeout> | null = null;
       const finish = () => {
         cleanup();
-        resolve();
+        resolve(true);
+      };
+      const quiesce = () => {
+        cleanup();
+        resolve(false);
       };
       const cancel = () => {
         cleanup();
@@ -231,7 +245,7 @@ export class PushVideoAccessUnitReader implements VideoAccessUnitReader {
       this.pushListeners.add(finish);
       signal.addEventListener("abort", cancel, { once: true });
       if (Number.isFinite(deadlineMs)) {
-        timer = setTimeout(finish, Math.max(0, deadlineMs - playbackNowMs()));
+        timer = setTimeout(quiesce, Math.max(0, deadlineMs - playbackNowMs()));
       }
     });
   }

--- a/app/packages/multimodal/src/video/push-reader.ts
+++ b/app/packages/multimodal/src/video/push-reader.ts
@@ -40,7 +40,7 @@ export class PushVideoAccessUnitReader implements VideoAccessUnitReader {
   private bytes = 0;
   private readonly insertionOrder: InsertionReference[] = [];
   private nextToken = 0;
-  private readonly pushListeners = new Set<() => void>();
+  private readonly pushListeners = new Map<string, Set<() => void>>();
   private readonly streams = new Map<string, StreamHistory>();
   private units = 0;
 
@@ -111,7 +111,7 @@ export class PushVideoAccessUnitReader implements VideoAccessUnitReader {
     this.insertionOrder.push({ stream, timeNs: unit.timeNs, token });
     this.bytes += unit.frame.bytes.byteLength;
     this.evictToBudget();
-    this.notifyPushListeners();
+    this.notifyPushListeners(stream);
   }
 
   async read({
@@ -123,6 +123,7 @@ export class PushVideoAccessUnitReader implements VideoAccessUnitReader {
   }: Parameters<
     VideoAccessUnitReader["read"]
   >[0]): Promise<VideoAccessUnitReadResult> {
+    const deadlineMs = playbackNowMs() + budget.maxWallTimeMs;
     for (;;) {
       if (signal.aborted) throw new VideoIntentCancelledError();
       const retained = this.readRetained(
@@ -136,13 +137,14 @@ export class PushVideoAccessUnitReader implements VideoAccessUnitReader {
         retained.complete ||
         retained.stopReason === "push-budget" ||
         !retained.canGrowToComplete ||
-        playbackNowMs() >= budget.deadlineMs
+        playbackNowMs() >= deadlineMs
       ) {
         return retained.result;
       }
       const pushed = await this.waitForPush(
+        stream,
         signal,
-        Math.min(budget.deadlineMs, playbackNowMs() + PUSH_VIDEO_QUIESCENCE_MS),
+        Math.min(deadlineMs, playbackNowMs() + PUSH_VIDEO_QUIESCENCE_MS),
       );
       if (!pushed) return retained.result;
     }
@@ -153,7 +155,7 @@ export class PushVideoAccessUnitReader implements VideoAccessUnitReader {
     this.insertionOrder.length = 0;
     this.streams.clear();
     this.units = 0;
-    this.notifyPushListeners();
+    this.notifyAllPushListeners();
   }
 
   private readRetained(
@@ -219,6 +221,7 @@ export class PushVideoAccessUnitReader implements VideoAccessUnitReader {
   }
 
   private waitForPush(
+    stream: string,
     signal: AbortSignal,
     deadlineMs: number,
   ): Promise<boolean> {
@@ -238,11 +241,18 @@ export class PushVideoAccessUnitReader implements VideoAccessUnitReader {
         reject(new VideoIntentCancelledError());
       };
       const cleanup = () => {
-        this.pushListeners.delete(finish);
+        const listeners = this.pushListeners.get(stream);
+        listeners?.delete(finish);
+        if (listeners?.size === 0) this.pushListeners.delete(stream);
         signal.removeEventListener("abort", cancel);
         if (timer !== null) clearTimeout(timer);
       };
-      this.pushListeners.add(finish);
+      let listeners = this.pushListeners.get(stream);
+      if (!listeners) {
+        listeners = new Set();
+        this.pushListeners.set(stream, listeners);
+      }
+      listeners.add(finish);
       signal.addEventListener("abort", cancel, { once: true });
       if (Number.isFinite(deadlineMs)) {
         timer = setTimeout(quiesce, Math.max(0, deadlineMs - playbackNowMs()));
@@ -250,8 +260,16 @@ export class PushVideoAccessUnitReader implements VideoAccessUnitReader {
     });
   }
 
-  private notifyPushListeners(): void {
-    for (const listener of [...this.pushListeners]) listener();
+  private notifyPushListeners(stream: string): void {
+    for (const listener of [...(this.pushListeners.get(stream) ?? [])]) {
+      listener();
+    }
+  }
+
+  private notifyAllPushListeners(): void {
+    for (const listeners of [...this.pushListeners.values()]) {
+      for (const listener of [...listeners]) listener();
+    }
   }
 
   private evictToBudget(): void {

--- a/app/packages/multimodal/src/video/react.tsx
+++ b/app/packages/multimodal/src/video/react.tsx
@@ -8,7 +8,7 @@ import {
   type ReactNode,
 } from "react";
 
-import type { EncodedH264VideoVisualization } from "../ir";
+import type { EncodedVideoVisualization } from "../ir";
 import type {
   VideoPlaybackManager,
   VideoStreamLease,
@@ -56,7 +56,7 @@ export function useVideoStreamPresentation({
   targetTimeNs,
 }: {
   readonly enabled?: boolean;
-  readonly frame: EncodedH264VideoVisualization | null;
+  readonly frame: EncodedVideoVisualization | null;
   readonly manager?: VideoPlaybackManager | null;
   readonly priority?: VideoIntentPriority;
   readonly stream: string;

--- a/app/packages/multimodal/src/video/react.tsx
+++ b/app/packages/multimodal/src/video/react.tsx
@@ -8,12 +8,15 @@ import {
   type ReactNode,
 } from "react";
 
-import type { EncodedVideoVisualization } from "../ir";
 import type {
   VideoPlaybackManager,
   VideoStreamLease,
 } from "./playback-manager";
-import type { VideoIntentPriority, VideoStreamSnapshot } from "./types";
+import type {
+  SharedEncodedVideoVisualization,
+  VideoIntentPriority,
+  VideoStreamSnapshot,
+} from "./types";
 
 const EMPTY_VIDEO_SNAPSHOT: VideoStreamSnapshot = {
   diagnostic: null,
@@ -56,7 +59,7 @@ export function useVideoStreamPresentation({
   targetTimeNs,
 }: {
   readonly enabled?: boolean;
-  readonly frame: EncodedVideoVisualization | null;
+  readonly frame: SharedEncodedVideoVisualization | null;
   readonly manager?: VideoPlaybackManager | null;
   readonly priority?: VideoIntentPriority;
   readonly stream: string;

--- a/app/packages/multimodal/src/video/stream-engine.test.ts
+++ b/app/packages/multimodal/src/video/stream-engine.test.ts
@@ -6,6 +6,7 @@ import { VideoPlaybackManager } from "./playback-manager";
 import { SharedVideoPresentation } from "./presentation";
 import { MAX_VIDEO_DEPENDENCY_ACCESS_UNITS } from "./stream-engine";
 import type {
+  EncodedVideoAccessUnit,
   H264AccessUnit,
   VideoAccessUnitReader,
   VideoDecoderActor,
@@ -945,7 +946,7 @@ class FakeDecoderActor implements VideoDecoderActor {
   cursorTimeNs: bigint | null = null;
   readonly decodeCalls: Array<{
     readonly target: bigint;
-    readonly units: readonly H264AccessUnit[];
+    readonly units: readonly EncodedVideoAccessUnit[];
   }> = [];
   readonly outputs: ReturnType<typeof fakeVideoFrame>[] = [];
   private readonly readyPresentations = new Set<bigint>();
@@ -982,7 +983,7 @@ class FakeDecoderActor implements VideoDecoderActor {
   }
 
   async decode(
-    units: readonly H264AccessUnit[],
+    units: readonly EncodedVideoAccessUnit[],
     {
       signal,
       targetTimeNs,
@@ -1017,7 +1018,11 @@ class FakeDecoderActor implements VideoDecoderActor {
       this.readyPresentations.delete(targetTimeNs);
       this.cursorDecodeTimeNs =
         units.at(-1)?.frame.decodeTimestampNs ?? targetTimeNs;
-      this.configuredCodec = units[0]?.frame.h264.codecString ?? "avc1.4D001F";
+      const firstFrame = units[0]?.frame;
+      this.configuredCodec =
+        (firstFrame?.codec === "h264"
+          ? firstFrame.h264.codecString
+          : undefined) ?? "avc1.4D001F";
       const output = fakeVideoFrame();
       this.outputs.push(output);
       return output.frame;

--- a/app/packages/multimodal/src/video/stream-engine.test.ts
+++ b/app/packages/multimodal/src/video/stream-engine.test.ts
@@ -377,6 +377,33 @@ describe("VideoPlaybackManager and VideoStreamEngine", () => {
     lease.release();
   });
 
+  it("keeps same-target work after promotion to playing priority", async () => {
+    const gate = deferred<void>();
+    const harness = createHarness({
+      decodeGate: gate.promise,
+      honorAbort: true,
+    });
+    const manager = new VideoPlaybackManager("source", harness.dependencies);
+    const lease = manager.acquire("/camera");
+    const keyframe = accessUnit(0, true);
+
+    lease.request({ ...keyframe, priority: "visible" });
+    await vi.waitFor(() =>
+      expect(harness.decoders[0].decodeCalls).toHaveLength(1),
+    );
+    lease.request({ ...keyframe, priority: "playing" });
+    lease.request({ ...accessUnit(1), priority: "playing" });
+    gate.resolve();
+
+    await presented(lease, 1n);
+    expect(harness.decoders[0].decodeCalls.map((call) => call.target)).toEqual([
+      0n,
+      1n,
+    ]);
+    expect(harness.decoders[0].resetCount).toBe(0);
+    lease.release();
+  });
+
   it("uses decode-order dependencies that present after a B-frame target", async () => {
     const harness = createHarness();
     const keyframe = accessUnit(0, true, "avc1.4D001F", 0);
@@ -406,6 +433,61 @@ describe("VideoPlaybackManager and VideoStreamEngine", () => {
     expect(
       harness.decoders[0].decodeCalls.at(-1)?.units.map((unit) => unit.timeNs),
     ).toEqual([2n]);
+    expect(harness.decoders[0].resetCount).toBe(0);
+    lease.release();
+  });
+
+  it("feeds successors before awaiting a submitted but pending target", async () => {
+    const keyframe = accessUnit(0, true, "avc1.4D001F", 0);
+    const target = accessUnit(100_000_000, false, "avc1.4D001F", 260_000_000);
+    const futurePresentation = accessUnit(
+      166_000_000,
+      false,
+      "avc1.4D001F",
+      100_000_000,
+    );
+    const successor = accessUnit(
+      200_000_000,
+      false,
+      "avc1.4D001F",
+      300_000_000,
+    );
+    const laterSuccessor = accessUnit(
+      300_000_000,
+      false,
+      "avc1.4D001F",
+      400_000_000,
+    );
+    const harness = createHarness({
+      hasReadyPresentation: (_id, timeNs, decodeCallCount) =>
+        timeNs !== target.timeNs || decodeCallCount > 1,
+    });
+    const units = [
+      keyframe,
+      target,
+      futurePresentation,
+      successor,
+      laterSuccessor,
+    ];
+    const read = vi.fn(async ({ endTimeNs, startTimeNs }) => ({
+      complete: true,
+      units: units.filter(
+        (unit) => unit.timeNs >= startTimeNs && unit.timeNs <= endTimeNs,
+      ),
+    }));
+    const manager = new VideoPlaybackManager("source", harness.dependencies);
+    manager.setReader({ timelineStartTimeNs: 0n, read });
+    const lease = manager.acquire("/camera");
+
+    lease.request({ ...keyframe, priority: "playing" });
+    await presented(lease, keyframe.timeNs);
+    lease.request({ ...target, priority: "playing" });
+    await presented(lease, target.timeNs);
+
+    expect(read).toHaveBeenCalledTimes(2);
+    expect(
+      harness.decoders[0].decodeCalls.at(-1)?.units.map((unit) => unit.timeNs),
+    ).toEqual([target.timeNs, laterSuccessor.timeNs]);
     expect(harness.decoders[0].resetCount).toBe(0);
     lease.release();
   });
@@ -682,6 +764,11 @@ function createHarness(
     readonly beforeCopy?: (timeNs: bigint) => Promise<void>;
     readonly decodeGate?: Promise<void>;
     readonly firstDecode?: ReturnType<typeof deferred<VideoFrame>>;
+    readonly hasReadyPresentation?: (
+      id: string,
+      timeNs: bigint,
+      decodeCallCount: number,
+    ) => boolean;
     readonly honorAbort?: boolean;
   } = {},
 ) {
@@ -725,6 +812,7 @@ class FakeDecoderActor implements VideoDecoderActor {
     readonly units: readonly H264AccessUnit[];
   }> = [];
   readonly outputs: ReturnType<typeof fakeVideoFrame>[] = [];
+  private readonly readyPresentations = new Set<bigint>();
   resetCount = 0;
 
   constructor(
@@ -738,9 +826,24 @@ class FakeDecoderActor implements VideoDecoderActor {
       readonly beforeCopy?: (timeNs: bigint) => Promise<void>;
       readonly decodeGate?: Promise<void>;
       readonly firstDecode?: ReturnType<typeof deferred<VideoFrame>>;
+      readonly hasReadyPresentation?: (
+        id: string,
+        timeNs: bigint,
+        decodeCallCount: number,
+      ) => boolean;
       readonly honorAbort?: boolean;
     },
   ) {}
+
+  hasReadyPresentation(timeNs: bigint): boolean {
+    return (
+      this.options.hasReadyPresentation?.(
+        this.id,
+        timeNs,
+        this.decodeCalls.length,
+      ) ?? this.readyPresentations.has(timeNs)
+    );
+  }
 
   async decode(
     units: readonly H264AccessUnit[],
@@ -756,6 +859,7 @@ class FakeDecoderActor implements VideoDecoderActor {
     this.active = true;
     try {
       this.decodeCalls.push({ target: targetTimeNs, units });
+      for (const unit of units) this.readyPresentations.add(unit.timeNs);
       this.decodeOrder.push(this.id.replace("decoder-", "/camera/"));
       await this.options.beforeDecode?.(this.id, targetTimeNs);
       if (this.options.firstDecode && this.decodeCalls.length === 1) {
@@ -765,6 +869,7 @@ class FakeDecoderActor implements VideoDecoderActor {
           this.options.honorAbort === true,
         );
         this.cursorTimeNs = targetTimeNs;
+        this.readyPresentations.delete(targetTimeNs);
         return frame;
       }
       await abortable(
@@ -773,6 +878,7 @@ class FakeDecoderActor implements VideoDecoderActor {
         this.options.honorAbort === true,
       );
       this.cursorTimeNs = targetTimeNs;
+      this.readyPresentations.delete(targetTimeNs);
       this.cursorDecodeTimeNs =
         units.at(-1)?.frame.decodeTimestampNs ?? targetTimeNs;
       this.configuredCodec = units[0]?.frame.h264.codecString ?? "avc1.4D001F";
@@ -791,6 +897,7 @@ class FakeDecoderActor implements VideoDecoderActor {
     this.cursorTimeNs = null;
     this.cursorDecodeTimeNs = null;
     this.configuredCodec = null;
+    this.readyPresentations.clear();
   }
 
   close(): void {

--- a/app/packages/multimodal/src/video/stream-engine.test.ts
+++ b/app/packages/multimodal/src/video/stream-engine.test.ts
@@ -410,6 +410,57 @@ describe("VideoPlaybackManager and VideoStreamEngine", () => {
     lease.release();
   });
 
+  it("refills reordered playback with successor frames before awaiting output", async () => {
+    const harness = createHarness();
+    const keyframe = accessUnit(0, true, "avc1.4D001F", 0);
+    const preceding = accessUnit(
+      300_000_000,
+      false,
+      "avc1.4D001F",
+      300_000_000,
+    );
+    const target = accessUnit(333_333_333, false, "avc1.4D001F", 366_666_666);
+    const successor = accessUnit(
+      366_666_666,
+      false,
+      "avc1.4D001F",
+      333_333_333,
+    );
+    const read = vi.fn(
+      async ({
+        endTimeNs,
+        startTimeNs,
+      }: {
+        endTimeNs: bigint;
+        startTimeNs: bigint;
+      }) => ({
+        complete: true,
+        units: [keyframe, preceding, target, successor].filter(
+          (unit) => unit.timeNs >= startTimeNs && unit.timeNs <= endTimeNs,
+        ),
+      }),
+    );
+    const manager = new VideoPlaybackManager("source", harness.dependencies);
+    manager.setReader({ timelineStartTimeNs: 0n, read });
+    const lease = manager.acquire("/camera");
+
+    lease.request({ ...keyframe, priority: "playing" });
+    await presented(lease, keyframe.timeNs);
+    lease.request({ ...target, priority: "playing" });
+    await presented(lease, target.timeNs);
+
+    expect(read).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        endTimeNs: target.timeNs + 250_000_000n,
+        startTimeNs: 1n,
+      }),
+    );
+    expect(
+      harness.decoders[0].decodeCalls.at(-1)?.units.map((unit) => unit.timeNs),
+    ).toEqual([preceding.timeNs, successor.timeNs, target.timeNs]);
+    lease.release();
+  });
+
   it.each([601, 1_024])(
     "consumes a complete %i-frame long GOP with its keyframe and target",
     async (target) => {

--- a/app/packages/multimodal/src/video/stream-engine.test.ts
+++ b/app/packages/multimodal/src/video/stream-engine.test.ts
@@ -350,6 +350,63 @@ describe("VideoPlaybackManager and VideoStreamEngine", () => {
     lease.release();
   });
 
+  it("lets useful playing work finish while conflating rapid forward intents", async () => {
+    const gate = deferred<void>();
+    const harness = createHarness({
+      decodeGate: gate.promise,
+      honorAbort: true,
+    });
+    const manager = new VideoPlaybackManager("source", harness.dependencies);
+    const lease = manager.acquire("/camera");
+    lease.request({ ...accessUnit(0, true), priority: "playing" });
+    await vi.waitFor(() =>
+      expect(harness.decoders[0].decodeCalls).toHaveLength(1),
+    );
+
+    lease.request({ ...accessUnit(1), priority: "playing" });
+    lease.request({ ...accessUnit(2), priority: "playing" });
+    lease.request({ ...accessUnit(3), priority: "playing" });
+    gate.resolve();
+    await presented(lease, 3n);
+
+    expect(harness.decoders[0].decodeCalls.map((call) => call.target)).toEqual([
+      0n,
+      3n,
+    ]);
+    expect(harness.decoders[0].resetCount).toBe(0);
+    lease.release();
+  });
+
+  it("uses decode-order dependencies that present after a B-frame target", async () => {
+    const harness = createHarness();
+    const keyframe = accessUnit(0, true, "avc1.4D001F", 0);
+    const futurePresentation = accessUnit(2, false, "avc1.4D001F", 1);
+    const target = accessUnit(1, false, "avc1.4D001F", 2);
+    const read = vi.fn(async () => ({
+      complete: true,
+      units: [keyframe, futurePresentation, target],
+    }));
+    const manager = new VideoPlaybackManager("source", harness.dependencies);
+    manager.setReader({ timelineStartTimeNs: 0n, read });
+    const lease = manager.acquire("/camera");
+    lease.request({ ...keyframe, priority: "playing" });
+    await presented(lease, 0n);
+
+    lease.request({ ...target, priority: "playing" });
+    await presented(lease, 1n);
+    expect(
+      harness.decoders[0].decodeCalls.at(-1)?.units.map((unit) => unit.timeNs),
+    ).toEqual([2n, 1n]);
+
+    lease.request({ ...futurePresentation, priority: "playing" });
+    await presented(lease, 2n);
+    expect(
+      harness.decoders[0].decodeCalls.at(-1)?.units.map((unit) => unit.timeNs),
+    ).toEqual([2n]);
+    expect(harness.decoders[0].resetCount).toBe(0);
+    lease.release();
+  });
+
   it.each([601, 1_024])(
     "consumes a complete %i-frame long GOP with its keyframe and target",
     async (target) => {
@@ -607,6 +664,7 @@ function createHarness(
 class FakeDecoderActor implements VideoDecoderActor {
   closeCount = 0;
   configuredCodec: string | null = null;
+  cursorDecodeTimeNs: bigint | null = null;
   cursorTimeNs: bigint | null = null;
   readonly decodeCalls: Array<{
     readonly target: bigint;
@@ -661,6 +719,8 @@ class FakeDecoderActor implements VideoDecoderActor {
         this.options.honorAbort === true,
       );
       this.cursorTimeNs = targetTimeNs;
+      this.cursorDecodeTimeNs =
+        units.at(-1)?.frame.decodeTimestampNs ?? targetTimeNs;
       this.configuredCodec = units[0]?.frame.h264.codecString ?? "avc1.4D001F";
       const output = fakeVideoFrame();
       this.outputs.push(output);
@@ -675,6 +735,7 @@ class FakeDecoderActor implements VideoDecoderActor {
   resetForDiscontinuity(): void {
     this.resetCount += 1;
     this.cursorTimeNs = null;
+    this.cursorDecodeTimeNs = null;
     this.configuredCodec = null;
   }
 
@@ -687,12 +748,16 @@ function accessUnit(
   time: number,
   keyframe = false,
   codecString = "avc1.4D001F",
+  decodeTime?: number,
 ): H264AccessUnit {
   const timeNs = BigInt(time);
   return {
     frame: {
       bytes: Uint8Array.of(0, 0, 1, keyframe ? 0x65 : 0x41, time & 0xff),
       codec: "h264",
+      ...(decodeTime === undefined
+        ? {}
+        : { decodeTimestampNs: BigInt(decodeTime) }),
       format: "h264",
       h264: keyframe
         ? {

--- a/app/packages/multimodal/src/video/stream-engine.test.ts
+++ b/app/packages/multimodal/src/video/stream-engine.test.ts
@@ -404,6 +404,84 @@ describe("VideoPlaybackManager and VideoStreamEngine", () => {
     lease.release();
   });
 
+  it("promotes a pending scrub seek when playback advances", async () => {
+    const gate = deferred<void>();
+    const harness = createHarness({
+      decodeGate: gate.promise,
+      honorAbort: true,
+    });
+    const keyframe = accessUnit(0, true);
+    const scrubTarget = accessUnit(333_333_333);
+    const playbackTarget = accessUnit(366_666_666);
+    const manager = new VideoPlaybackManager("source", harness.dependencies);
+    manager.setReader(rangeReader([keyframe, scrubTarget, playbackTarget]));
+    const lease = manager.acquire("/camera");
+
+    lease.request({ ...scrubTarget, priority: "visible" });
+    await vi.waitFor(() =>
+      expect(harness.decoders[0].decodeCalls).toHaveLength(1),
+    );
+    lease.request({ ...playbackTarget, priority: "playing" });
+    gate.resolve();
+
+    await presented(lease, playbackTarget.timeNs);
+    expect(harness.decoders[0].outputs).toHaveLength(2);
+    expect(harness.presentationSources).toHaveLength(1);
+    expect(harness.decoders[0].resetCount).toBe(1);
+    lease.release();
+  });
+
+  it("rebuilds from a keyframe after cancelling uncertain decoder work", async () => {
+    const blockedDecode = deferred<void>();
+    const firstTarget = accessUnit(
+      333_333_333,
+      false,
+      "avc1.4D001F",
+      366_666_666,
+    );
+    const firstSuccessor = accessUnit(
+      366_666_666,
+      false,
+      "avc1.4D001F",
+      333_333_333,
+    );
+    const latestTarget = accessUnit(
+      3_000_000_000,
+      false,
+      "avc1.4D001F",
+      3_000_000_000,
+    );
+    const keyframe = accessUnit(0, true, "avc1.4D001F", 0);
+    const harness = createHarness({
+      beforeDecode: (_id, targetTimeNs) =>
+        targetTimeNs === firstTarget.timeNs
+          ? blockedDecode.promise
+          : Promise.resolve(),
+      honorAbort: true,
+    });
+    const manager = new VideoPlaybackManager("source", harness.dependencies);
+    manager.setReader(
+      rangeReader([keyframe, firstTarget, firstSuccessor, latestTarget]),
+    );
+    const lease = manager.acquire("/camera");
+
+    lease.request({ ...keyframe, priority: "playing" });
+    await presented(lease, keyframe.timeNs);
+    lease.request({ ...firstTarget, priority: "playing" });
+    await vi.waitFor(() =>
+      expect(harness.decoders[0].decodeCalls.at(-1)?.target).toBe(
+        firstTarget.timeNs,
+      ),
+    );
+    lease.request({ ...latestTarget, priority: "playing" });
+    blockedDecode.resolve();
+
+    await presented(lease, latestTarget.timeNs);
+    expect(harness.decoders[0].resetCount).toBe(1);
+    expect(harness.decoders[0].decodeCalls.at(-1)?.units[0]).toBe(keyframe);
+    lease.release();
+  });
+
   it("uses decode-order dependencies that present after a B-frame target", async () => {
     const harness = createHarness();
     const keyframe = accessUnit(0, true, "avc1.4D001F", 0);
@@ -540,6 +618,57 @@ describe("VideoPlaybackManager and VideoStreamEngine", () => {
     expect(
       harness.decoders[0].decodeCalls.at(-1)?.units.map((unit) => unit.timeNs),
     ).toEqual([preceding.timeNs, successor.timeNs, target.timeNs]);
+    lease.release();
+  });
+
+  it("prerolls a reordered seek through successor frames", async () => {
+    const harness = createHarness();
+    const keyframe = accessUnit(0, true, "avc1.4D001F", 0);
+    const preceding = accessUnit(
+      300_000_000,
+      false,
+      "avc1.4D001F",
+      300_000_000,
+    );
+    const target = accessUnit(333_333_333, false, "avc1.4D001F", 366_666_666);
+    const successor = accessUnit(
+      366_666_666,
+      false,
+      "avc1.4D001F",
+      333_333_333,
+    );
+    const read = vi.fn(
+      async ({
+        endTimeNs,
+        startTimeNs,
+      }: Parameters<VideoAccessUnitReader["read"]>[0]) => ({
+        complete: true,
+        units: [keyframe, preceding, target, successor].filter(
+          (unit) => unit.timeNs >= startTimeNs && unit.timeNs <= endTimeNs,
+        ),
+      }),
+    );
+    const manager = new VideoPlaybackManager("source", harness.dependencies);
+    manager.setReader({ timelineStartTimeNs: 0n, read });
+    const lease = manager.acquire("/camera");
+
+    lease.request({ ...target, priority: "visible" });
+    await presented(lease, target.timeNs);
+
+    expect(read).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        endTimeNs: target.timeNs + 250_000_000n,
+        startTimeNs: keyframe.timeNs,
+      }),
+    );
+    expect(
+      harness.decoders[0].decodeCalls[0].units.map((unit) => unit.timeNs),
+    ).toEqual([
+      keyframe.timeNs,
+      preceding.timeNs,
+      successor.timeNs,
+      target.timeNs,
+    ]);
     lease.release();
   });
 

--- a/app/packages/multimodal/src/video/stream-engine.test.ts
+++ b/app/packages/multimodal/src/video/stream-engine.test.ts
@@ -4,7 +4,10 @@ import type { EncodedH264VideoVisualization } from "../ir";
 import { VISUALIZATION_KIND } from "../ir";
 import { VideoPlaybackManager } from "./playback-manager";
 import { SharedVideoPresentation } from "./presentation";
-import { MAX_VIDEO_DEPENDENCY_ACCESS_UNITS } from "./stream-engine";
+import {
+  MAX_VIDEO_DEPENDENCY_ACCESS_UNITS,
+  REORDERED_VIDEO_DECODE_LOOKAHEAD_NS,
+} from "./stream-engine";
 import type {
   EncodedVideoAccessUnit,
   H264AccessUnit,
@@ -619,13 +622,51 @@ describe("VideoPlaybackManager and VideoStreamEngine", () => {
 
     expect(read).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        endTimeNs: target.timeNs + 250_000_000n,
+        endTimeNs: target.timeNs + REORDERED_VIDEO_DECODE_LOOKAHEAD_NS,
         startTimeNs: 1n,
       }),
     );
     expect(
       harness.decoders[0].decodeCalls.at(-1)?.units.map((unit) => unit.timeNs),
     ).toEqual([preceding.timeNs, successor.timeNs, target.timeNs]);
+    lease.release();
+  });
+
+  it("reconfigures a decode-ordered forward runway at its latest keyframe", async () => {
+    const harness = createHarness();
+    const initial = accessUnit(0, true, "avc1.4D001F", 0);
+    const nextKeyframe = accessUnit(
+      300_000_000,
+      true,
+      "avc1.640028",
+      300_000_000,
+    );
+    const target = accessUnit(333_333_333, false, "avc1.640028", 366_666_666);
+    const successor = accessUnit(
+      366_666_666,
+      false,
+      "avc1.640028",
+      333_333_333,
+    );
+    const read = vi.fn(async ({ endTimeNs, startTimeNs }) => ({
+      complete: true,
+      units: [nextKeyframe, target, successor].filter(
+        (unit) => unit.timeNs >= startTimeNs && unit.timeNs <= endTimeNs,
+      ),
+    }));
+    const manager = new VideoPlaybackManager("source", harness.dependencies);
+    manager.setReader({ timelineStartTimeNs: 0n, read });
+    const lease = manager.acquire("/camera");
+
+    lease.request({ ...initial, priority: "playing" });
+    await presented(lease, initial.timeNs);
+    lease.request({ ...target, priority: "playing" });
+    await presented(lease, target.timeNs);
+
+    expect(harness.decoders[0].resetCount).toBe(1);
+    expect(
+      harness.decoders[0].decodeCalls.at(-1)?.units.map((unit) => unit.timeNs),
+    ).toEqual([nextKeyframe.timeNs, successor.timeNs, target.timeNs]);
     lease.release();
   });
 
@@ -665,7 +706,7 @@ describe("VideoPlaybackManager and VideoStreamEngine", () => {
 
     expect(read).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        endTimeNs: target.timeNs + 250_000_000n,
+        endTimeNs: target.timeNs + REORDERED_VIDEO_DECODE_LOOKAHEAD_NS,
         startTimeNs: keyframe.timeNs,
       }),
     );

--- a/app/packages/multimodal/src/video/stream-engine.test.ts
+++ b/app/packages/multimodal/src/video/stream-engine.test.ts
@@ -167,6 +167,13 @@ describe("VideoPlaybackManager and VideoStreamEngine", () => {
         waitingSeekCount: 6,
       });
     });
+    const waitingSnapshots = leases
+      .map((lease) => lease.getSnapshot())
+      .filter((snapshot) => snapshot.phase === "waiting-for-capacity");
+    expect(waitingSnapshots).toHaveLength(6);
+    expect(
+      waitingSnapshots.every((snapshot) => snapshot.diagnostic === null),
+    ).toBe(true);
     expect(harness.decoders.every((decoder) => decoder.closeCount === 0)).toBe(
       true,
     );

--- a/app/packages/multimodal/src/video/stream-engine.test.ts
+++ b/app/packages/multimodal/src/video/stream-engine.test.ts
@@ -4,7 +4,7 @@ import type { EncodedH264VideoVisualization } from "../ir";
 import { VISUALIZATION_KIND } from "../ir";
 import { VideoPlaybackManager } from "./playback-manager";
 import { SharedVideoPresentation } from "./presentation";
-import { MAX_H264_GOP_ACCESS_UNITS } from "./stream-engine";
+import { MAX_VIDEO_DEPENDENCY_ACCESS_UNITS } from "./stream-engine";
 import type {
   H264AccessUnit,
   VideoAccessUnitReader,
@@ -703,7 +703,7 @@ describe("VideoPlaybackManager and VideoStreamEngine", () => {
 
   it("rejects a dependency chain beyond the bounded decode budget", async () => {
     const harness = createHarness();
-    const target = MAX_H264_GOP_ACCESS_UNITS;
+    const target = MAX_VIDEO_DEPENDENCY_ACCESS_UNITS;
     const units = Array.from({ length: target + 1 }, (_, index) =>
       accessUnit(index, index === 0),
     );

--- a/app/packages/multimodal/src/video/stream-engine.test.ts
+++ b/app/packages/multimodal/src/video/stream-engine.test.ts
@@ -99,7 +99,7 @@ describe("VideoPlaybackManager and VideoStreamEngine", () => {
     lease.request({ ...accessUnit(1_000_000_000), priority: "visible" });
     await vi.waitFor(() =>
       expect(lease.getSnapshot()).toMatchObject({
-        diagnostic: { message: "Waiting for an H.264 access unit reader" },
+        diagnostic: { message: "Waiting for a video access unit reader" },
         phase: "waiting-for-keyframe",
       }),
     );
@@ -708,7 +708,7 @@ describe("VideoPlaybackManager and VideoStreamEngine", () => {
     await vi.waitFor(() =>
       expect(lease.getSnapshot()).toMatchObject({
         diagnostic: {
-          message: "H.264 dependency chain exceeds the bounded decode budget",
+          message: "Video dependency chain exceeds the bounded decode budget",
         },
         phase: "waiting-for-keyframe",
       }),

--- a/app/packages/multimodal/src/video/stream-engine.test.ts
+++ b/app/packages/multimodal/src/video/stream-engine.test.ts
@@ -391,12 +391,15 @@ describe("VideoPlaybackManager and VideoStreamEngine", () => {
     const lease = manager.acquire("/camera");
     lease.request({ ...keyframe, priority: "playing" });
     await presented(lease, 0n);
+    expect(
+      harness.decoders[0].decodeCalls.at(-1)?.units.map((unit) => unit.timeNs),
+    ).toEqual([0n, 2n, 1n]);
 
     lease.request({ ...target, priority: "playing" });
     await presented(lease, 1n);
     expect(
       harness.decoders[0].decodeCalls.at(-1)?.units.map((unit) => unit.timeNs),
-    ).toEqual([2n, 1n]);
+    ).toEqual([1n]);
 
     lease.request({ ...futurePresentation, priority: "playing" });
     await presented(lease, 2n);

--- a/app/packages/multimodal/src/video/stream-engine.ts
+++ b/app/packages/multimodal/src/video/stream-engine.ts
@@ -23,12 +23,13 @@ import {
 const NS_PER_SECOND = 1_000_000_000n;
 const MAX_DIRECT_FORWARD_GAP_NS = 500_000_000n;
 /** Forward presentation coverage retained while decoding reordered video. */
-export const H264_REORDERED_DECODE_LOOKAHEAD_NS = 250_000_000n;
-export const MAX_H264_GOP_ACCESS_UNITS = 4_096;
+export const REORDERED_VIDEO_DECODE_LOOKAHEAD_NS = 250_000_000n;
+/** Maximum access units admitted for one bounded video dependency chain. */
+export const MAX_VIDEO_DEPENDENCY_ACCESS_UNITS = 4_096;
 const VIDEO_SEEK_READ_POLICY = {
   initialLookbackNs: 15n * NS_PER_SECOND,
   maxLookbackNs: 120n * NS_PER_SECOND,
-  maxMessages: MAX_H264_GOP_ACCESS_UNITS,
+  maxMessages: MAX_VIDEO_DEPENDENCY_ACCESS_UNITS,
   maxObservedPayloadBytes: 128 * 1024 * 1024,
   maxWallTimeMs: 8_000,
 } as const;
@@ -434,7 +435,7 @@ export class VideoStreamEngine {
     const reorderedForwardRead =
       targetDecodeTimeNs !== undefined && cursorDecodeTimeNs !== null;
     const endTimeNs = reorderedForwardRead
-      ? intent.timeNs + H264_REORDERED_DECODE_LOOKAHEAD_NS
+      ? intent.timeNs + REORDERED_VIDEO_DECODE_LOOKAHEAD_NS
       : intent.timeNs;
     const read = await this.readRange(reader, startTimeNs, endTimeNs, signal);
     const decodeEndTimeNs = maxDecodeTimeNs([...read, intent]);
@@ -460,7 +461,7 @@ export class VideoStreamEngine {
     if (!units.some((unit) => unit.timeNs === intent.timeNs)) {
       throw new VideoDependencyWaitError("Waiting for the video seek target");
     }
-    if (units.length > MAX_H264_GOP_ACCESS_UNITS) {
+    if (units.length > MAX_VIDEO_DEPENDENCY_ACCESS_UNITS) {
       throw new VideoDependencyWaitError(
         "Video dependency chain exceeds the bounded decode budget",
       );
@@ -496,7 +497,7 @@ export class VideoStreamEngine {
     const runwayEndTimeNs =
       intent.frame.decodeTimestampNs === undefined
         ? intent.timeNs
-        : intent.timeNs + H264_REORDERED_DECODE_LOOKAHEAD_NS;
+        : intent.timeNs + REORDERED_VIDEO_DECODE_LOOKAHEAD_NS;
     if (intent.frame.keyframe) {
       if (intent.frame.decodeTimestampNs === undefined) return [intent];
       const reader = this.reader();
@@ -514,7 +515,7 @@ export class VideoStreamEngine {
           "Waiting for the video runway keyframe",
         );
       }
-      if (units.length > MAX_H264_GOP_ACCESS_UNITS) {
+      if (units.length > MAX_VIDEO_DEPENDENCY_ACCESS_UNITS) {
         throw new VideoDependencyWaitError(
           "Video dependency chain exceeds the bounded decode budget",
         );
@@ -615,7 +616,7 @@ export class VideoStreamEngine {
     if (!units.some((unit) => unit.timeNs === intent.timeNs)) {
       throw new VideoDependencyWaitError("Waiting for the video runway target");
     }
-    if (units.length > MAX_H264_GOP_ACCESS_UNITS) {
+    if (units.length > MAX_VIDEO_DEPENDENCY_ACCESS_UNITS) {
       throw new VideoDependencyWaitError(
         "Video dependency chain exceeds the bounded decode budget",
       );

--- a/app/packages/multimodal/src/video/stream-engine.ts
+++ b/app/packages/multimodal/src/video/stream-engine.ts
@@ -197,11 +197,22 @@ export class VideoStreamEngine {
         this.nominalForwardStepNs !== null &&
         forwardGapNs <=
           this.nominalForwardStepNs + this.nominalForwardStepNs / 2n;
+      const targetDecodeTimeNs = intent.frame.decodeTimestampNs;
+      const decodeCursorTimeNs = this.decoder.cursorDecodeTimeNs;
+      const decodeCadenceAllowsDirect =
+        targetDecodeTimeNs === undefined ||
+        (decodeCursorTimeNs !== null &&
+          (targetDecodeTimeNs <= decodeCursorTimeNs ||
+            (this.nominalForwardStepNs !== null &&
+              targetDecodeTimeNs - decodeCursorTimeNs > 0n &&
+              targetDecodeTimeNs - decodeCursorTimeNs <=
+                this.nominalForwardStepNs + this.nominalForwardStepNs / 2n)));
       const directForward =
         cursorTimeNs !== null &&
         forwardGapNs !== null &&
         forwardGapNs <= MAX_DIRECT_FORWARD_GAP_NS &&
         (!this.reader() || cadenceAllowsDirect) &&
+        decodeCadenceAllowsDirect &&
         !this.continuityUncertain;
       const directKeyframe =
         intent.frame.keyframe &&
@@ -382,12 +393,30 @@ export class VideoStreamEngine {
       intent.timeNs,
       signal,
     );
-    const units = uniqueSortedAccessUnits([
-      ...this.cache.range(startTimeNs, intent.timeNs),
-      ...read,
-      intent,
-    ]);
-    if (units.at(-1)?.timeNs !== intent.timeNs) {
+    const targetDecodeTimeNs = intent.frame.decodeTimestampNs;
+    const cursorDecodeTimeNs = this.decoder.cursorDecodeTimeNs;
+    const units =
+      targetDecodeTimeNs !== undefined && cursorDecodeTimeNs !== null
+        ? uniqueDecodeSortedAccessUnits([
+            ...this.cache.rangeByDecodeTime(
+              cursorDecodeTimeNs + 1n,
+              targetDecodeTimeNs,
+            ),
+            ...read,
+            intent,
+          ]).filter(
+            (unit) =>
+              (unit.frame.decodeTimestampNs ?? unit.timeNs) >
+                cursorDecodeTimeNs &&
+              (unit.frame.decodeTimestampNs ?? unit.timeNs) <=
+                targetDecodeTimeNs,
+          )
+        : uniqueSortedAccessUnits([
+            ...this.cache.range(startTimeNs, intent.timeNs),
+            ...read,
+            intent,
+          ]);
+    if (!units.some((unit) => unit.timeNs === intent.timeNs)) {
       throw new VideoDependencyWaitError("Waiting for the H.264 seek target");
     }
     if (units.length > MAX_H264_GOP_ACCESS_UNITS) {
@@ -404,7 +433,7 @@ export class VideoStreamEngine {
     units: readonly H264AccessUnit[],
   ): void {
     let previous = previousTimeNs;
-    for (const unit of units) {
+    for (const unit of uniqueSortedAccessUnits(units)) {
       if (previous !== null && unit.timeNs > previous) {
         const step = unit.timeNs - previous;
         if (
@@ -486,16 +515,28 @@ export class VideoStreamEngine {
         "Waiting for complete H.264 runway coverage",
       );
     }
-    const units = uniqueSortedAccessUnits([
-      ...this.cache.range(keyframeTimeNs, intent.timeNs),
-      intent,
-    ]);
+    const keyframe = this.cache.get(keyframeTimeNs);
+    const targetDecodeTimeNs = intent.frame.decodeTimestampNs;
+    const keyframeDecodeTimeNs = keyframe?.frame.decodeTimestampNs;
+    const units =
+      targetDecodeTimeNs !== undefined && keyframeDecodeTimeNs !== undefined
+        ? uniqueDecodeSortedAccessUnits([
+            ...this.cache.rangeByDecodeTime(
+              keyframeDecodeTimeNs,
+              targetDecodeTimeNs,
+            ),
+            intent,
+          ])
+        : uniqueSortedAccessUnits([
+            ...this.cache.range(keyframeTimeNs, intent.timeNs),
+            intent,
+          ]);
     if (!units[0]?.frame.keyframe || units[0].timeNs !== keyframeTimeNs) {
       throw new VideoDependencyWaitError(
         "Waiting for the H.264 runway keyframe",
       );
     }
-    if (units.at(-1)?.timeNs !== intent.timeNs) {
+    if (!units.some((unit) => unit.timeNs === intent.timeNs)) {
       throw new VideoDependencyWaitError("Waiting for the H.264 runway target");
     }
     if (units.length > MAX_H264_GOP_ACCESS_UNITS) {
@@ -620,4 +661,24 @@ function strongerIntent(
     VIDEO_INTENT_PRIORITY_WEIGHT[current.priority]
     ? candidate
     : current;
+}
+
+function uniqueDecodeSortedAccessUnits(
+  units: readonly H264AccessUnit[],
+): H264AccessUnit[] {
+  const byTime = new Map<bigint, H264AccessUnit>();
+  for (const unit of units) byTime.set(unit.timeNs, unit);
+  return [...byTime.values()].sort((left, right) => {
+    const leftTimeNs = left.frame.decodeTimestampNs ?? left.timeNs;
+    const rightTimeNs = right.frame.decodeTimestampNs ?? right.timeNs;
+    return leftTimeNs < rightTimeNs
+      ? -1
+      : leftTimeNs > rightTimeNs
+        ? 1
+        : left.timeNs < right.timeNs
+          ? -1
+          : left.timeNs > right.timeNs
+            ? 1
+            : 0;
+  });
 }

--- a/app/packages/multimodal/src/video/stream-engine.ts
+++ b/app/packages/multimodal/src/video/stream-engine.ts
@@ -1,6 +1,7 @@
 import { diagnosticMessage } from "../utils/errors";
 import { VideoSeekAdmissionScheduler } from "./admission-scheduler";
 import {
+  compareUnitDecodeTime,
   EncodedAccessUnitCache,
   uniqueSortedAccessUnits,
   VideoGopIndex,
@@ -774,19 +775,7 @@ function uniqueDecodeSortedAccessUnits(
 ): EncodedVideoAccessUnit[] {
   const byTime = new Map<bigint, EncodedVideoAccessUnit>();
   for (const unit of units) byTime.set(unit.timeNs, unit);
-  return [...byTime.values()].sort((left, right) => {
-    const leftTimeNs = left.frame.decodeTimestampNs ?? left.timeNs;
-    const rightTimeNs = right.frame.decodeTimestampNs ?? right.timeNs;
-    return leftTimeNs < rightTimeNs
-      ? -1
-      : leftTimeNs > rightTimeNs
-        ? 1
-        : left.timeNs < right.timeNs
-          ? -1
-          : left.timeNs > right.timeNs
-            ? 1
-            : 0;
-  });
+  return [...byTime.values()].sort(compareUnitDecodeTime);
 }
 
 function maxDecodeTimeNs(

--- a/app/packages/multimodal/src/video/stream-engine.ts
+++ b/app/packages/multimodal/src/video/stream-engine.ts
@@ -47,6 +47,7 @@ export class VideoStreamEngine {
   private activeController: AbortController | null = null;
   private activeForwardPublicationProtected = false;
   private activeIntent: VideoPlaybackIntent | null = null;
+  private activePublicationSupersededButAllowed = false;
   private readonly cache: EncodedAccessUnitCache;
   private closed = false;
   private continuityUncertain = false;
@@ -124,7 +125,13 @@ export class VideoStreamEngine {
       this.activeIntent = { ...this.activeIntent, priority: "playing" };
       this.scheduler.promote(this.activeController.signal, "playing");
     }
-    if (this.activeController && !retainActiveForwardPublication) {
+    const retainActiveWork =
+      retainActiveForwardPublication ||
+      canFinishActivePlaybackIntent(this.activeIntent, intent);
+    if (retainActiveForwardPublication) {
+      this.activePublicationSupersededButAllowed = true;
+    }
+    if (this.activeController && !retainActiveWork) {
       this.continuityUncertain = true;
       this.activeController.abort();
     }
@@ -135,7 +142,7 @@ export class VideoStreamEngine {
         this.decoder.cursorTimeNs === null ? "seeking.locating" : "forward",
       targetTimeNs: intent.timeNs,
     });
-    if (retainActiveForwardPublication) return;
+    if (retainActiveWork) return;
     void this.pump();
   }
 
@@ -177,6 +184,7 @@ export class VideoStreamEngine {
         const controller = new AbortController();
         this.activeController = controller;
         this.activeIntent = intent;
+        this.activePublicationSupersededButAllowed = false;
         try {
           await this.processIntent(intent, generation, controller.signal);
         } catch (error) {
@@ -185,6 +193,7 @@ export class VideoStreamEngine {
           if (this.activeController === controller) {
             this.activeController = null;
             this.activeIntent = null;
+            this.activePublicationSupersededButAllowed = false;
           }
         }
       }
@@ -312,7 +321,11 @@ export class VideoStreamEngine {
         signal,
       );
       if (directForward) this.observeForwardCadence(cursorTimeNs, units);
-      if (signal.aborted) {
+      if (
+        signal.aborted ||
+        (generation !== this.generation &&
+          !this.activePublicationSupersededButAllowed)
+      ) {
         decoded.close();
         throw new VideoIntentCancelledError();
       }
@@ -328,7 +341,12 @@ export class VideoStreamEngine {
         decoded.close();
         throw error;
       }
-      if (signal.aborted || this.closed) {
+      if (
+        signal.aborted ||
+        (generation !== this.generation &&
+          !this.activePublicationSupersededButAllowed) ||
+        this.closed
+      ) {
         presentation.releaseOwner();
         throw new VideoIntentCancelledError();
       }
@@ -356,6 +374,7 @@ export class VideoStreamEngine {
     return (
       this.activeController !== null &&
       this.activeForwardPublicationProtected &&
+      this.activeIntent?.priority === "playing" &&
       previousTargetTimeNs !== null &&
       timeNs > previousTargetTimeNs &&
       timeNs - previousTargetTimeNs <= MAX_DIRECT_FORWARD_GAP_NS
@@ -718,6 +737,22 @@ function strongerIntent(
     VIDEO_INTENT_PRIORITY_WEIGHT[current.priority]
     ? candidate
     : current;
+}
+
+function canFinishActivePlaybackIntent(
+  active: VideoPlaybackIntent | null,
+  requested: VideoPlaybackIntent,
+): boolean {
+  if (
+    !active ||
+    active.priority !== "playing" ||
+    requested.priority !== "playing" ||
+    requested.frame.keyframe ||
+    requested.timeNs <= active.timeNs
+  ) {
+    return false;
+  }
+  return requested.timeNs - active.timeNs <= MAX_DIRECT_FORWARD_GAP_NS;
 }
 
 function canPromoteActivePlaybackIntent(

--- a/app/packages/multimodal/src/video/stream-engine.ts
+++ b/app/packages/multimodal/src/video/stream-engine.ts
@@ -45,6 +45,7 @@ const INITIAL_SNAPSHOT: VideoStreamSnapshot = {
 export class VideoStreamEngine {
   private activeController: AbortController | null = null;
   private activeForwardPublicationProtected = false;
+  private activeIntent: VideoPlaybackIntent | null = null;
   private readonly cache: EncodedAccessUnitCache;
   private closed = false;
   private continuityUncertain = false;
@@ -115,6 +116,13 @@ export class VideoStreamEngine {
     this.requestedPriority = intent.priority;
     this.generation += 1;
     this.latestIntent = intent;
+    if (
+      this.activeController &&
+      canPromoteActivePlaybackIntent(this.activeIntent, intent)
+    ) {
+      this.activeIntent = { ...this.activeIntent, priority: "playing" };
+      this.scheduler.promote(this.activeController.signal, "playing");
+    }
     if (this.activeController && !retainActiveForwardPublication) {
       this.continuityUncertain = true;
       this.activeController.abort();
@@ -136,6 +144,7 @@ export class VideoStreamEngine {
     this.latestIntent = null;
     this.activeController?.abort();
     this.activeController = null;
+    this.activeIntent = null;
     this.decoder.close();
     this.cache.clear();
     this.gopIndex.clear();
@@ -166,6 +175,7 @@ export class VideoStreamEngine {
         const generation = this.generation;
         const controller = new AbortController();
         this.activeController = controller;
+        this.activeIntent = intent;
         try {
           await this.processIntent(intent, generation, controller.signal);
         } catch (error) {
@@ -173,6 +183,7 @@ export class VideoStreamEngine {
         } finally {
           if (this.activeController === controller) {
             this.activeController = null;
+            this.activeIntent = null;
           }
         }
       }
@@ -261,7 +272,11 @@ export class VideoStreamEngine {
           if (this.decoder.configuredCodec !== null) {
             this.decoder.resetForDiscontinuity();
           }
-        } else if (cursorTimeNs !== null && intent.timeNs > cursorTimeNs) {
+        } else if (
+          cursorTimeNs !== null &&
+          intent.timeNs > cursorTimeNs &&
+          !this.continuityUncertain
+        ) {
           this.publishIfCurrent(generation, {
             diagnostic: null,
             phase: "seeking.reading",
@@ -462,6 +477,10 @@ export class VideoStreamEngine {
     signal: AbortSignal,
     generation: number,
   ): Promise<readonly H264AccessUnit[]> {
+    const runwayEndTimeNs =
+      intent.frame.decodeTimestampNs === undefined
+        ? intent.timeNs
+        : intent.timeNs + REORDERED_DECODE_LOOKAHEAD_NS;
     if (intent.frame.keyframe) {
       if (intent.frame.decodeTimestampNs === undefined) return [intent];
       const reader = this.reader();
@@ -470,7 +489,7 @@ export class VideoStreamEngine {
       const read = await this.readRange(
         reader,
         intent.timeNs,
-        intent.timeNs + REORDERED_DECODE_LOOKAHEAD_NS,
+        runwayEndTimeNs,
         signal,
       );
       const units = uniqueDecodeSortedAccessUnits([intent, ...read]);
@@ -493,8 +512,8 @@ export class VideoStreamEngine {
     const knownKeyframe = this.gopIndex.keyframeTimeAtOrBefore(intent.timeNs);
     if (knownKeyframe !== null) {
       this.publishIfCurrent(generation, { phase: "seeking.reading" });
-      await this.readRange(reader, knownKeyframe, intent.timeNs, signal);
-      return this.validatedRunway(knownKeyframe, intent);
+      await this.readRange(reader, knownKeyframe, runwayEndTimeNs, signal);
+      return this.validatedRunway(knownKeyframe, runwayEndTimeNs, intent);
     }
 
     const timelineStartNs = reader.timelineStartTimeNs;
@@ -525,8 +544,10 @@ export class VideoStreamEngine {
       await this.readRange(reader, startTimeNs, endTimeNs, signal);
       const keyframe = this.gopIndex.keyframeTimeAtOrBefore(intent.timeNs);
       if (keyframe !== null && keyframe >= startTimeNs) {
-        // Every searched interval and the target are now in the encoded cache.
-        return this.validatedRunway(keyframe, intent);
+        // The lookback found the GOP. Re-read it through a bounded successor
+        // window so reordered targets can leave the browser decoder.
+        await this.readRange(reader, keyframe, runwayEndTimeNs, signal);
+        return this.validatedRunway(keyframe, runwayEndTimeNs, intent);
       }
       if (startTimeNs === timelineStartNs) break;
       endTimeNs = startTimeNs - 1n;
@@ -538,6 +559,7 @@ export class VideoStreamEngine {
 
   private validatedRunway(
     keyframeTimeNs: bigint,
+    runwayEndTimeNs: bigint,
     intent: VideoPlaybackIntent,
   ): readonly H264AccessUnit[] {
     if (
@@ -551,12 +573,17 @@ export class VideoStreamEngine {
     const keyframe = this.cache.get(keyframeTimeNs);
     const targetDecodeTimeNs = intent.frame.decodeTimestampNs;
     const keyframeDecodeTimeNs = keyframe?.frame.decodeTimestampNs;
+    const runwayDecodeEndTimeNs = maxDecodeTimeNs(
+      this.cache.range(keyframeTimeNs, runwayEndTimeNs),
+    );
     const units =
-      targetDecodeTimeNs !== undefined && keyframeDecodeTimeNs !== undefined
+      targetDecodeTimeNs !== undefined &&
+      keyframeDecodeTimeNs !== undefined &&
+      runwayDecodeEndTimeNs !== null
         ? uniqueDecodeSortedAccessUnits([
             ...this.cache.rangeByDecodeTime(
               keyframeDecodeTimeNs,
-              targetDecodeTimeNs,
+              runwayDecodeEndTimeNs,
             ),
             intent,
           ])
@@ -696,6 +723,19 @@ function strongerIntent(
     : current;
 }
 
+function canPromoteActivePlaybackIntent(
+  active: VideoPlaybackIntent | null,
+  requested: VideoPlaybackIntent,
+): active is VideoPlaybackIntent {
+  return Boolean(
+    active &&
+    active.priority !== "playing" &&
+    requested.priority === "playing" &&
+    !requested.frame.keyframe &&
+    requested.timeNs > active.timeNs &&
+    requested.timeNs - active.timeNs <= MAX_DIRECT_FORWARD_GAP_NS,
+  );
+}
 function uniqueDecodeSortedAccessUnits(
   units: readonly H264AccessUnit[],
 ): H264AccessUnit[] {

--- a/app/packages/multimodal/src/video/stream-engine.ts
+++ b/app/packages/multimodal/src/video/stream-engine.ts
@@ -22,7 +22,8 @@ import {
 
 const NS_PER_SECOND = 1_000_000_000n;
 const MAX_DIRECT_FORWARD_GAP_NS = 500_000_000n;
-const REORDERED_DECODE_LOOKAHEAD_NS = 250_000_000n;
+/** Forward presentation coverage retained while decoding reordered H.264. */
+export const H264_REORDERED_DECODE_LOOKAHEAD_NS = 250_000_000n;
 export const MAX_H264_GOP_ACCESS_UNITS = 4_096;
 const VIDEO_SEEK_READ_POLICY = {
   initialLookbackNs: 15n * NS_PER_SECOND,
@@ -418,7 +419,7 @@ export class VideoStreamEngine {
     const reorderedForwardRead =
       targetDecodeTimeNs !== undefined && cursorDecodeTimeNs !== null;
     const endTimeNs = reorderedForwardRead
-      ? intent.timeNs + REORDERED_DECODE_LOOKAHEAD_NS
+      ? intent.timeNs + H264_REORDERED_DECODE_LOOKAHEAD_NS
       : intent.timeNs;
     const read = await this.readRange(reader, startTimeNs, endTimeNs, signal);
     const decodeEndTimeNs = maxDecodeTimeNs([...read, intent]);
@@ -480,7 +481,7 @@ export class VideoStreamEngine {
     const runwayEndTimeNs =
       intent.frame.decodeTimestampNs === undefined
         ? intent.timeNs
-        : intent.timeNs + REORDERED_DECODE_LOOKAHEAD_NS;
+        : intent.timeNs + H264_REORDERED_DECODE_LOOKAHEAD_NS;
     if (intent.frame.keyframe) {
       if (intent.frame.decodeTimestampNs === undefined) return [intent];
       const reader = this.reader();

--- a/app/packages/multimodal/src/video/stream-engine.ts
+++ b/app/packages/multimodal/src/video/stream-engine.ts
@@ -6,7 +6,7 @@ import {
   VideoGopIndex,
 } from "./gop-index";
 import type {
-  H264AccessUnit,
+  EncodedVideoAccessUnit,
   OwnedVideoPresentation,
   VideoAccessUnitReader,
   VideoDecoderActor,
@@ -22,7 +22,7 @@ import {
 
 const NS_PER_SECOND = 1_000_000_000n;
 const MAX_DIRECT_FORWARD_GAP_NS = 500_000_000n;
-/** Forward presentation coverage retained while decoding reordered H.264. */
+/** Forward presentation coverage retained while decoding reordered video. */
 export const H264_REORDERED_DECODE_LOOKAHEAD_NS = 250_000_000n;
 export const MAX_H264_GOP_ACCESS_UNITS = 4_096;
 const VIDEO_SEEK_READ_POLICY = {
@@ -200,7 +200,7 @@ export class VideoStreamEngine {
     generation: number,
     signal: AbortSignal,
   ): Promise<void> {
-    let units: readonly H264AccessUnit[];
+    let units: readonly EncodedVideoAccessUnit[];
     let releaseAdmission: (() => void) | null = null;
     try {
       const cursorTimeNs = this.decoder.cursorTimeNs;
@@ -256,7 +256,7 @@ export class VideoStreamEngine {
         this.publishIfCurrent(generation, {
           diagnostic: {
             code: "capacity",
-            message: "Waiting for H.264 seek capacity",
+            message: "Waiting for video seek capacity",
             severity: "info",
           },
           phase: "waiting-for-capacity",
@@ -367,7 +367,7 @@ export class VideoStreamEngine {
   }
 
   private async decodeWithOneRecovery(
-    units: readonly H264AccessUnit[],
+    units: readonly EncodedVideoAccessUnit[],
     intent: VideoPlaybackIntent,
     generation: number,
     signal: AbortSignal,
@@ -388,7 +388,7 @@ export class VideoStreamEngine {
       this.publishIfCurrent(generation, {
         diagnostic: {
           code: "decode",
-          message: "Retrying H.264 decoder after a terminal failure",
+          message: "Retrying video decoder after a terminal failure",
           severity: "info",
         },
         phase: "seeking.locating",
@@ -406,11 +406,11 @@ export class VideoStreamEngine {
     cursorTimeNs: bigint,
     intent: VideoPlaybackIntent,
     signal: AbortSignal,
-  ): Promise<readonly H264AccessUnit[]> {
+  ): Promise<readonly EncodedVideoAccessUnit[]> {
     const reader = this.reader();
     if (!reader) {
       throw new VideoDependencyWaitError(
-        "Waiting for an H.264 access unit reader",
+        "Waiting for a video access unit reader",
       );
     }
     const startTimeNs = cursorTimeNs + 1n;
@@ -443,11 +443,11 @@ export class VideoStreamEngine {
             intent,
           ]);
     if (!units.some((unit) => unit.timeNs === intent.timeNs)) {
-      throw new VideoDependencyWaitError("Waiting for the H.264 seek target");
+      throw new VideoDependencyWaitError("Waiting for the video seek target");
     }
     if (units.length > MAX_H264_GOP_ACCESS_UNITS) {
       throw new VideoDependencyWaitError(
-        "H.264 dependency chain exceeds the bounded decode budget",
+        "Video dependency chain exceeds the bounded decode budget",
       );
     }
     return units;
@@ -456,7 +456,7 @@ export class VideoStreamEngine {
   /** Learns the smallest complete positive access-unit step for this stream. */
   private observeForwardCadence(
     previousTimeNs: bigint | null,
-    units: readonly H264AccessUnit[],
+    units: readonly EncodedVideoAccessUnit[],
   ): void {
     let previous = previousTimeNs;
     for (const unit of uniqueSortedAccessUnits(units)) {
@@ -477,7 +477,7 @@ export class VideoStreamEngine {
     intent: VideoPlaybackIntent,
     signal: AbortSignal,
     generation: number,
-  ): Promise<readonly H264AccessUnit[]> {
+  ): Promise<readonly EncodedVideoAccessUnit[]> {
     const runwayEndTimeNs =
       intent.frame.decodeTimestampNs === undefined
         ? intent.timeNs
@@ -496,19 +496,19 @@ export class VideoStreamEngine {
       const units = uniqueDecodeSortedAccessUnits([intent, ...read]);
       if (!units[0]?.frame.keyframe || units[0].timeNs !== intent.timeNs) {
         throw new VideoDependencyWaitError(
-          "Waiting for the H.264 runway keyframe",
+          "Waiting for the video runway keyframe",
         );
       }
       if (units.length > MAX_H264_GOP_ACCESS_UNITS) {
         throw new VideoDependencyWaitError(
-          "H.264 dependency chain exceeds the bounded decode budget",
+          "Video dependency chain exceeds the bounded decode budget",
         );
       }
       return units;
     }
     const reader = this.reader();
     if (!reader || reader.timelineStartTimeNs === null) {
-      throw new VideoDependencyWaitError("Waiting for an H.264 keyframe");
+      throw new VideoDependencyWaitError("Waiting for a video keyframe");
     }
     const knownKeyframe = this.gopIndex.keyframeTimeAtOrBefore(intent.timeNs);
     if (knownKeyframe !== null) {
@@ -554,7 +554,7 @@ export class VideoStreamEngine {
       endTimeNs = startTimeNs - 1n;
     }
     throw new VideoDependencyWaitError(
-      "No H.264 keyframe was found within the bounded lookback",
+      "No video keyframe was found within the bounded lookback",
     );
   }
 
@@ -562,13 +562,13 @@ export class VideoStreamEngine {
     keyframeTimeNs: bigint,
     runwayEndTimeNs: bigint,
     intent: VideoPlaybackIntent,
-  ): readonly H264AccessUnit[] {
+  ): readonly EncodedVideoAccessUnit[] {
     if (
       keyframeTimeNs < intent.timeNs &&
       !this.gopIndex.covers(keyframeTimeNs, intent.timeNs - 1n)
     ) {
       throw new VideoDependencyWaitError(
-        "Waiting for complete H.264 runway coverage",
+        "Waiting for complete video runway coverage",
       );
     }
     const keyframe = this.cache.get(keyframeTimeNs);
@@ -594,15 +594,15 @@ export class VideoStreamEngine {
           ]);
     if (!units[0]?.frame.keyframe || units[0].timeNs !== keyframeTimeNs) {
       throw new VideoDependencyWaitError(
-        "Waiting for the H.264 runway keyframe",
+        "Waiting for the video runway keyframe",
       );
     }
     if (!units.some((unit) => unit.timeNs === intent.timeNs)) {
-      throw new VideoDependencyWaitError("Waiting for the H.264 runway target");
+      throw new VideoDependencyWaitError("Waiting for the video runway target");
     }
     if (units.length > MAX_H264_GOP_ACCESS_UNITS) {
       throw new VideoDependencyWaitError(
-        "H.264 dependency chain exceeds the bounded decode budget",
+        "Video dependency chain exceeds the bounded decode budget",
       );
     }
     return units;
@@ -613,7 +613,7 @@ export class VideoStreamEngine {
     startTimeNs: bigint,
     endTimeNs: bigint,
     signal: AbortSignal,
-  ): Promise<readonly H264AccessUnit[]> {
+  ): Promise<readonly EncodedVideoAccessUnit[]> {
     const result = await reader.read({
       budget: {
         deadlineMs:
@@ -631,7 +631,7 @@ export class VideoStreamEngine {
     for (const unit of result.units) this.gopIndex.observe(unit);
     if (!result.complete) {
       throw new VideoDependencyWaitError(
-        `H.264 runway read stopped at ${result.stopReason ?? "its budget"}`,
+        `Video runway read stopped at ${result.stopReason ?? "its budget"}`,
       );
     }
     if (result.units.every((unit) => this.cache.has(unit.timeNs))) {
@@ -668,7 +668,7 @@ export class VideoStreamEngine {
     this.publish({
       diagnostic: {
         code: "decode",
-        message: diagnosticMessage(error, "H.264 decoder failed"),
+        message: diagnosticMessage(error, "Video decoder failed"),
         severity: "error",
       },
       generation,
@@ -696,20 +696,20 @@ export class VideoStreamEngine {
 }
 
 function runwayStartingAtLastKeyframe(
-  units: readonly H264AccessUnit[],
+  units: readonly EncodedVideoAccessUnit[],
   targetTimeNs: bigint,
-): readonly H264AccessUnit[] {
+): readonly EncodedVideoAccessUnit[] {
   let lastKeyframe = -1;
   units.forEach((unit, index) => {
     if (unit.timeNs <= targetTimeNs && unit.frame.keyframe)
       lastKeyframe = index;
   });
   if (lastKeyframe < 0) {
-    throw new VideoDependencyWaitError("Waiting for an H.264 keyframe");
+    throw new VideoDependencyWaitError("Waiting for a video keyframe");
   }
   const runway = units.slice(lastKeyframe);
   if (runway.at(-1)?.timeNs !== targetTimeNs) {
-    throw new VideoDependencyWaitError("Waiting for the H.264 seek target");
+    throw new VideoDependencyWaitError("Waiting for the video seek target");
   }
   return runway;
 }
@@ -738,9 +738,9 @@ function canPromoteActivePlaybackIntent(
   );
 }
 function uniqueDecodeSortedAccessUnits(
-  units: readonly H264AccessUnit[],
-): H264AccessUnit[] {
-  const byTime = new Map<bigint, H264AccessUnit>();
+  units: readonly EncodedVideoAccessUnit[],
+): EncodedVideoAccessUnit[] {
+  const byTime = new Map<bigint, EncodedVideoAccessUnit>();
   for (const unit of units) byTime.set(unit.timeNs, unit);
   return [...byTime.values()].sort((left, right) => {
     const leftTimeNs = left.frame.decodeTimestampNs ?? left.timeNs;
@@ -757,7 +757,9 @@ function uniqueDecodeSortedAccessUnits(
   });
 }
 
-function maxDecodeTimeNs(units: readonly H264AccessUnit[]): bigint | null {
+function maxDecodeTimeNs(
+  units: readonly EncodedVideoAccessUnit[],
+): bigint | null {
   let maximum: bigint | null = null;
   for (const unit of units) {
     const decodeTimeNs = unit.frame.decodeTimestampNs ?? unit.timeNs;

--- a/app/packages/multimodal/src/video/stream-engine.ts
+++ b/app/packages/multimodal/src/video/stream-engine.ts
@@ -254,11 +254,7 @@ export class VideoStreamEngine {
         });
       } else {
         this.publishIfCurrent(generation, {
-          diagnostic: {
-            code: "capacity",
-            message: "Waiting for video seek capacity",
-            severity: "info",
-          },
+          diagnostic: null,
           phase: "waiting-for-capacity",
         });
         releaseAdmission = await this.scheduler.acquire(

--- a/app/packages/multimodal/src/video/stream-engine.ts
+++ b/app/packages/multimodal/src/video/stream-engine.ts
@@ -22,6 +22,7 @@ import {
 
 const NS_PER_SECOND = 1_000_000_000n;
 const MAX_DIRECT_FORWARD_GAP_NS = 500_000_000n;
+const REORDERED_KEYFRAME_LOOKAHEAD_NS = 250_000_000n;
 export const MAX_H264_GOP_ACCESS_UNITS = 4_096;
 const VIDEO_SEEK_READ_POLICY = {
   initialLookbackNs: 15n * NS_PER_SECOND,
@@ -207,6 +208,10 @@ export class VideoStreamEngine {
               targetDecodeTimeNs - decodeCursorTimeNs > 0n &&
               targetDecodeTimeNs - decodeCursorTimeNs <=
                 this.nominalForwardStepNs + this.nominalForwardStepNs / 2n)));
+      const reorderedKeyframeNeedsRunway =
+        intent.frame.keyframe &&
+        targetDecodeTimeNs !== undefined &&
+        Boolean(this.reader());
       const directForward =
         cursorTimeNs !== null &&
         forwardGapNs !== null &&
@@ -216,9 +221,13 @@ export class VideoStreamEngine {
         !this.continuityUncertain;
       const directKeyframe =
         intent.frame.keyframe &&
+        !reorderedKeyframeNeedsRunway &&
         (cursorTimeNs === null || intent.timeNs > cursorTimeNs);
       const keyframeOnlyDiscontinuity =
-        intent.frame.keyframe && !directKeyframe && !directForward;
+        intent.frame.keyframe &&
+        !reorderedKeyframeNeedsRunway &&
+        !directKeyframe &&
+        !directForward;
 
       if (directKeyframe || directForward) {
         units = [intent];
@@ -250,7 +259,13 @@ export class VideoStreamEngine {
         );
         if (signal.aborted) throw new VideoIntentCancelledError();
 
-        if (cursorTimeNs !== null && intent.timeNs > cursorTimeNs) {
+        if (reorderedKeyframeNeedsRunway) {
+          units = await this.buildSeekRunway(intent, signal, generation);
+          this.observeForwardCadence(null, units);
+          if (this.decoder.configuredCodec !== null) {
+            this.decoder.resetForDiscontinuity();
+          }
+        } else if (cursorTimeNs !== null && intent.timeNs > cursorTimeNs) {
           this.publishIfCurrent(generation, {
             diagnostic: null,
             phase: "seeking.reading",
@@ -452,7 +467,30 @@ export class VideoStreamEngine {
     signal: AbortSignal,
     generation: number,
   ): Promise<readonly H264AccessUnit[]> {
-    if (intent.frame.keyframe) return [intent];
+    if (intent.frame.keyframe) {
+      if (intent.frame.decodeTimestampNs === undefined) return [intent];
+      const reader = this.reader();
+      if (!reader) return [intent];
+      this.publishIfCurrent(generation, { phase: "seeking.reading" });
+      const read = await this.readRange(
+        reader,
+        intent.timeNs,
+        intent.timeNs + REORDERED_KEYFRAME_LOOKAHEAD_NS,
+        signal,
+      );
+      const units = uniqueDecodeSortedAccessUnits([intent, ...read]);
+      if (!units[0]?.frame.keyframe || units[0].timeNs !== intent.timeNs) {
+        throw new VideoDependencyWaitError(
+          "Waiting for the H.264 runway keyframe",
+        );
+      }
+      if (units.length > MAX_H264_GOP_ACCESS_UNITS) {
+        throw new VideoDependencyWaitError(
+          "H.264 dependency chain exceeds the bounded decode budget",
+        );
+      }
+      return units;
+    }
     const reader = this.reader();
     if (!reader || reader.timelineStartTimeNs === null) {
       throw new VideoDependencyWaitError("Waiting for an H.264 keyframe");

--- a/app/packages/multimodal/src/video/stream-engine.ts
+++ b/app/packages/multimodal/src/video/stream-engine.ts
@@ -99,6 +99,9 @@ export class VideoStreamEngine {
           VIDEO_INTENT_PRIORITY_WEIGHT[this.requestedPriority]
       ) {
         this.requestedPriority = intent.priority;
+        if (this.activeIntent) {
+          this.activeIntent = strongerIntent(this.activeIntent, intent);
+        }
         if (this.activeController) {
           this.scheduler.promote(this.activeController.signal, intent.priority);
         }
@@ -199,11 +202,9 @@ export class VideoStreamEngine {
         forwardGapNs <=
           this.nominalForwardStepNs + this.nominalForwardStepNs / 2n;
       const targetDecodeTimeNs = intent.frame.decodeTimestampNs;
-      const decodeCursorTimeNs = this.decoder.cursorDecodeTimeNs;
       const decodeCadenceAllowsDirect =
         targetDecodeTimeNs === undefined ||
-        (decodeCursorTimeNs !== null &&
-          targetDecodeTimeNs <= decodeCursorTimeNs);
+        this.decoder.hasReadyPresentation(intent.timeNs);
       const reorderedKeyframeNeedsRunway =
         intent.frame.keyframe &&
         targetDecodeTimeNs !== undefined &&
@@ -224,7 +225,6 @@ export class VideoStreamEngine {
         !reorderedKeyframeNeedsRunway &&
         !directKeyframe &&
         !directForward;
-
       if (directKeyframe || directForward) {
         units = [intent];
         this.continuityUncertain = false;
@@ -419,7 +419,7 @@ export class VideoStreamEngine {
           ]).filter(
             (unit) =>
               (unit.frame.decodeTimestampNs ?? unit.timeNs) >
-              cursorDecodeTimeNs,
+                cursorDecodeTimeNs || unit.timeNs === intent.timeNs,
           )
         : uniqueSortedAccessUnits([
             ...this.cache.range(startTimeNs, intent.timeNs),

--- a/app/packages/multimodal/src/video/stream-engine.ts
+++ b/app/packages/multimodal/src/video/stream-engine.ts
@@ -22,7 +22,7 @@ import {
 
 const NS_PER_SECOND = 1_000_000_000n;
 const MAX_DIRECT_FORWARD_GAP_NS = 500_000_000n;
-const REORDERED_KEYFRAME_LOOKAHEAD_NS = 250_000_000n;
+const REORDERED_DECODE_LOOKAHEAD_NS = 250_000_000n;
 export const MAX_H264_GOP_ACCESS_UNITS = 4_096;
 const VIDEO_SEEK_READ_POLICY = {
   initialLookbackNs: 15n * NS_PER_SECOND,
@@ -203,11 +203,7 @@ export class VideoStreamEngine {
       const decodeCadenceAllowsDirect =
         targetDecodeTimeNs === undefined ||
         (decodeCursorTimeNs !== null &&
-          (targetDecodeTimeNs <= decodeCursorTimeNs ||
-            (this.nominalForwardStepNs !== null &&
-              targetDecodeTimeNs - decodeCursorTimeNs > 0n &&
-              targetDecodeTimeNs - decodeCursorTimeNs <=
-                this.nominalForwardStepNs + this.nominalForwardStepNs / 2n)));
+          targetDecodeTimeNs <= decodeCursorTimeNs);
       const reorderedKeyframeNeedsRunway =
         intent.frame.keyframe &&
         targetDecodeTimeNs !== undefined &&
@@ -402,29 +398,28 @@ export class VideoStreamEngine {
       );
     }
     const startTimeNs = cursorTimeNs + 1n;
-    const read = await this.readRange(
-      reader,
-      startTimeNs,
-      intent.timeNs,
-      signal,
-    );
     const targetDecodeTimeNs = intent.frame.decodeTimestampNs;
     const cursorDecodeTimeNs = this.decoder.cursorDecodeTimeNs;
+    const reorderedForwardRead =
+      targetDecodeTimeNs !== undefined && cursorDecodeTimeNs !== null;
+    const endTimeNs = reorderedForwardRead
+      ? intent.timeNs + REORDERED_DECODE_LOOKAHEAD_NS
+      : intent.timeNs;
+    const read = await this.readRange(reader, startTimeNs, endTimeNs, signal);
+    const decodeEndTimeNs = maxDecodeTimeNs([...read, intent]);
     const units =
-      targetDecodeTimeNs !== undefined && cursorDecodeTimeNs !== null
+      reorderedForwardRead && decodeEndTimeNs !== null
         ? uniqueDecodeSortedAccessUnits([
             ...this.cache.rangeByDecodeTime(
               cursorDecodeTimeNs + 1n,
-              targetDecodeTimeNs,
+              decodeEndTimeNs,
             ),
             ...read,
             intent,
           ]).filter(
             (unit) =>
               (unit.frame.decodeTimestampNs ?? unit.timeNs) >
-                cursorDecodeTimeNs &&
-              (unit.frame.decodeTimestampNs ?? unit.timeNs) <=
-                targetDecodeTimeNs,
+              cursorDecodeTimeNs,
           )
         : uniqueSortedAccessUnits([
             ...this.cache.range(startTimeNs, intent.timeNs),
@@ -475,7 +470,7 @@ export class VideoStreamEngine {
       const read = await this.readRange(
         reader,
         intent.timeNs,
-        intent.timeNs + REORDERED_KEYFRAME_LOOKAHEAD_NS,
+        intent.timeNs + REORDERED_DECODE_LOOKAHEAD_NS,
         signal,
       );
       const units = uniqueDecodeSortedAccessUnits([intent, ...read]);
@@ -719,4 +714,13 @@ function uniqueDecodeSortedAccessUnits(
             ? 1
             : 0;
   });
+}
+
+function maxDecodeTimeNs(units: readonly H264AccessUnit[]): bigint | null {
+  let maximum: bigint | null = null;
+  for (const unit of units) {
+    const decodeTimeNs = unit.frame.decodeTimestampNs ?? unit.timeNs;
+    if (maximum === null || decodeTimeNs > maximum) maximum = decodeTimeNs;
+  }
+  return maximum;
 }

--- a/app/packages/multimodal/src/video/stream-engine.ts
+++ b/app/packages/multimodal/src/video/stream-engine.ts
@@ -633,8 +633,7 @@ export class VideoStreamEngine {
   ): Promise<readonly EncodedVideoAccessUnit[]> {
     const result = await reader.read({
       budget: {
-        deadlineMs:
-          this.dependencies.nowMs() + VIDEO_SEEK_READ_POLICY.maxWallTimeMs,
+        maxWallTimeMs: VIDEO_SEEK_READ_POLICY.maxWallTimeMs,
         maxMessages: VIDEO_SEEK_READ_POLICY.maxMessages,
         maxObservedPayloadBytes: VIDEO_SEEK_READ_POLICY.maxObservedPayloadBytes,
       },
@@ -713,9 +712,13 @@ export class VideoStreamEngine {
 }
 
 function runwayStartingAtLastKeyframe(
-  units: readonly EncodedVideoAccessUnit[],
+  input: readonly EncodedVideoAccessUnit[],
   targetTimeNs: bigint,
 ): readonly EncodedVideoAccessUnit[] {
+  const reordered = input.some(
+    (unit) => unit.frame.decodeTimestampNs !== undefined,
+  );
+  const units = uniqueSortedAccessUnits(input);
   let lastKeyframe = -1;
   units.forEach((unit, index) => {
     if (unit.timeNs <= targetTimeNs && unit.frame.keyframe)
@@ -725,10 +728,10 @@ function runwayStartingAtLastKeyframe(
     throw new VideoDependencyWaitError("Waiting for a video keyframe");
   }
   const runway = units.slice(lastKeyframe);
-  if (runway.at(-1)?.timeNs !== targetTimeNs) {
+  if (!runway.some((unit) => unit.timeNs === targetTimeNs)) {
     throw new VideoDependencyWaitError("Waiting for the video seek target");
   }
-  return runway;
+  return reordered ? uniqueDecodeSortedAccessUnits(runway) : runway;
 }
 
 function strongerIntent(

--- a/app/packages/multimodal/src/video/types.test.ts
+++ b/app/packages/multimodal/src/video/types.test.ts
@@ -22,6 +22,10 @@ describe("video errors", () => {
       "VideoDecoderFailureError",
       "VideoSchedulerClosedError",
     ]);
+    for (const error of errors) {
+      error.name = "RenamedError";
+      expect(error.name).toBe("RenamedError");
+    }
   });
 });
 

--- a/app/packages/multimodal/src/video/types.test.ts
+++ b/app/packages/multimodal/src/video/types.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  VideoDecoderFailureError,
+  VideoDependencyWaitError,
+  VideoIntentCancelledError,
+  VideoSchedulerClosedError,
+} from "./types";
+
+describe("video errors", () => {
+  it("constructs typed errors when the host freezes the base Error name", () => {
+    const errors = withReadonlyErrorName(() => [
+      new VideoIntentCancelledError(),
+      new VideoDependencyWaitError("waiting"),
+      new VideoDecoderFailureError("failed"),
+      new VideoSchedulerClosedError(),
+    ]);
+
+    expect(errors.map((error) => error.name)).toEqual([
+      "VideoIntentCancelledError",
+      "VideoDependencyWaitError",
+      "VideoDecoderFailureError",
+      "VideoSchedulerClosedError",
+    ]);
+  });
+});
+
+function withReadonlyErrorName<T>(construct: () => T): T {
+  const descriptor = Object.getOwnPropertyDescriptor(Error.prototype, "name");
+  if (!descriptor) throw new Error("Error.prototype.name is unavailable");
+  Object.defineProperty(Error.prototype, "name", {
+    ...descriptor,
+    writable: false,
+  });
+  try {
+    return construct();
+  } finally {
+    Object.defineProperty(Error.prototype, "name", descriptor);
+  }
+}

--- a/app/packages/multimodal/src/video/types.ts
+++ b/app/packages/multimodal/src/video/types.ts
@@ -124,6 +124,8 @@ export interface VideoDecoderActor {
       readonly targetTimeNs: bigint;
     },
   ): Promise<VideoFrame>;
+  /** Whether an explicitly reordered presentation is decoded and ready now. */
+  hasReadyPresentation(timeNs: bigint): boolean;
   resetForDiscontinuity(): void;
 }
 

--- a/app/packages/multimodal/src/video/types.ts
+++ b/app/packages/multimodal/src/video/types.ts
@@ -145,27 +145,32 @@ export interface OwnedVideoPresentation extends VideoPresentation {
 export class VideoIntentCancelledError extends Error {
   constructor() {
     super("Video playback intent was superseded");
-    this.name = "VideoIntentCancelledError";
+    setErrorName(this, "VideoIntentCancelledError");
   }
 }
 
 export class VideoDependencyWaitError extends Error {
   constructor(message: string) {
     super(message);
-    this.name = "VideoDependencyWaitError";
+    setErrorName(this, "VideoDependencyWaitError");
   }
 }
 
 export class VideoDecoderFailureError extends Error {
   constructor(message: string, options?: ErrorOptions) {
     super(message, options);
-    this.name = "VideoDecoderFailureError";
+    setErrorName(this, "VideoDecoderFailureError");
   }
 }
 
 export class VideoSchedulerClosedError extends Error {
   constructor() {
     super("Video scheduler closed");
-    this.name = "VideoSchedulerClosedError";
+    setErrorName(this, "VideoSchedulerClosedError");
   }
+}
+
+/** Defines an own name even when the host freezes Error.prototype. */
+function setErrorName(error: Error, name: string): void {
+  Object.defineProperty(error, "name", { configurable: true, value: name });
 }

--- a/app/packages/multimodal/src/video/types.ts
+++ b/app/packages/multimodal/src/video/types.ts
@@ -30,6 +30,16 @@ export function isSharedEncodedVideoVisualization(
   );
 }
 
+/** Explains why an encoded frame rejected by shared playback is unavailable. */
+export function sharedVideoRejectionMessage(
+  frame: EncodedVideoVisualization,
+): string {
+  if (frame.codec === "h264" && frame.h264.hasFrame === false) {
+    return "H.264 video frame data is unavailable";
+  }
+  return `Video codec ${frame.codec} is unsupported`;
+}
+
 /** Presentation copy that no longer owns a WebCodecs decoder surface. */
 export interface VideoPresentationLease {
   readonly height: number;

--- a/app/packages/multimodal/src/video/types.ts
+++ b/app/packages/multimodal/src/video/types.ts
@@ -109,6 +109,8 @@ export interface VideoAccessUnitReader {
 /** Small interface that lets the engine use real or fake WebCodecs actors. */
 export interface VideoDecoderActor {
   readonly configuredCodec: string | null;
+  /** Furthest decode-order timestamp submitted in the current codec epoch. */
+  readonly cursorDecodeTimeNs: bigint | null;
   readonly cursorTimeNs: bigint | null;
   close(): void;
   /**

--- a/app/packages/multimodal/src/video/types.ts
+++ b/app/packages/multimodal/src/video/types.ts
@@ -1,9 +1,32 @@
-import type { EncodedH264VideoVisualization } from "../ir";
+import type {
+  EncodedAv1VideoVisualization,
+  EncodedH264VideoVisualization,
+  EncodedVideoVisualization,
+} from "../ir";
 
-/** One timestamped H.264 access unit owned by the video engine. */
-export interface H264AccessUnit {
-  readonly frame: EncodedH264VideoVisualization;
+/** One timestamped encoded-video access unit owned by the video engine. */
+export interface EncodedVideoAccessUnit {
+  readonly frame: EncodedVideoVisualization;
   readonly timeNs: bigint;
+}
+
+/** H.264 specialization retained for codec-specific producers and tests. */
+export interface H264AccessUnit extends EncodedVideoAccessUnit {
+  readonly frame: EncodedH264VideoVisualization;
+}
+
+/** Codec subset implemented by the shared synchronized WebCodecs pipeline. */
+export type SharedEncodedVideoVisualization =
+  | EncodedH264VideoVisualization
+  | EncodedAv1VideoVisualization;
+
+export function isSharedEncodedVideoVisualization(
+  frame: EncodedVideoVisualization,
+): frame is SharedEncodedVideoVisualization {
+  return (
+    frame.codec === "av1" ||
+    (frame.codec === "h264" && frame.h264.hasFrame !== false)
+  );
 }
 
 /** Presentation copy that no longer owns a WebCodecs decoder surface. */
@@ -78,7 +101,7 @@ export const VIDEO_INTENT_PRIORITY_WEIGHT: Readonly<
 };
 
 /** Latest-wins playback intent from one or more mounted consumers. */
-export interface VideoPlaybackIntent extends H264AccessUnit {
+export interface VideoPlaybackIntent extends EncodedVideoAccessUnit {
   readonly priority: VideoIntentPriority;
 }
 
@@ -91,7 +114,7 @@ export interface VideoReadBudget {
 export interface VideoAccessUnitReadResult {
   readonly complete: boolean;
   readonly stopReason?: string;
-  readonly units: readonly H264AccessUnit[];
+  readonly units: readonly EncodedVideoAccessUnit[];
 }
 
 /** Framework-independent read boundary supplied by SourcePlayback. */
@@ -118,7 +141,7 @@ export interface VideoDecoderActor {
    * rejection the actor closes every decoder output it produced.
    */
   decode(
-    units: readonly H264AccessUnit[],
+    units: readonly EncodedVideoAccessUnit[],
     options: {
       readonly signal: AbortSignal;
       readonly targetTimeNs: bigint;

--- a/app/packages/multimodal/src/video/types.ts
+++ b/app/packages/multimodal/src/video/types.ts
@@ -117,7 +117,7 @@ export interface VideoPlaybackIntent extends EncodedVideoAccessUnit {
 }
 
 export interface VideoReadBudget {
-  readonly deadlineMs: number;
+  readonly maxWallTimeMs: number;
   readonly maxMessages: number;
   readonly maxObservedPayloadBytes: number;
 }
@@ -208,5 +208,9 @@ export class VideoSchedulerClosedError extends Error {
 
 /** Defines an own name even when the host freezes Error.prototype. */
 function setErrorName(error: Error, name: string): void {
-  Object.defineProperty(error, "name", { configurable: true, value: name });
+  Object.defineProperty(error, "name", {
+    configurable: true,
+    value: name,
+    writable: true,
+  });
 }

--- a/app/packages/multimodal/src/video/types.ts
+++ b/app/packages/multimodal/src/video/types.ts
@@ -20,6 +20,7 @@ export type SharedEncodedVideoVisualization =
   | EncodedH264VideoVisualization
   | EncodedAv1VideoVisualization;
 
+/** Whether the shared synchronized decoder supports this encoded frame. */
 export function isSharedEncodedVideoVisualization(
   frame: EncodedVideoVisualization,
 ): frame is SharedEncodedVideoVisualization {

--- a/app/packages/multimodal/src/video/webcodecs-decoder.test.ts
+++ b/app/packages/multimodal/src/video/webcodecs-decoder.test.ts
@@ -10,19 +10,18 @@ import { VideoDecoderFailureError, VideoIntentCancelledError } from "./types";
 import {
   MAX_VIDEO_DECODE_IN_FLIGHT,
   VIDEO_DECODE_PROGRESS_TIMEOUT_MS,
-  WebCodecsH264Decoder,
   WebCodecsVideoDecoder,
   type WebCodecsDecoderEnvironment,
 } from "./webcodecs-decoder";
 
-describe("WebCodecsH264Decoder", () => {
+describe("WebCodecsVideoDecoder", () => {
   afterEach(() => {
     vi.useRealTimers();
   });
 
   it("decodes a slow 1,024-frame GOP with bounded submission and no reset storm", async () => {
     const harness = fakeWebCodecs();
-    const actor = new WebCodecsH264Decoder(harness.environment);
+    const actor = new WebCodecsVideoDecoder(harness.environment);
     const units = Array.from({ length: 1_025 }, (_, index) =>
       unit(index, index === 0),
     );
@@ -46,7 +45,7 @@ describe("WebCodecsH264Decoder", () => {
 
   it("reconfigures only at a keyframe configuration epoch", async () => {
     const harness = fakeWebCodecs();
-    const actor = new WebCodecsH264Decoder(harness.environment);
+    const actor = new WebCodecsVideoDecoder(harness.environment);
     await actor.decode([unit(0, true, "avc1.4D001F")], {
       signal: new AbortController().signal,
       targetTimeNs: 0n,
@@ -71,7 +70,7 @@ describe("WebCodecsH264Decoder", () => {
 
   it("splits one runway before an in-batch codec configuration boundary", async () => {
     const harness = fakeWebCodecs();
-    const actor = new WebCodecsH264Decoder(harness.environment);
+    const actor = new WebCodecsVideoDecoder(harness.environment);
     const output = await actor.decode(
       [unit(0, true, "avc1.4D001F"), unit(1), unit(2, true, "avc1.640028")],
       {
@@ -93,7 +92,7 @@ describe("WebCodecsH264Decoder", () => {
   it("treats supersession as cancellation without resetting the decoder", async () => {
     const outputGate = deferred<void>();
     const harness = fakeWebCodecs({ outputGate: outputGate.promise });
-    const actor = new WebCodecsH264Decoder(harness.environment);
+    const actor = new WebCodecsVideoDecoder(harness.environment);
     const controller = new AbortController();
     const decode = actor.decode(
       [
@@ -120,7 +119,7 @@ describe("WebCodecsH264Decoder", () => {
 
   it("uses unique submission timestamps without losing nanosecond cursor time", async () => {
     const harness = fakeWebCodecs();
-    const actor = new WebCodecsH264Decoder(harness.environment);
+    const actor = new WebCodecsVideoDecoder(harness.environment);
     const output = await actor.decode([unit(1_000, true), unit(1_999)], {
       signal: new AbortController().signal,
       targetTimeNs: 1_999n,
@@ -137,7 +136,7 @@ describe("WebCodecsH264Decoder", () => {
 
   it("submits B-frames in decode order while preserving presentation timestamps", async () => {
     const harness = fakeWebCodecs();
-    const actor = new WebCodecsH264Decoder(harness.environment);
+    const actor = new WebCodecsVideoDecoder(harness.environment);
     const output = await actor.decode(
       [
         unit(0, true, "avc1.4D001F", 0),
@@ -162,7 +161,7 @@ describe("WebCodecsH264Decoder", () => {
 
   it("reuses a decoded future B-frame without flushing or resubmitting it", async () => {
     const harness = fakeWebCodecs();
-    const actor = new WebCodecsH264Decoder(harness.environment);
+    const actor = new WebCodecsVideoDecoder(harness.environment);
     const keyframe = unit(0, true, "avc1.4D001F", 0);
     const futurePresentation = unit(2_000_000, false, undefined, 1_000_000);
     const target = unit(1_000_000, false, undefined, 2_000_000);
@@ -189,7 +188,7 @@ describe("WebCodecsH264Decoder", () => {
 
   it("feeds reorder successors before awaiting an opening keyframe", async () => {
     const harness = fakeWebCodecs({ holdOutputsUntilSubmissions: 2 });
-    const actor = new WebCodecsH264Decoder(harness.environment);
+    const actor = new WebCodecsVideoDecoder(harness.environment);
     const output = await actor.decode(
       [
         unit(0, true, "avc1.4D001F", 0),
@@ -212,7 +211,7 @@ describe("WebCodecsH264Decoder", () => {
     const harness = fakeWebCodecs({
       holdOutputsUntilSubmissions: retainedOutputs,
     });
-    const actor = new WebCodecsH264Decoder(harness.environment);
+    const actor = new WebCodecsVideoDecoder(harness.environment);
     const units = Array.from({ length: retainedOutputs }, (_, index) =>
       unit(index, index === 0, undefined, index),
     );
@@ -232,7 +231,7 @@ describe("WebCodecsH264Decoder", () => {
   it("fails stalled B-frame progress at the transaction boundary", async () => {
     vi.useFakeTimers();
     const harness = fakeWebCodecs({ shouldOutput: () => false });
-    const actor = new WebCodecsH264Decoder(harness.environment);
+    const actor = new WebCodecsVideoDecoder(harness.environment);
     const decode = actor.decode([unit(0, true, undefined, 0)], {
       signal: new AbortController().signal,
       targetTimeNs: 0n,
@@ -250,7 +249,7 @@ describe("WebCodecsH264Decoder", () => {
 
   it("rejects insecure contexts with a typed decoder failure", async () => {
     const harness = fakeWebCodecs({ isSecureContext: false });
-    const actor = new WebCodecsH264Decoder(harness.environment);
+    const actor = new WebCodecsVideoDecoder(harness.environment);
 
     await expect(
       actor.decode([unit(0, true)], {
@@ -264,7 +263,7 @@ describe("WebCodecsH264Decoder", () => {
 
   it("reports unsupported codec configuration with the codec string", async () => {
     const harness = fakeWebCodecs({ supported: false });
-    const actor = new WebCodecsH264Decoder(harness.environment);
+    const actor = new WebCodecsVideoDecoder(harness.environment);
 
     await expect(
       actor.decode([unit(0, true, "avc1.640028")], {
@@ -280,7 +279,7 @@ describe("WebCodecsH264Decoder", () => {
 
   it("still closes a decoder whose reset throws", async () => {
     const harness = fakeWebCodecs();
-    const actor = new WebCodecsH264Decoder(harness.environment);
+    const actor = new WebCodecsVideoDecoder(harness.environment);
     const output = await actor.decode([unit(0, true)], {
       signal: new AbortController().signal,
       targetTimeNs: 0n,
@@ -297,7 +296,7 @@ describe("WebCodecsH264Decoder", () => {
 
   it("closes explicit source ownership without an unnecessary reset", async () => {
     const harness = fakeWebCodecs();
-    const actor = new WebCodecsH264Decoder(harness.environment);
+    const actor = new WebCodecsVideoDecoder(harness.environment);
     const output = await actor.decode([unit(0, true)], {
       signal: new AbortController().signal,
       targetTimeNs: 0n,
@@ -314,7 +313,7 @@ describe("WebCodecsH264Decoder", () => {
     const harness = fakeWebCodecs({
       shouldOutput: (submission) => submission === 0,
     });
-    const actor = new WebCodecsH264Decoder(harness.environment);
+    const actor = new WebCodecsVideoDecoder(harness.environment);
     const decode = actor.decode([unit(0, true), unit(1)], {
       signal: new AbortController().signal,
       targetTimeNs: 0n,

--- a/app/packages/multimodal/src/video/webcodecs-decoder.test.ts
+++ b/app/packages/multimodal/src/video/webcodecs-decoder.test.ts
@@ -163,11 +163,13 @@ describe("WebCodecsH264Decoder", () => {
     const futurePresentation = unit(2_000_000, false, undefined, 1_000_000);
     const target = unit(1_000_000, false, undefined, 2_000_000);
 
+    expect(actor.hasReadyPresentation(futurePresentation.timeNs)).toBe(false);
     const first = await actor.decode([keyframe, futurePresentation, target], {
       signal: new AbortController().signal,
       targetTimeNs: target.timeNs,
     });
     first.close();
+    expect(actor.hasReadyPresentation(futurePresentation.timeNs)).toBe(true);
     const second = await actor.decode([futurePresentation], {
       signal: new AbortController().signal,
       targetTimeNs: futurePresentation.timeNs,
@@ -176,6 +178,7 @@ describe("WebCodecsH264Decoder", () => {
     expect(harness.instances[0].decode).toHaveBeenCalledTimes(3);
     expect(harness.instances[0].flush).not.toHaveBeenCalled();
     expect(actor.cursorTimeNs).toBe(futurePresentation.timeNs);
+    expect(actor.hasReadyPresentation(futurePresentation.timeNs)).toBe(false);
     second.close();
     actor.close();
   });

--- a/app/packages/multimodal/src/video/webcodecs-decoder.test.ts
+++ b/app/packages/multimodal/src/video/webcodecs-decoder.test.ts
@@ -180,6 +180,26 @@ describe("WebCodecsH264Decoder", () => {
     actor.close();
   });
 
+  it("feeds reorder successors before awaiting an opening keyframe", async () => {
+    const harness = fakeWebCodecs({ holdOutputsUntilSubmissions: 2 });
+    const actor = new WebCodecsH264Decoder(harness.environment);
+    const output = await actor.decode(
+      [
+        unit(0, true, "avc1.4D001F", 0),
+        unit(1_000_000, false, undefined, 1_000_000),
+      ],
+      {
+        signal: new AbortController().signal,
+        targetTimeNs: 0n,
+      },
+    );
+
+    expect(harness.instances[0].decode).toHaveBeenCalledTimes(2);
+    expect(harness.instances[0].flush).not.toHaveBeenCalled();
+    output.close();
+    actor.close();
+  });
+
   it("fails stalled B-frame progress at the transaction boundary", async () => {
     vi.useFakeTimers();
     const harness = fakeWebCodecs({ shouldOutput: () => false });
@@ -286,6 +306,7 @@ describe("WebCodecsH264Decoder", () => {
 
 function fakeWebCodecs(
   options: {
+    readonly holdOutputsUntilSubmissions?: number;
     readonly isSecureContext?: boolean;
     readonly outputGate?: Promise<void>;
     readonly shouldOutput?: (submission: number) => boolean;
@@ -297,6 +318,10 @@ function fakeWebCodecs(
   const frames: Array<{
     readonly closed: () => boolean;
     readonly frame: VideoFrame;
+  }> = [];
+  const queuedOutputs: Array<{
+    readonly decoder: FakeDecoder;
+    readonly chunk: FakeChunk;
   }> = [];
   const instances: Array<{
     readonly close: ReturnType<typeof vi.fn>;
@@ -332,22 +357,31 @@ function fakeWebCodecs(
       outstanding += 1;
       maximumOutstanding = Math.max(maximumOutstanding, outstanding);
       if (options.shouldOutput && !options.shouldOutput(submission)) return;
-      void Promise.resolve(options.outputGate).then(() => {
-        outstanding -= 1;
-        let closed = false;
-        const frame = {
-          close: () => {
-            closed = true;
-          },
-          codedHeight: 480,
-          codedWidth: 640,
-          displayHeight: 480,
-          displayWidth: 640,
-          timestamp: chunk.timestamp,
-        } as unknown as VideoFrame;
-        frames.push({ closed: () => closed, frame });
-        this.init.output(frame);
-      });
+      queuedOutputs.push({ chunk, decoder: this });
+      if (
+        this.decode.mock.calls.length <
+        (options.holdOutputsUntilSubmissions ?? 1)
+      ) {
+        return;
+      }
+      for (const queued of queuedOutputs.splice(0)) {
+        void Promise.resolve(options.outputGate).then(() => {
+          outstanding -= 1;
+          let closed = false;
+          const frame = {
+            close: () => {
+              closed = true;
+            },
+            codedHeight: 480,
+            codedWidth: 640,
+            displayHeight: 480,
+            displayWidth: 640,
+            timestamp: queued.chunk.timestamp,
+          } as unknown as VideoFrame;
+          frames.push({ closed: () => closed, frame });
+          queued.decoder.init.output(frame);
+        });
+      }
     });
     readonly flush = vi.fn(async () => {
       this.keyRequired = true;

--- a/app/packages/multimodal/src/video/webcodecs-decoder.test.ts
+++ b/app/packages/multimodal/src/video/webcodecs-decoder.test.ts
@@ -247,6 +247,37 @@ describe("WebCodecsVideoDecoder", () => {
     actor.close();
   });
 
+  it("rejects a saturated queue wait when decoder progress fails", async () => {
+    vi.useFakeTimers();
+    const harness = fakeWebCodecs({
+      holdDecodeQueue: true,
+      shouldOutput: () => false,
+    });
+    const actor = new WebCodecsVideoDecoder(harness.environment);
+    const decode = actor.decode(
+      Array.from({ length: MAX_VIDEO_DECODE_IN_FLIGHT + 1 }, (_, index) =>
+        unit(index, index === 0, undefined, index),
+      ),
+      {
+        signal: new AbortController().signal,
+        targetTimeNs: BigInt(MAX_VIDEO_DECODE_IN_FLIGHT),
+      },
+    );
+    const rejection = expect(decode).rejects.toBeInstanceOf(
+      VideoDecoderFailureError,
+    );
+
+    await vi.advanceTimersByTimeAsync(VIDEO_DECODE_PROGRESS_TIMEOUT_MS + 1);
+
+    await rejection;
+    expect(harness.instances[0].decode).toHaveBeenCalledTimes(
+      MAX_VIDEO_DECODE_IN_FLIGHT,
+    );
+    expect(harness.instances[0].reset).toHaveBeenCalledOnce();
+    expect(harness.instances[0].close).toHaveBeenCalledOnce();
+    actor.close();
+  });
+
   it("rejects insecure contexts with a typed decoder failure", async () => {
     const harness = fakeWebCodecs({ isSecureContext: false });
     const actor = new WebCodecsVideoDecoder(harness.environment);
@@ -362,6 +393,7 @@ describe("WebCodecsVideoDecoder AV1", () => {
 
 function fakeWebCodecs(
   options: {
+    readonly holdDecodeQueue?: boolean;
     readonly holdOutputsUntilSubmissions?: number;
     readonly isSecureContext?: boolean;
     readonly outputGate?: Promise<void>;
@@ -419,12 +451,14 @@ function fakeWebCodecs(
         maximumDecodeQueueSize,
         this.decodeQueueSize,
       );
-      queueMicrotask(() => {
-        this.decodeQueueSize -= 1;
-        for (const listener of this.dequeueListeners) {
-          listener.call(this, new Event("dequeue"));
-        }
-      });
+      if (!options.holdDecodeQueue) {
+        queueMicrotask(() => {
+          this.decodeQueueSize -= 1;
+          for (const listener of this.dequeueListeners) {
+            listener.call(this, new Event("dequeue"));
+          }
+        });
+      }
       outstanding += 1;
       maximumOutstanding = Math.max(maximumOutstanding, outstanding);
       if (options.shouldOutput && !options.shouldOutput(submission)) return;

--- a/app/packages/multimodal/src/video/webcodecs-decoder.test.ts
+++ b/app/packages/multimodal/src/video/webcodecs-decoder.test.ts
@@ -287,6 +287,7 @@ describe("WebCodecsVideoDecoder", () => {
     harness.releaseOutputs();
 
     const second = await secondDecode;
+    expect(harness.frames).toHaveLength(34);
     expect(harness.frames.slice(1, -1).every((frame) => frame.closed())).toBe(
       true,
     );

--- a/app/packages/multimodal/src/video/webcodecs-decoder.test.ts
+++ b/app/packages/multimodal/src/video/webcodecs-decoder.test.ts
@@ -203,6 +203,28 @@ describe("WebCodecsH264Decoder", () => {
     actor.close();
   });
 
+  it("keeps feeding a decoder that retains more outputs than the queue limit", async () => {
+    const retainedOutputs = MAX_VIDEO_DECODE_IN_FLIGHT + 4;
+    const harness = fakeWebCodecs({
+      holdOutputsUntilSubmissions: retainedOutputs,
+    });
+    const actor = new WebCodecsH264Decoder(harness.environment);
+    const units = Array.from({ length: retainedOutputs }, (_, index) =>
+      unit(index, index === 0, undefined, index),
+    );
+
+    const output = await actor.decode(units, {
+      signal: new AbortController().signal,
+      targetTimeNs: BigInt(retainedOutputs - 1),
+    });
+
+    expect(harness.instances[0].decode).toHaveBeenCalledTimes(retainedOutputs);
+    expect(harness.maxDecodeQueueSize()).toBe(MAX_VIDEO_DECODE_IN_FLIGHT);
+    expect(harness.instances[0].flush).not.toHaveBeenCalled();
+    output.close();
+    actor.close();
+  });
+
   it("fails stalled B-frame progress at the transaction boundary", async () => {
     vi.useFakeTimers();
     const harness = fakeWebCodecs({ shouldOutput: () => false });
@@ -318,6 +340,7 @@ function fakeWebCodecs(
 ) {
   let outstanding = 0;
   let maximumOutstanding = 0;
+  let maximumDecodeQueueSize = 0;
   const frames: Array<{
     readonly closed: () => boolean;
     readonly frame: VideoFrame;
@@ -351,12 +374,24 @@ function fakeWebCodecs(
     }));
     readonly close = vi.fn();
     readonly configure = vi.fn();
+    decodeQueueSize = 0;
     readonly decode = vi.fn((chunk: FakeChunk) => {
       if (this.keyRequired && chunk.type !== "key") {
         throw new DOMException("A key chunk is required", "DataError");
       }
       this.keyRequired = false;
       const submission = this.decode.mock.calls.length - 1;
+      this.decodeQueueSize += 1;
+      maximumDecodeQueueSize = Math.max(
+        maximumDecodeQueueSize,
+        this.decodeQueueSize,
+      );
+      queueMicrotask(() => {
+        this.decodeQueueSize -= 1;
+        for (const listener of this.dequeueListeners) {
+          listener.call(this, new Event("dequeue"));
+        }
+      });
       outstanding += 1;
       maximumOutstanding = Math.max(maximumOutstanding, outstanding);
       if (options.shouldOutput && !options.shouldOutput(submission)) return;
@@ -392,6 +427,19 @@ function fakeWebCodecs(
     readonly reset = vi.fn(() => {
       this.keyRequired = true;
     });
+    readonly addEventListener = vi.fn(
+      (type: string, listener: EventListenerOrEventListenerObject) => {
+        if (type !== "dequeue" || typeof listener !== "function") return;
+        this.dequeueListeners.add(listener);
+      },
+    );
+    readonly removeEventListener = vi.fn(
+      (type: string, listener: EventListenerOrEventListenerObject) => {
+        if (type !== "dequeue" || typeof listener !== "function") return;
+        this.dequeueListeners.delete(listener);
+      },
+    );
+    private readonly dequeueListeners = new Set<EventListener>();
     private keyRequired = true;
 
     constructor(
@@ -415,6 +463,7 @@ function fakeWebCodecs(
     environment,
     frames,
     instances,
+    maxDecodeQueueSize: () => maximumDecodeQueueSize,
     maxOutstanding: () => maximumOutstanding,
   };
 }

--- a/app/packages/multimodal/src/video/webcodecs-decoder.test.ts
+++ b/app/packages/multimodal/src/video/webcodecs-decoder.test.ts
@@ -1,13 +1,17 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import type { EncodedH264VideoVisualization } from "../ir";
+import type {
+  EncodedAv1VideoVisualization,
+  EncodedH264VideoVisualization,
+} from "../ir";
 import { VISUALIZATION_KIND } from "../ir";
-import type { H264AccessUnit } from "./types";
+import type { EncodedVideoAccessUnit, H264AccessUnit } from "./types";
 import { VideoDecoderFailureError, VideoIntentCancelledError } from "./types";
 import {
   MAX_VIDEO_DECODE_IN_FLIGHT,
   VIDEO_DECODE_PROGRESS_TIMEOUT_MS,
   WebCodecsH264Decoder,
+  WebCodecsVideoDecoder,
   type WebCodecsDecoderEnvironment,
 } from "./webcodecs-decoder";
 
@@ -329,6 +333,34 @@ describe("WebCodecsH264Decoder", () => {
   });
 });
 
+describe("WebCodecsVideoDecoder AV1", () => {
+  it("configures the container codec string and submits raw temporal-unit bytes", async () => {
+    const harness = fakeWebCodecs();
+    const actor = new WebCodecsVideoDecoder(harness.environment);
+    const accessUnit = av1Unit(0, true);
+
+    const output = await actor.decode([accessUnit], {
+      signal: new AbortController().signal,
+      targetTimeNs: 0n,
+    });
+
+    expect(harness.instances[0].configure).toHaveBeenCalledWith(
+      expect.objectContaining({ codec: "av01.0.00M.08" }),
+    );
+    expect(harness.instances[0].decode).toHaveBeenCalledOnce();
+    expect(
+      (
+        harness.instances[0].decode.mock.calls[0][0] as {
+          readonly data: Uint8Array;
+        }
+      ).data,
+    ).toEqual(accessUnit.frame.bytes);
+    expect(harness.instances[0].flush).not.toHaveBeenCalled();
+    output.close();
+    actor.close();
+  });
+});
+
 function fakeWebCodecs(
   options: {
     readonly holdOutputsUntilSubmissions?: number;
@@ -358,10 +390,12 @@ function fakeWebCodecs(
   }> = [];
 
   class FakeChunk {
+    readonly data: Uint8Array;
     readonly timestamp: number;
     readonly type: "key" | "delta";
 
     constructor(init: EncodedVideoChunkInit) {
+      this.data = Uint8Array.from(init.data as ArrayLike<number>);
       this.timestamp = init.timestamp;
       this.type = init.type;
     }
@@ -465,6 +499,22 @@ function fakeWebCodecs(
     instances,
     maxDecodeQueueSize: () => maximumDecodeQueueSize,
     maxOutstanding: () => maximumOutstanding,
+  };
+}
+
+function av1Unit(time: number, keyframe = false): EncodedVideoAccessUnit {
+  const timeNs = BigInt(time);
+  return {
+    frame: {
+      bytes: Uint8Array.of(0x12, 0x0a, keyframe ? 0x20 : 0x30),
+      codec: "av1",
+      decodeTimestampNs: timeNs,
+      format: "av01.0.00M.08",
+      keyframe,
+      kind: VISUALIZATION_KIND.ENCODED_VIDEO,
+      timestampNs: timeNs,
+    } satisfies EncodedAv1VideoVisualization,
+    timeNs,
   };
 }
 

--- a/app/packages/multimodal/src/video/webcodecs-decoder.test.ts
+++ b/app/packages/multimodal/src/video/webcodecs-decoder.test.ts
@@ -131,6 +131,50 @@ describe("WebCodecsH264Decoder", () => {
     actor.close();
   });
 
+  it("submits B-frames in decode order while preserving presentation timestamps", async () => {
+    const harness = fakeWebCodecs();
+    const actor = new WebCodecsH264Decoder(harness.environment);
+    const output = await actor.decode(
+      [
+        unit(0, true, "avc1.4D001F", 0),
+        unit(1_000_000, false, undefined, 2_000_000),
+        unit(2_000_000, false, undefined, 1_000_000),
+      ],
+      {
+        signal: new AbortController().signal,
+        targetTimeNs: 1_000_000n,
+      },
+    );
+
+    expect(
+      harness.instances[0].decode.mock.calls.map(
+        ([chunk]) => (chunk as { readonly timestamp: number }).timestamp,
+      ),
+    ).toEqual([0, 2_000, 1_000]);
+    expect(harness.instances[0].flush).toHaveBeenCalledOnce();
+    output.close();
+    actor.close();
+  });
+
+  it("fails stalled B-frame progress at the transaction boundary", async () => {
+    vi.useFakeTimers();
+    const harness = fakeWebCodecs({ shouldOutput: () => false });
+    const actor = new WebCodecsH264Decoder(harness.environment);
+    const decode = actor.decode([unit(0, true, undefined, 0)], {
+      signal: new AbortController().signal,
+      targetTimeNs: 0n,
+    });
+    const rejection = expect(decode).rejects.toBeInstanceOf(
+      VideoDecoderFailureError,
+    );
+
+    await vi.advanceTimersByTimeAsync(VIDEO_DECODE_PROGRESS_TIMEOUT_MS + 1);
+    await rejection;
+    expect(harness.instances[0].reset).toHaveBeenCalledOnce();
+    expect(harness.instances[0].close).toHaveBeenCalledOnce();
+    actor.close();
+  });
+
   it("rejects insecure contexts with a typed decoder failure", async () => {
     const harness = fakeWebCodecs({ isSecureContext: false });
     const actor = new WebCodecsH264Decoder(harness.environment);
@@ -234,6 +278,7 @@ function fakeWebCodecs(
     readonly close: ReturnType<typeof vi.fn>;
     readonly configure: ReturnType<typeof vi.fn>;
     readonly decode: ReturnType<typeof vi.fn>;
+    readonly flush: ReturnType<typeof vi.fn>;
     readonly reset: ReturnType<typeof vi.fn>;
   }> = [];
 
@@ -276,6 +321,7 @@ function fakeWebCodecs(
         this.init.output(frame);
       });
     });
+    readonly flush = vi.fn(async () => undefined);
     readonly reset = vi.fn();
 
     constructor(
@@ -307,12 +353,16 @@ function unit(
   time: number,
   keyframe = false,
   codecString = keyframe ? "avc1.4D001F" : undefined,
+  decodeTime?: number,
 ): H264AccessUnit {
   const timeNs = BigInt(time);
   return {
     frame: {
       bytes: Uint8Array.of(0, 0, 1, keyframe ? 0x65 : 0x41),
       codec: "h264",
+      ...(decodeTime === undefined
+        ? {}
+        : { decodeTimestampNs: BigInt(decodeTime) }),
       format: "h264",
       h264: {
         ...(codecString ? { codecString } : {}),

--- a/app/packages/multimodal/src/video/webcodecs-decoder.test.ts
+++ b/app/packages/multimodal/src/video/webcodecs-decoder.test.ts
@@ -151,8 +151,32 @@ describe("WebCodecsH264Decoder", () => {
         ([chunk]) => (chunk as { readonly timestamp: number }).timestamp,
       ),
     ).toEqual([0, 2_000, 1_000]);
-    expect(harness.instances[0].flush).toHaveBeenCalledOnce();
+    expect(harness.instances[0].flush).not.toHaveBeenCalled();
     output.close();
+    actor.close();
+  });
+
+  it("reuses a decoded future B-frame without flushing or resubmitting it", async () => {
+    const harness = fakeWebCodecs();
+    const actor = new WebCodecsH264Decoder(harness.environment);
+    const keyframe = unit(0, true, "avc1.4D001F", 0);
+    const futurePresentation = unit(2_000_000, false, undefined, 1_000_000);
+    const target = unit(1_000_000, false, undefined, 2_000_000);
+
+    const first = await actor.decode([keyframe, futurePresentation, target], {
+      signal: new AbortController().signal,
+      targetTimeNs: target.timeNs,
+    });
+    first.close();
+    const second = await actor.decode([futurePresentation], {
+      signal: new AbortController().signal,
+      targetTimeNs: futurePresentation.timeNs,
+    });
+
+    expect(harness.instances[0].decode).toHaveBeenCalledTimes(3);
+    expect(harness.instances[0].flush).not.toHaveBeenCalled();
+    expect(actor.cursorTimeNs).toBe(futurePresentation.timeNs);
+    second.close();
     actor.close();
   });
 
@@ -300,6 +324,10 @@ function fakeWebCodecs(
     readonly close = vi.fn();
     readonly configure = vi.fn();
     readonly decode = vi.fn((chunk: FakeChunk) => {
+      if (this.keyRequired && chunk.type !== "key") {
+        throw new DOMException("A key chunk is required", "DataError");
+      }
+      this.keyRequired = false;
       const submission = this.decode.mock.calls.length - 1;
       outstanding += 1;
       maximumOutstanding = Math.max(maximumOutstanding, outstanding);
@@ -321,8 +349,13 @@ function fakeWebCodecs(
         this.init.output(frame);
       });
     });
-    readonly flush = vi.fn(async () => undefined);
-    readonly reset = vi.fn();
+    readonly flush = vi.fn(async () => {
+      this.keyRequired = true;
+    });
+    readonly reset = vi.fn(() => {
+      this.keyRequired = true;
+    });
+    private keyRequired = true;
 
     constructor(
       private readonly init: {

--- a/app/packages/multimodal/src/video/webcodecs-decoder.test.ts
+++ b/app/packages/multimodal/src/video/webcodecs-decoder.test.ts
@@ -228,6 +228,73 @@ describe("WebCodecsVideoDecoder", () => {
     actor.close();
   });
 
+  it("does not trim the reordered output awaited by the active transaction", async () => {
+    const harness = fakeWebCodecs({ deferOutputs: true });
+    const actor = new WebCodecsVideoDecoder(harness.environment);
+    const units = Array.from({ length: 34 }, (_, index) =>
+      unit(index, index === 0, undefined, index),
+    );
+    const decode = actor.decode(units, {
+      signal: new AbortController().signal,
+      targetTimeNs: 0n,
+    });
+
+    await vi.waitFor(() =>
+      expect(harness.instances[0].decode).toHaveBeenCalledTimes(32),
+    );
+    harness.releaseOutputs();
+    await vi.waitFor(() =>
+      expect(harness.instances[0].decode).toHaveBeenCalledTimes(34),
+    );
+    harness.releaseOutputs();
+
+    const output = await decode;
+    expect(output).toBe(harness.frames[0].frame);
+    expect(harness.frames[0].closed()).toBe(false);
+    output.close();
+    actor.close();
+  });
+
+  it("waits on discarded pending outputs before extending the decode window", async () => {
+    const harness = fakeWebCodecs({ deferOutputs: true });
+    const actor = new WebCodecsVideoDecoder(harness.environment);
+    const initial = Array.from({ length: 33 }, (_, index) =>
+      unit(index, index === 0, undefined, index),
+    );
+    const firstDecode = actor.decode(initial, {
+      signal: new AbortController().signal,
+      targetTimeNs: 0n,
+    });
+
+    await vi.waitFor(() =>
+      expect(harness.instances[0].decode).toHaveBeenCalledTimes(32),
+    );
+    harness.releaseOutputs(1);
+    await vi.waitFor(() =>
+      expect(harness.instances[0].decode).toHaveBeenCalledTimes(33),
+    );
+    const first = await firstDecode;
+
+    const next = unit(1_000, true, "avc1.4D001F", 1_000);
+    const secondDecode = actor.decode([next], {
+      signal: new AbortController().signal,
+      targetTimeNs: next.timeNs,
+    });
+    harness.releaseOutputs();
+    await vi.waitFor(() =>
+      expect(harness.instances[0].decode).toHaveBeenCalledTimes(34),
+    );
+    harness.releaseOutputs();
+
+    const second = await secondDecode;
+    expect(harness.frames.slice(1, -1).every((frame) => frame.closed())).toBe(
+      true,
+    );
+    first.close();
+    second.close();
+    actor.close();
+  });
+
   it("fails stalled B-frame progress at the transaction boundary", async () => {
     vi.useFakeTimers();
     const harness = fakeWebCodecs({ shouldOutput: () => false });
@@ -393,6 +460,7 @@ describe("WebCodecsVideoDecoder AV1", () => {
 
 function fakeWebCodecs(
   options: {
+    readonly deferOutputs?: boolean;
     readonly holdDecodeQueue?: boolean;
     readonly holdOutputsUntilSubmissions?: number;
     readonly isSecureContext?: boolean;
@@ -463,30 +531,14 @@ function fakeWebCodecs(
       maximumOutstanding = Math.max(maximumOutstanding, outstanding);
       if (options.shouldOutput && !options.shouldOutput(submission)) return;
       queuedOutputs.push({ chunk, decoder: this });
+      if (options.deferOutputs) return;
       if (
         this.decode.mock.calls.length <
         (options.holdOutputsUntilSubmissions ?? 1)
       ) {
         return;
       }
-      for (const queued of queuedOutputs.splice(0)) {
-        void Promise.resolve(options.outputGate).then(() => {
-          outstanding -= 1;
-          let closed = false;
-          const frame = {
-            close: () => {
-              closed = true;
-            },
-            codedHeight: 480,
-            codedWidth: 640,
-            displayHeight: 480,
-            displayWidth: 640,
-            timestamp: queued.chunk.timestamp,
-          } as unknown as VideoFrame;
-          frames.push({ closed: () => closed, frame });
-          queued.decoder.init.output(frame);
-        });
-      }
+      releaseOutputs();
     });
     readonly flush = vi.fn(async () => {
       this.keyRequired = true;
@@ -517,7 +569,32 @@ function fakeWebCodecs(
     ) {
       instances.push(this);
     }
+
+    emitOutput(chunk: FakeChunk): void {
+      void Promise.resolve(options.outputGate).then(() => {
+        outstanding -= 1;
+        let closed = false;
+        const frame = {
+          close: () => {
+            closed = true;
+          },
+          codedHeight: 480,
+          codedWidth: 640,
+          displayHeight: 480,
+          displayWidth: 640,
+          timestamp: chunk.timestamp,
+        } as unknown as VideoFrame;
+        frames.push({ closed: () => closed, frame });
+        this.init.output(frame);
+      });
+    }
   }
+
+  const releaseOutputs = (count = queuedOutputs.length) => {
+    for (const queued of queuedOutputs.splice(0, count)) {
+      queued.decoder.emitOutput(queued.chunk);
+    }
+  };
 
   const environment: WebCodecsDecoderEnvironment = {
     EncodedVideoChunk: FakeChunk as unknown as typeof EncodedVideoChunk,
@@ -532,6 +609,7 @@ function fakeWebCodecs(
     instances,
     maxDecodeQueueSize: () => maximumDecodeQueueSize,
     maxOutstanding: () => maximumOutstanding,
+    releaseOutputs,
   };
 }
 

--- a/app/packages/multimodal/src/video/webcodecs-decoder.ts
+++ b/app/packages/multimodal/src/video/webcodecs-decoder.ts
@@ -1,7 +1,9 @@
 import { h264AccessUnitWithParameterSets } from "../codecs/h264-annexb";
 import { toError } from "../utils/errors";
-import type { H264AccessUnit, VideoDecoderActor } from "./types";
+import type { EncodedVideoVisualization } from "../ir";
+import type { EncodedVideoAccessUnit, VideoDecoderActor } from "./types";
 import {
+  isSharedEncodedVideoVisualization,
   VideoDecoderFailureError,
   VideoDependencyWaitError,
   VideoIntentCancelledError,
@@ -32,7 +34,7 @@ export interface WebCodecsDecoderEnvironment {
 }
 
 /** One serialized WebCodecs actor. It never flushes per frame. */
-export class WebCodecsH264Decoder implements VideoDecoderActor {
+export class WebCodecsVideoDecoder implements VideoDecoderActor {
   private active = false;
   private closed = false;
   private codecString: string | null = null;
@@ -71,7 +73,7 @@ export class WebCodecsH264Decoder implements VideoDecoderActor {
   }
 
   async decode(
-    units: readonly H264AccessUnit[],
+    units: readonly EncodedVideoAccessUnit[],
     {
       signal,
       targetTimeNs,
@@ -82,14 +84,12 @@ export class WebCodecsH264Decoder implements VideoDecoderActor {
       throw new Error("Concurrent video decoder transaction");
     }
     if (signal.aborted) throw new VideoIntentCancelledError();
-    const decodable = units
-      .filter((unit) => unit.frame.h264.hasFrame !== false)
-      .sort(compareDecodeOrder);
+    const decodable = units.filter(isDecodableUnit).sort(compareDecodeOrder);
     if (decodable.length === 0) {
-      throw new VideoDependencyWaitError("Waiting for an H.264 access unit");
+      throw new VideoDependencyWaitError("Waiting for a video access unit");
     }
     if (!this.decoder && !decodable[0].frame.keyframe) {
-      throw new VideoDependencyWaitError("Waiting for an H.264 keyframe");
+      throw new VideoDependencyWaitError("Waiting for a video keyframe");
     }
 
     this.active = true;
@@ -120,7 +120,7 @@ export class WebCodecsH264Decoder implements VideoDecoderActor {
       }
       if (!target) {
         throw new VideoDecoderFailureError(
-          "H.264 target produced no decoder output",
+          `${codecDisplayName(decodable[0].frame)} target produced no decoder output`,
         );
       }
       return target;
@@ -134,7 +134,7 @@ export class WebCodecsH264Decoder implements VideoDecoderActor {
 
   /** Keeps a bounded, persistent submission window for MP4 decode-order samples. */
   private async decodeReordered(
-    units: readonly H264AccessUnit[],
+    units: readonly EncodedVideoAccessUnit[],
     targetTimeNs: bigint,
     signal: AbortSignal,
   ): Promise<VideoFrame> {
@@ -148,7 +148,7 @@ export class WebCodecsH264Decoder implements VideoDecoderActor {
         timer = null;
         this.failDecoder(
           new VideoDecoderFailureError(
-            "Timed out waiting for H.264 decoder progress",
+            `Timed out waiting for ${codecDisplayName(units[0].frame)} decoder progress`,
           ),
         );
       }, VIDEO_DECODE_PROGRESS_TIMEOUT_MS);
@@ -166,7 +166,7 @@ export class WebCodecsH264Decoder implements VideoDecoderActor {
           decodeTimeNs <= this.lastSubmittedDecodeTimeNs
         ) {
           throw new VideoDecoderFailureError(
-            "H.264 dependency arrived behind the decode-order cursor",
+            `${codecDisplayName(unit.frame)} dependency arrived behind the decode-order cursor`,
           );
         }
         // A reordered decoder may consume queued chunks without emitting their
@@ -191,7 +191,7 @@ export class WebCodecsH264Decoder implements VideoDecoderActor {
       const target = this.reorderedOutputs.get(targetTimeNs);
       if (!target) {
         throw new VideoDecoderFailureError(
-          "H.264 target produced no decoder output",
+          `${codecDisplayName(units[0].frame)} target produced no decoder output`,
         );
       }
       const frame = await abortableDecoderOutput(target.promise, signal);
@@ -207,13 +207,16 @@ export class WebCodecsH264Decoder implements VideoDecoderActor {
   }
 
   /** Never submit access units from two codec epochs to one decoder batch. */
-  private batchEnd(units: readonly H264AccessUnit[], start: number): number {
+  private batchEnd(
+    units: readonly EncodedVideoAccessUnit[],
+    start: number,
+  ): number {
     const limit = Math.min(units.length, start + MAX_VIDEO_DECODE_IN_FLIGHT);
     const batchCodec =
-      units[start].frame.h264.codecString ?? this.codecString ?? undefined;
+      frameCodecString(units[start].frame) ?? this.codecString ?? undefined;
     for (let index = start + 1; index < limit; index += 1) {
       const unit = units[index];
-      const codec = unit.frame.h264.codecString;
+      const codec = frameCodecString(unit.frame);
       if (unit.frame.keyframe && codec && batchCodec && codec !== batchCodec) {
         return index;
       }
@@ -227,7 +230,7 @@ export class WebCodecsH264Decoder implements VideoDecoderActor {
     this.sps = undefined;
     this.pps = undefined;
     this.disposeDecoder(
-      new VideoDecoderFailureError("H.264 decoder discontinuity"),
+      new VideoDecoderFailureError("Video decoder discontinuity"),
     );
   }
 
@@ -240,7 +243,7 @@ export class WebCodecsH264Decoder implements VideoDecoderActor {
   }
 
   private async decodeBatch(
-    units: readonly H264AccessUnit[],
+    units: readonly EncodedVideoAccessUnit[],
     targetTimeNs: bigint,
   ): Promise<readonly (VideoFrame | undefined)[]> {
     const first = units[0];
@@ -255,7 +258,7 @@ export class WebCodecsH264Decoder implements VideoDecoderActor {
         timer = null;
         this.failDecoder(
           new VideoDecoderFailureError(
-            "Timed out waiting for H.264 decoder progress",
+            `Timed out waiting for ${codecDisplayName(units[0].frame)} decoder progress`,
           ),
         );
       }, VIDEO_DECODE_PROGRESS_TIMEOUT_MS);
@@ -288,26 +291,26 @@ export class WebCodecsH264Decoder implements VideoDecoderActor {
     }
   }
 
-  private async ensureDecoder(unit: H264AccessUnit): Promise<void> {
+  private async ensureDecoder(unit: EncodedVideoAccessUnit): Promise<void> {
     if (this.failed) {
       const failure = this.failed;
       this.failed = null;
       throw failure;
     }
-    const nextCodec = unit.frame.h264.codecString ?? this.codecString;
+    const nextCodec = frameCodecString(unit.frame) ?? this.codecString;
     if (!nextCodec) {
       throw new VideoDependencyWaitError(
-        "Waiting for an H.264 keyframe with SPS/PPS",
+        `Waiting for a ${codecDisplayName(unit.frame)} keyframe with decoder configuration`,
       );
     }
     if (unit.frame.keyframe && this.decoder && this.codecString !== nextCodec) {
       this.disposeDecoder(
-        new VideoDecoderFailureError("H.264 codec configuration changed"),
+        new VideoDecoderFailureError("Video codec configuration changed"),
       );
     }
     if (this.decoder) return;
     if (!unit.frame.keyframe) {
-      throw new VideoDependencyWaitError("Waiting for an H.264 keyframe");
+      throw new VideoDependencyWaitError("Waiting for a video keyframe");
     }
     if (!this.environment.isSecureContext) {
       throw new VideoDecoderFailureError(
@@ -323,7 +326,7 @@ export class WebCodecsH264Decoder implements VideoDecoderActor {
       await this.environment.VideoDecoder.isConfigSupported(config);
     if (!support.supported) {
       throw new VideoDecoderFailureError(
-        `H.264 codec '${nextCodec}' is unsupported`,
+        `${codecDisplayName(unit.frame)} codec '${nextCodec}' is unsupported`,
       );
     }
     if (this.closed) throw new Error("Video decoder closed");
@@ -337,7 +340,7 @@ export class WebCodecsH264Decoder implements VideoDecoderActor {
       this.decoder.configure(config);
     } catch (error) {
       const failure = new VideoDecoderFailureError(
-        "Failed to configure the H.264 decoder",
+        `Failed to configure the ${codecDisplayName(unit.frame)} decoder`,
         { cause: error },
       );
       this.failDecoder(failure);
@@ -347,16 +350,10 @@ export class WebCodecsH264Decoder implements VideoDecoderActor {
 
   private submit(
     decoder: VideoDecoder,
-    unit: H264AccessUnit,
+    unit: EncodedVideoAccessUnit,
     onProgress: () => void,
   ): Promise<VideoFrame> {
-    if (unit.frame.h264.sps) this.sps = unit.frame.h264.sps;
-    if (unit.frame.h264.pps) this.pps = unit.frame.h264.pps;
-    const data = h264AccessUnitWithParameterSets({
-      bytes: unit.frame.bytes,
-      pps: unit.frame.h264.pps ? undefined : this.pps,
-      sps: unit.frame.h264.sps ? undefined : this.sps,
-    });
+    const data = this.chunkData(unit);
     // Preserve source PTS for browser-level observability. LeRobot MP4 units
     // carry an explicit DTS and may be submitted in non-monotonic PTS order
     // when B-frames are present. Legacy streams retain monotonic nudging.
@@ -391,7 +388,7 @@ export class WebCodecsH264Decoder implements VideoDecoderActor {
         const index = this.pending.indexOf(pending);
         if (index >= 0) this.pending.splice(index, 1);
         const failure = new VideoDecoderFailureError(
-          "Failed to submit an H.264 access unit",
+          `Failed to submit a ${codecDisplayName(unit.frame)} access unit`,
           { cause: error },
         );
         this.failDecoder(failure);
@@ -402,7 +399,7 @@ export class WebCodecsH264Decoder implements VideoDecoderActor {
 
   private submitReordered(
     decoder: VideoDecoder,
-    unit: H264AccessUnit,
+    unit: EncodedVideoAccessUnit,
     onProgress: () => void,
   ): Promise<VideoFrame> {
     const existing = this.reorderedOutputs.get(unit.timeNs);
@@ -434,7 +431,7 @@ export class WebCodecsH264Decoder implements VideoDecoderActor {
       .map((output) => output.promise);
     if (pending.length === 0) {
       throw new VideoDecoderFailureError(
-        "H.264 decoder submission window made no progress",
+        "Video decoder submission window made no progress",
       );
     }
     await abortableDecoderOutput(Promise.race(pending), signal);
@@ -489,7 +486,7 @@ export class WebCodecsH264Decoder implements VideoDecoderActor {
     const failure =
       error instanceof VideoDecoderFailureError
         ? error
-        : new VideoDecoderFailureError("H.264 decoder failed", {
+        : new VideoDecoderFailureError("Video decoder failed", {
             cause: error,
           });
     this.failed = failure;
@@ -527,9 +524,26 @@ export class WebCodecsH264Decoder implements VideoDecoderActor {
     this.lastOutputTimeNs = null;
     this.lastSubmissionTimestampUs = null;
   }
+
+  private chunkData(unit: EncodedVideoAccessUnit): Uint8Array {
+    if (unit.frame.codec !== "h264") return unit.frame.bytes;
+    if (unit.frame.h264.sps) this.sps = unit.frame.h264.sps;
+    if (unit.frame.h264.pps) this.pps = unit.frame.h264.pps;
+    return h264AccessUnitWithParameterSets({
+      bytes: unit.frame.bytes,
+      pps: unit.frame.h264.pps ? undefined : this.pps,
+      sps: unit.frame.h264.sps ? undefined : this.sps,
+    });
+  }
 }
 
-function compareDecodeOrder(left: H264AccessUnit, right: H264AccessUnit) {
+/** Compatibility export for existing H.264-specific callers. */
+export { WebCodecsVideoDecoder as WebCodecsH264Decoder };
+
+function compareDecodeOrder(
+  left: EncodedVideoAccessUnit,
+  right: EncodedVideoAccessUnit,
+) {
   const leftTime = left.frame.decodeTimestampNs ?? left.timeNs;
   const rightTime = right.frame.decodeTimestampNs ?? right.timeNs;
   return leftTime < rightTime ? -1 : leftTime > rightTime ? 1 : 0;
@@ -606,7 +620,7 @@ function browserWebCodecsEnvironment(): WebCodecsDecoderEnvironment {
     typeof EncodedVideoChunk === "undefined"
   ) {
     throw new VideoDecoderFailureError(
-      "WebCodecs H.264 decoding is unavailable",
+      "WebCodecs video decoding is unavailable",
     );
   }
   return {
@@ -616,4 +630,20 @@ function browserWebCodecsEnvironment(): WebCodecsDecoderEnvironment {
     isSecureContext: globalThis.isSecureContext !== false,
     setTimeout: globalThis.setTimeout.bind(globalThis),
   };
+}
+
+function isDecodableUnit(unit: EncodedVideoAccessUnit): boolean {
+  return isSharedEncodedVideoVisualization(unit.frame);
+}
+
+function frameCodecString(frame: EncodedVideoVisualization): string | null {
+  if (frame.codec === "h264") return frame.h264.codecString ?? null;
+  if (frame.codec === "av1") return frame.format;
+  return null;
+}
+
+function codecDisplayName(frame: EncodedVideoVisualization): string {
+  if (frame.codec === "h264") return "H.264";
+  if (frame.codec === "av1") return "AV1";
+  return frame.codec.toUpperCase();
 }

--- a/app/packages/multimodal/src/video/webcodecs-decoder.ts
+++ b/app/packages/multimodal/src/video/webcodecs-decoder.ts
@@ -66,6 +66,10 @@ export class WebCodecsH264Decoder implements VideoDecoderActor {
     return this.lastSubmittedDecodeTimeNs;
   }
 
+  hasReadyPresentation(timeNs: bigint): boolean {
+    return this.reorderedOutputs.get(timeNs)?.frame != null;
+  }
+
   async decode(
     units: readonly H264AccessUnit[],
     {

--- a/app/packages/multimodal/src/video/webcodecs-decoder.ts
+++ b/app/packages/multimodal/src/video/webcodecs-decoder.ts
@@ -169,8 +169,22 @@ export class WebCodecsH264Decoder implements VideoDecoderActor {
             "H.264 dependency arrived behind the decode-order cursor",
           );
         }
-        while (this.pending.length >= MAX_VIDEO_DECODE_IN_FLIGHT) {
-          await this.waitForReorderedProgress(signal);
+        // A reordered decoder may consume queued chunks without emitting their
+        // frames yet. Bound its input queue separately from the wider retained
+        // output window so B-frame delay cannot deadlock submission.
+        while (
+          decoder.decodeQueueSize >= MAX_VIDEO_DECODE_IN_FLIGHT ||
+          this.pending.length >= MAX_REORDERED_VIDEO_OUTPUTS
+        ) {
+          if (decoder.decodeQueueSize >= MAX_VIDEO_DECODE_IN_FLIGHT) {
+            await waitForDecoderQueueProgress(
+              decoder,
+              MAX_VIDEO_DECODE_IN_FLIGHT,
+              signal,
+            );
+          } else {
+            await this.waitForReorderedProgress(signal);
+          }
         }
         this.submitReordered(decoder, unit, armProgressTimer);
       }
@@ -554,6 +568,35 @@ function abortableDecoderOutput<T>(
         reject(error);
       },
     );
+  });
+}
+
+function waitForDecoderQueueProgress(
+  decoder: VideoDecoder,
+  limit: number,
+  signal: AbortSignal,
+): Promise<void> {
+  if (signal.aborted) return Promise.reject(new VideoIntentCancelledError());
+  if (decoder.decodeQueueSize < limit) return Promise.resolve();
+  return new Promise<void>((resolve, reject) => {
+    const cleanup = () => {
+      decoder.removeEventListener("dequeue", onDequeue);
+      signal.removeEventListener("abort", onAbort);
+    };
+    const onAbort = () => {
+      cleanup();
+      reject(new VideoIntentCancelledError());
+    };
+    const onDequeue = () => {
+      if (decoder.decodeQueueSize >= limit) return;
+      cleanup();
+      resolve();
+    };
+    decoder.addEventListener("dequeue", onDequeue);
+    signal.addEventListener("abort", onAbort, { once: true });
+    // The queue can drain between the caller's check and listener install.
+    if (signal.aborted) onAbort();
+    else onDequeue();
   });
 }
 

--- a/app/packages/multimodal/src/video/webcodecs-decoder.ts
+++ b/app/packages/multimodal/src/video/webcodecs-decoder.ts
@@ -66,9 +66,9 @@ export class WebCodecsH264Decoder implements VideoDecoderActor {
       throw new Error("Concurrent video decoder transaction");
     }
     if (signal.aborted) throw new VideoIntentCancelledError();
-    const decodable = units.filter(
-      (unit) => unit.frame.h264.hasFrame !== false,
-    );
+    const decodable = units
+      .filter((unit) => unit.frame.h264.hasFrame !== false)
+      .sort(compareDecodeOrder);
     if (decodable.length === 0) {
       throw new VideoDependencyWaitError("Waiting for an H.264 access unit");
     }
@@ -79,6 +79,11 @@ export class WebCodecsH264Decoder implements VideoDecoderActor {
     this.active = true;
     let target: VideoFrame | undefined;
     try {
+      if (
+        decodable.some((unit) => unit.frame.decodeTimestampNs !== undefined)
+      ) {
+        return await this.decodeReordered(decodable, targetTimeNs, signal);
+      }
       for (let start = 0; start < decodable.length; ) {
         if (signal.aborted) throw new VideoIntentCancelledError();
         const end = this.batchEnd(decodable, start);
@@ -108,6 +113,82 @@ export class WebCodecsH264Decoder implements VideoDecoderActor {
       throw error;
     } finally {
       this.active = false;
+    }
+  }
+
+  /**
+   * Keeps a bounded sliding submission window for MP4 decode-order samples.
+   * B-frame decoders may retain a few inputs until later references arrive,
+   * so waiting for every fixed batch would deadlock before those references
+   * can be submitted. One flush at the transaction boundary drains the tail.
+   */
+  private async decodeReordered(
+    units: readonly H264AccessUnit[],
+    targetTimeNs: bigint,
+    signal: AbortSignal,
+  ): Promise<VideoFrame> {
+    await this.ensureDecoder(units[0]);
+    const decoder = this.decoder;
+    if (!decoder) throw new Error("Video decoder closed");
+    const inFlight = new Set<Promise<VideoFrame | undefined>>();
+    let target: VideoFrame | undefined;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const armProgressTimer = () => {
+      if (timer !== null) this.environment.clearTimeout(timer);
+      timer = this.environment.setTimeout(() => {
+        timer = null;
+        this.failDecoder(
+          new VideoDecoderFailureError(
+            "Timed out waiting for H.264 decoder progress",
+          ),
+        );
+      }, VIDEO_DECODE_PROGRESS_TIMEOUT_MS);
+    };
+    const waitForOne = async () => {
+      const settled = await Promise.race(
+        [...inFlight].map(async (promise) => ({
+          output: await promise,
+          promise,
+        })),
+      );
+      inFlight.delete(settled.promise);
+      if (settled.output) {
+        target?.close();
+        target = settled.output;
+      }
+    };
+
+    try {
+      armProgressTimer();
+      for (const unit of units) {
+        if (signal.aborted) throw new VideoIntentCancelledError();
+        while (inFlight.size >= MAX_VIDEO_DECODE_IN_FLIGHT) {
+          await waitForOne();
+        }
+        inFlight.add(
+          this.submit(
+            decoder,
+            unit,
+            unit.timeNs === targetTimeNs,
+            armProgressTimer,
+          ),
+        );
+      }
+      await decoder.flush();
+      while (inFlight.size) await waitForOne();
+      if (signal.aborted) throw new VideoIntentCancelledError();
+      if (!target) {
+        throw new VideoDecoderFailureError(
+          "H.264 target produced no decoder output",
+        );
+      }
+      return target;
+    } catch (error) {
+      target?.close();
+      await Promise.allSettled(inFlight);
+      throw error;
+    } finally {
+      if (timer !== null) this.environment.clearTimeout(timer);
     }
   }
 
@@ -263,14 +344,16 @@ export class WebCodecsH264Decoder implements VideoDecoderActor {
       pps: unit.frame.h264.pps ? undefined : this.pps,
       sps: unit.frame.h264.sps ? undefined : this.sps,
     });
-    // Preserve source PTS for browser-level observability. Adjacent source
-    // nanoseconds can collide when truncated to WebCodecs microseconds, so
-    // nudge only collisions forward while preserving monotonic decode order.
+    // Preserve source PTS for browser-level observability. LeRobot MP4 units
+    // carry an explicit DTS and may be submitted in non-monotonic PTS order
+    // when B-frames are present. Legacy streams retain monotonic nudging.
     const sourceTimestampUs = Number(unit.timeNs / 1_000n);
     const submissionTimestampUs =
-      this.lastSubmissionTimestampUs === null
-        ? sourceTimestampUs
-        : Math.max(sourceTimestampUs, this.lastSubmissionTimestampUs + 1);
+      unit.frame.decodeTimestampNs !== undefined
+        ? uniquePendingTimestamp(sourceTimestampUs, this.pending)
+        : this.lastSubmissionTimestampUs === null
+          ? sourceTimestampUs
+          : Math.max(sourceTimestampUs, this.lastSubmissionTimestampUs + 1);
     this.lastSubmissionTimestampUs = submissionTimestampUs;
     return new Promise<VideoFrame | undefined>((resolve, reject) => {
       const pending: PendingOutput = {
@@ -360,6 +443,23 @@ export class WebCodecsH264Decoder implements VideoDecoderActor {
     this.lastOutputTimeNs = null;
     this.lastSubmissionTimestampUs = null;
   }
+}
+
+function compareDecodeOrder(left: H264AccessUnit, right: H264AccessUnit) {
+  const leftTime = left.frame.decodeTimestampNs ?? left.timeNs;
+  const rightTime = right.frame.decodeTimestampNs ?? right.timeNs;
+  return leftTime < rightTime ? -1 : leftTime > rightTime ? 1 : 0;
+}
+
+function uniquePendingTimestamp(
+  preferred: number,
+  pending: readonly PendingOutput[],
+) {
+  let timestamp = preferred;
+  while (pending.some((entry) => entry.submissionTimestampUs === timestamp)) {
+    timestamp += 1;
+  }
+  return timestamp;
 }
 
 function browserWebCodecsEnvironment(): WebCodecsDecoderEnvironment {

--- a/app/packages/multimodal/src/video/webcodecs-decoder.ts
+++ b/app/packages/multimodal/src/video/webcodecs-decoder.ts
@@ -15,6 +15,7 @@ const MAX_REORDERED_VIDEO_OUTPUTS = 32;
 export const VIDEO_DECODE_PROGRESS_TIMEOUT_MS = 15_000;
 
 interface PendingOutput {
+  readonly promise: Promise<VideoFrame>;
   readonly reject: (error: Error) => void;
   readonly resolve: (frame: VideoFrame) => void;
   readonly timeNs: bigint;
@@ -47,6 +48,7 @@ export class WebCodecsVideoDecoder implements VideoDecoderActor {
   private lastSubmissionTimestampUs: number | null = null;
   private readonly pending: PendingOutput[] = [];
   private pps: Uint8Array | undefined;
+  private protectedReorderedOutputTimeNs: bigint | null = null;
   private readonly reorderedOutputs = new Map<bigint, ReorderedOutput>();
   private readonly reorderedSubmitted = new Set<bigint>();
   private sps: Uint8Array | undefined;
@@ -156,6 +158,7 @@ export class WebCodecsVideoDecoder implements VideoDecoderActor {
       }, VIDEO_DECODE_PROGRESS_TIMEOUT_MS);
     };
 
+    this.protectedReorderedOutputTimeNs = targetTimeNs;
     try {
       armProgressTimer();
       this.discardReorderedOutputsBefore(targetTimeNs);
@@ -204,6 +207,9 @@ export class WebCodecsVideoDecoder implements VideoDecoderActor {
       this.discardSubmittedTimesBefore(targetTimeNs);
       return frame;
     } finally {
+      if (this.protectedReorderedOutputTimeNs === targetTimeNs) {
+        this.protectedReorderedOutputTimeNs = null;
+      }
       if (timer !== null) this.environment.clearTimeout(timer);
     }
   }
@@ -367,36 +373,42 @@ export class WebCodecsVideoDecoder implements VideoDecoderActor {
           ? sourceTimestampUs
           : Math.max(sourceTimestampUs, this.lastSubmissionTimestampUs + 1);
     this.lastSubmissionTimestampUs = submissionTimestampUs;
-    return new Promise<VideoFrame>((resolve, reject) => {
-      const pending: PendingOutput = {
-        reject,
-        resolve: (frame) => {
-          onProgress();
-          resolve(frame);
-        },
-        timeNs: unit.timeNs,
-        submissionTimestampUs,
-      };
-      this.pending.push(pending);
-      try {
-        decoder.decode(
-          new this.environment.EncodedVideoChunk({
-            data,
-            timestamp: submissionTimestampUs,
-            type: unit.frame.keyframe ? "key" : "delta",
-          }),
-        );
-      } catch (error) {
-        const index = this.pending.indexOf(pending);
-        if (index >= 0) this.pending.splice(index, 1);
-        const failure = new VideoDecoderFailureError(
-          `Failed to submit a ${codecDisplayName(unit.frame)} access unit`,
-          { cause: error },
-        );
-        this.failDecoder(failure);
-        reject(failure);
-      }
+    let resolveOutput!: (frame: VideoFrame) => void;
+    let rejectOutput!: (error: Error) => void;
+    const promise = new Promise<VideoFrame>((resolve, reject) => {
+      resolveOutput = resolve;
+      rejectOutput = reject;
     });
+    const pending: PendingOutput = {
+      promise,
+      reject: rejectOutput,
+      resolve: (frame) => {
+        onProgress();
+        resolveOutput(frame);
+      },
+      timeNs: unit.timeNs,
+      submissionTimestampUs,
+    };
+    this.pending.push(pending);
+    try {
+      decoder.decode(
+        new this.environment.EncodedVideoChunk({
+          data,
+          timestamp: submissionTimestampUs,
+          type: unit.frame.keyframe ? "key" : "delta",
+        }),
+      );
+    } catch (error) {
+      const index = this.pending.indexOf(pending);
+      if (index >= 0) this.pending.splice(index, 1);
+      const failure = new VideoDecoderFailureError(
+        `Failed to submit a ${codecDisplayName(unit.frame)} access unit`,
+        { cause: error },
+      );
+      this.failDecoder(failure);
+      rejectOutput(failure);
+    }
+    return promise;
   }
 
   private submitReordered(
@@ -414,6 +426,10 @@ export class WebCodecsVideoDecoder implements VideoDecoderActor {
     this.lastSubmittedDecodeTimeNs = decodeTimeNs;
     void promise.then(
       (frame) => {
+        if (this.reorderedOutputs.get(unit.timeNs) !== output) {
+          frame.close();
+          return;
+        }
         output.frame = frame;
         this.trimReorderedOutputs();
       },
@@ -428,9 +444,7 @@ export class WebCodecsVideoDecoder implements VideoDecoderActor {
   }
 
   private async waitForReorderedProgress(signal: AbortSignal): Promise<void> {
-    const pending = [...this.reorderedOutputs.values()]
-      .filter((output) => output.frame === null)
-      .map((output) => output.promise);
+    const pending = this.pending.map((output) => output.promise);
     if (pending.length === 0) {
       throw new VideoDecoderFailureError(
         "Video decoder submission window made no progress",
@@ -478,12 +492,8 @@ export class WebCodecsVideoDecoder implements VideoDecoderActor {
     for (const [outputTimeNs, output] of this.reorderedOutputs) {
       if (outputTimeNs >= timeNs) continue;
       this.reorderedOutputs.delete(outputTimeNs);
+      this.reorderedSubmitted.delete(outputTimeNs);
       if (output.frame) output.frame.close();
-      else
-        void output.promise.then(
-          (frame) => frame.close(),
-          () => undefined,
-        );
     }
   }
 
@@ -498,6 +508,7 @@ export class WebCodecsVideoDecoder implements VideoDecoderActor {
   private trimReorderedOutputs(): void {
     if (this.reorderedOutputs.size <= MAX_REORDERED_VIDEO_OUTPUTS) return;
     for (const [timeNs, output] of this.reorderedOutputs) {
+      if (timeNs === this.protectedReorderedOutputTimeNs) continue;
       if (!output.frame) continue;
       this.reorderedOutputs.delete(timeNs);
       this.reorderedSubmitted.delete(timeNs);
@@ -535,12 +546,8 @@ export class WebCodecsVideoDecoder implements VideoDecoderActor {
     for (const pending of this.pending.splice(0)) pending.reject(error);
     for (const output of this.reorderedOutputs.values()) {
       if (output.frame) output.frame.close();
-      else
-        void output.promise.then(
-          (frame) => frame.close(),
-          () => undefined,
-        );
     }
+    this.protectedReorderedOutputTimeNs = null;
     this.reorderedOutputs.clear();
     this.reorderedSubmitted.clear();
     const decoder = this.decoder;

--- a/app/packages/multimodal/src/video/webcodecs-decoder.ts
+++ b/app/packages/multimodal/src/video/webcodecs-decoder.ts
@@ -8,14 +8,19 @@ import {
 } from "./types";
 
 export const MAX_VIDEO_DECODE_IN_FLIGHT = 8;
+export const MAX_REORDERED_VIDEO_OUTPUTS = 32;
 export const VIDEO_DECODE_PROGRESS_TIMEOUT_MS = 15_000;
 
 interface PendingOutput {
   readonly reject: (error: Error) => void;
-  readonly resolve: (frame: VideoFrame | undefined) => void;
-  readonly retain: boolean;
+  readonly resolve: (frame: VideoFrame) => void;
   readonly timeNs: bigint;
   readonly submissionTimestampUs: number;
+}
+
+interface ReorderedOutput {
+  frame: VideoFrame | null;
+  readonly promise: Promise<VideoFrame>;
 }
 
 export interface WebCodecsDecoderEnvironment {
@@ -34,9 +39,12 @@ export class WebCodecsH264Decoder implements VideoDecoderActor {
   private decoder: VideoDecoder | null = null;
   private failed: Error | null = null;
   private lastOutputTimeNs: bigint | null = null;
+  private lastSubmittedDecodeTimeNs: bigint | null = null;
   private lastSubmissionTimestampUs: number | null = null;
   private readonly pending: PendingOutput[] = [];
   private pps: Uint8Array | undefined;
+  private readonly reorderedOutputs = new Map<bigint, ReorderedOutput>();
+  private readonly reorderedSubmitted = new Set<bigint>();
   private sps: Uint8Array | undefined;
 
   constructor(private environmentValue?: WebCodecsDecoderEnvironment) {}
@@ -52,6 +60,10 @@ export class WebCodecsH264Decoder implements VideoDecoderActor {
 
   get cursorTimeNs(): bigint | null {
     return this.lastOutputTimeNs;
+  }
+
+  get cursorDecodeTimeNs(): bigint | null {
+    return this.lastSubmittedDecodeTimeNs;
   }
 
   async decode(
@@ -116,12 +128,7 @@ export class WebCodecsH264Decoder implements VideoDecoderActor {
     }
   }
 
-  /**
-   * Keeps a bounded sliding submission window for MP4 decode-order samples.
-   * B-frame decoders may retain a few inputs until later references arrive,
-   * so waiting for every fixed batch would deadlock before those references
-   * can be submitted. One flush at the transaction boundary drains the tail.
-   */
+  /** Keeps a bounded, persistent submission window for MP4 decode-order samples. */
   private async decodeReordered(
     units: readonly H264AccessUnit[],
     targetTimeNs: bigint,
@@ -130,8 +137,6 @@ export class WebCodecsH264Decoder implements VideoDecoderActor {
     await this.ensureDecoder(units[0]);
     const decoder = this.decoder;
     if (!decoder) throw new Error("Video decoder closed");
-    const inFlight = new Set<Promise<VideoFrame | undefined>>();
-    let target: VideoFrame | undefined;
     let timer: ReturnType<typeof setTimeout> | null = null;
     const armProgressTimer = () => {
       if (timer !== null) this.environment.clearTimeout(timer);
@@ -144,49 +149,40 @@ export class WebCodecsH264Decoder implements VideoDecoderActor {
         );
       }, VIDEO_DECODE_PROGRESS_TIMEOUT_MS);
     };
-    const waitForOne = async () => {
-      const settled = await Promise.race(
-        [...inFlight].map(async (promise) => ({
-          output: await promise,
-          promise,
-        })),
-      );
-      inFlight.delete(settled.promise);
-      if (settled.output) {
-        target?.close();
-        target = settled.output;
-      }
-    };
 
     try {
       armProgressTimer();
+      this.discardReorderedOutputsBefore(targetTimeNs);
       for (const unit of units) {
         if (signal.aborted) throw new VideoIntentCancelledError();
-        while (inFlight.size >= MAX_VIDEO_DECODE_IN_FLIGHT) {
-          await waitForOne();
+        if (this.reorderedSubmitted.has(unit.timeNs)) continue;
+        const decodeTimeNs = unit.frame.decodeTimestampNs ?? unit.timeNs;
+        if (
+          this.lastSubmittedDecodeTimeNs !== null &&
+          decodeTimeNs <= this.lastSubmittedDecodeTimeNs
+        ) {
+          throw new VideoDecoderFailureError(
+            "H.264 dependency arrived behind the decode-order cursor",
+          );
         }
-        inFlight.add(
-          this.submit(
-            decoder,
-            unit,
-            unit.timeNs === targetTimeNs,
-            armProgressTimer,
-          ),
-        );
+        while (this.pending.length >= MAX_VIDEO_DECODE_IN_FLIGHT) {
+          await this.waitForReorderedProgress(signal);
+        }
+        this.submitReordered(decoder, unit, armProgressTimer);
       }
-      await decoder.flush();
-      while (inFlight.size) await waitForOne();
-      if (signal.aborted) throw new VideoIntentCancelledError();
+      const target = this.reorderedOutputs.get(targetTimeNs);
       if (!target) {
         throw new VideoDecoderFailureError(
           "H.264 target produced no decoder output",
         );
       }
-      return target;
-    } catch (error) {
-      target?.close();
-      await Promise.allSettled(inFlight);
-      throw error;
+      const frame = await abortableDecoderOutput(target.promise, signal);
+      if (signal.aborted) throw new VideoIntentCancelledError();
+      this.reorderedOutputs.delete(targetTimeNs);
+      target.frame = null;
+      this.lastOutputTimeNs = targetTimeNs;
+      this.discardSubmittedTimesBefore(targetTimeNs);
+      return frame;
     } finally {
       if (timer !== null) this.environment.clearTimeout(timer);
     }
@@ -249,12 +245,11 @@ export class WebCodecsH264Decoder implements VideoDecoderActor {
     armProgressTimer();
     try {
       const promises = units.map((unit) =>
-        this.submit(
-          decoder,
-          unit,
-          unit.timeNs === targetTimeNs,
-          armProgressTimer,
-        ),
+        this.submit(decoder, unit, armProgressTimer).then((frame) => {
+          if (unit.timeNs === targetTimeNs) return frame;
+          frame.close();
+          return undefined;
+        }),
       );
       const results = await Promise.allSettled(promises);
       const outputs = results.map((result) =>
@@ -268,6 +263,7 @@ export class WebCodecsH264Decoder implements VideoDecoderActor {
         for (const output of outputs) output?.close();
         throw this.failed ?? toError(rejection?.reason);
       }
+      if (outputs.some(Boolean)) this.lastOutputTimeNs = targetTimeNs;
       return outputs;
     } finally {
       if (timer !== null) this.environment.clearTimeout(timer);
@@ -334,9 +330,8 @@ export class WebCodecsH264Decoder implements VideoDecoderActor {
   private submit(
     decoder: VideoDecoder,
     unit: H264AccessUnit,
-    retain: boolean,
     onProgress: () => void,
-  ): Promise<VideoFrame | undefined> {
+  ): Promise<VideoFrame> {
     if (unit.frame.h264.sps) this.sps = unit.frame.h264.sps;
     if (unit.frame.h264.pps) this.pps = unit.frame.h264.pps;
     const data = h264AccessUnitWithParameterSets({
@@ -355,14 +350,13 @@ export class WebCodecsH264Decoder implements VideoDecoderActor {
           ? sourceTimestampUs
           : Math.max(sourceTimestampUs, this.lastSubmissionTimestampUs + 1);
     this.lastSubmissionTimestampUs = submissionTimestampUs;
-    return new Promise<VideoFrame | undefined>((resolve, reject) => {
+    return new Promise<VideoFrame>((resolve, reject) => {
       const pending: PendingOutput = {
         reject,
         resolve: (frame) => {
           onProgress();
           resolve(frame);
         },
-        retain,
         timeNs: unit.timeNs,
         submissionTimestampUs,
       };
@@ -388,6 +382,78 @@ export class WebCodecsH264Decoder implements VideoDecoderActor {
     });
   }
 
+  private submitReordered(
+    decoder: VideoDecoder,
+    unit: H264AccessUnit,
+    onProgress: () => void,
+  ): Promise<VideoFrame> {
+    const existing = this.reorderedOutputs.get(unit.timeNs);
+    if (existing) return existing.promise;
+    const promise = this.submit(decoder, unit, onProgress);
+    const output: ReorderedOutput = { frame: null, promise };
+    this.reorderedOutputs.set(unit.timeNs, output);
+    this.reorderedSubmitted.add(unit.timeNs);
+    const decodeTimeNs = unit.frame.decodeTimestampNs ?? unit.timeNs;
+    this.lastSubmittedDecodeTimeNs = decodeTimeNs;
+    void promise.then(
+      (frame) => {
+        output.frame = frame;
+        this.trimReorderedOutputs();
+      },
+      () => {
+        if (this.reorderedOutputs.get(unit.timeNs) === output) {
+          this.reorderedOutputs.delete(unit.timeNs);
+          this.reorderedSubmitted.delete(unit.timeNs);
+        }
+      },
+    );
+    return promise;
+  }
+
+  private async waitForReorderedProgress(signal: AbortSignal): Promise<void> {
+    const pending = [...this.reorderedOutputs.values()]
+      .filter((output) => output.frame === null)
+      .map((output) => output.promise);
+    if (pending.length === 0) {
+      throw new VideoDecoderFailureError(
+        "H.264 decoder submission window made no progress",
+      );
+    }
+    await abortableDecoderOutput(Promise.race(pending), signal);
+  }
+
+  private discardReorderedOutputsBefore(timeNs: bigint): void {
+    for (const [outputTimeNs, output] of this.reorderedOutputs) {
+      if (outputTimeNs >= timeNs) continue;
+      this.reorderedOutputs.delete(outputTimeNs);
+      if (output.frame) output.frame.close();
+      else
+        void output.promise.then(
+          (frame) => frame.close(),
+          () => undefined,
+        );
+    }
+  }
+
+  private discardSubmittedTimesBefore(timeNs: bigint): void {
+    for (const submittedTimeNs of this.reorderedSubmitted) {
+      if (submittedTimeNs < timeNs) {
+        this.reorderedSubmitted.delete(submittedTimeNs);
+      }
+    }
+  }
+
+  private trimReorderedOutputs(): void {
+    if (this.reorderedOutputs.size <= MAX_REORDERED_VIDEO_OUTPUTS) return;
+    for (const [timeNs, output] of this.reorderedOutputs) {
+      if (!output.frame) continue;
+      this.reorderedOutputs.delete(timeNs);
+      this.reorderedSubmitted.delete(timeNs);
+      output.frame.close();
+      if (this.reorderedOutputs.size <= MAX_REORDERED_VIDEO_OUTPUTS) return;
+    }
+  }
+
   private handleOutput(frame: VideoFrame): void {
     const timestamp = frame.timestamp;
     const index = this.pending.findIndex(
@@ -398,18 +464,7 @@ export class WebCodecsH264Decoder implements VideoDecoderActor {
       frame.close();
       return;
     }
-    if (
-      this.lastOutputTimeNs === null ||
-      pending.timeNs > this.lastOutputTimeNs
-    ) {
-      this.lastOutputTimeNs = pending.timeNs;
-    }
-    if (pending.retain) {
-      pending.resolve(frame);
-    } else {
-      frame.close();
-      pending.resolve(undefined);
-    }
+    pending.resolve(frame);
   }
 
   private failDecoder(error: Error): void {
@@ -425,6 +480,16 @@ export class WebCodecsH264Decoder implements VideoDecoderActor {
 
   private disposeDecoder(error: Error, reset = true): void {
     for (const pending of this.pending.splice(0)) pending.reject(error);
+    for (const output of this.reorderedOutputs.values()) {
+      if (output.frame) output.frame.close();
+      else
+        void output.promise.then(
+          (frame) => frame.close(),
+          () => undefined,
+        );
+    }
+    this.reorderedOutputs.clear();
+    this.reorderedSubmitted.clear();
     const decoder = this.decoder;
     if (reset) {
       try {
@@ -440,6 +505,7 @@ export class WebCodecsH264Decoder implements VideoDecoderActor {
     }
     this.decoder = null;
     this.codecString = null;
+    this.lastSubmittedDecodeTimeNs = null;
     this.lastOutputTimeNs = null;
     this.lastSubmissionTimestampUs = null;
   }
@@ -460,6 +526,31 @@ function uniquePendingTimestamp(
     timestamp += 1;
   }
   return timestamp;
+}
+
+function abortableDecoderOutput<T>(
+  promise: Promise<T>,
+  signal: AbortSignal,
+): Promise<T> {
+  if (signal.aborted) return Promise.reject(new VideoIntentCancelledError());
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      cleanup();
+      reject(new VideoIntentCancelledError());
+    };
+    const cleanup = () => signal.removeEventListener("abort", onAbort);
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => {
+        cleanup();
+        resolve(value);
+      },
+      (error) => {
+        cleanup();
+        reject(error);
+      },
+    );
+  });
 }
 
 function browserWebCodecsEnvironment(): WebCodecsDecoderEnvironment {

--- a/app/packages/multimodal/src/video/webcodecs-decoder.ts
+++ b/app/packages/multimodal/src/video/webcodecs-decoder.ts
@@ -1,6 +1,7 @@
 import { h264AccessUnitWithParameterSets } from "../codecs/h264-annexb";
 import { toError } from "../utils/errors";
 import type { EncodedVideoVisualization } from "../ir";
+import { compareUnitDecodeTime } from "./gop-index";
 import type { EncodedVideoAccessUnit, VideoDecoderActor } from "./types";
 import {
   isSharedEncodedVideoVisualization,
@@ -39,6 +40,7 @@ export class WebCodecsVideoDecoder implements VideoDecoderActor {
   private closed = false;
   private codecString: string | null = null;
   private decoder: VideoDecoder | null = null;
+  private readonly decoderQueueWaiters = new Set<(error: Error) => void>();
   private failed: Error | null = null;
   private lastOutputTimeNs: bigint | null = null;
   private lastSubmittedDecodeTimeNs: bigint | null = null;
@@ -84,7 +86,7 @@ export class WebCodecsVideoDecoder implements VideoDecoderActor {
       throw new Error("Concurrent video decoder transaction");
     }
     if (signal.aborted) throw new VideoIntentCancelledError();
-    const decodable = units.filter(isDecodableUnit).sort(compareDecodeOrder);
+    const decodable = units.filter(isDecodableUnit).sort(compareUnitDecodeTime);
     if (decodable.length === 0) {
       throw new VideoDependencyWaitError("Waiting for a video access unit");
     }
@@ -177,7 +179,7 @@ export class WebCodecsVideoDecoder implements VideoDecoderActor {
           this.pending.length >= MAX_REORDERED_VIDEO_OUTPUTS
         ) {
           if (decoder.decodeQueueSize >= MAX_VIDEO_DECODE_IN_FLIGHT) {
-            await waitForDecoderQueueProgress(
+            await this.waitForDecoderQueueProgress(
               decoder,
               MAX_VIDEO_DECODE_IN_FLIGHT,
               signal,
@@ -437,6 +439,41 @@ export class WebCodecsVideoDecoder implements VideoDecoderActor {
     await abortableDecoderOutput(Promise.race(pending), signal);
   }
 
+  private waitForDecoderQueueProgress(
+    decoder: VideoDecoder,
+    limit: number,
+    signal: AbortSignal,
+  ): Promise<void> {
+    if (signal.aborted) return Promise.reject(new VideoIntentCancelledError());
+    if (decoder.decodeQueueSize < limit) return Promise.resolve();
+    return new Promise<void>((resolve, reject) => {
+      const cleanup = () => {
+        this.decoderQueueWaiters.delete(fail);
+        decoder.removeEventListener("dequeue", onDequeue);
+        signal.removeEventListener("abort", onAbort);
+      };
+      const fail = (error: Error) => {
+        cleanup();
+        reject(error);
+      };
+      const onAbort = () => {
+        cleanup();
+        reject(new VideoIntentCancelledError());
+      };
+      const onDequeue = () => {
+        if (decoder.decodeQueueSize >= limit) return;
+        cleanup();
+        resolve();
+      };
+      this.decoderQueueWaiters.add(fail);
+      decoder.addEventListener("dequeue", onDequeue);
+      signal.addEventListener("abort", onAbort, { once: true });
+      // The queue can drain between the caller's check and listener install.
+      if (signal.aborted) onAbort();
+      else onDequeue();
+    });
+  }
+
   private discardReorderedOutputsBefore(timeNs: bigint): void {
     for (const [outputTimeNs, output] of this.reorderedOutputs) {
       if (outputTimeNs >= timeNs) continue;
@@ -494,6 +531,7 @@ export class WebCodecsVideoDecoder implements VideoDecoderActor {
   }
 
   private disposeDecoder(error: Error, reset = true): void {
+    for (const fail of [...this.decoderQueueWaiters]) fail(error);
     for (const pending of this.pending.splice(0)) pending.reject(error);
     for (const output of this.reorderedOutputs.values()) {
       if (output.frame) output.frame.close();
@@ -537,15 +575,6 @@ export class WebCodecsVideoDecoder implements VideoDecoderActor {
   }
 }
 
-function compareDecodeOrder(
-  left: EncodedVideoAccessUnit,
-  right: EncodedVideoAccessUnit,
-) {
-  const leftTime = left.frame.decodeTimestampNs ?? left.timeNs;
-  const rightTime = right.frame.decodeTimestampNs ?? right.timeNs;
-  return leftTime < rightTime ? -1 : leftTime > rightTime ? 1 : 0;
-}
-
 function uniquePendingTimestamp(
   preferred: number,
   pending: readonly PendingOutput[],
@@ -579,35 +608,6 @@ function abortableDecoderOutput<T>(
         reject(error);
       },
     );
-  });
-}
-
-function waitForDecoderQueueProgress(
-  decoder: VideoDecoder,
-  limit: number,
-  signal: AbortSignal,
-): Promise<void> {
-  if (signal.aborted) return Promise.reject(new VideoIntentCancelledError());
-  if (decoder.decodeQueueSize < limit) return Promise.resolve();
-  return new Promise<void>((resolve, reject) => {
-    const cleanup = () => {
-      decoder.removeEventListener("dequeue", onDequeue);
-      signal.removeEventListener("abort", onAbort);
-    };
-    const onAbort = () => {
-      cleanup();
-      reject(new VideoIntentCancelledError());
-    };
-    const onDequeue = () => {
-      if (decoder.decodeQueueSize >= limit) return;
-      cleanup();
-      resolve();
-    };
-    decoder.addEventListener("dequeue", onDequeue);
-    signal.addEventListener("abort", onAbort, { once: true });
-    // The queue can drain between the caller's check and listener install.
-    if (signal.aborted) onAbort();
-    else onDequeue();
   });
 }
 

--- a/app/packages/multimodal/src/video/webcodecs-decoder.ts
+++ b/app/packages/multimodal/src/video/webcodecs-decoder.ts
@@ -10,7 +10,7 @@ import {
 } from "./types";
 
 export const MAX_VIDEO_DECODE_IN_FLIGHT = 8;
-export const MAX_REORDERED_VIDEO_OUTPUTS = 32;
+const MAX_REORDERED_VIDEO_OUTPUTS = 32;
 export const VIDEO_DECODE_PROGRESS_TIMEOUT_MS = 15_000;
 
 interface PendingOutput {
@@ -356,7 +356,7 @@ export class WebCodecsVideoDecoder implements VideoDecoderActor {
     const data = this.chunkData(unit);
     // Preserve source PTS for browser-level observability. LeRobot MP4 units
     // carry an explicit DTS and may be submitted in non-monotonic PTS order
-    // when B-frames are present. Legacy streams retain monotonic nudging.
+    // when B-frames are present. Units without DTS retain monotonic nudging.
     const sourceTimestampUs = Number(unit.timeNs / 1_000n);
     const submissionTimestampUs =
       unit.frame.decodeTimestampNs !== undefined
@@ -536,9 +536,6 @@ export class WebCodecsVideoDecoder implements VideoDecoderActor {
     });
   }
 }
-
-/** Compatibility export for existing H.264-specific callers. */
-export { WebCodecsVideoDecoder as WebCodecsH264Decoder };
 
 function compareDecodeOrder(
   left: EncodedVideoAccessUnit,

--- a/app/packages/multimodal/src/views/entry.tsx
+++ b/app/packages/multimodal/src/views/entry.tsx
@@ -56,7 +56,9 @@ export function registerEpisodeViews(): void {
     type: PluginComponentType.SampleRenderer,
     activator: (ctx) => ctx.dataset?.mediaType === "multimodal",
     sampleRendererOptions: {
-      supports: { extensions: ["mcap"] },
+      supports: (ctx) =>
+        ctx.media.extension === "mcap" ||
+        ctx.media.mediaReference?.kind === "lerobot-episode",
       modal: { persistAcrossSamples: true },
       grid: {
         clickBehavior: "passthrough",

--- a/app/packages/multimodal/src/views/entry.tsx
+++ b/app/packages/multimodal/src/views/entry.tsx
@@ -43,6 +43,17 @@ const GridStreamSelector = withSuspense(LazyGridStreamSelector);
 const McapExplorer = withSuspense(LazyMcapExplorer);
 const McapExplorerIcon = withSuspense(LazyMcapExplorerIcon);
 
+/**
+ * Lazily registers the LeRobot-only view extensions (the State & Action
+ * tile) as a module side effect. The injection root awaits this alongside
+ * the LeRobot format adapter's own lazy load, so the extension exists
+ * before any session can expose `hasStateAction` and never enters the
+ * initial bundle for non-LeRobot sessions.
+ */
+export async function loadLeRobotViewExtensions(): Promise<void> {
+  await import("./episode/state-action/register-state-action-tile");
+}
+
 let registered = false;
 
 /** Registers lightweight episode view shells whose heavy graphs load on use. */

--- a/app/packages/multimodal/src/views/episode/grid/GridRenderer.module.css
+++ b/app/packages/multimodal/src/views/episode/grid/GridRenderer.module.css
@@ -53,6 +53,17 @@
   z-index: 2;
 }
 
+.nativeVideoError {
+  background: rgba(16, 17, 20, 0.82);
+  bottom: 8px;
+  left: 50%;
+  max-width: calc(100% - 16px);
+  padding: 3px 6px;
+  position: absolute;
+  transform: translateX(-50%);
+  z-index: 3;
+}
+
 .pointCloud {
   cursor: default;
 }

--- a/app/packages/multimodal/src/views/episode/grid/GridRenderer.module.css
+++ b/app/packages/multimodal/src/views/episode/grid/GridRenderer.module.css
@@ -29,26 +29,6 @@
   z-index: 2;
 }
 
-.episodeMetadata {
-  background: linear-gradient(transparent, rgba(10, 11, 14, 0.86));
-  bottom: 0;
-  box-sizing: border-box;
-  color: rgba(255, 255, 255, 0.9);
-  font-size: 10px;
-  font-weight: 600;
-  left: 0;
-  line-height: 1.3;
-  overflow: hidden;
-  padding: 18px 34px 6px 7px;
-  pointer-events: none;
-  position: absolute;
-  right: 0;
-  text-overflow: ellipsis;
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.9);
-  white-space: nowrap;
-  z-index: 2;
-}
-
 .imagePanel {
   inset: 0;
   position: absolute;

--- a/app/packages/multimodal/src/views/episode/grid/GridRenderer.module.css
+++ b/app/packages/multimodal/src/views/episode/grid/GridRenderer.module.css
@@ -29,6 +29,26 @@
   z-index: 2;
 }
 
+.episodeMetadata {
+  background: linear-gradient(transparent, rgba(10, 11, 14, 0.86));
+  bottom: 0;
+  box-sizing: border-box;
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 10px;
+  font-weight: 600;
+  left: 0;
+  line-height: 1.3;
+  overflow: hidden;
+  padding: 18px 34px 6px 7px;
+  pointer-events: none;
+  position: absolute;
+  right: 0;
+  text-overflow: ellipsis;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.9);
+  white-space: nowrap;
+  z-index: 2;
+}
+
 .imagePanel {
   inset: 0;
   position: absolute;

--- a/app/packages/multimodal/src/views/episode/grid/GridRenderer.module.css
+++ b/app/packages/multimodal/src/views/episode/grid/GridRenderer.module.css
@@ -34,6 +34,17 @@
   position: absolute;
 }
 
+.nativeVideo {
+  height: 100%;
+  inset: 0;
+  object-fit: cover;
+  pointer-events: none;
+  position: absolute;
+  visibility: hidden;
+  width: 100%;
+  z-index: 1;
+}
+
 .pointCloud {
   cursor: default;
 }

--- a/app/packages/multimodal/src/views/episode/grid/GridRenderer.module.css
+++ b/app/packages/multimodal/src/views/episode/grid/GridRenderer.module.css
@@ -34,6 +34,7 @@
   position: absolute;
 }
 
+.nativePoster,
 .nativeVideo {
   height: 100%;
   inset: 0;
@@ -42,7 +43,14 @@
   position: absolute;
   visibility: hidden;
   width: 100%;
+}
+
+.nativePoster {
   z-index: 1;
+}
+
+.nativeVideo {
+  z-index: 2;
 }
 
 .pointCloud {

--- a/app/packages/multimodal/src/views/episode/grid/GridRenderer.test.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/GridRenderer.test.tsx
@@ -28,7 +28,7 @@ import type {
   EpisodePreviewReadResult,
 } from "../../../ir";
 import { PushVideoAccessUnitReader } from "../../../video/push-reader";
-import { H264_REORDERED_DECODE_LOOKAHEAD_NS } from "../../../video/stream-engine";
+import { REORDERED_VIDEO_DECODE_LOOKAHEAD_NS } from "../../../video/stream-engine";
 import {
   gridPreviewStateKey,
   pointCloudPoseKey,
@@ -510,7 +510,7 @@ describe("GridRenderer", () => {
     });
 
     expect(vi.mocked(useGridPreview).mock.lastCall?.[0]).toMatchObject({
-      initialVideoDecodeLookaheadNs: H264_REORDERED_DECODE_LOOKAHEAD_NS,
+      initialVideoDecodeLookaheadNs: REORDERED_VIDEO_DECODE_LOOKAHEAD_NS,
       posterStartTimeNs: null,
       posterSourceName: null,
     });

--- a/app/packages/multimodal/src/views/episode/grid/GridRenderer.test.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/GridRenderer.test.tsx
@@ -224,7 +224,12 @@ vi.mock("./use-grid-poster-provider", () => ({
 }));
 
 vi.mock("./LeRobotGridHoverVideo", () => ({
-  LeRobotGridHoverVideo: () => <div data-testid="lerobot-grid-hover-video" />,
+  LeRobotGridHoverVideo: ({ playing }: { readonly playing?: boolean }) => (
+    <div
+      data-playing={playing ? "true" : "false"}
+      data-testid="lerobot-grid-hover-video"
+    />
+  ),
 }));
 
 vi.mock("./grid-camera-state", () => ({
@@ -686,7 +691,7 @@ describe("GridRenderer", () => {
     expect(screen.getByTestId("bitmap-image-view")).toBeTruthy();
   });
 
-  it("mounts native LeRobot playback over the retained poster only while playing", () => {
+  it("activates native LeRobot playback over the retained poster only while playing", () => {
     previewHarness.preview.cachedPoster = {
       bytes: new Uint8Array([1, 2, 3]),
       height: 180,
@@ -699,6 +704,8 @@ describe("GridRenderer", () => {
     };
     previewHarness.preview.frame = videoFrame(new Uint8Array([9, 9, 9]));
     previewHarness.preview.nativeVideo = {
+      codec: "h264",
+      codecString: "avc1.64000a",
       endTimeSeconds: 37.5,
       source: { sourceId: "video", url: "/asset/video.mp4" },
       startTimeSeconds: 14.2,
@@ -708,16 +715,22 @@ describe("GridRenderer", () => {
     const { rerender } = render(<GridRenderer ctx={rendererCtx()} />);
 
     expect(screen.getByTestId("bitmap-cached-image-view")).toBeTruthy();
-    expect(screen.queryByTestId("lerobot-grid-hover-video")).toBeNull();
+    expect(screen.getByTestId("lerobot-grid-hover-video").dataset.playing).toBe(
+      "false",
+    );
 
     previewHarness.preview.isPlaying = true;
     rerender(<GridRenderer ctx={rendererCtx()} />);
     expect(screen.getByTestId("bitmap-cached-image-view")).toBeTruthy();
-    expect(screen.getByTestId("lerobot-grid-hover-video")).toBeTruthy();
+    expect(screen.getByTestId("lerobot-grid-hover-video").dataset.playing).toBe(
+      "true",
+    );
 
     previewHarness.preview.isPlaying = false;
     rerender(<GridRenderer ctx={rendererCtx()} />);
-    expect(screen.queryByTestId("lerobot-grid-hover-video")).toBeNull();
+    expect(screen.getByTestId("lerobot-grid-hover-video").dataset.playing).toBe(
+      "false",
+    );
     expect(screen.getByTestId("bitmap-cached-image-view")).toBeTruthy();
   });
 

--- a/app/packages/multimodal/src/views/episode/grid/GridRenderer.test.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/GridRenderer.test.tsx
@@ -21,7 +21,11 @@ import {
   gridLiveLeaseStats,
   resetGridLiveLeasesForTests,
 } from "../../../visualization/webgpu/webgpu-live-lease";
-import type { ByteSourceDescriptor, EpisodePosterFrame } from "../../../ir";
+import type {
+  ByteSourceDescriptor,
+  EpisodePosterFrame,
+  EpisodePreviewNativeVideo,
+} from "../../../ir";
 import {
   gridPreviewStateKey,
   pointCloudPoseKey,
@@ -89,6 +93,8 @@ const previewHarness = vi.hoisted(() => ({
     frame: null as EpisodePosterFrame | null,
     hasPreviewStreams: false,
     isBuffering: false,
+    isPlaying: false,
+    nativeVideo: null as EpisodePreviewNativeVideo | null,
     pause: vi.fn(),
     play: vi.fn(),
     streamId: null as string | null,
@@ -206,6 +212,10 @@ vi.mock("./use-grid-poster-provider", () => ({
   useProvidedGridPoster: () => providerHarness.poster,
 }));
 
+vi.mock("./LeRobotGridHoverVideo", () => ({
+  LeRobotGridHoverVideo: () => <div data-testid="lerobot-grid-hover-video" />,
+}));
+
 vi.mock("./grid-camera-state", () => ({
   useGridCameraPose: vi.fn(() => [
     cameraPoseHarness.pose,
@@ -320,6 +330,8 @@ afterEach(() => {
   previewHarness.preview.frame = null;
   previewHarness.preview.hasPreviewStreams = false;
   previewHarness.preview.isBuffering = false;
+  previewHarness.preview.isPlaying = false;
+  previewHarness.preview.nativeVideo = null;
   previewHarness.preview.status = "idle";
   previewHarness.preview.streamId = null;
   previewHarness.preview.streamSourceName = null;
@@ -621,6 +633,41 @@ describe("GridRenderer", () => {
 
     expect(screen.queryByTestId("bitmap-cached-image-view")).toBeNull();
     expect(screen.getByTestId("bitmap-image-view")).toBeTruthy();
+  });
+
+  it("mounts native LeRobot playback over the retained poster only while playing", () => {
+    previewHarness.preview.cachedPoster = {
+      bytes: new Uint8Array([1, 2, 3]),
+      height: 180,
+      mimeType: "image/webp",
+      sourceKind: "image",
+      streamId: "/cam/video",
+      streamSourceName: "/cam/video",
+      streamSourceNames: ["/cam/video"],
+      width: 320,
+    };
+    previewHarness.preview.frame = videoFrame(new Uint8Array([9, 9, 9]));
+    previewHarness.preview.nativeVideo = {
+      endTimeSeconds: 37.5,
+      source: { sourceId: "video", url: "/asset/video.mp4" },
+      startTimeSeconds: 14.2,
+    };
+    previewHarness.preview.status = "ready";
+    previewHarness.preview.streamId = "/cam/video";
+    const { rerender } = render(<GridRenderer ctx={rendererCtx()} />);
+
+    expect(screen.getByTestId("bitmap-cached-image-view")).toBeTruthy();
+    expect(screen.queryByTestId("lerobot-grid-hover-video")).toBeNull();
+
+    previewHarness.preview.isPlaying = true;
+    rerender(<GridRenderer ctx={rendererCtx()} />);
+    expect(screen.getByTestId("bitmap-cached-image-view")).toBeTruthy();
+    expect(screen.getByTestId("lerobot-grid-hover-video")).toBeTruthy();
+
+    previewHarness.preview.isPlaying = false;
+    rerender(<GridRenderer ctx={rendererCtx()} />);
+    expect(screen.queryByTestId("lerobot-grid-hover-video")).toBeNull();
+    expect(screen.getByTestId("bitmap-cached-image-view")).toBeTruthy();
   });
 
   it("shows a tiny buffering indicator over the last rendered frame", () => {

--- a/app/packages/multimodal/src/views/episode/grid/GridRenderer.test.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/GridRenderer.test.tsx
@@ -25,7 +25,10 @@ import type {
   ByteSourceDescriptor,
   EpisodePosterFrame,
   EpisodePreviewNativeVideo,
+  EpisodePreviewReadResult,
 } from "../../../ir";
+import { PushVideoAccessUnitReader } from "../../../video/push-reader";
+import { H264_REORDERED_DECODE_LOOKAHEAD_NS } from "../../../video/stream-engine";
 import {
   gridPreviewStateKey,
   pointCloudPoseKey,
@@ -87,6 +90,7 @@ function renderWithMatches(ui: ReactElement, byEpisode: PublishedWindows) {
 }
 
 const previewHarness = vi.hoisted(() => ({
+  onReadResult: null as ((result: EpisodePreviewReadResult) => void) | null,
   preview: {
     cachedPoster: null as GridPosterCacheEntry | null,
     error: null as string | null,
@@ -204,7 +208,14 @@ vi.mock("../../session/use-episode-preview-session", () => ({
 }));
 
 vi.mock("./use-grid-preview", () => ({
-  useGridPreview: vi.fn(() => previewHarness.preview),
+  useGridPreview: vi.fn(
+    (options: {
+      readonly onReadResult?: (result: EpisodePreviewReadResult) => void;
+    }) => {
+      previewHarness.onReadResult = options.onReadResult ?? null;
+      return previewHarness.preview;
+    },
+  ),
 }));
 
 vi.mock("./use-grid-poster-provider", () => ({
@@ -325,6 +336,7 @@ afterEach(() => {
   bitmapViewHarness.lastProps = null;
   setGridFit = null;
   cameraPoseHarness.pose = null;
+  previewHarness.onReadResult = null;
   previewHarness.preview.error = null;
   previewHarness.preview.cachedPoster = null;
   previewHarness.preview.frame = null;
@@ -493,9 +505,48 @@ describe("GridRenderer", () => {
     });
 
     expect(vi.mocked(useGridPreview).mock.lastCall?.[0]).toMatchObject({
+      initialVideoDecodeLookaheadNs: H264_REORDERED_DECODE_LOOKAHEAD_NS,
       posterStartTimeNs: null,
       posterSourceName: null,
     });
+  });
+
+  it("retains the complete initial H.264 decode runway", () => {
+    sourceHarness.byteSource = {
+      sourceId: "video-runway",
+      url: "memory://video-runway",
+    };
+    const push = vi.spyOn(PushVideoAccessUnitReader.prototype, "push");
+    render(<GridRenderer ctx={rendererCtx()} />);
+
+    const keyframe = videoFrame(new Uint8Array([1]), 0n, true);
+    const successor = videoFrame(new Uint8Array([2]), 33_333_333n, false);
+    act(() => {
+      previewHarness.onReadResult?.({
+        frame: keyframe,
+        frameTimeNs: 0n,
+        streamId: "/camera/front",
+        streamSourceName: "/camera/front",
+        streamSourceNames: ["/camera/front"],
+        status: "ready",
+        videoDecodeRunway: [keyframe, successor],
+      });
+    });
+
+    expect(push.mock.calls).toEqual([
+      [
+        "/camera/front",
+        expect.objectContaining({ frame: keyframe.image, timeNs: 0n }),
+      ],
+      [
+        "/camera/front",
+        expect.objectContaining({
+          frame: successor.image,
+          timeNs: 33_333_333n,
+        }),
+      ],
+    ]);
+    push.mockRestore();
   });
 
   it("renders a cached point-cloud poster with point-cloud activation semantics", () => {
@@ -1272,19 +1323,23 @@ function imageFrame(bytes: Uint8Array): EpisodePosterFrame {
   } as unknown as EpisodePosterFrame;
 }
 
-function videoFrame(bytes: Uint8Array): EpisodePosterFrame {
+function videoFrame(
+  bytes: Uint8Array,
+  timestampNs = 0n,
+  keyframe = true,
+): Extract<EpisodePosterFrame, { kind: "image" }> {
   return {
     image: {
       bytes,
       codec: "h264",
       format: "h264",
       h264: { codecString: "avc1.4D001F", hasFrame: true },
-      keyframe: true,
+      keyframe,
       kind: "encoded-video",
-      timestampNs: 0n,
+      timestampNs,
     },
     kind: "image",
-  } as unknown as EpisodePosterFrame;
+  } as unknown as Extract<EpisodePosterFrame, { kind: "image" }>;
 }
 
 function pointCloudFrame(): EpisodePosterFrame {

--- a/app/packages/multimodal/src/views/episode/grid/GridRenderer.test.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/GridRenderer.test.tsx
@@ -148,6 +148,10 @@ const gridStreamHarness = vi.hoisted(() => ({
   selected: "__auto__",
 }));
 
+const nativeVideoHarness = vi.hoisted(() => ({
+  onError: null as ((error: Error) => void) | null,
+}));
+
 const providerHarness = vi.hoisted(() => ({
   descriptor: {
     resolved: null as ResolvedGridPosterProviderDescriptor | null,
@@ -224,12 +228,21 @@ vi.mock("./use-grid-poster-provider", () => ({
 }));
 
 vi.mock("./LeRobotGridHoverVideo", () => ({
-  LeRobotGridHoverVideo: ({ playing }: { readonly playing?: boolean }) => (
-    <div
-      data-playing={playing ? "true" : "false"}
-      data-testid="lerobot-grid-hover-video"
-    />
-  ),
+  LeRobotGridHoverVideo: ({
+    onError,
+    playing,
+  }: {
+    readonly onError: (error: Error) => void;
+    readonly playing?: boolean;
+  }) => {
+    nativeVideoHarness.onError = onError;
+    return (
+      <div
+        data-playing={playing ? "true" : "false"}
+        data-testid="lerobot-grid-hover-video"
+      />
+    );
+  },
 }));
 
 vi.mock("./grid-camera-state", () => ({
@@ -359,6 +372,7 @@ afterEach(() => {
   posterCaptureHarness.capture.mockReset();
   sourceHarness.byteSource = null;
   gridStreamHarness.selected = "__auto__";
+  nativeVideoHarness.onError = null;
   providerHarness.descriptor = { resolved: null, status: "miss" };
   providerHarness.poster = { entry: null, status: "miss" };
 });
@@ -732,6 +746,33 @@ describe("GridRenderer", () => {
       "false",
     );
     expect(screen.getByTestId("bitmap-cached-image-view")).toBeTruthy();
+  });
+
+  it("shows native playback failures over a retained poster", () => {
+    previewHarness.preview.cachedPoster = {
+      bytes: new Uint8Array([1, 2, 3]),
+      height: 180,
+      mimeType: "image/webp",
+      sourceKind: "image",
+      streamId: "/cam/video",
+      streamSourceName: "/cam/video",
+      streamSourceNames: ["/cam/video"],
+      width: 320,
+    };
+    previewHarness.preview.nativeVideo = {
+      codec: "h264",
+      codecString: "avc1.64000a",
+      endTimeSeconds: 37.5,
+      source: { sourceId: "video", url: "/asset/video.mp4" },
+      startTimeSeconds: 14.2,
+    };
+    previewHarness.preview.status = "ready";
+
+    render(<GridRenderer ctx={rendererCtx()} />);
+    act(() => nativeVideoHarness.onError?.(new Error("Native decode failed")));
+
+    expect(screen.getByTestId("bitmap-cached-image-view")).toBeTruthy();
+    expect(screen.getByRole("alert").textContent).toBe("Native decode failed");
   });
 
   it("shows a tiny buffering indicator over the last rendered frame", () => {

--- a/app/packages/multimodal/src/views/episode/grid/GridRenderer.test.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/GridRenderer.test.tsx
@@ -108,6 +108,7 @@ const bitmapViewHarness = vi.hoisted(() => ({
       canvas: HTMLCanvasElement,
       size: { readonly height: number; readonly width: number },
     ) => void;
+    videoPriority?: "playing" | "visible";
   } | null,
 }));
 
@@ -239,6 +240,7 @@ vi.mock("../../../visualization/media-2d/BitmapImageView", async () => {
         canvas: HTMLCanvasElement,
         size: { readonly height: number; readonly width: number },
       ) => void;
+      readonly videoPriority?: "playing" | "visible";
     }) => {
       bitmapHostHarness.lastBitmap = bitmap;
       bitmapHostHarness.onCanvasCommitted = onCanvasCommitted ?? null;
@@ -726,12 +728,14 @@ describe("GridRenderer", () => {
     previewHarness.preview.status = "ready";
 
     render(<GridRenderer ctx={rendererCtx()} />);
+    expect(bitmapViewHarness.lastProps?.videoPriority).toBe("visible");
     const root = screen.getByTestId("bitmap-image-view").parentElement;
     if (!root) {
       throw new Error("Expected bitmap view to have a grid root");
     }
 
     fireEvent.pointerOver(root);
+    expect(bitmapViewHarness.lastProps?.videoPriority).toBe("playing");
     expect(vi.mocked(useGridPreview)).toHaveBeenLastCalledWith(
       expect.objectContaining({ hovered: true }),
     );
@@ -741,6 +745,7 @@ describe("GridRenderer", () => {
     expect(previewHarness.preview.play).not.toHaveBeenCalled();
 
     fireEvent.pointerOut(root);
+    expect(bitmapViewHarness.lastProps?.videoPriority).toBe("visible");
     expect(vi.mocked(useGridPreview)).toHaveBeenLastCalledWith(
       expect.objectContaining({ hovered: false }),
     );

--- a/app/packages/multimodal/src/views/episode/grid/GridRenderer.test.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/GridRenderer.test.tsx
@@ -590,6 +590,37 @@ describe("GridRenderer", () => {
     );
   });
 
+  it("keeps the cached poster visible until a new image decode family commits", () => {
+    previewHarness.preview.cachedPoster = {
+      bytes: new Uint8Array([1, 2, 3]),
+      height: 180,
+      mimeType: "image/webp",
+      sourceKind: "image",
+      streamId: "/cam/video",
+      streamSourceName: "/cam/video",
+      streamSourceNames: ["/cam/video"],
+      width: 320,
+    };
+    previewHarness.preview.frame = videoFrame(new Uint8Array([9, 9, 9]));
+    previewHarness.preview.status = "ready";
+    previewHarness.preview.streamId = "/cam/video";
+
+    render(<GridRenderer ctx={rendererCtx()} />);
+
+    expect(screen.getByTestId("bitmap-cached-image-view")).toBeTruthy();
+    expect(screen.getByTestId("bitmap-image-view")).toBeTruthy();
+
+    act(() => {
+      bitmapViewHarness.lastProps?.onCanvasCommitted?.(
+        document.createElement("canvas"),
+        { height: 180, width: 320 },
+      );
+    });
+
+    expect(screen.queryByTestId("bitmap-cached-image-view")).toBeNull();
+    expect(screen.getByTestId("bitmap-image-view")).toBeTruthy();
+  });
+
   it("shows a tiny buffering indicator over the last rendered frame", () => {
     previewHarness.preview.frame = imageFrame(new Uint8Array([1]));
     previewHarness.preview.isBuffering = true;
@@ -1185,6 +1216,21 @@ function pointCloudCells(): HTMLElement[] {
 function imageFrame(bytes: Uint8Array): EpisodePosterFrame {
   return {
     image: { bytes, kind: "encoded-image", mimeType: "image/jpeg" },
+    kind: "image",
+  } as unknown as EpisodePosterFrame;
+}
+
+function videoFrame(bytes: Uint8Array): EpisodePosterFrame {
+  return {
+    image: {
+      bytes,
+      codec: "h264",
+      format: "h264",
+      h264: { codecString: "avc1.4D001F", hasFrame: true },
+      keyframe: true,
+      kind: "encoded-video",
+      timestampNs: 0n,
+    },
     kind: "image",
   } as unknown as EpisodePosterFrame;
 }

--- a/app/packages/multimodal/src/views/episode/grid/GridRenderer.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/GridRenderer.tsx
@@ -23,6 +23,7 @@ import { PushVideoAccessUnitReader } from "../../../video/push-reader";
 import { VideoPlaybackManagerProvider } from "../../../video/react";
 import { H264_REORDERED_DECODE_LOOKAHEAD_NS } from "../../../video/stream-engine";
 import type { VideoStreamLease } from "../../../video/playback-manager";
+import { isSharedEncodedVideoVisualization } from "../../../video/types";
 import { PointCloudPanel } from "../../../visualization/composition";
 import { acquireGridLiveLease } from "../../../visualization/webgpu/webgpu-live-lease";
 import { renderPointCloudSnapshot } from "../../../visualization/scene-3d/gpu/webgpu-snapshot-renderer";
@@ -434,7 +435,7 @@ interface GridVideoPlaybackController {
 }
 
 /**
- * Pushes every H.264 access unit into one mounted source/stream engine, even
+ * Pushes every supported video access unit into one source/stream engine, even
  * when the 12fps grid presentation policy skips the corresponding React
  * frame. The bitmap consumer then subscribes to that same engine.
  */
@@ -491,8 +492,7 @@ function useGridVideoPlayback(sourceKey: string | null): {
       if (
         !image ||
         image.kind !== "encoded-video" ||
-        image.codec !== "h264" ||
-        image.h264.hasFrame === false
+        !isSharedEncodedVideoVisualization(image)
       ) {
         continue;
       }

--- a/app/packages/multimodal/src/views/episode/grid/GridRenderer.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/GridRenderer.tsx
@@ -716,6 +716,7 @@ function PreviewFrame({
       cachedPoster={cachedPoster}
       frame={frame}
       imageFit={imageFit}
+      hovered={hovered}
       onCanvasCommitted={onCanvasCommitted}
       onSurfaceRetainedBytesChange={onSurfaceRetainedBytesChange}
       videoStream={videoStream}
@@ -1032,6 +1033,7 @@ function ImagePreviewFrame({
   cachedPoster,
   frame,
   imageFit,
+  hovered,
   onCanvasCommitted,
   onSurfaceRetainedBytesChange,
   videoStream,
@@ -1039,6 +1041,7 @@ function ImagePreviewFrame({
   readonly cachedPoster: GridPosterCacheEntry | null;
   readonly frame: Extract<EpisodePosterFrame, { kind: "image" }>;
   readonly imageFit: MultimodalGridFit;
+  readonly hovered: boolean;
   readonly onCanvasCommitted: (
     sourceKind: "image" | "point-cloud",
     canvas: HTMLCanvasElement,
@@ -1090,6 +1093,7 @@ function ImagePreviewFrame({
           onCanvasCommitted("image", canvas, size);
         }}
         onBitmapRetainedBytesChange={setFrameRetainedBytes}
+        videoPriority={hovered ? "playing" : "visible"}
         videoSessionKey={videoStream ?? undefined}
       />
     </>

--- a/app/packages/multimodal/src/views/episode/grid/GridRenderer.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/GridRenderer.tsx
@@ -28,7 +28,6 @@ import { renderPointCloudSnapshot } from "../../../visualization/scene-3d/gpu/we
 import { sampleDescriptorFromContext } from "../../session/episode-source";
 import { useEpisodePreviewSession } from "../../session/use-episode-preview-session";
 import { useStableEpisodeSource } from "../../session/use-stable-episode-source";
-import { episodeDisplayName } from "../../session/episode-label";
 import classes from "./GridRenderer.module.css";
 import { LoadingAscii } from "../shell/LoadingAscii";
 import {
@@ -102,7 +101,6 @@ export function GridRenderer({
     return sample._id ?? sample.id;
   }, [ctx.sample.sample]);
   const [selectedStream] = useGridSelectedStream(ctx.dataset.name);
-  const episodeLabel = episodeDisplayName(ctx.sample.sample);
   const selectedSourceName =
     selectedStream === GRID_STREAM_AUTO ? null : selectedStream;
   // A lasso/search in the embeddings panel posters this tile at its earliest
@@ -386,9 +384,6 @@ export function GridRenderer({
         >
           <Spinner size={Size.Xs} />
         </span>
-      ) : null}
-      {episodeLabel ? (
-        <span className={classes.episodeMetadata}>{episodeLabel}</span>
       ) : null}
     </div>
   );

--- a/app/packages/multimodal/src/views/episode/grid/GridRenderer.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/GridRenderer.tsx
@@ -28,6 +28,7 @@ import { renderPointCloudSnapshot } from "../../../visualization/scene-3d/gpu/we
 import { sampleDescriptorFromContext } from "../../session/episode-source";
 import { useEpisodePreviewSession } from "../../session/use-episode-preview-session";
 import { useStableEpisodeSource } from "../../session/use-stable-episode-source";
+import { episodeDisplayName } from "../../session/episode-label";
 import classes from "./GridRenderer.module.css";
 import { LoadingAscii } from "../shell/LoadingAscii";
 import {
@@ -101,6 +102,7 @@ export function GridRenderer({
     return sample._id ?? sample.id;
   }, [ctx.sample.sample]);
   const [selectedStream] = useGridSelectedStream(ctx.dataset.name);
+  const episodeLabel = episodeDisplayName(ctx.sample.sample);
   const selectedSourceName =
     selectedStream === GRID_STREAM_AUTO ? null : selectedStream;
   // A lasso/search in the embeddings panel posters this tile at its earliest
@@ -384,6 +386,9 @@ export function GridRenderer({
         >
           <Spinner size={Size.Xs} />
         </span>
+      ) : null}
+      {episodeLabel ? (
+        <span className={classes.episodeMetadata}>{episodeLabel}</span>
       ) : null}
     </div>
   );

--- a/app/packages/multimodal/src/views/episode/grid/GridRenderer.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/GridRenderer.tsx
@@ -21,6 +21,7 @@ import { retainedBinaryBytes } from "../../../runtime";
 import { VideoPlaybackManager } from "../../../video/playback-manager";
 import { PushVideoAccessUnitReader } from "../../../video/push-reader";
 import { VideoPlaybackManagerProvider } from "../../../video/react";
+import { H264_REORDERED_DECODE_LOOKAHEAD_NS } from "../../../video/stream-engine";
 import type { VideoStreamLease } from "../../../video/playback-manager";
 import { PointCloudPanel } from "../../../visualization/composition";
 import { acquireGridLiveLease } from "../../../visualization/webgpu/webgpu-live-lease";
@@ -222,6 +223,7 @@ export function GridRenderer({
     cachedPoster: effectivePoster,
     enabled: visible,
     hovered,
+    initialVideoDecodeLookaheadNs: H264_REORDERED_DECODE_LOOKAHEAD_NS,
     onReadResult: gridVideoPlayback.onReadResult,
     posterStartTimeNs: firstMatch?.startNs ?? null,
     posterSourceName: firstMatch?.stream ?? null,
@@ -447,21 +449,33 @@ function useGridVideoPlayback(sourceKey: string | null): {
 
   const onReadResult = useCallback((result: EpisodePreviewReadResult) => {
     const controller = controllerRef.current;
-    const image = result.frame?.kind === "image" ? result.frame.image : null;
     const stream = result.streamId;
-    if (
-      !controller ||
-      !image ||
-      image.kind !== "encoded-video" ||
-      image.codec !== "h264" ||
-      image.h264.hasFrame === false ||
-      !stream
-    ) {
-      return;
+    if (!controller || !stream) return;
+
+    const frames = result.videoDecodeRunway?.length
+      ? result.videoDecodeRunway
+      : result.frame
+        ? [result.frame]
+        : [];
+    let pushed = false;
+    for (const frame of frames) {
+      const image = frame.kind === "image" ? frame.image : null;
+      if (
+        !image ||
+        image.kind !== "encoded-video" ||
+        image.codec !== "h264" ||
+        image.h264.hasFrame === false
+      ) {
+        continue;
+      }
+      const timeNs =
+        image.timestampNs ??
+        (frame === result.frame ? result.frameTimeNs : undefined);
+      if (timeNs === undefined) continue;
+      controller.reader.push(stream, { frame: image, timeNs });
+      pushed = true;
     }
-    const timeNs = image.timestampNs ?? result.frameTimeNs;
-    if (timeNs === undefined) return;
-    controller.reader.push(stream, { frame: image, timeNs });
+    if (!pushed) return;
 
     let lease = controller.leases.get(stream);
     if (!lease) {

--- a/app/packages/multimodal/src/views/episode/grid/GridRenderer.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/GridRenderer.tsx
@@ -21,7 +21,7 @@ import { retainedBinaryBytes } from "../../../runtime";
 import { VideoPlaybackManager } from "../../../video/playback-manager";
 import { PushVideoAccessUnitReader } from "../../../video/push-reader";
 import { VideoPlaybackManagerProvider } from "../../../video/react";
-import { H264_REORDERED_DECODE_LOOKAHEAD_NS } from "../../../video/stream-engine";
+import { REORDERED_VIDEO_DECODE_LOOKAHEAD_NS } from "../../../video/stream-engine";
 import type { VideoStreamLease } from "../../../video/playback-manager";
 import { isSharedEncodedVideoVisualization } from "../../../video/types";
 import { PointCloudPanel } from "../../../visualization/composition";
@@ -224,7 +224,7 @@ export function GridRenderer({
     cachedPoster: effectivePoster,
     enabled: visible,
     hovered,
-    initialVideoDecodeLookaheadNs: H264_REORDERED_DECODE_LOOKAHEAD_NS,
+    initialVideoDecodeLookaheadNs: REORDERED_VIDEO_DECODE_LOOKAHEAD_NS,
     onReadResult: gridVideoPlayback.onReadResult,
     posterStartTimeNs: firstMatch?.startNs ?? null,
     posterSourceName: firstMatch?.stream ?? null,
@@ -259,6 +259,8 @@ export function GridRenderer({
   const [nativeSurfaceRetainedBytes, setNativeSurfaceRetainedBytes] =
     useState(0);
   const [nativeVideoError, setNativeVideoError] = useState<string | null>(null);
+  // This effect clears a native-playback failure when the selected episode
+  // video changes so a previous source cannot poison the next preview.
   useEffect(() => {
     setNativeVideoError(null);
   }, [preview.nativeVideo]);
@@ -1107,6 +1109,8 @@ function ImagePreviewFrame({
   const showFallback =
     cachedPoster !== null && committedKind !== frame.image.kind;
 
+  // This effect reports both canvases while a cached poster covers the first
+  // decode from a newly mounted image family.
   useEffect(() => {
     onSurfaceRetainedBytesChange(
       frameRetainedBytes + (showFallback ? fallbackRetainedBytes : 0),

--- a/app/packages/multimodal/src/views/episode/grid/GridRenderer.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/GridRenderer.tsx
@@ -56,6 +56,7 @@ import {
   useGridPosterProviderDescriptor,
   useProvidedGridPoster,
 } from "./use-grid-poster-provider";
+import { LeRobotGridHoverVideo } from "./LeRobotGridHoverVideo";
 
 // Trailing debounce for shared-pose and cell-resize re-snapshots: orbiting
 // the one hovered cell staleness-marks every visible point-cloud cell, so
@@ -384,6 +385,12 @@ export function GridRenderer({
         >
           <Spinner size={Size.Xs} />
         </span>
+      ) : null}
+      {preview.isPlaying && preview.nativeVideo ? (
+        <LeRobotGridHoverVideo
+          key={`${preview.nativeVideo.source.sourceId}:${preview.nativeVideo.startTimeSeconds}:${preview.nativeVideo.endTimeSeconds}`}
+          video={preview.nativeVideo}
+        />
       ) : null}
     </div>
   );

--- a/app/packages/multimodal/src/views/episode/grid/GridRenderer.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/GridRenderer.tsx
@@ -405,6 +405,14 @@ export function GridRenderer({
           status={nativeVideoError ? "error" : preview.status}
         />
       )}
+      {nativeVideoError && (preview.frame || preview.cachedPoster) ? (
+        <div
+          className={`${classes.error} ${classes.nativeVideoError}`}
+          role="alert"
+        >
+          {nativeVideoError}
+        </div>
+      ) : null}
       {preview.frame && preview.isBuffering ? (
         <span
           className={classes.bufferingIndicator}

--- a/app/packages/multimodal/src/views/episode/grid/GridRenderer.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/GridRenderer.tsx
@@ -713,6 +713,7 @@ function PreviewFrame({
     />
   ) : (
     <ImagePreviewFrame
+      cachedPoster={cachedPoster}
       frame={frame}
       imageFit={imageFit}
       onCanvasCommitted={onCanvasCommitted}
@@ -1028,12 +1029,14 @@ function PointCloudPreviewFrame({
 }
 
 function ImagePreviewFrame({
+  cachedPoster,
   frame,
   imageFit,
   onCanvasCommitted,
   onSurfaceRetainedBytesChange,
   videoStream,
 }: {
+  readonly cachedPoster: GridPosterCacheEntry | null;
   readonly frame: Extract<EpisodePosterFrame, { kind: "image" }>;
   readonly imageFit: MultimodalGridFit;
   readonly onCanvasCommitted: (
@@ -1044,19 +1047,52 @@ function ImagePreviewFrame({
   readonly onSurfaceRetainedBytesChange: (bytes: number) => void;
   readonly videoStream: string | null;
 }) {
+  const [committedKind, setCommittedKind] = useState<
+    Extract<EpisodePosterFrame, { kind: "image" }>["image"]["kind"] | null
+  >(null);
+  const [fallbackRetainedBytes, setFallbackRetainedBytes] = useState(0);
+  const [frameRetainedBytes, setFrameRetainedBytes] = useState(0);
+  const showFallback =
+    cachedPoster !== null && committedKind !== frame.image.kind;
+
+  useEffect(() => {
+    onSurfaceRetainedBytesChange(
+      frameRetainedBytes + (showFallback ? fallbackRetainedBytes : 0),
+    );
+  }, [
+    fallbackRetainedBytes,
+    frameRetainedBytes,
+    onSurfaceRetainedBytesChange,
+    showFallback,
+  ]);
+
   // GPU-free bitmap path: image preview cells hold zero WebGPU devices (the
-  // modal's ImagePanel is untouched).
+  // modal's ImagePanel is untouched). Keep the last poster under a newly
+  // mounted decode family so encoded-image -> encoded-video hover handoff
+  // cannot expose an empty canvas while its first presentation is pending.
   return (
-    <BitmapImageFrameView
-      className={classes.imagePanel}
-      fit={imageFit}
-      frame={frame.image}
-      onCanvasCommitted={(canvas, size) =>
-        onCanvasCommitted("image", canvas, size)
-      }
-      onBitmapRetainedBytesChange={onSurfaceRetainedBytesChange}
-      videoSessionKey={videoStream ?? undefined}
-    />
+    <>
+      {showFallback ? (
+        <BitmapImageView
+          bytes={cachedPoster.bytes}
+          className={classes.imagePanel}
+          fit={imageFit}
+          mimeType={cachedPoster.mimeType}
+          onBitmapRetainedBytesChange={setFallbackRetainedBytes}
+        />
+      ) : null}
+      <BitmapImageFrameView
+        className={classes.imagePanel}
+        fit={imageFit}
+        frame={frame.image}
+        onCanvasCommitted={(canvas, size) => {
+          setCommittedKind(frame.image.kind);
+          onCanvasCommitted("image", canvas, size);
+        }}
+        onBitmapRetainedBytesChange={setFrameRetainedBytes}
+        videoSessionKey={videoStream ?? undefined}
+      />
+    </>
   );
 }
 

--- a/app/packages/multimodal/src/views/episode/grid/GridRenderer.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/GridRenderer.tsx
@@ -255,6 +255,12 @@ export function GridRenderer({
     readonly owner: EpisodePosterFrame | GridPosterCacheEntry;
   } | null>(null);
   const displayOwner = preview.frame ?? preview.cachedPoster;
+  const [nativeSurfaceRetainedBytes, setNativeSurfaceRetainedBytes] =
+    useState(0);
+  const [nativeVideoError, setNativeVideoError] = useState<string | null>(null);
+  useEffect(() => {
+    setNativeVideoError(null);
+  }, [preview.nativeVideo]);
   const surfaceRetainedBytes =
     surfaceRetention && surfaceRetention.owner === displayOwner
       ? surfaceRetention.bytes
@@ -321,13 +327,29 @@ export function GridRenderer({
       preview.streamSourceNames,
     ],
   );
+  const handleNativePosterCanvasCommitted = useCallback(
+    (canvas: HTMLCanvasElement, size: BitmapDrawSize) =>
+      handlePosterCanvasCommitted("image", canvas, size),
+    [handlePosterCanvasCommitted],
+  );
+  const handleNativeVideoError = useCallback(
+    (error: Error) => setNativeVideoError(error.message),
+    [],
+  );
 
   // This effect keeps the grid cache's retained-byte estimate current.
   useEffect(() => {
     onRetainedBytesChange?.(
-      retainedBinaryBytes(preview.frame) + surfaceRetainedBytes,
+      retainedBinaryBytes(preview.frame) +
+        surfaceRetainedBytes +
+        nativeSurfaceRetainedBytes,
     );
-  }, [onRetainedBytesChange, preview.frame, surfaceRetainedBytes]);
+  }, [
+    nativeSurfaceRetainedBytes,
+    onRetainedBytesChange,
+    preview.frame,
+    surfaceRetainedBytes,
+  ]);
 
   // This effect registers the sample's previewable streams for grid controls.
   useEffect(() => {
@@ -375,9 +397,9 @@ export function GridRenderer({
         />
       ) : (
         <PreviewStatus
-          error={preview.error}
+          error={nativeVideoError ?? preview.error}
           hasPreviewStreams={preview.hasPreviewStreams}
-          status={preview.status}
+          status={nativeVideoError ? "error" : preview.status}
         />
       )}
       {preview.frame && preview.isBuffering ? (
@@ -388,9 +410,15 @@ export function GridRenderer({
           <Spinner size={Size.Xs} />
         </span>
       ) : null}
-      {preview.isPlaying && preview.nativeVideo ? (
+      {preview.nativeVideo ? (
         <LeRobotGridHoverVideo
-          key={`${preview.nativeVideo.source.sourceId}:${preview.nativeVideo.startTimeSeconds}:${preview.nativeVideo.endTimeSeconds}`}
+          active={visible}
+          capturePoster={!preview.frame && !preview.cachedPoster}
+          key={`${preview.nativeVideo.source.sourceId}:${preview.nativeVideo.codec}:${preview.nativeVideo.startTimeSeconds}:${preview.nativeVideo.endTimeSeconds}`}
+          onCanvasCommitted={handleNativePosterCanvasCommitted}
+          onError={handleNativeVideoError}
+          onSurfaceRetainedBytesChange={setNativeSurfaceRetainedBytes}
+          playing={preview.isPlaying}
           video={preview.nativeVideo}
         />
       ) : null}

--- a/app/packages/multimodal/src/views/episode/grid/LeRobotGridHoverVideo.test.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/LeRobotGridHoverVideo.test.tsx
@@ -9,6 +9,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { EpisodePreviewNativeVideo } from "../../../ir";
 import { LeRobotGridHoverVideo } from "./LeRobotGridHoverVideo";
+import { resetGridNativeVideoLeasesForTests } from "./grid-native-video-lease";
 
 type FrameCallback = (
   now: number,
@@ -21,6 +22,7 @@ const frameHarness = {
 };
 
 beforeEach(() => {
+  resetGridNativeVideoLeasesForTests();
   frameHarness.callbacks.clear();
   frameHarness.nextHandle = 1;
   Object.defineProperty(
@@ -52,10 +54,19 @@ beforeEach(() => {
     () => undefined,
   );
   vi.spyOn(HTMLMediaElement.prototype, "play").mockResolvedValue(undefined);
+  Object.defineProperty(HTMLVideoElement.prototype, "videoWidth", {
+    configurable: true,
+    get: () => 320,
+  });
+  Object.defineProperty(HTMLVideoElement.prototype, "videoHeight", {
+    configurable: true,
+    get: () => 180,
+  });
 });
 
 afterEach(() => {
   cleanup();
+  resetGridNativeVideoLeasesForTests();
   vi.restoreAllMocks();
 });
 
@@ -83,7 +94,7 @@ describe("LeRobotGridHoverVideo", () => {
     expect(screen.getByTestId("cached-poster")).toBeTruthy();
     expect(element.style.visibility).not.toBe("visible");
 
-    presentFrame(14.2);
+    presentFrame(14.1995);
     expect(element.style.visibility).toBe("visible");
     expect(screen.getByTestId("cached-poster")).toBeTruthy();
   });
@@ -127,6 +138,70 @@ describe("LeRobotGridHoverVideo", () => {
     expect(element.style.visibility).not.toBe("visible");
   });
 
+  it("captures and retains an uncached native poster without playing", () => {
+    const drawImage = vi.fn();
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockImplementation(
+      () => ({ drawImage }) as unknown as never,
+    );
+    const onCanvasCommitted = vi.fn();
+    const onSurfaceRetainedBytesChange = vi.fn();
+    render(
+      <LeRobotGridHoverVideo
+        capturePoster
+        onCanvasCommitted={onCanvasCommitted}
+        onSurfaceRetainedBytesChange={onSurfaceRetainedBytesChange}
+        playing={false}
+        video={nativeVideo(14.2, 37.5)}
+      />,
+    );
+    const element = screen.getByTestId(
+      "lerobot-grid-hover-video",
+    ) as HTMLVideoElement;
+    const poster = screen.getByTestId(
+      "lerobot-grid-native-poster",
+    ) as HTMLCanvasElement;
+
+    fireEvent.loadedMetadata(element);
+    expect(element.currentTime).toBe(14.2);
+    expect(HTMLMediaElement.prototype.play).not.toHaveBeenCalled();
+
+    Object.defineProperty(element, "readyState", {
+      configurable: true,
+      value: 4,
+    });
+    presentFrame(14.2);
+    expect(drawImage).toHaveBeenCalledWith(element, 0, 0, 320, 180);
+    expect(onCanvasCommitted).toHaveBeenCalledWith(poster, {
+      height: 180,
+      width: 320,
+    });
+    expect(onSurfaceRetainedBytesChange).toHaveBeenCalledWith(320 * 180 * 4);
+    expect(poster.style.visibility).toBe("visible");
+    expect(element.getAttribute("src")).toBeNull();
+  });
+
+  it("reports native AV1 capability failure without loading the asset", () => {
+    vi.spyOn(HTMLMediaElement.prototype, "canPlayType").mockReturnValue("");
+    const onError = vi.fn();
+
+    render(
+      <LeRobotGridHoverVideo
+        onError={onError}
+        video={nativeVideo(0, 1, "av1")}
+      />,
+    );
+
+    const element = screen.getByTestId(
+      "lerobot-grid-hover-video",
+    ) as HTMLVideoElement;
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "AV1 video playback is unsupported by this browser",
+      }),
+    );
+    expect(element.getAttribute("src")).toBeNull();
+  });
+
   it("cancels frame work and releases the media source on cleanup", () => {
     const { unmount } = render(
       <LeRobotGridHoverVideo video={nativeVideo(30, 31)} />,
@@ -152,8 +227,11 @@ describe("LeRobotGridHoverVideo", () => {
 function nativeVideo(
   startTimeSeconds: number,
   endTimeSeconds: number,
+  codec: EpisodePreviewNativeVideo["codec"] = "h264",
 ): EpisodePreviewNativeVideo {
   return {
+    codec,
+    codecString: codec === "av1" ? "av01.0.00M.08" : "avc1.64000a",
     endTimeSeconds,
     source: {
       sourceId: "video",

--- a/app/packages/multimodal/src/views/episode/grid/LeRobotGridHoverVideo.test.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/LeRobotGridHoverVideo.test.tsx
@@ -6,6 +6,7 @@ import {
   screen,
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ComponentProps } from "react";
 
 import type { EpisodePreviewNativeVideo } from "../../../ir";
 import { LeRobotGridHoverVideo } from "./LeRobotGridHoverVideo";
@@ -75,7 +76,7 @@ describe("LeRobotGridHoverVideo", () => {
     render(
       <>
         <div data-testid="cached-poster" />
-        <LeRobotGridHoverVideo video={nativeVideo(14.2, 37.533333)} />
+        <TestLeRobotGridHoverVideo video={nativeVideo(14.2, 37.533333)} />
       </>,
     );
     const element = screen.getByTestId(
@@ -100,7 +101,7 @@ describe("LeRobotGridHoverVideo", () => {
   });
 
   it("hides and loops before presenting the adjacent episode", () => {
-    render(<LeRobotGridHoverVideo video={nativeVideo(10, 12)} />);
+    render(<TestLeRobotGridHoverVideo video={nativeVideo(10, 12)} />);
     const element = screen.getByTestId(
       "lerobot-grid-hover-video",
     ) as HTMLVideoElement;
@@ -123,7 +124,7 @@ describe("LeRobotGridHoverVideo", () => {
       "requestVideoFrameCallback",
       { configurable: true, value: undefined },
     );
-    render(<LeRobotGridHoverVideo video={nativeVideo(20, 21)} />);
+    render(<TestLeRobotGridHoverVideo video={nativeVideo(20, 21)} />);
     const element = screen.getByTestId(
       "lerobot-grid-hover-video",
     ) as HTMLVideoElement;
@@ -146,7 +147,7 @@ describe("LeRobotGridHoverVideo", () => {
     const onCanvasCommitted = vi.fn();
     const onSurfaceRetainedBytesChange = vi.fn();
     render(
-      <LeRobotGridHoverVideo
+      <TestLeRobotGridHoverVideo
         capturePoster
         onCanvasCommitted={onCanvasCommitted}
         onSurfaceRetainedBytesChange={onSurfaceRetainedBytesChange}
@@ -185,7 +186,7 @@ describe("LeRobotGridHoverVideo", () => {
     const onError = vi.fn();
 
     render(
-      <LeRobotGridHoverVideo
+      <TestLeRobotGridHoverVideo
         onError={onError}
         video={nativeVideo(0, 1, "av1")}
       />,
@@ -204,7 +205,7 @@ describe("LeRobotGridHoverVideo", () => {
 
   it("cancels frame work and releases the media source on cleanup", () => {
     const { unmount } = render(
-      <LeRobotGridHoverVideo video={nativeVideo(30, 31)} />,
+      <TestLeRobotGridHoverVideo video={nativeVideo(30, 31)} />,
     );
     const element = screen.getByTestId(
       "lerobot-grid-hover-video",
@@ -239,6 +240,29 @@ function nativeVideo(
     },
     startTimeSeconds,
   };
+}
+
+function TestLeRobotGridHoverVideo({
+  active = true,
+  capturePoster = false,
+  onCanvasCommitted = () => undefined,
+  onError = () => undefined,
+  onSurfaceRetainedBytesChange = () => undefined,
+  playing = true,
+  video,
+}: Pick<ComponentProps<typeof LeRobotGridHoverVideo>, "video"> &
+  Partial<Omit<ComponentProps<typeof LeRobotGridHoverVideo>, "video">>) {
+  return (
+    <LeRobotGridHoverVideo
+      active={active}
+      capturePoster={capturePoster}
+      onCanvasCommitted={onCanvasCommitted}
+      onError={onError}
+      onSurfaceRetainedBytesChange={onSurfaceRetainedBytesChange}
+      playing={playing}
+      video={video}
+    />
+  );
 }
 
 function presentFrame(mediaTime: number): void {

--- a/app/packages/multimodal/src/views/episode/grid/LeRobotGridHoverVideo.test.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/LeRobotGridHoverVideo.test.tsx
@@ -203,6 +203,39 @@ describe("LeRobotGridHoverVideo", () => {
     expect(element.getAttribute("src")).toBeNull();
   });
 
+  it("releases native media state when playback fails", () => {
+    const onError = vi.fn();
+    render(
+      <TestLeRobotGridHoverVideo onError={onError} video={nativeVideo(0, 1)} />,
+    );
+    const element = screen.getByTestId(
+      "lerobot-grid-hover-video",
+    ) as HTMLVideoElement;
+
+    fireEvent.error(element);
+
+    expect(onError).toHaveBeenCalledWith(
+      new Error("Unable to play native H264 video"),
+    );
+    expect(element.getAttribute("src")).toBeNull();
+    expect(HTMLMediaElement.prototype.load).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps the media lifecycle stable across callback-only rerenders", () => {
+    const rendered = render(
+      <TestLeRobotGridHoverVideo video={nativeVideo(0, 1)} />,
+    );
+    const element = screen.getByTestId(
+      "lerobot-grid-hover-video",
+    ) as HTMLVideoElement;
+    expect(HTMLMediaElement.prototype.load).toHaveBeenCalledOnce();
+
+    rendered.rerender(<TestLeRobotGridHoverVideo video={nativeVideo(0, 1)} />);
+
+    expect(HTMLMediaElement.prototype.load).toHaveBeenCalledOnce();
+    expect(element.getAttribute("src")).toContain("/asset/video.mp4");
+  });
+
   it("cancels frame work and releases the media source on cleanup", () => {
     const { unmount } = render(
       <TestLeRobotGridHoverVideo video={nativeVideo(30, 31)} />,

--- a/app/packages/multimodal/src/views/episode/grid/LeRobotGridHoverVideo.test.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/LeRobotGridHoverVideo.test.tsx
@@ -1,0 +1,172 @@
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { EpisodePreviewNativeVideo } from "../../../ir";
+import { LeRobotGridHoverVideo } from "./LeRobotGridHoverVideo";
+
+type FrameCallback = (
+  now: number,
+  metadata: { readonly mediaTime: number },
+) => void;
+
+const frameHarness = {
+  callbacks: new Map<number, FrameCallback>(),
+  nextHandle: 1,
+};
+
+beforeEach(() => {
+  frameHarness.callbacks.clear();
+  frameHarness.nextHandle = 1;
+  Object.defineProperty(
+    HTMLVideoElement.prototype,
+    "requestVideoFrameCallback",
+    {
+      configurable: true,
+      value: vi.fn((callback: FrameCallback) => {
+        const handle = frameHarness.nextHandle++;
+        frameHarness.callbacks.set(handle, callback);
+        return handle;
+      }),
+    },
+  );
+  Object.defineProperty(
+    HTMLVideoElement.prototype,
+    "cancelVideoFrameCallback",
+    {
+      configurable: true,
+      value: vi.fn((handle: number) => {
+        frameHarness.callbacks.delete(handle);
+      }),
+    },
+  );
+  vi.spyOn(HTMLMediaElement.prototype, "load").mockImplementation(
+    () => undefined,
+  );
+  vi.spyOn(HTMLMediaElement.prototype, "pause").mockImplementation(
+    () => undefined,
+  );
+  vi.spyOn(HTMLMediaElement.prototype, "play").mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("LeRobotGridHoverVideo", () => {
+  it("maps hover playback onto the asset interval before revealing video", () => {
+    render(
+      <>
+        <div data-testid="cached-poster" />
+        <LeRobotGridHoverVideo video={nativeVideo(14.2, 37.533333)} />
+      </>,
+    );
+    const element = screen.getByTestId(
+      "lerobot-grid-hover-video",
+    ) as HTMLVideoElement;
+
+    expect(element.muted).toBe(true);
+    expect(element.playsInline).toBe(true);
+    expect(element.preload).toBe("metadata");
+    expect(element.getAttribute("src")).toContain("/asset/video.mp4");
+    expect(element.style.visibility).not.toBe("visible");
+
+    fireEvent.loadedMetadata(element);
+    expect(element.currentTime).toBe(14.2);
+    expect(HTMLMediaElement.prototype.play).toHaveBeenCalledOnce();
+    expect(screen.getByTestId("cached-poster")).toBeTruthy();
+    expect(element.style.visibility).not.toBe("visible");
+
+    presentFrame(14.2);
+    expect(element.style.visibility).toBe("visible");
+    expect(screen.getByTestId("cached-poster")).toBeTruthy();
+  });
+
+  it("hides and loops before presenting the adjacent episode", () => {
+    render(<LeRobotGridHoverVideo video={nativeVideo(10, 12)} />);
+    const element = screen.getByTestId(
+      "lerobot-grid-hover-video",
+    ) as HTMLVideoElement;
+    fireEvent.loadedMetadata(element);
+    presentFrame(11.9);
+    expect(element.style.visibility).toBe("visible");
+
+    presentFrame(12);
+    expect(element.currentTime).toBe(10);
+    expect(element.style.visibility).not.toBe("visible");
+    expect(HTMLMediaElement.prototype.play).toHaveBeenCalledTimes(2);
+
+    presentFrame(10);
+    expect(element.style.visibility).toBe("visible");
+  });
+
+  it("uses media events when presented-frame callbacks are unavailable", () => {
+    Object.defineProperty(
+      HTMLVideoElement.prototype,
+      "requestVideoFrameCallback",
+      { configurable: true, value: undefined },
+    );
+    render(<LeRobotGridHoverVideo video={nativeVideo(20, 21)} />);
+    const element = screen.getByTestId(
+      "lerobot-grid-hover-video",
+    ) as HTMLVideoElement;
+
+    fireEvent.loadedMetadata(element);
+    fireEvent.seeked(element);
+    expect(element.style.visibility).toBe("visible");
+
+    element.currentTime = 21;
+    fireEvent.timeUpdate(element);
+    expect(element.currentTime).toBe(20);
+    expect(element.style.visibility).not.toBe("visible");
+  });
+
+  it("cancels frame work and releases the media source on cleanup", () => {
+    const { unmount } = render(
+      <LeRobotGridHoverVideo video={nativeVideo(30, 31)} />,
+    );
+    const element = screen.getByTestId(
+      "lerobot-grid-hover-video",
+    ) as HTMLVideoElement;
+    fireEvent.loadedMetadata(element);
+    const pendingHandle = [...frameHarness.callbacks.keys()][0];
+
+    unmount();
+
+    expect(
+      HTMLVideoElement.prototype.cancelVideoFrameCallback,
+    ).toHaveBeenCalledWith(pendingHandle);
+    expect(HTMLMediaElement.prototype.pause).toHaveBeenCalled();
+    expect(HTMLMediaElement.prototype.load).toHaveBeenCalled();
+    expect(element.getAttribute("src")).toBeNull();
+    expect(frameHarness.callbacks.size).toBe(0);
+  });
+});
+
+function nativeVideo(
+  startTimeSeconds: number,
+  endTimeSeconds: number,
+): EpisodePreviewNativeVideo {
+  return {
+    endTimeSeconds,
+    source: {
+      sourceId: "video",
+      url: "/asset/video.mp4",
+    },
+    startTimeSeconds,
+  };
+}
+
+function presentFrame(mediaTime: number): void {
+  const entry = [...frameHarness.callbacks.entries()][0];
+  if (!entry) throw new Error("Expected a pending video frame callback");
+  const [handle, callback] = entry;
+  frameHarness.callbacks.delete(handle);
+  act(() => callback(performance.now(), { mediaTime }));
+}

--- a/app/packages/multimodal/src/views/episode/grid/LeRobotGridHoverVideo.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/LeRobotGridHoverVideo.tsx
@@ -23,28 +23,30 @@ type VideoWithFrameCallbacks = HTMLVideoElement & {
 // One millisecond accepts that representation loss while remaining far below
 // one 15fps DROID frame, so an adjacent episode frame is never admitted.
 const START_TIME_EPSILON_SECONDS = 0.001;
+const POSTER_RETRY_INTERVAL_MS = 100;
+const POSTER_RETRY_LIMIT = 50;
 
 interface LeRobotGridHoverVideoProps {
-  readonly active?: boolean;
-  readonly capturePoster?: boolean;
-  readonly onCanvasCommitted?: (
+  readonly active: boolean;
+  readonly capturePoster: boolean;
+  readonly onCanvasCommitted: (
     canvas: HTMLCanvasElement,
     size: BitmapDrawSize,
   ) => void;
-  readonly onError?: (error: Error) => void;
-  readonly onSurfaceRetainedBytesChange?: (bytes: number) => void;
-  readonly playing?: boolean;
+  readonly onError: (error: Error) => void;
+  readonly onSurfaceRetainedBytesChange: (bytes: number) => void;
+  readonly playing: boolean;
   readonly video: EpisodePreviewNativeVideo;
 }
 
 /** Native MP4 grid surface constrained to one LeRobot episode interval. */
 export function LeRobotGridHoverVideo({
-  active = true,
-  capturePoster = false,
+  active,
+  capturePoster,
   onCanvasCommitted,
   onError,
   onSurfaceRetainedBytesChange,
-  playing = true,
+  playing,
   video,
 }: LeRobotGridHoverVideoProps) {
   const videoRef = useRef<HTMLVideoElement | null>(null);
@@ -57,13 +59,15 @@ export function LeRobotGridHoverVideo({
   const sourceUrl = getFetchUrl(video.source.url);
   const wantsMedia = active && (playing || (capturePoster && !posterReady));
 
+  // This effect owns one native decoder lease and its complete media-element
+  // lifecycle for the selected episode interval.
   useEffect(() => {
     if (!wantsMedia) return undefined;
     const element = videoRef.current as VideoWithFrameCallbacks | null;
     const poster = posterRef.current;
     if (!element || !poster) return undefined;
     if (codec === "av1" && !supportsNativeCodec(element, codecString)) {
-      onError?.(new Error("AV1 video playback is unsupported by this browser"));
+      onError(new Error("AV1 video playback is unsupported by this browser"));
       return undefined;
     }
 
@@ -137,8 +141,8 @@ export function LeRobotGridHoverVideo({
       context.drawImage(element, 0, 0, width, height);
       posterCaptured = true;
       poster.style.visibility = playing ? "hidden" : "visible";
-      onSurfaceRetainedBytesChange?.(width * height * 4);
-      onCanvasCommitted?.(poster, { height, width });
+      onSurfaceRetainedBytesChange(width * height * 4);
+      onCanvasCommitted(poster, { height, width });
       posterReadyRef.current = true;
       setPosterReady(true);
       if (!playing) requestRef.current?.release();
@@ -148,7 +152,7 @@ export function LeRobotGridHoverVideo({
       if (disposed || playing || posterCaptured || posterRetryTimer !== null) {
         return;
       }
-      if (posterRetryCount >= 50) {
+      if (posterRetryCount >= POSTER_RETRY_LIMIT) {
         fail(new Error("Timed out waiting for a native video poster frame"));
         return;
       }
@@ -162,7 +166,7 @@ export function LeRobotGridHoverVideo({
         } catch (error) {
           fail(error);
         }
-      }, 100);
+      }, POSTER_RETRY_INTERVAL_MS);
     };
     const presentFallbackFrame = () => {
       if (
@@ -198,7 +202,7 @@ export function LeRobotGridHoverVideo({
       cancelPendingFrame();
       element?.pause();
       requestRef.current?.release();
-      onError?.(error instanceof Error ? error : new Error(String(error)));
+      onError(error instanceof Error ? error : new Error(String(error)));
     }
 
     function onPresentedFrame(
@@ -289,6 +293,8 @@ export function LeRobotGridHoverVideo({
     wantsMedia,
   ]);
 
+  // This effect releases the captured poster surface when the grid cell is no
+  // longer visible, even if the component remains mounted by virtualization.
   useEffect(() => {
     if (active) return;
     const poster = posterRef.current;
@@ -299,9 +305,10 @@ export function LeRobotGridHoverVideo({
     }
     posterReadyRef.current = false;
     setPosterReady(false);
-    onSurfaceRetainedBytesChange?.(0);
+    onSurfaceRetainedBytesChange(0);
   }, [active, onSurfaceRetainedBytesChange]);
 
+  // This effect clears retained poster memory and accounting on unmount.
   useEffect(
     () => () => {
       const poster = posterRef.current;
@@ -309,7 +316,7 @@ export function LeRobotGridHoverVideo({
         poster.width = 0;
         poster.height = 0;
       }
-      onSurfaceRetainedBytesChange?.(0);
+      onSurfaceRetainedBytesChange(0);
     },
     [onSurfaceRetainedBytesChange],
   );

--- a/app/packages/multimodal/src/views/episode/grid/LeRobotGridHoverVideo.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/LeRobotGridHoverVideo.tsx
@@ -1,0 +1,166 @@
+import { getFetchUrl } from "@fiftyone/utilities";
+import { useEffect, useRef } from "react";
+
+import type { EpisodePreviewNativeVideo } from "../../../ir";
+import classes from "./GridRenderer.module.css";
+
+type VideoFrameCallback = (
+  now: number,
+  metadata: { readonly mediaTime: number },
+) => void;
+
+type VideoWithFrameCallbacks = HTMLVideoElement & {
+  cancelVideoFrameCallback?: (handle: number) => void;
+  requestVideoFrameCallback?: (callback: VideoFrameCallback) => number;
+};
+
+/** Native MP4 hover surface constrained to one LeRobot episode interval. */
+export function LeRobotGridHoverVideo({
+  video,
+}: {
+  readonly video: EpisodePreviewNativeVideo;
+}) {
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const { endTimeSeconds, startTimeSeconds } = video;
+  const sourceUrl = getFetchUrl(video.source.url);
+
+  // This effect owns the native media lifecycle for exactly one hover. It
+  // seeks into the shared MP4, loops before the adjacent episode, and drops
+  // the source on cleanup so rapid hover changes cannot retain old work.
+  useEffect(() => {
+    const element = videoRef.current as VideoWithFrameCallbacks | null;
+    if (!element) return undefined;
+
+    const requestFrame = element.requestVideoFrameCallback;
+    const cancelFrame = element.cancelVideoFrameCallback;
+    const supportsFrameCallbacks = typeof requestFrame === "function";
+    let disposed = false;
+    let failed = false;
+    let frameHandle: number | null = null;
+    let playGeneration = 0;
+    let showingVideo = false;
+    element.style.visibility = "hidden";
+
+    const setShowingVideo = (showing: boolean) => {
+      if (showingVideo === showing) return;
+      showingVideo = showing;
+      element.style.visibility = showing ? "visible" : "hidden";
+    };
+    const inEpisode = (timeSeconds: number) =>
+      timeSeconds >= startTimeSeconds && timeSeconds < endTimeSeconds;
+    const cancelPendingFrame = () => {
+      const handle = frameHandle;
+      frameHandle = null;
+      if (handle !== null && typeof cancelFrame === "function") {
+        cancelFrame.call(element, handle);
+      }
+    };
+    const scheduleFrame = () => {
+      if (
+        disposed ||
+        frameHandle !== null ||
+        typeof requestFrame !== "function"
+      ) {
+        return;
+      }
+      frameHandle = requestFrame.call(element, onPresentedFrame);
+    };
+    const play = () => {
+      const generation = ++playGeneration;
+      void element.play().catch(() => {
+        if (!disposed && generation === playGeneration) {
+          setShowingVideo(false);
+        }
+      });
+    };
+    const playFromEpisodeStart = () => {
+      if (disposed || failed) return;
+      setShowingVideo(false);
+      cancelPendingFrame();
+      element.pause();
+      element.currentTime = startTimeSeconds;
+      scheduleFrame();
+      play();
+    };
+    const presentFallbackFrame = () => {
+      if (!supportsFrameCallbacks && inEpisode(element.currentTime)) {
+        setShowingVideo(true);
+      }
+    };
+    const onTimeUpdate = () => {
+      if (element.currentTime >= endTimeSeconds) {
+        playFromEpisodeStart();
+      } else if (element.currentTime < startTimeSeconds) {
+        setShowingVideo(false);
+      } else {
+        presentFallbackFrame();
+      }
+    };
+    const onError = () => {
+      failed = true;
+      playGeneration += 1;
+      setShowingVideo(false);
+      cancelPendingFrame();
+      element.pause();
+    };
+
+    function onPresentedFrame(
+      _now: number,
+      metadata: { readonly mediaTime: number },
+    ) {
+      frameHandle = null;
+      if (disposed) return;
+      if (metadata.mediaTime >= endTimeSeconds) {
+        playFromEpisodeStart();
+        return;
+      }
+      setShowingVideo(inEpisode(metadata.mediaTime));
+      scheduleFrame();
+    }
+
+    element.addEventListener("ended", playFromEpisodeStart);
+    element.addEventListener("error", onError);
+    element.addEventListener("loadeddata", presentFallbackFrame);
+    element.addEventListener("loadedmetadata", playFromEpisodeStart);
+    element.addEventListener("seeked", presentFallbackFrame);
+    element.addEventListener("timeupdate", onTimeUpdate);
+    setShowingVideo(false);
+    if (element.getAttribute("src") !== sourceUrl) {
+      element.setAttribute("src", sourceUrl);
+      element.load();
+    }
+
+    if (element.readyState >= 1) {
+      playFromEpisodeStart();
+    }
+
+    return () => {
+      disposed = true;
+      playGeneration += 1;
+      cancelPendingFrame();
+      element.removeEventListener("ended", playFromEpisodeStart);
+      element.removeEventListener("error", onError);
+      element.removeEventListener("loadeddata", presentFallbackFrame);
+      element.removeEventListener("loadedmetadata", playFromEpisodeStart);
+      element.removeEventListener("seeked", presentFallbackFrame);
+      element.removeEventListener("timeupdate", onTimeUpdate);
+      element.style.visibility = "hidden";
+      element.pause();
+      element.removeAttribute("src");
+      element.load();
+    };
+  }, [endTimeSeconds, sourceUrl, startTimeSeconds]);
+
+  return (
+    <video
+      aria-hidden
+      className={classes.nativeVideo}
+      data-testid="lerobot-grid-hover-video"
+      muted
+      playsInline
+      preload="metadata"
+      ref={videoRef}
+      src={sourceUrl}
+    />
+  );
+}

--- a/app/packages/multimodal/src/views/episode/grid/LeRobotGridHoverVideo.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/LeRobotGridHoverVideo.tsx
@@ -3,6 +3,7 @@ import { useEffect, useId, useRef, useState } from "react";
 
 import type { EpisodePreviewNativeVideo } from "../../../ir";
 import type { BitmapDrawSize } from "../../../visualization/media-2d/BitmapImageView";
+import { useLatestRef } from "../../../visualization/media-2d/use-latest-ref";
 import classes from "./GridRenderer.module.css";
 import {
   requestGridNativeVideoLease,
@@ -53,6 +54,11 @@ export function LeRobotGridHoverVideo({
   const posterRef = useRef<HTMLCanvasElement | null>(null);
   const posterReadyRef = useRef(false);
   const requestRef = useRef<GridNativeVideoLeaseRequest | null>(null);
+  const onCanvasCommittedRef = useLatestRef(onCanvasCommitted);
+  const onErrorRef = useLatestRef(onError);
+  const onSurfaceRetainedBytesChangeRef = useLatestRef(
+    onSurfaceRetainedBytesChange,
+  );
   const holderId = useId();
   const [posterReady, setPosterReady] = useState(false);
   const { codec, codecString, endTimeSeconds, startTimeSeconds } = video;
@@ -67,7 +73,9 @@ export function LeRobotGridHoverVideo({
     const poster = posterRef.current;
     if (!element || !poster) return undefined;
     if (codec === "av1" && !supportsNativeCodec(element, codecString)) {
-      onError(new Error("AV1 video playback is unsupported by this browser"));
+      onErrorRef.current(
+        new Error("AV1 video playback is unsupported by this browser"),
+      );
       return undefined;
     }
 
@@ -141,8 +149,8 @@ export function LeRobotGridHoverVideo({
       context.drawImage(element, 0, 0, width, height);
       posterCaptured = true;
       poster.style.visibility = playing ? "hidden" : "visible";
-      onSurfaceRetainedBytesChange(width * height * 4);
-      onCanvasCommitted(poster, { height, width });
+      onSurfaceRetainedBytesChangeRef.current(width * height * 4);
+      onCanvasCommittedRef.current(poster, { height, width });
       posterReadyRef.current = true;
       setPosterReady(true);
       if (!playing) requestRef.current?.release();
@@ -194,15 +202,38 @@ export function LeRobotGridHoverVideo({
       fail(new Error(`Unable to play native ${codec.toUpperCase()} video`));
     };
 
+    const cleanupMedia = () => {
+      if (!started) return;
+      started = false;
+      playGeneration += 1;
+      cancelPendingFrame();
+      if (posterRetryTimer !== null) {
+        clearTimeout(posterRetryTimer);
+        posterRetryTimer = null;
+      }
+      element.removeEventListener("ended", startAtEpisodeStart);
+      element.removeEventListener("error", onMediaError);
+      element.removeEventListener("loadeddata", presentFallbackFrame);
+      element.removeEventListener("loadedmetadata", startAtEpisodeStart);
+      element.removeEventListener("seeked", presentFallbackFrame);
+      element.removeEventListener("timeupdate", onTimeUpdate);
+      element.style.visibility = "hidden";
+      poster.style.visibility = posterCaptured ? "visible" : "hidden";
+      element.pause();
+      element.removeAttribute("src");
+      element.load();
+    };
+
     function fail(error: unknown) {
       if (failed || disposed) return;
       failed = true;
       playGeneration += 1;
       setShowingVideo(false);
-      cancelPendingFrame();
-      element?.pause();
+      cleanupMedia();
       requestRef.current?.release();
-      onError(error instanceof Error ? error : new Error(String(error)));
+      onErrorRef.current(
+        error instanceof Error ? error : new Error(String(error)),
+      );
     }
 
     function onPresentedFrame(
@@ -229,27 +260,6 @@ export function LeRobotGridHoverVideo({
       }
     }
 
-    const cleanupMedia = () => {
-      if (!started) return;
-      started = false;
-      playGeneration += 1;
-      cancelPendingFrame();
-      if (posterRetryTimer !== null) {
-        clearTimeout(posterRetryTimer);
-        posterRetryTimer = null;
-      }
-      element.removeEventListener("ended", startAtEpisodeStart);
-      element.removeEventListener("error", onMediaError);
-      element.removeEventListener("loadeddata", presentFallbackFrame);
-      element.removeEventListener("loadedmetadata", startAtEpisodeStart);
-      element.removeEventListener("seeked", presentFallbackFrame);
-      element.removeEventListener("timeupdate", onTimeUpdate);
-      element.style.visibility = "hidden";
-      poster.style.visibility = posterCaptured ? "visible" : "hidden";
-      element.pause();
-      element.removeAttribute("src");
-      element.load();
-    };
     const startMedia = () => {
       if (disposed || started) return;
       started = true;
@@ -284,9 +294,9 @@ export function LeRobotGridHoverVideo({
     codecString,
     endTimeSeconds,
     holderId,
-    onCanvasCommitted,
-    onError,
-    onSurfaceRetainedBytesChange,
+    onCanvasCommittedRef,
+    onErrorRef,
+    onSurfaceRetainedBytesChangeRef,
     playing,
     sourceUrl,
     startTimeSeconds,
@@ -305,8 +315,8 @@ export function LeRobotGridHoverVideo({
     }
     posterReadyRef.current = false;
     setPosterReady(false);
-    onSurfaceRetainedBytesChange(0);
-  }, [active, onSurfaceRetainedBytesChange]);
+    onSurfaceRetainedBytesChangeRef.current(0);
+  }, [active, onSurfaceRetainedBytesChangeRef]);
 
   // This effect clears retained poster memory and accounting on unmount.
   useEffect(
@@ -316,9 +326,9 @@ export function LeRobotGridHoverVideo({
         poster.width = 0;
         poster.height = 0;
       }
-      onSurfaceRetainedBytesChange(0);
+      onSurfaceRetainedBytesChangeRef.current(0);
     },
-    [onSurfaceRetainedBytesChange],
+    [onSurfaceRetainedBytesChangeRef],
   );
 
   return (

--- a/app/packages/multimodal/src/views/episode/grid/LeRobotGridHoverVideo.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/LeRobotGridHoverVideo.tsx
@@ -1,8 +1,13 @@
 import { getFetchUrl } from "@fiftyone/utilities";
-import { useEffect, useRef } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 
 import type { EpisodePreviewNativeVideo } from "../../../ir";
+import type { BitmapDrawSize } from "../../../visualization/media-2d/BitmapImageView";
 import classes from "./GridRenderer.module.css";
+import {
+  requestGridNativeVideoLease,
+  type GridNativeVideoLeaseRequest,
+} from "./grid-native-video-lease";
 
 type VideoFrameCallback = (
   now: number,
@@ -14,22 +19,53 @@ type VideoWithFrameCallbacks = HTMLVideoElement & {
   requestVideoFrameCallback?: (callback: VideoFrameCallback) => number;
 };
 
-/** Native MP4 hover surface constrained to one LeRobot episode interval. */
-export function LeRobotGridHoverVideo({
-  video,
-}: {
-  readonly video: EpisodePreviewNativeVideo;
-}) {
-  const videoRef = useRef<HTMLVideoElement | null>(null);
-  const { endTimeSeconds, startTimeSeconds } = video;
-  const sourceUrl = getFetchUrl(video.source.url);
+// Native media clocks commonly round MP4 timestamps to six decimal places.
+// One millisecond accepts that representation loss while remaining far below
+// one 15fps DROID frame, so an adjacent episode frame is never admitted.
+const START_TIME_EPSILON_SECONDS = 0.001;
 
-  // This effect owns the native media lifecycle for exactly one hover. It
-  // seeks into the shared MP4, loops before the adjacent episode, and drops
-  // the source on cleanup so rapid hover changes cannot retain old work.
+interface LeRobotGridHoverVideoProps {
+  readonly active?: boolean;
+  readonly capturePoster?: boolean;
+  readonly onCanvasCommitted?: (
+    canvas: HTMLCanvasElement,
+    size: BitmapDrawSize,
+  ) => void;
+  readonly onError?: (error: Error) => void;
+  readonly onSurfaceRetainedBytesChange?: (bytes: number) => void;
+  readonly playing?: boolean;
+  readonly video: EpisodePreviewNativeVideo;
+}
+
+/** Native MP4 grid surface constrained to one LeRobot episode interval. */
+export function LeRobotGridHoverVideo({
+  active = true,
+  capturePoster = false,
+  onCanvasCommitted,
+  onError,
+  onSurfaceRetainedBytesChange,
+  playing = true,
+  video,
+}: LeRobotGridHoverVideoProps) {
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const posterRef = useRef<HTMLCanvasElement | null>(null);
+  const posterReadyRef = useRef(false);
+  const requestRef = useRef<GridNativeVideoLeaseRequest | null>(null);
+  const holderId = useId();
+  const [posterReady, setPosterReady] = useState(false);
+  const { codec, codecString, endTimeSeconds, startTimeSeconds } = video;
+  const sourceUrl = getFetchUrl(video.source.url);
+  const wantsMedia = active && (playing || (capturePoster && !posterReady));
+
   useEffect(() => {
+    if (!wantsMedia) return undefined;
     const element = videoRef.current as VideoWithFrameCallbacks | null;
-    if (!element) return undefined;
+    const poster = posterRef.current;
+    if (!element || !poster) return undefined;
+    if (codec === "av1" && !supportsNativeCodec(element, codecString)) {
+      onError?.(new Error("AV1 video playback is unsupported by this browser"));
+      return undefined;
+    }
 
     const requestFrame = element.requestVideoFrameCallback;
     const cancelFrame = element.cancelVideoFrameCallback;
@@ -39,15 +75,21 @@ export function LeRobotGridHoverVideo({
     let frameHandle: number | null = null;
     let playGeneration = 0;
     let showingVideo = false;
-    element.style.visibility = "hidden";
+    let started = false;
+    let posterCaptured = posterReadyRef.current;
+    let posterRetryCount = 0;
+    let posterRetryTimer: ReturnType<typeof setTimeout> | null = null;
 
     const setShowingVideo = (showing: boolean) => {
       if (showingVideo === showing) return;
       showingVideo = showing;
       element.style.visibility = showing ? "visible" : "hidden";
+      poster.style.visibility =
+        showing || !posterCaptured ? "hidden" : "visible";
     };
     const inEpisode = (timeSeconds: number) =>
-      timeSeconds >= startTimeSeconds && timeSeconds < endTimeSeconds;
+      timeSeconds >= startTimeSeconds - START_TIME_EPSILON_SECONDS &&
+      timeSeconds < endTimeSeconds;
     const cancelPendingFrame = () => {
       const handle = frameHandle;
       frameHandle = null;
@@ -73,36 +115,91 @@ export function LeRobotGridHoverVideo({
         }
       });
     };
-    const playFromEpisodeStart = () => {
+    const startAtEpisodeStart = () => {
       if (disposed || failed) return;
       setShowingVideo(false);
       cancelPendingFrame();
-      element.pause();
+      element?.pause();
       element.currentTime = startTimeSeconds;
       scheduleFrame();
-      play();
+      if (playing) play();
+      else schedulePosterRetry();
+    };
+    const capturePresentedPoster = () => {
+      if (posterCaptured || !capturePoster) return true;
+      const width = element.videoWidth;
+      const height = element.videoHeight;
+      if (width <= 0 || height <= 0 || element.readyState < 2) return false;
+      const context = poster.getContext("2d");
+      if (!context) throw new Error("Unable to create native video poster");
+      poster.width = width;
+      poster.height = height;
+      context.drawImage(element, 0, 0, width, height);
+      posterCaptured = true;
+      poster.style.visibility = playing ? "hidden" : "visible";
+      onSurfaceRetainedBytesChange?.(width * height * 4);
+      onCanvasCommitted?.(poster, { height, width });
+      posterReadyRef.current = true;
+      setPosterReady(true);
+      if (!playing) requestRef.current?.release();
+      return true;
+    };
+    const schedulePosterRetry = () => {
+      if (disposed || playing || posterCaptured || posterRetryTimer !== null) {
+        return;
+      }
+      if (posterRetryCount >= 50) {
+        fail(new Error("Timed out waiting for a native video poster frame"));
+        return;
+      }
+      posterRetryCount += 1;
+      posterRetryTimer = setTimeout(() => {
+        posterRetryTimer = null;
+        try {
+          if (!inEpisode(element.currentTime) || !capturePresentedPoster()) {
+            schedulePosterRetry();
+          }
+        } catch (error) {
+          fail(error);
+        }
+      }, 100);
     };
     const presentFallbackFrame = () => {
-      if (!supportsFrameCallbacks && inEpisode(element.currentTime)) {
-        setShowingVideo(true);
+      if (
+        inEpisode(element.currentTime) &&
+        (!supportsFrameCallbacks || !playing)
+      ) {
+        try {
+          if (!capturePresentedPoster()) schedulePosterRetry();
+          setShowingVideo(playing);
+        } catch (error) {
+          fail(error);
+        }
       }
     };
     const onTimeUpdate = () => {
       if (element.currentTime >= endTimeSeconds) {
-        playFromEpisodeStart();
+        startAtEpisodeStart();
       } else if (element.currentTime < startTimeSeconds) {
         setShowingVideo(false);
       } else {
         presentFallbackFrame();
       }
     };
-    const onError = () => {
+    const onMediaError = () => {
+      fail(new Error(`Unable to play native ${codec.toUpperCase()} video`));
+    };
+
+    function fail(error: unknown) {
+      if (failed || disposed) return;
       failed = true;
       playGeneration += 1;
       setShowingVideo(false);
       cancelPendingFrame();
-      element.pause();
-    };
+      element?.pause();
+      requestRef.current?.release();
+      onError?.(error instanceof Error ? error : new Error(String(error)));
+    }
 
     function onPresentedFrame(
       _now: number,
@@ -111,56 +208,136 @@ export function LeRobotGridHoverVideo({
       frameHandle = null;
       if (disposed) return;
       if (metadata.mediaTime >= endTimeSeconds) {
-        playFromEpisodeStart();
+        startAtEpisodeStart();
         return;
       }
-      setShowingVideo(inEpisode(metadata.mediaTime));
-      scheduleFrame();
+      if (!inEpisode(metadata.mediaTime)) {
+        setShowingVideo(false);
+        scheduleFrame();
+        return;
+      }
+      try {
+        if (!capturePresentedPoster()) schedulePosterRetry();
+        setShowingVideo(playing);
+        if (playing) scheduleFrame();
+      } catch (error) {
+        fail(error);
+      }
     }
 
-    element.addEventListener("ended", playFromEpisodeStart);
-    element.addEventListener("error", onError);
-    element.addEventListener("loadeddata", presentFallbackFrame);
-    element.addEventListener("loadedmetadata", playFromEpisodeStart);
-    element.addEventListener("seeked", presentFallbackFrame);
-    element.addEventListener("timeupdate", onTimeUpdate);
-    setShowingVideo(false);
-    if (element.getAttribute("src") !== sourceUrl) {
-      element.setAttribute("src", sourceUrl);
-      element.load();
-    }
-
-    if (element.readyState >= 1) {
-      playFromEpisodeStart();
-    }
-
-    return () => {
-      disposed = true;
+    const cleanupMedia = () => {
+      if (!started) return;
+      started = false;
       playGeneration += 1;
       cancelPendingFrame();
-      element.removeEventListener("ended", playFromEpisodeStart);
-      element.removeEventListener("error", onError);
+      if (posterRetryTimer !== null) {
+        clearTimeout(posterRetryTimer);
+        posterRetryTimer = null;
+      }
+      element.removeEventListener("ended", startAtEpisodeStart);
+      element.removeEventListener("error", onMediaError);
       element.removeEventListener("loadeddata", presentFallbackFrame);
-      element.removeEventListener("loadedmetadata", playFromEpisodeStart);
+      element.removeEventListener("loadedmetadata", startAtEpisodeStart);
       element.removeEventListener("seeked", presentFallbackFrame);
       element.removeEventListener("timeupdate", onTimeUpdate);
       element.style.visibility = "hidden";
+      poster.style.visibility = posterCaptured ? "visible" : "hidden";
       element.pause();
       element.removeAttribute("src");
       element.load();
     };
-  }, [endTimeSeconds, sourceUrl, startTimeSeconds]);
+    const startMedia = () => {
+      if (disposed || started) return;
+      started = true;
+      element.addEventListener("ended", startAtEpisodeStart);
+      element.addEventListener("error", onMediaError);
+      element.addEventListener("loadeddata", presentFallbackFrame);
+      element.addEventListener("loadedmetadata", startAtEpisodeStart);
+      element.addEventListener("seeked", presentFallbackFrame);
+      element.addEventListener("timeupdate", onTimeUpdate);
+      setShowingVideo(false);
+      element.setAttribute("src", sourceUrl);
+      element.load();
+      if (element.readyState >= 1) startAtEpisodeStart();
+    };
+    const request = requestGridNativeVideoLease(
+      holderId,
+      playing ? "playing" : "poster",
+      startMedia,
+      cleanupMedia,
+    );
+    requestRef.current = request;
+
+    return () => {
+      disposed = true;
+      request.release();
+      if (requestRef.current === request) requestRef.current = null;
+      cleanupMedia();
+    };
+  }, [
+    capturePoster,
+    codec,
+    codecString,
+    endTimeSeconds,
+    holderId,
+    onCanvasCommitted,
+    onError,
+    onSurfaceRetainedBytesChange,
+    playing,
+    sourceUrl,
+    startTimeSeconds,
+    wantsMedia,
+  ]);
+
+  useEffect(() => {
+    if (active) return;
+    const poster = posterRef.current;
+    if (poster) {
+      poster.width = 0;
+      poster.height = 0;
+      poster.style.visibility = "hidden";
+    }
+    posterReadyRef.current = false;
+    setPosterReady(false);
+    onSurfaceRetainedBytesChange?.(0);
+  }, [active, onSurfaceRetainedBytesChange]);
+
+  useEffect(
+    () => () => {
+      const poster = posterRef.current;
+      if (poster) {
+        poster.width = 0;
+        poster.height = 0;
+      }
+      onSurfaceRetainedBytesChange?.(0);
+    },
+    [onSurfaceRetainedBytesChange],
+  );
 
   return (
-    <video
-      aria-hidden
-      className={classes.nativeVideo}
-      data-testid="lerobot-grid-hover-video"
-      muted
-      playsInline
-      preload="metadata"
-      ref={videoRef}
-      src={sourceUrl}
-    />
+    <>
+      <canvas
+        aria-hidden
+        className={classes.nativePoster}
+        data-testid="lerobot-grid-native-poster"
+        ref={posterRef}
+      />
+      <video
+        aria-hidden
+        className={classes.nativeVideo}
+        data-testid="lerobot-grid-hover-video"
+        muted
+        playsInline
+        preload="metadata"
+        ref={videoRef}
+      />
+    </>
   );
+}
+
+function supportsNativeCodec(
+  element: HTMLVideoElement,
+  codecString: string,
+): boolean {
+  return element.canPlayType(`video/mp4; codecs="${codecString}"`) !== "";
 }

--- a/app/packages/multimodal/src/views/episode/grid/grid-native-video-lease.test.ts
+++ b/app/packages/multimodal/src/views/episode/grid/grid-native-video-lease.test.ts
@@ -77,4 +77,21 @@ describe("grid native video leases", () => {
       pending: 1,
     });
   });
+
+  it("keeps an active slot when the same holder replaces its request", () => {
+    requestGridNativeVideoLease("first", "poster", vi.fn(), vi.fn());
+    requestGridNativeVideoLease("second", "poster", vi.fn(), vi.fn());
+    const queuedGrant = vi.fn();
+    requestGridNativeVideoLease("queued", "poster", queuedGrant, vi.fn());
+    const replacementGrant = vi.fn();
+
+    requestGridNativeVideoLease("first", "playing", replacementGrant, vi.fn());
+
+    expect(replacementGrant).toHaveBeenCalledOnce();
+    expect(queuedGrant).not.toHaveBeenCalled();
+    expect(gridNativeVideoLeaseStats()).toMatchObject({
+      active: 2,
+      pending: 1,
+    });
+  });
 });

--- a/app/packages/multimodal/src/views/episode/grid/grid-native-video-lease.test.ts
+++ b/app/packages/multimodal/src/views/episode/grid/grid-native-video-lease.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  GRID_NATIVE_VIDEO_CAP,
+  gridNativeVideoLeaseStats,
+  requestGridNativeVideoLease,
+  resetGridNativeVideoLeasesForTests,
+} from "./grid-native-video-lease";
+
+afterEach(() => {
+  resetGridNativeVideoLeasesForTests();
+});
+
+describe("grid native video leases", () => {
+  it("queues poster captures behind the bounded active set", () => {
+    const grants = [vi.fn(), vi.fn(), vi.fn()];
+    const first = requestGridNativeVideoLease(
+      "first",
+      "poster",
+      grants[0],
+      vi.fn(),
+    );
+    requestGridNativeVideoLease("second", "poster", grants[1], vi.fn());
+    requestGridNativeVideoLease("third", "poster", grants[2], vi.fn());
+
+    expect(grants.map((grant) => grant.mock.calls.length)).toEqual([1, 1, 0]);
+    expect(gridNativeVideoLeaseStats()).toEqual({
+      active: GRID_NATIVE_VIDEO_CAP,
+      cap: GRID_NATIVE_VIDEO_CAP,
+      pending: 1,
+    });
+
+    first.release();
+    expect(grants[2]).toHaveBeenCalledOnce();
+    expect(gridNativeVideoLeaseStats()).toMatchObject({
+      active: 2,
+      pending: 0,
+    });
+  });
+
+  it("lets playback revoke the oldest active poster capture", () => {
+    const firstRevoked = vi.fn();
+    requestGridNativeVideoLease("first", "poster", vi.fn(), firstRevoked);
+    requestGridNativeVideoLease("second", "poster", vi.fn(), vi.fn());
+    const playGranted = vi.fn();
+
+    const playback = requestGridNativeVideoLease(
+      "playing",
+      "playing",
+      playGranted,
+      vi.fn(),
+    );
+
+    expect(firstRevoked).toHaveBeenCalledOnce();
+    expect(playGranted).toHaveBeenCalledOnce();
+    expect(gridNativeVideoLeaseStats()).toMatchObject({
+      active: 2,
+      pending: 1,
+    });
+
+    playback.release();
+    expect(gridNativeVideoLeaseStats()).toMatchObject({
+      active: 2,
+      pending: 0,
+    });
+  });
+
+  it("keeps playback queued when every active lease is interactive", () => {
+    requestGridNativeVideoLease("first", "playing", vi.fn(), vi.fn());
+    requestGridNativeVideoLease("second", "playing", vi.fn(), vi.fn());
+    const thirdGranted = vi.fn();
+    requestGridNativeVideoLease("third", "playing", thirdGranted, vi.fn());
+
+    expect(thirdGranted).not.toHaveBeenCalled();
+    expect(gridNativeVideoLeaseStats()).toMatchObject({
+      active: 2,
+      pending: 1,
+    });
+  });
+});

--- a/app/packages/multimodal/src/views/episode/grid/grid-native-video-lease.ts
+++ b/app/packages/multimodal/src/views/episode/grid/grid-native-video-lease.ts
@@ -1,8 +1,9 @@
 /** Bounds browser-native video decoders retained by episode grid cells. */
 export const GRID_NATIVE_VIDEO_CAP = 2;
 
-export type GridNativeVideoPriority = "playing" | "poster";
+type GridNativeVideoPriority = "playing" | "poster";
 
+/** Handle for one pending or active native-video decoder lease. */
 export interface GridNativeVideoLeaseRequest {
   release(): void;
 }
@@ -61,6 +62,7 @@ export function requestGridNativeVideoLease(
   return record.request;
 }
 
+/** Current scheduler counts exposed to the focused lease tests. */
 export function gridNativeVideoLeaseStats() {
   return {
     active: active.size,

--- a/app/packages/multimodal/src/views/episode/grid/grid-native-video-lease.ts
+++ b/app/packages/multimodal/src/views/episode/grid/grid-native-video-lease.ts
@@ -30,8 +30,10 @@ export function requestGridNativeVideoLease(
   onGranted: () => void,
   onRevoked: () => void,
 ): GridNativeVideoLeaseRequest {
-  active.get(holderId)?.request.release();
-  pending.get(holderId)?.request.release();
+  const replacingActive = active.get(holderId) ?? null;
+  if (replacingActive) release(replacingActive, false);
+  const replacingPending = pending.get(holderId);
+  if (replacingPending) release(replacingPending, false);
 
   const record: LeaseRecord = {
     holderId,
@@ -40,16 +42,17 @@ export function requestGridNativeVideoLease(
     priority,
     request: {
       release() {
-        if (record.state === "released") return;
-        const wasActive = record.state === "active";
-        record.state = "released";
-        active.delete(holderId);
-        pending.delete(holderId);
-        if (wasActive) pump();
+        release(record, true);
       },
     },
     state: "pending",
   };
+
+  if (replacingActive) {
+    activate(record);
+    return record.request;
+  }
+
   pending.set(holderId, record);
 
   if (priority === "playing" && active.size >= GRID_NATIVE_VIDEO_CAP) {
@@ -89,14 +92,27 @@ function pump(): void {
     if (!record) return;
     pending.delete(record.holderId);
     if (record.state !== "pending") continue;
-    record.state = "active";
-    active.set(record.holderId, record);
-    try {
-      record.onGranted();
-    } catch {
-      record.request.release();
-    }
+    activate(record);
   }
+}
+
+function activate(record: LeaseRecord): void {
+  record.state = "active";
+  active.set(record.holderId, record);
+  try {
+    record.onGranted();
+  } catch {
+    record.request.release();
+  }
+}
+
+function release(record: LeaseRecord, shouldPump: boolean): void {
+  if (record.state === "released") return;
+  const wasActive = record.state === "active";
+  record.state = "released";
+  active.delete(record.holderId);
+  pending.delete(record.holderId);
+  if (wasActive && shouldPump) pump();
 }
 
 function revoke(record: LeaseRecord): void {

--- a/app/packages/multimodal/src/views/episode/grid/grid-native-video-lease.ts
+++ b/app/packages/multimodal/src/views/episode/grid/grid-native-video-lease.ts
@@ -1,0 +1,110 @@
+/** Bounds browser-native video decoders retained by episode grid cells. */
+export const GRID_NATIVE_VIDEO_CAP = 2;
+
+export type GridNativeVideoPriority = "playing" | "poster";
+
+export interface GridNativeVideoLeaseRequest {
+  release(): void;
+}
+
+interface LeaseRecord {
+  readonly holderId: string;
+  readonly onGranted: () => void;
+  readonly onRevoked: () => void;
+  readonly priority: GridNativeVideoPriority;
+  readonly request: GridNativeVideoLeaseRequest;
+  state: "active" | "pending" | "released";
+}
+
+const active = new Map<string, LeaseRecord>();
+const pending = new Map<string, LeaseRecord>();
+
+/**
+ * Requests one native decoder slot. Playing work may revoke the oldest poster
+ * capture, while ordinary poster requests wait FIFO for a slot.
+ */
+export function requestGridNativeVideoLease(
+  holderId: string,
+  priority: GridNativeVideoPriority,
+  onGranted: () => void,
+  onRevoked: () => void,
+): GridNativeVideoLeaseRequest {
+  active.get(holderId)?.request.release();
+  pending.get(holderId)?.request.release();
+
+  const record: LeaseRecord = {
+    holderId,
+    onGranted,
+    onRevoked,
+    priority,
+    request: {
+      release() {
+        if (record.state === "released") return;
+        const wasActive = record.state === "active";
+        record.state = "released";
+        active.delete(holderId);
+        pending.delete(holderId);
+        if (wasActive) pump();
+      },
+    },
+    state: "pending",
+  };
+  pending.set(holderId, record);
+
+  if (priority === "playing" && active.size >= GRID_NATIVE_VIDEO_CAP) {
+    const poster = [...active.values()].find(
+      (candidate) => candidate.priority === "poster",
+    );
+    if (poster) revoke(poster);
+  }
+  pump();
+  return record.request;
+}
+
+export function gridNativeVideoLeaseStats() {
+  return {
+    active: active.size,
+    cap: GRID_NATIVE_VIDEO_CAP,
+    pending: pending.size,
+  } as const;
+}
+
+/** Test-only reset. */
+export function resetGridNativeVideoLeasesForTests(): void {
+  for (const record of [...active.values(), ...pending.values()]) {
+    record.state = "released";
+  }
+  active.clear();
+  pending.clear();
+}
+
+function pump(): void {
+  while (active.size < GRID_NATIVE_VIDEO_CAP && pending.size > 0) {
+    const record =
+      [...pending.values()].find(
+        (candidate) => candidate.priority === "playing",
+      ) ?? pending.values().next().value;
+    if (!record) return;
+    pending.delete(record.holderId);
+    if (record.state !== "pending") continue;
+    record.state = "active";
+    active.set(record.holderId, record);
+    try {
+      record.onGranted();
+    } catch {
+      record.request.release();
+    }
+  }
+}
+
+function revoke(record: LeaseRecord): void {
+  if (record.state !== "active") return;
+  active.delete(record.holderId);
+  record.state = "pending";
+  pending.set(record.holderId, record);
+  try {
+    record.onRevoked();
+  } catch {
+    // A failed holder fallback must not prevent the interactive grant.
+  }
+}

--- a/app/packages/multimodal/src/views/episode/grid/use-grid-preview.test.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/use-grid-preview.test.tsx
@@ -1122,6 +1122,8 @@ function readyResult({
 
 function nativeVideo(): EpisodePreviewNativeVideo {
   return {
+    codec: "h264",
+    codecString: "avc1.64000a",
     endTimeSeconds: 37.5,
     source: { sourceId: "video", url: "/asset/video.mp4" },
     startTimeSeconds: 14.2,

--- a/app/packages/multimodal/src/views/episode/grid/use-grid-preview.test.tsx
+++ b/app/packages/multimodal/src/views/episode/grid/use-grid-preview.test.tsx
@@ -5,6 +5,7 @@ import {
   type ByteSourceDescriptor,
   type EncodedImageVisualization,
   type EpisodePosterFrame,
+  type EpisodePreviewNativeVideo,
   type EpisodePreviewReadResult,
   VISUALIZATION_KIND,
 } from "../../../ir";
@@ -194,6 +195,43 @@ describe("useGridPreview", () => {
     unmount();
 
     expect(signal.aborted).toBe(true);
+  });
+
+  it("delegates native hover playback without starting a frame-read loop", async () => {
+    const latest = { current: null as GridPreviewState | null };
+    const video = nativeVideo();
+    sessionHarness.session.read.mockResolvedValueOnce(
+      readyResult({ bytes: [1, 2, 3], nativeVideo: video }),
+    );
+    const source = sourceForId("native-hover");
+    const { rerender } = render(
+      <PreviewHarness
+        enabled
+        id="native-hover"
+        onState={(state) => {
+          latest.current = state;
+        }}
+        source={source}
+      />,
+    );
+    await waitFor(() => expect(latest.current?.nativeVideo).toBe(video));
+
+    act(() => latest.current?.play());
+    await waitFor(() => expect(latest.current?.isPlaying).toBe(true));
+    expect(sessionHarness.session.read).toHaveBeenCalledOnce();
+
+    rerender(
+      <PreviewHarness
+        enabled={false}
+        id="native-hover"
+        onState={(state) => {
+          latest.current = state;
+        }}
+        source={source}
+      />,
+    );
+    await waitFor(() => expect(latest.current?.isPlaying).toBe(false));
+    expect(sessionHarness.session.read).toHaveBeenCalledOnce();
   });
 
   it("cancels pending demand and starts no replacement while the grid is inactive", async () => {
@@ -1054,6 +1092,7 @@ function formatState(state: GridPreviewState): string {
 
 function readyResult({
   bytes,
+  nativeVideo,
   nextStartTimeNs = 5n,
   frameTimeNs = nextStartTimeNs === undefined
     ? undefined
@@ -1062,6 +1101,7 @@ function readyResult({
 }: {
   readonly bytes: readonly number[];
   readonly frameTimeNs?: bigint;
+  readonly nativeVideo?: EpisodePreviewNativeVideo;
   readonly streamId?: string;
   readonly nextStartTimeNs?: bigint;
 }): EpisodePreviewReadResult {
@@ -1071,11 +1111,20 @@ function readyResult({
       kind: "image",
     },
     frameTimeNs,
+    ...(nativeVideo ? { nativeVideo } : {}),
     nextStartTimeNs,
     streamId,
     streamSourceName: streamId,
     streamSourceNames: [streamId],
     status: "ready",
+  };
+}
+
+function nativeVideo(): EpisodePreviewNativeVideo {
+  return {
+    endTimeSeconds: 37.5,
+    source: { sourceId: "video", url: "/asset/video.mp4" },
+    startTimeSeconds: 14.2,
   };
 }
 

--- a/app/packages/multimodal/src/views/episode/grid/use-grid-preview.ts
+++ b/app/packages/multimodal/src/views/episode/grid/use-grid-preview.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import {
   type ByteSourceDescriptor,
   type EpisodePosterFrame,
+  type EpisodePreviewNativeVideo,
   type EpisodePreviewReadResult,
 } from "../../../ir";
 import type { EpisodePreviewSession } from "../../../ports";
@@ -30,6 +31,7 @@ export interface GridPreviewSnapshot {
   readonly error: string | null;
   readonly frame: EpisodePosterFrame | null;
   readonly hasPreviewStreams: boolean;
+  readonly nativeVideo: EpisodePreviewNativeVideo | null;
   readonly streamId: string | null;
   readonly streamSourceName: string | null;
   readonly streamSourceNames: readonly string[];
@@ -41,6 +43,7 @@ export interface GridPreviewSnapshot {
  */
 export interface GridPreviewState extends GridPreviewSnapshot {
   readonly isBuffering: boolean;
+  readonly isPlaying: boolean;
   pause(): void;
   play(): void;
 }
@@ -84,6 +87,7 @@ const IDLE_PREVIEW_STATE: GridPreviewSnapshot = {
   error: null,
   frame: null,
   hasPreviewStreams: false,
+  nativeVideo: null,
   streamId: null,
   streamSourceName: null,
   streamSourceNames: [],
@@ -298,6 +302,7 @@ export function useGridPreview({
       !source ||
       !previewSession ||
       state.status !== "ready" ||
+      state.nativeVideo !== null ||
       initialLoadInFlightRef.current
     ) {
       return undefined;
@@ -434,13 +439,20 @@ export function useGridPreview({
     sourceFactsScope,
     startBuffering,
     state.status,
+    state.nativeVideo,
   ]);
 
   const visibleState =
     stateOwnerKey === cacheRequestKey
       ? state
       : seededSnapshot(source, cachedPoster);
-  return { ...visibleState, isBuffering, pause, play };
+  return {
+    ...visibleState,
+    isBuffering,
+    isPlaying: enabled && stateOwnerKey === cacheRequestKey && playing,
+    pause,
+    play,
+  };
 }
 
 function seededSnapshot(
@@ -456,6 +468,7 @@ function seededSnapshot(
     error: null,
     frame: null,
     hasPreviewStreams: cachedPoster.streamSourceNames.length > 0,
+    nativeVideo: null,
     streamId: cachedPoster.streamId,
     streamSourceName: cachedPoster.streamSourceName,
     streamSourceNames: cachedPoster.streamSourceNames,
@@ -576,6 +589,7 @@ function snapshotFromResult(
     error: null,
     frame: timestampedFrame,
     hasPreviewStreams: result.streamSourceNames.length > 0,
+    nativeVideo: result.nativeVideo ?? null,
     streamId: result.streamId,
     streamSourceName: result.streamSourceName,
     streamSourceNames: result.streamSourceNames,

--- a/app/packages/multimodal/src/views/episode/grid/use-grid-preview.ts
+++ b/app/packages/multimodal/src/views/episode/grid/use-grid-preview.ts
@@ -58,6 +58,8 @@ export interface UseGridPreviewOptions {
   readonly enabled?: boolean;
   /** Whether this tile is the user's current interactive target. */
   readonly hovered?: boolean;
+  /** Initial forward coverage required by the mounted video decoder. */
+  readonly initialVideoDecodeLookaheadNs?: bigint;
   /** Receives every adapter result, including frames skipped by UI pacing. */
   readonly onReadResult?: (result: EpisodePreviewReadResult) => void;
   /** Capture time the still frame should show, instead of the recording
@@ -104,6 +106,7 @@ export function useGridPreview({
   cachedPoster = null,
   enabled = true,
   hovered = false,
+  initialVideoDecodeLookaheadNs,
   onReadResult,
   posterStartTimeNs = null,
   posterSourceName = null,
@@ -235,6 +238,9 @@ export function useGridPreview({
     nextStartTimeNsRef.current = undefined;
 
     const request = {
+      ...(initialVideoDecodeLookaheadNs === undefined
+        ? {}
+        : { decodeLookaheadNs: initialVideoDecodeLookaheadNs }),
       ...(effectiveSourceName ? { sourceName: effectiveSourceName } : {}),
       ...(posterStartTimeNs === null ? {} : { startTimeNs: posterStartTimeNs }),
     };
@@ -286,6 +292,7 @@ export function useGridPreview({
     enabled,
     effectiveSourceName,
     hovered,
+    initialVideoDecodeLookaheadNs,
     posterStartTimeNs,
     previewSession,
     source,

--- a/app/packages/multimodal/src/views/episode/image/ImageTile.tsx
+++ b/app/packages/multimodal/src/views/episode/image/ImageTile.tsx
@@ -21,6 +21,7 @@ import type {
 } from "../../../ir";
 import { SCENE_SOURCE_METADATA, SCENE_SOURCE_TYPE } from "../../../ir";
 import { useSceneSourcesByType } from "../../../scene-inventory/react";
+import { isSharedEncodedVideoVisualization } from "../../../video/types";
 import { VISUALIZATION_KIND } from "../../../visualization";
 import { ImagePanel } from "../../../visualization/media-2d/ImagePanel";
 import { VideoPanel } from "../../../visualization/media-2d/VideoPanel";
@@ -924,7 +925,7 @@ const ImageTile: React.FC<EpisodeTileProps> = ({ initialSourceId }) => {
         >
           {frame && playbackFrame ? (
             frame.kind === "encoded-video" ? (
-              frame.codec === "h264" ? (
+              isSharedEncodedVideoVisualization(frame) ? (
                 <VideoPanel
                   canvasSurface="modal-image"
                   className={styles.panel}

--- a/app/packages/multimodal/src/views/episode/image/ImageTile.tsx
+++ b/app/packages/multimodal/src/views/episode/image/ImageTile.tsx
@@ -21,7 +21,10 @@ import type {
 } from "../../../ir";
 import { SCENE_SOURCE_METADATA, SCENE_SOURCE_TYPE } from "../../../ir";
 import { useSceneSourcesByType } from "../../../scene-inventory/react";
-import { isSharedEncodedVideoVisualization } from "../../../video/types";
+import {
+  isSharedEncodedVideoVisualization,
+  sharedVideoRejectionMessage,
+} from "../../../video/types";
 import { VISUALIZATION_KIND } from "../../../visualization";
 import { ImagePanel } from "../../../visualization/media-2d/ImagePanel";
 import { VideoPanel } from "../../../visualization/media-2d/VideoPanel";
@@ -945,7 +948,7 @@ const ImageTile: React.FC<EpisodeTileProps> = ({ initialSourceId }) => {
                 />
               ) : (
                 <div className={styles.panel} role="alert">
-                  Video codec {frame.codec} is unsupported
+                  {sharedVideoRejectionMessage(frame)}
                 </div>
               )
             ) : (

--- a/app/packages/multimodal/src/views/episode/layout/use-modal-layout.test.tsx
+++ b/app/packages/multimodal/src/views/episode/layout/use-modal-layout.test.tsx
@@ -75,6 +75,7 @@ function renderLayoutHook(
       availableTileTypes: tileTypesFor({
         hasNumericSeries: true,
         hasRawRecords: true,
+        hasStateAction: false,
         hasTransformTopology: false,
         sourceTypes: sources.map((source) => source.type),
       }),
@@ -752,6 +753,7 @@ describe("useModalLayout", () => {
           availableTileTypes: tileTypesFor({
             hasNumericSeries: true,
             hasRawRecords: true,
+            hasStateAction: false,
             hasTransformTopology: false,
             sourceTypes: SCENE_SOURCES.map((source) => source.type),
           }),

--- a/app/packages/multimodal/src/views/episode/playback/video-playback-provider.tsx
+++ b/app/packages/multimodal/src/views/episode/playback/video-playback-provider.tsx
@@ -8,6 +8,7 @@ import type {
 } from "../../../video/types";
 import { isSharedEncodedVideoVisualization } from "../../../video/types";
 import { VISUALIZATION_KIND } from "../../../visualization";
+import { monotonicNowMs } from "../../../utils/monotonic-time";
 import { useDataStream } from "./data-stream-context";
 
 /** Binds the source manager to the current bounded episode read port. */
@@ -34,7 +35,11 @@ export function SourceVideoPlaybackProvider({
       timelineStartTimeNs,
       read: async ({ budget, endTimeNs, signal, startTimeNs, stream }) => {
         const result = await readStreamFrames({
-          budget,
+          budget: {
+            deadlineMs: monotonicNowMs() + budget.maxWallTimeMs,
+            maxMessages: budget.maxMessages,
+            maxObservedPayloadBytes: budget.maxObservedPayloadBytes,
+          },
           endTimeNs,
           signal,
           startTimeNs,

--- a/app/packages/multimodal/src/views/episode/playback/video-playback-provider.tsx
+++ b/app/packages/multimodal/src/views/episode/playback/video-playback-provider.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useMemo, useState, type ReactNode } from "react";
 
-import type { EncodedH264VideoVisualization } from "../../../ir";
 import { VideoPlaybackManager } from "../../../video/playback-manager";
 import { VideoPlaybackManagerProvider } from "../../../video/react";
 import type {
-  H264AccessUnit,
+  EncodedVideoAccessUnit,
   VideoAccessUnitReader,
 } from "../../../video/types";
+import { isSharedEncodedVideoVisualization } from "../../../video/types";
 import { VISUALIZATION_KIND } from "../../../visualization";
 import { useDataStream } from "./data-stream-context";
 
@@ -40,18 +40,17 @@ export function SourceVideoPlaybackProvider({
           startTimeNs,
           stream,
         });
-        const units: H264AccessUnit[] = [];
+        const units: EncodedVideoAccessUnit[] = [];
         for (const decoded of result.frames) {
           const visualization = decoded.output.visualization;
           if (
             visualization?.kind !== VISUALIZATION_KIND.ENCODED_VIDEO ||
-            visualization.codec !== "h264" ||
-            visualization.h264.hasFrame === false
+            !isSharedEncodedVideoVisualization(visualization)
           ) {
             continue;
           }
           units.push({
-            frame: visualization satisfies EncodedH264VideoVisualization,
+            frame: visualization,
             timeNs: decoded.timestampNs,
           });
         }

--- a/app/packages/multimodal/src/views/episode/plots/numeric-series-context.tsx
+++ b/app/packages/multimodal/src/views/episode/plots/numeric-series-context.tsx
@@ -19,7 +19,9 @@ import {
   createDemandFailureBackoff,
   createDemandInventoryMachine,
   createNumericSeriesTileCache,
+  DEMAND_DEFERRED_RETRY_MS,
   DEMAND_FAILURE_BACKOFF_MS,
+  DEMAND_TIMELINE_RETRY_MS,
   flattenSeriesSegments,
   FULL_NUMERIC_SERIES_COVERAGE,
   nearestNumericSeriesRange,
@@ -71,13 +73,6 @@ const PLAYHEAD_FILL_THROTTLE_MS = 500;
 
 /** Coalesces a short burst of plot-field toggles into one stream scan. */
 const FIELD_SELECTION_DEBOUNCE_MS = 250;
-
-/** Starved-link stand-down retry, matching the pose-trajectory gate. */
-const DEFERRED_RETRY_MS = 2_000;
-
-/** The timeline index lands moments after stream registration; wait for
- * it instead of falling back to an unbounded scan. */
-const TIMELINE_RETRY_MS = 250;
 
 /** Prevents a long continuation chain from monopolizing one demand epoch. */
 const MAX_NUMERIC_SLICE_PAGES_PER_EPOCH = 8;
@@ -598,7 +593,7 @@ export function NumericSeriesBridge({
     >({
       dataStreamRef,
       demandDebounceMs: FIELD_SELECTION_DEBOUNCE_MS,
-      deferredRetryMs: DEFERRED_RETRY_MS,
+      deferredRetryMs: DEMAND_DEFERRED_RETRY_MS,
       handlersRef,
       inventoryReplay,
       makeHandlers: ({ isCancelled, queueFill }) => {
@@ -1068,7 +1063,7 @@ export function NumericSeriesBridge({
       refCountsRef,
       requireTimeline: Boolean(playbackStore),
       shouldDeferIdleWork: (store) => shouldDeferIdleWorkForStore(store, null),
-      timelineRetryMs: TIMELINE_RETRY_MS,
+      timelineRetryMs: DEMAND_TIMELINE_RETRY_MS,
     });
 
     return () => {

--- a/app/packages/multimodal/src/views/episode/plots/plot-series-display.ts
+++ b/app/packages/multimodal/src/views/episode/plots/plot-series-display.ts
@@ -10,6 +10,15 @@ export function plotSeriesDisplayName(
 ): string {
   const sourceName =
     sourceNamesByBinding.get(config.stream) ?? "Unknown source";
+  // Some formats (LeRobot features) already carry the source name in the
+  // field path; repeating it reads as "action.action.gripper.pos".
+  if (
+    config.fieldPath === sourceName ||
+    config.fieldPath.startsWith(`${sourceName}.`) ||
+    config.fieldPath.startsWith(`${sourceName}[`)
+  ) {
+    return config.fieldPath;
+  }
   return `${sourceName}.${config.fieldPath}`;
 }
 

--- a/app/packages/multimodal/src/views/episode/raw/raw-message-context.tsx
+++ b/app/packages/multimodal/src/views/episode/raw/raw-message-context.tsx
@@ -12,7 +12,10 @@ import {
 import {
   createDemandFailureBackoff,
   createDemandInventoryMachine,
+  DEMAND_DEFERRED_RETRY_MS,
   DEMAND_FAILURE_BACKOFF_MS,
+  DEMAND_TIMELINE_RETRY_MS,
+  EXACT_RECORD_PLAYHEAD_THROTTLE_MS,
   startDemandBridge,
 } from "../../../runtime";
 import {
@@ -28,19 +31,10 @@ import type {
   RawRecordStream,
 } from "../../../ir";
 import type { RawRecordCapability } from "../../../ports";
+import { linkAbortSignals } from "../../../utils/cancellation";
 import { errorMessage } from "../../../utils/errors";
 import { shouldDeferIdleWorkForStore } from "../playback/network-health";
 import { useDataStream } from "../playback/data-stream-context";
-
-/** Playhead-driven refetches run at most this often per bridge tick. */
-const PLAYHEAD_THROTTLE_MS = 300;
-
-/** Starved-link stand-down retry, matching the numeric-series gate. */
-const DEFERRED_RETRY_MS = 2_000;
-
-/** The timeline index lands moments after stream registration; wait for
- * it instead of fetching at a meaningless time. */
-const TIMELINE_RETRY_MS = 250;
 
 /**
  * One stream row for the raw-message stream picker: every channel in the
@@ -273,7 +267,7 @@ export function RawMessageBridge({
       NonNullable<typeof dataStream>
     >({
       dataStreamRef,
-      deferredRetryMs: DEFERRED_RETRY_MS,
+      deferredRetryMs: DEMAND_DEFERRED_RETRY_MS,
       expeditePausedSeeks: true,
       handlersRef,
       inventoryReplay,
@@ -560,11 +554,11 @@ export function RawMessageBridge({
         }
       },
       playbackStore,
-      playheadThrottleMs: PLAYHEAD_THROTTLE_MS,
+      playheadThrottleMs: EXACT_RECORD_PLAYHEAD_THROTTLE_MS,
       refCountsRef,
       requireTimeline: true,
       shouldDeferIdleWork: (store) => shouldDeferIdleWorkForStore(store, null),
-      timelineRetryMs: TIMELINE_RETRY_MS,
+      timelineRetryMs: DEMAND_TIMELINE_RETRY_MS,
     });
     return () => {
       epochController.abort();
@@ -591,30 +585,4 @@ export function RawMessageBridge({
 
 function useInternalValue() {
   return rawMessageDemandContext.useDemandContext();
-}
-
-/** Links source-epoch and user cancellation without requiring AbortSignal.any. */
-function linkAbortSignals(
-  epochSignal: AbortSignal,
-  requestSignal?: AbortSignal,
-): { readonly cleanup: () => void; readonly signal: AbortSignal } {
-  if (!requestSignal) {
-    return { cleanup: () => undefined, signal: epochSignal };
-  }
-
-  const controller = new AbortController();
-  const abort = () => controller.abort();
-  if (epochSignal.aborted || requestSignal.aborted) {
-    controller.abort();
-  } else {
-    epochSignal.addEventListener("abort", abort, { once: true });
-    requestSignal.addEventListener("abort", abort, { once: true });
-  }
-  return {
-    cleanup: () => {
-      epochSignal.removeEventListener("abort", abort);
-      requestSignal.removeEventListener("abort", abort);
-    },
-    signal: controller.signal,
-  };
 }

--- a/app/packages/multimodal/src/views/episode/scene/camera/use-scene-3d-frustum-layers.ts
+++ b/app/packages/multimodal/src/views/episode/scene/camera/use-scene-3d-frustum-layers.ts
@@ -1,7 +1,10 @@
 import { useMemo } from "react";
 
 import type { CameraVisualization, SceneSource } from "../../../../ir";
-import { isSharedEncodedVideoVisualization } from "../../../../video/types";
+import {
+  isSharedEncodedVideoVisualization,
+  sharedVideoRejectionMessage,
+} from "../../../../video/types";
 import { imageTextureCacheKey } from "../../../../visualization/media-2d/image-texture-cache";
 import { useKeyedIdentityMap } from "../../../../visualization/panel-ui/use-keyed-identity-map";
 import type { CameraFrustumPanelLayer } from "../../../../visualization/scene-3d/types";
@@ -133,7 +136,9 @@ export function buildScene3dFrustumLayer({
               video: imageFrame.frame,
             }
           : {
-              imageUnavailableReason: `Video codec ${imageFrame.frame.codec} is unsupported`,
+              imageUnavailableReason: sharedVideoRejectionMessage(
+                imageFrame.frame,
+              ),
             }
         : {
             image: imageFrame.frame,

--- a/app/packages/multimodal/src/views/episode/scene/camera/use-scene-3d-frustum-layers.ts
+++ b/app/packages/multimodal/src/views/episode/scene/camera/use-scene-3d-frustum-layers.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 
 import type { CameraVisualization, SceneSource } from "../../../../ir";
+import { isSharedEncodedVideoVisualization } from "../../../../video/types";
 import { imageTextureCacheKey } from "../../../../visualization/media-2d/image-texture-cache";
 import { useKeyedIdentityMap } from "../../../../visualization/panel-ui/use-keyed-identity-map";
 import type { CameraFrustumPanelLayer } from "../../../../visualization/scene-3d/types";
@@ -126,7 +127,7 @@ export function buildScene3dFrustumLayer({
   const imageProps: Partial<CameraFrustumPanelLayer> = imageFrame
     ? cameraModelResolution.status === "ready"
       ? imageFrame.frame.kind === "encoded-video"
-        ? imageFrame.frame.codec === "h264"
+        ? isSharedEncodedVideoVisualization(imageFrame.frame)
           ? {
               imageContentTimeNs: imageFrame.contentTimeNs,
               video: imageFrame.frame,

--- a/app/packages/multimodal/src/views/episode/settings/modal/RecordingSettings.tsx
+++ b/app/packages/multimodal/src/views/episode/settings/modal/RecordingSettings.tsx
@@ -37,8 +37,8 @@ const RecordingSettings = memo(function RecordingSettings({
     ["Format", format],
     ["Size", size],
     ["Duration", duration],
-    ["Start time", formatTimestampNs(facts.startTimeNs)],
-    ["End time", formatTimestampNs(facts.endTimeNs)],
+    ["Start time", facts.lerobot ? null : formatTimestampNs(facts.startTimeNs)],
+    ["End time", facts.lerobot ? null : formatTimestampNs(facts.endTimeNs)],
     ["Topics", formatInteger(facts.topicCount)],
     ["Channels", formatInteger(facts.channelCount)],
     ["Messages", formatIntegerString(facts.messageCount)],
@@ -47,6 +47,7 @@ const RecordingSettings = memo(function RecordingSettings({
     ["App support", formatApplicationSupport(facts)],
   ];
   const mcapRows = facts.mcap ? mcapFactRows(facts) : [];
+  const leRobotRows = facts.lerobot ? leRobotFactRows(facts) : [];
 
   return (
     <SidebarGroup defaultExpanded={false} summary={summary} title="Recording">
@@ -58,6 +59,15 @@ const RecordingSettings = memo(function RecordingSettings({
           title="MCAP details"
         >
           <FactRows rows={mcapRows} />
+        </SidebarGroup>
+      ) : null}
+      {leRobotRows.length > 0 ? (
+        <SidebarGroup
+          defaultExpanded={false}
+          summary={leRobotDetailsSummary(facts)}
+          title="LeRobot details"
+        >
+          <FactRows rows={leRobotRows} />
         </SidebarGroup>
       ) : null}
       <div className={styles.recordingActions}>
@@ -90,6 +100,30 @@ function FactRows({ rows }: { readonly rows: readonly RecordingFactRow[] }) {
       ))}
     </div>
   );
+}
+
+function leRobotFactRows(
+  facts: EpisodeRecordingFacts,
+): readonly RecordingFactRow[] {
+  const lerobot = facts.lerobot;
+  if (!lerobot) return [];
+  return [
+    ["Codebase version", lerobot.codebaseVersion ?? null],
+    ["Episode index", lerobot.episodeIndex ?? null],
+    ["Robot type", lerobot.robotType ?? null],
+    ["FPS", lerobot.fps === undefined ? null : formatDecimal(lerobot.fps)],
+    ["Logical rows", formatInteger(lerobot.logicalRowCount)],
+    ["Features", formatInteger(lerobot.featureCount)],
+    ["Media features", formatInteger(lerobot.mediaFeatureCount)],
+    [
+      "Task labels",
+      lerobot.taskLabels?.length ? lerobot.taskLabels.join(" · ") : null,
+    ],
+    [
+      "Video codecs",
+      lerobot.videoCodecs?.length ? lerobot.videoCodecs.join(", ") : null,
+    ],
+  ];
 }
 
 function mcapFactRows(
@@ -187,6 +221,23 @@ function mcapDetailsSummary(facts: EpisodeRecordingFacts): string | undefined {
   const indexes = formatIndexStatus(facts.mcap?.messageIndexStatus);
   return (
     [chunks ? `${chunks} chunks` : null, indexes ? `${indexes} indexes` : null]
+      .filter(Boolean)
+      .join(" · ") || undefined
+  );
+}
+
+function leRobotDetailsSummary(
+  facts: EpisodeRecordingFacts,
+): string | undefined {
+  const lerobot = facts.lerobot;
+  if (!lerobot) return undefined;
+  return (
+    [
+      lerobot.robotType ?? null,
+      lerobot.logicalRowCount === undefined
+        ? null
+        : `${lerobot.logicalRowCount.toLocaleString()} rows`,
+    ]
       .filter(Boolean)
       .join(" · ") || undefined
   );

--- a/app/packages/multimodal/src/views/episode/settings/modal/RecordingSettings.tsx
+++ b/app/packages/multimodal/src/views/episode/settings/modal/RecordingSettings.tsx
@@ -41,7 +41,10 @@ const RecordingSettings = memo(function RecordingSettings({
     ["End time", facts.lerobot ? null : formatTimestampNs(facts.endTimeNs)],
     ["Topics", formatInteger(facts.topicCount)],
     ["Channels", formatInteger(facts.channelCount)],
-    ["Messages", formatIntegerString(facts.messageCount)],
+    [
+      "Messages",
+      facts.lerobot ? null : formatIntegerString(facts.messageCount),
+    ],
     ["Schemas", formatInteger(facts.schemaCount)],
     ["Schema coverage", formatSchemaCoverage(facts)],
     ["App support", formatApplicationSupport(facts)],

--- a/app/packages/multimodal/src/views/episode/settings/modal/RecordingSettings.tsx
+++ b/app/packages/multimodal/src/views/episode/settings/modal/RecordingSettings.tsx
@@ -61,7 +61,7 @@ const RecordingSettings = memo(function RecordingSettings({
           <FactRows rows={mcapRows} />
         </SidebarGroup>
       ) : null}
-      {leRobotRows.length > 0 ? (
+      {leRobotRows.some(([, value]) => value !== null) ? (
         <SidebarGroup
           defaultExpanded={false}
           summary={leRobotDetailsSummary(facts)}

--- a/app/packages/multimodal/src/views/episode/settings/modal/SettingsSidebar.test.tsx
+++ b/app/packages/multimodal/src/views/episode/settings/modal/SettingsSidebar.test.tsx
@@ -595,6 +595,7 @@ describe("SettingsSidebar", () => {
       recordingFacts: {
         durationNs: "1000000000",
         format: "lerobot",
+        messageCount: "30",
         lerobot: {
           codebaseVersion: "v3.0",
           episodeIndex: "7",

--- a/app/packages/multimodal/src/views/episode/settings/modal/SettingsSidebar.test.tsx
+++ b/app/packages/multimodal/src/views/episode/settings/modal/SettingsSidebar.test.tsx
@@ -549,7 +549,7 @@ describe("SettingsSidebar", () => {
     );
   });
 
-  it("labels video-backed image tiles as Video and hides unsupported inspection", () => {
+  it("labels video-backed image tiles as Video and omits unavailable count metadata", () => {
     renderSidebar({
       sources: [
         {
@@ -562,7 +562,7 @@ describe("SettingsSidebar", () => {
       streams: [
         {
           ...stream("observation.images.camera", {
-            count: "3",
+            approxRateHz: 2,
             decodeStatus: "decodable",
             encoding: "mp4",
             id: "camera",
@@ -582,6 +582,7 @@ describe("SettingsSidebar", () => {
     expect(
       screen.getByRole("button", { name: "Video observation.images.camera" }),
     ).toBeTruthy();
+    expect(screen.getByText("2 Hz · Image")).toBeTruthy();
     expect(
       screen.queryByRole("button", {
         name: "Inspect observation.images.camera",
@@ -605,7 +606,6 @@ describe("SettingsSidebar", () => {
           taskLabels: ["pick up cube"],
           videoCodecs: ["h264"],
         },
-        messageCount: "30",
         startTimeNs: "0",
         endTimeNs: "1000000000",
       },
@@ -614,7 +614,10 @@ describe("SettingsSidebar", () => {
     fireEvent.click(screen.getByRole("button", { name: /Recording LEROBOT/ }));
     expect(screen.queryByText("Start time")).toBeNull();
     expect(screen.queryByText("End time")).toBeNull();
+    expect(screen.queryByText("Messages")).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: /LeRobot details/ }));
+    expect(screen.getByText("Logical rows")).toBeTruthy();
+    expect(screen.getAllByText("30")).toHaveLength(2);
     expect(screen.getByText("v3.0")).toBeTruthy();
     expect(screen.getByText("pick up cube")).toBeTruthy();
   });
@@ -808,7 +811,7 @@ function stream(
     schema,
   }: {
     readonly approxRateHz?: number;
-    readonly count: string;
+    readonly count?: string;
     readonly decodeStatus: string;
     readonly encoding: string;
     readonly id?: string;
@@ -818,7 +821,7 @@ function stream(
   const sceneType = testSceneType(schema);
   return {
     ...(approxRateHz !== undefined ? { approxRateHz } : {}),
-    count: Number(count),
+    ...(count === undefined ? {} : { count: Number(count) }),
     id,
     kind: "unknown",
     metadata: {

--- a/app/packages/multimodal/src/views/episode/settings/modal/SettingsSidebar.test.tsx
+++ b/app/packages/multimodal/src/views/episode/settings/modal/SettingsSidebar.test.tsx
@@ -470,7 +470,7 @@ describe("SettingsSidebar", () => {
     ).toBeTruthy();
     expect(screen.getByText("/lidar/top")).toBeTruthy();
     expect(screen.getByText("/imu")).toBeTruthy();
-    expect(screen.getByText("8 msgs · 29.97 Hz · Plot · Raw")).toBeTruthy();
+    expect(screen.getByText("8 messages · 29.97 Hz · Plot · Raw")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Inspect /imu" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "3D /lidar/top" })).toBeTruthy();
     expect(
@@ -479,11 +479,11 @@ describe("SettingsSidebar", () => {
     expect(screen.queryByRole("button", { name: /Open 3D/ })).toBeNull();
     expect(screen.queryByRole("button", { name: /^Open / })).toBeNull();
     expect(
-      screen.getByRole("button", { name: "Inspect /broken" }),
-    ).toBeTruthy();
+      screen.queryByRole("button", { name: "Inspect /broken" }),
+    ).toBeNull();
     expect(
-      screen.getByRole("button", { name: "Inspect /binary" }),
-    ).toBeTruthy();
+      screen.queryByRole("button", { name: "Inspect /binary" }),
+    ).toBeNull();
     expect(screen.queryByText("Inspectable")).toBeNull();
     expect(screen.getByText("Schema unavailable")).toBeTruthy();
     expect(screen.getByText("Encoding unsupported")).toBeTruthy();
@@ -549,6 +549,76 @@ describe("SettingsSidebar", () => {
     );
   });
 
+  it("labels video-backed image tiles as Video and hides unsupported inspection", () => {
+    renderSidebar({
+      sources: [
+        {
+          id: "camera",
+          label: "camera",
+          sourceName: "observation.images.camera",
+          type: SCENE_SOURCE_TYPE.IMAGE,
+        },
+      ],
+      streams: [
+        {
+          ...stream("observation.images.camera", {
+            count: "3",
+            decodeStatus: "decodable",
+            encoding: "mp4",
+            id: "camera",
+            schema: "h264",
+          }),
+          kind: "video",
+          metadata: {
+            [SCENE_SOURCE_METADATA.SOURCE_NAME]: "observation.images.camera",
+            [SCENE_SOURCE_METADATA.TYPE]: SCENE_SOURCE_TYPE.IMAGE,
+            [STREAM_METADATA.INSPECTABLE]: "false",
+          },
+        },
+      ],
+    });
+
+    fireEvent.click(screen.getByRole("tab", { name: "Streams" }));
+    expect(
+      screen.getByRole("button", { name: "Video observation.images.camera" }),
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("button", {
+        name: "Inspect observation.images.camera",
+      }),
+    ).toBeNull();
+  });
+
+  it("renders LeRobot recording details without episode timestamps", () => {
+    renderSidebar({
+      recordingFacts: {
+        durationNs: "1000000000",
+        format: "lerobot",
+        lerobot: {
+          codebaseVersion: "v3.0",
+          episodeIndex: "7",
+          featureCount: 8,
+          fps: 30,
+          logicalRowCount: 30,
+          mediaFeatureCount: 2,
+          robotType: "so101",
+          taskLabels: ["pick up cube"],
+          videoCodecs: ["h264"],
+        },
+        messageCount: "30",
+        startTimeNs: "0",
+        endTimeNs: "1000000000",
+      },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Recording LEROBOT/ }));
+    expect(screen.queryByText("Start time")).toBeNull();
+    expect(screen.queryByText("End time")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: /LeRobot details/ }));
+    expect(screen.getByText("v3.0")).toBeTruthy();
+    expect(screen.getByText("pick up cube")).toBeTruthy();
+  });
+
   it("opens GPS streams in a Map panel without leaving Streams", () => {
     const { probeState } = renderSidebar({
       streams: [
@@ -563,7 +633,7 @@ describe("SettingsSidebar", () => {
 
     fireEvent.click(screen.getByRole("tab", { name: "Streams" }));
 
-    expect(screen.getByText("5 msgs · Map · Raw")).toBeTruthy();
+    expect(screen.getByText("5 messages · Map · Raw")).toBeTruthy();
     expect(screen.queryByRole("button", { name: "3D /gps" })).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Map /gps" }));
 
@@ -755,6 +825,8 @@ function stream(
       [SCENE_SOURCE_METADATA.SOURCE_NAME]: name,
       ...(sceneType ? { [SCENE_SOURCE_METADATA.TYPE]: sceneType } : {}),
       [STREAM_METADATA.DECODE_STATUS]: decodeStatus,
+      [STREAM_METADATA.INSPECTABLE]:
+        decodeStatus === "decodable" ? "true" : "false",
       [STREAM_METADATA.ENCODING]: encoding,
       [STREAM_METADATA.SCHEMA_NAME]: schema,
     },

--- a/app/packages/multimodal/src/views/episode/settings/modal/SettingsSidebar.test.tsx
+++ b/app/packages/multimodal/src/views/episode/settings/modal/SettingsSidebar.test.tsx
@@ -622,6 +622,24 @@ describe("SettingsSidebar", () => {
     expect(screen.getByText("pick up cube")).toBeTruthy();
   });
 
+  it("omits empty LeRobot recording details", () => {
+    renderSidebar({
+      recordingFacts: {
+        durationNs: "1000000000",
+        endTimeNs: "1000000000",
+        format: "lerobot",
+        lerobot: {},
+        startTimeNs: "0",
+      },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Recording LEROBOT/ }));
+
+    expect(
+      screen.queryByRole("button", { name: /LeRobot details/ }),
+    ).toBeNull();
+  });
+
   it("opens GPS streams in a Map panel without leaving Streams", () => {
     const { probeState } = renderSidebar({
       streams: [

--- a/app/packages/multimodal/src/views/episode/settings/modal/StreamsSettings.tsx
+++ b/app/packages/multimodal/src/views/episode/settings/modal/StreamsSettings.tsx
@@ -5,7 +5,7 @@ import {
   SCENE_SOURCE_TYPE,
   STREAM_CATEGORY,
   type StreamDescriptor,
-} from "../../../../ir";
+} from "../../../../ir/manifest";
 import type { EpisodeTerminology } from "../../../../ports";
 import {
   STREAM_CAPABILITY,

--- a/app/packages/multimodal/src/views/episode/settings/modal/StreamsSettings.tsx
+++ b/app/packages/multimodal/src/views/episode/settings/modal/StreamsSettings.tsx
@@ -1,12 +1,15 @@
 import { Input, InputType, Size } from "@voxel51/voodo";
 import React, { useMemo, useState } from "react";
 import { useSceneInventory } from "../../../../scene-inventory/react";
-import { SCENE_SOURCE_TYPE, type StreamDescriptor } from "../../../../ir";
+import {
+  SCENE_SOURCE_TYPE,
+  STREAM_CATEGORY,
+  type StreamDescriptor,
+} from "../../../../ir";
 import type { EpisodeTerminology } from "../../../../ports";
 import {
   STREAM_CAPABILITY,
   STREAM_CAPABILITY_LABEL,
-  STREAM_CATEGORY,
   STREAM_CATEGORY_LABEL,
   STREAM_CATEGORY_ORDER,
   STREAM_SUPPORT_LABEL,
@@ -142,6 +145,13 @@ function StreamRow({
   const capabilitySummary = row.capabilities
     .map((capability) => STREAM_CAPABILITY_LABEL[capability])
     .join(" · ");
+  const metadataSummary = [
+    row.countLabel,
+    row.rateLabel,
+    capabilitySummary || null,
+  ]
+    .filter((value): value is string => value !== null)
+    .join(" · ");
 
   return (
     <div className={styles.streamRow} title={streamDetails(row)}>
@@ -152,11 +162,7 @@ function StreamRow({
         ) : null}
       </div>
       <div className={styles.streamMetaLine}>
-        <span className={styles.streamMeta}>
-          {row.countLabel ?? ""}
-          {row.rateLabel ? ` · ${row.rateLabel}` : ""}
-          {capabilitySummary ? ` · ${capabilitySummary}` : ""}
-        </span>
+        <span className={styles.streamMeta}>{metadataSummary}</span>
         <div className={styles.streamActions}>
           {actions.map((action) => (
             <button

--- a/app/packages/multimodal/src/views/episode/settings/modal/StreamsSettings.tsx
+++ b/app/packages/multimodal/src/views/episode/settings/modal/StreamsSettings.tsx
@@ -153,7 +153,7 @@ function StreamRow({
       </div>
       <div className={styles.streamMetaLine}>
         <span className={styles.streamMeta}>
-          {row.countLabel}
+          {row.countLabel ?? ""}
           {row.rateLabel ? ` · ${row.rateLabel}` : ""}
           {capabilitySummary ? ` · ${capabilitySummary}` : ""}
         </span>
@@ -201,9 +201,9 @@ function streamActionsForRow(
 
   if (row.sourceType === SCENE_SOURCE_TYPE.IMAGE) {
     actions.push({
-      ariaLabel: `Image ${row.sourceName}`,
+      ariaLabel: `${row.kind === "video" ? "Video" : "Image"} ${row.sourceName}`,
       id: "image",
-      label: "Image",
+      label: row.kind === "video" ? "Video" : "Image",
       onClick: () => handlers.openImageTile(row.streamId),
     });
   }
@@ -238,16 +238,18 @@ function streamActionsForRow(
     });
   }
 
-  actions.push({
-    ariaLabel: `Inspect ${row.sourceName}`,
-    id: "inspect",
-    label: "Inspect",
-    onClick: () =>
-      handlers.openRawMessageTile({
-        sourceName: row.sourceName,
-        streamId: row.streamId,
-      }),
-  });
+  if (row.canInspect) {
+    actions.push({
+      ariaLabel: `Inspect ${row.sourceName}`,
+      id: "inspect",
+      label: "Inspect",
+      onClick: () =>
+        handlers.openRawMessageTile({
+          sourceName: row.sourceName,
+          streamId: row.streamId,
+        }),
+    });
+  }
 
   return actions;
 }

--- a/app/packages/multimodal/src/views/episode/shell/AddTileMenu.test.tsx
+++ b/app/packages/multimodal/src/views/episode/shell/AddTileMenu.test.tsx
@@ -145,6 +145,7 @@ describe("tileTypesFor", () => {
       tileTypesFor({
         hasNumericSeries: true,
         hasRawRecords: false,
+        hasStateAction: false,
         hasTransformTopology: false,
         sourceTypes: ["image", "location"],
       }),
@@ -154,6 +155,7 @@ describe("tileTypesFor", () => {
       tileTypesFor({
         hasNumericSeries: false,
         hasRawRecords: true,
+        hasStateAction: false,
         hasTransformTopology: false,
         sourceTypes: [],
       }),
@@ -165,6 +167,7 @@ describe("tileTypesFor", () => {
       tileTypesFor({
         hasNumericSeries: false,
         hasRawRecords: false,
+        hasStateAction: false,
         hasTransformTopology: true,
         sourceTypes: ["point-cloud"],
       }),
@@ -173,6 +176,7 @@ describe("tileTypesFor", () => {
       tileTypesFor({
         hasNumericSeries: false,
         hasRawRecords: false,
+        hasStateAction: false,
         hasTransformTopology: false,
         sourceTypes: ["point-cloud"],
       }),
@@ -193,6 +197,7 @@ describe("tileTypesFor", () => {
       tileTypesFor({
         hasNumericSeries: true,
         hasRawRecords: false,
+        hasStateAction: false,
         hasTransformTopology: false,
         sourceTypes: ["event"],
       }),

--- a/app/packages/multimodal/src/views/episode/shell/ModalRenderer.tsx
+++ b/app/packages/multimodal/src/views/episode/shell/ModalRenderer.tsx
@@ -3,6 +3,7 @@ import React, { useMemo } from "react";
 import { sampleDescriptorFromContext } from "../../session/episode-source";
 import { useEpisodeSession } from "../../session/use-episode-session";
 import { useStableEpisodeSource } from "../../session/use-stable-episode-source";
+import { episodeDisplayName } from "../../session/episode-label";
 import {
   AnnotationStreamsProvider,
   TimelineExtensionHost,
@@ -31,7 +32,10 @@ const ModalRenderer: React.FC<SampleRendererProps> = ({ ctx }) => {
   const sampleDescriptor = sampleDescriptorFromContext(ctx);
   const sessionState = useEpisodeSession(sampleDescriptor, episodeSource);
   const timeRange = useTimeRange(sessionState.session);
-  const fileName = sourceDisplayName(ctx.media.path) ?? "recording";
+  const fileName =
+    episodeDisplayName(ctx.sample.sample) ??
+    sourceDisplayName(ctx.media.path) ??
+    "recording";
   const datasetId = ctx.dataset.datasetId;
   const sampleId = ctx.sample.sample._id;
   const {

--- a/app/packages/multimodal/src/views/episode/shell/RightSidebar.test.tsx
+++ b/app/packages/multimodal/src/views/episode/shell/RightSidebar.test.tsx
@@ -11,6 +11,15 @@ import RightSidebar from "./RightSidebar";
 vi.mock("../scene/picking/InspectorSidebar", () => ({
   default: () => <div data-testid="stub-inspector" />,
 }));
+vi.mock("../state-action/StateActionStatisticsSidebar", () => ({
+  default: () => <div data-testid="stub-statistics" />,
+}));
+const stateActionMocks = vi.hoisted(() => ({
+  schema: null as unknown,
+}));
+vi.mock("../state-action/state-action-context", () => ({
+  useStateActionSchemaIfPresent: () => stateActionMocks.schema,
+}));
 vi.mock("./FieldsSidebar", () => ({
   default: () => <div data-testid="stub-fields" />,
 }));
@@ -82,5 +91,18 @@ describe("RightSidebar", () => {
 
     expect(screen.getByTestId("stub-fields")).toBeTruthy();
     expect(screen.queryByTestId("stub-inspector")).toBeNull();
+  });
+
+  it("swaps Inspect for Statistics when the session has state/action", () => {
+    stateActionMocks.schema = { rowCount: 167 };
+    try {
+      render(<RightSidebar />);
+      expect(screen.getByText("Statistics")).toBeTruthy();
+      expect(screen.queryByText("Inspect")).toBeNull();
+      expect(screen.getByTestId("stub-statistics")).toBeTruthy();
+      expect(screen.queryByTestId("stub-inspector")).toBeNull();
+    } finally {
+      stateActionMocks.schema = null;
+    }
   });
 });

--- a/app/packages/multimodal/src/views/episode/shell/RightSidebar.tsx
+++ b/app/packages/multimodal/src/views/episode/shell/RightSidebar.tsx
@@ -1,24 +1,40 @@
 import React from "react";
 import InspectorSidebar from "../scene/picking/InspectorSidebar";
 import EpisodeSidebarTabs from "../settings/controls/EpisodeSidebarTabs";
+import { useStateActionSchemaIfPresent } from "../state-action/state-action-context";
+import StateActionStatisticsSidebar from "../state-action/StateActionStatisticsSidebar";
 import FieldsSidebar from "./FieldsSidebar";
 
 /**
- * MM right panel: "Inspect" / "Fields" tabs, through the same
- * `EpisodeSidebarTabs` shell the left sidebar (`SettingsSidebar`) uses, so
- * both stay visually and structurally identical.
+ * MM right panel, through the same `EpisodeSidebarTabs` shell the left
+ * sidebar (`SettingsSidebar`) uses, so both stay visually and structurally
+ * identical.
+ *
+ * The first tab is format-aware: state/action sessions (LeRobot) have no
+ * pickable objects, so they get a "Statistics" tab of dataset-declared
+ * per-dimension facts instead of the object "Inspect" tab MCAP keeps.
  *
  * A bottom discussion tray (Teams-only, via an OSS extension seam) lands in
  * a follow-up PR once the Teams-side registration exists.
  */
 const RightSidebar: React.FC = () => {
+  const stateActionSchema = useStateActionSchemaIfPresent();
   return (
     <EpisodeSidebarTabs
+      remountKey={stateActionSchema ? "statistics" : "inspect"}
       tabs={[
-        {
-          id: "inspect",
-          data: { label: "Inspect", content: <InspectorSidebar /> },
-        },
+        stateActionSchema
+          ? {
+              id: "statistics",
+              data: {
+                label: "Statistics",
+                content: <StateActionStatisticsSidebar />,
+              },
+            }
+          : {
+              id: "inspect",
+              data: { label: "Inspect", content: <InspectorSidebar /> },
+            },
         {
           id: "fields",
           data: { label: "Fields", content: <FieldsSidebar /> },

--- a/app/packages/multimodal/src/views/episode/shell/SourcePlayback.tsx
+++ b/app/packages/multimodal/src/views/episode/shell/SourcePlayback.tsx
@@ -106,6 +106,7 @@ export const TRANSITION_STATUS_DELAY_MS = 200;
 interface ReadyInventory {
   readonly hasNumericSeries: boolean;
   readonly hasRawRecords: boolean;
+  readonly hasStateAction: boolean;
   readonly hasTransformTopology: boolean;
   readonly recordingFacts?: EpisodeRecordingFacts;
   readonly sources: readonly SceneSource[];
@@ -278,6 +279,7 @@ const SourcePlaybackContent: React.FC<SourcePlaybackProps> = ({
         ? {
             hasNumericSeries: session?.numericSeries !== undefined,
             hasRawRecords: session?.rawRecords !== undefined,
+            hasStateAction: session?.stateAction !== undefined,
             hasTransformTopology: session?.transformTopology !== undefined,
             recordingFacts: session?.manifest?.recordingFacts,
             sources,
@@ -290,6 +292,7 @@ const SourcePlaybackContent: React.FC<SourcePlaybackProps> = ({
       session?.numericSeries,
       session?.rawRecords,
       session?.manifest?.recordingFacts,
+      session?.stateAction,
       session?.transformTopology,
       session?.terminology,
       sources,
@@ -306,6 +309,7 @@ const SourcePlaybackContent: React.FC<SourcePlaybackProps> = ({
     return {
       hasNumericSeries: false,
       hasRawRecords: false,
+      hasStateAction: false,
       hasTransformTopology: false,
       recordingFacts: manifest.recordingFacts,
       sources,
@@ -425,6 +429,7 @@ const SourcePlaybackContent: React.FC<SourcePlaybackProps> = ({
       tileTypesFor({
         hasNumericSeries: shellInventory?.hasNumericSeries ?? false,
         hasRawRecords: shellInventory?.hasRawRecords ?? false,
+        hasStateAction: shellInventory?.hasStateAction ?? false,
         hasTransformTopology: shellInventory?.hasTransformTopology ?? false,
         sourceTypes: shellSources.map((source) => source.type),
       }),

--- a/app/packages/multimodal/src/views/episode/shell/SourcePlayback.tsx
+++ b/app/packages/multimodal/src/views/episode/shell/SourcePlayback.tsx
@@ -66,6 +66,7 @@ import { MapViewportScopeProvider } from "../map/viewport/context";
 import { NumericSeriesProvider } from "../plots/numeric-series-context";
 import { PoseTrajectoriesProvider } from "../scene/entities/pose-trajectories-context";
 import { RawMessageProvider } from "../raw/raw-message-context";
+import { StateActionProvider } from "../state-action/state-action-context";
 import { SceneUpdateHistoryProvider } from "../scene/entities/scene-update-history-context";
 import { SelectionHotkeys } from "../interaction/selection/selected-object";
 import AddTileMenu from "./AddTileMenu";
@@ -541,177 +542,188 @@ const SourcePlaybackContent: React.FC<SourcePlaybackProps> = ({
               <SceneUpdateHistoryProvider>
                 <NumericSeriesProvider>
                   <RawMessageProvider>
-                    <LogConsoleProvider
-                      budgetAccount={sourceReadBudgetAccount}
-                      session={readyInventory ? session : null}
-                      sourceKey={playbackSource ? sourceAccessKey : null}
-                    >
-                      <DataStreamProvider
-                        expectedSourceKey={
-                          playbackSource ? sourceAccessKey : null
-                        }
+                    <StateActionProvider>
+                      <LogConsoleProvider
+                        budgetAccount={sourceReadBudgetAccount}
+                        session={readyInventory ? session : null}
+                        sourceKey={playbackSource ? sourceAccessKey : null}
                       >
-                        <SourceVideoPlaybackProvider
-                          sourceKey={playbackSource ? sourceAccessKey : null}
+                        <DataStreamProvider
+                          expectedSourceKey={
+                            playbackSource ? sourceAccessKey : null
+                          }
                         >
-                          <SourceResourceBoundary />
-                          <Scene3dViewSettingsProvider
-                            defaultTrackingMode={defaultTrackingMode}
-                            preferredCameraTargetFrameId={
-                              preferredCameraTargetFrameId
-                            }
-                            preferredWorldFrameId={preferredWorldFrameId}
-                            sceneUpAxis={sceneUpAxis}
-                            setDefaultTrackingMode={onDefaultTrackingModeChange}
-                            setPreferredCameraTargetFrameId={
-                              onPreferredCameraTargetFrameIdChange
-                            }
-                            setPreferredWorldFrameId={
-                              onPreferredWorldFrameIdChange
-                            }
-                            setSceneUpAxis={onSceneUpAxisChange}
+                          <SourceVideoPlaybackProvider
+                            sourceKey={playbackSource ? sourceAccessKey : null}
                           >
-                            <ImageAspectRatioProvider
-                              onChange={onImageAspectRatioChange}
+                            <SourceResourceBoundary />
+                            <Scene3dViewSettingsProvider
+                              defaultTrackingMode={defaultTrackingMode}
+                              preferredCameraTargetFrameId={
+                                preferredCameraTargetFrameId
+                              }
+                              preferredWorldFrameId={preferredWorldFrameId}
+                              sceneUpAxis={sceneUpAxis}
+                              setDefaultTrackingMode={
+                                onDefaultTrackingModeChange
+                              }
+                              setPreferredCameraTargetFrameId={
+                                onPreferredCameraTargetFrameIdChange
+                              }
+                              setPreferredWorldFrameId={
+                                onPreferredWorldFrameIdChange
+                              }
+                              setSceneUpAxis={onSceneUpAxisChange}
                             >
-                              <PlaybackShell
-                                key={playbackShellKey}
-                                fileName={fileName}
-                                decorateTrack={decorateTrack}
-                                headerCaption={headerCaption}
-                                headerActions={
-                                  <HeaderActions
-                                    actions={
-                                      episodeContext &&
-                                      session?.manifest &&
-                                      source ? (
-                                        <>
-                                          {headerActions}
-                                          <EpisodeHeaderActions
-                                            context={episodeContext}
-                                            rawRecords={session.rawRecords}
-                                            recordingFacts={
-                                              session.manifest.recordingFacts
-                                            }
-                                            source={source}
-                                            streams={shellStreams}
-                                            timeRange={
-                                              session.manifest.timeRange
-                                            }
-                                            transformTopology={
-                                              session.manifest.transformTopology
-                                            }
-                                          />
-                                        </>
-                                      ) : (
-                                        headerActions
-                                      )
+                              <ImageAspectRatioProvider
+                                onChange={onImageAspectRatioChange}
+                              >
+                                <PlaybackShell
+                                  key={playbackShellKey}
+                                  fileName={fileName}
+                                  decorateTrack={decorateTrack}
+                                  headerCaption={headerCaption}
+                                  headerActions={
+                                    <HeaderActions
+                                      actions={
+                                        episodeContext &&
+                                        session?.manifest &&
+                                        source ? (
+                                          <>
+                                            {headerActions}
+                                            <EpisodeHeaderActions
+                                              context={episodeContext}
+                                              rawRecords={session.rawRecords}
+                                              recordingFacts={
+                                                session.manifest.recordingFacts
+                                              }
+                                              source={source}
+                                              streams={shellStreams}
+                                              timeRange={
+                                                session.manifest.timeRange
+                                              }
+                                              transformTopology={
+                                                session.manifest
+                                                  .transformTopology
+                                              }
+                                            />
+                                          </>
+                                        ) : (
+                                          headerActions
+                                        )
+                                      }
+                                      loading={
+                                        transitioning && !hasTerminalTransition
+                                      }
+                                    />
+                                  }
+                                  addTileMenu={
+                                    <AddTileMenu
+                                      tileTypes={availableTileTypes}
+                                    />
+                                  }
+                                  timelineReadouts={<TimestampReadout />}
+                                  sceneSources={shellSources}
+                                  mode={playbackTimelineMode}
+                                  deselectFocusedTileOnRepeatSelect={false}
+                                  initialTiles={initialTiles}
+                                  initialManualTileTitles={
+                                    initialManualTileTitles
+                                  }
+                                  autoLayoutStrategy={autoLayoutStrategy}
+                                  initialLayout={initialLayout}
+                                  initialExpandedTileId={initialExpandedTileId}
+                                  resetTiles={resetTiles}
+                                  resetManualTileTitles={
+                                    EMPTY_MANUAL_TILE_TITLES
+                                  }
+                                  resetLayoutStrategy={autoLayoutStrategy}
+                                  tracks={
+                                    tracks && tracks.length > 0
+                                      ? [...tracks]
+                                      : undefined
+                                  }
+                                  defaultPinnedTrackIds={
+                                    defaultPinnedTrackIds &&
+                                    defaultPinnedTrackIds.length > 0
+                                      ? [...defaultPinnedTrackIds]
+                                      : undefined
+                                  }
+                                  onTagDelete={onTagDelete}
+                                  leftSidebar={
+                                    <SettingsSidebar
+                                      onTimelineSamplingRateChange={
+                                        onTimelineSamplingRateChange
+                                      }
+                                      recordingFacts={
+                                        destinationInventory?.recordingFacts
+                                      }
+                                      streams={
+                                        destinationInventory?.streams ?? []
+                                      }
+                                      terminology={
+                                        destinationInventory?.terminology
+                                      }
+                                      timelineSamplingRateHz={
+                                        timelineSamplingRateHz
+                                      }
+                                    />
+                                  }
+                                  mainOverlay={
+                                    hasTerminalTransition ? (
+                                      <PlaybackState
+                                        error={status === "error"}
+                                        text={transitionMessage}
+                                      />
+                                    ) : null
+                                  }
+                                  rightSidebar={<RightSidebar />}
+                                  sharedImageWebGpuViews
+                                  defaultRightOpen={false}
+                                  defaultLeftOpen={defaultLeftOpen}
+                                  onLeftOpenChange={onLeftOpenChange}
+                                  leftSidebarWidth={defaultLeftSidebarWidth}
+                                  onLeftSidebarWidthChange={
+                                    onLeftSidebarWidthChange
+                                  }
+                                  onTagCreate={onTagCreate}
+                                  onTagUpdate={onTagUpdate}
+                                  onTimelineDrawerOpenChange={
+                                    onTimelineDrawerOpenChange
+                                  }
+                                  timelineDrawerMaxSize={timelineDrawerMaxSize}
+                                >
+                                  <Streams
+                                    availableTileTypes={availableTileTypes}
+                                    budgetAccount={sourceReadBudgetAccount}
+                                    initialSeekTimeNs={initialSeekTimeNs}
+                                    onPlayheadDataReady={
+                                      handlePlayheadDataReady
                                     }
-                                    loading={
-                                      transitioning && !hasTerminalTransition
-                                    }
-                                  />
-                                }
-                                addTileMenu={
-                                  <AddTileMenu tileTypes={availableTileTypes} />
-                                }
-                                timelineReadouts={<TimestampReadout />}
-                                sceneSources={shellSources}
-                                mode={playbackTimelineMode}
-                                deselectFocusedTileOnRepeatSelect={false}
-                                initialTiles={initialTiles}
-                                initialManualTileTitles={
-                                  initialManualTileTitles
-                                }
-                                autoLayoutStrategy={autoLayoutStrategy}
-                                initialLayout={initialLayout}
-                                initialExpandedTileId={initialExpandedTileId}
-                                resetTiles={resetTiles}
-                                resetManualTileTitles={EMPTY_MANUAL_TILE_TITLES}
-                                resetLayoutStrategy={autoLayoutStrategy}
-                                tracks={
-                                  tracks && tracks.length > 0
-                                    ? [...tracks]
-                                    : undefined
-                                }
-                                defaultPinnedTrackIds={
-                                  defaultPinnedTrackIds &&
-                                  defaultPinnedTrackIds.length > 0
-                                    ? [...defaultPinnedTrackIds]
-                                    : undefined
-                                }
-                                onTagDelete={onTagDelete}
-                                leftSidebar={
-                                  <SettingsSidebar
-                                    onTimelineSamplingRateChange={
-                                      onTimelineSamplingRateChange
-                                    }
-                                    recordingFacts={
-                                      destinationInventory?.recordingFacts
-                                    }
-                                    streams={
-                                      destinationInventory?.streams ?? []
-                                    }
-                                    terminology={
-                                      destinationInventory?.terminology
-                                    }
+                                    session={readyInventory ? session : null}
+                                    source={playbackSource}
                                     timelineSamplingRateHz={
                                       timelineSamplingRateHz
                                     }
                                   />
-                                }
-                                mainOverlay={
-                                  hasTerminalTransition ? (
-                                    <PlaybackState
-                                      error={status === "error"}
-                                      text={transitionMessage}
-                                    />
-                                  ) : null
-                                }
-                                rightSidebar={<RightSidebar />}
-                                sharedImageWebGpuViews
-                                defaultRightOpen={false}
-                                defaultLeftOpen={defaultLeftOpen}
-                                onLeftOpenChange={onLeftOpenChange}
-                                leftSidebarWidth={defaultLeftSidebarWidth}
-                                onLeftSidebarWidthChange={
-                                  onLeftSidebarWidthChange
-                                }
-                                onTagCreate={onTagCreate}
-                                onTagUpdate={onTagUpdate}
-                                onTimelineDrawerOpenChange={
-                                  onTimelineDrawerOpenChange
-                                }
-                                timelineDrawerMaxSize={timelineDrawerMaxSize}
-                              >
-                                <Streams
-                                  availableTileTypes={availableTileTypes}
-                                  budgetAccount={sourceReadBudgetAccount}
-                                  initialSeekTimeNs={initialSeekTimeNs}
-                                  onPlayheadDataReady={handlePlayheadDataReady}
-                                  session={readyInventory ? session : null}
-                                  source={playbackSource}
-                                  timelineSamplingRateHz={
-                                    timelineSamplingRateHz
-                                  }
-                                />
-                                <NetworkHealthTracker
-                                  playback={session?.playback ?? null}
-                                />
-                                <RegisterMcapAudioStreams />
-                                <SelectionHotkeys />
-                                <ExtensionRuntimeBoundary>
-                                  {children}
-                                </ExtensionRuntimeBoundary>
-                                <ModalLayoutPersistence
-                                  datasetId={effectiveLayoutScopeKey}
-                                />
-                              </PlaybackShell>
-                            </ImageAspectRatioProvider>
-                          </Scene3dViewSettingsProvider>
-                        </SourceVideoPlaybackProvider>
-                      </DataStreamProvider>
-                    </LogConsoleProvider>
+                                  <NetworkHealthTracker
+                                    playback={session?.playback ?? null}
+                                  />
+                                  <RegisterMcapAudioStreams />
+                                  <SelectionHotkeys />
+                                  <ExtensionRuntimeBoundary>
+                                    {children}
+                                  </ExtensionRuntimeBoundary>
+                                  <ModalLayoutPersistence
+                                    datasetId={effectiveLayoutScopeKey}
+                                  />
+                                </PlaybackShell>
+                              </ImageAspectRatioProvider>
+                            </Scene3dViewSettingsProvider>
+                          </SourceVideoPlaybackProvider>
+                        </DataStreamProvider>
+                      </LogConsoleProvider>
+                    </StateActionProvider>
                   </RawMessageProvider>
                 </NumericSeriesProvider>
               </SceneUpdateHistoryProvider>

--- a/app/packages/multimodal/src/views/episode/shell/Streams.tsx
+++ b/app/packages/multimodal/src/views/episode/shell/Streams.tsx
@@ -19,6 +19,7 @@ import { LocationTracksBridge } from "../map/tracks/context";
 import { NumericSeriesBridge } from "../plots/numeric-series-context";
 import { PoseTrajectoriesStartupGate } from "../scene/entities/pose-trajectories-context";
 import { RawMessageBridge } from "../raw/raw-message-context";
+import { StateActionBridge } from "../state-action/state-action-context";
 import { SceneUpdateHistoryBridge } from "../scene/entities/scene-update-history-context";
 import { useDataStream } from "../playback/data-stream-context";
 import { useFrameTransforms } from "../spatial/frame-transforms/use-frame-transforms";
@@ -74,6 +75,7 @@ export function Streams({
     fullHistoryStreams.get("scene-update") ?? EMPTY_STREAMS;
   const numericSeries = session?.numericSeries ?? null;
   const rawRecords = session?.rawRecords ?? null;
+  const stateAction = session?.stateAction ?? null;
   const transformRead = useMemo(
     () => (session ? createEpisodeTransformReadRuntime(session) : null),
     [session],
@@ -235,6 +237,7 @@ export function Streams({
       />
       <NumericSeriesBridge capability={numericSeries} sourceKey={sourceKey} />
       <RawMessageBridge capability={rawRecords} sourceKey={sourceKey} />
+      <StateActionBridge capability={stateAction} sourceKey={sourceKey} />
     </>
   );
 }

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionStatisticsSidebar.module.css
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionStatisticsSidebar.module.css
@@ -8,28 +8,6 @@
   gap: 12px;
 }
 
-.title {
-  align-items: center;
-  color: var(--color-content-text-primary);
-  display: flex;
-  font-size: 12px;
-  font-weight: 600;
-  gap: 8px;
-}
-
-.titleBadge {
-  background: color-mix(
-    in srgb,
-    var(--color-content-text-secondary) 18%,
-    transparent
-  );
-  border-radius: 8px;
-  color: var(--color-content-text-secondary);
-  font-size: 10px;
-  font-weight: 400;
-  padding: 1px 6px;
-}
-
 .feature {
   display: flex;
   flex-direction: column;

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionStatisticsSidebar.module.css
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionStatisticsSidebar.module.css
@@ -174,14 +174,12 @@
   gap: 2px 4px;
 }
 
-.episodeLabel {
-  font-size: 9px;
-  opacity: 0.7;
-  text-transform: uppercase;
-}
-
 .episodeOutOfRange {
   color: var(--color-content-text-destructive);
+  font-size: 9px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .seekButton {

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionStatisticsSidebar.module.css
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionStatisticsSidebar.module.css
@@ -85,6 +85,18 @@
   text-align: right;
 }
 
+.scopeRow {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+}
+
+.scopeLabel {
+  color: var(--color-content-text-secondary);
+  font-size: 9px;
+  text-transform: uppercase;
+}
+
 .caption {
   color: var(--color-content-text-secondary);
   font-size: 10px;
@@ -121,6 +133,20 @@
   top: 0;
 }
 
+/* This episode's observed range, drawn over the dataset band so an
+   episode hugging one edge of its declared range reads at a glance. */
+.rangeEpisode {
+  background: color-mix(
+    in srgb,
+    var(--color-voxel-secondary, #f5b700) 45%,
+    transparent
+  );
+  border-radius: 2px;
+  height: 2px;
+  position: absolute;
+  top: 1px;
+}
+
 .rangeMean {
   background: var(--color-voxel-secondary, #f5b700);
   height: 8px;
@@ -128,4 +154,74 @@
   top: -2px;
   transform: translateX(-50%);
   width: 2px;
+}
+
+.timingLine {
+  align-items: baseline;
+  color: var(--color-content-text-secondary);
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 10px;
+  gap: 2px 6px;
+}
+
+.episodeLine {
+  align-items: baseline;
+  color: var(--color-content-text-secondary);
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 10px;
+  gap: 2px 4px;
+}
+
+.episodeLabel {
+  font-size: 9px;
+  opacity: 0.7;
+  text-transform: uppercase;
+}
+
+.episodeOutOfRange {
+  color: var(--color-content-text-destructive);
+}
+
+.seekButton {
+  background: transparent;
+  border: none;
+  border-radius: 3px;
+  color: var(--color-content-text-primary);
+  cursor: pointer;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 10px;
+  padding: 0 2px;
+  text-decoration: underline dotted
+    color-mix(in srgb, var(--color-content-text-secondary) 60%, transparent);
+  text-underline-offset: 2px;
+}
+
+.seekButton:hover {
+  background: color-mix(
+    in srgb,
+    var(--color-content-text-secondary) 16%,
+    transparent
+  );
+  color: var(--color-voxel-secondary, #f5b700);
+}
+
+.seekButton:focus-visible {
+  outline: 1px solid var(--color-voxel-secondary, #f5b700);
+  outline-offset: 1px;
+}
+
+.statSeekCell {
+  overflow: hidden;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.trackingRow {
+  align-items: center;
+  display: grid;
+  gap: 6px;
+  grid-template-columns: minmax(56px, 1fr) minmax(44px, auto);
+  min-height: 16px;
 }

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionStatisticsSidebar.module.css
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionStatisticsSidebar.module.css
@@ -1,0 +1,153 @@
+/* Statistics tab for state/action sessions: dataset-declared
+   per-dimension statistics as compact monospace rows, each with a
+   min–max strip carrying the q01–q99 band and a mean tick. */
+
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.title {
+  align-items: center;
+  color: var(--color-content-text-primary);
+  display: flex;
+  font-size: 12px;
+  font-weight: 600;
+  gap: 8px;
+}
+
+.titleBadge {
+  background: color-mix(
+    in srgb,
+    var(--color-content-text-secondary) 18%,
+    transparent
+  );
+  border-radius: 8px;
+  color: var(--color-content-text-secondary);
+  font-size: 10px;
+  font-weight: 400;
+  padding: 1px 6px;
+}
+
+.feature {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.featureHeading {
+  align-items: baseline;
+  color: var(--color-content-text-primary);
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 11px;
+  font-weight: 600;
+  gap: 4px 8px;
+}
+
+.featureSchema {
+  background: color-mix(
+    in srgb,
+    var(--color-content-text-secondary) 18%,
+    transparent
+  );
+  border-radius: 8px;
+  color: var(--color-content-text-secondary);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 10px;
+  font-weight: 400;
+  padding: 1px 6px;
+}
+
+.statRow {
+  align-items: center;
+  display: grid;
+  gap: 6px;
+  grid-template-columns:
+    minmax(56px, 1fr) minmax(44px, auto) minmax(44px, auto)
+    minmax(44px, auto);
+  min-height: 18px;
+}
+
+.statHeader,
+.statHeaderValue {
+  color: var(--color-content-text-secondary);
+  font-size: 9px;
+  text-transform: uppercase;
+}
+
+.statHeaderValue {
+  text-align: right;
+}
+
+.statName {
+  color: var(--color-content-text-secondary);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 10px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.statValue {
+  color: var(--color-content-text-primary);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 10px;
+  overflow: hidden;
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.statMissing {
+  color: var(--color-content-text-secondary);
+  font-size: 10px;
+  opacity: 0.6;
+  text-align: right;
+}
+
+.caption {
+  color: var(--color-content-text-secondary);
+  font-size: 10px;
+  line-height: 1.45;
+}
+
+.dimBlock {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 2px 0 4px;
+}
+
+.rangeBar {
+  background: color-mix(
+    in srgb,
+    var(--color-content-text-secondary) 14%,
+    transparent
+  );
+  border-radius: 2px;
+  height: 4px;
+  position: relative;
+}
+
+.rangeBand {
+  background: color-mix(
+    in srgb,
+    var(--color-content-text-secondary) 45%,
+    transparent
+  );
+  border-radius: 2px;
+  height: 100%;
+  position: absolute;
+  top: 0;
+}
+
+.rangeMean {
+  background: var(--color-voxel-secondary, #f5b700);
+  height: 8px;
+  position: absolute;
+  top: -2px;
+  transform: translateX(-50%);
+  width: 2px;
+}

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionStatisticsSidebar.test.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionStatisticsSidebar.test.tsx
@@ -179,7 +179,9 @@ describe("StateActionStatisticsSidebar", () => {
       "2.677",
     ]);
     // Quantiles and std ride the row's hover detail, not extra columns.
-    expect(firstRow.title).toBe("q01 -2.4 · q50 0.08 · q99 2.5 · std 0.9");
+    expect(firstRow.parentElement?.title).toBe(
+      "q01 -2.4 · q50 0.08 · q99 2.5 · std 0.9",
+    );
     // One distribution strip per dimension with declared stats.
     expect(
       within(statePane).queryAllByRole("row").length,
@@ -246,14 +248,23 @@ describe("StateActionStatisticsSidebar", () => {
     const statePane = screen.getByRole("table", {
       name: "observation.state declared statistics",
     });
-    const firstRow = within(statePane)
-      .getAllByRole("row")
-      .find((row) => within(row).queryByText("joint_0")) as HTMLElement;
+    const rows = within(statePane).getAllByRole("row");
+    const declaredRow = rows.find((row) =>
+      within(row).queryByText("joint_0"),
+    ) as HTMLElement;
+    const episodeRow = rows.find((row) =>
+      within(row).queryByText("14 outside"),
+    ) as HTMLElement;
     expect(
-      within(firstRow)
+      within(declaredRow)
         .getAllByRole("cell")
         .map((cell) => cell.textContent),
-    ).toEqual(["-2.672", "—", "2.677", "-2.1", "0.2", "1.9"]);
+    ).toEqual(["-2.672", "—", "2.677"]);
+    expect(
+      within(episodeRow)
+        .getAllByRole("cell")
+        .map((cell) => cell.textContent),
+    ).toEqual(["14 outside", "-2.1", "0.2", "1.9"]);
     expect(screen.getByText("14 outside")).toBeDefined();
     expect(screen.getAllByText(/outside/).length).toBe(1);
     // The episode strip overlays the declared bar.

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionStatisticsSidebar.test.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionStatisticsSidebar.test.tsx
@@ -84,7 +84,8 @@ describe("StateActionStatisticsSidebar", () => {
     });
     const { container } = render(<StateActionStatisticsSidebar />);
 
-    expect(screen.getByText("167 rows this episode")).toBeDefined();
+    // No panel title: the row count leads the caption line itself.
+    expect(screen.getByText(/^167 rows this episode/)).toBeDefined();
     await waitFor(() =>
       expect(screen.getByText(/across 53,102 frames/)).toBeDefined(),
     );

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionStatisticsSidebar.test.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionStatisticsSidebar.test.tsx
@@ -1,20 +1,48 @@
 import {
   cleanup,
+  fireEvent,
   render,
   screen,
   waitFor,
   within,
 } from "@testing-library/react";
+import { getDefaultStore } from "jotai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { StateActionStats } from "../../../ports";
+import type {
+  StateActionEpisodeProfile,
+  StateActionStats,
+} from "../../../ports";
 import type { StateActionSchemaState } from "./state-action-context";
+import {
+  readStoredStatsScope,
+  stateActionStatsScopeAtom,
+} from "./state-action-display";
 import StateActionStatisticsSidebar from "./StateActionStatisticsSidebar";
 
 const mocks = vi.hoisted(() => ({
+  dataStream: {
+    getTimelineIndex: () => ({
+      nsToSec: (timeNs: bigint) => Number(timeNs) / 1e9,
+      secToNs: (timeSec: number) => BigInt(Math.round(timeSec * 1e9)),
+      startTimeNs: 0n,
+    }),
+    sourceKey: "source-1",
+  },
   ensureSchema: vi.fn(),
   hasProvider: true,
+  pause: vi.fn(),
   readDimensionStats: vi.fn<() => Promise<StateActionStats | null>>(),
+  readEpisodeProfile: vi.fn<() => Promise<StateActionEpisodeProfile | null>>(),
   schema: { schema: null, status: "idle" } as unknown,
+  seek: vi.fn(),
+}));
+
+vi.mock("@fiftyone/playback/runtime", () => ({
+  usePlayback: () => ({ pause: mocks.pause, seek: mocks.seek }),
+}));
+
+vi.mock("../playback/data-stream-context", () => ({
+  useDataStream: () => mocks.dataStream,
 }));
 
 vi.mock("./state-action-context", () => ({
@@ -22,6 +50,7 @@ vi.mock("./state-action-context", () => ({
   useStateActionContext: () => ({
     ensureSchema: mocks.ensureSchema,
     readDimensionStats: mocks.readDimensionStats,
+    readEpisodeProfile: mocks.readEpisodeProfile,
     schema: mocks.schema as StateActionSchemaState,
   }),
 }));
@@ -48,14 +77,59 @@ const SCHEMA: StateActionSchemaState = {
   status: "ready",
 };
 
+const PROFILE: StateActionEpisodeProfile = {
+  action: {
+    max: [null, null],
+    mean: [null, null],
+    min: [null, null],
+    outOfRangeCounts: null,
+  },
+  rowCount: 167,
+  state: {
+    max: [
+      { frameIndex: 120, timestampNs: 8_000_000_000n, value: 1.9 },
+      { frameIndex: 60, timestampNs: 4_000_000_000n, value: 1 },
+    ],
+    mean: [0.2, 0.4],
+    min: [
+      { frameIndex: 43, timestampNs: 2_867_000_000n, value: -2.1 },
+      { frameIndex: 0, timestampNs: 0n, value: 0 },
+    ],
+    outOfRangeCounts: [14, null],
+  },
+  timing: {
+    gapCount: 3,
+    gaps: [
+      {
+        beforeFrameIndex: 88,
+        durationNs: 410_000_000n,
+        timestampNs: 6_100_000_000n,
+      },
+    ],
+    medianIntervalNs: 66_666_667n,
+  },
+  trackingError: [0.05, null],
+};
+
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.hasProvider = true;
   mocks.schema = SCHEMA;
   mocks.readDimensionStats.mockResolvedValue(null);
+  mocks.readEpisodeProfile.mockResolvedValue(null);
+  window.localStorage.clear();
+  getDefaultStore().set(stateActionStatsScopeAtom, "both");
 });
 
 afterEach(cleanup);
+
+/** Drives the voodo-backed scope select the way a keyboard user would. */
+function selectScope(value: string) {
+  const select = screen.getByRole("combobox", { name: /Scope/ });
+  fireEvent.focus(select);
+  fireEvent.change(select, { target: { value } });
+  fireEvent.keyDown(select, { key: "Enter" });
+}
 
 describe("StateActionStatisticsSidebar", () => {
   it("renders nothing without a provider or before the schema", () => {
@@ -127,5 +201,124 @@ describe("StateActionStatisticsSidebar", () => {
         screen.getByText(/declares no statistics \(meta\/stats\.json\)/),
       ).toBeDefined(),
     );
+  });
+
+  it("reports the recorded cadence and seeks to the largest gap", async () => {
+    mocks.readEpisodeProfile.mockResolvedValue(PROFILE);
+    render(<StateActionStatisticsSidebar />);
+
+    const line = await screen.findByTestId("episode-timing-line");
+    expect(line.textContent).toContain("Recorded cadence 15 Hz");
+    expect(line.textContent).toContain("3 irregular gaps");
+    fireEvent.click(
+      within(line).getByRole("button", { name: "largest 0.41s" }),
+    );
+    expect(mocks.pause).toHaveBeenCalled();
+    expect(mocks.seek).toHaveBeenCalledWith(6.1);
+  });
+
+  it("seeks to a dimension's episode extremes and counts declared-range violations", async () => {
+    mocks.readDimensionStats.mockResolvedValue({
+      state: { max: [2.677, 1], min: [-2.672, 0] },
+    });
+    mocks.readEpisodeProfile.mockResolvedValue(PROFILE);
+    const { container } = render(<StateActionStatisticsSidebar />);
+
+    const minButton = await screen.findByRole("button", {
+      name: "Seek to joint_0 episode minimum (frame 43)",
+    });
+    fireEvent.click(minButton);
+    expect(mocks.pause).toHaveBeenCalled();
+    expect(mocks.seek).toHaveBeenCalledWith(2.867);
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Seek to joint_0 episode maximum (frame 120)",
+      }),
+    );
+    expect(mocks.seek).toHaveBeenLastCalledWith(8);
+
+    // Out-of-range facts render only where declared bounds existed.
+    expect(screen.getByText("· 14 outside declared")).toBeDefined();
+    expect(screen.getAllByText(/outside declared/).length).toBe(1);
+    // The episode strip overlays the declared bar.
+    expect(container.querySelectorAll('[class*="rangeEpisode"]').length).toBe(
+      2,
+    );
+  });
+
+  it("scopes the tables to this episode with seekable extreme cells", async () => {
+    mocks.readDimensionStats.mockResolvedValue({
+      state: { max: [2.677, 1], min: [-2.672, 0] },
+    });
+    mocks.readEpisodeProfile.mockResolvedValue(PROFILE);
+    render(<StateActionStatisticsSidebar />);
+
+    selectScope("episode");
+    const statePane = await screen.findByRole("table", {
+      name: "observation.state episode statistics",
+    });
+    // Min and max cells carry this episode's numbers and seek on click.
+    const minButton = within(statePane).getByRole("button", {
+      name: "Seek to joint_0 episode minimum (frame 43)",
+    });
+    expect(minButton.textContent).toBe("-2.1");
+    fireEvent.click(minButton);
+    expect(mocks.seek).toHaveBeenCalledWith(2.867);
+    const firstRow = within(statePane)
+      .getAllByRole("row")
+      .find((row) => within(row).queryByText("joint_0")) as HTMLElement;
+    expect(within(firstRow).getByText("0.2")).toBeDefined();
+    // The separate per-dimension episode line folds into the table; only
+    // the out-of-range fact remains as its own note.
+    expect(screen.queryByText("episode")).toBe(null);
+    expect(screen.getByText("· 14 outside declared")).toBeDefined();
+    // The choice persists for the next session.
+    expect(readStoredStatsScope()).toBe("episode");
+  });
+
+  it("hides episode-computed facts in dataset scope", async () => {
+    mocks.readDimensionStats.mockResolvedValue({
+      sampleCount: 53102,
+      state: {
+        max: [2.677, 1],
+        mean: [0.1, 0.5],
+        min: [-2.672, 0],
+        q01: [-2.4, 0.01],
+        q99: [2.5, 0.99],
+      },
+    });
+    mocks.readEpisodeProfile.mockResolvedValue(PROFILE);
+    const { container } = render(<StateActionStatisticsSidebar />);
+
+    selectScope("dataset");
+    await waitFor(() =>
+      expect(screen.getByText(/across 53,102 frames/)).toBeDefined(),
+    );
+    // Give the profile promise time to land; dataset scope must still not
+    // surface any episode-computed fact.
+    await waitFor(() => expect(mocks.readEpisodeProfile).toHaveBeenCalled());
+    expect(screen.queryByTestId("episode-timing-line")).toBe(null);
+    expect(screen.queryByRole("table", { name: "Tracking error" })).toBe(null);
+    expect(screen.queryByText(/outside declared/)).toBe(null);
+    expect(container.querySelectorAll('[class*="rangeEpisode"]').length).toBe(
+      0,
+    );
+    expect(container.querySelectorAll('[class*="rangeBar"]').length).toBe(2);
+    expect(readStoredStatsScope()).toBe("dataset");
+  });
+
+  it("tabulates per-dimension tracking error when the profile carries it", async () => {
+    mocks.readEpisodeProfile.mockResolvedValue(PROFILE);
+    render(<StateActionStatisticsSidebar />);
+
+    const table = await screen.findByRole("table", {
+      name: "Tracking error",
+    });
+    const rows = within(table).getAllByRole("row");
+    expect(rows.length).toBe(2);
+    expect(within(rows[0]).getByText("joint_0")).toBeDefined();
+    expect(within(rows[0]).getByRole("cell").textContent).toBe("0.05");
+    // A dimension with no comparable finite pairs shows a placeholder.
+    expect(within(rows[1]).getByRole("cell").textContent).toBe("—");
   });
 });

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionStatisticsSidebar.test.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionStatisticsSidebar.test.tsx
@@ -1,0 +1,130 @@
+import {
+  cleanup,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { StateActionStats } from "../../../ports";
+import type { StateActionSchemaState } from "./state-action-context";
+import StateActionStatisticsSidebar from "./StateActionStatisticsSidebar";
+
+const mocks = vi.hoisted(() => ({
+  ensureSchema: vi.fn(),
+  hasProvider: true,
+  readDimensionStats: vi.fn<() => Promise<StateActionStats | null>>(),
+  schema: { schema: null, status: "idle" } as unknown,
+}));
+
+vi.mock("./state-action-context", () => ({
+  useHasStateActionProvider: () => mocks.hasProvider,
+  useStateActionContext: () => ({
+    ensureSchema: mocks.ensureSchema,
+    readDimensionStats: mocks.readDimensionStats,
+    schema: mocks.schema as StateActionSchemaState,
+  }),
+}));
+
+const SCHEMA: StateActionSchemaState = {
+  schema: {
+    action: {
+      dimensions: [{ index: 0 }, { index: 1 }],
+      dtype: "float32",
+      featureName: "action",
+      shape: [2],
+    },
+    rowCount: 167,
+    state: {
+      dimensions: [
+        { index: 0, name: "joint_0" },
+        { index: 1, name: "gripper" },
+      ],
+      dtype: "float32",
+      featureName: "observation.state",
+      shape: [2],
+    },
+  },
+  status: "ready",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.hasProvider = true;
+  mocks.schema = SCHEMA;
+  mocks.readDimensionStats.mockResolvedValue(null);
+});
+
+afterEach(cleanup);
+
+describe("StateActionStatisticsSidebar", () => {
+  it("renders nothing without a provider or before the schema", () => {
+    mocks.hasProvider = false;
+    const { container, rerender } = render(<StateActionStatisticsSidebar />);
+    expect(container.firstChild).toBe(null);
+
+    mocks.hasProvider = true;
+    mocks.schema = { schema: null, status: "idle" };
+    rerender(<StateActionStatisticsSidebar />);
+    expect(container.firstChild).toBe(null);
+  });
+
+  it("renders declared statistics with quantile bands and detail titles", async () => {
+    mocks.readDimensionStats.mockResolvedValue({
+      sampleCount: 53102,
+      state: {
+        max: [2.677, 1],
+        mean: [0.1, 0.5],
+        min: [-2.672, 0],
+        q01: [-2.4, 0.01],
+        q50: [0.08, 0.5],
+        q99: [2.5, 0.99],
+        std: [0.9, 0.2],
+      },
+    });
+    const { container } = render(<StateActionStatisticsSidebar />);
+
+    expect(screen.getByText("167 rows this episode")).toBeDefined();
+    await waitFor(() =>
+      expect(screen.getByText(/across 53,102 frames/)).toBeDefined(),
+    );
+    const statePane = screen.getByRole("table", {
+      name: "observation.state declared statistics",
+    });
+    const firstRow = within(statePane)
+      .getAllByRole("row")
+      .find((row) => within(row).queryByText("joint_0")) as HTMLElement;
+    const cells = within(firstRow).getAllByRole("cell");
+    expect(cells.map((cell) => cell.textContent)).toEqual([
+      "-2.672",
+      "0.1",
+      "2.677",
+    ]);
+    // Quantiles and std ride the row's hover detail, not extra columns.
+    expect(firstRow.title).toBe("q01 -2.4 · q50 0.08 · q99 2.5 · std 0.9");
+    // One distribution strip per dimension with declared stats.
+    expect(
+      within(statePane).queryAllByRole("row").length,
+    ).toBeGreaterThanOrEqual(3);
+    expect(container.querySelectorAll('[class*="rangeBar"]').length).toBe(2);
+    // The action feature declares no stats: placeholders and no bars.
+    const actionPane = screen.getByRole("table", {
+      name: "action declared statistics",
+    });
+    expect(
+      within(actionPane)
+        .getAllByRole("cell")
+        .every((cell) => cell.textContent === "—"),
+    ).toBe(true);
+  });
+
+  it("says when the source declares no statistics", async () => {
+    mocks.readDimensionStats.mockResolvedValue(null);
+    render(<StateActionStatisticsSidebar />);
+    await waitFor(() =>
+      expect(
+        screen.getByText(/declares no statistics \(meta\/stats\.json\)/),
+      ).toBeDefined(),
+    );
+  });
+});

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionStatisticsSidebar.test.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionStatisticsSidebar.test.tsx
@@ -123,12 +123,15 @@ beforeEach(() => {
 
 afterEach(cleanup);
 
-/** Drives the voodo-backed scope select the way a keyboard user would. */
-function selectScope(value: string) {
+/** Opens the scope select with the keyboard and picks one option. */
+function selectScope(label: string) {
   const select = screen.getByRole("combobox", { name: /Scope/ });
   fireEvent.focus(select);
-  fireEvent.change(select, { target: { value } });
-  fireEvent.keyDown(select, { key: "Enter" });
+  fireEvent.keyDown(select, { key: "ArrowDown" });
+  const option = screen.getByRole("option", { name: label });
+  fireEvent.mouseDown(option);
+  fireEvent.mouseUp(option);
+  fireEvent.click(option);
 }
 
 describe("StateActionStatisticsSidebar", () => {
@@ -237,9 +240,22 @@ describe("StateActionStatisticsSidebar", () => {
     );
     expect(mocks.seek).toHaveBeenLastCalledWith(8);
 
-    // Out-of-range facts render only where declared bounds existed.
-    expect(screen.getByText("· 14 outside declared")).toBeDefined();
-    expect(screen.getAllByText(/outside declared/).length).toBe(1);
+    // The episode numbers ride the same columns as the declared row, with
+    // the out-of-range count in the episode row's leading cell — only
+    // where declared bounds existed.
+    const statePane = screen.getByRole("table", {
+      name: "observation.state declared statistics",
+    });
+    const firstRow = within(statePane)
+      .getAllByRole("row")
+      .find((row) => within(row).queryByText("joint_0")) as HTMLElement;
+    expect(
+      within(firstRow)
+        .getAllByRole("cell")
+        .map((cell) => cell.textContent),
+    ).toEqual(["-2.672", "—", "2.677", "-2.1", "0.2", "1.9"]);
+    expect(screen.getByText("14 outside")).toBeDefined();
+    expect(screen.getAllByText(/outside/).length).toBe(1);
     // The episode strip overlays the declared bar.
     expect(container.querySelectorAll('[class*="rangeEpisode"]').length).toBe(
       2,
@@ -253,7 +269,7 @@ describe("StateActionStatisticsSidebar", () => {
     mocks.readEpisodeProfile.mockResolvedValue(PROFILE);
     render(<StateActionStatisticsSidebar />);
 
-    selectScope("episode");
+    selectScope("Episode");
     const statePane = await screen.findByRole("table", {
       name: "observation.state episode statistics",
     });
@@ -271,7 +287,7 @@ describe("StateActionStatisticsSidebar", () => {
     // The separate per-dimension episode line folds into the table; only
     // the out-of-range fact remains as its own note.
     expect(screen.queryByText("episode")).toBe(null);
-    expect(screen.getByText("· 14 outside declared")).toBeDefined();
+    expect(screen.getByText("14 outside declared")).toBeDefined();
     // The choice persists for the next session.
     expect(readStoredStatsScope()).toBe("episode");
   });
@@ -290,7 +306,7 @@ describe("StateActionStatisticsSidebar", () => {
     mocks.readEpisodeProfile.mockResolvedValue(PROFILE);
     const { container } = render(<StateActionStatisticsSidebar />);
 
-    selectScope("dataset");
+    selectScope("Dataset");
     await waitFor(() =>
       expect(screen.getByText(/across 53,102 frames/)).toBeDefined(),
     );

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionStatisticsSidebar.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionStatisticsSidebar.tsx
@@ -1,23 +1,40 @@
-import React, { useEffect, useState } from "react";
+import { usePlayback } from "@fiftyone/playback/runtime";
+import { useAtom } from "jotai";
+import React, { useCallback, useEffect, useState } from "react";
 import type {
+  StateActionDimensionExtreme,
+  StateActionEpisodeProfile,
+  StateActionFeatureProfile,
   StateActionFeatureSchema,
   StateActionFeatureStats,
   StateActionStats,
+  StateActionTimingProfile,
 } from "../../../ports";
+import { useDataStream } from "../playback/data-stream-context";
+import { SettingsSelect } from "../settings/controls/SettingsSelect";
 import {
   useHasStateActionProvider,
   useStateActionContext,
 } from "./state-action-context";
-import { formatStateActionValue } from "./state-action-format";
+import {
+  STATE_ACTION_STATS_SCOPES,
+  stateActionStatsScopeAtom,
+  type StateActionStatsScope,
+} from "./state-action-display";
+import {
+  formatEpisodeTime,
+  formatStateActionValue,
+} from "./state-action-format";
 import styles from "./StateActionStatisticsSidebar.module.css";
 
 /**
- * "Statistics" sidebar tab for state/action sessions: the source-declared
- * per-dimension statistics (`meta/stats.json`) beside the declared names,
- * so an exact row value in the tile can be read against the ranges the
- * dataset itself reports. Everything shown is dataset-level source truth —
- * nothing here is computed from the episode. Renders nothing for sessions
- * without the state/action capability.
+ * "Statistics" sidebar tab for state/action sessions. A persisted scope
+ * chooses what the per-dimension tables show: the dataset-declared
+ * statistics (`meta/stats.json`), this episode's computed numbers with
+ * seekable extremes, or both layered together. Episode-computed facts —
+ * recorded cadence, out-of-declared-range counts, action-vs-state
+ * tracking error — ride along whenever the episode is in scope. Renders
+ * nothing for sessions without the state/action capability.
  */
 const StateActionStatisticsSidebar: React.FC = () => {
   // Compositions without the provider (isolated renders) simply show
@@ -27,9 +44,27 @@ const StateActionStatisticsSidebar: React.FC = () => {
 };
 
 const ProvidedStatistics: React.FC = () => {
-  const { ensureSchema, readDimensionStats, schema } = useStateActionContext();
+  const { ensureSchema, readDimensionStats, readEpisodeProfile, schema } =
+    useStateActionContext();
   const [stats, setStats] = useState<StateActionStats | null | "loading">(
     "loading",
+  );
+  const [profile, setProfile] = useState<StateActionEpisodeProfile | null>(
+    null,
+  );
+  const [scope, setScope] = useAtom(stateActionStatsScopeAtom);
+  const { pause, seek } = usePlayback();
+  const dataStream = useDataStream();
+  const timeline = dataStream?.getTimelineIndex() ?? null;
+  const originNs = timeline?.startTimeNs ?? 0n;
+  const seekToNs = useCallback(
+    (timestampNs: bigint) => {
+      const index = dataStream?.getTimelineIndex();
+      if (!index) return;
+      pause();
+      seek(index.nsToSec(timestampNs));
+    },
+    [dataStream, pause, seek],
   );
 
   // This passive effect (re)publishes the schema in case a shell remount
@@ -57,45 +92,157 @@ const ProvidedStatistics: React.FC = () => {
     return () => controller.abort();
   }, [facts, readDimensionStats]);
 
+  // This effect kicks off the episode profile scan; the capability caches
+  // it for the session, and everything below renders without it until the
+  // scan lands.
+  useEffect(() => {
+    if (!facts) return undefined;
+    const controller = new AbortController();
+    setProfile(null);
+    readEpisodeProfile(controller.signal).then(
+      (result) => {
+        if (!controller.signal.aborted) setProfile(result);
+      },
+      () => undefined,
+    );
+    return () => controller.abort();
+  }, [facts, readEpisodeProfile]);
+
   if (!facts) return null;
 
   const resolvedStats = stats === "loading" ? null : stats;
   const rowsFact = `${facts.rowCount.toLocaleString()} rows this episode`;
+  const showEpisode = scope !== "dataset";
   return (
     <div className={styles.root} data-testid="episode-state-action-summary">
+      <label className={styles.scopeRow}>
+        <span className={styles.scopeLabel}>Scope</span>
+        <SettingsSelect
+          ariaLabel="Statistics scope"
+          onChange={(next) => setScope(next as StateActionStatsScope)}
+          options={STATE_ACTION_STATS_SCOPES}
+          value={scope}
+        />
+      </label>
       <span className={styles.caption}>
-        {resolvedStats
-          ? `${rowsFact} · dataset-declared statistics (meta/stats.json)${
-              resolvedStats.sampleCount
-                ? ` across ${resolvedStats.sampleCount.toLocaleString()} frames`
-                : ""
-            }. Bars span min–max; the band covers q01–q99 and the tick marks
-            the mean.`
-          : stats === "loading"
-            ? `${rowsFact} · reading declared statistics…`
-            : `${rowsFact} · this source declares no statistics (meta/stats.json).`}
+        {captionText(scope, rowsFact, stats, resolvedStats)}
       </span>
+      {showEpisode && profile ? (
+        <TimingLine
+          onSeek={seekToNs}
+          originNs={originNs}
+          timing={profile.timing}
+        />
+      ) : null}
       {facts.state ? (
         <FeatureStatistics
           feature={facts.state}
+          onSeek={seekToNs}
+          originNs={originNs}
+          profile={showEpisode ? (profile?.state ?? null) : null}
+          scope={scope}
           stats={resolvedStats?.state ?? null}
         />
       ) : null}
       {facts.action ? (
         <FeatureStatistics
           feature={facts.action}
+          onSeek={seekToNs}
+          originNs={originNs}
+          profile={showEpisode ? (profile?.action ?? null) : null}
+          scope={scope}
           stats={resolvedStats?.action ?? null}
+        />
+      ) : null}
+      {showEpisode && profile?.trackingError ? (
+        <TrackingErrorTable
+          dimensions={(facts.state ?? facts.action)?.dimensions ?? []}
+          trackingError={profile.trackingError}
         />
       ) : null}
     </div>
   );
 };
 
+function captionText(
+  scope: StateActionStatsScope,
+  rowsFact: string,
+  stats: StateActionStats | null | "loading",
+  resolvedStats: StateActionStats | null,
+): string {
+  if (scope === "episode") {
+    return `${rowsFact} · statistics computed from this episode's rows. Click a min or max to seek to its frame; bars show where the episode sits in the declared range.`;
+  }
+  if (resolvedStats) {
+    const across = resolvedStats.sampleCount
+      ? ` across ${resolvedStats.sampleCount.toLocaleString()} frames`
+      : "";
+    return scope === "dataset"
+      ? `${rowsFact} · dataset-declared statistics (meta/stats.json)${across}. Bars span declared min–max with the q01–q99 band and mean tick.`
+      : `${rowsFact} · dataset-declared statistics (meta/stats.json)${across}. Bars span declared min–max with the q01–q99 band and mean tick; the bright strip is this episode's range.`;
+  }
+  return stats === "loading"
+    ? `${rowsFact} · reading declared statistics…`
+    : `${rowsFact} · this source declares no statistics (meta/stats.json).`;
+}
+
+/**
+ * Recorded-cadence line: the episode's median sampling rate plus any
+ * irregular inter-row gaps, with a jump to where the largest gap ends.
+ * Dropped or delayed frames quietly poison policy training; this line is
+ * where they stop being quiet.
+ */
+function TimingLine({
+  onSeek,
+  originNs,
+  timing,
+}: {
+  readonly onSeek: (timestampNs: bigint) => void;
+  readonly originNs: bigint;
+  readonly timing: StateActionTimingProfile;
+}) {
+  if (timing.medianIntervalNs <= 0n) return null;
+  const rateHz = 1e9 / Number(timing.medianIntervalNs);
+  const rate = rateHz >= 10 ? rateHz.toFixed(0) : rateHz.toFixed(1);
+  const largest = timing.gaps[0];
+  return (
+    <div className={styles.timingLine} data-testid="episode-timing-line">
+      <span>
+        {`Recorded cadence ${rate} Hz · ${
+          timing.gapCount === 0
+            ? "steady"
+            : `${timing.gapCount} irregular ${
+                timing.gapCount === 1 ? "gap" : "gaps"
+              }`
+        }`}
+      </span>
+      {largest ? (
+        <button
+          className={styles.seekButton}
+          onClick={() => onSeek(largest.timestampNs)}
+          title={`Largest gap follows frame ${largest.beforeFrameIndex} — click to seek to where rows resume (${formatEpisodeTime(largest.timestampNs, originNs)})`}
+          type="button"
+        >
+          {`largest ${formatGapSeconds(largest.durationNs)}s`}
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
 function FeatureStatistics({
   feature,
+  onSeek,
+  originNs,
+  profile,
+  scope,
   stats,
 }: {
   readonly feature: StateActionFeatureSchema;
+  readonly onSeek: (timestampNs: bigint) => void;
+  readonly originNs: bigint;
+  readonly profile: StateActionFeatureProfile | null;
+  readonly scope: StateActionStatsScope;
   readonly stats: StateActionFeatureStats | null;
 }) {
   return (
@@ -107,7 +254,9 @@ function FeatureStatistics({
         </span>
       </div>
       <div
-        aria-label={`${feature.featureName} declared statistics`}
+        aria-label={`${feature.featureName} ${
+          scope === "episode" ? "episode" : "declared"
+        } statistics`}
         role="table"
       >
         <div className={styles.statRow} role="row">
@@ -129,6 +278,10 @@ function FeatureStatistics({
             <DimensionRow
               dimension={dimension}
               key={dimension.index}
+              onSeek={onSeek}
+              originNs={originNs}
+              profile={profile}
+              scope={scope}
               stats={stats}
             />
           ))}
@@ -140,9 +293,17 @@ function FeatureStatistics({
 
 function DimensionRow({
   dimension,
+  onSeek,
+  originNs,
+  profile,
+  scope,
   stats,
 }: {
   readonly dimension: StateActionFeatureSchema["dimensions"][number];
+  readonly onSeek: (timestampNs: bigint) => void;
+  readonly originNs: bigint;
+  readonly profile: StateActionFeatureProfile | null;
+  readonly scope: StateActionStatsScope;
   readonly stats: StateActionFeatureStats | null;
 }) {
   const index = dimension.index;
@@ -150,6 +311,10 @@ function DimensionRow({
   const min = stats?.min?.[index];
   const max = stats?.max?.[index];
   const mean = stats?.mean?.[index];
+  const episodeMin = profile?.min[index] ?? null;
+  const episodeMax = profile?.max[index] ?? null;
+  const episodeMean = profile?.mean[index] ?? null;
+  const outOfRange = profile?.outOfRangeCounts?.[index] ?? null;
   const detail = [
     stat("q01", stats?.q01?.[index]),
     stat("q50", stats?.q50?.[index]),
@@ -158,40 +323,164 @@ function DimensionRow({
   ]
     .filter((entry): entry is string => entry !== null)
     .join(" · ");
+  const outOfRangeNote =
+    outOfRange !== null && outOfRange > 0 ? (
+      <span
+        className={styles.episodeOutOfRange}
+        title="Rows whose value falls outside the declared min–max"
+      >
+        {`· ${outOfRange.toLocaleString()} outside declared`}
+      </span>
+    ) : null;
   return (
     <div className={styles.dimBlock} role="row" title={detail || undefined}>
       <div className={styles.statRow}>
         <span className={styles.statName} role="rowheader" title={name}>
           {name}
         </span>
-        <StatCell value={min} />
-        <StatCell value={mean} />
-        <StatCell value={max} />
+        {scope === "episode" ? (
+          // Episode scope puts this episode's numbers in the table itself,
+          // and its min/max cells are the seek affordance.
+          <>
+            <SeekableStatCell
+              extreme={episodeMin}
+              kind="minimum"
+              name={name}
+              onSeek={onSeek}
+              originNs={originNs}
+            />
+            <StatCell value={episodeMean ?? undefined} />
+            <SeekableStatCell
+              extreme={episodeMax}
+              kind="maximum"
+              name={name}
+              onSeek={onSeek}
+              originNs={originNs}
+            />
+          </>
+        ) : (
+          <>
+            <StatCell value={min} />
+            <StatCell value={mean} />
+            <StatCell value={max} />
+          </>
+        )}
       </div>
       <RangeBar
+        episodeMax={scope === "dataset" ? undefined : episodeMax?.value}
+        episodeMin={scope === "dataset" ? undefined : episodeMin?.value}
         max={max}
         mean={mean}
         min={min}
         q01={stats?.q01?.[index]}
         q99={stats?.q99?.[index]}
       />
+      {scope === "both" && episodeMin && episodeMax ? (
+        <div className={styles.episodeLine}>
+          <span className={styles.episodeLabel}>episode</span>
+          <ExtremeSeekButton
+            extreme={episodeMin}
+            kind="minimum"
+            name={name}
+            onSeek={onSeek}
+            originNs={originNs}
+          />
+          <span aria-hidden>…</span>
+          <ExtremeSeekButton
+            extreme={episodeMax}
+            kind="maximum"
+            name={name}
+            onSeek={onSeek}
+            originNs={originNs}
+          />
+          {outOfRangeNote}
+        </div>
+      ) : scope === "episode" && outOfRangeNote ? (
+        <div className={styles.episodeLine}>{outOfRangeNote}</div>
+      ) : null}
     </div>
+  );
+}
+
+/** Right-aligned table cell whose content seeks to an episode extreme. */
+function SeekableStatCell({
+  extreme,
+  kind,
+  name,
+  onSeek,
+  originNs,
+}: {
+  readonly extreme: StateActionDimensionExtreme | null;
+  readonly kind: "maximum" | "minimum";
+  readonly name: string;
+  readonly onSeek: (timestampNs: bigint) => void;
+  readonly originNs: bigint;
+}) {
+  if (!extreme) {
+    return (
+      <span className={styles.statMissing} role="cell">
+        —
+      </span>
+    );
+  }
+  return (
+    <span className={styles.statSeekCell} role="cell">
+      <ExtremeSeekButton
+        extreme={extreme}
+        kind={kind}
+        name={name}
+        onSeek={onSeek}
+        originNs={originNs}
+      />
+    </span>
+  );
+}
+
+/** Compact seekable episode extreme: click jumps the playhead to its row. */
+function ExtremeSeekButton({
+  extreme,
+  kind,
+  name,
+  onSeek,
+  originNs,
+}: {
+  readonly extreme: StateActionDimensionExtreme;
+  readonly kind: "maximum" | "minimum";
+  readonly name: string;
+  readonly onSeek: (timestampNs: bigint) => void;
+  readonly originNs: bigint;
+}) {
+  return (
+    <button
+      aria-label={`Seek to ${name} episode ${kind} (frame ${extreme.frameIndex})`}
+      className={styles.seekButton}
+      onClick={() => onSeek(extreme.timestampNs)}
+      title={`Episode ${kind} at frame ${extreme.frameIndex} (${formatEpisodeTime(extreme.timestampNs, originNs)}) — click to seek`}
+      type="button"
+    >
+      {formatStateActionValue(extreme.value).text}
+    </button>
   );
 }
 
 /**
  * Per-dimension distribution strip on the dimension's own [min, max]
- * domain: the shaded band covers q01–q99 and the tick marks the mean. A
- * narrow band against a wide range flags rare extremes — exactly what
- * quantile-normalized training pipelines need to notice.
+ * domain: the shaded band covers q01–q99, the tick marks the mean, and
+ * the bright strip spans this episode's observed range. A narrow band
+ * against a wide range flags rare extremes; an episode strip hugging one
+ * edge flags an atypical episode.
  */
 function RangeBar({
+  episodeMax,
+  episodeMin,
   max,
   mean,
   min,
   q01,
   q99,
 }: {
+  readonly episodeMax?: number;
+  readonly episodeMin?: number;
   readonly max?: number;
   readonly mean?: number;
   readonly min?: number;
@@ -211,6 +500,14 @@ function RangeBar({
     Math.min(1, Math.max(0, (value - min) / (max - min)));
   const bandStart = q01 !== undefined ? position(q01) : 0;
   const bandEnd = q99 !== undefined ? position(q99) : 1;
+  const episodeStart =
+    episodeMin !== undefined && Number.isFinite(episodeMin)
+      ? position(episodeMin)
+      : null;
+  const episodeEnd =
+    episodeMax !== undefined && Number.isFinite(episodeMax)
+      ? position(episodeMax)
+      : null;
   return (
     <div aria-hidden className={styles.rangeBar}>
       <div
@@ -220,12 +517,60 @@ function RangeBar({
           width: `${Math.max(1, (bandEnd - bandStart) * 100)}%`,
         }}
       />
+      {episodeStart !== null && episodeEnd !== null ? (
+        <div
+          className={styles.rangeEpisode}
+          style={{
+            left: `${episodeStart * 100}%`,
+            width: `${Math.max(1, (episodeEnd - episodeStart) * 100)}%`,
+          }}
+        />
+      ) : null}
       {mean !== undefined && Number.isFinite(mean) ? (
         <div
           className={styles.rangeMean}
           style={{ left: `${position(mean) * 100}%` }}
         />
       ) : null}
+    </div>
+  );
+}
+
+/**
+ * Mean |action − state| per dimension over this episode. Action is the
+ * command, state is the measurement; a joint that cannot follow its
+ * command shows up here before it shows up in a training curve.
+ */
+function TrackingErrorTable({
+  dimensions,
+  trackingError,
+}: {
+  readonly dimensions: StateActionFeatureSchema["dimensions"];
+  readonly trackingError: readonly (number | null)[];
+}) {
+  return (
+    <div className={styles.feature}>
+      <div className={styles.featureHeading}>
+        <span>Tracking error</span>
+        <span className={styles.featureSchema}>
+          mean |action − state| · this episode
+        </span>
+      </div>
+      <div aria-label="Tracking error" role="table">
+        <div role="rowgroup">
+          {trackingError.map((value, index) => {
+            const name = dimensions[index]?.name ?? `[${index}]`;
+            return (
+              <div className={styles.trackingRow} key={index} role="row">
+                <span className={styles.statName} role="rowheader" title={name}>
+                  {name}
+                </span>
+                <StatCell value={value ?? undefined} />
+              </div>
+            );
+          })}
+        </div>
+      </div>
     </div>
   );
 }
@@ -249,6 +594,10 @@ function StatCell({ value }: { readonly value?: number }) {
 function stat(label: string, value: number | undefined): string | null {
   if (value === undefined || !Number.isFinite(value)) return null;
   return `${label} ${formatStateActionValue(value).text}`;
+}
+
+function formatGapSeconds(durationNs: bigint): string {
+  return (Number(durationNs) / 1e9).toFixed(2);
 }
 
 export default StateActionStatisticsSidebar;

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionStatisticsSidebar.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionStatisticsSidebar.tsx
@@ -60,25 +60,20 @@ const ProvidedStatistics: React.FC = () => {
   if (!facts) return null;
 
   const resolvedStats = stats === "loading" ? null : stats;
+  const rowsFact = `${facts.rowCount.toLocaleString()} rows this episode`;
   return (
     <div className={styles.root} data-testid="episode-state-action-summary">
-      <div className={styles.title}>
-        <span>State &amp; Action</span>
-        <span className={styles.titleBadge}>
-          {`${facts.rowCount.toLocaleString()} rows this episode`}
-        </span>
-      </div>
       <span className={styles.caption}>
         {resolvedStats
-          ? `Dataset-declared statistics (meta/stats.json)${
+          ? `${rowsFact} · dataset-declared statistics (meta/stats.json)${
               resolvedStats.sampleCount
                 ? ` across ${resolvedStats.sampleCount.toLocaleString()} frames`
                 : ""
             }. Bars span min–max; the band covers q01–q99 and the tick marks
             the mean.`
           : stats === "loading"
-            ? "Reading declared statistics…"
-            : "This source declares no statistics (meta/stats.json)."}
+            ? `${rowsFact} · reading declared statistics…`
+            : `${rowsFact} · this source declares no statistics (meta/stats.json).`}
       </span>
       {facts.state ? (
         <FeatureStatistics

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionStatisticsSidebar.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionStatisticsSidebar.tsx
@@ -324,8 +324,8 @@ function DimensionRow({
     .filter((entry): entry is string => entry !== null)
     .join(" · ");
   return (
-    <div className={styles.dimBlock} role="row" title={detail || undefined}>
-      <div className={styles.statRow}>
+    <div className={styles.dimBlock} title={detail || undefined}>
+      <div className={styles.statRow} role="row">
         <span className={styles.statName} role="rowheader" title={name}>
           {name}
         </span>
@@ -361,9 +361,10 @@ function DimensionRow({
         // This episode's numbers ride the same columns as the declared row
         // above them — the underlined min/max are the seek affordance, and
         // the leading cell flags declared-range violations.
-        <div className={styles.statRow}>
+        <div className={styles.statRow} role="row">
           <span
             className={styles.episodeOutOfRange}
+            role="cell"
             title="Rows whose value falls outside the declared min–max"
           >
             {outOfRange !== null && outOfRange > 0

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionStatisticsSidebar.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionStatisticsSidebar.tsx
@@ -1,0 +1,259 @@
+import React, { useEffect, useState } from "react";
+import type {
+  StateActionFeatureSchema,
+  StateActionFeatureStats,
+  StateActionStats,
+} from "../../../ports";
+import {
+  useHasStateActionProvider,
+  useStateActionContext,
+} from "./state-action-context";
+import { formatStateActionValue } from "./state-action-format";
+import styles from "./StateActionStatisticsSidebar.module.css";
+
+/**
+ * "Statistics" sidebar tab for state/action sessions: the source-declared
+ * per-dimension statistics (`meta/stats.json`) beside the declared names,
+ * so an exact row value in the tile can be read against the ranges the
+ * dataset itself reports. Everything shown is dataset-level source truth —
+ * nothing here is computed from the episode. Renders nothing for sessions
+ * without the state/action capability.
+ */
+const StateActionStatisticsSidebar: React.FC = () => {
+  // Compositions without the provider (isolated renders) simply show
+  // nothing rather than requiring the state/action stack.
+  const hasProvider = useHasStateActionProvider();
+  return hasProvider ? <ProvidedStatistics /> : null;
+};
+
+const ProvidedStatistics: React.FC = () => {
+  const { ensureSchema, readDimensionStats, schema } = useStateActionContext();
+  const [stats, setStats] = useState<StateActionStats | null | "loading">(
+    "loading",
+  );
+
+  // This passive effect (re)publishes the schema in case a shell remount
+  // wiped the bridge's initial publication before this panel opened.
+  useEffect(() => {
+    ensureSchema();
+  }, [ensureSchema]);
+
+  const facts = schema.status === "ready" ? schema.schema : null;
+
+  // This effect fetches the source-declared statistics once per session
+  // schema; the capability caches, so re-opens of this tab cost nothing.
+  useEffect(() => {
+    if (!facts) return undefined;
+    const controller = new AbortController();
+    setStats("loading");
+    readDimensionStats(controller.signal).then(
+      (result) => {
+        if (!controller.signal.aborted) setStats(result);
+      },
+      () => {
+        if (!controller.signal.aborted) setStats(null);
+      },
+    );
+    return () => controller.abort();
+  }, [facts, readDimensionStats]);
+
+  if (!facts) return null;
+
+  const resolvedStats = stats === "loading" ? null : stats;
+  return (
+    <div className={styles.root} data-testid="episode-state-action-summary">
+      <div className={styles.title}>
+        <span>State &amp; Action</span>
+        <span className={styles.titleBadge}>
+          {`${facts.rowCount.toLocaleString()} rows this episode`}
+        </span>
+      </div>
+      <span className={styles.caption}>
+        {resolvedStats
+          ? `Dataset-declared statistics (meta/stats.json)${
+              resolvedStats.sampleCount
+                ? ` across ${resolvedStats.sampleCount.toLocaleString()} frames`
+                : ""
+            }. Bars span min–max; the band covers q01–q99 and the tick marks
+            the mean.`
+          : stats === "loading"
+            ? "Reading declared statistics…"
+            : "This source declares no statistics (meta/stats.json)."}
+      </span>
+      {facts.state ? (
+        <FeatureStatistics
+          feature={facts.state}
+          stats={resolvedStats?.state ?? null}
+        />
+      ) : null}
+      {facts.action ? (
+        <FeatureStatistics
+          feature={facts.action}
+          stats={resolvedStats?.action ?? null}
+        />
+      ) : null}
+    </div>
+  );
+};
+
+function FeatureStatistics({
+  feature,
+  stats,
+}: {
+  readonly feature: StateActionFeatureSchema;
+  readonly stats: StateActionFeatureStats | null;
+}) {
+  return (
+    <div className={styles.feature}>
+      <div className={styles.featureHeading}>
+        <span>{feature.featureName}</span>
+        <span className={styles.featureSchema}>
+          {`${feature.dtype} [${feature.shape.join(",")}]`}
+        </span>
+      </div>
+      <div
+        aria-label={`${feature.featureName} declared statistics`}
+        role="table"
+      >
+        <div className={styles.statRow} role="row">
+          <span className={styles.statHeader} role="columnheader">
+            Dimension
+          </span>
+          <span className={styles.statHeaderValue} role="columnheader">
+            Min
+          </span>
+          <span className={styles.statHeaderValue} role="columnheader">
+            Mean
+          </span>
+          <span className={styles.statHeaderValue} role="columnheader">
+            Max
+          </span>
+        </div>
+        <div role="rowgroup">
+          {feature.dimensions.map((dimension) => (
+            <DimensionRow
+              dimension={dimension}
+              key={dimension.index}
+              stats={stats}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DimensionRow({
+  dimension,
+  stats,
+}: {
+  readonly dimension: StateActionFeatureSchema["dimensions"][number];
+  readonly stats: StateActionFeatureStats | null;
+}) {
+  const index = dimension.index;
+  const name = dimension.name ?? `[${index}]`;
+  const min = stats?.min?.[index];
+  const max = stats?.max?.[index];
+  const mean = stats?.mean?.[index];
+  const detail = [
+    stat("q01", stats?.q01?.[index]),
+    stat("q50", stats?.q50?.[index]),
+    stat("q99", stats?.q99?.[index]),
+    stat("std", stats?.std?.[index]),
+  ]
+    .filter((entry): entry is string => entry !== null)
+    .join(" · ");
+  return (
+    <div className={styles.dimBlock} role="row" title={detail || undefined}>
+      <div className={styles.statRow}>
+        <span className={styles.statName} role="rowheader" title={name}>
+          {name}
+        </span>
+        <StatCell value={min} />
+        <StatCell value={mean} />
+        <StatCell value={max} />
+      </div>
+      <RangeBar
+        max={max}
+        mean={mean}
+        min={min}
+        q01={stats?.q01?.[index]}
+        q99={stats?.q99?.[index]}
+      />
+    </div>
+  );
+}
+
+/**
+ * Per-dimension distribution strip on the dimension's own [min, max]
+ * domain: the shaded band covers q01–q99 and the tick marks the mean. A
+ * narrow band against a wide range flags rare extremes — exactly what
+ * quantile-normalized training pipelines need to notice.
+ */
+function RangeBar({
+  max,
+  mean,
+  min,
+  q01,
+  q99,
+}: {
+  readonly max?: number;
+  readonly mean?: number;
+  readonly min?: number;
+  readonly q01?: number;
+  readonly q99?: number;
+}) {
+  if (
+    min === undefined ||
+    max === undefined ||
+    !Number.isFinite(min) ||
+    !Number.isFinite(max) ||
+    max <= min
+  ) {
+    return null;
+  }
+  const position = (value: number) =>
+    Math.min(1, Math.max(0, (value - min) / (max - min)));
+  const bandStart = q01 !== undefined ? position(q01) : 0;
+  const bandEnd = q99 !== undefined ? position(q99) : 1;
+  return (
+    <div aria-hidden className={styles.rangeBar}>
+      <div
+        className={styles.rangeBand}
+        style={{
+          left: `${bandStart * 100}%`,
+          width: `${Math.max(1, (bandEnd - bandStart) * 100)}%`,
+        }}
+      />
+      {mean !== undefined && Number.isFinite(mean) ? (
+        <div
+          className={styles.rangeMean}
+          style={{ left: `${position(mean) * 100}%` }}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function StatCell({ value }: { readonly value?: number }) {
+  if (value === undefined) {
+    return (
+      <span className={styles.statMissing} role="cell">
+        —
+      </span>
+    );
+  }
+  const formatted = formatStateActionValue(value);
+  return (
+    <span className={styles.statValue} role="cell" title={formatted.exact}>
+      {formatted.text}
+    </span>
+  );
+}
+
+function stat(label: string, value: number | undefined): string | null {
+  if (value === undefined || !Number.isFinite(value)) return null;
+  return `${label} ${formatStateActionValue(value).text}`;
+}
+
+export default StateActionStatisticsSidebar;

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionStatisticsSidebar.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionStatisticsSidebar.tsx
@@ -323,15 +323,6 @@ function DimensionRow({
   ]
     .filter((entry): entry is string => entry !== null)
     .join(" · ");
-  const outOfRangeNote =
-    outOfRange !== null && outOfRange > 0 ? (
-      <span
-        className={styles.episodeOutOfRange}
-        title="Rows whose value falls outside the declared min–max"
-      >
-        {`· ${outOfRange.toLocaleString()} outside declared`}
-      </span>
-    ) : null;
   return (
     <div className={styles.dimBlock} role="row" title={detail || undefined}>
       <div className={styles.statRow}>
@@ -366,6 +357,36 @@ function DimensionRow({
           </>
         )}
       </div>
+      {scope === "both" && episodeMin && episodeMax ? (
+        // This episode's numbers ride the same columns as the declared row
+        // above them — the underlined min/max are the seek affordance, and
+        // the leading cell flags declared-range violations.
+        <div className={styles.statRow}>
+          <span
+            className={styles.episodeOutOfRange}
+            title="Rows whose value falls outside the declared min–max"
+          >
+            {outOfRange !== null && outOfRange > 0
+              ? `${outOfRange.toLocaleString()} outside`
+              : ""}
+          </span>
+          <SeekableStatCell
+            extreme={episodeMin}
+            kind="minimum"
+            name={name}
+            onSeek={onSeek}
+            originNs={originNs}
+          />
+          <StatCell value={episodeMean ?? undefined} />
+          <SeekableStatCell
+            extreme={episodeMax}
+            kind="maximum"
+            name={name}
+            onSeek={onSeek}
+            originNs={originNs}
+          />
+        </div>
+      ) : null}
       <RangeBar
         episodeMax={scope === "dataset" ? undefined : episodeMax?.value}
         episodeMin={scope === "dataset" ? undefined : episodeMin?.value}
@@ -375,28 +396,15 @@ function DimensionRow({
         q01={stats?.q01?.[index]}
         q99={stats?.q99?.[index]}
       />
-      {scope === "both" && episodeMin && episodeMax ? (
+      {scope === "episode" && outOfRange !== null && outOfRange > 0 ? (
         <div className={styles.episodeLine}>
-          <span className={styles.episodeLabel}>episode</span>
-          <ExtremeSeekButton
-            extreme={episodeMin}
-            kind="minimum"
-            name={name}
-            onSeek={onSeek}
-            originNs={originNs}
-          />
-          <span aria-hidden>…</span>
-          <ExtremeSeekButton
-            extreme={episodeMax}
-            kind="maximum"
-            name={name}
-            onSeek={onSeek}
-            originNs={originNs}
-          />
-          {outOfRangeNote}
+          <span
+            className={styles.episodeOutOfRange}
+            title="Rows whose value falls outside the declared min–max"
+          >
+            {`${outOfRange.toLocaleString()} outside declared`}
+          </span>
         </div>
-      ) : scope === "episode" && outOfRangeNote ? (
-        <div className={styles.episodeLine}>{outOfRangeNote}</div>
       ) : null}
     </div>
   );

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionTile.module.css
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionTile.module.css
@@ -86,6 +86,36 @@
   outline-offset: 1px;
 }
 
+/* Keep transient refresh status out of normal flow so playhead updates do
+   not push the panes around during playback. */
+.content {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+  position: relative;
+}
+
+.staleNotice {
+  line-height: 1.3;
+  max-width: calc(100% - 16px);
+  text-align: left;
+  white-space: normal;
+}
+
+.missingNote {
+  border-bottom: 1px solid
+    color-mix(
+      in srgb,
+      var(--color-content-border-default, #383835) 60%,
+      transparent
+    );
+  color: var(--color-content-text-secondary);
+  flex: none;
+  font-size: 11px;
+  padding: 4px 10px;
+}
+
 .panes {
   display: grid;
   flex: 1;
@@ -139,12 +169,6 @@
   font-size: 11px;
   line-height: 1.4;
   padding: 4px 10px;
-}
-
-.paneMissing {
-  color: var(--color-content-text-secondary);
-  font-size: 11px;
-  padding: 10px;
 }
 
 .paneScroll {

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionTile.module.css
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionTile.module.css
@@ -200,7 +200,9 @@
   display: grid;
   font-size: 10px;
   gap: 8px;
-  grid-template-columns: minmax(64px, 1fr) 44px minmax(72px, auto) 18px;
+  grid-template-columns:
+    minmax(64px, 1fr) 44px minmax(64px, auto) minmax(40px, auto)
+    18px;
   padding: 2px 10px;
   text-transform: uppercase;
 }
@@ -209,7 +211,9 @@
   align-items: center;
   display: grid;
   gap: 8px;
-  grid-template-columns: minmax(64px, 1fr) 44px minmax(72px, auto) 18px;
+  grid-template-columns:
+    minmax(64px, 1fr) 44px minmax(64px, auto) minmax(40px, auto)
+    18px;
   height: 22px;
   padding: 0 10px;
 }
@@ -233,6 +237,16 @@
 
 .dimValue {
   text-align: right;
+}
+
+.dimDelta {
+  color: var(--color-content-text-secondary);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 11px;
+  overflow: hidden;
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .dimTrackCell {

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionTile.module.css
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionTile.module.css
@@ -211,7 +211,7 @@
   display: grid;
   font-size: 10px;
   gap: 8px;
-  grid-template-columns: minmax(80px, 1fr) minmax(72px, auto);
+  grid-template-columns: minmax(80px, 1fr) minmax(72px, auto) 18px;
   padding: 2px 10px;
   text-transform: uppercase;
 }
@@ -220,7 +220,7 @@
   align-items: center;
   display: grid;
   gap: 8px;
-  grid-template-columns: minmax(80px, 1fr) minmax(72px, auto);
+  grid-template-columns: minmax(80px, 1fr) minmax(72px, auto) 18px;
   height: 22px;
   padding: 0 10px;
 }
@@ -270,6 +270,51 @@
 }
 
 .valueButton:focus-visible {
+  outline: 1px solid var(--color-voxel-secondary, #f5b700);
+  outline-offset: 1px;
+}
+
+.dimAction {
+  align-items: center;
+  display: inline-flex;
+  height: 18px;
+  justify-content: center;
+  width: 18px;
+}
+
+/* The plot affordance stays quiet until the row is hovered or the
+   button itself holds keyboard focus. */
+.plotButton {
+  align-items: center;
+  background: transparent;
+  border: none;
+  border-radius: 3px;
+  color: var(--color-content-text-secondary);
+  cursor: pointer;
+  display: inline-flex;
+  height: 18px;
+  justify-content: center;
+  opacity: 0;
+  padding: 0;
+  width: 18px;
+}
+
+.dimRow:hover .plotButton,
+.dimRow:focus-within .plotButton,
+.plotButton:focus-visible {
+  opacity: 1;
+}
+
+.plotButton:hover {
+  background: color-mix(
+    in srgb,
+    var(--color-content-text-secondary) 16%,
+    transparent
+  );
+  color: var(--color-content-text-primary);
+}
+
+.plotButton:focus-visible {
   outline: 1px solid var(--color-voxel-secondary, #f5b700);
   outline-offset: 1px;
 }

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionTile.module.css
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionTile.module.css
@@ -441,7 +441,6 @@
 }
 
 .srOnly {
-  clip: rect(0 0 0 0);
   clip-path: inset(50%);
   height: 1px;
   overflow: hidden;

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionTile.module.css
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionTile.module.css
@@ -200,9 +200,9 @@
   display: grid;
   font-size: 10px;
   gap: 8px;
-  grid-template-columns:
-    minmax(64px, 1fr) 44px minmax(64px, auto) minmax(40px, auto)
-    18px;
+  /* Fixed value and delta widths: each row is its own grid, so auto
+     columns would size per row and never align with the header. */
+  grid-template-columns: minmax(48px, 1fr) 44px 84px 56px 18px;
   padding: 2px 10px;
   text-transform: uppercase;
 }
@@ -211,9 +211,9 @@
   align-items: center;
   display: grid;
   gap: 8px;
-  grid-template-columns:
-    minmax(64px, 1fr) 44px minmax(64px, auto) minmax(40px, auto)
-    18px;
+  /* Fixed value and delta widths: each row is its own grid, so auto
+     columns would size per row and never align with the header. */
+  grid-template-columns: minmax(48px, 1fr) 44px 84px 56px 18px;
   height: 22px;
   padding: 0 10px;
 }

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionTile.module.css
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionTile.module.css
@@ -129,6 +129,22 @@
   padding: 4px 10px;
 }
 
+.filterBar {
+  border-bottom: 1px solid
+    color-mix(
+      in srgb,
+      var(--color-content-border-default, #383835) 60%,
+      transparent
+    );
+  flex: none;
+  padding: 6px 10px;
+}
+
+.filterInput {
+  min-width: 0;
+  width: 100%;
+}
+
 .panes {
   display: grid;
   flex: 1;
@@ -189,6 +205,13 @@
   min-height: 0;
   overflow: auto;
   padding: 2px 0 6px;
+}
+
+.noMatches {
+  color: var(--color-content-text-secondary);
+  font-size: 11px;
+  padding: 12px 10px;
+  text-align: center;
 }
 
 .rowSpacer {

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionTile.module.css
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionTile.module.css
@@ -211,7 +211,7 @@
   display: grid;
   font-size: 10px;
   gap: 8px;
-  grid-template-columns: minmax(80px, 1fr) minmax(72px, auto) 18px;
+  grid-template-columns: minmax(64px, 1fr) 44px minmax(72px, auto) 18px;
   padding: 2px 10px;
   text-transform: uppercase;
 }
@@ -220,7 +220,7 @@
   align-items: center;
   display: grid;
   gap: 8px;
-  grid-template-columns: minmax(80px, 1fr) minmax(72px, auto) 18px;
+  grid-template-columns: minmax(64px, 1fr) 44px minmax(72px, auto) 18px;
   height: 22px;
   padding: 0 10px;
 }
@@ -244,6 +244,56 @@
 
 .dimValue {
   text-align: right;
+}
+
+.dimTrackCell {
+  align-items: center;
+  display: inline-flex;
+  height: 100%;
+}
+
+/* Faint declared-range strip: min–max track, q01–q99 band, value tick.
+   Deliberately quiet so the exact numbers stay the primary reading. */
+.dimTrack {
+  background: color-mix(
+    in srgb,
+    var(--color-content-text-secondary) 12%,
+    transparent
+  );
+  border-radius: 2px;
+  display: block;
+  height: 3px;
+  position: relative;
+  width: 100%;
+}
+
+.dimTrackBand {
+  background: color-mix(
+    in srgb,
+    var(--color-content-text-secondary) 26%,
+    transparent
+  );
+  border-radius: 2px;
+  height: 100%;
+  position: absolute;
+  top: 0;
+}
+
+.dimTrackTick {
+  background: color-mix(
+    in srgb,
+    var(--color-voxel-secondary, #f5b700) 75%,
+    transparent
+  );
+  height: 7px;
+  position: absolute;
+  top: -2px;
+  transform: translateX(-50%);
+  width: 2px;
+}
+
+.dimTrackTickOut {
+  background: var(--color-content-text-destructive);
 }
 
 .valueButton {

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionTile.module.css
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionTile.module.css
@@ -103,6 +103,30 @@
   white-space: normal;
 }
 
+/* The shared badge is pointer-inert; this variant hosts a retry action. */
+.staleInteractive {
+  pointer-events: auto;
+}
+
+.staleRetryButton {
+  background: transparent;
+  border: 1px solid var(--color-content-border-default, #383835);
+  border-radius: 4px;
+  color: var(--color-content-text-primary);
+  cursor: pointer;
+  font-size: 10px;
+  line-height: 1;
+  padding: 2px 6px;
+}
+
+.staleRetryButton:hover {
+  background: color-mix(
+    in srgb,
+    var(--color-content-text-secondary) 12%,
+    transparent
+  );
+}
+
 .missingNote {
   border-bottom: 1px solid
     color-mix(

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionTile.module.css
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionTile.module.css
@@ -31,17 +31,6 @@
   white-space: nowrap;
 }
 
-.headerBadge {
-  background: color-mix(
-    in srgb,
-    var(--color-content-text-secondary) 18%,
-    transparent
-  );
-  border-radius: 8px;
-  padding: 1px 6px;
-  white-space: nowrap;
-}
-
 .headerError {
   color: var(--color-content-text-destructive);
 }

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionTile.module.css
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionTile.module.css
@@ -1,0 +1,282 @@
+/* State & Action tile: exact single-row inspection over the shared dark
+   tile surface — a pinned header strip above two independently scrollable
+   feature panes that stack when the tile is narrow. */
+
+.body {
+  background: var(--plot-surface, #050b12);
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  width: 100%;
+}
+
+.header {
+  align-items: center;
+  border-bottom: 1px solid var(--color-content-border-default, #383835);
+  color: var(--color-content-text-secondary);
+  display: flex;
+  flex: none;
+  flex-wrap: wrap;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 11px;
+  gap: 4px 10px;
+  line-height: 1.4;
+  padding: 6px 10px;
+}
+
+.headerFrame {
+  color: var(--color-content-text-primary);
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.headerBadge {
+  background: color-mix(
+    in srgb,
+    var(--color-content-text-secondary) 18%,
+    transparent
+  );
+  border-radius: 8px;
+  padding: 1px 6px;
+  white-space: nowrap;
+}
+
+.headerError {
+  color: var(--color-content-text-destructive);
+}
+
+.headerActions {
+  align-items: center;
+  display: inline-flex;
+  gap: 2px;
+  margin-left: auto;
+}
+
+.actionButton {
+  align-items: center;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  color: var(--color-content-text-secondary);
+  cursor: pointer;
+  display: inline-flex;
+  height: 22px;
+  justify-content: center;
+  padding: 0;
+  width: 22px;
+}
+
+.actionButton:hover:not(:disabled) {
+  background: color-mix(
+    in srgb,
+    var(--color-content-text-secondary) 16%,
+    transparent
+  );
+  color: var(--color-content-text-primary);
+}
+
+.actionButton:disabled {
+  cursor: default;
+  opacity: 0.4;
+}
+
+.actionButton:focus-visible {
+  outline: 1px solid var(--color-voxel-secondary, #f5b700);
+  outline-offset: 1px;
+}
+
+.panes {
+  display: grid;
+  flex: 1;
+  gap: 1px;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.pane {
+  display: flex;
+  flex-direction: column;
+  min-height: 120px;
+  min-width: 0;
+}
+
+.paneHeading {
+  align-items: baseline;
+  border-bottom: 1px solid
+    color-mix(
+      in srgb,
+      var(--color-content-border-default, #383835) 60%,
+      transparent
+    );
+  color: var(--color-content-text-primary);
+  display: flex;
+  flex: none;
+  flex-wrap: wrap;
+  font-size: 11px;
+  font-weight: 600;
+  gap: 4px 8px;
+  padding: 6px 10px 4px;
+}
+
+.paneSchema {
+  background: color-mix(
+    in srgb,
+    var(--color-content-text-secondary) 18%,
+    transparent
+  );
+  border-radius: 8px;
+  color: var(--color-content-text-secondary);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-weight: 400;
+  padding: 1px 6px;
+}
+
+.paneError {
+  color: var(--color-content-text-destructive);
+  flex: none;
+  font-size: 11px;
+  line-height: 1.4;
+  padding: 4px 10px;
+}
+
+.paneMissing {
+  color: var(--color-content-text-secondary);
+  font-size: 11px;
+  padding: 10px;
+}
+
+.paneScroll {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: 2px 0 6px;
+}
+
+.rowSpacer {
+  position: relative;
+}
+
+.columnHeaders {
+  color: var(--color-content-text-secondary);
+  display: grid;
+  font-size: 10px;
+  gap: 8px;
+  grid-template-columns: minmax(80px, 1fr) minmax(72px, auto);
+  padding: 2px 10px;
+  text-transform: uppercase;
+}
+
+.dimRow {
+  align-items: center;
+  display: grid;
+  gap: 8px;
+  grid-template-columns: minmax(80px, 1fr) minmax(72px, auto);
+  height: 22px;
+  padding: 0 10px;
+}
+
+.dimRow:hover {
+  background: color-mix(
+    in srgb,
+    var(--color-content-text-secondary) 8%,
+    transparent
+  );
+}
+
+.dimName {
+  color: var(--color-content-text-secondary);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dimValue {
+  text-align: right;
+}
+
+.valueButton {
+  background: transparent;
+  border: none;
+  border-radius: 3px;
+  color: var(--color-content-text-primary);
+  cursor: copy;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 11px;
+  max-width: 100%;
+  overflow: hidden;
+  padding: 1px 4px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.valueButton:hover {
+  background: color-mix(
+    in srgb,
+    var(--color-content-text-secondary) 16%,
+    transparent
+  );
+}
+
+.valueButton:focus-visible {
+  outline: 1px solid var(--color-voxel-secondary, #f5b700);
+  outline-offset: 1px;
+}
+
+.invalidValue {
+  color: var(--color-content-text-destructive);
+  font-style: italic;
+}
+
+.skeletonValue {
+  color: var(--color-content-text-secondary);
+  opacity: 0.55;
+}
+
+.notice {
+  align-items: center;
+  color: var(--color-content-text-secondary);
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  font-size: 12px;
+  gap: 8px;
+  justify-content: center;
+  padding: 12px;
+  text-align: center;
+}
+
+.noticeError {
+  color: var(--color-content-text-destructive);
+}
+
+.retryButton {
+  background: transparent;
+  border: 1px solid var(--color-content-border-default, #383835);
+  border-radius: 4px;
+  color: var(--color-content-text-primary);
+  cursor: pointer;
+  font-size: 11px;
+  padding: 3px 10px;
+}
+
+.retryButton:hover {
+  background: color-mix(
+    in srgb,
+    var(--color-content-text-secondary) 12%,
+    transparent
+  );
+}
+
+.srOnly {
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionTile.test.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionTile.test.tsx
@@ -189,8 +189,6 @@ describe("StateActionTile", () => {
     render(<StateActionTile />);
 
     expect(screen.getAllByText("Frame 4 of 20").length).toBeGreaterThan(0);
-    expect(screen.getByText("fold the towel")).toBeDefined();
-    expect(screen.getByText("Exact row")).toBeDefined();
 
     const statePane = screen.getByRole("table", {
       name: "Observation state values",
@@ -214,19 +212,6 @@ describe("StateActionTile", () => {
     );
     rerender(<StateActionTile />);
     expect(screen.getByText("playhead t=+4.500s")).toBeDefined();
-  });
-
-  it("falls back to the numeric task index when no label resolves", () => {
-    setState(
-      { schema: SCHEMA, status: "ready" },
-      {
-        row: row({ task: { index: 7 } }),
-        status: "ready",
-        targetNs: 4n * NS_PER_SECOND,
-      },
-    );
-    render(<StateActionTile />);
-    expect(screen.getByText("Task #7")).toBeDefined();
   });
 
   it("marks each value's place on its declared dataset range", async () => {

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionTile.test.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionTile.test.tsx
@@ -1,0 +1,423 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { StateActionRow, StateActionSchema } from "../../../ports";
+import type {
+  StateActionRowState,
+  StateActionSchemaState,
+} from "./state-action-context";
+import StateActionTile from "./StateActionTile";
+
+const NS_PER_SECOND = 1_000_000_000n;
+
+const mocks = vi.hoisted(() => ({
+  dataStream: {
+    getTimelineIndex: () => ({
+      nsToSec: (timeNs: bigint) => Number(timeNs) / 1e9,
+      secToNs: (timeSec: number) => BigInt(Math.round(timeSec * 1e9)),
+      startTimeNs: 0n,
+    }),
+    sourceKey: "source-1",
+  },
+  holdCursorRow: vi.fn(),
+  isPlaying: false,
+  isPlayPending: false,
+  pause: vi.fn(),
+  readRowAtCursor: vi.fn(),
+  readRowIndexWindow: vi.fn(),
+  retryRead: vi.fn(),
+  rowState: undefined as unknown,
+  schema: { schema: null, status: "idle" } as unknown,
+  seek: vi.fn(),
+  setTileTitle: vi.fn(),
+  subscribeRow: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("@fiftyone/tiling", () => ({
+  useSetTileTitle: () => mocks.setTileTitle,
+  useTileId: () => "lerobot:state-action-1",
+}));
+
+vi.mock("@fiftyone/playback/runtime", () => ({
+  useIsPlaying: () => mocks.isPlaying,
+  useIsPlayPending: () => mocks.isPlayPending,
+  usePlayback: () => ({ pause: mocks.pause, seek: mocks.seek }),
+}));
+
+vi.mock("../playback/data-stream-context", () => ({
+  useDataStream: () => mocks.dataStream,
+}));
+
+vi.mock("./state-action-context", () => ({
+  useStateActionContext: () => ({
+    holdCursorRow: mocks.holdCursorRow,
+    readRowAtCursor: mocks.readRowAtCursor,
+    readRowIndexWindow: mocks.readRowIndexWindow,
+    retryRead: mocks.retryRead,
+    rowState: mocks.rowState as StateActionRowState | undefined,
+    schema: mocks.schema as StateActionSchemaState,
+    subscribeRow: mocks.subscribeRow,
+  }),
+}));
+
+const SCHEMA: StateActionSchema = {
+  action: {
+    dimensions: [{ index: 0 }, { index: 1 }, { index: 2 }],
+    dtype: "float32",
+    featureName: "action",
+    shape: [3],
+  },
+  rowCount: 20,
+  state: {
+    dimensions: [
+      { index: 0, name: "shoulder" },
+      { index: 1, name: "elbow" },
+    ],
+    dtype: "float32",
+    featureName: "observation.state",
+    shape: [2],
+  },
+};
+
+function row(overrides: Partial<StateActionRow> = {}): StateActionRow {
+  return {
+    action: [0.5, Number.NaN, 7],
+    cursor: "row:4",
+    frameIndex: 4,
+    state: [1.25, -2],
+    task: { index: 1, label: "fold the towel" },
+    timestampNs: 4n * NS_PER_SECOND,
+    ...overrides,
+  };
+}
+
+function setState(
+  schema: StateActionSchemaState,
+  rowState: StateActionRowState | undefined,
+) {
+  mocks.schema = schema;
+  mocks.rowState = rowState;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.isPlaying = false;
+  mocks.isPlayPending = false;
+  setState({ schema: SCHEMA, status: "ready" }, undefined);
+});
+
+afterEach(cleanup);
+
+describe("StateActionTile", () => {
+  it("titles itself and subscribes to the canonical row", () => {
+    render(<StateActionTile />);
+    expect(mocks.setTileTitle).toHaveBeenCalledWith("State & Action", {
+      source: "auto",
+    });
+    expect(mocks.subscribeRow).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders schema-derived names as a skeleton before any value read", () => {
+    render(<StateActionTile />);
+    const statePane = screen.getByRole("table", {
+      name: "Observation state values",
+    });
+    expect(within(statePane).getByText("shoulder")).toBeDefined();
+    expect(within(statePane).getByText("elbow")).toBeDefined();
+    const actionPane = screen.getByRole("table", { name: "Action values" });
+    expect(within(actionPane).getByText("[0]")).toBeDefined();
+    expect(within(actionPane).getByText("[2]")).toBeDefined();
+    expect(screen.queryByRole("button", { name: /Copy exact value/ })).toBe(
+      null,
+    );
+  });
+
+  it("renders both panes from the committed row without pairing them", () => {
+    setState(
+      { schema: SCHEMA, status: "ready" },
+      { row: row(), status: "ready", targetNs: 4n * NS_PER_SECOND },
+    );
+    render(<StateActionTile />);
+
+    expect(screen.getAllByText("Frame 4 of 20").length).toBeGreaterThan(0);
+    expect(screen.getByText("fold the towel")).toBeDefined();
+    expect(screen.getByText("Exact row")).toBeDefined();
+
+    const statePane = screen.getByRole("table", {
+      name: "Observation state values",
+    });
+    const stateValues = within(statePane).getAllByRole("cell");
+    expect(stateValues.map((cell) => cell.textContent)).toEqual(["1.25", "-2"]);
+    const actionPane = screen.getByRole("table", { name: "Action values" });
+    const actionValues = within(actionPane).getAllByRole("cell");
+    expect(actionValues.map((cell) => cell.textContent)).toEqual([
+      "0.5",
+      "NaN",
+      "7",
+    ]);
+  });
+
+  it("shows the playhead time only when it differs from the row time", () => {
+    setState(
+      { schema: SCHEMA, status: "ready" },
+      { row: row(), status: "ready", targetNs: 4n * NS_PER_SECOND },
+    );
+    const { rerender } = render(<StateActionTile />);
+    expect(screen.queryByText(/playhead/)).toBe(null);
+
+    setState(
+      { schema: SCHEMA, status: "ready" },
+      { row: row(), status: "ready", targetNs: 4_500_000_000n },
+    );
+    rerender(<StateActionTile />);
+    expect(screen.getByText("playhead t=+4.500s")).toBeDefined();
+  });
+
+  it("falls back to the numeric task index when no label resolves", () => {
+    setState(
+      { schema: SCHEMA, status: "ready" },
+      {
+        row: row({ task: { index: 7 } }),
+        status: "ready",
+        targetNs: 4n * NS_PER_SECOND,
+      },
+    );
+    render(<StateActionTile />);
+    expect(screen.getByText("Task #7")).toBeDefined();
+  });
+
+  it("names the absent canonical feature when only one pane exists", () => {
+    setState(
+      {
+        schema: { action: SCHEMA.action, rowCount: 20 },
+        status: "ready",
+      },
+      {
+        row: row({ state: undefined }),
+        status: "ready",
+        targetNs: 4n * NS_PER_SECOND,
+      },
+    );
+    render(<StateActionTile />);
+    expect(
+      screen.getByText("No observation.state feature declared"),
+    ).toBeDefined();
+    expect(screen.getByRole("table", { name: "Action values" })).toBeDefined();
+  });
+
+  it("shows a feature-scoped error without shifting later values", () => {
+    setState(
+      { schema: SCHEMA, status: "ready" },
+      {
+        row: row({
+          featureErrors: { state: "'observation.state' row has 3 values" },
+          state: [1, 2, 3],
+        }),
+        status: "ready",
+        targetNs: 4n * NS_PER_SECOND,
+      },
+    );
+    render(<StateActionTile />);
+    expect(
+      screen.getByText("'observation.state' row has 3 values"),
+    ).toBeDefined();
+    const statePane = screen.getByRole("table", {
+      name: "Observation state values",
+    });
+    const names = within(statePane)
+      .getAllByRole("rowheader")
+      .map((cell) => cell.textContent);
+    expect(names).toEqual(["shoulder", "elbow", "[2]"]);
+    const values = within(statePane)
+      .getAllByRole("cell")
+      .map((cell) => cell.textContent);
+    expect(values).toEqual(["1", "2", "3"]);
+  });
+
+  it("marks a dimension missing from the source row explicitly", () => {
+    setState(
+      { schema: SCHEMA, status: "ready" },
+      {
+        row: row({
+          featureErrors: { state: "'observation.state' row has 1 value" },
+          state: [1],
+        }),
+        status: "ready",
+        targetNs: 4n * NS_PER_SECOND,
+      },
+    );
+    render(<StateActionTile />);
+    const statePane = screen.getByRole("table", {
+      name: "Observation state values",
+    });
+    const values = within(statePane)
+      .getAllByRole("cell")
+      .map((cell) => cell.textContent);
+    expect(values).toEqual(["1", "missing"]);
+  });
+
+  it("shows the empty state distinctly from loading and errors", () => {
+    setState(
+      { schema: SCHEMA, status: "ready" },
+      { row: null, status: "ready", targetNs: 0n },
+    );
+    render(<StateActionTile />);
+    expect(screen.getByText("No state/action row at this time")).toBeDefined();
+  });
+
+  it("offers retry on a blocking read failure", () => {
+    setState(
+      { schema: SCHEMA, status: "ready" },
+      { error: "link starved", status: "error", targetNs: 0n },
+    );
+    render(<StateActionTile />);
+    expect(
+      screen.getByText(/Could not read the state\/action row: link starved/),
+    ).toBeDefined();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(mocks.retryRead).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the previous row visible through a failed refetch", () => {
+    setState(
+      { schema: SCHEMA, status: "ready" },
+      {
+        error: "link starved",
+        row: row(),
+        status: "error",
+        targetNs: 9n * NS_PER_SECOND,
+      },
+    );
+    render(<StateActionTile />);
+    expect(screen.getAllByText("Frame 4 of 20").length).toBeGreaterThan(0);
+    expect(screen.queryByText(/Could not read/)).toBe(null);
+  });
+
+  it("steps to the adjacent cursor, seeks the playhead, and pins the row", async () => {
+    setState(
+      { schema: SCHEMA, status: "ready" },
+      { row: row(), status: "ready", targetNs: 4n * NS_PER_SECOND },
+    );
+    const nextRow = row({
+      cursor: "row:5",
+      frameIndex: 5,
+      timestampNs: 5n * NS_PER_SECOND,
+    });
+    mocks.readRowIndexWindow.mockResolvedValue({
+      entries: [
+        { cursor: "row:4", timestampNs: 4n * NS_PER_SECOND },
+        { cursor: "row:5", timestampNs: 5n * NS_PER_SECOND },
+      ],
+      hasNext: true,
+      hasPrevious: true,
+      selectedCursor: "row:4",
+    });
+    mocks.readRowAtCursor.mockResolvedValue(nextRow);
+    render(<StateActionTile />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Next row (frame 5)" }));
+    await waitFor(() => expect(mocks.holdCursorRow).toHaveBeenCalled());
+
+    expect(mocks.readRowIndexWindow).toHaveBeenCalledWith({
+      after: 1,
+      anchorCursor: "row:4",
+      before: 0,
+    });
+    expect(mocks.readRowAtCursor).toHaveBeenCalledWith("row:5");
+    expect(mocks.pause).toHaveBeenCalled();
+    expect(mocks.seek).toHaveBeenCalledWith(5);
+    expect(mocks.holdCursorRow).toHaveBeenCalledWith(
+      nextRow,
+      5n * NS_PER_SECOND,
+    );
+  });
+
+  it("disables stepping at the episode boundaries", () => {
+    setState(
+      { schema: SCHEMA, status: "ready" },
+      {
+        row: row({ cursor: "row:0", frameIndex: 0, timestampNs: 0n }),
+        status: "ready",
+        targetNs: 0n,
+      },
+    );
+    const { rerender } = render(<StateActionTile />);
+    expect(
+      screen.getByRole<HTMLButtonElement>("button", {
+        name: "Previous row (frame -1)",
+      }).disabled,
+    ).toBe(true);
+    expect(
+      screen.getByRole<HTMLButtonElement>("button", {
+        name: "Next row (frame 1)",
+      }).disabled,
+    ).toBe(false);
+
+    setState(
+      { schema: SCHEMA, status: "ready" },
+      {
+        row: row({ cursor: "row:19", frameIndex: 19 }),
+        status: "ready",
+        targetNs: 19n * NS_PER_SECOND,
+      },
+    );
+    rerender(<StateActionTile />);
+    expect(
+      screen.getByRole<HTMLButtonElement>("button", {
+        name: "Next row (frame 20)",
+      }).disabled,
+    ).toBe(true);
+  });
+
+  it("steps with the keyboard when the tile is focused", async () => {
+    setState(
+      { schema: SCHEMA, status: "ready" },
+      { row: row(), status: "ready", targetNs: 4n * NS_PER_SECOND },
+    );
+    mocks.readRowIndexWindow.mockResolvedValue({
+      entries: [
+        { cursor: "row:3", timestampNs: 3n * NS_PER_SECOND },
+        { cursor: "row:4", timestampNs: 4n * NS_PER_SECOND },
+      ],
+      hasNext: true,
+      hasPrevious: true,
+      selectedCursor: "row:4",
+    });
+    mocks.readRowAtCursor.mockResolvedValue(
+      row({ cursor: "row:3", frameIndex: 3, timestampNs: 3n * NS_PER_SECOND }),
+    );
+    render(<StateActionTile />);
+
+    fireEvent.keyDown(
+      screen.getByRole("group", { name: "State and action table" }),
+      { key: "ArrowLeft" },
+    );
+    await waitFor(() => expect(mocks.holdCursorRow).toHaveBeenCalled());
+    expect(mocks.readRowIndexWindow).toHaveBeenCalledWith({
+      after: 0,
+      anchorCursor: "row:4",
+      before: 1,
+    });
+    expect(mocks.seek).toHaveBeenCalledWith(3);
+  });
+
+  it("announces committed rows politely only while paused", () => {
+    setState(
+      { schema: SCHEMA, status: "ready" },
+      { row: row(), status: "ready", targetNs: 4n * NS_PER_SECOND },
+    );
+    const { container, rerender } = render(<StateActionTile />);
+    const liveRegion = container.querySelector('[aria-live="polite"]');
+    expect(liveRegion?.textContent).toBe("Frame 4 of 20");
+
+    mocks.isPlaying = true;
+    rerender(<StateActionTile />);
+    expect(liveRegion?.textContent).toBe("");
+  });
+});

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionTile.test.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionTile.test.tsx
@@ -326,8 +326,10 @@ describe("StateActionTile", () => {
     expect(screen.getAllByText("Frame 4 of 20").length).toBeGreaterThan(0);
     expect(screen.queryByText(/Could not read/)).toBe(null);
     const badge = screen.getByTestId("episode-state-action-stale");
-    expect(badge.textContent).toBe("Refresh failed. Previous shown.");
+    expect(badge.textContent).toContain("Refresh failed. Previous shown.");
     expect(badge.title).toContain("link starved");
+    fireEvent.click(within(badge).getByRole("button", { name: "Retry" }));
+    expect(mocks.retryRead).toHaveBeenCalledTimes(1);
   });
 
   it("marks a slow refetch pending while keeping the previous row visible", () => {

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionTile.test.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionTile.test.tsx
@@ -79,6 +79,7 @@ vi.mock("./state-action-context", () => ({
   useStateActionContext: () => ({
     ensureSchema: mocks.ensureSchema,
     holdCursorRow: mocks.holdCursorRow,
+    readDimensionStats: async () => null,
     readRowAtCursor: mocks.readRowAtCursor,
     readRowIndexWindow: mocks.readRowIndexWindow,
     retryRead: mocks.retryRead,

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionTile.test.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionTile.test.tsx
@@ -25,6 +25,7 @@ const mocks = vi.hoisted(() => ({
     }),
     sourceKey: "source-1",
   },
+  addFieldToPlot: vi.fn(),
   ensureSchema: vi.fn(),
   holdCursorRow: vi.fn(),
   registerTileSettings: vi.fn(),
@@ -63,6 +64,10 @@ vi.mock("@fiftyone/playback/runtime", async () => {
 
 vi.mock("../playback/data-stream-context", () => ({
   useDataStream: () => mocks.dataStream,
+}));
+
+vi.mock("../plots/use-add-field-to-plot", () => ({
+  useAddFieldToPlot: () => mocks.addFieldToPlot,
 }));
 
 vi.mock("../tiles/tile-settings-context", () => ({
@@ -112,6 +117,14 @@ function row(overrides: Partial<StateActionRow> = {}): StateActionRow {
     timestampNs: 4n * NS_PER_SECOND,
     ...overrides,
   };
+}
+
+/** Texts of the value column only; plot-action cells are icon-only. */
+function valueCellTexts(pane: HTMLElement): (string | null)[] {
+  return within(pane)
+    .getAllByRole("cell")
+    .map((cell) => cell.textContent)
+    .filter((text) => text !== "");
 }
 
 function setState(
@@ -175,15 +188,9 @@ describe("StateActionTile", () => {
     const statePane = screen.getByRole("table", {
       name: "Observation state values",
     });
-    const stateValues = within(statePane).getAllByRole("cell");
-    expect(stateValues.map((cell) => cell.textContent)).toEqual(["1.25", "-2"]);
+    expect(valueCellTexts(statePane)).toEqual(["1.25", "-2"]);
     const actionPane = screen.getByRole("table", { name: "Action values" });
-    const actionValues = within(actionPane).getAllByRole("cell");
-    expect(actionValues.map((cell) => cell.textContent)).toEqual([
-      "0.5",
-      "NaN",
-      "7",
-    ]);
+    expect(valueCellTexts(actionPane)).toEqual(["0.5", "NaN", "7"]);
   });
 
   it("shows the playhead time only when it differs from the row time", () => {
@@ -262,10 +269,7 @@ describe("StateActionTile", () => {
       .getAllByRole("rowheader")
       .map((cell) => cell.textContent);
     expect(names).toEqual(["shoulder", "elbow", "[2]"]);
-    const values = within(statePane)
-      .getAllByRole("cell")
-      .map((cell) => cell.textContent);
-    expect(values).toEqual(["1", "2", "3"]);
+    expect(valueCellTexts(statePane)).toEqual(["1", "2", "3"]);
   });
 
   it("marks a dimension missing from the source row explicitly", () => {
@@ -284,10 +288,7 @@ describe("StateActionTile", () => {
     const statePane = screen.getByRole("table", {
       name: "Observation state values",
     });
-    const values = within(statePane)
-      .getAllByRole("cell")
-      .map((cell) => cell.textContent);
-    expect(values).toEqual(["1", "missing"]);
+    expect(valueCellTexts(statePane)).toEqual(["1", "missing"]);
   });
 
   it("shows the empty state distinctly from loading and errors", () => {
@@ -497,6 +498,42 @@ describe("StateActionTile", () => {
       before: 1,
     });
     expect(mocks.seek).toHaveBeenCalledWith(3);
+  });
+
+  it("offers an on-hover plot affordance for plottable dimensions", () => {
+    setState(
+      {
+        schema: {
+          action: SCHEMA.action,
+          rowCount: 20,
+          state: {
+            dimensions: [
+              {
+                index: 0,
+                name: "shoulder",
+                numericFieldPath: "observation.state.shoulder",
+              },
+              { index: 1, name: "elbow" },
+            ],
+            dtype: "float32",
+            featureName: "observation.state",
+            numericStreamId: "lerobot:observation.state",
+            shape: [2],
+          },
+        },
+        status: "ready",
+      },
+      { row: row(), status: "ready", targetNs: 4n * NS_PER_SECOND },
+    );
+    render(<StateActionTile />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Plot shoulder" }));
+    expect(mocks.addFieldToPlot).toHaveBeenCalledWith(
+      "lerobot:observation.state",
+      "observation.state.shoulder",
+    );
+    // A dimension without a numeric binding offers no affordance.
+    expect(screen.queryByRole("button", { name: "Plot elbow" })).toBe(null);
   });
 
   it("announces committed rows politely only while paused", () => {

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionTile.test.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionTile.test.tsx
@@ -182,6 +182,25 @@ describe("StateActionTile", () => {
     );
   });
 
+  it("settles settings fallbacks when declared statistics fail", async () => {
+    getDefaultStore().set(stateActionValueModeAtom, "zscore");
+    mocks.readDimensionStats.mockRejectedValue(
+      new Error("Unable to read declared statistics"),
+    );
+    render(<StateActionTile />);
+    const registration = mocks.registerTileSettings.mock.calls[0]?.[1] as {
+      readonly content: Parameters<typeof render>[0];
+    };
+
+    render(registration.content);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/this source declares no statistics/i),
+      ).toBeDefined(),
+    );
+  });
+
   it("renders schema-derived names as a skeleton before any value read", () => {
     render(<StateActionTile />);
     const statePane = screen.getByRole("table", {

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionTile.test.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionTile.test.tsx
@@ -214,6 +214,65 @@ describe("StateActionTile", () => {
     expect(valueCellTexts(actionPane)).toEqual(["0.5", "NaN", "7"]);
   });
 
+  it("filters both panes by case-insensitive dimension substrings without reindexing values", () => {
+    setState(
+      {
+        schema: {
+          ...SCHEMA,
+          action: {
+            dimensions: [
+              { index: 0, name: "wrist" },
+              { index: 1, name: "shoulder_target" },
+              { index: 2, name: "gripper" },
+            ],
+            dtype: "float32",
+            featureName: "action",
+            shape: [3],
+          },
+        },
+        status: "ready",
+      },
+      {
+        row: row({
+          action: [10, 20, 30],
+          cursor: "row:0",
+          frameIndex: 0,
+          timestampNs: 0n,
+        }),
+        status: "ready",
+        targetNs: 0n,
+      },
+    );
+    render(<StateActionTile />);
+
+    const filter = screen.getByRole("searchbox", {
+      name: "Filter dimensions",
+    });
+    fireEvent.change(filter, { target: { value: "  OUL  " } });
+    fireEvent.keyDown(filter, { key: "ArrowRight" });
+    expect(mocks.readRowIndexWindow).not.toHaveBeenCalled();
+
+    const statePane = screen.getByRole("table", {
+      name: "Observation state values",
+    });
+    expect(within(statePane).getByText("shoulder")).toBeDefined();
+    expect(within(statePane).queryByText("elbow")).toBe(null);
+    expect(valueCellTexts(statePane)).toEqual(["1.25"]);
+
+    const actionPane = screen.getByRole("table", { name: "Action values" });
+    expect(within(actionPane).getByText("shoulder_target")).toBeDefined();
+    expect(within(actionPane).queryByText("wrist")).toBe(null);
+    expect(within(actionPane).queryByText("gripper")).toBe(null);
+    expect(valueCellTexts(actionPane)).toEqual(["20"]);
+
+    fireEvent.change(filter, { target: { value: "not-a-dimension" } });
+    expect(screen.getAllByText("No matching dimensions")).toHaveLength(2);
+
+    fireEvent.change(filter, { target: { value: "" } });
+    expect(within(statePane).getByText("elbow")).toBeDefined();
+    expect(within(actionPane).getByText("gripper")).toBeDefined();
+  });
+
   it("shows the playhead time only when it differs from the row time", () => {
     setState(
       { schema: SCHEMA, status: "ready" },

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionTile.test.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionTile.test.tsx
@@ -312,7 +312,9 @@ describe("StateActionTile", () => {
     expect(container.querySelectorAll('[class*="dimTrackBand"]').length).toBe(
       0,
     );
-    const track = container.querySelector<HTMLElement>('[class="dimTrack"]');
+    const track = container.querySelector<HTMLElement>(
+      '[class*="dimTrack"][title]',
+    );
     expect(track?.title).toBe("episode -2.5 … 2.5");
   });
 

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionTile.test.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionTile.test.tsx
@@ -7,7 +7,11 @@ import {
   within,
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { StateActionRow, StateActionSchema } from "../../../ports";
+import type {
+  StateActionRow,
+  StateActionSchema,
+  StateActionStats,
+} from "../../../ports";
 import type {
   StateActionRowState,
   StateActionSchemaState,
@@ -33,6 +37,7 @@ const mocks = vi.hoisted(() => ({
   isPlayPending: false,
   pause: vi.fn(),
   playheadSec: 4,
+  readDimensionStats: vi.fn<() => Promise<StateActionStats | null>>(),
   readRowAtCursor: vi.fn(),
   readRowIndexWindow: vi.fn(),
   retryRead: vi.fn(),
@@ -79,7 +84,7 @@ vi.mock("./state-action-context", () => ({
   useStateActionContext: () => ({
     ensureSchema: mocks.ensureSchema,
     holdCursorRow: mocks.holdCursorRow,
-    readDimensionStats: async () => null,
+    readDimensionStats: mocks.readDimensionStats,
     readRowAtCursor: mocks.readRowAtCursor,
     readRowIndexWindow: mocks.readRowIndexWindow,
     retryRead: mocks.retryRead,
@@ -141,6 +146,7 @@ beforeEach(() => {
   mocks.isPlaying = false;
   mocks.isPlayPending = false;
   mocks.playheadSec = 4;
+  mocks.readDimensionStats.mockResolvedValue(null);
   setState({ schema: SCHEMA, status: "ready" }, undefined);
 });
 
@@ -221,6 +227,46 @@ describe("StateActionTile", () => {
     );
     render(<StateActionTile />);
     expect(screen.getByText("Task #7")).toBeDefined();
+  });
+
+  it("marks each value's place on its declared dataset range", async () => {
+    // dim 0: 1.25 inside [-2, 2] → tick at 81.25%; dim 1: -2 below the
+    // declared [0, 1] → clamped to the left edge and tinted out-of-range.
+    mocks.readDimensionStats.mockResolvedValue({
+      state: {
+        max: [2, 1],
+        min: [-2, 0],
+        q01: [-1.5, 0.1],
+        q99: [1.5, 0.9],
+      },
+    });
+    setState(
+      { schema: SCHEMA, status: "ready" },
+      { row: row(), status: "ready", targetNs: 4n * NS_PER_SECOND },
+    );
+    const { container } = render(<StateActionTile />);
+
+    await waitFor(() =>
+      expect(container.querySelectorAll('[class*="dimTrackTick"]').length).toBe(
+        2,
+      ),
+    );
+    const ticks = container.querySelectorAll<HTMLElement>(
+      '[class*="dimTrackTick"]',
+    );
+    expect(ticks[0].style.left).toBe("81.25%");
+    expect(ticks[0].className).not.toContain("dimTrackTickOut");
+    expect(ticks[1].style.left).toBe("0%");
+    expect(ticks[1].className).toContain("dimTrackTickOut");
+    // The declared band renders behind the tick; the action pane, with no
+    // declared stats, carries no markers at all.
+    expect(container.querySelectorAll('[class*="dimTrackBand"]').length).toBe(
+      2,
+    );
+    const actionPane = screen.getByRole("table", { name: "Action values" });
+    expect(actionPane.querySelectorAll('[class*="dimTrackTick"]').length).toBe(
+      0,
+    );
   });
 
   it("names the absent canonical feature when only one pane exists", () => {

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionTile.test.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionTile.test.tsx
@@ -6,12 +6,14 @@ import {
   waitFor,
   within,
 } from "@testing-library/react";
+import { getDefaultStore } from "jotai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   StateActionRow,
   StateActionSchema,
   StateActionStats,
 } from "../../../ports";
+import { stateActionValueModeAtom } from "./state-action-display";
 import type {
   StateActionRowState,
   StateActionSchemaState,
@@ -125,10 +127,11 @@ function row(overrides: Partial<StateActionRow> = {}): StateActionRow {
   };
 }
 
-/** Texts of the value column only; plot-action cells are icon-only. */
+/** Texts of the value column only; marker, delta, and plot cells drop out. */
 function valueCellTexts(pane: HTMLElement): (string | null)[] {
   return within(pane)
     .getAllByRole("cell")
+    .filter((cell) => !cell.className.includes("dimDelta"))
     .map((cell) => cell.textContent)
     .filter((text) => text !== "");
 }
@@ -143,10 +146,15 @@ function setState(
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Implementations set with mockResolvedValue survive clearAllMocks; the
+  // exact-read mocks must not leak a previous test's rows into the next.
+  mocks.readRowAtCursor.mockReset();
+  mocks.readRowIndexWindow.mockReset();
   mocks.isPlaying = false;
   mocks.isPlayPending = false;
   mocks.playheadSec = 4;
   mocks.readDimensionStats.mockResolvedValue(null);
+  getDefaultStore().set(stateActionValueModeAtom, "raw");
   setState({ schema: SCHEMA, status: "ready" }, undefined);
 });
 
@@ -252,6 +260,85 @@ describe("StateActionTile", () => {
     expect(actionPane.querySelectorAll('[class*="dimTrackTick"]').length).toBe(
       0,
     );
+  });
+
+  it("shows each value's change from the previous row", async () => {
+    setState(
+      { schema: SCHEMA, status: "ready" },
+      { row: row(), status: "ready", targetNs: 4n * NS_PER_SECOND },
+    );
+    mocks.readRowIndexWindow.mockResolvedValue({
+      entries: [
+        { cursor: "row:3", timestampNs: 3n * NS_PER_SECOND },
+        { cursor: "row:4", timestampNs: 4n * NS_PER_SECOND },
+      ],
+      hasNext: true,
+      hasPrevious: true,
+      selectedCursor: "row:4",
+    });
+    mocks.readRowAtCursor.mockResolvedValue(
+      row({
+        action: [0.25, 1, 7],
+        cursor: "row:3",
+        frameIndex: 3,
+        state: [1, -2.5],
+        timestampNs: 3n * NS_PER_SECOND,
+      }),
+    );
+    render(<StateActionTile />);
+
+    // The previous row resolves through the exact index, never through
+    // time; state and action dimension 0 both moved by exactly +0.25.
+    await waitFor(() => expect(screen.getAllByText("+0.25").length).toBe(2));
+    expect(mocks.readRowAtCursor).toHaveBeenCalledWith(
+      "row:3",
+      expect.anything(),
+    );
+    expect(screen.getByText("+0.5")).toBeDefined();
+    // A NaN pair renders no delta; an unchanged value shows an exact zero.
+    const statePane = screen.getByRole("table", {
+      name: "Observation state values",
+    });
+    expect(within(statePane).getByText("+0.25").className).toContain(
+      "dimDelta",
+    );
+    const actionPane = screen.getByRole("table", { name: "Action values" });
+    const actionDeltas = within(actionPane)
+      .getAllByRole("cell")
+      .filter((cell) => cell.className.includes("dimDelta"))
+      .map((cell) => cell.textContent);
+    expect(actionDeltas).toEqual(["+0.25", "", "0"]);
+  });
+
+  it("displays z-scored values while copy keeps the raw exact value", async () => {
+    getDefaultStore().set(stateActionValueModeAtom, "zscore");
+    mocks.readDimensionStats.mockResolvedValue({
+      state: { mean: [1, 0], std: [0.5, 1] },
+    });
+    setState(
+      { schema: SCHEMA, status: "ready" },
+      { row: row(), status: "ready", targetNs: 4n * NS_PER_SECOND },
+    );
+    render(<StateActionTile />);
+
+    const statePane = screen.getByRole("table", {
+      name: "Observation state values",
+    });
+    // (1.25 − 1) / 0.5 and (−2 − 0) / 1, under a mode-labeled column.
+    await waitFor(() =>
+      expect(valueCellTexts(statePane)).toEqual(["0.5", "-2"]),
+    );
+    expect(
+      within(statePane).getByRole("columnheader", { name: "Z-score" }),
+    ).toBeDefined();
+    const copyButton = screen.getByRole("button", {
+      name: "Copy exact value 1.25",
+    });
+    expect(copyButton.textContent).toBe("0.5");
+    // The action feature has no declared stats: raw values and a raw-shaped
+    // fallback keep the pane honest instead of inventing a scale.
+    const actionPane = screen.getByRole("table", { name: "Action values" });
+    expect(valueCellTexts(actionPane)).toEqual(["0.5", "NaN", "7"]);
   });
 
   it("names the absent canonical feature when only one pane exists", () => {

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionTile.test.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionTile.test.tsx
@@ -31,6 +31,7 @@ const mocks = vi.hoisted(() => ({
   isPlaying: false,
   isPlayPending: false,
   pause: vi.fn(),
+  playheadSec: 4,
   readRowAtCursor: vi.fn(),
   readRowIndexWindow: vi.fn(),
   retryRead: vi.fn(),
@@ -46,11 +47,19 @@ vi.mock("@fiftyone/tiling", () => ({
   useTileId: () => "lerobot:state-action-1",
 }));
 
-vi.mock("@fiftyone/playback/runtime", () => ({
-  useIsPlaying: () => mocks.isPlaying,
-  useIsPlayPending: () => mocks.isPlayPending,
-  usePlayback: () => ({ pause: mocks.pause, seek: mocks.seek }),
-}));
+vi.mock("@fiftyone/playback/runtime", async () => {
+  const { createContext } = await import("react");
+  return {
+    getIsPlaying: () => mocks.isPlaying,
+    getIsPlayPending: () => mocks.isPlayPending,
+    getPlayhead: () => mocks.playheadSec,
+    // Non-null default so the tile's supersede guard is active in tests.
+    PlaybackStoreContext: createContext<object>({}),
+    useIsPlaying: () => mocks.isPlaying,
+    useIsPlayPending: () => mocks.isPlayPending,
+    usePlayback: () => ({ pause: mocks.pause, seek: mocks.seek }),
+  };
+});
 
 vi.mock("../playback/data-stream-context", () => ({
   useDataStream: () => mocks.dataStream,
@@ -117,6 +126,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   mocks.isPlaying = false;
   mocks.isPlayPending = false;
+  mocks.playheadSec = 4;
   setState({ schema: SCHEMA, status: "ready" }, undefined);
 });
 
@@ -222,6 +232,11 @@ describe("StateActionTile", () => {
       screen.getByText("No observation.state feature declared"),
     ).toBeDefined();
     expect(screen.getByRole("table", { name: "Action values" })).toBeDefined();
+    // The absent feature is a compact note, not a pane that starves the
+    // available values of space.
+    expect(
+      screen.queryByRole("table", { name: "Observation state values" }),
+    ).toBe(null);
   });
 
   it("shows a feature-scoped error without shifting later values", () => {
@@ -297,7 +312,7 @@ describe("StateActionTile", () => {
     expect(mocks.retryRead).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps the previous row visible through a failed refetch", () => {
+  it("marks a failed refetch stale while keeping the previous row visible", () => {
     setState(
       { schema: SCHEMA, status: "ready" },
       {
@@ -310,6 +325,21 @@ describe("StateActionTile", () => {
     render(<StateActionTile />);
     expect(screen.getAllByText("Frame 4 of 20").length).toBeGreaterThan(0);
     expect(screen.queryByText(/Could not read/)).toBe(null);
+    const badge = screen.getByTestId("episode-state-action-stale");
+    expect(badge.textContent).toBe("Refresh failed. Previous shown.");
+    expect(badge.title).toContain("link starved");
+  });
+
+  it("marks a slow refetch pending while keeping the previous row visible", () => {
+    setState(
+      { schema: SCHEMA, status: "ready" },
+      { row: row(), status: "loading", targetNs: 9n * NS_PER_SECOND },
+    );
+    render(<StateActionTile />);
+    expect(screen.getAllByText("Frame 4 of 20").length).toBeGreaterThan(0);
+    expect(screen.getByTestId("episode-state-action-stale").textContent).toBe(
+      "Loading… Previous shown.",
+    );
   });
 
   it("steps to the adjacent cursor, seeks the playhead, and pins the row", async () => {
@@ -361,10 +391,10 @@ describe("StateActionTile", () => {
       },
     );
     const { rerender } = render(<StateActionTile />);
+    // Boundary controls stay disabled and never name an impossible frame.
     expect(
-      screen.getByRole<HTMLButtonElement>("button", {
-        name: "Previous row (frame -1)",
-      }).disabled,
+      screen.getByRole<HTMLButtonElement>("button", { name: "Previous row" })
+        .disabled,
     ).toBe(true);
     expect(
       screen.getByRole<HTMLButtonElement>("button", {
@@ -382,10 +412,57 @@ describe("StateActionTile", () => {
     );
     rerender(<StateActionTile />);
     expect(
-      screen.getByRole<HTMLButtonElement>("button", {
-        name: "Next row (frame 20)",
-      }).disabled,
+      screen.getByRole<HTMLButtonElement>("button", { name: "Next row" })
+        .disabled,
     ).toBe(true);
+    expect(
+      screen.getByRole<HTMLButtonElement>("button", {
+        name: "Previous row (frame 18)",
+      }).disabled,
+    ).toBe(false);
+  });
+
+  it("abandons a stale step when the playhead moves before it commits", async () => {
+    setState(
+      { schema: SCHEMA, status: "ready" },
+      { row: row(), status: "ready", targetNs: 4n * NS_PER_SECOND },
+    );
+    mocks.readRowIndexWindow.mockResolvedValue({
+      entries: [
+        { cursor: "row:4", timestampNs: 4n * NS_PER_SECOND },
+        { cursor: "row:5", timestampNs: 5n * NS_PER_SECOND },
+      ],
+      hasNext: true,
+      hasPrevious: true,
+      selectedCursor: "row:4",
+    });
+    let resolveRead!: (value: StateActionRow) => void;
+    mocks.readRowAtCursor.mockImplementation(
+      () =>
+        new Promise<StateActionRow>((resolve) => {
+          resolveRead = resolve;
+        }),
+    );
+    render(<StateActionTile />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Next row (frame 5)" }));
+    await waitFor(() => expect(mocks.readRowAtCursor).toHaveBeenCalled());
+    // The user scrubs elsewhere while the exact read is still in flight.
+    mocks.playheadSec = 12;
+    resolveRead(
+      row({ cursor: "row:5", frameIndex: 5, timestampNs: 5n * NS_PER_SECOND }),
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByRole<HTMLButtonElement>("button", {
+          name: "Next row (frame 5)",
+        }).disabled,
+      ).toBe(false),
+    );
+
+    expect(mocks.pause).not.toHaveBeenCalled();
+    expect(mocks.seek).not.toHaveBeenCalled();
+    expect(mocks.holdCursorRow).not.toHaveBeenCalled();
   });
 
   it("steps with the keyboard when the tile is focused", async () => {

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionTile.test.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionTile.test.tsx
@@ -25,7 +25,9 @@ const mocks = vi.hoisted(() => ({
     }),
     sourceKey: "source-1",
   },
+  ensureSchema: vi.fn(),
   holdCursorRow: vi.fn(),
+  registerTileSettings: vi.fn(),
   isPlaying: false,
   isPlayPending: false,
   pause: vi.fn(),
@@ -54,8 +56,14 @@ vi.mock("../playback/data-stream-context", () => ({
   useDataStream: () => mocks.dataStream,
 }));
 
+vi.mock("../tiles/tile-settings-context", () => ({
+  useRegisterTileSettings: (tileId: string, registration: unknown) =>
+    mocks.registerTileSettings(tileId, registration),
+}));
+
 vi.mock("./state-action-context", () => ({
   useStateActionContext: () => ({
+    ensureSchema: mocks.ensureSchema,
     holdCursorRow: mocks.holdCursorRow,
     readRowAtCursor: mocks.readRowAtCursor,
     readRowIndexWindow: mocks.readRowIndexWindow,
@@ -115,12 +123,17 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe("StateActionTile", () => {
-  it("titles itself and subscribes to the canonical row", () => {
+  it("titles itself, ensures the schema, and subscribes to the row", () => {
     render(<StateActionTile />);
     expect(mocks.setTileTitle).toHaveBeenCalledWith("State & Action", {
       source: "auto",
     });
+    expect(mocks.ensureSchema).toHaveBeenCalled();
     expect(mocks.subscribeRow).toHaveBeenCalledTimes(1);
+    expect(mocks.registerTileSettings).toHaveBeenCalledWith(
+      "lerobot:state-action-1",
+      expect.objectContaining({ content: expect.anything() }),
+    );
   });
 
   it("renders schema-derived names as a skeleton before any value read", () => {

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionTile.test.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionTile.test.tsx
@@ -9,11 +9,15 @@ import {
 import { getDefaultStore } from "jotai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
+  StateActionEpisodeProfile,
   StateActionRow,
   StateActionSchema,
   StateActionStats,
 } from "../../../ports";
-import { stateActionValueModeAtom } from "./state-action-display";
+import {
+  stateActionMarkerScopeAtom,
+  stateActionValueModeAtom,
+} from "./state-action-display";
 import type {
   StateActionRowState,
   StateActionSchemaState,
@@ -40,6 +44,7 @@ const mocks = vi.hoisted(() => ({
   pause: vi.fn(),
   playheadSec: 4,
   readDimensionStats: vi.fn<() => Promise<StateActionStats | null>>(),
+  readEpisodeProfile: vi.fn<() => Promise<StateActionEpisodeProfile | null>>(),
   readRowAtCursor: vi.fn(),
   readRowIndexWindow: vi.fn(),
   retryRead: vi.fn(),
@@ -87,6 +92,7 @@ vi.mock("./state-action-context", () => ({
     ensureSchema: mocks.ensureSchema,
     holdCursorRow: mocks.holdCursorRow,
     readDimensionStats: mocks.readDimensionStats,
+    readEpisodeProfile: mocks.readEpisodeProfile,
     readRowAtCursor: mocks.readRowAtCursor,
     readRowIndexWindow: mocks.readRowIndexWindow,
     retryRead: mocks.retryRead,
@@ -154,7 +160,9 @@ beforeEach(() => {
   mocks.isPlayPending = false;
   mocks.playheadSec = 4;
   mocks.readDimensionStats.mockResolvedValue(null);
+  mocks.readEpisodeProfile.mockResolvedValue(null);
   getDefaultStore().set(stateActionValueModeAtom, "raw");
+  getDefaultStore().set(stateActionMarkerScopeAtom, "episode");
   setState({ schema: SCHEMA, status: "ready" }, undefined);
 });
 
@@ -223,6 +231,7 @@ describe("StateActionTile", () => {
   });
 
   it("marks each value's place on its declared dataset range", async () => {
+    getDefaultStore().set(stateActionMarkerScopeAtom, "dataset");
     // dim 0: 1.25 inside [-2, 2] → tick at 81.25%; dim 1: -2 below the
     // declared [0, 1] → clamped to the left edge and tinted out-of-range.
     mocks.readDimensionStats.mockResolvedValue({
@@ -260,6 +269,51 @@ describe("StateActionTile", () => {
     expect(actionPane.querySelectorAll('[class*="dimTrackTick"]').length).toBe(
       0,
     );
+  });
+
+  it("spans markers over this episode's observed range by default", async () => {
+    // Episode scope: dim 0's 1.25 sits at 75% of [-2.5, 2.5]; dim 1's -2
+    // IS its episode minimum, so the tick pins to the left edge untinted.
+    mocks.readEpisodeProfile.mockResolvedValue({
+      rowCount: 20,
+      state: {
+        max: [
+          { frameIndex: 10, timestampNs: 10n * NS_PER_SECOND, value: 2.5 },
+          { frameIndex: 3, timestampNs: 3n * NS_PER_SECOND, value: 3 },
+        ],
+        mean: [0, 0],
+        min: [
+          { frameIndex: 2, timestampNs: 2n * NS_PER_SECOND, value: -2.5 },
+          { frameIndex: 4, timestampNs: 4n * NS_PER_SECOND, value: -2 },
+        ],
+        outOfRangeCounts: null,
+      },
+      timing: { gapCount: 0, gaps: [], medianIntervalNs: 1_000_000_000n },
+    });
+    setState(
+      { schema: SCHEMA, status: "ready" },
+      { row: row(), status: "ready", targetNs: 4n * NS_PER_SECOND },
+    );
+    const { container } = render(<StateActionTile />);
+
+    await waitFor(() =>
+      expect(container.querySelectorAll('[class*="dimTrackTick"]').length).toBe(
+        2,
+      ),
+    );
+    const ticks = container.querySelectorAll<HTMLElement>(
+      '[class*="dimTrackTick"]',
+    );
+    expect(ticks[0].style.left).toBe("75%");
+    expect(ticks[1].style.left).toBe("0%");
+    expect(ticks[1].className).not.toContain("dimTrackTickOut");
+    // Episode scope carries no quantile band, and the profile-less action
+    // feature carries no markers at all.
+    expect(container.querySelectorAll('[class*="dimTrackBand"]').length).toBe(
+      0,
+    );
+    const track = container.querySelector<HTMLElement>('[class="dimTrack"]');
+    expect(track?.title).toBe("episode -2.5 … 2.5");
   });
 
   it("shows each value's change from the previous row", async () => {

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionTile.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionTile.tsx
@@ -219,9 +219,6 @@ const StateActionTile: React.FC<EpisodeTileProps> = () => {
   const paused = !isPlaying && !isPlayPending;
   const announcement =
     paused && row ? `Frame ${row.frameIndex} of ${rowCount}` : "";
-  const taskLabel = row?.task
-    ? (row.task.label ?? `Task #${row.task.index}`)
-    : null;
   const status = rowState?.status;
   const hasCommittedRow = rowState?.row !== undefined;
   const showEmpty = status === "ready" && row === null;
@@ -260,20 +257,6 @@ const StateActionTile: React.FC<EpisodeTileProps> = () => {
             {`playhead ${formatEpisodeTime(rowState.targetNs, startTimeNs)}`}
           </span>
         ) : null}
-        {taskLabel ? (
-          <span
-            className={styles.headerBadge}
-            title="Task supervising this row"
-          >
-            {taskLabel}
-          </span>
-        ) : null}
-        <span
-          className={styles.headerBadge}
-          title="Every value comes from the identified source row"
-        >
-          Exact row
-        </span>
         {stepError ? (
           <span className={styles.headerError} role="status">
             {stepError}

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionTile.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionTile.tsx
@@ -23,6 +23,7 @@ import { errorMessage } from "../../../utils/errors";
 import { relativeTimeParts } from "../../../utils/relative-time";
 import { virtualLogRowRange } from "../../../visualization/logs/log-console-virtualization";
 import { useDataStream } from "../playback/data-stream-context";
+import { useAddFieldToPlot } from "../plots/use-add-field-to-plot";
 import { useRegisterTileSettings } from "../tiles/tile-settings-context";
 import type { EpisodeTileProps } from "../tiles/tile-types";
 import tileStyles from "../tiles/Tile.module.css";
@@ -60,6 +61,7 @@ const StateActionTile: React.FC<EpisodeTileProps> = () => {
     subscribeRow,
   } = useStateActionContext();
   const dataStream = useDataStream();
+  const addFieldToPlot = useAddFieldToPlot();
   // Nullable on purpose: standalone tests render the tile without a
   // playback provider; inside the shell the store is always present.
   const playbackStore = useContext(PlaybackStoreContext);
@@ -368,6 +370,7 @@ const StateActionTile: React.FC<EpisodeTileProps> = () => {
                 <FeaturePane
                   featureError={row?.featureErrors?.state}
                   label={STATE_PANE_LABEL}
+                  onPlotField={addFieldToPlot}
                   schema={schemaFacts.state}
                   values={row?.state}
                 />
@@ -376,6 +379,7 @@ const StateActionTile: React.FC<EpisodeTileProps> = () => {
                 <FeaturePane
                   featureError={row?.featureErrors?.action}
                   label={ACTION_PANE_LABEL}
+                  onPlotField={addFieldToPlot}
                   schema={schemaFacts.action}
                   values={row?.action}
                 />
@@ -394,11 +398,13 @@ const StateActionTile: React.FC<EpisodeTileProps> = () => {
 function FeaturePane({
   featureError,
   label,
+  onPlotField,
   schema,
   values,
 }: {
   readonly featureError?: string;
   readonly label: string;
+  readonly onPlotField?: (stream: string, fieldPath: string) => void;
   readonly schema: StateActionFeatureSchema;
   readonly values?: readonly unknown[];
 }) {
@@ -468,6 +474,9 @@ function FeaturePane({
             <span role="columnheader" style={{ textAlign: "right" }}>
               Value
             </span>
+            <span role="columnheader">
+              <span className={styles.srOnly}>Plot</span>
+            </span>
           </div>
           <div
             className={styles.rowSpacer}
@@ -500,6 +509,27 @@ function FeaturePane({
                   <span className={styles.dimValue} role="cell">
                     <ValueCell value={paneRow.value} />
                   </span>
+                  <span className={styles.dimAction} role="cell">
+                    {onPlotField &&
+                    schema.numericStreamId &&
+                    paneRow.plotFieldPath ? (
+                      <button
+                        aria-label={`Plot ${paneRow.name}`}
+                        className={styles.plotButton}
+                        onClick={() =>
+                          onPlotField(
+                            schema.numericStreamId as string,
+                            paneRow.plotFieldPath as string,
+                          )
+                        }
+                        onPointerDown={(event) => event.stopPropagation()}
+                        title={`Plot ${paneRow.name} over the episode`}
+                        type="button"
+                      >
+                        <Icon name={IconName.Insights} size={Size.Xs} />
+                      </button>
+                    ) : null}
+                  </span>
                 </div>
               ))}
             </div>
@@ -513,6 +543,7 @@ function FeaturePane({
 interface PaneRow {
   readonly index: number;
   readonly name: string;
+  readonly plotFieldPath?: string;
   readonly value: PaneValue;
 }
 
@@ -534,14 +565,22 @@ function paneRows(
   // dimension and every extra source value under its stable numeric index.
   const count = Math.max(schema.dimensions.length, values?.length ?? 0);
   return Array.from({ length: count }, (_, index) => {
-    const name = schema.dimensions[index]?.name ?? `[${index}]`;
+    const dimension = schema.dimensions[index];
+    const name = dimension?.name ?? `[${index}]`;
     const value: PaneValue =
       values === undefined
         ? { kind: "skeleton" }
         : index >= values.length
           ? { kind: "missing" }
           : formatStateActionValue(values[index]);
-    return { index, name, value };
+    return {
+      index,
+      name,
+      ...(dimension?.numericFieldPath
+        ? { plotFieldPath: dimension.numericFieldPath }
+        : {}),
+      value,
+    };
   });
 }
 

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionTile.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionTile.tsx
@@ -20,7 +20,6 @@ import React, {
 } from "react";
 import type { StateActionFeatureSchema } from "../../../ports";
 import { errorMessage } from "../../../utils/errors";
-import { relativeTimeParts } from "../../../utils/relative-time";
 import { virtualLogRowRange } from "../../../visualization/logs/log-console-virtualization";
 import { useDataStream } from "../playback/data-stream-context";
 import { useAddFieldToPlot } from "../plots/use-add-field-to-plot";
@@ -28,6 +27,11 @@ import { useRegisterTileSettings } from "../tiles/tile-settings-context";
 import type { EpisodeTileProps } from "../tiles/tile-types";
 import tileStyles from "../tiles/Tile.module.css";
 import { useStateActionContext } from "./state-action-context";
+import {
+  formatEpisodeTime,
+  formatStateActionValue,
+  type FormattedStateActionValue,
+} from "./state-action-format";
 import StateActionTileSettings from "./StateActionTileSettings";
 import styles from "./StateActionTile.module.css";
 
@@ -550,12 +554,7 @@ interface PaneRow {
 type PaneValue =
   | { readonly kind: "skeleton" }
   | { readonly kind: "missing" }
-  | {
-      readonly exact: string;
-      readonly invalid: boolean;
-      readonly kind: "value";
-      readonly text: string;
-    };
+  | FormattedStateActionValue;
 
 function paneRows(
   schema: StateActionFeatureSchema,
@@ -613,67 +612,6 @@ function ValueCell({ value }: { readonly value: PaneValue }) {
       {value.text}
     </button>
   );
-}
-
-/** Compact display value plus the exact parsed value for copy and hover. */
-export function formatStateActionValue(value: unknown): {
-  readonly exact: string;
-  readonly invalid: boolean;
-  readonly kind: "value";
-  readonly text: string;
-} {
-  if (typeof value === "number") {
-    if (Number.isNaN(value)) {
-      return { exact: "NaN", invalid: true, kind: "value", text: "NaN" };
-    }
-    if (!Number.isFinite(value)) {
-      return {
-        exact: String(value),
-        invalid: true,
-        kind: "value",
-        text: value > 0 ? "∞" : "-∞",
-      };
-    }
-    if (Number.isInteger(value)) {
-      return {
-        exact: String(value),
-        invalid: false,
-        kind: "value",
-        text: String(value),
-      };
-    }
-    return {
-      exact: String(value),
-      invalid: false,
-      kind: "value",
-      text: compactFloat(value),
-    };
-  }
-  if (typeof value === "bigint" || typeof value === "boolean") {
-    const text = value.toString();
-    return { exact: text, invalid: false, kind: "value", text };
-  }
-  if (value === null || value === undefined) {
-    return { exact: "null", invalid: true, kind: "value", text: "null" };
-  }
-  const text = String(value);
-  return { exact: text, invalid: true, kind: "value", text };
-}
-
-function compactFloat(value: number): string {
-  const magnitude = Math.abs(value);
-  if (magnitude !== 0 && (magnitude >= 1e6 || magnitude < 1e-4)) {
-    return value.toExponential(4);
-  }
-  return String(Number(value.toPrecision(6)));
-}
-
-/** Formats an episode-local time for the header, exact to the millisecond. */
-export function formatEpisodeTime(timeNs: bigint, originNs: bigint): string {
-  const { milliseconds, negative, seconds } = relativeTimeParts(
-    timeNs - originNs,
-  );
-  return `t=${negative ? "-" : "+"}${seconds}.${milliseconds}s`;
 }
 
 function exactTimeTitle(timeNs: bigint, originNs: bigint): string {

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionTile.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionTile.tsx
@@ -18,7 +18,11 @@ import React, {
   useRef,
   useState,
 } from "react";
-import type { StateActionFeatureSchema } from "../../../ports";
+import type {
+  StateActionFeatureSchema,
+  StateActionFeatureStats,
+  StateActionStats,
+} from "../../../ports";
 import { errorMessage } from "../../../utils/errors";
 import { virtualLogRowRange } from "../../../visualization/logs/log-console-virtualization";
 import { useDataStream } from "../playback/data-stream-context";
@@ -57,6 +61,7 @@ const StateActionTile: React.FC<EpisodeTileProps> = () => {
   const {
     ensureSchema,
     holdCursorRow,
+    readDimensionStats,
     readRowAtCursor,
     readRowIndexWindow,
     retryRead,
@@ -96,6 +101,22 @@ const StateActionTile: React.FC<EpisodeTileProps> = () => {
   useEffect(() => subscribeRow(), [subscribeRow]);
 
   const schemaFacts = schema.status === "ready" ? schema.schema : null;
+  const [dimensionStats, setDimensionStats] = useState<StateActionStats | null>(
+    null,
+  );
+  // This effect loads the declared dataset ranges once per session so value
+  // rows can carry faint in-context markers; absent stats render none.
+  useEffect(() => {
+    if (!schemaFacts) return undefined;
+    const controller = new AbortController();
+    readDimensionStats(controller.signal).then(
+      (result) => {
+        if (!controller.signal.aborted) setDimensionStats(result);
+      },
+      () => undefined,
+    );
+    return () => controller.abort();
+  }, [readDimensionStats, schemaFacts]);
   const row = rowState?.row ?? null;
   const rowCount = schemaFacts?.rowCount ?? 0;
   const canStepPrevious = Boolean(row && row.frameIndex > 0 && !stepPending);
@@ -376,6 +397,7 @@ const StateActionTile: React.FC<EpisodeTileProps> = () => {
                   label={STATE_PANE_LABEL}
                   onPlotField={addFieldToPlot}
                   schema={schemaFacts.state}
+                  stats={dimensionStats?.state}
                   values={row?.state}
                 />
               ) : null}
@@ -385,6 +407,7 @@ const StateActionTile: React.FC<EpisodeTileProps> = () => {
                   label={ACTION_PANE_LABEL}
                   onPlotField={addFieldToPlot}
                   schema={schemaFacts.action}
+                  stats={dimensionStats?.action}
                   values={row?.action}
                 />
               ) : null}
@@ -404,17 +427,22 @@ function FeaturePane({
   label,
   onPlotField,
   schema,
+  stats,
   values,
 }: {
   readonly featureError?: string;
   readonly label: string;
   readonly onPlotField?: (stream: string, fieldPath: string) => void;
   readonly schema: StateActionFeatureSchema;
+  readonly stats?: StateActionFeatureStats;
   readonly values?: readonly unknown[];
 }) {
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const [viewport, setViewport] = useState({ height: 0, scrollTop: 0 });
-  const rows = useMemo(() => paneRows(schema, values), [schema, values]);
+  const rows = useMemo(
+    () => paneRows(schema, values, stats),
+    [schema, stats, values],
+  );
   const virtualize = rows.length > VIRTUALIZE_AFTER_ROWS;
 
   // This effect tracks the fixed-row viewport for large vectors so long
@@ -475,6 +503,9 @@ function FeaturePane({
         >
           <div className={styles.columnHeaders} role="row">
             <span role="columnheader">Dimension</span>
+            <span role="columnheader">
+              <span className={styles.srOnly}>Declared range</span>
+            </span>
             <span role="columnheader" style={{ textAlign: "right" }}>
               Value
             </span>
@@ -509,6 +540,9 @@ function FeaturePane({
                     title={paneRow.name}
                   >
                     {paneRow.name}
+                  </span>
+                  <span className={styles.dimTrackCell} role="cell">
+                    <ValueMarker marker={paneRow.marker} />
                   </span>
                   <span className={styles.dimValue} role="cell">
                     <ValueCell value={paneRow.value} />
@@ -546,9 +580,18 @@ function FeaturePane({
 
 interface PaneRow {
   readonly index: number;
+  readonly marker?: ValueMarkerFacts;
   readonly name: string;
   readonly plotFieldPath?: string;
   readonly value: PaneValue;
+}
+
+/** Where one exact value sits inside its declared dataset range. */
+interface ValueMarkerFacts {
+  readonly band?: readonly [number, number];
+  readonly outOfRange: boolean;
+  readonly position: number;
+  readonly title: string;
 }
 
 type PaneValue =
@@ -559,6 +602,7 @@ type PaneValue =
 function paneRows(
   schema: StateActionFeatureSchema,
   values: readonly unknown[] | undefined,
+  stats: StateActionFeatureStats | undefined,
 ): readonly PaneRow[] {
   // Never shift or hide values on a shape mismatch: render every declared
   // dimension and every extra source value under its stable numeric index.
@@ -566,14 +610,18 @@ function paneRows(
   return Array.from({ length: count }, (_, index) => {
     const dimension = schema.dimensions[index];
     const name = dimension?.name ?? `[${index}]`;
+    const raw =
+      values !== undefined && index < values.length ? values[index] : undefined;
     const value: PaneValue =
       values === undefined
         ? { kind: "skeleton" }
         : index >= values.length
           ? { kind: "missing" }
-          : formatStateActionValue(values[index]);
+          : formatStateActionValue(raw);
+    const marker = valueMarker(stats, index, raw);
     return {
       index,
+      ...(marker ? { marker } : {}),
       name,
       ...(dimension?.numericFieldPath
         ? { plotFieldPath: dimension.numericFieldPath }
@@ -581,6 +629,69 @@ function paneRows(
       value,
     };
   });
+}
+
+/**
+ * Positions one exact value on its dimension's declared dataset range so
+ * the row carries a faint in-context marker. Only source-declared facts
+ * feed the geometry; a value outside the declared range clamps to the
+ * edge and tints the tick instead of stretching the scale.
+ */
+function valueMarker(
+  stats: StateActionFeatureStats | undefined,
+  index: number,
+  value: unknown,
+): ValueMarkerFacts | undefined {
+  if (!stats || typeof value !== "number" || !Number.isFinite(value)) {
+    return undefined;
+  }
+  const min = stats.min?.[index];
+  const max = stats.max?.[index];
+  if (
+    min === undefined ||
+    max === undefined ||
+    !Number.isFinite(min) ||
+    !Number.isFinite(max) ||
+    max <= min
+  ) {
+    return undefined;
+  }
+  const position = (candidate: number) =>
+    Math.min(1, Math.max(0, (candidate - min) / (max - min)));
+  const q01 = stats.q01?.[index];
+  const q99 = stats.q99?.[index];
+  return {
+    ...(q01 !== undefined && q99 !== undefined
+      ? { band: [position(q01), position(q99)] as const }
+      : {}),
+    outOfRange: value < min || value > max,
+    position: position(value),
+    title: `declared ${formatStateActionValue(min).text} … ${formatStateActionValue(max).text}`,
+  };
+}
+
+/** Faint declared-range strip with a tick at the current value. */
+function ValueMarker({ marker }: { readonly marker?: ValueMarkerFacts }) {
+  if (!marker) return null;
+  return (
+    <span aria-hidden className={styles.dimTrack} title={marker.title}>
+      {marker.band ? (
+        <span
+          className={styles.dimTrackBand}
+          style={{
+            left: `${marker.band[0] * 100}%`,
+            width: `${Math.max(1, (marker.band[1] - marker.band[0]) * 100)}%`,
+          }}
+        />
+      ) : null}
+      <span
+        className={`${styles.dimTrackTick} ${
+          marker.outOfRange ? styles.dimTrackTickOut : ""
+        }`}
+        style={{ left: `${marker.position * 100}%` }}
+      />
+    </span>
+  );
 }
 
 function ValueCell({ value }: { readonly value: PaneValue }) {

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionTile.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionTile.tsx
@@ -20,6 +20,8 @@ import React, {
   useState,
 } from "react";
 import type {
+  StateActionEpisodeProfile,
+  StateActionFeatureProfile,
   StateActionFeatureSchema,
   StateActionFeatureStats,
   StateActionRow,
@@ -36,8 +38,10 @@ import { useStateActionContext } from "./state-action-context";
 import {
   formatStateActionDelta,
   normalizeStateActionValue,
+  stateActionMarkerScopeAtom,
   stateActionValueHeader,
   stateActionValueModeAtom,
+  type StateActionMarkerScope,
   type StateActionValueMode,
 } from "./state-action-display";
 import {
@@ -72,6 +76,7 @@ const StateActionTile: React.FC<EpisodeTileProps> = () => {
     ensureSchema,
     holdCursorRow,
     readDimensionStats,
+    readEpisodeProfile,
     readRowAtCursor,
     readRowIndexWindow,
     retryRead,
@@ -127,8 +132,24 @@ const StateActionTile: React.FC<EpisodeTileProps> = () => {
     );
     return () => controller.abort();
   }, [readDimensionStats, schemaFacts]);
+  const [episodeProfile, setEpisodeProfile] =
+    useState<StateActionEpisodeProfile | null>(null);
+  // This effect loads the episode profile once per session so markers can
+  // span this episode's observed ranges; the capability caches the scan.
+  useEffect(() => {
+    if (!schemaFacts) return undefined;
+    const controller = new AbortController();
+    readEpisodeProfile(controller.signal).then(
+      (result) => {
+        if (!controller.signal.aborted) setEpisodeProfile(result);
+      },
+      () => undefined,
+    );
+    return () => controller.abort();
+  }, [readEpisodeProfile, schemaFacts]);
   const row = rowState?.row ?? null;
   const valueMode = useAtomValue(stateActionValueModeAtom);
+  const markerScope = useAtomValue(stateActionMarkerScopeAtom);
 
   const [previousRow, setPreviousRow] = useState<{
     readonly forCursor: string;
@@ -438,9 +459,11 @@ const StateActionTile: React.FC<EpisodeTileProps> = () => {
                 <FeaturePane
                   featureError={row?.featureErrors?.state}
                   label={STATE_PANE_LABEL}
+                  markerScope={markerScope}
                   mode={valueMode}
                   onPlotField={addFieldToPlot}
                   previousValues={previousForRow?.state}
+                  profile={episodeProfile?.state}
                   schema={schemaFacts.state}
                   stats={dimensionStats?.state}
                   values={row?.state}
@@ -450,9 +473,11 @@ const StateActionTile: React.FC<EpisodeTileProps> = () => {
                 <FeaturePane
                   featureError={row?.featureErrors?.action}
                   label={ACTION_PANE_LABEL}
+                  markerScope={markerScope}
                   mode={valueMode}
                   onPlotField={addFieldToPlot}
                   previousValues={previousForRow?.action}
+                  profile={episodeProfile?.action}
                   schema={schemaFacts.action}
                   stats={dimensionStats?.action}
                   values={row?.action}
@@ -472,18 +497,22 @@ const StateActionTile: React.FC<EpisodeTileProps> = () => {
 function FeaturePane({
   featureError,
   label,
+  markerScope,
   mode,
   onPlotField,
   previousValues,
+  profile,
   schema,
   stats,
   values,
 }: {
   readonly featureError?: string;
   readonly label: string;
+  readonly markerScope: StateActionMarkerScope;
   readonly mode: StateActionValueMode;
   readonly onPlotField?: (stream: string, fieldPath: string) => void;
   readonly previousValues?: readonly unknown[];
+  readonly profile?: StateActionFeatureProfile;
   readonly schema: StateActionFeatureSchema;
   readonly stats?: StateActionFeatureStats;
   readonly values?: readonly unknown[];
@@ -491,8 +520,17 @@ function FeaturePane({
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const [viewport, setViewport] = useState({ height: 0, scrollTop: 0 });
   const rows = useMemo(
-    () => paneRows(schema, values, stats, mode, previousValues),
-    [mode, previousValues, schema, stats, values],
+    () =>
+      paneRows(
+        schema,
+        values,
+        stats,
+        mode,
+        previousValues,
+        markerScope,
+        profile,
+      ),
+    [markerScope, mode, previousValues, profile, schema, stats, values],
   );
   const virtualize = rows.length > VIRTUALIZE_AFTER_ROWS;
 
@@ -555,7 +593,9 @@ function FeaturePane({
           <div className={styles.columnHeaders} role="row">
             <span role="columnheader">Dimension</span>
             <span role="columnheader">
-              <span className={styles.srOnly}>Declared range</span>
+              <span className={styles.srOnly}>
+                {markerScope === "dataset" ? "Declared range" : "Episode range"}
+              </span>
             </span>
             <span role="columnheader" style={{ textAlign: "right" }}>
               {stateActionValueHeader(mode)}
@@ -671,6 +711,8 @@ function paneRows(
   stats: StateActionFeatureStats | undefined,
   mode: StateActionValueMode,
   previousValues: readonly unknown[] | undefined,
+  markerScope: StateActionMarkerScope,
+  profile: StateActionFeatureProfile | undefined,
 ): readonly PaneRow[] {
   // Never shift or hide values on a shape mismatch: render every declared
   // dimension and every extra source value under its stable numeric index.
@@ -695,7 +737,7 @@ function paneRows(
           : normalized !== null
             ? { ...rawFormatted, text: compactStateActionFloat(normalized) }
             : rawFormatted;
-    const marker = valueMarker(stats, index, raw);
+    const marker = valueMarker(markerScope, stats, profile, index, raw);
     const delta = paneRowDelta(
       raw,
       previousValues?.[index],
@@ -764,21 +806,26 @@ function paneRowDelta(
 }
 
 /**
- * Positions one exact value on its dimension's declared dataset range so
- * the row carries a faint in-context marker. Only source-declared facts
- * feed the geometry; a value outside the declared range clamps to the
- * edge and tints the tick instead of stretching the scale.
+ * Positions one exact value on its dimension's marker range — this
+ * episode's observed min–max, or the dataset-declared range — so the row
+ * carries a faint in-context marker. In dataset scope a value outside the
+ * declared range clamps to the edge and tints the tick instead of
+ * stretching the scale.
  */
 function valueMarker(
+  scope: StateActionMarkerScope,
   stats: StateActionFeatureStats | undefined,
+  profile: StateActionFeatureProfile | undefined,
   index: number,
   value: unknown,
 ): ValueMarkerFacts | undefined {
-  if (!stats || typeof value !== "number" || !Number.isFinite(value)) {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
     return undefined;
   }
-  const min = stats.min?.[index];
-  const max = stats.max?.[index];
+  const min =
+    scope === "episode" ? profile?.min[index]?.value : stats?.min?.[index];
+  const max =
+    scope === "episode" ? profile?.max[index]?.value : stats?.max?.[index];
   if (
     min === undefined ||
     max === undefined ||
@@ -790,8 +837,17 @@ function valueMarker(
   }
   const position = (candidate: number) =>
     Math.min(1, Math.max(0, (candidate - min) / (max - min)));
-  const q01 = stats.q01?.[index];
-  const q99 = stats.q99?.[index];
+  if (scope === "episode") {
+    // An episode value can never leave its own observed range, and the
+    // profile carries no quantiles — the track and tick say everything.
+    return {
+      outOfRange: false,
+      position: position(value),
+      title: `episode ${formatStateActionValue(min).text} … ${formatStateActionValue(max).text}`,
+    };
+  }
+  const q01 = stats?.q01?.[index];
+  const q99 = stats?.q99?.[index];
   return {
     ...(q01 !== undefined && q99 !== undefined
       ? { band: [position(q01), position(q99)] as const }
@@ -802,7 +858,7 @@ function valueMarker(
   };
 }
 
-/** Faint declared-range strip with a tick at the current value. */
+/** Faint range strip with a tick at the current value. */
 function ValueMarker({ marker }: { readonly marker?: ValueMarkerFacts }) {
   if (!marker) return null;
   return (

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionTile.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionTile.tsx
@@ -8,7 +8,7 @@ import {
   usePlayback,
 } from "@fiftyone/playback/runtime";
 import { useSetTileTitle, useTileId } from "@fiftyone/tiling";
-import { Icon, IconName, Size } from "@voxel51/voodo";
+import { Icon, IconName, Input, InputType, Size } from "@voxel51/voodo";
 import { useAtomValue } from "jotai";
 import React, {
   useCallback,
@@ -93,6 +93,8 @@ const StateActionTile: React.FC<EpisodeTileProps> = () => {
   const [stepPending, setStepPending] = useState(false);
   const stepPendingRef = useRef(false);
   const [cursorCopied, setCursorCopied] = useState(false);
+  const [dimensionFilter, setDimensionFilter] = useState("");
+  const normalizedDimensionFilter = dimensionFilter.trim().toLowerCase();
 
   // Settings render through the sidebar's tile-settings registry, not here.
   const settingsRegistration = useMemo(
@@ -449,6 +451,22 @@ const StateActionTile: React.FC<EpisodeTileProps> = () => {
               {missingFeatureNote}
             </div>
           ) : null}
+          {!showEmpty && (schemaFacts.state || schemaFacts.action) ? (
+            <div className={styles.filterBar}>
+              <Input
+                aria-label="Filter dimensions"
+                className={styles.filterInput}
+                icon={IconName.Search}
+                onChange={(event) => setDimensionFilter(event.target.value)}
+                onKeyDown={(event) => event.stopPropagation()}
+                onPointerDown={(event) => event.stopPropagation()}
+                placeholder="Filter dimensions"
+                size={Size.Sm}
+                type={InputType.Search}
+                value={dimensionFilter}
+              />
+            </div>
+          ) : null}
           {showEmpty ? (
             <div className={styles.notice} data-cy="episode-state-action-empty">
               No state/action row at this time
@@ -457,6 +475,7 @@ const StateActionTile: React.FC<EpisodeTileProps> = () => {
             <div className={styles.panes}>
               {schemaFacts.state ? (
                 <FeaturePane
+                  dimensionFilter={normalizedDimensionFilter}
                   featureError={row?.featureErrors?.state}
                   label={STATE_PANE_LABEL}
                   markerScope={markerScope}
@@ -471,6 +490,7 @@ const StateActionTile: React.FC<EpisodeTileProps> = () => {
               ) : null}
               {schemaFacts.action ? (
                 <FeaturePane
+                  dimensionFilter={normalizedDimensionFilter}
                   featureError={row?.featureErrors?.action}
                   label={ACTION_PANE_LABEL}
                   markerScope={markerScope}
@@ -495,6 +515,7 @@ const StateActionTile: React.FC<EpisodeTileProps> = () => {
 };
 
 function FeaturePane({
+  dimensionFilter,
   featureError,
   label,
   markerScope,
@@ -506,6 +527,7 @@ function FeaturePane({
   stats,
   values,
 }: {
+  readonly dimensionFilter: string;
   readonly featureError?: string;
   readonly label: string;
   readonly markerScope: StateActionMarkerScope;
@@ -519,7 +541,7 @@ function FeaturePane({
 }) {
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const [viewport, setViewport] = useState({ height: 0, scrollTop: 0 });
-  const rows = useMemo(
+  const allRows = useMemo(
     () =>
       paneRows(
         schema,
@@ -532,7 +554,25 @@ function FeaturePane({
       ),
     [markerScope, mode, previousValues, profile, schema, stats, values],
   );
+  const rows = useMemo(
+    () =>
+      dimensionFilter.length === 0
+        ? allRows
+        : allRows.filter((row) =>
+            row.name.toLowerCase().includes(dimensionFilter),
+          ),
+    [allRows, dimensionFilter],
+  );
   const virtualize = rows.length > VIRTUALIZE_AFTER_ROWS;
+
+  // A new query starts at the first match instead of preserving a stale
+  // scroll offset that can leave a shorter filtered result out of view.
+  useLayoutEffect(() => {
+    const scroll = scrollRef.current;
+    if (!scroll || scroll.scrollTop === 0) return;
+    scroll.scrollTop = 0;
+    setViewport((current) => ({ ...current, scrollTop: 0 }));
+  }, [dimensionFilter]);
 
   // This effect tracks the fixed-row viewport for large vectors so long
   // action/state vectors stay usable through row virtualization.
@@ -625,9 +665,9 @@ function FeaturePane({
                   : undefined
               }
             >
-              {visible.map((paneRow) => (
+              {visible.map((paneRow, visibleIndex) => (
                 <div
-                  aria-rowindex={paneRow.index + 1}
+                  aria-rowindex={range.startIndex + visibleIndex + 1}
                   className={styles.dimRow}
                   key={paneRow.index}
                   role="row"
@@ -678,6 +718,11 @@ function FeaturePane({
             </div>
           </div>
         </div>
+        {dimensionFilter.length > 0 && rows.length === 0 ? (
+          <div className={styles.noMatches} role="status">
+            No matching dimensions
+          </div>
+        ) : null}
       </div>
     </section>
   );

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionTile.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionTile.tsx
@@ -1,4 +1,8 @@
 import {
+  getIsPlaying,
+  getIsPlayPending,
+  getPlayhead,
+  PlaybackStoreContext,
   useIsPlaying,
   useIsPlayPending,
   usePlayback,
@@ -7,6 +11,7 @@ import { useSetTileTitle, useTileId } from "@fiftyone/tiling";
 import { Icon, IconName, Size } from "@voxel51/voodo";
 import React, {
   useCallback,
+  useContext,
   useEffect,
   useLayoutEffect,
   useMemo,
@@ -20,6 +25,7 @@ import { virtualLogRowRange } from "../../../visualization/logs/log-console-virt
 import { useDataStream } from "../playback/data-stream-context";
 import { useRegisterTileSettings } from "../tiles/tile-settings-context";
 import type { EpisodeTileProps } from "../tiles/tile-types";
+import tileStyles from "../tiles/Tile.module.css";
 import { useStateActionContext } from "./state-action-context";
 import StateActionTileSettings from "./StateActionTileSettings";
 import styles from "./StateActionTile.module.css";
@@ -54,6 +60,9 @@ const StateActionTile: React.FC<EpisodeTileProps> = () => {
     subscribeRow,
   } = useStateActionContext();
   const dataStream = useDataStream();
+  // Nullable on purpose: standalone tests render the tile without a
+  // playback provider; inside the shell the store is always present.
+  const playbackStore = useContext(PlaybackStoreContext);
   const [stepError, setStepError] = useState<string | null>(null);
   const [stepPending, setStepPending] = useState(false);
   const stepPendingRef = useRef(false);
@@ -96,6 +105,12 @@ const StateActionTile: React.FC<EpisodeTileProps> = () => {
       stepPendingRef.current = true;
       setStepPending(true);
       setStepError(null);
+      const playheadAtClick = playbackStore ? getPlayhead(playbackStore) : null;
+      const superseded = () =>
+        playbackStore !== null &&
+        (getPlayhead(playbackStore) !== playheadAtClick ||
+          getIsPlaying(playbackStore) ||
+          getIsPlayPending(playbackStore));
       try {
         const window = await readRowIndexWindow({
           after: direction === 1 ? 1 : 0,
@@ -114,6 +129,9 @@ const StateActionTile: React.FC<EpisodeTileProps> = () => {
         if (nextRow.cursor !== target.cursor) {
           throw new Error("Exact row read returned a different cursor");
         }
+        // A newer user gesture wins: a seek or play issued while the exact
+        // reads were in flight must not be yanked back to this step target.
+        if (superseded()) return;
         // Render the cursor row, then land cameras on the same frame with an
         // ordinary paused seek. The synchronous hold after seek() precedes the
         // seek's microtask fill, so the echo cannot re-resolve through time.
@@ -132,6 +150,7 @@ const StateActionTile: React.FC<EpisodeTileProps> = () => {
       dataStream,
       holdCursorRow,
       pause,
+      playbackStore,
       readRowAtCursor,
       readRowIndexWindow,
       row,
@@ -180,6 +199,13 @@ const StateActionTile: React.FC<EpisodeTileProps> = () => {
   const hasCommittedRow = rowState?.row !== undefined;
   const showEmpty = status === "ready" && row === null;
   const showBlockingError = status === "error" && !hasCommittedRow;
+  const missingFeatureNote = schemaFacts
+    ? !schemaFacts.state
+      ? "No observation.state feature declared"
+      : !schemaFacts.action
+        ? "No action feature declared"
+        : null
+    : null;
 
   return (
     <div
@@ -247,7 +273,7 @@ const StateActionTile: React.FC<EpisodeTileProps> = () => {
           </button>
           <button
             aria-label={
-              row
+              row && row.frameIndex > 0
                 ? `Previous row (frame ${row.frameIndex - 1})`
                 : "Previous row"
             }
@@ -263,7 +289,9 @@ const StateActionTile: React.FC<EpisodeTileProps> = () => {
           </button>
           <button
             aria-label={
-              row ? `Next row (frame ${row.frameIndex + 1})` : "Next row"
+              row && row.frameIndex < rowCount - 1
+                ? `Next row (frame ${row.frameIndex + 1})`
+                : "Next row"
             }
             className={styles.actionButton}
             data-cy="episode-state-action-next"
@@ -292,26 +320,60 @@ const StateActionTile: React.FC<EpisodeTileProps> = () => {
             Retry
           </button>
         </div>
-      ) : showEmpty ? (
-        <div className={styles.notice} data-cy="episode-state-action-empty">
-          No state/action row at this time
-        </div>
       ) : (
-        <div className={styles.panes}>
-          <FeaturePane
-            featureError={row?.featureErrors?.state}
-            label={STATE_PANE_LABEL}
-            missingName="observation.state"
-            schema={schemaFacts.state}
-            values={row?.state}
-          />
-          <FeaturePane
-            featureError={row?.featureErrors?.action}
-            label={ACTION_PANE_LABEL}
-            missingName="action"
-            schema={schemaFacts.action}
-            values={row?.action}
-          />
+        <div className={styles.content}>
+          {hasCommittedRow && status === "loading" ? (
+            <div
+              className={`${tileStyles.statusBadge} ${styles.staleNotice}`}
+              data-testid="episode-state-action-stale"
+              role="status"
+              title="Resolving the row at the playhead; showing the previous result"
+            >
+              Loading… Previous shown.
+            </div>
+          ) : hasCommittedRow && status === "error" ? (
+            <div
+              className={`${tileStyles.statusBadge} ${tileStyles.statusBadgeError} ${styles.staleNotice}`}
+              data-testid="episode-state-action-stale"
+              role="status"
+              title={
+                rowState?.error
+                  ? `Refresh failed: ${rowState.error}`
+                  : "Refresh failed"
+              }
+            >
+              Refresh failed. Previous shown.
+            </div>
+          ) : null}
+          {missingFeatureNote ? (
+            <div className={styles.missingNote} role="note">
+              {missingFeatureNote}
+            </div>
+          ) : null}
+          {showEmpty ? (
+            <div className={styles.notice} data-cy="episode-state-action-empty">
+              No state/action row at this time
+            </div>
+          ) : (
+            <div className={styles.panes}>
+              {schemaFacts.state ? (
+                <FeaturePane
+                  featureError={row?.featureErrors?.state}
+                  label={STATE_PANE_LABEL}
+                  schema={schemaFacts.state}
+                  values={row?.state}
+                />
+              ) : null}
+              {schemaFacts.action ? (
+                <FeaturePane
+                  featureError={row?.featureErrors?.action}
+                  label={ACTION_PANE_LABEL}
+                  schema={schemaFacts.action}
+                  values={row?.action}
+                />
+              ) : null}
+            </div>
+          )}
         </div>
       )}
       <span aria-live="polite" className={styles.srOnly}>
@@ -324,14 +386,12 @@ const StateActionTile: React.FC<EpisodeTileProps> = () => {
 function FeaturePane({
   featureError,
   label,
-  missingName,
   schema,
   values,
 }: {
   readonly featureError?: string;
   readonly label: string;
-  readonly missingName: string;
-  readonly schema?: StateActionFeatureSchema;
+  readonly schema: StateActionFeatureSchema;
   readonly values?: readonly unknown[];
 }) {
   const scrollRef = useRef<HTMLDivElement | null>(null);
@@ -352,17 +412,6 @@ function FeaturePane({
     observer.observe(scroll);
     return () => observer.disconnect();
   }, [virtualize]);
-
-  if (!schema) {
-    return (
-      <section aria-label={label} className={styles.pane}>
-        <div className={styles.paneHeading}>{label}</div>
-        <div className={styles.paneMissing}>
-          {`No ${missingName} feature declared`}
-        </div>
-      </section>
-    );
-  }
 
   const range = virtualize
     ? virtualLogRowRange({
@@ -470,10 +519,9 @@ type PaneValue =
     };
 
 function paneRows(
-  schema: StateActionFeatureSchema | undefined,
+  schema: StateActionFeatureSchema,
   values: readonly unknown[] | undefined,
 ): readonly PaneRow[] {
-  if (!schema) return [];
   // Never shift or hide values on a shape mismatch: render every declared
   // dimension and every extra source value under its stable numeric index.
   const count = Math.max(schema.dimensions.length, values?.length ?? 0);

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionTile.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionTile.tsx
@@ -3,7 +3,7 @@ import {
   useIsPlayPending,
   usePlayback,
 } from "@fiftyone/playback/runtime";
-import { useSetTileTitle } from "@fiftyone/tiling";
+import { useSetTileTitle, useTileId } from "@fiftyone/tiling";
 import { Icon, IconName, Size } from "@voxel51/voodo";
 import React, {
   useCallback,
@@ -18,8 +18,10 @@ import { errorMessage } from "../../../utils/errors";
 import { relativeTimeParts } from "../../../utils/relative-time";
 import { virtualLogRowRange } from "../../../visualization/logs/log-console-virtualization";
 import { useDataStream } from "../playback/data-stream-context";
+import { useRegisterTileSettings } from "../tiles/tile-settings-context";
 import type { EpisodeTileProps } from "../tiles/tile-types";
 import { useStateActionContext } from "./state-action-context";
+import StateActionTileSettings from "./StateActionTileSettings";
 import styles from "./StateActionTile.module.css";
 
 const ROW_HEIGHT_PX = 22;
@@ -36,11 +38,13 @@ const ACTION_PANE_LABEL = "Action";
  * exact row cursor while seeking cameras to the row's timestamp.
  */
 const StateActionTile: React.FC<EpisodeTileProps> = () => {
+  const tileId = useTileId();
   const setTileTitle = useSetTileTitle();
   const { pause, seek } = usePlayback();
   const isPlaying = useIsPlaying();
   const isPlayPending = useIsPlayPending();
   const {
+    ensureSchema,
     holdCursorRow,
     readRowAtCursor,
     readRowIndexWindow,
@@ -55,9 +59,22 @@ const StateActionTile: React.FC<EpisodeTileProps> = () => {
   const stepPendingRef = useRef(false);
   const [cursorCopied, setCursorCopied] = useState(false);
 
+  // Settings render through the sidebar's tile-settings registry, not here.
+  const settingsRegistration = useMemo(
+    () => ({ content: <StateActionTileSettings /> }),
+    [],
+  );
+  useRegisterTileSettings(tileId, settingsRegistration);
+
   useEffect(() => {
     setTileTitle("State & Action", { source: "auto" });
   }, [setTileTitle]);
+
+  // This passive effect (re)publishes the schema after any shell remount
+  // whose stale cleanup wiped the bridge's layout-phase publication.
+  useEffect(() => {
+    ensureSchema();
+  }, [ensureSchema]);
 
   // This effect declares interest in the canonical row while the tile is
   // mounted; the bridge follows the playhead for interested tiles.

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionTile.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionTile.tsx
@@ -333,7 +333,7 @@ const StateActionTile: React.FC<EpisodeTileProps> = () => {
             </div>
           ) : hasCommittedRow && status === "error" ? (
             <div
-              className={`${tileStyles.statusBadge} ${tileStyles.statusBadgeError} ${styles.staleNotice}`}
+              className={`${tileStyles.statusBadge} ${tileStyles.statusBadgeError} ${styles.staleNotice} ${styles.staleInteractive}`}
               data-testid="episode-state-action-stale"
               role="status"
               title={
@@ -343,6 +343,14 @@ const StateActionTile: React.FC<EpisodeTileProps> = () => {
               }
             >
               Refresh failed. Previous shown.
+              <button
+                className={styles.staleRetryButton}
+                onClick={retryRead}
+                onPointerDown={(event) => event.stopPropagation()}
+                type="button"
+              >
+                Retry
+              </button>
             </div>
           ) : null}
           {missingFeatureNote ? (

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionTile.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionTile.tsx
@@ -103,6 +103,8 @@ const StateActionTile: React.FC<EpisodeTileProps> = () => {
   );
   useRegisterTileSettings(tileId, settingsRegistration);
 
+  // This effect restores the automatic title if a persisted layout carried a
+  // stale generated title from an earlier tile registration.
   useEffect(() => {
     setTileTitle("State & Action", { source: "auto" });
   }, [setTileTitle]);
@@ -699,12 +701,13 @@ function FeaturePane({
                       <button
                         aria-label={`Plot ${paneRow.name}`}
                         className={styles.plotButton}
-                        onClick={() =>
-                          onPlotField(
-                            schema.numericStreamId as string,
-                            paneRow.plotFieldPath as string,
-                          )
-                        }
+                        onClick={() => {
+                          const stream = schema.numericStreamId;
+                          const fieldPath = paneRow.plotFieldPath;
+                          if (stream && fieldPath) {
+                            onPlotField(stream, fieldPath);
+                          }
+                        }}
                         onPointerDown={(event) => event.stopPropagation()}
                         title={`Plot ${paneRow.name} over the episode`}
                         type="button"

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionTile.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionTile.tsx
@@ -9,6 +9,7 @@ import {
 } from "@fiftyone/playback/runtime";
 import { useSetTileTitle, useTileId } from "@fiftyone/tiling";
 import { Icon, IconName, Size } from "@voxel51/voodo";
+import { useAtomValue } from "jotai";
 import React, {
   useCallback,
   useContext,
@@ -21,6 +22,7 @@ import React, {
 import type {
   StateActionFeatureSchema,
   StateActionFeatureStats,
+  StateActionRow,
   StateActionStats,
 } from "../../../ports";
 import { errorMessage } from "../../../utils/errors";
@@ -32,6 +34,14 @@ import type { EpisodeTileProps } from "../tiles/tile-types";
 import tileStyles from "../tiles/Tile.module.css";
 import { useStateActionContext } from "./state-action-context";
 import {
+  formatStateActionDelta,
+  normalizeStateActionValue,
+  stateActionValueHeader,
+  stateActionValueModeAtom,
+  type StateActionValueMode,
+} from "./state-action-display";
+import {
+  compactStateActionFloat,
   formatEpisodeTime,
   formatStateActionValue,
   type FormattedStateActionValue,
@@ -118,6 +128,56 @@ const StateActionTile: React.FC<EpisodeTileProps> = () => {
     return () => controller.abort();
   }, [readDimensionStats, schemaFacts]);
   const row = rowState?.row ?? null;
+  const valueMode = useAtomValue(stateActionValueModeAtom);
+
+  const [previousRow, setPreviousRow] = useState<{
+    readonly forCursor: string;
+    readonly row: StateActionRow | null;
+  } | null>(null);
+  const rowCursor = row?.cursor;
+  const rowFrameIndex = row?.frameIndex;
+  // This effect resolves the row before the committed one so each value can
+  // show its change from the previous frame; both reads hit the cached slab.
+  useEffect(() => {
+    if (rowCursor === undefined || rowFrameIndex === undefined) {
+      setPreviousRow(null);
+      return undefined;
+    }
+    if (rowFrameIndex <= 0) {
+      setPreviousRow({ forCursor: rowCursor, row: null });
+      return undefined;
+    }
+    const controller = new AbortController();
+    (async () => {
+      const window = await readRowIndexWindow(
+        { after: 0, anchorCursor: rowCursor, before: 1 },
+        controller.signal,
+      );
+      const anchorIndex = window.entries.findIndex(
+        (entry) => entry.cursor === window.selectedCursor,
+      );
+      const previous =
+        anchorIndex > 0 ? window.entries[anchorIndex - 1] : undefined;
+      return previous
+        ? readRowAtCursor(previous.cursor, controller.signal)
+        : null;
+    })().then(
+      (resolved) => {
+        if (!controller.signal.aborted) {
+          setPreviousRow({ forCursor: rowCursor, row: resolved });
+        }
+      },
+      () => undefined,
+    );
+    return () => controller.abort();
+  }, [readRowAtCursor, readRowIndexWindow, rowCursor, rowFrameIndex]);
+  const previousForRow =
+    previousRow &&
+    rowCursor !== undefined &&
+    previousRow.forCursor === rowCursor
+      ? previousRow.row
+      : null;
+
   const rowCount = schemaFacts?.rowCount ?? 0;
   const canStepPrevious = Boolean(row && row.frameIndex > 0 && !stepPending);
   const canStepNext = Boolean(
@@ -378,7 +438,9 @@ const StateActionTile: React.FC<EpisodeTileProps> = () => {
                 <FeaturePane
                   featureError={row?.featureErrors?.state}
                   label={STATE_PANE_LABEL}
+                  mode={valueMode}
                   onPlotField={addFieldToPlot}
+                  previousValues={previousForRow?.state}
                   schema={schemaFacts.state}
                   stats={dimensionStats?.state}
                   values={row?.state}
@@ -388,7 +450,9 @@ const StateActionTile: React.FC<EpisodeTileProps> = () => {
                 <FeaturePane
                   featureError={row?.featureErrors?.action}
                   label={ACTION_PANE_LABEL}
+                  mode={valueMode}
                   onPlotField={addFieldToPlot}
+                  previousValues={previousForRow?.action}
                   schema={schemaFacts.action}
                   stats={dimensionStats?.action}
                   values={row?.action}
@@ -408,14 +472,18 @@ const StateActionTile: React.FC<EpisodeTileProps> = () => {
 function FeaturePane({
   featureError,
   label,
+  mode,
   onPlotField,
+  previousValues,
   schema,
   stats,
   values,
 }: {
   readonly featureError?: string;
   readonly label: string;
+  readonly mode: StateActionValueMode;
   readonly onPlotField?: (stream: string, fieldPath: string) => void;
+  readonly previousValues?: readonly unknown[];
   readonly schema: StateActionFeatureSchema;
   readonly stats?: StateActionFeatureStats;
   readonly values?: readonly unknown[];
@@ -423,8 +491,8 @@ function FeaturePane({
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const [viewport, setViewport] = useState({ height: 0, scrollTop: 0 });
   const rows = useMemo(
-    () => paneRows(schema, values, stats),
-    [schema, stats, values],
+    () => paneRows(schema, values, stats, mode, previousValues),
+    [mode, previousValues, schema, stats, values],
   );
   const virtualize = rows.length > VIRTUALIZE_AFTER_ROWS;
 
@@ -490,7 +558,14 @@ function FeaturePane({
               <span className={styles.srOnly}>Declared range</span>
             </span>
             <span role="columnheader" style={{ textAlign: "right" }}>
-              Value
+              {stateActionValueHeader(mode)}
+            </span>
+            <span
+              role="columnheader"
+              style={{ textAlign: "right" }}
+              title="Change from the previous row"
+            >
+              Δ
             </span>
             <span role="columnheader">
               <span className={styles.srOnly}>Plot</span>
@@ -530,6 +605,13 @@ function FeaturePane({
                   <span className={styles.dimValue} role="cell">
                     <ValueCell value={paneRow.value} />
                   </span>
+                  <span
+                    className={styles.dimDelta}
+                    role="cell"
+                    title={paneRow.delta?.exact}
+                  >
+                    {paneRow.delta?.text ?? ""}
+                  </span>
                   <span className={styles.dimAction} role="cell">
                     {onPlotField &&
                     schema.numericStreamId &&
@@ -562,6 +644,7 @@ function FeaturePane({
 }
 
 interface PaneRow {
+  readonly delta?: { readonly exact: string; readonly text: string };
   readonly index: number;
   readonly marker?: ValueMarkerFacts;
   readonly name: string;
@@ -586,6 +669,8 @@ function paneRows(
   schema: StateActionFeatureSchema,
   values: readonly unknown[] | undefined,
   stats: StateActionFeatureStats | undefined,
+  mode: StateActionValueMode,
+  previousValues: readonly unknown[] | undefined,
 ): readonly PaneRow[] {
   // Never shift or hide values on a shape mismatch: render every declared
   // dimension and every extra source value under its stable numeric index.
@@ -595,14 +680,31 @@ function paneRows(
     const name = dimension?.name ?? `[${index}]`;
     const raw =
       values !== undefined && index < values.length ? values[index] : undefined;
+    // A dimension whose declared normalization parameters are unusable
+    // falls back to the raw value instead of inventing a scale.
+    const normalized =
+      mode !== "raw" && typeof raw === "number" && Number.isFinite(raw)
+        ? normalizeStateActionValue(mode, stats, index, raw)
+        : null;
+    const rawFormatted = formatStateActionValue(raw);
     const value: PaneValue =
       values === undefined
         ? { kind: "skeleton" }
         : index >= values.length
           ? { kind: "missing" }
-          : formatStateActionValue(raw);
+          : normalized !== null
+            ? { ...rawFormatted, text: compactStateActionFloat(normalized) }
+            : rawFormatted;
     const marker = valueMarker(stats, index, raw);
+    const delta = paneRowDelta(
+      raw,
+      previousValues?.[index],
+      mode,
+      stats,
+      index,
+    );
     return {
+      ...(delta ? { delta } : {}),
       index,
       ...(marker ? { marker } : {}),
       name,
@@ -612,6 +714,53 @@ function paneRows(
       value,
     };
   });
+}
+
+/**
+ * Change from the previous row, on the same scale the value column shows:
+ * normalized when this dimension normalizes, raw otherwise. Non-numeric
+ * pairs render no delta rather than a fabricated zero.
+ */
+function paneRowDelta(
+  raw: unknown,
+  previousRaw: unknown,
+  mode: StateActionValueMode,
+  stats: StateActionFeatureStats | undefined,
+  index: number,
+): PaneRow["delta"] | undefined {
+  if (
+    typeof raw !== "number" ||
+    !Number.isFinite(raw) ||
+    typeof previousRaw !== "number" ||
+    !Number.isFinite(previousRaw)
+  ) {
+    return undefined;
+  }
+  let current = raw;
+  let previous = previousRaw;
+  if (mode !== "raw") {
+    const currentNormalized = normalizeStateActionValue(
+      mode,
+      stats,
+      index,
+      raw,
+    );
+    const previousNormalized = normalizeStateActionValue(
+      mode,
+      stats,
+      index,
+      previousRaw,
+    );
+    if (currentNormalized !== null && previousNormalized !== null) {
+      current = currentNormalized;
+      previous = previousNormalized;
+    }
+  }
+  const delta = current - previous;
+  return {
+    exact: `Δ ${String(delta)} from the previous row`,
+    text: formatStateActionDelta(delta),
+  };
 }
 
 /**

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionTile.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionTile.tsx
@@ -1,0 +1,576 @@
+import {
+  useIsPlaying,
+  useIsPlayPending,
+  usePlayback,
+} from "@fiftyone/playback/runtime";
+import { useSetTileTitle } from "@fiftyone/tiling";
+import { Icon, IconName, Size } from "@voxel51/voodo";
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import type { StateActionFeatureSchema } from "../../../ports";
+import { errorMessage } from "../../../utils/errors";
+import { relativeTimeParts } from "../../../utils/relative-time";
+import { virtualLogRowRange } from "../../../visualization/logs/log-console-virtualization";
+import { useDataStream } from "../playback/data-stream-context";
+import type { EpisodeTileProps } from "../tiles/tile-types";
+import { useStateActionContext } from "./state-action-context";
+import styles from "./StateActionTile.module.css";
+
+const ROW_HEIGHT_PX = 22;
+const VIRTUALIZE_AFTER_ROWS = 150;
+const VIRTUALIZE_OVERSCAN = 12;
+const STATE_PANE_LABEL = "Observation state";
+const ACTION_PANE_LABEL = "Action";
+
+/**
+ * State & Action tile: exact single-row inspection for VLA practitioners.
+ * At any playhead position it shows `observation.state` and `action` from
+ * one canonical source row — the playhead selects a row but is never the
+ * transport for the displayed values — and previous/next controls step an
+ * exact row cursor while seeking cameras to the row's timestamp.
+ */
+const StateActionTile: React.FC<EpisodeTileProps> = () => {
+  const setTileTitle = useSetTileTitle();
+  const { pause, seek } = usePlayback();
+  const isPlaying = useIsPlaying();
+  const isPlayPending = useIsPlayPending();
+  const {
+    holdCursorRow,
+    readRowAtCursor,
+    readRowIndexWindow,
+    retryRead,
+    rowState,
+    schema,
+    subscribeRow,
+  } = useStateActionContext();
+  const dataStream = useDataStream();
+  const [stepError, setStepError] = useState<string | null>(null);
+  const [stepPending, setStepPending] = useState(false);
+  const stepPendingRef = useRef(false);
+  const [cursorCopied, setCursorCopied] = useState(false);
+
+  useEffect(() => {
+    setTileTitle("State & Action", { source: "auto" });
+  }, [setTileTitle]);
+
+  // This effect declares interest in the canonical row while the tile is
+  // mounted; the bridge follows the playhead for interested tiles.
+  useEffect(() => subscribeRow(), [subscribeRow]);
+
+  const schemaFacts = schema.status === "ready" ? schema.schema : null;
+  const row = rowState?.row ?? null;
+  const rowCount = schemaFacts?.rowCount ?? 0;
+  const canStepPrevious = Boolean(row && row.frameIndex > 0 && !stepPending);
+  const canStepNext = Boolean(
+    row && row.frameIndex < rowCount - 1 && !stepPending,
+  );
+
+  const step = useCallback(
+    async (direction: -1 | 1) => {
+      const anchor = row;
+      const timeline = dataStream?.getTimelineIndex();
+      if (!anchor || !timeline || stepPendingRef.current) return;
+      stepPendingRef.current = true;
+      setStepPending(true);
+      setStepError(null);
+      try {
+        const window = await readRowIndexWindow({
+          after: direction === 1 ? 1 : 0,
+          anchorCursor: anchor.cursor,
+          before: direction === -1 ? 1 : 0,
+        });
+        const anchorIndex = window.entries.findIndex(
+          (entry) => entry.cursor === window.selectedCursor,
+        );
+        const target =
+          anchorIndex >= 0
+            ? window.entries[anchorIndex + direction]
+            : undefined;
+        if (!target) return;
+        const nextRow = await readRowAtCursor(target.cursor);
+        if (nextRow.cursor !== target.cursor) {
+          throw new Error("Exact row read returned a different cursor");
+        }
+        // Render the cursor row, then land cameras on the same frame with an
+        // ordinary paused seek. The synchronous hold after seek() precedes the
+        // seek's microtask fill, so the echo cannot re-resolve through time.
+        const seekSec = timeline.nsToSec(nextRow.timestampNs);
+        pause();
+        seek(seekSec);
+        holdCursorRow(nextRow, timeline.secToNs(seekSec));
+      } catch (error) {
+        setStepError(errorMessage(error));
+      } finally {
+        stepPendingRef.current = false;
+        setStepPending(false);
+      }
+    },
+    [
+      dataStream,
+      holdCursorRow,
+      pause,
+      readRowAtCursor,
+      readRowIndexWindow,
+      row,
+      seek,
+    ],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
+        return;
+      }
+      if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
+      event.preventDefault();
+      event.stopPropagation();
+      void step(event.key === "ArrowLeft" ? -1 : 1);
+    },
+    [step],
+  );
+
+  const copyCursor = useCallback(() => {
+    if (!row) return;
+    void navigator.clipboard?.writeText?.(row.cursor).then(
+      () => setCursorCopied(true),
+      () => undefined,
+    );
+  }, [row]);
+  // This effect clears transient copy feedback when the selected row moves.
+  useEffect(() => {
+    setCursorCopied(false);
+  }, [row?.cursor]);
+
+  const startTimeNs = dataStream?.getTimelineIndex()?.startTimeNs ?? 0n;
+  const playheadDiffers =
+    row !== null &&
+    rowState?.targetNs !== undefined &&
+    !rowState.pinned &&
+    rowState.targetNs !== row.timestampNs;
+  const paused = !isPlaying && !isPlayPending;
+  const announcement =
+    paused && row ? `Frame ${row.frameIndex} of ${rowCount}` : "";
+  const taskLabel = row?.task
+    ? (row.task.label ?? `Task #${row.task.index}`)
+    : null;
+  const status = rowState?.status;
+  const hasCommittedRow = rowState?.row !== undefined;
+  const showEmpty = status === "ready" && row === null;
+  const showBlockingError = status === "error" && !hasCommittedRow;
+
+  return (
+    <div
+      aria-label="State and action table"
+      className={styles.body}
+      data-cy="episode-state-action-tile"
+      onKeyDown={handleKeyDown}
+      role="group"
+      tabIndex={0}
+    >
+      <div className={styles.header}>
+        <span
+          className={styles.headerFrame}
+          data-cy="episode-state-action-frame"
+        >
+          {row ? `Frame ${row.frameIndex} of ${rowCount}` : `— of ${rowCount}`}
+        </span>
+        {row ? (
+          <span title={exactTimeTitle(row.timestampNs, startTimeNs)}>
+            {formatEpisodeTime(row.timestampNs, startTimeNs)}
+          </span>
+        ) : null}
+        {playheadDiffers && rowState?.targetNs !== undefined ? (
+          <span title="Playhead time; the row holds until the next recorded row">
+            {`playhead ${formatEpisodeTime(rowState.targetNs, startTimeNs)}`}
+          </span>
+        ) : null}
+        {taskLabel ? (
+          <span
+            className={styles.headerBadge}
+            title="Task supervising this row"
+          >
+            {taskLabel}
+          </span>
+        ) : null}
+        <span
+          className={styles.headerBadge}
+          title="Every value comes from the identified source row"
+        >
+          Exact row
+        </span>
+        {stepError ? (
+          <span className={styles.headerError} role="status">
+            {stepError}
+          </span>
+        ) : null}
+        <div className={styles.headerActions}>
+          <button
+            aria-label={cursorCopied ? "Row cursor copied" : "Copy row cursor"}
+            className={styles.actionButton}
+            disabled={!row}
+            onClick={copyCursor}
+            onPointerDown={(event) => event.stopPropagation()}
+            title={
+              cursorCopied
+                ? "Row cursor copied"
+                : "Copy the opaque row cursor for reconciliation"
+            }
+            type="button"
+          >
+            <Icon
+              name={cursorCopied ? IconName.Check : IconName.ContentCopy}
+              size={Size.Xs}
+            />
+          </button>
+          <button
+            aria-label={
+              row
+                ? `Previous row (frame ${row.frameIndex - 1})`
+                : "Previous row"
+            }
+            className={styles.actionButton}
+            data-cy="episode-state-action-previous"
+            disabled={!canStepPrevious}
+            onClick={() => void step(-1)}
+            onPointerDown={(event) => event.stopPropagation()}
+            title="Previous row"
+            type="button"
+          >
+            <Icon name={IconName.ChevronLeft} size={Size.Xs} />
+          </button>
+          <button
+            aria-label={
+              row ? `Next row (frame ${row.frameIndex + 1})` : "Next row"
+            }
+            className={styles.actionButton}
+            data-cy="episode-state-action-next"
+            disabled={!canStepNext}
+            onClick={() => void step(1)}
+            onPointerDown={(event) => event.stopPropagation()}
+            title="Next row"
+            type="button"
+          >
+            <Icon name={IconName.ChevronRight} size={Size.Xs} />
+          </button>
+        </div>
+      </div>
+      {!schemaFacts ? (
+        <div className={styles.notice}>Preparing state/action schema…</div>
+      ) : showBlockingError ? (
+        <div className={`${styles.notice} ${styles.noticeError}`} role="alert">
+          <span>
+            {`Could not read the state/action row: ${rowState?.error ?? "unknown error"}`}
+          </span>
+          <button
+            className={styles.retryButton}
+            onClick={retryRead}
+            type="button"
+          >
+            Retry
+          </button>
+        </div>
+      ) : showEmpty ? (
+        <div className={styles.notice} data-cy="episode-state-action-empty">
+          No state/action row at this time
+        </div>
+      ) : (
+        <div className={styles.panes}>
+          <FeaturePane
+            featureError={row?.featureErrors?.state}
+            label={STATE_PANE_LABEL}
+            missingName="observation.state"
+            schema={schemaFacts.state}
+            values={row?.state}
+          />
+          <FeaturePane
+            featureError={row?.featureErrors?.action}
+            label={ACTION_PANE_LABEL}
+            missingName="action"
+            schema={schemaFacts.action}
+            values={row?.action}
+          />
+        </div>
+      )}
+      <span aria-live="polite" className={styles.srOnly}>
+        {announcement}
+      </span>
+    </div>
+  );
+};
+
+function FeaturePane({
+  featureError,
+  label,
+  missingName,
+  schema,
+  values,
+}: {
+  readonly featureError?: string;
+  readonly label: string;
+  readonly missingName: string;
+  readonly schema?: StateActionFeatureSchema;
+  readonly values?: readonly unknown[];
+}) {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const [viewport, setViewport] = useState({ height: 0, scrollTop: 0 });
+  const rows = useMemo(() => paneRows(schema, values), [schema, values]);
+  const virtualize = rows.length > VIRTUALIZE_AFTER_ROWS;
+
+  // This effect tracks the fixed-row viewport for large vectors so long
+  // action/state vectors stay usable through row virtualization.
+  useLayoutEffect(() => {
+    const scroll = scrollRef.current;
+    if (!scroll || !virtualize) return undefined;
+    const publish = () =>
+      setViewport({ height: scroll.clientHeight, scrollTop: scroll.scrollTop });
+    publish();
+    if (typeof ResizeObserver === "undefined") return undefined;
+    const observer = new ResizeObserver(publish);
+    observer.observe(scroll);
+    return () => observer.disconnect();
+  }, [virtualize]);
+
+  if (!schema) {
+    return (
+      <section aria-label={label} className={styles.pane}>
+        <div className={styles.paneHeading}>{label}</div>
+        <div className={styles.paneMissing}>
+          {`No ${missingName} feature declared`}
+        </div>
+      </section>
+    );
+  }
+
+  const range = virtualize
+    ? virtualLogRowRange({
+        overscan: VIRTUALIZE_OVERSCAN,
+        rowCount: rows.length,
+        rowHeightPx: ROW_HEIGHT_PX,
+        scrollTop: viewport.scrollTop,
+        viewportHeight: viewport.height,
+      })
+    : { endIndex: rows.length, offsetPx: 0, startIndex: 0 };
+  const visible = rows.slice(range.startIndex, range.endIndex);
+
+  return (
+    <section aria-label={label} className={styles.pane}>
+      <div className={styles.paneHeading}>
+        <span>{label}</span>
+        <span className={styles.paneSchema} title="Declared dtype and shape">
+          {`${schema.dtype} [${schema.shape.join(",")}]`}
+        </span>
+      </div>
+      {featureError ? (
+        <div className={styles.paneError} role="alert">
+          {featureError}
+        </div>
+      ) : null}
+      <div
+        className={styles.paneScroll}
+        onScroll={
+          virtualize
+            ? (event) =>
+                setViewport({
+                  height: event.currentTarget.clientHeight,
+                  scrollTop: event.currentTarget.scrollTop,
+                })
+            : undefined
+        }
+        ref={scrollRef}
+      >
+        <div
+          aria-label={`${label} values`}
+          aria-rowcount={rows.length}
+          role="table"
+        >
+          <div className={styles.columnHeaders} role="row">
+            <span role="columnheader">Dimension</span>
+            <span role="columnheader" style={{ textAlign: "right" }}>
+              Value
+            </span>
+          </div>
+          <div
+            className={styles.rowSpacer}
+            role="rowgroup"
+            style={
+              virtualize ? { height: rows.length * ROW_HEIGHT_PX } : undefined
+            }
+          >
+            <div
+              style={
+                virtualize
+                  ? { transform: `translateY(${range.offsetPx}px)` }
+                  : undefined
+              }
+            >
+              {visible.map((paneRow) => (
+                <div
+                  aria-rowindex={paneRow.index + 1}
+                  className={styles.dimRow}
+                  key={paneRow.index}
+                  role="row"
+                >
+                  <span
+                    className={styles.dimName}
+                    role="rowheader"
+                    title={paneRow.name}
+                  >
+                    {paneRow.name}
+                  </span>
+                  <span className={styles.dimValue} role="cell">
+                    <ValueCell value={paneRow.value} />
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+interface PaneRow {
+  readonly index: number;
+  readonly name: string;
+  readonly value: PaneValue;
+}
+
+type PaneValue =
+  | { readonly kind: "skeleton" }
+  | { readonly kind: "missing" }
+  | {
+      readonly exact: string;
+      readonly invalid: boolean;
+      readonly kind: "value";
+      readonly text: string;
+    };
+
+function paneRows(
+  schema: StateActionFeatureSchema | undefined,
+  values: readonly unknown[] | undefined,
+): readonly PaneRow[] {
+  if (!schema) return [];
+  // Never shift or hide values on a shape mismatch: render every declared
+  // dimension and every extra source value under its stable numeric index.
+  const count = Math.max(schema.dimensions.length, values?.length ?? 0);
+  return Array.from({ length: count }, (_, index) => {
+    const name = schema.dimensions[index]?.name ?? `[${index}]`;
+    const value: PaneValue =
+      values === undefined
+        ? { kind: "skeleton" }
+        : index >= values.length
+          ? { kind: "missing" }
+          : formatStateActionValue(values[index]);
+    return { index, name, value };
+  });
+}
+
+function ValueCell({ value }: { readonly value: PaneValue }) {
+  const copy = useCallback((text: string) => {
+    void navigator.clipboard?.writeText?.(text).catch(() => undefined);
+  }, []);
+  if (value.kind === "skeleton") {
+    return <span className={styles.skeletonValue}>…</span>;
+  }
+  if (value.kind === "missing") {
+    return (
+      <span
+        className={styles.invalidValue}
+        title="This dimension is missing from the source row"
+      >
+        missing
+      </span>
+    );
+  }
+  return (
+    <button
+      aria-label={`Copy exact value ${value.exact}`}
+      className={`${styles.valueButton} ${value.invalid ? styles.invalidValue : ""}`}
+      onClick={() => copy(value.exact)}
+      onPointerDown={(event) => event.stopPropagation()}
+      title={`${value.exact} — click to copy the exact value`}
+      type="button"
+    >
+      {value.text}
+    </button>
+  );
+}
+
+/** Compact display value plus the exact parsed value for copy and hover. */
+export function formatStateActionValue(value: unknown): {
+  readonly exact: string;
+  readonly invalid: boolean;
+  readonly kind: "value";
+  readonly text: string;
+} {
+  if (typeof value === "number") {
+    if (Number.isNaN(value)) {
+      return { exact: "NaN", invalid: true, kind: "value", text: "NaN" };
+    }
+    if (!Number.isFinite(value)) {
+      return {
+        exact: String(value),
+        invalid: true,
+        kind: "value",
+        text: value > 0 ? "∞" : "-∞",
+      };
+    }
+    if (Number.isInteger(value)) {
+      return {
+        exact: String(value),
+        invalid: false,
+        kind: "value",
+        text: String(value),
+      };
+    }
+    return {
+      exact: String(value),
+      invalid: false,
+      kind: "value",
+      text: compactFloat(value),
+    };
+  }
+  if (typeof value === "bigint" || typeof value === "boolean") {
+    const text = value.toString();
+    return { exact: text, invalid: false, kind: "value", text };
+  }
+  if (value === null || value === undefined) {
+    return { exact: "null", invalid: true, kind: "value", text: "null" };
+  }
+  const text = String(value);
+  return { exact: text, invalid: true, kind: "value", text };
+}
+
+function compactFloat(value: number): string {
+  const magnitude = Math.abs(value);
+  if (magnitude !== 0 && (magnitude >= 1e6 || magnitude < 1e-4)) {
+    return value.toExponential(4);
+  }
+  return String(Number(value.toPrecision(6)));
+}
+
+/** Formats an episode-local time for the header, exact to the millisecond. */
+export function formatEpisodeTime(timeNs: bigint, originNs: bigint): string {
+  const { milliseconds, negative, seconds } = relativeTimeParts(
+    timeNs - originNs,
+  );
+  return `t=${negative ? "-" : "+"}${seconds}.${milliseconds}s`;
+}
+
+function exactTimeTitle(timeNs: bigint, originNs: bigint): string {
+  const deltaNs = timeNs - originNs;
+  const negative = deltaNs < 0n;
+  const magnitude = negative ? -deltaNs : deltaNs;
+  const seconds = magnitude / 1_000_000_000n;
+  const nanoseconds = (magnitude % 1_000_000_000n).toString().padStart(9, "0");
+  return `Row time t=${negative ? "-" : "+"}${seconds}.${nanoseconds}s`;
+}
+
+export default StateActionTile;

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionTileSettings.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionTileSettings.tsx
@@ -40,7 +40,9 @@ const StateActionTileSettings: React.FC = () => {
       (result) => {
         if (!controller.signal.aborted) setStats(result);
       },
-      () => undefined,
+      () => {
+        if (!controller.signal.aborted) setStats(null);
+      },
     );
     return () => controller.abort();
   }, [readDimensionStats]);

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionTileSettings.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionTileSettings.tsx
@@ -1,0 +1,73 @@
+import React, { useEffect } from "react";
+import type { StateActionFeatureSchema } from "../../../ports";
+import settingsStyles from "../tiles/Tile.settings.module.css";
+import { useStateActionContext } from "./state-action-context";
+
+/**
+ * Settings sidebar for the State & Action tile. The tile has no
+ * configuration — the two canonical features are fixed — so this panel
+ * states the declared schema facts practitioners reconcile against:
+ * feature dtypes, shapes, dimension counts, and the episode row count.
+ */
+const StateActionTileSettings: React.FC = () => {
+  const { ensureSchema, schema } = useStateActionContext();
+
+  // This effect republishes the session schema in case a shell remount
+  // wiped the bridge's initial publication before this panel opened.
+  useEffect(() => {
+    ensureSchema();
+  }, [ensureSchema]);
+
+  const facts = schema.status === "ready" ? schema.schema : null;
+  if (!facts) {
+    return (
+      <div className={settingsStyles.root}>
+        <span className={settingsStyles.emptyText}>
+          Reading the state/action schema…
+        </span>
+      </div>
+    );
+  }
+  return (
+    <div
+      className={settingsStyles.root}
+      data-cy="episode-state-action-settings"
+    >
+      <span className={settingsStyles.metaText}>
+        {`Exact per-row values from ${facts.rowCount.toLocaleString()} episode rows. The playhead selects a row; every displayed value comes from that one source row.`}
+      </span>
+      <FeatureFacts feature={facts.state} missingName="observation.state" />
+      <FeatureFacts feature={facts.action} missingName="action" />
+    </div>
+  );
+};
+
+function FeatureFacts({
+  feature,
+  missingName,
+}: {
+  readonly feature?: StateActionFeatureSchema;
+  readonly missingName: string;
+}) {
+  if (!feature) {
+    return (
+      <span className={settingsStyles.emptyText}>
+        {`No ${missingName} feature declared`}
+      </span>
+    );
+  }
+  const named = feature.dimensions.filter(
+    (dimension) => dimension.name !== undefined,
+  ).length;
+  return (
+    <div className={settingsStyles.field}>
+      <span className={settingsStyles.metaText}>
+        {`${feature.featureName} — ${feature.dtype} [${feature.shape.join(",")}], ${feature.dimensions.length} dimensions${
+          named ? ` (${named} named)` : ""
+        }`}
+      </span>
+    </div>
+  );
+}
+
+export default StateActionTileSettings;

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionTileSettings.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionTileSettings.tsx
@@ -1,22 +1,51 @@
-import React, { useEffect } from "react";
-import type { StateActionFeatureSchema } from "../../../ports";
+import { useAtom } from "jotai";
+import React, { useEffect, useState } from "react";
+import type {
+  StateActionFeatureSchema,
+  StateActionStats,
+} from "../../../ports";
+import { SettingsLabel } from "../settings/controls/SettingsLabel";
+import { SettingsSelect } from "../settings/controls/SettingsSelect";
 import settingsStyles from "../tiles/Tile.settings.module.css";
 import { useStateActionContext } from "./state-action-context";
+import {
+  STATE_ACTION_VALUE_MODES,
+  stateActionValueModeAtom,
+  type StateActionValueMode,
+} from "./state-action-display";
+
+const VALUE_SCALE_TOOLTIP =
+  "How the tile displays numeric values. Z-score shows (v − mean) / std and Quantile maps q01–q99 onto [−1, 1], both from the dataset-declared statistics — the scales normalization-trained policies actually see. Copy always yields the raw exact value.";
 
 /**
- * Settings sidebar for the State & Action tile. The tile has no
- * configuration — the two canonical features are fixed — so this panel
- * states the declared schema facts practitioners reconcile against:
- * feature dtypes, shapes, dimension counts, and the episode row count.
+ * Settings sidebar for the State & Action tile: the value display scale
+ * plus the declared schema facts practitioners reconcile against.
  */
 const StateActionTileSettings: React.FC = () => {
-  const { ensureSchema, schema } = useStateActionContext();
+  const { ensureSchema, readDimensionStats, schema } = useStateActionContext();
+  const [valueMode, setValueMode] = useAtom(stateActionValueModeAtom);
+  const [stats, setStats] = useState<StateActionStats | null | "loading">(
+    "loading",
+  );
 
   // This effect republishes the session schema in case a shell remount
   // wiped the bridge's initial publication before this panel opened.
   useEffect(() => {
     ensureSchema();
   }, [ensureSchema]);
+
+  // This effect resolves whether declared statistics exist so the panel
+  // can say when a normalized scale has nothing to normalize with.
+  useEffect(() => {
+    const controller = new AbortController();
+    readDimensionStats(controller.signal).then(
+      (result) => {
+        if (!controller.signal.aborted) setStats(result);
+      },
+      () => undefined,
+    );
+    return () => controller.abort();
+  }, [readDimensionStats]);
 
   const facts = schema.status === "ready" ? schema.schema : null;
   if (!facts) {
@@ -33,6 +62,21 @@ const StateActionTileSettings: React.FC = () => {
       className={settingsStyles.root}
       data-cy="episode-state-action-settings"
     >
+      <label className={settingsStyles.field}>
+        <SettingsLabel label="Value scale" tooltip={VALUE_SCALE_TOOLTIP} />
+        <SettingsSelect
+          ariaLabel="Value scale"
+          onChange={(next) => setValueMode(next as StateActionValueMode)}
+          options={STATE_ACTION_VALUE_MODES}
+          value={valueMode}
+        />
+        {valueMode !== "raw" && stats === null ? (
+          <span className={settingsStyles.emptyText}>
+            This source declares no statistics (meta/stats.json); raw values are
+            shown.
+          </span>
+        ) : null}
+      </label>
       <span className={settingsStyles.metaText}>
         {`Exact per-row values · ${facts.rowCount.toLocaleString()} episode rows. Declared per-dimension statistics live in the Statistics tab.`}
       </span>

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionTileSettings.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionTileSettings.tsx
@@ -34,7 +34,7 @@ const StateActionTileSettings: React.FC = () => {
       data-cy="episode-state-action-settings"
     >
       <span className={settingsStyles.metaText}>
-        {`Exact per-row values from ${facts.rowCount.toLocaleString()} episode rows. The playhead selects a row; every displayed value comes from that one source row.`}
+        {`Exact per-row values · ${facts.rowCount.toLocaleString()} episode rows. Declared per-dimension statistics live in the Statistics tab.`}
       </span>
       <FeatureFacts feature={facts.state} missingName="observation.state" />
       <FeatureFacts feature={facts.action} missingName="action" />

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionTileSettings.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionTileSettings.tsx
@@ -1,9 +1,6 @@
 import { useAtom } from "jotai";
 import React, { useEffect, useState } from "react";
-import type {
-  StateActionFeatureSchema,
-  StateActionStats,
-} from "../../../ports";
+import type { StateActionStats } from "../../../ports";
 import { SettingsLabel } from "../settings/controls/SettingsLabel";
 import { SettingsSelect } from "../settings/controls/SettingsSelect";
 import settingsStyles from "../tiles/Tile.settings.module.css";
@@ -15,24 +12,18 @@ import {
 } from "./state-action-display";
 
 const VALUE_SCALE_TOOLTIP =
-  "How the tile displays numeric values. Z-score shows (v − mean) / std and Quantile maps q01–q99 onto [−1, 1], both from the dataset-declared statistics — the scales normalization-trained policies actually see. Copy always yields the raw exact value.";
+  "Z-score is (v − mean) / std; Quantile maps q01–q99 onto [−1, 1] — both from the dataset-declared statistics. Copy always yields the raw exact value.";
 
 /**
- * Settings sidebar for the State & Action tile: the value display scale
- * plus the declared schema facts practitioners reconcile against.
+ * Settings sidebar for the State & Action tile: the value display scale.
+ * Schema facts and statistics live in the Statistics tab, not here.
  */
 const StateActionTileSettings: React.FC = () => {
-  const { ensureSchema, readDimensionStats, schema } = useStateActionContext();
+  const { readDimensionStats } = useStateActionContext();
   const [valueMode, setValueMode] = useAtom(stateActionValueModeAtom);
   const [stats, setStats] = useState<StateActionStats | null | "loading">(
     "loading",
   );
-
-  // This effect republishes the session schema in case a shell remount
-  // wiped the bridge's initial publication before this panel opened.
-  useEffect(() => {
-    ensureSchema();
-  }, [ensureSchema]);
 
   // This effect resolves whether declared statistics exist so the panel
   // can say when a normalized scale has nothing to normalize with.
@@ -47,16 +38,6 @@ const StateActionTileSettings: React.FC = () => {
     return () => controller.abort();
   }, [readDimensionStats]);
 
-  const facts = schema.status === "ready" ? schema.schema : null;
-  if (!facts) {
-    return (
-      <div className={settingsStyles.root}>
-        <span className={settingsStyles.emptyText}>
-          Reading the state/action schema…
-        </span>
-      </div>
-    );
-  }
   return (
     <div
       className={settingsStyles.root}
@@ -77,41 +58,8 @@ const StateActionTileSettings: React.FC = () => {
           </span>
         ) : null}
       </label>
-      <span className={settingsStyles.metaText}>
-        {`Exact per-row values · ${facts.rowCount.toLocaleString()} episode rows. Declared per-dimension statistics live in the Statistics tab.`}
-      </span>
-      <FeatureFacts feature={facts.state} missingName="observation.state" />
-      <FeatureFacts feature={facts.action} missingName="action" />
     </div>
   );
 };
-
-function FeatureFacts({
-  feature,
-  missingName,
-}: {
-  readonly feature?: StateActionFeatureSchema;
-  readonly missingName: string;
-}) {
-  if (!feature) {
-    return (
-      <span className={settingsStyles.emptyText}>
-        {`No ${missingName} feature declared`}
-      </span>
-    );
-  }
-  const named = feature.dimensions.filter(
-    (dimension) => dimension.name !== undefined,
-  ).length;
-  return (
-    <div className={settingsStyles.field}>
-      <span className={settingsStyles.metaText}>
-        {`${feature.featureName} — ${feature.dtype} [${feature.shape.join(",")}], ${feature.dimensions.length} dimensions${
-          named ? ` (${named} named)` : ""
-        }`}
-      </span>
-    </div>
-  );
-}
 
 export default StateActionTileSettings;

--- a/app/packages/multimodal/src/views/episode/state-action/StateActionTileSettings.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/StateActionTileSettings.tsx
@@ -6,10 +6,16 @@ import { SettingsSelect } from "../settings/controls/SettingsSelect";
 import settingsStyles from "../tiles/Tile.settings.module.css";
 import { useStateActionContext } from "./state-action-context";
 import {
+  STATE_ACTION_MARKER_SCOPES,
   STATE_ACTION_VALUE_MODES,
+  stateActionMarkerScopeAtom,
   stateActionValueModeAtom,
+  type StateActionMarkerScope,
   type StateActionValueMode,
 } from "./state-action-display";
+
+const MARKER_RANGE_TOOLTIP =
+  "The span behind each row's faint marker. Episode uses this episode's observed min–max, so ticks travel the full track; Dataset uses the declared min–max with its q01–q99 band and flags out-of-range values.";
 
 const VALUE_SCALE_TOOLTIP =
   "Z-score is (v − mean) / std; Quantile maps q01–q99 onto [−1, 1] — both from the dataset-declared statistics. Copy always yields the raw exact value.";
@@ -21,6 +27,7 @@ const VALUE_SCALE_TOOLTIP =
 const StateActionTileSettings: React.FC = () => {
   const { readDimensionStats } = useStateActionContext();
   const [valueMode, setValueMode] = useAtom(stateActionValueModeAtom);
+  const [markerScope, setMarkerScope] = useAtom(stateActionMarkerScopeAtom);
   const [stats, setStats] = useState<StateActionStats | null | "loading">(
     "loading",
   );
@@ -55,6 +62,21 @@ const StateActionTileSettings: React.FC = () => {
           <span className={settingsStyles.emptyText}>
             This source declares no statistics (meta/stats.json); raw values are
             shown.
+          </span>
+        ) : null}
+      </label>
+      <label className={settingsStyles.field}>
+        <SettingsLabel label="Marker range" tooltip={MARKER_RANGE_TOOLTIP} />
+        <SettingsSelect
+          ariaLabel="Marker range"
+          onChange={(next) => setMarkerScope(next as StateActionMarkerScope)}
+          options={STATE_ACTION_MARKER_SCOPES}
+          value={markerScope}
+        />
+        {markerScope === "dataset" && stats === null ? (
+          <span className={settingsStyles.emptyText}>
+            This source declares no statistics (meta/stats.json); no markers can
+            span the dataset range.
           </span>
         ) : null}
       </label>

--- a/app/packages/multimodal/src/views/episode/state-action/register-state-action-tile.test.ts
+++ b/app/packages/multimodal/src/views/episode/state-action/register-state-action-tile.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { leRobotAdapterDescriptor } from "../../../adapters/lerobot/descriptor";
+import { getEpisodeTileExtension } from "../../../extensions/tiles/registry";
+import { TILE_TYPE } from "../tiles/tile-types";
+import { tileTypesFor } from "../shell/tile-catalog";
+
+describe("lerobot:state-action registration", () => {
+  it("registers only through the lazy LeRobot chunk, before open can run", async () => {
+    // Importing the eager descriptor must not register the tile: no
+    // LeRobot table code loads for ordinary media or MCAP-only sessions.
+    expect(getEpisodeTileExtension("lerobot:state-action")).toBeNull();
+
+    await leRobotAdapterDescriptor.load();
+
+    const extension = getEpisodeTileExtension("lerobot:state-action");
+    expect(extension).not.toBeNull();
+    expect(extension?.typeLabel).toBe("State & Action");
+    expect(extension?.isAvailable).toBeDefined();
+  });
+
+  it("appears in the catalog only when the session exposes the capability", async () => {
+    await leRobotAdapterDescriptor.load();
+
+    const withCapability = tileTypesFor({
+      hasNumericSeries: true,
+      hasRawRecords: true,
+      hasStateAction: true,
+      hasTransformTopology: false,
+      sourceTypes: ["image"],
+    });
+    expect(withCapability).toEqual([
+      TILE_TYPE.IMAGE,
+      TILE_TYPE.PLOT,
+      "lerobot:state-action",
+      TILE_TYPE.RAW,
+    ]);
+
+    const withoutCapability = tileTypesFor({
+      hasNumericSeries: true,
+      hasRawRecords: true,
+      hasStateAction: false,
+      hasTransformTopology: false,
+      sourceTypes: ["image"],
+    });
+    expect(withoutCapability).not.toContain("lerobot:state-action");
+  });
+
+  it("survives duplicate chunk evaluation without a conflict", async () => {
+    await leRobotAdapterDescriptor.load();
+    await expect(leRobotAdapterDescriptor.load()).resolves.toBeDefined();
+    expect(getEpisodeTileExtension("lerobot:state-action")).not.toBeNull();
+  });
+});

--- a/app/packages/multimodal/src/views/episode/state-action/register-state-action-tile.test.ts
+++ b/app/packages/multimodal/src/views/episode/state-action/register-state-action-tile.test.ts
@@ -5,12 +5,17 @@ import { TILE_TYPE } from "../tiles/tile-types";
 import { tileTypesFor } from "../shell/tile-catalog";
 
 describe("lerobot:state-action registration", () => {
-  it("registers only through the lazy LeRobot chunk, before open can run", async () => {
+  it("registers only through its lazy view chunk, never the adapter", async () => {
     // Importing the eager descriptor must not register the tile: no
     // LeRobot table code loads for ordinary media or MCAP-only sessions.
     expect(getEpisodeTileExtension("lerobot:state-action")).toBeNull();
 
+    // The adapter layer is view-free: even a full format load registers
+    // nothing — the injection root composes the view extension in.
     await leRobotAdapterDescriptor.load();
+    expect(getEpisodeTileExtension("lerobot:state-action")).toBeNull();
+
+    await import("./register-state-action-tile");
 
     const extension = getEpisodeTileExtension("lerobot:state-action");
     expect(extension).not.toBeNull();
@@ -19,7 +24,7 @@ describe("lerobot:state-action registration", () => {
   });
 
   it("appears in the catalog only when the session exposes the capability", async () => {
-    await leRobotAdapterDescriptor.load();
+    await import("./register-state-action-tile");
 
     const withCapability = tileTypesFor({
       hasNumericSeries: true,
@@ -46,8 +51,8 @@ describe("lerobot:state-action registration", () => {
   });
 
   it("survives duplicate chunk evaluation without a conflict", async () => {
-    await leRobotAdapterDescriptor.load();
-    await expect(leRobotAdapterDescriptor.load()).resolves.toBeDefined();
+    await import("./register-state-action-tile");
+    await expect(import("./register-state-action-tile")).resolves.toBeDefined();
     expect(getEpisodeTileExtension("lerobot:state-action")).not.toBeNull();
   });
 });

--- a/app/packages/multimodal/src/views/episode/state-action/register-state-action-tile.ts
+++ b/app/packages/multimodal/src/views/episode/state-action/register-state-action-tile.ts
@@ -1,0 +1,25 @@
+import { IconName } from "@voxel51/voodo";
+import {
+  getEpisodeTileExtension,
+  registerEpisodeTileExtension,
+} from "../../../extensions/tiles/registry";
+import StateActionTile from "./StateActionTile";
+
+/** Namespaced tile id persisted layouts reference for this extension. */
+export const STATE_ACTION_TILE_ID = "lerobot:state-action";
+
+// Module side effect of the lazy LeRobot client chunk: the chunk loads
+// before the adapter can open a session, and the tile only becomes
+// available once a session exposes hasStateAction, so the registry always
+// holds this definition before the catalog can offer it. The existence
+// guard keeps duplicate module evaluations (HMR, tests) harmless.
+if (!getEpisodeTileExtension(STATE_ACTION_TILE_ID)) {
+  registerEpisodeTileExtension({
+    icon: IconName.Sliders,
+    id: STATE_ACTION_TILE_ID,
+    isAvailable: ({ hasStateAction }) => hasStateAction,
+    order: 58,
+    Tile: StateActionTile,
+    typeLabel: "State & Action",
+  });
+}

--- a/app/packages/multimodal/src/views/episode/state-action/register-state-action-tile.ts
+++ b/app/packages/multimodal/src/views/episode/state-action/register-state-action-tile.ts
@@ -6,7 +6,7 @@ import {
 import StateActionTile from "./StateActionTile";
 
 /** Namespaced tile id persisted layouts reference for this extension. */
-export const STATE_ACTION_TILE_ID = "lerobot:state-action";
+const STATE_ACTION_TILE_ID = "lerobot:state-action";
 
 // Module side effect of the lazy LeRobot client chunk: the chunk loads
 // before the adapter can open a session, and the tile only becomes

--- a/app/packages/multimodal/src/views/episode/state-action/state-action-context.test.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/state-action-context.test.tsx
@@ -471,6 +471,26 @@ describe("StateActionBridge", () => {
     expect(context.current?.rowState).toBeUndefined();
   });
 
+  it("forwards dimension-stat reads and defaults to null without support", async () => {
+    const stats = {
+      state: { max: [1], mean: [0.5], min: [0] },
+    };
+    const capability = createCapability({
+      readDimensionStats: vi.fn(async () => stats),
+    });
+    const context = createContextRef();
+    render(<Harness capability={capability} contextRef={context} />);
+    await act(flushMicrotasks);
+    await expect(context.current?.readDimensionStats()).resolves.toEqual(stats);
+
+    const bare = createCapability();
+    delete (bare as { readDimensionStats?: unknown }).readDimensionStats;
+    const bareContext = createContextRef();
+    render(<Harness capability={bare} contextRef={bareContext} />);
+    await act(flushMicrotasks);
+    await expect(bareContext.current?.readDimensionStats()).resolves.toBe(null);
+  });
+
   it("forwards exact cursor and index reads with linked cancellation", async () => {
     const capability = createCapability();
     const context = createContextRef();

--- a/app/packages/multimodal/src/views/episode/state-action/state-action-context.test.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/state-action-context.test.tsx
@@ -348,6 +348,60 @@ describe("StateActionBridge", () => {
     });
   });
 
+  it("surfaces a pending state only when a committed-row refetch is slow", async () => {
+    vi.useFakeTimers();
+    let resolveSlow: ((next: StateActionRow | null) => void) | null = null;
+    let slow = false;
+    const capability = createCapability({
+      readAtTime: vi.fn(async ({ timestampNs }) => {
+        if (!slow) return rowAt(Number(timestampNs / NS_PER_SECOND));
+        return new Promise<StateActionRow | null>((resolve) => {
+          resolveSlow = resolve;
+        });
+      }),
+    });
+    const context = createContextRef();
+    const store = createStore();
+    store.set(playheadAtom, 2);
+
+    render(
+      <Harness capability={capability} contextRef={context} store={store} />,
+    );
+    await act(async () => {
+      context.current?.subscribeRow();
+      await flushMicrotasks();
+    });
+    expect(context.current?.rowState?.status).toBe("ready");
+
+    slow = true;
+    await act(async () => {
+      store.set(playheadAtom, 7);
+      await flushMicrotasks();
+    });
+    // Fast in-memory relookups never flash: the committed row stays ready
+    // until the pending-badge delay elapses with the read still in flight.
+    expect(context.current?.rowState).toMatchObject({
+      row: rowAt(2),
+      status: "ready",
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200);
+    });
+    expect(context.current?.rowState).toMatchObject({
+      row: rowAt(2),
+      status: "loading",
+      targetNs: 7n * NS_PER_SECOND,
+    });
+    await act(async () => {
+      resolveSlow?.(rowAt(7));
+      await flushMicrotasks();
+    });
+    expect(context.current?.rowState).toMatchObject({
+      row: rowAt(7),
+      status: "ready",
+    });
+  });
+
   it("clears the published row when the source changes", async () => {
     const capability = createCapability();
     const context = createContextRef();

--- a/app/packages/multimodal/src/views/episode/state-action/state-action-context.test.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/state-action-context.test.tsx
@@ -99,6 +99,46 @@ describe("StateActionBridge", () => {
     expect(capability.readAtTime).not.toHaveBeenCalled();
   });
 
+  it("replays a schema request registered before the bridge mounts", async () => {
+    const capability = createCapability();
+    const context = createContextRef();
+    const { rerender } = render(
+      <Harness bridge={false} capability={capability} contextRef={context} />,
+    );
+
+    act(() => context.current?.ensureSchema());
+    expect(context.current?.schema.status).toBe("idle");
+
+    rerender(<Harness bridge capability={capability} contextRef={context} />);
+    await act(flushMicrotasks);
+
+    expect(context.current?.schema).toEqual({
+      schema: SCHEMA,
+      status: "ready",
+    });
+  });
+
+  it("republishes the schema through ensureSchema after it is wiped", async () => {
+    const capability = createCapability();
+    const context = createContextRef();
+
+    render(<Harness capability={capability} contextRef={context} />);
+    await act(flushMicrotasks);
+    expect(context.current?.schema.status).toBe("ready");
+
+    // A shell remount's stale passive cleanup can reset the inventory after
+    // the new epoch's layout-phase publish; the tile heals it by calling
+    // ensureSchema from its own passive effect.
+    await act(async () => {
+      context.current?.ensureSchema();
+      await flushMicrotasks();
+    });
+    expect(context.current?.schema).toEqual({
+      schema: SCHEMA,
+      status: "ready",
+    });
+  });
+
   it("resolves the subscribed row at the playhead with paused intent", async () => {
     const capability = createCapability();
     const context = createContextRef();

--- a/app/packages/multimodal/src/views/episode/state-action/state-action-context.test.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/state-action-context.test.tsx
@@ -1,0 +1,488 @@
+import { playheadAtom, PlaybackStoreContext } from "@fiftyone/playback/runtime";
+import { act, cleanup, render } from "@testing-library/react";
+import { createStore } from "jotai";
+import { useEffect } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createTimelineIndex, type DataStream } from "../../../runtime";
+import { DataStreamProvider, useSetDataStream } from "../../../runtime/react";
+import type {
+  StateActionCapability,
+  StateActionRow,
+  StateActionSchema,
+} from "../../../ports";
+import {
+  StateActionBridge,
+  StateActionProvider,
+  useStateActionContext,
+  type StateActionContextValue,
+} from "./state-action-context";
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+const SCHEMA: StateActionSchema = {
+  action: {
+    dimensions: [{ index: 0 }, { index: 1 }],
+    dtype: "float32",
+    featureName: "action",
+    shape: [2],
+  },
+  rowCount: 100,
+  state: {
+    dimensions: [{ index: 0, name: "shoulder" }, { index: 1 }],
+    dtype: "float32",
+    featureName: "observation.state",
+    shape: [2],
+  },
+};
+
+const NS_PER_SECOND = 1_000_000_000n;
+
+/** Fake rows: one per whole second at t = 0s, 1s, 2s, … */
+function rowAt(offset: number): StateActionRow {
+  return {
+    action: [offset, offset + 0.5],
+    cursor: `row:${offset}`,
+    frameIndex: offset,
+    state: [offset * 10, offset * 10 + 1],
+    task: { index: 0, label: "test task" },
+    timestampNs: BigInt(offset) * NS_PER_SECOND,
+  };
+}
+
+function createCapability(
+  overrides: Partial<StateActionCapability> = {},
+): StateActionCapability {
+  return {
+    readAtCursor: vi.fn(async ({ cursor }) =>
+      rowAt(Number(cursor.slice("row:".length))),
+    ),
+    readAtTime: vi.fn(async ({ timestampNs }) =>
+      timestampNs < 0n ? null : rowAt(Number(timestampNs / NS_PER_SECOND)),
+    ),
+    readIndexWindow: vi.fn(async (request) => {
+      const selected =
+        request.anchorCursor !== undefined
+          ? Number(request.anchorCursor.slice("row:".length))
+          : Number(request.anchorTimestampNs / NS_PER_SECOND);
+      const start = Math.max(0, selected - request.before);
+      const end = Math.min(100, selected + request.after + 1);
+      return {
+        entries: Array.from({ length: end - start }, (_, index) => ({
+          cursor: `row:${start + index}`,
+          timestampNs: BigInt(start + index) * NS_PER_SECOND,
+        })),
+        hasNext: end < 100,
+        hasPrevious: start > 0,
+        selectedCursor: `row:${selected}`,
+      };
+    }),
+    schema: SCHEMA,
+    ...overrides,
+  };
+}
+
+describe("StateActionBridge", () => {
+  it("publishes the schema at bridge start without any read", async () => {
+    const capability = createCapability();
+    const context = createContextRef();
+
+    render(<Harness capability={capability} contextRef={context} />);
+    await act(flushMicrotasks);
+
+    expect(context.current?.schema).toEqual({
+      schema: SCHEMA,
+      status: "ready",
+    });
+    expect(capability.readAtTime).not.toHaveBeenCalled();
+  });
+
+  it("resolves the subscribed row at the playhead with paused intent", async () => {
+    const capability = createCapability();
+    const context = createContextRef();
+    const store = createStore();
+    store.set(playheadAtom, 3);
+
+    render(
+      <Harness capability={capability} contextRef={context} store={store} />,
+    );
+    await act(async () => {
+      context.current?.subscribeRow();
+      await flushMicrotasks();
+    });
+
+    expect(capability.readAtTime).toHaveBeenCalledTimes(1);
+    expect(capability.readAtTime).toHaveBeenCalledWith(
+      expect.objectContaining({
+        intent: "paused-inspection",
+        timestampNs: 3n * NS_PER_SECOND,
+      }),
+    );
+    expect(context.current?.rowState).toMatchObject({
+      row: rowAt(3),
+      status: "ready",
+      targetNs: 3n * NS_PER_SECOND,
+    });
+  });
+
+  it("follows playhead movement on the background intent", async () => {
+    const capability = createCapability();
+    const context = createContextRef();
+    const store = createStore();
+    store.set(playheadAtom, 3);
+
+    render(
+      <Harness capability={capability} contextRef={context} store={store} />,
+    );
+    await act(async () => {
+      context.current?.subscribeRow();
+      await flushMicrotasks();
+    });
+    await act(async () => {
+      store.set(playheadAtom, 8);
+      await flushMicrotasks();
+    });
+
+    expect(capability.readAtTime).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        intent: "background",
+        timestampNs: 8n * NS_PER_SECOND,
+      }),
+    );
+    expect(context.current?.rowState?.row).toEqual(rowAt(8));
+  });
+
+  it("publishes only the newest target after rapid seeks", async () => {
+    vi.useFakeTimers();
+    const resolvers: ((row: StateActionRow | null) => void)[] = [];
+    const requested: bigint[] = [];
+    const capability = createCapability({
+      readAtTime: vi.fn(async ({ timestampNs }) => {
+        requested.push(timestampNs);
+        return new Promise<StateActionRow | null>((resolve) => {
+          resolvers.push(resolve);
+        });
+      }),
+    });
+    const context = createContextRef();
+    const store = createStore();
+    store.set(playheadAtom, 1);
+
+    render(
+      <Harness capability={capability} contextRef={context} store={store} />,
+    );
+    await act(async () => {
+      context.current?.subscribeRow();
+      await flushMicrotasks();
+    });
+    expect(requested).toEqual([1n * NS_PER_SECOND]);
+
+    // Two rapid seeks inside the throttle window coalesce to the newest.
+    await act(async () => {
+      store.set(playheadAtom, 5);
+      store.set(playheadAtom, 9);
+      await flushMicrotasks();
+    });
+    await act(async () => {
+      resolvers[0](rowAt(1));
+      await flushMicrotasks();
+      await vi.advanceTimersByTimeAsync(400);
+    });
+    await act(async () => {
+      resolvers[1]?.(rowAt(9));
+      await flushMicrotasks();
+    });
+
+    expect(requested).toEqual([1n * NS_PER_SECOND, 9n * NS_PER_SECOND]);
+    expect(context.current?.rowState?.row).toEqual(rowAt(9));
+  });
+
+  it("keeps a cursor-pinned row through its own paused-seek echo", async () => {
+    vi.useFakeTimers();
+    const capability = createCapability();
+    const context = createContextRef();
+    const store = createStore();
+    store.set(playheadAtom, 2);
+
+    render(
+      <Harness capability={capability} contextRef={context} store={store} />,
+    );
+    await act(async () => {
+      context.current?.subscribeRow();
+      await flushMicrotasks();
+    });
+    expect(capability.readAtTime).toHaveBeenCalledTimes(1);
+
+    // Step to row 3: pin it and predict the echoed seek target.
+    await act(async () => {
+      context.current?.holdCursorRow(rowAt(3), 3n * NS_PER_SECOND);
+      store.set(playheadAtom, 3);
+      await flushMicrotasks();
+      await vi.advanceTimersByTimeAsync(400);
+    });
+
+    expect(capability.readAtTime).toHaveBeenCalledTimes(1);
+    expect(context.current?.rowState).toMatchObject({
+      pinned: true,
+      row: rowAt(3),
+      status: "ready",
+    });
+
+    // A real user movement resumes ordinary time following.
+    await act(async () => {
+      store.set(playheadAtom, 7);
+      await flushMicrotasks();
+      await vi.advanceTimersByTimeAsync(400);
+    });
+    expect(capability.readAtTime).toHaveBeenCalledTimes(2);
+    expect(context.current?.rowState).toMatchObject({
+      row: rowAt(7),
+      status: "ready",
+    });
+    expect(context.current?.rowState?.pinned).toBeUndefined();
+  });
+
+  it("publishes an empty resolution as a ready null row", async () => {
+    const capability = createCapability({
+      readAtTime: vi.fn(async () => null),
+    });
+    const context = createContextRef();
+    const store = createStore();
+    store.set(playheadAtom, 0);
+
+    render(
+      <Harness capability={capability} contextRef={context} store={store} />,
+    );
+    await act(async () => {
+      context.current?.subscribeRow();
+      await flushMicrotasks();
+    });
+
+    expect(context.current?.rowState).toMatchObject({
+      row: null,
+      status: "ready",
+    });
+  });
+
+  it("retains the previous row through a failed refetch and retries on demand", async () => {
+    let failing = false;
+    const capability = createCapability({
+      readAtTime: vi.fn(async ({ timestampNs }) => {
+        if (failing) throw new Error("link starved");
+        return rowAt(Number(timestampNs / NS_PER_SECOND));
+      }),
+    });
+    const context = createContextRef();
+    const store = createStore();
+    store.set(playheadAtom, 2);
+
+    render(
+      <Harness capability={capability} contextRef={context} store={store} />,
+    );
+    await act(async () => {
+      context.current?.subscribeRow();
+      await flushMicrotasks();
+    });
+    failing = true;
+    await act(async () => {
+      store.set(playheadAtom, 5);
+      await flushMicrotasks();
+    });
+
+    expect(context.current?.rowState).toMatchObject({
+      error: "link starved",
+      row: rowAt(2),
+      status: "error",
+    });
+
+    failing = false;
+    await act(async () => {
+      context.current?.retryRead();
+      await flushMicrotasks();
+    });
+    expect(context.current?.rowState).toMatchObject({
+      row: rowAt(5),
+      status: "ready",
+    });
+  });
+
+  it("clears the published row when the source changes", async () => {
+    const capability = createCapability();
+    const context = createContextRef();
+    const store = createStore();
+    store.set(playheadAtom, 2);
+
+    const { rerender } = render(
+      <Harness capability={capability} contextRef={context} store={store} />,
+    );
+    await act(async () => {
+      context.current?.subscribeRow();
+      await flushMicrotasks();
+    });
+    expect(context.current?.rowState?.row).toEqual(rowAt(2));
+
+    const pending = createCapability({
+      readAtTime: vi.fn(() => new Promise<never>(() => undefined)),
+    });
+    rerender(
+      <Harness
+        capability={pending}
+        contextRef={context}
+        sourceKey="other"
+        store={store}
+      />,
+    );
+    await act(flushMicrotasks);
+
+    expect(context.current?.rowState?.row).toBeUndefined();
+    expect(context.current?.rowState?.status).not.toBe("ready");
+  });
+
+  it("never publishes a late result after the bridge unmounts", async () => {
+    let resolveRead!: (row: StateActionRow | null) => void;
+    const capability = createCapability({
+      readAtTime: vi.fn(
+        () =>
+          new Promise<StateActionRow | null>((resolve) => {
+            resolveRead = resolve;
+          }),
+      ),
+    });
+    const context = createContextRef();
+    const store = createStore();
+    store.set(playheadAtom, 2);
+
+    const { rerender } = render(
+      <Harness capability={capability} contextRef={context} store={store} />,
+    );
+    await act(async () => {
+      context.current?.subscribeRow();
+      await flushMicrotasks();
+    });
+    rerender(
+      <Harness
+        bridge={false}
+        capability={capability}
+        contextRef={context}
+        store={store}
+      />,
+    );
+    await act(async () => {
+      resolveRead(rowAt(2));
+      await flushMicrotasks();
+    });
+
+    expect(context.current?.rowState).toBeUndefined();
+  });
+
+  it("forwards exact cursor and index reads with linked cancellation", async () => {
+    const capability = createCapability();
+    const context = createContextRef();
+
+    render(<Harness capability={capability} contextRef={context} />);
+    await act(flushMicrotasks);
+
+    let row: StateActionRow | undefined;
+    await act(async () => {
+      row = await context.current?.readRowAtCursor("row:4");
+      await context.current?.readRowIndexWindow({
+        after: 1,
+        anchorCursor: "row:4",
+        before: 1,
+      });
+    });
+
+    expect(row).toEqual(rowAt(4));
+    expect(capability.readAtCursor).toHaveBeenCalledWith({
+      cursor: "row:4",
+      signal: expect.any(AbortSignal),
+    });
+    expect(capability.readIndexWindow).toHaveBeenCalledWith({
+      after: 1,
+      anchorCursor: "row:4",
+      before: 1,
+      signal: expect.any(AbortSignal),
+    });
+  });
+});
+
+function Harness({
+  bridge = true,
+  capability,
+  contextRef,
+  sourceKey = "test",
+  store,
+}: {
+  readonly bridge?: boolean;
+  readonly capability: StateActionCapability;
+  readonly contextRef: { current: StateActionContextValue | null };
+  readonly sourceKey?: string;
+  readonly store?: ReturnType<typeof createStore>;
+}) {
+  const body = (
+    <StateActionProvider>
+      <DataStreamProvider>
+        <FakeDataStream />
+        {bridge ? (
+          <StateActionBridge capability={capability} sourceKey={sourceKey} />
+        ) : null}
+        <ContextProbe contextRef={contextRef} />
+      </DataStreamProvider>
+    </StateActionProvider>
+  );
+  return store ? (
+    <PlaybackStoreContext.Provider value={store}>
+      {body}
+    </PlaybackStoreContext.Provider>
+  ) : (
+    body
+  );
+}
+
+function FakeDataStream() {
+  const setDataStream = useSetDataStream();
+  // This effect publishes a synthetic data-stream handle whose timeline
+  // index spans [0, 7200s] — the bridge only reads getTimelineIndex().
+  useEffect(() => {
+    const timeline = createTimelineIndex({
+      endNs: 7_200_000_000_000n,
+      startNs: 0n,
+    });
+    const stream: DataStream = {
+      getStreamCache: () => undefined,
+      getTimelineIndex: () => timeline,
+      sourceKey: "test",
+      subscribeToStream: () => () => undefined,
+    };
+    setDataStream(stream);
+    return () => setDataStream(null);
+  }, [setDataStream]);
+  return null;
+}
+
+function ContextProbe({
+  contextRef,
+}: {
+  readonly contextRef: { current: StateActionContextValue | null };
+}) {
+  const value = useStateActionContext();
+  // This effect forwards the latest context snapshot to the test body.
+  useEffect(() => {
+    contextRef.current = value;
+  }, [contextRef, value]);
+  return null;
+}
+
+function createContextRef(): {
+  current: StateActionContextValue | null;
+} {
+  return { current: null };
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}

--- a/app/packages/multimodal/src/views/episode/state-action/state-action-context.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/state-action-context.tsx
@@ -43,6 +43,10 @@ const DEFERRED_RETRY_MS = 2_000;
  * it instead of resolving at a meaningless time. */
 const TIMELINE_RETRY_MS = 250;
 
+/** A refetch over a committed row surfaces a pending state only after this
+ * delay, so in-memory relookups during playback do not flash the table. */
+const PENDING_ROW_BADGE_MS = 150;
+
 /** The single demand key: one canonical row follows the shared playhead. */
 const ROW_KEY = "state-action:row";
 
@@ -392,6 +396,19 @@ export function StateActionBridge({
             targetNs: playheadNs,
           });
           publishValues(published, isCancelled);
+        } else {
+          // Keep the committed row visible and mark it pending only when
+          // the refetch is genuinely slow.
+          later(() => {
+            if (isCancelled() || inflight?.controller !== controller) return;
+            const current = published.get(ROW_KEY);
+            published.set(ROW_KEY, {
+              ...(current?.row !== undefined ? { row: current.row } : {}),
+              status: "loading",
+              targetNs: playheadNs,
+            });
+            publishValues(published, isCancelled);
+          }, PENDING_ROW_BADGE_MS);
         }
         void capability
           .readAtTime({

--- a/app/packages/multimodal/src/views/episode/state-action/state-action-context.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/state-action-context.tsx
@@ -74,6 +74,13 @@ export interface StateActionContextValue {
   readonly schema: StateActionSchemaState;
 
   /**
+   * Idempotently (re)publishes the session schema. Tiles call this from a
+   * passive effect so the publication survives shell remounts, whose stale
+   * unmount cleanups can otherwise wipe a one-shot layout-phase publish.
+   */
+  ensureSchema(): void;
+
+  /**
    * Pins one cursor-selected row and predicts the paused-seek echo so the
    * bridge keeps the exact row instead of re-resolving through time.
    */
@@ -139,7 +146,7 @@ export const StateActionProvider = stateActionDemandContext.Provider;
 
 /** Reads the state/action cache and demand hooks for the tile. */
 export function useStateActionContext(): StateActionContextValue {
-  const { handlersRef, inventory, subscribeKey, valuesByKey } =
+  const { ensureInventory, handlersRef, inventory, subscribeKey, valuesByKey } =
     useInternalValue();
   const subscribeRow = useCallback(() => subscribeKey(ROW_KEY), [subscribeKey]);
   const holdCursorRow = useCallback(
@@ -175,6 +182,7 @@ export function useStateActionContext(): StateActionContextValue {
   }, [handlersRef]);
   return useMemo(
     () => ({
+      ensureSchema: ensureInventory,
       holdCursorRow,
       readRowAtCursor,
       readRowIndexWindow,
@@ -184,6 +192,7 @@ export function useStateActionContext(): StateActionContextValue {
       subscribeRow,
     }),
     [
+      ensureInventory,
       holdCursorRow,
       inventory,
       readRowAtCursor,
@@ -257,9 +266,17 @@ export function StateActionBridge({
       handlersRef,
       inventoryReplay,
       makeHandlers: ({ isCancelled, queueExpeditedFill }) => {
-        setInventory({ schema: capability.schema, status: "ready" });
+        // Publish eagerly for the common mount order, and again through
+        // ensureInventory: a shell remount runs the outgoing bridge's
+        // passive reset after this layout-phase publish, and the tile's
+        // ensureSchema effect is what restores the wiped schema.
+        const publishSchema = () => {
+          if (isCancelled()) return;
+          setInventory({ schema: capability.schema, status: "ready" });
+        };
+        publishSchema();
         return {
-          ensureInventory: () => undefined,
+          ensureInventory: publishSchema,
           holdCursorRow(row, echoNs) {
             if (isCancelled()) return;
             held = { echoNs, row };

--- a/app/packages/multimodal/src/views/episode/state-action/state-action-context.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/state-action-context.tsx
@@ -1,0 +1,504 @@
+// Deep import on purpose: the playback package root barrel pulls view
+// components whose relay fragments cannot evaluate under vitest, and this
+// bridge has direct unit tests (same rule as raw-message-context).
+import { PlaybackStoreContext } from "@fiftyone/playback/runtime";
+import {
+  useCallback,
+  useContext,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+} from "react";
+import {
+  createDemandFailureBackoff,
+  DEMAND_FAILURE_BACKOFF_MS,
+  startDemandBridge,
+} from "../../../runtime";
+import {
+  createDemandContextProvider,
+  useResetDemandContextOnUnmount,
+  type DemandContextHandlers,
+} from "../../../runtime/react";
+import type {
+  RawRecordCursor,
+  RawRecordIndexWindow,
+  RawRecordIndexWindowRequest,
+} from "../../../ir";
+import type {
+  StateActionCapability,
+  StateActionRow,
+  StateActionSchema,
+} from "../../../ports";
+import { errorMessage } from "../../../utils/errors";
+import { shouldDeferIdleWorkForStore } from "../playback/network-health";
+import { useDataStream } from "../playback/data-stream-context";
+
+/** Playhead-driven relookups run at most this often per bridge tick. */
+const PLAYHEAD_THROTTLE_MS = 300;
+
+/** Starved-link stand-down retry, matching the raw-message gate. */
+const DEFERRED_RETRY_MS = 2_000;
+
+/** The timeline index lands moments after stream registration; wait for
+ * it instead of resolving at a meaningless time. */
+const TIMELINE_RETRY_MS = 250;
+
+/** The single demand key: one canonical row follows the shared playhead. */
+const ROW_KEY = "state-action:row";
+
+/** Session schema facts published at bridge start; no read required. */
+export interface StateActionSchemaState {
+  readonly schema: StateActionSchema | null;
+  readonly status: "idle" | "ready";
+}
+
+/**
+ * The one committed exact row. A retained row remains visible through
+ * refetches while `loading`/`error` honestly mark it stale. `row: null`
+ * means the playhead resolved to no row (before the first row).
+ */
+export interface StateActionRowState {
+  readonly error?: string;
+  /** Row pinned by exact cursor stepping; the echoed paused seek to its
+   * timestamp must not re-resolve through time or replace it. */
+  readonly pinned?: boolean;
+  readonly row?: StateActionRow | null;
+  readonly status: "loading" | "ready" | "error";
+  /** Latest coalesced playhead target this state is resolving. */
+  readonly targetNs?: bigint;
+}
+
+/** Public state/action cache and demand API consumed by the tile. */
+export interface StateActionContextValue {
+  readonly rowState: StateActionRowState | undefined;
+  readonly schema: StateActionSchemaState;
+
+  /**
+   * Pins one cursor-selected row and predicts the paused-seek echo so the
+   * bridge keeps the exact row instead of re-resolving through time.
+   */
+  holdCursorRow(row: StateActionRow, echoNs: bigint): void;
+
+  /** Reads one exact row on the explicit interactive lane. */
+  readRowAtCursor(
+    cursor: RawRecordCursor,
+    signal?: AbortSignal,
+  ): Promise<StateActionRow>;
+
+  /** Reads a bounded exact index window without decoding its rows. */
+  readRowIndexWindow(
+    request: RawRecordIndexWindowRequest,
+    signal?: AbortSignal,
+  ): Promise<RawRecordIndexWindow>;
+
+  /** User-initiated retry after a failed read; bypasses the backoff. */
+  retryRead(): void;
+
+  /**
+   * Declares interest in the canonical row while the returned unsubscribe
+   * is outstanding. Interested tiles follow the playhead together.
+   */
+  subscribeRow(): () => void;
+}
+
+type StateActionHandlers = DemandContextHandlers & {
+  holdCursorRow(row: StateActionRow, echoNs: bigint): void;
+  readRowAtCursor(
+    cursor: RawRecordCursor,
+    signal?: AbortSignal,
+  ): Promise<StateActionRow>;
+  readRowIndexWindow(
+    request: RawRecordIndexWindowRequest,
+    signal?: AbortSignal,
+  ): Promise<RawRecordIndexWindow>;
+  retryRead(): void;
+};
+
+const IDLE_SCHEMA: StateActionSchemaState = { schema: null, status: "idle" };
+const EMPTY_ROWS: ReadonlyMap<string, StateActionRowState> = new Map();
+
+const stateActionDemandContext = createDemandContextProvider<
+  StateActionSchemaState,
+  StateActionRowState,
+  StateActionHandlers
+>({
+  displayName: "StateActionProvider",
+  emptyValues: EMPTY_ROWS,
+  idleInventory: IDLE_SCHEMA,
+  missingProviderMessage:
+    "episode state/action rows must be used inside <StateActionProvider>",
+});
+
+/**
+ * Shares the playhead-synced exact state/action row with its tiles. The
+ * provider holds state plus the interest registry; `StateActionBridge`
+ * inside the shell owns the capability and services demand, so several
+ * tiles share one resolution.
+ */
+export const StateActionProvider = stateActionDemandContext.Provider;
+
+/** Reads the state/action cache and demand hooks for the tile. */
+export function useStateActionContext(): StateActionContextValue {
+  const { handlersRef, inventory, subscribeKey, valuesByKey } =
+    useInternalValue();
+  const subscribeRow = useCallback(() => subscribeKey(ROW_KEY), [subscribeKey]);
+  const holdCursorRow = useCallback(
+    (row: StateActionRow, echoNs: bigint) => {
+      handlersRef.current?.holdCursorRow(row, echoNs);
+    },
+    [handlersRef],
+  );
+  const readRowAtCursor = useCallback(
+    (cursor: RawRecordCursor, signal?: AbortSignal) => {
+      const handlers = handlersRef.current;
+      return handlers
+        ? handlers.readRowAtCursor(cursor, signal)
+        : Promise.reject(
+            new Error("episode state/action reader is unavailable"),
+          );
+    },
+    [handlersRef],
+  );
+  const readRowIndexWindow = useCallback(
+    (request: RawRecordIndexWindowRequest, signal?: AbortSignal) => {
+      const handlers = handlersRef.current;
+      return handlers
+        ? handlers.readRowIndexWindow(request, signal)
+        : Promise.reject(
+            new Error("episode state/action index is unavailable"),
+          );
+    },
+    [handlersRef],
+  );
+  const retryRead = useCallback(() => {
+    handlersRef.current?.retryRead();
+  }, [handlersRef]);
+  return useMemo(
+    () => ({
+      holdCursorRow,
+      readRowAtCursor,
+      readRowIndexWindow,
+      retryRead,
+      rowState: valuesByKey.get(ROW_KEY),
+      schema: inventory,
+      subscribeRow,
+    }),
+    [
+      holdCursorRow,
+      inventory,
+      readRowAtCursor,
+      readRowIndexWindow,
+      retryRead,
+      subscribeRow,
+      valuesByKey,
+    ],
+  );
+}
+
+/**
+ * Bridge that services exact-row demand against the session capability.
+ * Playhead following rides the throttled demand-bridge cadence and always
+ * resolves the newest target; explicit paused seeks are expedited onto the
+ * responsive inspection intent. A cursor-pinned row survives its own
+ * paused-seek echo, so stepping never re-resolves through time.
+ */
+export function StateActionBridge({
+  capability,
+  sourceKey,
+}: {
+  readonly capability: StateActionCapability | null;
+  readonly sourceKey: string | null;
+}) {
+  const {
+    handlersRef,
+    inventoryReplay,
+    publishValues,
+    refCountsRef,
+    reset,
+    setInventory,
+  } = useInternalValue();
+  // Nullable on purpose: callers inside the playback shell provide the
+  // store; standalone callers and tests resolve at the timeline start.
+  const playbackStore = useContext(PlaybackStoreContext);
+  const dataStream = useDataStream();
+  const dataStreamRef = useRef(dataStream);
+  dataStreamRef.current = dataStream;
+
+  // This effect owns one source epoch: the published row, demand handlers,
+  // and the playhead-following loop. It re-keys (full reset) when the
+  // source changes, before the browser paints the newly presented source.
+  useLayoutEffect(() => {
+    reset();
+    if (!capability || !sourceKey) {
+      return undefined;
+    }
+
+    const published = new Map<string, StateActionRowState>();
+    let inflight: {
+      readonly controller: AbortController;
+      readonly expedited: boolean;
+      readonly targetNs: bigint;
+    } | null = null;
+    let desiredTargetNs: bigint | null = null;
+    let desiredExpedited = false;
+    let held: { readonly echoNs: bigint; readonly row: StateActionRow } | null =
+      null;
+    let failureRetryToken: object | null = null;
+    const failures = createDemandFailureBackoff<string>();
+    const epochController = new AbortController();
+
+    const stopBridge = startDemandBridge<
+      StateActionHandlers,
+      NonNullable<typeof dataStream>
+    >({
+      dataStreamRef,
+      deferredRetryMs: DEFERRED_RETRY_MS,
+      expeditePausedSeeks: true,
+      handlersRef,
+      inventoryReplay,
+      makeHandlers: ({ isCancelled, queueExpeditedFill }) => {
+        setInventory({ schema: capability.schema, status: "ready" });
+        return {
+          ensureInventory: () => undefined,
+          holdCursorRow(row, echoNs) {
+            if (isCancelled()) return;
+            held = { echoNs, row };
+            desiredTargetNs = echoNs;
+            inflight?.controller.abort();
+            inflight = null;
+            published.set(ROW_KEY, {
+              pinned: true,
+              row,
+              status: "ready",
+              targetNs: echoNs,
+            });
+            publishValues(published, isCancelled);
+          },
+          onDemandChanged: queueExpeditedFill,
+          async readRowAtCursor(cursor, signal) {
+            const linked = linkAbortSignals(epochController.signal, signal);
+            try {
+              return await capability.readAtCursor({
+                cursor,
+                signal: linked.signal,
+              });
+            } finally {
+              linked.cleanup();
+            }
+          },
+          async readRowIndexWindow(request, signal) {
+            const linked = linkAbortSignals(epochController.signal, signal);
+            try {
+              return await capability.readIndexWindow({
+                ...request,
+                signal: linked.signal,
+              });
+            } finally {
+              linked.cleanup();
+            }
+          },
+          retryRead() {
+            failures.clear(ROW_KEY);
+            queueExpeditedFill();
+          },
+        };
+      },
+      onFill({
+        demandKeys,
+        expedited,
+        isCancelled,
+        later,
+        nowMs,
+        playheadSec,
+        queueExpeditedFill,
+        queueImmediateFill,
+        timeline,
+        userInitiated,
+      }) {
+        if (!timeline) return;
+        const demanded = new Set(demandKeys).has(ROW_KEY);
+        if (!demanded) {
+          inflight?.controller.abort();
+          inflight = null;
+          desiredTargetNs = null;
+          desiredExpedited = false;
+          held = null;
+          failureRetryToken = null;
+          return;
+        }
+        const playheadNs = timeline.secToNs(playheadSec);
+        if (held) {
+          // The pinned row already answers its own paused-seek echo. Any
+          // other target is a real user movement and resumes time following.
+          if (playheadNs === held.echoNs) return;
+          held = null;
+        }
+        const previousTarget = desiredTargetNs;
+        desiredTargetNs = playheadNs;
+        desiredExpedited =
+          expedited || (previousTarget === playheadNs && desiredExpedited);
+
+        if (inflight) {
+          // Only explicit paused intent supersedes in-flight work; during
+          // playback the completion is validated against desiredTargetNs.
+          if (
+            expedited &&
+            (!inflight.expedited || inflight.targetNs !== playheadNs)
+          ) {
+            inflight.controller.abort();
+            inflight = null;
+          } else {
+            return;
+          }
+        }
+        const state = published.get(ROW_KEY);
+        if (
+          state?.status === "ready" &&
+          state.row?.timestampNs === playheadNs &&
+          state.targetNs === playheadNs
+        ) {
+          return;
+        }
+        if (failures.isBlocked(ROW_KEY, nowMs(), userInitiated)) return;
+
+        const controller = new AbortController();
+        const readExpedited = desiredExpedited;
+        inflight = {
+          controller,
+          expedited: readExpedited,
+          targetNs: playheadNs,
+        };
+        if (state?.row === undefined || state.status === "error") {
+          published.set(ROW_KEY, {
+            ...(state?.row !== undefined ? { row: state.row } : {}),
+            status: "loading",
+            targetNs: playheadNs,
+          });
+          publishValues(published, isCancelled);
+        }
+        void capability
+          .readAtTime({
+            intent: readExpedited ? "paused-inspection" : "background",
+            signal: controller.signal,
+            timestampNs: playheadNs,
+          })
+          .then((row) => {
+            if (
+              isCancelled() ||
+              controller.signal.aborted ||
+              inflight?.controller !== controller
+            ) {
+              return;
+            }
+            inflight = null;
+            failures.clear(ROW_KEY);
+            failureRetryToken = null;
+            if (held || desiredTargetNs === null) return;
+            if (desiredTargetNs !== playheadNs) {
+              // Rapid seeks publish only the newest result: discard this
+              // one and immediately admit the latest target.
+              if (desiredExpedited) queueExpeditedFill();
+              else queueImmediateFill();
+              return;
+            }
+            published.set(ROW_KEY, {
+              row,
+              status: "ready",
+              targetNs: playheadNs,
+            });
+            publishValues(published, isCancelled);
+          })
+          .catch((error: unknown) => {
+            if (inflight?.controller === controller) {
+              inflight = null;
+            }
+            if (isCancelled() || controller.signal.aborted) {
+              return;
+            }
+            failures.record(ROW_KEY, nowMs());
+            const previous = published.get(ROW_KEY);
+            published.set(ROW_KEY, {
+              error: errorMessage(error),
+              ...(previous?.row !== undefined ? { row: previous.row } : {}),
+              status: "error",
+              ...(desiredTargetNs !== null
+                ? { targetNs: desiredTargetNs }
+                : {}),
+            });
+            publishValues(published, isCancelled);
+
+            const retryToken = {};
+            failureRetryToken = retryToken;
+            later(() => {
+              if (
+                isCancelled() ||
+                failureRetryToken !== retryToken ||
+                desiredTargetNs === null
+              ) {
+                return;
+              }
+              failureRetryToken = null;
+              if (desiredExpedited) queueExpeditedFill();
+              else queueImmediateFill();
+            }, DEMAND_FAILURE_BACKOFF_MS);
+          });
+      },
+      playbackStore,
+      playheadThrottleMs: PLAYHEAD_THROTTLE_MS,
+      refCountsRef,
+      requireTimeline: true,
+      shouldDeferIdleWork: (store) => shouldDeferIdleWorkForStore(store, null),
+      timelineRetryMs: TIMELINE_RETRY_MS,
+    });
+    return () => {
+      epochController.abort();
+      inflight?.controller.abort();
+      inflight = null;
+      stopBridge();
+    };
+  }, [
+    capability,
+    handlersRef,
+    inventoryReplay,
+    playbackStore,
+    publishValues,
+    refCountsRef,
+    reset,
+    setInventory,
+    sourceKey,
+  ]);
+
+  useResetDemandContextOnUnmount(reset);
+
+  return null;
+}
+
+function useInternalValue() {
+  return stateActionDemandContext.useDemandContext();
+}
+
+/** Links source-epoch and user cancellation without requiring AbortSignal.any. */
+function linkAbortSignals(
+  epochSignal: AbortSignal,
+  requestSignal?: AbortSignal,
+): { readonly cleanup: () => void; readonly signal: AbortSignal } {
+  if (!requestSignal) {
+    return { cleanup: () => undefined, signal: epochSignal };
+  }
+
+  const controller = new AbortController();
+  const abort = () => controller.abort();
+  if (epochSignal.aborted || requestSignal.aborted) {
+    controller.abort();
+  } else {
+    epochSignal.addEventListener("abort", abort, { once: true });
+    requestSignal.addEventListener("abort", abort, { once: true });
+  }
+  return {
+    cleanup: () => {
+      epochSignal.removeEventListener("abort", abort);
+      requestSignal.removeEventListener("abort", abort);
+    },
+    signal: controller.signal,
+  };
+}

--- a/app/packages/multimodal/src/views/episode/state-action/state-action-context.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/state-action-context.tsx
@@ -11,7 +11,10 @@ import {
 } from "react";
 import {
   createDemandFailureBackoff,
+  DEMAND_DEFERRED_RETRY_MS,
   DEMAND_FAILURE_BACKOFF_MS,
+  DEMAND_TIMELINE_RETRY_MS,
+  EXACT_RECORD_PLAYHEAD_THROTTLE_MS,
   startDemandBridge,
 } from "../../../runtime";
 import {
@@ -31,19 +34,10 @@ import type {
   StateActionSchema,
   StateActionStats,
 } from "../../../ports";
+import { linkAbortSignals } from "../../../utils/cancellation";
 import { errorMessage } from "../../../utils/errors";
 import { shouldDeferIdleWorkForStore } from "../playback/network-health";
 import { useDataStream } from "../playback/data-stream-context";
-
-/** Playhead-driven relookups run at most this often per bridge tick. */
-const PLAYHEAD_THROTTLE_MS = 300;
-
-/** Starved-link stand-down retry, matching the raw-message gate. */
-const DEFERRED_RETRY_MS = 2_000;
-
-/** The timeline index lands moments after stream registration; wait for
- * it instead of resolving at a meaningless time. */
-const TIMELINE_RETRY_MS = 250;
 
 /** A refetch over a committed row surfaces a pending state only after this
  * delay, so in-memory relookups during playback do not flash the table. */
@@ -313,7 +307,7 @@ export function StateActionBridge({
       NonNullable<typeof dataStream>
     >({
       dataStreamRef,
-      deferredRetryMs: DEFERRED_RETRY_MS,
+      deferredRetryMs: DEMAND_DEFERRED_RETRY_MS,
       expeditePausedSeeks: true,
       handlersRef,
       inventoryReplay,
@@ -548,11 +542,11 @@ export function StateActionBridge({
           });
       },
       playbackStore,
-      playheadThrottleMs: PLAYHEAD_THROTTLE_MS,
+      playheadThrottleMs: EXACT_RECORD_PLAYHEAD_THROTTLE_MS,
       refCountsRef,
       requireTimeline: true,
       shouldDeferIdleWork: (store) => shouldDeferIdleWorkForStore(store, null),
-      timelineRetryMs: TIMELINE_RETRY_MS,
+      timelineRetryMs: DEMAND_TIMELINE_RETRY_MS,
     });
     return () => {
       epochController.abort();
@@ -579,30 +573,4 @@ export function StateActionBridge({
 
 function useInternalValue() {
   return stateActionDemandContext.useDemandContext();
-}
-
-/** Links source-epoch and user cancellation without requiring AbortSignal.any. */
-function linkAbortSignals(
-  epochSignal: AbortSignal,
-  requestSignal?: AbortSignal,
-): { readonly cleanup: () => void; readonly signal: AbortSignal } {
-  if (!requestSignal) {
-    return { cleanup: () => undefined, signal: epochSignal };
-  }
-
-  const controller = new AbortController();
-  const abort = () => controller.abort();
-  if (epochSignal.aborted || requestSignal.aborted) {
-    controller.abort();
-  } else {
-    epochSignal.addEventListener("abort", abort, { once: true });
-    requestSignal.addEventListener("abort", abort, { once: true });
-  }
-  return {
-    cleanup: () => {
-      epochSignal.removeEventListener("abort", abort);
-      requestSignal.removeEventListener("abort", abort);
-    },
-    signal: controller.signal,
-  };
 }

--- a/app/packages/multimodal/src/views/episode/state-action/state-action-context.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/state-action-context.tsx
@@ -28,6 +28,7 @@ import type {
   StateActionCapability,
   StateActionRow,
   StateActionSchema,
+  StateActionStats,
 } from "../../../ports";
 import { errorMessage } from "../../../utils/errors";
 import { shouldDeferIdleWorkForStore } from "../playback/network-health";
@@ -102,6 +103,9 @@ export interface StateActionContextValue {
     signal?: AbortSignal,
   ): Promise<RawRecordIndexWindow>;
 
+  /** Source-declared per-dimension statistics, or null when absent. */
+  readDimensionStats(signal?: AbortSignal): Promise<StateActionStats | null>;
+
   /** User-initiated retry after a failed read; bypasses the backoff. */
   retryRead(): void;
 
@@ -114,6 +118,7 @@ export interface StateActionContextValue {
 
 type StateActionHandlers = DemandContextHandlers & {
   holdCursorRow(row: StateActionRow, echoNs: bigint): void;
+  readDimensionStats(signal?: AbortSignal): Promise<StateActionStats | null>;
   readRowAtCursor(
     cursor: RawRecordCursor,
     signal?: AbortSignal,
@@ -148,6 +153,18 @@ const stateActionDemandContext = createDemandContextProvider<
  */
 export const StateActionProvider = stateActionDemandContext.Provider;
 
+/** Whether a StateActionProvider is mounted above the calling component. */
+export function useHasStateActionProvider(): boolean {
+  return stateActionDemandContext.useOptionalDemandContext() !== null;
+}
+
+/** The published session schema, or null without a provider or session. */
+export function useStateActionSchemaIfPresent(): StateActionSchema | null {
+  const controller = stateActionDemandContext.useOptionalDemandContext();
+  const inventory = controller?.inventory;
+  return inventory?.status === "ready" ? inventory.schema : null;
+}
+
 /** Reads the state/action cache and demand hooks for the tile. */
 export function useStateActionContext(): StateActionContextValue {
   const { ensureInventory, handlersRef, inventory, subscribeKey, valuesByKey } =
@@ -181,6 +198,15 @@ export function useStateActionContext(): StateActionContextValue {
     },
     [handlersRef],
   );
+  const readDimensionStats = useCallback(
+    (signal?: AbortSignal) => {
+      const handlers = handlersRef.current;
+      return handlers
+        ? handlers.readDimensionStats(signal)
+        : Promise.resolve(null);
+    },
+    [handlersRef],
+  );
   const retryRead = useCallback(() => {
     handlersRef.current?.retryRead();
   }, [handlersRef]);
@@ -188,6 +214,7 @@ export function useStateActionContext(): StateActionContextValue {
     () => ({
       ensureSchema: ensureInventory,
       holdCursorRow,
+      readDimensionStats,
       readRowAtCursor,
       readRowIndexWindow,
       retryRead,
@@ -199,6 +226,7 @@ export function useStateActionContext(): StateActionContextValue {
       ensureInventory,
       holdCursorRow,
       inventory,
+      readDimensionStats,
       readRowAtCursor,
       readRowIndexWindow,
       retryRead,
@@ -296,6 +324,17 @@ export function StateActionBridge({
             publishValues(published, isCancelled);
           },
           onDemandChanged: queueExpeditedFill,
+          async readDimensionStats(signal) {
+            if (!capability.readDimensionStats) return null;
+            const linked = linkAbortSignals(epochController.signal, signal);
+            try {
+              return await capability.readDimensionStats({
+                signal: linked.signal,
+              });
+            } finally {
+              linked.cleanup();
+            }
+          },
           async readRowAtCursor(cursor, signal) {
             const linked = linkAbortSignals(epochController.signal, signal);
             try {

--- a/app/packages/multimodal/src/views/episode/state-action/state-action-context.tsx
+++ b/app/packages/multimodal/src/views/episode/state-action/state-action-context.tsx
@@ -26,6 +26,7 @@ import type {
 } from "../../../ir";
 import type {
   StateActionCapability,
+  StateActionEpisodeProfile,
   StateActionRow,
   StateActionSchema,
   StateActionStats,
@@ -106,6 +107,11 @@ export interface StateActionContextValue {
   /** Source-declared per-dimension statistics, or null when absent. */
   readDimensionStats(signal?: AbortSignal): Promise<StateActionStats | null>;
 
+  /** Episode-computed profile, or null when the provider cannot profile. */
+  readEpisodeProfile(
+    signal?: AbortSignal,
+  ): Promise<StateActionEpisodeProfile | null>;
+
   /** User-initiated retry after a failed read; bypasses the backoff. */
   retryRead(): void;
 
@@ -119,6 +125,9 @@ export interface StateActionContextValue {
 type StateActionHandlers = DemandContextHandlers & {
   holdCursorRow(row: StateActionRow, echoNs: bigint): void;
   readDimensionStats(signal?: AbortSignal): Promise<StateActionStats | null>;
+  readEpisodeProfile(
+    signal?: AbortSignal,
+  ): Promise<StateActionEpisodeProfile | null>;
   readRowAtCursor(
     cursor: RawRecordCursor,
     signal?: AbortSignal,
@@ -207,6 +216,15 @@ export function useStateActionContext(): StateActionContextValue {
     },
     [handlersRef],
   );
+  const readEpisodeProfile = useCallback(
+    (signal?: AbortSignal) => {
+      const handlers = handlersRef.current;
+      return handlers
+        ? handlers.readEpisodeProfile(signal)
+        : Promise.resolve(null);
+    },
+    [handlersRef],
+  );
   const retryRead = useCallback(() => {
     handlersRef.current?.retryRead();
   }, [handlersRef]);
@@ -215,6 +233,7 @@ export function useStateActionContext(): StateActionContextValue {
       ensureSchema: ensureInventory,
       holdCursorRow,
       readDimensionStats,
+      readEpisodeProfile,
       readRowAtCursor,
       readRowIndexWindow,
       retryRead,
@@ -227,6 +246,7 @@ export function useStateActionContext(): StateActionContextValue {
       holdCursorRow,
       inventory,
       readDimensionStats,
+      readEpisodeProfile,
       readRowAtCursor,
       readRowIndexWindow,
       retryRead,
@@ -329,6 +349,17 @@ export function StateActionBridge({
             const linked = linkAbortSignals(epochController.signal, signal);
             try {
               return await capability.readDimensionStats({
+                signal: linked.signal,
+              });
+            } finally {
+              linked.cleanup();
+            }
+          },
+          async readEpisodeProfile(signal) {
+            if (!capability.readEpisodeProfile) return null;
+            const linked = linkAbortSignals(epochController.signal, signal);
+            try {
+              return await capability.readEpisodeProfile({
                 signal: linked.signal,
               });
             } finally {

--- a/app/packages/multimodal/src/views/episode/state-action/state-action-display.ts
+++ b/app/packages/multimodal/src/views/episode/state-action/state-action-display.ts
@@ -12,6 +12,7 @@ export type StateActionValueMode = "raw" | "zscore" | "quantile";
 /** Shared across State & Action tiles: one inspection mode per modal. */
 export const stateActionValueModeAtom = atom<StateActionValueMode>("raw");
 
+/** Selectable value-display modes and their UI labels. */
 export const STATE_ACTION_VALUE_MODES: readonly {
   readonly label: string;
   readonly value: StateActionValueMode;
@@ -27,6 +28,7 @@ export const STATE_ACTION_VALUE_MODES: readonly {
  */
 export type StateActionStatsScope = "both" | "dataset" | "episode";
 
+/** Selectable statistics scopes and their UI labels. */
 export const STATE_ACTION_STATS_SCOPES: readonly {
   readonly label: string;
   readonly value: StateActionStatsScope;
@@ -73,6 +75,7 @@ export const stateActionStatsScopeAtom = atom(
  */
 export type StateActionMarkerScope = "dataset" | "episode";
 
+/** Selectable marker-range scopes and their UI labels. */
 export const STATE_ACTION_MARKER_SCOPES: readonly {
   readonly label: string;
   readonly value: StateActionMarkerScope;

--- a/app/packages/multimodal/src/views/episode/state-action/state-action-display.ts
+++ b/app/packages/multimodal/src/views/episode/state-action/state-action-display.ts
@@ -33,7 +33,7 @@ export const STATE_ACTION_STATS_SCOPES: readonly {
 }[] = [
   { label: "Dataset", value: "dataset" },
   { label: "Episode", value: "episode" },
-  { label: "Both", value: "both" },
+  { label: "Dataset + Episode", value: "both" },
 ];
 
 const STATS_SCOPE_STORAGE_KEY = "fiftyone-multimodal-state-action-stats-scope";

--- a/app/packages/multimodal/src/views/episode/state-action/state-action-display.ts
+++ b/app/packages/multimodal/src/views/episode/state-action/state-action-display.ts
@@ -1,0 +1,79 @@
+import { atom } from "jotai";
+import type { StateActionFeatureStats } from "../../../ports";
+import { compactStateActionFloat } from "./state-action-format";
+
+/**
+ * How the State & Action tile displays numeric values. "raw" shows source
+ * values; "zscore" and "quantile" show what a normalization-trained policy
+ * sees, using the dataset-declared statistics. Copy always yields the raw
+ * exact value — normalized floats are derived, not reconciliation-grade.
+ */
+export type StateActionValueMode = "raw" | "zscore" | "quantile";
+
+/** Shared across State & Action tiles: one inspection mode per modal. */
+export const stateActionValueModeAtom = atom<StateActionValueMode>("raw");
+
+export const STATE_ACTION_VALUE_MODES: readonly {
+  readonly label: string;
+  readonly value: StateActionValueMode;
+}[] = [
+  { label: "Raw", value: "raw" },
+  { label: "Z-score", value: "zscore" },
+  { label: "Quantile [−1, 1]", value: "quantile" },
+];
+
+/** Value-column header per display mode. */
+export function stateActionValueHeader(mode: StateActionValueMode): string {
+  if (mode === "zscore") return "Z-score";
+  if (mode === "quantile") return "Q-scaled";
+  return "Value";
+}
+
+/**
+ * Normalizes one value with the dataset-declared statistics, or null when
+ * the mode is raw or this dimension lacks usable declared parameters — the
+ * caller then falls back to the raw value rather than inventing a scale.
+ */
+export function normalizeStateActionValue(
+  mode: StateActionValueMode,
+  stats: StateActionFeatureStats | undefined,
+  index: number,
+  value: number,
+): number | null {
+  if (mode === "zscore") {
+    const mean = stats?.mean?.[index];
+    const std = stats?.std?.[index];
+    if (
+      mean === undefined ||
+      std === undefined ||
+      !Number.isFinite(mean) ||
+      !Number.isFinite(std) ||
+      std <= 0
+    ) {
+      return null;
+    }
+    return (value - mean) / std;
+  }
+  if (mode === "quantile") {
+    const q01 = stats?.q01?.[index];
+    const q99 = stats?.q99?.[index];
+    if (
+      q01 === undefined ||
+      q99 === undefined ||
+      !Number.isFinite(q01) ||
+      !Number.isFinite(q99) ||
+      q99 <= q01
+    ) {
+      return null;
+    }
+    return ((value - q01) / (q99 - q01)) * 2 - 1;
+  }
+  return null;
+}
+
+/** Compact signed delta, or null for a change too small to print. */
+export function formatStateActionDelta(delta: number): string {
+  if (delta === 0) return "0";
+  const compact = compactStateActionFloat(delta);
+  return delta > 0 ? `+${compact}` : compact;
+}

--- a/app/packages/multimodal/src/views/episode/state-action/state-action-display.ts
+++ b/app/packages/multimodal/src/views/episode/state-action/state-action-display.ts
@@ -65,6 +65,52 @@ export const stateActionStatsScopeAtom = atom(
   },
 );
 
+/**
+ * Which range the tile's in-context value markers span: this episode's
+ * observed min–max (the default — declared dataset ranges often dwarf a
+ * single episode's motion and pin every tick near the middle), or the
+ * dataset-declared min–max with its q01–q99 band.
+ */
+export type StateActionMarkerScope = "dataset" | "episode";
+
+export const STATE_ACTION_MARKER_SCOPES: readonly {
+  readonly label: string;
+  readonly value: StateActionMarkerScope;
+}[] = [
+  { label: "Episode", value: "episode" },
+  { label: "Dataset", value: "dataset" },
+];
+
+const MARKER_SCOPE_STORAGE_KEY =
+  "fiftyone-multimodal-state-action-marker-scope";
+
+/** Returns the persisted marker scope, defaulting to "episode". */
+export function readStoredMarkerScope(): StateActionMarkerScope {
+  try {
+    const raw = globalThis.localStorage?.getItem(MARKER_SCOPE_STORAGE_KEY);
+    return raw === "dataset" || raw === "episode" ? raw : "episode";
+  } catch {
+    return "episode";
+  }
+}
+
+const baseMarkerScopeAtom = atom<StateActionMarkerScope>(
+  readStoredMarkerScope(),
+);
+
+/** Tile marker-range scope, persisted browser-wide across sessions. */
+export const stateActionMarkerScopeAtom = atom(
+  (get) => get(baseMarkerScopeAtom),
+  (_get, set, next: StateActionMarkerScope) => {
+    set(baseMarkerScopeAtom, next);
+    try {
+      globalThis.localStorage?.setItem(MARKER_SCOPE_STORAGE_KEY, next);
+    } catch {
+      // Private windows without storage still honor the in-session choice.
+    }
+  },
+);
+
 /** Value-column header per display mode. */
 export function stateActionValueHeader(mode: StateActionValueMode): string {
   if (mode === "zscore") return "Z-score";

--- a/app/packages/multimodal/src/views/episode/state-action/state-action-display.ts
+++ b/app/packages/multimodal/src/views/episode/state-action/state-action-display.ts
@@ -22,6 +22,50 @@ export const STATE_ACTION_VALUE_MODES: readonly {
   { label: "Quantile [−1, 1]", value: "quantile" },
 ];
 
+/**
+ * Which statistics the Statistics tab shows: the dataset-declared numbers,
+ * this episode's computed numbers, or both layered together.
+ */
+export type StateActionStatsScope = "both" | "dataset" | "episode";
+
+export const STATE_ACTION_STATS_SCOPES: readonly {
+  readonly label: string;
+  readonly value: StateActionStatsScope;
+}[] = [
+  { label: "Dataset", value: "dataset" },
+  { label: "Episode", value: "episode" },
+  { label: "Both", value: "both" },
+];
+
+const STATS_SCOPE_STORAGE_KEY = "fiftyone-multimodal-state-action-stats-scope";
+
+/** Returns the persisted scope, defaulting to "both" on anything else. */
+export function readStoredStatsScope(): StateActionStatsScope {
+  try {
+    const raw = globalThis.localStorage?.getItem(STATS_SCOPE_STORAGE_KEY);
+    return raw === "dataset" || raw === "episode" || raw === "both"
+      ? raw
+      : "both";
+  } catch {
+    return "both";
+  }
+}
+
+const baseStatsScopeAtom = atom<StateActionStatsScope>(readStoredStatsScope());
+
+/** Statistics-tab scope, persisted browser-wide across sessions. */
+export const stateActionStatsScopeAtom = atom(
+  (get) => get(baseStatsScopeAtom),
+  (_get, set, next: StateActionStatsScope) => {
+    set(baseStatsScopeAtom, next);
+    try {
+      globalThis.localStorage?.setItem(STATS_SCOPE_STORAGE_KEY, next);
+    } catch {
+      // Private windows without storage still honor the in-session choice.
+    }
+  },
+);
+
 /** Value-column header per display mode. */
 export function stateActionValueHeader(mode: StateActionValueMode): string {
   if (mode === "zscore") return "Z-score";

--- a/app/packages/multimodal/src/views/episode/state-action/state-action-display.ts
+++ b/app/packages/multimodal/src/views/episode/state-action/state-action-display.ts
@@ -1,6 +1,5 @@
 import { atom } from "jotai";
 import type { StateActionFeatureStats } from "../../../ports";
-import { compactStateActionFloat } from "./state-action-format";
 
 /**
  * How the State & Action tile displays numeric values. "raw" shows source
@@ -115,9 +114,18 @@ export function normalizeStateActionValue(
   return null;
 }
 
-/** Compact signed delta, or null for a change too small to print. */
+/**
+ * Compact signed delta. Three significant digits on purpose: a delta is a
+ * change indicator, not a reconciliation value (the exact delta rides the
+ * cell's hover title), and the tight bound keeps the Δ column at a fixed
+ * width so value and delta columns align across every row.
+ */
 export function formatStateActionDelta(delta: number): string {
   if (delta === 0) return "0";
-  const compact = compactStateActionFloat(delta);
+  const magnitude = Math.abs(delta);
+  const compact =
+    magnitude >= 1e5 || magnitude < 1e-3
+      ? delta.toExponential(1)
+      : String(Number(delta.toPrecision(3)));
   return delta > 0 ? `+${compact}` : compact;
 }

--- a/app/packages/multimodal/src/views/episode/state-action/state-action-format.ts
+++ b/app/packages/multimodal/src/views/episode/state-action/state-action-format.ts
@@ -1,0 +1,68 @@
+import { relativeTimeParts } from "../../../utils/relative-time";
+
+/** One displayable state/action value with its exact copyable form. */
+export interface FormattedStateActionValue {
+  readonly exact: string;
+  readonly invalid: boolean;
+  readonly kind: "value";
+  readonly text: string;
+}
+
+/** Compact display value plus the exact parsed value for copy and hover. */
+export function formatStateActionValue(
+  value: unknown,
+): FormattedStateActionValue {
+  if (typeof value === "number") {
+    if (Number.isNaN(value)) {
+      return { exact: "NaN", invalid: true, kind: "value", text: "NaN" };
+    }
+    if (!Number.isFinite(value)) {
+      return {
+        exact: String(value),
+        invalid: true,
+        kind: "value",
+        text: value > 0 ? "∞" : "-∞",
+      };
+    }
+    if (Number.isInteger(value)) {
+      return {
+        exact: String(value),
+        invalid: false,
+        kind: "value",
+        text: String(value),
+      };
+    }
+    return {
+      exact: String(value),
+      invalid: false,
+      kind: "value",
+      text: compactStateActionFloat(value),
+    };
+  }
+  if (typeof value === "bigint" || typeof value === "boolean") {
+    const text = value.toString();
+    return { exact: text, invalid: false, kind: "value", text };
+  }
+  if (value === null || value === undefined) {
+    return { exact: "null", invalid: true, kind: "value", text: "null" };
+  }
+  const text = String(value);
+  return { exact: text, invalid: true, kind: "value", text };
+}
+
+/** Compact float rendering that keeps scanability without losing scale. */
+export function compactStateActionFloat(value: number): string {
+  const magnitude = Math.abs(value);
+  if (magnitude !== 0 && (magnitude >= 1e6 || magnitude < 1e-4)) {
+    return value.toExponential(4);
+  }
+  return String(Number(value.toPrecision(6)));
+}
+
+/** Formats an episode-local time for the header, exact to the millisecond. */
+export function formatEpisodeTime(timeNs: bigint, originNs: bigint): string {
+  const { milliseconds, negative, seconds } = relativeTimeParts(
+    timeNs - originNs,
+  );
+  return `t=${negative ? "-" : "+"}${seconds}.${milliseconds}s`;
+}

--- a/app/packages/multimodal/src/views/episode/stream-discovery/stream-inventory.test.ts
+++ b/app/packages/multimodal/src/views/episode/stream-discovery/stream-inventory.test.ts
@@ -217,6 +217,60 @@ describe("buildStreamInventoryRows", () => {
       });
     }
   });
+
+  it("uses adapter categories and semantic count nouns without inventing counts", () => {
+    const rows = buildStreamInventoryRows({
+      sceneSources: [],
+      streams: [
+        {
+          ...stream("observation.images.front", "image", "parquet", "", "3"),
+          kind: "image",
+          metadata: {
+            [STREAM_METADATA.CATEGORY]: STREAM_CATEGORY.OBSERVATIONS,
+            [STREAM_METADATA.COUNT_NOUN]: "frames",
+            [STREAM_METADATA.INSPECTABLE]: "false",
+          },
+        },
+        {
+          ...stream("action", "float32", "parquet", "", "3"),
+          kind: "scalar",
+          metadata: {
+            [STREAM_METADATA.CATEGORY]: STREAM_CATEGORY.ACTIONS,
+            [STREAM_METADATA.COUNT_NOUN]: "samples",
+            [STREAM_METADATA.INSPECTABLE]: "true",
+          },
+        },
+        {
+          ...stream("instruction.text", "string", "parquet", "", "1"),
+          metadata: {
+            [STREAM_METADATA.CATEGORY]: STREAM_CATEGORY.INSTRUCTIONS,
+            [STREAM_METADATA.INSPECTABLE]: "false",
+          },
+        },
+        {
+          ...stream("camera.video", "h264", "mp4", "", "1"),
+          count: undefined,
+          kind: "video",
+          metadata: { [STREAM_METADATA.INSPECTABLE]: "false" },
+        },
+      ],
+    });
+
+    expect(row(rows, "observation.images.front")).toMatchObject({
+      category: STREAM_CATEGORY.OBSERVATIONS,
+      countLabel: "3 frames",
+      canInspect: false,
+    });
+    expect(row(rows, "action")).toMatchObject({
+      category: STREAM_CATEGORY.ACTIONS,
+      countLabel: "3 samples",
+      canInspect: true,
+    });
+    expect(row(rows, "instruction.text").category).toBe(
+      STREAM_CATEGORY.INSTRUCTIONS,
+    );
+    expect(row(rows, "camera.video").countLabel).toBeNull();
+  });
 });
 
 function row(rows: readonly StreamInventoryRow[], stream: string) {
@@ -248,6 +302,8 @@ function stream(
       [SCENE_SOURCE_METADATA.SOURCE_NAME]: name,
       ...(sceneType ? { [SCENE_SOURCE_METADATA.TYPE]: sceneType } : {}),
       [STREAM_METADATA.DECODE_STATUS]: decodeStatus,
+      [STREAM_METADATA.INSPECTABLE]:
+        decodeStatus === "decodable" ? "true" : "false",
       [STREAM_METADATA.ENCODING]: encoding,
       [STREAM_METADATA.SCHEMA_NAME]: schema,
     },

--- a/app/packages/multimodal/src/views/episode/stream-discovery/stream-inventory.test.ts
+++ b/app/packages/multimodal/src/views/episode/stream-discovery/stream-inventory.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, it } from "vitest";
 import {
   SCENE_SOURCE_METADATA,
   SCENE_SOURCE_TYPE,
+  STREAM_CATEGORY,
   STREAM_METADATA,
   type StreamDescriptor,
 } from "../../../ir/index";
 import { sceneSourcesFromStreamDescriptors } from "../../../stream-selection";
 import {
   STREAM_CAPABILITY,
-  STREAM_CATEGORY,
   buildStreamInventoryRows,
   filterStreamInventoryRows,
   type StreamInventoryRow,

--- a/app/packages/multimodal/src/views/episode/stream-discovery/stream-inventory.ts
+++ b/app/packages/multimodal/src/views/episode/stream-discovery/stream-inventory.ts
@@ -1,28 +1,17 @@
 import {
   SCENE_SOURCE_METADATA,
   SCENE_SOURCE_TYPE,
+  STREAM_CATEGORY,
+  STREAM_COUNT_NOUN,
   STREAM_METADATA,
   type SceneSource,
   type SceneSourceType,
   type StreamDescriptor,
+  type StreamCategory,
+  type StreamCountNoun,
   type StreamKind,
   type StreamId,
 } from "../../../ir/index";
-
-export const STREAM_CATEGORY = {
-  ACTIONS: "actions",
-  SENSORS: "sensors",
-  ANNOTATIONS_PLANNING: "annotations-planning",
-  INSTRUCTIONS: "instructions",
-  OBSERVATIONS: "observations",
-  TRANSFORMS_POSES: "transforms-poses",
-  DIAGNOSTICS: "diagnostics",
-  TELEMETRY: "telemetry",
-  CUSTOM: "custom",
-} as const;
-
-export type StreamCategory =
-  (typeof STREAM_CATEGORY)[keyof typeof STREAM_CATEGORY];
 
 export const STREAM_CATEGORY_ORDER: readonly StreamCategory[] = [
   STREAM_CATEGORY.OBSERVATIONS,
@@ -229,28 +218,40 @@ function countLabelFor(stream: StreamDescriptor): string | null {
   const count = recordCountFor(stream.count);
   if (count === null) return null;
   const noun =
-    stream.metadata?.[STREAM_METADATA.COUNT_NOUN] ?? countNoun(stream.kind);
+    knownCountNoun(stream.metadata?.[STREAM_METADATA.COUNT_NOUN]) ??
+    countNoun(stream.kind);
   return `${count.toLocaleString()} ${count === 1 ? singularNoun(noun) : noun}`;
 }
 
-function countNoun(kind: StreamKind): string {
+function countNoun(kind: StreamKind): StreamCountNoun {
   switch (kind) {
     case "image":
     case "video":
-      return "frames";
+      return STREAM_COUNT_NOUN.FRAMES;
     case "audio":
     case "scalar":
-      return "samples";
+      return STREAM_COUNT_NOUN.SAMPLES;
     default:
-      return "messages";
+      return STREAM_COUNT_NOUN.MESSAGES;
   }
 }
 
-function singularNoun(noun: string): string {
-  if (noun === "messages") return "message";
-  if (noun === "frames") return "frame";
-  if (noun === "samples") return "sample";
-  return noun;
+function knownCountNoun(value: string | undefined): StreamCountNoun | null {
+  return value !== undefined &&
+    Object.values(STREAM_COUNT_NOUN).includes(value as StreamCountNoun)
+    ? (value as StreamCountNoun)
+    : null;
+}
+
+function singularNoun(noun: StreamCountNoun): string {
+  switch (noun) {
+    case STREAM_COUNT_NOUN.FRAMES:
+      return "frame";
+    case STREAM_COUNT_NOUN.SAMPLES:
+      return "sample";
+    case STREAM_COUNT_NOUN.MESSAGES:
+      return "message";
+  }
 }
 
 function messageRateLabel(

--- a/app/packages/multimodal/src/views/episode/stream-discovery/stream-inventory.ts
+++ b/app/packages/multimodal/src/views/episode/stream-discovery/stream-inventory.ts
@@ -5,12 +5,16 @@ import {
   type SceneSource,
   type SceneSourceType,
   type StreamDescriptor,
+  type StreamKind,
   type StreamId,
 } from "../../../ir/index";
 
 export const STREAM_CATEGORY = {
+  ACTIONS: "actions",
   SENSORS: "sensors",
   ANNOTATIONS_PLANNING: "annotations-planning",
+  INSTRUCTIONS: "instructions",
+  OBSERVATIONS: "observations",
   TRANSFORMS_POSES: "transforms-poses",
   DIAGNOSTICS: "diagnostics",
   TELEMETRY: "telemetry",
@@ -21,6 +25,9 @@ export type StreamCategory =
   (typeof STREAM_CATEGORY)[keyof typeof STREAM_CATEGORY];
 
 export const STREAM_CATEGORY_ORDER: readonly StreamCategory[] = [
+  STREAM_CATEGORY.OBSERVATIONS,
+  STREAM_CATEGORY.ACTIONS,
+  STREAM_CATEGORY.INSTRUCTIONS,
   STREAM_CATEGORY.SENSORS,
   STREAM_CATEGORY.ANNOTATIONS_PLANNING,
   STREAM_CATEGORY.TRANSFORMS_POSES,
@@ -30,8 +37,11 @@ export const STREAM_CATEGORY_ORDER: readonly StreamCategory[] = [
 ];
 
 export const STREAM_CATEGORY_LABEL: Record<StreamCategory, string> = {
+  [STREAM_CATEGORY.ACTIONS]: "Actions",
   [STREAM_CATEGORY.SENSORS]: "Sensors",
   [STREAM_CATEGORY.ANNOTATIONS_PLANNING]: "Annotations & Planning",
+  [STREAM_CATEGORY.INSTRUCTIONS]: "Instructions",
+  [STREAM_CATEGORY.OBSERVATIONS]: "Observations",
   [STREAM_CATEGORY.TRANSFORMS_POSES]: "Transforms & Poses",
   [STREAM_CATEGORY.DIAGNOSTICS]: "Diagnostics",
   [STREAM_CATEGORY.TELEMETRY]: "Telemetry",
@@ -78,11 +88,12 @@ export interface StreamInventoryRow {
   readonly canInspect: boolean;
   readonly capabilities: readonly StreamCapability[];
   readonly category: StreamCategory;
-  readonly countLabel: string;
+  readonly countLabel: string | null;
   readonly encoding: string;
   readonly rateHz: number | null;
   readonly rateLabel: string | null;
   readonly recordCount: number | null;
+  readonly kind: StreamKind;
   readonly schemaName: string;
   readonly sourceName: string;
   readonly sourceType: SceneSourceType | null;
@@ -149,7 +160,8 @@ export function buildStreamInventoryRows({
       const decodeStatus = genericDecodeStatus(
         stream.metadata?.[STREAM_METADATA.DECODE_STATUS],
       );
-      const canInspect = decodeStatus === "decodable";
+      const canInspect =
+        stream.metadata?.[STREAM_METADATA.INSPECTABLE] === "true";
       const schemaName = schemaNameFor(stream);
       const telemetry = isTelemetrySchema(schemaName);
       const rateHz = messageRateHz(stream.approxRateHz);
@@ -166,13 +178,15 @@ export function buildStreamInventoryRows({
           frameTransform,
           sourceName,
           sourceType,
+          stream,
           telemetry,
         }),
-        countLabel: messageCountLabel(stream.count),
+        countLabel: countLabelFor(stream),
         encoding: encodingFor(stream),
         rateHz,
         rateLabel: messageRateLabel(rateHz),
         recordCount: recordCountFor(stream.count),
+        kind: stream.kind,
         schemaName,
         sourceName,
         sourceType,
@@ -211,12 +225,32 @@ export function filterStreamInventoryRows(
   );
 }
 
-function messageCountLabel(recordCount: number | undefined): string {
-  const count = recordCountFor(recordCount);
-  if (count === null) {
-    return "unknown msgs";
+function countLabelFor(stream: StreamDescriptor): string | null {
+  const count = recordCountFor(stream.count);
+  if (count === null) return null;
+  const noun =
+    stream.metadata?.[STREAM_METADATA.COUNT_NOUN] ?? countNoun(stream.kind);
+  return `${count.toLocaleString()} ${count === 1 ? singularNoun(noun) : noun}`;
+}
+
+function countNoun(kind: StreamKind): string {
+  switch (kind) {
+    case "image":
+    case "video":
+      return "frames";
+    case "audio":
+    case "scalar":
+      return "samples";
+    default:
+      return "messages";
   }
-  return `${count.toLocaleString()} ${count === 1 ? "msg" : "msgs"}`;
+}
+
+function singularNoun(noun: string): string {
+  if (noun === "messages") return "message";
+  if (noun === "frames") return "frame";
+  if (noun === "samples") return "sample";
+  return noun;
 }
 
 function messageRateLabel(
@@ -238,13 +272,22 @@ function categoryForStream({
   frameTransform,
   sourceName,
   sourceType,
+  stream,
   telemetry,
 }: {
   readonly frameTransform: boolean;
   readonly sourceName: string;
   readonly sourceType: SceneSourceType | null;
+  readonly stream: StreamDescriptor;
   readonly telemetry: boolean;
 }): StreamCategory {
+  const adapterCategory = stream.metadata?.[STREAM_METADATA.CATEGORY];
+  if (
+    adapterCategory &&
+    Object.values(STREAM_CATEGORY).includes(adapterCategory as StreamCategory)
+  ) {
+    return adapterCategory as StreamCategory;
+  }
   if (/(?:^|\/)imu(?:\/|$)/i.test(sourceName)) {
     return STREAM_CATEGORY.SENSORS;
   }

--- a/app/packages/multimodal/src/views/session/episode-label.ts
+++ b/app/packages/multimodal/src/views/session/episode-label.ts
@@ -1,0 +1,30 @@
+import type { SampleRendererSampleLike } from "@fiftyone/plugins";
+
+/** Compact identity for reference-backed episodes in shared grid/modal chrome. */
+export function episodeDisplayName(
+  sample: SampleRendererSampleLike["sample"] & {
+    readonly duration?: unknown;
+    readonly episode_index?: unknown;
+    readonly task?: unknown;
+  },
+): string | null {
+  const episodeIndex = finiteNumber(sample.episode_index);
+  if (episodeIndex === null) return null;
+  const parts = [`Episode ${Math.trunc(episodeIndex)}`];
+  if (typeof sample.task === "string" && sample.task.trim()) {
+    parts.push(sample.task.trim());
+  }
+  const duration = finiteNumber(sample.duration);
+  if (duration !== null && duration >= 0) {
+    parts.push(`${formatDuration(duration)}s`);
+  }
+  return parts.join(" · ");
+}
+
+function finiteNumber(value: unknown) {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function formatDuration(value: number) {
+  return value.toFixed(value >= 10 ? 1 : 2).replace(/\.0+$/, "");
+}

--- a/app/packages/multimodal/src/views/session/episode-source.test.ts
+++ b/app/packages/multimodal/src/views/session/episode-source.test.ts
@@ -198,7 +198,6 @@ describe("episodeSourceFromMediaReference", () => {
     const source = episodeSourceFromMediaReference("d", "s", {
       kind: "lerobot-episode",
       key: "source:17",
-      version: "1",
     });
 
     await expect(source.assets.list()).rejects.toThrow(
@@ -230,7 +229,6 @@ describe("episodeSourceFromMediaReference", () => {
     const source = episodeSourceFromMediaReference("d", "s", {
       kind: "lerobot-episode",
       key: "source:17",
-      version: "1",
     });
 
     await expect(source.assets.list()).rejects.toThrow("unknown asset role");
@@ -268,7 +266,6 @@ describe("episodeSourceFromMediaReference", () => {
     const source = episodeSourceFromMediaReference("d", "s", {
       kind: "lerobot-episode",
       key: "source:17",
-      version: "1",
     });
 
     await expect(source.assets.list()).resolves.toEqual([

--- a/app/packages/multimodal/src/views/session/episode-source.test.ts
+++ b/app/packages/multimodal/src/views/session/episode-source.test.ts
@@ -14,11 +14,26 @@ import {
   episodeSourceFromByteSource,
   episodeSourceFromMediaReference,
 } from "./episode-source";
+import { episodeDisplayName } from "./episode-label";
 
 afterEach(() => {
   resetSourceBootstrapCacheForTests();
   setFetchFunction("");
   vi.unstubAllGlobals();
+});
+
+describe("episodeDisplayName", () => {
+  it("formats thin LeRobot episode metadata without requiring a filepath", () => {
+    expect(
+      episodeDisplayName({
+        _id: "sample",
+        duration: 14.2,
+        episode_index: 7,
+        task: "sort objects",
+      }),
+    ).toBe("Episode 7 · sort objects · 14.2s");
+    expect(episodeDisplayName({ _id: "sample" })).toBeNull();
+  });
 });
 
 describe("episodeSourceFromByteSource", () => {
@@ -67,6 +82,12 @@ describe("episodeSourceFromMediaReference", () => {
             asset_id: "camera",
             media_type: "video/mp4",
             role: "video-stream",
+            feature_name: "observation.images.camera",
+            selector: {
+              from_timestamp: 1.25,
+              kind: "video-timestamp-interval",
+              to_timestamp: 2.5,
+            },
             size_bytes: 1234,
             url: "/dataset/d/sample/s/multimodal/assets/camera",
           },
@@ -102,7 +123,18 @@ describe("episodeSourceFromMediaReference", () => {
     resolveRequest(response);
 
     await expect(listed).resolves.toEqual([
-      { id: "camera", mediaType: "video/mp4", role: "video-stream" },
+      {
+        featureName: "observation.images.camera",
+        id: "camera",
+        mediaType: "video/mp4",
+        metadata: { sizeBytes: "1234" },
+        role: "video-stream",
+        selector: {
+          fromTimestamp: 1.25,
+          kind: "video-timestamp-interval",
+          toTimestamp: 2.5,
+        },
+      },
     ]);
     await expect(resolved).resolves.toMatchObject({
       sizeBytes: "1234",
@@ -140,6 +172,68 @@ describe("episodeSourceFromMediaReference", () => {
     );
     await expect(source.assets.list()).resolves.toEqual([]);
     expect(request).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects unknown manifest selectors before exposing an asset", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        json: async () => ({
+          assets: [
+            {
+              asset_id: "unsafe",
+              media_type: "application/octet-stream",
+              role: "tabular-frame-data",
+              selector: { kind: "filesystem-path" },
+              size_bytes: 1,
+              url: "/asset",
+            },
+          ],
+        }),
+        ok: true,
+        status: 200,
+        statusText: "OK",
+      }),
+    );
+    const source = episodeSourceFromMediaReference("d", "s", {
+      kind: "lerobot-episode",
+      key: "source:17",
+      version: "1",
+    });
+
+    await expect(source.assets.list()).rejects.toThrow(
+      "unknown asset selector",
+    );
+  });
+
+  it("rejects unknown manifest roles before exposing an asset", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        json: async () => ({
+          assets: [
+            {
+              asset_id: "unsafe",
+              media_type: "application/octet-stream",
+              role: "filesystem-root",
+              selector: { kind: "whole-file" },
+              size_bytes: 1,
+              url: "/asset",
+            },
+          ],
+        }),
+        ok: true,
+        status: 200,
+        statusText: "OK",
+      }),
+    );
+    const source = episodeSourceFromMediaReference("d", "s", {
+      kind: "lerobot-episode",
+      key: "source:17",
+      version: "1",
+    });
+
+    await expect(source.assets.list()).rejects.toThrow("unknown asset role");
   });
 
   it("isolates caller cancellation on a shared manifest request", async () => {

--- a/app/packages/multimodal/src/views/session/episode-source.test.ts
+++ b/app/packages/multimodal/src/views/session/episode-source.test.ts
@@ -236,6 +236,59 @@ describe("episodeSourceFromMediaReference", () => {
     await expect(source.assets.list()).rejects.toThrow("unknown asset role");
   });
 
+  it("accepts the auxiliary metadata roles emitted by the server", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        json: async () => ({
+          assets: [
+            {
+              asset_id: "statistics",
+              media_type: "application/json",
+              role: "dataset-statistics",
+              selector: { kind: "whole-file" },
+              size_bytes: 10,
+              url: "/statistics",
+            },
+            {
+              asset_id: "tasks",
+              media_type: "application/octet-stream",
+              role: "tasks-metadata",
+              selector: { kind: "whole-file" },
+              size_bytes: 20,
+              url: "/tasks",
+            },
+          ],
+        }),
+        ok: true,
+        status: 200,
+        statusText: "OK",
+      }),
+    );
+    const source = episodeSourceFromMediaReference("d", "s", {
+      kind: "lerobot-episode",
+      key: "source:17",
+      version: "1",
+    });
+
+    await expect(source.assets.list()).resolves.toEqual([
+      {
+        id: "statistics",
+        mediaType: "application/json",
+        metadata: { sizeBytes: "10" },
+        role: "dataset-statistics",
+        selector: { kind: "whole-file" },
+      },
+      {
+        id: "tasks",
+        mediaType: "application/octet-stream",
+        metadata: { sizeBytes: "20" },
+        role: "tasks-metadata",
+        selector: { kind: "whole-file" },
+      },
+    ]);
+  });
+
   it("isolates caller cancellation on a shared manifest request", async () => {
     const response = {
       json: async () => ({ assets: [] }),

--- a/app/packages/multimodal/src/views/session/episode-source.ts
+++ b/app/packages/multimodal/src/views/session/episode-source.ts
@@ -8,6 +8,7 @@ import { getFetchFunctionExtended } from "@fiftyone/utilities";
 
 import { BYTE_SOURCE_READ_PROFILE, type ByteSourceDescriptor } from "../../ir";
 import type {
+  AssetSelectorDescriptor,
   EpisodeOpenOptions,
   EpisodeSource,
   ManifestEpisodeSource,
@@ -161,9 +162,12 @@ export function episodeSourceFromMediaReference(
     assets: {
       list: async (options) =>
         (await getManifest(options)).assets.map((asset) => ({
+          ...(asset.feature_name ? { featureName: asset.feature_name } : {}),
           id: asset.asset_id,
           mediaType: asset.media_type,
-          role: asset.role,
+          metadata: { sizeBytes: normalizedSizeBytes(asset.size_bytes) },
+          role: normalizedAssetRole(asset.role),
+          selector: normalizeAssetSelector(asset.selector),
         })),
       resolve: async (assetId, options) => {
         const resolvedManifest = await getManifest(options);
@@ -254,8 +258,94 @@ type TransportMediaAssetManifest = {
 
 type TransportMediaAsset = {
   readonly asset_id: string;
+  readonly feature_name?: string | null;
   readonly media_type: string;
   readonly role: string;
+  readonly selector: TransportMediaAssetSelector;
   readonly size_bytes: number;
   readonly url: string;
 };
+
+type TransportMediaAssetSelector =
+  | { readonly kind: "whole-file" }
+  | {
+      readonly coordinate_system: string;
+      readonly end: number;
+      readonly kind: "row-interval";
+      readonly start: number;
+    }
+  | {
+      readonly from_timestamp: number;
+      readonly kind: "video-timestamp-interval";
+      readonly to_timestamp: number;
+    };
+
+function normalizedSizeBytes(value: number): string {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error("Episode manifest contains an invalid asset size");
+  }
+  return value.toString();
+}
+
+const LEROBOT_ASSET_ROLES = new Set([
+  "dataset-info",
+  "episode-metadata",
+  "image-payload",
+  "tabular-frame-data",
+  "video-stream",
+]);
+
+function normalizedAssetRole(value: string): string {
+  if (!LEROBOT_ASSET_ROLES.has(value)) {
+    throw new Error("Episode manifest contains an unknown asset role");
+  }
+  return value;
+}
+
+function normalizeAssetSelector(selector: unknown): AssetSelectorDescriptor {
+  if (!selector || typeof selector !== "object" || !("kind" in selector)) {
+    throw new Error("Episode manifest contains a malformed asset selector");
+  }
+  const value = selector as Record<string, unknown>;
+  switch (value.kind) {
+    case "whole-file":
+      return { kind: "whole-file" };
+    case "row-interval":
+      if (
+        (value.coordinate_system !== "parquet-file-row" &&
+          value.coordinate_system !== "lerobot-v3-global-dataset-row") ||
+        !Number.isSafeInteger(value.start) ||
+        !Number.isSafeInteger(value.end) ||
+        (value.start as number) < 0 ||
+        (value.start as number) >= (value.end as number)
+      ) {
+        throw new Error(
+          "Episode manifest contains an unsupported row selector",
+        );
+      }
+      return {
+        coordinateSystem: value.coordinate_system,
+        end: value.end as number,
+        kind: value.kind,
+        start: value.start as number,
+      };
+    case "video-timestamp-interval":
+      if (
+        typeof value.from_timestamp !== "number" ||
+        !Number.isFinite(value.from_timestamp) ||
+        value.from_timestamp < 0 ||
+        typeof value.to_timestamp !== "number" ||
+        !Number.isFinite(value.to_timestamp) ||
+        value.from_timestamp >= value.to_timestamp
+      ) {
+        throw new Error("Episode manifest contains an invalid video selector");
+      }
+      return {
+        fromTimestamp: value.from_timestamp,
+        kind: value.kind,
+        toTimestamp: value.to_timestamp,
+      };
+    default:
+      throw new Error("Episode manifest contains an unknown asset selector");
+  }
+}

--- a/app/packages/multimodal/src/views/session/episode-source.ts
+++ b/app/packages/multimodal/src/views/session/episode-source.ts
@@ -289,9 +289,11 @@ function normalizedSizeBytes(value: number): string {
 
 const LEROBOT_ASSET_ROLES = new Set([
   "dataset-info",
+  "dataset-statistics",
   "episode-metadata",
   "image-payload",
   "tabular-frame-data",
+  "tasks-metadata",
   "video-stream",
 ]);
 

--- a/app/packages/multimodal/src/views/session/episode-source.ts
+++ b/app/packages/multimodal/src/views/session/episode-source.ts
@@ -316,10 +316,12 @@ function normalizeAssetSelector(selector: unknown): AssetSelectorDescriptor {
       if (
         (value.coordinate_system !== "parquet-file-row" &&
           value.coordinate_system !== "lerobot-v3-global-dataset-row") ||
+        typeof value.start !== "number" ||
         !Number.isSafeInteger(value.start) ||
+        typeof value.end !== "number" ||
         !Number.isSafeInteger(value.end) ||
-        (value.start as number) < 0 ||
-        (value.start as number) >= (value.end as number)
+        value.start < 0 ||
+        value.start >= value.end
       ) {
         throw new Error(
           "Episode manifest contains an unsupported row selector",
@@ -327,9 +329,9 @@ function normalizeAssetSelector(selector: unknown): AssetSelectorDescriptor {
       }
       return {
         coordinateSystem: value.coordinate_system,
-        end: value.end as number,
+        end: value.end,
         kind: value.kind,
-        start: value.start as number,
+        start: value.start,
       };
     case "video-timestamp-interval":
       if (

--- a/app/packages/multimodal/src/views/session/use-stable-episode-source.ts
+++ b/app/packages/multimodal/src/views/session/use-stable-episode-source.ts
@@ -1,7 +1,7 @@
 import type { SampleRendererProps } from "@fiftyone/plugins";
 import { useMemo, useRef } from "react";
 
-import type { ByteSourceDescriptor } from "../../ir";
+import { BYTE_SOURCE_READ_PROFILE, type ByteSourceDescriptor } from "../../ir";
 import type { EpisodeSource } from "../../ports";
 import { episodeSourceAccessKey } from "../../runtime/episode-resources";
 import {
@@ -18,19 +18,32 @@ import {
 export function useStableEpisodeSource(ctx: SampleRendererProps["ctx"]): {
   readonly byteSource: ByteSourceDescriptor | null;
   readonly episodeSource: EpisodeSource | null;
-  readonly sourceFactsScope: SourceFactsScope;
+  readonly sourceFactsScope: SourceFactsScope | undefined;
 } {
-  const next = episodeByteSourceFromContext(ctx);
   const datasetId = ctx.dataset.datasetId;
   const mediaField = ctx.media?.field ?? null;
   const mediaReference = ctx.media?.mediaReference;
+  const next = mediaReference
+    ? {
+        readProfile: BYTE_SOURCE_READ_PROFILE.REMOTE,
+        sourceId: mediaReference.key,
+        url: `/dataset/${encodeURIComponent(
+          datasetId,
+        )}/sample/${encodeURIComponent(
+          ctx.sample.sample._id,
+        )}/multimodal/manifest`,
+      }
+    : episodeByteSourceFromContext(ctx);
   const sourceFactsScope = useMemo(
-    () => ({
-      cachePartition: OSS_SOURCE_FACTS_CACHE_PARTITION,
-      datasetId,
-      mediaField,
-    }),
-    [datasetId, mediaField],
+    () =>
+      mediaReference
+        ? undefined
+        : {
+            cachePartition: OSS_SOURCE_FACTS_CACHE_PARTITION,
+            datasetId,
+            mediaField,
+          },
+    [datasetId, mediaField, mediaReference],
   );
   const sourceKey = mediaReference
     ? JSON.stringify([
@@ -63,7 +76,7 @@ export function useStableEpisodeSource(ctx: SampleRendererProps["ctx"]): {
   const episodeSource = useMemo(
     () =>
       manifestSource ??
-      (byteSource
+      (byteSource && sourceFactsScope
         ? episodeSourceFromByteSource(byteSource, sourceFactsScope)
         : null),
     [byteSource, manifestSource, sourceFactsScope],

--- a/app/packages/multimodal/src/visualization/media-2d/BitmapImageView.test.tsx
+++ b/app/packages/multimodal/src/visualization/media-2d/BitmapImageView.test.tsx
@@ -743,7 +743,7 @@ describe("BitmapImageFrameView", () => {
 
     await waitFor(() =>
       expect(onError).toHaveBeenCalledWith(
-        new Error("H.264 preview is waiting for a keyframe"),
+        new Error("Video preview is waiting for a keyframe"),
       ),
     );
     expect(decoder.instances).toHaveLength(0);
@@ -815,7 +815,7 @@ describe("BitmapImageFrameView", () => {
 
     await waitFor(() => expect(onError).toHaveBeenCalledTimes(1));
     expect(onError.mock.calls[0]?.[0]).toEqual(
-      new Error("WebCodecs H.264 decoding is unavailable"),
+      new Error("WebCodecs video decoding is unavailable"),
     );
     expect(onImageLoaded).not.toHaveBeenCalled();
   });

--- a/app/packages/multimodal/src/visualization/media-2d/BitmapImageView.test.tsx
+++ b/app/packages/multimodal/src/visualization/media-2d/BitmapImageView.test.tsx
@@ -821,6 +821,20 @@ describe("BitmapImageFrameView", () => {
     );
     expect(onImageLoaded).not.toHaveBeenCalled();
   });
+
+  it("reports unavailable H.264 frame data separately from codec support", async () => {
+    const onError = vi.fn();
+
+    render(
+      <BitmapImageFrameView frame={videoFrame(false)} onError={onError} />,
+    );
+
+    await waitFor(() =>
+      expect(onError).toHaveBeenCalledWith(
+        new Error("H.264 video frame data is unavailable"),
+      ),
+    );
+  });
 });
 
 describe("BitmapCanvasHost", () => {
@@ -989,14 +1003,14 @@ function depthFrame(): RawImageVisualization {
   };
 }
 
-function videoFrame(): EncodedVideoVisualization {
+function videoFrame(hasFrame = true): EncodedVideoVisualization {
   return {
     bytes: Uint8Array.of(0, 0, 1, 0x65),
     codec: "h264",
     format: "h264",
     h264: {
       codecString: "avc1.4D001F",
-      hasFrame: true,
+      hasFrame,
       pps: Uint8Array.of(0x68, 0xce),
       sps: Uint8Array.of(0x67, 0x4d, 0x00, 0x1f),
     },

--- a/app/packages/multimodal/src/visualization/media-2d/BitmapImageView.test.tsx
+++ b/app/packages/multimodal/src/visualization/media-2d/BitmapImageView.test.tsx
@@ -697,6 +697,7 @@ describe("BitmapImageFrameView", () => {
         frame={frames[0]}
         onCanvasCommitted={onCanvasCommitted}
         onImageLoaded={onImageLoaded}
+        videoPriority="playing"
       />,
     );
     for (let index = 1; index < frames.length; index += 1) {
@@ -706,6 +707,7 @@ describe("BitmapImageFrameView", () => {
           frame={frames[index]}
           onCanvasCommitted={onCanvasCommitted}
           onImageLoaded={onImageLoaded}
+          videoPriority="playing"
         />,
       );
       await act(async () => {

--- a/app/packages/multimodal/src/visualization/media-2d/BitmapImageView.tsx
+++ b/app/packages/multimodal/src/visualization/media-2d/BitmapImageView.tsx
@@ -42,6 +42,7 @@ import {
   useOptionalVideoPlaybackManager,
   useVideoStreamPresentation,
 } from "../../video/react";
+import type { VideoIntentPriority } from "../../video/types";
 import { useLatestRef } from "./use-latest-ref";
 import { fittedImageSize } from "./image-fit";
 import { rawImageRgba } from "./raw-image-rgba";
@@ -135,6 +136,8 @@ export interface BitmapImageFrameViewProps {
     size: BitmapDrawSize,
   ) => void;
   readonly style?: CSSProperties;
+  /** Playback admission priority for encoded-video frames. */
+  readonly videoPriority?: VideoIntentPriority;
   /** Stable source/stream owner key for encoded-video decoder cleanup. */
   readonly videoSessionKey?: string;
 }
@@ -502,6 +505,7 @@ export function BitmapImageFrameView({
   onError,
   onImageLoaded,
   style,
+  videoPriority,
   videoSessionKey,
 }: BitmapImageFrameViewProps) {
   if (frame.kind === "encoded-video") {
@@ -515,6 +519,7 @@ export function BitmapImageFrameView({
         onCanvasCommitted={onCanvasCommitted}
         onImageLoaded={onImageLoaded}
         style={style}
+        videoPriority={videoPriority}
         videoSessionKey={videoSessionKey}
       />
     );
@@ -555,6 +560,7 @@ function BitmapEncodedVideoView({
   onCanvasCommitted,
   onImageLoaded,
   style,
+  videoPriority = "visible",
   videoSessionKey,
 }: Omit<BitmapImageFrameViewProps, "frame"> & {
   readonly frame: EncodedVideoVisualization;
@@ -632,7 +638,7 @@ function BitmapEncodedVideoView({
       (contextManager !== null || hasPrivateRunway),
     frame: frame.codec === "h264" ? frame : null,
     manager,
-    priority: "visible",
+    priority: videoPriority,
     stream: previewTextureKey,
     targetTimeNs,
   });

--- a/app/packages/multimodal/src/visualization/media-2d/BitmapImageView.tsx
+++ b/app/packages/multimodal/src/visualization/media-2d/BitmapImageView.tsx
@@ -44,6 +44,7 @@ import {
 } from "../../video/react";
 import {
   isSharedEncodedVideoVisualization,
+  sharedVideoRejectionMessage,
   type VideoIntentPriority,
 } from "../../video/types";
 import { useLatestRef } from "./use-latest-ref";
@@ -693,9 +694,7 @@ function BitmapEncodedVideoView({
 
   useEffect(() => {
     if (!sharedVideo) {
-      onErrorRef.current?.(
-        new Error(`Video codec ${frame.codec} is unsupported`),
-      );
+      onErrorRef.current?.(new Error(sharedVideoRejectionMessage(frame)));
       return;
     }
     if (targetTimeNs === null) {
@@ -720,7 +719,7 @@ function BitmapEncodedVideoView({
     }
   }, [
     contextManager,
-    frame.codec,
+    frame,
     hasPrivateRunway,
     localManager,
     onErrorRef,

--- a/app/packages/multimodal/src/visualization/media-2d/BitmapImageView.tsx
+++ b/app/packages/multimodal/src/visualization/media-2d/BitmapImageView.tsx
@@ -42,7 +42,10 @@ import {
   useOptionalVideoPlaybackManager,
   useVideoStreamPresentation,
 } from "../../video/react";
-import type { VideoIntentPriority } from "../../video/types";
+import {
+  isSharedEncodedVideoVisualization,
+  type VideoIntentPriority,
+} from "../../video/types";
 import { useLatestRef } from "./use-latest-ref";
 import { fittedImageSize } from "./image-fit";
 import { rawImageRgba } from "./raw-image-rgba";
@@ -602,6 +605,7 @@ function BitmapEncodedVideoView({
     ownedManager?.key === previewTextureKey ? ownedManager.manager : null;
   const manager = contextManager ?? localManager;
   const targetTimeNs = frame.timestampNs ?? null;
+  const sharedVideo = isSharedEncodedVideoVisualization(frame);
   const hasPrivateRunway =
     targetTimeNs !== null &&
     (frame.keyframe ||
@@ -613,7 +617,7 @@ function BitmapEncodedVideoView({
     if (
       contextManager ||
       ownedManager?.key !== previewTextureKey ||
-      frame.codec !== "h264" ||
+      !sharedVideo ||
       targetTimeNs === null ||
       !hasPrivateRunway
     ) {
@@ -629,14 +633,15 @@ function BitmapEncodedVideoView({
     hasPrivateRunway,
     ownedManager,
     previewTextureKey,
+    sharedVideo,
     targetTimeNs,
   ]);
   const snapshot = useVideoStreamPresentation({
     enabled:
-      frame.codec === "h264" &&
+      sharedVideo &&
       targetTimeNs !== null &&
       (contextManager !== null || hasPrivateRunway),
-    frame: frame.codec === "h264" ? frame : null,
+    frame: sharedVideo ? frame : null,
     manager,
     priority: videoPriority,
     stream: previewTextureKey,
@@ -687,27 +692,26 @@ function BitmapEncodedVideoView({
   ]);
 
   useEffect(() => {
-    if (frame.codec !== "h264") {
+    if (!sharedVideo) {
       onErrorRef.current?.(
         new Error(`Video codec ${frame.codec} is unsupported`),
       );
       return;
     }
-    if (frame.codec === "h264" && targetTimeNs === null) {
+    if (targetTimeNs === null) {
       onErrorRef.current?.(
-        new Error("H.264 preview frame is missing a presentation timestamp"),
+        new Error("Video preview frame is missing a presentation timestamp"),
       );
       return;
     }
     if (
-      frame.codec === "h264" &&
       targetTimeNs !== null &&
       contextManager === null &&
       localManager !== null &&
       !hasPrivateRunway
     ) {
       onErrorRef.current?.(
-        new Error("H.264 preview is waiting for a keyframe"),
+        new Error("Video preview is waiting for a keyframe"),
       );
       return;
     }
@@ -720,6 +724,7 @@ function BitmapEncodedVideoView({
     hasPrivateRunway,
     localManager,
     onErrorRef,
+    sharedVideo,
     snapshot.diagnostic,
     targetTimeNs,
   ]);

--- a/app/packages/multimodal/src/visualization/media-2d/VideoPanel.tsx
+++ b/app/packages/multimodal/src/visualization/media-2d/VideoPanel.tsx
@@ -5,9 +5,11 @@ import {
   type ReactNode,
 } from "react";
 
-import type { EncodedVideoVisualization } from "../../ir";
 import { useVideoStreamPresentation } from "../../video/react";
-import type { VideoIntentPriority } from "../../video/types";
+import type {
+  SharedEncodedVideoVisualization,
+  VideoIntentPriority,
+} from "../../video/types";
 import {
   Base2dScene,
   ImageTexturePlane,
@@ -26,7 +28,7 @@ export interface VideoPanelProps {
   readonly canvasSurface?: string;
   readonly className?: string;
   readonly fit?: "contain" | "cover";
-  readonly frame: EncodedVideoVisualization;
+  readonly frame: SharedEncodedVideoVisualization;
   readonly notices?: readonly PanelNotice[];
   readonly onImageLoaded?: (width: number, height: number) => void;
   readonly onResetView?: () => void;

--- a/app/packages/multimodal/src/visualization/media-2d/VideoPanel.tsx
+++ b/app/packages/multimodal/src/visualization/media-2d/VideoPanel.tsx
@@ -5,7 +5,7 @@ import {
   type ReactNode,
 } from "react";
 
-import type { EncodedH264VideoVisualization } from "../../ir";
+import type { EncodedVideoVisualization } from "../../ir";
 import { useVideoStreamPresentation } from "../../video/react";
 import type { VideoIntentPriority } from "../../video/types";
 import {
@@ -26,7 +26,7 @@ export interface VideoPanelProps {
   readonly canvasSurface?: string;
   readonly className?: string;
   readonly fit?: "contain" | "cover";
-  readonly frame: EncodedH264VideoVisualization;
+  readonly frame: EncodedVideoVisualization;
   readonly notices?: readonly PanelNotice[];
   readonly onImageLoaded?: (width: number, height: number) => void;
   readonly onResetView?: () => void;
@@ -39,7 +39,7 @@ export interface VideoPanelProps {
   readonly viewTransform?: ImageViewTransform;
 }
 
-/** Dedicated H.264 sibling of ImagePanel backed by the source video engine. */
+/** Dedicated encoded-video sibling of ImagePanel backed by the source engine. */
 export function VideoPanel({
   alt = "Video",
   canvasSurface,

--- a/app/packages/multimodal/src/visualization/plot/TimeseriesChart.test.tsx
+++ b/app/packages/multimodal/src/visualization/plot/TimeseriesChart.test.tsx
@@ -176,19 +176,19 @@ describe("TimeseriesChart interactions", () => {
     fireEvent.click(screen.getByLabelText("Zoom in"));
     expect(resetZoom.getAttribute("data-active")).toBe("true");
     expect(chart.scales.x).toEqual({ min: 2, max: 18 });
-    expect(chart.scales.y).toEqual({ min: 1, max: 9 });
+    // The y domain seeds from the data ([1, 2] padded to [0.95, 2.05]),
+    // so zooming in scales that window rather than the mock's preset.
+    expect(chart.scales.y.min).toBeCloseTo(1.06, 6);
+    expect(chart.scales.y.max).toBeCloseTo(1.94, 6);
     expect(chart.setScale).toHaveBeenCalledWith("x", {
       min: 2,
       max: 18,
     });
-    expect(chart.setScale).toHaveBeenCalledWith("y", {
-      min: 1,
-      max: 9,
-    });
 
     fireEvent.click(screen.getByLabelText("Zoom out"));
     expect(chart.scales.x).toEqual({ min: 0, max: 20 });
-    expect(chart.scales.y).toEqual({ min: 0, max: 10 });
+    expect(chart.scales.y.min).toBeCloseTo(0.95, 6);
+    expect(chart.scales.y.max).toBeCloseTo(2.05, 6);
 
     chart.setData.mockClear();
     chart.over.dispatchEvent(new MouseEvent("dblclick", { bubbles: true }));
@@ -282,9 +282,10 @@ describe("TimeseriesChart interactions", () => {
         series={[{ color: "#f00", label: "speed" }]}
       />,
     );
+    // The mount seed ([0.95, 2.05] from the initial data) only expands.
     expect(chart.setScale).toHaveBeenLastCalledWith("y", {
-      max: 10,
-      min: 0,
+      max: 5.05,
+      min: 0.95,
     });
 
     const wider = [
@@ -302,6 +303,90 @@ describe("TimeseriesChart interactions", () => {
     expect(chart.setScale).toHaveBeenLastCalledWith("y", {
       max: 32.5,
       min: -22.5,
+    });
+    unmount();
+  });
+
+  it("sources the stable y domain from the intended window, not mid-commit scales", () => {
+    const { rerender, unmount } = renderChart();
+    const chart = lastChart();
+    // Simulate uPlot mid-commit: the x scale reads as a degenerate window
+    // while newly published data arrives. The y domain must come from the
+    // intended follow window, never from this transient scale state.
+    chart.scales.x.min = 0;
+    chart.scales.x.max = 0;
+    chart.setScale.mockClear();
+
+    const arrived = [
+      [0, 10, 20],
+      [1, -80, 90],
+    ] as AlignedData;
+    rerender(
+      <TimeseriesChart
+        {...FOLLOW_POLICY_PROPS}
+        data={arrived}
+        durationSec={20}
+        series={[{ color: "#f00", label: "speed" }]}
+      />,
+    );
+    const lastY = chart.setScale.mock.calls
+      .filter((call) => call[0] === "y")
+      .at(-1)?.[1] as { max: number; min: number };
+    expect(lastY.min).toBeLessThanOrEqual(-80);
+    expect(lastY.max).toBeGreaterThanOrEqual(90);
+    unmount();
+  });
+
+  it("ignores its own asynchronously committed y writes but adopts user zooms", () => {
+    const { rerender, unmount } = renderChart();
+    const chart = lastChart();
+    const fireSetScale = (key: string) => {
+      const hooks = chart.options.hooks?.setScale;
+      for (const hook of Array.isArray(hooks) ? hooks : [hooks]) {
+        (hook as (chart: MockChart, key: string) => void)(chart, key);
+      }
+    };
+
+    // An own write committing late must not be misread as a user zoom:
+    // the stable domain keeps expanding from the seeded range afterwards.
+    fireSetScale("y");
+    const wider = [
+      [0, 10, 20],
+      [-20, 30, 0],
+    ] as AlignedData;
+    rerender(
+      <TimeseriesChart
+        {...FOLLOW_POLICY_PROPS}
+        data={wider}
+        durationSec={20}
+        series={[{ color: "#f00", label: "speed" }]}
+      />,
+    );
+    expect(chart.setScale).toHaveBeenLastCalledWith("y", {
+      max: 32.5,
+      min: -22.5,
+    });
+
+    // A range this surface never wrote is a real user zoom and becomes
+    // the new stable domain that later data only expands.
+    chart.scales.y.min = -50;
+    chart.scales.y.max = 60;
+    fireSetScale("y");
+    const narrower = [
+      [0, 10, 20],
+      [4, 5, 4],
+    ] as AlignedData;
+    rerender(
+      <TimeseriesChart
+        {...FOLLOW_POLICY_PROPS}
+        data={narrower}
+        durationSec={20}
+        series={[{ color: "#f00", label: "speed" }]}
+      />,
+    );
+    expect(chart.setScale).toHaveBeenLastCalledWith("y", {
+      max: 60,
+      min: -50,
     });
     unmount();
   });

--- a/app/packages/multimodal/src/visualization/plot/TimeseriesChart.tsx
+++ b/app/packages/multimodal/src/visualization/plot/TimeseriesChart.tsx
@@ -222,26 +222,38 @@ function finiteYRange(
   return [min - padding, max + padding];
 }
 
+/** Recent own y writes retained to recognize their asynchronous commits. */
+const OWN_Y_WRITE_HISTORY = 4;
+
+/**
+ * Expands the stable y domain from the finite data inside `window` and
+ * applies it. The window is the caller's intended x viewport, never
+ * `chart.scales.x`: uPlot commits scale writes asynchronously, so reading
+ * scales mid-update can source a degenerate window and freeze the domain
+ * on a garbage range. Every write is remembered so the y setScale hook can
+ * tell this surface's own commits apart from a user zoom.
+ */
 function setStableYRange(
   chart: uPlot,
   data: AlignedData,
   stableRef: React.MutableRefObject<readonly [number, number] | null>,
-  settingRef: React.MutableRefObject<boolean>,
+  ownWritesRef: React.MutableRefObject<(readonly [number, number])[]>,
+  window: readonly [number, number],
   reset: boolean,
 ): void {
   if (reset) stableRef.current = null;
-  const xMin = chart.scales.x.min ?? 0;
-  const xMax = chart.scales.x.max ?? xMin;
-  const candidate = finiteYRange(data, xMin, xMax);
+  const candidate = finiteYRange(data, window[0], window[1]);
   if (!candidate) return;
   const previous = stableRef.current;
   const stable: readonly [number, number] = previous
     ? [Math.min(previous[0], candidate[0]), Math.max(previous[1], candidate[1])]
     : candidate;
   stableRef.current = stable;
-  settingRef.current = true;
+  ownWritesRef.current.push(stable);
+  if (ownWritesRef.current.length > OWN_Y_WRITE_HISTORY) {
+    ownWritesRef.current.shift();
+  }
   chart.setScale("y", { min: stable[0], max: stable[1] });
-  settingRef.current = false;
 }
 
 function renderCoverageBands(
@@ -357,7 +369,8 @@ const TimeseriesChart: React.FC<TimeseriesChartProps> = ({
   const [zoomConstrained, setZoomConstrained] = useState(false);
   const coverageLayerRef = useRef<HTMLDivElement | null>(null);
   const stableYRangeRef = useRef<readonly [number, number] | null>(null);
-  const settingStableYRef = useRef(false);
+  const ownYWritesRef = useRef<(readonly [number, number])[]>([]);
+  const stableXWindowRef = useRef<readonly [number, number]>([0, 0]);
   const dataRef = useRef(data);
   dataRef.current = data;
   const seriesRef = useRef(series);
@@ -436,6 +449,8 @@ const TimeseriesChart: React.FC<TimeseriesChartProps> = ({
     hasInteractiveScaleRef.current = false;
     setZoomConstrained(false);
     stableYRangeRef.current = null;
+    ownYWritesRef.current = [];
+    stableXWindowRef.current = [0, xMax];
     const xLimits = [0, xMax] as const;
     let viewportFrame: number | undefined;
     let stableViewportKey = "";
@@ -500,14 +515,20 @@ const TimeseriesChart: React.FC<TimeseriesChartProps> = ({
         setScale: [
           (chart, key) => {
             if (key === "x") {
-              const viewportKey = `${chart.scales.x.min}:${chart.scales.x.max}`;
+              const xWindow: readonly [number, number] = [
+                chart.scales.x.min ?? 0,
+                chart.scales.x.max ?? xMax,
+              ];
+              stableXWindowRef.current = xWindow;
+              const viewportKey = `${xWindow[0]}:${xWindow[1]}`;
               if (viewportKey !== stableViewportKey) {
                 stableViewportKey = viewportKey;
                 setStableYRange(
                   chart,
                   dataRef.current,
                   stableYRangeRef,
-                  settingStableYRef,
+                  ownYWritesRef,
+                  xWindow,
                   true,
                 );
               }
@@ -518,10 +539,19 @@ const TimeseriesChart: React.FC<TimeseriesChartProps> = ({
                 unavailableRangesRef.current,
               );
               queueViewportPublication(chart);
-            } else if (key === "y" && !settingStableYRef.current) {
+            } else if (key === "y") {
               const min = chart.scales.y.min;
               const max = chart.scales.y.max;
-              if (min !== undefined && max !== undefined) {
+              if (min === undefined || max === undefined) {
+                return;
+              }
+              // Own writes commit asynchronously, possibly after a newer
+              // write superseded them; only a range this surface never set
+              // is a user zoom worth adopting as the stable domain.
+              const own = ownYWritesRef.current.some(
+                (write) => write[0] === min && write[1] === max,
+              );
+              if (!own) {
                 stableYRangeRef.current = [min, max];
               }
             }
@@ -563,12 +593,16 @@ const TimeseriesChart: React.FC<TimeseriesChartProps> = ({
     const chart = new uPlot(options, dataRef.current, host);
     chartRef.current = chart;
     chart.setScale("x", { min: 0, max: xMax });
-    const initialYMin = chart.scales.y.min;
-    const initialYMax = chart.scales.y.max;
-    stableYRangeRef.current =
-      initialYMin !== undefined && initialYMax !== undefined
-        ? [initialYMin, initialYMax]
-        : null;
+    // Seed the y domain from the data over the intended follow window; the
+    // chart's own scales may not have committed yet at this point.
+    setStableYRange(
+      chart,
+      dataRef.current,
+      stableYRangeRef,
+      ownYWritesRef,
+      [0, xMax],
+      true,
+    );
 
     const coverageLayer = document.createElement("div");
     coverageLayer.className = styles.coverageLayer;
@@ -890,7 +924,14 @@ const TimeseriesChart: React.FC<TimeseriesChartProps> = ({
       return;
     }
     chart.setData(data, false);
-    setStableYRange(chart, data, stableYRangeRef, settingStableYRef, false);
+    setStableYRange(
+      chart,
+      data,
+      stableYRangeRef,
+      ownYWritesRef,
+      stableXWindowRef.current,
+      false,
+    );
     chart.redraw();
     if (!pointerInsideRef.current) {
       syncLegendCursor(

--- a/app/packages/multimodal/src/visualization/plot/TimeseriesChart.tsx
+++ b/app/packages/multimodal/src/visualization/plot/TimeseriesChart.tsx
@@ -592,7 +592,11 @@ const TimeseriesChart: React.FC<TimeseriesChartProps> = ({
 
     const chart = new uPlot(options, dataRef.current, host);
     chartRef.current = chart;
-    chart.setScale("x", { min: 0, max: xMax });
+    // A bare setScale on a freshly constructed chart may never commit, and
+    // an uncommitted x scale strokes nothing. The reset batch — setData with
+    // a scale reset plus the explicit x range — is the sequence uPlot
+    // reliably commits, so the first paint always has real scales.
+    resetTimeseriesChart(chart, dataRef.current, [0, xMax]);
     // Seed the y domain from the data over the intended follow window; the
     // chart's own scales may not have committed yet at this point.
     setStableYRange(
@@ -924,6 +928,12 @@ const TimeseriesChart: React.FC<TimeseriesChartProps> = ({
       return;
     }
     chart.setData(data, false);
+    if (chart.scales.x.min == null || chart.scales.x.max == null) {
+      // A chart that missed its initial scale commit (created mid-transition,
+      // superseded by a recreation) strokes nothing; give it the committing
+      // reset sequence over the intended window once.
+      resetTimeseriesChart(chart, data, stableXWindowRef.current);
+    }
     setStableYRange(
       chart,
       data,

--- a/app/packages/multimodal/src/visualization/scene-3d/types.ts
+++ b/app/packages/multimodal/src/visualization/scene-3d/types.ts
@@ -3,7 +3,7 @@ import * as THREE from "three";
 
 import type {
   CameraCalibrationVisualization,
-  EncodedH264VideoVisualization,
+  EncodedVideoVisualization,
   GridVisualization,
   ImageVisualization,
   PointCloudVisualization,
@@ -299,8 +299,8 @@ export interface CameraFrustumPanelLayer {
   readonly frameTransform?: PointCloudFrameTransform;
   readonly id: string;
   readonly image?: ImageVisualization;
-  /** H.264 content is presented by the source-scoped video engine. */
-  readonly video?: EncodedH264VideoVisualization;
+  /** Encoded content is presented by the source-scoped video engine. */
+  readonly video?: EncodedVideoVisualization;
   readonly imageContentTimeNs?: bigint;
   /**
    * Presentational distance from optical center to image plane, in scene

--- a/app/packages/multimodal/src/visualization/scene-3d/types.ts
+++ b/app/packages/multimodal/src/visualization/scene-3d/types.ts
@@ -3,12 +3,12 @@ import * as THREE from "three";
 
 import type {
   CameraCalibrationVisualization,
-  EncodedVideoVisualization,
   GridVisualization,
   ImageVisualization,
   PointCloudVisualization,
   SceneUpdateVisualization,
 } from "../../ir";
+import type { SharedEncodedVideoVisualization } from "../../video/types";
 import type {
   ThreeCameraPose,
   ThreeCameraPoseChangeSource,
@@ -300,7 +300,7 @@ export interface CameraFrustumPanelLayer {
   readonly id: string;
   readonly image?: ImageVisualization;
   /** Encoded content is presented by the source-scoped video engine. */
-  readonly video?: EncodedVideoVisualization;
+  readonly video?: SharedEncodedVideoVisualization;
   readonly imageContentTimeNs?: bigint;
   /**
    * Presentational distance from optical center to image plane, in scene

--- a/app/packages/utilities/src/fetch.test.ts
+++ b/app/packages/utilities/src/fetch.test.ts
@@ -45,6 +45,17 @@ describe("fetch", () => {
     });
   });
 
+  it("resolves configured paths and preserves absolute URLs", () => {
+    setFetchFunction("http://localhost:5151", {}, "/proxy");
+
+    expect(getFetchUrl("/dataset/sample/asset")).toBe(
+      "http://localhost:5151/proxy/dataset/sample/asset",
+    );
+    expect(getFetchUrl("https://signed.example/video.mp4?token=secret")).toBe(
+      "https://signed.example/video.mp4?token=secret",
+    );
+  });
+
   it("forwards external abort signals", async () => {
     const mockFetch = vi.fn(
       (_url: string, init: RequestInit) =>

--- a/app/packages/utilities/src/fetch.ts
+++ b/app/packages/utilities/src/fetch.ts
@@ -328,12 +328,26 @@ const joinFetchUrl = (
   return `${base}/${relative}`;
 };
 
+const resolveFetchUrl = (
+  origin: string | undefined,
+  pathPrefix: string,
+  path: string,
+): string => {
+  try {
+    new URL(path);
+    return path;
+  } catch {
+    if (typeof origin !== "string") {
+      throw new Error("Fetch parameters are not configured");
+    }
+
+    return joinFetchUrl(origin, pathPrefix, path);
+  }
+};
+
 /** Builds an absolute URL from the configured fetch origin and path prefix. */
 export const getFetchUrl = (path: string): string => {
-  if (typeof fetchOrigin !== "string") {
-    throw new Error("Fetch parameters are not configured");
-  }
-  return joinFetchUrl(fetchOrigin, fetchPathPrefix, path);
+  return resolveFetchUrl(fetchOrigin, fetchPathPrefix, path);
 };
 
 // Identical GraphQL QUERIES that are in flight at the same moment share one
@@ -383,16 +397,8 @@ export const setFetchFunction = (
     signal,
     onProgress,
   ) => {
-    let url: string;
     const controller = new AbortController();
-
-    try {
-      // if a valid URL is provided, make no adjustments
-      new URL(path);
-      url = path;
-    } catch {
-      url = joinFetchUrl(origin, fetchPathPrefix, path);
-    }
+    const url = resolveFetchUrl(origin, fetchPathPrefix, path);
 
     // set content type only if body is present, otherwise it can cause Bad Request
     // errors for endpoints that don't expect a body

--- a/fiftyone/multimodal/media.py
+++ b/fiftyone/multimodal/media.py
@@ -649,14 +649,17 @@ class _MediaAssetManifest:
         assets = []
         for asset in self.assets:
             description = asset.description
-            assets.append(
-                {
-                    "asset_id": asset.asset_id,
-                    "role": description.role.value,
-                    "size_bytes": asset.size_bytes,
-                    "media_type": asset.media_type,
-                }
-            )
+            public = {
+                "asset_id": asset.asset_id,
+                "role": description.role.value,
+                "selector": _serialize_selector(description.selector),
+                "size_bytes": asset.size_bytes,
+                "media_type": asset.media_type,
+            }
+            if description.feature_name is not None:
+                public["feature_name"] = description.feature_name
+
+            assets.append(public)
 
         return {"assets": assets}
 

--- a/tests/unittests/multimodal/lerobot_tests.py
+++ b/tests/unittests/multimodal/lerobot_tests.py
@@ -2035,21 +2035,31 @@ class LeRobotServerTests(unittest.TestCase):
             self.assertNotIn(root, encoded)
             self.assertNotIn("relative_path", encoded)
             self.assertNotIn("locator", encoded)
-            self.assertNotIn("selector", encoded)
-            self.assertNotIn("feature_name", encoded)
             self.assertNotIn("fingerprint", encoded)
+            required_asset_keys = {
+                "asset_id",
+                "role",
+                "selector",
+                "size_bytes",
+                "media_type",
+                "url",
+            }
             self.assertTrue(
                 all(
-                    set(asset)
-                    == {
-                        "asset_id",
-                        "role",
-                        "size_bytes",
-                        "media_type",
-                        "url",
-                    }
+                    required_asset_keys
+                    <= set(asset)
+                    <= required_asset_keys | {"feature_name"}
                     for asset in manifest["assets"]
                 )
+            )
+            video = next(
+                asset
+                for asset in manifest["assets"]
+                if asset["role"] == "video-stream"
+            )
+            self.assertEqual(video["feature_name"], _VIDEO_FEATURE)
+            self.assertEqual(
+                video["selector"]["kind"], "video-timestamp-interval"
             )
             self.assertTrue(
                 {


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

Add synchronized LeRobot v3 episode playback to the multimodal viewer. The App resolves episode assets, renders native grid previews and synchronized camera streams (including AV1 and reordered video), and adds exact state/action inspection with episode statistics.

## 🧪 How is this patch tested? If it is not, please explain why.

- `yarn workspace @fiftyone/multimodal check`
- `yarn vitest run packages/multimodal/src --no-coverage` (3,561 passed; 3 skipped)
- `yarn vitest run packages/utilities/src/fetch.test.ts --no-coverage` (8 passed)
- `pytest -q tests/unittests/multimodal/lerobot_tests.py` (31 passed)
- Imported a two-episode LeRobot v3 fixture in the App, verified grid posters and side/wrist camera pixels, and confirmed playback advanced from 0:00 to 0:02.65 with synchronized frame changes and no errors in the default layout.

## Notes to Reviewer

Best reviewed by path:

- `adapters/lerobot`, `ports`, and `runtime` for manifest, session, and playback contracts
- `video` and grid preview code for codec-agnostic synchronized decoding
- `views/episode/state-action` for exact-row inspection and statistics

## High Level Architecture

The LeRobot adapter resolves media-reference assets into format-neutral episode sessions. Shared video policy reads bounded decode runways and presents codec-agnostic access units through the existing playback engine. An optional state/action capability publishes exact rows and statistics to the LeRobot-only tile extension.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

FiftyOne can now visualize LeRobot v3 episodes with synchronized camera playback, native grid previews, and exact state/action inspection.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added State & Action tiles with row inspection, filtering, normalization, navigation, plotting, and statistics.
  * Added dataset and episode statistics, timing-gap analysis, tracking-error views, and seek controls.
  * Added native hover video previews with poster retention, playback errors, and AV1 support.
  * Expanded video playback for reordered frames and multiple codecs.
  * Added richer stream metadata, inspectability indicators, LeRobot recording details, asset selectors, and descriptive playback filenames.
* **Bug Fixes**
  * Improved URL resolution, synchronization ordering, cancellation handling, cursor errors, and video preview reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3955
<!-- enterprise-sync-pr:end -->