### PR TITLE
Number html-strategy frames by presentation order via the container's frame table

### DIFF
--- a/app/packages/video-annotation/src/components/VideoAnnotationSurface.tsx
+++ b/app/packages/video-annotation/src/components/VideoAnnotationSurface.tsx
@@ -13,6 +13,7 @@ import { useSyncAnnotationFrameClock } from "../hooks/useSyncAnnotationFrameCloc
 import { useDynamicGroupPersistence } from "../hooks/useDynamicGroupPersistence";
 import { useSyncAnnotationVideoStore } from "../hooks/useSyncAnnotationVideoStore";
 import { useVideoLighterEngineBridge } from "../hooks/useVideoLighterEngineBridge";
+import { FrameTableContext } from "../state/frameTableContext";
 import {
   useSetTimelineLoaded,
   useSurfaceRevealed,
@@ -20,6 +21,8 @@ import {
 import { useFollowAnchorFrame } from "../state/useVideoInteraction";
 import { useAnnotatePrerequisites } from "../hooks/useAnnotatePrerequisites";
 import { useDecodeStrategy } from "../hooks/useDecodeStrategy";
+import { getFrameTable } from "../streams/frameTable";
+import type { FrameTable } from "../streams/frameTable";
 import type { DecodeStrategy } from "../utils/decodeStrategy";
 import { PlaybackProvider, TIMELINE_DRAWER_MAX_SIZE } from "@fiftyone/playback";
 import {
@@ -196,6 +199,38 @@ export const VideoAnnotationSurface: React.FC<VideoAnnotationSurfaceProps> = ({
     force: isImageDynamicGroupVideo ? "fetch" : undefined,
   });
 
+  // The html strategy's presentation-order frame table (see
+  // `streams/frameTable.ts`): the `<video>` clock's `time × fps` numbering
+  // drifts ahead of the persisted frame labels on dropped-frame media, so the
+  // table restores label-order numbering. Only the html path needs it — the
+  // `extract` stream's times are synthetic `(frame-1)/fps` (already
+  // presentation-ordered) and `fetch` (ImaVid) renders one image per frame —
+  // so consumers see `null` (the `time × fps` fallback) on those strategies,
+  // while the table loads, and when the header can't be demuxed.
+  const [frameTable, setFrameTable] = useState<FrameTable | null>(null);
+  const wantsFrameTable =
+    resolution.status === "resolved" &&
+    resolution.strategy === "html" &&
+    Boolean(videoSrc);
+  useEffect(() => {
+    if (!wantsFrameTable || !videoSrc) {
+      setFrameTable(null);
+      return undefined;
+    }
+
+    let cancelled = false;
+    getFrameTable(videoSrc).then((table) => {
+      if (!cancelled) {
+        setFrameTable(table);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      setFrameTable(null);
+    };
+  }, [wantsFrameTable, videoSrc]);
+
   // Metadata gate: without a frame count no strategy can mount, so show an
   // actionable prompt instead of a stream that would throw or blank out.
   // Wrapped in the provider (see the resolved return) — the top bar reads the
@@ -308,12 +343,18 @@ export const VideoAnnotationSurface: React.FC<VideoAnnotationSurfaceProps> = ({
     // scrub-drag, so the labels snapshot and any keyframe op align to a frame.
     // Scrubbing stays continuous — only the settle position snaps.
     <PlaybackProvider snapToFrameOnSettle>
-      <VideoAnnotationHandlerRegistration />
-      <RegisterTimelineAudio
-        videoSrc={videoSrc}
-        hasAudio={resolution.hasAudio}
-      />
-      {registered}
+      {/* Every `useCurrentFrame` consumer sits under this provider — including
+          the handler registrars — so the frame clock flips to table numbering
+          the moment the table resolves. `frameTable` is only ever non-null on
+          the html strategy (see the loader above). */}
+      <FrameTableContext.Provider value={frameTable}>
+        <VideoAnnotationHandlerRegistration />
+        <RegisterTimelineAudio
+          videoSrc={videoSrc}
+          hasAudio={resolution.hasAudio}
+        />
+        {registered}
+      </FrameTableContext.Provider>
     </PlaybackProvider>
   );
 };

--- a/app/packages/video-annotation/src/state/frameTableContext.ts
+++ b/app/packages/video-annotation/src/state/frameTableContext.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { createContext, useContext } from "react";
+import type { FrameTable } from "../streams/frameTable";
+
+/**
+ * The current sample's presentation-order frame table (see
+ * `streams/frameTable.ts`), provided by the surface only on the `html` decode
+ * strategy — the `<video>` clock is the one time source whose `time × fps`
+ * numbering drifts on dropped-frame media. `null` (the default) everywhere
+ * else: while the table loads, when the header can't be demuxed, and on the
+ * `extract` / `fetch` paths whose times are already presentation-ordered.
+ */
+export const FrameTableContext = createContext<FrameTable | null>(null);
+
+/** The active frame table, or `null` to fall back to `time × fps` numbering. */
+export const useFrameTable = (): FrameTable | null =>
+  useContext(FrameTableContext);

--- a/app/packages/video-annotation/src/state/useCurrentFrame.test.ts
+++ b/app/packages/video-annotation/src/state/useCurrentFrame.test.ts
@@ -1,5 +1,5 @@
 import { renderHook } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // NTSC-style sample: 120 frames at 30000/1001 fps, duration 4.004s. The
 // engine's seek/step clamp is inclusive of `duration`, so the playhead can
@@ -14,6 +14,7 @@ const { source } = vi.hoisted(() => ({
     presented: null as number | null,
     frameRate: undefined as number | undefined,
     totalFrameCount: undefined as number | undefined,
+    frameTable: null as { timesSec: number[] } | null,
   },
 }));
 
@@ -41,7 +42,18 @@ vi.mock("./accessors", () => ({
     sample?.frameRate,
 }));
 
+// The surface provides the table only on the html strategy; the hook just
+// reads the context accessor.
+vi.mock("./frameTableContext", () => ({
+  useFrameTable: () => source.frameTable,
+}));
+
 import { useCurrentFrame } from "./useCurrentFrame";
+
+beforeEach(() => {
+  source.presented = null;
+  source.frameTable = null;
+});
 
 describe("useCurrentFrame", () => {
   it("converts the playhead to a 1-indexed frame", () => {
@@ -103,5 +115,58 @@ describe("useCurrentFrame presented-frame authority", () => {
 
     const { result } = renderHook(() => useCurrentFrame());
     expect(result.current).toBe(30);
+  });
+});
+
+describe("useCurrentFrame frame-table numbering", () => {
+  // A 30fps source with two dropped frames: presentation runs 0, 1/30, 2/30,
+  // then jumps to 5/30, 6/30 — so table frames 4-5 sit where the clock says
+  // frames 6-7 live. `to_frames` and the persisted labels use table order.
+  const TABLE_FPS = 30;
+  const GAPPED = {
+    timesSec: [0, 1 / TABLE_FPS, 2 / TABLE_FPS, 5 / TABLE_FPS, 6 / TABLE_FPS],
+  };
+
+  it("numbers by the table, not time × fps, inside a dropped-frame gap", () => {
+    // 3/30s is inside the gap: the picture still shows table frame 3, while
+    // clock math (the null-table fallback below) reports 4.
+    source.playhead = 3 / TABLE_FPS;
+    source.frameRate = TABLE_FPS;
+    source.totalFrameCount = GAPPED.timesSec.length;
+    source.frameTable = GAPPED;
+
+    const { result } = renderHook(() => useCurrentFrame());
+    expect(result.current).toBe(3);
+  });
+
+  it("falls back to time × fps numbering without a table", () => {
+    source.playhead = 3 / TABLE_FPS;
+    source.frameRate = TABLE_FPS;
+    source.totalFrameCount = GAPPED.timesSec.length;
+    source.frameTable = null;
+
+    const { result } = renderHook(() => useCurrentFrame());
+    expect(result.current).toBe(4);
+  });
+
+  it("clamps a table frame to the sample's frame count", () => {
+    source.playhead = 6 / TABLE_FPS;
+    source.frameRate = TABLE_FPS;
+    source.totalFrameCount = 4;
+    source.frameTable = GAPPED;
+
+    const { result } = renderHook(() => useCurrentFrame());
+    expect(result.current).toBe(4);
+  });
+
+  it("converts the presented time, not the playhead, through the table", () => {
+    source.playhead = 6 / TABLE_FPS;
+    source.presented = 3 / TABLE_FPS;
+    source.frameRate = TABLE_FPS;
+    source.totalFrameCount = GAPPED.timesSec.length;
+    source.frameTable = GAPPED;
+
+    const { result } = renderHook(() => useCurrentFrame());
+    expect(result.current).toBe(3);
   });
 });

--- a/app/packages/video-annotation/src/state/useCurrentFrame.ts
+++ b/app/packages/video-annotation/src/state/useCurrentFrame.ts
@@ -5,7 +5,9 @@
 import { frameAt, usePlayhead, usePresentedTime } from "@fiftyone/playback";
 import { useModalSample } from "@fiftyone/state";
 import { useCallback, useRef } from "react";
+import { frameAtTableTime } from "../streams/frameTable";
 import { resolveFrameCount } from "../utils/frameCount";
+import { useFrameTable } from "./frameTableContext";
 import { useModalSampleFrameRate } from "./accessors";
 
 /**
@@ -29,6 +31,7 @@ export const useCurrentFrame = (): number => {
   const sample = useModalSample();
   const playhead = usePlayhead();
   const presented = usePresentedTime();
+  const table = useFrameTable();
   const fps = useModalSampleFrameRate(sample);
 
   if (!fps || !Number.isFinite(fps) || fps <= 0) {
@@ -42,8 +45,19 @@ export const useCurrentFrame = (): number => {
   // should track what the user sees. The playhead is the fallback for
   // tiles that never present (no media, no vfc support).
   const time = presented ?? playhead;
+  const count = resolveFrameCount(sample, fps) ?? undefined;
 
-  return frameAt(time, fps, resolveFrameCount(sample, fps) ?? undefined);
+  // On the html strategy the surface provides the container's frame table:
+  // number by presentation order (matching `to_frames` and every persisted
+  // frame label) instead of `time × fps`, which lands ahead of the labels on
+  // dropped-frame media. `time × fps` is the fallback while the table loads
+  // or when the header can't be demuxed.
+  if (table?.timesSec.length) {
+    const frame = frameAtTableTime(table, time);
+    return count ? Math.min(frame, count) : frame;
+  }
+
+  return frameAt(time, fps, count);
 };
 
 /**

--- a/app/packages/video-annotation/src/streams/frameTable.test.ts
+++ b/app/packages/video-annotation/src/streams/frameTable.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import type { FrameTable } from "./frameTable";
+import { frameAtTableTime, timeAtTableFrame } from "./frameTable";
+
+// A 30fps source with two dropped frames: presentation carries on at
+// frames 1-3 (0, 1/30, 2/30), then jumps to 5/30 — so frames 4 and 5 of
+// the table sit where `time × fps` says frames 6 and 7 live. This is the
+// exact shape where clock-based numbering drifts ahead of `to_frames`.
+const FPS = 30;
+const GAPPED: FrameTable = {
+  timesSec: [0, 1 / FPS, 2 / FPS, 5 / FPS, 6 / FPS],
+};
+
+const EMPTY: FrameTable = { timesSec: [] };
+
+describe("frameAtTableTime", () => {
+  it("numbers frames by presentation order, not time × fps", () => {
+    // 3/30s is inside the dropped-frame gap: the picture still shows the
+    // last pre-gap frame (table frame 3), while time × fps would say 4.
+    expect(frameAtTableTime(GAPPED, 3 / FPS)).toBe(3);
+    expect(Math.floor((3 / FPS) * FPS) + 1).toBe(4);
+  });
+
+  it("holds the last pre-gap frame across the whole gap", () => {
+    expect(frameAtTableTime(GAPPED, 2 / FPS)).toBe(3);
+    expect(frameAtTableTime(GAPPED, 3.5 / FPS)).toBe(3);
+    expect(frameAtTableTime(GAPPED, 4.999 / FPS)).toBe(3);
+    expect(frameAtTableTime(GAPPED, 5 / FPS)).toBe(4);
+  });
+
+  it("lands exactly on a boundary within the float epsilon", () => {
+    // A start time reconstructed with float error just below the boundary
+    // must still resolve to the boundary's frame, not the one before it.
+    expect(frameAtTableTime(GAPPED, 5 / FPS - 5e-7)).toBe(4);
+    expect(frameAtTableTime(GAPPED, 1 / FPS - 5e-7)).toBe(2);
+    // ...but a genuinely earlier time (beyond the epsilon) must not.
+    expect(frameAtTableTime(GAPPED, 5 / FPS - 1e-3)).toBe(3);
+  });
+
+  it("clamps below the first frame and past the last", () => {
+    expect(frameAtTableTime(GAPPED, -1)).toBe(1);
+    expect(frameAtTableTime(GAPPED, 100)).toBe(GAPPED.timesSec.length);
+  });
+
+  it("returns frame 1 for an empty table", () => {
+    expect(frameAtTableTime(EMPTY, 0.5)).toBe(1);
+  });
+});
+
+describe("timeAtTableFrame", () => {
+  it("round-trips every frame through frameAtTableTime", () => {
+    for (let frame = 1; frame <= GAPPED.timesSec.length; frame++) {
+      expect(frameAtTableTime(GAPPED, timeAtTableFrame(GAPPED, frame))).toBe(
+        frame,
+      );
+    }
+  });
+
+  it("clamps out-of-range frames to the table", () => {
+    expect(timeAtTableFrame(GAPPED, 0)).toBe(0);
+    expect(timeAtTableFrame(GAPPED, -3)).toBe(0);
+    expect(timeAtTableFrame(GAPPED, 99)).toBe(6 / FPS);
+  });
+
+  it("returns 0 for an empty table", () => {
+    expect(timeAtTableFrame(EMPTY, 3)).toBe(0);
+  });
+});

--- a/app/packages/video-annotation/src/streams/frameTable.ts
+++ b/app/packages/video-annotation/src/streams/frameTable.ts
@@ -1,0 +1,160 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ *
+ * The presentation-order frame table of a source video: sorted per-frame
+ * start times demuxed from the container header. On a video with dropped
+ * frames the media timeline has gaps, so `time × fps` numbering (the html
+ * `<video>` clock) drifts ahead of the decode/presentation-order numbering
+ * that `to_frames` — and therefore every persisted frame label — uses. The
+ * table restores the exact mapping in both directions.
+ *
+ * Only the `html` strategy needs it: the `extract` path decodes by sample
+ * table already (its times are synthetic `(frame-1)/fps`), and the `fetch`
+ * (ImaVid) path renders one image per frame.
+ */
+
+import { LRUCache } from "lru-cache";
+import type {
+  FrameTableMessage,
+  FrameWorkerOutbound,
+} from "./frameWorkerProtocol";
+
+export interface FrameTable {
+  /** Sorted presentation start times in seconds; index i ↔ frame i+1. */
+  readonly timesSec: readonly number[];
+}
+
+/** Float guard for times that should land exactly on a frame boundary. */
+const EPSILON_SEC = 1e-6;
+
+/**
+ * The 1-indexed frame on glass at `time`: the last frame whose start is at or
+ * before it. Times before the first frame clamp to 1; past the last, to the
+ * table's length.
+ */
+export const frameAtTableTime = (table: FrameTable, time: number): number => {
+  const times = table.timesSec;
+
+  if (times.length === 0) {
+    return 1;
+  }
+
+  const target = time + EPSILON_SEC;
+  let low = 0;
+  let high = times.length - 1;
+  let hit = 0;
+
+  while (low <= high) {
+    const mid = (low + high) >> 1;
+    if (times[mid] <= target) {
+      hit = mid;
+      low = mid + 1;
+    } else {
+      high = mid - 1;
+    }
+  }
+
+  return hit + 1;
+};
+
+/** The presentation start time (seconds) of a 1-indexed frame, clamped. */
+export const timeAtTableFrame = (table: FrameTable, frame: number): number => {
+  const times = table.timesSec;
+
+  if (times.length === 0) {
+    return 0;
+  }
+
+  const index = Math.min(Math.max(Math.round(frame), 1), times.length) - 1;
+  return times[index];
+};
+
+/** Give up (report no table) if the probe hasn't answered by now. */
+const TABLE_TIMEOUT_MS = 15_000;
+
+/**
+ * Demux `videoSrc`'s header in the WebCodecs worker (`tableOnly` mode) and
+ * return its frame table, or `null` when unavailable (non-MP4 container,
+ * fetch failure, timeout) — callers fall back to `time × fps` numbering,
+ * today's behavior. Never rejects.
+ */
+export function fetchFrameTable(
+  videoSrc: string,
+  opts: { headers?: Record<string, string> } = {},
+): Promise<FrameTable | null> {
+  return new Promise((resolve) => {
+    const worker = new Worker(
+      new URL("./videoDecodeWorker.ts", import.meta.url),
+      { type: "module" },
+    );
+
+    let settled = false;
+
+    const finish = (result: FrameTable | null) => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      clearTimeout(timer);
+      worker.removeEventListener("message", onMessage);
+      worker.removeEventListener("error", onError);
+      worker.terminate();
+      resolve(result);
+    };
+
+    const onMessage = (event: MessageEvent<FrameWorkerOutbound>) => {
+      if (event.data?.type !== "frameTable") {
+        return;
+      }
+
+      const msg = event.data as FrameTableMessage;
+      finish(
+        msg.timesMicros
+          ? { timesSec: msg.timesMicros.map((us) => us / 1e6) }
+          : null,
+      );
+    };
+
+    const onError = () => finish(null);
+    const timer = setTimeout(() => finish(null), TABLE_TIMEOUT_MS);
+
+    worker.addEventListener("message", onMessage);
+    worker.addEventListener("error", onError);
+    worker.postMessage({
+      type: "init",
+      videoSrc,
+      headers: opts.headers,
+      tableOnly: true,
+    });
+  });
+}
+
+/**
+ * A long-video table is a few MB of floats — cap the cache at a handful of
+ * recently-viewed sources rather than every sample paged through in a session.
+ */
+const TABLE_CACHE_MAX = 8;
+
+/**
+ * One in-flight/settled table promise per media URL — paging back to a recent
+ * sample must not re-demux its header. Failures are cached too: a source that
+ * can't demux won't start demuxing on retry.
+ */
+const tableCache = new LRUCache<string, Promise<FrameTable | null>>({
+  max: TABLE_CACHE_MAX,
+});
+
+export function getFrameTable(
+  videoSrc: string,
+  opts: { headers?: Record<string, string> } = {},
+): Promise<FrameTable | null> {
+  let cached = tableCache.get(videoSrc);
+
+  if (!cached) {
+    cached = fetchFrameTable(videoSrc, opts);
+    tableCache.set(videoSrc, cached);
+  }
+
+  return cached;
+}

--- a/app/packages/video-annotation/src/streams/frameWorkerProtocol.ts
+++ b/app/packages/video-annotation/src/streams/frameWorkerProtocol.ts
@@ -79,8 +79,24 @@ export interface CapabilityMessage {
   hasAudio?: boolean;
 }
 
+/**
+ * worker → main: the verdict of a `tableOnly` init — the source's
+ * presentation-order frame table (sorted start timestamps, µs; index i is
+ * frame i+1), or `null` when the header couldn't be demuxed. Emitted only by
+ * the WebCodecs worker's table branch (the frame-table fetcher awaits it and
+ * then terminates the worker).
+ */
+export interface FrameTableMessage {
+  type: "frameTable";
+  /** Sorted presentation start times in µs; index i ↔ frame i+1. */
+  timesMicros: number[] | null;
+  /** Why the table is unavailable, when `timesMicros` is null (diagnostics). */
+  reason?: string;
+}
+
 export type FrameWorkerOutbound =
   | FrameReadyMessage
   | ChunkDoneMessage
   | ChunkFailedMessage
-  | CapabilityMessage;
+  | CapabilityMessage
+  | FrameTableMessage;

--- a/app/packages/video-annotation/src/streams/videoDecodeWorker.ts
+++ b/app/packages/video-annotation/src/streams/videoDecodeWorker.ts
@@ -65,6 +65,12 @@ interface NativeInitMessage extends InitMessage {
    * Drives the decode-strategy resolver (which then terminates this worker).
    */
   probeOnly?: boolean;
+  /**
+   * Frame-table probe only: stream just far enough to demux the `moov`, post
+   * a `frameTable` message with the presentation-order timestamps, and stop —
+   * no decode. Drives the html-strategy frame clock on dropped-frame videos.
+   */
+  tableOnly?: boolean;
 }
 
 /** The `request` payload the native stream's `buildChunkRequest` produces. */
@@ -163,6 +169,13 @@ async function handleInit(msg: NativeInitMessage): Promise<void> {
     return;
   }
 
+  // Frame-table probe: demux the header only, report the presentation-order
+  // timestamps, and stop.
+  if (msg.tableOnly) {
+    await handleTableProbe(msg);
+    return;
+  }
+
   videoSrc = msg.videoSrc;
   mediaHeaders = msg.headers;
 
@@ -208,6 +221,29 @@ async function initSampleTable(
   }
 
   buildSampleTable(samples, track.timescale);
+}
+
+/**
+ * Frame-table probe: stream just enough of the source to demux its `moov`,
+ * read the sample table's presentation timestamps, and post a single
+ * `frameTable` message — no decode. The fetcher terminates this worker once
+ * it has the answer.
+ */
+async function handleTableProbe(msg: NativeInitMessage): Promise<void> {
+  try {
+    const { file, track } = await streamMoov(msg.videoSrc, msg.headers);
+    const samples = file.getTrackSamplesInfo(track.id);
+    const timesMicros = samples
+      .map((s) => Math.round((s.cts * 1e6) / track.timescale))
+      .sort((a, b) => a - b);
+    post({ type: "frameTable", timesMicros });
+  } catch (error) {
+    post({
+      type: "frameTable",
+      timesMicros: null,
+      reason: errorMessage(error),
+    });
+  }
 }
 
 /**


### PR DESCRIPTION
Slice 1 of FOEPD-4580 (dropped-frames label offset in video Annotate).

## What

Annotate must number frames by presentation order — the order `to_frames` walks and the order every persisted frame label is keyed on. The html `<video>` path converted its clock to a frame with `time × fps`, which assumes a gapless media timeline. On a video with dropped frames the media timeline has gaps, so that arithmetic lands ahead of the label numbering by exactly the dropped count, and labels render offset from the picture.

## How

- `videoDecodeWorker.ts`: a `tableOnly` init mode — stream just enough of the source to demux the `moov`, post a `frameTable` message with the sample table's sorted presentation timestamps (µs), and stop. No decode.
- `frameTable.ts`: the `FrameTable` type plus `frameAtTableTime` (binary search over the sorted start times, 1e-6s boundary epsilon, clamped) and `timeAtTableFrame`; `fetchFrameTable` runs the worker probe (15s timeout, never rejects — `null` on any failure); `getFrameTable` caches one promise per media URL in an 8-entry LRU.
- `VideoAnnotationSurface.tsx` loads the table when the resolved decode strategy is `html` and a media URL exists, and provides it through the new `FrameTableContext` (`useFrameTable()` accessor) wrapping everything under the surface's `PlaybackProvider`.
- `useCurrentFrame` converts time → frame through the table when one is present (clamped to the sample's frame count), and only there — the time source (presented time, playhead fallback) is unchanged.

## Fallbacks

The context stays `null` — and the existing `frameAt(time, fps, count)` math applies, i.e. today's behavior — while the table loads, when the header can't be demuxed (non-MP4 container, fetch failure, timeout), and on the `extract`/`fetch` (ImaVid) strategies, whose times are synthetic and already presentation-ordered.

## Tests

- `frameTable.test.ts`: gap-aware numbering on a synthetic dropped-frame table, boundary epsilon behavior, below/above clamps, `timeAtTableFrame` round-trip, empty table.
- `useCurrentFrame.test.ts`: table-present cases proving the table wins over `time × fps` inside a gap (through both the presented time and the playhead), frame-count clamping, and the null-table fallback.
- Full `packages/video-annotation` + `packages/playback` vitest suites pass (76 files, 892 tests).

## Follow-ups

- Slice 2: timeline geometry (`frameTracks.ts` / `temporalDetectionTracks.ts`) still places segments with `time × fps`.
- Looker's time-based frame numbering has the same drift and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)