### PR TITLE
Add Label Studio VectorLabels support for polylines

### DIFF
--- a/docs/source/integrations/labelstudio.rst
+++ b/docs/source/integrations/labelstudio.rst
@@ -189,6 +189,12 @@ In order to use the Label Studio backend, you must install the
 
     pip install label-studio-sdk
 
+.. note::
+
+    Polyline annotation requires a Label Studio server version of 1.23.0 or
+    later. This is a server requirement, not a Label Studio Python SDK version
+    requirement.
+
 Using the Label Studio backend
 ------------------------------
 
@@ -434,7 +440,8 @@ more details:
         attributes populated
     -   ``"polylines"``: polylines stored in |Polylines| fields with their
         :attr:`filled <fiftyone.core.labels.Polyline.filled>` attributes set to
-        `False`
+        `False`. Only straight, single-path geometry is supported; Bezier,
+        skeleton, and multi-path geometry are not yet supported
     -   ``"polygons"``: polygons stored in |Polylines| fields with their
         :attr:`filled <fiftyone.core.labels.Polyline.filled>` attributes set to
         `True`

--- a/fiftyone/utils/labelstudio.py
+++ b/fiftyone/utils/labelstudio.py
@@ -171,6 +171,7 @@ class LabelStudioAnnotationAPI(foua.AnnotationAPI):
         self._api_key = api_key
         self.backend = "labelstudio"
         self._min_server_version = "1.5.0"
+        self._min_polyline_server_version = "1.23.0"
 
         self._setup()
 
@@ -186,12 +187,24 @@ class LabelStudioAnnotationAPI(foua.AnnotationAPI):
         server_version = self._client.make_request(
             "GET", "/api/version"
         ).json()["release"]
-        if not version.parse(server_version) >= version.parse(
-            self._min_server_version
-        ):
+        self._server_version = version.parse(server_version)
+        if self._server_version < version.parse(self._min_server_version):
             raise ValueError(
                 "Current Label Studio integration is only compatible with "
                 "version>=%s" % self._min_server_version
+            )
+
+    def _verify_label_schema(self, label_schema):
+        if any(
+            label_info["type"] in ("polyline", "polylines")
+            for label_info in label_schema.values()
+        ) and self._server_version < version.parse(
+            self._min_polyline_server_version
+        ):
+            raise ValueError(
+                "Polyline labels require Label Studio installed version %s; "
+                "required version %s or newer"
+                % (self._server_version, self._min_polyline_server_version)
             )
 
     def _init_project(self, config, samples):
@@ -210,6 +223,7 @@ class LabelStudioAnnotationAPI(foua.AnnotationAPI):
         """
         project_name = deepcopy(config.project_name)
         label_schema = deepcopy(config.label_schema)
+        self._verify_label_schema(label_schema)
 
         if project_name is None:
             _dataset_name = samples._root_dataset.name.replace(" ", "_")
@@ -432,10 +446,7 @@ class LabelStudioAnnotationAPI(foua.AnnotationAPI):
                 "segmentations. Use upload_samples() instead"
             )
 
-        if _LABEL_TYPES[label_type]["multiple"] is None:
-            return export_label_to_label_studio(labels)
-
-        return [export_label_to_label_studio(l) for l in labels]
+        return export_label_to_label_studio(labels, label_type=label_type)
 
     def upload_samples(self, samples, anno_key, backend):
         """Uploads the given samples to Label Studio according to the given
@@ -667,6 +678,8 @@ def import_label_studio_annotation(result):
         label = _from_rectanglelabels(result)
     elif ls_type == "polygonlabels":
         label = _from_polygonlabels(result)
+    elif ls_type == "vectorlabels":
+        label = _from_vectorlabels(result)
     elif ls_type == "keypointlabels":
         label = _from_keypointlabels(result)
     elif ls_type == "brushlabels":
@@ -698,10 +711,10 @@ def export_label_to_label_studio(label, label_type=None, full_result=None):
         label: a :class:`fiftyone.core.labels.Label` or list of
             :class:`fiftyone.core.labels.Label` instances
         label_type (None): the label type to use when exporting the annotation.
-            This argument is only used when exporting object detections. By
-            default, only the bounding boxes are exported, but you can pass
-            ``label_type="instances"`` to export them as brush labels encoding
-            the instance masks instead
+            When exporting object detections, you can pass
+            ``label_type="instances"`` to export instance masks as brush
+            labels. When exporting polylines, use ``"polylines"`` for
+            VectorLabels or ``"polygons"`` for PolygonLabels
         full_result (None): if non-empty, return the full Label Studio result
 
     Returns:
@@ -724,7 +737,31 @@ def export_label_to_label_studio(label, label_type=None, full_result=None):
         else:
             result_value, ls_type, ids = _to_detection(label)
     elif _check_type(label, fol.Polyline, fol.Polylines):
-        result_value, ls_type, ids = _to_polyline(label)
+        if label_type in ("polyline", "polylines"):
+            result_value, ls_type, ids = _to_vectorlabels(label)
+        elif label_type in ("polygon", "polygons"):
+            result_value, ls_type, ids = _to_polyline(label)
+        elif label_type is None:
+            if isinstance(label, fol.Polylines):
+                polylines = label.polylines
+            elif isinstance(label, list):
+                polylines = label
+            else:
+                polylines = [label]
+
+            filled_values = {polyline.filled for polyline in polylines}
+            if len(filled_values) > 1:
+                raise ValueError(
+                    "Cannot infer Label Studio type from mixed filled "
+                    "polylines"
+                )
+
+            if filled_values == {True}:
+                result_value, ls_type, ids = _to_polyline(label)
+            else:
+                result_value, ls_type, ids = _to_vectorlabels(label)
+        else:
+            raise ValueError("Unsupported polyline type: %s" % label_type)
     elif _check_type(label, fol.Keypoint, fol.Keypoints):
         result_value, ls_type, ids = _to_keypoint(label)
     elif isinstance(label, fol.Segmentation):
@@ -850,6 +887,51 @@ def _to_polyline(label):
     return result, ls_type, label.id
 
 
+def _to_vectorlabels(label):
+    ls_type = "vectorlabels"
+
+    if isinstance(label, list):
+        return (
+            [_to_vectorlabels(l)[0] for l in label],
+            ls_type,
+            [l.id for l in label],
+        )
+
+    if isinstance(label, fol.Polylines):
+        return (
+            [_to_vectorlabels(l)[0] for l in label.polylines],
+            ls_type,
+            [l.id for l in label.polylines],
+        )
+
+    if len(label.points) != 1:
+        raise ValueError(
+            "VectorLabels export requires exactly one path per polyline"
+        )
+
+    vertices = []
+    previous_id = None
+    for point in _denormalize_values(label.points[0]):
+        point_id = str(ObjectId())
+        vertices.append(
+            {
+                "id": point_id,
+                "x": point[0],
+                "y": point[1],
+                "prevPointId": previous_id,
+                "isBezier": False,
+            }
+        )
+        previous_id = point_id
+
+    result = {
+        "vertices": vertices,
+        "closed": label.closed,
+        "vectorlabels": [label.label],
+    }
+    return result, ls_type, label.id
+
+
 def _to_keypoint(label):
     ls_type = "keypointlabels"
 
@@ -921,6 +1003,71 @@ def _from_polygonlabels(result):
     label_values = result["value"][result["type"]]
     kwargs = dict(points=[ls_points], filled=True, closed=True)
     return fol.Polyline(label=label_values[0], **kwargs)
+
+
+def _from_vectorlabels(result):
+    value = result["value"]
+    vertices = value["vertices"]
+    vertex_ids = set()
+    children = defaultdict(list)
+    roots = []
+
+    for vertex in vertices:
+        if (
+            vertex.get("isBezier", False)
+            or "controlPoint1" in vertex
+            or "controlPoint2" in vertex
+        ):
+            raise ValueError(
+                "Bezier vertices are not supported by FiftyOne polylines"
+            )
+
+        vertex_id = vertex.get("id")
+        if vertex_id is None or vertex_id in vertex_ids:
+            raise ValueError(
+                "VectorLabels vertices must form a single linear path"
+            )
+
+        vertex_ids.add(vertex_id)
+        previous_id = vertex.get("prevPointId")
+        if previous_id is None:
+            roots.append(vertex_id)
+        else:
+            children[previous_id].append(vertex_id)
+
+    if len(roots) != 1 or any(len(c) > 1 for c in children.values()):
+        raise ValueError(
+            "VectorLabels vertices must form a single linear path"
+        )
+
+    vertices_by_id = {vertex["id"]: vertex for vertex in vertices}
+    ordered_vertices = []
+    vertex_id = roots[0]
+    while vertex_id is not None:
+        vertex = vertices_by_id.get(vertex_id)
+        if vertex is None:
+            raise ValueError(
+                "VectorLabels vertices must form a single linear path"
+            )
+
+        ordered_vertices.append(vertex)
+        next_vertices = children.get(vertex_id, [])
+        vertex_id = next_vertices[0] if next_vertices else None
+
+    if len(ordered_vertices) != len(vertices):
+        raise ValueError(
+            "VectorLabels vertices must form a single linear path"
+        )
+
+    points = _normalize_values(
+        [[vertex["x"], vertex["y"]] for vertex in ordered_vertices]
+    )
+    return fol.Polyline(
+        label=value["vectorlabels"][0],
+        points=[points],
+        closed=value["closed"],
+        filled=False,
+    )
 
 
 def _from_keypointlabels(result):
@@ -1051,7 +1198,32 @@ _LABEL_TYPES = {
         child_tag="Label",
         label=fol.Detection,
     ),
+    "polyline": dict(
+        parent_tag="VectorLabels",
+        child_tag="Label",
+        label=fol.Polyline,
+        tag_kwargs={
+            "closable": "true",
+            "curves": "false",
+            "skeleton": "false",
+        },
+    ),
     "polylines": dict(
+        parent_tag="VectorLabels",
+        child_tag="Label",
+        label=fol.Polyline,
+        tag_kwargs={
+            "closable": "true",
+            "curves": "false",
+            "skeleton": "false",
+        },
+    ),
+    "polygon": dict(
+        parent_tag="PolygonLabels",
+        child_tag="Label",
+        label=fol.Polyline,
+    ),
+    "polygons": dict(
         parent_tag="PolygonLabels",
         child_tag="Label",
         label=fol.Polyline,

--- a/tests/intensive/labelstudio_tests.py
+++ b/tests/intensive/labelstudio_tests.py
@@ -120,10 +120,10 @@ def label_configs():
             },
             "output": """<View>
   <Image name="image" value="$image"/>
-  <PolygonLabels name="some_random_field" toName="image">
+  <VectorLabels name="some_random_field" toName="image" closable="true" curves="false" skeleton="false">
     <Label value="Airplane"/>
     <Label value="Car"/>
-  </PolygonLabels>
+  </VectorLabels>
 </View>""",
         },
         {

--- a/tests/unittests/labelstudio_unit_tests.py
+++ b/tests/unittests/labelstudio_unit_tests.py
@@ -1,0 +1,304 @@
+"""Tests for the Label Studio vector labels codec."""
+
+from types import SimpleNamespace
+
+import pytest
+from packaging import version
+
+import fiftyone as fo
+import fiftyone.utils.labelstudio as fouls
+
+
+def _vector_result(vertices, closed=False):
+    return {
+        "original_width": 1920,
+        "original_height": 1280,
+        "image_rotation": 0,
+        "from_name": "roads",
+        "to_name": "image",
+        "type": "vectorlabels",
+        "value": {
+            "vertices": vertices,
+            "closed": closed,
+            "vectorlabels": ["Road"],
+        },
+    }
+
+
+class _FakeResponse(object):
+    def __init__(self, release):
+        self._release = release
+
+    def json(self):
+        return {"release": self._release}
+
+
+class _FakeClient(object):
+    def __init__(self, release):
+        self._release = release
+
+    def make_request(self, method, endpoint):
+        assert method == "GET"
+        assert endpoint == "/api/version"
+        return _FakeResponse(self._release)
+
+
+def _make_annotation_api(server_version):
+    api = object.__new__(fouls.LabelStudioAnnotationAPI)
+    api._client = _FakeClient(server_version)
+    api._min_server_version = "1.5.0"
+    api._min_polyline_server_version = "1.23.0"
+    api._verify_server_version()
+    return api
+
+
+def test_verify_server_version_stores_parsed_release():
+    api = _make_annotation_api("1.22.7")
+
+    assert api._server_version == version.parse(  # pylint: disable=no-member
+        "1.22.7"
+    )
+
+
+@pytest.mark.parametrize("label_type", ("polyline", "polylines"))
+def test_verify_label_schema_rejects_polylines_before_1_23(label_type):
+    api = _make_annotation_api("1.22.7")
+
+    with pytest.raises(
+        ValueError,
+        match=r"installed version 1\.22\.7.*required version 1\.23\.0",
+    ):
+        api._verify_label_schema(  # pylint: disable=no-member
+            {"roads": {"type": label_type}}
+        )
+
+
+@pytest.mark.parametrize("label_type", ("polyline", "polylines"))
+def test_verify_label_schema_accepts_polylines_at_1_23(label_type):
+    api = _make_annotation_api("1.23.0")
+
+    api._verify_label_schema(  # pylint: disable=no-member
+        {"roads": {"type": label_type}}
+    )
+
+
+@pytest.mark.parametrize("label_type", ("polygon", "polygons"))
+def test_verify_label_schema_accepts_polygons_before_1_23(label_type):
+    api = _make_annotation_api("1.22.7")
+
+    api._verify_label_schema(  # pylint: disable=no-member
+        {"buildings": {"type": label_type}}
+    )
+
+
+def test_init_project_validates_polylines_before_project_lookup():
+    api = _make_annotation_api("1.22.7")
+
+    def _unexpected_project_lookup():
+        raise AssertionError("attempted project lookup")
+
+    api._client.list_projects = _unexpected_project_lookup
+    config = SimpleNamespace(
+        project_name="Vector labels",
+        label_schema={"roads": {"type": "polylines"}},
+    )
+
+    with pytest.raises(ValueError, match="1.23.0"):
+        api._init_project(config, samples=None)
+
+
+def test_export_to_label_studio_forwards_polyline_type():
+    api = object.__new__(fouls.LabelStudioAnnotationAPI)
+    label = fo.Polyline(
+        label="Road",
+        points=[[[0.1, 0.1], [0.2, 0.2]]],
+        filled=True,
+    )
+
+    prediction = api._export_to_label_studio(label, "polylines")
+
+    assert prediction["vectorlabels"] == ["Road"]
+
+
+def test_generate_labeling_config_routes_polylines_to_vectorlabels():
+    config = fouls.generate_labeling_config(
+        {
+            "roads": {"type": "polylines", "classes": ["Road"]},
+            "buildings": {
+                "type": "polygons",
+                "classes": ["Building"],
+            },
+        },
+        "image",
+    )
+
+    assert (
+        '<VectorLabels name="roads" toName="image" closable="true" '
+        'curves="false" skeleton="false">'
+    ) in config
+    assert '<Label value="Road"/>' in config
+    assert '<PolygonLabels name="buildings" toName="image">' in config
+    assert '<Label value="Building"/>' in config
+
+
+@pytest.mark.parametrize("closed", [False, True])
+def test_vectorlabels_round_trip_single_unfilled_path(closed):
+    label = fo.Polyline(
+        label="Road",
+        points=[[[0.25, 0.3], [0.75, 0.7]]],
+        closed=closed,
+        filled=False,
+    )
+    full_result = {
+        "original_width": 1920,
+        "original_height": 1280,
+        "image_rotation": 0,
+        "from_name": "roads",
+        "to_name": "image",
+    }
+
+    result = fouls.export_label_to_label_studio(
+        label, label_type="polylines", full_result=full_result
+    )[0]
+
+    assert result["type"] == "vectorlabels"
+    assert result["value"]["vertices"] == [
+        {
+            "id": result["value"]["vertices"][0]["id"],
+            "x": 25.0,
+            "y": 30.0,
+            "prevPointId": None,
+            "isBezier": False,
+        },
+        {
+            "id": result["value"]["vertices"][1]["id"],
+            "x": 75.0,
+            "y": 70.0,
+            "prevPointId": result["value"]["vertices"][0]["id"],
+            "isBezier": False,
+        },
+    ]
+    assert len({v["id"] for v in result["value"]["vertices"]}) == 2
+    assert result["value"]["closed"] is closed
+    assert result["value"]["vectorlabels"] == ["Road"]
+
+    from_name, imported = fouls.import_label_studio_annotation(result)
+
+    assert from_name == "roads"
+    assert imported.label == "Road"
+    assert imported.points == [[[0.25, 0.3], [0.75, 0.7]]]
+    assert imported.closed is closed
+    assert imported.filled is False
+
+
+def test_vectorlabels_export_rejects_multiple_paths():
+    label = fo.Polyline(
+        label="Road",
+        points=[[[0.1, 0.2], [0.2, 0.3]], [[0.7, 0.8], [0.8, 0.9]]],
+        filled=False,
+    )
+
+    with pytest.raises(ValueError, match="exactly one path"):
+        fouls.export_label_to_label_studio(label, label_type="polylines")
+
+
+def test_vectorlabels_import_rejects_bezier_vertices():
+    result = _vector_result(
+        [
+            {
+                "id": "point-1",
+                "x": 25.0,
+                "y": 30.0,
+                "prevPointId": None,
+                "isBezier": True,
+                "controlPoint1": {"x": 30.0, "y": 35.0},
+                "controlPoint2": {"x": 40.0, "y": 45.0},
+            }
+        ]
+    )
+
+    with pytest.raises(ValueError, match="Bezier"):
+        fouls.import_label_studio_annotation(result)
+
+
+def test_vectorlabels_import_rejects_branching_vertices():
+    result = _vector_result(
+        [
+            {
+                "id": "point-1",
+                "x": 25.0,
+                "y": 30.0,
+                "prevPointId": None,
+                "isBezier": False,
+            },
+            {
+                "id": "point-2",
+                "x": 50.0,
+                "y": 50.0,
+                "prevPointId": "point-1",
+                "isBezier": False,
+            },
+            {
+                "id": "point-3",
+                "x": 75.0,
+                "y": 70.0,
+                "prevPointId": "point-1",
+                "isBezier": False,
+            },
+        ]
+    )
+
+    with pytest.raises(ValueError, match="linear"):
+        fouls.import_label_studio_annotation(result)
+
+
+def test_polyline_export_infers_type_from_filled_value():
+    polygon = fo.Polyline(
+        label="Building",
+        points=[[[0.1, 0.1], [0.2, 0.1], [0.2, 0.2]]],
+        filled=True,
+    )
+    polyline = fo.Polyline(
+        label="Road",
+        points=[[[0.1, 0.1], [0.2, 0.2]]],
+        filled=False,
+    )
+
+    assert fouls.export_label_to_label_studio(polygon)["polygonlabels"] == [
+        "Building"
+    ]
+    assert fouls.export_label_to_label_studio(polyline)["vectorlabels"] == [
+        "Road"
+    ]
+
+
+def test_polyline_export_uses_explicit_schema_type():
+    label = fo.Polyline(
+        label="Road",
+        points=[[[0.1, 0.1], [0.2, 0.2]]],
+        filled=True,
+    )
+
+    assert fouls.export_label_to_label_studio(label, label_type="polylines")[
+        "vectorlabels"
+    ] == ["Road"]
+
+
+def test_polyline_export_rejects_ambiguous_filled_values():
+    labels = fo.Polylines(
+        polylines=[
+            fo.Polyline(
+                label="Building",
+                points=[[[0.1, 0.1], [0.2, 0.1], [0.2, 0.2]]],
+                filled=True,
+            ),
+            fo.Polyline(
+                label="Road",
+                points=[[[0.1, 0.1], [0.2, 0.2]]],
+                filled=False,
+            ),
+        ]
+    )
+
+    with pytest.raises(ValueError, match="mixed filled"):
+        fouls.export_label_to_label_studio(labels)


### PR DESCRIPTION
## 🔗 Related Issues

Fixes #5260

## 📋 What changes are proposed in this pull request?

This PR adds Label Studio `VectorLabels` support for FiftyOne polyline annotations.

- Routes `polyline`/`polylines` schemas to `VectorLabels` while preserving `PolygonLabels` for polygon schemas
- Supports import and export of straight, single-path vector geometry, including the closed state
- Rejects unsupported Bezier, branching, and multi-path geometry with explicit errors
- Requires Label Studio server 1.23.0 or newer when a polyline schema is used
- Updates the Label Studio integration tests and documentation to describe the supported geometry and version requirement

## 🧪 How is this patch tested? If it is not, please explain why.

- `python -m pytest tests/unittests/labelstudio_unit_tests.py tests/intensive/labelstudio_tests.py::test_labelling_config tests/intensive/labelstudio_tests.py::test_import_labels tests/intensive/labelstudio_tests.py::test_export_labels -q` — 21 passed, 8 existing third-party deprecation warnings
- `python -m py_compile fiftyone/utils/labelstudio.py tests/unittests/labelstudio_unit_tests.py` — passed
- `git diff --check` — passed

The intensive tests used here do not require a running Label Studio server. A live Label Studio service was not used for this validation.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

Label Studio annotation now supports FiftyOne polyline fields through `VectorLabels` when using Label Studio server 1.23.0 or newer. Straight, single-path geometry is supported.

### What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [x] Core: Core `fiftyone` Python library changes
- [x] Documentation: FiftyOne documentation changes
- [ ] Other