### PR TITLE
Media reference tweaks

### DIFF
--- a/fiftyone/core/media_assets.py
+++ b/fiftyone/core/media_assets.py
@@ -550,19 +550,17 @@ def _bind_materialized_media_sources(manifest_sources, dataset_dir):
 def _validate_materialized_media_sources(manifest_sources, dataset_dir):
     """Validates materialized source roots without changing bindings."""
     validated = []
-    dataset_root = os.path.realpath(dataset_dir)
+    dataset_root = fos.realpath(dataset_dir)
     for source, relative_root, required in manifest_sources:
         if relative_root is None:
             validated.append((source, None, required))
             continue
 
-        root = os.path.realpath(
-            os.path.join(dataset_root, *relative_root.split("/"))
-        )
-        if os.path.commonpath((dataset_root, root)) != dataset_root:
+        root = fos.realpath(fos.join(dataset_root, *relative_root.split("/")))
+        if fos.commonpath((dataset_root, root)) != dataset_root:
             raise ValueError("Materialized media source escapes the dataset")
 
-        if not os.path.isdir(root):
+        if not fos.isdir(root):
             raise ValueError(
                 "Materialized media source '%s' is missing" % relative_root
             )
@@ -590,13 +588,13 @@ def _validate_materialized_reference_assets(
         if root is None:
             continue
 
-        path = os.path.realpath(os.path.join(root, *asset.location.split("/")))
-        if os.path.commonpath((root, path)) != root:
+        path = fos.realpath(fos.join(root, *asset.location.split("/")))
+        if fos.commonpath((root, path)) != root:
             raise InvalidMediaLocationError(
                 "Materialized media asset escapes its portable source root"
             )
 
-        if not os.path.isfile(path):
+        if not fos.isfile(path):
             raise ValueError(
                 "Materialized media asset '%s' is missing" % asset.location
             )

--- a/fiftyone/core/storage.py
+++ b/fiftyone/core/storage.py
@@ -315,6 +315,18 @@ def realpath(path):
     return os.path.realpath(path)
 
 
+def commonpath(paths):
+    """Returns the longest common subpath of the given paths.
+
+    Args:
+        paths: an iterable of paths
+
+    Returns:
+        the longest common subpath
+    """
+    return os.path.commonpath(paths)
+
+
 def isabs(path):
     """Determines whether the given path is absolute.
 

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -1216,6 +1216,7 @@ class BaseChunkyBatcher(Batcher):
 
         if self.return_views:
             if self._last_offset >= self._num_samples:
+                self._last_batch_size = 0
                 raise StopIteration
 
             offset = self._last_offset

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -1244,10 +1244,12 @@ class BaseChunkyBatcher(Batcher):
                 batch.append(next(self._iter))
                 idx += 1
         except StopIteration:
-            if not batch:
-                raise StopIteration
+            pass
 
         self._last_batch_size = len(batch)
+
+        if not batch:
+            raise StopIteration
 
         return batch
 

--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -2401,10 +2401,7 @@ class FiftyOneDatasetExporter(BatchDatasetExporter):
         logger.info("Exporting samples...")
 
         coll, pipeline = fod._get_samples_pipeline(_sample_collection)
-        if not self._media_exporter.is_reference_export:
-            num_samples = foo.count_documents(coll, pipeline)
-        else:
-            num_samples = None
+        num_samples = foo.count_documents(coll, pipeline)
 
         _samples = foo.aggregate(coll, pipeline)
 

--- a/tests/unittests/multimodal/lerobot_tests.py
+++ b/tests/unittests/multimodal/lerobot_tests.py
@@ -1190,12 +1190,6 @@ class MediaAssetLifecycleTests(unittest.TestCase):
                 "_finalize_reference_export",
                 new=track_finalization,
             ), mock.patch.object(
-                foudi.foo,
-                "count_documents",
-                side_effect=AssertionError(
-                    "reference exports must not run an exact-count pre-scan"
-                ),
-            ), mock.patch.object(
                 foma,
                 "_export_media_reference_bindings",
                 wraps=foma._export_media_reference_bindings,


### PR DESCRIPTION
## Change log

- When exporting media reference datasets in `FiftyOneDataset` format, compute total count for progress bars, for consistency with filepath datasets
- Fixed a bug where dynamic batchers would display the wrong final count when no total is available
- Upgraded some `fiftyone.core.media_assets` methods to be cloud-friendly

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3956
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media path validation while preserving existing validation behavior and error messages.
  * Fixed batch processing state when iteration ends, ensuring empty final batches are handled consistently.
  * Corrected progress tracking for exports that use media references.

* **Improvements**
  * Added more reliable path handling for storage-backed media operations.
  * Export progress indicators now include accurate sample counts for all export types.
  * Improved consistency when processing media stored across different storage locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->