### PR TITLE
Stabilize viewport-driven MCAP plots

### DIFF
--- a/app/packages/multimodal/src/adapters/mcap/contracts/index.ts
+++ b/app/packages/multimodal/src/adapters/mcap/contracts/index.ts
@@ -422,11 +422,12 @@ export interface McapReadNumericSeriesSliceRequest {
   readonly absoluteBudget: ReadWorkBudget;
   readonly absoluteMaxChunks: number;
   readonly activeTimeline?: McapActiveTimeline;
+  /** Absolute-time-aligned aggregate resolution requested by the viewport. */
+  readonly bucketDurationNs: bigint;
   readonly budget: ReadWorkBudget;
   readonly continuation?: ReadContinuation;
   readonly endTimeNs: bigint;
   readonly maxChunks: number;
-  readonly maxPointsPerField?: number;
   readonly preferredTimeNs?: bigint;
   readonly selections: readonly McapNumericSeriesSelection[];
   readonly source: ByteSourceDescriptor;
@@ -445,6 +446,8 @@ export interface McapNumericSeriesSliceResult {
   readonly baseTimeNs: bigint;
   readonly continuation?: ReadContinuation;
   readonly coverageByTopic: ReadonlyMap<string, readonly TimeWindow[]>;
+  /** Earliest timestamp not yet inspected by a chronological continuation. */
+  readonly resumeAtNs?: bigint;
   /** Exact source spans omitted because one atomic unit exceeded the hard ceiling. */
   readonly skippedByTopic: ReadonlyMap<string, readonly TimeWindow[]>;
   readonly series: readonly McapNumericTopicSeries[];

--- a/app/packages/multimodal/src/adapters/mcap/contracts/index.ts
+++ b/app/packages/multimodal/src/adapters/mcap/contracts/index.ts
@@ -378,6 +378,8 @@ export interface McapReadNumericSeriesRequest {
  * render gaps.
  */
 export interface McapNumericSeriesField {
+  /** Exact absolute bucket identity for aligned bounded-read summaries. */
+  readonly bucketIndexes?: BigInt64Array;
   /** Per-decimation-bucket discontinuity bits, when decimation was applied. */
   readonly bucketGapMask?: Uint8Array;
   readonly path: string;

--- a/app/packages/multimodal/src/adapters/mcap/format-adapter.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/format-adapter.test.ts
@@ -1221,6 +1221,7 @@ describe("MCAP format adapter", () => {
       const slice = await session.numericSeries?.readNumericSeriesSlice?.({
         absoluteBudget: budget,
         absoluteMaxChunks: 2,
+        bucketDurationNs: 1_000_000_000n,
         budget,
         maxChunks: 1,
         selections: [{ fields: ["exposure"], stream: "camera" }],

--- a/app/packages/multimodal/src/adapters/mcap/format-adapter.ts
+++ b/app/packages/multimodal/src/adapters/mcap/format-adapter.ts
@@ -426,11 +426,11 @@ export function createMcapNumericSeriesCapability({
           absoluteBudget: request.absoluteBudget,
           absoluteMaxChunks: request.absoluteMaxChunks,
           activeTimeline: MCAP_ACTIVE_TIMELINE.LOG,
+          bucketDurationNs: request.bucketDurationNs,
           budget: request.budget,
           continuation: request.continuation,
           endTimeNs: request.window.endNs,
           maxChunks: request.maxChunks,
-          maxPointsPerField: request.maxPointsPerField,
           preferredTimeNs: request.preferredTimeNs,
           selections: request.selections.map((selection) => ({
             fieldPaths: selection.fields,
@@ -443,6 +443,9 @@ export function createMcapNumericSeriesCapability({
       );
       return {
         ...(result.continuation ? { continuation: result.continuation } : {}),
+        ...(result.resumeAtNs !== undefined
+          ? { resumeAtNs: result.resumeAtNs }
+          : {}),
         coverageByStream: new Map(
           [...result.coverageByTopic].map(([topic, windows]) => [
             streamsByTopic.get(topic) ?? topic,

--- a/app/packages/multimodal/src/adapters/mcap/resource-client/operations/read-numeric-series.test.ts
+++ b/app/packages/multimodal/src/adapters/mcap/resource-client/operations/read-numeric-series.test.ts
@@ -8,7 +8,6 @@ import { describe, expect, it, vi } from "vitest";
 import type { McapIndexedReaderLike, McapReadContinuation } from "../../reader";
 import { resolveMcapTimelineStrategy } from "../timeline";
 import {
-  numericSeriesSlicePointBudget,
   projectNumericField,
   readMcapNumericSeries,
   readMcapNumericSeriesSlice,
@@ -499,25 +498,6 @@ describe("readMcapNumericSeriesSlice", () => {
     maxWallTimeMs: 1_000,
   };
 
-  it("shares the viewport point budget across continuation coverage", () => {
-    const minute = 60_000_000_000n;
-    const firstSecond = [{ endNs: 999_999_999n, startNs: 0n }];
-    const fullMinute = [{ endNs: minute - 1n, startNs: 0n }];
-
-    expect(
-      numericSeriesSlicePointBudget(4_000, firstSecond, 0n, minute - 1n),
-    ).toBeLessThanOrEqual(72);
-    expect(
-      numericSeriesSlicePointBudget(4_000, fullMinute, 0n, minute - 1n),
-    ).toBeLessThanOrEqual(4_000);
-    expect(
-      numericSeriesSlicePointBudget(4_000, fullMinute, 0n, minute - 1n),
-    ).toBeGreaterThan(3_900);
-    expect(numericSeriesSlicePointBudget(4, firstSecond, 0n, minute - 1n)).toBe(
-      4,
-    );
-  });
-
   it("escalates a zero-coverage fallback scan to one atomic source unit", async () => {
     const continuation = {} as McapReadContinuation;
     const base = createReader({ messages: [] });
@@ -545,6 +525,7 @@ describe("readMcapNumericSeriesSlice", () => {
       request: {
         absoluteBudget: { ...budget, maxMessages: 250_000 },
         absoluteMaxChunks: 4,
+        bucketDurationNs: 1_000_000_000n,
         budget,
         endTimeNs: 2n,
         maxChunks: 1,
@@ -612,6 +593,7 @@ describe("readMcapNumericSeriesSlice", () => {
       request: {
         absoluteBudget: budget,
         absoluteMaxChunks: 4,
+        bucketDurationNs: 1_000_000_000n,
         budget,
         endTimeNs: 2_000_000_000n,
         maxChunks: 2,
@@ -679,6 +661,7 @@ describe("readMcapNumericSeriesSlice", () => {
       request: {
         absoluteBudget: budget,
         absoluteMaxChunks: 4,
+        bucketDurationNs: 1_000_000_000n,
         budget,
         endTimeNs: 2_000_000_000n,
         maxChunks: 2,
@@ -759,6 +742,7 @@ describe("readMcapNumericSeriesSlice", () => {
       request: {
         absoluteBudget,
         absoluteMaxChunks: 4,
+        bucketDurationNs: 1_000_000_000n,
         budget,
         endTimeNs: 2_000_000_000n,
         maxChunks: 1,

--- a/app/packages/multimodal/src/adapters/mcap/resource-client/operations/read-numeric-series.ts
+++ b/app/packages/multimodal/src/adapters/mcap/resource-client/operations/read-numeric-series.ts
@@ -19,8 +19,8 @@ import type {
   McapReadNumericSeriesSliceRequest,
 } from "../../contracts/index";
 import type { ReadWorkUsage } from "../../../../ports";
-import { NUMERIC_SERIES_MAX_BUCKET_SURVIVORS } from "../../../../ports/numeric-series";
 import { nsDeltaToSeconds } from "../../../../utils/nanoseconds";
+import { aggregateAlignedNumericSeries } from "../../../../utils/numeric-series-buckets";
 import { decimateMinMax } from "../numeric-series-decimate";
 import { mcapTimelineRangeFromReader } from "./read-timeline-range";
 import { throwIfAborted } from "../../../../utils/cancellation";
@@ -363,19 +363,13 @@ export async function readMcapNumericSeriesSlice({
     usage: () => usage,
   });
 
-  const maxPoints =
-    request.maxPointsPerField ?? DEFAULT_NUMERIC_SERIES_MAX_POINTS;
   const series: McapNumericTopicSeries[] = [];
   for (const accumulator of accumulatorsByTopic.values()) {
     series.push(
-      finalizeNumericSeries(
+      finalizeAlignedNumericSeries(
         accumulator,
-        numericSeriesSlicePointBudget(
-          maxPoints,
-          bounded.coverageByTopic.get(accumulator.topic) ?? [],
-          request.startTimeNs,
-          request.endTimeNs,
-        ),
+        baseTimeNs,
+        request.bucketDurationNs,
       ),
     );
   }
@@ -384,50 +378,14 @@ export async function readMcapNumericSeriesSlice({
     baseTimeNs,
     ...(bounded.continuation ? { continuation: bounded.continuation } : {}),
     coverageByTopic: bounded.coverageByTopic,
+    ...(bounded.resumeAtNs !== undefined
+      ? { resumeAtNs: bounded.resumeAtNs }
+      : {}),
     skippedByTopic: bounded.skippedByTopic ?? new Map(),
     series,
     stopReason: bounded.stopReason,
     usage,
   };
-}
-
-/**
- * Allocates an M4 survivor budget in proportion to this page's inspected
- * share of the requested viewport. Continuation pages therefore converge on
- * the viewport budget instead of each independently consuming all of it.
- */
-export function numericSeriesSlicePointBudget(
-  maxPoints: number,
-  coverage: readonly { readonly endNs: bigint; readonly startNs: bigint }[],
-  startTimeNs: bigint,
-  endTimeNs: bigint,
-): number {
-  if (!Number.isFinite(maxPoints) || coverage.length === 0) return maxPoints;
-  const budget = Math.max(0, Math.floor(maxPoints));
-  const globalBuckets = Math.floor(
-    (budget - 2) / NUMERIC_SERIES_MAX_BUCKET_SURVIVORS,
-  );
-  if (globalBuckets < 1 || endTimeNs < startTimeNs) return budget;
-
-  const viewportDurationNs = endTimeNs - startTimeNs + 1n;
-  const coveredDurationNs = coverage.reduce(
-    (sum, range) => sum + (range.endNs - range.startNs + 1n),
-    0n,
-  );
-  const boundedCoveredDurationNs =
-    coveredDurationNs < viewportDurationNs
-      ? coveredDurationNs
-      : viewportDurationNs;
-  const pageBuckets = Number(
-    (BigInt(globalBuckets) * boundedCoveredDurationNs +
-      viewportDurationNs -
-      1n) /
-      viewportDurationNs,
-  );
-  return Math.min(
-    budget,
-    2 + pageBuckets * NUMERIC_SERIES_MAX_BUCKET_SURVIVORS,
-  );
 }
 
 function createNumericSeriesAccumulator(
@@ -485,6 +443,31 @@ function finalizeNumericSeries(
         path,
         timesSec: decimated.times,
         values: decimated.values,
+      };
+    }),
+    messageCount: accumulator.messageCount,
+    topic: accumulator.topic,
+  };
+}
+
+function finalizeAlignedNumericSeries(
+  accumulator: NumericSeriesAccumulator,
+  baseTimeNs: bigint,
+  bucketDurationNs: bigint,
+): McapNumericTopicSeries {
+  const sharedTimes = Float64Array.from(accumulator.times);
+  return {
+    fields: accumulator.fieldPaths.map((path, index) => {
+      const aggregated = aggregateAlignedNumericSeries(
+        sharedTimes,
+        Float64Array.from(accumulator.valuesByField[index]),
+        baseTimeNs,
+        bucketDurationNs,
+      );
+      return {
+        path,
+        timesSec: aggregated.timesSec,
+        values: aggregated.values,
       };
     }),
     messageCount: accumulator.messageCount,

--- a/app/packages/multimodal/src/adapters/mcap/resource-client/operations/read-numeric-series.ts
+++ b/app/packages/multimodal/src/adapters/mcap/resource-client/operations/read-numeric-series.ts
@@ -20,7 +20,10 @@ import type {
 } from "../../contracts/index";
 import type { ReadWorkUsage } from "../../../../ports";
 import { nsDeltaToSeconds } from "../../../../utils/nanoseconds";
-import { aggregateAlignedNumericSeries } from "../../../../utils/numeric-series-buckets";
+import {
+  aggregateAlignedNumericSeries,
+  numericSeriesBucketIndex,
+} from "../../../../utils/numeric-series-buckets";
 import { decimateMinMax } from "../numeric-series-decimate";
 import { mcapTimelineRangeFromReader } from "./read-timeline-range";
 import { throwIfAborted } from "../../../../utils/cancellation";
@@ -42,7 +45,7 @@ const MAX_SCAN_MESSAGES = 500_000;
 interface NumericSeriesAccumulator {
   readonly fieldPaths: readonly string[];
   readonly pathSegments: readonly (readonly string[])[];
-  readonly times: number[];
+  readonly timesNs: bigint[];
   readonly topic: string;
   readonly valuesByField: number[][];
   messageCount: number;
@@ -214,7 +217,6 @@ export async function readMcapNumericSeries({
       accumulator,
       message.data,
       timeline.messageTimeNs(message),
-      baseTimeNs,
       decodersByChannelId.get(message.channelId),
     );
   }
@@ -222,7 +224,7 @@ export async function readMcapNumericSeries({
 
   const maxPoints =
     request.maxPointsPerField ?? DEFAULT_NUMERIC_SERIES_MAX_POINTS;
-  const finalized = finalizeNumericSeries(accumulator, maxPoints);
+  const finalized = finalizeNumericSeries(accumulator, baseTimeNs, maxPoints);
 
   return {
     baseTimeNs,
@@ -355,7 +357,6 @@ export async function readMcapNumericSeriesSlice({
         selected.accumulator,
         message.data,
         timeline.messageTimeNs(message),
-        baseTimeNs,
         selected.decodeRecord,
       );
     },
@@ -396,7 +397,7 @@ function createNumericSeriesAccumulator(
     fieldPaths,
     messageCount: 0,
     pathSegments: fieldPaths.map((path) => path.split(".")),
-    times: [],
+    timesNs: [],
     topic,
     valuesByField: fieldPaths.map(() => []),
   };
@@ -406,10 +407,9 @@ function pushNumericSeriesMessage(
   accumulator: NumericSeriesAccumulator,
   data: Uint8Array,
   timeNs: bigint,
-  baseTimeNs: bigint,
   decodeRecord?: (data: Uint8Array) => Record<string, unknown>,
 ): void {
-  accumulator.times.push(nsDeltaToSeconds(timeNs - baseTimeNs));
+  accumulator.timesNs.push(timeNs);
   accumulator.messageCount += 1;
 
   let record: Record<string, unknown> | undefined;
@@ -428,9 +428,12 @@ function pushNumericSeriesMessage(
 
 function finalizeNumericSeries(
   accumulator: NumericSeriesAccumulator,
+  baseTimeNs: bigint,
   maxPoints: number,
 ): McapNumericTopicSeries {
-  const sharedTimes = Float64Array.from(accumulator.times);
+  const sharedTimes = Float64Array.from(accumulator.timesNs, (timeNs) =>
+    nsDeltaToSeconds(timeNs - baseTimeNs),
+  );
   return {
     fields: accumulator.fieldPaths.map((path, index) => {
       const decimated = decimateMinMax(
@@ -455,7 +458,12 @@ function finalizeAlignedNumericSeries(
   baseTimeNs: bigint,
   bucketDurationNs: bigint,
 ): McapNumericTopicSeries {
-  const sharedTimes = Float64Array.from(accumulator.times);
+  const sharedTimes = Float64Array.from(accumulator.timesNs, (timeNs) =>
+    nsDeltaToSeconds(timeNs - baseTimeNs),
+  );
+  const bucketIndexes = BigInt64Array.from(accumulator.timesNs, (timeNs) =>
+    numericSeriesBucketIndex(timeNs, bucketDurationNs),
+  );
   return {
     fields: accumulator.fieldPaths.map((path, index) => {
       const aggregated = aggregateAlignedNumericSeries(
@@ -463,8 +471,10 @@ function finalizeAlignedNumericSeries(
         Float64Array.from(accumulator.valuesByField[index]),
         baseTimeNs,
         bucketDurationNs,
+        bucketIndexes,
       );
       return {
+        bucketIndexes: aggregated.bucketIndexes,
         path,
         timesSec: aggregated.timesSec,
         values: aggregated.values,

--- a/app/packages/multimodal/src/ir/numeric.ts
+++ b/app/packages/multimodal/src/ir/numeric.ts
@@ -26,6 +26,8 @@ export interface NumericStreamFields {
 
 /** Packed recording-relative values for one requested numeric field. */
 export interface NumericSeriesField {
+  /** Exact absolute bucket identity for aligned bounded-read summaries. */
+  readonly bucketIndexes?: BigInt64Array;
   /** Per-decimation-bucket discontinuity bits, when supplied by the adapter. */
   readonly bucketGapMask?: Uint8Array;
   readonly path: string;

--- a/app/packages/multimodal/src/ports/session.ts
+++ b/app/packages/multimodal/src/ports/session.ts
@@ -397,10 +397,11 @@ export interface NumericSeriesSliceSelection {
 export interface NumericSeriesSliceRequest {
   readonly absoluteBudget: ReadWorkBudget;
   readonly absoluteMaxChunks: number;
+  /** Absolute-time-aligned aggregate resolution requested by the viewport. */
+  readonly bucketDurationNs: bigint;
   readonly budget: ReadWorkBudget;
   readonly continuation?: ReadContinuation;
   readonly maxChunks: number;
-  readonly maxPointsPerField?: number;
   readonly preferredTimeNs?: bigint;
   readonly selections: readonly NumericSeriesSliceSelection[];
   readonly signal?: AbortSignal;
@@ -411,6 +412,8 @@ export interface NumericSeriesSliceRequest {
 export interface NumericSeriesSliceResult {
   readonly continuation?: ReadContinuation;
   readonly coverageByStream: ReadonlyMap<StreamId, readonly TimeWindow[]>;
+  /** Earliest timestamp not yet inspected by a chronological continuation. */
+  readonly resumeAtNs?: bigint;
   /** Exact unreadable source spans, distinct from successfully inspected coverage. */
   readonly unavailableByStream?: ReadonlyMap<StreamId, readonly TimeWindow[]>;
   readonly series: readonly NumericSeriesResult[];

--- a/app/packages/multimodal/src/runtime/numeric-series-tile-cache.test.ts
+++ b/app/packages/multimodal/src/runtime/numeric-series-tile-cache.test.ts
@@ -42,6 +42,33 @@ describe("numeric-series tile cache", () => {
     ).toBe(13);
   });
 
+  it("assembles cached ranges independently of loading order", () => {
+    const forward = createCache({ maxBytes: 1_000, maxTiles: 10 });
+    const reverse = createCache({ maxBytes: 1_000, maxTiles: 10 });
+    const left = tile({ endSec: 9, timesSec: [2, 8], values: [2, 8] });
+    const right = tile({
+      endSec: 19,
+      startSec: 10,
+      timesSec: [12, 18],
+      values: [12, 18],
+    });
+    forward.put(left);
+    forward.put(right);
+    reverse.put(right);
+    reverse.put(left);
+    const demand = {
+      bucketDurationNs: SECOND,
+      range: secondsRange(0, 19),
+      seriesKey: "speed",
+    } as const;
+
+    expect(
+      forward.assembleVisible(demand).parts.map((part) => [...part.values]),
+    ).toEqual(
+      reverse.assembleVisible(demand).parts.map((part) => [...part.values]),
+    );
+  });
+
   it("retains explicit gap bits with mixed finite and NaN values", () => {
     const cache = createCache({ maxBytes: 1_000, maxTiles: 10 });
     cache.put(

--- a/app/packages/multimodal/src/runtime/numeric-series-tile-cache.test.ts
+++ b/app/packages/multimodal/src/runtime/numeric-series-tile-cache.test.ts
@@ -29,8 +29,9 @@ describe("numeric-series tile cache", () => {
     expect(visible.parts).toHaveLength(1);
     expect([...visible.parts[0].timesSec]).toEqual([3, 4, 5]);
     expect([...visible.parts[0].values]).toEqual([13, 14, 15]);
+    expect([...visible.parts[0].bucketIndexes]).toEqual([3n, 4n, 5n]);
     expect(visible.work.pointsCopied).toBe(3);
-    expect(cache.getStats().retainedBytes).toBe(10 * 2 * 8);
+    expect(cache.getStats().retainedBytes).toBe(10 * 3 * 8);
 
     visible.parts[0].values[0] = 999;
     expect(
@@ -87,7 +88,7 @@ describe("numeric-series tile cache", () => {
 
     expect([...part.values]).toEqual([1, Number.NaN, 3]);
     expect([...part.gapMask]).toEqual([0b00000010]);
-    expect(cache.getStats().retainedBytes).toBe(3 * 2 * 8 + 1);
+    expect(cache.getStats().retainedBytes).toBe(3 * 3 * 8 + 1);
   });
 
   it("uses the coarsest sufficient resolution without using coarse for fine", () => {
@@ -179,10 +180,10 @@ describe("numeric-series tile cache", () => {
   });
 
   it("evicts least-recently used payloads with exact byte accounting", () => {
-    const cache = createCache({ maxBytes: 32, maxTiles: 10 });
+    const cache = createCache({ maxBytes: 48, maxTiles: 10 });
     const first = cache.put(pointTile(0));
     const second = cache.put(pointTile(1));
-    expect(cache.getStats().retainedBytes).toBe(32);
+    expect(cache.getStats().retainedBytes).toBe(48);
 
     cache.assembleVisible(demandAt(0));
     const third = cache.put(pointTile(2));
@@ -191,15 +192,15 @@ describe("numeric-series tile cache", () => {
     expect(cache.has(second)).toBe(false);
     expect(cache.has(third)).toBe(true);
     expect(cache.getStats()).toMatchObject({
-      evictedBytes: 16,
+      evictedBytes: 24,
       evictedTiles: 1,
-      retainedBytes: 32,
+      retainedBytes: 48,
       retainedTiles: 2,
     });
   });
 
   it("pins the tiles selected for visible demand above the byte budget", () => {
-    const cache = createCache({ maxBytes: 16, maxTiles: 1 });
+    const cache = createCache({ maxBytes: 24, maxTiles: 1 });
     const visible = cache.put(pointTile(0));
     cache.setPinnedDemand("plot", demandAt(0));
 
@@ -235,7 +236,7 @@ describe("numeric-series tile cache", () => {
 
     expect(replacementId).toBe(firstId);
     expect(cache.getStats()).toMatchObject({
-      retainedBytes: 16,
+      retainedBytes: 24,
       retainedTiles: 1,
     });
     expect([...cache.assembleVisible(demandAt(0)).parts[0].values]).toEqual([
@@ -245,7 +246,7 @@ describe("numeric-series tile cache", () => {
 
   it("keeps long-session assembly work bounded to the visible tiles", () => {
     const maxTiles = 64;
-    const cache = createCache({ maxBytes: maxTiles * 16, maxTiles });
+    const cache = createCache({ maxBytes: maxTiles * 24, maxTiles });
     const pinned = cache.put(pointTile(0));
     cache.setPinnedDemand("old-viewport", demandAt(0));
 

--- a/app/packages/multimodal/src/runtime/numeric-series-tile-cache.ts
+++ b/app/packages/multimodal/src/runtime/numeric-series-tile-cache.ts
@@ -1,9 +1,12 @@
 import type { NsRange } from "../ir";
+import { numericSeriesBucketIndex } from "../utils/numeric-series-buckets";
 
 /** One immutable, fully addressable numeric-series tile. */
 export interface NumericSeriesTile {
   /** Resolution represented by one aggregate bucket. Smaller is finer. */
   readonly bucketDurationNs: bigint;
+  /** Exact absolute bucket identity for each retained representative. */
+  readonly bucketIndexes?: BigInt64Array;
   /** Successfully acquired source ranges, including known-empty ranges. */
   readonly coverageRanges: readonly NsRange[];
   /** Entire time range addressed by this tile. */
@@ -26,6 +29,7 @@ export interface NumericSeriesTileDemand {
 /** One independently clipped array part returned by visible assembly. */
 export interface NumericSeriesTilePart {
   readonly bucketDurationNs: bigint;
+  readonly bucketIndexes: BigInt64Array;
   /** Packed one-bit markers for retained NaN gap representatives. */
   readonly gapMask: Uint8Array;
   readonly range: NsRange;
@@ -95,6 +99,7 @@ export interface NumericSeriesTileCache {
 }
 
 interface StoredTile extends NumericSeriesTile {
+  readonly bucketIndexes: BigInt64Array;
   readonly byteLength: number;
   readonly gapMask: Uint8Array;
   readonly id: string;
@@ -379,6 +384,19 @@ function storeTile(input: NumericSeriesTile, timeOriginNs: bigint): StoredTile {
 
   const timesSec = Float64Array.from(input.timesSec);
   const values = Float64Array.from(input.values);
+  const bucketIndexes = input.bucketIndexes
+    ? BigInt64Array.from(input.bucketIndexes)
+    : BigInt64Array.from(timesSec, (timeSec) =>
+        numericSeriesBucketIndex(
+          timeOriginNs + BigInt(Math.round(timeSec * 1e9)),
+          input.bucketDurationNs,
+        ),
+      );
+  if (bucketIndexes.length !== timesSec.length) {
+    throw new Error(
+      "numeric tile bucket indexes must match times and values length",
+    );
+  }
   const gapMask = packGapMask(values);
   let previous = Number.NEGATIVE_INFINITY;
   for (const timeSec of timesSec) {
@@ -393,7 +411,12 @@ function storeTile(input: NumericSeriesTile, timeOriginNs: bigint): StoredTile {
   }
   return {
     bucketDurationNs: input.bucketDurationNs,
-    byteLength: timesSec.byteLength + values.byteLength + gapMask.byteLength,
+    bucketIndexes,
+    byteLength:
+      timesSec.byteLength +
+      values.byteLength +
+      bucketIndexes.byteLength +
+      gapMask.byteLength,
     coverageRanges,
     gapMask,
     id: tileIdFor(input),
@@ -452,9 +475,11 @@ function copyVisiblePart(
   if (start === end) return null;
   const timesSec = tile.timesSec.slice(start, end);
   const values = tile.values.slice(start, end);
+  const bucketIndexes = tile.bucketIndexes.slice(start, end);
   work.pointsCopied += end - start;
   return {
     bucketDurationNs: tile.bucketDurationNs,
+    bucketIndexes,
     gapMask: packGapMask(values),
     range: { ...range },
     tileId: tile.id,

--- a/app/packages/multimodal/src/runtime/numeric-series-window.test.ts
+++ b/app/packages/multimodal/src/runtime/numeric-series-window.test.ts
@@ -209,6 +209,34 @@ describe("flattenSeriesSegments", () => {
     expect([...flat.values.slice(3)]).toEqual([50, 60]);
   });
 
+  it("assigns an absolute bucket to an inserted gap sample", () => {
+    const flat = flattenSeriesSegments(
+      [
+        {
+          bucketIndexes: BigInt64Array.from([10n, 11n]),
+          endNs: 20n,
+          startNs: 10n,
+          timesSec: Float64Array.from([1, 2]),
+          values: Float64Array.from([10, 20]),
+        },
+        {
+          bucketIndexes: BigInt64Array.from([15n, 16n]),
+          endNs: 60n,
+          startNs: 50n,
+          timesSec: Float64Array.from([5, 6]),
+          values: Float64Array.from([50, 60]),
+        },
+      ],
+      [{ endNs: 49n, startNs: 21n }],
+    );
+
+    expect([...flat.timesSec]).toEqual([1, 2, 3.5, 5, 6]);
+    expect([...flat.values]).toEqual([10, 20, Number.NaN, 50, 60]);
+    expect(flat.bucketIndexes).toEqual(
+      BigInt64Array.from([10n, 11n, 12n, 15n, 16n]),
+    );
+  });
+
   it("connects non-abutting parts across known-empty coverage", () => {
     const flat = flattenSeriesSegments(
       [

--- a/app/packages/multimodal/src/runtime/numeric-series-window.test.ts
+++ b/app/packages/multimodal/src/runtime/numeric-series-window.test.ts
@@ -322,12 +322,14 @@ describe("numeric-series window policy", () => {
   it("clips decoded fields and applies proportional point budgets", () => {
     const clipped = sliceNumericFieldToRange(
       {
+        bucketIndexes: BigInt64Array.from([0n, 1n, 2n, 3n]),
         timesSec: Float64Array.from([0, 1, 2, 3]),
         values: Float64Array.from([10, 11, 12, 13]),
       },
       0n,
       range(1_000_000_000n, 2_000_000_000n),
     );
+    expect(clipped.bucketIndexes).toEqual(BigInt64Array.from([1n, 2n]));
     expect([...clipped.timesSec]).toEqual([1, 2]);
     expect([...clipped.values]).toEqual([11, 12]);
     expect(numericSeriesWindowPointBudget(null, undefined)).toBe(4_000);

--- a/app/packages/multimodal/src/runtime/numeric-series-window.test.ts
+++ b/app/packages/multimodal/src/runtime/numeric-series-window.test.ts
@@ -140,80 +140,115 @@ describe("insertSeriesSegment", () => {
 
 describe("flattenSeriesSegments", () => {
   it("returns empty arrays for no segments", () => {
-    const flat = flattenSeriesSegments([]);
+    const flat = flattenSeriesSegments([], []);
     expect(flat.timesSec.length).toBe(0);
     expect(flat.values.length).toBe(0);
   });
 
   it("passes a single segment through", () => {
-    const flat = flattenSeriesSegments([
-      {
-        endNs: 20n,
-        startNs: 10n,
-        timesSec: Float64Array.from([1, 2]),
-        values: Float64Array.from([10, 20]),
-      },
-    ]);
+    const flat = flattenSeriesSegments(
+      [
+        {
+          endNs: 20n,
+          startNs: 10n,
+          timesSec: Float64Array.from([1, 2]),
+          values: Float64Array.from([10, 20]),
+        },
+      ],
+      [],
+    );
     expect([...flat.timesSec]).toEqual([1, 2]);
     expect([...flat.values]).toEqual([10, 20]);
   });
 
   it("inserts a NaN gap sample between non-abutting segments", () => {
-    const flat = flattenSeriesSegments([
-      {
-        endNs: 20n,
-        startNs: 10n,
-        timesSec: Float64Array.from([1, 2]),
-        values: Float64Array.from([10, 20]),
-      },
-      {
-        endNs: 60n,
-        startNs: 50n,
-        timesSec: Float64Array.from([5, 6]),
-        values: Float64Array.from([50, 60]),
-      },
-    ]);
+    const flat = flattenSeriesSegments(
+      [
+        {
+          endNs: 20n,
+          startNs: 10n,
+          timesSec: Float64Array.from([1, 2]),
+          values: Float64Array.from([10, 20]),
+        },
+        {
+          endNs: 60n,
+          startNs: 50n,
+          timesSec: Float64Array.from([5, 6]),
+          values: Float64Array.from([50, 60]),
+        },
+      ],
+      [{ endNs: 49n, startNs: 21n }],
+    );
     expect([...flat.timesSec]).toEqual([1, 2, 3.5, 5, 6]);
     expect(flat.values[2]).toBeNaN();
     expect([...flat.values.slice(0, 2)]).toEqual([10, 20]);
     expect([...flat.values.slice(3)]).toEqual([50, 60]);
   });
 
+  it("connects non-abutting parts across known-empty coverage", () => {
+    const flat = flattenSeriesSegments(
+      [
+        {
+          endNs: 20n,
+          startNs: 10n,
+          timesSec: Float64Array.from([1, 2]),
+          values: Float64Array.from([10, 20]),
+        },
+        {
+          endNs: 60n,
+          startNs: 50n,
+          timesSec: Float64Array.from([5, 6]),
+          values: Float64Array.from([50, 60]),
+        },
+      ],
+      [],
+    );
+
+    expect([...flat.timesSec]).toEqual([1, 2, 5, 6]);
+    expect([...flat.values]).toEqual([10, 20, 50, 60]);
+  });
+
   it("does not invent a gap between abutting immutable parts", () => {
-    const flat = flattenSeriesSegments([
-      {
-        endNs: 20n,
-        startNs: 10n,
-        timesSec: Float64Array.from([1, 2]),
-        values: Float64Array.from([10, 20]),
-      },
-      {
-        endNs: 30n,
-        startNs: 21n,
-        timesSec: Float64Array.from([3]),
-        values: Float64Array.from([30]),
-      },
-    ]);
+    const flat = flattenSeriesSegments(
+      [
+        {
+          endNs: 20n,
+          startNs: 10n,
+          timesSec: Float64Array.from([1, 2]),
+          values: Float64Array.from([10, 20]),
+        },
+        {
+          endNs: 30n,
+          startNs: 21n,
+          timesSec: Float64Array.from([3]),
+          values: Float64Array.from([30]),
+        },
+      ],
+      [],
+    );
 
     expect([...flat.timesSec]).toEqual([1, 2, 3]);
     expect([...flat.values]).toEqual([10, 20, 30]);
   });
 
   it("skips empty segments", () => {
-    const flat = flattenSeriesSegments([
-      {
-        endNs: 20n,
-        startNs: 10n,
-        timesSec: new Float64Array(0),
-        values: new Float64Array(0),
-      },
-      {
-        endNs: 60n,
-        startNs: 50n,
-        timesSec: Float64Array.from([5]),
-        values: Float64Array.from([50]),
-      },
-    ]);
+    const flat = flattenSeriesSegments(
+      [
+        {
+          endNs: 20n,
+          startNs: 10n,
+          timesSec: new Float64Array(0),
+          values: new Float64Array(0),
+        },
+        {
+          endNs: 60n,
+          startNs: 50n,
+          timesSec: Float64Array.from([5]),
+          values: Float64Array.from([50]),
+        },
+      ],
+      [],
+    );
     expect([...flat.timesSec]).toEqual([5]);
   });
 });

--- a/app/packages/multimodal/src/runtime/numeric-series-window.test.ts
+++ b/app/packages/multimodal/src/runtime/numeric-series-window.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   addCoveredRange,
+  completeNumericSeriesPrefix,
+  contiguousNumericSeriesPrefix,
   coveredNumericSeriesSeconds,
   flattenSeriesSegments,
   FULL_NUMERIC_SERIES_COVERAGE,
@@ -17,6 +19,28 @@ import {
   subtractCoveredRanges,
   type NsRange,
 } from "./numeric-series-window";
+
+describe("contiguous numeric-series publication", () => {
+  it("stops before unread interior coverage", () => {
+    expect(
+      contiguousNumericSeriesPrefix({ endNs: 99n, startNs: 0n }, [
+        { endNs: 39n, startNs: 20n },
+        { endNs: 19n, startNs: 0n },
+        { endNs: 99n, startNs: 60n },
+      ]),
+    ).toEqual({ endNs: 39n, startNs: 0n });
+  });
+
+  it("publishes only complete progressive buckets", () => {
+    const window = { endNs: 99n, startNs: 5n };
+    expect(
+      completeNumericSeriesPrefix(window, { endNs: 54n, startNs: 5n }, 20n),
+    ).toEqual({ endNs: 39n, startNs: 5n });
+    expect(completeNumericSeriesPrefix(window, { ...window }, 20n)).toEqual(
+      window,
+    );
+  });
+});
 import { createTimelineIndex } from "./timeline-index";
 
 const range = (startNs: bigint, endNs: bigint): NsRange => ({ endNs, startNs });

--- a/app/packages/multimodal/src/runtime/numeric-series-window.ts
+++ b/app/packages/multimodal/src/runtime/numeric-series-window.ts
@@ -167,12 +167,17 @@ export function completeNumericSeriesPrefix(
 /** Clips a decoded numeric field to one recording-time range. */
 export function sliceNumericFieldToRange(
   field: {
+    readonly bucketIndexes?: BigInt64Array;
     readonly timesSec: Float64Array;
     readonly values: Float64Array;
   },
   baseTimeNs: bigint,
   range: NsRange,
-): { readonly timesSec: Float64Array; readonly values: Float64Array } {
+): {
+  readonly bucketIndexes?: BigInt64Array;
+  readonly timesSec: Float64Array;
+  readonly values: Float64Array;
+} {
   const startSec = nsDeltaToSeconds(range.startNs - baseTimeNs);
   const endSec = nsDeltaToSeconds(range.endNs - baseTimeNs);
   let start = 0;
@@ -184,6 +189,9 @@ export function sliceNumericFieldToRange(
     end += 1;
   }
   return {
+    ...(field.bucketIndexes
+      ? { bucketIndexes: field.bucketIndexes.slice(start, end) }
+      : {}),
     timesSec: field.timesSec.slice(start, end),
     values: field.values.slice(start, end),
   };
@@ -219,6 +227,7 @@ function distanceToRange(range: NsRange, preferredTimeNs: bigint): bigint {
 
 /** One fetched slice of a signal, tagged with the range it covers. */
 export interface NumericSeriesSegment {
+  readonly bucketIndexes?: BigInt64Array;
   readonly startNs: bigint;
   readonly endNs: bigint;
   /** Recording-relative seconds, ascending. */
@@ -337,7 +346,15 @@ export function insertSeriesSegment(
     }
   }
   mergedParts.sort(compareByStartNs);
+  const indexedParts = mergedParts.filter(hasBucketIndexes);
   result.push({
+    ...(indexedParts.length === mergedParts.length
+      ? {
+          bucketIndexes: concatBigInt64Parts(
+            indexedParts.map((part) => part.bucketIndexes),
+          ),
+        }
+      : {}),
     endNs: mergedEndNs,
     startNs: mergedStartNs,
     timesSec: concatFloat64Parts(mergedParts.map((part) => part.timesSec)),
@@ -355,7 +372,11 @@ export function insertSeriesSegment(
 export function flattenSeriesSegments(
   segments: readonly NumericSeriesSegment[],
   discontinuities: readonly NsRange[],
-): { readonly timesSec: Float64Array; readonly values: Float64Array } {
+): {
+  readonly bucketIndexes?: BigInt64Array;
+  readonly timesSec: Float64Array;
+  readonly values: Float64Array;
+} {
   const nonEmpty = segments.filter((segment) => segment.timesSec.length > 0);
   if (nonEmpty.length === 0) {
     return { timesSec: new Float64Array(0), values: new Float64Array(0) };
@@ -369,11 +390,19 @@ export function flattenSeriesSegments(
     separators;
   const timesSec = new Float64Array(total);
   const values = new Float64Array(total);
+  const indexedSegments = nonEmpty.filter(hasBucketIndexes);
+  const bucketIndexes =
+    indexedSegments.length === nonEmpty.length
+      ? new BigInt64Array(total)
+      : undefined;
   let offset = 0;
   for (let index = 0; index < nonEmpty.length; index += 1) {
     const segment = nonEmpty[index];
     timesSec.set(segment.timesSec, offset);
     values.set(segment.values, offset);
+    if (bucketIndexes) {
+      bucketIndexes.set(indexedSegments[index].bucketIndexes, offset);
+    }
     offset += segment.timesSec.length;
     const next = nonEmpty[index + 1];
     if (next && separatorBefore[index + 1]) {
@@ -381,10 +410,23 @@ export function flattenSeriesSegments(
       const nextFirst = next.timesSec[0];
       timesSec[offset] = (previousLast + nextFirst) / 2;
       values[offset] = Number.NaN;
+      if (bucketIndexes) {
+        const indexedSegment = indexedSegments[index];
+        const left =
+          indexedSegment.bucketIndexes[indexedSegment.bucketIndexes.length - 1];
+        const right = indexedSegments[index + 1].bucketIndexes[0];
+        bucketIndexes[offset] = left < right ? left + 1n : left;
+      }
       offset += 1;
     }
   }
-  return { timesSec, values };
+  return { ...(bucketIndexes ? { bucketIndexes } : {}), timesSec, values };
+}
+
+function hasBucketIndexes(
+  segment: NumericSeriesSegment,
+): segment is NumericSeriesSegment & { readonly bucketIndexes: BigInt64Array } {
+  return segment.bucketIndexes !== undefined;
 }
 
 function segmentSeparators(
@@ -413,6 +455,18 @@ function segmentSeparators(
 
 function concatFloat64Parts(parts: readonly Float64Array[]): Float64Array {
   const result = new Float64Array(
+    parts.reduce((total, part) => total + part.length, 0),
+  );
+  let offset = 0;
+  for (const part of parts) {
+    result.set(part, offset);
+    offset += part.length;
+  }
+  return result;
+}
+
+function concatBigInt64Parts(parts: readonly BigInt64Array[]): BigInt64Array {
+  const result = new BigInt64Array(
     parts.reduce((total, part) => total + part.length, 0),
   );
   let offset = 0;

--- a/app/packages/multimodal/src/runtime/numeric-series-window.ts
+++ b/app/packages/multimodal/src/runtime/numeric-series-window.ts
@@ -14,6 +14,7 @@
 
 import type { NsRange } from "../ir";
 import { nsDeltaToSeconds } from "../utils/nanoseconds";
+import { numericSeriesBucketIndex } from "../utils/numeric-series-buckets";
 import type { TimelineIndex } from "./timeline-index";
 
 export type { NsRange } from "../ir";
@@ -119,6 +120,48 @@ export function coveredNumericSeriesSeconds(
 /** Duration of one inclusive numeric-series range in seconds. */
 export function numericSeriesRangeDurationSeconds(range: NsRange): number {
   return Number(range.endNs - range.startNs) / 1_000_000_000;
+}
+
+/** Contiguous known prefix of `window`, including unavailable source spans. */
+export function contiguousNumericSeriesPrefix(
+  window: NsRange,
+  knownRanges: readonly NsRange[],
+): NsRange | undefined {
+  const known = knownRanges
+    .map((range) => ({
+      endNs: range.endNs < window.endNs ? range.endNs : window.endNs,
+      startNs: range.startNs > window.startNs ? range.startNs : window.startNs,
+    }))
+    .filter((range) => range.endNs >= range.startNs)
+    .sort(compareByStartNs);
+  let endNs = window.startNs - 1n;
+  for (const range of known) {
+    if (range.startNs > endNs + 1n) break;
+    if (range.endNs > endNs) endNs = range.endNs;
+    if (endNs >= window.endNs) return { ...window };
+  }
+  return endNs >= window.startNs
+    ? { endNs, startNs: window.startNs }
+    : undefined;
+}
+
+/**
+ * Excludes the incomplete absolute-time bucket at a progressive prefix's
+ * right edge. Once the full viewport is known, its final partial bucket is
+ * safe to publish too.
+ */
+export function completeNumericSeriesPrefix(
+  window: NsRange,
+  prefix: NsRange | undefined,
+  bucketDurationNs: bigint,
+): NsRange | undefined {
+  if (!prefix || prefix.endNs >= window.endNs) return prefix;
+  const nextNs = prefix.endNs + 1n;
+  const bucket = numericSeriesBucketIndex(nextNs, bucketDurationNs);
+  const endNs = bucket * bucketDurationNs - 1n;
+  return endNs >= window.startNs
+    ? { endNs, startNs: window.startNs }
+    : undefined;
 }
 
 /** Clips a decoded numeric field to one recording-time range. */

--- a/app/packages/multimodal/src/runtime/numeric-series-window.ts
+++ b/app/packages/multimodal/src/runtime/numeric-series-window.ts
@@ -304,25 +304,23 @@ export function insertSeriesSegment(
 }
 
 /**
- * Flattens segments into one ascending series, inserting a NaN sample
- * between non-abutting segments so charts render the unfetched region
- * as a gap instead of a connecting line.
+ * Flattens segments into one ascending series, inserting a NaN sample only
+ * when an explicit unread or unavailable range separates two parts. MCAP
+ * chunk coverage normally leaves time between adjacent message bounds; that
+ * known-empty interval is not a signal discontinuity.
  */
 export function flattenSeriesSegments(
   segments: readonly NumericSeriesSegment[],
+  discontinuities: readonly NsRange[],
 ): { readonly timesSec: Float64Array; readonly values: Float64Array } {
   const nonEmpty = segments.filter((segment) => segment.timesSec.length > 0);
   if (nonEmpty.length === 0) {
     return { timesSec: new Float64Array(0), values: new Float64Array(0) };
   }
 
-  const separators = nonEmpty.reduce(
-    (count, segment, index) =>
-      index > 0 && nonEmpty[index - 1].endNs + 1n < segment.startNs
-        ? count + 1
-        : count,
-    0,
-  );
+  const sortedDiscontinuities = [...discontinuities].sort(compareByStartNs);
+  const separatorBefore = segmentSeparators(nonEmpty, sortedDiscontinuities);
+  const separators = separatorBefore.filter(Boolean).length;
   const total =
     nonEmpty.reduce((sum, segment) => sum + segment.timesSec.length, 0) +
     separators;
@@ -335,7 +333,7 @@ export function flattenSeriesSegments(
     values.set(segment.values, offset);
     offset += segment.timesSec.length;
     const next = nonEmpty[index + 1];
-    if (next && segment.endNs + 1n < next.startNs) {
+    if (next && separatorBefore[index + 1]) {
       const previousLast = segment.timesSec[segment.timesSec.length - 1];
       const nextFirst = next.timesSec[0];
       timesSec[offset] = (previousLast + nextFirst) / 2;
@@ -344,6 +342,30 @@ export function flattenSeriesSegments(
     }
   }
   return { timesSec, values };
+}
+
+function segmentSeparators(
+  segments: readonly NumericSeriesSegment[],
+  discontinuities: readonly NsRange[],
+): readonly boolean[] {
+  const separatorBefore = new Array<boolean>(segments.length).fill(false);
+  let discontinuity = 0;
+  for (let index = 1; index < segments.length; index += 1) {
+    const leftEndNs = segments[index - 1].endNs;
+    while (
+      discontinuity < discontinuities.length &&
+      discontinuities[discontinuity].endNs <= leftEndNs
+    ) {
+      discontinuity += 1;
+    }
+    const range = discontinuities[discontinuity];
+    separatorBefore[index] = Boolean(
+      range &&
+      range.startNs < segments[index].startNs &&
+      range.endNs > leftEndNs,
+    );
+  }
+  return separatorBefore;
 }
 
 function concatFloat64Parts(parts: readonly Float64Array[]): Float64Array {

--- a/app/packages/multimodal/src/utils/numeric-series-buckets.test.ts
+++ b/app/packages/multimodal/src/utils/numeric-series-buckets.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { aggregateAlignedNumericSeries } from "./numeric-series-buckets";
+
+describe("aggregateAlignedNumericSeries", () => {
+  it("preserves spikes and source gaps", () => {
+    const result = aggregateAlignedNumericSeries(
+      Float64Array.from({ length: 20 }, (_, index) => index / 10),
+      Float64Array.from({ length: 20 }, (_, index) =>
+        index === 7 ? 100 : index === 12 ? Number.NaN : index % 3,
+      ),
+      0n,
+      1_000_000_000n,
+    );
+
+    expect([...result.values]).toContain(100);
+    expect([...result.values].some(Number.isNaN)).toBe(true);
+  });
+
+  it("is invariant to continuation page boundaries", () => {
+    const times = Float64Array.from(
+      { length: 40 },
+      (_, index) => 10.03 + index * 0.025,
+    );
+    const values = Float64Array.from({ length: 40 }, (_, index) =>
+      index === 13
+        ? 90
+        : index === 11 || index === 24
+          ? Number.NaN
+          : Math.sin(index / 3),
+    );
+    const bucketDurationNs = 200_000_000n;
+    const whole = aggregateAlignedNumericSeries(
+      times,
+      values,
+      1_700_000_000_000_000_000n,
+      bucketDurationNs,
+    );
+    const pages = [
+      aggregateAlignedNumericSeries(
+        times.slice(0, 17),
+        values.slice(0, 17),
+        1_700_000_000_000_000_000n,
+        bucketDurationNs,
+      ),
+      aggregateAlignedNumericSeries(
+        times.slice(17, 29),
+        values.slice(17, 29),
+        1_700_000_000_000_000_000n,
+        bucketDurationNs,
+      ),
+      aggregateAlignedNumericSeries(
+        times.slice(29),
+        values.slice(29),
+        1_700_000_000_000_000_000n,
+        bucketDurationNs,
+      ),
+    ];
+    const merged = aggregateAlignedNumericSeries(
+      Float64Array.from(pages.flatMap((page) => [...page.timesSec])),
+      Float64Array.from(pages.flatMap((page) => [...page.values])),
+      1_700_000_000_000_000_000n,
+      bucketDurationNs,
+    );
+
+    expect([...merged.timesSec]).toEqual([...whole.timesSec]);
+    expect([...merged.values]).toEqual([...whole.values]);
+  });
+
+  it("emits at most five representatives per bucket", () => {
+    const result = aggregateAlignedNumericSeries(
+      Float64Array.from({ length: 100_000 }, (_, index) => index / 1_000),
+      Float64Array.from({ length: 100_000 }, (_, index) =>
+        index % 29 === 0 ? Number.NaN : Math.sin(index),
+      ),
+      0n,
+      61_000_000n,
+    );
+
+    expect(result.values.length).toBeLessThanOrEqual(10_000);
+    expect([...result.values].some(Number.isNaN)).toBe(true);
+  });
+});

--- a/app/packages/multimodal/src/utils/numeric-series-buckets.test.ts
+++ b/app/packages/multimodal/src/utils/numeric-series-buckets.test.ts
@@ -60,13 +60,37 @@ describe("aggregateAlignedNumericSeries", () => {
       Float64Array.from(pages.flatMap((page) => [...page.values])),
       1_700_000_000_000_000_000n,
       bucketDurationNs,
+      BigInt64Array.from(pages.flatMap((page) => [...page.bucketIndexes])),
     );
 
     expect([...merged.timesSec]).toEqual([...whole.timesSec]);
     expect([...merged.values]).toEqual([...whole.values]);
   });
 
-  it("emits at most five representatives per bucket", () => {
+  it("retains exact bucket identities beyond float nanosecond precision", () => {
+    const baseTimeNs = 1_700_000_000_000_000_000n;
+    const absoluteTimes = [
+      baseTimeNs + 9_007_199_254_740_992n,
+      baseTimeNs + 9_007_199_254_740_993n,
+    ];
+    const timesSec = Float64Array.from(
+      absoluteTimes,
+      (timeNs) => Number(timeNs - baseTimeNs) / 1e9,
+    );
+    const bucketIndexes = BigInt64Array.from(absoluteTimes, (timeNs) => timeNs);
+    const result = aggregateAlignedNumericSeries(
+      timesSec,
+      Float64Array.from([1, 2]),
+      baseTimeNs,
+      1n,
+      bucketIndexes,
+    );
+
+    expect([...result.bucketIndexes]).toEqual(absoluteTimes);
+    expect([...result.values]).toEqual([1, 2]);
+  });
+
+  it("emits at most six representatives per bucket", () => {
     const result = aggregateAlignedNumericSeries(
       Float64Array.from({ length: 100_000 }, (_, index) => index / 1_000),
       Float64Array.from({ length: 100_000 }, (_, index) =>

--- a/app/packages/multimodal/src/utils/numeric-series-buckets.test.ts
+++ b/app/packages/multimodal/src/utils/numeric-series-buckets.test.ts
@@ -6,7 +6,13 @@ describe("aggregateAlignedNumericSeries", () => {
     const result = aggregateAlignedNumericSeries(
       Float64Array.from({ length: 20 }, (_, index) => index / 10),
       Float64Array.from({ length: 20 }, (_, index) =>
-        index === 7 ? 100 : index === 12 ? Number.NaN : index % 3,
+        index === 7
+          ? 100
+          : index === 12
+            ? Number.NaN
+            : index === 15
+              ? Number.POSITIVE_INFINITY
+              : index % 3,
       ),
       0n,
       1_000_000_000n,
@@ -14,6 +20,7 @@ describe("aggregateAlignedNumericSeries", () => {
 
     expect([...result.values]).toContain(100);
     expect([...result.values].some(Number.isNaN)).toBe(true);
+    expect([...result.values]).not.toContain(Number.POSITIVE_INFINITY);
   });
 
   it("is invariant to continuation page boundaries", () => {

--- a/app/packages/multimodal/src/utils/numeric-series-buckets.ts
+++ b/app/packages/multimodal/src/utils/numeric-series-buckets.ts
@@ -1,0 +1,131 @@
+/** Maximum representatives retained by one aligned numeric-series bucket. */
+export const ALIGNED_NUMERIC_BUCKET_MAX_POINTS = 6;
+
+/** Numeric samples reduced onto an absolute-time bucket grid. */
+export interface AggregatedNumericSeries {
+  readonly timesSec: Float64Array;
+  readonly values: Float64Array;
+}
+
+/** Returns the absolute bucket containing `timeNs`. */
+export function numericSeriesBucketIndex(
+  timeNs: bigint,
+  bucketDurationNs: bigint,
+): bigint {
+  const quotient = timeNs / bucketDurationNs;
+  return timeNs < 0n && timeNs % bucketDurationNs !== 0n
+    ? quotient - 1n
+    : quotient;
+}
+
+/**
+ * Reduces sorted numeric samples into absolute-time-aligned M4 buckets.
+ * Each bucket keeps its finite extrema before the first source gap and after
+ * the last one. The gap endpoints collapse any intervening finite islands
+ * into one conservative break. This six-point summary is associative:
+ * aggregating page summaries produces the same result as aggregating their
+ * raw samples in one pass.
+ */
+export function aggregateAlignedNumericSeries(
+  timesSec: Float64Array,
+  values: Float64Array,
+  baseTimeNs: bigint,
+  bucketDurationNs: bigint,
+): AggregatedNumericSeries {
+  if (bucketDurationNs <= 0n) {
+    throw new Error("numeric series bucket duration must be positive");
+  }
+  const length = Math.min(timesSec.length, values.length);
+  if (length === 0) {
+    return {
+      timesSec: new Float64Array(0),
+      values: new Float64Array(0),
+    };
+  }
+
+  const kept: number[] = [];
+  let bucketStart = 0;
+  let bucket: bigint | undefined = bucketIndex(
+    timesSec[0],
+    baseTimeNs,
+    bucketDurationNs,
+  );
+  for (let index = 1; index <= length; index += 1) {
+    const nextBucket =
+      index < length
+        ? bucketIndex(timesSec[index], baseTimeNs, bucketDurationNs)
+        : undefined;
+    if (nextBucket === bucket) continue;
+    kept.push(...summarizeBucket(values, bucketStart, index));
+    bucketStart = index;
+    bucket = nextBucket;
+  }
+
+  const outTimes = new Float64Array(kept.length);
+  const outValues = new Float64Array(kept.length);
+  for (let index = 0; index < kept.length; index += 1) {
+    outTimes[index] = timesSec[kept[index]];
+    outValues[index] = values[kept[index]];
+  }
+  return { timesSec: outTimes, values: outValues };
+}
+
+function bucketIndex(
+  timeSec: number,
+  baseTimeNs: bigint,
+  bucketDurationNs: bigint,
+): bigint {
+  const timeNs = baseTimeNs + BigInt(Math.round(timeSec * 1e9));
+  return numericSeriesBucketIndex(timeNs, bucketDurationNs);
+}
+
+function summarizeBucket(
+  values: Float64Array,
+  start: number,
+  end: number,
+): readonly number[] {
+  const firstNaN = findNaN(values, start, end);
+  if (firstNaN === -1) {
+    return finiteExtremaIndexes(values, start, end);
+  }
+  const lastNaN = findLastNaN(values, firstNaN, end);
+  return [
+    ...finiteExtremaIndexes(values, start, firstNaN),
+    firstNaN,
+    ...(lastNaN === firstNaN ? [] : [lastNaN]),
+    ...finiteExtremaIndexes(values, lastNaN + 1, end),
+  ];
+}
+
+function finiteExtremaIndexes(
+  values: Float64Array,
+  start: number,
+  end: number,
+): readonly number[] {
+  let minIndex = -1;
+  let maxIndex = -1;
+  for (let index = start; index < end; index += 1) {
+    const value = values[index];
+    if (Number.isNaN(value)) continue;
+    if (minIndex === -1 || value < values[minIndex]) minIndex = index;
+    if (maxIndex === -1 || value >= values[maxIndex]) maxIndex = index;
+  }
+  if (minIndex === -1) return [];
+  return minIndex === maxIndex
+    ? [minIndex]
+    : [minIndex, maxIndex].sort((left, right) => left - right);
+}
+
+function findNaN(values: Float64Array, start: number, end: number): number {
+  for (let index = start; index < end; index += 1) {
+    if (Number.isNaN(values[index])) return index;
+  }
+  return -1;
+}
+
+function findLastNaN(values: Float64Array, start: number, end: number): number {
+  for (let index = end - 1; index >= start; index -= 1) {
+    if (Number.isNaN(values[index])) return index;
+  }
+  return -1;
+}

--- a/app/packages/multimodal/src/utils/numeric-series-buckets.ts
+++ b/app/packages/multimodal/src/utils/numeric-series-buckets.ts
@@ -138,7 +138,7 @@ function finiteExtremaIndexes(
   let maxIndex = -1;
   for (let index = start; index < end; index += 1) {
     const value = values[index];
-    if (Number.isNaN(value)) continue;
+    if (!Number.isFinite(value)) continue;
     if (minIndex === -1 || value < values[minIndex]) minIndex = index;
     if (maxIndex === -1 || value >= values[maxIndex]) maxIndex = index;
   }

--- a/app/packages/multimodal/src/utils/numeric-series-buckets.ts
+++ b/app/packages/multimodal/src/utils/numeric-series-buckets.ts
@@ -3,6 +3,8 @@ export const ALIGNED_NUMERIC_BUCKET_MAX_POINTS = 6;
 
 /** Numeric samples reduced onto an absolute-time bucket grid. */
 export interface AggregatedNumericSeries {
+  /** Exact absolute bucket identity for each retained representative. */
+  readonly bucketIndexes: BigInt64Array;
   readonly timesSec: Float64Array;
   readonly values: Float64Array;
 }
@@ -31,6 +33,7 @@ export function aggregateAlignedNumericSeries(
   values: Float64Array,
   baseTimeNs: bigint,
   bucketDurationNs: bigint,
+  bucketIndexes?: BigInt64Array | readonly bigint[],
 ): AggregatedNumericSeries {
   if (bucketDurationNs <= 0n) {
     throw new Error("numeric series bucket duration must be positive");
@@ -38,22 +41,34 @@ export function aggregateAlignedNumericSeries(
   const length = Math.min(timesSec.length, values.length);
   if (length === 0) {
     return {
+      bucketIndexes: new BigInt64Array(0),
       timesSec: new Float64Array(0),
       values: new Float64Array(0),
     };
   }
+  if (bucketIndexes && bucketIndexes.length < length) {
+    throw new Error("numeric series bucket indexes must cover every sample");
+  }
 
   const kept: number[] = [];
   let bucketStart = 0;
-  let bucket: bigint | undefined = bucketIndex(
-    timesSec[0],
+  let bucket: bigint | undefined = sampleBucketIndex(
+    0,
+    timesSec,
     baseTimeNs,
     bucketDurationNs,
+    bucketIndexes,
   );
   for (let index = 1; index <= length; index += 1) {
     const nextBucket =
       index < length
-        ? bucketIndex(timesSec[index], baseTimeNs, bucketDurationNs)
+        ? sampleBucketIndex(
+            index,
+            timesSec,
+            baseTimeNs,
+            bucketDurationNs,
+            bucketIndexes,
+          )
         : undefined;
     if (nextBucket === bucket) continue;
     kept.push(...summarizeBucket(values, bucketStart, index));
@@ -63,19 +78,36 @@ export function aggregateAlignedNumericSeries(
 
   const outTimes = new Float64Array(kept.length);
   const outValues = new Float64Array(kept.length);
+  const outBucketIndexes = new BigInt64Array(kept.length);
   for (let index = 0; index < kept.length; index += 1) {
-    outTimes[index] = timesSec[kept[index]];
-    outValues[index] = values[kept[index]];
+    const keptIndex = kept[index];
+    outTimes[index] = timesSec[keptIndex];
+    outValues[index] = values[keptIndex];
+    outBucketIndexes[index] = sampleBucketIndex(
+      keptIndex,
+      timesSec,
+      baseTimeNs,
+      bucketDurationNs,
+      bucketIndexes,
+    );
   }
-  return { timesSec: outTimes, values: outValues };
+  return {
+    bucketIndexes: outBucketIndexes,
+    timesSec: outTimes,
+    values: outValues,
+  };
 }
 
-function bucketIndex(
-  timeSec: number,
+function sampleBucketIndex(
+  index: number,
+  timesSec: Float64Array,
   baseTimeNs: bigint,
   bucketDurationNs: bigint,
+  bucketIndexes?: BigInt64Array | readonly bigint[],
 ): bigint {
-  const timeNs = baseTimeNs + BigInt(Math.round(timeSec * 1e9));
+  const supplied = bucketIndexes?.[index];
+  if (supplied !== undefined) return supplied;
+  const timeNs = baseTimeNs + BigInt(Math.round(timesSec[index] * 1e9));
   return numericSeriesBucketIndex(timeNs, bucketDurationNs);
 }
 

--- a/app/packages/multimodal/src/views/episode/plots/numeric-series-context.test.tsx
+++ b/app/packages/multimodal/src/views/episode/plots/numeric-series-context.test.tsx
@@ -550,7 +550,7 @@ describe("NumericSeriesBridge (playback store: windowed fetches)", () => {
     expect(client.readNumericSeriesSlice).toHaveBeenCalledTimes(1);
     const request = sliceRequestOf(client, 0);
     expect(request.maxChunks).toBe(1);
-    expect(request.preferredTimeNs).toBe(60_000_000_000n);
+    expect(request.preferredTimeNs).toBe(30_000_000_000n);
     expect(request.selections).toEqual([
       { fields: ["accel.x"], stream: "/imu" },
       { fields: ["speed"], stream: "/odom" },
@@ -573,7 +573,8 @@ describe("NumericSeriesBridge (playback store: windowed fetches)", () => {
       .mockImplementationOnce(async (request) =>
         sliceResult(request, {
           continuation,
-          coverage: [{ endNs: 61_000_000_000n, startNs: 59_000_000_000n }],
+          coverage: [{ endNs: 49_999_999_999n, startNs: 30_000_000_000n }],
+          resumeAtNs: 50_000_000_000n,
           stopReason: "budget-exhausted",
         }),
       )
@@ -605,8 +606,10 @@ describe("NumericSeriesBridge (playback store: windowed fetches)", () => {
       numericSeriesKey("/imu", "accel.x"),
     );
     expect(state?.status).toBe("ready");
-    expect(state?.coverageSeconds).toBe(2);
+    expect(state?.coverageSeconds).toBeGreaterThan(18);
+    expect(state?.coverage?.at(-1)?.endNs).toBeLessThan(50_000_000_000n);
     expect(state?.targetSeconds).toBeCloseTo(60);
+    expect(state?.values?.some(Number.isNaN) ?? false).toBe(false);
 
     await act(async () => {
       resolveSecond?.(
@@ -799,7 +802,7 @@ describe("NumericSeriesBridge (playback store: windowed fetches)", () => {
 
     expect(firstSignal?.aborted).toBe(true);
     expect(readNumericSeriesSlice).toHaveBeenCalledTimes(2);
-    expect(sliceRequestOf(client, 1).preferredTimeNs).toBe(1_800_000_000_000n);
+    expect(sliceRequestOf(client, 1).preferredTimeNs).toBe(1_770_000_000_000n);
   });
 
   it("keeps useful in-flight work across transient demand changes", async () => {
@@ -882,7 +885,7 @@ describe("NumericSeriesBridge (playback store: windowed fetches)", () => {
       context.current?.setViewportDemand("plot", null);
       await advanceTimers(FIELD_SELECTION_DEBOUNCE_MS);
     });
-    expect(sliceRequestOf(client, 2).preferredTimeNs).toBe(1_800_000_000_000n);
+    expect(sliceRequestOf(client, 2).preferredTimeNs).toBe(1_770_000_000_000n);
   });
 
   it("refines a pinned viewport without reusing insufficient resolution", async () => {
@@ -910,19 +913,21 @@ describe("NumericSeriesBridge (playback store: windowed fetches)", () => {
       context.current?.subscribeSeries("/imu", "accel.x");
       await advanceTimers(FIELD_SELECTION_DEBOUNCE_MS);
     });
-    expect(sliceRequestOf(client, 0).maxPointsPerField).toBe(200);
+    expect(sliceRequestOf(client, 0).bucketDurationNs).toBe(202_020_203n);
 
     await act(async () => {
       context.current?.setViewportDemand("plot", {
         endSec: 1_020,
         mode: "pinned",
-        pixelWidth: 1_000,
+        pixelWidth: 5_000,
         startSec: 1_000,
       });
       await advanceTimers(FIELD_SELECTION_DEBOUNCE_MS);
     });
     expect(client.readNumericSeriesSlice).toHaveBeenCalledTimes(2);
-    expect(sliceRequestOf(client, 1).maxPointsPerField).toBe(2_000);
+    expect(sliceRequestOf(client, 1).bucketDurationNs).toBeLessThan(
+      sliceRequestOf(client, 0).bucketDurationNs,
+    );
 
     // The finer retained tile is sufficient when demand later coarsens.
     await act(async () => {
@@ -935,6 +940,84 @@ describe("NumericSeriesBridge (playback store: windowed fetches)", () => {
       await advanceTimers(FIELD_SELECTION_DEBOUNCE_MS);
     });
     expect(client.readNumericSeriesSlice).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps the previous coherent plot while a refinement is loading", async () => {
+    const continuation = {} as ReadContinuation;
+    let resolveFinalPage:
+      | ((result: NumericSeriesSliceResult) => void)
+      | undefined;
+    const finalPage = new Promise<NumericSeriesSliceResult>((resolve) => {
+      resolveFinalPage = resolve;
+    });
+    const readNumericSeriesSlice = vi
+      .fn<NonNullable<NumericSeriesCapability["readNumericSeriesSlice"]>>()
+      .mockImplementationOnce(async (request) =>
+        sliceResult(request, { stopReason: "source-exhausted" }),
+      )
+      .mockImplementationOnce(async (request) =>
+        sliceResult(request, {
+          continuation,
+          coverage: [
+            {
+              endNs: request.window.startNs + 9_999_999_999n,
+              startNs: request.window.startNs,
+            },
+          ],
+          resumeAtNs: request.window.startNs + 10_000_000_000n,
+          stopReason: "budget-exhausted",
+        }),
+      )
+      .mockImplementationOnce(() => finalPage);
+    const client = createClient({ readNumericSeriesSlice });
+    const context = createContextRef();
+    const store = createStore();
+    store.set(playheadAtom, 60);
+    render(
+      <Harness
+        client={client}
+        contextRef={context}
+        durationSec={DURATION_SEC}
+        source={createSource()}
+        store={store}
+      />,
+    );
+
+    await act(async () => {
+      context.current?.setViewportDemand("plot", {
+        endSec: 1_020,
+        mode: "pinned",
+        pixelWidth: 100,
+        startSec: 1_000,
+      });
+      context.current?.subscribeSeries("/imu", "accel.x");
+      await advanceTimers(FIELD_SELECTION_DEBOUNCE_MS);
+    });
+    const key = numericSeriesKey("/imu", "accel.x");
+    const initialValues = context.current?.seriesByKey.get(key)?.values;
+
+    await act(async () => {
+      context.current?.setViewportDemand("plot", {
+        endSec: 1_020,
+        mode: "pinned",
+        pixelWidth: 5_000,
+        startSec: 1_000,
+      });
+      await advanceTimers(FIELD_SELECTION_DEBOUNCE_MS);
+    });
+
+    expect(readNumericSeriesSlice).toHaveBeenCalledTimes(3);
+    expect(context.current?.seriesByKey.get(key)?.status).toBe("ready");
+    expect(context.current?.seriesByKey.get(key)?.values).toBe(initialValues);
+
+    await act(async () => {
+      resolveFinalPage?.(
+        sliceResult(sliceRequestOf(client, 2), {
+          stopReason: "source-exhausted",
+        }),
+      );
+      await flushMicrotasks();
+    });
   });
 
   it("does not debounce a playhead-driven fill", async () => {
@@ -1234,6 +1317,7 @@ function sliceResult(
       readonly endNs: bigint;
       readonly startNs: bigint;
     }[];
+    readonly resumeAtNs?: bigint;
     readonly stopReason: NumericSeriesSliceResult["stopReason"];
     readonly unavailable?: readonly {
       readonly endNs: bigint;
@@ -1245,6 +1329,16 @@ function sliceResult(
   const coverage = options.coverage ?? [request.window];
   return {
     ...(options.continuation ? { continuation: options.continuation } : {}),
+    ...(options.continuation
+      ? {
+          resumeAtNs:
+            options.resumeAtNs ??
+            [...coverage, ...(options.unavailable ?? [])].reduce(
+              (endNs, range) => (range.endNs > endNs ? range.endNs : endNs),
+              request.window.startNs - 1n,
+            ) + 1n,
+        }
+      : {}),
     coverageByStream: new Map(
       request.selections.map((selection) => [selection.stream, coverage]),
     ),

--- a/app/packages/multimodal/src/views/episode/plots/numeric-series-context.test.tsx
+++ b/app/packages/multimodal/src/views/episode/plots/numeric-series-context.test.tsx
@@ -1018,6 +1018,11 @@ describe("NumericSeriesBridge (playback store: windowed fetches)", () => {
       );
       await flushMicrotasks();
     });
+
+    expect(context.current?.seriesByKey.get(key)?.status).toBe("ready");
+    expect(context.current?.seriesByKey.get(key)?.values).not.toBe(
+      initialValues,
+    );
   });
 
   it("does not debounce a playhead-driven fill", async () => {

--- a/app/packages/multimodal/src/views/episode/plots/numeric-series-context.tsx
+++ b/app/packages/multimodal/src/views/episode/plots/numeric-series-context.tsx
@@ -551,6 +551,7 @@ export function NumericSeriesBridge({
               timesSec: part.timesSec,
               values: part.values,
             })),
+            [...assembled.unavailableRanges, ...assembled.unreadRanges],
           );
           setPublished(key, {
             coverage: assembled.coverageRanges,

--- a/app/packages/multimodal/src/views/episode/plots/numeric-series-context.tsx
+++ b/app/packages/multimodal/src/views/episode/plots/numeric-series-context.tsx
@@ -15,6 +15,8 @@ import {
 } from "react";
 import {
   addCoveredRange,
+  completeNumericSeriesPrefix,
+  contiguousNumericSeriesPrefix,
   coveredNumericSeriesSeconds,
   createDemandFailureBackoff,
   createDemandInventoryMachine,
@@ -39,7 +41,6 @@ import {
   type NumericSeriesTileCache,
   type TimelineIndex,
 } from "../../../runtime";
-import { NUMERIC_SERIES_MAX_BUCKET_SURVIVORS } from "../../../ports";
 import {
   createDemandContextProvider,
   useResetDemandContextOnUnmount,
@@ -53,6 +54,10 @@ import type {
   ReadWorkBudget,
 } from "../../../ports";
 import { errorMessage } from "../../../utils/errors";
+import {
+  aggregateAlignedNumericSeries,
+  ALIGNED_NUMERIC_BUCKET_MAX_POINTS,
+} from "../../../utils/numeric-series-buckets";
 import { useDataStream } from "../playback/data-stream-context";
 import { shouldDeferIdleWorkForStore } from "../playback/network-health";
 
@@ -83,6 +88,7 @@ const TIMELINE_RETRY_MS = 250;
 const MAX_NUMERIC_SLICE_PAGES_PER_EPOCH = 8;
 const NUMERIC_TILE_CACHE_MAX_BYTES = 64 * 1024 * 1024;
 const NUMERIC_TILE_CACHE_MAX_TILES = 2_048;
+const MAX_NUMERIC_REPRESENTATIVE_POINTS = 10_000;
 
 const MIB = 1024 * 1024;
 
@@ -183,7 +189,6 @@ interface NumericSliceJob {
   readonly continuation?: ReadContinuation;
   readonly horizon: NsRange;
   readonly horizonKey: string;
-  readonly maxPointsPerField: number;
   readonly notBeforeMs?: number;
   readonly pageCount: number;
   readonly preferredTimeNs: bigint;
@@ -384,6 +389,7 @@ export function NumericSeriesBridge({
     let tileCache: NumericSeriesTileCache | undefined;
     let tileOriginNs: bigint | undefined;
     const published = publication.valuesByKey;
+    const publishedHorizonKeys = new Map<string, string>();
     const setPublished = (key: string, state: NumericSeriesState) => {
       published.set(key, state);
       publicationEpoch.set(key, state);
@@ -534,7 +540,8 @@ export function NumericSeriesBridge({
       bucketDurationNs: bigint,
     ) => {
       const cache = tileCache;
-      if (!cache) return;
+      if (!cache || tileOriginNs === undefined) return;
+      const horizonKey = `${horizon.startNs}:${horizon.endNs}:${bucketDurationNs}`;
       const targetSeconds = numericSeriesRangeDurationSeconds(horizon);
       for (const selection of selections) {
         for (const field of selection.fields) {
@@ -544,28 +551,58 @@ export function NumericSeriesBridge({
             range: horizon,
             seriesKey: key,
           });
+          const prefix = completeNumericSeriesPrefix(
+            horizon,
+            contiguousNumericSeriesPrefix(horizon, [
+              ...assembled.coverageRanges,
+              ...assembled.unavailableRanges,
+            ]),
+            bucketDurationNs,
+          );
+          if (!prefix) continue;
+          const publishedHorizonKey = publishedHorizonKeys.get(key);
+          if (
+            published.get(key)?.status === "ready" &&
+            publishedHorizonKey !== undefined &&
+            publishedHorizonKey !== horizonKey &&
+            prefix.endNs < horizon.endNs
+          ) {
+            continue;
+          }
+          const visible = cache.assembleVisible({
+            bucketDurationNs,
+            range: prefix,
+            seriesKey: key,
+          });
           const flat = flattenSeriesSegments(
-            assembled.parts.map((part) => ({
+            visible.parts.map((part) => ({
               endNs: part.range.endNs,
               startNs: part.range.startNs,
               timesSec: part.timesSec,
               values: part.values,
             })),
-            [...assembled.unavailableRanges, ...assembled.unreadRanges],
+            visible.unavailableRanges,
+          );
+          const aggregated = aggregateAlignedNumericSeries(
+            flat.timesSec,
+            flat.values,
+            tileOriginNs,
+            bucketDurationNs,
           );
           setPublished(key, {
-            coverage: assembled.coverageRanges,
+            coverage: visible.coverageRanges,
             coverageSeconds: coveredNumericSeriesSeconds(
-              assembled.coverageRanges,
+              visible.coverageRanges,
               horizon,
             ),
             status: "ready",
             targetSeconds,
-            timesSec: flat.timesSec,
+            timesSec: aggregated.timesSec,
             truncated: truncatedKeys.has(key) || undefined,
-            unavailable: assembled.unavailableRanges,
-            values: flat.values,
+            unavailable: visible.unavailableRanges,
+            values: aggregated.values,
           });
+          publishedHorizonKeys.set(key, horizonKey);
         }
       }
     };
@@ -782,13 +819,9 @@ export function NumericSeriesBridge({
           window,
           maxPointsPerField,
         );
-        const rawPreferredTimeNs = timeline.secToNs(playheadSec);
-        const preferredTimeNs =
-          rawPreferredTimeNs < window.startNs
-            ? window.startNs
-            : rawPreferredTimeNs > window.endNs
-              ? window.endNs
-              : rawPreferredTimeNs;
+        // Chronological admission makes every publishable replacement a
+        // stable prefix that can extend only at its right edge.
+        const preferredTimeNs = window.startNs;
         const horizonKey = `${window.startNs}:${window.endNs}:${bucketDurationNs}`;
         const cache = cacheForOrigin(timeline.startTimeNs);
         syncPinnedCacheDemand(
@@ -875,7 +908,6 @@ export function NumericSeriesBridge({
             bucketDurationNs,
             horizon: window,
             horizonKey,
-            maxPointsPerField,
             pageCount: 0,
             preferredTimeNs,
             range,
@@ -895,6 +927,7 @@ export function NumericSeriesBridge({
           .readNumericSeriesSlice({
             absoluteBudget: ABSOLUTE_NUMERIC_SOURCE_UNIT_BUDGET,
             absoluteMaxChunks: ABSOLUTE_NUMERIC_SOURCE_UNIT_MAX_CHUNKS,
+            bucketDurationNs: sliceJob.bucketDurationNs,
             budget: isFirstPage
               ? FIRST_NUMERIC_SLICE_BUDGET
               : STEADY_NUMERIC_SLICE_BUDGET,
@@ -902,7 +935,6 @@ export function NumericSeriesBridge({
             maxChunks: isFirstPage
               ? FIRST_NUMERIC_SLICE_MAX_CHUNKS
               : STEADY_NUMERIC_SLICE_MAX_CHUNKS,
-            maxPointsPerField: sliceJob.maxPointsPerField,
             preferredTimeNs: sliceJob.preferredTimeNs,
             selections: sliceJob.selections,
             signal: controller.signal,
@@ -965,29 +997,36 @@ export function NumericSeriesBridge({
                     0) > 0,
               });
             }
-            putKnownEmpty(
-              sliceJob.selections,
-              result.coverageByStream,
-              sliceJob.bucketDurationNs,
-              timeOriginNs,
-            );
             putUnavailable(
               sliceJob.selections,
               result.unavailableByStream ?? new Map(),
               sliceJob.bucketDurationNs,
               timeOriginNs,
             );
+            const inspectedThroughNs = result.continuation
+              ? result.resumeAtNs !== undefined
+                ? result.resumeAtNs - 1n
+                : undefined
+              : result.stopReason === "horizon-reached" ||
+                  result.stopReason === "oversized-source-unit" ||
+                  result.stopReason === "source-exhausted"
+                ? sliceJob.range.endNs
+                : undefined;
             if (
-              !result.continuation &&
-              (result.stopReason === "source-exhausted" ||
-                result.stopReason === "oversized-source-unit")
+              inspectedThroughNs !== undefined &&
+              inspectedThroughNs >= sliceJob.range.startNs
             ) {
               putKnownEmpty(
                 sliceJob.selections,
                 new Map(
                   sliceJob.selections.map((selection) => [
                     selection.stream,
-                    [sliceJob.range],
+                    [
+                      {
+                        endNs: inspectedThroughNs,
+                        startNs: sliceJob.range.startNs,
+                      },
+                    ],
                   ]),
                 ),
                 sliceJob.bucketDurationNs,
@@ -1142,8 +1181,15 @@ function numericSeriesDemandPointBudget(
   viewports: Iterable<NumericSeriesViewportDemand>,
 ): number {
   const pinned = smallestPinnedViewport(viewports);
-  if (!pinned) return numericSeriesWindowPointBudget(range, durationSec);
-  return Math.max(200, Math.min(4_000, Math.round(pinned.pixelWidth * 2)));
+  const viewport = pinned ?? widestViewport(viewports);
+  if (!viewport) return numericSeriesWindowPointBudget(range, durationSec);
+  return Math.max(
+    ALIGNED_NUMERIC_BUCKET_MAX_POINTS,
+    Math.min(
+      MAX_NUMERIC_REPRESENTATIVE_POINTS,
+      Math.round(viewport.pixelWidth) * ALIGNED_NUMERIC_BUCKET_MAX_POINTS,
+    ),
+  );
 }
 
 function numericSeriesBucketDurationNs(
@@ -1151,13 +1197,17 @@ function numericSeriesBucketDurationNs(
   maxPoints: number,
 ): bigint {
   const spanNs = range.endNs - range.startNs + 1n;
-  const buckets = BigInt(
-    Math.max(
-      1,
-      Math.floor((maxPoints - 2) / NUMERIC_SERIES_MAX_BUCKET_SURVIVORS),
+  const buckets = Math.max(
+    2,
+    Math.min(
+      Math.floor(
+        MAX_NUMERIC_REPRESENTATIVE_POINTS / ALIGNED_NUMERIC_BUCKET_MAX_POINTS,
+      ),
+      Math.floor(maxPoints / ALIGNED_NUMERIC_BUCKET_MAX_POINTS),
     ),
   );
-  return (spanNs + buckets - 1n) / buckets;
+  const intervals = BigInt(buckets - 1);
+  return (spanNs + intervals - 1n) / intervals;
 }
 
 function smallestPinnedViewport(
@@ -1169,6 +1219,14 @@ function smallestPinnedViewport(
       (left, right) =>
         left.endSec - left.startSec - (right.endSec - right.startSec),
     )[0];
+}
+
+function widestViewport(
+  viewports: Iterable<NumericSeriesViewportDemand>,
+): NumericSeriesViewportDemand | undefined {
+  return [...viewports].sort(
+    (left, right) => right.pixelWidth - left.pixelWidth,
+  )[0];
 }
 
 function selectionsForNumericSeriesKeys(

--- a/app/packages/multimodal/src/views/episode/plots/numeric-series-context.tsx
+++ b/app/packages/multimodal/src/views/episode/plots/numeric-series-context.tsx
@@ -1186,8 +1186,9 @@ function numericSeriesDemandPointBudget(
   durationSec: number,
   viewports: Iterable<NumericSeriesViewportDemand>,
 ): number {
-  const pinned = smallestPinnedViewport(viewports);
-  const viewport = pinned ?? widestViewport(viewports);
+  const viewportList = [...viewports];
+  const pinned = smallestPinnedViewport(viewportList);
+  const viewport = pinned ?? widestViewport(viewportList);
   if (!viewport) return numericSeriesWindowPointBudget(range, durationSec);
   return Math.max(
     ALIGNED_NUMERIC_BUCKET_MAX_POINTS,

--- a/app/packages/multimodal/src/views/episode/plots/numeric-series-context.tsx
+++ b/app/packages/multimodal/src/views/episode/plots/numeric-series-context.tsx
@@ -430,6 +430,7 @@ export function NumericSeriesBridge({
       readonly baseTimeNs: bigint;
       readonly bucketDurationNs: bigint;
       readonly fields: readonly {
+        readonly bucketIndexes?: BigInt64Array;
         readonly path: string;
         readonly timesSec: Float64Array;
         readonly values: Float64Array;
@@ -459,6 +460,9 @@ export function NumericSeriesBridge({
             );
             cache.put({
               bucketDurationNs,
+              ...(sliced.bucketIndexes
+                ? { bucketIndexes: sliced.bucketIndexes }
+                : {}),
               coverageRanges: [missingRange],
               range: missingRange,
               seriesKey: key,
@@ -576,6 +580,7 @@ export function NumericSeriesBridge({
           });
           const flat = flattenSeriesSegments(
             visible.parts.map((part) => ({
+              bucketIndexes: part.bucketIndexes,
               endNs: part.range.endNs,
               startNs: part.range.startNs,
               timesSec: part.timesSec,
@@ -588,6 +593,7 @@ export function NumericSeriesBridge({
             flat.values,
             tileOriginNs,
             bucketDurationNs,
+            flat.bucketIndexes,
           );
           setPublished(key, {
             coverage: visible.coverageRanges,
@@ -1224,9 +1230,11 @@ function smallestPinnedViewport(
 function widestViewport(
   viewports: Iterable<NumericSeriesViewportDemand>,
 ): NumericSeriesViewportDemand | undefined {
-  return [...viewports].sort(
-    (left, right) => right.pixelWidth - left.pixelWidth,
-  )[0];
+  let widest: NumericSeriesViewportDemand | undefined;
+  for (const viewport of viewports) {
+    if (!widest || viewport.pixelWidth > widest.pixelWidth) widest = viewport;
+  }
+  return widest;
 }
 
 function selectionsForNumericSeriesKeys(

--- a/app/packages/multimodal/src/visualization/plot/TimeseriesChart.test.tsx
+++ b/app/packages/multimodal/src/visualization/plot/TimeseriesChart.test.tsx
@@ -176,10 +176,9 @@ describe("TimeseriesChart interactions", () => {
     fireEvent.click(screen.getByLabelText("Zoom in"));
     expect(resetZoom.getAttribute("data-active")).toBe("true");
     expect(chart.scales.x).toEqual({ min: 2, max: 18 });
-    // The y domain seeds from the data ([1, 2] padded to [0.95, 2.05]),
-    // so zooming in scales that window rather than the mock's preset.
-    expect(chart.scales.y.min).toBeCloseTo(1.06, 6);
-    expect(chart.scales.y.max).toBeCloseTo(1.94, 6);
+    // No samples fall inside [2, 18], so the previous fitted y domain stays.
+    expect(chart.scales.y.min).toBeCloseTo(0.95, 6);
+    expect(chart.scales.y.max).toBeCloseTo(2.05, 6);
     expect(chart.setScale).toHaveBeenCalledWith("x", {
       min: 2,
       max: 18,
@@ -265,7 +264,7 @@ describe("TimeseriesChart interactions", () => {
     unmount();
   });
 
-  it("keeps the y domain stable while progressive data fills", () => {
+  it("auto-fits the y domain when coherent data changes", () => {
     const { rerender, unmount } = renderChart();
     const chart = lastChart();
     chart.setScale.mockClear();
@@ -282,10 +281,9 @@ describe("TimeseriesChart interactions", () => {
         series={[{ color: "#f00", label: "speed" }]}
       />,
     );
-    // The mount seed ([0.95, 2.05] from the initial data) only expands.
     expect(chart.setScale).toHaveBeenLastCalledWith("y", {
       max: 5.05,
-      min: 0.95,
+      min: 3.95,
     });
 
     const wider = [
@@ -337,56 +335,32 @@ describe("TimeseriesChart interactions", () => {
     unmount();
   });
 
-  it("ignores its own asynchronously committed y writes but adopts user zooms", () => {
-    const { rerender, unmount } = renderChart();
-    const chart = lastChart();
-    const fireSetScale = (key: string) => {
-      const hooks = chart.options.hooks?.setScale;
-      for (const hook of Array.isArray(hooks) ? hooks : [hooks]) {
-        (hook as (chart: MockChart, key: string) => void)(chart, key);
-      }
-    };
-
-    // An own write committing late must not be misread as a user zoom:
-    // the stable domain keeps expanding from the seeded range afterwards.
-    fireSetScale("y");
-    const wider = [
-      [0, 10, 20],
-      [-20, 30, 0],
+  it("excludes finite values outside coherent coverage from the y domain", () => {
+    const coveredData = [
+      [0, 5, 10, 15],
+      [1, 3, 5, 1_000],
     ] as AlignedData;
-    rerender(
+    const { unmount } = render(
       <TimeseriesChart
         {...FOLLOW_POLICY_PROPS}
-        data={wider}
+        coverageRanges={[{ endSec: 10, startSec: 0 }]}
+        data={coveredData}
         durationSec={20}
         series={[{ color: "#f00", label: "speed" }]}
       />,
     );
+    const chart = lastChart();
     expect(chart.setScale).toHaveBeenLastCalledWith("y", {
-      max: 32.5,
-      min: -22.5,
+      max: 5.2,
+      min: 0.8,
     });
 
-    // A range this surface never wrote is a real user zoom and becomes
-    // the new stable domain that later data only expands.
-    chart.scales.y.min = -50;
-    chart.scales.y.max = 60;
-    fireSetScale("y");
-    const narrower = [
-      [0, 10, 20],
-      [4, 5, 4],
-    ] as AlignedData;
-    rerender(
-      <TimeseriesChart
-        {...FOLLOW_POLICY_PROPS}
-        data={narrower}
-        durationSec={20}
-        series={[{ color: "#f00", label: "speed" }]}
-      />,
-    );
+    chart.scales.x.min = 5;
+    chart.scales.x.max = 10;
+    runHooks(chart.options.hooks?.setScale, chart, "x");
     expect(chart.setScale).toHaveBeenLastCalledWith("y", {
-      max: 60,
-      min: -50,
+      max: 5.1,
+      min: 2.9,
     });
     unmount();
   });

--- a/app/packages/multimodal/src/visualization/plot/TimeseriesChart.test.tsx
+++ b/app/packages/multimodal/src/visualization/plot/TimeseriesChart.test.tsx
@@ -176,19 +176,19 @@ describe("TimeseriesChart interactions", () => {
     fireEvent.click(screen.getByLabelText("Zoom in"));
     expect(resetZoom.getAttribute("data-active")).toBe("true");
     expect(chart.scales.x).toEqual({ min: 2, max: 18 });
-    expect(chart.scales.y).toEqual({ min: 1, max: 9 });
+    // The y domain seeds from the data ([1, 2] padded to [0.95, 2.05]),
+    // so zooming in scales that window rather than the mock's preset.
+    expect(chart.scales.y.min).toBeCloseTo(1.06, 6);
+    expect(chart.scales.y.max).toBeCloseTo(1.94, 6);
     expect(chart.setScale).toHaveBeenCalledWith("x", {
       min: 2,
       max: 18,
     });
-    expect(chart.setScale).toHaveBeenCalledWith("y", {
-      min: 1,
-      max: 9,
-    });
 
     fireEvent.click(screen.getByLabelText("Zoom out"));
     expect(chart.scales.x).toEqual({ min: 0, max: 20 });
-    expect(chart.scales.y).toEqual({ min: 0, max: 10 });
+    expect(chart.scales.y.min).toBeCloseTo(0.95, 6);
+    expect(chart.scales.y.max).toBeCloseTo(2.05, 6);
 
     chart.setData.mockClear();
     chart.over.dispatchEvent(new MouseEvent("dblclick", { bubbles: true }));
@@ -282,9 +282,10 @@ describe("TimeseriesChart interactions", () => {
         series={[{ color: "#f00", label: "speed" }]}
       />,
     );
+    // The mount seed ([0.95, 2.05] from the initial data) only expands.
     expect(chart.setScale).toHaveBeenLastCalledWith("y", {
-      max: 10,
-      min: 0,
+      max: 5.05,
+      min: 0.95,
     });
 
     const wider = [
@@ -302,6 +303,90 @@ describe("TimeseriesChart interactions", () => {
     expect(chart.setScale).toHaveBeenLastCalledWith("y", {
       max: 32.5,
       min: -22.5,
+    });
+    unmount();
+  });
+
+  it("sources the stable y domain from the intended window, not mid-commit scales", () => {
+    const { rerender, unmount } = renderChart();
+    const chart = lastChart();
+    // Simulate uPlot mid-commit: the x scale reads as a degenerate window
+    // while newly published data arrives. The y domain must come from the
+    // intended follow window, never from this transient scale state.
+    chart.scales.x.min = 0;
+    chart.scales.x.max = 0;
+    chart.setScale.mockClear();
+
+    const arrived = [
+      [0, 10, 20],
+      [1, -80, 90],
+    ] as AlignedData;
+    rerender(
+      <TimeseriesChart
+        {...FOLLOW_POLICY_PROPS}
+        data={arrived}
+        durationSec={20}
+        series={[{ color: "#f00", label: "speed" }]}
+      />,
+    );
+    const lastY = chart.setScale.mock.calls
+      .filter((call) => call[0] === "y")
+      .at(-1)?.[1] as { max: number; min: number };
+    expect(lastY.min).toBeLessThanOrEqual(-80);
+    expect(lastY.max).toBeGreaterThanOrEqual(90);
+    unmount();
+  });
+
+  it("ignores its own asynchronously committed y writes but adopts user zooms", () => {
+    const { rerender, unmount } = renderChart();
+    const chart = lastChart();
+    const fireSetScale = (key: string) => {
+      const hooks = chart.options.hooks?.setScale;
+      for (const hook of Array.isArray(hooks) ? hooks : [hooks]) {
+        (hook as (chart: MockChart, key: string) => void)(chart, key);
+      }
+    };
+
+    // An own write committing late must not be misread as a user zoom:
+    // the stable domain keeps expanding from the seeded range afterwards.
+    fireSetScale("y");
+    const wider = [
+      [0, 10, 20],
+      [-20, 30, 0],
+    ] as AlignedData;
+    rerender(
+      <TimeseriesChart
+        {...FOLLOW_POLICY_PROPS}
+        data={wider}
+        durationSec={20}
+        series={[{ color: "#f00", label: "speed" }]}
+      />,
+    );
+    expect(chart.setScale).toHaveBeenLastCalledWith("y", {
+      max: 32.5,
+      min: -22.5,
+    });
+
+    // A range this surface never wrote is a real user zoom and becomes
+    // the new stable domain that later data only expands.
+    chart.scales.y.min = -50;
+    chart.scales.y.max = 60;
+    fireSetScale("y");
+    const narrower = [
+      [0, 10, 20],
+      [4, 5, 4],
+    ] as AlignedData;
+    rerender(
+      <TimeseriesChart
+        {...FOLLOW_POLICY_PROPS}
+        data={narrower}
+        durationSec={20}
+        series={[{ color: "#f00", label: "speed" }]}
+      />,
+    );
+    expect(chart.setScale).toHaveBeenLastCalledWith("y", {
+      max: 60,
+      min: -50,
     });
     unmount();
   });

--- a/app/packages/multimodal/src/visualization/plot/TimeseriesChart.tsx
+++ b/app/packages/multimodal/src/visualization/plot/TimeseriesChart.tsx
@@ -222,26 +222,38 @@ function finiteYRange(
   return [min - padding, max + padding];
 }
 
+/** Recent own y writes retained to recognize their asynchronous commits. */
+const OWN_Y_WRITE_HISTORY = 4;
+
+/**
+ * Expands the stable y domain from the finite data inside `window` and
+ * applies it. The window is the caller's intended x viewport, never
+ * `chart.scales.x`: uPlot commits scale writes asynchronously, so reading
+ * scales mid-update can source a degenerate window and freeze the domain
+ * on a garbage range. Every write is remembered so the y setScale hook can
+ * tell this surface's own commits apart from a user zoom.
+ */
 function setStableYRange(
   chart: uPlot,
   data: AlignedData,
   stableRef: React.MutableRefObject<readonly [number, number] | null>,
-  settingRef: React.MutableRefObject<boolean>,
+  ownWritesRef: React.MutableRefObject<(readonly [number, number])[]>,
+  window: readonly [number, number],
   reset: boolean,
 ): void {
   if (reset) stableRef.current = null;
-  const xMin = chart.scales.x.min ?? 0;
-  const xMax = chart.scales.x.max ?? xMin;
-  const candidate = finiteYRange(data, xMin, xMax);
+  const candidate = finiteYRange(data, window[0], window[1]);
   if (!candidate) return;
   const previous = stableRef.current;
   const stable: readonly [number, number] = previous
     ? [Math.min(previous[0], candidate[0]), Math.max(previous[1], candidate[1])]
     : candidate;
   stableRef.current = stable;
-  settingRef.current = true;
+  ownWritesRef.current.push(stable);
+  if (ownWritesRef.current.length > OWN_Y_WRITE_HISTORY) {
+    ownWritesRef.current.shift();
+  }
   chart.setScale("y", { min: stable[0], max: stable[1] });
-  settingRef.current = false;
 }
 
 function renderCoverageBands(
@@ -357,7 +369,8 @@ const TimeseriesChart: React.FC<TimeseriesChartProps> = ({
   const [zoomConstrained, setZoomConstrained] = useState(false);
   const coverageLayerRef = useRef<HTMLDivElement | null>(null);
   const stableYRangeRef = useRef<readonly [number, number] | null>(null);
-  const settingStableYRef = useRef(false);
+  const ownYWritesRef = useRef<(readonly [number, number])[]>([]);
+  const stableXWindowRef = useRef<readonly [number, number]>([0, 0]);
   const dataRef = useRef(data);
   dataRef.current = data;
   const seriesRef = useRef(series);
@@ -436,6 +449,8 @@ const TimeseriesChart: React.FC<TimeseriesChartProps> = ({
     hasInteractiveScaleRef.current = false;
     setZoomConstrained(false);
     stableYRangeRef.current = null;
+    ownYWritesRef.current = [];
+    stableXWindowRef.current = [0, xMax];
     const xLimits = [0, xMax] as const;
     let viewportFrame: number | undefined;
     let stableViewportKey = "";
@@ -500,14 +515,20 @@ const TimeseriesChart: React.FC<TimeseriesChartProps> = ({
         setScale: [
           (chart, key) => {
             if (key === "x") {
-              const viewportKey = `${chart.scales.x.min}:${chart.scales.x.max}`;
+              const xWindow: readonly [number, number] = [
+                chart.scales.x.min ?? 0,
+                chart.scales.x.max ?? xMax,
+              ];
+              stableXWindowRef.current = xWindow;
+              const viewportKey = `${xWindow[0]}:${xWindow[1]}`;
               if (viewportKey !== stableViewportKey) {
                 stableViewportKey = viewportKey;
                 setStableYRange(
                   chart,
                   dataRef.current,
                   stableYRangeRef,
-                  settingStableYRef,
+                  ownYWritesRef,
+                  xWindow,
                   true,
                 );
               }
@@ -518,10 +539,19 @@ const TimeseriesChart: React.FC<TimeseriesChartProps> = ({
                 unavailableRangesRef.current,
               );
               queueViewportPublication(chart);
-            } else if (key === "y" && !settingStableYRef.current) {
+            } else if (key === "y") {
               const min = chart.scales.y.min;
               const max = chart.scales.y.max;
-              if (min !== undefined && max !== undefined) {
+              if (min === undefined || max === undefined) {
+                return;
+              }
+              // Own writes commit asynchronously, possibly after a newer
+              // write superseded them; only a range this surface never set
+              // is a user zoom worth adopting as the stable domain.
+              const own = ownYWritesRef.current.some(
+                (write) => write[0] === min && write[1] === max,
+              );
+              if (!own) {
                 stableYRangeRef.current = [min, max];
               }
             }
@@ -562,13 +592,21 @@ const TimeseriesChart: React.FC<TimeseriesChartProps> = ({
 
     const chart = new uPlot(options, dataRef.current, host);
     chartRef.current = chart;
-    chart.setScale("x", { min: 0, max: xMax });
-    const initialYMin = chart.scales.y.min;
-    const initialYMax = chart.scales.y.max;
-    stableYRangeRef.current =
-      initialYMin !== undefined && initialYMax !== undefined
-        ? [initialYMin, initialYMax]
-        : null;
+    // A bare setScale on a freshly constructed chart may never commit, and
+    // an uncommitted x scale strokes nothing. The reset batch — setData with
+    // a scale reset plus the explicit x range — is the sequence uPlot
+    // reliably commits, so the first paint always has real scales.
+    resetTimeseriesChart(chart, dataRef.current, [0, xMax]);
+    // Seed the y domain from the data over the intended follow window; the
+    // chart's own scales may not have committed yet at this point.
+    setStableYRange(
+      chart,
+      dataRef.current,
+      stableYRangeRef,
+      ownYWritesRef,
+      [0, xMax],
+      true,
+    );
 
     const coverageLayer = document.createElement("div");
     coverageLayer.className = styles.coverageLayer;
@@ -890,7 +928,20 @@ const TimeseriesChart: React.FC<TimeseriesChartProps> = ({
       return;
     }
     chart.setData(data, false);
-    setStableYRange(chart, data, stableYRangeRef, settingStableYRef, false);
+    if (chart.scales.x.min == null || chart.scales.x.max == null) {
+      // A chart that missed its initial scale commit (created mid-transition,
+      // superseded by a recreation) strokes nothing; give it the committing
+      // reset sequence over the intended window once.
+      resetTimeseriesChart(chart, data, stableXWindowRef.current);
+    }
+    setStableYRange(
+      chart,
+      data,
+      stableYRangeRef,
+      ownYWritesRef,
+      stableXWindowRef.current,
+      false,
+    );
     chart.redraw();
     if (!pointerInsideRef.current) {
       syncLegendCursor(

--- a/app/packages/multimodal/src/visualization/plot/TimeseriesChart.tsx
+++ b/app/packages/multimodal/src/visualization/plot/TimeseriesChart.tsx
@@ -351,12 +351,14 @@ function appendCoverageBand(
  * acquired data from unread and hard-unavailable spans. Touch gestures or
  * controls pin a viewport whose range and pixel width drive acquisition.
  */
+const EMPTY_COVERAGE_RANGES: readonly TimeseriesCoverageRange[] = [];
+
 const TimeseriesChart: React.FC<TimeseriesChartProps> = ({
   data,
   durationSec,
   followWindowQuantumSeconds,
   followWindowSeconds,
-  coverageRanges = [],
+  coverageRanges = EMPTY_COVERAGE_RANGES,
   onHoverTime,
   onSeek,
   onSeekEnd,
@@ -365,7 +367,7 @@ const TimeseriesChart: React.FC<TimeseriesChartProps> = ({
   registerPlayheadListener,
   resetZoomRevision = 0,
   series,
-  unavailableRanges = [],
+  unavailableRanges = EMPTY_COVERAGE_RANGES,
 }) => {
   const plotRef = useRef<HTMLDivElement | null>(null);
   const chartRef = useRef<uPlot | null>(null);

--- a/app/packages/multimodal/src/visualization/plot/TimeseriesChart.tsx
+++ b/app/packages/multimodal/src/visualization/plot/TimeseriesChart.tsx
@@ -198,15 +198,39 @@ function finiteYRange(
   data: AlignedData,
   startSec: number,
   endSec: number,
+  coverage: readonly TimeseriesCoverageRange[],
 ): readonly [number, number] | null {
   const xs = data[0];
+  const visibleCoverage =
+    coverage.length > 0
+      ? mergeCoverageRanges(coverage, startSec, endSec)
+      : null;
+  const visible = new Uint8Array(xs.length);
+  let coverageIndex = 0;
+  for (let index = 0; index < xs.length; index += 1) {
+    const x = xs[index];
+    if (x < startSec || x > endSec) continue;
+    if (!visibleCoverage) {
+      visible[index] = 1;
+      continue;
+    }
+    while (
+      coverageIndex < visibleCoverage.length &&
+      visibleCoverage[coverageIndex].endSec < x
+    ) {
+      coverageIndex += 1;
+    }
+    const range = visibleCoverage[coverageIndex];
+    if (range && x >= range.startSec && x <= range.endSec) {
+      visible[index] = 1;
+    }
+  }
   let min = Number.POSITIVE_INFINITY;
   let max = Number.NEGATIVE_INFINITY;
   for (let column = 1; column < data.length; column += 1) {
     const values = data[column];
     for (let index = 0; index < xs.length; index += 1) {
-      const x = xs[index];
-      if (x < startSec || x > endSec) continue;
+      if (visible[index] === 0) continue;
       const value = values[index];
       if (typeof value !== "number" || !Number.isFinite(value)) continue;
       if (value < min) min = value;
@@ -215,45 +239,31 @@ function finiteYRange(
   }
   if (!Number.isFinite(min) || !Number.isFinite(max)) return null;
   if (min === max) {
-    const padding = Math.max(Math.abs(min) * 0.05, 1);
+    const padding = Math.max(Math.abs(min) * 0.05, 1e-6);
     return [min - padding, max + padding];
   }
   const padding = (max - min) * 0.05;
   return [min - padding, max + padding];
 }
 
-/** Recent own y writes retained to recognize their asynchronous commits. */
-const OWN_Y_WRITE_HISTORY = 4;
-
 /**
- * Expands the stable y domain from the finite data inside `window` and
- * applies it. The window is the caller's intended x viewport, never
- * `chart.scales.x`: uPlot commits scale writes asynchronously, so reading
- * scales mid-update can source a degenerate window and freeze the domain
- * on a garbage range. Every write is remembered so the y setScale hook can
- * tell this surface's own commits apart from a user zoom.
+ * Fits y to finite, coherently loaded data inside the intended x viewport.
+ * When no replacement values are ready, the last finite domain is restored.
+ * The caller supplies the x viewport because uPlot commits scale writes
+ * asynchronously and a mid-commit scale read can be degenerate.
  */
-function setStableYRange(
+function fitVisibleYRange(
   chart: uPlot,
   data: AlignedData,
-  stableRef: React.MutableRefObject<readonly [number, number] | null>,
-  ownWritesRef: React.MutableRefObject<(readonly [number, number])[]>,
+  coverage: readonly TimeseriesCoverageRange[],
+  previousRef: React.MutableRefObject<readonly [number, number] | null>,
   window: readonly [number, number],
-  reset: boolean,
 ): void {
-  if (reset) stableRef.current = null;
-  const candidate = finiteYRange(data, window[0], window[1]);
-  if (!candidate) return;
-  const previous = stableRef.current;
-  const stable: readonly [number, number] = previous
-    ? [Math.min(previous[0], candidate[0]), Math.max(previous[1], candidate[1])]
-    : candidate;
-  stableRef.current = stable;
-  ownWritesRef.current.push(stable);
-  if (ownWritesRef.current.length > OWN_Y_WRITE_HISTORY) {
-    ownWritesRef.current.shift();
-  }
-  chart.setScale("y", { min: stable[0], max: stable[1] });
+  const next = finiteYRange(data, window[0], window[1], coverage);
+  if (next) previousRef.current = next;
+  const range = next ?? previousRef.current;
+  if (!range) return;
+  chart.setScale("y", { min: range[0], max: range[1] });
 }
 
 function renderCoverageBands(
@@ -368,8 +378,7 @@ const TimeseriesChart: React.FC<TimeseriesChartProps> = ({
   const hasInteractiveScaleRef = useRef(false);
   const [zoomConstrained, setZoomConstrained] = useState(false);
   const coverageLayerRef = useRef<HTMLDivElement | null>(null);
-  const stableYRangeRef = useRef<readonly [number, number] | null>(null);
-  const ownYWritesRef = useRef<(readonly [number, number])[]>([]);
+  const visibleYRangeRef = useRef<readonly [number, number] | null>(null);
   const stableXWindowRef = useRef<readonly [number, number]>([0, 0]);
   const dataRef = useRef(data);
   dataRef.current = data;
@@ -417,15 +426,19 @@ const TimeseriesChart: React.FC<TimeseriesChartProps> = ({
     }
     hasInteractiveScaleRef.current = false;
     setZoomConstrained(false);
-    resetTimeseriesChart(
+    const xRange = followTimeseriesRange(
+      playheadSecRef.current ?? 0,
+      durationSec,
+      followWindowSeconds,
+      followWindowQuantumSeconds,
+    );
+    resetTimeseriesChart(chart, dataRef.current, xRange);
+    fitVisibleYRange(
       chart,
       dataRef.current,
-      followTimeseriesRange(
-        playheadSecRef.current ?? 0,
-        durationSec,
-        followWindowSeconds,
-        followWindowQuantumSeconds,
-      ),
+      coverageRangesRef.current,
+      visibleYRangeRef,
+      xRange,
     );
     if (!pointerInsideRef.current) {
       syncLegendCursor(
@@ -448,8 +461,7 @@ const TimeseriesChart: React.FC<TimeseriesChartProps> = ({
     }
     hasInteractiveScaleRef.current = false;
     setZoomConstrained(false);
-    stableYRangeRef.current = null;
-    ownYWritesRef.current = [];
+    visibleYRangeRef.current = null;
     stableXWindowRef.current = [0, xMax];
     const xLimits = [0, xMax] as const;
     let viewportFrame: number | undefined;
@@ -523,13 +535,12 @@ const TimeseriesChart: React.FC<TimeseriesChartProps> = ({
               const viewportKey = `${xWindow[0]}:${xWindow[1]}`;
               if (viewportKey !== stableViewportKey) {
                 stableViewportKey = viewportKey;
-                setStableYRange(
+                fitVisibleYRange(
                   chart,
                   dataRef.current,
-                  stableYRangeRef,
-                  ownYWritesRef,
+                  coverageRangesRef.current,
+                  visibleYRangeRef,
                   xWindow,
-                  true,
                 );
               }
               renderCoverageBands(
@@ -539,21 +550,6 @@ const TimeseriesChart: React.FC<TimeseriesChartProps> = ({
                 unavailableRangesRef.current,
               );
               queueViewportPublication(chart);
-            } else if (key === "y") {
-              const min = chart.scales.y.min;
-              const max = chart.scales.y.max;
-              if (min === undefined || max === undefined) {
-                return;
-              }
-              // Own writes commit asynchronously, possibly after a newer
-              // write superseded them; only a range this surface never set
-              // is a user zoom worth adopting as the stable domain.
-              const own = ownYWritesRef.current.some(
-                (write) => write[0] === min && write[1] === max,
-              );
-              if (!own) {
-                stableYRangeRef.current = [min, max];
-              }
             }
           },
         ],
@@ -599,13 +595,12 @@ const TimeseriesChart: React.FC<TimeseriesChartProps> = ({
     resetTimeseriesChart(chart, dataRef.current, [0, xMax]);
     // Seed the y domain from the data over the intended follow window; the
     // chart's own scales may not have committed yet at this point.
-    setStableYRange(
+    fitVisibleYRange(
       chart,
       dataRef.current,
-      stableYRangeRef,
-      ownYWritesRef,
+      coverageRangesRef.current,
+      visibleYRangeRef,
       [0, xMax],
-      true,
     );
 
     const coverageLayer = document.createElement("div");
@@ -919,9 +914,9 @@ const TimeseriesChart: React.FC<TimeseriesChartProps> = ({
     };
   }, [durationSec, seriesIdentity, xMax]);
 
-  // This effect pushes progressive data without resetting either viewport.
-  // The y domain may expand to reveal new extrema, but never contracts while
-  // the same viewport fills, avoiding page-by-page scale oscillation.
+  // This effect pushes coherent data without resetting the x viewport. The
+  // y domain follows finite values in that viewport; the provider retains the
+  // prior coherent data while a replacement is still loading.
   useEffect(() => {
     const chart = chartRef.current;
     if (!chart) {
@@ -934,13 +929,12 @@ const TimeseriesChart: React.FC<TimeseriesChartProps> = ({
       // reset sequence over the intended window once.
       resetTimeseriesChart(chart, data, stableXWindowRef.current);
     }
-    setStableYRange(
+    fitVisibleYRange(
       chart,
       data,
-      stableYRangeRef,
-      ownYWritesRef,
+      coverageRangesRef.current,
+      visibleYRangeRef,
       stableXWindowRef.current,
-      false,
     );
     chart.redraw();
     if (!pointerInsideRef.current) {
@@ -970,6 +964,13 @@ const TimeseriesChart: React.FC<TimeseriesChartProps> = ({
       coverageLayerRef.current,
       coverageRanges,
       unavailableRanges,
+    );
+    fitVisibleYRange(
+      chart,
+      dataRef.current,
+      coverageRanges,
+      visibleYRangeRef,
+      stableXWindowRef.current,
     );
   }, [coverageRanges, unavailableRanges]);
 

--- a/app/packages/multimodal/src/visualization/plot/timeseries-zoom.test.ts
+++ b/app/packages/multimodal/src/visualization/plot/timeseries-zoom.test.ts
@@ -13,18 +13,15 @@ afterEach(() => {
 });
 
 describe("zoomTimeseriesChart", () => {
-  it("zooms both axes around their midpoint", () => {
+  it("zooms only x around its midpoint", () => {
     const chart = chartStub({ x: [0, 100], y: [-50, 50] });
 
     zoomTimeseriesChart(chart.value, TIMESERIES_ZOOM_IN_FACTOR, [0, 100]);
 
-    expect(chart.setScale).toHaveBeenNthCalledWith(1, "x", {
+    expect(chart.setScale).toHaveBeenCalledOnce();
+    expect(chart.setScale).toHaveBeenCalledWith("x", {
       min: 10,
       max: 90,
-    });
-    expect(chart.setScale).toHaveBeenNthCalledWith(2, "y", {
-      min: -40,
-      max: 40,
     });
   });
 
@@ -33,13 +30,10 @@ describe("zoomTimeseriesChart", () => {
 
     zoomTimeseriesChart(chart.value, TIMESERIES_ZOOM_OUT_FACTOR, [0, 100]);
 
-    expect(chart.setScale).toHaveBeenNthCalledWith(1, "x", {
+    expect(chart.setScale).toHaveBeenCalledOnce();
+    expect(chart.setScale).toHaveBeenCalledWith("x", {
       min: 0,
       max: 100,
-    });
-    expect(chart.setScale).toHaveBeenNthCalledWith(2, "y", {
-      min: -50,
-      max: 50,
     });
   });
 
@@ -77,7 +71,7 @@ describe("touchZoomPanPlugin", () => {
     destroyPlugin(plugin, chart.value);
   });
 
-  it("pinches uniformly around the gesture midpoint", () => {
+  it("pinches x around the gesture midpoint without changing y", () => {
     const chart = interactiveChartStub({ x: [20, 80], y: [20, 80] });
     const plugin = touchZoomPanPlugin({ xLimits: [0, 100] });
     initializePlugin(plugin, chart.value);
@@ -94,7 +88,7 @@ describe("touchZoomPanPlugin", () => {
     runFrame();
 
     expect(chart.scales.x).toEqual({ min: 35, max: 65 });
-    expect(chart.scales.y).toEqual({ min: 35, max: 65 });
+    expect(chart.scales.y).toEqual({ min: 20, max: 80 });
 
     destroyPlugin(plugin, chart.value);
   });

--- a/app/packages/multimodal/src/visualization/plot/timeseries-zoom.ts
+++ b/app/packages/multimodal/src/visualization/plot/timeseries-zoom.ts
@@ -8,7 +8,6 @@ type Range = readonly [min: number, max: number];
 interface TouchPosition {
   readonly distance: number;
   readonly x: number;
-  readonly y: number;
 }
 
 interface TouchZoomPanPluginOptions {
@@ -17,9 +16,8 @@ interface TouchZoomPanPluginOptions {
 }
 
 /**
- * Zooms both chart axes around their current midpoint. The x range is
- * constrained to the recording while y remains free so signal offsets can be
- * inspected without losing the time domain.
+ * Zooms the time axis around its current midpoint, constrained to the
+ * recording. The chart independently auto-fits y to the resulting viewport.
  */
 export function zoomTimeseriesChart(
   chart: uPlot,
@@ -31,25 +29,16 @@ export function zoomTimeseriesChart(
   }
 
   const xRange = scaledRange(chart.scales.x, factor, xLimits);
-  const yRange = scaledRange(chart.scales.y, factor);
-  if (!xRange && !yRange) {
-    return;
-  }
-
+  if (!xRange) return;
   chart.batch(() => {
-    if (xRange) {
-      chart.setScale("x", { min: xRange[0], max: xRange[1] });
-    }
-    if (yRange) {
-      chart.setScale("y", { min: yRange[0], max: yRange[1] });
-    }
+    chart.setScale("x", { min: xRange[0], max: xRange[1] });
   });
 }
 
 /**
  * uPlot touch plugin based on its pinch-zoom demo. One finger pans and two
- * fingers pinch uniformly across x/y. Gesture state and document listeners
- * stay outside React so move-frequency work never causes component renders.
+ * fingers pinch the time axis only. Gesture state and document listeners stay
+ * outside React so move-frequency work never causes component renders.
  */
 export function touchZoomPanPlugin({
   onInteraction,
@@ -69,10 +58,8 @@ export function touchZoomPanPlugin({
         let initialPosition: TouchPosition | null = null;
         let currentPosition: TouchPosition | null = null;
         let initialXRange = 0;
-        let initialYRange = 0;
         let rect: DOMRect | null = null;
         let xAnchor = 0;
-        let yAnchor = 0;
         let tracking = false;
 
         const stopTracking = () => {
@@ -99,17 +86,11 @@ export function touchZoomPanPlugin({
           const xSize = initialXRange * factor;
           const xMin = xAnchor - (currentPosition.x / rect.width) * xSize;
           const nextXRange = clampRange([xMin, xMin + xSize], xLimits);
-
-          const ySize = initialYRange * factor;
-          const bottomFraction = 1 - currentPosition.y / rect.height;
-          const yMin = yAnchor - bottomFraction * ySize;
-
           chart.batch(() => {
             chart.setScale("x", {
               min: nextXRange[0],
               max: nextXRange[1],
             });
-            chart.setScale("y", { min: yMin, max: yMin + ySize });
           });
           onInteraction?.();
         };
@@ -122,17 +103,14 @@ export function touchZoomPanPlugin({
 
           const position = touchPosition(event.touches, rect);
           const xScale = finiteScaleRange(chart.scales.x);
-          const yScale = finiteScaleRange(chart.scales.y);
-          if (!position || !xScale || !yScale) {
+          if (!position || !xScale) {
             return;
           }
 
           initialPosition = position;
           currentPosition = position;
           initialXRange = xScale[1] - xScale[0];
-          initialYRange = yScale[1] - yScale[0];
           xAnchor = chart.posToVal(position.x, "x");
-          yAnchor = chart.posToVal(position.y, "y");
 
           if (!tracking) {
             tracking = true;
@@ -207,13 +185,13 @@ function touchPosition(
 
   const first = touches[0];
   const firstX = first.clientX - rect.left;
-  const firstY = first.clientY - rect.top;
   if (touches.length === 1) {
-    return { distance: 1, x: firstX, y: firstY };
+    return { distance: 1, x: firstX };
   }
 
   const second = touches[1];
   const secondX = second.clientX - rect.left;
+  const firstY = first.clientY - rect.top;
   const secondY = second.clientY - rect.top;
   const deltaX = secondX - firstX;
   const deltaY = secondY - firstY;
@@ -221,7 +199,6 @@ function touchPosition(
   return {
     distance: Math.max(Math.hypot(deltaX, deltaY), Number.EPSILON),
     x: (firstX + secondX) / 2,
-    y: (firstY + secondY) / 2,
   };
 }
 


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

MCAP numeric plots now read chronologically under the existing source budgets, summarize onto a viewport-sized absolute-time grid, and retain only bounded representatives in the tile cache. Publication advances through known contiguous coverage, preserves explicit source gaps and spikes, and keeps the previous coherent plot while a new range or resolution loads.

Zoom controls and drag selection now change time only. uPlot auto-fits y to finite values in the coherently loaded visible range and retains the previous y-domain until replacement data is ready.

## 🧪 How is this patch tested? If it is not, please explain why.

- `yarn vitest run --no-coverage` on the focused MCAP reader, bucket aggregation, tile cache, numeric window/context/join, uPlot chart, and zoom suites: 156 tests passed across 9 files.
- `yarn workspace @fiftyone/multimodal check`: lint, dependency, architecture, bounded-read, and package type checks passed.
- Manually verified NIULINX IMU and odometry plus nuScenes numeric signals across time zoom, fullscreen resize, progressive loading, and field toggling. Traces remained continuous, spikes remained visible, replacement data did not blank or jump, and the browser console stayed clean.

## Notes to Reviewer

Best reviewed commit-by-commit. The core slices are the aligned MCAP aggregation and cache path, coherent publication, and x-only uPlot scale behavior.

## High Level Architecture

Bounded indexed MCAP pages produce deterministic min/max summaries on an absolute-time grid. Exact bucket identities follow representatives through the bounded tile cache so continuation boundaries and loading order cannot change aggregation. The plot context publishes only complete contiguous bucket prefixes, then uPlot renders that coherent data and fits y within the visible x-range.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

MCAP numeric plots now load continuously without temporary interior gaps, preserve spikes and real source gaps, and keep stable x-only zoom with visible-range y fitting.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3950
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Numeric-series data now uses time-aligned buckets with exact bucket identities.
  - Progressive loading can resume from the earliest uninspected timestamp.
  - Charts preserve coherent data while refined results load and handle gaps more accurately.
  - Y-axis fitting now responds to visible, covered data.

- **Improvements**
  - Zooming and pinch gestures now affect only the time axis.
  - Numeric-series rendering better preserves spikes, gaps, and contiguous coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->